### PR TITLE
FIX: Temporary Directory for Catalog Migrations

### DIFF
--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -163,7 +163,7 @@ int CommandMigrate::Main(const ArgumentList &args) {
     spooler_->WaitForUpload();
 
     // Configure the concurrent catalog migration facility
-    MigrationWorker_20x::worker_context context(spooler_definition.temporary_path,
+    MigrationWorker_20x::worker_context context(temporary_directory_,
                                                 collect_catalog_statistics,
                                                 fix_transition_points,
                                                 analyze_file_linkcounts,
@@ -172,7 +172,7 @@ int CommandMigrate::Main(const ArgumentList &args) {
     migration_succeeded =
       DoMigrationAndCommit<MigrationWorker_20x>(context, manifest_path);
   } else if (migration_base == "2.1.7") {
-    MigrationWorker_217::worker_context context(spooler_definition.temporary_path,
+    MigrationWorker_217::worker_context context(temporary_directory_,
                                                 collect_catalog_statistics);
     migration_succeeded =
       DoMigrationAndCommit<MigrationWorker_217>(context, manifest_path);


### PR DESCRIPTION
The catalog migrations were performed in `/srv/cvmfs/.../data/txn` which might not be local storage in production systems. This potentially slows down the catalog migration since SQLite would do the database mangling remotely. (For example on the CERN stratum zeros this would happen over NFS)

See [CVM-656](https://sft.its.cern.ch/jira/browse/CVM-656).
