### PR TITLE
FIX: Compile Errors due to Misplaced Typename

### DIFF
--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -12,10 +12,10 @@
 
 using namespace swissknife;
 
-typedef CatalogTraversal<MockObjectFetcher>          MockedCatalogTraversal;
-typedef typename MockedCatalogTraversal::Parameters  TraversalParams;
-typedef std::pair<unsigned int, std::string>         CatalogIdentifier;
-typedef std::vector<CatalogIdentifier>               CatalogIdentifiers;
+typedef CatalogTraversal<MockObjectFetcher>   MockedCatalogTraversal;
+typedef MockedCatalogTraversal::Parameters    TraversalParams;
+typedef std::pair<unsigned int, std::string>  CatalogIdentifier;
+typedef std::vector<CatalogIdentifier>        CatalogIdentifiers;
 
 class T_CatalogTraversal : public ::testing::Test {
  public:

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -16,8 +16,8 @@
 using namespace swissknife;
 using namespace upload;
 
-typedef CatalogTraversal<MockObjectFetcher>          MockedCatalogTraversal;
-typedef typename MockedCatalogTraversal::Parameters  TraversalParams;
+typedef CatalogTraversal<MockObjectFetcher>  MockedCatalogTraversal;
+typedef MockedCatalogTraversal::Parameters   TraversalParams;
 
 class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
  public:


### PR DESCRIPTION
Apparently GCC 4.8 doesn't care about that... 