### PR TITLE
FIX: Cloud testing FakeS3 Installation

### DIFF
--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -269,12 +269,20 @@ install_from_repo() {
 
 
 install_ruby_gem() {
-  local gem_name=$1
+  local gem_name="$1"
+  local gem_version="$2"
   local pkg_mgr_name="gem"
   local pkg_mgr_output=""
 
-  echo -n "Installing Ruby gem '$gem_name' ... "
-  pkg_mgr_output=$(sudo gem install $gem_name 2>&1)
+  local gem_install_cmd="sudo gem install $gem_name"
+  if [ ! -z "$gem_version" ]; then
+    gem_install_cmd="$gem_install_cmd --version $gem_version"
+  else
+    gem_version="latest"
+  fi
+
+  echo -n "Installing Ruby gem '$gem_name' (version: $gem_version) ... "
+  pkg_mgr_output=$($gem_install_cmd 2>&1)
   check_package_manager_response $? $pkg_mgr_name "$pkg_mgr_output"
 }
 

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -78,7 +78,7 @@ install_from_repo rubygems
 install_from_repo java
 
 # install ruby gem for FakeS3
-install_ruby_gem fakes3
+install_ruby_gem fakes3 0.2.0  # latest is 0.2.1 (23.07.2015) that didn't work.
 
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "


### PR DESCRIPTION
The latest version of [FakeS3](https://github.com/jubos/fake-s3) (0.2.1) seems not to work on SLC6. This allows to install an older (working) version of the ruby gem. With that the S3 cloud tests should hopefully not fail anymore.