### PR TITLE
Fix: Rename Timestamp Threshold and Remove CVMFS_GARBAGE_COLLECTION from Stratum 1

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -715,6 +715,16 @@ is_garbage_collectable() {
   [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]
 }
 
+# checks if a repository has automatic garbage collection enabled
+#
+# @param name  the name of the repository to be checked
+# @return      0 if automatic garbage collection is enabled
+has_auto_garbage_collection_enabled() {
+  local name=$1
+  load_repo_config $name
+  is_garbage_collectable $name && [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]
+}
+
 # checks if a repository is currently in a transaction
 #
 # @param name  the repository name to be checked
@@ -3649,8 +3659,7 @@ publish() {
     $user_shell "$tag_command" || { publish_failed $name; die "Tagging failed\n\nExecuted Command:\n$tag_command";  }
 
     # run the automatic garbage collection (if configured)
-    if is_garbage_collectable $name && [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]
-    then
+    if has_auto_garbage_collection_enabled $name; then
       echo "Running automatic garbage collection"
       local tst="$(date --date "$CVMFS_AUTO_GC_TIMESPAN" +%s 2>/dev/null)"
       [ $? -eq 0 ] || { publish_failed $name; die "Cannot parse time stamp '$timestamp_threshold'"; }
@@ -4091,8 +4100,7 @@ snapshot() {
       -o .cvmfs_last_snapshot"
 
     # run the automatic garbage collection (if configured)
-    if is_garbage_collectable $alias_name && [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]
-    then
+    if has_auto_garbage_collection_enabled $alias_name; then
       echo "Running automatic garbage collection"
       local tst="$(date --date "$CVMFS_AUTO_GC_TIMESPAN" +%s 2>/dev/null)"
       [ $? -eq 0 ] || die "Cannot parse time stamp '$timestamp_threshold'"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -712,7 +712,11 @@ is_master_replica() {
 is_garbage_collectable() {
   local name=$1
   load_repo_config $name
-  [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]
+  if is_stratum0 $name; then
+    [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]
+  else
+    [ x"$(cvmfs_swissknife info -r $CVMFS_STRATUM1 -g)" = x"yes" ]
+  fi
 }
 
 # checks if a repository has automatic garbage collection enabled
@@ -2422,10 +2426,6 @@ add_replica() {
   local temp_dir="${spool_dir}/tmp"
   local storage_dir=""
   is_local_upstream $upstream && storage_dir=$(get_upstream_config $upstream)
-  local garbage_collectable=false;
-  if [ "$(cvmfs_swissknife info -r $stratum0 -g 2>/dev/null)" = "yes" ]; then
-    garbage_collectable=true;
-  fi
   local stratum1="http://localhost/cvmfs/${alias_name}"
   [ ! -z "$stratum1_url" ] && stratum1="$stratum1_url"
 
@@ -2461,7 +2461,6 @@ CVMFS_SPOOL_DIR=$spool_dir
 CVMFS_STRATUM0=$stratum0
 CVMFS_STRATUM1=$stratum1
 CVMFS_UPSTREAM_STORAGE=$upstream
-CVMFS_GARBAGE_COLLECTION=$garbage_collectable
 EOF
   cat > /etc/cvmfs/repositories.d/${alias_name}/replica.conf << EOF
 # Created by cvmfs_server.

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1692,7 +1692,7 @@ EOF
   # append GC specific configuration
   if [ x"$garbage_collectable" = x"true" ]; then
     cat >> $server_conf << EOF
-CVMFS_GC_TIMESTAMP_THRESHOLD='3 days ago'
+CVMFS_AUTO_GC_TIMESPAN='3 days ago'
 EOF
   fi
 
@@ -2464,7 +2464,7 @@ EOF
   # append GC specific configuration
   if [ $enable_auto_gc != 0 ]; then
     cat >> /etc/cvmfs/repositories.d/${alias_name}/server.conf << EOF
-CVMFS_GC_TIMESTAMP_THRESHOLD='3 days ago'
+CVMFS_AUTO_GC_TIMESPAN='3 days ago'
 EOF
   fi
 
@@ -3649,10 +3649,10 @@ publish() {
     $user_shell "$tag_command" || { publish_failed $name; die "Tagging failed\n\nExecuted Command:\n$tag_command";  }
 
     # run the automatic garbage collection (if configured)
-    if is_garbage_collectable $name && [ ! -z "$CVMFS_GC_TIMESTAMP_THRESHOLD" ]
+    if is_garbage_collectable $name && [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]
     then
       echo "Running automatic garbage collection"
-      local tst="$(date --date "$CVMFS_GC_TIMESTAMP_THRESHOLD" +%s 2>/dev/null)"
+      local tst="$(date --date "$CVMFS_AUTO_GC_TIMESPAN" +%s 2>/dev/null)"
       [ $? -eq 0 ] || { publish_failed $name; die "Cannot parse time stamp '$timestamp_threshold'"; }
       local dry_run=0
       __run_gc $name       \
@@ -4091,10 +4091,10 @@ snapshot() {
       -o .cvmfs_last_snapshot"
 
     # run the automatic garbage collection (if configured)
-    if is_garbage_collectable $alias_name && [ ! -z "$CVMFS_GC_TIMESTAMP_THRESHOLD" ]
+    if is_garbage_collectable $alias_name && [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]
     then
       echo "Running automatic garbage collection"
-      local tst="$(date --date "$CVMFS_GC_TIMESTAMP_THRESHOLD" +%s 2>/dev/null)"
+      local tst="$(date --date "$CVMFS_AUTO_GC_TIMESPAN" +%s 2>/dev/null)"
       [ $? -eq 0 ] || die "Cannot parse time stamp '$timestamp_threshold'"
       local dry_run=0
       __run_gc "$alias_name" \

--- a/test/src/578-automaticgarbagecollection/main
+++ b/test/src/578-automaticgarbagecollection/main
@@ -36,7 +36,7 @@ cvmfs_run_test() {
 
   echo "configure repository to automatically delete revisions older than $thresh_seconds seconds"
   local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
-  cat $server_conf | sed -e "s/^\(CVMFS_GC_TIMESTAMP_THRESHOLD\)=.*$/\1='$thresh_seconds seconds ago'/" > server_1.conf
+  cat $server_conf | sed -e "s/^\(CVMFS_AUTO_GC_TIMESPAN\)=.*$/\1='$thresh_seconds seconds ago'/" > server_1.conf
   sudo cp server_1.conf $server_conf || return 1
   cat $server_conf                   || return 2
 
@@ -134,7 +134,7 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog5 || return 23 # trunk
 
   echo "disable automatic garbage collection"
-  cat $server_conf | grep -v 'CVMFS_GC_TIMESTAMP_THRESHOLD' > server_2.conf
+  cat $server_conf | grep -v 'CVMFS_AUTO_GC_TIMESPAN' > server_2.conf
   sudo cp server_2.conf $server_conf || return 24
   cat $server_conf                   || return 25
 

--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -44,7 +44,7 @@ cvmfs_run_test() {
 
   echo "disable automatic garbage collection on stratum 0"
   local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
-  cat $server_conf | grep -v 'CVMFS_GC_TIMESTAMP_THRESHOLD' > server_1.conf
+  cat $server_conf | grep -v 'CVMFS_AUTO_GC_TIMESPAN' > server_1.conf
   sudo cp server_1.conf $server_conf || return 1
   cat $server_conf                   || return 2
 
@@ -75,9 +75,8 @@ cvmfs_run_test() {
 
   echo "configure stratum 1 to automatically delete revisions older than $thresh_seconds seconds"
   local replica_server_conf="/etc/cvmfs/repositories.d/${replica_name}/server.conf"
-  cat $replica_server_conf | grep -q 'CVMFS_GC_TIMESTAMP_THRESHOLD' || return 7
-  cat $replica_server_conf                                          >  replica_1.conf
-  echo "CVMFS_GC_TIMESTAMP_THRESHOLD='$thresh_seconds seconds ago'" >> replica_1.conf
+  cat $replica_server_conf | grep -q 'CVMFS_AUTO_GC_TIMESPAN' || return 7
+  cat $replica_server_conf | sed -e "s/^\(CVMFS_AUTO_GC_TIMESPAN\)=.*$/\1='$thresh_seconds seconds ago'/" > replica_1.conf
   sudo cp replica_1.conf $replica_server_conf || return 8
   cat $replica_server_conf                    || return 9
 
@@ -208,7 +207,7 @@ cvmfs_run_test() {
   peek_backend $replica_name    $root_catalog5 || return 67 # trunk
 
   echo "disable automatic garbage collection on stratum 1"
-  cat $replica_server_conf | grep -v 'CVMFS_GC_TIMESTAMP_THRESHOLD' > replica_2.conf
+  cat $replica_server_conf | grep -v 'CVMFS_AUTO_GC_TIMESPAN' > replica_2.conf
   sudo cp replica_2.conf $replica_server_conf || return 68
   cat $replica_server_conf                    || return 69
 


### PR DESCRIPTION
As @DrDaveD correctly pointed out, `CVMFS_GARBAGE_COLLECTION=true` is not necessary on stratum 1 as this information is already embedded in the manifest file put together and signed by stratum 0. Therefore, this makes `CVMFS_GARBAGE_COLLECTION` a stratum-0-only configuration variable and takes only the *.cvmfspublished* file into account on stratum 1. Furthermore this renames `CVMFS_GC_TIMESTAMP_THRESHOLD` to `CVMFS_AUTO_GC_TIMESPAN` for better usability.