### PR TITLE
FIX: Temp File Leakage in test_functions

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3506,7 +3506,7 @@ check() {
         check_integrity=1
       ;;
       t)
-        tag="-t $OPTARG"
+        tag="-n $OPTARG"
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -3549,7 +3549,11 @@ check() {
   [ $check_chunks -ne 0 ]      && check_chunks_param="-c"
 
   echo "Verifying Catalog Integrity of $name ..."
-  __swissknife check $tag $check_chunks_param $log_level_param -r $stratum0
+  __swissknife check $tag                \
+                     $check_chunks_param \
+                     $log_level_param    \
+                     -r $stratum0        \
+                     -t ${CVMFS_SPOOL_DIR}/tmp
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3366,6 +3366,7 @@ tag() {
   # sanity checks
   check_repository_existence $name || die "The repository $name does not exist"
   load_repo_config $name
+  is_owner_or_root $name           || die "Permission denied: Repository $name is owned by $CVMFS_USER"
   is_stratum0 $name                || die "This is not a stratum 0 repository"
   ! is_publishing $name            || die "Repository is currently publishing"
   health_check $name $silence_warnings
@@ -3409,7 +3410,6 @@ tag() {
   # all following commands need an open repository transaction and are supposed
   # to commit or abort it after performing a tag database manipulation. Hence,
   # they also need to performed by the repository owner or root
-  is_owner_or_root $name                    || die "Permission denied: Repository $name is owned by $CVMFS_USER"
   [ ! -z "$tag_name" -o ! -z "$tag_names" ] || die "Tag name missing"
   echo "$tag_name" | grep -q -v " "         || die "Spaces are not allowed in tag names"
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3559,11 +3559,14 @@ check() {
   [ $check_chunks -ne 0 ]      && check_chunks_param="-c"
 
   echo "Verifying Catalog Integrity of $name ..."
-  __swissknife check $tag                \
-                     $check_chunks_param \
-                     $log_level_param    \
-                     -r $stratum0        \
-                     -t ${CVMFS_SPOOL_DIR}/tmp
+  local user_shell="$(get_user_shell $name)"
+  local check_cmd
+  check_cmd="$(__swissknife_cmd dbg) check $tag  \
+                     $check_chunks_param         \
+                     $log_level_param            \
+                     -r $stratum0                \
+                     -t ${CVMFS_SPOOL_DIR}/tmp"
+  $user_shell "$check_cmd"
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3236,7 +3236,7 @@ list_catalogs() {
   # do it!
   local user_shell="$(get_user_shell $name)"
   local lsrepo_cmd
-  lsrepo_cmd="$(__swissknife_cmd) lsrepo         \
+  lsrepo_cmd="$(__swissknife_cmd dbg) lsrepo     \
                        -r $CVMFS_STRATUM0        \
                        -n $CVMFS_REPOSITORY_NAME \
                        -k $CVMFS_PUBLIC_KEY      \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3522,10 +3522,13 @@ check() {
 
   # sanity checks
   check_repository_existence $name || die "The repository $name does not exist"
-  health_check $name
 
   # get repository information
   load_repo_config $name
+
+  # more sanity checks
+  is_owner_or_root $name || die "Permission denied: Repository $name is owned by $CVMFS_USER"
+  health_check $name
 
   # check if repository is compatible to the installed CernVM-FS version
   check_repository_compatibility

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3222,20 +3222,27 @@ list_catalogs() {
 
   # sanity checks
   check_repository_existence $name || die "The repository $name does not exist"
-  health_check $name $silence_warnings
 
   # get repository information
   load_repo_config $name
+
+  # more sanity checks
+  is_owner_or_root $name || die "Permission denied: Repository $name is owned by $CVMFS_USER"
+  health_check $name $silence_warnings
 
   # check if repository is compatible to the installed CernVM-FS version
   check_repository_compatibility
 
   # do it!
-  __swissknife lsrepo         \
-    -r $CVMFS_STRATUM0        \
-    -n $CVMFS_REPOSITORY_NAME \
-    -k $CVMFS_PUBLIC_KEY      \
-    $param_list
+  local user_shell="$(get_user_shell $name)"
+  local lsrepo_cmd
+  lsrepo_cmd="$(__swissknife_cmd) lsrepo         \
+                       -r $CVMFS_STRATUM0        \
+                       -n $CVMFS_REPOSITORY_NAME \
+                       -k $CVMFS_PUBLIC_KEY      \
+                       -l ${CVMFS_SPOOL_DIR}/tmp \
+                       $param_list"
+  $user_shell "$lsrepo_cmd"
 }
 
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -401,7 +401,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
 
 string CommandCheck::DownloadPiece(const shash::Any catalog_hash) {
   string source = "data/" + catalog_hash.MakePath();
-  const string dest = "/tmp/" + catalog_hash.ToString();
+  const string dest = temp_directory_ + "/" + catalog_hash.ToString();
   const string url = *remote_repository + "/" + source;
   download::JobInfo download_catalog(&url, true, false, &dest, &catalog_hash);
   download::Failures retval = g_download_manager->Fetch(&download_catalog);
@@ -417,7 +417,7 @@ string CommandCheck::DownloadPiece(const shash::Any catalog_hash) {
 
 string CommandCheck::DecompressPiece(const shash::Any catalog_hash) {
   string source = "data/" + catalog_hash.MakePath();
-  const string dest = "/tmp/" + catalog_hash.ToString();
+  const string dest = temp_directory_ + "/" + catalog_hash.ToString();
   if (!zlib::DecompressPath2Path(source, dest))
     return "";
 
@@ -570,8 +570,11 @@ bool CommandCheck::InspectTree(const string &path,
 int CommandCheck::Main(const swissknife::ArgumentList &args) {
   string tag_name;
   check_chunks = false;
-  if (args.find('t') != args.end())
-    tag_name = *args.find('t')->second;
+
+  temp_directory_ = (args.find('t') != args.end()) ? *args.find('t')->second
+                                                   : "/tmp";
+  if (args.find('n') != args.end())
+    tag_name = *args.find('n')->second;
   if (args.find('c') != args.end())
     check_chunks = true;
   if (args.find('l') != args.end()) {

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -29,7 +29,8 @@ class CommandCheck : public Command {
   ParameterList GetParams() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('r', "repository directory / url"));
-    r.push_back(Parameter::Optional('t', "check specific repository tag"));
+    r.push_back(Parameter::Optional('n', "check specific repository tag"));
+    r.push_back(Parameter::Optional('t', "temporary directory (default: /tmp)"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Switch('c', "check availability of data chunks"));
     return r;
@@ -54,6 +55,9 @@ class CommandCheck : public Command {
                       const catalog::DirectoryEntry &b,
                       const bool compare_names,
                       const bool is_transition_point = false);
+
+ private:
+  std::string temp_directory_;
 };
 
 }  // namespace swissknife

--- a/test/test_functions
+++ b/test/test_functions
@@ -769,7 +769,7 @@ check_catalog_presence() {
   local catalog_path=$1
   local repo_name=$2
 
-  cvmfs_server list-catalogs -x $repo_name | grep -x -q $catalog_path
+  cvmfs_server list-catalogs -x $repo_name | grep -x $catalog_path > /dev/null 2>&1
   return $?
 }
 


### PR DESCRIPTION
Funny insight: `my_program | grep -q needle` searches for the first occurrence of *needle* in the output stream of `my_program`. As soon as it found something, `grep` is exiting with return code 0, invalidating the pipe that is attached to `my_program's` stdout. This causes `my_program` to crash (most likely with SIGPIPE).

Unfortunately `cvmfs_swissknife lsrepo` cannot cleanup after himself in that case and leaves some temporary files behind. 

Note: This is based on [FIX: Consistent Usage of Temporary Directories](https://github.com/cvmfs/cvmfs/pull/1071).