### PR TITLE
FIX: server package not installed on NFS, EXLCACHE

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
@@ -8,6 +8,7 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo "installing RPM packages... "
 install_rpm $KEYS_PACKAGE
 install_rpm $CLIENT_PACKAGE
+install_rpm $SERVER_PACKAGE   # only needed for tbb shared libs (unit tests)
 install_rpm $UNITTEST_PACKAGE
 
 # setup environment

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
@@ -8,6 +8,7 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo "installing RPM packages... "
 install_rpm $KEYS_PACKAGE
 install_rpm $CLIENT_PACKAGE
+install_rpm $SERVER_PACKAGE   # only needed for tbb shared libs (unit tests)
 install_rpm $UNITTEST_PACKAGE
 
 # setup environment


### PR DESCRIPTION
Of course we need the server package on the NFS and Exclusive Cache test machines as well >.<
