### PR TITLE
FIX: Race Condition in Test 534

### DIFF
--- a/test/src/534-interleavingpublishes/main
+++ b/test/src/534-interleavingpublishes/main
@@ -19,16 +19,24 @@ cvmfs_run_test() {
 
   echo "creating CVMFS snapshot (in the backgroud)"
   cvmfs_server publish $CVMFS_TEST_REPO &
-  local first_publish=$!
-  echo "PID: $first_publish"
+  local first_publish_pid=$!
+  echo "PID: $first_publish_pid"
 
   echo "try an (immediate) interleaving publish operation"
-  cvmfs_server publish $CVMFS_TEST_REPO
-  [ $? -ne 0 ] || return 2
+  cvmfs_server publish $CVMFS_TEST_REPO &
+  local second_publish_pid=$!
+  echo "PID: $second_publish_pid"
 
   echo "wait for the first publish process to successfully finish"
-  wait $first_publish
-  [ $? -eq 0 ] || return 3
+  wait $first_publish_pid
+  local first_publish_ret=$?
+  wait $second_publish_pid
+  local second_publish_ret=$?
+  if [ $first_publish_ret -eq 0 ]; then
+    [ $second_publish_ret -ne 0 ] || return 2
+  else
+    [ $second_publish_ret -eq 0 ] || return 3
+  fi
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?


### PR DESCRIPTION
This fixes a race in integration test 534. The test spawns two interleaving publish operations and expected the second one to fail due to an interleaving detection. This led to problems, since sometimes the second one was actually faster than the first one.
Now the test checks that either one fails and two succeeds or vice versa.
