### PR TITLE
FIX: Always set Correct HTTP Verb

### DIFF
--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -532,7 +532,19 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
                                            "",
                                            info->bucket,
                                            info->object_key).c_str());
+    info->http_headers =
+        curl_slist_append(info->http_headers, "Content-Length: 0");
+
+    if (info->request == JobInfo::kReqDelete) {
+      retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, req.c_str());
+      assert(retval == CURLE_OK);
+    } else {
+      retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, NULL);
+      assert(retval == CURLE_OK);
+    }
   } else {
+    retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, NULL);
+    assert(retval == CURLE_OK);
     retval = curl_easy_setopt(handle, CURLOPT_UPLOAD, 1);
     assert(retval == CURLE_OK);
     retval = curl_easy_setopt(handle, CURLOPT_NOBODY, 0);


### PR DESCRIPTION
Cherry-picked a missing commit from Seppo to fix the proper setting of HTTP verbs in curl handles. This fixes a problem with the garbage collection in conjunction with the S3 backend. (Thanks for the hint on that, @ssheikki).