### PR TITLE
FIX: Compile Error on SLC5

### DIFF
--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -103,7 +103,7 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
 
  public:
   FP_MockUploader(const upload::SpoolerDefinition &spooler_definition) :
-    AbstractMockUploader(spooler_definition) {}
+    AbstractMockUploader<FP_MockUploader>(spooler_definition) {}
 
   const Results& results() const { return results_; }
 

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -39,7 +39,7 @@ int UF_MockStreamHandle::instances = 0;
 class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
  public:
   UF_MockUploader(const SpoolerDefinition &spooler_definition) :
-    AbstractMockUploader(spooler_definition),
+    AbstractMockUploader<UF_MockUploader>(spooler_definition),
     initialize_called(false) {}
 
   upload::UploadStreamHandle* InitStreamedUpload(


### PR DESCRIPTION
SLC5's compiler does need the template parameter for c'tor up-calls.
