### PR TITLE
TEST: Finer Grained Integration Test Selection

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -191,7 +191,6 @@ do
     report_skipped "test case was marked to be skipped" >> $logfile
     echo "Skipped"
     touch ${scratchdir}/skipped
-    echo "0.000" > ${scratchdir}/elapsed
     continue
   fi
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -38,16 +38,17 @@ while getopts "xo:" option; do
 done
 shift $(( $OPTIND - 1 ))
 
-# configure the test set to run
-exclusions=""
-testsuite=""
+# configure the exclusion list of tests
+exclusions="$CVMFS_TEST_EXCLUDE"
 if [ $test_exclusions -ne 0 ]; then
-  exclusions=$@
-else
-  testsuite=$@
+  while [ $# -ne 0 ] && [ x"$1" != x"--" ]; do
+    exclusions="$exclusions $1"
+    shift
+  done
+  shift # get rid of '--'
 fi
 
-exclusions="$exclusions $CVMFS_TEST_EXCLUDE"
+testsuite="$@"
 if [ -z "$testsuite" ]; then
   testsuite=$(find src -mindepth 1 -maxdepth 1 -type d | sort)
 fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 usage() {
-  echo "$0 <logfile> [<test list> | -x <exclusion list>]"
+  echo "$0 <logfile> [-o xUnit XML output] [-x <exclusion list> --] [test list]"
 }
 
 export LC_ALL=C

--- a/test/test_functions
+++ b/test/test_functions
@@ -1506,20 +1506,28 @@ xunit_testcase() {
 
   local test_name="$(cat ${test_scratchdir}/name)"
   local test_number="$(cat ${test_scratchdir}/number)"
-  local t_elapsed="$(cat ${test_scratchdir}/elapsed)"
-  local log_begin=$(cat ${test_scratchdir}/log_begin)
-  local log_end=$(cat ${test_scratchdir}/log_end)
-  local log_length=$(( $log_end - $log_begin ))
 
   if [ -f ${test_scratchdir}/skipped ]; then
     cat >> $xml_file << EOF
     <testcase name="$test_name" status="notrun" time="0.000" classname="$CVMFS_TEST_CLASS_NAME" />
 EOF
-  elif [ -f ${test_scratchdir}/success ]; then
+    return 0
+  fi
+
+  local t_elapsed=$(cat ${test_scratchdir}/elapsed)
+
+  if [ -f ${test_scratchdir}/success ]; then
     cat >> $xml_file << EOF
     <testcase name="$test_name" status="run" time="$(milliseconds_to_seconds $t_elapsed)" classname="$CVMFS_TEST_CLASS_NAME" />
 EOF
-  elif [ -f ${test_scratchdir}/failure ]; then
+    return 0
+  fi
+
+  local log_begin=$(cat ${test_scratchdir}/log_begin)
+  local log_end=$(cat ${test_scratchdir}/log_end)
+  local log_length=$(( $log_end - $log_begin ))
+
+  if [ -f ${test_scratchdir}/failure ]; then
     local retval="$(cat ${test_scratchdir}/retval)"
     cat >> $xml_file << EOF
     <testcase name="$test_name" status="run" time="$(milliseconds_to_seconds $t_elapsed)" classname="$CVMFS_TEST_CLASS_NAME">
@@ -1528,8 +1536,7 @@ EOF
       </failure>
     </testcase>
 EOF
-  else
-    echo "Warning: unknown test state for '$test_name'"
+    return 0
   fi
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -1507,6 +1507,7 @@ xunit_testcase() {
   local test_name="$(cat ${test_scratchdir}/name)"
   local test_number="$(cat ${test_scratchdir}/number)"
 
+  # check if the test was skipped
   if [ -f ${test_scratchdir}/skipped ]; then
     cat >> $xml_file << EOF
     <testcase name="$test_name" status="notrun" time="0.000" classname="$CVMFS_TEST_CLASS_NAME" />
@@ -1516,6 +1517,7 @@ EOF
 
   local t_elapsed=$(cat ${test_scratchdir}/elapsed)
 
+  # check if the test was a success
   if [ -f ${test_scratchdir}/success ]; then
     cat >> $xml_file << EOF
     <testcase name="$test_name" status="run" time="$(milliseconds_to_seconds $t_elapsed)" classname="$CVMFS_TEST_CLASS_NAME" />
@@ -1527,6 +1529,7 @@ EOF
   local log_end=$(cat ${test_scratchdir}/log_end)
   local log_length=$(( $log_end - $log_begin ))
 
+  # check if the test has failed
   if [ -f ${test_scratchdir}/failure ]; then
     local retval="$(cat ${test_scratchdir}/retval)"
     cat >> $xml_file << EOF


### PR DESCRIPTION
This allows a finer grained test case selection in `run.sh` like this:

```bash
./run.sh -o output.xml -x src/001* src/002* -- src/0*
```

The above line would run all client integration test except number 001 and 002. Before it was only possible to *either* provide an exclusion list *or* a test list.

Furthermore it contains minor fixes in the xUnit export code.