### PR TITLE
FIX: read permission issue in test 021 caused it to fail under SLC5

### DIFF
--- a/test/src/021-stacktrace/main
+++ b/test/src/021-stacktrace/main
@@ -22,7 +22,7 @@ cvmfs_run_test() {
   sleep 2
 
   # check if we got a stacktrace of a decent length
-  [ -f $stacktrace_path ] || return 4
+  sudo [ -f $stacktrace_path ] || return 4
   [ $(sudo cat $stacktrace_path | wc -l) -gt 20 ] || return 5
   if ! sudo cat $stacktrace_path | grep '(gdb)' > /dev/null 2>&1; then
   	return 6


### PR DESCRIPTION
The shared cache directory (location of the post mortem stacktrace file) is not readable by a normal user and the `[ -f $stacktrace_path ]` therefore needs sudo. 
