### PR TITLE
FIX: Sudo Fails After Start Up of Ubuntu VMs

### DIFF
--- a/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
@@ -9,6 +9,19 @@ echo -n "configure package manager for non-interactive usage... "
 export DEBIAN_FRONTEND=noninteractive
 echo "done"
 
+# sudo cannot resolve host name right after startup for some reason
+echo -n "wait for sudo to work properly... "
+timeout=1800
+while sudo echo "foo" 2>&1 | grep -q "unable to resolve host"; do
+  sleep 1
+  timeout=$(( $timeout - 1 ))
+  if [ $timeout -le 0 ]; then
+    echo "FAIL!"
+    exit 1
+  fi
+done
+echo "done"
+
 # update package manager cache
 echo -n "updating package manager cache... "
 sudo apt-get update > /dev/null || die "fail (apt-get update)"


### PR DESCRIPTION
This is more like a hacky quick fix. For some reason `sudo` tries to resolve the host name of the VM. Though this might fail directly after startup. I guess DNS is not updated yet. However we have a chicken-egg problem here, since with `sudo` failing I cannot change anything of the configuration.

This just uses `sudo`, checks the output and gives it half an hour time (which should be well enough for the DNS to update).
