### PR TITLE
FIX: autofs tab handling on os x

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -261,46 +261,36 @@ cvmfs_chksetup() {
     fi
   fi
 
-  for path in /etc/auto.master /etc/autofs/auto.master; do
+  # No autofs integration on OS X
+  if [ "$sys_arch" = "Linux" ]; then
+    for path in /etc/auto.master /etc/autofs/auto.master; do
       if [ -f $path ]; then
-          AUTOMASTER=$path
-          break;
+        AUTOMASTER=$path
+        break;
       fi
-  done
-  if [ -z "$AUTOMASTER" ]; then
+    done
+    if [ -z "$AUTOMASTER" ]; then
       echo "Error: unable to find auto.master in any of the supplied paths!"
       num_errors=$(($num_errors+1))
       AUTOMASTER=/dev/null
-  fi
-  # Check that /etc/auto.cvmfs is referenced in auto.master
-  # Check that /etc/auto.cvmfs is executable on Linux
-  local global_mount_dir
-  global_mount_dir=$CVMFS_MOUNT_DIR
-  case $sys_arch in
-    Linux )
-      if ! grep -q "^$CVMFS_MOUNT_DIR[[:space:]]\+\(program:\|\)/etc/auto.cvmfs" $AUTOMASTER 2> /dev/null; then
-        if ! check_is_on CVMFS_NFS_SOURCE; then
-          echo "Warning: CernVM-FS map is not referenced from autofs master map"
-          num_warnings=$(($num_warnings+1))
-        fi
-      fi
-
-      # Check that /etc/auto.cvmfs is executable
-      if [ ! -x /etc/auto.cvmfs ]; then
-        echo "Error: /etc/auto.cvmfs is not executable"
-        num_errors=$(($num_errors+1))
-      fi ;;
-
-    Darwin )
-      if ! grep -q "^$CVMFS_MOUNT_DIR[[:space:]]\+/etc/auto_cvmfs" $AUTOMASTER 2> /dev/null; then
+    fi
+    # Check that /etc/auto.cvmfs is referenced in auto.master
+    # Check that /etc/auto.cvmfs is executable on Linux
+    local global_mount_dir
+    global_mount_dir=$CVMFS_MOUNT_DIR
+    if ! grep -q "^$CVMFS_MOUNT_DIR[[:space:]]\+\(program:\|\)/etc/auto.cvmfs" $AUTOMASTER 2> /dev/null; then
+      if ! check_is_on CVMFS_NFS_SOURCE; then
         echo "Warning: CernVM-FS map is not referenced from autofs master map"
         num_warnings=$(($num_warnings+1))
-      fi ;;
+      fi
+    fi
 
-    * )
-      echo "Architecture $sys_arch is not supported"
-      exit 1 ;;
-  esac
+    # Check that /etc/auto.cvmfs is executable
+    if [ ! -x /etc/auto.cvmfs ]; then
+      echo "Error: /etc/auto.cvmfs is not executable"
+      num_errors=$(($num_errors+1))
+    fi
+  fi
 
   # Check that cvmfs user exists
   if ! check_cvmfs_user; then
@@ -1438,20 +1428,20 @@ reload_service() {
 
 
 configure_autofs() {
-  for path in /etc/auto.master /etc/autofs/auto.master; do
-    if [ -f $path ]; then
-      AUTOMASTER=$path
-      break;
-    fi
-  done
-  if [ -z "$AUTOMASTER" ]; then
-    echo "Error: unable to find auto.master in any of the supplied paths!"
-    num_errors=$(($num_errors+1))
-    AUTOMASTER=/dev/null
-  fi
   case $sys_arch in
     Linux )
-      sed -i "/^\/mnt\/cvmfs \/etc\/auto.cvmfs/d" $AUTOMASTER #Still needed or needs to be adjusted?
+      for path in /etc/auto.master /etc/autofs/auto.master; do
+        if [ -f $path ]; then
+          AUTOMASTER=$path
+          break;
+        fi
+      done
+      if [ -z "$AUTOMASTER" ]; then
+        echo "Error: unable to find auto.master in any of the supplied paths!"
+        num_errors=$(($num_errors+1))
+        AUTOMASTER=/dev/null
+      fi
+      sed -i "/^\/mnt\/cvmfs \/etc\/auto.cvmfs/d" $AUTOMASTER # Still needed or needs to be adjusted?
       local cvmfs_map="$CVMFS_MOUNT_DIR /etc/auto.cvmfs"
       if ! grep -q "^$cvmfs_map" $AUTOMASTER; then
         echo "$cvmfs_map" >> $AUTOMASTER


### PR DESCRIPTION
No integration with autofs on OS X, hence the `cvmfs_config` script shouldn't try to tamper with it.  This problem was introduced by fixing `cvmfs_config` for Arch Linux.