### PR TITLE
FIX: shash::HashFile() Produced Wrong Content Hashes

### DIFF
--- a/cvmfs/hash.cc
+++ b/cvmfs/hash.cc
@@ -114,7 +114,7 @@ bool HashFile(const std::string filename, Any *any_digest) {
   unsigned char io_buffer[4096];
   int actual_bytes;
   while ((actual_bytes = fread(io_buffer, 1, 4096, file))) {
-    Update(io_buffer, 4096, context);
+    Update(io_buffer, actual_bytes, context);
   }
 
   if (ferror(file)) {


### PR DESCRIPTION
I just came across that issue, when I was writing a test set for `LocalUploader`. Due to wrong input buffer length handling in `shash::HashFile()` it produced wrong hashes. Fortunately I didn't find any code that uses this function. Hopefully it has never been used as well. 
