### PR TITLE
Temporarily Disable the Migration Test Suite on Ubuntu

### DIFF
--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -24,6 +24,8 @@ cd ${SOURCE_DIRECTORY}/test
                           src/524-corruptmanifestfailover || it_retval=$?
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+echo "--> disabled! CernVM-FS 2.1.15 has a different debian packaging model"
+echo "    Re-Enable after 2.1.16 is released"
+#./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
 
 [ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]


### PR DESCRIPTION
Currently CernVM-FS 2.1.15 has an incompatible _.deb_ package layout making this migration test fail by design.
**Note:** This should be re-enabled when 2.1.16 is tagged. Hopefully it works out of the box then.
