### PR TITLE
Python: Backporting python-cvmfsutils to RHEL5

### DIFF
--- a/python/cvmfs/__init__.py
+++ b/python/cvmfs/__init__.py
@@ -73,10 +73,10 @@ client_version = None
 
 try:
     server_version = _get_server_version()
-except (ServerNotInstalled, VersionNotDetected) as e:
+except ServerNotInstalled, VersionNotDetected:
     has_server = False
 
 try:
     client_version = _get_client_version()
-except ClientNotInstalled, e:
+except ClientNotInstalled:
     has_client = False

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -8,7 +8,6 @@ This file is part of the CernVM File System auxiliary tools.
 import ctypes
 import tempfile
 import zlib
-import sqlite3
 import subprocess
 import shutil
 import math

--- a/python/cvmfs/availability.py
+++ b/python/cvmfs/availability.py
@@ -20,7 +20,7 @@ class Availability:
 
     def _get_param_or_default(self, argname, default, **kwargs):
         if argname not in kwargs:
-            return default
+            setattr(self, argname, default)
         else:
             setattr(self, argname, kwargs[argname])
 

--- a/python/cvmfs/manifest.py
+++ b/python/cvmfs/manifest.py
@@ -28,8 +28,10 @@ class Manifest(RootFile):
     @staticmethod
     def open(manifest_path):
         """ Initializes a Manifest from a local file path """
-        with open(manifest_path) as manifest_file:
-            return Manifest(manifest_file)
+        manifest_file = open(manifest_path)
+        manifest      = Manifest(manifest_file)
+        manifest_file.close()
+        return manifest
 
     def __init__(self, manifest_file):
         RootFile.__init__(self, manifest_file)

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -5,7 +5,6 @@ Created by René Meusel
 This file is part of the CernVM File System auxiliary tools.
 """
 
-import abc
 import os
 import urlparse
 import tempfile
@@ -62,8 +61,6 @@ class RepositoryVerificationFailed(Exception):
 
 class Repository:
     """ Abstract Wrapper around a CVMFS Repository representation """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         self._read_manifest()
@@ -144,10 +141,9 @@ class Repository:
         return Certificate(certificate)
 
 
-    @abc.abstractmethod
     def retrieve_file(self, file_name):
         """ Abstract method to retrieve a file from the repository """
-        pass
+        raise NotImplementedError()
 
 
     def retrieve_object(self, object_hash, hash_suffix = ''):

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -238,7 +238,7 @@ class RemoteRepository(Repository):
         response = None
         try:
             response = urllib2.urlopen(request)
-        except HTTPError, e:
+        except urllib2.HTTPError, e:
             raise FileNotFoundInRepository(self, file_url)
 
         tmp_file.write(response.read())

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -233,7 +233,8 @@ class RemoteRepository(Repository):
         file_url = self.endpoint + "/" + file_name
         tmp_file = tempfile.NamedTemporaryFile('w+b')
 
-        request  = urllib2.Request(file_url, {'User-Agent': self._user_agent})
+        request  = urllib2.Request(file_url)
+        request.add_header('User-Agent', self._user_agent)
         response = None
         try:
             response = urllib2.urlopen(request)

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -73,8 +73,9 @@ class Repository:
 
     def _read_manifest(self):
         try:
-            with self.retrieve_file(_common._MANIFEST_NAME) as manifest_file:
-                self.manifest = Manifest(manifest_file)
+            manifest_file = self.retrieve_file(_common._MANIFEST_NAME)
+            self.manifest = Manifest(manifest_file)
+            manifest_file.close()
             self.fqrn = self.manifest.repository_name
         except FileNotFoundInRepository, e:
             raise RepositoryNotFound(self.endpoint)
@@ -90,9 +91,10 @@ class Repository:
 
     def _try_to_get_last_replication_timestamp(self):
         try:
-            with self.retrieve_file(_common._LAST_REPLICATION_NAME) as rf:
-                timestamp = rf.readline()
-                self.last_replication = self.__read_timestamp(timestamp)
+            last_rep_file = self.retrieve_file(_common._LAST_REPLICATION_NAME)
+            timestamp = last_rep_file.readline()
+            last_rep_file.close()
+            self.last_replication = self.__read_timestamp(timestamp)
             if not self.has_repository_type():
                 self.type = 'stratum1'
         except FileNotFoundInRepository, e:
@@ -102,10 +104,11 @@ class Repository:
     def _try_to_get_replication_state(self):
         self.replicating = False
         try:
-            with self.retrieve_file(_common._REPLICATING_NAME) as rf:
-                timestamp = rf.readline()
-                self.replicating = True
-                self.replicating_since = self.__read_timestamp(timestamp)
+            rep_state_file = self.retrieve_file(_common._REPLICATING_NAME)
+            timestamp = rep_state_file.readline()
+            rep_state_file.close()
+            self.replicating = True
+            self.replicating_since = self.__read_timestamp(timestamp)
         except FileNotFoundInRepository, e:
             pass
 
@@ -184,10 +187,11 @@ class LocalRepository(Repository):
     def read_server_config(self, config_field):
         if not self._server_config:
             raise ConfigurationNotFound(self, "no such file or directory")
-        with open(self._server_config) as config_file:
-            for config_line in config_file:
-                if config_line.startswith(config_field):
-                    return config_line[len(config_field)+1:].strip()
+        config_file = open(self._server_config)
+        for config_line in config_file:
+            if config_line.startswith(config_field):
+                return config_line[len(config_field)+1:].strip()
+        config_file.close()
         raise ConfigurationNotFound(self, config_field)
 
 

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -246,9 +246,13 @@ class RemoteRepository(Repository):
 
 def open_repository(repository_path, public_key = None):
     """ wrapper function accessing a repository by URL, local FQRN or path """
-    repo = RemoteRepository(repository_path)              \
-                if repository_path.startswith("http://")  \
-                else LocalRepository(repository_path)
+    repo = None
+    if repository_path.startswith("http://"):
+        repo = RemoteRepository(repository_path)
+    else:
+        repo = LocalRepository(repository_path)
+
     if public_key:
         repo.verify(public_key)
+
     return repo

--- a/python/cvmfs/root_file.py
+++ b/python/cvmfs/root_file.py
@@ -21,7 +21,6 @@ key-value line content (without the termination line) followed by an \n and a
 binary string containing the private-key signature terminated by EOF.
 """
 
-import abc
 import hashlib
 
 class IncompleteRootFileSignature(Exception):
@@ -36,17 +35,12 @@ class InvalidRootFileSignature(Exception):
 class RootFile:
     """ Base class for CernVM-FS repository's signed 'root files' """
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
     def _read_line(self, line):
-        pass
+        raise NotImplementedError()
 
-    @abc.abstractmethod
     def _check_validity(self):
-        pass
+        raise NotImplementedError()
 
-    @abc.abstractmethod
     def __init__(self, file_object):
         """ Initializes a root file object from a file pointer """
         self.has_signature = False
@@ -61,9 +55,8 @@ class RootFile:
             self._read_signature(file_object)
         self._check_validity()
 
-    @abc.abstractmethod
     def _verify_signature(public_entity):
-        pass
+        raise NotImplementedError()
 
 
     def verify_signature(self, public_entity):

--- a/python/cvmfs/test/availability_test.py
+++ b/python/cvmfs/test/availability_test.py
@@ -8,10 +8,7 @@ This file is part of the CernVM File System auxiliary tools.
 from datetime    import datetime, timedelta
 from dateutil.tz import tzutc
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import cvmfs
 
@@ -73,15 +70,15 @@ class TestAvailability(unittest.TestCase):
         severe   = MockRepository(revision =  992, last_replication=self._get_recent_time(45))
         fatal    = MockRepository(revision =  980, last_replication=self._get_recent_time(90))
 
-        self.assertLess(0.95, avail.get_stratum1_health_score(healthy))
+        self.assertTrue(0.95 < avail.get_stratum1_health_score(healthy))
 
-        self.assertGreater(0.9, avail.get_stratum1_health_score(degraded))
-        self.assertLess   (0.7, avail.get_stratum1_health_score(degraded))
+        self.assertTrue(0.9 > avail.get_stratum1_health_score(degraded))
+        self.assertTrue(0.7 < avail.get_stratum1_health_score(degraded))
 
-        self.assertGreater(0.7, avail.get_stratum1_health_score(severe))
-        self.assertLess   (0.4, avail.get_stratum1_health_score(severe))
+        self.assertTrue(0.7 > avail.get_stratum1_health_score(severe))
+        self.assertTrue(0.4 < avail.get_stratum1_health_score(severe))
 
-        self.assertGreater(0.2, avail.get_stratum1_health_score(fatal))
+        self.assertTrue(0.2 > avail.get_stratum1_health_score(fatal))
 
 
     def test_repository_scores(self):
@@ -95,19 +92,19 @@ class TestAvailability(unittest.TestCase):
 
         avail.add_stratum1(healthy)
         avail.add_stratum1(healthy)
-        self.assertLess(0.95, avail.get_repository_health_score())
+        self.assertTrue(0.95 < avail.get_repository_health_score())
 
         avail.add_stratum1(degraded)
-        self.assertGreater(0.9, avail.get_repository_health_score())
-        self.assertLess   (0.8, avail.get_repository_health_score())
+        self.assertTrue(0.9 > avail.get_repository_health_score())
+        self.assertTrue(0.8 < avail.get_repository_health_score())
 
         avail.add_stratum1(severe)
-        self.assertGreater(0.8, avail.get_repository_health_score())
-        self.assertLess   (0.5, avail.get_repository_health_score())
+        self.assertTrue(0.8 > avail.get_repository_health_score())
+        self.assertTrue(0.5 < avail.get_repository_health_score())
 
         avail.add_stratum1(severe)
-        self.assertGreater(0.5, avail.get_repository_health_score())
-        self.assertLess   (0.2, avail.get_repository_health_score())
+        self.assertTrue(0.5 > avail.get_repository_health_score())
+        self.assertTrue(0.2 < avail.get_repository_health_score())
 
         avail.add_stratum1(fatal)
-        self.assertGreater(0.2, avail.get_repository_health_score())
+        self.assertTrue(0.2 > avail.get_repository_health_score())

--- a/python/cvmfs/test/certificate_test.py
+++ b/python/cvmfs/test/certificate_test.py
@@ -43,30 +43,35 @@ class TestCertificate(unittest.TestCase):
 
 
     def test_load(self):
-        with open(self.certificate_file) as cert_file:
-            cert = cvmfs.Certificate(cert_file)
+        cert_file = open(self.certificate_file)
+        cert = cvmfs.Certificate(cert_file)
+        cert_file.close()
 
 
     def test_get_openssl_x509(self):
-        with open(self.certificate_file) as cert_file:
-            cert = cvmfs.Certificate(cert_file)
-            x509 = cert.get_openssl_certificate()
-            self.assertTrue(isinstance(x509, X509))
+        cert_file = open(self.certificate_file)
+        cert = cvmfs.Certificate(cert_file)
+        cert_file.close()
+        x509 = cert.get_openssl_certificate()
+        self.assertTrue(isinstance(x509, X509))
 
 
     def test_verify_message(self):
-        with open(self.certificate_file) as cert_file:
-            cert = cvmfs.Certificate(cert_file)
-            self.assertTrue(cert.verify(self.signature, self.message_digest))
+        cert_file = open(self.certificate_file)
+        cert = cvmfs.Certificate(cert_file)
+        cert_file.close()
+        self.assertTrue(cert.verify(self.signature, self.message_digest))
 
 
     def test_verify_tampered_message(self):
-        with open(self.certificate_file) as cert_file:
-            cert = cvmfs.Certificate(cert_file)
-            self.assertFalse(cert.verify(self.signature, "I am Malory!"))
+        cert_file = open(self.certificate_file)
+        cert = cvmfs.Certificate(cert_file)
+        cert_file.close()
+        self.assertFalse(cert.verify(self.signature, "I am Malory!"))
 
 
     def test_certificate_fingerprint(self):
-        with open(self.certificate_file) as cert_file:
-            cert = cvmfs.Certificate(cert_file)
-            self.assertEqual(self.fingerprint, cert.get_fingerprint())
+        cert_file = open(self.certificate_file)
+        cert = cvmfs.Certificate(cert_file)
+        cert_file.close()
+        self.assertEqual(self.fingerprint, cert.get_fingerprint())

--- a/python/cvmfs/test/file_sandbox.py
+++ b/python/cvmfs/test/file_sandbox.py
@@ -23,12 +23,12 @@ class FileSandbox:
     def write_to_temporary(self, string_buffer):
         """ stores the provided content into a /tmp path that is returned """
         filename = None
-        with tempfile.NamedTemporaryFile(mode='w+b',
-                                         prefix=self.file_prefix,
-                                         dir=self.temporary_dir,
-                                         delete=False) as f:
-            filename = f.name
-            f.write(string_buffer)
+        tmp_file_tuple = tempfile.mkstemp(prefix=self.file_prefix,
+                                          dir=self.temporary_dir)
+        tmp_fd   = tmp_file_tuple[0]
+        filename = tmp_file_tuple[1]
+        os.write(tmp_fd, string_buffer)
+        os.close(tmp_fd)
         return filename
 
 
@@ -42,5 +42,6 @@ class FileSandbox:
         full_file_path = os.path.join(self.temporary_dir, file_path)
         if os.path.isfile(full_file_path):
             os.unlink(full_file_path)
-        with open(full_file_path, "w+") as f:
-            f.write(string_buffer)
+        f = open(full_file_path, "w+")
+        f.write(string_buffer)
+        f.close()

--- a/python/cvmfs/test/logistic_function_test.py
+++ b/python/cvmfs/test/logistic_function_test.py
@@ -24,8 +24,8 @@ class TestLogisticFunction(unittest.TestCase):
             if i > 10:
                 i_05 = float(i) * 0.5
                 i_15 = float(i) * 1.5
-                self.assertLess   (0.90, f(i_05), msg=("i = %d | i_05 = %f" % (i , i_05)))
-                self.assertGreater(0.10, f(i_15), msg=("i = %d | i_15 = %f" % (i , i_15)))
+                self.assertTrue(0.90 < f(i_05), msg=("i = %d | i_05 = %f" % (i , i_05)))
+                self.assertTrue(0.10 > f(i_15), msg=("i = %d | i_15 = %f" % (i , i_15)))
 
 
     def test_large_numbers(self):
@@ -38,5 +38,5 @@ class TestLogisticFunction(unittest.TestCase):
 
             i_05 = float(i) * 0.5
             i_15 = float(i) * 1.5
-            self.assertLess   (0.90, f(i_05), msg=("i = %d | i_05 = %f" % (i , i_05)))
-            self.assertGreater(0.10, f(i_15), msg=("i = %d | i_15 = %f" % (i , i_15)))
+            self.assertTrue(0.90 < f(i_05), msg=("i = %d | i_05 = %f" % (i , i_05)))
+            self.assertTrue(0.10 > f(i_15), msg=("i = %d | i_15 = %f" % (i , i_15)))

--- a/python/cvmfs/test/mock_repository.py
+++ b/python/cvmfs/test/mock_repository.py
@@ -72,26 +72,28 @@ class MockRepository:
         old_whitelist = os.path.join(self.dir, ".cvmfswhitelist")
         new_whitelist = os.path.join(self.dir, ".cvmfswhitelist.new")
         wl_hash = hashlib.sha1()
-        with open(new_whitelist, 'w+') as new_wl: # TODO: more elegant is Py 2.7
-            with open(old_whitelist) as old_wl:
-                pos = old_wl.tell()
-                while True:
-                    line = old_wl.readline()
-                    if len(line) >= 3 and line[0:3] == 'E20': #fails in 85 years
-                        line = 'E' + expiry_date.strftime("%Y%m%d%H%M%S") + '\n'
-                    if line[0:2] == "--":
-                        break
-                    if pos == old_wl.tell():
-                        raise Exception("Signature not found in whitelist")
-                    wl_hash.update(line)
-                    new_wl.write(line)
-                    pos = old_wl.tell()
-            new_wl.write("--\n")
-            new_wl.write(wl_hash.hexdigest())
-            new_wl.write("\n")
-            key = RSA.load_key(self.master_key)
-            sig = key.private_encrypt(wl_hash.hexdigest(), RSA.pkcs1_padding)
-            new_wl.write(sig)
+        new_wl = open(new_whitelist, 'w+')
+        old_wl = open(old_whitelist)
+        pos = old_wl.tell()
+        while True:
+            line = old_wl.readline()
+            if len(line) >= 3 and line[0:3] == 'E20': #fails in 85 years
+                line = 'E' + expiry_date.strftime("%Y%m%d%H%M%S") + '\n'
+            if line[0:2] == "--":
+                break
+            if pos == old_wl.tell():
+                raise Exception("Signature not found in whitelist")
+            wl_hash.update(line)
+            new_wl.write(line)
+            pos = old_wl.tell()
+        old_wl.close()
+        new_wl.write("--\n")
+        new_wl.write(wl_hash.hexdigest())
+        new_wl.write("\n")
+        key = RSA.load_key(self.master_key)
+        sig = key.private_encrypt(wl_hash.hexdigest(), RSA.pkcs1_padding)
+        new_wl.write(sig)
+        new_wl.close()
         os.rename(new_whitelist, old_whitelist)
 
 

--- a/python/cvmfs/test/mock_repository.py
+++ b/python/cvmfs/test/mock_repository.py
@@ -17,15 +17,15 @@ import unittest
 from M2Crypto import RSA
 
 import SimpleHTTPServer
-import SocketServer
 
-from file_sandbox import FileSandbox
+from file_sandbox     import FileSandbox
+from tcp_server_26ish import Py26ishTCPServer
 
-class CvmfsTestServer(SocketServer.TCPServer):
+class CvmfsTestServer(Py26ishTCPServer):
     allow_reuse_address = True
     def __init__(self, document_root, bind_address, handler):
         self.document_root = document_root
-        SocketServer.TCPServer.__init__(self, bind_address, handler)
+        Py26ishTCPServer.__init__(self, bind_address, handler)
 
 class CvmfsRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     def translate_path(self, path):

--- a/python/cvmfs/test/repository_test.py
+++ b/python/cvmfs/test/repository_test.py
@@ -97,3 +97,13 @@ class TestRepositoryWrapper(unittest.TestCase):
         self.assertRaises(cvmfs.RepositoryVerificationFailed,
                           cvmfs.open_repository,
                           self.mock_repo.dir, self.mock_repo.public_key)
+
+
+    def test_download_non_existent_file(self):
+        self.mock_repo.make_valid_whitelist()
+        self.mock_repo.serve_via_http()
+        repo = cvmfs.open_repository(self.mock_repo.url,
+                                     self.mock_repo.public_key)
+        self.assertRaises(cvmfs.FileNotFoundInRepository,
+                          repo.retrieve_file,
+                          "unobtainium.txt")

--- a/python/cvmfs/test/tcp_server_26ish.py
+++ b/python/cvmfs/test/tcp_server_26ish.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created by René Meusel
+This file is part of the CernVM File System auxiliary tools.
+"""
+
+import select
+import threading
+import SocketServer
+
+import sys
+
+class BackportedTCPServer(SocketServer.ThreadingTCPServer):
+    """ Backport of the Python 2.6's TCPServer `shutdown()` functionality
+        Found here: http://fw-geekycoder.blogspot.ch/2011/09/
+                           how-to-implement-shutdown-method-in.html
+    """
+    def __init__(self, address_tuple, handler):
+        SocketServer.ThreadingTCPServer.__init__(self, address_tuple, handler)
+        self.__is_shut_down = threading.Event()
+        self.__shutdown_request = False
+
+    def serve_forever(self, poll_interval=0.5):
+        """ Handle one request at a time until shutdown.
+
+            Polls for shutdown every poll_interval seconds. Ignores
+            self.timeout. If you need to do periodic tasks, do them in
+            another thread.
+        """
+        self.__is_shut_down.clear()
+        try:
+            while not self.__shutdown_request:
+                r, w, e = select.select([self], [], [], poll_interval)
+                if self in r:
+                    self._handle_request_noblock()
+        finally:
+            self.__shutdown_request = False
+            self.__is_shut_down.set()
+
+    def shutdown(self):
+        """ Stops the serve_forever loop.
+
+            Blocks until the loop has finished. This must be called while
+            serve_forever() is running in another thread, or it will
+            deadlock.
+        """
+        self.__shutdown_request = True
+        self.__is_shut_down.wait()
+
+    def _handle_request_noblock(self):
+        """ Handle one request, without blocking.
+
+            I assume that select.select has returned that the socket is
+            readable before this function was called, so there should be
+            no risk of blocking in get_request().
+        """
+        try:
+            request, client_address = self.get_request()
+        except socket.error:
+            return
+        if self.verify_request(request, client_address):
+            try:
+                self.process_request(request, client_address)
+            except:
+                self.handle_error(request, client_address)
+                self.close_request(request)
+
+
+# decide which server implementation to use
+python_version = sys.version_info
+Py26ishTCPServer = None
+
+if python_version[1] < 6:
+    Py26ishTCPServer = BackportedTCPServer
+else:
+    Py26ishTCPServer = SocketServer.TCPServer

--- a/python/cvmfs/test/whitelist_test.py
+++ b/python/cvmfs/test/whitelist_test.py
@@ -278,17 +278,19 @@ class TestWhitelist(unittest.TestCase):
 
 
     def test_contains_certificate(self):
-        with open(self.certificate_file) as cert:
-            whitelist   = cvmfs.Whitelist(self.sane_whitelist)
-            certificate = cvmfs.Certificate(cert)
-            self.assertTrue(whitelist.contains(certificate))
+        cert = open(self.certificate_file)
+        whitelist   = cvmfs.Whitelist(self.sane_whitelist)
+        certificate = cvmfs.Certificate(cert)
+        cert.close()
+        self.assertTrue(whitelist.contains(certificate))
 
 
     def test_doesnt_contain_certificate(self):
-        with open(self.certificate_file) as cert:
-            whitelist   = cvmfs.Whitelist(self.insane_whitelist_signature_mismatch)
-            certificate = cvmfs.Certificate(cert)
-            self.assertFalse(whitelist.contains(certificate))
+        cert = open(self.certificate_file)
+        whitelist   = cvmfs.Whitelist(self.insane_whitelist_signature_mismatch)
+        certificate = cvmfs.Certificate(cert)
+        cert.close()
+        self.assertFalse(whitelist.contains(certificate))
 
 
     def test_expired_whitelist(self):

--- a/python/cvmfs/whitelist.py
+++ b/python/cvmfs/whitelist.py
@@ -32,8 +32,10 @@ class Whitelist(RootFile):
     @staticmethod
     def open(whitelist_path):
         """ Initializes a whitelist from a local file path """
-        with open(whitelist_path) as manifest_file:
-            return Whitelist(manifest_file)
+        whitelist_file = open(whitelist_path)
+        whitelist = Whitelist(whitelist_file)
+        whitelist_file.close()
+        return whitelist
 
     _fingerprint_re = None
     _timestamp_re   = None


### PR DESCRIPTION
This backports the cvmfsutils python package to Python 2.4 and makes it compliant to the python dependencies provided in RHEL5.

Things that needed to be done:
* Adapt exception handling in some places
* Replace ternary if-else operator with conventional if-else
* Python 2.4 doesn't have the `with open(<file>) as file_object` block
* There is no Abstract Base Class module (replaced by `raise NotImplementedError()`)
* Remove `requests` package as it is not provided on RHEL5
* Remove `unittest2` backport dependency
* Detect RHEL5's ancient `M2Crypto` library and work around missing features
* Backport Python 2.6's [`TCPServer.shutdown()`](http://fw-geekycoder.blogspot.ch/2011/09/how-to-implement-shutdown-method-in.html) functionality for the unittest suite
* The `ctypes` package is a dependency on RHEL5 instead of a standard library member

Unfortunately the RPM packaging doesn't work yet.