### PR TITLE
Feature: Dedicated Configuration Variable for Automatic Garbage Collection 

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -730,6 +730,21 @@ has_auto_garbage_collection_enabled() {
   is_garbage_collectable $name && [ x"$CVMFS_AUTO_GC" = x"true" ]
 }
 
+# get the configured (or default) timespan for an automatic garbage
+# collection run.
+#
+# @param name  the name of the repository to be checked
+# @return      the configured CVMFS_AUTO_GC_TIMESPAN or default (3 days ago)
+get_auto_garbage_collection_timespan() {
+  local name=$1
+  load_repo_config $name
+  if [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]; then
+    echo "$CVMFS_AUTO_GC_TIMESPAN"
+  else
+    echo "3 days ago"
+  fi
+}
+
 # checks if a repository is currently in a transaction
 #
 # @param name  the repository name to be checked
@@ -3704,7 +3719,8 @@ publish() {
     # run the automatic garbage collection (if configured)
     if has_auto_garbage_collection_enabled $name; then
       echo "Running automatic garbage collection"
-      local tst="$(date --date "$CVMFS_AUTO_GC_TIMESPAN" +%s 2>/dev/null)"
+      local gc_timespan="$(get_auto_garbage_collection_timespan $name)"
+      local tst="$(date --date "$gc_timespan" +%s 2>/dev/null)"
       [ $? -eq 0 ] || { publish_failed $name; die "Cannot parse time stamp '$timestamp_threshold'"; }
       local dry_run=0
       __run_gc $name       \
@@ -4169,7 +4185,8 @@ snapshot() {
     # run the automatic garbage collection (if configured)
     if has_auto_garbage_collection_enabled $alias_name; then
       echo "Running automatic garbage collection"
-      local tst="$(date --date "$CVMFS_AUTO_GC_TIMESPAN" +%s 2>/dev/null)"
+      local gc_timespan="$(get_auto_garbage_collection_timespan $name)"
+      local tst="$(date --date "$gc_timespan" +%s 2>/dev/null)"
       [ $? -eq 0 ] || die "Cannot parse time stamp '$timestamp_threshold'"
       local dry_run=0
       __run_gc "$alias_name" \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -727,7 +727,7 @@ is_garbage_collectable() {
 has_auto_garbage_collection_enabled() {
   local name=$1
   load_repo_config $name
-  is_garbage_collectable $name && [ ! -z "$CVMFS_AUTO_GC_TIMESPAN" ]
+  is_garbage_collectable $name && [ x"$CVMFS_AUTO_GC" = x"true" ]
 }
 
 # checks if a repository is currently in a transaction
@@ -1742,7 +1742,7 @@ EOF
   # append GC specific configuration
   if [ x"$garbage_collectable" = x"true" ]; then
     cat >> $server_conf << EOF
-CVMFS_AUTO_GC_TIMESPAN='3 days ago'
+CVMFS_AUTO_GC=true
 EOF
   fi
 
@@ -2514,7 +2514,7 @@ EOF
   # append GC specific configuration
   if [ $enable_auto_gc != 0 ]; then
     cat >> /etc/cvmfs/repositories.d/${alias_name}/server.conf << EOF
-CVMFS_AUTO_GC_TIMESPAN='3 days ago'
+CVMFS_AUTO_GC=true
 EOF
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3913,6 +3913,12 @@ gc() {
     preserve_revisions=0
   fi
 
+  # print a warning to scare off people that might not know what they are doing
+  echo
+  echo 'WARNING: `cvmfs_server gc` is an internal command and will be subject to change'
+  echo '         in future versions of CernVM-FS. Please do not use it manually!'
+  echo
+
   if [ $force -eq 0 ] && [ $dry_run -eq 0 ]; then
     echo "YOU ARE ABOUT TO DELETE DATA! Are you sure you want to do the following:"
   fi

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -129,6 +129,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"

--- a/test/src/558-garbagecollectnestedcatalogs/main
+++ b/test/src/558-garbagecollectnestedcatalogs/main
@@ -175,6 +175,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"

--- a/test/src/559-garbagecollectnamedtags/main
+++ b/test/src/559-garbagecollectnamedtags/main
@@ -177,6 +177,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -z || return $?
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"

--- a/test/src/560-garbagecollectpreservehistory/main
+++ b/test/src/560-garbagecollectpreservehistory/main
@@ -150,6 +150,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo -n "create a series of commits... "

--- a/test/src/561-garbagecollectmultihash/main
+++ b/test/src/561-garbagecollectmultihash/main
@@ -179,6 +179,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   root_clg_0="$(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -63,6 +63,9 @@ cvmfs_run_test() {
   echo "enable garbage collection in the imported repository"
   toggle_gc $legacy_repo_name || return 5
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   echo "create an additional revision after the migration to create the history database"
   start_transaction $legacy_repo_name || return 5
 

--- a/test/src/573-garbagecollecttimestamp/main
+++ b/test/src/573-garbagecollecttimestamp/main
@@ -187,6 +187,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   root_catalog0="$(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"

--- a/test/src/574-garbagecollecttimestampwithtags/main
+++ b/test/src/574-garbagecollecttimestampwithtags/main
@@ -194,6 +194,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   root_catalog0="$(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -183,6 +183,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   # echo "install a desaster cleanup function"
@@ -196,6 +199,9 @@ cvmfs_run_test() {
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
+
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $replica_name || return $?
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   cvmfs_server snapshot $replica_name || return 2

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -42,6 +42,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   # echo "install a desaster cleanup function"
@@ -55,6 +58,9 @@ cvmfs_run_test() {
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
+
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $replica_name || return $?
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   cvmfs_server snapshot $replica_name || return 2

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -162,7 +162,7 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $catalog4 || return 50 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $catalog5 || return 51 # trunk
 
-  peek_backend $replica_name    $catalog1 && return 52 # deleted by GC
+  peek_backend $replica_name    $catalog1 && return 52 # deleted by GC  <-- TODO: this test case fails here
   peek_backend $replica_name    $catalog2 && return 53 # never replicated...
   peek_backend $replica_name    $catalog3 && return 54 # deleted by GC
   peek_backend $replica_name    $catalog4 || return 55 # trunk-previous

--- a/test/src/578-automaticgarbagecollection/main
+++ b/test/src/578-automaticgarbagecollection/main
@@ -36,9 +36,8 @@ cvmfs_run_test() {
 
   echo "configure repository to automatically delete revisions older than $thresh_seconds seconds"
   local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
-  cat $server_conf | sed -e "s/^\(CVMFS_AUTO_GC_TIMESPAN\)=.*$/\1='$thresh_seconds seconds ago'/" > server_1.conf
-  sudo cp server_1.conf $server_conf || return 1
-  cat $server_conf                   || return 2
+  echo "CVMFS_AUTO_GC_TIMESPAN='$thresh_seconds seconds ago'" | sudo tee --append $server_conf || return 1
+  cat $server_conf || return 2
 
   echo "check if initial catalog is there"
   peek_backend $CVMFS_TEST_REPO $root_catalog0 || return 3 # just created
@@ -134,9 +133,7 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog5 || return 23 # trunk
 
   echo "disable automatic garbage collection"
-  cat $server_conf | grep -v 'CVMFS_AUTO_GC_TIMESPAN' > server_2.conf
-  sudo cp server_2.conf $server_conf || return 24
-  cat $server_conf                   || return 25
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
   echo "sleep $seconds seconds"
   sleep $seconds

--- a/test/src/579-garbagecollectstratum1legacytag/main
+++ b/test/src/579-garbagecollectstratum1legacytag/main
@@ -196,7 +196,7 @@ cvmfs_run_test() {
   cvmfs_server gc -f $replica_name || return 54
 
   peek_backend $replica_name $catalog1 && return 55 # GC'ed
-  peek_backend $replica_name $catalog2 && return 56 # GC'ed
+  peek_backend $replica_name $catalog2 && return 56 # GC'ed <-- TODO: test case fails here
   peek_backend $replica_name $catalog3 && return 57 # GC'ed
   peek_backend $replica_name $catalog4 && return 58 # GC'ed
   peek_backend $replica_name $catalog5 || return 59 # trunk-previous

--- a/test/src/579-garbagecollectstratum1legacytag/main
+++ b/test/src/579-garbagecollectstratum1legacytag/main
@@ -42,6 +42,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   # echo "install a desaster cleanup function"
@@ -55,6 +58,9 @@ cvmfs_run_test() {
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
+
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $replica_name || return $?
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   cvmfs_server snapshot $replica_name || return 2

--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -60,10 +60,7 @@ cvmfs_run_test() {
   root_catalog0="$(get_current_root_catalog $CVMFS_TEST_REPO)C"
 
   echo "disable automatic garbage collection on stratum 0"
-  local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
-  cat $server_conf | grep -v 'CVMFS_AUTO_GC_TIMESPAN' > server_1.conf
-  sudo cp server_1.conf $server_conf || return 1
-  cat $server_conf                   || return 2
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
   echo "list named snapshots"
   cvmfs_server tag -l $CVMFS_TEST_REPO || return 3
@@ -92,10 +89,8 @@ cvmfs_run_test() {
 
   echo "configure stratum 1 to automatically delete revisions older than $thresh_seconds seconds"
   local replica_server_conf="/etc/cvmfs/repositories.d/${replica_name}/server.conf"
-  cat $replica_server_conf | grep -q 'CVMFS_AUTO_GC_TIMESPAN' || return 7
-  cat $replica_server_conf | sed -e "s/^\(CVMFS_AUTO_GC_TIMESPAN\)=.*$/\1='$thresh_seconds seconds ago'/" > replica_1.conf
-  sudo cp replica_1.conf $replica_server_conf || return 8
-  cat $replica_server_conf                    || return 9
+  echo "CVMFS_AUTO_GC_TIMESPAN='$thresh_seconds seconds ago'" | sudo tee --append $replica_server_conf || return 8
+  cat $replica_server_conf || return 9
 
   echo "create revision 1 ($(display_timestamp now))"
   root_catalog1="$(create_revision $CVMFS_TEST_REPO)"
@@ -220,9 +215,7 @@ cvmfs_run_test() {
   peek_backend $replica_name    $root_catalog5 || return 67 # trunk
 
   echo "disable automatic garbage collection on stratum 1"
-  cat $replica_server_conf | grep -v 'CVMFS_AUTO_GC_TIMESPAN' > replica_2.conf
-  sudo cp replica_2.conf $replica_server_conf || return 68
-  cat $replica_server_conf                    || return 69
+  disable_auto_garbage_collection $replica_name || return $?
 
   sleep_to_match_threshold
 

--- a/test/src/581-snapshotgarbagecollectedrepo/main
+++ b/test/src/581-snapshotgarbagecollectedrepo/main
@@ -127,6 +127,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
   # ============================================================================
 
   echo "register cleanup trap"
@@ -140,6 +143,9 @@ cvmfs_run_test() {
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
+
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $replica_name || return $?
 
   echo "create an initial snapshot"
   cvmfs_server snapshot $replica_name || return 2

--- a/test/test_functions
+++ b/test/test_functions
@@ -1122,6 +1122,20 @@ toggle_gc() {
   return 0
 }
 
+# disables the automatic garbage collection of a given repository configuration
+#
+# @param name  the name of the repository to reconfigure
+disable_auto_garbage_collection() {
+  local name="$1"
+  local cfg_file="/etc/cvmfs/repositories.d/${name}/server.conf"
+
+  if cat $cfg_file | grep -q 'CVMFS_AUTO_GC'; then
+    local tmp_cfg="$(mktemp)"
+    cat $cfg_file | sed -e 's/^\(CVMFS_AUTO_GC\)=.*$/\1=false/' > $tmp_cfg || return 1
+    sudo mv -f $tmp_cfg $cfg_file || return 2
+  fi
+}
+
 
 # get the current unix timestamp
 get_timestamp() {


### PR DESCRIPTION
This adds the configuration variable `CVMFS_AUTO_GC` that enables the automatic garbage collection both for `cvmfs_server publish` and `cvmfs_server snapshot`. Eventually Dave [convinced me](https://github.com/cvmfs/cvmfs/pull/686) that this is the clearer way to configure the automatic garbage collection. Furthermore `CVMFS_AUTO_GC_TIMESPAN` becomes an optional parameter that defaults to *3 days ago* if not set. 

Also this places a comment in integration tests 577 and 579 to mark the line where they are supposed to break until the 'orphaned revision issue' is solved.