### PR TITLE
Custom Kernel Download on SLC6 Depends on Current Kernel Version

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -17,12 +17,14 @@ create_partition $disk_to_partition $partition_size || die "fail (creating parti
 echo "done"
 
 # custom kernel packages
-knl_firmware="http://ecsft.cern.ch/dist/cvmfs/kernel/2.6.32-358.18.1.el6/kernel-firmware-2.6.32-358.18.1.el6.aufs21.x86_64.rpm"
-knl="http://ecsft.cern.ch/dist/cvmfs/kernel/2.6.32-358.18.1.el6/kernel-2.6.32-358.18.1.el6.aufs21.x86_64.rpm"
-aufs_util="http://ecsft.cern.ch/dist/cvmfs/kernel/aufs2-util/aufs2-util-2.1-2.x86_64.rpm"
+knl_version=$(uname -r)
+aufs_util_version="2.1-2"
+knl_firmware="http://ecsft.cern.ch/dist/cvmfs/kernel/${knl_version}/kernel-firmware-${knl_version}.aufs21.x86_64.rpm"
+knl="http://ecsft.cern.ch/dist/cvmfs/kernel/${knl_version}/kernel-${knl_version}.aufs21.x86_64.rpm"
+aufs_util="http://ecsft.cern.ch/dist/cvmfs/kernel/aufs2-util/aufs2-util-${aufs_util_version}.x86_64.rpm"
 
 # download the custom kernel RPMs (including AUFS)
-echo -n "download custom kernel RPMs... "
+echo -n "download custom kernel RPMs for $knl_version ... "
 wget $knl_firmware > /dev/null || die "fail"
 wget $knl          > /dev/null || die "fail"
 echo "done"


### PR DESCRIPTION
This changes the setup script of the SLC6 x64 cloud test to automatically download the AUFS inoculated kernel version based on the currently running kernel. If this kernel has not yet been built, it will fail an report the error. 

This saves us from changing this script each time the SLC kernel gets an update.
