### PR TITLE
FIX: SELinux Context not set Properly in SLC5 x64 Test Setup

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -46,8 +46,8 @@ echo "done"
 
 # allow httpd on backend storage
 echo -n "allowing httpd to access /srv/cvmfs... "
-sudo mkdir /srv/cvmfs                                        || die "fail (mkdir)"
-sudo chcon --type httpd_sys_content_t /srv/cvmfs > /dev/null || die "fail (chcon)"
+sudo mkdir /srv/cvmfs                                      || die "fail (mkdir)"
+sudo chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail (chcon)"
 echo "done"
 
 # create the server's client cache directory in /srv (AUFS kernel deadlock workaround)


### PR DESCRIPTION
[eom]
