### PR TITLE
Feature: Skip Apache Configuration/Reload if Requested

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -263,18 +263,19 @@ Supported Commands:
                 [-m replicable] [-f union filesystem type] [-v volatile content]
                 [-g disable auto tags] [-a hash algorithm (default: SHA-1)]
                 [-z enable garbage collection] [-s S3 config file]
-                [-k path to existing keychain]
+                [-k path to existing keychain] [-p no apache config]
                 <fully qualified repository name>
                 Creates a new repository with a given name
   add-replica   [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
                 [-a silence apache warning] [-z enable garbage collection]
-                [-n alias name] [-s S3 config file]
+                [-n alias name] [-s S3 config file] [-p no apache config]
                 <stratum 0 url> <public key>
                 Creates a Stratum 1 replica of a Stratum 0 repository
   import        [-w stratum0 url] [-o owner] [-u upstream storage]
                 [-l import legacy repo (2.0.x)] [-s show migration statistics]
                 [-f union filesystem type] [-c file ownership (UID:GID)]
                 [-k path to keys] [-g chown backend] [-r recreate whitelist]
+                [-p no apache config]
                 <fully qualified repository name>
                 Imports an old CernVM-FS repository into a fresh 2.1.x repo
   publish       [-p pause for tweaks] [-n manual revision number] [-v verbose]

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1933,6 +1933,7 @@ create_config_files_for_new_repository() {
   local hash_algo=$6
   local autotagging=$7
   local garbage_collectable=$8
+  local configure_apache=$9
 
   # other configurations
   local spool_dir="/var/spool/cvmfs/${name}"
@@ -1975,17 +1976,18 @@ CVMFS_AUTO_GC=true
 EOF
   fi
 
-  # make sure that the config file does not exist, yet
-  remove_apache_config_file "cvmfs.${name}.conf" || true
+  if [ $configure_apache -eq 1 ]; then
+    # make sure that the config file does not exist, yet
+    remove_apache_config_file "cvmfs.${name}.conf" || true
 
-  create_apache_config_file "cvmfs.${name}.conf" << EOF
+    create_apache_config_file "cvmfs.${name}.conf" << EOF
 # Created by cvmfs_server.  Don't touch.
 EOF
 
-  # ONLY FOR LOCAL UPSTREAM
-  if is_local_upstream $upstream; then
-    local repository_dir=$(get_upstream_config $upstream)
-    create_apache_config_file "cvmfs.${name}.conf" << EOF
+    # ONLY FOR LOCAL UPSTREAM
+    if is_local_upstream $upstream; then
+      local repository_dir=$(get_upstream_config $upstream)
+      create_apache_config_file "cvmfs.${name}.conf" << EOF
 KeepAlive On
 # Translation URL to real pathname
 Alias /cvmfs/$name ${repository_dir}
@@ -2008,6 +2010,7 @@ Alias /cvmfs/$name ${repository_dir}
     ExpiresByType application/x-cvmfs "access plus 2 minutes"
 </Directory>
 EOF
+    fi
   fi
 
   cat > $client_conf << EOF

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2579,15 +2579,16 @@ mkfs() {
 
   # create system-wide configuration
   echo -n "Creating Configuration Files... "
-  create_config_files_for_new_repository "$name"        \
-                                         "$upstream"    \
-                                         "$stratum0"    \
-                                         "$cvmfs_user"  \
-                                         "$unionfs"     \
-                                         "$hash_algo"   \
-                                         "$autotagging" \
-                                         "$garbage_collectable" || die "fail"
-  if is_local_upstream $upstream; then
+  create_config_files_for_new_repository "$name"                \
+                                         "$upstream"            \
+                                         "$stratum0"            \
+                                         "$cvmfs_user"          \
+                                         "$unionfs"             \
+                                         "$hash_algo"           \
+                                         "$autotagging"         \
+                                         "$garbage_collectable" \
+                                         "$configure_apache" || die "fail"
+  if is_local_upstream $upstream && [ $configure_apache -eq 1 ]; then
     reload_apache > /dev/null
   fi
   echo "done"
@@ -2817,7 +2818,7 @@ CVMFS_AUTO_GC=true
 EOF
   fi
 
-  if is_local_upstream $upstream; then
+  if is_local_upstream $upstream && [ $configure_apache -eq 1 ]; then
     create_apache_config_file "cvmfs.${alias_name}.conf" << EOF
 # Created by cvmfs_server.  Don't touch.
 $(cat_wsgi_config ${alias_name})
@@ -3040,7 +3041,8 @@ import() {
                                          "$unionfs"    \
                                          "sha1"        \
                                          "true"        \
-                                         "false" || die "fail!"
+                                         "false"       \
+                                         "$configure_apache" || die "fail!"
   echo "done"
 
   # import the old repository security keys
@@ -3054,8 +3056,8 @@ import() {
 
   # create storage
   echo -n "Creating CernVM-FS Repository Infrastructure... "
-  create_spool_area_for_new_repository $name || die "fail!"
-  reload_apache > /dev/null                  || die "fail!"
+  create_spool_area_for_new_repository $name               || die "fail!"
+  [ $configure_apache -eq 0 ] || reload_apache > /dev/null || die "fail!"
   echo "done"
 
   # load repository configuration file

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2033,8 +2033,11 @@ EOF
 remove_config_files() {
   local name=$1
   load_repo_config $name
-  if is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
-    remove_apache_config_file "cvmfs.${name}.conf"
+
+  local apache_conf_file_name="cvmfs.${name}.conf"
+  if is_local_upstream $CVMFS_UPSTREAM_STORAGE &&
+     has_apache_config_file "$apache_conf_file_name"; then
+    remove_apache_config_file "$apache_conf_file_name"
     reload_apache > /dev/null
   fi
   rm -rf /etc/cvmfs/repositories.d/$name

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2454,10 +2454,11 @@ mkfs() {
   local garbage_collectable=false
   local s3_config=""
   local keys_import_location
+  local configure_apache=1
 
   # parameter handling
   OPTIND=1
-  while getopts "w:u:o:mf:vga:zs:k:" option; do
+  while getopts "w:u:o:mf:vga:zs:k:p" option; do
     case $option in
       w)
         stratum0=$OPTARG
@@ -2491,6 +2492,9 @@ mkfs() {
       ;;
       k)
         keys_import_location=$OPTARG
+      ;;
+      p)
+        configure_apache=0
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -2671,12 +2675,13 @@ add_replica() {
   local upstream
   local owner
   local silence_httpd_warning=0
+  local configure_apache=1
   local enable_auto_gc=0
   local s3_config
 
   # optional parameter handling
   OPTIND=1
-  while getopts "o:u:n:w:azs:" option
+  while getopts "o:u:n:w:azs:p" option
   do
     case $option in
       u)
@@ -2699,6 +2704,9 @@ add_replica() {
       ;;
       s)
         s3_config=$OPTARG
+      ;;
+      p)
+        configure_apache=0
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -2904,10 +2912,11 @@ import() {
   local chown_backend=0
   local unionfs=
   local recreate_whitelist=0
+  local configure_apache=1
 
   # parameter handling
   OPTIND=1
-  while getopts "w:o:c:u:k:lsmgf:r" option; do
+  while getopts "w:o:c:u:k:lsmgf:rp" option; do
     case $option in
       w)
         stratum0=$OPTARG
@@ -2941,6 +2950,9 @@ import() {
       ;;
       r)
         recreate_whitelist=1
+      ;;
+      p)
+        configure_apache=0
       ;;
       ?)
         shift $(($OPTIND-2))

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -744,6 +744,16 @@ remove_apache_config_file() {
 }
 
 
+# check if an apache configuration file exists. This looks in the appropriate
+# place, depending on the installed apache version.
+has_apache_config_file() {
+  local file_name=$1
+  local conf_path
+  conf_path="$(get_apache_conf_path)/${file_name}"
+  [ -f $conf_path ]
+}
+
+
 get_fd_modes() {
   local path=$1
   lsof -Fan 2>/dev/null | grep -B1 -e "^n$path" | grep -e '^a.*'

--- a/test/common/mock_services/http_server.py
+++ b/test/common/mock_services/http_server.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+import SimpleHTTPServer
+import SocketServer
+import sys
+import os
+from optparse import OptionParser
+
+parser = OptionParser()
+parser.add_option("-p", "--port", dest="http_port", action="store", type="int",
+                  help="port number to be bound to", metavar="PORT")
+parser.add_option("-r", "--root", dest="docroot", action="store", type="string",
+                  help="directory to be served", metavar="DOCROOT")
+
+(options, args) = parser.parse_args()
+
+if not options.docroot or not options.http_port:
+    parser.print_help()
+    sys.exit(1)
+
+print "changing directory to" , options.docroot
+os.chdir(options.docroot)
+
+print "start serving..."
+handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+httpd = SocketServer.TCPServer(("", options.http_port), handler)
+httpd.serve_forever()

--- a/test/src/607-noapache/main
+++ b/test/src/607-noapache/main
@@ -1,0 +1,156 @@
+cvmfs_test_name="Create Repository (S0 and S1) w/o Apache"
+cvmfs_test_autofs_on_startup=false
+
+get_http_response() {
+  local url="$1"
+  curl -I -s $url | head -n 1 || return 0
+}
+
+CVMFS_TEST_607_HTTP_PID=
+CVMFS_TEST_607_REPLICA_NAME=
+CVMFS_TEST_607_S1_MOUNTPOINT=
+cleanup() {
+  echo "running cleanup..."
+  [ -z $CVMFS_TEST_607_HTTP_PID ]      || sudo kill -9 $CVMFS_TEST_607_HTTP_PID
+  [ -z $CVMFS_TEST_607_S1_MOUNTPOINT ] || sudo umount $CVMFS_TEST_607_S1_MOUNTPOINT
+  [ -z $CVMFS_TEST_607_REPLICA_NAME ]  || destroy_repo $CVMFS_TEST_607_REPLICA_NAME
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  src_location=$2
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local replica_name="${CVMFS_TEST_REPO}.replic"
+  local s1_mnt_point="$(pwd)/s1_mnt"
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  local http_logfile="$(pwd)/http.log"
+  local document_root="$(pwd)/docroot"
+
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "create the document root"
+  local s0_location=${document_root}/cvmfs/${CVMFS_TEST_REPO}
+  local s1_location=${document_root}/cvmfs/${replica_name}
+
+  mkdir -p $s0_location || return 1
+  mkdir -p $s1_location || return 2
+  touch ${document_root}/sentinel || return 3
+
+  echo -n "spawning a simple HTTP server (logging to $http_logfile)... "
+  local http_server="${src_location}/../../common/mock_services/http_server.py"
+  local http_pid=
+  local http_port=8888
+  local http_base_url="http://localhost:${http_port}"
+  local s0_http_address="${http_base_url}/cvmfs/${CVMFS_TEST_REPO}"
+  local s1_http_address="${http_base_url}/cvmfs/${replica_name}"
+
+  http_pid=$(run_background_service $http_logfile "$http_server -p $http_port -r $document_root")
+  CVMFS_TEST_607_HTTP_PID=$http_pid
+  echo "done (PID: $http_pid)"
+
+  echo -n "waiting for the server to come up..."
+  local timeout=10
+  while ! get_http_response ${http_base_url}/sentinel | grep "200 OK" > /dev/null && \
+        [ $timeout -gt 0 ]; do
+    echo -n "."
+    sleep 1
+    if ! kill -0 $http_pid > /dev/null 2>&1;then
+      echo " broken"
+      return 3
+    fi
+    timeout=$(( $timeout - 1 ))
+  done
+  if [ $timeout -eq 0 ]; then
+    echo " timeout"
+    return 3
+  else
+    echo " done"
+  fi
+
+  echo "create a repository without apache backend"
+  local s0_upstream="local,${s0_location}/data/txn,${s0_location}"
+  create_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER $logfile -w $s0_http_address \
+                                                         -u $s0_upstream     \
+                                                         -p || return $?
+
+  echo "check that apache doesn't have access to the new repository"
+  local bogus_apache_s0_url="http://localhost/cvmfs/${CVMFS_TEST_REPO}/.cvmfspublished"
+  local http_response=$(get_http_response $bogus_apache_s0_url)
+  echo "$http_response" | grep "200 OK" && return 4
+
+  echo "opening a new transaction"
+  start_transaction $CVMFS_TEST_REPO || return 5
+
+  echo "putting some stuff into the repository"
+  rm -fR ${repo_dir}/new_repository
+  cp_bin $repo_dir || return 6
+
+  echo "putting the same stuff in the reference directory"
+  cp_bin $reference_dir || return 7
+
+  local publish_1_log="publish_1.log"
+  echo "publishing transaction (logging into $publish_1_log)"
+  publish_repo $CVMFS_TEST_REPO > $publish_1_log 2>&1 || return 8
+
+  echo "compare reference and repository"
+  compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
+
+  echo "create a replication of the repository w/o apache"
+  local s1_upstream="local,${s1_location}/data/txn,${s1_location}"
+  CVMFS_TEST_607_REPLICA_NAME="$replica_name"
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $s0_http_address                       \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+                  -w $s1_http_address                    \
+                  -u $s1_upstream                        \
+                  -p || return 9
+
+  echo "snapshot the changes"
+  cvmfs_server snapshot $replica_name || return 10
+
+  echo "check that apache doesn't serve the Stratum 1"
+  local bogus_apache_s1_url="http://localhost/cvmfs/${replica_name}/.cvmfspublished"
+  local http_response=$(get_http_response $bogus_apache_s1_url)
+  echo "$http_response" | grep "200 OK" && return 11
+
+  echo "mount the stratum 1 for comparison"
+  CVMFS_TEST_607_S1_MOUNTPOINT=$s1_mnt_point
+  do_local_mount $s1_mnt_point $CVMFS_TEST_REPO $s1_http_address || return 12
+
+  echo "compare reference and stratum 1 mountpoint"
+  compare_directories $s1_mnt_point $reference_dir $CVMFS_TEST_REPO || return $?
+
+  echo "gracefully remove stratum0"
+  destroy_repo $CVMFS_TEST_REPO -p || return 13
+
+  echo "check that the stratum 0 storage is still there"
+  [ -d $s0_location ] || return 14
+
+  echo "import just deleted stratum 0"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -u $s0_upstream     \
+                                                -w $s0_http_address \
+                                                -p || return 15
+
+  echo "check that apache doesn't serve the imported Stratum 0"
+  local http_response=$(get_http_response $bogus_apache_s0_url)
+  echo "$http_response" | grep "200 OK" && return 16
+
+  echo "compare reference and stratum 1 mountpoint"
+  compare_directories $s1_mnt_point $reference_dir $CVMFS_TEST_REPO || return $?
+
+  local publish_2_log="publish_2.log"
+  echo "create another transaction (publish log: $publish_2_log)"
+  start_transaction $CVMFS_TEST_REPO                  || return 17
+  cp_usrbin $repo_dir                                 || return 18
+  publish_repo $CVMFS_TEST_REPO > $publish_2_log 2>&1 || return 19
+
+  return 0
+}
+


### PR DESCRIPTION
This allows to skip the Apache configuration when running `cvmfs_server mkfs`, `import` or `add-replica`. All of those commands can be called with `-p` for that purpose. An integration test is added that uses a minimal python webserver as a backend instead of Apache.