### PR TITLE
Disable Integration Test 525 for S3

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -67,6 +67,7 @@ if [ $s3_retval -eq 0 ]; then
                                  src/522-missingchunkfailover         \
                                  src/523-corruptchunkfailover         \
                                  src/524-corruptmanifestfailover      \
+                                 src/525-bigrepo                      \
                                  src/528-recreatespoolarea            \
                                  src/530-recreatespoolarea_defaultkey \
                                  src/537-symlinkedbackend             \


### PR DESCRIPTION
This disabled the integration test 525 (_Split a Huge Repository into Nested Catalogs_) for the S3 tests. It takes forever with the current test setup and is intended to test the nested catalog handling anyway.
In any case, I need to revise the S3 tests at some point, as they are only run on SLC6 x64 and utilise a pretty simple configuration. Then we might opt to switch it on again. At the moment is just slows down test cycles too much.
