### PR TITLE
FIX: Local Backend Overwrites Unchanged Files

### DIFF
--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -196,7 +196,7 @@ bool CommandTag::CloseAndPublishHistory(Environment *env) {
 
   // compress and upload the new history database
   Future<shash::Any> history_hash;
-  upload::Spooler::CallbackTN* callback =
+  upload::Spooler::CallbackPtr callback =
     env->spooler->RegisterListener(&CommandTag::UploadClosure,
                                     this,
                                    &history_hash);
@@ -246,7 +246,7 @@ bool CommandTag::UploadCatalogAndUpdateManifest(
 
   // upload the catalog
   Future<shash::Any> catalog_hash;
-  upload::Spooler::CallbackTN* callback =
+  upload::Spooler::CallbackPtr callback =
     env->spooler->RegisterListener(&CommandTag::UploadClosure,
                                     this,
                                    &catalog_hash);

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -235,3 +235,15 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   return 1;
 }
 
+
+void swissknife::CommandSign::CertificateUploadCallback(
+                                          const upload::SpoolerResult &result) {
+  shash::Any certificate_hash;
+  if (result.return_code == 0) {
+    certificate_hash = result.content_hash;
+  } else {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to upload certificate (retcod: %d)",
+             result.return_code);
+  }
+  certificate_hash_.Set(certificate_hash);
+}

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -145,6 +145,11 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
     const shash::Any certificate_hash = certificate_hash_.Get();
     spooler->UnregisterListener(callback);
 
+    if (certificate_hash.IsNull()) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to upload certificate");
+      goto sign_fail;
+    }
+
     // Update manifest
     manifest->set_certificate(certificate_hash);
     manifest->set_repository_name(repo_name);

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -7,7 +7,13 @@
 
 #include <string>
 
+#include "hash.h"
+#include "util_concurrency.h"
 #include "swissknife.h"
+
+namespace upload {
+  struct SpoolerResult;
+}
 
 namespace swissknife {
 
@@ -30,6 +36,12 @@ class CommandSign : public Command {
     return r;
   }
   int Main(const ArgumentList &args);
+
+ protected:
+  void CertificateUploadCallback(const upload::SpoolerResult &result);
+
+ private:
+  Future<shash::Any> certificate_hash_;
 };
 
 }  // namespace swissknife

--- a/cvmfs/upload.cc
+++ b/cvmfs/upload.cc
@@ -64,6 +64,10 @@ void Spooler::ProcessHistory(const std::string &local_path) {
   file_processor_->Process(local_path, false, shash::kSuffixHistory);
 }
 
+void Spooler::ProcessCertificate(const std::string &local_path) {
+  file_processor_->Process(local_path, false, shash::kSuffixCertificate);
+}
+
 
 void Spooler::Upload(const std::string &local_path,
                      const std::string &remote_path) {

--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -176,6 +176,16 @@ class Spooler : public Observable<SpoolerResult> {
    */
   void ProcessHistory(const std::string &local_path);
 
+
+  /**
+   * Convenience wrapper to process a certificate file. This sets the
+   * processing parameters (like chunking and hash suffixes) accordingly.
+   *
+   * @param local_path  the location of the certificate file
+   */
+  void ProcessCertificate(const std::string &local_path);
+
+
   /**
    * Deletes the given file from the repository backend storage. This is done
    * synchronous, in any case.

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -193,17 +193,26 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
   }
 
   const std::string final_path = "data/" + content_hash.MakePath();
-  retval = Move(local_handle->temporary_path.c_str(), final_path.c_str());
-  if (retval != 0) {
-    const int cpy_errno = errno;
-    LogCvmfs(kLogSpooler, kLogVerboseMsg, "failed to move temp file '%s' to "
-                                          "final location '%s' (errno: %d)",
-             local_handle->temporary_path.c_str(),
-             final_path.c_str(),
-             cpy_errno);
-    atomic_inc32(&copy_errors_);
-    Respond(handle->commit_callback, UploaderResults(cpy_errno));
-    return;
+  if (! Peek(final_path)) {
+    retval = Move(local_handle->temporary_path, final_path);
+    if (retval != 0) {
+      const int cpy_errno = errno;
+      LogCvmfs(kLogSpooler, kLogVerboseMsg, "failed to move temp file '%s' to "
+                                            "final location '%s' (errno: %d)",
+               local_handle->temporary_path.c_str(),
+               final_path.c_str(),
+               cpy_errno);
+      atomic_inc32(&copy_errors_);
+      Respond(handle->commit_callback, UploaderResults(cpy_errno));
+      return;
+    }
+  } else {
+    const int retval = unlink(local_handle->temporary_path.c_str());
+    if (retval != 0) {
+      LogCvmfs(kLogSpooler, kLogVerboseMsg, "failed to remove temporary '%s' "
+                                            "(errno: %d)",
+               local_handle->temporary_path.c_str(), errno);
+    }
   }
 
   const CallbackTN *callback = handle->commit_callback;

--- a/cvmfs/util_concurrency.h
+++ b/cvmfs/util_concurrency.h
@@ -310,8 +310,9 @@ class Observable;
 template <typename ParamT>
 class Observable : public Callbackable<ParamT>,
                    SingleCopy {
- protected:
+ public:
   typedef typename Callbackable<ParamT>::CallbackTN*  CallbackPtr;
+ protected:
   typedef std::set<CallbackPtr>                       Callbacks;
 
  public:

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -115,6 +115,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/583-httpredirects                        \
                                src/585-xattrs                               \
                                src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
                                --                                           \
                                src/5* || retval=1
 

--- a/test/src/594-backendoverwrite/main
+++ b/test/src/594-backendoverwrite/main
@@ -1,0 +1,175 @@
+
+cvmfs_test_name="Backend File Overwrite Behaviour"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in() {
+  local working_dir=$1
+
+  currd="$(pwd)"
+
+  pushdir $working_dir
+
+  echo "meaningless file content" > file1
+  echo "more clever file content" > file2
+
+  cp ${currd}/big big
+
+  popdir
+}
+
+change_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  # change the big file slightly close to the end
+  # Note: replaces four bytes in the last 1MiB block of the file
+  local fiddle_string="MOEP"
+  local last_block=$(( 1024 * 1024 - $(echo -n "$fiddle_string" | wc -c) ))
+
+  dd if=big of=big_changed bs=1024k count=49
+  echo -n "$fiddle_string" >> big_changed
+  tail -c $last_block big  >> big_changed
+
+  # touch one of the small files and edit the other one
+  touch file1
+  echo "way more stuff in this file" >> file2
+
+  popdir
+}
+
+
+get_last_modified_timestamps_in_backend() {
+  for f in $(find /srv/cvmfs/$CVMFS_TEST_REPO/data/ | \
+      grep -E "^/srv/cvmfs/$CVMFS_TEST_REPO/data/[a-z0-9]+/[a-z0-9]+.$"); do
+    echo "$f $(stat -c %Y $f)"
+  done
+}
+
+compare_file_modification_times() {
+  local before=$1
+  local after=$2
+
+  local old_ifs=$IFS
+  IFS='
+'
+
+  local touches=0
+  local adds=0
+
+  # O(n^2) takes forever... but hey... :-)
+  for l1 in $(cat $after); do
+    local file=$(echo "$l1" | awk '{print $1}')
+    local mtime=$(echo "$l1" | awk '{print $2}')
+    local found=0
+
+    for l2 in $(cat $before); do
+      local file2=$(echo "$l2" | awk '{print $1}')
+      local mtime2=$(echo "$l2" | awk '{print $2}')
+
+      if [ x"$file" = x"$file2" ]; then
+        found=1
+        if [ x"$mtime" != x"$mtime2" ]; then
+          echo "TOUCH $file" >&2
+          touches=$(( $touches + 1 ))
+        fi
+      fi
+    done
+
+    if [ $found -eq 0 ]; then
+      echo "ADDED $file" >&2
+      adds=$(( $adds + 1 ))
+    fi
+  done
+
+  IFS=$old_ifs
+  echo "$touches $adds"
+}
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "create a random big file"
+  dd if=/dev/urandom of=big bs=1024k count=50
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in $repo_dir || return 3
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  produce_files_in $reference_dir || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir|| return $?
+
+  echo "take note of last file changes in the backend"
+  local mtime_log_1="mtime_1.log"
+  get_last_modified_timestamps_in_backend > $mtime_log_1
+
+  # ============================================================================
+
+  echo "wait a moment to avoid race conditions"
+  sleep 2
+
+  # ============================================================================
+
+  echo "init a new transaction to change something in repository $CVMFS_TEST_REPO"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "change stuff in the repository"
+  change_files_in $repo_dir || return 7
+
+  echo "change exactly the same stuff in the scratch space"
+  change_files_in $reference_dir || return 8
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the changed directories"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "take note of last file changes in the backend"
+  local mtime_log_2="mtime_2.log"
+  get_last_modified_timestamps_in_backend > $mtime_log_2
+
+  # ============================================================================
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # ============================================================================
+
+  echo "check that legacy files haven't been modified by the second publish"
+  local comparison_log="comparison.log"
+  local summary=$(compare_file_modification_times $mtime_log_1 $mtime_log_2 2>$comparison_log)
+  local touches=$(echo $summary | awk '{print $1}')
+  local adds=$(echo $summary | awk '{print $2}')
+
+  echo "Summary:"
+  echo "Touches:   $touches"
+  echo "Additions: $adds"
+
+  if [ $touches -gt 0 ]; then
+    echo "found touched files in the backend, printing log:"
+    cat $comparison_log
+    return 9
+  fi
+
+  return 0
+}

--- a/test/src/594-backendoverwrite/main
+++ b/test/src/594-backendoverwrite/main
@@ -171,5 +171,10 @@ cvmfs_run_test() {
     return 9
   fi
 
+  # ============================================================================
+
+  echo "check that the transaction directory is empty"
+  [ $(ls /srv/cvmfs/${CVMFS_TEST_REPO}/data/txn | wc -l) -eq 0 ] || return 10
+
   return 0
 }


### PR DESCRIPTION
When `touch`-ing a file in a repository the following publish will need to process this file (since it must figure out if the file was only `touch`'ed or actually modified). Processing an unchanged file will result in a content hash that is already present in the repository's backend storage. The local backend implementation didn't check for existing files and did an overwrite in such a case.

Technically this is not a problem, but it requires some extra IOPs and changes the 'last modified' timestamp of those files, which might have an influence on backup performance. See [CVM-894](https://sft.its.cern.ch/jira/browse/CVM-894) for details.

This adds a check for existence before overwriting those files. Furthermore it adds an integration test verifying that no overwrites happen anymore. Note that `swissknife sign` needed a small refactoring to make it happen because it was manually dealing with the uploading. Now there is a `Spooler::ProcessCertificate()` that automatically does the right things and refrains from overwriting already existent certificate files in the backend.