### PR TITLE
FIX: Compiler Warnings in t_uuid.cc and t_dns.cc

### DIFF
--- a/test/unittests/t_dns.cc
+++ b/test/unittests/t_dns.cc
@@ -647,7 +647,7 @@ TEST_F(T_Dns, CaresResolverReadConfig) {
 
 TEST_F(T_Dns, CaresResolverBadResolver) {
   UniquePtr<CaresResolver> quick_resolver(CaresResolver::Create(false, 0, 100));
-  ASSERT_FALSE(quick_resolver == NULL);
+  ASSERT_TRUE(quick_resolver.IsValid());
 
   vector<string> bad_resolvers;
   bad_resolvers.push_back("127.0.0.2");
@@ -664,7 +664,7 @@ TEST_F(T_Dns, CaresResolverBadResolver) {
 TEST_F(T_Dns, CaresResolverTimeout) {
   // Because of backoff, timeout can actually be as high as 2s
   UniquePtr<CaresResolver> quick_resolver(CaresResolver::Create(false, 3, 200));
-  ASSERT_FALSE(quick_resolver == NULL);
+  ASSERT_TRUE(quick_resolver.IsValid());
 
   vector<string> bad_resolvers;
   bad_resolvers.push_back("127.0.0.2");
@@ -850,7 +850,7 @@ TEST_F(T_Dns, HostfileResolverMultipleAddresses) {
 
 TEST_F(T_Dns, NormalResolverConstruct) {
   UniquePtr<NormalResolver> resolver(NormalResolver::Create(false, 2, 2000));
-  ASSERT_TRUE(resolver != NULL);
+  ASSERT_TRUE(resolver.IsValid());
   ASSERT_EQ(resolver->domains(), resolver->cares_resolver_->domains());
   ASSERT_EQ(resolver->resolvers(), resolver->cares_resolver_->resolvers());
   ASSERT_EQ(resolver->timeout_ms(), resolver->cares_resolver_->timeout_ms());
@@ -859,13 +859,13 @@ TEST_F(T_Dns, NormalResolverConstruct) {
   int retval = setenv("HOST_ALIASES", "/no/such/file", 1);
   ASSERT_EQ(retval, 0);
   UniquePtr<NormalResolver> resolver2(NormalResolver::Create(false, 2, 2000));
-  ASSERT_TRUE(resolver2 == NULL);
+  ASSERT_FALSE(resolver2.IsValid());
 }
 
 
 TEST_F(T_Dns, NormalResolverSimple) {
   UniquePtr<NormalResolver> resolver(NormalResolver::Create(false, 2, 2000));
-  ASSERT_TRUE(resolver != NULL);
+  ASSERT_TRUE(resolver.IsValid());
 
   Host host = resolver->Resolve("localhost");
   EXPECT_EQ(host.status(), kFailOk);
@@ -877,7 +877,7 @@ TEST_F(T_Dns, NormalResolverSimple) {
 
 TEST_F(T_Dns, NormalResolverLocalonly) {
   UniquePtr<NormalResolver> resolver(NormalResolver::Create(false, 2, 2000));
-  ASSERT_TRUE(resolver != NULL);
+  ASSERT_TRUE(resolver.IsValid());
 
   vector<string> no_resolvers;
   no_resolvers.push_back("127.0.0.2");
@@ -889,7 +889,7 @@ TEST_F(T_Dns, NormalResolverLocalonly) {
 
 TEST_F(T_Dns, NormalResolverCombined) {
   UniquePtr<NormalResolver> resolver(NormalResolver::Create(false, 2, 2000));
-  ASSERT_TRUE(resolver != NULL);
+  ASSERT_TRUE(resolver.IsValid());
 
   vector<string> names;
   names.push_back("a.root-servers.net");

--- a/test/unittests/t_dns.cc
+++ b/test/unittests/t_dns.cc
@@ -19,18 +19,18 @@ class T_Dns : public ::testing::Test {
  protected:
   virtual void SetUp() {
     int retval = unsetenv("HOST_ALIASES");
-    assert(retval == 0);
+    ASSERT_EQ(0, retval);
     default_resolver =
       CaresResolver::Create(false /* ipv4_only */, 1 /* retries */, 2000);
-    assert(default_resolver);
+    ASSERT_TRUE(default_resolver);
     ipv4_resolver =
       CaresResolver::Create(true /* ipv4_only */, 1 /* retries */, 2000);
-    assert(ipv4_resolver);
+    ASSERT_TRUE(ipv4_resolver);
 
     fhostfile = CreateTempFile("/tmp/cvmfstest", 0600, "w", &hostfile);
-    assert(fhostfile);
+    ASSERT_TRUE(fhostfile);
     hostfile_resolver = HostfileResolver::Create(hostfile, false);
-    assert(hostfile_resolver);
+    ASSERT_TRUE(hostfile_resolver);
   }
 
   virtual ~T_Dns() {
@@ -44,9 +44,10 @@ class T_Dns : public ::testing::Test {
   void CreateHostfile(const string &content) {
     int retval = ftruncate(fileno(fhostfile), 0);
     rewind(fhostfile);
-    assert(retval == 0);
+    ASSERT_EQ(0, retval);
     int num = fprintf(fhostfile, "%s", content.c_str());
-    assert((num >= 0) && (unsigned(num) == content.length()));
+    ASSERT_LT(0, num);
+    ASSERT_EQ(unsigned(num), content.length());
     fflush(fhostfile);
   }
 

--- a/test/unittests/t_uuid.cc
+++ b/test/unittests/t_uuid.cc
@@ -52,7 +52,7 @@ TEST(T_Uuid, FromCache) {
 
 TEST(T_Uuid, FailWrite) {
   UniquePtr<Uuid> uuid(Uuid::Create("/no/such/path"));
-  EXPECT_TRUE(uuid.IsValid());
+  EXPECT_FALSE(uuid.IsValid());
 }
 
 TEST(T_Uuid, FailRead) {
@@ -62,7 +62,7 @@ TEST(T_Uuid, FailRead) {
   fclose(f);
   UnlinkGuard unlink_guard(path);
   UniquePtr<Uuid> uuid(Uuid::Create(path));
-  EXPECT_TRUE(uuid.IsValid());
+  EXPECT_FALSE(uuid.IsValid());
 }
 
 }  // namespace cvmfs

--- a/test/unittests/t_uuid.cc
+++ b/test/unittests/t_uuid.cc
@@ -12,8 +12,8 @@ namespace cvmfs {
 TEST(T_Uuid, Unique) {
   UniquePtr<Uuid> uuid(Uuid::Create(""));
   UniquePtr<Uuid> uuid2(Uuid::Create(""));
-  ASSERT_TRUE(uuid != NULL);
-  ASSERT_TRUE(uuid2 != NULL);
+  ASSERT_TRUE(uuid.IsValid());
+  ASSERT_TRUE(uuid2.IsValid());
   EXPECT_NE(uuid->uuid(), uuid2->uuid());
 }
 
@@ -26,7 +26,7 @@ TEST(T_Uuid, Create) {
   unlink(path.c_str());
 
   UniquePtr<Uuid> uuid(Uuid::Create(path));
-  ASSERT_TRUE(uuid != NULL);
+  ASSERT_TRUE(uuid.IsValid());
   UnlinkGuard unlink_guard(path);
 
   f = fopen(path.c_str(), "r");
@@ -46,13 +46,13 @@ TEST(T_Uuid, FromCache) {
   UnlinkGuard unlink_guard(path);
 
   UniquePtr<Uuid> uuid(Uuid::Create(path));
-  ASSERT_TRUE(uuid != NULL);
+  ASSERT_TRUE(uuid.IsValid());
   EXPECT_EQ("unique", uuid->uuid());
 }
 
 TEST(T_Uuid, FailWrite) {
   UniquePtr<Uuid> uuid(Uuid::Create("/no/such/path"));
-  EXPECT_TRUE(uuid == NULL);
+  EXPECT_TRUE(uuid.IsValid());
 }
 
 TEST(T_Uuid, FailRead) {
@@ -62,7 +62,7 @@ TEST(T_Uuid, FailRead) {
   fclose(f);
   UnlinkGuard unlink_guard(path);
   UniquePtr<Uuid> uuid(Uuid::Create(path));
-  EXPECT_TRUE(uuid == NULL);
+  EXPECT_TRUE(uuid.IsValid());
 }
 
 }  // namespace cvmfs


### PR DESCRIPTION
This fixes a couple of compiler warnings in `t_uuid.cc` and `t_dns.cc`. Googletest is pedantic when it comes to type safe comparisons. Furthermore I replaced some `assert()` calls by googletest's `ASSERT_TRUE()` with the advantage that this fails only the current test and doesn't kill the `cvmfs_unittests` binary entirely.

Some general remarks to the usage of googletest that I've seen in the code base:
* `ASSERT_EQ(<expected>, <actual>)` --> The first parameter is the expected value!
* `ASSERT_TRUE(a == b)` is bad practise, because there is an `ASSERT_EQ()`  