### PR TITLE
Python new Repository class

### DIFF
--- a/python/cvmfs/__init__.py
+++ b/python/cvmfs/__init__.py
@@ -44,7 +44,6 @@ def check_output(popen_args):
 
 
 def _get_server_version():
-    output = ''
     try:
         output = check_output(['cvmfs_server'])
         return __extract_version_string(output)
@@ -53,7 +52,6 @@ def _get_server_version():
 
 
 def _get_client_version():
-    output = ''
     try:
         output = check_output(['cvmfs2', '--version'])
     except OSError, e:

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -72,9 +72,9 @@ def _binary_buffer_to_hex_string(binbuf):
 def _split_md5(md5digest):
     hi = lo = 0
     for i in range(0, 8):
-        lo = lo | (ord(md5digest[i]) << (i * 8))
+        lo |= (ord(md5digest[i]) << (i * 8))
     for i in range(8,16):
-        hi = hi | (ord(md5digest[i]) << ((i - 8) * 8))
+        hi |= (ord(md5digest[i]) << ((i - 8) * 8))
     return ctypes.c_int64(lo).value, ctypes.c_int64(hi).value  # signed int!
 
 def _combine_md5(lo, hi):

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -75,17 +75,17 @@ class CompressedObject:
 
 
 
-class DatabaseObject(CompressedObject):
+class DatabaseObject:
     db_handle_ = None
 
-    def __init__(self, compressed_db_file):
-        CompressedObject.__init__(self, compressed_db_file)
+    def __init__(self, db_file):
+        self.file_ = db_file
         self._open_database()
 
     def __del__(self):
         if self.db_handle_:
             self.db_handle_.close()
-        self._close()
+        self.file_.close()
 
     def _open_database(self):
         """ Create and configure a database handle to the Catalog """

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -36,6 +36,8 @@ class DatabaseObject:
         self._open_database()
 
     def __del__(self):
+        if self._db_handle:
+            self._db_handle.close()
         self._file.close()
 
     def _open_database(self):
@@ -58,7 +60,9 @@ class DatabaseObject:
         """ Run an arbitrary SQL query on the catalog database """
         cursor = self._db_handle.cursor()
         cursor.execute(sql)
-        return cursor.fetchall()
+        data = cursor.fetchall()
+        cursor.close()
+        return data
 
     def open_interactive(self):
         """ Spawns a sqlite shell for interactive catalog database inspection """

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -29,24 +29,22 @@ class CvmfsNotInstalled(Exception):
 
 
 class DatabaseObject:
-    db_handle_ = None
+    _db_handle = None
 
     def __init__(self, db_file):
-        self.file_ = db_file
+        self._file = db_file
         self._open_database()
 
     def __del__(self):
-        if self.db_handle_:
-            self.db_handle_.close()
-        self.file_.close()
+        self._file.close()
 
     def _open_database(self):
         """ Create and configure a database handle to the Catalog """
-        self.db_handle_ = sqlite3.connect(self.file_.name)
-        self.db_handle_.text_factory = str
+        self._db_handle = sqlite3.connect(self._file.name)
+        self._db_handle.text_factory = str
 
     def db_size(self):
-        return os.path.getsize(self.file_.name)
+        return os.path.getsize(self._file.name)
 
     def read_properties_table(self, reader):
         """ Retrieve all properties stored in the 'properties' table """
@@ -58,21 +56,15 @@ class DatabaseObject:
 
     def run_sql(self, sql):
         """ Run an arbitrary SQL query on the catalog database """
-        cursor = self.db_handle_.cursor()
+        cursor = self._db_handle.cursor()
         cursor.execute(sql)
         return cursor.fetchall()
 
     def open_interactive(self):
         """ Spawns a sqlite shell for interactive catalog database inspection """
-        subprocess.call(['sqlite3', self.file_.name])
+        subprocess.call(['sqlite3', self._file.name])
 
 
-class FileObject(CompressedObject):
-    def __init__(self, compressed_file):
-        CompressedObject.__init__(self, compressed_file)
-
-    def file(self):
-        return self.get_uncompressed_file()
 
 def _binary_buffer_to_hex_string(binbuf):
     return "".join(map(lambda c: ("%0.2X" % c).lower(),map(ord,binbuf)))
@@ -90,8 +82,8 @@ def _combine_md5(lo, hi):
                   '\x00','\x00','\x00','\x00','\x00','\x00','\x00','\x00' ]
     for i in range(0, 8):
         md5digest[i] = chr(lo & 0xFF)
-        lo = lo >> 8
+        lo >>= 8
     for i in range(8,16):
         md5digest[i] = chr(hi & 0xFF)
-        hi = hi >> 8
+        hi >>= 8
     return ''.join(md5digest)

--- a/python/cvmfs/_common.py
+++ b/python/cvmfs/_common.py
@@ -6,11 +6,8 @@ This file is part of the CernVM File System auxiliary tools.
 """
 
 import ctypes
-import tempfile
-import zlib
 import sqlite3
 import subprocess
-import shutil
 import os
 
 
@@ -28,50 +25,6 @@ _REPLICATING_NAME      = ".cvmfs_is_snapshotting"
 class CvmfsNotInstalled(Exception):
     def __init__(self):
         Exception.__init__(self, "It seems that cvmfs is not installed on this machine!")
-
-
-class CompressedObject:
-    file_            = None
-    compressed_file_ = None
-
-    def __init__(self, compressed_file):
-        self.compressed_file_ = compressed_file
-        self._decompress()
-
-    def get_compressed_file(self):
-        return self.compressed_file_
-
-    def get_uncompressed_file(self):
-        return self.file_
-
-    def save_to(self, path):
-        shutil.copyfile(self.get_compressed_file().name, path)
-
-    def save_uncompressed_to(self, path):
-        shutil.copyfile(self.get_uncompressed_file().name, path)
-
-    def size_compressed(self):
-        """ Size of the compressed file in bytes """
-        return os.path.getsize(self.compressed_file_.name)
-
-    def size_uncompressed(self):
-        """Size of the uncompressed file in bytes """
-        return os.path.getsize(self.file_.name)
-
-    def _decompress(self):
-        """ Unzip a file to a temporary referenced by self.file_ """
-        self.file_ = tempfile.NamedTemporaryFile('w+b')
-        self.compressed_file_.seek(0)
-        self.file_.write(zlib.decompress(self.compressed_file_.read()))
-        self.file_.flush()
-        self.file_.seek(0)
-        self.compressed_file_.seek(0)
-
-    def _close(self):
-        if self.file_:
-            self.file_.close()
-        if self.compressed_file_:
-            self.compressed_file_.close()
 
 
 
@@ -92,6 +45,8 @@ class DatabaseObject:
         self.db_handle_ = sqlite3.connect(self.file_.name)
         self.db_handle_.text_factory = str
 
+    def db_size(self):
+        return os.path.getsize(self.file_.name)
 
     def read_properties_table(self, reader):
         """ Retrieve all properties stored in the 'properties' table """

--- a/python/cvmfs/availability.py
+++ b/python/cvmfs/availability.py
@@ -14,11 +14,13 @@ class WrongRepositoryType(Exception):
         self.expected_type = expected_type
 
     def __str__(self):
-        return self.repo.fqrn + " is of type '" + self.repo.type  + "' but '" + self.expected_type + "' was expected"
+        return self.repo.fqrn + " is of type '" + self.repo.type + "' but '" + \
+            self.expected_type + "' was expected"
 
 
 class AvailabilityAssessment:
-    def _check_repo_type(self, repo, expected_type):
+    @staticmethod
+    def _check_repo_type(repo, expected_type):
         if repo.has_repository_type() and repo.type != expected_type:
             raise WrongRepositoryType(repo, expected_type)
         return True;

--- a/python/cvmfs/catalog.py
+++ b/python/cvmfs/catalog.py
@@ -227,7 +227,7 @@ class Catalog(DatabaseObject):
 
     def list_directory_split_md5(self, parent_1, parent_2):
         """ Create a directory listing of DirectoryEntry items based on MD5 path """
-        res = self.run_sql("SELECT " + DirectoryEntry._catalog_db_fields() + " \
+        res = self.run_sql("SELECT " + DirectoryEntry.catalog_db_fields() + " \
                             FROM catalog                                       \
                             WHERE parent_1 = " + str(parent_1) + " AND         \
                                   parent_2 = " + str(parent_2) + "             \
@@ -250,7 +250,7 @@ class Catalog(DatabaseObject):
 
     def find_directory_entry_split_md5(self, md5path_1, md5path_2):
         """ Finds the DirectoryEntry for the given split MD5 hashed path """
-        res = self.run_sql("SELECT " + DirectoryEntry._catalog_db_fields() + " \
+        res = self.run_sql("SELECT " + DirectoryEntry.catalog_db_fields() + " \
                             FROM catalog                                       \
                             WHERE md5path_1 = " + str(md5path_1) + " AND       \
                                   md5path_2 = " + str(md5path_2) + "           \
@@ -305,7 +305,7 @@ class Catalog(DatabaseObject):
         """ Finds and adds the file chunk of a DirectoryEntry """
         if self.schema < 2.4:
             return
-        res = self.run_sql("SELECT " + Chunk._catalog_db_fields() + "           \
+        res = self.run_sql("SELECT " + Chunk.catalog_db_fields() + "            \
                             FROM chunks                                         \
                             WHERE md5path_1 = " + str(dirent.md5path_1) + " AND \
                                   md5path_2 = " + str(dirent.md5path_2) + "     \
@@ -325,7 +325,8 @@ class Catalog(DatabaseObject):
             self.last_modified = datetime.datetime.min
 
 
-    def _canonicalize_path(self, path):
+    @staticmethod
+    def _canonicalize_path(path):
         if not path:
             return ""
         return os.path.abspath(path)
@@ -334,12 +335,12 @@ class Catalog(DatabaseObject):
     def _check_validity(self):
         """ Check that all crucial properties have been found in the database """
         if not hasattr(self, 'revision'):
-          raise Exception("Catalog lacks a revision entry")
+            raise Exception("Catalog lacks a revision entry")
         if not hasattr(self, 'schema'):
-          raise Exception("Catalog lacks a schema entry")
+            raise Exception("Catalog lacks a schema entry")
         if not hasattr(self, 'root_prefix'):
-          raise Exception("Catalog lacks a root prefix entry")
+            raise Exception("Catalog lacks a root prefix entry")
         if not hasattr(self, 'last_modified'):
-          raise Exception("Catalog lacks a last modification entry")
+            raise Exception("Catalog lacks a last modification entry")
 
 

--- a/python/cvmfs/certificate.py
+++ b/python/cvmfs/certificate.py
@@ -25,12 +25,10 @@ class Certificate:
         """ return the certificate as M2Crypto.X509 object """
         return self.openssl_certificate
 
-
     def get_fingerprint(self, algorithm='sha1'):
         """ returns the fingerprint of the X509 certificate """
         fp = self.openssl_certificate.get_fingerprint(algorithm)
         return ':'.join([ x + y for x, y in zip(fp[0::2], fp[1::2]) ])
-
 
     def verify(self, signature, message):
         """ verify a given signature to an expected 'message' string """

--- a/python/cvmfs/certificate.py
+++ b/python/cvmfs/certificate.py
@@ -7,14 +7,12 @@ This file is part of the CernVM File System auxiliary tools.
 
 from M2Crypto import X509
 
-from _common import CompressedObject
-
-class Certificate(CompressedObject):
+class Certificate:
     """ Wraps an X.509 certificate object as stored in CVMFS repositories """
 
     def __init__(self, certificate_file):
-        CompressedObject.__init__(self, certificate_file)
-        cert = X509.load_cert_string(self.get_uncompressed_file().read())
+        self._certificate_file = certificate_file
+        cert = X509.load_cert_string(self._certificate_file.read())
         self.openssl_certificate = cert
 
     def __str__(self):

--- a/python/cvmfs/dirent.py
+++ b/python/cvmfs/dirent.py
@@ -92,8 +92,7 @@ class DirectoryEntry:
             raise Exception("Cannot retrieve symlink")
         elif self.is_directory():
             raise Exception("Cannot retrieve directory")
-        f = repository.retrieve_object(self.content_hash_string())
-        return f.file()
+        return repository.retrieve_object(self.content_hash_string())
 
     def is_directory(self):
         return (self.flags & _Flags.Directory) > 0

--- a/python/cvmfs/dirent.py
+++ b/python/cvmfs/dirent.py
@@ -57,7 +57,7 @@ class Chunk:
         return _binary_buffer_to_hex_string(self.content_hash) + suffix
 
     @staticmethod
-    def _catalog_db_fields():
+    def catalog_db_fields():
         return "md5path_1, md5path_2, offset, size, hash"
 
 
@@ -82,7 +82,7 @@ class DirectoryEntry:
                str(self.md5path_1) + "|" + str(self.md5path_2) + ">"
 
     @staticmethod
-    def _catalog_db_fields():
+    def catalog_db_fields():
         # see DirectoryEntry.__init__()
         return "md5path_1, md5path_2, parent_1, parent_2, hash, \
                 flags, size, mode, mtime, name, symlink"
@@ -130,11 +130,11 @@ class DirectoryEntry:
         bit_mask     = _Flags.ContentHashType
         right_shifts = 0
         while bit_mask & 1 == 0:
-            bit_mask = bit_mask >> 1
+            bit_mask >>= 1
             right_shifts += 1
         hash_type = ((self.flags & _Flags.ContentHashType) >> right_shifts) + 1
         self.content_hash_type = \
-            hash_type if hash_type > 0 and hash_type < ContentHashTypes.UpperBound \
+            hash_type if 0 < hash_type < ContentHashTypes.UpperBound \
                       else ContentHashTypes.Unknown
 
     # def BacktracePath(self, containing_catalog, repo):

--- a/python/cvmfs/dirent.py
+++ b/python/cvmfs/dirent.py
@@ -5,7 +5,7 @@ Created by René Meusel
 This file is part of the CernVM File System auxiliary tools.
 """
 
-from _common import _binary_buffer_to_hex_string, FileObject
+from _common import _binary_buffer_to_hex_string
 
 
 class _Flags:
@@ -92,7 +92,7 @@ class DirectoryEntry:
             raise Exception("Cannot retrieve symlink")
         elif self.is_directory():
             raise Exception("Cannot retrieve directory")
-        f = FileObject(repository.retrieve_object(self.content_hash_string()))
+        f = repository.retrieve_object(self.content_hash_string())
         return f.file()
 
     def is_directory(self):

--- a/python/cvmfs/history.py
+++ b/python/cvmfs/history.py
@@ -50,21 +50,17 @@ class History(DatabaseObject):
     def __repr__(self):
         return self.__str__()
 
-
     def __iter__(self):
         return self.list_tags().__iter__()
-
 
     def list_tags(self):
         results = self.run_sql(RevisionTag.sql_query())
         return [ RevisionTag(sql_res) for sql_res in results ]
 
-
     def _read_properties(self):
         self.read_properties_table(lambda prop_key, prop_value:
             self._read_property(prop_key, prop_value))
         assert hasattr(self, 'schema') and self.schema == '1.0'
-
 
     def _read_property(self, prop_key, prop_value):
         if prop_key == "schema":

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -164,7 +164,7 @@ class CatalogTreeIterator:
             self.catalog_reference = None
 
         def get_catalog(self):
-            if self.catalog == None:
+            if self.catalog is None:
                 self.catalog = self.catalog_reference.retrieve_from(self.repository)
             return self.catalog
 

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -487,15 +487,10 @@ class Repository:
         return Certificate(certificate)
 
 
-    def retrieve_file(self, file_name):
-        """ Method to retrieve a file from the repository """
-        return self._fetcher.retrieve_file(file_name)
-
-
     def retrieve_object(self, object_hash, hash_suffix = ''):
         """ Retrieves an object from the content addressable storage """
         path = "data/" + object_hash[:2] + "/" + object_hash[2:] + hash_suffix
-        return self.retrieve_file(path)
+        return self._fetcher.retrieve_file(path)
 
 
     def retrieve_root_catalog(self):
@@ -505,10 +500,9 @@ class Repository:
     def retrieve_catalog_for_path(self, needle_path):
         """ Recursively walk down the Catalogs and find the best fit for a path """
         clg = self.retrieve_root_catalog()
-        nested_reference = None
         while True:
             new_nested_reference = clg.FindNestedForPath(needle_path)
-            if new_nested_reference == None:
+            if new_nested_reference is None:
                 break
             nested_reference = new_nested_reference
             clg = self.retrieve_catalog(nested_reference.hash)

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -269,16 +269,6 @@ class Fetcher:
 
 
     @staticmethod
-    def _decompress_file(compressed_file):
-        """ Decompresses a file in a temporary directory """
-        decompressed_data = zlib.decompress(compressed_file.read())
-        temp_file_path = tempfile.mktemp(dir='/tmp')
-        temp_file = open(temp_file_path, 'w+')
-        Fetcher._write_content_into_file(decompressed_data, temp_file)
-        return temp_file
-
-
-    @staticmethod
     def _write_content_into_file(content, opened_file):
         """ Writes content into the opened file. The file must have
          write permission
@@ -289,7 +279,9 @@ class Fetcher:
 
 
     def retrieve_file(self, file_name):
-        """ Method to retrieve a file from the repository """
+        """ Method to retrieve a file from the cache if exists, or from
+        the repository if it doesn't
+        """
         cached_file = self.cache.get(file_name)
         if not cached_file:
             return self._retrieve_file(file_name)

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -475,7 +475,7 @@ class Repository:
 
 
     def retrieve_whitelist(self):
-        whitelist = self._fetcher.retrieve_file(_common._WHITELIST_NAME)
+        whitelist = self._fetcher.retrieve_raw_file(_common._WHITELIST_NAME)
         return Whitelist(whitelist)
 
 
@@ -537,3 +537,8 @@ def all_local():
 def all_local_stratum0():
     return [ repo for repo in all_local() if repo.type == 'stratum0' ]
 
+def open_repository(repository_path, public_key = None):
+    repo = Repository(repository_path)
+    if public_key and not repo.verify(public_key):
+        return None
+    return repo

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -364,14 +364,14 @@ class RemoteFetcher(Fetcher):
     def _retrieve_file(self, file_name):
         file_url = self._make_file_uri(file_name)
         cached_file = self.cache.add(file_name)
-        RemoteFetcher._download_content_and_decompress(cached_file, file_url)
+        self._download_content_and_decompress(cached_file, file_url)
         return self.cache.get(file_name)
 
 
     def retrieve_raw_file(self, file_name):
         cached_file = self.cache.add(file_name)
         file_url = self._make_file_uri(file_name)
-        RemoteFetcher._download_content_and_store(cached_file, file_url)
+        self._download_content_and_store(cached_file, file_url)
         return self.cache.get(file_name)
 
 
@@ -423,7 +423,7 @@ class Repository:
         try:
             with self._fetcher.retrieve_raw_file(_common._LAST_REPLICATION_NAME) as rf:
                 timestamp = rf.readline()
-                self.last_replication = Repository.__read_timestamp(timestamp)
+                self.last_replication = self.__read_timestamp(timestamp)
             if not self.has_repository_type():
                 self.type = 'stratum1'
         except FileNotFoundInRepository, e:
@@ -436,7 +436,7 @@ class Repository:
             with self._fetcher.retrieve_raw_file(_common._REPLICATING_NAME) as rf:
                 timestamp = rf.readline()
                 self.replicating = True
-                self.replicating_since = Repository.__read_timestamp(timestamp)
+                self.replicating_since = self.__read_timestamp(timestamp)
         except FileNotFoundInRepository, e:
             pass
 
@@ -475,7 +475,7 @@ class Repository:
 
 
     def retrieve_whitelist(self):
-        whitelist = self.retrieve_file(_common._WHITELIST_NAME)
+        whitelist = self._fetcher.retrieve_file(_common._WHITELIST_NAME)
         return Whitelist(whitelist)
 
 

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -196,26 +196,27 @@ class CatalogTreeIterator(object):
         return wrapper.get_catalog()
 
 
-class Resource(file):
-    """ Wrapper around a writable file. The actual file will be renamed
-    to a different location once it is closed
-    """
-
-    def __init__(self, name, tmp_dir):
-        self.__final_destination_path = name
-        temp_file_path = tempfile.mktemp(dir=tmp_dir, prefix='tmp.')
-        super(Resource, self).__init__(temp_file_path, 'w+')
-
-    def __del__(self):
-        if not self.closed:
-            self.close()
-
-    def close(self):
-        super(Resource, self).close()
-        os.rename(self.name, self.__final_destination_path)
-
 
 class Cache(object):
+
+    class TransactionFile(file):
+        """ Wrapper around a writable file. The actual file will be renamed
+        to a different location once it is closed
+        """
+
+        def __init__(self, name, tmp_dir):
+            self.__final_destination_path = name
+            temp_file_path = tempfile.mktemp(dir=tmp_dir, prefix='tmp.')
+            super(Cache.TransactionFile, self).__init__(temp_file_path, 'w+')
+
+        def __del__(self):
+            if not self.closed:
+                self.close()
+
+        def close(self):
+            super(Cache.TransactionFile, self).close()
+            os.rename(self.name, self.__final_destination_path)
+
     def __init__(self, cache_dir):
         if not os.path.exists(cache_dir):
             cache_dir = tempfile.mkdtemp(dir='/tmp', prefix='cache.')
@@ -257,7 +258,7 @@ class Cache(object):
     def transaction(self, file_name):
         full_path = os.path.join(self._cache_dir, file_name)
         tmp_dir = self.get_transaction_dir()
-        return Resource(full_path, tmp_dir)
+        return Cache.TransactionFile(full_path, tmp_dir)
 
     @staticmethod
     def commit(resource):

--- a/python/cvmfs/repository.py
+++ b/python/cvmfs/repository.py
@@ -558,15 +558,13 @@ def all_local():
     d = _common._REPO_CONFIG_PATH
     if not os.path.isdir(d):
         raise _common.CvmfsNotInstalled
-    return [ Repository(cache_dir=repo) for repo in os.listdir(d) if os.path.isdir(os.path.join(d, repo)) ]
+    return [ Repository(repo) for repo in os.listdir(d) if os.path.isdir(os.path.join(d, repo)) ]
 
 def all_local_stratum0():
     return [ repo for repo in all_local() if repo.type == 'stratum0' ]
 
 def open_repository(repository_path, public_key = None):
-    repo = Repository(repo_url=repository_path)              \
-                if repository_path.startswith("http://")  \
-                else Repository(cache_dir=repository_path)
+    repo = Repository(repository_path)
     if public_key and not repo.verify(public_key):
         return None
     return repo

--- a/python/cvmfs/root_file.py
+++ b/python/cvmfs/root_file.py
@@ -62,7 +62,7 @@ class RootFile:
         self._check_validity()
 
     @abc.abstractmethod
-    def _verify_signature(public_entity):
+    def _verify_signature(self, public_entity):
         pass
 
 
@@ -70,7 +70,8 @@ class RootFile:
         return self.has_signature and self._verify_signature(public_entity)
 
 
-    def _hash_over_content(self, file_object):
+    @staticmethod
+    def _hash_over_content(file_object):
         pos = file_object.tell()
         hash_sum = hashlib.sha1()
         while True:

--- a/python/cvmfs/test/certificate_test.py
+++ b/python/cvmfs/test/certificate_test.py
@@ -7,6 +7,7 @@ This file is part of the CernVM File System auxiliary tools.
 
 import base64
 import unittest
+import zlib
 
 from M2Crypto.X509 import X509
 
@@ -35,7 +36,7 @@ class TestCertificate(unittest.TestCase):
             ''
         ])
         compressed_cert = base64.b64decode(self.compressed_certificate)
-        self.certificate_file = self.sandbox.write_to_temporary(compressed_cert)
+        self.certificate_file = self.sandbox.write_to_temporary(zlib.decompress(compressed_cert))
         self.fingerprint = "81:8D:BE:49:A7:3E:F1:C4:DA:01:50:F0:80:D4:CB:27:96:80:1D"
 
         self.message_digest = "e380c3276b33440dd3e80af116fd6ee307b8ca6a"
@@ -44,7 +45,7 @@ class TestCertificate(unittest.TestCase):
 
     def test_load(self):
         with open(self.certificate_file) as cert_file:
-            cert = cvmfs.Certificate(cert_file)
+            cvmfs.Certificate(cert_file)
 
 
     def test_get_openssl_x509(self):

--- a/python/cvmfs/test/manifest_test.py
+++ b/python/cvmfs/test/manifest_test.py
@@ -9,6 +9,7 @@ import base64
 import datetime
 import StringIO
 import unittest
+import zlib
 
 from dateutil.tz import tzutc
 
@@ -39,7 +40,7 @@ class TestManifest(unittest.TestCase):
             ''
         ])
         compressed_cert = base64.b64decode(self.compressed_certificate)
-        self.certificate_file = self.sandbox.write_to_temporary(compressed_cert)
+        self.certificate_file = self.sandbox.write_to_temporary(zlib.decompress(compressed_cert))
 
         self.sane_manifest = StringIO.StringIO('\n'.join([
             'C044206fcff4545283aaa452b80edfd5d8c740b20',

--- a/python/cvmfs/test/mock_repository.py
+++ b/python/cvmfs/test/mock_repository.py
@@ -12,7 +12,6 @@ import os
 import StringIO
 import tarfile
 import threading
-import unittest
 
 from M2Crypto import RSA
 
@@ -31,7 +30,7 @@ class CvmfsRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     def translate_path(self, path):
         return os.path.normpath(self.server.document_root + os.sep + path)
 
-    def log_message(self, format, *args):
+    def log_message(self, msg_format, *args):
         pass
 
 

--- a/python/cvmfs/test/repository_test.py
+++ b/python/cvmfs/test/repository_test.py
@@ -39,13 +39,13 @@ class TestRepositoryWrapper(unittest.TestCase):
     def test_open_repository_http(self):
         self.mock_repo.serve_via_http()
         repo = cvmfs.open_repository(self.mock_repo.url)
-        self.assertTrue(isinstance(repo, cvmfs.RemoteRepository))
+        self.assertTrue(isinstance(repo, cvmfs.Repository))
         self.assertEqual(self.mock_repo.repo_name, repo.manifest.repository_name)
 
 
     def test_open_repository_local(self):
         repo = cvmfs.open_repository(self.mock_repo.dir)
-        self.assertTrue(isinstance(repo, cvmfs.LocalRepository))
+        self.assertTrue(isinstance(repo, cvmfs.Repository))
         self.assertEqual(self.mock_repo.repo_name, repo.manifest.repository_name)
 
 
@@ -54,23 +54,23 @@ class TestRepositoryWrapper(unittest.TestCase):
         self.mock_repo.serve_via_http()
         repo1 = cvmfs.open_repository(self.mock_repo.url,
                                       self.mock_repo.public_key)
-        self.assertTrue(isinstance(repo1, cvmfs.RemoteRepository))
+        self.assertTrue(isinstance(repo1, cvmfs.Repository))
         self.assertTrue(repo1.verify(self.mock_repo.public_key))
         self.assertEqual(self.mock_repo.repo_name, repo1.manifest.repository_name)
 
         repo2 = cvmfs.open_repository(self.mock_repo.dir,
                                       self.mock_repo.public_key)
-        self.assertTrue(isinstance(repo2, cvmfs.LocalRepository))
+        self.assertTrue(isinstance(repo2, cvmfs.Repository))
         self.assertTrue(repo2.verify(self.mock_repo.public_key))
         self.assertEqual(self.mock_repo.repo_name, repo2.manifest.repository_name)
 
         repo3 = cvmfs.open_repository(self.mock_repo.url)
-        self.assertTrue(isinstance(repo3, cvmfs.RemoteRepository))
+        self.assertTrue(isinstance(repo3, cvmfs.Repository))
         self.assertTrue(repo3.verify(self.mock_repo.public_key))
         self.assertEqual(self.mock_repo.repo_name, repo3.manifest.repository_name)
 
         repo4 = cvmfs.open_repository(self.mock_repo.dir)
-        self.assertTrue(isinstance(repo4, cvmfs.LocalRepository))
+        self.assertTrue(isinstance(repo4, cvmfs.Repository))
         self.assertTrue(repo4.verify(self.mock_repo.public_key))
         self.assertEqual(self.mock_repo.repo_name, repo4.manifest.repository_name)
 

--- a/python/cvmfs/test/whitelist_test.py
+++ b/python/cvmfs/test/whitelist_test.py
@@ -9,6 +9,7 @@ import base64
 import datetime
 import StringIO
 import unittest
+import zlib
 
 from dateutil.tz import tzutc
 
@@ -53,7 +54,7 @@ class TestWhitelist(unittest.TestCase):
             ''
         ])
         compressed_cert = base64.b64decode(self.compressed_certificate)
-        self.certificate_file = self.sandbox.write_to_temporary(compressed_cert)
+        self.certificate_file = self.sandbox.write_to_temporary(zlib.decompress(compressed_cert))
 
         self.sane_whitelist = StringIO.StringIO('\n'.join([
             '20150603095527',

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,7 @@ setup(
   test_suite='cvmfs.test',
   install_requires=[ # don't forget to adapt the matching RPM dependencies!
     'python-dateutil >= 1.4.1',
-    'requests >= 1.1.0'
+    'requests >= 1.1.0',
+    'M2Crypto >= 0.20.0'
   ]
 )


### PR DESCRIPTION
This pull request changes the Repository class in the python API. Before it was necessary to instantiate a sub-class of Repository, i.e., RemoteRepository or LocalRepository. The first one always downloaded everything and didn't use any permanent cache, while the second one only could work in local.

In this context, I thought it was better to have just a Repository class so that the user can specify the cache directory and the remote directory. This way he can abstract from the use of full-cached, full-remote and the combination of these two, which is the way the client actually works.

Catalog class has been modified in consequence since it doesn't require a compressed file to be initialised, but an already decompressed one.

Updated example usage:
```
import cvmfs

   repo = cvmfs.Repository('http://cvmfs-stratum-one.cern.ch/opt/boss', cache_dir='/home/user/cvmfs_cache')
   print 'Last Revision:' , repo.manifest.revision , repo.manifest.last_modified
   root_catalog = repo.retrieve_root_catalog()
   print 'Catalog Schema:' , root_catalog.schema
   for nested_catalog_ref in root_catalog.list_nested():
       print 'Nested Catalog at:' , nested_catalog_ref.root_path
   print 'Listing repository'
   for full_path, dirent in repo:
       print full_path
```