### PR TITLE
support for overlayfs

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2047,7 +2047,7 @@ publish() {
     -t ${spool_dir}/tmp \
     -r ${upstream}"
 
-  $user_shell "$sync_command" || die "Synchronization failed\n\nExecuted Command:\n$sync_command"
+  $user_shell "$sync_command" || (sudo /bin/mount -o remount,rw /cvmfs/$name && die "Synchronization failed\n\nExecuted Command:\n$sync_command")
   local trunk_hash=$(grep "^C" ${spool_dir}/tmp/manifest | tr -d C)
   local trunk_revision=$(grep "^S" ${spool_dir}/tmp/manifest | tr -d S)
   tag_command="$tag_command -t $trunk_hash -i $trunk_revision $tag_hash"

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -65,22 +65,22 @@ uint64_t SyncItem::GetRdOnlyInode() const {
 
 
 unsigned int SyncItem::GetUnionLinkcount() const {
-	StatUnion();
-	return union_stat_.stat.st_nlink;
+  StatUnion();
+  return union_stat_.stat.st_nlink;
 }
 
 
 uint64_t SyncItem::GetUnionInode() const {
-	StatUnion();
-	return union_stat_.stat.st_ino;
+  StatUnion();
+  return union_stat_.stat.st_ino;
 }
 
 
 void SyncItem::StatGeneric(const string &path, EntryStat *info) {
-	int retval = platform_lstat(path.c_str(), &info->stat);
+  int retval = platform_lstat(path.c_str(), &info->stat);
   if (retval != 0)
     info->error_code = errno;
-	info->obtained = true;
+  info->obtained = true;
 }
 
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -143,8 +143,8 @@ void SyncMediator::EnterDirectory(SyncItem &entry) {
 void SyncMediator::LeaveDirectory(SyncItem &entry)
 {
   CompleteHardlinks(entry);
-	AddLocalHardlinkGroups(GetHardlinkMap());
-	hardlink_stack_.pop();
+  AddLocalHardlinkGroups(GetHardlinkMap());
+  hardlink_stack_.pop();
 }
 
 

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -89,7 +89,7 @@ class SyncMediator {
   void Remove(SyncItem &entry);
   void Replace(SyncItem &entry);
 
-	void EnterDirectory(SyncItem &entry);
+  void EnterDirectory(SyncItem &entry);
   void LeaveDirectory(SyncItem &entry);
 
   manifest::Manifest *Commit();
@@ -145,7 +145,7 @@ class SyncMediator {
   // Hardlink handling
   void CompleteHardlinks(SyncItem &entry);
   HardlinkGroupMap &GetHardlinkMap() { return hardlink_stack_.top(); }
-	void LegacyRegularHardlinkCallback(const std::string &parent_dir,
+  void LegacyRegularHardlinkCallback(const std::string &parent_dir,
                                      const std::string &file_name);
   void LegacySymlinkHardlinkCallback(const std::string &parent_dir,
                                       const std::string &file_name);
@@ -168,10 +168,10 @@ class SyncMediator {
    */
   HardlinkGroupMapStack hardlink_stack_;
 
-	/**
-	 * New and modified files are sent to an external spooler for hashing and
+  /**
+   * New and modified files are sent to an external spooler for hashing and
    * compression.  A spooler callback adds them to the catalogs, once processed.
-	 */
+   */
   pthread_mutex_t lock_file_queue_;
   SyncItemList file_queue_;
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -32,6 +32,8 @@ SyncUnion::SyncUnion(SyncMediator *mediator,
 bool SyncUnion::ProcessDirectory(const string &parent_dir,
                                  const string &dir_name)
 {
+  LogCvmfs(kLogUnion, kLogDebug, "SyncUnion::ProcessDirectory(%s, %s)",
+           parent_dir.c_str(), dir_name.c_str());
   SyncItem entry(parent_dir, dir_name, kItemDir, this);
 
   if (entry.IsNew()) {
@@ -53,6 +55,8 @@ bool SyncUnion::ProcessDirectory(const string &parent_dir,
 void SyncUnion::ProcessRegularFile(const string &parent_dir,
                                    const string &filename)
 {
+  LogCvmfs(kLogUnion, kLogDebug, "SyncUnion::ProcessRegularFile(%s, %s)",
+           parent_dir.c_str(), filename.c_str());
   SyncItem entry(parent_dir, filename, kItemFile, this);
   ProcessFile(entry);
 }
@@ -61,12 +65,16 @@ void SyncUnion::ProcessRegularFile(const string &parent_dir,
 void SyncUnion::ProcessSymlink(const string &parent_dir,
                                const string &link_name)
 {
+  LogCvmfs(kLogUnion, kLogDebug, "SyncUnion::ProcessSymlink(%s, %s)",
+           parent_dir.c_str(), link_name.c_str());
   SyncItem entry(parent_dir, link_name, kItemSymlink, this);
   ProcessFile(entry);
 }
 
 
 void SyncUnion::ProcessFile(SyncItem &entry) {
+  LogCvmfs(kLogUnion, kLogDebug, "SyncUnion::ProcessFile(%s)",
+           entry.filename().c_str());
   // Process whiteout prefix
   if (IsWhiteoutEntry(entry)) {
     string actual_filename = UnwindWhiteoutFilename(entry.filename());
@@ -165,6 +173,101 @@ SyncUnionOverlayfs::SyncUnionOverlayfs(SyncMediator *mediator,
   
 }
   
+  void SyncUnionOverlayfs::ProcessFile(SyncItem &entry) {
+    LogCvmfs(kLogUnion, kLogDebug, "SyncUnionOverlayfs::ProcessFile(%s)",
+             entry.filename().c_str());
+
+    // if lower-level file exists and has multiple hard links, warn user 
+    if (!entry.IsNew() && entry.GetRdOnlyLinkcount() > 1) {
+    
+      LogCvmfs(kLogPublish, kLogVerboseMsg, 
+               "OverlayFS have copied-up file %s with "
+               "existing hardlinks in lowerdir.",
+               entry.GetUnionPath().c_str());
+
+      hardlink_lower_inode_ = entry.GetRdOnlyInode();
+      hardlink_lower_files_.clear();
+
+      std::string rdonly_parent_dir = GetParentPath(entry.GetRdOnlyPath());
+      std::string scratch_parent_dir = GetParentPath(entry.GetScratchPath());
+      std::string union_parent_dir = GetParentPath(entry.GetUnionPath());
+
+      // Find all hardlinks in lowerdir corresponding to this entry
+      // (only check this dir since we don't allow cross-dir hardlinks in CVMFS)
+      FileSystemTraversal<SyncUnionOverlayfs> traversal(this, rdonly_path(), false);
+      traversal.fn_new_file = &SyncUnionOverlayfs::ProcessFileHardlinkCallback;
+      traversal.fn_new_symlink = &SyncUnionOverlayfs::ProcessFileHardlinkCallback;
+      traversal.Recurse(rdonly_parent_dir);
+
+      // Should now have hardlink_lower_files_ populated with the files in this hardlink group
+      if ( hardlink_lower_files_.size() != entry.GetRdOnlyLinkcount() ) {
+        LogCvmfs(kLogUnion, kLogWarning, "Found %u entries in hardlink group for %s in overlayfs lowerdir directory %s, was expecting %u (do the hardlinks span directories?)",
+                 hardlink_lower_files_.size(),
+		 entry.GetRdOnlyPath().c_str(),
+       	         rdonly_parent_dir.c_str(),
+                 entry.GetRdOnlyLinkcount());
+      } else {
+        LogCvmfs(kLogUnion, kLogDebug, "Found %u entries in hardlink group for %s in overlayfs lowerdir directory %s, as expected.",
+                 hardlink_lower_files_.size(),
+		 entry.GetRdOnlyPath().c_str(),
+       	         GetParentPath(entry.GetRdOnlyPath()).c_str());
+	// have the expected number of entries in the hardlink group, 
+        // check if they are all present in the scratch layer (upperdir)
+        for (std::set<std::string>::iterator i = hardlink_lower_files_.begin(); i != hardlink_lower_files_.end(); ++i) {
+	  std::string filename = *i;
+
+	  std::string scratch_path = scratch_parent_dir + "/" + filename;
+	  std::string union_path = union_parent_dir + "/" + filename;
+	  platform_stat64 scratch_stat;
+          LogCvmfs(kLogUnion, kLogDebug, "Checking file %s",
+		   scratch_path.c_str());
+          if ( platform_lstat(scratch_path.c_str(), &scratch_stat) < 0 ) {
+	    if ( errno == ENOENT ) {
+              // file is not present in scratch, warn, and/or abort
+	      LogCvmfs(kLogUnion, kLogWarning, 
+		       "[WARNING] a file in the OverlayFS lowerdir (%s) has multiple "
+		       "hard links one of which (%s) has been modified in CVMFS.  " 
+		       "Due to a limitation in OverlayFS, after this sync the modified "
+		       "file would no longer be part of its previous hardlink group "
+		       "(CVMFS inode %u).  The sync operation will now be aborted so "
+                       "that this issue can be corrected manually by explicitly "
+		       "including all files in the entire hardlink group in the "
+		       "CVMFS transaction. To restore this hardlink, try something like:\n"
+		       "rm %s && ln %s %s\n"
+		       "To restore all hardlinks in this group, try something like:\n"
+		       "for file in $(find %s -inum %u); do rm ${file} && ln %s ${file}; done",
+		       filename.c_str(), 
+		       entry.GetUnionPath().c_str(),
+		       entry.GetRdOnlyInode(),
+		       union_path.c_str(),
+		       entry.GetUnionPath().c_str(), union_path.c_str(),
+		       union_parent_dir.c_str(), entry.GetRdOnlyInode(), entry.GetUnionPath().c_str()
+		       );
+	      abort();
+	    }
+	  }
+        }
+      }
+    }
+    
+    SyncUnion::ProcessFile(entry);
+  }
+
+  void SyncUnionOverlayfs::ProcessFileHardlinkCallback(const string &parent_dir,
+                                                       const string &filename) {
+    LogCvmfs(kLogUnion, kLogDebug, "SyncUnionOverlayfs::ProcessFileHardlinkCallback(%s, %s)",
+             parent_dir.c_str(), filename.c_str());
+    SyncItem entry(parent_dir, filename, kItemFile, this);
+    if ( entry.GetRdOnlyLinkcount() > 1 ) {
+      if ( hardlink_lower_inode_ == entry.GetRdOnlyInode() ) {
+        LogCvmfs(kLogUnion, kLogDebug, "SyncUnionOverlayfs::ProcessFileHardlinkCallback "
+                 "have member of inode group %u: %s/%s",
+                 hardlink_lower_inode_, parent_dir.c_str(), filename.c_str());
+        hardlink_lower_files_.insert(entry.filename());
+      }
+    }
+  }
+
   void SyncUnionOverlayfs::Traverse() {
     FileSystemTraversal<SyncUnionOverlayfs>
       traversal(this, scratch_path(), true);
@@ -176,12 +279,12 @@ SyncUnionOverlayfs::SyncUnionOverlayfs(SyncMediator *mediator,
     traversal.fn_new_dir_prefix = &SyncUnionOverlayfs::ProcessDirectory;
     traversal.fn_new_symlink = &SyncUnionOverlayfs::ProcessSymlink;
     
-    LogCvmfs(kLogUnion, kLogVerboseMsg, "overlayfs starting traversal "
+    LogCvmfs(kLogUnion, kLogVerboseMsg, "OverlayFS starting traversal "
              "recursion for scratch_path=[%s]",
              scratch_path().c_str());
     traversal.Recurse(scratch_path());
   }
-  
+
   /**
    * Wrapper around readlink to read the value of the symbolic link 
    * and return true if it is equal to the supplied value, or false 
@@ -237,10 +340,10 @@ SyncUnionOverlayfs::SyncUnionOverlayfs(SyncMediator *mediator,
   bool SyncUnionOverlayfs::IsWhiteoutSymlinkPath(const std::string &path) const {
     bool is_whiteout = ReadlinkEquals(path, "(overlay-whiteout)") && XattrEquals(path.c_str(), "trusted.overlay.whiteout", "y");
     if (is_whiteout) {
-      LogCvmfs(kLogUnion, kLogDebug, "overlayfs [%s] is whiteout symlink",
+      LogCvmfs(kLogUnion, kLogDebug, "OverlayFS [%s] is whiteout symlink",
                path.c_str());
     } else {
-      LogCvmfs(kLogUnion, kLogDebug, "overlayfs [%s] is not a whiteout symlink",
+      LogCvmfs(kLogUnion, kLogDebug, "OverlayFS [%s] is not a whiteout symlink",
                path.c_str());
     }
     return is_whiteout;
@@ -253,7 +356,7 @@ SyncUnionOverlayfs::SyncUnionOverlayfs(SyncMediator *mediator,
   bool SyncUnionOverlayfs::IsOpaqueDirPath(const std::string &path) const {
     bool is_opaque = XattrEquals(path.c_str(), "trusted.overlay.opaque", "y");
     if (is_opaque) {
-      LogCvmfs(kLogUnion, kLogDebug, "overlayfs [%s] has opaque xattr", 
+      LogCvmfs(kLogUnion, kLogDebug, "OverlayFS [%s] has opaque xattr", 
                path.c_str());
     }
     return is_opaque;
@@ -265,8 +368,8 @@ SyncUnionOverlayfs::SyncUnionOverlayfs(SyncMediator *mediator,
   
   bool SyncUnionOverlayfs::IgnoreFilePredicate(const std::string &parent_dir,
                                                const std::string &filename) {
-    // no files need to be ignored for overlayfs 
+    // no files need to be ignored for OverlayFS 
     return false;
   }
-  
+
 }  // namespace sync

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -122,7 +122,7 @@ class SyncUnion {
    * @param filename the filename
    */
   virtual void ProcessRegularFile(const std::string &parent_dir,
-	                                const std::string &filename);
+                                  const std::string &filename);
 
   /**
    * Callback when a directory is found.
@@ -157,8 +157,14 @@ class SyncUnion {
   virtual void LeaveDirectory(const std::string &parent_dir,
                               const std::string &dir_name);
 
+
+  /**
+   * Called to actually process the file entry.
+   * @param entry the SyncItem corresponding to the union file to be processed
+   */
+  virtual void ProcessFile(SyncItem &entry);
+
  private:
-  void ProcessFile(SyncItem &entry);
 };  // class SyncUnion
 
 
@@ -193,26 +199,32 @@ class SyncUnionAufs : public SyncUnion {
  */
 class SyncUnionOverlayfs : public SyncUnion {
  public:
-	SyncUnionOverlayfs(SyncMediator *mediator,
-  	            const std::string &rdonly_path,
-  	            const std::string &union_path,
-                const std::string &scratch_path);
+  SyncUnionOverlayfs(SyncMediator *mediator,
+                     const std::string &rdonly_path,
+                     const std::string &union_path,
+                     const std::string &scratch_path);
 
-	void Traverse();
-	static bool ReadlinkEquals(std::string const &path, std::string const &compare_value);
-	static bool XattrEquals(std::string const &path, std::string const &attr_name, std::string const &compare_value);
+  void Traverse();
+  void ProcessFileHardlinkCallback(const std::string &parent_dir,
+                                   const std::string &filename);
+  static bool ReadlinkEquals(std::string const &path, std::string const &compare_value);
+  static bool XattrEquals(std::string const &path, std::string const &attr_name, 
+                          std::string const &compare_value);
 
  protected:
-	bool IsWhiteoutEntry(const SyncItem &entry) const;
-	bool IsOpaqueDirectory(const SyncItem &directory) const;
-	bool IgnoreFilePredicate(const std::string &parent_dir,
-	                         const std::string &filename);
-	std::string UnwindWhiteoutFilename(const std::string &filename) const;
-	std::set<std::string> GetIgnoreFilenames() const;
+  bool IsWhiteoutEntry(const SyncItem &entry) const;
+  bool IsOpaqueDirectory(const SyncItem &directory) const;
+  bool IgnoreFilePredicate(const std::string &parent_dir,
+                           const std::string &filename);
+  std::string UnwindWhiteoutFilename(const std::string &filename) const;
+  std::set<std::string> GetIgnoreFilenames() const;
+  virtual void ProcessFile(SyncItem &entry);
 
  private:
-	bool IsWhiteoutSymlinkPath(const std::string &path) const;
-	bool IsOpaqueDirPath(const std::string &path) const;
+  bool IsWhiteoutSymlinkPath(const std::string &path) const;
+  bool IsOpaqueDirPath(const std::string &path) const;
+  std::set<std::string> hardlink_lower_files_;
+  uint64_t hardlink_lower_inode_;
 
 };  // class SyncUnionOverlayfs
 


### PR DESCRIPTION
I've added support for overlayfs (in place of aufs).  

The default is always aufs, so I think nothing should break as a result. Overlayfs support can be enabled by passing a "-f overlayfs" argument to cvmfs_server (i.e. "cvmfs_server mkfs -f overlayfs"). 

Behind the scenes, this adds a "CVMFS_UNION_FS_TYPE=overlayfs" line to server.conf under repositories.d which causes "cvmfs_swissknife sync" to rely on overlayfs code instead of aufs code (both are implemented in sync_union.cc). I think this way it should be possible to have both overlayfs and aufs based repositories on the same machine (not sure why one would want to, but I didn't see any reason not to support it). 

I welcome any questions or review before merging...

Josh.
