### PR TITLE
Fix S3 and download HTTP redirects

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1054,7 +1054,7 @@ get_item() {
   local noproxy="$2"
 
   if [ x"$noproxy" != x"" ]; then
-    unset http_proxy && curl "$url" 2>/dev/null
+    unset http_proxy && curl -L "$url" 2>/dev/null
   else
     curl "$url" 2>/dev/null
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -793,12 +793,17 @@ is_master_replica() {
   local name=$1
   local is_master_replica
 
+  load_repo_config $name
+  local swissknife_info_params="-m"
+  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+    swissknife_info_params="${swissknife_info_params} -L"
+  fi
+
   if [ $(echo $name | cut --bytes=1-7) = "http://" ]; then
-    is_master_replica=$(cvmfs_swissknife info -r $name -m 2>/dev/null)
+    is_master_replica=$(cvmfs_swissknife info -r $name ${swissknife_info_params} 2>/dev/null)
   else
     is_stratum0 $name || return 1
-    load_repo_config $name
-    is_master_replica=$(cvmfs_swissknife info -r $CVMFS_STRATUM0 -m 2>/dev/null)
+    is_master_replica=$(cvmfs_swissknife info -r $CVMFS_STRATUM0 ${swissknife_info_params} 2>/dev/null)
   fi
 
   [ "x$is_master_replica" = "xtrue" ]
@@ -815,7 +820,11 @@ is_garbage_collectable() {
   if is_stratum0 $name; then
     [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]
   else
-    [ x"$(cvmfs_swissknife info -r $CVMFS_STRATUM1 -g)" = x"yes" ]
+    local swissknife_info_params="-g"
+    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+      swissknife_info_params="${swissknife_info_params} -L"
+    fi
+    [ x"$(cvmfs_swissknife info -r $CVMFS_STRATUM1 ${swissknife_info_params})" = x"yes" ]
   fi
 }
 
@@ -1050,13 +1059,20 @@ try_mount_remount_cycle_overlayfs() {
 # download a given file from the backend storage
 # @param noproxy  (optional)
 get_item() {
-  local url="$1"
-  local noproxy="$2"
+  local name="$1"
+  local url="$2"
+  local noproxy="$3"
+
+  load_repo_config $name
+  curl_cmd="curl"
+  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+    curl_cmd="${curl_cmd} -L"
+  fi
 
   if [ x"$noproxy" != x"" ]; then
-    unset http_proxy && curl -L "$url" 2>/dev/null
+    unset http_proxy && ${curl_cmd} "$url" 2>/dev/null
   else
-    curl "$url" 2>/dev/null
+    ${curl_cmd} "$url" 2>/dev/null
   fi
 }
 
@@ -1485,9 +1501,10 @@ create_whitelist() {
 # @param stratum0  path/URL to stratum0 storage
 # @return          number of seconds until expiry (negativ if already expired)
 get_expiry() {
-  local stratum0=$1
+  local name=$1
+  local stratum0=$2
 
-  local expires=$(get_item $stratum0/.cvmfswhitelist 'noproxy' | head -2 | tail -1 | tail -c15)
+  local expires=$(get_item $name $stratum0/.cvmfswhitelist 'noproxy' | head -2 | tail -1 | tail -c15)
   if echo $expires | grep -q -E --invert-match '^[0-9]{14}$'; then
     echo -1
     return 1
@@ -1512,10 +1529,11 @@ get_expiry() {
 # @param stratum0  path/URL to stratum0 storage
 # @return          0 if whitelist is still valid
 check_expiry() {
-  local stratum0=$1
+  local name=$1
+  local stratum0=$2
   local expiry="-1"
 
-  expiry=$(get_expiry $stratum0)
+  expiry=$(get_expiry $name $stratum0)
   if [ $? -ne 0 ]; then
     echo "Failed to retrieve repository expiry date" >&2
     return 100
@@ -1734,7 +1752,11 @@ get_published_root_hash() {
   local repository_name=$1
 
   load_repo_config $repository_name
-  cvmfs_swissknife info -r $CVMFS_STRATUM0 -c
+  local swissknife_info_params="-c"
+  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+    swissknife_info_params="${swissknife_info_params} -L"
+  fi
+  cvmfs_swissknife info -r $CVMFS_STRATUM0 ${swissknife_info_params}
 }
 
 
@@ -1893,6 +1915,7 @@ CVMFS_IGNORE_SIGNATURE=no
 CVMFS_AUTO_UPDATE=no
 CVMFS_NFS_SOURCE=no
 CVMFS_HIDE_MAGIC_XATTRS=yes
+CVMFS_FOLLOW_REDIRECTS=yes
 EOF
 }
 
@@ -2543,7 +2566,7 @@ add_replica() {
   public_key=$2
 
   # get the name of the repository pointed to by $stratum0
-  name=$(cvmfs_swissknife info -r $stratum0 -n 2>/dev/null) || die "Failed to access Stratum0 repository at $stratum0"
+  name=$(cvmfs_swissknife info -L -r $stratum0 -n 2>/dev/null) || die "Failed to access Stratum0 repository at $stratum0"
   if [ x$alias_name = x"" ]; then
     alias_name=$name
   else
@@ -3110,7 +3133,7 @@ info() {
   local replication_allowed="yes"
   is_master_replica $name || replication_allowed="no"
   echo "Stratum1 Replication Allowed: $replication_allowed"
-  local expire_countdown=$(get_expiry $stratum0)
+  local expire_countdown=$(get_expiry $name $stratum0)
   if [ $expire_countdown -le 0 ]; then
     echo "Whitelist is expired"
   else
@@ -3259,6 +3282,10 @@ tag() {
   # adds (or moves) a tag in the database
   if [ $action_add -eq 1 ]; then
     local new_manifest="${CVMFS_SPOOL_DIR}/tmp/manifest"
+    local swissknife_tag_create_params=""
+    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+      swissknife_tag_create_params="${swissknife_tag_create_params} -L"
+    fi
     local tag_create_command="cvmfs_swissknife tag_create \
       -w $CVMFS_STRATUM0                                  \
       -t ${CVMFS_SPOOL_DIR}/tmp                           \
@@ -3269,6 +3296,7 @@ tag() {
       -m $new_manifest                                    \
       -b $base_hash                                       \
       -e $hash_algorithm                                  \
+      $swissknife_tag_create_params                       \
       -a $tag_name"
     if [ ! -z "$add_tag_channel" ]; then
       tag_create_command="$tag_create_command -c $add_tag_channel"
@@ -3444,7 +3472,7 @@ list() {
     local whitelist_info=""
     if is_stratum0 $name; then
       local retval=0
-      check_expiry $CVMFS_STRATUM0 2>/dev/null || retval=$?
+      check_expiry $name $CVMFS_STRATUM0 2>/dev/null || retval=$?
       if [ $retval -eq 100 ]; then
         whitelist_info=" - whitelist unreachable"
       elif [ $retval -ne 0 ]; then
@@ -3513,8 +3541,8 @@ transaction() {
     if [ $force -eq 0 ]; then
       is_in_transaction $name && { echo "Repository $name is already in a transaction"; retcode=1; continue; }
     fi
-    check_expiry $stratum0 || { echo "Repository whitelist for $name is expired!"; retcode=1; continue; }
-    [ $(get_expiry $stratum0) -le $(( 12 * 60 * 60 )) ] && { echo "Warning: Repository whitelist stays valid for less than 12 hours!"; }
+    check_expiry $name $stratum0 || { echo "Repository whitelist for $name is expired!"; retcode=1; continue; }
+    [ $(get_expiry $name $stratum0) -le $(( 12 * 60 * 60 )) ] && { echo "Warning: Repository whitelist stays valid for less than 12 hours!"; }
 
     # do it!
     transaction_before_hook $name
@@ -3692,12 +3720,16 @@ publish() {
     # more sanity checks
     is_owner_or_root $name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }
     check_repository_compatibility
-    check_expiry $stratum0         || { echo "Repository whitelist for $name is expired!"; retcode=1; continue; }
+    check_expiry $name $stratum0   || { echo "Repository whitelist for $name is expired!"; retcode=1; continue; }
     is_in_transaction $name        || { echo "Repository $name is not in a transaction"; retcode=1; continue; }
     [ $(count_wr_fds /cvmfs/$name) -eq 0 ] || { echo "Open writable file descriptors on $name"; retcode=1; continue; }
     is_cwd_on_path "/cvmfs/$name" && { echo "Current working directory is in /cvmfs/$name.  Please release, e.g. by 'cd \$HOME'."; retcode=1; continue; } || true
     gc_timespan="$(get_auto_garbage_collection_timespan $name)" || { retcode=1; continue; }
-    local revision_number=$($swissknife info -r $stratum0 -v)
+    local swissknife_info_params="-v"
+    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+      swissknife_info_params="${swissknife_info_params} -L"
+    fi
+    local revision_number=$($swissknife info -r $stratum0 ${swissknife_info_params})
     if [ x"$manual_revision" != x"" ] && [ $manual_revision -le $revision_number ]; then
       echo "Current revision '$revision_number' is ahead of manual revision number '$manual_revision'."
       retcode=1
@@ -3745,6 +3777,10 @@ publish() {
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-z $CVMFS_LOG_LEVEL"
 
+    local swissknife_sync_params=""
+    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+      swissknife_sync_params="${swissknife_sync_params} -L"
+    fi
     local sync_command="$swissknife sync $verbosity -u /cvmfs/$name \
       -s ${spool_dir}/scratch \
       -c ${spool_dir}/rdonly \
@@ -3754,6 +3790,7 @@ publish() {
       -w $stratum0 \
       -o $manifest \
       -e $hash_algorithm \
+      $swissknife_sync_params \
       $log_level $tweaks_option"
     if [ "x$CVMFS_UNION_FS_TYPE" != "x" ]; then
       sync_command="$sync_command -f $CVMFS_UNION_FS_TYPE"
@@ -3782,6 +3819,10 @@ publish() {
     if [ "x$CVMFS_MAXIMAL_CONCURRENT_WRITES" != "x" ]; then
       sync_command="$sync_command -q $CVMFS_MAXIMAL_CONCURRENT_WRITES"
     fi
+    local swissknife_tag_create_params=""
+    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+      swissknife_tag_create_params="${swissknife_tag_create_params} -L"
+    fi
     local tag_command="$swissknife tag_create \
       -r $upstream                            \
       -w $stratum0                            \
@@ -3791,6 +3832,7 @@ publish() {
       -f $name                                \
       -b $base_hash                           \
       -e $hash_algorithm                      \
+      $swissknife_tag_create_params           \
       -x" # -x enables magic undo tag handling
     if [ ! -z "$tag_name" ]; then
       tag_command="$tag_command -a $tag_name"
@@ -3915,7 +3957,7 @@ rollback() {
   # more sanity checks
   is_owner_or_root $name || die "Permission denied: Repository $name is owned by $user"
   check_repository_compatibility
-  check_expiry $stratum0  || die "Repository whitelist is expired!"
+  check_expiry $name $stratum0  || die "Repository whitelist is expired!"
   is_in_transaction $name && die "Cannot rollback a repository in a transaction"
   is_cwd_on_path "/cvmfs/$name" && die "Current working directory is in /cvmfs/$name.  Please release, e.g. by 'cd \$HOME'." || true
 
@@ -4073,7 +4115,11 @@ gc() {
     is_owner_or_root       $name || die "Permission denied: Repository $name is owned by $user"
     is_in_transaction      $name && die "Cannot run garbage collection while in a transaction"
 
-    local head_timestamp="$(cvmfs_swissknife info -r $CVMFS_STRATUM0 -t)"
+    local swissknife_info_params="-t"
+    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+      swissknife_info_params="${swissknife_info_params} -L"
+    fi
+    local head_timestamp="$(cvmfs_swissknife info -r $CVMFS_STRATUM0 ${swissknife_info_params})"
     [ $head_timestamp -gt $preserve_timestamp ] || die "Latest repository revision is older than given timestamp"
 
     # figure out the URL of the repository

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -794,16 +794,11 @@ is_master_replica() {
   local is_master_replica
 
   load_repo_config $name
-  local swissknife_info_params="-m"
-  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-    swissknife_info_params="${swissknife_info_params} -L"
-  fi
-
   if [ $(echo $name | cut --bytes=1-7) = "http://" ]; then
-    is_master_replica=$(cvmfs_swissknife info -r $name ${swissknife_info_params} 2>/dev/null)
+    is_master_replica=$(cvmfs_swissknife info -r $name -m $(get_follow_http_redirects_flag) 2>/dev/null)
   else
     is_stratum0 $name || return 1
-    is_master_replica=$(cvmfs_swissknife info -r $CVMFS_STRATUM0 ${swissknife_info_params} 2>/dev/null)
+    is_master_replica=$(cvmfs_swissknife info -r $CVMFS_STRATUM0 -m $(get_follow_http_redirects_flag) 2>/dev/null)
   fi
 
   [ "x$is_master_replica" = "xtrue" ]
@@ -820,11 +815,7 @@ is_garbage_collectable() {
   if is_stratum0 $name; then
     [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]
   else
-    local swissknife_info_params="-g"
-    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-      swissknife_info_params="${swissknife_info_params} -L"
-    fi
-    [ x"$(cvmfs_swissknife info -r $CVMFS_STRATUM1 ${swissknife_info_params})" = x"yes" ]
+    [ x"$(cvmfs_swissknife info -r $CVMFS_STRATUM1 -g $(get_follow_http_redirects_flag))" = x"yes" ]
   fi
 }
 
@@ -1064,15 +1055,11 @@ get_item() {
   local noproxy="$3"
 
   load_repo_config $name
-  curl_cmd="curl"
-  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-    curl_cmd="${curl_cmd} -L"
-  fi
 
   if [ x"$noproxy" != x"" ]; then
-    unset http_proxy && ${curl_cmd} "$url" 2>/dev/null
+    unset http_proxy && curl $(get_follow_http_redirects_flag) "$url" 2>/dev/null
   else
-    ${curl_cmd} "$url" 2>/dev/null
+    curl $(get_follow_http_redirects_flag) "$url" 2>/dev/null
   fi
 }
 
@@ -1752,11 +1739,8 @@ get_published_root_hash() {
   local repository_name=$1
 
   load_repo_config $repository_name
-  local swissknife_info_params="-c"
-  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-    swissknife_info_params="${swissknife_info_params} -L"
-  fi
-  cvmfs_swissknife info -r $CVMFS_STRATUM0 ${swissknife_info_params}
+
+  cvmfs_swissknife info -r $CVMFS_STRATUM0 -c $(get_follow_http_redirects_flag)
 }
 
 
@@ -2305,6 +2289,13 @@ alterfs() {
   fi
 }
 
+# Parse redirects configuration into redirect flag.
+# Assumes that config is loaded already, i.e. load_repo_config().
+get_follow_http_redirects_flag() {
+  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+    echo "-L"
+  fi
+}
 
 ################################################################################
 
@@ -3282,10 +3273,6 @@ tag() {
   # adds (or moves) a tag in the database
   if [ $action_add -eq 1 ]; then
     local new_manifest="${CVMFS_SPOOL_DIR}/tmp/manifest"
-    local swissknife_tag_create_params=""
-    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-      swissknife_tag_create_params="${swissknife_tag_create_params} -L"
-    fi
     local tag_create_command="cvmfs_swissknife tag_create \
       -w $CVMFS_STRATUM0                                  \
       -t ${CVMFS_SPOOL_DIR}/tmp                           \
@@ -3296,7 +3283,7 @@ tag() {
       -m $new_manifest                                    \
       -b $base_hash                                       \
       -e $hash_algorithm                                  \
-      $swissknife_tag_create_params                       \
+      $(get_follow_http_redirects_flag)                   \
       -a $tag_name"
     if [ ! -z "$add_tag_channel" ]; then
       tag_create_command="$tag_create_command -c $add_tag_channel"
@@ -3725,11 +3712,7 @@ publish() {
     [ $(count_wr_fds /cvmfs/$name) -eq 0 ] || { echo "Open writable file descriptors on $name"; retcode=1; continue; }
     is_cwd_on_path "/cvmfs/$name" && { echo "Current working directory is in /cvmfs/$name.  Please release, e.g. by 'cd \$HOME'."; retcode=1; continue; } || true
     gc_timespan="$(get_auto_garbage_collection_timespan $name)" || { retcode=1; continue; }
-    local swissknife_info_params="-v"
-    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-      swissknife_info_params="${swissknife_info_params} -L"
-    fi
-    local revision_number=$($swissknife info -r $stratum0 ${swissknife_info_params})
+    local revision_number=$($swissknife info -r $stratum0 -v $(get_follow_http_redirects_flag))
     if [ x"$manual_revision" != x"" ] && [ $manual_revision -le $revision_number ]; then
       echo "Current revision '$revision_number' is ahead of manual revision number '$manual_revision'."
       retcode=1
@@ -3777,10 +3760,6 @@ publish() {
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-z $CVMFS_LOG_LEVEL"
 
-    local swissknife_sync_params=""
-    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-      swissknife_sync_params="${swissknife_sync_params} -L"
-    fi
     local sync_command="$swissknife sync $verbosity -u /cvmfs/$name \
       -s ${spool_dir}/scratch \
       -c ${spool_dir}/rdonly \
@@ -3790,7 +3769,7 @@ publish() {
       -w $stratum0 \
       -o $manifest \
       -e $hash_algorithm \
-      $swissknife_sync_params \
+      $(get_follow_http_redirects_flag) \
       $log_level $tweaks_option"
     if [ "x$CVMFS_UNION_FS_TYPE" != "x" ]; then
       sync_command="$sync_command -f $CVMFS_UNION_FS_TYPE"
@@ -3819,10 +3798,6 @@ publish() {
     if [ "x$CVMFS_MAXIMAL_CONCURRENT_WRITES" != "x" ]; then
       sync_command="$sync_command -q $CVMFS_MAXIMAL_CONCURRENT_WRITES"
     fi
-    local swissknife_tag_create_params=""
-    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-      swissknife_tag_create_params="${swissknife_tag_create_params} -L"
-    fi
     local tag_command="$swissknife tag_create \
       -r $upstream                            \
       -w $stratum0                            \
@@ -3832,7 +3807,7 @@ publish() {
       -f $name                                \
       -b $base_hash                           \
       -e $hash_algorithm                      \
-      $swissknife_tag_create_params           \
+      $(get_follow_http_redirects_flag)       \
       -x" # -x enables magic undo tag handling
     if [ ! -z "$tag_name" ]; then
       tag_command="$tag_command -a $tag_name"
@@ -4115,11 +4090,7 @@ gc() {
     is_owner_or_root       $name || die "Permission denied: Repository $name is owned by $user"
     is_in_transaction      $name && die "Cannot run garbage collection while in a transaction"
 
-    local swissknife_info_params="-t"
-    if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
-      swissknife_info_params="${swissknife_info_params} -L"
-    fi
-    local head_timestamp="$(cvmfs_swissknife info -r $CVMFS_STRATUM0 ${swissknife_info_params})"
+    local head_timestamp="$(cvmfs_swissknife info -r $CVMFS_STRATUM0 -t $(get_follow_http_redirects_flag))"
     [ $head_timestamp -gt $preserve_timestamp ] || die "Latest repository revision is older than given timestamp"
 
     # figure out the URL of the repository

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -695,7 +695,6 @@ void DownloadManager::ReleaseCurlHandle(CURL *handle) {
  */
 void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
   // Initialize internal download state
-  EnableRedirects();
   info->curl_handle = handle;
   info->error_code = kFailOk;
   info->nocache = false;

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -695,6 +695,7 @@ void DownloadManager::ReleaseCurlHandle(CURL *handle) {
  */
 void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
   // Initialize internal download state
+  EnableRedirects();
   info->curl_handle = handle;
   info->error_code = kFailOk;
   info->nocache = false;

--- a/cvmfs/logging.cc
+++ b/cvmfs/logging.cc
@@ -50,7 +50,7 @@ const char *module_names[] = { "unknown", "cache", "catalog", "sql", "cvmfs",
   "hash", "download", "compress", "quota", "talk", "monitor", "lru",
   "fuse stub", "signature", "fs traversal", "catalog traversal",
   "nfs maps", "publish", "spooler", "concurrency", "utility", "glue buffer",
-  "history", "unionfs", "pathspec", "s3fanout", "gc", "dns" };
+  "history", "unionfs", "pathspec", "upload s3", "s3fanout", "gc", "dns" };
 int syslog_facility = LOG_USER;
 int syslog_level = LOG_NOTICE;
 char *syslog_prefix = NULL;

--- a/cvmfs/logging_internal.h
+++ b/cvmfs/logging_internal.h
@@ -65,6 +65,7 @@ enum LogSource {
   kLogHistory,
   kLogUnionFs,
   kLogPathspec,
+  kLogUploadS3,
   kLogS3Fanout,
   kLogGc,
   kLogDns

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -38,7 +38,7 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
     if (header_line[i] == '2') {
       return num_bytes;
     } else {
-      LogCvmfs(kLogDownload, kLogDebug, "http status error code: %s",
+      LogCvmfs(kLogS3Fanout, kLogDebug, "http status error code: %s",
                header_line.c_str());
       if (header_line.length() < i+3) {
         info->error_code = kFailOther;
@@ -95,7 +95,7 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
     size_t read_bytes = fread(ptr, 1, num_bytes, info->origin_file);
     if (read_bytes != num_bytes) {
       if (ferror(info->origin_file) != 0) {
-        LogCvmfs(kLogS3Fanout, kLogDebug, "local I/O error reading %s",
+        LogCvmfs(kLogS3Fanout, kLogStderr, "local I/O error reading %s",
                  info->origin_path.c_str());
         return CURL_READFUNC_ABORT;
       }
@@ -116,7 +116,7 @@ int S3FanoutManager::CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
   S3FanoutManager *s3fanout_mgr = static_cast<S3FanoutManager *>(userp);
   int ajobs = 0;
   sem_getvalue(&s3fanout_mgr->available_jobs_, &ajobs);
-  LogCvmfs(kLogDownload, kLogDebug, "CallbackCurlSocket called with easy "
+  LogCvmfs(kLogS3Fanout, kLogDebug, "CallbackCurlSocket called with easy "
            "handle %p, socket %d, action %d, up %d, "
            "sp %d, fds_inuse %d, jobs %d",
            easy, s, action, userp,
@@ -230,11 +230,11 @@ void *S3FanoutManager::MainUpload(void *data) {
                                         0,
                                         &still_running);
       if (retval != CURLM_OK) {
-        LogCvmfs(kLogS3Fanout, kLogDebug, "Error, timeout due to: %d", retval);
+        LogCvmfs(kLogS3Fanout, kLogStderr, "Error, timeout due to: %d", retval);
         assert(retval == CURLM_OK);
       }
     } else if (retval < 0) {
-      LogCvmfs(kLogS3Fanout, kLogDebug, "Error, event poll failed: %d", errno);
+      LogCvmfs(kLogS3Fanout, kLogStderr, "Error, event poll failed: %d", errno);
       assert(retval >= 0);
     }
 
@@ -482,7 +482,7 @@ int S3FanoutManager::InitializeDnsSettings(
     sharehandles_->insert(dnse);
   }
   if (dnse == NULL) {
-    LogCvmfs(kLogS3Fanout, kLogDebug | kLogSyslogErr,
+    LogCvmfs(kLogS3Fanout, kLogStderr | kLogSyslogErr,
              "Error: DNS resolve failed for address '%s'.",
              remote_host.c_str());
     assert(dnse != NULL);
@@ -751,7 +751,7 @@ bool S3FanoutManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
       // Error set by callback
       break;
     default:
-      LogCvmfs(kLogS3Fanout, kLogDebug | kLogSyslogErr,
+      LogCvmfs(kLogS3Fanout, kLogStderr | kLogSyslogErr,
                "unexpected curl error (%d) while trying to upload %s",
                curl_error, info->object_key.c_str());
       info->error_code = kFailOther;
@@ -786,7 +786,7 @@ bool S3FanoutManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
   if (try_again) {
     if (info->request == JobInfo::kReqPut ||
         info->request == JobInfo::kReqPutNoCache) {
-      LogCvmfs(kLogDownload, kLogDebug, "Trying again to upload %s",
+      LogCvmfs(kLogS3Fanout, kLogDebug, "Trying again to upload %s",
                info->object_key.c_str());
       // Reset origin
       if (info->origin == kOriginMem)

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -636,6 +636,9 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
     retval = curl_easy_setopt(handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
     assert(retval == CURLE_OK);
   }
+  // Follow HTTP redirects
+  retval = curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+  assert(retval == CURLE_OK);
 
   return kFailOk;
 }

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -39,6 +39,7 @@ void CommandTag::InsertCommonParameters(ParameterList *r) {
   r->push_back(Parameter::Optional('b', "mounted repository base hash"));
   r->push_back(Parameter::Optional(
     'e', "hash algorithm to use (default SHA1)"));
+  r->push_back(Parameter::Switch('L', "follow HTTP redirects"));
 }
 
 
@@ -115,7 +116,10 @@ CommandTag::Environment* CommandTag::InitializeEnvironment(
 
   // initialize the (swissknife global) download manager
   g_download_manager->Init(1, true, g_statistics);
-
+  const bool follow_redirects = (args.count('L') > 0);
+  if (follow_redirects) {
+    g_download_manager->EnableRedirects();
+  }
   // open the (yet unsigned) manifest file if it is there, otherwise load the
   // latest manifest from the server
   env->manifest = (FileExists(env->manifest_path.path()))

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -56,6 +56,7 @@ ParameterList CommandInfo::GetParams() {
   r.push_back(Parameter::Switch('g', "check if repository is garbage "
                                         "collectable"));
   r.push_back(Parameter::Switch('h', "print results in human readable form"));
+  r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
   return r;
 }
 
@@ -81,6 +82,11 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
   manifest::Manifest *manifest = NULL;
   if (IsRemote(repository)) {
     g_download_manager->Init(1, true, g_statistics);
+
+    const bool follow_redirects = args.count('L') > 0;
+    if (follow_redirects) {
+      g_download_manager->EnableRedirects();
+    }
 
     const string url = repository + "/.cvmfspublished";
     download::JobInfo download_manifest(&url, false, false, NULL);

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -248,6 +248,10 @@ int swissknife::CommandApplyDirtab::Main(const ArgumentList &args) {
   // initialize catalog infrastructure
   g_download_manager->Init(1, true, g_statistics);
   const bool auto_manage_catalog_files = true;
+  const bool follow_redirects = (args.count('L') > 0);
+  if (follow_redirects) {
+    g_download_manager->EnableRedirects();
+  }
   catalog::SimpleCatalogManager catalog_manager(base_hash,
                                                 stratum0,
                                                 dir_temp,
@@ -544,7 +548,10 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     return 3;
 
   g_download_manager->Init(1, true, g_statistics);
-
+  const bool follow_redirects = (args.count('L') > 0);
+  if (follow_redirects) {
+    g_download_manager->EnableRedirects();
+  }
   catalog::WritableCatalogManager
     catalog_manager(params.base_hash, params.stratum0, params.dir_temp,
                     params.spooler, g_download_manager,

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -200,6 +200,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Switch('n', "create new repository"));
     r.push_back(Parameter::Switch('x', "print change set"));
     r.push_back(Parameter::Switch('y', "dry run"));
+    r.push_back(Parameter::Switch('L', "enable HTTP redirects"));
     r.push_back(Parameter::Switch('m', "create micro catalogs"));
     r.push_back(Parameter::Switch('i', "ignore x-directory hardlinks"));
     r.push_back(Parameter::Switch('d', "pause publishing to allow for "


### PR DESCRIPTION
This fix enables CVMFS to follow HTTP redirect requests. This is useful when using repositories with several buckets and Squid. The only change required in the Squid configuration is that mapped url is returned with "302:"-prefix, which in effect redirects the CVMFS to download the requested file directly from the cloud storage.