### PR TITLE
Fix: Race between Automatic Garbage Collection and Consecutive Snapshots

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4128,14 +4128,14 @@ snapshot() {
   local timeout
   local retries
   local retcode=0
-  local dont_wait=
+  local abort_on_conflict=0
   local gc_timespan=0
 
   OPTIND=1
   while getopts "t" option; do
     case $option in
       t)
-        dont_wait="-s"
+        abort_on_conflict=1
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -4190,6 +4190,28 @@ snapshot() {
       initial_snapshot=1
     fi
 
+    # check for other snapshots in progress
+    if ! acquire_snapshot_lock $alias_name; then
+      if [ $abort_on_conflict -eq 1 ]; then
+        echo "another snapshot is in progress... aborting"
+        retcode=1
+        continue
+      fi
+
+      if [ $initial_snapshot -eq 1 ]; then
+        echo "an initial snapshot is in progress... aborting"
+        retcode=1
+        continue
+      fi
+
+      echo "waiting for another snapshot to finish..."
+      if ! wait_and_acquire_snapshot_lock $alias_name; then
+        echo "failed to acquire snapshot lock"
+        retcode=1
+        continue
+      fi
+    fi
+
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-l $CVMFS_LOG_LEVEL"
     if [ $initial_snapshot -eq 1 ]; then
@@ -4218,7 +4240,8 @@ snapshot() {
         -k $public_key \
         -n $num_workers \
         -t $timeout \
-        -a $retries $with_history $log_level $dont_wait"
+        -a $retries $with_history $log_level"
+
     $user_shell "date > ${spool_dir}/tmp/last_snapshot"
     $user_shell "cvmfs_swissknife upload -r ${upstream} \
       -i ${spool_dir}/tmp/last_snapshot \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4185,12 +4185,14 @@ snapshot() {
     # do it!
     local user_shell="$(get_user_shell $alias_name)"
 
+    local initial_snapshot=0
+    if $user_shell "cvmfs_swissknife peek -d .cvmfs_last_snapshot -r ${upstream}" | grep -v -q "available"; then
+      initial_snapshot=1
+    fi
+
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-l $CVMFS_LOG_LEVEL"
-    local with_history=
-    if $user_shell "cvmfs_swissknife peek -d .cvmfs_last_snapshot -r ${upstream}" | grep -q "available"; then
-      with_history="-p"
-    else
+    if [ $initial_snapshot -eq 1 ]; then
       echo "Initial snapshot"
     fi
 
@@ -4207,6 +4209,8 @@ snapshot() {
       -o .cvmfs_is_snapshotting"
 
     # do the actual snapshot actions
+    local with_history=""
+    [ $initial_snapshot -ne 1 ] && with_history="-p"
     $user_shell "cvmfs_swissknife pull -m $name \
         -u $stratum0 \
         -r ${upstream} \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -847,7 +847,6 @@ acquire_snapshot_lock() {
   load_repo_config $name
   local snapshot_lock="${CVMFS_SPOOL_DIR}/is_snapshotting"
   mkdir $snapshot_lock > /dev/null 2>&1 || return 1
-  trap "release_snapshot_lock $name" EXIT HUP INT TERM
 }
 
 wait_and_acquire_snapshot_lock() {
@@ -861,7 +860,6 @@ release_snapshot_lock() {
   local name=$1
   load_repo_config $name
   local snapshot_lock="${CVMFS_SPOOL_DIR}/is_snapshotting"
-  trap - EXIT HUP INT TERM
   rmdir $snapshot_lock > /dev/null 2>&1
 }
 
@@ -4116,6 +4114,18 @@ __run_gc() {
 ################################################################################
 
 
+__snapshot_cleanup() {
+  local alias_name=$1
+
+  load_repo_config $alias_name
+  local user_shell="$(get_user_shell $alias_name)"
+
+  $user_shell "cvmfs_swissknife remove        \
+                 -r ${CVMFS_UPSTREAM_STORAGE} \
+                 -o .cvmfs_is_snapshotting" || echo "Warning: failed to remove .cvmfs_is_snapshotting"
+  release_snapshot_lock $alias_name         || echo "Warning: failed to release snapshotting lock"
+}
+
 snapshot() {
   local alias_names
   local name
@@ -4212,17 +4222,14 @@ snapshot() {
       fi
     fi
 
+    # here the lock is already acquired and needs to be cleared in case of abort
+    trap "__snapshot_cleanup $alias_name" EXIT HUP INT TERM
+
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-l $CVMFS_LOG_LEVEL"
     if [ $initial_snapshot -eq 1 ]; then
       echo "Initial snapshot"
     fi
-
-    # command to remove the magic file when finished (or aborted)
-    delete_command="cvmfs_swissknife remove \
-                      -r ${upstream} \
-                      -o .cvmfs_is_snapshotting"
-    trap "$delete_command" HUP INT TERM QUIT
 
     # put a magic file in the repository root to signal a snapshot in progress
     $user_shell "date > ${spool_dir}/tmp/snapshotting"
@@ -4258,6 +4265,10 @@ snapshot() {
                ""            \
                -z $gc_timespan || die "Garbage collection failed ($?)"
     fi
+
+    # all done, clear the trap and run the cleanup manually
+    trap - EXIT HUP INT TERM
+    __snapshot_cleanup $alias_name
 
   done
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -842,6 +842,35 @@ publish_succeeded() {
   rmdir $pub_lock > /dev/null 2>&1
 }
 
+acquire_snapshot_lock() {
+  local name=$1
+  load_repo_config $name
+  local snapshot_lock="${CVMFS_SPOOL_DIR}/is_snapshotting"
+  mkdir $snapshot_lock > /dev/null 2>&1 || return 1
+  trap "release_snapshot_lock $name" EXIT HUP INT TERM
+}
+
+wait_and_acquire_snapshot_lock() {
+  local name=$1
+  while ! acquire_snapshot_lock $name; do
+    sleep 10
+  done
+}
+
+release_snapshot_lock() {
+  local name=$1
+  load_repo_config $name
+  local snapshot_lock="${CVMFS_SPOOL_DIR}/is_snapshotting"
+  trap - EXIT HUP INT TERM
+  rmdir $snapshot_lock > /dev/null 2>&1
+}
+
+is_snapshotting() {
+  local name=$1
+  load_repo_config $name
+  [ -d ${CVMFS_SPOOL_DIR}/is_snapshotting ]
+}
+
 
 # checks if a user exists in the system
 #

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -64,7 +64,6 @@ string              *temp_dir = NULL;
 unsigned             num_parallel = 1;
 bool                 pull_history = false;
 bool                 is_garbage_collectable = false;
-bool                 wait_for_other_snapshots = true;
 upload::Spooler     *spooler = NULL;
 int                  pipe_chunks[2];
 // required for concurrent reading
@@ -389,8 +388,6 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     retries = String2Uint64(*args.find('a')->second);
   if (args.find('p') != args.end())
     pull_history = true;
-  if (args.find('s') != args.end())
-    wait_for_other_snapshots = false;
   pthread_t *workers =
     reinterpret_cast<pthread_t *>(smalloc(sizeof(pthread_t) * num_parallel));
   typedef std::vector<history::History::Tag> TagVector;

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -399,31 +399,6 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: replicating from %s",
            stratum0_url->c_str());
 
-  // Wait for another instance to finish
-  fd_lockfile = TryLockFile(*temp_dir + "/lock_snapshot");
-  if (fd_lockfile < 0) {
-    if (! wait_for_other_snapshots) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "another snapshot is in progress... aborting");
-      free(workers);
-      return 2;
-    }
-
-    if (! pull_history) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "an initial snapshot is in progress... aborting");
-      free(workers);
-      return 2;
-    }
-
-    LogCvmfs(kLogCvmfs, kLogStdout, "waiting for another snapshot to finish...");
-    fd_lockfile = LockFile(*temp_dir + "/lock_snapshot");
-    if (fd_lockfile < 0) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to lock on %s",
-               (*temp_dir + "/lock_snapshot").c_str());
-      free(workers);
-      return 1;
-    }
-  }
-
   int result = 1;
   const string url_sentinel = *stratum0_url + "/.cvmfs_master_replica";
   download::JobInfo download_sentinel(&url_sentinel, false);

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -30,7 +30,6 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional ('a', "number of retries"));
     r.push_back(Parameter::Switch   ('p', "pull catalog history, too"));
     r.push_back(Parameter::Switch   ('c', "preload cache instead of stratum 1"));
-    r.push_back(Parameter::Switch   ('s', "don't wait for other snapshots"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -1,0 +1,246 @@
+
+cvmfs_test_name="Interleaving Stratum1 Snapshot Behaviour"
+cvmfs_test_autofs_on_startup=false
+
+
+create_fake_lock() {
+  local name=$1
+  load_repo_config $name
+  echo "creating ${CVMFS_SPOOL_DIR}/is_snapshotting"
+  mkdir ${CVMFS_SPOOL_DIR}/is_snapshotting
+}
+
+remove_fake_lock() {
+  local name=$1
+  load_repo_config $name
+  echo "removing ${CVMFS_SPOOL_DIR}/is_snapshotting"
+  rmdir ${CVMFS_SPOOL_DIR}/is_snapshotting
+}
+
+check_lock() {
+  local name=$1
+  load_repo_config $name
+  [ -d ${CVMFS_SPOOL_DIR}/is_snapshotting ]
+}
+
+run_background_snapshot() {
+  local name=$1
+  local logfile=$2
+  shift 2
+  local snapshot_params="$*"
+
+  local max_waiting_time=180
+  local snapshot_command="cvmfs_server snapshot $snapshot_params $name"
+  local pid=0
+
+  echo "running \`${snapshot_command}\`"
+  pid=$(run_background_service $logfile "$snapshot_command") || return $?
+
+  echo -n "waiting for snapshot (PID: $pid) for $max_waiting_time seconds... "
+  local timeout=$max_waiting_time
+  while kill -0 $pid > /dev/null 2>&1 && [ $timeout -gt 0 ]; do
+    sleep 1
+    timeout=$(( $timeout - 1 ))
+  done
+  echo "done (waited $(( $max_waiting_time - $timeout )) seconds)"
+
+  if ! kill -0 $pid > /dev/null 2>&1; then
+    echo "snapshot has terminated"
+  else
+    echo -n "snapshot is still running - aborting it... "
+    kill -9 $pid && echo "done" || echo "fail"
+    return 1
+  fi
+}
+
+
+CVMFS_TEST_584_REPLICA_NAME=""
+cleanup() {
+  echo "running cleanup()"
+  if [ ! -z $CVMFS_TEST_584_REPLICA_NAME ]; then
+    sudo cvmfs_server rmfs -f $CVMFS_TEST_584_REPLICA_NAME
+  fi
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+  local scratch_dir=$(pwd)
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO || return $?
+
+  # echo "install a desaster cleanup function"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "create Stratum1 repository on the same machine"
+  local replica_name="${CVMFS_TEST_REPO}.replic"
+  CVMFS_TEST_584_REPLICA_NAME="$replica_name"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
+
+  # ============================================================================
+
+  echo "fake a running snapshot"
+  create_fake_lock $replica_name || return 2
+
+  echo "create an initial snapshot (should immediately fail)"
+  local snapshot_log_1="snapshot_1.log"
+  run_background_snapshot $replica_name $snapshot_log_1 || return 2
+
+  echo "check if the snapshotting lock is there"
+  check_lock $replica_name || return 3
+
+  echo "check log file for proper error message"
+  cat $snapshot_log_1 | grep 'initial snapshot.*in progress.*abort' || return 4
+
+  echo "create an initial snapshot without waiting (should immediately fail)"
+  local snapshot_log_2="snapshot_2.log"
+  run_background_snapshot $replica_name $snapshot_log_2 -t || return 5
+
+  echo "check if the snapshotting lock is there"
+  check_lock $replica_name || return 6
+
+  echo "check log file for proper error message"
+  cat $snapshot_log_2 | grep 'another snapshot.*in progress.*abort' || return 7
+
+  echo "remove faked lock"
+  remove_fake_lock $replica_name || return 8
+
+  # ============================================================================
+
+  echo "create an initial snapshot (should work)"
+  local snapshot_log_3="snapshot_3.log"
+  run_background_snapshot $replica_name $snapshot_log_3 || return 9
+
+  echo "check if the snapshotting lock is gone"
+  check_lock $replica_name && return 10
+
+  echo "check the log file for proper manifest upload"
+  cat $snapshot_log_3 | grep 'Uploading manifest' || return 11
+
+  # ============================================================================
+
+  echo "create a couple of transactions in stratum 0"
+  local publish_log_1="publish_1.log"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir ${repo_dir}/foo
+  cp_bin $repo_dir/foo
+  publish_repo $CVMFS_TEST_REPO >> $publish_log_1 2>&1 || return $?
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir ${repo_dir}/bar
+  cp_bin $repo_dir/bar
+  publish_repo $CVMFS_TEST_REPO >> $publish_log_1 2>&1 || return $?
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir ${repo_dir}/baz
+  cp_bin $repo_dir/baz
+  publish_repo $CVMFS_TEST_REPO >> $publish_log_1 2>&1 || return $?
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir ${repo_dir}/bam
+  cp_bin $repo_dir/bam
+  publish_repo $CVMFS_TEST_REPO >> $publish_log_1 2>&1 || return $?
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir ${repo_dir}/buz
+  cp_bin $repo_dir/buz
+  publish_repo $CVMFS_TEST_REPO >> $publish_log_1 2>&1 || return $?
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir ${repo_dir}/big
+  dd if=/dev/urandom of=${repo_dir}/big/1 count=100 bs=1MiB > /dev/null 2>&1 || return 12
+  dd if=/dev/urandom of=${repo_dir}/big/2 count=100 bs=1MiB > /dev/null 2>&1 || return 13
+  dd if=/dev/urandom of=${repo_dir}/big/3 count=100 bs=1MiB > /dev/null 2>&1 || return 14
+  dd if=/dev/urandom of=${repo_dir}/big/4 count=100 bs=1MiB > /dev/null 2>&1 || return 15
+  publish_repo $CVMFS_TEST_REPO >> $publish_log_1 2>&1 || return $?
+
+  # ============================================================================
+
+  echo "create a fake lock"
+  create_fake_lock $replica_name || return 16
+
+  echo "try to snapshot (should hang forever)"
+  local snapshot_log_4="snapshot_4.log"
+  run_background_snapshot $replica_name $snapshot_log_4 && return 17
+
+  echo "check if the snapshotting lock is there"
+  check_lock $replica_name || return 18
+
+  echo "check error message"
+  cat $snapshot_log_4 | grep 'waiting .* snapshot .* finish' || return 19
+
+  echo "try to snapshot (without waiting)"
+  local snapshot_log_5="snapshot_5.log"
+  run_background_snapshot $replica_name $snapshot_log_5 -t || return 20
+
+  echo "check if the snapshotting lock is there"
+  check_lock $replica_name || return 21
+
+  echo "check log file for proper error message"
+  cat $snapshot_log_2 | grep 'another snapshot.*in progress.*abort' || return 22
+
+  echo "remove the fake log"
+  remove_fake_lock $replica_name || return 23
+
+  # ============================================================================
+
+  echo "try to snapshot (in the background)"
+  local snapshot_log_6="snapshot_6.log"
+  local pid6=$(run_background_service $snapshot_log_6 "cvmfs_server snapshot $replica_name") || return 24
+  echo "running with PID: $pid6"
+
+  echo "sleep for one second"
+  sleep 1
+
+  echo "check if the snapshotting lock is there"
+  check_lock $replica_name || return 25
+
+  echo "run a second snapshot concurrently (should abort immediately)"
+  local snapshot_log_7="snapshot_7.log"
+  run_background_snapshot $replica_name $snapshot_log_7 -t || return 26
+
+  echo "check if the snapshotting lock is there"
+  check_lock $replica_name || return 27
+
+  echo "check if the first snapshot is still running (we missed the race otherwise)"
+  kill -0 $pid6 || return 28
+
+  echo "check if the snapshotting lock is there"
+  check_lock  $replica_name || return 29
+
+  echo "run a second snapshot concurrently (should wait and later do the snapshot)"
+  local snapshot_log_8="snapshot_8.log"
+  run_background_snapshot $replica_name $snapshot_log_8 || return 30
+
+  echo "check if the first snapshot is gone (kill it otherwise)"
+  if kill -0 $pid6 > /dev/null 2>&1; then
+    echo -n "PID $pid6 is still around - killing it... "
+    kill -9 $pid6
+    echo "done"
+    return 31
+  fi
+
+  echo "check if the snapshotting lock is gone"
+  check_lock $replica_name && return 32
+
+  echo "check the log files"
+  echo "(6 should have snapshotted, 7 should have aborted, 8 should have waited and later snapshotted)"
+  local revisions_snapshotted_by_6=$(cat $snapshot_log_6 | grep 'Processing chunks' | wc -l)
+  local revisions_snapshotted_by_7=$(cat $snapshot_log_7 | grep 'Processing chunks' | wc -l)
+  echo "Number 6 snapshotted $revisions_snapshotted_by_6 revisions"
+  echo "Number 7 snapshotted $revisions_snapshotted_by_7 revisions"
+  [ $revisions_snapshotted_by_6 -eq 6 ]                             || return 33
+  [ $revisions_snapshotted_by_7 -eq 0 ]                             || return 34
+  cat $snapshot_log_6 | grep 'Uploading manifest'                   || return 35
+  cat $snapshot_log_7 | grep 'another snapshot.*in progress.*abort' || return 36
+  cat $snapshot_log_8 | grep 'waiting.*snapshot to finish'          || return 37
+  cat $snapshot_log_8 | grep 'Uploading manifest'                   || return 38
+
+  return 0
+}


### PR DESCRIPTION
This fixes a potential race in `cvmfs_server snapshot` where an automatic garbage collection could still be running while a cron job could start a new snapshot already. With a certain possibility this could lead to files being removed just after they have been snapshotted.
Fix in short: The snapshotting lock maintained by `cvmfs_swissknife` was ported into the `cvmfs_server` script.

The automatic garbage collection in `cvmfs_server publish` is not affected by this, since we can use the common *transaction* mechanism to shield mutex concurrent invocations from each other.

Furthermore this contains an integration test case that checks the proper functionality of the `cvmfs_server snapshot` locking mechanism as well as the `cvmfs_server snapshot -t` flag to abort a snapshot instead of waiting in case another snapshot is already running. Also the behaviour for running *initial snapshots* requested by @DrDaveD in [CVM-278](https://sft.its.cern.ch/jira/browse/CVM-278) is tested here.