### PR TITLE
Enable OSX in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,13 @@ Vagrant.configure(2) do |config|
     slc6.vm.provision :reload
   end
 
+  config.vm.define "yosemite" do |yosemite|
+    yosemite.vm.box = "yosemite"
+    yosemite.vm.network "private_network", ip: "192.168.33.15"
+    yosemite.vm.synced_folder '.', '/Users/vagrant/cvmfs', nfs: true
+    yosemite.vm.provision "shell", path: "vagrant/provision_osx.sh"
+  end
+
   config.vm.define "ubuntu" do |ub|
     ub.vm.box = "ubuntu/trusty64"
     ub.vm.network "private_network", ip: "192.168.33.12"

--- a/vagrant/provision_osx.sh
+++ b/vagrant/provision_osx.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+
+set -e
+
+brew install wget Caskroom/cask/osxfuse


### PR DESCRIPTION
Enables the creation of Mac OS X Yosemite as a Vagrant VM