### PR TITLE
Fix: cvmfs_server add-replica -z to enable automatic garbage collection

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -203,8 +203,9 @@ Supported Commands:
                 [-k path to existing keychain]
                 <fully qualified repository name>
                 Creates a new repository with a given name
-  add-replica   [-u stratum1 upstream storage] [-o owner] [-n alias name]
-                [-w stratum1 url] [-a silence apache warning]
+  add-replica   [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
+                [-a silence apache warning] [-z enable garbage collection]
+                [-n alias name]
                 <stratum 0 url> <public key>
                 Creates a Stratum 1 replica of a Stratum 0 repository
   import        [-w stratum0 url] [-o owner] [-u upstream storage]
@@ -2343,10 +2344,11 @@ add_replica() {
   local upstream
   local owner
   local silence_httpd_warning=0
+  local enable_auto_gc=0
 
   # optional parameter handling
   OPTIND=1
-  while getopts "o:u:n:w:a" option
+  while getopts "o:u:n:w:az" option
   do
     case $option in
       u)
@@ -2363,6 +2365,9 @@ add_replica() {
       ;;
       a)
         silence_httpd_warning=1
+      ;;
+      z)
+        enable_auto_gc=1
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -2455,6 +2460,13 @@ CVMFS_PUBLIC_KEY=$public_key
 CVMFS_HTTP_TIMEOUT=10
 CVMFS_HTTP_RETRIES=3
 EOF
+
+  # append GC specific configuration
+  if [ $enable_auto_gc != 0 ]; then
+    cat >> /etc/cvmfs/repositories.d/${alias_name}/server.conf << EOF
+CVMFS_GC_TIMESTAMP_THRESHOLD='3 days ago'
+EOF
+  fi
 
   if is_local_upstream $upstream; then
     ((echo "# Created by cvmfs_server.  Don't touch."

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3919,11 +3919,11 @@ gc() {
 
     # run the garbage collection
     echo "Running Garbage Collection"
-    __run_gc $name           \
-             $repository_url \
-             $dry_run        \
-             $manifest       \
-             $base_hash      \
+    __run_gc "$name"           \
+             "$repository_url" \
+             "$dry_run"        \
+             "$manifest"       \
+             "$base_hash"      \
              $additional_switches || die "Fail ($?)!"
 
     # sign the result

--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -75,12 +75,9 @@ cvmfs_run_test() {
 
   echo "configure stratum 1 to automatically delete revisions older than $thresh_seconds seconds"
   local replica_server_conf="/etc/cvmfs/repositories.d/${replica_name}/server.conf"
-  if ! cat $replica_server_conf | grep -q 'CVMFS_GC_TIMESTAMP_THRESHOLD'; then
-    cat $replica_server_conf                                          >  replica_1.conf
-    echo "CVMFS_GC_TIMESTAMP_THRESHOLD='$thresh_seconds seconds ago'" >> replica_1.conf
-  else
-    cat $replica_server_conf | sed -e "s/^\(CVMFS_GC_TIMESTAMP_THRESHOLD\)=.*$/\1='$thresh_seconds seconds ago'/" > replica_1.conf
-  fi
+  cat $replica_server_conf | grep -q 'CVMFS_GC_TIMESTAMP_THRESHOLD' || return 7
+  cat $replica_server_conf                                          >  replica_1.conf
+  echo "CVMFS_GC_TIMESTAMP_THRESHOLD='$thresh_seconds seconds ago'" >> replica_1.conf
   sudo cp replica_1.conf $replica_server_conf || return 8
   cat $replica_server_conf                    || return 9
 

--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -54,14 +54,15 @@ cvmfs_run_test() {
   echo "register cleanup trap"
   trap cleanup EXIT HUP INT TERM || return $?
 
-  echo "create a stratum1 replication"
+  echo "create a stratum1 replication (with enabled auto garbage collection)"
   replica_name="${CVMFS_TEST_REPO}.replic"
   CVMFS_TEST_580_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
-                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 4
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+                  -z || return 4
 
   echo "create an initial snapshot"
   cvmfs_server snapshot $replica_name || return 5

--- a/test/test_functions
+++ b/test/test_functions
@@ -491,6 +491,8 @@ create_stratum1() {
   local uid=$2
   local stratum0_url=$3
   local stratum0_pub=$4
+  shift 4
+  local additional_parameters="$*"
   local s3_config=""
   # TODO: Re-enable this as soon as Stratum1 is supported
   #       with an S3 backend
@@ -498,11 +500,12 @@ create_stratum1() {
   #   echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
   #   s3_config=" -s $CVMFS_TEST_S3_CONFIG"
   # fi
-  sudo cvmfs_server add-replica -o $CVMFS_TEST_USER \
-                                -n $replica_name    \
-                                -a                  \
-                                $s3_config          \
-                                $stratum0_url       \
+  sudo cvmfs_server add-replica -o $CVMFS_TEST_USER    \
+                                -n $replica_name       \
+                                -a                     \
+                                $s3_config             \
+                                $additional_parameters \
+                                $stratum0_url          \
                                 $stratum0_pub
 }
 


### PR DESCRIPTION
This allows to use `cvmfs_server add-replica -z` to create a stratum 1 that runs the garbage collection after every `cvmfs_server snapshot`. As a default `CVMFS_GC_TIMESTAMP_THRESHOLD` is set to *3 days ago*. Furthermore this contains a minor fix for `cvmfs_server gc` that had a shell quotation flaw after another recent Pull Request.

Also integration test 580 is adapted to use the new `cvmfs_server add-replica -z` switch and to check the generated configuration file more strictly.