### PR TITLE
Feature: Centralise the Use of `sudo` in `cvmfs_server`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -606,6 +606,11 @@ is_root() {
 }
 
 
+# create a shell invocation to be used by commands to impersonate the owner of
+# a specific CVMFS repository.
+#
+# @param name   the name of the repository whose owner should be impersonated
+# @return       a shell invocation to impersonate $CVMFS_USER
 get_user_shell() {
   local name=$1
 


### PR DESCRIPTION
This introduces the function `get_user_shell()` that returns a shell invocation to impersonate the repository owner of a provided repository in `cvmfs_server`. With that patch `cvmfs_server` has only _one_ occurrence of `sudo`, making it easily replaceable (i.e. [CVM-245](https://sft.its.cern.ch/jira/browse/CVM-245)).
