### PR TITLE
FIX: ASSERT_DEATH() segfaults for no obvious reason under SLC6

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -9,7 +9,8 @@ sudo service httpd start
 
 # run tests
 echo "running CernVM-FS unit tests..."
-cvmfs_unittests --gtest_shuffle >> $UNITTEST_LOGFILE 2>&1 || die "fail"
+cvmfs_unittests --gtest_shuffle \
+                --gtest_death_test_use_fork >> $UNITTEST_LOGFILE 2>&1 || die "fail"
 
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test


### PR DESCRIPTION
googletest uses `clone()` to spawn a new process when using `ASSERT_DEATH()`. For no obvious reason this segfaults and interrupts the test run on SLC6 x64. Fortunately one can configure googletest to use `fork()`/`_exit()` instead, which works fine.
