### PR TITLE
FIX: disable proxies for .cvmfswhitelist retrieval

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -619,7 +619,14 @@ get_expiry() {
 
 check_expiry() {
   local stratum0=$1
-  [ $(get_expiry $stratum0) -ge 0 ]
+  local expiry="-1"
+
+  expiry=$(get_expiry $stratum0)
+  if [ $? -ne 0 ]; then
+    die "Failed to retrieve repository expiry date"
+  fi
+
+  [ $expiry -ge 0 ]
 }
 
 


### PR DESCRIPTION
This fixes a problem posted by _John S. De Stefano_ with locally defined proxies failing a `cvmfs_server mkfs`. It disables the usage of system defined proxies when checking the expiry-time in `cvmfs_server transaction`.
Additionally it adds a meaningful error message for a failed .cvmfswhitelist retrieval.
