### PR TITLE
FIX: Hardlink Check and Preprocessing in OverlayFS

### DIFF
--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -8,6 +8,7 @@
 #define CVMFS_PLATFORM_LINUX_H_
 
 #include <sys/types.h>  // contains ssize_t needed inside <attr/xattr.h>
+#include <sys/xattr.h>
 #include <attr/xattr.h>  // NOLINT(build/include_alpha)
 #include <dirent.h>
 #include <errno.h>

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -52,14 +52,11 @@ class SyncItem {
   inline bool IsSymlink()         const { return IsType(kItemSymlink);         }
   inline bool WasSymlink()        const { return WasType(kItemSymlink);        }
   inline bool IsNew()             const { return WasType(kItemNew);            }
+  inline bool IsCharacterDevice() const { return IsType(kItemCharacterDevice); }
 
   inline bool IsWhiteout()        const { return whiteout_;                    }
   inline bool IsCatalogMarker()   const { return filename_ == ".cvmfscatalog"; }
   inline bool IsOpaqueDirectory() const { return IsDirectory() && opaque_;     }
-
-  inline bool IsCharacterDevice() const {
-    return scratch_type_ == kItemCharacterDevice;
-  }
 
   inline shash::Any GetContentHash() const { return content_hash_; }
   inline void SetContentHash(const shash::Any &hash) { content_hash_ = hash; }
@@ -157,6 +154,7 @@ class SyncItem {
       if (S_ISDIR(stat.st_mode)) return kItemDir;
       if (S_ISREG(stat.st_mode)) return kItemFile;
       if (S_ISLNK(stat.st_mode)) return kItemSymlink;
+      if (S_ISCHR(stat.st_mode)) return kItemCharacterDevice;
       return kItemUnknown;
     }
 

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -39,22 +39,7 @@ class SyncUnion;
  * details.
  */
 class SyncItem {
- private:
-  /**
-   * create a new SyncItem
-   * Note: SyncItems cannot be created by any using code. SyncUnion will take
-   *       care of their creating through a factory method to make sure they
-   *       are initialised correctly (whiteout, hardlink handling, ...)
-   *
-   * @param dirPath the RELATIVE path to the file
-   * @param filename the name of the file ;-)
-   * @param entryType well...
-   */
-  SyncItem(const std::string  &relative_parent_path,
-           const std::string  &filename,
-           const SyncUnion    *union_engine,
-           const SyncItemType  entry_type);
-
+  // only SyncUnion can create SyncItems (see SyncUnion::CreateSyncItem)
   friend class SyncUnion;
 
  public:
@@ -144,6 +129,21 @@ class SyncItem {
   }
 
  private:
+  /**
+   * create a new SyncItem
+   * Note: SyncItems cannot be created by any using code. SyncUnion will take
+   *       care of their creating through a factory method to make sure they
+   *       are initialised correctly (whiteout, hardlink handling, ...)
+   *
+   * @param dirPath the RELATIVE path to the file
+   * @param filename the name of the file ;-)
+   * @param entryType well...
+   */
+  SyncItem(const std::string  &relative_parent_path,
+           const std::string  &filename,
+           const SyncUnion    *union_engine,
+           const SyncItemType  entry_type);
+
   /**
    * Structure to cache stat calls to the different file locations.
    */

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -92,10 +92,6 @@ class SyncItem {
   uint64_t GetRdOnlyInode() const;
   unsigned int GetUnionLinkcount() const;
   uint64_t GetUnionInode() const;
-  inline platform_stat64 GetUnionStat() const {
-    StatUnion();
-    return union_stat_.stat;
-  }
 
   inline std::string filename() const { return filename_; }
   inline std::string relative_parent_path() const {
@@ -108,6 +104,11 @@ class SyncItem {
   }
 
  protected:
+  inline platform_stat64 GetUnionStat() const {
+    StatUnion();
+    return union_stat_.stat;
+  }
+
   SyncItemType GetRdOnlyFiletype() const;
   SyncItemType GetScratchFiletype() const;
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -360,12 +360,12 @@ void SyncMediator::AddDirectoryRecursively(const SyncItem &entry) {
   // created directory
   FileSystemTraversal<SyncMediator> traversal(
     this, union_engine_->scratch_path(), true);
-  traversal.fn_enter_dir = &SyncMediator::EnterAddedDirectoryCallback;
-  traversal.fn_leave_dir = &SyncMediator::LeaveAddedDirectoryCallback;
-  traversal.fn_new_file = &SyncMediator::AddFileCallback;
-  traversal.fn_new_symlink = &SyncMediator::AddSymlinkCallback;
+  traversal.fn_enter_dir      = &SyncMediator::EnterAddedDirectoryCallback;
+  traversal.fn_leave_dir      = &SyncMediator::LeaveAddedDirectoryCallback;
+  traversal.fn_new_file       = &SyncMediator::AddFileCallback;
+  traversal.fn_new_symlink    = &SyncMediator::AddSymlinkCallback;
   traversal.fn_new_dir_prefix = &SyncMediator::AddDirectoryCallback;
-  traversal.fn_ignore_file = &SyncMediator::IgnoreFileCallback;
+  traversal.fn_ignore_file    = &SyncMediator::IgnoreFileCallback;
   traversal.Recurse(entry.GetScratchPath());
 }
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -17,6 +17,7 @@
 #include "fs_traversal.h"
 #include "hash.h"
 #include "smalloc.h"
+#include "sync_union.h"
 #include "upload.h"
 #include "util.h"
 #include "util_concurrency.h"
@@ -340,7 +341,7 @@ void SyncMediator::CompleteHardlinks(const SyncItem &entry) {
 void SyncMediator::LegacyRegularHardlinkCallback(const string &parent_dir,
                                                  const string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, union_engine_, kItemFile);
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemFile);
   InsertLegacyHardlink(entry);
 }
 
@@ -348,7 +349,7 @@ void SyncMediator::LegacyRegularHardlinkCallback(const string &parent_dir,
 void SyncMediator::LegacySymlinkHardlinkCallback(const string &parent_dir,
                                                   const string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, union_engine_, kItemSymlink);
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemSymlink);
   InsertLegacyHardlink(entry);
 }
 
@@ -373,7 +374,7 @@ void SyncMediator::AddDirectoryRecursively(const SyncItem &entry) {
 bool SyncMediator::AddDirectoryCallback(const std::string &parent_dir,
                                         const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
+  SyncItem entry = CreateSyncItem(parent_dir, dir_name, kItemDir);
   AddDirectory(entry);
   return true;  // The recursion engine should recurse deeper here
 }
@@ -382,7 +383,7 @@ bool SyncMediator::AddDirectoryCallback(const std::string &parent_dir,
 void SyncMediator::AddFileCallback(const std::string &parent_dir,
                                    const std::string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, union_engine_, kItemFile);
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemFile);
   Add(entry);
 }
 
@@ -390,7 +391,7 @@ void SyncMediator::AddFileCallback(const std::string &parent_dir,
 void SyncMediator::AddSymlinkCallback(const std::string &parent_dir,
                                       const std::string &link_name)
 {
-  SyncItem entry(parent_dir, link_name, union_engine_, kItemSymlink);
+  SyncItem entry = CreateSyncItem(parent_dir, link_name, kItemSymlink);
   Add(entry);
 }
 
@@ -398,7 +399,7 @@ void SyncMediator::AddSymlinkCallback(const std::string &parent_dir,
 void SyncMediator::EnterAddedDirectoryCallback(const std::string &parent_dir,
                                                const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
+  SyncItem entry = CreateSyncItem(parent_dir, dir_name, kItemDir);
   EnterDirectory(entry);
 }
 
@@ -406,7 +407,7 @@ void SyncMediator::EnterAddedDirectoryCallback(const std::string &parent_dir,
 void SyncMediator::LeaveAddedDirectoryCallback(const std::string &parent_dir,
                                                const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
+  SyncItem entry = CreateSyncItem(parent_dir, dir_name, kItemDir);
   LeaveDirectory(entry);
 }
 
@@ -432,7 +433,7 @@ void SyncMediator::RemoveDirectoryRecursively(const SyncItem &entry) {
 void SyncMediator::RemoveFileCallback(const std::string &parent_dir,
                                       const std::string &file_name)
 {
-  SyncItem entry(parent_dir, file_name, union_engine_, kItemFile);
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemFile);
   Remove(entry);
 }
 
@@ -440,7 +441,7 @@ void SyncMediator::RemoveFileCallback(const std::string &parent_dir,
 void SyncMediator::RemoveSymlinkCallback(const std::string &parent_dir,
                                          const std::string &link_name)
 {
-  SyncItem entry(parent_dir, link_name, union_engine_, kItemSymlink);
+  SyncItem entry = CreateSyncItem(parent_dir, link_name, kItemSymlink);
   Remove(entry);
 }
 
@@ -448,7 +449,7 @@ void SyncMediator::RemoveSymlinkCallback(const std::string &parent_dir,
 void SyncMediator::RemoveDirectoryCallback(const std::string &parent_dir,
                                            const std::string &dir_name)
 {
-  SyncItem entry(parent_dir, dir_name, union_engine_, kItemDir);
+  SyncItem entry = CreateSyncItem(parent_dir, dir_name, kItemDir);
   RemoveDirectoryRecursively(entry);
 }
 
@@ -460,10 +461,18 @@ bool SyncMediator::IgnoreFileCallback(const std::string &parent_dir,
     return true;
   }
 
-  SyncItem entry(parent_dir, file_name, union_engine_);
-  return union_engine_->IsWhiteoutEntry(entry);
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemUnknown);
+  return entry.IsWhiteout();
 }
 
+
+SyncItem SyncMediator::CreateSyncItem(const std::string  &relative_parent_path,
+                                      const std::string  &filename,
+                                      const SyncItemType  entry_type) const {
+  return union_engine_->CreateSyncItem(relative_parent_path,
+                                       filename,
+                                       entry_type);
+}
 
 void SyncMediator::PublishFilesCallback(const upload::SpoolerResult &result) {
   LogCvmfs(kLogPublish, kLogVerboseMsg,

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -152,6 +152,10 @@ class SyncMediator {
   bool IgnoreFileCallback(const std::string &parent_dir,
                           const std::string &file_name);
 
+  SyncItem CreateSyncItem(const std::string  &relative_parent_path,
+                          const std::string  &filename,
+                          const SyncItemType  entry_type) const;
+
   // Called by Upload Spooler
   void PublishFilesCallback(const upload::SpoolerResult &result);
   void PublishHardlinksCallback(const upload::SpoolerResult &result);

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -293,10 +293,18 @@ void SyncUnionOverlayfs::ProcessFile(SyncItem &entry) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnionOverlayfs::ProcessFile(%s)",
            entry.filename().c_str());
 
+  SyncUnion::ProcessFile(entry);
+}
+
+
+void SyncUnionOverlayfs::PreprocessSyncItem(SyncItem &entry) const {
+  SyncUnion::PreprocessSyncItem(entry);
+  if (entry.IsWhiteout() || entry.IsDirectory()) {
+    return;
+  }
+
   CheckForBrokenHardlink(entry);
   MaskFileHardlinks(entry);
-
-  SyncUnion::ProcessFile(entry);
 }
 
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -14,10 +14,8 @@
 #include "fs_traversal.h"
 #include "logging.h"
 #include "platform.h"
-#include "sync_item.h"
 #include "sync_mediator.h"
 #include "util.h"
-#include "xattr.h"
 
 using namespace std;  // NOLINT
 
@@ -40,6 +38,14 @@ SyncUnion::SyncUnion(SyncMediator *mediator,
 bool SyncUnion::Initialize() {
   initialized_ = true;
   return true;
+}
+
+
+SyncItem SyncUnion::CreateSyncItem(const std::string  &relative_parent_path,
+                                   const std::string  &filename,
+                                   const SyncItemType  entry_type) const {
+  SyncItem entry(relative_parent_path, filename, this, entry_type);
+  return entry;
 }
 
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -105,7 +105,7 @@ void SyncUnion::ProcessSymlink(const string &parent_dir,
 }
 
 
-void SyncUnion::ProcessFile(SyncItem &entry) {
+void SyncUnion::ProcessFile(const SyncItem &entry) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessFile(%s)",
            entry.filename().c_str());
   if (entry.IsWhiteout()) {
@@ -286,14 +286,6 @@ bool SyncUnionOverlayfs::ObtainSysAdminCapability() const {
   const bool result = ObtainSysAdminCapabilityInternal(caps);
   cap_free(caps);
   return result;
-}
-
-
-void SyncUnionOverlayfs::ProcessFile(SyncItem &entry) {
-  LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnionOverlayfs::ProcessFile(%s)",
-           entry.filename().c_str());
-
-  SyncUnion::ProcessFile(entry);
 }
 
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -301,7 +301,9 @@ void SyncUnionOverlayfs::PreprocessSyncItem(SyncItem *entry) const {
 
 
 void SyncUnionOverlayfs::CheckForBrokenHardlink(const SyncItem &entry) const {
-  if (!entry.IsNew() && entry.GetRdOnlyLinkcount() > 1) {
+  if (!entry.IsNew()        &&
+      !entry.WasDirectory() &&
+       entry.GetRdOnlyLinkcount() > 1) {
     LogCvmfs(kLogPublish, kLogStderr, "OverlayFS has copied-up a file (%s) "
                                       "with existing hardlinks in lowerdir "
                                       "(linkcount %d). OverlayFS cannot handle "

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -96,8 +96,7 @@ class SyncUnion {
    * @param filename the filename as in the scratch directory
    * @return the original filename of the scratched out file in CVMFS repository
    */
-  virtual std::string UnwindWhiteoutFilename(const std::string &filename)
-          const = 0;
+  virtual std::string UnwindWhiteoutFilename(const SyncItem &entry) const = 0;
 
   /**
    * Union file systems use opaque directories to fully support rmdir
@@ -184,7 +183,7 @@ class SyncUnion {
    * Called to actually process the file entry.
    * @param entry the SyncItem corresponding to the union file to be processed
    */
-  virtual void ProcessFile(SyncItem *entry);
+  virtual void ProcessFile(SyncItem &entry);
 
  private:
   bool initialized_;
@@ -210,7 +209,7 @@ class SyncUnionAufs : public SyncUnion {
   bool IsOpaqueDirectory(const SyncItem &directory) const;
   bool IgnoreFilePredicate(const std::string &parent_dir,
                            const std::string &filename);
-  std::string UnwindWhiteoutFilename(const std::string &filename) const;
+  std::string UnwindWhiteoutFilename(const SyncItem &entry) const;
 
  private:
   std::set<std::string> ignore_filenames_;
@@ -232,8 +231,6 @@ class SyncUnionOverlayfs : public SyncUnion {
   bool Initialize();
 
   void Traverse();
-  void ProcessFileHardlinkCallback(const std::string &parent_dir,
-                                   const std::string &filename);
   static bool ReadlinkEquals(std::string const &path,
                              std::string const &compare_value);
   static bool HasXattr(std::string const &path, std::string const &attr_name);
@@ -247,12 +244,12 @@ class SyncUnionOverlayfs : public SyncUnion {
                            const std::string &filename);
   void ProcessCharacterDevice(const std::string &parent_dir,
                               const std::string &filename);
-  std::string UnwindWhiteoutFilename(const std::string &filename) const;
+  std::string UnwindWhiteoutFilename(const SyncItem &entry) const;
   std::set<std::string> GetIgnoreFilenames() const;
-  virtual void ProcessFile(SyncItem *entry);
+  virtual void ProcessFile(SyncItem &entry);
 
-  void CheckForBrokenHardlink(SyncItem *entry) const;
-  void MaskFileHardlinks(SyncItem *entry) const;
+  void CheckForBrokenHardlink(SyncItem &entry) const;
+  void MaskFileHardlinks(SyncItem &entry) const;
 
   bool ObtainSysAdminCapability() const;
 

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -244,6 +244,8 @@ class SyncUnionOverlayfs : public SyncUnion {
   static bool HasXattr(std::string const &path, std::string const &attr_name);
 
  protected:
+  void PreprocessSyncItem(SyncItem &entry) const;
+
   bool IsWhiteoutEntry(const SyncItem &entry) const;
   bool IsOpaqueDirectory(const SyncItem &directory) const;
   bool IsWhiteoutSymlinkPath(const std::string &path) const;

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -138,6 +138,14 @@ class SyncUnion {
   SyncMediator *mediator_;
 
   /**
+   * Allow for preprocessing steps before emiting any SyncItems from SyncUnion.
+   * This can be overridden by sub-classes but should always be up-called. Typi-
+   * cally this sets whiteout and opaque-directory flags or handles hardlinks.
+   * @param entry  the SyncItem to be pre-processed
+   */
+  virtual void PreprocessSyncItem(SyncItem &entry) const;
+
+  /**
    * Callback when a regular file is found.
    * @param parent_dir the relative directory path
    * @param filename the filename

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -35,9 +35,10 @@
 #include <set>
 #include <string>
 
+#include "sync_item.h"
+
 namespace publish {
 
-class SyncItem;
 class SyncMediator;
 
 /**
@@ -71,6 +72,19 @@ class SyncUnion {
    * Main routine, process scratch space
    */
   virtual void Traverse() = 0;
+
+  /**
+   * This produces a SyncItem and initialises it accordingly. This is the only
+   * way client code can generate SyncItems to make sure it is always set up
+   * properly (see SyncItem::SyncItem() for further details).
+   * @param relative_parent_path  the directory path the SyncItem resides in
+   * @param filename              file/directory name of directory entry
+   * @param entry_type            type of the item in the union directory
+   * @return                      a SyncItem object wrapping the dirent
+   */
+  SyncItem CreateSyncItem(const std::string  &relative_parent_path,
+                          const std::string  &filename,
+                          const SyncItemType  entry_type) const;
 
   inline std::string rdonly_path() const { return rdonly_path_; }
   inline std::string union_path() const { return union_path_; }

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -142,8 +142,11 @@ class SyncUnion {
    * This can be overridden by sub-classes but should always be up-called. Typi-
    * cally this sets whiteout and opaque-directory flags or handles hardlinks.
    * @param entry  the SyncItem to be pre-processed
+   *               (pointer parameter for google style guide compliance [1])
+   * [1] https://google-styleguide.googlecode.com/svn/trunk/
+   *             cppguide.html#Function_Parameter_Ordering
    */
-  virtual void PreprocessSyncItem(SyncItem &entry) const;
+  virtual void PreprocessSyncItem(SyncItem *entry) const;
 
   /**
    * Callback when a regular file is found.
@@ -244,7 +247,7 @@ class SyncUnionOverlayfs : public SyncUnion {
   static bool HasXattr(std::string const &path, std::string const &attr_name);
 
  protected:
-  void PreprocessSyncItem(SyncItem &entry) const;
+  void PreprocessSyncItem(SyncItem *entry) const;
 
   bool IsWhiteoutEntry(const SyncItem &entry) const;
   bool IsOpaqueDirectory(const SyncItem &directory) const;
@@ -257,8 +260,8 @@ class SyncUnionOverlayfs : public SyncUnion {
   std::string UnwindWhiteoutFilename(const SyncItem &entry) const;
   std::set<std::string> GetIgnoreFilenames() const;
 
-  void CheckForBrokenHardlink(SyncItem &entry) const;
-  void MaskFileHardlinks(SyncItem &entry) const;
+  void CheckForBrokenHardlink(const SyncItem &entry) const;
+  void MaskFileHardlinks(SyncItem *entry) const;
 
   bool ObtainSysAdminCapability() const;
 

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -191,7 +191,7 @@ class SyncUnion {
    * Called to actually process the file entry.
    * @param entry the SyncItem corresponding to the union file to be processed
    */
-  virtual void ProcessFile(SyncItem &entry);
+  void ProcessFile(const SyncItem &entry);
 
  private:
   bool initialized_;
@@ -256,7 +256,6 @@ class SyncUnionOverlayfs : public SyncUnion {
                               const std::string &filename);
   std::string UnwindWhiteoutFilename(const SyncItem &entry) const;
   std::set<std::string> GetIgnoreFilenames() const;
-  virtual void ProcessFile(SyncItem &entry);
 
   void CheckForBrokenHardlink(SyncItem &entry) const;
   void MaskFileHardlinks(SyncItem &entry) const;


### PR DESCRIPTION
This fixes a problem with hardlink handling in OverlayFS where certain `SyncItem`s where skipped due to the *silent* creation of `SyncItem` objects inside `SyncMediator`.

*Note:* This depends on the pull request [Refactor: SyncItem Factory Method](https://github.com/cvmfs/cvmfs/pull/1149).