### PR TITLE
FIX: treat HTTP 400 return codes as host failure (CVM-819)

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -202,9 +202,11 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
       if (header_line[i] == '5') {
         // 5XX returned by host
         info->error_code = kFailHostHttp;
-      } else if ((header_line.length() > i+2) && (header_line[i] == '4') &&
-                 (header_line[i+1] == '0') && (header_line[i+2] == '4'))
+      } else if ( (header_line.length() > i+2) && (header_line[i] == '4') &&
+                  (header_line[i+1] == '0') &&
+                  ((header_line[i+2] == '4') || (header_line[i+2] == '0')) )
       {
+        // 400: error from the GeoAPI module
         // 404: the stratum 1 does not have the newest files
         info->error_code = kFailHostHttp;
       } else {

--- a/test/common/mock_services/http_400.sh
+++ b/test/common/mock_services/http_400.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+PORT=$1
+
+tmpfile=$(mktemp /tmp/cvmfs-test.XXXXX)
+rm -f $tmpfile
+mkfifo $tmpfile
+trap "rm -f $tmpfile" HUP INT QUIT TERM EXIT
+while true; do
+  cat $tmpfile | nc -l localhost $PORT | (
+    while read; do
+      line=$(echo $REPLY | sed 's/[^A-Za-z0-9/*:._ -]//g')
+      [ "x$line" = "x" ] && break;
+    done
+    echo -en "HTTP/1.1 400 Bad Request\r\n\r\n" > $tmpfile
+  )
+done;
+rm -f $tmpfile

--- a/test/src/065-http-400/main
+++ b/test/src/065-http-400/main
@@ -1,0 +1,34 @@
+
+cvmfs_test_name="Probing host failover on HTTP 400"
+
+cvmfs_run_test() {
+  logfile=$1
+  src_location=$2
+
+  ${src_location}/../../common/mock_services/http_400.sh 9090 &
+  local http_server_pid=$!
+  trap "kill $http_server_pid" EXIT HUP INT TERM
+
+  sudo cat << EOF > /etc/cvmfs/config.d/grid.cern.ch.conf
+CVMFS_SERVER_URL="http://localhost:9090/cvmfs/grid.cern.ch;http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch"
+CVMFS_USE_GEOAPI=no
+EOF
+  cvmfs_mount grid.cern.ch \
+    "CVMFS_HTTP_PROXY='DIRECT;DIRECT'" || return 1
+
+  no_host_failover="$(get_internal_value grid.cern.ch download.n_host_failover)"
+  no_proxy_failover="$(get_internal_value grid.cern.ch download.n_proxy_failover)"
+
+  if [ "x$no_host_failover" != "x1" ]; then
+    echo "number of host failovers: $no_host_failover, expected: 1"
+    return 10
+  fi
+
+  if [ "x$no_proxy_failover" != "x0" ]; then
+    echo "number of proxy failovers: $no_proxy_failover, expected: 0"
+    return 20
+  fi
+
+  return 0
+}
+

--- a/test/test_functions
+++ b/test/test_functions
@@ -1889,3 +1889,10 @@ remove_local_mount() {
   sudo umount $mountpoint
   rm -fR $cache $mountpoint
 }
+
+get_internal_value() {
+  local repo=$1
+  local key=$2
+  
+  echo $(sudo cvmfs_talk -i $repo internal affairs | grep "^$key" | cut -d\| -f2)
+}


### PR DESCRIPTION
The Geo-API can return a 400 response code, which should trigger a host fail-over and not a proxy fail-over.  Integration test and mock HTTP server included.