### PR TITLE
FIX: Set SELinux Context of /var/lib/cvmfs after Installing

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -265,6 +265,7 @@ do
   /usr/sbin/semodule -s ${selinuxvariant} -i \
     %{_datadir}/selinux/${selinuxvariant}/cvmfs.pp &> /dev/null || :
 done
+restorecon -R /var/lib/cvmfs
 %endif
 /sbin/ldconfig
 if [ -d /var/run/cvmfs ]; then


### PR DESCRIPTION
This adds `restorecon -R /var/lib/cvmfs` to the post-install script of the RPM package (if SELinux handling is enabled). Otherwise the `/var/lib/cvmfs` directory does not pick up the context defined in `cvmfs.fc`.

**Caveat:** (to be fixed) there should be a mechanism to invoke `restorecon` when updating CVMFS and cache directories have been relocated by the administrator. Where would be the best place to do that?
