### PR TITLE
TEST: Disable Integration Test 585 (xattrs) in Ubuntu

### DIFF
--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -44,6 +44,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/524-corruptmanifestfailover              \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
+                                 src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -32,6 +32,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/524-corruptmanifestfailover              \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
+                                 src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
                               || retval=1


### PR DESCRIPTION
Since Ubuntu doesn't support xattrs out of the box I disable it for now in the cloud tests on those platforms.