### PR TITLE
FIX: Kernel Deadlock in CentOS 7 with OverlayFS + Hardlink Stresstest in Ubuntu 12.04

### DIFF
--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -39,7 +39,8 @@ echo "running CernVM-FS server test cases..."
 CVMFS_TEST_SERVER_CACHE="$custom_cache_dir"                                   \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                              -x src/523-corruptchunkfailover                 \
+                              -x src/518-hardlinkstresstest                   \
+                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \


### PR DESCRIPTION
Seems that OverlayFS suffers from the same problem as old AUFS versions. :-( This adds the [kernel deadlock workaround](http://cernvm.cern.ch/portal/cvmfs/workaround-krnl-deadlock) to the CentOS 7 integration test context. 

Furthermore this disables the hardlink stresstest for Ubuntu 12.04 since the AUFS version is too old to handle it correctly in this distribution.