### PR TITLE
Test: Preparing unit test set for CVMFS Python Package

### DIFF
--- a/python/cvmfs/test/__main__.py
+++ b/python/cvmfs/test/__main__.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+# make the unittests ignore the installed version of the cvmfs python package
+# Note: this assumes the current directory layout of the package and the tests
+import os, sys, inspect
+cmd_folder =    os.path.dirname(
+                   os.path.dirname(
+                       os.path.realpath(
+                           os.path.abspath(
+                               os.path.split(
+                                   inspect.getfile(inspect.currentframe())
+                               )[0]
+                           )
+                       )
+                   )
+                )
+
+if cmd_folder not in sys.path:
+    sys.path.insert(0, cmd_folder)
+
+from manifest_test     import *
+from md5_handling_test import *
+
+import unittest
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -12,7 +12,6 @@ from dateutil.tz import tzutc
 
 import cvmfs
 
-
 class TestManifest(unittest.TestCase):
     def setUp(self):
         self.sane_manifest = StringIO.StringIO('\n'.join([

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -24,6 +24,9 @@ class TestManifest(unittest.TestCase):
             'S4264',
             'T1390395640',
             'X0b457ac12225018e0a15330364c20529e15012ab',
+            'B12154365',
+            'H8296cd873f8cb00d45fb4fd62a003e711ef06bc5',
+            'Gno',
             '--',
             '0f41e81ed7faade7ad1dafc4be6fa3f7fdc51b05',
             '(§3Êõ0ð¬a˜‚Û}Y„¨x3q    ·EÖ£%²é³üŽ6Ö+>¤XâñÅ=_X‡Ä'
@@ -62,7 +65,9 @@ class TestManifest(unittest.TestCase):
         self.assertTrue(hasattr(manifest, 'revision'))
         self.assertTrue(hasattr(manifest, 'last_modified'))
         self.assertTrue(hasattr(manifest, 'certificate'))
-        self.assertFalse(hasattr(manifest, 'history_database'))
+        self.assertTrue(hasattr(manifest, 'root_catalog_size'))
+        self.assertTrue(hasattr(manifest, 'history_database'))
+        self.assertTrue(hasattr(manifest, 'garbage_collectable'))
         self.assertEqual('600230b0ba7620426f2e898f1e1f43c5466efe59', manifest.root_catalog)
         self.assertEqual(3600                                      , manifest.ttl)
         self.assertEqual('0000000000000000000000000000000000000000', manifest.micro_catalog)
@@ -71,6 +76,9 @@ class TestManifest(unittest.TestCase):
         self.assertEqual(4264                                      , manifest.revision)
         self.assertEqual(last_modified                             , manifest.last_modified)
         self.assertEqual('0b457ac12225018e0a15330364c20529e15012ab', manifest.certificate)
+        self.assertEqual(12154365                                  , manifest.root_catalog_size)
+        self.assertEqual('8296cd873f8cb00d45fb4fd62a003e711ef06bc5', manifest.history_database)
+        self.assertFalse(manifest.garbage_collectable)
 
 
     def test_minimal_manifest(self):


### PR DESCRIPTION
This adds a `__main__.py` to the already partly implemented unit test set for the python library. With that, one can run the unit tests simply by invoking:
`python python/cvmfs/test`

Furthermore this adds all newly added manifest fields to the test case.