### PR TITLE
FIX: Inconsistent Magic File Names in cachedb Rebuild

### DIFF
--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -809,7 +809,8 @@ catalog::LoadError CatalogManager::LoadCatalog(const PathString &mountpoint,
   }
 
   // Happens only on init/remount, i.e. quota won't delete a cached catalog
-  const string checksum_path = (*cache_path_) + "/cvmfschecksum." + repo_name_;
+  const string checksum_path = (*cache_path_) + "/" +
+                               quota::checksum_file_prefix + "." + repo_name_;
   hash::Any cache_hash;
   uint64_t cache_last_modified = 0;
 

--- a/cvmfs/quota.cc
+++ b/cvmfs/quota.cc
@@ -806,7 +806,10 @@ bool RebuildDatabase() {
     if (d->d_type != DT_REG) continue;
 
     const string name = d->d_name;
-    if (name.substr(0, 14) == "cvmfs.checksum") {
+    if (name.substr(0, quota::checksum_file_prefix.size()) ==
+        quota::checksum_file_prefix) {
+      LogCvmfs(kLogQuota, kLogDebug, "found catalog checksum file %s in cache "
+                                     "directory", name.c_str());
       FILE *f = fopen(((*cache_dir_) + "/" + name).c_str(), "r");
       if (f != NULL) {
         char sha1[40];

--- a/cvmfs/quota.h
+++ b/cvmfs/quota.h
@@ -18,6 +18,8 @@ struct Any;
 
 namespace quota {
 
+static const std::string checksum_file_prefix = "cvmfschecksum";
+
 bool Init(const std::string &cache_dir, const uint64_t limit,
           const uint64_t cleanup_threshold, const bool rebuild_database);
 bool InitShared(const std::string &exe_path, const std::string &cache_dir,


### PR DESCRIPTION
When rebuilding the cachedb file after a crashed cvmfs instance the `cvmfschecksum.*` files are used to recover additional information about available catalogs. Unfortunately this never worked, because the magic file name was inconsistent in `cache.cc` and `quota.cc`.
