### PR TITLE
New feature: files already in S3 are not reuploaded

### DIFF
--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -373,8 +373,7 @@ bool S3Uploader::UploadFile(const std::string &filename,
                             char              *buff,
                             unsigned long     size_of_file,
                             const callback_t  *callback,
-                            MemoryMappedFile  *mmf)
-{
+                            MemoryMappedFile  *mmf) {
   // Choose S3 account and bucket based on the filename
   std::string access_key, secret_key, bucket_name;
   const std::string mangled_filename = repository_alias_ + "/" + filename;
@@ -387,6 +386,7 @@ bool S3Uploader::UploadFile(const std::string &filename,
                                                   mangled_filename,
                                                   (unsigned char*)buff,
                                                   size_of_file);
+
   info->request        = s3fanout::JobInfo::kReqPut;
 #ifndef S3_UPLOAD_OBJECTS_EVEN_IF_THEY_EXIST
   if (filename.substr(0, 1) != ".") {

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -388,6 +388,11 @@ bool S3Uploader::UploadFile(const std::string &filename,
                                                   (unsigned char*)buff,
                                                   size_of_file);
   info->request        = s3fanout::JobInfo::kReqPut;
+#ifndef S3_UPLOAD_OBJECTS_EVEN_IF_THEY_EXIST
+  if (filename.substr(0, 1) != ".") {
+    info->request        = s3fanout::JobInfo::kReqHead;
+  }
+#endif
   info->origin_mem.pos = 0;
   info->callback       = const_cast<void*>(static_cast<void const*>(callback));
   info->mmf            = mmf;


### PR DESCRIPTION
Default behaviour is now that HEAD request is first done to all data files before possible PUT request. PUT request is done only if the file did not exist. This should speedup the upload process in case there is lots of duplicate files.