### PR TITLE
FIX: S3 Upstream Temporary Directory

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4370,10 +4370,12 @@ snapshot() {
     fi
 
     # put a magic file in the repository root to signal a snapshot in progress
-    $user_shell "date > ${spool_dir}/tmp/snapshotting"
+    local snapshotting_tmp="${spool_dir}/tmp/snapshotting"
+    $user_shell "date > $snapshotting_tmp"
     $user_shell "$(__swissknife_cmd) upload -r ${upstream} \
-      -i ${spool_dir}/tmp/snapshotting \
+      -i $snapshotting_tmp                                 \
       -o .cvmfs_is_snapshotting"
+    $user_shell "rm -f $snapshotting_tmp"
 
     # do the actual snapshot actions
     local with_history=""
@@ -4387,10 +4389,12 @@ snapshot() {
         -t $timeout                                    \
         -a $retries $with_history $log_level"
 
-    $user_shell "date --utc > ${spool_dir}/tmp/last_snapshot"
+    local last_snapshot_tmp="${spool_dir}/tmp/last_snapshot"
+    $user_shell "date --utc > $last_snapshot_tmp"
     $user_shell "$(__swissknife_cmd) upload -r ${upstream} \
-      -i ${spool_dir}/tmp/last_snapshot                    \
+      -i $last_snapshot_tmp                                \
       -o .cvmfs_last_snapshot"
+    $user_shell "rm -f $last_snapshot_tmp"
 
     # run the automatic garbage collection (if configured)
     if has_auto_garbage_collection_enabled $alias_name; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1652,7 +1652,7 @@ make_local_upstream() {
 make_s3_upstream() {
   local repo_name=$1
   local s3_config=$2
-  make_upstream "S3" "/tmp" "${repo_name}@${s3_config}"
+  make_upstream "S3" "/var/spool/cvmfs/${repo_name}/tmp" "${repo_name}@${s3_config}"
 }
 
 mangle_s3_cvmfs_url() {

--- a/test/src/515-createsnapshot/main
+++ b/test/src/515-createsnapshot/main
@@ -75,6 +75,15 @@ desaster_cleanup() {
   sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
 }
 
+check_stratum1_tmp_dir_emptiness() {
+  local tmp_dir="$1"
+  local tmp_dir_entries
+  echo "check stratum1 tmp directory"
+  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  echo "$tmp_dir contains: $tmp_dir_entries"
+  [ $tmp_dir_entries -eq 0 ]
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -117,8 +126,17 @@ cvmfs_run_test() {
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
     || { desaster_cleanup $mnt_point $replica_name; return 7; }
 
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
+
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
   mkdir $mnt_point cache

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -104,6 +104,15 @@ desaster_cleanup() {
   sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
 }
 
+check_stratum1_tmp_dir_emptiness() {
+  local tmp_dir="$1"
+  local tmp_dir_entries
+  echo "check stratum1 tmp directory"
+  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  echo "$tmp_dir contains: $tmp_dir_entries"
+  [ $tmp_dir_entries -eq 0 ]
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -146,9 +155,17 @@ cvmfs_run_test() {
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
     || { desaster_cleanup $mnt_point $replica_name; return 7; }
 
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
   mkdir $mnt_point cache

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -237,6 +237,15 @@ produce_last_files_in() {
   popdir
 }
 
+check_stratum1_tmp_dir_emptiness() {
+  local tmp_dir="$1"
+  local tmp_dir_entries
+  echo "check stratum1 tmp directory"
+  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  echo "$tmp_dir contains: $tmp_dir_entries"
+  [ $tmp_dir_entries -eq 0 ]
+}
+
 desaster_cleanup() {
   local mountpoint=$1
   local replica_name=$2
@@ -287,8 +296,17 @@ cvmfs_run_test() {
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
     || { desaster_cleanup $mnt_point $replica_name; return 7; }
 
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
+
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
   mkdir $mnt_point cache
@@ -326,6 +344,9 @@ EOF
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 17; }
 
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 102; }
+
   echo "remount the replica"
   cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 18; }
 
@@ -353,6 +374,9 @@ EOF
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 25; }
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 103; }
 
   echo "remount the replica"
   cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 26; }

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -206,6 +206,18 @@ cvmfs_run_test() {
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   cvmfs_server snapshot $replica_name || return 2
 
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
+
+  echo "check that tmp directory is empty after replicating"
+  local s1_tmp_no=
+  s1_tmp_no=$(ls "$s1_spool_tmp_dir" | wc -l)
+  echo "$s1_spool_tmp_dir contains: $s1_tmp_no entries"
+  [ $s1_tmp_no -eq 0 ] || return 101
+
   # ============================================================================
 
   echo "starting transaction to edit repository (1)"
@@ -288,6 +300,11 @@ cvmfs_run_test() {
 
   echo "update the stratum 1"
   cvmfs_server snapshot $replica_name
+
+  echo "check that tmp directory is empty after replicating"
+  s1_tmp_no=$(ls "$s1_spool_tmp_dir" | wc -l)
+  echo "$s1_spool_tmp_dir contains: $s1_tmp_no entries"
+  [ $s1_tmp_no -eq 0 ] || return 102
 
   # ============================================================================
 


### PR DESCRIPTION
This changes the default temporary directory used by the S3 upstream definition from `/tmp` to `/var/spool/cvmfs/${repo_name}/tmp`. Furthermore it cleans out two leaked sentinel files that were left in the latter tmp directory.

Additionally some of the Stratum1 related tests are amended to check for an empty tmp directory after `cvmfs_server snapshot`.