### PR TITLE
Add support for external data URLs.

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -231,7 +231,9 @@ bool Catalog::LookupEntry(const shash::Md5 &md5path, const bool expand_symlink,
   bool found = sql_lookup_md5path_->FetchRow();
   if (found && (dirent != NULL)) {
     *dirent = sql_lookup_md5path_->GetDirent(this, expand_symlink);
-    dirent->set_external_data(GetExternalDataLocked() == Present);
+    bool is_external = GetExternalDataLocked() == Present;
+    LogCvmfs(kLogCatalog, kLogDebug, "Entry data is external: %d.", is_external);
+    dirent->set_external_data(is_external);
     FixTransitionPoint(md5path, dirent);
   }
   sql_lookup_md5path_->Reset();

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -167,6 +167,7 @@ class Catalog : public SingleCopy {
     return ((database_ != NULL) && database_->OwnsFile()) || managed_database_;
   }
 
+  bool GetExternalData() const;
   uint64_t GetTTL() const;
   uint64_t GetRevision() const;
   uint64_t GetLastModified() const;
@@ -246,6 +247,7 @@ class Catalog : public SingleCopy {
 
   void FixTransitionPoint(const shash::Md5 &md5path,
                           DirectoryEntry *dirent) const;
+  bool GetExternalDataLocked() const; // For holders of lock_
 
  private:
   bool LookupEntry(const shash::Md5 &md5path, const bool expand_symlink,
@@ -259,6 +261,13 @@ class Catalog : public SingleCopy {
   bool volatile_flag_;
   const bool is_root_;
   bool managed_database_;
+
+  enum ExternalDataStatus {
+    Unknown,
+    None,
+    Present
+  };
+  mutable atomic_int32 external_data_status_;
 
   Catalog *parent_;
   NestedCatalogMap children_;

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -247,7 +247,15 @@ class Catalog : public SingleCopy {
 
   void FixTransitionPoint(const shash::Md5 &md5path,
                           DirectoryEntry *dirent) const;
-  bool GetExternalDataLocked() const; // For holders of lock_
+
+  enum ExternalDataStatus {
+    Unknown,
+    None,
+    Present,
+    Unspecified,
+  };
+  ExternalDataStatus GetExternalDataUnlocked() const;
+  ExternalDataStatus GetExternalDataLocked() const; // For holders of lock_
 
  private:
   bool LookupEntry(const shash::Md5 &md5path, const bool expand_symlink,
@@ -262,11 +270,6 @@ class Catalog : public SingleCopy {
   const bool is_root_;
   bool managed_database_;
 
-  enum ExternalDataStatus {
-    Unknown,
-    None,
-    Present
-  };
   mutable atomic_int32 external_data_status_;
 
   Catalog *parent_;

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -218,7 +218,7 @@ LoadError ClientCatalogManager::LoadCatalogCas(
   string *catalog_path)
 {
   assert(hash.suffix == shash::kSuffixCatalog);
-  int fd = fetcher_->Fetch(hash, cache::CacheManager::kSizeUnknown, name,
+  int fd = fetcher_->Fetch(hash, cache::CacheManager::kSizeUnknown, false, name,
                            cache::CacheManager::kTypeCatalog);
   if (fd >= 0) {
     *catalog_path = "@" + StringifyInt(fd);

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -87,6 +87,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   const string     &dir_temp,
   const bool        volatile_content,
   const bool        garbage_collectable,
+  const bool        external_data,
   upload::Spooler  *spooler)
 {
   // Create a new root catalog at file_path
@@ -114,6 +115,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
     if (!new_clg_db.IsValid() ||
         !new_clg_db->InsertInitialValues(root_path,
                                           volatile_content,
+                                          external_data,
                                           root_entry))
     {
       LogCvmfs(kLogCatalog, kLogStderr, "creation of catalog '%s' failed",
@@ -515,9 +517,10 @@ void WritableCatalogManager::TouchDirectory(const DirectoryEntryBase &entry,
  * Create a new nested catalog.  Includes moving all entries belonging there
  * from it's parent catalog.
  * @param mountpoint the path of the directory to become a nested root
+ * @param external_data whether data for this catalog is external to the repository
  * @return true on success, false otherwise
  */
-void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
+void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint, const bool external_data)
 {
   const string nested_root_path = MakeRelativePath(mountpoint);
 
@@ -548,6 +551,7 @@ void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
   assert(NULL != new_catalog_db);
   retval = new_catalog_db->InsertInitialValues(nested_root_path,
                                                volatile_content,
+                                               external_data,
                                                new_root_entry);
   assert(retval);
   // TODO(rmeusel): we need a way to attach a catalog directy from an open

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -87,7 +87,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   const string     &dir_temp,
   const bool        volatile_content,
   const bool        garbage_collectable,
-  const bool        external_data,
+  CatalogProperty   external_data,
   upload::Spooler  *spooler)
 {
   // Create a new root catalog at file_path
@@ -520,7 +520,7 @@ void WritableCatalogManager::TouchDirectory(const DirectoryEntryBase &entry,
  * @param external_data whether data for this catalog is external to the repository
  * @return true on success, false otherwise
  */
-void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint, const bool external_data)
+void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint, CatalogProperty external_data)
 {
   const string nested_root_path = MakeRelativePath(mountpoint);
 

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -72,6 +72,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   static manifest::Manifest *CreateRepository(const std::string &dir_temp,
                                               const bool volatile_content,
                                               const bool garbage_collectable,
+                                              const bool external_data,
                                               upload::Spooler   *spooler);
 
   // DirectoryEntry handling
@@ -100,7 +101,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void ShrinkHardlinkGroup(const std::string &remove_path);
 
   // Nested catalog handling
-  void CreateNestedCatalog(const std::string &mountpoint);
+  void CreateNestedCatalog(const std::string &mountpoint, const bool external_data);
   void RemoveNestedCatalog(const std::string &mountpoint);
   bool IsTransitionPoint(const std::string &path);
 

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -72,7 +72,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   static manifest::Manifest *CreateRepository(const std::string &dir_temp,
                                               const bool volatile_content,
                                               const bool garbage_collectable,
-                                              const bool external_data,
+                                              CatalogProperty external_data,
                                               upload::Spooler   *spooler);
 
   // DirectoryEntry handling
@@ -101,7 +101,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void ShrinkHardlinkGroup(const std::string &remove_path);
 
   // Nested catalog handling
-  void CreateNestedCatalog(const std::string &mountpoint, const bool external_data);
+  void CreateNestedCatalog(const std::string &mountpoint, CatalogProperty external_data);
   void RemoveNestedCatalog(const std::string &mountpoint);
   bool IsTransitionPoint(const std::string &path);
 

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -127,6 +127,7 @@ bool CatalogDatabase::CreateEmptyDatabase() {
 bool CatalogDatabase::InsertInitialValues(
   const std::string    &root_path,
   const bool            volatile_content,
+  const bool            external_data,
   const DirectoryEntry &root_entry)
 {
   assert(read_write());
@@ -156,6 +157,14 @@ bool CatalogDatabase::InsertInitialValues(
   if (volatile_content) {
     if (!this->SetProperty("volatile", 1)) {
       PrintSqlError("failed to insert volatile flag into the newly created "
+                    "catalog tables.");
+      return false;
+    }
+  }
+
+  if (external_data) {
+    if (!this->SetProperty("external_data", static_cast<int>(external_data))) {
+      PrintSqlError("failed to set external data flag into the newly created "
                     "catalog tables.");
       return false;
     }

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -127,7 +127,7 @@ bool CatalogDatabase::CreateEmptyDatabase() {
 bool CatalogDatabase::InsertInitialValues(
   const std::string    &root_path,
   const bool            volatile_content,
-  const bool            external_data,
+  CatalogProperty       external_data,
   const DirectoryEntry &root_entry)
 {
   assert(read_write());
@@ -162,8 +162,8 @@ bool CatalogDatabase::InsertInitialValues(
     }
   }
 
-  if (external_data) {
-    if (!this->SetProperty("external_data", static_cast<int>(external_data))) {
+  if (external_data != kUnset) {
+    if (!this->SetProperty("external_data", external_data == kYes ? 1 : 0)) {
       PrintSqlError("failed to set external data flag into the newly created "
                     "catalog tables.");
       return false;

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -47,7 +47,7 @@ class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
   bool CreateEmptyDatabase();
   bool InsertInitialValues(const std::string     &root_path,
                            const bool             volatile_content,
-                           const bool             external_data,
+                           CatalogProperty        external_data,
                            const DirectoryEntry  &root_entry
                                              = DirectoryEntry(kDirentNegative));
 

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -47,6 +47,7 @@ class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
   bool CreateEmptyDatabase();
   bool InsertInitialValues(const std::string     &root_path,
                            const bool             volatile_content,
+                           const bool             external_data,
                            const DirectoryEntry  &root_entry
                                              = DirectoryEntry(kDirentNegative));
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1106,6 +1106,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   fd = fetcher_->Fetch(
     dirent.checksum(),
     dirent.size(),
+    dirent.external(),
     string(path.GetChars(), path.GetLength()),
     volatile_repository_ ? cache::CacheManager::kTypeVolatile :
                            cache::CacheManager::kTypeRegular);
@@ -1202,6 +1203,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
         chunk_fd.fd = fetcher_->Fetch(
           chunks.list->AtPtr(chunk_idx)->content_hash(),
           chunks.list->AtPtr(chunk_idx)->size(),
+          false, // For now, using chunks automatically disables external data
           verbose_path,
           volatile_repository_ ? cache::CacheManager::kTypeVolatile
                                : cache::CacheManager::kTypeRegular);
@@ -1488,6 +1490,8 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
     } else {
       attribute_value = "DIRECT";
     }
+  } else if (attr == "user.external_host") {
+    attribute_value = download_manager_->GetExternalHost();
   } else if (attr == "user.host") {
     vector<string> host_chain;
     vector<int> rtt;
@@ -1597,7 +1601,8 @@ static void cvmfs_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
     "user.root_hash\0user.expires\0user.maxfd\0user.usedfd\0user.nioerr\0"
     "user.host\0user.proxy\0user.uptime\0user.nclg\0user.nopen\0"
     "user.ndownload\0user.timeout\0user.timeout_direct\0user.rx\0user.speed\0"
-    "user.fqrn\0user.ndiropen\0user.inode_max\0user.tag\0user.host_list\0";
+    "user.fqrn\0user.ndiropen\0user.inode_max\0user.tag\0user.host_list\0"
+    "user.external_host\0";
   string attribute_list;
   if (hide_magic_xattrs_) {
     LogCvmfs(kLogCvmfs, kLogDebug, "Hiding extended attributes");
@@ -1669,6 +1674,7 @@ bool Pin(const string &path) {
       int fd = fetcher_->Fetch(
         chunks.AtPtr(i)->content_hash(),
         chunks.AtPtr(i)->size(),
+        false, // Chunking and external data is incompatible
         "Part of " + path,
         cache::CacheManager::kTypePinned);
       if (fd < 0) {
@@ -1685,7 +1691,7 @@ bool Pin(const string &path) {
   if (!retval)
     return false;
   int fd = fetcher_->Fetch(
-    dirent.checksum(), dirent.size(), path, cache::CacheManager::kTypePinned);
+    dirent.checksum(), dirent.size(), dirent.external(), path, cache::CacheManager::kTypePinned);
   if (fd < 0) {
     return false;
   }
@@ -1826,6 +1832,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
   string proxies = "";
   string fallback_proxies = "";
   string dns_server = "";
+  std::string external_host;
   string public_keys = "";
   string root_hash = "";
   string repository_tag = "";
@@ -1930,6 +1937,13 @@ static int Init(const loader::LoaderExports *loader_exports) {
     fallback_proxies = parameter;
   if (cvmfs::options_manager_->GetValue("CVMFS_DNS_SERVER", &parameter))
     dns_server = parameter;
+  if (cvmfs::options_manager_->GetValue("CVMFS_EXTERNAL_URL", &parameter)) {
+    external_host = parameter;
+    vector<string> tokens = SplitString(loader_exports->repository_name, '.');
+    const string org = tokens[0];
+    external_host = ReplaceAll(external_host, "@org@", org);
+    external_host = ReplaceAll(external_host, "@fqrn@", loader_exports->repository_name);
+  }
   if (cvmfs::options_manager_->GetValue("CVMFS_TRUSTED_CERTS", &parameter))
     trusted_certs = parameter;
   if (cvmfs::options_manager_->GetValue("CVMFS_PUBLIC_KEY", &parameter)) {
@@ -2322,6 +2336,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
   if (follow_redirects) {
     cvmfs::download_manager_->EnableRedirects();
   }
+  cvmfs::download_manager_->SetExternalHost(external_host);
   cvmfs::download_manager_->SetTimeout(timeout, timeout_direct);
   cvmfs::download_manager_->SetLowSpeedLimit(low_speed_limit);
   cvmfs::download_manager_->SetProxyGroupResetDelay(proxy_reset_after);

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -246,7 +246,7 @@ CernVM-FS Server Tool $(cvmfs_version_string)
 Usage: cvmfs_server COMMAND [options] <parameters>
 
 Supported Commands:
-  mkfs          [-w stratum0 url] [-u upstream storage] [-o owner]
+  mkfs          [-w stratum0 url] [-u upstream storage] [-o owner] [-X (enable external data)]
                 [-m replicable] [-f union filesystem type] [-v volatile content]
                 [-g disable auto tags] [-a hash algorithm (default: SHA-1)]
                 [-z enable garbage collection] [-s S3 config file]
@@ -2416,11 +2416,15 @@ mkfs() {
   local garbage_collectable=false
   local s3_config=""
   local keys_import_location
+  local external=0
 
   # parameter handling
   OPTIND=1
-  while getopts "w:u:o:mf:vga:zs:k:" option; do
+  while getopts "Xw:u:o:mf:vga:zs:k:" option; do
     case $option in
+      X)
+        external=1
+      ;;
       w)
         stratum0=$OPTARG
       ;;
@@ -2566,6 +2570,10 @@ mkfs() {
   local temp_dir="${CVMFS_SPOOL_DIR}/tmp"
   local rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
   local scratch_dir="${CVMFS_SPOOL_DIR}/scratch"
+  local external_data_opt=""
+  if [ $external_data -eq 1 ]; then
+    external_data_opt="-X"
+  fi
 
   echo -n "Creating Initial Repository... "
   create_whitelist $name $cvmfs_user $upstream $temp_dir > /dev/null
@@ -2576,6 +2584,7 @@ mkfs() {
   fi
   local user_shell="$(get_user_shell $name)"
   local create_cmd="$(__swissknife_cmd) create \
+    $external_data_opt                         \
     -t $temp_dir                               \
     -r $upstream                               \
     -a $hash_algo $volatile_opt                \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2614,7 +2614,7 @@ mkfs() {
   # When publishing an external repository, it is the user's responsibility to
   # stage the actual data files to the web server - not the publication function.
   # Hence, the following is guaranteed to not work.
-  if [ external_data -eq 0 ]; then
+  if [ $external_data -eq 0 ]; then
     cat $rdonly_dir/new_repository || die "fail (finish)"
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2416,14 +2416,14 @@ mkfs() {
   local garbage_collectable=false
   local s3_config=""
   local keys_import_location
-  local external=0
+  local external_data=0
 
   # parameter handling
   OPTIND=1
   while getopts "Xw:u:o:mf:vga:zs:k:" option; do
     case $option in
       X)
-        external=1
+        external_data=1
       ;;
       w)
         stratum0=$OPTARG
@@ -2611,7 +2611,12 @@ mkfs() {
   echo "New CernVM-FS repository for $name" > /cvmfs/${name}/new_repository
   chown $cvmfs_user /cvmfs/${name}/new_repository
   publish $name > /dev/null      || die "fail (publish)"
-  cat $rdonly_dir/new_repository || die "fail (finish)"
+  # When publishing an external repository, it is the user's responsibility to
+  # stage the actual data files to the web server - not the publication function.
+  # Hence, the following is guaranteed to not work.
+  if [ external_data -eq 0 ]; then
+    cat $rdonly_dir/new_repository || die "fail (finish)"
+  fi
 
   print_new_repository_notice $name $cvmfs_user
 }

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -227,7 +227,8 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_nested_catalog_root_(false)
     , is_nested_catalog_mountpoint_(false)
     , is_chunked_file_(false)
-    , is_negative_(false) { }
+    , is_negative_(false)
+    , external_data_(false) { }
 
   inline DirectoryEntry()
     : cached_mtime_(0)
@@ -235,7 +236,8 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_nested_catalog_root_(false)
     , is_nested_catalog_mountpoint_(false)
     , is_chunked_file_(false)
-    , is_negative_(false) { }
+    , is_negative_(false)
+    , external_data_(false) { }
 
   inline explicit DirectoryEntry(SpecialDirents special_type)
     : cached_mtime_(0)
@@ -243,7 +245,8 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_nested_catalog_root_(false)
     , is_nested_catalog_mountpoint_(false)
     , is_chunked_file_(false)
-    , is_negative_(true) { assert(special_type == kDirentNegative); }
+    , is_negative_(true)
+    , external_data_(false) { assert(special_type == kDirentNegative); }
 
   inline SpecialDirents GetSpecial() const {
     return is_negative_ ? kDirentNegative : kDirentNormal;
@@ -279,6 +282,10 @@ class DirectoryEntry : public DirectoryEntryBase {
   inline void set_is_chunked_file(const bool val) {
     is_chunked_file_ = val;
   }
+  void set_external_data(bool val) {
+    external_data_ = val;
+  }
+  bool external() const {return external_data_;}
 
  private:
    /**
@@ -296,6 +303,7 @@ class DirectoryEntry : public DirectoryEntryBase {
   bool is_nested_catalog_mountpoint_;
   bool is_chunked_file_;
   bool is_negative_;
+  bool external_data_;
 };
 
 

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -863,7 +863,9 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   if (opt_dns_server_)
     curl_easy_setopt(curl_handle, CURLOPT_DNS_SERVERS, opt_dns_server_);
 
-  if (info->probe_hosts && opt_host_chain_)
+  if (info->external && opt_external_host_.size())
+    url_prefix = opt_external_host_;
+  else if (info->probe_hosts && opt_host_chain_)
     url_prefix = (*opt_host_chain_)[opt_host_chain_current_];
 
   string url = url_prefix + *(info->url);
@@ -1588,6 +1590,26 @@ Failures DownloadManager::Fetch(JobInfo *info) {
   return result;
 }
 
+
+/**
+ * Sets the server to use in the case of an external host.
+ *
+ * NOTE: currently takes the option lock, which is a bit heavy for
+ * the use case.  Atomics would be better, but the UniquePtr class
+ * isn't currently thread-safe.
+ */
+void DownloadManager::SetExternalHost(const std::string &host) {
+  pthread_mutex_lock(lock_options_);
+  opt_external_host_ = host;
+  pthread_mutex_unlock(lock_options_);
+}
+
+std::string DownloadManager::GetExternalHost() const {
+  pthread_mutex_lock(lock_options_);
+  std::string result = opt_external_host_;
+  pthread_mutex_unlock(lock_options_);
+  return result;
+}
 
 /**
  * Sets a DNS server.  Only for testing as it cannot be reverted to the system

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -119,6 +119,7 @@ struct JobInfo {
   bool probe_hosts;
   bool head_request;
   bool follow_redirects;
+  bool external;
   Destination destination;
   struct {
     size_t size;
@@ -138,6 +139,7 @@ struct JobInfo {
     probe_hosts = false;
     head_request = false;
     follow_redirects = false;
+    external = false;
     destination = kDestinationNone;
     destination_mem.size = destination_mem.pos = 0;
     destination_mem.data = NULL;
@@ -316,6 +318,8 @@ class DownloadManager {
   void Spawn();
   Failures Fetch(JobInfo *info);
 
+  void SetExternalHost(const std::string &host);
+  std::string GetExternalHost() const;
   void SetDnsServer(const std::string &address);
   void SetDnsParameters(const unsigned retries, const unsigned timeout_sec);
   void SetTimeout(const unsigned seconds_proxy, const unsigned seconds_direct);
@@ -412,6 +416,12 @@ class DownloadManager {
    */
   std::vector<int> *opt_host_chain_rtt_;
   unsigned opt_host_chain_current_;
+
+  /**
+   * If data files are kept outside CVMFS (and stored by path instead of hash),
+   * then this is the prefix URL to find them.
+   */
+  std::string opt_external_host_;
 
   // Proxy list
   std::vector< std::vector<ProxyInfo> > *opt_proxy_groups_;

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -76,6 +76,7 @@ Fetcher::ThreadLocalStorage *Fetcher::GetTls() {
 int Fetcher::Fetch(
   const shash::Any &id,
   const uint64_t size,
+  const bool external,
   const std::string &name,
   const cache::CacheManager::ObjectType object_type)
 {
@@ -121,7 +122,7 @@ int Fetcher::Fetch(
 
   // Involve the download manager
   LogCvmfs(kLogCache, kLogDebug, "downloading %s", name.c_str());
-  const string url = "/data/" + id.MakePath();
+  const std::string url = external ? name : "/data/" + id.MakePath();
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   retval = cache_mgr_->StartTxn(id, size, txn);
   if (retval < 0) {
@@ -138,6 +139,7 @@ int Fetcher::Fetch(
   tls->download_job.destination_sink = &sink;
   tls->download_job.expected_hash = &id;
   tls->download_job.extra_info = &name;
+  tls->download_job.external = external;
   download_mgr_->Fetch(&tls->download_job);
 
   if (tls->download_job.error_code == download::kFailOk) {

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -75,6 +75,7 @@ class Fetcher : SingleCopy {
   ~Fetcher();
   int Fetch(const shash::Any &id,
             const uint64_t size,
+            const bool external,
             const std::string &name,
             const cache::CacheManager::ObjectType object_type);
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -600,6 +600,7 @@ int cvmfs_context::Open(const char *c_path) {
   fd = fetcher_->Fetch(
     dirent.checksum(),
     dirent.size(),
+    dirent.external(),
     string(path.GetChars(), path.GetLength()),
     cache::CacheManager::kTypeRegular);
   atomic_inc64(&num_fs_open_);
@@ -646,6 +647,7 @@ int64_t cvmfs_context::Pread(
         chunk_fd->fd = fetcher_->Fetch(
           chunk_list->AtPtr(chunk_idx)->content_hash(),
           chunk_list->AtPtr(chunk_idx)->size(),
+          false,
           "no path info",
           cache::CacheManager::kTypeRegular);
         if (chunk_fd->fd < 0) {

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -756,7 +756,7 @@ bool CommandMigrate::MigrationWorker_20x::CreateNewEmptyCatalog(
     UniquePtr<catalog::CatalogDatabase>
       new_clg_db(catalog::CatalogDatabase::Create(clg_db_path));
     if (!new_clg_db.IsValid() ||
-        !new_clg_db->InsertInitialValues(root_path, volatile_content)) {
+        !new_clg_db->InsertInitialValues(root_path, volatile_content, false)) {
       Error("Failed to create database for new catalog");
       unlink(clg_db_path.c_str());
       return false;

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -756,7 +756,7 @@ bool CommandMigrate::MigrationWorker_20x::CreateNewEmptyCatalog(
     UniquePtr<catalog::CatalogDatabase>
       new_clg_db(catalog::CatalogDatabase::Create(clg_db_path));
     if (!new_clg_db.IsValid() ||
-        !new_clg_db->InsertInitialValues(root_path, volatile_content, false)) {
+        !new_clg_db->InsertInitialValues(root_path, volatile_content, kUnset)) {
       Error("Failed to create database for new catalog");
       unlink(clg_db_path.c_str());
       return false;

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -118,7 +118,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
   // TODO(rmeusel): use UniquePtr
   manifest::Manifest *manifest =
     catalog::WritableCatalogManager::CreateRepository(
-      dir_temp, volatile_content, garbage_collectable, external_data, spooler);
+      dir_temp, volatile_content, garbage_collectable, external_data ? kYes : kUnset, spooler);
   if (!manifest) {
     PrintError("Failed to create new repository");
     return 1;

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -109,6 +109,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
   }
   const bool volatile_content    = (args.count('v') > 0);
   const bool garbage_collectable = (args.count('z') > 0);
+  const bool external_data       = (args.count('X') > 0);
 
   const upload::SpoolerDefinition sd(spooler_definition, hash_algorithm);
   upload::Spooler *spooler = upload::Spooler::Construct(sd);
@@ -117,7 +118,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
   // TODO(rmeusel): use UniquePtr
   manifest::Manifest *manifest =
     catalog::WritableCatalogManager::CreateRepository(
-      dir_temp, volatile_content, garbage_collectable, spooler);
+      dir_temp, volatile_content, garbage_collectable, external_data, spooler);
   if (!manifest) {
     PrintError("Failed to create new repository");
     return 1;

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -73,6 +73,7 @@ class CommandCreate : public Command {
   ParameterList GetParams() {
     ParameterList r;
     r.push_back(Parameter::Mandatory('o', "manifest output file"));
+    r.push_back(Parameter::Switch('X', "enable external data"));
     r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -10,6 +10,71 @@
 
 using namespace std;  // NOLINT
 
+
+static bool ProcessCatalogProperties(const std::string &scratch_path, bool &external_data) {
+  char buf[128];
+  external_data = false;
+  ssize_t retval;
+  if (-1 != (retval = lgetxattr(scratch_path.c_str(), "user.external_data", buf, 127))) {
+    if (retval == 0) {
+      LogCvmfs(kLogFsTraversal, kLogWarning, "Extended attribute 'external_data' set on %s, "
+               "but no value provided.", scratch_path.c_str());
+      return false;
+    }
+    if ((retval != 1) || (buf[0] != '0' && buf[0] != '1')) {
+      LogCvmfs(kLogFsTraversal, kLogWarning, "Extended attribute 'external_data' set on %s, "
+               "but value is not one of '0' or '1'.", scratch_path.c_str());
+      return false;
+    }
+    external_data = buf[0] == '1';
+    return true;
+  } else if (errno == ERANGE) {
+    LogCvmfs(kLogFsTraversal, kLogWarning, "Value of extended attribute on path %s is too long; "
+             "must be '1' or '0'", scratch_path.c_str());
+    return false;
+  }
+  LogCvmfs(kLogFsTraversal, kLogDebug, "Processing catalog marker %s.", scratch_path.c_str());
+  FILE *fp = fopen(scratch_path.c_str(), "r");
+  if (fp == NULL) {
+    LogCvmfs(kLogFsTraversal, kLogWarning, "Unable to open catalog marker (%s): %s (errno=%d)",
+             scratch_path.c_str(), strerror(errno), errno);
+    return false;
+  }
+  size_t len = 0;
+  ssize_t read;
+  char *line = NULL;
+  bool retval2 = false;
+  while (1) {
+    read = getline(&line, &len, fp);
+    if (read == -1) {
+      if (errno == EINTR) {continue;}
+      else {
+        break;
+      }
+    }
+    if (line[read-1] == '\n') {line[read-1] = '\0';}
+    char *value;
+    if ((value = strcasestr(line, "external_data="))) {
+      value += 14;
+      if (strlen(value) != 1 || (value[0] != '0' && value[0] != '1')) {
+        LogCvmfs(kLogFsTraversal, kLogWarning, "Attribute 'external_data' set in %s, "
+               "but value is not one of '0' or '1'.  Ignoring.", scratch_path.c_str());
+        continue;
+      }
+      external_data = value[0] == '1';
+      retval2 = true;
+    }
+  }
+  free(line);
+  if (!feof(fp)) { // ERROR reading
+    LogCvmfs(kLogFsTraversal, kLogWarning, "Unable to read from catalog marker (%s): %s (errno=%d)",
+             scratch_path.c_str(), strerror(errno), errno);
+  }
+  fclose(fp);
+  return retval2;
+}
+
+
 namespace publish {
 
 
@@ -35,6 +100,11 @@ SyncItem::SyncItem(const string       &relative_parent_path,
   rdonly_type_(kItemUnknown)
 {
   content_hash_.algorithm = shash::kAny;
+  bool external_data;
+  if (IsCatalogMarker() && ProcessCatalogProperties(GetScratchPath(), external_data)) {
+    LogCvmfs(kLogFsTraversal, kLogDebug, "Setting external data to %d in catalog.", external_data);
+    SetExternalData(external_data);
+  }
 }
 
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -15,6 +15,7 @@ namespace publish {
 
 SyncItem::SyncItem() :
   union_engine_(NULL),
+  external_data_(false),
   whiteout_(false),
   scratch_type_(static_cast<SyncItemType>(0)),
   rdonly_type_(static_cast<SyncItemType>(0))
@@ -26,6 +27,7 @@ SyncItem::SyncItem(const string       &relative_parent_path,
                    const SyncUnion    *union_engine,
                    const SyncItemType  entry_type) :
   union_engine_(union_engine),
+  external_data_(false),
   whiteout_(false),
   relative_parent_path_(relative_parent_path),
   filename_(filename),

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -15,7 +15,7 @@ namespace publish {
 
 SyncItem::SyncItem() :
   union_engine_(NULL),
-  external_data_(false),
+  external_data_(kUnset),
   whiteout_(false),
   scratch_type_(static_cast<SyncItemType>(0)),
   rdonly_type_(static_cast<SyncItemType>(0))
@@ -27,7 +27,7 @@ SyncItem::SyncItem(const string       &relative_parent_path,
                    const SyncUnion    *union_engine,
                    const SyncItemType  entry_type) :
   union_engine_(union_engine),
-  external_data_(false),
+  external_data_(kUnset),
   whiteout_(false),
   relative_parent_path_(relative_parent_path),
   filename_(filename),

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -59,7 +59,7 @@ class SyncItem {
   inline bool IsSymlink()       const { return IsType(kItemSymlink);          }
   inline bool WasSymlink()      const { return WasType(kItemSymlink);         }
   inline bool IsNew()           const { return WasType(kItemNew);             }
-         bool IsExternalData()  const { return external_data_;                }
+  CatalogProperty IsExternalData() const { return external_data_;             }
 
   // TODO(reneme): code smell! This depends on the UnionEngine to call
   //                           MarkAsWhiteout(), before it potentially gives the
@@ -71,7 +71,7 @@ class SyncItem {
   inline shash::Any GetContentHash() const { return content_hash_; }
   inline void SetContentHash(const shash::Any &hash) { content_hash_ = hash; }
   inline bool HasContentHash() const { return !content_hash_.IsNull(); }
-  void SetExternalData() { if (IsCatalogMarker()) external_data_ = true; }
+  void SetExternalData(bool val) { if (IsCatalogMarker()) external_data_ = val ? kYes : kNo; }
 
   catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
 
@@ -154,7 +154,7 @@ class SyncItem {
   mutable EntryStat union_stat_;
   mutable EntryStat scratch_stat_;
 
-  bool external_data_;
+  CatalogProperty external_data_;
   bool whiteout_;
   std::string relative_parent_path_;
   std::string filename_;

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -59,6 +59,7 @@ class SyncItem {
   inline bool IsSymlink()       const { return IsType(kItemSymlink);          }
   inline bool WasSymlink()      const { return WasType(kItemSymlink);         }
   inline bool IsNew()           const { return WasType(kItemNew);             }
+         bool IsExternalData()  const { return external_data_;                }
 
   // TODO(reneme): code smell! This depends on the UnionEngine to call
   //                           MarkAsWhiteout(), before it potentially gives the
@@ -70,6 +71,7 @@ class SyncItem {
   inline shash::Any GetContentHash() const { return content_hash_; }
   inline void SetContentHash(const shash::Any &hash) { content_hash_ = hash; }
   inline bool HasContentHash() const { return !content_hash_.IsNull(); }
+  void SetExternalData() { if (IsCatalogMarker()) external_data_ = true; }
 
   catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
 
@@ -152,6 +154,7 @@ class SyncItem {
   mutable EntryStat union_stat_;
   mutable EntryStat scratch_stat_;
 
+  bool external_data_;
   bool whiteout_;
   std::string relative_parent_path_;
   std::string filename_;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -530,7 +530,7 @@ void SyncMediator::CreateNestedCatalog(const SyncItem &requestFile) {
   const std::string notice = "Nested catalog at ";
   PrintChangesetNotice(kAddCatalog, notice + requestFile.GetUnionPath());
   if (!params_->dry_run) {
-    catalog_manager_->CreateNestedCatalog(requestFile.relative_parent_path());
+    catalog_manager_->CreateNestedCatalog(requestFile.relative_parent_path(), requestFile.IsExternalData());
   }
 }
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -71,6 +71,12 @@ void SyncUnion::ProcessRegularFile(const string &parent_dir,
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessRegularFile(%s, %s)",
            parent_dir.c_str(), filename.c_str());
   SyncItem entry(parent_dir, filename, this, kItemFile);
+  if (entry.IsCatalogMarker()) {
+    char buf[128];
+    if ((-1 != lgetxattr(entry.GetScratchPath().c_str(), "user.external_data", buf, 128)) || (errno == ERANGE)) {
+      entry.SetExternalData();
+    }
+  }
   ProcessFile(&entry);
 }
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -65,17 +65,75 @@ bool SyncUnion::ProcessDirectory(const string &parent_dir,
 }
 
 
+static bool ProcessCatalogProperties(const std::string &scratch_path, bool &external_data) {
+  char buf[128];
+  external_data = false;
+  ssize_t retval;
+  if (-1 != (retval = lgetxattr(scratch_path.c_str(), "user.external_data", buf, 127))) {
+    if (retval == 0) {
+      LogCvmfs(kLogUnionFs, kLogWarning, "Extended attribute 'external_data' set on %s, "
+               "but no value provided.", scratch_path.c_str());
+      return false;
+    }
+    if ((retval != 1) || (buf[0] != '0' && buf[0] != '1')) {
+      LogCvmfs(kLogUnionFs, kLogWarning, "Extended attribute 'external_data' set on %s, "
+               "but value is not one of '0' or '1'.", scratch_path.c_str());
+      return false;
+    }
+    external_data = buf[0] == '1';
+    return true;
+  } else if (errno == ERANGE) {
+    LogCvmfs(kLogUnionFs, kLogWarning, "Value of extended attribute on path %s is too long; "
+             "must be '1' or '0'", scratch_path.c_str());
+    return false;
+  }
+  FILE *fp = fopen(scratch_path.c_str(), "r");
+  if (fp == NULL) {
+    LogCvmfs(kLogUnionFs, kLogWarning, "Unable to open catalog marker (%s): %s (errno=%d)",
+             scratch_path.c_str(), strerror(errno), errno);
+    return false;
+  }
+  size_t len = 0;
+  ssize_t read;
+  char *line = NULL;
+  bool retval2 = false;
+  while (1) {
+    read = getline(&line, &len, fp);
+    if (read == -1) {
+      if (errno == EINTR) {continue;}
+      else {
+        break;
+      }
+    }
+    if (line[read-1] == '\n') {line[read-1] = '\0';}
+    char *value;
+    if ((value = strcasestr(line, "external_data="))) {
+      if (strlen(value) != 1 || (value[0] != '0' && value[0] != '1')) {
+        LogCvmfs(kLogUnionFs, kLogWarning, "Attribute 'external_data' set in %s, "
+               "but value is not one of '0' or '1'.  Ignoring.", scratch_path.c_str());
+        continue;
+      }
+      retval2 = true;
+    }
+  }
+  free(line);
+  if (!feof(fp)) { // ERROR reading
+    LogCvmfs(kLogUnionFs, kLogWarning, "Unable to read from catalog marker (%s): %s (errno=%d)",
+             scratch_path.c_str(), strerror(errno), errno);
+  }
+  fclose(fp);
+  return retval2;
+}
+
 void SyncUnion::ProcessRegularFile(const string &parent_dir,
                                    const string &filename)
 {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessRegularFile(%s, %s)",
            parent_dir.c_str(), filename.c_str());
   SyncItem entry(parent_dir, filename, this, kItemFile);
-  if (entry.IsCatalogMarker()) {
-    char buf[128];
-    if ((-1 != lgetxattr(entry.GetScratchPath().c_str(), "user.external_data", buf, 128)) || (errno == ERANGE)) {
-      entry.SetExternalData();
-    }
+  bool external_data;
+  if (entry.IsCatalogMarker() && ProcessCatalogProperties(entry.GetScratchPath(), external_data)) {
+    entry.SetExternalData(external_data);
   }
   ProcessFile(&entry);
 }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -236,6 +236,12 @@ static void *MainTalk(void *data __attribute__((unused))) {
           cvmfs::download_manager_->SetDnsServer(host);
           Answer(con_fd, "OK\n");
         }
+      } else if (line == "external URL info") {
+        std::string external_host = cvmfs::download_manager_->GetExternalHost();
+        if (external_host.size())
+          Answer(con_fd, "External data URL " + external_host);
+        else
+          Answer(con_fd, "No external URL configured.");
       } else if (line == "host info") {
         vector<string> host_chain;
         vector<int> rtt;
@@ -270,6 +276,14 @@ static void *MainTalk(void *data __attribute__((unused))) {
       } else if (line == "host switch") {
         cvmfs::download_manager_->SwitchHost();
         Answer(con_fd, "OK\n");
+      } else if (line.substr(0, 16) == "external url set") {
+        if (line.length() < 18) {
+          Answer(con_fd, "Usage: external url set <URL>\n");
+        } else {
+          const std::string host = line.substr(17);
+          cvmfs::download_manager_->SetExternalHost(host);
+          Answer(con_fd, "OK\n");
+        }
       } else if (line.substr(0, 8) == "host set") {
         if (line.length() < 10) {
           Answer(con_fd, "Usage: host set <host list>\n");

--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -38,6 +38,12 @@ const int kDefaultFileMode = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH;
 const int kDefaultDirMode = S_IXUSR | S_IWUSR | S_IRUSR |
                             S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 
+enum CatalogProperty {
+  kUnset,
+  kNo,
+  kYes
+};
+
 /**
  * Type Trait:
  * "Static" assertion that a template parameter is a pointer


### PR DESCRIPTION
This option allows CVMFS to fetch data files from a location separate
from the metadata files (such as a HTTP data federation).

Does not work with chunked files -- support is planned after the
patches for uncompressed files land.

TODO:
  - Server-side support to set this property has not been added.
  - This is done on a *per-catalog* basis; I'd like to change this
    to be hierarchical (i.e., catalog inherits this setting from
    its parent).

See CVM-907 for more information.