### PR TITLE
Refactor: DRY up Some Minor Things in cvmfs_server

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -38,6 +38,8 @@ CVMFS_UPDATEGEO_URL="http://geolite.maxmind.com/download/geoip/database/GeoLiteC
 CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo"
 CVMFS_UPDATEGEO_DB=${CVMFS_UPDATEGEO_DIR}/GeoLiteCity.dat
 
+DEFAULT_LOCAL_STORAGE="/srv/cvmfs"
+
 
 # setup server hooks: no-ops (overrideable by /etc/cvmfs/cvmfs_server_hooks.sh)
 transaction_before_hook() { :; }
@@ -1393,14 +1395,6 @@ get_or_guess_multiple_repository_names() {
 foreclose_legacy_cvmfs() {
   local found_something=0
 
-  # This can potentially prevent 2.0 to 2.1 migration
-  #if [ $(ls /srv/cvmfs/ 2>/dev/null | wc -l) -eq 1 ]; then
-  #  if [ -d /srv/cvmfs/*/pub ] || [ -d /srv/cvmfs/*/shadow ]; then
-  #    echo "found legacy repo structure in /srv/cvmfs" 1>&2
-  #    found_something=1
-  #  fi
-  #fi
-
   if [ -f /etc/cvmfs/server.conf ] || [ -f /etc/cvmfs/replica.conf ]; then
     echo "found legacy configuration files in /etc/cvmfs" 1>&2
     found_something=1
@@ -1766,7 +1760,8 @@ make_upstream() {
 
 make_local_upstream() {
   local repo_name=$1
-  make_upstream "local" "/srv/cvmfs/${repo_name}/data/txn" "/srv/cvmfs/${repo_name}"
+  local repo_storage="${DEFAULT_LOCAL_STORAGE}/${repo_name}"
+  make_upstream "local" "${repo_storage}/data/txn" "$repo_storage"
 }
 
 make_s3_upstream() {

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1992,6 +1992,45 @@ Alias /cvmfs/$name/api /var/www/wsgi-scripts/cvmfs-api.wsgi/$name
 "
 }
 
+
+# creates a standard Apache configuration file for a repository
+#
+# @param name         the name of the repository to be served
+# @param storage_dir  the storage location of the repository
+# @param with_wsgi    wether or not to enable WSGI api functions
+create_apache_config_for_repository() {
+  local name=$1
+  local storage_dir=$2
+  local with_wsgi="$3"
+
+  create_apache_config_file "cvmfs.${name}.conf" << EOF
+# Created by cvmfs_server.  Don't touch.
+$(cat_wsgi_config $name $with_wsgi)
+
+KeepAlive On
+# Translation URL to real pathname
+Alias /cvmfs/${name} ${storage_dir}
+<Directory "${storage_dir}">
+    Options -MultiViews
+    AllowOverride Limit
+    $(get_compatible_apache_allow_from_all_config)
+
+    EnableMMAP Off
+    EnableSendFile Off
+
+    AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist
+
+    Header unset Last-Modified
+    FileETag None
+
+    ExpiresActive On
+    ExpiresDefault "access plus 3 days"
+    ExpiresByType text/html "access plus 5 minutes"
+    ExpiresByType application/x-cvmfs "access plus 2 minutes"
+</Directory>
+EOF
+}
+
 # puts all configuration files in place that are need for a stratum0 repository
 #
 # @param name        the name of the repository
@@ -2050,41 +2089,11 @@ CVMFS_AUTO_GC=true
 EOF
   fi
 
-  if [ $configure_apache -eq 1 ]; then
+  if [ $configure_apache -eq 1 ] && is_local_upstream $upstream; then
+    local repository_dir=$(get_upstream_config $upstream)
     # make sure that the config file does not exist, yet
     remove_apache_config_file "cvmfs.${name}.conf" || true
-
-    create_apache_config_file "cvmfs.${name}.conf" << EOF
-# Created by cvmfs_server.  Don't touch.
-EOF
-
-    # ONLY FOR LOCAL UPSTREAM
-    if is_local_upstream $upstream; then
-      local repository_dir=$(get_upstream_config $upstream)
-      create_apache_config_file "cvmfs.${name}.conf" << EOF
-KeepAlive On
-# Translation URL to real pathname
-Alias /cvmfs/$name ${repository_dir}
-<Directory "${repository_dir}">
-    Options -MultiViews
-    AllowOverride Limit
-    $(get_compatible_apache_allow_from_all_config)
-
-    EnableMMAP Off
-    EnableSendFile Off
-
-    AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist
-
-    Header unset Last-Modified
-    FileETag None
-
-    ExpiresActive On
-    ExpiresDefault "access plus 3 days"
-    ExpiresByType text/html "access plus 5 minutes"
-    ExpiresByType application/x-cvmfs "access plus 2 minutes"
-</Directory>
-EOF
-    fi
+    create_apache_config_for_repository $name $repository_dir
   fi
 
   cat > $client_conf << EOF
@@ -2897,33 +2906,7 @@ EOF
   fi
 
   if is_local_upstream $upstream && [ $configure_apache -eq 1 ]; then
-    create_apache_config_file "cvmfs.${alias_name}.conf" << EOF
-# Created by cvmfs_server.  Don't touch.
-$(cat_wsgi_config ${alias_name})
-
-KeepAlive On
-# Translation URL to real pathname
-Alias /cvmfs/$alias_name ${storage_dir}
-<Directory "${storage_dir}">
-    Options -MultiViews
-    AllowOverride Limit
-    $(get_compatible_apache_allow_from_all_config)
-
-    EnableMMAP Off
-    EnableSendFile Off
-
-    AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist
-
-    Header unset Last-Modified
-    FileETag None
-
-    ExpiresActive On
-    ExpiresDefault "access plus 3 days"
-    ExpiresByType text/html "access plus 5 minutes"
-    ExpiresByType application/x-cvmfs "access plus 2 minutes"
-</Directory>
-EOF
-
+    create_apache_config_for_repository $alias_name $storage_dir "with wsgi"
     reload_apache > /dev/null
   fi
   echo "done"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3034,7 +3034,7 @@ import() {
 
   # default values
   [ x"$stratum0" = x ] && stratum0="$(mangle_local_cvmfs_url $name)"
-  [ x"$upstream" = x ] && upstream=$(make_upstream "local" "/srv/cvmfs/$name/data/txn" "/srv/cvmfs/$name")
+  [ x"$upstream" = x ] && upstream=$(make_local_upstream $name)
   [ x"$unionfs"  = x ] && unionfs="$(get_available_union_fs)"
 
   local private_key="${name}.key"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1973,8 +1973,12 @@ migrate_legacy_dirtab() {
 # sends wsgi configuration to stdout
 #
 # @param name        the name of the repository
+# @param with_wsgi   if not set, this function is a NOOP
 cat_wsgi_config() {
   local name=$1
+  local with_wsgi="$2"
+
+  [ x"$with_wsgi" != x"" ] || return 0
   echo "# Enable api functions
 WSGIPythonPath /usr/share/cvmfs-server/webapi
 Alias /cvmfs/$name/api /var/www/wsgi-scripts/cvmfs-api.wsgi/$name


### PR DESCRIPTION
This DRYs up a couple of things in \`cvmfs_server\`. I need those changes for the implementation of [CVM-860](https://sft.its.cern.ch/jira/browse/CVM-860) but want to keep them out of the way, to keep the change set sleek and readable.