### PR TITLE
Fix: Migration Test on SLC5 and SLC6

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -32,7 +32,8 @@ export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&         \
                           src/024-reload-during-asetup \
                           src/5* || it_retval=$?
 
-echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+# TODO: enable this as soon as 2.1.20 is released
+echo "skipping CernVM-FS migration test case (no EL7 package for 2.1.19)"
+#./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
 
 [ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $s3_retval -eq 0 ] && [ $mg_retval -eq 0 ]

--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -11,12 +11,14 @@ aufs_user_tools="http://ftp.scientificlinux.org/linux/scientific/5x/x86_64/SL/au
 echo -n "creating additional disk partitions... "
 disk_to_partition=/dev/vda
 free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 25000000000 ]; then # at least 25GB required
+if [ $free_disk_space -lt 37580963840 ]; then # at least 35GiB required
   die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
 fi
-partition_size=$(( $free_disk_space / 2 - 10240000))
-create_partition $disk_to_partition $partition_size || die "fail (creating partition 1)"
-create_partition $disk_to_partition $partition_size || die "fail (creating partition 2)"
+cache_partition_size=10737418240 # 10 GiB
+server_partition_size=$(( ( $free_disk_space - $cache_partition_size ) / 2 - 52428800))
+create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 1)"
+create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 2)"
+create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 3)"
 echo "done"
 
 # install AUFS kernel modules and userspace tools

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -21,16 +21,19 @@ extend_path "/sbin"
 # format additional disks with ext4 and many inodes
 echo -n "formatting new disk partitions... "
 disk_to_partition=/dev/vda
-partition_2=$(get_last_partition_number $disk_to_partition)
-partition_1=$(( $partition_2 - 1 ))
+partition_3=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
+partition_2=$(( $partition_3 - 1 ))
+partition_1=$(( $partition_3 - 2 ))
 format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
 format_partition_ext4 $disk_to_partition$partition_2 || die "fail (formatting partition 2)"
+format_partition_ext4 $disk_to_partition$partition_3 || die "fail (formatting partition 3)"
 echo "done"
 
 # mount additional disk partitions on strategic cvmfs location
 echo -n "mounting new disk partitions into cvmfs specific locations... "
 mount_partition $disk_to_partition$partition_1 /srv             || die "fail (mounting /srv $?)"
 mount_partition $disk_to_partition$partition_2 /var/spool/cvmfs || die "fail (mounting /var/spool/cvmfs $?)"
+mount_partition $disk_to_partition$partition_3 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
 echo "done"
 
 # start apache

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
@@ -4,6 +4,17 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+# create additional disk partitions to accomodate CVMFS cache
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+if [ $free_disk_space -lt 10789847040 ]; then # at least 10GiB required
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+cache_partition_size=10737418240 # 10 GiB
+create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 1)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
@@ -8,6 +8,18 @@ ut_retval=0
 it_retval=0
 mg_retval=0
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partitions... "
+disk_to_partition=/dev/vda
+partition_1=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
+format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partitions into cvmfs specific locations... "
+mount_partition $disk_to_partition$partition_1 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 # run tests
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_setup.sh
@@ -4,6 +4,17 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+# create additional disk partitions to accomodate CVMFS cache
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+if [ $free_disk_space -lt 10789847040 ]; then # at least 10GiB required
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+cache_partition_size=10737418240 # 10 GiB
+create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 1)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
@@ -8,6 +8,18 @@ ut_retval=0
 it_retval=0
 mg_retval=0
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partitions... "
+disk_to_partition=/dev/vda
+partition_1=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
+format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partitions into cvmfs specific locations... "
+mount_partition $disk_to_partition$partition_1 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 # run tests
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
@@ -4,6 +4,17 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+# create additional disk partitions to accomodate CVMFS cache
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+if [ $free_disk_space -lt 10789847040 ]; then # at least 10GiB required
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+cache_partition_size=10737418240 # 10 GiB
+create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 1)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
@@ -8,6 +8,18 @@ ut_retval=0
 it_retval=0
 mg_retval=0
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partitions... "
+disk_to_partition=/dev/vda
+partition_1=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
+format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partitions into cvmfs specific locations... "
+mount_partition $disk_to_partition$partition_1 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 # run tests
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -8,12 +8,14 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo -n "creating additional disk partitions... "
 disk_to_partition=/dev/vda
 free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 25000000000 ]; then # at least 25GB required
+if [ $free_disk_space -lt 37580963840 ]; then # at least 35GiB required
   die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
 fi
-partition_size=$(( $free_disk_space / 2 - 10240000))
-create_partition $disk_to_partition $partition_size || die "fail (creating partition 1)"
-create_partition $disk_to_partition $partition_size || die "fail (creating partition 2)"
+cache_partition_size=10737418240 # 10 GiB
+server_partition_size=$(( ( $free_disk_space - $cache_partition_size ) / 2 - 52428800))
+create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 1)"
+create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 2)"
+create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 3)"
 echo "done"
 
 # custom kernel packages (figures out the newest installed kernel, downloads and

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -12,16 +12,19 @@ mg_retval=0
 # format additional disks with ext4 and many inodes
 echo -n "formatting new disk partitions... "
 disk_to_partition=/dev/vda
-partition_2=$(get_last_partition_number $disk_to_partition)
-partition_1=$(( $partition_2 - 1 ))
+partition_3=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
+partition_2=$(( $partition_3 - 1 ))
+partition_1=$(( $partition_3 - 2 ))
 format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
 format_partition_ext4 $disk_to_partition$partition_2 || die "fail (formatting partition 2)"
+format_partition_ext4 $disk_to_partition$partition_3 || die "fail (formatting partition 3)"
 echo "done"
 
 # mount additional disk partitions on strategic cvmfs location
 echo -n "mounting new disk partitions into cvmfs specific locations... "
 mount_partition $disk_to_partition$partition_1 /srv             || die "fail (mounting /srv $?)"
 mount_partition $disk_to_partition$partition_2 /var/spool/cvmfs || die "fail (mounting /var/spool/cvmfs $?)"
+mount_partition $disk_to_partition$partition_3 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
 echo "done"
 
 # allow apache access to the mounted server file system

--- a/test/migration_tests/common.sh
+++ b/test/migration_tests/common.sh
@@ -215,12 +215,12 @@ install_packages() {
 
 
 uninstall_package() {
-  local pkg_name=$1
+  local pkg_names="$1"
 
   if has_binary yum; then
-    sudo yum -y erase $pkg_name
+    sudo yum -y erase $pkg_names
   elif has_binary apt-get; then
-    sudo apt-get --assume-yes purge $pkg_name
+    sudo apt-get --assume-yes purge $pkg_names
   else
     return 1
   fi

--- a/test/migration_tests/common.sh
+++ b/test/migration_tests/common.sh
@@ -53,6 +53,39 @@ guess_package_url() {
 }
 
 
+# makes sure that a version is always of the form x.y.z
+normalize_version() {
+  local version_string="$1"
+  while [ $(echo "$version_string" | grep -o '\.' | wc -l) -lt 2 ]; do
+    version_string="${version_string}.0"
+  done
+  echo "$version_string"
+}
+version_major() { echo $1 | cut --delimiter=. --fields=1; }
+version_minor() { echo $1 | cut --delimiter=. --fields=2; }
+version_patch() { echo $1 | cut --delimiter=. --fields=3; }
+prepend_zeros() { printf %05d "$1"; }
+compare_versions() {
+  local lhs="$(normalize_version $1)"
+  local comparison_operator=$2
+  local rhs="$(normalize_version $3)"
+
+  local lhs1=$(prepend_zeros $(version_major $lhs))
+  local lhs2=$(prepend_zeros $(version_minor $lhs))
+  local lhs3=$(prepend_zeros $(version_patch $lhs))
+  local rhs1=$(prepend_zeros $(version_major $rhs))
+  local rhs2=$(prepend_zeros $(version_minor $rhs))
+  local rhs3=$(prepend_zeros $(version_patch $rhs))
+
+  [ $lhs1$lhs2$lhs3 $comparison_operator $rhs1$rhs2$rhs3 ]
+}
+version_lower_or_equal() {
+  local testee=$1
+  local compare=$2
+  compare_versions $testee -le $compare
+}
+
+
 has_binary() {
   local binary_name=$1
   which $binary_name > /dev/null 2>&1


### PR DESCRIPTION
This adds a partition for `/var/lib/cvmfs`. It seems that the migration test fails on SLC 5 and 6 because the cache partition runs full. Furthermore this disables the migration test on CentOS 7, because there is no package of CernVM-FS 2.1.19 for it. Keeping my fingers crossed...