### PR TITLE
Allow for Debugging Runs of cvmfs_server without Attaching gdb 

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -130,6 +130,10 @@ if [ $CVMFS_SERVER_DEBUG -ne 0 ]; then
         # attach gdb and provide a prompt WITHOUT actual running the program
         CVMFS_SERVER_SWISSKNIFE_DEBUG="gdb --quiet --args cvmfs_swissknife_debug"
       ;;
+      3)
+        # do not attach gdb just run debug version
+        CVMFS_SERVER_SWISSKNIFE_DEBUG="cvmfs_swissknife_debug"
+      ;;
     esac
   else
     echo -e "WARNING: compile with CVMFS_SERVER_DEBUG to allow for debug mode!\nFalling back to release mode...."


### PR DESCRIPTION
Adding another debug mode to `cvmfs_server`. Can be used when `gdb` produces Heisenbugs or if only the verbose debug output is of interest.

```bash
CVMFS_SERVER_DEBUG=3 cvmfs_server XXXX
```