### PR TITLE
Rename Unit Test Binary in *.deb Package

### DIFF
--- a/packaging/debian/cvmfs-unittests.install
+++ b/packaging/debian/cvmfs-unittests.install
@@ -1,1 +1,1 @@
-usr/bin/CernVM-FS_test
+usr/bin/cvmfs_unittests


### PR DESCRIPTION
Of course the name change of the unit test binary to `cvmfs_unittests` needs to be reflected in the deb build process as well. :o)
