### PR TITLE
FIX: Remove cvmfs Packages from Build Machines

### DIFF
--- a/ci/cleanup_node.sh
+++ b/ci/cleanup_node.sh
@@ -1,16 +1,15 @@
 #!/bin/sh
 
 if [ -f /bin/rpm ]; then
-  sudo rpm -e cvmfs-auto-setup || true
-  sudo rpm -e cvmfs-init-scripts || true
-  sudo rpm -e cvmfs-replica || true
-  sudo rpm -e cvmfs-selinux || true
-  sudo rpm -e cvmfs || true
-  sudo rpm -e cvmfs-server || true
-  sudo rpm -e cvmfs-keys || true
-  sudo rpm -e cvmfs-devel || true
-  sudo rpm -e cvmfs-unittests || true
+  echo -n "removing packages: cvmfs* ... "
+  sudo rpm -e $(rpm -qa | grep cvmfs) > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "fail"
+    exit 3
+  fi
+  echo "done"
 fi
+
 sudo /usr/sbin/userdel cvmfs
 sudo rm -rf /etc/cvmfs /var/cache/cvmfs2 /var/lib/cvmfs
 sudo sed -i "/^\/cvmfs \/etc\/auto.cvmfs/d" /etc/auto.master


### PR DESCRIPTION
Packages were erased one after another. This causes problems if the packages have inter-dependencies and are not removed in the right order.
Now all packages that start with _cvmfs_ will be removed, even if their inter-dependencies change.
