### PR TITLE
FIX: Mitigate Race in Integration Test 580

### DIFF
--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -7,8 +7,8 @@ unix_timestamp() {
 }
 
 export CVMFS_TEST_580_LAST_PUBLISH=last_publish
-export CVMFS_TEST_580_THRESH_SECONDS=20
-export CVMFS_TEST_580_SECONDS_MARGIN=10
+export CVMFS_TEST_580_THRESH_SECONDS=200
+export CVMFS_TEST_580_SECONDS_MARGIN=50
 
 create_revision() {
   local repo_name=$1


### PR DESCRIPTION
This mitigates a potential race in integration test 580. The test will take longer but hopefully won't fail due to too slow publishing and time steered garbage collection anymore....