### PR TITLE
Python: Add Availability Class to Python Package

### DIFF
--- a/python/cvmfs/__init__.py
+++ b/python/cvmfs/__init__.py
@@ -10,6 +10,7 @@ from manifest     import *
 from whitelist    import *
 from certificate  import *
 from repository   import *
+from availability import *
 
 import subprocess
 import re

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -11,6 +11,7 @@ import zlib
 import sqlite3
 import subprocess
 import shutil
+import math
 
 
 _REPO_CONFIG_PATH      = "/etc/cvmfs/repositories.d"
@@ -69,3 +70,7 @@ class FileObject(CompressedObject):
 
     def file(self):
         return self.get_uncompressed_file()
+
+
+def _logistic_function(a):
+    return lambda x: round(1 - (1/(1 + math.exp(-5.5 * ((float(x)/float(a)) - 1)))), 2)

--- a/python/cvmfs/availability.py
+++ b/python/cvmfs/availability.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+import math
+from datetime    import datetime
+from dateutil.tz import tzutc
+
+from _common import _logistic_function
+
+class Availability:
+    def __init__(self, stratum0, **kwargs):
+        self.stratum0  = stratum0
+        self.stratum1s = []
+        self._get_param_or_default('revision_threshold',     5, **kwargs)
+        self._get_param_or_default('replication_threshold', 60, **kwargs)
+
+    def _get_param_or_default(self, argname, default, **kwargs):
+        value = default if argname not in kwargs else kwargs[argname]
+        setattr(self, argname, value)
+
+    def add_stratum1(self, stratum1):
+        self.stratum1s.append(stratum1)
+
+    def has_stratum1s(self):
+        return len(self.stratum1s) > 0
+
+    def get_current_revision(self):
+        return self.stratum0.manifest.revision
+
+    def get_oldest_revision(self):
+        return min([ s1.manifest.revision for s1 in self.stratum1s ]) \
+            if   self.has_stratum1s()                                 \
+            else self.get_current_revision()
+
+    def get_oldest_stratum1(self):
+        return min(self.stratum1s, key=lambda s1: s1.manifest.revision) \
+            if   self.has_stratum1s()                                   \
+            else None
+
+    def get_stratum1_health_score(self, stratum1):
+        f_revision    = _logistic_function(self.revision_threshold)
+        f_replication = _logistic_function(self.replication_threshold)
+        d_revision    = self.get_current_revision() - stratum1.manifest.revision
+        d_replication = datetime.now(tzutc()) - stratum1.last_replication
+        d_replication = d_replication.days * 24*60*60 + d_replication.seconds
+        return f_revision(d_revision) * f_replication(d_replication / 60.0)
+
+    def get_stratum1_health_scores(self):
+        get_score = lambda s1: self.get_stratum1_health_score(s1)
+        return [ (s1, get_score(s1)) for s1 in self.stratum1s ]
+
+    def get_repository_health_score(self):
+        scores = [ score for s1, score in self.get_stratum1_health_scores() ]
+        return reduce(lambda x,y: x*y, scores)
+

--- a/python/cvmfs/test/availability_test.py
+++ b/python/cvmfs/test/availability_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+from datetime    import datetime, timedelta
+from dateutil.tz import tzutc
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import cvmfs
+
+class MockManifest:
+    def __init__(self, **kwargs):
+        for kw, arg in kwargs.iteritems():
+            setattr(self, kw, arg)
+
+class MockRepository:
+    def __init__(self, **kwargs):
+        self._filter_kwarg('last_replication', **kwargs)
+        self.manifest = MockManifest(**kwargs)
+
+    def _filter_kwarg(self, argname, **kwargs):
+        if argname in kwargs:
+            setattr(self, argname, kwargs[argname])
+            del kwargs[argname]
+
+
+class TestAvailability(unittest.TestCase):
+    def _get_recent_time(self, minutes_ago):
+        return datetime.now(tzutc()) - timedelta(seconds=minutes_ago*60)
+
+    def test_get_oldest_revision(self):
+        s0    = MockRepository(revision = 1000)
+        avail = cvmfs.Availability(s0)
+        self.assertEqual(1000, avail.get_oldest_revision())
+
+        self.assertFalse(avail.has_stratum1s())
+        avail.add_stratum1(MockRepository(revision = 1000))
+        avail.add_stratum1(MockRepository(revision =  999))
+        avail.add_stratum1(MockRepository(revision =  995))
+        self.assertTrue(avail.has_stratum1s())
+        self.assertEqual(995, avail.get_oldest_revision())
+
+
+    def test_get_oldest_stratum1(self):
+        s0    = MockRepository(revision = 1000)
+        avail = cvmfs.Availability(s0)
+        self.assertEqual(None, avail.get_oldest_stratum1())
+
+        self.assertFalse(avail.has_stratum1s())
+        avail.add_stratum1(MockRepository(revision = 1000))
+        avail.add_stratum1(MockRepository(revision =  999))
+        self.assertTrue(avail.has_stratum1s())
+
+        oldest_s1 = MockRepository(revision =  995)
+        avail.add_stratum1(oldest_s1)
+        self.assertEqual(oldest_s1, avail.get_oldest_stratum1())
+
+
+    def test_stratum1_scores(self):
+        s0    = MockRepository(revision = 1000)
+        avail = cvmfs.Availability(s0, revision_threshold=10, replication_threshold=60)
+        self.assertEqual(1000, avail.get_oldest_revision())
+
+        healthy  = MockRepository(revision = 1000, last_replication=self._get_recent_time(10))
+        degraded = MockRepository(revision =  995, last_replication=self._get_recent_time(30))
+        severe   = MockRepository(revision =  992, last_replication=self._get_recent_time(45))
+        fatal    = MockRepository(revision =  980, last_replication=self._get_recent_time(90))
+
+        self.assertLess(0.95, avail.get_stratum1_health_score(healthy))
+
+        self.assertGreater(0.9, avail.get_stratum1_health_score(degraded))
+        self.assertLess   (0.7, avail.get_stratum1_health_score(degraded))
+
+        self.assertGreater(0.7, avail.get_stratum1_health_score(severe))
+        self.assertLess   (0.4, avail.get_stratum1_health_score(severe))
+
+        self.assertGreater(0.2, avail.get_stratum1_health_score(fatal))
+
+
+    def test_repository_scores(self):
+        s0    = MockRepository(revision = 1000)
+        avail = cvmfs.Availability(s0, revision_threshold=10, replication_threshold=60)
+
+        healthy  = MockRepository(revision = 1000, last_replication=self._get_recent_time(10))
+        degraded = MockRepository(revision =  995, last_replication=self._get_recent_time(30))
+        severe   = MockRepository(revision =  992, last_replication=self._get_recent_time(45))
+        fatal    = MockRepository(revision =  980, last_replication=self._get_recent_time(90))
+
+        avail.add_stratum1(healthy)
+        avail.add_stratum1(healthy)
+        self.assertLess(0.95, avail.get_repository_health_score())
+
+        avail.add_stratum1(degraded)
+        self.assertGreater(0.9, avail.get_repository_health_score())
+        self.assertLess   (0.8, avail.get_repository_health_score())
+
+        avail.add_stratum1(severe)
+        self.assertGreater(0.8, avail.get_repository_health_score())
+        self.assertLess   (0.5, avail.get_repository_health_score())
+
+        avail.add_stratum1(severe)
+        self.assertGreater(0.5, avail.get_repository_health_score())
+        self.assertLess   (0.2, avail.get_repository_health_score())
+
+        avail.add_stratum1(fatal)
+        self.assertGreater(0.2, avail.get_repository_health_score())

--- a/python/cvmfs/test/logistic_function_test.py
+++ b/python/cvmfs/test/logistic_function_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from cvmfs._common import _logistic_function
+
+class TestLogisticFunction(unittest.TestCase):
+    def test_small_numbers(self):
+        for i in range(1, 100):
+            f = _logistic_function(i)
+
+            self.assertAlmostEqual(1.0, f(0),   places=2)
+            self.assertAlmostEqual(0.5, f(i),   places=2)
+            self.assertAlmostEqual(0.0, f(2*i), places=2)
+
+            if i > 10:
+                i_05 = float(i) * 0.5
+                i_15 = float(i) * 1.5
+                self.assertLess   (0.90, f(i_05), msg=("i = %d | i_05 = %f" % (i , i_05)))
+                self.assertGreater(0.10, f(i_15), msg=("i = %d | i_15 = %f" % (i , i_15)))
+
+
+    def test_large_numbers(self):
+        for i in range(1000000, 1000100):
+            f = _logistic_function(i)
+
+            self.assertAlmostEqual(1.0, f(0),   places=2)
+            self.assertAlmostEqual(0.5, f(i),   places=2)
+            self.assertAlmostEqual(0.0, f(2*i), places=2)
+
+            i_05 = float(i) * 0.5
+            i_15 = float(i) * 1.5
+            self.assertLess   (0.90, f(i_05), msg=("i = %d | i_05 = %f" % (i , i_05)))
+            self.assertGreater(0.10, f(i_15), msg=("i = %d | i_15 = %f" % (i , i_15)))


### PR DESCRIPTION
With the `Availability` class one can judge the current replication health of a repository given a *Stratum0* and a number of *Stratum1s*. The `Availability` class can be parameterised with thresholds for *revision difference* and *last snapshot attempt* (to be extended) which are used to compute a health score either for each individual replica or the entire repository network.

The score is computed using a [logistic function](https://www.wikiwand.com/en/Logistic_function) that provides a smooth curve between *healthy* and *fatal* for each observable. For example, given a *revision difference threshold* of 5, a repository would get health scores like the following:

Δrevision | health score
------------ | -------------
0 | 1.0
1 | 0.99
2 | 0.96
3 | 0.9
4 | 0.75
5 | 0.5
6 | 0.25
7 | 0.1
8 | 0.04
9 | 0.01

The *last snapshot attempt* score is computed the same way. The final health score for a repository is obtained by multiplying both observable scores. To get the overall health of the entire repository's network, all those replication-scores are being multiplied. This is up for discussion, since a single 'fatal' replica already marks the entire repository as 'fatal'. Maybe a mean would make more sense here, frankly I'm not sure.
