### PR TITLE
Allow to install CernVM-FS outside of /usr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,20 +28,6 @@ set (CernVM-FS_VERSION_STRING "${CernVM-FS_VERSION_MAJOR}.${CernVM-FS_VERSION_MI
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 #
-# Set install prefix to /usr.  Cvmfs is not relocatable.
-#
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  SET(CMAKE_INSTALL_PREFIX
-    "/usr" CACHE PATH "/usr install prefix" FORCE
-  )
-else (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  if (NOT ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr")
-    Message("Warning: CernVM-FS is not relotable and expects to be installed under /usr")
-  endif ()
-endif (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-
-
-#
 # detect the operating system and the distribution we are compiling on
 #
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,20 @@ endif (MACOSX)
 message ("Installing shared libraries to: ${CMAKE_INSTALL_LIBDIR}")
 
 #
+# set the system configuration directory depending on CMAKE_INSTALL_PREFIX
+# Note: Found here http://osdir.com/ml/kde-commits/2011-05/msg01375.html
+#
+if (NOT DEFINED SYSCONF_INSTALL_DIR)
+  if ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
+    set (SYSCONF_INSTALL_DIR "/etc") # conform to LFSH
+  else ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
+    set(SYSCONF_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/etc")
+  endif ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
+else (NOT DEFINED SYSCONF_INSTALL_DIR)
+  set (SYSCONF_INSTALL_DIR "${SYSCONF_INSTALL_DIR}" CACHE STRING "The sysconfig install dir")
+endif (NOT DEFINED SYSCONF_INSTALL_DIR)
+
+#
 # Workaround for Debian packaging debhelper trying to pass -D_FORTIFY_SOURCE=2
 # through CPPFLAGS that is not officially supported by CMake. Hence, debhelper
 # appends CPPFLAGS to CFLAGS which breaks the build of the c-ares external.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
 if (MACOSX)
   set (CMAKE_INSTALL_LIBDIR "lib")
   set (CMAKE_MOUNT_INSTALL_BINDIR "/sbin")
+  set (CMAKE_MACOSX_RPATH false)
 else (MACOSX) # --> Linux
   if (DEBIAN OR ARCHLINUX)
     if (ARCHLINUX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
 #
 if (MACOSX)
   set (CMAKE_INSTALL_LIBDIR "lib")
-  set (CMAKE_MOUNT_INSTALL_BINDIR "/sbin")
+  set (CMAKE_MOUNT_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/sbin")
   set (CMAKE_MACOSX_RPATH false)
 else (MACOSX) # --> Linux
   if (DEBIAN OR ARCHLINUX)

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -584,7 +584,7 @@ if (BUILD_CVMFS)
     install (
         FILES         bash_completion/cvmfs.bash_completion
         RENAME        cvmfs
-        DESTINATION   /etc/bash_completion.d
+        DESTINATION   ${SYSCONF_INSTALL_DIR}/bash_completion.d
         PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (INSTALL_BASH_COMPLETION)
@@ -632,7 +632,7 @@ if (BUILD_SERVER)
 
   install(
     FILES      cvmfs_server_hooks.sh.demo
-    DESTINATION    "/etc/cvmfs"
+    DESTINATION    "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS    OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -7,6 +7,8 @@ SBIN_BASE="$( [ x"$INSTALL_BASE" = x"/usr" ] && echo "/sbin" || echo "${INSTALL_
 
 if [ -f /etc/cvmfs/config.sh ]; then
   . /etc/cvmfs/config.sh
+elif [ -f ${INSTALL_BASE}/etc/cvmfs/config.sh ]; then
+  . ${INSTALL_BASE}/etc/cvmfs/config.sh
 else
   echo "/etc/cvmfs/config.sh missing"
   exit 1

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -192,6 +192,15 @@ cvmfs_setup() {
   mkdir -p /var/lib/cvmfs
   chown cvmfs:cvmfs /var/lib/cvmfs
 
+  # symlink configuration into /etc on OS X (>= 10.11)
+  if [ x"$sys_arch" = x"Darwin" ] && \
+     compare_versions $(sw_vers -productVersion) -ge "10.11"; then
+    if [ ! -e /etc/cvmfs           ] && \
+       [   -e /usr/local/etc/cvmfs ]; then
+      ln -s /usr/local/etc/cvmfs /etc/cvmfs
+    fi
+  fi
+
   # if group fuse exists, add user cvmfs
   if check_group "fuse"; then
     if ! add_user_to_group_fuse; then

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -85,6 +85,39 @@ required_list="CVMFS_USER CVMFS_NFILES CVMFS_MOUNT_DIR CVMFS_STRICT_MOUNT CVMFS_
                CVMFS_TIMEOUT CVMFS_TIMEOUT_DIRECT CVMFS_SHARED_CACHE CVMFS_CHECK_PERMISSIONS"
 var_list="$parm_list $switch_list"
 
+# makes sure that a version is always of the form x.y.z-b
+normalize_version() {
+  local version_string="$1"
+  while [ $(echo "$version_string" | grep -o '\.' | wc -l) -lt 2 ]; do
+    version_string="${version_string}.0"
+  done
+  while [ $(echo "$version_string" | grep -o '-' | wc -l) -lt 1 ]; do
+    version_string="${version_string}-1"
+  done
+  echo "$version_string"
+}
+version_major() { echo $1 | cut -d. -f1 | grep -oe '^[0-9]\+'; }
+version_minor() { echo $1 | cut -d. -f2 | grep -oe '^[0-9]\+'; }
+version_patch() { echo $1 | cut -d. -f3 | grep -oe '^[0-9]\+'; }
+version_build() { echo $1 | cut -d- -f2 | grep -oe '^[0-9]\+'; }
+prepend_zeros() { printf %03d "$1"; }
+compare_versions() {
+  local lhs="$(normalize_version $1)"
+  local comparison_operator=$2
+  local rhs="$(normalize_version $3)"
+
+  local lhs1=$(prepend_zeros $(version_major $lhs))
+  local lhs2=$(prepend_zeros $(version_minor $lhs))
+  local lhs3=$(prepend_zeros $(version_patch $lhs))
+  local lhs4=$(prepend_zeros $(version_build $lhs))
+  local rhs1=$(prepend_zeros $(version_major $rhs))
+  local rhs2=$(prepend_zeros $(version_minor $rhs))
+  local rhs3=$(prepend_zeros $(version_patch $rhs))
+  local rhs4=$(prepend_zeros $(version_build $rhs))
+
+  [ $lhs1$lhs2$lhs3$lhs4 $comparison_operator $rhs1$rhs2$rhs3$rhs4 ]
+}
+
 cvmfs_config_usage() {
  echo "Common configuration tasks for CernVM-FS"
  echo "Usage: $0 <command>"

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Common configuration tasks for CernVM-FS
 
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+INSTALL_BASE=$(echo "$SCRIPT_LOCATION" | sed -e 's/^\(.*\)\/bin$/\1/')
+SBIN_BASE="$( [ x"$INSTALL_BASE" = x"/usr" ] && echo "/sbin" || echo "${INSTALL_BASE}/sbin" )"
+
 if [ -f /etc/cvmfs/config.sh ]; then
   . /etc/cvmfs/config.sh
 else
@@ -199,7 +203,7 @@ cvmfs_chksetup() {
   local binary
   for binary in cvmfs2 cvmfs_fsck cvmfs_talk
   do
-    if ! test -f /usr/bin/$binary; then
+    if ! test -f ${INSTALL_BASE}/bin/$binary; then
       echo "Error: $binary not found"
       num_errors=$(($num_errors+1))
     fi
@@ -213,8 +217,8 @@ cvmfs_chksetup() {
   for library in $cvmfs_libs
   do
     foundlib=0
-    for libdir in /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu; do
-      if test -f ${libdir}/${library}; then
+    for libdir in lib lib64 lib/x86_64-linux-gnu lib/i386-linux-gnu; do
+      if test -f ${INSTALL_BASE}/${libdir}/${library}; then
         foundlib=1
       fi
     done
@@ -227,12 +231,12 @@ cvmfs_chksetup() {
   # Check mount helper
   local tools
   if [ "$sys_arch" = "Darwin" ]; then
-    tools="/sbin/mount_cvmfs"
+    tools="${SBIN_BASE}/mount_cvmfs"
   elif [ "$sys_arch" = "Linux" ]; then
-    if [ -d /sbin ]; then
-      tools="/sbin/mount.cvmfs"
+    if [ -d ${SBIN_BASE} ]; then
+      tools="${SBIN_BASE}/mount.cvmfs"
     else
-      tools="/usr/bin/mount.cvmfs"
+      tools="${INSTALL_BASE}/bin/mount.cvmfs"
     fi
   fi
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -249,6 +249,12 @@ cvmfs_chksetup() {
     fi
   done
 
+  # Check that CVMFS_USER is set
+  if [ x"$CVMFS_USER" = x"" ]; then
+    echo "CVMFS_USER variable is empty"
+    num_errors=$(($num_errors+1))
+  fi
+
   # Fusermount (not necessary under Mac OS X)
   if [ "$sys_arch" = "Linux" ]; then
     if [ ! -x $fusermount ]; then

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -22,6 +22,7 @@
 #include <sys/prctl.h>
 #include <sys/select.h>
 #include <sys/stat.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 
 #include <cassert>
@@ -292,6 +293,16 @@ inline const char* platform_getexepath() {
     }
   }
   return buf;
+}
+
+inline void platform_get_os_version(int32_t *major,
+                                    int32_t *minor,
+                                    int32_t *patch) {
+  struct utsname uts_info;
+  const int res = uname(&uts_info);
+  assert(res == 0);
+  const int matches = sscanf(uts_info.release, "%u.%u.%u", major, minor, patch);
+  assert(matches == 3 && "failed to read version string");
 }
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -22,6 +22,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cstdio>
 #include <cstring>
 
 #include <string>
@@ -191,6 +192,61 @@ inline void platform_disable_kcache(int filedes) {
 inline int platform_readahead(int filedes) {
   // TODO(jblomer): is there a readahead equivalent?
   return 0;
+}
+
+inline bool read_line(FILE *f, std::string *line) {
+  char   *buffer_line = NULL;
+  size_t  buffer_size = 0;
+  const int res = getline(&buffer_line, &buffer_size, f);
+  if (res < 0) {
+    free(buffer_line);
+    return false;
+  }
+
+  line->clear();
+  line->assign(buffer_line);
+  free(buffer_line);
+  return true;
+}
+
+inline void platform_get_os_version(int32_t *major,
+                                    int32_t *minor,
+                                    int32_t *patch) {
+  const std::string plist = "/System/Library/CoreServices/SystemVersion.plist";
+  const std::string plist_key = "ProductVersion";
+
+  FILE *plist_file = fopen(plist.c_str(), "r");
+  assert(plist_file != NULL && "couldn't open SystemVersion.plist");
+
+  std::string line;
+  bool found_key = false;
+  while (read_line(plist_file, &line) && !found_key) {
+    if (line.find(plist_key) != std::string::npos) {
+      found_key = true;
+      break;
+    }
+  }
+  assert(found_key && "didn't find key in SystemVersion.plist");
+
+  const std::string start_tag = "<string>";
+  const std::string end_tag   = "</string>";
+  size_t start, end;
+  bool found_value = false;
+  while (read_line(plist_file, &line) && !found_value) {
+    start = line.find(start_tag);
+    end   = line.find(end_tag);
+    if (start != std::string::npos && end != std::string::npos) {
+      found_value = true;
+      break;
+    }
+  }
+  assert(found_value && "didn't find value in SystemVersion.plist");
+  fclose(plist_file);
+
+  start = start + start_tag.length();
+  const std::string version = line.substr(start, end - start);
+  const int matches = sscanf(version.c_str(), "%u.%u.%u", major, minor, patch);
+  assert(matches == 3 && "failed to read OS X version string");
 }
 
 /**

--- a/externals/c-ares/src/configureHook.sh
+++ b/externals/c-ares/src/configureHook.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Note (OS X): might need XCode CLT to configure c-ares properly
+#              Please install XCode and run `xcode-select --install` afterwards.
+#              Also remember to start XCode at least once and agree to the EULA.
+
 cp config.guess.updated config.guess
 sh configure LDFLAGS="$LDFLAGS -rdynamic" CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" CFLAGS="$CFLAGS -fno-strict-aliasing -fasynchronous-unwind-tables -fno-omit-frame-pointer -fno-optimize-sibling-calls -fvisibility=hidden -fPIC"
-  

--- a/externals/pacparser/src/makeHook.sh
+++ b/externals/pacparser/src/makeHook.sh
@@ -4,10 +4,10 @@ set -e
 
 static_result_dir=src/static
 
-echo "make clean && make for libpacparser..."
+echo "make clean && make for libpacparser (omitting test execution)..."
 [ -d $static_result_dir ] && rm -fR $static_result_dir
 make -C src clean
-make -j1 -C src
+make -j1 -C src pacparser.o libjs.a # default target runs tests!
 echo "finished internal build of libpacparser"
 
 echo "creating static link library for libpacparser..."

--- a/mount/CMakeLists.txt
+++ b/mount/CMakeLists.txt
@@ -170,113 +170,113 @@ else (MACOSX)
 
   install (
     FILES         config.sh default.conf
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/README
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   if (DEBIAN)
     install (
       FILES         default.d/50-cern-debian.conf
-      DESTINATION   "/etc/cvmfs/default.d"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   else (DEBIAN)
     install (
       FILES         default.d/50-cern.conf
-      DESTINATION   "/etc/cvmfs/default.d"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (DEBIAN)
 
   install (
     FILES         default.d/60-egi.conf
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/cern.ch.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/egi.eu.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/opensciencegrid.org.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/grid.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/atlas-nightlies.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/cms.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   if (INSTALL_PUBLIC_KEYS)
     install (
       FILES         keys/cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it1.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it2.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it3.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/egi.eu.pub
-      DESTINATION   "/etc/cvmfs/keys/egi.eu"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/egi.eu"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/opensciencegrid.org.pub
-      DESTINATION   "/etc/cvmfs/keys/opensciencegrid.org"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/opensciencegrid.org"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (INSTALL_PUBLIC_KEYS)
 
   install (
     FILES         serverorder.sh
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 endif (MACOSX)

--- a/mount/CMakeLists.txt
+++ b/mount/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties (${MOUNT_TARGET_NAME} PROPERTIES COMPILE_FLAGS "${CVMFS_MO
 if (MACOSX)
   install (
     FILES         auto_cvmfs
-    DESTINATION   "/etc"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}"
   )
 
   install (
@@ -33,105 +33,105 @@ if (MACOSX)
 
   install (
     FILES         config.sh default.conf
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/50-cern.conf
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/60-egi.conf
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/README
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/cern.ch.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
   
   install (
     FILES         domain.d/egi.eu.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/opensciencegrid.org.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/grid.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/atlas-nightlies.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/cms.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   if (INSTALL_PUBLIC_KEYS)
     install (
       FILES         keys/cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it1.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it2.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it3.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/egi.eu.pub
-      DESTINATION   "/etc/cvmfs/keys/egi.eu"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/egi.eu"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/opensciencegrid.org.pub
-      DESTINATION   "/etc/cvmfs/keys/opensciencegrid.org"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/opensciencegrid.org"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (INSTALL_PUBLIC_KEYS)
 
   install (
     FILES         serverorder.sh
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -220,6 +220,34 @@ static bool GetCvmfsUser(string *cvmfs_user) {
 }
 
 
+static std::string GetCvmfsBinary() {
+  std::string result;
+  vector<string> paths;
+  paths.push_back("/usr/bin");
+
+#ifdef __APPLE__
+  int major, minor, patch;
+  platform_get_os_version(&major, &minor, &patch);
+  if (major == 10 && minor >= 11) {    // OS X El Capitan came with SIP, forcing
+    paths.push_back("/usr/local/bin"); // us to become relocatable
+  }
+#endif
+
+  // TODO(reneme): C++11 range based for loop
+        vector<string>::const_iterator i    = paths.begin();
+  const vector<string>::const_iterator iend = paths.end();
+  for (; i != iend; ++i) {
+    const std::string cvmfs2 = *i + "/cvmfs2";
+    if (FileExists(cvmfs2)) {
+      result = cvmfs2;
+      break;
+    }
+  }
+
+  return result;
+}
+
+
 int main(int argc, char **argv) {
   bool dry_run = false;
   vector<string> mount_options;
@@ -390,7 +418,11 @@ int main(int argc, char **argv) {
   if (options_manager_.IsDefined("CVMFS_DEBUGLOG"))
     AddMountOption("debug", &mount_options);
 
-  const string cvmfs_binary = "/usr/bin/cvmfs2";
+  const string cvmfs_binary = GetCvmfsBinary();
+  if (cvmfs_binary.empty()) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to locate the cvmfs2 binary");
+    return 1;
+  }
 
   // Dry run early exit
   if (dry_run) {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(CVMFS_UNITTEST_FILES
   t_manifest.cc
   t_tracer.cc
   t_file_chunk.cc
+  t_platforms.cc
 )
 
 #

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -229,25 +229,27 @@ endif (BUILD_UNITTESTS_DEBUG)
 #
 # add optional dependencies
 #
-if (LIBCURL_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} libcares libcurl)
-endif (LIBCURL_BUILTIN)
+if (BUILD_UNITTESTS)
+  if (LIBCURL_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} libcares libcurl)
+  endif (LIBCURL_BUILTIN)
 
-if (SQLITE3_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} sqlite3)
-endif (SQLITE3_BUILTIN)
+  if (SQLITE3_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} sqlite3)
+  endif (SQLITE3_BUILTIN)
 
-if (ZLIB_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} zlib)
-endif (ZLIB_BUILTIN)
+  if (ZLIB_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} zlib)
+  endif (ZLIB_BUILTIN)
 
-if (PACPARSER_BUILTIN)
-  add_dependencies (${PROJECT_TEST_NAME} libpacparser)
-endif (PACPARSER_BUILTIN)
+  if (PACPARSER_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} libpacparser)
+  endif (PACPARSER_BUILTIN)
 
-if (TBB_PRIVATE_LIB)
-  add_dependencies (${PROJECT_TEST_NAME} libtbb)
-endif (TBB_PRIVATE_LIB)
+  if (TBB_PRIVATE_LIB)
+    add_dependencies (${PROJECT_TEST_NAME} libtbb)
+  endif (TBB_PRIVATE_LIB)
+endif (BUILD_UNITTESTS)
 
 if (BUILD_UNITTESTS_DEBUG)
   if (LIBCURL_BUILTIN)

--- a/test/unittests/t_platforms.cc
+++ b/test/unittests/t_platforms.cc
@@ -1,0 +1,18 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/platform.h"
+
+TEST(T_Platforms, OsVersion) {
+  int major = -1;
+  int minor = -1;
+  int patch = -1;
+  platform_get_os_version(&major, &minor, &patch);
+
+  EXPECT_GT(major, 0);
+  EXPECT_GE(minor, 0);
+  EXPECT_GE(patch, 0);
+}


### PR DESCRIPTION
This allows to install all artefacts of the CernVM-FS client into other locations than `/usr`, `/etc` and `/sbin` as a first step to conform with SIP on OS X El Capitan. Furthermore `brew` requires to install without `sudo` into `/usr/local`.

With that and `CMAKE_INSTALL_PREFIX=/usr/local` I can create private mounts of LHC repositories on El Capitan.

Note: This build on top of [FIX: OS X El Capitan Build](https://github.com/cvmfs/cvmfs/pull/1228).