### PR TITLE
Change RAL machine name from cernvmfs to cvmfs-egi in opensciencegrid.org.conf

### DIFF
--- a/mount/domain.d/opensciencegrid.org.conf
+++ b/mount/domain.d/opensciencegrid.org.conf
@@ -1,6 +1,6 @@
 # Don't edit here.  Create /etc/cvmfs/domain.d/opensciencegrid.org.local
 # As a rule of thumb, overwrite only parameters you find in here.
 
-CVMFS_SERVER_URL="${CVMFS_SERVER_URL:-`. /etc/cvmfs/serverorder.sh;orderservers oasis.opensciencegrid.org cernvmfs.gridpp.rl.ac.uk:8000 klei.nikhef.nl:8000 cvmfs-s1bnl.opensciencegrid.org:8000 cvmfs-s1fnal.opensciencegrid.org:8000 cvmfsrep.grid.sinica.edu.tw:8000`}"
+CVMFS_SERVER_URL="${CVMFS_SERVER_URL:-`. /etc/cvmfs/serverorder.sh;orderservers oasis.opensciencegrid.org cvmfs-egi.gridpp.rl.ac.uk:8000 klei.nikhef.nl:8000 cvmfs-s1bnl.opensciencegrid.org:8000 cvmfs-s1fnal.opensciencegrid.org:8000 cvmfsrep.grid.sinica.edu.tw:8000`}"
 
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/opensciencegrid.org.pub


### PR DESCRIPTION
Sorry, I made a mistake in the opensciencegrid.org.conf config and forgot to change it to cmvfs-egi when I changed egi.eu.conf.
