### PR TITLE
RFC: Improved Database Reading by using Exclusive Locking

### DIFF
--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -168,7 +168,8 @@ bool Database<DerivedT>::Configure() {
   // unexpected open read-write file descriptors in the cache directory like
   // etilqs_<number>.
   if (!read_write_) {
-    return Sql(sqlite_db() , "PRAGMA temp_store=2;").Execute();
+    return Sql(sqlite_db() , "PRAGMA temp_store=2;").Execute() &&
+           Sql(sqlite_db() , "PRAGMA locking_mode=EXCLUSIVE;").Execute();
   }
   return true;
 }


### PR DESCRIPTION
Competing against José's Java implementation I found this little tweak: If an SQLite database is opened read-only, one can set `PRAGMA locking_mode=EXCLUSIVE`. However, I am not entirely sure about the implications - therefore RFC. :-)

Regarding the [SQLite documentation](http://sqlite.org/pragma.html#pragma_locking_mode) this implies that no two processes can access the SQLite file at the same time anymore. In `NORMAL` mode, SQLite acquires and releases a file-lock for every read operation. Now: Do we rely on accessing a single SQLite database file read-only in multiple processes concurrently?

Mini-Benchmark:
* traversing all catalog entries in **boss.cern.ch** (~1.6 million entries)
* only considering the actual traversal (no catalog loading, initialisation, ...)

With `locking_mode=NORMAL` this takes (3.09s, 3.11s, 3.02s, 3.15s): **3.09s**
With `locking_mode=EXCLUSIVE` this takes (2.49s, 2.65s, 2.50s, 2.49s): **2.53s**

