### PR TITLE
FIX: SLC6 S3 Integration Tests

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -113,6 +113,8 @@ if [ $s3_retval -eq 0 ]; then
                                src/577-garbagecollecthiddenstratum1revision \
                                src/579-garbagecollectstratum1legacytag      \
                                src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
                                --                                           \
                                src/5* || retval=1
 

--- a/test/src/592-magicsymlinks/main
+++ b/test/src/592-magicsymlinks/main
@@ -165,7 +165,7 @@ cvmfs_run_test() {
   TEST_592_MOUNTPOINT="$(pwd)/local_mount"
   do_local_mount "$TEST_592_MOUNTPOINT" \
                  "$CVMFS_TEST_REPO"     \
-                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 4
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 4
 
   echo "check magic symlinks"
   check_symlinks "$TEST_592_MOUNTPOINT" || return 5
@@ -189,7 +189,7 @@ cvmfs_run_test() {
   echo "create a local mount of the created repository"
   do_local_mount "$TEST_592_MOUNTPOINT" \
                  "$CVMFS_TEST_REPO"     \
-                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 10
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 10
 
   echo "check magic symlinks"
   check_symlinks $TEST_592_MOUNTPOINT || return 11
@@ -213,7 +213,7 @@ cvmfs_run_test() {
   echo "create a local mount of the created repository"
   do_local_mount "$TEST_592_MOUNTPOINT" \
                  "$CVMFS_TEST_REPO"     \
-                 "$(get_local_repo_url $CVMFS_TEST_REPO)" || return 16
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 16
 
   echo "check magic symlinks"
   check_symlinks $TEST_592_MOUNTPOINT || return 17


### PR DESCRIPTION
This fixes some S3 based server integration tests. Namely 585 and 591 don't make sense for S3 and are thus disabled in the cloud tests. The rather new 592 had a bug that broke it on S3.