### PR TITLE
FIX: mktime Produced Non-Deterministic Results on SL6

### DIFF
--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -69,14 +69,17 @@ pid_t GetParentPid(const pid_t pid) {
 time_t t(const int day, const int month, const int year) {
   struct tm time_descriptor;
 
-  time_descriptor.tm_hour = 0;
-  time_descriptor.tm_min  = 0;
-  time_descriptor.tm_sec  = 0;
-  time_descriptor.tm_mday = day;
-  time_descriptor.tm_mon  = month;
-  time_descriptor.tm_year = year - 1900;
+  time_descriptor.tm_hour  = 0;
+  time_descriptor.tm_min   = 0;
+  time_descriptor.tm_sec   = 0;
+  time_descriptor.tm_mday  = day;
+  time_descriptor.tm_mon   = month - 1;
+  time_descriptor.tm_year  = year - 1900;
+  time_descriptor.tm_isdst = 0;
 
-  return mktime(&time_descriptor);
+  const time_t result = mktime(&time_descriptor);
+  assert (result >= 0);
+  return result;
 }
 
 shash::Any h(const std::string &hash, const shash::Suffix suffix) {


### PR DESCRIPTION
Turns out, that the `mktime()` function seems to react non-deterministic for semi-correct inputs. First, the [documentation](http://www.cplusplus.com/reference/ctime/tm/) says, that `tm_mon` needs to be from 0 to 11 (January == 0) and furthermore I specified the `tm_isdst` 'daylight saving time' flag. This seems to fix some unit tests that failed occasionally (not always) on SLC6 x64.... Enjoy the little things!