### PR TITLE
FIX: Segfault on Malformed Spooler d'tor

### DIFF
--- a/cvmfs/upload.cc
+++ b/cvmfs/upload.cc
@@ -27,7 +27,9 @@ Spooler::Spooler(const SpoolerDefinition &spooler_definition) :
 
 
 Spooler::~Spooler() {
-  uploader_->TearDown();
+  if (uploader_) {
+    uploader_->TearDown();
+  }
 }
 
 


### PR DESCRIPTION
When a `Spooler` was not properly initialised (for example because of a malformed spooler definition string) it segfaulted due to a missing NULL-check of the `AbstractUploader` member in the `Spooler`'s destructor. [CVM-891](https://sft.its.cern.ch/jira/browse/CVM-891)