### PR TITLE
HOTFIX: Testcase 508 uses available versions of cvmfs source tar balls

### DIFF
--- a/test/src/508-cvmfsdevelopment/main
+++ b/test/src/508-cvmfsdevelopment/main
@@ -3,10 +3,11 @@ cvmfs_test_name="Simulate CVMFS Development"
 cvmfs_test_autofs_on_startup=false
 
 # cvmfs source tarballs to be downloaded and used as test data
-cvmfs_versions="http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.1/cvmfs-2.1.1.tar.gz
-http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.2/cvmfs-2.1.2.tar.gz
-http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.3/cvmfs-2.1.3.tar.gz
-http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.4/cvmfs-2.1.4.tar.gz"
+# TODO: replace this by upcoming CVMFS versions...
+cvmfs_versions="http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.11/cvmfs-2.1.11.tar.gz
+http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.12/cvmfs-2.1.12.tar.gz
+http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.11/cvmfs-2.1.11.tar.gz
+http://ecsft.cern.ch/dist/cvmfs/cvmfs-2.1.12/cvmfs-2.1.12.tar.gz"
 
 
 # retrieve the URL at a given index (dash workaround)
@@ -69,8 +70,8 @@ configure_nested_catalogs() {
       rm -f $working_dir/cvmfs/.cvmfscatalog
       ;;
     2)
-      touch $working_dir/test/HTTP/.cvmfscatalog
-      touch $working_dir/test/LWP/.cvmfscatalog
+      touch $working_dir/test/cloud_testing/platforms/.cvmfscatalog
+      touch $working_dir/test/cloud_testing/steering/.cvmfscatalog
       rm -f $working_dir/test/.cvmfscatalog
       ;;
     3)
@@ -78,8 +79,8 @@ configure_nested_catalogs() {
       rm -f $working_dir/externals/zlib/.cvmfscatalog
       rm -f $working_dir/externals/sqlite3/.cvmfscatalog
       rm -f $working_dir/cvmfs/.cvmfscatalog
-      rm -f $working_dir/test/HTTP/.cvmfscatalog
-      rm -f $working_dir/test/LWP/.cvmfscatalog
+      rm -f $working_dir/test/cloud_testing/steering/.cvmfscatalog
+      rm -f $working_dir/test/cloud_testing/platforms/.cvmfscatalog
       ;;
   esac
 }
@@ -127,12 +128,12 @@ check_catalog_configuration() {
       if [ $(get_catalog_count $repo_name) -ne 6 ]; then
         return 2
       fi
-      if check_catalog_presence /                  $repo_name && \
-         check_catalog_presence /externals         $repo_name && \
-         check_catalog_presence /externals/zlib    $repo_name && \
-         check_catalog_presence /externals/sqlite3 $repo_name && \
-         check_catalog_presence /test/HTTP         $repo_name && \
-         check_catalog_presence /test/LWP          $repo_name
+      if check_catalog_presence /                             $repo_name && \
+         check_catalog_presence /externals                    $repo_name && \
+         check_catalog_presence /externals/zlib               $repo_name && \
+         check_catalog_presence /externals/sqlite3            $repo_name && \
+         check_catalog_presence /test/cloud_testing/platforms $repo_name && \
+         check_catalog_presence /test/cloud_testing/steering  $repo_name
       then
         return 0
       else


### PR DESCRIPTION
This works around the loss of the old cvmfs tar balls.

**Note:** The test requires 4 tar balls, but at the moment we only have two of them. This test should be adapted to use new versions of cvmfs source tar balls, as soon as they are available.
