### PR TITLE
Fix s3 thread safety

### DIFF
--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -449,9 +449,16 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
     info->http_headers =
         curl_slist_append(info->http_headers, "Content-Length: 0");
 
-    retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, req.c_str());
-    assert(retval == CURLE_OK);
+    if (info->request == JobInfo::kReqDelete) {
+      retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, req.c_str());
+      assert(retval == CURLE_OK);
+    } else {
+      retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, NULL);
+      assert(retval == CURLE_OK);
+    }
   } else {
+    retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, NULL);
+    assert(retval == CURLE_OK);
     retval = curl_easy_setopt(handle, CURLOPT_UPLOAD, 1);
     assert(retval == CURLE_OK);
     retval = curl_easy_setopt(handle, CURLOPT_NOBODY, 0);

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -193,6 +193,7 @@ class S3FanoutManager : SingleCopy {
   }
 
   Prng prng_;
+  pthread_mutex_t  *lock_handle_pool_;
   std::set<CURL *> *pool_handles_idle_;
   std::set<CURL *> *pool_handles_inuse_;
   std::map<CURL *, CURLSH *> *pool_sharehandles_;


### PR DESCRIPTION
We figured out that `S3Uploader` is not thread safe and thus fails when used as a stratum 1 backend. Fixed.