### PR TITLE
FIX: Integration Tests 500 to 559 for OverlayFS 

### DIFF
--- a/test/src/501-changerepo/main
+++ b/test/src/501-changerepo/main
@@ -3,23 +3,23 @@ cvmfs_test_name="Change Repository"
 cvmfs_test_autofs_on_startup=false
 
 produce_files_in() {
-	local working_dir=$1
+  local working_dir=$1
 
-	pushdir $working_dir
+  pushdir $working_dir
 
-	echo "meaningless file content" > file
-	echo "more clever file content" > clever
+  echo "meaningless file content" > file
+  echo "more clever file content" > clever
 
-	mkdir foo
-	mkdir bar
+  mkdir foo
+  mkdir bar
 
-	mkdir foo/bar
-	mkdir bar/foo
+  mkdir foo/bar
+  mkdir bar/foo
 
-	ln file hardlinkToFile
-	ln -s clever symlinkToClever
+  ln file hardlinkToFile
+  ln -s clever symlinkToClever
 
-	popdir
+  popdir
 }
 
 change_files_in() {

--- a/test/src/501-changerepo/main
+++ b/test/src/501-changerepo/main
@@ -27,20 +27,9 @@ change_files_in() {
 
   pushdir $working_dir
 
-  if uses_overlayfs $CVMFS_TEST_REPO; then
-    # OverlayFS would break hard links when copying up 'hardlinkToFile'
-    # therefore we do it proactively here
-    cp hardlinkToFile hardlinkToFile1
-    rm -f hardlinkToFile
-  elif uses_aufs $CVMFS_TEST_REPO; then
-    # AUFS is handling this hardlink use case correctly
-    mv hardlinkToFile hardlinkToFile1
-  else
-    echo "Which union file system?"
-    popdir
-    return 1
-  fi
+  mv hardlinkToFile hardlinkToFile1
 
+  uses_overlayfs $CVMFS_TEST_REPO && break_hardlink file
   echo "additional meaningless content" >> file
 
   mkdir newdirectory
@@ -87,7 +76,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir|| return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -104,7 +93,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/503-deletedirrecursive/main
+++ b/test/src/503-deletedirrecursive/main
@@ -82,7 +82,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/504-opaquedir/main
+++ b/test/src/504-opaquedir/main
@@ -99,7 +99,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -116,7 +116,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/505-createnested/main
+++ b/test/src/505-createnested/main
@@ -88,7 +88,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?

--- a/test/src/506-removenested/main
+++ b/test/src/506-removenested/main
@@ -113,7 +113,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "check if the right catalogs are present after the first stage"
   check_initial_nested_catalog_presence $CVMFS_TEST_REPO || return $?
@@ -133,7 +133,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/507-removeintermediatenested/main
+++ b/test/src/507-removeintermediatenested/main
@@ -135,7 +135,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "check if the right catalogs are present after the first stage"
   check_initial_nested_catalog_presence $CVMFS_TEST_REPO || return $?
@@ -155,7 +155,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -136,11 +136,12 @@ cvmfs_run_test() {
   echo "putting exactly the same stuff in the scratch space for comparison"
   produce_files_in $reference_dir || return 4
 
-  echo "creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO || return $?
+  local publish_log_1="publish_1.log"
+  echo "creating CVMFS snapshot (logging into $publish_log_1)"
+  publish_repo $CVMFS_TEST_REPO > $publish_log_1 2>&1 || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -171,7 +172,7 @@ cvmfs_run_test() {
   do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
-  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }
+  compare_directories $mnt_point $reference_dir $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 11; }
 
   echo "unmount the Stratum1 repository"
   sudo umount $mnt_point || { desaster_cleanup $mnt_point $replica_name; return 12; }

--- a/test/src/517-touchnested/main
+++ b/test/src/517-touchnested/main
@@ -100,7 +100,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "check if the right catalogs are present after the first stage"
   check_nested_catalog_presence $CVMFS_TEST_REPO || return $?
@@ -120,7 +120,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/520-history/main
+++ b/test/src/520-history/main
@@ -195,7 +195,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO -a $first_tag -m "$first_tag_desc" || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir1 || return $?
+  compare_directories $repo_dir $reference_dir1 $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -215,7 +215,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO -a $second_tag -m "$second_tag_desc" || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir2 || return $?
+  compare_directories $repo_dir $reference_dir2 $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -232,7 +232,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO -a $third_tag -m "$third_tag_desc1" || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir3 || return $?
+  compare_directories $repo_dir $reference_dir3 $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -262,7 +262,7 @@ cvmfs_run_test() {
   cvmfs_server rollback -f -t $second_tag $CVMFS_TEST_REPO || return $?
 
   echo "compare to reference directory"
-  compare_directories $repo_dir $reference_dir2 || return 10
+  compare_directories $repo_dir $reference_dir2 $CVMFS_TEST_REPO || return 10
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -301,7 +301,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir4 || return $?
+  compare_directories $repo_dir $reference_dir4 $CVMFS_TEST_REPO || return $?
 
   echo "current tag statistics:"
   cvmfs_server tag -l $CVMFS_TEST_REPO
@@ -328,7 +328,7 @@ cvmfs_run_test() {
   cvmfs_server rollback -f -t $first_tag $CVMFS_TEST_REPO || return $?
 
   echo "compare to reference directory"
-  compare_directories $repo_dir $reference_dir1 || return 17
+  compare_directories $repo_dir $reference_dir1 $CVMFS_TEST_REPO || return 17
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -377,7 +377,7 @@ cvmfs_run_test() {
   cvmfs_server tag -a $first_tag -h $newest_hash -m "$first_tag_desc+1" $CVMFS_TEST_REPO || return $?
 
   echo "compare to reference directory"
-  compare_directories $repo_dir $reference_dir1 || return 20
+  compare_directories $repo_dir $reference_dir1 $CVMFS_TEST_REPO || return 20
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -440,7 +440,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare to reference directory"
-  compare_directories $repo_dir $reference_dir5 || return 28
+  compare_directories $repo_dir $reference_dir5 $CVMFS_TEST_REPO || return 28
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -468,7 +468,7 @@ cvmfs_run_test() {
   cvmfs_server rollback -f $CVMFS_TEST_REPO || return 31
 
   echo "compare to reference directory"
-  compare_directories $repo_dir $reference_dir1 || return 32
+  compare_directories $repo_dir $reference_dir1 $CVMFS_TEST_REPO || return 32
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -281,7 +281,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -312,7 +312,7 @@ cvmfs_run_test() {
   do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
-  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }
+  compare_directories $mnt_point $reference_dir $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 11; }
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -343,7 +343,7 @@ cvmfs_run_test() {
   do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 18; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
-  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 19; }
+  compare_directories $mnt_point $reference_dir $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 19; }
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -374,7 +374,7 @@ cvmfs_run_test() {
   do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 26; }
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
-  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 27; }
+  compare_directories $mnt_point $reference_dir $CVMFS_TEST_REPO || { desaster_cleanup $mnt_point $replica_name; return 27; }
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/test/src/525-bigrepo/main
+++ b/test/src/525-bigrepo/main
@@ -18,8 +18,8 @@ cvmfs_run_test() {
   make_huge_repo $repo_dir || return 1
 
   echo "creating CVMFS snapshot"
-  echo "--> redirecting publishing output to publish_output_1.log"
-  publish_repo $CVMFS_TEST_REPO > publish_output_1.log || return $?
+  echo "--> redirecting publishing output to publish_output_1.log and publish_error_1.log"
+  publish_repo $CVMFS_TEST_REPO > publish_output_1.log 2>publish_error_1.log || return $?
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -41,8 +41,8 @@ cvmfs_run_test() {
   echo "generated $num_nested_catalogs catalogs"
 
   echo "creating nested catalogs by cvmfs_server publish"
-  echo "--> redirecting publishing output to publish_output_2.log"
-  publish_repo $CVMFS_TEST_REPO > publish_output_2.log || return $?
+  echo "--> redirecting publishing output to publish_output_2.log and publish_error_2.log"
+  publish_repo $CVMFS_TEST_REPO > publish_output_2.log 2>publish_error_2.log || return $?
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?

--- a/test/src/541-preloadcache/main
+++ b/test/src/541-preloadcache/main
@@ -100,8 +100,8 @@ EOF
   trap cleanup EXIT HUP INT TERM || return 15
 
   cvmfs2 -o config=$(pwd)/local.conf $CVMFS_TEST_REPO $CVMFS_TEST_541_MOUNTPOINT || return 20
-  compare_directories $repo_dir $reference_dir                  || return 21
-  compare_directories $CVMFS_TEST_541_MOUNTPOINT $reference_dir || return 22
+  compare_directories $repo_dir                  $reference_dir $CVMFS_TEST_REPO || return 21
+  compare_directories $CVMFS_TEST_541_MOUNTPOINT $reference_dir $CVMFS_TEST_REPO || return 22
 
   return 0
 }

--- a/test/src/547-createintermediatenested/main
+++ b/test/src/547-createintermediatenested/main
@@ -183,7 +183,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -208,7 +208,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -233,7 +233,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/548-createintermediatenested2/main
+++ b/test/src/548-createintermediatenested2/main
@@ -191,7 +191,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -216,7 +216,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 
@@ -241,7 +241,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the changed directories"
-  compare_directories $repo_dir $reference_dir || return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -639,9 +639,11 @@ create_big_file() {
 # - symlink destination (when applicable)
 #
 # @param directory          the directory to be listed
+# @param show_linkcount     yes be default, otherwise linkcount is left out
 # @return                   a custom directory listing
 create_listing() {
   local directory=$1
+  local show_linkcount=$2
   local lst
 
   lst=$(ls --almost-all --recursive -l --file-type --time-style=+ $directory | \
@@ -678,7 +680,10 @@ create_listing() {
 
     # print out file information
     printf $1                     " ";
-    printf $2                     " ";
+    if (show_linkcount == "yes")
+    {
+      printf $2                   " ";
+    }
     printf $3                     " ";
     printf $4                     " ";
     printf $6;
@@ -686,7 +691,7 @@ create_listing() {
     if(first == "l") printf " " $7 " " $8;
     if(first != "d") printf " " $5;
     printf "\n"
-  }' base_dir=$directory)
+  }' base_dir=$directory show_linkcount=$show_linkcount)
 
   echo -e "$lst"
 }
@@ -697,13 +702,21 @@ create_listing() {
 #
 # @param dir1    the directory to probe
 # @param dir2    the ground truth directory
+# @param repo    the underlying repository name (optional - to detect overlayfs)
 # @return        != 0 to indicate inequality, 0 means success
 compare_directories() {
   local dir1=$1
   local dir2=$2
+  local repo_name=$3
+  local show_linkcount="yes"
 
-  listing1=$(create_listing $dir1)
-  listing2=$(create_listing $dir2)
+  if [ ! -z $repo_name ] && uses_overlayfs $repo_name; then
+    echo "NOTE: $repo_name is based on OverlayFS - ignoring link counts"
+    show_linkcount="no"
+  fi
+
+  listing1=$(create_listing $dir1 $show_linkcount)
+  listing2=$(create_listing $dir2 $show_linkcount)
 
   echo "check if directory structure and file meta data fits"
   local listingFile1="listing_$(basename $dir1)"

--- a/test/test_functions
+++ b/test/test_functions
@@ -637,16 +637,11 @@ create_big_file() {
 # - file size
 # - parent directory
 # - symlink destination (when applicable)
-# - uid and gid can be specified
 #
 # @param directory          the directory to be listed
-# @param uid                specify a UID for the file owner (optional)
-# @param gid                specify a GID for the file owner (optional)
 # @return                   a custom directory listing
 create_listing() {
   local directory=$1
-  local uid=$2
-  local gid=$3
   local lst
 
   lst=$(ls --almost-all --recursive -l --file-type --time-style=+ $directory | \
@@ -684,14 +679,14 @@ create_listing() {
     # print out file information
     printf $1                     " ";
     printf $2                     " ";
-    printf (uid == "" ? $3 : uid) " ";
-    printf (gid == "" ? $4 : gid) " ";
+    printf $3                     " ";
+    printf $4                     " ";
     printf $6;
 
     if(first == "l") printf " " $7 " " $8;
     if(first != "d") printf " " $5;
     printf "\n"
-  }' uid=$uid gid=$gid base_dir=$directory)
+  }' base_dir=$directory)
 
   echo -e "$lst"
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -250,6 +250,18 @@ uses_overlayfs() {
 }
 
 
+break_hardlink() {
+  local path="$1"
+  local tmp_file="$(mktemp)"
+  local linkcount="$(stat --format=%h $path)"
+
+  echo "Note: breaking up hardlink to '$path' linkcount: $linkcount"
+  cp -f $path $tmp_file
+  rm -f $path
+  mv    $tmp_file $path
+}
+
+
 cvmfs_clean() {
   sudo cvmfs_config umount > /dev/null || return 100
   sudo sh -c "rm -rf /var/lib/cvmfs/*"


### PR DESCRIPTION
Picking the low hanging fruits, mainly adapting test cases for the differing hard link semantics of OverlayFS. There are some more failing test cases in the above mentioned range that are either intrinsically failing with OverlayFS and/or need a bit more adaption to the newer httpd on Fedora 22. More to come in other Pull Requests...