### PR TITLE
Feature: Vagrant-managed Development Environment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test/cloud_testing/ec2_config.sh
 python/dist/*
 python/python_cvmfsutils.egg-info/*
 python/MANIFEST
+.vagrant/
 
 # Eclipse-related files
 .project

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  config.vm.box = "cernvm"
+  # config.vm.box_url = ... TODO(reneme): maybe add later for convenience
+
+  config.vm.boot_timeout = 1200 # CernVM might load stuff over a slow network
+                                # and need a lot of time on first boot up
+
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # config.vm.synced_folder '.', '/vagrant', nfs: true   TODO(reneme): quicker!
+
+  config.vm.provision "shell", path: "vagrant/provision_cernvm.sh"
+
+  # allow virtual box to take advantage of the host's speed
+  # Snippet found here (thanks to Stefan Wrobel): 
+  # https://stefanwrobel.com/how-to-make-vagrant-performance-not-suck
+  config.vm.provider "virtualbox" do |v|
+    host = RbConfig::CONFIG['host_os']
+
+    # Give VM 1/4 system memory & access to all cpu cores on the host
+    if host =~ /darwin/
+      cpus = `sysctl -n hw.ncpu`.to_i
+      # sysctl returns Bytes and we need to convert to MB
+      mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
+    elsif host =~ /linux/
+      cpus = `nproc`.to_i
+      # meminfo shows KB and we need to convert to MB
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
+    else # sorry Windows folks, I can't help you
+      cpus = 2
+      mem = 1024
+    end
+
+    v.customize ["modifyvm", :id, "--memory", mem]
+    v.customize ["modifyvm", :id, "--cpus", cpus]
+  end
+end

--- a/vagrant/provision_cernvm.sh
+++ b/vagrant/provision_cernvm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# link the cvmfs source tree conveniently into the home directory
+[ -L cvmfs ] || ln -s /vagrant cvmfs
+
+# link /var/spool/cvmfs into the bare r/w mount of CernVM
+CVMFS_SPOOL_DIR=/var/spool/cvmfs
+CVMFS_SPOOL_IMPOSTER=/mnt/.rw/cvmfs_server
+mkdir -p $CVMFS_SPOOL_IMPOSTER
+[ ! -d $CVMFS_SPOOL_DIR ] || rm -fR $CVMFS_SPOOL_DIR
+[ -L $CVMFS_SPOOL_DIR   ] || ln -s $CVMFS_SPOOL_IMPOSTER $CVMFS_SPOOL_DIR


### PR DESCRIPTION
This adds the possibility to bootstrap a Vagrant-managed build environment based on CernVM. What needs to be done, to make it work is as easy as that:

```bash
vagrant box add cernvm http://cernvm.cern.ch/releases/testing/ucernvm-prod.2.2-1.cernvm.x86_64.box
vagrant up
vagrant ssh
```