### PR TITLE
FIX: Garbage Collection leaks Empty Temp File

### DIFF
--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -183,7 +183,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::CheckPreservedRevisions()
 
 template <class CatalogTraversalT, class HashFilterT>
 bool GarbageCollector<CatalogTraversalT, HashFilterT>::
-SweepCondemnedCatalogTree()
+  SweepCondemnedCatalogTree()
 {
   if (configuration_.verbose) {
     LogCvmfs(kLogGc, kLogStdout, "Sweeping Condemned Catalog Graphs");

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -235,6 +235,8 @@ class LocalObjectFetcher :
                                         "to '%s' (errno: %d)",
                object_hash.ToString().c_str(), source.c_str(),
                file_path->c_str(), errno);
+      unlink(file_path->c_str());
+      file_path->clear();
     }
 
     return success;
@@ -366,6 +368,8 @@ class HttpObjectFetcher :
                                         "%s to '%s' (%d - %s)",
                object_hash.ToString().c_str(), object_file->c_str(),
                retval, Code2Ascii(retval));
+      unlink(object_file->c_str());
+      object_file->clear();
     }
 
     return success;

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -230,6 +230,8 @@ class LocalObjectFetcher :
     // decompress the requested object file
     const bool success = zlib::DecompressPath2File(source, f);
     fclose(f);
+
+    // check the decompression success and remove the temporary file otherwise
     if (!success) {
       LogCvmfs(kLogDownload, kLogDebug, "failed to extract object %s from '%s' "
                                         "to '%s' (errno: %d)",
@@ -362,7 +364,7 @@ class HttpObjectFetcher :
     const bool success = (retval == download::kFailOk);
     fclose(f);
 
-    // error checking
+    // check if download worked and remove temporary file if not
     if (!success) {
       LogCvmfs(kLogDownload, kLogDebug, "failed to download object "
                                         "%s to '%s' (%d - %s)",

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -229,6 +229,7 @@ class LocalObjectFetcher :
 
     // decompress the requested object file
     const bool success = zlib::DecompressPath2File(source, f);
+    fclose(f);
     if (!success) {
       LogCvmfs(kLogDownload, kLogDebug, "failed to extract object %s from '%s' "
                                         "to '%s' (errno: %d)",
@@ -236,7 +237,6 @@ class LocalObjectFetcher :
                file_path->c_str(), errno);
     }
 
-    fclose(f);
     return success;
   }
 
@@ -358,6 +358,7 @@ class HttpObjectFetcher :
     download::JobInfo download_catalog(&url, true, false, f, &object_hash);
     download::Failures retval = download_manager_->Fetch(&download_catalog);
     const bool success = (retval == download::kFailOk);
+    fclose(f);
 
     // error checking
     if (!success) {
@@ -367,7 +368,6 @@ class HttpObjectFetcher :
                retval, Code2Ascii(retval));
     }
 
-    fclose(f);
     return success;
   }
 

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -291,5 +291,35 @@ cvmfs_run_test() {
   echo "check that the temporary scratch directory is empty"
   [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
 
+  # ============================================================================
+
+  echo "perform another basic garbage collection as dryrun (empty tmp dir regression)"
+  cvmfs_server gc -ldf $CVMFS_TEST_REPO || return 18
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
+  echo "check if shakespeare is gone"
+  peek_backend $CVMFS_TEST_REPO $shakespeare_object    && return 19
+  peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_1 && return 19
+  peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_2 && return 19
+  peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_3 && return 19
+
+  echo "check if kafka is still there"
+  peek_backend $CVMFS_TEST_REPO $kafka_object    || return 20
+  peek_backend $CVMFS_TEST_REPO $chopped_kafka_1 || return 20
+  peek_backend $CVMFS_TEST_REPO $chopped_kafka_2 || return 20
+  peek_backend $CVMFS_TEST_REPO $chopped_kafka_3 || return 20
+
+  echo "check if the catalog revisions 1-4 are gone"
+  for clg_hash in $condemned_clgs; do
+    peek_backend $CVMFS_TEST_REPO ${clg_hash}C && return 21
+  done
+
+  echo "check if the catalog revisions 5-6 are preserved"
+  for clg_hash in $preserved_clgs; do
+    peek_backend $CVMFS_TEST_REPO ${clg_hash}C || return 22
+  done
+
   return 0
 }

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -613,6 +613,9 @@ TYPED_TEST_CASE(T_ObjectFetcher, ObjectFetcherTypes);
 TYPED_TEST(T_ObjectFetcher, InitializeSlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   EXPECT_TRUE(object_fetcher.IsValid());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 
@@ -625,6 +628,9 @@ TYPED_TEST(T_ObjectFetcher, FetchManifestSlow) {
 
   EXPECT_EQ(TestFixture::root_hash,    manifest->catalog_hash());
   EXPECT_EQ(TestFixture::history_hash, manifest->history());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 
@@ -638,6 +644,9 @@ TYPED_TEST(T_ObjectFetcher, FetchHistorySlow) {
     history(object_fetcher->FetchHistory());
   ASSERT_TRUE(history.IsValid());
   EXPECT_EQ(TestFixture::previous_history_hash, history->previous_revision());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_LE(1u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 
@@ -651,6 +660,9 @@ TYPED_TEST(T_ObjectFetcher, FetchLegacyHistorySlow) {
     << "didn't find: "
     << TestFixture::previous_history_hash.ToStringWithSuffix();
   EXPECT_TRUE(history->previous_revision().IsNull());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_LE(1u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 
@@ -678,6 +690,9 @@ TYPED_TEST(T_ObjectFetcher, FetchCatalogSlow) {
   ASSERT_TRUE(catalog.IsValid());
   EXPECT_EQ("",                            catalog->path().ToString());
   EXPECT_EQ(TestFixture::catalog_revision, catalog->revision());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_LE(1u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -662,6 +662,9 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidHistorySlow) {
       object_fetcher->FetchHistory(h("400d35465f179a4acacb5fe749e6ce20a0bbdb84",
                                      shash::kSuffixHistory)));
   ASSERT_FALSE(history.IsValid());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 
@@ -686,6 +689,9 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalogSlow) {
     object_fetcher->FetchCatalog(h("5739dc30f42525a261b2f4b383b220df3e36f04d",
                                    shash::kSuffixCatalog), ""));
   ASSERT_FALSE(catalog.IsValid());
+  if (TestFixture::NeedsFilesystemSandbox()) {
+    EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
+  }
 }
 
 


### PR DESCRIPTION
Turns out that both `HttpObjectFetcher` and `LocalObjectFetcher` leak empty temporary files when the download of an object fails.

This inserts the necessary error handling and extends both integration test `557` and `T_ObjectFetcher` to check this condition.