### PR TITLE
Check the Presence of libattr1-dev in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,16 @@ set (REQUIRED_HEADERS sys/xattr.h zlib.h netinet/in.h arpa/inet.h sys/socket.h
                       signal.h errno.h dirent.h unistd.h fcntl.h netdb.h
                       syslog.h sys/resource.h execinfo.h poll.h)
 if (NOT MACOSX)
+  # Unfortunately, attr/xattr.h fails to compile without including sys/types.h
+  # before including attr/xattr.h (it uses size_t and ssize_t).
+  # CMake searches for include files by compiling a minimal *.c file like:
+  #    #include <${SEARCHED_HEADER_FILE}>
+  #    int main(int argc, char **argv) { return 0; }
+  #
+  # We pre-define the include guard of attr/xattr.h and thus still check, if the
+  # file is found by the compiler but mitigating the compiler errors caused by
+  # a standalone inclusion of attr/xattr.h
+  set (CMAKE_REQUIRED_DEFINITIONS "-D__XATTR_H__")
   set (REQUIRED_HEADERS ${REQUIRED_HEADERS}
                         sys/statfs.h
                         attr/xattr.h)


### PR DESCRIPTION
This adds (pedantic) checking for the include file `attr/xattr.h` and thus for the presence of `libattr1-dev`. Also all other required headers are now checked pedantically.

**Note:** The defined macro `look_for_include_files` will (pedantically) check for a list of given header files. For each header it finds, a variable like `HAVE_SYS_SOCKET_H` will be defined. This variable name is derived from the include file path by prepending it with `HAVE_`, replacing `/` and `.` with `_` and changing all characters to upper case.

**Note:** attr/xattr.h is broken in a sense that it requires the inclusion of `sys/types.h` before including `attr/xattr.h`. Since CMake creates a minimal C program that includes the requested header and checks if it compiles successfully, `attr/xattr.h` is reported to be _not found_ even if it is there. I worked around that by pre-defining the include guard macro of `attr/xattr.h` namely `__XATTR_H__`. This still checks if `attr/xattr.h` is there, but essentially does not compile the _broken_ header.
