### PR TITLE
STATISTICS: added memory median and maximum in benchmarks

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -1421,10 +1421,13 @@ EOF
 
 }
 
+
 # creates a statistics file
 create_statistics_file() {
   local iteration=$1
   local total_time=$2
+  local memory_median=$3
+  local memory_max=$4
   local statistics_file="${FQRN}_${iteration}.data"
   benchmark_log "creating the statistics file ${statistics_file} calling cvmfs_talk"
   cat >$statistics_file << EOF
@@ -1437,6 +1440,36 @@ EOF
   benchmark_log "Executing cvmfs_talk"
   cvmfs_talk -p "$CVMFS_OPT_CACHEDIR"/$FQRN/cvmfs_io.$FQRN internal affairs | grep \| | tail -n +2 >> $statistics_file
   echo "global.sz_total_time|$total_time|Total execution time (seconds)" >> $statistics_file # of only one iteration without valgrind!
+  echo "global.sz_memory_median|$memory_median|Median memory consumption (KB)" >> $statistics_file
+  echo "global.sz_memory_max|$memory_max|Maximum memory consumption (KB)" >> $statistics_file
+}
+
+
+# collects data during the run
+statistics_daemon() {
+  local dump_file=$1
+  local PID=$2
+  touch $dump_file
+  while [ -f /proc/${PID}/smaps ]; do
+    # memory in KB
+    echo 0 $(awk '/Rss/ {print "+", $2}' /proc/${PID}/smaps) | bc >> $dump_file
+    sleep 2
+  done
+}
+
+
+# collects the median of a file
+collect_median() {
+  local file=$1
+  local num_lines=$(cat $file | wc -l)
+  local median_pos=$(( num_lines / 2 ))
+  echo $(sort $file | sed "${median_pos}q;d")
+}
+
+
+# collects the maximum of a file
+collect_maximum() {
+  echo $(sort $1 | tail -n 1)
 }
 
 
@@ -1445,17 +1478,25 @@ execute_statistics_loop() {
   local code=0
   local iteration=1
   local PID=0
+  local daemon=0
+  local memory_file="memory.stat"
 
   while (( iteration <= $CVMFS_OPT_ITERATIONS && code == 0 )); do
     local start_time=$(date +%s)
+
     cvmfs2 -f -o config=cvmfs.conf,disable_watchdog,simple_options_parsing $FQRN /cvmfs/$FQRN 2>&1 &
     PID=$!
     wait_fqrn_mount
+    statistics_daemon $memory_file $PID &
+    daemon=$!
     ( cvmfs_run_benchmark )
     code=$?
     local end_time=$(date +%s)
     local total_time=$(( end_time - start_time )) # in seconds
-    create_statistics_file $iteration $total_time
+
+    local memory_median=$(collect_median $memory_file)
+    local memory_max=$(collect_maximum $memory_file)
+    create_statistics_file $iteration $total_time $memory_median $memory_max
     cvmfs_umount $FQRN
     wait $PID
     iteration=$(( iteration + 1 ))


### PR DESCRIPTION
Example of the current output (look at the bottom to see the new counters):

\# repo=atlas.cern.ch
\# iterations=1
\# warm_cache=no

cache.n_certificate_hits|0|Number of certificate hits
cache.n_certificate_misses|1|Number of certificate misses
catalog_mgr.n_listing|381|Number of listings
catalog_mgr.n_lookup_inode|0|Number of inode lookups
catalog_mgr.n_lookup_path|36383|Number of path lookups
catalog_mgr.n_lookup_path_negative|24460|Number of negative path lookups
catalog_mgr.n_lookup_xattrs|0|Number of xattrs lookups
catalog_mgr.n_nested_listing|24849|Number of listings of nested catalogs
cvmfs.n_fs_dir_open|381|Overall number of directory open operations
cvmfs.n_fs_forget|502|Number of inode forgets
cvmfs.n_fs_lookup|26894|Number of lookups
cvmfs.n_fs_lookup_negative|24460|Number of negative lookups
cvmfs.n_fs_open|5088|Overall number of file open operations
cvmfs.n_fs_read|6138|Number of files read
cvmfs.n_fs_readlink|12506|Number of links read
cvmfs.n_fs_stat|4868|Number of stats
cvmfs.n_io_error|0|Number of I/O errors
cvmfs.no_open_dirs|0|Number of currently opened directories
cvmfs.no_open_files|0|Number of currently opened files
download.n_host_failover|0|Number of host failovers
download.n_proxy_failover|0|Number of proxy failovers
download.n_requests|818|Number of requests
download.n_retries|0|Number of retries
download.sz_transfer_time|72530|Transfer time (miliseconds)
download.sz_transferred_bytes|115735998|Number of transferred bytes
inode_cache.n_drop|0|Number of drops for inode_cache
inode_cache.n_forget|0|Number of forgets for inode_cache
inode_cache.n_hit|21361|Number of hits for inode_cache
inode_cache.n_insert|1483|Number of inserts for inode_cache
inode_cache.n_insert_negative|0|Number of negative inserts for inode_cache
inode_cache.n_miss|1483|Number of misses for inode_cache
inode_cache.n_replace|0|Number of replaces for inode_cache
inode_cache.n_update|0|Number of updates for inode_cache
inode_cache.sz_allocated|1663672|Number of allocated bytes for inode_cache
inode_cache.sz_size|5568|Size for inode_cache
md5_path_cache.n_drop|0|Number of drops for md5_path_cache
md5_path_cache.n_forget|0|Number of forgets for md5_path_cache
md5_path_cache.n_hit|23784|Number of hits for md5_path_cache
md5_path_cache.n_insert|34893|Number of inserts for md5_path_cache
md5_path_cache.n_insert_negative|24460|Number of negative inserts for md5_path_cache
md5_path_cache.n_miss|34893|Number of misses for md5_path_cache
md5_path_cache.n_replace|0|Number of replaces for md5_path_cache
md5_path_cache.n_update|0|Number of updates for md5_path_cache
md5_path_cache.sz_allocated|13186784|Number of allocated bytes for md5_path_cache
md5_path_cache.sz_size|39232|Size for md5_path_cache
path_cache.n_drop|0|Number of drops for path_cache
path_cache.n_forget|0|Number of forgets for path_cache
path_cache.n_hit|30514|Number of hits for path_cache
path_cache.n_insert|1847|Number of inserts for path_cache
path_cache.n_insert_negative|0|Number of negative inserts for path_cache
path_cache.n_miss|1849|Number of misses for path_cache
path_cache.n_replace|0|Number of replaces for path_cache
path_cache.n_update|0|Number of updates for path_cache
path_cache.sz_allocated|1901240|Number of allocated bytes for path_cache
path_cache.sz_size|5568|Size for path_cache
sqlite.n_access|0|overall number of access() calls
sqlite.n_rand|0|overall number of random() calls
sqlite.n_read|69959|overall number of read() calls
sqlite.n_sleep|0|overall number of sleep() calls
sqlite.n_time|0|overall number of time() calls
sqlite.no_open|4|currently open sqlite files
sqlite.sz_rand|0|overall number of random bytes
sqlite.sz_read|34547984|overall bytes read()
sqlite.sz_sleep|0|overall microseconds slept
global.sz_total_time|89|Total execution time (seconds)
**global.sz_memory_median|26196|Median memory consumption (KB)
global.sz_memory_max|30000|Maximum memory consumption (KB)**