### PR TITLE
Fix reload traversal

### DIFF
--- a/test/src/023-reload_safe_path_traversal/main
+++ b/test/src/023-reload_safe_path_traversal/main
@@ -45,6 +45,7 @@ cvmfs_run_test() {
 
   # gracefully get rid of the catalog reload worker
   kill -s HUP $reload_cmd >> $logfile 2>&1
+  wait $reload_cmd
 
   # check if all went well
   if [ $retval -ne 0 ]; then


### PR DESCRIPTION
**Note:** Please review! I'm not 100% sure that this is the right way to go. In a simple test script with some `echo` and `sleep` it worked fine, though. 

the reload worker is now terminated gracefully... it seemed that otherwise it might stay alive and affect successive tests
