### PR TITLE
Remove std::string support from pipe wrapper

### DIFF
--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -213,34 +213,6 @@ void MakePipe(int pipe_fd[2]) {
 }
 
 
-template<>
-bool Pipe::Write<std::string>(const std::string &data) {
-  const size_t string_length = data.size();
-  return Write(string_length) && Write(data.c_str(), string_length);
-}
-
-
-template<>
-bool Pipe::Read<std::string>(std::string *data) {
-  size_t string_length;
-  bool retval = Read(&string_length);
-  if (!retval)
-    return false;
-
-  void *buffer = smalloc(string_length + 1);
-  retval = Read(buffer, string_length);
-  if (!retval)
-    return false;
-
-  char *c_buffer = static_cast<char *>(buffer);
-  c_buffer[string_length] = '\0';
-  data->assign(c_buffer);
-  free(buffer);
-
-  return true;
-}
-
-
 /**
  * Writes to a pipe should always succeed.
  */

--- a/test/unittests/t_pipe.cc
+++ b/test/unittests/t_pipe.cc
@@ -118,16 +118,3 @@ TEST_F(T_Pipe, ReadRaw) {
 
   EXPECT_EQ (0, strncmp(data, res_data, data_length)) << "Data did not match";
 }
-
-
-TEST_F(T_Pipe, StdString) {
-  const std::string foo = "Just a usual string...";
-
-  bool retval;
-  retval = pipe.Write(foo); EXPECT_TRUE (retval);
-
-  std::string ret_string;
-  retval = pipe.Read(&ret_string); EXPECT_TRUE (retval);
-
-  EXPECT_EQ (foo, ret_string);
-}


### PR DESCRIPTION
This removes the template specialization for `std::string` from the pipe wrapper template. It was anyway not used at the moment.
(Caused fatal problems on SLC5... obviously it was linked to the general template and not to the specialization)
