### PR TITLE
Expose a Magic File While Stratum1 Snapshotting is Running

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2470,24 +2470,28 @@ snapshot() {
       -i ${spool_dir}/tmp/snapshotting \
       -o .cvmfs_is_snapshotting"
 
+    # command to remove the magic file when finished (or aborted)
+    delete_command="cvmfs_swissknife remove \
+                      -r ${upstream} \
+                      -o .cvmfs_is_snapshotting"
+
     # do the actual snapshot actions
-    $user_shell "cvmfs_swissknife pull -m $name \
-      -u $stratum0 \
-      -r ${upstream} \
-      -x ${spool_dir}/tmp \
-      -k $public_key \
-      -n $num_workers \
-      -t $timeout \
-      -a $retries $with_history $log_level"
+    $user_shell "trap \"$delete_command\" HUP INT TERM QUIT && \
+      cvmfs_swissknife pull -m $name \
+        -u $stratum0 \
+        -r ${upstream} \
+        -x ${spool_dir}/tmp \
+        -k $public_key \
+        -n $num_workers \
+        -t $timeout \
+        -a $retries $with_history $log_level"
     $user_shell "sh -c \"date > ${spool_dir}/tmp/last_snapshot\""
     $user_shell "cvmfs_swissknife upload -r ${upstream} \
       -i ${spool_dir}/tmp/last_snapshot \
       -o .cvmfs_last_snapshot"
 
-    # remove the magic file
-    $user_shell "cvmfs_swissknife remove -r ${upstream} \
-      -o .cvmfs_is_snapshotting"
-
+    # remove magic file after successful replication
+    $user_shell "$delete_command"
 
   done
 


### PR DESCRIPTION
This exposes a magic file called `.cvmfs_is_snapshotting` in the repository root while the snapshot procedure is running. Monitoring tools can use that to show nice spinner-animations while replication is in progress. Initially I put this status information in the mini-REST-API but it would be nice to have this information, even if the stratum 1 administrator decides to not expose the REST-API at all.
