### PR TITLE
FIX: CVMFS_FOLLOW_REDIRECTS switch (+ minor of previous PR)

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2292,7 +2292,7 @@ alterfs() {
 # Parse redirects configuration into redirect flag.
 # Assumes that config is loaded already, i.e. load_repo_config().
 get_follow_http_redirects_flag() {
-  if [ x"$CVMFS_FOLLOW_REDIRECTS" == x"yes" ]; then
+  if [ x"$CVMFS_FOLLOW_REDIRECTS" = x"yes" ]; then
     echo "-L"
   fi
 }

--- a/test/src/588-manydirectories/main
+++ b/test/src/588-manydirectories/main
@@ -78,8 +78,9 @@ cvmfs_run_test() {
   monitor_pid=$!
   echo "monitor's PID: $monitor_pid"
 
-  echo "creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO || return $?
+  local publish_log="publish.log"
+  echo "creating CVMFS snapshot (log: $publish_log)"
+  publish_repo $CVMFS_TEST_REPO > $publish_log 2>&1 || return $?
 
   echo "waiting for the monitor to stop"
   wait $monitor_pid || return $?


### PR DESCRIPTION
This fixes a problem introduced with the latest [S3 pull request](https://github.com/cvmfs/cvmfs/pull/859) by @ssheikki. Furthermore it cleans up logging in the 588 test from this [pull request](https://github.com/cvmfs/cvmfs/pull/874).