### PR TITLE
Fix IP resolving: prefer IPv4 over IPv6

### DIFF
--- a/cvmfs/dns.h
+++ b/cvmfs/dns.h
@@ -96,6 +96,7 @@ class Host {
 
   time_t deadline() const { return deadline_; }
   int64_t id() const { return id_; }
+  bool HasIpv4() const { return !ipv4_addresses_.empty(); }
   bool HasIpv6() const { return !ipv6_addresses_.empty(); }
   const std::set<std::string> &ipv4_addresses() const { return ipv4_addresses_; }
   const std::set<std::string> &ipv6_addresses() const { return ipv6_addresses_; }

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -888,18 +888,18 @@ void DownloadManager::ValidateProxyIpsUnlocked(
     }
   }
   vector<ProxyInfo> new_infos;
-  // IPv6 addresses have precedence
+  // IPv4 addresses have precedence
   set<string>::const_iterator iter_ips;
-  if (new_host.HasIpv6()) {
-    iter_ips = new_host.ipv6_addresses().begin();
-    for (; iter_ips != new_host.ipv6_addresses().end(); ++iter_ips) {
+  if (new_host.HasIpv4()) {
+    iter_ips = new_host.ipv4_addresses().begin();
+    for (; iter_ips != new_host.ipv4_addresses().end(); ++iter_ips) {
       string url_ip = dns::RewriteUrl(url, *iter_ips);
       new_infos.push_back(ProxyInfo(new_host, url_ip));
     }
   } else {
-    // IPv4
-    iter_ips = new_host.ipv4_addresses().begin();
-    for (; iter_ips != new_host.ipv4_addresses().end(); ++iter_ips) {
+    // IPv6
+    iter_ips = new_host.ipv6_addresses().begin();
+    for (; iter_ips != new_host.ipv6_addresses().end(); ++iter_ips) {
       string url_ip = dns::RewriteUrl(url, *iter_ips);
       new_infos.push_back(ProxyInfo(new_host, url_ip));
     }
@@ -2003,21 +2003,21 @@ void DownloadManager::SetProxyChain(const string &proxy_list) {
         continue;
       }
 
-      // IPv6 addresses have precedence
+      // IPv4 addresses have precedence
       set<string>::const_iterator iter_ips;
-      if (hosts[num_proxy].HasIpv6()) {
-        // IPv6
-        iter_ips = hosts[num_proxy].ipv6_addresses().begin();
-        for (; iter_ips != hosts[num_proxy].ipv6_addresses().end();
+      if (hosts[num_proxy].HasIpv4()) {
+        // IPv4
+        iter_ips = hosts[num_proxy].ipv4_addresses().begin();
+        for (; iter_ips != hosts[num_proxy].ipv4_addresses().end();
              ++iter_ips)
         {
           string url_ip = dns::RewriteUrl(this_group[j], *iter_ips);
           infos.push_back(ProxyInfo(hosts[num_proxy], url_ip));
         }
       } else {
-        // IPv4
-        iter_ips = hosts[num_proxy].ipv4_addresses().begin();
-        for (; iter_ips != hosts[num_proxy].ipv4_addresses().end();
+        // IPv6
+        iter_ips = hosts[num_proxy].ipv6_addresses().begin();
+        for (; iter_ips != hosts[num_proxy].ipv6_addresses().end();
              ++iter_ips)
         {
           string url_ip = dns::RewriteUrl(this_group[j], *iter_ips);

--- a/test/src/052-roundrobindns/main
+++ b/test/src/052-roundrobindns/main
@@ -88,7 +88,6 @@ run_dns_test() {
   num_dns_changes=$(count_dns_changes)
   echo "::2 round-robin.localdomain" > host_tests
   echo "::3 round-robin.localdomain" >> host_tests
-  echo "127.0.0.2 round-robin.localdomain" >> host_tests  # IPv6 has precedence
   sudo cvmfs_talk -i aleph.cern.ch proxy group switch
   sudo date $(date +%m%d%H%M%Y.%S -d '+4 hour')
   sudo cvmfs_talk -i aleph.cern.ch proxy info
@@ -105,7 +104,8 @@ run_dns_test() {
   # IPv6 --> IPv4
   echo "IPv6 --> IPv4"
   num_dns_changes=$(count_dns_changes)
-  echo "127.0.0.2 round-robin.localdomain" > host_tests
+  # IPv4 has precedence over already existing IPv6 entries
+  echo "127.0.0.2 round-robin.localdomain" >> host_tests
   echo "127.0.0.3 round-robin.localdomain" >> host_tests
   sudo cvmfs_talk -i aleph.cern.ch proxy group switch
   sudo date $(date +%m%d%H%M%Y.%S -d '+5 hour')

--- a/test/unittests/t_dns.cc
+++ b/test/unittests/t_dns.cc
@@ -141,9 +141,11 @@ static void ExpectResolvedName(
 {
   set<string> ipv4_addresses = host.ipv4_addresses();
   if (!ipv4.empty()) {
+    EXPECT_TRUE(host.HasIpv4());
     ASSERT_EQ(1U, ipv4_addresses.size());
     EXPECT_EQ(ipv4, *ipv4_addresses.begin());
   } else {
+    EXPECT_FALSE(host.HasIpv4());
     EXPECT_EQ(0U, ipv4_addresses.size());
   }
   if (!ipv6.empty()) {
@@ -408,6 +410,7 @@ TEST_F(T_Dns, Resolver) {
   EXPECT_EQ(host.name(), "normal");
   EXPECT_EQ(host.status(), kFailOk);
   EXPECT_TRUE(host.IsValid());
+  EXPECT_TRUE(host.HasIpv4());
   EXPECT_TRUE(host.HasIpv6());
   EXPECT_EQ(host.ipv4_addresses().size(), 2U);
   EXPECT_EQ(host.ipv6_addresses().size(), 2U);
@@ -416,6 +419,7 @@ TEST_F(T_Dns, Resolver) {
   EXPECT_EQ(host.name(), "ipv4");
   EXPECT_EQ(host.status(), kFailOk);
   EXPECT_TRUE(host.IsValid());
+  EXPECT_TRUE(host.HasIpv4());
   EXPECT_FALSE(host.HasIpv6());
   EXPECT_EQ(host.ipv4_addresses().size(), 2U);
   EXPECT_EQ(host.ipv6_addresses().size(), 0U);
@@ -424,6 +428,7 @@ TEST_F(T_Dns, Resolver) {
   EXPECT_EQ(host.name(), "ipv6");
   EXPECT_EQ(host.status(), kFailOk);
   EXPECT_TRUE(host.IsValid());
+  EXPECT_FALSE(host.HasIpv4());
   EXPECT_TRUE(host.HasIpv6());
   EXPECT_EQ(host.ipv4_addresses().size(), 0U);
   EXPECT_EQ(host.ipv6_addresses().size(), 2U);
@@ -432,6 +437,7 @@ TEST_F(T_Dns, Resolver) {
   EXPECT_EQ(host.name(), "bad-ipv4");
   EXPECT_EQ(host.status(), kFailOk);
   EXPECT_TRUE(host.IsValid());
+  EXPECT_TRUE(host.HasIpv4());
   EXPECT_FALSE(host.HasIpv6());
   EXPECT_EQ(host.ipv4_addresses().size(), 1U);
   EXPECT_EQ(host.ipv6_addresses().size(), 0U);
@@ -440,6 +446,7 @@ TEST_F(T_Dns, Resolver) {
   EXPECT_EQ(host.name(), "bad-ipv6");
   EXPECT_EQ(host.status(), kFailOk);
   EXPECT_TRUE(host.IsValid());
+  EXPECT_FALSE(host.HasIpv4());
   EXPECT_TRUE(host.HasIpv6());
   EXPECT_EQ(host.ipv4_addresses().size(), 0U);
   EXPECT_EQ(host.ipv6_addresses().size(), 1U);


### PR DESCRIPTION
At least VMware Fusion, possibly other clients too, have problems connecting to IPv6 servers. Hence IPv4 addresses are preferred if available.