### PR TITLE
FIX: Remove Unintentional Debug Print

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3571,7 +3571,6 @@ publish() {
     if [ "x$CVMFS_MAXIMAL_CONCURRENT_WRITES" != "x" ]; then
       sync_command="$sync_command -q $CVMFS_MAXIMAL_CONCURRENT_WRITES"
     fi
-    echo $sync_command
     local tag_command="$swissknife tag_create \
       -r $upstream                            \
       -w $stratum0                            \


### PR DESCRIPTION
Removes an accidentally added debug print from `cvmfs_server`.