### PR TITLE
FIX: Mistaken Variable Name in `cvmfs_server snapshot`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4179,7 +4179,7 @@ snapshot() {
     retries=$CVMFS_HTTP_RETRIES
 
     # more sanity checks
-    is_owner_or_root $alias_name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }
+    is_owner_or_root $alias_name || { echo "Permission denied: Repository $alias_name is owned by $user"; retcode=1; continue; }
     check_repository_compatibility
     if is_local_upstream $CVMFS_UPSTREAM_STORAGE && check_apache; then
         # this might have been missed if add-replica -a was used or
@@ -4190,7 +4190,7 @@ snapshot() {
         update_geodb -l || true
     fi
     [ ! -z $stratum1 ] || die "Missing CVMFS_STRATUM1 URL in server.conf"
-    gc_timespan="$(get_auto_garbage_collection_timespan $name)" || { retcode=1; continue; }
+    gc_timespan="$(get_auto_garbage_collection_timespan $alias_name)" || { retcode=1; continue; }
 
     # do it!
     local user_shell="$(get_user_shell $alias_name)"


### PR DESCRIPTION
This fixes a variable name mistake in `cvmfs_server snapshot` that was detected by the failing integration test 550.