### PR TITLE
FIX: Make T_Smalloc::BigMmap More Strict

### DIFF
--- a/test/unittests/t_smalloc.cc
+++ b/test/unittests/t_smalloc.cc
@@ -67,6 +67,6 @@ TEST(T_Smalloc, SmallMmap) {
 
 TEST(T_Smalloc, BigMmap) {
   void *mem = NULL;
-  ASSERT_DEATH(mem = smmap(kBigAllocation - 4096), ".*");
+  ASSERT_DEATH(mem = smmap(kBigAllocation - 8192), ".*Out Of Memory.*");
   ASSERT_DEATH(smunmap(mem), ".*");
 }


### PR DESCRIPTION
Looking into that again due to an itching little toe: We actually just provoked the newly added assert. I increased the safety margin in the `T_Smalloc::BigMmap` test and checked for the expected error message.