### PR TITLE
FIX: T_Libcvmfs Poisons Working Directory for Other Tests

### DIFF
--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -28,6 +28,8 @@ class T_Libcvmfs : public ::testing::Test {
       first_test = false;
     }
 
+    previous_working_directory_ = GetCurrentWorkingDirectory();
+
     cvmfs_set_log_fn(cvmfs_log_ignore);
     tmp_path_ = CreateTempDir("./cvmfs_ut_libcvmfs");
     ASSERT_NE("", tmp_path_);
@@ -44,6 +46,8 @@ class T_Libcvmfs : public ::testing::Test {
     if (tmp_path_ != "")
       RemoveTree(tmp_path_);
     cvmfs_set_log_fn(NULL);
+
+    EXPECT_EQ(0, chdir(previous_working_directory_.c_str()));
   }
 
   // Other tests might have initialized sqlite3.  This cannot happen in real
@@ -52,6 +56,12 @@ class T_Libcvmfs : public ::testing::Test {
   // within the library can still be tested in the tests following the first
   // one.
   static bool first_test;
+
+  // Libcvmfs chdir()s internally. This must be reverted since the unit tests
+  // depend on the binary's working directory for sandboxing temporary files.
+  // We note the working directory before executing any test code and chdir()
+  // back to it in the test's TearDown().
+  string previous_working_directory_;
 
   string tmp_path_;
   string alien_path_;


### PR DESCRIPTION
I guess Libcvmfs is using `chdir()` internally. Since the tmp file sandboxing depends on the working directory of the `cvmfs_unittests` process to be in a certain place, this poisons the execution environments of the following tests. In particular `T_Util.MakeSocket` and friends, as they depend on short paths. 