### PR TITLE
Modified: support for client context

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -60,6 +60,7 @@ set (CVMFS_CLIENT_SOURCES
   sqlitevfs.cc sqlitevfs.h
   fetch.cc fetch.h
   sink.h
+  clientctx.cc clientctx.h
 )
 
 

--- a/cvmfs/clientctx.cc
+++ b/cvmfs/clientctx.cc
@@ -1,0 +1,94 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "clientctx.h"
+
+#include <cassert>
+
+ClientCtx *ClientCtx::instance_ = NULL;
+
+namespace {
+
+void TLSDestructor(void *data) {
+  ClientCtx::ThreadLocalStorage *tls =
+    static_cast<ClientCtx::ThreadLocalStorage *>(data);
+  delete tls;
+}
+
+}
+
+void ClientCtx::CleanupInstance() {
+  if (instance_ == NULL)
+    return;
+
+  int retval = pthread_key_delete(instance_->thread_local_storage_);
+  assert(retval == 0);
+  delete instance_;
+  instance_ = NULL;
+}
+
+
+ClientCtx *ClientCtx::GetInstance() {
+  if (instance_ == NULL) {
+    instance_ = new ClientCtx();
+    int retval =
+      pthread_key_create(&instance_->thread_local_storage_, TLSDestructor);
+    assert(retval == 0);
+  }
+
+  return instance_;
+}
+
+
+void ClientCtx::Get(uid_t *uid, gid_t *gid, pid_t *pid) {
+  ThreadLocalStorage *tls = static_cast<ThreadLocalStorage *>(
+    pthread_getspecific(thread_local_storage_));
+  if ((tls == NULL) || !tls->is_set) {
+    *uid = -1;
+    *gid = -1;
+    *pid = -1;
+  } else {
+    *uid = tls->uid;
+    *gid = tls->gid;
+    *pid = tls->pid;
+  }
+}
+
+
+bool ClientCtx::IsSet() {
+  ThreadLocalStorage *tls = static_cast<ThreadLocalStorage *>(
+    pthread_getspecific(thread_local_storage_));
+  if (tls == NULL)
+    return false;
+
+  return tls->is_set;
+}
+
+
+void ClientCtx::Set(uid_t uid, gid_t gid, pid_t pid) {
+  ThreadLocalStorage *tls = static_cast<ThreadLocalStorage *>(
+    pthread_getspecific(thread_local_storage_));
+
+  if (tls == NULL) {
+    tls = new ThreadLocalStorage(uid, gid, pid);
+    int retval = pthread_setspecific(thread_local_storage_, tls);
+    assert(retval == 0);
+  } else {
+    tls->uid = uid;
+    tls->gid = gid;
+    tls->pid = pid;
+    tls->is_set = true;
+  }
+}
+
+void ClientCtx::Unset() {
+  ThreadLocalStorage *tls = static_cast<ThreadLocalStorage *>(
+    pthread_getspecific(thread_local_storage_));
+  if (tls != NULL) {
+    tls->is_set = false;
+    tls->uid = -1;
+    tls->gid = -1;
+    tls->pid = -1;
+  }
+}

--- a/cvmfs/clientctx.h
+++ b/cvmfs/clientctx.h
@@ -1,0 +1,49 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_CLIENTCTX_H_
+#define CVMFS_CLIENTCTX_H_
+
+#include <pthread.h>
+#include <unistd.h>
+
+/**
+ * A client context associates a file system call with the uid, gid, and pid
+ * of the calling process.  For the library, that's the current process and
+ * user.  For the Fuse module, the uid and gid are provided by fuse, the pid
+ * can be figured out from the system. A client context is used to download
+ * files with the credentials of the caller.
+ *
+ * A ClientCtx encapulates thread-local storage.  It can be set somewhere at the
+ * beginning of a file system call and used anywhere during the processing of
+ * the call.  It is a singleton.
+ */
+class ClientCtx {
+ public:
+  struct ThreadLocalStorage {
+    ThreadLocalStorage(uid_t u, gid_t g, pid_t p)
+      : uid(u), gid(g), pid(p), is_set(true) { }
+    uid_t uid;
+    gid_t gid;
+    pid_t pid;
+    bool is_set;  ///< either not yet set or deliberately unset
+  };
+
+  static ClientCtx *GetInstance();
+  static void CleanupInstance();
+
+  void Set(uid_t uid, gid_t gid, pid_t pid);
+  void Unset();
+  void Get(uid_t *uid, gid_t *gid, pid_t *pid);
+  bool IsSet();
+
+ private:
+  static ClientCtx *instance_;
+
+  ClientCtx() { }
+
+  pthread_key_t thread_local_storage_;
+};
+
+#endif  // CVMFS_CLIENTCTX_H_

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -75,6 +75,7 @@ set(CVMFS_UNITTEST_FILES
   t_file_chunk.cc
   t_platforms.cc
   t_compression.cc
+  t_clientctx.cc
 )
 
 #
@@ -195,6 +196,8 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/fetch.cc
   ${CVMFS_SOURCE_DIR}/sqlitevfs.cc
   ${CVMFS_SOURCE_DIR}/sqlitevfs.h
+  ${CVMFS_SOURCE_DIR}/clientctx.h
+  ${CVMFS_SOURCE_DIR}/clientctx.cc
 )
 
 set (CVMFS_UNITTEST_DEBUG_SOURCES ${CVMFS_UNITTEST_SOURCES})

--- a/test/unittests/t_clientctx.cc
+++ b/test/unittests/t_clientctx.cc
@@ -15,6 +15,7 @@ TEST(T_ClientCtx, GetInstance) {
   EXPECT_TRUE(ClientCtx::GetInstance()->IsSet());
   ClientCtx::CleanupInstance();
   EXPECT_FALSE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::CleanupInstance();
 }
 
 TEST(T_ClientCtx, GetSet) {
@@ -54,4 +55,6 @@ TEST(T_ClientCtx, GetSet) {
   EXPECT_EQ(10U, uid);
   EXPECT_EQ(11U, gid);
   EXPECT_EQ(12, pid);
+
+  ClientCtx::CleanupInstance();
 }

--- a/test/unittests/t_clientctx.cc
+++ b/test/unittests/t_clientctx.cc
@@ -1,0 +1,57 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cvmfs/clientctx.h"
+
+TEST(T_ClientCtx, GetInstance) {
+  // Noop, don't crash
+  ClientCtx::CleanupInstance();
+
+  EXPECT_FALSE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::GetInstance()->Set(1, 2, 3);
+  EXPECT_TRUE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::CleanupInstance();
+  EXPECT_FALSE(ClientCtx::GetInstance()->IsSet());
+}
+
+TEST(T_ClientCtx, GetSet) {
+  uid_t uid;
+  gid_t gid;
+  pid_t pid;
+  ClientCtx::GetInstance()->Get(&uid, &gid, &pid);
+  EXPECT_FALSE(ClientCtx::GetInstance()->IsSet());
+  EXPECT_EQ(uid_t(-1), uid);
+  EXPECT_EQ(gid_t(-1), gid);
+  EXPECT_EQ(pid_t(-1), pid);
+
+  ClientCtx::GetInstance()->Set(1, 2, 3);
+  EXPECT_TRUE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::GetInstance()->Get(&uid, &gid, &pid);
+  EXPECT_EQ(1U, uid);
+  EXPECT_EQ(2U, gid);
+  EXPECT_EQ(3, pid);
+
+  ClientCtx::GetInstance()->Set(5, 6, 7);
+  EXPECT_TRUE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::GetInstance()->Get(&uid, &gid, &pid);
+  EXPECT_EQ(5U, uid);
+  EXPECT_EQ(6U, gid);
+  EXPECT_EQ(7, pid);
+
+  ClientCtx::GetInstance()->Unset();
+  EXPECT_FALSE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::GetInstance()->Get(&uid, &gid, &pid);
+  EXPECT_EQ(uid_t(-1), uid);
+  EXPECT_EQ(gid_t(-1), gid);
+  EXPECT_EQ(pid_t(-1), pid);
+
+  ClientCtx::GetInstance()->Set(10, 11, 12);
+  EXPECT_TRUE(ClientCtx::GetInstance()->IsSet());
+  ClientCtx::GetInstance()->Get(&uid, &gid, &pid);
+  EXPECT_EQ(10U, uid);
+  EXPECT_EQ(11U, gid);
+  EXPECT_EQ(12, pid);
+}


### PR DESCRIPTION
This PR is supposed to replace #1309.  Instead of passing the context through the call stack, I'd prefer to store the information in thread local storage at the beginning of a file system callback.  It can then be retrieved by the fetcher when needed.

There is a risk of bugs where mistakenly someone else's context is used but we have only very few, well-known file system callbacks.  So we should be able to get this right.