### PR TITLE
Fix: S3-backend caching disabled for mutable objects (CVM-808)

### DIFF
--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -597,6 +597,12 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
     info->http_headers =
         curl_slist_append(info->http_headers,
                           "Content-Type: binary/octet-stream");
+
+    if (info->request == JobInfo::kReqPutNoCache) {
+      std::string cache_control = "Cache-Control: no-cache";
+      info->http_headers =
+          curl_slist_append(info->http_headers, cache_control.c_str());
+    }
   }
 
   // Common headers
@@ -775,7 +781,8 @@ bool S3FanoutManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     try_again = CanRetry(info);
   }
   if (try_again) {
-    if (info->request == JobInfo::kReqPut) {
+    if (info->request == JobInfo::kReqPut ||
+        info->request == JobInfo::kReqPutNoCache) {
       LogCvmfs(kLogDownload, kLogDebug, "Trying again to upload %s",
                info->object_key.c_str());
       // Reset origin

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -92,6 +92,7 @@ struct JobInfo {
   enum RequestType {
     kReqHead = 0,
     kReqPut,
+    kReqPutNoCache,
     kReqDelete,
   };
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -361,11 +361,14 @@ void S3Uploader::FileUpload(
                             const_cast<void*>(
                                 static_cast<void const*>(callback)),
                             local_path);
+
+  if (remote_path.substr(0, 1) == ".") {
+    info->request = s3fanout::JobInfo::kReqPutNoCache;
+  } else {
 #ifndef S3_UPLOAD_OBJECTS_EVEN_IF_THEY_EXIST
-  if (remote_path.substr(0, 1) != ".") {
     info->request = s3fanout::JobInfo::kReqHead;
-  }
 #endif
+  }
 
   // Upload job
   const bool retval = UploadJobInfo(info);

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -362,7 +362,7 @@ void S3Uploader::FileUpload(
                                 static_cast<void const*>(callback)),
                             local_path);
 
-  if (remote_path.substr(0, 1) == ".") {
+  if (remote_path.compare(0, 6, ".cvmfs") == 0) {
     info->request = s3fanout::JobInfo::kReqPutNoCache;
   } else {
 #ifndef S3_UPLOAD_OBJECTS_EVEN_IF_THEY_EXIST


### PR DESCRIPTION
Mutable objects are uploaded now with "Cache-control: no-cache" header. This is needed at least with Google cloud storage to execute consecutive changes to the repository (e.g. twice mkfs). The problem is described in more detailed at Jira ticket CVM-808.