### PR TITLE
FIX: Stacktrace Creation

### DIFF
--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -269,8 +269,7 @@ static string GenerateStackTrace(const string &exe_path,
                           argv,
                           double_fork,
                          &gdb_pid);
-  assert(false);
-  //assert(retval);
+  assert(retval);
 
   // Skip the gdb startup output
   ReadUntilGdbPrompt(fd_stdout);


### PR DESCRIPTION
There was an `assert (false)` in the middle of the code... I have no idea how this ended up there O.o
