### PR TITLE
Refactor: GarbageCollector<> Extensibility Preparations

### DIFF
--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -54,7 +54,6 @@ class GarbageCollector {
       , object_fetcher(NULL)
       , keep_history_depth(kFullHistory)
       , keep_history_timestamp(kNoTimestamp)
-      , base_history_database(kLatestHistoryDatabase)
       , dry_run(false)
       , verbose(false) {}
 
@@ -62,7 +61,6 @@ class GarbageCollector {
     ObjectFetcherTN           *object_fetcher;
     unsigned int               keep_history_depth;
     time_t                     keep_history_timestamp;
-    shash::Any                 base_history_database;
     bool                       dry_run;
     bool                       verbose;
   };

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -40,6 +40,7 @@ template<class CatalogTraversalT, class HashFilterT>
 class GarbageCollector {
  protected:
   typedef typename CatalogTraversalT::ObjectFetcherTN ObjectFetcherTN;
+  typedef typename ObjectFetcherTN::HistoryTN         HistoryTN;
 
  public:
   struct Configuration {

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -88,7 +88,6 @@ class GarbageCollector {
   void SweepDataObjects   (const TraversalCallbackDataTN &data);
 
   bool AnalyzePreservedCatalogTree();
-  bool PreserveLatestHistoryDatabase();
   bool CheckPreservedRevisions();
   bool SweepCondemnedCatalogTree();
   bool SweepHistoricRevisions();

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -89,7 +89,10 @@ class GarbageCollector {
   void SweepDataObjects   (const TraversalCallbackDataTN &data);
 
   bool AnalyzePreservedCatalogTree();
+  bool PreserveLatestHistoryDatabase();
+  bool CheckPreservedRevisions();
   bool SweepCondemnedCatalogTree();
+  bool SweepHistoricRevisions();
 
   bool GetHistoryRecycleBinContents(std::set<shash::Any> *result_set) const;
 

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -41,6 +41,10 @@ class GarbageCollector {
  protected:
   typedef typename CatalogTraversalT::ObjectFetcherTN ObjectFetcherTN;
   typedef typename ObjectFetcherTN::HistoryTN         HistoryTN;
+  typedef typename CatalogTraversalT::CatalogTN       CatalogTN;
+  typedef typename CatalogTraversalT::CallbackDataTN  TraversalCallbackDataTN;
+  typedef typename CatalogTraversalT::Parameters      TraversalParameters;
+  typedef std::vector<shash::Any>                     HashVector;
 
  public:
   struct Configuration {
@@ -64,12 +68,6 @@ class GarbageCollector {
     bool                       dry_run;
     bool                       verbose;
   };
-
- protected:
-  typedef typename CatalogTraversalT::CatalogTN       CatalogTN;
-  typedef typename CatalogTraversalT::CallbackDataTN  TraversalCallbackDataTN;
-  typedef typename CatalogTraversalT::Parameters      TraversalParameters;
-  typedef std::vector<shash::Any>                     HashVector;
 
  public:
   GarbageCollector(const Configuration &configuration);

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -92,8 +92,6 @@ class GarbageCollector {
   bool SweepCondemnedCatalogTree();
   bool SweepHistoricRevisions();
 
-  bool GetHistoryRecycleBinContents(std::set<shash::Any> *result_set) const;
-
   void CheckAndSweep(const shash::Any &hash);
   void Sweep(const shash::Any &hash);
 

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -19,12 +19,6 @@ template<class CatalogTraversalT, class HashFilterT>
 const time_t GarbageCollector<CatalogTraversalT,
                               HashFilterT>::Configuration::kNoTimestamp = 0;
 
-template<class CatalogTraversalT, class HashFilterT>
-const shash::Any GarbageCollector<
-                   CatalogTraversalT,
-                   HashFilterT>::Configuration::kLatestHistoryDatabase =
-  shash::Any();
-
 
 template <class CatalogTraversalT, class HashFilterT>
 GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -195,7 +195,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveLatestHistoryData
 template <class CatalogTraversalT, class HashFilterT>
 bool GarbageCollector<CatalogTraversalT, HashFilterT>::CheckPreservedRevisions() {
   const bool keeps_revisions = (preserved_catalog_count() > 0);
-  if (keeps_revisions && configuration_.verbose) {
+  if (! keeps_revisions && configuration_.verbose) {
     LogCvmfs(kLogGc, kLogStderr, "This would delete everything! Abort.");
   }
 

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -182,6 +182,12 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveLatestHistoryData
   const bool success = traversal_.TraverseNamedSnapshots();
   traversal_.UnregisterListener(callback);
 
+  // preserve the latest history database file itself
+  object_fetcher_t *fetcher = configuration_.object_fetcher;
+  UniquePtr<manifest::Manifest> manifest(fetcher->FetchManifest());
+  assert (manifest.IsValid());
+  hash_filter_.Fill(manifest->history());
+
   return success;
 }
 

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -209,9 +209,8 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepHistoricRevisions() 
   ObjectFetcherTN *fetcher = configuration_.object_fetcher;
 
   // find the content hash for the current HEAD history database
-  UniquePtr<manifest::Manifest> manifest(fetcher->FetchManifest());
-  assert (manifest.IsValid());
-  if (manifest->history().IsNull()) {
+  UniquePtr<HistoryTN> history(fetcher->FetchHistory());
+  if (! history.IsValid()) {
     if (configuration_.verbose) {
       LogCvmfs(kLogGc, kLogStdout, "No history found");
     }
@@ -223,58 +222,20 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepHistoricRevisions() 
        &GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects,
         this);
 
-  // go through all legacy history databases and sweep the revisions in the
-  // recycle bins along with the legacy history databases itself
-  shash::Any   history_hash  = manifest->history();
-  unsigned int history_depth = 0;
-  while (! history_hash.IsNull()) {
+   // list the recycle bin of the current HEAD history database for sweeping
+  typedef std::vector<shash::Any> Hashes;
+  Hashes recycled_snapshots;
+  if (! history->ListRecycleBin(&recycled_snapshots)) {
+    return false;
+  }
 
-    // fetch the history database for the current history hash
-    UniquePtr<HistoryTN> history(fetcher->FetchHistory(history_hash));
-
-    // check if the history database was successfully fetched and stop execution
-    // (if the HEAD history was not accessible we report a failure otherwise
-    //  it is assumed that the rest of the history chain was swept before)
-    const bool download_successful = history.IsValid();
-    if (! download_successful) {
-      const bool is_head_history = (manifest->history() == history_hash);
-      if (is_head_history) {
-        LogCvmfs(kLogGc, kLogStderr, "Failed to fetch latest history (%s)",
-                 history_hash.ToString().c_str());
-        return false;
-      }
-
-      if (configuration_.verbose) {
-        LogCvmfs(kLogGc, kLogStdout, "History chain ended after %d databases "
-                                     "with %s. Done.",
-                 history_depth, history_hash.ToString().c_str());
-      }
-
-      break;
-    }
-
-    // list the recycle bin of the current history database for sweeping
-    typedef std::vector<shash::Any> Hashes;
-    Hashes recycled_snapshots;
-    if (! history->ListRecycleBin(&recycled_snapshots)) {
+  // sweep all revisions that were marked as deleted in the recycle bin
+        Hashes::const_iterator i    = recycled_snapshots.begin();
+  const Hashes::const_iterator iend = recycled_snapshots.end();
+  for (; i != iend; ++i) {
+    if (! traversal_.Traverse(*i, CatalogTraversalT::kDepthFirstTraversal)) {
       return false;
     }
-
-    // sweep all revisions that were marked as deleted in the recycle bin
-          Hashes::const_iterator i    = recycled_snapshots.begin();
-    const Hashes::const_iterator iend = recycled_snapshots.end();
-    for (; i != iend; ++i) {
-      if (! traversal_.Traverse(*i, CatalogTraversalT::kDepthFirstTraversal)) {
-        return false;
-      }
-    }
-
-    // sweep the history database file itself
-    CheckAndSweep(history_hash);
-
-    // continue with the next history database hash
-    history_hash = history->previous_revision();
-    ++history_depth;
   }
 
   traversal_.UnregisterListener(callback);

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -174,7 +174,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveLatestHistoryData
   }
 
   // traverse the latest history database
-  typename CatalogTraversalT::callback_t *callback =
+  typename CatalogTraversalT::CallbackTN *callback =
   traversal_.RegisterListener(
      &GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveDataObjects,
       this);
@@ -183,7 +183,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveLatestHistoryData
   traversal_.UnregisterListener(callback);
 
   // preserve the latest history database file itself
-  object_fetcher_t *fetcher = configuration_.object_fetcher;
+  ObjectFetcherTN *fetcher = configuration_.object_fetcher;
   UniquePtr<manifest::Manifest> manifest(fetcher->FetchManifest());
   assert (manifest.IsValid());
   hash_filter_.Fill(manifest->history());

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -991,87 +991,88 @@ TEST_F(T_GarbageCollector, NamedTagsInRecycleBin) {
 }
 
 
-TEST_F(T_GarbageCollector, FindAndSweepOrphanedNamedSnapshot) {
-  GcConfiguration config = GetStandardGarbageCollectorConfiguration();
-  MyGarbageCollector gc(config);
+// TODO: re-enable once the 'orphaned named snapshots' problem is solved
+//
+// TEST_F(T_GarbageCollector, FindAndSweepOrphanedNamedSnapshot) {
+//   GcConfiguration config = GetStandardGarbageCollectorConfiguration();
+//   MyGarbageCollector gc(config);
 
-  GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
-  RevisionMap     &c   = catalogs_;
+//   GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
+//   RevisionMap     &c   = catalogs_;
 
-  // wire up std::set<> deleted_hashes in uploader with the MockObjectFetcher
-  // to simulate the actual deletion of objects
-  MockCatalog::s_deleted_objects = &upl->deleted_hashes;
+//   // wire up std::set<> deleted_hashes in uploader with the MockObjectFetcher
+//   // to simulate the actual deletion of objects
+//   MockCatalog::s_deleted_objects = &upl->deleted_hashes;
 
-  const bool gc1 = gc.Collect();
-  EXPECT_TRUE (gc1);
+//   const bool gc1 = gc.Collect();
+//   EXPECT_TRUE (gc1);
 
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "00")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "10")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "11")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "20")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "00")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "10")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "11")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "20")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(2, "00")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(2, "10")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(2, "11")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "00")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "10")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "11")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "20")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "00")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "10")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "11")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "20")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(2, "00")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(2, "10")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(2, "11")]->hash()));
 
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "00")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "10")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "11")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "00")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "10")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "00")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "10")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "11")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "00")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "10")]->hash()));
 
-  EXPECT_EQ (11u, gc.preserved_catalog_count());
+//   EXPECT_EQ (11u, gc.preserved_catalog_count());
 
-  // + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + -
+//   // + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + -
 
-  // mock a history database chain that contains the information of the deleted
-  // snapshot "Revision2" in its recycle bin and remove it entirely from the
-  // latest history database
-  MockHistory *history         = MockHistory::Get(MockHistory::root_hash);
-  MockHistory *old_history     = static_cast<MockHistory*>(history->Clone());
-  MockHistory *initial_history = static_cast<MockHistory*>(history->Clone());
+//   // mock a history database chain that contains the information of the deleted
+//   // snapshot "Revision2" in its recycle bin and remove it entirely from the
+//   // latest history database
+//   MockHistory *history         = MockHistory::Get(MockHistory::root_hash);
+//   MockHistory *old_history     = static_cast<MockHistory*>(history->Clone());
+//   MockHistory *initial_history = static_cast<MockHistory*>(history->Clone());
 
-  old_history->Remove("Revision2");
-  history->Remove("Revision2");
-  history->EmptyRecycleBin();
+//   old_history->Remove("Revision2");
+//   history->Remove("Revision2");
+//   history->EmptyRecycleBin();
 
-  shash::Any old_history_hash     = h("cb431d5bd49df9ba5f1be54642bb8790477ee7f7",
-                                      shash::kSuffixHistory);
-  shash::Any initial_history_hash = h("963f943b84c478731329709ff90d64978f7feeb4",
-                                      shash::kSuffixHistory);
+//   shash::Any old_history_hash     = h("cb431d5bd49df9ba5f1be54642bb8790477ee7f7",
+//                                       shash::kSuffixHistory);
+//   shash::Any initial_history_hash = h("963f943b84c478731329709ff90d64978f7feeb4",
+//                                       shash::kSuffixHistory);
 
-  history->SetPreviousRevision(old_history_hash);
-  old_history->SetPreviousRevision(initial_history_hash);
-  MockHistory::RegisterObject(old_history_hash, old_history);
-  MockHistory::RegisterObject(initial_history_hash, initial_history);
+//   history->SetPreviousRevision(old_history_hash);
+//   old_history->SetPreviousRevision(initial_history_hash);
+//   MockHistory::RegisterObject(old_history_hash, old_history);
+//   MockHistory::RegisterObject(initial_history_hash, initial_history);
 
-  // + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + -
+//   // + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + - + -
 
-  config.base_history_database = initial_history_hash;
-  MyGarbageCollector new_gc(config);
-  const bool gc2 = new_gc.Collect();
-  EXPECT_TRUE (gc2);
+//   MyGarbageCollector new_gc(config);
+//   const bool gc2 = new_gc.Collect();
+//   EXPECT_TRUE (gc2);
 
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "00")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "10")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "11")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(5, "20")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "00")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "10")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "11")]->hash()));
-  EXPECT_FALSE (upl->HasDeleted(c[mp(4, "20")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "00")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "10")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "11")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(5, "20")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "00")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "10")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "11")]->hash()));
+//   EXPECT_FALSE (upl->HasDeleted(c[mp(4, "20")]->hash()));
 
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "00")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "10")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "11")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(2, "00")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(2, "10")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(2, "11")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "00")]->hash()));
-  EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "10")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "00")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "10")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(3, "11")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(2, "00")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(2, "10")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(2, "11")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "00")]->hash()));
+//   EXPECT_TRUE  (upl->HasDeleted(c[mp(1, "10")]->hash()));
 
-  EXPECT_EQ (8u, new_gc.preserved_catalog_count());
-}
+//   EXPECT_EQ (8u, new_gc.preserved_catalog_count());
+// }


### PR DESCRIPTION
This disentangles things in the garbage collector a bit and removes an experimental solution to the 'orphaned named snapshot' problem. We leave this particular thing as a known issue for later.