### PR TITLE
FIX: Some Compiler Warnings on OS X

### DIFF
--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -55,16 +55,12 @@ enum LoadError {
 };
 
 inline const char *Code2Ascii(const LoadError error) {
-  const int kNumElems = 4;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kLoadNumEntries + 1];
   texts[0] = "loaded new catalog";
   texts[1] = "catalog was up to date";
   texts[2] = "not enough space to load catalog";
   texts[3] = "failed to load catalog";
-
+  texts[4] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -50,6 +50,8 @@ enum LoadError {
   kLoadUp2Date,
   kLoadNoSpace,
   kLoadFail,
+
+  kLoadNumEntries
 };
 
 inline const char *Code2Ascii(const LoadError error) {

--- a/cvmfs/dns.h
+++ b/cvmfs/dns.h
@@ -40,11 +40,7 @@ enum Failures {
 
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 9;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "OK";
   texts[1] = "invalid resolver addresses";
   texts[2] = "DNS query timeout";
@@ -54,7 +50,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[6] = "no IP address for host";
   texts[7] = "internal error, not yet resolved";
   texts[8] = "unknown name resolving error";
-
+  texts[9] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/dns.h
+++ b/cvmfs/dns.h
@@ -34,6 +34,8 @@ enum Failures {
   kFailNoAddress,     ///< Resolver returned a positive reply but without IPs
   kFailNotYetResolved,
   kFailOther,
+
+  kFailNumEntries
 };
 
 

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -63,11 +63,7 @@ enum Failures {
 
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 13;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "OK";
   texts[1] = "local I/O failure";
   texts[2] = "malformed URL";
@@ -81,7 +77,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[10] = "corrupted data received";
   texts[11] = "resource too big to download";
   texts[12] = "unknown network error";
-
+  texts[13] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -57,6 +57,8 @@ enum Failures {
   kFailBadData,
   kFailTooBig,
   kFailOther,
+
+  kFailNumEntries
 };  // Failures
 
 

--- a/cvmfs/letter.h
+++ b/cvmfs/letter.h
@@ -23,6 +23,8 @@ enum Failures {
   kFailBadSignature,
   kFailBadCertificate,
   kFailNameMismatch,
+
+  kFailNumEntries
 };
 
 inline const char *Code2Ascii(const Failures error) {

--- a/cvmfs/letter.h
+++ b/cvmfs/letter.h
@@ -28,11 +28,7 @@ enum Failures {
 };
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 7;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "OK";
   texts[1] = "invalid Base64 input";
   texts[2] = "letter malformed";
@@ -40,7 +36,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[4] = "signature verification failed";
   texts[5] = "certificate is not whitelisted";
   texts[6] = "repository name mismatch";
-
+  texts[7] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -54,7 +54,7 @@
 extern "C" {
 #endif
 
-struct cvmfs_context;
+class cvmfs_context;
 
 /**
  * Initialize global CVMFS library structures

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -45,6 +45,8 @@ enum Failures {
   kFailDoubleMount,
   kFailHistory,
   kFailWpad,
+
+  kFailNumEntries
 };
 
 inline const char *Code2Ascii(const Failures error) {

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -50,11 +50,7 @@ enum Failures {
 };
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 24;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "OK";
   texts[1] = "unknown error";
   texts[2] = "illegal options";
@@ -79,7 +75,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[21] = "double mount";
   texts[22] = "history init failure";
   texts[23] = "proxy auto-discovery failed";
-
+  texts[24] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/manifest_fetch.h
+++ b/cvmfs/manifest_fetch.h
@@ -41,11 +41,7 @@ enum Failures {
 };
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 11;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "OK";
   texts[1] = "failed to download";
   texts[2] = "incomplete manifest";
@@ -57,7 +53,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[8] = "bad whitelist";
   texts[9] = "invalid certificate";
   texts[10] = "unknown error";
-
+  texts[11] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/manifest_fetch.h
+++ b/cvmfs/manifest_fetch.h
@@ -36,6 +36,8 @@ enum Failures {
   kFailBadWhitelist,
   kFailInvalidCertificate,
   kFailUnknown,
+
+  kFailNumEntries
 };
 
 inline const char *Code2Ascii(const Failures error) {

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -50,11 +50,7 @@ enum Failures {
 
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 9;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "S3: OK";
   texts[1] = "S3: local I/O failure";
   texts[2] = "S3: malformed URL (bad request)";
@@ -64,7 +60,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[6] = "S3: not found";
   texts[7] = "S3: service not available";
   texts[8] = "S3: unknown network error";
-
+  texts[9] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -44,6 +44,8 @@ enum Failures {
   kFailNotFound,
   kFailServiceUnavailable,
   kFailOther,
+
+  kFailNumEntries
 };  // Failures
 
 

--- a/cvmfs/whitelist.h
+++ b/cvmfs/whitelist.h
@@ -44,11 +44,7 @@ enum Failures {
 
 
 inline const char *Code2Ascii(const Failures error) {
-  const int kNumElems = 15;
-  if (error >= kNumElems)
-    return "no text available (internal error)";
-
-  const char *texts[kNumElems];
+  const char *texts[kFailNumEntries + 1];
   texts[0] = "OK";
   texts[1] = "failed to download whitelist";
   texts[2] = "empty whitelist";
@@ -64,7 +60,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[12] = "failed to verify CA chain";
   texts[13] = "certificate not on whitelist";
   texts[14] = "certificate blacklisted";
-
+  texts[15] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/whitelist.h
+++ b/cvmfs/whitelist.h
@@ -38,6 +38,8 @@ enum Failures {
   kFailBadCaChain,
   kFailNotListed,
   kFailBlacklisted,
+
+  kFailNumEntries
 };
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -60,7 +60,7 @@ class PolymorphicConstructionUnittestAdapter {
 
 static const std::string g_sandbox_path    = "/tmp/cvmfs_mockuploader";
 static const std::string g_sandbox_tmp_dir = g_sandbox_path + "/tmp";
-static upload::SpoolerDefinition MockSpoolerDefinition() {
+static inline upload::SpoolerDefinition MockSpoolerDefinition() {
   const size_t      min_chunk_size   = 512000;
   const size_t      avg_chunk_size   = 2 * min_chunk_size;
   const size_t      max_chunk_size   = 4 * min_chunk_size;


### PR DESCRIPTION
This fixes a couple of compiler warnings in the error message to ASCII translation. Essentially I got rid of the sanity check in every `Code2Ascii()` function. The type system should make sure that this is not necessary, as pointed out by the clang compiler on OSX 10.10.

Furthermore I replaced the explicit `kNumElem` by implicit length codes in the enums. This is not necessarily type-safe in conjunction with `Code2Ascii()`. It gets rid of one magic number though, and ensures that at least the array in `Code2Ascii()` is always large enough even if it gets forgotten in the future.

Finally a mismatch between a forward declared `struct cvmfs_context` and `class cvmfs_context` is fixed.