### PR TITLE
`cvmfs_server rmfs` now handles a missing mountpoint correctly

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -588,7 +588,9 @@ rmfs() {
     sed -i -e "/added by CernVM-FS for ${name}/d" /etc/fstab
     mount | grep -q " /cvmfs/$name " && umount /cvmfs/$name
     mount | grep -q " ${spool_dir}/rdonly " && umount ${spool_dir}/rdonly
-    if [ -f /cvmfs/$name ]; then rmdir /cvmfs/$name; fi
+    if [ -d /cvmfs/$name ]; then 
+      rmdir /cvmfs/$name
+    fi
     echo "done"
   fi
 


### PR DESCRIPTION
If for some reason the mountpoint in /cvmfs/<repo name> was not present `cvmfs_server rmfs <repo name>` was not able to remove the repository.
