### PR TITLE
Fix to cvmfs_listxattr

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1114,10 +1114,10 @@ static void cvmfs_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
     "user.host\0user.proxy\0user.uptime\0user.nclg\0user.nopen\0user.ndownload\0"
     "user.timeout\0user.timeout_direct\0user.rx\0user.speed\0user.fqrn\0"
     "user.ndiropen\0";
-  string attribute_list(base_list, sizeof(base_list));
+  string attribute_list(base_list, sizeof(base_list)-1);
   if (!d.checksum().IsNull()) {
     const char regular_file_list[] = "user.hash\0user.lhash\0";
-    attribute_list += string(regular_file_list, sizeof(regular_file_list));
+    attribute_list += string(regular_file_list, sizeof(regular_file_list)-1);
   }
 
   if (size == 0) {


### PR DESCRIPTION
The listxattr fuse function (cvmfs_listxattr) returns a list that contains an entry with a null string for regular files, which causes some xattr programs that don't check for this to error out when they subsequently do a getxattr on the empty string. This is because when the C++ std:string objects are constructed, the sizeof the char[] contains the terminating null in addition to the null explicitly within the string. 

This fix changes the two instances of sizeof(char[]) to be sizeof(char[])-1 to address this issue. 
