### PR TITLE
Fix: Reentrant Garbage Collection

### DIFF
--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -468,9 +468,9 @@ class CatalogTraversal
                                                 ! job.IsRootCatalog(),
                                                 job.parent);
     if (! job.catalog) {
-      if (ignore_load_failure_ && job.IsRootCatalog()) {
-        LogCvmfs(kLogCatalogTraversal, kLogDebug, "ignore missing root catalog "
-                                                  "%s (possibly sweeped before)",
+      if (ignore_load_failure_) {
+        LogCvmfs(kLogCatalogTraversal, kLogDebug, "ignoring missing catalog %s "
+                                                  "(possibly swept before)",
                  job.hash.ToString().c_str());
         job.ignore = true;
         return true;

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -138,9 +138,9 @@ class CatalogTraversal
    *                             them in previous revisions
    * @param no_close             do not close catalogs after they were attached
    *                             (catalogs retain their parent/child pointers)
-   * @param ignore_load_failure  suppressed an error message if a revision's root
-   *                             catalog could not be loaded (i.e. was sweeped
-   *                             before by a garbage collection run)
+   * @param ignore_load_failure  suppressed an error message if a catalog file
+   *                             could not be loaded (i.e. was sweeped before by
+   *                             a garbage collection run)
    * @param quiet                silence messages that would go to stderr
    * @param tmp_dir              path to the temporary directory to be used
    *                             (default: /tmp)

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -2334,6 +2334,90 @@ TEST_F(T_CatalogTraversal, UnavailableNestedNoRepeat) {
 //
 
 
+CatalogIdentifiers IgnoreUnavailableNestedNoRepeat_visited_catalogs;
+void IgnoreUnavailableNestedNoRepeatCallback(
+                             const MockedCatalogTraversal::CallbackDataTN &data) {
+  IgnoreUnavailableNestedNoRepeat_visited_catalogs.push_back(
+    std::make_pair(data.catalog->GetRevision(), data.catalog->path().ToString()));
+}
+
+TEST_F(T_CatalogTraversal, IgnoreUnavailableNestedNoRepeat) {
+  IgnoreUnavailableNestedNoRepeat_visited_catalogs.clear();
+  EXPECT_EQ (0u, IgnoreUnavailableNestedNoRepeat_visited_catalogs.size());
+
+  MockCatalog* doomed_nested_catalog = GetCatalog(2, "/00/10/20");
+  ASSERT_NE (static_cast<MockCatalog*>(NULL), doomed_nested_catalog);
+
+  std::set<shash::Any> deleted_catalogs;
+  deleted_catalogs.insert(doomed_nested_catalog->hash());
+  MockCatalog::s_deleted_objects = &deleted_catalogs;
+
+  CatalogIdentifiers catalogs;
+
+  TraversalParams params = GetBasicTraversalParams();
+  params.history             = 4;
+  params.quiet               = true;
+  params.no_repeat_history   = true;
+  params.ignore_load_failure = true;
+  MockedCatalogTraversal traverse(params);
+  traverse.RegisterListener(&IgnoreUnavailableNestedNoRepeatCallback);
+
+  const bool t1 = traverse.Traverse();
+  EXPECT_TRUE (t1);
+
+  catalogs.push_back(std::make_pair(6, ""));
+  catalogs.push_back(std::make_pair(5, "/00/13"));
+  catalogs.push_back(std::make_pair(5, "/00/13/29"));
+  catalogs.push_back(std::make_pair(5, "/00/13/28"));
+  catalogs.push_back(std::make_pair(4, "/00/12"));
+  catalogs.push_back(std::make_pair(4, "/00/12/27"));
+  catalogs.push_back(std::make_pair(4, "/00/12/26"));
+  catalogs.push_back(std::make_pair(4, "/00/12/26/38"));
+  catalogs.push_back(std::make_pair(4, "/00/12/26/37"));
+  catalogs.push_back(std::make_pair(4, "/00/12/26/36"));
+  catalogs.push_back(std::make_pair(4, "/00/12/26/35"));
+  catalogs.push_back(std::make_pair(4, "/00/12/25"));
+  catalogs.push_back(std::make_pair(4, "/00/11"));
+  catalogs.push_back(std::make_pair(4, "/00/11/24"));
+  catalogs.push_back(std::make_pair(4, "/00/11/23"));
+  catalogs.push_back(std::make_pair(4, "/00/11/22"));
+  catalogs.push_back(std::make_pair(4, "/00/11/22/34"));
+  catalogs.push_back(std::make_pair(4, "/00/11/22/34/43"));
+  catalogs.push_back(std::make_pair(4, "/00/11/22/34/42"));
+  catalogs.push_back(std::make_pair(4, "/00/11/22/34/41"));
+  catalogs.push_back(std::make_pair(4, "/00/11/22/33"));
+  catalogs.push_back(std::make_pair(5, ""));
+  catalogs.push_back(std::make_pair(2, "/00/10"));
+  catalogs.push_back(std::make_pair(2, "/00/10/21"));
+  // --> here the missing catalog (and its descendents should have been)
+  // catalogs.push_back(std::make_pair(2, "/00/10/20"));
+  // catalogs.push_back(std::make_pair(2, "/00/10/20/32"));
+  // catalogs.push_back(std::make_pair(2, "/00/10/20/31"));
+  // catalogs.push_back(std::make_pair(2, "/00/10/20/30"));
+  // catalogs.push_back(std::make_pair(2, "/00/10/20/30/40"));
+  catalogs.push_back(std::make_pair(4, ""));
+  catalogs.push_back(std::make_pair(3, ""));
+  catalogs.push_back(std::make_pair(3, "/00/11"));
+  catalogs.push_back(std::make_pair(3, "/00/11/24"));
+  catalogs.push_back(std::make_pair(3, "/00/11/23"));
+  catalogs.push_back(std::make_pair(3, "/00/11/22"));
+  catalogs.push_back(std::make_pair(3, "/00/11/22/34"));
+  catalogs.push_back(std::make_pair(3, "/00/11/22/34/43"));
+  catalogs.push_back(std::make_pair(3, "/00/11/22/34/42"));
+  catalogs.push_back(std::make_pair(3, "/00/11/22/34/41"));
+  catalogs.push_back(std::make_pair(3, "/00/11/22/33"));
+  catalogs.push_back(std::make_pair(2, ""));
+
+  CheckVisitedCatalogs(catalogs, IgnoreUnavailableNestedNoRepeat_visited_catalogs);
+  CheckCatalogSequence(catalogs, IgnoreUnavailableNestedNoRepeat_visited_catalogs);
+}
+
+
+//
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+//
+
+
 CatalogIdentifiers DepthFirstSearchFullHistoryTraversalNoRepeat_visited_catalogs;
 void DepthFirstSearchFullHistoryTraversalNoRepeatCallback(
                              const MockedCatalogTraversal::CallbackDataTN &data) {

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -2281,10 +2281,7 @@ TEST_F(T_CatalogTraversal, UnavailableNestedNoRepeat) {
   params.history             = 4;
   params.quiet               = true;
   params.no_repeat_history   = true;
-  params.ignore_load_failure = true; // even though load failures should be
-                                     // ignored, traversal is supposed to fail
-                                     // because a missing nested catalog is con-
-                                     // sidered an error!
+  params.ignore_load_failure = false;
   MockedCatalogTraversal traverse(params);
   traverse.RegisterListener(&UnavailableNestedNoRepeatCallback);
 
@@ -2314,10 +2311,21 @@ TEST_F(T_CatalogTraversal, UnavailableNestedNoRepeat) {
   catalogs.push_back(std::make_pair(4, "/00/11/22/34/42"));
   catalogs.push_back(std::make_pair(4, "/00/11/22/34/41"));
   catalogs.push_back(std::make_pair(4, "/00/11/22/33"));
+  catalogs.push_back(std::make_pair(5, ""));
+  catalogs.push_back(std::make_pair(2, "/00/10"));
+  catalogs.push_back(std::make_pair(2, "/00/10/21"));
+  // --> here the missing catalog (and its descendents should have been)
+  //     since the catalog traversal aborted, the overall traversed tree is
+  //     truncated (see `IgnoreUnavailableNestedNoRepeat`)
+  // catalogs.push_back(std::make_pair(2, "/00/10/20"));
+  // catalogs.push_back(std::make_pair(2, "/00/10/20/32"));
+  // catalogs.push_back(std::make_pair(2, "/00/10/20/31"));
+  // ...
+  // catalogs.push_back(std::make_pair(4, ""));
+  // ...
 
-  const bool dont_check_catalog_count = false;
-  CheckVisitedCatalogs(catalogs, UnavailableNestedNoRepeat_visited_catalogs,
-                       dont_check_catalog_count);
+  CheckVisitedCatalogs(catalogs, UnavailableNestedNoRepeat_visited_catalogs);
+  CheckCatalogSequence(catalogs, UnavailableNestedNoRepeat_visited_catalogs);
 }
 
 


### PR DESCRIPTION
While running the GC manually on *cvm-cmstest01* I needed to interrupt it using CTRL+C. Afterwards it turned out, that the garbage collection was not properly reentrant. The second run failed when trying to download a nested catalog, because (presumably) I interrupted it while sweeping a nested catalog tree.

`CatalogTraversal` already allows to ignore load-failures of root catalogs. This was to support consecutive garbage collection runs. However, to make GC fully reentrant (also for interrupted runs) it needs to ignore nested catalog load failures as well. I changed the behaviour of `CatalogTraversal` accordingly and added another unit test to verify the proper functionality.