### PR TITLE
FIX: ci/installrpm.sh does not handle rpm lists

### DIFF
--- a/ci/installrpm.sh
+++ b/ci/installrpm.sh
@@ -4,10 +4,14 @@ set -e
 
 tmpdir=$1
 [ -z $tmpdir ] && exit 1
-cvmfsrpm=$2
-[ -z $cvmfsrpm ] && exit 2
-selinuxrpm=$3
-serverrpm=$4
+shift
+
+cvmfsrpms=$@
+for cvmfsrpm in $cvmfsrpms; do
+  if [ -z $cvmfsrpm ]; then
+    exit 2
+  fi
+done
 
 initScriptsVersion=1.0.18-2
 keysVersion=1.4-1
@@ -15,6 +19,6 @@ keysVersion=1.4-1
 curl -k https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/5/x86_64/cvmfs-init-scripts-${initScriptsVersion}.noarch.rpm > $tmpdir/cvmfs-init-scripts-${initScriptsVersion}.noarch.rpm
 curl -k https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/5/x86_64/cvmfs-keys-${keysVersion}.noarch.rpm > $tmpdir/cvmfs-keys-${keysVersion}.noarch.rpm
 
-sudo rpm -vi $tmpdir/cvmfs-keys-${keysVersion}.noarch.rpm $cvmfsrpm $selinuxrpm $serverrpm
+sudo rpm -vi $tmpdir/cvmfs-keys-${keysVersion}.noarch.rpm $cvmfsrpms
 sudo rpm -vi $tmpdir/cvmfs-init-scripts-${initScriptsVersion}.noarch.rpm
 sudo cvmfs_config setup


### PR DESCRIPTION
The parameter handling of `ci/installrpm.sh` was broken. It was expecting three distinct rpm packages (namely: _cvmfs_, _selinux_ and _server_), though the invoking EC jobs did provide paths to other rpms and in particular often more than three packages.
So far there was no failure, since only three packages were provided and the distinction was not utilized by the script at all. Additionally the cvmfs packages did not depend on each other. Thus if (say) `cvmfs-server` was provided as a forth package to `ci/installrpm.sh` it would just have been silently skipped from installation.

Now it broke since `cvmfs-unittests` depends on `cvmfs-server` and `cvmfs-server` was provided but skipped by `ci/installrpm.sh`. I fixed it by allowing an arbitrary long list of rpms to be installed by `ci/installrpm.sh`.
