### PR TITLE
FIX: CMake 2.6.3 required for unset()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # See externals/CMake-Register_External_Lib.txt for details on external inclusion
 #
 
-cmake_minimum_required (VERSION 2.6.2)
+cmake_minimum_required (VERSION 2.6.3)
 set (PROJECT_NAME "CernVM-FS")
 project (${PROJECT_NAME})
 


### PR DESCRIPTION
This is a follow up for the [last pull request](https://github.com/cvmfs/cvmfs/pull/868). Turns out, that `unset()` [needs](http://www.cmake.org/pipermail/cmake/2010-January/034307.html) at least CMake 2.6.3 thus I'm bumping the required version. We have it installed on all our build machines - after I updated the package on SLES11.