### PR TITLE
Support for "grafted" files

### DIFF
--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -196,7 +196,7 @@ std::string SyncItem::GetScratchPath() const {
 }
 
 
-std::string SyncItem::GetGraftPath() const {
+std::string SyncItem::GetGraftMarkerPath() const {
   return union_engine_->scratch_path() + "/" +
       ((relative_parent_path_.empty()) ?
         ".cvmfsgraft-" + filename_ :
@@ -209,7 +209,7 @@ void SyncItem::CheckGraft() {
   bool found_checksum = false;
   std::string checksum_type;
   std::string checksum_value;
-  std::string graftfile = GetGraftPath();
+  std::string graftfile = GetGraftMarkerPath();
   LogCvmfs(kLogFsTraversal, kLogDebug, "Checking potential graft path %s.",
            graftfile.c_str());
   FILE *fp = fopen(graftfile.c_str(), "r");

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -152,7 +152,7 @@ class SyncItem {
 
   SyncItemType GetGenericFiletype(const EntryStat &stat) const;
 
-  std::string GetGraftPath() const;
+  std::string GetGraftMarkerPath() const;
   void CheckGraft();
 
   const SyncUnion *union_engine_;

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -166,7 +166,7 @@ class SyncItem {
   bool graft_marker_present_;
   std::string relative_parent_path_;
   std::string filename_;
-  ssize_t size_;
+  ssize_t graft_size_;
 
   mutable SyncItemType scratch_type_;
   mutable SyncItemType rdonly_type_;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -78,13 +78,16 @@ void SyncMediator::Add(const SyncItem &entry) {
     // A file is a hard link if the link count is greater than 1
     if (entry.GetUnionLinkcount() > 1)
       InsertHardlink(entry);
-    else if (!entry.IsGraftMarker())
+    else
       AddFile(entry);
     return;
+  } else if (entry.IsGraftMarker()) {
+    LogCvmfs(kLogPublish, kLogDebug, "Ignoring graft marker file.");
+    return; // Ignore markers.
   }
 
   PrintWarning("'" + entry.GetRelativePath() + "' cannot be added. "
-               "Unregcognized file type.");
+               "Unrecognized file type.");
 }
 
 
@@ -111,7 +114,7 @@ void SyncMediator::Touch(const SyncItem &entry) {
   }
 
   PrintWarning("'" + entry.GetRelativePath() + "' cannot be touched. "
-               "Unregcognized file type.");
+               "Unrecognied file type.");
 }
 
 
@@ -137,7 +140,7 @@ void SyncMediator::Remove(const SyncItem &entry) {
   }
 
   PrintWarning("'" + entry.GetRelativePath() + "' cannot be deleted. "
-               "Unregcognized file type.");
+               "Unrecognized file type.");
 }
 
 
@@ -587,7 +590,7 @@ void SyncMediator::AddFile(const SyncItem &entry) {
       default_xattrs,
       entry.relative_parent_path());
   } else if (entry.HasGraftMarker()) {
-    if (!entry.IsValidGraft()) {
+    if (entry.IsValidGraft()) {
       // Graft files are added to catalog immediately.
       catalog_manager_->AddFile(
         entry.CreateBasicCatalogDirent(),

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -83,7 +83,7 @@ void SyncMediator::Add(const SyncItem &entry) {
     return;
   } else if (entry.IsGraftMarker()) {
     LogCvmfs(kLogPublish, kLogDebug, "Ignoring graft marker file.");
-    return; // Ignore markers.
+    return;  // Ignore markers.
   }
 
   PrintWarning("'" + entry.GetRelativePath() + "' cannot be added. "
@@ -594,14 +594,16 @@ void SyncMediator::AddFile(const SyncItem &entry) {
       // Graft files are added to catalog immediately.
       catalog_manager_->AddFile(
         entry.CreateBasicCatalogDirent(),
-        default_xattrs, // TODO: For now, use default xattrs on grafted files.
+        default_xattrs,  // TODO(bbockelm): For now, use default xattrs
+                         // on grafted files.
         entry.relative_parent_path());
     } else {
       // Unlike with regular files, grafted files can be "unpublishable" - i.e.,
       // the graft file is missing information.  It's not clear that continuing
       // forward with the publish is the correct thing to do; abort for now.
-      LogCvmfs(kLogPublish, kLogStdout, "Encountered a grafted file (%s) with invalid"
-               " grafting information; check contents of .cvmfsgraft-* file.  Aborting publish.",
+      LogCvmfs(kLogPublish, kLogStdout, "Encountered a grafted file (%s) with "
+               "invalid grafting information; check contents of .cvmfsgraft-*"
+               " file.  Aborting publish.",
                entry.GetRelativePath().c_str());
       abort();
     }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -584,6 +584,11 @@ void SyncMediator::AddFile(const SyncItem &entry) {
   PrintChangesetNotice(kAdd, entry.GetUnionPath());
 
   if (entry.IsSymlink() && !params_->dry_run) {
+    if (entry.HasGraftMarker()) {
+      LogCvmfs(kLogPublish, kLogWarning, "File (%s) has an associated graft, "
+               "but the file itself is a symlink.  Ignoring graft.",
+               entry.GetRelativePath().c_str());
+    }
     // Symlinks are completely stored in the catalog
     catalog_manager_->AddFile(
       entry.CreateBasicCatalogDirent(),
@@ -636,6 +641,13 @@ void SyncMediator::AddDirectory(const SyncItem &entry) {
   PrintChangesetNotice(kAdd, entry.GetUnionPath());
 
   if (!params_->dry_run) {
+
+    if (entry.HasGraftMarker()) {
+      LogCvmfs(kLogPublish, kLogWarning, "Directory (%s) has an associated "
+               "graft, but the file itself is a symlink.  Ignoring graft.",
+               entry.GetRelativePath().c_str());
+    }
+
     catalog_manager_->AddDirectory(entry.CreateBasicCatalogDirent(),
                                    entry.relative_parent_path());
   }

--- a/cvmfs/util.cc
+++ b/cvmfs/util.cc
@@ -879,6 +879,23 @@ uint64_t String2Uint64(const string &value) {
 }
 
 
+bool String2Uint64Parse(const std::string &value, uint64_t *result) {
+  char *endptr = NULL;
+  errno = 0;
+  long long myval = strtoll(value.c_str(), &endptr, 10);  // NOLINT
+  if ((value.size() == 0) || (endptr != (value.c_str() + value.size()))) {
+    errno = EINVAL;
+    return false;
+  }
+  if (errno) {
+    return false;
+  }
+  if (result) {
+    *result = myval;
+  }
+  return true;
+}
+
 void String2Uint64Pair(const string &value, uint64_t *a, uint64_t *b) {
   sscanf(value.c_str(), "%"PRIu64" %"PRIu64, a, b);
 }
@@ -1044,7 +1061,12 @@ string GetLineMem(const char *text, const int text_size) {
 bool GetLineFile(FILE *f, std::string *line) {
   int retval;
   line->clear();
-  while ((retval = fgetc(f)) != EOF) {
+  while (true) {
+    retval = fgetc(f);
+    if (ferror(f) && (errno == EINTR)) {
+      clearerr(f);
+      continue;
+    } else if (retval == EOF) {break;}
     char c = retval;
     if (c == '\n')
       break;
@@ -1058,7 +1080,11 @@ bool GetLineFd(const int fd, std::string *line) {
   int retval;
   char c;
   line->clear();
-  while ((retval = read(fd, &c, 1)) == 1) {
+  while (true) {
+    retval = read(fd, &c, 1);
+    if (retval == 0) {break;}
+    if ((retval == -1) && (errno == EINTR)) {continue;}
+    if (retval == -1) {break;}
     if (c == '\n')
       break;
     line->push_back(c);

--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -163,6 +163,18 @@ std::string RfcTimestamp();
 time_t IsoTimestamp2UtcTime(const std::string &iso8601);
 int64_t String2Int64(const std::string &value);
 uint64_t String2Uint64(const std::string &value);
+
+/**
+ * Parse a string into a a uint64_t.
+ *
+ * Unlike String2Uint64, this:
+ *   - Checks to make sure the full string is parsed
+ *   - Can indicate an error occurred. 
+ *
+ * If an error occurs, this returns false and sets errno appropriately.
+ */
+bool String2Uint64Parse(const std::string &value, uint64_t *result);
+
 void String2Uint64Pair(const std::string &value, uint64_t *a, uint64_t *b);
 bool HasPrefix(const std::string &str, const std::string &prefix,
                const bool ignore_case);

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -6,7 +6,7 @@ verify_grafting() {
   testfname=$1
   local file1=$(cat /cvmfs/$CVMFS_TEST_REPO/file1)
   local file2=$(cat $testfname)
-  if [ "x$file1 " == "x" ]; then
+  if [ "x$file1" == "x" ]; then
     return 20
   fi
   if [ "x$file1" != "x$file2" ]; then

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -3,8 +3,9 @@ cvmfs_test_name="Grafting"
 cvmfs_test_autofs_on_startup=false
 
 verify_grafting() {
+  testfname=$1
   local file1=$(cat /cvmfs/$CVMFS_TEST_REPO/file1)
-  local file2=$(cat /cvmfs/$CVMFS_TEST_REPO/file2)
+  local file2=$(cat $testfname)
   if [ "x$file1 " == "x" ]; then
     return 20
   fi
@@ -33,13 +34,45 @@ cvmfs_run_test() {
   echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-file2
   echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-file2
 
-  publish_repo $CVMFS_TEST_REPO || return $?
+  #export CVMFS_LOG_LEVEL=4
+  publish_repo $CVMFS_TEST_REPO -v || return $?
 
-  verify_grafting
+  echo "Contents of file2: `cat /cvmfs/$CVMFS_TEST_REPO/file2`"
+  verify_grafting /cvmfs/$CVMFS_TEST_REPO/file2
   local verify_result=$?
   if [ $verify_result -ne 0 ]; then
     return $verify_result
   fi
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  # Verify grafting works in sub-catalogs
+  mkdir -p /cvmfs/$CVMFS_TEST_REPO/subdir/
+  touch /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfscatalog
+  echo "Some other file" > /cvmfs/$CVMFS_TEST_REPO/subdir/file3
+  echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file3
+  echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file3
+
+  # Verify that symlinks do not graft
+  echo "Some other file" > /cvmfs/$CVMFS_TEST_REPO/subdir/file4
+  ln -s /cvmfs/$CVMFS_TEST_REPO/subdir/file4 /cvmfs/$CVMFS_TEST_REPO/subdir/file5
+  echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file5
+  echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file5
+
+  #export CVMFS_LOG_LEVEL=4
+  publish_repo $CVMFS_TEST_REPO -v || return $?
+
+  echo "Contents of file2: `cat /cvmfs/$CVMFS_TEST_REPO/subdir/file3`"
+  verify_grafting /cvmfs/$CVMFS_TEST_REPO/subdir/file3
+  local verify_result=$?
+  if [ $verify_result -ne 0 ]; then
+    return $verify_result
+  fi
+
+  if [ ! -L /cvmfs/$CVMFS_TEST_REPO/subdir/file5 ]; then
+    return 22
+  fi
+
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
   

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -1,0 +1,48 @@
+
+cvmfs_test_name="Grafting"
+cvmfs_test_autofs_on_startup=false
+
+verify_grafting() {
+  local file1=$(cat /cvmfs/$CVMFS_TEST_REPO/file1)
+  local file2=$(cat /cvmfs/$CVMFS_TEST_REPO/file2)
+  if [ "x$file1 " == "x" ]; then
+    return 20
+  fi
+  if [ "x$file1" != "x$file2" ]; then
+    return 21
+  fi
+  return 0
+}
+
+cvmfs_run_test() {
+  logfile=$1
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "Hello world" > /cvmfs/$CVMFS_TEST_REPO/file1
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  local hash=$(attr -qg hash /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/file1)
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "Some other file" > /cvmfs/$CVMFS_TEST_REPO/file2
+  echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-file2
+  echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-file2
+
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  verify_grafting
+  local verify_result=$?
+  if [ $verify_result -ne 0 ]; then
+    return $verify_result
+  fi
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+  
+  return 0
+}
+


### PR DESCRIPTION
This PR adds support for 'grafted' files - files that are added to the repository without being physically present on the scratch filesystem.

For a given file $FOO in a directory, we denote a grafted file by the presence of .cvmfsgraft-$FOO in the same directory.  The .cvmfsgraft- file is line-oriented with key-value pairs.  Currently, two keys are recognized:

size=<integer size>
checksum=<checksum value>

The checksum must be a valid CVMFS checksum, following CVMFS checksumming conventions (such as having suffixes and being applied to the compressed contents).

If grafting is used, it is the responsibility of the repository maintainer to stage the files into the repository.

See CVM-908 for more information.