### PR TITLE
Fix: Partition Management on Cloud Testing Instances

### DIFF
--- a/test/cloud_testing/platforms/slc5_i386_setup.sh
+++ b/test/cloud_testing/platforms/slc5_i386_setup.sh
@@ -4,6 +4,16 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+cache_partition_size=16106127360 # 15 GiB
+if [ $free_disk_space -lt $cache_partition_size ]; then
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+create_partition $disk_to_partition $cache_partition_size || die "fail (creating partition)"
+echo "done"
+
 # install RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"
@@ -28,3 +38,8 @@ echo "done"
 # install test dependencies
 echo "installing test dependencies..."
 install_from_repo gcc
+
+# rebooting the system (returning 0 value)
+echo "sleep 1 && reboot" > killme.sh
+sudo nohup sh < killme.sh &
+exit 0

--- a/test/cloud_testing/platforms/slc5_i386_test.sh
+++ b/test/cloud_testing/platforms/slc5_i386_test.sh
@@ -4,6 +4,18 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_test.sh
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partition... "
+disk_to_partition=/dev/vda
+partition=$(get_last_partition_number $disk_to_partition)
+format_partition_ext4 $disk_to_partition$partition || die "fail (formatting partition)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partition into cvmfs specific location... "
+mount_partition $disk_to_partition$partition /var/lib/cvmfs || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 ut_retval=0
 it_retval=0
 mg_retval=0

--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -11,14 +11,12 @@ aufs_user_tools="http://ftp.scientificlinux.org/linux/scientific/5x/x86_64/SL/au
 echo -n "creating additional disk partitions... "
 disk_to_partition=/dev/vda
 free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 37580963840 ]; then # at least 35GiB required
+if [ $free_disk_space -lt 25000000000 ]; then # at least 25GB required
   die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
 fi
-cache_partition_size=10737418240 # 10 GiB
-server_partition_size=$(( ( $free_disk_space - $cache_partition_size ) / 2 - 52428800))
-create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 1)"
-create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 2)"
-create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 3)"
+partition_size=$(( $free_disk_space / 2 - 10240000))
+create_partition $disk_to_partition $partition_size || die "fail (creating partition 1)"
+create_partition $disk_to_partition $partition_size || die "fail (creating partition 2)"
 echo "done"
 
 # install AUFS kernel modules and userspace tools

--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -27,7 +27,6 @@ echo "done"
 echo "installing aufs... "
 install_rpm $(basename $aufs_user_tools)                   || die "fail (installing aufs)"
 yum list installed | grep "kernel-module-aufs" > /dev/null || die "fail (check installed aufs)"
-echo "done"
 
 echo -n "activate aufs... "
 kobj=$(rpm -ql $(rpm -qa | grep kernel-module-aufs) | tail -n1)

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -51,8 +51,17 @@ sudo chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail (chcon)"
 echo "done"
 
 # create the server's client cache directory in /srv (AUFS kernel deadlock workaround)
-echo -n "creating client cache on extra partition... "
-sudo mkdir /srv/cache || die "fail"
+echo -n "creating client caches on extra partition... "
+sudo mkdir -p /srv/cache/server || die "fail (cache for server test cases)"
+sudo mkdir -p /srv/cache/client || die "fail (cache for client test cases)"
+echo "done"
+
+echo -n "bind mount client cache to /var/lib/cvmfs... "
+if [ ! -d /var/lib/cvmfs ]; then
+  sudo rm -fR   /var/lib/cvmfs || true
+  sudo mkdir -p /var/lib/cvmfs || die "fail (mkdir /var/lib/cvmfs)"
+fi
+sudo mount --bind /srv/cache/client /var/lib/cvmfs || die "fail (cannot bind mount /var/lib/cvmfs)"
 echo "done"
 
 # running unit test suite
@@ -60,7 +69,7 @@ run_unittests --gtest_shuffle || ut_retval=$?
 
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&                         \
+export CVMFS_TEST_SERVER_CACHE='/srv/cache/server' &&                  \
 ./run.sh $TEST_LOGFILE -x src/004-davinci                              \
                           src/007-testjobs                             \
                           src/045-oasis                                \

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -21,19 +21,16 @@ extend_path "/sbin"
 # format additional disks with ext4 and many inodes
 echo -n "formatting new disk partitions... "
 disk_to_partition=/dev/vda
-partition_3=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
-partition_2=$(( $partition_3 - 1 ))
-partition_1=$(( $partition_3 - 2 ))
+partition_2=$(get_last_partition_number $disk_to_partition)
+partition_1=$(( $partition_2 - 1 ))
 format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
 format_partition_ext4 $disk_to_partition$partition_2 || die "fail (formatting partition 2)"
-format_partition_ext4 $disk_to_partition$partition_3 || die "fail (formatting partition 3)"
 echo "done"
 
 # mount additional disk partitions on strategic cvmfs location
 echo -n "mounting new disk partitions into cvmfs specific locations... "
 mount_partition $disk_to_partition$partition_1 /srv             || die "fail (mounting /srv $?)"
 mount_partition $disk_to_partition$partition_2 /var/spool/cvmfs || die "fail (mounting /var/spool/cvmfs $?)"
-mount_partition $disk_to_partition$partition_3 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
 echo "done"
 
 # start apache

--- a/test/cloud_testing/platforms/slc6_i386_setup.sh
+++ b/test/cloud_testing/platforms/slc6_i386_setup.sh
@@ -4,6 +4,16 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+cache_partition_size=16106127360 # 15 GiB
+if [ $free_disk_space -lt $cache_partition_size ]; then
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+create_partition $disk_to_partition $cache_partition_size || die "fail (creating partition)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"
@@ -23,3 +33,8 @@ echo "done"
 # install test dependencies
 echo "installing additional RPM packages..."
 install_from_repo gcc
+
+# rebooting the system (returning 0 value)
+echo "sleep 1 && reboot" > killme.sh
+sudo nohup sh < killme.sh &
+exit 0

--- a/test/cloud_testing/platforms/slc6_i386_test.sh
+++ b/test/cloud_testing/platforms/slc6_i386_test.sh
@@ -4,6 +4,18 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_test.sh
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partition... "
+disk_to_partition=/dev/vda
+partition=$(get_last_partition_number $disk_to_partition)
+format_partition_ext4 $disk_to_partition$partition || die "fail (formatting partition)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partition into cvmfs specific location... "
+mount_partition $disk_to_partition$partition /var/lib/cvmfs || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 ut_retval=0
 it_retval=0
 mg_retval=0

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
@@ -4,17 +4,6 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
-# create additional disk partitions to accomodate CVMFS cache
-echo -n "creating additional disk partitions... "
-disk_to_partition=/dev/vda
-free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 10789847040 ]; then # at least 10GiB required
-  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
-fi
-cache_partition_size=10737418240 # 10 GiB
-create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 1)"
-echo "done"
-
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_setup.sh
@@ -4,6 +4,16 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+cache_partition_size=16106127360 # 15 GiB
+if [ $free_disk_space -lt $cache_partition_size ]; then
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+create_partition $disk_to_partition $cache_partition_size || die "fail (creating partition)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"
@@ -26,3 +36,7 @@ echo "installing additional RPM packages..."
 install_from_repo gcc
 install_from_repo gcc-c++
 
+# rebooting the system (returning 0 value)
+echo "sleep 1 && reboot" > killme.sh
+sudo nohup sh < killme.sh &
+exit 0

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
@@ -8,18 +8,6 @@ ut_retval=0
 it_retval=0
 mg_retval=0
 
-# format additional disks with ext4 and many inodes
-echo -n "formatting new disk partitions... "
-disk_to_partition=/dev/vda
-partition_1=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
-format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
-echo "done"
-
-# mount additional disk partitions on strategic cvmfs location
-echo -n "mounting new disk partitions into cvmfs specific locations... "
-mount_partition $disk_to_partition$partition_1 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
-echo "done"
-
 # run tests
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
@@ -4,6 +4,18 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_test.sh
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partition... "
+disk_to_partition=/dev/vda
+partition=$(get_last_partition_number $disk_to_partition)
+format_partition_ext4 $disk_to_partition$partition || die "fail (formatting partition)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partition into cvmfs specific location... "
+mount_partition $disk_to_partition$partition /var/lib/cvmfs || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 ut_retval=0
 it_retval=0
 mg_retval=0

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_setup.sh
@@ -4,17 +4,6 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
-# create additional disk partitions to accomodate CVMFS cache
-echo -n "creating additional disk partitions... "
-disk_to_partition=/dev/vda
-free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 10789847040 ]; then # at least 10GiB required
-  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
-fi
-cache_partition_size=10737418240 # 10 GiB
-create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 1)"
-echo "done"
-
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_setup.sh
@@ -4,6 +4,16 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+cache_partition_size=16106127360 # 15 GiB
+if [ $free_disk_space -lt $cache_partition_size ]; then
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+create_partition $disk_to_partition $cache_partition_size || die "fail (creating partition)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"
@@ -26,3 +36,7 @@ echo "installing additional RPM packages..."
 install_from_repo gcc
 install_from_repo gcc-c++
 
+# rebooting the system (returning 0 value)
+echo "sleep 1 && reboot" > killme.sh
+sudo nohup sh < killme.sh &
+exit 0

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
@@ -8,18 +8,6 @@ ut_retval=0
 it_retval=0
 mg_retval=0
 
-# format additional disks with ext4 and many inodes
-echo -n "formatting new disk partitions... "
-disk_to_partition=/dev/vda
-partition_1=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
-format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
-echo "done"
-
-# mount additional disk partitions on strategic cvmfs location
-echo -n "mounting new disk partitions into cvmfs specific locations... "
-mount_partition $disk_to_partition$partition_1 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
-echo "done"
-
 # run tests
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
@@ -4,6 +4,18 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_test.sh
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partition... "
+disk_to_partition=/dev/vda
+partition=$(get_last_partition_number $disk_to_partition)
+format_partition_ext4 $disk_to_partition$partition || die "fail (formatting partition)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partition into cvmfs specific location... "
+mount_partition $disk_to_partition$partition /var/lib/cvmfs || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 ut_retval=0
 it_retval=0
 mg_retval=0

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
@@ -4,17 +4,6 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
-# create additional disk partitions to accomodate CVMFS cache
-echo -n "creating additional disk partitions... "
-disk_to_partition=/dev/vda
-free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 10789847040 ]; then # at least 10GiB required
-  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
-fi
-cache_partition_size=10737418240 # 10 GiB
-create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 1)"
-echo "done"
-
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_setup.sh
@@ -4,6 +4,16 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
+echo -n "creating additional disk partitions... "
+disk_to_partition=/dev/vda
+free_disk_space=$(get_unpartitioned_space $disk_to_partition)
+cache_partition_size=16106127360 # 15 GiB
+if [ $free_disk_space -lt $cache_partition_size ]; then
+  die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
+fi
+create_partition $disk_to_partition $cache_partition_size || die "fail (creating partition)"
+echo "done"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"
@@ -26,3 +36,7 @@ echo "installing additional RPM packages..."
 install_from_repo gcc
 install_from_repo gcc-c++
 
+# rebooting the system (returning 0 value)
+echo "sleep 1 && reboot" > killme.sh
+sudo nohup sh < killme.sh &
+exit 0

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
@@ -8,18 +8,6 @@ ut_retval=0
 it_retval=0
 mg_retval=0
 
-# format additional disks with ext4 and many inodes
-echo -n "formatting new disk partitions... "
-disk_to_partition=/dev/vda
-partition_1=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
-format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
-echo "done"
-
-# mount additional disk partitions on strategic cvmfs location
-echo -n "mounting new disk partitions into cvmfs specific locations... "
-mount_partition $disk_to_partition$partition_1 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
-echo "done"
-
 # run tests
 echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
@@ -4,6 +4,18 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_test.sh
 
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partition... "
+disk_to_partition=/dev/vda
+partition=$(get_last_partition_number $disk_to_partition)
+format_partition_ext4 $disk_to_partition$partition || die "fail (formatting partition)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partition into cvmfs specific location... "
+mount_partition $disk_to_partition$partition /var/lib/cvmfs || die "fail (mounting /var/lib/cvmfs $?)"
+echo "done"
+
 ut_retval=0
 it_retval=0
 mg_retval=0

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -8,14 +8,12 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo -n "creating additional disk partitions... "
 disk_to_partition=/dev/vda
 free_disk_space=$(get_unpartitioned_space $disk_to_partition)
-if [ $free_disk_space -lt 37580963840 ]; then # at least 35GiB required
+if [ $free_disk_space -lt 25000000000 ]; then # at least 25GB required
   die "fail (not enough unpartitioned disk space - $free_disk_space bytes)"
 fi
-cache_partition_size=10737418240 # 10 GiB
-server_partition_size=$(( ( $free_disk_space - $cache_partition_size ) / 2 - 52428800))
-create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 1)"
-create_partition $disk_to_partition $server_partition_size || die "fail (creating partition 2)"
-create_partition $disk_to_partition $cache_partition_size  || die "fail (creating partition 3)"
+partition_size=$(( $free_disk_space / 2 - 10240000))
+create_partition $disk_to_partition $partition_size || die "fail (creating partition 1)"
+create_partition $disk_to_partition $partition_size || die "fail (creating partition 2)"
 echo "done"
 
 # custom kernel packages (figures out the newest installed kernel, downloads and

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -12,19 +12,16 @@ mg_retval=0
 # format additional disks with ext4 and many inodes
 echo -n "formatting new disk partitions... "
 disk_to_partition=/dev/vda
-partition_3=$(get_last_partition_number $disk_to_partition) # 10GiB Cache Partition
-partition_2=$(( $partition_3 - 1 ))
-partition_1=$(( $partition_3 - 2 ))
+partition_2=$(get_last_partition_number $disk_to_partition)
+partition_1=$(( $partition_2 - 1 ))
 format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
 format_partition_ext4 $disk_to_partition$partition_2 || die "fail (formatting partition 2)"
-format_partition_ext4 $disk_to_partition$partition_3 || die "fail (formatting partition 3)"
 echo "done"
 
 # mount additional disk partitions on strategic cvmfs location
 echo -n "mounting new disk partitions into cvmfs specific locations... "
 mount_partition $disk_to_partition$partition_1 /srv             || die "fail (mounting /srv $?)"
 mount_partition $disk_to_partition$partition_2 /var/spool/cvmfs || die "fail (mounting /var/spool/cvmfs $?)"
-mount_partition $disk_to_partition$partition_3 /var/lib/cvmfs   || die "fail (mounting /var/lib/cvmfs $?)"
 echo "done"
 
 # allow apache access to the mounted server file system

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -35,8 +35,17 @@ sudo service httpd start > /dev/null 2>&1 || die "fail"
 echo "OK"
 
 # create the server's client cache directory in /srv (AUFS kernel deadlock workaround)
-echo -n "creating client cache on extra partition... "
-sudo mkdir /srv/cache || die "fail"
+echo -n "creating client caches on extra partition... "
+sudo mkdir -p /srv/cache/server || die "fail (cache for server test cases)"
+sudo mkdir -p /srv/cache/client || die "fail (cache for client test cases)"
+echo "done"
+
+echo -n "bind mount client cache to /var/lib/cvmfs... "
+if [ ! -d /var/lib/cvmfs ]; then
+  sudo rm -fR   /var/lib/cvmfs || true
+  sudo mkdir -p /var/lib/cvmfs || die "fail (mkdir /var/lib/cvmfs)"
+fi
+sudo mount --bind /srv/cache/client /var/lib/cvmfs || die "fail (cannot bind mount /var/lib/cvmfs)"
 echo "done"
 
 # running unit test suite


### PR DESCRIPTION
This reverts the partition management [merged yesterday](https://github.com/cvmfs/cvmfs/pull/735) because it caused problems.
Now, we create a single partition on the SLC5/6 32bit machines and those SLC6 64bit machines that are used to test special CernVM-FS configurations and mount it to `/var/lib/cvmfs`. On the ordinary SLC5/6 x64 machines this client cache directory is bind-mounted to the partition accommodating the local backend storage of the server tests. Simply symlinking the `/var/lib/cvmfs` directory didn't work, because the symlink is removed when the CernVM-FS rpm is uninstalled.