### PR TITLE
FIX: Integration Tests for Symlinked Backends

### DIFF
--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -22,6 +22,14 @@ produce_files_in() {
 	popdir
 }
 
+CVMFS_TEST_537_REPO_CREATED=0
+CVMFS_TEST_537_SELINUX_DISABLED=0
+cleanup() {
+  echo "running cleanup..."
+  [ $CVMFS_TEST_537_REPO_CREATED     -eq 0 ] || destroy_repo $CVMFS_TEST_REPO
+  [ $CVMFS_TEST_537_SELINUX_DISABLED -eq 0 ] || sudo setsebool httpd_enable_homedirs false
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -44,14 +52,18 @@ cvmfs_run_test() {
   mkdir $symlink_destination || return 2
   sudo ln --symbolic $symlink_destination $backend_dir || return 3
 
+  echo "register cleanup trap"
+  trap cleanup EXIT HUP INT TERM || return $?
+
   if has_selinux; then
     echo "make sure that SELinux does not interfere"
+    CVMFS_TEST_537_SELINUX_DISABLED=1
     sudo setsebool httpd_enable_homedirs true || return 6
-    selinux_disabled=1
   fi
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+  CVMFS_TEST_537_REPO_CREATED=1
 
   echo "check that repository backend is redirected"
   [ -f ${symlink_destination}/.cvmfspublished ] || return 4
@@ -78,18 +90,6 @@ cvmfs_run_test() {
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
-
-  # ============================================================================
-
-  echo "remove 'unusual' repository before successful test result"
-  destroy_repo $CVMFS_TEST_REPO || return 5
-
-  # ============================================================================
-
-  if [ $selinux_disabled -ne 0 ]; then
-    echo "reverting SELinux config"
-    sudo setsebool httpd_enable_homedirs false || return 7
-  fi
 
   return 0
 }

--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -27,7 +27,7 @@ CVMFS_TEST_537_SELINUX_DISABLED=0
 cleanup() {
   echo "running cleanup..."
   [ $CVMFS_TEST_537_REPO_CREATED     -eq 0 ] || destroy_repo $CVMFS_TEST_REPO
-  [ $CVMFS_TEST_537_SELINUX_DISABLED -eq 0 ] || sudo setsebool httpd_enable_homedirs false
+  [ $CVMFS_TEST_537_SELINUX_DISABLED -eq 0 ] || sudo setenforce 1
 }
 
 cvmfs_run_test() {
@@ -58,7 +58,7 @@ cvmfs_run_test() {
   if has_selinux; then
     echo "make sure that SELinux does not interfere"
     CVMFS_TEST_537_SELINUX_DISABLED=1
-    sudo setsebool httpd_enable_homedirs true || return 6
+    sudo setenforce 0 || return 6
   fi
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -16,7 +16,7 @@ CVMFS_TEST_538_S1_NAME=
 CVMFS_TEST_538_MOUNTPOINT=
 cleanup() {
   echo "running cleanup..."
-  [ $CVMFS_TEST_538_SELINUX_DISABLED -eq 0 ] || sudo setsebool httpd_enable_homedirs false
+  [ $CVMFS_TEST_538_SELINUX_DISABLED -eq 0 ] || sudo setenforce 1
   [ -z $CVMFS_TEST_538_S1_NAME ]             || sudo cvmfs_server rmfs -f $CVMFS_TEST_538_S1_NAME
   [ -z $CVMFS_TEST_538_MOUNTPOINT ]          || sudo umount $CVMFS_TEST_538_MOUNTPOINT
 }
@@ -74,7 +74,7 @@ cvmfs_run_test() {
   if has_selinux; then
     echo "make sure that SELinux does not interfere"
     CVMFS_TEST_538_SELINUX_DISABLED=1
-    sudo setsebool httpd_enable_homedirs true || return 16
+    sudo setenforce 0 || return 16
   fi
 
   echo "create Stratum1 repository on the same machine"

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -11,12 +11,14 @@ produce_files_in() {
   popdir
 }
 
-desaster_cleanup() {
-  local mountpoint=$1
-  local replica_name=$2
-
-  sudo umount $mountpoint > /dev/null 2>&1
-  sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
+CVMFS_TEST_538_SELINUX_DISABLED=0
+CVMFS_TEST_538_S1_NAME=
+CVMFS_TEST_538_MOUNTPOINT=
+cleanup() {
+  echo "running cleanup..."
+  [ $CVMFS_TEST_538_SELINUX_DISABLED -eq 0 ] || sudo setsebool httpd_enable_homedirs false
+  [ -z $CVMFS_TEST_538_S1_NAME ]             || sudo cvmfs_server rmfs -f $CVMFS_TEST_538_S1_NAME
+  [ -z $CVMFS_TEST_538_MOUNTPOINT ]          || sudo umount $CVMFS_TEST_538_MOUNTPOINT
 }
 
 cvmfs_run_test() {
@@ -66,26 +68,29 @@ cvmfs_run_test() {
   mkdir $symlink_destination || return 6
   sudo ln --symbolic $symlink_destination $backend_dir || return 7
 
+  echo "register cleanup trap"
+  trap cleanup EXIT HUP INT TERM || return $?
+
   if has_selinux; then
     echo "make sure that SELinux does not interfere"
+    CVMFS_TEST_538_SELINUX_DISABLED=1
     sudo setsebool httpd_enable_homedirs true || return 16
-    selinux_disabled=1
   fi
 
   echo "create Stratum1 repository on the same machine"
   load_repo_config $CVMFS_TEST_REPO
+  CVMFS_TEST_538_S1_NAME="$replica_name"
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
-                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
-    || { desaster_cleanup $mnt_point $replica_name; return 8; }
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 8
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
-  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+  cvmfs_server snapshot $replica_name || return 9
 
   echo "check if there is snapshot data in the symlink destination"
-  [ -f ${symlink_destination}/.cvmfspublished ] || { desaster_cleanup $mnt_point $replica_name; return 10; }
-  [ -d ${symlink_destination}/data ]             || { desaster_cleanup $mnt_point $replica_name; return 11; }
+  [ -f ${symlink_destination}/.cvmfspublished ] || return 10
+  [ -d ${symlink_destination}/data ]            || return 11
 
   echo "mount the Stratum1 repository on a local mountpoint"
   mkdir $mnt_point cache
@@ -96,24 +101,14 @@ CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/$replica_name
 CVMFS_HTTP_PROXY=DIRECT
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
 EOF
-  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 12; }
+  CVMFS_TEST_538_MOUNTPOINT="$mnt_point"
+  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || return 12
 
   echo "check the integrity of the stratum 1"
-  check_repository $replica_name -i || { desaster_cleanup $mnt_point $replica_name; return 13; }
+  check_repository $replica_name -i || return 13
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
-  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 14; }
-
-  echo "unmount the Stratum1 repository"
-  sudo umount $mnt_point || { desaster_cleanup $mnt_point $replica_name; return 15; }
-
-  echo "clean up"
-  sudo cvmfs_server rmfs -f $replica_name
-
-  if [ $selinux_disabled -ne 0 ]; then
-    echo "reverting SELinux config"
-    sudo setsebool httpd_enable_homedirs false || return 17
-  fi
+  compare_directories $mnt_point $reference_dir || return 14
 
   return 0
 }


### PR DESCRIPTION
Apparently the SELinux default behaviour on SL5 has changed so that `httpd` cannot read files when a backend is symlinked from **/srv/cvmfs/test.cern.ch** to **/tmp/test-workspace/...**.
I've disabled the enforcing mode for SELinux on those tests to work around it. What we really want to test here is that CVMFS can deal with those symlinked backends. Proper SELinux setup depends on the setup environment anyways .

Furthermore I refactored the `desaster_cleanup()` method into a `trap` based approach as done in newer tests as well. This gives better test maintainability and also more resilience against test interruptions.