### PR TITLE
Add support for passing compression algorithm when creating graft files.

### DIFF
--- a/cvmfs/catalog_balancer_impl.h
+++ b/cvmfs/catalog_balancer_impl.h
@@ -55,8 +55,10 @@ void CatalogBalancer<CatalogMgrT>::AddCatalogMarker(string path) {
       MakeEmptyDirectoryEntryBase(".cvmfsautocatalog", parent.uid(),
                                            parent.gid());
   string relative_path = path.substr(1);
-  catalog_mgr_->AddFile(cvmfscatalog, xattr, false, relative_path);
-  catalog_mgr_->AddFile(cvmfsautocatalog, xattr, false, relative_path);
+  catalog_mgr_->AddFile(cvmfscatalog, xattr, false, zlib::kZlibDefault,
+                        relative_path);
+  catalog_mgr_->AddFile(cvmfsautocatalog, xattr, false, zlib::kZlibDefault,
+                        relative_path);
 }
 
 template <class CatalogMgrT>

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -336,6 +336,7 @@ void WritableCatalogManager::AddFile(
   const DirectoryEntry  &entry,
   const XattrList       &xattrs,
         bool             external_data,
+        zlib::Algorithms compression_algorithm,
   const std::string     &parent_directory)
 {
   const string parent_path = MakeRelativePath(parent_directory);
@@ -350,7 +351,8 @@ void WritableCatalogManager::AddFile(
   }
 
   assert(!entry.IsRegular() || !entry.checksum().IsNull());
-  catalog->AddEntry(entry, xattrs, file_path, parent_path, external_data);
+  catalog->AddEntry(entry, xattrs, file_path, parent_path, external_data,
+                    compression_algorithm);
   SyncUnlock();
 }
 
@@ -366,7 +368,7 @@ void WritableCatalogManager::AddChunkedFile(
   DirectoryEntry full_entry(entry);
   full_entry.set_is_chunked_file(true);
 
-  AddFile(full_entry, xattrs, false, parent_directory);
+  AddFile(full_entry, xattrs, false, entry.compression_algorithm(), parent_directory);
 
   const string parent_path = MakeRelativePath(parent_directory);
   const string file_path   = entry.GetFullPath(parent_path);
@@ -402,7 +404,9 @@ void WritableCatalogManager::AddHardlinkGroup(
   if (entries.size() == 1) {
     DirectoryEntry fix_linkcount(entries[0]);
     fix_linkcount.set_linkcount(1);
-    return AddFile(fix_linkcount, xattrs, false, parent_directory);
+    return AddFile(fix_linkcount, xattrs, false,
+                   entries[0].compression_algorithm(),
+                   parent_directory);
   }
 
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "adding hardlink group %s/%s",

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -88,9 +88,11 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void AddFile(const DirectoryEntryBase &entry,
                const XattrList &xattrs,
                      bool       external_data,
+                     zlib::Algorithms compression_algorithm,
                const std::string &parent_directory)
   {
-    AddFile(DirectoryEntry(entry), xattrs, external_data, parent_directory);
+    AddFile(DirectoryEntry(entry), xattrs, external_data, compression_algorithm,
+            parent_directory);
   }
   void AddChunkedFile(const DirectoryEntryBase &entry,
                       const XattrList &xattrs,
@@ -144,6 +146,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void AddFile(const DirectoryEntry  &entry,
                const XattrList       &xattrs,
                      bool             external_data,
+                     zlib::Algorithms compression_algorithm,
                const std::string     &parent_directory);
 
  private:

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -138,7 +138,8 @@ void WritableCatalog::AddEntry(
   const XattrList &xattrs,
   const string &entry_path,
   const string &parent_path,
-  const bool external_data)
+  const bool external_data,
+  const zlib::Algorithms compression_algorithm)
 {
   SetDirty();
 
@@ -150,6 +151,7 @@ void WritableCatalog::AddEntry(
   shash::Md5 parent_hash((shash::AsciiPtr(parent_path)));
   DirectoryEntry effective_entry(entry);
   effective_entry.set_has_xattrs(!xattrs.IsEmpty());
+  effective_entry.set_compression_algorithm(compression_algorithm);
 
   if (effective_entry.IsRegular() && (GetExternalData() || external_data)) {
     LogCvmfs(kLogCatalog, kLogDebug, "Entry is set as external data.");

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -60,7 +60,9 @@ class WritableCatalog : public Catalog {
                 const XattrList &xattr,
                 const std::string &entry_path,
                 const std::string &parent_path,
-                const bool external_data = false);
+                const bool external_data=false,
+                const zlib::Algorithms compression_algorithm =
+                                            zlib::kZlibDefault);
   void TouchEntry(const DirectoryEntryBase &entry, const shash::Md5 &path_hash);
   inline void TouchEntry(
     const DirectoryEntryBase &entry,

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -147,6 +147,10 @@ class DirectoryEntryBase {
   inline zlib::Algorithms compression_algorithm() const {
     return compression_algorithm_;
   }
+  inline void set_compression_algorithm(
+      zlib::Algorithms compression_algorithm) {
+    compression_algorithm_ = compression_algorithm;
+  }
 
   /**
    * Converts to a stat struct as required by many Fuse callbacks.

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -625,6 +625,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     return 4;
   }
   sync->SetExternalData(params.external_data);
+  sync->SetCompressionAlgorithm(compression_algorithm);
 
   sync->Traverse();
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -523,6 +523,7 @@ void SyncMediator::PublishFilesCallback(const upload::SpoolerResult &result) {
       item.CreateBasicCatalogDirent(),
       *xattrs,
       item.IsExternalData(),
+      item.GetCompressionAlgorithm(),
       item.relative_parent_path());
   }
 
@@ -627,6 +628,7 @@ void SyncMediator::AddFile(const SyncItem &entry) {
       entry.CreateBasicCatalogDirent(),
       default_xattrs,
       entry.IsExternalData(),
+      entry.GetCompressionAlgorithm(),
       entry.relative_parent_path());
   } else if (entry.HasGraftMarker()) {
     if (entry.IsValidGraft()) {
@@ -636,6 +638,7 @@ void SyncMediator::AddFile(const SyncItem &entry) {
         default_xattrs,  // TODO(bbockelm): For now, use default xattrs
                          // on grafted files.
         entry.IsExternalData(),  // TODO(bbockelm): Take this from in graft.
+        union_engine_->GetCompressionAlgorithm(),
         entry.relative_parent_path());
     } else {
       // Unlike with regular files, grafted files can be "unpublishable" - i.e.,

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -31,7 +31,8 @@ SyncUnion::SyncUnion(SyncMediator *mediator,
   scratch_path_(scratch_path),
   union_path_(union_path),
   mediator_(mediator),
-  initialized_(false) {}
+  initialized_(false),
+  compression_algorithm_(zlib::kZlibDefault) {}
 
 
 bool SyncUnion::Initialize() {
@@ -306,7 +307,7 @@ bool SyncUnionOverlayfs::ObtainSysAdminCapability() const {
 
 void SyncUnionOverlayfs::PreprocessSyncItem(SyncItem *entry) const {
   SyncUnion::PreprocessSyncItem(entry);
-  if (entry->IsWhiteout() || entry->IsDirectory()) {
+  if (entry->IsGraftMarker() || entry->IsWhiteout() || entry->IsDirectory()) {
     return;
   }
 

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -134,6 +134,13 @@ class SyncUnion {
   void SetExternalData(bool external_data) {external_data_ = external_data;}
   bool GetExternalData() const {return external_data_;}
 
+  void SetCompressionAlgorithm(zlib::Algorithms compression_algorithm) {
+    compression_algorithm_ = compression_algorithm;
+  }
+  zlib::Algorithms GetCompressionAlgorithm() const {
+    return compression_algorithm_;
+  }
+
  protected:
   std::string rdonly_path_;
   std::string scratch_path_;
@@ -203,6 +210,7 @@ class SyncUnion {
  private:
   bool initialized_;
   bool external_data_;
+  zlib::Algorithms compression_algorithm_;
 };  // class SyncUnion
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -558,6 +558,7 @@ class MockCatalogManager : public AbstractCatalogManager<MockCatalog> {
   void AddFile(const DirectoryEntryBase &entry,
                const XattrList &xattrs,
                      bool       external_data,
+                     zlib::Algorithms compression_algorithm,
                const std::string &parent_directory)
   {
     ++num_added_files_;


### PR DESCRIPTION
Grafting does not go through the spooler process, yet compression
algorithm is only known post-spooling.  This passes the compression
algorithm to the sync stage, allowing us to set the graft's properties
correctly.

Without this, all grafted files have the default zlib compression bit set.