### PR TITLE
FIX: Snapshotting/Preloading Code after Hash Cleanup

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -379,8 +379,8 @@ bool Catalog::AllChunksBegin() {
 }
 
 
-bool Catalog::AllChunksNext(shash::Any *hash, ChunkTypes *type) {
-  return sql_all_chunks_->Next(hash, type);
+bool Catalog::AllChunksNext(shash::Any *hash) {
+  return sql_all_chunks_->Next(hash);
 }
 
 

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -145,7 +145,7 @@ class Catalog : public SingleCopy {
                               listing);
   }
   bool AllChunksBegin();
-  bool AllChunksNext(shash::Any *hash, ChunkTypes *type);
+  bool AllChunksNext(shash::Any *hash);
   bool AllChunksEnd();
 
   inline bool ListPathChunks(const PathString &path,

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1021,6 +1021,10 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
     " ((flags&" + StringifyInt(hash_mask) + ") >> " +
     StringifyInt(SqlDirent::kFlagPosHash) + ")+1 AS hash_algorithm ";
 
+  // TODO(reneme): this depends on shash::kSuffix* being a char!
+  //               it should be more generic or replaced entirely
+  // TODO(reneme): this is practically the same as SqlListContentHashes and
+  //               should be consolidated
   string sql = "SELECT DISTINCT hash, "
   "CASE WHEN flags & " + StringifyInt(SqlDirent::kFlagFile) + " THEN " +
     StringifyInt(shash::kSuffixNone) + " " +

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1046,7 +1046,7 @@ bool SqlAllChunks::Open() {
 }
 
 
-bool SqlAllChunks::Next(shash::Any *hash, ChunkTypes *type) {
+bool SqlAllChunks::Next(shash::Any *hash) {
   if (! FetchRow()) {
     return false;
   }

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -36,17 +36,6 @@ namespace catalog {
 
 class Catalog;
 
-/**
- * Content-addressable chunks can be entire files, micro catalogs (ending L) or
- * pieces of large files (ending P).  Micro catalogs are currently not
- * implemented.
- */
-enum ChunkTypes {
-  kChunkFile = 0,
-  kChunkMicroCatalog,
-  kChunkPiece,
-};
-
 
 class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
  public:
@@ -519,7 +508,7 @@ class SqlAllChunks : public Sql {
  public:
   explicit SqlAllChunks(const CatalogDatabase &database);
   bool Open();
-  bool Next(shash::Any *hash, ChunkTypes *type);
+  bool Next(shash::Any *hash);
   bool Close();
 };
 


### PR DESCRIPTION
This retro-fixes the problem @jblomer pointed out pointed out [here](https://github.com/cvmfs/cvmfs/pull/918#discussion_r31390901). It ended up in a new pull request since the fix requires some refactoring which is worth reviewing individually.

Changes done:

1. `Catalog::AllChunksNext()` now returns hashes with proper suffix annotation instead of `hash` and `type` individually
2. `catalog::ChunkTypes` was removed and replaced by `shash::Suffix` directly (this depends on `shash::Suffix` being a `char` and should be fixed in the future, see TODO)
3. Consolidate `Peek()` and `Store()` functions in `swissknife pull` that depend on `preload_cache`
4. Extend `struct ChunkJob` to encapsulate the hash (de)serialisation