### PR TITLE
Fix: Inefficient Defragmentation SQL Query

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -185,14 +185,10 @@ double CatalogDatabase::GetRowIdWasteRatio() const {
 /**
  * Cleanup unused database space
  *
- * This creates a temporary table 'mapping' filled with the current rowIDs from
- * the catalog table. The new table will implicitly have an auto-increment rowID
- * that is compact. Thus, we create a 'mapping' from each catalog's rowID to a
- * new rowID-space that does not have any gaps. Notice, that the order of old
- * and new rowIDs will stay the same to fulfill the PRIMARY KEY constraints
- * during update.
- * Thereafter the catalog's rowIDs are mapped to their new (unique and compact)
- * rowIDs and the temporary table is deleted.
+ * This copies the entire catalog content into a temporary SQLite table, sweeps
+ * the original data from the 'catalog' table and reinserts everything from the
+ * temporary table afterwards. That way the implicit rowid field of 'catalog' is
+ * defragmented.
  *
  * Note: VACUUM used to have a similar behaviour but it was dropped from SQLite
  *       at some point. Since we compute client-inodes from the rowIDs, we are

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -204,15 +204,15 @@ double CatalogDatabase::GetRowIdWasteRatio() const {
 bool CatalogDatabase::CompactDatabase() const {
   assert (read_write());
 
-  return Sql(*this, "BEGIN;").Execute()                                 &&
-         Sql(*this, "CREATE TEMPORARY TABLE mapping AS "
-                    "  SELECT rowid AS cid FROM catalog "
-                    "  ORDER BY cid;").Execute()                        &&
-         Sql(*this, "UPDATE OR ROLLBACK catalog SET "
-                    "  rowid = (SELECT mapping.rowid FROM mapping "
-                    "           WHERE cid = catalog.rowid);").Execute() &&
-         Sql(*this, "DROP TABLE mapping;").Execute()                    &&
-         Sql(*this, "COMMIT;").Execute();
+  return Sql(*this, "BEGIN;").Execute()                                   &&
+         Sql(*this, "CREATE TEMPORARY TABLE duplicate AS "
+                    "  SELECT * FROM catalog "
+                    "  ORDER BY rowid ASC;").Execute()                    &&
+         Sql(*this, "DELETE FROM catalog;").Execute()                     &&
+         Sql(*this, "INSERT INTO catalog "
+                    "  SELECT * FROM duplicate ORDER BY rowid").Execute() &&
+         Sql(*this, "COMMIT;").Execute()                                  &&
+         Sql(*this, "DROP TABLE duplicate;").Execute();
 }
 
 

--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -165,11 +165,15 @@ cvmfs_run_test() {
   echo "Catalog Size: $second_root_size"
   [ $absdiff -lt 10240 ] || [ $absdiff -gt -10240 ] || return 45
 
+  echo "check that the Row IDs are actually dense now"
+  local wasted_row_ids="$(get_wasted_row_ids_in_root_catalog $CVMFS_TEST_REPO)"
+  [ $wasted_row_ids -eq 0 ] || return 46
+
   echo "create a last transaction to check if defrag info is gone"
-  start_transaction $CVMFS_TEST_REPO                   || return 46
+  start_transaction $CVMFS_TEST_REPO                   || return 47
   local publish_log_5=publish_5.log
-  publish_repo $CVMFS_TEST_REPO > $publish_log_5       || return 47
-  cat $publish_log_5 | grep -e '/ gets defragmented.*' && return 48
+  publish_repo $CVMFS_TEST_REPO > $publish_log_5       || return 48
+  cat $publish_log_5 | grep -e '/ gets defragmented.*' && return 49
 
   return 0
 }

--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -9,6 +9,27 @@ get_catalog_file_size() {
   cvmfs_server list-catalogs -xs $repo_name | grep -e "^.* $catalog_path$" | sed 's/^\([0-9]*\)B\s.*$/\1/'
 }
 
+
+get_and_decompress_root_catalog() {
+  local repo_name="$1"
+  local root_catalog="$(get_current_root_catalog $repo_name)C"
+  local object_url="$(get_object_url $repo_name $root_catalog)"
+  local sqlite_db="${root_catalog}.uncompressed"
+
+  wget --quiet $object_url                                             || return 1
+  cat $(basename $object_url) | cvmfs_swissknife zpipe -d > $sqlite_db || return 2
+  echo $sqlite_db
+}
+
+
+get_wasted_row_ids_in_root_catalog() {
+  local repo_name="$1"
+  local root_clg="$(get_and_decompress_root_catalog $repo_name)"
+
+  sqlite3 $root_clg "SELECT max(rowid) - count(*) FROM catalog;"
+}
+
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO

--- a/test/test_functions
+++ b/test/test_functions
@@ -971,6 +971,14 @@ get_repo_url() {
   fi
 }
 
+get_object_url() {
+  local repo_name="$1"
+  local object_hash="$2"
+  local repo_url="$(get_repo_url $repo_name)"
+  local object_path="$(echo -n $object_hash | sed -e 's/^\(..\)\(.*\)$/\1\/\2/')"
+  echo "${repo_url}/data/${object_path}"
+}
+
 get_apache_config_filename() {
   local repo_name="$1"
   echo "${repo_name}.conf"


### PR DESCRIPTION
This replaces the - pretty inefficient and complex - SQL statement compacting the *rowid* field of the *catalog* SQLite table in catalog files. Furthermore it adds an additional check to the integration test 554 making sure that the *rowid* is dense after this transformation has run.