### PR TITLE
TEST: Disable Failing Tests 577 and 579 for S3

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -60,24 +60,26 @@ echo "done ($fakes3_pid)"
 
 if [ $s3_retval -eq 0 ]; then
     echo "running CernVM-FS server test cases against FakeS3..."
-    export CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                    && \
-    export CVMFS_TEST_STRATUM0=$FAKE_S3_URL                        && \
-    export CVMFS_TEST_SERVER_CACHE='/srv/cache'                    && \
-    ./run.sh $TEST_S3_LOGFILE -x src/0*                               \
-                                 src/518-hardlinkstresstest           \
-                                 src/519-importlegacyrepo             \
-                                 src/522-missingchunkfailover         \
-                                 src/523-corruptchunkfailover         \
-                                 src/524-corruptmanifestfailover      \
-                                 src/525-bigrepo                      \
-                                 src/528-recreatespoolarea            \
-                                 src/530-recreatespoolarea_defaultkey \
-                                 src/537-symlinkedbackend             \
-                                 src/538-symlinkedstratum1backend     \
-                                 src/542-storagescrubbing             \
-                                 src/543-storagescrubbing_scriptable  \
-                                 src/550-livemigration                \
-                                 src/571-localbackendumask || s3_retval=$?
+    export CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                    &&         \
+    export CVMFS_TEST_STRATUM0=$FAKE_S3_URL                        &&         \
+    export CVMFS_TEST_SERVER_CACHE='/srv/cache'                    &&         \
+    ./run.sh $TEST_S3_LOGFILE -x src/0*                                       \
+                                 src/518-hardlinkstresstest                   \
+                                 src/519-importlegacyrepo                     \
+                                 src/522-missingchunkfailover                 \
+                                 src/523-corruptchunkfailover                 \
+                                 src/524-corruptmanifestfailover              \
+                                 src/525-bigrepo                              \
+                                 src/528-recreatespoolarea                    \
+                                 src/530-recreatespoolarea_defaultkey         \
+                                 src/537-symlinkedbackend                     \
+                                 src/538-symlinkedstratum1backend             \
+                                 src/542-storagescrubbing                     \
+                                 src/543-storagescrubbing_scriptable          \
+                                 src/550-livemigration                        \
+                                 src/571-localbackendumask                    \
+                                 src/577-garbagecollecthiddenstratum1revision \
+                                 src/579-garbagecollectstratum1legacytag || s3_retval=$?
 
     echo -n "killing FakeS3... "
     sudo kill -2 $fakes3_pid && echo "done" || echo "fail"


### PR DESCRIPTION
This is a follow up of "[TEST: Disable Integration Tests 577 and 579](https://github.com/cvmfs/cvmfs/pull/692)". I forgot to disable them for the S3 based test cases as well.