### PR TITLE
Iteration 6: Partitioning and Formatting Additional Test Volumes on SLC5 x64

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -44,6 +44,11 @@ kobj=$(rpm -ql $(rpm -qa | grep kernel-module-aufs) | tail -n1)
 sudo /sbin/insmod $kobj || die "fail"
 echo "done"
 
+# allow httpd on backend storage
+echo -n "allowing httpd to access /srv/cvmfs..."
+sudo chcon --type httpd_sys_content_t /srv/cvmfs > /dev/null || die "fail"
+echo "done"
+
 # running unit test suite
 run_unittests --gtest_shuffle || ut_retval=$?
 


### PR DESCRIPTION
Reload aufs kernel module after reboot and set selinux context _httpd_sys_content_t_ for `/srv/cvmfs` after successful storage formatting and mounting.
