### PR TITLE
Cleanup: Content Hash and Derived Storage Path Handling

### DIFF
--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -971,25 +971,23 @@ catalog::LoadError CatalogManager::LoadCatalog(const PathString  &mountpoint,
   if (manifest_failure != manifest::kFailOk) {
     LogCvmfs(kLogCache, kLogDebug, "failed to fetch manifest (%d - %s)",
              manifest_failure, manifest::Code2Ascii(manifest_failure));
-    if (!cache_hash.IsNull()) {
-      if (catalog_path) {
-        if (cache_mode_ == kCacheReadWrite) {
-          *catalog_path = *cache_path_ + "/" + cache_hash.MakePathWithoutSuffix();
-          int64_t size = GetFileSize(*catalog_path);
-          retval = quota::Pin(cache_hash, uint64_t(size),
-                              cvmfs_path, true);
-          if (!retval) {
-            LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
-                     "failed to pin cached root catalog (no space)");
-            return catalog::kLoadFail;
-          }
+    if (!cache_hash.IsNull() && catalog_path) {
+      if (cache_mode_ == kCacheReadWrite) {
+        *catalog_path = *cache_path_ + "/" + cache_hash.MakePathWithoutSuffix();
+        int64_t size = GetFileSize(*catalog_path);
+        retval = quota::Pin(cache_hash, uint64_t(size),
+                            cvmfs_path, true);
+        if (!retval) {
+          LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
+                   "failed to pin cached root catalog (no space)");
+          return catalog::kLoadFail;
         }
-        loaded_catalogs_[mountpoint] = cache_hash;
-        *catalog_hash = cache_hash;
-        offline_mode_ = true;
-
-        return catalog::kLoadUp2Date;
       }
+      loaded_catalogs_[mountpoint] = cache_hash;
+      *catalog_hash = cache_hash;
+      offline_mode_ = true;
+
+      return catalog::kLoadUp2Date;
     }
     return catalog::kLoadFail;
   }

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -239,7 +239,7 @@ void TearDown2ReadOnly() {
  * \return Absolute path in local cache.
  */
 static inline string GetPathInCache(const shash::Any &id) {
-  return *cache_path_ + id.MakePathExplicit(1, 2);
+  return *cache_path_ + "/" + id.MakePathWithoutSuffix();
 }
 
 
@@ -479,7 +479,6 @@ static bool CommitFromMem(const shash::Any &id, const unsigned char *buffer,
  * and only the first one performs the download.
  *
  * @param[in] checksum     content hash of the file to be fetched
- * @param[in] hash_suffix  optional hash suffix to append in the download job
  * @param[in] size         the required disk size of the downloaded data chunk
  * @param[in] cvmfs_path   Path of the chunk as seen in cvmfs
  *
@@ -487,7 +486,6 @@ static bool CommitFromMem(const shash::Any &id, const unsigned char *buffer,
  *         On failure a negative error code.
  */
 static int Fetch(const shash::Any &checksum,
-                 const char        hash_suffix,
                  const uint64_t    size,
                  const string     &cvmfs_path,
                  const bool        volatile_content,
@@ -571,7 +569,7 @@ static int Fetch(const shash::Any &checksum,
   LogCvmfs(kLogCache, kLogDebug, "downloading %s", cvmfs_path.c_str());
   atomic_inc64(&num_download_);
 
-  const string url = "/data" + checksum.MakePathWithSuffix(1, 2, hash_suffix);
+  const string url = "/data/" + checksum.MakePath();
   string final_path;
   string temp_path;
   int fd;  // Used to write the downloaded file
@@ -692,7 +690,6 @@ int FetchDirent(const catalog::DirectoryEntry &d,
                 download::DownloadManager *download_manager)
 {
   return Fetch(d.checksum(),
-               shash::kSuffixNone,
                d.size(),
                cvmfs_path,
                volatile_content,
@@ -715,7 +712,6 @@ int FetchChunk(const FileChunk &chunk,
                download::DownloadManager *download_manager)
 {
   return Fetch(chunk.content_hash(),
-               shash::kSuffixPartial,
                chunk.size(),
                cvmfs_path,
                volatile_content,
@@ -792,13 +788,15 @@ catalog::LoadError CatalogManager::LoadCatalogCas(const shash::Any &hash,
                                                   const string &cvmfs_path,
                                                   std::string *catalog_path)
 {
+  assert (hash.suffix == shash::kSuffixCatalog);
+
   CallGuard call_guard;
   int64_t size;
   int retval;
   bool pin_retval;
 
   // Try from cache
-  const string cache_path = *cache_path_ + hash.MakePathExplicit(1, 2);
+  const string cache_path = *cache_path_ + "/" + hash.MakePathWithoutSuffix();
   if (alien_cache_) {
     *catalog_path = cache_path;
     if (FileExists(cache_path)) {
@@ -848,7 +846,7 @@ catalog::LoadError CatalogManager::LoadCatalogCas(const shash::Any &hash,
     return catalog::kLoadFail;
   }
 
-  const string url = "/data" + hash.MakePathExplicit(1, 2) + "C";
+  const string url = "/data/" + hash.MakePath();
   download::JobInfo download_catalog(&url, true, true, catalog_file, &hash);
   download_catalog.extra_info = &cvmfs_path;
   download_manager_->Fetch(&download_catalog);
@@ -944,7 +942,7 @@ catalog::LoadError CatalogManager::LoadCatalog(const PathString  &mountpoint,
          ++separator_pos) { }
     cache_hash = shash::MkFromHexPtr(shash::HexPtr(string(tmp, separator_pos)),
                                      shash::kSuffixCatalog);
-    if (!FileExists(*cache_path_ + cache_hash.MakePathExplicit(1, 2))) {
+    if (!FileExists(*cache_path_ + "/" + cache_hash.MakePathWithoutSuffix())) {
       LogCvmfs(kLogCache, kLogDebug, "found checksum hint without catalog");
       cache_hash = shash::Any();
     } else {
@@ -976,7 +974,7 @@ catalog::LoadError CatalogManager::LoadCatalog(const PathString  &mountpoint,
     if (!cache_hash.IsNull()) {
       if (catalog_path) {
         if (cache_mode_ == kCacheReadWrite) {
-          *catalog_path = *cache_path_ + cache_hash.MakePathExplicit(1, 2);
+          *catalog_path = *cache_path_ + "/" + cache_hash.MakePathWithoutSuffix();
           int64_t size = GetFileSize(*catalog_path);
           retval = quota::Pin(cache_hash, uint64_t(size),
                               cvmfs_path, true);
@@ -1004,7 +1002,7 @@ catalog::LoadError CatalogManager::LoadCatalog(const PathString  &mountpoint,
   // Short way out, use cached copy
   if (ensemble.manifest->catalog_hash() == cache_hash) {
     if (catalog_path) {
-      *catalog_path = *cache_path_ + cache_hash.MakePathExplicit(1, 2);
+      *catalog_path = *cache_path_ + "/" + cache_hash.MakePathWithoutSuffix();
       // quota::Pin is only effective on first load, afterwards it is a NOP
       if (cache_mode_ == kCacheReadWrite) {
         int64_t size = GetFileSize(*catalog_path);

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -788,7 +788,7 @@ catalog::LoadError CatalogManager::LoadCatalogCas(const shash::Any &hash,
                                                   const string &cvmfs_path,
                                                   std::string *catalog_path)
 {
-  assert (hash.suffix == shash::kSuffixCatalog);
+  assert(hash.suffix == shash::kSuffixCatalog);
 
   CallGuard call_guard;
   int64_t size;

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -27,8 +27,8 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
                                             shash::Any        *catalog_hash)
 {
   shash::Any effective_hash = hash.IsNull() ? base_hash_ : hash;
-  const string url = stratum0_ + "/data" +
-                     effective_hash.MakePathExplicit(1, 2) + "C";
+  assert (shash::kSuffixCatalog == effective_hash.suffix);
+  const string url = stratum0_ + "/data/" + effective_hash.MakePath();
   FILE *fcatalog = CreateTempFile(dir_temp_ + "/catalog", 0666, "w",
                                   catalog_path);
   if (!fcatalog) {

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -27,7 +27,7 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
                                             shash::Any        *catalog_hash)
 {
   shash::Any effective_hash = hash.IsNull() ? base_hash_ : hash;
-  assert (shash::kSuffixCatalog == effective_hash.suffix);
+  assert(shash::kSuffixCatalog == effective_hash.suffix);
   const string url = stratum0_ + "/data/" + effective_hash.MakePath();
   FILE *fcatalog = CreateTempFile(dir_temp_ + "/catalog", 0666, "w",
                                   catalog_path);

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -147,8 +147,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   manifest->set_garbage_collectability(garbage_collectable);
 
   // Upload catalog
-  spooler->Upload(file_path_compressed,
-                  "data" + hash_catalog.MakePathExplicit(1, 2) + "C");
+  spooler->Upload(file_path_compressed, "data/" + hash_catalog.MakePath());
   spooler->WaitForUpload();
   unlink(file_path_compressed.c_str());
   if (spooler->GetNumberOfErrors() > 0) {
@@ -824,7 +823,7 @@ shash::Any WritableCatalogManager::SnapshotCatalog(WritableCatalog *catalog)
 
   // Upload catalog
   spooler_->Upload(catalog->database_path() + ".compressed",
-                   "data" + hash_catalog.MakePathExplicit(1, 2) + "C");
+                   "data/" + hash_catalog.MakePath());
 
   // Update registered catalog hash in nested catalog
   if (catalog->HasParent()) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2390,7 +2390,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
     }
     string history_path = "txn/historydb" + history_hash.ToString() + "." +
                           *cvmfs::repository_name_;
-    string history_url = "/data" + history_hash.MakePathExplicit(1, 2) + "H";
+    string history_url = "/data/" + history_hash.MakePath();
     download::JobInfo download_history(&history_url, true, true, &history_path,
                                        &history_hash);
     retval_dl = cvmfs::download_manager_->Fetch(&download_history);

--- a/cvmfs/file_processing/chunk.cc
+++ b/cvmfs/file_processing/chunk.cc
@@ -166,9 +166,4 @@ void Chunk::SetAsBulkChunk() {
                                                // content hash suffix
 }
 
-
-shash::Suffix Chunk::hash_suffix() const {
-  return (IsBulkChunk()) ? file_->hash_suffix() : shash::kSuffixPartial;
-}
-
 }  // namespace upload

--- a/cvmfs/file_processing/chunk.cc
+++ b/cvmfs/file_processing/chunk.cc
@@ -160,6 +160,13 @@ Chunk* Chunk::CopyAsBulkChunk(const size_t file_size) {
 }
 
 
+void Chunk::SetAsBulkChunk() {
+  is_bulk_chunk_       = true;
+  content_hash_.suffix = file_->hash_suffix(); // bulk chunks inherit the file's
+                                               // content hash suffix
+}
+
+
 shash::Suffix Chunk::hash_suffix() const {
   return (IsBulkChunk()) ? file_->hash_suffix() : shash::kSuffixPartial;
 }

--- a/cvmfs/file_processing/chunk.h
+++ b/cvmfs/file_processing/chunk.h
@@ -52,7 +52,7 @@ class Chunk {
   void Finalize();
   void ScheduleCommit();
   Chunk* CopyAsBulkChunk(const size_t file_size);
-  void SetAsBulkChunk() { is_bulk_chunk_ = true; }
+  void SetAsBulkChunk();
 
   /**
    * Provides the ChunkProcessingTask with memory for the data compression. The

--- a/cvmfs/file_processing/chunk.h
+++ b/cvmfs/file_processing/chunk.h
@@ -91,7 +91,6 @@ class Chunk {
 
   shash::ContextPtr& content_hash_context() { return content_hash_context_; }
   const shash::Any&  content_hash() const { return content_hash_; }
-  shash::Suffix      hash_suffix() const;
   z_stream&          zlib_context() { return zlib_context_; }
 
   UploadStreamHandle* upload_stream_handle() const {

--- a/cvmfs/file_processing/chunk.h
+++ b/cvmfs/file_processing/chunk.h
@@ -28,6 +28,8 @@ class File;
  * Note that it deliberately _does not_ contain the actual chunk data which is
  * managed dynamically by a stream of Buffers. Still the Chunk class is in
  * charge of scheduling (or deferred scheduling) the write of processed Buffers.
+ * Note: When creating a chunk it is seen as a 'partial' data chunk and can be
+ *       promoted to a 'bulk' chunk (representing an entire file).
  */
 class Chunk {
  public:
@@ -35,9 +37,9 @@ class Chunk {
     file_(file), file_offset_(offset), chunk_size_(0),
     is_bulk_chunk_(false), is_fully_defined_(false), deferred_write_(false),
     zlib_initialized_(false), content_hash_context_(hash_algorithm),
-    content_hash_(hash_algorithm), content_hash_initialized_(false),
-    upload_stream_handle_(NULL), current_deflate_buffer_(NULL),
-    bytes_written_(0)
+    content_hash_(hash_algorithm, shash::kSuffixPartial),
+    content_hash_initialized_(false), upload_stream_handle_(NULL),
+    current_deflate_buffer_(NULL), bytes_written_(0)
   {
     Initialize();
   }

--- a/cvmfs/file_processing/file_processor.cc
+++ b/cvmfs/file_processing/file_processor.cc
@@ -86,8 +86,12 @@ void FileProcessor::FileDone(File *file) {
                                         current_chunk->size()));
   }
 
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "File '%s' processed completely",
-           file->path().c_str());
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "File '%s' processed completely "
+                                        "(bulk hash: %s suffix: %c)",
+           file->path().c_str(),
+           file->bulk_chunk()->content_hash().ToString().c_str(),
+           file->hash_suffix());
+  assert (file->hash_suffix() == file->bulk_chunk()->content_hash().suffix);
   NotifyListeners(SpoolerResult(0,
                                 file->path(),
                                 file->bulk_chunk()->content_hash(),

--- a/cvmfs/file_processing/io_dispatcher.cc
+++ b/cvmfs/file_processing/io_dispatcher.cc
@@ -58,8 +58,7 @@ void IoDispatcher::ScheduleCommit(Chunk* chunk) {
 
   // Finalize the streamed upload for the committed Chunk
   uploader_->ScheduleCommit(chunk->upload_stream_handle(),
-                            chunk->content_hash(),
-                            chunk->hash_suffix());
+                            chunk->content_hash());
 }
 
 

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -213,6 +213,13 @@ struct Digest {
   bool HasSuffix() const { return suffix != kSuffixNone; }
   void set_suffix(const Suffix s) { suffix = s; }
 
+  /**
+   * Generates a hexified repesentation of the digest including the identifier
+   * string for newly added hashes.
+   *
+   * @param with_suffix  append the hash suffix (C,H,X, ...) to the result
+   * @return             a string representation of the digest
+   */
   std::string ToString(const bool with_suffix = false) const {
     Hex hex(this);
     const bool     use_suffix  = with_suffix && HasSuffix();
@@ -231,24 +238,49 @@ struct Digest {
     return result;
   }
 
+  /**
+   * Convenience method to generate a string representation of the digest.
+   * See Digest<>::ToString() for details
+   *
+   * @return  a string representation including the hash suffix of the digest
+   */
   std::string ToStringWithSuffix() const {
     return ToString(true);
   }
 
+  /**
+   * Generate the standard relative path from the hexified digest to be used in
+   * CAS areas or cache directories. Throughout the entire system we use one
+   * directory level (first to hex digest characters) for namespace splitting.
+   * Note: This method appends the internal hash suffix to the path.
+   *
+   * @return  a relative path representation of the digest including the suffix
+   */
   std::string MakePath() const {
     return MakePathExplicit(1, 2, suffix);
   }
 
+  /**
+   * Produces a relative path representation of the digest without appending the
+   * hash suffix. See Digest<>::MakePath() for more details.
+   *
+   * @return  a relative path representation of the digest without the suffix
+   */
   std::string MakePathWithoutSuffix() const {
     return MakePathExplicit(1, 2, kSuffixNone);
   }
 
   /**
-   * Create a path string from the hex notation of the digest.
-   * Note: This method takes an explicit suffix. This is a crutch to allow for
-   *       MakePathWithSuffix() until MakePathExplicit() is replaced by the more
-   *       convenient MakePath() everywhere in the code. Then this method will
-   *       use the member variable suffix by default.
+   * Generates an arbitrary path representation of the digest. Both number of
+   * directory levels and the hash-digits per level can be customized. Further-
+   * more an arbitrary hash suffix can be provided.
+   * Note: This method is mainly meant for internal usage but stays public for
+   *       historical reasons.
+   *
+   * @param dir_levels        the number of namespace splitting directory levels
+   * @param digits_per_level  each directory level's number of hex-digits
+   * @param hash_suffix       the hash suffix character to be appended
+   * @return                  a relative path representation of the digest
    */
   std::string MakePathExplicit(const unsigned dir_levels,
                                const unsigned digits_per_level,

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -235,26 +235,12 @@ struct Digest {
     return ToString(true);
   }
 
-  std::string MakePath(const std::string &prefix = "data") const {
-    return MakePathExplicit(1, 2, prefix, shash::kSuffixNone);
+  std::string MakePath() const {
+    return MakePathExplicit2(1, 2, suffix);
   }
 
-  /**
-   * Note: This is a crutch method until we replace MakePathExplicit() anywhere
-   *       with MakePath() which will handle this suffix magic internally.
-   */
-  std::string MakePathWithSuffix(const unsigned   dir_levels,
-                                 const unsigned   digits_per_level,
-                                 const Suffix     hash_suffix) const {
-    const std::string no_prefix = "";
-    return MakePathExplicit(dir_levels,
-                            digits_per_level,
-                            no_prefix,
-                            hash_suffix);
-  }
-
-  std::string MakePathWithSuffix(const std::string &prefix = "data") const {
-    return MakePathExplicit(1, 2, prefix, suffix);
+  std::string MakePathWithoutSuffix() const {
+    return MakePathExplicit2(1, 2, kSuffixNone);
   }
 
   /**
@@ -264,25 +250,21 @@ struct Digest {
    *       convenient MakePath() everywhere in the code. Then this method will
    *       use the member variable suffix by default.
    */
-  std::string MakePathExplicit(
+  std::string MakePathExplicit2(
                           const unsigned      dir_levels,
                           const unsigned      digits_per_level,
-                          const std::string  &prefix = "",
                           const Suffix        hash_suffix = kSuffixNone) const {
     Hex hex(this);
     const bool use_suffix = (hash_suffix != kSuffixNone);
 
-    const unsigned string_length =   prefix.length()
-                                   + hex.length()
+    const unsigned string_length =   hex.length()
                                    + dir_levels
-                                   + 1  // slash between prefix and hash
                                    + use_suffix;
-    // prepend prefix string
-    std::string result(prefix);
+    std::string result;
     result.resize(string_length);
 
     // build hexified hash and path delimiters
-    unsigned pos = prefix.length();
+    unsigned pos = 0;
     for (unsigned i = 0; i < hex.length(); ++i) {
       if ((i % digits_per_level == 0) && (i / digits_per_level <= dir_levels)) {
         result[pos++] = '/';

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -297,7 +297,8 @@ struct Digest {
     unsigned i   = 0;
     unsigned pos = 0;
     for (; i < hex.length(); ++i) {
-      if (i > 0 && (i % digits_per_level == 0) && (i / digits_per_level <= dir_levels)) {
+      if (i > 0 && (i % digits_per_level == 0)
+                && (i / digits_per_level <= dir_levels)) {
         result[pos++] = '/';
       }
       result[pos++] = hex[i];

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -236,11 +236,11 @@ struct Digest {
   }
 
   std::string MakePath() const {
-    return MakePathExplicit2(1, 2, suffix);
+    return MakePathExplicit(1, 2, suffix);
   }
 
   std::string MakePathWithoutSuffix() const {
-    return MakePathExplicit2(1, 2, kSuffixNone);
+    return MakePathExplicit(1, 2, kSuffixNone);
   }
 
   /**
@@ -250,8 +250,7 @@ struct Digest {
    *       convenient MakePath() everywhere in the code. Then this method will
    *       use the member variable suffix by default.
    */
-  std::string MakePathExplicit2(
-                               const unsigned dir_levels,
+  std::string MakePathExplicit(const unsigned dir_levels,
                                const unsigned digits_per_level,
                                const Suffix   hash_suffix = kSuffixNone) const {
     Hex hex(this);

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -251,22 +251,22 @@ struct Digest {
    *       use the member variable suffix by default.
    */
   std::string MakePathExplicit2(
-                          const unsigned      dir_levels,
-                          const unsigned      digits_per_level,
-                          const Suffix        hash_suffix = kSuffixNone) const {
+                               const unsigned dir_levels,
+                               const unsigned digits_per_level,
+                               const Suffix   hash_suffix = kSuffixNone) const {
     Hex hex(this);
-    const bool use_suffix = (hash_suffix != kSuffixNone);
 
-    const unsigned string_length =   hex.length()
-                                   + dir_levels
-                                   + use_suffix;
+    // figure out how big the output string needs to be
+    const bool use_suffix = (hash_suffix != kSuffixNone);
+    const unsigned string_length = hex.length() + dir_levels + use_suffix;
     std::string result;
     result.resize(string_length);
 
     // build hexified hash and path delimiters
+    unsigned i   = 0;
     unsigned pos = 0;
-    for (unsigned i = 0; i < hex.length(); ++i) {
-      if ((i % digits_per_level == 0) && (i / digits_per_level <= dir_levels)) {
+    for (; i < hex.length(); ++i) {
+      if (i > 0 && (i % digits_per_level == 0) && (i / digits_per_level <= dir_levels)) {
         result[pos++] = '/';
       }
       result[pos++] = hex[i];
@@ -277,6 +277,7 @@ struct Digest {
       result[pos++] = hash_suffix;
     }
 
+    assert(i   == hex.length());
     assert(pos == string_length);
     return result;
   }

--- a/cvmfs/manifest_fetch.cc
+++ b/cvmfs/manifest_fetch.cc
@@ -97,7 +97,7 @@ Failures Fetch(const std::string &base_url, const std::string &repository_name,
   certificate_hash = ensemble->manifest->certificate();
   ensemble->FetchCertificate(certificate_hash);
   if (!ensemble->cert_buf) {
-    certificate_url += certificate_hash.MakePathExplicit(1, 2) + "X";
+    certificate_url += "/" + certificate_hash.MakePath();
     retval_dl = download_manager->Fetch(&download_certificate);
     if (retval_dl != download::kFailOk) {
       result = kFailLoad;

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -77,11 +77,13 @@ class AbstractObjectFetcher {
     shash::Any effective_history_hash = (!history_hash.IsNull())
             ? history_hash
             : GetHistoryHash();
+    assert (history_hash.suffix == shash::kSuffixHistory ||
+            history_hash.IsNull());
 
     // download the history hash
     std::string path;
     if (effective_history_hash.IsNull() ||
-        !Fetch(effective_history_hash, shash::kSuffixHistory, &path)) {
+        !Fetch(effective_history_hash, &path)) {
       return NULL;
     }
 
@@ -109,9 +111,10 @@ class AbstractObjectFetcher {
                           const bool         is_nested = false,
                                 CatalogTN   *parent    = NULL) {
     assert(!catalog_hash.IsNull());
+    assert(catalog_hash.suffix == shash::kSuffixCatalog);
 
     std::string path;
-    if (!Fetch(catalog_hash, shash::kSuffixCatalog, &path)) {
+    if (!Fetch(catalog_hash, &path)) {
       return NULL;
     }
 
@@ -140,16 +143,11 @@ class AbstractObjectFetcher {
    * of this base class.
    *
    * @param object_hash  the content hash of the object to be downloaded
-   * @param hash_suffix  the (optional) hash suffix of the object to be fetched
    * @param file_path    temporary file path to store the download result
    * @return             true on success (if false, file_path is invalid)
    */
-  bool Fetch(const shash::Any    &object_hash,
-             const shash::Suffix  hash_suffix,
-             std::string         *file_path) {
-    return static_cast<DerivedT*>(this)->Fetch(object_hash,
-                                               hash_suffix,
-                                               file_path);
+  bool Fetch(const shash::Any &object_hash, std::string *file_path) {
+    return static_cast<DerivedT*>(this)->Fetch(object_hash, file_path);
   }
 
   /**
@@ -203,17 +201,15 @@ class LocalObjectFetcher :
     return manifest::Manifest::LoadFile(BuildPath(BaseTN::kManifestFilename));
   }
 
-  bool Fetch(const shash::Any    &object_hash,
-             const shash::Suffix  hash_suffix,
-             std::string         *file_path) {
+  bool Fetch(const shash::Any &object_hash, std::string *file_path) {
     assert(file_path != NULL);
     file_path->clear();
 
     // check if the requested file object is available locally
-    const std::string source = BuildPath(object_hash, hash_suffix);
+    const std::string source = BuildPath(object_hash);
     if (!FileExists(source)) {
       LogCvmfs(kLogDownload, kLogDebug, "failed to locate object %s",
-               object_hash.ToString().c_str());
+               object_hash.ToStringWithSuffix().c_str());
       return false;
     }
 
@@ -246,9 +242,8 @@ class LocalObjectFetcher :
     return base_path_ + "/" + relative_path;
   }
 
-  std::string BuildPath(const shash::Any    &hash,
-                        const shash::Suffix  suffix) const {
-    return BuildPath("data" + hash.MakePathWithSuffix(1, 2, suffix));
+  std::string BuildPath(const shash::Any &hash) const {
+    return BuildPath("data/" + hash.MakePath());
   }
 
  private:
@@ -335,9 +330,7 @@ class HttpObjectFetcher :
     return manifest;
   }
 
-  bool Fetch(const shash::Any     &object_hash,
-             const shash::Suffix   hash_suffix,
-             std::string          *object_file) {
+  bool Fetch(const shash::Any &object_hash, std::string *object_file) {
     assert(object_file != NULL);
     assert(!object_hash.IsNull());
 
@@ -354,7 +347,7 @@ class HttpObjectFetcher :
     }
 
     // fetch and decompress the requested objected
-    const std::string url = BuildUrl(object_hash, hash_suffix);
+    const std::string url = BuildUrl(object_hash);
     download::JobInfo download_catalog(&url, true, false, f, &object_hash);
     download::Failures retval = download_manager_->Fetch(&download_catalog);
     const bool success = (retval == download::kFailOk);
@@ -376,9 +369,8 @@ class HttpObjectFetcher :
     return repo_url_ + "/" + relative_path;
   }
 
-  std::string BuildUrl(const shash::Any     &hash,
-                       const shash::Suffix  &suffix) const {
-    return BuildUrl("data" + hash.MakePathWithSuffix(1, 2, suffix));
+  std::string BuildUrl(const shash::Any &hash) const {
+    return BuildUrl("data/" + hash.MakePath());
   }
 
  private:

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -77,8 +77,8 @@ class AbstractObjectFetcher {
     shash::Any effective_history_hash = (!history_hash.IsNull())
             ? history_hash
             : GetHistoryHash();
-    assert (history_hash.suffix == shash::kSuffixHistory ||
-            history_hash.IsNull());
+    assert(history_hash.suffix == shash::kSuffixHistory ||
+           history_hash.IsNull());
 
     // download the history hash
     std::string path;

--- a/cvmfs/quota.cc
+++ b/cvmfs/quota.cc
@@ -311,7 +311,7 @@ static bool DoCleanup(const uint64_t leave_size) {
     // pinned file as it is already reserved (but will be inserted later).
     // Instead, set the pin bit in the db to not run into an endless loop
     if (pinned_chunks_->find(hash) == pinned_chunks_->end()) {
-      trash.push_back((*cache_dir_) + hash.MakePathExplicit(1, 2));
+      trash.push_back((*cache_dir_) + "/" + hash.MakePathWithoutSuffix());
       gauge_ -= sqlite3_column_int64(stmt_lru_, 1);
       LogCvmfs(kLogQuota, kLogDebug, "lru cleanup %s, new gauge %"PRIu64,
                hash_str.c_str(), gauge_);
@@ -1771,7 +1771,7 @@ void Remove(const shash::Any &hash) {
     CloseReturnPipe(pipe_remove);
   }
 
-  unlink(((*cache_dir_) + hash.MakePathExplicit(1, 2)).c_str());
+  unlink(((*cache_dir_) + "/" + hash.MakePathWithoutSuffix()).c_str());
 }
 
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -208,7 +208,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
     if (!entries[i].checksum().IsNull() && check_chunks) {
       string chunk_path = "data/" + entries[i].checksum().MakePath();
       if (entries[i].IsDirectory())
-        chunk_path += "L";
+        chunk_path += shash::kSuffixMicroCatalog;
       if (!Exists(chunk_path)) {
         LogCvmfs(kLogCvmfs, kLogStderr, "data chunk %s (%s) missing",
                  entries[i].checksum().ToString().c_str(), full_path.c_str());

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -206,8 +206,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
 
     // Check if the chunk is there
     if (!entries[i].checksum().IsNull() && check_chunks) {
-      string chunk_path = "data" +
-                          entries[i].checksum().MakePathExplicit(1, 2);
+      string chunk_path = "data/" + entries[i].checksum().MakePath();
       if (entries[i].IsDirectory())
         chunk_path += "L";
       if (!Exists(chunk_path)) {
@@ -342,15 +341,11 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
         // are all data chunks in the data store?
         if (check_chunks) {
           const shash::Any &chunk_hash = this_chunk.content_hash();
-          const string chunk_path = "data"                            +
-                                    chunk_hash.MakePathExplicit(1, 2) +
-                                    shash::kSuffixPartial;
+          const string chunk_path = "data/" + chunk_hash.MakePath();
           if (!Exists(chunk_path)) {
-            const std::string chunk_name =
-                   this_chunk.content_hash().ToString() + shash::kSuffixPartial;
             LogCvmfs(kLogCvmfs, kLogStderr, "partial data chunk %s (%s -> "
                                             "offset: %d | size: %d) missing",
-                     chunk_name.c_str(),
+                     this_chunk.content_hash().ToStringWithSuffix().c_str(),
                      full_path.c_str(),
                      this_chunk.offset(),
                      this_chunk.size());
@@ -404,11 +399,8 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
 }
 
 
-string CommandCheck::DownloadPiece(const shash::Any catalog_hash,
-                                   const char suffix)
-{
-  string source = "data" + catalog_hash.MakePathExplicit(1, 2);
-  source.push_back(suffix);
+string CommandCheck::DownloadPiece(const shash::Any catalog_hash) {
+  string source = "data/" + catalog_hash.MakePath();
   const string dest = "/tmp/" + catalog_hash.ToString();
   const string url = *remote_repository + "/" + source;
   download::JobInfo download_catalog(&url, true, false, &dest, &catalog_hash);
@@ -423,11 +415,8 @@ string CommandCheck::DownloadPiece(const shash::Any catalog_hash,
 }
 
 
-string CommandCheck::DecompressPiece(const shash::Any catalog_hash,
-                                     const char suffix)
-{
-  string source = "data" + catalog_hash.MakePathExplicit(1, 2);
-  source.push_back(suffix);
+string CommandCheck::DecompressPiece(const shash::Any catalog_hash) {
+  string source = "data/" + catalog_hash.MakePath();
   const string dest = "/tmp/" + catalog_hash.ToString();
   if (!zlib::DecompressPath2Path(source, dest))
     return "";
@@ -450,9 +439,9 @@ bool CommandCheck::InspectTree(const string &path,
 
   string tmp_file;
   if (remote_repository == NULL)
-    tmp_file = DecompressPiece(catalog_hash, 'C');
+    tmp_file = DecompressPiece(catalog_hash);
   else
-    tmp_file = DownloadPiece(catalog_hash, 'C');
+    tmp_file = DownloadPiece(catalog_hash);
   if (tmp_file == "") {
     LogCvmfs(kLogCvmfs, kLogStdout, "failed to load catalog %s",
              catalog_hash.ToString().c_str());
@@ -636,8 +625,7 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
   }
 
   // Validate Manifest
-  const string certificate_path =
-    "data" + manifest->certificate().MakePathExplicit(1, 2) + "X";
+  const string certificate_path = "data/" + manifest->certificate().MakePath();
   if (!Exists(certificate_path)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to find certificate (%s)",
              certificate_path.c_str());
@@ -655,9 +643,9 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     }
     string tmp_file;
     if (remote_repository == NULL)
-      tmp_file = DecompressPiece(manifest->history(), 'H');
+      tmp_file = DecompressPiece(manifest->history());
     else
-      tmp_file = DownloadPiece(manifest->history(), 'H');
+      tmp_file = DownloadPiece(manifest->history());
     if (tmp_file == "") {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to load history database %s",
                manifest->history().ToString().c_str());

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -42,10 +42,8 @@ class CommandCheck : public Command {
                    const uint64_t catalog_size,
                    const catalog::DirectoryEntry *transition_point,
                    catalog::DeltaCounters *computed_counters);
-  std::string DecompressPiece(const shash::Any catalog_hash,
-                              const char suffix);
-  std::string DownloadPiece(const shash::Any catalog_hash,
-                            const char suffix);
+  std::string DecompressPiece(const shash::Any catalog_hash);
+  std::string DownloadPiece(const shash::Any catalog_hash);
   bool Find(const catalog::Catalog *catalog,
             const PathString &path,
             catalog::DeltaCounters *computed_counters);

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -468,7 +468,7 @@ catalog::Catalog* CommandTag::GetCatalog(const std::string  &repository_url,
                                          const shash::Any   &catalog_hash,
                                          const std::string   catalog_path,
                                          const bool          read_write) const {
-  assert (shash::kSuffixCatalog == catalog_hash.suffix);
+  assert(shash::kSuffixCatalog == catalog_hash.suffix);
   if (!FetchObject(repository_url, catalog_hash, catalog_path)) {
     return NULL;
   }

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -406,22 +406,19 @@ manifest::Manifest* CommandTag::FetchManifest(
 
 bool CommandTag::FetchObject(const std::string    &repository_url,
                              const shash::Any     &object_hash,
-                             const shash::Suffix   hash_suffix,
                              const std::string    &destination_path) const {
   assert(!object_hash.IsNull());
 
   download::Failures dl_retval;
-  const std::string url = repository_url + "/data" +
-                          object_hash.MakePathWithSuffix(1, 2, hash_suffix);
+  const std::string url = repository_url + "/data/" + object_hash.MakePath();
 
   download::JobInfo download_object(&url, true, false, &destination_path,
                                     &object_hash);
   dl_retval = g_download_manager->Fetch(&download_object);
 
   if (dl_retval != download::kFailOk) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to download object '%s' with "
-                                    "suffix '%c' (%d - %s)",
-             object_hash.ToString().c_str(), hash_suffix,
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to download object '%s' (%d - %s)",
+             object_hash.ToStringWithSuffix().c_str(),
              dl_retval, download::Code2Ascii(dl_retval));
     return false;
   }
@@ -447,10 +444,7 @@ history::History* CommandTag::GetHistory(
       return NULL;
     }
   } else {
-    if (!FetchObject(repository_url,
-                      history_hash,
-                      shash::kSuffixHistory,
-                      history_path)) {
+    if (!FetchObject(repository_url, history_hash, history_path)) {
       return NULL;
     }
 
@@ -470,16 +464,12 @@ history::History* CommandTag::GetHistory(
 }
 
 
-catalog::Catalog* CommandTag::GetCatalog(
-                                       const std::string  &repository_url,
-                                       const shash::Any   &catalog_hash,
-                                       const std::string   catalog_path,
-                                       const bool          read_write) const {
-  if (!FetchObject(repository_url,
-                   catalog_hash,
-                   shash::kSuffixCatalog,
-                   catalog_path))
-  {
+catalog::Catalog* CommandTag::GetCatalog(const std::string  &repository_url,
+                                         const shash::Any   &catalog_hash,
+                                         const std::string   catalog_path,
+                                         const bool          read_write) const {
+  assert (shash::kSuffixCatalog == catalog_hash.suffix);
+  if (!FetchObject(repository_url, catalog_hash, catalog_path)) {
     return NULL;
   }
 

--- a/cvmfs/swissknife_history.h
+++ b/cvmfs/swissknife_history.h
@@ -82,7 +82,6 @@ class CommandTag : public Command {
                                     const shash::Any   &base_hash) const;
   bool FetchObject(const std::string    &repository_url,
                    const shash::Any     &object_hash,
-                   const shash::Suffix   hash_suffix,
                    const std::string    &destination_path) const;
   history::History* GetHistory(const manifest::Manifest  *manifest,
                                const std::string         &repository_url,

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -116,8 +116,7 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
   }
 
   // Validate Manifest
-  const string certificate_path =
-    "data" + manifest->certificate().MakePathExplicit(1, 2) + "X";
+  const string certificate_path = "data/" + manifest->certificate().MakePath();
   if (!Exists(repository, certificate_path)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to find certificate (%s)",
              certificate_path.c_str());

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -79,7 +79,7 @@ string              *preload_cachedir = NULL;
 static bool Peek(const string &remote_path) {
   if (preload_cache) {
     // Strip "data"
-    // TODO: Fix that! It's ugly and error prone!
+    // TODO(rene): Fix that! It's ugly and error prone!
     return FileExists(*preload_cachedir + remote_path.substr(4));
   } else {
     return spooler->Peek(remote_path);
@@ -90,7 +90,7 @@ static bool Peek(const string &remote_path) {
 static void Store(const string &local_path, const string &remote_path) {
   if (preload_cache) {
     // Strip "data"
-    // TODO: Fix that! taking assumptions on the path? Wut?!
+    // TODO(rene): Fix that! taking assumptions on the path? Wut?!
     const string dest_path = *preload_cachedir + remote_path.substr(4);
     string tmp_dest;
     FILE *fdest = CreateTempFile(dest_path, 0660, "w", &tmp_dest);
@@ -190,7 +190,7 @@ static void *MainWorker(void *data) {
 static bool Pull(const shash::Any &catalog_hash, const std::string &path) {
   int retval;
   download::Failures dl_retval;
-  assert (shash::kSuffixCatalog == catalog_hash.suffix);
+  assert(shash::kSuffixCatalog == catalog_hash.suffix);
 
   // Check if the catalog already exists
   if (Peek("data/" + catalog_hash.MakePath())) {
@@ -462,7 +462,8 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   // Fetch tag list
   if (!ensemble.manifest->history().IsNull()) {
     shash::Any history_hash = ensemble.manifest->history();
-    const string history_url = *stratum0_url + "/data/" + history_hash.MakePath();
+    const string history_url = *stratum0_url + "/data/"
+                                             + history_hash.MakePath();
     const string history_path = *temp_dir + "/" + history_hash.ToString();
     download::JobInfo download_history(&history_url, false, false,
                                        &history_path,
@@ -551,7 +552,9 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     const string certificate_path =
       "data/" + ensemble.manifest->certificate().MakePath();
     if (!Peek(certificate_path)) {
-      StoreBuffer(ensemble.cert_buf, ensemble.cert_size, certificate_path, true);
+      StoreBuffer(ensemble.cert_buf,
+                  ensemble.cert_size,
+                  certificate_path, true);
     }
     if (preload_cache) {
       bool retval = ensemble.manifest->ExportChecksum(*preload_cachedir, 0660);

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -172,12 +172,12 @@ std::string CommandScrub::CheckPathAndExtractHash(
   if (std::isupper(last_character)) {
     has_object_modifier = true;
   }
-  if (has_object_modifier   &&
-      last_character != 'H' &&  // history
-      last_character != 'C' &&  // catalog
-      last_character != 'P' &&  // partial
-      last_character != 'X' &&  // certificate
-      last_character != 'L')    // micro catalogs (currently only reserved)
+  if (has_object_modifier                          &&
+      last_character != shash::kSuffixHistory      &&
+      last_character != shash::kSuffixCatalog      &&
+      last_character != shash::kSuffixPartial      &&
+      last_character != shash::kSuffixCertificate  &&
+      last_character != shash::kSuffixMicroCatalog)
   {
     PrintAlert(Alerts::kUnexpectedModifier, full_path);
     return "";

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -146,7 +146,8 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
       delete manifest;
       goto sign_fail;
     }
-    shash::Any certificate_hash(manifest->GetHashAlgorithm());
+    shash::Any certificate_hash(manifest->GetHashAlgorithm(),
+                                shash::kSuffixCertificate);
     shash::HashMem((unsigned char *)compr_buf, compr_size, &certificate_hash);
     const string cert_path_tmp = temp_dir + "/cvmfspublisher.tmp";
     if (!CopyMem2Path((unsigned char *)compr_buf, compr_size, cert_path_tmp)) {
@@ -156,8 +157,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
     }
     free(compr_buf);
 
-    const string cert_hash_path = "data" +
-                                  certificate_hash.MakePathExplicit(1, 2) + "X";
+    const string cert_hash_path = "data/" + certificate_hash.MakePath();
     spooler->Upload(cert_path_tmp, cert_hash_path);
 
     // Update manifest

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -227,7 +227,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    *                        object is a successful deletion as well!)
    */
   virtual bool Remove(const shash::Any &hash_to_delete) {
-    return Remove(hash_to_delete.MakePathWithSuffix("data"));
+    return Remove("data/" + hash_to_delete.MakePath());
   }
 
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -81,18 +81,15 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
     UploadJob(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
               const CallbackTN    *callback = NULL) :
-      type(Upload), stream_handle(handle), buffer(buffer), callback(callback),
-      hash_suffix(shash::kSuffixNone) {}
+      type(Upload), stream_handle(handle), buffer(buffer), callback(callback) {}
 
-    UploadJob(UploadStreamHandle   *handle,
-              const shash::Any     &content_hash,
-              const shash::Suffix  &hash_suffix) :
+    UploadJob(UploadStreamHandle  *handle,
+              const shash::Any    &content_hash) :
       type(Commit), stream_handle(handle), buffer(NULL), callback(NULL),
-      content_hash(content_hash), hash_suffix(hash_suffix) {}
+      content_hash(content_hash) {}
 
     UploadJob() :
-      type(Terminate), stream_handle(NULL), buffer(NULL), callback(NULL),
-      hash_suffix(shash::kSuffixNone) {}
+      type(Terminate), stream_handle(NULL), buffer(NULL), callback(NULL) {}
 
     Type                 type;
     UploadStreamHandle  *stream_handle;
@@ -103,7 +100,6 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
     // type=Commit specific fields
     shash::Any           content_hash;
-    shash::Suffix        hash_suffix;
   };
 
  public:
@@ -193,13 +189,11 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    *
    * @param handle        Pointer to a previously acquired UploadStreamHandle
    * @param content_hash  the content hash of the full uploaded data Chunk
-   * @param hash_suffix   the suffix string to be appended to the content hash
    */
   void ScheduleCommit(UploadStreamHandle   *handle,
-                      const shash::Any     &content_hash,
-                      const shash::Suffix  &hash_suffix) {
+                      const shash::Any     &content_hash) {
     ++jobs_in_flight_;
-    upload_queue_.push(UploadJob(handle, content_hash, hash_suffix));
+    upload_queue_.push(UploadJob(handle, content_hash));
   }
 
 

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -54,9 +54,7 @@ void LocalUploader::WorkerThread() {
                job.callback);
         break;
       case UploadJob::Commit:
-        FinalizeStreamedUpload(job.stream_handle,
-                               job.content_hash,
-                               job.hash_suffix);
+        FinalizeStreamedUpload(job.stream_handle, job.content_hash);
         break;
       case UploadJob::Terminate:
         running = false;
@@ -179,8 +177,7 @@ void LocalUploader::Upload(UploadStreamHandle  *handle,
 
 
 void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
-                                           const shash::Any     content_hash,
-                                           const shash::Suffix  hash_suffix) {
+                                           const shash::Any    &content_hash) {
   int retval = 0;
   LocalStreamHandle *local_handle = static_cast<LocalStreamHandle*>(handle);
 
@@ -195,9 +192,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
     return;
   }
 
-  const std::string final_path =
-                "data" + content_hash.MakePathWithSuffix(1, 2, hash_suffix);
-
+  const std::string final_path = "data/" + content_hash.MakePath();
   retval = Move(local_handle->temporary_path.c_str(), final_path.c_str());
   if (retval != 0) {
     const int cpy_errno = errno;

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -60,8 +60,7 @@ class LocalUploader : public AbstractUploader {
               CharBuffer          *buffer,
               const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
-                              const shash::Any     content_hash,
-                              const shash::Suffix  hash_suffix);
+                              const shash::Any    &content_hash);
 
   bool Remove(const std::string &file_to_delete);
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -182,9 +182,7 @@ void S3Uploader::WorkerThread() {
           break;
         case UploadJob::Commit:
           // Note, this block until upload is possible
-          FinalizeStreamedUpload(job.stream_handle,
-                                 job.content_hash,
-                                 job.hash_suffix);
+          FinalizeStreamedUpload(job.stream_handle, job.content_hash);
           break;
         case UploadJob::Terminate:
           running = false;
@@ -481,9 +479,8 @@ void S3Uploader::Upload(UploadStreamHandle  *handle,
 }
 
 
-void S3Uploader::FinalizeStreamedUpload(UploadStreamHandle   *handle,
-                                        const shash::Any     &content_hash,
-                                        const shash::Suffix   hash_suffix) {
+void S3Uploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
+                                        const shash::Any    &content_hash) {
   int retval = 0;
   S3StreamHandle *local_handle = static_cast<S3StreamHandle*>(handle);
 
@@ -511,8 +508,7 @@ void S3Uploader::FinalizeStreamedUpload(UploadStreamHandle   *handle,
   }
 
   // New file name based on content hash
-  std::string final_path("data" +
-                         content_hash.MakePathWithSuffix(1, 2, hash_suffix));
+  std::string final_path("data/" + content_hash.MakePath());
 
   // Choose S3 account and bucket based on the filename
   std::string access_key, secret_key, bucket_name;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -56,9 +56,8 @@ class S3Uploader : public AbstractUploader {
   void Upload(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
               const CallbackTN    *callback = NULL);
-  void FinalizeStreamedUpload(UploadStreamHandle   *handle,
-                              const shash::Any     &content_hash,
-                              const shash::Suffix   hash_suffix);
+  void FinalizeStreamedUpload(UploadStreamHandle  *handle,
+                              const shash::Any    &content_hash);
 
   bool Remove(const std::string &file_to_delete);
   bool Peek(const std::string& path) const;

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -67,10 +67,8 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
  public:
   struct Result {
     Result(MockStreamHandle     *handle,
-           const shash::Any     &computed_content_hash,
-           const shash::Suffix   hash_suffix) :
-      computed_content_hash(computed_content_hash),
-      hash_suffix(hash_suffix)
+           const shash::Any     &computed_content_hash)
+      : computed_content_hash(computed_content_hash)
     {
       RecomputeContentHash(handle->data, handle->nbytes);
 
@@ -99,7 +97,6 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
 
     shash::Any     computed_content_hash;
     shash::Any     recomputed_content_hash;
-    shash::Suffix  hash_suffix;
   };
   typedef std::vector<Result> Results;
 
@@ -130,13 +127,12 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
   }
 
   void FinalizeStreamedUpload(upload::UploadStreamHandle *handle,
-                              const shash::Any            content_hash,
-                              const shash::Suffix         hash_suffix) {
+                              const shash::Any            content_hash) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
     assert(local_handle != NULL);
 
     // summarize the results produced by the FileProcessor
-    results_.push_back(Result(local_handle, content_hash, hash_suffix));
+    results_.push_back(Result(local_handle, content_hash));
 
     // remove the stream handle and fire callback
     const CallbackTN *callback = local_handle->commit_callback;
@@ -392,7 +388,8 @@ class T_FileProcessing : public FileSandbox {
       ExpectedHashes::const_iterator kend = reference_hashes.end();
       for (; k != kend; ++k) {
         if (k->first == j->computed_content_hash) {
-          EXPECT_EQ(k->second, j->hash_suffix) << "hash suffix does not fit";
+          EXPECT_EQ(k->second, j->computed_content_hash.suffix)
+            << "hash suffix does not fit";
           found = true;
           break;
         }

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -366,7 +366,8 @@ class T_FileProcessing : public FileSandbox {
   }
 
   void CheckHashes(const FP_MockUploader::Results &results,
-                   const ExpectedHashStrings   &reference_hash_strings) const {
+                   const ExpectedHashStrings      &reference_hash_strings) const
+  {
     EXPECT_EQ(reference_hash_strings.size(), results.size())
       << "number of generated chunks did not match";
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -507,8 +507,8 @@ class T_ObjectFetcher : public ::testing::Test {
     const std::string txn_path = CreateTempPath(temp_directory + "/blob", 0600);
     ASSERT_TRUE(zlib::CompressPath2Path(tmp_path, txn_path, content_hash)) <<
       "failed to compress file " << tmp_path << " to " << tmp_path;
-    const std::string res_path = backend_storage + "/" +
-                                 content_hash->MakePathWithSuffix();
+    const std::string res_path = backend_storage + "/data/" +
+                                 content_hash->MakePath();
     ASSERT_EQ(0, rename(txn_path.c_str(), res_path.c_str())) <<
       "failed to rename() compressed file " << txn_path << " to " << res_path <<
       " with content hash " << content_hash->ToString() <<

--- a/test/unittests/t_shash.cc
+++ b/test/unittests/t_shash.cc
@@ -149,80 +149,38 @@ TEST(T_Shash, MakePathExplicit) {
   shash::Any hash_md5(shash::kMd5);
   hash_md5.Randomize(&prng);
   ASSERT_FALSE(hash_md5.IsNull());
-  EXPECT_EQ("/91/3969a1ae06052779065b87eb53cb64",
+  EXPECT_EQ("91/3969a1ae06052779065b87eb53cb64",
             hash_md5.MakePathExplicit(1, 2));
-  EXPECT_EQ("/913/969/a1ae06052779065b87eb53cb64",
+  EXPECT_EQ("913/969/a1ae06052779065b87eb53cb64",
             hash_md5.MakePathExplicit(2, 3));
-  EXPECT_EQ("/913969a1ae06052779065b87eb53cb64",
+  EXPECT_EQ("913969a1ae06052779065b87eb53cb64",
             hash_md5.MakePathExplicit(0, 3));
-  EXPECT_EQ("/9/1/3/969a1ae06052779065b87eb53cb64",
+  EXPECT_EQ("9/1/3/969a1ae06052779065b87eb53cb64",
             hash_md5.MakePathExplicit(3, 1));
 
   shash::Any hash_sha1(shash::kSha1);
   hash_sha1.Randomize(&prng);
   ASSERT_FALSE(hash_sha1.IsNull());
-  EXPECT_EQ("/c9/116bb5576d69586386887c6a9eeeb569a406a1",
+  EXPECT_EQ("c9/116bb5576d69586386887c6a9eeeb569a406a1",
             hash_sha1.MakePathExplicit(1, 2));
-  EXPECT_EQ("/c91/16b/b5576d69586386887c6a9eeeb569a406a1",
+  EXPECT_EQ("c91/16b/b5576d69586386887c6a9eeeb569a406a1",
             hash_sha1.MakePathExplicit(2, 3));
-  EXPECT_EQ("/c9116bb5576d69586386887c6a9eeeb569a406a1",
+  EXPECT_EQ("c9116bb5576d69586386887c6a9eeeb569a406a1",
             hash_sha1.MakePathExplicit(0, 3));
-  EXPECT_EQ("/c/9/1/16bb5576d69586386887c6a9eeeb569a406a1",
+  EXPECT_EQ("c/9/1/16bb5576d69586386887c6a9eeeb569a406a1",
             hash_sha1.MakePathExplicit(3, 1));
 
   shash::Any hash_rmd160(shash::kRmd160);
   hash_rmd160.Randomize(&prng);
   ASSERT_FALSE(hash_rmd160.IsNull());
-  EXPECT_EQ("/2e/5beea626f6ddef63d56405371f80732782086f-rmd160",
+  EXPECT_EQ("2e/5beea626f6ddef63d56405371f80732782086f-rmd160",
             hash_rmd160.MakePathExplicit(1, 2));
-  EXPECT_EQ("/2e5/bee/a626f6ddef63d56405371f80732782086f-rmd160",
+  EXPECT_EQ("2e5/bee/a626f6ddef63d56405371f80732782086f-rmd160",
             hash_rmd160.MakePathExplicit(2, 3));
-  EXPECT_EQ("/2e5beea626f6ddef63d56405371f80732782086f-rmd160",
+  EXPECT_EQ("2e5beea626f6ddef63d56405371f80732782086f-rmd160",
             hash_rmd160.MakePathExplicit(0, 3));
-  EXPECT_EQ("/2/e/5/beea626f6ddef63d56405371f80732782086f-rmd160",
+  EXPECT_EQ("2/e/5/beea626f6ddef63d56405371f80732782086f-rmd160",
             hash_rmd160.MakePathExplicit(3, 1));
-}
-
-
-TEST(T_Shash, MakePathExplicitWithPrefix) {
-  Prng prng;
-  prng.InitSeed(42);
-
-  shash::Any hash_md5(shash::kMd5);
-  hash_md5.Randomize(&prng);
-  ASSERT_FALSE(hash_md5.IsNull());
-  EXPECT_EQ("dataA/91/3969a1ae06052779065b87eb53cb64",
-            hash_md5.MakePathExplicit(1, 2, "dataA"));
-  EXPECT_EQ("dataB/913/969/a1ae06052779065b87eb53cb64",
-            hash_md5.MakePathExplicit(2, 3, "dataB"));
-  EXPECT_EQ("dataC/913969a1ae06052779065b87eb53cb64",
-            hash_md5.MakePathExplicit(0, 3, "dataC"));
-  EXPECT_EQ("dataD/9/1/3/969a1ae06052779065b87eb53cb64",
-            hash_md5.MakePathExplicit(3, 1, "dataD"));
-
-  shash::Any hash_sha1(shash::kSha1);
-  hash_sha1.Randomize(&prng);
-  ASSERT_FALSE(hash_sha1.IsNull());
-  EXPECT_EQ("dataA/c9/116bb5576d69586386887c6a9eeeb569a406a1",
-            hash_sha1.MakePathExplicit(1, 2, "dataA"));
-  EXPECT_EQ("dataB/c91/16b/b5576d69586386887c6a9eeeb569a406a1",
-            hash_sha1.MakePathExplicit(2, 3, "dataB"));
-  EXPECT_EQ("dataC/c9116bb5576d69586386887c6a9eeeb569a406a1",
-            hash_sha1.MakePathExplicit(0, 3, "dataC"));
-  EXPECT_EQ("dataD/c/9/1/16bb5576d69586386887c6a9eeeb569a406a1",
-            hash_sha1.MakePathExplicit(3, 1, "dataD"));
-
-  shash::Any hash_rmd160(shash::kRmd160);
-  hash_rmd160.Randomize(&prng);
-  ASSERT_FALSE(hash_rmd160.IsNull());
-  EXPECT_EQ("dataA/2e/5beea626f6ddef63d56405371f80732782086f-rmd160",
-            hash_rmd160.MakePathExplicit(1, 2, "dataA"));
-  EXPECT_EQ("dataB/2e5/bee/a626f6ddef63d56405371f80732782086f-rmd160",
-            hash_rmd160.MakePathExplicit(2, 3, "dataB"));
-  EXPECT_EQ("dataC/2e5beea626f6ddef63d56405371f80732782086f-rmd160",
-            hash_rmd160.MakePathExplicit(0, 3, "dataC"));
-  EXPECT_EQ("dataD/2/e/5/beea626f6ddef63d56405371f80732782086f-rmd160",
-            hash_rmd160.MakePathExplicit(3, 1, "dataD"));
 }
 
 
@@ -233,37 +191,58 @@ TEST(T_Shash, MakePathDefault) {
   shash::Any hash_md5(shash::kMd5);
   hash_md5.Randomize(&prng);
   ASSERT_FALSE(hash_md5.IsNull());
-  EXPECT_EQ("data/95/9a032bcfdd999742a321eb0daeddd5",  hash_md5.MakePath());
-  EXPECT_EQ("dataX/95/9a032bcfdd999742a321eb0daeddd5",
-            hash_md5.MakePath("dataX"));
-  EXPECT_EQ("dataY/95/9a032bcfdd999742a321eb0daeddd5",
-            hash_md5.MakePath("dataY"));
-  EXPECT_EQ("dataZ/95/9a032bcfdd999742a321eb0daeddd5",
-            hash_md5.MakePath("dataZ"));
+  EXPECT_EQ("95/9a032bcfdd999742a321eb0daeddd5", hash_md5.MakePath());
+  hash_md5.suffix = 'Q';
+  EXPECT_EQ("95/9a032bcfdd999742a321eb0daeddd5Q", hash_md5.MakePath());
 
   shash::Any hash_sha1(shash::kSha1);
   hash_sha1.Randomize(&prng);
   ASSERT_FALSE(hash_sha1.IsNull());
-  EXPECT_EQ("data/cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068",
-            hash_sha1.MakePath());
-  EXPECT_EQ("dataX/cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068",
-            hash_sha1.MakePath("dataX"));
-  EXPECT_EQ("dataY/cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068",
-            hash_sha1.MakePath("dataY"));
-  EXPECT_EQ("dataZ/cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068",
-            hash_sha1.MakePath("dataZ"));
+  EXPECT_EQ("cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068", hash_sha1.MakePath());
+  hash_sha1.suffix = 'V';
+  EXPECT_EQ("cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068V", hash_sha1.MakePath());
 
   shash::Any hash_rmd160(shash::kRmd160);
   hash_rmd160.Randomize(&prng);
   ASSERT_FALSE(hash_rmd160.IsNull());
-  EXPECT_EQ("data/aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
+  EXPECT_EQ("aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
             hash_rmd160.MakePath());
-  EXPECT_EQ("dataX/aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
-            hash_rmd160.MakePath("dataX"));
-  EXPECT_EQ("dataY/aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
-            hash_rmd160.MakePath("dataY"));
-  EXPECT_EQ("dataZ/aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
-            hash_rmd160.MakePath("dataZ"));
+  hash_rmd160.suffix = 'C';
+  EXPECT_EQ("aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160C",
+            hash_rmd160.MakePath());
+}
+
+
+TEST(T_Shash, MakePathWithoutSuffix) {
+  Prng prng;
+  prng.InitSeed(27111987);
+
+  shash::Any hash_md5(shash::kMd5);
+  hash_md5.Randomize(&prng);
+  ASSERT_FALSE(hash_md5.IsNull());
+  EXPECT_EQ("95/9a032bcfdd999742a321eb0daeddd5",
+            hash_md5.MakePathWithoutSuffix());
+  hash_md5.suffix = 'Q';
+  EXPECT_EQ("95/9a032bcfdd999742a321eb0daeddd5",
+            hash_md5.MakePathWithoutSuffix());
+
+  shash::Any hash_sha1(shash::kSha1);
+  hash_sha1.Randomize(&prng);
+  ASSERT_FALSE(hash_sha1.IsNull());
+  EXPECT_EQ("cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068",
+            hash_sha1.MakePathWithoutSuffix());
+  hash_sha1.suffix = 'V';
+  EXPECT_EQ("cf/3e56cf3da37ad17cf1f2c2ff5d86497fc29068",
+            hash_sha1.MakePathWithoutSuffix());
+
+  shash::Any hash_rmd160(shash::kRmd160);
+  hash_rmd160.Randomize(&prng);
+  ASSERT_FALSE(hash_rmd160.IsNull());
+  EXPECT_EQ("aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
+            hash_rmd160.MakePathWithoutSuffix());
+  hash_rmd160.suffix = 'C';
+  EXPECT_EQ("aa/1deda59d5329553580d78fcd0b393157a5d28e-rmd160",
+            hash_rmd160.MakePathWithoutSuffix());
 }
 
 
@@ -276,78 +255,42 @@ TEST(T_Shash, HashSuffix) {
   hash_md5.suffix = 'A';
   ASSERT_FALSE(hash_md5.IsNull());
   ASSERT_TRUE(hash_md5.HasSuffix());
+  EXPECT_EQ("2ec5fe3c17045abdb136a5e6a913e32a",
+            hash_md5.ToString());
   EXPECT_EQ("2ec5fe3c17045abdb136a5e6a913e32aA",
             hash_md5.ToStringWithSuffix());
-  EXPECT_EQ("data/2e/c5fe3c17045abdb136a5e6a913e32aA",
-            hash_md5.MakePathWithSuffix());
-  EXPECT_EQ("dataX/2e/c5fe3c17045abdb136a5e6a913e32aA",
-            hash_md5.MakePathWithSuffix("dataX"));
-  EXPECT_EQ("dataY/2e/c5fe3c17045abdb136a5e6a913e32aA",
-            hash_md5.MakePathWithSuffix("dataY"));
-  EXPECT_EQ("dataZ/2e/c5fe3c17045abdb136a5e6a913e32aA",
-            hash_md5.MakePathWithSuffix("dataZ"));
-  EXPECT_EQ("dataX/2e/c5fe3c17045abdb136a5e6a913e32a",
-            hash_md5.MakePath("dataX"));
-  EXPECT_EQ("dataY/2e/c5fe3c17045abdb136a5e6a913e32a",
-            hash_md5.MakePath("dataY"));
-  EXPECT_EQ("dataZ/2e/c5fe3c17045abdb136a5e6a913e32a",
-            hash_md5.MakePath("dataZ"));
-  EXPECT_EQ("/2e/c5fe3c17045abdb136a5e6a913e32aP",
-            hash_md5.MakePathWithSuffix(1, 2, shash::kSuffixPartial));
-  EXPECT_EQ("/2ec/5fe3c17045abdb136a5e6a913e32aC",
-            hash_md5.MakePathWithSuffix(1, 3, shash::kSuffixCatalog));
+  EXPECT_EQ("2e/c5fe3c17045abdb136a5e6a913e32a",
+            hash_md5.MakePathWithoutSuffix());
+  EXPECT_EQ("2e/c5fe3c17045abdb136a5e6a913e32aA",
+            hash_md5.MakePath());
 
   shash::Any hash_sha1(shash::kSha1);
   hash_sha1.Randomize(&prng);
   hash_sha1.suffix = 'B';
   ASSERT_FALSE(hash_sha1.IsNull());
   ASSERT_TRUE(hash_sha1.HasSuffix());
+  EXPECT_EQ("b75ae68b53d2fc149b77e504132d37569b7e766b",
+            hash_sha1.ToString());
   EXPECT_EQ("b75ae68b53d2fc149b77e504132d37569b7e766bB",
             hash_sha1.ToStringWithSuffix());
-  EXPECT_EQ("data/b7/5ae68b53d2fc149b77e504132d37569b7e766bB",
-            hash_sha1.MakePathWithSuffix());
-  EXPECT_EQ("dataX/b7/5ae68b53d2fc149b77e504132d37569b7e766bB",
-            hash_sha1.MakePathWithSuffix("dataX"));
-  EXPECT_EQ("dataY/b7/5ae68b53d2fc149b77e504132d37569b7e766bB",
-            hash_sha1.MakePathWithSuffix("dataY"));
-  EXPECT_EQ("dataZ/b7/5ae68b53d2fc149b77e504132d37569b7e766bB",
-            hash_sha1.MakePathWithSuffix("dataZ"));
-  EXPECT_EQ("dataX/b7/5ae68b53d2fc149b77e504132d37569b7e766b",
-            hash_sha1.MakePath("dataX"));
-  EXPECT_EQ("dataY/b7/5ae68b53d2fc149b77e504132d37569b7e766b",
-            hash_sha1.MakePath("dataY"));
-  EXPECT_EQ("dataZ/b7/5ae68b53d2fc149b77e504132d37569b7e766b",
-            hash_sha1.MakePath("dataZ"));
-  EXPECT_EQ("/b7/5ae68b53d2fc149b77e504132d37569b7e766bP",
-            hash_sha1.MakePathWithSuffix(1, 2, shash::kSuffixPartial));
-  EXPECT_EQ("/b75/ae68b53d2fc149b77e504132d37569b7e766bC",
-            hash_sha1.MakePathWithSuffix(1, 3, shash::kSuffixCatalog));
+  EXPECT_EQ("b7/5ae68b53d2fc149b77e504132d37569b7e766b",
+            hash_sha1.MakePathWithoutSuffix());
+  EXPECT_EQ("b7/5ae68b53d2fc149b77e504132d37569b7e766bB",
+            hash_sha1.MakePath());
 
   shash::Any hash_rmd160(shash::kRmd160);
   hash_rmd160.Randomize(&prng);
   hash_rmd160.suffix = 'C';
   ASSERT_FALSE(hash_rmd160.IsNull());
   ASSERT_TRUE(hash_rmd160.HasSuffix());
+  EXPECT_EQ("a74a19bd6162343a21c8590aa9cebca9014c636d-rmd160",
+            hash_rmd160.ToString());
   EXPECT_EQ("a74a19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
             hash_rmd160.ToStringWithSuffix());
-  EXPECT_EQ("data/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
-            hash_rmd160.MakePathWithSuffix());
-  EXPECT_EQ("dataX/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
-            hash_rmd160.MakePathWithSuffix("dataX"));
-  EXPECT_EQ("dataY/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
-            hash_rmd160.MakePathWithSuffix("dataY"));
-  EXPECT_EQ("dataZ/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
-            hash_rmd160.MakePathWithSuffix("dataZ"));
-  EXPECT_EQ("dataX/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160",
-            hash_rmd160.MakePath("dataX"));
-  EXPECT_EQ("dataY/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160",
-            hash_rmd160.MakePath("dataY"));
-  EXPECT_EQ("dataZ/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160",
-            hash_rmd160.MakePath("dataZ"));
-  EXPECT_EQ("/a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160P",
-            hash_rmd160.MakePathWithSuffix(1, 2, shash::kSuffixPartial));
-  EXPECT_EQ("/a74a/19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
-            hash_rmd160.MakePathWithSuffix(1, 4, shash::kSuffixCatalog));
+  EXPECT_EQ("a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160",
+            hash_rmd160.MakePathWithoutSuffix());
+  EXPECT_EQ("a7/4a19bd6162343a21c8590aa9cebca9014c636d-rmd160C",
+            hash_rmd160.MakePath());
 }
 
 

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -66,8 +66,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
   }
 
   void FinalizeStreamedUpload(upload::UploadStreamHandle *abstract_handle,
-                              const shash::Any            content_hash,
-                              const shash::Suffix         hash_suffix) {
+                              const shash::Any            content_hash) {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->commits++;
@@ -169,7 +168,7 @@ TEST(T_UploadFacility, CallbacksSlow) {
   EXPECT_EQ(0, chunk_upload_complete_callback_calls);
   EXPECT_EQ(2, buffer_upload_complete_callback_calls);
 
-  uploader->ScheduleCommit(handle, shash::Any(), shash::kSuffixNone);
+  uploader->ScheduleCommit(handle, shash::Any());
 
   uploader->WaitForUpload();
   uploader->TearDown();
@@ -249,7 +248,7 @@ TEST(T_UploadFacility, DataBlockBasicOrdering) {
       AbstractUploader::MakeCallback(&BufferUploadCompleteCallback_T_Ordering));
   }
 
-  uploader->ScheduleCommit(handle, shash::Any(), shash::kSuffixNone);
+  uploader->ScheduleCommit(handle, shash::Any());
   uploader->WaitForUpload();
   uploader->TearDown();
 

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -820,10 +820,9 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
   EXPECT_EQ(0u,
             this->delegate_.streamed_upload_complete_invocations);
 
-  shash::Any content_hash(shash::kSha1);
+  shash::Any content_hash(shash::kSha1, 'A');
   content_hash.Randomize(42);
-  const shash::Suffix hash_suffix = 'A';
-  this->uploader_->ScheduleCommit(handle, content_hash, hash_suffix);
+  this->uploader_->ScheduleCommit(handle, content_hash);
   this->uploader_->WaitForUpload();
 
   EXPECT_EQ(number_of_buffers,
@@ -847,7 +846,6 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
 TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
   const unsigned int  number_of_files        = 100;
   const unsigned int  max_buffers_per_stream = 15;
-  const shash::Suffix hash_suffix            = 'K';
   typename TestFixture::BufferStreams streams =
       TestFixture::MakeRandomizedBufferStreams(number_of_files,
                                                max_buffers_per_stream,
@@ -891,8 +889,7 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
       buffers.erase(buffers.begin());
     } else {
       this->uploader_->ScheduleCommit(current_handle.handle,
-                                      current_handle.content_hash,
-                                      hash_suffix);
+                                      current_handle.content_hash);
       j = active_streams.erase(j);
     }
   }

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -831,8 +831,7 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
   EXPECT_EQ(1u,
             this->delegate_.streamed_upload_complete_invocations);
 
-  const std::string dest = "data" +
-                           content_hash.MakePathExplicit(1, 2) + hash_suffix;
+  const std::string dest = "data/" + content_hash.MakePath();
   EXPECT_TRUE(TestFixture::CheckFile(dest));
   TestFixture::CompareBuffersAndFileContents(
       buffers,
@@ -877,7 +876,7 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
   typename TestFixture::BufferStreams::iterator j    = active_streams.begin();
   unsigned int number_of_buffers                     = 0;
   while (!active_streams.empty()) {
-    typename TestFixture::Buffers       &buffers        = j->first;
+    typename TestFixture::Buffers             &buffers        = j->first;
     const typename TestFixture::StreamHandle  &current_handle = j->second;
 
     if (!buffers.empty()) {
@@ -892,8 +891,8 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
       buffers.erase(buffers.begin());
     } else {
       this->uploader_->ScheduleCommit(current_handle.handle,
-                                current_handle.content_hash,
-                                hash_suffix);
+                                      current_handle.content_hash,
+                                      hash_suffix);
       j = active_streams.erase(j);
     }
   }
@@ -909,8 +908,7 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
   typename TestFixture::BufferStreams::const_iterator kend = streams.end();
   for (; k != kend; ++k) {
     const shash::Any &content_hash = k->second.content_hash;
-    const std::string dest =
-        "data" + content_hash.MakePathWithSuffix(1, 2, hash_suffix);
+    const std::string dest = "data/" + content_hash.MakePath();
     EXPECT_TRUE(TestFixture::CheckFile(dest));
     TestFixture::CompareBuffersAndFileContents(
         k->first,

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -271,9 +271,8 @@ manifest::Manifest* MockObjectFetcher::FetchManifest() {
   return manifest;
 }
 
-bool MockObjectFetcher::Fetch(const shash::Any    &object_hash,
-                              const shash::Suffix  hash_suffix,
-                              std::string         *file_path) {
+bool MockObjectFetcher::Fetch(const shash::Any &object_hash,
+                              std::string      *file_path) {
   assert(file_path != NULL);
   *file_path = object_hash.ToString();
   return true;

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -553,10 +553,7 @@ struct object_fetcher_traits<MockObjectFetcher> {
 class MockObjectFetcher : public AbstractObjectFetcher<MockObjectFetcher> {
  public:
   manifest::Manifest* FetchManifest();
-
-  bool Fetch(const shash::Any    &object_hash,
-             const shash::Suffix  hash_suffix,
-             std::string         *file_path);
+  bool Fetch(const shash::Any &object_hash, std::string *file_path);
 };
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -126,8 +126,7 @@ class AbstractMockUploader : public upload::AbstractUploader {
           break;
         case UploadJob::Commit:
           FinalizeStreamedUpload(job.stream_handle,
-                                 job.content_hash,
-                                 job.hash_suffix);
+                                 job.content_hash);
           break;
         case UploadJob::Terminate:
           running = false;
@@ -160,8 +159,8 @@ class AbstractMockUploader : public upload::AbstractUploader {
   }
 
   virtual void FinalizeStreamedUpload(upload::UploadStreamHandle *handle,
-                                      const shash::Any            content_hash,
-                                      const shash::Suffix         hash_suffix) {
+                                      const shash::Any            content_hash)
+  {
     assert(AbstractMockUploader::not_implemented);
   }
 


### PR DESCRIPTION
This is the follow-up to a [Pull Request](https://github.com/cvmfs/cvmfs/pull/602) that went into 2.1.20 which made the `Digest<>` aware of the hash suffix (i.e. **C**, **H**, **X**, ...).

Currently, in many places you would see code like:
```C++
// const shash::Any hash("b09b1bcf01ee6414525f3307d1f0bbf7a6d8ade3");
const string url = "/data" + hash.MakePathExplicit(1, 2) + "C";
```
This patch aims for the elimination of shared knowledge of how CAS paths are derived from hashes. Namely, the two magic numbers `1` and `2` in `MakePathExplicit()` and the need of appending a suffix to it, depending on what is going to be fetched. Furthermore `MakePathExplicit()` did emit an absolute path like */b0/9b1...* for unclear reasons.

This patch changes the above call to:
```C++
// const shash::Any hash("b09b1bcf01ee6414525f3307d1f0bbf7a6d8ade3", shash::kSuffixCatalog);
const string url = "/data/" + hash.MakePath();
```
The hash suffix is specified only once when creating the hash object, because this should be the place where one knows most about the object that will be referenced by this specific hash. Furthermore hashes are never created 'out of the blue', but fall out of other data structures like `Catalog`, `Manifest` or `History`. These classes can take care of creating hash objects with the right suffixes internally, benefitting information hiding.

Furthermore the magic numbers (`1`, `2`) are removed and hidden inside `MakePath()` because they are the same throughout the code base anyway. Also `MakePath()` now generates a relative path like *b0/9b1...C* that can be easily prepended by any other paths or URLs in the using code.

There is a second method `Digest<>::MakePathWithoutSuffix()` that omits the hash suffix (if there is one specified) which is necessary for the local file cache accesses.

Stringifying hashes with `Digest<>::ToString()` does omit the suffix while `Digest<>::ToStringWithSuffix()` appends it. I argue that the suffix is primarily interesting for the CAS path creation and should not appear in the default string representation of a hash.

I am aware that this is quite a surgery in the code, but it greatly improves readability and flexibility. For instance, passing an `shash::Any` to an `ObjectFetcher::Fetch()` method would now be universal, since the caller doesn't need to be aware of the type of object to be fetched anymore. Also it simplifies many method signatures where `shash::Any` and `shash::Suffix` were handed in separately.

Throughout the code `Digest<>::MakePathExplicit()` was used before and I changed the signature of this method, making sure to properly find all occurrences.