### PR TITLE
Allow for configuration of dns timeout and retry (CVM-875)

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1805,6 +1805,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   unsigned timeout = cvmfs::kDefaultTimeout;
   unsigned timeout_direct = cvmfs::kDefaultTimeout;
   unsigned low_speed_limit = cvmfs::kDefaultLowSpeedLimit;
+  unsigned dns_timeout_ms = download::DownloadManager::kDnsDefaultTimeoutMs;
+  unsigned dns_retries = download::DownloadManager::kDnsDefaultRetries;
   unsigned proxy_reset_after = 0;
   unsigned host_reset_after = 0;
   unsigned max_retries = 1;
@@ -1894,9 +1896,13 @@ static int Init(const loader::LoaderExports *loader_exports) {
   if (cvmfs::options_manager_->GetValue("CVMFS_MAX_RETRIES", &parameter))
     max_retries = String2Uint64(parameter);
   if (cvmfs::options_manager_->GetValue("CVMFS_BACKOFF_INIT", &parameter))
-    backoff_init = String2Uint64(parameter)*1000;
+    backoff_init = String2Uint64(parameter) * 1000;
   if (cvmfs::options_manager_->GetValue("CVMFS_BACKOFF_MAX", &parameter))
-    backoff_max = String2Uint64(parameter)*1000;
+    backoff_max = String2Uint64(parameter) * 1000;
+  if (cvmfs::options_manager_->GetValue("CVMFS_DNS_TIMEOUT", &parameter))
+    dns_timeout_ms = String2Uint64(parameter) * 1000;
+  if (cvmfs::options_manager_->GetValue("CVMFS_DNS_RETRIES", &parameter))
+    dns_retries = String2Uint64(parameter);
   if (cvmfs::options_manager_->GetValue("CVMFS_SEND_INFO_HEADER", &parameter) &&
       cvmfs::options_manager_->IsOn(parameter))
   {
@@ -2322,6 +2328,11 @@ static int Init(const loader::LoaderExports *loader_exports) {
   cvmfs::download_manager_->Init(cvmfs::kDefaultNumConnections, false,
       cvmfs::statistics_);
   cvmfs::download_manager_->SetHostChain(hostname);
+  if ((dns_timeout_ms != download::DownloadManager::kDnsDefaultTimeoutMs) ||
+      (dns_retries != download::DownloadManager::kDnsDefaultRetries))
+  {
+    cvmfs::download_manager_->SetDnsParameters(dns_retries, dns_timeout_ms);
+  }
   if (!dns_server.empty()) {
     cvmfs::download_manager_->SetDnsServer(dns_server);
   }

--- a/cvmfs/dns.cc
+++ b/cvmfs/dns.cc
@@ -392,8 +392,9 @@ void Resolver::ResolveMany(const vector<string> &names, vector<Host> *hosts) {
     host.deadline_ = time(NULL) + effective_ttl;
 
     if (host.status_ != kFailOk) {
-      LogCvmfs(kLogDns, kLogDebug, "failed to resolve %s - %d (%s)",
-               names[i].c_str(), host.status_, Code2Ascii(host.status_));
+      LogCvmfs(kLogDns, kLogDebug, "failed to resolve %s - %d (%s), ttl %u",
+               names[i].c_str(), host.status_, Code2Ascii(host.status_),
+               effective_ttl);
       (*hosts)[i] = host;
       continue;
     }

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -849,9 +849,8 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
     if (proxy_ptr->host.status() == dns::kFailOk) {
       curl_easy_setopt(info->curl_handle, CURLOPT_PROXY, info->proxy.c_str());
     } else {
-      // We know it can't work, don't even try to download: TODO(jblomer)
-      curl_easy_setopt(info->curl_handle, CURLOPT_PROXY, info->proxy.c_str());
-      // curl_easy_setopt(info->curl_handle, CURLOPT_PROXY, "http://$.");
+      // We know it can't work, don't even try to download
+      curl_easy_setopt(info->curl_handle, CURLOPT_PROXY, "0.0.0.0");
     }
   }
   curl_easy_setopt(curl_handle, CURLOPT_LOW_SPEED_LIMIT, opt_low_speed_limit_);
@@ -1435,7 +1434,7 @@ void DownloadManager::Init(const unsigned max_pool_handles,
     opt_ipv4_only_ = true;
   }
   resolver = dns::NormalResolver::Create(opt_ipv4_only_,
-                                         1 /* retries */, 3000 /* timeout */);
+    kDnsDefaultRetries, kDnsDefaultTimeoutMs);
   assert(resolver);
 
   // Parsing environment variables
@@ -1619,13 +1618,13 @@ void DownloadManager::SetDnsServer(const string &address) {
  */
 void DownloadManager::SetDnsParameters(
   const unsigned retries,
-  const unsigned timeout_sec)
+  const unsigned timeout_ms)
 {
   pthread_mutex_lock(lock_options_);
   delete resolver;
   resolver = NULL;
   resolver =
-    dns::NormalResolver::Create(opt_ipv4_only_, retries, timeout_sec*1000);
+    dns::NormalResolver::Create(opt_ipv4_only_, retries, timeout_ms);
   assert(resolver);
   pthread_mutex_unlock(lock_options_);
 }

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -306,6 +306,9 @@ class DownloadManager {
    */
   static const unsigned kMaxMemSize;
 
+  static const unsigned kDnsDefaultRetries = 1;
+  static const unsigned kDnsDefaultTimeoutMs = 3000;
+
   DownloadManager();
   ~DownloadManager();
 
@@ -316,7 +319,7 @@ class DownloadManager {
   Failures Fetch(JobInfo *info);
 
   void SetDnsServer(const std::string &address);
-  void SetDnsParameters(const unsigned retries, const unsigned timeout_sec);
+  void SetDnsParameters(const unsigned retries, const unsigned timeout_ms);
   void SetTimeout(const unsigned seconds_proxy, const unsigned seconds_direct);
   void GetTimeout(unsigned *seconds_proxy, unsigned *seconds_direct);
   void SetLowSpeedLimit(const unsigned low_speed_limit);

--- a/test/common/mock_services/silent_socket.py
+++ b/test/common/mock_services/silent_socket.py
@@ -27,6 +27,8 @@ def print_msg(msg):
 class SilentHandler(SocketServer.BaseRequestHandler):
 	def handle(self):
 		print_msg("(" + str(datetime.datetime.now()) + ") incoming connection: " + str(self.client_address))
+		data = self.request[0].strip()
+		print "   * " + data;
 		time.sleep(100000000)
 
 class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):

--- a/test/src/017-dnstimeout/main
+++ b/test/src/017-dnstimeout/main
@@ -2,12 +2,17 @@
 cvmfs_test_name="DNS Timeout"
 
 do_faulty_mount() {
+  local repo=$1
+  shift
+
   cvmfs_mount $repo \
+              "CVMFS_HTTP_PROXY=http://no-such-proxy.cern.ch:3128" \
               "CVMFS_CONFIG_REPOSITORY=" \
+              "CVMFS_USE_GEOAPI=no" \
               "CVMFS_DNS_SERVER=127.0.0.1" \
               "CVMFS_TIMEOUT=3" \
               "CVMFS_TIMEOUT_DIRECT=3" \
-              "CVMFS_MAX_RETRIES=0"
+              "CVMFS_MAX_RETRIES=0" $@
 }
 
 cvmfs_run_test() {
@@ -33,21 +38,41 @@ cvmfs_run_test() {
   echo "silent DNS server running as PID $server_pid"
 
   echo "trying to mount again with unresponsive DNS"
-  local seconds
-  seconds=$(stop_watch do_faulty_mount)
-  echo "timeout was $timeout seconds"
-
-  num_host=$(cvmfs_config showconfig $repo |grep CVMFS_SERVER_URL | tr \; \\n  | wc -l)
+  local milliseconds
+  milliseconds=$(stop_watch do_faulty_mount $repo)
+  echo "timeout was $milliseconds ms"
 
   # DNS Timeout for proxies is hard-coded to 2 attempts with 3 second timeout
   # for the first attempt and up to 6 seconds for the second attempt. In the
   # beginning, there is a single request to resolve all the proxies.
-  # Resolving the hosts is cut off by the CVMFS_TIMEOUT setting.
-  # Two extra seconds for measurement uncertainties.
-  local expected_max=$(($num_host*3 + 9 + 2))
-  if [ $seconds -gt $expected_max ]; then
-    echo "timeout was too long: $seconds (expected at most $expected_max)"
+  local expected_max=$(((9 + 5) * 1000))
+  local expected_min=$(((6 - 1) * 1000))
+  if [ $milliseconds -gt $expected_max ]; then
+    echo "timeout was too long: $milliseconds (expected at most $expected_max)"
     CVMFS_TIME_WARNING_FLAG=1
+  fi
+  if [ $milliseconds -lt $expected_min ]; then
+    echo "timeout was too short: $milliseconds (expected at leat $expected_min)"
+    retcode=19
+  fi
+  
+  echo "restarting autofs"
+  autofs_switch off || return 10
+  autofs_switch on  || return 11
+
+  echo "trying to mount again with unresponsive DNS and long timeout"
+  milliseconds=$(stop_watch do_faulty_mount $repo \
+    "CVMFS_DNS_TIMEOUT=20" "CVMFS_DNS_RETRIES=0")
+  echo "timeout was $milliseconds seconds"
+  expected_max=$(((20 + 5) * 1000))
+  expected_min=$(((20 - 1) * 1000))
+  if [ $milliseconds -gt $expected_max ]; then
+    echo "timeout was too long: $milliseconds (expected at most $expected_max)"
+    CVMFS_TIME_WARNING_FLAG=1
+  fi
+  if [ $milliseconds -lt $expected_min ]; then
+    echo "timeout was too short: $milliseconds (expected at least $expected_min)"
+    retcode=20
   fi
 
   echo "killing the mocked DNS server"


### PR DESCRIPTION
Introduces `CVMFS_DNS_RETRIES` and `CVMFS_DNS_TIMEOUT` (which are only affective for resolving proxies).  Contains also a fix to the download manager when a DNS name cannot be resolved.  Multiple fixes to the DNS timeout integration test.