### PR TITLE
STATISTICS: added ShortString counters to cvmfs_talk

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1540,13 +1540,13 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
     download_manager_->GetTimeout(&seconds, &seconds_direct);
     attribute_value = StringifyInt(seconds_direct);
   } else if (attr == "user.rx") {
-    int64_t rx = 
+    int64_t rx =
       cvmfs::statistics_->Lookup("download.sz_transferred_bytes")->Get();
     attribute_value = StringifyInt(rx/1024);
   } else if (attr == "user.speed") {
-    int64_t rx = 
+    int64_t rx =
       cvmfs::statistics_->Lookup("download.sz_transferred_bytes")->Get();
-    int64_t time = 
+    int64_t time =
       cvmfs::statistics_->Lookup("download.sz_transfer_time")->Get();
     if (time == 0)
       attribute_value = "n/a";
@@ -2007,6 +2007,14 @@ static int Init(const loader::LoaderExports *loader_exports) {
   }
 
   cvmfs::statistics_ = new perf::Statistics();
+
+  // register the ShortString's static counters
+  cvmfs::statistics_->Register("pathstring.n_instances", "Number of instances");
+  cvmfs::statistics_->Register("pathstring.n_overflows", "Number of overflows");
+  cvmfs::statistics_->Register("namestring.n_instances", "Number of instances");
+  cvmfs::statistics_->Register("namestring.n_overflows", "Number of overflows");
+  cvmfs::statistics_->Register("linkstring.n_instances", "Number of instances");
+  cvmfs::statistics_->Register("linkstring.n_overflows", "Number of overflows");
 
   // Fill cvmfs option variables from configuration
   cvmfs::foreground_ = loader_exports->foreground;

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -362,15 +362,19 @@ static void *MainTalk(void *data __attribute__((unused))) {
         int highwater;
         string result;
 
-        result += "Path Strings:\n  instances: " +
-          StringifyInt(PathString::num_instances()) + "  overflows: " +
-          StringifyInt(PathString::num_overflows()) + "\n";
-        result += "Name Strings:\n  instances: " +
-          StringifyInt(NameString::num_instances()) + "  overflows: " +
-          StringifyInt(NameString::num_overflows()) + "\n";
-        result += "Symlink Strings:\n  instances: " +
-          StringifyInt(LinkString::num_instances()) + "  overflows: " +
-          StringifyInt(LinkString::num_overflows()) + "\n";
+        // manually setting the values of the ShortString counters
+        cvmfs::statistics_->Lookup("pathstring.n_instances")->
+            Set(PathString::num_instances());
+        cvmfs::statistics_->Lookup("pathstring.n_overflows")->
+            Set(PathString::num_overflows());
+        cvmfs::statistics_->Lookup("namestring.n_instances")->
+            Set(NameString::num_instances());
+        cvmfs::statistics_->Lookup("namestring.n_overflows")->
+            Set(NameString::num_overflows());
+        cvmfs::statistics_->Lookup("linkstring.n_instances")->
+            Set(LinkString::num_instances());
+        cvmfs::statistics_->Lookup("linkstring.n_overflows")->
+            Set(LinkString::num_overflows());
 
         result += "\nCache Mode: ";
         switch (cache::GetCacheMode()) {


### PR DESCRIPTION
Example output:

Cache Mode: read-write
Drainout Mode: no
Maintenance Mode: no
SQlite Statistics:
  Number of allocations 212
  General purpose allocator 45 KB / 55 KB
  Largest malloc 8194 Bytes
  Page cache allocations 12 / 12
  Page cache overflows 0 KB / 0 KB
  Largest page cache allocation 1272 Bytes
  Scratch allocations 0 / 0
  Scratch overflows 0 / 0
  Largest scratch allocation 0 KB

Raw Counters:
Name|Value|Description
cache.n_certificate_hits|0|Number of certificate hits
cache.n_certificate_misses|1|Number of certificate misses
catalog_mgr.n_listing|0|Number of listings
catalog_mgr.n_lookup_inode|0|Number of inode lookups
catalog_mgr.n_lookup_path|0|Number of path lookups
catalog_mgr.n_lookup_path_negative|0|Number of negative path lookups
catalog_mgr.n_lookup_xattrs|0|Number of xattrs lookups
catalog_mgr.n_nested_listing|0|Number of listings of nested catalogs
cvmfs.n_fs_dir_open|0|Overall number of directory open operations
cvmfs.n_fs_forget|0|Number of inode forgets
cvmfs.n_fs_lookup|0|Number of lookups
cvmfs.n_fs_lookup_negative|0|Number of negative lookups
cvmfs.n_fs_open|0|Overall number of file open operations
cvmfs.n_fs_read|0|Number of files read
cvmfs.n_fs_readlink|0|Number of links read
cvmfs.n_fs_stat|0|Number of stats
cvmfs.n_io_error|0|Number of I/O errors
cvmfs.no_open_dirs|0|Number of currently opened directories
cvmfs.no_open_files|0|Number of currently opened files
download.n_host_failover|0|Number of host failovers
download.n_proxy_failover|0|Number of proxy failovers
download.n_requests|5|Number of requests
download.n_retries|0|Number of retries
download.sz_transfer_time|4626|Transfer time (miliseconds)
download.sz_transferred_bytes|37807838|Number of transferred bytes
inode_cache.n_drop|0|Number of drops for inode_cache
inode_cache.n_forget|0|Number of forgets for inode_cache
inode_cache.n_hit|0|Number of hits for inode_cache
inode_cache.n_insert|0|Number of inserts for inode_cache
inode_cache.n_insert_negative|0|Number of negative inserts for inode_cache
inode_cache.n_miss|0|Number of misses for inode_cache
inode_cache.n_replace|0|Number of replaces for inode_cache
inode_cache.n_update|0|Number of updates for inode_cache
inode_cache.sz_allocated|1663672|Number of allocated bytes for inode_cache
inode_cache.sz_size|5568|Size for inode_cache
**linkstring.n_instances|59735|Number of instances**
**linkstring.n_overflows|0|Number of overflows**
md5_path_cache.n_drop|0|Number of drops for md5_path_cache
md5_path_cache.n_forget|0|Number of forgets for md5_path_cache
md5_path_cache.n_hit|0|Number of hits for md5_path_cache
md5_path_cache.n_insert|0|Number of inserts for md5_path_cache
md5_path_cache.n_insert_negative|0|Number of negative inserts for md5_path_cache
md5_path_cache.n_miss|0|Number of misses for md5_path_cache
md5_path_cache.n_replace|0|Number of replaces for md5_path_cache
md5_path_cache.n_update|0|Number of updates for md5_path_cache
md5_path_cache.sz_allocated|13186784|Number of allocated bytes for md5_path_cache
md5_path_cache.sz_size|39232|Size for md5_path_cache
**namestring.n_instances|59735|Number of instances**
**namestring.n_overflows|0|Number of overflows**
path_cache.n_drop|0|Number of drops for path_cache
path_cache.n_forget|0|Number of forgets for path_cache
path_cache.n_hit|0|Number of hits for path_cache
path_cache.n_insert|0|Number of inserts for path_cache
path_cache.n_insert_negative|0|Number of negative inserts for path_cache
path_cache.n_miss|0|Number of misses for path_cache
path_cache.n_replace|0|Number of replaces for path_cache
path_cache.n_update|0|Number of updates for path_cache
path_cache.sz_allocated|1901240|Number of allocated bytes for path_cache
path_cache.sz_size|5568|Size for path_cache
**pathstring.n_instances|7452|Number of instances**
**pathstring.n_overflows|0|Number of overflows**
sqlite.n_access|0|overall number of access() calls
sqlite.n_rand|0|overall number of random() calls
sqlite.n_read|20|overall number of read() calls
sqlite.n_sleep|0|overall number of sleep() calls
sqlite.n_time|0|overall number of time() calls
sqlite.no_open|1|currently open sqlite files
sqlite.sz_rand|0|overall number of random bytes
sqlite.sz_read|11492|overall bytes read()
sqlite.sz_sleep|0|overall microseconds slept
