### PR TITLE
FIX: Flaky Test 595

### DIFF
--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -122,7 +122,7 @@ cvmfs_run_test() {
   fi
 
   local current_weekday=$(date +%w)
-  local current_hour=$(date +%k)
+  local current_hour=$(date +%-k)
   local mindays=3
   local maxdays=5
 


### PR DESCRIPTION
`date +%k` returns one-digit hours with a pre-pended whitespace. Sigh...