### PR TITLE
Add libcvmfs integration tests (597)

### DIFF
--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -1,0 +1,41 @@
+cvmfs_test_name="Libcvmfs test"
+cvmfs_test_autofs_on_startup=false
+
+cvmfs_run_test() {
+  local workdir="$2"
+  # compile the source first
+  local bin_name="597-test"
+  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -luuid -lrt
+
+  apache_switch on
+  local num_repos=5
+  local base_name="local.libcvmfs_test_"
+  for i in $(seq 1 $num_repos); do
+    local repo_name="$base_name$i"
+    local repo_dir="/cvmfs/$repo_name"
+
+    create_repo "$repo_name" $(whoami)
+    start_transaction "$repo_name"
+
+    rm $repo_dir/*  # cleanup the repository before starting
+    mkdir "$repo_dir/main"
+    echo "$i" > "$repo_dir/main/mainfile"
+
+    mkdir "$repo_dir/list"
+    for j in $(seq 1 $i); do
+      touch "$repo_dir/list/file$j"
+    done
+
+    publish_repo "$repo_name"
+  done
+
+  # check libcvmfs with the generated binary
+  "./$bin_name" "$base_name" "$num_repos"
+  return_code=$?
+
+  for i in $(seq 1 $num_repos); do
+    destroy_repo "$base_name$i"
+  done
+
+  return $return_code
+}

--- a/test/src/597-libcvmfs/main.cc
+++ b/test/src/597-libcvmfs/main.cc
@@ -1,0 +1,101 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+#include <errno.h>
+#include <stdio.h>
+
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "libcvmfs.h"
+
+#define TEST_LINE_MAX 1024
+
+using namespace std;  // NOLINT
+
+const char *repo_options =
+  "repo_name=%s,url=http://localhost/cvmfs/%s,"
+  "pubkey=/etc/cvmfs/keys/%s.pub,"
+  "proxies=DIRECT";
+
+int main(int argc, char *argv[]) {
+  if (argc < 3) {
+    printf("Not enough arguments\n");
+    return -2;
+  }
+  const char *global_options = "cache_directory=/tmp/test-libcvmfs-cache";
+  int retval = cvmfs_init(global_options);
+  if (retval != 0) {
+    fprintf(stderr, "couldn't initialize libcvmfs!\n");
+    return -1;
+  }
+  cvmfs_context *ctx = NULL;
+  string base_repo_name = argv[1];
+  int num_repos = atoi(argv[2]);
+  vector<cvmfs_context*> ctx_vector;
+  char options[TEST_LINE_MAX];
+
+  for (int counter = 1; counter <= num_repos; ++counter) {
+    ostringstream s;
+    s << base_repo_name;
+    s << counter;
+    string repo_name = s.str();
+    snprintf(options, TEST_LINE_MAX, repo_options, repo_name.c_str(),
+      repo_name.c_str(), repo_name.c_str());
+    printf("Trying to mount with options:\n%s\n", options);
+    ctx = cvmfs_attach_repo(options);
+    ctx_vector.push_back(ctx);
+    if (ctx == NULL) {
+      printf("couldn't attach the repository %s\n", repo_name.c_str());
+      return counter;
+    }
+
+    // first test: check that the content of /${testname}/main/mainfile
+    // is ${counter}
+    string mainfile_path = "/main/mainfile";
+    int fd = cvmfs_open(ctx, mainfile_path.c_str());
+    if (fd < 0) {
+      printf("Couldn't perform the lookup operation in %s\n",
+        mainfile_path.c_str());
+      return fd;
+    }
+    char buffer[10];
+    read(fd, buffer, sizeof(buffer));
+    int number = atoi(buffer);
+    if (number != counter) {
+      printf("Failed to verify value: %d != %d", number, counter);
+      return -3;
+    }
+
+    // second test: check that listing /${testname}/list produces
+    // ${counter} entries
+    string list_path = "/list";
+    size_t length = 0;
+    char **list_buffer = 0;
+    int result = cvmfs_listdir(ctx, list_path.c_str(), &list_buffer, &length);
+    if (result < 0) {
+      printf("Couldn't perform the list operation in %s\n", list_path.c_str());
+      return result;
+    }
+    int num_elem = 0;
+    for (int i = 0; list_buffer[i]; ++i) {
+      ++num_elem;
+    }
+    // remove the . and .. entries
+    num_elem -= 2;
+    if (num_elem != counter) {
+      printf("Failed to list the correct number of files\n"
+        "Current: %d       Expected: %d\n", num_elem, num_repos);
+      return -6;
+    }
+  }
+
+  for (int i = 0; i < ctx_vector.size(); ++i) {
+    cvmfs_detach_repo(ctx_vector[i]);
+  }
+
+  cvmfs_fini();
+  return 0;
+}


### PR DESCRIPTION
This test creates the typical integration test structure and compiles a binary whose source is included in the same folder. This binary actually tests if the repositories contain the required structure, and it is compiled against libcvmfs.a 