### PR TITLE
FIX: SLES 11 Docker Recipe

### DIFF
--- a/ci/docker/sles11_x86_64/build_internal.sh
+++ b/ci/docker/sles11_x86_64/build_internal.sh
@@ -39,10 +39,14 @@ zypper --non-interactive      \
        refresh
 
 echo "downloading necessary RPMs..."
+# Workaround: Some versions of zypper report an error even if the download-only
+#             job finished successfully. We ignore this and hope for follow-up
+#             errors in case something _actually_ went wrong.
+#   Bugzilla: https://bugzilla.opensuse.org/show_bug.cgi?id=956480
 zypper --non-interactive       \
        --root ${DESTINATION}   \
        install --download-only \
-       sles-release zypper
+       sles-release zypper || true
 
 echo "copying zypper cache for later re-build..."
 zypper_cache="${DESTINATION}/var/cache/zypp/packages"

--- a/ci/run_on_docker.sh
+++ b/ci/run_on_docker.sh
@@ -12,7 +12,7 @@ SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
 if [ $# -lt 4 ]; then
   echo "Usage: $0 <workspace>" "<docker image name>"
-  echo "<build script invocation with OPTIONAL parameters>"
+  echo "<build script invocation>"
   echo
   echo "This script runs a build script inside a docker container. The docker "
   echo "image is generated on demand - i.e. look into ci/docker for available"
@@ -104,17 +104,13 @@ elif [ $(image_creation $image_name) -lt $(image_recipe $container_dir) ]; then
   bootstrap_image "$image_name" "$container_dir"
 fi
 
-# parse the command line arguments (keep quotation marks)
-# Note: By convention the build scripts are called like this:
-#       ./script.sh <source location> <build location> <optional parameters>
-#       Source and build location are dpendent on the docker environment and
-#       are appended here accordingly
 build_script="$1"
 shift 1
 
 [ -f $build_script ] || die "build script $build_script not found"
 [ -x $build_script ] || die "build script $build_script not executable"
 
+# parse the command line arguments (keep quotation marks)
 while [ $# -gt 0 ]; do
   if echo "$1" | grep -q "[[:space:]]"; then
     args="$args \"$1\""
@@ -127,7 +123,7 @@ done
 # run provided script inside the docker container
 uid=$(id -u)
 gid=$(id -g)
-echo "++ $docker_build_script $args"
+echo "++ $build_script $args"
 sudo docker run --volume=${CVMFS_WORKSPACE}:${CVMFS_WORKSPACE}        \
                 --volume=/etc/passwd:/etc/passwd                      \
                 --volume=/etc/group:/etc/group                        \


### PR DESCRIPTION
Turns out that `zypper` [contains a bug](https://bugzilla.opensuse.org/show_bug.cgi?id=956480) and reports an error code when running in download-only mode. It was fixed recently, but we need to work around it. Furthermore this contains minor fixes for the adaptions done to `run_on_docker.sh`.