### PR TITLE
Create cache dir hierarchy when using alien_cache.

### DIFF
--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -161,10 +161,23 @@ bool Init(const string &cache_path, const bool alien_cache) {
   tls_blocks_ = new vector<ThreadLocalStorage *>();
   atomic_init64(&num_download_);
 
-  if (!alien_cache_) {
-    if (!MakeCacheDirectories(cache_path, 0700))
-      return false;
+  if(alien_cache_)
+  {
+	  if (!MakeCacheDirectories(cache_path, 0770))
+	  {
+		  /* Ignore possible EEXIST when two different processes race to create
+		   * the directory hierarchy. */
+		  if(errno != EEXIST)
+			  return false;
+	  }
   }
+  else
+  {
+	  if (!MakeCacheDirectories(cache_path, 0700))
+		  return false;
+  }
+
+  LogCvmfs(kLogCache, kLogDebug, "Cache directory structure created.");
 
   if (FileExists(cache_path + "/cvmfscatalog.cache")) {
     LogCvmfs(kLogCache, kLogStderr | kLogSyslogErr,


### PR DESCRIPTION
This pull request is to ensure the creation of the cache directory hierarchy when using the alien_cache option. If alien_cache is being used, the hierarchy is created with 0770 permissions, and the EEXIST error is ignored, in case two processes are racing to create the hierarchy.
