### PR TITLE
FIX: Dirtab Application Leaks Temporary Catalog Database Files

### DIFF
--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -163,7 +163,7 @@ class Catalog : public SingleCopy {
   void TakeDatabaseFileOwnership();
   void DropDatabaseFileOwnership();
   bool OwnsDatabaseFile() const {
-    return NULL != database_ && database_->OwnsFile();
+    return ((database_ != NULL) && database_->OwnsFile()) || managed_database_;
   }
 
   uint64_t GetTTL() const;
@@ -256,6 +256,7 @@ class Catalog : public SingleCopy {
   PathString path_;
   bool volatile_flag_;
   const bool is_root_;
+  bool managed_database_;
 
   Catalog *parent_;
   NestedCatalogMap children_;

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -55,11 +55,10 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
 }
 
 
-Catalog* SimpleCatalogManager::CreateCatalog(
-  const PathString  &mountpoint,
-  const shash::Any  &catalog_hash,
-  Catalog           *parent_catalog
-) {
+Catalog* SimpleCatalogManager::CreateCatalog(const PathString  &mountpoint,
+                                             const shash::Any  &catalog_hash,
+                                             Catalog           *parent_catalog)
+{
   Catalog *new_catalog = new Catalog(mountpoint, catalog_hash, parent_catalog);
   if (manage_catalog_files_) {
     new_catalog->TakeDatabaseFileOwnership();

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -47,6 +47,7 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
     LogCvmfs(kLogCatalog, kLogStderr,
              "failed to load %s from Stratum 0 (%d - %s)", url.c_str(),
              retval, download::Code2Ascii(retval));
+    unlink(catalog_path->c_str());
     assert(false);
   }
 

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -60,7 +60,12 @@ Catalog* SimpleCatalogManager::CreateCatalog(
   const shash::Any  &catalog_hash,
   Catalog           *parent_catalog
 ) {
-  return new Catalog(mountpoint, catalog_hash, parent_catalog);
+  Catalog *new_catalog = new Catalog(mountpoint, catalog_hash, parent_catalog);
+  if (manage_catalog_files_) {
+    new_catalog->TakeDatabaseFileOwnership();
+  }
+
+  return new_catalog;
 }
 
 }  // namespace catalog

--- a/cvmfs/catalog_mgr_ro.h
+++ b/cvmfs/catalog_mgr_ro.h
@@ -63,9 +63,9 @@ class SimpleCatalogManager : public AbstractCatalogManager {
   }
 
  private:
-  shash::Any                 base_hash_;
-  std::string                stratum0_;
-  std::string                dir_temp_;
+  shash::Any                  base_hash_;
+  std::string                 stratum0_;
+  std::string                 dir_temp_;
   download::DownloadManager  *download_manager_;
   const bool                  manage_catalog_files_;
 };  // class SimpleCatalogManager

--- a/cvmfs/catalog_mgr_ro.h
+++ b/cvmfs/catalog_mgr_ro.h
@@ -31,11 +31,13 @@ class SimpleCatalogManager : public AbstractCatalogManager {
     const shash::Any           &base_hash,
     const std::string          &stratum0,
     const std::string          &dir_temp,
-    download::DownloadManager  *download_manager)
+    download::DownloadManager  *download_manager,
+    const bool                  manage_catalog_files = false)
     : base_hash_(base_hash)
     , stratum0_(stratum0)
     , dir_temp_(dir_temp)
-    , download_manager_(download_manager) { }
+    , download_manager_(download_manager)
+    , manage_catalog_files_(manage_catalog_files) { }
 
  protected:
   virtual LoadError LoadCatalog(const PathString  &mountpoint,
@@ -65,6 +67,7 @@ class SimpleCatalogManager : public AbstractCatalogManager {
   std::string                stratum0_;
   std::string                dir_temp_;
   download::DownloadManager  *download_manager_;
+  const bool                  manage_catalog_files_;
 };  // class SimpleCatalogManager
 
 }  // namespace catalog

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -899,7 +899,7 @@ close_transaction() {
     cvmfs_suid_helper rdonly_umount $name
   fi
   cvmfs_suid_helper clear_scratch $name
-  rm -rf ${tmp_dir}/*
+  [ -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
   cvmfs_suid_helper rdonly_mount $name > /dev/null
   cvmfs_suid_helper rw_mount $name
   rmdir "$tx_lock"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -899,7 +899,7 @@ close_transaction() {
     cvmfs_suid_helper rdonly_umount $name
   fi
   cvmfs_suid_helper clear_scratch $name
-  rm -rf "${tmp_dir}/*"
+  rm -rf ${tmp_dir}/*
   cvmfs_suid_helper rdonly_mount $name > /dev/null
   cvmfs_suid_helper rw_mount $name
   rmdir "$tx_lock"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -899,7 +899,7 @@ close_transaction() {
     cvmfs_suid_helper rdonly_umount $name
   fi
   cvmfs_suid_helper clear_scratch $name
-  [ -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
+  [ ! -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
   cvmfs_suid_helper rdonly_mount $name > /dev/null
   cvmfs_suid_helper rw_mount $name
   rmdir "$tx_lock"

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -147,8 +147,9 @@ bool Database<DerivedT>::OpenDatabase(const int flags) {
 template <class DerivedT>
 Database<DerivedT>::DatabaseRaiiWrapper::~DatabaseRaiiWrapper() {
   if (NULL != sqlite_db) {
-    LogCvmfs(kLogSql, kLogDebug, "closing SQLite database '%s'",
-             filename().c_str());
+    LogCvmfs(kLogSql, kLogDebug, "closing SQLite database '%s' (unlink: %s)",
+             filename().c_str(),
+             (db_file_guard.IsEnabled() ? "yes" : "no"));
     const int result = sqlite3_close(sqlite_db);
     if (result != SQLITE_OK) {
       LogCvmfs(kLogSql, kLogDebug,

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -247,10 +247,12 @@ int swissknife::CommandApplyDirtab::Main(const ArgumentList &args) {
 
   // initialize catalog infrastructure
   g_download_manager->Init(1, true);
+  const bool auto_manage_catalog_files = true;
   catalog::SimpleCatalogManager catalog_manager(base_hash,
                                                 stratum0,
                                                 dir_temp,
-                                                g_download_manager);
+                                                g_download_manager,
+                                                auto_manage_catalog_files);
   catalog_manager.Init();
 
   vector<string> new_nested_catalogs;

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -49,6 +49,12 @@ cvmfs_run_test() {
   echo "list newly generated repository under /cvmfs/${legacy_repo_name}"
   ls -lisa /cvmfs/${legacy_repo_name} || return 5
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # check if the migrated and imported catalogs are sane
   echo "check migrated catalogs and data chunks"
   check_repository $legacy_repo_name || return 6
@@ -72,6 +78,9 @@ cvmfs_run_test() {
   # check if still everything is fine
   echo "check catalogs again"
   check_repository $legacy_repo_name || return 7
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # see if the files ended up in the catalog
   echo "check created files"

--- a/test/src/544-cvmfsdirtab/main
+++ b/test/src/544-cvmfsdirtab/main
@@ -161,6 +161,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -177,6 +180,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository (1)"
   check_catalog_presence_1 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -195,6 +201,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository (2)"
   check_catalog_presence_2 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 51
 
   # ============================================================================
 
@@ -223,6 +232,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository (4)"
   check_catalog_presence_4 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 52
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -245,6 +257,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository (5)"
   check_catalog_presence_5 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 53
 
   return 0
 }

--- a/test/src/546-extendeddirtab/main
+++ b/test/src/546-extendeddirtab/main
@@ -198,6 +198,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -214,6 +217,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_1 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -232,6 +238,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_2 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -249,6 +258,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_3 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -265,6 +277,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_4 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -295,6 +310,9 @@ cvmfs_run_test() {
 
   echo "abort transaction"
   abort_transaction $CVMFS_TEST_REPO || return 13
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   return 0
 }

--- a/test/src/549-dirtabexclusions/main
+++ b/test/src/549-dirtabexclusions/main
@@ -181,6 +181,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -197,6 +200,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_1 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -215,6 +221,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_2 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -232,6 +241,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_3 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -248,6 +260,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_4 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   return 0
 }

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -129,6 +129,9 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
   echo "disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
@@ -146,6 +149,9 @@ cvmfs_run_test() {
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir1 || return $?
@@ -165,6 +171,9 @@ cvmfs_run_test() {
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
   condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir2 || return $?
@@ -186,6 +195,9 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?
   preserved_clgs="$preserved_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir3 || return $?
 
@@ -206,6 +218,9 @@ cvmfs_run_test() {
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_4.log 2>&1 || return $?
   preserved_clgs="$preserved_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir4 || return $?
@@ -240,6 +255,9 @@ cvmfs_run_test() {
   echo "perform basic garbage collection"
   cvmfs_server gc -f $CVMFS_TEST_REPO || return 11
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   echo "check if shakespeare is gone"
   peek_backend $CVMFS_TEST_REPO $shakespeare_object    && return 12
   peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_1 && return 12
@@ -269,6 +287,9 @@ cvmfs_run_test() {
 
   echo "check if the repository's previous revision is still sane"
   check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 17
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   return 0
 }

--- a/test/src/565-dirtabwildcardexclusions/main
+++ b/test/src/565-dirtabwildcardexclusions/main
@@ -187,6 +187,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -203,6 +206,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_1 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -221,6 +227,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_2 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -238,6 +247,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_3 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -254,6 +266,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository"
   check_catalog_presence_4 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   return 0
 }

--- a/test/src/566-dirtabrecreatenested/main
+++ b/test/src/566-dirtabrecreatenested/main
@@ -244,6 +244,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -265,6 +268,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository (0)"
   check_catalog_presence_0 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -285,6 +291,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository (1)"
   check_catalog_presence_1 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -311,6 +320,9 @@ cvmfs_run_test() {
   echo "check if eventually the right catalogs are present in the repository (2)"
   check_catalog_presence_2 $CVMFS_TEST_REPO || return $?
 
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -331,6 +343,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository (3)"
   check_catalog_presence_3 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   # ============================================================================
 
@@ -355,6 +370,9 @@ cvmfs_run_test() {
 
   echo "check if eventually the right catalogs are present in the repository (4)"
   check_catalog_presence_4 $CVMFS_TEST_REPO || return $?
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
   return 0
 }


### PR DESCRIPTION
As described in [CVM-818](https://sft.its.cern.ch/jira/browse/CVM-818) the application of `.cvmfsdirtab` doesn't properly remove temporarily downloaded catalog database files. This fixes it by adding an auto-management feature to `SimpleCatalogManager`. It uses the `TakeDatabaseFileOwnership()` method of `Catalog` to automatically clean up the underlying SQLite database files as soon as a catalog is closed.

Furthermore this fixes a malformed shell quotation in `cvmfs_server` that would have acted as a safe guard to clear out the temp directory after each publishing. During normal operation the procedures in `cvmfs_swissknife` should not leak any tmp files. However, crashes or user aborts could still cause it (cf. [CVM-816](https://sft.its.cern.ch/jira/browse/CVM-816)), hence I'd like to keep this safe guard in place.

Also this introduces checks for an empty tmp directory in various integration test cases.