### PR TITLE
Fix: Memory Error in Sql::Bind<>

### DIFF
--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -300,6 +300,14 @@ class Sql {
     last_error_code_ = sqlite3_bind_text(statement_, index, value, size, dtor);
     return Successful();
   }
+
+  /**
+   * Figures out the type to be bound by template parameter deduction
+   * NOTE: For strings or char* buffers this is suboptimal, since it needs to
+   *       assume that the provided buffer is transient and copy it to be sure.
+   *       Furthermore, for char* buffers we need to assume a null-terminated
+   *       C-like string to obtain its length using strlen().
+   */
   template <typename T>
   inline bool Bind(const int index, const T value);
 

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -285,7 +285,10 @@ class Sql {
     return Successful();
   }
   bool BindTextTransient(const int index, const std::string &value) {
-    return BindText(index, value.data(), value.length(), SQLITE_TRANSIENT);
+    return BindTextTransient(index, value.data(), value.length());
+  }
+  bool BindTextTransient(const int index, const char *value, const int size) {
+    return BindText(index, value, size, SQLITE_TRANSIENT);
   }
   bool BindText(const int index, const std::string &value) {
     return BindText(index, value.data(), value.length(), SQLITE_STATIC);

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -349,8 +349,8 @@ class Sql {
    */
   inline bool Successful() const {
     return SQLITE_OK   == last_error_code_ ||
-    SQLITE_ROW  == last_error_code_ ||
-    SQLITE_DONE == last_error_code_;
+           SQLITE_ROW  == last_error_code_ ||
+           SQLITE_DONE == last_error_code_;
   }
 
   sqlite3_stmt *statement_;

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -276,7 +276,6 @@ bool Database<DerivedT>::SetProperty(const std::string &key,
          set_property_->Reset();
 }
 
-
 template <class DerivedT>
 std::string Database<DerivedT>::GetLastErrorMsg() const {
   const std::string msg = sqlite3_errmsg(sqlite_db_);

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -363,12 +363,12 @@ inline bool Sql::Bind(const int index, const sqlite3_int64 value) {
 
 template <>
 inline bool Sql::Bind(const int index, const std::string value) {
-  return this->BindText(index, value);
+  return this->BindTextTransient(index, value);
 }
 
 template <>
 inline bool Sql::Bind(const int index, const char *value) {
-  return this->BindText(index, value);
+  return this->BindTextTransient(index, value, strlen(value));
 }
 
 template <>

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -515,8 +515,8 @@ TEST_F(T_SQLite_Wrapper, DataAccess) {
 
     EXPECT_TRUE (db1->BeginTransaction());
     for (int i = 0; i < entry_count; ++i) {
-      EXPECT_TRUE(insert.Bind(1, "foobar!" + StringifyInt(i)));
-      EXPECT_TRUE(insert.Bind(2, "this is a very useless text!!"));
+      EXPECT_TRUE(insert.BindTextTransient(1, "foobar!" + StringifyInt(i)));
+      EXPECT_TRUE(insert.BindText         (2, "this is a very useless text!!"));
       EXPECT_TRUE(insert.Execute());
       EXPECT_TRUE(insert.Reset());
     }
@@ -558,8 +558,8 @@ TEST_F(T_SQLite_Wrapper, VacuumDatabase) {
 
     EXPECT_TRUE (db1->BeginTransaction());
     for (int i = 0; i < entry_count; ++i) {
-      EXPECT_TRUE(insert.Bind(1, "foobar!" + StringifyInt(i)));
-      EXPECT_TRUE(insert.Bind(2, "this is a very useless text!!"));
+      EXPECT_TRUE(insert.BindTextTransient(1, "foobar!" + StringifyInt(i)));
+      EXPECT_TRUE(insert.BindText         (2, "this is a very useless text!!"));
       EXPECT_TRUE(insert.Execute());
       EXPECT_TRUE(insert.Reset());
     }
@@ -634,10 +634,11 @@ TEST_F(T_SQLite_Wrapper, FailingCompaction) {
                                           "VALUES (:f, :b);");
 
     EXPECT_TRUE (db1->BeginTransaction());
-    for (int i = 0; i < entry_count; ++i) {
-      EXPECT_TRUE(insert.Bind(1, "foobar!" + StringifyInt(i)));
-      EXPECT_TRUE(insert.Bind(2, "this is a very useless text!!"));
+    for (int i = 1; i < entry_count; ++i) {
+      EXPECT_TRUE(insert.BindTextTransient(1, "foobar!" + StringifyInt(i)));
+      EXPECT_TRUE(insert.BindText         (2, "this is a very useless text!!"));
       EXPECT_TRUE(insert.Execute());
+
       EXPECT_TRUE(insert.Reset());
     }
     EXPECT_TRUE (db1->CommitTransaction());


### PR DESCRIPTION
This fixes the 'sporadic SQL insert failure' that showed up in some unit test cases. There is a convenience method `Sql::Bind<>()` that binds a specific value to an internal SQLite query placeholder and uses template parameter deduction to figure out which concrete `Sql::Bind...()` method to use (f.e. `BindInteger()`, `BindDouble()`, ...). For `std::string` it was using `BindText()` which just binds a pointer to the internal string buffer. This is fine for strings that stay around until `Sql::Execute()` is called on the same query object. Hence, it was causing undefined behaviour when using `Sql::Bind<>()` with temporary strings like:

```C++
const int bar = 1337;
Sql q(db, "INSERT INTO foo (:bar);")
q->Bind(1, "foo" + StringifyInt(bar)); // binding a temporary (resulted in undefined behaviour)
q->Execute();
```

The `Sql::Bind<std::string>()` method now uses `Sql::BindTextTransient()` to avoid this problem. However, this comes at the cost of copying strings in any case, even if it is not necessary. In general this shouldn't be a big deal, but if binding large strings to a query it is probably beneficial to use the concrete `Sql::BindText()` instead of the convenience method. I've added a comment to `Sql::Bind<>()` for clarification.