### PR TITLE
FIX: Deadlock in debug-enabled cvmfs_server publish

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1875,7 +1875,7 @@ check_tag_existence() {
     -t ${CVMFS_SPOOL_DIR}/tmp                 \
     -p /etc/cvmfs/keys/${repository_name}.pub \
     -f $repository_name                       \
-    -n "$tag" 2>&1 | grep -qv "does not exist" > /dev/null
+    -n "$tag" > /dev/null 2>&1
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3894,7 +3894,7 @@ publish() {
       local timestamp=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
       tag_name="generic-$timestamp"
       local tag_name_number=1
-      while tag -x -i $tag_name $name > /dev/null 2>&1; do
+      while check_tag_existence $name $tag_name; do
         tag_name="generic_$tag_name_number-$timestamp"
         tag_name_number=$(( $tag_name_number + 1 ))
       done


### PR DESCRIPTION
This has been [recently introduced](https://github.com/cvmfs/cvmfs/pull/1130) when using `cvmfs_server tag` internally in `cvmfs_server publish`. When running the publish command in debug mode like so:
```CVMFS_SERVER_DEBUG=1 cvmfs_server publish```
it produces a (de facto) deadlock, since gdb prompt is opened but connected to `/dev/null`.

It's _not_ a good idea to sub-call `cvmfs_server` commands in other `cvmfs_server` commands! Furthermore it turns out that there already is a helper-function doing the necessary tag existence check.