### PR TITLE
Fix: Leaked Temporary Catalog Files during Publish

### DIFF
--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -774,8 +774,9 @@ catalog::Catalog *CatalogManager::CreateCatalog(const PathString  &mountpoint,
 /**
  * Triggered when the catalog is attached (db file opened)
  */
-void CatalogManager::ActivateCatalog(const catalog::Catalog *catalog) {
-  const catalog::Counters &counters = catalog->GetCounters();
+void CatalogManager::ActivateCatalog(catalog::Catalog *catalog) {
+  const catalog::Counters &counters =
+                    const_cast<const catalog::Catalog*>(catalog)->GetCounters();
   if (catalog->IsRoot()) {
     all_inodes_ = counters.GetAllEntries();
   }

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -96,7 +96,7 @@ class CatalogManager : public catalog::AbstractCatalogManager {
   catalog::Catalog* CreateCatalog(const PathString &mountpoint,
                                   const shash::Any  &catalog_hash,
                                   catalog::Catalog *parent_catalog);
-  void ActivateCatalog(const catalog::Catalog *catalog);
+  void ActivateCatalog(catalog::Catalog *catalog);
 
  private:
   catalog::LoadError LoadCatalogCas(const shash::Any &hash,

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -228,7 +228,7 @@ class AbstractCatalogManager : public SingleCopy {
                                 std::string  *catalog_path,
                                 shash::Any   *catalog_hash) = 0;
   virtual void UnloadCatalog(const Catalog *catalog) { };
-  virtual void ActivateCatalog(const Catalog *catalog) { };
+  virtual void ActivateCatalog(Catalog *catalog) { };
 
   /**
    * Create a new Catalog object.

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -654,6 +654,8 @@ manifest::Manifest *WritableCatalogManager::Commit(const bool     stop_for_tweak
   WritableCatalogList catalogs_to_snapshot;
   GetModifiedCatalogs(&catalogs_to_snapshot);
 
+  spooler_->RegisterListener(&WritableCatalogManager::CatalogUploadCallback, this);
+
   manifest::Manifest *result = NULL;
   for (WritableCatalogList::iterator i = catalogs_to_snapshot.begin(),
        iEnd = catalogs_to_snapshot.end(); i != iEnd; ++i)
@@ -709,6 +711,8 @@ manifest::Manifest *WritableCatalogManager::Commit(const bool     stop_for_tweak
       result->set_revision((*i)->GetRevision());
     }
   }
+
+  spooler_->UnregisterListeners();
 
   return result;
 }
@@ -809,6 +813,17 @@ shash::Any WritableCatalogManager::SnapshotCatalog(WritableCatalog *catalog)
   }
 
   return hash_catalog;
+}
+
+void WritableCatalogManager::CatalogUploadCallback(
+                                          const upload::SpoolerResult &result) {
+  if (result.return_code != 0) {
+    LogCvmfs(kLogCatalog, kLogStderr, "failed to upload '%s' (retval: %d)",
+             result.local_path.c_str(), result.return_code);
+    assert (false);
+  }
+
+  unlink(result.local_path.c_str());
 }
 
 }

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -69,6 +69,11 @@ Catalog* WritableCatalogManager::CreateCatalog(const PathString &mountpoint,
 }
 
 
+void WritableCatalogManager::ActivateCatalog(Catalog *catalog) {
+  catalog->TakeDatabaseFileOwnership();
+}
+
+
 /**
  * This method is invoked if we create a completely new repository.
  * The new root catalog will already contain a root entry.

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -37,6 +37,7 @@
 
 #include "catalog_rw.h"
 #include "catalog_mgr_ro.h"
+#include "upload_spooler_result.h"
 
 namespace upload {
 class Spooler;
@@ -125,6 +126,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
                                      WritableCatalogList *result) const;
 
   shash::Any SnapshotCatalog(WritableCatalog *catalog) const;
+  void CatalogUploadCallback(const upload::SpoolerResult &result);
 
  private:
   inline void SyncLock() { pthread_mutex_lock(sync_lock_); }

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -105,6 +105,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   Catalog* CreateCatalog(const PathString &mountpoint,
                          const shash::Any &catalog_hash,
                          Catalog *parent_catalog);
+  void ActivateCatalog(Catalog *catalog);
 
   void AddFile(const DirectoryEntry  &entry,
                const std::string     &parent_directory);


### PR DESCRIPTION
This fixes a problem with the catalog handling during publish. Temporary files for downloaded, opened and committed catalogs were not cleaned up properly. I've reused the auto-cleanup feature implemented [earlier this week](https://github.com/cvmfs/cvmfs/pull/667) to take care of opened writable catalogs. Besides that, committed (and compressed) catalog files needed to be treated asynchronously in a callback. 