### PR TITLE
FIX: OverlayFS Version Guessing on CentOS 7

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -613,8 +613,15 @@ get_overlayfs_type() {
   ofs_name="$(get_overlayfs_name)"
   vermagic="$(modinfo --field vermagic $ofs_name)"
   krnl_version="$(echo "$vermagic" | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+')"
+
+  post_v22_krnl_version="3.18.0"
+  if is_redhat; then post_v22_krnl_version="3.10.0"; fi
+
   ofs_type=$OFS_POST_V22
-  if compare_versions "$krnl_version" -lt 3.18.0; then ofs_type=$OFS_PRE_V22; fi
+  if compare_versions "$krnl_version" -lt "$post_v22_krnl_version"; then
+    ofs_type=$OFS_PRE_V22
+  fi
+
   echo "$ofs_type"
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -361,6 +361,10 @@ NOTE: $errormsg
   fi
 }
 
+is_redhat() {
+  [ -f /etc/redhat-release ]
+}
+
 load_repo_config() {
   local name=$1
   . /etc/cvmfs/repositories.d/${name}/server.conf
@@ -663,7 +667,7 @@ check_wsgi_module() {
 
   echo "The apache wsgi module must be installed and enabled.
 The required package is called ${APACHE_WSGI_MODPKG}."
-  if [ -f /etc/redhat-release ]; then
+  if is_redhat; then
     case "`cat /etc/redhat-release`" in
       *"release 5."*)
         if [ -f /etc/httpd/conf.d/wsgi.conf ]; then


### PR DESCRIPTION
This fixes the guessing procedure for the OverlayFS version on CentOS. I didn't find a better way to figure this out, yet. :-1: 