### PR TITLE
FIX: Add libtbb to unittest rpm

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -118,7 +118,7 @@ CernVM-FS tools to maintain Stratum 0/1 repositories
 %package unittests
 Summary: CernVM-FS unit tests binary
 Group: Application/System
-Requires: cvmfs-server >= 2.1.16 # cvmfs specific TBB shared libraries
+Requires: cvmfs-server = %{version} # cvmfs specific TBB shared libraries (since 2.1.16)
 %description unittests
 CernVM-FS unit tests binary.  This RPM is not required except for testing.
 


### PR DESCRIPTION
This adds the libtbb shared objects to the unittests rpm.
**Question:** Does it actually work, if the same libraries are part of `cvmfs_server.rpm` AND `cvmfs_unittests.rpm`?
