### PR TITLE
FIX: Remove Package on Ubuntu _with_ Dependencies

### DIFF
--- a/test/migration_tests/common.sh
+++ b/test/migration_tests/common.sh
@@ -130,7 +130,7 @@ uninstall_package() {
   if has_binary yum; then
     sudo yum -y erase $pkg_name
   elif has_binary apt-get; then
-    sudo dpkg --remove $pkg_name
+    sudo apt-get --assume-yes remove $pkg_name
   else
     return 1
   fi


### PR DESCRIPTION
This fixes the migration test on Ubuntu. It failed because of dependencies between the _cvmfs_ packages.
