### PR TITLE
TEST: xUnit Output in Cloud Tests + CentOS 7 Server Tests

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
-ut_retval=0
-it_retval=0
-s3_retval=0
-mg_retval=0
+retval = 0
 
 # allow apache access to the mounted server file system
 echo -n "setting SELinux labels for apache... "
@@ -21,19 +18,22 @@ echo "OK"
 
 # running unit test suite
 run_unittests --gtest_shuffle \
-              --gtest_death_test_use_fork || ut_retval=$?
+              --gtest_death_test_use_fork || retval=1
 
-echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&         \
-./run.sh $TEST_LOGFILE -x src/005-asetup               \
-                          src/004-davinci              \
-                          src/007-testjobs             \
-                          src/024-reload-during-asetup \
-                          src/5* || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/005-asetup                               \
+                                 src/004-davinci                              \
+                                 src/007-testjobs                             \
+                                 src/024-reload-during-asetup                 \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
 
 # TODO: enable this as soon as 2.1.20 is released
 echo "skipping CernVM-FS migration test case (no EL7 package for 2.1.19)"
 #./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $s3_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -40,8 +40,10 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               || retval=1
 
 
-# TODO: enable this as soon as 2.1.20 is released
-echo "skipping CernVM-FS migration test case (no EL7 package for 2.1.19)"
-#./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+echo "running CernVM-FS migration test cases..."
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -43,7 +43,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -32,6 +32,14 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/0*                                       \
                               || retval=1
 
+
+echo "running CernVM-FS server test cases..."
+CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                 src/5*                                       \
+                              || retval=1
+
+
 # TODO: enable this as soon as 2.1.20 is released
 echo "skipping CernVM-FS migration test case (no EL7 package for 2.1.19)"
 #./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -131,7 +131,8 @@ check_result() {
 
 run_unittests() {
   echo -n "running CernVM-FS unit tests... "
-  cvmfs_unittests $@ >> $UNITTEST_LOGFILE 2>&1
+  local xml_output="${UNITTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}"
+  cvmfs_unittests --gtest_output="xml:$xml_output" $@ >> $UNITTEST_LOGFILE 2>&1
   local ut_retval=$?
   check_result $ut_retval
 

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -77,7 +77,8 @@ if [ x$SOURCE_DIRECTORY      = "x" ] ||
   exit 100
 fi
 
-TEST_LOGFILE="${LOG_DIRECTORY}/test.log"
+CLIENT_TEST_LOGFILE="${LOG_DIRECTORY}/test_client.log"
+SERVER_TEST_LOGFILE="${LOG_DIRECTORY}/test_server.log"
 TEST_S3_LOGFILE="${LOG_DIRECTORY}/test_s3.log"
 FAKE_S3_LOGFILE="${LOG_DIRECTORY}/fake_s3.log"
 UNITTEST_LOGFILE="${LOG_DIRECTORY}/unittest.log"

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -83,6 +83,8 @@ FAKE_S3_LOGFILE="${LOG_DIRECTORY}/fake_s3.log"
 UNITTEST_LOGFILE="${LOG_DIRECTORY}/unittest.log"
 MIGRATIONTEST_LOGFILE="${LOG_DIRECTORY}/migrationtest.log"
 
+XUNIT_OUTPUT_SUFFIX=".xunit.xml"
+
 # check that the script is running under the correct user account
 if [ $(id --user --name) != "sftnight" ]; then
   echo "test cases need to run under user 'sftnight'... aborting"

--- a/test/cloud_testing/platforms/slc5_i386_test.sh
+++ b/test/cloud_testing/platforms/slc5_i386_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
 # format additional disks with ext4 and many inodes
@@ -16,23 +16,28 @@ echo -n "mounting new disk partition into cvmfs specific location... "
 mount_partition $disk_to_partition$partition /var/lib/cvmfs || die "fail (mounting /var/lib/cvmfs $?)"
 echo "done"
 
-ut_retval=0
-it_retval=0
-mg_retval=0
+retval=0
 
 # running unit test suite
-run_unittests --gtest_shuffle || ut_retval=$?
+run_unittests --gtest_shuffle || retval=1
 
-echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/004-davinci               \
-                          src/005-asetup                \
-                          src/007-testjobs              \
-                          src/024-reload-during-asetup  \
-                          src/045-oasis                 \
-                          src/5* || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/004-davinci                              \
+                                 src/005-asetup                               \
+                                 src/007-testjobs                             \
+                                 src/024-reload-during-asetup                 \
+                                 src/045-oasis                                \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/slc5_i386_test.sh
+++ b/test/cloud_testing/platforms/slc5_i386_test.sh
@@ -37,7 +37,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -99,7 +99,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
-ut_retval=0
-it_retval=0
-mg_retval=0
+retval=0
 
 # check $PATH variable
 extend_path() {
@@ -70,21 +68,38 @@ sudo restorecon -R /var/lib/cvmfs || die "fail"
 echo "done"
 
 # running unit test suite
-run_unittests --gtest_shuffle || ut_retval=$?
+run_unittests --gtest_shuffle || retval=1
 
-echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-export CVMFS_TEST_SERVER_CACHE='/srv/cache/server' &&                  \
-./run.sh $TEST_LOGFILE -x src/004-davinci                              \
-                          src/007-testjobs                             \
-                          src/045-oasis                                \
-                          src/518-hardlinkstresstest                   \
-                          src/523-corruptchunkfailover                 \
-                          src/524-corruptmanifestfailover              \
-                          src/577-garbagecollecthiddenstratum1revision \
-                          src/579-garbagecollectstratum1legacytag || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/004-davinci                              \
+                                 src/007-testjobs                             \
+                                 src/045-oasis                                \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
+
+
+echo "running CernVM-FS server test cases..."
+CVMFS_TEST_SERVER_CACHE='/srv/cache/server'                                   \
+CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/518-hardlinkstresstest                   \
+                                 src/523-corruptchunkfailover                 \
+                                 src/524-corruptmanifestfailover              \
+                                 src/577-garbagecollecthiddenstratum1revision \
+                                 src/579-garbagecollectstratum1legacytag      \
+                                 --                                           \
+                                 src/5*                                       \
+                              || retval=1
+
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/slc6_i386_test.sh
+++ b/test/cloud_testing/platforms/slc6_i386_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
 # format additional disks with ext4 and many inodes
@@ -21,22 +21,29 @@ echo -n "restoring SELinux context for /var/lib/cvmfs... "
 sudo restorecon -R /var/lib/cvmfs || die "fail"
 echo "done"
 
-ut_retval=0
-it_retval=0
-mg_retval=0
+retval=0
 
 # running unit test suite
-run_unittests --gtest_shuffle || ut_retval=$?
+run_unittests --gtest_shuffle || retval=1
 
-echo "running CernVM-FS test cases..."
+
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/004-davinci              \
-                          src/005-asetup               \
-                          src/007-testjobs             \
-                          src/024-reload-during-asetup \
-                          src/5* || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/004-davinci                              \
+                                 src/005-asetup                               \
+                                 src/007-testjobs                             \
+                                 src/024-reload-during-asetup                 \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
+
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/slc6_i386_test.sh
+++ b/test/cloud_testing/platforms/slc6_i386_test.sh
@@ -43,7 +43,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
@@ -39,7 +39,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-EXCLCACHE_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
 # format additional disks with ext4 and many inodes
@@ -21,20 +21,25 @@ echo -n "restoring SELinux context for /var/lib/cvmfs... "
 sudo restorecon -R /var/lib/cvmfs || die "fail"
 echo "done"
 
-ut_retval=0
-it_retval=0
-mg_retval=0
+retval=0
 
 # run tests
-echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/005-asetup               \
-                          src/024-reload-during-asetup \
-                          src/035-unpinumount          \
-                          src/042-cleanuppipes         \
-                          src/5* || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/005-asetup                               \
+                                 src/024-reload-during-asetup                 \
+                                 src/035-unpinumount                          \
+                                 src/042-cleanuppipes                         \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
@@ -40,7 +40,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-INFOHEADER_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
 # format additional disks with ext4 and many inodes
@@ -21,20 +21,26 @@ echo -n "restoring SELinux context for /var/lib/cvmfs... "
 sudo restorecon -R /var/lib/cvmfs || die "fail"
 echo "done"
 
-ut_retval=0
-it_retval=0
-mg_retval=0
+retval=0
 
 # run tests
-echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/005-asetup               \
-                          src/024-reload-during-asetup \
-                          src/035-unpinumount          \
-                          src/042-cleanuppipes         \
-                          src/5* || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/005-asetup                               \
+                                 src/024-reload-during-asetup                 \
+                                 src/035-unpinumount                          \
+                                 src/042-cleanuppipes                         \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
+
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
 # format additional disks with ext4 and many inodes
@@ -21,23 +21,29 @@ echo -n "restoring SELinux context for /var/lib/cvmfs... "
 sudo restorecon -R /var/lib/cvmfs || die "fail"
 echo "done"
 
-ut_retval=0
-it_retval=0
-mg_retval=0
+retval=0
 
 # run tests
-echo "running CernVM-FS test cases..."
 cd ${SOURCE_DIRECTORY}/test
-./run.sh $TEST_LOGFILE -x src/001-chksetup             \
-                          src/005-asetup               \
-                          src/008-default_domain       \
-                          src/024-reload-during-asetup \
-                          src/026-tightcache           \
-                          src/041-rocache              \
-                          src/043-highinodes           \
-                          src/5* || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/001-chksetup                             \
+                                 src/005-asetup                               \
+                                 src/008-default_domain                       \
+                                 src/024-reload-during-asetup                 \
+                                 src/026-tightcache                           \
+                                 src/041-rocache                              \
+                                 src/043-highinodes                           \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
+
 
 echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
@@ -43,7 +43,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 
 # source the common platform independent functionality and option parsing
-script_location=$(dirname $(readlink --canonicalize $0))
+script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
-ut_retval=0
-it_retval=0
-s3_retval=0
-mg_retval=0
+retval=0
 
 # format additional disks with ext4 and many inodes
 echo -n "formatting new disk partitions... "
@@ -55,55 +52,78 @@ echo "done"
 
 # running unit test suite
 run_unittests --gtest_shuffle \
-              --gtest_death_test_use_fork || ut_retval=$?
+              --gtest_death_test_use_fork || retval=1
 
-echo "running CernVM-FS test cases..."
+
 cd ${SOURCE_DIRECTORY}/test
-export CVMFS_TEST_SERVER_CACHE='/srv/cache' &&                         \
-./run.sh $TEST_LOGFILE -x src/005-asetup                               \
-                          src/024-reload-during-asetup                 \
-                          src/518-hardlinkstresstest                   \
-                          src/523-corruptchunkfailover                 \
-                          src/524-corruptmanifestfailover              \
-                          src/577-garbagecollecthiddenstratum1revision \
-                          src/579-garbagecollectstratum1legacytag || it_retval=$?
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/005-asetup                               \
+                                 src/024-reload-during-asetup                 \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
+
+
+echo "running CernVM-FS server test cases..."
+CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
+CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/518-hardlinkstresstest                   \
+                                 src/523-corruptchunkfailover                 \
+                                 src/524-corruptmanifestfailover              \
+                                 src/577-garbagecollecthiddenstratum1revision \
+                                 src/579-garbagecollectstratum1legacytag      \
+                                 --                                           \
+                                 src/5*                                       \
+                              || retval=1
+
 
 echo -n "starting FakeS3 service... "
-fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=$?; die "fail"; }
+s3_retval=0
+fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
 echo "done ($fakes3_pid)"
 
 if [ $s3_retval -eq 0 ]; then
-    echo "running CernVM-FS server test cases against FakeS3..."
-    export CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                    &&         \
-    export CVMFS_TEST_STRATUM0=$FAKE_S3_URL                        &&         \
-    export CVMFS_TEST_SERVER_CACHE='/srv/cache'                    &&         \
-    ./run.sh $TEST_S3_LOGFILE -x src/0*                                       \
-                                 src/518-hardlinkstresstest                   \
-                                 src/519-importlegacyrepo                     \
-                                 src/522-missingchunkfailover                 \
-                                 src/523-corruptchunkfailover                 \
-                                 src/524-corruptmanifestfailover              \
-                                 src/525-bigrepo                              \
-                                 src/528-recreatespoolarea                    \
-                                 src/530-recreatespoolarea_defaultkey         \
-                                 src/537-symlinkedbackend                     \
-                                 src/538-symlinkedstratum1backend             \
-                                 src/542-storagescrubbing                     \
-                                 src/543-storagescrubbing_scriptable          \
-                                 src/550-livemigration                        \
-                                 src/563-garbagecollectlegacy                 \
-                                 src/568-migratecorruptrepo                   \
-                                 src/571-localbackendumask                    \
-                                 src/572-proxyfailover                        \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
-                                 src/583-httpredirects || s3_retval=$?
+  echo "running CernVM-FS server test cases against FakeS3..."
+  CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
+  CVMFS_TEST_STRATUM0=$FAKE_S3_URL                                          \
+  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/524-corruptmanifestfailover              \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/577-garbagecollecthiddenstratum1revision \
+                               src/579-garbagecollectstratum1legacytag      \
+                               src/583-httpredirects                        \
+                               --                                           \
+                               src/5* || retval=1
 
-    echo -n "killing FakeS3... "
-    sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
+  echo -n "killing FakeS3... "
+  sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
 fi
 
-echo "running CernVM-FS migration test cases..."
-./run.sh $MIGRATIONTEST_LOGFILE migration_tests/001-hotpatch || mg_retval=$?
 
-[ $ut_retval -eq 0 ] && [ $it_retval -eq 0 ] && [ $s3_retval -eq 0 ] && [ $mg_retval -eq 0 ]
+echo "running CernVM-FS migration test cases..."
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/001-hotpatch                   \
+                                || retval=1
+
+exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -123,7 +123,7 @@ fi
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -40,7 +40,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/001-hotpatch                   \
+                                   migration_tests/*                              \
                                 || retval=1
 
 exit $retval


### PR DESCRIPTION
This changes the cloud test scripts in the following way:

* Produce xUnit XML outputs for unit tests and integration tests
* Split integration tests into *client* and *server* test runs
* Produce xUnit XML for S3 server tests (currently only on SLC6 x86_64)
* Enable server integration tests on CentOS 7 (OverlayFS - many failures expected)
* Enable migration tests on CentOS 7
* Automatically pick up new migration tests

Furthermore this contains minor script improvements in the cloud test scripts and builds on top of [TEST: Finer Grained Integration Test Selection](https://github.com/cvmfs/cvmfs/pull/846).