### PR TITLE
FIX: `get_user_shell()` in `mkfs()` and `snapshot()`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3573,7 +3573,7 @@ snapshot() {
     fi
 
     # do it!
-    local user_shell="$(get_user_shell $name)"
+    local user_shell="$(get_user_shell $alias_name)"
 
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-l $CVMFS_LOG_LEVEL"


### PR DESCRIPTION
Running the server tests over night revealed two problems with a [Pull Request](https://github.com/cvmfs/cvmfs/pull/581) from yesterday. Fixed...
