### PR TITLE
FIX: T_GarbageCollector didn't clean up properly

### DIFF
--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -76,19 +76,22 @@ class T_GarbageCollector : public ::testing::Test {
   void SetUp() {
     dice_.InitLocaltime();
     SetupDummyCatalogs();
+    uploader_ = GC_MockUploader::MockConstruct();
   }
 
   void TearDown() {
     MockCatalog::Reset();
     MockHistory::Reset();
     EXPECT_EQ(0u, MockCatalog::instances);
+    uploader_->TearDown();
+    delete uploader_;
   }
 
   GcConfiguration GetStandardGarbageCollectorConfiguration() {
-    MyGarbageCollector::Configuration config;
+    GcConfiguration config;
     config.keep_history_depth = 1;
     config.dry_run            = false;
-    config.uploader           = GC_MockUploader::MockConstruct();
+    config.uploader           = uploader_;
     config.object_fetcher     = &object_fetcher_;
     return config;
   }
@@ -460,6 +463,7 @@ class T_GarbageCollector : public ::testing::Test {
  private:
   Prng               dice_;
   MockObjectFetcher  object_fetcher_;
+  GC_MockUploader   *uploader_;
 };
 
 const std::string T_GarbageCollector::fqrn = "test.cern.ch";

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -83,6 +83,7 @@ class T_GarbageCollector : public ::testing::Test {
     MockCatalog::Reset();
     MockHistory::Reset();
     EXPECT_EQ(0u, MockCatalog::instances);
+    ASSERT_NE(static_cast<GC_MockUploader*>(NULL), uploader_);
     uploader_->TearDown();
     delete uploader_;
   }


### PR DESCRIPTION
As @Moliholy figured out, there were threads straying around under some circumstances in the unit tests. It turns out that those are spawned by `AbstractUploader` which is used in the `T_GarbageCollector` test case through the `GC_MockUploader` which is not properly cleaned up afterwards.