### PR TITLE
Fix: Reading of Legacy History Databases

### DIFF
--- a/cvmfs/history_sql.cc
+++ b/cvmfs/history_sql.cc
@@ -123,7 +123,11 @@ bool HistoryDatabase::UpgradeSchemaRevision_10_2() {
 //------------------------------------------------------------------------------
 
 
-const std::string SqlHistory::db_fields =
+
+const std::string SqlHistory::db_fields_v1r0 =
+  "name, hash, revision, timestamp, channel, description";
+
+const std::string SqlHistory::db_fields_v1r1 =
   "name, hash, revision, timestamp, channel, description, size";
 
 const std::string SqlInsertTag::db_placeholders =
@@ -131,7 +135,7 @@ const std::string SqlInsertTag::db_placeholders =
 
 SqlInsertTag::SqlInsertTag(const HistoryDatabase *database) {
   const std::string stmt =
-    "INSERT INTO tags (" + db_fields + ")"
+    "INSERT INTO tags (" + db_fields(database) + ")"
     "VALUES (" + db_placeholders + ");";
   const bool success = Init(database->sqlite_db(), stmt);
   assert (success);
@@ -170,7 +174,7 @@ bool SqlRemoveTag::BindName(const std::string &name) {
 
 SqlFindTag::SqlFindTag(const HistoryDatabase *database) {
   const std::string stmt =
-    "SELECT " + db_fields + " FROM tags WHERE name = :name LIMIT 1;";
+    "SELECT " + db_fields(database) + " FROM tags WHERE name = :name LIMIT 1;";
   const bool success = Init(database->sqlite_db(), stmt);
   assert (success);
 }
@@ -190,7 +194,7 @@ SqlFindTagByDate::SqlFindTagByDate(const HistoryDatabase *database) {
   // and picks the first tag                         |  LIMIT 1
   // that is older than the given timestamp          |  WHICH timestamp <= :ts
   const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields + " FROM tags "
+                            "SELECT " + db_fields(database) + " FROM tags "
                             "WHERE timestamp <= :timestamp "
                             "ORDER BY revision DESC LIMIT 1;");
   assert (success);
@@ -222,7 +226,7 @@ unsigned SqlCountTags::RetrieveCount() const {
 
 SqlListTags::SqlListTags(const HistoryDatabase *database) {
   const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields + " FROM tags "
+                            "SELECT " + db_fields(database) + " FROM tags "
                             "ORDER BY revision DESC;");
   assert (success);
 }
@@ -233,7 +237,7 @@ SqlListTags::SqlListTags(const HistoryDatabase *database) {
 
 SqlGetChannelTips::SqlGetChannelTips(const HistoryDatabase *database) {
   const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields + ", "
+                            "SELECT " + db_fields(database) + ", "
                             "  MAX(revision) AS max_rev "
                             "FROM tags "
                             "GROUP BY channel;");
@@ -269,7 +273,7 @@ SqlRollbackTag::SqlRollbackTag(const HistoryDatabase *database) {
 
 SqlListRollbackTags::SqlListRollbackTags(const HistoryDatabase *database) {
   const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields + " FROM tags "
+                            "SELECT " + db_fields(database) + " FROM tags "
                             "WHERE " + rollback_condition + " "
                             "ORDER BY revision DESC;");
   assert (success);

--- a/cvmfs/history_sql.h
+++ b/cvmfs/history_sql.h
@@ -56,7 +56,18 @@ class HistoryDatabase : public sqlite::Database<HistoryDatabase> {
 
 class SqlHistory : public sqlite::Sql {
  protected:
-  static const std::string db_fields;
+  const std::string& db_fields(const HistoryDatabase *database) const {
+    if (database->IsEqualSchema(database->schema_version(), 1.0f) &&
+        database->schema_revision() == 0) {
+      return db_fields_v1r0;
+    } else {
+      return db_fields_v1r1;
+    }
+  }
+
+ private:
+  static const std::string db_fields_v1r0;
+  static const std::string db_fields_v1r1;
 };
 
 

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -1515,3 +1515,81 @@ TYPED_TEST(T_History, ReadLegacyVersion1Revision1) {
 
   TestFixture::CloseHistory(history);
 }
+
+
+TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision0) {
+  if (TestFixture::IsMocked()) {
+    // this is only valid for the production code...
+    // the mocked history does not deal with legacy formats
+    return;
+  }
+
+  History *history = TestFixture::OpenWritableHistory(
+                                               TestFixture::history_v1_r0_path);
+  ASSERT_NE (static_cast<History*>(NULL), history);
+
+  const History::Tag dummy = TestFixture::GetDummyTag();
+  ASSERT_TRUE (history->Insert(dummy));
+  EXPECT_EQ (2u, history->GetNumberOfTags());
+
+  History::Tag tag;
+  ASSERT_TRUE (history->GetByName(dummy.name, &tag));
+  TestFixture::CompareTags (dummy, tag);
+
+  std::vector<shash::Any> recycled_hashes;
+  ASSERT_TRUE (history->ListRecycleBin(&recycled_hashes));
+  EXPECT_EQ (0u, recycled_hashes.size());
+
+  ASSERT_TRUE (history->Remove(dummy.name));
+  EXPECT_EQ (1u, history->GetNumberOfTags());
+
+  ASSERT_TRUE (history->ListRecycleBin(&recycled_hashes));
+  EXPECT_EQ (1u, recycled_hashes.size());
+  EXPECT_EQ (dummy.root_hash, recycled_hashes[0]);
+
+  ASSERT_TRUE (history->EmptyRecycleBin());
+
+  ASSERT_TRUE (history->ListRecycleBin(&recycled_hashes));
+  EXPECT_EQ (0u, recycled_hashes.size());
+
+  TestFixture::CloseHistory(history);
+}
+
+
+TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision1) {
+  if (TestFixture::IsMocked()) {
+    // this is only valid for the production code...
+    // the mocked history does not deal with legacy formats
+    return;
+  }
+
+  History *history = TestFixture::OpenWritableHistory(
+                                               TestFixture::history_v1_r1_path);
+  ASSERT_NE (static_cast<History*>(NULL), history);
+
+  const History::Tag dummy = TestFixture::GetDummyTag();
+  ASSERT_TRUE (history->Insert(dummy));
+  EXPECT_EQ (3u, history->GetNumberOfTags());
+
+  History::Tag tag;
+  ASSERT_TRUE (history->GetByName(dummy.name, &tag));
+  TestFixture::CompareTags (dummy, tag);
+
+  std::vector<shash::Any> recycled_hashes;
+  ASSERT_TRUE (history->ListRecycleBin(&recycled_hashes));
+  EXPECT_EQ (0u, recycled_hashes.size());
+
+  ASSERT_TRUE (history->Remove(dummy.name));
+  EXPECT_EQ (2u, history->GetNumberOfTags());
+
+  ASSERT_TRUE (history->ListRecycleBin(&recycled_hashes));
+  EXPECT_EQ (1u, recycled_hashes.size());
+  EXPECT_EQ (dummy.root_hash, recycled_hashes[0]);
+
+  ASSERT_TRUE (history->EmptyRecycleBin());
+
+  ASSERT_TRUE (history->ListRecycleBin(&recycled_hashes));
+  EXPECT_EQ (0u, recycled_hashes.size());
+
+  TestFixture::CloseHistory(history);
+}

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -117,6 +117,14 @@ class T_History : public ::testing::Test {
     return false;
   }
 
+  bool IsMocked(const type<history::SqliteHistory> type_specifier) const {
+    return false;
+  }
+
+  bool IsMocked(const type<MockHistory> type_specifier) const {
+    return true;
+  }
+
  protected:
   History* CreateHistory(const std::string &filename) {
     return CreateHistory(type<HistoryT>(), filename);
@@ -136,6 +144,10 @@ class T_History : public ::testing::Test {
 
   bool NeedsSandbox() const {
     return NeedsSandbox(type<HistoryT>());
+  }
+
+  bool IsMocked() const {
+    return IsMocked(type<HistoryT>());
   }
 
   std::string GetHistoryFilename() const {

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -2,10 +2,12 @@
 #include <string>
 #include <map>
 
-#include "../../cvmfs/util.h"
-#include "../../cvmfs/prng.h"
 #include "testutil.h"
+
+#include "../../cvmfs/compression.h"
 #include "../../cvmfs/history_sqlite.h"
+#include "../../cvmfs/prng.h"
+#include "../../cvmfs/util.h"
 
 using namespace history;
 
@@ -14,6 +16,12 @@ class T_History : public ::testing::Test {
  protected:
   static const std::string sandbox;
   static const std::string fqrn;
+
+  static const std::string history_v1_r0;
+  static const std::string history_v1_r1;
+
+  static const std::string history_v1_r0_path;
+  static const std::string history_v1_r1_path;
 
   typedef std::vector<History::Tag>            TagVector;
   typedef std::map<std::string, MockHistory*>  MockHistoryMap;
@@ -249,6 +257,41 @@ const std::string T_History<HistoryT>::sandbox = "/tmp/cvmfs_ut_history";
 
 template <class HistoryT>
 const std::string T_History<HistoryT>::fqrn    = "test.cern.ch";
+
+template <class HistoryT>
+const std::string T_History<HistoryT>::history_v1_r0_path =
+  T_History<HistoryT>::sandbox + "/history_v1_r0";
+
+template <class HistoryT>
+const std::string T_History<HistoryT>::history_v1_r1_path =
+  T_History<HistoryT>::sandbox + "/history_v1_r1";
+
+template <class HistoryT>
+const std::string T_History<HistoryT>::history_v1_r0 =
+  "eJztlb1v00AUwM8+N00QnVBkul0main9cBxBUJeayqoiSgHHAx1QdLEv8Sn+qn2uqJjKH8HM/4SQ"
+  "mJnpwgALA3dOkVMkBAsClfvp3tO7p3vn92T7vdHTQ8oImqZ5jBmygAYUBewhBABocFkBNSoXbWmv"
+  "gF/TAJsfjDX4FWhqCmAHvlVT9eNvxEmuJy/hqt7pKOc2w5OIZHmakZxRUtSWtu86tucgz35w6KDa"
+  "jzbm5Ax5zjOvi05xVJJLe//x0chz7eGRh7L5eOn8E3f4yHaP0UPnuIo1DEtr6AcdBdAkIC+Kk4h/"
+  "+GNcsrTaL4WOzdpeOd9WVvV2W3m1SJnhWSFEvZKm8KCNBMffswpxEV6aOTmlBU0TxFN0Dhy3ixBi"
+  "NCb8mjirnX6Ik4REtSMghZ/TjInQxU0/1Fo99EqVIgHDuKM29N32z8oUUWNTaMjfh7bGlQJfA74k"
+  "Esk/Qch7zvOW1oxZXibzwLT8+4NJf9If+CTAfoCt3oAQ3MfWzqB31+KYPd+8N3ozfBdhxjsLyspJ"
+  "RIuQBKhIcFaEKesi0QP4kKc+jqIzVGYBPxrcAOL//wL4kkgk/wdNqLeq3iLmvwrfA/iJK4lEci24"
+  "rcL29vQkT/w0mdLZJpnRrUrKmwpcv1X4IYmxubUj5r8KLwC8gJ//ds4SieQP0oRtRfQEtQXXW4sW"
+  "8A15t8pp";
+
+template <class HistoryT>
+const std::string T_History<HistoryT>::history_v1_r1 =
+  "eJztl09r1EAUwCd5absVS6FlWXoQpniwoX/Y7KbZLaK4lqUUa9VtDvYg28lkYkKzSZqZLa2e6kfw"
+  "W3n21EMvxU/gQS8ezOy2ZFcoehDEkh/M5M1j3j+SN0P2Xu0EgmEvTntE4DrSkKKgJxgjhGayMYFy"
+  "1GxoI2sF/Z4ZtHqpz8APpKkHCObgs3qgXvyBXcEt4T1MVRYXlbOWIE7IkjROWCoCxnNJ2+y0W3Yb"
+  "262nO22c6/HSITvFdvu1vYKPSdhnV/Lmi909u9Pa3rVxctgd2f+ys/281dnHz9r7A1tdr2uTla1F"
+  "BQWRy074UZh96V3SF/FgPWLaNXJ54uyxMlUpl5UP3UHKgrzlcqhjaUoNXopI7zorn3D/SkzZccCD"
+  "OMJZiu2tdmcFYyyCHsvc9JJcSX0SRSzMFS7jNA0SIU2Hnnjwjo16GS99kMNY0TIfXX+gTlYelm+q"
+  "Wlp1DTlD9no02eQq3EPwMZsKCgpyuFrS3yhaKVBF2o8OVxPZ2nGfNxuWZXoNt05N0lgnTbrhWTVW"
+  "J2bD2bBqtFo1XMtZrxHV5rN60nfCgPvMxRE7EVjEeOBsBcuezC7dgJIwPMX9xCWCuU0UKqWKDNob"
+  "BvVMx3Isz2IbTeZQ5hGTsapBTcOxTIcQ5jhmbZ0yF2z+KAgzF1zgPCSPSML9WNwY7Q6S/f8Fwfds"
+  "KigouHXMga6MH2BqCSrTA5W8/wE+IfgKF9mjoKDgf2QOoHzfO0ojj9I1ytJojfrzKizPcuqzHule"
+  "/5UYdxVYmB8qjbWqvP8BzhGcwze4/NdFFBQU/BVKUFbkcQDzsKz8cgao07AwPdT9BBspCA8=";
 
 
 typedef ::testing::Types<history::SqliteHistory, MockHistory> HistoryTypes;


### PR DESCRIPTION
When opening a legacy history database file in read-only mode, the database is not automagically migrated to the newest schema. Unfortunately the code was not prepared to handle older database schemas and failed due to missing database fields. (Fixes [CVM-762](https://sft.its.cern.ch/jira/browse/CVM-762) - thanks for reporting @DrDaveD).

Additionally this adds some regression tests to ensure the bug stays fixed.