### PR TITLE
FIX: T_ManagedExec test case

### DIFF
--- a/test/unittests/t_managed_exec.cc
+++ b/test/unittests/t_managed_exec.cc
@@ -72,11 +72,13 @@ TEST(T_ManagedExec, ExecuteBinaryAsChild) {
   pid_t my_pid = getpid();
 
   // spawn a child process (not double forked)
+  const bool double_fork = false;
   bool retval = ExecuteBinary(&fd_stdin,
                               &fd_stdout,
                               &fd_stderr,
                                "gdb",
                                std::vector<std::string>(),
+                               double_fork,
                               &child_pid);
 
   // check that the process is running


### PR DESCRIPTION
This re-inserts the `double_fork` flag into the call to `MangedExec()` in the `ExecuteBinaryAsChild` test.
**HOT:** The compiler does not complain about passing a `pid_t*` as a `bool`. _sigh_
