### PR TITLE
FIX: remove double listing of testutil.{cc|h}

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -26,9 +26,6 @@ set (CVMFS_UNITTEST_SOURCES
   # test utility functions
   testutil.cc testutil.h
 
-  # test utility functions
-  testutil.cc testutil.h
-
   # test dependencies
   ${CVMFS_SOURCE_DIR}/atomic.h
   ${CVMFS_SOURCE_DIR}/logging.h


### PR DESCRIPTION
Obviously one of the merges screwed up the source file listing for the unit tests. CMake produced a warning.
[Fixed]
