### PR TITLE
Feature: Create Fresh Repository Signing Keys on `cvmfs_server import`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -275,7 +275,7 @@ Supported Commands:
                 [-l import legacy repo (2.0.x)] [-s show migration statistics]
                 [-f union filesystem type] [-c file ownership (UID:GID)]
                 [-k path to keys] [-g chown backend] [-r recreate whitelist]
-                [-p no apache config]
+                [-p no apache config] [-t recreate repo key and certificate]
                 <fully qualified repository name>
                 Imports an old CernVM-FS repository into a fresh 2.1.x repo
   publish       [-p pause for tweaks] [-n manual revision number] [-v verbose]

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3037,6 +3037,19 @@ import() {
     [ $chown_backend -ne 0 ] || [ x"$cvmfs_user" = x"$(stat -c%U $item)" ] || die "$item not owned by $cvmfs_user"
   done
 
+  # check availability of repository signing key and certificate
+  local keys="$public_key"
+  if [ $recreate_repo_key -eq 0 ]; then
+    if [ ! -f ${keys_location}/${private_key} ] || \
+       [ ! -f ${keys_location}/${certificate} ]; then
+      die "repository signing key or certificate not found (use -t maybe?)"
+    fi
+    keys="$keys $private_key $certificate"
+  else
+    [ $recreate_whitelist -ne 0 ] || die "using -t implies whitelist recreation (use -r maybe?)"
+  fi
+
+  # check whitelist expiry date
   if [ $recreate_whitelist -eq 0 ]; then
     [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"
     local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
@@ -3064,7 +3077,6 @@ import() {
 
   # import the old repository security keys
   echo -n "Importing the given key files... "
-  keys="$private_key $certificate $public_key"
   if [ -f ${keys_location}/${master_key} ]; then
     keys="$keys $master_key"
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3103,6 +3103,19 @@ import() {
     echo "done"
   fi
 
+  # creating a new repository signing key if requested
+  if [ $recreate_repo_key -ne 0 ]; then
+    echo -n "Creating new repository signing key... "
+    local manifest_url="${CVMFS_STRATUM0}/.cvmfspublished"
+    local unsigned_manifest="${CVMFS_SPOOL_DIR}/tmp/unsigned_manifest"
+    create_cert $name $CVMFS_USER                     || die "fail (certificate creation)!"
+    get_item $name $manifest_url | \
+      strip_manifest_signature - > $unsigned_manifest || die "fail (manifest download)!"
+    chown $CVMFS_USER $unsigned_manifest              || die "fail (manifest chown)!"
+    sign_manifest $name $unsigned_manifest            || die "fail (manifest resign)!"
+    echo "done"
+  fi
+
   # recreate whitelist if requested
   if [ $recreate_whitelist -ne 0 ]; then
     echo -n "Recreating whitelist... "

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2927,10 +2927,11 @@ import() {
   local unionfs=
   local recreate_whitelist=0
   local configure_apache=1
+  local recreate_repo_key=0
 
   # parameter handling
   OPTIND=1
-  while getopts "w:o:c:u:k:lsmgf:rp" option; do
+  while getopts "w:o:c:u:k:lsmgf:rpt" option; do
     case $option in
       w)
         stratum0=$OPTARG
@@ -2967,6 +2968,9 @@ import() {
       ;;
       p)
         configure_apache=0
+      ;;
+      t)
+        recreate_repo_key=1
       ;;
       ?)
         shift $(($OPTIND-2))

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1643,6 +1643,16 @@ sign_manifest() {
 }
 
 
+# this strips both the attached signature block and the certificate hash from
+# an already signed manifest file and prints the result to stdout
+strip_manifest_signature() {
+  local signed_manifest="$1"
+  # print lines starting with a capital letter (except X for the certificate)
+  # and stop as soon as we find the signature delimiter '--'
+  awk '/^[A-WY-Z]/ {print $0}; /--/ {exit}' $signed_manifest
+}
+
+
 check_upstream_validity() {
   local upstream=$1
   local silent=0

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -318,6 +318,16 @@ cvmfs_run_test() {
   echo "importing repository recreating repo signing keys and create a fresh whitelist"
   import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -r -t || return 45
 
+  echo "open transaction to change something"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository (same as a bit up)"
+  change_some_files_in $repo_dir || return $?
+
+  local publish3_log="publish3.log"
+  echo "creating CVMFS snapshot (log: $publish3_log)"
+  publish_repo $CVMFS_TEST_REPO > $publish3_log 2>&1 || return $?
+
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir || return $?
 

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -278,7 +278,7 @@ cvmfs_run_test() {
 
   local publish2_log="publish2.log"
   echo "creating CVMFS snapshot (log: $publish2_log)"
-  publish_repo $CVMFS_TEST_REPO > $publish_log 2>&1 || return $?
+  publish_repo $CVMFS_TEST_REPO > $publish2_log 2>&1 || return $?
 
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir || return $?

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -286,5 +286,43 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
+  # ============================================================================
+
+  echo "removing repository again"
+  destroy_repo $CVMFS_TEST_REPO || return 37
+
+  echo "repair the tampered whitelist"
+  cp .cvmfswhitelist.bak ${repo_backend}/$CVMFS_TEST_REPO/.cvmfswhitelist || return 38
+
+  echo "planting the repository again"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain || return $?
+
+  echo "removing the repository signing key and certificate"
+  sudo rm -f /etc/cvmfs/keys/${CVMFS_TEST_REPO}.key || return 39
+  sudo rm -f /etc/cvmfs/keys/${CVMFS_TEST_REPO}.crt || return 40
+
+  echo "importing repository (should fail due to missing repo signing key)"
+  local import_log_5="import_5.log"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER > $import_log_5 2>&1 && return 41
+
+  echo "check error messages"
+  cat $import_log_5 | grep 'repository signing key or certificate not found' || return 42
+
+  echo "importing repository recreating the repo signing key (should fail due to non-explicit whitelist rewrite)"
+  local import_log_6="import_6.log"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -t > $import_log_6 2>&1 && return 43
+
+  echo "check error messages"
+  cat $import_log_6 | grep 'implies whitelist recreation' || return 44
+
+  echo "importing repository recreating repo signing keys and create a fresh whitelist"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -r -t || return 45
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
   return 0
 }


### PR DESCRIPTION
This implements [a feature request](https://sft.its.cern.ch/jira/browse/CVM-865) from @DrDaveD. It allows to create a fresh repository signing key and an associated certificate on `cvmfs_server import` like so:

```bash
cvmfs_server import -r -t atlas.cern.ch
```

Both switches are required for that to work `-t` is enabling the fresh creation of repository signing key and certificate while `-r` will rewrite the repository's whitelist. Note that `-r` can also be used alone (it was already implemented), for example if an expired whitelist needs to be imported. Both cases require the repository's masterkey naturally.

I didn't write a completely new integration test but extended 591 for that purpose.