### PR TITLE
Add a Buffer template to util.h

### DIFF
--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -445,9 +445,9 @@ PolymorphicConstruction<AbstractProductT, ParameterT>::registered_plugins_;
 template<typename T, class A = std::allocator<T> >
 class Buffer {
  public:
-  Buffer() : used_bytes_(0), size_(0), buffer_(NULL), initialized_(false) {}
+  Buffer() : used_(0), size_(0), buffer_(NULL), initialized_(false) {}
 
-  Buffer(const size_t size) : used_bytes_(0), size_(0), buffer_(NULL),
+  Buffer(const size_t size) : used_(0), size_(0), buffer_(NULL),
                               initialized_(false)
   {
     Allocate(size);
@@ -460,7 +460,7 @@ class Buffer {
   void Allocate(const size_t size) {
     assert (!IsInitialized());
     size_        = size;
-    buffer_      = A().allocate(size_);
+    buffer_      = A().allocate(size_bytes());
     initialized_ = true;
   }
 
@@ -475,10 +475,21 @@ class Buffer {
     return buffer_;
   }
 
-  void SetUsedBytes(const size_t bytes)  { used_bytes_ = bytes; }
+  void SetUsed(const size_t items) {
+    assert (items <= size());
+    used_ = items;
+  }
 
-  size_t size()        const { return size_;        }
-  size_t used_bytes()  const { return used_bytes_;  }
+  void SetUsedBytes(const size_t bytes) {
+    assert (bytes <= size_bytes());
+    assert (bytes % sizeof(T) == 0);
+    used_ = bytes / sizeof(T);
+  }
+
+  size_t size()        const { return size_;             }
+  size_t size_bytes()  const { return size_ * sizeof(T); }
+  size_t used()        const { return used_;             }
+  size_t used_bytes()  const { return used_ * sizeof(T); }
 
  private:
   Buffer(const Buffer &other) { assert (false); } // no copy!
@@ -488,15 +499,15 @@ class Buffer {
     if (size_ == 0) {
       return;
     }
-    A().deallocate(buffer_, size_);
+    A().deallocate(buffer_, size_bytes());
     buffer_      = NULL;
     size_        = 0;
-    used_bytes_  = 0;
+    used_        = 0;
     initialized_ = false;
   }
 
  private:
-  size_t               used_bytes_;
+  size_t               used_;
   size_t               size_;
   typename A::pointer  buffer_;
   bool                 initialized_;


### PR DESCRIPTION
This is a small template wrapping a memory buffer containing objects of an arbitrary type. The template is able to use custom allocators like `std::allocator` or `tbb::scalable_allocator`
