### PR TITLE
TEST: Enable Hardlink Stresstest on Ubuntu

### DIFF
--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -21,8 +21,7 @@ cd ${SOURCE_DIRECTORY}/test
                           src/024-reload-during-asetup    \
                           src/045-oasis                   \
                           src/523-corruptchunkfailover    \
-                          src/524-corruptmanifestfailover \
-                          src/562-aufsexdevrename         || it_retval=$?
+                          src/524-corruptmanifestfailover || it_retval=$?
 
 echo "running CernVM-FS migration test cases..."
 ./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?


### PR DESCRIPTION
Apparently my hard link stresstest I put together in April 2013 finally runs through since Ubuntu 13.10. Let's enable it on ubuntu and see... Also the AUFS kernel deadlock bug runs fine since I don't user Ubuntu 13.04 for testing anymore, hence enable it as well.
