### PR TITLE
FIX: OS X El Capitan Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
 if (MACOSX)
   set (CMAKE_INSTALL_LIBDIR "lib")
   set (CMAKE_MOUNT_INSTALL_BINDIR "/sbin")
+  set (CMAKE_MACOSX_RPATH false)
 else (MACOSX) # --> Linux
   if (DEBIAN OR ARCHLINUX)
     if (ARCHLINUX)

--- a/externals/c-ares/src/configureHook.sh
+++ b/externals/c-ares/src/configureHook.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Note (OS X): might need XCode CLT to configure c-ares properly
+#              Please install XCode and run `xcode-select --install` afterwards.
+#              Also remember to start XCode at least once and agree to the EULA.
+
 cp config.guess.updated config.guess
 sh configure LDFLAGS="$LDFLAGS -rdynamic" CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" CFLAGS="$CFLAGS -fno-strict-aliasing -fasynchronous-unwind-tables -fno-omit-frame-pointer -fno-optimize-sibling-calls -fvisibility=hidden -fPIC"
-  

--- a/externals/pacparser/src/makeHook.sh
+++ b/externals/pacparser/src/makeHook.sh
@@ -4,10 +4,10 @@ set -e
 
 static_result_dir=src/static
 
-echo "make clean && make for libpacparser..."
+echo "make clean && make for libpacparser (omitting test execution)..."
 [ -d $static_result_dir ] && rm -fR $static_result_dir
 make -C src clean
-make -j1 -C src
+make -j1 -C src pacparser.o libjs.a # default target runs tests!
 echo "finished internal build of libpacparser"
 
 echo "creating static link library for libpacparser..."

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -229,25 +229,27 @@ endif (BUILD_UNITTESTS_DEBUG)
 #
 # add optional dependencies
 #
-if (LIBCURL_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} libcares libcurl)
-endif (LIBCURL_BUILTIN)
+if (BUILD_UNITTESTS)
+  if (LIBCURL_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} libcares libcurl)
+  endif (LIBCURL_BUILTIN)
 
-if (SQLITE3_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} sqlite3)
-endif (SQLITE3_BUILTIN)
+  if (SQLITE3_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} sqlite3)
+  endif (SQLITE3_BUILTIN)
 
-if (ZLIB_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} zlib)
-endif (ZLIB_BUILTIN)
+  if (ZLIB_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} zlib)
+  endif (ZLIB_BUILTIN)
 
-if (PACPARSER_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} libpacparser)
-endif (PACPARSER_BUILTIN)
+  if (PACPARSER_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} libpacparser)
+  endif (PACPARSER_BUILTIN)
 
-if (TBB_PRIVATE_LIB)
-  add_dependencies (${PROJECT_TEST_NAME} libtbb)
-endif (TBB_PRIVATE_LIB)
+  if (TBB_PRIVATE_LIB)
+    add_dependencies (${PROJECT_TEST_NAME} libtbb)
+  endif (TBB_PRIVATE_LIB)
+endif (BUILD_UNITTESTS)
 
 if (BUILD_UNITTESTS_DEBUG)
   if (LIBCURL_BUILTIN)


### PR DESCRIPTION
This attempts to fix the CernVM-FS build on OS X El Capitan. Notably this *does not* mean that it also works. Furthermore a successful build depends on OpenSSL installed from `brew` and XCode's CLTs:

```bash
brew install openssl
brew link --force openssl
xcode-select --install
```

* Fix CMake Warning regarding OS X rpath
* Fix CMake Warning for unittest build dependency
* Omit test execution of pacparser external on build (fails on OS X El Capitan)

Unit test set works mostly, except three test cases (see below). Likely these failures coincide with the failing c-ares tests. Left for TODO right now.

Failing unittests:
* T_Dns.CaresResolverSearchDomain
* T_Dns.CaresResolverMany
* T_Dns.NormalResolverCombined