### PR TITLE
FIX: Ulimit is too Low for Some (Server) Test Cases

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -104,6 +104,9 @@ setup_environment() {
     fi
   fi
 
+  # increase ulimit (mainly for server tests)
+  sudo ulimit -n 65536 ||  return 105
+
   # reset the test warning flags
   reset_test_warning_flags
 


### PR DESCRIPTION
Increase ulimit by default before running any test cases. It is arguable whether this should be a permanent fix...
