### PR TITLE
Fix: Read Permission Problems when Copying from /usr/bin/*

### DIFF
--- a/test/src/544-cvmfsdirtab/main
+++ b/test/src/544-cvmfsdirtab/main
@@ -46,7 +46,7 @@ produce_files_in_2() {
   # add some files to some of the directories
   cp_bin People/Germans/AlbertEinstein
   cp /etc/passwd People/Americans/BarackObama
-  cp /usr/bin/* People/Russians/MikhailKalashnikov
+  cp_usrbin People/Russians/MikhailKalashnikov
 
   # add a file in the French People Directory
   echo "French Don't Believe in Directories" > People/French/NapoleonBonaparte

--- a/test/src/566-dirtabrecreatenested/main
+++ b/test/src/566-dirtabrecreatenested/main
@@ -18,7 +18,7 @@ produce_files_in_0() {
   # add some files to some of the directories
   cp_bin People/Germans/AlbertEinstein
   cp /etc/passwd People/Americans/BarackObama
-  cp /usr/bin/* People/Russians/MikhailKalashnikov
+  cp_usrbin People/Russians/MikhailKalashnikov
 
   # add a file in the French People Directory
   echo "Napoleon doesn't believe in directories" > People/French/NapoleonBonaparte

--- a/test/test_functions
+++ b/test/test_functions
@@ -1168,3 +1168,16 @@ cp_bin() {
     sudo chmod 0444 $f || return 3
   done
 }
+
+
+# copy all content of /usr/bin/* into a given directory (for server testing purposes)
+#
+# @param destination_directory
+cp_usrbin() {
+  local destination_directory="$1"
+  cp -R /usr/bin/* $destination_directory   || return 1
+  sudo chmod -R a+rw $destination_directory || return 2
+  for f in $(find $destination_directory -type f); do
+    sudo chmod 0444 $f || return 3
+  done
+}


### PR DESCRIPTION
Same problem [as before](https://github.com/cvmfs/cvmfs/pull/753), but with `/usr/bin/*`. This is not critical but just to be sure.