### PR TITLE
FIX: Integer Constant too Large

### DIFF
--- a/test/unittests/t_atomic.cc
+++ b/test/unittests/t_atomic.cc
@@ -189,7 +189,7 @@ TEST_F(T_Atomic, TransactionalAssignment) {
 
   const int64_t value4 = 124786234862;
   const int64_t value5 = 53847432;
-  const int64_t value6 = 0xFFFFFFFFFFFFFF;
+  const int64_t value6 = 0xFFFFFFFF;
 
   atomic_write32(&atomic32_, value1);
   EXPECT_EQ (value1, atomic_read32(&atomic32_));


### PR DESCRIPTION
Fixes a compile error on 32bit ...
