### PR TITLE
FIX: Bogus Output on Creation of Repo with Apache 2.4

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1143,7 +1143,7 @@ remove_apache_config_file() {
 
   # disable configuration on newer apache versions
   if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_NEW" ]; then
-    a2disconf $file_name > /dev/null || return 1
+    a2disconf $file_name > /dev/null 2>&1 || return 1
   fi
 
   # remove configuration file


### PR DESCRIPTION
When creating a repository `cvmfs_server` makes sure that there is no apache configuration related to repository to be created already. This check printed some misleading barf on the console.
