### PR TITLE
FIX: MockUploader and T_UploadFacility::InitializeAndTearDown

### DIFF
--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -94,9 +94,9 @@ TEST(T_UploadFacility, InitializeAndTearDown) {
   EXPECT_TRUE(uploader->worker_thread_running);
 
   uploader->TearDown();
-  delete uploader;
-
   EXPECT_FALSE(uploader->worker_thread_running);
+
+  delete uploader;
 }
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -93,8 +93,9 @@ class AbstractMockUploader : public upload::AbstractUploader {
   explicit AbstractMockUploader(
     const upload::SpoolerDefinition &spooler_definition)
     : AbstractUploader(spooler_definition)
-    , worker_thread_running(false)
-  { }
+  {
+    worker_thread_running = false;
+  }
 
   static DerivedT* MockConstruct() {
     PolymorphicConstructionUnittestAdapter::RegisterPlugin<
@@ -177,7 +178,7 @@ class AbstractMockUploader : public upload::AbstractUploader {
   }
 
  public:
-  volatile bool worker_thread_running;
+  tbb::atomic<bool> worker_thread_running;
 };
 
 template <class DerivedT>


### PR DESCRIPTION
This replaces the volatile flag `worker_thread_running` with a `tbb::atomic<>`. Furthermore there was a data race in `T_UploadFacility::InitializeAndTearDown` where the same flag was checked after the object has been deleted.