### PR TITLE
FIX: enable HTTPS integration test on CernVM

### DIFF
--- a/ci/docker/cc7_x86_64/Dockerfile
+++ b/ci/docker/cc7_x86_64/Dockerfile
@@ -9,6 +9,7 @@ RUN         yum -y update && yum -y install                     \
                                         gcc                     \
                                         gcc-c++                 \
                                         git                     \
+                                        gridsite                \
                                         hardlink                \
                                         libattr-devel           \
                                         libcap-devel            \

--- a/ci/docker/fedora22_x86_64/Dockerfile
+++ b/ci/docker/fedora22_x86_64/Dockerfile
@@ -9,6 +9,7 @@ RUN         dnf -y update && dnf -y install                     \
                                         gcc                     \
                                         gcc-c++                 \
                                         git                     \
+                                        gridsite                \
                                         hardlink                \
                                         libattr-devel           \
                                         libcap-devel            \

--- a/ci/docker/slc5_x86_64/Dockerfile
+++ b/ci/docker/slc5_x86_64/Dockerfile
@@ -11,6 +11,7 @@ RUN         yum -y update && yum -y install                     \
                                         gcc-c++                 \
                                         gdb                     \
                                         git                     \
+                                        gridsite                \
                                         hardlink                \
                                         libattr-devel           \
                                         libcap-devel            \

--- a/ci/docker/slc6_x86_64/Dockerfile
+++ b/ci/docker/slc6_x86_64/Dockerfile
@@ -9,6 +9,7 @@ RUN         yum -y update && yum -y install                     \
                                         gcc                     \
                                         gcc-c++                 \
                                         git                     \
+                                        gridsite                \
                                         hardlink                \
                                         libattr-devel           \
                                         libcap-devel            \

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1085,6 +1085,8 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   catalog::ClientCtx ctx(fctx->uid, fctx->gid, fctx->pid);
 
   // Get VOMS information, if any,
+  // TODO(jblomer): without VOMS, cvmfs will allow access.  This is probably
+  // not the right default.
 #ifdef VOMS_AUTHZ
   if ((ctx.uid != 0) && voms_requirements.size())
   {

--- a/cvmfs/voms_authz/voms_authz.cc
+++ b/cvmfs/voms_authz/voms_authz.cc
@@ -414,7 +414,7 @@ bool
 CheckVOMSAuthz(const struct fuse_ctx *ctx, const std::string & authz)
 {
     if (g_VOMS_Init == NULL) {
-        LogCvmfs(kLogVoms, kLogDebug, "VOMS library not present; failing VOMS "
+        LogCvmfs(kLogVoms, kLogSyslog, "VOMS library not present; failing VOMS "
                  "authz.");
         return false;
     }

--- a/cvmfs/voms_authz/voms_cred.cc
+++ b/cvmfs/voms_authz/voms_cred.cc
@@ -205,6 +205,8 @@ struct ProxyHelper {
   }
 
 
+  // TODO(jblomer): more error handling here: if the user proxy certificate
+  // does not exist, it is hard to figure out.
   FILE *GetProxyFile(pid_t pid, uid_t uid, gid_t gid) {
     if (!CheckHelperLaunched()) {return NULL;}
 

--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -45,6 +45,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -33,6 +33,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \
                               || retval=1

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -3,16 +3,28 @@ cvmfs_test_name="Test CVMFS over HTTPS"
 cvmfs_test_autofs_on_startup=false
 
 TEST600_HTTPS_CONFIG=/etc/httpd/conf.d/test600.cvmfs.secure.conf
-TEST600_HOSTCERT=/etc/grid-security/hostcert-cvmfs.pem
-TEST600_HOSTKEY=/etc/grid-security/hostkey-cvmfs.pem
-TEST600_VOMSDIR=/etc/grid-security/vomsdir/cvmfs
-TEST600_TESTCA=/etc/grid-security/certificates/OSG-Test-CA.pem
-TEST600_TESTCRL=/etc/grid-security/certificates/OSG-Test-CA.r0
+# Set later to the scratch dir
+TEST600_HOSTCERT=
+TEST600_HOSTKEY=
+TEST600_VOMSDIR=
+TEST600_TESTCA=
+TEST600_TESTCRL=
 # These two variables will be updated later with the generated hash
-TEST600_TESTCA_HASH=/etc/grid-security/certificates/OSG-Test-CA.pem
-TEST600_TESTCRL_HASH=/etc/grid-security/certificates/OSG-Test-CA.r0
+TEST600_TESTCA_HASH=
+TEST600_TESTCRL_HASH=
+# replacing /etc/grid-security
+TEST600_GRID_SECURITY_DIR=
+# Mountpoint and cache directory for grid.cern.ch private mount
+TEST600_GRID_MOUNTPOINT=
+TEST600_GRID_CACHE=
+# For generate_certs
+TEST600_CERTS_DIR=
+# Bind mount to /etc/grid-security active
+TEST600_GRID_SECURITY_TAINTED=
 
 cleanup() {
+  sudo umount ${TEST600_GRID_MOUNTPOINT}
+  [ "x$TEST600_GRID_SECURITY_TAINTED" = "xyes" ] && sudo umount /etc/grid-security
   [ -z "$TEST600_HTTPS_CONFIG" ] || sudo rm -f $TEST600_HTTPS_CONFIG
   [ -z "$TEST600_HOSTCERT" ] || sudo rm -f $TEST600_HOSTCERT
   [ -z "$TEST600_HOSTKEY" ] || sudo rm -f $TEST600_HOSTKEY
@@ -23,36 +35,63 @@ cleanup() {
   [ -z "$TEST600_TESTCRL_HASH" ] || sudo rm -f $TEST600_TESTCRL_HASH
 }
 
-generate_certs() {
-  local certs_dir=$(pwd)/certs
-  local script_location=$1
-  mkdir $certs_dir
-  cp $script_location/ca-generate-certs $certs_dir/
-  cp $script_location/openssl-usercert-extensions.conf $certs_dir/
-  cp $script_location/openssl-cert-extensions-template.conf $certs_dir/
-  cp $script_location/openssl.config $certs_dir/
+mount_cvmfs_grid() {
+  local mountpoint=$1
+  local cache_dir=$2
 
-  pushd $certs_dir
+  mkdir -p $mountpoint $cache_dir
+
+  echo "writing config in ${cache_dir}/client.conf"
+  cat << EOF > ${cache_dir}/client.conf
+CVMFS_CACHE_BASE=$cache_dir
+CVMFS_RELOAD_SOCKETS=$cache_dir
+CVMFS_CLAIM_OWNERSHIP=yes
+CVMFS_SERVER_URL=http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch
+CVMFS_HTTP_PROXY="${CVMFS_TEST_PROXY}"
+EOF
+  cat ${cache_dir}/client.conf
+
+  cvmfs2 -o config=${cache_dir}/client.conf grid.cern.ch $mountpoint
+  return $?
+}
+
+generate_certs() {
+  local script_location=$1
+  mkdir -p $TEST600_CERTS_DIR $TEST600_GRID_CACHE $TEST600_GRID_MOUNTPOINT
+  local voms_path=${TEST600_GRID_MOUNTPOINT}/emi-ui-2.10.4-1_sl5v1
+
+  cp $script_location/ca-generate-certs $TEST600_CERTS_DIR/
+  cp $script_location/openssl-usercert-extensions.conf $TEST600_CERTS_DIR/
+  cp $script_location/openssl-cert-extensions-template.conf $TEST600_CERTS_DIR/
+  cp $script_location/openssl.config $TEST600_CERTS_DIR/
+
+  pushd $TEST600_CERTS_DIR
   ./ca-generate-certs $HOSTNAME
   result=$?
-  voms-proxy-fake -cert usercert.pem -key userkey.pem -out vomsproxy.pem -rfc -hostcert hostcert.pem -hostkey hostkey.pem -fqan /cvmfs/Role=NULL -voms cvmfs -uri $HOSTNAME:15000
+  LD_LIBRARY_PATH=${voms_path}/usr/lib64 \
+     ${voms_path}/usr/bin/voms-proxy-fake -certdir ${TEST600_GRID_SECURITY_DIR}/certificates \
+      -cert usercert.pem -key userkey.pem -out vomsproxy.pem -rfc \
+      -hostcert hostcert.pem -hostkey hostkey.pem -fqan /cvmfs/Role=NULL \
+      -voms cvmfs -uri $HOSTNAME:15000
   popd
 
-  mkdir -p /etc/grid-security/vomsdir/cvmfs
+  mkdir -p ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs
 
   set -x
-  echo "/DC=org/DC=Open Science Grid/O=OSG Test/OU=Services/CN=$HOSTNAME" > /etc/grid-security/vomsdir/cvmfs/$HOSTNAME.lsc
-  echo "/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA" >> /etc/grid-security/vomsdir/cvmfs/$HOSTNAME.lsc
+  echo "/DC=org/DC=Open Science Grid/O=OSG Test/OU=Services/CN=$HOSTNAME" > ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs/$HOSTNAME.lsc
+  echo "/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA" >> ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs/$HOSTNAME.lsc
 
-  voms-proxy-info -file $certs_dir/vomsproxy.pem -all
+  LD_LIBRARY_PATH=${voms_path}/usr/lib64 X509_CERT_DIR=${TEST600_GRID_SECURITY_DIR}/certificates \
+    ${voms_path}/usr/bin/voms-proxy-info -file $TEST600_CERTS_DIR/vomsproxy.pem \
+    -all
 
-  sudo cp $certs_dir/hostcert.pem $TEST600_HOSTCERT || return 1
-  sudo cp $certs_dir/hostkey.pem $TEST600_HOSTKEY || return 1
-  sudo cp $certs_dir/OSG-Test-CA.pem $TEST600_TESTCA || return 1
-  sudo cp $certs_dir/OSG-Test-CA.r0 $TEST600_TESTCRL || return 1
+  sudo cp $TEST600_CERTS_DIR/hostcert.pem $TEST600_HOSTCERT || return 1
+  sudo cp $TEST600_CERTS_DIR/hostkey.pem $TEST600_HOSTKEY || return 1
+  sudo cp $TEST600_CERTS_DIR/OSG-Test-CA.pem $TEST600_TESTCA || return 1
+  sudo cp $TEST600_CERTS_DIR/OSG-Test-CA.r0 $TEST600_TESTCRL || return 1
   local hash=`openssl x509 -in $TEST600_TESTCA -noout -hash`
-  TEST600_TESTCA_HASH=/etc/grid-security/certificates/${hash}.0
-  TEST600_TESTCRL_HASH=/etc/grid-security/certificates/${hash}.r0
+  TEST600_TESTCA_HASH=${TEST600_GRID_SECURITY_DIR}/certificates/${hash}.0
+  TEST600_TESTCRL_HASH=${TEST600_GRID_SECURITY_DIR}/certificates/${hash}.r0
   sudo ln -sf $TEST600_TESTCA $TEST600_TESTCA_HASH || return 1
   sudo ln -sf $TEST600_TESTCRL $TEST600_TESTCRL_HASH || return 1
   set +x
@@ -64,6 +103,21 @@ cvmfs_run_test() {
   local logfile=$1
   local script_location=$2
   local scratch_dir=$(pwd)
+
+  local TEST600_GRID_SECURITY_DIR=${scratch_dir}/grid-security
+  mkdir -p ${TEST600_GRID_SECURITY_DIR}/certificates ${scratch_dir}/vomsdir
+  TEST600_HOSTCERT=${TEST600_GRID_SECURITY_DIR}/hostcert-cvmfs.pem
+  TEST600_HOSTKEY=${TEST600_GRID_SECURITY_DIR}/hostkey-cvmfs.pem
+  TEST600_VOMSDIR=${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs
+  TEST600_TESTCA=${TEST600_GRID_SECURITY_DIR}/certificates/OSG-Test-CA.pem
+  TEST600_TESTCRL=${TEST600_GRID_SECURITY_DIR}/certificates/OSG-Test-CA.r0
+  # These two variables will be updated later with the generated hash
+  TEST600_TESTCA_HASH=${TEST600_GRID_SECURITY_DIR}/certificates/OSG-Test-CA.pem
+  TEST600_TESTCRL_HASH=${TEST600_GRID_SECURITY_DIR}/certificates/OSG-Test-CA.r0
+
+  TEST600_CERTS_DIR=$(pwd)/certs
+  TEST600_GRID_MOUNTPOINT=$(pwd)/cvmfs-grid/mountpoint
+  TEST600_GRID_CACHE=$(pwd)/cvmfs-grid/cache
 
   # Generate repo first - check will fail after apache change below until we
   # change the default URL.
@@ -82,33 +136,45 @@ cvmfs_run_test() {
   # ( . ${script_location}/../../common/migration_tests/common.sh; install_packages gridsite voms-clients-cpp )
 
   echo "set a trap for system directory cleanup"
-  #trap cleanup EXIT HUP INT TERM
+  trap cleanup EXIT HUP INT TERM
 
+  mount_cvmfs_grid $TEST600_GRID_MOUNTPOINT $TEST600_GRID_CACHE || return 10
+  ls $TEST600_GRID_MOUNTPOINT
   generate_certs $script_location
   # requires mod_gridsite from the gridsite package
   cp $script_location/test600.cvmfs.secure.conf $TEST600_HTTPS_CONFIG
   sed -i "s/@REPONAME@/$CVMFS_TEST_REPO/" $TEST600_HTTPS_CONFIG
+  sed -i "s,@GRIDSECURITYDIR@,$TEST600_GRID_SECURITY_DIR," $TEST600_HTTPS_CONFIG
   cp $script_location/gacl /srv/cvmfs/$CVMFS_TEST_REPO/data/.gacl
   echo "restarting apache"
   apache_switch off
   apache_switch on
 
   sed -i "s|CVMFS_SERVER_URL=http://localhost/cvmfs/$CVMFS_TEST_REPO|CVMFS_SERVER_URL=https://$HOSTNAME:8443/cvmfs/$CVMFS_TEST_REPO|" /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf
-  umount /cvmfs/$CVMFS_TEST_REPO
-  umount /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly
+  echo "X509_CERT_DIR=${TEST600_GRID_SECURITY_DIR}/certificates" >> /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf
+  # TODO(jblomer): Fixed catalogs with alternative path should be properly solved
+  sed -i -e '/^CVMFS_ROOT_HASH=/d' /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local
+  cvmfs_suid_helper rw_umount $CVMFS_TEST_REPO
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO
   # Remove any cached files to make sure we reload over https.
   rm -rf /var/spool/cvmfs/$CVMFS_TEST_REPO/cache/$CVMFS_TEST_REPO
-  cvmfs2 $CVMFS_TEST_REPO /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly -o rw,allow_other,config=/etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf,cvmfs_suid,dev,suid || return $?
-  mount /cvmfs/$CVMFS_TEST_REPO
+  cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return $?
+  cvmfs_suid_helper rw_mount $CVMFS_TEST_REPO || return $?
   export X509_USER_PROXY=$(pwd)/certs/vomsproxy.pem
   cp $(pwd)/certs/vomsproxy.pem $(pwd)/certs/vomsproxy.pem.nobody
   chown nobody: $(pwd)/certs/vomsproxy.pem.nobody
   cat $X509_USER_PROXY
-  sudo -u nobody /bin/sh -c "X509_USER_PROXY=$PWD/certs/vomsproxy.pem.nobody cat /cvmfs/$CVMFS_TEST_REPO/hello_world" > /dev/null || return $?
+  sudo mkdir -p /etc/grid-security || return 20
+  sudo mount --bind $TEST600_GRID_SECURITY_DIR /etc/grid-security || return 21
+  TEST600_GRID_SECURITY_TAINTED="yes"
+  sudo -u nobody /bin/sh -c "X509_USER_PROXY=$PWD/certs/vomsproxy.pem.nobody cat /cvmfs/$CVMFS_TEST_REPO/hello_world" > /dev/null || return 30
   # This should work because the above and below are in the same session id.
-  sudo -u nobody /bin/sh -c "cat /cvmfs/$CVMFS_TEST_REPO/hello_world" > /dev/null || return $?
-  sudo -u nobody setsid /bin/sh -c "cat /cvmfs/$CVMFS_TEST_REPO/hello_world" > /dev/null || return 0
-
+  sudo -u nobody /bin/sh -c "cat /cvmfs/$CVMFS_TEST_REPO/hello_world" || return 31
+  sudo -u nobody setsid /bin/sh -c "env && cat /cvmfs/$CVMFS_TEST_REPO/hello_world"
   # Last line should have resulted in an IO error.
-  return 1
+  if [ $? -eq 0 ]; then
+    return 40
+  fi
+
+  return 0
 }

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -85,6 +85,7 @@ cvmfs_run_test() {
   #trap cleanup EXIT HUP INT TERM
 
   generate_certs $script_location
+  # requires mod_gridsite from the gridsite package
   cp $script_location/test600.cvmfs.secure.conf $TEST600_HTTPS_CONFIG
   sed -i "s/@REPONAME@/$CVMFS_TEST_REPO/" $TEST600_HTTPS_CONFIG
   cp $script_location/gacl /srv/cvmfs/$CVMFS_TEST_REPO/data/.gacl

--- a/test/src/600-securecvmfs/test600.cvmfs.secure.conf
+++ b/test/src/600-securecvmfs/test600.cvmfs.secure.conf
@@ -3,9 +3,9 @@ Listen 8443
 
 <VirtualHost _default_:8443>
 SSLEngine on
-SSLCertificateFile /etc/grid-security/hostcert-cvmfs.pem
-SSLCertificateKeyFile /etc/grid-security/hostkey-cvmfs.pem
-SSLCACertificatePath /etc/grid-security/certificates
+SSLCertificateFile @GRIDSECURITYDIR@/hostcert-cvmfs.pem
+SSLCertificateKeyFile @GRIDSECURITYDIR@/hostkey-cvmfs.pem
+SSLCACertificatePath @GRIDSECURITYDIR@/certificates
 
 SSLVerifyClient optional
 SSLVerifyDepth  10


### PR DESCRIPTION
While working on it I discovered a problem with the alternative catalog path: we have the option to set `CVMFS_ROOT_HASH` to load a very specific catalog.  This circumvents downloading the manifest, so the client doesn't know it should look under a different path for the root catalog.

This feature is used with the clients that provide the read-only branch of a cvmfs server.

We could solve it by introducing another parameter, e.g. `CVMFS_ROOT_CATALOG_PATH`.  Not sure yet if this is the best way to deal with it.