### PR TITLE
FIX: Print errno in Error Message

### DIFF
--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -108,7 +108,7 @@ int LocalUploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
                                               0644);
   if (tmp_path.empty()) {
     LogCvmfs(kLogSpooler, kLogStderr, "Failed to create temp file for upload of "
-                                      "file chunk.");
+                                      "file chunk (errno: %d).", errno);
     atomic_inc32(&copy_errors_);
     return -1;
   }


### PR DESCRIPTION
There was a transient issue on SLC6 x64 from which I suspect that it is related to too many open file descriptors. However, the error message didn't contain an 'errno', so I cannot be sure... Next time...
