### PR TITLE
TEST: added t_smalloc.cc

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -58,6 +58,7 @@ set (CVMFS_UNITTEST_SOURCES
   t_xattr.cc
   t_statistics.cc
   t_options.cc
+  t_smalloc.cc
 
   # test utility functions
   testutil.cc testutil.h

--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -1,0 +1,71 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/smalloc.h"
+
+
+const size_t kSmallAllocation = 1024UL;
+const size_t kBigAllocation = 1125899906842624UL;  // 1024⁵ Bytes -> 1024 TB
+
+TEST(T_Smalloc, SmallAlloc) {
+  void *mem = smalloc(kSmallAllocation);
+  EXPECT_NE(static_cast<void*>(NULL), mem);
+  free(mem);
+}
+
+TEST(T_Smalloc, BigAlloc) {
+  void *mem = NULL;
+  EXPECT_DEATH(mem = smalloc(kBigAllocation), ".*");
+  EXPECT_EQ(static_cast<void*>(NULL), mem);
+}
+
+TEST(T_Smalloc, SmallRealloc) {
+  void *mem = smalloc(kSmallAllocation);
+  mem = srealloc(mem, kSmallAllocation * 2);
+  EXPECT_NE(static_cast<void*>(NULL), mem);
+  mem = srealloc(mem, kSmallAllocation / 2);
+  EXPECT_NE(static_cast<void*>(NULL), mem);
+  free(mem);
+}
+
+TEST(T_Smalloc, BigRealloc) {
+  void *mem = smalloc(kSmallAllocation);
+  ASSERT_DEATH(mem = srealloc(mem, kBigAllocation), ".*");
+  EXPECT_NE(static_cast<void*>(NULL), mem);
+  free(mem);
+}
+
+TEST(T_Smalloc, SmallCalloc) {
+  int size = sizeof(char);
+  void *mem = scalloc(kSmallAllocation, size);
+  EXPECT_NE(static_cast<void*>(NULL), mem);
+  free(mem);
+}
+
+TEST(T_Smalloc, BigCalloc) {
+  int size = sizeof(char);
+  void *mem = NULL;
+  ASSERT_DEATH(mem = scalloc(kBigAllocation, size), ".*");
+  EXPECT_EQ(static_cast<void*>(NULL), mem);
+}
+
+TEST(T_Smalloc, SmallMmap) {
+  void *mem = smmap(kSmallAllocation);
+  EXPECT_NE(MAP_FAILED, mem);
+  size_t *details = reinterpret_cast<size_t*>(mem);
+  size_t pages = ((kSmallAllocation + 2 * sizeof(size_t)) + 4095) / 4096;
+  EXPECT_EQ(pages, *(details - 1));
+  EXPECT_EQ(0xAAAAAAAA, *(details - 2));
+  smunmap(mem);
+  EXPECT_NE(MAP_FAILED, mem);
+}
+
+TEST(T_Smalloc, BigMmap) {
+  void *mem = NULL;
+  ASSERT_DEATH(mem = smmap(kBigAllocation), ".*");
+  ASSERT_DEATH(smunmap(mem), ".*");
+}


### PR DESCRIPTION
There are basically two type of tests:
1) Normal functionality, using normal numbers and checking that it doesn't crash.
2) The opposite: making reservations of a huge amount of memory that should force CVMFS to crash.

The tests passed, by the way.