### PR TITLE
FIX: TAR Checksumming in Migration Test

### DIFF
--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -10,10 +10,15 @@ skip_bytes() {
 tar_gzip_and_hash() {
     local dir_path=$1
     local tar_log=$2
-    local result_file=$3
+    local script_location=$3
+    local result_file=$4
 
+    local tar_archive="$(mktemp ./tar.XXXX)"
+
+    tar czv $dir_path 2>$tar_log > $tar_archive || return 1
     local md5_result
-    md5_result=$(tar czv $dir_path 2>$tar_log | skip_bytes 6 | md5sum | head -c32)
+    md5_result="$(${script_location}/tarsum $tar_archive | cut -d' ' -f1 | sort | md5sum | cut -d' ' -f1)"
+    rm -f $tar_archive || return 2
 
     if [ x"$result_file" != x"" ]; then
       echo -n "$md5_result" > $result_file
@@ -178,14 +183,14 @@ cvmfs_run_test() {
 
   # do some hammering on the file system (without interruption)
   echo "tar $src_dir (without interruption)"
-  md5_1=$(tar_gzip_and_hash $src_dir $tar_log1)
+  md5_1=$(tar_gzip_and_hash $src_dir $tar_log1 $script_location)
   echo "checksumming large files in $xxl_files_dir (without interruption)"
   checksum_large_files $xxl_files_dir $chksum_log1
 
   # do some hammering on the file system
   sudo cvmfs_talk -i sft cleanup 0
   echo "starting to tar $src_dir (log output in separate file)"
-  tar_gzip_and_hash $src_dir $tar_log2 $md5_output &
+  tar_gzip_and_hash $src_dir $tar_log2 $script_location $md5_output &
   local tar_pid=$!
   echo "tar runs under PID $tar_pid"
   echo "starting to checksum large files in $xxl_files_dir (log output in separate file)"
@@ -221,7 +226,7 @@ cvmfs_run_test() {
 
   # do some hammering on the file system (after update)
   echo "tar $src_dir (without interruption - after update)"
-  md5_3=$(tar_gzip_and_hash $src_dir $tar_log3)
+  md5_3=$(tar_gzip_and_hash $src_dir $tar_log3 $script_location)
   echo "checksumming large files in $xxl_files_dir (without interruption - after update)"
   checksum_large_files $xxl_files_dir $chksum_log3
 

--- a/test/migration_tests/001-hotpatch/tarsum
+++ b/test/migration_tests/001-hotpatch/tarsum
@@ -1,0 +1,77 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2008-2009 by Guy Rutenberg
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import hashlib
+import tarfile
+
+def tarsum(input_file, hash, output_file):
+        """
+        input_file  - A FILE object to read the tar file from.
+        hash - The name of the hash to use. Must be supported by hashlib.
+        output_file - A FILE to write the computed signatures to.
+        """
+        tar = tarfile.open(mode="r:*", fileobj=input_file)
+
+        chunk_size = 100*1024
+        store_digests = {}
+
+        for member in tar:
+            if not member.isfile():
+                continue
+            f = tar.extractfile(member)
+            h = hashlib.new(hash)
+            data = f.read(chunk_size)
+            while data:
+                h.update(data)
+                data = f.read(chunk_size)
+            output_file.write("%s  %s\n" % (h.hexdigest(), member.name))
+
+def main():
+    parser = OptionParser()
+
+    version=("%prog 0.2\n"
+             "Copyright (C) 2008-2009 Guy Rutenberg <http://www.guyrutenberg.com/contact-me>")
+    usage=("%prog [options] TARFILE\n"
+           "Print a checksum signature for every file in TARFILE.\n"
+           "With no FILE, or when FILE is -, read standard input.")
+    parser = OptionParser(usage=usage, version=version)
+    parser.add_option("-c", "--checksum", dest="checksum", type="string",
+        help="use HASH as for caclculating the checksums. [default: %default]", metavar="HASH",
+        default="md5")
+    parser.add_option("-o", "--output", dest="output", type="string",
+        help="save signatures to FILE.", metavar="FILE")
+
+    (option, args) = parser.parse_args()
+
+    output_file = sys.stdout
+    if option.output:
+        output_file = open(option.output, "w")
+
+    input_file = sys.stdin
+    if len(args)==1 and args[0]!="-":
+        input_file = open(args[0], "r")
+
+    tarsum(input_file, option.checksum, output_file)
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+    import sys
+    main()
+
+# vim: ai ts=4 sts=4 et sw=4


### PR DESCRIPTION
Hopefully this way of checking the content of the generated tar archives is more resilient.