### PR TITLE
FIX: Detect and React on OverlayFS older than V22

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2121,9 +2121,14 @@ setup_and_mount_new_repository() {
     if has_selinux && try_mount_remount_cycle_overlayfs; then
       selinux_context=",context=\"system_u:object_r:default_t:s0\""
     fi
+    if [ x"$(get_overlayfs_type)" = x"$OFS_POST_V22" ]; then
+      ofs_workdir=",workdir=${ofs_workdir}"
+    else
+      ofs_workdir=""
+    fi
     cat >> /etc/fstab << EOF
 cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid 0 0 # added by CernVM-FS for $name
-${overlayfs_name}_$name /cvmfs/$name $overlayfs_name upperdir=${scratch_dir},lowerdir=${rdonly_dir},workdir=${ofs_workdir},ro$selinux_context 0 0 # added by CernVM-FS for $name
+${overlayfs_name}_$name /cvmfs/$name $overlayfs_name upperdir=${scratch_dir},lowerdir=${rdonly_dir}$ofs_workdir,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   else
     echo -n "(aufs) "

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -507,9 +507,10 @@ check_aufs() {
 # of if overlayfs is compiled in
 # @return   0 if the overlayfs kernel module is loaded
 check_overlayfs() {
+  local conf_gz="/proc/config.gz"
   /sbin/modprobe -q overlayfs || test -d /sys/module/overlayfs || \
   /sbin/modprobe -q overlay   || test -d /sys/module/overlay || \
-  test x"$(zgrep OVERLAY_FS /proc/config.gz | awk -F = '{print $2}')" = xy
+  [ x"$(zgrep OVERLAY_FS $conf_gz 2>/dev/null | awk -F = '{print $2}')" = x"y" ]
 }
 
 # check if at least one of the supported union file systems is available

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -541,6 +541,20 @@ get_overlayfs_name() {
   fi
 }
 
+# guess the installed OverlayFS version since starting from OverlayFS V22 it
+# requires to specify a 'workdir' and uses character devices for whiteouts
+# TODO: Is there a better way than guessing based on the kernel version?
+OFS_PRE_V22=1
+OFS_POST_V22=2
+get_overlayfs_type() {
+  ofs_name="$(get_overlayfs_name)"
+  vermagic="$(modinfo --field vermagic $ofs_name)"
+  krnl_version="$(echo "$vermagic" | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+')"
+  ofs_type=OFS_POST_V22
+  if compare_versions "$krnl_version" -lt 3.18.0; then ofs_type=$OFS_PRE_V22; fi
+  echo "$ofs_type"
+}
+
 
 # checks if autofs is disabled on /cvmfs
 #


### PR DESCRIPTION
OverlayFS v22 is the version that went into the 3.18 kernel; it requires a `workdir` specification on mount and uses character devices for whiteouts. Before (like on ubuntu) it used symlinks for whiteouts and doesn't mount when a `workdir` is specified. Hence, we need to distinguish them.

Unfortunate I didn't find a way to get the version number of OverlayFS, hence I use the kernel version as an indicator.