### PR TITLE
Doc: Adapt Documentation to Script Rename

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -7,7 +7,7 @@ To simplify the integration with CI systems most of the scripts in this director
 ## Scripts
 * `build_cvmfs_???.sh <source location> <build location>`
   * builds the CernVM-FS main packages (cvmfs, cvmfs-server, cvmfs-unittests). Depending on the target platform there might be different packages or individual packages might be omitted.
-* `build_config_default_???.sh <source location> <build location> [<nightly number>]`
+* `build_config_???.sh <source location> <build location> [<nightly number>]`
   * builds the cvmfs-config-default and cvmfs-config-none packages
 * `build_incremental_multi.sh <source location> [<number of cores to use>]`
   * performs an incremental build without producing any packages. This script is meant to be platform independent and should not install anything into system paths.


### PR DESCRIPTION
Follow up of previous [Pull Request](https://github.com/cvmfs/cvmfs/pull/803). Documentation that becomes outdated after less than one hour... O.o