### PR TITLE
Workaround: Retry Failed Openstack Instances

### DIFF
--- a/test/cloud_testing/steering/instance_handler.py
+++ b/test/cloud_testing/steering/instance_handler.py
@@ -38,7 +38,31 @@ def connect_to_openstack(access_key, secret_key, endpoint):
   return connection
 
 
-def spawn_instance(connection, ami, key_name, flavor):
+def spawn_instance(connection, ami, key_name, flavor, max_retries = 5):
+  instance     = None
+  time_backoff = 20
+  retries      = 0
+
+  while not is_running(instance) and retries < max_retries:
+    instance = spawn_instance_on_openstack(connection, ami, key_name, flavor)
+    retries += 1
+    if not is_running(instance):
+      instance_id    = "unknown"
+      instance_state = "unknown"
+      if instance != None:
+        instance_id    = str(instance.id)
+        instance_state = str(instance.state)
+        kill_instance(connection, instance_id)
+      print_error("Failed spawning instance " + instance_id +
+                  " (#: " + str(retries) + " | state: " + instance_state + ")")
+      time.sleep(time_backoff)
+
+  if not is_running(instance):
+    return None
+  return instance
+
+
+def spawn_instance_on_openstack(connection, ami, key_name, flavor):
   try:
     reservation = connection.run_instances(ami,
                                            key_name=key_name,


### PR DESCRIPTION
This checks freshly spawned instances on OpenStack and retries to spawn them if they ended up in an error state. Additionally it adds a timeout to waiting for an instance to deal with endless pending instances.
