### PR TITLE
FIX: Trap Specification in Test Case 024

### DIFF
--- a/test/src/024-reload-during-asetup/main
+++ b/test/src/024-reload-during-asetup/main
@@ -59,7 +59,7 @@ cvmfs_run_test() {
   reload_pid=$!
 
   # always kill the detached processes
-  trap "kill -9 $(cat $pidsfile | tr '\n' " ") $reload_pid > /dev/null 2>&1; rm -f $pidsfile; exit" SIGHUP SIGINT SIGTERM
+  trap "kill -9 $(cat $pidsfile | tr '\n' " ") $reload_pid > /dev/null 2>&1; rm -f $pidsfile; exit" HUP INT TERM
 
   # wait for the find calls to succeed
   wait $(cat $pidsfile | tr '\n' " ")


### PR DESCRIPTION
Dash wants to have `HUP`, `TERM`, ... instead of `SIGHUP` and so on...
