### PR TITLE
FIX: SLC6 Vagrant Provision

### DIFF
--- a/vagrant/provision_slc6.sh
+++ b/vagrant/provision_slc6.sh
@@ -46,7 +46,7 @@ yum -y install libuuid-devel gcc gcc-c++ glibc-common cmake fuse fuse-devel  \
                shadow-utils util-linux-ng selinux-policy checkpolicy         \
                selinux-policy-devel hardlink selinux-policy-targeted         \
                python-devel initscripts bash coreutils grep sed sudo psmisc  \
-               curl attr httpd
+               curl attr httpd libcap-devel
 
 # install convenience packages for development
 yum -y install git tig iftop htop jq rubygems screen nc python-unittest2

--- a/vagrant/provision_slc6.sh
+++ b/vagrant/provision_slc6.sh
@@ -17,6 +17,9 @@ PREV_DIR="$(pwd)"
 mkdir -p $WORKSPACE
 cd $WORKSPACE
 
+# update installed packages
+yum -y --exclude='kernel*' update
+
 # install cvmfs-release RPM
 if ! rpm -q cvmfs-release > /dev/null 2>&1; then
   echo "installing cvmfs-release package"
@@ -32,9 +35,6 @@ if ! rpm -q kernel | grep -q 'aufs'; then
   echo "installing custom AUFS enabled kernel"
   yum -y --disablerepo='*' --enablerepo='cernvm-kernel' install kernel kernel-headers
 fi
-
-# update installed packages
-yum -y --exclude='kernel*' update
 
 # activate EPEL to get as much of the fun stuff as possible
 yum -y install epel-release


### PR DESCRIPTION
Two things:

1. update packages before installing AUFS enabled kernel
2. add `libcap-devel` to the game