### PR TITLE
Remove the %{?dist} from the cvmfs-keys rpm Release

### DIFF
--- a/packaging/rpm/cvmfs-keys.spec
+++ b/packaging/rpm/cvmfs-keys.spec
@@ -1,7 +1,7 @@
 Summary: CernVM File System Public Keys and Configs
 Name: cvmfs-keys
 Version: 1.5
-Release: 1%{?dist}
+Release: 1
 Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
 Requires: curl


### PR DESCRIPTION
This will remove the .el5 from the built package name
