### PR TITLE
FIX T_Util.RfcTimestamp

### DIFF
--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -14,6 +14,7 @@
 
 #include <ctime>
 #include <limits>
+#include <string>
 #include <vector>
 
 #include "../../cvmfs/shortstring.h"
@@ -737,8 +738,17 @@ TEST_F(T_Util, StringifyTime) {
 
 TEST_F(T_Util, RfcTimestamp) {
   char *curr_locale = setlocale(LC_TIME, NULL);
+  char *format = "%a, %e %h %Y %H:%M:%S %z";
   setlocale(LC_TIME, "C");
-  EXPECT_EQ(GetRfcTimeString(), RfcTimestamp());
+  struct tm tm1;
+  struct tm tm2;
+  string str1 = GetRfcTimeString();
+  string str2 = RfcTimestamp();
+  strptime(str1.c_str(), format, &tm1);
+  strptime(str2.c_str(), format, &tm2);
+  time_t time1 = mktime(&tm1);
+  time_t time2 = mktime(&tm2);
+  EXPECT_GT(time1, time2 - 2000);  // two seconds less of tolerance
   setlocale(LC_TIME, curr_locale);
 }
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -14,7 +14,6 @@
 
 #include <ctime>
 #include <limits>
-#include <string>
 #include <vector>
 
 #include "../../cvmfs/shortstring.h"
@@ -738,7 +737,7 @@ TEST_F(T_Util, StringifyTime) {
 
 TEST_F(T_Util, RfcTimestamp) {
   char *curr_locale = setlocale(LC_TIME, NULL);
-  char *format = "%a, %e %h %Y %H:%M:%S %z";
+  const char *format = "%a, %e %h %Y %H:%M:%S %z";
   setlocale(LC_TIME, "C");
   struct tm tm1;
   struct tm tm2;
@@ -748,7 +747,7 @@ TEST_F(T_Util, RfcTimestamp) {
   strptime(str2.c_str(), format, &tm2);
   time_t time1 = mktime(&tm1);
   time_t time2 = mktime(&tm2);
-  EXPECT_GT(time1, time2 - 2000);  // two seconds less of tolerance
+  EXPECT_GT(2, time2 - time1);
   setlocale(LC_TIME, curr_locale);
 }
 


### PR DESCRIPTION
Now the comparison is made within a maximum of two seconds between both values