### PR TITLE
FIX: missing template parameters

### DIFF
--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -594,11 +594,11 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::CleanupNestedCatalogs(
 
 CommandMigrate::MigrationWorker_20x::MigrationWorker_20x(
                                                 const worker_context *context) :
-  AbstractMigrationWorker        (context),
-  fix_nested_catalog_transitions_(context->fix_nested_catalog_transitions),
-  analyze_file_linkcounts_       (context->analyze_file_linkcounts),
-  uid_                           (context->uid),
-  gid_                           (context->gid) { }
+  AbstractMigrationWorker<MigrationWorker_20x> (context),
+  fix_nested_catalog_transitions_              (context->fix_nested_catalog_transitions),
+  analyze_file_linkcounts_                     (context->analyze_file_linkcounts),
+  uid_                                         (context->uid),
+  gid_                                         (context->gid) { }
 
 
 bool CommandMigrate::MigrationWorker_20x::RunMigration(PendingCatalog *data) const {
@@ -1320,7 +1320,7 @@ bool CommandMigrate::MigrationWorker_20x::DetachOldCatalogDatabase(
 
 CommandMigrate::MigrationWorker_217::MigrationWorker_217(
                                                 const worker_context *context) :
-  AbstractMigrationWorker(context) {
+  AbstractMigrationWorker<MigrationWorker_217>(context) {
 
 }
 

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -130,8 +130,8 @@ class CommandMigrate : public Command {
                      const bool          analyze_file_linkcounts,
                      const uid_t         uid,
                      const gid_t         gid) :
-        AbstractMigrationWorker::worker_context(temporary_directory,
-                                                collect_catalog_statistics),
+        AbstractMigrationWorker<MigrationWorker_20x>::worker_context(temporary_directory,
+                                                                     collect_catalog_statistics),
         fix_nested_catalog_transitions(fix_nested_catalog_transitions),
         analyze_file_linkcounts(analyze_file_linkcounts),
         uid(uid),


### PR DESCRIPTION
GCC 4.4.x did not digest the left out template parameters _inside_ a derived template class. The question is: What is actually more standard conform. :o)
