### PR TITLE
Feature: Print OverlayFS Kernel Deadlock Warning

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1469,10 +1469,15 @@ health_check() {
   fi
 
   # check configuration for harzardous AUFS setup
-  if [ $quiet -eq 0 ] && find_hazardous_aufs_config $name; then
-    echo "WARNING: AUFS config is vulnerable to kernel deadlocks. Please store "
-    echo "         the scratch space and the cvmfs client cache on different "
-    echo "         partitions. (Silence this with CVMFS_AUFS_WARNING=false)"
+  if [ $quiet -eq 0 ] && find_hazardous_union_file_system_config $name; then
+    echo "WARNING: Union filesystem config is vulnerable to kernel deadlocks."
+    echo "         Please store the scratch space and the CVMFS client cache on"
+    echo "         different partitions."
+    echo ""
+    echo "         This can be silenced with either"
+    echo "             CVMFS_AUFS_WARNING=false"
+    echo "         or  CVMFS_OVERLAYFS_WARNING=false"
+    echo ""
     echo " Scratch Space: ${CVMFS_SPOOL_DIR}/scratch"
     echo " Client Cache:  ${CVMFS_CACHE_BASE}"
     echo ""

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1333,27 +1333,11 @@ foreclose_legacy_cvmfs() {
   return $found_something
 }
 
-
-# checks if the configuration of a given repository is vulnerable to a kernel
-# deadlock bug of AUFS.
-#
-# @param name  the name of the repository to check
-# @return      0 if config is vulnerable
-find_hazardous_aufs_config() {
-  local name=$1
-
+_has_vulnerable_aufs_version() {
   # threshold definitions
   local aufs_minimum_required="20130300"
   local krnl_minimum_required="3.10.0"
   local krnl_sl6_minimal_fixed="431.29.2"
-
-  # check if we are actually dealing with AUFS or if the warning message is
-  # silenced... in these cases no more checks are needed
-  load_repo_config $name
-  if [ x"$CVMFS_UNION_FS_TYPE" != x"aufs"  ] || \
-     [ x"$CVMFS_AUFS_WARNING"  =  x"false" ]; then
-    return 1
-  fi
 
   # find the AUFS release date (if available)
   # 1. try using modinfo
@@ -1394,7 +1378,42 @@ find_hazardous_aufs_config() {
     fi
   fi
 
-  # at this point, we have a potential AUFS kernel deadlock vulnerability if
+  # the AUFS version is most likely vulnerable for the known kernel deadlock
+  return 0
+}
+
+_has_vulnerable_overlayfs_version() {
+  return 0 # to our knowledge all OverlayFS versions are currently vulnerable
+}
+
+# checks if the configuration of a given repository is vulnerable to a kernel
+# deadlock bug of AUFS or OverlayFS. (see CVM-651 for further details)
+#
+# @param name  the name of the repository to check
+# @return      0 if config is vulnerable
+find_hazardous_union_file_system_config() {
+  local name=$1
+
+  load_repo_config $name
+
+  # check if we are dealing with a vulnerable union file system or if the
+  # warning message is silenced... in these cases no more checks are needed
+  if [ x"$CVMFS_UNION_FS_TYPE" = x"aufs" ]; then
+    if [ x"$CVMFS_AUFS_WARNING" = x"false" ] || \
+       ! _has_vulnerable_aufs_version; then
+      return 1
+    fi
+  fi
+
+  if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
+    if [ x"$CVMFS_OVERLAYFS_WARNING" = x"false"  ] || \
+       ! _has_vulnerable_overlayfs_version; then
+      return 1
+    fi
+  fi
+
+
+  # at this point, we have a potential kernel deadlock vulnerability if
   # cache and scratch directory are on the same partition
   local cache_dir="$CVMFS_CACHE_BASE"
   local scratch_dir="${CVMFS_SPOOL_DIR}/scratch"

--- a/test/src/564-detectaufsvulnerability/main
+++ b/test/src/564-detectaufsvulnerability/main
@@ -1,4 +1,4 @@
-cvmfs_test_name="Detect AUFS Kernel Deadlock Vulnerability"
+cvmfs_test_name="Detect Union File System Kernel Deadlock Vulnerability"
 cvmfs_test_autofs_on_startup=false
 
 check_aufs() {

--- a/test/src/564-detectaufsvulnerability/main
+++ b/test/src/564-detectaufsvulnerability/main
@@ -47,6 +47,11 @@ is_kernel_vulnerable() {
   fi
 }
 
+check_for_warning() {
+  local path_to_log="$1"
+  cat $path_to_log | grep -q 'WARNING: Union filesystem config is vulnerable'
+}
+
 CVMFS_TEST_564_SERVER_CACHE=
 cleanup() {
   if [ ! -z $CVMFS_TEST_564_SERVER_CACHE ]; then
@@ -83,7 +88,7 @@ cvmfs_run_test() {
   echo "starting transaction to check for warning message"
   local transaction_output_1="transaction_1.log"
   start_transaction $CVMFS_TEST_REPO 2>&1 > $transaction_output_1 || return 1
-  if ! cat $transaction_output_1 | grep -q 'WARNING: AUFS config is vulnerable'; then
+  if ! check_for_warning $transaction_output_1; then
     if [ $krnl_vulnerable -eq 1 ]; then
       return 2
     else
@@ -99,8 +104,8 @@ cvmfs_run_test() {
 
   echo "starting transaction to check for warning message to be gone"
   local transaction_output_2="transaction_2.log"
-  start_transaction $CVMFS_TEST_REPO 2>&1 > $transaction_output_2          || return 4
-  cat $transaction_output_2 | grep -q 'WARNING: AUFS config is vulnerable' && return 5
+  start_transaction $CVMFS_TEST_REPO 2>&1 > $transaction_output_2 || return 4
+  check_for_warning $transaction_output_2                         && return 5
 
   echo "aborting transaction"
   abort_transaction $CVMFS_TEST_REPO || return 6
@@ -110,8 +115,8 @@ cvmfs_run_test() {
 
   echo "starting transaction to check for absence of warning message"
   local transaction_output_3="transaction_3.log"
-  start_transaction $CVMFS_TEST_REPO 2>&1 > $transaction_output_3          || return 7
-  cat $transaction_output_3 | grep -q 'WARNING: AUFS config is vulnerable' && return 8
+  start_transaction $CVMFS_TEST_REPO 2>&1 > $transaction_output_3 || return 7
+  check_for_warning $transaction_output_3                         && return 8
 
   echo "aborting transaction"
   abort_transaction $CVMFS_TEST_REPO || return 9

--- a/test/src/564-detectaufsvulnerability/main
+++ b/test/src/564-detectaufsvulnerability/main
@@ -100,7 +100,15 @@ cvmfs_run_test() {
   abort_transaction $CVMFS_TEST_REPO || return 3
 
   echo "add silence configuration flag"
-  echo "CVMFS_AUFS_WARNING=false" | sudo tee --append /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  if has_aufs; then
+    echo "adding silencer for AUFS"
+    echo "CVMFS_AUFS_WARNING=false" | sudo tee --append /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  fi
+
+  if has_overlayfs; then
+    echo "adding silencer for OverlayFS"
+    echo "CVMFS_OVERLAYFS_WARNING=false" | sudo tee --append /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  fi
 
   echo "starting transaction to check for warning message to be gone"
   local transaction_output_2="transaction_2.log"

--- a/test/src/564-detectaufsvulnerability/main
+++ b/test/src/564-detectaufsvulnerability/main
@@ -26,14 +26,22 @@ check_overlayfs() {
   return 0 # OverlayFS does suffer from this in any case!
 }
 
+has_aufs() {
+  /sbin/modprobe -q aufs || [ -d /sys/fs/aufs ]
+}
+
+has_overlayfs() {
+  /sbin/modprobe -q overlayfs || [ -d /sys/module/overlayfs ] || \
+  /sbin/modprobe -q overlay   || [ -d /sys/module/overlay   ]
+}
+
 # see if the kernel should be vulnerable in the first place
 # Note: This is a simplified version of what is checked in `cvmfs_server`
 is_kernel_vulnerable() {
-  if /sbin/modprobe -q overlayfs || [ -d /sys/module/overlayfs ] || \
-     /sbin/modprobe -q overlay   || [ -d /sys/module/overlay   ]; then
+  if has_overlayfs; then
     echo "Found OverlayFS"
     check_overlayfs; return $?
-  elif /sbin/modprobe -q aufs || [ -d /sys/fs/aufs ]; then
+  elif has_aufs; then
     echo "Found AUFS"
     check_aufs; return $?
   fi

--- a/test/src/564-detectaufsvulnerability/main
+++ b/test/src/564-detectaufsvulnerability/main
@@ -39,6 +39,14 @@ is_kernel_vulnerable() {
   fi
 }
 
+CVMFS_TEST_564_SERVER_CACHE=
+cleanup() {
+  if [ ! -z $CVMFS_TEST_564_SERVER_CACHE ]; then
+    echo "Resetting CVMFS_TEST_SERVER_CACHE to '$CVMFS_TEST_564_SERVER_CACHE'"
+    export CVMFS_TEST_SERVER_CACHE=$CVMFS_TEST_564_SERVER_CACHE
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -51,11 +59,18 @@ cvmfs_run_test() {
   fi
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER that might be vulnerable"
-  echo "Using default cache directory instead of CVMFS_TEST_SERVER_CACHE='$CVMFS_TEST_SERVER_CACHE'"
-  local old_server_cache_setting=$CVMFS_TEST_SERVER_CACHE
-  export CVMFS_TEST_SERVER_CACHE=""
+  if [ ! -z $CVMFS_TEST_SERVER_CACHE ]; then
+    echo "Using default cache directory instead of CVMFS_TEST_SERVER_CACHE='$CVMFS_TEST_SERVER_CACHE'"
+    trap cleanup EXIT HUP INT TERM
+    CVMFS_TEST_564_SERVER_CACHE=$CVMFS_TEST_SERVER_CACHE
+    export CVMFS_TEST_SERVER_CACHE=""
+  fi
+
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
-  export CVMFS_TEST_SERVER_CACHE=$old_server_cache_setting
+
+  # cleanup trap is not necessary anymore
+  trap - EXIT HUP INT TERM
+  cleanup
 
   echo "starting transaction to check for warning message"
   local transaction_output_1="transaction_1.log"

--- a/test/src/564-detectaufsvulnerability/main
+++ b/test/src/564-detectaufsvulnerability/main
@@ -1,9 +1,7 @@
 cvmfs_test_name="Detect AUFS Kernel Deadlock Vulnerability"
 cvmfs_test_autofs_on_startup=false
 
-# see if the kernel should be vulnerable in the first place
-# Note: This is a simplified version of what is checked in `cvmfs_server`
-is_kernel_vulnerable() {
+check_aufs() {
   # threshold definitions
   local krnl_minimum_required="3.10.0"
   local krnl_sl6_minimal_fixed="431.29.2"
@@ -22,6 +20,23 @@ is_kernel_vulnerable() {
   fi
 
   return 0
+}
+
+check_overlayfs() {
+  return 0 # OverlayFS does suffer from this in any case!
+}
+
+# see if the kernel should be vulnerable in the first place
+# Note: This is a simplified version of what is checked in `cvmfs_server`
+is_kernel_vulnerable() {
+  if /sbin/modprobe -q overlayfs || [ -d /sys/module/overlayfs ] || \
+     /sbin/modprobe -q overlay   || [ -d /sys/module/overlay   ]; then
+    echo "Found OverlayFS"
+    check_overlayfs; return $?
+  elif /sbin/modprobe -q aufs || [ -d /sys/fs/aufs ]; then
+    echo "Found AUFS"
+    check_aufs; return $?
+  fi
 }
 
 cvmfs_run_test() {


### PR DESCRIPTION
As stated before, OverlayFS can cause the same kernel deadlock [as we've seen with AUFS](https://sft.its.cern.ch/jira/browse/CVM-651). Therefore, this adapts the sanity-check code in `cvmfs_server` to also warn on vulnerable OverlayFS configurations. Furthermore this adapts the integration test case 564 to also check the proper warning functionality with OverlayFS.