### PR TITLE
Remove use of 'altpath'

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -158,8 +158,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   }
 
   // Upload catalog
-  spooler->Upload(file_path_compressed, "data/" + hash_catalog.MakePath(),
-                  manifest->MakeCatalogPath());
+  spooler->Upload(file_path_compressed, "data/" + hash_catalog.MakePath());
   spooler->WaitForUpload();
   unlink(file_path_compressed.c_str());
   if (spooler->GetNumberOfErrors() > 0) {
@@ -844,12 +843,8 @@ shash::Any WritableCatalogManager::SnapshotCatalog(WritableCatalog *catalog)
   }
 
   // Upload catalog
-  std::string alt_path, voms_authz;
-  if (catalog->IsRoot() && GetVOMSAuthz(voms_authz) && voms_authz.size()) {
-    alt_path = ".cvmfsroot";
-  }
   spooler_->Upload(catalog->database_path() + ".compressed",
-                   "data/" + hash_catalog.MakePath(), alt_path);
+                   "data/" + hash_catalog.MakePath());
 
   // Update registered catalog hash in nested catalog
   if (catalog->HasParent()) {

--- a/cvmfs/file_processing/file.cc
+++ b/cvmfs/file_processing/file.cc
@@ -16,8 +16,7 @@ File::File(const std::string    &path,
            IoDispatcher         *io_dispatcher,
            ChunkDetector        *chunk_detector,
            shash::Algorithms     hash_algorithm,
-           const shash::Suffix   hash_suffix,
-           const std::string    &alt_path) :
+           const shash::Suffix   hash_suffix) :
   AbstractFile(path, GetFileSize(path)),
   might_become_chunked_(chunk_detector != NULL &&
                         chunk_detector->MightFindChunks(size())),
@@ -25,8 +24,7 @@ File::File(const std::string    &path,
   hash_suffix_(hash_suffix),
   bulk_chunk_(NULL),
   io_dispatcher_(io_dispatcher),
-  chunk_detector_(chunk_detector),
-  alt_path_(alt_path)
+  chunk_detector_(chunk_detector)
 {
   chunks_to_commit_ = 0;  // tbb::atomic has no init constructor
   CreateInitialChunk();

--- a/cvmfs/file_processing/file.h
+++ b/cvmfs/file_processing/file.h
@@ -34,8 +34,7 @@ class File : public AbstractFile {
        IoDispatcher         *io_dispatcher,
        ChunkDetector        *chunk_detector,
        shash::Algorithms     hash_algorithm,
-       const shash::Suffix   hash_suffix = shash::kSuffixNone,
-       const std::string    &alt_path = "");
+       const shash::Suffix   hash_suffix = shash::kSuffixNone);
   ~File();
 
   bool MightBecomeChunked() const { return might_become_chunked_; }
@@ -74,8 +73,6 @@ class File : public AbstractFile {
   const Chunk*        bulk_chunk()  const { return bulk_chunk_;  }
   const ChunkVector&  chunks()      const { return chunks_;      }
         shash::Suffix hash_suffix() const { return hash_suffix_; }
-
-  const std::string&  alt_path()    const { return alt_path_; }
 
   Chunk* current_chunk() {
     return (chunks_.size() > 0) ? chunks_.back() : NULL;
@@ -116,11 +113,6 @@ class File : public AbstractFile {
    * The ChunkDetector to be used for this file.
    */
   ChunkDetector *chunk_detector_;
-
-  /**
-   * An alternate path where this file should be committed.
-   */
-  const std::string alt_path_;
 };
 
 }  // namespace upload

--- a/cvmfs/file_processing/file_processor.cc
+++ b/cvmfs/file_processing/file_processor.cc
@@ -44,8 +44,7 @@ FileProcessor::~FileProcessor() {
 
 void FileProcessor::Process(const std::string   &local_path,
                             const bool           allow_chunking,
-                            const shash::Suffix  hash_suffix,
-                            const std::string   &alt_path) {
+                            const shash::Suffix  hash_suffix) {
   ChunkDetector *chunk_detector = (chunking_enabled_ && allow_chunking)
                                         ? new Xor32Detector(minimal_chunk_size_,
                                                             average_chunk_size_,
@@ -55,8 +54,7 @@ void FileProcessor::Process(const std::string   &local_path,
                         io_dispatcher_,
                         chunk_detector,
                         hash_algorithm_,
-                        hash_suffix,
-                        alt_path);
+                        hash_suffix);
 
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "Scheduling '%s' for processing ("
                                         "chunking: %s, hash_suffix: %c)",

--- a/cvmfs/file_processing/file_processor.h
+++ b/cvmfs/file_processing/file_processor.h
@@ -80,8 +80,7 @@ class FileProcessor : public Observable<SpoolerResult> {
 
   void Process(const std::string   &local_path,
                const bool           allow_chunking,
-               const shash::Suffix  hash_suffix = shash::kSuffixNone,
-               const std::string   &alt_path="");
+               const shash::Suffix  hash_suffix = shash::kSuffixNone);
 
   void WaitForProcessing();
 

--- a/cvmfs/file_processing/io_dispatcher.cc
+++ b/cvmfs/file_processing/io_dispatcher.cc
@@ -33,8 +33,7 @@ void IoDispatcher::ScheduleWrite(Chunk       *chunk,
       // it successfully committed the complete chunk
       AbstractUploader::MakeClosure(&IoDispatcher::ChunkUploadCompleteCallback,
                                     this,
-                                    chunk),
-      chunk->file()->alt_path());
+                                    chunk));
     if (handle == NULL) {
       LogCvmfs(kLogSpooler, kLogStderr, "initiating streamed upload failed");
       abort();

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -141,10 +141,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
       spooler->RegisterListener(&CommandSign::CertificateUploadCallback, this);
 
     // Safe certificate (and wait for the upload through a Future)
-    spooler->ProcessCertificate(certificate, "");
-    if (manifest->has_alt_catalog_path()) {
-      spooler->ProcessCertificate(certificate, manifest->MakeCertificatePath());
-    }
+    spooler->ProcessCertificate(certificate);
     const shash::Any certificate_hash = certificate_hash_.Get();
     spooler->UnregisterListener(callback);
 

--- a/cvmfs/upload.cc
+++ b/cvmfs/upload.cc
@@ -66,20 +66,15 @@ void Spooler::ProcessHistory(const std::string &local_path) {
   file_processor_->Process(local_path, false, shash::kSuffixHistory);
 }
 
-void Spooler::ProcessCertificate(const std::string &local_path,
-    const std::string &alt_path)
-{
-  file_processor_->Process(local_path, false, shash::kSuffixCertificate,
-                           alt_path);
+void Spooler::ProcessCertificate(const std::string &local_path) {
+  file_processor_->Process(local_path, false, shash::kSuffixCertificate);
 }
 
 
 void Spooler::Upload(const std::string &local_path,
-                     const std::string &remote_path,
-                     const std::string &alt_path) {
+                     const std::string &remote_path) {
   uploader_->Upload(local_path,
                     remote_path,
-                    alt_path,
                     AbstractUploader::MakeCallback(&Spooler::UploadingCallback,
                                                    this));
 }

--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -135,11 +135,9 @@ class Spooler : public Observable<SpoolerResult> {
    *                      backend storage
    * @param remote_path   the destination of the file to be copied in the
    *                      backend storage
-   * @param alt_path      a secondary destination where the file should be saved.
    */
   void Upload(const std::string &local_path,
-              const std::string &remote_path,
-              const std::string &alt_path = "");
+              const std::string &remote_path);
 
   /**
    * Schedules a process job that compresses and hashes the provided file in
@@ -184,10 +182,8 @@ class Spooler : public Observable<SpoolerResult> {
    * processing parameters (like chunking and hash suffixes) accordingly.
    *
    * @param local_path  the location of the certificate file
-   * @param alt_path    the alternate location of the certificate file (if any)
    */
-  void ProcessCertificate(const std::string &local_path,
-                          const std::string &alt_catalog_path = "");
+  void ProcessCertificate(const std::string &local_path);
 
 
   /**

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -131,15 +131,13 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    *
    * @param local_path   path to the file to be uploaded
    * @param remote_path  desired path for the file in the backend storage
-   * @param alt_path     alternate destination to also save the path
    * @param callback     (optional) gets notified when the upload was finished
    */
   void Upload(const std::string  &local_path,
               const std::string  &remote_path,
-              const std::string  &alt_path,
               const CallbackTN   *callback = NULL) {
     ++jobs_in_flight_;
-    FileUpload(local_path, remote_path, alt_path, callback);
+    FileUpload(local_path, remote_path, callback);
   }
 
 
@@ -152,13 +150,10 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    *
    * @param callback   (optional) this callback will be invoked once this parti-
    *                   cular streamed upload is committed.
-   * @param alt_path   (optional) a path where the uploader should also make this
-   *                   file available.
    * @return           a pointer to the initialized UploadStreamHandle
    */
   virtual UploadStreamHandle* InitStreamedUpload(
-                                       const CallbackTN   *callback = NULL,
-                                       const std::string  &alt_path = "") = 0;
+                                       const CallbackTN   *callback = NULL) = 0;
 
 
   /**
@@ -269,7 +264,6 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
   virtual void FileUpload(const std::string  &local_path,
                           const std::string  &remote_path,
-                          const std::string  &alt_path,
                           const CallbackTN   *callback = NULL) = 0;
 
   /**

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -73,7 +73,6 @@ void LocalUploader::WorkerThread() {
 void LocalUploader::FileUpload(
   const std::string &local_path,
   const std::string &remote_path,
-  const std::string &alt_path,
   const CallbackTN   *callback
 ) {
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "FileUpload call started.");
@@ -112,17 +111,6 @@ void LocalUploader::FileUpload(
     Respond(callback, UploaderResults(retcode, local_path));
     return;
   }
-  const std::string destination_path = upstream_path_ + "/" + alt_path;
-  if (alt_path.size() &&
-    ((0 == unlink(destination_path.c_str())) || (errno == ENOENT)) &&
-    ((retcode = symlink(remote_path.c_str(), destination_path.c_str())) != 0))
-  {
-    LogCvmfs(kLogSpooler, kLogVerboseMsg, "failed to symlink file '%s' to its "
-                                          "alternate path %s: %s (errno=%d)",
-             remote_path.c_str(), destination_path.c_str(), strerror(errno),
-             errno);
-    atomic_inc32(&copy_errors_);
-  }
   Respond(callback, UploaderResults(retcode, local_path));
 }
 
@@ -154,16 +142,14 @@ int LocalUploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
 
 
 UploadStreamHandle* LocalUploader::InitStreamedUpload(
-                                                   const CallbackTN *callback,
-                                                   const std::string &alt_path)
-{
+                                                   const CallbackTN *callback) {
   std::string tmp_path;
   const int tmp_fd = CreateAndOpenTemporaryChunkFile(&tmp_path);
   if (tmp_fd < 0) {
     return NULL;
   }
 
-  return new LocalStreamHandle(callback, tmp_fd, tmp_path, alt_path);
+  return new LocalStreamHandle(callback, tmp_fd, tmp_path);
 }
 
 
@@ -229,22 +215,6 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
                                             "(errno: %d)",
                local_handle->temporary_path.c_str(), errno);
     }
-  }
-
-  const std::string &alt_path = local_handle->alt_path_;
-  const std::string destination_path = upstream_path_ + "/" + alt_path;
-  if (alt_path.size() &&
-    ((0 == unlink(destination_path.c_str())) || (errno == ENOENT)) &&
-    (symlink(final_path.c_str(), destination_path.c_str()) != 0))
-  {
-    const int cpy_errno = errno;
-    LogCvmfs(kLogSpooler, kLogVerboseMsg, "failed to symlink file '%s' to its "
-                                          "alternate path %s: %s (errno=%d)",
-             final_path.c_str(), destination_path.c_str(), strerror(errno),
-             errno);
-    atomic_inc32(&copy_errors_);
-    Respond(handle->commit_callback, UploaderResults(cpy_errno));
-    return;
   }
 
   const CallbackTN *callback = handle->commit_callback;

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -18,16 +18,13 @@ namespace upload {
 struct LocalStreamHandle : public UploadStreamHandle {
   LocalStreamHandle(const CallbackTN   *commit_callback,
                     const int           tmp_fd,
-                    const std::string  &tmp_path,
-                    const std::string  &alt_path = "") :
+                    const std::string  &tmp_path) :
     UploadStreamHandle(commit_callback),
     file_descriptor(tmp_fd),
-    temporary_path(tmp_path),
-    alt_path_(alt_path) {}
+    temporary_path(tmp_path) {}
 
   const int         file_descriptor;
   const std::string temporary_path;
-  const std::string alt_path_;
 };
 
 /**
@@ -56,11 +53,9 @@ class LocalUploader : public AbstractUploader {
    */
   void FileUpload(const std::string  &local_path,
                   const std::string  &remote_path,
-                  const std::string  &alt_path,
                   const CallbackTN   *callback = NULL);
 
-  UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL,
-                                         const std::string &alt_path = "");
+  UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
   void Upload(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
               const CallbackTN    *callback = NULL);

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -343,7 +343,6 @@ int S3Uploader::SelectBucket(const std::string &rem_filename) const {
 void S3Uploader::FileUpload(
   const std::string &local_path,
   const std::string &remote_path,
-  const std::string & /*alt_path*/,
   const CallbackTN  *callback
 ) {
   // Choose S3 account and bucket based on the target
@@ -433,9 +432,7 @@ int S3Uploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
 }
 
 
-UploadStreamHandle *S3Uploader::InitStreamedUpload(const CallbackTN *callback,
-    const std::string & /*alt_path*/)
-{
+UploadStreamHandle *S3Uploader::InitStreamedUpload(const CallbackTN *callback) {
   std::string tmp_path;
   const int tmp_fd = CreateAndOpenTemporaryChunkFile(&tmp_path);
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -50,11 +50,9 @@ class S3Uploader : public AbstractUploader {
    */
   void FileUpload(const std::string  &local_path,
                   const std::string  &remote_path,
-                  const std::string  & /*alt_path*/,
                   const CallbackTN   *callback = NULL);
 
-  UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL,
-                                         const std::string &alt_path = "");
+  UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
   void Upload(UploadStreamHandle  *handle,
               CharBuffer          *buffer,
               const CallbackTN    *callback = NULL);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -31,7 +31,7 @@ set(CVMFS_UNITTEST_FILES
   t_buffer.cc
   t_chunk_detectors.cc
   t_upload_facility.cc
-  # t_uploaders.cc
+  t_uploaders.cc
   t_file_processing.cc
   t_async_reader.cc
   t_test_utils.cc

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -243,7 +243,7 @@ TEST_F(T_Fetcher, FetchAltPath) {
   EXPECT_LT(fd, 0);
 
   fd = fetcher_->Fetch(hash_regular_, cache::CacheManager::kSizeUnknown, "reg",
-                       cache::CacheManager::kTypeRegular, "altpath");
+                       cache::CacheManager::kTypeRegular, -1, -1, -1, "altpath");
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 }

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -110,9 +110,7 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
   }
 
   upload::UploadStreamHandle* InitStreamedUpload(
-    const CallbackTN *callback = NULL,
-    const std::string  &alt_path = "") 
-  {
+                                            const CallbackTN *callback = NULL) {
     return new MockStreamHandle(callback);
   }
 

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -28,9 +28,7 @@ class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
     AbstractMockUploader<GC_MockUploader>(spooler_definition) {}
 
   upload::UploadStreamHandle* InitStreamedUpload(
-    const CallbackTN *callback = NULL,
-    const std::string  &alt_path = "") 
-  {
+                                            const CallbackTN *callback = NULL) {
     return NULL;
   }
 

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -46,9 +46,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     initialize_called(false) {}
 
   upload::UploadStreamHandle* InitStreamedUpload(
-    const CallbackTN *callback = NULL,
-    const std::string  &alt_path = "") 
-  {
+                                            const CallbackTN *callback = NULL) {
     return new UF_MockStreamHandle(callback);
   }
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -170,7 +170,6 @@ class AbstractMockUploader : public upload::AbstractUploader {
 
   virtual void FileUpload(const std::string  &local_path,
                           const std::string  &remote_path,
-                          const std::string  &alt_path,
                           const CallbackTN   *callback = NULL) {
     assert(AbstractMockUploader::not_implemented);
   }


### PR DESCRIPTION
The `altpath` mechanism has been superseded by the new bootstrapping method, already in devel.  This switches the CVM-904 branch to use the bootstrapping.