### PR TITLE
FIX: Avoid Rollback to Outdated Catalog Schemas

### DIFF
--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -1101,6 +1101,16 @@ int CommandRollbackTag::Main(const ArgumentList &args) {
     return 1;
   }
 
+  // check if the catalog has a supported revision
+  if (catalog->schema() < catalog::CatalogDatabase::kLatestSupportedSchema -
+                          catalog::CatalogDatabase::kSchemaEpsilon) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "not rolling back to outdated and "
+                                    "incompatible catalog schema (%.1f < %.1f)",
+             catalog->schema(),
+             catalog::CatalogDatabase::kLatestSupportedSchema);
+    return 1;
+  }
+
   // update the catalog to be republished
   catalog->Transaction();
   catalog->UpdateLastModified();

--- a/test/src/604-resurrectancientcatalog/main
+++ b/test/src/604-resurrectancientcatalog/main
@@ -1,0 +1,112 @@
+
+cvmfs_test_name="Avoid Resurrection of Legacy Catalog via Rollback"
+cvmfs_test_autofs_on_startup=false
+
+
+get_head_revision() {
+  local repo_name="$1"
+  cvmfs_server tag -i trunk -x $repo_name | cut -f4 -d' '
+}
+
+
+TEST604_WORKSPACE=""
+TEST604_LEGACY_STORAGE=""
+TEST604_NEW_REPO_NAME=""
+cleanup() {
+  [ -z "$TEST604_WORKSPACE" ]      || cd $TEST604_WORKSPACE
+  [ -z "$TEST604_NEW_REPO_NAME" ]  || sudo cvmfs_server rmfs -f $TEST604_NEW_REPO_NAME
+  [ -z "$TEST604_LEGACY_STORAGE" ] || sudo rm -fR $TEST604_LEGACY_STORAGE
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+  local scratch_dir=$(pwd)
+
+  local guinea_pig_location="${script_location}/../../common/guinea_pig_repo_20"
+  local legacy_repo_name="testmigration.cern.ch"
+  local repo_dir="/cvmfs/${legacy_repo_name}"
+  local legacy_repo_storage="$(get_local_repo_storage $legacy_repo_name)"
+  TEST604_WORKSPACE="$scratch_dir"
+
+  echo "make sure there are no legacy repo leftovers from previous tests"
+  cleanup_legacy_repo_leftovers "$legacy_repo_name"
+
+  echo "set a trap for desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo -n "resurrect legacy repository... "
+  TEST604_LEGACY_STORAGE="$legacy_repo_storage"
+  plant_tarball "${guinea_pig_location}/keys.tar.gz"                                              || return $?
+  plant_legacy_repository_revision "${guinea_pig_location}/revision-6.tar.gz" "$legacy_repo_name" || return $?
+  echo "done"
+
+  echo -n "get root hash of top-most legacy revision... "
+  local legacy_root_catalog="$(cat ${legacy_repo_storage}/pub/catalogs/.cvmfspublished | get_root_hash_from_manifest)"
+  echo "done ($legacy_root_catalog)"
+
+  echo "run the repository migration"
+  TEST604_NEW_REPO_NAME="$legacy_repo_name"
+  sudo mv $legacy_repo_storage/pub/data $legacy_repo_storage         || return 1
+  sudo ln -s $legacy_repo_storage/data $legacy_repo_storage/pub/data || return 2
+  sudo cp $legacy_repo_storage/pub/catalogs/.cvmfspublished         \
+          $legacy_repo_storage/pub/catalogs/.cvmfswhitelist         \
+          $legacy_repo_storage/pub/catalogs/.cvmfs_master_replica   \
+          $legacy_repo_storage || return 3
+  import_repo "$legacy_repo_name" "$CVMFS_TEST_USER" \
+    -l                                               \
+    -s                                               \
+    -g || return 4
+
+  echo -n "get root hash of first new catalog... "
+  local uptodate_root_catalog="$(get_current_root_catalog $legacy_repo_name)"
+  echo "done ($uptodate_root_catalog)"
+
+  echo "create some new revisions"
+  start_transaction $legacy_repo_name || return  5
+  publish_repo      $legacy_repo_name || return  6
+  start_transaction $legacy_repo_name || return  7
+  publish_repo      $legacy_repo_name || return  8
+  start_transaction $legacy_repo_name || return  9
+  publish_repo      $legacy_repo_name || return 10
+
+  echo "list current tags"
+  cvmfs_server tag $legacy_repo_name || return 11
+
+  echo "create tag pointing to the legacy repository"
+  local legacy_tag="legacy"
+  cvmfs_server tag -a $legacy_tag -h "$legacy_root_catalog" $legacy_repo_name || return 12
+
+  echo "create tag pointing to the up-to-date repository"
+  local uptodate_tag="uptodate"
+  cvmfs_server tag -a $uptodate_tag -h "$uptodate_root_catalog" $legacy_repo_name || return 13
+
+  echo "list current tags"
+  cvmfs_server tag $legacy_repo_name || return 14
+
+  echo "roll back to the first up-to-date catalog"
+  rollback_repo $legacy_repo_name $uptodate_tag || return 15
+
+  echo -n "get HEAD revision... "
+  local head_revision=$(get_head_revision $legacy_repo_name)
+  echo "done ($head_revision)"
+
+  echo "list current tags"
+  cvmfs_server tag $legacy_repo_name || return 16
+
+  echo "try to roll back to an outdated catalog schema (should fail)"
+  rollback_repo $legacy_repo_name $legacy_tag && return 17
+
+  echo -n "getting HEAD revision again..."
+  local head_revision_after=$(get_head_revision $legacy_repo_name)
+  echo "done ($head_revision_after)"
+
+  echo "revision should not have changed"
+  [ $head_revision -eq $head_revision_after ] || return 18
+
+  echo "create a new repository transaction"
+  start_transaction $legacy_repo_name || return  19
+  publish_repo      $legacy_repo_name || return  20
+
+  return 0
+}

--- a/test/src/604-resurrectancientcatalog/main
+++ b/test/src/604-resurrectancientcatalog/main
@@ -95,18 +95,22 @@ cvmfs_run_test() {
   cvmfs_server tag $legacy_repo_name || return 16
 
   echo "try to roll back to an outdated catalog schema (should fail)"
-  rollback_repo $legacy_repo_name $legacy_tag && return 17
+  local rollback_log="rollback.log"
+  rollback_repo $legacy_repo_name $legacy_tag > $rollback_log 2>&1 && return 17
+
+  echo "check log file for error message"
+  cat $rollback_log | grep -e 'outdated and incompatible catalog schema' || return 18
 
   echo -n "getting HEAD revision again..."
   local head_revision_after=$(get_head_revision $legacy_repo_name)
   echo "done ($head_revision_after)"
 
   echo "revision should not have changed"
-  [ $head_revision -eq $head_revision_after ] || return 18
+  [ $head_revision -eq $head_revision_after ] || return 19
 
   echo "create a new repository transaction"
-  start_transaction $legacy_repo_name || return  19
-  publish_repo      $legacy_repo_name || return  20
+  start_transaction $legacy_repo_name || return  20
+  publish_repo      $legacy_repo_name || return  21
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -838,6 +838,18 @@ get_catalog_count() {
   echo $(cvmfs_server list-catalogs -x $repo_name | wc -l)
 }
 
+# read the manifest piped in through stdin and figure out the root catalog hash
+# @param (stdin)  a manifest file content
+# return          the catalog root hash referenced in the manifest
+get_root_hash_from_manifest() {
+  grep --text '^C[a-f0-9]*\(-[a-z0-9]*\)\?$' | sed -e 's/^C\(.*\)$/\1/'
+              # ^^~~~~~~~^ ^~~~~~~~~~~~^
+              # ||       | |           |
+              # ||       | +-----------+-- (optional) Hash Suffix
+              # |+-------+---------------- Hash String
+              # +------------------------- Manifest Field Identifier
+}
+
 # retrieves the hash of the current root catalog of the given
 # repository by investigating the manifest
 # @param repo_name  the name of the repository
@@ -845,14 +857,7 @@ get_catalog_count() {
 get_current_root_catalog() {
   local repo_name=$1
   local manifest_url="$(get_repo_url $repo_name)/.cvmfspublished"
-  local catalog_record=$(curl "$manifest_url" 2>/dev/null | grep --text '^C[a-f0-9]*\(-[a-z0-9]*\)\?$')
-                                                                        # ^^~~~~~~~^ ^~~~~~~~~~~~^
-                                                                        # ||       | |           |
-                                                                        # ||       | +-----------+-- (optional) Hash Suffix
-                                                                        # |+-------+---------------- Hash String
-                                                                        # +------------------------- Manifest Field Identifier
-  local characters=$(echo -n $catalog_record | wc -c)
-  echo -n $catalog_record | tail -c $(( $characters - 1 ))
+  curl "$manifest_url" 2>/dev/null | get_root_hash_from_manifest
 }
 
 # uses `cvmfs_server check` to check the integrity of the catalog structure


### PR DESCRIPTION
This is related to a pretty [ancient known issue](https://sft.its.cern.ch/jira/browse/CVM-252) that after a repository was migrated from 2.0.x-style to 2.1.x-style catalogs, rolling back too far might 'break' the repository. The problem is a bit constructed, but possible like so (see integration test also):

1. take a 2.0.x repository
2. migrate it to 2.1.x-style catalogs (`cvmfs_server import -l ...`)
3. create a tag to an old-style catalog revision (`cvmfs_server tag -a old -h <old clg hash>`)
4. roll back to the **old** tag.
5. Congrats, your 2.1.x repository is now populated by 2.0.x catalogs
6. cry a lot

This patch introduces a check to avoid rolling back to such tags.