### PR TITLE
Feature: download_catalog_graph.py can skip history

### DIFF
--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -20,17 +20,31 @@ class MerkleCatalogTreeIterator(cvmfs.CatalogTreeIterator):
 
 
 def usage():
-    print sys.argv[0] + "<repo url/path> <download destination>"
-    print "Downloads the whole catalog graph of a given repository"
+    print sys.argv[0] + "<repo url/path> <download destination> [<history depth>]"
+    print "Downloads the whole catalog graph of a given repository."
+    print "The optional <history depth> puts a threshold on how many historic"
+    print "catalog tree revisions should be downloaded (default: all)"
 
-if len(sys.argv) != 3:
+if len(sys.argv) < 3 or len(sys.argv) > 4:
     usage()
     sys.exit(1)
 
-dest = sys.argv[2]
-repo = cvmfs.open_repository(sys.argv[1])
+dest  = sys.argv[2]
+repo  = cvmfs.open_repository(sys.argv[1])
+depth = sys.argv[3] if len(sys.argv) == 4 else 0
 
-print "Downloading catalog tree from " + repo.manifest.repository_name
+try:
+    depth = int(depth)
+except ValueError, e:
+    usage()
+    print
+    print "<history depth> needs to be an integer"
+    sys.exit(1)
+
+if depth == 0:
+    print "Downloading entire catalog tree from " + repo.manifest.repository_name
+else:
+    print "Downloading last" , depth , "catalog revisions from " + repo.manifest.repository_name
 
 root_clg       = repo.retrieve_root_catalog()
 visited_hashes = set()
@@ -42,6 +56,12 @@ while True:
             print "Downloading revision" , catalog.revision , "..."
         catalog.save_to(dest + "/" + catalog.hash + "C")
         repo.close_catalog(catalog)
+
+    if depth > 0:
+        depth -= 1
+        if depth == 0:
+            print "all requested catalog tree revisions downloaded"
+            break
 
     if next_root_clg != None:
         try:


### PR DESCRIPTION
This is useful when downloading a full catalog tree of a production repository. Until now `download_catalog_tree.py` would always download the entire history graph however.