### PR TITLE
FIX: cvmfs-keys.deb is Not Platform Independent

### DIFF
--- a/packaging/debian/keys/control
+++ b/packaging/debian/keys/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9), make
 Homepage: http://cernvm.cern.ch/portal/filesystem
 
 Package: cvmfs-keys
-Architecture: any
+Architecture: all 
 Depends: ${misc:Depends}
 Description: CernVM File System Public Keys


### PR DESCRIPTION
This sets the target deb package architecture to: `architecture: all` specifying that _cvmfs-keys.deb_ is platform independent. Before it was set to `architecture: any` which means it builds on all platforms but the result is platform specific.

Additionally it fixes a missing line break at the end of the control file.
