### PR TITLE
FIX: Inconsistent const-ness of cap_value_t* in cap_set_flag()

### DIFF
--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -222,7 +222,9 @@ bool SyncUnionOverlayfs::Initialize() {
 
 
 bool ObtainSysAdminCapabilityInternal(cap_t caps) {
-  const cap_value_t cap = CAP_SYS_ADMIN;
+  /*const*/ cap_value_t cap = CAP_SYS_ADMIN; // is non-const as cap_set_flag()
+                                             // expects a non-const pointer
+                                             // on RHEL 5 and older
 
   // do sanity-check if supported in <sys/capability.h> otherwise just pray...
   // Note: CAP_SYS_ADMIN is a rather common capability and is very likely to be


### PR DESCRIPTION
Turns out that `cap_set_flag()` requires a non-const pointer to the flag it should set. Starting from RHEL 6 this changed to `const`.

`int cap_set_flag(cap_t, cap_flag_t, int, cap_value_t *, cap_flag_value_t);`
`int cap_set_flag(cap_t, cap_flag_t, int, const cap_value_t *, cap_flag_value_t);`