### PR TITLE
FIX: Legacy Catalog Migration

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -40,23 +40,23 @@ bool CatalogDatabase::LiveSchemaUpgradeIfNecessary() {
   assert(read_write());
 
   if (IsEqualSchema(schema_version(), 2.5) && (schema_revision() == 0)) {
-    LogCvmfs(kLogCatalog, kLogDebug, "upgrading schema revision");
+    LogCvmfs(kLogCatalog, kLogDebug, "upgrading schema revision (0 --> 1)");
 
     Sql sql_upgrade(*this, "ALTER TABLE nested_catalogs ADD size INTEGER;");
     if (!sql_upgrade.Execute()) {
-      LogCvmfs(kLogCatalog, kLogDebug, "failed tp upgrade nested_catalogs");
+      LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade nested_catalogs");
       return false;
     }
 
     set_schema_revision(1);
     if (!StoreSchemaRevision()) {
-      LogCvmfs(kLogCatalog, kLogDebug, "failed tp upgrade schema revision");
+      LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade schema revision");
       return false;
     }
   }
 
   if (IsEqualSchema(schema_version(), 2.5) && (schema_revision() == 1)) {
-    LogCvmfs(kLogCatalog, kLogDebug, "upgrading schema revision");
+    LogCvmfs(kLogCatalog, kLogDebug, "upgrading schema revision (1 --> 2)");
 
     Sql sql_upgrade1(*this, "ALTER TABLE catalog ADD xattr BLOB;");
     Sql sql_upgrade2(*this,
@@ -66,13 +66,13 @@ bool CatalogDatabase::LiveSchemaUpgradeIfNecessary() {
     if (!sql_upgrade1.Execute() || !sql_upgrade2.Execute() ||
         !sql_upgrade3.Execute())
     {
-      LogCvmfs(kLogCatalog, kLogDebug, "failed tp upgrade catalogs (1 --> 2)");
+      LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade catalogs (1 --> 2)");
       return false;
     }
 
     set_schema_revision(2);
     if (!StoreSchemaRevision()) {
-      LogCvmfs(kLogCatalog, kLogDebug, "failed tp upgrade schema revision");
+      LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade schema revision");
       return false;
     }
   }

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -18,6 +18,12 @@ using namespace std;  // NOLINT
 
 namespace catalog {
 
+/**
+ * NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
+ * Always remember to update the legacy catalog migration classes to produce a
+ * compatible catalog structure when updating the schema revisions here!
+ * NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
+ */
 const float CatalogDatabase::kLatestSchema = 2.5;
 const float CatalogDatabase::kLatestSupportedSchema = 2.5;  // + 1.X (r/o)
 // ChangeLog

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -827,10 +827,10 @@ is_master_replica() {
   local name=$1
   local is_master_replica
 
-  load_repo_config $name
   if [ $(echo $name | cut --bytes=1-7) = "http://" ]; then
     is_master_replica=$(__swissknife info -r $name -m $(get_follow_http_redirects_flag) 2>/dev/null)
   else
+    load_repo_config $name
     is_stratum0 $name || return 1
     is_master_replica=$(__swissknife info -r $CVMFS_STRATUM0 -m $(get_follow_http_redirects_flag) 2>/dev/null)
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -828,7 +828,7 @@ is_master_replica() {
   local is_master_replica
 
   if [ $(echo $name | cut --bytes=1-7) = "http://" ]; then
-    is_master_replica=$(__swissknife info -r $name -m $(get_follow_http_redirects_flag) 2>/dev/null)
+    is_master_replica=$(__swissknife info -L -r $name -m  2>/dev/null)
   else
     load_repo_config $name
     is_stratum0 $name || return 1

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -821,7 +821,7 @@ is_stratum1() {
 
 # checks if a given repository is replicable
 #
-# @param name   the repository name to be checked
+# @param name   the repository name or URL to be checked
 # @return       0 if it is a stratum0 repository and replicable
 is_master_replica() {
   local name=$1

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -627,6 +627,12 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::CleanupNestedCatalogs(
 }
 
 
+/**
+ * Those values _must_ reflect the schema version in catalog_sql.h so that a
+ * legacy catalog migration generates always the latest catalog revision.
+ * This is a deliberately duplicated piece of information to ensure that always
+ * both the catalog management and migration classes get updated.
+ */
 const float    CommandMigrate::MigrationWorker_20x::kSchema         = 2.5;
 const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 2;
 
@@ -643,6 +649,8 @@ CommandMigrate::MigrationWorker_20x::MigrationWorker_20x(
 bool CommandMigrate::MigrationWorker_20x::RunMigration(PendingCatalog *data)
   const
 {
+  // double-check that we are generating compatible catalogs to the actual
+  // catalog management classes
   assert(kSchema         == catalog::CatalogDatabase::kLatestSupportedSchema);
   assert(kSchemaRevision == catalog::CatalogDatabase::kLatestSchemaRevision);
 

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -627,6 +627,10 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::CleanupNestedCatalogs(
 }
 
 
+const float    CommandMigrate::MigrationWorker_20x::kSchema         = 2.5;
+const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 2;
+
+
 CommandMigrate::MigrationWorker_20x::MigrationWorker_20x(
   const worker_context *context)
   : AbstractMigrationWorker<MigrationWorker_20x>(context)
@@ -639,6 +643,9 @@ CommandMigrate::MigrationWorker_20x::MigrationWorker_20x(
 bool CommandMigrate::MigrationWorker_20x::RunMigration(PendingCatalog *data)
   const
 {
+  assert(kSchema         == catalog::CatalogDatabase::kLatestSupportedSchema);
+  assert(kSchemaRevision == catalog::CatalogDatabase::kLatestSchemaRevision);
+
   return CreateNewEmptyCatalog(data) &&
          CheckDatabaseSchemaCompatibility(data) &&
          AttachOldCatalogDatabase(data) &&

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -857,7 +857,8 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
     "         hash, size, mode, mtime, "
     "         flags, name, symlink, "
     "         :uid, "
-    "         :gid "
+    "         :gid, "
+    "         NULL " // set empty xattr BLOB (default)
     "  FROM old.catalog "
     "  LEFT JOIN hardlinks "
     "    ON catalog.inode = hardlinks.inode "

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -873,7 +873,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
     "         flags, name, symlink, "
     "         :uid, "
     "         :gid, "
-    "         NULL " // set empty xattr BLOB (default)
+    "         NULL "  // set empty xattr BLOB (default)
     "  FROM old.catalog "
     "  LEFT JOIN hardlinks "
     "    ON catalog.inode = hardlinks.inode "

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -129,6 +129,9 @@ class CommandMigrate : public Command {
     public AbstractMigrationWorker<MigrationWorker_20x>
   {
     friend class AbstractMigrationWorker<MigrationWorker_20x>;
+   protected:
+    static const float    kSchema;
+    static const unsigned kSchemaRevision;
 
    public:
     struct worker_context :


### PR DESCRIPTION
This fixes integration tests 519, 550, 563 and 568 that are all related to the legacy catalog migration from 2.0 catalogs. With the [introduction of `xattr`](https://github.com/cvmfs/cvmfs/pull/768) in the catalog database schema, the migration code was not updated accordingly and therefore crashed.
Additionally this adds a check for such situations to catch them easier next time.

Furthermore this fixes an issue introduced by @ssheikki's [S3 Redirects Pull Request](https://github.com/cvmfs/cvmfs/pull/859) that was using a repository URL as the repository name, leading to a failure in `cvmfs_server` - `load_repo_config()`.