### PR TITLE
FIX: Inspect Python Suitability Beforehand

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -6,6 +6,12 @@ die() {
   exit 1
 }
 
+complain() {
+  local msg="$1"
+  echo "$msg"
+  exit 0
+}
+
 is_linux() {
   [ x"$(uname)" = x"Linux" ]
 }
@@ -85,4 +91,41 @@ server=$server
 unittests=$unittests
 config=$config
 EOF
+}
+
+python_version() {
+  python --version 2>&1 | grep -oh '[0-9]\+\.[0-9]\+.[0-9]\+'
+}
+
+check_python_module() {
+  local module="$1"
+  python -c "import re, ${module}; \
+             print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+}
+
+# makes sure that a version is always of the form x.y.z
+normalize_version() {
+  local version_string="$1"
+  while [ $(echo "$version_string" | grep -o '\.' | wc -l) -lt 2 ]; do
+    version_string="${version_string}.0"
+  done
+  echo "$version_string"
+}
+version_major() { echo $1 | cut --delimiter=. --fields=1; }
+version_minor() { echo $1 | cut --delimiter=. --fields=2; }
+version_patch() { echo $1 | cut --delimiter=. --fields=3; }
+prepend_zeros() { printf %05d "$1"; }
+compare_versions() {
+  local lhs="$(normalize_version $1)"
+  local comparison_operator=$2
+  local rhs="$(normalize_version $3)"
+
+  local lhs1=$(prepend_zeros $(version_major $lhs))
+  local lhs2=$(prepend_zeros $(version_minor $lhs))
+  local lhs3=$(prepend_zeros $(version_patch $lhs))
+  local rhs1=$(prepend_zeros $(version_major $rhs))
+  local rhs2=$(prepend_zeros $(version_minor $rhs))
+  local rhs3=$(prepend_zeros $(version_patch $rhs))
+
+  [ $lhs1$lhs2$lhs3 $comparison_operator $rhs1$rhs2$rhs3 ]
 }

--- a/ci/run_python_unittests.sh
+++ b/ci/run_python_unittests.sh
@@ -20,6 +20,11 @@ if [ $# -gt 1 ]; then
 fi
 PY_UT_XML_PREFIX=$1
 
+# check if python is capable of running the unit tests on the current platform
+which python > /dev/null 2>&1                    || complain "no python available"
+compare_versions "$(python_version)" -gt "2.6.0" || complain "ancient python version"
+check_python_module "xmlrunner"                  || complain "no python-xmlrunner installed"
+
 # run the unit tests
 UNITTESTS="${SCRIPT_LOCATION}/../python/cvmfs/test"
 if [ ! -z "$PY_UT_XML_PREFIX" ]; then


### PR DESCRIPTION
This checks if Python is installed, if it is not ancient (yes < 2.6 is ancient!) and if `python-xmlrunner` is installed on the system.