### PR TITLE
Fix timeouts in NFS shared maps

### DIFF
--- a/cvmfs/nfs_shared_maps.cc
+++ b/cvmfs/nfs_shared_maps.cc
@@ -225,6 +225,9 @@ string GetStatistics() {
 
 static int BusyHandler(void *data, int attempt) {
   BusyHandlerInfo *handler_info = static_cast<BusyHandlerInfo *>(data);
+  // Reset the accumulated time if this is the start of a new request
+  if (attempt == 0)
+    handler_info->accumulated_ms = 0;
   LogCvmfs(kLogNfsMaps, kLogDebug,
            "busy handler, attempt %d, accumulated waiting time %u",
            attempt, handler_info->accumulated_ms);


### PR DESCRIPTION
Hi Jakob,

I've found a bug in the NFS shared maps code where the time-out counter's accumulated time field is never reset which eventually causes it to abort(). This small patch fixes the problem.

Regards,
Simon
