### PR TITLE
FIX: Reliability of Integration Test 554

### DIFF
--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -18,62 +18,137 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   echo "start transactions to create huge root catalog (in steps)"
+  # we create a repository in small steps in order to have control over the
+  # row IDs assigned to the entries in the different directories.
+  # while creating the repository row IDs will increase...
   start_transaction $CVMFS_TEST_REPO || return $?
 
   echo "create a synthetically huge root catalog"
   mkdir ${repo_dir}/foo || return 1
-  mkdir ${repo_dir}/bar || return 2
-  mkdir ${repo_dir}/baz || return 3
-  mkdir ${repo_dir}/mop || return 4
-  mkdir ${repo_dir}/pom || return 5
+  mkdir ${repo_dir}/bar || return 1
+  mkdir ${repo_dir}/baz || return 1
+  mkdir ${repo_dir}/mop || return 1
+  mkdir ${repo_dir}/pom || return 1
+  mkdir ${repo_dir}/lol || return 1
+  mkdir ${repo_dir}/wtf || return 1
+  mkdir ${repo_dir}/brb || return 1
 
   echo "publish directory structure first"
-  publish_repo $CVMFS_TEST_REPO > /dev/null || return 6
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 7
+
+  # in each of the publishing steps the same amount of row IDs is created in
+  # each of the six directories. Thus, afterwards each directory will make up
+  # approximately one sixths (16%) of overall row ID count in the catalog
 
   echo "second transaction"
-  start_transaction $CVMFS_TEST_REPO        || return 7
-  cp /bin/* ${repo_dir}/foo                 || return 8
-  publish_repo $CVMFS_TEST_REPO > /dev/null || return 9
+  start_transaction $CVMFS_TEST_REPO        || return 8
+  cp /bin/* ${repo_dir}/foo                 || return 9
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 10
 
   echo "third transaction"
-  start_transaction $CVMFS_TEST_REPO        || return 10
-  cp /bin/* ${repo_dir}/bar                 || return 11
-  publish_repo $CVMFS_TEST_REPO > /dev/null || return 12
+  start_transaction $CVMFS_TEST_REPO        || return 11
+  cp /bin/* ${repo_dir}/bar                 || return 12
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 13
 
   echo "fourth transaction"
-  start_transaction $CVMFS_TEST_REPO        || return 13
-  cp /bin/* ${repo_dir}/baz                 || return 14
-  publish_repo $CVMFS_TEST_REPO > /dev/null || return 15
+  start_transaction $CVMFS_TEST_REPO        || return 14
+  cp /bin/* ${repo_dir}/baz                 || return 15
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 16
+
+  echo "fifth transaction"
+  start_transaction $CVMFS_TEST_REPO        || return 17
+  cp /bin/* ${repo_dir}/mop                 || return 18
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 19
+
+  echo "sixth transaction"
+  start_transaction $CVMFS_TEST_REPO        || return 20
+  cp /bin/* ${repo_dir}/pom                 || return 21
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 22
+
+  echo "seventh transaction"
+  start_transaction $CVMFS_TEST_REPO        || return 23
+  cp /bin/* ${repo_dir}/lol                 || return 24
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 25
+
+  # create one last file which is guaranteed to get the highest row ID in the
+  # whole catalog
+
+  echo "eighth transaction"
+  start_transaction $CVMFS_TEST_REPO        || return 26
+  touch ${repo_dir}/biggest_row_id_sentinel || return 27
+  publish_repo $CVMFS_TEST_REPO > /dev/null || return 28
 
   echo "find the file size of the root catalog"
   local initial_root_size=$(get_catalog_file_size $CVMFS_TEST_REPO '/')
   echo "Catalog Size: $initial_root_size"
 
-  echo "start next transaction to edit root catalog"
-  start_transaction $CVMFS_TEST_REPO || return 16
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  echo "remove files from /bar and /foo and add files to /mop"
-  cp /bin/* ${repo_dir}/mop || return 17
-  cp /bin/* ${repo_dir}/pom || return 18
-  rm -fR ${repo_dir}/bar    || return 19
-  rm -fR ${repo_dir}/foo    || return 20
+  # now we are going to remove some of the files from the catalog.
+  # Note: we are staying below the thresholds of both free pages and wasted row
+  #       IDs, thus not causing a catalog defragmentation
 
-  echo "publish repository (should trigger root catalog defragmatation)"
+  echo "start next transaction to remove files from /bar"
+  start_transaction $CVMFS_TEST_REPO || return 29
+  rm -fR ${repo_dir}/bar             || return 30
+
+  echo "publish (shouldn't trigger defrag)"
   local publish_log_1=publish_1.log
-  publish_repo $CVMFS_TEST_REPO > $publish_log_1 || return 21
-  cat $publish_log_1 | grep -e '/ gets defragmented.*wasted row' || return 22
+  publish_repo $CVMFS_TEST_REPO > $publish_log_1       || return 31
+  cat $publish_log_1 | grep -e '/ gets defragmented.*' && return 32
+
+  # we are recreating some files in /wtf to further increase the maximal row ID
+  # and to re-fill the free pages in the catalog
+  # Note: The files removed in the previous transaction created a hole in the
+  #       continuous row ID space of the catalog that was below the wasted row
+  #       ID threshold.
+
+  echo "start next transaction to create some files in /wtf"
+  start_transaction $CVMFS_TEST_REPO || return 33
+  cp /bin/* ${repo_dir}/wtf          || return 34
+
+  echo "publish (shouldn't trigger defrag either)"
+  local publish_log_2=publish_2.log
+  publish_repo $CVMFS_TEST_REPO > $publish_log_2       || return 35
+  cat $publish_log_2 | grep -e '/ gets defragmented.*' && return 36
+
+  # now an additional delete of /foo should tear a second hole into the row ID
+  # space of the catalog (now exceeding the wasted row ID threshold)
+  # Note: Since we re-filled the empty pages of the catalog before, the free
+  #       page threshold should not be exceeded.
+
+  echo "start next transaction to remove files in /foo"
+  start_transaction $CVMFS_TEST_REPO || return 37
+  rm -fR ${repo_dir}/foo             || return 38
+
+  echo "publish repository (should trigger root catalog defragmentation)"
+  local publish_log_3=publish_3.log
+  publish_repo $CVMFS_TEST_REPO > $publish_log_3                 || return 39
+  cat $publish_log_3 | grep -e '/ gets defragmented.*wasted row' || return 40
+
+  # finally we fill up the previously freed pages again, to bring the overall
+  # catalog file size back to approximately the initial file size
+
+  echo "start next transaction to create some files in /brb"
+  start_transaction $CVMFS_TEST_REPO || return 41
+  cp /bin/* ${repo_dir}/brb          || return 42
+
+  echo "publish (shouldn't trigger defrag again)"
+  local publish_log_4=publish_4.log
+  publish_repo $CVMFS_TEST_REPO > $publish_log_4       || return 43
+  cat $publish_log_4 | grep -e '/ gets defragmented.*' && return 44
 
   echo "check if root catalog is approximately the same size than before"
   local second_root_size=$(get_catalog_file_size $CVMFS_TEST_REPO '/')
   local absdiff=$(( $second_root_size - $initial_root_size ))
   echo "Catalog Size: $second_root_size"
-  [ $absdiff -lt 10240 ] || [ $absdiff -gt -10240 ] || return 23
+  [ $absdiff -lt 10240 ] || [ $absdiff -gt -10240 ] || return 45
 
   echo "create a last transaction to check if defrag info is gone"
-  start_transaction $CVMFS_TEST_REPO || return 24
-  local publish_log_2=publish_2.log
-  publish_repo $CVMFS_TEST_REPO > $publish_log_2 || return 25
-  cat $publish_log_2 | grep -e '/ gets defragmented.*wasted row' && return 26
+  start_transaction $CVMFS_TEST_REPO                   || return 46
+  local publish_log_5=publish_5.log
+  publish_repo $CVMFS_TEST_REPO > $publish_log_5       || return 47
+  cat $publish_log_5 | grep -e '/ gets defragmented.*' && return 48
 
   return 0
 }


### PR DESCRIPTION
Test case 554 was dependent on the order of the file system traversal. However this is platform dependent and caused problems on SLC.
