### PR TITLE
TEST: Adding systemd Awareness to the Integration Test System

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -13,15 +13,15 @@ install_rpm $UNITTEST_PACKAGE
 
 # installing WSGI apache module
 echo "installing python WSGI module..."
-install_from_repo mod_wsgi || die "fail (installing mod_wsgi)"
-sudo service httpd restart || die "fail (restarting apache)"
+install_from_repo mod_wsgi   || die "fail (installing mod_wsgi)"
+sudo systemctl restart httpd || die "fail (restarting apache)"
 
 # setup environment
 echo -n "setting up CernVM-FS environment..."
 sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"
 sudo mkdir -p /var/log/cvmfs-test                || die "fail (mkdir /var/log/cvmfs-test)"
 sudo chown sftnight:sftnight /var/log/cvmfs-test || die "fail (chown /var/log/cvmfs-test)"
-sudo service autofs start                        || die "fail (service autofs start)"
+sudo systemctl start autofs                      || die "fail (systemctl start autofs)"
 sudo cvmfs_config chksetup > /dev/null           || die "fail (cvmfs_config chksetup)"
 echo "done"
 

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -16,7 +16,7 @@ echo "done"
 
 # start apache
 echo -n "starting apache... "
-sudo service httpd start > /dev/null 2>&1 || die "fail"
+sudo systemctl start httpd > /dev/null 2>&1 || die "fail"
 echo "OK"
 
 # running unit test suite

--- a/test/test_functions
+++ b/test/test_functions
@@ -106,6 +106,16 @@ compare_versions() {
   [ $lhs1$lhs2$lhs3 $comparison_operator $rhs1$rhs2$rhs3 ]
 }
 
+service_request() {
+  local service_name=$1
+  local request_verb=$2
+  if is_systemd; then
+    sudo systemctl $request_verb $service_name
+  else
+    sudo $SERVICE_BIN $service_name $request_verb
+  fi
+}
+
 # ensures that a generic service is running
 # @param service  the name of the service
 # @param state    the desired state of the service (on|off)
@@ -114,19 +124,18 @@ service_switch() {
   local service_name=$1
   local state=$2
 
-  # switch it on or off, if necessary
   case $state in
     on)
       echo "starting $service_name..."
-      sudo $service_binary $service_name start || return 100
+      service_request $service_name start || return 100
       ;;
     off)
       echo "stopping $service_name..."
-      sudo $service_binary $service_name stop || return 101
+      service_request $service_name stop || return 101
       ;;
     restart)
       echo "restarting $service_name..."
-      sudo $service_binary $service_name restart || return 102
+      service_request $service_name restart || return 102
       ;;
     *)
       echo "unrecognized state switching for $service_name"
@@ -184,7 +193,7 @@ autofs_switch() {
 # @param state   the desired state of autofs (on|off)
 # @return        0 on success
 apache_switch() {
-  sudo $service_binary $APACHE_SERVICE status > /dev/null 2>&1
+  service_request $APACHE_SERVICE status > /dev/null 2>&1
   service_should_switch $1 $?
   if [ $? -eq 0 ]; then
     service_switch $APACHE_SERVICE $1

--- a/test/test_functions
+++ b/test/test_functions
@@ -179,12 +179,8 @@ autofs_check() {
 # @return        0 on success
 autofs_switch() {
   autofs_check
-  service_should_switch $1 $?
-  if [ $? -eq 0 ]; then
+  if service_should_switch $1 $?; then
     service_switch autofs $1
-    return $?
-  else
-    return 0
   fi
 }
 
@@ -194,12 +190,8 @@ autofs_switch() {
 # @return        0 on success
 apache_switch() {
   service_request $APACHE_SERVICE status > /dev/null 2>&1
-  service_should_switch $1 $?
-  if [ $? -eq 0 ]; then
+  if service_should_switch $1 $?; then
     service_switch $APACHE_SERVICE $1
-    return $?
-  else
-    return 0 # already in correct state
   fi
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -43,13 +43,23 @@ die() {
 }
 
 
-# find the service binary
-if [ -x /sbin/service ]; then
-  service_binary="/sbin/service"
-else
-  # Ubuntu
-  service_binary="/usr/sbin/service"
+# Find the service binary (or detect systemd)
+SERVICE_BIN="false"
+if ! pidof systemd > /dev/null 2>&1 || [ $(pidof systemd) -ne 1 ]; then
+  if [ -x /sbin/service ]; then
+    SERVICE_BIN="/sbin/service"
+  elif [ -x /usr/sbin/service ]; then
+    SERVICE_BIN="/usr/sbin/service" # Ubuntu
+  elif [ -x /sbin/rc-service ]; then
+    SERVICE_BIN="/sbin/rc-service" # OpenRC
+  else
+    die "Neither systemd nor service binary detected"
+  fi
 fi
+
+is_systemd() {
+  [ x"$SERVICE_BIN" = x"false" ]
+}
 
 # find the name of the httpd service
 


### PR DESCRIPTION
No magic here. The manipulating calls for `autofs` and `httpd` were already abstracted, just adding a conditional for `systemd` based systems. 