### PR TITLE
Python: Verify Signatures of Manifest and Whitelist

### DIFF
--- a/python/cvmfs/__init__.py
+++ b/python/cvmfs/__init__.py
@@ -8,6 +8,7 @@ This file is part of the CernVM File System auxiliary tools.
 from root_file    import IncompleteRootFileSignature
 from manifest     import *
 from whitelist    import *
+from certificate  import *
 from repository   import *
 from availability import *
 from _common      import _split_md5

--- a/python/cvmfs/certificate.py
+++ b/python/cvmfs/certificate.py
@@ -18,7 +18,7 @@ class Certificate(CompressedObject):
         self.openssl_certificate = cert
 
     def __str__(self):
-        return "<Certificate>"
+        return "<Certificate " + self.get_fingerprint() + ">"
 
     def __repr__(self):
         return self.__str__()
@@ -26,6 +26,13 @@ class Certificate(CompressedObject):
     def get_openssl_certificate(self):
         """ return the certificate as M2Crypto.X509 object """
         return self.openssl_certificate
+
+
+    def get_fingerprint(self, algorithm='sha1'):
+        """ returns the fingerprint of the X509 certificate """
+        fp = self.openssl_certificate.get_fingerprint(algorithm)
+        return ':'.join([ x + y for x, y in zip(fp[0::2], fp[1::2]) ])
+
 
     def verify(self, signature, message):
         """ verify a given signature to an expected 'message' string """

--- a/python/cvmfs/certificate.py
+++ b/python/cvmfs/certificate.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+from M2Crypto import X509
+
+from _common import CompressedObject
+
+class Certificate(CompressedObject):
+    """ Wraps an X.509 certificate object as stored in CVMFS repositories """
+
+    def __init__(self, certificate_file):
+        CompressedObject.__init__(self, certificate_file)
+        cert = X509.load_cert_string(self.get_uncompressed_file().read())
+        self.openssl_certificate = cert
+
+    def __str__(self):
+        return "<Certificate>"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def get_openssl_certificate(self):
+        """ return the certificate as M2Crypto.X509 object """
+        return self.openssl_certificate
+
+    def verify(self, signature, message):
+        """ verify a given signature to an expected 'message' string """
+        pubkey = self.openssl_certificate.get_pubkey()
+        pubkey.reset_context(md='sha1')
+        pubkey.verify_init()
+        pubkey.verify_update(message)
+        return pubkey.verify_final(signature)

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -89,3 +89,7 @@ class Manifest(RootFile):
             raise ManifestValidityError("Manifest lacks a revision entry")
         if not hasattr(self, 'repository_name'):
             raise ManifestValidityError("Manifest lacks a repository name")
+
+
+    def _verify_signature(self, public_key_path):
+        return False

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -91,5 +91,5 @@ class Manifest(RootFile):
             raise ManifestValidityError("Manifest lacks a repository name")
 
 
-    def _verify_signature(self, public_key_path):
-        return False
+    def _verify_signature(self, certificate):
+        return certificate.verify(self.signature, self.signature_checksum)

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -19,6 +19,7 @@ import cvmfs
 from manifest import Manifest
 from catalog import Catalog
 from history import History
+from certificate import Certificate
 
 class RepositoryNotFound(Exception):
     def __init__(self, repo_path):
@@ -248,6 +249,11 @@ class Repository:
             raise HistoryNotFound(self)
         history_db = self.retrieve_object(self.manifest.history_database, 'H')
         return History(history_db)
+
+
+    def retrieve_certificate(self):
+        certificate = self.retrieve_object(self.manifest.certificate, 'X')
+        return Certificate(certificate)
 
 
     def retrieve_file(self, file_name):

--- a/python/cvmfs/root_file.py
+++ b/python/cvmfs/root_file.py
@@ -61,6 +61,14 @@ class RootFile:
             self._read_signature(file_object)
         self._check_validity()
 
+    @abc.abstractmethod
+    def _verify_signature(public_entity):
+        pass
+
+
+    def verify_signature(self, public_entity):
+        return self.has_signature and self._verify_signature(public_entity)
+
 
     def _hash_over_content(self, file_object):
         pos = file_object.tell()

--- a/python/cvmfs/root_file.py
+++ b/python/cvmfs/root_file.py
@@ -28,6 +28,10 @@ class IncompleteRootFileSignature(Exception):
     def __init__(self, message):
         Exception.__init__(self, message)
 
+class InvalidRootFileSignature(Exception):
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
 
 class RootFile:
     """ Base class for CernVM-FS repository's signed 'root files' """
@@ -80,6 +84,8 @@ class RootFile:
         self.signature_checksum = file_object.readline().rstrip()
         if len(self.signature_checksum) != 40:
             raise IncompleteRootFileSignature("Signature checksum malformed")
+        if message_digest != self.signature_checksum:
+            raise InvalidRootFileSignature("Signature checksum doesn't match")
         self.signature = file_object.read()
         if len(self.signature) == 0:
             raise IncompleteRootFileSignature("Binary signature not found")

--- a/python/cvmfs/test/__main__.py
+++ b/python/cvmfs/test/__main__.py
@@ -26,6 +26,7 @@ if cmd_folder not in sys.path:
 from manifest_test     import *
 from whitelist_test    import *
 from md5_handling_test import *
+from certificate_test  import *
 
 import optparse
 import sys

--- a/python/cvmfs/test/certificate_test.py
+++ b/python/cvmfs/test/certificate_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+import base64
+
+from M2Crypto.X509 import X509
+
+from file_sandbox import FileSandbox
+import cvmfs
+
+class TestCertificate(FileSandbox):
+    def setUp(self):
+        self.compressed_certificate = '\n'.join([
+            'eJyVlDmvq0gQhXN+xeTWlTFgbAcTNHSDm53LYkPWYNYGA+ay+deP3wtGI71oKqjgVEmfjo6qvr4+',
+            'JSEVW3/J6NvHCpaBj36JX4yJsXysZRmkgiy78kgWxfaqXTe/gSUVdChppV4WVgJuoAAIDqZvLqYb',
+            'wdB1Idr6kSGqVRmt1aStMEVcUbhcuCVNbBlB7GPUBFjRmkQNy5QLCv+mTNHt0aRPc7mWqWX6eGE+',
+            'jTX9gLWgu91+ix+Cj9//avWf1P9Cmf9DLQpUmYBVZW9QPZzw0EUS8/EGgIAluIBfCzro8Mcv1DG5',
+            'uXXiJVvch6UVmncOxjsx4OeXezj2km91Lkv2YcoUwDQe2dPO63GXs7XArfSeT2ZrZwUeW0OwrmvG',
+            'Cq1A+zDv+kgO2h88H0YjvOT+t/0omYYGr1NYNbjn0+aGnrNRBJG2hGzpPuMyL+M+u+3oco6+UzGb',
+            'XDF5y/OmhLsmx4kjT4SJyDRSEiihfs/ZJldeb5PuzcvEvqqATGtipEPGnxpOQa8mLwih97dGLFGU',
+            'dE+rj+6ZUQV5HDa1mO7aYb2AWSHTZrSLnIshD/1OPJXyXCx5aXeZjYxj1DpUIXUa45Mz4mSGjCEJ',
+            'J4dvB/Tuif/TddkpihbT7oVQuHlt1qw2T4f27noacEBhSgCgBbqRpncxLufU+qSAFMkF8JPAZ0hh',
+            'BEt6PmAhFbrxGImb+mBn9nVRLn4pWJofPvQDUkA7vjxqcFH0ZHRnuMv4hy6sthzDV3+lQ+yRya+v',
+            'KtKFbLlVMKmMvX47bHsL9aXonh1pvTzaM/LsTZKYkWtIALOd1xVrmL/pdztCObiofbB+n8ZZJZJu',
+            'U5LzY7ubDUrKmMh+dTKhtM116awDgzK0r9flshqOJGK450+CrBaOgPLJJnl/BZFs7nX9B8WHlK20',
+            'Kz3UaU15XjPJ3LaKz+RWdoqV6bArinRP+vfDXVulyiLzrKRJbIFr5ltSfufKAa0XuCufaRFkhnHO',
+            'Qqo/NjQysr/VLo2Hl7M3mjmcF9torwQAEu9hQW8iNwZ/M78vH1nwz2/wD2fJXIA=',
+            ''
+        ])
+        compressed_cert = base64.b64decode(self.compressed_certificate)
+        self.certificate_file = self.write_to_temporary(compressed_cert)
+
+        self.message_digest = "e380c3276b33440dd3e80af116fd6ee307b8ca6a"
+        self.signature = 'q?\xd8p\r\x98w}3A\xc9/\x05\xd5\xf7\x19\xe1B-4\xcec\xe1\xa7\xb8\xb2&\xdbG\xd9\xc9\x81T\xfa\xdeX\xda\xd3\x11s\\H\xce\x82\xab\xcc\nP+*\x1eO\x02Q\x8f\xb0L\x11\xcd\x8fm\x10\xe7\xcc\xce\xc6\xd4hU\xf0d\x84\x8f\x82\xc3.G<\x1dt\x11\xd51\xb4\x13L t\x92\x02FO\x9e\x8e\xd7\x07#\xb9\xcd\x03)b\xffM\x13\x05v\xa43\xe9t\xbf\xfda\xa9\xb2K\x7f\x8b\xee\xd2\xa3\xb27\xb4\xa6\xc4\x88\xf5\xf9~}0\xdc\x8e\xfa\xf8q\xe6\x90\xf73w=\xd0\xff\xcbX\xdd\x10\x18e\x15\xec\xbb\xbf\xd6\x03\xc4\xf7\x86\x1fr\x11+\xbffmY\xff\x84q\xa1*{ \xca\xf2\nN\x8b\xfc\x85x3`\xab\xd5&\xb3\xb1\x03\xc6G5\xee\xebh\x91\xe3\xd5Y2\x96\x87\xe7\xd2\xaeu\xf7\xea\x80\x9c\xfc\x05HjZ\x81\xb7Qz\xd2p\x8e\xf6\xad\x0c\x9a\xf2\xdd"\x02\xf3\xab\xff2E\x03\xea\xd7W\x9b\xe2^`\xdc\xec5\x92z\xed\x02\xe7\xaa&'
+
+    def temporary_prefix(self):
+        return "py_certificate_ut_"
+
+
+    def test_load(self):
+        with open(self.certificate_file) as cert_file:
+            cert = cvmfs.Certificate(cert_file)
+
+
+    def test_get_openssl_x509(self):
+        with open(self.certificate_file) as cert_file:
+            cert = cvmfs.Certificate(cert_file)
+            x509 = cert.get_openssl_certificate()
+            self.assertTrue(isinstance(x509, X509))
+
+
+    def test_verify_message(self):
+        with open(self.certificate_file) as cert_file:
+            cert = cvmfs.Certificate(cert_file)
+            self.assertTrue(cert.verify(self.signature, self.message_digest))
+
+
+    def test_verify_tampered_message(self):
+        with open(self.certificate_file) as cert_file:
+            cert = cvmfs.Certificate(cert_file)
+            self.assertFalse(cert.verify(self.signature, "I am Malory!"))

--- a/python/cvmfs/test/certificate_test.py
+++ b/python/cvmfs/test/certificate_test.py
@@ -33,6 +33,7 @@ class TestCertificate(FileSandbox):
         ])
         compressed_cert = base64.b64decode(self.compressed_certificate)
         self.certificate_file = self.write_to_temporary(compressed_cert)
+        self.fingerprint = "81:8D:BE:49:A7:3E:F1:C4:DA:01:50:F0:80:D4:CB:27:96:80:1D"
 
         self.message_digest = "e380c3276b33440dd3e80af116fd6ee307b8ca6a"
         self.signature = 'q?\xd8p\r\x98w}3A\xc9/\x05\xd5\xf7\x19\xe1B-4\xcec\xe1\xa7\xb8\xb2&\xdbG\xd9\xc9\x81T\xfa\xdeX\xda\xd3\x11s\\H\xce\x82\xab\xcc\nP+*\x1eO\x02Q\x8f\xb0L\x11\xcd\x8fm\x10\xe7\xcc\xce\xc6\xd4hU\xf0d\x84\x8f\x82\xc3.G<\x1dt\x11\xd51\xb4\x13L t\x92\x02FO\x9e\x8e\xd7\x07#\xb9\xcd\x03)b\xffM\x13\x05v\xa43\xe9t\xbf\xfda\xa9\xb2K\x7f\x8b\xee\xd2\xa3\xb27\xb4\xa6\xc4\x88\xf5\xf9~}0\xdc\x8e\xfa\xf8q\xe6\x90\xf73w=\xd0\xff\xcbX\xdd\x10\x18e\x15\xec\xbb\xbf\xd6\x03\xc4\xf7\x86\x1fr\x11+\xbffmY\xff\x84q\xa1*{ \xca\xf2\nN\x8b\xfc\x85x3`\xab\xd5&\xb3\xb1\x03\xc6G5\xee\xebh\x91\xe3\xd5Y2\x96\x87\xe7\xd2\xaeu\xf7\xea\x80\x9c\xfc\x05HjZ\x81\xb7Qz\xd2p\x8e\xf6\xad\x0c\x9a\xf2\xdd"\x02\xf3\xab\xff2E\x03\xea\xd7W\x9b\xe2^`\xdc\xec5\x92z\xed\x02\xe7\xaa&'
@@ -63,3 +64,9 @@ class TestCertificate(FileSandbox):
         with open(self.certificate_file) as cert_file:
             cert = cvmfs.Certificate(cert_file)
             self.assertFalse(cert.verify(self.signature, "I am Malory!"))
+
+
+    def test_certificate_fingerprint(self):
+        with open(self.certificate_file) as cert_file:
+            cert = cvmfs.Certificate(cert_file)
+            self.assertEqual(self.fingerprint, cert.get_fingerprint())

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -32,7 +32,7 @@ class TestManifest(FileSandbox):
             'H8296cd873f8cb00d45fb4fd62a003e711ef06bc5',
             'Gno',
             '--',
-            '0f41e81ed7faade7ad1dafc4be6fa3f7fdc51b05',
+            '90d52f3d6d29ce142a75949f815f05580af61974',
             '(§3Êõ0ð¬a˜‚Û}Y„¨x3q    ·EÖ£%²é³üŽ6Ö+>¤XâñÅ=_X‡Ä'
         ]))
         self.file_manifest = self.write_to_temporary(self.sane_manifest.getvalue())
@@ -88,7 +88,7 @@ class TestManifest(FileSandbox):
             'S4264',
             'Natlas.cern.ch',
             '--',
-            '0f41e81ed7faade7ad1dafc4be6fa3f7fdc51b05',
+            'b748926022513a4398743d31c49578bc3a5fc3ef',
             ''
         ]))
 

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -42,20 +42,18 @@ class TestManifest(FileSandbox):
         self.certificate_file = self.write_to_temporary(compressed_cert)
 
         self.sane_manifest = StringIO.StringIO('\n'.join([
-            'C600230b0ba7620426f2e898f1e1f43c5466efe59',
-            'D3600',
-            'L0000000000000000000000000000000000000000',
-            'Natlas.cern.ch',
+            'C044206fcff4545283aaa452b80edfd5d8c740b20',
+            'B75834368',
             'Rd41d8cd98f00b204e9800998ecf8427e',
-            'S4264',
-            'T1390395640',
+            'D900',
+            'S8722',
+            'Natlas.cern.ch',
             'X0b457ac12225018e0a15330364c20529e15012ab',
-            'B12154365',
-            'H8296cd873f8cb00d45fb4fd62a003e711ef06bc5',
-            'Gno',
+            'H50c37f5517aea2ce9a22c3f17a7056a4f60e7d07',
+            'T1433937750',
             '--',
-            '90d52f3d6d29ce142a75949f815f05580af61974',
-            '(§3Êõ0ð¬a˜‚Û}Y„¨x3q    ·EÖ£%²é³üŽ6Ö+>¤XâñÅ=_X‡Ä'
+            'e7d58bfaaf75e9b725aa23c3a666daffd6351b8f',
+            '"P4\x99a>LR\x8eE\x91\xdb\xf13\xd9\xec!\xfe\x81\xf4\x1d\x98\xbe\xa7\x80:D\xcd0\x12\x06\x84\x0c(\x89\xe3\x01\x03s\x02\r\x14\xe3\x00{E\x18\x11E/\xa1)\xd7\xc7\x1a\x7f\xf1k"\x08\xbf\xdb3\xa1\xec-8\xb3z\xd5\x95\xcel\x82\x8a\x9a\xb5\xb6\x14\xd8sD\x80\xa7X\x0fx\x03T\x07\x12\xa6\'E\x04\x06\xf9\x17\'s\xeb\xfe\x19`l\xe7\xf4\x96,2\x84-\xa0\xbd.\x86#\xe0\xc09l\xc0\xcbZ\x95\x14# \xc4\xc7\xe1\x00\xc0\x84>\x8a\xae\x86\xc0\xe5\xa82\xc9\x86\xe5\x19\xe7\x85n\xac\xb4\xd8\x0bX\x81q\xdb\x97q\xe8\xacz\xd5\xfa+\n(\xe1\x0c\xff.\x91\xa2\x00\xfa"\xa5IS\xc5\xac\x13&\xda\x96+\xc6mU3\xb0\xd8\x92)Jd\xc14O\x02Gd\x90!\xdf\x06\x9f\xf4\xa5\xd2y\xab\x8c\xf6\x13\xe0d)\x90\xd7\x14\xb5\xf2f%\x80D\x94\xe0d\xb8\xe3\x17\xc4\x0f\xa5\x14\x08\xf4x\xd4\x7f\xa0T\xd4\xb9\xc0\x81d\x9bD\xe8V\xe5\x90\x16'
         ]))
         self.file_manifest = self.write_to_temporary(self.sane_manifest.getvalue())
         self.assertNotEqual(None, self.file_manifest)
@@ -121,10 +119,9 @@ class TestManifest(FileSandbox):
 
     def test_manifest_creation(self):
         manifest = cvmfs.Manifest(self.sane_manifest)
-        last_modified = datetime.datetime(2014, 1, 22, 13, 0, 40, tzinfo=tzutc())
+        last_modified = datetime.datetime(2015, 6, 10, 12, 2, 30, tzinfo=tzutc())
         self.assertTrue(hasattr(manifest, 'root_catalog'))
         self.assertTrue(hasattr(manifest, 'ttl'))
-        self.assertTrue(hasattr(manifest, 'micro_catalog'))
         self.assertTrue(hasattr(manifest, 'repository_name'))
         self.assertTrue(hasattr(manifest, 'root_hash'))
         self.assertTrue(hasattr(manifest, 'revision'))
@@ -132,26 +129,22 @@ class TestManifest(FileSandbox):
         self.assertTrue(hasattr(manifest, 'certificate'))
         self.assertTrue(hasattr(manifest, 'root_catalog_size'))
         self.assertTrue(hasattr(manifest, 'history_database'))
-        self.assertTrue(hasattr(manifest, 'garbage_collectable'))
-        self.assertEqual('600230b0ba7620426f2e898f1e1f43c5466efe59', manifest.root_catalog)
-        self.assertEqual(3600                                      , manifest.ttl)
-        self.assertEqual('0000000000000000000000000000000000000000', manifest.micro_catalog)
+        self.assertEqual('044206fcff4545283aaa452b80edfd5d8c740b20', manifest.root_catalog)
+        self.assertEqual(900                                       , manifest.ttl)
         self.assertEqual('atlas.cern.ch'                           , manifest.repository_name)
         self.assertEqual('d41d8cd98f00b204e9800998ecf8427e'        , manifest.root_hash)
-        self.assertEqual(4264                                      , manifest.revision)
+        self.assertEqual(8722                                      , manifest.revision)
         self.assertEqual(last_modified                             , manifest.last_modified)
         self.assertEqual('0b457ac12225018e0a15330364c20529e15012ab', manifest.certificate)
-        self.assertEqual(12154365                                  , manifest.root_catalog_size)
-        self.assertEqual('8296cd873f8cb00d45fb4fd62a003e711ef06bc5', manifest.history_database)
-        self.assertFalse(manifest.garbage_collectable)
+        self.assertEqual(75834368                                  , manifest.root_catalog_size)
+        self.assertEqual('50c37f5517aea2ce9a22c3f17a7056a4f60e7d07', manifest.history_database)
 
 
     def test_mainfest_from_file(self):
         manifest = cvmfs.Manifest.open(self.file_manifest)
-        last_modified = datetime.datetime(2014, 1, 22, 13, 0, 40, tzinfo=tzutc())
+        last_modified = datetime.datetime(2015, 6, 10, 12, 2, 30, tzinfo=tzutc())
         self.assertTrue(hasattr(manifest, 'root_catalog'))
         self.assertTrue(hasattr(manifest, 'ttl'))
-        self.assertTrue(hasattr(manifest, 'micro_catalog'))
         self.assertTrue(hasattr(manifest, 'repository_name'))
         self.assertTrue(hasattr(manifest, 'root_hash'))
         self.assertTrue(hasattr(manifest, 'revision'))
@@ -159,18 +152,15 @@ class TestManifest(FileSandbox):
         self.assertTrue(hasattr(manifest, 'certificate'))
         self.assertTrue(hasattr(manifest, 'root_catalog_size'))
         self.assertTrue(hasattr(manifest, 'history_database'))
-        self.assertTrue(hasattr(manifest, 'garbage_collectable'))
-        self.assertEqual('600230b0ba7620426f2e898f1e1f43c5466efe59', manifest.root_catalog)
-        self.assertEqual(3600                                      , manifest.ttl)
-        self.assertEqual('0000000000000000000000000000000000000000', manifest.micro_catalog)
+        self.assertEqual('044206fcff4545283aaa452b80edfd5d8c740b20', manifest.root_catalog)
+        self.assertEqual(900                                       , manifest.ttl)
         self.assertEqual('atlas.cern.ch'                           , manifest.repository_name)
         self.assertEqual('d41d8cd98f00b204e9800998ecf8427e'        , manifest.root_hash)
-        self.assertEqual(4264                                      , manifest.revision)
+        self.assertEqual(8722                                      , manifest.revision)
         self.assertEqual(last_modified                             , manifest.last_modified)
         self.assertEqual('0b457ac12225018e0a15330364c20529e15012ab', manifest.certificate)
-        self.assertEqual(12154365                                  , manifest.root_catalog_size)
-        self.assertEqual('8296cd873f8cb00d45fb4fd62a003e711ef06bc5', manifest.history_database)
-        self.assertFalse(manifest.garbage_collectable)
+        self.assertEqual(75834368                                  , manifest.root_catalog_size)
+        self.assertEqual('50c37f5517aea2ce9a22c3f17a7056a4f60e7d07', manifest.history_database)
 
 
     def test_minimal_manifest(self):

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -5,6 +5,7 @@ Created by René Meusel
 This file is part of the CernVM File System auxiliary tools.
 """
 
+import base64
 import datetime
 import os
 import StringIO
@@ -19,6 +20,27 @@ import cvmfs
 
 class TestManifest(FileSandbox):
     def setUp(self):
+        self.compressed_certificate = '\n'.join([
+            'eJxllLmOq1gQQHO+YnLUMtDG4OAFdwODWc1iIDOYxew0q/n6cU8wyauodHSkUqmWr69PQCIrxj+I',
+            '3FxFUhBwyS/8onRFQccSIZB0CNl4CkPLYrtHIGJgwLwaiuoln1cGAtuTAAa77pJVW0Ps2zYm76Kg',
+            'nvJWJG++jAJ11hqjU4hRJw1/dx1W9t7Qie5bHQZGrRC2iBup/Xi7Do8Bdsmm42SjTJfwOvY2Q+p+',
+            '4fsXmvh/tur7R0SiDFiPgE3vwuA2hoE+h5z/jl98ST0QxL/V/YqZbrWee40/RndpjxxohHe+iD5i',
+            'sn9adJQV26F67SKlWBID2ARCG2Aqz4kF8EewO/TJIdBjNEnfUxspTHSCpaem45Yb8syRc9TTIx2+',
+            'uFzoWgk0D604y9RQbvIkDius8Njmg9nLHWqP/TTlImm2Q+uxOo5VMDyuomey65ZMoYNy9ZAflRqx',
+            'zEi59Ok6CBUOaU8RnRMyewW5AuQjjWuKPGba5GQBXcNbX17opJaP9Perjq2n1p84LJ0NqkSZSdTG',
+            'YGm59Gttq4dMzLlHF4usbmzZ2sYX3ZTENYZ25TyEBnZSx3Z+xrnv+RT/KNT67UQ8mI5qxhUnw4sv',
+            'c7vlXI+nLUWcxJQ3lWltV2+wOMWhnZBxaxdVBSGj5cTOpplKpS01Jk5hD1M43OJntNy6JQiRkJAS',
+            'stkhUiSzcggCKwHA/Xu5KADMzwQIWJkytdPoGgp75OFEep4SeQo6v6rol4rsq+CZmRtfZWScBfm+',
+            'BMf4ehh4kFIOdLRzvtepQEf38bK0l+v48NkIG8EG0ltj2NNxSplDLXqXlNi+V7N2pvhLKfpHf9YY',
+            'qk7qyIxzQW6Syqqf0ZhIqW+9cLjT6CbNZyxwlpMqluqqfXDPfe5aOeXhwDn+4g5yaFEwYuF5Bm27',
+            '6I3/cPKfMRgyvp/gyVwaa17S6soH9n5d70X582Mo+IQux83JaVQcGJM9U/39eOG9bm93etYjiTH4',
+            'gj0NUHy+jF7bnPGSvZ+zZ4ZBy77nn37a4XAZXqNys2BYZqJDOeL9wVSZFJmCtyfaUAvWub3Ygee7',
+            'HgJ//lD/XT0x8N+f4F81GFZb',
+            ''
+        ])
+        compressed_cert = base64.b64decode(self.compressed_certificate)
+        self.certificate_file = self.write_to_temporary(compressed_cert)
+
         self.sane_manifest = StringIO.StringIO('\n'.join([
             'C600230b0ba7620426f2e898f1e1f43c5466efe59',
             'D3600',

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -89,6 +89,23 @@ class TestManifest(FileSandbox):
             #                      ^-- this byte used to be a 'd'
         ]))
 
+        self.full_manifest = StringIO.StringIO('\n'.join([
+            'C044206fcff4545283aaa452b80edfd5d8c740b20',
+            'B75834368',
+            'Rd41d8cd98f00b204e9800998ecf8427e',
+            'D900',
+            'L0000000000000000000000000000000000000000',
+            'S8722',
+            'Natlas.cern.ch',
+            'X0b457ac12225018e0a15330364c20529e15012ab',
+            'H50c37f5517aea2ce9a22c3f17a7056a4f60e7d07',
+            'T1433937750',
+            'Gno',
+            '--',
+            'd79461faeaedc6875ee1592967811deee3fe2b99',
+            'invalid signature'
+        ]))
+
         self.unknown_field_manifest = StringIO.StringIO('\n'.join([
             'C600230b0ba7620426f2e898f1e1f43c5466efe59',
             'D3600',
@@ -192,6 +209,33 @@ class TestManifest(FileSandbox):
         self.assertEqual('0b457ac12225018e0a15330364c20529e15012ab', manifest.certificate)
         self.assertEqual(75834368                                  , manifest.root_catalog_size)
         self.assertEqual('50c37f5517aea2ce9a22c3f17a7056a4f60e7d07', manifest.history_database)
+
+
+    def test_full_manifest(self):
+        manifest = cvmfs.Manifest(self.full_manifest)
+        last_modified = datetime.datetime(2015, 6, 10, 12, 2, 30, tzinfo=tzutc())
+        self.assertTrue(hasattr(manifest, 'root_catalog'))
+        self.assertTrue(hasattr(manifest, 'ttl'))
+        self.assertTrue(hasattr(manifest, 'micro_catalog'))
+        self.assertTrue(hasattr(manifest, 'repository_name'))
+        self.assertTrue(hasattr(manifest, 'root_hash'))
+        self.assertTrue(hasattr(manifest, 'revision'))
+        self.assertTrue(hasattr(manifest, 'last_modified'))
+        self.assertTrue(hasattr(manifest, 'certificate'))
+        self.assertTrue(hasattr(manifest, 'root_catalog_size'))
+        self.assertTrue(hasattr(manifest, 'history_database'))
+        self.assertTrue(hasattr(manifest, 'garbage_collectable'))
+        self.assertEqual('044206fcff4545283aaa452b80edfd5d8c740b20', manifest.root_catalog)
+        self.assertEqual(900                                       , manifest.ttl)
+        self.assertEqual('0000000000000000000000000000000000000000', manifest.micro_catalog)
+        self.assertEqual('atlas.cern.ch'                           , manifest.repository_name)
+        self.assertEqual('d41d8cd98f00b204e9800998ecf8427e'        , manifest.root_hash)
+        self.assertEqual(8722                                      , manifest.revision)
+        self.assertEqual(last_modified                             , manifest.last_modified)
+        self.assertEqual('0b457ac12225018e0a15330364c20529e15012ab', manifest.certificate)
+        self.assertEqual(75834368                                  , manifest.root_catalog_size)
+        self.assertEqual('50c37f5517aea2ce9a22c3f17a7056a4f60e7d07', manifest.history_database)
+        self.assertFalse(                                             manifest.garbage_collectable)
 
 
     def test_minimal_manifest(self):

--- a/python/cvmfs/test/whitelist_test.py
+++ b/python/cvmfs/test/whitelist_test.py
@@ -71,7 +71,7 @@ class TestWhitelist(FileSandbox):
             #'Natlas.cern.ch',
             'C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4',
             '--',
-            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '006982cdd72e5342283e96db5c312ec65ab7f652',
             '-yw????Z%?????sB????f??1?v_ ',
             ''
         ]))
@@ -81,7 +81,7 @@ class TestWhitelist(FileSandbox):
             'E20150704095527',
             'Natlas.cern.ch',
             '--',
-            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '7ceba0a0533bfae3d1812beac2e87e4ecb684ecd',
             '-yw????Z%?????sB????f??1?v_ ',
             ''
         ]))
@@ -109,7 +109,7 @@ class TestWhitelist(FileSandbox):
             'E20150704095527',
             'Natlas.cern.ch',
             '--',
-            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '7ceba0a0533bfae3d1812beac2e87e4ecb684ecd',
             ''
         ]))
 

--- a/python/cvmfs/test/whitelist_test.py
+++ b/python/cvmfs/test/whitelist_test.py
@@ -19,6 +19,20 @@ import cvmfs
 
 class TestWhitelist(FileSandbox):
     def setUp(self):
+        self.cern_public_key = '\n'.join([
+            '-----BEGIN PUBLIC KEY-----',
+            'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAukBusmYyFW8KJxVMmeCj',
+            'N7vcU1mERMpDhPTa5PgFROSViiwbUsbtpP9CvfxB/KU1gggdbtWOTZVTQqA3b+p8',
+            'g5Vve3/rdnN5ZEquxeEfIG6iEZta9Zei5mZMeuK+DPdyjtvN1wP0982ppbZzKRBu',
+            'BbzR4YdrwwWXXNZH65zZuUISDJB4my4XRoVclrN5aGVz4PjmIZFlOJ+ytKsMlegW',
+            'SNDwZO9z/YtBFil/Ca8FJhRPFMKdvxK+ezgq+OQWAerVNX7fArMC+4Ya5pF3ASr6',
+            '3mlvIsBpejCUBygV4N2pxIcPJu/ZDaikmVvdPTNOTZlIFMf4zIP/YHegQSJmOyVp',
+            'HQIDAQAB',
+            '-----END PUBLIC KEY-----'
+            ''
+        ])
+        self.public_key_file = self.write_to_temporary(self.cern_public_key)
+
         self.sane_whitelist = StringIO.StringIO('\n'.join([
             '20150603095527',
             'E20150704095527',
@@ -28,11 +42,33 @@ class TestWhitelist(FileSandbox):
             'EA:74:15:E5:F5:A4:34:7D:79:37:37:88:33:6A:1E:0D:D0:A4:18:25 # Steve\'s certificate',
             '--',
             '65a35687479260c90d38e4e114dbc345fde90bbb',
-            '-yw????Z%?????sB????f??1?v_ ',
-            ''
+            '-yw\xfc\xa1\xa9\xc4Z%\xfd\x1d\xdf\x17\xa7\xa8\x99sB\x8a\xd9\xe0\xb1?f\xba\x1a\xa61\xa2v_\t\x1bl\x1a\xd9\x7f\n\x01\x9f\xf5\xf8j;\xf6\xaa;\xc7n\xfc\xc8\xa9{\xb5\xe2E.<?G\xfc|[f\'Xd\x05=u]\xc1\t?M\xb4\xab\x164\xc8\x0b\xec-<\xa0\xf6;E\x08\xdb@\xd6\x88!|\xb0f\x9c\xe3\x1a.\x04l\x8b)o\x89i\xdb\\\xf9\xff\xec\xebM\xc3\x87\x98\x8f\xc9\xea\xf1L\xa4\x08\x1b\xe9\xda\xf6\xff\xd1\xd3GN\x82AD\xd9\xc3\xd1\xdf\x17\x06\xd4Ad\xafS"\xc0\x8b\xc3\xeb\xa6\xe9\xaa\xf6\x90\xc7\x11PV\xa5Ls\xb5\x9b\xd2;\xdci\xdb\xa9\x03\x02\xf1\x8c\xb8^l\xb5\xb9\x11\xe1\xa0aM\x17\xe8\x8e\x7f;u\xa5S\xdc\xb2V\xa1\xe0\x91\x14\x02\xee\xe0a\x99\xda\xbc\x9cK\x1d\xa5\xf7\x13$:W\x91\xe6\xe6\x1f\xc4\xd7\x04\xbc\xe0\x86\xcb\x97\x17\x16 \xc0>\x04\x13\xbfr\xc6\xdeYn\xe8t+\xb4#\x05\xa6\xda\xef\xfd\xf6\x9c\xbf'
         ]))
         self.file_whitelist = self.write_to_temporary(self.sane_whitelist.getvalue())
         self.assertNotEqual(None, self.file_whitelist)
+
+        self.insane_whitelist_signature_mismatch = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            'Natlas.cern.ch',
+            'C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4',
+            '--',
+            '3fa17242c67b5f3e54b85bc6e4544cd9d80a8ac7',
+            '-yw\xfc\xa1\xa9\xc4Z%\xfd\x1d\xdf\x17\xa7\xa8\x99sB\x8a\xd9\xe0\xb1?f\xba\x1a\xa61\xa2v_\t\x1bl\x1a\xd9\x7f\n\x01\x9f\xf5\xf8j;\xf6\xaa;\xc7n\xfc\xc8\xa9{\xb5\xe2E.<?G\xfc|[f\'Xd\x05=u]\xc1\t?M\xb4\xab\x164\xc8\x0b\xec-<\xa0\xf6;E\x08\xdb@\xd6\x88!|\xb0f\x9c\xe3\x1a.\x04l\x8b)o\x89i\xdb\\\xf9\xff\xec\xebM\xc3\x87\x98\x8f\xc9\xea\xf1L\xa4\x08\x1b\xe9\xda\xf6\xff\xd1\xd3GN\x82AD\xd9\xc3\xd1\xdf\x17\x06\xd4Ad\xafS"\xc0\x8b\xc3\xeb\xa6\xe9\xaa\xf6\x90\xc7\x11PV\xa5Ls\xb5\x9b\xd2;\xdci\xdb\xa9\x03\x02\xf1\x8c\xb8^l\xb5\xb9\x11\xe1\xa0aM\x17\xe8\x8e\x7f;u\xa5S\xdc\xb2V\xa1\xe0\x91\x14\x02\xee\xe0a\x99\xda\xbc\x9cK\x1d\xa5\xf7\x13$:W\x91\xe6\xe6\x1f\xc4\xd7\x04\xbc\xe0\x86\xcb\x97\x17\x16 \xc0>\x04\x13\xbfr\xc6\xdeYn\xe8t+\xb4#\x05\xa6\xda\xef\xfd\xf6\x9c\xbf'
+        ]))
+
+        self.insane_whitelist_broken_signature = StringIO.StringIO('\n'.join([
+            '20150603095527',
+            'E20150704095527',
+            'Natlas.cern.ch',
+            '9A:C3:7D:9E:C5:EB:CF:C8:92:EF:1D:7C:DB:56:DC:9C:83:9A:15:71 # ATLAS Release Manager, expires Sep 2011',
+            'C1:2C:2F:7B:B6:8E:82:CF:50:8A:1D:2B:05:5F:14:1B:69:E6:44:E4 # Jakob Blomer, expires Jul 2011',
+            'EA:74:15:E5:F5:A4:34:7D:79:37:37:88:33:6A:1E:0D:D0:A4:18:25 # Steve\'s certificate',
+            '--',
+            '65a35687479260c90d38e4e114dbc345fde90bbb',
+            '-yx\xfc\xa1\xa9\xc4Z%\xfd\x1d\xdf\x17\xa7\xa8\x99sB\x8a\xd9\xe0\xb1?f\xba\x1a\xa61\xa2v_\t\x1bl\x1a\xd9\x7f\n\x01\x9f\xf5\xf8j;\xf6\xaa;\xc7n\xfc\xc8\xa9{\xb5\xe2E.<?G\xfc|[f\'Xd\x05=u]\xc1\t?M\xb4\xab\x164\xc8\x0b\xec-<\xa0\xf6;E\x08\xdb@\xd6\x88!|\xb0f\x9c\xe3\x1a.\x04l\x8b)o\x89i\xdb\\\xf9\xff\xec\xebM\xc3\x87\x98\x8f\xc9\xea\xf1L\xa4\x08\x1b\xe9\xda\xf6\xff\xd1\xd3GN\x82AD\xd9\xc3\xd1\xdf\x17\x06\xd4Ad\xafS"\xc0\x8b\xc3\xeb\xa6\xe9\xaa\xf6\x90\xc7\x11PV\xa5Ls\xb5\x9b\xd2;\xdci\xdb\xa9\x03\x02\xf1\x8c\xb8^l\xb5\xb9\x11\xe1\xa0aM\x17\xe8\x8e\x7f;u\xa5S\xdc\xb2V\xa1\xe0\x91\x14\x02\xee\xe0a\x99\xda\xbc\x9cK\x1d\xa5\xf7\x13$:W\x91\xe6\xe6\x1f\xc4\xd7\x04\xbc\xe0\x86\xcb\x97\x17\x16 \xc0>\x04\x13\xbfr\xc6\xdeYn\xe8t+\xb4#\x05\xa6\xda\xef\xfd\xf6\x9c\xbf'
+            #  ^-- that byte has been tampered with (was 'w')
+        ]))
 
         self.unknown_field_whitelist = StringIO.StringIO('\n'.join([
             '20150603095527',
@@ -185,3 +221,21 @@ class TestWhitelist(FileSandbox):
     def test_incomplete_signature(self):
         self.assertRaises(cvmfs.IncompleteRootFileSignature,
                           cvmfs.Whitelist, self.incomplete_signature)
+
+
+    def test_verify_signature(self):
+        whitelist = cvmfs.Whitelist(self.sane_whitelist)
+        signature_valid = whitelist.verify_signature(self.public_key_file)
+        self.assertTrue(signature_valid)
+
+
+    def test_verify_mismatching_signature(self):
+        whitelist = cvmfs.Whitelist(self.insane_whitelist_signature_mismatch)
+        signature_valid = whitelist.verify_signature(self.public_key_file)
+        self.assertFalse(signature_valid)
+
+
+    def test_verify_malformed_signature(self):
+        whitelist = cvmfs.Whitelist(self.insane_whitelist_broken_signature)
+        signature_valid = whitelist.verify_signature(self.public_key_file)
+        self.assertFalse(signature_valid)

--- a/python/cvmfs/whitelist.py
+++ b/python/cvmfs/whitelist.py
@@ -7,6 +7,7 @@ This file is part of the CernVM File System auxiliary tools.
 
 from datetime import datetime
 from dateutil.tz import tzutc
+from M2Crypto import RSA
 
 import re
 
@@ -84,6 +85,15 @@ class Whitelist(RootFile):
             raise WhitelistValidityError("Whitelist without repository name")
         if len(self.fingerprints) == 0:
             raise WhitelistValidityError("No fingerprints are white-listed")
+
+
+    def _verify_signature(self, public_key_path):
+        pubkey = RSA.load_pub_key(public_key_path)
+        try:
+            sig_sum = pubkey.public_decrypt(self.signature, RSA.pkcs1_padding)
+            return sig_sum == self.signature_checksum
+        except RSA.RSAError, e:
+            return False
 
 
     def _read_timestamp(self, timestamp):


### PR DESCRIPTION
This allows the verification of the signatures both in the `Manifest` and the `Whitelist`. I am using `M2Crypto` for this, because its both available for RedHat and provides a simple wrapper around libopenssl. What is missing, is the integration of these verifications into a simple method call.

In detail, this introduces `Certificate` as python class, so that one can simply do:
```python
import cvmfs
repo = cvmfs.open_repository("http://cvmfs-stratum-one.cern.ch/cvmfs/altas.cern.ch")
cert = repo.retrieve_certificate()
repo.manifest.verify_signature(cert)

# missing:
repo.verify_whitelist("/etc/cvmfs/keys/cern.ch/cern.ch.pub")
# and/or:
repo.open_repository("http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch", "/etc/cvmfs/keys/cern.ch/cern.ch.pub")
```

As always: Additional tests added to the python unit test suite.