### PR TITLE
FIX: Get GeoIP.so out of *.egg directory

### DIFF
--- a/externals/python-geoip/src/makeHook.sh
+++ b/externals/python-geoip/src/makeHook.sh
@@ -12,5 +12,9 @@ if [ -f .tmp/*.egg ]; then
     # older python versions like 2.4 install a .egg; extract GeoIP.so
     (cd .tmp; unzip -o *.egg GeoIP.so)
 fi
+if [ -d .tmp/*.egg ]; then
+	# for some reason SLC6 produces an uncompressed *.egg directory containing GeoIP.so
+	cp .tmp/*.egg/GeoIP.so .tmp
+fi
 cp .tmp/GeoIP.so dist
 rm -rf .tmp


### PR DESCRIPTION
For some reason the build on SLC6 failed, because the `python-geoip` build procedure didn't treat the build results correctly. This hopefully fixes it.

Note: I need to merge into devel first, in order to field-test it.

@DrDaveD: Do you see a reason, why this fix is necessary to make it work on SLC6?
