### PR TITLE
CI: Use rpmbuild --target instead of Default Architecture

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -39,6 +39,13 @@ get_package_type() {
   return 1
 }
 
+get_default_compiler_arch() {
+  local compiler=""
+  which gcc   > /dev/null 2>&1 && compiler="gcc"
+  which clang > /dev/null 2>&1 && compiler="clang"
+  [ ! -z $compiler ] && $compiler -dumpmachine | grep -ohe '^[^-]\+'
+}
+
 get_cvmfs_version_from_cmake() {
   local source_directory="$1"
   cat ${source_directory}/CMakeLists.txt | grep '## CVMFS_VERSION' | awk '{print $3}'

--- a/ci/cvmfs/rpm.sh
+++ b/ci/cvmfs/rpm.sh
@@ -69,9 +69,11 @@ else
 fi
 
 if [ x"$CVMFS_BUILD_ARCH" = x"native" ]; then
-  echo "building..."
+  default_arch="$(get_default_compiler_arch)"
+  echo "building ($default_arch)..."
   rpmbuild --define="_topdir $CVMFS_RESULT_LOCATION"        \
            --define="_tmppath ${CVMFS_RESULT_LOCATION}/TMP" \
+           --target="$default_arch"                         \
            -ba $spec_file
 else
   if [ $(id -u) -eq 0 ]; then


### PR DESCRIPTION
Turns out that `rpmbuild` retrieves its default architecture from the running kernel (like: `uname -m`) which is wrong inside 32bit docker containers. This explicitly passes `rpmbuild --target=...` and retrieves the architecture from GCC's default (`gcc -dumpmachine`).