### PR TITLE
Jenkins: Scripts for Building with Jenkins

### DIFF
--- a/ci/jenkins/README
+++ b/ci/jenkins/README
@@ -1,0 +1,27 @@
+Jenkins Continuous Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Scripts in this directory are supposed to be called from Jenkins. The idea is to
+put all build scripts under version control while Jenkins does not contain any
+knowledge on how to build the packages.
+These scripts, rely on environment variables set by Jenkins to control them.
+
+Here is a list:
+$BUILD_NUMBER    - a running number Jenkins increments for each build
+$PACKAGE_TYPE    - which package should be built
+                   Note: this is set as an environment variable in the
+                         configuration of the individual build machines
+                         of Jenkins.
+$BUILD_TYPE      - what is going to be built?
+                      release:      a releasable version of the packages
+                      nightly:      a nightly snapshot of the packages
+                      incremental:  an incremental version (not published)
+
+Script to be called by Jenkins are:
+build.sh       - build CVMFS's packages in a certain scenario (see $BUILD_TYPE)
+install.sh     - installs just built packages on the build machines to
+                 test if they are sane
+quick_test.sh  - run some tests on the build (i.e. the unit test suite)
+publish.sh     - publish the built packages
+cleanup.sh     - remove left-overs from the build node to prepare it for
+                 the next build run

--- a/ci/jenkins/build.sh
+++ b/ci/jenkins/build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -e
+
+set -e
+
+echo "Continuous Integration Build Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+# figure out some information about the version to be built
+archive_dir="$(pwd)/source_archive"
+
+# files and directories we want to have in the archive
+tarball_git_files="AUTHORS CMakeLists.txt COPYING CPackLists.txt  ChangeLog FAQ INSTALL NEWS README InstallerResources add-ons bootstrap.sh cmake config_cmake.h.in cvmfs doc externals keys mount test"
+tarball_file_prefix="$CVMFS_BUILD_TAG/"
+tarball=${archive_dir}/${CVMFS_BUILD_TAG}.tar.gz
+
+echo -n "Creating Source Tarball... "
+mkdir -p $archive_dir
+git archive --prefix=$tarball_file_prefix \
+            --format=tar                  \
+            $CVMFS_COMMIT                 \
+            $tarball_git_files | gzip -c > $tarball
+echo "done"
+
+echo "Building Packages"
+case $PACKAGE_TYPE in
+  rpm)
+    sh ci/jenkins/build_rpm.sh "$tarball"
+    ;;
+  deb)
+    sh ci/jenkins/build_deb.sh "$tarball"
+    ;;
+  *)
+    echo "unknown package type '$PACKAGE_TYPE'"
+    exit 1
+esac

--- a/ci/jenkins/build_deb.sh
+++ b/ci/jenkins/build_deb.sh
@@ -1,0 +1,54 @@
+#!/bin/sh -e
+
+set -e
+
+echo "Continuous Integration DEB Build Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+if [ $# -ne 1 ]; then
+  echo "USAGE: $0 <source tarball>"
+  exit 1
+fi
+
+# collect information about the package to be built
+source_tarball="$1"
+
+upstream_version="???"
+case $BUILD_TYPE in
+  nightly|incremental)
+    upstream_version="${CVMFS_VERSION}.${BUILD_NUMBER}${CVMFS_SNAPSHOT_VERSION}"
+    ;;
+  release)
+    upstream_version="$CVMFS_VERSION"
+    ;;
+  *)
+    echo "FAIL: unknown build type '$BUILD_TYPE'"
+    echo 1
+    ;;
+esac
+
+# create build environment
+git_dir="$(pwd)"
+build_dir="$(pwd)/${CVMFS_BUILD_DIR}"
+results_dir="$(pwd)/${CVMFS_BUILD_RESULTS}"
+mkdir -p $build_dir $results_dir
+
+# extract source tarball (for original source tree)
+cd $build_dir
+cp $source_tarball .
+tar xzf $(basename $source_tarball)
+mv ${CVMFS_BUILD_TAG} cvmfs_${upstream_version}.orig
+
+# extract source tarball (for build tree)
+tar xzf $(basename $source_tarball)
+cd ${CVMFS_BUILD_TAG}
+
+# prepare the source tarball for packaging
+cp -Rv $git_dir/packaging/debian/cvmfs ./debian
+dch -v $upstream_version -M "bumped upstream version number"
+cd debian
+
+# build the packages
+pdebuild --buildresult $results_dir

--- a/ci/jenkins/build_rpm.sh
+++ b/ci/jenkins/build_rpm.sh
@@ -1,0 +1,68 @@
+#!/bin/sh -e
+
+set -e
+
+echo "Continuous Integration RPM Build Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+if [ $# -ne 1 ]; then
+  echo "USAGE: $0 <source tarball>"
+  exit 1
+fi
+
+# collect information about the package to be built
+source_tarball="$1"
+git_dir="$(pwd)"
+build_dir="$(pwd)/${CVMFS_BUILD_DIR}"
+results_dir="$(pwd)/${CVMFS_BUILD_RESULTS}"
+prerelease=0 # TODO: needs some sense!
+
+# create build environments
+mkdir -p ${build_dir}/BUILD
+mkdir -p ${build_dir}/RPMS
+mkdir -p ${build_dir}/SOURCES
+mkdir -p ${build_dir}/SRPMS
+mkdir -p ${build_dir}/TMP
+mkdir -p $results_dir
+
+# prepare build environment
+cd $build_dir
+cp ${git_dir}/packaging/rpm/cvmfs-universal.spec .
+cp ${git_dir}/packaging/rpm/cvmfs.te             ./SOURCES
+cp $source_tarball                               ./SOURCES
+
+# configure spec file (if necessary)
+case $BUILD_TYPE in
+  nightly|incremental)
+    version_num="$(echo $CVMFS_SNAPSHOT_VERSION | sed 's/^git-//g')"
+    sed -i -e "s/^Release: .*/Release: 0.${prerelease}.${version_num}git%{?dist}/" cvmfs-universal.spec
+    sed -i -e "s/\(^Source0: .*\)%{version}/\1$CVMFS_SNAPSHOT_VERSION/"                    cvmfs-universal.spec
+    sed -i -e "s/^%setup -q/%setup -q -n cvmfs-$CVMFS_SNAPSHOT_VERSION/"                   cvmfs-universal.spec
+    ;;
+  release)
+    echo "Building a release!"
+    ;;
+  *)
+    echo "FAIL: unknown build type '$BUILD_TYPE'"
+    echo 1
+    ;;
+esac
+
+# work around for compiler architecture flags
+enforce_target=
+if grep -q "6\." /etc/redhat-release 2>/dev/null; then
+  if [ "$(uname -m)" = "i686" ]; then
+    enforce_target="--target=i686"
+  fi
+fi
+if [ "$(uname -m)" = "x86_64" -a $(getconf LONG_BIT) = 32 ]; then
+  enforce_target="--target=i686"
+fi
+
+# build the package
+rpmbuild --define="_topdir $build_dir" --define="_tmppath ${build_dir}/TMP" $enforce_target -ba cvmfs-universal.spec
+
+# copy the built RPMs in a central location
+cp ./RPMS/*/*.rpm $results_dir

--- a/ci/jenkins/cleanup.sh
+++ b/ci/jenkins/cleanup.sh
@@ -1,0 +1,50 @@
+#/bin/sh
+
+echo "Continuous Integration Cleanup Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+
+cleanup_rpms() {
+  local packages="$(rpm -qa | grep cvmfs)"
+  echo "Packages to be deleted:"
+  for package in $packages; do
+    echo $package
+  done
+  sudo rpm -e $packages > /dev/null
+}
+
+cleanup_debs() {
+  local packages="$(dpkg-query --showformat '${Package} ' --show 'cvmfs*')"
+  echo "Packages to be deleted:"
+  for package in $packages; do
+    echo $package
+  done
+  sudo dpkg --purge $packages
+}
+
+echo "Cleanup Packages"
+case $PACKAGE_TYPE in
+  rpm)
+    cleanup_rpms
+    ;;
+  deb)
+    cleanup_debs
+    ;;
+  *)
+    echo "FAIL: unknown package type '$PACKAGE_TYPE'"
+    ;;
+esac
+
+sudo rm -fR $(pwd)/${CVMFS_BUILD_RESULTS}
+
+sudo /usr/sbin/userdel cvmfs
+sudo rm -rf /etc/cvmfs /var/cache/cvmfs2 /var/lib/cvmfs
+sudo sed -i "/^\/cvmfs \/etc\/auto.cvmfs/d" /etc/auto.master
+if [ -e /etc/fuse.conf ]; then
+  sudo sed -i "/added by CernVM-FS/d" /etc/fuse.conf
+fi
+[ -f /var/lock/subsys/autofs ] && sudo /sbin/service autofs restart
+sudo rm -rf /cvmfs
+sudo rm -rf /usr/bin/cvmfs-* /usr/bin/cvmfs_* /sbin/mount.cvmfs /etc/auto.cvmfs /etc/init.d/cvmfs

--- a/ci/jenkins/common.sh
+++ b/ci/jenkins/common.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+make_build_tag() {
+  cvmfs_build_tag="cvmfs-???"
+  case $BUILD_TYPE in
+    nightly|incremental)
+      cvmfs_build_tag="cvmfs-$CVMFS_SNAPSHOT_VERSION"
+      ;;
+    release)
+      cvmfs_build_tag="cvmfs-$CVMFS_VERSION"
+      ;;
+    *)
+      echo "FAIL: unknown build type '$BUILD_TYPE'"
+      exit 1
+      ;;
+  esac
+
+  echo "$cvmfs_build_tag"
+}
+
+# figure out some information about the version to be built
+CVMFS_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+CVMFS_COMMIT="$(git rev-parse HEAD)"
+CVMFS_VERSION="$(grep CVMFS_VERSION CMakeLists.txt | cut -d' ' -f3)"
+CVMFS_SNAPSHOT_VERSION="git-$(echo $CVMFS_COMMIT | head -c16)"
+CVMFS_BUILD_DIR="build"
+CVMFS_BUILD_RESULTS="build_results"
+CVMFS_BUILD_TAG="$(make_build_tag)"
+
+CVMFS_INIT_SCRIPTS_VERSION="1.0.18-2"
+CVMFS_KEYS_VERSION="1.4-1"
+
+echo
+echo "Jenkins Environment"
+echo "~~~~~~~~~~~~~~~~~~~"
+echo "Job Name:              $JOB_NAME"
+echo "Building:              $BUILD_NUMBER"
+echo "Timestamp:             $(date)"
+echo "Build Node:            $NODE_NAME"
+echo "Labels:                $NODE_LABELS"
+echo "workspace:             $WORKSPACE"
+echo "Build URL:             $BUILD_URL"
+echo "Job URL:               $JOB_URL"
+echo "Working Dir:           $(pwd)"
+echo ""
+echo "System"
+echo "~~~~~~"
+echo "System (uname -srn):   $(uname -srn)"
+echo "User:                  $(whoami)"
+echo
+echo "CVMFS Build Environment"
+echo "~~~~~~~~~~~~~~~~~~~~~~~"
+echo "CVMFS Version:           $CVMFS_VERSION"
+echo "Snapshot Build Version:  $CVMFS_SNAPSHOT_VERSION"
+echo "Build Results:           $CVMFS_BUILD_RESULTS"
+echo "Package Type:            $PACKAGE_TYPE"
+echo "Build Type:              $BUILD_TYPE"
+echo "Git Branch:              $CVMFS_GIT_BRANCH"
+echo "Git Commit:              $CVMFS_COMMIT"
+echo "Last Change:             $(git log -1 --pretty=%B)"
+echo
+

--- a/ci/jenkins/install.sh
+++ b/ci/jenkins/install.sh
@@ -1,0 +1,20 @@
+#/bin/sh -e
+
+set -e
+
+echo "Continuous Integration Package Test Installation Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+case $PACKAGE_TYPE in
+  rpm)
+    sh ci/jenkins/install_rpm.sh
+    ;;
+  deb)
+    sh ci/jenkins/install_deb.sh
+    ;;
+  *)
+    "FAIL: unknown package type '$PACKAGE_TYPE'"
+    ;;
+esac

--- a/ci/jenkins/install_deb.sh
+++ b/ci/jenkins/install_deb.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+echo "Continuous Integration DEB Installation Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+cd $CVMFS_BUILD_RESULTS
+
+tmp_dir=/tmp
+
+echo "Downloading Extra Packages"
+curl -k "https://ecsft.cern.ch/dist/cvmfs/cvmfs-keys/cvmfs-keys_${CVMFS_KEYS_VERSION}_all.deb" > ${tmp_dir}/cvmfs-keys_${CVMFS_KEYS_VERSION}_all.deb
+
+echo "Installing Debian Packages"
+sudo dpkg --install --force-confnew ${tmp_dir}/cvmfs-keys_${CVMFS_KEYS_VERSION}_all.deb
+sudo dpkg --install --force-confnew *.deb
+
+echo "Configuring CVMFS Client"
+sudo cvmfs_config setup

--- a/ci/jenkins/install_rpm.sh
+++ b/ci/jenkins/install_rpm.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+echo "Continuous Integration RPM Installation Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+cd $CVMFS_BUILD_RESULTS
+
+tmp_dir=/tmp
+
+echo "Downloading Extra Packages"
+curl -k https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/5/x86_64/cvmfs-init-scripts-${CVMFS_INIT_SCRIPTS_VERSION}.noarch.rpm > $tmp_dir/cvmfs-init-scripts-${CVMFS_INIT_SCRIPTS_VERSION}.noarch.rpm
+curl -k https://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/5/x86_64/cvmfs-keys-${CVMFS_KEYS_VERSION}.noarch.rpm                 > $tmp_dir/cvmfs-keys-${CVMFS_KEYS_VERSION}.noarch.rpm
+
+echo "Installing packages"
+sudo rpm -vi $tmp_dir/cvmfs-keys-${CVMFS_KEYS_VERSION}.noarch.rpm
+sudo rpm -vi *.rpm
+sudo rpm -vi $tmp_dir/cvmfs-init-scripts-${CVMFS_INIT_SCRIPTS_VERSION}.noarch.rpm
+
+echo "Configuring CVMFS Client"
+sudo cvmfs_config setup

--- a/ci/jenkins/publish.sh
+++ b/ci/jenkins/publish.sh
@@ -1,0 +1,10 @@
+#/bin/sh -e
+
+set -e
+
+echo "Continuous Integration Package Publishing Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+echo "Coming Soon!"

--- a/ci/jenkins/quick_test.sh
+++ b/ci/jenkins/quick_test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+echo "Continuous Integration Quick Test Script"
+
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common.sh
+
+cvmfs_unittests --gtest_shuffle


### PR DESCRIPTION
This contains a number of new scripts to build in Jenkins. It's beta, but the first build went through. :-)

Basically it's a refactoring of the CI scripts we used to have before, however now everything is version controlled. Before, parts were buried in Electric Commander and had funny cross-dependencies with Perl scripts inside EC as well. Have a look into the `README` to learn how it works. In short: Jenkins controls the scripts with a small number of environment variables while it only calls this from the web interface:

```
ci/jenkins/cleanup.sh
ci/jenkins/build.sh
ci/jenkins/install.sh
ci/jenkins/quick_test.sh
ci/jenkins/publish.sh
```

Furthermore, the unit test suite is now executed for each fresh build. With Jenkins we can build practically every new commit that is merged into **devel**, since there is no licensing contention anymore.

Unfortunately, the Mac OS build is still missing and I want to integrate [CVM-247](https://sft.its.cern.ch/jira/browse/CVM-247), but for a start it works nicely. Thanks a lot Petr!
