### PR TITLE
FIX: Disable Test Case 007 on CentOS7

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -28,6 +28,7 @@ cd ${SOURCE_DIRECTORY}/test
 export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&         \
 ./run.sh $TEST_LOGFILE -x src/005-asetup               \
                           src/004-davinci              \
+                          src/007-testjobs             \
                           src/024-reload-during-asetup \
                           src/5* || it_retval=$?
 


### PR DESCRIPTION
This test case runs some physics software that is not yet compatible with CentOS 7.
