### PR TITLE
Python: Open Catalog, Manifest and History From a File

### DIFF
--- a/python/cvmfs/catalog.py
+++ b/python/cvmfs/catalog.py
@@ -148,6 +148,12 @@ class CatalogStatistics:
 class Catalog(DatabaseObject):
     """ Wraps the basic functionality of CernVM-FS Catalogs """
 
+    @staticmethod
+    def open(catalog_path):
+        """ Initializes a Catalog from a local file path """
+        f = open(catalog_path)
+        return Catalog(f)
+
     def __init__(self, catalog_file, catalog_hash = ""):
         DatabaseObject.__init__(self, catalog_file)
         self.hash = catalog_hash

--- a/python/cvmfs/history.py
+++ b/python/cvmfs/history.py
@@ -33,6 +33,13 @@ class RevisionTag:
 
 class History(DatabaseObject):
     """ Wrapper around CernVM-FS 2.1.x repository history databases """
+
+    @staticmethod
+    def open(history_path):
+        """ Initializes a History Database from a local file path """
+        f = open(history_path)
+        return History(f)
+
     def __init__(self, history_file):
         DatabaseObject.__init__(self, history_file)
         self._read_properties()

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -23,6 +23,13 @@ class ManifestValidityError(Exception):
 class Manifest:
     """ Wraps information from .cvmfspublished"""
 
+    @staticmethod
+    def open(manifest_path):
+        """ Initializes a Manifest from a local file path """
+        f = open(manifest_path)
+        return Manifest(f)
+
+
     def __init__(self, manifest_file):
         """ Initializes a Manifest object from a file pointer to .cvmfspublished """
         for line in manifest_file.readlines():


### PR DESCRIPTION
This allows to directly open `Manifest`, `Catalog` or `History` from a local file using the python library like this:

```python
import cvmfs
catalog  = cvmfs.Catalog.open("/tmp/downloaded_catalog_fileC")
history  = cvmfs.History.open("/tmp/emailed_history_fileH")
manifest = cvmfs.Manifest.open("/srv/cvmfs/test.cern.ch/.cvmfspublished")
```