### PR TITLE
FIX: Coverity Alerts

### DIFF
--- a/cvmfs/file_processing/chunk_detector.h
+++ b/cvmfs/file_processing/chunk_detector.h
@@ -56,10 +56,7 @@ class ChunkDetector {
 class StaticOffsetDetector : public ChunkDetector {
  public:
   StaticOffsetDetector(const size_t static_chunk_size) :
-    chunk_size_(static_chunk_size)
-  {
-    assert (chunk_size_ >= 0u);
-  }
+    chunk_size_(static_chunk_size) {}
 
   bool MightFindChunks(const size_t size) const { return size > chunk_size_; }
 

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -186,6 +186,7 @@ class MockUploader : public upload::AbstractUploader {
               upload::CharBuffer          *buffer,
               const callback_t            *callback = NULL) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
+    assert (local_handle != NULL);
     local_handle->Append(buffer);
 
     Respond(callback, upload::UploaderResults(0, buffer));
@@ -195,6 +196,7 @@ class MockUploader : public upload::AbstractUploader {
                               const shash::Any            content_hash,
                               const std::string           hash_suffix) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
+    assert (local_handle != NULL);
 
     // summarize the results produced by the FileProcessor
     results_.push_back(Result(local_handle, content_hash, hash_suffix));

--- a/test/unittests/t_file_sandbox.cc
+++ b/test/unittests/t_file_sandbox.cc
@@ -64,7 +64,7 @@ TEST_F(T_FileSandbox, CreateRandomBufferMethod) {
   const uint64_t buffer_size = 10 * 1024 * 1024;
   char *buffer = (char*)malloc(buffer_size);
   ASSERT_NE (static_cast<char*>(NULL), buffer);
-  memset(buffer, buffer_size, 0);
+  memset(buffer, 0, buffer_size);
 
   // count number of zero-bytes in the random buffer as 'checksum'
   CreateRandomBuffer(buffer, buffer_size, rng);

--- a/test/unittests/t_local_uploader.cc
+++ b/test/unittests/t_local_uploader.cc
@@ -82,7 +82,8 @@ class T_LocalUploader : public FileSandbox {
 
  public:
   T_LocalUploader() :
-    FileSandbox(T_LocalUploader::sandbox_path) {}
+    FileSandbox(T_LocalUploader::sandbox_path),
+    uploader_(NULL) {}
 
  protected:
   virtual void SetUp() {


### PR DESCRIPTION
There was nothing particularly harmful. One thing was a mixed-up parameter order in `memset()` but this should also not be too severe.
