### PR TITLE
Nested Catalog Tests check more pedantic

### DIFF
--- a/test/src/505-createnested/main
+++ b/test/src/505-createnested/main
@@ -46,6 +46,22 @@ produce_files_in() {
   popd
 }
 
+check_final_nested_catalog_presence() {
+  local repo_name=$1
+
+  if [ $(get_catalog_count $repo_name) -ne 2 ]; then
+    return 101
+  fi
+
+  if check_catalog_presence /                  $repo_name && \
+     check_catalog_presence /dir5/ndir5        $repo_name
+  then
+    return 0
+  else
+    return 102
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -76,6 +92,9 @@ cvmfs_run_test() {
 
   echo "check catalog integrity" >> $logfile
   check_catalogs $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
+
+  echo "check if eventually the right catalogs are present in the repository" >> $logfile
+  check_final_nested_catalog_presence $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
 
   return 0
 }

--- a/test/src/506-removenested/main
+++ b/test/src/506-removenested/main
@@ -56,6 +56,37 @@ change_files_in() {
   popd
 }
 
+check_initial_nested_catalog_presence() {
+  local repo_name=$1
+
+  if [ $(get_catalog_count $repo_name) -ne 2 ]; then
+    return 101
+  fi
+
+  if check_catalog_presence /                  $repo_name && \
+     check_catalog_presence /dir5/ndir5        $repo_name
+  then
+    return 0
+  else
+    return 102
+  fi
+}
+
+check_final_nested_catalog_presence() {
+  local repo_name=$1
+
+  if [ $(get_catalog_count $repo_name) -ne 1 ]; then
+    return 101
+  fi
+
+  if check_catalog_presence /                  $repo_name
+  then
+    return 0
+  else
+    return 102
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -84,6 +115,9 @@ cvmfs_run_test() {
   echo "compare the results of cvmfs to our reference copy" >> $logfile
   compare_directories $repo_dir $reference_dir >> $logfile || return $?
 
+  echo "check if the right catalogs are present after the first stage" >> $logfile
+  check_initial_nested_catalog_presence $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
+
   # ============================================================================
 
   echo "init a new transaction to change something in repository $CVMFS_TEST_REPO" >> $logfile
@@ -105,6 +139,9 @@ cvmfs_run_test() {
 
   echo "check catalog integrity" >> $logfile
   check_catalogs $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
+
+  echo "check if eventually the right catalogs are present in the repository" >> $logfile
+  check_final_nested_catalog_presence $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
 
   return 0
 }

--- a/test/src/507-removeintermediatenested/main
+++ b/test/src/507-removeintermediatenested/main
@@ -76,6 +76,39 @@ change_files_in() {
   popd
 }
 
+check_initial_nested_catalog_presence() {
+  local repo_name=$1
+
+  if [ $(get_catalog_count $repo_name) -ne 3 ]; then
+    return 101
+  fi
+
+  if check_catalog_presence /                  $repo_name && \
+     check_catalog_presence /dir5/ndir5        $repo_name && \
+     check_catalog_presence /dir5/ndir5/nndir3 $repo_name
+  then
+    return 0
+  else
+    return 102
+  fi
+}
+
+check_final_nested_catalog_presence() {
+  local repo_name=$1
+
+  if [ $(get_catalog_count $repo_name) -ne 2 ]; then
+    return 101
+  fi
+
+  if check_catalog_presence /                  $repo_name && \
+     check_catalog_presence /dir5/ndir5/nndir3 $repo_name
+  then
+    return 0
+  else
+    return 102
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -104,6 +137,9 @@ cvmfs_run_test() {
   echo "compare the results of cvmfs to our reference copy" >> $logfile
   compare_directories $repo_dir $reference_dir >> $logfile || return $?
 
+  echo "check if the right catalogs are present after the first stage" >> $logfile
+  check_initial_nested_catalog_presence $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
+
   # ============================================================================
 
   echo "init a new transaction to change something in repository $CVMFS_TEST_REPO" >> $logfile
@@ -125,6 +161,9 @@ cvmfs_run_test() {
 
   echo "check catalog integrity" >> $logfile
   check_catalogs $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
+
+  echo "check if eventually the right catalogs are present in the repository" >> $logfile
+  check_final_nested_catalog_presence $CVMFS_TEST_REPO >> $logfile 2>&1 || return $?
 
   return 0
 }

--- a/test/src/508-cvmfsdevelopment/main
+++ b/test/src/508-cvmfsdevelopment/main
@@ -84,21 +84,6 @@ configure_nested_catalogs() {
   esac
 }
 
-# checks if a nested catalog is part of the current catalog configuration
-# of the repository
-# @param catalog_path  the catalog root path to be checked
-# @param repo_name     the repository to be checked
-check_catalog_presence() {
-  local catalog_path=$1
-  local repo_name=$2
-
-  if cvmfs_swissknife lsrepo -r /srv/cvmfs/$repo_name | grep -x -q $catalog_path; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 # checks if all nested catalogs that were requested by configure_nested_catalogs()
 # are actually present in the catalog tree.
 # @param version    the repository version to be checked
@@ -110,6 +95,9 @@ check_catalog_configuration() {
 
   case $version in
     0)
+      if [ $(get_catalog_count $repo_name) -ne 4 ]; then
+        return 2
+      fi
       if check_catalog_presence /                  $repo_name && \
          check_catalog_presence /externals         $repo_name && \
          check_catalog_presence /cvmfs             $repo_name && \
@@ -121,6 +109,9 @@ check_catalog_configuration() {
       fi
       ;;
     1)
+      if [ $(get_catalog_count $repo_name) -ne 5 ]; then
+        return 2
+      fi
       if check_catalog_presence /                  $repo_name && \
          check_catalog_presence /externals         $repo_name && \
          check_catalog_presence /externals/zlib    $repo_name && \
@@ -133,7 +124,11 @@ check_catalog_configuration() {
       fi
       ;;
     2)
+      if [ $(get_catalog_count $repo_name) -ne 6 ]; then
+        return 2
+      fi
       if check_catalog_presence /                  $repo_name && \
+         check_catalog_presence /externals         $repo_name && \
          check_catalog_presence /externals/zlib    $repo_name && \
          check_catalog_presence /externals/sqlite3 $repo_name && \
          check_catalog_presence /test/HTTP         $repo_name && \
@@ -145,6 +140,9 @@ check_catalog_configuration() {
       fi
       ;;
     3)
+      if [ $(get_catalog_count $repo_name) -ne 1 ]; then
+        return 2
+      fi
       if check_catalog_presence /                  $repo_name
       then
         return 0

--- a/test/test_functions
+++ b/test/test_functions
@@ -285,6 +285,28 @@ compare_directories() {
   return 0
 }
 
+
+# checks if a nested catalog is part of the current catalog configuration
+# of the repository
+# @param catalog_path  the catalog root path to be checked
+# @param repo_name     the repository to be checked
+check_catalog_presence() {
+  local catalog_path=$1
+  local repo_name=$2
+
+  cvmfs_swissknife lsrepo -r /srv/cvmfs/$repo_name | grep -x -q $catalog_path
+  return $?
+}
+
+# counts the number of present catalogs in the repository
+# @param repo_name  the name of the repository to investigate
+# @return           the number of found catalogs
+get_catalog_count() {
+  local repo_name=$1
+
+  echo $(cvmfs_swissknife lsrepo -r /srv/cvmfs/$repo_name | wc -l)
+}
+
 # uses `cvmfs_server check` to check the integrity of the catalog structure
 # @param repo    the repository to be checked
 check_catalogs() {


### PR DESCRIPTION
Until now the checks in the nested catalog tests were somewhat weak. Now they check, if really the right catalogs are present in the repository. This was only done in the 'CVMFS development' testcase until now. Especially now it is checked if a catalog is _not_ present, when it was deleted before.
