### PR TITLE
Cleanup: Use Database<>::GetProperty<>() and Database<>::SetProperty()

### DIFF
--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -231,6 +231,7 @@ class Catalog : public SingleCopy {
   Counters& GetCounters() { return counters_; }
 
   inline const CatalogDatabase &database() const { return *database_; }
+  inline       CatalogDatabase &database()       { return *database_; }
   inline void set_parent(Catalog *catalog) { parent_ = catalog; }
 
   void ResetNestedCatalogCache();

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -294,11 +294,7 @@ void WritableCatalog::RemoveFileChunks(const std::string &entry_path) {
  * Sets the last modified time stamp of this catalog to current time.
  */
 void WritableCatalog::UpdateLastModified() {
-  const time_t now = time(NULL);
-  const string sql = "INSERT OR REPLACE INTO properties "
-     "(key, value) VALUES ('last_modified', '" + StringifyInt(now) + "');";
-  bool retval = Sql(database(), sql).Execute();
-  assert(retval);
+  database().SetProperty("last_modified", static_cast<uint64_t>(time(NULL)));
 }
 
 
@@ -306,19 +302,12 @@ void WritableCatalog::UpdateLastModified() {
  * Increments the revision of the catalog in the database.
  */
 void WritableCatalog::IncrementRevision() {
-  const string sql =
-    "UPDATE properties SET value=value+1 WHERE key='revision';";
-  bool retval = Sql(database(), sql).Execute();
-  assert(retval);
+  SetRevision(GetRevision() + 1);
 }
 
 
 void WritableCatalog::SetRevision(const uint64_t new_revision) {
-  const string sql =
-    "UPDATE properties SET value=" + StringifyInt(new_revision) +
-    " WHERE key='revision';";
-  bool retval = Sql(database(), sql).Execute();
-  assert(retval);
+  database().SetProperty("revision", new_revision);
 }
 
 
@@ -326,10 +315,7 @@ void WritableCatalog::SetRevision(const uint64_t new_revision) {
  * Sets the content hash of the previous catalog revision.
  */
 void WritableCatalog::SetPreviousRevision(const shash::Any &hash) {
-  const string sql = "INSERT OR REPLACE INTO properties "
-    "(key, value) VALUES ('previous_revision', '" + hash.ToString() + "');";
-  bool retval = Sql(database(), sql).Execute();
-  assert(retval);
+  database().SetProperty("previous_revision", hash.ToString());
 }
 
 

--- a/cvmfs/quota.cc
+++ b/cvmfs/quota.cc
@@ -980,6 +980,7 @@ init_recover:
     LogCvmfs(kLogQuota, kLogDebug, "could not open cache database (%d)", err);
     goto init_database_fail;
   }
+  // TODO(reneme): make this a `QuotaDatabase : public sqlite::Database`
   sql = "PRAGMA synchronous=0; PRAGMA locking_mode=EXCLUSIVE; "
   "PRAGMA auto_vacuum=1; "
   "CREATE TABLE IF NOT EXISTS cache_catalog (sha1 TEXT, size INTEGER, "

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -112,6 +112,8 @@ class Database : SingleCopy {
   template <typename T>
   T GetProperty(const std::string &key) const;
   template <typename T>
+  T GetPropertyDefault(const std::string &key, const T default_value) const;
+  template <typename T>
   bool SetProperty(const std::string &key, const T value);
   bool HasProperty(const std::string &key) const;
 

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -280,6 +280,14 @@ T Database<DerivedT>::GetProperty(const std::string &key) const {
 
 template <class DerivedT>
 template <typename T>
+T Database<DerivedT>::GetPropertyDefault(const std::string &key,
+                                         const T default_value) const {
+  return (HasProperty(key)) ? GetProperty<T>(key)
+                            : default_value;
+}
+
+template <class DerivedT>
+template <typename T>
 bool Database<DerivedT>::SetProperty(const std::string &key,
                                      const T            value) {
   assert(set_property_);

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -408,6 +408,11 @@ inline int Sql::Retrieve(const int index) {
 }
 
 template <>
+inline bool Sql::Retrieve(const int index) {
+  return static_cast<bool>(this->RetrieveInt(index));
+}
+
+template <>
 inline sqlite3_int64 Sql::Retrieve(const int index) {
   return this->RetrieveInt64(index);
 }

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -413,6 +413,11 @@ inline sqlite3_int64 Sql::Retrieve(const int index) {
 }
 
 template <>
+inline uint64_t Sql::Retrieve(const int index) {
+  return static_cast<uint64_t>(this->RetrieveInt64(index));
+}
+
+template <>
 inline std::string Sql::Retrieve(const int index) {
   return RetrieveString(index);
 }

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -377,6 +377,11 @@ inline bool Sql::Bind(const int index, const unsigned int value) {
 }
 
 template <>
+inline bool Sql::Bind(const int index, const uint64_t value) {
+  return this->BindInt64(index, value);
+}
+
+template <>
 inline bool Sql::Bind(const int index, const sqlite3_int64 value) {
   return this->BindInt64(index, value);
 }

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -342,6 +342,38 @@ TEST_F(T_SQLite_Wrapper, PropertyWithoutReopen) {
 }
 
 
+TEST_F(T_SQLite_Wrapper, GetDefaultPropertyWithoutReopen) {
+  const std::string dbp = GetDatabaseFilename();
+
+  DummyDatabase *db1 = DummyDatabase::Create(dbp);
+  ASSERT_NE(static_cast<DummyDatabase*>(NULL), db1);
+
+  EXPECT_TRUE(db1->SetProperty("foo",   "bar"));
+  EXPECT_TRUE(db1->SetProperty("file",  dbp));
+  EXPECT_TRUE(db1->SetProperty("int",   1337));
+  EXPECT_TRUE(db1->SetProperty("float", 13.37));
+
+  EXPECT_EQ("bar", db1->GetPropertyDefault<std::string>("foo",  "0"));
+  EXPECT_EQ(dbp,   db1->GetPropertyDefault<std::string>("file", "1"));
+  EXPECT_EQ(1337,  db1->GetPropertyDefault<int>("int",           2));
+  EXPECT_LT(13.36, db1->GetPropertyDefault<float>("float",       3));
+  EXPECT_GT(13.38, db1->GetPropertyDefault<double>("float",      4));
+  EXPECT_NE(42,    db1->GetPropertyDefault<int>("int",          42));
+
+  EXPECT_FALSE(db1->HasProperty("moep"));
+  EXPECT_FALSE(db1->HasProperty("baz"));
+
+  EXPECT_EQ("tok!", db1->GetPropertyDefault<std::string>("moep", "tok!"));
+  EXPECT_EQ(1337,   db1->GetPropertyDefault<int>("moep",         1337));
+  EXPECT_LT(13.36,  db1->GetPropertyDefault<double>("moep",      13.37));
+  EXPECT_GT(13.38f, db1->GetPropertyDefault<float>("moep",       13.37f));
+  EXPECT_EQ(0,      db1->GetPropertyDefault<double>("baz",       0));
+
+  delete db1;
+  EXPECT_EQ(0u, DummyDatabase::instances);
+}
+
+
 TEST_F(T_SQLite_Wrapper, PropertyWithReadOnlyReopen) {
   const std::string dbp = GetDatabaseFilename();
 


### PR DESCRIPTION
This replaces the explicit SQL queries in `catalog.cc` and `catalog_rw.cc` to access information in the `properties` table with calls to `Database<>::GetProperty<>()` and `Database<>::SetProperty()` as requested in [CVM-720](https://sft.its.cern.ch/jira/browse/CVM-720).