### PR TITLE
FIX: Add Changelog Entry for Debian

### DIFF
--- a/packaging/debian/keys/changelog
+++ b/packaging/debian/keys/changelog
@@ -1,3 +1,10 @@
+cvmfs-keys (1.5-1) lucid; urgency=low
+
+  * Add egi and osg keys and config.  Add automated server ordering to
+    egi and osg config.
+
+ -- Dave Dykstra <dwd@fnal.gov>  Thu, 2 Jul 2014 12:00:00 +0000
+
 cvmfs-keys (1.4-1) lucid; urgency=low
 
   * Initial release.


### PR DESCRIPTION
This bumps the version number and adds a changelog entry for cvmfs-keys.deb, following the changes contributed by @DrDaveD.
