### PR TITLE
FIX: Python Unittests Run Script

### DIFF
--- a/ci/run_python_unittests.sh
+++ b/ci/run_python_unittests.sh
@@ -27,10 +27,6 @@ check_python_module "xmlrunner"                  || complain "no python-xmlrunne
 check_python_module "dateutil"                   || complain "no python-dateutil installed"
 check_python_module "ctypes"                     || complain "no python-ctypes installed"
 check_python_module "M2Crypto"                   || complain "no m2crypto installed"
-if compare_versions "$(python_version)" -lt "2.7.0"; then
-  # unittest2 is a back-port of the Python 2.7 unittest features
-  check_python_module "unittest2" || complain "python 2.6 but no unittest2 installed"
-fi
 
 # run the unit tests
 UNITTEST_RUNNER="${SCRIPT_LOCATION}/../python/run_unittests.py"

--- a/ci/run_python_unittests.sh
+++ b/ci/run_python_unittests.sh
@@ -25,7 +25,7 @@ which python > /dev/null 2>&1                    || complain "no python availabl
 compare_versions "$(python_version)" -gt "2.6.0" || complain "ancient python version"
 check_python_module "xmlrunner"                  || complain "no python-xmlrunner installed"
 check_python_module "dateutil"                   || complain "no python-dateutil installed"
-check_python_module "requests"                   || complain "no python-requests installed"
+check_python_module "ctypes"                     || complain "no python-ctypes installed"
 check_python_module "M2Crypto"                   || complain "no m2crypto installed"
 if compare_versions "$(python_version)" -lt "2.7.0"; then
   # unittest2 is a back-port of the Python 2.7 unittest features


### PR DESCRIPTION
This adapts the unittest run script for `python-cvmfsutils` to check for the updated dependencies.