### PR TITLE
FIX: stack trace generation on OS X

### DIFF
--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -1375,7 +1375,7 @@ bool ManagedExec(const vector<string>  &command_line,
   assert(retcode);
   if (status_code != ForkFailures::kSendPid) {
     close(pipe_fork.read_end);
-    LogCvmfs(kLogQuota, kLogDebug, "managed execve failed (%s)",
+    LogCvmfs(kLogCvmfs, kLogDebug, "managed execve failed (%s)",
              ForkFailures::ToString(status_code).c_str());
     return false;
   }

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -69,7 +69,15 @@ static bool CheckFuse() {
   string fuse_device;
   int retval;
 #ifdef __APPLE__
-  retval = system("/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs");
+  if (FileExists("/Library/Filesystems/osxfuse.fs/Contents/Resources/"
+                 "load_osxfuse"))
+  {
+    // OS X Fuse 3
+    retval = system("/Library/Filesystems/osxfuse.fs/Contents/Resources/"
+                    "load_osxfuse");
+  } else {
+    retval = system("/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs");
+  }
   if (retval != 0) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Failed loading OSX Fuse");
     return false;


### PR DESCRIPTION
OS X uses lldb instead of gdb.  In addition this PR prepares the mount helper for osxfuse 3.