### PR TITLE
CI: Package Build Scripts for Debian and RPM

### DIFF
--- a/ci/build_deb.sh
+++ b/ci/build_deb.sh
@@ -1,3 +1,51 @@
 #!/bin/sh
 
-echo "will build DEB package here..."
+#
+# This script builds the debian packages of CernVM-FS.
+#
+
+set -e
+
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+. ${SCRIPT_LOCATION}/common.sh
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <CernVM-FS source directory> <build result location> [<nightly build number>]"
+  echo "This script builds CernVM-FS debian packages"
+  exit 1
+fi
+
+CVMFS_SOURCE_LOCATION="$1"
+CVMFS_RESULT_LOCATION="$2"
+CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
+
+# sanity checks
+[ ! -d ${CVMFS_SOURCE_LOCATION}/debian ] || die "source directory seemed to be built before (${CVMFS_SOURCE_LOCATION}/debian exists)"
+
+# retrieve the upstream version string from CVMFS
+cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"
+echo "detected upstream version: $cvmfs_version"
+
+# generate the release tag for either a nightly build or a release
+if [ $CVMFS_NIGHTLY_BUILD_NUMBER -gt 0 ]; then
+  git_hash="$(get_cvmfs_git_revision $CVMFS_SOURCE_LOCATION)"
+  cvmfs_version="${cvmfs_version}.${CVMFS_NIGHTLY_BUILD_NUMBER}git${git_hash}"
+  echo "creating nightly build '$cvmfs_version'"
+else
+  echo "creating release: $cvmfs_version"
+fi
+
+# produce the debian package
+echo "copy packaging meta information and get in place..."
+cp -r ${CVMFS_SOURCE_LOCATION}/packaging/debian/cvmfs ${CVMFS_SOURCE_LOCATION}/debian
+mkdir -p $CVMFS_RESULT_LOCATION
+cd ${CVMFS_SOURCE_LOCATION}
+
+echo "do the build..."
+dch -v $cvmfs_version -M "bumped upstream version number"
+cd debian
+pdebuild --buildresult $CVMFS_RESULT_LOCATION
+
+# clean up the source tree
+echo "cleaning up..."
+rm -fR ${CVMFS_SOURCE_LOCATION}/debian

--- a/ci/build_rpm.sh
+++ b/ci/build_rpm.sh
@@ -1,3 +1,67 @@
 #!/bin/sh
 
-echo "will build RPM here..."
+#
+# This script builds the RPM packages of CernVM-FS.
+#
+
+set -e
+
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+. ${SCRIPT_LOCATION}/common.sh
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <CernVM-FS source directory> <build result location> [<nightly build number>]"
+  echo "This script builds CernVM-FS RPM packages"
+  exit 1
+fi
+
+CVMFS_SOURCE_LOCATION="$1"
+CVMFS_RESULT_LOCATION="$2"
+CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
+
+rpm_infra_dirs="BUILD RPMS SOURCES SRPMS TMP"
+rpm_src_dir="${CVMFS_SOURCE_LOCATION}/packaging/rpm"
+spec_file="cvmfs-universal.spec"
+
+# sanity checks
+for d in $rpm_infra_dirs; do
+  [ ! -d ${CVMFS_RESULT_LOCATION}/${d} ] || die "build directory seems to be used before (${CVMFS_RESULT_LOCATION}/${d} exists)"
+done
+[ ! -f ${CVMFS_SOURCE_LOCATION}/${spec_file} ] || die "source directory seemed to be built before (${CVMFS_SOURCE_LOCATION}/$spec_file exists)"
+
+# retrieve the upstream version string from CVMFS
+cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"
+echo "detected upstream version: $cvmfs_version"
+
+echo "preparing build environment in '${CVMFS_RESULT_LOCATION}'..."
+for d in $rpm_infra_dirs; do
+  mkdir ${CVMFS_RESULT_LOCATION}/${d}
+done
+
+# copy RPM spec file and SELinux module files in place and cd there
+cp ${rpm_src_dir}/$spec_file $CVMFS_RESULT_LOCATION
+cp ${rpm_src_dir}/cvmfs.te \
+   ${rpm_src_dir}/cvmfs.fc \
+   $CVMFS_RESULT_LOCATION/SOURCES
+# cp $tarball $packagedir/SOURCES || exit 5
+cd  $CVMFS_RESULT_LOCATION
+
+# generate the release tag for either a nightly build or a release
+# (for the nightly build this requires some changes in the spec file)
+if [ $CVMFS_NIGHTLY_BUILD_NUMBER -gt 0 ]; then
+  git_hash="$(get_cvmfs_git_revision $CVMFS_SOURCE_LOCATION)"
+  build_tag="git-${git_hash}"
+  nightly_tag="0.${CVMFS_NIGHTLY_BUILD_NUMBER}.${git_hash}git"
+
+  echo "creating nightly build '$nightly_tag'"
+  sed -i -e "s/^Release: .*/Release: ${nightly_tag}%{?dist}/" $spec_file
+  sed -i -e "s/\(^Source0: .*\)%{version}/\1${build_tag}/"    $spec_file
+  sed -i -e "s/^%setup -q/%setup -q -n cvmfs-${build_tag}/"   $spec_file
+else
+  echo "creating release: $cvmfs_version"
+fi
+
+echo "building..."
+rpmbuild --define="_topdir $CVMFS_RESULT_LOCATION"        \
+         --define="_tmppath ${CVMFS_RESULT_LOCATION}/TMP" \
+         -ba $spec_file

--- a/ci/build_rpm.sh
+++ b/ci/build_rpm.sh
@@ -38,18 +38,23 @@ for d in $rpm_infra_dirs; do
   mkdir ${CVMFS_RESULT_LOCATION}/${d}
 done
 
+git_hash="$(get_cvmfs_git_revision $CVMFS_SOURCE_LOCATION)"
+tarball="cvmfs-${cvmfs_version}.${git_hash}.tar.gz"
+echo "creating source tar ball '$tarball'..."
+create_cvmfs_source_tarball ${CVMFS_SOURCE_LOCATION} \
+                            ${CVMFS_RESULT_LOCATION}/SOURCES/${tarball}
+
 # copy RPM spec file and SELinux module files in place and cd there
+echo "copying RPM package specification and dependencies..."
 cp ${rpm_src_dir}/$spec_file $CVMFS_RESULT_LOCATION
 cp ${rpm_src_dir}/cvmfs.te \
    ${rpm_src_dir}/cvmfs.fc \
    $CVMFS_RESULT_LOCATION/SOURCES
-# cp $tarball $packagedir/SOURCES || exit 5
 cd  $CVMFS_RESULT_LOCATION
 
 # generate the release tag for either a nightly build or a release
 # (for the nightly build this requires some changes in the spec file)
 if [ $CVMFS_NIGHTLY_BUILD_NUMBER -gt 0 ]; then
-  git_hash="$(get_cvmfs_git_revision $CVMFS_SOURCE_LOCATION)"
   build_tag="git-${git_hash}"
   nightly_tag="0.${CVMFS_NIGHTLY_BUILD_NUMBER}.${git_hash}git"
 

--- a/ci/build_rpm.sh
+++ b/ci/build_rpm.sh
@@ -39,7 +39,7 @@ for d in $rpm_infra_dirs; do
 done
 
 git_hash="$(get_cvmfs_git_revision $CVMFS_SOURCE_LOCATION)"
-tarball="cvmfs-${cvmfs_version}.${git_hash}.tar.gz"
+tarball="cvmfs-${cvmfs_version}.tar.gz"
 echo "creating source tar ball '$tarball'..."
 create_cvmfs_source_tarball ${CVMFS_SOURCE_LOCATION} \
                             ${CVMFS_RESULT_LOCATION}/SOURCES/${tarball}
@@ -60,8 +60,6 @@ if [ $CVMFS_NIGHTLY_BUILD_NUMBER -gt 0 ]; then
 
   echo "creating nightly build '$nightly_tag'"
   sed -i -e "s/^Release: .*/Release: ${nightly_tag}%{?dist}/" $spec_file
-  sed -i -e "s/\(^Source0: .*\)%{version}/\1${build_tag}/"    $spec_file
-  sed -i -e "s/^%setup -q/%setup -q -n cvmfs-${build_tag}/"   $spec_file
 else
   echo "creating release: $cvmfs_version"
 fi

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -15,3 +15,45 @@ get_cvmfs_git_revision() {
   local source_directory="$1"
   echo "$(cd $source_directory; git rev-parse HEAD | head -c16)"
 }
+
+create_cvmfs_source_tarball() {
+  local source_directory="$1"
+  local destination_path="$2"
+  local prev_dir="$(pwd)"
+
+  # sanity check
+  echo "$destination_path" | grep -q '\.tar\.gz$' || die "'$destination_path' should be a .tar.gz file"
+
+  # figure out the tar archive prefix
+  local tar_name
+  tar_name="$(basename $destination_path | sed -e 's/\(.*\)\.tar\.gz$/\1/')"
+
+  cd "$source_directory"
+  git archive --prefix ${tar_name}/ \
+              --format tar          \
+                                    \
+              HEAD                  \
+              AUTHORS               \
+              CMakeLists.txt        \
+              COPYING               \
+              CPackLists.txt        \
+              ChangeLog             \
+              INSTALL               \
+              NEWS                  \
+              README                \
+              InstallerResources    \
+              add-ons               \
+              bootstrap.sh          \
+              cmake                 \
+              config_cmake.h.in     \
+              cvmfs                 \
+              doc                   \
+              externals             \
+              keys                  \
+              mount                 \
+              test | gzip -c > $destination_path || true
+  local retval=$?
+  cd "$prev_dir"
+
+  return $retval
+}

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+die() {
+  local msg="$1"
+  echo "$msg"
+  exit 1
+}
+
+get_cvmfs_version_from_cmake() {
+  local source_directory="$1"
+  cat ${source_directory}/CMakeLists.txt | grep '## CVMFS_VERSION' | awk '{print $3}'
+}
+
+get_cvmfs_git_revision() {
+  local source_directory="$1"
+  echo "$(cd $source_directory; git rev-parse HEAD | head -c16)"
+}


### PR DESCRIPTION
This contains scripts to automate the build of both *Debian* and *RPM* packages. In case of the *RPM* build script I just overhauled the old `makerpm.sh` used in EC. Furthermore it incorporates the `makedist.sh` as a utility functions.

Both scripts expect exactly the same command line parameters and should be usable independently from Jenkins:
```bash
build_???.sh <CernVM-FS source directory> <build result location> [<nightly build number>]
```

When no *nightly build number* is given, it will create release package versions, otherwise nightly builds will be created.