### PR TITLE
Install bash_completion.d relative to installation prefix.

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -400,7 +400,7 @@ if (BUILD_CVMFS)
   install (
     FILES         bash_completion/cvmfs.bash_completion
     RENAME        cvmfs
-    DESTINATION   /etc/bash_completion.d
+    DESTINATION   etc/bash_completion.d
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 


### PR DESCRIPTION
Current installation fails if the user cannot write to /etc. This minor change install etc/bash_completion.d relative to the installation prefix.
