### PR TITLE
Fix/Refactor: Building on Ubuntu 14.04+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,27 @@ else (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
 endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
 
 #
+# define the installation location of the shared library files
+# Note: We do not support multi-arch on Debian systems for the time being and
+#       hence cannot use GNUInstallDirs as this would assume multi-arch.
+#       (https://wiki.debian.org/Multiarch)
+#
+if (MACOSX)
+  set (CMAKE_INSTALL_LIBDIR "lib")
+else (MACOSX) # --> Linux
+  if (DEBIAN)
+    set (CMAKE_INSTALL_LIBDIR "lib")
+  else (DEBIAN) # --> RedHat, Fedora, CentOS, SuSE
+    if (IS_64_BIT)
+      set (CMAKE_INSTALL_LIBDIR "lib64")
+    else (IS_64_BIT) # --> 32 Bit
+      set (CMAKE_INSTALL_LIBDIR "lib")
+    endif (IS_64_BIT)
+  endif (DEBIAN)
+endif (MACOSX)
+message ("Installing shared libraries to: ${CMAKE_INSTALL_LIBDIR}")
+
+#
 # provide some options to the user
 #
 option (BUILD_CVMFS             "Build the CernVM-FS FUSE module"                                  ON)
@@ -201,32 +222,15 @@ endif (EXISTS "${CMAKE_SOURCE_DIR}/bootstrap.sh")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-exceptions -fno-strict-aliasing -fasynchronous-unwind-tables -fno-omit-frame-pointer -fvisibility=hidden -Wall -D_REENTRANT -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fno-strict-aliasing -fasynchronous-unwind-tables -fno-omit-frame-pointer -fvisibility=hidden -Wall -D_REENTRANT -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES")
 
-if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-  set (IS_64_BIT FALSE)
-  set (CVMFS_INSTALL_LIBDIR "lib")
-  if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=i686")
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=i686")
-  endif (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
-else (CMAKE_SIZEOF_VOID_P EQUAL 4)
-  set (IS_64_BIT TRUE)
-  if (NOT DEBIAN)
-    set (CVMFS_INSTALL_LIBDIR "lib64")
-  else (NOT DEBIAN)
-    set (CVMFS_INSTALL_LIBDIR "lib")
-  endif (NOT DEBIAN)
-endif (CMAKE_SIZEOF_VOID_P EQUAL 4)
-
-include (GNUInstallDirs OPTIONAL)
-if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
-  message (WARNING " Did not find default library path for this system. Guessing '${CVMFS_INSTALL_LIBDIR}' ...")
-  set (CMAKE_INSTALL_LIBDIR ${CVMFS_INSTALL_LIBDIR})
-endif (NOT DEFINED CMAKE_INSTALL_LIBDIR)
-
 if (NOT USING_CLANG)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-optimize-sibling-calls")
   set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fno-optimize-sibling-calls")
 endif (NOT USING_CLANG)
+
+if (NOT ARM AND NOT IS_64_BIT)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=i686")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=i686")
+endif (NOT ARM AND NOT IS_64_BIT)
 
 set (INCLUDE_DIRECTORIES ${INCLUDE_DIRECTORIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,36 @@ option (GEOIP_BUILTIN           "Don't use system GeoIP library and python-GeoIP
 option (TBB_PRIVATE_LIB         "Compile our own TBB shared libraries"                             ON)
 
 #
+# Workaround for Debian packaging debhelper trying to pass -D_FORTIFY_SOURCE=2
+# through CPPFLAGS that is not officially supported by CMake. Hence, debhelper
+# appends CPPFLAGS to CFLAGS which breaks the build of the c-ares external.
+# This filters out flags that scares c-ares's ./configure script.
+#
+set (TMP_C_FLAGS "${CFLAGS} ${CMAKE_C_FLAGS}")
+unset (CFLAGS)
+unset (CMAKE_C_FLAGS)
+unset (ENV{CFLAGS})
+set (LDFLAGS $ENV{LDFLAGS})
+separate_arguments (TMP_C_FLAGS)
+foreach (CMPLR_FLAG ${TMP_C_FLAGS})
+  if (${CMPLR_FLAG} MATCHES ^-[DIU].*)
+    message ("Moving ${CMPLR_FLAG} from CFLAGS into CPPFLAGS")
+    set (CPPFLAGS "${CPPFLAGS} ${CMPLR_FLAG}")
+  elseif (${CMPLR_FLAG} MATCHES ^-[Ll].*)
+    message ("Moving ${CMPLR_FLAG} from CFLAGS into LDFLAGS")
+    set (LDFLAGS "${LDFLAGS} ${CMPLR_FLAG}")
+    set (CMAKE_LD_FLAGS "${CMAKE_LD_FLAGS} ${CMPLR_FLAG}")
+  else (${CMPLR_FLAG} MATCHES ^-[DUILl].*)
+    set (CFLAGS "${CFLAGS} ${CMPLR_FLAG}")
+  endif (${CMPLR_FLAG} MATCHES ^-[DIU].*)
+endforeach (CMPLR_FLAG)
+set (ENV{CPPFLAGS}   "${CPPFLAGS}")
+set (CMAKE_C_FLAGS   "${CFLAGS}")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPPFLAGS}")
+set (ENV{CFLAGS}     "${CFLAGS}")
+set (ENV{LDFLAGS}    "${LDFLAGS}")
+
+#
 # set name of fuse library (-losxfuse for osxfuse)
 #
 if (MACOSX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,35 +107,6 @@ endif (MACOSX)
 message ("Installing shared libraries to: ${CMAKE_INSTALL_LIBDIR}")
 
 #
-# provide some options to the user
-#
-option (BUILD_CVMFS             "Build the CernVM-FS FUSE module"                                  ON)
-if (MACOSX)
-  option (BUILD_LIBCVMFS        "Build the CernVM-FS client library"                               OFF)
-else ()
-  option (BUILD_LIBCVMFS        "Build the CernVM-FS client library"                               ON)
-endif()
-option (BUILD_SERVER            "Build writer's end programs"                                      ON)
-option (BUILD_SERVER_DEBUG      "Build writer's end programs with debug symbols and debug outputs" OFF)
-option (BUILD_UNITTESTS         "Build the CernVM-FS unit test set"                                OFF)
-option (BUILD_UNITTESTS_DEBUG   "Build the CernVM-FS unit test set with verbose output and -g"     OFF)
-option (BUILD_DOCUMENTATION     "Build the CerVM-FS documentation using Doxygen"                   OFF)
-option (INSTALL_UNITTESTS       "Install the unit test binary (mainly for packaging)"              OFF)
-option (INSTALL_UNITTESTS_DEBUG "Install the unit test debug binary"                               OFF)
-option (INSTALL_MOUNT_SCRIPTS   "Install CernVM-FS mount tools in /etc and /sbin"                  ON)
-option (INSTALL_PUBLIC_KEYS     "Install public key chain for CERN, EGI, and OSG"                  ON)
-option (INSTALL_BASH_COMPLETION "Install bash completion rules for cvmfs* commands in /etc"        ON)
-option (SQLITE3_BUILTIN         "Don't use system SQLite3"                                         ON)
-option (LIBCURL_BUILTIN         "Don't use system libcurl"                                         ON)
-option (PACPARSER_BUILTIN       "Don't use system installation of pacparser"                       ON)
-option (ZLIB_BUILTIN            "Don't use system zlib"                                            ON)
-option (SPARSEHASH_BUILTIN      "Don't use system installation of google sparse hash"              ON)
-option (LEVELDB_BUILTIN         "Don't use system leveldb"                                         ON)
-option (GOOGLETEST_BUILTIN      "Don't use system installation of google test"                     ON)
-option (GEOIP_BUILTIN           "Don't use system GeoIP library and python-GeoIP"                  ON)
-option (TBB_PRIVATE_LIB         "Compile our own TBB shared libraries"                             ON)
-
-#
 # Workaround for Debian packaging debhelper trying to pass -D_FORTIFY_SOURCE=2
 # through CPPFLAGS that is not officially supported by CMake. Hence, debhelper
 # appends CPPFLAGS to CFLAGS which breaks the build of the c-ares external.
@@ -173,6 +144,36 @@ if (MACOSX)
 else (MACOSX)
   set(LIBFUSE fuse)
 endif(MACOSX)
+
+
+#
+# provide some options to the user
+#
+option (BUILD_CVMFS             "Build the CernVM-FS FUSE module"                                  ON)
+if (MACOSX)
+  option (BUILD_LIBCVMFS        "Build the CernVM-FS client library"                               OFF)
+else ()
+  option (BUILD_LIBCVMFS        "Build the CernVM-FS client library"                               ON)
+endif()
+option (BUILD_SERVER            "Build writer's end programs"                                      ON)
+option (BUILD_SERVER_DEBUG      "Build writer's end programs with debug symbols and debug outputs" OFF)
+option (BUILD_UNITTESTS         "Build the CernVM-FS unit test set"                                OFF)
+option (BUILD_UNITTESTS_DEBUG   "Build the CernVM-FS unit test set with verbose output and -g"     OFF)
+option (BUILD_DOCUMENTATION     "Build the CerVM-FS documentation using Doxygen"                   OFF)
+option (INSTALL_UNITTESTS       "Install the unit test binary (mainly for packaging)"              OFF)
+option (INSTALL_UNITTESTS_DEBUG "Install the unit test debug binary"                               OFF)
+option (INSTALL_MOUNT_SCRIPTS   "Install CernVM-FS mount tools in /etc and /sbin"                  ON)
+option (INSTALL_PUBLIC_KEYS     "Install public key chain for CERN, EGI, and OSG"                  ON)
+option (INSTALL_BASH_COMPLETION "Install bash completion rules for cvmfs* commands in /etc"        ON)
+option (SQLITE3_BUILTIN         "Don't use system SQLite3"                                         ON)
+option (LIBCURL_BUILTIN         "Don't use system libcurl"                                         ON)
+option (PACPARSER_BUILTIN       "Don't use system installation of pacparser"                       ON)
+option (ZLIB_BUILTIN            "Don't use system zlib"                                            ON)
+option (SPARSEHASH_BUILTIN      "Don't use system installation of google sparse hash"              ON)
+option (LEVELDB_BUILTIN         "Don't use system leveldb"                                         ON)
+option (GOOGLETEST_BUILTIN      "Don't use system installation of google test"                     ON)
+option (GEOIP_BUILTIN           "Don't use system GeoIP library and python-GeoIP"                  ON)
+option (TBB_PRIVATE_LIB         "Compile our own TBB shared libraries"                             ON)
 
 #
 # define where to find the external dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,24 @@ if (CMAKE_CXX_COMPILER MATCHES ".*clang")
 endif (CMAKE_CXX_COMPILER MATCHES ".*clang")
 
 #
+# figure out if we are on a 64bit system
+#
+if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set (IS_64_BIT FALSE)
+else (CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set (IS_64_BIT TRUE)
+endif (CMAKE_SIZEOF_VOID_P EQUAL 4)
+
+#
+# check if we are compiling on ARM
+#
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
+  set (ARM TRUE)
+else (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
+  set (ARM FALSE)
+endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
+
+#
 # provide some options to the user
 #
 option (BUILD_CVMFS             "Build the CernVM-FS FUSE module"                                  ON)

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -2,7 +2,7 @@ Source: cvmfs
 Section: utils
 Priority: extra
 Maintainer: Jakob Blomer <jblomer@cern.ch>
-Build-Depends: debhelper (>= 9), autotools-dev, cmake, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev
+Build-Depends: debhelper (>= 9), autotools-dev, cmake, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, libc6-dev
 Standards-Version: 3.9.3.1
 Homepage: http://cernvm.cern.ch/portal/filesystem
 

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.3.1
 Homepage: http://cernvm.cern.ch/portal/filesystem
 
 Package: cvmfs
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
 Depends: cvmfs-config, bash, coreutils, grep, gawk, sed, perl, sudo, psmisc, autofs, fuse, curl, attr, libfuse2, debianutils, libc-bin, sysvinit-utils, zlib1g, gdb, uuid-dev, uuid
 #Multi-Arch: same   (preparation for multiarch support)
@@ -16,7 +16,7 @@ Description: CernVM File System
  HTTP File System for Distributing Software to CernVM.
 
 Package: cvmfs-server
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
 Depends: cvmfs (= ${source:Version}), insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2
 Conflicts: cvmfs-server (< 2.1)
@@ -26,7 +26,7 @@ Description: CernVM File System Server
  HTTP File System Repository Server for Distributing Software to CernVM.
 
 Package: cvmfs-unittests
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
 Depends: libssl-dev, uuid-dev, cvmfs (= ${source:Version}), cvmfs-server (= ${source:Version})
 #Multi-Arch: same   (preparation for multiarch support)


### PR DESCRIPTION
Firstly, Debian respectively Ubuntu decided to add `-D_FORTIFY_SOURCE=2` to `CPPFLAGS` which is not recognised by CMake. The [fix](http://www.cmake.org/Bug/view.php?id=12928) was that `CPPFLAGS` were automagically appended to `CFLAGS` in CMake. Unfortunately this is leads to an error when configuring the c-ares dependency. This workaround separates compiler and pre-processor flags in `CFLAGS` as it is supposed to be. This way we still get the benefits from `-D_FORTIFY_SOURCE=2` but are independent of any internal CMake tricks. Hopefully...

The second change in Debian is the introduction of [multi-arch](https://wiki.debian.org/Multiarch) support for shared libraries. It allows you to install i386 and x86_64 libraries side-by-side through stretching the FHS. Arguably we do not benefit from this feature, but it gets in our way when using CMake's `GNUInstallDirs` module, as this forces the installation of shared libraries into the multi-arch locations. This removes the usage of `GNUInstallDirs` and figures out the library installation path itself.

Furthermore I cleaned up the code paths involved in the above decisions in the main `CMakeLists.txt` file, added *arm64* as a supported architecture for debian packages and included a (before missing) build dependency for debian.

**Note:** This is subject to validation on all platforms.