### PR TITLE
Add Virtual Dtor to AbstractReader (Silence Warning)

### DIFF
--- a/cvmfs/file_processing/async_reader.h
+++ b/cvmfs/file_processing/async_reader.h
@@ -28,6 +28,8 @@ class AbstractReader {
     buffers_in_flight_counter_(max_buffers_in_flight)
   {}
 
+  virtual ~AbstractReader() {}
+
   /**
    * Releases CharBuffers that were previously allocated by the Reader. This
    * needs to be called for each Buffer that was created using CreateBuffer.


### PR DESCRIPTION
Silences a warning because `AbstractReader` has virtual methods but a non-virtual destructor. (In fact it didn't have a destructor at all, since it has nothing to deinitialise by now).
