### PR TITLE
FIX: Unittest Sandboxing

### DIFF
--- a/test/unittests/env.cc
+++ b/test/unittests/env.cc
@@ -5,8 +5,13 @@
 #include "env.h"
 #include "../../cvmfs/util.h"
 
+#include <cassert>
 #include <cerrno>
+#include <cstdlib>
+
+#include <fstream>
 #include <string>
+#include <sstream>
 #include <iostream>
 
 
@@ -14,7 +19,7 @@ const size_t CvmfsEnvironment::kMaxPathLength = 255;
 
 
 CvmfsEnvironment::CvmfsEnvironment(const int argc, char **argv) :
-  owns_sandbox_(! CvmfsEnvironment::IsDeathTestExecution(argc, argv)) {}
+  is_death_test_execution_(CvmfsEnvironment::IsDeathTestExecution(argc, argv)) {}
 
 
 bool CvmfsEnvironment::IsDeathTestExecution(const int argc, char **argv) {
@@ -31,25 +36,127 @@ bool CvmfsEnvironment::IsDeathTestExecution(const int argc, char **argv) {
 
 
 void CvmfsEnvironment::SetUp() {
-  if (owns_sandbox_) {
-    sandbox_ = CreateTempDir("/tmp/cvmfs_ut_sandbox");
-    if (sandbox_.empty()) {
-      std::cerr << "Unittest Setup: Failed to create sandbox directory in /tmp "
-                << " (errno: " << errno << ").";
-      abort();
-    }
+  assert(sandbox_.empty());
+  assert(sandbox_pointer_.empty());
 
-    if (chdir(sandbox_.c_str()) != 0) {
-      std::cerr << "Unittest Setup: Failed to chdir() into sandbox directory "
-                << "'" << sandbox_ << "' (errno: " << errno << ").";
-      abort();
-    }
+  if (! is_death_test_execution_) {
+    CreateSandbox();
+  } else {
+    AdoptSandboxFromParent();
   }
+
+  assert(!sandbox_.empty());
+  assert(!sandbox_pointer_.empty());
+
+  ChangeDirectoryToSandbox();
+  assert(GetCurrentWorkingDirectory() == sandbox_);
 }
 
 
 void CvmfsEnvironment::TearDown() {
-  if (owns_sandbox_) {
-    RemoveTree(sandbox_);
+  if (! is_death_test_execution_) {
+    RemoveSandbox();
+  }
+}
+
+
+std::string CvmfsEnvironment::GetSandboxPointerPath(const pid_t pid) const {
+  std::stringstream ss;
+  ss << "/tmp/cvmfs_ut_sandbox.pid." << pid;
+  return ss.str();
+}
+
+
+void CvmfsEnvironment::CreateSandbox() {
+  assert(sandbox_.empty());
+
+  // create sandbox directory
+  const std::string sandbox = CreateTempDir("/tmp/cvmfs_ut_sandbox");
+  if (sandbox.empty()) {
+    std::cerr << "Unittest Setup: Failed to create sandbox directory in /tmp "
+              << " (errno: " << errno << ")."
+              << std::endl;
+    abort();
+  }
+  sandbox_ = sandbox;
+
+  // create sandbox pointer file next to sandbox directory
+  const std::string sandbox_pointer_path = GetSandboxPointerPath(getpid());
+  std::ofstream sandbox_pointer;
+  sandbox_pointer.open(sandbox_pointer_path.c_str(),
+                       std::ios::out | std::ios::trunc);
+  if (!sandbox_pointer.is_open()) {
+    std::cerr << "Unittest Setup: Failed to create sandbox pointer file "
+              << "'" << sandbox_pointer_path << "' (errno: " << errno << ")."
+              << std::endl;
+    abort();
+  }
+
+  sandbox_pointer << sandbox_ << std::endl;
+  sandbox_pointer.close();
+  sandbox_pointer_ = sandbox_pointer_path;
+}
+
+
+void CvmfsEnvironment::AdoptSandboxFromParent() {
+  assert(sandbox_.empty());
+  assert(sandbox_pointer_.empty());
+
+  const std::string sandbox_pointer_path = GetSandboxPointerPath(getppid());
+  if (! FileExists(sandbox_pointer_path)) {
+    std::cerr << "Unittest Setup: Failed to find sandbox pointer file "
+              << "'" << sandbox_pointer_path << "' of parent process."
+              << std::endl;
+    abort();
+  }
+
+  std::ifstream sandbox_pointer;
+  sandbox_pointer.open(sandbox_pointer_path.c_str());
+  if (!sandbox_pointer.is_open()) {
+    std::cerr << "Unittest Setup: Failed to open sandbox pointer file "
+              << "'" << sandbox_pointer_path << "' (errno: " << errno << ")."
+              << std::endl;
+    abort();
+  }
+
+  char path[256] = { '\0' };
+  sandbox_pointer.getline(path, sizeof(path));
+  if (sandbox_pointer.fail() || sandbox_pointer.bad() || strlen(path) == 0) {
+    std::cerr << "Unittest Setup: Failed to read sandbox pointer file "
+              << "'" << sandbox_pointer_path << "' (errno: " << errno << ")."
+              << std::endl;
+    abort();
+  }
+
+  if (!DirectoryExists(path)) {
+    std::cerr << "Unittest Setup: Failed to find sandbox directory "
+              << "'" << path << "' pointed to by "
+              << "'" << sandbox_pointer_path << "'"
+              << std::endl;
+    abort();
+  }
+
+  sandbox_pointer_ = sandbox_pointer_path;
+  sandbox_         = path;
+}
+
+
+void CvmfsEnvironment::RemoveSandbox() {
+  assert (!sandbox_.empty());
+  assert (!sandbox_pointer_.empty());
+
+  unlink (sandbox_pointer_.c_str());
+  RemoveTree(sandbox_);
+}
+
+
+void CvmfsEnvironment::ChangeDirectoryToSandbox() const {
+  assert(!sandbox_.empty());
+
+  if (chdir(sandbox_.c_str()) != 0) {
+    std::cerr << "Unittest Setup: Failed to chdir() into sandbox directory "
+              << "'" << sandbox_ << "' (errno: " << errno << ")."
+              << std::endl;
+    abort();
   }
 }

--- a/test/unittests/env.h
+++ b/test/unittests/env.h
@@ -36,8 +36,18 @@ class CvmfsEnvironment : public ::testing::Environment {
   static bool IsDeathTestExecution(const int argc, char **argv);
 
  private:
-  const bool   owns_sandbox_;
+  std::string GetSandboxPointerPath(const pid_t pid) const;
+  void ChangeDirectoryToSandbox() const;
+
+  void CreateSandbox();
+  void AdoptSandboxFromParent();
+
+  void RemoveSandbox();
+
+ private:
+  const bool   is_death_test_execution_;
   std::string  sandbox_;
+  std::string  sandbox_pointer_;
 };
 
 #endif  /* TEST_UNITTESTS_ENV_H_ */

--- a/test/unittests/env.h
+++ b/test/unittests/env.h
@@ -10,11 +10,14 @@
 /**
  * This class manages the unit test file system sandbox in /tmp. Unittests that
  * need to create or interact with files are supposed to do that in the current
- * working directory.
+ * working directory. It creates a pointer file to advertise the created sand-
+ * box to child processes spawned to run death tests.
  *
  * Furthermore this class detects if it runs in a re-spawned death test process
  * and does not re-create a sandbox in that case. Obviously such death test
  * processes cannot clean up after themselves, leaving behind leaked temp files.
+ * In such cases the pointer file of the parent process is read and its sandbox
+ * directory is re-used.
  */
 class CvmfsEnvironment : public ::testing::Environment {
  private:

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1073,7 +1073,7 @@ TEST_F(T_Util, Shell) {
   char *buffer = static_cast<char*>(scalloc(buffer_size, sizeof(char)));
 
   EXPECT_TRUE(Shell(&fd_stdin, &fd_stdout, &fd_stderr));
-  string path = sandbox + "/" + "newfolder";
+  string path = sandbox + "/newfolder";
   string command = "mkdir -p " + path +  " && cd " + path + " && pwd\n";
   WritePipe(fd_stdin, command.c_str(), command.length());
   ReadPipe(fd_stdout, buffer, path.length());


### PR DESCRIPTION
This fixes [yesterday's pull request](https://github.com/cvmfs/cvmfs/pull/1069) that tried to exploit GTest's feature to switch to the working directory of the parent process when spawning child processes for death tests. Unfortunately this doesn't work, because GTest determines this working directory before even `main()` is running in the parent process. Hence, death tests would not properly switch to the sandbox directory and start littering in the wrong location.

This fixes `CvmfsEnvironment` which now drops a file like **/tmp/cvmfs_ut_sandbox.pid.$PID** which can be found by the child processes using `getppid()`. The file contains the full path of the sandbox directory created by the main GTest process. This way we can actively switch to the sandbox before the death test is running.