### PR TITLE
Python: Whitelist Wrapper

### DIFF
--- a/python/cvmfs/__init__.py
+++ b/python/cvmfs/__init__.py
@@ -5,8 +5,9 @@ Created by René Meusel
 This file is part of the CernVM File System auxiliary tools.
 """
 
-from manifest     import *
 from root_file    import IncompleteRootFileSignature
+from manifest     import *
+from whitelist    import *
 from repository   import *
 from availability import *
 from _common      import _split_md5

--- a/python/cvmfs/__init__.py
+++ b/python/cvmfs/__init__.py
@@ -6,6 +6,7 @@ This file is part of the CernVM File System auxiliary tools.
 """
 
 from manifest     import *
+from root_file    import IncompleteRootFileSignature
 from repository   import *
 from availability import *
 from _common      import _split_md5

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -26,8 +26,8 @@ class Manifest:
     @staticmethod
     def open(manifest_path):
         """ Initializes a Manifest from a local file path """
-        f = open(manifest_path)
-        return Manifest(f)
+        with open(manifest_path) as manifest_file:
+            return Manifest(manifest_file)
 
 
     def __init__(self, manifest_file):

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -19,6 +19,11 @@ class ManifestValidityError(Exception):
     def __init__(self, message):
         Exception.__init__(self, message)
 
+class IncompleteManifestSignature(Exception):
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
+
 
 class Manifest:
     """ Wraps information from .cvmfspublished"""
@@ -32,12 +37,16 @@ class Manifest:
 
     def __init__(self, manifest_file):
         """ Initializes a Manifest object from a file pointer to .cvmfspublished """
+        self.has_signature = False
         for line in manifest_file.readlines():
             if len(line) == 0:
                 continue
             if line[0:2] == "--":
+                self.has_signature = True
                 break
             self._read_line(line)
+        if self.has_signature:
+            self._read_signature(manifest_file)
         self._check_validity()
 
 
@@ -95,3 +104,23 @@ class Manifest:
             raise ManifestValidityError("Manifest lacks a revision entry")
         if not hasattr(self, 'repository_name'):
             raise ManifestValidityError("Manifest lacks a repository name")
+
+
+    def _read_signature(self, manifest_file):
+        """ Reads the signature's checksum and the binary signature string """
+        manifest_file.seek(0)
+        pos = manifest_file.tell()
+        while True:
+            line = manifest_file.readline()
+            if line[0:2] == "--":
+                break
+            if pos == manifest_file.tell():
+                raise IncompleteManifestSignature("Signature not found")
+            pos = manifest_file.tell()
+
+        self.signature_checksum = manifest_file.readline().rstrip()
+        if len(self.signature_checksum) != 40:
+            raise IncompleteManifestSignature("Signature checksum malformed")
+        self.signature = manifest_file.read()
+        if len(self.signature) == 0:
+            raise IncompleteManifestSignature("Binary signature not found")

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -26,7 +26,7 @@ class IncompleteManifestSignature(Exception):
 
 
 class Manifest:
-    """ Wraps information from .cvmfspublished"""
+    """ Wraps information from .cvmfspublished """
 
     @staticmethod
     def open(manifest_path):

--- a/python/cvmfs/root_file.py
+++ b/python/cvmfs/root_file.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+
+A CernVM-FS repository has essential 'root files' that have a defined name and
+serve as entry points into the repository.
+
+Namely the manifest (.cvmfspublished) and the whitelist (.cvmfswhitelist) that
+both have class representations inheriting from RootFile and implementing the
+abstract methods defined here.
+
+Any 'root file' in CernVM-FS is a signed list of line-by-line key-value pairs
+where the key is represented by a single character in the beginning of a line
+directly followed by the value. The key-value part of the file is terminted
+either by EOF or by a termination line (--) followed by a signature.
+
+The signature follows directly after the termination line with a hash of the
+key-value line content (without the termination line) followed by an \n and a
+binary string containing the private-key signature terminated by EOF.
+"""
+
+import abc
+
+class IncompleteRootFileSignature(Exception):
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
+
+class RootFile:
+    """ Base class for CernVM-FS repository's signed 'root files' """
+
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def _read_line(self, line):
+        pass
+
+    @abc.abstractmethod
+    def _check_validity(self):
+        pass
+
+    @abc.abstractmethod
+    def __init__(self, file_object):
+        """ Initializes a root file object from a file pointer """
+        self.has_signature = False
+        for line in file_object.readlines():
+            if len(line) == 0:
+                continue
+            if line[0:2] == "--":
+                self.has_signature = True
+                break
+            self._read_line(line)
+        if self.has_signature:
+            self._read_signature(file_object)
+        self._check_validity()
+
+
+    def _read_signature(self, manifest_file):
+        """ Reads the signature's checksum and the binary signature string """
+        manifest_file.seek(0)
+        pos = manifest_file.tell()
+        while True:
+            line = manifest_file.readline()
+            if line[0:2] == "--":
+                break
+            if pos == manifest_file.tell():
+                raise IncompleteRootFileSignature("Signature not found")
+            pos = manifest_file.tell()
+
+        self.signature_checksum = manifest_file.readline().rstrip()
+        if len(self.signature_checksum) != 40:
+            raise IncompleteRootFileSignature("Signature checksum malformed")
+        self.signature = manifest_file.read()
+        if len(self.signature) == 0:
+            raise IncompleteRootFileSignature("Binary signature not found")

--- a/python/cvmfs/test/__main__.py
+++ b/python/cvmfs/test/__main__.py
@@ -24,6 +24,7 @@ if cmd_folder not in sys.path:
     sys.path.insert(0, cmd_folder)
 
 from manifest_test     import *
+from whitelist_test    import *
 from md5_handling_test import *
 
 import unittest

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -69,6 +69,38 @@ class TestManifest(unittest.TestCase):
         self.minimal_manifest = StringIO.StringIO(
             '\n'.join(self.minimal_manifest_entries) + '\n')
 
+        self.missing_signature = StringIO.StringIO('\n'.join([
+            'C600230b0ba7620426f2e898f1e1f43c5466efe59',
+            'Rd41d8cd98f00b204e9800998ecf8427e',
+            'D3600',
+            'S4264',
+            'Natlas.cern.ch',
+            '--',
+            ''
+        ]))
+
+        self.broken_signature = StringIO.StringIO('\n'.join([
+            'C600230b0ba7620426f2e898f1e1f43c5466efe59',
+            'Rd41d8cd98f00b204e9800998ecf8427e',
+            'D3600',
+            'S4264',
+            'Natlas.cern.ch',
+            '--',
+            'foobar',
+            ''
+        ]))
+
+        self.incomplete_signature = StringIO.StringIO('\n'.join([
+            'C600230b0ba7620426f2e898f1e1f43c5466efe59',
+            'Rd41d8cd98f00b204e9800998ecf8427e',
+            'D3600',
+            'S4264',
+            'Natlas.cern.ch',
+            '--',
+            '0f41e81ed7faade7ad1dafc4be6fa3f7fdc51b05',
+            ''
+        ]))
+
 
     def tearDown(self):
         os.unlink(self.file_manifest)
@@ -154,3 +186,18 @@ class TestManifest(unittest.TestCase):
             incomplete_manifest = StringIO.StringIO('\n'.join(incomplete_manifest_entries))
             self.assertRaises(cvmfs.ManifestValidityError,
                               cvmfs.Manifest, incomplete_manifest)
+
+
+    def test_missing_signature(self):
+        self.assertRaises(cvmfs.IncompleteManifestSignature,
+                          cvmfs.Manifest, self.missing_signature)
+
+
+    def test_missing_signature(self):
+        self.assertRaises(cvmfs.IncompleteManifestSignature,
+                          cvmfs.Manifest, self.broken_signature)
+
+
+    def test_incomplete_signature(self):
+        self.assertRaises(cvmfs.IncompleteManifestSignature,
+                          cvmfs.Manifest, self.incomplete_signature)

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -13,20 +13,11 @@ import unittest
 
 from dateutil.tz import tzutc
 
+from file_sandbox import FileSandbox
+
 import cvmfs
 
-class TestManifest(unittest.TestCase):
-    def writeToTemporary(self, manifest):
-        filename = None
-        with tempfile.NamedTemporaryFile(mode='w+b',
-                                         prefix='py_manifest_ut_',
-                                         dir='/tmp',
-                                         delete=False) as f:
-            filename = f.name
-            f.write(manifest)
-        return filename
-
-
+class TestManifest(FileSandbox):
     def setUp(self):
         self.sane_manifest = StringIO.StringIO('\n'.join([
             'C600230b0ba7620426f2e898f1e1f43c5466efe59',
@@ -44,7 +35,7 @@ class TestManifest(unittest.TestCase):
             '0f41e81ed7faade7ad1dafc4be6fa3f7fdc51b05',
             '(§3Êõ0ð¬a˜‚Û}Y„¨x3q    ·EÖ£%²é³üŽ6Ö+>¤XâñÅ=_X‡Ä'
         ]))
-        self.file_manifest = self.writeToTemporary(self.sane_manifest.getvalue())
+        self.file_manifest = self.write_to_temporary(self.sane_manifest.getvalue())
         self.assertNotEqual(None, self.file_manifest)
 
         self.unknown_field_manifest = StringIO.StringIO('\n'.join([
@@ -102,8 +93,8 @@ class TestManifest(unittest.TestCase):
         ]))
 
 
-    def tearDown(self):
-        os.unlink(self.file_manifest)
+    def temporary_prefix(self):
+        return "py_manifest_ut_"
 
 
     def test_manifest_creation(self):

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -5,14 +5,28 @@ Created by René Meusel
 This file is part of the CernVM File System auxiliary tools.
 """
 
-import unittest
-import StringIO
 import datetime
+import os
+import StringIO
+import tempfile
+import unittest
+
 from dateutil.tz import tzutc
 
 import cvmfs
 
 class TestManifest(unittest.TestCase):
+    def writeToTemporary(self, manifest):
+        filename = None
+        with tempfile.NamedTemporaryFile(mode='w+b',
+                                         prefix='py_manifest_ut_',
+                                         dir='/tmp',
+                                         delete=False) as f:
+            filename = f.name
+            f.write(manifest)
+        return filename
+
+
     def setUp(self):
         self.sane_manifest = StringIO.StringIO('\n'.join([
             'C600230b0ba7620426f2e898f1e1f43c5466efe59',
@@ -30,6 +44,8 @@ class TestManifest(unittest.TestCase):
             '0f41e81ed7faade7ad1dafc4be6fa3f7fdc51b05',
             '(§3Êõ0ð¬a˜‚Û}Y„¨x3q    ·EÖ£%²é³üŽ6Ö+>¤XâñÅ=_X‡Ä'
         ]))
+        self.file_manifest = self.writeToTemporary(self.sane_manifest.getvalue())
+        self.assertNotEqual(None, self.file_manifest)
 
         self.unknown_field_manifest = StringIO.StringIO('\n'.join([
             'C600230b0ba7620426f2e898f1e1f43c5466efe59',
@@ -51,6 +67,9 @@ class TestManifest(unittest.TestCase):
 
         self.minimal_manifest = StringIO.StringIO('\n'.join(
             self.minimal_manifest_entries) + '\n--')
+
+    def tearDown(self):
+        os.unlink(self.file_manifest)
 
 
     def test_manifest_creation(self):

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -189,15 +189,15 @@ class TestManifest(unittest.TestCase):
 
 
     def test_missing_signature(self):
-        self.assertRaises(cvmfs.IncompleteManifestSignature,
+        self.assertRaises(cvmfs.IncompleteRootFileSignature,
                           cvmfs.Manifest, self.missing_signature)
 
 
     def test_missing_signature(self):
-        self.assertRaises(cvmfs.IncompleteManifestSignature,
+        self.assertRaises(cvmfs.IncompleteRootFileSignature,
                           cvmfs.Manifest, self.broken_signature)
 
 
     def test_incomplete_signature(self):
-        self.assertRaises(cvmfs.IncompleteManifestSignature,
+        self.assertRaises(cvmfs.IncompleteRootFileSignature,
                           cvmfs.Manifest, self.incomplete_signature)

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -54,7 +54,8 @@ class TestManifest(unittest.TestCase):
             'Natlas.cern.ch',
             'Rd41d8cd98f00b204e9800998ecf8427e',
             'S4264',
-            'Qi_am_unexpected!'
+            'Qi_am_unexpected!',
+            ''
         ]))
 
         self.minimal_manifest_entries = [
@@ -65,8 +66,9 @@ class TestManifest(unittest.TestCase):
             'Natlas.cern.ch'
         ]
 
-        self.minimal_manifest = StringIO.StringIO('\n'.join(
-            self.minimal_manifest_entries) + '\n--')
+        self.minimal_manifest = StringIO.StringIO(
+            '\n'.join(self.minimal_manifest_entries) + '\n')
+
 
     def tearDown(self):
         os.unlink(self.file_manifest)
@@ -149,6 +151,6 @@ class TestManifest(unittest.TestCase):
         for i in range(len(self.minimal_manifest_entries)):
             incomplete_manifest_entries = list(self.minimal_manifest_entries)
             del incomplete_manifest_entries[i]
-            incomplete_manifest = StringIO.StringIO('\n'.join(incomplete_manifest_entries) + '\n--')
+            incomplete_manifest = StringIO.StringIO('\n'.join(incomplete_manifest_entries))
             self.assertRaises(cvmfs.ManifestValidityError,
                               cvmfs.Manifest, incomplete_manifest)

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -99,6 +99,33 @@ class TestManifest(unittest.TestCase):
         self.assertFalse(manifest.garbage_collectable)
 
 
+    def test_mainfest_from_file(self):
+        manifest = cvmfs.Manifest.open(self.file_manifest)
+        last_modified = datetime.datetime(2014, 1, 22, 13, 0, 40, tzinfo=tzutc())
+        self.assertTrue(hasattr(manifest, 'root_catalog'))
+        self.assertTrue(hasattr(manifest, 'ttl'))
+        self.assertTrue(hasattr(manifest, 'micro_catalog'))
+        self.assertTrue(hasattr(manifest, 'repository_name'))
+        self.assertTrue(hasattr(manifest, 'root_hash'))
+        self.assertTrue(hasattr(manifest, 'revision'))
+        self.assertTrue(hasattr(manifest, 'last_modified'))
+        self.assertTrue(hasattr(manifest, 'certificate'))
+        self.assertTrue(hasattr(manifest, 'root_catalog_size'))
+        self.assertTrue(hasattr(manifest, 'history_database'))
+        self.assertTrue(hasattr(manifest, 'garbage_collectable'))
+        self.assertEqual('600230b0ba7620426f2e898f1e1f43c5466efe59', manifest.root_catalog)
+        self.assertEqual(3600                                      , manifest.ttl)
+        self.assertEqual('0000000000000000000000000000000000000000', manifest.micro_catalog)
+        self.assertEqual('atlas.cern.ch'                           , manifest.repository_name)
+        self.assertEqual('d41d8cd98f00b204e9800998ecf8427e'        , manifest.root_hash)
+        self.assertEqual(4264                                      , manifest.revision)
+        self.assertEqual(last_modified                             , manifest.last_modified)
+        self.assertEqual('0b457ac12225018e0a15330364c20529e15012ab', manifest.certificate)
+        self.assertEqual(12154365                                  , manifest.root_catalog_size)
+        self.assertEqual('8296cd873f8cb00d45fb4fd62a003e711ef06bc5', manifest.history_database)
+        self.assertFalse(manifest.garbage_collectable)
+
+
     def test_minimal_manifest(self):
         manifest = cvmfs.Manifest(self.minimal_manifest)
         self.assertTrue(hasattr(manifest, 'root_catalog'))

--- a/python/cvmfs/test/md5_handling_test.py
+++ b/python/cvmfs/test/md5_handling_test.py
@@ -24,6 +24,7 @@ class TestMD5Handling(unittest.TestCase):
         lo, hi = cvmfs._split_md5(path_md5.digest())
         self.assertEqual((lo, hi), (self.path_md5_lo, self.path_md5_hi))
 
+
     def test_md5_combination(self):
         digest = cvmfs._combine_md5(self.path_md5_lo, self.path_md5_hi)
         path_md5 = hashlib.md5(self.path)

--- a/python/cvmfs/test/whitelist_test.py
+++ b/python/cvmfs/test/whitelist_test.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+import datetime
+import os
+import StringIO
+import tempfile
+import unittest
+
+from dateutil.tz import tzutc
+
+import cvmfs
+
+class TestWhitelist(unittest.TestCase):
+    def writeToTemporary(self, whitelist):
+        filename = None
+        with tempfile.NamedTemporaryFile(mode='w+b',
+                                         prefix='py_whitelist_ut_',
+                                         dir='/tmp',
+                                         delete=False) as f:
+            filename = f.name
+            f.write(whitelist)
+        return filename
+
+
+    def setUp(self):
+        self.sane_whitelist = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            'Natlas.cern.ch',
+            '9A:C3:7D:9E:C5:EB:CF:C8:92:EF:1D:7C:DB:56:DC:9C:83:9A:15:71 # ATLAS Release Manager, expires Sep 2011',
+            'C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4 # Jakob Blomer, expires Jul 2011',
+            'EA:74:15:E5:F5:A4:34:7D:79:37:37:88:33:6A:1E:0D:D0:A4:18:25 # Steve\'s certificate',
+            '--',
+            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '-yw????Z%?????sB????f??1?v_ ',
+            ''
+        ]))
+        self.file_whitelist = self.writeToTemporary(self.sane_whitelist.getvalue())
+        self.assertNotEqual(None, self.file_whitelist)
+
+        self.unknown_field_whitelist = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            'Natlas.cern.ch',
+            'Foo',
+            'EA:74:15:E5:F5:A4:34:7D:79:37:37:88:33:6A:1E:0D:D0:A4:18:25 # Steve\'s certificate',
+            '--',
+            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '-yw????Z%?????sB????f??1?v_ ',
+            ''
+        ]))
+
+        self.invalid_fingerprint_whitelist = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            'Natlas.cern.ch',
+            'C1:2C:2G:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4', # 2G
+            '--',
+            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '-yw????Z%?????sB????f??1?v_ ',
+            ''
+        ]))
+
+        self.invalid_timestamp_whitelist = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E2015070409527', # <--
+            'Natlas.cern.ch',
+            'C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4',
+            ''
+        ]))
+
+        self.missing_field_whitelist = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            #'Natlas.cern.ch',
+            'C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4',
+            '--',
+            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '-yw????Z%?????sB????f??1?v_ ',
+            ''
+        ]))
+
+        self.no_fingerprints_whitelist = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            'Natlas.cern.ch',
+            '--',
+            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '-yw????Z%?????sB????f??1?v_ ',
+            ''
+        ]))
+
+
+    def tearDown(self):
+        os.unlink(self.file_whitelist)
+
+
+    def test_whitelist_creation(self):
+        whitelist = cvmfs.Whitelist(self.sane_whitelist)
+        last_modified = datetime.datetime(2015, 6, 3, 9, 55, 27, tzinfo=tzutc())
+        expires       = datetime.datetime(2015, 7, 4, 9, 55, 27, tzinfo=tzutc())
+        self.assertTrue(hasattr(whitelist, 'last_modified'))
+        self.assertTrue(hasattr(whitelist, 'expires'))
+        self.assertTrue(hasattr(whitelist, 'repository_name'))
+        self.assertTrue(hasattr(whitelist, 'fingerprints'))
+        self.assertEqual(last_modified   , whitelist.last_modified)
+        self.assertEqual(expires         , whitelist.expires)
+        self.assertEqual('atlas.cern.ch' , whitelist.repository_name)
+        self.assertEqual(3               , len(whitelist.fingerprints))
+
+
+    def test_whitelist_creation_from_file(self):
+        whitelist = cvmfs.Whitelist.open(self.file_whitelist)
+        last_modified = datetime.datetime(2015, 6, 3, 9, 55, 27, tzinfo=tzutc())
+        expires       = datetime.datetime(2015, 7, 4, 9, 55, 27, tzinfo=tzutc())
+        self.assertTrue(hasattr(whitelist, 'last_modified'))
+        self.assertTrue(hasattr(whitelist, 'expires'))
+        self.assertTrue(hasattr(whitelist, 'repository_name'))
+        self.assertTrue(hasattr(whitelist, 'fingerprints'))
+        self.assertEqual(last_modified   , whitelist.last_modified)
+        self.assertEqual(expires         , whitelist.expires)
+        self.assertEqual('atlas.cern.ch' , whitelist.repository_name)
+        self.assertEqual(3               , len(whitelist.fingerprints))
+
+
+    def test_unknown_field(self):
+        self.assertRaises(cvmfs.UnknownWhitelistLine,
+                          cvmfs.Whitelist, self.unknown_field_whitelist)
+
+
+    def test_invalid_fingerprint(self):
+        self.assertRaises(cvmfs.UnknownWhitelistLine,
+                          cvmfs.Whitelist, self.invalid_fingerprint_whitelist)
+
+
+    def test_invalid_timestamp(self):
+        self.assertRaises(cvmfs.InvalidWhitelistTimestamp,
+                          cvmfs.Whitelist, self.invalid_timestamp_whitelist)
+
+
+    def test_missing_field(self):
+        self.assertRaises(cvmfs.WhitelistValidityError,
+                          cvmfs.Whitelist, self.missing_field_whitelist)
+
+
+    def test_empty_whitelist(self):
+        self.assertRaises(cvmfs.WhitelistValidityError,
+                          cvmfs.Whitelist, self.no_fingerprints_whitelist)

--- a/python/cvmfs/test/whitelist_test.py
+++ b/python/cvmfs/test/whitelist_test.py
@@ -13,20 +13,11 @@ import unittest
 
 from dateutil.tz import tzutc
 
+from file_sandbox import FileSandbox
+
 import cvmfs
 
-class TestWhitelist(unittest.TestCase):
-    def writeToTemporary(self, whitelist):
-        filename = None
-        with tempfile.NamedTemporaryFile(mode='w+b',
-                                         prefix='py_whitelist_ut_',
-                                         dir='/tmp',
-                                         delete=False) as f:
-            filename = f.name
-            f.write(whitelist)
-        return filename
-
-
+class TestWhitelist(FileSandbox):
     def setUp(self):
         self.sane_whitelist = StringIO.StringIO('\n'.join([
             '20150603095527',
@@ -40,7 +31,7 @@ class TestWhitelist(unittest.TestCase):
             '-yw????Z%?????sB????f??1?v_ ',
             ''
         ]))
-        self.file_whitelist = self.writeToTemporary(self.sane_whitelist.getvalue())
+        self.file_whitelist = self.write_to_temporary(self.sane_whitelist.getvalue())
         self.assertNotEqual(None, self.file_whitelist)
 
         self.unknown_field_whitelist = StringIO.StringIO('\n'.join([
@@ -96,8 +87,8 @@ class TestWhitelist(unittest.TestCase):
         ]))
 
 
-    def tearDown(self):
-        os.unlink(self.file_whitelist)
+    def temporary_prefix(self):
+        return "py_whitelist_ut_"
 
 
     def test_whitelist_creation(self):

--- a/python/cvmfs/whitelist.py
+++ b/python/cvmfs/whitelist.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+from datetime import datetime
+from dateutil.tz import tzutc
+
+import re
+
+from root_file import RootFile
+
+class UnknownWhitelistLine(Exception):
+    def __init__(self, line):
+        Exception.__init__(self, line)
+
+class WhitelistValidityError(Exception):
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
+class InvalidWhitelistTimestamp(Exception):
+    def __init__(self, timestamp):
+        Exception.__init__(self, timestamp)
+
+
+class Whitelist(RootFile):
+    """ Wraps information from .cvmfswhitelist """
+
+    @staticmethod
+    def open(whitelist_path):
+        """ Initializes a whitelist from a local file path """
+        with open(whitelist_path) as manifest_file:
+            return Whitelist(manifest_file)
+
+    _fingerprint_re = None
+    _timestamp_re   = None
+
+    def __init__(self, whitelist_file):
+        self.fingerprints = []
+        self._fingerprint_re = re.compile('^(([0-9A-F]{2}:){19}[0-9A-F]{2}).*')
+        self._timestamp_re   = re.compile('[0-9]{14}')
+        RootFile.__init__(self, whitelist_file)
+
+    def __str__(self):
+        return "<Whitelist for " + self.repository_name + ">"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+    def _read_line(self, line):
+        """ Parse lines that appear in .cvmfswhitelist """
+        # Note: .cvmfswhitelist contains a last_modified field that does not
+        #       have a key_char. However, it is a timestamp starting with the
+        #       full year. We use '2' as the key, assuming that CernVM-FS will
+        #       not sustain the next 1000 years.
+        #
+        # Note: the whitelist contains a list of certificate fingerprints that
+        #       are not prepended by a key either. We use a regex to detect them
+        key_char = line[0]
+        data     = line[1:-1]
+        match    = self._fingerprint_re.search(line[:-1]) # full line!
+        if match:
+            self.fingerprints.append(match.groups(1))
+        elif key_char == "2":
+            self.last_modified   = self._read_timestamp(line[:-1]) # full line!!
+        elif key_char == "E":
+            self.expires         = self._read_timestamp(data)
+        elif key_char == "N":
+            self.repository_name = data
+        else:
+            raise UnknownWhitelistLine(line.strip())
+
+
+    def _check_validity(self):
+        """ Checks that all mandatory fields are found in .cvmfspublished """
+        if not hasattr(self, 'last_modified'):
+            raise WhitelistValidityError("Whitelist without a timestamp")
+        if not hasattr(self, 'expires'):
+            raise WhitelistValidityError("Whitelist without expiry date")
+        if not hasattr(self, 'repository_name'):
+            raise WhitelistValidityError("Whitelist without repository name")
+        if len(self.fingerprints) == 0:
+            raise WhitelistValidityError("No fingerprints are white-listed")
+
+
+    def _read_timestamp(self, timestamp):
+        if not self._timestamp_re.match(timestamp):
+            raise InvalidWhitelistTimestamp(timestamp)
+        return datetime(
+                    year   = int(timestamp[0:4]),
+                    month  = int(timestamp[4:6]),
+                    day    = int(timestamp[6:8]),
+                    hour   = int(timestamp[8:10]),
+                    minute = int(timestamp[10:12]),
+                    second = int(timestamp[12:14]),
+                    tzinfo = tzutc())
+


### PR DESCRIPTION
This factors out some logic from `Manifest` into `RootFile` to reuse it in the newly added `Whitelist` wrapper. Furthermore it contains extensions to the test suite for both `Manifest` and `Whitelist`.