### PR TITLE
Enable needed Apache modules on first usage in Ubuntu

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -135,6 +135,7 @@ reload_apache() {
 
 # lowers restrictions of hardlink creation if needed
 # allows AUFS to properly whiteout files without root privileges
+# Note: this function requires sudo
 lower_hardlink_restrictions() {
   if [ -f /proc/sys/kernel/yama/protected_nonaccess_hardlinks ] && \
      [ $(cat /proc/sys/kernel/yama/protected_nonaccess_hardlinks) -ne 0 ]; then
@@ -152,6 +153,32 @@ EOF
   fi
 
   return 0
+}
+
+
+# cvmfs requires a couple of apache modules to be enabled when running on
+# an ubuntu machine. This enables these modules on an ubuntu installation
+# Note: this function requires sudo
+ensure_enabled_apache_modules() {
+  which a2enmod > /dev/null 2>&1    || return 0
+  which apache2ctl > /dev/null 2>&1 || return 0
+
+  local restart=0
+  local retcode=0
+  local modules="headers expires"
+
+  for module in $modules; do
+    apache2ctl -M 2>/dev/null | grep -q "$module" && continue
+    a2enmod $module > /dev/null 2>&1 || { echo "Warning: failed to enable apache2 module $module"; retcode=1; }
+    restart=1
+  done
+
+  # restart apache if needed
+  if [ $restart -ne 0 ]; then
+    ${SERVICE_BIN} ${APACHE} restart > /dev/null 2>&1 | { echo "Warning: Failed to restart apache after enabling necessary modules"; retcode=2; }
+  fi
+
+  return $retcode
 }
 
 
@@ -360,6 +387,7 @@ mkfs() {
   cat /proc/mounts | grep -q "^/etc/auto.cvmfs /cvmfs " && die "Autofs on /cvmfs has to be disabled"
   [ -d /etc/${APACHE} ] && ${SERVICE_BIN} ${APACHE} status >/dev/null || die "Apache must be installed and running"
   lower_hardlink_restrictions
+  ensure_enabled_apache_modules
 
   echo -n "Creating configuration files... "
   mkdir -p /etc/cvmfs/repositories.d/${name}
@@ -600,6 +628,8 @@ rmfs() {
   local spool_dir=$2
   local upstream=$3
   local type=$4
+
+  ensure_enabled_apache_modules
 
   [ $(id -u) -ne 0 ] && die "Only root can remove a repository"
   [ x"$spool_dir" = x ] && die "Spool directory undefined"


### PR DESCRIPTION
This will automagically enable _headers_ and _expires_ apache modules in a fresh ubuntu installation.

Note: the function first checks if `a2enmod` and `apache2ctl` are present. If not we assume that we are not on debian/ubuntu and hope for the best...
