### PR TITLE
FIX: Opaque Directory Check Crashes for Non-Existent Dirs

### DIFF
--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -440,7 +440,8 @@ bool SyncUnionOverlayfs::IsWhiteoutSymlinkPath(const string &path) const {
 
 
 bool SyncUnionOverlayfs::IsOpaqueDirectory(const SyncItem &directory) const {
-  return (IsOpaqueDirPath(directory.GetScratchPath()));
+  const std::string path = directory.GetScratchPath();
+  return DirectoryExists(path) && IsOpaqueDirPath(path);
 }
 
 


### PR DESCRIPTION
When recursively deleting directories in `SyncMediator`, `SyncUnion` might check directories for *opaqueness* that are not actually existent anymore. For AUFS this wasn't a problem, since it was anyway checking for existence of a flag file. However, the OverlayFS implementation crashes as it tries to look for an extended attribute on a non-existent path.