### PR TITLE
FIX: integration tests 515 and 516 failed due to misconfiguration

### DIFF
--- a/test/src/515-createsnapshot/main
+++ b/test/src/515-createsnapshot/main
@@ -136,6 +136,7 @@ cvmfs_run_test() {
   mkdir $mnt_point cache
   cat > private.conf << EOF
 CVMFS_CACHE_BASE=$(pwd)/cache
+CVMFS_RELOAD_SOCKETS=$(pwd)/cache
 CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/${CVMFS_TEST_REPO}
 CVMFS_HTTP_PROXY=DIRECT
 CVMFS_PUBLIC_KEY=$(pwd)/keys/${CVMFS_TEST_REPO}.pub

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -165,6 +165,7 @@ cvmfs_run_test() {
   mkdir $mnt_point cache
   cat > private.conf << EOF
 CVMFS_CACHE_BASE=$(pwd)/cache
+CVMFS_RELOAD_SOCKETS=$(pwd)/cache
 CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/${CVMFS_TEST_REPO}
 CVMFS_HTTP_PROXY=DIRECT
 CVMFS_PUBLIC_KEY=$(pwd)/keys/${CVMFS_TEST_REPO}.pub


### PR DESCRIPTION
The CernVM-FS client was not able to allocate reload sockets in the default location when these test cases tried to create a private mount point.
This patch adds the missing configuration lines.
