### PR TITLE
FIX: setuid Flag Was Removed in Debian Packages

### DIFF
--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -74,7 +74,7 @@ binary-arch: build install
 	dh_link
 #	dh_strip
 	dh_compress
-	dh_fixperms
+	dh_fixperms --exclude cvmfs_suid_helper
 	dh_makeshlibs
 	dh_installdeb
 #        dh_perl


### PR DESCRIPTION
The CMakeLists.txt installs `cvmfs_suid_helper` _with_ the setuid flag correctly set. Unfortunately, during package building the **debhelper** [dh_fixperms](http://man.he.net/man1/dh_fixperms) removes the flag automagically.

**Note:** ~~This fix is untested, I'd like to try it using the nightly build procedure.~~
