### PR TITLE
FIX: CVMFS_KEYS_DIR Cannot be Unset

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1870,7 +1870,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
     dns_server = parameter;
   if (options::GetValue("CVMFS_TRUSTED_CERTS", &parameter))
     trusted_certs = parameter;
-  if (options::GetValue("CVMFS_KEYS_DIR", &parameter)) {
+  if (options::GetValue("CVMFS_KEYS_DIR", &parameter) && ! parameter.empty()) {
     // Collect .pub files from CVMFS_KEYS_DIR
     public_keys = JoinStrings(FindFiles(parameter, ".pub"), ":");
   } else if (options::GetValue("CVMFS_PUBLIC_KEY", &parameter)) {


### PR DESCRIPTION
@DrDaveD pointed out, that there is no way to use the config variable `CVMFS_PUBLIC_KEY` since it is always overwritten by `CVMFS_KEYS_DIR` which cannot be unset. This also checks for an empty `CVMFS_KEYS_DIR` and ignores it in favour of `CVMFS_PUBLIC_KEY`.
