### PR TITLE
FIX: open() with O_CREAT Requires Mode to be Set

### DIFF
--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -397,7 +397,8 @@ bool swissknife::CommandApplyDirtab::CreateCatalogMarkers(
     }
 
     // create a nested catalog marker
-    const int fd = open(marker_path.c_str(), O_CREAT);
+    const mode_t mode = kDefaultFileMode;
+    const int fd = open(marker_path.c_str(), O_CREAT, mode);
     if (fd <= 0) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create nested catalog marker "
                                       "at '%s' (errno: %d)",


### PR DESCRIPTION
POSIX required that there is a `mode` provided for `open()` with `O_CREAT`. If not, Ubuntu seems to set a sane default for `mode`, but f.e. the compiler of Fedora complains.
