### PR TITLE
TEST: Migration Test Adaptions for 2.1.20 to 2.1.21

### DIFF
--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -194,7 +194,7 @@ cvmfs_run_test() {
   echo "updating CernVM-FS package to version $current_version"
   kill -0 $tar_pid || return 11 # tar finished already >.<
   kill -0 $chksum_pid || return 11 # checksumming finished already >.<
-  install_packages "$CVMFS_CLIENT_PACKAGE $CVMFS_CONFIG_PACKAGES" || return 12 # TODO: revert that after 2.1.20 is released
+  install_packages "$CVMFS_CLIENT_PACKAGE"
   kill -0 $tar_pid || return 13 # tar finished already >.<
   kill -0 $chksum_pid || return 13 # checksumming finished already >.<
 

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -146,22 +146,6 @@ cvmfs_run_test() {
     uninstall_package "cvmfs" || return 3
   fi
 
-  # uninstall the cvmfs-config package for CernVM-FS and replace it by the
-  # last released cvmfs-keys package (1.5-1)
-  # Note: this will not be needed after CernVM-FS 2.1.20 is released
-  #       furthermore the re-install of cvmfs-config is not needed later on!
-  cvmfs_config_pkgs="$(get_providing_packages cvmfs-config)"
-  echo "Uninstalling $cvmfs_config_pkgs (providing cvmfs-config)"
-  for cvmfs_config_pkg in $cvmfs_config_pkgs; do
-    uninstall_package $cvmfs_config_pkg || return 20
-  done
-
-  local cvmfs_keys_url=$(guess_cvmfs_keys_url "1.5-1")
-  local cvmfs_keys=$(basename $cvmfs_keys_url)
-  echo "Download URL for cvmfs-keys: $cvmfs_keys_url"
-  wget --no-check-certificate --quiet $cvmfs_keys_url || return 21
-  install_packages $cvmfs_keys                        || return 22
-
   # install the upstream CernVM-FS package
   echo "installing CernVM-FS $previous_version"
   install_packages $upstream_package || return 4


### PR DESCRIPTION
CernVM-FS 2.1.20 introduced the new `cvmfs-config-*` packages which replaced `cvmfs-keys`. The hotpatch migration test cases needed to take that into account. Now, as CernVM-FS 2.1.20 has been released, the migration test case must forget about `cvmfs-keys` and `cvmfs-config-*` entirely as this is supposed to be handled by `yum` respectively `apt-get` again.