### PR TITLE
CI: Add Docker Recipe for SLES 11

### DIFF
--- a/ci/docker/sles11_x86_64/Dockerfile
+++ b/ci/docker/sles11_x86_64/Dockerfile
@@ -1,0 +1,27 @@
+## See README.md, build.sh and ../build_on_docker.sh
+
+FROM       scratch
+MAINTAINER Rene Meusel <rene.meusel@cern.ch>
+
+ADD        sles11_x86_64.tar.gz /
+RUN        zypper -n update && zypper -n install   \
+                                  cmake            \
+                                  fuse-devel       \
+                                  gcc              \
+                                  gcc-c++          \
+                                  git              \
+                                  libattr-devel    \
+                                  libcurl-devel    \
+                                  libopenssl-devel \
+                                  libuuid-devel    \
+                                  make             \
+                                  patch            \
+                                  pkgconfig        \
+                                  python-devel     \
+                                  tar              \
+                                  unzip            \
+                                  zlib-devel
+
+RUN        useradd sftnight
+USER       sftnight
+WORKDIR    /home/sftnight

--- a/ci/docker/sles11_x86_64/build.sh
+++ b/ci/docker/sles11_x86_64/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+. ${SCRIPT_LOCATION}/../common.sh
+
+SYSTEM_NAME="sles11"
+BASE_ARCH="x86_64"
+
+TARBALL_NAME="${SYSTEM_NAME}_${BASE_ARCH}.tar.gz"
+DESTINATION="$(mktemp -d)"
+
+echo "installing cleanup handler..."
+cleanup() {
+  echo "cleaning up the build environment..."
+  rm -fR $DESTINATION || true
+}
+trap cleanup EXIT HUP INT TERM
+
+echo "creating chroot dir..."
+[ ! -d $DESTINATION ] || rm -fR $DESTINATION
+mkdir -p $DESTINATION
+
+echo "running essential build script in a SuSE container..."
+docker run --volume ${DESTINATION}:/chroot    \
+           --volume ${SCRIPT_LOCATION}:/build \
+           --privileged=true                  \
+           opensuse:latest /build/build_internal.sh
+
+echo "package up the base image..."
+tar -czf $TARBALL_NAME -C $DESTINATION .

--- a/ci/docker/sles11_x86_64/build_internal.sh
+++ b/ci/docker/sles11_x86_64/build_internal.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+set -e
+
+REPO_BASE_URL=http://cvm-storage00.cern.ch/yum/sles11/
+REPO_BASE_URL_SDK=http://cvm-storage00.cern.ch/yum/sles11-sdk/
+DESTINATION=/chroot
+
+echo "registering cleanup handler..."
+cleanup() {
+  echo "cleaning up the chroot environment..."
+  umount ${DESTINATION}/proc || true
+  umount ${DESTINATION}/sys  || true
+  umount ${DESTINATION}/dev  || true
+}
+trap cleanup EXIT HUP INT TERM
+
+echo "setting up base system..."
+zypper --non-interactive      \
+       --gpg-auto-import-keys \
+       --root ${DESTINATION}  \
+       addrepo $REPO_BASE_URL repo-suse
+
+zypper --non-interactive      \
+       --gpg-auto-import-keys \
+       --root ${DESTINATION}  \
+       addrepo $REPO_BASE_URL_SDK repo-suse-sdk
+
+echo "mounting /proc, /sys and /dev file systems..."
+mkdir -p ${DESTINATION}/proc ${DESTINATION}/sys ${DESTINATION}/dev
+mount -t proc proc ${DESTINATION}/proc/
+mount -t sysfs sys ${DESTINATION}/sys/
+mount -o bind /dev ${DESTINATION}/dev/
+
+echo "refreshing metadata cache..."
+zypper --non-interactive      \
+       --gpg-auto-import-keys \
+       --root ${DESTINATION}  \
+       refresh
+
+echo "downloading necessary RPMs..."
+zypper --non-interactive       \
+       --root ${DESTINATION}   \
+       install --download-only \
+       sles-release zypper
+
+echo "copying zypper cache for later re-build..."
+zypper_cache="${DESTINATION}/var/cache/zypp/packages"
+mkdir -p ${DESTINATION}/tmp
+cp -r $zypper_cache ${DESTINATION}/tmp
+
+echo "installing dependencies for broken openldap2-client RPM..."
+# Workaround: openldap-client has a broken post-install script
+#             therefore we download and install it manually without running
+#             the install scripts.
+zypper --non-interactive     \
+       --root ${DESTINATION} \
+       install glibc libopenssl0_9_8 libldap-2_4-2 cyrus-sasl
+
+echo "downloading and installing broken openldap2-client RPM (--noscript)..."
+zypper --non-interactive install wget # on host container
+rpm_url=${REPO_BASE_URL}/suse/x86_64/openldap2-client-2.4.26-0.24.36.x86_64.rpm
+rpm_name=/tmp/$(basename $rpm_url)
+wget -O $rpm_name $rpm_url
+rpm --root ${DESTINATION} \
+    --noscripts           \
+    -i $rpm_name
+
+echo "installing base system and package manager..."
+zypper --non-interactive     \
+       --root ${DESTINATION} \
+       install sles-release zypper
+
+echo "checking for expected public key..."
+expected_pubkey1="gpg-pubkey-3dbdc284-53674dd4"
+expected_pubkey2="gpg-pubkey-307e3d54-4be01a65"
+[ $(rpm -qa | grep gpg-pubkey | wc -l) -eq 2 ] || { echo "more than two keys found"; exit 1; }
+rpm -qa | grep $expected_pubkey1               || { echo "public key doesn't match"; exit 1; }
+rpm -qa | grep $expected_pubkey2               || { echo "public key doesn't match"; exit 1; }
+
+echo "rebuilding rpm database..."
+rpm_db="${DESTINATION}/var/lib/rpm"
+rm -fR $rpm_db
+mkdir -p $rpm_db
+chroot $DESTINATION rpm --initdb
+chroot $DESTINATION rpm -ivh --justdb '/tmp/packages/repo-suse/suse/*/*.rpm'
+
+echo "cleaning up zypper cache copy..."
+rm -fR ${DESTINATION}/tmp/packages
+
+echo "cleaning zypper caches..."
+zypper --non-interactive     \
+       --root ${DESTINATION} \
+       clean


### PR DESCRIPTION
That was a bit of a fight. Mainly because the `openldap-client` RPM wasn't able to properly run it's post-install script. The workaround is as follows now:

1. install all dependencies for `openldap-client` via `zypper`
2. download the `openldap-client` RPM from the repository
3. install it via `rpm -i --noscript`
4. install `sles-release` via `zypper` that depends on `openldap-client`

This will probably render the installed LDAP package useless, but we don't care about that while using the docker container only for RPM builds.

A second complication was that there is no public SLES docker container that could have been used for bootstrapping. I am now using the `opensuse` container I used to bootstrap OpenSUSE 13. Hence, after bootstrapping I need to rebuild the RPM database as the distributions are not compatible. In order to do that, I need to stash all installed RPM packages from `zypper`'s cache temporarily.