### PR TITLE
FIX: Opportunistically Restart Autofs After Hard Crash in Test 015

### DIFF
--- a/test/src/015-rebuild_on_crash/main
+++ b/test/src/015-rebuild_on_crash/main
@@ -36,6 +36,8 @@ cvmfs_run_test() {
   sudo kill -9 $pid || return 21
   cvmfs_umount ${repo} || return 22
   
+  service_switch autofs restart || return 23
+
   ls /cvmfs/${repo} || return 30
   cache_list=$(sudo cvmfs_talk -i ${repo} cache list)
   if echo $cache_list | grep -v -q "automatic rebuild"; then


### PR DESCRIPTION
In test 015 _autofs_ seems get confused on SLC5 due to the cvmfs process killed with `kill -9`. When restarting _autofs_ opportunistically, the test works. Not sure if this is the right solution for the issue, though.
