### PR TITLE
FIX: Avoid using `attr -qg` for Retrieval of Mounted Root Hash

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1767,7 +1767,9 @@ get_mounted_root_hash() {
   local repository_name=$1
 
   load_repo_config $repository_name
-  attr -qg root_hash ${CVMFS_SPOOL_DIR}/rdonly
+  __swissknife info -r $CVMFS_STRATUM0           \
+                    -u ${CVMFS_SPOOL_DIR}/rdonly \
+                    -C $(get_follow_http_redirects_flag)
 }
 
 

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -80,7 +80,7 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
 
   // sanity check
   if (args.count('C') > 0 && mount_point.empty()) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "need a CerVM-FS mountpoint (-u) for -C");
+    LogCvmfs(kLogCvmfs, kLogStderr, "need a CernVM-FS mountpoint (-u) for -C");
     return 1;
   }
 

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -78,6 +78,12 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
                            :  "";
   const string repository = MakeCanonicalPath(*args.find('r')->second);
 
+  // sanity check
+  if (args.count('C') > 0 && mount_point.empty()) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "need a CerVM-FS mountpoint (-u) for -C");
+    return 1;
+  }
+
   // Load manifest file
   // Repository can be HTTP address or on local file system
   // TODO(jblomer): do this using Manifest::Fetch

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -46,8 +46,10 @@ static bool Exists(const string &repository, const string &file)
 ParameterList CommandInfo::GetParams() {
   swissknife::ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository directory / url"));
+  r.push_back(Parameter::Optional('u', "repository mount point"));
   r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
   r.push_back(Parameter::Switch('c', "show root catalog hash"));
+  r.push_back(Parameter::Switch('C', "show mounted root catalog hash"));
   r.push_back(Parameter::Switch('n', "show fully qualified repository name"));
   r.push_back(Parameter::Switch('t', "show time stamp"));
   r.push_back(Parameter::Switch('m', "check if repository is marked as "
@@ -71,6 +73,9 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
     }
     SetLogVerbosity(static_cast<LogLevels>(log_level));
   }
+  const string mount_point = (args.find('u') != args.end())
+                           ?  *args.find('u')->second
+                           :  "";
   const string repository = MakeCanonicalPath(*args.find('r')->second);
 
   // Load manifest file
@@ -126,6 +131,27 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
 
   // Check if we should be human readable
   const bool human_readable = (args.count('h') > 0);
+
+  // Get information from the mount point
+  if (args.count('C') > 0) {
+    assert(!mount_point.empty());
+    const std::string root_hash_xattr = "user.root_hash";
+    std::string root_hash;
+    const bool success = platform_getxattr(mount_point,
+                                           root_hash_xattr,
+                                           &root_hash);
+    if (!success) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed to retrieve extended attribute "
+                                      " '%s' from '%s' (errno: %d)",
+                                      root_hash_xattr.c_str(),
+                                      mount_point.c_str(),
+                                      errno);
+      return 1;
+    }
+    LogCvmfs(kLogCvmfs, kLogStdout, "%s%s",
+             (human_readable) ? "Mounted Root Hash:               " : "",
+             root_hash.c_str());
+  }
 
   // Get information from the Manifest
   if (args.count('c') > 0) {


### PR DESCRIPTION
In the past the `attr -qg` in `cvmfs_server` was failing every now and then because of tight kernel memory space. This now uses `cvmfs_swissknife info` to get the same information which hopefully fixes those hiccups.