### PR TITLE
Extra functionalities to the catalog downloader add-on

### DIFF
--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -3,6 +3,7 @@
 import cvmfs
 import sys
 import os
+import urllib
 
 class MerkleCatalogTreeIterator(cvmfs.CatalogTreeIterator):
     def __init__(self, repository, root_catalog, visited_hashes = set()):
@@ -30,8 +31,10 @@ if len(sys.argv) < 3 or len(sys.argv) > 4:
     usage()
     sys.exit(1)
 
-dest  = sys.argv[2] + "/data"
-repo  = cvmfs.open_repository(sys.argv[1])
+main_folder = sys.argv[2]
+dest  = main_folder + "/data"
+url = sys.argv[1]
+repo  = cvmfs.open_repository(url)
 depth = sys.argv[3] if len(sys.argv) == 4 else 0
 
 try:
@@ -41,6 +44,14 @@ except ValueError, e:
     print
     print "<history depth> needs to be an integer"
     sys.exit(1)
+
+# download the .cvmfspublished file first
+try:
+    urllib.URLopener().retrieve(url + "/.cvmfspublished", main_folder + "/.cvmfspublished")
+except ValueError, e:
+    usage()
+    print
+    print "<repo url> does not contain .cvmfspublished file"
 
 try:
     os.mkdir(dest, 0755)


### PR DESCRIPTION
Now it not only downloads the catalogs, but stores them in a cache-like structure, i.e., inside a data/ folder and with subfolders from 00 to ff. Also, it downloads the .cvmfspublished from the repository and stores it in the selected folder.

These changes have as their main target to create a catalog structure that can be immediately used by the cvmfs.LocalRepository class of the python library. This last functionality has already been tested and it works without (apparently) any problem.