### PR TITLE
FIX: Missing Permissions for `chcon` on /srv

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -25,7 +25,7 @@ echo "done"
 
 # allow apache access to the mounted server file system
 echo -n "setting SELinux labels for apache... "
-chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail"
+sudo chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail"
 echo "done"
 
 # start apache


### PR DESCRIPTION
This fixes a missing `sudo` when trying to change the SELinux context on `/srv` for the SLC6 x64 cloud test.
