### PR TITLE
FIX: SLC5 32bit Dockerfile Refers to Wrong Tarball

### DIFF
--- a/ci/docker/slc5_i386/Dockerfile
+++ b/ci/docker/slc5_i386/Dockerfile
@@ -1,7 +1,7 @@
 FROM        scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
-ADD         slc5_x86.tar.gz /
+ADD         slc5_i386.tar.gz /
 RUN         yum -y update && yum -y install                     \
                                         autofs                  \
                                         buildsys-macros         \


### PR DESCRIPTION
Generated tarball for SLC5 32bit is `slc5_i386.tar.gz`. Fixing that in the `Dockerfile`.