### PR TITLE
Add `cvmfs_talk cleanup rate` command (CVM-270)

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -358,7 +358,7 @@ if (BUILD_CVMFS)
   target_link_libraries (cvmfs_fuse       ${CVMFS2_LIBS} ${CVMFS_FUSE_LINK_LIBRARIES})
   target_link_libraries (cvmfs_fsck       ${CVMFS_FSCK_LIBS} ${ZLIB_LIBRARIES}
                                           ${OPENSSL_LIBRARIES} ${ZLIB_ARCHIVE} ${SHA2_ARCHIVE}
-                                          ${SHA3_ARCHIVE} pthread)
+                                          ${SHA3_ARCHIVE} ${RT_LIBRARY} pthread)
 
 endif (BUILD_CVMFS)
 

--- a/cvmfs/cvmfs_talk
+++ b/cvmfs/cvmfs_talk
@@ -28,7 +28,7 @@ sub usage {
   print "  cache list pinned      gets pinned file catalogs in cache       \n";
   print "  cache list catalogs    gets all file catalogs in cache          \n";
   print "  cleanup <MB>           cleans file cache until size <= <MB>     \n";
-  print "  cleanup rate <period>  no cleanups in the last <period> min     \n";
+  print "  cleanup rate <period>  n.o. cleanups in the last <period> min   \n";
   print "  evict <path>           removes <path> from the cache            \n";
   print "  pin <path>             pins <path> in the cache                 \n";
   print "  mountpoint             returns the mount point                  \n";

--- a/cvmfs/cvmfs_talk
+++ b/cvmfs/cvmfs_talk
@@ -28,6 +28,7 @@ sub usage {
   print "  cache list pinned      gets pinned file catalogs in cache       \n";
   print "  cache list catalogs    gets all file catalogs in cache          \n";
   print "  cleanup <MB>           cleans file cache until size <= <MB>     \n";
+  print "  cleanup rate <period>  no cleanups in the last <period> min     \n";
   print "  evict <path>           removes <path> from the cache            \n";
   print "  pin <path>             pins <path> in the cache                 \n";
   print "  mountpoint             returns the mount point                  \n";

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -29,6 +29,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <string>
 #include <vector>
 
@@ -303,6 +304,13 @@ inline void platform_get_os_version(int32_t *major,
   assert(res == 0);
   const int matches = sscanf(uts_info.release, "%u.%u.%u", major, minor, patch);
   assert(matches == 3 && "failed to read version string");
+}
+
+inline uint64_t platform_monotonic_time() {
+  struct timespec tp;
+  int retval = clock_gettime(CLOCK_MONOTONIC, &tp);
+  assert(retval == 0);
+  return tp.tv_sec + (tp.tv_nsec >= 500000000);
 }
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -308,7 +308,11 @@ inline void platform_get_os_version(int32_t *major,
 
 inline uint64_t platform_monotonic_time() {
   struct timespec tp;
+#ifdef CLOCK_MONOTONIC_COARSE
+  int retval = clock_gettime(CLOCK_MONOTONIC_COARSE, &tp);
+#else
   int retval = clock_gettime(CLOCK_MONOTONIC, &tp);
+#endif
   assert(retval == 0);
   return tp.tv_sec + (tp.tv_nsec >= 500000000);
 }

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <libkern/OSAtomic.h>
 #include <mach/mach.h>
+#include <mach/mach_time.h>
 #include <mach-o/dyld.h>
 #include <signal.h>
 #include <sys/mount.h>
@@ -248,6 +249,17 @@ inline void platform_get_os_version(int32_t *major,
   const int matches = sscanf(version.c_str(), "%u.%u.%u", major, minor, patch);
   assert(matches == 3 && "failed to read OS X version string");
 }
+
+
+inline uint64_t platform_monotonic_time() {
+  uint64_t val_abs = mach_absolute_time();
+  // Doing the conversion every time is slow but thread-safe
+  mach_timebase_info_data_t info;
+  mach_timebase_info(&info);
+  uint64_t val_ns = val_abs * (info.numer / info.denom);
+  return val_ns * 1e-9;
+}
+
 
 /**
  * strdupa does not exist on OSX

--- a/cvmfs/quota.h
+++ b/cvmfs/quota.h
@@ -332,12 +332,6 @@ class PosixQuotaManager : public QuotaManager {
    */
   static const uint64_t kVolatileFlag = 1ULL << 63;
 
-  /**
-   * Remember cleanup events for 1 day.
-   */
-  static const uint64_t kCleanupRetention = 86400;
-
-
   bool InitDatabase(const bool rebuild_database);
   bool RebuildDatabase();
   void CloseDatabase();

--- a/cvmfs/quota.h
+++ b/cvmfs/quota.h
@@ -16,7 +16,12 @@
 
 #include "duplex_sqlite3.h"
 #include "hash.h"
+#include "statistics.h"
 #include "util.h"
+
+namespace perf {
+class Recorder;
+}
 
 /**
  * The QuotaManager keeps track of the cache contents.  It is informed by the
@@ -38,9 +43,11 @@
 class QuotaManager : SingleCopy {
  public:
   /**
-   * Backchannel protocol revision.
+   * Quota manager protocol revision.
    * Revision 1:
-   *  command 'R': release pinned files if possible
+   *  - backchannel command 'R': release pinned files if possible
+   * Revision 2:
+   *  - add kCleanupRate command
    */
   static const uint32_t kProtocolRevision;
 
@@ -67,6 +74,7 @@ class QuotaManager : SingleCopy {
   virtual uint64_t GetCapacity() = 0;
   virtual uint64_t GetSize() = 0;
   virtual uint64_t GetSizePinned() = 0;
+  virtual uint64_t GetCleanupRate(uint64_t period_s) = 0;
 
   virtual void Spawn() = 0;
   virtual pid_t GetPid() = 0;
@@ -142,6 +150,7 @@ class NoopQuotaManager : public QuotaManager {
   virtual uint64_t GetCapacity() { return uint64_t(-1); }
   virtual uint64_t GetSize() { return 0; }
   virtual uint64_t GetSizePinned() { return 0; }
+  virtual uint64_t GetCleanupRate(uint64_t period_s) { return 0; }
 
   virtual void Spawn() { }
   virtual pid_t GetPid() { return getpid(); }
@@ -198,6 +207,7 @@ class PosixQuotaManager : public QuotaManager {
   virtual uint64_t GetCapacity();
   virtual uint64_t GetSize();
   virtual uint64_t GetSizePinned();
+  virtual uint64_t GetCleanupRate(uint64_t period_s);
 
   virtual void Spawn();
   virtual pid_t GetPid();
@@ -235,6 +245,8 @@ class PosixQuotaManager : public QuotaManager {
     kGetProtocolRevision,
     kInsertVolatile,
     kListVolatile,
+    // as of protocol revision 2
+    kCleanupRate,
   };
 
   /**
@@ -319,6 +331,11 @@ class PosixQuotaManager : public QuotaManager {
    * Volatile entries are used for instance for ALICE conditions data.
    */
   static const uint64_t kVolatileFlag = 1ULL << 63;
+
+  /**
+   * Remember cleanup events for 1 day.
+   */
+  static const uint64_t kCleanupRetention = 86400;
 
 
   bool InitDatabase(const bool rebuild_database);
@@ -417,6 +434,12 @@ class PosixQuotaManager : public QuotaManager {
    * will be performed in a detached, asynchronous process.
    */
   bool async_delete_;
+
+  /**
+   * Keeps track of the number of cleanups over time.  Use by
+   * `cvmfs_talk cleanup rate`
+   */
+  perf::MultiRecorder cleanup_recorder_;
 
   sqlite3 *database_;
   sqlite3_stmt *stmt_touch_;

--- a/cvmfs/statistics.cc
+++ b/cvmfs/statistics.cc
@@ -4,8 +4,10 @@
 
 #include "statistics.h"
 
+#include <algorithm>
 #include <cassert>
 
+#include "platform.h"
 #include "smalloc.h"
 #include "util.h"
 #include "util_concurrency.h"
@@ -32,6 +34,7 @@ std::string Counter::PrintRatio(Counter divider) {
 
 
 //-----------------------------------------------------------------------------
+
 
 Counter *Statistics::Lookup(const std::string &name) {
   MutexLockGuard lock_guard(lock_);
@@ -92,6 +95,114 @@ Statistics::~Statistics() {
   }
   pthread_mutex_destroy(lock_);
   free(lock_);
+}
+
+
+//------------------------------------------------------------------------------
+
+
+/**
+ * If necessary, capacity_s is extended to be a multiple of resolution_s
+ */
+Recorder::Recorder(uint32_t resolution_s, uint32_t capacity_s)
+  : last_timestamp_(0)
+  , capacity_s_(capacity_s)
+  , resolution_s_(resolution_s)
+{
+  assert((resolution_s > 0) && (capacity_s > resolution_s));
+  int has_remainder = (capacity_s_ % resolution_s_) != 0;  // 0 or 1
+  if (has_remainder) {
+    capacity_s_ += resolution_s_ - (capacity_s_ % resolution_s_);
+  }
+  no_bins_ = capacity_s_ / resolution_s_;
+  bins_.reserve(no_bins_);
+  for (unsigned i = 0; i < no_bins_; ++i)
+    bins_.push_back(0);
+}
+
+
+void Recorder::Tick() {
+  TickAt(platform_monotonic_time());
+}
+
+
+void Recorder::TickAt(uint64_t timestamp) {
+  uint64_t bin_abs = timestamp / resolution_s_;
+  uint64_t last_bin_abs = last_timestamp_ / resolution_s_;
+
+  // timestamp in the past: don't update last_timestamp_
+  if (bin_abs < last_bin_abs) {
+    // Do we still remember this event?
+    if ((last_bin_abs - bin_abs) < no_bins_)
+      bins_[bin_abs % no_bins_]++;
+    return;
+  }
+
+  if (last_bin_abs == bin_abs) {
+    bins_[bin_abs % no_bins_]++;
+  } else {
+    // When clearing bins between last_timestamp_ and now, avoid cycling the
+    // ring buffer multiple times.
+    unsigned max_bins_clear = std::min(bin_abs, last_bin_abs + no_bins_ + 1);
+    for (uint64_t i = last_bin_abs + 1; i < max_bins_clear; ++i)
+      bins_[i % no_bins_] = 0;
+    bins_[bin_abs % no_bins_] = 1;
+  }
+
+  last_timestamp_ = timestamp;
+}
+
+
+uint64_t Recorder::GetNoTicks(uint32_t retrospect_s) const {
+  uint64_t now = platform_monotonic_time();
+  if (retrospect_s > now)
+    retrospect_s = now;
+
+  uint64_t last_bin_abs = last_timestamp_ / resolution_s_;
+  uint64_t past_bin_abs = (now - retrospect_s) / resolution_s_;
+  int64_t min_bin_abs =
+    std::max(past_bin_abs,
+             (last_bin_abs < no_bins_) ? 0 : (last_bin_abs - (no_bins_ - 1)));
+  uint64_t result = 0;
+  for (int64_t i = last_bin_abs; i >= min_bin_abs; --i) {
+    result += bins_[i % no_bins_];
+  }
+
+  return result;
+}
+
+
+//------------------------------------------------------------------------------
+
+
+void MultiRecorder::AddRecorder(uint32_t resolution_s, uint32_t capacity_s) {
+  recorders_.push_back(Recorder(resolution_s, capacity_s));
+}
+
+
+uint64_t MultiRecorder::GetNoTicks(uint32_t retrospect_s) const {
+  unsigned N = recorders_.size();
+  for (unsigned i = 0; i < N; ++i) {
+    if ( (recorders_[i].capacity_s() >= retrospect_s) ||
+         (i == (N - 1)) )
+    {
+      return recorders_[i].GetNoTicks(retrospect_s);
+    }
+  }
+  return 0;
+}
+
+
+void MultiRecorder::Tick() {
+  uint64_t now = platform_monotonic_time();
+  for (unsigned i = 0; i < recorders_.size(); ++i)
+    recorders_[i].TickAt(now);
+}
+
+
+void MultiRecorder::TickAt(uint64_t timestamp) {
+  for (unsigned i = 0; i < recorders_.size(); ++i)
+    recorders_[i].TickAt(timestamp);
 }
 
 }  // namespace perf

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -151,6 +151,19 @@ static void *MainTalk(void *data __attribute__((unused))) {
           vector<string> ls_catalogs = quota_mgr->ListCatalogs();
           AnswerStringList(con_fd, ls_catalogs);
         }
+      } else if (line.substr(0, 12) == "cleanup rate") {
+        QuotaManager *quota_mgr = cvmfs::cache_manager_->quota_mgr();
+        if (!quota_mgr->IsEnforcing()) {
+          Answer(con_fd, "Cache is unmanaged\n");
+        } else {
+          if (line.length() < 9) {
+            Answer(con_fd, "Usage: cleanup rate <period in mn>\n");
+          } else {
+            const uint64_t period_s = String2Uint64(line.substr(13)) * 60;
+            const uint64_t rate = quota_mgr->GetCleanupRate(period_s);
+            Answer(con_fd, StringifyInt(rate) + "\n");
+          }
+        }
       } else if (line.substr(0, 7) == "cleanup") {
         QuotaManager *quota_mgr = cvmfs::cache_manager_->quota_mgr();
         if (!quota_mgr->IsEnforcing()) {

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -10,6 +10,11 @@ cvmfs_run_test() {
   find /cvmfs/atlas-condb.cern.ch -type f -size +100M -size -200M | head -n 64 | \
     xargs file > /dev/null || return 1
 
+  turnover=$(sudo cvmfs_talk -i atlas_condb.cern.ch cleanup rate 120)
+  if [ turnover -le 0 ]; then
+    return 2
+  fi
+
   return 0
 }
 

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -11,7 +11,8 @@ cvmfs_run_test() {
     xargs file > /dev/null || return 1
 
   turnover=$(sudo cvmfs_talk -i atlas_condb.cern.ch cleanup rate 120)
-  if [ turnover -le 0 ]; then
+  echo "number of cleanup in the last 2 hours: $turnover"
+  if [[ turnover -le 0 ]]; then
     return 2
   fi
 

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -213,6 +213,7 @@ class TestQuotaManager : public QuotaManager {
   virtual uint64_t GetCapacity() { return 100*1024*1024; }
   virtual uint64_t GetSize() { return 0; }
   virtual uint64_t GetSizePinned() { return 0; }
+  virtual uint64_t GetCleanupRate(uint64_t period_s) { return 0; }
 
   virtual void Spawn() { }
   virtual pid_t GetPid() { return getpid(); }

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -179,11 +179,15 @@ TEST_F(T_QuotaManager, Cleanup) {
 
   quota_mgr_->Insert(hash_null, 1, "");
   quota_mgr_->Insert(hash_rnd, 1, "");
+  EXPECT_EQ(0U, quota_mgr_->GetCleanupRate(60));
   EXPECT_TRUE(quota_mgr_->Cleanup(3));
+  EXPECT_EQ(0U, quota_mgr_->GetCleanupRate(60));
   EXPECT_EQ(2U, quota_mgr_->GetSize());
   EXPECT_TRUE(quota_mgr_->Cleanup(2));
+  EXPECT_EQ(0U, quota_mgr_->GetCleanupRate(60));
   EXPECT_EQ(2U, quota_mgr_->GetSize());
   EXPECT_TRUE(quota_mgr_->Cleanup(0));
+  EXPECT_EQ(1U, quota_mgr_->GetCleanupRate(60));
   EXPECT_EQ(0U, quota_mgr_->GetSize());
   EXPECT_FALSE(FileExists(tmp_path_ + "/" + hash_null.MakePath()));
   EXPECT_FALSE(FileExists(tmp_path_ + "/" + hash_rnd.MakePath()));

--- a/test/unittests/t_statistics.cc
+++ b/test/unittests/t_statistics.cc
@@ -4,6 +4,7 @@
 
 #include "gtest/gtest.h"
 
+#include "../../cvmfs/platform.h"
 #include "../../cvmfs/statistics.h"
 
 using namespace std;  // NOLINT
@@ -53,6 +54,83 @@ TEST(T_Statistics, Statistics) {
 
   EXPECT_EQ("test.counter|0|a test counter\n",
             statistics.PrintList(Statistics::kPrintSimple));
+}
+
+
+TEST(T_Statistics, RecorderConstruct) {
+  Recorder recorder(5, 10);
+  EXPECT_EQ(10U, recorder.capacity_s());
+  Recorder recorder2(5, 9);
+  EXPECT_EQ(10U, recorder2.capacity_s());
+  Recorder recorder3(5, 6);
+  EXPECT_EQ(10U, recorder3.capacity_s());
+  Recorder recorder4(1, 10);
+  EXPECT_EQ(10U, recorder4.capacity_s());
+}
+
+
+TEST(T_Statistics, RecorderTick) {
+  Recorder recorder(1, 10);
+
+  EXPECT_EQ(0U, recorder.GetNoTicks(0));
+  EXPECT_EQ(0U, recorder.GetNoTicks(1));
+  EXPECT_EQ(0U, recorder.GetNoTicks(uint32_t(-1)));
+
+  recorder.Tick();
+  recorder.TickAt(platform_monotonic_time() - 5);
+  EXPECT_EQ(1U, recorder.GetNoTicks(1));
+  EXPECT_EQ(2U, recorder.GetNoTicks(uint32_t(-1)));
+
+  // Don't record tick in the distant past
+  recorder.TickAt(0);
+  EXPECT_EQ(2U, recorder.GetNoTicks(uint32_t(-1)));
+
+  // Many ticks in a past period
+  Recorder recorder2(1, 10);
+  for (unsigned i = 0; i < 10; ++i)
+    recorder2.TickAt(i);
+  EXPECT_EQ(0U, recorder2.GetNoTicks(1));
+  EXPECT_EQ(10U, recorder2.GetNoTicks(uint32_t(-1)));
+  // Long gap with no ticks
+  recorder2.Tick();
+  EXPECT_EQ(1U, recorder2.GetNoTicks(uint32_t(-1)));
+
+  // Ticks not starting at zero
+  Recorder recorder3(1, 10);
+  for (unsigned i = 2; i < 12; ++i)
+    recorder3.TickAt(i);
+  EXPECT_EQ(0U, recorder3.GetNoTicks(1));
+  EXPECT_EQ(10U, recorder3.GetNoTicks(uint32_t(-1)));
+
+  // More coarse-grained binning, ring buffer overflow
+  Recorder recorder4(2, 10);
+  for (unsigned i = 2; i < 22; ++i)
+    recorder4.TickAt(i);
+  EXPECT_EQ(0U, recorder4.GetNoTicks(1));
+  EXPECT_EQ(10U, recorder4.GetNoTicks(uint32_t(-1)));
+
+  // Clear bins
+  Recorder recorder5(1, 10);
+  for (unsigned i = 2; i < 12; ++i)
+    recorder5.TickAt(i);
+  recorder5.TickAt(14);
+  EXPECT_EQ(8U, recorder5.GetNoTicks(uint32_t(-1)));
+}
+
+
+TEST(T_Statistics, MultiRecorder) {
+  MultiRecorder recorder;
+  recorder.Tick();
+  EXPECT_EQ(0U, recorder.GetNoTicks(uint32_t(-1)));
+
+  recorder.AddRecorder(1, 10);
+  recorder.AddRecorder(2, 20);
+  for (unsigned i = 2; i < 22; ++i)
+    recorder.TickAt(i);
+  EXPECT_EQ(20U, recorder.GetNoTicks(uint32_t(-1)));
+  recorder.Tick();
+  EXPECT_EQ(1U, recorder.GetNoTicks(1));
+  EXPECT_EQ(1U, recorder.GetNoTicks(uint32_t(-1)));
 }
 
 }  // namespace perf


### PR DESCRIPTION
Let the quota manager keep track of cleanup events over time.  

Adds helper to query monotonic time with second resolution.  Monotonic time is platform-specific.

Introduces the new `Recorder` class.  The recorder counts events in certain fixed interval bins and for a certain fixed maximum time window in the past.  Implemented as a ring buffer.  Multiple recorders can be put together with more coarse-grained interval bins as the time window in the past increases.  This way, we can keep track of the last 4 days with ~1.5kB memory that is allocated as a block.