### PR TITLE
FIX: manual cache cleanup for the benchmarks

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -1351,7 +1351,10 @@ EOF
 clean_benchmark_cache() {
   local cachedir="${CVMFS_OPT_CACHEDIR}/${FQRN}"
   if [ -d "$cachedir" ] && [ "x$cachedir" != x ]; then
-    rm -rf $cachedir/*
+  list=$(ls $cachedir | grep -P "^[0-9a-f]{2}$")
+    for dir in $list; do
+      rm -rf "$cachedir/$dir"/*
+    done
   fi
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -1351,9 +1351,9 @@ EOF
 clean_benchmark_cache() {
   local cachedir="${CVMFS_OPT_CACHEDIR}/${FQRN}"
   if [ -d "$cachedir" ] && [ "x$cachedir" != x ]; then
-  list=$(ls $cachedir | grep -P "^[0-9a-f]{2}$")
+  list=$(ls '$cachedir' | grep -P "^[0-9a-f]{2}$")
     for dir in $list; do
-      rm -rf "$cachedir/$dir"/*
+      rm -f "$cachedir/$dir"/*
     done
   fi
 }


### PR DESCRIPTION
Removing the whole cache directory only works if cvmfs is fully stopped. Otherwise removing the cache produces errors that made the last benchmarks fail (https://phsft-jenkins.cern.ch/view/CVMFS/job/CvmfsBenchmark/).  With this fix it should work.