### PR TITLE
Make alien_cache usable for libcvmfs

### DIFF
--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -113,6 +113,7 @@ struct cvmfs_repo_options : public cvmfs_context::options {
 struct cvmfs_global_options : public cvmfs_globals::options {
   int set_option(char const *name, char const *value) {
     CVMFS_OPT(cache_directory);
+    CVMFS_OPT(lock_directory);
     CVMFS_OPT(change_to_cache_directory);
     CVMFS_OPT(alien_cache);
     CVMFS_OPT(log_syslog_level);
@@ -208,6 +209,7 @@ typedef cvmfs_options<cvmfs_global_options> global_options;
 
             "global options are:\n"
             " cache_directory=DIR        Where to store disk cache\n"
+            " lock_directory=DIR         Where to store the per-instance locks (should be unique for alien cache)\n"
             " change_to_cache_directory  Performs a cd to the cache directory (performance tweak)\n"
             " alien_cache                Treat cache directory as alien cache\n"
             " log_syslog_level=LEVEL     Sets the level used for syslog to DEBUG (1), INFO (2), or NOTICE (3).\n"

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -50,6 +50,7 @@ class cvmfs_globals : SingleCopy {
                 max_open_files(0) {}
 
     std::string    cache_directory;
+    std::string    lock_directory;
     bool           change_to_cache_directory;
     bool           alien_cache;
 
@@ -83,6 +84,7 @@ class cvmfs_globals : SingleCopy {
 
  private:
   std::string       cache_directory_;
+  std::string       lock_directory_;
   uid_t             uid_;
   gid_t             gid_;
 


### PR DESCRIPTION
In libcvmfs, there's no way to separate the instance / quota lock directory from the alien cache directory.

This causes a flock to be taken within the alien cache directory, meaning that only one instance of libcvmfs can be active per alien cache (somewhat defeating the purpose of alien cache!).

This adversely affects parrot integration with CVMFS.  Discovered while trying to use Parrot at NERSC for CMS.

This PR adds an option to have a separate lock directory.

@btovar @dthain - if alien_cache is enabled for libcvmfs2, you probably will be interested in this option (or wherever the conversation goes...).  It probably should default to the cvmfs_locks directory created by parrot.
