### PR TITLE
Feature: Automatic Mountpoint Repair on Stratum0

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1139,15 +1139,33 @@ find_hazardous_aufs_config() {
 }
 
 
+__health_check_print_repair_info() {
+  local name=$1
+  local repair_in_txn=$2
+
+  load_repo_config $name
+
+  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" != x"true" ]; then
+    echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT != true)" >&2
+    exit 1
+  fi
+
+  if is_in_transaction $name && [ $repair_in_txn = 0 ]; then
+    echo "Repository $name is in a transaction and cannot be repaired." >&2
+    echo "--> Run \`cvmfs_server abort $name\` to revert and repair."     >&2
+    exit 1
+  fi
+}
+
 # checks and warns in inconsistent repository states or unfavorable configs.
 #
 # @param name  the FQRN of the repository to be checked
 health_check() {
   local name=$1
   local quiet=${2-0}
+  local repair_in_txn=${3-0}
 
   load_repo_config $name
-  local auto_repair="$CVMFS_AUTO_REPAIR_MOUNTPOINT"
 
   # for stratum 1 repositories there are no health checks
   if is_stratum1 $name; then
@@ -1180,7 +1198,7 @@ health_check() {
   # check mounted read-only cvmfs client
   if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
     echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly." >&2
-    [ x"$auto_repair" = x"true" ] || exit 1
+    __health_check_print_repair_info $name $repair_in_txn
     echo -n "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... "
     cvmfs_suid_helper rdonly_mount $name > /dev/null && echo "success" || { echo "fail"; exit 1; }
   fi
@@ -1188,7 +1206,7 @@ health_check() {
   # check mounted union file system
   if ! is_mounted "/cvmfs/$name"; then
     echo "/cvmfs/$name is not mounted properly." >&2
-    [ x"$auto_repair" = x"true" ] || exit 1
+    __health_check_print_repair_info $name $repair_in_txn
     echo -n "Note: Trying to mount /cvmfs/${name}... "
     cvmfs_suid_helper rw_mount $name && echo "success" || { echo "fail"; exit 1; }
   fi
@@ -1197,15 +1215,15 @@ health_check() {
   if is_in_transaction $name; then
     if ! is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
       echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
-      [ x"$auto_repair" = x"true" ] || exit 1
-      echo -n "Note: Trying to re-mount /cvmfs/${name} read/write... "
+      __health_check_print_repair_info $name $repair_in_txn
+      echo -n "Note: Trying to remount /cvmfs/${name} read/write... "
       cvmfs_suid_helper open $name && echo "success" || { echo "fail"; exit 1; }
     fi
   else
     if ! is_mounted "/cvmfs/$name" "^.* ro[, ].*$"; then
       echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
-      [ x"$auto_repair" = x"true" ] || exit 1
-      echo -n "Note: Trying to re-mount /cvmfs/${name} read-only... "
+      __health_check_print_repair_info $name $repair_in_txn
+      echo -n "Note: Trying to remount /cvmfs/${name} read-only... "
       cvmfs_suid_helper lock $name && echo "success" || { echo "fail"; exit 1; }
     fi
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1152,7 +1152,7 @@ __health_check_print_repair_info() {
 
   if is_in_transaction $name && [ $repair_in_txn = 0 ]; then
     echo "Repository $name is in a transaction and cannot be repaired." >&2
-    echo "--> Run \`cvmfs_server abort $name\` to revert and repair."     >&2
+    echo "--> Run \`cvmfs_server abort $name\` to revert and repair."   >&2
     exit 1
   fi
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1211,6 +1211,26 @@ health_check() {
     cvmfs_suid_helper rw_mount $name && echo "success" || { echo "fail"; exit 1; }
   fi
 
+  # check mounted CVMFS revision against published one
+  # Note: this needs to repaired first, so that the consecutive checks can put
+  #       the union mountpoint in the right state afterwards
+  if [ x"$(get_mounted_root_hash $name)" != x"$(get_published_root_hash $name)" ]; then
+    echo "$name is not based on the newest published revision" >&2
+    __health_check_print_repair_info $name $repair_in_txn
+    local published_hash="$(get_published_root_hash $name)"
+    echo -n "Note: Trying to remount repository mountpoints to $published_hash... "
+    if cvmfs_suid_helper rw_umount     $name                   && \
+       cvmfs_suid_helper rdonly_umount $name                   && \
+       set_ro_root_hash                $name "$published_hash" && \
+       cvmfs_suid_helper rdonly_mount  $name > /dev/null       && \
+       cvmfs_suid_helper rw_mount      $name; then
+      echo "success"
+    else
+      echo "fail"
+      exit 1
+    fi
+  fi
+
   # check transaction status
   if is_in_transaction $name; then
     if ! is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
@@ -1226,11 +1246,6 @@ health_check() {
       echo -n "Note: Trying to remount /cvmfs/${name} read-only... "
       cvmfs_suid_helper lock $name && echo "success" || { echo "fail"; exit 1; }
     fi
-  fi
-
-  # check mounted CVMFS revision against published
-  if [ x"$(get_mounted_root_hash $name)" != x"$(get_published_root_hash $name)" ]; then
-    die "$name is not based on the newest published revision"
   fi
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1159,7 +1159,9 @@ __health_check_print_repair_info() {
 
 # checks and warns in inconsistent repository states or unfavorable configs.
 #
-# @param name  the FQRN of the repository to be checked
+# @param name           the FQRN of the repository to be checked
+# @param quiet          disable printing of warnings
+# @param repair_in_txn  repair even if currently in a transaction
 health_check() {
   local name=$1
   local quiet=${2-0}

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1173,7 +1173,7 @@ health_check() {
   fi
 
   # health check cannot deal with repositories currently being published
-  if is_publishing $name; then
+  if [ $quiet -eq 0 ] &&  is_publishing $name; then
     echo "WARNING: The repository $name is currently publishing and should not"
     echo "be touched. If you are absolutely sure, that this is _not_ the case,"
     echo "please run the following command and retry:"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3445,7 +3445,6 @@ abort() {
     # sanity checks
     is_stratum0 $name   || { echo "Repository $name is not a stratum 0 repository"; retcode=1; continue; }
     is_publishing $name && { echo "Repository $name is currently published (aborting abort)"; retcode=1; continue; }
-    health_check $name
 
     # get repository information
     load_repo_config $name
@@ -3467,6 +3466,11 @@ abort() {
         continue
       fi
     fi
+
+    # do a health check (might also repair out-of-sync in_transaction repos)
+    local silence_warnings=0
+    local repair_in_txn=1
+    health_check $name $silence_warnings $repair_in_txn
 
     # check if we have open file descriptors on /cvmfs/<name>
     local use_fd_fallback=0

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -2,6 +2,28 @@ cvmfs_test_name="Auto-Repair Bogus Mountpoints"
 cvmfs_test_autofs_on_startup=false
 
 
+mount_old_root_hash() {
+  local name=$1
+  local old_root_hash=$2
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local rd_only=/var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly
+
+  load_repo_config $name
+
+  echo "create a manipulated client.local file with '$old_root_hash'"
+  local client_local="${CVMFS_SPOOL_DIR}/client.local"
+  local tampered_client_local="client.local.tampered"
+  cat $client_local | sed -e "s/^\(CVMFS_ROOT_HASH\)=.*$/\1=$old_root_hash/" > $tampered_client_local || return 1
+  sudo cp $tampered_client_local $client_local || return 2
+
+  echo "remount with the tampered root hash ($old_root_hash)"
+  sudo umount $repo_dir || return 3
+  sudo umount $rd_only  || return 4
+  sudo mount  $rd_only  || return 5
+  sudo mount  $repo_dir || return 6
+}
+
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -70,7 +92,7 @@ cvmfs_run_test() {
 
   echo "check the error and warning messages"
   cat $check_log_3 | grep -e "not in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* mounted read/write" || return 16
-  cat $check_log_3 | grep -e "Trying to re-mount /cvmfs/${CVMFS_TEST_REPO}" || return 17
+  cat $check_log_3 | grep -e "Trying to remount /cvmfs/${CVMFS_TEST_REPO}"                             || return 17
 
   echo "check if transaction is open"
   [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 18
@@ -80,21 +102,31 @@ cvmfs_run_test() {
   echo "remount union file system read-only"
   sudo mount -o remount,ro $repo_dir || return 19
 
-  echo "abort transaction"
+  echo "publish transaction (should fail)"
   local check_log_4="check_4.log"
-  abort_transaction $CVMFS_TEST_REPO > $check_log_4 2>&1 || return 20
+  publish_repo $CVMFS_TEST_REPO > $check_log_4 2>&1 && return 20
 
   echo "check the error and warning messages"
   cat $check_log_4 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 21
-  cat $check_log_4 | grep -e "Trying to re-mount /cvmfs/${CVMFS_TEST_REPO} read/write"                    || return 22
+  cat $check_log_4 | grep -e "${CVMFS_TEST_REPO} .* cannot be repaired"                                   || return 22
 
-  echo "check if transaction is closed"
-  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 23
+  echo "check if transaction is still open"
+  [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 23
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "run abort to bring the repository back in shape"
+  local check_log_5="check_5.log"
+  abort_transaction $CVMFS_TEST_REPO > $check_log_5 2>&1 || return 24
+
+  echo "check the error and warning messages"
+  cat $check_log_5 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 25
+  cat $check_log_5 | grep -e "Trying to remount /cvmfs/${CVMFS_TEST_REPO} read/write"                     || return 26
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "check the repository's integrity"
-  check_repository $CVMFS_TEST_REPO -i || return 24
+  check_repository $CVMFS_TEST_REPO -i || return 27
 
   echo "create a fresh transaction"
   start_transaction $CVMFS_TEST_REPO || return $?
@@ -103,33 +135,150 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "check repository integrity"
-  check_repository $CVMFS_TEST_REPO -i || return 25
+  check_repository $CVMFS_TEST_REPO -i || return 28
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "open transaction"
-  start_transaction $CVMFS_TEST_REPO || return 26
+  start_transaction $CVMFS_TEST_REPO || return 29
 
   echo "umount both $repo_dir and $rd_only"
-  sudo umount $repo_dir || return 27
-  sudo umount $rd_only  || return 28
+  sudo umount $repo_dir || return 30
+  sudo umount $rd_only  || return 31
 
-  echo "publish transaction"
-  local check_log_5="check_5.log"
-  publish_repo $CVMFS_TEST_REPO > $check_log_5 2>&1 || return 29
+  echo "publish transaction (should fail)"
+  local check_log_6="check_6.log"
+  publish_repo $CVMFS_TEST_REPO > $check_log_6 2>&1 && return 32
 
   echo "check the error and warning messages"
-  cat $check_log_5 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted"                                   || return 30
-  cat $check_log_5 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly"                                || return 31
-  cat $check_log_5 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"                                   || return 32
-  cat $check_log_5 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"                                  || return 33
-  cat $check_log_5 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 34
-  cat $check_log_5 | grep -e "Trying to re-mount /cvmfs/${CVMFS_TEST_REPO} read/write"                    || return 35
+  cat $check_log_6 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted" || return 33
+  cat $check_log_6 | grep -e "${CVMFS_TEST_REPO} .* cannot be repaired" || return 34
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "run abort to bring the repository back in shape"
+  local check_log_7="check_7.log"
+  abort_transaction $CVMFS_TEST_REPO > $check_log_7 2>&1 || return 35
+
+  echo "check the error and warning messages"
+  cat $check_log_7 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted"                                   || return 36
+  cat $check_log_7 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly"                                || return 37
+  cat $check_log_7 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"                                   || return 38
+  cat $check_log_7 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"                                  || return 39
+  cat $check_log_7 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 40
+  cat $check_log_7 | grep -e "Trying to remount /cvmfs/${CVMFS_TEST_REPO} read/write"                     || return 41
+
+  echo "check that repository is not in a transaction"
+  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 42
+
+  echo "check repository integrity"
+  check_repository $CVMFS_TEST_REPO -i || return 43
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "remember current root hash"
+  old_root_hash="$(attr -qg root_hash $rd_only)"
+  echo "root hash: $old_root_hash"
+
+  echo "open transaction"
+  start_transaction $CVMFS_TEST_REPO || return 44
+
+  echo "publish transaction"
+  local check_log_8="check_8.log"
+  publish_repo $CVMFS_TEST_REPO > $check_log_8 2>&1 || return 45
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "check the current root hash"
+  local current_root_hash="$(attr -qg root_hash $rd_only)"
+  echo "current root hash: $current_root_hash"
+
+  echo "create a manipulated client.local file with '$old_root_hash' and remount"
+  mount_old_root_hash $CVMFS_TEST_REPO $old_root_hash || return $?
+
+  echo "check that the root hash was successfully tampered with"
+  local tampered_root_hash="$(attr -qg root_hash $rd_only)"
+  [ x"$tampered_root_hash" = x"$old_root_hash" ] || return 46
+
+  echo "open a transaction (should remount the repository)"
+  local check_log_9="check_9.log"
+  start_transaction $CVMFS_TEST_REPO > $check_log_9 2>&1 || return 47
+
+  echo "check the error and warning messages"
+  cat $check_log_9 | grep -e "${CVMFS_TEST_REPO} .* not based on .* published revision" || return 48
+  cat $check_log_9 | grep -e "Trying to remount .* to $current_root_hash"               || return 49
+
+  echo "add a couple of files"
+  mkdir ${repo_dir}/foobar                  || return 50
+  echo "foobar" > ${repo_dir}/foobar/foobar || return 51
+  touch ${repo_dir}/foobar/.cvmfscatalog    || return 52
+
+  echo "publish transaction"
+  publish_repo $CVMFS_TEST_REPO || return 53
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "check repository integrity"
-  check_repository $CVMFS_TEST_REPO -i || return 36
+  check_repository $CVMFS_TEST_REPO -i || return 54
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "check the current root hash"
+  old_root_hash="$current_root_hash"
+  local current_root_hash="$(attr -qg root_hash $rd_only)"
+  echo "old_root_hash:     $old_root_hash"
+  echo "current root hash: $current_root_hash"
+
+  echo "open transaction"
+  start_transaction $CVMFS_TEST_REPO || return 55
+
+  echo "create a manipulated client.local file with '$old_root_hash' and remount"
+  mount_old_root_hash $CVMFS_TEST_REPO $old_root_hash || return $?
+
+  echo "publish repository (should fail)"
+  local check_log_10="check_10.log"
+  publish_repo $CVMFS_TEST_REPO > $check_log_10 2>&1 && return 56
+
+  echo "check error and warning messages"
+  cat $check_log_10 | grep -e "${CVMFS_TEST_REPO} .* not based on .* published revision" || return 57
+  cat $check_log_10 | grep -e "${CVMFS_TEST_REPO} .* cannot be repaired"                 || return 58
+
+  echo "check if transaction is still open"
+  [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 59
+
+  echo "run abort to bring the repository back in shape"
+  local check_log_11="check_11.log"
+  abort_transaction $CVMFS_TEST_REPO > $check_log_11 2>&1 || return 60
+
+  echo "check error and warning messages"
+  cat $check_log_11 | grep -e "${CVMFS_TEST_REPO} .* not based on .* published revision"         || return 61
+  cat $check_log_11 | grep -e "Trying to remount .* to $current_root_hash"                       || return 62
+  cat $check_log_11 | grep -e "${CVMFS_TEST_REPO} .* in a transaction .* not mounted read/write" || return 63
+  cat $check_log_11 | grep -e "Trying to remount .* read/write"                                  || return 64
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "check if transaction is closed"
+  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 65
+
+  echo "check repository integrity"
+  check_repository $CVMFS_TEST_REPO -i || return 66
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "open transaction"
+  start_transaction $CVMFS_TEST_REPO || return 67
+
+  echo "remove everything from repo"
+  rm -fR ${repo_dir}/* || return 68
+
+  echo "publish transaction"
+  publish_repo $CVMFS_TEST_REPO || return 69
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+  echo "check repository integrity"
+  check_repository $CVMFS_TEST_REPO -i || return 70
 
   return 0
 }


### PR DESCRIPTION
This extends the automatic repair feature that came with [Feature: Auto Recover Mountpoints](https://github.com/cvmfs/cvmfs/pull/689).

Most significantly this now refuses to tamper with repositories currently in a transaction. Instead, it suggests to use `cvmfs_server abort` that goes ahead and automatically repairs the out-of-sync mountpoints together with aborting the currently active transaction. This is a safe guard against bogus transactions potentially causing arbitrary damage by being published.

Furthermore, this patch now allows for the automatic repair of out-of-sync mounted repositories with differing mounted root hash and latest published root hash. These auto-repair features directly tackle the known issue and manual repair steps described [here](http://cernvm.cern.ch/portal/cvmfs/fix-failed-remount).

Additionally integration test 582 was adapted and extended to check the described functionality.