### PR TITLE
CVM-904 - Require explicit VO name

### DIFF
--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -130,7 +130,7 @@ cvmfs_run_test() {
   apache_switch on
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -V /cvmfs || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -V cvmfs:/cvmfs || return $?
 
   start_transaction $CVMFS_TEST_REPO || return $?
   echo "Hello World" > /cvmfs/$CVMFS_TEST_REPO/hello_world

--- a/test/unittests/t_voms.cc
+++ b/test/unittests/t_voms.cc
@@ -33,6 +33,8 @@ TEST(T_VOMS, VomsAuthz) {
     std::vector<char> user_dn; user_dn.reserve(100);
     strncpy(&user_dn[0], TEST_DN, 99);
     voms_entry.user = &user_dn[0];
+    char voname[] = "cms";
+    voms_entry.voname = voname;
     std::vector<char> group1; group1.reserve(50);
     strncpy(&group1[0], "/cms", 49);
     std::vector<char> group2; group2.reserve(50);
@@ -48,38 +50,38 @@ TEST(T_VOMS, VomsAuthz) {
     voms_data[2].role = &role1[0];
 
     // Ok, now let's verify the authz checks.
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms"), true);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/uscms"), true);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/atlas"), false);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms"), true);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/uscms"), true);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "atlas:/atlas"), false);
     EXPECT_EQ(CheckSingleAuthz(&voms_info, TEST_DN), true);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/dcms"), false);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/Role=pilot"), true);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/escms/Role=pilot"), true);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/Role=prod"), false);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/uscms/Role=pilot"), false);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/dcms/Role=pilot"), false);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/dcms"), false);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/Role=pilot"), true);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/escms/Role=pilot"), true);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/Role=prod"), false);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/uscms/Role=pilot"), false);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/dcms/Role=pilot"), false);
 
     voms_data[0].group = NULL;
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms"), true);
-    EXPECT_EQ(CheckSingleAuthz(&voms_info, "/cms/Role=pilot"), true);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms"), true);
+    EXPECT_EQ(CheckSingleAuthz(&voms_info, "cms:/cms/Role=pilot"), true);
     voms_entry.user = NULL;
     EXPECT_EQ(CheckSingleAuthz(&voms_info, TEST_DN), false);
 
     // Switch to multiple authz functions.
     EXPECT_EQ(CheckMultipleAuthz(&voms_info, ""), false);
     EXPECT_EQ(CheckMultipleAuthz(&voms_info, "\n"), false);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/cms"), true);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/cms\n"), true);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/atlas"), false);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/cms\natlas"), true);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/atlas\n/cms"), true);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/atlas\n\n/cms"), true);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "/atlas\n\n/dteam\n"), false);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "cms:/cms"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "cms:/cms\n"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "atlas:/atlas"), false);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "cms:/cms\natlas"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "atlas:/atlas\ncms:/cms"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "atlas:/atlas\n\ncms:/cms"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, "atlas:/atlas\n\ndteam:/dteam\n"), false);
     EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN), false);
     EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\n"), false);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\n/cms/Role=prod"), false);
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\n/cms/Role=pilot"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\ncms:/cms/Role=prod"), false);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\ncms:/cms/Role=pilot"), true);
     voms_entry.user = &user_dn[0];
-    EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\n/cms/Role=prod"), true);
+    EXPECT_EQ(CheckMultipleAuthz(&voms_info, TEST_DN "\ncms:/cms/Role=prod"), true);
 }
 


### PR DESCRIPTION
In case two VOs (purposely or accidentally) start using overlapping
group names, require the VOMS authz to explicitly name which VO is
being used.

For example, the LIGO VO issues attributes of the form /ligo; it
appears it's not safe to assume the VO name is part of the group
name.

Includes updated unit and integration tests.