### PR TITLE
FIX: Unittest Package requires cvmfs-server

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -118,7 +118,7 @@ CernVM-FS tools to maintain Stratum 0/1 repositories
 %package unittests
 Summary: CernVM-FS unit tests binary
 Group: Application/System
-Requires: cvmfs-server = %{version} # cvmfs specific TBB shared libraries (since 2.1.16)
+Requires: cvmfs-server = %{version}
 %description unittests
 CernVM-FS unit tests binary.  This RPM is not required except for testing.
 


### PR DESCRIPTION
Obviously the comment behind the `Requires:` directive did cause problems.
