### PR TITLE
Fix: Test Driver Inadvertently Failing Test Case Setup

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -299,7 +299,7 @@ mangle_test_retval() {
   if [ $CVMFS_TIME_WARNING_FLAG -ne 0 ]; then
     return $CVMFS_TIME_WARNING
   fi
-  
+
   # check if the test case produced any other warnings
   if [ $CVMFS_GENERAL_WARNING_FLAG -ne 0 ]; then
     return $CVMFS_GENERAL_WARNING

--- a/test/test_functions
+++ b/test/test_functions
@@ -198,7 +198,7 @@ cvmfs_clean() {
   sudo sh -c "rm -f /etc/cvmfs/config.d/*"
   sudo sh -c "cat /dev/null > $CVMFS_TEST_SYSLOG_TARGET"
 
-  timeout=5
+  timeout=60
   while $(pgrep -u cvmfs cvmfs2 > /dev/null); do
     if [ $timeout -eq 0 ]; then
       return 101


### PR DESCRIPTION
This mitigates a problem in the integration test driver that showed up on CentOS 7 where it didn't wait long enough for the umount of the previous test setup. I increased the timeout from five seconds to one minute. This should drastically decrease the probability to produce a false-fail during test case setup.