### PR TITLE
TEST: Disable 62 Slow Unit Tests

### DIFF
--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -32,7 +32,7 @@
  */
 template<class Key, class Value, class Derived>
 class SmallHashBase {
- FRIEND_TEST(T_Smallhash, InsertAndCopyMd5);
+ FRIEND_TEST(T_Smallhash, InsertAndCopyMd5Slow);
 
  public:
   static const double kLoadFactor;  // mainly useless for the dynamic version
@@ -132,7 +132,7 @@ class SmallHashBase {
   Key empty_key() const { return empty_key_; }
   Key *keys() const { return keys_; }
   Value *values() const { return values_; }
-  
+
   // Only needed by compat
   void SetHasher(uint32_t (*hasher)(const Key &key)) {
     hasher_ = hasher;

--- a/test/unittests/t_async_reader.cc
+++ b/test/unittests/t_async_reader.cc
@@ -256,7 +256,7 @@ TEST_F (T_AsyncReader, FileReadCallback) {
 //
 
 
-TEST_F (T_AsyncReader, ReadHugeFile) {
+TEST_F (T_AsyncReader, ReadHugeFileSlow) {
   TestFile *f = new TestFile(GetHugeFile(), GetHugeFileHash());
 
   const size_t        max_buffer_size = 524288; // will NOT fit in one buffer
@@ -279,7 +279,7 @@ TEST_F (T_AsyncReader, ReadHugeFile) {
 //
 
 
-TEST_F (T_AsyncReader, ReadManyBigFiles) {
+TEST_F (T_AsyncReader, ReadManyBigFilesSlow) {
   const int file_count = 5000;
 
   std::vector<TestFile*> files;
@@ -357,7 +357,7 @@ void *deadlock_test(void *v_files) {
   return (void*)1337;
 }
 
-TEST_F (T_AsyncReader, MultipleWaits) {
+TEST_F (T_AsyncReader, MultipleWaitsSlow) {
   const int file_count = 10000;
   std::vector<TestFile*> files;
   files.reserve(file_count);

--- a/test/unittests/t_atomic.cc
+++ b/test/unittests/t_atomic.cc
@@ -211,7 +211,7 @@ TEST_F(T_Atomic, TransactionalAssignment) {
 }
 
 
-TEST_F(T_Atomic, ConcurrentTransactionalAssignments) {
+TEST_F(T_Atomic, ConcurrentTransactionalAssignmentsSlow) {
   const int pthreads = 20;
 
   pthread_t threads32[pthreads];
@@ -253,7 +253,7 @@ TEST_F(T_Atomic, ConcurrentTransactionalAssignments) {
 }
 
 
-TEST_F(T_Atomic, ConcurrentWriteOfAtomicInts) {
+TEST_F(T_Atomic, ConcurrentWriteOfAtomicIntsSlow) {
   const int pthreads = 100;
 
   pthread_t threads32[pthreads];

--- a/test/unittests/t_blocking_counter.cc
+++ b/test/unittests/t_blocking_counter.cc
@@ -190,7 +190,7 @@ TEST_F(T_BlockingCounter, IncrementAndWait) {
 //
 
 
-TEST_F(T_BlockingCounter, BecomeZero) {
+TEST_F(T_BlockingCounter, BecomeZeroSlow) {
   T_BlockingCounter::concurrent_state_ = 0;
   EXPECT_EQ (0, T_BlockingCounter::concurrent_state_);
 
@@ -236,7 +236,7 @@ TEST_F(T_BlockingCounter, BecomeZero) {
 //
 
 
-TEST_F(T_BlockingCounter, BlockOnIncrementAndWaitForZero) {
+TEST_F(T_BlockingCounter, BlockOnIncrementAndWaitForZeroSlow) {
   T_BlockingCounter::concurrent_state_ = 0;
   EXPECT_EQ (0, T_BlockingCounter::concurrent_state_);
 
@@ -288,7 +288,7 @@ TEST_F(T_BlockingCounter, BlockOnIncrementAndWaitForZero) {
 //
 
 
-TEST_F(T_BlockingCounter, OrchestrateMultipleWaitingThreads) {
+TEST_F(T_BlockingCounter, OrchestrateMultipleWaitingThreadsSlow) {
   int_counter_ = max_value_;
   EXPECT_EQ (max_value_, int_counter_);
 

--- a/test/unittests/t_chunk_detectors.cc
+++ b/test/unittests/t_chunk_detectors.cc
@@ -56,7 +56,7 @@ class T_ChunkDetectors : public ::testing::Test {
   Prng rng_;
 };
 
-TEST_F(T_ChunkDetectors, StaticOffsetChunkDetector) {
+TEST_F(T_ChunkDetectors, StaticOffsetChunkDetectorSlow) {
   const size_t static_chunk_size = 1024;
 
   StaticOffsetDetector static_offset_detector(static_chunk_size);
@@ -160,7 +160,7 @@ TEST_F(T_ChunkDetectors, Xor32) {
 }
 
 
-TEST_F(T_ChunkDetectors, Xor32ChunkDetector) {
+TEST_F(T_ChunkDetectors, Xor32ChunkDetectorSlow) {
   const size_t base = 512000;
   const size_t min_chk_size = base;
   const size_t avg_chk_size = base * 2;

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -443,7 +443,7 @@ TEST_F(T_FileProcessing, ProcessBigFile) {
 }
 
 
-TEST_F(T_FileProcessing, ProcessHugeFile) {
+TEST_F(T_FileProcessing, ProcessHugeFileSlow) {
   ExpectedHashStrings hs = GetHugeFileChunkHashes();
   hs.push_back(GetHugeFileBulkHash());
   TestProcessFile(GetHugeFile(), hs);
@@ -455,7 +455,7 @@ TEST_F(T_FileProcessing, ProcessBigFileWithoutChunks) {
 }
 
 
-TEST_F(T_FileProcessing, ProcessMultipleFiles) {
+TEST_F(T_FileProcessing, ProcessMultipleFilesSlow) {
   std::vector<std::string> pathes;
   ExpectedHashStrings hs;
 
@@ -488,7 +488,7 @@ TEST_F(T_FileProcessing, ProcessMultipleFiles) {
 }
 
 
-TEST_F(T_FileProcessing, ProcessMultipeFilesWithoutChunking) {
+TEST_F(T_FileProcessing, ProcessMultipeFilesWithoutChunkingSlow) {
   std::vector<std::string> pathes;
   ExpectedHashStrings hs;
 
@@ -517,7 +517,7 @@ TEST_F(T_FileProcessing, ProcessMultipeFilesWithoutChunking) {
 }
 
 
-TEST_F(T_FileProcessing, ProcessMultipleFilesInSeparateWaves) {
+TEST_F(T_FileProcessing, ProcessMultipleFilesInSeparateWavesSlow) {
   upload::FileProcessor processor(uploader_, MockSpoolerDefinition());
 
   // first wave...

--- a/test/unittests/t_file_sandbox.cc
+++ b/test/unittests/t_file_sandbox.cc
@@ -109,7 +109,7 @@ TEST_F(T_FileSandbox, BigFile) {
 }
 
 
-TEST_F(T_FileSandbox, HugeFile) {
+TEST_F(T_FileSandbox, HugeFileSlow) {
   const std::string huge_file = GetHugeFile();
   const int64_t file_size = GetFileSize(huge_file);
 

--- a/test/unittests/t_hash_filters.cc
+++ b/test/unittests/t_hash_filters.cc
@@ -323,7 +323,7 @@ TYPED_TEST(T_HashFilter, FillHeterogeneousWithSuffixes) {
 }
 
 
-TYPED_TEST(T_HashFilter, FillManyRandomHashes) {
+TYPED_TEST(T_HashFilter, FillManyRandomHashesSlow) {
   TypeParam filter;
 
   Prng rng;

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -582,7 +582,7 @@ TYPED_TEST(T_History, RemoveNonExistentTag) {
 }
 
 
-TYPED_TEST(T_History, RemoveMultipleTags) {
+TYPED_TEST(T_History, RemoveMultipleTagsSlow) {
   typedef typename TestFixture::TagVector            TagVector;
   typedef typename TagVector::const_iterator         TagVectorItr;
   typedef typename TagVector::const_reverse_iterator TagVectorRevItr;
@@ -1518,7 +1518,7 @@ TYPED_TEST(T_History, ReadLegacyVersion1Revision1) {
 }
 
 
-TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision0) {
+TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision0Slow) {
   if (TestFixture::IsMocked()) {
     // this is only valid for the production code...
     // the mocked history does not deal with legacy formats
@@ -1557,7 +1557,7 @@ TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision0) {
 }
 
 
-TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision1) {
+TYPED_TEST(T_History, UpgradeAndWriteLegacyVersion1Revision1Slow) {
   if (TestFixture::IsMocked()) {
     // this is only valid for the production code...
     // the mocked history does not deal with legacy formats

--- a/test/unittests/t_lru.cc
+++ b/test/unittests/t_lru.cc
@@ -304,7 +304,7 @@ TEST(T_LruCache, FillCompletely) {
 }
 
 
-TEST(T_LruCache, LeastRecentlyUsedReplacement) {
+TEST(T_LruCache, LeastRecentlyUsedReplacementSlow) {
   LruCache<int, std::string> cache(cache_size, -1, hasher_int);
   EXPECT_TRUE  (cache.IsEmpty());
   EXPECT_FALSE (cache.IsFull());

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -580,13 +580,13 @@ typedef ::testing::Types<
 TYPED_TEST_CASE(T_ObjectFetcher, ObjectFetcherTypes);
 
 
-TYPED_TEST(T_ObjectFetcher, Initialize) {
+TYPED_TEST(T_ObjectFetcher, InitializeSlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   EXPECT_TRUE (object_fetcher.IsValid());
 }
 
 
-TYPED_TEST(T_ObjectFetcher, FetchManifest) {
+TYPED_TEST(T_ObjectFetcher, FetchManifestSlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
@@ -598,7 +598,7 @@ TYPED_TEST(T_ObjectFetcher, FetchManifest) {
 }
 
 
-TYPED_TEST(T_ObjectFetcher, FetchHistory) {
+TYPED_TEST(T_ObjectFetcher, FetchHistorySlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
@@ -610,7 +610,7 @@ TYPED_TEST(T_ObjectFetcher, FetchHistory) {
 }
 
 
-TYPED_TEST(T_ObjectFetcher, FetchLegacyHistory) {
+TYPED_TEST(T_ObjectFetcher, FetchLegacyHistorySlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
@@ -622,7 +622,7 @@ TYPED_TEST(T_ObjectFetcher, FetchLegacyHistory) {
 }
 
 
-TYPED_TEST(T_ObjectFetcher, FetchInvalidHistory) {
+TYPED_TEST(T_ObjectFetcher, FetchInvalidHistorySlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
@@ -633,7 +633,7 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidHistory) {
 }
 
 
-TYPED_TEST(T_ObjectFetcher, FetchCatalog) {
+TYPED_TEST(T_ObjectFetcher, FetchCatalogSlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
@@ -646,7 +646,7 @@ TYPED_TEST(T_ObjectFetcher, FetchCatalog) {
 }
 
 
-TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalog) {
+TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalogSlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE (object_fetcher.IsValid());
 
@@ -657,7 +657,7 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalog) {
 }
 
 
-TYPED_TEST(T_ObjectFetcher, AutoCleanupFetchedFiles) {
+TYPED_TEST(T_ObjectFetcher, AutoCleanupFetchedFilesSlow) {
   if (! TestFixture::NeedsFilesystemSandbox()) {
     // this is only valid if we are actually creating files...
     return;

--- a/test/unittests/t_smallhash.cc
+++ b/test/unittests/t_smallhash.cc
@@ -94,7 +94,7 @@ TEST_F(T_Smallhash, InsertMd5) {
 }
 
 
-TEST_F(T_Smallhash, InsertAndCopyMd5) {
+TEST_F(T_Smallhash, InsertAndCopyMd5Slow) {
   unsigned N = kNumElements;
   for (unsigned i = 0; i < N; ++i) {
     shash::Md5 random_hash;
@@ -163,7 +163,7 @@ TEST_F(T_Smallhash, Lookup) {
 }
 
 
-TEST_F(T_Smallhash, MultihashCycle) {
+TEST_F(T_Smallhash, MultihashCycleSlow) {
   unsigned N = kNumElements;
   for (unsigned i = 0; i < N; ++i) {
     multihash_.Insert(i, i);

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -500,7 +500,7 @@ TEST_F(T_SQLite_Wrapper, FailingSchemaUpdate) {
 }
 
 
-TEST_F(T_SQLite_Wrapper, DataAccess) {
+TEST_F(T_SQLite_Wrapper, DataAccessSlow) {
   // This test case might be dependent on SQLite updates
   // if it fails, check if the data compression or memory page behaviour of
   // SQLite changed...
@@ -544,7 +544,7 @@ TEST_F(T_SQLite_Wrapper, DataAccess) {
 }
 
 
-TEST_F(T_SQLite_Wrapper, VacuumDatabase) {
+TEST_F(T_SQLite_Wrapper, VacuumDatabaseSlow) {
   // This test case might be dependent on SQLite updates
   // if it fails, check if the VACUUM behaviour of SQLite changed...
   const std::string dbp = GetDatabaseFilename();

--- a/test/unittests/t_synchronizing_counter.cc
+++ b/test/unittests/t_synchronizing_counter.cc
@@ -236,7 +236,7 @@ void *thread_wait_for_decrement(void *arg) {
   return NULL;
 }
 
-TEST_F(T_SynchronizingCounter, WaitForDecrement) {
+TEST_F(T_SynchronizingCounter, WaitForDecrementSlow) {
   const unsigned int n_threads = 5;
   SynchronizingCounter<int64_t> counter;
   EXPECT_EQ (0, counter);
@@ -309,7 +309,7 @@ void *thread_wait_for_increment(void *arg) {
 //
 
 
-TEST_F(T_SynchronizingCounter, WaitForIncrement) {
+TEST_F(T_SynchronizingCounter, WaitForIncrementSlow) {
   const unsigned int n_threads = 5;
   SynchronizingCounter<int64_t> counter;
   EXPECT_EQ (0, counter);
@@ -377,7 +377,7 @@ void *concurrent_decrement(void *arg) {
 }
 
 
-TEST_F(T_SynchronizingCounter, MultiThreadCounting) {
+TEST_F(T_SynchronizingCounter, MultiThreadCountingSlow) {
   const int thread_count = 10;
   ASSERT_EQ (0, thread_count % 2);
 

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -125,7 +125,7 @@ void BufferUploadCompleteCallback_T_Callbacks(const UploaderResults &results) {
 }
 
 
-TEST(T_UploadFacility, Callbacks) {
+TEST(T_UploadFacility, CallbacksSlow) {
   UF_MockUploader *uploader = UF_MockUploader::MockConstruct();
 
   ASSERT_NE (static_cast<UF_MockUploader*>(NULL), uploader);

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -719,7 +719,7 @@ TYPED_TEST(T_Uploaders, UploadEmptyFile) {
 //
 
 
-TYPED_TEST(T_Uploaders, UploadHugeFile) {
+TYPED_TEST(T_Uploaders, UploadHugeFileSlow) {
   const std::string huge_file_path = TestFixture::GetHugeFile();
   const std::string dest_name     = "huge_file";
 
@@ -743,7 +743,7 @@ TYPED_TEST(T_Uploaders, UploadHugeFile) {
 //
 
 
-TYPED_TEST(T_Uploaders, UploadManyFiles) {
+TYPED_TEST(T_Uploaders, UploadManyFilesSlow) {
   const unsigned int number_of_files = 500;
   typedef std::vector<std::pair<std::string, std::string> > Files;
 
@@ -856,7 +856,7 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
 //
 
 
-TYPED_TEST(T_Uploaders, MultipleStreamedUpload) {
+TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
   const unsigned int  number_of_files        = 100;
   const unsigned int  max_buffers_per_stream = 15;
   const shash::Suffix hash_suffix            = 'K';


### PR DESCRIPTION
This appends the suffix *Slow* to unit tests that would usually run longer than two seconds. Using this, one can easily filter out these test cases with `cvmfs_unittests --gtest_filter='-*Slow'` and bring the unit test suite runtime down to about one minute.

I was taking a sample from a usual test run of the complete suite. These are the tests that have been disabled:

* T_Atomic.
  *  ConcurrentTransactionalAssignmentsSlow
  *  ConcurrentWriteOfAtomicIntsSlow
* T_Smallhash.
  *  InsertAndCopyMd5Slow
  *  MultihashCycleSlow
* T_ChunkDetectors.
  *  StaticOffsetChunkDetectorSlow
  *  Xor32ChunkDetectorSlow
* T_UploadFacility.
  *  CallbacksSlow
* T_Uploaders/0.  # TypeParam = upload::S3Uploader
  *  UploadHugeFileSlow
  *  UploadManyFilesSlow
  *  MultipleStreamedUploadSlow
* T_Uploaders/1.  # TypeParam = upload::LocalUploader
  *  UploadHugeFileSlow
  *  UploadManyFilesSlow
  *  MultipleStreamedUploadSlow
* T_FileProcessing.
  *  ProcessHugeFileSlow
  *  ProcessMultipleFilesSlow
  *  ProcessMultipeFilesWithoutChunkingSlow
  *  ProcessMultipleFilesInSeparateWavesSlow
* T_AsyncReader.
  *  ReadHugeFileSlow
  *  ReadManyBigFilesSlow
  *  MultipleWaitsSlow
* T_FileSandbox.
  *  HugeFileSlow
* T_SynchronizingCounter.
  *  WaitForDecrementSlow
  *  WaitForIncrementSlow
  *  MultiThreadCountingSlow
* T_BlockingCounter.
  *  BecomeZeroSlow
  *  BlockOnIncrementAndWaitForZeroSlow
  *  OrchestrateMultipleWaitingThreadsSlow
* T_LruCache.
  *  LeastRecentlyUsedReplacementSlow
* T_SQLite_Wrapper.
  *  DataAccessSlow
  *  VacuumDatabaseSlow
* T_History/0.  # TypeParam = history::SqliteHistory
  *  RemoveMultipleTagsSlow
  *  UpgradeAndWriteLegacyVersion1Revision0Slow
  *  UpgradeAndWriteLegacyVersion1Revision1Slow
* T_History/1.  # TypeParam = MockHistory
  *  RemoveMultipleTagsSlow
  *  UpgradeAndWriteLegacyVersion1Revision0Slow
  *  UpgradeAndWriteLegacyVersion1Revision1Slow
* T_HashFilter/0.  # TypeParam = SimpleHashFilter
  *  FillManyRandomHashesSlow
* T_HashFilter/1.  # TypeParam = SmallhashFilter
  *  FillManyRandomHashesSlow
* T_ObjectFetcher/0.  # TypeParam = MockObjectFetcher
  *  InitializeSlow
  *  FetchManifestSlow
  *  FetchHistorySlow
  *  FetchLegacyHistorySlow
  *  FetchInvalidHistorySlow
  *  FetchCatalogSlow
  *  FetchInvalidCatalogSlow
  *  AutoCleanupFetchedFilesSlow
* T_ObjectFetcher/1.  # TypeParam = LocalObjectFetcher<catalog::Catalog, history::SqliteHistory>
  *  InitializeSlow
  *  FetchManifestSlow
  *  FetchHistorySlow
  *  FetchLegacyHistorySlow
  *  FetchInvalidHistorySlow
  *  FetchCatalogSlow
  *  FetchInvalidCatalogSlow
  *  AutoCleanupFetchedFilesSlow
* T_ObjectFetcher/2.  # TypeParam = HttpObjectFetcher<catalog::Catalog, history::SqliteHistory>
  *  InitializeSlow
  *  FetchManifestSlow
  *  FetchHistorySlow
  *  FetchLegacyHistorySlow
  *  FetchInvalidHistorySlow
  *  FetchCatalogSlow
  *  FetchInvalidCatalogSlow
  *  AutoCleanupFetchedFilesSlow