### PR TITLE
FIX: Version discovery in deb package building

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -37,7 +37,7 @@ clean:
 	dh_clean
 
 debian/%.install: debian/%.install.in
-	sed "s/@CVMFS_VERSION@/$(shell dpkg-parsechangelog | sed -n -e 's/^Version: //p')/g" $< > $@
+	sed "s/@CVMFS_VERSION@/$(shell dpkg-parsechangelog | sed -n -e 's/^Version: \([0-9]\.[0-9]\.[0-9][0-9]*\).*$/\1/p" $< > $@
 
 install: build debian/cvmfs.install debian/cvmfs-keys.install debian/cvmfs-server.install debian/cvmfs-unittests.install
 	dh_testdir


### PR DESCRIPTION
This stabilizes the regular expression that parses the cvmfs version number to be used from the `debian/changelog` file.
