### PR TITLE
FIX: unqualified lookup fails on SLES's gcc >.<

### DIFF
--- a/cvmfs/file_processing/async_reader_impl.h
+++ b/cvmfs/file_processing/async_reader_impl.h
@@ -84,7 +84,7 @@ void Reader<FileScrubbingTaskT, FileT>::FinalizedFile(AbstractFile *file) {
 
   // notify subscribed callbacks for a finalized file
   FileT *concrete_file = static_cast<FileT*>(file);
-  NotifyListeners(concrete_file);
+  this->NotifyListeners(concrete_file);
 
   // check if all files have been processed
   {


### PR DESCRIPTION
My favorite legacy platform was making fun of me again. :o) At least gcc was kind enough to recommend a solution. Not sure, if this fixes the problem... Debugging by Pull Request...

**Correction:** The problem appeared on SuSE, Fedora and Mac... not SLES... I accused the wrong one of murder here. :-) 
