### PR TITLE
FIX: history controls in cvmfs_server

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1651,18 +1651,15 @@ publish() {
 
   # more sanity checks
   check_repository_compatibility
-  check_expiry $stratum0 || die "Repository whitelist is expired!"
-  [ -f ${spool_dir}/in_transaction ] || die "Not in a transaction"
+  check_expiry $stratum0                  || die "Repository whitelist is expired!"
+  [ -f ${spool_dir}/in_transaction ]      || die "Not in a transaction"
   $fuser -m /cvmfs/$name > /dev/null 2>&1 && die "Open file descriptors on $name"
   if [ "x$add_tag" != "x" ]; then
-    if [ "x$tag_name" = "x" ]; then
-      echo "Tag name missing"
-      return 1
-    fi
+    [ "x$tag_name" != "x" ]               || die "Tag name missing"
+    echo $tag_name | grep -q -v "\s"      || die "Spaces are not allowed in tag names"
     if lstags $name | cut --delimiter=' ' --fields=1 | grep -q "^$tag_name$" &&
        [ x"$tag_hash" = "x" ]; then
-      echo "Tag name '$tag_name' is already in use. Maybe you wanted to specify -h to move it?"
-      return 1
+      die "Tag name '$tag_name' is already in use. Maybe you wanted to specify -h to move it?"
     fi
     add_tag="-a \"${tag_name}@${tag_channel}@${tag_description}\""
   fi


### PR DESCRIPTION
This provides some improvements of the history handling in `cvmfs_server`.
In particular:
- possibility to use tag descriptions with spaces
- sanity check for duplicating tag names
