### PR TITLE
Fix: Proxy Failover Test

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -78,6 +78,7 @@ if [ $s3_retval -eq 0 ]; then
                                  src/543-storagescrubbing_scriptable          \
                                  src/550-livemigration                        \
                                  src/571-localbackendumask                    \
+                                 src/572-proxyfailover                        \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag || s3_retval=$?
 

--- a/test/wiremock_wrapper.sh
+++ b/test/wiremock_wrapper.sh
@@ -32,6 +32,26 @@ EOF
   echo "done"
 }
 
+wait_for_local_port() {
+  local port="$1"
+  local initial_timeout=60
+  local timeout=$initial_timeout
+
+  echo -n "waiting for port ${port}... "
+  while ! nc -z localhost $port && [ $timeout -gt 0 ]; do
+    timeout=$(( $timeout - 1 ))
+    sleep 1
+  done
+
+  if [ $timeout -eq 0 ]; then
+    echo "fail (waited $initial_timeout seconds)"
+    return 1
+  else
+    echo "okay"
+    return 0
+  fi
+}
+
 start_wiremock() {
   local document_root="$1"
   local port="$2"

--- a/test/wiremock_wrapper.sh
+++ b/test/wiremock_wrapper.sh
@@ -62,7 +62,8 @@ start_wiremock() {
                                    --root $document_root \
                                    --port $port          \
                                    $is_proxy             \
-                                   --verbose "
+                                   --verbose " > /dev/null
+  wait_for_local_port $port
 }
 
 send_wiremock_admin_command() {


### PR DESCRIPTION
Seems that `wiremock` needs a considerable amount of time to start up as a background service. The proxy-failover integration test case (572) fails occasionally because it tries to mount the CernVM-FS client through `wiremock` before it came up properly and fails. Java... ;-)

Furthermore the same test case is disabled for the S3 tests, because it relies on a local backend.
