### PR TITLE
Add infrastructure for storing / fetching VOMS authz.

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -56,6 +56,7 @@ Catalog::Catalog(const PathString &path,
   managed_database_(false),
   parent_(parent),
   nested_catalog_cache_dirty_(true),
+  voms_authz_status_(Unknown),
   initialized_(false)
 {
   max_row_id_ = 0;
@@ -447,6 +448,28 @@ uint64_t Catalog::GetTTL() const {
   return result;
 }
 
+
+bool Catalog::GetVOMSAuthz(std::string &voms_authz) const {
+  bool result;
+  pthread_mutex_lock(lock_);
+  if (voms_authz_status_ == Present) {
+    voms_authz = voms_authz_;
+    result = true;
+  } else if (voms_authz_status_ == None) {
+    result = false;
+  } else {
+    if (database().HasProperty("voms_authz")) {
+      voms_authz_ = database().GetProperty<std::string>("voms_authz");
+      voms_authz = voms_authz_;
+      voms_authz_status_ = Present;
+    } else {
+      voms_authz_status_ = None;
+    }
+    result = voms_authz_status_ == Present;
+  }
+  pthread_mutex_unlock(lock_);
+  return result;
+}
 
 uint64_t Catalog::GetRevision() const {
   pthread_mutex_lock(lock_);

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -171,6 +171,7 @@ class Catalog : public SingleCopy {
   bool GetExternalData() const;
   uint64_t GetTTL() const;
   uint64_t GetRevision() const;
+  bool GetVOMSAuthz(std::string &) const;
   uint64_t GetLastModified() const;
   uint64_t GetNumEntries() const;
   uint64_t GetNumChunks() const;
@@ -286,6 +287,14 @@ class Catalog : public SingleCopy {
   NestedCatalogMap children_;
   mutable NestedCatalogList nested_catalog_cache_;
   mutable bool              nested_catalog_cache_dirty_;
+
+  enum VomsAuthzLookup {
+    Unknown,
+    None,
+    Present
+  };
+  mutable VomsAuthzLookup voms_authz_status_;
+  mutable std::string voms_authz_;
 
   bool initialized_;
   InodeRange inode_range_;

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -184,6 +184,7 @@ class AbstractCatalogManager : public SingleCopy {
   uint64_t GetRevision() const;
   bool GetVolatileFlag() const;
   uint64_t GetTTL() const;
+  bool GetVOMSAuthz(std::string&) const;
   int GetNumCatalogs() const;
   std::string PrintHierarchy() const;
 

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -451,6 +451,14 @@ uint64_t AbstractCatalogManager<CatalogT>::GetRevision() const {
 }
 
 template <class CatalogT>
+bool AbstractCatalogManager<CatalogT>::GetVOMSAuthz(std::string &authz) const {  //NOLINT
+  ReadLock();
+  const bool has_authz = GetRootCatalog()->GetVOMSAuthz(authz);
+  Unlock();
+  return has_authz;
+}
+
+template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::GetVolatileFlag() const {
   ReadLock();
   const bool volatile_flag = GetRootCatalog()->volatile_flag();

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -94,6 +94,7 @@ void WritableCatalogManager::ActivateCatalog(Catalog *catalog) {
 manifest::Manifest *WritableCatalogManager::CreateRepository(
   const string     &dir_temp,
   const bool        volatile_content,
+  const std::string &voms_authz,
   CatalogProperty   external_data,
   upload::Spooler  *spooler)
 {
@@ -122,6 +123,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
     if (!new_clg_db.IsValid() ||
         !new_clg_db->InsertInitialValues(root_path,
                                           volatile_content,
+                                          voms_authz,
                                           external_data,
                                           root_entry))
     {
@@ -153,6 +155,9 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   const string manifest_path = dir_temp + "/manifest";
   manifest::Manifest *manifest =
     new manifest::Manifest(hash_catalog, catalog_size, "");
+  if (voms_authz.size()) {
+    manifest->set_has_alt_catalog_path(true);
+  }
 
   // Upload catalog
   spooler->Upload(file_path_compressed, "data/" + hash_catalog.MakePath());
@@ -559,6 +564,8 @@ void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
   // Note we do not set the external_data bit for nested catalogs
   retval = new_catalog_db->InsertInitialValues(nested_root_path,
                                                volatile_content,
+                                               "",  // At this point, only root
+                                                    // catalog gets VOMS authz
                                                kUnset,
                                                new_root_entry);
   assert(retval);

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -80,6 +80,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   ~WritableCatalogManager();
   static manifest::Manifest *CreateRepository(const std::string &dir_temp,
                                               const bool volatile_content,
+                                              const std::string &voms_authz,
                                               CatalogProperty external_data,
                                               upload::Spooler   *spooler);
 

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -182,6 +182,7 @@ bool CatalogDatabase::CreateEmptyDatabase() {
 bool CatalogDatabase::InsertInitialValues(
   const std::string    &root_path,
   const bool            volatile_content,
+  const std::string    &voms_authz,
   CatalogProperty       external_data,
   const DirectoryEntry &root_entry)
 {
@@ -217,6 +218,13 @@ bool CatalogDatabase::InsertInitialValues(
     }
   }
 
+  if (voms_authz.size()) {
+    if (!this->SetProperty("voms_authz", voms_authz)) {
+      PrintSqlError("failed to insert VOMS authz flag into the newly created "
+                    "catalog tables.");
+      return false;
+    }
+  }
   if (external_data != kUnset) {
     if (!root_path.empty()) {
       PrintSqlError("External data bit may not be set for nested catalog.");

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -47,6 +47,7 @@ class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
   bool CreateEmptyDatabase();
   bool InsertInitialValues(const std::string     &root_path,
                            const bool             volatile_content,
+                           const std::string     &voms_authz,
                            CatalogProperty        external_data,
                            const DirectoryEntry  &root_entry
                                              = DirectoryEntry(kDirentNegative));

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2892,10 +2892,10 @@ mkfs() {
   fi
   local user_shell="$(get_user_shell $name)"
   local create_cmd="$(__swissknife_cmd) create  \
-    $external_data_opt                         \
+    $external_data_opt                          \
     -t $temp_dir                                \
     -r $upstream                                \
-    -a $hash_algo $volatile_opt $voms_authz_opt \
+    -a $hash_algo $volatile_opt                 \
     -o ${temp_dir}/new_manifest"
   if $garbage_collectable; then
     create_cmd="$create_cmd -z"

--- a/cvmfs/logging.cc
+++ b/cvmfs/logging.cc
@@ -50,7 +50,8 @@ const char *module_names[] = { "unknown", "cache", "catalog", "sql", "cvmfs",
   "hash", "download", "compress", "quota", "talk", "monitor", "lru",
   "fuse stub", "signature", "fs traversal", "catalog traversal",
   "nfs maps", "publish", "spooler", "concurrency", "utility", "glue buffer",
-  "history", "unionfs", "pathspec", "upload s3", "s3fanout", "gc", "dns" };
+  "history", "unionfs", "pathspec", "upload s3", "s3fanout", "gc", "dns",
+  "voms" };
 int syslog_facility = LOG_USER;
 int syslog_level = LOG_NOTICE;
 char *syslog_prefix = NULL;

--- a/cvmfs/logging_internal.h
+++ b/cvmfs/logging_internal.h
@@ -68,7 +68,8 @@ enum LogSource {
   kLogUploadS3,
   kLogS3Fanout,
   kLogGc,
-  kLogDns
+  kLogDns,
+  kLogVoms
 };
 
 const int kLogVerboseMsg = kLogStdout | kLogShowSource | kLogVerbose;

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -789,7 +789,7 @@ bool CommandMigrate::MigrationWorker_20x::CreateNewEmptyCatalog(
     UniquePtr<catalog::CatalogDatabase>
       new_clg_db(catalog::CatalogDatabase::Create(clg_db_path));
     if (!new_clg_db.IsValid() ||
-        !new_clg_db->InsertInitialValues(root_path, volatile_content, kUnset)) {
+        !new_clg_db->InsertInitialValues(root_path, volatile_content, "", kUnset)) {
       Error("Failed to create database for new catalog");
       unlink(clg_db_path.c_str());
       return false;

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -123,6 +123,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
   manifest::Manifest *manifest =
     catalog::WritableCatalogManager::CreateRepository(dir_temp,
                                                       volatile_content,
+                                                      voms_authz,
                                                       external_data ? kYes :
                                                                       kUnset,
                                                       spooler);

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -101,6 +101,8 @@ class CommandCreate : public Command {
     r.push_back(Parameter::Switch('v', "repository containing volatile files"));
     r.push_back(Parameter::Switch(
       'z', "mark new repository as garbage collectable"));
+    r.push_back(Parameter::Optional('V', "VOMS authz requirement "
+                                         "(default: none)"));
     return r;
   }
   int Main(const ArgumentList &args);
@@ -228,6 +230,8 @@ class CommandSync : public Command {
     r.push_back(Parameter::Switch('d', "pause publishing to allow for "
                                           "catalog tweaks"));
     r.push_back(Parameter::Switch('g', "repo is garbage collectable"));
+    r.push_back(Parameter::Optional('V', "VOMS authz requirement "
+                                         "(default: none)"));
     r.push_back(Parameter::Switch('p', "enable file chunking"));
     r.push_back(Parameter::Switch('k', "include extended attributes"));
     r.push_back(Parameter::Optional('z', "log level (0-4, default: 2)"));

--- a/test/unittests/t_catalog.cc
+++ b/test/unittests/t_catalog.cc
@@ -89,7 +89,7 @@ class T_Catalog : public ::testing::Test {
         new_clg_db(catalog::CatalogDatabase::Create(db_file));
       EXPECT_TRUE(new_clg_db.IsValid());
       bool retval =
-          new_clg_db->InsertInitialValues(root_path, volatile_content, kUnset);
+          new_clg_db->InsertInitialValues(root_path, volatile_content, "", kUnset);
       EXPECT_TRUE(retval);
     }
     return db_file;

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -488,6 +488,7 @@ class T_ObjectFetcher : public ::testing::Test {
     catalog::DirectoryEntry root_entry;  // mocked root entry...
     const bool success = catalog_db->InsertInitialValues(root_path,
                                                          volatile_content,
+                                                         "",
                                                          kUnset,
                                                          root_entry) &&
                          catalog_db->SetProperty("revision", catalog_revision);


### PR DESCRIPTION
Nothing is plumbed to actually use this on the client side, but
the VOMS authz information is now stored in the database.

Another part of the prep work for CVM-904.

When merged, please merge `devel` back into `CVM-904` so I can prep the next round of PRs.