### PR TITLE
Fix api changes

### DIFF
--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -179,6 +179,7 @@ class T_Uploaders : public FileSandbox {
 
     return SpoolerDefinition(definition,
                              shash::kSha1,
+                             zlib::kZlibDefault,
                              use_file_chunking,
                              min_chunk_size,
                              avg_chunk_size,

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -96,6 +96,7 @@ static inline upload::SpoolerDefinition MockSpoolerDefinition() {
   return upload::SpoolerDefinition("mock," + std::string(g_sandbox_path) + "," +
                                              std::string(g_sandbox_tmp_dir),
                                    shash::kSha1,
+                                   zlib::kZlibDefault,
                                    true,
                                    min_chunk_size,
                                    avg_chunk_size,


### PR DESCRIPTION
This adapts the API changes of both `SpoolerDefinition::SpoolerDefinition()` and `Fetcher::Fetch()` in the unit testing code. That should fix the [latest Jenkins failure](https://phsft-jenkins.cern.ch/view/CVMFS/job/CvmfsFullBuildDocker/67/).