### PR TITLE
Fix: Catalog Defragmentation

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -190,6 +190,11 @@ double CatalogDatabase::GetRowIdWasteRatio() const {
  * temporary table afterwards. That way the implicit rowid field of 'catalog' is
  * defragmented.
  *
+ * Since the 'chunks' table has a foreign key relationship to the 'catalog' we
+ * need to temporarily switch off the foreign key checks. Otherwise the clearing
+ * of the 'catalog' table would fail due to foreign key violations. Note that it
+ * is a NOOP to change the foreign key setting during a transaction!
+ *
  * Note: VACUUM used to have a similar behaviour but it was dropped from SQLite
  *       at some point. Since we compute client-inodes from the rowIDs, we are
  *       probably one of the few use cases where a defragmented rowID is indeed

--- a/cvmfs/sql.cc
+++ b/cvmfs/sql.cc
@@ -33,6 +33,12 @@ Sql::~Sql() {
  */
 bool Sql::Execute() {
   last_error_code_ = sqlite3_step(statement_);
+#ifdef DEBUGMSG
+  if (! Successful()) {
+    LogCvmfs(kLogSql, kLogDebug, "SQL query failed - SQLite: %d - %s",
+             GetLastError(), GetLastErrorMsg().c_str());
+  }
+#endif
   return Successful();
 }
 

--- a/test/src/553-defragcatalog/main
+++ b/test/src/553-defragcatalog/main
@@ -28,6 +28,9 @@ cvmfs_run_test() {
   cp_bin ${repo_dir}/bar || return 5
   cp_bin ${repo_dir}/baz || return 6
 
+  echo "produce a large file in the root catalog"
+  dd if=/dev/urandom of=${repo_dir}/big_file count=50 bs=1MiB || return 6
+
   echo "create a first snapshot of the root catalog"
   publish_repo $CVMFS_TEST_REPO > /dev/null || return 7
 
@@ -43,7 +46,9 @@ cvmfs_run_test() {
   touch ${repo_dir}/baz/.cvmfscatalog || return 10
 
   echo "publish repository (should trigger root catalog defragmatation)"
-  publish_repo $CVMFS_TEST_REPO | grep '/ gets defragmented' || return 11
+  local publish_log_1="publish_1.log"
+  publish_repo $CVMFS_TEST_REPO > $publish_log_1 2>&1 || return 11
+  cat $publish_log_1 | grep '/ gets defragmented'     || return 11
 
   echo "check if root catalog is smaller than before (including safety margin)"
   local second_root_size=$(get_catalog_file_size $CVMFS_TEST_REPO '/')


### PR DESCRIPTION
The [recently implemented optimisation](https://github.com/cvmfs/cvmfs/pull/727) of the catalog defragmentation query was flawed. The *chunks* table has a foreign key into the *catalog* table. Therefore, the - intermediate - sweeping of the *catalog* table caused a foreign key violation. I fixed it by temporarily disabling the foreign key checks in SQLite (`PRAGMA foreign_keys = OFF`). Furthermore I added a large file to the catalog defragmentation integration test (553) to actively check for this problem.