### PR TITLE
Fix setting of external data for nested directory creation.

### DIFF
--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -46,6 +46,9 @@ SyncItem SyncUnion::CreateSyncItem(const std::string  &relative_parent_path,
                                    const SyncItemType  entry_type) const {
   SyncItem entry(relative_parent_path, filename, this, entry_type);
   PreprocessSyncItem(&entry);
+  if (entry_type == kItemFile) {
+    entry.SetExternalData(GetExternalData());
+  }
   return entry;
 }
 
@@ -91,7 +94,6 @@ void SyncUnion::ProcessRegularFile(const string &parent_dir,
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessRegularFile(%s, %s)",
            parent_dir.c_str(), filename.c_str());
   SyncItem entry = CreateSyncItem(parent_dir, filename, kItemFile);
-  entry.SetExternalData(GetExternalData());
   ProcessFile(entry);
 }
 


### PR DESCRIPTION
When the union traversal finds a subdirectory, it creates a separate
filesystem crawler to process the new subdirectory.  The latter is
a different object whose code path doesn't set the external data
property.  Move the setting of this property to a common function for
both.

Discovered this when doing some large-scale testing of grafting.  Other than this problem, all is looking well!