### PR TITLE
Feature: `cvmfs_server rmfs -p` to Preserve Repository Data

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -281,7 +281,7 @@ Supported Commands:
                 [-a tag name] [-c tag channel] [-m tag description]
                 <fully qualified name>
                 Make a new repository snapshot
-  rmfs          [-f don't ask again]
+  rmfs          [-p(reserve) repo data and keys] [-f don't ask again]
                 <fully qualified name>
                 Remove the repository
   abort         [-f don't ask again]

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3127,15 +3127,19 @@ import() {
 rmfs() {
   local names
   local force=0
+  local preserve_data=0
   local retcode=0
 
   # optional parameter handling
   OPTIND=1
-  while getopts "f" option
+  while getopts "fp" option
   do
     case $option in
       f)
         force=1
+      ;;
+      p)
+        preserve_data=1
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -3188,13 +3192,15 @@ rmfs() {
     remove_spool_area $name
     echo done
 
-    if is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
+    if [ $preserve_data -eq 0 ] && \
+       is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
       echo -n "Removing Repository Storage... "
       remove_repository_storage $name || die "fail"
       echo "done"
     fi
 
-    if [ "$CVMFS_REPOSITORY_TYPE" = stratum0 ]; then
+    if [ $preserve_data -eq 0 ] && \
+       [ "$CVMFS_REPOSITORY_TYPE" = stratum0 ]; then
       echo -n "Removing Keys and Certificate... "
       rm -f /etc/cvmfs/keys/$name.masterkey \
           /etc/cvmfs/keys/$name.pub \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3203,9 +3203,9 @@ rmfs() {
        [ "$CVMFS_REPOSITORY_TYPE" = stratum0 ]; then
       echo -n "Removing Keys and Certificate... "
       rm -f /etc/cvmfs/keys/$name.masterkey \
-          /etc/cvmfs/keys/$name.pub \
-          /etc/cvmfs/keys/$name.key \
-          /etc/cvmfs/keys/$name.crt || die "fail"
+            /etc/cvmfs/keys/$name.pub       \
+            /etc/cvmfs/keys/$name.key       \
+            /etc/cvmfs/keys/$name.crt || die "fail"
       echo "done"
     fi
 

--- a/test/src/606-gracefulrmfs/main
+++ b/test/src/606-gracefulrmfs/main
@@ -1,0 +1,118 @@
+cvmfs_test_name="Data Preservation when Removing Repository"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  echo "meaningless file content" > file
+  echo "more clever file content" > clever
+
+  mkdir foo
+  mkdir bar
+
+  mkdir foo/bar
+  mkdir bar/foo
+
+  ln file hardlinkToFile
+  ln -s clever symlinkToClever
+
+  popdir
+}
+
+check_repo_data() {
+  local repo_name="$1"
+  local backend_dir="$2"
+
+  [ -d $backend_dir ]                   || return 1
+  [ -f ${backend_dir}/.cvmfspublished ] || return 2
+  [ -f ${backend_dir}/.cvmfswhitelist ] || return 3
+  [ -d ${backend_dir}/data            ] || return 4
+
+  [ -f /etc/cvmfs/keys/${repo_name}.pub       ] || return 5
+  [ -f /etc/cvmfs/keys/${repo_name}.key       ] || return 6
+  [ -f /etc/cvmfs/keys/${repo_name}.crt       ] || return 7
+  [ -f /etc/cvmfs/keys/${repo_name}.masterkey ] || return 8
+}
+
+check_repo_data_inversed() {
+  local repo_name="$1"
+  local backend_dir="$2"
+
+  [ -d $backend_dir ]                   && { echo 1; return 1; }
+  [ -f ${backend_dir}/.cvmfspublished ] && { echo 2; return 2; }
+  [ -f ${backend_dir}/.cvmfswhitelist ] && { echo 3; return 3; }
+  [ -d ${backend_dir}/data            ] && { echo 4; return 4; }
+
+  [ -f /etc/cvmfs/keys/${repo_name}.pub       ] && return 5
+  [ -f /etc/cvmfs/keys/${repo_name}.key       ] && return 6
+  [ -f /etc/cvmfs/keys/${repo_name}.crt       ] && return 7
+  [ -f /etc/cvmfs/keys/${repo_name}.masterkey ] && return 8
+
+  return 0
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo -n "retrieving the created backend directory... "
+  load_repo_config $CVMFS_TEST_REPO || return 1
+  local backend_dir=$(read_upstream_config $CVMFS_UPSTREAM_STORAGE)
+  echo "done ($backend_dir)"
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in $repo_dir || return 3
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  produce_files_in $reference_dir || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "check if backend storage and keys are there"
+  check_repo_data $CVMFS_TEST_REPO $backend_dir || return $?
+
+  echo "remove the repository (keeping the authorative data)"
+  destroy_repo $CVMFS_TEST_REPO -p || return 5
+
+  echo "check if backend storage and keys are there"
+  check_repo_data $CVMFS_TEST_REPO $backend_dir || return $?
+
+  echo "importing the repository again"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 6
+
+  echo "compare the imported repository to our reference copy"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "check if backend storage and keys are there"
+  check_repo_data $CVMFS_TEST_REPO $backend_dir || return $?
+
+  echo "remove the repository (removing the authorative data)"
+  destroy_repo $CVMFS_TEST_REPO || return 7
+
+  echo "check if backend storage and keys are gone"
+  check_repo_data_inversed $CVMFS_TEST_REPO $backend_dir || return $?
+
+  return 0
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -1326,6 +1326,14 @@ peek_backend() {
 }
 
 
+# reads the upstream config part of a CernVM-FS server configuration file
+# This is the third comma-separated field in the upstream string
+read_upstream_config() {
+  local upstream_string="$1"
+  echo "$upstream_string" | cut -f3 -d','
+}
+
+
 # switches on/off the garbage collection for a given repository
 #
 # @param name  the name of the repository to be changed

--- a/test/test_functions
+++ b/test/test_functions
@@ -338,7 +338,7 @@ cvmfs_umount() {
       timeout=$(($timeout-1))
       sleep 1
     done
-    
+
     times=5
     result=-1
   done

--- a/test/test_functions
+++ b/test/test_functions
@@ -456,7 +456,10 @@ min() {
 
 destroy_repo() {
   local repo=$1
-  sudo cvmfs_server rmfs -f $repo || return 100
+  shift 1
+  local additional_flags="$@"
+
+  sudo cvmfs_server rmfs -f $additional_flags $repo || return 100
 }
 
 


### PR DESCRIPTION
This allows to remove a repository without deleting its backend storage and keychain. They are just left behind and can conveniently be re-imported. Of course it comes with an integration test case.