### PR TITLE
Feature: Bulk Change of File Owner on Catalog Level

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -159,7 +159,7 @@ is_subcommand() {
   local subcommand="$1"
   local supported_commands="mkfs add-replica import publish rollback rmfs alterfs \
     resign list info tag list-tags lstags check transaction abort snapshot \
-    skeleton migrate list-catalogs update-geodb gc"
+    skeleton migrate list-catalogs update-geodb gc catalog-chown"
 
   for possible_command in $supported_commands; do
     if [ x"$possible_command" = x"$subcommand" ]; then
@@ -4618,6 +4618,89 @@ migrate() {
   done
 
   return $retcode
+}
+
+
+################################################################################
+
+
+catalog_chown() {
+  local names
+  local uid_map
+  local gid_map
+
+  OPTIND=1
+  while getopts "u:g:" option; do
+    case $option in
+      u)
+        uid_map=$OPTARG
+      ;;
+      g)
+        gid_map=$OPTARG
+      ;;
+      ?)
+        shift $(($OPTIND-2))
+        usage "Command catalog-chown: Unrecognized option: $1"
+      ;;
+    esac
+  done
+  shift $(($OPTIND-1))
+
+   # get repository names
+  check_parameter_count_with_guessing $#
+  name=$(get_or_guess_repository_name $@)
+  check_repository_existence "$name"
+
+  # sanity checks
+  [ x"$uid_map" != x"" ] && [ -f $uid_map ] || die "UID map file not found (-u)"
+  [ x"$gid_map" != x"" ] && [ -f $gid_map ] || die "GID map file not found (-g)"
+
+  load_repo_config $name
+
+  # more sanity checks
+  is_stratum0 $name       || die "This is not a stratum 0 repository"
+  is_root $name           || die "Permission denied: Only root can do that"
+  is_in_transaction $name && die "Repository is already in a transaction"
+  health_check $name
+
+  # all following commands need an open repository transaction and are supposed
+  # to commit or abort it after performing the catalog chmod.
+  echo "Opening repository transaction"
+  trap "close_transaction $name 0" EXIT HUP INT TERM
+  open_transaction $name || die "Failed to open repository transaction"
+
+  # run the catalog level chmod operation
+  echo "Starting catalog chown"
+
+  local tmp_dir=${CVMFS_SPOOL_DIR}/tmp
+  local manifest=${tmp_dir}/manifest
+  cvmfs_swissknife migrate     \
+    -v "chown"                 \
+    -r $CVMFS_STRATUM0         \
+    -n $name                   \
+    -u $CVMFS_UPSTREAM_STORAGE \
+    -t $tmp_dir                \
+    -k $CVMFS_PUBLIC_KEY       \
+    -o $manifest               \
+    -i $uid_map                \
+    -j $gid_map                \
+    -s || die "fail"
+
+  local trunk_hash=$(grep "^C" $manifest | tr -d C)
+
+  # finalizing transaction
+  echo "Flushing file system buffers"
+  sync
+
+  # committing newly created revision
+  echo "Signing new manifest"
+  sign_manifest $name $manifest      || { publish_failed $name; die "Signing failed"; }
+  set_ro_root_hash $name $trunk_hash || { publish_failed $name; die "Root hash update failed"; }
+
+  # remount the repository
+  close_transaction $name
+
+  return
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4674,18 +4674,18 @@ catalog_chown() {
 
   local tmp_dir=${CVMFS_SPOOL_DIR}/tmp
   local manifest=${tmp_dir}/manifest
-  cvmfs_swissknife migrate     \
-    -v "chown"                 \
-    -r $CVMFS_STRATUM0         \
-    -n $name                   \
-    -u $CVMFS_UPSTREAM_STORAGE \
-    -t $tmp_dir                \
-    -k $CVMFS_PUBLIC_KEY       \
-    -o $manifest               \
-    -i $uid_map                \
-    -j $gid_map                \
-    -s || die "fail"
-
+  local migrate_command="$(__swissknife_cmd dbg) migrate     \
+                              -v 'chown'                     \
+                              -r $CVMFS_STRATUM0             \
+                              -n $name                       \
+                              -u $CVMFS_UPSTREAM_STORAGE     \
+                              -t $tmp_dir                    \
+                              -k $CVMFS_PUBLIC_KEY           \
+                              -o $manifest                   \
+                              -i $uid_map                    \
+                              -j $gid_map                    \
+                              -s"
+  sh -c "$migrate_command" || die "Fail (executed command: $migrate_command)"
   local trunk_hash=$(grep "^C" $manifest | tr -d C)
 
   # finalizing transaction
@@ -4694,11 +4694,9 @@ catalog_chown() {
 
   # committing newly created revision
   echo "Signing new manifest"
-  sign_manifest $name $manifest      || { publish_failed $name; die "Signing failed"; }
-  set_ro_root_hash $name $trunk_hash || { publish_failed $name; die "Root hash update failed"; }
-
-  # remount the repository
-  close_transaction $name
+  chown $CVMFS_USER $manifest        || die "chmod of new manifest failed";
+  sign_manifest $name $manifest      || die "Signing failed";
+  set_ro_root_hash $name $trunk_hash || die "Root hash update failed";
 
   return
 }

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -1727,8 +1727,10 @@ bool CommandMigrate::ChownMigrationWorker::ListAssignedPersonas(
                                                    PendingCatalog *data) const {
   assert(data->assigned_uids.empty());
   assert(data->assigned_gids.empty());
+  assert(data->old_catalog != NULL);
+  assert(data->new_catalog == NULL);
 
-  const catalog::CatalogDatabase &catalog_db = data->new_catalog->database();
+  const catalog::CatalogDatabase &catalog_db = data->old_catalog->database();
   catalog::Sql get_uids(catalog_db, "SELECT DISTINCT uid FROM catalog;");
   while (get_uids.FetchRow()) {
     data->assigned_uids.push_back(get_uids.RetrieveInt(0));
@@ -1741,6 +1743,7 @@ bool CommandMigrate::ChownMigrationWorker::ListAssignedPersonas(
 
   return true;
 }
+
 
 bool CommandMigrate::ChownMigrationWorker::CheckAssignedPersonas(
                                                    PendingCatalog *data) const {
@@ -1772,14 +1775,17 @@ bool CommandMigrate::ChownMigrationWorker::CheckAssignedPersonas(
   return true;
 }
 
+
 bool CommandMigrate::ChownMigrationWorker::ApplyPersonaMappings(
                                                    PendingCatalog *data) const {
   assert(uid_map_.RuleCount() > 0 || uid_map_.HasDefault());
   assert(gid_map_.RuleCount() > 0 || gid_map_.HasDefault());
   assert(!data->assigned_uids.empty());
   assert(!data->assigned_gids.empty());
+  assert(data->old_catalog != NULL);
+  assert(data->new_catalog == NULL);
 
-  const catalog::CatalogDatabase &db = data->new_catalog->database();
+  const catalog::CatalogDatabase &db=GetWritable(data->old_catalog)->database();
   catalog::Sql update_uid(db, "UPDATE catalog SET uid = :new WHERE uid = :old");
   catalog::Sql update_gid(db, "UPDATE catalog SET gid = :new WHERE gid = :old");
 

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -696,6 +696,15 @@ const float    CommandMigrate::MigrationWorker_20x::kSchema         = 2.5;
 const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 2;
 
 
+template<class DerivedT>
+catalog::WritableCatalog*
+CommandMigrate::AbstractMigrationWorker<DerivedT>::GetWritable(
+                                        const catalog::Catalog *catalog) const {
+  return dynamic_cast<catalog::WritableCatalog*>(const_cast<catalog::Catalog*>(
+    catalog));
+}
+
+
 CommandMigrate::MigrationWorker_20x::MigrationWorker_20x(
   const worker_context *context)
   : AbstractMigrationWorker<MigrationWorker_20x>(context)
@@ -1694,14 +1703,6 @@ bool CommandMigrate::MigrationWorker_217::CommitDatabaseTransaction
   assert(!data->HasNew());
   GetWritable(data->old_catalog)->Commit();
   return true;
-}
-
-
-catalog::WritableCatalog* CommandMigrate::MigrationWorker_217::GetWritable(
-  const catalog::Catalog *catalog) const
-{
-  return dynamic_cast<catalog::WritableCatalog*>(const_cast<catalog::Catalog*>(
-    catalog));
 }
 
 

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -167,17 +167,9 @@ int CommandMigrate::Main(const ArgumentList &args) {
   // Do the actual migration step
   bool migration_succeeded = false;
   if (migration_base == "2.0.x") {
-    if (uid.empty()) {
-      Error("Please provide a user ID");
+    if (!ReadPersona(uid, gid)) {
       return 1;
     }
-    if (gid.empty()) {
-      Error("Please provide a group ID");
-      return 1;
-    }
-
-    uid_ = String2Int64(uid);
-    gid_ = String2Int64(gid);
 
     // Generate and upload a nested catalog marker
     if (!GenerateNestedCatalogMarkerChunk()) {
@@ -220,6 +212,23 @@ int CommandMigrate::Main(const ArgumentList &args) {
 
   LogCvmfs(kLogCatalog, kLogStdout, "\nCatalog Migration succeeded");
   return 0;
+}
+
+
+bool CommandMigrate::ReadPersona(const std::string &uid,
+                                   const std::string &gid) {
+  if (uid.empty()) {
+    Error("Please provide a user ID");
+    return false;
+  }
+  if (gid.empty()) {
+    Error("Please provide a group ID");
+    return false;
+  }
+
+  uid_ = String2Int64(uid);
+  gid_ = String2Int64(gid);
+  return true;
 }
 
 

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -33,7 +33,7 @@ CommandMigrate::CommandMigrate() :
 ParameterList CommandMigrate::GetParams() {
   ParameterList r;
   r.push_back(Parameter::Mandatory('v',
-    "migration base version ( 2.0.x | 2.1.7 )"));
+    "migration base version ( 2.0.x | 2.1.7 | chown )"));
   r.push_back(Parameter::Mandatory('r',
     "repository URL (absolute local path or remote URL)"));
   r.push_back(Parameter::Mandatory('u', "upstream definition string"));
@@ -192,6 +192,17 @@ int CommandMigrate::Main(const ArgumentList &args) {
                                                 collect_catalog_statistics);
     migration_succeeded =
       DoMigrationAndCommit<MigrationWorker_217>(manifest_path, &context);
+  } else if (migration_base == "chown") {
+    if (!ReadUidAndGid(uid, gid)) {
+      return 1;
+    }
+
+    ChownMigrationWorker::worker_context context(temporary_directory_,
+                                                 collect_catalog_statistics,
+                                                 uid_,
+                                                 gid_);
+    migration_succeeded =
+      DoMigrationAndCommit<ChownMigrationWorker>(manifest_path, &context);
   } else {
     const std::string err_msg = "Unknown migration base: " + migration_base;
     Error(err_msg);

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -1808,7 +1808,7 @@ bool CommandMigrate::ChownMigrationWorker::ApplyPersonaMappings(
 
         std::vector<gid_t>::const_iterator j    = data->assigned_gids.begin();
   const std::vector<gid_t>::const_iterator jend = data->assigned_gids.end();
-  for (; j != jend; ++i) {
+  for (; j != jend; ++j) {
     const bool success = update_gid.Bind(1, *j)               &&
                          update_gid.Bind(2, gid_map_.Map(*i)) &&
                          update_gid.Execute()                 &&

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -1654,4 +1654,20 @@ catalog::WritableCatalog* CommandMigrate::MigrationWorker_217::GetWritable(
     catalog));
 }
 
+
+//------------------------------------------------------------------------------
+
+
+CommandMigrate::ChownMigrationWorker::ChownMigrationWorker(
+                                                const worker_context *context)
+  : AbstractMigrationWorker<ChownMigrationWorker>(context)
+{
+
+}
+
+bool CommandMigrate::ChownMigrationWorker::RunMigration(
+                                                   PendingCatalog *data) const {
+  return true;
+}
+
 }  // namespace swissknife

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -1796,8 +1796,8 @@ bool CommandMigrate::ChownMigrationWorker::ApplyPersonaMappings(
         std::vector<uid_t>::const_iterator i    = data->assigned_uids.begin();
   const std::vector<uid_t>::const_iterator iend = data->assigned_uids.end();
   for (; i != iend; ++i) {
-    const bool success = update_uid.Bind(1, *i)               &&
-                         update_uid.Bind(2, uid_map_.Map(*i)) &&
+    const bool success = update_uid.Bind(1, uid_map_.Map(*i)) &&
+                         update_uid.Bind(2, *i)               &&
                          update_uid.Execute()                 &&
                          update_uid.Reset();
     if (!success) {
@@ -1809,8 +1809,8 @@ bool CommandMigrate::ChownMigrationWorker::ApplyPersonaMappings(
         std::vector<gid_t>::const_iterator j    = data->assigned_gids.begin();
   const std::vector<gid_t>::const_iterator jend = data->assigned_gids.end();
   for (; j != jend; ++j) {
-    const bool success = update_gid.Bind(1, *j)               &&
-                         update_gid.Bind(2, gid_map_.Map(*i)) &&
+    const bool success = update_gid.Bind(1, gid_map_.Map(*i)) &&
+                         update_gid.Bind(2, *j)               &&
                          update_gid.Execute()                 &&
                          update_gid.Reset();
     if (!success) {

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -207,6 +207,21 @@ class CommandMigrate : public Command {
     public AbstractMigrationWorker<ChownMigrationWorker>
   {
     friend class AbstractMigrationWorker<ChownMigrationWorker>;
+   public:
+    struct worker_context :
+      AbstractMigrationWorker<ChownMigrationWorker>::worker_context
+    {
+      worker_context(const std::string  &temporary_directory,
+                     const bool          collect_catalog_statistics,
+                     const uid_t         uid,
+                     const gid_t         gid)
+        : AbstractMigrationWorker<ChownMigrationWorker>::worker_context(
+            temporary_directory, collect_catalog_statistics)
+        , uid(uid)
+        , gid(gid) { }
+      const uid_t uid;
+      const gid_t gid;
+    };
 
    public:
     explicit ChownMigrationWorker(const worker_context *context);

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -308,9 +308,9 @@ class CommandMigrate : public Command {
   std::string                     nested_catalog_marker_tmp_path_;
   static catalog::DirectoryEntry  nested_catalog_marker_;
 
-  catalog::Catalog const*                        root_catalog_;
-  UniquePtr<upload::Spooler>                     spooler_;
-  PendingCatalogMap                              pending_catalogs_;
+  catalog::Catalog const*     root_catalog_;
+  UniquePtr<upload::Spooler>  spooler_;
+  PendingCatalogMap           pending_catalogs_;
 
   StopWatch  catalog_loading_stopwatch_;
   StopWatch  migration_stopwatch_;

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -203,6 +203,18 @@ class CommandMigrate : public Command {
       GetWritable(const catalog::Catalog *catalog) const;
   };
 
+  class ChownMigrationWorker :
+    public AbstractMigrationWorker<ChownMigrationWorker>
+  {
+    friend class AbstractMigrationWorker<ChownMigrationWorker>;
+
+   public:
+    explicit ChownMigrationWorker(const worker_context *context);
+
+   protected:
+    bool RunMigration(PendingCatalog *data) const;
+  };
+
  public:
   CommandMigrate();
   ~CommandMigrate() { }

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -259,6 +259,7 @@ class CommandMigrate : public Command {
   bool RaiseFileDescriptorLimit() const;
   bool ConfigureSQLite() const;
   void AnalyzeCatalogStatistics() const;
+  bool ReadPersona(const std::string &uid, const std::string &gid);
 
   bool GenerateNestedCatalogMarkerChunk();
   void CreateNestedCatalogMarkerDirent(const shash::Any &content_hash);

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -233,6 +233,10 @@ class CommandMigrate : public Command {
    protected:
     bool RunMigration(PendingCatalog *data) const;
 
+    bool ListAssignedPersonas(PendingCatalog *data) const;
+    bool CheckAssignedPersonas(PendingCatalog *data) const;
+    bool ApplyPersonaMappings(PendingCatalog *data) const;
+
    private:
     const UidMap &uid_map_;
     const GidMap &gid_map_;

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -288,8 +288,8 @@ class CommandMigrate : public Command {
   bool ReadPersona(const std::string &uid, const std::string &gid);
   bool ReadPersonaMaps(const std::string &uid_map_path,
                        const std::string &gid_map_path,
-                             UidMap      &uid_map,
-                             GidMap      &gid_map) const;
+                             UidMap      *uid_map,
+                             GidMap      *gid_map) const;
 
   bool GenerateNestedCatalogMarkerChunk();
   void CreateNestedCatalogMarkerDirent(const shash::Any &content_hash);

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -122,6 +122,9 @@ class CommandMigrate : public Command {
     bool CleanupNestedCatalogs(PendingCatalog *data) const;
     bool CollectAndAggregateStatistics(PendingCatalog *data) const;
 
+    catalog::WritableCatalog*
+      GetWritable(const catalog::Catalog *catalog) const;
+
    protected:
     const std::string  temporary_directory_;
     const bool         collect_catalog_statistics_;
@@ -202,9 +205,6 @@ class CommandMigrate : public Command {
     bool GenerateNewStatisticsCounters(PendingCatalog *data) const;
     bool UpdateCatalogSchema(PendingCatalog *data) const;
     bool CommitDatabaseTransaction(PendingCatalog *data) const;
-
-    catalog::WritableCatalog*
-      GetWritable(const catalog::Catalog *catalog) const;
   };
 
   class ChownMigrationWorker :

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -86,9 +86,6 @@ class CommandMigrate : public Command {
 
     Future<shash::Any>                new_catalog_hash;
     Future<size_t>                    new_catalog_size;
-
-    std::vector<uid_t>                assigned_uids;
-    std::vector<gid_t>                assigned_gids;
   };
 
   class PendingCatalogMap : public std::map<std::string, const PendingCatalog*>,
@@ -232,14 +229,16 @@ class CommandMigrate : public Command {
 
    protected:
     bool RunMigration(PendingCatalog *data) const;
-
-    bool ListAssignedPersonas(PendingCatalog *data) const;
-    bool CheckAssignedPersonas(PendingCatalog *data) const;
     bool ApplyPersonaMappings(PendingCatalog *data) const;
 
    private:
-    const UidMap &uid_map_;
-    const GidMap &gid_map_;
+    template <class MapT>
+    std::string GenerateMappingStatement(const MapT         &map,
+                                         const std::string  &column) const;
+
+   private:
+    const std::string uid_map_statement_;
+    const std::string gid_map_statement_;
   };
 
  public:

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -189,7 +189,8 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
     // Write new manifest
     FILE *fmanifest = fopen(manifest_path.c_str(), "w");
     if (!fmanifest) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to write manifest");
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to open manifest (errno: %d)",
+               errno);
       delete manifest;
       goto sign_fail;
     }
@@ -197,7 +198,8 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
          != signed_manifest.length()) ||
         (fwrite(sig, 1, sig_size, fmanifest) != sig_size))
     {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to write manifest");
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to write manifest (errno: %d)",
+               errno);
       fclose(fmanifest);
       unlink(cert_path_tmp.c_str());
       delete manifest;

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -5,10 +5,12 @@
 #ifndef CVMFS_UID_MAP_H_
 #define CVMFS_UID_MAP_H_
 
+#include <sys/types.h>
+
 #include <cerrno>
 #include <map>
+#include <string>
 #include <vector>
-#include <sys/types.h>
 
 #include "util.h"
 
@@ -37,12 +39,12 @@ class IntegerMap {
   }
 
   bool Contains(const T k) const {
-    assert (IsValid());
+    assert(IsValid());
     return map_.find(k) != map_.end();
   }
 
   T Map(const T k) const {
-    assert (IsValid());
+    assert(IsValid());
     typename map_type::const_iterator i = map_.find(k);
     if (i != map_.end()) {
       return i->second;
@@ -79,7 +81,7 @@ class IntegerMap {
       }
 
       std::vector<std::string> components = SplitString(line, ' ');
-      FilterEmptyStrings(components);
+      FilterEmptyStrings(&components);
       if (components.size() != 2    ||
           !IsNumeric(components[1]) ||
           (components[0] != "*" && !IsNumeric(components[0]))) {
@@ -103,11 +105,11 @@ class IntegerMap {
     return true;
   }
 
-  void FilterEmptyStrings(std::vector<std::string> &vec) const {
-          std::vector<std::string>::iterator       i    = vec.begin();
-    const std::vector<std::string>::const_iterator iend = vec.end();
+  void FilterEmptyStrings(std::vector<std::string> *vec) const {
+          std::vector<std::string>::iterator       i    = vec->begin();
+    const std::vector<std::string>::const_iterator iend = vec->end();
     for (; i != iend ;) {
-      i = (i->empty()) ? vec.erase(i) : i + 1;
+      i = (i->empty()) ? vec->erase(i) : i + 1;
     }
   }
 
@@ -122,4 +124,4 @@ class IntegerMap {
 typedef IntegerMap<uid_t> UidMap;
 typedef IntegerMap<gid_t> GidMap;
 
-#endif // CVMFS_UTIL_H_
+#endif  // CVMFS_UID_MAP_H_

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -80,7 +80,9 @@ class IntegerMap {
 
       std::vector<std::string> components = SplitString(line, ' ');
       FilterEmptyStrings(components);
-      if (components.size() != 2) {
+      if (components.size() != 2    ||
+          !IsNumeric(components[1]) ||
+          (components[0] != "*" && !IsNumeric(components[0]))) {
         fclose(fmap);
         LogCvmfs(kLogUtility, kLogDebug, "failed to read line %d in %s",
                  line_number, path.c_str());

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -57,6 +57,9 @@ class IntegerMap {
   bool   HasDefault() const { return has_default_value_; }
   size_t RuleCount()  const { return map_.size();        }
 
+  T GetDefault() const { assert(has_default_value_); return default_value_; }
+  const map_type& GetRuleMap() const { return map_; }
+
  protected:
   bool ReadFromFile(const std::string &path) {
     FILE *fmap = fopen(path.c_str(), "r");

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "logging.h"
+#include "sanitizer.h"
 #include "util.h"
 
 /**
@@ -128,6 +129,8 @@ class IntegerMap {
       return false;
     }
 
+    sanitizer::IntegerSanitizer int_sanitizer;
+
     std::string line;
     unsigned int line_number = 0;
     while (GetLineFile(fmap, &line)) {
@@ -139,9 +142,9 @@ class IntegerMap {
 
       std::vector<std::string> components = SplitString(line, ' ');
       FilterEmptyStrings(&components);
-      if (components.size() != 2    ||
-          !IsNumeric(components[1]) ||
-          (components[0] != "*" && !IsNumeric(components[0]))) {
+      if (components.size() != 2                ||
+          !int_sanitizer.IsValid(components[1]) ||
+          (components[0] != "*" && !int_sanitizer.IsValid(components[0]))) {
         fclose(fmap);
         LogCvmfs(kLogUtility, kLogDebug, "failed to read line %d in %s",
                  line_number, path.c_str());

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "logging.h"
 #include "util.h"
 
 /**

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -1,0 +1,120 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_UID_MAP_H_
+#define CVMFS_UID_MAP_H_
+
+#include <cerrno>
+#include <map>
+#include <vector>
+#include <sys/types.h>
+
+#include "util.h"
+
+template <typename T>
+class IntegerMap {
+ public:
+  typedef T                                       key_type;
+  typedef T                                       value_type;
+  typedef typename std::map<key_type, value_type> map_type;
+
+ public:
+  IntegerMap()
+    : valid_(true)
+    , has_default_value_(false)
+    , default_value_(T(0)) {}
+
+  void Set(const T k, const T v) { map_[k] = v; }
+  void SetDefault(const T v) {
+    has_default_value_ = true;
+    default_value_     = v;
+  }
+
+  bool Read(const std::string &path) {
+    valid_ = ReadFromFile(path);
+    return IsValid();
+  }
+
+  bool Contains(const T k) const {
+    assert (IsValid());
+    return map_.find(k) != map_.end();
+  }
+
+  T Map(const T k) const {
+    assert (IsValid());
+    typename map_type::const_iterator i = map_.find(k);
+    if (i != map_.end()) {
+      return i->second;
+    }
+
+    return (HasDefault())
+      ? default_value_
+      : T(0);
+  }
+
+  bool   IsValid()    const { return valid_;             }
+  bool   HasDefault() const { return has_default_value_; }
+  size_t RuleCount()  const { return map_.size();        }
+
+ protected:
+  bool ReadFromFile(const std::string &path) {
+    FILE *fmap = fopen(path.c_str(), "r");
+    if (!fmap) {
+      LogCvmfs(kLogUtility, kLogDebug, "failed to open %s (errno: %d)",
+               path.c_str(), errno);
+      return false;
+    }
+
+    std::string line;
+    unsigned int line_number = 0;
+    while (GetLineFile(fmap, &line)) {
+      ++line_number;
+      line = Trim(line);
+      if (line.empty() || line[0] == '#') {
+        continue;
+      }
+
+      std::vector<std::string> components = SplitString(line, ' ');
+      FilterEmptyStrings(components);
+      if (components.size() != 2) {
+        fclose(fmap);
+        LogCvmfs(kLogUtility, kLogDebug, "failed to read line %d in %s",
+                 line_number, path.c_str());
+        return false;
+      }
+
+      value_type to = String2Uint64(components[1]);
+      if (components[0] == "*") {
+        SetDefault(to);
+        continue;
+      }
+
+      key_type from = String2Uint64(components[0]);
+      Set(from, to);
+    }
+
+    fclose(fmap);
+    return true;
+  }
+
+  void FilterEmptyStrings(std::vector<std::string> &vec) const {
+          std::vector<std::string>::iterator       i    = vec.begin();
+    const std::vector<std::string>::const_iterator iend = vec.end();
+    for (; i != iend ;) {
+      i = (i->empty()) ? vec.erase(i) : i + 1;
+    }
+  }
+
+ private:
+  bool      valid_;
+  map_type  map_;
+
+  bool      has_default_value_;
+  T         default_value_;
+};
+
+typedef IntegerMap<uid_t> UidMap;
+typedef IntegerMap<gid_t> GidMap;
+
+#endif // CVMFS_UTIL_H_

--- a/test/src/589-catalogchown/main
+++ b/test/src/589-catalogchown/main
@@ -1,0 +1,464 @@
+cvmfs_test_name="Map UID and GID in Repository on Catalog Level"
+cvmfs_test_autofs_on_startup=false
+
+id_exists() {
+  local id_type=$1
+  local needle_id=$2
+
+  local id_offset=$( [ x"$id_type" = x"uid" ] && echo "3" || echo "4" )
+  cat /etc/passwd                                 | \
+  awk "{split(\$0,a,\":\"); print a[$id_offset]}" | \
+  grep -qe "^${needle_id}\$"
+}
+
+find_next_free_id() {
+  local id_type=$1
+  local next_id=$2
+
+  while [ $next_id -lt 3000 ]; do
+    next_id=$(( $next_id + 1 ))
+    id_exists "$id_type" $next_id || { echo $next_id; return 0; }
+  done
+
+  return 1
+}
+
+find_next_free_uid() {
+  local start_from=${1:-300}
+  find_next_free_id "uid" $start_from
+}
+
+find_next_free_gid() {
+  local start_from=${1:-300}
+  find_next_free_id "gid" $start_from
+}
+
+create_file() {
+  local path=$1
+  local uid=$2
+  local gid=$3
+
+  echo "owned by $uid : $gid" > $path || return 1
+  sudo chown ${uid}:${gid}      $path || return 2
+}
+
+check_file() {
+  local path=$1
+  local uid=$2
+  local gid=$3
+
+  local persona="$(stat --format='%u:%g' $path)"
+  [ x"$persona" = x"${uid}:${gid}" ]
+}
+
+produce_files_in_1() {
+  local working_dir=$1
+  local uid_1=$2
+  local uid_2=$3
+  local uid_3=$4
+  local gid_1=$5
+  local gid_2=$6
+  local gid_3=$7
+
+  pushdir $working_dir
+
+  mkdir foo
+  mkdir bar
+  mkdir baz
+
+  create_file foo/owned_by_root $(id -ru root) $(id -rg root)
+  create_file foo/owned_by_id1  $uid_1         $gid_1
+  create_file foo/owned_by_id2  $uid_2         $gid_2
+  create_file foo/owned_by_id3  $uid_3         $gid_3
+
+  create_file bar/owned_by_root $(id -ru root) $(id -rg root)
+  create_file bar/owned_by_id1  $uid_1         $gid_1
+  create_file bar/owned_by_id2  $uid_2         $gid_2
+  create_file bar/owned_by_id3  $uid_3         $gid_3
+
+  create_file baz/owned_by_root $(id -ru root) $(id -rg root)
+  create_file baz/owned_by_id1  $uid_1         $gid_1
+  create_file baz/owned_by_id2  $uid_2         $gid_2
+  create_file baz/owned_by_id3  $uid_3         $gid_3
+
+  touch foo/.cvmfscatalog
+  touch baz/.cvmfscatalog
+
+  sudo chown ${uid_1}:${gid_1} foo
+  sudo chown ${uid_2}:${gid_3} bar # <<== Note: the UID/GID switch
+  sudo chown ${uid_3}:${gid_2} baz # <<==       here as well
+
+  sudo chmod -R 777 . # to make it deletable by everyone (including the test executor)
+
+  popdir
+}
+
+check_file_permissions_1() {
+  local working_dir=$1
+  local uid_1=$2
+  local uid_2=$3
+  local uid_3=$4
+  local gid_1=$5
+  local gid_2=$6
+  local gid_3=$7
+
+  pushdir $working_dir
+
+  check_file foo/owned_by_root $(id -ru root) $(id -rg root) || return 1
+  check_file foo/owned_by_id1  $uid_1         $gid_1         || return 2
+  check_file foo/owned_by_id2  $uid_2         $gid_2         || return 3
+  check_file foo/owned_by_id3  $uid_3         $gid_3         || return 4
+
+  check_file bar/owned_by_root $(id -ru root) $(id -rg root) || return 5
+  check_file bar/owned_by_id1  $uid_1         $gid_1         || return 6
+  check_file bar/owned_by_id2  $uid_2         $gid_2         || return 7
+  check_file bar/owned_by_id3  $uid_3         $gid_3         || return 8
+
+  check_file baz/owned_by_root $(id -ru root) $(id -rg root) || return 9
+  check_file baz/owned_by_id1  $uid_1         $gid_1         || return 10
+  check_file baz/owned_by_id2  $uid_2         $gid_2         || return 11
+  check_file baz/owned_by_id3  $uid_3         $gid_3         || return 12
+
+  check_file foo ${uid_1} ${gid_1}                           || return 13
+  check_file bar ${uid_2} ${gid_3}                           || return 14
+  check_file baz ${uid_3} ${gid_2}                           || return 15
+
+  popdir
+}
+
+apply_uid_gid_map_1_to() {
+  local working_dir=$1
+  local uid_1=$2
+  local uid_2=$3
+  local uid_3=$4
+  local gid_1=$5
+  local gid_2=$6
+  local gid_3=$7
+
+  local ctu=$(id -ru $CVMFS_TEST_USER)
+  local ctg=$(id -rg $CVMFS_TEST_USER)
+
+  pushdir $working_dir
+
+  sudo chown ${ctu}:${ctg}     foo/owned_by_root  || return 1
+  sudo chown ${uid_2}:${gid_3} foo/owned_by_id1   || return 2
+  sudo chown ${uid_1}:${ctg}   foo/owned_by_id2   || return 3
+  sudo chown ${ctu}:${gid_1}   foo/owned_by_id3   || return 4
+
+  sudo chown ${ctu}:${ctg}     bar/owned_by_root  || return 5
+  sudo chown ${uid_2}:${gid_3} bar/owned_by_id1   || return 6
+  sudo chown ${uid_1}:${ctg}   bar/owned_by_id2   || return 7
+  sudo chown ${ctu}:${gid_1}   bar/owned_by_id3   || return 8
+
+  sudo chown ${ctu}:${ctg}     baz/owned_by_root  || return 9
+  sudo chown ${uid_2}:${gid_3} baz/owned_by_id1   || return 10
+  sudo chown ${uid_1}:${ctg}   baz/owned_by_id2   || return 11
+  sudo chown ${ctu}:${gid_1}   baz/owned_by_id3   || return 12
+
+  sudo chown ${uid_2}:${gid_3} foo                || return 13
+  sudo chown ${uid_1}:${gid_1} bar                || return 14
+  sudo chown ${ctu}:${ctg}     baz                || return 15
+
+  popdir
+}
+
+check_file_permissions_2() {
+  local working_dir=$1
+  local uid_1=$2
+  local uid_2=$3
+  local uid_3=$4
+  local gid_1=$5
+  local gid_2=$6
+  local gid_3=$7
+
+  local ctu=$(id -ru $CVMFS_TEST_USER)
+  local ctg=$(id -rg $CVMFS_TEST_USER)
+
+  pushdir $working_dir
+
+  check_file foo/owned_by_root $ctu    $ctg   || return 1
+  check_file foo/owned_by_id1  $uid_2  $gid_3 || return 2
+  check_file foo/owned_by_id2  $uid_1  $ctg   || return 3
+  check_file foo/owned_by_id3  $ctu    $gid_1 || return 4
+
+  check_file bar/owned_by_root $ctu    $ctg   || return 5
+  check_file bar/owned_by_id1  $uid_2  $gid_3 || return 6
+  check_file bar/owned_by_id2  $uid_1  $ctg   || return 7
+  check_file bar/owned_by_id3  $ctu    $gid_1 || return 8
+
+  check_file baz/owned_by_root $ctu    $ctg   || return 9
+  check_file baz/owned_by_id1  $uid_2  $gid_3 || return 10
+  check_file baz/owned_by_id2  $uid_1  $ctg   || return 11
+  check_file baz/owned_by_id3  $ctu    $gid_1 || return 12
+
+  check_file foo $uid_2 $gid_3                || return 13
+  check_file bar $uid_1 $gid_1                || return 14
+  check_file baz $ctu   $ctg                  || return 15
+
+  popdir
+}
+
+apply_uid_gid_map_2_to() {
+  local working_dir=$1
+  local uid_1=$2
+  local uid_2=$3
+  local uid_3=$4
+  local gid_1=$5
+  local gid_2=$6
+  local gid_3=$7
+
+  local ctu=$(id -ru $CVMFS_TEST_USER)
+  local ctg=$(id -rg $CVMFS_TEST_USER)
+
+  pushdir $working_dir
+
+  sudo chown ${ctu}:${ctg}   foo/owned_by_root  || return 1
+  sudo chown ${ctu}:${gid_3} foo/owned_by_id1   || return 2
+  sudo chown ${ctu}:${ctg}   foo/owned_by_id2   || return 3
+  sudo chown ${ctu}:${ctg}   foo/owned_by_id3   || return 4
+
+  sudo chown ${ctu}:${ctg}   bar/owned_by_root  || return 5
+  sudo chown ${ctu}:${gid_3} bar/owned_by_id1   || return 6
+  sudo chown ${ctu}:${ctg}   bar/owned_by_id2   || return 7
+  sudo chown ${ctu}:${ctg}   bar/owned_by_id3   || return 8
+
+  sudo chown ${ctu}:${ctg}   baz/owned_by_root  || return 9
+  sudo chown ${ctu}:${gid_3} baz/owned_by_id1   || return 10
+  sudo chown ${ctu}:${ctg}   baz/owned_by_id2   || return 11
+  sudo chown ${ctu}:${ctg}   baz/owned_by_id3   || return 12
+
+  sudo chown ${ctu}:${gid_3} foo                || return 13
+  sudo chown ${ctu}:${ctg}   bar                || return 14
+  sudo chown ${ctu}:${ctg}   baz                || return 15
+
+  popdir
+}
+
+check_file_permissions_3() {
+  local working_dir=$1
+  local uid_1=$2
+  local uid_2=$3
+  local uid_3=$4
+  local gid_1=$5
+  local gid_2=$6
+  local gid_3=$7
+
+  local ctu=$(id -ru $CVMFS_TEST_USER)
+  local ctg=$(id -rg $CVMFS_TEST_USER)
+
+  pushdir $working_dir
+
+  check_file foo/owned_by_root $ctu  $ctg   || return 1
+  check_file foo/owned_by_id1  $ctu  $gid_3 || return 2
+  check_file foo/owned_by_id2  $ctu  $ctg   || return 3
+  check_file foo/owned_by_id3  $ctu  $ctg   || return 4
+
+  check_file bar/owned_by_root $ctu  $ctg   || return 5
+  check_file bar/owned_by_id1  $ctu  $gid_3 || return 6
+  check_file bar/owned_by_id2  $ctu  $ctg   || return 7
+  check_file bar/owned_by_id3  $ctu  $ctg   || return 8
+
+  check_file baz/owned_by_root $ctu  $ctg   || return 9
+  check_file baz/owned_by_id1  $ctu  $gid_3 || return 10
+  check_file baz/owned_by_id2  $ctu  $ctg   || return 11
+  check_file baz/owned_by_id3  $ctu  $ctg   || return 12
+
+  check_file foo $ctu $gid_3                || return 13
+  check_file bar $ctu $ctg                  || return 14
+  check_file baz $ctu $ctg                  || return 15
+
+  popdir
+}
+
+produce_files_in_2() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  rm -f foo/.cvmfscatalog
+  rm -f baz/.cvmfscatalog
+
+  popdir
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local fd_logfile="file_descriptors.log"
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  echo "creating some dummy UIDs and GIDs"
+  local uid_1=$(find_next_free_uid 300)
+  local uid_2=$(find_next_free_uid $uid_1)
+  local uid_3=$(find_next_free_uid $uid_2)
+  local gid_1=$(find_next_free_gid 400)
+  local gid_2=$(find_next_free_gid $gid_1)
+  local gid_3=$(find_next_free_gid $gid_2)
+
+    echo "generate UID and GID mapping files"
+  local uid_map_1="uid_1.map"
+  local gid_map_1="gid_1.map"
+  local uid_map_2="uid_2.map"
+  local gid_map_2="gid_2.map"
+  local uid_map_x="uid_broken.map"
+  local gid_map_x="gid_broken.map"
+  cat > $uid_map_1 << EOF
+# map root to $CVMFS_TEST_USER
+$(id -ru root)  $(id -ru $CVMFS_TEST_USER)
+
+# swap UID1 and UID2
+$uid_1  $uid_2
+$uid_2 $uid_1
+
+# map everything else to $CVMFS_TEST_USER
+*   $(id -ru $CVMFS_TEST_USER)
+EOF
+
+  cat > $gid_map_1 << EOF
+# map root-group to ${CVMFS_TEST_USER}'s group
+$(id -rg root)  $(id -rg $CVMFS_TEST_USER)
+
+# swap GID1 and GID3
+$gid_1  $gid_3
+$gid_3 $gid_1
+
+# map everything else to ${CVMFS_TEST_USER}'s group
+* $(id -rg $CVMFS_TEST_USER)
+EOF
+
+  cat > $uid_map_2 << EOF
+# map everything to $CVMFS_TEST_USER
+* $(id -ru $CVMFS_TEST_USER)
+EOF
+
+  cat > $gid_map_2 << EOF
+# map $gid_1 to ${CVMFS_TEST_USER}'s group
+$gid_1  $(id -rg $CVMFS_TEST_USER)
+EOF
+
+  cat > $uid_map_x << EOF
+# this map file is broken (no rules at all)
+EOF
+
+  cat > $gid_map_x << EOF
+# this map file is broken (bogus rule)
+1337 *
+EOF
+
+  echo "$uid_map_1 looks like this:"
+  echo "-----------------------"
+  cat $uid_map_1
+  echo "-----------------------"
+
+  echo ""
+
+  echo "$gid_map_1 looks like this:"
+  echo "-----------------------"
+  cat $gid_map_1
+  echo "-----------------------"
+
+  echo "$uid_map_2 looks like this:"
+  echo "-----------------------"
+  cat $uid_map_2
+  echo "-----------------------"
+
+  echo "$gid_map_2 looks like this:"
+  echo "-----------------------"
+  cat $gid_map_2
+  echo "-----------------------"
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "create some directories and files"
+  produce_files_in_1 $repo_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return 1
+
+  echo "create some directories and files"
+  produce_files_in_1 $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return 2
+
+  echo "publish repository"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check if the file permissions are properly set (repo)"
+  check_file_permissions_1 $repo_dir      $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return $?
+
+  echo "check if the file permissions are properly set (reference)"
+  check_file_permissions_1 $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # ============================================================================
+
+  echo "run the chown on catalog level"
+  sudo cvmfs_server catalog-chown -u $uid_map_1 -g $gid_map_1 $CVMFS_TEST_REPO || return 3
+
+  echo "apply the same UID and GID changes to the reference directory"
+  apply_uid_gid_map_1_to $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return 4
+
+  echo "check if the file permissions are properly set (reference)"
+  check_file_permissions_2 $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return $?
+
+  echo "compare_directories"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check if the file permissions are properly set (repo)"
+  check_file_permissions_2 $repo_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "remove the nested catalogs"
+  produce_files_in_2 $repo_dir || return 5
+
+  echo "remove the nested catalog markers in the reference dir as well"
+  produce_files_in_2 $reference_dir || return 6
+
+  echo "publish repository (without any nested catalogs)"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  # ============================================================================
+
+  echo "run the chown on catalog level again"
+  sudo cvmfs_server catalog-chown -u $uid_map_2 -g $gid_map_2 $CVMFS_TEST_REPO || return 7
+
+  echo "apply the same UID and GID changes to the reference directory"
+  apply_uid_gid_map_2_to $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return 8
+
+  echo "check if the file permissions are properly set (reference)"
+  check_file_permissions_3 $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return $?
+
+  echo "compare_directories"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check if the file permissions are properly set (repo)"
+  check_file_permissions_3 $repo_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # ============================================================================
+
+  echo "try to apply a broken map files"
+  sudo cvmfs_server catalog-chown -u $uid_map_x -g $gid_map_1 $CVMFS_TEST_REPO && return 9
+  sudo cvmfs_server catalog-chown -u $uid_map_1 -g $gid_map_x $CVMFS_TEST_REPO && return 10
+
+  return 0
+}

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -62,6 +62,7 @@ set (CVMFS_UNITTEST_SOURCES
   t_backoff.cc
   t_wpad.cc
   t_smalloc.cc
+  t_uid_map.cc
 
   # test utility functions
   testutil.cc testutil.h
@@ -163,6 +164,8 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/libcvmfs.cc
   ${CVMFS_SOURCE_DIR}/libcvmfs_int.h
   ${CVMFS_SOURCE_DIR}/libcvmfs_int.cc
+
+  ${CVMFS_SOURCE_DIR}/uid_map.h
 )
 
 set (CVMFS_UNITTEST_DEBUG_SOURCES ${CVMFS_UNITTEST_SOURCES})

--- a/test/unittests/t_uid_map.cc
+++ b/test/unittests/t_uid_map.cc
@@ -106,6 +106,7 @@ TYPED_TEST(T_UidMap, SetDefault) {
   EXPECT_TRUE(map.IsValid());
   EXPECT_TRUE(map.HasDefault());
   EXPECT_EQ(0u, map.RuleCount());
+  EXPECT_EQ(42u, map.GetDefault());
 }
 
 
@@ -153,6 +154,7 @@ TYPED_TEST(T_UidMap, ReadFromFile) {
   EXPECT_TRUE(map.IsValid());
   EXPECT_EQ(2u, map.RuleCount());
   EXPECT_TRUE(map.HasDefault());
+  EXPECT_EQ(1337u, map.GetDefault());
 
   EXPECT_TRUE(map.Contains(TestFixture::k(42)));
   EXPECT_TRUE(map.Contains(TestFixture::k(1)));

--- a/test/unittests/t_uid_map.cc
+++ b/test/unittests/t_uid_map.cc
@@ -1,0 +1,176 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/uid_map.h"
+#include "../../cvmfs/util.h"
+
+template <typename MapT>
+class T_UidMap : public ::testing::Test {
+ protected:
+  static const std::string sandbox;
+
+ protected:
+  typedef typename MapT::key_type   key_type;
+  typedef typename MapT::value_type value_type;
+
+ protected:
+  void SetUp() {
+    const bool retval = MkdirDeep(sandbox, 0700);
+    ASSERT_TRUE(retval) << "failed to create sandbox";
+  }
+
+  void TearDown() {
+    const bool retval = RemoveTree(sandbox);
+    ASSERT_TRUE(retval) << "failed to remove sandbox";
+  }
+
+  void WriteFile(const std::string &path, const std::string &content) {
+    FILE *f = fopen(path.c_str(), "w+");
+    ASSERT_NE(static_cast<FILE*>(NULL), f)
+      << "failed to open. errno: " << errno;
+    const size_t bytes_written = fwrite(content.data(), 1, content.length(), f);
+    ASSERT_EQ(bytes_written, content.length())
+      << "failed to write. errno: " << errno;
+
+    const int retval = fclose(f);
+    ASSERT_EQ(0, retval) << "failed to close. errno: " << errno;
+  }
+
+  std::string GetValidFile() {
+    const std::string valid_file =
+      "# comment\n"  // comment
+      "42 3\n"       // ordinary rule
+      "1  2\n"       // ordinary rule with multiple spaces
+      "\n"           // empty line
+      "# comment\n"  // comment
+      "*   1337\n";  // default value
+
+    const std::string path = CreateTempPath(sandbox + "/valid", 0600);
+    WriteFile(path, valid_file);
+    return path;
+  }
+
+  std::string GetInvalidFile() {
+    const std::string invalid_file =
+      "# comment\n"  // comment
+      "42 3\n"       // ordinary rule
+      "1\n"          // invalid rule     <---
+      "\n"           // empty line
+      "# comment\n"  // comment
+      "*   1337\n";  // default value
+
+    const std::string path = CreateTempPath(sandbox + "/invalid", 0600);
+    WriteFile(path, invalid_file);
+    return path;
+  }
+
+  template <typename T>
+  key_type k(const T k) const { return key_type(k); }
+  template <typename T>
+  value_type v(const T v) const { return value_type(v); }
+
+};
+
+template <typename MapT>
+const std::string T_UidMap<MapT>::sandbox = "/tmp/cvmfs_ut_uid_map";
+
+typedef ::testing::Types<
+  UidMap,
+  GidMap > UidMapTypes;
+TYPED_TEST_CASE(T_UidMap, UidMapTypes);
+
+TYPED_TEST(T_UidMap, Initialize) {
+  TypeParam map;
+  EXPECT_TRUE (map.IsValid());
+  EXPECT_FALSE(map.HasDefault());
+}
+
+
+TYPED_TEST(T_UidMap, Insert) {
+  TypeParam map;
+  map.Set(TestFixture::k(0), TestFixture::v(1));
+  map.Set(TestFixture::k(1), TestFixture::v(2));
+  EXPECT_TRUE (map.IsValid());
+  EXPECT_FALSE(map.HasDefault());
+  EXPECT_EQ(2u, map.RuleCount());
+}
+
+
+TYPED_TEST(T_UidMap, SetDefault) {
+  TypeParam map;
+  map.SetDefault(TestFixture::v(42));
+  EXPECT_EQ(0u, map.RuleCount());
+  EXPECT_TRUE(map.IsValid());
+  EXPECT_TRUE(map.HasDefault());
+  EXPECT_EQ(0u, map.RuleCount());
+}
+
+
+TYPED_TEST(T_UidMap, Contains) {
+  TypeParam map;
+  map.Set(TestFixture::k(0), TestFixture::v(1));
+  map.Set(TestFixture::k(1), TestFixture::v(2));
+
+  EXPECT_TRUE(map.Contains(TestFixture::k(0)));
+  EXPECT_TRUE(map.Contains(TestFixture::k(1)));
+  EXPECT_FALSE(map.Contains(TestFixture::k(2)));
+
+  map.SetDefault(TestFixture::v(42));
+  EXPECT_FALSE(map.Contains(TestFixture::k(2)));
+}
+
+
+TYPED_TEST(T_UidMap, MapWithoutDefault) {
+  TypeParam map;
+  map.Set(TestFixture::k(0), TestFixture::v(1));
+  map.Set(TestFixture::k(1), TestFixture::v(2));
+
+  EXPECT_EQ(TestFixture::v(1), map.Map(TestFixture::k(0)));
+  EXPECT_EQ(TestFixture::v(2), map.Map(TestFixture::k(1)));
+  EXPECT_EQ(TestFixture::v(0), map.Map(TestFixture::k(3)));
+}
+
+
+TYPED_TEST(T_UidMap, MapWithDefault) {
+  TypeParam map;
+  map.Set(TestFixture::k(0), TestFixture::v(1));
+  map.Set(TestFixture::k(1), TestFixture::v(2));
+  map.SetDefault(TestFixture::v(42));
+
+  EXPECT_EQ(TestFixture::v(1),  map.Map(TestFixture::k(0)));
+  EXPECT_EQ(TestFixture::v(2),  map.Map(TestFixture::k(1)));
+  EXPECT_EQ(TestFixture::v(42), map.Map(TestFixture::k(3)));
+}
+
+
+TYPED_TEST(T_UidMap, ReadFromFile) {
+  TypeParam map;
+  const std::string path = TestFixture::GetValidFile();
+  ASSERT_TRUE(map.Read(path));
+  EXPECT_TRUE(map.IsValid());
+  EXPECT_EQ(2u, map.RuleCount());
+  EXPECT_TRUE(map.HasDefault());
+
+  EXPECT_TRUE(map.Contains(TestFixture::k(42)));
+  EXPECT_TRUE(map.Contains(TestFixture::k(1)));
+
+  EXPECT_FALSE(map.Contains(TestFixture::k(2)));
+  EXPECT_FALSE(map.Contains(TestFixture::k(1337)));
+
+  EXPECT_EQ(TestFixture::v(3),  map.Map(TestFixture::k(42)));
+  EXPECT_EQ(TestFixture::v(2),  map.Map(TestFixture::k(1)));
+  EXPECT_EQ(TestFixture::v(1337), map.Map(TestFixture::k(3)));
+  EXPECT_EQ(TestFixture::v(1337), map.Map(TestFixture::k(4)));
+  EXPECT_EQ(TestFixture::v(1337), map.Map(TestFixture::k(0)));
+}
+
+
+TYPED_TEST(T_UidMap, ReadFromCorruptFile) {
+  TypeParam map;
+  const std::string path = TestFixture::GetInvalidFile();
+  ASSERT_FALSE(map.Read(path));
+  EXPECT_FALSE(map.IsValid());
+}

--- a/test/unittests/t_uid_map.cc
+++ b/test/unittests/t_uid_map.cc
@@ -53,14 +53,35 @@ class T_UidMap : public ::testing::Test {
     return path;
   }
 
-  std::string GetInvalidFile() {
+  std::string GetInvalidFile1() {
     const std::string invalid_file =
       "# comment\n"  // comment
       "42 3\n"       // ordinary rule
-      "1\n"          // invalid rule     <---
+      "1 *\n"        // invalid rule (non-numeric map result)    <---
       "\n"           // empty line
       "# comment\n"  // comment
       "*   1337\n";  // default value
+
+    const std::string path = CreateTempPath(sandbox + "/invalid", 0600);
+    WriteFile(path, invalid_file);
+    return path;
+  }
+
+  std::string GetInvalidFile2() {
+    const std::string invalid_file =
+      "# comment\n"  // comment
+      "12 4\n"       // ordinary rule
+      "1\n";         // invalid rule (no map result) <---
+
+    const std::string path = CreateTempPath(sandbox + "/invalid", 0600);
+    WriteFile(path, invalid_file);
+    return path;
+  }
+
+  std::string GetInvalidFile3() {
+    const std::string invalid_file =
+      "# empty file\n"  // comment
+      "foo 14";         // invalid rule (non-numeric ID value) <---
 
     const std::string path = CreateTempPath(sandbox + "/invalid", 0600);
     WriteFile(path, invalid_file);
@@ -170,9 +191,20 @@ TYPED_TEST(T_UidMap, ReadFromFile) {
 }
 
 
-TYPED_TEST(T_UidMap, ReadFromCorruptFile) {
-  TypeParam map;
-  const std::string path = TestFixture::GetInvalidFile();
-  ASSERT_FALSE(map.Read(path));
-  EXPECT_FALSE(map.IsValid());
+TYPED_TEST(T_UidMap, ReadFromCorruptFiles) {
+  TypeParam map1;
+  TypeParam map2;
+  TypeParam map3;
+  const std::string path1 = TestFixture::GetInvalidFile1();
+  const std::string path2 = TestFixture::GetInvalidFile2();
+  const std::string path3 = TestFixture::GetInvalidFile3();
+
+  ASSERT_FALSE(map1.Read(path1));
+  EXPECT_FALSE(map1.IsValid());
+
+  ASSERT_FALSE(map2.Read(path2));
+  EXPECT_FALSE(map2.IsValid());
+
+  ASSERT_FALSE(map3.Read(path3));
+  EXPECT_FALSE(map3.IsValid());
 }


### PR DESCRIPTION
This allows to map the 'user ID' and 'group ID' meta-data fields for an entire repository on catalog level using a simple mapping description (Jira: [CVM-836](https://sft.its.cern.ch/jira/browse/CVM-836)). It is based on map files similar to the ones for `CVMFS_UID_MAP` and `CVMFS_GID_MAP` on the client. For large repositories, a simple `chown -R foo:bar /cvmfs/foo.bar.ch` is not practical, as it would re-compress and re-hash the entire repository content.

Doing this on catalog level is still a heavy-weight operation and is not supposed to be done regularly. The feature is meant to simplify migration of existing repositories to new infrastructure with different user ID requirements.

To run it on an existing repository, one first needs to create two map files, both for UIDs and GIDs and afterwards run:
```bash
cvmfs_server catalog-chown -u $uid_map -g $gid_map $repo_name
``` 
This will recreate the entire catalog tree with the updated UID and GID configuration.

The format of the map files looks like this:
```bash
# map UIDs 137 and 138 to 1001
137 1001
138 1001

# swap UID 1002 and 1001
1001 1002
1002 1001

# wildcard: map all others to 1000
*   1000
```

*Note:* I added the class `IntegerMap<>` to encapsulate the handling of such map files. The file format is backward compatible to the files used in the client, but a bit more agnostic and versatile. In particular it can deal with multiple spaces as field separator and knows about a 'map all to this' wild-card. Furthermore it comes with unit tests.

**TODO:** Potentially this should be re-used for the aforementioned client-side UID/GID maps which currently use a pretty simplistic read function.