### PR TITLE
Fix: Properly Close Database Files

### DIFF
--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -68,6 +68,27 @@ class Sql;
  */
 template <class DerivedT>
 class Database : SingleCopy {
+ private:
+  struct DatabaseRaiiWrapper {
+    DatabaseRaiiWrapper(const std::string   &filename,
+                        Database<DerivedT>  *delegate)
+      : sqlite_db(NULL)
+      , db_file_guard(filename, UnlinkGuard::kDisabled)
+      , delegate_(delegate) {}
+    ~DatabaseRaiiWrapper();
+
+    sqlite3*           database() const { return sqlite_db;            }
+    const std::string& filename() const { return db_file_guard.path(); }
+
+    void TakeFileOwnership() { db_file_guard.Enable();           }
+    void DropFileOwnership() { db_file_guard.Disable();          }
+    bool OwnsFile() const    { return db_file_guard.IsEnabled(); }
+
+    sqlite3             *sqlite_db;
+    UnlinkGuard          db_file_guard;
+    Database<DerivedT>  *delegate_;
+  };
+
  public:
   enum OpenMode {
     kOpenReadOnly,
@@ -105,12 +126,6 @@ class Database : SingleCopy {
   static DerivedT* Open(const std::string  &filename,
                         const OpenMode      open_mode);
 
-  /**
-   * The internal SQLite context object is freed by this destructor. Hence, a
-   * simple `delete` is enough to uninitialize the database.
-   */
-  ~Database();
-
   bool IsEqualSchema(const float value, const float compare) const {
     return (value > compare - kSchemaEpsilon &&
             value < compare + kSchemaEpsilon);
@@ -125,11 +140,11 @@ class Database : SingleCopy {
   bool SetProperty(const std::string &key, const T value);
   bool HasProperty(const std::string &key) const;
 
-  sqlite3     *sqlite_db()       const { return sqlite_db_;            }
-  std::string  filename()        const { return db_file_guard_.path(); }
-  float        schema_version()  const { return schema_version_;       }
-  unsigned     schema_revision() const { return schema_revision_;      }
-  bool         read_write()      const { return read_write_;           }
+  sqlite3*            sqlite_db()       const { return database_.database();  }
+  const std::string&  filename()        const { return database_.filename();  }
+  float               schema_version()  const { return schema_version_;       }
+  unsigned            schema_revision() const { return schema_revision_;      }
+  bool                read_write()      const { return read_write_;           }
 
   /**
    * Figures out the ratio of free SQLite memory pages in the SQLite database
@@ -187,7 +202,7 @@ class Database : SingleCopy {
    *
    * @return  false if file is unmanaged
    */
-  bool OwnsFile() const { return db_file_guard_.IsEnabled(); }
+  bool OwnsFile() const { return database_.OwnsFile(); }
 
  protected:
   /**
@@ -213,8 +228,8 @@ class Database : SingleCopy {
   void set_schema_revision(const unsigned rev) { schema_revision_ = rev; }
 
  private:
-  sqlite3            *sqlite_db_;
-  UnlinkGuard         db_file_guard_;
+  DatabaseRaiiWrapper database_;
+
   const bool          read_write_;
   float               schema_version_;
   unsigned            schema_revision_;

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -69,6 +69,12 @@ class Sql;
 template <class DerivedT>
 class Database : SingleCopy {
  private:
+
+  /**
+   * This wraps the opaque SQLite database object along with a file unlink guard
+   * to control the life time of the database connection and the database file
+   * in an RAII fashion.
+   */
   struct DatabaseRaiiWrapper {
     DatabaseRaiiWrapper(const std::string   &filename,
                         Database<DerivedT>  *delegate)

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -143,7 +143,13 @@ bool Database<DerivedT>::OpenDatabase(const int flags) {
 template <class DerivedT>
 Database<DerivedT>::~Database() {
   if (NULL != sqlite_db_) {
-    sqlite3_close_v2(sqlite_db_);
+    LogCvmfs(kLogSql, kLogDebug, "closing SQLite database '%s'",
+             filename().c_str());
+    const int result = sqlite3_close_v2(sqlite_db_);
+    if (result != SQLITE_OK) {
+      LogCvmfs(kLogSql, kLogDebug, "failed to close SQLite database '%s' (%d)",
+               filename().c_str(), result);
+    }
     sqlite_db_ = NULL;
   }
 }

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -143,7 +143,7 @@ bool Database<DerivedT>::OpenDatabase(const int flags) {
 template <class DerivedT>
 Database<DerivedT>::~Database() {
   if (NULL != sqlite_db_) {
-    sqlite3_close(sqlite_db_);
+    sqlite3_close_v2(sqlite_db_);
     sqlite_db_ = NULL;
   }
 }


### PR DESCRIPTION
Since `sqlite::Database<>` used `sqlite3_close()` to close a database handle that was opened with `sqlite3_open_v2()` it failed. Unfortunately the failing happened silently, essentially leaking file descriptors. This uses `sqlite3_close_v2()` and does some debug error checking on the function.