### PR TITLE
Feature: Auto Recover Mountpoints

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3371,6 +3371,7 @@ abort() {
     # sanity checks
     is_stratum0 $name   || { echo "Repository $name is not a stratum 0 repository"; retcode=1; continue; }
     is_publishing $name && { echo "Repository $name is currently published (aborting abort)"; retcode=1; continue; }
+    health_check $name
 
     # get repository information
     load_repo_config $name
@@ -3478,8 +3479,8 @@ publish() {
 
     # sanity checks
     is_stratum0 $name   || die "This is not a stratum 0 repository"
-    health_check $name
     is_publishing $name && die "Another publish process is active for $name"
+    health_check $name
 
     # get repository information
     load_repo_config $name
@@ -3705,8 +3706,8 @@ rollback() {
   # sanity checks
   check_repository_existence $name || die "The repository $name does not exist"
   is_stratum0 $name                || die "This is not a stratum 0 repository"
-  health_check $name
   is_publishing $name              && die "Repository $name is currently being published"
+  health_check $name
 
   # get repository information
   load_repo_config $name

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3636,14 +3636,14 @@ publish() {
                -z $tst || { local err=$?; publish_failed $name; die "Garbage collection failed ($err)"; }
     fi
 
-    # committing newly created revision
-    echo "Signing new manifest"
-    sign_manifest $name $manifest || { publish_failed $name; die "Signing failed"; }
-    set_ro_root_hash $name $trunk_hash
-
     # finalizing transaction
     echo "Flushing file system buffers"
     sync
+
+    # committing newly created revision
+    echo "Signing new manifest"
+    sign_manifest $name $manifest      || { publish_failed $name; die "Signing failed"; }
+    set_ro_root_hash $name $trunk_hash || { publish_failed $name; die "Root hash update failed"; }
 
     # check again for open file descriptors (potential race condition)
     if has_file_descriptors_on_mount_point $name && \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1166,15 +1166,15 @@ health_check() {
   if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
     echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly." >&2
     [ x"$auto_repair" = x"true" ] || exit 1
-    echo "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly..."
-    cvmfs_suid_helper rdonly_mount $name && echo "success" || { echo "fail"; exit 1; }
+    echo -n "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... "
+    cvmfs_suid_helper rdonly_mount $name > /dev/null && echo "success" || { echo "fail"; exit 1; }
   fi
 
   # check mounted union file system
   if ! is_mounted "/cvmfs/$name"; then
     echo "/cvmfs/$name is not mounted properly." >&2
     [ x"$auto_repair" = x"true" ] || exit 1
-    echo "Note: Trying to mount /cvmfs/${name}..."
+    echo -n "Note: Trying to mount /cvmfs/${name}... "
     cvmfs_suid_helper rw_mount $name && echo "success" || { echo "fail"; exit 1; }
   fi
 
@@ -1183,14 +1183,14 @@ health_check() {
     if ! is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
       echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
       [ x"$auto_repair" = x"true" ] || exit 1
-      echo "Note: Trying to re-mount /cvmfs/${name} read/write..."
+      echo -n "Note: Trying to re-mount /cvmfs/${name} read/write... "
       cvmfs_suid_helper open $name && echo "success" || { echo "fail"; exit 1; }
     fi
   else
     if ! is_mounted "/cvmfs/$name" "^.* ro[, ].*$"; then
       echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
       [ x"$auto_repair" = x"true" ] || exit 1
-      echo "Note: Trying to re-mount /cvmfs/${name} read-only..."
+      echo -n "Note: Trying to re-mount /cvmfs/${name} read-only... "
       cvmfs_suid_helper lock $name && echo "success" || { echo "fail"; exit 1; }
     fi
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1131,6 +1131,9 @@ health_check() {
   local name=$1
   local quiet=${2-0}
 
+  load_repo_config $name
+  local auto_repair="$CVMFS_AUTO_REPAIR_MOUNTPOINT"
+
   # for stratum 1 repositories there are no health checks
   if is_stratum1 $name; then
     return 0
@@ -1149,7 +1152,6 @@ health_check() {
 
   # check configuration for harzardous AUFS setup
   if [ $quiet -eq 0 ] && find_hazardous_aufs_config $name; then
-    load_repo_config $name
     echo "WARNING: AUFS config is vulnerable to kernel deadlocks. Please store "
     echo "         the scratch space and the cvmfs client cache on different "
     echo "         partitions. (Silence this with CVMFS_AUFS_WARNING=false)"
@@ -1160,24 +1162,36 @@ health_check() {
     echo ""
   fi
 
-  # check mounted union file system
-  if ! is_mounted "/cvmfs/$name"; then
-    die "/cvmfs/$name is not mounted properly."
+  # check mounted read-only cvmfs client
+  if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
+    echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly." >&2
+    [ x"$auto_repair" = x"true" ] || exit 1
+    echo "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly..."
+    cvmfs_suid_helper rdonly_mount $name && echo "success" || { echo "fail"; exit 1; }
   fi
 
-  # check mounted read-only cvmfs client
-  if ! is_mounted "/var/spool/cvmfs/$name/rdonly"; then
-    die "/var/spool/cvmfs/$name/rdonly is not mounted properly."
+  # check mounted union file system
+  if ! is_mounted "/cvmfs/$name"; then
+    echo "/cvmfs/$name is not mounted properly." >&2
+    [ x"$auto_repair" = x"true" ] || exit 1
+    echo "Note: Trying to mount /cvmfs/${name}..."
+    cvmfs_suid_helper rw_mount $name && echo "success" || { echo "fail"; exit 1; }
   fi
 
   # check transaction status
   if is_in_transaction $name; then
     if ! is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
-      die "$name is in a transaction but /cvmfs/$name is not mounted read/write"
+      echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
+      [ x"$auto_repair" = x"true" ] || exit 1
+      echo "Note: Trying to re-mount /cvmfs/${name} read/write..."
+      cvmfs_suid_helper open $name && echo "success" || { echo "fail"; exit 1; }
     fi
   else
     if ! is_mounted "/cvmfs/$name" "^.* ro[, ].*$"; then
-      die "$name is not in a transaction but /cvmfs/$name is mounted read/write"
+      echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
+      [ x"$auto_repair" = x"true" ] || exit 1
+      echo "Note: Trying to re-mount /cvmfs/${name} read-only..."
+      cvmfs_suid_helper lock $name && echo "success" || { echo "fail"; exit 1; }
     fi
   fi
 
@@ -1671,6 +1685,7 @@ CVMFS_UNION_FS_TYPE=$unionfs
 CVMFS_HASH_ALGORITHM=$hash_algo
 CVMFS_AUTO_TAG=$autotagging
 CVMFS_GARBAGE_COLLECTION=$garbage_collectable
+CVMFS_AUTO_REPAIR_MOUNTPOINT=true
 EOF
 
   # append GC specific configuration

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1136,6 +1136,17 @@ health_check() {
     return 0
   fi
 
+  # health check cannot deal with repositories currently being published
+  if is_publishing $name; then
+    echo "WARNING: The repository $name is currently publishing and should not"
+    echo "be touched. If you are absolutely sure, that this is _not_ the case,"
+    echo "please run the following command and retry:"
+    echo
+    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing"
+    echo
+    exit 1
+  fi
+
   # check configuration for harzardous AUFS setup
   if [ $quiet -eq 0 ] && find_hazardous_aufs_config $name; then
     load_repo_config $name

--- a/test/src/536-healthcheck/main
+++ b/test/src/536-healthcheck/main
@@ -12,6 +12,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
+  sudo sed -i "s/^\(CVMFS_AUTO_REPAIR_MOUNTPOINT\)=.*\$/\1=false/" $server_conf
+
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
 
@@ -35,7 +38,7 @@ cvmfs_run_test() {
   sudo umount $rd_only || return 5
 
   echo "check the repository (failure is expected)"
-  cvmfs_server check $CVMFS_TEST_REPO 2>&1 | grep -q "$repo_dir is not mounted" || return 6
+  cvmfs_server check $CVMFS_TEST_REPO 2>&1 | grep -q "$rd_only is not mounted" || return 6
 
   echo "mount union file system mountpoint"
   sudo mount $repo_dir || return 7

--- a/test/src/536-healthcheck/main
+++ b/test/src/536-healthcheck/main
@@ -1,4 +1,4 @@
-cvmfs_test_name="Repository Health Check"
+cvmfs_test_name="Repository Health Check (Disabled Auto-Repair)"
 cvmfs_test_autofs_on_startup=false
 
 

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -1,0 +1,136 @@
+cvmfs_test_name="Auto-Repair Bogus Mountpoints"
+cvmfs_test_autofs_on_startup=false
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local rd_only=/var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly
+
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "read repository configuration"
+  load_repo_config $CVMFS_TEST_REPO || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "filling the repository with contents of /bin"
+  cp_bin $repo_dir || return 1
+
+  echo "creating CVMFS snapshot"
+  cvmfs_server publish $CVMFS_TEST_REPO || return 2
+
+  echo "remember the root hash of this revision"
+  local old_root_hash
+  old_root_hash="$(attr -qg root_hash $rd_only)"
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "unmount union file system mountpoint"
+  sudo umount $repo_dir || return 3
+
+  echo "check the repository"
+  local check_log_1="check_1.log"
+  cvmfs_server check $CVMFS_TEST_REPO > $check_log_1 2>&1 || return 4
+
+  echo "check the error and warning messages"
+  cat $check_log_1 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"  || return 5
+  cat $check_log_1 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}" || return 6
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "unmount union file system mountpoint"
+  sudo umount $repo_dir || return 7
+
+  echo "unmount read-only cvmfs branch"
+  sudo umount $rd_only || return 8
+
+  echo "check the repository"
+  local check_log_2="check_2.log"
+  cvmfs_server check $CVMFS_TEST_REPO > $check_log_2 2>&1 || return 9
+
+  echo "check the error and warning messages"
+  cat $check_log_2 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted"    || return 10
+  cat $check_log_2 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly" || return 11
+  cat $check_log_2 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"    || return 12
+  cat $check_log_2 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"   || return 13
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "remount union file system read/write"
+  sudo mount -o remount,rw $repo_dir || return 14
+
+  echo "open transaction"
+  local check_log_3="check_3.log"
+  start_transaction $CVMFS_TEST_REPO > $check_log_3 2>&1 || return 15
+
+  echo "check the error and warning messages"
+  cat $check_log_3 | grep -e "not in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* mounted read/write" || return 16
+  cat $check_log_3 | grep -e "Trying to re-mount /cvmfs/${CVMFS_TEST_REPO}" || return 17
+
+  echo "check if transaction is open"
+  [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 18
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "remount union file system read-only"
+  sudo mount -o remount,ro $repo_dir || return 19
+
+  echo "abort transaction"
+  local check_log_4="check_4.log"
+  abort_transaction $CVMFS_TEST_REPO > $check_log_4 2>&1 || return 20
+
+  echo "check the error and warning messages"
+  cat $check_log_4 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 21
+  cat $check_log_4 | grep -e "Trying to re-mount /cvmfs/${CVMFS_TEST_REPO} read/write"                    || return 22
+
+  echo "check if transaction is closed"
+  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 23
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "check the repository's integrity"
+  check_repository $CVMFS_TEST_REPO -i || return 24
+
+  echo "create a fresh transaction"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "create a snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check repository integrity"
+  check_repository $CVMFS_TEST_REPO -i || return 25
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "open transaction"
+  start_transaction $CVMFS_TEST_REPO || return 26
+
+  echo "umount both $repo_dir and $rd_only"
+  sudo umount $repo_dir || return 27
+  sudo umount $rd_only  || return 28
+
+  echo "publish transaction"
+  local check_log_5="check_5.log"
+  publish_repo $CVMFS_TEST_REPO > $check_log_5 2>&1 || return 29
+
+  echo "check the error and warning messages"
+  cat $check_log_5 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted"                                   || return 30
+  cat $check_log_5 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly"                                || return 31
+  cat $check_log_5 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"                                   || return 32
+  cat $check_log_5 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"                                  || return 33
+  cat $check_log_5 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 34
+  cat $check_log_5 | grep -e "Trying to re-mount /cvmfs/${CVMFS_TEST_REPO} read/write"                    || return 35
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "check repository integrity"
+  check_repository $CVMFS_TEST_REPO -i || return 36
+
+  return 0
+}
+


### PR DESCRIPTION
We've seen the stratum 0 repository mount and transaction state get out of sync in certain occasions. CernVM-FS 2.1.19 was able to detect that inconsistency but didn't recover from it ([CVM-650](https://sft.its.cern.ch/jira/browse/CVM-650)). This extends the health check to automatically mount the repository's mount points as expected by the transaction state. Using the configuration variable `CVMFS_AUTO_REPAIR_MOUNTPOINT` one can disable this repair mechanism and go back to the same behaviour as 2.1.19.

There is one more health check making sure that the stored base hash is equal to the currently mounted hash. I will take care of that one in an independent pull request.

Additionally this contains adaptions to the previous health check test case (536) which makes use of the `CVMFS_AUTO_REPAIR_MOUNTPOINT` opt-out. Furthermore there is an integration test to check if the auto mountpoint recovery works properly.