### PR TITLE
FIX: use `docker run --rm=true` for cleanup

### DIFF
--- a/ci/build_on_docker.sh
+++ b/ci/build_on_docker.sh
@@ -121,6 +121,7 @@ done
 echo "++ $docker_build_script $args"
 sudo docker run --volume=${CVMFS_SOURCE_LOCATION}:${docker_source_location} \
                 --volume=${CVMFS_RESULT_LOCATION}:${docker_build_location}  \
+                --rm=true                                                   \
                 --privileged=true                                           \
                 --env="CVMFS_BUILD_ARCH=$CVMFS_BUILD_ARCH"                  \
                 --env="CVMFS_CI_PLATFORM_LABEL=$CVMFS_DOCKER_IMAGE"         \

--- a/ci/docker/opensuse13_x86_64/build.sh
+++ b/ci/docker/opensuse13_x86_64/build.sh
@@ -25,6 +25,7 @@ mkdir -p $DESTINATION
 echo "running essential build script in a SuSE container..."
 docker run --volume ${DESTINATION}:/chroot    \
            --volume ${SCRIPT_LOCATION}:/build \
+           --rm=true                          \
            opensuse:latest /build/build_internal.sh
 
 echo "package up the base image..."

--- a/ci/docker/sles11_x86_64/build.sh
+++ b/ci/docker/sles11_x86_64/build.sh
@@ -25,6 +25,7 @@ mkdir -p $DESTINATION
 echo "running essential build script in a SuSE container..."
 docker run --volume ${DESTINATION}:/chroot    \
            --volume ${SCRIPT_LOCATION}:/build \
+           --rm=true                          \
            --privileged=true                  \
            opensuse:latest /build/build_internal.sh
 


### PR DESCRIPTION
Removes the docker containers after they have been finished executing.