### PR TITLE
FIX: SELinux issue in integration tests 537, 538 on SLC6

### DIFF
--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -25,6 +25,7 @@ produce_files_in() {
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local selinux_disabled=0
 
   local scratch_dir=$(pwd)
   mkdir reference_dir
@@ -42,6 +43,12 @@ cvmfs_run_test() {
   fi
   mkdir $symlink_destination || return 2
   sudo ln --symbolic $symlink_destination $backend_dir || return 3
+
+  if has_selinux; then
+    echo "make sure that SELinux does not interfere"
+    sudo setsebool httpd_enable_homedirs true || return 6
+    selinux_disabled=1
+  fi
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -76,6 +83,13 @@ cvmfs_run_test() {
 
   echo "remove 'unusual' repository before successful test result"
   destroy_repo $CVMFS_TEST_REPO || return 5
+
+  # ============================================================================
+
+  if [ $selinux_disabled -ne 0 ]; then
+    echo "reverting SELinux config"
+    sudo setsebool httpd_enable_homedirs false || return 7
+  fi
 
   return 0
 }

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -22,6 +22,7 @@ desaster_cleanup() {
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local selinux_disabled=0
 
   local scratch_dir=$(pwd)
   mkdir reference_dir
@@ -65,6 +66,12 @@ cvmfs_run_test() {
   mkdir $symlink_destination || return 6
   sudo ln --symbolic $symlink_destination $backend_dir || return 7
 
+  if has_selinux; then
+    echo "make sure that SELinux does not interfere"
+    sudo setsebool httpd_enable_homedirs true || return 16
+    selinux_disabled=1
+  fi
+
   echo "create Stratum1 repository on the same machine"
   sudo cvmfs_server add-replica -o $CVMFS_TEST_USER -n $replica_name http://127.0.0.1/cvmfs/$CVMFS_TEST_REPO /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || { desaster_cleanup $mnt_point $replica_name; return 8; }
 
@@ -97,6 +104,11 @@ EOF
 
   echo "clean up"
   sudo cvmfs_server rmfs -f $replica_name
+
+  if [ $selinux_disabled -ne 0 ]; then
+    echo "reverting SELinux config"
+    sudo setsebool httpd_enable_homedirs false || return 17
+  fi
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -232,6 +232,10 @@ cvmfs_umount() {
 }
 
 
+has_selinux() {
+  [ -f /selinux/enforce ] && [ $(cat /selinux/enforce) -ne 0 ]
+}
+
 
 get_cvmfs_cachedir() {
   repository=$1


### PR DESCRIPTION
SELinux prevented apache to access the backend storage that was located in `/tmp/cvmfs-test/[...]/backend` in integration tests 537 and 538 on SLC6.
