### PR TITLE
CI: Ubuntu 64bit docker recipe

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -122,6 +122,16 @@ config=$config
 EOF
 }
 
+get_number_of_cpu_cores() {
+  if is_linux; then
+    cat /proc/cpuinfo | grep -e '^processor' | wc -l
+  elif is_macos; then
+    sysctl -n hw.ncpu
+  else
+    echo "1"
+  fi
+}
+
 python_version() {
   python --version 2>&1 | grep -oh '[0-9]\+\.[0-9]\+.[0-9]\+'
 }

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -21,9 +21,6 @@ CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
 CVMFS_CONFIG_PACKAGE="cvmfs-config-default_1.1-1_all.deb"
 
-# sanity checks
-[ ! -d ${CVMFS_SOURCE_LOCATION}/debian ] || die "source directory seemed to be built before (${CVMFS_SOURCE_LOCATION}/debian exists)"
-
 # retrieve the upstream version string from CVMFS
 cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"
 echo "detected upstream version: $cvmfs_version"
@@ -37,11 +34,18 @@ else
   echo "creating release: $cvmfs_version"
 fi
 
+# copy the entire source tree into a working directory
+echo "copying source into workspace..."
+mkdir -p $CVMFS_RESULT_LOCATION
+copied_source="${CVMFS_RESULT_LOCATION}/wd_src"
+[ ! -d $copied_source ] || die "build directory is not empty"
+mkdir -p $copied_source
+cp -r ${CVMFS_SOURCE_LOCATION}/* $copied_source
+
 # produce the debian package
 echo "copy packaging meta information and get in place..."
-cp -r ${CVMFS_SOURCE_LOCATION}/packaging/debian/cvmfs ${CVMFS_SOURCE_LOCATION}/debian
-mkdir -p $CVMFS_RESULT_LOCATION
-cd ${CVMFS_SOURCE_LOCATION}
+cp -r ${CVMFS_SOURCE_LOCATION}/packaging/debian/cvmfs ${copied_source}/debian
+cd $copied_source
 
 echo "do the build..."
 dch -v $cvmfs_version -M "bumped upstream version number"

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -47,9 +47,10 @@ echo "copy packaging meta information and get in place..."
 cp -r ${CVMFS_SOURCE_LOCATION}/packaging/debian/cvmfs ${copied_source}/debian
 cd $copied_source
 
-echo "do the build..."
+cpu_cores=$(get_number_of_cpu_cores)
+echo "do the build (with $cpu_cores cores)..."
 dch -v $cvmfs_version -M "bumped upstream version number"
-debuild -us -uc
+DEB_BUILD_OPTIONS=parallel=$cpu_cores debuild -us -uc # -us -uc == skip signing
 cd ${CVMFS_RESULT_LOCATION}
 
 # generating package map section for specific platform

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -64,4 +64,4 @@ fi
 
 # clean up the source tree
 echo "cleaning up..."
-rm -fR ${CVMFS_SOURCE_LOCATION}/debian
+rm -fR $copied_source

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -49,8 +49,7 @@ cd $copied_source
 
 echo "do the build..."
 dch -v $cvmfs_version -M "bumped upstream version number"
-cd debian
-pdebuild --buildresult $CVMFS_RESULT_LOCATION
+debuild -us -uc
 cd ${CVMFS_RESULT_LOCATION}
 
 # generating package map section for specific platform

--- a/ci/docker/ubuntu1404_x86_64/Dockerfile
+++ b/ci/docker/ubuntu1404_x86_64/Dockerfile
@@ -1,0 +1,17 @@
+FROM        scratch
+MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
+
+ADD         ubuntu1404_x86_64.tar.gz /
+RUN         apt-get -y update && apt-get -y upgrade
+RUN         apt-get -y update && apt-get -y install         \
+                                              autotools-dev \
+                                              cmake         \
+                                              debhelper     \
+                                              devscripts    \
+                                              libattr1-dev  \
+                                              libfuse-dev   \
+                                              libssl-dev    \
+                                              pkg-config    \
+                                              python-dev    \
+                                              unzip         \
+                                              uuid-dev

--- a/ci/docker/ubuntu1404_x86_64/build.sh
+++ b/ci/docker/ubuntu1404_x86_64/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+. ${SCRIPT_LOCATION}/../common.sh
+
+SYSTEM_NAME="ubuntu1404"
+BASE_ARCH="x86_64"
+# REPO_BASE_URL="http://linuxsoft.cern.ch/cern/slc6X/$BASE_ARCH/yum/os/"
+# GPG_KEY_PATHS="file:///etc/pki/rpm-gpg/RPM-GPG-KEY-cern"
+# BASE_PACKAGES="sl-release coreutils tar iputils rpm yum yum-conf"
+
+
+TARBALL_NAME="${SYSTEM_NAME}_${BASE_ARCH}.tar.gz"
+DESTINATION="$(mktemp -d)"
+
+which debootstrap || die "debootstrap is not installed"
+
+echo "installing cleanup handler..."
+cleanup() {
+  echo "cleaning up the build environment..."
+  umount ${DESTINATION}/dev  || true
+  umount ${DESTINATION}/proc || true
+  rm -fR $DESTINATION        || true
+}
+trap cleanup EXIT HUP INT TERM
+
+echo "creating chroot dir..."
+[ ! -d $DESTINATION ] || rm -fR $DESTINATION
+mkdir -p $DESTINATION
+
+echo "bootstrapping a build environment..."
+debootstrap --variant=buildd  \
+            trusty            \
+            $DESTINATION      \
+            http://archive.ubuntu.com/ubuntu/
+
+echo "packaging up the image..."
+tar -czf $TARBALL_NAME -C $DESTINATION .

--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -24,7 +24,7 @@ Makefile:
 build: build-stamp
 build-stamp: Makefile
 	dh_testdir
-	dh_auto_build
+	dh_auto_build --parallel
 	touch build-stamp
 
 clean:


### PR DESCRIPTION
This allows for dockerized builds on Ubuntu 64bit including a recipe to generate the Docker image. Furthermore it builds with `make -j XX` now.