### PR TITLE
Allowing to Install CVMFS outside of /usr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,20 +28,6 @@ set (CernVM-FS_VERSION_STRING "${CernVM-FS_VERSION_MAJOR}.${CernVM-FS_VERSION_MI
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 #
-# Set install prefix to /usr.  Cvmfs is not relocatable.
-#
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  SET(CMAKE_INSTALL_PREFIX
-    "/usr" CACHE PATH "/usr install prefix" FORCE
-  )
-else (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  if (NOT ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr")
-    Message("Warning: CernVM-FS is not relotable and expects to be installed under /usr")
-  endif ()
-endif (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-
-
-#
 # detect the operating system and the distribution we are compiling on
 #
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,20 @@ endif (MACOSX)
 message ("Installing shared libraries to: ${CMAKE_INSTALL_LIBDIR}")
 
 #
+# set the system configuration directory depending on CMAKE_INSTALL_PREFIX
+# Note: Found here http://osdir.com/ml/kde-commits/2011-05/msg01375.html
+#
+if (NOT DEFINED SYSCONF_INSTALL_DIR)
+  if ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
+    set (SYSCONF_INSTALL_DIR "/etc") # conform to LFSH
+  else ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
+    set(SYSCONF_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/etc")
+  endif ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr")
+else (NOT DEFINED SYSCONF_INSTALL_DIR)
+  set (SYSCONF_INSTALL_DIR "${SYSCONF_INSTALL_DIR}" CACHE STRING "The sysconfig install dir")
+endif (NOT DEFINED SYSCONF_INSTALL_DIR)
+
+#
 # Workaround for Debian packaging debhelper trying to pass -D_FORTIFY_SOURCE=2
 # through CPPFLAGS that is not officially supported by CMake. Hence, debhelper
 # appends CPPFLAGS to CFLAGS which breaks the build of the c-ares external.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm.*$")
 #
 if (MACOSX)
   set (CMAKE_INSTALL_LIBDIR "lib")
-  set (CMAKE_MOUNT_INSTALL_BINDIR "/sbin")
+  set (CMAKE_MOUNT_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/sbin")
   set (CMAKE_MACOSX_RPATH false)
 else (MACOSX) # --> Linux
   if (DEBIAN OR ARCHLINUX)

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -584,7 +584,7 @@ if (BUILD_CVMFS)
     install (
         FILES         bash_completion/cvmfs.bash_completion
         RENAME        cvmfs
-        DESTINATION   /etc/bash_completion.d
+        DESTINATION   ${SYSCONF_INSTALL_DIR}/bash_completion.d
         PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (INSTALL_BASH_COMPLETION)
@@ -632,7 +632,7 @@ if (BUILD_SERVER)
 
   install(
     FILES      cvmfs_server_hooks.sh.demo
-    DESTINATION    "/etc/cvmfs"
+    DESTINATION    "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS    OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 

--- a/mount/CMakeLists.txt
+++ b/mount/CMakeLists.txt
@@ -170,113 +170,113 @@ else (MACOSX)
 
   install (
     FILES         config.sh default.conf
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/README
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   if (DEBIAN)
     install (
       FILES         default.d/50-cern-debian.conf
-      DESTINATION   "/etc/cvmfs/default.d"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   else (DEBIAN)
     install (
       FILES         default.d/50-cern.conf
-      DESTINATION   "/etc/cvmfs/default.d"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (DEBIAN)
 
   install (
     FILES         default.d/60-egi.conf
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/cern.ch.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/egi.eu.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/opensciencegrid.org.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/grid.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/atlas-nightlies.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/cms.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   if (INSTALL_PUBLIC_KEYS)
     install (
       FILES         keys/cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it1.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it2.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it3.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/egi.eu.pub
-      DESTINATION   "/etc/cvmfs/keys/egi.eu"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/egi.eu"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/opensciencegrid.org.pub
-      DESTINATION   "/etc/cvmfs/keys/opensciencegrid.org"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/opensciencegrid.org"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (INSTALL_PUBLIC_KEYS)
 
   install (
     FILES         serverorder.sh
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 endif (MACOSX)

--- a/mount/CMakeLists.txt
+++ b/mount/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties (${MOUNT_TARGET_NAME} PROPERTIES COMPILE_FLAGS "${CVMFS_MO
 if (MACOSX)
   install (
     FILES         auto_cvmfs
-    DESTINATION   "/etc"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}"
   )
 
   install (
@@ -33,105 +33,105 @@ if (MACOSX)
 
   install (
     FILES         config.sh default.conf
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/50-cern.conf
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/60-egi.conf
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         default.d/README
-    DESTINATION   "/etc/cvmfs/default.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/default.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/cern.ch.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
   
   install (
     FILES         domain.d/egi.eu.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         domain.d/opensciencegrid.org.conf
-    DESTINATION   "/etc/cvmfs/domain.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/domain.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/grid.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/atlas-nightlies.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   install (
     FILES         config.d/cms.cern.ch.conf
-    DESTINATION   "/etc/cvmfs/config.d"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/config.d"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
   if (INSTALL_PUBLIC_KEYS)
     install (
       FILES         keys/cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it1.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it2.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/cern-it3.cern.ch.pub
-      DESTINATION   "/etc/cvmfs/keys/cern.ch"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/cern.ch"
       PERMISSIONS   OWNER_READ GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/egi.eu.pub
-      DESTINATION   "/etc/cvmfs/keys/egi.eu"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/egi.eu"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
 
     install (
       FILES         keys/opensciencegrid.org.pub
-      DESTINATION   "/etc/cvmfs/keys/opensciencegrid.org"
+      DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/keys/opensciencegrid.org"
       PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
     )
   endif (INSTALL_PUBLIC_KEYS)
 
   install (
     FILES         serverorder.sh
-    DESTINATION   "/etc/cvmfs"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs"
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 


### PR DESCRIPTION
This allows most of CernVM-FS's build artefacts to be installed under a user-defined install prefix. We need this, to support OS X El Capitan with enabled [SIP](https://support.apple.com/en-us/HT204899).

Note that this doesn't yet include any production code changes to actually support relocatable installations. 