### PR TITLE
FIX: instance_handler.py now handles a missing subcommand correctly

### DIFF
--- a/test/cloud_testing/steering/instance_handler.py
+++ b/test/cloud_testing/steering/instance_handler.py
@@ -153,12 +153,16 @@ parser.add_argument("--cloud-endpoint",
                        dest     = "cloud_endpoint",
                        help     = "URL to the cloud controller")
 
+if len(sys.argv) < 2:
+    print_error("please provide 'spawn' or 'terminate' as a subcommand...")
+    exit(1)
+
 subcommand = sys.argv[1]
-argv = sys.argv[2:]
-if subcommand == "spawn":
+argv       = sys.argv[2:]
+if   subcommand == "spawn":
   create_instance(parser, argv)
 elif subcommand == "terminate":
   terminate_instance(parser, argv)
 else:
-  print_error("give 'spawn' or 'terminate' as subcommand...")
+  print_error("unrecognized subcommand '" + subcommand + "'")
   exit(1)


### PR DESCRIPTION
(the script also works fine on cvmappi13)
