### PR TITLE
FIX: Unreachable .cvmfswhitelist Kills `cvmfs_server list`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -911,7 +911,8 @@ check_expiry() {
 
   expiry=$(get_expiry $stratum0)
   if [ $? -ne 0 ]; then
-    die "Failed to retrieve repository expiry date"
+    echo "Failed to retrieve repository expiry date" >&2
+    return 1
   fi
 
   [ $expiry -ge 0 ]


### PR DESCRIPTION
The function `check_expiry()` in `cvmfs_server` called `die()` when the whitelist expiry check failed (i.e. the whitelist was not available). This is bad, since it truncates the output of `cvmfs_server list` for example. Now it only prints a message to **stderr** instead of interrupting the processing of the whole script.
