### PR TITLE
FIX: improved readability in StringifyTime function

### DIFF
--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -772,21 +772,16 @@ string StringifyDouble(const double value) {
  * Converts seconds since UTC 0 into something readable
  */
 string StringifyTime(const time_t seconds, const bool utc) {
-  struct tm timestamp;
+  time_t now = time(NULL);
+  char buf[80];
+  struct tm ts;
   if (utc) {
-    localtime_r(&seconds, &timestamp);
+    ts = *localtime(&now);
   } else {
-    gmtime_r(&seconds, &timestamp);
+    ts = *gmtime(&now);
   }
-
-  const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
-    "Aug", "Sep", "Oct", "Nov", "Dec"};
-  char buffer[21];
-  snprintf(buffer, sizeof(buffer), "%d %s %d %02d:%02d:%02d", timestamp.tm_mday,
-           months[timestamp.tm_mon], timestamp.tm_year + 1900,
-           timestamp.tm_hour, timestamp.tm_min, timestamp.tm_sec);
-
-  return string(buffer);
+  strftime(buf, sizeof(buf), "%d %h %Y %H:%M:%S", &ts);
+  return string(buf);
 }
 
 

--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -772,15 +772,14 @@ string StringifyDouble(const double value) {
  * Converts seconds since UTC 0 into something readable
  */
 string StringifyTime(const time_t seconds, const bool utc) {
-  time_t now = time(NULL);
-  char buf[80];
+  char buf[32];
   struct tm ts;
   if (utc) {
-    ts = *localtime(&now);
+    localtime_r(&seconds, &ts);
   } else {
-    ts = *gmtime(&now);
+    gmtime_r(&seconds, &ts);
   }
-  strftime(buf, sizeof(buf), "%d %h %Y %H:%M:%S", &ts);
+  strftime(buf, sizeof(buf), "%d %b %Y %H:%M:%S", &ts);
   return string(buf);
 }
 


### PR DESCRIPTION
I did it while I was writing the unittests for util.cc and the result is the same than before