### PR TITLE
FIX: Test Failures related to OverlayFS and Legacy Imports

### DIFF
--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -64,6 +64,11 @@ cvmfs_run_test() {
   start_transaction $legacy_repo_name || return $?
   publish_repo      $legacy_repo_name || return $?
 
+  if uses_overlayfs $legacy_repo_name; then
+    echo "we are running on OverlayFS. We need to erase all hardlinks now..."
+    sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 101
+  fi
+
   # cheate a new repository revision of the migrated catalogs
   echo "create a new repository revision"
   local big_file="${repo_dir}/dir6/bigfile"

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -204,6 +204,11 @@ cvmfs_run_test() {
   echo "list newly generated repository under /cvmfs/${legacy_repo_name}"
   ls -lisa /cvmfs/${legacy_repo_name} || return 15
 
+  if uses_overlayfs $legacy_repo_name; then
+    echo "we are running on OverlayFS. We need to erase all hardlinks now..."
+    sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 101
+  fi
+
   echo "do a snapshot on stratum 1 that spans from CernVM-FS 2.1.x to 2.0"
   sudo cvmfs_server snapshot $replica_name || return 16
 

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -49,6 +49,11 @@ cvmfs_run_test() {
     -s                                           \
     -g > $import_log 2>&1 || return 4
 
+  if uses_overlayfs $legacy_repo_name; then
+    echo "we are running on OverlayFS. We need to erase all hardlinks now..."
+    sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 101
+  fi
+
   echo "get all data chunks in the legacy repository"
   local data_chunks="$(cat $resurrect_log | grep -o '[0-9a-f]\{2\}\/[0-9a-f]\+$' | sed 's/\///g')"
 

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -29,9 +29,10 @@ cvmfs_run_test() {
   echo -n "resurrect legacy repository... "
   local resurrect_log="resurrect.log"
   TEST519_LEGACY_STORAGE="$legacy_repo_storage"
-  plant_tarball "${guinea_pig_location}/keys.tar.gz"                                                                              || return $?
+  plant_tarball "${guinea_pig_location}/keys.tar.gz" || return $?
   plant_legacy_repository_revision "${guinea_pig_location}/revision-6.tar.gz" \
                                    "$legacy_repo_name"                        \
+                                   "$CVMFS_TEST_USER"                         \
                                    "verbose" > $resurrect_log 2>&1 || return $?
   echo "done"
 

--- a/test/src/568-migratecorruptrepo/main
+++ b/test/src/568-migratecorruptrepo/main
@@ -50,9 +50,21 @@ cvmfs_run_test() {
   cat "$migration_log" | grep '^NOTE: fixed.*dangling.*mountpoint.*dangling_mountpoint'       || return 6
   cat "$migration_log" | grep '^WARNING.*non-empty.*mountpoint.*non_empty_nested_mountpoint'  || return 7
 
+  local expected_warnings=1
+  local expected_notes=2
+  if uses_overlayfs $legacy_repo_name; then
+    echo "we are running on OverlayFS."
+    echo " OverlayFS: Need to check for one more warning"
+    cat "$migration_log" | grep '^WARNING:.*using.*OverlayFS.*hard.*links' || return 101
+    expected_warnings=$(( $expected_warnings + 1 ))
+
+    echo " OverlayFS: We should eliminate all hardlinks in the legacy repo"
+    sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 102
+  fi
+
   echo "check that there are no unexpected warnings"
-  [ $(cat "$migration_log" | grep '^NOTE'    | wc -l) -eq 2 ] || return 8
-  [ $(cat "$migration_log" | grep '^WARNING' | wc -l) -eq 1 ] || return 9
+  [ $(cat "$migration_log" | grep '^NOTE'    | wc -l) -eq $expected_notes ]    || return 8
+  [ $(cat "$migration_log" | grep '^WARNING' | wc -l) -eq $expected_warnings ] || return 9
 
   echo "remove the (legacy) quarantaine directory"
   sudo rm -fR ${legacy_repo_storage}/data/quarantaine || return 10

--- a/test/test_functions
+++ b/test/test_functions
@@ -1260,9 +1260,10 @@ plant_legacy_repository_revision() {
   local tarball="$1"
   local legacy_repo_name="$2"
   local repo_owner="$3"
+  local verbose="$4"
   local legacy_repo_storage="$(get_local_repo_storage $legacy_repo_name)"
 
-  plant_tarball "$tarball" "$verbose"                                  || return 104
+  plant_tarball "$tarball" "$verbose" || return 104
 
   # figure out if we just planted a CVMFS 2.0.x repository or something newer
   local is_cvmfs_20=0


### PR DESCRIPTION
Since our legacy (2.0.x) guinea-pig repository contains hardlinks these tests fail on OverlayFS. This adds invocations to `cvmfs_server eliminate-hardlinks` accordingly to make the tests succeed. Apart from that their are some other minor tweaks necessary in the OverlayFS case. For example to `grep` for the warning generated by `cvmfs_server import` when importing with OverlayFS.