### PR TITLE
FIX: SyncUnion::SupportsHardlinks() must be called virtually

### DIFF
--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -29,13 +29,11 @@ SyncUnion::SyncUnion(SyncMediator *mediator,
   scratch_path_(scratch_path),
   union_path_(union_path),
   mediator_(mediator),
-  initialized_(false)
-{
-  mediator_->RegisterUnionEngine(this);
-}
+  initialized_(false) {}
 
 
 bool SyncUnion::Initialize() {
+  mediator_->RegisterUnionEngine(this);
   initialized_ = true;
   return true;
 }

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -128,7 +128,7 @@ class SyncUnion {
                                    const std::string &filename) = 0;
 
   bool IsInitialized() const { return initialized_; }
-  bool SupportsHardlinks() const { return false; }
+  virtual bool SupportsHardlinks() const { return false; }
 
  protected:
   std::string rdonly_path_;


### PR DESCRIPTION
Trying to publish some hardlinks in AUFS since quite a while. Turns out that this was broken by some adaptions done for OverlayFS.

The bug is two-fold:
1. `SyncUnion::SupportsHardlinks()` needs to be declared `virtual`
2. `SyncMediator::RegisterUnionEngine()` must not be called in `SyncUnion`'s c'tor because at this stage the polymorphism for `SyncUnion::SupportsHardlinks()` doesn't work yet as `SyncUnionAufs`'s c'tor didn't run yet.