### PR TITLE
Whitelist Expiry Warning in Transaction

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2211,10 +2211,11 @@ transaction() {
 
     # more sanity checks
     check_repository_compatibility
-    check_expiry $stratum0 || { echo "Repository whitelist for $name is expired!"; retcode=1; continue; }
     if [ $force -eq 0 ]; then
       is_in_transaction $name && { echo "Repository $name is already in a transaction"; continue; }
     fi
+    check_expiry $stratum0 || { echo "Repository whitelist for $name is expired!"; retcode=1; continue; }
+    [ $(get_expiry $stratum0) -le $(( 12 * 60 * 60 )) ] && { echo "Warning: Repository whitelist stays valid for less than 12 hours!"; }
 
     # do it!
     transaction_before_hook $name


### PR DESCRIPTION
When entering a transaction with a whitelist that is valid for less than 12 hours, `cvmfs_server` will print a warning but will still succeed. Since there is a race condition in the following workflow:
`cvmfs_server transaction` => `[whitelist expires]` => `cvmfs_server publish`
this might come in handy when dissecting log files.
