### PR TITLE
FIX: SLC6 Cloudtest SELinux Issue

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -23,6 +23,11 @@ mount_partition $disk_to_partition$partition_1 /srv/cvmfs       || die "fail (mo
 mount_partition $disk_to_partition$partition_2 /var/spool/cvmfs || die "fail (mounting /var/spool/cvmfs $?)"
 echo "done"
 
+# allow apache access to the mounted server file system
+echo -n "setting SELinux labels for apache... "
+chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail"
+echo "done"
+
 # start apache
 echo -n "starting apache... "
 sudo service httpd start > /dev/null 2>&1 || die "fail"


### PR DESCRIPTION
The backend tests on SLC6 are using two additional disk partitions that are mounted on `/srv/cvmfs` as well as `/var/spool/cvmfs`. This fixes the SELinux issue preventing apache to access files in `/srv/cvmfs/<fqrn>`.

Additionally there was a typo in the log strings. :-1: 
