### PR TITLE
Fix: Acquire and Release handle protected with mutex

### DIFF
--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -183,6 +183,7 @@ class S3FanoutManager : SingleCopy {
   pthread_mutex_t *jobs_todo_lock_;
   std::vector<s3fanout::JobInfo*> jobs_completed_;
   pthread_mutex_t *jobs_completed_lock_;
+  pthread_mutex_t *curl_handle_lock_;
 
   CURL *AcquireCurlHandle() const;
   void ReleaseCurlHandle(JobInfo *info, CURL *handle) const;


### PR DESCRIPTION
Several threads acquire and release easy handles when creating stratum1 replica. This adds locks to protect the curl easy handle management.
