### PR TITLE
Add `cvmfs_config killall` command

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -134,7 +134,7 @@ cvmfs_config_usage() {
  echo "  reload [-c | <repository>]"
  echo "  umount"
  echo "  wipecache"
- echo "  killall"
+ echo "  killall [-l(azy unmount)] [-k(ill cvmfs user sessions)]"
  echo "  bugreport"
 }
 
@@ -1093,6 +1093,7 @@ cvmfs_config_fsck() {
 
 
 cvmfs_umount() {
+  local silent=$1
   local mount_list
   mount_list=`list_mounts | awk '{print $3}'`
 
@@ -1101,14 +1102,16 @@ cvmfs_umount() {
   local m
   for m in $mount_list
   do
-    echo -n "Unmounting ${m}: "
+    [ "x$silent" != "x" ] || echo -n "Unmounting ${m}: "
     umount $m 2>/dev/null
     if [ $? -ne 0 ]; then
       RETVAL=1
-      echo "Failed!"
-      $fuser -m -a -v $m
+      if [ "x$silent" != "x" ]; then
+        echo "Failed!"
+        $fuser -m -a -v $m
+      fi
     else
-      echo "OK"
+      [ "x$silent" != "x" ] || echo "OK"
     fi
   done
 
@@ -1147,15 +1150,11 @@ cvmfs_killall() {
   echo "OK"
 
   echo -n "Unmounting stale mount points... "
-  mount_list=`list_mounts | awk '{print $3}'`
-  for m in $mount_list; do
-    umount $m 2>/dev/null
-    if [ $? -ne 0 ]; then
-      echo "Failed!"
-      $fuser -m -a -v $m
-      return 1
-    fi
-  done
+  cvmfs_umount silent
+  if [ $? -ne 0 ]; then
+    echo "Failed!"
+    return 1
+  fi
   echo "OK"
 
   echo -n "Cleaning up run-time variable data... "
@@ -1959,7 +1958,7 @@ case "$1" in
       echo "root privileges required"
       exit 1
     fi
-    cvmfs_killall
+    cvmfs_killall $@
     RETVAL=$?
     ;;
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -134,6 +134,7 @@ cvmfs_config_usage() {
  echo "  reload [-c | <repository>]"
  echo "  umount"
  echo "  wipecache"
+ echo "  killall"
  echo "  bugreport"
 }
 
@@ -1115,6 +1116,63 @@ cvmfs_umount() {
 }
 
 
+cvmfs_killall() {
+  local pid=$$
+
+  echo -n "Terminating cvmfs_config processes... "
+  local config_pids=$(pgrep -x cvmfs_config)
+  other_config_pids=
+  for p in $config_pids; do
+    if [ $p -ne $pid ]; then
+      other_config_pids="$p $other_config_pids"
+    fi
+  done
+  if [ "x$other_config_pids" != "x" ]; then
+    kill -s KILL $other_config_pids
+    waitfor cvmfs_config 10
+    if [ $? -ne 0 ]; then
+      echo "Failed!"
+      return 1
+    fi
+  fi
+  echo "OK"
+
+  echo -n "Terminating cvmfs2 processes... "
+  killall -q -KILL ${INSTALL_BASE}/bin/cvmfs2
+  waitfor cvmfs2 10
+  if [ $? -ne 0 ]; then
+    echo "Failed!"
+    return 1
+  fi
+  echo "OK"
+
+  echo -n "Unmounting stale mount points... "
+  mount_list=`list_mounts | awk '{print $3}'`
+  for m in $mount_list; do
+    umount $m 2>/dev/null
+    if [ $? -ne 0 ]; then
+      echo "Failed!"
+      $fuser -m -a -v $m
+      return 1
+    fi
+  done
+  echo "OK"
+
+  echo -n "Cleaning up run-time variable data... "
+  rm -rf /var/run/cvmfs/*
+  echo "OK"
+
+  $pidof automount > /dev/null
+  if [ $? -eq 0 ]; then
+    echo -n "Reloading autofs... "
+    reload_service autofs
+    echo "OK"
+  fi
+
+  return 0
+}
+
+
 cvmfs_bugreport() {
   tmpdir=`mktemp -d -t cvmfs-bugreport.XXXXXX` || exit 1
   cd $tmpdir
@@ -1206,6 +1264,46 @@ cvmfs_bugreport() {
 die() {
   echo -e $1 >&2
   exit 1
+}
+
+
+waitfor() {
+  local process=$1
+  local timeout=$2
+  local pid=$$
+
+  local seconds=0
+  while [ $seconds -lt $timeout ]; do
+    local procs=$(pgrep -x $process)
+    local num_other_procs=0
+    for p in $procs; do
+      # Not myself
+      if [ $p -eq $pid ]; then
+        continue;
+      fi
+      # No zombies
+      local pstate=$(ps -p "$p" -o state=)
+      if echo "$pstate" | grep "Z"; then
+        continue
+      fi
+      # Not the CernVM instance of cvmfs
+      case $sys_arch in
+        Linux )
+          if [ "x$(cat /proc/$p/cmdline 2>/dev/null | head -c1)" = "x@" ]; then
+            continue
+          fi
+        ;;
+      esac
+      num_other_procs=$(($num_other_procs + 1))
+    done
+    if [ $num_other_procs -eq 0 ]; then
+      return 0
+    fi
+    sleep 1
+    seconds=$(($seconds + 1))
+  done
+
+  return 1
 }
 
 
@@ -1853,6 +1951,15 @@ case "$1" in
     fi
     shift 1
     cvmfs_reload -c
+    RETVAL=$?
+    ;;
+
+  killall)
+    if [ `id -u` -ne 0 ]; then
+      echo "root privileges required"
+      exit 1
+    fi
+    cvmfs_killall
     RETVAL=$?
     ;;
 

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -1,0 +1,20 @@
+
+cvmfs_test_name="Killing all cvmfs2 instances"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  sudo cvmfs_config killall || return 1
+
+  cvmfs_mount grid.cern.ch || return 10
+  cvmfs_mount atlas.cern.ch || return 11
+  sudo cvmfs_config reload &
+
+  # Let cvmfs_config reload start
+  sleep 2
+
+  sudo cvmfs_config killall || return 20
+
+  return 0
+}
+


### PR DESCRIPTION
This is supposed to get out of stuck situations, e.g. when `cvmfs_config reload` hangs.  It kills all `cvmfs_config` and `cvmfs2` processes and clears /var/run/cvmfs/

@traylenator @DrDaveD: I'd appreciate a second look on the bash code.