### PR TITLE
AUFS Deadlock Warning Detects Kernel Patch

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -973,7 +973,7 @@ find_hazardous_aufs_config() {
   # silenced... in these cases no more checks are needed
   load_repo_config $name
   if [ x"$CVMFS_UNION_FS_TYPE" != x"aufs"  ] || \
-     [ x"$CVMFS_AUFS_WARNING" = x"false"   ]; then
+     [ x"$CVMFS_AUFS_WARNING"  =  x"false" ]; then
     return 1
   fi
 


### PR DESCRIPTION
This adds a check into `find_hazardous_aufs_config()` for the SL6 kernel version that @jblomer patched with a workaround. Furthermore it contains minor refactorings to simplify version comparisons.
