### PR TITLE
Feature: Detect Character Device in FsTraversal

### DIFF
--- a/cvmfs/fs_traversal.h
+++ b/cvmfs/fs_traversal.h
@@ -47,6 +47,7 @@ class FileSystemTraversal {
   VoidCallback fn_new_symlink;
   VoidCallback fn_new_socket;
   VoidCallback fn_new_block_dev;
+  VoidCallback fn_new_character_dev;
   VoidCallback fn_new_fifo;
 
   /**
@@ -91,6 +92,7 @@ class FileSystemTraversal {
     fn_new_symlink(NULL),
     fn_new_socket(NULL),
     fn_new_block_dev(NULL),
+    fn_new_character_dev(NULL),
     fn_new_fifo(NULL),
     fn_ignore_file(NULL),
     fn_new_dir_prefix(NULL),
@@ -113,6 +115,7 @@ class FileSystemTraversal {
            fn_new_symlink != NULL ||
            fn_new_dir_prefix != NULL ||
            fn_new_block_dev != NULL ||
+           fn_new_character_dev != NULL ||
            fn_new_fifo != NULL ||
            fn_new_socket != NULL);
 
@@ -199,6 +202,11 @@ class FileSystemTraversal {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg,
             "passing blocked device %s/%s", path.c_str(), dit->d_name);
         Notify(fn_new_block_dev, path, dit->d_name);
+      } else if (S_ISCHR(info.st_mode)) {
+        LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing character-device "
+                                                  "%s/%s",
+                 path.c_str(), dit->d_name);
+        Notify(fn_new_character_dev, path, dit->d_name);
       } else if (S_ISFIFO(info.st_mode)) {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing FIFO %s/%s",
                  path.c_str(), dit->d_name);

--- a/cvmfs/fs_traversal.h
+++ b/cvmfs/fs_traversal.h
@@ -199,8 +199,8 @@ class FileSystemTraversal {
                  path.c_str(), dit->d_name);
         Notify(fn_new_socket, path, dit->d_name);
       } else if (S_ISBLK(info.st_mode)) {
-        LogCvmfs(kLogFsTraversal, kLogVerboseMsg,
-            "passing blocked device %s/%s", path.c_str(), dit->d_name);
+        LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing block-device %s/%s",
+                 path.c_str(), dit->d_name);
         Notify(fn_new_block_dev, path, dit->d_name);
       } else if (S_ISCHR(info.st_mode)) {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing character-device "

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -657,11 +657,17 @@ class CustomDelegate {
 
   void BlockDevice(const std::string &relative_path,
                    const std::string &object_name) {
+    struct stat s;
+    GetStat(relative_path, object_name, &s);
+    EXPECT_TRUE(S_ISBLK(s.st_mode));
     ++num_block_dev;
   }
 
   void CharacterDevice(const std::string &relative_path,
                        const std::string &object_name) {
+    struct stat s;
+    GetStat(relative_path, object_name, &s);
+    EXPECT_TRUE(S_ISCHR(s.st_mode));
     ++num_character_dev;
   }
 

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -667,10 +667,13 @@ class CustomDelegate {
 
   bool CheckPermissions(const std::string &relative_path,
                         const std::string &dir_name) {
-    std::string file = root_path + "/" + relative_path + "/" + dir_name;
+    const std::string file = root_path + "/" + relative_path + "/" + dir_name;
     struct stat s;
     stat(file.c_str(), &s);
-    return !S_ISBLK(s.st_mode);
+    const bool can_read = ( S_ISDIR(s.st_mode) && s.st_mode & S_IRUSR &&
+                                                  s.st_mode & S_IXUSR)
+                       || (!S_ISDIR(s.st_mode) && s.st_mode & S_IRUSR);
+    return !can_read;
   }
 
   int num_block_dev;

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -673,11 +673,6 @@ class CustomDelegate {
     return !S_ISBLK(s.st_mode);
   }
 
-  int getNumBlockedDev() const {
-    return num_block_dev;
-  }
-
- private:
   int num_block_dev;
   int num_character_dev;
   std::string root_path;
@@ -691,5 +686,5 @@ TEST_F(T_FsTraversal, BlockDevice) {
   traverse.fn_new_block_dev = &CustomDelegate::BlockDevice;
   traverse.fn_ignore_file = &CustomDelegate::CheckPermissions;
   traverse.Recurse("/dev");
-  EXPECT_LT(0, delegate.getNumBlockedDev());
+  EXPECT_LT(0, delegate.num_block_dev);
 }

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -30,6 +30,7 @@ class T_FsTraversal : public ::testing::Test {
       Unspecified,
       Socket,
       BlockDevice,
+      CharacterDevice,
       FIFO
     };
 
@@ -41,15 +42,16 @@ class T_FsTraversal : public ::testing::Test {
     }
 
     void Init() {
-      enter_dir     = false;
-      leave_dir     = false;
-      file_found    = false;
-      symlink_found = false;
-      dir_prefix    = false;
-      dir_postfix   = false;
-      socket_found  = false;
-      block_dev_found   = false;
-      fifo_found    = false;
+      enter_dir       = false;
+      leave_dir       = false;
+      file_found      = false;
+      symlink_found   = false;
+      dir_prefix      = false;
+      dir_postfix     = false;
+      socket_found    = false;
+      block_dev_found = false;
+      chr_dev_found   = false;
+      fifo_found      = false;
     }
 
     void Check(const Type overwrite_type = Unspecified) const {
@@ -59,45 +61,48 @@ class T_FsTraversal : public ::testing::Test {
 
       switch (type_to_check) {
         case Directory:
-          EXPECT_TRUE(enter_dir)     << path;
-          EXPECT_TRUE(leave_dir)     << path;
-          EXPECT_TRUE(dir_prefix)    << path;
-          EXPECT_TRUE(dir_postfix)   << path;
+          EXPECT_TRUE(enter_dir)       << path;
+          EXPECT_TRUE(leave_dir)       << path;
+          EXPECT_TRUE(dir_prefix)      << path;
+          EXPECT_TRUE(dir_postfix)     << path;
           break;
         case RootDirectory:
-          EXPECT_TRUE(enter_dir)     << path;
-          EXPECT_TRUE(leave_dir)     << path;
-          EXPECT_FALSE(dir_prefix)    << path;
-          EXPECT_FALSE(dir_postfix)   << path;
+          EXPECT_TRUE(enter_dir)       << path;
+          EXPECT_TRUE(leave_dir)       << path;
+          EXPECT_FALSE(dir_prefix)     << path;
+          EXPECT_FALSE(dir_postfix)    << path;
           break;
         case NonTraversedDirectory:
-          EXPECT_TRUE(dir_prefix)    << path;
-          EXPECT_TRUE(dir_postfix)   << path;
-          EXPECT_FALSE(enter_dir)     << path;
-          EXPECT_FALSE(leave_dir)     << path;
+          EXPECT_TRUE(dir_prefix)      << path;
+          EXPECT_TRUE(dir_postfix)     << path;
+          EXPECT_FALSE(enter_dir)      << path;
+          EXPECT_FALSE(leave_dir)      << path;
           break;
         case File:
-          EXPECT_TRUE(file_found)    << path;
+          EXPECT_TRUE(file_found)      << path;
           break;
         case Symlink:
-          EXPECT_TRUE(symlink_found) << path;
+          EXPECT_TRUE(symlink_found)   << path;
           break;
         case Untouched:
-          EXPECT_FALSE(enter_dir)     << path;
-          EXPECT_FALSE(leave_dir)     << path;
-          EXPECT_FALSE(file_found)    << path;
-          EXPECT_FALSE(symlink_found) << path;
-          EXPECT_FALSE(dir_prefix)    << path;
-          EXPECT_FALSE(dir_postfix)   << path;
+          EXPECT_FALSE(enter_dir)      << path;
+          EXPECT_FALSE(leave_dir)      << path;
+          EXPECT_FALSE(file_found)     << path;
+          EXPECT_FALSE(symlink_found)  << path;
+          EXPECT_FALSE(dir_prefix)     << path;
+          EXPECT_FALSE(dir_postfix)    << path;
           break;
         case Socket:
-          EXPECT_TRUE(socket_found)   << path;
+          EXPECT_TRUE(socket_found)    << path;
           break;
         case BlockDevice:
-          EXPECT_TRUE(block_dev_found)    << path;
+          EXPECT_TRUE(block_dev_found) << path;
+          break;
+        case CharacterDevice:
+          EXPECT_TRUE(chr_dev_found)   << path;
           break;
         case FIFO:
-          EXPECT_TRUE(fifo_found)     << path;
+          EXPECT_TRUE(fifo_found)      << path;
           break;
         default:
           FAIL() << "Encountered an unexpected file type";
@@ -116,6 +121,7 @@ class T_FsTraversal : public ::testing::Test {
     bool dir_postfix;
     bool socket_found;
     bool block_dev_found;
+    bool chr_dev_found;
     bool fifo_found;
   };
 
@@ -647,11 +653,16 @@ TEST_F(T_FsTraversal, SteeredTraversal) {
 class CustomDelegate {
  public:
   explicit CustomDelegate(const std::string &path) :
-    num_block_dev(0), root_path(path) {}
+    num_block_dev(0), num_character_dev(0), root_path(path) {}
 
   void BlockDevice(const std::string &relative_path,
                    const std::string &dir_name) {
     ++num_block_dev;
+  }
+
+  void CharacterDevice(const std::string &relative_path,
+                       const std::string &dir_name) {
+    ++num_character_dev;
   }
 
   bool CheckPermissions(const std::string &relative_path,
@@ -668,6 +679,7 @@ class CustomDelegate {
 
  private:
   int num_block_dev;
+  int num_character_dev;
   std::string root_path;
 };
 

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -656,26 +656,35 @@ class CustomDelegate {
     num_block_dev(0), num_character_dev(0), root_path(path) {}
 
   void BlockDevice(const std::string &relative_path,
-                   const std::string &dir_name) {
+                   const std::string &object_name) {
     ++num_block_dev;
   }
 
   void CharacterDevice(const std::string &relative_path,
-                       const std::string &dir_name) {
+                       const std::string &object_name) {
     ++num_character_dev;
   }
 
   bool CheckPermissions(const std::string &relative_path,
-                        const std::string &dir_name) {
-    const std::string file = root_path + "/" + relative_path + "/" + dir_name;
+                        const std::string &object_name) {
     struct stat s;
-    stat(file.c_str(), &s);
+    GetStat(relative_path, object_name, &s);
     const bool can_read = ( S_ISDIR(s.st_mode) && s.st_mode & S_IRUSR &&
                                                   s.st_mode & S_IXUSR)
                        || (!S_ISDIR(s.st_mode) && s.st_mode & S_IRUSR);
     return !can_read;
   }
 
+ protected:
+  void GetStat(const std::string  &relative_path,
+               const std::string  &obj_name,
+               struct stat        *s) const {
+    const std::string file = root_path + "/" + relative_path + "/" + obj_name;
+    const int retval = stat(file.c_str(), s);
+    ASSERT_EQ(0, retval) << "cannot stat '" << file << "'";
+  }
+
+ public:
   int                num_block_dev;
   int                num_character_dev;
   const std::string  root_path;

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -646,23 +646,21 @@ TEST_F(T_FsTraversal, SteeredTraversal) {
 
 class CustomDelegate {
  public:
-  explicit CustomDelegate(std::string path) :
+  explicit CustomDelegate(const std::string &path) :
     num_block_dev(0), root_path(path) {}
 
-  virtual void BlockDevice(const std::string &relative_path,
-      const std::string &dir_name) {
+  void BlockDevice(const std::string &relative_path,
+                   const std::string &dir_name) {
     ++num_block_dev;
   }
 
-  virtual bool CheckPermissions(const std::string &relative_path,
-      const std::string &dir_name) {
-    std::string file = root_path + relative_path + "/" + dir_name;
+  bool CheckPermissions(const std::string &relative_path,
+                        const std::string &dir_name) {
+    std::string file = root_path + "/" + relative_path + "/" + dir_name;
     struct stat s;
     stat(file.c_str(), &s);
     return !S_ISBLK(s.st_mode);
   }
-
-  virtual ~CustomDelegate() {}
 
   int getNumBlockedDev() const {
     return num_block_dev;

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -688,3 +688,14 @@ TEST_F(T_FsTraversal, BlockDevice) {
   traverse.Recurse("/dev");
   EXPECT_LT(0, delegate.num_block_dev);
 }
+
+TEST_F(T_FsTraversal, CharacterDevice) {
+  CustomDelegate delegate("/dev");
+  FileSystemTraversal<CustomDelegate> traverse(&delegate,
+                                                "/dev",
+                                                true);
+  traverse.fn_new_character_dev = &CustomDelegate::CharacterDevice;
+  traverse.fn_ignore_file       = &CustomDelegate::CheckPermissions;
+  traverse.Recurse("/dev");
+  EXPECT_LT(0, delegate.num_character_dev);
+}

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -676,9 +676,9 @@ class CustomDelegate {
     return !can_read;
   }
 
-  int num_block_dev;
-  int num_character_dev;
-  std::string root_path;
+  int                num_block_dev;
+  int                num_character_dev;
+  const std::string  root_path;
 };
 
 TEST_F(T_FsTraversal, BlockDevice) {


### PR DESCRIPTION
This adds support for `S_ISCHR()` in `FsTraversal<>`. @Moliholy did already add quite some file system object types but for some reason the *character device* was missing. This is needed for the integration with `overlayfs`. Furthermore this pull request does some adaptions to `T_FsTraversal` for resilience and testing of the newly added character device.