### PR TITLE
Allow underscore and tilde to be in cvmfs-info without url escape

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -67,6 +67,7 @@ static inline bool EscapeUrlChar(char input, char output[3]) {
       ((input >= 'a') && (input <= 'z')) ||
       (input == '/') || (input == ':') || (input == '.') ||
       (input == '+') || (input == '-') ||
+      (input == '_') || (input == '~') ||
       (input == '[') || (input == ']'))
   {
     output[0] = input;


### PR DESCRIPTION
Underscore and tilde are included in URI unreserved characters (see http://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters) and they're the only two of that set that were being escaped.
