### PR TITLE
switch cern.ch stratum 1 URLs to port 8000

### DIFF
--- a/mount/domain.d/cern.ch.conf
+++ b/mount/domain.d/cern.ch.conf
@@ -15,6 +15,6 @@
 # Use cvmfs_config showconfig to get the effective parameters.
 #
 
-CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk/cvmfs/@fqrn@;http://cvmfs.racf.bnl.gov/cvmfs/@fqrn@;http://cvmfs.fnal.gov/cvmfs/@fqrn@;http://cvmfs02.grid.sinica.edu.tw/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs.racf.bnl.gov:8000/cvmfs/@fqrn@;http://cvmfs.fnal.gov:8000/cvmfs/@fqrn@;http://cvmfs02.grid.sinica.edu.tw:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/cern.ch
 CVMFS_USE_GEOAPI=yes


### PR DESCRIPTION
Port 8000 avoids transparent proxies.  The osg and egi domain configurations use port 8000 and all the stratum 1s support it.