### PR TITLE
FIX: Test 539 Failed due to Permission Problems

### DIFF
--- a/test/src/539-symlinkedvarspoolcvmfs/main
+++ b/test/src/539-symlinkedvarspoolcvmfs/main
@@ -41,34 +41,34 @@ cvmfs_run_test() {
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || { desaster_cleanup; return 5; }
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || { desaster_cleanup; return 6; }
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   echo "check that repository spooler is redirected"
-  [ -f ${spool_dir_destination}/client.local ] || { desaster_cleanup; return 6; }
-  [ -d ${spool_dir_destination}/cache ]        || { desaster_cleanup; return 7; }
-  [ -d ${spool_dir_destination}/rdonly ]       || { desaster_cleanup; return 8; }
+  [ -f ${spool_dir_destination}/client.local ] || { desaster_cleanup; return 7; }
+  [ -d ${spool_dir_destination}/cache ]        || { desaster_cleanup; return 8; }
+  [ -d ${spool_dir_destination}/rdonly ]       || { desaster_cleanup; return 9; }
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   echo "starting transaction to edit repository"
-  start_transaction $CVMFS_TEST_REPO || { desaster_cleanup; return 9; } 
+  start_transaction $CVMFS_TEST_REPO || { desaster_cleanup; return 10; } 
 
   echo "putting some stuff in the new repository"
-  produce_files_in $repo_dir || { desaster_cleanup; return 10; }
+  produce_files_in $repo_dir || { desaster_cleanup; return 11; }
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || { desaster_cleanup; return 11; }
+  produce_files_in $reference_dir || { desaster_cleanup; return 12; }
 
   echo "creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO || { desaster_cleanup; return 12; }
+  publish_repo $CVMFS_TEST_REPO || { desaster_cleanup; return 13; }
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || { desaster_cleanup; return 13; }
+  compare_directories $repo_dir $reference_dir || { desaster_cleanup; return 14; }
 
   echo "check catalog and data integrity"
-  check_repository $CVMFS_TEST_REPO -i || { desaster_cleanup; return 14; }
+  check_repository $CVMFS_TEST_REPO -i || { desaster_cleanup; return 15; }
 
   echo "remove repository garbage"
   desaster_cleanup


### PR DESCRIPTION
The `cvmfs_suid_helper` binary reported an error, because it found `/var/spool/cvmfs/<fqrn>` to be owned by root instead of the repository owner. Saying: "called as 1001, repository owned by 0". In the fixed test case a symlink was created at this location using `sudo ln` and without a `chown` afterwards. Fixed.

However, I find the error message of `cvmfs_suid_helper` slightly misleading. Shouldn't it do a `platform_stat` instead of `platform_lstat` and don't care about the permission of this symlink? Or at least be more specific about what actually is wrong.
