### PR TITLE
FIX: Hardlink Check for Whiteouts

### DIFF
--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -281,8 +281,10 @@ void SyncUnionOverlayfs::ProcessFile(SyncItem *entry) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnionOverlayfs::ProcessFile(%s)",
            entry->filename().c_str());
 
-  CheckForBrokenHardlink(entry);
-  MaskFileHardlinks(entry);
+  if (! IsWhiteoutEntry(*entry)) {
+    CheckForBrokenHardlink(entry);
+    MaskFileHardlinks(entry);
+  }
 
   SyncUnion::ProcessFile(entry);
 }


### PR DESCRIPTION
`SyncUnionOverlayfs::ProcessFile()` needs to check if the passed `SyncItem` is a whiteout before doing any hardlink masking on it.