### PR TITLE
FIX: download of local files into memory

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -247,7 +247,7 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
       if (info->destination_mem.size == 0)
 	LogCvmfs(kLogDownload, kLogDebug, "Content-Length was missing or zero, but %d bytes were received", info->destination_mem.pos + num_bytes);
       else
-	LogCvmfs(kLogDownload, kLogDebug, "Data callback failed with too much data: start %d, bytes %d, expected content-length %d", 
+	LogCvmfs(kLogDownload, kLogDebug, "Data callback failed with too much data: start %d, bytes %d, expected content-length %d",
 	  info->destination_mem.pos, num_bytes, info->destination_mem.size);
       info->error_code = kFailBadData;
       return 0;
@@ -990,6 +990,13 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
           info->error_code = kFailBadData;
           break;
         }
+      }
+
+      // Set actual size in case of file:// download into memory
+      if ((info->destination == kDestinationMem) &&
+          (HasPrefix(*(info->url), "file://", false)))
+      {
+        info->destination_mem.size = info->destination_mem.pos;
       }
 
       // Decompress memory in a single run

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -44,10 +44,28 @@ TEST_F(T_Download, File) {
   UnlinkGuard unlink_guard(dest_path);
 
   JobInfo info(&foo_url, false /* compressed */, false /* probe hosts */,
-               fdest, NULL);
+               fdest,  NULL);
   download_mgr.Fetch(&info);
   EXPECT_EQ(info.error_code, kFailOk);
   fclose(fdest);
+}
+
+
+TEST_F(T_Download, LocalFile2Mem) {
+  string dest_path;
+  FILE *fdest = CreateTempFile("/tmp/cvmfstest", 0600, "w+", &dest_path);
+  ASSERT_TRUE(fdest != NULL);
+  UnlinkGuard unlink_guard(dest_path);
+  char buf = '1';
+  fwrite(&buf, 1, 1, fdest);
+  fclose(fdest);
+
+  string url = "file://" + dest_path;
+  JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.size, 1U);
+  EXPECT_EQ(info.destination_mem.data[0], '1');
 }
 
 


### PR DESCRIPTION
Fix the destination_mem.size field of the JobInfo struct.