### PR TITLE
FIX: .cvmfs_last_snapshot is locale dependent

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4371,7 +4371,7 @@ snapshot() {
         -t $timeout                                    \
         -a $retries $with_history $log_level"
 
-    $user_shell "date > ${spool_dir}/tmp/last_snapshot"
+    $user_shell "date --utc > ${spool_dir}/tmp/last_snapshot"
     $user_shell "$(__swissknife_cmd) upload -r ${upstream} \
       -i ${spool_dir}/tmp/last_snapshot                    \
       -o .cvmfs_last_snapshot"


### PR DESCRIPTION
Turns out that the timestamp in `.cvmfs_last_snapshot` is dependent on the *locale* of the system and hence not easily parsable. For instance, Fermilab is currently in *CDT* which might be *Central Daylight Time* or *Cuba Daylight Time*. Meh!
This changes the timestamp to UTC regardless of the system's time zone.