### PR TITLE
Feature: `cvmfs_server check -s /path/to/nested/catalog` for Partial File System Checks

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -327,6 +327,7 @@ Supported Commands:
   check         [-c disable data chunk existence check]
                 [-i check data integrity] (may take some time)]
                 [-t tag (check given tag instead of trunk)]
+                [-s path to nested catalog subtree to check]
                 <fully qualified name>
                 Checks if the repository is sane
   transaction   <fully qualified name>
@@ -3859,11 +3860,12 @@ check() {
   local stratum0
   local check_chunks=1
   local check_integrity=0
+  local subtree_path=""
   local tag=
 
   # optional parameter handling
   OPTIND=1
-  while getopts "cit:" option
+  while getopts "cit:s:" option
   do
     case $option in
       c)
@@ -3874,6 +3876,9 @@ check() {
       ;;
       t)
         tag="-n $OPTARG"
+      ;;
+      s)
+        subtree_path="$OPTARG"
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -3918,12 +3923,20 @@ check() {
   [ "x$CVMFS_LOG_LEVEL" != x ] && log_level_param="-l $CVMFS_LOG_LEVEL"
   [ $check_chunks -ne 0 ]      && check_chunks_param="-c"
 
-  echo "Verifying Catalog Integrity of $name ..."
+  local subtree_msg=""
+  local subtree_param=""
+  if [ "x$subtree_path" != "x" ]; then
+    subtree_param="-s '$subtree_path'"
+    subtree_msg=" (starting at nested catalog '$subtree_path')"
+  fi
+
+  echo "Verifying Catalog Integrity of ${name}${subtree_msg}..."
   local user_shell="$(get_user_shell $name)"
   local check_cmd
   check_cmd="$(__swissknife_cmd dbg) check $tag  \
                      $check_chunks_param         \
                      $log_level_param            \
+                     $subtree_param              \
                      -r $stratum0                \
                      -t ${CVMFS_SPOOL_DIR}/tmp"
   $user_shell "$check_cmd"

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -425,10 +425,9 @@ string CommandCheck::DecompressPiece(const shash::Any catalog_hash) {
 }
 
 
-const catalog::Catalog* CommandCheck::FetchCatalog(
-                                          const string      &path,
-                                          const shash::Any  &catalog_hash,
-                                          const uint64_t     catalog_size) {
+catalog::Catalog* CommandCheck::FetchCatalog(const string      &path,
+                                             const shash::Any  &catalog_hash,
+                                             const uint64_t     catalog_size) {
   string tmp_file;
   if (remote_repository == NULL)
     tmp_file = DecompressPiece(catalog_hash);
@@ -441,8 +440,8 @@ const catalog::Catalog* CommandCheck::FetchCatalog(
     return NULL;
   }
 
-  const catalog::Catalog *catalog =
-    catalog::Catalog::AttachFreely(path, tmp_file, catalog_hash);
+  catalog::Catalog *catalog =
+                   catalog::Catalog::AttachFreely(path, tmp_file, catalog_hash);
   int64_t catalog_file_size = GetFileSize(tmp_file);
   assert(catalog_file_size > 0);
   unlink(tmp_file.c_str());
@@ -584,6 +583,7 @@ bool CommandCheck::InspectTree(const string &path,
 int CommandCheck::Main(const swissknife::ArgumentList &args) {
   string tag_name;
   check_chunks = false;
+  string subtree_path = "";
 
   temp_directory_ = (args.find('t') != args.end()) ? *args.find('t')->second
                                                    : "/tmp";
@@ -601,6 +601,8 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     SetLogVerbosity(static_cast<LogLevels>(log_level));
   }
   const string repository = MakeCanonicalPath(*args.find('r')->second);
+  if (args.find('s') != args.end())
+    subtree_path = MakeCanonicalPath(*args.find('s')->second);
 
   // Repository can be HTTP address or on local file system
   if (repository.substr(0, 7) == "http://") {
@@ -708,6 +710,10 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     root_size = tag.size;
     LogCvmfs(kLogCvmfs, kLogStdout, "Inspecting repository tag %s",
              tag_name.c_str());
+  }
+
+  if (subtree_path != "") {
+
   }
 
   catalog::DeltaCounters computed_counters;

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -32,6 +32,7 @@ class CommandCheck : public Command {
     r.push_back(Parameter::Optional('n', "check specific repository tag"));
     r.push_back(Parameter::Optional('t', "temp directory (default: /tmp)"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Optional('s', "check subtree (nested catalog)"));
     r.push_back(Parameter::Switch('c', "check availability of data chunks"));
     return r;
   }
@@ -43,9 +44,9 @@ class CommandCheck : public Command {
                    const uint64_t catalog_size,
                    const catalog::DirectoryEntry *transition_point,
                    catalog::DeltaCounters *computed_counters);
-  const catalog::Catalog* FetchCatalog(const std::string  &path,
-                                       const shash::Any   &catalog_hash,
-                                       const uint64_t      catalog_size = 0);
+  catalog::Catalog* FetchCatalog(const std::string  &path,
+                                 const shash::Any   &catalog_hash,
+                                 const uint64_t      catalog_size = 0);
 
   std::string DecompressPiece(const shash::Any catalog_hash);
   std::string DownloadPiece(const shash::Any catalog_hash);

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -39,11 +39,12 @@ class CommandCheck : public Command {
   int Main(const ArgumentList &args);
 
  protected:
-  bool InspectTree(const std::string &path,
-                   const shash::Any &catalog_hash,
-                   const uint64_t catalog_size,
-                   const catalog::DirectoryEntry *transition_point,
-                   catalog::DeltaCounters *computed_counters);
+  bool InspectTree(const std::string               &path,
+                   const shash::Any                &catalog_hash,
+                   const uint64_t                   catalog_size,
+                   const bool                       is_nested_catalog,
+                   const catalog::DirectoryEntry  *transition_point,
+                   catalog::DeltaCounters         *computed_counters);
   catalog::Catalog* FetchCatalog(const std::string  &path,
                                  const shash::Any   &catalog_hash,
                                  const uint64_t      catalog_size = 0);

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -43,6 +43,10 @@ class CommandCheck : public Command {
                    const uint64_t catalog_size,
                    const catalog::DirectoryEntry *transition_point,
                    catalog::DeltaCounters *computed_counters);
+  const catalog::Catalog* FetchCatalog(const std::string  &path,
+                                       const shash::Any   &catalog_hash,
+                                       const uint64_t      catalog_size = 0);
+
   std::string DecompressPiece(const shash::Any catalog_hash);
   std::string DownloadPiece(const shash::Any catalog_hash);
   bool Find(const catalog::Catalog *catalog,

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -47,6 +47,9 @@ class CommandCheck : public Command {
   catalog::Catalog* FetchCatalog(const std::string  &path,
                                  const shash::Any   &catalog_hash,
                                  const uint64_t      catalog_size = 0);
+  bool FindSubtreeRootCatalog(const std::string &subtree_path,
+                              shash::Any        *root_hash,
+                              uint64_t          *root_size);
 
   std::string DecompressPiece(const shash::Any catalog_hash);
   std::string DownloadPiece(const shash::Any catalog_hash);

--- a/test/src/611-subtreecheck/main
+++ b/test/src/611-subtreecheck/main
@@ -8,10 +8,20 @@ produce_files_in() {
   pushdir $working_dir
 
   mkdir -p foo
+  mkdir -p foo/1
+  mkdir -p foo/2
+  mkdir -p foo/3
+  mkdir -p foo/4
   mkdir -p bar
   mkdir -p baz
 
-  echo "/*" > .cvmfsdirtab
+  echo "foobar" > foo/3/foobar
+
+  echo "/*"     >  .cvmfsdirtab
+  echo "/foo/*" >> .cvmfsdirtab
+
+  create_big_file foo/4/moo 100
+  create_big_file foo/2/muh 100
 
   popdir
 }
@@ -35,17 +45,35 @@ cvmfs_run_test() {
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
+  local check_log_1="check_1.log"
   echo "check catalog and data integrity"
-  check_repository $CVMFS_TEST_REPO -i || return $?
+  check_repository $CVMFS_TEST_REPO -i > $check_log_1 2>&1 || return $?
+
+  echo "checking the log file"
+  cat $check_log_1 | grep -e 'at /$'      || return  4
+  cat $check_log_1 | grep -e 'at /baz$'   || return  5
+  cat $check_log_1 | grep -e 'at /bar$'   || return  6
+  cat $check_log_1 | grep -e 'at /foo$'   || return  7
+  cat $check_log_1 | grep -e 'at /foo/4$' || return  8
+  cat $check_log_1 | grep -e 'at /foo/2$' || return  9
+  cat $check_log_1 | grep -e 'at /foo/3$' || return 10
+  cat $check_log_1 | grep -e 'at /foo/1$' || return 11
 
   # ============================================================================
 
-  local check_log_1="check_1.log"
-  echo "check only subtree (foo) - logging to $check_log_1"
-  check_repository $CVMFS_TEST_REPO -s /foo > $check_log_1 2>&1 || return 4
+  local check_log_2="check_2.log"
+  echo "check only subtree (foo) - logging to $check_log_2"
+  check_repository $CVMFS_TEST_REPO -s /foo > $check_log_2 2>&1 || return 12
 
   echo "checking log file"
-  cat $check_log_1
+  cat $check_log_2 | grep -e 'at /$'      && return 13
+  cat $check_log_2 | grep -e 'at /baz$'   && return 14
+  cat $check_log_2 | grep -e 'at /bar$'   && return 15
+  cat $check_log_2 | grep -e 'at /foo$'   || return 16
+  cat $check_log_2 | grep -e 'at /foo/4$' || return 17
+  cat $check_log_2 | grep -e 'at /foo/2$' || return 18
+  cat $check_log_2 | grep -e 'at /foo/3$' || return 19
+  cat $check_log_2 | grep -e 'at /foo/1$' || return 20
 
   return 0
 }

--- a/test/src/611-subtreecheck/main
+++ b/test/src/611-subtreecheck/main
@@ -1,0 +1,52 @@
+
+cvmfs_test_name="Health Check a Catalog Subtree"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir -p foo
+  mkdir -p bar
+  mkdir -p baz
+
+  echo "/*" > .cvmfsdirtab
+
+  popdir
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in $repo_dir || return 3
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # ============================================================================
+
+  local check_log_1="check_1.log"
+  echo "check only subtree (foo) - logging to $check_log_1"
+  check_repository $CVMFS_TEST_REPO -s /foo > $check_log_1 2>&1 || return 4
+
+  echo "checking log file"
+  cat $check_log_1
+
+  return 0
+}
+

--- a/test/src/611-subtreecheck/main
+++ b/test/src/611-subtreecheck/main
@@ -10,15 +10,21 @@ produce_files_in() {
   mkdir -p foo
   mkdir -p foo/1
   mkdir -p foo/2
+  mkdir -p foo/2/hallo
+  mkdir -p foo/2/welt
+  mkdir -p foo/2/hallo/welt
   mkdir -p foo/3
   mkdir -p foo/4
   mkdir -p bar
   mkdir -p baz
+  mkdir -p baz/foo
+  mkdir -p baz/bar
 
   echo "foobar" > foo/3/foobar
 
-  echo "/*"     >  .cvmfsdirtab
-  echo "/foo/*" >> .cvmfsdirtab
+  echo "/*"                >  .cvmfsdirtab
+  echo "/foo/*"            >> .cvmfsdirtab
+  echo "/foo/2/hallo/welt" >> .cvmfsdirtab
 
   create_big_file foo/4/moo 100
   create_big_file foo/2/muh 100
@@ -50,30 +56,58 @@ cvmfs_run_test() {
   check_repository $CVMFS_TEST_REPO -i > $check_log_1 2>&1 || return $?
 
   echo "checking the log file"
-  cat $check_log_1 | grep -e 'at /$'      || return  4
-  cat $check_log_1 | grep -e 'at /baz$'   || return  5
-  cat $check_log_1 | grep -e 'at /bar$'   || return  6
-  cat $check_log_1 | grep -e 'at /foo$'   || return  7
-  cat $check_log_1 | grep -e 'at /foo/4$' || return  8
-  cat $check_log_1 | grep -e 'at /foo/2$' || return  9
-  cat $check_log_1 | grep -e 'at /foo/3$' || return 10
-  cat $check_log_1 | grep -e 'at /foo/1$' || return 11
+  cat $check_log_1 | grep -e 'at /$'                || return  4
+  cat $check_log_1 | grep -e 'at /baz$'             || return  5
+  cat $check_log_1 | grep -e 'at /bar$'             || return  6
+  cat $check_log_1 | grep -e 'at /foo$'             || return  7
+  cat $check_log_1 | grep -e 'at /foo/4$'           || return  8
+  cat $check_log_1 | grep -e 'at /foo/2$'           || return  9
+  cat $check_log_1 | grep -e 'at /foo/3$'           || return 10
+  cat $check_log_1 | grep -e 'at /foo/1$'           || return 11
+  cat $check_log_1 | grep -e 'at /foo/2/hallo/welt' || return 12
 
   # ============================================================================
 
   local check_log_2="check_2.log"
   echo "check only subtree (foo) - logging to $check_log_2"
-  check_repository $CVMFS_TEST_REPO -s /foo > $check_log_2 2>&1 || return 12
+  check_repository $CVMFS_TEST_REPO -s /foo > $check_log_2 2>&1 || return 13
 
   echo "checking log file"
-  cat $check_log_2 | grep -e 'at /$'      && return 13
-  cat $check_log_2 | grep -e 'at /baz$'   && return 14
-  cat $check_log_2 | grep -e 'at /bar$'   && return 15
-  cat $check_log_2 | grep -e 'at /foo$'   || return 16
-  cat $check_log_2 | grep -e 'at /foo/4$' || return 17
-  cat $check_log_2 | grep -e 'at /foo/2$' || return 18
-  cat $check_log_2 | grep -e 'at /foo/3$' || return 19
-  cat $check_log_2 | grep -e 'at /foo/1$' || return 20
+  cat $check_log_2 | grep -e 'at /$'                 && return 20
+  cat $check_log_2 | grep -e 'at /baz$'              && return 21
+  cat $check_log_2 | grep -e 'at /bar$'              && return 22
+  cat $check_log_2 | grep -e 'at /foo$'              || return 23
+  cat $check_log_2 | grep -e 'at /foo/4$'            || return 24
+  cat $check_log_2 | grep -e 'at /foo/2$'            || return 25
+  cat $check_log_2 | grep -e 'at /foo/3$'            || return 26
+  cat $check_log_2 | grep -e 'at /foo/1$'            || return 27
+  cat $check_log_2 | grep -e 'at /foo/2/hallo/welt$' || return 28
+
+  # ============================================================================
+
+  local check_log_3="check_3.log"
+  echo "try to base the check outside a nested catalog"
+  check_repository $CVMFS_TEST_REPO -s /baz/foo > $check_log_3 2>&1 && return 29
+
+  echo "checking the log"
+  cat $check_log_3 | grep -e "cannot find .* catalog at /baz/foo" || return 30
+
+  # ============================================================================
+
+  local check_log_4="check_4.log"
+  echo "check a second-level nested catalog (/foo/2)"
+  check_repository $CVMFS_TEST_REPO -s /foo/2 > $check_log_4 2>&1 || return 31
+
+  echo "checking the log file"
+  cat $check_log_4 | grep -e 'at /$'                 && return 40
+  cat $check_log_4 | grep -e 'at /baz$'              && return 41
+  cat $check_log_4 | grep -e 'at /bar$'              && return 42
+  cat $check_log_4 | grep -e 'at /foo$'              && return 43
+  cat $check_log_4 | grep -e 'at /foo/4$'            && return 44
+  cat $check_log_4 | grep -e 'at /foo/3$'            && return 46
+  cat $check_log_4 | grep -e 'at /foo/1$'            && return 47
+  cat $check_log_4 | grep -e 'at /foo/2$'            || return 45
+  cat $check_log_4 | grep -e 'at /foo/2/hallo/welt$' || return 48
 
   return 0
 }


### PR DESCRIPTION
This allows `cvmfs_server check` to only go through a subtree of the repository. The idea is, to allow for quicker turn-around time when debugging problems. Instead of always checking everything, consecutive checks can be done more focussed to the actually affected catalogs.