### PR TITLE
TEST: Integration Test Runner can Export XUnit XML

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -170,6 +170,8 @@ do
     continue
   fi
 
+  wc -l < $logfile > ${scratchdir}/log_begin
+
   cvmfs_test_autofs_on_startup=true # might be overwritten by some tests
   if ! . $t/main; then
     report_failure "failed to source $t/main" >> $logfile
@@ -256,6 +258,8 @@ do
       echo "Failed!"
       ;;
   esac
+
+  wc -l < $logfile > ${scratchdir}/log_end
 done
 
 testsuite_end="$(get_millisecond_epoch)"
@@ -270,11 +274,11 @@ echo "$num_failures"           > ${scratch_basedir}/num_failures
 
 # export xunit XML
 if [ ! -z "$xml_output" ]; then
-  export_xunit_xml "$xml_output" $scratch_basedir
+  export_xunit_xml "$xml_output" $scratch_basedir $logfile
 fi
 
 # remove runtime information
-rm -rf $scratch_basedir
+# rm -rf $scratch_basedir
 
 # print final status information
 date >> $logfile

--- a/test/run.sh
+++ b/test/run.sh
@@ -21,11 +21,14 @@ date >> $logfile
 # read command line paramters
 shift
 test_exclusions=0
-while getopts "x" option; do
+xml_output=""
+while getopts "xo:" option; do
   case $option in
     x)
-      echo "foo"
       test_exclusions=1
+    ;;
+    o)
+      xml_output="$OPTARG"
     ;;
     ?)
       usage
@@ -33,7 +36,7 @@ while getopts "x" option; do
     ;;
   esac
 done
-shift
+shift $(( $OPTIND - 1 ))
 
 # configure the test set to run
 exclusions=""
@@ -269,6 +272,11 @@ echo "$num_skipped"            > ${scratch_basedir}/num_skipped
 echo "$num_passed"             > ${scratch_basedir}/num_passed
 echo "$num_warnings"           > ${scratch_basedir}/num_warnings
 echo "$num_failures"           > ${scratch_basedir}/num_failures
+
+# export xunit XML
+if [ ! -z "$xml_output" ]; then
+  export_xunit_xml "$xml_output" $scratch_basedir
+fi
 
 # remove runtime information
 rm -rf $scratch_basedir

--- a/test/run.sh
+++ b/test/run.sh
@@ -158,14 +158,17 @@ do
   fi
 
   # run the test
+  test_logfile="${workdir}/test-$(basename $workdir).log"
+  echo "temporary log: $test_logfile" >> $logfile
   sh -c ". ./test_functions                     && \
          . $t/main                              && \
          cd $workdir                            && \
          cvmfs_run_test $logfile $(pwd)/${t}    && \
          retval=\$?                             && \
          retval=\$(mangle_test_retval \$retval) && \
-         exit \$retval" >> $logfile 2>&1
+         exit \$retval" >> $test_logfile 2>&1
   RETVAL=$?
+  cat $test_logfile >> $logfile
 
   # if the test is a benchmark we have to collect the results before removing the folder
   if [ x"$cvmfs_benchmark" = x"yes" ]; then

--- a/test/run.sh
+++ b/test/run.sh
@@ -143,10 +143,8 @@ testsuite_start="$(get_millisecond_epoch)"
 
 workdir_basedir="${CVMFS_TEST_SCRATCH}/workdir"
 scratch_basedir="${CVMFS_TEST_SCRATCH}/scratch"
-if [ -d $scratch_basedir ]; then
-  rm -fR $scratch_basedir
-  mkdir -p $scratch_basedir
-fi
+[ ! -d $scratch_basedir ] || rm -fR $scratch_basedir
+mkdir -p $scratch_basedir
 
 get_iso8601_timestamp > ${scratch_basedir}/starttime
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -118,6 +118,8 @@ setup_environment() {
 # source common functions used in the test cases
 . ./test_functions
 
+testsuite_start="$(get_millisecond_epoch)"
+
 # run the tests
 for t in $testsuite
 do
@@ -211,9 +213,12 @@ do
   esac
 done
 
+testsuite_end="$(get_millisecond_epoch)"
+testsuite_time_elapsed=$(( $testsuite_end - $testsuite_start ))
+
 # print final status information
 date >> $logfile
-echo "Finished test suite" >> $logfile
+echo "Finished test suite in $(milliseconds_to_human_readable $testsuite_time_elapsed)" >> $logfile
 
 echo ""
 echo "Tests:    $num_tests"
@@ -222,6 +227,7 @@ echo "Passed:   $num_passed"
 echo "Warnings: $num_warnings"
 echo "Failures: $num_failures"
 echo ""
+echo "took $(milliseconds_to_human_readable $testsuite_time_elapsed)"
 
 exit $num_failures
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -18,20 +18,38 @@ fi
 echo "Start test suite for cvmfs $(cvmfs2 --version)" > $logfile
 date >> $logfile
 
-# configure the test set to run
+# read command line paramters
 shift
+test_exclusions=0
+while getopts "x" option; do
+  case $option in
+    x)
+      echo "foo"
+      test_exclusions=1
+    ;;
+    ?)
+      usage
+      exit 1
+    ;;
+  esac
+done
+shift
+
+# configure the test set to run
 exclusions=""
-if [ x$1 = "x-x" ]; then
-  shift
+testsuite=""
+if [ $test_exclusions -ne 0 ]; then
   exclusions=$@
 else
   testsuite=$@
 fi
+
 exclusions="$exclusions $CVMFS_TEST_EXCLUDE"
 if [ -z "$testsuite" ]; then
   testsuite=$(find src -mindepth 1 -maxdepth 1 -type d | sort)
 fi
 
+# start running the tests
 TEST_ROOT=$(readlink -f $(dirname $0))
 export TEST_ROOT
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -164,7 +164,6 @@ do
   # source the test code
   workdir="${workdir_basedir}/$(basename $t)"
   scratchdir="${scratch_basedir}/$(basename $t)"
-  test_logfile="${scratchdir}/test.log"
 
   if ! mkdir -p $scratchdir; then
     report_failure "failed to create $scratchdir" >> $logfile
@@ -173,20 +172,20 @@ do
 
   cvmfs_test_autofs_on_startup=true # might be overwritten by some tests
   if ! . $t/main; then
-    report_failure "failed to source $t/main" >> $test_logfile
+    report_failure "failed to source $t/main" >> $logfile
     echo "101" > ${scratchdir}/retval
     continue
   fi
 
   # write some status info to the screen
-  echo "-- Testing ${cvmfs_test_name} ($(date) / test number $(basename $t | head -c3))" >> $test_logfile
+  echo "-- Testing ${cvmfs_test_name} ($(date) / test number $(basename $t | head -c3))" >> $logfile
   echo -n "Testing ${cvmfs_test_name}... "
   echo "$cvmfs_test_name"          > ${scratchdir}/name
   echo "$(basename $t | head -c3)" > ${scratchdir}/number
 
   # check if test should be skipped
   if contains "$exclusions" $t; then
-    report_skipped "test case was marked to be skipped" >> $test_logfile
+    report_skipped "test case was marked to be skipped" >> $logfile
     echo "Skipped"
     touch ${scratchdir}/skipped
     echo "0.000" > ${scratchdir}/elapsed
@@ -194,8 +193,8 @@ do
   fi
 
   # configure the environment for the test
-  if ! setup_environment $cvmfs_test_autofs_on_startup $workdir >> $test_logfile 2>&1; then
-    report_failure "failed to setup environment" >> $test_logfile
+  if ! setup_environment $cvmfs_test_autofs_on_startup $workdir >> $logfile 2>&1; then
+    report_failure "failed to setup environment" >> $logfile
     echo "Failed! (setup)"
     echo "102" > ${scratchdir}/retval
     continue
@@ -203,18 +202,16 @@ do
 
   # run the test
   test_start=$(get_millisecond_epoch)
-  echo "temporary log: $test_logfile" >> $logfile
   sh -c ". ./test_functions                     && \
          . $t/main                              && \
          cd $workdir                            && \
          cvmfs_run_test $logfile $(pwd)/${t}    && \
          retval=\$?                             && \
          retval=\$(mangle_test_retval \$retval) && \
-         exit \$retval" >> $test_logfile 2>&1
+         exit \$retval" >> $logfile 2>&1
   RETVAL=$?
   test_end=$(get_millisecond_epoch)
   test_time_elapsed=$(( ( $test_end - $test_start ) ))
-  cat $test_logfile >> $logfile
   echo "execution took $(milliseconds_to_seconds $test_time_elapsed) seconds" >> $logfile
   echo "$test_time_elapsed" > ${scratchdir}/elapsed
   echo "$RETVAL"            > ${scratchdir}/retval

--- a/test/run.sh
+++ b/test/run.sh
@@ -159,6 +159,7 @@ do
 
   # run the test
   test_logfile="${workdir}/test-$(basename $workdir).log"
+  test_start=$(get_millisecond_epoch)
   echo "temporary log: $test_logfile" >> $logfile
   sh -c ". ./test_functions                     && \
          . $t/main                              && \
@@ -168,7 +169,10 @@ do
          retval=\$(mangle_test_retval \$retval) && \
          exit \$retval" >> $test_logfile 2>&1
   RETVAL=$?
+  test_end=$(get_millisecond_epoch)
+  test_time_elapsed=$(( ( $test_end - $test_start ) ))
   cat $test_logfile >> $logfile
+  echo "execution took $(milliseconds_to_seconds $test_time_elapsed) seconds" >> $logfile
 
   # if the test is a benchmark we have to collect the results before removing the folder
   if [ x"$cvmfs_benchmark" = x"yes" ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -844,13 +844,34 @@ load_repo_config() {
 }
 
 
-# runs the given command and measures the time it took to execute
+get_millisecond_epoch() {
+  echo $(( $(date +%s%N) / 1000000 ))
+}
+
+
+milliseconds_to_seconds() {
+  local milliseconds="$1"
+
+  # add a zero padding if necessary
+  while [ $(echo -n "$milliseconds" | wc -c) -lt 4 ]; do
+    milliseconds="0$milliseconds"
+  done
+
+  # insert a decimal point to make seconds
+  digits=$(echo -n "$milliseconds" | wc -c)
+  echo -n "$milliseconds" | head -c $(( $digits - 3 ))
+  echo -n "."
+  echo -n "$milliseconds" | tail -c 3
+}
+
+
+# runs the given command and measures the execution time in milliseconds
 stop_watch() {
-  begin=$(date +%s)
+  begin=$(get_millisecond_epoch)
   cmd="$@"
   $cmd
   res=$?
-  end=$(date +%s)
+  end=$(get_millisecond_epoch)
   echo $((end - begin))
   return $res
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -204,7 +204,7 @@ contains() {
 
   for elem in $haystack
   do
-    if [ $(readlink --canonicalize $elem) = $(readlink --canonicalize $needle) ]; then
+    if [ $(basename $elem) = $(basename $needle) ]; then
       return 0
     fi
   done

--- a/test/test_functions
+++ b/test/test_functions
@@ -12,6 +12,8 @@
 CVMFS_TEST_DEBUGLOG=${CVMFS_TEST_DEBUGLOG:=}
 CVMFS_TEST_PROXY=${CVMFS_TEST_PROXY:=http://ca-proxy.cern.ch:3128}
 CVMFS_TEST_SCRATCH=${CVMFS_TEST_SCRATCH:=/tmp/cvmfs-test}
+CVMFS_TEST_SUITE_NAME=${CVMFS_TEST_SUITE_NAME:=Integration Tests}
+CVMFS_TEST_CLASS_NAME=${CVMFS_TEST_CLASS_NAME:=IntegrationTests}
 CVMFS_TEST_EXCLUDE=${CVMFS_TEST_EXCLUDE:=}
 CVMFS_TEST_SYSLOG_FACILITY=${CVMFS_TEST_SYSLOG_FACILITY:=5}
 CVMFS_TEST_SYSLOG_TARGET=${CVMFS_TEST_SYSLOG_TARGET:=/var/log/cvmfs-testing.log}
@@ -1473,4 +1475,75 @@ collect_benchmark_results() {
   fi
   cp  -rf $workdir/system.info $workdir/$FQRN.*.log $workdir/callgrind.out.* $workdir/$FQRN.memcheck.xml $workdir/cvmfs.conf $benchmark_output_dir > /dev/null 2>&1
   benchmark_log "Test results copied into $benchmark_output_dir" >> $logfile
+}
+
+
+#
+#  XUnit XML generation helper functions
+#
+
+xunit_preamble() {
+  local xml_file="$1"
+  local scratchdir="$2"
+
+  local num_tests="$(cat ${scratchdir}/num_tests)"
+  local num_fails="$(cat ${scratchdir}/num_failures)"
+  local num_skips="$(cat ${scratchdir}/num_skipped)"
+  local t_start="$(cat ${scratchdir}/starttime)"
+  local t_elapsed="$(cat ${scratchdir}/elapsed)"
+
+  cat > $xml_file << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="$num_tests" failures="$num_fails" disabled="$num_skips" errors="0" timestamp="$t_start" time="$(milliseconds_to_seconds $t_elapsed)" name="CVMFS Test Runner">
+  <testsuite name="$CVMFS_TEST_SUITE_NAME" tests="$num_tests" failures="$num_fails" disabled="$num_skips" errors="0" time="$(milliseconds_to_seconds $t_elapsed)">
+EOF
+}
+
+xunit_testcase() {
+  local xml_file="$1"
+  local test_scratchdir="$2"
+
+  local test_name="$(cat ${test_scratchdir}/name)"
+  local test_number="$(cat ${test_scratchdir}/number)"
+  local t_elapsed="$(cat ${test_scratchdir}/elapsed)"
+
+  if [ -f ${test_scratchdir}/skipped ]; then
+    cat >> $xml_file << EOF
+    <testcase name="$test_name" status="notrun" time="0.000" classname="$CVMFS_TEST_CLASS_NAME" />
+EOF
+  elif [ -f ${test_scratchdir}/success ]; then
+    cat >> $xml_file << EOF
+    <testcase name="$test_name" status="run" time="$(milliseconds_to_seconds $t_elapsed)" classname="$CVMFS_TEST_CLASS_NAME" />
+EOF
+  elif [ -f ${test_scratchdir}/failure ]; then
+    local retval="$(cat ${test_scratchdir}/retval)"
+    cat >> $xml_file << EOF
+    <testcase name="$test_name" status="run" time="$(milliseconds_to_seconds $t_elapsed)" classname="$CVMFS_TEST_CLASS_NAME">
+      <failure message="Failed with Retval $retval" type="">
+      <![CDATA[$(cat ${test_scratchdir}/test.log)]]>
+      </failure>
+    </testcase>
+EOF
+  else
+    echo "Warning: unknown test state for '$test_name'"
+  fi
+}
+
+xunit_epilogue() {
+  local xml_file="$1"
+  cat >> $xml_file << EOF
+  </testsuite>
+</testsuites>
+EOF
+}
+
+export_xunit_xml() {
+  local xml_file="$1"
+  local scratchdir="$2"
+
+  xunit_preamble "$xml_file" "$scratchdir"
+  for testcase in $(find $scratchdir -mindepth 1 -maxdepth 1 -type d); do
+    xunit_testcase "$xml_file" "$testcase"
+  done
+  xunit_epilogue "$xml_file"
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -1502,10 +1502,14 @@ EOF
 xunit_testcase() {
   local xml_file="$1"
   local test_scratchdir="$2"
+  local logfile="$3"
 
   local test_name="$(cat ${test_scratchdir}/name)"
   local test_number="$(cat ${test_scratchdir}/number)"
   local t_elapsed="$(cat ${test_scratchdir}/elapsed)"
+  local log_begin=$(cat ${test_scratchdir}/log_begin)
+  local log_end=$(cat ${test_scratchdir}/log_end)
+  local log_length=$(( $log_end - $log_begin ))
 
   if [ -f ${test_scratchdir}/skipped ]; then
     cat >> $xml_file << EOF
@@ -1520,7 +1524,7 @@ EOF
     cat >> $xml_file << EOF
     <testcase name="$test_name" status="run" time="$(milliseconds_to_seconds $t_elapsed)" classname="$CVMFS_TEST_CLASS_NAME">
       <failure message="Failed with Retval $retval" type="">
-      <![CDATA[$(cat ${test_scratchdir}/test.log)]]>
+      <![CDATA[$(head -n $log_end $logfile | tail -n $log_length)]]>
       </failure>
     </testcase>
 EOF
@@ -1540,10 +1544,11 @@ EOF
 export_xunit_xml() {
   local xml_file="$1"
   local scratchdir="$2"
+  local logfile="$3"
 
   xunit_preamble "$xml_file" "$scratchdir"
   for testcase in $(find $scratchdir -mindepth 1 -maxdepth 1 -type d); do
-    xunit_testcase "$xml_file" "$testcase"
+    xunit_testcase "$xml_file" "$testcase" "$logfile"
   done
   xunit_epilogue "$xml_file"
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -849,6 +849,11 @@ get_millisecond_epoch() {
 }
 
 
+get_iso8601_timestamp() {
+  date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+
 milliseconds_to_seconds() {
   local milliseconds="$1"
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -865,6 +865,37 @@ milliseconds_to_seconds() {
 }
 
 
+milliseconds_to_human_readable() {
+  local milliseconds="$1"
+  local scratch=$milliseconds
+
+  local seconds=1000
+  local minutes=$(( $seconds * 60 ))
+  local hours=$(( $minutes * 60))
+  local days=$(( $hours * 24 ))
+
+  local o_days=$(( $scratch / $days ))
+  if [ $o_days -gt 0 ]; then
+    echo -n "$o_days days "
+    scratch=$(( $scratch % $days ))
+  fi
+
+  local o_hours=$(( $scratch / $hours ))
+  if [ $o_days -gt 0 ] || [ $o_hours -gt 0 ]; then
+    echo -n "$o_hours hours "
+    scratch=$(( $scratch % $hours ))
+  fi
+
+  local o_minutes=$(( $scratch / $minutes ))
+  if [ $o_days -gt 0 ] || [ $o_hours -gt 0 ] || [ $o_minutes -gt 0 ]; then
+    echo -n "$o_minutes minutes "
+    scratch=$(( $scratch % $minutes ))
+  fi
+
+  echo "$(milliseconds_to_seconds $scratch) seconds"
+}
+
+
 # runs the given command and measures the execution time in milliseconds
 stop_watch() {
   begin=$(get_millisecond_epoch)


### PR DESCRIPTION
This allows the `run.sh` integration test runner to generate an XUnit compliant XML output that can be used by Jenkins to generate convenient test reports.

Features:

* Overview of passed and failed tests
* Failed tests attach their log output to the XML (easy accessibility in Jenkins)
* Measurement of test execution time in milliseconds
* Historic overview of test results in Jenkins

Sneak peek of Jenkins output for failed, skipped and succeeded integration and unit tests combined:

![trend](https://cloud.githubusercontent.com/assets/1562139/7133651/d7666166-e295-11e4-933f-94dc8773205c.png)
