### PR TITLE
FIX: ci/makedist.sh Reads issnapshot 

### DIFF
--- a/ci/makedist.sh
+++ b/ci/makedist.sh
@@ -10,7 +10,7 @@ issnapshot=$3
 mkdir -p $distdir
 cd $gitdir
 treeish=`git show master | head -n1 | cut -d" " -f2 | head -c16`
-if [ $issnapshot -eq 1 ]; then
+if [ x"$issnapshot" = x"true" ] || [ x"$issnapshot" = x"1" ]; then
   version="git-$treeish"  
 else
   version=`grep CVMFS_VERSION CMakeLists.txt | cut -d" " -f3`


### PR DESCRIPTION
This fixes a script run by the continuous integration system to create the base tarball. This will hopefully fix the nightly build creation after I generalised it a bit...
