### PR TITLE
Initialize external download manager counters.

### DIFF
--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -316,7 +316,7 @@ int cvmfs_context::Setup(const options &opts, perf::Statistics *statistics) {
   download_ready_ = true;
 
   external_download_manager_ = new download::DownloadManager();
-  external_download_manager_->Init(16, false, statistics);
+  external_download_manager_->Init(16, false, statistics, "download-external");
   external_download_manager_->SetHostChain(opts.external_url);
   external_download_manager_->SetTimeout(opts.timeout,
                                 opts.timeout_direct);


### PR DESCRIPTION
Without this, both download managers try to register the same
counters and trigger an assert (only when using libcvmfs).

This now initializes the external download manager for libcvmfs and fuse the same way.