### PR TITLE
FIX: Shortstring<>::Append() didn't take any Shortstring

### DIFF
--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -68,8 +68,9 @@ class ShortString {
     Assign(other.GetChars(), other.GetLength());
   }
 
-  void Append(const ShortString &other) {
-    Append(other.stack_, other.length_);
+  template <class ShortStringT>
+  void Append(const ShortStringT &other) {
+    Append(other.GetChars(), other.GetLength());
   }
 
   void Append(const char *chars, const unsigned length) {


### PR DESCRIPTION
This allows the `Shortstring<>` template to `Append()` from any other incarnation of `Shortstring<>`. Additionally I believe the implementation was wrong, since it only appended from `other.stack_`.
