### PR TITLE
Run Server Test Cases on SLC5 (experimental)

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -4,11 +4,29 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+# URLs
+aufs_user_tools="http://ftp.scientificlinux.org/linux/scientific/5x/x86_64/SL/aufs-0.20090202.cvs-6.sl5.x86_64.rpm"
+
+# install AUFS kernel modules and userspace tools
+echo -n "downloading aufs user space tools... "
+wget --no-check-certificate --quiet $aufs_user_tools || die "fail"
+echo "done"
+
+echo "installing aufs... "
+install_rpm $(basename $aufs_user_tools)                   || die "fail (installing aufs)"
+yum list installed | grep "kernel-module-aufs" > /dev/null || die "fail (check installed aufs)"
+echo "done"
+
+echo -n "activate aufs... "
+kobj=$(rpm -ql $(yum list installed | grep kernel-module-aufs) | tail -n1)
+insmod $kobj || die "fail"
+echo "done"
+
 # install RPM packages
 echo "installing RPM packages... "
 install_rpm $KEYS_PACKAGE
 install_rpm $CLIENT_PACKAGE
-install_rpm $SERVER_PACKAGE   # only needed for tbb shared libs (unit tests)
+install_rpm $SERVER_PACKAGE
 install_rpm $UNITTEST_PACKAGE
 
 # setup environment
@@ -20,6 +38,12 @@ attach_user_group fuse                           || die "fail (add fuse group to
 sudo cvmfs_config chksetup > /dev/null           || die "fail (cvmfs_config chksetup)"
 echo "done"
 
+# start apache
+echo -n "starting apache... "
+sudo service httpd start > /dev/null 2>&1 || die "fail"
+echo "OK"
+
 # install test dependencies
 echo "installing test dependencies..."
-install_from_repo gcc || die "fail (installing gcc)"
+install_from_repo gcc     || die "fail (installing gcc)"
+install_from_repo gcc-c++ || die "fail (installing gcc-c++)"

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -13,7 +13,9 @@ run_unittests --gtest_shuffle || ut_retval=$?
 
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/5* || it_retval=$?
+./run.sh $TEST_LOGFILE -x src/518-hardlinkstresstest   \
+                          src/523-corruptchunkfailover \
+                          src/524-corruptmanifestfailover || it_retval=$?
 
 echo "running CernVM-FS migration test cases..."
 ./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?


### PR DESCRIPTION
This should enable the server test cases under SLC5. We are dependent from [Scientific Linux's FTP server](http://ftp.scientificlinux.org/linux/scientific/5x/x86_64/SL/), but I believe this isn't too bad.
