### PR TITLE
FIX: Sudo Requires a TTY on RHEL and SLC

### DIFF
--- a/test/cloud_testing/steering/remote_setup.sh
+++ b/test/cloud_testing/steering/remote_setup.sh
@@ -69,6 +69,13 @@ source_tarball=""
 unittest_package=""
 test_username="sftnight"
 
+# RHEL (SLC) requires a tty for sudo... work around that
+if [ $(id -u) -eq 0 ]; then
+  if ! cat /etc/sudoers | grep -q "Defaults:root !requiretty"; then
+    echo "Defaults:root !requiretty" | tee --append /etc/sudoers > /dev/null 2>&1
+  fi
+fi
+
 # create a workspace
 sudo rm -fR $cvmfs_workspace > /dev/null 2>&1
 mkdir -p $cvmfs_workspace
@@ -144,11 +151,6 @@ if [ $? -ne 0 ]; then
   fi
   echo "$test_username ALL = NOPASSWD: ALL"  | sudo tee --append /etc/sudoers
   echo "Defaults:$test_username !requiretty" | sudo tee --append /etc/sudoers
-fi
-
-# adapt sudo configuration for non-tty usage if necessary
-if ! sudo cat /etc/sudoers | grep -q "Defaults:root !requiretty"; then
-  echo "Defaults:root !requiretty" | sudo tee --append /etc/sudoers
 fi
 
 # download the needed packages


### PR DESCRIPTION
This fixes an issue introduced with the previous Pull Request. Turns out, that RHEL (and therefore SLC) enable the _requiretty_ setting of `sudo` by default. Since the cloud testing setup scripts are run without a tty attached they fail on those platforms.

Now the first thing the `remote_setup.sh` does is checking for 'root' permissions and disabling the _requiretty_ setting. If it does not run as 'root', it could neither disable the setting nor use `sudo` and would therefore be screwed.
