### PR TITLE
FIX: T_FsTraversal unit test

### DIFF
--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -686,7 +686,7 @@ class CustomDelegate {
                const std::string  &obj_name,
                struct stat        *s) const {
     const std::string file = root_path + "/" + relative_path + "/" + obj_name;
-    const int retval = stat(file.c_str(), s);
+    const int retval = lstat(file.c_str(), s);
     ASSERT_EQ(0, retval) << "cannot stat '" << file << "' (" << errno << ")";
   }
 

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -687,7 +687,7 @@ class CustomDelegate {
                struct stat        *s) const {
     const std::string file = root_path + "/" + relative_path + "/" + obj_name;
     const int retval = stat(file.c_str(), s);
-    ASSERT_EQ(0, retval) << "cannot stat '" << file << "'";
+    ASSERT_EQ(0, retval) << "cannot stat '" << file << "' (" << errno << ")";
   }
 
  public:


### PR DESCRIPTION
On some platforms both `T_FsTraversal::CharacterDevice` and `T_FsTraversal::BlockDevice` were failing due to `stat()`-ing dangling symlinks in `/dev/**`.