### PR TITLE
Add use of geoapi to egi.eu and opensciencegrid.org, and correct BNL stratum 1 URL

### DIFF
--- a/mount/domain.d/egi.eu.conf
+++ b/mount/domain.d/egi.eu.conf
@@ -3,3 +3,4 @@
 
 CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/egi.eu
+CVMFS_USE_GEOAPI=yes

--- a/mount/domain.d/opensciencegrid.org.conf
+++ b/mount/domain.d/opensciencegrid.org.conf
@@ -3,3 +3,4 @@
 
 CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@@fqrn;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/opensciencegrid.org
+CVMFS_USE_GEOAPI=yes

--- a/mount/domain.d/opensciencegrid.org.conf
+++ b/mount/domain.d/opensciencegrid.org.conf
@@ -1,6 +1,6 @@
 # Don't edit here.  Create /etc/cvmfs/domain.d/opensciencegrid.org.local
 # As a rule of thumb, overwrite only parameters you find in here.
 
-CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@@fqrn;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@@fqrn;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/opensciencegrid.org
 CVMFS_USE_GEOAPI=yes

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -77,6 +77,7 @@ done
 %changelog
 * Tue Feb 02 2015 Dave Dykstra <dwd@fnal.gov> - 1.1-1
 - add CVMFS_USE_GEOAPI=yes to egi.eu and opensciencegrid.org
+- fix BNL URL for opensciencegrid.org
 
 * Thu Jan 22 2015 Jakob Blomer <jblomer@cern.ch> - 1.0-1
 - initial packaging

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -1,6 +1,6 @@
 Summary: CernVM File System Default Configuration and Public Keys
 Name: cvmfs-config-default
-Version: 1.0
+Version: 1.1
 Release: 1
 Source0: cern.ch.pub
 Source1: cern-it1.cern.ch.pub
@@ -75,5 +75,8 @@ done
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
+* Tue Feb 02 2015 Dave Dykstra <dwd@fnal.gov> - 1.1-1
+- add CVMFS_USE_GEOAPI=yes to egi.eu and opensciencegrid.org
+
 * Thu Jan 22 2015 Jakob Blomer <jblomer@cern.ch> - 1.0-1
 - initial packaging


### PR DESCRIPTION
There are less than 3 (2, actually) stratum 1s on both egi.eu and opensciencegrid.org that don't yet support the geo api, so we can set CVMFS_USE_GEOAPI=yes. 

In addition, the BNL URL in opensciencegrid.org.conf was missing http://.