### PR TITLE
Refactor options

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 /**
  * CernVM-FS is a FUSE module which implements an HTTP read-only filesystem.
  * The original idea is based on GROW-FS.
@@ -1867,7 +1866,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   cvmfs::backoff_throttle_ = new BackoffThrottle();
 
   // Option parsing
-  if (cvmfs::loader_exports_->simple_options_parsing) {
+  if (cvmfs::loader_exports_->version >= 3 &&
+      cvmfs::loader_exports_->simple_options_parsing) {
     cvmfs::options_manager_ = new FastOptionsManager();
   } else {
     cvmfs::options_manager_ = new BashOptionsManager();

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1868,7 +1868,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
   // Option parsing
   if (cvmfs::loader_exports_->version >= 3 &&
       cvmfs::loader_exports_->simple_options_parsing) {
-    cvmfs::options_manager_ = new FastOptionsManager();
+    cvmfs::options_manager_ = new SimpleOptionsParser();
   } else {
     cvmfs::options_manager_ = new BashOptionsManager();
   }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 /**
  * CernVM-FS is a FUSE module which implements an HTTP read-only filesystem.
  * The original idea is based on GROW-FS.
@@ -1866,7 +1867,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
   cvmfs::backoff_throttle_ = new BackoffThrottle();
 
   // Option parsing
-  if (cvmfs::loader_exports_->fast_parse) {
+  if (cvmfs::loader_exports_->simple_options_parsing) {
     cvmfs::options_manager_ = new FastOptionsManager();
   } else {
     cvmfs::options_manager_ = new BashOptionsManager();

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1896,7 +1896,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
     SetLogDebugFile(parameter);
   SetLogSyslogPrefix(loader_exports->repository_name);
 
-  LogCvmfs(kLogCvmfs, kLogDebug, "Options:\n%s", cvmfs::options_manager_->Dump().c_str());
+  LogCvmfs(kLogCvmfs, kLogDebug, "Options:\n%s",
+           cvmfs::options_manager_->Dump().c_str());
 
   // Overwrite default options
   if (cvmfs::options_manager_->GetValue("CVMFS_MEMCACHE_SIZE", &parameter))
@@ -2023,7 +2024,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   {
     g_claim_ownership = true;
   }
-  if (cvmfs::options_manager_->GetValue("CVMFS_INITIAL_GENERATION", &parameter)) {
+  if (cvmfs::options_manager_->GetValue("CVMFS_INITIAL_GENERATION",
+                                        &parameter)) {
     initial_generation = String2Uint64(parameter);
   }
   if (cvmfs::options_manager_->GetValue("CVMFS_PROXY_TEMPLATE", &parameter)) {

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -55,7 +55,7 @@ struct CvmfsOptions {
   int grab_mountpoint;
   int cvmfs_suid;
   int disable_watchdog;
-  int fast_parse;
+  int simple_options_parsing;
 
   // Ignored options
   int ign_netdev;
@@ -84,7 +84,7 @@ static struct fuse_opt cvmfs_array_opts[] = {
   CVMFS_SWITCH("grab_mountpoint",  grab_mountpoint),
   CVMFS_SWITCH("cvmfs_suid",       cvmfs_suid),
   CVMFS_SWITCH("disable_watchdog", disable_watchdog),
-  CVMFS_SWITCH("fast_parse",       fast_parse),
+  CVMFS_SWITCH("simple_options_parsing",       simple_options_parsing),
 
   // Ignore these options
   CVMFS_SWITCH("_netdev",          ign_netdev),
@@ -122,7 +122,7 @@ bool grab_mountpoint_ = false;
 bool parse_options_only_ = false;
 bool suid_mode_ = false;
 bool disable_watchdog_ = false;
-bool fast_parse_ = false;
+bool simple_options_parsing_ = false;
 atomic_int32 blocking_;
 atomic_int64 num_operations_;
 void *library_handle_;
@@ -406,7 +406,7 @@ static fuse_args *ParseCmdLine(int argc, char *argv[]) {
   grab_mountpoint_ = cvmfs_options.grab_mountpoint;
   suid_mode_ = cvmfs_options.cvmfs_suid;
   disable_watchdog_ = cvmfs_options.disable_watchdog;
-  fast_parse_ = cvmfs_options.fast_parse;
+  simple_options_parsing_ = cvmfs_options.simple_options_parsing;
 
   return mount_options;
 }
@@ -674,7 +674,7 @@ int main(int argc, char *argv[]) {
 
   string parameter;
   OptionsManager *options_manager;
-  if (fast_parse_) {
+  if (simple_options_parsing_) {
     options_manager = new FastOptionsManager();
   } else {
     options_manager = new BashOptionsManager();
@@ -713,7 +713,7 @@ int main(int argc, char *argv[]) {
   loader_exports_->repository_name = *repository_name_;
   loader_exports_->mount_point = *mount_point_;
   loader_exports_->disable_watchdog = disable_watchdog_;
-  loader_exports_->fast_parse = fast_parse_;
+  loader_exports_->simple_options_parsing = simple_options_parsing_;
   if (config_files_)
     loader_exports_->config_files = *config_files_;
   else

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -78,13 +78,13 @@ enum {
 #define CVMFS_OPT(t, p, v) { t, offsetof(struct CvmfsOptions, p), v }
 #define CVMFS_SWITCH(t, p) { t, offsetof(struct CvmfsOptions, p), 1 }
 static struct fuse_opt cvmfs_array_opts[] = {
-  CVMFS_OPT("config=%s",           config, 0),
-  CVMFS_OPT("uid=%d",              uid, 0),
-  CVMFS_OPT("gid=%d",              gid, 0),
-  CVMFS_SWITCH("grab_mountpoint",  grab_mountpoint),
-  CVMFS_SWITCH("cvmfs_suid",       cvmfs_suid),
-  CVMFS_SWITCH("disable_watchdog", disable_watchdog),
-  CVMFS_SWITCH("simple_options_parsing",       simple_options_parsing),
+  CVMFS_OPT("config=%s",                    config, 0),
+  CVMFS_OPT("uid=%d",                       uid, 0),
+  CVMFS_OPT("gid=%d",                       gid, 0),
+  CVMFS_SWITCH("grab_mountpoint",           grab_mountpoint),
+  CVMFS_SWITCH("cvmfs_suid",                cvmfs_suid),
+  CVMFS_SWITCH("disable_watchdog",          disable_watchdog),
+  CVMFS_SWITCH("simple_options_parsing",    simple_options_parsing),
 
   // Ignore these options
   CVMFS_SWITCH("_netdev",          ign_netdev),

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -675,7 +675,7 @@ int main(int argc, char *argv[]) {
   string parameter;
   OptionsManager *options_manager;
   if (simple_options_parsing_) {
-    options_manager = new FastOptionsManager();
+    options_manager = new SimpleOptionsParser();
   } else {
     options_manager = new BashOptionsManager();
   }

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -140,7 +140,7 @@ struct LoaderExports {
   LoaderExports() :
     version(2),
     size(sizeof(LoaderExports)), boot_time(0), foreground(false),
-    disable_watchdog(false) {}
+    disable_watchdog(false), fast_parse(false) {}
 
   uint32_t version;
   uint32_t size;
@@ -156,6 +156,7 @@ struct LoaderExports {
 
   // added with CernVM-FS 2.1.8 (LoaderExports Version: 2)
   bool disable_watchdog;
+  bool fast_parse;
 };
 
 

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -140,7 +140,7 @@ struct LoaderExports {
   LoaderExports() :
     version(2),
     size(sizeof(LoaderExports)), boot_time(0), foreground(false),
-    disable_watchdog(false), fast_parse(false) {}
+    disable_watchdog(false), simple_options_parsing(false) {}
 
   uint32_t version;
   uint32_t size;
@@ -156,7 +156,7 @@ struct LoaderExports {
 
   // added with CernVM-FS 2.1.8 (LoaderExports Version: 2)
   bool disable_watchdog;
-  bool fast_parse;
+  bool simple_options_parsing;
 };
 
 

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -134,11 +134,12 @@ typedef std::vector<LoadEvent *> EventList;
  * Note: Do not forget to check the version of LoaderExports in cvmfs.cc when
  *       using fields that were not present in version 1
  *
- * CernVM-FS 2.1.8 --> Version 2
+ * CernVM-FS 2.1.8  --> Version 2
+ * CernVM-FS 2.1.21 --> Version 3
  */
 struct LoaderExports {
   LoaderExports() :
-    version(2),
+    version(3),
     size(sizeof(LoaderExports)), boot_time(0), foreground(false),
     disable_watchdog(false), simple_options_parsing(false) {}
 
@@ -156,6 +157,8 @@ struct LoaderExports {
 
   // added with CernVM-FS 2.1.8 (LoaderExports Version: 2)
   bool disable_watchdog;
+
+  // added with CernVM-FS 2.1.21 (LoaderExports Version: 3)
   bool simple_options_parsing;
 };
 

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -28,26 +28,6 @@ using namespace std;  // NOLINT
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-namespace options {
-
-struct ConfigValue {
-  string value;
-  string source;
-};
-
-map<string, ConfigValue> *config_ = NULL;
-
-
-void Init() {
-  config_ = new map<string, ConfigValue>();
-}
-
-
-void Fini() {
-  delete config_;
-  config_ = NULL;
-}
-
 
 static string EscapeShell(const std::string &raw) {
   for (unsigned i = 0, l = raw.length(); i < l; ++i) {
@@ -74,10 +54,38 @@ static string EscapeShell(const std::string &raw) {
 }
 
 
-void ParsePath(const string &config_file, const bool external) {
+void FastOptionsManager::ParsePath(const string &config_file, const bool external) {
+  LogCvmfs(kLogCvmfs, kLogDebug, "Fast-parsing config file %s", config_file.c_str());
+  int retval;
+  string line;
+  FILE *fconfig = fopen(config_file.c_str(), "r");
+  if (fconfig == NULL)
+	return;
+
+  // Read line by line and extract parameters
+  while (GetLineFile(fconfig, &line)) {
+    line = Trim(line);
+    if (line.empty() || line[0] == '#' || line.find("if ") == 0 || line.find(" ") < string::npos)
+      continue;
+    vector<string> tokens = SplitString(line, '=');
+    if (tokens.size() < 2 || tokens.size() > 2)
+      continue;
+
+    ConfigValue value;
+    value.source = config_file;
+    value.value = Trim(tokens[1]);
+    string parameter = Trim(tokens[0]);
+    config_[parameter] = value;
+    retval = setenv(parameter.c_str(), value.value.c_str(), 1);
+    assert(retval == 0);
+  }
+  fclose(fconfig);
+}
+
+
+void BashOptionsManager::ParsePath(const string &config_file, const bool external) {
   LogCvmfs(kLogCvmfs, kLogDebug, "Parsing config file %s", config_file.c_str());
   int retval;
-
   int pipe_open[2];
   int pipe_quit[2];
   pid_t pid_child = 0;
@@ -182,7 +190,7 @@ void ParsePath(const string &config_file, const bool external) {
     const string sh_echo = "echo $" + parameter + "\n";
     WritePipe(fd_stdin, sh_echo.data(), sh_echo.length());
     GetLineFd(fd_stdout, &value.value);
-    (*config_)[parameter] = value;
+    config_[parameter] = value;
     retval = setenv(parameter.c_str(), value.value.c_str(), 1);
     assert(retval == 0);
   }
@@ -194,7 +202,7 @@ void ParsePath(const string &config_file, const bool external) {
 }
 
 
-static bool HasConfigRepository(const string &fqrn, string *config_path) {
+bool OptionsManager::HasConfigRepository(const string &fqrn, string *config_path) {
   string cvmfs_mount_dir;
   if (!GetValue("CVMFS_MOUNT_DIR", &cvmfs_mount_dir)) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "CVMFS_MOUNT_DIR missing");
@@ -219,7 +227,7 @@ static bool HasConfigRepository(const string &fqrn, string *config_path) {
 }
 
 
-void ParseDefault(const string &fqrn) {
+void OptionsManager::ParseDefault(const string &fqrn) {
   int retval = setenv("CVMFS_FQRN", fqrn.c_str(), 1);
   assert(retval == 0);
 
@@ -251,20 +259,20 @@ void ParseDefault(const string &fqrn) {
 }
 
 
-void ClearConfig() {
-  config_->clear();
+void OptionsManager::ClearConfig() {
+  config_.clear();
 }
 
 
-bool IsDefined(const std::string &key) {
-  map<string, ConfigValue>::const_iterator iter = config_->find(key);
-  return iter != config_->end();
+bool OptionsManager::IsDefined(const std::string &key) {
+  map<string, ConfigValue>::const_iterator iter = config_.find(key);
+  return iter != config_.end();
 }
 
 
-bool GetValue(const string &key, string *value) {
-  map<string, ConfigValue>::const_iterator iter = config_->find(key);
-  if (iter != config_->end()) {
+bool OptionsManager::GetValue(const string &key, string *value) {
+  map<string, ConfigValue>::const_iterator iter = config_.find(key);
+  if (iter != config_.end()) {
     *value = iter->second.value;
     return true;
   }
@@ -273,9 +281,9 @@ bool GetValue(const string &key, string *value) {
 }
 
 
-bool GetSource(const string &key, string *value) {
-  map<string, ConfigValue>::const_iterator iter = config_->find(key);
-  if (iter != config_->end()) {
+bool OptionsManager::GetSource(const string &key, string *value) {
+  map<string, ConfigValue>::const_iterator iter = config_.find(key);
+  if (iter != config_.end()) {
     *value = iter->second.source;
     return true;
   }
@@ -284,16 +292,16 @@ bool GetSource(const string &key, string *value) {
 }
 
 
-bool IsOn(const std::string &param_value) {
+bool OptionsManager::IsOn(const std::string &param_value) {
   const string uppercase = ToUpper(param_value);
   return ((uppercase == "YES") || (uppercase == "ON") || (uppercase == "1"));
 }
 
 
-vector<string> GetAllKeys() {
+vector<string> OptionsManager::GetAllKeys() {
   vector<string> result;
-  for (map<string, ConfigValue>::const_iterator i = config_->begin(),
-       iEnd = config_->end(); i != iEnd; ++i)
+  for (map<string, ConfigValue>::const_iterator i = config_.begin(),
+       iEnd = config_.end(); i != iEnd; ++i)
   {
     result.push_back(i->first);
   }
@@ -301,7 +309,7 @@ vector<string> GetAllKeys() {
 }
 
 
-string Dump() {
+string OptionsManager::Dump() {
   string result;
   vector<string> keys = GetAllKeys();
   for (unsigned i = 0, l = keys.size(); i < l; ++i) {
@@ -320,7 +328,7 @@ string Dump() {
 }
 
 
-bool ParseUIntMap(const string &path, map<uint64_t, uint64_t> *map) {
+bool OptionsManager::ParseUIntMap(const string &path, map<uint64_t, uint64_t> *map) {
   assert(map);
 
   FILE *fmap = fopen(path.c_str(), "r");
@@ -345,8 +353,6 @@ bool ParseUIntMap(const string &path, map<uint64_t, uint64_t> *map) {
   fclose(fmap);
   return true;
 }
-
-}  // namespace options
 
 #ifdef CVMFS_NAMESPACE_GUARD
 }

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -16,7 +16,6 @@
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
-#include <map>
 
 #include "logging.h"
 #include "sanitizer.h"
@@ -54,7 +53,8 @@ static string EscapeShell(const std::string &raw) {
 }
 
 
-void FastOptionsManager::ParsePath(const string &config_file, const bool external) {
+void FastOptionsManager::ParsePath(const string &config_file,
+                                   const bool external __attribute__((unused))) {
   LogCvmfs(kLogCvmfs, kLogDebug, "Fast-parsing config file %s", config_file.c_str());
   int retval;
   string line;
@@ -65,7 +65,7 @@ void FastOptionsManager::ParsePath(const string &config_file, const bool externa
   // Read line by line and extract parameters
   while (GetLineFile(fconfig, &line)) {
     line = Trim(line);
-    if (line.empty() || line[0] == '#' || line.find("if ") == 0 || line.find(" ") < string::npos)
+    if (line.empty() || line[0] == '#' || line.find(" ") < string::npos)
       continue;
     vector<string> tokens = SplitString(line, '=');
     if (tokens.size() < 2 || tokens.size() > 2)
@@ -73,8 +73,8 @@ void FastOptionsManager::ParsePath(const string &config_file, const bool externa
 
     ConfigValue value;
     value.source = config_file;
-    value.value = Trim(tokens[1]);
-    string parameter = Trim(tokens[0]);
+    value.value = tokens[1];
+    string parameter = tokens[0];
     config_[parameter] = value;
     retval = setenv(parameter.c_str(), value.value.c_str(), 1);
     assert(retval == 0);

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -53,7 +53,7 @@ static string EscapeShell(const std::string &raw) {
 }
 
 
-void FastOptionsManager::ParsePath(const string &config_file,
+void SimpleOptionsParser::ParsePath(const string &config_file,
                                  const bool external __attribute__((unused))) {
   LogCvmfs(kLogCvmfs, kLogDebug, "Fast-parsing config file %s",
       config_file.c_str());

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -60,7 +60,7 @@ void FastOptionsManager::ParsePath(const string &config_file,
   string line;
   FILE *fconfig = fopen(config_file.c_str(), "r");
   if (fconfig == NULL)
-	return;
+    return;
 
   // Read line by line and extract parameters
   while (GetLineFile(fconfig, &line)) {

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -54,8 +54,9 @@ static string EscapeShell(const std::string &raw) {
 
 
 void FastOptionsManager::ParsePath(const string &config_file,
-                                   const bool external __attribute__((unused))) {
-  LogCvmfs(kLogCvmfs, kLogDebug, "Fast-parsing config file %s", config_file.c_str());
+                                 const bool external __attribute__((unused))) {
+  LogCvmfs(kLogCvmfs, kLogDebug, "Fast-parsing config file %s",
+      config_file.c_str());
   int retval;
   string line;
   FILE *fconfig = fopen(config_file.c_str(), "r");
@@ -83,7 +84,8 @@ void FastOptionsManager::ParsePath(const string &config_file,
 }
 
 
-void BashOptionsManager::ParsePath(const string &config_file, const bool external) {
+void BashOptionsManager::ParsePath(const string &config_file,
+                                   const bool external) {
   LogCvmfs(kLogCvmfs, kLogDebug, "Parsing config file %s", config_file.c_str());
   int retval;
   int pipe_open[2];
@@ -202,7 +204,8 @@ void BashOptionsManager::ParsePath(const string &config_file, const bool externa
 }
 
 
-bool OptionsManager::HasConfigRepository(const string &fqrn, string *config_path) {
+bool OptionsManager::HasConfigRepository(const string &fqrn,
+                                         string *config_path) {
   string cvmfs_mount_dir;
   if (!GetValue("CVMFS_MOUNT_DIR", &cvmfs_mount_dir)) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "CVMFS_MOUNT_DIR missing");
@@ -328,7 +331,8 @@ string OptionsManager::Dump() {
 }
 
 
-bool OptionsManager::ParseUIntMap(const string &path, map<uint64_t, uint64_t> *map) {
+bool OptionsManager::ParseUIntMap(const string &path,
+    map<uint64_t, uint64_t> *map) {
   assert(map);
 
   FILE *fmap = fopen(path.c_str(), "r");

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -20,18 +20,10 @@ namespace CVMFS_NAMESPACE_GUARD {
  * and stores the information contained in different config files, keeping
  * the last parsed file that changed each property. It stores the information
  * in a key-value map so that for each variable name the value and last source
- * are stored.
+ * are stored, and makes each property part of the program's environments
  */
 class OptionsManager {
  public:
-  /**
-   * The ConfigValue structure contains a concrete value of a variable, as well
-   * as the source (complete path) of the config file where it was obtained.
-   */
-  struct ConfigValue {
-    std::string value;
-    std::string source;
-  };
 
   OptionsManager() {}
   virtual ~OptionsManager() {}
@@ -46,15 +38,15 @@ class OptionsManager {
    *                     repository. If false the configuration file is in /etc
    */
   virtual void ParsePath(const std::string &config_file,
-      const bool external) = 0;
+                         const bool external) = 0;
 
   /**
-   * Parses the default config files for cvmfs.
+   * Parses the default config files for cvmfs
    */
   void ParseDefault(const std::string &fqrn);
 
   /**
-   * Cleans all information about the variables.
+   * Cleans all information about the variables
    */
   void ClearConfig();
 
@@ -62,7 +54,7 @@ class OptionsManager {
    * Checks if a concrete key (variable) is defined
    *
    * @param   key variable to be checked in the map
-   * @return  true if there is a value for key, false otherwise.
+   * @return  true if there is a value for key, false otherwise
    */
   bool IsDefined(const std::string &key);
 
@@ -89,12 +81,12 @@ class OptionsManager {
    * Checks if a variable contains a boolean value
    *
    * @param   param_value variable to be accessed in the map
-   * @return  true if param has as value "YES", "ON" or "1". False otherwise.
+   * @return  true if param has as value "YES", "ON" or "1". False otherwise
    */
   bool IsOn(const std::string &param_value);
 
   /**
-   * Retrieves a vector containing all stored keys.
+   * Retrieves a vector containing all stored keys
    *
    * @return a vector with all keys contained in the map
    */
@@ -106,24 +98,32 @@ class OptionsManager {
    *
    * "KEY=VALUE    # from SOURCE"
    *
-   * @return a vector containing all key-values in a string format.
+   * @return a vector containing all key-values in a string format
    */
   std::string Dump();
 
   /**
-   * Parse a configuration file whose variables's values are positive integers
+   * Parse a configuration file whose variables' values are positive integers
    *
    * @param  path absolute path to the configuration file
    * @param  map map to store the generated key-value
    * @return true if the file exists, is readable and all values can be parsed
-   *  to integers
+   *         to integers
    */
   bool ParseUIntMap(const std::string &path, std::map<uint64_t, uint64_t> *map);
 
  protected:
+  /**
+    * The ConfigValue structure contains a concrete value of a variable, as well
+    * as the source (complete path) of the config file where it was obtained
+    */
+   struct ConfigValue {
+     std::string value;
+     std::string source;
+   };
+
   bool HasConfigRepository(const std::string &fqrn, std::string *config_path);
 
- protected:
   std::map<std::string, ConfigValue> config_;
 };  // class OptionManager
 
@@ -139,32 +139,26 @@ class OptionsManager {
  *  No comments (#) are allowed.
  *
  *  @note In order to use this parse it is necessary to execute the program
- *  with the "-o simple_options_parsing" flag
+ *        with the "-o simple_options_parsing" flag
  *  @note If using IgProf profiling tool it is necessary to use this parser in
- *  order to avoid a fork.
+ *        order to avoid a fork
  */
-class FastOptionsManager : public OptionsManager {
+class SimpleOptionsParser : public OptionsManager {
  public:
   void ParsePath(const std::string &config_file, const bool external);
-};  // class FastOptionManager
+};  // class SimpleOptionsManager
 
 
 /**
- * Derived class from OptionsManager. This class provides the original an most
+ * Derived class from OptionsManager. This class provides the
  * complete parsing of the configuration files. In order to parse the
  * configuration files it retrieves the "KEY=VALUE" pairs and uses bash for
- * the rest, so that you can execute sightly complex scripts.
- *
- * @note if no "-o simple_options_parsing" flag is passed to the program this
- * class will parse the configuration files by default
- *
- * @note do not use this class if profiling with IgProf. Instead use the
- * FastOptionsManager class
+ * the rest, so that you can execute sightly complex scripts
  */
 class BashOptionsManager : public OptionsManager {
  public:
   void ParsePath(const std::string &config_file, const bool external);
-};  // class BashOptionManager
+};  // class BashOptionsManager
 
 
 

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -15,9 +15,19 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-
+/**
+ * This is the abstract base class for the different option parsers. It parses
+ * and stores the information contained in different config files, keeping
+ * the last parsed file that changed each property. It stores the information
+ * in a key-value map so that for each variable name the value and last source
+ * are stored.
+ */
 class OptionsManager {
  public:
+  /**
+   * The ConfigValue structure contains a concrete value of a variable, as well
+   * as the source (complete path) of the config file where it was obtained.
+   */
   struct ConfigValue {
     std::string value;
     std::string source;
@@ -26,16 +36,88 @@ class OptionsManager {
   OptionsManager() {}
   virtual ~OptionsManager() {}
 
-  virtual void ParsePath(const std::string &config_file, const bool external) = 0;
+  /**
+   * Opens the config_file and extracts all contained variables and their
+   * corresponding values. The new variables are set (and overwritten in case
+   * they were previously defined) as environment variables
+   *
+   * @param config_file  absolute path to the configuration file
+   * @param external     if true it indicates the configuration file is in the
+   *                     repository. If false the configuration file is in /etc
+   */
+  virtual void ParsePath(const std::string &config_file,
+      const bool external) = 0;
+
+  /**
+   * Parses the default config files for cvmfs.
+   */
   void ParseDefault(const std::string &fqrn);
+
+  /**
+   * Cleans all information about the variables.
+   */
   void ClearConfig();
+
+  /**
+   * Checks if a concrete key (variable) is defined
+   *
+   * @param   key variable to be checked in the map
+   * @return  true if there is a value for key, false otherwise.
+   */
   bool IsDefined(const std::string &key);
+
+  /**
+   * Gets the stored value for a concrete variable
+   *
+   * @param  key variable to be accessed in the map
+   * @param  value container of the received value, if it exists
+   * @return true if there was a value stored in the map for key
+   */
   bool GetValue(const std::string &key, std::string *value);
+
+  /**
+   * Gets the stored last source of a concrete variable
+   *
+   * @param  key variable to be accessed in the map
+   * @param  value container of the received value, if it exists
+   * @return true if that variable was previously defined in
+   *         at least one source
+   */
   bool GetSource(const std::string &key, std::string *value);
+
+  /**
+   * Checks if a variable contains a boolean value
+   *
+   * @param   param_value variable to be accessed in the map
+   * @return  true if param has as value "YES", "ON" or "1". False otherwise.
+   */
   bool IsOn(const std::string &param_value);
+
+  /**
+   * Retrieves a vector containing all stored keys.
+   *
+   * @return a vector with all keys contained in the map
+   */
   std::vector<std::string> GetAllKeys();
+
+  /**
+   * Gets all stored key-values of the map in an string format. This format
+   * follows the following pattern:
+   *
+   * "KEY=VALUE    # from SOURCE"
+   *
+   * @return a vector containing all key-values in a string format.
+   */
   std::string Dump();
 
+  /**
+   * Parse a configuration file whose variables's values are positive integers
+   *
+   * @param  path absolute path to the configuration file
+   * @param  map map to store the generated key-value
+   * @return true if the file exists, is readable and all values can be parsed
+   *  to integers
+   */
   bool ParseUIntMap(const std::string &path, std::map<uint64_t, uint64_t> *map);
 
  protected:
@@ -46,14 +128,39 @@ class OptionsManager {
 };  // class OptionManager
 
 
-
+/**
+ * Derived class from OptionsManager. This class provides a so-called fast
+ * parsing procedure which does not create a fork of the process and only
+ * retrieves those options of the configuration file which strictly are in the
+ * following format:
+ *
+ *  "KEY=VALUE".
+ *
+ *  No comments (#) are allowed.
+ *
+ *  @note In order to use this parse it is necessary to execute the program
+ *  with the "-o simple_options_parsing" flag
+ *  @note If using IgProf profiling tool it is necessary to use this parser in
+ *  order to avoid a fork.
+ */
 class FastOptionsManager : public OptionsManager {
  public:
   void ParsePath(const std::string &config_file, const bool external);
 };  // class FastOptionManager
 
 
-
+/**
+ * Derived class from OptionsManager. This class provides the original an most
+ * complete parsing of the configuration files. In order to parse the
+ * configuration files it retrieves the "KEY=VALUE" pairs and uses bash for
+ * the rest, so that you can execute sightly complex scripts.
+ *
+ * @note if no "-o simple_options_parsing" flag is passed to the program this
+ * class will parse the configuration files by default
+ *
+ * @note do not use this class if profiling with IgProf. Instead use the
+ * FastOptionsManager class
+ */
 class BashOptionsManager : public OptionsManager {
  public:
   void ParsePath(const std::string &config_file, const bool external);

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -6,7 +6,7 @@
 #define CVMFS_OPTIONS_H_
 
 #include <stdint.h>
-#include <map>
+
 #include <string>
 #include <vector>
 #include <map>
@@ -15,19 +15,15 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-struct ConfigValue {
-  std::string value;
-  std::string source;
-};
 
 class OptionsManager {
+ public:
+  struct ConfigValue {
+    std::string value;
+    std::string source;
+  };
 
-protected:
-  bool HasConfigRepository(const std::string &fqrn, std::string *config_path);
-
-public:
-  OptionsManager() :
-    config_(std::map<std::string, ConfigValue>()) {}
+  OptionsManager() {}
   virtual ~OptionsManager() {}
 
   virtual void ParsePath(const std::string &config_file, const bool external) = 0;
@@ -42,27 +38,25 @@ public:
 
   bool ParseUIntMap(const std::string &path, std::map<uint64_t, uint64_t> *map);
 
-protected:
-  std::map<std::string, ConfigValue> config_;
+ protected:
+  bool HasConfigRepository(const std::string &fqrn, std::string *config_path);
 
+ protected:
+  std::map<std::string, ConfigValue> config_;
 };  // class OptionManager
 
 
 
 class FastOptionsManager : public OptionsManager {
-
-public:
+ public:
   void ParsePath(const std::string &config_file, const bool external);
-
 };  // class FastOptionManager
 
 
 
 class BashOptionsManager : public OptionsManager {
-
-public:
+ public:
   void ParsePath(const std::string &config_file, const bool external);
-
 };  // class BashOptionManager
 
 

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -6,7 +6,7 @@
 #define CVMFS_OPTIONS_H_
 
 #include <stdint.h>
-
+#include <map>
 #include <string>
 #include <vector>
 #include <map>
@@ -15,24 +15,57 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-namespace options {
+struct ConfigValue {
+  std::string value;
+  std::string source;
+};
 
-void Init();
-void Fini();
+class OptionsManager {
 
-void ParsePath(const std::string &config_file, const bool external);
-void ParseDefault(const std::string &fqrn);
-void ClearConfig();
-bool IsDefined(const std::string &key);
-bool GetValue(const std::string &key, std::string *value);
-bool GetSource(const std::string &key, std::string *value);
-bool IsOn(const std::string &param_value);
-std::vector<std::string> GetAllKeys();
-std::string Dump();
+protected:
+  bool HasConfigRepository(const std::string &fqrn, std::string *config_path);
 
-bool ParseUIntMap(const std::string &path, std::map<uint64_t, uint64_t> *map);
+public:
+  OptionsManager() :
+    config_(std::map<std::string, ConfigValue>()) {}
+  virtual ~OptionsManager() {}
 
-}  // namespace options
+  virtual void ParsePath(const std::string &config_file, const bool external) = 0;
+  void ParseDefault(const std::string &fqrn);
+  void ClearConfig();
+  bool IsDefined(const std::string &key);
+  bool GetValue(const std::string &key, std::string *value);
+  bool GetSource(const std::string &key, std::string *value);
+  bool IsOn(const std::string &param_value);
+  std::vector<std::string> GetAllKeys();
+  std::string Dump();
+
+  bool ParseUIntMap(const std::string &path, std::map<uint64_t, uint64_t> *map);
+
+protected:
+  std::map<std::string, ConfigValue> config_;
+
+};  // class OptionManager
+
+
+
+class FastOptionsManager : public OptionsManager {
+
+public:
+  void ParsePath(const std::string &config_file, const bool external);
+
+};  // class FastOptionManager
+
+
+
+class BashOptionsManager : public OptionsManager {
+
+public:
+  void ParsePath(const std::string &config_file, const bool external);
+
+};  // class BashOptionManager
+
+
 
 #ifdef CVMFS_NAMESPACE_GUARD
 }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -56,6 +56,7 @@ const unsigned kMaxCommandSize = 512;
 string *cachedir_ = NULL;  /**< Stores the cache directory from cvmfs.
                                 Pipe files will be created here. */
 string *socket_path_ = NULL;  /**< $cache_dir/cvmfs_io */
+OptionsManager *options_manager_ = NULL;
 int socket_fd_;
 pthread_t thread_talk_;
 bool spawned_;
@@ -473,7 +474,7 @@ static void *MainTalk(void *data __attribute__((unused))) {
         const string pid_str = StringifyInt(monitor::GetPid()) + "\n";
         Answer(con_fd, pid_str);
       } else if (line == "parameters") {
-        Answer(con_fd, options::Dump());
+        Answer(con_fd, options_manager_->Dump());
       } else if (line == "hotpatch history") {
         string history_str =
           StringifyTime(cvmfs::loader_exports_->boot_time, true) +
@@ -510,11 +511,12 @@ static void *MainTalk(void *data __attribute__((unused))) {
 /**
  * Init the socket.
  */
-bool Init(const string &cachedir) {
+bool Init(const string &cachedir, OptionsManager *options_manager) {
   if (initialized_) return true;
   spawned_ = false;
   cachedir_ = new string(cachedir);
   socket_path_ = new string(cachedir + "/cvmfs_io." + *cvmfs::repository_name_);
+  options_manager_ = options_manager;
 
   socket_fd_ = MakeSocket(*socket_path_, 0660);
   if (socket_fd_ == -1)

--- a/cvmfs/talk.h
+++ b/cvmfs/talk.h
@@ -7,9 +7,11 @@
 
 #include <string>
 
+class OptionsManager;
+
 namespace talk {
 
-bool Init(const std::string &cachedir);
+bool Init(const std::string &cachedir, OptionsManager *options_manager);
 void Spawn();
 void Fini();
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -69,20 +69,20 @@ bool S3Uploader::ParseSpoolerDefinition(
 
   // Parse S3 configuration
   // TODO: separate option handling and sanity checks
-  options::Init();
-  options::ParsePath(config_path, false);
+  OptionsManager *options_manager = new BashOptionsManager();
+  options_manager->ParsePath(config_path, false);
   std::string parameter;
   std::string s3_host;
-  if (!options::GetValue("CVMFS_S3_HOST", &s3_host)) {
+  if (!options_manager->GetValue("CVMFS_S3_HOST", &s3_host)) {
     LogCvmfs(kLogSpooler, kLogStderr, "Failed to parse CVMFS_S3_HOST from '%s'",
              config_path.c_str());
     return false;
   }
   const std::string kStandardPort = "80";
   std::string s3_port = kStandardPort;
-  options::GetValue("CVMFS_S3_PORT", &s3_port);
+  options_manager->GetValue("CVMFS_S3_PORT", &s3_port);
   int s3_buckets_per_account = 1;
-  if (options::GetValue("CVMFS_S3_BUCKETS_PER_ACCOUNT", &parameter)) {
+  if (options_manager->GetValue("CVMFS_S3_BUCKETS_PER_ACCOUNT", &parameter)) {
     s3_buckets_per_account = String2Uint64(parameter);
     if (s3_buckets_per_account < 1 || s3_buckets_per_account > 100) {
       LogCvmfs(kLogSpooler, kLogStderr,
@@ -95,26 +95,26 @@ bool S3Uploader::ParseSpoolerDefinition(
     }
   }
   std::string s3_access_key;
-  if (!options::GetValue("CVMFS_S3_ACCESS_KEY", &s3_access_key)) {
+  if (!options_manager->GetValue("CVMFS_S3_ACCESS_KEY", &s3_access_key)) {
     LogCvmfs(kLogSpooler, kLogStderr,
              "Failed to parse CVMFS_S3_ACCESS_KEY from '%s'.",
              config_path.c_str());
     return false;
   }
   std::string s3_secret_key;
-  if (!options::GetValue("CVMFS_S3_SECRET_KEY", &s3_secret_key)) {
+  if (!options_manager->GetValue("CVMFS_S3_SECRET_KEY", &s3_secret_key)) {
     LogCvmfs(kLogSpooler, kLogStderr,
              "Failed to parse CVMFS_S3_SECRET_KEY from '%s'.",
              config_path.c_str());
     return false;
   }
-  if (!options::GetValue("CVMFS_S3_BUCKET", &bucket_body_name_)) {
+  if (!options_manager->GetValue("CVMFS_S3_BUCKET", &bucket_body_name_)) {
     LogCvmfs(kLogSpooler, kLogStderr,
              "Failed to parse CVMFS_S3_BUCKET from '%s'.",
              config_path.c_str());
     return false;
   }
-  if (!options::GetValue("CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS",
+  if (!options_manager->GetValue("CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS",
                          &parameter)) {
     LogCvmfs(kLogSpooler, kLogStderr, "Failed to parse "
              "CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS "
@@ -123,7 +123,8 @@ bool S3Uploader::ParseSpoolerDefinition(
     return false;
   }
   max_num_parallel_uploads_ = String2Uint64(parameter);
-  options::Fini();
+  delete options_manager;
+  options_manager = NULL;
 
   std::vector<std::string> s3_access_keys = SplitString(s3_access_key, ':');
   std::vector<std::string> s3_secret_keys = SplitString(s3_secret_key, ':');

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -27,6 +27,8 @@
 
 using namespace std;  // NOLINT
 
+BashOptionsManager options_manager_;
+
 static void Usage(int output_dest) {
   LogCvmfs(kLogCvmfs, output_dest,
            "Mount helper for CernVM-FS.  Used my mount(8)\n"
@@ -51,7 +53,7 @@ static string MkFqrn(const string &repository) {
   const string::size_type idx = repository.find_last_of('.');
   if (idx == string::npos) {
     string domain;
-    bool retval = options::GetValue("CVMFS_DEFAULT_DOMAIN", &domain);
+    bool retval = options_manager_.GetValue("CVMFS_DEFAULT_DOMAIN", &domain);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
                "CVMFS_DEFAULT_DOMAIN missing");
@@ -88,11 +90,11 @@ static bool CheckFuse() {
 
 static bool CheckStrictMount(const string &fqrn) {
   string param_strict_mount;
-  if (options::GetValue("CVMFS_STRICT_MOUNT", &param_strict_mount) &&
-      options::IsOn(param_strict_mount))
+  if (options_manager_.GetValue("CVMFS_STRICT_MOUNT", &param_strict_mount) &&
+      options_manager_.IsOn(param_strict_mount))
   {
     string repository_list;
-    bool retval = options::GetValue("CVMFS_REPOSITORIES", &repository_list);
+    bool retval = options_manager_.GetValue("CVMFS_REPOSITORIES", &repository_list);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr, "CVMFS_REPOSITORIES missing");
       return false;
@@ -103,7 +105,7 @@ static bool CheckStrictMount(const string &fqrn) {
         return true;
     }
     string config_repository;
-    retval = options::GetValue("CVMFS_CONFIG_REPOSITORY", &config_repository);
+    retval = options_manager_.GetValue("CVMFS_CONFIG_REPOSITORY", &config_repository);
     if (retval && (config_repository == fqrn))
       return true;
     LogCvmfs(kLogCvmfs, kLogStderr, "Not allowed to mount %s, "
@@ -116,7 +118,7 @@ static bool CheckStrictMount(const string &fqrn) {
 
 static bool CheckProxy() {
   string param;
-  int retval = options::GetValue("CVMFS_HTTP_PROXY", &param);
+  int retval = options_manager_.GetValue("CVMFS_HTTP_PROXY", &param);
   if (!retval) {
     LogCvmfs(kLogCvmfs, kLogStderr, "CVMFS_HTTP_PROXY required");
     return false;
@@ -150,14 +152,14 @@ static bool CheckConcurrentMount(const string &fqrn, const string &cachedir) {
 
 static bool GetCacheDir(const string &fqrn, string *cachedir) {
   string param;
-  int retval = options::GetValue("CVMFS_CACHE_BASE", &param);
+  int retval = options_manager_.GetValue("CVMFS_CACHE_BASE", &param);
   if (!retval) {
     LogCvmfs(kLogCvmfs, kLogStderr, "CVMFS_CACHE_BASE required");
     return false;
   }
   *cachedir = MakeCanonicalPath(param);
-  if (options::GetValue("CVMFS_SHARED_CACHE", &param) &&
-      options::IsOn(param))
+  if (options_manager_.GetValue("CVMFS_SHARED_CACHE", &param) &&
+      options_manager_.IsOn(param))
   {
     *cachedir = *cachedir + "/shared";
   } else {
@@ -169,7 +171,7 @@ static bool GetCacheDir(const string &fqrn, string *cachedir) {
 
 static bool WaitForReload(const std::string &mountpoint) {
   string param;
-  int retval = options::GetValue("CVMFS_RELOAD_SOCKETS", &param);
+  int retval = options_manager_.GetValue("CVMFS_RELOAD_SOCKETS", &param);
   if (!retval) {
     LogCvmfs(kLogCvmfs, kLogStderr, "CVMFS_RELOAD_SOCKETS required");
     return false;
@@ -198,7 +200,7 @@ static bool WaitForReload(const std::string &mountpoint) {
 
 static bool GetCvmfsUser(string *cvmfs_user) {
   string param;
-  int retval = options::GetValue("CVMFS_USER", &param);
+  int retval = options_manager_.GetValue("CVMFS_USER", &param);
   if (!retval) {
     LogCvmfs(kLogCvmfs, kLogStderr, "CVMFS_USER required");
     return false;
@@ -252,10 +254,9 @@ int main(int argc, char **argv) {
   }
   string mountpoint = argv[optind+1];
 
-  options::Init();
-  options::ParseDefault("");
+  options_manager_.ParseDefault("");
   const string fqrn = MkFqrn(device);
-  options::ParseDefault(fqrn);
+  options_manager_.ParseDefault(fqrn);
 
   int retval;
   int sysret;
@@ -323,7 +324,7 @@ int main(int argc, char **argv) {
   // Set maximum number of files
 #ifdef __APPLE__
   string param;
-  if (options::GetValue("CVMFS_NFILES", &param)) {
+  if (options_manager_.GetValue("CVMFS_NFILES", &param)) {
     sanitizer::IntegerSanitizer integer_sanitizer;
     if (!integer_sanitizer.IsValid(param)) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Invalid CVMFS_NFILES: %s",
@@ -376,10 +377,10 @@ int main(int argc, char **argv) {
   AddMountOption("grab_mountpoint", &mount_options);
   AddMountOption("uid=" + StringifyInt(uid_cvmfs), &mount_options);
   AddMountOption("gid=" + StringifyInt(gid_cvmfs), &mount_options);
-  if (options::IsDefined("CVMFS_DEBUGLOG"))
+  if (options_manager_.IsDefined("CVMFS_DEBUGLOG"))
     AddMountOption("debug", &mount_options);
 
-  const string cvmfs_binary = "/usr/bin/cvmfs2";;
+  const string cvmfs_binary = "/usr/bin/cvmfs2";
 
   // Dry run early exit
   if (dry_run) {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -57,6 +57,7 @@ set (CVMFS_UNITTEST_SOURCES
   t_catalog_sql.cc
   t_xattr.cc
   t_statistics.cc
+  t_options.cc
 
   # test utility functions
   testutil.cc testutil.h

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -14,7 +14,8 @@ using namespace std;  // NOLINT
 class T_Options : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    FILE *temp_file = CreateTempFile("/tmp/cvmfs-test", 0600, "w", &config_file_);
+    FILE *temp_file = CreateTempFile("/tmp/cvmfs-test", 0600, "w",
+        &config_file_);
     ASSERT_TRUE(temp_file != NULL);
     unlink_guard_.Set(config_file_);
     fprintf(temp_file,

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -10,17 +10,13 @@
 
 using namespace std;  // NOLINT
 
-namespace options {
 
 class T_Options : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    string filename;
-    FILE *temp_file = CreateTempFile("/tmp/cvmfs-test", 0600, "w", &filename);
+    FILE *temp_file = CreateTempFile("/tmp/cvmfs-test", 0600, "w", &config_file_);
     ASSERT_TRUE(temp_file != NULL);
-    config_file = filename;
-	unlink_guard.Set(filename);
-
+    unlink_guard_.Set(config_file_);
     fprintf(temp_file,
     		"CVMFS_CACHE_BASE=/root/cvmfs_testing/cache\n"
             "CVMFS_RELOAD_SOCKETS=/root/cvmfs_testing/cache\n"
@@ -32,59 +28,76 @@ class T_Options : public ::testing::Test {
             "CVMFS_SHARED_CACHE=no\n"
             "CVMFS_HTTP_PROXY=DIRECT\n"
 			"export A=B\n");
-    fflush(temp_file);
-    fclose(temp_file);
+    int result = fclose(temp_file);
+    ASSERT_EQ(0, result);
   }
 
  protected:
-  FastOptionsManager options_manager;
-  UnlinkGuard unlink_guard;
-  string config_file;
-
+  BashOptionsManager    bash_options_manager_;
+  FastOptionsManager    fast_options_manager_;
+  UnlinkGuard           unlink_guard_;
+  string                config_file_;
 };  // class T_Options
 
 
-TEST_F(T_Options, ParsePathSimple) {
+void Parse(OptionsManager* options_manager, string config_file,
+    unsigned expected_number_elements) {
   string container;
-  options_manager.ParsePath(config_file, false);
+  options_manager->ParsePath(config_file, false);
+  ASSERT_EQ(expected_number_elements, options_manager->GetAllKeys().size());
 
-  ASSERT_EQ(6u, options_manager.GetAllKeys().size());
-
-  EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &container));
+  EXPECT_TRUE(options_manager->GetValue("CVMFS_CACHE_BASE", &container));
   EXPECT_EQ("/root/cvmfs_testing/cache", container);
-  EXPECT_TRUE(options_manager.GetSource("CVMFS_CACHE_BASE", &container));
+  EXPECT_TRUE(options_manager->GetSource("CVMFS_CACHE_BASE", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager.GetValue("CVMFS_RELOAD_SOCKETS", &container));
+  EXPECT_TRUE(options_manager->GetValue("CVMFS_RELOAD_SOCKETS", &container));
   EXPECT_EQ("/root/cvmfs_testing/cache", container);
-  EXPECT_TRUE(options_manager.GetSource("CVMFS_RELOAD_SOCKETS", &container));
+  EXPECT_TRUE(options_manager->GetSource("CVMFS_RELOAD_SOCKETS", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager.GetValue("CVMFS_SERVER_URL", &container));
+  EXPECT_TRUE(options_manager->GetValue("CVMFS_SERVER_URL", &container));
   EXPECT_EQ("http://volhcb28:3128/data", container);
-  EXPECT_TRUE(options_manager.GetSource("CVMFS_SERVER_URL", &container));
+  EXPECT_TRUE(options_manager->GetSource("CVMFS_SERVER_URL", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager.GetValue("CVMFS_SHARED_CACHE", &container));
+  EXPECT_TRUE(options_manager->GetValue("CVMFS_SHARED_CACHE", &container));
   EXPECT_EQ("no", container);
-  EXPECT_TRUE(options_manager.GetSource("CVMFS_SHARED_CACHE", &container));
+  EXPECT_TRUE(options_manager->GetSource("CVMFS_SHARED_CACHE", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager.GetValue("CVMFS_HTTP_PROXY", &container));
+  EXPECT_TRUE(options_manager->GetValue("CVMFS_HTTP_PROXY", &container));
   EXPECT_EQ("DIRECT", container);
-  EXPECT_TRUE(options_manager.GetSource("CVMFS_HTTP_PROXY", &container));
+  EXPECT_TRUE(options_manager->GetSource("CVMFS_HTTP_PROXY", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager.GetValue("value", &container));
+  EXPECT_TRUE(options_manager->GetValue("value", &container));
   EXPECT_EQ("", container);
-  EXPECT_TRUE(options_manager.GetSource("value", &container));
+  EXPECT_TRUE(options_manager->GetSource("value", &container));
   EXPECT_EQ(config_file, container);
+}
+
+
+void ParseNoValidFile(OptionsManager* options_manager) {
+  string fileName = "somethingThatDoesntExists";
+  options_manager->ParsePath(fileName, false);
+  ASSERT_EQ(0u, options_manager->GetAllKeys().size());
+}
+
+
+TEST_F(T_Options, ParsePathSimple) {
+  Parse(&fast_options_manager_, config_file_, 6u);
 }
 
 TEST_F(T_Options, ParsePathSimpleNoFile) {
-  string fileName="somethingThatDoesntExists";
-  options_manager.ParsePath(fileName, false);
-  ASSERT_EQ(0u, options_manager.GetAllKeys().size());
+  ParseNoValidFile(&fast_options_manager_);
 }
 
-}  // namespace options
+TEST_F(T_Options, ParsePathBash) {
+  Parse(&bash_options_manager_, config_file_, 9u);
+}
+
+TEST_F(T_Options, ParsePathBashNoFile) {
+  ParseNoValidFile(&bash_options_manager_);
+}
+

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -44,7 +44,7 @@ class T_Options : public ::testing::Test {
     return 9u;
   }
 
-  unsigned ExpectedValues(const type<FastOptionsManager>  type_specifier) {
+  unsigned ExpectedValues(const type<SimpleOptionsParser>  type_specifier) {
     return 6u;
   }
 
@@ -58,7 +58,7 @@ class T_Options : public ::testing::Test {
   string       config_file_;
 };  // class T_Options
 
-typedef ::testing::Types<BashOptionsManager, FastOptionsManager> OptionsManagers;
+typedef ::testing::Types<BashOptionsManager, SimpleOptionsParser> OptionsManagers;
 TYPED_TEST_CASE(T_Options, OptionsManagers);
 
 

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+
+#include "gtest/gtest.h"
+
+#include "../../cvmfs/options.h"
+#include "../../cvmfs/util.h"
+
+using namespace std;  // NOLINT
+
+namespace options {
+
+class T_Options : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    string filename;
+    FILE *temp_file = CreateTempFile("/tmp/cvmfs-test", 0600, "w", &filename);
+    ASSERT_TRUE(temp_file != NULL);
+    config_file = filename;
+	unlink_guard.Set(filename);
+
+    fprintf(temp_file,
+    		"CVMFS_CACHE_BASE=/root/cvmfs_testing/cache\n"
+            "CVMFS_RELOAD_SOCKETS=/root/cvmfs_testing/cache\n"
+            "CVMFS_SERVER_URL=http://volhcb28:3128/data\n"
+    		"IdontHaveAnEqual\n"
+    		"I=have=twoEquals\n"
+    		"I = and spaces\n"
+    		"value=\n"
+            "CVMFS_SHARED_CACHE=no\n"
+            "CVMFS_HTTP_PROXY=DIRECT\n"
+			"export A=B\n");
+    fflush(temp_file);
+    fclose(temp_file);
+  }
+
+ protected:
+  FastOptionsManager options_manager;
+  UnlinkGuard unlink_guard;
+  string config_file;
+
+};  // class T_Options
+
+
+TEST_F(T_Options, ParsePathSimple) {
+  string container;
+  options_manager.ParsePath(config_file, false);
+
+  ASSERT_EQ(6u, options_manager.GetAllKeys().size());
+
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &container));
+  EXPECT_EQ("/root/cvmfs_testing/cache", container);
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_CACHE_BASE", &container));
+  EXPECT_EQ(config_file, container);
+
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_RELOAD_SOCKETS", &container));
+  EXPECT_EQ("/root/cvmfs_testing/cache", container);
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_RELOAD_SOCKETS", &container));
+  EXPECT_EQ(config_file, container);
+
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_SERVER_URL", &container));
+  EXPECT_EQ("http://volhcb28:3128/data", container);
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_SERVER_URL", &container));
+  EXPECT_EQ(config_file, container);
+
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_SHARED_CACHE", &container));
+  EXPECT_EQ("no", container);
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_SHARED_CACHE", &container));
+  EXPECT_EQ(config_file, container);
+
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_HTTP_PROXY", &container));
+  EXPECT_EQ("DIRECT", container);
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_HTTP_PROXY", &container));
+  EXPECT_EQ(config_file, container);
+
+  EXPECT_TRUE(options_manager.GetValue("value", &container));
+  EXPECT_EQ("", container);
+  EXPECT_TRUE(options_manager.GetSource("value", &container));
+  EXPECT_EQ(config_file, container);
+}
+
+TEST_F(T_Options, ParsePathSimpleNoFile) {
+  string fileName="somethingThatDoesntExists";
+  options_manager.ParsePath(fileName, false);
+  ASSERT_EQ(0u, options_manager.GetAllKeys().size());
+}
+
+}  // namespace options

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -19,16 +19,16 @@ class T_Options : public ::testing::Test {
     ASSERT_TRUE(temp_file != NULL);
     unlink_guard_.Set(config_file_);
     fprintf(temp_file,
-    		"CVMFS_CACHE_BASE=/root/cvmfs_testing/cache\n"
+            "CVMFS_CACHE_BASE=/root/cvmfs_testing/cache\n"
             "CVMFS_RELOAD_SOCKETS=/root/cvmfs_testing/cache\n"
             "CVMFS_SERVER_URL=http://volhcb28:3128/data\n"
-    		"IdontHaveAnEqual\n"
-    		"I=have=twoEquals\n"
-    		"I = and spaces\n"
-    		"value=\n"
+            "IdontHaveAnEqual\n"
+            "I=have=twoEquals\n"
+            "I = and spaces\n"
+            "value=\n"
             "CVMFS_SHARED_CACHE=no\n"
             "CVMFS_HTTP_PROXY=DIRECT\n"
-			"export A=B\n");
+            "export A=B\n");
     int result = fclose(temp_file);
     ASSERT_EQ(0, result);
   }

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -10,7 +10,7 @@
 
 using namespace std;  // NOLINT
 
-
+template <class OptionsT>
 class T_Options : public ::testing::Test {
  protected:
   virtual void SetUp() {
@@ -34,71 +34,77 @@ class T_Options : public ::testing::Test {
   }
 
  protected:
-  BashOptionsManager    bash_options_manager_;
-  FastOptionsManager    fast_options_manager_;
-  UnlinkGuard           unlink_guard_;
-  string                config_file_;
+  // type-based overlaoded instantiation of History object wrapper
+  // Inspired from here:
+  //   http://stackoverflow.com/questions/5512910/
+  //          explicit-specialization-of-template-class-member-function
+  template <typename T> struct type {};
+
+  unsigned ExpectedValues(const type<BashOptionsManager>  type_specifier) {
+    return 9u;
+  }
+
+  unsigned ExpectedValues(const type<FastOptionsManager>  type_specifier) {
+    return 6u;
+  }
+
+  unsigned ExpectedValues() {
+    return ExpectedValues(type<OptionsT>());
+  }
+
+ protected:
+  OptionsT     options_manager_;
+  UnlinkGuard  unlink_guard_;
+  string       config_file_;
 };  // class T_Options
 
+typedef ::testing::Types<BashOptionsManager, FastOptionsManager> OptionsManagers;
+TYPED_TEST_CASE(T_Options, OptionsManagers);
 
-void Parse(OptionsManager* options_manager, string config_file,
-    unsigned expected_number_elements) {
+
+TYPED_TEST(T_Options, ParsePath) {
   string container;
-  options_manager->ParsePath(config_file, false);
-  ASSERT_EQ(expected_number_elements, options_manager->GetAllKeys().size());
+  OptionsManager &options_manager = TestFixture::options_manager_;
+  const string &config_file = TestFixture::config_file_;
+  const unsigned expected_number_elements = TestFixture::ExpectedValues();
+  options_manager.ParsePath(config_file, false);
 
-  EXPECT_TRUE(options_manager->GetValue("CVMFS_CACHE_BASE", &container));
+  ASSERT_EQ(expected_number_elements, options_manager.GetAllKeys().size());
+
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &container));
   EXPECT_EQ("/root/cvmfs_testing/cache", container);
-  EXPECT_TRUE(options_manager->GetSource("CVMFS_CACHE_BASE", &container));
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_CACHE_BASE", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager->GetValue("CVMFS_RELOAD_SOCKETS", &container));
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_RELOAD_SOCKETS", &container));
   EXPECT_EQ("/root/cvmfs_testing/cache", container);
-  EXPECT_TRUE(options_manager->GetSource("CVMFS_RELOAD_SOCKETS", &container));
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_RELOAD_SOCKETS", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager->GetValue("CVMFS_SERVER_URL", &container));
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_SERVER_URL", &container));
   EXPECT_EQ("http://volhcb28:3128/data", container);
-  EXPECT_TRUE(options_manager->GetSource("CVMFS_SERVER_URL", &container));
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_SERVER_URL", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager->GetValue("CVMFS_SHARED_CACHE", &container));
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_SHARED_CACHE", &container));
   EXPECT_EQ("no", container);
-  EXPECT_TRUE(options_manager->GetSource("CVMFS_SHARED_CACHE", &container));
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_SHARED_CACHE", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager->GetValue("CVMFS_HTTP_PROXY", &container));
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_HTTP_PROXY", &container));
   EXPECT_EQ("DIRECT", container);
-  EXPECT_TRUE(options_manager->GetSource("CVMFS_HTTP_PROXY", &container));
+  EXPECT_TRUE(options_manager.GetSource("CVMFS_HTTP_PROXY", &container));
   EXPECT_EQ(config_file, container);
 
-  EXPECT_TRUE(options_manager->GetValue("value", &container));
+  EXPECT_TRUE(options_manager.GetValue("value", &container));
   EXPECT_EQ("", container);
-  EXPECT_TRUE(options_manager->GetSource("value", &container));
+  EXPECT_TRUE(options_manager.GetSource("value", &container));
   EXPECT_EQ(config_file, container);
 }
 
-
-void ParseNoValidFile(OptionsManager* options_manager) {
+TYPED_TEST(T_Options, ParsePathNoFile) {
   string fileName = "somethingThatDoesntExists";
-  options_manager->ParsePath(fileName, false);
-  ASSERT_EQ(0u, options_manager->GetAllKeys().size());
-}
-
-
-TEST_F(T_Options, ParsePathSimple) {
-  Parse(&fast_options_manager_, config_file_, 6u);
-}
-
-TEST_F(T_Options, ParsePathSimpleNoFile) {
-  ParseNoValidFile(&fast_options_manager_);
-}
-
-TEST_F(T_Options, ParsePathBash) {
-  Parse(&bash_options_manager_, config_file_, 9u);
-}
-
-TEST_F(T_Options, ParsePathBashNoFile) {
-  ParseNoValidFile(&bash_options_manager_);
+  TestFixture::options_manager_.ParsePath(fileName, false);
+  ASSERT_EQ(0u, TestFixture::options_manager_.GetAllKeys().size());
 }
 


### PR DESCRIPTION
Changed the `namespace options` into the `class OptionsManager` and the derived classes `FastOptionsManager` and `BashOptionsManager`. We have just created a unique pull request since it was too complicated to split the changes.