### PR TITLE
FIX: Sanity check for the bug Aaron encountered

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -117,7 +117,7 @@ Supported Commands:
                 Start to edit a repository
   snapshot      <fully qualified name>
                 Synchronize a Stratum 1 replica with the Stratum 0 source
-  list:         List available repositories
+  list          List available repositories
 "
 
 
@@ -1009,6 +1009,10 @@ list() {
   for repository in /etc/cvmfs/repositories.d/*; do
     if [ "x$repository" = "x/etc/cvmfs/repositories.d/*" ]; then
       return 0
+    fi
+    if [ -f $repository ]; then
+      echo "Warning: unexpected file '$repository' in directory /etc/cvmfs/repositories.d/"
+      continue
     fi
     . ${repository}/server.conf
     local name=$(basename $repository)


### PR DESCRIPTION
If there is a file in /etc/cvmfs/repositories.d the script now warns the user instead of crash.
