### PR TITLE
FIX: Publishing Crashes when Large File Does just Fit into Chunk Sizes

### DIFF
--- a/cvmfs/file_processing/processor.cc
+++ b/cvmfs/file_processing/processor.cc
@@ -220,7 +220,10 @@ FileScrubbingTask::CutMarks FileScrubbingTask::FindNextChunkCutMarks() {
   CutMarks result;
   off_t next_cut;
   while ((next_cut = file->FindNextCutMark(buffer)) != 0) {
-    result.push_back(next_cut);
+    assert (next_cut > 0);
+    if (static_cast<size_t>(next_cut) < file->size()) {
+      result.push_back(next_cut);
+    }
   }
 
   return result;

--- a/test/src/510-filechunks/main
+++ b/test/src/510-filechunks/main
@@ -73,6 +73,12 @@ produce_files_in() {
   inflate_file big_file/ein_paar_mehr_heidenroeslein big_file/ein_paar_heidenroeslein 10000000
   inflate_file big_file/viele_heidenroeslein big_file/ein_paar_mehr_heidenroeslein 60000000
 
+  # regression test
+  mkdir regression
+  create_big_file regression/32   32
+  create_big_file regression/64   64
+  create_big_file regression/128 128
+
 	popdir
 }
 

--- a/test/unittests/t_chunk_detectors.cc
+++ b/test/unittests/t_chunk_detectors.cc
@@ -14,20 +14,19 @@ namespace upload {
 
 class T_ChunkDetectors : public ::testing::Test {
  protected:
+  static const size_t data_size_ = 104857600; // 100 MiB
+
   void CreateBuffers(const size_t buffer_size) {
     ClearBuffers();
-
-    const size_t MB          = 1048576;
-    const size_t full_size   = 100 * MB;
 
     // make sure we always produce the same test data
     rng_.InitSeed(42);
 
     // produce some test data
     size_t i = 0;
-    while (i < full_size) {
+    while (i < data_size()) {
       CharBuffer * buffer = new CharBuffer(buffer_size);
-      buffer->SetUsedBytes(std::min(full_size - i, buffer_size));
+      buffer->SetUsedBytes(std::min(data_size() - i, buffer_size));
       buffer->SetBaseOffset(i);
 
       for (size_t j = 0; j < buffer->size(); ++j) {
@@ -42,6 +41,8 @@ class T_ChunkDetectors : public ::testing::Test {
   virtual void TearDown() {
     ClearBuffers();
   }
+
+  size_t data_size() const { return data_size_; }
 
  private:
   void ClearBuffers() {

--- a/test/unittests/t_chunk_detectors.cc
+++ b/test/unittests/t_chunk_detectors.cc
@@ -300,7 +300,12 @@ TEST_F(T_ChunkDetectors, Xor32ChunkDetectorZerosBufferPowerOfTwo) {
   for (; !fail && j != jend; ++j) {
     while ((next_cut = xor32_detector.FindNextCutMark(*j)) != 0) {
       EXPECT_EQ(0, next_cut % max_chk_size);
-      EXPECT_GT(data_size(), next_cut);
+      EXPECT_GE(data_size(), next_cut); // ChunkDetector might decide to cut
+                                        // right in the end of a file. This is
+                                        // because it works on CharBuffer-level
+                                        // and doesn't have a notion about the
+                                        // actual file's size.
+                                        // Hence: EXPECT_GreaterEqual()
     }
   }
 }


### PR DESCRIPTION
This fixes [CVM-957](https://sft.its.cern.ch/jira/browse/CVM-957) where a large file has a file size that is exactly a multiple of `CVMFS_MAX_CHUNK_SIZE` and does not contain any XOR32-based chunk cut marks. This is very unlikely to happen but I stumbled over it by accident.

I fix it by checking the output of `ChunkDetector` to be lower than `File::size()`. This is not an optimal solution, since it is more of a patch around the root cause. However, `ChunkDetector` is designed to take a stream and it doesn't know how much data will come. Hence, I cannot easily check for *EOF* inside the `ChunkDetector`.

**Note:** This contains [TEST: Regression in File Chunking](https://github.com/cvmfs/cvmfs/pull/1298).