### PR TITLE
FIX: sysvinit-tools are Superseded by procps-ng on Fedora 21

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -87,7 +87,11 @@ Requires: shadow-utils
 Requires: SysVinit
 Requires: e2fsprogs
   %else
+    %if 0%{?fc21}
+Requires: procps-ng
+    %else
 Requires: sysvinit-tools
+    %endif
     %if 0%{?el6}
 Requires: util-linux-ng
     %else


### PR DESCRIPTION
_keep your fingers crossed_ ... merging myself and starting a new build...
