### PR TITLE
Don't use localhost as default stratum 1 (CVM-892)

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1822,7 +1822,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
   string nfs_shared_dir = string(cvmfs::kDefaultCachedir);
   bool shared_cache = false;
   int64_t quota_limit = cvmfs::kDefaultCacheSizeMb;
-  string hostname = "localhost";
+  string hostname = "";
   string proxies = "";
   string fallback_proxies = "";
   string dns_server = "";


### PR DESCRIPTION
As a result, if `CVMFS_SERVER_URL` is empty, the error from the downloader is "malformed url" instead of "connection problem".  This leads to immediate failure as it is supposed to be (CVM-892).