### PR TITLE
FIX: cvmfs_server import can recreate an expired whitelist

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -252,7 +252,7 @@ Supported Commands:
   import        [-w stratum0 url] [-o owner] [-u upstream storage]
                 [-l import legacy repo (2.0.x)] [-s show migration statistics]
                 [-f union filesystem type] [-c file ownership (UID:GID)]
-                [-k path to keys] [-g chown backend]
+                [-k path to keys] [-g chown backend] [-r recreate whitelist]
                 <fully qualified repository name>
                 Imports an old CernVM-FS repository into a fresh 2.1.x repo
   publish       [-p pause for tweaks] [-n manual revision number] [-v verbose]

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2766,10 +2766,11 @@ import() {
   local replicable=0
   local chown_backend=0
   local unionfs=
+  local recreate_whitelist=0
 
   # parameter handling
   OPTIND=1
-  while getopts "w:o:c:u:k:lsmgf:" option; do
+  while getopts "w:o:c:u:k:lsmgf:r" option; do
     case $option in
       w)
         stratum0=$OPTARG
@@ -2801,6 +2802,9 @@ import() {
       f)
         unionfs=$OPTARG
       ;;
+      r)
+        recreate_whitelist=1
+      ;;
       ?)
         shift $(($OPTIND-2))
         usage "Command import: Unrecognized option: $1"
@@ -2817,6 +2821,11 @@ import() {
   [ x"$stratum0" = x ] && stratum0="http://localhost/cvmfs/$name"
   [ x"$upstream" = x ] && upstream=$(make_upstream "local" "/srv/cvmfs/$name/data/txn" "/srv/cvmfs/$name")
   [ x"$unionfs"  = x ] && unionfs="$(get_available_union_fs)"
+
+  local private_key="${name}.key"
+  local master_key="${name}.masterkey"
+  local certificate="${name}.crt"
+  local public_key="${name}.pub"
 
   # sanity checks
   check_repository_existence $name  && die "The repository $name already exists"
@@ -2842,9 +2851,13 @@ import() {
   [ -d $storage_location ] || die "Did not find repository storage to import at $storage_location"
   [ -f "${storage_location}/.cvmfspublished" ] && \
   [ -d "${storage_location}/data" ] || die "$storage_location does not seem to be a repository storage"
-  [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"
-  local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
-  [ $expiry -gt 0 ] || die "Repository whitelist expired (use -r maybe?)"
+  if [ $recreate_whitelist -eq 0 ]; then
+    [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"
+    local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
+    [ $expiry -gt 0 ] || die "Repository whitelist expired (use -r maybe?)"
+  else
+    [ -f ${keys_location}/${master_key} ] || die "no master key found for whitelist recreation"
+  fi
 
   # repository owner dialog
   local cvmfs_user=$(get_cvmfs_owner $name $owner)
@@ -2865,10 +2878,6 @@ import() {
 
   # import the old repository security keys
   echo -n "Importing the given key files... "
-  local private_key="${name}.key"
-  local master_key="${name}.masterkey"
-  local certificate="${name}.crt"
-  local public_key="${name}.pub"
   keys="$private_key $certificate $public_key"
   if [ -f ${keys_location}/${master_key} ]; then
     keys="$keys $master_key"
@@ -2893,6 +2902,15 @@ import() {
     if has_selinux; then
       chcon -Rv --type=httpd_sys_content_t $storage_location > /dev/null || die "fail!"
     fi
+    echo "done"
+  fi
+
+  # recreate whitelist if requested
+  if [ $recreate_whitelist -ne 0 ]; then
+    echo -n "Recreating whitelist... "
+    create_whitelist $name $CVMFS_USER               \
+                           ${CVMFS_UPSTREAM_STORAGE} \
+                           ${CVMFS_SPOOL_DIR}/tmp > /dev/null || die "fail!"
     echo "done"
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1517,16 +1517,11 @@ create_whitelist() {
 }
 
 
-# figures out the time to expiry of the repository's whitelist
-#
-# @param stratum0  path/URL to stratum0 storage
-# @return          number of seconds until expiry (negativ if already expired)
-get_expiry() {
-  local name=$1
-  local stratum0=$2
+get_expiry_from_string() {
+  local whitelist_string="$1"
 
-  local expires=$(get_item $name $stratum0/.cvmfswhitelist 'noproxy' | head -2 | tail -1 | tail -c15)
-  if echo $expires | grep -q -E --invert-match '^[0-9]{14}$'; then
+  local expires=$(echo "$whitelist_string" | grep -e '^E[0-9]\{14\}$' | tr -d E)
+  if echo "$expires" | grep -q -E --invert-match '^[0-9]{14}$'; then
     echo -1
     return 1
   fi
@@ -1542,6 +1537,17 @@ get_expiry() {
   local now=$(/bin/date -u +%s)
   local valid_countdown=$(( $expires_num-$now ))
   echo $valid_countdown
+}
+
+
+# figures out the time to expiry of the repository's whitelist
+#
+# @param stratum0  path/URL to stratum0 storage
+# @return          number of seconds until expiry (negativ if already expired)
+get_expiry() {
+  local name=$1
+  local stratum0=$2
+  get_expiry_from_string "$(get_item $name $stratum0/.cvmfswhitelist 'noproxy')"
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2843,6 +2843,8 @@ import() {
   [ -f "${storage_location}/.cvmfspublished" ] && \
   [ -d "${storage_location}/data" ] || die "$storage_location does not seem to be a repository storage"
   [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"
+  local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
+  [ $expiry -gt 0 ] || die "Repository whitelist expired (use -r maybe?)"
 
   # repository owner dialog
   local cvmfs_user=$(get_cvmfs_owner $name $owner)

--- a/test/src/589-importrepo/main
+++ b/test/src/589-importrepo/main
@@ -39,6 +39,29 @@ respawn_repository() {
   fi
 }
 
+tamper_whitelist() {
+  local name=$1
+  local repo_backend=$2
+  local repo_keychain=$3
+
+  # recreate whitelist
+  local whitelist=whitelist.${name}
+  echo `date -u --date='last year' "+%Y%m%d%H%M%S" `       >  ${whitelist}.unsigned
+  echo "E`date -u --date='11 months ago' "+%Y%m%d%H%M%S"`" >> ${whitelist}.unsigned
+  echo "N$name"                                            >> ${whitelist}.unsigned
+  openssl x509 -fingerprint -sha1 -in ${repo_keychain}/${name}.crt | grep "SHA1 Fingerprint" | sed 's/SHA1 Fingerprint=//' >> ${whitelist}.unsigned
+  local hash;
+  hash=`openssl sha1 < ${whitelist}.unsigned | tr -d '\n' | tail -c40`
+  echo "--"     >> ${whitelist}.unsigned
+  echo $hash    >> ${whitelist}.unsigned
+  echo -n $hash >  ${whitelist}.hash
+
+  openssl rsautl -inkey ${repo_keychain}/${name}.masterkey -sign -in ${whitelist}.hash -out ${whitelist}.signature
+  cat ${whitelist}.unsigned ${whitelist}.signature | sudo tee ${repo_backend}/.cvmfswhitelist > /dev/null
+
+  rm -f ${whitelist}.unsigned ${whitelist}.signature ${whitelist}.hash
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -87,8 +110,6 @@ cvmfs_run_test() {
   echo "removing repository"
   destroy_repo $CVMFS_TEST_REPO || return 8
 
-  # ============================================================================
-
   echo "planting repository backend and keychain again"
   respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
 
@@ -100,6 +121,38 @@ cvmfs_run_test() {
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
+  echo "removing repository again"
+  destroy_repo $CVMFS_TEST_REPO || return 10
+
+  echo "planting repository backend but not the keychain again"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend || return $?
+
+  echo "importing repository with a provided keychain"
+  sudo cvmfs_server import -o $CVMFS_TEST_USER -k $(pwd)/$repo_keychain $CVMFS_TEST_REPO || return 11
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
+  echo "removing repository again"
+  destroy_repo $CVMFS_TEST_REPO || return 12
+
+  echo "tamper the whitelist of the copied repository (expire!)"
+  cp ${repo_backend}/$CVMFS_TEST_REPO/.cvmfswhitelist .cvmfswhitelist.bak             || return 13
+  tamper_whitelist $CVMFS_TEST_REPO ${repo_backend}/${CVMFS_TEST_REPO} $repo_keychain || return 14
+
+  echo "planting the repository with the tampered whitelist"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
+
+  echo "importing repository with a provided keychain (should fail due to whitelist)"
+  sudo cvmfs_server import -o $CVMFS_TEST_USER $CVMFS_TEST_REPO && return 14
 
   return 0
 }

--- a/test/src/589-importrepo/main
+++ b/test/src/589-importrepo/main
@@ -21,6 +21,20 @@ put_some_files_in() {
   popdir
 }
 
+change_some_files_in() {
+  local working_dir="$1"
+
+  pushdir $working_dir
+
+  rm -f foo/bar/hello
+  rm -fR bar
+  touch foo/.cvmfscatalog
+
+  create_big_file bar 100
+
+  popdir
+}
+
 respawn_repository() {
   local name=$1
   local user=$2
@@ -151,8 +165,49 @@ cvmfs_run_test() {
   echo "planting the repository with the tampered whitelist"
   respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
 
-  echo "importing repository with a provided keychain (should fail due to whitelist)"
+  echo "importing repository (should fail due to whitelist)"
   sudo cvmfs_server import -o $CVMFS_TEST_USER $CVMFS_TEST_REPO && return 14
+
+  echo "(temporarily) moving the masterkey"
+  local masterkey="/etc/cvmfs/keys/${CVMFS_TEST_REPO}.masterkey"
+  local hidden_masterkey="${masterkey}.hidden"
+  sudo mv $masterkey $hidden_masterkey || return 15
+
+  echo "importing repository (should fail due to missing masterkey)"
+  sudo cvmfs_server import -o $CVMFS_TEST_USER -r $CVMFS_TEST_REPO && return 16
+
+  echo "moving the masterkey back in place"
+  sudo mv $hidden_masterkey $masterkey || return 17
+
+  echo "importing repository and create a fresh whitelist"
+  sudo cvmfs_server import -o $CVMFS_TEST_USER -r $CVMFS_TEST_REPO || return 18
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
+  echo "open transaction to change something"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  change_some_files_in $repo_dir || return $?
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  change_some_files_in $reference_dir || return $?
+
+  local publish2_log="publish2.log"
+  echo "creating CVMFS snapshot (log: $publish2_log)"
+  publish_repo $CVMFS_TEST_REPO > $publish_log 2>&1 || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
 
   return 0
 }

--- a/test/src/589-importrepo/main
+++ b/test/src/589-importrepo/main
@@ -1,0 +1,105 @@
+cvmfs_test_name="Import Contemporary Repository"
+cvmfs_test_autofs_on_startup=false
+
+put_some_files_in() {
+  local working_dir="$1"
+
+  pushdir $working_dir
+
+  mkdir foo
+  mkdir foo/bar
+  echo "hello world" > foo/bar/hello
+  create_big_file foo/bar/big 75
+
+  mkdir bar
+  mkdir bar/foo
+  echo "foobar" >> bar/foo/baz
+  create_big_file bar/foo/large 50
+
+  touch bar/.cvmfscatalog
+
+  popdir
+}
+
+respawn_repository() {
+  local name=$1
+  local user=$2
+  local repo_backend=$3
+  local repo_keychain="$4"
+
+  sudo cp -R ${repo_backend}/* $(get_local_repo_storage) || return 1
+  sudo chown -R $user $(get_local_repo_storage $name)    || return 2
+
+  if [ x"$repo_keychain" != x"" ]; then
+    sudo cp ${repo_keychain}/${CVMFS_TEST_REPO}.pub       /etc/cvmfs/keys || return 3
+    sudo cp ${repo_keychain}/${CVMFS_TEST_REPO}.crt       /etc/cvmfs/keys || return 4
+    sudo cp ${repo_keychain}/${CVMFS_TEST_REPO}.key       /etc/cvmfs/keys || return 5
+    sudo cp ${repo_keychain}/${CVMFS_TEST_REPO}.masterkey /etc/cvmfs/keys || return 6
+    sudo chown $user /etc/cvmfs/keys/${CVMFS_TEST_REPO}.*                 || return 7
+  fi
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  put_some_files_in $repo_dir || return $?
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  put_some_files_in $reference_dir || return $?
+
+  local publish_log="publish.log"
+  echo "creating CVMFS snapshot (log: $publish_log)"
+  publish_repo $CVMFS_TEST_REPO > $publish_log 2>&1 || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
+  echo "rescue repository backend storage and keychain"
+  local repo_backend="repo_backend"
+  local repo_keychain="repo_keychain"
+  mkdir $repo_backend  || return 1
+  mkdir $repo_keychain || return 2
+  cp -R $(get_local_repo_storage $CVMFS_TEST_REPO) $repo_backend  || return 3
+  cp /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub        $repo_keychain || return 4
+  cp /etc/cvmfs/keys/${CVMFS_TEST_REPO}.crt        $repo_keychain || return 5
+  cp /etc/cvmfs/keys/${CVMFS_TEST_REPO}.key        $repo_keychain || return 6
+  cp /etc/cvmfs/keys/${CVMFS_TEST_REPO}.masterkey  $repo_keychain || return 7
+
+  # ============================================================================
+
+  echo "removing repository"
+  destroy_repo $CVMFS_TEST_REPO || return 8
+
+  # ============================================================================
+
+  echo "planting repository backend and keychain again"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
+
+  echo "importing repository to recreate the backend infrastructure"
+  sudo cvmfs_server import -o $CVMFS_TEST_USER $CVMFS_TEST_REPO || return 9
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  return 0
+}


### PR DESCRIPTION
As described in [CVM-780](https://sft.its.cern.ch/jira/browse/CVM-780), `cvmfs_server import` fails to import a repository that contains an expired whitelist. Unfortunately one cannot resign a whitelist if the repository is not registered to a release manager machine. This adds `cvmfs_server import -r` allowing to recreate the whitelist (given a valid repository master key) during the import procedure.

Furthermore this adds an integration test that imports a contemporary repository both with and without expired whitelists.