### PR TITLE
FIX: Race Condition in FileProcessor

### DIFF
--- a/cvmfs/upload_file_processor.cc
+++ b/cvmfs/upload_file_processor.cc
@@ -215,7 +215,14 @@ void FileProcessor::RemoveCompletedPendingFiles() {
 
   PendingFilesList::iterator       i    = completed_files_.begin();
   PendingFilesList::const_iterator iend = completed_files_.end();
+  PendingFile *file_to_delete;
   for (; i != iend; ++i) {
+    file_to_delete = *i;
+
+    // Prevent a race condition with ProcessingCompleted()
+    // makes sure that this PendingFile is not deleted too early by locking it
+    // before deleting it. The locked mutex will be destroyed by the delete
+    file_to_delete->Lock();
     delete *i;
   }
   completed_files_.clear();


### PR DESCRIPTION
Due to a race condition the FileProcessor occasionally produced a heap corruption, leading to a segmentation fault while publishing a repository.

After a PendingFile is successfully processed and uploaded, the worker thread pushes it into a garbage queue for later deletion. Following this push operation the PendingFile was unlocked by a LockGuard running out of scope.
The race condition occurred, when the garbage queue was emptied by another thread BEFORE this unlock has happened, resulting in a heap corruption when unlocking the already destroyed mutex.

That was nasty! Thanks valgrind!
