### PR TITLE
Add support for client contexts.

### DIFF
--- a/cvmfs/catalog_balancer.h
+++ b/cvmfs/catalog_balancer.h
@@ -112,7 +112,7 @@ class CatalogBalancer {
     VirtualNode(const std::string &path, CatalogMgrT *catalog_mgr)
       : children(), weight(1), dirent(), path(path),
         is_new_nested_catalog(false) {
-      catalog_mgr->LookupPath(path, kLookupSole, &dirent);
+      catalog_mgr->LookupPath(path, kLookupSole, &dirent, NULL);
     }
     VirtualNode(const std::string &path, const DirectoryEntry &dirent,
                 CatalogMgrT *catalog_mgr)

--- a/cvmfs/catalog_balancer_impl.h
+++ b/cvmfs/catalog_balancer_impl.h
@@ -46,7 +46,7 @@ void CatalogBalancer<CatalogMgrT>::AddCatalogMarker(string path) {
   XattrList xattr;
   DirectoryEntry parent;
   bool retval;
-  retval = catalog_mgr_->LookupPath(PathString(path), kLookupSole, &parent);
+  retval = catalog_mgr_->LookupPath(PathString(path), kLookupSole, &parent, NULL);
   assert(retval);
   DirectoryEntryBase cvmfscatalog =
       MakeEmptyDirectoryEntryBase(".cvmfscatalog", parent.uid(),

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -41,6 +41,18 @@ enum LookupOptions {
   kLookupRawSymlink  = 0x10,
 };
 
+/**
+ * The context of the catalog operation.
+ * Represents a client this is performed on behalf of.
+ */
+struct ClientCtx {
+  ClientCtx(uid_t u, gid_t g, pid_t p) : uid(u), gid(g), pid(p) {}
+  ClientCtx() : uid(-1), gid(-1), pid(-1) {}
+  uid_t uid;
+  gid_t gid;
+  pid_t pid;
+};
+
 
 /**
  * Results upon loading a catalog file.
@@ -154,15 +166,16 @@ class AbstractCatalogManager : public SingleCopy {
   //  bool LookupInode(const inode_t inode, const LookupOptions options,
   //                   DirectoryEntry *entry);
   bool LookupPath(const PathString &path, const LookupOptions options,
-                  DirectoryEntry *entry);
+                  DirectoryEntry *entry, ClientCtx *);
   bool LookupPath(const std::string &path, const LookupOptions options,
-                  DirectoryEntry *entry)
+                  DirectoryEntry *entry, ClientCtx *ctx)
   {
     PathString p;
     p.Assign(&path[0], path.length());
-    return LookupPath(p, options, entry);
+    return LookupPath(p, options, entry, ctx);
   }
-  bool LookupXattrs(const PathString &path, XattrList *xattrs);
+  bool LookupXattrs(const PathString &path, XattrList *xattrs,
+                    const ClientCtx *);
 
   bool Listing(const PathString &path, DirectoryEntryList *listing);
   bool Listing(const std::string &path, DirectoryEntryList *listing) {
@@ -170,11 +183,12 @@ class AbstractCatalogManager : public SingleCopy {
     p.Assign(&path[0], path.length());
     return Listing(p, listing);
   }
-  bool ListingStat(const PathString &path, StatEntryList *listing);
+  bool ListingStat(const PathString &path, StatEntryList *listing,
+                   const ClientCtx *);
 
   bool ListFileChunks(const PathString &path,
                       const shash::Algorithms interpret_hashes_as,
-                      FileChunkList *chunks);
+                      FileChunkList *chunks, const ClientCtx *);
   void SetOwnerMaps(const OwnerMap &uid_map, const OwnerMap &gid_map);
 
   Statistics statistics() const { return statistics_; }
@@ -215,7 +229,8 @@ class AbstractCatalogManager : public SingleCopy {
   virtual LoadError LoadCatalog(const PathString &mountpoint,
                                 const shash::Any &hash,
                                 std::string  *catalog_path,
-                                shash::Any   *catalog_hash) = 0;
+                                shash::Any   *catalog_hash,
+                                const ClientCtx *ctx) = 0;
   virtual void UnloadCatalog(const CatalogT *catalog) { }
   virtual void ActivateCatalog(CatalogT *catalog) { }
   const std::vector<CatalogT*>& GetCatalogs() const { return catalogs_; }
@@ -234,9 +249,9 @@ class AbstractCatalogManager : public SingleCopy {
                                   CatalogT *parent_catalog) = 0;
 
   CatalogT *MountCatalog(const PathString &mountpoint, const shash::Any &hash,
-                         CatalogT *parent_catalog);
+                         CatalogT *parent_catalog, const ClientCtx *ctx);
   bool MountSubtree(const PathString &path, const CatalogT *entry_point,
-                    CatalogT **leaf_catalog);
+                    CatalogT **leaf_catalog, const ClientCtx *ctx);
 
   bool AttachCatalog(const std::string &db_path, CatalogT *new_catalog);
   void DetachCatalog(CatalogT *catalog);

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -73,7 +73,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
   LoadError LoadCatalog(const PathString  &mountpoint,
                         const shash::Any  &hash,
                         std::string       *catalog_path,
-                        shash::Any        *catalog_hash);
+                        shash::Any        *catalog_hash,
+                        const ClientCtx   *ctx);
   void UnloadCatalog(const catalog::Catalog *catalog);
   catalog::Catalog* CreateCatalog(const PathString &mountpoint,
                                   const shash::Any  &catalog_hash,
@@ -84,7 +85,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
   LoadError LoadCatalogCas(const shash::Any &hash,
                            const std::string &name,
                            const std::string &alt_catalog_path,
-                           std::string *catalog_path);
+                           std::string *catalog_path,
+                           const ClientCtx *ctx);
 
   /**
    * Required for unpinning

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -89,7 +89,7 @@ template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::Init() {
   LogCvmfs(kLogCatalog, kLogDebug, "Initialize catalog");
   WriteLock();
-  bool attached = MountCatalog(PathString("", 0), shash::Any(), NULL);
+  bool attached = MountCatalog(PathString("", 0), shash::Any(), NULL, NULL);
   Unlock();
 
   if (!attached) {
@@ -110,7 +110,7 @@ LoadError AbstractCatalogManager<CatalogT>::Remount(const bool dry_run) {
   LogCvmfs(kLogCatalog, kLogDebug,
            "remounting repositories (dry run %d)", dry_run);
   if (dry_run)
-    return LoadCatalog(PathString("", 0), shash::Any(), NULL, NULL);
+    return LoadCatalog(PathString("", 0), shash::Any(), NULL, NULL, NULL);
 
   WriteLock();
 
@@ -119,7 +119,8 @@ LoadError AbstractCatalogManager<CatalogT>::Remount(const bool dry_run) {
   const LoadError load_error = LoadCatalog(PathString("", 0),
                                            shash::Any(),
                                            &catalog_path,
-                                           &catalog_hash);
+                                           &catalog_hash,
+                                           NULL);
   if (load_error == kLoadNew) {
     inode_t old_inode_gauge = inode_gauge_;
     DetachAll();
@@ -177,7 +178,8 @@ void AbstractCatalogManager<CatalogT>::DetachNested() {
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
                                         const LookupOptions options,
-                                        DirectoryEntry *dirent)
+                                        DirectoryEntry *dirent,
+                                        ClientCtx *ctx)
 {
   // initialize as non-negative
   assert(dirent);
@@ -199,7 +201,7 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
   bool found = best_fit->LookupPath(path, dirent);
 
   // Possibly in a nested catalog
-  if (!found && MountSubtree(path, best_fit, NULL)) {
+  if (!found && MountSubtree(path, best_fit, NULL, ctx)) {
     LogCvmfs(kLogCatalog, kLogDebug, "looking up '%s' in a nested catalog",
              path.c_str());
     Unlock();
@@ -215,7 +217,7 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
                "entry not found, we may have to load nested catalogs");
 
       CatalogT *nested_catalog;
-      found = MountSubtree(path, best_fit, &nested_catalog);
+      found = MountSubtree(path, best_fit, &nested_catalog, ctx);
       // DowngradeLock(); TODO
 
       if (!found) {
@@ -297,7 +299,8 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::LookupXattrs(
   const PathString &path,
-  XattrList *xattrs)
+  XattrList *xattrs,
+  const ClientCtx *ctx)
 {
   EnforceSqliteMemLimit();
   bool result;
@@ -306,12 +309,12 @@ bool AbstractCatalogManager<CatalogT>::LookupXattrs(
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
-  if (MountSubtree(path, best_fit, NULL)) {
+  if (MountSubtree(path, best_fit, NULL, ctx)) {
     Unlock();
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, &catalog);
+    result = MountSubtree(path, best_fit, &catalog, ctx);
     // DowngradeLock(); TODO
     if (!result) {
       Unlock();
@@ -344,12 +347,12 @@ bool AbstractCatalogManager<CatalogT>::Listing(const PathString &path,
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
-  if (MountSubtree(path, best_fit, NULL)) {
+  if (MountSubtree(path, best_fit, NULL, NULL)) {
     Unlock();
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, &catalog);
+    result = MountSubtree(path, best_fit, &catalog, NULL);
     // DowngradeLock(); TODO
     if (!result) {
       Unlock();
@@ -373,7 +376,8 @@ bool AbstractCatalogManager<CatalogT>::Listing(const PathString &path,
  */
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::ListingStat(const PathString &path,
-                                        StatEntryList *listing)
+                                        StatEntryList *listing,
+                                        const ClientCtx *fctx)
 {
   EnforceSqliteMemLimit();
   bool result;
@@ -382,12 +386,12 @@ bool AbstractCatalogManager<CatalogT>::ListingStat(const PathString &path,
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
-  if (MountSubtree(path, best_fit, NULL)) {
+  if (MountSubtree(path, best_fit, NULL, fctx)) {
     Unlock();
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, &catalog);
+    result = MountSubtree(path, best_fit, &catalog, fctx);
     // DowngradeLock(); TODO
     if (!result) {
       Unlock();
@@ -414,7 +418,8 @@ template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::ListFileChunks(
   const PathString &path,
   const shash::Algorithms interpret_hashes_as,
-  FileChunkList *chunks)
+  FileChunkList *chunks,
+  const ClientCtx *ctx)
 {
   EnforceSqliteMemLimit();
   bool result;
@@ -423,12 +428,12 @@ bool AbstractCatalogManager<CatalogT>::ListFileChunks(
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
-  if (MountSubtree(path, best_fit, NULL)) {
+  if (MountSubtree(path, best_fit, NULL, ctx)) {
     Unlock();
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, &catalog);
+    result = MountSubtree(path, best_fit, &catalog, ctx);
     if (!result) {
       Unlock();
       return false;
@@ -572,7 +577,8 @@ bool AbstractCatalogManager<CatalogT>::IsAttached(const PathString &root_path,
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::MountSubtree(const PathString &path,
                                           const CatalogT *entry_point,
-                                          CatalogT **leaf_catalog)
+                                          CatalogT **leaf_catalog,
+                                          const ClientCtx *ctx)
 {
   bool result = true;
   CatalogT *parent = (entry_point == NULL) ?
@@ -602,11 +608,11 @@ bool AbstractCatalogManager<CatalogT>::MountSubtree(const PathString &path,
       // (due to reloading root)
       if (i->hash.IsNull())
         return false;
-      new_nested = MountCatalog(i->path, i->hash, parent);
+      new_nested = MountCatalog(i->path, i->hash, parent, ctx);
       if (!new_nested)
         return false;
 
-      result = MountSubtree(path, new_nested, &parent);
+      result = MountSubtree(path, new_nested, &parent, ctx);
       break;
     }
   }
@@ -626,7 +632,8 @@ template <class CatalogT>
 CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
                                               const PathString &mountpoint,
                                               const shash::Any &hash,
-                                              CatalogT *parent_catalog)
+                                              CatalogT *parent_catalog,
+                                              const ClientCtx *ctx)
 {
   CatalogT *attached_catalog = NULL;
   if (IsAttached(mountpoint, &attached_catalog))
@@ -635,7 +642,7 @@ CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
   string     catalog_path;
   shash::Any catalog_hash;
   const LoadError retval =
-    LoadCatalog(mountpoint, hash, &catalog_path, &catalog_hash);
+    LoadCatalog(mountpoint, hash, &catalog_path, &catalog_hash, ctx);
   if ((retval == kLoadFail) || (retval == kLoadNoSpace)) {
     LogCvmfs(kLogCatalog, kLogDebug, "failed to load catalog '%s' (%d - %s)",
              mountpoint.c_str(), retval, Code2Ascii(retval));

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -24,7 +24,8 @@ namespace catalog {
 LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
                                             const shash::Any  &hash,
                                             std::string       *catalog_path,
-                                            shash::Any        *catalog_hash)
+                                            shash::Any        *catalog_hash,
+                                            const ClientCtx   *ctx)
 {
   shash::Any effective_hash = hash.IsNull() ? base_hash_ : hash;
   assert(shash::kSuffixCatalog == effective_hash.suffix);

--- a/cvmfs/catalog_mgr_ro.h
+++ b/cvmfs/catalog_mgr_ro.h
@@ -49,7 +49,8 @@ class SimpleCatalogManager : public AbstractCatalogManager<Catalog> {
   virtual LoadError LoadCatalog(const PathString  &mountpoint,
                                 const shash::Any  &hash,
                                 std::string       *catalog_path,
-                                shash::Any        *catalog_hash);
+                                shash::Any        *catalog_hash,
+                                const ClientCtx   *ctx);
   virtual Catalog* CreateCatalog(const PathString  &mountpoint,
                                  const shash::Any  &catalog_hash,
                                  Catalog           *parent_catalog);

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -185,12 +185,12 @@ bool WritableCatalogManager::FindCatalog(const string &path,
   assert(best_fit != NULL);
   Catalog *catalog = NULL;
   bool retval = MountSubtree(PathString(path.data(), path.length()),
-                             best_fit, &catalog);
+                             best_fit, &catalog, NULL);
   if (!retval)
     return false;
 
   catalog::DirectoryEntry dummy;
-  bool found = LookupPath(path, kLookupSole, &dummy);
+  bool found = LookupPath(path, kLookupSole, &dummy, NULL);
   if (!found || !catalog->IsWritable())
     return false;
 
@@ -505,7 +505,7 @@ void WritableCatalogManager::TouchDirectory(const DirectoryEntryBase &entry,
     retval = catalog->FindNested(transition_path, &nested_hash, &nested_size);
     assert(retval);
     Catalog *nested_catalog;
-    nested_catalog = MountCatalog(transition_path, nested_hash, catalog);
+    nested_catalog = MountCatalog(transition_path, nested_hash, catalog, NULL);
     assert(nested_catalog != NULL);
 
     // update nested catalog root in the child catalog

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -78,6 +78,9 @@ int Fetcher::Fetch(
   const uint64_t size,
   const std::string &name,
   const cache::CacheManager::ObjectType object_type,
+  pid_t pid,
+  uid_t uid,
+  gid_t gid,
   const std::string &alt_url)
 {
   int fd_return;  // Read-only file descriptor that is returned

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -77,6 +77,9 @@ class Fetcher : SingleCopy {
             const uint64_t size,
             const std::string &name,
             const cache::CacheManager::ObjectType object_type,
+            pid_t pid = -1,
+            uid_t uid = -1,
+            gid_t gid = -1,
             const std::string &alt_url = "");
 
   cache::CacheManager *cache_mgr() { return cache_mgr_; }

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -362,7 +362,8 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
     // a new directory and thus not in any catalog yet.
     catalog::DirectoryEntry dirent;
     const bool lookup_success =
-      catalog_manager->LookupPath(candidate_rel, catalog::kLookupSole, &dirent);
+      catalog_manager->LookupPath(candidate_rel, catalog::kLookupSole, &dirent,
+                                  NULL);
     if (!lookup_success) {
       LogCvmfs(kLogCatalog, kLogDebug, "Didn't find '%s' in catalogs, could "
                                        "be a new directory and nested catalog.",

--- a/test/unittests/t_catalog_mgr.cc
+++ b/test/unittests/t_catalog_mgr.cc
@@ -167,33 +167,34 @@ TEST_F(T_CatalogManager, Lookup) {
   catalog::DirectoryEntry dirent;
   ASSERT_TRUE(catalog_mgr_.Init());
   AddTree();
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir", kLookupSole, &dirent, NULL));
   EXPECT_TRUE(dirent.IsDirectory());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir", kLookupSole, &dirent, NULL));
   EXPECT_TRUE(dirent.IsDirectory());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/file1", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/file1", kLookupSole, &dirent, NULL));
   EXPECT_TRUE(dirent.IsRegular());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/file1", kLookupFull, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/file1", kLookupFull, &dirent, NULL));
   EXPECT_TRUE(dirent.IsRegular());
   // the father directory belongs to the catalog, so there is no problem
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/file2", kLookupFull, &dirent));
+  EXPECT_TRUE(
+    catalog_mgr_.LookupPath("/dir/dir/file2", kLookupFull, &dirent, NULL));
   EXPECT_TRUE(dirent.IsRegular());
   // /dir/dir/dir/file4 belongs to a catalog that is not mounted yet
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/file4", kLookupSole,
-                                      &dirent));
+                                      &dirent, NULL));
   // the new catalog should be mounted now
   EXPECT_EQ(2, catalog_mgr_.GetNumCatalogs());
 
   // the father directory should also belong to the nested catalog
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/file4", kLookupFull,
-                                      &dirent));
+                                      &dirent, NULL));
   // it is not a symplink, so it should crash
   EXPECT_DEATH(catalog_mgr_.LookupPath("/dir/dir/dir/file4", kLookupRawSymlink,
-                                      &dirent), ".*");
+                                      &dirent, NULL), ".*");
 
   // load the next catalog
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/dir/dir/file5",
-                                      kLookupFull, &dirent));
+                                      kLookupFull, &dirent, NULL));
   // the new catalog should be mounted now
   EXPECT_EQ(3, catalog_mgr_.GetNumCatalogs());
 }
@@ -203,7 +204,7 @@ TEST_F(T_CatalogManager, LongLookup) {
   ASSERT_TRUE(catalog_mgr_.Init());
   AddTree();
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/dir/dir/file5",
-                                      kLookupFull, &dirent));
+                                      kLookupFull, &dirent, NULL));
   EXPECT_TRUE(dirent.IsRegular());
   // we should have mounted two catalogs
   EXPECT_EQ(3, catalog_mgr_.GetNumCatalogs());
@@ -284,7 +285,7 @@ TEST_F(T_CatalogManager, Balance) {
 
   // load the other catalogs so that they can be removed
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/dir/dir/file5",
-                                      kLookupFull, &dirent));
+                                      kLookupFull, &dirent, NULL));
 }
 
 TEST_F(T_CatalogManager, Remount) {

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -243,7 +243,7 @@ TEST_F(T_Fetcher, FetchAltPath) {
   EXPECT_LT(fd, 0);
 
   fd = fetcher_->Fetch(hash_regular_, cache::CacheManager::kSizeUnknown, "reg",
-                       cache::CacheManager::kTypeRegular, "altpath");
+                       cache::CacheManager::kTypeRegular, -1, -1, -1, "altpath");
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 }

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -398,7 +398,8 @@ catalog::LoadError catalog::MockCatalogManager::LoadCatalog(
                                                   const PathString &mountpoint,
                                                   const shash::Any &hash,
                                                   string  *catalog_path,
-                                                  shash::Any *catalog_hash)
+                                                  shash::Any *catalog_hash,
+                                                  const catalog::ClientCtx *c)
 {
   map<PathString, MockCatalog*>::iterator it = catalog_map_.find(mountpoint);
   if (it != catalog_map_.end() && catalog_hash != NULL) {

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -547,7 +547,8 @@ class MockCatalogManager : public AbstractCatalogManager<MockCatalog> {
   virtual LoadError LoadCatalog(const PathString &mountpoint,
                                 const shash::Any &hash,
                                 std::string  *catalog_path,
-                                shash::Any   *catalog_hash);
+                                shash::Any   *catalog_hash,
+                                const catalog::ClientCtx *c);
 
   virtual MockCatalog* CreateCatalog(const PathString  &mountpoint,
                                  const shash::Any  &catalog_hash,


### PR DESCRIPTION
When doing secure CVMFS, any time we fetch a remote object, we must
understand what context the fetch occurs in - who requests the
fetch operation?

Having this information will allow us, within a FUSE process, grab
the underlying credential corresponding to the current context.

This is not immediately useful in itself, but helps to decrease the size of CVM-904.