### PR TITLE
Add support for chunked files to libcvmfs

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1182,24 +1182,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     assert(retval);
     chunk_tables_->Unlock();
 
-    // Find the chunk that holds the beginning of the requested data
-    assert(chunks.list->size() > 0);
-    unsigned idx_low = 0, idx_high = chunks.list->size()-1;
-    unsigned chunk_idx = idx_high/2;
-    while (idx_low < idx_high) {
-      if (chunks.list->AtPtr(chunk_idx)->offset() > off) {
-        assert(idx_high > 0);
-        idx_high = chunk_idx-1;
-      } else {
-        if ((chunk_idx == chunks.list->size()-1) ||
-            chunks.list->AtPtr(chunk_idx+1)->offset() > off)
-        {
-          break;
-        }
-        idx_low = chunk_idx + 1;
-      }
-      chunk_idx = idx_low + (idx_high-idx_low)/2;
-    }
+    unsigned chunk_idx = chunks.FindChunkIdx(off);
 
     // Lock chunk handle
     pthread_mutex_t *handle_lock = chunk_tables_->Handle2Lock(chunk_handle);

--- a/cvmfs/file_chunk.cc
+++ b/cvmfs/file_chunk.cc
@@ -15,6 +15,36 @@ static inline uint32_t hasher_uint64t(const uint64_t &value) {
   return MurmurHash2(&value, sizeof(value), 0x07387a4f);
 }
 
+
+//------------------------------------------------------------------------------
+
+
+unsigned FileChunkReflist::FindChunkIdx(const uint64_t off) {
+  assert(list && (list->size() > 0));
+  unsigned idx_low = 0;
+  unsigned idx_high = list->size()-1;
+  unsigned chunk_idx = idx_high/2;
+  while (idx_low < idx_high) {
+    if (static_cast<uint64_t>(list->AtPtr(chunk_idx)->offset()) > off) {
+      assert(idx_high > 0);
+      idx_high = chunk_idx - 1;
+    } else {
+      if ((chunk_idx == list->size() - 1) ||
+          (static_cast<uint64_t>(list->AtPtr(chunk_idx + 1)->offset()) > off))
+      {
+        break;
+      }
+      idx_low = chunk_idx + 1;
+    }
+    chunk_idx = idx_low + (idx_high - idx_low) / 2;
+  }
+  return chunk_idx;
+}
+
+
+//------------------------------------------------------------------------------
+
+
 void ChunkTables::InitLocks() {
   lock =
     reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));

--- a/cvmfs/file_chunk.h
+++ b/cvmfs/file_chunk.h
@@ -53,6 +53,9 @@ struct FileChunkReflist {
   FileChunkReflist() : list(NULL) { }
   FileChunkReflist(FileChunkList *l, const PathString &p) :
     list(l), path(p) { }
+  
+  unsigned FindChunkIdx(const uint64_t offset);
+
   FileChunkList *list;
   PathString path;
 };

--- a/cvmfs/file_chunk.h
+++ b/cvmfs/file_chunk.h
@@ -114,7 +114,7 @@ struct ChunkTables {
 /**
  * Connects virtual file descriptors to FileChunkLists.  Used by libcvmfs.
  * Tries to keep the file descriptors small because they need to fit within
- * 32bit.  This class takes the ownership of the FileChunkList objects pointed
+ * 29bit.  This class takes the ownership of the FileChunkList objects pointed
  * to by the elements of fd_table_.
  */
 class SimpleChunkTables : SingleCopy {

--- a/cvmfs/file_chunk.h
+++ b/cvmfs/file_chunk.h
@@ -53,7 +53,7 @@ struct FileChunkReflist {
   FileChunkReflist() : list(NULL) { }
   FileChunkReflist(FileChunkList *l, const PathString &p) :
     list(l), path(p) { }
-  
+
   unsigned FindChunkIdx(const uint64_t offset);
 
   FileChunkList *list;

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -450,6 +450,23 @@ int cvmfs_open(cvmfs_context *ctx, const char *path) {
   return rc;
 }
 
+
+ssize_t cvmfs_pread(
+  cvmfs_context *ctx,
+  int fd,
+  void *buf,
+  size_t size,
+  off_t off)
+{
+  ssize_t nbytes = ctx->Pread(fd, buf, size, off);
+  if (nbytes < 0) {
+    errno = -nbytes;
+    return -1;
+  }
+  return nbytes;
+}
+
+
 int cvmfs_close(cvmfs_context *ctx, int fd)
 {
   int rc = ctx->Close(fd);

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -18,7 +18,7 @@
 // 15: remove counting of open file descriptors
 // 16: remove unnecessary free
 // 17: apply new classes around the cache manager
-// 18: add cvmfs_pread
+// 18: add cvmfs_pread and support for chunked files
 #define LIBCVMFS_REVISION 18
 
 #include <sys/stat.h>

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -18,7 +18,8 @@
 // 15: remove counting of open file descriptors
 // 16: remove unnecessary free
 // 17: apply new classes around the cache manager
-#define LIBCVMFS_REVISION 17
+// 18: add cvmfs_pread
+#define LIBCVMFS_REVISION 18
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -106,6 +107,13 @@ void cvmfs_set_log_fn( void (*log_fn)(const char *msg) );
  * \return read-only file descriptor, -1 on failure (sets errno)
  */
 int cvmfs_open(cvmfs_context *ctx, const char *path);
+
+/**
+ * Reads from a file descriptor returned by cvmfs_open.  File descriptors that
+ * have bit 31 set indicate chunked files.
+ */
+ssize_t cvmfs_pread(cvmfs_context *ctx,
+                    int fd, void *buf, size_t size, off_t off);
 
 /* Closes a file previously opened with cvmfs_open().
  *

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -606,6 +606,15 @@ int cvmfs_context::Open(const char *c_path) {
   return fd;
 }
 
+int64_t cvmfs_context::Pread(
+  int fd,
+  void *buf,
+  uint64_t size,
+  uint64_t offset)
+{
+  return fetcher_->cache_mgr()->Pread(fd, buf, size, offset);
+}
+
 int cvmfs_context::Close(int fd) {
   LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_close on file number: %d", fd);
   cvmfs_globals::Instance()->cache_mgr()->Close(fd);

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -581,6 +581,63 @@ int cvmfs_context::Open(const char *c_path) {
   if (!found) {
     return -ENOENT;
   }
+  
+  /*if (dirent.IsChunkedFile()) {
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "chunked file %s opened (download delayed to read() call)",
+             path.c_str());
+
+    
+
+    chunk_tables_->Lock();
+    if (!chunk_tables_->inode2chunks.Contains(ino)) {
+      chunk_tables_->Unlock();
+
+      // Retrieve File chunks from the catalog
+      FileChunkList *chunks = new FileChunkList();
+      if (!catalog_manager_->ListFileChunks(path, dirent.hash_algorithm(),
+                                           chunks) ||
+          chunks->IsEmpty())
+      {
+        remount_fence_->Leave();
+        LogCvmfs(kLogCvmfs, kLogDebug| kLogSyslogErr, "file %s is marked as "
+                 "'chunked', but no chunks found.", path.c_str());
+        fuse_reply_err(req, EIO);
+        return;
+      }
+      remount_fence_->Leave();
+
+      chunk_tables_->Lock();
+      // Check again to avoid race
+      if (!chunk_tables_->inode2chunks.Contains(ino)) {
+        chunk_tables_->inode2chunks.Insert(ino, FileChunkReflist(chunks, path));
+        chunk_tables_->inode2references.Insert(ino, 1);
+      } else {
+        uint32_t refctr;
+        bool retval = chunk_tables_->inode2references.Lookup(ino, &refctr);
+        assert(retval);
+        chunk_tables_->inode2references.Insert(ino, refctr+1);
+      }
+    } else {
+      remount_fence_->Leave();
+      uint32_t refctr;
+      bool retval = chunk_tables_->inode2references.Lookup(ino, &refctr);
+      assert(retval);
+      chunk_tables_->inode2references.Insert(ino, refctr+1);
+    }
+
+    // Update the chunk handle list
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "linking chunk handle %d to inode: %"PRIu64,
+             chunk_tables_->next_handle, uint64_t(ino));
+    chunk_tables_->handle2fd.Insert(chunk_tables_->next_handle, ChunkFd());
+    fi->fh = static_cast<uint64_t>(-chunk_tables_->next_handle);
+    ++chunk_tables_->next_handle;
+    chunk_tables_->Unlock();
+
+    fuse_reply_open(req, fi);
+    return;
+  }*/
 
   fd = fetcher_->Fetch(
     dirent.checksum(),

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -160,6 +160,7 @@ class cvmfs_context : SingleCopy {
   int ListDirectory(const char *path, char ***buf, size_t *buflen);
 
   int Open(const char *c_path);
+  int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset);
   int Close(int fd);
 
   catalog::LoadError RemountStart();

--- a/cvmfs/libcvmfs_public_syms.txt
+++ b/cvmfs/libcvmfs_public_syms.txt
@@ -7,6 +7,7 @@ cvmfs_detach_repo
 cvmfs_remount
 cvmfs_set_log_fn
 cvmfs_open
+cvmfs_pread
 cvmfs_close
 cvmfs_readlink
 cvmfs_stat

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(CVMFS_UNITTEST_FILES
   t_fetch.cc
   t_manifest.cc
   t_tracer.cc
+  t_file_chunk.cc
 )
 
 #

--- a/test/unittests/t_file_chunk.cc
+++ b/test/unittests/t_file_chunk.cc
@@ -44,14 +44,14 @@ TEST_F(T_FileChunk, Simple) {
   simple_.Release(3);
   simple_.Release(4);
   EXPECT_EQ(3, simple_.Add(NewChunks()));
-  
-  FileChunkReflist chunks;
-  chunks = simple_.Get(0);
-  EXPECT_TRUE(chunks.list != NULL);
-  chunks = simple_.Get(-1);
-  EXPECT_EQ(NULL, chunks.list);
-  chunks = simple_.Get(4);
-  EXPECT_EQ(NULL, chunks.list);
+
+  SimpleChunkTables::OpenChunks open_chunks;
+  open_chunks = simple_.Get(0);
+  EXPECT_TRUE(open_chunks.chunk_reflist.list != NULL);
+  open_chunks = simple_.Get(-1);
+  EXPECT_EQ(NULL, open_chunks.chunk_reflist.list);
+  open_chunks = simple_.Get(4);
+  EXPECT_EQ(NULL, open_chunks.chunk_reflist.list);
 
   simple_.Release(0);
   simple_.Release(1);

--- a/test/unittests/t_file_chunk.cc
+++ b/test/unittests/t_file_chunk.cc
@@ -28,7 +28,34 @@ class T_FileChunk : public ::testing::Test {
 };
 
 
+TEST_F(T_FileChunk, FindChunkIdx) {
+  FileChunkList single;
+  FileChunkReflist reflist(&single, PathString(""));
+  EXPECT_DEATH(reflist.FindChunkIdx(0), ".*");
+
+  single.PushBack(FileChunk());
+  EXPECT_EQ(0U, reflist.FindChunkIdx(0));
+  EXPECT_EQ(0U, reflist.FindChunkIdx(100));
+
+  single.PushBack(FileChunk(shash::Any(), 1, 0));
+  EXPECT_EQ(0U, reflist.FindChunkIdx(0));
+  EXPECT_EQ(1U, reflist.FindChunkIdx(1));
+  EXPECT_EQ(1U, reflist.FindChunkIdx(100));
+
+  for (unsigned i = 2; i < 10; ++i) {
+    single.PushBack(FileChunk(shash::Any(), i, 0));
+  }
+  EXPECT_EQ(0U, reflist.FindChunkIdx(0));
+  EXPECT_EQ(5U, reflist.FindChunkIdx(5));
+  EXPECT_EQ(9U, reflist.FindChunkIdx(9));
+  EXPECT_EQ(9U, reflist.FindChunkIdx(10));
+  EXPECT_EQ(9U, reflist.FindChunkIdx(100));
+}
+
+
 TEST_F(T_FileChunk, Simple) {
+  EXPECT_DEATH(simple_.Add(FileChunkReflist()), ".*");
+
   EXPECT_EQ(0, simple_.Add(NewChunks()));
   EXPECT_EQ(1, simple_.Add(NewChunks()));
   EXPECT_EQ(2, simple_.Add(NewChunks()));

--- a/test/unittests/t_file_chunk.cc
+++ b/test/unittests/t_file_chunk.cc
@@ -1,0 +1,61 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../../cvmfs/file_chunk.h"
+
+using namespace std;  // NOLINT
+
+class T_FileChunk : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+  virtual void TearDown() {
+  }
+
+  FileChunkReflist NewChunks() {
+    FileChunkReflist result;
+    result.list = new FileChunkList();
+    result.path.Assign("/42", 3);
+    return result;
+  }
+
+  SimpleChunkTables simple_;
+};
+
+
+TEST_F(T_FileChunk, Simple) {
+  EXPECT_EQ(0, simple_.Add(NewChunks()));
+  EXPECT_EQ(1, simple_.Add(NewChunks()));
+  EXPECT_EQ(2, simple_.Add(NewChunks()));
+  EXPECT_EQ(3, simple_.Add(NewChunks()));
+
+  simple_.Release(-1);
+  simple_.Release(4);
+
+  simple_.Release(1);
+  EXPECT_EQ(1, simple_.Add(NewChunks()));
+  EXPECT_EQ(4, simple_.Add(NewChunks()));
+
+  simple_.Release(3);
+  simple_.Release(4);
+  EXPECT_EQ(3, simple_.Add(NewChunks()));
+  
+  FileChunkReflist chunks;
+  chunks = simple_.Get(0);
+  EXPECT_TRUE(chunks.list != NULL);
+  chunks = simple_.Get(-1);
+  EXPECT_EQ(NULL, chunks.list);
+  chunks = simple_.Get(4);
+  EXPECT_EQ(NULL, chunks.list);
+
+  simple_.Release(0);
+  simple_.Release(1);
+  simple_.Release(2);
+  simple_.Release(3);
+  EXPECT_EQ(0, simple_.Add(NewChunks()));
+}


### PR DESCRIPTION
Add a new function `cvmfs_pread` to libcvmfs.  Channeling all read calls through the library allows to take care of chunked files.  Instead of whole file caching, chunked files are downloaded and cached only once the corresponding byte range is requested.  Chunked files have a file descriptor with bit 30 set to 1.  The first 29 bit point to an array in `SimpleChunkTables` that holds a file descriptor and the list of chunks and offsets for this file.

The new functionality requires a small modification to the parrot source code (separate request to cctools project).  The change is backwards compatible and only effective if `LIBCVMFS_REVISION` >= 18.

This PR also moves the binary search to find a chunk idx given an offset from the fuse module to the `FileChunkReflist` and adds a unit test.

This PR fixes a problem in the handling of the return value of `CacheManager::Pread`.