### PR TITLE
TEST: Pre-test Installation of mod_wsgi

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -41,6 +41,10 @@ install_rpm $CLIENT_PACKAGE
 install_rpm $SERVER_PACKAGE
 install_rpm $UNITTEST_PACKAGE
 
+# installing WSGI apache module
+echo "installing python WSGI module..."
+install_from_repo mod_wsgi || die "fail (installing mod_wsgi)"
+
 # setup environment
 echo -n "setting up CernVM-FS environment... "
 sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -52,6 +52,11 @@ install_rpm $CLIENT_PACKAGE
 install_rpm $SERVER_PACKAGE
 install_rpm $UNITTEST_PACKAGE
 
+# installing WSGI apache module
+echo "installing python WSGI module..."
+install_from_repo mod_wsgi || die "fail (installing mod_wsgi)"
+sudo service httpd restart || die "fail (restarting apache)"
+
 # setup environment
 echo -n "setting up CernVM-FS environment..."
 sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"

--- a/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
@@ -39,6 +39,11 @@ install_deb $CLIENT_PACKAGE
 install_deb $SERVER_PACKAGE
 install_deb $UNITTEST_PACKAGE
 
+# installing WSGI apache module
+echo "installing python WSGI module..."
+install_from_repo libapache2-mod-wsgi    || die "fail (installing libapache2-mod-wsgi)"
+sudo service apache2 restart > /dev/null || die "fail (restarting apache)"
+
 # setup environment
 echo -n "setting up CernVM-FS environment... "
 sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"


### PR DESCRIPTION
For some of the cloud tests `mod_wsgi` needs to be installed before running the actual test suite. This updates the cloud test contextualisation scripts for the corresponding platforms.
