### PR TITLE
FIX: Build on Ubuntu

### DIFF
--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -80,7 +80,7 @@ class T_Util : public ::testing::Test {
       const string &content) {
     string complete_path = sandbox + "/" + filename;
     FILE *myfile = fopen(complete_path.c_str(), "w");
-    fprintf(myfile, content.c_str());
+    fprintf(myfile, "%s", content.c_str());
     fclose(myfile);
     return complete_path;
   }


### PR DESCRIPTION
Failed because an `fprintf()` parameter string warning was treated as error on debian package build.