### PR TITLE
FIX: Stratum0/1 Custom URL Handling

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2526,13 +2526,18 @@ mkfs() {
   # upstream generation (defaults to local upstream)
   if [ x"$upstream" = x"" ]; then
     if [ x"$s3_config" != x"" ]; then
-      [ x"$stratum0" = x"" ] && die "Please specify the HTTP-URL for S3 (add option -w)"
       upstream=$(make_s3_upstream $name $s3_config)
-      stratum0=$(mangle_s3_cvmfs_url $name "$stratum0")
     else
       upstream=$(make_local_upstream $name)
-      [ x"$stratum0" = x"" ] && stratum0="http://localhost/cvmfs/$name"
     fi
+  fi
+
+  # stratum0 URL generation (defaults to local URL)
+  if [ x"$s3_config" != x"" ]; then
+    [ x"$stratum0" = x"" ] && die "Please specify the HTTP-URL for S3 (add option -w)"
+    stratum0=$(mangle_s3_cvmfs_url $name "$stratum0")
+  elif [ x"$stratum0" = x"" ]; then
+    stratum0="http://localhost/cvmfs/${name}"
   fi
 
   # sanity checks

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1728,13 +1728,17 @@ make_s3_upstream() {
   make_upstream "S3" "/var/spool/cvmfs/${repo_name}/tmp" "${repo_name}@${s3_config}"
 }
 
+mangle_local_cvmfs_url() {
+  local repo_name=$1
+  echo "http://localhost/cvmfs/${repo_name}"
+}
+
 mangle_s3_cvmfs_url() {
   local repo_name=$1
   local s3_url="$2"
   [ $(echo -n "$s3_url" | tail -c1) = "/" ] || s3_url="${s3_url}/"
   echo "${s3_url}${repo_name}"
 }
-
 
 # lowers restrictions of hardlink creation if needed
 # allows AUFS to properly whiteout files without root privileges
@@ -2537,7 +2541,7 @@ mkfs() {
     [ x"$stratum0" = x"" ] && die "Please specify the HTTP-URL for S3 (add option -w)"
     stratum0=$(mangle_s3_cvmfs_url $name "$stratum0")
   elif [ x"$stratum0" = x"" ]; then
-    stratum0="http://localhost/cvmfs/${name}"
+    stratum0="$(mangle_local_cvmfs_url $name)"
   fi
 
   # sanity checks
@@ -2756,7 +2760,7 @@ add_replica() {
     [ x"$stratum1_url" = x"" ] && die "Please specify the HTTP-URL for S3 (add option -w)"
     stratum1=$(mangle_s3_cvmfs_url $alias_name "$stratum1_url")
   elif [ x"stratum1_url" = x"" ]; then
-    stratum1="http://localhost/cvmfs/${alias_name}"
+    stratum1="$(mangle_local_cvmfs_url $alias_name)"
   else
     stratum1="$stratum1_url"
   fi
@@ -2963,7 +2967,7 @@ import() {
   name=$(get_repository_name $1)
 
   # default values
-  [ x"$stratum0" = x ] && stratum0="http://localhost/cvmfs/$name"
+  [ x"$stratum0" = x ] && stratum0="$(mangle_local_cvmfs_url $name)"
   [ x"$upstream" = x ] && upstream=$(make_upstream "local" "/srv/cvmfs/$name/data/txn" "/srv/cvmfs/$name")
   [ x"$unionfs"  = x ] && unionfs="$(get_available_union_fs)"
 
@@ -4768,7 +4772,7 @@ migrate_2_1_15() {
   echo "--> updating server.conf"
   local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
   sed -i -e "s/^CVMFS_CREATOR_VERSION=.*/CVMFS_CREATOR_VERSION=$destination_version/" $server_conf
-  echo "CVMFS_STRATUM1=http://localhost/cvmfs/${name}" >> $server_conf
+  echo "CVMFS_STRATUM1=$(mangle_local_cvmfs_url $name)" >> $server_conf
 
   # reload (updated) repository information
   load_repo_config $name

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2766,7 +2766,7 @@ add_replica() {
   if [ x"$s3_config" != x"" ]; then
     [ x"$stratum1_url" = x"" ] && die "Please specify the HTTP-URL for S3 (add option -w)"
     stratum1=$(mangle_s3_cvmfs_url $alias_name "$stratum1_url")
-  elif [ x"stratum1_url" = x"" ]; then
+  elif [ x"$stratum1_url" = x"" ]; then
     stratum1="$(mangle_local_cvmfs_url $alias_name)"
   else
     stratum1="$stratum1_url"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2594,7 +2594,14 @@ mkfs() {
 
   # create system-wide configuration
   echo -n "Creating Configuration Files... "
-  create_config_files_for_new_repository $name $upstream $stratum0 $cvmfs_user $unionfs $hash_algo $autotagging $garbage_collectable || die "fail"
+  create_config_files_for_new_repository "$name"        \
+                                         "$upstream"    \
+                                         "$stratum0"    \
+                                         "$cvmfs_user"  \
+                                         "$unionfs"     \
+                                         "$hash_algo"   \
+                                         "$autotagging" \
+                                         "$garbage_collectable" || die "fail"
   if is_local_upstream $upstream; then
     reload_apache > /dev/null
   fi
@@ -3022,7 +3029,14 @@ import() {
 
   # create the configuration for the new repository
   echo -n "Creating configuration files... "
-  create_config_files_for_new_repository $name $upstream $stratum0 $cvmfs_user $unionfs sha1 true false || die "fail!"
+  create_config_files_for_new_repository "$name"       \
+                                         "$upstream"   \
+                                         "$stratum0"   \
+                                         "$cvmfs_user" \
+                                         "$unionfs"    \
+                                         "sha1"        \
+                                         "true"        \
+                                         "false" || die "fail!"
   echo "done"
 
   # import the old repository security keys

--- a/test/src/556-customupstream/main
+++ b/test/src/556-customupstream/main
@@ -1,0 +1,157 @@
+cvmfs_test_name="Create Stratum0/Stratum1 with custom Upstream String"
+cvmfs_test_autofs_on_startup=false
+
+make_upstream() {
+  local type_name=$1
+  local tmp_dir=$2
+  local config_string=$3
+  echo "$type_name,$tmp_dir,$config_string"
+}
+
+make_local_upstream() {
+  local repo_name=$1
+  make_upstream "local" "/srv/cvmfs/${repo_name}/data/txn" "/srv/cvmfs/${repo_name}"
+}
+
+make_s3_upstream() {
+  local repo_name=$1
+  local s3_config=$2
+  make_upstream "S3" "/var/spool/cvmfs/${repo_name}/tmp" "${repo_name}@${s3_config}"
+}
+
+produce_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir poems
+
+  cat > poems/zueignung.txt << EOF
+Der Kabeljau
+Das Meer ist weit, das Meer ist blau,
+im Wasser schwimmt ein Kabeljau.
+Da kömmt ein Hai von ungefähr,
+ich glaub’ von links, ich weiß nicht mehr,
+verschluckt den Fisch mit Haut und Haar,
+das ist zwar traurig, aber wahr. ---
+Das Meer ist weit, das Meer ist blau,
+im Wasser schwimmt kein Kabeljau.
+
+   Heinz Erhardt
+EOF
+
+  cat > poems/unordnung.txt << EOF
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung  unordn  g
+ordnung    ordnung
+EOF
+
+  ln -s poems/unordnung.txt unordnung
+
+  popdir
+}
+
+CVMFS_TEST_556_REPLICA_NAME=
+CVMFS_TEST_556_MOUNTPOINT=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_556_MOUNTPOINT   ] || sudo umount $CVMFS_TEST_556_MOUNTPOINT
+  [ -z $CVMFS_TEST_556_REPLICA_NAME ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_556_REPLICA_NAME
+}
+
+check_stratum1_tmp_dir_emptiness() {
+  local tmp_dir="$1"
+  local tmp_dir_entries
+  echo "check stratum1 tmp directory"
+  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  echo "$tmp_dir contains: $tmp_dir_entries"
+  [ $tmp_dir_entries -eq 0 ]
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  local mnt_point="$(pwd)/mountpount"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  local s0upstream=
+  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
+    s0upstream=$(make_local_upstream $CVMFS_TEST_REPO)
+    s1upstream=$(make_local_upstream $replica_name)
+  else
+    s0upstream=$(make_s3_upstream $CVMFS_TEST_REPO $CVMFS_TEST_S3_CONFIG)
+    s1upstream=$(make_s3_upstream $replica_name $CVMFS_TEST_S3_CONFIG)
+  fi
+
+  echo "Using the following 'custom' upstream strings"
+  echo "  Stratum0 Upstream: $s0upstream"
+  echo "  Stratum1 Upstream: $s1upstream"
+
+  echo "install a desaster cleanup trap"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER "NO" -u "$s0upstream" || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in $repo_dir || return 3
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  produce_files_in $reference_dir || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "create Stratum1 repository on the same machine"
+  load_repo_config $CVMFS_TEST_REPO
+  CVMFS_TEST_556_REPLICA_NAME=$replica_name
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+                  -u "$s1upstream" || return 7
+
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
+
+  echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
+  sudo cvmfs_server snapshot $replica_name || return 9
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || return 101
+
+  echo "mount the Stratum1 repository on a local mountpoint"
+  CVMFS_TEST_556_MOUNTPOINT=$mnt_point
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || return 10
+
+  echo "check if the Stratum1 repository contains exactly the same as the reference copy"
+  compare_directories $mnt_point $reference_dir || return 11
+
+  return 0
+}
+


### PR DESCRIPTION
This is a follow up for [FIX: Stratum1 URL Handling](https://github.com/cvmfs/cvmfs/pull/1174). When revisiting this today I found a similar problem in `cvmfs_server mkfs`. Therefore I added a regression test (no. 556) and found a bug introduced by yesterday's pull request.

Furthermore this applies mild refactorings:
* introducing `mangle_local_cvmfs_url()` analogous to `mangle_s3_cvmfs_url()`
* proper quotation for invocations of `create_config_files_for_new_repository()`