### PR TITLE
TEST/FIX: GeoIP Database Update

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4379,15 +4379,16 @@ snapshot() {
     # more sanity checks
     is_owner_or_root $alias_name || { echo "Permission denied: Repository $alias_name is owned by $user"; retcode=1; continue; }
     check_repository_compatibility
-    if is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
-        # try to update the geodb, but continue if it doesn't work
-        _update_geodb -l || true
-    fi
     [ ! -z $stratum1 ] || die "Missing CVMFS_STRATUM1 URL in server.conf"
     gc_timespan="$(get_auto_garbage_collection_timespan $alias_name)" || { retcode=1; continue; }
 
     # do it!
     local user_shell="$(get_user_shell $alias_name)"
+
+    if is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
+        # try to update the geodb, but continue if it doesn't work
+        _update_geodb -l || true
+    fi
 
     local initial_snapshot=0
     if $user_shell "$(__swissknife_cmd) peek -d .cvmfs_last_snapshot -r ${upstream}" | grep -v -q "available"; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2711,7 +2711,12 @@ add_replica() {
     if [ $silence_httpd_warning -eq 0 ]; then
       check_apache || die "Apache must be installed and running"
       check_wsgi_module
-      [ x"$cvmfs_user" = x"root" ] || echo "NOTE: If snapshot is not run regularly as root, do update-geodb monthly from cron"
+      if [ x"$cvmfs_user" != x"root" ]; then
+        echo "NOTE: If snapshot is not run regularly as root, the GeoIP database will not be updated."
+        echo "      You have two options, either:"
+        echo "      1. chown $CVMFS_UPDATEGEO_DIR and $CVMFS_UPDATEGEO_DB accordingly OR"
+        echo "      2. run update-geodb monthly as root"
+      fi
     else
       check_apache || echo "Warning: Apache is needed to access this CVMFS replication"
     fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4379,11 +4379,7 @@ snapshot() {
     # more sanity checks
     is_owner_or_root $alias_name || { echo "Permission denied: Repository $alias_name is owned by $user"; retcode=1; continue; }
     check_repository_compatibility
-    if is_local_upstream $CVMFS_UPSTREAM_STORAGE && check_apache; then
-        # this might have been missed if add-replica -a was used or
-        #  if a migrate was done while apache wasn't running, but then
-        #  apache was enabled later
-        check_wsgi_module
+    if is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
         # try to update the geodb, but continue if it doesn't work
         _update_geodb -l || true
     fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2322,10 +2322,6 @@ _update_geodb() {
 }
 
 update_geodb() {
-  local dbdir=$CVMFS_UPDATEGEO_DIR
-  local dbfile=$CVMFS_UPDATEGEO_DB
-  [ -w "$dbdir"  ] || die "Directory '$dbdir' not writable by $(whoami)"
-  [ ! -f "$dbfile" ] || [ -w "$dbfile" ] || die "GeoIP database '$dbfile' is not writable by $(whoami)"
   _update_geodb $@
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2233,7 +2233,7 @@ _update_geodb_days_since_update() {
 
 _update_geodb_lazy_install_slot() {
   [ "`date +%w`" -eq "$CVMFS_UPDATEGEO_DAY"  ] && \
-  [ "`date +%k`" -gt "$CVMFS_UPDATEGEO_HOUR" ]
+  [ "`date +%k`" -ge "$CVMFS_UPDATEGEO_HOUR" ]
 }
 
 _update_geodb_install() {

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2713,9 +2713,11 @@ add_replica() {
       check_wsgi_module
       if [ x"$cvmfs_user" != x"root" ]; then
         echo "NOTE: If snapshot is not run regularly as root, the GeoIP database will not be updated."
-        echo "      You have two options, either:"
+        echo "      You have three options:"
         echo "      1. chown $CVMFS_UPDATEGEO_DIR and $CVMFS_UPDATEGEO_DB accordingly OR"
-        echo "      2. run update-geodb monthly as root"
+        echo "      2. run update-geodb monthly as root                               OR"
+        echo "      3. chown $CVMFS_UPDATEGEO_DIR and $CVMFS_UPDATEGEO_DB to a dedicated"
+        echo "         user ID and run update-geodb monthly as that user"
       fi
     else
       check_apache || echo "Warning: Apache is needed to access this CVMFS replication"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2312,7 +2312,8 @@ _update_geodb() {
       return 0
     fi
   else
-    echo "GeoIP Database is up to date. Nothing to do."
+    local days_old=$(_update_geodb_days_since_update)
+    echo "GeoIP Database is up to date ($days_old days old). Nothing to do."
     return 0
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4382,6 +4382,13 @@ snapshot() {
     check_repository_compatibility
     [ ! -z $stratum1 ] || die "Missing CVMFS_STRATUM1 URL in server.conf"
     gc_timespan="$(get_auto_garbage_collection_timespan $alias_name)" || { retcode=1; continue; }
+    if is_local_upstream $CVMFS_UPSTREAM_STORAGE && is_root && check_apache; then
+      # this might have been missed if add-replica -a was used or
+      #  if a migrate was done while apache wasn't running, but then
+      #  apache was enabled later
+      # unfortunately we can only check it if snapshot is run as root...
+      check_wsgi_module
+    fi
 
     # do it!
     local user_shell="$(get_user_shell $alias_name)"

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -116,6 +116,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/585-xattrs                               \
                                src/591-importrepo                           \
                                src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
                                --                                           \
                                src/5* || retval=1
 

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -1,0 +1,252 @@
+cvmfs_test_name="Update GeoIP Database"
+cvmfs_test_autofs_on_startup=false
+
+#
+# Location of the system-wide GeoIP database
+# configurable: to be changed if $CVMFS_UPDATEGEO_DB in cvmfs_server changes
+#
+CVMFS_TEST_595_GEODB="/var/lib/cvmfs-server/geo/GeoLiteCity.dat"
+CVMFS_TEST_595_SERVER_HOOKS="/etc/cvmfs/cvmfs_server_hooks.sh"
+
+CVMFS_TEST_595_REPLICA_NAME=
+CVMFS_TEST_595_GEODB_TOUCHED=0
+CVMFS_TEST_595_GEODB_STASH=
+CVMFS_TEST_595_GEODB_OWNER=
+CVMFS_TEST_595_SERVER_HOOKS_TOUCHED=0
+CVMFS_TEST_595_SERVER_HOOKS_STASH=
+cleanup() {
+  echo "running cleanup... "
+  [ -z $CVMFS_TEST_595_REPLICA_NAME ]            || sudo cvmfs_server rmfs -f $CVMFS_TEST_595_REPLICA_NAME
+  [ $CVMFS_TEST_595_GEODB_TOUCHED -eq 0 ]        || sudo rm -f $CVMFS_TEST_595_GEODB
+  [ -z $CVMFS_TEST_595_GEODB_STASH  ]            || sudo cp -f $CVMFS_TEST_595_GEODB_STASH $CVMFS_TEST_595_GEODB
+  [ -z $CVMFS_TEST_595_GEODB_STASH  ]            || sudo chown ${CVMFS_TEST_595_GEODB_OWNER}:${CVMFS_TEST_595_GEODB_OWNER} $CVMFS_TEST_595_GEODB
+  [ -z $CVMFS_TEST_595_GEODB_OWNER ]             || sudo chown ${CVMFS_TEST_595_GEODB_OWNER}:${CVMFS_TEST_595_GEODB_OWNER} $(dirname $CVMFS_TEST_595_GEODB)
+  [ $CVMFS_TEST_595_SERVER_HOOKS_TOUCHED -eq 0 ] || sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS
+  [ -z $CVMFS_TEST_595_SERVER_HOOKS_STASH ]      || sudo cp -f $CVMFS_TEST_595_SERVER_HOOKS_STASH $CVMFS_TEST_595_SERVER_HOOKS
+}
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  local mnt_point="$(pwd)/mountpount"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  local geodb_dir=$(dirname $CVMFS_TEST_595_GEODB)
+  echo "save the owner of $geodb_dir"
+  CVMFS_TEST_595_GEODB_OWNER=$(stat --format='%U' $geodb_dir)
+
+  if [ -f $CVMFS_TEST_595_GEODB ]; then
+    local stash=$(pwd)/$(basename $CVMFS_TEST_595_GEODB)
+    echo "stash away ($stash) the GeoIP database file '$CVMFS_TEST_595_GEODB' prior to the test"
+    sudo cp -f $CVMFS_TEST_595_GEODB $stash || return 1
+    CVMFS_TEST_595_GEODB_STASH=$stash
+    sudo rm -f $CVMFS_TEST_595_GEODB        || return 1
+  fi
+
+  if [ -f $CVMFS_TEST_595_SERVER_HOOKS ]; then
+    local stash=$(pwd)/$(basename $CVMFS_TEST_595_SERVER_HOOKS)
+    echo "stash away ($stash) to server hooks '$CVMFS_TEST_595_SERVER_HOOKS' prior to the test"
+    sudo cp -p $CVMFS_TEST_595_SERVER_HOOKS $stash || return 2
+    CVMFS_TEST_595_SERVER_HOOKS_STASH=$stash
+    sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS        || return 2
+  fi
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "install a desaster cleanup function"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "check that there is no GeoIP database"
+  [ ! -f $CVMFS_TEST_595_GEODB ] || return 3
+
+  echo "create Stratum1 repository on the same machine"
+  local create_s1_log="create_stratum1.log"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+                  > $create_s1_log 2>&1 || return 1
+  CVMFS_TEST_595_REPLICA_NAME=$replica_name
+  CVMFS_TEST_595_GEODB_TOUCHED=1
+
+  echo "check that there is a GeoIP database now"
+  [ -f $CVMFS_TEST_595_GEODB ] || return 4
+
+  echo "check the logging output for the GeoIP update strategy"
+  cat $create_s1_log | grep "Installing GeoIP Database" || return 5
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "manually start a GeoIP database update as '$CVMFS_TEST_USER' (should fail)"
+  local update_1_log="update_geodb_1.log"
+  cvmfs_server update-geodb > $update_1_log 2>&1 && return 6
+
+  echo "manually start a lazy GeoIP database update as '$CVMFS_TEST_USER' (should fail as well)"
+  local update_2_log="update_geodb_2.log"
+  cvmfs_server update-geodb -l > $update_2_log 2>&1 && return 7
+
+  echo "check output logs for the expected error messages"
+  cat $update_1_log | grep "not writable by $CVMFS_TEST_USER" || return 8
+  cat $update_2_log | grep "not writable by $CVMFS_TEST_USER" || return 9
+
+  echo "manually start a lazy GeoIP database update as 'root' (should work but not update)"
+  local update_3_log="update_geodb_3.log"
+  sudo cvmfs_server update-geodb -l > $update_3_log 2>&1 || return 10
+
+  echo "manually start a GeoIP database update as 'root' (should work and update)"
+  local update_4_log="update_geodb_4.log"
+  sudo cvmfs_server update-geodb > $update_4_log 2>&1 || return 11
+
+  echo "check output logs for the expected status messages"
+  cat $update_3_log | grep "is up to date"           || return 12
+  cat $update_4_log | grep "Updating GeoIP Database" || return 13
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  local minutes_to_next_hour=$(( 60 - $(date +'%-M') ))
+  if [ $minutes_to_next_hour -lt 3 ]; then
+    echo "Avoiding potential race (only $minutes_to_next_hour minutes left to next full hour)"
+    echo -n "Sleeping for $minutes_to_next_hour minutes..."
+    sleep $(( 60 * $minutes_to_next_hour ))
+    echo "done"
+  fi
+
+  local current_weekday=$(date +%w)
+  local current_hour=$(date +%k)
+  local mindays=3
+  local maxdays=5
+
+  echo "configure the GeoIP database update policy"
+  echo "  (mindays: $mindays | maxdays: $maxdays | weekday: $current_weekday | hour: $current_hour)"
+  echo "CVMFS_UPDATEGEO_MINDAYS=$mindays"     | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 14
+  echo "CVMFS_UPDATEGEO_MAXDAYS=$maxdays"     | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 15
+  echo "CVMFS_UPDATEGEO_DAY=$current_weekday" | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 16
+  echo "CVMFS_UPDATEGEO_HOUR=$current_hour"   | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 17
+  echo
+  echo "$CVMFS_TEST_595_SERVER_HOOKS"
+  cat $CVMFS_TEST_595_SERVER_HOOKS
+  echo
+  CVMFS_TEST_595_SERVER_HOOKS_TOUCHED=1
+
+  local old=$(( $mindays + 1 ))
+  local very_old=$(( $maxdays + 1 ))
+  echo "set mtime of the GeoIP database to $very_old days ago (very old)"
+  sudo touch -d "$very_old days ago" $CVMFS_TEST_595_GEODB || return 18
+
+  echo "do a lazy update as 'root' (should work and force the update)"
+  local update_5_log="update_geodb_5.log"
+  sudo cvmfs_server update-geodb -l > $update_5_log 2>&1 || return 19
+
+  echo "do a lazy update as 'root' (should work but not update again)"
+  local update_6_log="update_geodb_6.log"
+  sudo cvmfs_server update-geodb -l > $update_6_log 2>&1 || return 20
+
+  echo "set mtime of the GeoIP database to $old days ago (old)"
+  sudo touch -d "$old days ago" $CVMFS_TEST_595_GEODB || return 21
+
+  echo "do a lazy update as 'root' (should work and update)"
+  local update_7_log="update_geodb_7.log"
+  sudo cvmfs_server update-geodb -l > $update_7_log 2>&1 || return 22
+
+  echo "check output logs for the expected status messages"
+  cat $update_5_log | grep -e "very old.* Updating"   || return 23
+  cat $update_6_log | grep -e "is up to date"         || return 24
+  cat $update_7_log | grep -e "is expired.* Updating" || return 25
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "set mtime of the GeoIP database to $old days ago (old)"
+  sudo touch -d "$old days ago" $CVMFS_TEST_595_GEODB || return 26
+
+  if [ $current_hour -lt 23 ]; then
+    local next_hour=$(( $current_hour + 1 ))
+    echo "change GeoIP database update policy (hour: $next_hour)"
+    sudo sed -i -e "s/^\(CVMFS_UPDATEGEO_HOUR\)=.*$/\1=$next_hour/" $CVMFS_TEST_595_SERVER_HOOKS || return 27
+
+    echo
+    echo "$CVMFS_TEST_595_SERVER_HOOKS"
+    cat $CVMFS_TEST_595_SERVER_HOOKS
+    echo
+
+    echo "do a lazy update as 'root' (should work but refrain from updating)"
+    local update_8_log="update_geodb_8.log"
+    sudo cvmfs_server update-geodb -l > $update_8_log 2>&1 || return 28
+
+    echo "check output logs for the expected status messages"
+    cat $update_8_log | grep -e "doing nothing right now" || return 29
+  else
+    echo "WARNING: It's nearly midnight cannot easily test the update time slot."
+  fi
+
+  echo "change GeoIP database update policy"
+  local yesterday_weekday=$(( $current_weekday - 1 ))
+  [ $yesterday_weekday -ge 0 ] || yesterday_weekday=0
+  sudo sed -i -e "s/^\(CVMFS_UPDATEGEO_HOUR\)=.*$/\1=$current_hour/"     $CVMFS_TEST_595_SERVER_HOOKS || return 29
+  sudo sed -i -e "s/^\(CVMFS_UPDATEGEO_DAY\)=.*$/\1=$yesterday_weekday/" $CVMFS_TEST_595_SERVER_HOOKS || return 30
+
+  echo
+  echo "$CVMFS_TEST_595_SERVER_HOOKS"
+  cat $CVMFS_TEST_595_SERVER_HOOKS
+  echo
+
+  echo "do a lazy update as 'root' (should work but refrain from updating)"
+  local update_9_log="update_geodb_9.log"
+  sudo cvmfs_server update-geodb -l > $update_9_log 2>&1 || return 28
+
+  echo "check output logs for the expected status messages"
+  cat $update_9_log | grep -e "doing nothing right now" || return 30
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "change ownership of $CVMFS_TEST_595_GEODB to '$CVMFS_TEST_USER'"
+  sudo chown ${CVMFS_TEST_USER}:${CVMFS_TEST_USER} $(dirname $CVMFS_TEST_595_GEODB) || return 31
+  sudo chown ${CVMFS_TEST_USER}:${CVMFS_TEST_USER} $CVMFS_TEST_595_GEODB            || return 32
+
+  echo "try to update the GeoIP database as user '$CVMFS_TEST_USER' (should work and update)"
+  local update_10_log="update_geodb_10.log"
+  cvmfs_server update-geodb > $update_10_log 2>&1 || return 33
+
+  echo "check output logs for the expected status messages"
+  cat $update_10_log | grep -e "Updating GeoIP Database" || return 34
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "removing $CVMFS_TEST_595_SERVER_HOOKS"
+  sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS || return 35
+
+  echo "create a stratum1 snapshot (should find database up to date)"
+  local snapshot_1_log="snapshot_1.log"
+  cvmfs_server snapshot $replica_name > $snapshot_1_log 2>&1 || return 36
+
+  echo "change ownership of $CVMFS_TEST_595_GEODB to 'root'"
+  sudo chown root:root $CVMFS_TEST_595_GEODB || return 37
+
+  echo "create a stratum1 snapshot (should 'fail' due to permissions)"
+  local snapshot_2_log="snapshot_2.log"
+  cvmfs_server snapshot $replica_name > $snapshot_2_log 2>&1 || return 38
+
+  echo "change ownership of $(dirname $CVMFS_TEST_595_GEODB) to 'root'"
+  sudo chown root:root $(dirname $CVMFS_TEST_595_GEODB) || return 39
+
+  echo "create a stratum1 snapshot (should 'fail' due to permissions)"
+  local snapshot_3_log="snapshot_3.log"
+  cvmfs_server snapshot $replica_name > $snapshot_3_log 2>&1 || return 40
+
+  echo "check output logs for the expected status messages"
+  cat $snapshot_1_log | grep -e "is up to date"                                  || return 41
+  cat $snapshot_2_log | grep -e "GeoIP database.*not writable.*$CVMFS_TEST_USER" || return 42
+  cat $snapshot_3_log | grep -e "Directory.*not writable.*$CVMFS_TEST_USER"      || return 43
+
+  return 0
+}
+


### PR DESCRIPTION
This is a followup to yesterday's [pull request](https://github.com/cvmfs/cvmfs/pull/1056). Mainly it adds an integration test to verify the proper updating behaviour of the GeoIP database on Stratum1s. Furthermore it fixes a couple of minor sanity check inconsistencies.

@DrDaveD: Could you have a specific look at [this commit](https://github.com/cvmfs/cvmfs/commit/2964e13ca5d13f1a75412524954170b36e8ad3ba). I needed to remove the `check_apache()` and `check_wsgi_module()` calls from `cvmfs_server snapshot` as they assume root privileges. Do you think, we can survive without checking the proper installation of apache and WSGI on every `snapshot`?