### PR TITLE
Have graft generate chunked files.

### DIFF
--- a/cvmfs/compression.cc
+++ b/cvmfs/compression.cc
@@ -123,7 +123,6 @@ bool CopyPath2Mem(const string &path,
 
 namespace zlib {
 
-const unsigned kZChunk = 16384;
 const unsigned kBufferSize = 32768;
 
 /**

--- a/cvmfs/compression.h
+++ b/cvmfs/compression.h
@@ -30,6 +30,8 @@ bool CopyPath2Mem(const std::string &path,
 
 namespace zlib {
 
+const unsigned kZChunk = 16384;
+
 enum StreamStates {
   kStreamDataError = 0,
   kStreamIOError,

--- a/cvmfs/swissknife_graft.h
+++ b/cvmfs/swissknife_graft.h
@@ -31,6 +31,7 @@ class CommandGraft : public Command {
     r.push_back(Parameter::Switch('v', "Verbose output"));
     r.push_back(Parameter::Optional('Z', "Compression algorithm "
                                     "(default: none)"));
+    r.push_back(Parameter::Optional('c', "Chunk size (in MB; default: 32)"));
     r.push_back(Parameter::Optional('a', "hash algorithm (default: SHA-1)"));
     return r;
   }
@@ -47,11 +48,19 @@ class CommandGraft : public Command {
   bool DirCallback(const std::string &relative_path,
                    const std::string &dir_name);
 
+  bool ChecksumFdWithChunks(int fd,
+                            zlib::Compressor *compressor,
+                            uint64_t *file_size,
+                            shash::Any *file_hash,
+                            std::vector<uint64_t> *chunk_offsets,
+                            std::vector<shash::Any> *chunk_checksums);
+
   std::string output_file_;
   std::string input_file_;
   bool verbose_;
   zlib::Algorithms compression_alg_;
   shash::Algorithms hash_alg_;
+  size_t chunk_size_;
 };
 
 }  // namespace swissknife

--- a/test/src/624-chunkedexternalgraft/main
+++ b/test/src/624-chunkedexternalgraft/main
@@ -1,0 +1,45 @@
+
+cvmfs_test_name="Pubkeys xattr"
+cvmfs_test_autofs_on_startup=false
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -X -Z none || return $?
+
+  echo "creating test file"
+  dd if=/dev/urandom of=chunks count=16 bs=1M
+  local correct_sha1=$(sha1sum chunks | awk '{print $1;}')
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  cvmfs_swissknife graft -i chunks -o /cvmfs/$CVMFS_TEST_REPO/chunks -c 1
+  echo "----- START GRAFT -----"
+  cat /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-chunks
+  echo "----- END GRAFT -----"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  # Verify we have an external file.
+  if `sha1sum /cvmfs/$CVMFS_TEST_REPO/chunks > /dev/null`; then
+    return 1
+  fi
+
+  # Now the file should be available.
+  cp chunks /srv/cvmfs/$CVMFS_TEST_REPO/chunks
+
+  local chunks=$(attr -qg chunks /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/chunks)
+  if [ "$chunks" -ne 16 ]; then
+    echo "Chunk count incorrect; found $chunks, expected 16."
+    return 2
+  fi
+
+  local cvmfs_sha1=$(sha1sum /cvmfs/$CVMFS_TEST_REPO/chunks | awk '{print $1;}')
+  if [ "$cvmfs_sha1" != "$correct_sha1" ]; then
+    echo "CVMFS had the incorrect SHA1; expected $correct_sha1, found $cvmfs_sha1"
+    return 3
+  fi
+
+  return 0
+}
+


### PR DESCRIPTION
When a graft file is sufficiently large, we should automatically generate a chunked version.

Chunked grafts was already merged previously - this simply decreases the barrier of generating them.

Includes an integration test which combines external data, uncompressed files, chunks, and grafts.