### PR TITLE
FIX: AUFS Kernel Module Activation

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -18,8 +18,8 @@ yum list installed | grep "kernel-module-aufs" > /dev/null || die "fail (check i
 echo "done"
 
 echo -n "activate aufs... "
-kobj=$(rpm -ql $(yum list installed | grep kernel-module-aufs) | tail -n1)
-insmod $kobj || die "fail"
+kobj=$(rpm -ql $(rpm -qa | grep kernel-module-aufs) | tail -n1)
+sudo /sbin/insmod $kobj || die "fail"
 echo "done"
 
 # install RPM packages


### PR DESCRIPTION
Updated SLC5 script didn't work in the supplied sudo-ed environment.
