### PR TITLE
FIX: Mountpoint Auto Repair Failed when only CVMFS was Broken

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1370,8 +1370,8 @@ __health_check_print_repair_info() {
 
   load_repo_config $name
 
-  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" != x"true" ]; then
-    echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT != true)" >&2
+  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
+    echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT = false)" >&2
     exit 1
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1400,12 +1400,12 @@ health_check() {
   fi
 
   # health check cannot deal with repositories currently being published
-  if [ $quiet -eq 0 ] &&  is_publishing $name; then
+  if [ $quiet -eq 0 ] && is_publishing $name; then
     echo "WARNING: The repository $name is currently publishing and should not"
     echo "be touched. If you are absolutely sure, that this is _not_ the case,"
     echo "please run the following command and retry:"
     echo
-    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing"
+    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing.lock"
     echo
     exit 1
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1391,6 +1391,8 @@ health_check() {
   local name=$1
   local quiet=${2-0}
   local repair_in_txn=${3-0}
+  local rdonly_broken=0
+  local rw_broken=0
 
   load_repo_config $name
 
@@ -1414,14 +1416,30 @@ health_check() {
   if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
     echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly." >&2
     __health_check_print_repair_info $name $repair_in_txn
-    echo -n "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... "
-    cvmfs_suid_helper rdonly_mount $name > /dev/null && echo "success" || { echo "fail"; exit 1; }
+    rdonly_broken=1
   fi
 
   # check mounted union file system
   if ! is_mounted "/cvmfs/$name"; then
     echo "/cvmfs/$name is not mounted properly." >&2
     __health_check_print_repair_info $name $repair_in_txn
+    rw_broken=1
+  fi
+
+  # try to repair the mountpoints
+  if [ $rdonly_broken -eq 1 ]; then
+    if [ $rw_broken -eq 0 ]; then
+      echo "Only the lower union file system branch is broken" >&2
+      echo -n "Note: Trying to umount /cvmfs/${name}... "
+      cvmfs_suid_helper rw_umount $name && echo "success" || { echo "fail"; exit 1; }
+      rw_broken=1 # will be fixed downstream
+    fi
+
+    echo -n "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... "
+    cvmfs_suid_helper rdonly_mount $name > /dev/null && echo "success" || { echo "fail"; exit 1; }
+  fi
+
+  if [ $rw_broken -eq 1 ]; then
     echo -n "Note: Trying to mount /cvmfs/${name}... "
     cvmfs_suid_helper rw_mount $name && echo "success" || { echo "fail"; exit 1; }
   fi

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -100,6 +100,9 @@ cvmfs_run_test() {
   cat $check_log_1 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"  || return 5
   cat $check_log_1 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}" || return 6
 
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 106
+
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "unmount union file system mountpoint"
@@ -117,6 +120,9 @@ cvmfs_run_test() {
   cat $check_log_2 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly" || return 11
   cat $check_log_2 | grep -e "/cvmfs/${CVMFS_TEST_REPO} is not mounted"    || return 12
   cat $check_log_2 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"   || return 13
+
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 113
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -160,6 +166,9 @@ cvmfs_run_test() {
   cat $check_log_5 | grep -e "is in a transaction .* /cvmfs/${CVMFS_TEST_REPO} .* not mounted read/write" || return 25
   cat $check_log_5 | grep -e "Trying to remount /cvmfs/${CVMFS_TEST_REPO} read/write"                     || return 26
 
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 126
+
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "check the repository's integrity"
@@ -173,6 +182,9 @@ cvmfs_run_test() {
 
   echo "check repository integrity"
   check_repository $CVMFS_TEST_REPO -i || return 28
+
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 128
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -210,6 +222,9 @@ cvmfs_run_test() {
 
   echo "check repository integrity"
   check_repository $CVMFS_TEST_REPO -i || return 43
+
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 143
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -253,6 +268,9 @@ cvmfs_run_test() {
 
   echo "publish transaction"
   publish_repo $CVMFS_TEST_REPO || return 53
+
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 153
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -302,6 +320,9 @@ cvmfs_run_test() {
   echo "check repository integrity"
   check_repository $CVMFS_TEST_REPO -i || return 66
 
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 166
+
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "open transaction"
@@ -314,12 +335,15 @@ cvmfs_run_test() {
   remove_everything_from $reference_dir || return 69
 
   echo "publish transaction"
-  publish_repo $CVMFS_TEST_REPO || return 69
+  publish_repo $CVMFS_TEST_REPO || return 70
+
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 71
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
   echo "check repository integrity"
-  check_repository $CVMFS_TEST_REPO -i || return 70
+  check_repository $CVMFS_TEST_REPO -i || return 72
 
   return 0
 }

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -24,12 +24,46 @@ mount_old_root_hash() {
 }
 
 
+add_bin_to() {
+  local path="$1"
+
+  pushdir $path
+  cp_bin . || return 1
+  popdir
+}
+
+
+do_some_changes_to() {
+  local path="$1"
+
+  pushdir $path
+
+  mkdir foobar                  || return 1
+  echo "foobar" > foobar/foobar || return 2
+  touch foobar/.cvmfscatalog    || return 3
+
+  popdir
+}
+
+
+remove_everything_from() {
+  local path="$1"
+
+  pushdir $path
+  rm -fR ./*
+  popdir
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local rd_only=/var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly
 
   local scratch_dir=$(pwd)
+  local reference_dir="${scratch_dir}/reference"
+
+  echo "create a local reference directory"
+  mkdir $reference_dir || return 101
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -41,7 +75,10 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return $?
 
   echo "filling the repository with contents of /bin"
-  cp_bin $repo_dir || return 1
+  add_bin_to $repo_dir || return 1
+
+  echo "filling the reference dir with contents of /bin"
+  add_bin_to $reference_dir || return 101
 
   echo "creating CVMFS snapshot"
   cvmfs_server publish $CVMFS_TEST_REPO || return 2
@@ -209,9 +246,10 @@ cvmfs_run_test() {
   cat $check_log_9 | grep -e "Trying to remount .* to $current_root_hash"               || return 49
 
   echo "add a couple of files"
-  mkdir ${repo_dir}/foobar                  || return 50
-  echo "foobar" > ${repo_dir}/foobar/foobar || return 51
-  touch ${repo_dir}/foobar/.cvmfscatalog    || return 52
+  do_some_changes_to $repo_dir || return 50
+
+  echo "add a couple of files to the reference dir as well"
+  do_some_changes_to $reference_dir || return 51
 
   echo "publish transaction"
   publish_repo $CVMFS_TEST_REPO || return 53
@@ -270,7 +308,10 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return 67
 
   echo "remove everything from repo"
-  rm -fR ${repo_dir}/* || return 68
+  remove_everything_from $repo_dir || return 68
+
+  echo "remove everything from reference dir"
+  remove_everything_from $reference_dir || return 69
 
   echo "publish transaction"
   publish_repo $CVMFS_TEST_REPO || return 69

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -126,6 +126,31 @@ cvmfs_run_test() {
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
+  echo "unmount union file system mountpoint"
+  sudo umount $repo_dir || return 106
+
+  echo "unmount read-only cvmfs branch"
+  sudo umount $rd_only || return 107
+
+  echo "mount the union file system again (without CVMFS mounted underneath)"
+  sudo mount $repo_dir || return 108
+
+  echo "check the repository"
+  local check_log_2_1="check_2.1.log"
+  cvmfs_server check $CVMFS_TEST_REPO > $check_log_2_1 2>&1 || return 109
+
+  echo "check the error and warning messages"
+  cat $check_log_2_1 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted"    || return 110
+  cat $check_log_2_1 | grep -e "Only.*lower.*branch is broken"               || return 111
+  cat $check_log_2_1 | grep -e "Trying.*umount.* /cvmfs/${CVMFS_TEST_REPO}"  || return 112
+  cat $check_log_2_1 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly" || return 113
+  cat $check_log_2_1 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"   || return 114
+
+  echo "compare repository to reference directory"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return 115
+
+  # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
   echo "remount union file system read/write"
   sudo mount -o remount,rw $repo_dir || return 14
 


### PR DESCRIPTION
This fixes a bug in the mountpoint auto-repair feature [found by the ATLAS nightlies repository](https://sft.its.cern.ch/jira/browse/CVM-918). Concretely if `/var/spool/cvmfs/.../rdonly` is not mounted but `/cvmfs/...` is fine, `cvmfs_server` will try to mount CVMFS *underneath* a mounted union file system. Of course this doesn't have the desired effect.

I fix it by first checking both `.../rdonly` and `/cvmfs/...` and temporarily unmounting `/cvmfs/...` in the situation described above. Furthermore this extends integration test case 582 both for detecting this regression and to make it check the actual repository content more resiliently.

Finally this changes the default behaviour of `cvmfs_server` to always try the auto-repair if `CVMFS_AUTO_REPAIR_MOUNTPOINTS` is not explicitly set to false. It was the default behaviour for newly created repositories before, but wasn't used for legacy repos when not explicitly enabled ([CVM-889](https://sft.its.cern.ch/jira/browse/CVM-889)).