### PR TITLE
FIX: Debian Dependencies of Server and Unittests

### DIFF
--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -28,7 +28,7 @@ Description: CernVM File System Server
 Package: cvmfs-unittests
 Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: libssl-dev, uuid-dev, cvmfs (= ${source:Version}), cvmfs-server (= ${source:Version})
+Depends: libssl-dev, uuid-dev, cvmfs-server (= ${source:Version})
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System Unit Tests

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -18,7 +18,7 @@ Description: CernVM File System
 Package: cvmfs-server
 Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: cvmfs (= ${source:Version}), insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2
+Depends: insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2
 Conflicts: cvmfs-server (< 2.1)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch


### PR DESCRIPTION
On Debian both packages `cvmfs-server` and `cvmfs-unittests` were depending on `cvmfs` which makes problems when running cloud tests against an older client. I've removed those dependencies to harmonise the packages with RPM.