### PR TITLE
FIX: Source test_functions Into Cloud Test Steering

### DIFF
--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -2,6 +2,9 @@
 
 export LC_ALL=C
 
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/../../test_functions
+
 # splits onelined CSV strings and prints the desired field offset
 #
 # @param cvs     the CSV string to be cut


### PR DESCRIPTION
Turns out that I rely on `run_background_service()` for spawning of FakeS3 but didn't source `test_functions`, which contains this function, in the cloud test steering scripts.
