### PR TITLE
Fix: Garbage Collection in cvmfs_server snapshot

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4025,17 +4025,17 @@ snapshot() {
       echo "Initial snapshot"
     fi
 
-    # put a magic file in the repository root to signal a snapshot in progress
-    $user_shell "date > ${spool_dir}/tmp/snapshotting"
-    $user_shell "cvmfs_swissknife upload -r ${upstream} \
-      -i ${spool_dir}/tmp/snapshotting \
-      -o .cvmfs_is_snapshotting"
-
     # command to remove the magic file when finished (or aborted)
     delete_command="cvmfs_swissknife remove \
                       -r ${upstream} \
                       -o .cvmfs_is_snapshotting"
     trap "$delete_command" HUP INT TERM QUIT
+
+    # put a magic file in the repository root to signal a snapshot in progress
+    $user_shell "date > ${spool_dir}/tmp/snapshotting"
+    $user_shell "cvmfs_swissknife upload -r ${upstream} \
+      -i ${spool_dir}/tmp/snapshotting \
+      -o .cvmfs_is_snapshotting"
 
     # do the actual snapshot actions
     $user_shell "cvmfs_swissknife pull -m $name \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3937,14 +3937,13 @@ __run_gc() {
 
   # do it!
   local user_shell="$(get_user_shell $name)"
-
   local gc_command="cvmfs_swissknife gc -r $repository_url         \
                                         -u $CVMFS_UPSTREAM_STORAGE \
                                         -n $CVMFS_REPOSITORY_NAME  \
                                         -k $CVMFS_PUBLIC_KEY       \
                                         -t ${CVMFS_SPOOL_DIR}/tmp/ \
                                         $additional_switches"
-  $user_shell "$gc_command" || return 5
+  $user_shell "$gc_command" || return 6
 
   if is_stratum0 $name && [ $dry_run -eq 0 ]; then
     tag_command="cvmfs_swissknife tag_empty_bin \
@@ -3956,7 +3955,7 @@ __run_gc() {
       -f $name                                  \
       -b $base_hash                             \
       -e $CVMFS_HASH_ALGORITHM"
-    $user_shell "$tag_command" || return 6
+    $user_shell "$tag_command" || return 7
   fi
 
   return 0

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4052,7 +4052,7 @@ snapshot() {
       -o .cvmfs_last_snapshot"
 
     # run the automatic garbage collection (if configured)
-    if is_garbage_collectable $name && [ ! -z "$CVMFS_GC_TIMESTAMP_THRESHOLD" ]
+    if is_garbage_collectable $alias_name && [ ! -z "$CVMFS_GC_TIMESTAMP_THRESHOLD" ]
     then
       echo "Running automatic garbage collection"
       local tst="$(date --date "$CVMFS_GC_TIMESTAMP_THRESHOLD" +%s 2>/dev/null)"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3876,8 +3876,8 @@ gc() {
     [ $preserve_timestamp   -gt 0 ] && additional_switches="$additional_switches -z $preserve_timestamp"
 
     # retrieve the base hash of the repository to be editied
-    local base_hash="xx"
-    local manifest="xx"
+    local base_hash=""
+    local manifest=""
 
     # gather extra information for a stratum0 repository and open a transaction
     if is_stratum0 $name; then

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -67,7 +67,7 @@ int CommandGc::Main(const ArgumentList &args) {
   download_manager.Init(1, true);
   signature_manager.Init();
   if (! signature_manager.LoadPublicRsaKeys(repo_keys)) {
-    LogCvmfs(kLogCatalog, kLogStderr, "Failed to load public key(s)");
+    LogCvmfs(kLogCatalog, kLogStderr, "failed to load public key(s)");
     return 1;
   }
 
@@ -78,7 +78,12 @@ int CommandGc::Main(const ArgumentList &args) {
                                &signature_manager);
 
   UniquePtr<manifest::Manifest> manifest(object_fetcher.FetchManifest());
-  if (! manifest || ! manifest->garbage_collectable()) {
+  if (! manifest.IsValid()) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load repository manifest");
+    return 1;
+  }
+
+  if (! manifest->garbage_collectable()) {
     LogCvmfs(kLogCvmfs, kLogStderr, "repository does not allow garbage collection");
     return 1;
   }


### PR DESCRIPTION
This fixes a problem with the automatic garbage collection in `cvmfs_server snapshot` when the replication has an alias name. Furthermore it contains some minor logging improvements.