### PR TITLE
FIX: Segmentation Fault because of inconsistent logging data structures

### DIFF
--- a/cvmfs/logging.cc
+++ b/cvmfs/logging.cc
@@ -43,7 +43,7 @@ string *path_debug = NULL;
 #endif
 const char *module_names[] = { "unknown", "cache", "catalog", "sql", "cvmfs",
   "hash", "download", "compress", "quota", "talk", "monitor", "lru",
-  "fuse stub", "signature", "peers", "fs traversal", "nfs maps", "publish",
+  "fuse stub", "signature", "peers", "fs traversal", "catalog traversal", "nfs maps", "publish",
   "spooler" };
 int syslog_facility = LOG_USER;
 int syslog_level = LOG_NOTICE;

--- a/cvmfs/logging_internal.h
+++ b/cvmfs/logging_internal.h
@@ -34,6 +34,11 @@ enum LogLevels {
   kLogNone = 2048,
 };
 
+/**
+ * CAUTION!
+ * Changes in this enum must be done in logging.cc as well!
+ * (see const char *module_names[] = {....})
+ */
 enum LogSource {
   kLogCache = 1,
   kLogCatalog,


### PR DESCRIPTION
I've changed `enum LogSource` somewhen before (adding kLogCatalogTraversal) but was not aware of the fact that there is the array `const char *module_names[]` in another file that needs to be updated as well.

TODO: think about something less dangerous here...
