### PR TITLE
FIX: .cvmfs_last_snapshot contains ambiguous time zones

### DIFF
--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -74,3 +74,70 @@ class FileObject(CompressedObject):
 
 def _logistic_function(a):
     return lambda x: round(1 - (1/(1 + math.exp(-5.5 * ((float(x)/float(a)) - 1)))), 2)
+
+
+class TzInfos:
+    tzd = None
+
+    @staticmethod
+    def get_tzinfos():
+        """ Time Zone Codes are ambiguous but dateutil.parser.parse allows to
+            pass a desired mapping of these codes to offsets to UTC.
+
+            This is taken from Stack Overflow:
+            http://stackoverflow.com/questions/1703546/
+            parsing-date-time-string-with-timezone-abbreviated-name-in-python/
+            4766400#4766400
+        """
+        if not TzInfos.tzd:
+            TzInfos._generate_tzd()
+        return TzInfos.tzd
+
+
+    @staticmethod
+    def _generate_tzd():
+        print "generating"
+        TzInfos.tzd = {}
+        tz_str = '''-12 Y
+-11 X NUT SST
+-10 W CKT HAST HST TAHT TKT
+-9 V AKST GAMT GIT HADT HNY
+-8 U AKDT CIST HAY HNP PST PT
+-7 T HAP HNR MST PDT
+-6 S CST EAST GALT HAR HNC MDT
+-5 R CDT COT EASST ECT EST ET HAC HNE PET
+-4 Q AST BOT CLT COST EDT FKT GYT HAE HNA PYT
+-3 P ADT ART BRT CLST FKST GFT HAA PMST PYST SRT UYT WGT
+-2 O BRST FNT PMDT UYST WGST
+-1 N AZOT CVT EGT
+0 Z EGST GMT UTC WET WT
+1 A CET DFT WAT WEDT WEST
+2 B CAT CEDT CEST EET SAST WAST
+3 C EAT EEDT EEST IDT MSK
+4 D AMT AZT GET GST KUYT MSD MUT RET SAMT SCT
+5 E AMST AQTT AZST HMT MAWT MVT PKT TFT TJT TMT UZT YEKT
+6 F ALMT BIOT BTT IOT KGT NOVT OMST YEKST
+7 G CXT DAVT HOVT ICT KRAT NOVST OMSST THA WIB
+8 H ACT AWST BDT BNT CAST HKT IRKT KRAST MYT PHT SGT ULAT WITA WST
+9 I AWDT IRKST JST KST PWT TLT WDT WIT YAKT
+10 K AEST ChST PGT VLAT YAKST YAPT
+11 L AEDT LHDT MAGT NCT PONT SBT VLAST VUT
+12 M ANAST ANAT FJT GILT MAGST MHT NZST PETST PETT TVT WFT
+13 FJST NZDT
+11.5 NFT
+10.5 ACDT LHST
+9.5 ACST
+6.5 CCT MMT
+5.75 NPT
+5.5 SLT
+4.5 AFT IRDT
+3.5 IRST
+-2.5 HAT NDT
+-3.5 HNT NST NT
+-4.5 HLV VET
+-9.5 MART MIT'''
+
+        for tz_descr in map(str.split, tz_str.split('\n')):
+            tz_offset = int(float(tz_descr[0]) * 3600)
+            for tz_code in tz_descr[1:]:
+                TzInfos.tzd[tz_code] = tz_offset

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -96,7 +96,6 @@ class TzInfos:
 
     @staticmethod
     def _generate_tzd():
-        print "generating"
         TzInfos.tzd = {}
         tz_str = '''-12 Y
 -11 X NUT SST

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -81,7 +81,11 @@ class Repository:
 
 
     def __read_timestamp(self, timestamp_string):
-        return dateutil.parser.parse(timestamp_string)
+        local_ts = dateutil.parser.parse(timestamp_string,
+                                         ignoretz=False,
+                                         tzinfos=_common.TzInfos.get_tzinfos())
+        return local_ts.astimezone(tzutc())
+
 
 
     def _try_to_get_last_replication_timestamp(self):


### PR DESCRIPTION
This uses a timezone mapping I found on [StackOverflow](http://stackoverflow.com/questions/1703546/parsing-date-time-string-with-timezone-abbreviated-name-in-python/4766400#4766400) to work around the ambiguous time stamps in `.cvmfs_last_snapshot` in CernVM-FS 2.1.20. The [next release](https://github.com/cvmfs/cvmfs/pull/971) of CVMFS will put UTC time stamps there.