### PR TITLE
FIX: bug in T_Util.StringifyDate for 1-digit days

### DIFF
--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -97,7 +97,7 @@ class T_Util : public ::testing::Test {
     } else {
       gmtime_r(&seconds, &ts);
     }
-    strftime(buf, sizeof(buf), "%d %b %Y %H:%M:%S", &ts);
+    strftime(buf, sizeof(buf), "%-d %b %Y %H:%M:%S", &ts);
     return string(buf);
   }
 


### PR DESCRIPTION
With this "-" it automatically removes the 0 character in a date.

For example:
"01 Jun 2015 12:00:05" -> "1 Jun 2015 12:00:05"

The main difference between %-d and %e is that %e adds a whitespace where the "0" was supposed to be, which makes the comparison fail. Like this:
"01 Jun 2015 12:00:05" -> " 1 Jun 2015 12:00:05"