### PR TITLE
Use IntegerMap for CVMFS_{U/G}ID_MAP

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -46,6 +46,7 @@ set (CVMFS_CLIENT_SOURCES
   globals.h globals.cc
   sql.h sql_impl.h sql.cc
   catalog_sql.h catalog_sql.cc
+  uid_map.h
   catalog.h catalog.cc
   catalog_mgr.h catalog_mgr_impl.h
   catalog_mgr_client.h catalog_mgr_client.cc
@@ -162,6 +163,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
   catalog_traversal.h
   sql.h sql_impl.h sql.cc
   catalog_sql.h catalog_sql.cc
+  uid_map.h
   catalog.h catalog.cc
   catalog_rw.h catalog_rw.cc
   catalog_mgr.h catalog_mgr_impl.h

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -578,8 +578,8 @@ void Catalog::SetInodeAnnotation(InodeAnnotation *new_annotation) {
 
 
 void Catalog::SetOwnerMaps(const OwnerMap *uid_map, const OwnerMap *gid_map) {
-  uid_map_ = (uid_map && !uid_map->IsEmpty()) ? uid_map : NULL;
-  gid_map_ = (gid_map && !gid_map->IsEmpty()) ? gid_map : NULL;
+  uid_map_ = (uid_map && uid_map->HasEffect()) ? uid_map : NULL;
+  gid_map_ = (gid_map && gid_map->HasEffect()) ? gid_map : NULL;
 }
 
 

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -578,8 +578,8 @@ void Catalog::SetInodeAnnotation(InodeAnnotation *new_annotation) {
 
 
 void Catalog::SetOwnerMaps(const OwnerMap *uid_map, const OwnerMap *gid_map) {
-  uid_map_ = (uid_map && !uid_map->empty()) ? uid_map : NULL;
-  gid_map_ = (gid_map && !gid_map->empty()) ? gid_map : NULL;
+  uid_map_ = (uid_map && !uid_map->IsEmpty()) ? uid_map : NULL;
+  gid_map_ = (gid_map && !gid_map->IsEmpty()) ? gid_map : NULL;
 }
 
 

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -20,6 +20,7 @@
 #include "hash.h"
 #include "shortstring.h"
 #include "sql.h"
+#include "uid_map.h"
 #include "util.h"
 #include "xattr.h"
 
@@ -37,7 +38,7 @@ class Catalog;
 class Counters;
 
 typedef std::vector<Catalog *> CatalogList;
-typedef std::map<uint64_t, uint64_t> OwnerMap;  // used to map uid/gid
+typedef IntegerMap<uint64_t> OwnerMap;  // used to map uid/gid
 
 
 /**

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -543,16 +543,10 @@ DirectoryEntry SqlLookup::GetDirent(const Catalog *catalog,
     } else {
       result.uid_              = RetrieveInt64(13);
       result.gid_              = RetrieveInt64(14);
-      if (catalog->uid_map_) {
-        OwnerMap::const_iterator i = catalog->uid_map_->find(result.uid_);
-        if (i != catalog->uid_map_->end())
-          result.uid_ = i->second;
-      }
-      if (catalog->gid_map_) {
-        OwnerMap::const_iterator i = catalog->gid_map_->find(result.gid_);
-        if (i != catalog->gid_map_->end())
-          result.gid_ = i->second;
-      }
+      if (catalog->uid_map_)
+        result.uid_ = catalog->uid_map_->Map(result.uid_);
+      if (catalog->gid_map_)
+        result.gid_ = catalog->gid_map_->Map(result.gid_);
     }
   }
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1833,8 +1833,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   string alien_cache = ".";  // default: exclusive cache
   string trusted_certs = "";
   string proxy_template = "";
-  map<uint64_t, uint64_t> uid_map;
-  map<uint64_t, uint64_t> gid_map;
+  catalog::OwnerMap uid_map;
+  catalog::OwnerMap gid_map;
   uint64_t initial_generation = 0;
   cvmfs::Uuid *uuid;
   bool use_geo_api = false;
@@ -1989,14 +1989,14 @@ static int Init(const loader::LoaderExports *loader_exports) {
     alien_cache = parameter;
   }
   if (cvmfs::options_manager_->GetValue("CVMFS_UID_MAP", &parameter)) {
-    retval = cvmfs::options_manager_->ParseUIntMap(parameter, &uid_map);
+    retval = uid_map.Read(parameter);
     if (!retval) {
       *g_boot_error = "failed to parse uid map " + parameter;
       return loader::kFailOptions;
     }
   }
   if (cvmfs::options_manager_->GetValue("CVMFS_GID_MAP", &parameter)) {
-    retval = cvmfs::options_manager_->ParseUIntMap(parameter, &gid_map);
+    gid_map.Read(parameter);
     if (!retval) {
       *g_boot_error = "failed to parse gid map " + parameter;
       return loader::kFailOptions;

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -331,34 +331,6 @@ string OptionsManager::Dump() {
   return result;
 }
 
-
-bool OptionsManager::ParseUIntMap(const string &path,
-    map<uint64_t, uint64_t> *map) {
-  assert(map);
-
-  FILE *fmap = fopen(path.c_str(), "r");
-  if (!fmap)
-    return false;
-
-  string line;
-  while (GetLineFile(fmap, &line)) {
-    line = Trim(line);
-    if (line.empty() || line[0] == '#') {
-      continue;
-    }
-    vector<string> components = SplitString(line, ' ');
-    if (components.size() != 2) {
-      fclose(fmap);
-      return false;
-    }
-    uint64_t from = String2Uint64(components[0]);
-    uint64_t to = String2Uint64(components[1]);
-    map->insert(pair<uint64_t, uint64_t>(from, to));
-  }
-  fclose(fmap);
-  return true;
-}
-
 #ifdef CVMFS_NAMESPACE_GUARD
 }  // namespace CVMFS_NAMESPACE_GUARD
 #endif

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -101,16 +101,6 @@ class OptionsManager {
    */
   std::string Dump();
 
-  /**
-   * Parse a configuration file whose variables' values are positive integers
-   *
-   * @param  path absolute path to the configuration file
-   * @param  map map to store the generated key-value
-   * @return true if the file exists, is readable and all values can be parsed
-   *         to integers
-   */
-  bool ParseUIntMap(const std::string &path, std::map<uint64_t, uint64_t> *map);
-
  protected:
   /**
     * The ConfigValue structure contains a concrete value of a variable, as well

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -113,10 +113,10 @@ class IntegerMap {
       : k;
   }
 
-  bool IsEmpty() const { 
-    return map_.size() == 0 && !has_default_value_;   
+  bool IsEmpty() const {
+    return map_.size() == 0 && !has_default_value_;
   }
-    
+
   bool   IsValid()    const { return valid_;             }
   bool   HasDefault() const { return has_default_value_; }
   size_t RuleCount()  const { return map_.size();        }

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -110,9 +110,13 @@ class IntegerMap {
 
     return (HasDefault())
       ? default_value_
-      : T(0);
+      : k;
   }
 
+  bool IsEmpty() const { 
+    return map_.size() == 0 && !has_default_value_;   
+  }
+    
   bool   IsValid()    const { return valid_;             }
   bool   HasDefault() const { return has_default_value_; }
   size_t RuleCount()  const { return map_.size();        }

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -113,10 +113,11 @@ class IntegerMap {
       : k;
   }
 
-  bool IsEmpty() const {
-    return map_.size() == 0 && !has_default_value_;
+  bool HasEffect() const {
+    return (map_.size() != 0) || has_default_value_;
   }
 
+  bool   IsEmpty()    const { return map_.size() == 0;   }
   bool   IsValid()    const { return valid_;             }
   bool   HasDefault() const { return has_default_value_; }
   size_t RuleCount()  const { return map_.size();        }

--- a/test/src/063-uidmap/main
+++ b/test/src/063-uidmap/main
@@ -1,0 +1,36 @@
+
+cvmfs_test_name="Uid/Gid Mapping of files and directories"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  local uid_map=$(mktemp)
+  local gid_map=$(mktemp)
+
+  echo "* 1337" > "$uid_map"
+  echo "* 1338" > "$gid_map"
+  chmod 0444 "$uid_map" "$gid_map"
+
+  cvmfs_mount grid.cern.ch "CVMFS_CLAIM_OWNERSHIP=no" \
+    "CVMFS_UID_MAP=$uid_map" "CVMFS_GID_MAP=$gid_map"
+  local retval=$?
+  rm -f "$uid_map" "$gid_map"
+
+  if [ $retval -ne 0 ]; then
+    echo "mount returned $retval"
+    return 1
+  fi
+
+  local discovered_uid=$(stat -c %u /cvmfs/grid.cern.ch)
+  local discovered_gid=$(stat -c %g /cvmfs/grid.cern.ch)
+
+  echo "$discovered_uid $discovered_gid"
+  if [ "x1337" != "x$discovered_uid" ]; then
+    return 10
+  fi
+  if [ "x1338" != "x$discovered_gid" ]; then
+    return 11
+  fi
+
+  return 0
+}

--- a/test/unittests/t_uid_map.cc
+++ b/test/unittests/t_uid_map.cc
@@ -107,6 +107,7 @@ TYPED_TEST(T_UidMap, Initialize) {
   EXPECT_TRUE(map.IsValid());
   EXPECT_FALSE(map.HasDefault());
   EXPECT_TRUE(map.IsEmpty());
+  EXPECT_FALSE(map.HasEffect());
 }
 
 
@@ -118,6 +119,7 @@ TYPED_TEST(T_UidMap, Insert) {
   EXPECT_FALSE(map.HasDefault());
   EXPECT_EQ(2u, map.RuleCount());
   EXPECT_FALSE(map.IsEmpty());
+  EXPECT_TRUE(map.HasEffect());
 }
 
 
@@ -149,8 +151,10 @@ TYPED_TEST(T_UidMap, Contains) {
 TYPED_TEST(T_UidMap, Empty) {
   TypeParam map;
   EXPECT_TRUE(map.IsEmpty());
+  EXPECT_FALSE(map.HasEffect());
   map.SetDefault(TestFixture::v(42));
-  EXPECT_FALSE(map.IsEmpty());
+  EXPECT_TRUE(map.IsEmpty());
+  EXPECT_TRUE(map.HasEffect());
 }
 
 

--- a/test/unittests/t_uid_map.cc
+++ b/test/unittests/t_uid_map.cc
@@ -106,6 +106,7 @@ TYPED_TEST(T_UidMap, Initialize) {
   TypeParam map;
   EXPECT_TRUE(map.IsValid());
   EXPECT_FALSE(map.HasDefault());
+  EXPECT_TRUE(map.IsEmpty());
 }
 
 
@@ -116,6 +117,7 @@ TYPED_TEST(T_UidMap, Insert) {
   EXPECT_TRUE(map.IsValid());
   EXPECT_FALSE(map.HasDefault());
   EXPECT_EQ(2u, map.RuleCount());
+  EXPECT_FALSE(map.IsEmpty());
 }
 
 
@@ -144,6 +146,14 @@ TYPED_TEST(T_UidMap, Contains) {
 }
 
 
+TYPED_TEST(T_UidMap, Empty) {
+  TypeParam map;
+  EXPECT_TRUE(map.IsEmpty());
+  map.SetDefault(TestFixture::v(42));
+  EXPECT_FALSE(map.IsEmpty());
+}
+
+
 TYPED_TEST(T_UidMap, MapWithoutDefault) {
   TypeParam map;
   map.Set(TestFixture::k(0), TestFixture::v(1));
@@ -151,7 +161,7 @@ TYPED_TEST(T_UidMap, MapWithoutDefault) {
 
   EXPECT_EQ(TestFixture::v(1), map.Map(TestFixture::k(0)));
   EXPECT_EQ(TestFixture::v(2), map.Map(TestFixture::k(1)));
-  EXPECT_EQ(TestFixture::v(0), map.Map(TestFixture::k(3)));
+  EXPECT_EQ(TestFixture::v(3), map.Map(TestFixture::k(3)));
 }
 
 


### PR DESCRIPTION
Remove the parsing of UID/GID maps from the options manager and uses the `IntegerMap` class developed for catalog migration.

NOTE: The semantics of `Map()` has been changed: instead of mapping values without explicit rule to zero, they are now mapped to themselves.  The `Map()` method wasn't used so far.