### PR TITLE
add cvmfs_rsync to cvmfs-server package

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -636,6 +636,12 @@ if (BUILD_SERVER)
     PERMISSIONS    OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
 
+  install (
+    FILES      cvmfs_rsync
+    DESTINATION    bin
+    PERMISSIONS    OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+
   install(
     FILES      webapi/cvmfs-api.wsgi
     DESTINATION    "/var/www/wsgi-scripts"

--- a/cvmfs/cvmfs_rsync
+++ b/cvmfs/cvmfs_rsync
@@ -35,57 +35,33 @@ if [ -z "$REPO" ]; then
     usage
 fi
 
-DESTSUBDIR="${DESTWITHOUTCVMFS%*/}"
-
 if [[ "$SRC" =~ ^[^/]*: ]]; then
     echo "$ME: srcdir must be locally mounted, not a remote host, sorry" >&2
     usage
 fi
 
-if [ -f /cvmfs/$REPO/.cvmfsdirtab ]; then
-    DESTDIR="$DEST"
-    if [ "${SRC%/}" = "$SRC" ]; then
-        # there's no trailing slash, so rsync will append $SRC basename to $DEST
-        DESTDIR="$DEST/${SRC##*/}"
-    fi
-    # look for entries that match under $DESTSUBDIR and expand them to
-    #   see if any of them have .cvmfscatalog or .cvmfsautocatalog files
-    #   in directories that have gone away from the source.
-    grep -vE '^(!|#)' /cvmfs/$REPO/.cvmfsdirtab|while read PAT; do
-        FULLPAT="/cvmfs/$REPO$PAT"
-        PATSLASHES="${FULLPAT//[^\/]}"
-        let NPATFIELDS="${#PATSLASHES} + 1"
-        DESTSLASHES="${DESTDIR//[^\/]}"
-        let NDESTFIELDS="${#DESTSLASHES} + 1"
-        MATCHPAT="$FULLPAT"
-        if [ $NPATFIELDS -gt $NDESTFIELDS ]; then
-            MATCHPAT="`echo "$FULLPAT"|cut -d/ -f-$NDESTFIELDS`"
-        fi
-        if [ "${DESTDIR#$MATCHPAT}" != "$DESTDIR" ]; then
-            # $PAT matches $DESTDIR, look in all matching directories
-            let NDESTFIELDS+=1
-            SUBPAT="`echo "$FULLPAT"|cut -d/ -f$NDESTFIELDS-`"
-            if [ -n "$SUBPAT" ]; then
-                SUBPAT="/$SUBPAT"
-            fi
-            # enable dotglob because .cvmfsdirtab matches dots
-            for D in `shopt -s dotglob;echo $DESTDIR$SUBPAT 2>/dev/null`; do
-                SRCSUBD="${D#$DESTDIR/}"
-                if [ "$SRCSUBD" = "$D" ]; then
-                    # it didn't really match, the .cvmfsdirtab pattern
-                    #  included other directories outside of this one
-                    # (shouldn't happen because of $SUBPAT, but just in case)
-                    continue
-                fi
-                for F in .cvmfscatalog .cvmfsautocatalog; do
-                    if [ -f $D/$F ] && [ ! -d $SRC/$SRCSUBD ]; then
-                        echo "removing $F from deleted ${D#$DEST/}"
-                        rm -f $D/$F
-                    fi
-                done
-            done
-        fi
-    done
+DESTDIR="$DEST"
+if [ "${SRC%/}" = "$SRC" ]; then
+    # there's no trailing slash, so rsync will append $SRC basename to $DEST
+    DESTDIR="$DEST/${SRC##*/}"
 fi
+# Look for catalogs under $DESTDIR, and if any of the corresponding source 
+# directories have gone away, remove any .cvmfscatalog or .cvmfsautocatalog
+# in the destination.  Note: $DESTSUBDIR may be empty, and $SRC may or
+# may not have a trailing slash.
+DESTSUBDIR="${DESTDIR#/cvmfs/$REPO}"
+cvmfs_server list-catalogs -x $REPO|grep -E "^$DESTSUBDIR(/|$)"|while read DIR; do
+    # SRCSUBD will always either start with a slash or be empty
+    SRCSUBD="${DIR#$DESTSUBDIR}"
+    if [ ! -d "$SRC$SRCSUBD" ]; then
+        for F in .cvmfscatalog .cvmfsautocatalog; do
+            CATFILE="/cvmfs/$REPO$DIR/$F"
+            if [ -f "$CATFILE" ] ; then
+                echo "removing $F from deleted dir $DIR"
+                rm -f "$CATFILE"
+            fi
+        done
+    fi
+done
 
 exec rsync $RSYNC_OPTIONS $SRC $DEST

--- a/cvmfs/cvmfs_rsync
+++ b/cvmfs/cvmfs_rsync
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Rsync directories into cvmfs.
+
+ME=cvmfs_rsync
+
+usage()
+{
+    echo "$ME [rsync_options] srcdir /cvmfs/reponame[/destsubdir]" >&2
+    echo "  Rsync to cvmfs repositories.  Avoids .cvmfscatalog and .cvmfsautocatalog" >&2
+    echo "  files while allowing directories containing them to be deleted when their" >&2
+    echo "  source goes away." >&2
+    exit 1
+}
+
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+# readlink -m canonicalizes paths, removing extra slashes, etc.
+DEST="`readlink -m ${@:$#}`"
+let IDX="$# - 1"
+SRC="${@:$IDX:1}"
+let IDX-=1
+RSYNC_OPTIONS="${@:1:$IDX} --exclude .cvmfscatalog --exclude .cvmfsautocatalog"
+
+DESTWITHOUTCVMFS="${DEST#/cvmfs/}"
+if [ "DESTWITHOUTCVMFS" = "$DEST" ]; then
+    echo "$ME: destination does not begin with /cvmfs/" >&2
+    usage
+fi
+
+REPO="${DESTWITHOUTCVMFS%%/*}"
+if [ -z "$REPO" ]; then
+    echo "$ME: no reponame given" >&2
+    usage
+fi
+
+DESTSUBDIR="${DESTWITHOUTCVMFS%*/}"
+
+if [[ "$SRC" =~ ^[^/]*: ]]; then
+    echo "$ME: srcdir must be locally mounted, not a remote host, sorry" >&2
+    usage
+fi
+
+if [ -f /cvmfs/$REPO/.cvmfsdirtab ]; then
+    DESTDIR="$DEST"
+    if [ "${SRC%/}" = "$SRC" ]; then
+        # there's no trailing slash, so rsync will append $SRC basename to $DEST
+        DESTDIR="$DEST/${SRC##*/}"
+    fi
+    # look for entries that match under $DESTSUBDIR and expand them to
+    #   see if any of them have .cvmfscatalog or .cvmfsautocatalog files
+    #   in directories that have gone away from the source.
+    grep -vE '^(!|#)' /cvmfs/$REPO/.cvmfsdirtab|while read PAT; do
+        FULLPAT="/cvmfs/$REPO$PAT"
+        PATSLASHES="${FULLPAT//[^\/]}"
+        let NPATFIELDS="${#PATSLASHES} + 1"
+        DESTSLASHES="${DESTDIR//[^\/]}"
+        let NDESTFIELDS="${#DESTSLASHES} + 1"
+        MATCHPAT="$FULLPAT"
+        if [ $NPATFIELDS -gt $NDESTFIELDS ]; then
+            MATCHPAT="`echo "$FULLPAT"|cut -d/ -f-$NDESTFIELDS`"
+        fi
+        if [ "${DESTDIR#$MATCHPAT}" != "$DESTDIR" ]; then
+            # $PAT matches $DESTDIR, look in all matching directories
+            let NDESTFIELDS+=1
+            SUBPAT="`echo "$FULLPAT"|cut -d/ -f$NDESTFIELDS-`"
+            if [ -n "$SUBPAT" ]; then
+                SUBPAT="/$SUBPAT"
+            fi
+            # enable dotglob because .cvmfsdirtab matches dots
+            for D in `shopt -s dotglob;echo $DESTDIR$SUBPAT 2>/dev/null`; do
+                SRCSUBD="${D#$DESTDIR/}"
+                if [ "$SRCSUBD" = "$D" ]; then
+                    # it didn't really match, the .cvmfsdirtab pattern
+                    #  included other directories outside of this one
+                    # (shouldn't happen because of $SUBPAT, but just in case)
+                    continue
+                fi
+                for F in .cvmfscatalog .cvmfsautocatalog; do
+                    if [ -f $D/$F ] && [ ! -d $SRC/$SRCSUBD ]; then
+                        echo "removing $F from deleted ${D#$DEST/}"
+                        rm -f $D/$F
+                    fi
+                done
+            done
+        fi
+    done
+fi
+
+exec rsync $RSYNC_OPTIONS $SRC $DEST

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -18,7 +18,7 @@ Description: CernVM File System
 Package: cvmfs-server
 Architecture: i386 amd64 arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2, libcap2, lsof
+Depends: insserv, initscripts, bash, coreutils, grep, sed, sudo, psmisc, curl, gzip, attr, openssl, apache2, libcap2, lsof, rsync
 Conflicts: cvmfs-server (< 2.1)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch

--- a/packaging/debian/cvmfs/cvmfs-server.install
+++ b/packaging/debian/cvmfs/cvmfs-server.install
@@ -10,6 +10,7 @@ usr/bin/cvmfs_swissknife
 usr/bin/cvmfs_swissknife_debug
 usr/bin/cvmfs_suid_helper
 usr/bin/cvmfs_server
+usr/bin/cvmfs_rsync
 etc/cvmfs/cvmfs_server_hooks.sh.demo
 var/www/wsgi-scripts/cvmfs-api.wsgi
 usr/share/cvmfs-server/webapi/cvmfs_api.py

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -154,6 +154,7 @@ Requires: openssl
 Requires: httpd
 Requires: libcap
 Requires: lsof
+Requires: rsync
 
 Conflicts: cvmfs-server < 2.1
 

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -365,6 +365,7 @@ fi
 %{_bindir}/cvmfs_swissknife_debug
 %{_bindir}/cvmfs_suid_helper
 %{_bindir}/cvmfs_server
+%{_bindir}/cvmfs_rsync
 %{_sysconfdir}/cvmfs/cvmfs_server_hooks.sh.demo
 %{_libdir}/libtbb_cvmfs.so
 %{_libdir}/libtbb_cvmfs.so.2

--- a/test/src/604-cvmfsrsync/main
+++ b/test/src/604-cvmfsrsync/main
@@ -1,0 +1,141 @@
+
+cvmfs_test_name="Sync files into a repository using cvmfs_rsync"
+cvmfs_test_autofs_on_startup=false
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+  local src_dir=$scratch_dir/srcdir/
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new source dir"
+  # create source dir
+  mkdir $src_dir
+  pushdir $src_dir
+
+  # create a .cvmfsdirtab for its subdirectories
+  (echo "/People/*"
+  echo "/Continents/*/*") > .cvmfsdirtab
+
+  # create some directories that will have catalogs including one with a dot
+  mkdir People
+  mkdir People/Germans People/Americans People/Russians People/.French
+  mkdir -p Continents/NorthAmerica/UnitedStates
+  mkdir -p Continents/Europe/Germany Continents/Europe/.Switzerland
+
+  # create some directories for famous people
+  mkdir People/Germans/AlbertEinstein People/Germans/JohannWolfgangGoethe 
+  mkdir People/Americans/GeorgeWashington People/Americans/BarackObama
+  mkdir People/Russians/MikhailKalashnikov People/Russians/YuriGagarin 
+
+  # add some files to some of the directories
+  cp_bin People/Germans/AlbertEinstein
+  cp /etc/passwd People/Americans/BarackObama
+  cp_usrbin People/Russians/MikhailKalashnikov
+  echo Batavia >Continents/NorthAmerica/UnitedStates/Illinois 
+  echo Geneva >Continents/Europe/.Switzerland/Geneva 
+
+  # add a top-level file as well
+  echo "refugee" > People/AManWithoutACountry
+
+  popdir
+
+  echo "syncing it to the new repository"
+  cvmfs_rsync -av $src_dir $repo_dir || return 1
+
+  # testing .cvmfsautocatalog files without auto-generation because only
+  #  need to show that they aren't removed until their source dir is removed
+  AUTOCATFILE=/cvmfs/$CVMFS_TEST_REPO/People/Americans/.cvmfsautocatalog
+  touch $AUTOCATFILE
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "check if the right number of catalogs are present in the repository (1)"
+  [ $(get_catalog_count $repo_name) -eq 8 ] || return 101
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing stuff in the source dir"
+  pushdir $src_dir
+  rm -rf People/.French
+  rm -rf Continents/NorthAmerica
+  popdir
+
+  echo "syncing it to the new repository"
+  cvmfs_rsync -av --delete $src_dir $repo_dir || return 2
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check if the right number of catalogs are present in the repository (2)"
+  [ $(get_catalog_count $repo_name) -eq 6 ] || return 102
+
+  echo "making sure test .cvmfsautocatalog file still exists"
+  [ -f $AUTOCATFILE ] || return 122
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing stuff in the source dir"
+  pushdir $src_dir
+  rm -rf People/Americans
+  rm -rf Continents/Europe/Germany
+  popdir
+
+  echo "syncing it to the new repository in two steps"
+  cvmfs_rsync -av --delete $src_dir/People/ $repo_dir/People || return 3
+  cvmfs_rsync -av --delete $src_dir/Continents/ $repo_dir/Continents || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check if the right number of catalogs are present in the repository (3)"
+  [ $(get_catalog_count $repo_name) -eq 4 ] || return 103
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "removing stuff in the source dir"
+  pushdir $src_dir
+  rm -f People/Germans/AlbertEinstein/rm
+  rm -rf People/Russians/MikhailKalashnikov
+  popdir
+
+  echo "syncing subdir to the new repository in two steps"
+  cvmfs_rsync -av --delete $src_dir/People/Germans/AlbertEinstein/ $repo_dir/People/Germans/AlbertEinstein || return 5
+  cvmfs_rsync -av --delete $src_dir/People/Russians/ $repo_dir/People/Russians || return 6
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check if the right number of catalogs are present in the repository (4)"
+  [ $(get_catalog_count $repo_name) -eq 4 ] || return 105
+
+  # ============================================================================
+
+  return 0
+}
+

--- a/test/src/604-cvmfsrsync/main
+++ b/test/src/604-cvmfsrsync/main
@@ -53,12 +53,12 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing it to the new repository"
-  cvmfs_rsync -av $src_dir $repo_dir || return 1
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av $src_dir $repo_dir || return 1
 
   # testing .cvmfsautocatalog files without auto-generation because only
   #  need to show that they aren't removed until their source dir is removed
   AUTOCATFILE=/cvmfs/$CVMFS_TEST_REPO/People/Americans/.cvmfsautocatalog
-  touch $AUTOCATFILE
+  sudo -u $CVMFS_TEST_USER touch $AUTOCATFILE
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
@@ -81,7 +81,7 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing it to the new repository"
-  cvmfs_rsync -av --delete $src_dir $repo_dir || return 2
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir $repo_dir || return 2
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
@@ -104,8 +104,8 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing it to the new repository in two steps"
-  cvmfs_rsync -av --delete $src_dir/People/ $repo_dir/People || return 3
-  cvmfs_rsync -av --delete $src_dir/Continents/ $repo_dir/Continents || return 4
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/ $repo_dir/People || return 3
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/Continents/ $repo_dir/Continents || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
@@ -125,8 +125,8 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing subdir to the new repository in two steps"
-  cvmfs_rsync -av --delete $src_dir/People/Germans/AlbertEinstein/ $repo_dir/People/Germans/AlbertEinstein || return 5
-  cvmfs_rsync -av --delete $src_dir/People/Russians/ $repo_dir/People/Russians || return 6
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/Germans/AlbertEinstein/ $repo_dir/People/Germans/AlbertEinstein || return 5
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/Russians/ $repo_dir/People/Russians || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/604-cvmfsrsync/main
+++ b/test/src/604-cvmfsrsync/main
@@ -7,7 +7,8 @@ cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local scratch_dir=$(pwd)
-  local src_dir=$scratch_dir/srcdir/
+  local src_dir=$scratch_dir/srcdir
+  local pubtime_file=$scratch_dir/pubtime
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -53,7 +54,7 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing it to the new repository"
-  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av $src_dir $repo_dir || return 1
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av $src_dir/ $repo_dir || return 1
 
   # testing .cvmfsautocatalog files without auto-generation because only
   #  need to show that they aren't removed until their source dir is removed
@@ -69,6 +70,9 @@ cvmfs_run_test() {
   echo "check if the right number of catalogs are present in the repository (1)"
   [ $(get_catalog_count $repo_name) -eq 8 ] || return 101
 
+  # no catalogs should be created after this point
+  touch $pubtime_file
+
   # ============================================================================
 
   echo "starting transaction to edit repository"
@@ -81,13 +85,16 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing it to the new repository"
-  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir $repo_dir || return 2
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/ $repo_dir || return 2
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "check if the right number of catalogs are present in the repository (2)"
   [ $(get_catalog_count $repo_name) -eq 6 ] || return 102
+
+  echo "making sure no catalog files were recreated"
+  [ -z "`find $repo_dir -name .cvmfscatalog -newer $pubtime_file`" ] || return 112
 
   echo "making sure test .cvmfsautocatalog file still exists"
   [ -f $AUTOCATFILE ] || return 122
@@ -104,7 +111,7 @@ cvmfs_run_test() {
   popdir
 
   echo "syncing it to the new repository in two steps"
-  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/ $repo_dir/People || return 3
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People $repo_dir/ || return 3
   sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/Continents/ $repo_dir/Continents || return 4
 
   echo "creating CVMFS snapshot"
@@ -112,6 +119,9 @@ cvmfs_run_test() {
 
   echo "check if the right number of catalogs are present in the repository (3)"
   [ $(get_catalog_count $repo_name) -eq 4 ] || return 103
+
+  echo "making sure no catalog files were recreated"
+  [ -z "`find $repo_dir -name .cvmfscatalog -newer $pubtime_file`" ] || return 113
 
   # ============================================================================
 
@@ -126,13 +136,16 @@ cvmfs_run_test() {
 
   echo "syncing subdir to the new repository in two steps"
   sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/Germans/AlbertEinstein/ $repo_dir/People/Germans/AlbertEinstein || return 5
-  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/Russians/ $repo_dir/People/Russians || return 6
+  sudo -u $CVMFS_TEST_USER cvmfs_rsync -av --delete $src_dir/People/Russians $repo_dir/People || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "check if the right number of catalogs are present in the repository (4)"
   [ $(get_catalog_count $repo_name) -eq 4 ] || return 105
+
+  echo "making sure no catalog files were recreated"
+  [ -z "`find $repo_dir -name .cvmfscatalog -newer $pubtime_file`" ] || return 115
 
   # ============================================================================
 


### PR DESCRIPTION
As described in [CVM-814](https://sft.its.cern.ch/jira/browse/CVM-814).

Requires that rsync be installed on the test machines.   How do I ensure that?