### PR TITLE
FIX: Use `cp_bin` Helper Instead of `cp -R /bin`

### DIFF
--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -90,7 +90,7 @@ EOF
 
   # create some nasty other stuff
   ln big_ascii/viel_unordnung big_ascii/ganz_viel_unordnung
-  cp /bin/cp .
+  cp_bin .
   ln -s poems/unordnung.txt unordnung
 
   popdir

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -232,7 +232,7 @@ produce_last_files_in() {
 
   rm -fR poems
   rm -f unordnung
-  cp -R /bin     many_small_binaries
+  cp_bin many_small_binaries
 
   popdir
 }


### PR DESCRIPTION
This is done to take care of read access rights. Some binaries in `/bin` might not be readable by *sftnight*.