### PR TITLE
FIX: use timezone variable in T_Util.RfcTimestamp

### DIFF
--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -792,7 +792,7 @@ TEST_F(T_Util, RfcTimestamp) {
   time_t time1 = time(NULL);
   string str = RfcTimestamp();
   strptime(str.c_str(), format, &tm);
-  time_t time2 = mktime(&tm);
+  time_t time2 = mktime(&tm) - timezone;
   EXPECT_GT(2, time2 - time1);
   setlocale(LC_TIME, curr_locale);
 }

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -793,6 +793,9 @@ TEST_F(T_Util, RfcTimestamp) {
   string str = RfcTimestamp();
   strptime(str.c_str(), format, &tm);
   time_t time2 = mktime(&tm) - timezone;
+  if (tm.tm_isdst > 0) {
+    time2 -= 3600;
+  }
   EXPECT_GT(2, time2 - time1);
   setlocale(LC_TIME, curr_locale);
 }


### PR DESCRIPTION
The (I hope) last fix for this test. Navigating through the documentation and the own time.h file I've seen there is a variable called timezone that represents the seconds of difference with respect to GMT, which is exactly what was left in the test.

Tested on the ARM fedora machine that was having problems with this issue, and in a standard SLC6. According to http://stackoverflow.com/a/5157134/2352087 this should be a platform-independent solution.