### PR TITLE
FIX/TEST: Magic Symlinks and Nested Catalogs

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -316,17 +316,19 @@ bool Catalog::ListingMd5PathStat(const shash::Md5 &md5path,
  * Returns only struct stat values
  * @param path_hash the MD5 hash of the path of the directory to list
  * @param listing will be set to the resulting DirectoryEntryList
+ * @param expand_symlink defines if magic symlinks should be resolved
  * @return true on successful listing, false otherwise
  */
 bool Catalog::ListingMd5Path(const shash::Md5 &md5path,
-                             DirectoryEntryList *listing) const
+                             DirectoryEntryList *listing,
+                             const bool expand_symlink) const
 {
   assert(IsInitialized());
 
   pthread_mutex_lock(lock_);
   sql_listing_->BindPathHash(md5path);
   while (sql_listing_->FetchRow()) {
-    DirectoryEntry dirent = sql_listing_->GetDirent(this);
+    DirectoryEntry dirent = sql_listing_->GetDirent(this, expand_symlink);
     FixTransitionPoint(md5path, &dirent);
     listing->push_back(dirent);
   }

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -126,12 +126,14 @@ class Catalog : public SingleCopy {
   }
 
   bool ListingMd5Path(const shash::Md5 &md5path,
-                      DirectoryEntryList *listing) const;
+                      DirectoryEntryList *listing,
+                      const bool expand_symlink = true) const;
   inline bool ListingPath(const PathString &path,
-                      DirectoryEntryList *listing) const
+                          DirectoryEntryList *listing,
+                          const bool expand_symlink = true) const
   {
     return ListingMd5Path(shash::Md5(path.GetChars(), path.GetLength()),
-                          listing);
+                          listing, expand_symlink);
   }
   bool ListingMd5PathStat(const shash::Md5 &md5path,
                           StatEntryList *listing) const;

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -377,7 +377,9 @@ void WritableCatalog::MoveToNestedRecursively(
   // After creating a new nested catalog we have to move all elements
   // now contained by the new one.  List and move them recursively.
   DirectoryEntryList listing;
-  bool retval = ListingPath(PathString(directory), &listing);
+  const bool resolve_magic_symlinks = false;
+  bool retval = ListingPath(PathString(directory), &listing,
+                            resolve_magic_symlinks);
   assert(retval);
 
   // Go through the listing

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -3,12 +3,6 @@ cvmfs_test_name="Migrating CernVM-FS 2.0 Repository to 2.1.x"
 cvmfs_test_autofs_on_startup=false
 
 
-get_cache_directory() {
-  local mountpoint="$1"
-  echo "${mountpoint}c"
-}
-
-
 get_talk_pipe() {
   local mountpoint="$1"
   local repo_name="$2"
@@ -64,27 +58,6 @@ stop_mocked_apache_access() {
   apache_switch on  > /dev/null
   curl --output /dev/null --silent --head --fail "$legacy_repo_url/.cvmfspublished" && die "fail (.cvmfspublished still reachable)"
   echo "done"
-}
-
-
-do_local_mount() {
-  local mountpoint="$1"
-  local repo_name="$2"
-  local repo_url="$3"
-  local cache="$(get_cache_directory $mountpoint)"
-  local config="${mountpoint}.conf"
-  local output="${mountpoint}.log"
-
-  mkdir $mountpoint $cache
-  cat > $config << EOF
-CVMFS_CACHE_BASE=$cache
-CVMFS_RELOAD_SOCKETS=$cache
-CVMFS_SERVER_URL=$repo_url
-CVMFS_HTTP_PROXY=DIRECT
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${repo_name}.pub
-CVMFS_KCACHE_TIMEOUT=15
-EOF
-  cvmfs2 -d -o config=$config $repo_name $mountpoint >> $output 2>&1
 }
 
 

--- a/test/src/592-magicsymlinks/main
+++ b/test/src/592-magicsymlinks/main
@@ -30,6 +30,65 @@ produce_files_in_1() {
   popdir
 }
 
+produce_files_in_2() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  touch foo/1.0/.cvmfscatalog
+  touch foo/1.1/.cvmfscatalog
+  touch foo/1.2/.cvmfscatalog
+
+  touch bar/.cvmfscatalog
+
+  popdir
+}
+
+produce_files_in_3() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  rm -f foo/.cvmfscatalog
+  rm -f bar/.cvmfscatalog
+
+  touch bar/2.0/.cvmfscatalog
+  touch bar/2.1/.cvmfscatalog
+  touch bar/2.2/.cvmfscatalog
+
+  popdir
+}
+
+
+setup_environment_variables_1() {
+  export FOO_VERSION=1.2
+  export BAR_VERSION=2.1
+  export PROGRAM_TYPE=foo
+  export GENERIC_VERSION=1.1
+}
+
+setup_environment_variables_2() {
+  export FOO_VERSION=1.0
+  export BAR_VERSION=2.2
+  export PROGRAM_TYPE=bar
+  export GENERIC_VERSION=2.1
+}
+
+setup_environment_variables_3() {
+  export FOO_VERSION=1.1
+  export BAR_VERSION=2.0
+  export PROGRAM_TYPE=foo
+  export GENERIC_VERSION=1.0
+}
+
+
+print_envionment_variables() {
+  echo "\$FOO_VERSION     = $FOO_VERSION"
+  echo "\$BAR_VERSION     = $BAR_VERSION"
+  echo "\$PROGRAM_TYPE    = $PROGRAM_TYPE"
+  echo "\$GENERIC_VERSION = $GENERIC_VERSION"
+}
+
 
 check_symlink() {
   local symlink_path="$1"
@@ -56,11 +115,20 @@ check_symlink() {
 }
 
 
+check_symlinks() {
+  local mountpoint="$1"
+  check_symlink "${mountpoint}/bar/current" "${BAR_VERSION}"                     || return 1
+  check_symlink "${mountpoint}/foo/current" "${FOO_VERSION}"                     || return 2
+  check_symlink "${mountpoint}/bin"         "${PROGRAM_TYPE}/current"            || return 3
+  check_symlink "${mountpoint}/general"     "${PROGRAM_TYPE}/${GENERIC_VERSION}" || return 4
+}
+
+
 TEST_592_MOUNTPOINT=""
 cleanup() {
   if [ ! -z $TEST_592_MOUNTPOINT ]; then
     echo -n "umounting ${TEST_592_MOUNTPOINT}... "
-    sudo umount $TEST_592_MOUNTPOINT && echo "done" || echo "fail"
+    remove_local_mount $TEST_592_MOUNTPOINT && echo "done" || echo "fail"
   fi
 }
 
@@ -90,26 +158,65 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM
 
   echo "set up environment variables"
-  export FOO_VERSION=1.2
-  export BAR_VERSION=2.1
-  export PROGRAM_TYPE=foo
-  export GENERIC_VERSION=1.1
-  echo "\$FOO_VERSION     = $FOO_VERSION"
-  echo "\$BAR_VERSION     = $BAR_VERSION"
-  echo "\$PROGRAM_TYPE    = $PROGRAM_TYPE"
-  echo "\$GENERIC_VERSION = $GENERIC_VERSION"
+  setup_environment_variables_1 || return 2
+  print_envionment_variables    || return 3
 
   echo "create a local mount of the created repository"
   TEST_592_MOUNTPOINT="$(pwd)/local_mount"
   do_local_mount "$TEST_592_MOUNTPOINT" \
                  "$CVMFS_TEST_REPO"     \
-                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 2
+                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 4
 
   echo "check magic symlinks"
-  check_symlink "${TEST_592_MOUNTPOINT}/bar/current" "${BAR_VERSION}"                     || return 3
-  check_symlink "${TEST_592_MOUNTPOINT}/foo/current" "${FOO_VERSION}"                     || return 4
-  check_symlink "${TEST_592_MOUNTPOINT}/bin"         "${PROGRAM_TYPE}/current"            || return 5
-  check_symlink "${TEST_592_MOUNTPOINT}/general"     "${PROGRAM_TYPE}/${GENERIC_VERSION}" || return 6
+  check_symlinks "$TEST_592_MOUNTPOINT" || return 5
+
+  echo "umount private mount"
+  remove_local_mount $TEST_592_MOUNTPOINT || return 6
+
+  echo "open transaction to fiddle with nested catalogs"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "change repository structure"
+  produce_files_in_2 $repo_dir || return 7
+
+  echo "publish changes"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "set up new environment variables"
+  setup_environment_variables_2 || return 8
+  print_envionment_variables    || return 9
+
+  echo "create a local mount of the created repository"
+  do_local_mount "$TEST_592_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO"     \
+                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 10
+
+  echo "check magic symlinks"
+  check_symlinks $TEST_592_MOUNTPOINT || return 11
+
+  echo "umount private mount"
+  remove_local_mount $TEST_592_MOUNTPOINT || return 12
+
+  echo "open transaction to fiddle with nested catalogs"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "change repository structure"
+  produce_files_in_3 $repo_dir || return 13
+
+  echo "publish changes"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "set up new environment variables"
+  setup_environment_variables_3 || return 14
+  print_envionment_variables    || return 15
+
+  echo "create a local mount of the created repository"
+  do_local_mount "$TEST_592_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO"     \
+                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 16
+
+  echo "check magic symlinks"
+  check_symlinks $TEST_592_MOUNTPOINT || return 17
 
   return 0
 }

--- a/test/src/592-magicsymlinks/main
+++ b/test/src/592-magicsymlinks/main
@@ -1,0 +1,116 @@
+cvmfs_test_name="Magic Symlinks"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in_1() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir -p 'foo/1.0' 'foo/1.1' 'foo/1.2'
+  mkdir -p 'bar/2.0' 'bar/2.1' 'bar/2.2'
+
+  for d in $(find . -mindepth 2 -type d); do
+    head -c 10 /dev/urandom > ${d}/f
+    head -c 10 /dev/urandom > ${d}/g
+    head -c 10 /dev/urandom > ${d}/h
+  done
+
+  ln -s 'foo' foo_dir
+  ln -s 'bar' bar_dir
+
+  ln -s '$(FOO_VERSION)' foo/current
+  ln -s '$(BAR_VERSION)' bar/current
+
+  ln -s '$(PROGRAM_TYPE)/current' bin
+
+  ln -s '$(PROGRAM_TYPE)/$(GENERIC_VERSION)' general
+
+  touch foo/.cvmfscatalog
+
+  popdir
+}
+
+
+check_symlink() {
+  local symlink_path="$1"
+  local expected_link="$2"
+
+  if [ ! -h $symlink_path ]; then
+    echo "symlink '$symlink_path' doesn't exist"
+    return 1
+  fi
+
+  local link_content=
+  link_content=$(readlink $symlink_path)
+  if [ $? != 0 ]; then
+    echo "failed to read link value for '$symlink_path'"
+    return 2
+  fi
+
+  if [ x"$link_content" != x"$expected_link" ]; then
+    echo "symlink doesn't have the expected content"
+    echo "expected: $expected_link"
+    echo "found:    $link_content"
+    return 3
+  fi
+}
+
+
+TEST_592_MOUNTPOINT=""
+cleanup() {
+  if [ ! -z $TEST_592_MOUNTPOINT ]; then
+    echo -n "umounting ${TEST_592_MOUNTPOINT}... "
+    sudo umount $TEST_592_MOUNTPOINT && echo "done" || echo "fail"
+  fi
+}
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in_1 $repo_dir || return 1
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "set a trap for desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "set up environment variables"
+  export FOO_VERSION=1.2
+  export BAR_VERSION=2.1
+  export PROGRAM_TYPE=foo
+  export GENERIC_VERSION=1.1
+  echo "\$FOO_VERSION     = $FOO_VERSION"
+  echo "\$BAR_VERSION     = $BAR_VERSION"
+  echo "\$PROGRAM_TYPE    = $PROGRAM_TYPE"
+  echo "\$GENERIC_VERSION = $GENERIC_VERSION"
+
+  echo "create a local mount of the created repository"
+  TEST_592_MOUNTPOINT="$(pwd)/local_mount"
+  do_local_mount "$TEST_592_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO"     \
+                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 2
+
+  echo "check magic symlinks"
+  check_symlink "${TEST_592_MOUNTPOINT}/bar/current" "${BAR_VERSION}"                     || return 3
+  check_symlink "${TEST_592_MOUNTPOINT}/foo/current" "${FOO_VERSION}"                     || return 4
+  check_symlink "${TEST_592_MOUNTPOINT}/bin"         "${PROGRAM_TYPE}/current"            || return 5
+  check_symlink "${TEST_592_MOUNTPOINT}/general"     "${PROGRAM_TYPE}/${GENERIC_VERSION}" || return 6
+
+  return 0
+}
+

--- a/test/test_functions
+++ b/test/test_functions
@@ -1743,8 +1743,8 @@ do_local_mount() {
   local repo_name="$2"
   local repo_url="$3"
   local cache="$(get_cache_directory $mountpoint)"
-  local config="${mountpoint}.conf"
-  local output="${mountpoint}.log"
+  local config="$(mktemp ${mountpoint}.XXXXX.conf)"
+  local output="$(mktemp ${mountpoint}.XXXXX.log)"
 
   mkdir $mountpoint $cache
   cat > $config << EOF
@@ -1756,4 +1756,12 @@ CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${repo_name}.pub
 CVMFS_KCACHE_TIMEOUT=15
 EOF
   cvmfs2 -d -o config=$config $repo_name $mountpoint >> $output 2>&1
+}
+
+remove_local_mount() {
+  local mountpoint="$1"
+  local cache="$(get_cache_directory $mountpoint)"
+
+  sudo umount $mountpoint
+  rm -fR $cache $mountpoint
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -274,7 +274,7 @@ cvmfs_umount() {
   local repositories=$1
   local times=5
   local result=-1
-  
+
   for r in $(echo $repositories | tr , " "); do
     while (( result != 0 && times > 0  )); do
       sudo umount /cvmfs/$r > /dev/null 2>&1
@@ -285,7 +285,7 @@ cvmfs_umount() {
         sleep 1
       fi
     done
-    
+
     if [ $result -ne 0 ]; then
       lsof /cvmfs/$r
       return 200
@@ -1386,13 +1386,13 @@ setup_benchmark_environment() {
   local me=$(whoami)
   mkdir -p "$CVMFS_OPT_OUTPUT_DIR/$FQRN"
   mkdir -p $workspace/cache
-  
+
   # make sure the user can execute /bin/fusermount, write into /dev/fuse and write into /cvmfs/<repo>
   sudo chmod 666 /dev/fuse
   sudo chmod 4755 /bin/fusermount
   sudo mkdir -p /cvmfs/$FQRN
   sudo chown $me /cvmfs/$FQRN
-  
+
   # mtab trick
   if [ ! -h /etc/mtab ]; then
     sudo sh -c "mv /etc/mtab /etc/mtab.save"
@@ -1511,7 +1511,7 @@ execute_statistics_loop() {
     if [ x"$CVMFS_OPT_WARM_CACHE" != x"yes" ]; then
       clean_benchmark_cache
     fi
-    
+
     cvmfs2 -f -o config=cvmfs.conf,disable_watchdog,simple_options_parsing $FQRN /cvmfs/$FQRN 2>&1 &
     PID=$!
     wait_fqrn_mount
@@ -1556,7 +1556,7 @@ execute_benchmark_loop() {
   local iteration=1
   local code=0
   local count=$CVMFS_OPT_ITERATIONS
-  
+
   valgrind $OPTIONS cvmfs2 -f -o config=cvmfs.conf,disable_watchdog,simple_options_parsing $FQRN /cvmfs/$FQRN &
   PID=$!
   wait_fqrn_mount
@@ -1572,7 +1572,7 @@ execute_benchmark_loop() {
     count=$(( count - 1 ))
     iteration=$(( iteration + 1 ))
   done
-  
+
   create_info_file
 
   if [ "$code" -ne 0 ]; then
@@ -1580,7 +1580,7 @@ execute_benchmark_loop() {
     benchmark_log $(lsof /cvmfs/${FQRN})
     exit 100
   fi
-  
+
   benchmark_log "Iterations finished. Unmounting cvmfs"
   cvmfs_umount $FQRN
   wait $PID

--- a/test/test_functions
+++ b/test/test_functions
@@ -1731,3 +1731,29 @@ export_xunit_xml() {
   done
   xunit_epilogue "$xml_file"
 }
+
+
+get_cache_directory() {
+  local mountpoint="$1"
+  echo "${mountpoint}c"
+}
+
+do_local_mount() {
+  local mountpoint="$1"
+  local repo_name="$2"
+  local repo_url="$3"
+  local cache="$(get_cache_directory $mountpoint)"
+  local config="${mountpoint}.conf"
+  local output="${mountpoint}.log"
+
+  mkdir $mountpoint $cache
+  cat > $config << EOF
+CVMFS_CACHE_BASE=$cache
+CVMFS_RELOAD_SOCKETS=$cache
+CVMFS_SERVER_URL=$repo_url
+CVMFS_HTTP_PROXY=DIRECT
+CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${repo_name}.pub
+CVMFS_KCACHE_TIMEOUT=15
+EOF
+  cvmfs2 -d -o config=$config $repo_name $mountpoint >> $output 2>&1
+}


### PR DESCRIPTION
As described in [CVM-874](https://sft.its.cern.ch/jira/browse/CVM-874) magic symlinks can break when the repository's nested catalog structure changes. This adds a regression test for this issue and fixes the bug.

*Note*: The integration test neither checks the behaviour of magic symlinks in absence of their required environment variables nor their proper recreation in a CVMFS server installation. This is left for another test in conjunction with the implementation of [CVM-879](https://sft.its.cern.ch/jira/browse/CVM-879).