### PR TITLE
Feature: Print Warning If AUTO_TAG and GC are Enabled

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2267,6 +2267,11 @@ mkfs() {
   local cvmfs_user=$(get_cvmfs_owner $name $owner)
   check_user $cvmfs_user || die "No user $cvmfs_user"
 
+  # GC and auto-tag warning
+  if [ x"$autotagging" = x"true" ] && [ x"$garbage_collectable" = x"true" ]; then
+    echo "Note: Autotagging all revisions impedes garbage collection"
+  fi
+
   # create system-wide configuration
   echo -n "Creating Configuration Files... "
   create_config_files_for_new_repository $name $upstream $stratum0 $cvmfs_user $unionfs $hash_algo $autotagging $garbage_collectable || die "fail"


### PR DESCRIPTION
`cvmfs_server mkfs -z` would produce a repository that has garbage collection and auto-tagging enabled. This would produce a warning message, that auto-tagging might obstruct the garbage collection. If there is a tag created for each published revision, the garbage collection will not remove anything. The resulting repository is sane though, and potentially people might want to have just that behaviour. Also one can always change this configuration and/or delete already generated auto-tags. Therefore I decided to just make this a warning instead of an error.