### PR TITLE
FIX: Build GeoIP External on ArchLinux

### DIFF
--- a/externals/python-geoip/src/makeHook.sh
+++ b/externals/python-geoip/src/makeHook.sh
@@ -11,10 +11,12 @@ mkdir dist
 if [ -f .tmp/*.egg ]; then
     # older python versions like 2.4 install a .egg; extract GeoIP.so
     (cd .tmp; unzip -o *.egg GeoIP.so)
-fi
-if [ -d .tmp/*.egg ]; then
+elif [ -d .tmp/*.egg ]; then
 	# for some reason SLC6 produces an uncompressed *.egg directory containing GeoIP.so
 	cp .tmp/*.egg/GeoIP.so .tmp
+elif [ -f .tmp/GeoIP*.so ]; then
+  # on ArchLinux no *.egg is created but a GeoIP.<system tag>.so file
+  cp .tmp/GeoIP*.so .tmp/GeoIP.so
 fi
 cp .tmp/GeoIP.so dist
 rm -rf .tmp

--- a/externals/python-geoip/src/makeHook.sh
+++ b/externals/python-geoip/src/makeHook.sh
@@ -17,6 +17,9 @@ elif [ -d .tmp/*.egg ]; then
 elif [ -f .tmp/GeoIP*.so ]; then
   # on ArchLinux no *.egg is created but a GeoIP.<system tag>.so file
   cp .tmp/GeoIP*.so .tmp/GeoIP.so
+else
+  echo "couldn't extract GeoIP build result in makeHook.sh"
+  exit 1
 fi
 cp .tmp/GeoIP.so dist
 rm -rf .tmp

--- a/externals/python-geoip/src/makeHook.sh
+++ b/externals/python-geoip/src/makeHook.sh
@@ -9,11 +9,11 @@ PYTHONPATH=$PWD/.tmp python setup.py install --install-lib=$PWD/.tmp
 rm -rf dist
 mkdir dist
 if [ -f .tmp/*.egg ]; then
-    # older python versions like 2.4 install a .egg; extract GeoIP.so
-    (cd .tmp; unzip -o *.egg GeoIP.so)
+  # older python versions like 2.4 install a .egg; extract GeoIP.so
+  (cd .tmp; unzip -o *.egg GeoIP.so)
 elif [ -d .tmp/*.egg ]; then
-	# for some reason SLC6 produces an uncompressed *.egg directory containing GeoIP.so
-	cp .tmp/*.egg/GeoIP.so .tmp
+  # for some reason SLC6 produces an uncompressed *.egg directory containing GeoIP.so
+  cp .tmp/*.egg/GeoIP.so .tmp
 elif [ -f .tmp/GeoIP*.so ]; then
   # on ArchLinux no *.egg is created but a GeoIP.<system tag>.so file
   cp .tmp/GeoIP*.so .tmp/GeoIP.so


### PR DESCRIPTION
Used this docker container to debug the build:
```bash
host$# sudo docker run --rm -t -i pritunl/archlinux:latest /bin/bash
arch$# pacman -S cmake gcc make patch fuse python unzip
```

The `makeHook.sh` of the geoip external didn't properly find the build result on ArchLinux. Should work now.