### PR TITLE
FIX: Ignore stderr on Bash Completion

### DIFF
--- a/cvmfs/bash_completion/cvmfs.bash_completion
+++ b/cvmfs/bash_completion/cvmfs.bash_completion
@@ -67,9 +67,9 @@ __hosted_repos() {
   local predicate="$1"
   local reply=
   if [ x"$predicate" != x"" ]; then
-    reply=$(cvmfs_server list | awk "$predicate")
+    reply=$(cvmfs_server list 2>/dev/null | awk "$predicate")
   else
-    reply=$(cvmfs_server list)
+    reply=$(cvmfs_server list 2>/dev/null)
   fi
   echo "$reply" | awk '{ print $1 }'
 }


### PR DESCRIPTION
When using the bash completion, we don't want to see the **stderr** output introduced in the Pull Request before...
