### PR TITLE
FIX: Whitelist Signed for 'next month' (now: '+30 days')

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1101,7 +1101,7 @@ create_whitelist() {
 
   echo -n "Signing 30 day whitelist with master key... "
   echo `date -u "+%Y%m%d%H%M%S"` > ${whitelist}.unsigned
-  echo "E`date -u --date='next month' "+%Y%m%d%H%M%S"`" >> ${whitelist}.unsigned
+  echo "E`date -u --date='+30 days' "+%Y%m%d%H%M%S"`" >> ${whitelist}.unsigned
   echo "N$name" >> ${whitelist}.unsigned
   if [ "x$CVMFS_HASH_ALGORITHM" = "xrmd160" ]; then
     fingerprint="$(openssl x509 -fingerprint -rmd160 -in /etc/cvmfs/keys/${name}.crt | grep 'RIPEMD160 Fingerprint' | sed 's/RIPEMD160 Fingerprint=//')-RMD160"


### PR DESCRIPTION
As proposed by @DrDaveD `cvmfs_server` now always signs the whitelist for 30 days instead of the next month. 
