### PR TITLE
FIX: Integration Test 597 (libcvmfs)

### DIFF
--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -17,7 +17,7 @@ cvmfs_run_test() {
   local base_name="$CVMFS_TEST_597_REPO_PREFIX"
 
   echo "compiling libcvmfs test binary..."
-  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt
+  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt || return 1
 
   echo "register cleanup trap"
   trap cleanup EXIT HUP INT TERM || return $?
@@ -28,18 +28,18 @@ cvmfs_run_test() {
     local repo_dir="/cvmfs/$repo_name"
 
     CVMFS_TEST_597_REPO_COUNT=$(( $CVMFS_TEST_597_REPO_COUNT + 1 ))
-    create_empty_repo "$repo_name" $CVMFS_TEST_USER
-    start_transaction "$repo_name"
+    create_empty_repo "$repo_name" $CVMFS_TEST_USER || return 2
+    start_transaction "$repo_name"                  || return 3
 
-    mkdir "$repo_dir/main"
-    echo "$i" > "$repo_dir/main/mainfile"
+    mkdir "$repo_dir/main"                || return 4
+    echo "$i" > "$repo_dir/main/mainfile" || return 5
 
-    mkdir "$repo_dir/list"
+    mkdir "$repo_dir/list" || return 6
     for j in $(seq 1 $i); do
-      touch "$repo_dir/list/file$j"
+      touch "$repo_dir/list/file$j" || return 7
     done
 
-    publish_repo "$repo_name"
+    publish_repo "$repo_name" || return 8
   done
 
   echo "check libcvmfs with the generated binary"

--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -9,7 +9,7 @@ cvmfs_run_test() {
 
   apache_switch on
   local num_repos=5
-  local base_name="local.libcvmfs_test_"
+  local base_name="test.cern.ch.libcvmfs_"
   for i in $(seq 1 $num_repos); do
     local repo_name="$base_name$i"
     local repo_dir="/cvmfs/$repo_name"

--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -3,13 +3,14 @@ cvmfs_test_autofs_on_startup=false
 
 cvmfs_run_test() {
   local workdir="$2"
-  # compile the source first
   local bin_name="597-test"
-  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt
-
-  apache_switch on
   local num_repos=5
   local base_name="test.cern.ch.libcvmfs_"
+
+  echo "compiling libcvmfs test binary..."
+  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt
+
+  echo "creating $num_repos local test repositories"
   for i in $(seq 1 $num_repos); do
     local repo_name="$base_name$i"
     local repo_dir="/cvmfs/$repo_name"
@@ -29,7 +30,7 @@ cvmfs_run_test() {
     publish_repo "$repo_name"
   done
 
-  # check libcvmfs with the generated binary
+  echo "check libcvmfs with the generated binary"
   "./$bin_name" "$base_name" "$num_repos"
   return_code=$?
 

--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -15,10 +15,9 @@ cvmfs_run_test() {
     local repo_name="$base_name$i"
     local repo_dir="/cvmfs/$repo_name"
 
-    create_repo "$repo_name" $CVMFS_TEST_USER
+    create_empty_repo "$repo_name" $CVMFS_TEST_USER
     start_transaction "$repo_name"
 
-    rm $repo_dir/*  # cleanup the repository before starting
     mkdir "$repo_dir/main"
     echo "$i" > "$repo_dir/main/mainfile"
 

--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -5,7 +5,7 @@ cvmfs_run_test() {
   local workdir="$2"
   # compile the source first
   local bin_name="597-test"
-  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -luuid -lrt
+  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt
 
   apache_switch on
   local num_repos=5

--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -1,20 +1,33 @@
 cvmfs_test_name="Libcvmfs test"
 cvmfs_test_autofs_on_startup=false
 
+CVMFS_TEST_597_REPO_COUNT=0
+CVMFS_TEST_597_REPO_PREFIX="test.cern.ch.libcvmfs_"
+cleanup() {
+  echo "running cleanup()"
+  for i in $(seq 1 $CVMFS_TEST_597_REPO_COUNT); do
+    destroy_repo "$CVMFS_TEST_597_REPO_PREFIX$i"
+  done
+}
+
 cvmfs_run_test() {
   local workdir="$2"
   local bin_name="597-test"
   local num_repos=5
-  local base_name="test.cern.ch.libcvmfs_"
+  local base_name="$CVMFS_TEST_597_REPO_PREFIX"
 
   echo "compiling libcvmfs test binary..."
   g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt
+
+  echo "register cleanup trap"
+  trap cleanup EXIT HUP INT TERM || return $?
 
   echo "creating $num_repos local test repositories"
   for i in $(seq 1 $num_repos); do
     local repo_name="$base_name$i"
     local repo_dir="/cvmfs/$repo_name"
 
+    CVMFS_TEST_597_REPO_COUNT=$(( $CVMFS_TEST_597_REPO_COUNT + 1 ))
     create_empty_repo "$repo_name" $CVMFS_TEST_USER
     start_transaction "$repo_name"
 
@@ -30,12 +43,5 @@ cvmfs_run_test() {
   done
 
   echo "check libcvmfs with the generated binary"
-  "./$bin_name" "$base_name" "$num_repos"
-  return_code=$?
-
-  for i in $(seq 1 $num_repos); do
-    destroy_repo "$base_name$i"
-  done
-
-  return $return_code
+  ./$bin_name "$base_name" "$num_repos"
 }

--- a/test/src/597-libcvmfs/main
+++ b/test/src/597-libcvmfs/main
@@ -15,7 +15,7 @@ cvmfs_run_test() {
     local repo_name="$base_name$i"
     local repo_dir="/cvmfs/$repo_name"
 
-    create_repo "$repo_name" $(whoami)
+    create_repo "$repo_name" $CVMFS_TEST_USER
     start_transaction "$repo_name"
 
     rm $repo_dir/*  # cleanup the repository before starting


### PR DESCRIPTION
The test cases compiles a small test program but on Fedora 22 one needs to link against `-lcrypto` when doing so (fixed).

Also I've refactored the test case a little, to make it more resilient against failure (i.e. using a cleanup-trap for reliable test repository destruction). Finally I added a couple of debug print outs and return statements to make the test case fail in case of problems.