### PR TITLE
improve logging of T_Xattr::CreateFromFile

### DIFF
--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -58,7 +58,8 @@ TEST_F(T_Xattr, CreateFromFile) {
   EXPECT_EQ(default_attrs, from_file1->ListKeys().size());
 
   string value;
-  ASSERT_TRUE(platform_setxattr(tmp_path, "user.test", "value"));
+  ASSERT_TRUE(platform_setxattr(tmp_path, "user.test", "value"))
+    << "failed to set user defined extended attribute (errno: " << errno << ")";
   UniquePtr<XattrList> from_file2(XattrList::CreateFromFile(tmp_path));
   ASSERT_TRUE(from_file2.IsValid());
   EXPECT_EQ(default_attrs + 1, from_file2->ListKeys().size());


### PR DESCRIPTION
On older platforms (like SLES11) extended attributes might not be supported (or need to be enabled at mount). This just adds a bit more verbose logging for the failing test case `T_Xattr::CreateFromFile` to make it easier to debug.