### PR TITLE
FIX: Extra Partition Setup on SLC5 x64

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -46,7 +46,8 @@ echo "done"
 
 # allow httpd on backend storage
 echo -n "allowing httpd to access /srv/cvmfs... "
-sudo chcon --type httpd_sys_content_t /srv/cvmfs > /dev/null || die "fail"
+sudo mkdir /srv/cvmfs                                        || die "fail (mkdir)"
+sudo chcon --type httpd_sys_content_t /srv/cvmfs > /dev/null || die "fail (chcon)"
 echo "done"
 
 # create the server's client cache directory in /srv (AUFS kernel deadlock workaround)


### PR DESCRIPTION
The SLC5 x64 cloud testing setup script didn't correctly handle the freshly mounted volume on `/srv` after the mount point was changed from `/srv/cvmfs` to re-use this as the extra partition for the client cache. (AUFS kernel deadlock) 
