### PR TITLE
Refactor: Use Environment Variable for Test Sandbox

### DIFF
--- a/test/unittests/env.h
+++ b/test/unittests/env.h
@@ -23,7 +23,7 @@
  */
 class CvmfsEnvironment : public ::testing::Environment {
  private:
-  static const size_t kMaxPathLength;
+  static const char* kSandboxEnvVariable;
 
  public:
   CvmfsEnvironment(const int argc, char **argv);
@@ -41,7 +41,6 @@ class CvmfsEnvironment : public ::testing::Environment {
   static bool IsDeathTestExecution(const int argc, char **argv);
 
  private:
-  std::string GetSandboxPointerPath(const pid_t pid) const;
   void ChangeDirectoryToSandbox() const;
 
   void CreateSandbox();
@@ -52,7 +51,6 @@ class CvmfsEnvironment : public ::testing::Environment {
  private:
   const bool   is_death_test_execution_;
   std::string  sandbox_;
-  std::string  sandbox_pointer_;
 };
 
 #endif  /* TEST_UNITTESTS_ENV_H_ */


### PR DESCRIPTION
As [proposed](https://github.com/cvmfs/cvmfs/pull/1073#issuecomment-134540065) by @jblomer, I've replaced the sandbox pointer file with an environment variable set but the parent and read by the death test children processes. That safes quite a bit of boilerplate and should be safer than the PID-file.