### PR TITLE
FIX: `cvmfs_server import` backend sanity check

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3016,6 +3016,19 @@ import() {
     echo "done"
   fi
 
+  # check imported storage location
+  echo -n "Sanity-Checking imported CernVM-FS storage... "
+  [ -d ${storage_location}/data     ] || die "fail! (${storage_location}/data missing)"
+  [ -d ${storage_location}/data/txn ] || die "fail! (${storage_location}/data/txn missing)"
+  i=0
+  while [ $i -lt 256 ]; do
+    subdir=$(printf "%02x" $i)
+    [ -d ${storage_location}/data/${subdir} ] || die "fail! (${storage_location}/data/XX incomplete [XX = $subdir])"
+    i=$(($i+1))
+  done
+  [ -f ${storage_location}/.cvmfspublished ] || die "fail! (${storage_location}/.cvmfspublished missing)"
+  echo "done"
+
   # recreate whitelist if requested
   if [ $recreate_whitelist -ne 0 ]; then
     echo -n "Recreating whitelist... "

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2953,8 +2953,17 @@ import() {
   # investigate the given repository storage for sanity
   local storage_location=$(get_upstream_config $upstream)
   [ -d $storage_location ] || die "Did not find repository storage to import at $storage_location"
-  [ -f "${storage_location}/.cvmfspublished" ] && \
-  [ -d "${storage_location}/data" ] || die "$storage_location does not seem to be a repository storage"
+  [ -f "${storage_location}/.cvmfspublished" ] || die "${storage_location}/.cvmfspublished missing"
+  [ -d "${storage_location}/data"     ] || die "${storage_location}/data missing"
+  [ -d "${storage_location}/data/txn" ] || die "${storage_location}/data/txn missing"
+  i=0
+  while [ $i -lt 256 ]; do
+    subdir=$(printf "%02x" $i)
+    [ -d ${storage_location}/data/${subdir} ] || die "${storage_location}/data/XX incomplete [XX = $subdir]"
+    i=$(($i+1))
+  done
+  echo "done"
+
   if [ $recreate_whitelist -eq 0 ]; then
     [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"
     local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
@@ -3015,19 +3024,6 @@ import() {
     fi
     echo "done"
   fi
-
-  # check imported storage location
-  echo -n "Sanity-Checking imported CernVM-FS storage... "
-  [ -d ${storage_location}/data     ] || die "fail! (${storage_location}/data missing)"
-  [ -d ${storage_location}/data/txn ] || die "fail! (${storage_location}/data/txn missing)"
-  i=0
-  while [ $i -lt 256 ]; do
-    subdir=$(printf "%02x" $i)
-    [ -d ${storage_location}/data/${subdir} ] || die "fail! (${storage_location}/data/XX incomplete [XX = $subdir])"
-    i=$(($i+1))
-  done
-  [ -f ${storage_location}/.cvmfspublished ] || die "fail! (${storage_location}/.cvmfspublished missing)"
-  echo "done"
 
   # recreate whitelist if requested
   if [ $recreate_whitelist -ne 0 ]; then

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -190,6 +190,55 @@ cvmfs_run_test() {
 
   # ============================================================================
 
+  echo "removing repository again"
+  destroy_repo $CVMFS_TEST_REPO || return 19
+
+  echo "planting the repository with the tampered whitelist"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
+
+  echo "tamper with the backend storage (rename .../data)"
+  repo_storage=$(get_local_repo_storage $CVMFS_TEST_REPO)
+  sudo mv ${repo_storage}/data ${repo_storage}/dataX || return 20
+
+  echo "importing repository (should fail due to missing data dir)"
+  local import_log_1="import_1.log"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER > $import_log_1 2>&1 && return 21
+
+  echo "tamper with the backend storage (rename .../data/txn)"
+  sudo mv ${repo_storage}/dataX    ${repo_storage}/data      || return 22
+  sudo mv ${repo_storage}/data/txn ${repo_storage}/data/txnX || return 23
+
+  echo "importing repository (should fail due to missing data/txn dir)"
+  local import_log_2="import_2.log"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER > $import_log_2 2>&1 && return 24
+
+  echo "tamper with the backend storage (rename .../data/01)"
+  sudo mv ${repo_storage}/data/txnX ${repo_storage}/data/txn || return 25
+  sudo mv ${repo_storage}/data/01   ${repo_storage}/data/01X || return 26
+
+  echo "importing repository (should fail due to missing data/01 dir)"
+  local import_log_3="import_3.log"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER > $import_log_3 2>&1 && return 27
+
+  echo "check error messages"
+  cat $import_log_1 | grep 'data missing'              || return 28
+  cat $import_log_2 | grep 'txn missing'               || return 29
+  cat $import_log_3 | grep 'XX incomplete' | grep '01' || return 30
+
+  echo "repair the backend storage"
+  sudo mv ${repo_storage}/data/01X ${repo_storage}/data/01 || return 31
+
+  echo "importing repository and create a fresh whitelist"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -r || return 32
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
   echo "open transaction to change something"
   start_transaction $CVMFS_TEST_REPO || return $?
 


### PR DESCRIPTION
I was struggling with `cvmfs_server import` of a given repository backend directory for more than an hour today. Turns out that the command failed ungracefully because the **/srv/cvmfs/.../data/txn** directory was missing. This extends the sanity checks in `cvmfs_server import` to check more aspects of CernVM-FS backend directories to be imported. In the hope it will save me (and potentially others) time down the road.

Also it comes with an extension to integration test 591 to provoke the added error messages.