### PR TITLE
Refactor: Database::Create and ::Open() use UniquePtr<>

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -101,19 +101,18 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   string root_path = "";
 
   // Create the database schema and the inital root entry
-  CatalogDatabase *new_catalog_db = CatalogDatabase::Create(file_path);
-  if (NULL == new_catalog_db ||
-      ! new_catalog_db->InsertInitialValues(root_path,
-                                            volatile_content,
-                                            root_entry))
   {
-    LogCvmfs(kLogCatalog, kLogStderr, "creation of catalog '%s' failed",
-             file_path.c_str());
-    return NULL;
+    UniquePtr<CatalogDatabase> new_clg_db(CatalogDatabase::Create(file_path));
+    if (! new_clg_db.IsValid() ||
+        ! new_clg_db->InsertInitialValues(root_path,
+                                          volatile_content,
+                                          root_entry))
+    {
+      LogCvmfs(kLogCatalog, kLogStderr, "creation of catalog '%s' failed",
+               file_path.c_str());
+      return NULL;
+    }
   }
-
-  // closing the newly created catalog again
-  delete new_catalog_db;
 
   // Compress root catalog;
   int64_t catalog_size = GetFileSize(file_path);

--- a/cvmfs/file_processing/file.h
+++ b/cvmfs/file_processing/file.h
@@ -73,7 +73,7 @@ class File : public AbstractFile {
         Chunk*        bulk_chunk()        { return bulk_chunk_;  }
   const Chunk*        bulk_chunk()  const { return bulk_chunk_;  }
   const ChunkVector&  chunks()      const { return chunks_;      }
-  const shash::Suffix hash_suffix() const { return hash_suffix_; }
+        shash::Suffix hash_suffix() const { return hash_suffix_; }
 
   Chunk* current_chunk() {
     return (chunks_.size() > 0) ? chunks_.back() : NULL;

--- a/cvmfs/pathspec/pathspec_pattern.cc
+++ b/cvmfs/pathspec/pathspec_pattern.cc
@@ -31,14 +31,17 @@ PathspecElementPattern::PathspecElementPattern(
 PathspecElementPattern& PathspecElementPattern::operator=(
                                             const PathspecElementPattern& other)
 {
-  valid_ = other.valid_;
-  subpatterns_.clear();
-  subpatterns_.reserve(other.subpatterns_.size());
-  SubPatterns::const_iterator i    = other.subpatterns_.begin();
-  SubPatterns::const_iterator iend = other.subpatterns_.end();
-  for (; i != iend; ++i) {
-    subpatterns_.push_back((*i)->Clone());
+  if (this != &other) {
+    valid_ = other.valid_;
+    subpatterns_.clear();
+    subpatterns_.reserve(other.subpatterns_.size());
+    SubPatterns::const_iterator i    = other.subpatterns_.begin();
+    SubPatterns::const_iterator iend = other.subpatterns_.end();
+    for (; i != iend; ++i) {
+      subpatterns_.push_back((*i)->Clone());
+    }
   }
+
   return *this;
 }
 

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -26,13 +26,14 @@ template <class DerivedT>
 DerivedT* Database<DerivedT>::Create(const std::string &filename) {
   // TODO: SharedPointer to avoid 'delete' in error conditions
   DerivedT *database = new DerivedT(filename, kOpenReadWrite);
-  database->set_schema_version(DerivedT::kLatestSchema);
-  database->set_schema_revision(DerivedT::kLatestSchemaRevision);
 
   if (! database) {
     LogCvmfs(kLogSql, kLogDebug, "Failed to create new database object");
     return NULL;
   }
+
+  database->set_schema_version(DerivedT::kLatestSchema);
+  database->set_schema_revision(DerivedT::kLatestSchemaRevision);
 
   const int open_flags = SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_READWRITE |
                          SQLITE_OPEN_CREATE;

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -240,7 +240,7 @@ template <class DerivedT>
 template <typename T>
 T Database<DerivedT>::GetProperty(const std::string &key) const {
   assert (get_property_);
-  const bool retval = get_property_->BindText(1, key);
+  const bool retval = get_property_->BindText(1, key) &&
                       get_property_->FetchRow();
   assert (retval);
   const T result = get_property_->Retrieve<T>(0);

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -69,6 +69,13 @@ template <class DerivedT>
 DerivedT* Database<DerivedT>::Open(const std::string  &filename,
                                    const OpenMode      open_mode) {
   UniquePtr<DerivedT> database(new DerivedT(filename, open_mode));
+
+  if (! database.IsValid()) {
+    LogCvmfs(kLogSql, kLogDebug, "Failed to open database file '%s' - errno: %d",
+             filename.c_str(), errno);
+    return NULL;
+  }
+
   if (! database->Initialize()) {
     return NULL;
   }

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -24,10 +24,9 @@ Database<DerivedT>::Database(const std::string  &filename,
 
 template <class DerivedT>
 DerivedT* Database<DerivedT>::Create(const std::string &filename) {
-  // TODO: SharedPointer to avoid 'delete' in error conditions
-  DerivedT *database = new DerivedT(filename, kOpenReadWrite);
+  UniquePtr<DerivedT> database(new DerivedT(filename, kOpenReadWrite));
 
-  if (! database) {
+  if (! database.IsValid()) {
     LogCvmfs(kLogSql, kLogDebug, "Failed to create new database object");
     return NULL;
   }
@@ -39,48 +38,42 @@ DerivedT* Database<DerivedT>::Create(const std::string &filename) {
                          SQLITE_OPEN_CREATE;
   if (! database->OpenDatabase(open_flags)) {
     LogCvmfs(kLogSql, kLogDebug, "Failed to create new database file");
-    delete database;
     return NULL;
   }
 
   if (! database->CreatePropertiesTable()) {
     database->PrintSqlError("Failed to create common properties table");
-    delete database;
     return NULL;
   }
 
   if (! database->CreateEmptyDatabase()) {
     database->PrintSqlError("Failed to create empty database");
-    delete database;
     return NULL;
   }
 
   if (! database->PrepareCommonQueries()) {
     database->PrintSqlError("Failed to initialize properties queries");
-    delete database;
     return NULL;
   }
 
   if (! database->StoreSchemaRevision()) {
     database->PrintSqlError("Failed to store initial schema revision");
-    delete database;
     return NULL;
   }
 
-  return database;
+  return database.Release();
 }
 
 
 template <class DerivedT>
 DerivedT* Database<DerivedT>::Open(const std::string  &filename,
                                    const OpenMode      open_mode) {
-  DerivedT* database = new DerivedT(filename, open_mode);
+  UniquePtr<DerivedT> database(new DerivedT(filename, open_mode));
   if (! database->Initialize()) {
-    delete database;
-    database = NULL;
+    return NULL;
   }
 
-  return database;
+  return database.Release();
 }
 
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -80,7 +80,8 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
     UploadJob(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
               const callback_t    *callback = NULL) :
-      type(Upload), stream_handle(handle), buffer(buffer), callback(callback) {}
+      type(Upload), stream_handle(handle), buffer(buffer), callback(callback),
+      hash_suffix(shash::kSuffixNone) {}
 
     UploadJob(UploadStreamHandle   *handle,
               const shash::Any     &content_hash,
@@ -89,7 +90,8 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
       content_hash(content_hash), hash_suffix(hash_suffix) {}
 
     UploadJob() :
-      type(Terminate), stream_handle(NULL), buffer(NULL), callback(NULL) {}
+      type(Terminate), stream_handle(NULL), buffer(NULL), callback(NULL),
+      hash_suffix(shash::kSuffixNone) {}
 
     Type                 type;
     UploadStreamHandle  *stream_handle;

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -44,6 +44,7 @@ class T_CatalogTraversal : public ::testing::Test {
 
  public:
   T_CatalogTraversal() :
+    dummy_catalog_hierarchy(NULL),
     max_revision(6),
     initial_catalog_instances(42) /* depends on max_revision */ {}
 

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -28,7 +28,7 @@ class T_CatalogTraversal : public ::testing::Test {
   typedef std::map<unsigned int, CatalogPathMap> RevisionMap;
 
   struct RootCatalogInfo {
-    RootCatalogInfo() {}
+    RootCatalogInfo() : timestamp(0) {}
     RootCatalogInfo(const shash::Any &hash, const time_t timestamp) :
       catalog_hash(hash),
       timestamp(timestamp) {}

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -923,7 +923,7 @@ TYPED_TEST(T_History, RollbackToOldTag) {
   EXPECT_TRUE  (history3->Exists("bar"));
   EXPECT_TRUE  (history3->Exists("first_release"));
   EXPECT_TRUE  (history3->Exists("moep"));
-  EXPECT_TRUE  (history2->Exists("moep_duplicate"));
+  EXPECT_TRUE  (history3->Exists("moep_duplicate"));
   EXPECT_TRUE  (history3->Exists("second_release"));
   EXPECT_TRUE  (history3->Exists("third_release"));
   EXPECT_TRUE  (history3->Exists("forth_release"));

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -162,14 +162,14 @@ MockCatalog* MockCatalog::AttachFreely(const std::string  &root_path,
                                              MockCatalog  *parent,
                                        const bool          is_not_root) {
   const MockCatalog *catalog = MockCatalog::GetCatalog(catalog_hash);
-  assert (catalog->IsRoot() || is_not_root);
   if (catalog == NULL) {
     return NULL;
-  } else {
-    MockCatalog *new_catalog = catalog->Clone();
-    new_catalog->set_parent(parent);
-    return new_catalog;
   }
+
+  assert (catalog->IsRoot() || is_not_root);
+  MockCatalog *new_catalog = catalog->Clone();
+  new_catalog->set_parent(parent);
+  return new_catalog;
 }
 
 void MockCatalog::RegisterChild(MockCatalog *child) {

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -242,7 +242,8 @@ MockHistory::MockHistory(const bool          writable,
 
 MockHistory::MockHistory(const MockHistory &other) :
   tags_(other.tags_),
-  recycle_bin_(other.recycle_bin_)
+  recycle_bin_(other.recycle_bin_),
+  writable_(other.writable_)
 {
   set_fqrn(other.fqrn());
 }

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -259,6 +259,10 @@ class MockCatalog {
     --MockCatalog::instances;
   }
 
+ protected:
+  // silence coverity
+  MockCatalog& operator= (const MockCatalog &other);
+
  public: /* API in this 'public block' is used by CatalogTraversal
           * (see catalog.h - catalog::Catalog for details)
           */

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -337,6 +337,11 @@ class MockHistory : public history::History {
   MockHistory(const MockHistory &other);
   ~MockHistory() {}
 
+ protected:
+  // silence coverity
+  MockHistory& operator= (const MockHistory &other);
+
+ public:
   history::History* Clone(const bool writable = false) const;
 
   bool IsWritable()          const { return writable_;    }


### PR DESCRIPTION
This uses the `UniquePtr<>` in the `Database::Open()` and `Database::Create()` methods removing facilitating the error handling of those methods. Additionally a null pointer check was added for `Database::Open()`.

**Note:** This is based on [Fix: Coverity Warnings](https://github.com/cvmfs/cvmfs/pull/654).