### PR TITLE
FIX: Migration Test (again)

### DIFF
--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -152,7 +152,7 @@ cvmfs_run_test() {
   echo "starting to checksum large files in $xxl_files_dir (log output in separate file)"
   checksum_large_files $xxl_files_dir $chksum_log2 &
   local chksum_pid=$!
-  echo "checksumming runs under PID chksum_pid"
+  echo "checksumming runs under PID $chksum_pid"
 
   # wait some time to bring tar up to speed
   echo "giving tar and checksumming some time to screw around"

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -36,9 +36,9 @@ checksum_large_files() {
   pid2=$!
   (find $dir -type f -size +4M -exec crc32 {} \; | sort > $result_file) &
   pid3=$!
-  wait pid1
-  wait pid2
-  wait pid3
+  wait $pid1
+  wait $pid2
+  wait $pid3
 }
 
 

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -110,8 +110,10 @@ cvmfs_run_test() {
   # last released cvmfs-keys package (1.5-1)
   # Note: this will not be needed after CernVM-FS 2.1.20 is released
   #       furthermore the re-install of cvmfs-config is not needed later on!
-  uninstall_package "cvmfs-config" || true # always succeeds, even if it doesn't
-                                           # exist as an installed package
+  cvmfs_config_pkg="$(get_providing_package cvmfs-config)"
+  echo "Uninstalling $cvmfs_config_pkg (providing cvmfs-config)"
+  uninstall_package $cvmfs_config_pkg || return 20
+
   local cvmfs_keys_url=$(guess_cvmfs_keys_url "1.5-1")
   local cvmfs_keys=$(basename $cvmfs_keys_url)
   echo "Download URL for cvmfs-keys: $cvmfs_keys_url"

--- a/test/migration_tests/common.sh
+++ b/test/migration_tests/common.sh
@@ -84,6 +84,19 @@ package_version() {
 }
 
 
+get_providing_package() {
+  local virt_pkg_name=$1
+
+  if has_binary yum; then
+    rpm -q --whatprovides $virt_pkg_name
+  elif has_binary dpkg; then
+    dpkg -l | grep $virt_pkg_name | awk '{print $2}'
+  else
+    return 1
+  fi
+}
+
+
 installed_package_version() {
   local pkg_name=$1
 


### PR DESCRIPTION
This fixes more quirks in the migration test. Namely, that `dpkg` cannot erase packages based on their *provides* field. We first need to figure out which actual package *provides* `cvmfs-config`. Furthermore in `checksum_large_files()` waiting for the background processes was flawed and didn't work.

Merging myself, to start a new test run...