### PR TITLE
Improve Logging for Exceeded ulimit -n

### DIFF
--- a/cvmfs/file_processing/async_reader_impl.h
+++ b/cvmfs/file_processing/async_reader_impl.h
@@ -2,6 +2,8 @@
  * This file is part of the CernVM File System.
  */
 
+#include "../logging.h"
+
 
 namespace upload { // TODO: remove this... wrong namespace (for testing)
 
@@ -90,6 +92,11 @@ bool Reader<FileScrubbingTaskT, FileT>::TryToAcquireNewJob(FileJob &next_job) {
 template <class FileScrubbingTaskT, class FileT>
 void Reader<FileScrubbingTaskT, FileT>::OpenNewFile(FileT *file) {
   const int fd = open(file->path().c_str(), O_RDONLY, 0);
+  if (fd < 0 && errno == EMFILE) {
+    LogCvmfs(kLogSpooler, kLogStderr, "File open() failed due to a lack of file"
+                                      "descriptors! Please increase this limit. "
+                                      "(see unlimit -n)");
+  }
   assert (fd > 0);
 
   OpenFile open_file;

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -107,16 +107,16 @@ int LocalUploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
   const std::string tmp_path = CreateTempPath(temporary_path_ + "/" + "chunk",
                                               0644);
   if (tmp_path.empty()) {
-    LogCvmfs(kLogSpooler, kLogVerboseMsg, "Failed to create temp file for "
-                                          "upload of file chunk.");
+    LogCvmfs(kLogSpooler, kLogStderr, "Failed to create temp file for upload of "
+                                      "file chunk.");
     atomic_inc32(&copy_errors_);
     return -1;
   }
 
   const int tmp_fd = open(tmp_path.c_str(), O_WRONLY);
   if (tmp_fd < 0) {
-    LogCvmfs(kLogSpooler, kLogVerboseMsg, "Failed to open temp file '%s' for "
-                                          "upload of file chunk (errno: %d",
+    LogCvmfs(kLogSpooler, kLogStderr, "Failed to open temp file '%s' for upload "
+                                      "of file chunk (errno: %d)",
              tmp_path.c_str(), errno);
     unlink(tmp_path.c_str());
     atomic_inc32(&copy_errors_);


### PR DESCRIPTION
This prints a warning to **stderr**, if `open()` failed in the Spooler code.
