### PR TITLE
FIX: enable docker pull and push from local repository

### DIFF
--- a/python/statistics_comparison.py
+++ b/python/statistics_comparison.py
@@ -8,7 +8,7 @@ import tempfile
 from docker import Client
 from parser import Parser
 
-image = "moliholy/slc6"
+image = "cvm-dockerhub02:5000/slc6"
 tag = "cvmfs"
 tmpdir = tempfile.mkdtemp(prefix="comparison.", dir="/tmp")
 
@@ -160,7 +160,7 @@ def main():
     # download firstly the image
     print("Downloading the image " + image + ":" + tag)
     c = Client(base_url=args.socket_url, version=args.docker_api_version)
-    c.pull(repository=image, tag=tag)
+    c.pull(repository=image, tag=tag, insecure_registry=True)
     # stop all running containers before
     for container in c.containers():
         print("    Stopping container " + container["Id"])


### PR DESCRIPTION
However now it prints an ugly warning while downloading the image, but it works like a charm.
```
/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
```

After a bit of research it looks like there is nothing to do in order to suppress that warning...