### PR TITLE
FIX: Sensitivity of `cvmfs_umount()` in test_functions

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -222,7 +222,7 @@ cvmfs_umount() {
     sudo umount /cvmfs/$r || return 100
 
     timeout=5
-    while cat /proc/mounts | grep -q /cvmfs/$r; do
+    while cat /proc/mounts | grep -q " /cvmfs/$r "; do
       if [ $timeout -eq 0 ]; then
         return 101
       fi


### PR DESCRIPTION
The helper function `cvmfs_umount()` was too sensitive when cross-checking a successful unmount in `/proc/mounts`. This lead to failing tests when `cvmfs_umount atlas.cern.ch` was called while there was a file system mounted on `/srv/cvmfs/atlas.cern.ch/cache` for example. Fixed.
