### PR TITLE
FIX: Platform dependent Python Package RPM

### DIFF
--- a/ci/build_python-cvmfsutils_rpm.sh
+++ b/ci/build_python-cvmfsutils_rpm.sh
@@ -42,7 +42,7 @@ python setup.py bdist_rpm                                                       
   --requires 'python-requests >= 1.1.0, python-dateutil >= 1.4.1, m2crypto >= 0.20.0' \
   --dist-dir "$CVMFS_RESULT_LOCATION"                                                 \
   --build-requires 'python-setuptools >= 0.6.10'                                      \
-  --release 1
+  --release "1%{?dist}"  # appends RPM dist tag (el6, el7, fc19, ...)
 
 echo "switching to ${CVMFS_RESULT_LOCATION}"
 cd ${CVMFS_RESULT_LOCATION}

--- a/ci/build_python-cvmfsutils_rpm.sh
+++ b/ci/build_python-cvmfsutils_rpm.sh
@@ -41,7 +41,7 @@ echo "build the RPM package..."
 python setup.py bdist_rpm                                                             \
   --requires 'python-requests >= 1.1.0, python-dateutil >= 1.4.1, m2crypto >= 0.20.0' \
   --dist-dir "$CVMFS_RESULT_LOCATION"                                                 \
-  --build-requires 'python-setuptools >= 0.6.10'                                      \
+  --build-requires 'python-setuptools >= 0.6'                                         \
   --release "1%{?dist}"  # appends RPM dist tag (el6, el7, fc19, ...)
 
 echo "switching to ${CVMFS_RESULT_LOCATION}"

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,6 +2,9 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
+from os         import path
+
+readme_path = path.join(path.dirname(__file__), 'README')
 
 setup(
   name='python-cvmfsutils',
@@ -11,7 +14,7 @@ setup(
   author_email='rene.meusel@cern.ch',
   license='(c) 2015 CERN - BSD License',
   description='Inspect CernVM-FS repositories',
-  long_description=open('README').read(),
+  long_description=open(readme_path).read(),
   classifiers= [
     'Development Status :: 4 - Beta',
     'Environment :: Console',


### PR DESCRIPTION
Unfortunately we cannot easily provide a universal RPM for el6 and el7 since the python version (and thus the installation destinations) differ.