### PR TITLE
FIX: Startup of Apache Failed on SLC5 x64 Test VM

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -40,7 +40,7 @@ echo "done"
 
 # start apache
 echo -n "starting apache... "
-sudo service httpd start > /dev/null 2>&1 || die "fail"
+sudo /sbin/service httpd start > /dev/null 2>&1 || die "fail"
 echo "OK"
 
 # install test dependencies


### PR DESCRIPTION
This development process truly is inefficient...
