### PR TITLE
Feature: Vagrant Environment for Scientific Linux 6

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,18 +6,6 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box = "cernvm"
-  # config.vm.box_url = ... TODO(reneme): maybe add later for convenience
-
-  config.vm.boot_timeout = 1200 # CernVM might load stuff over a slow network
-                                # and need a lot of time on first boot up
-
-  config.vm.network "private_network", ip: "192.168.33.10"
-
-  # config.vm.synced_folder '.', '/vagrant', nfs: true   TODO(reneme): quicker!
-
-  config.vm.provision "shell", path: "vagrant/provision_cernvm.sh"
-
   # allow virtual box to take advantage of the host's speed
   # Snippet found here (thanks to Stefan Wrobel): 
   # https://stefanwrobel.com/how-to-make-vagrant-performance-not-suck
@@ -40,5 +28,19 @@ Vagrant.configure(2) do |config|
 
     v.customize ["modifyvm", :id, "--memory", mem]
     v.customize ["modifyvm", :id, "--cpus", cpus]
+  end
+
+  config.vm.define "cernvm" do |cvm|
+    cvm.vm.box = "cernvm"
+    # cvm.vm.box_url = ... TODO(reneme): maybe add later for convenience
+
+    cvm.vm.boot_timeout = 1200 # CernVM might load stuff over a slow network
+                                  # and need a lot of time on first boot up
+
+    cvm.vm.network "private_network", ip: "192.168.33.10"
+
+    # cvm.vm.synced_folder '.', '/vagrant', nfs: true   TODO(reneme): quicker!
+
+    cvm.vm.provision "shell", path: "vagrant/provision_cernvm.sh"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,4 +43,20 @@ Vagrant.configure(2) do |config|
 
     cvm.vm.provision "shell", path: "vagrant/provision_cernvm.sh"
   end
+
+  config.vm.define "slc6" do |slc6|
+    unless Vagrant.has_plugin?("vagrant-reload")
+      puts "-------------------- WARNING --------------------"
+      puts "Vagrant plugin 'vagrant-reload' is not installed."
+      puts "Please run: vagrant plugin install vagrant-reload"
+      puts "-------------------------------------------------"
+    end
+
+    slc6.vm.box = "bytepark/scientific-6.5-64"
+    slc6.vm.network "private_network", ip: "192.168.33.11"
+    slc6.vm.synced_folder '.', '/vagrant', nfs: true
+
+    slc6.vm.provision "shell", path: "vagrant/provision_slc6.sh"
+    slc6.vm.provision :reload
+  end
 end

--- a/vagrant/provision_slc6.sh
+++ b/vagrant/provision_slc6.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+WORKSPACE="provision"
+RELEASE_PKG="https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-2-5.noarch.rpm"
+CVMFS_TEST_USER="sftnight"
+CVMFS_SOURCE_DIR="$(pwd)/cvmfs"
+
+# set VM locale
+export LANG="en_US.UTF-8"
+echo "LANG=\"$LANG\"" > /etc/sysconfig/i18n
+
+# create a provisioning workspace
+PREV_DIR="$(pwd)"
+mkdir -p $WORKSPACE
+cd $WORKSPACE
+
+# install cvmfs-release RPM
+if ! rpm -q cvmfs-release > /dev/null 2>&1; then
+  echo "installing cvmfs-release package"
+  wget --quiet "$RELEASE_PKG"
+  yum -y install $(basename $RELEASE_PKG)
+fi
+
+# jump back to the home directory
+cd $PREV_DIR
+
+# install custom kernel
+if ! rpm -q kernel | grep -q 'aufs'; then
+  echo "installing custom AUFS enabled kernel"
+  yum -y --disablerepo='*' --enablerepo='cernvm-kernel' install kernel kernel-headers
+fi
+
+# update installed packages
+yum -y --exclude='kernel*' update
+
+# activate EPEL to get as much of the fun stuff as possible
+yum -y install epel-release
+
+# install necessary development packages
+yum -y install libuuid-devel gcc gcc-c++ glibc-common cmake fuse fuse-devel  \
+               fuse-libs libattr-devel openssl openssl-devel patch pkgconfig \
+               gawk perl autofs zlib gzip unzip gdb chkconfig which          \
+               shadow-utils util-linux-ng selinux-policy checkpolicy         \
+               selinux-policy-devel hardlink selinux-policy-targeted         \
+               python-devel initscripts bash coreutils grep sed sudo psmisc  \
+               curl attr httpd
+
+# install convenience packages for development
+yum -y install git tig iftop htop
+
+# link the CernVM-FS source directory in place
+if [ ! -L $CVMFS_SOURCE_DIR ]; then
+  ln -s /vagrant $CVMFS_SOURCE_DIR
+  chown -h vagrant:vagrant $CVMFS_SOURCE_DIR
+fi
+
+# enable httpd on boot
+if ! /sbin/chkconfig httpd > /dev/null 2>&1; then
+  /sbin/chkconfig --add httpd
+  /sbin/chkconfig httpd on
+  /sbin/service httpd start
+fi
+
+# allow user 'vagrant' to do everything
+sed -i -e 's/^vagrant.*/vagrant ALL=(ALL) NOPASSWD:ALL/' /etc/sudoers
+
+# create CVMFS test user
+useradd $CVMFS_TEST_USER
+echo "$CVMFS_TEST_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
This adds a vagrant environment for SLC6 besides the CernVM based development environment. To run it, Vagrant needs to have the [vagrant-reload](https://github.com/aidanns/vagrant-reload) plugin installed to allow for a VM reboot at provisioning time (AUFS kernel install).

To use the SLC6 based development environment do:
```bash
vagrant plugin install vagrant-reload
vagrant up slc6
vagrant ssh slc6
```