### PR TITLE
FIX: Having trouble with SELinux on CernVM

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -203,7 +203,7 @@ is_local_upstream() {
 
 
 has_selinux() {
-  [ -f /selinux/enforce ]
+  [ -f /selinux/enforce ] && [ $(cat /selinux/enforce) -ne 0 ]
 }
 
 


### PR DESCRIPTION
It now checks for SELinux to be installed and to be **enforced** before trying to change any labeling.
