### PR TITLE
FIX: Dependent Type Naming Convention

### DIFF
--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -106,21 +106,21 @@ struct CatalogTraversalData {
  *
  * @param ObjectFetcherT  Strategy Pattern implementation that defines how to
  *                        retrieve catalogs from various backend storage types.
- *                        Furthermore the ObjectFetcherT::catalog_t is the type
+ *                        Furthermore the ObjectFetcherT::CatalogTN is the type
  *                        of catalog to be instantiated by CatalogTraversal<>.
  *
- * CAUTION: the catalog_t* pointer passed into the callback becomes invalid
+ * CAUTION: the CatalogTN* pointer passed into the callback becomes invalid
  *          directly after the callback method returns, unless you create the
  *          CatalogTraversal object with no_close = true.
  */
 template<class ObjectFetcherT>
 class CatalogTraversal
-  : public Observable<CatalogTraversalData<typename ObjectFetcherT::catalog_t> >
+  : public Observable<CatalogTraversalData<typename ObjectFetcherT::CatalogTN> >
 {
  public:
-  typedef ObjectFetcherT                      object_fetcher_t;
-  typedef typename ObjectFetcherT::catalog_t  catalog_t;
-  typedef CatalogTraversalData<catalog_t>     callback_data_t;
+  typedef ObjectFetcherT                      ObjectFetcherTN;
+  typedef typename ObjectFetcherT::CatalogTN  CatalogTN;
+  typedef CatalogTraversalData<CatalogTN>     CallbackDataTN;
 
   /**
    * @param repo_url             the path to the repository to be traversed:
@@ -188,7 +188,7 @@ class CatalogTraversal
                const shash::Any   &hash,
                const unsigned      tree_level,
                const unsigned      history_depth,
-                     catalog_t    *parent = NULL) :
+                     CatalogTN    *parent = NULL) :
       path(path),
       hash(hash),
       tree_level(tree_level),
@@ -202,9 +202,9 @@ class CatalogTraversal
 
     bool IsRootCatalog() const { return tree_level == 0; }
 
-    callback_data_t GetCallbackData() const {
-      return callback_data_t(catalog, hash, tree_level,
-                             catalog_file_size, history_depth);
+    CallbackDataTN GetCallbackData() const {
+      return CallbackDataTN(catalog, hash, tree_level,
+                            catalog_file_size, history_depth);
     }
 
     // initial state description
@@ -212,13 +212,13 @@ class CatalogTraversal
     const shash::Any    hash;
     const unsigned      tree_level;
     const unsigned      history_depth;
-          catalog_t    *parent;
+          CatalogTN    *parent;
 
     // dynamic processing state (used internally)
     std::string   catalog_file_path;
     size_t        catalog_file_size;
     bool          ignore;
-    catalog_t    *catalog;
+    CatalogTN    *catalog;
     unsigned int  referenced_catalogs;
     bool          postponed;
   };
@@ -492,7 +492,7 @@ class CatalogTraversal
     assert (! job.ignore);
     assert (job.catalog == NULL);
 
-    job.catalog = catalog_t::AttachFreely(job.path,
+    job.catalog = CatalogTN::AttachFreely(job.path,
                                           job.catalog_file_path,
                                           job.hash,
                                           job.parent,
@@ -611,12 +611,12 @@ class CatalogTraversal
   unsigned int PushNestedCatalogs(      TraversalContext  &ctx,
                                   const CatalogJob        &job)
   {
-    typedef typename catalog_t::NestedCatalogList NestedCatalogList;
+    typedef typename CatalogTN::NestedCatalogList NestedCatalogList;
     const NestedCatalogList &nested = job.catalog->ListNestedCatalogs();
     typename NestedCatalogList::const_iterator i    = nested.begin();
     typename NestedCatalogList::const_iterator iend = nested.end();
     for (; i != iend; ++i) {
-      catalog_t* parent = (no_close_) ? job.catalog : NULL;
+      CatalogTN* parent = (no_close_) ? job.catalog : NULL;
       const CatalogJob new_job(i->path.ToString(),
                                i->hash,
                                job.tree_level + 1,

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -39,7 +39,7 @@
 template<class CatalogTraversalT, class HashFilterT>
 class GarbageCollector {
  protected:
-  typedef typename CatalogTraversalT::object_fetcher_t object_fetcher_t;
+  typedef typename CatalogTraversalT::ObjectFetcherTN ObjectFetcherTN;
 
  public:
   struct Configuration {
@@ -58,7 +58,7 @@ class GarbageCollector {
       , verbose(false) {}
 
     upload::AbstractUploader  *uploader;
-    object_fetcher_t          *object_fetcher;
+    ObjectFetcherTN           *object_fetcher;
     unsigned int               keep_history_depth;
     time_t                     keep_history_timestamp;
     shash::Any                 base_history_database;
@@ -67,10 +67,10 @@ class GarbageCollector {
   };
 
  protected:
-  typedef typename CatalogTraversalT::catalog_t        catalog_t;
-  typedef typename CatalogTraversalT::callback_data_t  traversal_callback_data_t;
-  typedef typename CatalogTraversalT::Parameters       TraversalParameters;
-  typedef std::vector<shash::Any>                      HashVector;
+  typedef typename CatalogTraversalT::CatalogTN       CatalogTN;
+  typedef typename CatalogTraversalT::CallbackDataTN  TraversalCallbackDataTN;
+  typedef typename CatalogTraversalT::Parameters      TraversalParameters;
+  typedef std::vector<shash::Any>                     HashVector;
 
  public:
   GarbageCollector(const Configuration &configuration);
@@ -85,8 +85,8 @@ class GarbageCollector {
   static TraversalParameters GetTraversalParams(
                                             const Configuration &configuration);
 
-  void PreserveDataObjects(const traversal_callback_data_t &data);
-  void SweepDataObjects   (const traversal_callback_data_t &data);
+  void PreserveDataObjects(const TraversalCallbackDataTN &data);
+  void SweepDataObjects   (const TraversalCallbackDataTN &data);
 
   bool AnalyzePreservedCatalogTree();
   bool SweepCondemnedCatalogTree();
@@ -97,7 +97,7 @@ class GarbageCollector {
   void Sweep(const shash::Any &hash);
 
   void PrintCatalogTreeEntry(const unsigned int  tree_level,
-                             const catalog_t    *catalog) const;
+                             const CatalogTN    *catalog) const;
 
  private:
   const Configuration   configuration_;

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -60,7 +60,8 @@ typename GarbageCollector<CatalogTraversalT, HashFilterT>::TraversalParameters
 
 template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveDataObjects(
- const GarbageCollector<CatalogTraversalT, HashFilterT>::traversal_callback_data_t &data) {
+ const GarbageCollector<CatalogTraversalT,
+                        HashFilterT>::TraversalCallbackDataTN &data) {
   ++preserved_catalogs_;
 
   if (configuration_.verbose) {
@@ -86,7 +87,8 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveDataObjects(
 
 template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects(
- const GarbageCollector<CatalogTraversalT, HashFilterT>::traversal_callback_data_t &data) {
+ const GarbageCollector<CatalogTraversalT,
+                        HashFilterT>::TraversalCallbackDataTN &data) {
   ++condemned_catalogs_;
 
   if (configuration_.verbose) {
@@ -155,7 +157,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::AnalyzePreservedCatalogTr
   }
   bool success = true;
 
-  typename CatalogTraversalT::callback_t *callback =
+  typename CatalogTraversalT::CallbackTN *callback =
     traversal_.RegisterListener(
        &GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveDataObjects,
         this);
@@ -200,7 +202,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepCondemnedCatalogTree
     return true;
   }
 
-  typename CatalogTraversalT::callback_t *callback =
+  typename CatalogTraversalT::CallbackTN *callback =
     traversal_.RegisterListener(
        &GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects,
         this);
@@ -227,7 +229,7 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GetHistoryRecycleBinContents(
   assert (result_set != NULL);
   result_set->clear();
 
-  object_fetcher_t *fetcher = configuration_.object_fetcher;
+  ObjectFetcherTN *fetcher = configuration_.object_fetcher;
   const shash::Any &base_hash = configuration_.base_history_database;
 
   // fetch the latest history database
@@ -276,7 +278,7 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GetHistoryRecycleBinContents(
 template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::PrintCatalogTreeEntry(
                                               const unsigned int  tree_level,
-                                              const catalog_t    *catalog) const
+                                              const CatalogTN    *catalog) const
 {
   std::string tree_indent;
   for (unsigned int i = 0; i < tree_level; ++i) {

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -43,8 +43,8 @@ struct object_fetcher_traits;
 template <class DerivedT>
 class AbstractObjectFetcher {
  public:
-  typedef typename object_fetcher_traits<DerivedT>::catalog_t catalog_t;
-  typedef typename object_fetcher_traits<DerivedT>::history_t history_t;
+  typedef typename object_fetcher_traits<DerivedT>::CatalogTN CatalogTN;
+  typedef typename object_fetcher_traits<DerivedT>::HistoryTN HistoryTN;
 
   static const std::string kManifestFilename;
 
@@ -67,7 +67,7 @@ class AbstractObjectFetcher {
    *                                 if left blank, the latest one is downloaded
    * @return              a history database object or NULL on error
    */
-  history_t* FetchHistory(const shash::Any &history_hash = shash::Any()) {
+  HistoryTN* FetchHistory(const shash::Any &history_hash = shash::Any()) {
     // retrieve the current HEAD history hash (if nothing else given)
     shash::Any effective_history_hash = (! history_hash.IsNull())
             ? history_hash
@@ -81,7 +81,7 @@ class AbstractObjectFetcher {
     }
 
     // open the history file
-    return history_t::Open(path);
+    return HistoryTN::Open(path);
   }
 
   /**
@@ -94,10 +94,10 @@ class AbstractObjectFetcher {
    * @param parent         (optional) parent catalog of the requested catalog
    * @return               a catalog object or NULL on error
    */
-  catalog_t* FetchCatalog(const shash::Any  &catalog_hash,
+  CatalogTN* FetchCatalog(const shash::Any  &catalog_hash,
                           const std::string &catalog_path,
                           const bool         is_nested = false,
-                                catalog_t   *parent    = NULL) {
+                                CatalogTN   *parent    = NULL) {
     assert (! catalog_hash.IsNull());
 
     std::string path;
@@ -105,7 +105,7 @@ class AbstractObjectFetcher {
       return NULL;
     }
 
-    return catalog_t::AttachFreely(catalog_path,
+    return CatalogTN::AttachFreely(catalog_path,
                                    path,
                                    catalog_hash,
                                    parent,
@@ -169,8 +169,8 @@ class LocalObjectFetcher :
   public AbstractObjectFetcher<LocalObjectFetcher<CatalogT, HistoryT> >
 {
  protected:
-  typedef LocalObjectFetcher<CatalogT, HistoryT> this_t;
-  typedef AbstractObjectFetcher<this_t>          base_t;
+  typedef LocalObjectFetcher<CatalogT, HistoryT> ThisTN;
+  typedef AbstractObjectFetcher<ThisTN>          BaseTN;
 
  public:
   /**
@@ -185,7 +185,7 @@ class LocalObjectFetcher :
     , temporary_directory_(temp_dir) {}
 
   manifest::Manifest* FetchManifest() {
-    return manifest::Manifest::LoadFile(BuildPath(base_t::kManifestFilename));
+    return manifest::Manifest::LoadFile(BuildPath(BaseTN::kManifestFilename));
   }
 
   bool Fetch(const shash::Any    &object_hash,
@@ -233,8 +233,8 @@ class LocalObjectFetcher :
 
 template <class CatalogT, class HistoryT>
 struct object_fetcher_traits<LocalObjectFetcher<CatalogT, HistoryT> > {
-    typedef CatalogT catalog_t;
-    typedef HistoryT history_t;
+    typedef CatalogT CatalogTN;
+    typedef HistoryT HistoryTN;
 };
 
 
@@ -249,8 +249,8 @@ class HttpObjectFetcher :
   public AbstractObjectFetcher<HttpObjectFetcher<CatalogT, HistoryT> >
 {
  protected:
-  typedef HttpObjectFetcher<CatalogT, HistoryT>  this_t;
-  typedef AbstractObjectFetcher<this_t>          base_t;
+  typedef HttpObjectFetcher<CatalogT, HistoryT>  ThisTN;
+  typedef AbstractObjectFetcher<ThisTN>          BaseTN;
 
  public:
   /**
@@ -277,7 +277,7 @@ class HttpObjectFetcher :
   manifest::Manifest* FetchManifest() {
     manifest::Manifest *manifest = NULL;
 
-    const std::string url = BuildUrl(base_t::kManifestFilename);
+    const std::string url = BuildUrl(BaseTN::kManifestFilename);
 
     // Download manifest file
     struct manifest::ManifestEnsemble manifest_ensemble;
@@ -354,8 +354,8 @@ class HttpObjectFetcher :
 
 template <class CatalogT, class HistoryT>
 struct object_fetcher_traits<HttpObjectFetcher<CatalogT, HistoryT> > {
-    typedef CatalogT catalog_t;
-    typedef HistoryT history_t;
+    typedef CatalogT CatalogTN;
+    typedef HistoryT HistoryTN;
 };
 
 #endif /* OBJECT_FETCHER_H */

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -189,7 +189,7 @@ bool CommandTag::CloseAndPublishHistory(Environment *env) {
 
   // compress and upload the new history database
   Future<shash::Any> history_hash;
-  upload::Spooler::callback_t* callback =
+  upload::Spooler::CallbackTN* callback =
     env->spooler->RegisterListener(&CommandTag::UploadClosure,
                                     this,
                                    &history_hash);
@@ -240,7 +240,7 @@ bool CommandTag::UploadCatalogAndUpdateManifest(
 
   // upload the catalog
   Future<shash::Any> catalog_hash;
-  upload::Spooler::callback_t* callback =
+  upload::Spooler::CallbackTN* callback =
     env->spooler->RegisterListener(&CommandTag::UploadClosure,
                                     this,
                                    &catalog_hash);

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -68,7 +68,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
                                                         SpoolerDefinition>,
                          public Callbackable<UploaderResults> {
  protected:
-  typedef Callbackable<UploaderResults>::callback_t* callback_ptr;
+  typedef Callbackable<UploaderResults>::CallbackTN* CallbackPtr;
 
   struct UploadJob {
     enum Type {
@@ -79,7 +79,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
     UploadJob(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
-              const callback_t    *callback = NULL) :
+              const CallbackTN    *callback = NULL) :
       type(Upload), stream_handle(handle), buffer(buffer), callback(callback),
       hash_suffix(shash::kSuffixNone) {}
 
@@ -98,7 +98,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
     // type=Upload specific fields
     CharBuffer          *buffer;
-    const callback_t    *callback;
+    const CallbackTN    *callback;
 
     // type=Commit specific fields
     shash::Any           content_hash;
@@ -138,7 +138,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    */
   void Upload(const std::string  &local_path,
               const std::string  &remote_path,
-              const callback_t   *callback = NULL) {
+              const CallbackTN   *callback = NULL) {
     ++jobs_in_flight_;
     FileUpload(local_path, remote_path, callback);
   }
@@ -156,7 +156,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    * @return           a pointer to the initialized UploadStreamHandle
    */
   virtual UploadStreamHandle* InitStreamedUpload(
-                                       const callback_t   *callback = NULL) = 0;
+                                       const CallbackTN   *callback = NULL) = 0;
 
 
   /**
@@ -176,7 +176,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    */
   void ScheduleUpload(UploadStreamHandle  *handle,
                       CharBuffer          *buffer,
-                      const callback_t    *callback = NULL) {
+                      const CallbackTN    *callback = NULL) {
     ++jobs_in_flight_;
     upload_queue_.push(UploadJob(handle, buffer, callback));
   }
@@ -258,7 +258,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
   virtual void FileUpload(const std::string  &local_path,
                           const std::string  &remote_path,
-                          const callback_t   *callback = NULL) = 0;
+                          const CallbackTN   *callback = NULL) = 0;
 
   /**
    * This notifies the callback that is associated to a finishing job. Please
@@ -269,7 +269,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    *       Therefore you must not call Respond() twice or use the callback later
    *       by any means!
    */
-  void Respond(const callback_t       *callback,
+  void Respond(const CallbackTN       *callback,
                const UploaderResults  &result) const {
     if (callback != NULL) {
       (*callback)(result);
@@ -360,13 +360,13 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
  * the streamed upload is committed.
  */
 struct UploadStreamHandle {
-  typedef AbstractUploader::callback_t callback_t;
+  typedef AbstractUploader::CallbackTN CallbackTN;
 
-  UploadStreamHandle(const callback_t *commit_callback) :
+  UploadStreamHandle(const CallbackTN *commit_callback) :
     commit_callback(commit_callback) {}
   virtual ~UploadStreamHandle() {}
 
-  const callback_t *commit_callback;
+  const CallbackTN *commit_callback;
 };
 
 

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -73,7 +73,7 @@ void LocalUploader::WorkerThread() {
 
 void LocalUploader::FileUpload(const std::string &local_path,
                                const std::string &remote_path,
-                               const callback_t   *callback) {
+                               const CallbackTN   *callback) {
 
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "FileUpload call started.");
 
@@ -139,7 +139,7 @@ int LocalUploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
 
 
 UploadStreamHandle* LocalUploader::InitStreamedUpload(
-                                                   const callback_t *callback) {
+                                                   const CallbackTN *callback) {
   std::string tmp_path;
   const int tmp_fd = CreateAndOpenTemporaryChunkFile(&tmp_path);
   if (tmp_fd < 0) {
@@ -152,7 +152,7 @@ UploadStreamHandle* LocalUploader::InitStreamedUpload(
 
 void LocalUploader::Upload(UploadStreamHandle  *handle,
                            CharBuffer          *buffer,
-                           const callback_t    *callback) {
+                           const CallbackTN    *callback) {
   assert (buffer->IsInitialized());
   LocalStreamHandle *local_handle = static_cast<LocalStreamHandle*>(handle);
 
@@ -208,7 +208,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
     return;
   }
 
-  const callback_t *callback = handle->commit_callback;
+  const CallbackTN *callback = handle->commit_callback;
   delete local_handle;
 
   Respond(callback, UploaderResults(0));

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -15,7 +15,7 @@
 namespace upload
 {
   struct LocalStreamHandle : public UploadStreamHandle {
-    LocalStreamHandle(const callback_t   *commit_callback,
+    LocalStreamHandle(const CallbackTN   *commit_callback,
                       const int           tmp_fd,
                       const std::string  &tmp_path) :
       UploadStreamHandle(commit_callback),
@@ -52,12 +52,12 @@ namespace upload
      */
     void FileUpload(const std::string  &local_path,
                     const std::string  &remote_path,
-                    const callback_t   *callback = NULL);
+                    const CallbackTN   *callback = NULL);
 
-    UploadStreamHandle* InitStreamedUpload(const callback_t *callback = NULL);
+    UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
     void Upload(UploadStreamHandle  *handle,
                 CharBuffer          *buffer,
-                const callback_t    *callback = NULL);
+                const CallbackTN    *callback = NULL);
     void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                                 const shash::Any     content_hash,
                                 const shash::Suffix  hash_suffix);

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -203,10 +203,10 @@ void S3Uploader::WorkerThread() {
       s3fanout::JobInfo *info = *it;
       if (info->error_code == s3fanout::kFailOk) {
         if (info->origin == s3fanout::kOriginMem) {
-          Respond(static_cast<callback_t*>(info->callback),
+          Respond(static_cast<CallbackTN*>(info->callback),
           UploaderResults(0));
         } else {
-          Respond(static_cast<callback_t*>(info->callback),
+          Respond(static_cast<CallbackTN*>(info->callback),
                   UploaderResults(0, info->mmf->file_path()));
         }
       } else {
@@ -215,7 +215,7 @@ void S3Uploader::WorkerThread() {
                  info->origin_path.c_str(), info->error_code,
                  s3fanout::Code2Ascii(info->error_code));
 
-        Respond(static_cast<callback_t*>(info->callback),
+        Respond(static_cast<CallbackTN*>(info->callback),
                 UploaderResults(99, info->mmf->file_path()));
       }
       info->mmf->Unmap();
@@ -340,7 +340,7 @@ int S3Uploader::SelectBucket(const std::string &rem_filename) const {
 
 void S3Uploader::FileUpload(const std::string &local_path,
                             const std::string &remote_path,
-                            const callback_t  *callback) {
+                            const CallbackTN  *callback) {
   // Check that we can read the given file
   MemoryMappedFile *mmf = new MemoryMappedFile(local_path);
   if (!mmf->Map()) {
@@ -377,7 +377,7 @@ void S3Uploader::FileUpload(const std::string &local_path,
 bool S3Uploader::UploadFile(const std::string &filename,
                             char              *buff,
                             unsigned long     size_of_file,
-                            const callback_t  *callback,
+                            const CallbackTN  *callback,
                             MemoryMappedFile  *mmf)
 {
   // Choose S3 account and bucket based on the filename
@@ -456,7 +456,7 @@ int S3Uploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
 }
 
 
-UploadStreamHandle *S3Uploader::InitStreamedUpload(const callback_t *callback) {
+UploadStreamHandle *S3Uploader::InitStreamedUpload(const CallbackTN *callback) {
   std::string tmp_path;
   const int tmp_fd = CreateAndOpenTemporaryChunkFile(&tmp_path);
 
@@ -477,7 +477,7 @@ UploadStreamHandle *S3Uploader::InitStreamedUpload(const callback_t *callback) {
 
 void S3Uploader::Upload(UploadStreamHandle  *handle,
                         CharBuffer          *buffer,
-                        const callback_t    *callback) {
+                        const CallbackTN    *callback) {
   assert(buffer->IsInitialized());
   S3StreamHandle *local_handle = static_cast<S3StreamHandle*>(handle);
 
@@ -536,7 +536,7 @@ void S3Uploader::FinalizeStreamedUpload(UploadStreamHandle   *handle,
                          content_hash.MakePathWithSuffix(1, 2, hash_suffix));
 
   // Request upload
-  const callback_t *callback = handle->commit_callback;
+  const CallbackTN *callback = handle->commit_callback;
   const bool retval_b = UploadFile(final_path,
                                    reinterpret_cast<char*>(mmf->buffer()),
                                    static_cast<long unsigned int>(mmf->size()),

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -15,7 +15,7 @@
 namespace upload {
 
 struct S3StreamHandle : public UploadStreamHandle {
-    S3StreamHandle(const callback_t   *commit_callback,
+    S3StreamHandle(const CallbackTN   *commit_callback,
                    const int           tmp_fd,
                    const std::string  &tmp_path) :
     UploadStreamHandle(commit_callback),
@@ -50,12 +50,12 @@ class S3Uploader : public AbstractUploader {
    */
   void FileUpload(const std::string  &local_path,
                   const std::string  &remote_path,
-                  const callback_t   *callback = NULL);
+                  const CallbackTN   *callback = NULL);
 
-  UploadStreamHandle* InitStreamedUpload(const callback_t *callback = NULL);
+  UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
   void Upload(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
-              const callback_t    *callback = NULL);
+              const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle   *handle,
                               const shash::Any     &content_hash,
                               const shash::Suffix   hash_suffix);
@@ -79,7 +79,7 @@ class S3Uploader : public AbstractUploader {
   bool UploadFile(const std::string &filename,
                   char              *buff,
                   unsigned long      size_of_file,
-                  const callback_t  *callback,
+                  const CallbackTN  *callback,
                   MemoryMappedFile  *mmf);
 
   int GetKeysAndBucket(const std::string  &filename,

--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -569,7 +569,7 @@ class BoundClosure<void, DelegateT, ClosureDataT> : public CallbackBase<void> {
 template <class ParamT>
 class Callbackable {
  public:
-  typedef CallbackBase<ParamT> callback_t;
+  typedef CallbackBase<ParamT> CallbackTN;
 
  public:
   /**
@@ -581,7 +581,7 @@ class Callbackable {
    * @param closure_data  The closure data to be passed along to <method>
    */
   template <class DelegateT, typename ClosureDataT>
-  static callback_t* MakeClosure(
+  static CallbackTN* MakeClosure(
       typename BoundClosure<ParamT, DelegateT, ClosureDataT>::CallbackMethod method,
       DelegateT           *delegate,
       const ClosureDataT  &closure_data) {
@@ -597,7 +597,7 @@ class Callbackable {
    * @param delegate  The delegate object on which <method> will be called
    */
   template <class DelegateT>
-  static callback_t* MakeCallback(
+  static CallbackTN* MakeCallback(
         typename BoundCallback<ParamT, DelegateT>::CallbackMethod method,
         DelegateT *delegate) {
     return new BoundCallback<ParamT, DelegateT>(method, delegate);
@@ -609,7 +609,7 @@ class Callbackable {
    *
    * @param function  Function pointer to the function to be invoked
    */
-  static callback_t* MakeCallback(
+  static CallbackTN* MakeCallback(
         typename Callback<ParamT>::CallbackFunction function) {
     return new Callback<ParamT>(function);
   }

--- a/cvmfs/util_concurrency.h
+++ b/cvmfs/util_concurrency.h
@@ -312,8 +312,8 @@ template <typename ParamT>
 class Observable : public Callbackable<ParamT>,
                    SingleCopy {
  protected:
-  typedef typename Callbackable<ParamT>::callback_t*  callback_ptr;
-  typedef std::set<callback_ptr>                      Callbacks;
+  typedef typename Callbackable<ParamT>::CallbackTN*  CallbackPtr;
+  typedef std::set<CallbackPtr>                       Callbacks;
 
  public:
   virtual ~Observable();
@@ -332,7 +332,7 @@ class Observable : public Callbackable<ParamT>,
    * @return  a handle to the registered callback
    */
   template <class DelegateT, class ClosureDataT>
-  callback_ptr RegisterListener(
+  CallbackPtr RegisterListener(
           typename BoundClosure<ParamT,
                                 DelegateT,
                                 ClosureDataT>::CallbackMethod   method,
@@ -350,7 +350,7 @@ class Observable : public Callbackable<ParamT>,
    * @return  a handle to the registered callback
    */
   template <class DelegateT>
-  callback_ptr RegisterListener(
+  CallbackPtr RegisterListener(
           typename BoundCallback<ParamT, DelegateT>::CallbackMethod method,
           DelegateT *delegate);
 
@@ -362,7 +362,7 @@ class Observable : public Callbackable<ParamT>,
    * @param fn  a pointer to the function to be called by the callback
    * @return  a handle to the registered callback
    */
-  callback_ptr RegisterListener(typename Callback<ParamT>::CallbackFunction fn);
+  CallbackPtr RegisterListener(typename Callback<ParamT>::CallbackFunction fn);
 
   /**
    * Removes the given callback from the listeners group of this Observable.
@@ -370,7 +370,7 @@ class Observable : public Callbackable<ParamT>,
    * @param callback_object  a callback handle that was returned by
    *                         RegisterListener() before.
    */
-  void UnregisterListener(callback_ptr callback_object);
+  void UnregisterListener(CallbackPtr callback_object);
 
   /**
    * Removes all listeners from the Observable
@@ -380,7 +380,7 @@ class Observable : public Callbackable<ParamT>,
  protected:
   Observable(); // don't instantiate this as a stand alone object
 
-  void RegisterListener(callback_ptr callback_object);
+  void RegisterListener(CallbackPtr callback_object);
 
   /**
    * Notifies all registered listeners and passes them the provided argument

--- a/cvmfs/util_concurrency_impl.h
+++ b/cvmfs/util_concurrency_impl.h
@@ -136,7 +136,7 @@ Observable<ParamT>::~Observable() {
 
 template <typename ParamT>
 template <class DelegateT, class ClosureDataT>
-typename Observable<ParamT>::callback_ptr Observable<ParamT>::RegisterListener(
+typename Observable<ParamT>::CallbackPtr Observable<ParamT>::RegisterListener(
         typename BoundClosure<ParamT,
                               DelegateT,
                               ClosureDataT>::CallbackMethod   method,
@@ -152,7 +152,7 @@ typename Observable<ParamT>::callback_ptr Observable<ParamT>::RegisterListener(
 
 template <typename ParamT>
 template <class DelegateT>
-typename Observable<ParamT>::callback_ptr Observable<ParamT>::RegisterListener(
+typename Observable<ParamT>::CallbackPtr Observable<ParamT>::RegisterListener(
     typename BoundCallback<ParamT, DelegateT>::CallbackMethod method,
     DelegateT *delegate) {
   // create a new BoundCallback, register it and return the handle
@@ -164,7 +164,7 @@ typename Observable<ParamT>::callback_ptr Observable<ParamT>::RegisterListener(
 
 
 template <typename ParamT>
-typename Observable<ParamT>::callback_ptr Observable<ParamT>::RegisterListener(
+typename Observable<ParamT>::CallbackPtr Observable<ParamT>::RegisterListener(
     typename Callback<ParamT>::CallbackFunction fn) {
   // create a new Callback, register it and return the handle
   CallbackBase<ParamT> *callback =
@@ -176,7 +176,7 @@ typename Observable<ParamT>::callback_ptr Observable<ParamT>::RegisterListener(
 
 template <typename ParamT>
 void Observable<ParamT>::RegisterListener(
-    Observable<ParamT>::callback_ptr callback_object) {
+    Observable<ParamT>::CallbackPtr callback_object) {
   // register a generic CallbackBase callback
   WriteLockGuard guard(listeners_rw_lock_);
   listeners_.insert(callback_object);
@@ -185,7 +185,7 @@ void Observable<ParamT>::RegisterListener(
 
 template <typename ParamT>
 void Observable<ParamT>::UnregisterListener(
-    typename Observable<ParamT>::callback_ptr callback_object) {
+    typename Observable<ParamT>::CallbackPtr callback_object) {
   // remove a callback handle from the callbacks list
   // if it is not registered --> crash
   WriteLockGuard guard(listeners_rw_lock_);

--- a/test/unittests/t_callbacks.cc
+++ b/test/unittests/t_callbacks.cc
@@ -154,7 +154,7 @@ int DummyCallbackableVoid::g_void_callback_calls = 0;
 TEST(T_Callbacks, CallbackableCallback) {
   ASSERT_EQ (-1, DummyCallbackable::g_callback_result);
 
-  DummyCallbackable::callback_t *callback =
+  DummyCallbackable::CallbackTN *callback =
     DummyCallbackable::MakeCallback(&DummyCallbackable::CallbackFn);
   EXPECT_EQ (-1, DummyCallbackable::g_callback_result);
 
@@ -169,7 +169,7 @@ TEST(T_Callbacks, CallbackableBoundCallback) {
   DummyCallbackable callbackable;
   ASSERT_EQ (-1, callbackable.callback_result);
 
-  DummyCallbackable::callback_t *callback =
+  DummyCallbackable::CallbackTN *callback =
     DummyCallbackable::MakeCallback(&DummyCallbackable::CallbackMd,
                                     &callbackable);
   (*callback)(1337);
@@ -184,7 +184,7 @@ TEST(T_Callbacks, CallbackableBoundClosure) {
   ClosureData closure_data;
   ASSERT_EQ (closure_data_item, closure_data.data);
 
-  DummyCallbackable::callback_t *callback =
+  DummyCallbackable::CallbackTN *callback =
     DummyCallbackable::MakeClosure(&DummyCallbackable::CallbackClosureMd,
                                    &callbackable,
                                     closure_data);
@@ -200,7 +200,7 @@ TEST(T_Callbacks, CallbackableBoundClosure) {
 TEST(T_Callbacks, CallbackableVoidCallback) {
   ASSERT_EQ (0, DummyCallbackableVoid::g_void_callback_calls);
 
-  DummyCallbackableVoid::callback_t *callback =
+  DummyCallbackableVoid::CallbackTN *callback =
     DummyCallbackableVoid::MakeCallback(&DummyCallbackableVoid::CallbackFn);
   EXPECT_EQ (0, DummyCallbackableVoid::g_void_callback_calls);
 
@@ -219,7 +219,7 @@ TEST(T_Callbacks, CallbackableVoidBoundCallback) {
   DummyCallbackableVoid callbackable;
   ASSERT_EQ (-1, callbackable.callback_result);
 
-  DummyCallbackableVoid::callback_t *callback =
+  DummyCallbackableVoid::CallbackTN *callback =
     DummyCallbackableVoid::MakeCallback(&DummyCallbackableVoid::CallbackMd,
                                         &callbackable);
   EXPECT_EQ (-1, callbackable.callback_result);
@@ -237,7 +237,7 @@ TEST(T_Callbacks, CallbackableVoidBoundClosure) {
   ClosureData closure_data;
   ASSERT_EQ (closure_data_item, closure_data.data);
 
-  DummyCallbackableVoid::callback_t *callback =
+  DummyCallbackableVoid::CallbackTN *callback =
     DummyCallbackableVoid::MakeClosure(&DummyCallbackableVoid::CallbackClosureMd,
                                        &callbackable,
                                         closure_data);

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -408,7 +408,7 @@ TEST_F(T_CatalogTraversal, Initialize) {
 
 
 CatalogIdentifiers SimpleTraversal_visited_catalogs;
-void SimpleTraversalCallback(const MockedCatalogTraversal::callback_data_t &data) {
+void SimpleTraversalCallback(const MockedCatalogTraversal::CallbackDataTN &data) {
   SimpleTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -458,7 +458,7 @@ TEST_F(T_CatalogTraversal, SimpleTraversal) {
 
 std::vector<MockCatalog*> SimpleTraversalNoCloseCallback_visited_catalogs;
 void SimpleTraversalNoCloseCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   SimpleTraversalNoCloseCallback_visited_catalogs.push_back(
     const_cast<MockCatalog*>(data.catalog));
 }
@@ -494,7 +494,7 @@ TEST_F(T_CatalogTraversal, SimpleTraversalNoClose) {
 
 CatalogIdentifiers ZeroLevelHistoryTraversal_visited_catalogs;
 void ZeroLevelHistoryTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   ZeroLevelHistoryTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -545,7 +545,7 @@ TEST_F(T_CatalogTraversal, ZeroLevelHistoryTraversal) {
 
 CatalogIdentifiers FirstLevelHistoryTraversal_visited_catalogs;
 void FirstLevelHistoryTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FirstLevelHistoryTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -624,7 +624,7 @@ TEST_F(T_CatalogTraversal, FirstLevelHistoryTraversal) {
 
 std::vector<MockCatalog*> FirstLevelHistoryTraversalNoClose_visited_catalogs;
 void FirstLevelHistoryTraversalNoCloseCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FirstLevelHistoryTraversalNoClose_visited_catalogs.push_back(
                                         const_cast<MockCatalog*>(data.catalog));
 }
@@ -660,7 +660,7 @@ TEST_F(T_CatalogTraversal, FirstLevelHistoryTraversalNoClose) {
 
 CatalogIdentifiers SecondLevelHistoryTraversal_visited_catalogs;
 void SecondLevelHistoryTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   SecondLevelHistoryTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -764,7 +764,7 @@ TEST_F(T_CatalogTraversal, SecondLevelHistoryTraversal) {
 
 CatalogIdentifiers FullHistoryTraversal_visited_catalogs;
 void FullHistoryTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FullHistoryTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -894,7 +894,7 @@ TEST_F(T_CatalogTraversal, FullHistoryTraversal) {
 
 CatalogIdentifiers SecondLevelHistoryTraversalNoRepeat_visited_catalogs;
 void SecondLevelHistoryTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   SecondLevelHistoryTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -955,7 +955,7 @@ TEST_F(T_CatalogTraversal, SecondLevelHistoryTraversalNoRepeat) {
 
 CatalogIdentifiers FullHistoryTraversalNoRepeat_visited_catalogs;
 void FullHistoryTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FullHistoryTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1030,7 +1030,7 @@ TEST_F(T_CatalogTraversal, FullHistoryTraversalNoRepeat) {
 
 CatalogIdentifiers MultiTraversal_visited_catalogs;
 void MultiTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   MultiTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1126,7 +1126,7 @@ TEST_F(T_CatalogTraversal, MultiTraversal) {
 
 CatalogIdentifiers MultiTraversalNoRepeat_visited_catalogs;
 void MultiTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   MultiTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1199,7 +1199,7 @@ TEST_F(T_CatalogTraversal, MultiTraversalNoRepeat) {
 
 CatalogIdentifiers MultiTraversalFirstLevelHistory_visited_catalogs;
 void MultiTraversalFirstLevelHistoryCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   MultiTraversalFirstLevelHistory_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1342,7 +1342,7 @@ TEST_F(T_CatalogTraversal, MultiTraversalFirstLevelHistory) {
 
 CatalogIdentifiers MultiTraversalFirstLevelHistoryNoRepeat_visited_catalogs;
 void MultiTraversalFirstLevelHistoryNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   MultiTraversalFirstLevelHistoryNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1428,7 +1428,7 @@ TEST_F(T_CatalogTraversal, MultiTraversalFirstLevelHistoryNoRepeat) {
 
 CatalogIdentifiers EmptyTraversePruned_visited_catalogs;
 void EmptyTraversePrunedCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   EmptyTraversePruned_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1458,7 +1458,7 @@ TEST_F(T_CatalogTraversal, EmptyTraversePruned) {
 
 CatalogIdentifiers TraversePrunedAfterSimpleTraversal_visited_catalogs;
 void TraversePrunedAfterSimpleTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraversePrunedAfterSimpleTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1599,7 +1599,7 @@ TEST_F(T_CatalogTraversal, TraversePrunedAfterSimpleTraversal) {
 
 CatalogIdentifiers TraversePrunedAfterSimpleTraversalNoRepeat_visited_catalogs;
 void TraversePrunedAfterSimpleTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraversePrunedAfterSimpleTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1683,7 +1683,7 @@ TEST_F(T_CatalogTraversal, TraversePrunedAfterSimpleTraversalNoRepeat) {
 
 CatalogIdentifiers TraversePrunedAfterSecondLevelHistoryTraversalNoRepeat_visited_catalogs;
 void TraversePrunedAfterSecondLevelHistoryTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraversePrunedAfterSecondLevelHistoryTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1767,7 +1767,7 @@ TEST_F(T_CatalogTraversal, TraversePrunedAfterSecondLevelHistoryTraversalNoRepea
 
 CatalogIdentifiers TraversePrunedAfterMultiTraversalNoRepeat_visited_catalogs;
 void TraversePrunedAfterMultiTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraversePrunedAfterMultiTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1864,7 +1864,7 @@ TEST_F(T_CatalogTraversal, TraversePrunedAfterMultiTraversalNoRepeat) {
 
 CatalogIdentifiers TraverseRepositoryTagList_visited_catalogs;
 void TraverseRepositoryTagListCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraverseRepositoryTagList_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -1952,7 +1952,7 @@ TEST_F(T_CatalogTraversal, TraverseRepositoryTagList) {
 
 CatalogIdentifiers TraverseRepositoryTagListSecondHistoryLevel_visited_catalogs;
 void TraverseRepositoryTagListSecondHistoryLevelCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraverseRepositoryTagListSecondHistoryLevel_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2042,7 +2042,7 @@ TEST_F(T_CatalogTraversal, TraverseRepositoryTagListSecondHistoryLevel) {
 
 CatalogIdentifiers TraverseRepositoryTagListSecondHistoryLevelNoRepeat_visited_catalogs;
 void TraverseRepositoryTagListSecondHistoryLevelNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraverseRepositoryTagListSecondHistoryLevelNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2106,7 +2106,7 @@ TEST_F(T_CatalogTraversal, TraverseRepositoryTagListSecondHistoryLevelNoRepeat) 
 
 CatalogIdentifiers TraverseRepositoryTagListFirstLevelHistoryTraversePrunedNoRepeat_visited_catalogs;
 void TraverseRepositoryTagListFirstLevelHistoryTraversePrunedNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraverseRepositoryTagListFirstLevelHistoryTraversePrunedNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2190,7 +2190,7 @@ TEST_F(T_CatalogTraversal, TraverseRepositoryTagListFirstLevelHistoryTraversePru
 
 CatalogIdentifiers TraverseUntilUnavailableRevisionNoRepeat_visited_catalogs;
 void TraverseUntilUnavailableRevisionNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraverseUntilUnavailableRevisionNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2259,7 +2259,7 @@ TEST_F(T_CatalogTraversal, TraverseUntilUnavailableRevisionNoRepeat) {
 
 CatalogIdentifiers UnavailableNestedNoRepeat_visited_catalogs;
 void UnavailableNestedNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   UnavailableNestedNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2328,7 +2328,7 @@ TEST_F(T_CatalogTraversal, UnavailableNestedNoRepeat) {
 
 CatalogIdentifiers DepthFirstSearchFullHistoryTraversalNoRepeat_visited_catalogs;
 void DepthFirstSearchFullHistoryTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   DepthFirstSearchFullHistoryTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2404,7 +2404,7 @@ TEST_F(T_CatalogTraversal, DepthFirstSearchFullHistoryTraversalNoRepeat) {
 
 CatalogIdentifiers FullHistoryDepthFirstTraversal_visited_catalogs;
 void FullHistoryDepthFirstTraversalCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FullHistoryDepthFirstTraversal_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2535,7 +2535,7 @@ TEST_F(T_CatalogTraversal, FullHistoryDepthFirstTraversal) {
 
 CatalogIdentifiers DepthFirstTraversePrunedAfterMultiTraversalNoRepeat_visited_catalogs;
 void DepthFirstTraversePrunedAfterMultiTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   DepthFirstTraversePrunedAfterMultiTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2628,7 +2628,7 @@ TEST_F(T_CatalogTraversal, DepthFirstTraversePrunedAfterMultiTraversalNoRepeat) 
 
 CatalogIdentifiers DepthFirstTraversalSequence_visited_catalogs;
 void DepthFirstTraversalSequenceCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   DepthFirstTraversalSequence_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2669,7 +2669,7 @@ TEST_F(T_CatalogTraversal, DepthFirstTraversalSequence) {
 
 CatalogIdentifiers FullHistoryDepthFirstTraversalUnavailableAncestor_visited_catalogs;
 void FullHistoryDepthFirstTraversalUnavailableAncestorCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FullHistoryDepthFirstTraversalUnavailableAncestor_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2794,7 +2794,7 @@ TEST_F(T_CatalogTraversal, FullHistoryDepthFirstTraversalUnavailableAncestor) {
 
 
 void FullTraversalRootCatalogDetectionCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   const bool should_be_root = (data.catalog->path().ToString() == "" ||
                                data.tree_level                 == 0);
   EXPECT_EQ (should_be_root, data.catalog->IsRoot());
@@ -2818,7 +2818,7 @@ TEST_F(T_CatalogTraversal, FullTraversalRootCatalogDetection) {
 
 CatalogIdentifiers TimestampThreshold_visited_catalogs;
 void TimestampThresholdCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThreshold_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2899,7 +2899,7 @@ TEST_F(T_CatalogTraversal, TimestampThreshold) {
 
 CatalogIdentifiers FutureTimestampThreshold_visited_catalogs;
 void FutureTimestampThresholdCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   FutureTimestampThreshold_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -2952,7 +2952,7 @@ TEST_F(T_CatalogTraversal, FutureTimestampThreshold) {
 
 CatalogIdentifiers TimestampThresholdAndNamedSnapshots_visited_catalogs;
 void TimestampThresholdAndNamedSnapshotsCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThresholdAndNamedSnapshots_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3042,7 +3042,7 @@ TEST_F(T_CatalogTraversal, TimestampThresholdAndNamedSnapshots) {
 
 CatalogIdentifiers TraversePrunedAfterTimestampThresholdHistoryDepthAndNamedSnapshotsAndAfterHeadTraversalNoRepeat_visited_catalogs;
 void TraversePrunedAfterTimestampThresholdHistoryDepthAndNamedSnapshotsAndAfterHeadTraversalNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraversePrunedAfterTimestampThresholdHistoryDepthAndNamedSnapshotsAndAfterHeadTraversalNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3135,7 +3135,7 @@ TEST_F(T_CatalogTraversal, TraversePrunedAfterTimestampThresholdHistoryDepthAndN
 
 CatalogIdentifiers TimestampThresholdDepthFirst_visited_catalogs;
 void TimestampThresholdDepthFirstCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThresholdDepthFirst_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3215,7 +3215,7 @@ TEST_F(T_CatalogTraversal, TimestampThresholdDepthFirst) {
 
 CatalogIdentifiers TimestampThresholdDepthFirstAndTraversePruned_visited_catalogs;
 void TimestampThresholdDepthFirstAndTraversePrunedCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThresholdDepthFirstAndTraversePruned_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3355,7 +3355,7 @@ TEST_F(T_CatalogTraversal, TimestampThresholdDepthFirstAndTraversePruned) {
 
 CatalogIdentifiers TimestampThresholdHistoryDepthAndNamedSnapshotsDepthFirstNoRepeat_visited_catalogs;
 void TimestampThresholdHistoryDepthAndNamedSnapshotsDepthFirstNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThresholdHistoryDepthAndNamedSnapshotsDepthFirstNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3419,7 +3419,7 @@ TEST_F(T_CatalogTraversal, TimestampThresholdHistoryDepthDepthFirstAndNamedSnaps
 
 CatalogIdentifiers TimestampThresholdHistoryDepthNamedSnapshotsDeletedRevisionDepthFirstNoRepeat_visited_catalogs;
 void TimestampThresholdHistoryDepthNamedSnapshotsDeletedRevisionDepthFirstNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThresholdHistoryDepthNamedSnapshotsDeletedRevisionDepthFirstNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3487,7 +3487,7 @@ TEST_F(T_CatalogTraversal, TimestampThresholdHistoryDepthNamedSnapshotsDeletedRe
 
 CatalogIdentifiers TimestampThresholdHistoryDepthNamedSnapshotsDeletedRevisionDepthFirstNoRepeatTraversePruned_visited_catalogs;
 void TimestampThresholdHistoryDepthNamedSnapshotsDeletedRevisionDepthFirstNoRepeatTraversePrunedCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TimestampThresholdHistoryDepthNamedSnapshotsDeletedRevisionDepthFirstNoRepeatTraversePruned_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3566,7 +3566,7 @@ TEST_F(T_CatalogTraversal, TimestampThresholdHistoryDepthNamedSnapshotsDeletedRe
 
 CatalogIdentifiers NamedSnapshotTraversalWithTimestampThresholdNoRepeat_visited_catalogs;
 void NamedSnapshotTraversalWithTimestampThresholdNoRepeatCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   NamedSnapshotTraversalWithTimestampThresholdNoRepeat_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }
@@ -3635,7 +3635,7 @@ TEST_F(T_CatalogTraversal, NamedSnapshotTraversalWithTimestampThresholdNoRepeat)
 
 CatalogIdentifiers TraverseNamedSnapshotsWithoutHistory_visited_catalogs;
 void TraverseNamedSnapshotsWithoutHistoryCallback(
-                             const MockedCatalogTraversal::callback_data_t &data) {
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
   TraverseNamedSnapshotsWithoutHistory_visited_catalogs.push_back(
     std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
 }

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -16,7 +16,7 @@
 #include "testutil.h"
 
 struct MockStreamHandle : public upload::UploadStreamHandle {
-  MockStreamHandle(const callback_t *commit_callback) :
+  MockStreamHandle(const CallbackTN *commit_callback) :
     UploadStreamHandle(commit_callback),
     data(NULL), nbytes(0), marker(0) {}
 
@@ -112,13 +112,13 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
   }
 
   upload::UploadStreamHandle* InitStreamedUpload(
-                                            const callback_t *callback = NULL) {
+                                            const CallbackTN *callback = NULL) {
     return new MockStreamHandle(callback);
   }
 
   void Upload(upload::UploadStreamHandle  *handle,
               upload::CharBuffer          *buffer,
-              const callback_t            *callback = NULL) {
+              const CallbackTN            *callback = NULL) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
     assert (local_handle != NULL);
     local_handle->Append(buffer);
@@ -136,7 +136,7 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
     results_.push_back(Result(local_handle, content_hash, hash_suffix));
 
     // remove the stream handle and fire callback
-    const callback_t *callback = local_handle->commit_callback;
+    const CallbackTN *callback = local_handle->commit_callback;
     delete handle;
     Respond(callback, upload::UploaderResults(0));
   }

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -25,13 +25,13 @@ class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
     AbstractMockUploader<GC_MockUploader>(spooler_definition) {}
 
   upload::UploadStreamHandle* InitStreamedUpload(
-                                            const callback_t *callback = NULL) {
+                                            const CallbackTN *callback = NULL) {
     return NULL;
   }
 
   void Upload(upload::UploadStreamHandle  *abstract_handle,
               upload::CharBuffer          *buffer,
-              const callback_t            *callback = NULL) {
+              const CallbackTN            *callback = NULL) {
     assert (AbstractMockUploader<GC_MockUploader>::not_implemented);
   }
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -388,7 +388,7 @@ class T_ObjectFetcher : public ::testing::Test {
     ASSERT_FALSE (tmp_path.empty()) << "failed to create tmp in: " << sandbox;
 
     history::SqliteHistory *history =
-                              ObjectFetcherT::history_t::Create(tmp_path, fqrn);
+                              ObjectFetcherT::HistoryTN::Create(tmp_path, fqrn);
     ASSERT_NE (static_cast<history::SqliteHistory*>(NULL), history) <<
       "failed to create new history database in: " << tmp_path;
     history->SetPreviousRevision(previous_revision);
@@ -584,7 +584,7 @@ TYPED_TEST(T_ObjectFetcher, FetchHistory) {
 
   EXPECT_TRUE (object_fetcher->HasHistory());
 
-  UniquePtr<typename TypeParam::history_t> history(object_fetcher->FetchHistory());
+  UniquePtr<typename TypeParam::HistoryTN> history(object_fetcher->FetchHistory());
   ASSERT_TRUE (history.IsValid());
   EXPECT_EQ (TestFixture::previous_history_hash, history->previous_revision());
 }
@@ -594,7 +594,7 @@ TYPED_TEST(T_ObjectFetcher, FetchLegacyHistory) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
-  UniquePtr<typename TypeParam::history_t> history(
+  UniquePtr<typename TypeParam::HistoryTN> history(
               object_fetcher->FetchHistory(TestFixture::previous_history_hash));
   ASSERT_TRUE (history.IsValid())
     << "didn't find: " << TestFixture::previous_history_hash.ToStringWithSuffix();
@@ -606,7 +606,7 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidHistory) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
-  UniquePtr<typename TypeParam::history_t> history(
+  UniquePtr<typename TypeParam::HistoryTN> history(
       object_fetcher->FetchHistory(h("400d35465f179a4acacb5fe749e6ce20a0bbdb84",
                                      shash::kSuffixHistory)));
   ASSERT_FALSE (history.IsValid());
@@ -617,7 +617,7 @@ TYPED_TEST(T_ObjectFetcher, FetchCatalog) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
-  UniquePtr<typename TypeParam::catalog_t> catalog(
+  UniquePtr<typename TypeParam::CatalogTN> catalog(
     object_fetcher->FetchCatalog(TestFixture::root_hash, ""));
 
   ASSERT_TRUE (catalog.IsValid());
@@ -630,7 +630,7 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalog) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
-  UniquePtr<typename TypeParam::catalog_t> catalog(
+  UniquePtr<typename TypeParam::CatalogTN> catalog(
     object_fetcher->FetchCatalog(h("5739dc30f42525a261b2f4b383b220df3e36f04d",
                                    shash::kSuffixCatalog), ""));
   ASSERT_FALSE (catalog.IsValid());

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -12,7 +12,7 @@ using namespace upload;
 
 
 struct UF_MockStreamHandle : public upload::UploadStreamHandle {
-  UF_MockStreamHandle(const callback_t *commit_callback) :
+  UF_MockStreamHandle(const CallbackTN *commit_callback) :
     UploadStreamHandle(commit_callback),
     commits(0), uploads(0)
   {
@@ -43,7 +43,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     initialize_called(false) {}
 
   upload::UploadStreamHandle* InitStreamedUpload(
-                                            const callback_t *callback = NULL) {
+                                            const CallbackTN *callback = NULL) {
     return new UF_MockStreamHandle(callback);
   }
 
@@ -55,7 +55,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
 
   void Upload(upload::UploadStreamHandle  *abstract_handle,
               upload::CharBuffer          *buffer,
-              const callback_t            *callback = NULL) {
+              const CallbackTN            *callback = NULL) {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->uploads++;
@@ -68,7 +68,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->commits++;
-    const UF_MockStreamHandle::callback_t *callback = handle->commit_callback;
+    const UF_MockStreamHandle::CallbackTN *callback = handle->commit_callback;
     delete handle;
     Respond(callback, UploaderResults(0));
   }

--- a/test/unittests/t_util_concurrency.cc
+++ b/test/unittests/t_util_concurrency.cc
@@ -215,14 +215,14 @@ TEST(T_UtilConcurrency, Observable) {
   ASSERT_EQ (-1, observer.observation_result);
   ASSERT_EQ (-1, g_fn_observation_result);
 
-  DummyObservable::callback_t *bound_callback =
+  DummyObservable::CallbackTN *bound_callback =
     observee.RegisterListener(&DummyObserver::CallbackMd, &observer);
-  DummyObservable::callback_t *closure_callback =
+  DummyObservable::CallbackTN *closure_callback =
     observee.RegisterListener(&DummyObserver::ClosureMd, &observer, 123);
-  DummyObservable::callback_t *static_callback =
+  DummyObservable::CallbackTN *static_callback =
     observee.RegisterListener(&ObserverFn);
 
-  static const DummyObservable::callback_t *null_clb = NULL;
+  static const DummyObservable::CallbackTN *null_clb = NULL;
 
   ASSERT_NE (null_clb, bound_callback);
   ASSERT_NE (null_clb, closure_callback);

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -131,19 +131,19 @@ class AbstractMockUploader : public upload::AbstractUploader {
 
   virtual void FileUpload(const std::string  &local_path,
                           const std::string  &remote_path,
-                          const callback_t   *callback = NULL) {
+                          const CallbackTN   *callback = NULL) {
     assert (AbstractMockUploader::not_implemented);
   }
 
   virtual upload::UploadStreamHandle* InitStreamedUpload(
-                                            const callback_t *callback = NULL) {
+                                            const CallbackTN *callback = NULL) {
     assert (AbstractMockUploader::not_implemented);
     return NULL;
   }
 
   virtual void Upload(upload::UploadStreamHandle  *handle,
                       upload::CharBuffer          *buffer,
-                      const callback_t            *callback = NULL) {
+                      const CallbackTN            *callback = NULL) {
     assert (AbstractMockUploader::not_implemented);
   }
 
@@ -524,8 +524,8 @@ class MockObjectFetcher;
 
 template <>
 struct object_fetcher_traits<MockObjectFetcher> {
-  typedef MockCatalog catalog_t;
-  typedef MockHistory history_t;
+  typedef MockCatalog CatalogTN;
+  typedef MockHistory HistoryTN;
 };
 
 /**


### PR DESCRIPTION

I'd define a dependent type as a type that is dependent on a class template parameter. In the case below, `Foo<T>::VectorTN` would be a dependent type in `Foo<>` and can be used as:

```C++
template<typename T>
class Foo {
 public:
  typedef std::vector<T> VectorTN;
};

int main() {
  typedef Foo<int> FooInt;
  FooInt foo;
  FooInt::VectorTN foo_int_vector;
  return 0;
}
```

Instead of writing `dependent_type_name_t` for a dependent type this changes the convention to `DependentTypeNameTN` to comply with the naming convention, that types must be CamelCase. Hope that I caught all of them...