### PR TITLE
Adds INSTALL_BASH_COMPLETION option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ option (BUILD_UNITTESTS       "Build the CernVM-FS unit test set"               
 option (INSTALL_UNITTESTS     "Install the unit test binary (mainly for packaging)"              OFF)
 option (INSTALL_MOUNT_SCRIPTS "Install CernVM-FS mount tools in /etc and /sbin"                  ON)
 option (INSTALL_CERN_KEYS     "Install CERN specific public key chain"                           ON)
+option (INSTALL_BASH_COMPLETION "Install bash completion rules for cvmfs* commands in /etc"      ON)
 option (SQLITE3_BUILTIN       "Don't use system SQLite3"                                         ON)
 option (LIBCURL_BUILTIN       "Don't use system libcurl"                                         ON)
 option (PACPARSER_BUILTIN     "Don't use system installation of pacparser"                       ON)

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -397,12 +397,14 @@ if (BUILD_CVMFS)
     PERMISSIONS    OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
   )
 
-  install (
-    FILES         bash_completion/cvmfs.bash_completion
-    RENAME        cvmfs
-    DESTINATION   /etc/bash_completion.d
-    PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-  )
+  if(INSTALL_BASH_COMPLETION)
+    install (
+        FILES         bash_completion/cvmfs.bash_completion
+        RENAME        cvmfs
+        DESTINATION   /etc/bash_completion.d
+        PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+    )
+   endif (INSTALL_BASH_COMPLETION)
 
 endif (BUILD_CVMFS)
 


### PR DESCRIPTION
Default is ON. Disable bash completion installation with: -DINSTALL_BASH_COMPLETION=OFF
