### PR TITLE
FIX: Compile Error due to Dependent Base Class Lookup Failure

### DIFF
--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -237,11 +237,11 @@ class CatalogTraversal : public Observable<CatalogTraversalData<CatalogT> > {
     }
 
     // Provide the user with the catalog
-    NotifyListeners(CallbackData(catalog,
-                                 job.hash,
-                                 job.tree_level,
-                                 file_size,
-                                 job.history_depth));
+    this->NotifyListeners(CallbackData(catalog,
+                                       job.hash,
+                                       job.tree_level,
+                                       file_size,
+                                       job.history_depth));
 
     // Inception! Go deeper into the catalog tree
     PushReferencedCatalogs(catalog, job);


### PR DESCRIPTION
This fixes a compile error due to a lookup error of a method in a template argument dependent base class. One of the more subtile things of C++ apparently. See this [StackOverflow entry](http://stackoverflow.com/questions/10639053/name-lookups-in-c-templates) for details.

TL;DR: `NotifyListeners()` is a member of the `Observable<>` template, which is dependant on the template parameter of `CatalogTraversal<T>` and thus cannot be inferred by the compiler without knowing the `T`.
