### PR TITLE
Make unittests run under OS X

### DIFF
--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ftw.h>
+#include <errno.h>
 
 #include <string>
 #include <sstream>

--- a/test/unittests/t_util_concurrency.cc
+++ b/test/unittests/t_util_concurrency.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <errno.h>
 
 #include "../../cvmfs/util_concurrency.h"
 


### PR DESCRIPTION
Simpler than expected:
- some missing includes
- GetParentPID() uses `/proc` which of course is not available in OS X
