### PR TITLE
Feature: Print Catalog Timestamp in verbose GC

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -480,7 +480,10 @@ uint64_t Catalog::GetRevision() const {
 }
 
 uint64_t Catalog::GetLastModified() const {
-  return database().GetProperty<int>("last_modified");
+  const std::string prop_name = "last_modified";
+  return (database().HasProperty(prop_name))
+    ? database().GetProperty<int>(prop_name)
+    : 0u;
 }
 
 

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -122,10 +122,10 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
     UniquePtr<CatalogDatabase> new_clg_db(CatalogDatabase::Create(file_path));
     if (!new_clg_db.IsValid() ||
         !new_clg_db->InsertInitialValues(root_path,
-                                          volatile_content,
-                                          voms_authz,
-                                          external_data,
-                                          root_entry))
+                                         volatile_content,
+                                         voms_authz,
+                                         external_data,
+                                         root_entry))
     {
       LogCvmfs(kLogCatalog, kLogStderr, "creation of catalog '%s' failed",
                file_path.c_str());

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -272,6 +272,12 @@ bool CatalogDatabase::InsertInitialValues(
     }
   }
 
+  // Set creation timestamp
+  if (!this->SetProperty("last_modified", static_cast<uint64_t>(time(NULL)))) {
+    PrintSqlError("failed to store creation timestamp in the new catalog.");
+    return false;
+  }
+
   // Commit initial filling transaction
   retval = Sql(*this, "COMMIT;").Execute();
   if (!retval) {

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -66,8 +66,10 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveDataObjects(
 
   if (configuration_.verbose) {
     if (data.catalog->IsRoot()) {
-      LogCvmfs(kLogGc, kLogStdout, "Preserving Revision %d",
-                                   data.catalog->revision());
+      const int    rev   = data.catalog->revision();
+      const time_t mtime = static_cast<time_t>(data.catalog->GetLastModified());
+      LogCvmfs(kLogGc, kLogStdout, "Preserving Revision %d (%s)",
+                                   rev, StringifyTime(mtime, true).c_str());
     }
     PrintCatalogTreeEntry(data.tree_level, data.catalog);
   }
@@ -94,8 +96,10 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects(
 
   if (configuration_.verbose) {
     if (data.catalog->IsRoot()) {
-      LogCvmfs(kLogGc, kLogStdout, "Sweeping Revision %d",
-                                   data.catalog->revision());
+      const int    rev   = data.catalog->revision();
+      const time_t mtime = static_cast<time_t>(data.catalog->GetLastModified());
+      LogCvmfs(kLogGc, kLogStdout, "Sweeping Revision %d (%s)",
+                                   rev, StringifyTime(mtime, true).c_str());
     }
     PrintCatalogTreeEntry(data.tree_level, data.catalog);
   }


### PR DESCRIPTION
This is a convenience feature for debugging. In a verbose garbage collection run, we now immediately see the `last_modified` timestamp of root catalogs being preserved or swept.

Note that this revealed the necessity for some minor fixes to `Catalog::GetLastModified()` and the bootstrapping of the first catalog in a repository. This particular catalog (revision number 0) didn't have the `last_modified` property set.