### PR TITLE
FIX: Migration Statistics Didn't Show

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1961,7 +1961,7 @@ import() {
 
   # parameter handling
   OPTIND=1
-  while getopts "w:o:c:u:k:l:smg" option; do
+  while getopts "w:o:c:u:k:lsmg" option; do
     case $option in
       w)
         stratum0=$OPTARG
@@ -1980,7 +1980,7 @@ import() {
       ;;
       l)
         is_legacy=1
-        ;;
+      ;;
       s)
         show_statistics=1
       ;;


### PR DESCRIPTION
I specified a command line switch to be a parameter. This basically 'ate' the following switch.
