### PR TITLE
FIX: ObjectFetcher<> Leaks Temporary Files

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -389,6 +389,15 @@ const Catalog::HashVector& Catalog::GetReferencedObjects() const {
 }
 
 
+void Catalog::TakeFileOwnership() {
+  if (NULL == database_) {
+    return;
+  }
+
+  database_->TakeFileOwnership();
+}
+
+
 uint64_t Catalog::GetTTL() const {
   const string sql = "SELECT value FROM properties WHERE key='TTL';";
 

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -389,12 +389,21 @@ const Catalog::HashVector& Catalog::GetReferencedObjects() const {
 }
 
 
-void Catalog::TakeFileOwnership() {
+void Catalog::TakeDatabaseFileOwnership() {
   if (NULL == database_) {
     return;
   }
 
   database_->TakeFileOwnership();
+}
+
+
+void Catalog::DropDatabaseFileOwnership() {
+  if (NULL == database_) {
+    return;
+  }
+
+  database_->DropFileOwnership();
 }
 
 

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -155,6 +155,7 @@ class Catalog : public SingleCopy {
                          FileChunkList *chunks) const;
 
   const HashVector& GetReferencedObjects() const;
+  void TakeFileOwnership();
 
   uint64_t GetTTL() const;
   uint64_t GetRevision() const;

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -155,7 +155,11 @@ class Catalog : public SingleCopy {
                          FileChunkList *chunks) const;
 
   const HashVector& GetReferencedObjects() const;
-  void TakeFileOwnership();
+  void TakeDatabaseFileOwnership();
+  void DropDatabaseFileOwnership();
+  bool OwnsDatabaseFile() const {
+    return NULL != database_ && database_->OwnsFile();
+  }
 
   uint64_t GetTTL() const;
   uint64_t GetRevision() const;

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -481,6 +481,10 @@ class CatalogTraversal
       }
     }
 
+    // catalogs returned by ObjectFetcher<> are managing their database files by
+    // default... we need to manage this file manually here
+    job.catalog->DropDatabaseFileOwnership();
+
     job.catalog_file_path = job.catalog->database_path();
     job.catalog_file_size = GetFileSize(job.catalog->database_path());
 

--- a/cvmfs/history.h
+++ b/cvmfs/history.h
@@ -165,12 +165,11 @@ class History {
    */
   virtual bool GetHashes(std::vector<shash::Any> *hashes) const = 0;
 
-  /**
-   * If the concrete history implementation deals with local files internally
-   * the cleanup responsability is retained by the concrete implementation of
-   * this class.
-   */
-  virtual void TakeFileOwnership() {};
+  // database file management controls
+  virtual void TakeDatabaseFileOwnership() {};
+  virtual void DropDatabaseFileOwnership() {};
+  virtual bool OwnsDatabaseFile() const { return false; }
+
 
   const std::string& fqrn() const { return fqrn_; }
 

--- a/cvmfs/history.h
+++ b/cvmfs/history.h
@@ -166,10 +166,9 @@ class History {
   virtual bool GetHashes(std::vector<shash::Any> *hashes) const = 0;
 
   // database file management controls
-  virtual void TakeDatabaseFileOwnership() {};
-  virtual void DropDatabaseFileOwnership() {};
-  virtual bool OwnsDatabaseFile() const { return false; }
-
+  virtual void TakeDatabaseFileOwnership() = 0;
+  virtual void DropDatabaseFileOwnership() = 0;
+  virtual bool OwnsDatabaseFile() const    = 0;
 
   const std::string& fqrn() const { return fqrn_; }
 

--- a/cvmfs/history.h
+++ b/cvmfs/history.h
@@ -165,6 +165,13 @@ class History {
    */
   virtual bool GetHashes(std::vector<shash::Any> *hashes) const = 0;
 
+  /**
+   * If the concrete history implementation deals with local files internally
+   * the cleanup responsability is retained by the concrete implementation of
+   * this class.
+   */
+  virtual void TakeFileOwnership() {};
+
   const std::string& fqrn() const { return fqrn_; }
 
  protected:

--- a/cvmfs/history_sqlite.cc
+++ b/cvmfs/history_sqlite.cc
@@ -382,9 +382,15 @@ bool SqliteHistory::GetHashes(std::vector<shash::Any> *hashes) const {
 }
 
 
-void SqliteHistory::TakeFileOwnership() {
+void SqliteHistory::TakeDatabaseFileOwnership() {
   assert (database_);
   database_->TakeFileOwnership();
 }
+
+
+void SqliteHistory::DropDatabaseFileOwnership() {
+  assert (database_);
+  database_->DropFileOwnership();
+};
 
 }  // namespace history

--- a/cvmfs/history_sqlite.cc
+++ b/cvmfs/history_sqlite.cc
@@ -381,4 +381,10 @@ bool SqliteHistory::GetHashes(std::vector<shash::Any> *hashes) const {
   return get_hashes_->Reset();
 }
 
+
+void SqliteHistory::TakeFileOwnership() {
+  assert (database_);
+  database_->TakeFileOwnership();
+}
+
 }  // namespace history

--- a/cvmfs/history_sqlite.h
+++ b/cvmfs/history_sqlite.h
@@ -134,7 +134,12 @@ class SqliteHistory : public History {
    */
   bool GetHashes(std::vector<shash::Any> *hashes) const;
 
-  void TakeFileOwnership();
+  // database file management controls
+  void TakeDatabaseFileOwnership();
+  void DropDatabaseFileOwnership();
+  bool OwnsDatabaseFile() const {
+    return database_.IsValid() && database_->OwnsFile();
+  }
 
  protected:
   static SqliteHistory* Open(const std::string &file_name,

--- a/cvmfs/history_sqlite.h
+++ b/cvmfs/history_sqlite.h
@@ -134,6 +134,8 @@ class SqliteHistory : public History {
    */
   bool GetHashes(std::vector<shash::Any> *hashes) const;
 
+  void TakeFileOwnership();
+
  protected:
   static SqliteHistory* Open(const std::string &file_name,
                              const bool read_write);

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -208,8 +208,10 @@ class LocalObjectFetcher :
     file_path->clear();
 
     const std::string source = BuildPath(object_hash, hash_suffix);
-    const std::string dest   = temporary_directory_ + "/" +
-                               object_hash.ToString();
+    const std::string dest   = CreateTempPath(temporary_directory_ + "/" +
+                                              object_hash.ToStringWithSuffix(),
+                                              0600);
+
     if (! FileExists(source)) {
       LogCvmfs(kLogDownload, kLogDebug, "failed to locate object %s at '%s'",
                object_hash.ToString().c_str(), dest.c_str());
@@ -332,7 +334,9 @@ class HttpObjectFetcher :
     object_file->clear();
 
     const std::string url  = BuildUrl(object_hash, hash_suffix);
-    const std::string dest = temporary_directory_ + "/" + object_hash.ToString();
+    const std::string dest = CreateTempPath(temporary_directory_ + "/" +
+                                            object_hash.ToStringWithSuffix(),
+                                            0600);
 
     download::JobInfo download_catalog(&url, true, false, &dest, &object_hash);
     download::Failures retval = download_manager_->Fetch(&download_catalog);

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -64,7 +64,9 @@ class AbstractObjectFetcher {
 
   /**
    * Downloads and opens (read-only) a history database. Note that the user is
-   * responsible to remove the history object after usage.
+   * responsible to remove the history object after usage. The fetched SQLite
+   * database file will be unlinked automatically during the destruction of the
+   * HistoryTN object.
    *
    * @param history_hash  (optional) the content hash of the history database
    *                                 if left blank, the latest one is downloaded
@@ -86,7 +88,7 @@ class AbstractObjectFetcher {
     // open the history file
     HistoryTN *history = HistoryTN::Open(path);
     if (NULL != history) {
-      history->TakeFileOwnership();
+      history->TakeDatabaseFileOwnership();
     }
 
     return history;
@@ -119,7 +121,7 @@ class AbstractObjectFetcher {
                                                  parent,
                                                  is_nested);
     if (NULL != catalog) {
-      catalog->TakeFileOwnership();
+      catalog->TakeDatabaseFileOwnership();
     }
 
     return catalog;

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -120,11 +120,11 @@ class Database : SingleCopy {
   bool SetProperty(const std::string &key, const T value);
   bool HasProperty(const std::string &key) const;
 
-  sqlite3     *sqlite_db()       const { return sqlite_db_;       }
-  std::string  filename()        const { return filename_;        }
-  float        schema_version()  const { return schema_version_;  }
-  unsigned     schema_revision() const { return schema_revision_; }
-  bool         read_write()      const { return read_write_;      }
+  sqlite3     *sqlite_db()       const { return sqlite_db_;            }
+  std::string  filename()        const { return db_file_guard_.path(); }
+  float        schema_version()  const { return schema_version_;       }
+  unsigned     schema_revision() const { return schema_revision_;      }
+  bool         read_write()      const { return read_write_;           }
 
   /**
    * Figures out the ratio of free SQLite memory pages in the SQLite database
@@ -184,7 +184,7 @@ class Database : SingleCopy {
 
  private:
   sqlite3            *sqlite_db_;
-  const std::string   filename_;
+  UnlinkGuard         db_file_guard_;
   const bool          read_write_;
   float               schema_version_;
   unsigned            schema_revision_;

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -24,6 +24,11 @@ class Sql;
  * templated methods SetProperty(), GetProperty<>() and HasProperty() that take
  * all common data types and persist it in the database.
  *
+ * By default Database<> objects do not take ownership of the underlying SQLite
+ * database file and hence do not unlink it on database closure. If the using
+ * code calls Database<>::TakeFileOwnership() the SQLite file will be unlinked
+ * in the destructor of the Database<> object.
+ *
  * Note: This implements a Curiously Recurring Template Pattern in order to
  *       implement Database::Create and Database::Open as a static polymorphism
  *
@@ -159,6 +164,14 @@ class Database : SingleCopy {
    * @return   english language error description of last error
    */
   std::string GetLastErrorMsg() const;
+
+
+  /**
+   * Transfers the ownership of the SQLite database file to the Database<> ob-
+   * ject. Hence, it will automatically unlink the file, once the Database<>
+   * object goes out of scope or is deleted.
+   */
+  void TakeFileOwnership();
 
  protected:
   /**

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -173,6 +173,22 @@ class Database : SingleCopy {
    */
   void TakeFileOwnership();
 
+  /**
+   * Resigns from the ownership of the SQLite database file underlying this
+   * Database<> object. After calling this the using code is responsible of
+   * managing the database file.
+   */
+  void DropFileOwnership();
+
+  /**
+   * Check if the SQLite database file is managed by the Database<> object
+   * Note: unmanaged means, that the using code needs to take care of the file
+   *       management (i.e. delete the file after usage)
+   *
+   * @return  false if file is unmanaged
+   */
+  bool OwnsFile() const { return db_file_guard_.IsEnabled(); }
+
  protected:
   /**
    * Private constructor! Use the factory methods DerivedT::Create() or

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -16,7 +16,7 @@ template <class DerivedT>
 Database<DerivedT>::Database(const std::string  &filename,
                              const OpenMode      open_mode) :
   sqlite_db_(NULL),
-  filename_(filename),
+  db_file_guard_(filename, UnlinkGuard::kDisabled),
   read_write_(kOpenReadWrite == open_mode),
   schema_version_(0.0f),
   schema_revision_(0) {}
@@ -94,7 +94,7 @@ bool Database<DerivedT>::Initialize() {
                           PrepareCommonQueries();
   if (! successful) {
     LogCvmfs(kLogSql, kLogDebug, "failed to open database file '%s'",
-                                 filename_.c_str());
+                                 filename().c_str());
     return false;
   }
 
@@ -105,7 +105,7 @@ bool Database<DerivedT>::Initialize() {
 
   if (! static_cast<DerivedT*>(this)->CheckSchemaCompatibility()) {
     LogCvmfs(kLogSql, kLogDebug, "schema version %f not supported (%s)",
-             schema_version_, filename_.c_str());
+             schema_version_, filename().c_str());
     return false;
   }
 
@@ -123,11 +123,11 @@ template <class DerivedT>
 bool Database<DerivedT>::OpenDatabase(const int flags) {
   // Open database file (depending on the flags read-only or read-write)
   LogCvmfs(kLogSql, kLogDebug, "opening database file %s",
-           filename_.c_str());
-  if (SQLITE_OK != sqlite3_open_v2(filename_.c_str(), &sqlite_db_, flags, NULL))
+           filename().c_str());
+  if (SQLITE_OK != sqlite3_open_v2(filename().c_str(), &sqlite_db_, flags, NULL))
   {
     LogCvmfs(kLogSql, kLogDebug, "cannot open database file %s",
-             filename_.c_str());
+             filename().c_str());
     return false;
   }
 
@@ -151,10 +151,10 @@ template <class DerivedT>
 bool Database<DerivedT>::FileReadAhead() {
   // Read-ahead into file system buffers
   // TODO: mmap, re-readahead
-  int fd_readahead = open(filename_.c_str(), O_RDONLY);
+  int fd_readahead = open(filename().c_str(), O_RDONLY);
   if (fd_readahead < 0) {
     LogCvmfs(kLogSql, kLogDebug, "failed to open %s for read-ahead (%d)",
-             filename_.c_str(), errno);
+             filename().c_str(), errno);
     return false;
   }
 
@@ -162,7 +162,7 @@ bool Database<DerivedT>::FileReadAhead() {
   close(fd_readahead);
   if (retval != 0) {
     LogCvmfs(kLogSql, kLogDebug | kLogSyslogWarn,
-             "failed to read-ahead %s (%d)", filename_.c_str(), errno);
+             "failed to read-ahead %s (%d)", filename().c_str(), errno);
     return false;
   }
 

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -268,6 +268,14 @@ std::string Database<DerivedT>::GetLastErrorMsg() const {
 }
 
 
+template <class DerivedT>
+void Database<DerivedT>::TakeFileOwnership() {
+  db_file_guard_.Enable();
+  LogCvmfs(kLogSql, kLogDebug, "Database object took ownership of '%s'",
+           db_file_guard_.path().c_str());
+}
+
+
 /**
  * Used to check if the database needs cleanup
  */

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -276,6 +276,13 @@ void Database<DerivedT>::TakeFileOwnership() {
 }
 
 
+template <class DerivedT>
+void Database<DerivedT>::DropFileOwnership() {
+  db_file_guard_.Disable();
+  LogCvmfs(kLogSql, kLogDebug, "Database object dropped ownership of '%s'",
+           db_file_guard_.path().c_str());
+}
+
 /**
  * Used to check if the database needs cleanup
  */

--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -298,8 +298,14 @@ class UniquePtr : SingleCopy {
  */
 class UnlinkGuard : SingleCopy {
  public:
+  enum InitialState { kEnabled, kDisabled };
+
+ public:
   inline UnlinkGuard() : enabled_(false) {}
-  inline UnlinkGuard(const std::string &path) : path_(path), enabled_(true) {}
+  inline UnlinkGuard(const std::string &path,
+                     const InitialState state = kEnabled)
+            : path_(path)
+            , enabled_(state == kEnabled) {}
   inline ~UnlinkGuard() { if (IsEnabled()) unlink(path_.c_str()); }
 
   inline void Set(const std::string &path) { path_ = path; Enable(); }

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -684,6 +684,7 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
 
   DummyDatabase *db1 = DummyDatabase::Create(file_name1);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db1);
+  EXPECT_FALSE(db1->OwnsFile());
   EXPECT_TRUE (FileExists(file_name1));
   delete db1;
 
@@ -692,6 +693,7 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
 
   DummyDatabase *db2 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadOnly);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db2);
+  EXPECT_FALSE(db2->OwnsFile());
   EXPECT_TRUE (FileExists(file_name1));
   delete db2;
 
@@ -700,6 +702,7 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
 
   DummyDatabase *db3 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadWrite);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db3);
+  EXPECT_FALSE(db3->OwnsFile());
   EXPECT_TRUE (FileExists(file_name1));
   delete db3;
 
@@ -709,7 +712,9 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
   DummyDatabase *db4 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadOnly);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db4);
   EXPECT_TRUE (FileExists(file_name1));
+  EXPECT_FALSE(db4->OwnsFile());
   db4->TakeFileOwnership();
+  EXPECT_TRUE (db4->OwnsFile());
   EXPECT_TRUE (FileExists(file_name1));
   delete db4;
 
@@ -720,8 +725,10 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
   ASSERT_TRUE (FileExists(file_name2));
   DummyDatabase *db5 = DummyDatabase::Create(file_name2);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db5);
+  EXPECT_FALSE(db5->OwnsFile());
   EXPECT_TRUE (FileExists(file_name2));
   db5->TakeFileOwnership();
+  EXPECT_TRUE (db5->OwnsFile());
   delete db5;
 
   EXPECT_EQ   (0u, DummyDatabase::instances);
@@ -731,6 +738,7 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
   ASSERT_TRUE (FileExists(file_name3));
   DummyDatabase *db6 = DummyDatabase::Create(file_name3);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db6);
+  EXPECT_FALSE(db6->OwnsFile());
   EXPECT_TRUE (FileExists(file_name3));
   delete db6;
 
@@ -739,8 +747,10 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
 
   DummyDatabase *db7 = DummyDatabase::Open(file_name3, DummyDatabase::kOpenReadWrite);
   ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db7);
+  EXPECT_FALSE(db7->OwnsFile());
   EXPECT_TRUE (FileExists(file_name3));
   db7->TakeFileOwnership();
+  EXPECT_TRUE (db7->OwnsFile());
   EXPECT_TRUE (FileExists(file_name3));
   delete db7;
 

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -676,3 +676,74 @@ TEST_F(T_SQLite_Wrapper, FailingCompaction) {
 
   EXPECT_GT (150000, GetFileSize(dbp));
 }
+
+
+TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
+  const std::string file_name1 = GetDatabaseFilename();
+  ASSERT_TRUE (FileExists(file_name1));
+
+  DummyDatabase *db1 = DummyDatabase::Create(file_name1);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db1);
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db1;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name1));
+
+  DummyDatabase *db2 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadOnly);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db2);
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db2;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name1));
+
+  DummyDatabase *db3 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadWrite);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db3);
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db3;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name1));
+
+  DummyDatabase *db4 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadOnly);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db4);
+  EXPECT_TRUE (FileExists(file_name1));
+  db4->TakeFileOwnership();
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db4;
+
+  EXPECT_EQ   (0u, DummyDatabase::instances);
+  EXPECT_FALSE(FileExists(file_name1));
+
+  const std::string file_name2 = GetDatabaseFilename();
+  ASSERT_TRUE (FileExists(file_name2));
+  DummyDatabase *db5 = DummyDatabase::Create(file_name2);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db5);
+  EXPECT_TRUE (FileExists(file_name2));
+  db5->TakeFileOwnership();
+  delete db5;
+
+  EXPECT_EQ   (0u, DummyDatabase::instances);
+  EXPECT_FALSE(FileExists(file_name2));
+
+  const std::string file_name3 = GetDatabaseFilename();
+  ASSERT_TRUE (FileExists(file_name3));
+  DummyDatabase *db6 = DummyDatabase::Create(file_name3);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db6);
+  EXPECT_TRUE (FileExists(file_name3));
+  delete db6;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name3));
+
+  DummyDatabase *db7 = DummyDatabase::Open(file_name3, DummyDatabase::kOpenReadWrite);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db7);
+  EXPECT_TRUE (FileExists(file_name3));
+  db7->TakeFileOwnership();
+  EXPECT_TRUE (FileExists(file_name3));
+  delete db7;
+
+  EXPECT_EQ   (0u, DummyDatabase::instances);
+  EXPECT_FALSE(FileExists(file_name3));
+}

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -757,3 +757,90 @@ TEST_F(T_SQLite_Wrapper, TakeFileOwnership) {
   EXPECT_EQ   (0u, DummyDatabase::instances);
   EXPECT_FALSE(FileExists(file_name3));
 }
+
+
+TEST_F(T_SQLite_Wrapper, DropFileOwnership) {
+  const std::string file_name1 = GetDatabaseFilename();
+  ASSERT_TRUE (FileExists(file_name1));
+
+  DummyDatabase *db1 = DummyDatabase::Create(file_name1);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db1);
+  EXPECT_FALSE(db1->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db1;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name1));
+
+  DummyDatabase *db2 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadOnly);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db2);
+  EXPECT_FALSE(db2->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db2;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name1));
+
+  DummyDatabase *db3 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadWrite);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db3);
+  EXPECT_FALSE(db3->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db3;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name1));
+
+  DummyDatabase *db4 = DummyDatabase::Open(file_name1, DummyDatabase::kOpenReadOnly);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db4);
+  EXPECT_TRUE (FileExists(file_name1));
+  EXPECT_FALSE(db4->OwnsFile());
+  db4->TakeFileOwnership();
+  EXPECT_TRUE (db4->OwnsFile());
+  db4->DropFileOwnership();
+  EXPECT_FALSE(db4->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name1));
+  delete db4;
+
+  EXPECT_EQ   (0u, DummyDatabase::instances);
+  EXPECT_TRUE (FileExists(file_name1));
+
+  const std::string file_name2 = GetDatabaseFilename();
+  ASSERT_TRUE (FileExists(file_name2));
+  DummyDatabase *db5 = DummyDatabase::Create(file_name2);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db5);
+  EXPECT_FALSE(db5->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name2));
+  db5->TakeFileOwnership();
+  EXPECT_TRUE (db5->OwnsFile());
+  db5->DropFileOwnership();
+  EXPECT_FALSE(db5->OwnsFile());
+  delete db5;
+
+  EXPECT_EQ   (0u, DummyDatabase::instances);
+  EXPECT_TRUE (FileExists(file_name2));
+
+  const std::string file_name3 = GetDatabaseFilename();
+  ASSERT_TRUE (FileExists(file_name3));
+  DummyDatabase *db6 = DummyDatabase::Create(file_name3);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db6);
+  EXPECT_FALSE(db6->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name3));
+  delete db6;
+
+  EXPECT_EQ  (0u, DummyDatabase::instances);
+  EXPECT_TRUE(FileExists(file_name3));
+
+  DummyDatabase *db7 = DummyDatabase::Open(file_name3, DummyDatabase::kOpenReadWrite);
+  ASSERT_NE   (static_cast<DummyDatabase*>(NULL), db7);
+  EXPECT_FALSE(db7->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name3));
+  db7->TakeFileOwnership();
+  EXPECT_TRUE (db7->OwnsFile());
+  db7->DropFileOwnership();
+  EXPECT_FALSE(db7->OwnsFile());
+  EXPECT_TRUE (FileExists(file_name3));
+  delete db7;
+
+  EXPECT_EQ   (0u, DummyDatabase::instances);
+  EXPECT_TRUE (FileExists(file_name3));
+}

--- a/test/unittests/t_unlink_guard.cc
+++ b/test/unittests/t_unlink_guard.cc
@@ -146,3 +146,57 @@ TEST_F(T_UnlinkGuard, DeferredInit) {
   }
   EXPECT_FALSE (FileExists(file_path));
 }
+
+
+TEST_F(T_UnlinkGuard, DisabledInit) {
+  const std::string file_path = GetFilename();
+  {
+    ASSERT_TRUE (FileExists(file_path));
+
+    UnlinkGuard d(file_path, UnlinkGuard::kDisabled);
+    EXPECT_FALSE(d.IsEnabled());
+    EXPECT_TRUE (FileExists(file_path));
+  }
+
+  EXPECT_TRUE (FileExists(file_path));
+
+  {
+    ASSERT_TRUE (FileExists(file_path));
+
+    UnlinkGuard d(file_path, UnlinkGuard::kDisabled);
+    EXPECT_FALSE(d.IsEnabled());
+    EXPECT_TRUE (FileExists(file_path));
+
+    d.Enable();
+    EXPECT_TRUE (d.IsEnabled());
+    EXPECT_TRUE (FileExists(file_path));
+  }
+  EXPECT_FALSE (FileExists(file_path));
+}
+
+
+TEST_F(T_UnlinkGuard, ExplicitEnabledInit) {
+  const std::string file_path = GetFilename();
+  {
+    ASSERT_TRUE (FileExists(file_path));
+
+    UnlinkGuard d(file_path, UnlinkGuard::kEnabled);
+    EXPECT_TRUE (d.IsEnabled());
+    EXPECT_TRUE (FileExists(file_path));
+
+    d.Disable();
+    EXPECT_FALSE (d.IsEnabled());
+    EXPECT_TRUE  (FileExists(file_path));
+  }
+
+  EXPECT_TRUE (FileExists(file_path));
+
+  {
+    ASSERT_TRUE (FileExists(file_path));
+
+    UnlinkGuard d(file_path, UnlinkGuard::kEnabled);
+    EXPECT_TRUE (d.IsEnabled());
+    EXPECT_TRUE (FileExists(file_path));
+  }
+  EXPECT_FALSE (FileExists(file_path));
+}

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -246,7 +246,9 @@ MockHistory* MockHistory::Open(const std::string &path) {
 
 
 MockHistory::MockHistory(const bool          writable,
-                         const std::string  &fqrn) : writable_(writable) {
+                         const std::string  &fqrn)
+        : writable_(writable)
+        , owns_database_file_(false) {
   set_fqrn(fqrn);
   ++MockHistory::instances;
 }
@@ -257,6 +259,7 @@ MockHistory::MockHistory(const MockHistory &other)
   , recycle_bin_(other.recycle_bin_)
   , writable_(other.writable_)
   , previous_revision_(other.previous_revision_)
+  , owns_database_file_(false)
 {
   set_fqrn(other.fqrn());
   ++MockHistory::instances;

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -309,7 +309,8 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
     root_path_(other.root_path_), catalog_hash_(other.catalog_hash_),
     catalog_size_(other.catalog_size_), revision_(other.revision_),
     last_modified_(other.last_modified_), is_root_(other.is_root_),
-    children_(other.children_), files_(other.files_), chunks_(other.chunks_)
+    owns_database_file_(false), children_(other.children_),
+    files_(other.files_), chunks_(other.chunks_)
   {
     ++MockCatalog::instances;
   }
@@ -335,7 +336,9 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
 
   const NestedCatalogList& ListNestedCatalogs() const { return children_; }
   const HashVector&        GetReferencedObjects() const;
-  void TakeFileOwnership() {}
+  void TakeDatabaseFileOwnership() { owns_database_file_ = true;  }
+  void DropDatabaseFileOwnership() { owns_database_file_ = false; }
+  bool OwnsDatabaseFile() const    { return owns_database_file_;  }
 
   unsigned int GetRevision()     const { return revision_;      }
   uint64_t     GetLastModified() const { return last_modified_; }
@@ -377,6 +380,7 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
   const unsigned int  revision_;
   const time_t        last_modified_;
   const bool          is_root_;
+  bool                owns_database_file_;
 
   NestedCatalogList   children_;
   FileList            files_;

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -335,6 +335,7 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
 
   const NestedCatalogList& ListNestedCatalogs() const { return children_; }
   const HashVector&        GetReferencedObjects() const;
+  void TakeFileOwnership() {}
 
   unsigned int GetRevision()     const { return revision_;      }
   uint64_t     GetLastModified() const { return last_modified_; }

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -450,6 +450,10 @@ class MockHistory : public history::History,
 
   bool GetHashes(std::vector<shash::Any> *hashes) const;
 
+  void TakeDatabaseFileOwnership() { owns_database_file_ = true;  }
+  void DropDatabaseFileOwnership() { owns_database_file_ = false; }
+  bool OwnsDatabaseFile() const    { return owns_database_file_;  }
+
  public:
   void set_writable(const bool writable) { writable_ = writable; }
 
@@ -517,6 +521,7 @@ class MockHistory : public history::History,
   HashSet     recycle_bin_;
   bool        writable_;
   shash::Any  previous_revision_;
+  bool        owns_database_file_;
 };
 
 


### PR DESCRIPTION
This add an auto-manage functionality to the `Database<>` class that unlinks the underlying SQLite file when the database is destructed. By default, this  feature is disabled (legacy compatibility) but it exposes an API to control it:
```C++
void Database<>::TakeFileOwnership();
void Database<>::DropFileOwnership();
void Database<>::OwnsFile();
```

The `ObjectFetcher<>` is hiding the file dependency of `Catalog` and `History` objects. Hence if returned by `ObjectFetcher<>` they have the auto-management enabled by default for convenience. If the using code of `ObjectFetcher<>` wishes to manage the database file manually, both `Catalog` and `History` expose a facade API for controlling the underlying database:
```C++
void History::TakeDatabaseFileOwnership();
void History::DropDatabaseFileOwnership();
void History::OwnsDatabaseFile();
```

Furthermore this contains a number of unit test cases to verify the proper functionality of the auto-management feature.