### PR TITLE
CI: CppLint Wrapper Script

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -16,6 +16,11 @@ get_cvmfs_git_revision() {
   echo "$(cd $source_directory; git rev-parse HEAD | head -c16)"
 }
 
+get_repository_root() {
+  local script_location=$(cd "$(dirname "$0")"; pwd)
+  echo $(cd "${script_location}/.."; pwd)
+}
+
 create_cvmfs_source_tarball() {
   local source_directory="$1"
   local destination_path="$2"

--- a/ci/run_cpplint.sh
+++ b/ci/run_cpplint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#
+# This script runs the CppLint program and checks the general code style
+#
+
+set -e
+
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+. ${SCRIPT_LOCATION}/common.sh
+
+REPO_ROOT="$(get_repository_root)"
+CPPLINT="${REPO_ROOT}/cpplint.py"
+
+[ -d $REPO_ROOT ] || die "$REPO_ROOT is malformed"
+[ -f $CPPLINT ]   || die "$CPPLINT missing"
+
+# define locations and file extensions of source files
+SOURCE_DIRS="cvmfs mount test/unittests"
+SOURCE_EXTS="h hpp cc cpp c"
+
+################################################################################
+
+cd $REPO_ROOT
+EXTS_REGEX=".*\.\($(echo $SOURCE_EXTS | sed -e 's/\s\+/\\\|/g')\)\$"
+python $CPPLINT $(find $SOURCE_DIRS -type f | grep -e "$EXTS_REGEX")


### PR DESCRIPTION
A fire-and-forget wrapper for `cpplint.py`. The wrapper looks for source files in `cvmfs`, `mount` and `test/unittests` for now. Also meant to be run manually before pushing or to be put into git-commit hooks...

Simply do:
```bash
sh ci/run_cpplint.sh
```