### PR TITLE
FIX/RFC: Do not Mount CVMFS Stratum0's on system boot

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -440,6 +440,7 @@ least CernVM-FS $creator to manipulate this repository."
   #
   #   2.1.20+ -> 2.2.0-1 (2.2.0-0 was a server pre-release and needs migration)
   #     -> new (mandatory) parameters in client.conf (Stratum 0)
+  #     -> adjustments in /etc/fstab
   #
   # Note: I tried to make this code as verbose as possible
   #

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2143,8 +2143,8 @@ setup_and_mount_new_repository() {
       ofs_workdir=""
     fi
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid 0 0 # added by CernVM-FS for $name
-${overlayfs_name}_$name /cvmfs/$name $overlayfs_name upperdir=${scratch_dir},lowerdir=${rdonly_dir}$ofs_workdir,ro$selinux_context 0 0 # added by CernVM-FS for $name
+cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+${overlayfs_name}_$name /cvmfs/$name $overlayfs_name upperdir=${scratch_dir},lowerdir=${rdonly_dir}$ofs_workdir,noauto,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   else
     echo -n "(aufs) "
@@ -2152,8 +2152,8 @@ EOF
       selinux_context=",context=\"system_u:object_r:default_t:s0\""
     fi
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid 0 0 # added by CernVM-FS for $name
-aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,ro$selinux_context 0 0 # added by CernVM-FS for $name
+cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,noauto,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   fi
   local user_shell="$(get_user_shell $name)"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4835,6 +4835,20 @@ migrate_2_1_20() {
   [ -z "$CVMFS_FOLLOW_REDIRECTS"  ] && echo "CVMFS_FOLLOW_REDIRECTS=yes"  >> $client_conf
   [ -z "$CVMFS_SERVER_CACHE_MODE" ] && echo "CVMFS_SERVER_CACHE_MODE=yes" >> $client_conf
 
+  echo "--> updating /etc/fstab"
+  local tmp_fstab=$(mktemp)
+  awk  "/added by CernVM-FS for $name/"' {
+          for (i = 1; i <= NF; i++) {
+            if (i == 4) $i = $i",noauto";
+            printf("%s ", $i);
+          }
+          print "";
+          next;
+        };
+        { print $0 }' /etc/fstab > $tmp_fstab
+  cat $tmp_fstab > /etc/fstab
+  rm -f $tmp_fstab
+
   echo "--> updating server.conf"
   local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
   sed -i -e "s/^\(CVMFS_CREATOR_VERSION\)=.*/\1=$destination_version/" $server_conf


### PR DESCRIPTION
Apparently there are various different scenarios how mounting both `/var/spool/cvmfs/$repo/rdonly` and `/cvmfs/$repo` on stratum0s can fail during system boot. Usually this results in the boot process being interrupted.

For example:
* `/var/spool/cvmfs` not mounted yet
* Apache not started yet
* mixed up order of mounting `.../rdonly` and `/cvmfs/...`
* ... probably more

I couldn't really wrap my head around what exactly happens in the different scenarios, so this is more of an RFC-Pull Request. Anyway, by just adding **noauto** to the CVMFS `/etc/fstab` entries this issue would be easily (and reliably) fixable. Mounting of both `.../rdonly` and `/cvmfs/...` would happen (pretty much transparently) on the first `cvmfs_server` invocation through the auto-repair-mountpoint feature of CVMFS.

We should make `CVMFS_AUTO_REPAIR_MOUNTPOINT` the default in the next release anyway, as it proved to work rather nicely.