### PR TITLE
CI: Remove Unnecessary Packages from Docker Images

### DIFF
--- a/ci/docker/cc7_x86_64/Dockerfile
+++ b/ci/docker/cc7_x86_64/Dockerfile
@@ -3,35 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         cc7_x86_64.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        attr                    \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        doxygen                 \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
-                                        glibc.i686              \
-                                        graphviz                \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
                                         policycoreutils-python  \
-                                        psmisc                  \
                                         python-devel            \
                                         rpm-build               \
-                                        screen                  \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/fedora20_i386/Dockerfile
+++ b/ci/docker/fedora20_i386/Dockerfile
@@ -3,31 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora20_i386.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         policycoreutils-python  \
                                         python-devel            \
                                         rpm-build               \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
-                                        sudo                    \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/fedora20_x86_64/Dockerfile
+++ b/ci/docker/fedora20_x86_64/Dockerfile
@@ -3,31 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora20_x86_64.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         policycoreutils-python  \
                                         python-devel            \
                                         rpm-build               \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
-                                        sudo                    \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/fedora21_i386/Dockerfile
+++ b/ci/docker/fedora21_i386/Dockerfile
@@ -3,31 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora21_i386.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         policycoreutils-python  \
                                         python-devel            \
                                         rpm-build               \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
-                                        sudo                    \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/fedora21_x86_64/Dockerfile
+++ b/ci/docker/fedora21_x86_64/Dockerfile
@@ -3,31 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora21_x86_64.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         policycoreutils-python  \
                                         python-devel            \
                                         rpm-build               \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
-                                        sudo                    \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/slc4_i386/Dockerfile
+++ b/ci/docker/slc4_i386/Dockerfile
@@ -20,14 +20,11 @@ ADD        sl4x-epel.repo     /etc/yum.repos.d/
 ADD        sl4x-fastbugs.repo /etc/yum.repos.d/
 
 RUN        yum -y update && yum -y install                      \
-                                        attr                    \
-                                        autofs                  \
                                         bash                    \
                                         checkpolicy             \
                                         chkconfig               \
                                         cmake                   \
                                         coreutils               \
-                                        curl                    \
                                         e2fsprogs               \
                                         e2fsprogs-devel         \
                                         fuse-devel              \
@@ -35,12 +32,10 @@ RUN        yum -y update && yum -y install                      \
                                         gawk                    \
                                         gcc4                    \
                                         gcc4-c++                \
-                                        gdb                     \
                                         git                     \
                                         glibc-common            \
                                         grep                    \
                                         gzip                    \
-                                        httpd                   \
                                         initscripts             \
                                         libattr-devel           \
                                         make                    \
@@ -49,13 +44,11 @@ RUN        yum -y update && yum -y install                      \
                                         patch                   \
                                         perl                    \
                                         pkgconfig               \
-                                        psmisc                  \
                                         python-devel            \
                                         rpm-build               \
                                         sed                     \
                                         selinux-policy-targeted \
                                         shadow-utils            \
-                                        sudo                    \
                                         SysVinit                \
                                         unzip                   \
                                         which                   \

--- a/ci/docker/slc5_i386/Dockerfile
+++ b/ci/docker/slc5_i386/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc5_i386.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         buildsys-macros         \
                                         cmake                   \
                                         curl-devel              \
@@ -11,25 +10,19 @@ RUN         yum -y update && yum -y install                     \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         make                    \
-                                        mock                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         python-devel            \
                                         rpm-build               \
-                                        screen                  \
                                         SysVinit                \
-                                        tree                    \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
+                                        which                   \
                                         zlib-devel
 
-RUN         useradd sftnight && usermod -a -G mock sftnight
+RUN         useradd sftnight
 USER        sftnight
 WORKDIR     /home/sftnight

--- a/ci/docker/slc5_x86_64/Dockerfile
+++ b/ci/docker/slc5_x86_64/Dockerfile
@@ -3,31 +3,23 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc5_x86_64.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         buildsys-macros         \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         make                    \
-                                        mock                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         python-devel            \
                                         rpm-build               \
-                                        screen                  \
                                         SysVinit                \
-                                        tree                    \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight && usermod -a -G mock sftnight

--- a/ci/docker/slc6_i386/Dockerfile
+++ b/ci/docker/slc6_i386/Dockerfile
@@ -3,31 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc6_i386.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         policycoreutils-python  \
                                         python-devel            \
                                         rpm-build               \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
-                                        sudo                    \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/slc6_x86_64/Dockerfile
+++ b/ci/docker/slc6_x86_64/Dockerfile
@@ -3,31 +3,24 @@ MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc6_x86_64.tar.gz /
 RUN         yum -y update && yum -y install                     \
-                                        autofs                  \
                                         cmake                   \
                                         curl-devel              \
-                                        fuse                    \
                                         fuse-devel              \
                                         gcc                     \
                                         gcc-c++                 \
-                                        gdb                     \
                                         git                     \
                                         hardlink                \
-                                        httpd                   \
                                         libattr-devel           \
                                         libuuid-devel           \
                                         make                    \
-                                        nfs-utils               \
                                         openssl-devel           \
-                                        perl-IO-Interface       \
                                         policycoreutils-python  \
                                         python-devel            \
                                         rpm-build               \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
-                                        sudo                    \
                                         sysvinit-tools          \
-                                        tree                    \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight


### PR DESCRIPTION
This removes a bunch of packages from the build docker images that are not necessary for building. This is both to save space and to speed up the build process of the images. Note: This is somewhat a blue shot, I hope I didn't remove too much. :-) We'll see.