### PR TITLE
WORKAROUND: Omit testing perl modules on install on SLC6 x64

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -67,10 +67,10 @@ cd ..
 sudo curl -o /usr/bin/cpanm -L http://cpanmin.us > /dev/null || die "fail (download cpan)"
 sudo chmod 555 /usr/bin/cpanm                                || die "fail (chmod cpan)"
 
-sudo cpanm ZeroMQ          > /dev/null                    || die "fail (install ZeroMQ-perl)"
-sudo cpanm IO::Interface   > /dev/null                    || die "fail (install IO::Interface)"
-sudo cpanm Socket          > /dev/null                    || die "fail (install Socket)"
-sudo cpanm URI             > /dev/null                    || die "fail (install URI)"
+sudo cpanm --notest ZeroMQ          > /dev/null   || die "fail (install ZeroMQ-perl)"
+sudo cpanm --notest IO::Interface   > /dev/null   || die "fail (install IO::Interface)"
+sudo cpanm --notest Socket          > /dev/null   || die "fail (install Socket)"
+sudo cpanm --notest URI             > /dev/null   || die "fail (install URI)"
 cd ..
 echo "done"
 


### PR DESCRIPTION
For some reason a test case in `ExtUtil::MakeMaker-6.66` failed suddenly when installing the `ZeroMQ` perl modules. These are just test dependencies of the perl-services.
This patch disables the test runs when installing perl module. We do not want to be disturbed by failing test cases in perl dependencies during setup of our test machine.
