### PR TITLE
Switch Off Tests that are Failing by Design

### DIFF
--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -18,7 +18,10 @@ cd ${SOURCE_DIRECTORY}/test
 ./run.sh $TEST_LOGFILE -x src/004-davinci               \
                           src/005-asetup                \
                           src/007-testjobs              \
-                          src/024-reload-during-asetup || it_retval=$?
+                          src/024-reload-during-asetup  \
+                          src/518-hardlinkstresstest    \
+                          src/523-corruptchunkfailover  \
+                          src/524-corruptmanifestfailover || it_retval=$?
 
 echo "running CernVM-FS migration test cases..."
 ./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?


### PR DESCRIPTION
There are two fail-over tests, that test a currently not-implemented fail-over scenario. Additionally there is a hardlink stress test for AUFS which still does not work in kernel 3.2.0 -.-
