### PR TITLE
FIX: Catalog Graph Download Python Script

### DIFF
--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -1,9 +1,33 @@
 #!/usr/bin/env python
 
 import cvmfs
-import sys
 import os
-import urllib
+import sys
+import zlib
+
+def usage():
+    print sys.argv[0] + " <repo url/path> <download destination> [<history depth>]"
+    print "Downloads the whole catalog graph of a given repository."
+    print "The optional <history depth> puts a threshold on how many historic"
+    print "catalog tree revisions should be downloaded (default: 0 i.e. all)"
+
+if len(sys.argv) < 3 or len(sys.argv) > 4:
+    usage()
+    sys.exit(1)
+
+dest  = os.path.normpath(sys.argv[2])
+url   = sys.argv[1]
+depth = sys.argv[3] if len(sys.argv) == 4 else 0
+
+try:
+    depth = int(depth)
+except ValueError, e:
+    usage()
+    print
+    print "<history depth> needs to be an integer"
+    sys.exit(1)
+
+
 
 class MerkleCatalogTreeIterator(cvmfs.CatalogTreeIterator):
     def __init__(self, repository, root_catalog, visited_hashes = set()):
@@ -20,48 +44,45 @@ class MerkleCatalogTreeIterator(cvmfs.CatalogTreeIterator):
                catalog.catalog_reference.hash not in self.visited_hashes:
             cvmfs.CatalogTreeIterator._push_catalog_wrapper(self, catalog)
 
+class DownloadingRemoteFetcher(cvmfs.RemoteFetcher):
+    def __init__(self, repo_url, destination):
+        super(DownloadingRemoteFetcher, self).__init__(repo_url)
+        self.destination = destination
+        self.__setup_destination()
 
-def usage():
-    print sys.argv[0] + " <repo url/path> <download destination> [<history depth>]"
-    print "Downloads the whole catalog graph of a given repository."
-    print "The optional <history depth> puts a threshold on how many historic"
-    print "catalog tree revisions should be downloaded (default: 0 i.e. all)"
+    def __setup_destination(self):
+        data_dir = self.destination + "/data"
+        try:
+            os.mkdir(data_dir, 0755)
+            for i in range(0x00, 0xff + 1):
+                new_folder = "{0:#0{1}x}".format(i, 4)[2:]
+                os.mkdir(data_dir + "/" + new_folder, 0755)
+        except ValueError, e:
+            usage()
+            print
+            print "<download destination> needs to exist and be writable"
 
-if len(sys.argv) < 3 or len(sys.argv) > 4:
-    usage()
-    sys.exit(1)
+    def _retrieve_file(self, file_name, cached_file):
+        file_url  = self._make_file_uri(file_name)
+        dest_file = self.destination + "/" + file_name
+        with open(dest_file, "w+") as f:
+            self._download_content_and_store(f, file_url)
+            f.seek(0)
+            decompressed_content = zlib.decompress(f.read())
+            cached_file.write(decompressed_content)
 
-main_folder = sys.argv[2]
-dest  = main_folder + "/data"
-url = sys.argv[1]
-repo  = cvmfs.open_repository(url)
-depth = sys.argv[3] if len(sys.argv) == 4 else 0
+    def _retrieve_raw_file(self, file_name, cached_file):
+        file_url  = self._make_file_uri(file_name)
+        dest_file = self.destination + "/" + file_name
+        with open(dest_file, "w+") as f:
+            self._download_content_and_store(f, file_url)
+            f.seek(0)
+            cached_file.write(f.read())
 
-try:
-    depth = int(depth)
-except ValueError, e:
-    usage()
-    print
-    print "<history depth> needs to be an integer"
-    sys.exit(1)
 
-# download the .cvmfspublished file first
-try:
-    urllib.URLopener().retrieve(url + "/.cvmfspublished", main_folder + "/.cvmfspublished")
-except ValueError, e:
-    usage()
-    print
-    print "<repo url> does not contain .cvmfspublished file"
 
-try:
-    os.mkdir(dest, 0755)
-    for i in range(0x00, 0xff + 1):
-        new_folder = "{0:#0{1}x}".format(i, 4)[2:]
-        os.mkdir(dest + "/" + new_folder, 0755)
-except ValueError, e:
-    usage()
-    print
-    print "<download destination> needs to exist and be writable"
+fetcher = DownloadingRemoteFetcher(url, dest)
+repo    = cvmfs.Repository.with_custom_fetcher(fetcher)
 
 if depth == 0:
     print "Downloading entire catalog tree from " + repo.manifest.repository_name
@@ -76,7 +97,6 @@ while True:
     for catalog in MerkleCatalogTreeIterator(repo, root_clg, visited_hashes):
         if catalog.is_root():
             print "Downloading revision" , catalog.revision , "..."
-        catalog.save_to(dest + "/" + catalog.hash[:2] + "/" + catalog.hash[2:] + "C")
         repo.close_catalog(catalog)
 
     if depth > 0:

--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -22,10 +22,10 @@ class MerkleCatalogTreeIterator(cvmfs.CatalogTreeIterator):
 
 
 def usage():
-    print sys.argv[0] + "<repo url/path> <download destination> [<history depth>]"
+    print sys.argv[0] + " <repo url/path> <download destination> [<history depth>]"
     print "Downloads the whole catalog graph of a given repository."
     print "The optional <history depth> puts a threshold on how many historic"
-    print "catalog tree revisions should be downloaded (default: all)"
+    print "catalog tree revisions should be downloaded (default: 0 i.e. all)"
 
 if len(sys.argv) < 3 or len(sys.argv) > 4:
     usage()


### PR DESCRIPTION
This fixes `add-ons/tools/download_catalog_graph.py` to work with the latest `python-cvmfsutils` code base (i.e. including [this pull request](https://github.com/cvmfs/python-cvmfsutils/pull/9)).

The idea of the fix is to remove the (deprecated) `Catalog::save_to()` call and replace it by a custom `DownloadingRemoteFetcher`. This `Fetcher` implementation 'wire-taps' into the `Repository`s fetch operations and duplicates all downloaded files into a given destination directory. Therefore, the actual business logic of this script only traverses all catalogs that must be downloaded and closes them immediately.