### PR TITLE
FIX: Minor improvements to `cvmfs_server repo-metainfo`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
   * Print error message at the end of a failing `cvmfs_server check` (CVM-958)
   * Use patched pacparser 1.3.5 for IPv6 support (CVM-903)
   * Add support for VOMS authentication in fuse module (CVM-904)
-  * Add `cvmfs_server repo-metainfo` command (CVM-804)
+  * Add `cvmfs_server update-repoinfo` command (CVM-804)
   * Add `cvmfs_talk cleanup rate` command (CVM-270)
   * Read blacklist from config repository if available (CVM-901)
   * Add support for uncompressed files (CVM-906)

--- a/cvmfs/bash_completion/cvmfs.bash_completion
+++ b/cvmfs/bash_completion/cvmfs.bash_completion
@@ -94,7 +94,7 @@ _cvmfs_server()
 
   local -r cmds="mkfs add-replica import publish rollback rmfs \
     resign list info tag check transaction abort snapshot migrate \
-    list-catalogs"
+    list-catalogs repo-metainfo"
 
   if [ $COMP_CWORD -le 1 ]; then
     COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )
@@ -177,6 +177,12 @@ _cvmfs_server()
       COMPREPLY=( $(compgen -W "$(__hosted_repos)" ${cur}))
       return 0
       ;;
+
+    repo-metainfo)
+      COMPREPLY=( $(compgen -W "$(__hosted_repos '/stratum0/')" ${cur}) )
+      return 0
+      ;;
+
   esac
 }
 

--- a/cvmfs/bash_completion/cvmfs.bash_completion
+++ b/cvmfs/bash_completion/cvmfs.bash_completion
@@ -94,7 +94,7 @@ _cvmfs_server()
 
   local -r cmds="mkfs add-replica import publish rollback rmfs \
     resign list info tag check transaction abort snapshot migrate \
-    list-catalogs update-info repo-metainfo"
+    list-catalogs update-info update-repoinfo"
 
   if [ $COMP_CWORD -le 1 ]; then
     COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )
@@ -178,7 +178,7 @@ _cvmfs_server()
       return 0
       ;;
 
-    repo-metainfo)
+    update-repoinfo)
       COMPREPLY=( $(compgen -W "$(__hosted_repos '/stratum0/')" ${cur}) )
       return 0
       ;;

--- a/cvmfs/bash_completion/cvmfs.bash_completion
+++ b/cvmfs/bash_completion/cvmfs.bash_completion
@@ -94,7 +94,7 @@ _cvmfs_server()
 
   local -r cmds="mkfs add-replica import publish rollback rmfs \
     resign list info tag check transaction abort snapshot migrate \
-    list-catalogs repo-metainfo"
+    list-catalogs update-info repo-metainfo"
 
   if [ $COMP_CWORD -le 1 ]; then
     COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2988,6 +2988,9 @@ mkfs() {
 
   echo -n "Creating Initial Repository... "
   create_whitelist $name $cvmfs_user $upstream $temp_dir > /dev/null
+  local repoinfo_file=${temp_dir}/new_repoinfo
+  touch $repoinfo_file
+  create_repometa_skeleton $repoinfo_file
   local volatile_opt=
   if [ $volatile_content -eq 1 ]; then
     volatile_opt="-v"
@@ -3007,8 +3010,8 @@ mkfs() {
     create_cmd="$create_cmd -V $voms_authz"
     echo "CVMFS_VOMS_AUTHZ=$voms_authz" >> /etc/cvmfs/repositories.d/$name/server.conf
   fi
-  $user_shell "$create_cmd" > /dev/null        || die "fail! (cannot init repo)"
-  sign_manifest $name ${temp_dir}/new_manifest || die "fail! (cannot sign repo)"
+  $user_shell "$create_cmd" > /dev/null                       || die "fail! (cannot init repo)"
+  sign_manifest $name ${temp_dir}/new_manifest $repoinfo_file || die "fail! (cannot sign repo)"
   echo "done"
 
   echo -n "Mounting CernVM-FS Storage... "

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -276,78 +276,79 @@ CernVM-FS Server Tool $(cvmfs_version_string)
 Usage: cvmfs_server COMMAND [options] <parameters>
 
 Supported Commands:
-  mkfs          [-w stratum0 url] [-u upstream storage] [-o owner] [-X (external data)]
-                [-m replicable] [-f union filesystem type] [-v volatile content]
-                [-g disable auto tags] [-a hash algorithm (default: SHA-1)]
-                [-z enable garbage collection] [-s S3 config file]
-                [-Z compression algorithm (default: zlib)]
-                [-k path to existing keychain] [-p no apache config]
-                [-V VOMS authorization]
-                <fully qualified repository name>
-                Creates a new repository with a given name
-  add-replica   [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
-                [-a silence apache warning] [-z enable garbage collection]
-                [-n alias name] [-s S3 config file] [-p no apache config]
-                <stratum 0 url> <public key>
-                Creates a Stratum 1 replica of a Stratum 0 repository
-  import        [-w stratum0 url] [-o owner] [-u upstream storage]
-                [-l import legacy repo (2.0.x)] [-s show migration statistics]
-                [-f union filesystem type] [-c file ownership (UID:GID)]
-                [-k path to keys] [-g chown backend] [-r recreate whitelist]
-                [-p no apache config] [-t recreate repo key and certificate]
-                <fully qualified repository name>
-                Imports an old CernVM-FS repository into a fresh 2.1.x repo
-  publish       [-p pause for tweaks] [-n manual revision number] [-v verbose]
-                [-a tag name] [-c tag channel] [-m tag description]
-                [-X (force external data) | -N (force native data)]
-                [-Z compression algorithm]
-                <fully qualified name>
-                Make a new repository snapshot
-  rmfs          [-p(reserve) repo data and keys] [-f don't ask again]
-                <fully qualified name>
-                Remove the repository
-  abort         [-f don't ask again]
-                <fully qualified name>
-                Abort transaction and return to the state before
-  rollback      [-t tag] [-f don't ask again]
-                <fully qualified name>
-                Re-publishes the given tag as the new latest revision.
-                All snapshots between trunk and the target tag become
-                inaccessible.  Without a tag name, trunk-previous is used.
-  resign        <fully qualified name>
-                Re-sign the 30 day whitelist
-  list-catalogs [-s catalog sizes] [-e catalog entry counts] [-h catalog hashes]
-                [-x machine readable]
-                <fully qualified name>
-                Print a full list of all nested catalogs of a repository
-  info          <fully qualified name>
-                Print summary about the repository
-  tag           Create and manage named snapshots
-                [-a create tag <name>] [-c channel] [-m message] [-h root hash]
-                [-r remove tag <name>] [-f don't ask again]
-                [-i inspect tag <name>] [-x machine readable]
-                [-l list tags] [-x machine readable]
-                <fully qualified name>
-                Print named tags (snapshots) of the repository
-  check         [-c disable data chunk existence check]
-                [-i check data integrity] (may take some time)]
-                [-t tag (check given tag instead of trunk)]
-                [-s path to nested catalog subtree to check]
-                <fully qualified name>
-                Checks if the repository is sane
-  transaction   <fully qualified name>
-                Start to edit a repository
-  snapshot      [-t fail if other snapshot is in progress]
-                <fully qualified name>
-                Synchronize a Stratum 1 replica with the Stratum 0 source
-  migrate       <fully qualified name>
-                Migrates a repository to the current version of CernVM-FS
-  list          List available repositories
-  update-geodb  [-l update lazily based on CVMFS_UPDATEGEO* variables]
-                Updates the geo-IP database
-  update-info   [-p no apache config] [-e don't edit /info/meta]
-                Open meta info JSON file for editing
-  update-repoinfo Open repository meta info JSON file for editing
+  mkfs            [-w stratum0 url] [-u upstream storage] [-o owner]
+                  [-m replicable] [-f union filesystem type] [-s S3 config file]
+                  [-g disable auto tags] [-a hash algorithm (default: SHA-1)]
+                  [-z enable garbage collection] [-v volatile content]
+                  [-Z compression algorithm (default: zlib)]
+                  [-k path to existing keychain] [-p no apache config]
+                  [-V VOMS authorization] [-X (external data)]
+                  <fully qualified repository name>
+                  Creates a new repository with a given name
+  add-replica     [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
+                  [-a silence apache warning] [-z enable garbage collection]
+                  [-n alias name] [-s S3 config file] [-p no apache config]
+                  <stratum 0 url> <public key>
+                  Creates a Stratum 1 replica of a Stratum 0 repository
+  import          [-w stratum0 url] [-o owner] [-u upstream storage]
+                  [-l import legacy repo (2.0.x)] [-s show migration statistics]
+                  [-f union filesystem type] [-c file ownership (UID:GID)]
+                  [-k path to keys] [-g chown backend] [-r recreate whitelist]
+                  [-p no apache config] [-t recreate repo key and certificate]
+                  <fully qualified repository name>
+                  Imports an old CernVM-FS repository into a fresh 2.1.x repo
+  publish         [-p pause for tweaks] [-n manual revision number] [-v verbose]
+                  [-a tag name] [-c tag channel] [-m tag description]
+                  [-X (force external data) | -N (force native data)]
+                  [-Z compression algorithm]
+                  <fully qualified name>
+                  Make a new repository snapshot
+  rmfs            [-p(reserve) repo data and keys] [-f don't ask again]
+                  <fully qualified name>
+                  Remove the repository
+  abort           [-f don't ask again]
+                  <fully qualified name>
+                  Abort transaction and return to the state before
+  rollback        [-t tag] [-f don't ask again]
+                  <fully qualified name>
+                  Re-publishes the given tag as the new latest revision.
+                  All snapshots between trunk and the target tag become
+                  inaccessible.  Without a tag name, trunk-previous is used.
+  resign          <fully qualified name>
+                  Re-sign the 30 day whitelist
+  list-catalogs   [-s catalog sizes] [-e catalog entry counts]
+                  [-h catalog hashes] [-x machine readable]
+                  <fully qualified name>
+                  Print a full list of all nested catalogs of a repository
+  info            <fully qualified name>
+                  Print summary about the repository
+  tag             Create and manage named snapshots
+                  [-a create tag <name>] [-c channel] [-m message] [-h hash]
+                  [-r remove tag <name>] [-f don't ask again]
+                  [-i inspect tag <name>] [-x machine readable]
+                  [-l list tags] [-x machine readable]
+                  <fully qualified name>
+                  Print named tags (snapshots) of the repository
+  check           [-c disable data chunk existence check]
+                  [-i check data integrity] (may take some time)]
+                  [-t tag (check given tag instead of trunk)]
+                  [-s path to nested catalog subtree to check]
+                  <fully qualified name>
+                  Checks if the repository is sane
+  transaction     <fully qualified name>
+                  Start to edit a repository
+  snapshot        [-t fail if other snapshot is in progress]
+                  <fully qualified name>
+                  Synchronize a Stratum 1 replica with the Stratum 0 source
+  migrate         <fully qualified name>
+                  Migrates a repository to the current version of CernVM-FS
+  list            List available repositories
+  update-geodb    [-l update lazily based on CVMFS_UPDATEGEO* variables]
+                  Updates the geo-IP database
+  update-info     [-p no apache config] [-e don't edit /info/meta]
+                  Open meta info JSON file for editing
+  update-repoinfo <fully qualified name>
+                  Open repository meta info JSON file for editing
 "
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -192,7 +192,7 @@ is_subcommand() {
   local supported_commands="mkfs add-replica import publish rollback rmfs alterfs \
     resign list info tag list-tags lstags check transaction abort snapshot \
     skeleton migrate list-catalogs update-geodb gc catalog-chown eliminate-hardlinks \
-    update-info repo-metainfo"
+    update-info update-repoinfo"
 
   for possible_command in $supported_commands; do
     if [ x"$possible_command" = x"$subcommand" ]; then
@@ -347,7 +347,7 @@ Supported Commands:
                 Updates the geo-IP database
   update-info   [-p no apache config] [-e don't edit /info/meta]
                 Open meta info JSON file for editing
-  repo-metainfo Open repository meta info JSON file for editing
+  update-repoinfo Open repository meta info JSON file for editing
 "
 
 
@@ -5578,12 +5578,12 @@ eliminate_hardlinks() {
 
 ################################################################################
 
-_repo_metainfo_cleanup() {
+_update_repoinfo_cleanup() {
   local tmp_file="$1"
   rm -f $tmp_file > /dev/null 2>&1
 }
 
-repo_metainfo() {
+update_repoinfo() {
   local name
   local tmp_file
 
@@ -5605,7 +5605,7 @@ repo_metainfo() {
   chown $CVMFS_USER $tmp_file_info $tmp_file_manifest || \
     die "Cannot change ownership of temporary files"
   is_in_transaction $name && die "Cannot edit repository meta info while in a transaction"
-  trap "_repo_metainfo_cleanup $tmp_file_info $tmp_file_manifest; \
+  trap "_update_repoinfo_cleanup $tmp_file_info $tmp_file_manifest; \
     close_transaction $name 0" EXIT HUP INT TERM
   open_transaction $name || die "Failed to open transaction for meta info editing"
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5580,8 +5580,10 @@ eliminate_hardlinks() {
 ################################################################################
 
 _update_repoinfo_cleanup() {
-  local tmp_file="$1"
-  rm -f $tmp_file > /dev/null 2>&1
+  while [ $# -gt 0 ]; do
+    rm -f $1 > /dev/null 2>&1
+    shift 1
+  done
 }
 
 update_repoinfo() {

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2530,7 +2530,7 @@ check_jq() {
 }
 
 
-edit_json_unil_valid() {
+edit_json_until_valid() {
   local json_file="$1"
   local editor=$(get_editor)
   local has_jq=$(check_jq)
@@ -5618,7 +5618,7 @@ repo_metainfo() {
     create_repometa_skeleton $tmp_file_info
   fi
 
-  edit_json_unil_valid $tmp_file_info
+  edit_json_until_valid $tmp_file_info
   sign_manifest $name $tmp_file_manifest $tmp_file_info
 }
 
@@ -5677,7 +5677,7 @@ update_info() {
     trap "_update_info_cleanup $tmp_file" EXIT HUP INT TERM
     cp -f "$(get_global_info_path)/meta" $tmp_file
 
-    edit_json_unil_valid $tmp_file || die "Aborting..."
+    edit_json_until_valid $tmp_file || die "Aborting..."
   fi
 
   # update the JSON files

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5613,8 +5613,8 @@ repo_metainfo() {
     die "Failed getting repository meta info for $name"
   get_repo_info -R > $tmp_file_manifest || \
     die "Failed getting repository manifest for $name"
-  # TODO: if empty file
-  if [ true ]; then
+
+  if [ -f $tmp_file_info ] && [ ! -s $tmp_file_info ]; then
     create_repometa_skeleton $tmp_file_info
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2568,7 +2568,7 @@ create_repometa_skeleton() {
   "administrator" : "Your Name",
   "email"         : "you@organisation.org",
   "organisation"  : "Your Organisation",
-  "description"   : "Repository content"
+  "description"   : "Repository content",
   "recommended-stratum1s" : [ "stratum1 url", "stratum1 url" ],
 
   "custom" : {

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -266,8 +266,9 @@ void swissknife::CommandSign::CertificateUploadCallback(
   if (result.return_code == 0) {
     certificate_hash = result.content_hash;
   } else {
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to upload certificate (retcod: %d)",
-             result.return_code);
+    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to upload certificate "
+                                    "(retcode: %d)",
+                                    result.return_code);
   }
   certificate_hash_.Set(certificate_hash);
 }
@@ -279,7 +280,7 @@ void swissknife::CommandSign::MetainfoUploadCallback(
   if (result.return_code == 0) {
     metainfo_hash = result.content_hash;
   } else {
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to upload meta info (retcod: %d)",
+    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to upload meta info (retcode: %d)",
              result.return_code);
   }
   metainfo_hash_.Set(metainfo_hash);

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -26,5 +26,13 @@ cvmfs_run_test() {
   cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded || return 30
   diff reference downloaded || return 40
 
+  echo "create a revision in the repository" # Regression test: used to lose the
+                                             # hash to the repoinfo on publish
+  start_transaction $CVMFS_TEST_REPO || return 41
+  publish_repo      $CVMFS_TEST_REPO || return 42
+
+  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded || return 50
+  diff reference downloaded || return 51
+
   return 0
 }

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -15,7 +15,7 @@ cvmfs_run_test() {
   sudo sh -c "echo 'echo reference' >> $tty_bin" || return 12
   sudo chmod +x $tty_bin || return 13
   touch reference
-  EDITOR="cat" cvmfs_server repo-metainfo $CVMFS_TEST_REPO
+  EDITOR="cat" cvmfs_server update-repoinfo $CVMFS_TEST_REPO
   local retval=$?
   sudo mv ${tty_bin}.disabled $tty_bin || return 14
   if [ $retval -ne 0 ]; then


### PR DESCRIPTION
This fixes some minor problems with `cvmfs_server repo-metainfo`:

* add missing bash completion (along with `cvmfs_server update-info`)
* typo in `edit_json_unTil_valid()`
* default JSON skeleton wasn't valid JSON

Furthermore I'd like to suggest two things:

1. rename `cvmfs_server repo-metainfo` to `cvmfs_server update-repo-info` to match its name to `cvmfs_server update-info` and show that both are related
2. create the dummy meta info by default on `cvmfs_server mkfs`
