### PR TITLE
FIX: Build of cvmfs_unittests didn't Depend on Zlib

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -96,6 +96,10 @@ if (SQLITE3_BUILTIN)
   add_dependencies (${PROJECT_TEST_NAME} sqlite3)
 endif (SQLITE3_BUILTIN)
 
+if (ZLIB_BUILTIN)
+  add_dependencies (${PROJECT_TEST_NAME} zlib)
+endif (ZLIB_BUILTIN)
+
 if (TBB_PRIVATE_LIB)
   add_dependencies (${PROJECT_TEST_NAME} libtbb)
 endif (TBB_PRIVATE_LIB)


### PR DESCRIPTION
`cmake -DBUILD_UNITTESTS=yes .. && make` failed because zlib was no dependency of `cvmfs_unittests` CMake target.
