### PR TITLE
FIX: Kernel Compile Testcase

### DIFF
--- a/test/src/006-buildkernel/main
+++ b/test/src/006-buildkernel/main
@@ -4,17 +4,20 @@ cvmfs_test_name="Linux Kernel Compile"
 cvmfs_run_test() {
   logfile=$1
 
+  local build_log
+  build_log="$(pwd)/build_kernel.log"
+
   cvmfs_mount sft.cern.ch || return 1
 
   outdir=${CVMFS_TEST_SCRATCH}/kbuild
 
   rm -rf $outdir
   cd /cvmfs/sft.cern.ch/lcg/external/experimental/linux
-  echo "writing kernel compile output to build_kernel.log"
-  ./compileKernel.sh 2.6.32.57 $outdir 8 >> build_kernel.log || return 2
-  ./compileKernel.sh 2.6.32.57 $outdir 8 >> build_kernel.log || return 3
+  echo "writing kernel compile output to $build_log"
+  ./compileKernel.sh 2.6.32.57 $outdir 8 >> $build_log || return 2
+  ./compileKernel.sh 2.6.32.57 $outdir 8 >> $build_log || return 3
   sudo cvmfs_talk -i sft.cern.ch cleanup 0 || return 4
-  ./compileKernel.sh 2.6.32.57 $outdir 8 >> build_kernel.log || return 5
+  ./compileKernel.sh 2.6.32.57 $outdir 8 >> $build_log || return 5
 
   ps aux | grep cvmfs2 | grep sft.cern.ch
   check_memory sft.cern.ch 50000


### PR DESCRIPTION
I screwed up the kernel compile test case by trying to improve it's logging behaviour. -.-
This fixes it.

**Sidenote:** Apart from an (intermittent *1) migration test failure and the screwed up kernel test case everything runs fine now on all 7 tested platforms. 

1) The migration test case is a race condition by design... in this one case we lost the race. It worked on this platform before, though. 
