### PR TITLE
FIX: Add %doc Files to cvmfs_unittests RPM

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -386,6 +386,7 @@ fi
 %files unittests
 %defattr(-,root,root)
 %{_bindir}/cvmfs_unittests
+%doc COPYING AUTHORS README ChangeLog
 
 %changelog
 * Wed Jan 07 2015 Jakob Blomer <jblomer@cern.ch> - 2.1.20


### PR DESCRIPTION
Seems that the SLC4 RPM build requires those files in the cvmfs-unittests RPM as well. When processing the building of this RPM, `rpmbuild` crashes with the complaint that those files are installed by not packaged... 