### PR TITLE
Fix: CVMFS_HASH_ALGORITHM is Optional + List Tags in Reverse Chronological Order

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3097,6 +3097,7 @@ tag() {
 
   local base_hash="$(get_mounted_root_hash $name)"
   local user_shell="$(get_user_shell $name)"
+  local hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
 
   # tag listing does not need an open repository transaction
   if [ $action_list -eq 1 ] || [ $actions -eq 0 ]; then
@@ -3153,7 +3154,7 @@ tag() {
       -r $CVMFS_UPSTREAM_STORAGE                          \
       -m $new_manifest                                    \
       -b $base_hash                                       \
-      -e $CVMFS_HASH_ALGORITHM                            \
+      -e $hash_algorithm                                  \
       -a $tag_name"
     if [ ! -z "$add_tag_channel" ]; then
       tag_create_command="$tag_create_command -c $add_tag_channel"
@@ -3191,7 +3192,7 @@ tag() {
       -r $CVMFS_UPSTREAM_STORAGE                         \
       -m $new_manifest                                   \
       -b $base_hash                                      \
-      -e $CVMFS_HASH_ALGORITHM                           \
+      -e $hash_algorithm                                 \
       -d '$tag_names'" || die "Did not remove anything"
     sign_manifest $name $new_manifest || die "Failed to sign repo"
   fi
@@ -3569,10 +3570,7 @@ publish() {
     spool_dir=$CVMFS_SPOOL_DIR
     stratum0=$CVMFS_STRATUM0
     upstream=$CVMFS_UPSTREAM_STORAGE
-    hash_algo=$CVMFS_HASH_ALGORITHM
-    if [ x"$hash_algo" != "x" ]; then
-      hash_algo="-e $hash_algo"
-    fi
+    hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
 
     local swissknife="cvmfs_swissknife"
 
@@ -3639,7 +3637,8 @@ publish() {
       -r ${upstream} \
       -w $stratum0 \
       -o $manifest \
-      $hash_algo $log_level $tweaks_option"
+      -e $hash_algorithm \
+      $log_level $tweaks_option"
     if [ "x$CVMFS_UNION_FS_TYPE" != "x" ]; then
       sync_command="$sync_command -f $CVMFS_UNION_FS_TYPE"
     fi
@@ -3672,7 +3671,7 @@ publish() {
       -p /etc/cvmfs/keys/${name}.pub          \
       -f $name                                \
       -b $base_hash                           \
-      $hash_algo                              \
+      -e $hash_algorithm                      \
       -x" # -x enables magic undo tag handling
     if [ ! -z "$tag_name" ]; then
       tag_command="$tag_command -a $tag_name"
@@ -3826,6 +3825,7 @@ rollback() {
   # prepare the shell commands
   local user_shell="$(get_user_shell $name)"
   local base_hash=$(get_mounted_root_hash $name)
+  local hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
 
   local rollback_command="cvmfs_swissknife tag_rollback \
     -w $stratum0                                        \
@@ -3836,7 +3836,7 @@ rollback() {
     -r $upstream                                        \
     -m ${spool_dir}/tmp/manifest                        \
     -b $base_hash                                       \
-    -e $CVMFS_HASH_ALGORITHM"
+    -e $hash_algorithm"
   if [ ! -z "$target_tag" ]; then
     rollback_command="$rollback_command -n $target_tag"
   fi
@@ -4037,6 +4037,7 @@ __run_gc() {
                                         $additional_switches"
   $user_shell "$gc_command" || return 6
 
+  local hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
   if is_stratum0 $name && [ $dry_run -eq 0 ]; then
     tag_command="cvmfs_swissknife tag_empty_bin \
       -r $CVMFS_UPSTREAM_STORAGE                \
@@ -4046,7 +4047,7 @@ __run_gc() {
       -p /etc/cvmfs/keys/${name}.pub            \
       -f $name                                  \
       -b $base_hash                             \
-      -e $CVMFS_HASH_ALGORITHM"
+      -e $hash_algorithm"
     $user_shell "$tag_command" || return 7
   fi
 

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -856,8 +856,8 @@ void CommandListTags::PrintHumanReadableList(
   const std::string desc_label = "Description";
 
   // figure out the maximal lengths of the fields in the lists
-        TagList::const_iterator i    = tags.begin();
-  const TagList::const_iterator iend = tags.end();
+        TagList::const_reverse_iterator i    = tags.rbegin();
+  const TagList::const_reverse_iterator iend = tags.rend();
   size_t max_name_len = name_label.size();
   size_t max_rev_len  = rev_label.size();
   size_t max_chan_len = chan_label.size();
@@ -885,7 +885,7 @@ void CommandListTags::PrintHumanReadableList(
            AddPadding("", desc_label.size() + 1, false, "\u2500").c_str());
 
   // print the rows of the list
-  i = tags.begin();
+  i = tags.rbegin();
   for (; i != iend; ++i) {
     LogCvmfs(kLogCvmfs, kLogStdout, "%s \u2502 %s \u2502 %s \u2502 %s \u2502 %s",
              AddPadding(i->name,                           max_name_len).c_str(),


### PR DESCRIPTION
Turns out, that `CVMFS_HASH_ALGORITHM` is not mandatory to be set in the server configuration and might be empty. Added a default for this setting.
Furthermore this reverses the order of tag listing (cf. `cvmfs_server tag -l`) for the human readable tag list.