### PR TITLE
Fix: Migration Test

### DIFF
--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -118,11 +118,11 @@ cvmfs_run_test() {
   local cvmfs_keys=$(basename $cvmfs_keys_url)
   echo "Download URL for cvmfs-keys: $cvmfs_keys_url"
   wget --no-check-certificate --quiet $cvmfs_keys_url || return 21
-  install_package $cvmfs_keys                         || return 22
+  install_packages $cvmfs_keys                        || return 22
 
   # install the upstream CernVM-FS package
   echo "installing CernVM-FS $previous_version"
-  install_package $upstream_package || return 4
+  install_packages $upstream_package || return 4
 
   # make sure that autofs is running
   echo "switching on autofs"
@@ -168,7 +168,7 @@ cvmfs_run_test() {
   echo "updating CernVM-FS package to version $current_version"
   kill -0 $tar_pid || return 11 # tar finished already >.<
   kill -0 $chksum_pid || return 11 # checksumming finished already >.<
-  install_package "$CVMFS_CLIENT_PACKAGE $CVMFS_CONFIG_PACKAGES" || return 12 # TODO: revert that after 2.1.20 is released
+  install_packages "$CVMFS_CLIENT_PACKAGE $CVMFS_CONFIG_PACKAGES" || return 12 # TODO: revert that after 2.1.20 is released
   kill -0 $tar_pid || return 13 # tar finished already >.<
   kill -0 $chksum_pid || return 13 # checksumming finished already >.<
 

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -68,6 +68,15 @@ guess_cvmfs_keys_url() {
   echo ${CVMFS_EC_BASE_URL}/cvmfs-keys/${package_file_name}
 }
 
+MIGTEST_001_IPV6_DISABLED=0
+cleanup() {
+  echo "running cleanup()"
+  if [ $MIGTEST_001_IPV6_DISABLED -eq 1 ]; then
+    echo "reenabling IPv6"
+    echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+  fi
+}
+
 
 cvmfs_run_test() {
   local logfile=$1
@@ -87,6 +96,32 @@ cvmfs_run_test() {
   local md5_2=""
   local md5_3=""
   local md5_output="async_md5.checksum"
+
+  # install a cleanup function
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  # disable IPv6 if it appears to be misconfigured
+  if [ -f /proc/net/if_inet6 ]; then
+    if cat /proc/net/if_inet6 | grep -q '^fe80'; then
+      echo "Found at least one link-local IPv6 address in the configuration:"
+      cat /proc/net/if_inet6 | grep '^fe80'
+
+      local test_server="ipv6.google.com"
+      if ! ping6 -c1 $test_server > /dev/null;  then
+        echo "Ping to $test_server failed... IPv6 seems to be broken... disabling it"
+        echo 1 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+
+        if [ $(cat /proc/net/if_inet6 | wc -l) -ne 0 ]; then
+          echo "WARNING: failed to disable a (probably) broken IPv6 setup"
+        else
+          echo "Successfully disabled a broken IPv6 setup"
+          MIGTEST_001_IPV6_DISABLED=1
+        fi
+      fi
+    fi
+  else
+    echo "No IPv6 available"
+  fi
 
   # download upstream package
   current_version=$(package_version $CVMFS_CLIENT_PACKAGE)

--- a/test/migration_tests/common.sh
+++ b/test/migration_tests/common.sh
@@ -123,13 +123,13 @@ is_installed() {
 }
 
 
-install_package() {
-  local pkg_path=$1
+install_packages() {
+  local pkg_paths="$1"
 
   if has_binary yum; then
-    sudo yum -y install --nogpgcheck $pkg_path
+    sudo yum -y install --nogpgcheck $pkg_paths
   elif has_binary dpkg; then
-    sudo dpkg --install $pkg_path
+    sudo dpkg --install $pkg_paths
     sudo apt-get --assume-yes -f install
   else
     return 1


### PR DESCRIPTION
Seems that OpenStack at CERN does not properly configure the IPv6 setup by default. However CernVM-FS 2.1.19 uses IPv6 as the preferred protocol and might fail to mount repositories under these circumstances. This adds code to (temporarily) disable IPv6 while running the migration test.

Furthermore this contains a fix to allow the installation of multiple packages with the helper function `install_packages()` (formerly known as `install_package()`.