### PR TITLE
FIX: replication for external files and uncompressed files

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -265,7 +265,8 @@ set (CVMFS_PRELOADER_SOURCES
   whitelist.cc whitelist.h
   sanitizer.cc sanitizer.h
   dns.cc dns.h
-  dirtab.cc dirtab.h
+  path_filters/dirtab.h path_filters/dirtab.cc
+  path_filters/relaxed_path_filter.h path_filters/relaxed_path_filter.cc
   catalog.cc catalog.h
   preload.cc
 )

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -352,8 +352,9 @@ bool Catalog::AllChunksBegin() {
 }
 
 
-bool Catalog::AllChunksNext(shash::Any *hash) {
-  return sql_all_chunks_->Next(hash);
+bool Catalog::AllChunksNext(shash::Any *hash, zlib::Algorithms *compression_alg)
+{
+  return sql_all_chunks_->Next(hash, compression_alg);
 }
 
 

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -147,7 +147,7 @@ class Catalog : public SingleCopy {
                               listing);
   }
   bool AllChunksBegin();
-  bool AllChunksNext(shash::Any *hash);
+  bool AllChunksNext(shash::Any *hash, zlib::Algorithms *compression_alg);
   bool AllChunksEnd();
 
   inline bool ListPathChunks(const PathString &path,

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1120,7 +1120,8 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
   "WHEN flags & " + StringifyInt(SqlDirent::kFlagDir) + " THEN " +
     StringifyInt(shash::kSuffixMicroCatalog) + " END " +
   "AS chunk_type, " + flags2hash +
-  "FROM catalog WHERE hash IS NOT NULL";
+  "FROM catalog WHERE (hash IS NOT NULL) AND "
+    "(flags & " + StringifyInt(SqlDirent::kFlagFileExternal) + " = 0)";
   if (database.schema_version() >= 2.4 - CatalogDatabase::kSchemaEpsilon) {
     sql +=
       " UNION "

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1110,6 +1110,12 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
     " ((flags&" + StringifyInt(hash_mask) + ") >> " +
     StringifyInt(SqlDirent::kFlagPosHash) + ")+1 AS hash_algorithm ";
 
+  int compression_mask = 7 << SqlDirent::kFlagPosCompression;
+  string flags2compression =
+    " ((flags&" + StringifyInt(compression_mask) + ") >> " +
+    StringifyInt(SqlDirent::kFlagPosCompression) + ") " +
+    "AS compression_algorithm ";
+
   // TODO(reneme): this depends on shash::kSuffix* being a char!
   //               it should be more generic or replaced entirely
   // TODO(reneme): this is practically the same as SqlListContentHashes and
@@ -1119,14 +1125,15 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
     StringifyInt(shash::kSuffixNone) + " " +
   "WHEN flags & " + StringifyInt(SqlDirent::kFlagDir) + " THEN " +
     StringifyInt(shash::kSuffixMicroCatalog) + " END " +
-  "AS chunk_type, " + flags2hash +
+  "AS chunk_type, " + flags2hash + "," + flags2compression +
   "FROM catalog WHERE (hash IS NOT NULL) AND "
     "(flags & " + StringifyInt(SqlDirent::kFlagFileExternal) + " = 0)";
   if (database.schema_version() >= 2.4 - CatalogDatabase::kSchemaEpsilon) {
     sql +=
       " UNION "
       "SELECT DISTINCT chunks.hash, " + StringifyInt(shash::kSuffixPartial) +
-      ", " + flags2hash + "FROM chunks, catalog WHERE "
+      ", " + flags2hash + "," + flags2compression +
+      "FROM chunks, catalog WHERE "
       "chunks.md5path_1=catalog.md5path_1 AND "
       "chunks.md5path_2=catalog.md5path_2";
   }
@@ -1140,13 +1147,14 @@ bool SqlAllChunks::Open() {
 }
 
 
-bool SqlAllChunks::Next(shash::Any *hash) {
+bool SqlAllChunks::Next(shash::Any *hash, zlib::Algorithms *compression_alg) {
   if (!FetchRow()) {
     return false;
   }
 
   *hash = RetrieveHashBlob(0, static_cast<shash::Algorithms>(RetrieveInt(2)),
                               static_cast<shash::Suffix>(RetrieveInt(1)));
+  *compression_alg = static_cast<zlib::Algorithms>(RetrieveInt(3));
   return true;
 }
 

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -525,7 +525,7 @@ class SqlAllChunks : public Sql {
  public:
   explicit SqlAllChunks(const CatalogDatabase &database);
   bool Open();
-  bool Next(shash::Any *hash);
+  bool Next(shash::Any *hash, zlib::Algorithms *compression_alg);
   bool Close();
 };
 

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -192,6 +192,7 @@ class SqlDirent : public Sql {
   // as of 2^8: 3 bit for hashes
   //   - 0: SHA-1
   //   - 1: RIPEMD-160
+  //   - ...
   // Corresponds to shash::algorithms with offset in order to support future
   // hashes
   static const int kFlagPosHash             = 8;

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -294,8 +294,8 @@ bool SignatureManager::LoadPublicRsaKeys(const string &path_list) {
  * Loads a list of blacklisted certificates (fingerprints) from a file.
  */
 bool SignatureManager::LoadBlacklist(
-  const std::string &path_blacklist, 
-  bool append) 
+  const std::string &path_blacklist,
+  bool append)
 {
   if (!append)
     blacklisted_certificates_.clear();

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -23,6 +23,7 @@
 
 #include "atomic.h"
 #include "catalog.h"
+#include "compression.h"
 #include "download.h"
 #include "hash.h"
 #include "history_sqlite.h"
@@ -49,11 +50,13 @@ class ChunkJob {
  public:
   ChunkJob()
     : suffix(shash::kSuffixNone)
-    , hash_algorithm(shash::kAny) {}
+    , hash_algorithm(shash::kAny)
+    , compression_alg(zlib::kZlibDefault) {}
 
-  explicit ChunkJob(const shash::Any &hash)
+  ChunkJob(const shash::Any &hash, zlib::Algorithms compression_alg)
     : suffix(hash.suffix)
     , hash_algorithm(hash.algorithm)
+    , compression_alg(compression_alg)
   {
     memcpy(digest, hash.digest, hash.GetDigestSize());
   }
@@ -71,6 +74,7 @@ class ChunkJob {
 
   const shash::Suffix      suffix;
   const shash::Algorithms  hash_algorithm;
+  const zlib::Algorithms   compression_alg;
   unsigned char            digest[shash::kMaxDigestSize];
 };
 
@@ -158,32 +162,50 @@ static void ReportDownloadError(const shash::Any &failed_hash,
 }
 
 
-static void Store(const string &local_path, const string &remote_path) {
+static void Store(
+  const string &local_path,
+  const string &remote_path,
+  const bool compressed_src)
+{
   if (preload_cache) {
-    string tmp_dest;
-    FILE *fdest = CreateTempFile(remote_path, 0660, "w", &tmp_dest);
-    if (fdest == NULL) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create temporary file '%s'",
-               remote_path.c_str());
-      abort();
+    if (!compressed_src) {
+      int retval = rename(local_path.c_str(), remote_path.c_str());
+      if (retval != 0) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Failed to move '%s' to '%s'",
+                 local_path.c_str(), remote_path.c_str());
+        abort();
+      }
+    } else {
+      // compressed input
+      string tmp_dest;
+      FILE *fdest = CreateTempFile(remote_path, 0660, "w", &tmp_dest);
+      if (fdest == NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create temporary file '%s'",
+                 remote_path.c_str());
+        abort();
+      }
+      int retval = zlib::DecompressPath2File(local_path, fdest);
+      if (!retval) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Failed to preload %s to %s",
+                 local_path.c_str(), remote_path.c_str());
+        abort();
+      }
+      fclose(fdest);
+      retval = rename(tmp_dest.c_str(), remote_path.c_str());
+      assert(retval == 0);
+      unlink(local_path.c_str());
     }
-    int retval = zlib::DecompressPath2File(local_path, fdest);
-    if (!retval) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to preload %s to %s",
-               local_path.c_str(), remote_path.c_str());
-      abort();
-    }
-    fclose(fdest);
-    retval = rename(tmp_dest.c_str(), remote_path.c_str());
-    assert(retval == 0);
-    unlink(local_path.c_str());
   } else {
     spooler->Upload(local_path, remote_path);
   }
 }
 
-static void Store(const string &local_path, const shash::Any &remote_hash) {
-  Store(local_path, MakePath(remote_hash));
+static void Store(
+  const string &local_path,
+  const shash::Any &remote_hash,
+  const bool compressed_src = true)
+{
+  Store(local_path, MakePath(remote_hash), compressed_src);
 }
 
 
@@ -201,7 +223,7 @@ static void StoreBuffer(const unsigned char *buffer, const unsigned size,
   }
   assert(retval);
   fclose(ftmp);
-  Store(tmp_file, dest_path);
+  Store(tmp_file, dest_path, true);
 }
 
 static void StoreBuffer(const unsigned char *buffer, const unsigned size,
@@ -225,6 +247,7 @@ static void *MainWorker(void *data) {
       break;
 
     shash::Any chunk_hash = next_chunk.hash();
+    zlib::Algorithms compression_alg = next_chunk.compression_alg;
     LogCvmfs(kLogCvmfs, kLogVerboseMsg, "processing chunk %s",
              chunk_hash.ToString().c_str());
 
@@ -248,7 +271,8 @@ static void *MainWorker(void *data) {
         attempts++;
       } while ((retval != download::kFailOk) && (attempts < retries));
       fclose(fchunk);
-      Store(tmp_file, chunk_hash);
+      Store(tmp_file, chunk_hash,
+            (compression_alg == zlib::kZlibDefault) ? true : false);
       atomic_inc64(&overall_new);
     }
     if (atomic_xadd64(&overall_chunks, 1) % 1000 == 0)
@@ -339,6 +363,7 @@ static bool Pull(const shash::Any &catalog_hash, const std::string &path) {
 
   // Download and uncompress catalog
   shash::Any chunk_hash;
+  zlib::Algorithms compression_alg;
   catalog::Catalog *catalog = NULL;
   string file_catalog;
   string file_catalog_vanilla;
@@ -395,8 +420,8 @@ static bool Pull(const shash::Any &catalog_hash, const std::string &path) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to gather chunks");
     goto pull_cleanup;
   }
-  while (catalog->AllChunksNext(&chunk_hash)) {
-    ChunkJob next_chunk(chunk_hash);
+  while (catalog->AllChunksNext(&chunk_hash, &compression_alg)) {
+    ChunkJob next_chunk(chunk_hash, compression_alg);
     WritePipe(pipe_chunks[1], &next_chunk, sizeof(next_chunk));
     atomic_inc64(&chunk_queue);
   }

--- a/test/src/620-pullmixedrepo/main
+++ b/test/src/620-pullmixedrepo/main
@@ -134,7 +134,7 @@ cvmfs_run_test() {
   compare_directories $repo_dir $reference_dir || return $?
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
-  
+
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -172,6 +172,34 @@ cvmfs_run_test() {
 
   echo "clean up"
   sudo cvmfs_server rmfs -f $replica_name
+
+  echo "preloading a cache"
+  local preload_dir=/srv/cvmfs/${CVMFS_TEST_REPO}/preloaded
+  cvmfs_preload -u "http://localhost/cvmfs/$CVMFS_TEST_REPO" \
+    -r $preload_dir \
+    -k "/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub" \
+    -m "$CVMFS_TEST_REPO" || return $?
+
+  local local_conf=$(pwd)/local.conf
+  echo "Create a local configuration file in $local_conf"
+  mkdir cache || return 40
+  cat > $local_conf << EOF
+CVMFS_CACHE_BASE=$(pwd)/cache
+CVMFS_QUOTA_LIMIT=-1
+CVMFS_RELOAD_SOCKETS=$(pwd)/cache
+CVMFS_ALIEN_CACHE=$preload_dir
+CVMFS_SERVER_URL=NOAVAIL
+CVMFS_HTTP_PROXY=NOAVAIL
+CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub
+EOF
+
+  echo "Mount the repository in $REPO_MOUNTPOINT to verify it"
+  REPO_MOUNTPOINT="$(pwd)/mnt"
+  trap desaster_cleanup EXIT HUP INT TERM
+  do_local_mount $mnt_point $CVMFS_TEST_REPO XXX $local_conf || return 41
+
+  ls $mnt_point || return 42
+  diff $mnt_point/large $reference_dir/large || return 43
 
   return 0
 }

--- a/test/src/620-pullmixedrepo/main
+++ b/test/src/620-pullmixedrepo/main
@@ -1,0 +1,177 @@
+cvmfs_test_name="Stratum1 / preloaded snapshot with uncompressed and external files"
+cvmfs_test_autofs_on_startup=false
+
+produce_more_files_in() {
+  local working_dir=$1
+  local large_file=$2
+
+  cp $large_file $working_dir/large
+  pushdir $working_dir
+  echo "an uncompressed file" > nested/uncompressed
+  popdir
+}
+
+produce_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir poems
+  cat > poems/todo.txt << EOF
+the empty sheet.
+EOF
+
+  cat > poems/unordnung.txt << EOF
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung    ordnung
+ordnung  unordn  g
+ordnung    ordnung
+EOF
+
+  ln -s poems/unordnung.txt unordnung
+
+  mkdir nested
+  touch nested/.cvmfscatalog
+  echo foo > nested/foo
+
+  popdir
+}
+
+graft_external() {
+  local repo=$1
+  local cvmfs_dir=$2
+  local reference_dir=$3
+
+  echo "I'm external" | cvmfs_swissknife zpipe > /srv/cvmfs/${repo}/external_file
+  local hash=$(cat /srv/cvmfs/${repo}/external_file | cvmfs_swissknife hash -a shake128)
+  local size=$(cat /srv/cvmfs/${repo}/external_file | cvmfs_swissknife zpipe -d | wc -c)
+  touch ${cvmfs_dir}/external_file
+  cat > ${cvmfs_dir}/.cvmfsgraft-external_file << EOF
+checksum=$hash
+size=$size
+EOF
+
+  ls -lah $cvmfs_dir
+
+  cvmfs_swissknife zpipe -d < /srv/cvmfs/${repo}/external_file > ${reference_dir}/external_file
+}
+
+desaster_cleanup() {
+  local mountpoint=$1
+  local replica_name=$2
+
+  sudo umount $mountpoint > /dev/null 2>&1
+  sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
+}
+
+check_stratum1_tmp_dir_emptiness() {
+  local tmp_dir="$1"
+  local tmp_dir_entries
+  echo "check stratum1 tmp directory"
+  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  echo "$tmp_dir contains: $tmp_dir_entries"
+  [ $tmp_dir_entries -eq 0 ]
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  local mnt_point="$(pwd)/mountpount"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_in $repo_dir || return 3
+
+  echo "putting exactly the same stuff in the scratch space for comparison"
+  produce_files_in $reference_dir || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "graft external file"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  graft_external $CVMFS_TEST_REPO $repo_dir $reference_dir || return 20
+  publish_repo $CVMFS_TEST_REPO -X || return $?
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "change to uncompressed files"
+  sudo sh -c "echo CVMFS_COMPRESSION_ALGORITHM=none >> \
+    /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf" || return 30
+  local large_file="large_file"
+  dd if=/dev/urandom of=$large_file bs=1024 count=$((100*1024))
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_more_files_in $repo_dir $large_file || return 31
+  produce_more_files_in $reference_dir $large_file || return 32
+  publish_repo $CVMFS_TEST_REPO || return $?
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+  
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "create Stratum1 repository on the same machine"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+    || { desaster_cleanup $mnt_point $replica_name; return 7; }
+
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
+
+  echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
+  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+
+  echo "copy external file"
+  cp /srv/cvmfs/${CVMFS_TEST_REPO}/external_file /srv/cvmfs/$replica_name/
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
+
+  echo "mount the Stratum1 repository on a local mountpoint"
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
+
+  echo "check if the Stratum1 repository contains exactly the same as the reference copy"
+  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }
+
+  echo "unmount the Stratum1 repository"
+  sudo umount $mnt_point || { desaster_cleanup $mnt_point $replica_name; return 12; }
+
+  echo "clean up"
+  sudo cvmfs_server rmfs -f $replica_name
+
+  return 0
+}

--- a/test/unittests/t_catalog.cc
+++ b/test/unittests/t_catalog.cc
@@ -291,10 +291,12 @@ TEST_F(T_Catalog, Chunks) {
                                            NULL,
                                            false);
   shash::Any hash;
+  zlib::Algorithms compression_alg;
   EXPECT_TRUE(catalog->AllChunksBegin());
   unsigned counter = 0;
-  while (catalog->AllChunksNext(&hash)) {
+  while (catalog->AllChunksNext(&hash, &compression_alg)) {
     ++counter;
+    EXPECT_EQ(zlib::kZlibDefault, compression_alg);
   }
   EXPECT_TRUE(catalog->AllChunksEnd());
   EXPECT_EQ(4u, counter);  // number of files with content + empty hash


### PR DESCRIPTION
External files need to be skipped during replication.  Uncompressed files need to be handled in the preloader.