### PR TITLE
FIX: python-geoip External was Constantly Rebuilt

### DIFF
--- a/externals/python-geoip/src/CVMFS-CMakeLists.txt
+++ b/externals/python-geoip/src/CVMFS-CMakeLists.txt
@@ -1,5 +1,5 @@
 include ("${EXTERNALS_LIB_LOCATION}/CMake-Register_External_Lib.txt")
 
-set (PYTHON_GEOIP_LIB "${GEOIP_PY_BUILTIN_LOCATION}/dist/GeoIP.so")
+set (PYTHON_GEOIP_LIB "${PYTHON_GEOIP_BUILTIN_LOCATION}/dist/GeoIP.so")
 
 register_external_lib (python-geoip ${PYTHON_GEOIP_BUILTIN_LOCATION} ${PYTHON_GEOIP_LIB})


### PR DESCRIPTION
Due to a wrongly named variable in the build system the external **python-geoip** was rebuilt for each run of `make`. 
