### PR TITLE
Feature: Garbage Collection can log deleted files

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4551,6 +4551,7 @@ publish() {
                $dry_run    \
                $manifest   \
                $trunk_hash \
+               ""          \
                -z $gc_timespan      || { local err=$?; publish_failed $name; die "Garbage collection failed ($err)"; }
       sign_manifest $name $manifest || { publish_failed $name; die "Signing failed"; }
     fi
@@ -4699,6 +4700,7 @@ gc() {
   local preserve_timestamp=0
   local timestamp_threshold=""
   local force=0
+  local deletion_log=""
 
   # optional parameter handling
   OPTIND=1
@@ -4828,6 +4830,7 @@ gc() {
              "$dry_run"        \
              "$manifest"       \
              "$base_hash"      \
+             "$deletion_log"   \
              $additional_switches || die "Fail ($?)!"
 
     # sign the result
@@ -4854,7 +4857,8 @@ __run_gc() {
   local dry_run="$3"
   local manifest="$4"
   local base_hash="$5"
-  shift 5
+  local deletion_log="$6"
+  shift 6
   local additional_switches="$*"
 
   load_repo_config $name
@@ -4869,6 +4873,13 @@ __run_gc() {
   if is_stratum0 $name; then
     [ x"$manifest"  != x"" ] || return 4
     [ x"$base_hash" != x"" ] || return 5
+  fi
+
+  # handle a configured deletion log (manually passed log has precedence)
+  if [ x"$deletion_log" != x"" ]; then
+    additional_switches="$additional_switches -L $deletion_log"
+  elif [ ! -z $CVMFS_GC_DELETION_LOG ]; then
+    additional_switches="$additional_switches -L $CVMFS_GC_DELETION_LOG"
   fi
 
   # do it!
@@ -5085,6 +5096,7 @@ snapshot() {
       __run_gc "$alias_name" \
                "$stratum1"   \
                "$dry_run"    \
+               ""            \
                ""            \
                ""            \
                -z $gc_timespan || die "Garbage collection failed ($?)"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4704,7 +4704,7 @@ gc() {
 
   # optional parameter handling
   OPTIND=1
-  while getopts "ldr:t:f" option
+  while getopts "ldr:t:fL:" option
   do
     case $option in
       l)
@@ -4721,6 +4721,9 @@ gc() {
       ;;
       f)
         force=1
+      ;;
+      L)
+        deletion_log="$OPTARG"
       ;;
       ?)
         shift $(($OPTIND-2))

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -100,6 +100,7 @@ class GarbageCollector {
 
   void PrintCatalogTreeEntry(const unsigned int  tree_level,
                              const CatalogTN    *catalog) const;
+  void LogDeletion(const shash::Any &hash) const;
 
  private:
   const Configuration   configuration_;

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -60,7 +60,10 @@ class GarbageCollector {
       , keep_history_depth(kFullHistory)
       , keep_history_timestamp(kNoTimestamp)
       , dry_run(false)
-      , verbose(false) {}
+      , verbose(false)
+      , deleted_objects_logfile(NULL) {}
+
+    bool has_deletion_log() const { return deleted_objects_logfile != NULL; }
 
     upload::AbstractUploader  *uploader;
     ObjectFetcherTN           *object_fetcher;
@@ -68,6 +71,7 @@ class GarbageCollector {
     time_t                     keep_history_timestamp;
     bool                       dry_run;
     bool                       verbose;
+    FILE                      *deleted_objects_logfile;
   };
 
  public:

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -282,7 +282,8 @@ template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::LogDeletion(
                                                  const shash::Any &hash) const {
   if (configuration_.verbose) {
-    LogCvmfs(kLogGc, kLogStdout, "Sweep: %s", hash.ToString().c_str());
+    LogCvmfs(kLogGc, kLogStdout, "Sweep: %s",
+                                 hash.ToStringWithSuffix().c_str());
   }
 }
 

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -285,6 +285,14 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::LogDeletion(
     LogCvmfs(kLogGc, kLogStdout, "Sweep: %s",
                                  hash.ToStringWithSuffix().c_str());
   }
+
+  if (configuration_.has_deletion_log()) {
+    const int written = fprintf(configuration_.deleted_objects_logfile,
+                                "%s\n", hash.ToStringWithSuffix().c_str());
+    if (written < 0) {
+      LogCvmfs(kLogGc, kLogStderr, "failed to write to deleted objects log");
+    }
+  }
 }
 
 #endif  // CVMFS_GARBAGE_COLLECTION_GARBAGE_COLLECTOR_IMPL_H_

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -132,10 +132,7 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
                                                        const shash::Any &hash) {
   ++condemned_objects_;
 
-  if (configuration_.verbose) {
-    LogCvmfs(kLogGc, kLogStdout, "Sweep: %s", hash.ToString().c_str());
-  }
-
+  LogDeletion(hash);
   if (configuration_.dry_run) {
     return;
   }
@@ -278,6 +275,15 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::PrintCatalogTreeEntry(
     tree_indent.c_str(),
     hash_string.c_str(),
     path.c_str());
+}
+
+
+template <class CatalogTraversalT, class HashFilterT>
+void GarbageCollector<CatalogTraversalT, HashFilterT>::LogDeletion(
+                                                 const shash::Any &hash) const {
+  if (configuration_.verbose) {
+    LogCvmfs(kLogGc, kLogStdout, "Sweep: %s", hash.ToString().c_str());
+  }
 }
 
 #endif  // CVMFS_GARBAGE_COLLECTION_GARBAGE_COLLECTOR_IMPL_H_

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -252,8 +252,14 @@ cvmfs_run_test() {
     peek_backend $CVMFS_TEST_REPO ${clg_hash}C || return 10
   done
 
-  echo "perform basic garbage collection"
-  cvmfs_server gc -f $CVMFS_TEST_REPO || return 11
+  local gc_log="${scratch_dir}/gc.log"
+  echo "perform basic garbage collection (logging deletions to $gc_log)"
+  cvmfs_server gc -fL "$gc_log" $CVMFS_TEST_REPO || return 11
+
+  echo "deletion log:"
+  echo "------------------------"
+  cat $gc_log
+  echo "------------------------"
 
   echo "check that the temporary scratch directory is empty"
   [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
@@ -264,11 +270,23 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_2 && return 12
   peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_3 && return 12
 
+  echo "check that deletion log contains shakespeare"
+  cat $gc_log | grep -q $shakespeare_object    || return 12
+  cat $gc_log | grep -q $chopped_shakespeare_1 || return 12
+  cat $gc_log | grep -q $chopped_shakespeare_2 || return 12
+  cat $gc_log | grep -q $chopped_shakespeare_3 || return 12
+
   echo "check if kafka is still there"
   peek_backend $CVMFS_TEST_REPO $kafka_object    || return 13
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_1 || return 13
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_2 || return 13
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_3 || return 13
+
+  echo "check that deletion log doesn't contain kafka"
+  cat $gc_log | grep -q $kafka_object    && return 13
+  cat $gc_log | grep -q $chopped_kafka_1 && return 13
+  cat $gc_log | grep -q $chopped_kafka_2 && return 13
+  cat $gc_log | grep -q $chopped_kafka_3 && return 13
 
   echo "check if the catalog revisions 1-4 are gone"
   for clg_hash in $condemned_clgs; do

--- a/test/src/561-garbagecollectmultihash/main
+++ b/test/src/561-garbagecollectmultihash/main
@@ -179,8 +179,10 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
   root_clg_0="$(get_current_root_catalog $CVMFS_TEST_REPO)"
 
-  echo "disable automatic garbage collection"
+  local gc_log="${scratch_dir}/gc.log"
+  echo "disable automatic garbage collection and enable GC logging ($gc_log)"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+  echo "CVMFS_GC_DELETION_LOG=$gc_log" | sudo tee -a "/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf" || return 100
 
   # ============================================================================
 
@@ -301,11 +303,23 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_2 && return 12
   peek_backend $CVMFS_TEST_REPO $chopped_shakespeare_3 && return 12
 
+  echo "check that deletion log contains shakespeare"
+  cat $gc_log | grep -q $shakespeare_object    || return 12
+  cat $gc_log | grep -q $chopped_shakespeare_1 || return 12
+  cat $gc_log | grep -q $chopped_shakespeare_2 || return 12
+  cat $gc_log | grep -q $chopped_shakespeare_3 || return 12
+
   echo "check if kafka is still there"
   peek_backend $CVMFS_TEST_REPO $kafka_object    || return 13
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_1 || return 13
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_2 || return 13
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_3 || return 13
+
+  echo "check that deletion log doesn't contain kafka"
+  cat $gc_log | grep -q $kafka_object    && return 13
+  cat $gc_log | grep -q $chopped_kafka_1 && return 13
+  cat $gc_log | grep -q $chopped_kafka_2 && return 13
+  cat $gc_log | grep -q $chopped_kafka_3 && return 13
 
   echo "check if the catalog revisions 1-4 are gone"
   for clg_hash in $root_clg_0 $root_clg_1 $root_clg_2; do
@@ -324,8 +338,9 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO > publish_5.log 2>&1 || return 17
   root_clg_5="$(get_current_root_catalog $CVMFS_TEST_REPO)"
 
-  echo "perform another garbage collection (should remove kafka)"
-  cvmfs_server gc -f $CVMFS_TEST_REPO || return 18
+  local manual_gc_log="${scratch_dir}/manual.gc.log"
+  echo "perform another garbage collection (should remove kafka) (logging to $manual_gc_log)"
+  cvmfs_server gc -fL $manual_gc_log $CVMFS_TEST_REPO || return 18
 
   echo "check if kafka is gone"
   peek_backend $CVMFS_TEST_REPO $kafka_object    && return 19
@@ -333,23 +348,35 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_2 && return 19
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_3 && return 19
 
+  echo "check if kafka is in the manual deletion"
+  cat $manual_gc_log | grep -q $kafka_object    || return 19
+  cat $manual_gc_log | grep -q $chopped_kafka_1 || return 19
+  cat $manual_gc_log | grep -q $chopped_kafka_2 || return 19
+  cat $manual_gc_log | grep -q $chopped_kafka_3 || return 19
+
+  echo "check that shakespeare is not in the manual deletion log"
+  cat $manual_gc_log | grep -q $shakespeare_object    && return 20
+  cat $manual_gc_log | grep -q $chopped_shakespeare_1 && return 20
+  cat $manual_gc_log | grep -q $chopped_shakespeare_2 && return 20
+  cat $manual_gc_log | grep -q $chopped_shakespeare_3 && return 20
+
   echo "check if the catalog revisions 1-5 are gone"
   for clg_hash in $root_clg_0 $root_clg_1 $root_clg_2 $root_clg_3; do
-    peek_backend $CVMFS_TEST_REPO ${clg_hash}C && return 20
+    peek_backend $CVMFS_TEST_REPO ${clg_hash}C && return 21
   done
 
   echo "check if the catalog revisions 6-7 are preserved"
   for clg_hash in $root_clg_4 $root_clg_5; do
-    peek_backend $CVMFS_TEST_REPO ${clg_hash}C || return 21
+    peek_backend $CVMFS_TEST_REPO ${clg_hash}C || return 22
   done
 
   # ============================================================================
 
   echo "check if the repository is still sane"
-  check_repository $CVMFS_TEST_REPO -i || return 22
+  check_repository $CVMFS_TEST_REPO -i || return 23
 
   echo "check if the repository's previous revision is still sane"
-  check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 23
+  check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 24
 
   return 0
 }

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -200,8 +200,10 @@ cvmfs_run_test() {
                   $CVMFS_STRATUM0                        \
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
 
-  echo "disable automatic garbage collection"
+  local gc_log="${scratch_dir}/gc.log"
+  echo "disable automatic garbage collection and configure deletion log $gc_log"
   disable_auto_garbage_collection $replica_name || return $?
+  echo "CVMFS_GC_DELETION_LOG=$gc_log" | sudo tee -a "/etc/cvmfs/repositories.d/${replica_name}/server.conf" || return 100
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   cvmfs_server snapshot $replica_name || return 2
@@ -429,6 +431,12 @@ cvmfs_run_test() {
   peek_backend $replica_name $chopped_shakespeare_2 && return 32
   peek_backend $replica_name $chopped_shakespeare_3 && return 32
 
+  echo "check that deletion log for stratum1 contains shakespeare"
+  cat $gc_log | grep -q $shakespeare_object    || return 32
+  cat $gc_log | grep -q $chopped_shakespeare_1 || return 32
+  cat $gc_log | grep -q $chopped_shakespeare_2 || return 32
+  cat $gc_log | grep -q $chopped_shakespeare_3 || return 32
+
   echo "check if kafka is still there (stratum 0)"
   peek_backend $CVMFS_TEST_REPO $kafka_object    || return 33
   peek_backend $CVMFS_TEST_REPO $chopped_kafka_1 || return 33
@@ -441,6 +449,12 @@ cvmfs_run_test() {
   peek_backend $replica_name $chopped_kafka_2 || return 34
   peek_backend $replica_name $chopped_kafka_3 || return 34
 
+  echo "check that deletion log doesn't contain kafka"
+  cat $gc_log | grep -q $kafka_object    && return 34
+  cat $gc_log | grep -q $chopped_kafka_1 && return 34
+  cat $gc_log | grep -q $chopped_kafka_2 && return 34
+  cat $gc_log | grep -q $chopped_kafka_3 && return 34
+
   echo "check if the catalog revisions 1-4 are gone (stratum 0)"
   for clg_hash in $condemned_clgs; do
     peek_backend $CVMFS_TEST_REPO ${clg_hash}C && return 35
@@ -449,6 +463,7 @@ cvmfs_run_test() {
   echo "check if the catalog revisions 1-4 are gone (stratum 0)"
   for clg_hash in $condemned_clgs; do
     peek_backend $replica_name ${clg_hash}C && return 36
+    cat $gc_log | grep -q ${clg_hash}C      || return 136
   done
 
   echo "check if the catalog revisions 5-6 are preserved (stratum 0)"
@@ -459,6 +474,7 @@ cvmfs_run_test() {
   echo "check if the catalog revisions 5-6 are preserved (stratum 1)"
   for clg_hash in $preserved_clgs; do
     peek_backend $replica_name ${clg_hash}C || return 38
+    cat $gc_log | grep -q ${clg_hash}C      && return 138
   done
 
   # ============================================================================

--- a/test/src/578-automaticgarbagecollection/main
+++ b/test/src/578-automaticgarbagecollection/main
@@ -12,6 +12,17 @@ create_revision() {
   echo "$(get_current_root_catalog $repo_name)C"
 }
 
+count_gc_events_in_log() {
+  local log_file=$1
+  cat $log_file | grep "Garbage Collection started" | wc -l
+}
+
+peek_gc_log() {
+  local log_file=$1
+  local needle="$2"
+  cat $log_file | grep -q "$needle"
+}
+
 cvmfs_run_test() {
   local logfile=$1
   local script_location=$2
@@ -37,6 +48,10 @@ cvmfs_run_test() {
   echo "configure repository to automatically delete revisions older than $thresh_seconds seconds"
   local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
   echo "CVMFS_AUTO_GC_TIMESPAN='$thresh_seconds seconds ago'" | sudo tee --append $server_conf || return 1
+
+  local gc_log="${scratch_dir}/gc.log"
+  echo "configure a deletion log ($gc_log) for $CVMFS_TEST_REPO"
+  echo "CVMFS_GC_DELETION_LOG=$gc_log" | sudo tee --append $server_conf || return 1
   cat $server_conf || return 2
 
   echo "check if initial catalog is there"
@@ -58,6 +73,11 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog0 || return 4 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog1 || return 5 # trunk
 
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 1 ] || return 101
+  peek_gc_log $gc_log $root_catalog0          && return 102
+  peek_gc_log $gc_log $root_catalog1          && return 103
+
   echo "sleep $seconds seconds"
   sleep $seconds
 
@@ -74,6 +94,12 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog0 || return 6 # sentinel revision
   peek_backend $CVMFS_TEST_REPO $root_catalog1 || return 7 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog2 || return 8 # trunk
+
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 2 ] || return 104
+  peek_gc_log $gc_log $root_catalog0          && return 105
+  peek_gc_log $gc_log $root_catalog1          && return 106
+  peek_gc_log $gc_log $root_catalog2          && return 107
 
   echo "sleep $seconds seconds"
   sleep $seconds
@@ -92,6 +118,13 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog1 || return 10 # sentinel revision
   peek_backend $CVMFS_TEST_REPO $root_catalog2 || return 11 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog3 || return 12 # trunk
+
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 3 ] || return 108
+  peek_gc_log $gc_log $root_catalog0          || return 109
+  peek_gc_log $gc_log $root_catalog1          && return 110
+  peek_gc_log $gc_log $root_catalog2          && return 111
+  peek_gc_log $gc_log $root_catalog3          && return 112
 
   echo "sleep $seconds seconds"
   sleep $seconds
@@ -112,6 +145,13 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog3 || return 16 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog4 || return 17 # trunk
 
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 4 ] || return 113
+  peek_gc_log $gc_log $root_catalog1          || return 114
+  peek_gc_log $gc_log $root_catalog2          && return 115
+  peek_gc_log $gc_log $root_catalog3          && return 116
+  peek_gc_log $gc_log $root_catalog4          && return 117
+
   echo "sleep $seconds seconds"
   sleep $seconds
 
@@ -131,6 +171,13 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog3 || return 21 # sentinel revision
   peek_backend $CVMFS_TEST_REPO $root_catalog4 || return 22 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog5 || return 23 # trunk
+
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 5 ] || return 119
+  peek_gc_log $gc_log $root_catalog2          || return 120
+  peek_gc_log $gc_log $root_catalog3          && return 121
+  peek_gc_log $gc_log $root_catalog4          && return 122
+  peek_gc_log $gc_log $root_catalog5          && return 123
 
   echo "disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
@@ -156,6 +203,13 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog5 || return 31 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog6 || return 32 # trunk
 
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 5 ] || return 124 # auto-GC disabled
+  peek_gc_log $gc_log $root_catalog3          && return 125
+  peek_gc_log $gc_log $root_catalog4          && return 126
+  peek_gc_log $gc_log $root_catalog5          && return 127
+  peek_gc_log $gc_log $root_catalog6          && return 101
+
   echo "run a manual garbage collection (delete all but last two)"
   cvmfs_server gc -f $CVMFS_TEST_REPO || return 33
 
@@ -170,6 +224,13 @@ cvmfs_run_test() {
   peek_backend $CVMFS_TEST_REPO $root_catalog4 && return 38 # GC'ed
   peek_backend $CVMFS_TEST_REPO $root_catalog5 || return 39 # trunk-previous
   peek_backend $CVMFS_TEST_REPO $root_catalog6 || return 40 # trunk
+
+  echo "check GC log"
+  [ $(count_gc_events_in_log $gc_log) -eq 6 ] || return 41
+  peek_gc_log $gc_log $root_catalog3          || return 42
+  peek_gc_log $gc_log $root_catalog4          || return 43
+  peek_gc_log $gc_log $root_catalog5          && return 44
+  peek_gc_log $gc_log $root_catalog6          && return 45
 
   return 0
 }

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -14,6 +14,7 @@
 #include "../../cvmfs/hash.h"
 #include "../../cvmfs/manifest.h"
 #include "../../cvmfs/prng.h"
+#include "../../cvmfs/util.h"
 #include "testutil.h"
 
 using swissknife::CatalogTraversal;
@@ -86,6 +87,11 @@ class T_GarbageCollector : public ::testing::Test {
     ASSERT_NE(static_cast<GC_MockUploader*>(NULL), uploader_);
     uploader_->TearDown();
     delete uploader_;
+  }
+
+  FILE *CreateTemporaryFile(std::string *path) const {
+    return CreateTempFile(GetCurrentWorkingDirectory() + "/cvmfs_ut_gc",
+                          0600, "w+", path);
   }
 
   GcConfiguration GetStandardGarbageCollectorConfiguration() {
@@ -1207,6 +1213,100 @@ TEST_F(T_GarbageCollector, NamedTagsInRecycleBin) {
 
   EXPECT_TRUE(upl->HasDeleted(h("380fe86b4cc68164afd5578eb21a32ab397e6d13")));
   EXPECT_TRUE(upl->HasDeleted(h("1a9ef17ae3597bf61d8229dc2bf6ec12ebb42d44")));
+}
+
+
+TEST_F(T_GarbageCollector, LogDeletionToFile) {
+  string dest_path;
+  FILE *deletion_log = CreateTemporaryFile(&dest_path);
+  ASSERT_TRUE(deletion_log != NULL);
+  UnlinkGuard unlink_guard(dest_path);
+
+  GcConfiguration config = GetStandardGarbageCollectorConfiguration();
+  config.keep_history_depth      = 0;            // no history preservation
+  config.deleted_objects_logfile = deletion_log; // log deletion to tmp file
+
+  MyGarbageCollector gc(config);
+  const bool gc1 = gc.Collect();
+  EXPECT_TRUE(gc1);
+  EXPECT_EQ(11u, gc.preserved_catalog_count());
+  EXPECT_EQ(5u, gc.condemned_catalog_count());
+
+  RevisionMap     &c   = catalogs_;
+
+  std::vector<shash::Any> preserved_hashes;
+  preserved_hashes.push_back(h("b52945d780f8cc16711d4e670d82499dad99032d"));
+  preserved_hashes.push_back(h("d650d325d59ea9ca754f9b37293cd08d0b12584c"));
+  preserved_hashes.push_back(h("4083d30ba1f72e1dfad4cdbfc60ea3c38bfa600d"));
+  preserved_hashes.push_back(h("c308c87d518c86130d9b9d34723b2a7d4e232ce9"));
+  preserved_hashes.push_back(h("8967a86ddf51d89aaad5ad0b7f29bdfc7f7aef2a"));
+  preserved_hashes.push_back(h("372e393bb9f5c33440f842b47b8f6aa3ed4f2943"));
+  preserved_hashes.push_back(h("50c44954ab4348a6a3772ee5bd30ab7a1494c692"));
+  preserved_hashes.push_back(h("2dc2b87b8ac840e4fb1cad25c806395c931f7b31"));
+  preserved_hashes.push_back(h("a727b47d99fba5fe196400a3c7bc1738172dff71"));
+  preserved_hashes.push_back(h("80b59550342b6f5141b42e5b2d58ce453f12d710"));
+  preserved_hashes.push_back(h("defae1853b929bbbdbc7c6d4e75531273f1ae4cb",'P'));
+  preserved_hashes.push_back(h("24bf4276fcdbe57e648b82af4e8fece5bd3581c7",'P'));
+  preserved_hashes.push_back(h("acc4c10cf875861ec8d6744a9ab81cb2abe433b4",'P'));
+  preserved_hashes.push_back(h("654be8b6938b3fb30be3e9476f3ed26db74e0a9e",'P'));
+  preserved_hashes.push_back(h("1a17be523120c7d3a7be745ada1658cc74e8507b",'P'));
+  preserved_hashes.push_back(h("18588c597700a7e2d3b4ce91bdf5a947a4ad13fc"));
+  preserved_hashes.push_back(h("fea3b5156ebbeddb89c85bc14c8e9caa185c10c7"));
+  preserved_hashes.push_back(h("0aceb47a362df1522a69217736617493bef07d5a"));
+  preserved_hashes.push_back(h("d2068490d25c1bd4ef2f3d3a0568a76046466860"));
+  preserved_hashes.push_back(h("283144632474a0e553e3b61c1f272257942e7a61"));
+  preserved_hashes.push_back(h("213bec88ed6729219d94fc9281893ba93fca2a02"));
+  preserved_hashes.push_back(h("7d4d0ec225ebe13839d71c0dc0982567cc810402"));
+  preserved_hashes.push_back(h("bb5a7bbe8410f0268a9b12285b6f1fd26e038023"));
+  preserved_hashes.push_back(h("59b63e8478fb7fc02c54a85767c7116573907364"));
+  preserved_hashes.push_back(h("09fd3486d370013d859651eb164ec71a3a09f5cb"));
+  preserved_hashes.push_back(h("e0862f1d936037eb0c2be7ccf289f5dbf469244b"));
+  preserved_hashes.push_back(h("8031b9ad81b52cd772db9b1b12d38994fdd9dbe4"));
+  preserved_hashes.push_back(c[mp(5, "00")]->hash());
+  preserved_hashes.push_back(c[mp(5, "10")]->hash());
+  preserved_hashes.push_back(c[mp(5, "11")]->hash());
+  preserved_hashes.push_back(c[mp(5, "20")]->hash());
+  preserved_hashes.push_back(c[mp(2, "00")]->hash());
+  preserved_hashes.push_back(c[mp(2, "10")]->hash());
+  preserved_hashes.push_back(c[mp(2, "11")]->hash());
+  preserved_hashes.push_back(c[mp(4, "00")]->hash());
+  preserved_hashes.push_back(c[mp(4, "10")]->hash());
+  preserved_hashes.push_back(c[mp(4, "11")]->hash());
+  preserved_hashes.push_back(c[mp(4, "20")]->hash());
+
+  std::vector<shash::Any> deleted_hashes;
+  deleted_hashes.push_back(h("2e87adef242bc67cb66fcd61238ad808a7b44aab"));
+  deleted_hashes.push_back(h("3bf4854891899670727fc8e9c6e454f7e4058454"));
+  deleted_hashes.push_back(h("12ea064b069d98cb9da09219568ff2f8dd7d0a7e"));
+  deleted_hashes.push_back(h("20c2e6328f943003254693a66434ff01ebba26f0"));
+  deleted_hashes.push_back(h("219d1ca4c958bd615822f8c125701e73ce379428"));
+  deleted_hashes.push_back(c[mp(1, "00")]->hash());
+  deleted_hashes.push_back(c[mp(1, "10")]->hash());
+  deleted_hashes.push_back(c[mp(3, "00")]->hash());
+  deleted_hashes.push_back(c[mp(3, "10")]->hash());
+  deleted_hashes.push_back(c[mp(3, "11")]->hash());
+
+  std::set<std::string> log_lines;
+  std::string log_line;
+  ASSERT_EQ(0, fseek(deletion_log, 0, SEEK_SET));
+  while (GetLineFile(deletion_log, &log_line)) {
+    log_lines.insert(log_line);
+  }
+  fclose(deletion_log);
+
+  EXPECT_EQ(11u, log_lines.size());
+
+        std::vector<shash::Any>::const_iterator i    = preserved_hashes.begin();
+  const std::vector<shash::Any>::const_iterator iend = preserved_hashes.end();
+  for (; i != iend; ++i) {
+    EXPECT_EQ(0, log_lines.count(i->ToStringWithSuffix()));
+  }
+
+        std::vector<shash::Any>::const_iterator j    = deleted_hashes.begin();
+  const std::vector<shash::Any>::const_iterator jend = deleted_hashes.end();
+  for (; j != jend; ++j) {
+    EXPECT_EQ(1, log_lines.count(j->ToStringWithSuffix()));
+  }
 }
 
 


### PR DESCRIPTION
This introduces a [logging mechanism for the garbage collection](https://sft.its.cern.ch/jira/browse/CVM-710) to keep track of deleted files. It is configured with `CVMFS_GC_DELETION_LOG=<file path>` and writes out all deleted object hashes like so:

```
# Garbage Collection finished at 6 Jan 2016 14:00:54
c24c4add5e84de6a4282ebbb949f395ff80e6615
fdd2627ceca191e5eebe36622063013d38e3a9b2C
af4eb9a66975d325cc00a1bea50d70524b0b0700C
# Garbage Collection finished at 6 Jan 2016 14:00:55

# Garbage Collection started at 6 Jan 2016 14:01:06
14a245b29cb6ee49a9a76de99755857f2f08af24C
# Garbage Collection finished at 6 Jan 2016 14:01:06
```

Furthermore a log can be specified for the (currently not officially supported manual garbage collection) like so: `cvmfs_server gc -L <file path>`. Manually specified log files take precedence over configured ones in that case.

This comes with one new unit test and several adaptions to existing integration tests.