### PR TITLE
FIX: cvmfs_server check -c doesn't ignore partials

### DIFF
--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -340,20 +340,22 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
         aggregated_file_size += this_chunk.size();
 
         // are all data chunks in the data store?
-        const shash::Any &chunk_hash = this_chunk.content_hash();
-        const string chunk_path = "data"                            +
-                                  chunk_hash.MakePathExplicit(1, 2) +
-                                  shash::kSuffixPartial;
-        if (!Exists(chunk_path)) {
-          const std::string chunk_name = this_chunk.content_hash().ToString() +
-                                         shash::kSuffixPartial;
-          LogCvmfs(kLogCvmfs, kLogStderr, "partial data chunk %s (%s -> "
-                                          "offset: %d | size: %d) missing",
-                   chunk_name.c_str(),
-                   full_path.c_str(),
-                   this_chunk.offset(),
-                   this_chunk.size());
-          retval = false;
+        if (check_chunks) {
+          const shash::Any &chunk_hash = this_chunk.content_hash();
+          const string chunk_path = "data"                            +
+                                    chunk_hash.MakePathExplicit(1, 2) +
+                                    shash::kSuffixPartial;
+          if (!Exists(chunk_path)) {
+            const std::string chunk_name =
+                   this_chunk.content_hash().ToString() + shash::kSuffixPartial;
+            LogCvmfs(kLogCvmfs, kLogStderr, "partial data chunk %s (%s -> "
+                                            "offset: %d | size: %d) missing",
+                     chunk_name.c_str(),
+                     full_path.c_str(),
+                     this_chunk.offset(),
+                     this_chunk.size());
+            retval = false;
+          }
         }
       }
 


### PR DESCRIPTION
Fixes the problem described in [CVM-842](https://sft.its.cern.ch/jira/browse/CVM-842). When running `cvmfs_server check -c` no checks for the existence of data chunks should be performed. However, partial file chunks (with hash suffix `P`) were still checked.