### PR TITLE
FIX: Memory leak in the FileProcessor.

### DIFF
--- a/cvmfs/upload_file_processor.h
+++ b/cvmfs/upload_file_processor.h
@@ -50,6 +50,8 @@ class TemporaryFileChunk : public FileChunk {
 };
 typedef std::vector<TemporaryFileChunk> TemporaryFileChunks;
 
+class FileProcessor;
+
 /**
  * PendingFiles are created for each processing job. It encapsulates the syn-
  * chronisation of FileProcessor and AbstractUploader.
@@ -59,19 +61,18 @@ typedef std::vector<TemporaryFileChunk> TemporaryFileChunks;
  * be completely finished, it notifies the FileProcessor which then hands out
  * the final results (FileProcessor::Results).
  */
-class PendingFile : public Callbackable<std::string>,
-                    public Lockable {
+class PendingFile : public Lockable {
  public:
   typedef std::map<std::string, TemporaryFileChunk> TemporaryFileChunkMap;
 
  public:
-  PendingFile(const std::string &local_path,
-              const callback_t  *callback) :
+  PendingFile(const std::string   &local_path,
+                    FileProcessor *delegate) :
     local_path_(local_path),
-    finished_callback_(callback),
+    delegate_(delegate),
     chunks_uploaded_(0), errors_(0),
     processing_complete_(false), uploading_complete_(false) {}
-  virtual ~PendingFile();
+  virtual ~PendingFile() {}
 
   void AddChunk(const TemporaryFileChunk  &file_chunk);
   void AddBulk (const TemporaryFileChunk  &file_chunk);
@@ -111,9 +112,11 @@ class PendingFile : public Callbackable<std::string>,
   bool IsCompleted() const { return processing_complete_ && uploading_complete_; }
   bool IsCompletedSuccessfully() const { return IsCompleted() && errors_ == 0; }
 
+  inline const std::string& local_path() const { return local_path_; }
+
  private:
   const std::string      local_path_;
-  const callback_t      *finished_callback_;
+  FileProcessor         *delegate_;
 
   TemporaryFileChunkMap  file_chunks_;
   TemporaryFileChunk     bulk_chunk_;
@@ -215,7 +218,8 @@ class FileProcessor : public ConcurrentWorker<FileProcessor> {
   void UploadChunk(const TemporaryFileChunk &file_chunk,
                          PendingFile        *file) const;
 
-  void ProcessingCompleted(const std::string &local_path);
+  friend class PendingFile;
+  void ProcessingCompleted(PendingFile *pending_file);
   void RemoveCompletedFiles();
 
  private:


### PR DESCRIPTION
`PendingFile` objects were created to keep track of file chunk uploads. Unfortunately they were not deleted properly afterwards.
This is a nasty bug since the deletion should happen when the `PendingFile` invokes it's callback, telling the `FileProcessor` that it is ready to be harvested and deleted. A deletion in the callback itself caused some nasty race conditions, though. My solution is, to save "completed `PendingFiles`" in a list and delete these list entries from time to time.
