### PR TITLE
Help Message for Machine Readable Output in `cvmfs_swissknife scrub`

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -152,7 +152,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
   swissknife_history.h swissknife_history.cc
   swissknife_migrate.h swissknife_migrate.cc
   swissknife_scrub.h swissknife_scrub.cc
-  swissknife.h swissknife.cc)
+  swissknife.h swissknife_impl.h swissknife.cc)
 
 
 set (CVMFS_SWISSKNIFE_DEBUG_SOURCES

--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -30,7 +30,6 @@
 using namespace std;  // NOLINT
 using namespace swissknife;
 
-vector<swissknife::Command *> command_list;
 download::DownloadManager *swissknife::g_download_manager;
 signature::SignatureManager *swissknife::g_signature_manager;
 
@@ -42,53 +41,125 @@ void swissknife::Usage() {
     "  cvmfs_swissknife <command> [options]\n",
     VERSION);
 
-  for (unsigned i = 0; i < command_list.size(); ++i) {
+  AbstractCommand::IntrospectionData info = AbstractCommand::Introspect();
+  AbstractCommand::IntrospectionData::const_iterator i    = info.begin();
+  AbstractCommand::IntrospectionData::const_iterator iend = info.end();
+  for (; i != iend; ++i) {
+    const CommandIntrospection &command_info = *i;
+
+    // headline
     LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n"
              "Command %s\n"
-             "--------", command_list[i]->GetName().c_str());
-    for (unsigned j = 0; j < command_list[i]->GetName().length(); ++j) {
+             "--------", command_info.name.c_str());
+    for (unsigned j = 0; j < command_info.name.length(); ++j) {
       LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "-");
     }
-    LogCvmfs(kLogCvmfs, kLogStdout, "");
-    LogCvmfs(kLogCvmfs, kLogStdout, "%s",
-             command_list[i]->GetDescription().c_str());
-    swissknife::ParameterList params = command_list[i]->GetParams();
-    if (!params.empty()) {
-      LogCvmfs(kLogCvmfs, kLogStdout, "Options:");
-      for (unsigned j = 0; j < params.size(); ++j) {
-        LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "  -%c    %s",
-                 params[j].key(), params[j].description().c_str());
-        if (params[j].optional())
-          LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, " (optional)");
-        LogCvmfs(kLogCvmfs, kLogStdout, "");
-      }
-    }  // Parameter list
-  }  // Command list
+
+    // description
+    LogCvmfs(kLogCvmfs, kLogStdout, "\n%s\n",
+             command_info.description.c_str());
+
+    // parameters
+    const ParameterList &params = command_info.parameters;
+    if (params.empty()) {
+      continue;
+    }
+    LogCvmfs(kLogCvmfs, kLogStdout, "Options:");
+    ParameterList::const_iterator j    = params.begin();
+    ParameterList::const_iterator jend = params.end();
+    for (; j != jend; ++j) {
+      LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "  -%c    %s",
+               j->key(), j->description().c_str());
+      if (j->optional())
+        LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, " (optional)");
+      LogCvmfs(kLogCvmfs, kLogStdout, "");
+    }
+  }
 
   LogCvmfs(kLogCvmfs, kLogStdout, "");
+}
+
+
+void AbstractCommand::RegisterPlugins() {
+  RegisterPlugin<swissknife::CommandCreate>();
+  RegisterPlugin<swissknife::CommandUpload>();
+  RegisterPlugin<swissknife::CommandRemove>();
+  RegisterPlugin<swissknife::CommandPeek>();
+  RegisterPlugin<swissknife::CommandSync>();
+  RegisterPlugin<swissknife::CommandTag>();
+  RegisterPlugin<swissknife::CommandRollback>();
+  RegisterPlugin<swissknife::CommandSign>();
+  RegisterPlugin<swissknife::CommandCheck>();
+  RegisterPlugin<swissknife::CommandListCatalogs>();
+  RegisterPlugin<swissknife::CommandPull>();
+  RegisterPlugin<swissknife::CommandZpipe>();
+  RegisterPlugin<swissknife::CommandInfo>();
+  RegisterPlugin<swissknife::CommandVersion>();
+  RegisterPlugin<swissknife::CommandMigrate>();
+  RegisterPlugin<swissknife::CommandScrub>();
+}
+
+
+ArgumentList AbstractCommand::ParseArguments(int argc, char **argv,
+                                             ParameterList &params) const
+{
+  ArgumentList args;
+
+  optind = 1;
+  std::string option_string = "";
+  ParameterList::const_iterator i    = params.begin();
+  ParameterList::const_iterator iend = params.end();
+
+  // define `getopt` option string
+  for (; i != iend; ++i) {
+    option_string.push_back(i->key());
+    if (! i->switch_only()) {
+      option_string.push_back(':');
+    }
+  }
+
+  // parse command line parameters
+  int c;
+  while ((c = getopt(argc, argv, option_string.c_str())) != -1) {
+    bool valid_option = false;
+
+    i = params.begin();
+    for (; i != iend; ++i) {
+      if (c == i->key()) {
+        valid_option = true;
+        std::string *argument = NULL;
+        if (! i->switch_only()) {
+          argument = new std::string(optarg);
+        }
+        args[c] = argument;
+
+        break;
+      }
+    }
+
+    if (!valid_option) {
+      swissknife::Usage();
+      exit(1);
+    }
+  }
+
+  // check if all mandatory parameters are found
+  i = params.begin();
+  for (; i != iend; ++i) {
+    if (i->mandatory() && args.find(i->key()) == args.end()) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "parameter -%c missing",
+               i->key());
+      exit(1);
+    }
+  }
+
+  return args;
 }
 
 
 int main(int argc, char **argv) {
   g_download_manager = new download::DownloadManager();
   g_signature_manager = new signature::SignatureManager();
-
-  command_list.push_back(new swissknife::CommandCreate());
-  command_list.push_back(new swissknife::CommandUpload());
-  command_list.push_back(new swissknife::CommandRemove());
-  command_list.push_back(new swissknife::CommandPeek());
-  command_list.push_back(new swissknife::CommandSync());
-  command_list.push_back(new swissknife::CommandTag());
-  command_list.push_back(new swissknife::CommandRollback());
-  command_list.push_back(new swissknife::CommandSign());
-  command_list.push_back(new swissknife::CommandCheck());
-  command_list.push_back(new swissknife::CommandListCatalogs());
-  command_list.push_back(new swissknife::CommandPull());
-  command_list.push_back(new swissknife::CommandZpipe());
-  command_list.push_back(new swissknife::CommandInfo());
-  command_list.push_back(new swissknife::CommandVersion());
-  command_list.push_back(new swissknife::CommandMigrate());
-  command_list.push_back(new swissknife::CommandScrub());
 
   if (argc < 2) {
     swissknife::Usage();
@@ -99,55 +170,20 @@ int main(int argc, char **argv) {
     return 0;
   }
   if ((string(argv[1]) == "--version")) {
-    swissknife::CommandVersion().Main(swissknife::ArgumentList());
+    AbstractCommand::Construct("version")->Run(swissknife::ArgumentList());
     return 0;
   }
 
-  for (unsigned i = 0; i < command_list.size(); ++i) {
-    if (command_list[i]->GetName() == string(argv[1])) {
-      swissknife::ArgumentList args;
-      optind = 1;
-      string option_string = "";
-      swissknife::ParameterList params = command_list[i]->GetParams();
-      for (unsigned j = 0; j < params.size(); ++j) {
-        option_string.push_back(params[j].key());
-        if (!params[j].switch_only())
-          option_string.push_back(':');
-      }
-      int c;
-      while ((c = getopt(argc, argv, option_string.c_str())) != -1) {
-        bool valid_option = false;
-        for (unsigned j = 0; j < params.size(); ++j) {
-          if (c == params[j].key()) {
-            valid_option = true;
-            string *argument = NULL;
-            if (!params[j].switch_only()) {
-              argument = new string(optarg);
-            }
-            args[c] = argument;
-            break;
-          }
-        }
-        if (!valid_option) {
-          swissknife::Usage();
-          return 1;
-        }
-      }
-      for (unsigned j = 0; j < params.size(); ++j) {
-        if (!params[j].optional()) {
-          if (args.find(params[j].key()) == args.end()) {
-            LogCvmfs(kLogCvmfs, kLogStderr, "parameter -%c missing",
-                     params[j].key());
-            return 1;
-          }
-        }
-      }
-      return command_list[i]->Main(args);
-    }
+  AbstractCommand *command = AbstractCommand::Construct(argv[1]);
+  if (command == NULL) {
+    swissknife::Usage();
+    exit(1);
   }
+
+  int exit_code = command->Main(argc, argv);
 
   delete g_signature_manager;
   delete g_download_manager;
-  swissknife::Usage();
-  return 1;
+
+  return exit_code;
 }

--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -104,6 +104,7 @@ ArgumentList AbstractCommand::ParseArguments(int argc, char **argv,
                                              ParameterList &params) const
 {
   ArgumentList args;
+  bool found_help_switch = false;
 
   optind = 1;
   std::string option_string = "";
@@ -133,6 +134,10 @@ ArgumentList AbstractCommand::ParseArguments(int argc, char **argv,
         }
         args[c] = argument;
 
+        if (i->help_switch()) {
+          found_help_switch = true;
+        }
+
         break;
       }
     }
@@ -144,12 +149,15 @@ ArgumentList AbstractCommand::ParseArguments(int argc, char **argv,
   }
 
   // check if all mandatory parameters are found
-  i = params.begin();
-  for (; i != iend; ++i) {
-    if (i->mandatory() && args.find(i->key()) == args.end()) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "parameter -%c missing",
-               i->key());
-      exit(1);
+  // (Note: the help switch might override all other mandatory options)
+  if (! found_help_switch) {
+    i = params.begin();
+    for (; i != iend; ++i) {
+      if (i->mandatory() && args.find(i->key()) == args.end()) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "parameter -%c missing",
+                 i->key());
+        exit(1);
+      }
     }
   }
 

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -29,13 +29,16 @@ void Usage();
 class Parameter {
  public:
   static Parameter Mandatory(const char key, const std::string &desc) {
-    return Parameter(key, desc, false, false);
+    return Parameter(key, desc, false, false, false);
   }
   static Parameter Optional(const char key, const std::string &desc) {
-    return Parameter(key, desc, true, false);
+    return Parameter(key, desc, true, false, false);
   }
   static Parameter Switch(const char key, const std::string &desc) {
-    return Parameter(key, desc, true, true);
+    return Parameter(key, desc, true, true, false);
+  }
+  static Parameter HelpSwitch(const char key, const std::string &desc) {
+    return Parameter(key, desc, true, true, true);
   }
 
   char key() const { return key_; }
@@ -43,18 +46,22 @@ class Parameter {
   bool optional() const { return optional_; }
   bool mandatory() const { return !optional_; }
   bool switch_only() const { return switch_only_; }
+  bool help_switch() const { return help_switch_; }
 
  protected:
   Parameter(const char          key,
             const std::string  &desc,
             const bool          opt,
-            const bool          switch_only) :
+            const bool          switch_only,
+            const bool          help_switch) :
     key_(key),
     description_(desc),
     optional_(opt),
-    switch_only_(switch_only)
+    switch_only_(switch_only),
+    help_switch_(help_switch)
   {
     assert (! switch_only_ || optional_); // switches are optional by definition
+    assert (! help_switch_ || switch_only_); // help switches _are_ switches
   }
 
  private:
@@ -62,6 +69,7 @@ class Parameter {
   std::string description_;
   bool optional_;
   bool switch_only_;
+  bool help_switch_;
 };
 
 typedef std::vector<Parameter> ParameterList;

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -10,6 +10,8 @@
 #include <map>
 #include <cassert>
 
+#include "util.h"
+
 namespace download {
 class DownloadManager;
 }
@@ -27,18 +29,19 @@ void Usage();
 class Parameter {
  public:
   static Parameter Mandatory(const char key, const std::string &desc) {
-    return Parameter(key, desc, false, false, false);
+    return Parameter(key, desc, false, false);
   }
   static Parameter Optional(const char key, const std::string &desc) {
-    return Parameter(key, desc, true, false, false);
+    return Parameter(key, desc, true, false);
   }
   static Parameter Switch(const char key, const std::string &desc) {
-    return Parameter(key, desc, true, true, false);
+    return Parameter(key, desc, true, true);
   }
 
   char key() const { return key_; }
   const std::string& description() const { return description_; }
   bool optional() const { return optional_; }
+  bool mandatory() const { return !optional_; }
   bool switch_only() const { return switch_only_; }
 
  protected:
@@ -49,9 +52,9 @@ class Parameter {
     key_(key),
     description_(desc),
     optional_(opt),
-    switch_only_(switch_only),
+    switch_only_(switch_only)
   {
-    assert (switch_only_ && optional_); // switches are optional by definition
+    assert (! switch_only_ || optional_); // switches are optional by definition
   }
 
  private:
@@ -64,16 +67,61 @@ class Parameter {
 typedef std::vector<Parameter> ParameterList;
 typedef std::map<char, std::string *> ArgumentList;
 
-class Command {
+struct CommandIntrospection {
+  CommandIntrospection(const std::string    &name,
+                       const std::string    &description,
+                       const ParameterList  &parameters) :
+    name(name), description(description), parameters(parameters) {}
+
+  std::string    name;
+  std::string    description;
+  ParameterList  parameters;
+};
+
+class AbstractCommand : public PolymorphicConstruction<AbstractCommand,
+                                                       std::string,
+                                                       CommandIntrospection> {
  public:
-  Command() { }
-  virtual ~Command() { }
-  virtual std::string GetName() = 0;
-  virtual std::string GetDescription() = 0;
-  virtual ParameterList GetParams() = 0;
-  virtual int Main(const ArgumentList &args) = 0;
+  static void RegisterPlugins();
+
+ public:
+  // this should be overridden and up-called for each Command implementation
+  AbstractCommand(const std::string &param) {}
+  virtual ~AbstractCommand() { }
+  virtual int Main(int argc, char** argv) = 0;
+  virtual int Run(const ArgumentList &args) = 0;
+
+ protected:
+  virtual ArgumentList ReadArguments(int argc, char **argv) const = 0;
+
+  ArgumentList ParseArguments(int argc, char **argv, ParameterList &params) const;
+};
+
+
+// CRTP - Curiously Recurring Template Pattern for static polymorphism
+template <class DerivedT>
+class Command : public AbstractCommand {
+ public:
+  Command(const std::string &param) : AbstractCommand(param) {}
+
+  static bool WillHandle(const std::string &param) {
+    return (param == DerivedT::GetName());
+  }
+
+  static CommandIntrospection GetInfo() {
+    return CommandIntrospection(DerivedT::GetName(),
+                                DerivedT::GetDescription(),
+                                DerivedT::GetParameters());
+  }
+
+  int Main(int argc, char **argv);
+
+ protected:
+  ArgumentList ReadArguments(int argc, char **argv) const;
 };
 
 }  // namespace swissknife
+
+#include "swissknife_impl.h"
 
 #endif  // CVMFS_SWISSKNIFE_H_

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cassert>
 
 namespace download {
 class DownloadManager;
@@ -25,19 +26,34 @@ void Usage();
 
 class Parameter {
  public:
-  Parameter(const char key, const std::string &desc, const bool opt,
-            const bool switch_only)
-  {
-    key_ = key;
-    description_ = desc;
-    optional_ = opt;
-    switch_only_ = switch_only;
+  static Parameter Mandatory(const char key, const std::string &desc) {
+    return Parameter(key, desc, false, false, false);
+  }
+  static Parameter Optional(const char key, const std::string &desc) {
+    return Parameter(key, desc, true, false, false);
+  }
+  static Parameter Switch(const char key, const std::string &desc) {
+    return Parameter(key, desc, true, true, false);
   }
 
   char key() const { return key_; }
-  std::string description() const { return description_; }
+  const std::string& description() const { return description_; }
   bool optional() const { return optional_; }
   bool switch_only() const { return switch_only_; }
+
+ protected:
+  Parameter(const char          key,
+            const std::string  &desc,
+            const bool          opt,
+            const bool          switch_only) :
+    key_(key),
+    description_(desc),
+    optional_(opt),
+    switch_only_(switch_only),
+  {
+    assert (switch_only_ && optional_); // switches are optional by definition
+  }
+
  private:
   char key_;
   std::string description_;

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -558,7 +558,7 @@ bool CommandCheck::InspectTree(const string &path,
 }
 
 
-int CommandCheck::Main(const swissknife::ArgumentList &args) {
+int CommandCheck::Run(const swissknife::ArgumentList &args) {
   string tag_name;
   check_chunks = false;
   if (args.find('t') != args.end())

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -15,16 +15,17 @@ class DownloadManager;
 
 namespace swissknife {
 
-class CommandCheck : public Command {
+class CommandCheck : public Command<CommandCheck> {
  public:
+  CommandCheck(const std::string &param) : Command(param) {}
   ~CommandCheck() { };
-  std::string GetName() { return "check"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "check"; };
+  static std::string GetDescription() {
     return "CernVM File System repository sanity checker\n"
       "This command checks the consisteny of the file catalogs of a "
         "cvmfs repository.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('r', "repository directory / url"));
     r.push_back(Parameter::Optional ('t', "check specific repository tag"));
@@ -32,7 +33,7 @@ class CommandCheck : public Command {
     r.push_back(Parameter::Switch   ('c', "check availability of data chunks"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 
  protected:
   bool InspectTree(const std::string &path,

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -25,15 +25,12 @@ class CommandCheck : public Command {
         "cvmfs repository.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('r', "repository directory / url",
-                               false, false));
-    result.push_back(Parameter('t', "check specific repository tag",
-                               true, false));
-    result.push_back(Parameter('l', "log level (0-4, default: 2)", true, false));
-    result.push_back(Parameter('c', "check availability of data chunks",
-                               true, true));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('r', "repository directory / url"));
+    r.push_back(Parameter::Optional ('t', "check specific repository tag"));
+    r.push_back(Parameter::Optional ('l', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Switch   ('c', "check availability of data chunks"));
+    return r;
   }
   int Main(const ArgumentList &args);
 

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -103,7 +103,7 @@ static bool FetchTagList(const string &repository_url,
 }
 
 
-int swissknife::CommandTag::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandTag::Run(const swissknife::ArgumentList &args) {
   const string repository_url = MakeCanonicalPath(*args.find('r')->second);
   const string repository_name = *args.find('n')->second;
   const string repository_key_path = *args.find('k')->second;
@@ -252,7 +252,7 @@ int swissknife::CommandTag::Main(const swissknife::ArgumentList &args) {
 }
 
 
-int swissknife::CommandRollback::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandRollback::Run(const swissknife::ArgumentList &args) {
   const string spooler_definition = *args.find('r')->second;
   const string repository_url = MakeCanonicalPath(*args.find('u')->second);
   const string repository_name = *args.find('n')->second;

--- a/cvmfs/swissknife_history.h
+++ b/cvmfs/swissknife_history.h
@@ -18,26 +18,22 @@ class CommandTag : public Command {
     return "Tags a snapshot.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('r', "repository directory / url",
-                               false, false));
-    result.push_back(Parameter('b', "base hash", false, false));
-    result.push_back(Parameter('t', "trunk hash", false, false));
-    result.push_back(Parameter('s', "trunk catalog size", false, false));
-    result.push_back(Parameter('i', "trunk revision", false, false));
-    result.push_back(Parameter('n', "repository name", false, false));
-    result.push_back(Parameter('k', "repository public key", false, false));
-    result.push_back(Parameter('o', "history db output file",
-                               false, false));
-    result.push_back(Parameter('d', "delete a tag", true, false));
-    result.push_back(Parameter('a', "add a tag (format: \"name@channel@desc\")",
-                               true, false));
-    result.push_back(Parameter('h', "tag hash (if different from trunk)",
-                               true, false));
-    result.push_back(Parameter('l', "list tags", true, true));
-    result.push_back(Parameter('z', "trusted certificate dir(s)", true, false));
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('r', "repository directory / url"));
+    r.push_back(Parameter::Mandatory('b', "base hash"));
+    r.push_back(Parameter::Mandatory('t', "trunk hash"));
+    r.push_back(Parameter::Mandatory('s', "trunk catalog size"));
+    r.push_back(Parameter::Mandatory('i', "trunk revision"));
+    r.push_back(Parameter::Mandatory('n', "repository name"));
+    r.push_back(Parameter::Mandatory('k', "repository public key"));
+    r.push_back(Parameter::Mandatory('o', "history db output file"));
+    r.push_back(Parameter::Optional ('d', "delete a tag"));
+    r.push_back(Parameter::Optional ('a', "add a tag (format: \"name@channel@desc\")"));
+    r.push_back(Parameter::Optional ('h', "tag hash (if different from trunk)"));
+    r.push_back(Parameter::Switch   ('l', "list tags"));
+    r.push_back(Parameter::Optional ('z', "trusted certificate dir(s)"));
 
-    return result;
+    return r;
   }
   int Main(const ArgumentList &args);
 };
@@ -52,20 +48,18 @@ class CommandRollback : public Command {
            "snapshots become inaccessible.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    result.push_back(Parameter('u', "repository directory / url",
-                               false, false));
-    result.push_back(Parameter('b', "base hash", false, false));
-    result.push_back(Parameter('n', "repository name", false, false));
-    result.push_back(Parameter('k', "repository public key", false, false));
-    result.push_back(Parameter('o', "history db output file",
-                               false, false));
-    result.push_back(Parameter('m', "manifest output file", false, false));
-    result.push_back(Parameter('t', "revert to this tag", false, false));
-    result.push_back(Parameter('d', "temp directory", false, false));
-    result.push_back(Parameter('z', "trusted certificate dir(s)", true, false));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Mandatory('u', "repository directory / url"));
+    r.push_back(Parameter::Mandatory('b', "base hash"));
+    r.push_back(Parameter::Mandatory('n', "repository name"));
+    r.push_back(Parameter::Mandatory('k', "repository public key"));
+    r.push_back(Parameter::Mandatory('o', "history db output file"));
+    r.push_back(Parameter::Mandatory('m', "manifest output file"));
+    r.push_back(Parameter::Mandatory('t', "revert to this tag"));
+    r.push_back(Parameter::Mandatory('d', "temp directory"));
+    r.push_back(Parameter::Optional ('z', "trusted certificate dir(s)"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };

--- a/cvmfs/swissknife_history.h
+++ b/cvmfs/swissknife_history.h
@@ -10,14 +10,13 @@
 
 namespace swissknife {
 
-class CommandTag : public Command {
+class CommandTag : public Command<CommandTag> {
  public:
+  CommandTag(const std::string &param) : Command(param) {}
   ~CommandTag() { };
-  std::string GetName() { return "tag"; };
-  std::string GetDescription() {
-    return "Tags a snapshot.";
-  };
-  ParameterList GetParams() {
+  static std::string GetName() { return "tag"; }
+  static std::string GetDescription() { return "Tags a snapshot."; }
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('r', "repository directory / url"));
     r.push_back(Parameter::Mandatory('b', "base hash"));
@@ -35,19 +34,21 @@ class CommandTag : public Command {
 
     return r;
   }
-  int Main(const ArgumentList &args);
+
+  int Run(const ArgumentList &args);
 };
 
 
-class CommandRollback : public Command {
+class CommandRollback : public Command<CommandRollback> {
  public:
+  CommandRollback(const std::string &param) : Command(param) {}
   ~CommandRollback() { };
-  std::string GetName() { return "rollback"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "rollback"; };
+  static std::string GetDescription() {
     return "Re-publishes a previous tagged snapshot.  All intermediate "
            "snapshots become inaccessible.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
     r.push_back(Parameter::Mandatory('u', "repository directory / url"));
@@ -61,7 +62,7 @@ class CommandRollback : public Command {
     r.push_back(Parameter::Optional ('z', "trusted certificate dir(s)"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 }  // namespace swissknife

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -1,0 +1,19 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+namespace swissknife {
+
+template <class DerivedT>
+int Command<DerivedT>::Main(int argc, char **argv) {
+  const ArgumentList arguments = ReadArguments(argc, argv);
+  return Run(arguments);
+}
+
+template <class DerivedT>
+ArgumentList Command<DerivedT>::ReadArguments(int argc, char **argv) const {
+  ParameterList params = DerivedT::GetParameters();
+  return ParseArguments(argc, argv, params);
+}
+
+} // namespace swissknife

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -43,17 +43,16 @@ static bool Exists(const string &repository, const string &file)
 }
 
 swissknife::ParameterList swissknife::CommandInfo::GetParams() {
-  swissknife::ParameterList result;
-  result.push_back(Parameter('r', "repository directory / url",
-                             false, false));
-  result.push_back(Parameter('l', "log level (0-4, default: 2)", true, false));
-  result.push_back(Parameter('c', "show root catalog hash", true, true));
-  result.push_back(Parameter('n', "show fully qualified repository name", true, true));
-  result.push_back(Parameter('t', "show time stamp", true, true));
-  result.push_back(Parameter('m', "check if repository is marked as replication master copy", true, true));
-  result.push_back(Parameter('h', "print results in human readable form", true, true));
+  swissknife::ParameterList r;
+  r.push_back(Parameter::Mandatory('r', "repository directory / url"));
+  r.push_back(Parameter::Optional ('l', "log level (0-4, default: 2)"));
+  r.push_back(Parameter::Switch   ('c', "show root catalog hash"));
+  r.push_back(Parameter::Switch   ('n', "show fully qualified repository name"));
+  r.push_back(Parameter::Switch   ('t', "show time stamp"));
+  r.push_back(Parameter::Switch   ('m', "check if repository is marked as replication master copy"));
+  r.push_back(Parameter::Switch   ('h', "print results in human readable form"));
   // to be extended...
-  return result;
+  return r;
 }
 
 

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -42,7 +42,7 @@ static bool Exists(const string &repository, const string &file)
   }
 }
 
-swissknife::ParameterList swissknife::CommandInfo::GetParams() {
+swissknife::ParameterList swissknife::CommandInfo::GetParameters() {
   swissknife::ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository directory / url"));
   r.push_back(Parameter::Optional ('l', "log level (0-4, default: 2)"));
@@ -56,7 +56,7 @@ swissknife::ParameterList swissknife::CommandInfo::GetParams() {
 }
 
 
-int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandInfo::Run(const swissknife::ArgumentList &args) {
   if (args.find('l') != args.end()) {
     unsigned log_level =
       1 << (kLogLevel0 + String2Uint64(*args.find('l')->second));
@@ -153,7 +153,7 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
 //
 
 
-int swissknife::CommandVersion::Main(const ArgumentList &args) {
+int swissknife::CommandVersion::Run(const ArgumentList &args) {
   LogCvmfs(kLogCvmfs, kLogStdout, "%s", PACKAGE_VERSION);
   return 0;
 }

--- a/cvmfs/swissknife_info.h
+++ b/cvmfs/swissknife_info.h
@@ -9,26 +9,28 @@
 
 namespace swissknife {
 
-class CommandInfo : public Command {
+class CommandInfo : public Command<CommandInfo> {
  public:
+  CommandInfo(const std::string &param) : Command(param) {}
   ~CommandInfo() { };
-  std::string GetName() { return "info"; }
-  std::string GetDescription() {
+  static std::string GetName() { return "info"; }
+  static std::string GetDescription() {
     return "CernVM File System repository information retrieval\n"
       "This command reads the content of a .cvmfspublished file and exposes it "
       "to the user.";
   };
-  ParameterList GetParams();
-  int Main(const ArgumentList &args);
+  static ParameterList GetParameters();
+  int Run(const ArgumentList &args);
 };
 
-class CommandVersion : public Command {
+class CommandVersion : public Command<CommandVersion> {
  public:
+  CommandVersion(const std::string &param) : Command(param) {}
   ~CommandVersion() {};
-  std::string GetName()        { return "version";                         }
-  std::string GetDescription() { return "Prints the version of CernVM-FS"; }
-  ParameterList GetParams()    { return ParameterList();                   }
-  int Main(const ArgumentList &args);
+  static std::string   GetName()        { return "version";                     }
+  static std::string   GetDescription() { return "Prints version of CernVM-FS"; }
+  static ParameterList GetParameters()  { return ParameterList();               }
+  int Run(const ArgumentList &args);
 };
 
 }

--- a/cvmfs/swissknife_lsrepo.cc
+++ b/cvmfs/swissknife_lsrepo.cc
@@ -8,12 +8,8 @@
 
 using namespace swissknife;
 
-CommandListCatalogs::CommandListCatalogs() :
-  print_tree_(false),
-  print_hash_(false) {}
 
-
-ParameterList CommandListCatalogs::GetParams() {
+ParameterList CommandListCatalogs::GetParameters() {
   ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository URL (absolute local path or remote URL)"));
   r.push_back(Parameter::Optional ('n', "fully qualified repository name"));
@@ -24,7 +20,7 @@ ParameterList CommandListCatalogs::GetParams() {
 }
 
 
-int CommandListCatalogs::Main(const ArgumentList &args) {
+int CommandListCatalogs::Run(const ArgumentList &args) {
   print_tree_ = (args.count('t') > 0);
   print_hash_ = (args.count('d') > 0);
 

--- a/cvmfs/swissknife_lsrepo.cc
+++ b/cvmfs/swissknife_lsrepo.cc
@@ -14,18 +14,13 @@ CommandListCatalogs::CommandListCatalogs() :
 
 
 ParameterList CommandListCatalogs::GetParams() {
-  ParameterList result;
-  result.push_back(Parameter('r', "repository URL (absolute local path or remote URL)",
-                             false, false));
-  result.push_back(Parameter('n', "fully qualified repository name",
-                             true, false));
-  result.push_back(Parameter('k', "repository master key(s)",
-                             true, false));
-  result.push_back(Parameter('t', "print tree structure of catalogs",
-                             true, true));
-  result.push_back(Parameter('d', "print digest for each catalog",
-                             true, true));
-  return result;
+  ParameterList r;
+  r.push_back(Parameter::Mandatory('r', "repository URL (absolute local path or remote URL)"));
+  r.push_back(Parameter::Optional ('n', "fully qualified repository name"));
+  r.push_back(Parameter::Optional ('k', "repository master key(s)"));
+  r.push_back(Parameter::Switch   ('t', "print tree structure of catalogs"));
+  r.push_back(Parameter::Switch   ('d', "print digest for each catalog"));
+  return r;
 }
 
 

--- a/cvmfs/swissknife_lsrepo.h
+++ b/cvmfs/swissknife_lsrepo.h
@@ -16,19 +16,21 @@ namespace catalog {
 
 namespace swissknife {
 
-class CommandListCatalogs : public Command {
+class CommandListCatalogs : public Command<CommandListCatalogs> {
  public:
-  CommandListCatalogs();
+  CommandListCatalogs(const std::string &param) : Command(param),
+                                                  print_tree_(false),
+                                                  print_hash_(false) {}
   ~CommandListCatalogs() { };
-  std::string GetName() { return "lsrepo"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "lsrepo"; };
+  static std::string GetDescription() {
     return "CernVM File System Repository Traversal\n"
       "This command lists the nested catalog tree that builds up a "
       "cvmfs repository structure.";
   };
-  ParameterList GetParams();
+  static ParameterList GetParameters();
 
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 
   void CatalogCallback(const CatalogTraversalData &data);
 

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -19,7 +19,8 @@ using namespace std;  // NOLINT
 
 catalog::DirectoryEntry  CommandMigrate::nested_catalog_marker_;
 
-CommandMigrate::CommandMigrate() :
+CommandMigrate::CommandMigrate(const std::string &param) :
+  Command(param),
   file_descriptor_limit_(8192),
   catalog_count_(0),
   uid_(0),
@@ -30,7 +31,7 @@ CommandMigrate::CommandMigrate() :
 }
 
 
-ParameterList CommandMigrate::GetParams() {
+ParameterList CommandMigrate::GetParameters() {
   ParameterList r;
   r.push_back(Parameter::Mandatory('v', "migration base version ( 2.0.x | 2.1.7 )"));
   r.push_back(Parameter::Mandatory('r', "repository URL (absolute local path "
@@ -72,7 +73,7 @@ static void Error(const std::string                     &message,
 }
 
 
-int CommandMigrate::Main(const ArgumentList &args) {
+int CommandMigrate::Run(const ArgumentList &args) {
   const std::string &migration_base     = *args.find('v')->second;
   const std::string &repo_url           = *args.find('r')->second;
   const std::string &spooler            = *args.find('u')->second;

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -31,33 +31,21 @@ CommandMigrate::CommandMigrate() :
 
 
 ParameterList CommandMigrate::GetParams() {
-  ParameterList result;
-  result.push_back(Parameter('v', "migration base version ( 2.0.x | 2.1.7 )",
-                             false, false));
-  result.push_back(Parameter('r', "repository URL (absolute local path "
-                                  "or remote URL)",
-                             false, false));
-  result.push_back(Parameter('u', "upstream definition string",
-                             false, false));
-  result.push_back(Parameter('o', "manifest output file",
-                             false, false));
-  result.push_back(Parameter('t', "temporary directory for catalog decompress",
-                             false, false));
-  result.push_back(Parameter('p', "user id to be used for this repository",
-                             true, false));
-  result.push_back(Parameter('g', "group id to be used for this repository",
-                             true, false));
-  result.push_back(Parameter('n', "fully qualified repository name",
-                             true, false));
-  result.push_back(Parameter('k', "repository master key(s)",
-                             true, false));
-  result.push_back(Parameter('f', "fix nested catalog transition points",
-                             true, true));
-  result.push_back(Parameter('l', "disable linkcount analysis of files",
-                             true, true));
-  result.push_back(Parameter('s', "enable collection of catalog statistics",
-                             true, true));
-  return result;
+  ParameterList r;
+  r.push_back(Parameter::Mandatory('v', "migration base version ( 2.0.x | 2.1.7 )"));
+  r.push_back(Parameter::Mandatory('r', "repository URL (absolute local path "
+                                        "or remote URL)"));
+  r.push_back(Parameter::Mandatory('u', "upstream definition string"));
+  r.push_back(Parameter::Mandatory('o', "manifest output file"));
+  r.push_back(Parameter::Mandatory('t', "temporary directory for catalog decompress"));
+  r.push_back(Parameter::Optional ('p', "user id to be used for this repository"));
+  r.push_back(Parameter::Optional ('g', "group id to be used for this repository"));
+  r.push_back(Parameter::Optional ('n', "fully qualified repository name"));
+  r.push_back(Parameter::Optional ('k', "repository master key(s)"));
+  r.push_back(Parameter::Switch   ('f', "fix nested catalog transition points"));
+  r.push_back(Parameter::Switch   ('l', "disable linkcount analysis of files"));
+  r.push_back(Parameter::Switch   ('s', "enable collection of catalog statistics"));
+  return r;
 }
 
 

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -25,7 +25,7 @@ namespace catalog {
 
 namespace swissknife {
 
-class CommandMigrate : public Command {
+class CommandMigrate : public Command<CommandMigrate> {
  protected:
   struct CatalogStatistics {
     CatalogStatistics() : max_row_id(0), entry_count(0), hardlink_group_count(0),
@@ -189,16 +189,16 @@ class CommandMigrate : public Command {
   };
 
  public:
-  CommandMigrate();
+  CommandMigrate(const std::string &param);
   ~CommandMigrate() { };
-  std::string GetName() { return "migrate"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "migrate"; };
+  static std::string GetDescription() {
     return "CernVM-FS catalog repository migration \n"
       "This command migrates the whole catalog structure of a given repository";
   };
-  ParameterList GetParams();
+  static ParameterList GetParameters();
 
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 
   static void FixNestedCatalogTransitionPoint(
                           catalog::DirectoryEntry &mountpoint,

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -333,7 +333,7 @@ static bool Pull(const shash::Any &catalog_hash, const std::string &path,
 }
 
 
-int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandPull::Run(const swissknife::ArgumentList &args) {
   int retval;
   unsigned timeout = 10;
   int fd_lockfile = -1;

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -17,23 +17,20 @@ class CommandPull : public Command {
     return "Makes a Stratum 1 replica of a Stratum 0 repository.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('u', "repository url", false, false));
-    result.push_back(Parameter('m', "repository name", false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    result.push_back(Parameter('k', "repository master key(s)", false, false));
-    result.push_back(Parameter('y', "trusted certificate directories",
-                               true, false));
-    result.push_back(Parameter('x', "directory for temporary files",
-                               false, false));
-    result.push_back(Parameter('n', "number of download threads", true, false));
-    result.push_back(Parameter('l', "log level (0-4, default: 2)", true, false));
-    result.push_back(Parameter('t', "timeout (s)", true, false));
-    result.push_back(Parameter('a', "number of retries", true, false));
-    result.push_back(Parameter('p', "pull catalog history, too", true, true));
-    result.push_back(Parameter('c', "preload cache instead of stratum 1",
-                               true, true));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('u', "repository url"));
+    r.push_back(Parameter::Mandatory('m', "repository name"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Mandatory('k', "repository master key(s)"));
+    r.push_back(Parameter::Optional ('y', "trusted certificate directories"));
+    r.push_back(Parameter::Mandatory('x', "directory for temporary files"));
+    r.push_back(Parameter::Optional ('n', "number of download threads"));
+    r.push_back(Parameter::Optional ('l', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Optional ('t', "timeout (s)"));
+    r.push_back(Parameter::Optional ('a', "number of retries"));
+    r.push_back(Parameter::Switch   ('p', "pull catalog history, too"));
+    r.push_back(Parameter::Switch   ('c', "preload cache instead of stratum 1"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -9,14 +9,15 @@
 
 namespace swissknife {
 
-class CommandPull : public Command {
+class CommandPull : public Command<CommandPull> {
  public:
+  CommandPull(const std::string &param) : Command(param) {}
   ~CommandPull() { };
-  std::string GetName() { return "pull"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "pull"; };
+  static std::string GetDescription() {
     return "Makes a Stratum 1 replica of a Stratum 0 repository.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('u', "repository url"));
     r.push_back(Parameter::Mandatory('m', "repository name"));
@@ -32,7 +33,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Switch   ('c', "preload cache instead of stratum 1"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 }

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -60,7 +60,7 @@ tbb::task* CommandScrub::StoredFileScrubbingTask::execute() {
 
 
 
-swissknife::ParameterList CommandScrub::GetParams() {
+swissknife::ParameterList CommandScrub::GetParameters() {
   swissknife::ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository directory"));
   r.push_back(Parameter::Switch   ('m', "machine readable output"));
@@ -188,7 +188,7 @@ std::string CommandScrub::CheckPathAndExtractHash(
 }
 
 
-int CommandScrub::Main(const swissknife::ArgumentList &args) {
+int CommandScrub::Run(const swissknife::ArgumentList &args) {
   repo_path_               = MakeCanonicalPath(*args.find('r')->second);
   machine_readable_output_ = (args.find('m') != args.end());
 

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -61,10 +61,10 @@ tbb::task* CommandScrub::StoredFileScrubbingTask::execute() {
 
 
 swissknife::ParameterList CommandScrub::GetParams() {
-  swissknife::ParameterList result;
-  result.push_back(Parameter('r', "repository directory", false, false));
-  result.push_back(Parameter('m', "machine readable output", true, true));
-  return result;
+  swissknife::ParameterList r;
+  r.push_back(Parameter::Mandatory('r', "repository directory"));
+  r.push_back(Parameter::Switch   ('m', "machine readable output"));
+  return r;
 }
 
 

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -62,13 +62,14 @@ tbb::task* CommandScrub::StoredFileScrubbingTask::execute() {
 
 swissknife::ParameterList CommandScrub::GetParameters() {
   swissknife::ParameterList r;
-  r.push_back(Parameter::Mandatory('r', "repository directory"));
-  r.push_back(Parameter::Switch   ('m', "machine readable output"));
+  r.push_back(Parameter::Mandatory ('r', "repository directory"));
+  r.push_back(Parameter::Switch    ('m', "machine readable output"));
+  r.push_back(Parameter::HelpSwitch('h', "list possible alerts (and exit)"));
   return r;
 }
 
 
- const char* CommandScrub::Alerts::ToString(const CommandScrub::Alerts::Type t) {
+const char* CommandScrub::Alerts::ToString(const CommandScrub::Alerts::Type t) {
   switch (t) {
     case Alerts::kUnexpectedFile:
       return "unexpected regular file";
@@ -86,6 +87,28 @@ swissknife::ParameterList CommandScrub::GetParameters() {
       return "mismatch of file name and content hash";
     default:
       return "unknown alert";
+  }
+}
+
+
+const char* CommandScrub::Alerts::ToDocString(const Type t) {
+  switch (t) {
+    case Alerts::kUnexpectedFile:
+      return " -               <path> | an unexpected regular file was found";
+    case Alerts::kUnexpectedSymlink:
+      return " -               <path> | an unexpected symlink was found";
+    case Alerts::kUnexpectedSubdir:
+      return " -               <path> | an unexpected subdir was found in a backend subdir";
+    case Alerts::kUnexpectedModifier:
+      return " -               <path> | the modifier (capital letter) behind a data object is unknown";
+    case Alerts::kMalformedHash:
+      return "<malformed hash> <path> | content hash is not retrievable for file name";
+    case Alerts::kMalformedCasSubdir:
+      return " -               <path> | subdir name in backend is of unexpected length";
+    case Alerts::kContentHashMismatch:
+      return "<content hash>   <path> | content hash of file does not match object name";
+    default:
+      assert(false && "unexpected alert id");
   }
 }
 
@@ -189,6 +212,11 @@ std::string CommandScrub::CheckPathAndExtractHash(
 
 
 int CommandScrub::Run(const swissknife::ArgumentList &args) {
+  if (args.find('h') != args.end()) {
+    ShowAlertsHelpMessage();
+    return 0;
+  }
+
   repo_path_               = MakeCanonicalPath(*args.find('r')->second);
   machine_readable_output_ = (args.find('m') != args.end());
 
@@ -247,7 +275,13 @@ std::string CommandScrub::MakeFullPath(const std::string &relative_path,
 
 
 void CommandScrub::ShowAlertsHelpMessage() const {
-  LogCvmfs(kLogUtility, kLogStdout, "to come...");
+  static const char *headline = "[Code] [Hash Info]      [Path] | [Description]";
+  static const char *alert_ln = " %d     %s";
+  LogCvmfs(kLogUtility, kLogStdout, headline);
+  for (unsigned int i = 1; i < Alerts::kNumberOfErrorTypes; ++i) {
+    LogCvmfs(kLogUtility, kLogStdout, alert_ln,
+      i, Alerts::ToDocString(static_cast<Alerts::Type>(i)));
+  }
 }
 
 

--- a/cvmfs/swissknife_scrub.h
+++ b/cvmfs/swissknife_scrub.h
@@ -31,6 +31,7 @@ class CommandScrub : public Command<CommandScrub> {
     };
 
     static const char* ToString(const Type t);
+    static const char* ToDocString(const Type t);
   };
 
  private:

--- a/cvmfs/swissknife_scrub.h
+++ b/cvmfs/swissknife_scrub.h
@@ -16,7 +16,7 @@
 
 namespace swissknife {
 
-class CommandScrub : public Command {
+class CommandScrub : public Command<CommandScrub> {
  private:
   struct Alerts {
     enum Type {
@@ -72,18 +72,19 @@ class CommandScrub : public Command {
   typedef upload::Reader<StoredFileScrubbingTask, StoredFile> ScrubbingReader;
 
  public:
-  CommandScrub() : machine_readable_output_(false),
-                   reader_(NULL),
-                   alerts_(0) {}
+  CommandScrub(const std::string &param) : Command(param),
+                                           machine_readable_output_(false),
+                                           reader_(NULL),
+                                           alerts_(0) {}
   ~CommandScrub();
-  std::string GetName() { return "scrub"; }
-  std::string GetDescription() {
+  static std::string GetName() { return "scrub"; }
+  static std::string GetDescription() {
     return "CernVM File System repository file storage checker. Finds silent "
            "disk corruptions by recomputing all file content checksums in the "
            "backend file storage.";
   };
-  ParameterList GetParams();
-  int Main(const ArgumentList &args);
+  static ParameterList GetParameters();
+  int Run(const ArgumentList &args);
 
 
  protected:

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -34,7 +34,7 @@
 using namespace std;  // NOLINT
 
 
-int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandSign::Run(const swissknife::ArgumentList &args) {
   string manifest_path = *args.find('m')->second;
   string spooler_definition = *args.find('r')->second;
   string temp_dir = *args.find('t')->second;

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -9,14 +9,15 @@
 
 namespace swissknife {
 
-class CommandSign : public Command {
+class CommandSign : public Command<CommandSign> {
  public:
+  CommandSign(const std::string &param) : Command(param) {}
   ~CommandSign() { };
-  std::string GetName() { return "sign"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "sign"; };
+  static std::string GetDescription() {
     return "Adds a signature to the repository manifest.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('m', "manifest file"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
@@ -28,7 +29,7 @@ class CommandSign : public Command {
     r.push_back(Parameter::Optional ('h', "history path"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 }  // namespace swissknife

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -17,19 +17,16 @@ class CommandSign : public Command {
     return "Adds a signature to the repository manifest.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('m', "manifest file", false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    result.push_back(Parameter('t', "directory for temporary files",
-                               false, false));
-    result.push_back(Parameter('c', "x509 certificate", true, false));
-    result.push_back(Parameter('k', "private key of the certificate",
-                               true, false));
-    result.push_back(Parameter('s', "password for the private key",
-                               true, false));
-    result.push_back(Parameter('n', "repository name", true, false));
-    result.push_back(Parameter('h', "history path", true, false));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('m', "manifest file"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Mandatory('t', "directory for temporary files"));
+    r.push_back(Parameter::Optional ('c', "x509 certificate"));
+    r.push_back(Parameter::Optional ('k', "private key of the certificate"));
+    r.push_back(Parameter::Optional ('s', "password for the private key"));
+    r.push_back(Parameter::Optional ('n', "repository name"));
+    r.push_back(Parameter::Optional ('h', "history path"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -78,7 +78,7 @@ bool swissknife::CommandSync::CheckParams(const SyncParameters &p) {
 }
 
 
-int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandCreate::Run(const swissknife::ArgumentList &args) {
   const string manifest_path = *args.find('o')->second;
   const string dir_temp = *args.find('t')->second;
   const string spooler_definition = *args.find('r')->second;
@@ -130,7 +130,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
 }
 
 
-int swissknife::CommandUpload::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandUpload::Run(const swissknife::ArgumentList &args) {
   const string source = *args.find('i')->second;
   const string dest = *args.find('o')->second;
   const string spooler_definition = *args.find('r')->second;
@@ -160,7 +160,7 @@ int swissknife::CommandUpload::Main(const swissknife::ArgumentList &args) {
 }
 
 
-int swissknife::CommandPeek::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandPeek::Run(const swissknife::ArgumentList &args) {
   const string file_to_peek = *args.find('d')->second;
   const string spooler_definition = *args.find('r')->second;
 
@@ -187,7 +187,7 @@ int swissknife::CommandPeek::Main(const swissknife::ArgumentList &args) {
 }
 
 
-int swissknife::CommandRemove::Main(const ArgumentList &args) {
+int swissknife::CommandRemove::Run(const ArgumentList &args) {
   const string file_to_delete     = *args.find('o')->second;
   const string spooler_definition = *args.find('r')->second;
 
@@ -244,7 +244,7 @@ bool swissknife::CommandSync::ReadFileChunkingArgs(
 }
 
 
-int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandSync::Run(const swissknife::ArgumentList &args) {
   SyncParameters params;
 
   // Initialization

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -55,18 +55,14 @@ class CommandCreate : public Command {
     return "Bootstraps a fresh repository.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('o', "manifest output file", false, false));
-    result.push_back(Parameter('t', "directory for temporary storage",
-                               false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    result.push_back(Parameter('l', "log level (0-4, default: 2)",
-                               true, false));
-    result.push_back(Parameter('a', "hash algorithm (default: SHA-1)",
-                               true, false));
-    result.push_back(Parameter('v', "repository containing volatile files",
-                               true, true));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('o', "manifest output file"));
+    r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Optional ('l', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Optional ('a', "hash algorithm (default: SHA-1)"));
+    r.push_back(Parameter::Switch   ('v', "repository containing volatile files"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };
@@ -80,13 +76,12 @@ class CommandUpload : public Command {
     return "Uploads a local file to the repository.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('i', "local file", false, false));
-    result.push_back(Parameter('o', "destination path", false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    result.push_back(Parameter('a', "hash algorithm (default: SHA-1)",
-                               true, false));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('i', "local file"));
+    r.push_back(Parameter::Mandatory('o', "destination path"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Optional ('a', "hash algorithm (default: SHA-1)"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };
@@ -100,10 +95,10 @@ public:
     return "Checks whether a file exists in the repository.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('d', "destination path", false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('d', "destination path"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };
@@ -117,10 +112,10 @@ class CommandRemove : public Command {
     return "Removes a file in the repository storage.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('o', "path to file", false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('o', "path to file"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };
@@ -134,39 +129,28 @@ class CommandSync : public Command {
     return "Pushes changes from scratch area back to the repository.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('u', "union volume", false, false));
-    result.push_back(Parameter('s', "scratch directory", false, false));
-    result.push_back(Parameter('c', "r/o volume", false, false));
-    result.push_back(Parameter('t', "directory for temporary storage",
-                               false, false));
-    result.push_back(Parameter('b', "base hash", false, false));
-    result.push_back(Parameter('w', "stratum 0 base url", false, false));
-    result.push_back(Parameter('o', "manifest output file", false, false));
-    result.push_back(Parameter('r', "spooler definition", false, false));
-
-    result.push_back(Parameter('n', "create new repository", true, true));
-    result.push_back(Parameter('x', "print change set", true, true));
-    result.push_back(Parameter('y', "dry run", true, true));
-    result.push_back(Parameter('m', "create micro catalogs", true, true));
-    result.push_back(Parameter('i', "ignore x-directory hardlinks",
-                               true, true));
-    result.push_back(Parameter('d', "pause publishing to allow for catalog tweaks",
-                               true, true));
-    result.push_back(Parameter('z', "log level (0-4, default: 2)",
-                               true, false));
-
-    result.push_back(Parameter('p', "enable file chunking", true, true));
-    result.push_back(Parameter('a', "desired average chunk size in bytes", true,
-                               false));
-    result.push_back(Parameter('l', "minimal file chunk size in bytes", true,
-                               false));
-    result.push_back(Parameter('h', "maximal file chunk size in bytes", true,
-                               false));
-    result.push_back(Parameter('f', "union filesystem type", true, false));
-    result.push_back(Parameter('e', "hash algorithm (default: SHA-1)",
-                               true, false));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('u', "union volume"));
+    r.push_back(Parameter::Mandatory('s', "scratch directory"));
+    r.push_back(Parameter::Mandatory('c', "r/o volume"));
+    r.push_back(Parameter::Mandatory('t', "directory for tee"));
+    r.push_back(Parameter::Mandatory('b', "base hash"));
+    r.push_back(Parameter::Mandatory('w', "stratum 0 base url"));
+    r.push_back(Parameter::Mandatory('o', "manifest output file"));
+    r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Switch   ('n', "create new repository"));
+    r.push_back(Parameter::Switch   ('x', "print change set"));
+    r.push_back(Parameter::Switch   ('y', "dry run"));
+    r.push_back(Parameter::Switch   ('m', "create micro catalogs"));
+    r.push_back(Parameter::Switch   ('i', "ignore x-directory hardlinks"));
+    r.push_back(Parameter::Switch   ('p', "enable file chunking"));
+    r.push_back(Parameter::Optional ('z', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Optional ('a', "desired average chunk size in bytes"));
+    r.push_back(Parameter::Optional ('l', "minimal file chunk size in bytes"));
+    r.push_back(Parameter::Optional ('h', "maximal file chunk size in bytes"));
+    r.push_back(Parameter::Optional ('f', "union filesystem type"));
+    r.push_back(Parameter::Optional ('e', "hash algorithm (default: SHA-1)"));
+    return r;
   }
   int Main(const ArgumentList &args);
 

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -47,14 +47,15 @@ struct SyncParameters {
 
 namespace swissknife {
 
-class CommandCreate : public Command {
+class CommandCreate : public Command<CommandCreate> {
  public:
+  CommandCreate(const std::string &param) : Command(param) {}
   ~CommandCreate() { };
-  std::string GetName() { return "create"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "create"; };
+  static std::string GetDescription() {
     return "Bootstraps a fresh repository.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('o', "manifest output file"));
     r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
@@ -64,18 +65,19 @@ class CommandCreate : public Command {
     r.push_back(Parameter::Switch   ('v', "repository containing volatile files"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 
-class CommandUpload : public Command {
+class CommandUpload : public Command<CommandUpload> {
  public:
+  CommandUpload(const std::string &param) : Command(param) {}
   ~CommandUpload() { };
-  std::string GetName() { return "upload"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "upload"; };
+  static std::string GetDescription() {
     return "Uploads a local file to the repository.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('i', "local file"));
     r.push_back(Parameter::Mandatory('o', "destination path"));
@@ -83,52 +85,55 @@ class CommandUpload : public Command {
     r.push_back(Parameter::Optional ('a', "hash algorithm (default: SHA-1)"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 
-class CommandPeek : public Command {
+class CommandPeek : public Command<CommandPeek> {
 public:
+  CommandPeek(const std::string &param) : Command(param) {}
   ~CommandPeek() { };
-  std::string GetName() { return "peek"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "peek"; };
+  static std::string GetDescription() {
     return "Checks whether a file exists in the repository.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('d', "destination path"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 
-class CommandRemove : public Command {
+class CommandRemove : public Command<CommandRemove> {
  public:
+  CommandRemove(const std::string &param) : Command(param) {}
   ~CommandRemove() { };
-  std::string GetName() { return "remove"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "remove"; };
+  static std::string GetDescription() {
     return "Removes a file in the repository storage.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('o', "path to file"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 
-class CommandSync : public Command {
+class CommandSync : public Command<CommandSync> {
  public:
+  CommandSync(const std::string &param) : Command(param) {}
   ~CommandSync() { };
-  std::string GetName() { return "sync"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "sync"; };
+  static std::string GetDescription() {
     return "Pushes changes from scratch area back to the repository.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('u', "union volume"));
     r.push_back(Parameter::Mandatory('s', "scratch directory"));
@@ -152,7 +157,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Optional ('e', "hash algorithm (default: SHA-1)"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 
  protected:
   bool ReadFileChunkingArgs(const swissknife::ArgumentList &args,

--- a/cvmfs/swissknife_zpipe.cc
+++ b/cvmfs/swissknife_zpipe.cc
@@ -178,7 +178,7 @@ void zerr(int ret)
 }
 
 /* compress or decompress from stdin to stdout */
-int swissknife::CommandZpipe::Main(const swissknife::ArgumentList &args) {
+int swissknife::CommandZpipe::Run(const swissknife::ArgumentList &args) {
     int ret;
 
     /* avoid end-of-line conversions */

--- a/cvmfs/swissknife_zpipe.h
+++ b/cvmfs/swissknife_zpipe.h
@@ -18,9 +18,9 @@ class CommandZpipe : public Command {
       "Input comes on stdin, output goes to stdout.";
   };
   ParameterList GetParams() {
-    ParameterList result;
-    result.push_back(Parameter('d', "decompress file", true, true));
-    return result;
+    ParameterList r;
+    r.push_back(Parameter::Switch('d', "decompress file"));
+    return r;
   }
   int Main(const ArgumentList &args);
 };

--- a/cvmfs/swissknife_zpipe.h
+++ b/cvmfs/swissknife_zpipe.h
@@ -9,20 +9,21 @@
 
 namespace swissknife {
 
-class CommandZpipe : public Command {
+class CommandZpipe : public Command<CommandZpipe> {
  public:
+  CommandZpipe(const std::string &param) : Command(param) {}
   ~CommandZpipe() { };
-  std::string GetName() { return "zpipe"; };
-  std::string GetDescription() {
+  static std::string GetName() { return "zpipe"; };
+  static std::string GetDescription() {
     return "Compresses or decompresses a file using the DEFLATE algorithm.\n"
       "Input comes on stdin, output goes to stdout.";
   };
-  ParameterList GetParams() {
+  static ParameterList GetParameters() {
     ParameterList r;
     r.push_back(Parameter::Switch('d', "decompress file"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  int Run(const ArgumentList &args);
 };
 
 }


### PR DESCRIPTION
This prints a table of all possible error and warning messages that `cvmfs_swissknife scrub -m` might emit. It is printed for `cvmfs_swissknife scrub -h`, thus this Pull Request adds a *HelpSwitch* feature to the parameter handling of `cvmfs_swissknife`. A *HelpSwitch* can override any other mandatory parameter checking.

*Note:* This contains the (open) Pull Requests [here](https://github.com/cvmfs/cvmfs/pull/381) and [here](https://github.com/cvmfs/cvmfs/pull/382).