### PR TITLE
Fix libcvmfs

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -12,6 +12,10 @@ echo "Current version: $VERSION"
 VERSION="$(echo $VERSION | cut -d. -f1).${NEW_MINOR}.${NEW_PATCH}"
 echo "New version: $VERSION"
 
+echo "Patching libcvmfs"
+sed -i -e "s/^#define LIBCVMFS_VERSION_MINOR \(.*\)/#define LIBCVMFS_VERSION_MINOR $NEW_MINOR/" cvmfs/libcvmfs.h
+grep VERSION cvmfs/libcvmfs.h
+
 echo "Patching CMakeLists.txt"
 sed -i -e "s/^## CVMFS_VERSION \(.*\)/## CVMFS_VERSION $VERSION/" CMakeLists.txt
 sed -i -e "s/^set (CernVM-FS_VERSION_MINOR \(.*\)/set (CernVM-FS_VERSION_MINOR $NEW_MINOR)/" CMakeLists.txt

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -85,18 +85,18 @@ int set_option(char const *name, char const *value, string *var) {
 
 struct cvmfs_repo_options : public cvmfs_context::options {
   int set_option(char const *name, char const *value) {
-    CVMFS_OPT(url);
+    CVMFS_OPT(allow_unsigned);
+    CVMFS_OPT(blacklist);
+    CVMFS_OPT(deep_mount);  // deprecated
+    CVMFS_OPT(fallback_proxies);
+    CVMFS_OPT(mountpoint);
+    CVMFS_OPT(proxies);
+    CVMFS_OPT(pubkey);
+    CVMFS_OPT(repo_name);
     CVMFS_OPT(timeout);
     CVMFS_OPT(timeout_direct);
-    CVMFS_OPT(proxies);
-    CVMFS_OPT(fallback_proxies);
     CVMFS_OPT(tracefile);
-    CVMFS_OPT(allow_unsigned);
-    CVMFS_OPT(pubkey);
-    CVMFS_OPT(deep_mount);
-    CVMFS_OPT(repo_name);
-    CVMFS_OPT(mountpoint);
-    CVMFS_OPT(blacklist);
+    CVMFS_OPT(url);
 
     fprintf(stderr, "Unknown repo option: %s\n", name);
     return -1;
@@ -118,12 +118,13 @@ struct cvmfs_repo_options : public cvmfs_context::options {
 
 struct cvmfs_global_options : public cvmfs_globals::options {
   int set_option(char const *name, char const *value) {
+    CVMFS_OPT(alien_cache);
+    CVMFS_OPT(alien_cachedir);
     CVMFS_OPT(cache_directory);
     CVMFS_OPT(change_to_cache_directory);
-    CVMFS_OPT(alien_cache);
-    CVMFS_OPT(log_syslog_level);
-    CVMFS_OPT(log_prefix);
     CVMFS_OPT(log_file);
+    CVMFS_OPT(log_prefix);
+    CVMFS_OPT(log_syslog_level);
     CVMFS_OPT(max_open_files);
 
     fprintf(stderr, "Unknown global option: %s\n", name);
@@ -216,6 +217,7 @@ typedef cvmfs_options<cvmfs_global_options> global_options;
   " change_to_cache_directory  Performs a cd to the cache directory "
                                "(performance tweak)\n"
   " alien_cache                Treat cache directory as alien cache\n"
+  " alien_cachedir             Explicitly set an alien cache directory\n"
   " log_syslog_level=LEVEL     Sets the level used for syslog to "
                                "DEBUG (1), INFO (2), or NOTICE (3).\n"
   "                            Default is NOTICE.\n"

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -9,7 +9,6 @@
  * NOTE: when adding or removing public symbols, you must also update
  * the list in libcvmfs_public_syms.txt.
  */
-
 #define LIBCVMFS_VERSION 2
 #define LIBCVMFS_VERSION_MAJOR LIBCVMFS_VERSION
 #define LIBCVMFS_VERSION_MINOR 2
@@ -21,6 +20,36 @@
 #include <unistd.h>
 
 #include "statistics.h"
+
+#define LIBCVMFS_FAIL_OK         0
+/**
+ * Could not increase the number of open files limit
+ */
+#define LIBCVMFS_FAIL_NOFILES   -1
+/**
+ * Could not create the cache directory
+ */
+#define LIBCVMFS_FAIL_MKCACHE   -2
+/**
+ * Could not change into the cache directory
+ */
+#define LIBCVMFS_FAIL_OPENCACHE -3
+/**
+ * Could not acquire lock file (flock)
+ */
+#define LIBCVMFS_FAIL_LOCKFILE  -4
+/**
+ * Could not create cache directory skeleton
+ */
+#define LIBCVMFS_FAIL_INITCACHE -5
+/**
+ * Could not initialize quota manager
+ */
+#define LIBCVMFS_FAIL_INITQUOTA -6
+/**
+ * Unknown option
+ */
+#define LIBCVMFS_FAIL_BADOPT    -7
 
 #ifdef __cplusplus
 extern "C" {

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -5,12 +5,15 @@
 #ifndef CVMFS_LIBCVMFS_H_
 #define CVMFS_LIBCVMFS_H_
 
-#define LIBCVMFS_VERSION 2
-
 /*
  * NOTE: when adding or removing public symbols, you must also update
  * the list in libcvmfs_public_syms.txt.
  */
+
+#define LIBCVMFS_VERSION 2
+// Revision Changelog
+// 13: revision introduced
+#define LIBCVMFS_REVISION 13
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -121,7 +124,7 @@ int cvmfs_lstat(cvmfs_context *ctx, const char *path, struct stat *st);
  * them.  The array (*buf) may be NULL when this function is called.
  *
  * @param[in] path, path of directory (e.g. /dir, not /cvmfs/repo/dir)
- * @param[out] buf, pointer to dynamically allocated NULL-terminated array of 
+ * @param[out] buf, pointer to dynamically allocated NULL-terminated array of
  *             strings
  * @param[in] buflen, pointer to variable containing size of array
  * \return 0 on success, -1 on failure (sets errno)

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -11,7 +11,7 @@
  */
 #define LIBCVMFS_VERSION 2
 #define LIBCVMFS_VERSION_MAJOR LIBCVMFS_VERSION
-#define LIBCVMFS_VERSION_MINOR 2
+#define LIBCVMFS_VERSION_MINOR 1
 // Revision Changelog
 // 13: revision introduced
 #define LIBCVMFS_REVISION 13

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -19,8 +19,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "statistics.h"
-
 #define LIBCVMFS_FAIL_OK         0
 /**
  * Could not increase the number of open files limit

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 struct cvmfs_context;
-extern perf::Statistics statistics_;
 
 /**
  * Initialize global CVMFS library structures

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -11,6 +11,8 @@
  */
 
 #define LIBCVMFS_VERSION 2
+#define LIBCVMFS_VERSION_MAJOR LIBCVMFS_VERSION
+#define LIBCVMFS_VERSION_MINOR 2
 // Revision Changelog
 // 13: revision introduced
 #define LIBCVMFS_REVISION 13

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -131,7 +131,7 @@ cvmfs_globals::~cvmfs_globals() {
     quota::Fini();
   }
 
-  // TODO: cleanup crypto
+  // TODO(jblomer): cleanup crypto
   sqlite3_shutdown();
 }
 
@@ -248,8 +248,8 @@ int cvmfs_globals::Setup(const options &opts) {
   }
   // Creates a set of cache directories (256 directories named 00..ff) if not
   // using alien cachdir
-  if (!cache::Init(cache_directory_, 
-                   opts.alien_cache || opts.alien_cachedir != "")) 
+  if (!cache::Init(cache_directory_,
+                   opts.alien_cache || opts.alien_cachedir != ""))
   {
     PrintError("Failed to setup cache in " + cache_directory_ +
                ": " + strerror(errno));

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -238,10 +238,13 @@ int cvmfs_globals::Setup(const options &opts) {
   }
   // Try to jump to cache directory.  This tests, if it is accessible.
   // Also, it brings speed later on.
-  if (opts.change_to_cache_directory &&
-      chdir(cache_directory_.c_str()) != 0) {
-    PrintError("cache directory " + cache_directory_ + " is unavailable");
-    return LIBCVMFS_FAIL_OPENCACHE;
+  if (opts.change_to_cache_directory) {
+    if (opts.alien_cachedir != "")
+      MkdirDeep(opts.alien_cachedir, 0770);
+    if (chdir(cache_directory_.c_str()) != 0) {
+      PrintError("cache directory " + cache_directory_ + " is unavailable");
+      return LIBCVMFS_FAIL_OPENCACHE;
+    }
   }
   // Creates a set of cache directories (256 directories named 00..ff) if not
   // using alien cachdir

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -50,21 +50,37 @@ class cvmfs_globals : SingleCopy {
  public:
   // Common options for all repositories
   struct options {
-    options() : change_to_cache_directory(false),
-                alien_cache(false),
-                log_syslog_level(LOG_ALERT),
-                max_open_files(0) {}
+    options()
+      : change_to_cache_directory(false)
+      , alien_cache(false)
+      , syslog_level(-1)
+      , log_syslog_level(-1)
+      , nofiles(-1)
+      , max_open_files(0)
+      , quota_limit(0)
+      , quota_threshold(0)
+      , rebuild_cachedb(0)
+    { }
 
     std::string    cache_directory;
     std::string    alien_cachedir;
+    std::string    lock_directory;
     bool           change_to_cache_directory;
     bool           alien_cache;
 
+    int            syslog_level;
     int            log_syslog_level;
     std::string    log_prefix;
+    std::string    logfile;
     std::string    log_file;
 
-    int            max_open_files;
+    int            nofiles;
+    int            max_open_files;  // Alias of nofiles
+
+    // Currently ignored
+    unsigned long  quota_limit;
+    unsigned long  quota_threshold;
+    bool rebuild_cachedb;
   };
 
   static int            Initialize(const options &opts);
@@ -87,6 +103,7 @@ class cvmfs_globals : SingleCopy {
   static cvmfs_globals *instance;
 
   std::string       cache_directory_;
+  std::string       lock_directory_;
   uid_t             uid_;
   gid_t             gid_;
   int               fd_lockfile_;

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -78,8 +78,8 @@ class cvmfs_globals : SingleCopy {
     int            max_open_files;  // Alias of nofiles
 
     // Currently ignored
-    unsigned long  quota_limit;
-    unsigned long  quota_threshold;
+    unsigned quota_limit;
+    unsigned quota_threshold;
     bool rebuild_cachedb;
   };
 

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -43,8 +43,12 @@ extern std::string  *repository_name_;
 extern bool          foreground_;
 }
 
+/**
+ * A singleton managing the cvmfs resources for all attached repositories.
+ */
 class cvmfs_globals : SingleCopy {
  public:
+  // Common options for all repositories
   struct options {
     options() : change_to_cache_directory(false),
                 alien_cache(false),
@@ -52,6 +56,7 @@ class cvmfs_globals : SingleCopy {
                 max_open_files(0) {}
 
     std::string    cache_directory;
+    std::string    alien_cachedir;
     bool           change_to_cache_directory;
     bool           alien_cache;
 
@@ -62,7 +67,6 @@ class cvmfs_globals : SingleCopy {
     int            max_open_files;
   };
 
- public:
   static int            Initialize(const options &opts);
   static void           Destroy();
   static cvmfs_globals* Instance();
@@ -71,7 +75,6 @@ class cvmfs_globals : SingleCopy {
 
  protected:
   int Setup(const options &opts);
-
   static void CallbackLibcryptoLock(int mode, int type,
                                     const char *file, int line);
   // unsigned long type required by libcrypto (openssl)
@@ -81,27 +84,25 @@ class cvmfs_globals : SingleCopy {
   cvmfs_globals();
   ~cvmfs_globals();
 
- private:
   static cvmfs_globals *instance;
 
- private:
   std::string       cache_directory_;
   uid_t             uid_;
   gid_t             gid_;
-
   int               fd_lockfile_;
   pthread_mutex_t  *libcrypto_locks_;
-
   void             *sqlite_scratch;
   void             *sqlite_page_cache;
-
- private:
   bool options_ready_;
   bool lock_created_;
   bool cache_ready_;
   bool quota_ready_;
 };
 
+
+/**
+ * Encapsulates state and manager objects for a single attached repository.
+ */
 class cvmfs_context : SingleCopy {
  public:
   struct options {

--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -790,27 +790,27 @@ string StringifyTime(const time_t seconds, const bool utc) {
 }
 
 
-  /**
-   * Current time in format Wed, 01 Mar 2006 12:00:00 GMT
-   */
-  std::string RfcTimestamp() {
-    const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
-      "Aug", "Sep", "Oct", "Nov", "Dec"};
-    const char *day_of_week[] =
-      {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+/**
+ * Current time in format Wed, 01 Mar 2006 12:00:00 GMT
+ */
+std::string RfcTimestamp() {
+  const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
+    "Aug", "Sep", "Oct", "Nov", "Dec"};
+  const char *day_of_week[] =
+    {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
-    struct tm timestamp;
-    time_t now = time(NULL);
-    gmtime_r(&now, &timestamp);
+  struct tm timestamp;
+  time_t now = time(NULL);
+  gmtime_r(&now, &timestamp);
 
-    char buffer[30];
-    snprintf(buffer, sizeof(buffer), "%s, %02d %s %d %02d:%02d:%02d %s",
-      day_of_week[timestamp.tm_wday], timestamp.tm_mday,
-      months[timestamp.tm_mon], timestamp.tm_year + 1900,
-      timestamp.tm_hour, timestamp.tm_min, timestamp.tm_sec,
-      timestamp.tm_zone);
-    return string(buffer);
-  }
+  char buffer[30];
+  snprintf(buffer, sizeof(buffer), "%s, %02d %s %d %02d:%02d:%02d %s",
+    day_of_week[timestamp.tm_wday], timestamp.tm_mday,
+    months[timestamp.tm_mon], timestamp.tm_year + 1900,
+    timestamp.tm_hour, timestamp.tm_min, timestamp.tm_sec,
+    timestamp.tm_zone);
+  return string(buffer);
+}
 
 string StringifyTimeval(const timeval value) {
   char buffer[64];

--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -590,6 +590,18 @@ string CreateTempPath(const std::string &path_prefix, const int mode) {
 
 
 /**
+ * Create a directory with a unique name.
+ */
+string CreateTempDir(const std::string &path_prefix, const int mode) {
+  char *tmp_dir = strdupa((path_prefix + ".XXXXXX").c_str());
+  tmp_dir = mkdtemp(tmp_dir);
+  if (tmp_dir == NULL)
+    return "";
+  return string(tmp_dir);
+}
+
+
+/**
  * Helper class that provides callback funtions for the file system traversal.
  */
 class RemoveTreeHelper {

--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -140,6 +140,7 @@ bool MakeCacheDirectories(const std::string &path, const mode_t mode);
 FILE *CreateTempFile(const std::string &path_prefix, const int mode,
                      const char *open_flags, std::string *final_path);
 std::string CreateTempPath(const std::string &path_prefix, const int mode);
+std::string CreateTempDir(const std::string &path_prefix, const int mode);
 int TryLockFile(const std::string &path);
 int LockFile(const std::string &path);
 void UnlockFile(const int filedes);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -59,6 +59,8 @@ set (CVMFS_UNITTEST_SOURCES
   t_statistics.cc
   t_options.cc
   t_libcvmfs.cc
+  t_backoff.cc
+  t_wpad.cc
 
   # test utility functions
   testutil.cc testutil.h
@@ -202,7 +204,7 @@ if (BUILD_UNITTESTS)
   if (ZLIB_BUILTIN)
     add_dependencies (${PROJECT_TEST_NAME} zlib)
   endif (ZLIB_BUILTIN)
-  
+
   if (PACPARSER_BUILTIN)
     add_dependencies (${PROJECT_TEST_NAME} libpacparser)
   endif (PACPARSER_BUILTIN)
@@ -224,7 +226,7 @@ if (BUILD_UNITTESTS_DEBUG)
   if (ZLIB_BUILTIN)
     add_dependencies (${PROJECT_TEST_DEBUG_NAME} zlib)
   endif (ZLIB_BUILTIN)
-  
+
   if (PACPARSER_BUILTIN)
     add_dependencies (${PROJECT_TEST_DEBUG_NAME} libpacparser)
   endif (PACPARSER_BUILTIN)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -58,6 +58,7 @@ set (CVMFS_UNITTEST_SOURCES
   t_xattr.cc
   t_statistics.cc
   t_options.cc
+  t_libcvmfs.cc
 
   # test utility functions
   testutil.cc testutil.h
@@ -140,6 +141,25 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/xattr.cc
   ${CVMFS_SOURCE_DIR}/statistics.h
   ${CVMFS_SOURCE_DIR}/statistics.cc
+
+  ${CVMFS_SOURCE_DIR}/cache.h
+  ${CVMFS_SOURCE_DIR}/cache.cc
+  ${CVMFS_SOURCE_DIR}/quota.h
+  ${CVMFS_SOURCE_DIR}/quota.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr.h
+  ${CVMFS_SOURCE_DIR}/backoff.h
+  ${CVMFS_SOURCE_DIR}/backoff.cc
+  ${CVMFS_SOURCE_DIR}/monitor.h
+  ${CVMFS_SOURCE_DIR}/monitor.cc
+  ${CVMFS_SOURCE_DIR}/tracer.cc
+  ${CVMFS_SOURCE_DIR}/tracer.h
+  ${CVMFS_SOURCE_DIR}/wpad.h
+  ${CVMFS_SOURCE_DIR}/wpad.cc
+  ${CVMFS_SOURCE_DIR}/libcvmfs.h
+  ${CVMFS_SOURCE_DIR}/libcvmfs.cc
+  ${CVMFS_SOURCE_DIR}/libcvmfs_int.h
+  ${CVMFS_SOURCE_DIR}/libcvmfs_int.cc
 )
 
 set (CVMFS_UNITTEST_DEBUG_SOURCES ${CVMFS_UNITTEST_SOURCES})
@@ -147,7 +167,7 @@ set (CVMFS_UNITTEST_DEBUG_SOURCES ${CVMFS_UNITTEST_SOURCES})
 #
 # Compiler and Linker Flags for unit tests
 #
-set (CVMFS_UNITTESTS_CFLAGS "${CVMFS_UNITTESTS_CFLAGS} -DGTEST_HAS_TR1_TUPLE=0 -D_FILE_OFFSET_BITS=64")
+set (CVMFS_UNITTESTS_CFLAGS "${CVMFS_UNITTESTS_CFLAGS} -DGTEST_HAS_TR1_TUPLE=0 -DCVMFS_LIBCVMFS -D_FILE_OFFSET_BITS=64")
 set (CVMFS_UNITTESTS_DEBUG_CFLAGS "${CVMFS_UNITTESTS_CFLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0 -DDEBUGMSG -g")
 set (CVMFS_UNITTESTS_LD_FLAGS "${CVMFS_UNITTESTS_LD_FLAGS}")
 set (CVMFS_UNITTESTS_DEBUG_LD_FLAGS "${CVMFS_UNITTESTS_LD_FLAGS} -fprofile-arcs -lgcov -coverage")
@@ -182,6 +202,10 @@ if (BUILD_UNITTESTS)
   if (ZLIB_BUILTIN)
     add_dependencies (${PROJECT_TEST_NAME} zlib)
   endif (ZLIB_BUILTIN)
+  
+  if (PACPARSER_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} libpacparser)
+  endif (PACPARSER_BUILTIN)
 
   if (TBB_PRIVATE_LIB)
     add_dependencies (${PROJECT_TEST_NAME} libtbb)
@@ -200,6 +224,10 @@ if (BUILD_UNITTESTS_DEBUG)
   if (ZLIB_BUILTIN)
     add_dependencies (${PROJECT_TEST_DEBUG_NAME} zlib)
   endif (ZLIB_BUILTIN)
+  
+  if (PACPARSER_BUILTIN)
+    add_dependencies (${PROJECT_TEST_DEBUG_NAME} libpacparser)
+  endif (PACPARSER_BUILTIN)
 
   if (TBB_PRIVATE_LIB)
     add_dependencies (${PROJECT_TEST_DEBUG_NAME} libtbb)
@@ -224,7 +252,7 @@ set (UNITTEST_LINK_LIBRARIES ${GTEST_LIBRARIES} ${GOOGLETEST_ARCHIVE} ${OPENSSL_
                              ${CURL_LIBRARIES} ${LIBCURL_ARCHIVE} ${CARES_ARCHIVE}
                              ${SQLITE3_LIBRARY} ${SQLITE3_ARCHIVE} ${TBB_LIBRARIES}
                              ${ZLIB_LIBRARIES} ${ZLIB_ARCHIVE} ${RT_LIBRARY} ${UUID_LIBRARIES}
-                             pthread dl)
+                             ${PACPARSER_LIBRARIES} ${PACPARSER_ARCHIVE} pthread dl)
 
 if (BUILD_UNITTESTS)
   target_link_libraries (${PROJECT_TEST_NAME} ${UNITTEST_LINK_LIBRARIES})

--- a/test/unittests/t_backoff.cc
+++ b/test/unittests/t_backoff.cc
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../../cvmfs/libcvmfs.h"
+#include "../../cvmfs/backoff.h"
 
 using namespace std;  // NOLINT
 

--- a/test/unittests/t_backoff.cc
+++ b/test/unittests/t_backoff.cc
@@ -1,0 +1,24 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/libcvmfs.h"
+
+using namespace std;  // NOLINT
+
+class T_Backoff : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+  BackoffThrottle throttle_;
+};
+
+
+TEST_F(T_Backoff, Create) {
+}

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -4,20 +4,99 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <string>
+
 #include "../../cvmfs/libcvmfs.h"
+#include "../../cvmfs/util.h"
 
 using namespace std;  // NOLINT
+
+static void cvmfs_log_ignore(const char *msg) {
+  // Remove comment to debug test failures
+  // fprintf(stderr, "%s\n", msg);
+}
 
 class T_Libcvmfs : public ::testing::Test {
  protected:
   virtual void SetUp() {
-  }
+    cvmfs_set_log_fn(cvmfs_log_ignore);
+    tmp_path_ = CreateTempDir("/tmp/cvmfs_test", 0700);
+    ASSERT_NE("", tmp_path_);
+    opt_cache_ = "quota_limit=0,quota_threshold=0,rebuild_cachedb,"
+                 "cache_directory=" + tmp_path_;
 
+    fdevnull_ = fopen("/dev/null", "w");
+    ASSERT_FALSE(fdevnull_ == NULL);
+  }
 
   virtual void TearDown() {
+    fclose(fdevnull_);
+    if (tmp_path_ != "")
+      RemoveTree(tmp_path_);
+    cvmfs_set_log_fn(NULL);
   }
+
+  string tmp_path_;
+  string opt_cache_;
+  FILE *fdevnull_;
 };
 
 
 TEST_F(T_Libcvmfs, Init) {
+  int retval;
+  string opt_cache = "cache_directory=" + tmp_path_;
+  retval = cvmfs_init(opt_cache_.c_str());
+  ASSERT_EQ(LIBCVMFS_FAIL_OK, retval);
+  EXPECT_DEATH(cvmfs_init(opt_cache_.c_str()), ".*");
+  cvmfs_fini();
+}
+
+
+TEST_F(T_Libcvmfs, InitFailures) {
+  int retval;
+  FILE *save_stderr = stderr;
+  stderr = fdevnull_;
+  retval = cvmfs_init("bad option");
+  stderr = save_stderr;
+  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+
+  retval = cvmfs_init((opt_cache_ + ",max_open_files=100000000").c_str());
+  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+
+  retval = cvmfs_init("");
+  ASSERT_EQ(LIBCVMFS_FAIL_MKCACHE, retval);
+}
+
+
+TEST_F(T_Libcvmfs, OptionAliases) {
+  int retval;
+  FILE *save_stderr = stderr;
+
+  retval = cvmfs_init((opt_cache_ +
+    ",nofiles=100000000,max_open_files=100000000").c_str());
+  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+
+  retval = cvmfs_init((opt_cache_ + ",nofiles=100000000").c_str());
+  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+
+  retval = cvmfs_init((opt_cache_ + ",max_open_files=100000000").c_str());
+  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+
+  stderr = fdevnull_;
+  retval = cvmfs_init((opt_cache_ + ",nofiles=999,max_open_files=888").c_str());
+  stderr = save_stderr;
+  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+
+  stderr = fdevnull_;
+  retval =
+    cvmfs_init((opt_cache_ + ",syslog_level=0,log_syslog_level=1").c_str());
+  stderr = save_stderr;
+  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+
+  stderr = fdevnull_;
+  retval =
+    cvmfs_init((opt_cache_ + ",log_file=abc,logfile=efg").c_str());
+  stderr = save_stderr;
+  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
 }

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -116,7 +116,7 @@ TEST_F(T_Libcvmfs, InitConcurrent) {
       EXPECT_EQ(LIBCVMFS_FAIL_OK, retval);
       WritePipe(pipe_p2c[1], &retval, sizeof(retval));
       cvmfs_fini();
-      
+
       ReadPipe(pipe_c2p[0], &retval, sizeof(retval));
       EXPECT_EQ(LIBCVMFS_FAIL_OK, retval);
       retval = cvmfs_init(opt_var2_p2.c_str());

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -1,0 +1,23 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/libcvmfs.h"
+
+using namespace std;  // NOLINT
+
+class T_Libcvmfs : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+
+
+  virtual void TearDown() {
+  }
+};
+
+
+TEST_F(T_Libcvmfs, Init) {
+}

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -3,6 +3,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <fcntl.h>
 #include <pthread.h>
 #include <tbb/tbb_thread.h>
 
@@ -81,6 +83,28 @@ TEST(T_Util, HasSuffix) {
   EXPECT_TRUE(HasSuffix("-foo", "-foo", false));
   EXPECT_FALSE(HasSuffix("abc+foo", "-foo", false));
   EXPECT_FALSE(HasSuffix("foo", "-foo", false));
+}
+
+
+TEST(T_Util, RemoveTree) {
+  string tmp_path_ = CreateTempDir("/tmp/cvmfs_test", 0700);
+  ASSERT_NE("", tmp_path_);
+  ASSERT_TRUE(DirectoryExists(tmp_path_));
+  EXPECT_TRUE(RemoveTree(tmp_path_));
+  EXPECT_FALSE(DirectoryExists(tmp_path_));
+
+  tmp_path_ = CreateTempDir("/tmp/cvmfs_test", 0700);
+  ASSERT_NE("", tmp_path_);
+  EXPECT_TRUE(MkdirDeep(tmp_path_ + "/subdir", 0700));
+  int fd = open((tmp_path_ + "/subdir/file").c_str(),
+                O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  EXPECT_GE(fd, 0);
+  if (fd >= 0)
+    close(fd);
+  EXPECT_TRUE(RemoveTree(tmp_path_));
+  EXPECT_FALSE(DirectoryExists(tmp_path_));
+
+  EXPECT_TRUE(RemoveTree(tmp_path_));
 }
 
 

--- a/test/unittests/t_wpad.cc
+++ b/test/unittests/t_wpad.cc
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../../cvmfs/libcvmfs.h"
+#include "../../cvmfs/wpad.h"
 
 using namespace std;  // NOLINT
 
@@ -12,7 +12,6 @@ class T_Wpad : public ::testing::Test {
  protected:
   virtual void SetUp() {
   }
-
 
   virtual void TearDown() {
   }

--- a/test/unittests/t_wpad.cc
+++ b/test/unittests/t_wpad.cc
@@ -1,0 +1,23 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/libcvmfs.h"
+
+using namespace std;  // NOLINT
+
+class T_Wpad : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+
+
+  virtual void TearDown() {
+  }
+};
+
+
+TEST_F(T_Wpad, Init) {
+}


### PR DESCRIPTION
Various fixes to libcvmfs:
  - Restore 2.1.19 option names (with new names as aliases)
  - Add unit tests
  - Use "unix-none" sqlite vfs
  - Defines for error codes
  - Don't start quota manager
  - Add LIBCVMFS_REVISION, LIBCVMFS_VERSION_MAJOR, LIBCVMFS_VERSION_MINOR