### PR TITLE
FIX: Sandbox Management in Unittests

### DIFF
--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -603,6 +603,15 @@ string CreateTempDir(const std::string &path_prefix) {
 
 
 /**
+ * Get the current working directory of the running process
+ */
+std::string GetCurrentWorkingDirectory() {
+  char cwd[PATH_MAX];
+  return (getcwd(cwd, sizeof(cwd)) != NULL) ? std::string(cwd) : std::string();
+}
+
+
+/**
  * Helper class that provides callback funtions for the file system traversal.
  */
 class RemoveTreeHelper {

--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -141,6 +141,7 @@ FILE *CreateTempFile(const std::string &path_prefix, const int mode,
                      const char *open_flags, std::string *final_path);
 std::string CreateTempPath(const std::string &path_prefix, const int mode);
 std::string CreateTempDir(const std::string &path_prefix);
+std::string GetCurrentWorkingDirectory();
 int TryLockFile(const std::string &path);
 int LockFile(const std::string &path);
 void UnlockFile(const int filedes);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CVMFS_UNITTEST_FILES
   
   # test utility functions
   testutil.cc testutil.h
+  env.cc env.h
   
   t_atomic.cc
   t_smallhash.cc

--- a/test/unittests/env.cc
+++ b/test/unittests/env.cc
@@ -1,0 +1,55 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "env.h"
+#include "../../cvmfs/util.h"
+
+#include <cerrno>
+#include <string>
+#include <iostream>
+
+
+const size_t CvmfsEnvironment::kMaxPathLength = 255;
+
+
+CvmfsEnvironment::CvmfsEnvironment(const int argc, char **argv) :
+  owns_sandbox_(! CvmfsEnvironment::IsDeathTestExecution(argc, argv)) {}
+
+
+bool CvmfsEnvironment::IsDeathTestExecution(const int argc, char **argv) {
+  const char* death_test_flag="--gtest_internal_run_death_test";
+
+  for (int i = 0; i < argc; ++i) {
+    if (strncmp(argv[i], death_test_flag, strlen(death_test_flag)) == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
+void CvmfsEnvironment::SetUp() {
+  if (owns_sandbox_) {
+    sandbox_ = CreateTempDir("/tmp/cvmfs_ut_sandbox");
+    if (sandbox_.empty()) {
+      std::cerr << "Unittest Setup: Failed to create sandbox directory in /tmp "
+                << " (errno: " << errno << ").";
+      abort();
+    }
+
+    if (chdir(sandbox_.c_str()) != 0) {
+      std::cerr << "Unittest Setup: Failed to chdir() into sandbox directory "
+                << "'" << sandbox_ << "' (errno: " << errno << ").";
+      abort();
+    }
+  }
+}
+
+
+void CvmfsEnvironment::TearDown() {
+  if (owns_sandbox_) {
+    RemoveTree(sandbox_);
+  }
+}

--- a/test/unittests/env.h
+++ b/test/unittests/env.h
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef TEST_UNITTESTS_ENV_H_
+#define TEST_UNITTESTS_ENV_H_
+
+#include <gtest/gtest.h>
+
+/**
+ * This class manages the unit test file system sandbox in /tmp. Unittests that
+ * need to create or interact with files are supposed to do that in the current
+ * working directory.
+ *
+ * Furthermore this class detects if it runs in a re-spawned death test process
+ * and does not re-create a sandbox in that case. Obviously such death test
+ * processes cannot clean up after themselves, leaving behind leaked temp files.
+ */
+class CvmfsEnvironment : public ::testing::Environment {
+ private:
+  static const size_t kMaxPathLength;
+
+ public:
+  CvmfsEnvironment(const int argc, char **argv);
+
+  virtual void SetUp();
+  virtual void TearDown();
+
+ protected:
+  /**
+   * Detects if it is running inside a re-spawned death test process by looking
+   * for gtest's internal command line flag --gtest_internal_run_death_test
+   *
+   * @return true   if it runs inside a death test process
+   */
+  static bool IsDeathTestExecution(const int argc, char **argv);
+
+ private:
+  const bool   owns_sandbox_;
+  std::string  sandbox_;
+};
+
+#endif  /* TEST_UNITTESTS_ENV_H_ */

--- a/test/unittests/main.cc
+++ b/test/unittests/main.cc
@@ -6,8 +6,9 @@
 #include "env.h"
 
 int main(int argc, char **argv) {
+  CvmfsEnvironment* env = new CvmfsEnvironment(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  ::testing::AddGlobalTestEnvironment(new CvmfsEnvironment(argc, argv));
+  ::testing::AddGlobalTestEnvironment(env);
   return RUN_ALL_TESTS();
 }

--- a/test/unittests/main.cc
+++ b/test/unittests/main.cc
@@ -3,9 +3,11 @@
  */
 
 #include <gtest/gtest.h>
+#include "env.h"
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ::testing::AddGlobalTestEnvironment(new CvmfsEnvironment(argc, argv));
   return RUN_ALL_TESTS();
 }

--- a/test/unittests/t_async_reader.cc
+++ b/test/unittests/t_async_reader.cc
@@ -119,7 +119,7 @@ class T_AsyncReader : public FileSandbox {
 
  public:
   T_AsyncReader() :
-    FileSandbox("/tmp/cvmfs_ut_asyncreader") {}
+    FileSandbox("./cvmfs_ut_asyncreader") {}
 
  protected:
   void SetUp() {

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -31,7 +31,7 @@ class T_CacheManager : public ::testing::Test {
   virtual void SetUp() {
     used_fds_ = GetNoUsedFds();
 
-    tmp_path_ = CreateTempDir("/tmp/cvmfs_test");
+    tmp_path_ = CreateTempDir("./cvmfs_ut_cache_manager");
     cache_mgr_ = PosixCacheManager::Create(tmp_path_, false);
     ASSERT_TRUE(cache_mgr_ != NULL);
     alien_cache_mgr_ = PosixCacheManager::Create(tmp_path_, true);

--- a/test/unittests/t_catalog.cc
+++ b/test/unittests/t_catalog.cc
@@ -23,7 +23,7 @@ class T_Catalog : public ::testing::Test {
   virtual void SetUp() {
     catalog = NULL;
     nested = NULL;
-    sandbox = CreateTempDir("/tmp/cvmfs_ut_catalog");
+    sandbox = CreateTempDir("./cvmfs_ut_catalog");
     ASSERT_FALSE(sandbox.empty());
     FileChunk file_chunk;
 

--- a/test/unittests/t_catalog_sql.cc
+++ b/test/unittests/t_catalog_sql.cc
@@ -82,7 +82,7 @@ static void RevertToRevision0(catalog::CatalogDatabase *db) {
 
 TEST_F(T_CatalogSql, SchemaMigration) {
   string path;
-  FILE *ftmp = CreateTempFile("/tmp/cvmfs-test", 0600, "w+", &path);
+  FILE *ftmp = CreateTempFile("./cvmfs_ut_catalog_sql", 0600, "w+", &path);
   ASSERT_TRUE(ftmp != NULL);
   fclose(ftmp);
   UnlinkGuard unlink_guard(path);

--- a/test/unittests/t_dns.cc
+++ b/test/unittests/t_dns.cc
@@ -29,7 +29,7 @@ class T_Dns : public ::testing::Test {
       CaresResolver::Create(true /* ipv4_only */, 1 /* retries */, 2000);
     ASSERT_TRUE(ipv4_resolver);
 
-    fhostfile = CreateTempFile("/tmp/cvmfstest", 0600, "w", &hostfile);
+    fhostfile = CreateTempFile("./cvmfs_ut_dns", 0600, "w", &hostfile);
     ASSERT_TRUE(fhostfile);
     hostfile_resolver = HostfileResolver::Create(hostfile, false);
     ASSERT_TRUE(hostfile_resolver);

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -25,7 +25,7 @@ class T_Download : public ::testing::Test {
   virtual void SetUp() {
     download_mgr.Init(8, false, /* use_system_proxy */
         &statistics);
-    ffoo = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &foo_path);
+    ffoo = CreateTemporaryFile(&foo_path);
     assert(ffoo);
     foo_url = "file://" + foo_path;
   }
@@ -34,6 +34,11 @@ class T_Download : public ::testing::Test {
     download_mgr.Fini();
     fclose(ffoo);
     unlink(foo_path.c_str());
+  }
+
+  FILE *CreateTemporaryFile(std::string *path) const {
+    return CreateTempFile(GetCurrentWorkingDirectory() + "/cvmfs_ut_download",
+                          0600, "w+", path);
   }
 
   perf::Statistics statistics;
@@ -80,7 +85,7 @@ class TestSink : public cvmfs::Sink {
 // A placeholder test for future unit testing of the download module
 TEST_F(T_Download, File) {
   string dest_path;
-  FILE *fdest = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &dest_path);
+  FILE *fdest = CreateTemporaryFile(&dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
 
@@ -94,7 +99,7 @@ TEST_F(T_Download, File) {
 
 TEST_F(T_Download, LocalFile2Mem) {
   string dest_path;
-  FILE *fdest = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &dest_path);
+  FILE *fdest = CreateTemporaryFile(&dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
   char buf = '1';
@@ -112,7 +117,7 @@ TEST_F(T_Download, LocalFile2Mem) {
 
 TEST_F(T_Download, LocalFile2Sink) {
   string dest_path;
-  FILE *fdest = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &dest_path);
+  FILE *fdest = CreateTemporaryFile(&dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
   char buf = '1';

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -25,7 +25,7 @@ class T_Download : public ::testing::Test {
   virtual void SetUp() {
     download_mgr.Init(8, false, /* use_system_proxy */
         &statistics);
-    ffoo = CreateTempFile("/tmp/cvmfstest", 0600, "w+", &foo_path);
+    ffoo = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &foo_path);
     assert(ffoo);
     foo_url = "file://" + foo_path;
   }
@@ -47,7 +47,7 @@ class T_Download : public ::testing::Test {
 class TestSink : public cvmfs::Sink {
  public:
   TestSink() {
-    FILE *f = CreateTempFile("/tmp/cvmfstest", 0600, "w+", &path);
+    FILE *f = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &path);
     assert(f);
     fd = dup(fileno(f));
     assert(f >= 0);
@@ -80,7 +80,7 @@ class TestSink : public cvmfs::Sink {
 // A placeholder test for future unit testing of the download module
 TEST_F(T_Download, File) {
   string dest_path;
-  FILE *fdest = CreateTempFile("/tmp/cvmfstest", 0600, "w+", &dest_path);
+  FILE *fdest = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
 
@@ -94,7 +94,7 @@ TEST_F(T_Download, File) {
 
 TEST_F(T_Download, LocalFile2Mem) {
   string dest_path;
-  FILE *fdest = CreateTempFile("/tmp/cvmfstest", 0600, "w+", &dest_path);
+  FILE *fdest = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
   char buf = '1';
@@ -112,7 +112,7 @@ TEST_F(T_Download, LocalFile2Mem) {
 
 TEST_F(T_Download, LocalFile2Sink) {
   string dest_path;
-  FILE *fdest = CreateTempFile("/tmp/cvmfstest", 0600, "w+", &dest_path);
+  FILE *fdest = CreateTempFile("./cvmfs_ut_download", 0600, "w+", &dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
   char buf = '1';

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -26,7 +26,7 @@ class T_Fetcher : public ::testing::Test {
   virtual void SetUp() {
     used_fds_ = GetNoUsedFds();
 
-    tmp_path_ = CreateTempDir("./cvmfs_ut_fetcher");
+    tmp_path_ = CreateTempDir(GetCurrentWorkingDirectory() + "/cvmfs_ut_fetch");
     // Three source files that can be downloaded
     src_path_ = tmp_path_ + "/data";
     hash_regular_ = shash::Any(shash::kSha1);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -26,7 +26,7 @@ class T_Fetcher : public ::testing::Test {
   virtual void SetUp() {
     used_fds_ = GetNoUsedFds();
 
-    tmp_path_ = CreateTempDir("/tmp/cvmfs_test");
+    tmp_path_ = CreateTempDir("./cvmfs_ut_fetcher");
     // Three source files that can be downloaded
     src_path_ = tmp_path_ + "/data";
     hash_regular_ = shash::Any(shash::kSha1);

--- a/test/unittests/t_file_sandbox.cc
+++ b/test/unittests/t_file_sandbox.cc
@@ -50,7 +50,7 @@ class T_FileSandbox : public FileSandbox {
   }
 };
 
-const std::string T_FileSandbox::sandbox_path = "/tmp/cvmfs_ut_filesandbox";
+const std::string T_FileSandbox::sandbox_path = "./cvmfs_ut_filesandbox";
 
 
 TEST_F(T_FileSandbox, SandboxCreation) {

--- a/test/unittests/t_fs_traversal.cc
+++ b/test/unittests/t_fs_traversal.cc
@@ -129,7 +129,7 @@ class T_FsTraversal : public ::testing::Test {
   typedef std::map<std::string, Checklist> ChecklistMap;
 
  protected:
-  T_FsTraversal() : tmp_path_("/tmp") {}
+  T_FsTraversal() : tmp_path_(".") {}
 
   virtual void SetUp() {
     // create a testbed directory

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -304,7 +304,7 @@ class T_History : public ::testing::Test {
 };
 
 template <class HistoryT>
-const std::string T_History<HistoryT>::sandbox = "/tmp/cvmfs_ut_history";
+const std::string T_History<HistoryT>::sandbox = "./cvmfs_ut_history";
 
 template <class HistoryT>
 const std::string T_History<HistoryT>::fqrn    = "test.cern.ch";

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -29,7 +29,7 @@ class T_Libcvmfs : public ::testing::Test {
     }
 
     cvmfs_set_log_fn(cvmfs_log_ignore);
-    tmp_path_ = CreateTempDir("/tmp/cvmfs_test");
+    tmp_path_ = CreateTempDir("./cvmfs_ut_libcvmfs");
     ASSERT_NE("", tmp_path_);
     opt_cache_ = "quota_limit=0,quota_threshold=0,rebuild_cachedb,"
                  "cache_directory=" + tmp_path_;

--- a/test/unittests/t_manifest.cc
+++ b/test/unittests/t_manifest.cc
@@ -20,7 +20,7 @@ namespace manifest {
 class T_Manifest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    tmp_path_ = CreateTempDir("/tmp/cvmfs-test");
+    tmp_path_ = CreateTempDir("./cvmfs_ut_manifest");
     EXPECT_NE("", tmp_path_);
   }
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -543,7 +543,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
 template <class ObjectFetcherT>
 const std::string T_ObjectFetcher<ObjectFetcherT>::sandbox =
-  "/tmp/cvmfs_ut_object_fetcher";
+  "./cvmfs_ut_object_fetcher";
 
 template <class ObjectFetcherT>
 const std::string T_ObjectFetcher<ObjectFetcherT>::fqrn = "test.cern.ch";

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -543,7 +543,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
 template <class ObjectFetcherT>
 const std::string T_ObjectFetcher<ObjectFetcherT>::sandbox =
-  "./cvmfs_ut_object_fetcher";
+  GetCurrentWorkingDirectory() + "/cvmfs_ut_object_fetcher";
 
 template <class ObjectFetcherT>
 const std::string T_ObjectFetcher<ObjectFetcherT>::fqrn = "test.cern.ch";

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -13,7 +13,7 @@ template <class OptionsT>
 class T_Options : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    FILE *temp_file = CreateTempFile("/tmp/cvmfs-test", 0600, "w",
+    FILE *temp_file = CreateTempFile("./cvmfs_ut_options", 0600, "w",
         &config_file_);
     ASSERT_TRUE(temp_file != NULL);
     unlink_guard_.Set(config_file_);

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -40,7 +40,7 @@ class T_QuotaManager : public ::testing::Test {
     sigpipe_save_ = signal(SIGPIPE, SIG_IGN);
 
     // Prepare cache directories
-    tmp_path_ = CreateTempDir("/tmp/cvmfs_test");
+    tmp_path_ = CreateTempDir("./cvmfs_ut_quota_manager");
     MkdirDeep(tmp_path_ + "/not_spawned", 0700);
     delete cache::PosixCacheManager::Create(tmp_path_, false);
     delete cache::PosixCacheManager::Create(tmp_path_ + "/not_spawned", false);

--- a/test/unittests/t_s3_uploader.cc
+++ b/test/unittests/t_s3_uploader.cc
@@ -518,7 +518,7 @@ class T_S3Uploader : public FileSandbox {
 };
 atomic_int64 T_S3Uploader::gSeed = 0;
 
-const std::string T_S3Uploader::sandbox_path = "/tmp/cvmfs_ut_s3uploader";
+const std::string T_S3Uploader::sandbox_path = "./cvmfs_ut_s3uploader";
 const std::string T_S3Uploader::tmp_dir =
   T_S3Uploader::sandbox_path + "/tmp";
 const std::string T_S3Uploader::dest_dir = T_S3Uploader::sandbox_path + "/dest";

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -134,7 +134,7 @@ class T_SQLite_Wrapper : public ::testing::Test {
   }
 };
 
-const std::string T_SQLite_Wrapper::sandbox = "/tmp/cvmfs_ut_sqlite_wrapper";
+const std::string T_SQLite_Wrapper::sandbox = "./cvmfs_ut_sqlite_wrapper";
 
 
 TEST_F(T_SQLite_Wrapper, Initialize) {}

--- a/test/unittests/t_tracer.cc
+++ b/test/unittests/t_tracer.cc
@@ -19,7 +19,7 @@ namespace tracer {
 class T_Tracer : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    trace_file_ = CreateTempPath("/tmp/cvmfs-test", 0600);
+    trace_file_ = CreateTempPath("./cvmfs_ut_tracer", 0600);
     EXPECT_NE("", trace_file_);
   }
 

--- a/test/unittests/t_uid_map.cc
+++ b/test/unittests/t_uid_map.cc
@@ -95,7 +95,7 @@ class T_UidMap : public ::testing::Test {
 };
 
 template <typename MapT>
-const std::string T_UidMap<MapT>::sandbox = "/tmp/cvmfs_ut_uid_map";
+const std::string T_UidMap<MapT>::sandbox = "./cvmfs_ut_uid_map";
 
 typedef ::testing::Types<
   UidMap,

--- a/test/unittests/t_unlink_guard.cc
+++ b/test/unittests/t_unlink_guard.cc
@@ -42,7 +42,7 @@ class T_UnlinkGuard : public ::testing::Test {
   }
 };
 
-const std::string T_UnlinkGuard::sandbox = "/tmp/cvmfs_ut_unlink_guard";
+const std::string T_UnlinkGuard::sandbox = "./cvmfs_ut_unlink_guard";
 
 
 TEST_F(T_UnlinkGuard, Initialize) {}

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -580,8 +580,7 @@ template <class UploadersT>
 atomic_int64 T_Uploaders<UploadersT>::gSeed = 0;
 
 template <class UploadersT>
-const std::string T_Uploaders<UploadersT>::sandbox_path =
-    "/tmp/cvmfs_ut_uploaders";
+const std::string T_Uploaders<UploadersT>::sandbox_path = "./cvmfs_ut_uploader";
 
 template <class UploadersT>
 const std::string T_Uploaders<UploadersT>::tmp_dir =

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -48,7 +48,7 @@ class T_Util : public ::testing::Test {
     path_without_slash = "/my/path";
     fake_path = "mypath";
     to_write = "Hello, world!\n";
-    sandbox = CreateTempDir("./cvmfs_ut_testutil");
+    sandbox = CreateTempDir(GetCurrentWorkingDirectory() + "/cvmfs_ut_util");
     socket_address = sandbox + "/mysocket";
     long_path = sandbox +
         "/path_path_path_path_path_path_path_path_path_path_path_path_path_"

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -48,7 +48,7 @@ class T_Util : public ::testing::Test {
     path_without_slash = "/my/path";
     fake_path = "mypath";
     to_write = "Hello, world!\n";
-    sandbox = CreateTempDir("/tmp/testutil");
+    sandbox = CreateTempDir("./cvmfs_ut_testutil");
     socket_address = sandbox + "/mysocket";
     long_path = sandbox +
         "/path_path_path_path_path_path_path_path_path_path_path_path_path_"

--- a/test/unittests/t_uuid.cc
+++ b/test/unittests/t_uuid.cc
@@ -24,7 +24,7 @@ TEST(T_Uuid, Unique) {
 
 TEST(T_Uuid, Create) {
   string path;
-  FILE *f = CreateTempFile("/tmp/cvmfstest", 0600, "w", &path);
+  FILE *f = CreateTempFile("./cvmfs_ut_uuid", 0600, "w", &path);
   ASSERT_TRUE(f != NULL);
   fclose(f);
   unlink(path.c_str());
@@ -44,7 +44,7 @@ TEST(T_Uuid, Create) {
 
 TEST(T_Uuid, FromCache) {
   string path;
-  FILE *f = CreateTempFile("/tmp/cvmfstest", 0600, "w", &path);
+  FILE *f = CreateTempFile("./cvmfs_ut_uuid", 0600, "w", &path);
   ASSERT_TRUE(f != NULL);
   fprintf(f, "unique");
   fclose(f);
@@ -62,7 +62,7 @@ TEST(T_Uuid, FailWrite) {
 
 TEST(T_Uuid, FailRead) {
   string path;
-  FILE *f = CreateTempFile("/tmp/cvmfstest", 0600, "w", &path);
+  FILE *f = CreateTempFile("./cvmfs_ut_uuid", 0600, "w", &path);
   ASSERT_TRUE(f != NULL);
   fclose(f);
   UnlinkGuard unlink_guard(path);

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -47,7 +47,7 @@ TEST_F(T_Xattr, CreateFromFile) {
 
   // Create extended attributes
   string tmp_path;
-  FILE *f = CreateTempFile("/tmp/cvmfs_ut_xattr", 0600, "w", &tmp_path);
+  FILE *f = CreateTempFile("./cvmfs_ut_xattr", 0600, "w", &tmp_path);
   ASSERT_TRUE(f != NULL);
   fclose(f);
   UnlinkGuard unlink_guard(tmp_path);

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -75,8 +75,8 @@ class PolymorphicConstructionUnittestAdapter {
 //------------------------------------------------------------------------------
 
 
-static const char* g_sandbox_path    = "/tmp/cvmfs_mockuploader";
-static const char* g_sandbox_tmp_dir = "/tmp/cvmfs_mockuploader/tmp";
+static const char* g_sandbox_path    = "./cvmfs_mockuploader";
+static const char* g_sandbox_tmp_dir = "./cvmfs_mockuploader/tmp";
 static inline upload::SpoolerDefinition MockSpoolerDefinition() {
   const size_t      min_chunk_size   = 512000;
   const size_t      avg_chunk_size   = 2 * min_chunk_size;


### PR DESCRIPTION
Turns out, that gtest cannot properly handle the tear down of death tests when they are run in *threadsafe* mode. Threadsafe mode means, that the `cvmfs_unittests` binary is `fork()/exec()`'ed with extra parameters for each death test. `Fixture::SetUp()` is called again for the death test execution (potentially recreating temporary files) but since the process will die later on `Fixture::TearDown()` is never called. Therefore, unit tests potentially leave behind some temporary files.

I've introduced a `CvmfsEnvironment` class that hooks into the global setup and tear down of the gtest environment. It manages a sandbox directory in `/tmp` that is supposed to be used as container by test cases requiring temporary files. The `CvmfsEnvironment` detects if it is run as a death test and does not re-create the sandbox directory but simply re-uses it. I am exploiting the fact, that gtest makes sure that the *current working directory* for the child process is the same as for the parent.

From now on, all tests requiring temporary files should create them in the current working directory rather than `/tmp/...`, this way they are contained inside the sandbox and are cleaned up when `cvmfs_unittests` terminates by `CvmfsEnvironment`.