### PR TITLE
FIX: Integration Tests and Ubuntu Provisioning for OverlayFS

### DIFF
--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -154,6 +154,9 @@ cvmfs_run_test() {
   mkdir reference_dir
   local reference_dir=$scratch_dir/reference_dir
 
+  echo "check for sqlite3 utility"
+  which sqlite3 || return 1
+
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 

--- a/test/src/533-volatilecacheset/main
+++ b/test/src/533-volatilecacheset/main
@@ -14,6 +14,8 @@ disaster_cleanup() {
 cvmfs_run_test() {
   logfile=$1
 
+  which sqlite3 || return 1
+
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
   create_empty_repo $CVMFS_TEST_REPO_MORE $CVMFS_TEST_USER NO -v || return $?
 

--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -84,7 +84,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "compare the results of cvmfs to our reference copy"
-  compare_directories $repo_dir $reference_dir|| return $?
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   # ============================================================================
 

--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -35,6 +35,9 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local scratch_dir=$(pwd)
 
+  echo "check for sqlite3 utility"
+  which sqlite3 || return 1
+
   echo "create test repository"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 

--- a/vagrant/provision_ubuntu.sh
+++ b/vagrant/provision_ubuntu.sh
@@ -8,13 +8,13 @@ VAGRANT_WORKSPACE="/vagrant"
 apt-get update
 
 # install required packages
-apt-get install -y apache2 attr autofs autotools-dev bash cmake coreutils     \
-                   curl debhelper debianutils debootstrap docker.io fuse g++  \
-                   gawk gcc gdb grep gzip initscripts insserv libattr1-dev    \
-                   libc-bin libc6-dev libcap-dev libfuse-dev libfuse2         \
-                   libssl-dev make openssl patch perl pkg-config psmisc       \
-                   python-dev python-lzma sed sudo sysvinit-utils unzip uuid  \
-                   uuid-dev yum zlib1g
+apt-get install -y apache2 attr autofs autotools-dev bash cmake coreutils curl \
+                   debhelper debianutils debootstrap docker.io fuse g++ gawk   \
+                   gcc gdb grep gzip initscripts insserv libattr1-dev libc-bin \
+                   libc6-dev libcap-dev libfuse-dev libfuse2 libssl-dev make   \
+                   openssl patch perl pkg-config psmisc python-dev python-lzma \
+                   sed sqlite3 sudo sysvinit-utils unzip uuid uuid-dev yum     \
+                   zlib1g
 
 # install some convenience packages
 apt-get install -y git tig iftop htop jq screen python-unittest2

--- a/vagrant/provision_ubuntu.sh
+++ b/vagrant/provision_ubuntu.sh
@@ -13,8 +13,9 @@ apt-get install -y apache2 attr autofs autotools-dev bash bc cmake coreutils   \
                    gawk gcc gdb grep gzip initscripts insserv                  \
                    libapache2-mod-wsgi libattr1-dev libc-bin libc6-dev         \
                    libcap-dev libfuse-dev libfuse2 libssl-dev make openssl     \
-                   patch perl pkg-config psmisc python-dev python-lzma sed     \
-                   sqlite3 sudo sysvinit-utils unzip uuid uuid-dev yum zlib1g
+                   default-jre-headless patch perl pkg-config psmisc           \
+                   python-dev python-lzma sed sqlite3 sudo sysvinit-utils      \
+                   unzip uuid uuid-dev yum zlib1g
 
 # install some convenience packages
 apt-get install -y git tig iftop htop jq screen python-unittest2

--- a/vagrant/provision_ubuntu.sh
+++ b/vagrant/provision_ubuntu.sh
@@ -10,11 +10,11 @@ apt-get update
 # install required packages
 apt-get install -y apache2 attr autofs autotools-dev bash cmake coreutils curl \
                    debhelper debianutils debootstrap docker.io fuse g++ gawk   \
-                   gcc gdb grep gzip initscripts insserv libattr1-dev libc-bin \
-                   libc6-dev libcap-dev libfuse-dev libfuse2 libssl-dev make   \
-                   openssl patch perl pkg-config psmisc python-dev python-lzma \
-                   sed sqlite3 sudo sysvinit-utils unzip uuid uuid-dev yum     \
-                   zlib1g
+                   gcc gdb grep gzip initscripts insserv libapache2-mod-wsgi   \
+                   libattr1-dev libc-bin libc6-dev libcap-dev libfuse-dev      \
+                   libfuse2 libssl-dev make openssl patch perl pkg-config      \
+                   psmisc python-dev python-lzma sed sqlite3 sudo              \
+                   sysvinit-utils unzip uuid uuid-dev yum zlib1g
 
 # install some convenience packages
 apt-get install -y git tig iftop htop jq screen python-unittest2

--- a/vagrant/provision_ubuntu.sh
+++ b/vagrant/provision_ubuntu.sh
@@ -8,13 +8,13 @@ VAGRANT_WORKSPACE="/vagrant"
 apt-get update
 
 # install required packages
-apt-get install -y apache2 attr autofs autotools-dev bash cmake coreutils curl \
-                   debhelper debianutils debootstrap docker.io fuse g++ gawk   \
-                   gcc gdb grep gzip initscripts insserv libapache2-mod-wsgi   \
-                   libattr1-dev libc-bin libc6-dev libcap-dev libfuse-dev      \
-                   libfuse2 libssl-dev make openssl patch perl pkg-config      \
-                   psmisc python-dev python-lzma sed sqlite3 sudo              \
-                   sysvinit-utils unzip uuid uuid-dev yum zlib1g
+apt-get install -y apache2 attr autofs autotools-dev bash bc cmake coreutils   \
+                   curl debhelper debianutils debootstrap docker.io fuse g++   \
+                   gawk gcc gdb grep gzip initscripts insserv                  \
+                   libapache2-mod-wsgi libattr1-dev libc-bin libc6-dev         \
+                   libcap-dev libfuse-dev libfuse2 libssl-dev make openssl     \
+                   patch perl pkg-config psmisc python-dev python-lzma sed     \
+                   sqlite3 sudo sysvinit-utils unzip uuid uuid-dev yum zlib1g
 
 # install some convenience packages
 apt-get install -y git tig iftop htop jq screen python-unittest2


### PR DESCRIPTION
This fixes the integration test 537 for OverlayFS's missing hardlink awareness. Furthermore it adds a couple of opportunistic checks for the availability of the `sqlite3` utility to make those fail gracefully in case it's not installed.

Finally this adds the following missing packages for the Ubuntu vagrant provisioning script:
* sqlite3
* libapache2-mod-wsgi
* bc
* default-jre-headless