### PR TITLE
FIX: Install Path on Linux Defaults to /usr/local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,14 @@ else (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 #
+# Set install prefix to /usr by default.
+#
+if (LINUX AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set (CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "CVMFS install path default is /usr" FORCE)
+  message("Setting default install prefix to ${CMAKE_INSTALL_PREFIX} on Linux")
+endif (LINUX AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+#
 # check if we use Clang
 #
 if (CMAKE_CXX_COMPILER MATCHES ".*clang")


### PR DESCRIPTION
From the [CMake documentation](https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html), `CMAKE_INSTALL_PREFIX` defaults to `/usr/local` on Unix. However, we do not plan to relocate CernVM-FS on Linux. I've seen this behaviour on my Ubuntu machine.