### PR TITLE
FIX: Package Dependencies

### DIFF
--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -18,7 +18,7 @@ Description: CernVM File System
 Package: cvmfs-server
 Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2, libcap2
+Depends: insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2, libcap2, lsof
 Conflicts: cvmfs-server (< 2.1)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -91,7 +91,7 @@ Requires: shadow-utils
 Requires: SysVinit
 Requires: e2fsprogs
   %else
-    %if 0%{?fc21}
+    %if 0%{?fc21} || 0%{?fc22}
 Requires: procps-ng
     %else
 Requires: sysvinit-tools

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -387,6 +387,9 @@ fi
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog
+* Fri Oct 23 2015 Rene Meusel <rene.meusel@cern.ch> - 2.2.0
+- Fix dependency for Fedora 22
+- Add lsof dependency for cvmfs-server
 * Tue Oct 13 2015 Rene Meusel <rene.meusel@cern.ch> - 2.2.0
 - Add libcap dependency for cvmfs-server
 * Wed Sep 30 2015 Rene Meusel <rene.meusel@cern.ch> - 2.2.0

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -153,6 +153,7 @@ Requires: attr
 Requires: openssl
 Requires: httpd
 Requires: libcap
+Requires: lsof
 
 Conflicts: cvmfs-server < 2.1
 


### PR DESCRIPTION
This adds `lsof` as a package dependency of `cvmfs-server` and fixes a dependency problems on Fedora 22.