### PR TITLE
Feature: Don't Wait for Initial Snapshots

### DIFF
--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -408,6 +408,12 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
       return 2;
     }
 
+    if (! pull_history) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "an initial snapshot is in progress... aborting");
+      free(workers);
+      return 2;
+    }
+
     LogCvmfs(kLogCvmfs, kLogStdout, "waiting for another snapshot to finish...");
     fd_lockfile = LockFile(*temp_dir + "/lock_snapshot");
     if (fd_lockfile < 0) {


### PR DESCRIPTION
This aborts `cvmfs_server snapshot` by default if another `cvmfs_server snapshot` is currently running an initial snapshot of the repository. This addresses the behaviour Dave was asking for in [CVM-278](https://sft.its.cern.ch/jira/browse/CVM-278). To be honest, I am not sure why an initial snapshot does not pull any historic revisions but `cvmfs_server` is implemented like this.