### PR TITLE
Vagrant: Secondary hard drive for Fedora 22

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,5 +72,22 @@ Vagrant.configure(2) do |config|
     fedora.vm.synced_folder '.', '/vagrant', nfs: true
 
     fedora.vm.provision "shell", path: "vagrant/provision_fedora.sh"
+
+    config.vm.provider "virtualbox" do |vb|
+      vb.name = "cvmfs_fedora"
+      # Get disk path
+      line = `VBoxManage list systemproperties | grep "Default machine folder"`
+      vb_machine_folder = line.split(':')[1].strip()
+      second_disk = File.join(vb_machine_folder, vb.name, 'disk2.vdi')
+
+      # Create and attach disk
+      unless File.exist?(second_disk)
+        vb.customize ['createhd', '--filename', second_disk, '--format', 'VDI',
+                      '--size', 10 * 1024]
+      end
+      vb.customize ['storageattach', :id, '--storagectl', 'IDE Controller',
+                    '--port', 0, '--device', 1, '--type', 'hdd',
+                    '--medium', second_disk]
+    end
   end
 end

--- a/vagrant/provision_fedora.sh
+++ b/vagrant/provision_fedora.sh
@@ -18,6 +18,9 @@ mkdir -p $mntpoint
 echo "$drive $mntpoint ext4 defaults 0 0" >> /etc/fstab
 mount $mntpoint
 
+# update packages
+dnf -y update
+
 # install necessary development packages
 dnf -y install libuuid-devel gcc gcc-c++ glibc-common cmake fuse fuse-devel  \
                fuse-libs libattr-devel openssl openssl-devel patch pkgconfig \

--- a/vagrant/provision_fedora.sh
+++ b/vagrant/provision_fedora.sh
@@ -38,8 +38,8 @@ fi
 
 # enable httpd on boot
 if ! systemctl status httpd > /dev/null 2>&1; then
-  systemctl enable httpd > /dev/null 2>&!
-  systemctl start  httpd > /dev/null 2>&!
+  systemctl enable httpd > /dev/null 2>&1
+  systemctl start  httpd > /dev/null 2>&1
 fi
 
 # load overlayfs kernel module on boot

--- a/vagrant/provision_fedora.sh
+++ b/vagrant/provision_fedora.sh
@@ -10,6 +10,14 @@ VAGRANT_WORKSPACE="/vagrant"
 export LANG="en_US.UTF-8"
 echo "LANG=\"$LANG\"" > /etc/sysconfig/i18n
 
+# create secondary hard drive as ext4 volume
+drive="/dev/sdb"
+mntpoint="/var/spool/cvmfs"
+mkfs.ext4 $drive
+mkdir -p $mntpoint
+echo "$drive $mntpoint ext4 defaults 0 0" >> /etc/fstab
+mount $mntpoint
+
 # install necessary development packages
 dnf -y install libuuid-devel gcc gcc-c++ glibc-common cmake fuse fuse-devel  \
                fuse-libs libattr-devel openssl openssl-devel patch pkgconfig \


### PR DESCRIPTION
This creates a secondary ext4 hard drive for the Fedora 22 vagrant box and mounts it to /var/spool/cvmfs. Furthermore it fixes two things:

* syntax error in provisioning script
* `dnf -y update` while provisioning