### PR TITLE
FIX: Startup of FakeS3

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -47,8 +47,8 @@ cd ${SOURCE_DIRECTORY}/test
                           src/524-corruptmanifestfailover || it_retval=$?
 
 echo -n "starting FakeS3 service... "
-fakes3_pid=$(start_fakes3 $TEST_FAKE_S3_LOGFILE) || { s3_retval=$?; die "fail"; }
-echo "done"
+fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=$?; die "fail"; }
+echo "done ($fakes3_pid)"
 
 if [ $s3_retval -eq 0 ]; then
     echo "running CernVM-FS server test cases against FakeS3..."


### PR DESCRIPTION
Startup of Fake S3 didn't work in the SLC6 x64 cloud test because of a misplaced variable name. Next try...
