### PR TITLE
FIX: systemd might run multiple times

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -78,7 +78,7 @@ minpidof() {
   pidof $1 | tr " " "\n" | sort | head -n1
 }
 SERVICE_BIN="false"
-if ! pidof systemd > /dev/null 2>&1 || [ $(pidof systemd) -ne 1 ]; then
+if ! pidof systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
   if [ -x /sbin/service ]; then
     SERVICE_BIN="/sbin/service"
   elif [ -x /usr/sbin/service ]; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -74,6 +74,9 @@ else # RedHat based
 fi
 
 # Find the service binary (or detect systemd)
+minpidof() {
+  pidof $1 | tr " " "\n" | sort | head -n1
+}
 SERVICE_BIN="false"
 if ! pidof systemd > /dev/null 2>&1 || [ $(pidof systemd) -ne 1 ]; then
   if [ -x /sbin/service ]; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -75,7 +75,7 @@ fi
 
 # Find the service binary (or detect systemd)
 minpidof() {
-  pidof $1 | tr " " "\n" | sort | head -n1
+  pidof $1 | tr " " "\n" | sort --numeric-sort | head -n1
 }
 SERVICE_BIN="false"
 if ! pidof systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -66,8 +66,11 @@ die() {
 
 
 # Find the service binary (or detect systemd)
+minpidof() {
+  pidof $1 | tr " " "\n" | sort --numeric-sort | head -n1
+}
 SERVICE_BIN="false"
-if ! pidof systemd > /dev/null 2>&1 || [ $(pidof systemd) -ne 1 ]; then
+if ! pidof systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
   if [ -x /sbin/service ]; then
     SERVICE_BIN="/sbin/service"
   elif [ -x /usr/sbin/service ]; then


### PR DESCRIPTION
Fedora 22 has multiple `systemd` processes running. Hence, the check for `systemd` in `cvmfs_server` cannot simply do `$(pidof systemd) -eq 1` since this might have returned multiple PIDs. This introduces a `minpidof()` helper to figure out the lowest running PID that can then be checked for `1`.