### PR TITLE
FIX: Race for Ambiguous Auto Tag Names

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3870,6 +3870,11 @@ publish() {
     if [ -z "$tag_name" ] && [ x"$CVMFS_AUTO_TAG" = x"true" ]; then
       local timestamp=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
       tag_name="generic-$timestamp"
+      local tag_name_number=1
+      while tag -x -i $tag_name $name > /dev/null 2>&1; do
+        tag_name="generic_$tag_name_number-$timestamp"
+        tag_name_number=$(( $tag_name_number + 1 ))
+      done
       echo "Using auto tag '$tag_name'"
     fi
 


### PR DESCRIPTION
Turns out that Fedora 22 with OverlayFS in a virtual machine on my laptop is fast enough to produce the same auto-tag for two distinct publish operations in integration tests. I.e. it runs two invocations of `cvmfs_server publish` in the same wall-clock second, generating the same auto-tag twice.

This checks if an auto-tag is already in use and adds a running number to the tag name in this case. Perhaps this can only happen with scripted setups, because a human cannot type fast enough. ;-)