### PR TITLE
FIX: CentOS 7 Docker Build

### DIFF
--- a/ci/docker/cc7_x86_64/build.sh
+++ b/ci/docker/cc7_x86_64/build.sh
@@ -7,7 +7,7 @@ SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
 SYSTEM_NAME="cc7"
 BASE_ARCH="x86_64"
-REPO_BASE_URL="http://linuxsoft.cern.ch/cern/centos/7/os/$BASE_ARCH/"
+REPO_BASE_URL="http://linuxsoft.cern.ch/cern/centos/7.2/os/$BASE_ARCH/"
 GPG_KEY_PATHS="file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
 BASE_PACKAGES="centos-release coreutils tar iputils rpm yum"
 


### PR DESCRIPTION
This uses the latest packages (CentOS 7.2) for docker image bootstrapping right away. That should fix our CentOS 7 build, that failed due to a docker image bootstrapping issue.
In more detail, `build.sh` bootstrapped from outdated CentOS 7 packages and the `Dockerfile` tried to update most of the packages in a second step. Unfortunately the `iputils` package fails to update, thus stopping the docker image bootstrapping and eventually the build.