### PR TITLE
FIX: unittest2 check on Python 2.7

### DIFF
--- a/ci/run_python_unittests.sh
+++ b/ci/run_python_unittests.sh
@@ -23,11 +23,14 @@ PY_UT_XML_PREFIX=$1
 # check if python is capable of running the unit tests on the current platform
 which python > /dev/null 2>&1                    || complain "no python available"
 compare_versions "$(python_version)" -gt "2.6.0" || complain "ancient python version"
-check_python_module "unittest2"                  || complain "no unittest2 installed"
 check_python_module "xmlrunner"                  || complain "no python-xmlrunner installed"
 check_python_module "dateutil"                   || complain "no python-dateutil installed"
 check_python_module "requests"                   || complain "no python-requests installed"
 check_python_module "M2Crypto"                   || complain "no m2crypto installed"
+if compare_versions "$(python_version)" -lt "2.7.0"; then
+  # unittest2 is a back-port of the Python 2.7 unittest features
+  check_python_module "unittest2" || complain "python 2.6 but no unittest2 installed"
+fi
 
 # run the unit tests
 UNITTEST_RUNNER="${SCRIPT_LOCATION}/../python/run_unittests.py"

--- a/python/run_unittests.py
+++ b/python/run_unittests.py
@@ -10,8 +10,12 @@ Use this script to run the python unit tests with an optional XML xUnit report.
 import optparse
 import os
 import sys
-from unittest2 import TestLoader, TextTestRunner
 from xmlrunner import XMLTestRunner
+
+try:
+    from unittest2 import TestLoader, TextTestRunner
+except ImportError:
+    from unittest import TestLoader, TextTestRunner
 
 base_path = os.path.dirname(__file__)
 


### PR DESCRIPTION
On Python 2.7 `unittest2` is actually `unittest`.