### PR TITLE
FIX: Configure failed because of misplaced library pathes

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -170,9 +170,9 @@ include_directories (${INCLUDE_DIRECTORIES})
 if (BUILD_CVMFS)
 
   add_executable (cvmfs2 ${CVMFS_LOADER_SOURCES})
-  add_library (cvmfs_fuse_debug SHARED  ${CVMFS2_DEBUG_SOURCES} ${LIBFUSE_ARCHIVE} ${SQLITE3_ARCHIVE} ${LIBCURL_ARCHIVE} ${CARES_ARCHIVE} ${ZLIB_ARCHIVE})
-  add_library (cvmfs_fuse SHARED ${CVMFS2_SOURCES} ${LIBFUSE_ARCHIVE} ${SQLITE3_ARCHIVE} ${LIBCURL_ARCHIVE} ${CARES_ARCHIVE} ${ZLIB_ARCHIVE})
-  add_executable (cvmfs_fsck    ${CVMFS_FSCK_SOURCES} ${ZLIB_ARCHIVE})
+  add_library (cvmfs_fuse_debug SHARED  ${CVMFS2_DEBUG_SOURCES})
+  add_library (cvmfs_fuse SHARED ${CVMFS2_SOURCES})
+  add_executable (cvmfs_fsck ${CVMFS_FSCK_SOURCES})
 
   if (LIBFUSE_BUILTIN)
     add_dependencies (cvmfs_fuse_debug libfuse) # here it does not matter if libfuse or libfuse4x


### PR DESCRIPTION
We've had library paths in CMake's `add_executable` and `add_library` directives. These libraries have to be built by `make` and are therefore not present at configure-time. Obviously older CMake versions complain about that...

This removes the library paths that do not belong there anyway. The dependencies were already correctly specified using `add_dependency` and `target_link_library`
