### PR TITLE
FIX: Detect Stale Snapshotting Locks

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1041,33 +1041,6 @@ publish_succeeded() {
   release_lock $pub_lock
 }
 
-acquire_snapshot_lock() {
-  local name=$1
-  load_repo_config $name
-  local snapshot_lock="${CVMFS_SPOOL_DIR}/is_snapshotting"
-  mkdir $snapshot_lock > /dev/null 2>&1 || return 1
-}
-
-wait_and_acquire_snapshot_lock() {
-  local name=$1
-  while ! acquire_snapshot_lock $name; do
-    sleep 10
-  done
-}
-
-release_snapshot_lock() {
-  local name=$1
-  load_repo_config $name
-  local snapshot_lock="${CVMFS_SPOOL_DIR}/is_snapshotting"
-  rmdir $snapshot_lock > /dev/null 2>&1
-}
-
-is_snapshotting() {
-  local name=$1
-  load_repo_config $name
-  [ -d ${CVMFS_SPOOL_DIR}/is_snapshotting ]
-}
-
 
 # checks if a user exists in the system
 #
@@ -4326,8 +4299,8 @@ __snapshot_cleanup() {
 
   $user_shell "$(__swissknife_cmd) remove     \
                  -r ${CVMFS_UPSTREAM_STORAGE} \
-                 -o .cvmfs_is_snapshotting" || echo "Warning: failed to remove .cvmfs_is_snapshotting"
-  release_snapshot_lock $alias_name         || echo "Warning: failed to release snapshotting lock"
+                 -o .cvmfs_is_snapshotting"       || echo "Warning: failed to remove .cvmfs_is_snapshotting"
+  release_lock ${CVMFS_SPOOL_DIR}/is_snapshotting || echo "Warning: failed to release snapshotting lock"
 }
 
 snapshot() {
@@ -4381,6 +4354,7 @@ snapshot() {
     public_key=$CVMFS_PUBLIC_KEY
     timeout=$CVMFS_HTTP_TIMEOUT
     retries=$CVMFS_HTTP_RETRIES
+    snapshot_lock=${spool_dir}/is_snapshotting
 
     # more sanity checks
     is_owner_or_root $alias_name || { echo "Permission denied: Repository $alias_name is owned by $user"; retcode=1; continue; }
@@ -4405,7 +4379,7 @@ snapshot() {
     fi
 
     # check for other snapshots in progress
-    if ! acquire_snapshot_lock $alias_name; then
+    if ! acquire_lock $snapshot_lock; then
       if [ $abort_on_conflict -eq 1 ]; then
         echo "another snapshot is in progress... aborting"
         retcode=1
@@ -4419,7 +4393,7 @@ snapshot() {
       fi
 
       echo "waiting for another snapshot to finish..."
-      if ! wait_and_acquire_snapshot_lock $alias_name; then
+      if ! wait_and_acquire_lock $snapshot_lock; then
         echo "failed to acquire snapshot lock"
         retcode=1
         continue

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -886,6 +886,72 @@ get_auto_garbage_collection_timespan() {
   fi
 }
 
+
+# Helper functions for file locking including detection of stale locks
+# Note: The implementation idea was found here:
+#       http://rute.2038bug.com/node23.html.gz
+__is_valid_lock() {
+  local path="$1"
+  local ignore_stale="$2"
+
+  local lock_file="${path}.lock"
+  [ -f $lock_file ]      || return 1 # lock doesn't exist
+  [ -z "$ignore_stale" ] || return 0 # lock is there (skip the stale test)
+
+  local stale_pid=$(cat $lock_file 2>/dev/null)
+  [ $stale_pid -gt 0 ]     && \
+  kill -0 $stale_pid 2>/dev/null
+}
+
+acquire_lock() { # hardlink creation is guaranteed to be atomic!
+  local path="$1"
+  local ignore_stale="$2"
+
+  local pid="$$"
+  local temp_file="${path}.${pid}"
+  local lock_file="${path}.lock"
+  echo $pid > $temp_file || return 1 # probably no access to $path
+
+  if ln $temp_file $lock_file 2>/dev/null; then
+    rm -f $temp_file 2>/dev/null
+    return 0 # lock acquired
+  fi
+
+  if __is_valid_lock "$path" "$ignore_stale"; then
+    rm -f $temp_file 2>/dev/null
+    return 1 # lock couldn't be acquired and appears valid
+  fi
+
+  rm -f $lock_file 2>/dev/null # lock was stale and can be removed
+  if ln $temp_file $lock_file; then
+    rm -f $temp_file 2>/dev/null
+    return 0 # lock acquired
+  fi
+
+  rm -f $temp_file 2>/dev/null
+  return 1 # lock couldn't be acquired after removing stale lock (lost the race)
+}
+
+wait_and_acquire_lock() {
+  local path="$1"
+  while ! acquire_lock "$path"; do
+    sleep 5
+  done
+}
+
+release_lock() {
+  local path="$1"
+  local lock_file="${path}.lock"
+  rm -f $lock_file 2>/dev/null
+}
+
+check_lock() {
+  local path="$1"
+  local ignore_stale="$2"
+  __is_valid_lock "${path}" "$ignore_stale"
+}
+
+
 # checks if a repository is currently in a transaction
 #
 # @param name  the repository name to be checked

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -959,7 +959,7 @@ check_lock() {
 is_in_transaction() {
   local name=$1
   load_repo_config $name
-  [ -d ${CVMFS_SPOOL_DIR}/in_transaction ]
+  check_lock ${CVMFS_SPOOL_DIR}/in_transaction ignore_stale
 }
 
 open_transaction() {
@@ -967,9 +967,9 @@ open_transaction() {
   load_repo_config $name
   local tx_lock="${CVMFS_SPOOL_DIR}/in_transaction"
 
-  is_stratum0 $name                 || die "Cannot open transaction on Stratum1"
-  mkdir "$tx_lock" > /dev/null 2>&1 || die "Failed to create transaction lock"
-  cvmfs_suid_helper open  $name     || die "Failed to make /cvmfs/$name writable"
+  is_stratum0 $name                    || die "Cannot open transaction on Stratum1"
+  acquire_lock "$tx_lock" ignore_stale || die "Failed to create transaction lock"
+  cvmfs_suid_helper open  $name        || die "Failed to make /cvmfs/$name writable"
 }
 
 # closes a previously opened transaction
@@ -1002,7 +1002,7 @@ close_transaction() {
   [ ! -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
   cvmfs_suid_helper rdonly_mount $name > /dev/null
   cvmfs_suid_helper rw_mount $name
-  rmdir "$tx_lock"
+  release_lock "$tx_lock"
 }
 
 # checks if a repository is currently runing a publish procedure
@@ -1012,14 +1012,14 @@ close_transaction() {
 is_publishing() {
   local name=$1
   load_repo_config $name
-  [ -d ${CVMFS_SPOOL_DIR}/is_publishing ]
+  check_lock ${CVMFS_SPOOL_DIR}/is_publishing ignore_stale
 }
 
 publish_starting() {
   local name=$1
   load_repo_config $name
   local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
-  mkdir "$pub_lock" > /dev/null 2>&1 || die "Failed to acquire publishing lock"
+  acquire_lock "$pub_lock" ignore_stale || die "Failed to acquire publishing lock"
   trap "publish_failed $name" EXIT HUP INT TERM
   cvmfs_suid_helper lock $name
 }
@@ -1029,7 +1029,7 @@ publish_failed() {
   load_repo_config $name
   local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
   trap - EXIT HUP INT TERM
-  rmdir $pub_lock > /dev/null 2>&1
+  release_lock $pub_lock
   cvmfs_suid_helper open $name
 }
 
@@ -1038,7 +1038,7 @@ publish_succeeded() {
   load_repo_config $name
   local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
   trap - EXIT HUP INT TERM
-  rmdir $pub_lock > /dev/null 2>&1
+  release_lock $pub_lock
 }
 
 acquire_snapshot_lock() {

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -95,7 +95,7 @@ cvmfs_run_test() {
   cat $check_log_3 | grep -e "Trying to remount /cvmfs/${CVMFS_TEST_REPO}"                             || return 17
 
   echo "check if transaction is open"
-  [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 18
+  [ -e ${CVMFS_SPOOL_DIR}/in_transaction.lock ] || return 18
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -111,7 +111,7 @@ cvmfs_run_test() {
   cat $check_log_4 | grep -e "${CVMFS_TEST_REPO} .* cannot be repaired"                                   || return 22
 
   echo "check if transaction is still open"
-  [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 23
+  [ -e ${CVMFS_SPOOL_DIR}/in_transaction.lock ] || return 23
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -169,7 +169,7 @@ cvmfs_run_test() {
   cat $check_log_7 | grep -e "Trying to remount /cvmfs/${CVMFS_TEST_REPO} read/write"                     || return 41
 
   echo "check that repository is not in a transaction"
-  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 42
+  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction.lock ] || return 42
 
   echo "check repository integrity"
   check_repository $CVMFS_TEST_REPO -i || return 43
@@ -244,7 +244,7 @@ cvmfs_run_test() {
   cat $check_log_10 | grep -e "${CVMFS_TEST_REPO} .* cannot be repaired"                 || return 58
 
   echo "check if transaction is still open"
-  [ -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 59
+  [ -e ${CVMFS_SPOOL_DIR}/in_transaction.lock ] || return 59
 
   echo "run abort to bring the repository back in shape"
   local check_log_11="check_11.log"
@@ -259,7 +259,7 @@ cvmfs_run_test() {
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "check if transaction is closed"
-  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction ] || return 65
+  [ ! -e ${CVMFS_SPOOL_DIR}/in_transaction.lock ] || return 65
 
   echo "check repository integrity"
   check_repository $CVMFS_TEST_REPO -i || return 66

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -5,10 +5,12 @@ cvmfs_test_autofs_on_startup=false
 
 create_fake_lock() {
   local name=$1
+  local pid=${2:-$$} # use our own PID by default to fool the stale lock check
+
   load_repo_config $name
-  echo "creating ${CVMFS_SPOOL_DIR}/is_snapshotting.lock"
-  echo "$$" > ${CVMFS_SPOOL_DIR}/is_snapshotting.lock # use our own PID to fool
-                                                      # the stale lock check
+
+  echo "creating ${CVMFS_SPOOL_DIR}/is_snapshotting.lock with PID $pid"
+  echo "$pid" > ${CVMFS_SPOOL_DIR}/is_snapshotting.lock
 }
 
 remove_fake_lock() {
@@ -253,6 +255,21 @@ cvmfs_run_test() {
   cat $snapshot_log_7 | grep 'another snapshot.*in progress.*abort' || return 36
   cat $snapshot_log_8 | grep 'waiting.*snapshot to finish'          || return 37
   cat $snapshot_log_8 | grep 'Uploading manifest'                   || return 38
+
+  # ============================================================================
+
+  echo "place a fake lock that is stale"
+  create_fake_lock $replica_name 3282168345613 || return 39
+
+  echo "create a snapshot (should work - despite the stale lock)"
+  local snapshot_log_9="snapshot_9.log"
+  run_background_snapshot $replica_name $snapshot_log_9 30 || return 40
+
+  echo "check if the lock is gone"
+  check_lock $replica_name && return 41
+
+  echo "check the log file"
+  cat $snapshot_log_9 | grep 'Uploading manifest' || return 42
 
   return 0
 }

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -6,21 +6,22 @@ cvmfs_test_autofs_on_startup=false
 create_fake_lock() {
   local name=$1
   load_repo_config $name
-  echo "creating ${CVMFS_SPOOL_DIR}/is_snapshotting"
-  mkdir ${CVMFS_SPOOL_DIR}/is_snapshotting
+  echo "creating ${CVMFS_SPOOL_DIR}/is_snapshotting.lock"
+  echo "$$" > ${CVMFS_SPOOL_DIR}/is_snapshotting.lock # use our own PID to fool
+                                                      # the stale lock check
 }
 
 remove_fake_lock() {
   local name=$1
   load_repo_config $name
-  echo "removing ${CVMFS_SPOOL_DIR}/is_snapshotting"
-  rmdir ${CVMFS_SPOOL_DIR}/is_snapshotting
+  echo "removing ${CVMFS_SPOOL_DIR}/is_snapshotting.lock"
+  rm -f ${CVMFS_SPOOL_DIR}/is_snapshotting.lock
 }
 
 check_lock() {
   local name=$1
   load_repo_config $name
-  [ -d ${CVMFS_SPOOL_DIR}/is_snapshotting ]
+  [ -f ${CVMFS_SPOOL_DIR}/is_snapshotting.lock ]
 }
 
 run_background_snapshot() {

--- a/test/src/587-serverhooks/main
+++ b/test/src/587-serverhooks/main
@@ -115,12 +115,12 @@ EOF
   echo "check the contents of the hooks"
   cat ${hook_dir}/transaction_before_hook | grep -q  "transaction_before_hook" || return 8
   cat ${hook_dir}/transaction_before_hook | grep -q  "$CVMFS_TEST_REPO"        || return 9
-  cat ${hook_dir}/transaction_before_hook | grep -qv "in_transaction"          || return 10
+  cat ${hook_dir}/transaction_before_hook | grep -qv "in_transaction.lock"     || return 10
   cat ${hook_dir}/transaction_before_hook | grep -q  "$user_string"            || return 11
 
   cat ${hook_dir}/transaction_after_hook  | grep -q "transaction_after_hook"  || return 12
   cat ${hook_dir}/transaction_after_hook  | grep -q "$CVMFS_TEST_REPO"        || return 13
-  cat ${hook_dir}/transaction_after_hook  | grep -q "in_transaction"          || return 14
+  cat ${hook_dir}/transaction_after_hook  | grep -q "in_transaction.lock"     || return 14
   cat ${hook_dir}/transaction_after_hook  | grep -q "$user_string"            || return 15
 
   # ============================================================================
@@ -184,15 +184,15 @@ EOF
   echo "check the contents of the publishing hooks"
   cat ${hook_dir}/publish_before_hook | grep -q  "publish_before_hook"         || return 24
   cat ${hook_dir}/publish_before_hook | grep -q  "$CVMFS_TEST_REPO"            || return 25
-  cat ${hook_dir}/publish_before_hook | grep -q  "in_transaction"              || return 26
-  cat ${hook_dir}/publish_before_hook | grep -qv "is_publishing"               || return 27
+  cat ${hook_dir}/publish_before_hook | grep -q  "in_transaction.lock"         || return 26
+  cat ${hook_dir}/publish_before_hook | grep -qv "is_publishing.lock"          || return 27
   cat ${hook_dir}/publish_before_hook | grep -q  "/cvmfs/$CVMFS_TEST_REPO.*rw" || return 28
   cat ${hook_dir}/publish_before_hook | grep -q  "$user_string"                || return 29
 
   cat ${hook_dir}/publish_after_hook  | grep -q  "publish_after_hook"          || return 30
   cat ${hook_dir}/publish_after_hook  | grep -q  "$CVMFS_TEST_REPO"            || return 31
-  cat ${hook_dir}/publish_after_hook  | grep -qv "in_transaction"              || return 32
-  cat ${hook_dir}/publish_after_hook  | grep -qv "is_publishing"               || return 33
+  cat ${hook_dir}/publish_after_hook  | grep -qv "in_transaction.lock"         || return 32
+  cat ${hook_dir}/publish_after_hook  | grep -qv "is_publishing.lock"          || return 33
   cat ${hook_dir}/publish_after_hook  | grep -q  "/cvmfs/$CVMFS_TEST_REPO.*ro" || return 34
   cat ${hook_dir}/publish_after_hook  | grep -q  "$user_string"                || return 35
 
@@ -263,15 +263,15 @@ EOF
   echo "check the contents of the abort hooks"
   cat ${hook_dir}/abort_before_hook | grep -q  "abort_before_hook"           || return 45
   cat ${hook_dir}/abort_before_hook | grep -q  "$CVMFS_TEST_REPO"            || return 46
-  cat ${hook_dir}/abort_before_hook | grep -q  "in_transaction"              || return 47
-  cat ${hook_dir}/abort_before_hook | grep -qv "is_publishing"               || return 48
+  cat ${hook_dir}/abort_before_hook | grep -q  "in_transaction.lock"         || return 47
+  cat ${hook_dir}/abort_before_hook | grep -qv "is_publishing.lock"          || return 48
   cat ${hook_dir}/abort_before_hook | grep -q  "/cvmfs/$CVMFS_TEST_REPO.*rw" || return 49
   cat ${hook_dir}/abort_before_hook | grep -q  "will_be_aborted"             || return 50
   cat ${hook_dir}/abort_before_hook | grep -q  "$user_string"                || return 51
 
   cat ${hook_dir}/abort_after_hook  | grep -q  "abort_after_hook"            || return 52
   cat ${hook_dir}/abort_after_hook  | grep -q  "$CVMFS_TEST_REPO"            || return 53
-  cat ${hook_dir}/abort_after_hook  | grep -qv "in_transaction"              || return 54
+  cat ${hook_dir}/abort_after_hook  | grep -qv "in_transaction.lock"         || return 54
   cat ${hook_dir}/abort_after_hook  | grep -q  "/cvmfs/$CVMFS_TEST_REPO.*ro" || return 55
   cat ${hook_dir}/abort_after_hook  | grep -qv "will_be_aborted"             || return 56
   cat ${hook_dir}/abort_after_hook  | grep -q  "$user_string"                || return 57


### PR DESCRIPTION
This works towards a fix for [CVM-810](https://sft.its.cern.ch/jira/browse/CVM-810) by unifying the various locks used in `cvmfs_server` into a couple of helper functions. I found a convincing implementation of [file based locks](http://rute.2038bug.com/node23.html.gz) in shell script which I built upon. The central idea is that hardlink creation is atomic in Unix.

Currently stale locks are only detected based on their creator's PID which might lead to false negatives. However, I wonder how likely this is, especially taking into account that stale locks itself should already be unlikely (requiring a host crash).

I am using the implementation for three different locks, namely: **in_transaction**, **is_publishing** and **is_snapshotting**. Furthermore the patch adapts a couple of integration tests that deal with these locks and extend test number 584 to fake a stale lock.

