### PR TITLE
FIX: malfunctioning regex in debian/rules

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -37,7 +37,7 @@ clean:
 	dh_clean
 
 debian/%.install: debian/%.install.in
-	sed "s/@CVMFS_VERSION@/$(shell dpkg-parsechangelog | sed -n -e 's/^Version: \([0-9]\.[0-9]\.[0-9][0-9]*\).*$/\1/p')/g" $< > $@
+	sed "s/@CVMFS_VERSION@/$(shell dpkg-parsechangelog | sed -n -e 's/^Version: \([0-9]\.[0-9]\.[0-9][0-9]*\).*/\1/p')/g" $< > $@
 
 install: build debian/cvmfs.install debian/cvmfs-keys.install debian/cvmfs-server.install debian/cvmfs-unittests.install
 	dh_testdir


### PR DESCRIPTION
Fix of the Fix of the Fix... 
Apparently variable expansion in make files works differently than in a usual shell... what a nightmare... >,<
