### PR TITLE
Refactor: Catalog Migration only Commits Changed Catalogs

### DIFF
--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -124,6 +124,13 @@ class Database : SingleCopy {
   bool                read_write()      const { return read_write_;           }
 
   /**
+   * Provides the number of rows modified by INSERT, UPDATE or DELETE statements
+   * that have been run against this database since it was opened.
+   * @return  number of rows modified by all executed manipulating statements
+   */
+  unsigned GetModifiedRowCount() const;
+
+  /**
    * Figures out the ratio of free SQLite memory pages in the SQLite database
    * file. A high ratio can be an indication of a necessary call to Vacuum().
    * Note: This is not done automatically and the decision is left to the using

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -322,6 +322,14 @@ void Database<DerivedT>::DropFileOwnership() {
            database_.filename().c_str());
 }
 
+
+template <class DerivedT>
+unsigned Database<DerivedT>::GetModifiedRowCount() const {
+  const int modified_rows = sqlite3_total_changes(sqlite_db());
+  assert(modified_rows >= 0);
+  return static_cast<unsigned>(modified_rows);
+}
+
 /**
  * Used to check if the database needs cleanup
  */

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -22,6 +22,7 @@ catalog::DirectoryEntry  CommandMigrate::nested_catalog_marker_;
 CommandMigrate::CommandMigrate() :
   file_descriptor_limit_(8192),
   catalog_count_(0),
+  has_committed_new_revision_(false),
   uid_(0),
   gid_(0),
   root_catalog_(NULL)
@@ -226,7 +227,7 @@ int CommandMigrate::Main(const ArgumentList &args) {
   }
 
   // Analyze collected statistics
-  if (collect_catalog_statistics) {
+  if (collect_catalog_statistics && has_committed_new_revision_) {
     LogCvmfs(kLogCatalog, kLogStdout, "\nCollected statistics results:");
     AnalyzeCatalogStatistics();
   }
@@ -336,6 +337,7 @@ bool CommandMigrate::DoMigrationAndCommit(
       Error("Manifest export failed.\nAborting...");
       return false;
     }
+    has_committed_new_revision_ = true;
   } else {
     LogCvmfs(kLogCatalog, kLogStdout,
              "\nNo catalogs migrated, skipping the commit...");

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -388,7 +388,7 @@ void CommandMigrate::MigrationCallback(PendingCatalog *const &data) {
   }
 
   if (!data->HasChanges()) {
-    PrintStatusMessage(data, data->GetOldContentHash(), "perserved");
+    PrintStatusMessage(data, data->GetOldContentHash(), "preserved");
     data->was_updated.Set(false);
     return;
   }

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -436,13 +436,7 @@ void CommandMigrate::UploadCallback(const upload::SpoolerResult &result) {
       pending_catalogs_.erase(i);
     }
 
-    atomic_inc32(&catalogs_processed_);
-    const unsigned int processed = (atomic_read32(&catalogs_processed_) * 100) /
-                                    catalog_count_;
-    LogCvmfs(kLogCatalog, kLogStdout, "[%d%%] migrated and uploaded %sC %s",
-             processed,
-             result.content_hash.ToString().c_str(),
-             catalog->root_path().c_str());
+    PrintStatusMessage(catalog, result.content_hash, "migrated and uploaded");
 
     // The catalog is completely processed... fill the hash-future to allow the
     // processing of parent catalogs
@@ -450,6 +444,20 @@ void CommandMigrate::UploadCallback(const upload::SpoolerResult &result) {
     //       should not be used anymore!
     catalog->new_catalog_hash.Set(result.content_hash);
   }
+}
+
+
+void CommandMigrate::PrintStatusMessage(const PendingCatalog *catalog,
+                                        const shash::Any     &content_hash,
+                                        const std::string    &message) {
+  atomic_inc32(&catalogs_processed_);
+  const unsigned int processed = (atomic_read32(&catalogs_processed_) * 100) /
+                                  catalog_count_;
+  LogCvmfs(kLogCatalog, kLogStdout, "[%d%%] %s %sC %s",
+           processed,
+           message.c_str(),
+           content_hash.ToString().c_str(),
+           catalog->root_path().c_str());
 }
 
 

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -316,6 +316,7 @@ class CommandMigrate : public Command {
   CatalogStatisticsList  catalog_statistics_list_;
   unsigned int           catalog_count_;
   atomic_int32           catalogs_processed_;
+  bool                   has_committed_new_revision_;
 
   uid_t                  uid_;
   gid_t                  gid_;

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -276,6 +276,10 @@ class CommandMigrate : public Command {
   void MigrationCallback(PendingCatalog *const &data);
   void UploadCallback(const upload::SpoolerResult &result);
 
+  void PrintStatusMessage(const PendingCatalog *catalog,
+                          const shash::Any     &content_hash,
+                          const std::string    &message);
+
   template <class MigratorT>
   bool DoMigrationAndCommit(const std::string                   &manifest_path,
                             typename MigratorT::worker_context  *context);

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -73,6 +73,15 @@ class CommandMigrate : public Command {
     inline bool IsRoot() const { return old_catalog->IsRoot(); }
     inline bool HasNew() const { return new_catalog != NULL;   }
 
+    inline bool HasChanges() const {
+      return (new_catalog != NULL ||
+              old_catalog->database().GetModifiedRowCount() > 0);
+    }
+
+    inline shash::Any GetOldContentHash() const {
+      return old_catalog->hash();
+    }
+
     bool                              success;
 
     const catalog::Catalog           *old_catalog;
@@ -84,8 +93,9 @@ class CommandMigrate : public Command {
 
     CatalogStatistics                 statistics;
 
-    Future<shash::Any>                new_catalog_hash;
-    Future<size_t>                    new_catalog_size;
+    Future<bool>                      was_updated;
+    shash::Any                        new_catalog_hash;
+    size_t                            new_catalog_size;
   };
 
   class PendingCatalogMap : public std::map<std::string, const PendingCatalog*>,

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -93,6 +93,9 @@ class CommandMigrate : public Command {
 
     CatalogStatistics                 statistics;
 
+    // Note: As soon as the `was_updated` future is set to 'true', both
+    //       `new_catalog_hash` and `new_catalog_size` are assumed to be set
+    //       accordingly. If it is set to 'false' they will be ignored.
     Future<bool>                      was_updated;
     shash::Any                        new_catalog_hash;
     size_t                            new_catalog_size;

--- a/test/unittests/t_sqlite_database.cc
+++ b/test/unittests/t_sqlite_database.cc
@@ -894,3 +894,97 @@ TEST_F(T_SQLite_Wrapper, DropFileOwnership) {
   EXPECT_EQ(0u, DummyDatabase::instances);
   EXPECT_TRUE(FileExists(file_name3));
 }
+
+
+TEST_F(T_SQLite_Wrapper, CountModifiedRows) {
+  const std::string dbp = GetDatabaseFilename();
+
+  DummyDatabase *db1 = DummyDatabase::Create(dbp);
+  ASSERT_NE(static_cast<DummyDatabase*>(NULL), db1);
+  EXPECT_EQ(1u, DummyDatabase::instances);
+  EXPECT_TRUE(db1->read_write());
+  EXPECT_EQ(2u, db1->GetModifiedRowCount()); // creation adds schema revision
+                                              // information to the database
+  delete db1;
+  EXPECT_EQ(0u, DummyDatabase::instances);
+
+  DummyDatabase *db2 = DummyDatabase::Open(dbp, DummyDatabase::kOpenReadWrite);
+  ASSERT_NE(static_cast<DummyDatabase*>(NULL), db2);
+  EXPECT_EQ(1u, DummyDatabase::instances);
+  EXPECT_TRUE(db2->read_write());
+  EXPECT_EQ(0u, db1->GetModifiedRowCount());
+
+  EXPECT_TRUE(db2->SetProperty("foo", 1337));
+  EXPECT_TRUE(db2->SetProperty("bar", 42));
+  EXPECT_EQ(2u, db2->GetModifiedRowCount());
+
+  EXPECT_EQ(1337, db2->GetProperty<int>("foo"));
+  EXPECT_EQ(2u, db2->GetModifiedRowCount());
+
+  const unsigned entries = 30;
+  {
+    sqlite::Sql insert(db1->sqlite_db(), "INSERT INTO foobar (foo, bar) "
+                                         "VALUES (:f, :b);");
+
+    EXPECT_TRUE(db1->BeginTransaction());
+    for (unsigned i = 0; i < entries; ++i) {
+      EXPECT_TRUE(insert.BindTextTransient(1, "foobar!" + StringifyInt(i)));
+      EXPECT_TRUE(insert.BindText(2, "this is a very useless text!!"));
+      EXPECT_TRUE(insert.Execute());
+      EXPECT_TRUE(insert.Reset());
+    }
+    EXPECT_TRUE(db1->CommitTransaction());
+  }
+
+  EXPECT_EQ(2u + entries, db2->GetModifiedRowCount());
+
+  delete db2;
+  EXPECT_EQ(0u, DummyDatabase::instances);
+
+  DummyDatabase *db3 = DummyDatabase::Open(dbp, DummyDatabase::kOpenReadOnly);
+  ASSERT_NE(static_cast<DummyDatabase*>(NULL), db3);
+  EXPECT_EQ(1u, DummyDatabase::instances);
+
+  EXPECT_EQ(0u, db3->GetModifiedRowCount());
+  {
+    sqlite::Sql read(db3->sqlite_db(), "SELECT * FROM foobar;");
+    unsigned count = 0;
+    while (read.FetchRow()) {
+      ++count;
+      read.Retrieve<std::string>(1);
+    }
+    EXPECT_EQ(entries, count);
+  }
+  EXPECT_EQ(0u, db3->GetModifiedRowCount());
+
+  delete db3;
+  EXPECT_EQ(0u, DummyDatabase::instances);
+
+  DummyDatabase *db4 = DummyDatabase::Open(dbp, DummyDatabase::kOpenReadWrite);
+  ASSERT_NE(static_cast<DummyDatabase*>(NULL), db4);
+  EXPECT_EQ(1u, DummyDatabase::instances);
+
+  EXPECT_EQ(0u, db4->GetModifiedRowCount());
+  db4->SetProperty("foo", 27);
+  EXPECT_EQ(1u, db4->GetModifiedRowCount());
+
+  {
+    sqlite::Sql update(db4->sqlite_db(), "UPDATE foobar SET bar = 'moep!' "
+                                         "WHERE foo = 'foobar!5';");
+    EXPECT_TRUE(db4->BeginTransaction());
+    update.Execute();
+    EXPECT_TRUE(db4->CommitTransaction());
+  }
+  EXPECT_EQ(2u, db4->GetModifiedRowCount());
+
+  {
+    sqlite::Sql erase(db4->sqlite_db(), "DELETE FROM foobar;");
+    EXPECT_TRUE(db4->BeginTransaction());
+    erase.Execute();
+    EXPECT_TRUE(db4->CommitTransaction());
+  }
+  EXPECT_EQ(2u + entries, db4->GetModifiedRowCount());
+
+  delete db4;
+  EXPECT_EQ(0u, DummyDatabase::instances);
+}


### PR DESCRIPTION
This changes `cvmfs_swissknife migrate` to upload nested catalogs only if they have been changed during the migration step. The rationale being that OverlayFS will need a catalog migration when a previous AUFS-based repository is imported.

To figure out if a catalog database has been modified, I've added `Database<>::GetModifiedRowCount()` along with a unit test case that figures out how many databases rows have been changed since the SQLite database has been opened.

Furthermore, the migration code of `cvmfs_swissknife` needs to step over unmodified catalogs which required an adaption in the concurrent processing. In detail, I replaced two individual `Future<>`s in `PendingCatalog` by a new one (cf. `Future<bool> was_modified`) that acts both as a modification flag and a signal for finished processing.