### PR TITLE
FIX: Compiler Warning in t_object_fetcher.cc

### DIFF
--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -667,7 +667,7 @@ TYPED_TEST(T_ObjectFetcher, AutoCleanupFetchedFiles) {
   DirectoryListing listing;
   TestFixture::ListDirectory(TestFixture::temp_directory, &listing);
 
-  int files = 0;
+  size_t files = 0;
 
   EXPECT_EQ (files, listing.size());
 


### PR DESCRIPTION
Googletest is pretty pedantic... apparently to a different extent on various platforms...