### PR TITLE
FIX: `cvmfs_server import` Checks for Wrong Backend Directory Ownership

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2971,6 +2971,7 @@ import() {
   done
   for item in $needed_items; do
     [ -e $item ] || die "$item missing"
+    [ $chown_backend -ne 0 ] || [ x"$cvmfs_user" = x"$(stat -c%U $item)" ] || die "$item not owned by $cvmfs_user"
   done
 
   if [ $recreate_whitelist -eq 0 ]; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2960,17 +2960,18 @@ import() {
 
   # investigate the given repository storage for sanity
   local storage_location=$(get_upstream_config $upstream)
-  [ -d $storage_location ] || die "Did not find repository storage to import at $storage_location"
-  [ -f "${storage_location}/.cvmfspublished" ] || die "${storage_location}/.cvmfspublished missing"
-  [ -d "${storage_location}/data"     ] || die "${storage_location}/data missing"
-  [ -d "${storage_location}/data/txn" ] || die "${storage_location}/data/txn missing"
-  i=0
+  local needed_items="${storage_location}                 \
+                      ${storage_location}/.cvmfspublished \
+                      ${storage_location}/data            \
+                      ${storage_location}/data/txn"
+  local i=0
   while [ $i -lt 256 ]; do
-    subdir=$(printf "%02x" $i)
-    [ -d ${storage_location}/data/${subdir} ] || die "${storage_location}/data/XX incomplete [XX = $subdir]"
+    needed_items="$needed_items ${storage_location}/data/$(printf "%02x" $i)"
     i=$(($i+1))
   done
-  echo "done"
+  for item in $needed_items; do
+    [ -e $item ] || die "$item missing"
+  done
 
   if [ $recreate_whitelist -eq 0 ]; then
     [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2950,6 +2950,14 @@ import() {
     check_aufs                      || die "aufs kernel module missing"
   fi
 
+  # repository owner dialog
+  local cvmfs_user=$(get_cvmfs_owner $name $owner)
+  check_user $cvmfs_user || die "No user $cvmfs_user"
+  [ x"$file_ownership" = x ] && file_ownership="$(id -u $cvmfs_user):$(id -g $cvmfs_user)"
+  echo $file_ownership | grep -q "^[0-9][0-9]*:[0-9][0-9]*$" || die "Unrecognized file ownership: $file_ownership | expected: <uid>:<gid>"
+  local cvmfs_uid=$(echo $file_ownership | cut -d: -f1)
+  local cvmfs_gid=$(echo $file_ownership | cut -d: -f2)
+
   # investigate the given repository storage for sanity
   local storage_location=$(get_upstream_config $upstream)
   [ -d $storage_location ] || die "Did not find repository storage to import at $storage_location"
@@ -2971,14 +2979,6 @@ import() {
   else
     [ -f ${keys_location}/${master_key} ] || die "no master key found for whitelist recreation"
   fi
-
-  # repository owner dialog
-  local cvmfs_user=$(get_cvmfs_owner $name $owner)
-  check_user $cvmfs_user || die "No user $cvmfs_user"
-  [ x"$file_ownership" = x ] && file_ownership="$(id -u $cvmfs_user):$(id -g $cvmfs_user)"
-  echo $file_ownership | grep -q "^[0-9][0-9]*:[0-9][0-9]*$" || die "Unrecognized file ownership: $file_ownership | expected: <uid>:<gid>"
-  local cvmfs_uid=$(echo $file_ownership | cut -d: -f1)
-  local cvmfs_gid=$(echo $file_ownership | cut -d: -f2)
 
   # set up desaster cleanup
   IMPORT_DESASTER_REPO_NAME="$name"

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -220,13 +220,13 @@ cvmfs_run_test() {
   local import_log_3="import_3.log"
   import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER > $import_log_3 2>&1 && return 27
 
-  echo "check error messages"
-  cat $import_log_1 | grep 'data missing'              || return 28
-  cat $import_log_2 | grep 'txn missing'               || return 29
-  cat $import_log_3 | grep 'XX incomplete' | grep '01' || return 30
-
   echo "repair the backend storage"
   sudo mv ${repo_storage}/data/01X ${repo_storage}/data/01 || return 31
+
+  echo "check error messages"
+  cat $import_log_1 | grep 'data missing' || return 28
+  cat $import_log_2 | grep 'txn missing'  || return 29
+  cat $import_log_3 | grep '/01 missing'  || return 30
 
   echo "importing repository and create a fresh whitelist"
   import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -r || return 32

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -239,6 +239,34 @@ cvmfs_run_test() {
 
   # ============================================================================
 
+  echo "removing repository again"
+  destroy_repo $CVMFS_TEST_REPO || return 33
+
+  echo "planting the repository with the tampered whitelist"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
+
+  echo "tamper with the backend storage (chown .../data/76)"
+  repo_storage=$(get_local_repo_storage $CVMFS_TEST_REPO)
+  sudo chown 1337 ${repo_storage}/data/76 || return 34
+
+  echo "importing repository (should fail due to not owning .../data/76)"
+  local import_log_4="import_4.log"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER > $import_log_4 2>&1 && return 35
+
+  echo "check error messages"
+  cat $import_log_4 | grep '/76 not owned by' || return 36
+
+  echo "importing repository chown-ing the backend and create a fresh whitelist"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -r -g || return 37
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
   echo "open transaction to change something"
   start_transaction $CVMFS_TEST_REPO || return $?
 


### PR DESCRIPTION
Same as yesterday, took long enough to figure this out by myself. So let's better make `cvmfs_server` check it when importing legacy repositories.
*Note:* I've done a small refactoring to safe some code lines for the different backend items to be checked.