### PR TITLE
FIX: Chunk Hashes getting Scrambled on Nested Catalog Creation

### DIFF
--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -408,7 +408,8 @@ void WritableCatalog::MoveToNestedRecursively(
       MoveToNestedRecursively(full_path, new_nested_catalog,
                               grand_child_mountpoints);
     } else if (i->IsChunkedFile()) {
-      MoveFileChunksToNested(full_path, new_nested_catalog);
+      MoveFileChunksToNested(full_path, i->hash_algorithm(),
+                             new_nested_catalog);
     }
 
     // Remove the entry from the current catalog
@@ -439,12 +440,12 @@ void WritableCatalog::MoveCatalogsToNested(
 
 
 void WritableCatalog::MoveFileChunksToNested(
-  const std::string  &full_path,
-  WritableCatalog    *new_nested_catalog)
+  const std::string       &full_path,
+  const shash::Algorithms  algorithm,
+  WritableCatalog         *new_nested_catalog)
 {
   FileChunkList chunks;
-  // Moving opaque chunks, we don't care about the hash algorithm
-  ListPathChunks(PathString(full_path), shash::kAny, &chunks);
+  ListPathChunks(PathString(full_path), algorithm, &chunks);
   assert(chunks.size() > 0);
 
   for (unsigned i = 0; i < chunks.size(); ++i) {

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -163,8 +163,9 @@ class WritableCatalog : public Catalog {
     std::vector<std::string> *grand_child_mountpoints);
   void MoveCatalogsToNested(const std::vector<std::string> &nested_catalogs,
                             WritableCatalog *new_nested_catalog);
-  void MoveFileChunksToNested(const std::string  &full_path,
-                              WritableCatalog    *new_nested_catalog);
+  void MoveFileChunksToNested(const std::string       &full_path,
+                              const shash::Algorithms  algorithm,
+                              WritableCatalog         *new_nested_catalog);
 
   void CopyToParent();
   void CopyCatalogsToParent();

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -102,6 +102,11 @@ class Sql : public sqlite::Sql {
     const shash::Algorithms  hash_algo,
     const char               hash_suffix = shash::kSuffixNone) const
   {
+    // Note: SQLite documentation advises to first define the data type of BLOB
+    //       by calling sqlite3_column_XXX() on the column and _afterwards_ get
+    //       the number of bytes using sqlite3_column_bytes().
+    //
+    //  See: https://www.sqlite.org/c3ref/column_blob.html
     const unsigned char *buffer = static_cast<const unsigned char *>(
       RetrieveBlob(idx_column));
     const int byte_count = RetrieveBytes(idx_column);

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -106,7 +106,7 @@ class Sql : public sqlite::Sql {
     if (byte_count > 0) {
       const unsigned char *buffer = static_cast<const unsigned char *>(
         RetrieveBlob(idx_column));
-      return shash::Any(hash_algo, buffer, byte_count, hash_suffix);
+      return shash::Any(hash_algo, buffer, hash_suffix);
     }
     return shash::Any(hash_algo);
   }

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -102,13 +102,11 @@ class Sql : public sqlite::Sql {
     const shash::Algorithms  hash_algo,
     const char               hash_suffix = shash::kSuffixNone) const
   {
+    const unsigned char *buffer = static_cast<const unsigned char *>(
+      RetrieveBlob(idx_column));
     const int byte_count = RetrieveBytes(idx_column);
-    if (byte_count > 0) {
-      const unsigned char *buffer = static_cast<const unsigned char *>(
-        RetrieveBlob(idx_column));
-      return shash::Any(hash_algo, buffer, hash_suffix);
-    }
-    return shash::Any(hash_algo);
+    return (byte_count > 0) ? shash::Any(hash_algo, buffer, hash_suffix)
+                            : shash::Any(hash_algo);
   }
 
   /**

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -168,12 +168,11 @@ struct Digest {
   }
 
   Digest(const Algorithms a,
-         const unsigned char *digest_buffer, const unsigned buffer_size,
+         const unsigned char *digest_buffer,
          const Suffix s = kSuffixNone) :
     algorithm(a), suffix(s)
   {
-    assert(buffer_size <= digest_size_);
-    memcpy(digest, digest_buffer, buffer_size);
+    memcpy(digest, digest_buffer, kDigestSizes[a]);
   }
 
   /**
@@ -391,9 +390,9 @@ struct Any : public Digest<32, kAny> {
     Digest<32, kAny>() { algorithm = a; suffix = s; }
 
   Any(const Algorithms     a,
-      const unsigned char *digest_buffer, const unsigned buffer_size,
+      const unsigned char *digest_buffer,
       const Suffix         suffix = kSuffixNone) :
-    Digest<32, kAny>(a, digest_buffer, buffer_size, suffix) { }
+    Digest<32, kAny>(a, digest_buffer, suffix) { }
 
   explicit Any(const Algorithms  a,
                const HexPtr      hex,

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -382,22 +382,22 @@ struct Sha256 : public Digest<32, kSha256> { };
  * To do real work, the class has to be "blessed" to be a real hash by
  * setting the algorithm field accordingly.
  */
-struct Any : public Digest<32, kAny> {
-  Any() : Digest<32, kAny>() { }
+struct Any : public Digest<kMaxDigestSize, kAny> {
+  Any() : Digest<kMaxDigestSize, kAny>() { }
 
   explicit Any(const Algorithms a,
                const char       s = kSuffixNone) :
-    Digest<32, kAny>() { algorithm = a; suffix = s; }
+    Digest<kMaxDigestSize, kAny>() { algorithm = a; suffix = s; }
 
   Any(const Algorithms     a,
       const unsigned char *digest_buffer,
       const Suffix         suffix = kSuffixNone) :
-    Digest<32, kAny>(a, digest_buffer, suffix) { }
+    Digest<kMaxDigestSize, kAny>(a, digest_buffer, suffix) { }
 
   explicit Any(const Algorithms  a,
                const HexPtr      hex,
                const char        suffix = kSuffixNone) :
-    Digest<32, kAny>(a, hex, suffix) { }
+    Digest<kMaxDigestSize, kAny>(a, hex, suffix) { }
 };
 
 

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -340,6 +340,15 @@ class Sql {
   int RetrieveType(const int idx_column) const {
     return sqlite3_column_type(statement_, idx_column);
   }
+
+  /**
+   * Determines the number of bytes necessary to store the column's data as a
+   * string. This might involve type conversions and depends on which other
+   * RetrieveXXX methods were called on the same column index before!
+   *
+   * See SQLite documentation for sqlite_column_bytes() for details:
+   *   https://www.sqlite.org/c3ref/column_blob.html
+   */
   int RetrieveBytes(const int idx_column) const {
     return sqlite3_column_bytes(statement_, idx_column);
   }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -68,7 +68,6 @@ class ChunkJob {
     assert(!IsTerminateJob());
     return shash::Any(hash_algorithm,
                       digest,
-                      shash::kDigestSizes[hash_algorithm],
                       suffix);
   }
 

--- a/test/unittests/t_async_reader.cc
+++ b/test/unittests/t_async_reader.cc
@@ -35,7 +35,7 @@ class TestFile : public upload::AbstractFile {
   off_t          read_offset() const { return read_offset_; }
 
   shash::Any GetHash() const {
-    return shash::Any(shash::kSha1, sha1_digest_, SHA_DIGEST_LENGTH);
+    return shash::Any(shash::kSha1, sha1_digest_);
   }
 
   const shash::Any& GetExpectedHash() const {

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -90,9 +90,7 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
       sha1_retval = SHA1_Final(sha1_digest_, &sha_context);
       ASSERT_EQ(1, sha1_retval) << "failed to finalize SHA1 checksum";
 
-      recomputed_content_hash = shash::Any(shash::kSha1,
-                                           sha1_digest_,
-                                           SHA_DIGEST_LENGTH);
+      recomputed_content_hash = shash::Any(shash::kSha1, sha1_digest_);
     }
 
     shash::Any     computed_content_hash;


### PR DESCRIPTION
Since the recently added **SHA2** hash has a length of 32 bytes in contrast to the previously supported hash algorithms **SHA1** and **RMD160** we now need to take the the hash length into account when copying them into nested catalogs. Otherwise all older client would have crashed when reading chunked files.

This pull request also incorporates minor refactorings; namely the removal of some magic numbers and the simplification of an `shash::Digest` and `shash::Any` c'tor.