### PR TITLE
FIX: Migration Didn't Determine Catalog Sizes Correctly

### DIFF
--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -79,6 +79,7 @@ class CommandMigrate : public Command {
     CatalogStatistics                 statistics;
 
     Future<shash::Any>                new_catalog_hash;
+    Future<size_t>                    new_catalog_size;
   };
 
   class PendingCatalogMap : public std::map<std::string, const PendingCatalog*>,


### PR DESCRIPTION
This fixes `swissknife migrate` which was broken by the newly introduced _nested catalog size_  bookkeeping. Additionally it now fills the newly introduced _size_ field in the _nested_catalogs_ table for all migrated nested catalogs on the go.
