### PR TITLE
FIX: Endless Loop due to Compiler Optimization

### DIFF
--- a/test/unittests/t_util_concurrency.cc
+++ b/test/unittests/t_util_concurrency.cc
@@ -101,7 +101,7 @@ TEST(T_UtilConcurrency, ReadLockGuard) {
 // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 //
 
-bool g_acquire_write_lock_killer = true;
+volatile bool g_acquire_write_lock_killer = true;
 
 void *acquire_write_lock(void *lock) {
   pthread_rwlock_t &rwlock = *static_cast<pthread_rwlock_t*>(lock);


### PR DESCRIPTION
Turns out that the compiler actually optimized my code into an endless loop... `volatile` for the win.
