### PR TITLE
Fix CVMFS libraries cannot find

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -210,8 +210,10 @@ cvmfs_chksetup() {
   for library in $cvmfs_libs
   do
     if ! test -f /usr/lib/$library && ! test -f /usr/lib64/$library; then
-      echo "Error: $library not found"
-      num_errors=$(($num_errors+1))
+      if ! test -f /usr/lib/i386-linux-gnu/$library && ! test -f /usr/lib/x86_64-linux-gnu/$library; then
+        echo "Error: $library not found"
+        num_errors=$(($num_errors+1))
+      fi
     fi
   done
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Install dependencies for CernVM File System
+#
+# Weiwei Jia <harryxiyou@gmail.com>, March 2015
+
+if test $(id -u) != 0 ; then
+	SUDO=sudo
+fi
+
+if which apt-get > /dev/null ; then
+	$SUDO apt-get install -y lsb-release
+fi
+
+case $(lsb_release -sc) in
+precise)
+	packages=cmake build-essential zlib1g-dev make libattr1-dev libssl-dev \
+		ssl libssl python-dev python libfuse-dev libuuid1 uuid uuid-dev
+    $SUDO apt-get install -y $packages
+	;;
+*)
+	echo "Distro version unknown, dependencies will have to be installed manually."
+	;;
+esac
+
+

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -27,6 +27,7 @@ set (CVMFS_UNITTEST_SOURCES
   t_managed_exec.cc
   t_prng.cc
   t_buffer.cc
+  t_smalloc.cc
   t_chunk_detectors.cc
   t_upload_facility.cc
   t_uploaders.cc

--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -7,24 +7,26 @@
 #include "../../cvmfs/smalloc.h"
 
 // Debug switcher
-//#define SMALLOC_DEBUG_
+// #define SMALLOC_DEBUG_
+
+// Max size is 10MB
+static const unsigned int max_size = 1024u * 1024u * 10u;
 
 // Test smalloc
 TEST(T_Smalloc, Smalloc) {
 	/* we need not test size 0 because smalloc returns either NULL, or a
 	 * unique pointer value that can later be successfully passed to free.
 	 * The largest malloc size is depending on the specific OS and
-	 * configuration so here we set 100MB is the largest test size.
+	 * configuration so here we set 10MB is the largest test size.
 	 * */
-  for (unsigned int size = 1u; size <= 1024u * 1024u * 100u; ) {
+  for (unsigned int size = 1u; size <= max_size; size = size * 512u) {
 #ifdef SMALLOC_DEBUG_
-		printf("size is %u.\n", size);
+    printf("size is %u.\n", size);
 #endif
-		void *mem = smalloc(size);
-		EXPECT_TRUE(mem != NULL);
-		free(mem);
-		size = size * 512u;
-	}
+    void *mem = smalloc(size);
+    EXPECT_TRUE(mem != NULL);
+    free(mem);
+  }
 }
 
 // Test srealloc
@@ -33,31 +35,37 @@ TEST(T_Smalloc, Srealloc) {
 	 * bytes. Size may be larger or smaller than old size. If ptr is NULL,
 	 * then it is the same as smalloc(). If size is zero and ptr is not
 	 * NULL, it is equivalent to free().*/
-	for (unsigned int size = 1u; size <= 1024u * 1024u * 100u; ) {
+  for (unsigned int size = 1u; size <= max_size; size = size * 1024) {
 #ifdef SMALLOC_DEBUG_
-		printf("size is %u.\n", size);
+    printf("size is %u.\n", size);
 #endif
-		//Test ptr is NULL
-		void *mem = srealloc(NULL, size);
-		EXPECT_TRUE(mem != NULL);
+    // Test ptr is NULL
+    void *mem = srealloc(NULL, size);
+    EXPECT_TRUE(mem != NULL);
 #ifdef SMALLOC_DEBUG_
-		printf("999 %p\n", mem);
+    printf("999 %p\n", mem);
 #endif
-		// Test size is larger than old size
-		mem = srealloc(mem, size + 1u);
-		EXPECT_TRUE(mem != NULL);
+    // Test size is larger than old size
+    mem = srealloc(mem, size + 1u);
+    EXPECT_TRUE(mem != NULL);
 #ifdef SMALLOC_DEBUG_
-		printf("999 %p\n", mem);
+    printf("999 %p\n", mem);
 #endif
-		// Test size is smaller than old size 
-		// mem = srealloc(mem, size - 1u); TODO
+    // Test size is smaller than old size
+    if (size != 1u) {
+			/*TODO: When size is 1u, srealloc would be asserted inside
+			 * beecause it is not allowed the second parameter of srealloc is
+       * zero. However, standard realloc(ptr, _size) permits _size is zero.
+			 * When _size is zero, it is free. Therefore, this maybe a bug for
+			 * current smalloc*/
+      mem = srealloc(mem, size - 1u);
+      EXPECT_TRUE(mem != NULL);
+    }
 #ifdef SMALLOC_DEBUG_
-		printf("999 %p\n", mem);
+    printf("999 %p\n", mem);
 #endif
-		//if (size != 1u)
-			free(mem);
-		size = size * 1024u;
-	}
+    free(mem);
+  }
 }
 
 // Test scalloc
@@ -67,37 +75,38 @@ TEST(T_Smalloc, Scalloc) {
 	 * unique pointer value. We cannot test the condition of nmemb or size
 	 * is 0.
 	 */
-	for (unsigned int size = 1u, num = 1u; size <= 1024u * 1024u; num++) {
+  for (unsigned int size = 1u, num = 1u; size <= max_size; num++) {
 #ifdef SMALLOC_DEBUG_
     printf("size is %u.\n", size);
-		printf("num is %u.\n", num);
+    printf("num is %u.\n", num);
 #endif
     int *mem = static_cast<int *>(scalloc(num, size));
-		EXPECT_FALSE(mem == NULL);
+    EXPECT_FALSE(mem == NULL);
     for (const int *tmp = mem; tmp < mem + num; tmp++) {
-			EXPECT_EQ(*tmp, 0);
-		}
-		free(mem);
-		size = size * 512u;
-	}
+      EXPECT_EQ(*tmp, 0);
+    }
+    free(mem);
+    size = size * 512u;
+  }
 }
 
-//Test smmap and smunmap
+// Test smmap and smunmap
 TEST(T_Smalloc, SmmapAndSunmap) {
-  for (unsigned int size = sizeof(size_t) * 2u; size <= 1024u * 1024u; size = size + 4096u) {
+  for (unsigned int size = sizeof(size_t) * 2u; size <= 1024u * 1024u; ) {
 #ifdef SMALLOC_DEBUG_
-		printf("size is %u.\n", size);
+    printf("size is %u.\n", size);
 #endif
-		size_t pages = ((size + 2 * sizeof(size_t)) + 4095) / 4096; 
-		void *mem = smmap(size);
-		EXPECT_FALSE(mem == NULL);
-		unsigned char *area = static_cast<unsigned char *>(mem);
-		area = area - sizeof(size_t);
-		size_t _pages = *(reinterpret_cast<size_t *>(area));
+    size_t pages = ((size + 2 * sizeof(size_t)) + 4095) / 4096;
+    void *mem = smmap(size);
+    EXPECT_FALSE(mem == NULL);
+    unsigned char *area = static_cast<unsigned char *>(mem);
+    area = area - sizeof(size_t);
+    size_t _pages = *(reinterpret_cast<size_t *>(area));
     EXPECT_EQ(_pages, pages);
-		area = area - sizeof(size_t);
+    area = area - sizeof(size_t);
     EXPECT_EQ(*(reinterpret_cast<size_t *>(area)), kMemMarker);
-		smunmap(mem);
-	}
+    smunmap(mem);
+    size = size + 4096u;
+  }
 }
 

--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -80,9 +80,9 @@ TEST(T_Smalloc, Scalloc) {
     printf("size is %u.\n", size);
     printf("num is %u.\n", num);
 #endif
-    int *mem = static_cast<int *>(scalloc(num, size));
+    int *mem = static_cast<int *>(scalloc(num, sizeof(int)));
     EXPECT_FALSE(mem == NULL);
-    for (const int *tmp = mem; tmp < num * size; tmp++) {
+    for (const int *tmp = mem; tmp < mem +  num; tmp++) {
       EXPECT_EQ(*tmp, 0);
     }
     free(mem);

--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -5,10 +5,9 @@
 #include <gtest/gtest.h>
 
 #include "../../cvmfs/smalloc.h"
-//#include "../../cvmfs/util.h"
 
 // Debug switcher
-#define SMALLOC_DEBUG_
+//#define SMALLOC_DEBUG_
 
 // Test smalloc
 TEST(T_Smalloc, Smalloc) {
@@ -83,8 +82,22 @@ TEST(T_Smalloc, Scalloc) {
 	}
 }
 
-TEST(T_Smalloc, Smmap) {
+//Test smmap and smunmap
+TEST(T_Smalloc, SmmapAndSunmap) {
+  for (unsigned int size = sizeof(size_t) * 2u; size <= 1024u * 1024u; size = size + 4096u) {
+#ifdef SMALLOC_DEBUG_
+		printf("size is %u.\n", size);
+#endif
+		size_t pages = ((size + 2 * sizeof(size_t)) + 4095) / 4096; 
+		void *mem = smmap(size);
+		EXPECT_FALSE(mem == NULL);
+		unsigned char *area = static_cast<unsigned char *>(mem);
+		area = area - sizeof(size_t);
+		size_t _pages = *(reinterpret_cast<size_t *>(area));
+    EXPECT_EQ(_pages, pages);
+		area = area - sizeof(size_t);
+    EXPECT_EQ(*(reinterpret_cast<size_t *>(area)), kMemMarker);
+		smunmap(mem);
+	}
 }
 
-TEST(T_Smalloc, Smunmap) {
-}

--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/smalloc.h"
+//#include "../../cvmfs/util.h"
+
+// Debug switcher
+#define SMALLOC_DEBUG_
+
+// Test smalloc
+TEST(T_Smalloc, Smalloc) {
+	/* we need not test size 0 because smalloc returns either NULL, or a
+	 * unique pointer value that can later be successfully passed to free.
+	 * The largest malloc size is depending on the specific OS and
+	 * configuration so here we set 100MB is the largest test size.
+	 * */
+  for (unsigned int size = 1u; size <= 1024u * 1024u * 100u; ) {
+#ifdef SMALLOC_DEBUG_
+		printf("size is %u.\n", size);
+#endif
+		void *mem = smalloc(size);
+		EXPECT_TRUE(mem != NULL);
+		free(mem);
+		size = size * 512u;
+	}
+}
+
+// Test srealloc
+TEST(T_Smalloc, Srealloc) {
+	/* Srealloc(ptr, size) changes the size of memory block pointed to ptr to size
+	 * bytes. Size may be larger or smaller than old size. If ptr is NULL,
+	 * then it is the same as smalloc(). If size is zero and ptr is not
+	 * NULL, it is equivalent to free().*/
+	for (unsigned int size = 1u; size <= 1024u * 1024u * 100u; ) {
+#ifdef SMALLOC_DEBUG_
+		printf("size is %u.\n", size);
+#endif
+		//Test ptr is NULL
+		void *mem = srealloc(NULL, size);
+		EXPECT_TRUE(mem != NULL);
+#ifdef SMALLOC_DEBUG_
+		printf("999 %p\n", mem);
+#endif
+		// Test size is larger than old size
+		mem = srealloc(mem, size + 1u);
+		EXPECT_TRUE(mem != NULL);
+#ifdef SMALLOC_DEBUG_
+		printf("999 %p\n", mem);
+#endif
+		// Test size is smaller than old size 
+		// mem = srealloc(mem, size - 1u); TODO
+#ifdef SMALLOC_DEBUG_
+		printf("999 %p\n", mem);
+#endif
+		//if (size != 1u)
+			free(mem);
+		size = size * 1024u;
+	}
+}
+
+// Test scalloc
+TEST(T_Smalloc, Scalloc) {
+	/* Scalloc(nmemb, size) allocates memory space for an array of nmemb elements of
+	 * size bytes each. If nmemb or size is 0, then returns NULL or a
+	 * unique pointer value. We cannot test the condition of nmemb or size
+	 * is 0.
+	 */
+	for (unsigned int size = 1u, num = 1u; size <= 1024u * 1024u; num++) {
+#ifdef SMALLOC_DEBUG_
+    printf("size is %u.\n", size);
+		printf("num is %u.\n", num);
+#endif
+    int *mem = static_cast<int *>(scalloc(num, size));
+		EXPECT_FALSE(mem == NULL);
+    for (const int *tmp = mem; tmp < mem + num; tmp++) {
+			EXPECT_EQ(*tmp, 0);
+		}
+		free(mem);
+		size = size * 512u;
+	}
+}
+
+TEST(T_Smalloc, Smmap) {
+}
+
+TEST(T_Smalloc, Smunmap) {
+}

--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -82,7 +82,7 @@ TEST(T_Smalloc, Scalloc) {
 #endif
     int *mem = static_cast<int *>(scalloc(num, size));
     EXPECT_FALSE(mem == NULL);
-    for (const int *tmp = mem; tmp < mem + num; tmp++) {
+    for (const int *tmp = mem; tmp < num * size; tmp++) {
       EXPECT_EQ(*tmp, 0);
     }
     free(mem);


### PR DESCRIPTION
For Ubuntu 14.04 i386 and x86_64, `cvmfs_config chksetup` cannot find cvmfs libraries. Commit d3abc28 fixes this bug.