### PR TITLE
Feature: Configure Maximal Concurrent Upload Count

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3568,6 +3568,10 @@ publish() {
     if [ "x$CVMFS_GARBAGE_COLLECTION" = "xtrue" ]; then
       sync_command="$sync_command -g"
     fi
+    if [ "x$CVMFS_MAXIMAL_CONCURRENT_WRITES" != "x" ]; then
+      sync_command="$sync_command -q $CVMFS_MAXIMAL_CONCURRENT_WRITES"
+    fi
+    echo $sync_command
     local tag_command="$swissknife tag_create \
       -r $upstream                            \
       -w $stratum0                            \

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -510,16 +510,25 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     params.manual_revision = String2Uint64(*args.find('v')->second);
   }
 
+  if (args.find('q') != args.end()) {
+    params.max_concurrent_write_jobs = String2Uint64(*args.find('q')->second);
+  }
+
   if (!CheckParams(params)) return 2;
 
   // Start spooler
-  const upload::SpoolerDefinition spooler_definition(
+  upload::SpoolerDefinition spooler_definition(
     params.spooler_definition,
     hash_algorithm,
     params.use_file_chunking,
     params.min_file_chunk_size,
     params.avg_file_chunk_size,
     params.max_file_chunk_size);
+  if (params.max_concurrent_write_jobs > 0) {
+    spooler_definition.number_of_concurrent_uploads =
+                                               params.max_concurrent_write_jobs;
+  }
+
   params.spooler = upload::Spooler::Construct(spooler_definition);
   if (NULL == params.spooler)
     return 3;

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -24,7 +24,8 @@ struct SyncParameters {
     min_file_chunk_size(4*1024*1024),
     avg_file_chunk_size(8*1024*1024),
     max_file_chunk_size(16*1024*1024),
-    manual_revision(0) {}
+    manual_revision(0),
+    max_concurrent_write_jobs(0) {}
 
   upload::Spooler *spooler;
   std::string      dir_union;
@@ -48,6 +49,7 @@ struct SyncParameters {
   size_t           avg_file_chunk_size;
   size_t           max_file_chunk_size;
   uint64_t         manual_revision;
+  uint64_t         max_concurrent_write_jobs;
 };
 
 namespace catalog {
@@ -207,6 +209,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Optional ('e', "hash algorithm (default: SHA-1)"));
     r.push_back(Parameter::Optional ('j', "catalog entry warning threshold"));
     r.push_back(Parameter::Optional ('v', "manual revision number"));
+    r.push_back(Parameter::Optional ('q', "number of concurrent write jobs"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -19,7 +19,7 @@ void AbstractUploader::RegisterPlugins() {
 AbstractUploader::AbstractUploader(const SpoolerDefinition& spooler_definition) :
   spooler_definition_(spooler_definition),
   torn_down_(false),
-  jobs_in_flight_(spooler_definition.number_of_threads * 100) {}
+  jobs_in_flight_(spooler_definition.number_of_concurrent_uploads) {}
 
 
 bool AbstractUploader::Initialize() {

--- a/cvmfs/upload_spooler_definition.cc
+++ b/cvmfs/upload_spooler_definition.cc
@@ -13,12 +13,12 @@
 using namespace upload;
 
 SpoolerDefinition::SpoolerDefinition(
-                      const std::string& definition_string,
-                      const shash::Algorithms hash_algorithm,
-                      const bool         use_file_chunking,
-                      const size_t       min_file_chunk_size,
-                      const size_t       avg_file_chunk_size,
-                      const size_t       max_file_chunk_size) :
+                      const std::string&       definition_string,
+                      const shash::Algorithms  hash_algorithm,
+                      const bool               use_file_chunking,
+                      const size_t             min_file_chunk_size,
+                      const size_t             avg_file_chunk_size,
+                      const size_t             max_file_chunk_size) :
   driver_type(Unknown),
   hash_algorithm(hash_algorithm),
   use_file_chunking(use_file_chunking),
@@ -26,6 +26,7 @@ SpoolerDefinition::SpoolerDefinition(
   avg_file_chunk_size(avg_file_chunk_size),
   max_file_chunk_size(max_file_chunk_size),
   number_of_threads(tbb::task_scheduler_init::default_num_threads()),
+  number_of_concurrent_uploads(number_of_threads * 100),
   valid_(false)
 {
   // check if given file chunking values are sane

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -34,12 +34,12 @@ struct SpoolerDefinition {
    * @param definition_string   the spooler definition string to be inter-
    *                            preted by the constructor
    */
-  explicit SpoolerDefinition(const std::string  &definition_string,
-                             const shash::Algorithms hash_algorithm,
-                             const bool          use_file_chunking   = false,
-                             const size_t        min_file_chunk_size = 0,
-                             const size_t        avg_file_chunk_size = 0,
-                             const size_t        max_file_chunk_size = 0);
+  explicit SpoolerDefinition(const std::string       &definition_string,
+                             const shash::Algorithms  hash_algorithm,
+                             const bool               use_file_chunking   = false,
+                             const size_t             min_file_chunk_size = 0,
+                             const size_t             avg_file_chunk_size = 0,
+                             const size_t             max_file_chunk_size = 0);
   bool IsValid() const { return valid_; }
 
   DriverType  driver_type;           //!< the type of the spooler driver
@@ -54,6 +54,7 @@ struct SpoolerDefinition {
   size_t             max_file_chunk_size;
 
   const unsigned int number_of_threads;
+  unsigned int       number_of_concurrent_uploads;
 
   bool valid_;
 };


### PR DESCRIPTION
This is related to [CVM-703](https://sft.its.cern.ch/jira/browse/CVM-703) and allows to configure the number of maximal concurrent writes in the `server.conf` using `CVMFS_MAXIMAL_CONCURRENT_WRITES=...`. However, I would not sell this as a real feature, yet. It configures the maximal number of upload jobs in the queue rather than actual concurrency. At least for the local uploader (into POSIX based backends) there is no real write concurrency right now. S3 does a better job with the cURL multi API, I believe.

Anyway, it doesn't hurt to have this configurable. We'll anyway need to have a deeper look into optimising the write backend so real concurrency, async I/O or similar is left to be implemented...