### PR TITLE
Solved some compiling and test problems in some platforms

### DIFF
--- a/cvmfs/fs_traversal.h
+++ b/cvmfs/fs_traversal.h
@@ -46,7 +46,7 @@ class FileSystemTraversal {
   VoidCallback fn_new_file;
   VoidCallback fn_new_symlink;
   VoidCallback fn_new_socket;
-  VoidCallback fn_new_blocked_dev;
+  VoidCallback fn_new_block_dev;
   VoidCallback fn_new_fifo;
 
   /**
@@ -90,7 +90,7 @@ class FileSystemTraversal {
     fn_new_file(NULL),
     fn_new_symlink(NULL),
     fn_new_socket(NULL),
-    fn_new_blocked_dev(NULL),
+    fn_new_block_dev(NULL),
     fn_new_fifo(NULL),
     fn_ignore_file(NULL),
     fn_new_dir_prefix(NULL),
@@ -112,7 +112,7 @@ class FileSystemTraversal {
            fn_new_file != NULL ||
            fn_new_symlink != NULL ||
            fn_new_dir_prefix != NULL ||
-           fn_new_blocked_dev != NULL ||
+           fn_new_block_dev != NULL ||
            fn_new_fifo != NULL ||
            fn_new_socket != NULL);
 
@@ -198,7 +198,7 @@ class FileSystemTraversal {
       } else if (S_ISBLK(info.st_mode)) {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg,
             "passing blocked device %s/%s", path.c_str(), dit->d_name);
-        Notify(fn_new_blocked_dev, path, dit->d_name);
+        Notify(fn_new_block_dev, path, dit->d_name);
       } else if (S_ISFIFO(info.st_mode)) {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing FIFO %s/%s",
                  path.c_str(), dit->d_name);

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -29,7 +29,7 @@ class T_FsTraversal : public ::testing::Test {
       Untouched,
       Unspecified,
       Socket,
-      BlockedDevice,
+      BlockDevice,
       FIFO
     };
 
@@ -48,7 +48,7 @@ class T_FsTraversal : public ::testing::Test {
       dir_prefix    = false;
       dir_postfix   = false;
       socket_found  = false;
-      blocked_dev_found   = false;
+      block_dev_found   = false;
       fifo_found    = false;
     }
 
@@ -93,8 +93,8 @@ class T_FsTraversal : public ::testing::Test {
         case Socket:
           EXPECT_TRUE(socket_found)   << path;
           break;
-        case BlockedDevice:
-          EXPECT_TRUE(blocked_dev_found)    << path;
+        case BlockDevice:
+          EXPECT_TRUE(block_dev_found)    << path;
           break;
         case FIFO:
           EXPECT_TRUE(fifo_found)     << path;
@@ -115,7 +115,7 @@ class T_FsTraversal : public ::testing::Test {
     bool dir_prefix;
     bool dir_postfix;
     bool socket_found;
-    bool blocked_dev_found;
+    bool block_dev_found;
     bool fifo_found;
   };
 
@@ -184,7 +184,7 @@ class T_FsTraversal : public ::testing::Test {
     traverse->fn_new_dir_prefix  = &DelegateT::DirPrefix;
     traverse->fn_new_dir_postfix = &DelegateT::DirPostfix;
     traverse->fn_new_socket      = &DelegateT::Socket;
-    traverse->fn_new_blocked_dev = &DelegateT::BlockedDevice;
+    traverse->fn_new_block_dev   = &DelegateT::BlockDevice;
     traverse->fn_new_fifo        = &DelegateT::Fifo;
   }
 
@@ -377,10 +377,10 @@ class BaseTraversalDelegate {
       checklist.fifo_found = true;
   }
 
-  virtual void BlockedDevice(const std::string &relative_path,
+  virtual void BlockDevice(const std::string &relative_path,
         const std::string &dir_name) {
       Checklist& checklist = GetChecklist(CombinePath(relative_path, dir_name));
-      checklist.blocked_dev_found = true;
+      checklist.block_dev_found = true;
   }
 
   virtual void Check() const {
@@ -647,28 +647,28 @@ TEST_F(T_FsTraversal, SteeredTraversal) {
 class CustomDelegate {
  public:
   CustomDelegate() :
-    num_blocked_dev(0) {}
-  virtual void BlockedDevice(const std::string &relative_path,
+    num_block_dev(0) {}
+  virtual void BlockDevice(const std::string &relative_path,
       const std::string &dir_name) {
-    ++num_blocked_dev;
+    ++num_block_dev;
   }
 
   virtual ~CustomDelegate() {}
 
   int getNumBlockedDev() const {
-    return num_blocked_dev;
+    return num_block_dev;
   }
 
  private:
-  int num_blocked_dev;
+  int num_block_dev;
 };
 
-TEST_F(T_FsTraversal, BlockedDevice) {
+TEST_F(T_FsTraversal, BlockDevice) {
   CustomDelegate delegate;
   FileSystemTraversal<CustomDelegate> traverse(&delegate,
                                                 "/dev",
                                                 true);
-  traverse.fn_new_blocked_dev = &CustomDelegate::BlockedDevice;
+  traverse.fn_new_block_dev = &CustomDelegate::BlockDevice;
   traverse.Recurse("/dev");
   EXPECT_LT(0, delegate.getNumBlockedDev());
 }

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -648,7 +648,7 @@ TEST_F(T_Util, CreateTempDir) {
 
   EXPECT_EQ("", directory = CreateTempDir("/fakepath/myfakedirectory"));
   EXPECT_FALSE(DirectoryExists(directory));
-  EXPECT_NE("", directory = CreateTempDir(sandbox +"/creatempdirectory"));
+  EXPECT_NE("", directory = CreateTempDir(sandbox + "/creatempdirectory"));
   EXPECT_TRUE(DirectoryExists(directory));
 }
 
@@ -720,7 +720,7 @@ TEST_F(T_Util, StringifyDouble) {
 
 TEST_F(T_Util, StringifyTime) {
   time_t now = time(NULL);
-  time_t other = 126865826343;
+  time_t other = 1263843;
 
   EXPECT_EQ(GetTimeString(now, true), StringifyTime(now, true));
   EXPECT_EQ(GetTimeString(now, false), StringifyTime(now, false));
@@ -1066,19 +1066,20 @@ TEST_F(T_Util, Shell) {
   int fd_stdout;
   int fd_stderr;
   const int buffer_size = 100;
-  char buffer[buffer_size];
+  char *buffer = static_cast<char*>(scalloc(buffer_size, sizeof(char)));
 
   EXPECT_TRUE(Shell(&fd_stdin, &fd_stdout, &fd_stderr));
   string path = sandbox + "/" + "newfolder";
   string command = "mkdir -p " + path +  " && cd " + path + " && pwd\n";
   WritePipe(fd_stdin, command.c_str(), command.length());
   ReadPipe(fd_stdout, buffer, path.length());
-  string result(buffer);
+  string result(buffer, 0, path.length());
 
   EXPECT_EQ(path, result);
   close(fd_stdin);
   close(fd_stdout);
   close(fd_stderr);
+  free(buffer);
 }
 
 TEST_F(T_Util, ManagedExecCommandLine) {


### PR DESCRIPTION
* Overflow in T_Util.StringifyTime
* \0 character in T_Util.Shell
* Check that a directory is readable in T_FsTraversal.BlockDevice to avoid insufficient permissions errors.

By the way, when running the non-slow tests now I see this in the end:

[----------] Global test environment tear-down
[==========] 492 tests from 50 test cases ran. (51419 ms total)
[  PASSED  ] 492 tests.

  YOU HAVE 1 DISABLED TEST

And it looks like that disabled test is not one of the new ones. Am I missing something?