### PR TITLE
FIX: Compile on 32bit Platforms

### DIFF
--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -4,12 +4,13 @@
 
 
 #include <gtest/gtest.h>
+#include <limits>
 
 #include "../../cvmfs/smalloc.h"
 
 
 const size_t kSmallAllocation = 1024UL;
-const size_t kBigAllocation = 1125899906842624UL;  // 1024⁵ Bytes -> 1024 TB
+const size_t kBigAllocation = std::numeric_limits<size_t>::max();
 
 TEST(T_Smalloc, SmallAlloc) {
   void *mem = smalloc(kSmallAllocation);


### PR DESCRIPTION
Turns out that 32bit platforms typedef `size_t` to a 32bit integer which raises a compile error since the numerical literal introduced [here](https://github.com/cvmfs/cvmfs/pull/879) is not representable by it. The testee `smalloc()` expects a `size_t` so I changed it to `std::numeric_limits<size_t>::max()` and hope that 4GiB are enough to cause a runtime error on `smalloc()`.