### PR TITLE
FIX: Detect service Utility under Ubuntu in cvmfs_config

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -14,7 +14,7 @@ case $sys_arch in
   Linux )
     if [ -x /sbin/service ]; then
       service="/sbin/service"
-    elif [ -x /sbin/service ]; then
+    elif [ -x /usr/sbin/service ]; then
       # Ubuntu
       service="/usr/sbin/service"
     elif [ -x /sbin/rc-service ] ; then


### PR DESCRIPTION
Under Ubuntu there was a (perhaps copy-and-paste related) error in the discovery of the `service` utility.
(Introduced by Sebastien Fabbro in the mid of June)
