### PR TITLE
FIX: Regression of Integration Test 593

### DIFF
--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -93,6 +93,10 @@ void SyncItem::MarkAsWhiteout(const std::string &actual_filename) {
     rdonly_type_  = GetRdOnlyFiletype();
     scratch_type_ = GetRdOnlyFiletype();
   } else {
+    // Marking a SyncItem as 'whiteout' but no file to be removed found: This
+    // should not happen (actually AUFS prevents users from creating whiteouts)
+    // but can be provoked through an AUFS 'bug' (see test 593 or CVM-880).
+    // --> Warn the user, continue with kItemUnknown and cross your fingers!
     rdonly_type_  = kItemUnknown;
     scratch_type_ = kItemUnknown;
     PrintWarning("'" + GetRelativePath() + "' should be deleted, but was not "

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -88,17 +88,19 @@ void SyncItem::MarkAsWhiteout(const std::string &actual_filename) {
 
   // Find the entry in the repository
   StatRdOnly(true);  // <== refreshing the stat (filename might have changed)
-  if (rdonly_stat_.error_code == 0) {
-    // What is deleted?
-    rdonly_type_  = GetRdOnlyFiletype();
-    scratch_type_ = GetRdOnlyFiletype();
-  } else {
+
+  const SyncItemType deleted_type = (rdonly_stat_.error_code == 0)
+                                        ? GetRdOnlyFiletype()
+                                        : kItemUnknown;
+
+  rdonly_type_  = deleted_type;
+  scratch_type_ = deleted_type;
+
+  if (deleted_type == kItemUnknown) {
     // Marking a SyncItem as 'whiteout' but no file to be removed found: This
     // should not happen (actually AUFS prevents users from creating whiteouts)
     // but can be provoked through an AUFS 'bug' (see test 593 or CVM-880).
     // --> Warn the user, continue with kItemUnknown and cross your fingers!
-    rdonly_type_  = kItemUnknown;
-    scratch_type_ = kItemUnknown;
     PrintWarning("'" + GetRelativePath() + "' should be deleted, but was not "
                  "found in repository.");
   }

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -88,16 +88,14 @@ void SyncItem::MarkAsWhiteout(const std::string &actual_filename) {
 
   // Find the entry in the repository
   StatRdOnly(true);  // <== refreshing the stat (filename might have changed)
-  if (rdonly_stat_.error_code != 0) {
+  if (rdonly_stat_.error_code == 0) {
+    // What is deleted?
+    rdonly_type_  = GetRdOnlyFiletype();
+    scratch_type_ = GetRdOnlyFiletype();
+  } else {
     PrintWarning("'" + GetRelativePath() + "' should be deleted, but was not "
                  "found in repository.");
-    abort();
-    return;
   }
-
-  // What is deleted?
-  rdonly_type_  = GetRdOnlyFiletype();
-  scratch_type_ = GetRdOnlyFiletype();
 }
 
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -93,6 +93,8 @@ void SyncItem::MarkAsWhiteout(const std::string &actual_filename) {
     rdonly_type_  = GetRdOnlyFiletype();
     scratch_type_ = GetRdOnlyFiletype();
   } else {
+    rdonly_type_  = kItemUnknown;
+    scratch_type_ = kItemUnknown;
     PrintWarning("'" + GetRelativePath() + "' should be deleted, but was not "
                  "found in repository.");
   }


### PR DESCRIPTION
Due to a 'harmless' AUFS bug the CernVM-FS server was misbehaving, when removing (exactly) one file  (creating a whiteout) in a directory and later renaming the very directory (producing a recursive up-copy). 

As discussed in [CVM-880](https://sft.its.cern.ch/jira/browse/CVM-880) and done in #1022 we must ignore whiteouts in newly created (or up-copied) directories to prevent this crash. However, #1149 centralised the creation of `SyncItem`s in a way that this warning fires due to the above-mentioned AUFS bug.

This keeps the warning print-out but removes the `abort()`. At the same time it marks the created `SyncItem` bogus (by setting it's type to `kItemUnknown`) which should crash the publishing down the road if there is actually an inconsistency.

Testing for the win!