### PR TITLE
cvmfs_server fixes

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -270,6 +270,7 @@ mkfs() {
   [ $(id -u) -ne 0 ] && die "Only root can create a new repository"
   /sbin/modprobe aufs || die "aufs kernel module missing"
   cat /proc/mounts | grep -q "^/etc/auto.cvmfs /cvmfs " && die "Autofs on /cvmfs has to be disabled"
+  [ -d /etc/httpd ] && /sbin/service httpd status >/dev/null || die "Apache must be installed and running"
 
   local cvmfs_user
   if [ "x$owner" == "x" ]; then


### PR DESCRIPTION
Hi Jakob,

I have tested to install the new server on a fresh SLC 5.8 installation. On that system the cvmfs_server did not run out of the box. I have fixed the problems I ran into. 
- The script did not check that /etc/httpd exists and that apache is running
- su $user -c did not work for me. I think that´s because the user cvmfs has no valid login shell on my system
- The script assumes that modprobe is in PATH, which was not the case on my setup
- Check that /etc/cvmfs/config.d exists or create it, before writing configurations there. 

Could you review an merge that pull request, please.

Thanks,
Manuel
