### PR TITLE
Statistics collector fix

### DIFF
--- a/python/parser.py
+++ b/python/parser.py
@@ -78,10 +78,8 @@ class Parser:
         csv.write(";origin;external\n")
         for key in parser1.counters:
             csv.write(parser1.counters[key].name + ";" +
-                      str(parser1.counters[key].avg())
-                      + ";" +
-                      str(parser2.counters[key].avg())
-                      + "\n")
+                      str(parser1.counters[key].avg()) + ";" +
+                      str(parser2.counters[key].avg()) + "\n")
         csv.close()
 
     @staticmethod

--- a/python/parser.py
+++ b/python/parser.py
@@ -70,7 +70,8 @@ class Parser:
         repository_names = sorted(parser_list1)
         csv = open(filename, "w")
         for repository_name in repository_names:
-            csv.write(";" + repository_name + ";")
+            pos = repository_name.rfind("/") + 1
+            csv.write(";" + repository_name[pos:] + ";")
         csv.write("\n")
         for i in range(0, len(parser_list1)):
             csv.write(";origin;external")

--- a/python/parser.py
+++ b/python/parser.py
@@ -75,11 +75,13 @@ class Parser:
     @staticmethod
     def to_csv_comparison(parser1, parser2, filename):
         csv = open(filename, "w")
-        csv.write(";origin;external\n")
+        csv.write(";origin_avg;origin_std;external_avg;external_std\n")
         for key in parser1.counters:
             csv.write(parser1.counters[key].name + ";" +
                       str(parser1.counters[key].avg()) + ";" +
-                      str(parser2.counters[key].avg()) + "\n")
+                      str(parser1.counters[key].std()) + ";" +
+                      str(parser2.counters[key].avg()) + ";" +
+                      str(parser2.counters[key].std()) + "\n")
         csv.close()
 
     @staticmethod
@@ -89,10 +91,10 @@ class Parser:
         csv = open(filename, "w")
         for repository_name in repository_names:
             pos = repository_name.rfind("/") + 1
-            csv.write(";" + repository_name[pos:] + ";")
+            csv.write(";" + repository_name[pos:] + ";;;")
         csv.write("\n")
         for i in range(0, len(parser_list1)):
-            csv.write(";origin;external")
+            csv.write(";origin_avg;origin_std;external_avg;external_std")
         csv.write("\n")
         for counter_name in counter_names:
             csv.write(counter_name + ";")
@@ -100,6 +102,8 @@ class Parser:
                 parser1 = parser_list1[repository_name]
                 parser2 = parser_list2[repository_name]
                 csv.write(str(parser1.counters[counter_name].avg()) + ";" +
-                          str(parser2.counters[counter_name].avg()) + ";")
+                          str(parser1.counters[counter_name].std()) + ";" +
+                          str(parser2.counters[counter_name].avg()) + ";" +
+                          str(parser2.counters[counter_name].std()) + ";")
             csv.write("\n")
         csv.close()

--- a/python/parser.py
+++ b/python/parser.py
@@ -1,11 +1,33 @@
+import math
+
 class Counter:
     def __init__(self, name, number, description):
         self.name = name
         self.description = description
         try:
-            self.number = int(number)
+            self.values = [int(number)]
         except ValueError:
-            self.number = 0
+            self.values = [0]
+
+    def sum(self):
+        counter = 0
+        for n in self.values:
+            counter += n
+        return counter
+
+    def avg(self):
+        return self.sum() / len(self.values)
+
+    def variance(self):
+        counter = 0
+        average = self.avg()
+        for n in self.values:
+            diff = n - average
+            counter += diff * diff
+        return counter / len(self.values)
+
+    def std(self):
+        return math.sqrt(self.variance())
 
 
 class Parser:
@@ -13,7 +35,6 @@ class Parser:
         self.counters = {}
         self.warm_cache = False
         self.repository = ""
-        self.num_files = 0
         if filename is not None:
             self.parse(filename)
 
@@ -34,12 +55,11 @@ class Parser:
             if len(params) == 3:
                 counter = Counter(params[0], params[1], params[2])
                 if counter.name in self.counters:
-                    self.counters[counter.name].number += counter.number
+                    self.counters[counter.name].values += counter.values
                 else:
                     self.counters[counter.name] = counter
 
     def parse(self, filename):
-        self.num_files += 1
         datafile = open(filename, "r")
         for line in datafile:
             self.__parseline(line)
@@ -49,7 +69,7 @@ class Parser:
         csv = open(filename, "w")
         csv.write(";" + self.repository)
         for counter in self.counters:
-            csv.write(counter.name + ";" + str(counter.number / self.num_files))
+            csv.write(counter.name + ";" + str(counter.avg()))
         csv.close()
 
     @staticmethod
@@ -58,9 +78,9 @@ class Parser:
         csv.write(";origin;external\n")
         for key in parser1.counters:
             csv.write(parser1.counters[key].name + ";" +
-                      str(parser1.counters[key].number / parser1.num_files)
+                      str(parser1.counters[key].avg())
                       + ";" +
-                      str(parser2.counters[key].number / parser2.num_files)
+                      str(parser2.counters[key].avg())
                       + "\n")
         csv.close()
 
@@ -81,9 +101,7 @@ class Parser:
             for repository_name in repository_names:
                 parser1 = parser_list1[repository_name]
                 parser2 = parser_list2[repository_name]
-                csv.write(str(parser1.counters[counter_name].number
-                              / parser1.num_files) + ";" +
-                          str(parser2.counters[counter_name].number
-                              / parser2.num_files) + ";")
+                csv.write(str(parser1.counters[counter_name].avg()) + ";" +
+                          str(parser2.counters[counter_name].avg()) + ";")
             csv.write("\n")
         csv.close()

--- a/python/parser.py
+++ b/python/parser.py
@@ -67,18 +67,19 @@ class Parser:
     @staticmethod
     def to_csv_multiple_comparison(parser_list1, parser_list2, filename):
         counter_names = parser_list1.values()[0].counters.keys()
+        repository_names = sorted(parser_list1)
         csv = open(filename, "w")
-        for parser in parser_list1.values():
-            csv.write(";" + parser.repository + ";")
+        for repository_name in repository_names:
+            csv.write(";" + repository_name + ";")
         csv.write("\n")
         for i in range(0, len(parser_list1)):
             csv.write(";origin;external")
         csv.write("\n")
         for counter_name in counter_names:
             csv.write(counter_name + ";")
-            for repository in parser_list1:
-                parser1 = parser_list1[repository]
-                parser2 = parser_list2[repository]
+            for repository_name in repository_names:
+                parser1 = parser_list1[repository_name]
+                parser2 = parser_list2[repository_name]
                 csv.write(str(parser1.counters[counter_name].number
                               / parser1.num_files) + ";" +
                           str(parser2.counters[counter_name].number


### PR DESCRIPTION
- Fixes a problem with the order benchmarks appear in the CSV files
- Calculates and retrieves the standard deviation between different iterations as another column in the generated CSV. Notice that this adds two more columns: one for the original repository and one for the external repository