### PR TITLE
Python: Allow to Store Objects Uncompressed

### DIFF
--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -2,7 +2,6 @@
 
 import cvmfs
 import sys
-import shutil
 
 class MerkleCatalogTreeIterator(cvmfs.CatalogTreeIterator):
     def __init__(self, repository, root_catalog, visited_hashes = set()):
@@ -41,7 +40,7 @@ while True:
     for catalog in MerkleCatalogTreeIterator(repo, root_clg, visited_hashes):
         if catalog.is_root():
             print "Downloading revision" , catalog.revision , "..."
-        shutil.copyfile(catalog.get_compressed_file().name, dest + "/" + catalog.hash)
+        catalog.save_to(dest + "/" + catalog.hash)
         repo.close_catalog(catalog)
 
     if next_root_clg != None:

--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -40,7 +40,7 @@ while True:
     for catalog in MerkleCatalogTreeIterator(repo, root_clg, visited_hashes):
         if catalog.is_root():
             print "Downloading revision" , catalog.revision , "..."
-        catalog.save_to(dest + "/" + catalog.hash)
+        catalog.save_to(dest + "/" + catalog.hash + "C")
         repo.close_catalog(catalog)
 
     if next_root_clg != None:

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -38,6 +38,9 @@ class CompressedObject:
     def get_compressed_file(self):
         return self.compressed_file_
 
+    def get_uncompressed_file(self):
+        return self.file_
+
     def _decompress(self):
         """ Unzip a file to a temporary referenced by self.file_ """
         self.file_ = tempfile.NamedTemporaryFile('w+b')

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -100,7 +100,7 @@ class FileObject(CompressedObject):
         CompressedObject.__init__(self, compressed_file)
 
     def file(self):
-        return self.file_
+        return self.get_uncompressed_file()
 
 def _binary_buffer_to_hex_string(binbuf):
     return "".join(map(lambda c: ("%0.2X" % c).lower(),map(ord,binbuf)))

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -10,6 +10,7 @@ import tempfile
 import zlib
 import sqlite3
 import subprocess
+import shutil
 
 
 _REPO_CONFIG_PATH      = "/etc/cvmfs/repositories.d"
@@ -40,6 +41,12 @@ class CompressedObject:
 
     def get_uncompressed_file(self):
         return self.file_
+
+    def save_to(self, path):
+        shutil.copyfile(self.get_compressed_file().name, path)
+
+    def save_uncompressed_to(self, path):
+        shutil.copyfile(self.get_uncompressed_file().name, path)
 
     def _decompress(self):
         """ Unzip a file to a temporary referenced by self.file_ """


### PR DESCRIPTION
This adds the possibility to easily save CernVM-FS repository objects to local disk both compressed and uncompressed by using `CompressedObject::save_to()` or `CompressedObject::save_uncompressed_to()`. Furthermore it updates *add-ons/tools/download_catalog_graph.py* to use this method and fixes the same script to append the 'C' suffix to downloaded files.