### PR TITLE
Polishing for failover test cases

### DIFF
--- a/test/src/016-dnsunreachable/main
+++ b/test/src/016-dnsunreachable/main
@@ -29,9 +29,8 @@ cvmfs_run_test() {
 
   if [ $seconds -gt 2 ]; then
     echo "timeout was too long: $seconds (expected at most 2)" >> $logfile
-    return 3
+    CVMFS_TIME_WARNING_FLAG=1
   fi
 
   return 0
 }
-

--- a/test/src/017-dnstimeout/main
+++ b/test/src/017-dnstimeout/main
@@ -36,7 +36,7 @@ cvmfs_run_test() {
 
   if [ $seconds -gt 8 ]; then
     echo "timeout was too long: $seconds (expected at most 8)" >> $logfile
-    retcode=5
+    CVMFS_TIME_WARNING_FLAG=1
   fi
 
   echo "killing the mocked DNS server" >> $logfile

--- a/test/src/018-httpunreachable/main
+++ b/test/src/018-httpunreachable/main
@@ -30,7 +30,7 @@ cvmfs_run_test() {
 
   if [ $seconds -gt 8 ]; then
     echo "mounting took too long with $seconds seconds (expected 8)" >> $logfile
-    return 1
+    CVMFS_TIME_WARNING_FLAG=1
   fi
 
   echo "checking host chain" >> $logfile

--- a/test/src/019-httptimeout/main
+++ b/test/src/019-httptimeout/main
@@ -50,7 +50,7 @@ cvmfs_run_test() {
 
   if [ $seconds -gt 6 ]; then
     echo "mounting took too long with $seconds seconds (expected 6)" >> $logfile
-    retval=7
+    CVMFS_TIME_WARNING_FLAG=1
   fi
 
   return $retval


### PR DESCRIPTION
This polishes the failover tests that are already up and running:
- add missing sudo
- timeout checks produce a warning instead of a failure
- working around autofs influences of consecutive tests
- do a host chain check to verify successful failover
