### PR TITLE
FIX: Integration Test 550 Failed with Apache 2.4 (Ubuntu 13.10)

### DIFF
--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -85,10 +85,10 @@ create_apache_config_file $apache_config_file << EOF
 # Created by test case 550.  Don't touch.
 Alias /cvmfs/${legacy_repo_name} ${legacy_repo_storage}/pub/catalogs
 <Directory "${legacy_repo_storage}/pub/catalogs">
-  Options -MultiViews FollowSymLinks
+  Options -MultiViews +FollowSymLinks
   AllowOverride All
-  Order allow,deny
-  Allow from all
+  $(get_compatible_apache_allow_from_all_config)
+
   EnableMMAP Off
   EnableSendFile Off
   AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist

--- a/test/test_functions
+++ b/test/test_functions
@@ -761,6 +761,21 @@ get_apache_conf_path() {
 }
 
 
+# returns the apache configuration string for 'allow from all'
+# Note: this is necessary, since apache 2.4.x formulates that different
+#
+# @return   a configuration snippet to allow s'th from all hosts (stdout)
+get_compatible_apache_allow_from_all_config() {
+  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_NEW" ]; then
+    echo "Require all granted"
+  else
+    local nl='
+'
+    echo "Order allow,deny${nl}    Allow from all"
+  fi
+}
+
+
 # writes apache configuration file
 # This figures out where to put the apache configuration file depending
 # on the running apache version


### PR DESCRIPTION
This mainly fixes the apache configuration to work with both apache 2.2 and 2.4.
