### PR TITLE
Sorted external hosts using CVMFS Stratum-1s.

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2643,7 +2643,10 @@ static int Init(const loader::LoaderExports *loader_exports) {
     download::DownloadManager::kSetProxyBoth);
   g_external_download_ready = true;
   if (use_geo_api) {
-    cvmfs::external_download_manager_->ProbeGeo();
+    std::vector<std::string> host_chain;
+    cvmfs::external_download_manager_->GetHostInfo(&host_chain, NULL, NULL);
+    cvmfs::download_manager_->GeoSortServers(&host_chain);
+    cvmfs::external_download_manager_->SetHostChain(host_chain);
   }
 
 

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1717,25 +1717,7 @@ void DownloadManager::GetTimeout(unsigned *seconds_proxy,
  * removes the host list.
  */
 void DownloadManager::SetHostChain(const string &host_list) {
-  pthread_mutex_lock(lock_options_);
-  opt_timestamp_backup_host_ = 0;
-  delete opt_host_chain_;
-  delete opt_host_chain_rtt_;
-  opt_host_chain_current_ = 0;
-
-  if (host_list == "") {
-    opt_host_chain_ = NULL;
-    opt_host_chain_rtt_ = NULL;
-    pthread_mutex_unlock(lock_options_);
-    return;
-  }
-
-  opt_host_chain_ = new vector<string>(SplitString(host_list, ';'));
-  opt_host_chain_rtt_ =
-    new vector<int>(opt_host_chain_->size(), kProbeUnprobed);
-  // LogCvmfs(kLogDownload, kLogSyslog, "using host %s",
-  //          (*opt_host_chain_)[0].c_str());
-  pthread_mutex_unlock(lock_options_);
+  SetHostChain(SplitString(host_list, ';'));
 }
 
 

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -2061,12 +2061,6 @@ bool DownloadManager::ProbeGeo() {
   if ((host_chain.size() < 2) && ((proxy_chain.size() - fallback_group) < 2))
     return true;
 
-  // Protect against concurrent access to prng_
-  pthread_mutex_lock(lock_options_);
-  // Determine random hosts for the Geo-API query
-  vector<string> host_chain_shuffled = Shuffle(host_chain, &prng_);
-  pthread_mutex_unlock(lock_options_);
-
   vector<string> host_names;
   for (unsigned i = 0; i < host_chain.size(); ++i)
     host_names.push_back(dns::ExtractHost(host_chain[i]));
@@ -2086,8 +2080,7 @@ bool DownloadManager::ProbeGeo() {
   std::vector<uint64_t> geo_order;
   bool success = GeoSortServers(&host_names, &geo_order);
   if (!success) {
-    LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-             "failed to retrieve geographic order from stratum 1 servers");
+    // GeoSortServers already logged a failure message.
     return false;
   }
 

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -336,10 +336,17 @@ class DownloadManager {
   void GetTimeout(unsigned *seconds_proxy, unsigned *seconds_direct);
   void SetLowSpeedLimit(const unsigned low_speed_limit);
   void SetHostChain(const std::string &host_list);
+  void SetHostChain(const std::vector<std::string> &host_list);
   void GetHostInfo(std::vector<std::string> *host_chain,
                    std::vector<int> *rtt, unsigned *current_host);
   void ProbeHosts();
   bool ProbeGeo();
+    // Sort list of servers using the Geo API.  If the output_order
+    // vector is NULL, then the servers vector input is itself sorted.
+    // If it is non-NULL, then servers is left unchanged and the zero-based
+    // ordering is stored into output_order.
+  bool GeoSortServers(std::vector<std::string> *servers,
+                      std::vector<uint64_t>    *output_order = NULL);
   void SwitchHost();
   void SetProxyChain(const std::string &proxy_list,
                      const std::string &fallback_proxy_list,


### PR DESCRIPTION
The external data hosts are assumed to not be running the GeoAPI
service.  Instead, use the CVMFS Stratum-1 servers listed in CVMFS_URL
to sort the external data hostnames with the GeoAPI.

@DrDaveD - this is the change we discussed earlier today.  Can you take a look at it?