### PR TITLE
Feature: Non-Blocking Snapshot on Stratum 1

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -251,7 +251,8 @@ Supported Commands:
                 Checks if the repository is sane
   transaction   <fully qualified name>
                 Start to edit a repository
-  snapshot      <fully qualified name>
+  snapshot      [-t fail if other snapshot is in progress]
+                <fully qualified name>
                 Synchronize a Stratum 1 replica with the Stratum 0 source
   migrate       <fully qualified name>
                 Migrates a repository to the current version of CernVM-FS

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4068,6 +4068,21 @@ snapshot() {
   local timeout
   local retries
   local retcode=0
+  local dont_wait=
+
+  OPTIND=1
+  while getopts "t" option; do
+    case $option in
+      t)
+        dont_wait="-s"
+      ;;
+      ?)
+        shift $(($OPTIND-2))
+        usage "Command snapshot: Unrecognized option: $1"
+      ;;
+    esac
+  done
+  shift $(($OPTIND-1))
 
   # get repository names
   check_parameter_count_for_multiple_repositories $#
@@ -4137,7 +4152,7 @@ snapshot() {
         -k $public_key \
         -n $num_workers \
         -t $timeout \
-        -a $retries $with_history $log_level"
+        -a $retries $with_history $log_level $dont_wait"
     $user_shell "date > ${spool_dir}/tmp/last_snapshot"
     $user_shell "cvmfs_swissknife upload -r ${upstream} \
       -i ${spool_dir}/tmp/last_snapshot \

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -64,6 +64,7 @@ string              *temp_dir = NULL;
 unsigned             num_parallel = 1;
 bool                 pull_history = false;
 bool                 is_garbage_collectable = false;
+bool                 wait_for_other_snapshots = true;
 upload::Spooler     *spooler = NULL;
 int                  pipe_chunks[2];
 // required for concurrent reading
@@ -388,6 +389,8 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     retries = String2Uint64(*args.find('a')->second);
   if (args.find('p') != args.end())
     pull_history = true;
+  if (args.find('s') != args.end())
+    wait_for_other_snapshots = false;
   pthread_t *workers =
     reinterpret_cast<pthread_t *>(smalloc(sizeof(pthread_t) * num_parallel));
   typedef std::vector<history::History::Tag> TagVector;
@@ -399,6 +402,11 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   // Wait for another instance to finish
   fd_lockfile = TryLockFile(*temp_dir + "/lock_snapshot");
   if (fd_lockfile < 0) {
+    if (! wait_for_other_snapshots) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "another snapshot is in progress... aborting");
+      return 2;
+    }
+
     LogCvmfs(kLogCvmfs, kLogStdout, "waiting for another snapshot to finish...");
     fd_lockfile = LockFile(*temp_dir + "/lock_snapshot");
     if (fd_lockfile < 0) {

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -30,6 +30,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional ('a', "number of retries"));
     r.push_back(Parameter::Switch   ('p', "pull catalog history, too"));
     r.push_back(Parameter::Switch   ('c', "preload cache instead of stratum 1"));
+    r.push_back(Parameter::Switch   ('s', "don't wait for other snapshots"));
     return r;
   }
   int Main(const ArgumentList &args);


### PR DESCRIPTION
This allows to opt-out of the blocking behaviour of `cvmfs_server snapshot`. By default it will detect if a snapshot is currently running and wait for it to finish. When run as `cvmfs_server snapshot -t` it will not wait but fail with an error code instead.