### PR TITLE
Fix: Stratum1 Migration Routine

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4064,6 +4064,7 @@ snapshot() {
         # try to update the geodb, but continue if it doesn't work
         update_geodb -l || true
     fi
+    [ ! -z $stratum1 ] || die "Missing CVMFS_STRATUM1 URL in server.conf"
 
     # do it!
     local user_shell="$(get_user_shell $alias_name)"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4309,7 +4309,9 @@ migrate_2_1_15() {
   fi
 
   echo "--> updating server.conf"
-  sed -i -e "s/^CVMFS_CREATOR_VERSION=.*/CVMFS_CREATOR_VERSION=$destination_version/" /etc/cvmfs/repositories.d/$name/server.conf
+  local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
+  sed -i -e "s/^CVMFS_CREATOR_VERSION=.*/CVMFS_CREATOR_VERSION=$destination_version/" $server_conf
+  echo "CVMFS_STRATUM1=http://localhost/cvmfs/${name}" >> $server_conf
 
   # reload (updated) repository information
   load_repo_config $name


### PR DESCRIPTION
This is a minor fix to the stratum 1 migration routine to be utilised for legacy 2.1.19 stratum 1s. What was missing is the addition of `CVMFS_STRATUM1=<url>` that was introduced with 2.1.20 to fully support the S3 backend.