### PR TITLE
TEST: Disable Integration Tests 577 and 579

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -60,13 +60,15 @@ run_unittests --gtest_shuffle || ut_retval=$?
 
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&         \
-./run.sh $TEST_LOGFILE -x src/004-davinci              \
-                          src/007-testjobs             \
-                          src/045-oasis                \
-                          src/518-hardlinkstresstest   \
-                          src/523-corruptchunkfailover \
-                          src/524-corruptmanifestfailover || it_retval=$?
+export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&                         \
+./run.sh $TEST_LOGFILE -x src/004-davinci                              \
+                          src/007-testjobs                             \
+                          src/045-oasis                                \
+                          src/518-hardlinkstresstest                   \
+                          src/523-corruptchunkfailover                 \
+                          src/524-corruptmanifestfailover              \
+                          src/577-garbagecollecthiddenstratum1revision \
+                          src/579-garbagecollectstratum1legacytag || it_retval=$?
 
 echo "running CernVM-FS migration test cases..."
 ./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -45,12 +45,14 @@ run_unittests --gtest_shuffle \
 
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&         \
-./run.sh $TEST_LOGFILE -x src/005-asetup               \
-                          src/024-reload-during-asetup \
-                          src/518-hardlinkstresstest   \
-                          src/523-corruptchunkfailover \
-                          src/524-corruptmanifestfailover || it_retval=$?
+export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&                         \
+./run.sh $TEST_LOGFILE -x src/005-asetup                               \
+                          src/024-reload-during-asetup                 \
+                          src/518-hardlinkstresstest                   \
+                          src/523-corruptchunkfailover                 \
+                          src/524-corruptmanifestfailover              \
+                          src/577-garbagecollecthiddenstratum1revision \
+                          src/579-garbagecollectstratum1legacytag || it_retval=$?
 
 echo -n "starting FakeS3 service... "
 fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=$?; die "fail"; }

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -15,13 +15,15 @@ run_unittests --gtest_shuffle \
 
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/004-davinci                 \
-                          src/005-asetup                  \
-                          src/007-testjobs                \
-                          src/024-reload-during-asetup    \
-                          src/045-oasis                   \
-                          src/523-corruptchunkfailover    \
-                          src/524-corruptmanifestfailover || it_retval=$?
+./run.sh $TEST_LOGFILE -x src/004-davinci                              \
+                          src/005-asetup                               \
+                          src/007-testjobs                             \
+                          src/024-reload-during-asetup                 \
+                          src/045-oasis                                \
+                          src/523-corruptchunkfailover                 \
+                          src/524-corruptmanifestfailover              \
+                          src/577-garbagecollecthiddenstratum1revision \
+                          src/579-garbagecollectstratum1legacytag || it_retval=$?
 
 echo "running CernVM-FS migration test cases..."
 ./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?


### PR DESCRIPTION
This disables the garbage collection integration tests 577 and 579 that both check for orphaned named snapshot deletion scenarios. This is a minor known issue of the garbage collection as freezed for CernVM-FS 2.1.20. 