### PR TITLE
FIX: zlib Needs Environment to Configure Properly

### DIFF
--- a/externals/zlib/src/configureHook.sh
+++ b/externals/zlib/src/configureHook.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-env -i sh configure --static
+sh configure --static


### PR DESCRIPTION
Hope you didn't have a good reason to configure zlib with `env -i` (ignore environment). Without that it works (on my ubuntu 14.04).
