### PR TITLE
Rewrite: GeoIP database Installation and Update Logic

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -34,6 +34,10 @@ CVMFS_UPDATEGEO_HOUR=10 # First hour of day for update, 0-23, default 10am
 CVMFS_UPDATEGEO_MINDAYS=25 # Minimum days between update attempts
 CVMFS_UPDATEGEO_MAXDAYS=100 # Maximum days old before considering it an error
 
+CVMFS_UPDATEGEO_URL="http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz"
+CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo"
+CVMFS_UPDATEGEO_DB=${CVMFS_UPDATEGEO_DIR}/GeoLiteCity.dat
+
 
 # setup server hooks: no-ops (overrideable by /etc/cvmfs/cvmfs_server_hooks.sh)
 transaction_before_hook() { :; }
@@ -2237,9 +2241,8 @@ _check_old_dbfile() {
 }
 
 update_geodb() {
-  local dburl="http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz"
-  local dbdir="/var/lib/cvmfs-server/geo"
-  local dbfile=$dbdir/GeoLiteCity.dat
+  local dbfile=$CVMFS_UPDATEGEO_DB
+  local dbdir=$CVMFS_UPDATEGEO_DIR
   local outfile=$dbdir/update.out
   local lazy=false
   local retcode=0
@@ -2276,7 +2279,7 @@ update_geodb() {
 
   if [ -w "$dbfile" ]; then
     echo "Downloading geoip database"
-    if ! curl -sS --fail --connect-timeout 10 --max-time 60 "$dburl" >$dbfile.gz 2>$outfile; then
+    if ! curl -sS --fail --connect-timeout 10 --max-time 60 "$CVMFS_UPDATEGEO_URL" >$dbfile.gz 2>$outfile; then
       retcode=1
     fi
     cat $outfile
@@ -2297,7 +2300,7 @@ update_geodb() {
       fi
     else
       rm -f $dbfile.gz
-      echo "error downloading $dburl"
+      echo "error downloading $CVMFS_UPDATEGEO_URL"
       $lazy || return 1
     fi
   # else not root, can't do the download

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2224,26 +2224,58 @@ has_file_descriptors_on_mount_point() {
 #                                                                              #
 ################################################################################
 
-_check_old_dbfile() {
-  local dbfile=$1
-  local lazy=$2
-  # only to be used from update_geodb
-  if [ -n "`find $dbfile -mtime +"$CVMFS_UPDATEGEO_MAXDAYS"`" ]; then
-    if ! is_root; then
-      echo "Geoip database more than $CVMFS_UPDATEGEO_MAXDAYS days old, do update-geodb as root regularly"
-    elif $lazy; then
-      echo "Geoip database more than $CVMFS_UPDATEGEO_MAXDAYS days old, try update-geodb without -l"
-    else
-      echo "Geoip database more than $CVMFS_UPDATEGEO_MAXDAYS days old, but should never reach this point"
-    fi
+_update_geodb_days_since_update() {
+  local timestamp=$(date +%s)
+  local db_mtime=$(stat --format='%Y' $CVMFS_UPDATEGEO_DB)
+  local days_since_update=$(( ( $timestamp - $db_mtime ) / 86400 ))
+  echo "$days_since_update"
+}
+
+_update_geodb_lazy_install_slot() {
+  [ "`date +%w`" -eq "$CVMFS_UPDATEGEO_DAY"  ] && \
+  [ "`date +%k`" -gt "$CVMFS_UPDATEGEO_HOUR" ]
+}
+
+_update_geodb_install() {
+  local retcode=0
+  local dbfile="$CVMFS_UPDATEGEO_DB"
+  local download_target=${CVMFS_UPDATEGEO_DB}.gz
+  local unzip_target=${CVMFS_UPDATEGEO_DB}.new
+
+  # downloading the GeoIP database file
+  if ! curl -sS                  \
+            --fail               \
+            --connect-timeout 10 \
+            --max-time 60        \
+            "$CVMFS_UPDATEGEO_URL" > $download_target 2>/dev/null; then
+    echo "failed to download $CVMFS_UPDATEGEO_URL" >&2
+    rm -f $download_target
     return 1
   fi
+
+  # unzipping the GeoIP database file
+  if ! zcat $download_target > $unzip_target 2>/dev/null; then
+    echo "failed to unzip $download_target to $unzip_target" >&2
+    rm -f $download_target $unzip_target
+    return 2
+  fi
+
+  # get rid of the zipped GeoIP database
+  rm -f $download_target
+
+  # atomically installing the GeoIP database
+  if ! mv -f $unzip_target $dbfile; then
+    echo "failed to install $dbfile" >&2
+    rm -f $unzip_target
+    return 3
+  fi
+
+  return 0
 }
 
 _update_geodb() {
   local dbfile=$CVMFS_UPDATEGEO_DB
   local dbdir=$CVMFS_UPDATEGEO_DIR
-  local outfile=$dbdir/update.out
   local lazy=false
   local retcode=0
 
@@ -2262,61 +2294,30 @@ _update_geodb() {
   done
 
   # sanity checks
-  [ -w "$dbfile" ] || $lazy || die "geo database is not writable by $(whoami)"
-  [ -d $dbdir ] || die "$dbdir does not exist"
+  [ -w "$dbdir"  ]   || { echo "Directory '$dbdir' doesn't exist or is not writable by $(whoami)" >&2; return 1; }
+  [ ! -f "$dbfile" ] || [ -w "$dbfile" ] || { echo "GeoIP database '$dbfile' is not writable by $(whoami)" >&2; return 2; }
 
-  # check if this is a lazy update and it isn't time to try again yet
-  if $lazy && [ -f $dbfile ] && [ -f $outfile ]; then
-    if [ -z "`find $outfile -mtime +$CVMFS_UPDATEGEO_MINDAYS`" ] || \
-        [ "`date +%w`" -ne "$CVMFS_UPDATEGEO_DAY" ] ||
-        [ "`date +%k`" -lt "$CVMFS_UPDATEGEO_HOUR" ]; then
-      # not time to try again yet
-      # if dbfile is old, warn but don't treat it as an error
-      _check_old_dbfile $dbfile $lazy || true
-      return
-    fi
-  fi
-
-  if [ -w "$dbfile" ]; then
-    echo "Downloading geoip database"
-    if ! curl -sS --fail --connect-timeout 10 --max-time 60 "$CVMFS_UPDATEGEO_URL" >$dbfile.gz 2>$outfile; then
-      retcode=1
-    fi
-    cat $outfile
-    if [ $retcode = 0 ]; then
-      if [ -s $dbfile.gz ]; then
-        if zcat $dbfile.gz >$dbfile.new; then
-          rm -f $dbfile.gz
-          mv -f $dbfile.new $dbfile
-        else
-          rm -f $dbfile.gz $dbfile.new
-          echo "error unzipping geoip database"
-          $lazy || return 1
-        fi
-      else
-        rm -f $dbfile.gz
-        echo "downloaded geoip database empty"
-        $lazy || return 1
-      fi
+  # check if an update/installation needs to be done
+  if [ ! -f "$dbfile" ]; then
+    echo -n "Installing GeoIP Database... "
+  elif ! $lazy; then
+    echo -n "Updating GeoIP Database... "
+  elif [ $(_update_geodb_days_since_update) -gt $CVMFS_UPDATEGEO_MAXDAYS ]; then
+    echo -n "GeoIP Database is very old. Updating... "
+  elif [ $(_update_geodb_days_since_update) -gt $CVMFS_UPDATEGEO_MINDAYS ]; then
+    if _update_geodb_lazy_install_slot; then
+      echo -n "GeoIP Database is expired. Updating... "
     else
-      rm -f $dbfile.gz
-      echo "error downloading $CVMFS_UPDATEGEO_URL"
-      $lazy || return 1
+      echo "GeoIP Database is expired but doing nothing right now."
+      return 0
     fi
-  # else not root, can't do the download
+  else
+    echo "GeoIP Database is up to date. Nothing to do."
+    return 0
   fi
 
-  if [ ! -f $dbfile ]; then
-    # database has never been downloaded, fatal error
-    is_root || die "Geoip database not downloaded, do update-geodb as root"
-    ! $lazy || die "Geoip database failed to download, do update-geodb without -l"
-    die "Geoip database not downloaded, should never reach this point"
-  fi
-
-  # treat an old dbfile as an error, but not fatal to other cvmfs_server functions
-  _check_old_dbfile $dbfile $lazy || return 1
-
-  return
+  # at this point the database needs to be installed or updated
+  _update_geodb_install && echo "done" || { echo "fail"; return 3; }
 }
 
 update_geodb() {

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2697,6 +2697,7 @@ add_replica() {
   # additional sanity checks
   is_root || die "Only root can create a new repository"
   check_user $cvmfs_user || die "No user $cvmfs_user"
+  check_upstream_validity $upstream
   if is_local_upstream $upstream; then
     if ! check_apache; then
       if [ $silence_httpd_warning -eq 1 ]; then
@@ -2712,7 +2713,6 @@ add_replica() {
       fi
     fi
   fi
-  check_upstream_validity $upstream
 
   echo -n "Creating Configuration Files... "
   mkdir -p /etc/cvmfs/repositories.d/${alias_name}

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2702,7 +2702,6 @@ add_replica() {
     if [ $silence_httpd_warning -eq 0 ]; then
       check_apache || die "Apache must be installed and running"
       check_wsgi_module
-      update_geodb -l
       [ x"$cvmfs_user" = x"root" ] || echo "NOTE: If snapshot is not run regularly as root, do update-geodb monthly from cron"
     else
       check_apache || echo "Warning: Apache is needed to access this CVMFS replication"
@@ -2764,11 +2763,14 @@ Alias /cvmfs/$alias_name ${storage_dir}
     ExpiresByType application/x-cvmfs "access plus 2 minutes"
 </Directory>
 EOF
+
     reload_apache > /dev/null
   fi
   echo "done"
 
   if is_local_upstream $upstream; then
+    _update_geodb -l
+
     echo -n "Create CernVM-FS Storage... "
     mkdir -p $storage_dir
     create_repository_skeleton $storage_dir $cvmfs_user > /dev/null

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2321,8 +2321,10 @@ _update_geodb() {
 }
 
 update_geodb() {
-  # sanity checks
-  [ -w $CVMFS_UPDATEGEO_DB ] || die "GeoIP database is not writable by $(whoami)"
+  local dbdir=$CVMFS_UPDATEGEO_DIR
+  local dbfile=$CVMFS_UPDATEGEO_DB
+  [ -w "$dbdir"  ] || die "Directory '$dbdir' not writable by $(whoami)"
+  [ ! -f "$dbfile" ] || [ -w "$dbfile" ] || die "GeoIP database '$dbfile' is not writable by $(whoami)"
   _update_geodb $@
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2699,18 +2699,13 @@ add_replica() {
   check_user $cvmfs_user || die "No user $cvmfs_user"
   check_upstream_validity $upstream
   if is_local_upstream $upstream; then
-    if ! check_apache; then
-      if [ $silence_httpd_warning -eq 1 ]; then
-        echo "Warning: Apache is needed to access this CVMFS replication"
-      else
-        die "Apache must be installed and running"
-      fi
-    elif [ $silence_httpd_warning -eq 0 ]; then
+    if [ $silence_httpd_warning -eq 0 ]; then
+      check_apache || die "Apache must be installed and running"
       check_wsgi_module
       update_geodb -l
-      if [ "$cvmfs_user" != root ]; then
-        echo "NOTE: If snapshot is not run regularly as root, do update-geodb monthly from cron"
-      fi
+      [ x"$cvmfs_user" = x"root" ] || echo "NOTE: If snapshot is not run regularly as root, do update-geodb monthly from cron"
+    else
+      check_apache || echo "Warning: Apache is needed to access this CVMFS replication"
     fi
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2743,9 +2743,10 @@ EOF
   fi
 
   if is_local_upstream $upstream; then
-    ((echo "# Created by cvmfs_server.  Don't touch."
-      cat_wsgi_config ${alias_name}; cat) | \
-      create_apache_config_file "cvmfs.${alias_name}.conf") << EOF
+    create_apache_config_file "cvmfs.${alias_name}.conf" << EOF
+# Created by cvmfs_server.  Don't touch.
+$(cat_wsgi_config ${alias_name})
+
 KeepAlive On
 # Translation URL to real pathname
 Alias /cvmfs/$alias_name ${storage_dir}

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2240,7 +2240,7 @@ _check_old_dbfile() {
   fi
 }
 
-update_geodb() {
+_update_geodb() {
   local dbfile=$CVMFS_UPDATEGEO_DB
   local dbdir=$CVMFS_UPDATEGEO_DIR
   local outfile=$dbdir/update.out
@@ -2317,6 +2317,12 @@ update_geodb() {
   _check_old_dbfile $dbfile $lazy || return 1
 
   return
+}
+
+update_geodb() {
+  # sanity checks
+  [ -w $CVMFS_UPDATEGEO_DB ] || die "GeoIP database is not writable by $(whoami)"
+  _update_geodb $@
 }
 
 ################################################################################
@@ -4375,7 +4381,7 @@ snapshot() {
         #  apache was enabled later
         check_wsgi_module
         # try to update the geodb, but continue if it doesn't work
-        update_geodb -l || true
+        _update_geodb -l || true
     fi
     [ ! -z $stratum1 ] || die "Missing CVMFS_STRATUM1 URL in server.conf"
     gc_timespan="$(get_auto_garbage_collection_timespan $alias_name)" || { retcode=1; continue; }
@@ -4623,7 +4629,7 @@ migrate_2_1_15() {
 
   if check_apache; then
     check_wsgi_module
-    update_geodb -l
+    _update_geodb -l
   fi
   # else apache is currently stopped, add-replica may have been run with -a
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -580,11 +580,10 @@ create_stratum1() {
     [ ! -z "$stratum1_url" ] || die "\$CVMFS_TEST_HTTP_BASE needs to be set for S3 tests to work!"
     echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
     echo "  Stratum1:  $stratum1_url"
-    s3_config=" -s $CVMFS_TEST_S3_CONFIG -w $stratum1_url"
+    s3_config=" -s $CVMFS_TEST_S3_CONFIG -w $stratum1_url -a"
   fi
   sudo cvmfs_server add-replica -o $CVMFS_TEST_USER    \
                                 -n $replica_name       \
-                                -a                     \
                                 $s3_config             \
                                 $additional_parameters \
                                 $stratum0_url          \


### PR DESCRIPTION
The GeoIP database update code in `cvmfs_server` along with a change in [#1052](https://github.com/cvmfs/cvmfs/pull/1052) caused several integration tests to fail. Looking into it, I found the entire update logic incomprehensibly complicated and decided to rewrite it.

**NOTE:** Please don't merge yet, I'll add an integration test for this later today.

The semantic should be very much the same, but with a reasonable control flow. Changes done:
* move main logic from `update_geodb()` to `_update_geodb()`
* wrap the `cvmfs_server update-geodb` call into a simple sanity checker
* centralise static config (download URL, database location and filename)
* simplify the Apache config file creation (remove an evil and unnecessary stdin-stdout hack)
* break previously convoluted update logic into several independent pieces:
   * sanity checks
   * strategy decision (initial install, forced update, lazy update, do nothing)
   * download and installation

As stated above, I will add an integration test for it soon...
