### PR TITLE
FIX: Compile Error because of Missing ssize_t

### DIFF
--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -7,6 +7,7 @@
 #ifndef CVMFS_PLATFORM_LINUX_H_
 #define CVMFS_PLATFORM_LINUX_H_
 
+#include <sys/types.h> // contains ssize_t needed inside <attr/xattr.h>
 #include <attr/xattr.h>
 #include <dirent.h>
 #include <errno.h>
@@ -20,7 +21,6 @@
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/select.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include <cassert>


### PR DESCRIPTION
Turns out that `<attr/xattr.h>` requires `ssize_t` but doesn't include the proper headers to use it. Hence `<sys/types.h>` needs to be included before it. At least on my platform.
