### PR TITLE
SELinux compliance

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -127,7 +127,7 @@ get_local_upstream() {
 
 
 has_selinux() {
-  return [ -f /selinux/enforce ]
+  [ -f /selinux/enforce ]
 }
 
 
@@ -346,7 +346,7 @@ create_repository_skeleton() {
     i=$(($i+1))
   done
   chown -R $user $directory
-  if [ has_selinux ]; then # on ubuntu selinux is not installed...
+  if has_selinux; then
     chcon -Rv --type=httpd_sys_content_t $directory
   fi
   echo "done"
@@ -513,7 +513,7 @@ EOF
 
   echo -n "Mounting CernVM-FS Storage... "
   local selinux_context=""
-  if [ has_selinux ]; then
+  if has_selinux; then
     selinux_context="context=\"system_u:object_r:default_t:s0\""
   fi
   cat >> /etc/fstab << EOF


### PR DESCRIPTION
The backend should now work with SELinux enabled.

I did two things to make it work:
- set _httpd_sys_content_t_ as type for the cvmfs repository directories in **/cvmfs/[repo name]**
- set _system_u:object_r:default_t:s0_ as the context for aufs mount points in **/etc/fstab** in order to allow access to normal users
