### PR TITLE
TEST: Regression in File Chunking

### DIFF
--- a/test/src/510-filechunks/main
+++ b/test/src/510-filechunks/main
@@ -73,6 +73,12 @@ produce_files_in() {
   inflate_file big_file/ein_paar_mehr_heidenroeslein big_file/ein_paar_heidenroeslein 10000000
   inflate_file big_file/viele_heidenroeslein big_file/ein_paar_mehr_heidenroeslein 60000000
 
+  # regression test
+  mkdir regression
+  create_big_file regression/32   32
+  create_big_file regression/64   64
+  create_big_file regression/128 128
+
 	popdir
 }
 

--- a/test/unittests/t_chunk_detectors.cc
+++ b/test/unittests/t_chunk_detectors.cc
@@ -14,20 +14,19 @@ namespace upload {
 
 class T_ChunkDetectors : public ::testing::Test {
  protected:
+  static const size_t data_size_ = 104857600; // 100 MiB
+
   void CreateBuffers(const size_t buffer_size) {
     ClearBuffers();
-
-    const size_t MB          = 1048576;
-    const size_t full_size   = 100 * MB;
 
     // make sure we always produce the same test data
     rng_.InitSeed(42);
 
     // produce some test data
     size_t i = 0;
-    while (i < full_size) {
+    while (i < data_size()) {
       CharBuffer * buffer = new CharBuffer(buffer_size);
-      buffer->SetUsedBytes(std::min(full_size - i, buffer_size));
+      buffer->SetUsedBytes(std::min(data_size() - i, buffer_size));
       buffer->SetBaseOffset(i);
 
       for (size_t j = 0; j < buffer->size(); ++j) {
@@ -42,6 +41,8 @@ class T_ChunkDetectors : public ::testing::Test {
   virtual void TearDown() {
     ClearBuffers();
   }
+
+  size_t data_size() const { return data_size_; }
 
  private:
   void ClearBuffers() {


### PR DESCRIPTION
Found that totally by chance while testing a different thing. Apparently file chunking fails with file sizes that are exactly a power of two. I expect something like an off-by-one error or similar. Possibly also in conjunction with the `CVMFS_MAX_CHUNK_SIZE`. I didn't look into it yet, this is more a TODO regression test.