### PR TITLE
adapt cvmfs_config and cvmfs_server for openrc

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -14,9 +14,12 @@ case $sys_arch in
   Linux )
     if [ -x /sbin/service ]; then
       service="/sbin/service"
-    else
+    elif [ -x /sbin/service ]; then
       # Ubuntu
       service="/usr/sbin/service"
+    elif [ -x /sbin/rc-service ] ; then
+      # OpenRC
+      service="/sbin/rc-service"
     fi
     if [ -x /sbin/pidof ]; then
       pidof="/sbin/pidof"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -48,8 +48,10 @@ fi
 # Find the service binary
 if [ -x /sbin/service ]; then
   SERVICE_BIN="/sbin/service"
-else
+elif [ -x /usr/sbin/service ]; then
   SERVICE_BIN="/usr/sbin/service" # Ubuntu
+elif [ -x /sbin/rc-service ]; then
+  SERVICE_BIN="/sbin/rc-service" # OpenRC
 fi
 [ -z "$SERVICE_BIN" ] && die "Could not locate 'service' utility"
 
@@ -57,7 +59,7 @@ fi
 if [ -x /sbin/fuser ]; then
   fuser="/sbin/fuser" # RHEL
 else
-  fuser="/bin/fuser"  # Ubuntu, SuSe
+  fuser="/bin/fuser"  # Ubuntu, SuSe, Gentoo
 fi
 
 # standard values


### PR DESCRIPTION
This simple patch allows OpenRC init service (Gentoo and other distros) to be called from cvmfs scripts.
