### PR TITLE
FIX: Check autofs Before Opening Transaction

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3815,6 +3815,9 @@ transaction() {
   names=$(get_or_guess_multiple_repository_names $@)
   check_multiple_repository_existence "$names"
 
+  # sanity checks
+  check_autofs_on_cvmfs && die "Autofs on /cvmfs has to be disabled"
+
   # go through the repositories
   for name in $names; do
 


### PR DESCRIPTION
This adds a check for enabled autofs on `/cvmfs` before trying to open a transaction with `cvmfs_server transaction`. Otherwise the (potential) `CVMFS_AUTO_REPAIR_MOUNTPOINT` feature fails with an unspecific error message. Let alone that autofs anyway needs to be switched off for `/cvmfs` on the server.