### PR TITLE
TEST: Use the S3 backend for Stratum1s in Integration Tests

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
@@ -111,7 +111,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 # if [ $s3_retval -eq 0 ]; then
 #   echo "running CernVM-FS server test cases against FakeS3..."
 #   CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
-#   CVMFS_TEST_STRATUM0=$FAKE_S3_URL                                          \
+#   CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
 #   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
 #   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
 #   ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -89,7 +89,7 @@ echo "done ($fakes3_pid)"
 if [ $s3_retval -eq 0 ]; then
   echo "running CernVM-FS server test cases against FakeS3..."
   CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
-  CVMFS_TEST_STRATUM0=$FAKE_S3_URL                                          \
+  CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
   ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \

--- a/test/src/515-createsnapshot/main
+++ b/test/src/515-createsnapshot/main
@@ -139,15 +139,7 @@ cvmfs_run_test() {
   check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
-  mkdir $mnt_point cache
-  cat > private.conf << EOF
-CVMFS_CACHE_BASE=$(pwd)/cache
-CVMFS_RELOAD_SOCKETS=$(pwd)/cache
-CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/$replica_name
-CVMFS_HTTP_PROXY=DIRECT
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
-EOF
-  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 10; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }

--- a/test/src/515-createsnapshot/main
+++ b/test/src/515-createsnapshot/main
@@ -93,7 +93,7 @@ cvmfs_run_test() {
   local reference_dir=$scratch_dir/reference_dir
 
   local mnt_point="$(pwd)/mountpount"
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -168,15 +168,7 @@ cvmfs_run_test() {
   check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
-  mkdir $mnt_point cache
-  cat > private.conf << EOF
-CVMFS_CACHE_BASE=$(pwd)/cache
-CVMFS_RELOAD_SOCKETS=$(pwd)/cache
-CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/$replica_name
-CVMFS_HTTP_PROXY=DIRECT
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
-EOF
-  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 10; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -122,7 +122,7 @@ cvmfs_run_test() {
   local reference_dir=$scratch_dir/reference_dir
 
   local mnt_point="$(pwd)/mountpount"
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -263,7 +263,7 @@ cvmfs_run_test() {
   local reference_dir=$scratch_dir/reference_dir
 
   local mnt_point="$(pwd)/mountpount"
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -309,15 +309,7 @@ cvmfs_run_test() {
   check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
-  mkdir $mnt_point cache
-  cat > private.conf << EOF
-CVMFS_CACHE_BASE=$(pwd)/cache
-CVMFS_RELOAD_SOCKETS=$(pwd)/cache
-CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/$replica_name
-CVMFS_HTTP_PROXY=DIRECT
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
-EOF
-  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 10; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }
@@ -348,7 +340,7 @@ EOF
   check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 102; }
 
   echo "remount the replica"
-  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 18; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 18; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 19; }
@@ -379,7 +371,7 @@ EOF
   check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 103; }
 
   echo "remount the replica"
-  cvmfs2 -d -o config=private.conf test.cern.ch $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 26; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 26; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 27; }

--- a/test/src/522-missingchunkfailover/main
+++ b/test/src/522-missingchunkfailover/main
@@ -11,7 +11,7 @@ desaster_cleanup() {
 cvmfs_run_test() {
   logfile=$1
   local scratch_dir=$(pwd)
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   local mnt_point="$scratch_dir/mountpoint"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"

--- a/test/src/523-corruptchunkfailover/main
+++ b/test/src/523-corruptchunkfailover/main
@@ -11,7 +11,7 @@ desaster_cleanup() {
 cvmfs_run_test() {
   logfile=$1
   local scratch_dir=$(pwd)
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   local mnt_point="$scratch_dir/mountpoint"
   local cache_dir="$scratch_dir/cache"
 

--- a/test/src/524-corruptmanifestfailover/main
+++ b/test/src/524-corruptmanifestfailover/main
@@ -11,7 +11,7 @@ desaster_cleanup() {
 cvmfs_run_test() {
   logfile=$1
   local scratch_dir=$(pwd)
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   local mnt_point="$scratch_dir/mountpoint"
   local cache_dir="$scratch_dir/cache"
 

--- a/test/src/529-ripemd160/main
+++ b/test/src/529-ripemd160/main
@@ -79,10 +79,11 @@ cvmfs_run_test() {
   echo sha1-hashed > /cvmfs/$CVMFS_TEST_REPO/sha1-hashed
   publish_repo $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 21; }
   sudo cvmfs_server resign $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 22; }
-  head -c8 /srv/cvmfs/$CVMFS_TEST_REPO/.cvmfspublished | grep rmd160
-  if [ $? -eq 0 ]; then
-    desaster_cleanup $mnt_point $replica_name; return 23;
-  fi
+
+  echo "checking if the hash algorithm was changed"
+  local manifest_url="$(get_repo_url $CVMFS_TEST_REPO)/.cvmfspublished"
+  echo "Manifest URL: $manifest_url"
+  [ -z $(curl "$manifest_url" | grep -e '^C.*rmd160$') ] || { desaster_cleanup $mnt_point $replica_name; return 23; }
 
   echo "replicating mixed hashes"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 24; }

--- a/test/src/529-ripemd160/main
+++ b/test/src/529-ripemd160/main
@@ -88,20 +88,11 @@ cvmfs_run_test() {
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 24; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
-  mkdir $mnt_point cache
-  cat > private.conf << EOF
-CVMFS_CACHE_BASE=$(pwd)/cache
-CVMFS_RELOAD_SOCKETS=$(pwd)/cache
-CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/$replica_name
-CVMFS_HTTP_PROXY=DIRECT
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
-EOF
-  cvmfs2 -d -o config=private.conf $CVMFS_TEST_REPO $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 14; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 14; }
 
   echo "clean up"
   sudo umount $mnt_point || { desaster_cleanup $mnt_point $replica_name; return 15; }
   sudo cvmfs_server rmfs -f $replica_name
-
 
   return 0
 }

--- a/test/src/529-ripemd160/main
+++ b/test/src/529-ripemd160/main
@@ -57,7 +57,7 @@ cvmfs_run_test() {
   sudo find /var/spool/cvmfs/$CVMFS_TEST_REPO/cache -type f | grep rmd160 || return 11
 
   local mnt_point="$(pwd)/mountpoint"
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   echo "create Stratum1 repository on the same machine"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -31,7 +31,7 @@ cvmfs_run_test() {
   local reference_dir=$scratch_dir/reference_dir
 
   local mnt_point="$(pwd)/mountpount"
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
 
   local backend_dir="/srv/cvmfs/${replica_name}"
   local symlink_destination="${scratch_dir}/backend"

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -119,7 +119,7 @@ cvmfs_run_test() {
   local legacy_repo_name="testmigration.cern.ch"
   local legacy_repo_storage="$(get_local_repo_storage $legacy_repo_name)"
   local legacy_repo_url="$(get_local_repo_url $legacy_repo_name)"
-  local replica_name="${legacy_repo_name}.stratum1"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   local replica_url="$(get_repo_url $replica_name)"
   local key_location="/etc/cvmfs/keys"
   local s0_mnt="$(pwd)/s0"

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -192,7 +192,7 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create Stratum1 repository on the same machine"
-  local replica_name="${CVMFS_TEST_REPO}.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   CVMFS_TEST_576_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -51,7 +51,7 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create Stratum1 repository on the same machine"
-  local replica_name="${CVMFS_TEST_REPO}.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   CVMFS_TEST_577_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/579-garbagecollectstratum1legacytag/main
+++ b/test/src/579-garbagecollectstratum1legacytag/main
@@ -51,7 +51,7 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create Stratum1 repository on the same machine"
-  local replica_name="${CVMFS_TEST_REPO}.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   CVMFS_TEST_579_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -69,7 +69,7 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create a stratum1 replication (with enabled auto garbage collection)"
-  replica_name="${CVMFS_TEST_REPO}.replic"
+  replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   CVMFS_TEST_580_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/581-snapshotgarbagecollectedrepo/main
+++ b/test/src/581-snapshotgarbagecollectedrepo/main
@@ -136,7 +136,7 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create a stratum1 replication"
-  replica_name="${CVMFS_TEST_REPO}.replic"
+  replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   CVMFS_TEST_581_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -53,6 +53,17 @@ run_background_snapshot() {
   fi
 }
 
+count_fetched_catalogs() {
+  local replication_log_file="$1"
+
+  # figure out where replication starts to process repository tags
+  # we do not want to count in that part of the log
+  local cutmark=$(cat $replication_log_file | grep -n "repository tag" | head -n 1 | cut -f1 -d:)
+
+  # count the number of times the pulling decided to fetch chunks
+  cat $replication_log_file | head -n $cutmark | grep 'Processing chunks' | wc -l
+}
+
 
 CVMFS_TEST_584_REPLICA_NAME=""
 cleanup() {
@@ -231,8 +242,8 @@ cvmfs_run_test() {
 
   echo "check the log files"
   echo "(6 should have snapshotted, 7 should have aborted, 8 should have waited and later snapshotted)"
-  local revisions_snapshotted_by_6=$(cat $snapshot_log_6 | grep 'Processing chunks' | wc -l)
-  local revisions_snapshotted_by_7=$(cat $snapshot_log_7 | grep 'Processing chunks' | wc -l)
+  local revisions_snapshotted_by_6=$(count_fetched_catalogs $snapshot_log_6)
+  local revisions_snapshotted_by_7=$(count_fetched_catalogs $snapshot_log_7)
   echo "Number 6 snapshotted $revisions_snapshotted_by_6 revisions"
   echo "Number 7 snapshotted $revisions_snapshotted_by_7 revisions"
   [ $revisions_snapshotted_by_6 -eq 6 ]                             || return 33

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -71,7 +71,7 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO || return $?
 
-  # echo "install a desaster cleanup function"
+  echo "install a desaster cleanup function"
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create Stratum1 repository on the same machine"

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -26,10 +26,10 @@ check_lock() {
 run_background_snapshot() {
   local name=$1
   local logfile=$2
-  shift 2
+  local max_waiting_time=$3
+  shift 3
   local snapshot_params="$*"
 
-  local max_waiting_time=180
   local snapshot_command="cvmfs_server snapshot $snapshot_params $name"
   local pid=0
 
@@ -90,7 +90,7 @@ cvmfs_run_test() {
 
   echo "create an initial snapshot (should immediately fail)"
   local snapshot_log_1="snapshot_1.log"
-  run_background_snapshot $replica_name $snapshot_log_1 || return 2
+  run_background_snapshot $replica_name $snapshot_log_1 15 || return 2
 
   echo "check if the snapshotting lock is there"
   check_lock $replica_name || return 3
@@ -100,7 +100,7 @@ cvmfs_run_test() {
 
   echo "create an initial snapshot without waiting (should immediately fail)"
   local snapshot_log_2="snapshot_2.log"
-  run_background_snapshot $replica_name $snapshot_log_2 -t || return 5
+  run_background_snapshot $replica_name $snapshot_log_2 15 -t || return 5
 
   echo "check if the snapshotting lock is there"
   check_lock $replica_name || return 6
@@ -115,7 +115,7 @@ cvmfs_run_test() {
 
   echo "create an initial snapshot (should work)"
   local snapshot_log_3="snapshot_3.log"
-  run_background_snapshot $replica_name $snapshot_log_3 || return 9
+  run_background_snapshot $replica_name $snapshot_log_3 120 || return 9
 
   echo "check if the snapshotting lock is gone"
   check_lock $replica_name && return 10
@@ -167,7 +167,7 @@ cvmfs_run_test() {
 
   echo "try to snapshot (should hang forever)"
   local snapshot_log_4="snapshot_4.log"
-  run_background_snapshot $replica_name $snapshot_log_4 && return 17
+  run_background_snapshot $replica_name $snapshot_log_4 30 && return 17
 
   echo "check if the snapshotting lock is there"
   check_lock $replica_name || return 18
@@ -177,7 +177,7 @@ cvmfs_run_test() {
 
   echo "try to snapshot (without waiting)"
   local snapshot_log_5="snapshot_5.log"
-  run_background_snapshot $replica_name $snapshot_log_5 -t || return 20
+  run_background_snapshot $replica_name $snapshot_log_5 30 -t || return 20
 
   echo "check if the snapshotting lock is there"
   check_lock $replica_name || return 21
@@ -203,7 +203,7 @@ cvmfs_run_test() {
 
   echo "run a second snapshot concurrently (should abort immediately)"
   local snapshot_log_7="snapshot_7.log"
-  run_background_snapshot $replica_name $snapshot_log_7 -t || return 26
+  run_background_snapshot $replica_name $snapshot_log_7 15 -t || return 26
 
   echo "check if the snapshotting lock is there"
   check_lock $replica_name || return 27
@@ -216,7 +216,7 @@ cvmfs_run_test() {
 
   echo "run a second snapshot concurrently (should wait and later do the snapshot)"
   local snapshot_log_8="snapshot_8.log"
-  run_background_snapshot $replica_name $snapshot_log_8 || return 30
+  run_background_snapshot $replica_name $snapshot_log_8 800 || return 30
 
   echo "check if the first snapshot is gone (kill it otherwise)"
   if kill -0 $pid6 > /dev/null 2>&1; then

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -86,7 +86,7 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "create Stratum1 repository on the same machine"
-  local replica_name="${CVMFS_TEST_REPO}.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   CVMFS_TEST_584_REPLICA_NAME="$replica_name"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/src/588-sha256/main
+++ b/test/src/588-sha256/main
@@ -79,10 +79,11 @@ cvmfs_run_test() {
   echo sha1-hashed > /cvmfs/$CVMFS_TEST_REPO/sha1-hashed
   publish_repo $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 21; }
   sudo cvmfs_server resign $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 22; }
-  head -c8 /srv/cvmfs/$CVMFS_TEST_REPO/.cvmfspublished | grep sha256
-  if [ $? -eq 0 ]; then
-    desaster_cleanup $mnt_point $replica_name; return 23;
-  fi
+
+  echo "checking if the hash algorithm was changed"
+  local manifest_url="$(get_repo_url $CVMFS_TEST_REPO)/.cvmfspublished"
+  echo "Manifest URL: $manifest_url"
+  [ -z $(curl "$manifest_url" | grep -e '^C.*sha256$') ] || { desaster_cleanup $mnt_point $replica_name; return 23; }
 
   echo "replicating mixed hashes"
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 24; }

--- a/test/src/588-sha256/main
+++ b/test/src/588-sha256/main
@@ -88,20 +88,11 @@ cvmfs_run_test() {
   sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 24; }
 
   echo "mount the Stratum1 repository on a local mountpoint"
-  mkdir $mnt_point cache
-  cat > private.conf << EOF
-CVMFS_CACHE_BASE=$(pwd)/cache
-CVMFS_RELOAD_SOCKETS=$(pwd)/cache
-CVMFS_SERVER_URL=http://127.0.0.1/cvmfs/$replica_name
-CVMFS_HTTP_PROXY=DIRECT
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
-EOF
-  cvmfs2 -d -o config=private.conf $CVMFS_TEST_REPO $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 14; }
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 14; }
 
   echo "clean up"
   sudo umount $mnt_point || { desaster_cleanup $mnt_point $replica_name; return 15; }
   sudo cvmfs_server rmfs -f $replica_name
-
 
   return 0
 }

--- a/test/src/588-sha256/main
+++ b/test/src/588-sha256/main
@@ -57,7 +57,7 @@ cvmfs_run_test() {
   sudo find /var/spool/cvmfs/$CVMFS_TEST_REPO/cache -type f | grep sha256 || return 11
 
   local mnt_point="$(pwd)/mountpoint"
-  local replica_name="$CVMFS_TEST_REPO.replic"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   echo "create Stratum1 repository on the same machine"
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \

--- a/test/test_functions
+++ b/test/test_functions
@@ -561,6 +561,12 @@ make_huge_repo() {
 }
 
 
+get_stratum1_name() {
+  local repo_name="$1"
+  echo "$repo_name.$(date +%s%N | md5sum | head -c6).replica"
+}
+
+
 create_stratum1() {
   local replica_name=$1
   local uid=$2

--- a/test/test_functions
+++ b/test/test_functions
@@ -27,7 +27,8 @@ CVMFS_TEST_UNIONFS=${CVMFS_TEST_UNIONFS:=} # union filesystem type to test
 CVMFS_TEST_SRVDEBUG=${CVMFS_TEST_SRVDEBUG:=}
 CVMFS_TEST_HASHALGO=${CVMFS_TEST_HASHALGO:=sha1}
 CVMFS_TEST_S3_CONFIG=${CVMFS_TEST_S3_CONFIG:=}
-CVMFS_TEST_STRATUM0=${CVMFS_TEST_STRATUM0:=}
+CVMFS_TEST_HTTP_BASE=${CVMFS_TEST_HTTP_BASE:=}
+CVMFS_TEST_STRATUM0=${CVMFS_TEST_STRATUM0:=}   # backward compatibility! use CVMFS_TEST_HTTP_BASE instead
 CVMFS_TEST_SERVER_CACHE=${CVMFS_TEST_SERVER_CACHE:=}
 
 # These OPT variables are for the benchmark options under the benchmarks folder
@@ -41,6 +42,15 @@ CVMFS_OPT_OUTPUT_DIR=${CVMFS_OPT_OUTPUT_DIR:=/tmp/cvmfs_benchmarks}
 CVMFS_OPT_CACHEDIR=${CVMFS_OPT_CACHEDIR:=~/.benchmark}
 CVMFS_OPT_PARALLEL_RUNS=${CVMFS_OPT_PARALLEL_RUNS:=1}
 CVMFS_OPT_MTAB_MODIFIED="false"
+
+# backward compatibility.
+#     CVMFS_TEST_STRATUM0 was replaced by CVMFS_TEST_HTTP_BASE to better reflect
+#     the purpose of this variable. Please don't use CVMFS_TEST_STRATUM0 anymore
+if [ -z "$CVMFS_TEST_HTTP_BASE" ] && [ ! -z "$CVMFS_TEST_STRATUM0" ]; then
+  echo "Warning: You are using the deprecated CVMFS_TEST_STRATUM0 variable."
+  echo "         Please consider switching to CVMFS_TEST_HTTP_BASE"
+  CVMFS_TEST_HTTP_BASE="$CVMFS_TEST_STRATUM0"
+fi
 
 
 if [ -f /.dockerinit ]; then
@@ -459,9 +469,9 @@ create_repo() {
     echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
     s3_config=" -s $CVMFS_TEST_S3_CONFIG"
   fi
-  if [ x"$CVMFS_TEST_STRATUM0" != x"" ]; then
-    echo "  Stratum0: $CVMFS_TEST_STRATUM0"
-    stratum0=" -w $CVMFS_TEST_STRATUM0"
+  if [ x"$CVMFS_TEST_HTTP_BASE" != x"" ]; then
+    echo "  Stratum0: $CVMFS_TEST_HTTP_BASE"
+    stratum0=" -w $CVMFS_TEST_HTTP_BASE"
   fi
   if [ x"$CVMFS_TEST_UNIONFS" != x"" ]; then
     echo "  UnionFS: $CVMFS_TEST_UNIONFS"
@@ -1078,8 +1088,8 @@ get_local_repo_url() {
 
 get_s3_repo_url() {
   local repo_name="$1"
-  local s3_stratum0_url="$CVMFS_TEST_STRATUM0"
-  [ x"$s3_stratum0_url" != x"" ] || die "\$CVMFS_TEST_STRATUM0 needs to be set for S3 tests to work!"
+  local s3_stratum0_url="$CVMFS_TEST_HTTP_BASE"
+  [ x"$s3_stratum0_url" != x"" ] || die "\$CVMFS_TEST_HTTP_BASE needs to be set for S3 tests to work!"
   [ $(echo -n "$s3_stratum0_url" | tail -c1) = "/" ] || s3_stratum0_url="${s3_stratum0_url}/"
   echo "${s3_stratum0_url}${repo_name}"
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -559,12 +559,12 @@ create_stratum1() {
   shift 4
   local additional_parameters="$*"
   local s3_config=""
-  # TODO: Re-enable this as soon as Stratum1 is supported
-  #       with an S3 backend
-  # if [ x"$CVMFS_TEST_S3_CONFIG" != x"" ]; then
-  #   echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
-  #   s3_config=" -s $CVMFS_TEST_S3_CONFIG"
-  # fi
+  if [ x"$CVMFS_TEST_S3_CONFIG" != x"" ]; then
+    local stratum1_url=$(get_repo_url $replica_name)
+    echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
+    echo "  Stratum1:  $stratum1_url"
+    s3_config=" -s $CVMFS_TEST_S3_CONFIG -w $stratum1_url"
+  fi
   sudo cvmfs_server add-replica -o $CVMFS_TEST_USER    \
                                 -n $replica_name       \
                                 -a                     \

--- a/test/test_functions
+++ b/test/test_functions
@@ -570,7 +570,8 @@ create_stratum1() {
   local additional_parameters="$*"
   local s3_config=""
   if [ x"$CVMFS_TEST_S3_CONFIG" != x"" ]; then
-    local stratum1_url=$(get_repo_url $replica_name)
+    local stratum1_url="$CVMFS_TEST_HTTP_BASE"
+    [ ! -z "$stratum1_url" ] || die "\$CVMFS_TEST_HTTP_BASE needs to be set for S3 tests to work!"
     echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
     echo "  Stratum1:  $stratum1_url"
     s3_config=" -s $CVMFS_TEST_S3_CONFIG -w $stratum1_url"


### PR DESCRIPTION
This enables the usage of the S3 backend in the integration tests dealing with Stratum1s. Some fixes were necessary to make it work:

* CVMFS_TEST_STRATUM0 was renamed to CVMFS_TEST_HTTP_BASE for consistency
* Stratum1s on S3 need a non-default HTTP URL to access the storage
* Refactor: use {{do_local_mount()}} in test cases 515, 516, 529 and 588 that takes the S3 based URLs into account
* Tests 529 and 588 were checking files directly in **/srv/cvmfs** which doesn't work with S3
* Timeouts in test 584 were too short for the slowish FakeS3
* Test 584 was failing due to slightly different logging output on S3
* The S3 backend is not cleared by `cvmfs_server rmfs` omitting the 'Initial Snapshot' on Stratum1s. Hence I made sure that the used Stratum1 names are unique

Furthermore this pull request contains some S3 backend logging enhancements needed for debugging.