### PR TITLE
FIX: Python Environment Retrieval

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -112,9 +112,9 @@ normalize_version() {
   done
   echo "$version_string"
 }
-version_major() { echo $1 | cut --delimiter=. --fields=1; }
-version_minor() { echo $1 | cut --delimiter=. --fields=2; }
-version_patch() { echo $1 | cut --delimiter=. --fields=3; }
+version_major() { echo $1 | cut -d. -f1; }
+version_minor() { echo $1 | cut -d. -f2; }
+version_patch() { echo $1 | cut -d. -f3; }
 prepend_zeros() { printf %05d "$1"; }
 compare_versions() {
   local lhs="$(normalize_version $1)"

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -99,8 +99,9 @@ python_version() {
 
 check_python_module() {
   local module="$1"
-  python -c "import re, ${module}; \
-             print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+  python -c "import re, ${module};                                           \
+             print(re.compile('/__init__.py.*').sub('',${module}.__file__))" \
+             > /dev/null 2>&1
 }
 
 # makes sure that a version is always of the form x.y.z


### PR DESCRIPTION
Turns out, that `cut` only knows the short-hand switches `-d` (instead of `--delimiter`) and `-f` (instead of `--field`) on OS X. meh!