### PR TITLE
Test: Disable Corrupt Legacy Repo Migration on S3

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -91,6 +91,7 @@ if [ $s3_retval -eq 0 ]; then
                                  src/542-storagescrubbing                     \
                                  src/543-storagescrubbing_scriptable          \
                                  src/550-livemigration                        \
+                                 src/568-migratecorruptrepo                   \
                                  src/571-localbackendumask                    \
                                  src/572-proxyfailover                        \
                                  src/577-garbagecollecthiddenstratum1revision \


### PR DESCRIPTION
This test does not fail on S3 but it doesn't use the S3 interface, since migration is only supported on local backends for now. Hence there is no point of running this test in the S3 test set.