### PR TITLE
FIX: Catalog Defragmentation Likely to Break PRIMARY KEY Constraint

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -365,7 +365,9 @@ double Database::GetRowIdWasteRatio() const {
  * This creates a temporary table 'mapping' filled with the current rowIDs from
  * the catalog table. The new table will implicitly have an auto-increment rowID
  * that is compactized. Thus, we create a 'mapping' from each catalog's rowID
- * to a new rowID-space that does not have any gaps.
+ * to a new rowID-space that does not have any gaps. Notice, that the order of
+ * old and new rowIDs will stay the same to fulfill the PRIMARY KEY constraints
+ * during update.
  * Thereafter the catalog's rowIDs are mapped to their new (unique and compact)
  * rowIDs and the temporary table is deleted.
  *


### PR DESCRIPTION
This makes sure, that the ordering of rowIDs does not change during compaction. Otherwise it is likely to cause the violation of the rowID's PRIMARY KEY constraint during the update step.
