### PR TITLE
FIX: Test Repo Wasn't Destroyable After Successful Test Run

### DIFF
--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -86,5 +86,8 @@ cvmfs_run_test() {
   [ -f ${repo_dir}/foo/bar ] && grep -q "no meaningful stuff" ${repo_dir}/foo/bar || return 14
   [ -f ${repo_dir}/bar/baz ] && grep -q "no meaningful stuff" ${repo_dir}/bar/baz || return 15
 
+  # remove the test repository
+  destroy_repo $CVMFS_TEST_REPO || return 16
+
   return 0
 }


### PR DESCRIPTION
Since the test repository in integration test 519 was generated inside the test's scratch space it got demolished by the global test steering scripts on successful completion. This led to failing re-creation of _test.cern.ch_ by all the next tests.
Now the testee repository is removed before the test finishes successfully.
