### PR TITLE
FIX: Some Failing OS X Unit Test

### DIFF
--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -179,6 +179,9 @@ struct S3FanOutDnsEntry {
 };  // S3FanOutDnsEntry
 
 class S3FanoutManager : SingleCopy {
+ protected:
+  typedef SynchronizingCounter<uint32_t> Semaphore;
+
  public:
   S3FanoutManager();
   ~S3FanoutManager();
@@ -263,7 +266,7 @@ class S3FanoutManager : SingleCopy {
   bool opt_ipv4_only_;
 
   unsigned int max_available_jobs_;
-  sem_t available_jobs_;
+  Semaphore *available_jobs_;
 
   // Writes and reads should be atomic because reading happens in a different
   // thread than writing.

--- a/test/unittests/c_file_sandbox.h
+++ b/test/unittests/c_file_sandbox.h
@@ -50,7 +50,8 @@ class FileSandbox : public ::testing::Test {
     bool retval;
 
     retval = MkdirDeep(sandbox_path_, 0700);
-    ASSERT_TRUE(retval) << "failed to create sandbox";
+    ASSERT_TRUE(retval) << "failed to create sandbox in '" << sandbox_path_
+                        << "' (" << errno << ")";
 
     if (!sandbox_tmp_dir.empty()) {
       retval = MkdirDeep(sandbox_tmp_dir, 0700);

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -56,8 +56,14 @@ TEST(T_Util, GetUidOf) {
 
 
 TEST(T_Util, GetGidOf) {
+#ifdef __APPLE__
+  const std::string group_name = "wheel";
+#else
+  const std::string group_name = "root";
+#endif
+
   gid_t gid;
-  EXPECT_TRUE(GetGidOf("root", &gid));
+  EXPECT_TRUE(GetGidOf(group_name, &gid));
   EXPECT_EQ(0U, gid);
   EXPECT_FALSE(GetGidOf("no-such-group", &gid));
 }

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -58,15 +58,15 @@ class PolymorphicConstructionUnittestAdapter {
 //------------------------------------------------------------------------------
 
 
-static const std::string g_sandbox_path    = "/tmp/cvmfs_mockuploader";
-static const std::string g_sandbox_tmp_dir = g_sandbox_path + "/tmp";
+static const char* g_sandbox_path    = "/tmp/cvmfs_mockuploader";
+static const char* g_sandbox_tmp_dir = "/tmp/cvmfs_mockuploader/tmp";
 static inline upload::SpoolerDefinition MockSpoolerDefinition() {
   const size_t      min_chunk_size   = 512000;
   const size_t      avg_chunk_size   = 2 * min_chunk_size;
   const size_t      max_chunk_size   = 4 * min_chunk_size;
 
-  return upload::SpoolerDefinition("mock," + g_sandbox_path + "," +
-                                             g_sandbox_tmp_dir,
+  return upload::SpoolerDefinition("mock," + std::string(g_sandbox_path) + "," +
+                                             std::string(g_sandbox_tmp_dir),
                                    shash::kSha1,
                                    true,
                                    min_chunk_size,


### PR DESCRIPTION
There were a number of OS X unit tests failing and that needed fixes:

1. `T_Util::GetGidOf` failed since the group 'root' is called 'wheel' on OS X
2. `T_Uploaders` failed for `S3Uploader` since it used a `sem_t` that is not supported on OS X
3. `T_FileProcessor` failed because of bogus global state initialisation

Regarding the `sem_t` problem: OS X does provide the proper definitions of `sem_init()`, `sem_wait()` and so forth, but their implementation always returns -1 and sets `errno` to 'not implemented'. Thanks Apple! I replaced the semaphore in `S3Fanout` by `SynchronisingCounter`.

The 'root' group name is just replaced by 'wheel' with an `#ifdef`.