### PR TITLE
FIX: cvmfs_server import Fails Gracefully 

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1408,7 +1408,8 @@ create_spool_area_for_new_repository() {
 remove_spool_area() {
   local name=$1
   load_repo_config $name
-  rm -fR $CVMFS_SPOOL_DIR
+  [ x"$CVMFS_SPOOL_DIR" != x"" ] || return 0
+  rm -fR "$CVMFS_SPOOL_DIR"
 }
 
 


### PR DESCRIPTION
This factors out some functionality of `cvmfs_server rmfs` and reuses it as crash-cleanup for `cvmfs_server import`.
