### PR TITLE
tune fuse mount options for Mac

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -690,6 +690,15 @@ int main(int argc, char *argv[]) {
     options_manager->ParseDefault(*repository_name_);
   }
 
+#ifdef __APPLE__
+  string volname = "-ovolname=" + *repository_name_ + " (CernVM-FS)";
+  fuse_opt_add_arg(mount_options, volname.c_str());
+  // Allow for up to 5 minute "hangs" before OS X may kill cvmfs
+  fuse_opt_add_arg(mount_options, "-odaemon_timeout=300");
+  fuse_opt_add_arg(mount_options, "-onoapplexattr");
+  // Make libfuse single-threaded for the time being; see CVM-871, CVM-855
+  single_threaded_ = true;
+#endif
   if (options_manager->GetValue("CVMFS_MOUNT_RW", &parameter) &&
       options_manager->IsOn(parameter))
   {


### PR DESCRIPTION
OS X Fuse has a few mount options that differ from Linux fuse.  Use them appropriately.  Also turn off multi-threaded fuse for the time being until we understand current problems on Mac.  