### PR TITLE
FIX: Repo Creation Did Not Abort on Failed Initial Mount

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1102,7 +1102,7 @@ aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,ro,
 EOF
   fi
   sudo -H -u $cvmfs_user sh -c "touch ${CVMFS_SPOOL_DIR}/client.local"
-  mount $rdonly_dir > /dev/null
+  mount $rdonly_dir > /dev/null || return 1
   mount /cvmfs/$name
 }
 


### PR DESCRIPTION
After initial creation of the repository structure the first mount attempt might have been failing without aborting the script. That happened in particular, when mounting the `/var/spool/<fqrn>/rdonly` cvmfs file system. I added an additional check to fix it.
