### PR TITLE
FIX: `cvmfs_swissknife scrub` didn't know about hash suffix M

### DIFF
--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -44,6 +44,10 @@ enum Algorithms {
   kAny,
 };
 
+/**
+ * NOTE: when adding a suffix here, one must edit `cvmfs_swissknife scrub`
+ *       accordingly, that checks for invalid hash suffixes
+ */
 const char kSuffixNone         = 0;
 const char kSuffixCatalog      = 'C';
 const char kSuffixHistory      = 'H';

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -177,7 +177,8 @@ std::string CommandScrub::CheckPathAndExtractHash(
       last_character != shash::kSuffixCatalog      &&
       last_character != shash::kSuffixPartial      &&
       last_character != shash::kSuffixCertificate  &&
-      last_character != shash::kSuffixMicroCatalog)
+      last_character != shash::kSuffixMicroCatalog &&
+      last_character != shash::kSuffixMetainfo)
   {
     PrintAlert(Alerts::kUnexpectedModifier, full_path);
     return "";


### PR DESCRIPTION
This new hash suffix `M` for repo info files was not known to `cvmfs_swissknife scrub` and produced false-positive alerts. Furthermore I added a reminder comment at a strategic location. Still a code smell, but okay....