### PR TITLE
FIX: add support for socket in fs_traversal.h

### DIFF
--- a/cvmfs/fs_traversal.h
+++ b/cvmfs/fs_traversal.h
@@ -45,6 +45,7 @@ class FileSystemTraversal {
   VoidCallback fn_leave_dir;
   VoidCallback fn_new_file;
   VoidCallback fn_new_symlink;
+  VoidCallback fn_new_socket;
 
   /**
    * Optional callback for all files during recursion to decide
@@ -182,6 +183,10 @@ class FileSystemTraversal {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing symlink %s/%s",
                  path.c_str(), dit->d_name);
         Notify(fn_new_symlink, path, dit->d_name);
+      } else if(S_ISSOCK(info.st_mode)){
+        LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing socket %s/%s",
+                 path.c_str(), dit->d_name);
+        Notify(fn_new_socket, path, dit->d_name);
       } else {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "unknown file type %s/%s",
                  path.c_str(), dit->d_name);

--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -639,6 +639,7 @@ bool RemoveTree(const string &path) {
                                                   true);
   traversal.fn_new_file = &RemoveTreeHelper::RemoveFile;
   traversal.fn_new_symlink = &RemoveTreeHelper::RemoveFile;
+  traversal.fn_new_socket = &RemoveTreeHelper::RemoveFile;
   traversal.fn_leave_dir = &RemoveTreeHelper::RemoveDir;
   traversal.Recurse(path);
   bool result = remove_tree_helper->success;


### PR DESCRIPTION
When running the unittests I realized that a socket I created was never deleted using the FileSystemTraversal class. I have just tested it now and it works.