### PR TITLE
FIX: OS X installation and relocatability

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1551,9 +1551,9 @@ configure_sudoers() {
     sudo sed -i .cvmfs_backup -e "/# added by CernVM-FS/d" /etc/sudoers
     sudo cat >> /etc/sudoers << EOF
 %everyone ALL=(cvmfs:cvmfs) NOPASSWD: /usr/bin/sudo # added by CernVM-FS
-cvmfs ALL= NOPASSWD: /usr/bin/cvmfs2 # added by CernVM-FS
-cvmfs ALL= NOPASSWD: /usr/bin/cvmfs2_debug # added by CernVM-FS
-%everyone ALL=(cvmfs:cvmfs) NOPASSWD: /usr/bin/cvmfs_talk -i * mountpoint # added by CernVM-FS
+cvmfs ALL= NOPASSWD: ${INSTALL_BASE}/bin/cvmfs2 # added by CernVM-FS
+cvmfs ALL= NOPASSWD: ${INSTALL_BASE}/bin/cvmfs2_debug # added by CernVM-FS
+%everyone ALL=(cvmfs:cvmfs) NOPASSWD: ${INSTALL_BASE}/bin/cvmfs_talk -i * mountpoint # added by CernVM-FS
 %everyone ALL=(cvmfs:cvmfs) NOPASSWD: /bin/mkdir # added by CernVM-FS
 cvmfs ALL= NOPASSWD: /usr/sbin/sysctl -w kern.maxfilesperproc=* kern.maxfiles=* # added by CernVM-FS
 %everyone ALL= NOPASSWD: /bin/mkdir -p /var/run/cvmfs # added by CernVM-FS

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -194,25 +194,29 @@ cvmfs_setup() {
   mkdir -p /var/lib/cvmfs
   chown cvmfs:cvmfs /var/lib/cvmfs
 
-  # put workarounds for OS X (>= 10.11) in place (SIP related)
-  if [ x"$sys_arch" = x"Darwin" ] && \
-     compare_versions $(sw_vers -productVersion) -ge "10.11"; then
+  # put workarounds for OS X in place (CernVM-FS poor-man's relocatability)
+  if [ x"$sys_arch" = x"Darwin" ]; then
     # symlink configuration files into /etc
     if [ ! -e /etc/cvmfs           ] && \
        [   -e /usr/local/etc/cvmfs ]; then
       ln -s /usr/local/etc/cvmfs /etc/cvmfs
     fi
 
-    # create a (minimal) file system bundle for `mount -t cvmfs` support
-    # Note: the `mount` utility in OS X 10.11.1 doesn't find the installed mount
-    #       helper in `/usr/local/sbin`. When disabling SIP and symlinking the
-    #       mount helper into `/sbin` it would work. Not sure if that is to be
-    #       considered a bug or a feature...
-    #       Currently the bundle creation below is considered a work around!
     if [ ! -e ${cvmfs_fs_bundle}/mount_cvmfs ] && \
+       [ ! -e /sbin/mount_cvmfs              ] && \
        [   -e /usr/local/sbin/mount_cvmfs ]; then
-      mkdir -p $cvmfs_fs_bundle
-      ln -s /usr/local/sbin/mount_cvmfs ${cvmfs_fs_bundle}/mount_cvmfs
+      if compare_versions $(sw_vers -productVersion) -ge "10.11"; then
+        # create a (minimal) file system bundle for `mount -t cvmfs` support
+        # Note: the `mount` utility in OS X 10.11.1 doesn't find the installed
+        #       mount helper in `/usr/local/sbin`. When disabling SIP and sym-
+        #       linking the mount helper into `/sbin` it would work. Not sure if
+        #       that is to be considered a bug or a feature...
+        #       Currently the bundle creation below is considered a work around!
+        mkdir -p $cvmfs_fs_bundle
+        ln -s /usr/local/sbin/mount_cvmfs ${cvmfs_fs_bundle}/mount_cvmfs
+      else
+        ln -s /usr/local/sbin/mount_cvmfs /sbin/mount_cvmfs
+      fi
     fi
   fi
 


### PR DESCRIPTION
This allows CernVM-FS 2.2.0 to be installed into `/usr/local` on older OS X versions. Furthermore it fixes the sudoers file adaption on OS X if CernVM-FS was installed into `/usr/local`.