### PR TITLE
Immediately pick up new catalogs after idle period (CVM-636)

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -673,6 +673,13 @@ void WritableCatalogManager::PrecalculateListings() {
 }
 
 
+void WritableCatalogManager::SetTTL(const uint64_t new_ttl) {
+  SyncLock();
+  reinterpret_cast<WritableCatalog *>(GetRootCatalog())->SetTTL(new_ttl);
+  SyncUnlock();
+}
+
+
 manifest::Manifest *WritableCatalogManager::Commit(
   const bool     stop_for_tweaks,
   const uint64_t manual_revision)

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -118,6 +118,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
    */
   void PrecalculateListings();
 
+  void SetTTL(const uint64_t new_ttl);
   manifest::Manifest *Commit(const bool     stop_for_tweaks,
                              const uint64_t manual_revision);
   void Balance() {

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -311,6 +311,11 @@ void WritableCatalog::SetRevision(const uint64_t new_revision) {
 }
 
 
+void WritableCatalog::SetTTL(const uint64_t new_ttl) {
+  database().SetProperty("TTL", new_ttl);
+}
+
+
 /**
  * Sets the content hash of the previous catalog revision.
  */

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -90,6 +90,7 @@ class WritableCatalog : public Catalog {
   void IncrementRevision();
   void SetRevision(const uint64_t new_revision);
   void SetPreviousRevision(const shash::Any &hash);
+  void SetTTL(const uint64_t new_ttl);
 
  protected:
   static const double kMaximalFreePageRatio   = 0.20;

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -285,6 +285,17 @@ class RemountFence : public SingleCopy {
 };
 RemountFence *remount_fence_;
 
+/**
+ * The thread that triggers the reload of the root catalog is informed through
+ * this pipe by the alarm signal handler when the TTL expires.
+ */
+int pipe_remount_trigger_[2];
+
+/**
+ * Triggers `RemountCheck()` when the repository TTL expires.
+ */
+pthread_t *thread_remount_trigger_ = NULL;
+
 
 unsigned GetMaxTTL() {
   pthread_mutex_lock(&lock_max_ttl_);
@@ -354,6 +365,10 @@ static void AlarmReload(int signal __attribute__((unused)),
                         void *context __attribute__((unused)))
 {
   atomic_cas32(&catalogs_expired_, 0, 1);
+  if (pipe_remount_trigger_[1] >= 0) {
+    char c = 'T';
+    WritePipe(pipe_remount_trigger_[1], &c, 1);
+  }
 }
 
 
@@ -460,6 +475,30 @@ static void RemountCheck() {
       catalogs_valid_until_ = time(NULL) + GetEffectiveTTL();
     }
   }
+}
+
+
+// TODO(jblomer): the remount functions need to move into a separate entity
+/**
+ * Gets triggered by the alarm timer to start `RemountCheck()`.  This can't
+ * be called from the alarm timer because of missing signal safety.
+ */
+static void *MainRemountTrigger(void *data) {
+  char c;
+  LogCvmfs(kLogCvmfs, kLogDebug, "starting remount trigger");
+  while (true) {
+    ReadPipe(pipe_remount_trigger_[0], &c, 1);
+    if (c == 'Q')
+      break;
+
+    // We don't need to call this if we are already draining the caches
+    if (!atomic_read32(&drainout_mode_)) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "trigger remount of idle mount point");
+      RemountCheck();
+    }
+  }
+  LogCvmfs(kLogCvmfs, kLogDebug, "stopping remount trigger");
+  return NULL;
 }
 
 
@@ -2499,6 +2538,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
     cvmfs::volatile_repository_ = true;
   }
 
+  cvmfs::pipe_remount_trigger_[0] = cvmfs::pipe_remount_trigger_[1] = -1;
   cvmfs::remount_fence_ = new cvmfs::RemountFence();
   auto_umount::SetMountpoint(*cvmfs::mountpoint_);
 
@@ -2513,6 +2553,7 @@ static void Spawn() {
   int retval;
 
   // Setup catalog reload alarm (_after_ fork())
+  MakePipe(cvmfs::pipe_remount_trigger_);
   atomic_init32(&cvmfs::maintenance_mode_);
   atomic_init32(&cvmfs::drainout_mode_);
   atomic_init32(&cvmfs::reload_critical_section_);
@@ -2532,6 +2573,12 @@ static void Spawn() {
   } else {
     cvmfs::catalogs_valid_until_ = cvmfs::kIndefiniteDeadline;
   }
+
+  cvmfs::thread_remount_trigger_ = reinterpret_cast<pthread_t *>(
+    smalloc(sizeof(pthread_t)));
+  retval = pthread_create(cvmfs::thread_remount_trigger_, NULL,
+                          cvmfs::MainRemountTrigger, NULL);
+  assert(retval == 0);
 
   cvmfs::pid_ = getpid();
   if (cvmfs::UseWatchdog() && g_monitor_ready) {
@@ -2569,6 +2616,16 @@ static string GetErrorMsg() {
 
 static void Fini() {
   signal(SIGALRM, SIG_IGN);
+  if (cvmfs::thread_remount_trigger_) {
+    char quit = 'Q';
+    WritePipe(cvmfs::pipe_remount_trigger_[1], &quit, 1);
+    pthread_join(*cvmfs::thread_remount_trigger_, NULL);
+    free(cvmfs::thread_remount_trigger_);
+    cvmfs::thread_remount_trigger_ = NULL;
+    ClosePipe(cvmfs::pipe_remount_trigger_);
+    cvmfs::pipe_remount_trigger_[0] = cvmfs::pipe_remount_trigger_[1] = -1;
+  }
+
   if (g_talk_ready) talk::Fini();
 
   // Must be before quota is stopped

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4304,6 +4304,9 @@ publish() {
     if [ "x$manual_revision" != "x" ]; then
       sync_command="$sync_command -v $manual_revision"
     fi
+    if [ "x$CVMFS_REPOSITORY_TTL" != "x" ]; then
+      sync_command="$sync_command -T $CVMFS_REPOSITORY_TTL"
+    fi
     if [ "x$CVMFS_GARBAGE_COLLECTION" = "xtrue" ]; then
       sync_command="$sync_command -g"
     fi

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -546,6 +546,10 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     params.max_concurrent_write_jobs = String2Uint64(*args.find('q')->second);
   }
 
+  if (args.find('T') != args.end()) {
+    params.ttl_seconds = String2Uint64(*args.find('T')->second);
+  }
+
   if (!CheckParams(params)) return 2;
 
   // Start spooler
@@ -604,6 +608,12 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   }
 
   sync->Traverse();
+
+  if (params.ttl_seconds > 0) {
+    LogCvmfs(kLogCvmfs, kLogStdout, "Setting repository TTL to %"PRIu64" s",
+             params.ttl_seconds);
+    catalog_manager.SetTTL(params.ttl_seconds);
+  }
 
   LogCvmfs(kLogCvmfs, kLogStdout, "Exporting repository manifest");
   UniquePtr<manifest::Manifest> manifest(mediator.Commit());

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -35,6 +35,7 @@ struct SyncParameters {
     avg_file_chunk_size(kDefaultAvgFileChunkSize),
     max_file_chunk_size(kDefaultMaxFileChunkSize),
     manual_revision(0),
+    ttl_seconds(0),
     max_concurrent_write_jobs(0),
     is_balanced(false),
     max_weight(kDefaultMaxWeight),
@@ -64,6 +65,7 @@ struct SyncParameters {
   size_t           avg_file_chunk_size;
   size_t           max_file_chunk_size;
   uint64_t         manual_revision;
+  uint64_t         ttl_seconds;
   uint64_t         max_concurrent_write_jobs;
   bool             is_balanced;
   unsigned         max_weight;
@@ -239,6 +241,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Optional('M', "minimum weight of the autocatalogs"));
     r.push_back(Parameter::Optional('V', "VOMS authz requirement "
                                          "(default: none)"));
+    r.push_back(Parameter::Optional('T', "Root catalog TTL in seconds"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/test/src/611-idleclient/main
+++ b/test/src/611-idleclient/main
@@ -1,0 +1,95 @@
+cvmfs_test_name="Idle client picking up new catalog version"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in_1() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  touch foo
+  touch bar
+  mkdir -p nested
+  touch nested/.cvmfscatalog
+  touch nested/more
+
+  popdir
+}
+
+produce_files_in_2() {
+  local working_dir=$1
+  pushdir $working_dir
+  touch nested/updated
+  popdir
+}
+
+TEST_611_MOUNTPOINT=""
+cleanup() {
+  if [ ! -z $TEST_611_MOUNTPOINT ]; then
+    echo -n "umounting ${TEST_611_MOUNTPOINT}... "
+    remove_local_mount $TEST_611_MOUNTPOINT && echo "done" || echo "fail"
+  fi
+}
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "updating TTL"
+  sudo sh -c "echo CVMFS_REPOSITORY_TTL=1 >> /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in_1 $repo_dir || return 1
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "set a trap for desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "create a local mount of the created repository"
+  TEST_611_MOUNTPOINT="$(pwd)/local_mount"
+  do_local_mount "$TEST_611_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO"     \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 4
+
+  stat $TEST_611_MOUNTPOINT/nested/updated
+  if [ $? -eq 0 ]; then
+    return 20
+  fi
+  stat $TEST_611_MOUNTPOINT/nested || return 25
+
+  echo "starting transaction to update repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "add new file"
+  produce_files_in_2 $repo_dir || return 1
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  local cache_dir="$(get_cache_directory $TEST_611_MOUNTPOINT)"
+  local kcache_timeout=$(sudo cvmfs_talk -p ${cache_dir}/${CVMFS_TEST_REPO}/cvmfs_io.${CVMFS_TEST_REPO} parameters | \
+    grep ^CVMFS_KCACHE_TIMEOUT= | cut -d= -f2 | awk '{print $1}')
+  # Add two seconds safety margin
+  local sleep_time=$((1 + $kcache_timeout + 2))
+  echo "sleeping $sleep_time seconds to let ttl and kernel caches expire"
+  sleep $sleep_time
+  stat $TEST_611_MOUNTPOINT/nested/updated
+  if [ $? -ne 0 ]; then
+    return 21
+  fi
+
+  return 0
+}
+

--- a/test/src/612-setttl/main
+++ b/test/src/612-setttl/main
@@ -1,0 +1,60 @@
+cvmfs_test_name="Setting non-standard repository TTL"
+cvmfs_test_autofs_on_startup=false
+
+TEST_612_MOUNTPOINT=""
+cleanup() {
+  if [ ! -z $TEST_612_MOUNTPOINT ]; then
+    echo -n "umounting ${TEST_612_MOUNTPOINT}... "
+    remove_local_mount $TEST_612_MOUNTPOINT && echo "done" || echo "fail"
+  fi
+}
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "set a trap for desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "create a local mount of the created repository"
+  TEST_612_MOUNTPOINT="$(pwd)/local_mount"
+  do_local_mount "$TEST_612_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO"     \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 4
+
+  local ttl=$(attr -qg expires $TEST_612_MOUNTPOINT)
+  echo "TTL is $ttl"
+  if [ $ttl -ne 15 -a $ttl -ne 14 ]; then
+    return 20
+  fi
+
+  echo "umount private mount"
+  remove_local_mount $TEST_612_MOUNTPOINT || return 6
+
+  sudo sh -c "echo CVMFS_REPOSITORY_TTL=60 >> /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
+
+  echo "open transaction to set new ttl"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "publish changes"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  do_local_mount "$TEST_612_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO"     \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 4
+
+  local ttl=$(attr -qg expires $TEST_612_MOUNTPOINT)
+  echo "TTL is $ttl"
+  if [ $ttl -ne 1 -a $ttl -ne 0 ]; then
+    return 21
+  fi
+
+  return 0
+}
+

--- a/test/test_functions
+++ b/test/test_functions
@@ -1874,6 +1874,7 @@ CVMFS_SERVER_URL=$repo_url
 CVMFS_HTTP_PROXY=DIRECT
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${repo_name}.pub
 CVMFS_KCACHE_TIMEOUT=15
+CVMFS_DEBUGLOG=$output
 EOF
   else
     cat $config_file > $config
@@ -1893,6 +1894,6 @@ remove_local_mount() {
 get_internal_value() {
   local repo=$1
   local key=$2
-  
+
   echo $(sudo cvmfs_talk -i $repo internal affairs | grep "^$key" | cut -d\| -f2)
 }


### PR DESCRIPTION
New catalogs cannot immediately be applied but only after draining the kernel caches.  The alarm signal handler that indicates an expired root catalog now triggers (via another thread for signal safety) looking for a new catalog and, if there is one, starting of the drainout period.  

Previously, the alarm signal would make the first subsequent file system call to start the drainout period and only after the drainout period apply a new catalog.  That did lead to strange situations in which idle mount points continued with an old catalog.

Because it made testing easier, this PR also adds a means to specify the repository ttl during publish.  To do so, the new `CVMFS_REPOSITORY_TTL` from server.conf is parsed.