### PR TITLE
Fix: S3 Configuration Variable Typo

### DIFF
--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -117,7 +117,7 @@ bool S3Uploader::ParseSpoolerDefinition(
   if (!options::GetValue("CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS",
                          &parameter)) {
     LogCvmfs(kLogSpooler, kLogStderr, "Failed to parse "
-             "CVMFS_S3_MAX_NUMBER_OF_PARALLELL_CONNECTIONS "
+             "CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS "
              "from '%s'.",
              config_path.c_str());
     return false;

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -114,7 +114,7 @@ bool S3Uploader::ParseSpoolerDefinition(
              config_path.c_str());
     return false;
   }
-  if (!options::GetValue("CVMFS_S3_MAX_NUMBER_OF_PARALLELL_CONNECTIONS",
+  if (!options::GetValue("CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS",
                          &parameter)) {
     LogCvmfs(kLogSpooler, kLogStderr, "Failed to parse "
              "CVMFS_S3_MAX_NUMBER_OF_PARALLELL_CONNECTIONS "


### PR DESCRIPTION
This is a cherry-pick of the configuration typo fix [pushed](https://github.com/cvmfs/cvmfs/pull/747) by @ssheikki earlier today. I additionally changed the associated error message.