### PR TITLE
FIX: Replication of Repositories

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -764,7 +764,7 @@ add_replica() {
   fi
 
   # default values
-  [ x"$upstream" = x ] && upstream="local:/srv/cvmfs/$name/data/txn:/srv/cvmfs/$name"
+  [ x"$upstream" = x ] && upstream=$(make_upstream "local" "/srv/cvmfs/$name/data/txn" "/srv/cvmfs/$name")
 
   # additional configuration
   local cvmfs_user=`get_cvmfs_owner $name $owner`

--- a/cvmfs/upload.cc
+++ b/cvmfs/upload.cc
@@ -96,6 +96,10 @@ void Spooler::Upload(const std::string &local_path,
 }
 
 
+bool Spooler::Peek(const std::string &path) const {
+  return uploader_->Peek(path);
+}
+
 void Spooler::ProcessingCallback(const FileProcessor::Results &data) {
   NotifyListeners(SpoolerResult(data.return_code,
                                 data.local_path,
@@ -124,27 +128,4 @@ void Spooler::WaitForTermination() const {
 unsigned int Spooler::GetNumberOfErrors() const {
   return concurrent_processing_->GetNumberOfFailedJobs() +
          uploader_->GetNumberOfErrors();
-}
-
-
-// -----------------------------------------------------------------------------
-
-
-bool LocalStat::Stat(const std::string &path) {
-  return FileExists(base_path_ + "/" + path);
-}
-
-
-namespace upload {
-
-  BackendStat *GetBackendStat(const std::string &spooler_definition) {
-    std::vector<std::string> components = SplitString(spooler_definition, ',');
-    std::vector<std::string> upstream = SplitString(components[0], ':');
-    if ((upstream.size() != 2) || (upstream[0] != "local")) {
-      PrintError("Invalid upstream");
-      return NULL;
-    }
-    return new LocalStat(upstream[1]);
-  }
-
 }

--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -97,28 +97,6 @@
 
 namespace upload
 {
-  class BackendStat {
-   public:
-    BackendStat(const std::string &base_path) { base_path_ = base_path; }
-    virtual ~BackendStat() { }
-    virtual bool Stat(const std::string &path) = 0;
-   protected:
-    std::string base_path_;
-  };
-
-
-  class LocalStat : public BackendStat {
-   public:
-    LocalStat(const std::string &base_path) : BackendStat(base_path) { }
-    bool Stat(const std::string &path);
-  };
-
-  BackendStat *GetBackendStat(const std::string &spooler_definition);
-
-
-  // ---------------------------------------------------------------------------
-
-
   /**
    * This data structure will be passed to every callback spoolers will invoke.
    * It encapsulates the results of a spooler command along with the given
@@ -209,6 +187,14 @@ namespace upload
      */
     void Process(const std::string &local_path,
                  const bool         allow_chunking = true);
+
+    /**
+     * Checks if a file is already present in the backend storage
+     *
+     * @param path  the path of the file to be peeked
+     * @return      true if the file was found in the backend storage
+     */
+    bool Peek(const std::string &path) const;
 
     /**
      * Blocks until all jobs currently under processing are finished. After it

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -73,6 +73,14 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
                       const std::string  &hash_suffix,
                       const callback_t   *callback = NULL) = 0;
 
+  /**
+   * Checks if a file is already present in the backend storage
+   *
+   * @param path  the path of the file to be checked
+   * @return      true if the file was found in the backend storage
+   */
+  virtual bool Peek(const std::string &path) const = 0;
+
   virtual void WaitForUpload() const;
   virtual unsigned int GetNumberOfErrors() const = 0;
 

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -41,6 +41,7 @@ void LocalUploader::Upload(const std::string &local_path,
   Respond(callback, retcode, local_path);
 }
 
+
 void LocalUploader::Upload(const std::string  &local_path,
                            const hash::Any    &content_hash,
                            const std::string  &hash_suffix,
@@ -49,6 +50,12 @@ void LocalUploader::Upload(const std::string  &local_path,
                            "data" + content_hash.MakePath(1,2) + hash_suffix);
   Respond(callback, retcode, local_path);
 }
+
+
+bool LocalUploader::Peek(const std::string& path) const {
+  return FileExists(upstream_path_ + "/" + path);
+}
+
 
 int LocalUploader::Copy(const std::string &local_path,
                         const std::string &remote_path) const {
@@ -63,6 +70,7 @@ int LocalUploader::Copy(const std::string &local_path,
 
   return retcode;
 }
+
 
 int LocalUploader::Move(const std::string &local_path,
                         const std::string &remote_path) const {

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -41,6 +41,8 @@ namespace upload
                 const std::string  &hash_suffix,
                 const callback_t   *callback = NULL);
 
+    bool Peek(const std::string& path) const;
+
     /**
      * Determines the number of failed jobs in the LocalCompressionWorker as
      * well as in the Upload() command.

--- a/cvmfs/upload_riak.cc
+++ b/cvmfs/upload_riak.cc
@@ -163,6 +163,11 @@ void RiakUploader::Upload(const std::string  &local_path,
 }
 
 
+bool RiakUploader::Peek(const std::string &path) const {
+  return false; // TODO: fill this with a lookup
+}
+
+
 void RiakUploader::UploadWorkerCallback(const UploadWorker::Results &result) {
   Respond(result.callback, result.return_code, result.local_path);
 }

--- a/cvmfs/upload_riak.h
+++ b/cvmfs/upload_riak.h
@@ -265,13 +265,15 @@ namespace upload {
      *                     able under a certain remote_path in Riak
      * @param callback     the callback to be notified when the upload finished
      */
-    virtual void Upload(const std::string  &local_path,
-                        const std::string  &remote_path,
-                        const callback_t   *callback = NULL);
-    virtual void Upload(const std::string  &local_path,
-                        const hash::Any    &content_hash,
-                        const std::string  &hash_suffix,
-                        const callback_t   *callback = NULL);
+    void Upload(const std::string  &local_path,
+                const std::string  &remote_path,
+                const callback_t   *callback = NULL);
+    void Upload(const std::string  &local_path,
+                const hash::Any    &content_hash,
+                const std::string  &hash_suffix,
+                const callback_t   *callback = NULL);
+
+    bool Peek(const std::string& path) const;
 
     void WaitForUpload() const;
 


### PR DESCRIPTION
This failed because of two things:
- `cvmfs_server add-replica` generated a misconfigured _upstream string_
- `BackendStat` was dead code that needed to be replaced but wasn't yet.

**Note:**
The temporary directory (download location for replicated files) might not work with Riak at the moment. This is kind of tailored for local backends in `cvmfs_server add-replica/snapshot` and might be replaced by a flexible C++ implementation to take different backends (with possibly different replication techniques) into account.
