### PR TITLE
FIX: Renaming a Directory containing Changes fails to Publish

### DIFF
--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -68,7 +68,7 @@ SyncItemType SyncItem::GetScratchFiletype() const {
   StatScratch();
   if (scratch_stat_.error_code != 0) {
     PrintWarning("Failed to stat() '" + GetRelativePath() + "' in scratch. "
-                 "errno: " + StringifyInt(scratch_stat_.error_code) + ")");
+                 "(errno: " + StringifyInt(scratch_stat_.error_code) + ")");
     abort();
   }
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -21,10 +21,10 @@ SyncItem::SyncItem() :
 {
 }
 
-SyncItem::SyncItem(const string &relative_parent_path,
-                   const string &filename,
-                   const SyncItemType entry_type,
-                   const SyncUnion *union_engine) :
+SyncItem::SyncItem(const string       &relative_parent_path,
+                   const string       &filename,
+                   const SyncUnion    *union_engine,
+                   const SyncItemType  entry_type) :
   union_engine_(union_engine),
   whiteout_(false),
   relative_parent_path_(relative_parent_path),

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -47,10 +47,10 @@ class SyncItem {
    *  @param entryType well...
    */
   SyncItem();  // TODO(rmeusel): Remove
-  SyncItem(const std::string &relative_parent_path,
-           const std::string &filename,
-           const SyncItemType entry_type,
-           const SyncUnion *union_engine);
+  SyncItem(const std::string  &relative_parent_path,
+           const std::string  &filename,
+           const SyncUnion    *union_engine,
+           const SyncItemType  entry_type = kItemUnknown);
 
   inline bool IsDirectory()     const { return IsType(kItemDir);              }
   inline bool WasDirectory()    const { return WasType(kItemDir);             }

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -139,7 +139,7 @@ class SyncItem {
   inline void StatUnion(const bool refresh = false) const {
     StatGeneric(GetUnionPath(), &union_stat_, refresh);
   }
-  inline void StatOverlay(const bool refresh = false) const {
+  inline void StatScratch(const bool refresh = false) const {
     StatGeneric(GetScratchPath(), &scratch_stat_, refresh);
   }
   static void StatGeneric(const std::string  &path,

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -60,6 +60,9 @@ class SyncItem {
   inline bool WasSymlink()      const { return WasType(kItemSymlink);         }
   inline bool IsNew()           const { return WasType(kItemNew);             }
 
+  // TODO(reneme): code smell! This depends on the UnionEngine to call
+  //                           MarkAsWhiteout(), before it potentially gives the
+  //                           wrong result!
   inline bool IsWhiteout()      const { return whiteout_;                     }
   inline bool IsCatalogMarker() const { return filename_ == ".cvmfscatalog";  }
   bool IsOpaqueDirectory() const;

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -21,7 +21,8 @@ enum SyncItemType {
   kItemDir,
   kItemFile,
   kItemSymlink,
-  kItemNew
+  kItemNew,
+  kItemUnknown
 };
 
 
@@ -51,16 +52,17 @@ class SyncItem {
            const SyncItemType entry_type,
            const SyncUnion *union_engine);
 
-  inline bool IsDirectory()     const { return scratch_type_ == kItemDir;     }
-  inline bool WasDirectory()    const { return rdonly_type_  == kItemDir;     }
-  inline bool IsRegularFile()   const { return scratch_type_ == kItemFile;    }
-  inline bool WasRegularFile()  const { return rdonly_type_  == kItemFile;    }
-  inline bool IsSymlink()       const { return scratch_type_ == kItemSymlink; }
-  inline bool WasSymlink()      const { return rdonly_type_  == kItemSymlink; }
+  inline bool IsDirectory()     const { return IsType(kItemDir);              }
+  inline bool WasDirectory()    const { return WasType(kItemDir);             }
+  inline bool IsRegularFile()   const { return IsType(kItemFile);             }
+  inline bool WasRegularFile()  const { return WasType(kItemFile);            }
+  inline bool IsSymlink()       const { return IsType(kItemSymlink);          }
+  inline bool WasSymlink()      const { return WasType(kItemSymlink);         }
+  inline bool IsNew()           const { return WasType(kItemNew);             }
+
   inline bool IsWhiteout()      const { return whiteout_;                     }
   inline bool IsCatalogMarker() const { return filename_ == ".cvmfscatalog";  }
   bool IsOpaqueDirectory() const;
-  bool IsNew() const { return rdonly_type_ == kItemNew; }
 
   inline shash::Any GetContentHash() const { return content_hash_; }
   inline void SetContentHash(const shash::Any &hash) { content_hash_ = hash; }
@@ -101,6 +103,21 @@ class SyncItem {
 
  protected:
   SyncItemType GetRdOnlyFiletype() const;
+  SyncItemType GetScratchFiletype() const;
+
+  inline bool IsType(const SyncItemType expected_type) const {
+    if (scratch_type_ == kItemUnknown) {
+      scratch_type_ = GetScratchFiletype();
+    }
+    return scratch_type_ == expected_type;
+  }
+
+  inline bool WasType(const SyncItemType expected_type) const {
+    if (rdonly_type_ == kItemUnknown) {
+      rdonly_type_ = GetRdOnlyFiletype();
+    }
+    return rdonly_type_ == expected_type;
+  }
 
  private:
   /**
@@ -111,10 +128,20 @@ class SyncItem {
       memset(&stat, 0, sizeof(stat));
     }
 
+    inline SyncItemType GetSyncItemType() const {
+      assert(obtained);
+      if (S_ISDIR(stat.st_mode)) return kItemDir;
+      if (S_ISREG(stat.st_mode)) return kItemFile;
+      if (S_ISLNK(stat.st_mode)) return kItemSymlink;
+      return kItemUnknown;
+    }
+
     bool obtained;   /**< false at the beginning, true after first stat call */
     int error_code;  /**< errno value of the stat call */
     platform_stat64 stat;
   };
+
+  SyncItemType GetGenericFiletype(const EntryStat &stat) const;
 
   const SyncUnion *union_engine_;
 
@@ -126,8 +153,8 @@ class SyncItem {
   std::string relative_parent_path_;
   std::string filename_;
 
-  SyncItemType scratch_type_;
-  SyncItemType rdonly_type_;
+  mutable SyncItemType scratch_type_;
+  mutable SyncItemType rdonly_type_;
 
   // The hash of regular file's content
   shash::Any content_hash_;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -434,7 +434,12 @@ void SyncMediator::RemoveDirectoryCallback(const std::string &parent_dir,
 bool SyncMediator::IgnoreFileCallback(const std::string &parent_dir,
                                       const std::string &file_name)
 {
-  return union_engine_->IgnoreFilePredicate(parent_dir, file_name);
+  if (union_engine_->IgnoreFilePredicate(parent_dir, file_name)) {
+    return true;
+  }
+
+  SyncItem entry(parent_dir, file_name, union_engine_);
+  return union_engine_->IsWhiteoutEntry(entry);
 }
 
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -318,7 +318,7 @@ void SyncMediator::CompleteHardlinks(const SyncItem &entry) {
 void SyncMediator::LegacyRegularHardlinkCallback(const string &parent_dir,
                                                  const string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, kItemFile, union_engine_);
+  SyncItem entry(parent_dir, file_name, union_engine_, kItemFile);
   InsertLegacyHardlink(entry);
 }
 
@@ -326,7 +326,7 @@ void SyncMediator::LegacyRegularHardlinkCallback(const string &parent_dir,
 void SyncMediator::LegacySymlinkHardlinkCallback(const string &parent_dir,
                                                   const string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, kItemSymlink, union_engine_);
+  SyncItem entry(parent_dir, file_name, union_engine_, kItemSymlink);
   InsertLegacyHardlink(entry);
 }
 
@@ -351,7 +351,7 @@ void SyncMediator::AddDirectoryRecursively(const SyncItem &entry) {
 bool SyncMediator::AddDirectoryCallback(const std::string &parent_dir,
                                         const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, kItemDir, union_engine_);
+  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
   AddDirectory(entry);
   return true;  // The recursion engine should recurse deeper here
 }
@@ -360,7 +360,7 @@ bool SyncMediator::AddDirectoryCallback(const std::string &parent_dir,
 void SyncMediator::AddFileCallback(const std::string &parent_dir,
                                    const std::string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, kItemFile, union_engine_);
+  SyncItem entry(parent_dir, file_name, union_engine_, kItemFile);
   Add(entry);
 }
 
@@ -368,7 +368,7 @@ void SyncMediator::AddFileCallback(const std::string &parent_dir,
 void SyncMediator::AddSymlinkCallback(const std::string &parent_dir,
                                       const std::string &link_name)
 {
-  SyncItem entry(parent_dir, link_name, kItemSymlink, union_engine_);
+  SyncItem entry(parent_dir, link_name, union_engine_, kItemSymlink);
   Add(entry);
 }
 
@@ -376,7 +376,7 @@ void SyncMediator::AddSymlinkCallback(const std::string &parent_dir,
 void SyncMediator::EnterAddedDirectoryCallback(const std::string &parent_dir,
                                                const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, kItemDir, union_engine_);
+  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
   EnterDirectory(entry);
 }
 
@@ -384,7 +384,7 @@ void SyncMediator::EnterAddedDirectoryCallback(const std::string &parent_dir,
 void SyncMediator::LeaveAddedDirectoryCallback(const std::string &parent_dir,
                                                const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, kItemDir, union_engine_);
+  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
   LeaveDirectory(entry);
 }
 
@@ -410,7 +410,7 @@ void SyncMediator::RemoveDirectoryRecursively(const SyncItem &entry) {
 void SyncMediator::RemoveFileCallback(const std::string &parent_dir,
                                       const std::string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, kItemFile, union_engine_);
+  SyncItem entry(parent_dir, file_name, union_engine_, kItemFile);
   Remove(entry);
 }
 
@@ -418,7 +418,7 @@ void SyncMediator::RemoveFileCallback(const std::string &parent_dir,
 void SyncMediator::RemoveSymlinkCallback(const std::string &parent_dir,
                                          const std::string &link_name)
 {
-  SyncItem entry(parent_dir, link_name, kItemSymlink, union_engine_);
+  SyncItem entry(parent_dir, link_name, union_engine_, kItemSymlink);
   Remove(entry);
 }
 
@@ -426,7 +426,7 @@ void SyncMediator::RemoveSymlinkCallback(const std::string &parent_dir,
 void SyncMediator::RemoveDirectoryCallback(const std::string &parent_dir,
                                            const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, kItemDir, union_engine_);
+  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
   RemoveDirectoryRecursively(entry);
 }
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -46,7 +46,7 @@ bool SyncUnion::ProcessDirectory(const string &parent_dir,
 {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessDirectory(%s, %s)",
            parent_dir.c_str(), dir_name.c_str());
-  SyncItem entry(parent_dir, dir_name, kItemDir, this);
+  SyncItem entry(parent_dir, dir_name, this, kItemDir);
 
   if (entry.IsNew()) {
     mediator_->Add(entry);
@@ -70,7 +70,7 @@ void SyncUnion::ProcessRegularFile(const string &parent_dir,
 {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessRegularFile(%s, %s)",
            parent_dir.c_str(), filename.c_str());
-  SyncItem entry(parent_dir, filename, kItemFile, this);
+  SyncItem entry(parent_dir, filename, this, kItemFile);
   ProcessFile(&entry);
 }
 
@@ -80,7 +80,7 @@ void SyncUnion::ProcessSymlink(const string &parent_dir,
 {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessSymlink(%s, %s)",
            parent_dir.c_str(), link_name.c_str());
-  SyncItem entry(parent_dir, link_name, kItemSymlink, this);
+  SyncItem entry(parent_dir, link_name, this, kItemSymlink);
   ProcessFile(&entry);
 }
 
@@ -115,7 +115,7 @@ void SyncUnion::ProcessFile(SyncItem *entry) {
 void SyncUnion::EnterDirectory(const string &parent_dir,
                                const string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, kItemDir, this);
+  SyncItem entry(parent_dir, dir_name, this, kItemDir);
   mediator_->EnterDirectory(entry);
 }
 
@@ -123,7 +123,7 @@ void SyncUnion::EnterDirectory(const string &parent_dir,
 void SyncUnion::LeaveDirectory(const string &parent_dir,
                                const string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, kItemDir, this);
+  SyncItem entry(parent_dir, dir_name, this, kItemDir);
   mediator_->LeaveDirectory(entry);
 }
 
@@ -301,7 +301,7 @@ void SyncUnionOverlayfs::ProcessFileHardlinkCallback(const string &parent_dir,
   LogCvmfs(kLogUnionFs, kLogDebug,
            "SyncUnionOverlayfs::ProcessFileHardlinkCallback(%s, %s)",
            parent_dir.c_str(), filename.c_str());
-  SyncItem entry(parent_dir, filename, kItemFile, this);
+  SyncItem entry(parent_dir, filename, this, kItemFile);
   if (entry.GetRdOnlyLinkcount() > 1) {
     if (hardlink_lower_inode_ == entry.GetRdOnlyInode()) {
       LogCvmfs(kLogUnionFs, kLogDebug,

--- a/test/src/593-nestedwhiteout/main
+++ b/test/src/593-nestedwhiteout/main
@@ -1,0 +1,225 @@
+cvmfs_test_name="Rename of Directory containing Changes"
+cvmfs_test_autofs_on_startup=false
+
+produce_initial_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir contains_nothing
+
+  mkdir contains_file
+  echo "another useless file" > contains_file/file
+
+  mkdir contains_empty_dir
+  mkdir contains_empty_dir/empty_dir
+
+  mkdir contains_dir
+  mkdir contains_dir/dir
+  echo "useless file content" > contains_dir/dir/useless
+
+  mkdir contains_many_entries
+  mkdir contains_many_entries/dir
+  echo "nothing to see here" > contains_many_entries/file
+
+  popdir
+}
+
+add_file_and_rename_parent() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  echo "additional file for testing" > contains_nothing/useful
+  mv contains_nothing contains_nothing_renamed
+
+  popdir
+}
+
+remove_file_and_rename_parent() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  rm -f contains_file/file
+  mv contains_file contains_file_renamed
+
+  popdir
+}
+
+remove_empty_directory_and_rename_parent() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  rm -fR contains_empty_dir/empty_dir
+  mv contains_empty_dir contains_empty_dir_renamed
+
+  popdir
+}
+
+remove_directory_and_rename_parent() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  rm -fR contains_dir/dir
+  mv contains_dir contains_dir_renamed
+
+  popdir
+}
+
+remove_directory_among_many_entries_and_rename_parent() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  rm -fR contains_many_entries/dir
+  mv contains_many_entries contains_many_entries_renamed
+
+  popdir
+}
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository (1)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_initial_files_in $repo_dir || return 3
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  produce_initial_files_in $reference_dir || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+#
+# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+#
+
+  echo "starting transaction to edit repository (2)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting a new file in dir and rename dir"
+  add_file_and_rename_parent $repo_dir || return 5
+
+  echo "doing exactly the same in the scratch space for comparison"
+  add_file_and_rename_parent $reference_dir || return 6
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+#
+# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+#
+
+  echo "starting transaction to edit repository (3)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing a file from dir and renaming dir"
+  remove_file_and_rename_parent $repo_dir || return 7
+
+  echo "doing exactly the same in the scratch space for comparison"
+  remove_file_and_rename_parent $reference_dir || return 8
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+#
+# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+#
+
+  echo "starting transaction to edit repository (4)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing an empty directory in dir and renaming dir"
+  remove_empty_directory_and_rename_parent $repo_dir || return 8
+
+  echo "doing exactly the same in the scratch space for comparison"
+  remove_empty_directory_and_rename_parent $reference_dir || return 9
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+#
+# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+#
+
+  echo "starting transaction to edit repository (5)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing a non-empty directory in dir and rename dir"
+  remove_directory_and_rename_parent $repo_dir || return 10
+
+  echo "doing exactly the same in the scratch space for comparison"
+  remove_directory_and_rename_parent $reference_dir || return 11
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+#
+# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+#
+
+  echo "starting transaction to edit repository (6)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing an entry among others in dir and rename dir"
+  remove_directory_among_many_entries_and_rename_parent $repo_dir || return 12
+
+  echo "doing exactly the same in the scratch space for comparison"
+  remove_directory_among_many_entries_and_rename_parent $reference_dir || return 13
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  return 0
+}
+


### PR DESCRIPTION
This fixes a problem found by Alice and tracked in [CVM-880](https://sft.its.cern.ch/jira/browse/CVM-880). In short: When renaming a directory that contains AUFS whiteout entries the whiteouts might persist (even though useless) under certain circumstances. The CVMFS syncing process didn't expect those and crashed. This fix now ignores whiteouts in this case. Furthermore the Pull Request contains a regression test for the issue.

Note that a bit of refactoring in `SyncItem` was necessary to properly implement this fix. Namely, `SyncItem` now lazy-evaluates both the `stat()` for the read-only AUFS branch and for the r/w scratch branch. Up to now `SyncItem` was relying on the user to provide the correct directory entry type, this is now optional.