### PR TITLE
FIX: stacktrace generation on private mount points in ubuntu

### DIFF
--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -20,6 +20,7 @@
 #endif
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <sys/prctl.h>
 #include <unistd.h>
 #include <errno.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Yama prevented the spawned gdb to ptrace the dying cvmfs process on ubuntu. This only occured for private mount points, because cvmfs cannot re-gain root rights which would override yama-rules.

This uses `prctl(PR_SET_PTRACER, ...)` to create an exception for the spawned gdb. However, this solution is rather complex and could be implemented easier. This requires a proper rewrite of the monitor...
