### PR TITLE
FIX: Integration Test 519 suffers from EXDEV bug in CentOS 7

### DIFF
--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -56,7 +56,7 @@ cvmfs_run_test() {
   ls -lisa /cvmfs/${legacy_repo_name} || return 5
 
   echo "load repository configuration"
-  load_repo_config $CVMFS_TEST_REPO
+  load_repo_config $legacy_repo_name
 
   echo "check that the temporary scratch directory is empty"
   [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -49,6 +49,9 @@ cvmfs_run_test() {
     -g                     \
     $legacy_repo_name || return 4
 
+  echo "make sure that we are not suffering from the exdev bug"
+  apply_server_cache_config $legacy_repo_name
+
   echo "list newly generated repository under /cvmfs/${legacy_repo_name}"
   ls -lisa /cvmfs/${legacy_repo_name} || return 5
 
@@ -61,6 +64,10 @@ cvmfs_run_test() {
   # check if the migrated and imported catalogs are sane
   echo "check migrated catalogs and data chunks"
   check_repository $legacy_repo_name || return 6
+
+  echo "create an empty repository revision (exdev workaround)"
+  start_transaction $legacy_repo_name || return $?
+  publish_repo      $legacy_repo_name || return $?
 
   # cheate a new repository revision of the migrated catalogs
   echo "create a new repository revision"

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -74,14 +74,14 @@ cvmfs_run_test() {
   local big_file="${repo_dir}/dir6/bigfile"
   start_transaction $legacy_repo_name || return $?
   cd $repo_dir
-    rm -fR dir7
-    mkdir -p foo bar
-    touch foo/.cvmfscatalog
-    echo "no meaningful stuff" > foo/bar
-    echo "even less meaning"   > bar/foo
-    ln foo/bar foo/baz
-    ln -s ../foo/baz bar/baz
-    touch $big_file
+    rm -fR dir7                          || return 60
+    mkdir -p foo bar                     || return 61
+    touch foo/.cvmfscatalog              || return 62
+    echo "no meaningful stuff" > foo/bar || return 63
+    echo "even less meaning"   > bar/foo || return 64
+    ln foo/bar foo/baz                   || return 65
+    ln -s ../foo/baz bar/baz             || return 66
+    touch $big_file                      || return 67
   cd $scratch_dir
   publish_repo $legacy_repo_name || return $?
 

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -2,9 +2,11 @@
 cvmfs_test_name="Import Legacy Repository"
 cvmfs_test_autofs_on_startup=false
 
+TEST519_WORKSPACE=""
 TEST519_LEGACY_STORAGE=""
 TEST519_NEW_REPO_NAME=""
 cleanup() {
+  [ -z "$TEST519_WORKSPACE" ]      || cd $TEST519_WORKSPACE
   [ -z "$TEST519_NEW_REPO_NAME" ]  || sudo cvmfs_server rmfs -f $TEST519_NEW_REPO_NAME
   [ -z "$TEST519_LEGACY_STORAGE" ] || sudo rm -fR $TEST519_LEGACY_STORAGE
 }
@@ -18,6 +20,7 @@ cvmfs_run_test() {
   local legacy_repo_name="testmigration.cern.ch"
   local repo_dir="/cvmfs/${legacy_repo_name}"
   local legacy_repo_storage="$(get_local_repo_storage $legacy_repo_name)"
+  TEST519_WORKSPACE="$scratch_dir"
 
   echo "make sure there are no legacy repo leftovers from previous tests"
   cleanup_legacy_repo_leftovers "$legacy_repo_name"

--- a/test/test_functions
+++ b/test/test_functions
@@ -414,6 +414,18 @@ has_repo() {
 }
 
 
+apply_server_cache_config() {
+  local repo=$1
+  local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
+  [ x"$CVMFS_TEST_SERVER_CACHE" != x"" ] || return 0
+
+  local cache_base=$(echo "$CVMFS_TEST_SERVER_CACHE" | sed 's/\//\\\//g')
+  # will take effect _after_ the first publish operation...
+  sudo sed -i "s/^\(CVMFS_CACHE_BASE\)=.*\$/\1=${cache_base}/"     $client_conf || return 1
+  sudo sed -i "s/^\(CVMFS_RELOAD_SOCKETS\)=.*\$/\1=${cache_base}/" $client_conf || return 2
+}
+
+
 create_repo() {
   local repo=$1
   local uid=$2
@@ -453,13 +465,7 @@ create_repo() {
                          $extra_options $repo || return 102
 
   local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
-
-  if [ x"$CVMFS_TEST_SERVER_CACHE" != x"" ]; then
-    local cache_base=$(echo "$CVMFS_TEST_SERVER_CACHE" | sed 's/\//\\\//g')
-    # will take effect _after_ the first publish operation...
-    sudo sed -i "s/^CVMFS_CACHE_BASE=.*\$/CVMFS_CACHE_BASE=${cache_base}/"         $client_conf
-    sudo sed -i "s/^CVMFS_RELOAD_SOCKETS=.*\$/CVMFS_RELOAD_SOCKETS=${cache_base}/" $client_conf
-  fi
+  apply_server_cache_config $repo || return 103
 
   if [ x$debug_log != x -a x$debug_log != xNO ]; then
     echo "CVMFS_DEBUGLOG=$debug_log" | sudo tee -a $client_conf


### PR DESCRIPTION
The integration test got stuck with the EXDEV bug because it didn't apply the [workaround](http://cernvm.cern.ch/portal/cvmfs/workaround-krnl-deadlock) properly.