### PR TITLE
FIX: Sorting Order of Multiple Kernels

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -18,7 +18,7 @@ echo "done"
 
 # custom kernel packages (figures out the newest installed kernel, downloads and
 #                         installs the associated patched aufs version of it)
-knl_version=$(yum list installed | grep -e '^kernel\.x86_64' | awk '{ print $2 }' | sort -r | head -n1)
+knl_version=$(rpm -qa --last | grep -e '^kernel-[0-9]' | head -n 1 | sed -e 's/^kernel-\(.*\)\.x86_64.*$/\1/')
 aufs_util_version="2.1-2"
 knl_firmware="https://ecsft.cern.ch/dist/cvmfs/kernel/${knl_version}/kernel-firmware-${knl_version}.aufs21.x86_64.rpm"
 knl="https://ecsft.cern.ch/dist/cvmfs/kernel/${knl_version}/kernel-${knl_version}.aufs21.x86_64.rpm"


### PR DESCRIPTION
When contextualizing SLC 6 x64, the script tried to install the wrong kernel version since the sorting of installed packages didn't properly work in the following case:

```
2.6.32-431.3.1.el6
2.6.32-431.11.2.el6
```

Now it is not sorted by version number anymore but by install date.
