### PR TITLE
FIX: Openstack Startup Failed (Perhaps Since they Updated)

### DIFF
--- a/test/cloud_testing/steering/instance_handler.py
+++ b/test/cloud_testing/steering/instance_handler.py
@@ -100,7 +100,7 @@ def create_instance(parent_parser, argv):
   instance   = spawn_instance(connection, ami, key_name, flavor)
 
   if instance != None:
-    print instance.id , instance.ip_address
+    print instance.id , instance.private_ip_address
   else:
     print_error("Failed to start instance")
     exit(2)


### PR DESCRIPTION
Apparently there was a change in the IP address announcement since Jan updated the openstack backend. This adapts to the new version. Additionally it removes 'ibex' from the method names. RIP Ibex.
