### PR TITLE
FIX: Mistakenly Ignoring Catalog Load Failures during GC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 2.2.0:
+  * Fix mistakenly ignoring catalogs during garbage collection (CVM-966)
   * Fix mounting with a read-only cache directory
   * Add user.pubkeys extended attribute
   * Add `cvmfs_server snapshot -a` (CVM-813)

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -499,7 +499,8 @@ class CatalogTraversal
       default:
         LogCvmfs(kLogCatalogTraversal, error_sink_, "failed to load catalog %s "
                                                     "(%d - %s)",
-                 job->hash.ToString().c_str(), retval, Code2Ascii(retval));
+                 job->hash.ToStringWithSuffix().c_str(),
+                 retval, Code2Ascii(retval));
         return false;
     }
 

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -277,6 +277,7 @@ class LocalObjectFetcher :
     : base_path_(base_path)
     , temporary_directory_(temp_dir) {}
 
+  using BaseTN::FetchManifest; // un-hiding convenience overload
   Failures FetchManifest(manifest::Manifest** manifest) {
     const std::string path = BuildPath(BaseTN::kManifestFilename);
     if (!FileExists(path)) {
@@ -389,6 +390,7 @@ class HttpObjectFetcher :
     download_manager_(download_mgr), signature_manager_(signature_mgr) {}
 
  public:
+  using BaseTN::FetchManifest; // un-hiding convenience overload
   Failures FetchManifest(manifest::Manifest** manifest) {
     const std::string url = BuildUrl(BaseTN::kManifestFilename);
 

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -43,6 +43,20 @@ struct ObjectFetcherFailures {
   };
 };
 
+inline const char* Code2Ascii(const ObjectFetcherFailures::Failures error) {
+  const char *texts[ObjectFetcherFailures::kFailNumEntries + 1];
+  texts[0] = "OK";
+  texts[1] = "object not found";
+  texts[2] = "local I/O failure";
+  texts[3] = "network failure";
+  texts[4] = "decompression failed";
+  texts[5] = "manifest name doesn't match";
+  texts[6] = "manifest signature is invalid";
+  texts[7] = "bad data received";
+  texts[8] = "no text";
+  return texts[error];
+}
+
 /**
  * This is the default class implementing the data object fetching strategy. It
  * is meant to be used when CVMFS specific data structures need to be downloaded

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -27,6 +27,22 @@
 template <class ConcreteObjectFetcherT>
 struct object_fetcher_traits;
 
+struct ObjectFetcherFailures {
+  enum Failures {
+    kFailOk,
+    kFailNotFound,
+    kFailLocalIO,
+    kFailNetwork,
+    kFailDecompression,
+    kFailManifestNameMismatch,
+    kFailManifestSignatureMismatch,
+    kFailBadData,
+    kFailUnknown,
+
+    kFailNumEntries
+  };
+};
+
 /**
  * This is the default class implementing the data object fetching strategy. It
  * is meant to be used when CVMFS specific data structures need to be downloaded

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -88,7 +88,8 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
    * Fetches and opens the manifest of the repository this object fetcher is
    * configured for. Note that the user is responsible to clean up this object.
    *
-   * @return  a manifest object or NULL on error
+   * @param manifest  pointer to a manifest object pointer
+   * @return          failure code, specifying the action's result
    */
   Failures FetchManifest(manifest::Manifest** manifest) {
     return static_cast<DerivedT*>(this)->FetchManifest(manifest);
@@ -100,9 +101,10 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
    * database file will be unlinked automatically during the destruction of the
    * HistoryTN object.
    *
+   * @param history       pointer to a history database object pointer
    * @param history_hash  (optional) the content hash of the history database
    *                                 if left blank, the latest one is downloaded
-   * @return              a history database object or NULL on error
+   * @return              failure code, specifying the action's result
    */
   Failures FetchHistory(      HistoryTN  **history,
                         const shash::Any  &history_hash = shash::Any()) {
@@ -139,9 +141,10 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
    *
    * @param catalog_hash   the content hash of the catalog object
    * @param catalog_path   the root_path the catalog is mounted on
+   * @param catalog        pointer to the fetched catalog object pointer
    * @param is_nested      a hint if the catalog to be loaded is a nested one
    * @param parent         (optional) parent catalog of the requested catalog
-   * @return               a catalog object or NULL on error
+   * @return               failure code, specifying the action's result
    */
   Failures FetchCatalog(const shash::Any   &catalog_hash,
                         const std::string  &catalog_path,
@@ -214,7 +217,7 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
    *
    * @param object_hash  the content hash of the object to be downloaded
    * @param file_path    temporary file path to store the download result
-   * @return             true on success (if false, file_path is invalid)
+   * @return             failure code (if not kFailOk, file_path is invalid)
    */
   Failures Fetch(const shash::Any &object_hash, std::string *file_path) {
     return static_cast<DerivedT*>(this)->Fetch(object_hash, file_path);

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -376,7 +376,7 @@ class HttpObjectFetcher :
         return BaseTN::kFailUnknown;
     }
 
-    assert(retval - manifest::kFailOk);
+    assert(retval == manifest::kFailOk);
     *manifest = new manifest::Manifest(*manifest_ensemble.manifest);
     return (*manifest != NULL) ? BaseTN::kFailOk
                                : BaseTN::kFailUnknown;

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -95,9 +95,12 @@ int CommandGc::Main(const ArgumentList &args) {
                                &download_manager,
                                &signature_manager);
 
-  UniquePtr<manifest::Manifest> manifest(object_fetcher.FetchManifest());
-  if (!manifest.IsValid()) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load repository manifest");
+  UniquePtr<manifest::Manifest> manifest;
+  ObjectFetcher::Failures retval = object_fetcher.FetchManifest(&manifest);
+  if (retval != ObjectFetcher::kFailOk) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load repository manifest "
+                                    "(%d - %s)",
+                                    retval, Code2Ascii(retval));
     return 1;
   }
 

--- a/test/src/625-loadfailureduringgarbagecollect/main
+++ b/test/src/625-loadfailureduringgarbagecollect/main
@@ -1,0 +1,384 @@
+
+cvmfs_test_name="Detect Catalog Load Failures during Garbage Collection"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_1_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  mkdir dir1
+  touch dir1/shakespeare
+
+  echo "That thou art blamed shall not be thy defect,"       >> dir1/shakespeare
+  echo "For slander's mark was ever yet the fair;"           >> dir1/shakespeare
+  echo "The ornament of beauty is suspect,"                  >> dir1/shakespeare
+  echo "A crow that flies in heaven's sweetest air."         >> dir1/shakespeare
+  echo "So thou be good, slander doth but approve"           >> dir1/shakespeare
+  echo "Thy worth the greater, being wooed of time;"         >> dir1/shakespeare
+  echo "For canker vice the sweetest buds doth love,"        >> dir1/shakespeare
+  echo "And thou present'st a pure unstained prime."         >> dir1/shakespeare
+  echo "Thou hast passed by the ambush of young days"        >> dir1/shakespeare
+  echo "Either not assailed, or victor being charged;"       >> dir1/shakespeare
+  echo "Yet this thy praise cannot be so thy praise,"        >> dir1/shakespeare
+  echo "To tie up envy, evermore enlarged,"                  >> dir1/shakespeare
+  echo "   If some suspect of ill masked not thy show,"      >> dir1/shakespeare
+  echo "   Then thou alone kingdoms of hearts shouldst owe." >> dir1/shakespeare
+
+  touch dir1/many_shakespeares
+  touch dir1/alotof_shakespeares
+  touch dir1/shakespeare_army
+
+  popdir
+}
+
+produce_files_2_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  mkdir dir2
+  cp_bin dir2
+
+  popdir
+}
+
+produce_files_3_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  mkdir dir3
+  cp_bin dir3
+
+  touch dir3/kafka
+  echo "Deeply lost in the night."                                   >> dir3/kafka
+  echo ""                                                            >> dir3/kafka
+  echo "Just as one sometimes lowers one's head to reflect, "        >> dir3/kafka
+  echo "thus to be utterly lost in the night. "                      >> dir3/kafka
+  echo "All around people are asleep. It's just play acting, "       >> dir3/kafka
+  echo "an innocent self-deception, that they sleep in houses, "     >> dir3/kafka
+  echo "in safe beds, under a safe roof, stretched out or "          >> dir3/kafka
+  echo "curled up on mattresses, in sheets, under blankets; "        >> dir3/kafka
+  echo "in reality they have flocked together as they had once "     >> dir3/kafka
+  echo "upon a time and again later in a deserted region, a camp "   >> dir3/kafka
+  echo "in the open, a countless number of men, an army, a people, " >> dir3/kafka
+  echo "under a cold sky on cold earth, collapsed where once they "  >> dir3/kafka
+  echo "had stood, forehead pressed on the arm, face to the "        >> dir3/kafka
+  echo "ground, breathing quietly."                                  >> dir3/kafka
+  echo ""                                                            >> dir3/kafka
+  echo "And you are watching, are one of the watchmen, you find "    >> dir3/kafka
+  echo "the next one by brandishing a burning stick from the "       >> dir3/kafka
+  echo "brushwood pile beside you."                                  >> dir3/kafka
+  echo ""                                                            >> dir3/kafka
+  echo "Why are you watching?"                                       >> dir3/kafka
+  echo ""                                                            >> dir3/kafka
+  echo "Someone must watch, it is said. Someone must be there."      >> dir3/kafka
+
+  touch dir3/many_kafkas
+  touch dir3/alotof_kafkas
+  touch dir3/kafka_army
+
+  touch dir3/.cvmfscatalog
+
+  rm -fR dir1
+
+  popdir
+}
+
+produce_files_4_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  rm -fR dir3
+
+  popdir
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+  local scratch_dir=$(pwd)
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  mkdir reference_dir1
+  mkdir reference_dir2
+  mkdir reference_dir3
+  mkdir reference_dir4
+  local reference_dir1=$scratch_dir/reference_dir1
+  local reference_dir2=$scratch_dir/reference_dir2
+  local reference_dir3=$scratch_dir/reference_dir3
+  local reference_dir4=$scratch_dir/reference_dir4
+
+  local condemned_clgs=""
+  local preserved_clgs=""
+
+  local revision_4_clg=""
+  local revision_5_clg=""
+  local revision_5_nested_clg=""
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+  condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+
+  echo "load repository configuration"
+  load_repo_config $CVMFS_TEST_REPO
+
+  echo "disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository (1)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_1_in $repo_dir || return 1
+
+  echo "putting exactly the same stuff in the scratch spaces for comparison"
+  produce_files_1_in $reference_dir1 || return 2
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
+  condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir1 || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository (2)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_2_in $repo_dir || return 3
+
+  echo "putting exactly the same stuff in the scratch spaces for comparison"
+  produce_files_1_in $reference_dir2 || return 4
+  produce_files_2_in $reference_dir2 || return 4
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
+  revision_4_clg="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  condemned_clgs="$condemned_clgs $revision_4_clg"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir2 || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository (3)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_3_in $repo_dir || return 5
+
+  echo "putting exactly the same stuff in the scratch spaces for comparison"
+  produce_files_1_in $reference_dir3 || return 6
+  produce_files_2_in $reference_dir3 || return 6
+  produce_files_3_in $reference_dir3 || return 6
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?
+  revision_5_clg=$(get_current_root_catalog $CVMFS_TEST_REPO)
+  revision_5_nested_clg=$(cvmfs_server list-catalogs -xh $CVMFS_TEST_REPO | tail -n1 | awk '{print $1}')
+  preserved_clgs="$preserved_clgs $revision_5_clg $revision_5_nested_clg"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir3 || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository (4)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "putting some stuff in the new repository"
+  produce_files_4_in $repo_dir || return 7
+
+  echo "putting exactly the same stuff in the scratch spaces for comparison"
+  produce_files_1_in $reference_dir4 || return 8
+  produce_files_2_in $reference_dir4 || return 8
+  produce_files_3_in $reference_dir4 || return 8
+  produce_files_4_in $reference_dir4 || return 8
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO > publish_4.log 2>&1 || return $?
+  preserved_clgs="$preserved_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+
+  echo "check that the temporary scratch directory is empty"
+  [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir4 || return $?
+
+  # ============================================================================
+
+  local clg5="${revision_5_clg}C"
+  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
+    local clg5_path="$(get_local_repo_storage $CVMFS_TEST_REPO)/$(make_path $clg5)"
+    echo "locking up root catalog of (preserved) revision 5 ($clg5)"
+    chmod 0200 $clg5_path || return 9
+
+    local gc_log_1="gc_1.log"
+    echo "perform a basic garbage collection as dryrun (should fail) "
+    cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_1 2>&1 && return 10
+
+    echo "check that the error was caught"
+    cat $gc_log_1 | grep -e "failed to load.*${clg5}.*network" || return 11
+
+    echo "repair the catalog"
+    chmod 0644 $clg5_path || return 12
+  else
+    echo "NOTE: skipping permission fiddling on S3"
+  fi
+
+  # ============================================================================
+
+  echo "destroy root catalog of (preserved) revision 5 ($clg5)"
+  local clg5_broken="${clg5}.broken"
+  curl -o $clg5 $(get_object_url $CVMFS_TEST_REPO $clg5) || return 13
+  echo "i am broken" >  $clg5_broken                     || return 14
+  cat $clg5          >> $clg5_broken                     || return 15
+  upload_into_backend $CVMFS_TEST_REPO \
+                      $clg5_broken     \
+                      $(make_path $clg5) || return 16
+
+  local gc_log_2="gc_2.log"
+  echo "perform a basic garbage collection as dryrun (should fail) "
+  cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_2 2>&1 && return 17
+
+  echo "check that the error was caught"
+  cat $gc_log_2 | grep -e "failed to load.*${clg5}.*bad data" || return 18
+
+  echo "repair catalog"
+  upload_into_backend $CVMFS_TEST_REPO \
+                      $clg5            \
+                      $(make_path $clg5) || return 19
+
+  # ============================================================================
+
+  echo "check if the repository is still sane"
+  check_repository $CVMFS_TEST_REPO -i || return 20
+
+  echo "check if the repository's previous revision is still sane"
+  check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 21
+
+  # ============================================================================
+
+  local clg4="${revision_4_clg}C"
+  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
+    local clg4_path="$(get_local_repo_storage $CVMFS_TEST_REPO)/$(make_path $clg4)"
+    echo "locking up root catalog of (condemned) revision 4 ($clg4)"
+    chmod 0200 $clg4_path || return 22
+
+    local gc_log_3="gc_3.log"
+    echo "perform a basic garbage collection as dryrun (should fail) "
+    cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_3 2>&1 && return 23
+
+    echo "check that the error was caught"
+    cat $gc_log_3 | grep -e "failed to load.*${clg4}.*network" || return 24
+
+    echo "repair the catalog"
+    chmod 0644 $clg4_path || return 25
+  else
+    echo "NOTE: skipping permission fiddling on S3"
+  fi
+
+  # ============================================================================
+
+  echo "destroy root catalog of (condemned) revision 4 ($clg4)"
+  local clg4_broken="${clg4}.broken"
+  curl -o $clg4 $(get_object_url $CVMFS_TEST_REPO $clg4) || return 26
+  echo "i am broken" >  $clg4_broken                     || return 27
+  cat $clg4          >> $clg4_broken                     || return 28
+  upload_into_backend $CVMFS_TEST_REPO \
+                      $clg4_broken     \
+                      $(make_path $clg4) || return 29
+
+  local gc_log_4="gc_4.log"
+  echo "perform a basic garbage collection as dryrun (should fail) "
+  cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_4 2>&1 && return 30
+
+  echo "check that the error was caught"
+  cat $gc_log_4 | grep -e "failed to load.*${clg4}.*bad data" || return 31
+
+  echo "repair catalog"
+  upload_into_backend $CVMFS_TEST_REPO \
+                      $clg4            \
+                      $(make_path $clg4) || return 32
+
+  # ============================================================================
+
+  echo "check if the repository is still sane"
+  check_repository $CVMFS_TEST_REPO -i || return 33
+
+  echo "check if the repository's previous revision is still sane"
+  check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 34
+
+  # ============================================================================
+
+  local gc_log_5="gc_5.log"
+  echo "run garbage collection to delete all old revisions"
+  cvmfs_server gc -lf $CVMFS_TEST_REPO > $gc_log_5 2>&1 || return 35
+
+  echo "check that catalog 4 is gone"
+  peek_backend $CVMFS_TEST_REPO $clg4 && return 36
+
+  # ============================================================================
+
+  local gc_log_6="gc_6.log"
+  echo "run a garbage collection that should not fail (error 404)"
+  cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_6 2>&1 || return 37
+
+  # ============================================================================
+
+  local clg5n="${revision_5_nested_clg}C"
+  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
+    local clg5n_path="$(get_local_repo_storage $CVMFS_TEST_REPO)/$(make_path $clg5n)"
+    echo "locking up nested catalog of (preserved) revision 5 ($clg5n)"
+    chmod 0200 $clg5n_path || return 38
+
+    local gc_log_7="gc_7.log"
+    echo "perform a basic garbage collection as dryrun (should fail) "
+    cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_7 2>&1 && return 39
+
+    echo "check that the error was caught"
+    cat $gc_log_7 | grep -e "failed to load.*${clg5n}.*network" || return 40
+
+    echo "repair the catalog"
+    chmod 0644 $clg5n_path || return 41
+  else
+    echo "NOTE: skipping permission fiddling on S3"
+  fi
+
+  # ============================================================================
+
+  echo "destroy nested catalog of (preserved) revision 5 ($clg5n)"
+  local clg5n_broken="${clg5n}.broken"
+  curl -o $clg5n $(get_object_url $CVMFS_TEST_REPO $clg5n) || return 42
+  echo "i am broken" >  $clg5n_broken                      || return 43
+  cat $clg5n         >> $clg5n_broken                      || return 44
+  upload_into_backend $CVMFS_TEST_REPO \
+                      $clg5n_broken    \
+                      $(make_path $clg5n) || return 45
+
+  local gc_log_8="gc_8.log"
+  echo "perform a basic garbage collection as dryrun (should fail) "
+  cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_8 2>&1 && return 46
+
+  echo "check that the error was caught"
+  cat $gc_log_8 | grep -e "failed to load.*${clg5n}.*bad data" || return 47
+
+  echo "repair catalog"
+  upload_into_backend $CVMFS_TEST_REPO \
+                      $clg5n           \
+                      $(make_path $clg5n) || return 48
+
+  return 0
+}

--- a/test/src/625-loadfailureduringgarbagecollect/main
+++ b/test/src/625-loadfailureduringgarbagecollect/main
@@ -2,7 +2,7 @@
 cvmfs_test_name="Detect Catalog Load Failures during Garbage Collection"
 cvmfs_test_autofs_on_startup=false
 
-produce_files_1_in() {
+produce_files_1_in() { # REVISION 3
   local working_dir=$1
   pushdir $working_dir
 
@@ -31,22 +31,12 @@ produce_files_1_in() {
   popdir
 }
 
-produce_files_2_in() {
+produce_files_2_in() { # REVISION 4
   local working_dir=$1
   pushdir $working_dir
 
   mkdir dir2
-  cp_bin dir2
-
-  popdir
-}
-
-produce_files_3_in() {
-  local working_dir=$1
-  pushdir $working_dir
-
   mkdir dir3
-  cp_bin dir3
 
   touch dir3/kafka
   echo "Deeply lost in the night."                                   >> dir3/kafka
@@ -78,12 +68,19 @@ produce_files_3_in() {
 
   touch dir3/.cvmfscatalog
 
+  popdir
+}
+
+produce_files_3_in() { # REVISION 5
+  local working_dir=$1
+  pushdir $working_dir
+
   rm -fR dir1
 
   popdir
 }
 
-produce_files_4_in() {
+produce_files_4_in() { # REVISION 6
   local working_dir=$1
   pushdir $working_dir
 
@@ -220,26 +217,6 @@ cvmfs_run_test() {
   # ============================================================================
 
   local clg5="${revision_5_clg}C"
-  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
-    local clg5_path="$(get_local_repo_storage $CVMFS_TEST_REPO)/$(make_path $clg5)"
-    echo "locking up root catalog of (preserved) revision 5 ($clg5)"
-    chmod 0200 $clg5_path || return 9
-
-    local gc_log_1="gc_1.log"
-    echo "perform a basic garbage collection as dryrun (should fail) "
-    cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_1 2>&1 && return 10
-
-    echo "check that the error was caught"
-    cat $gc_log_1 | grep -e "failed to load.*${clg5}.*network" || return 11
-
-    echo "repair the catalog"
-    chmod 0644 $clg5_path || return 12
-  else
-    echo "NOTE: skipping permission fiddling on S3"
-  fi
-
-  # ============================================================================
-
   echo "destroy root catalog of (preserved) revision 5 ($clg5)"
   local clg5_broken="${clg5}.broken"
   curl -o $clg5 $(get_object_url $CVMFS_TEST_REPO $clg5) || return 13
@@ -249,17 +226,55 @@ cvmfs_run_test() {
                       $clg5_broken     \
                       $(make_path $clg5) || return 16
 
-  local gc_log_2="gc_2.log"
+  local gc_log_1="gc_1.log"
+  local deletion_log="condemned_objects.log"
   echo "perform a basic garbage collection as dryrun (should fail) "
-  cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_2 2>&1 && return 17
+  local gc_retcode=0
+  cvmfs_server gc -ldfL $deletion_log $CVMFS_TEST_REPO > $gc_log_1 2>&1 || gc_retcode=0
+
+  echo "---- Deletion Log ----"
+  cat $deletion_log
+  echo "---- ------------ ----"
+
+  echo "check that revision 5's root catalog ($clg5) is NOT in the deletion log"
+  cat $deletion_log | grep -q $clg5 && return 100
+
+  # before the fix was added, garbage collection would have swept $kafka_object
+  # but left revision5's root catalog intact (because it was falsely ignored)
+  local kafka_object="fd8370662e701313534bfc2d2b860a7bf0fbf5da"
+  echo "check that kafka ($kafka_object) is NOT in the deletion log (regression test CVM-966)"
+  cat $deletion_log | grep -q $kafka_object && return 101
+
+  echo "do defered GC retcode check (for the regression test)"
+  [ $gc_retcode -eq 0 ] || return 17
 
   echo "check that the error was caught"
-  cat $gc_log_2 | grep -e "failed to load.*${clg5}.*bad data" || return 18
+  cat $gc_log_1 | grep -e "failed to load.*${clg5}.*bad data" || return 18
 
   echo "repair catalog"
   upload_into_backend $CVMFS_TEST_REPO \
                       $clg5            \
                       $(make_path $clg5) || return 19
+
+  # ============================================================================
+
+  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
+    local clg5_path="$(get_local_repo_storage $CVMFS_TEST_REPO)/$(make_path $clg5)"
+    echo "locking up root catalog of (preserved) revision 5 ($clg5)"
+    chmod 0200 $clg5_path || return 9
+
+    local gc_log_2="gc_2.log"
+    echo "perform a basic garbage collection as dryrun (should fail) "
+    cvmfs_server gc -ldf $CVMFS_TEST_REPO > $gc_log_2 2>&1 && return 10
+
+    echo "check that the error was caught"
+    cat $gc_log_2 | grep -e "failed to load.*${clg5}.*network" || return 11
+
+    echo "repair the catalog"
+    chmod 0644 $clg5_path || return 12
+  else
+    echo "NOTE: skipping permission fiddling on S3"
+  fi
 
   # ============================================================================
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -1336,6 +1336,24 @@ peek_backend() {
 }
 
 
+# uploads a random file into the backend storage of a CVMFS repository
+#
+# @param repository   the repository name to uploaded into
+# @param file_path    the file to be uploaded
+# @param remote_path  the relative remote path to be uploaded into
+upload_into_backend() {
+  local repo_name="$1"
+  local file_path="$2"
+  local remote_path="$3"
+
+  load_repo_config $repo_name
+  cvmfs_swissknife upload -i $file_path              \
+                          -o $remote_path            \
+                          -r $CVMFS_UPSTREAM_STORAGE \
+                          -a $CVMFS_HASH_ALGORITHM
+}
+
+
 # reads the upstream config part of a CernVM-FS server configuration file
 # This is the third comma-separated field in the upstream string
 read_upstream_config() {

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -355,6 +355,10 @@ class T_ObjectFetcher : public ::testing::Test {
     return NeedsFilesystemSandbox(type<ObjectFetcherT>());
   }
 
+  bool IsHttpObjectFetcher() {
+    return IsHttpObjectFetcher(type<ObjectFetcherT>());
+  }
+
   typedef std::vector<std::string> DirectoryListing;
   void ListDirectory(const std::string &path, DirectoryListing *listing) const {
     ASSERT_TRUE(listing != NULL);
@@ -534,6 +538,16 @@ class T_ObjectFetcher : public ::testing::Test {
   }
   bool NeedsFilesystemSandbox(const type<MockObjectFetcher> type_spec) {
     return false;
+  }
+
+  bool IsHttpObjectFetcher(const type<LocalObjectFetcher<> > type_spec) {
+    return false;
+  }
+  bool IsHttpObjectFetcher(const type<MockObjectFetcher> type_spec) {
+    return false;
+  }
+  bool IsHttpObjectFetcher(const type<HttpObjectFetcher<> > type_spec) {
+    return true;
   }
 
  private:

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -192,7 +192,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
     certificate_hash = h("0000000000000000000000000000000000000000",
                          shash::kSuffixCertificate);
-    InsertIntoStorage(certificate_path, &certificate_hash);
+    CommitIntoStorage(certificate_path, &certificate_hash);
   }
 
   void WriteFile(const std::string &path, const std::string &content) {
@@ -452,7 +452,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
     *content_hash = h("0000000000000000000000000000000000000000",
                       shash::kSuffixHistory);
-    InsertIntoStorage(tmp_path, content_hash);
+    CommitIntoStorage(tmp_path, content_hash);
   }
 
   void CreateHistory(const type<MockObjectFetcher>  type_spec,
@@ -511,7 +511,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
     *content_hash = h("0000000000000000000000000000000000000000",
                       shash::kSuffixCatalog);
-    InsertIntoStorage(tmp_path, content_hash);
+    CommitIntoStorage(tmp_path, content_hash);
   }
 
   void CreateCatalog(const type<MockObjectFetcher >  type_spec,
@@ -528,7 +528,7 @@ class T_ObjectFetcher : public ::testing::Test {
     MockCatalog::RegisterObject(catalog->hash(), catalog);
   }
 
-  void InsertIntoStorage(const std::string  &tmp_path,
+  void CommitIntoStorage(const std::string  &tmp_path,
                                shash::Any   *content_hash) {
     const std::string txn_path = CreateTempPath(temp_directory + "/blob", 0600);
     ASSERT_TRUE(zlib::CompressPath2Path(tmp_path, txn_path, content_hash)) <<

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -517,7 +517,7 @@ class T_ObjectFetcher : public ::testing::Test {
                                shash::Any   *content_hash) {
     const std::string txn_path = CreateTempPath(temp_directory + "/blob", 0600);
     ASSERT_TRUE(zlib::CompressPath2Path(tmp_path, txn_path, content_hash)) <<
-      "failed to compress file " << tmp_path << " to " << tmp_path;
+      "failed to compress file " << tmp_path << " to " << txn_path;
     const std::string res_path = backend_storage + "/data/" +
                                  content_hash->MakePath();
     ASSERT_EQ(0, rename(txn_path.c_str(), res_path.c_str())) <<

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -624,11 +624,16 @@ TYPED_TEST(T_ObjectFetcher, FetchManifestSlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE(object_fetcher.IsValid());
 
-  UniquePtr<manifest::Manifest> manifest(object_fetcher->FetchManifest());
-  ASSERT_TRUE(manifest.IsValid());
+  manifest::Manifest *manifest = NULL;
+  typename TypeParam::Failures retval =
+    object_fetcher->FetchManifest(&manifest);
+  EXPECT_EQ(TypeParam::kFailOk, retval);
+  ASSERT_NE(static_cast<manifest::Manifest*>(NULL), manifest);
 
   EXPECT_EQ(TestFixture::root_hash,    manifest->catalog_hash());
   EXPECT_EQ(TestFixture::history_hash, manifest->history());
+  delete manifest;
+
   if (TestFixture::NeedsFilesystemSandbox()) {
     EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
   }
@@ -641,12 +646,15 @@ TYPED_TEST(T_ObjectFetcher, FetchHistorySlow) {
 
   EXPECT_TRUE(object_fetcher->HasHistory());
 
-  UniquePtr<typename TypeParam::HistoryTN>
-    history(object_fetcher->FetchHistory());
-  ASSERT_TRUE(history.IsValid());
+  typename TypeParam::HistoryTN *history = NULL;
+  typename TypeParam::Failures retval = object_fetcher->FetchHistory(&history);
+  EXPECT_EQ(TypeParam::kFailOk, retval);
+  ASSERT_NE(static_cast<typename TypeParam::HistoryTN*>(NULL), history);
   EXPECT_EQ(TestFixture::previous_history_hash, history->previous_revision());
+  delete history;
+
   if (TestFixture::NeedsFilesystemSandbox()) {
-    EXPECT_LE(1u, TestFixture::CountTemporaryFiles());
+    EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
   }
 }
 
@@ -655,9 +663,11 @@ TYPED_TEST(T_ObjectFetcher, FetchLegacyHistorySlow) {
   UniquePtr<TypeParam> object_fetcher(TestFixture::GetObjectFetcher());
   ASSERT_TRUE(object_fetcher.IsValid());
 
-  UniquePtr<typename TypeParam::HistoryTN> history(
-              object_fetcher->FetchHistory(TestFixture::previous_history_hash));
-  ASSERT_TRUE(history.IsValid())
+  typename TypeParam::HistoryTN *history = NULL;
+  typename TypeParam::Failures retval =
+    object_fetcher->FetchHistory(&history, TestFixture::previous_history_hash);
+  EXPECT_EQ(TypeParam::kFailOk, retval);
+  ASSERT_NE(static_cast<typename TypeParam::HistoryTN*>(NULL), history)
     << "didn't find: "
     << TestFixture::previous_history_hash.ToStringWithSuffix();
   EXPECT_TRUE(history->previous_revision().IsNull());
@@ -694,6 +704,7 @@ TYPED_TEST(T_ObjectFetcher, FetchCatalogSlow) {
   if (TestFixture::NeedsFilesystemSandbox()) {
     EXPECT_LE(1u, TestFixture::CountTemporaryFiles());
   }
+  delete history;
 }
 
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -739,7 +739,12 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidHistorySlow) {
                                  h("400d35465f179a4acacb5fe749e6ce20a0bbdb84",
                                    shash::kSuffixHistory));
   EXPECT_FALSE(history.IsValid());
-  EXPECT_EQ(TypeParam::kFailNotFound, retval) << "code: " << Code2Ascii(retval);
+  typename TypeParam::Failures expected_failure =
+    (TestFixture::IsHttpObjectFetcher())
+      ? TypeParam::kFailUnknown   // HttpObjectFetcher is used via file://
+      : TypeParam::kFailNotFound; // which doesn't support proper errors
+                                  // TODO(rmeusel): fix me
+  EXPECT_EQ(expected_failure, retval) << "code: " << Code2Ascii(retval);
 
   if (TestFixture::NeedsFilesystemSandbox()) {
     EXPECT_EQ(0u, TestFixture::CountTemporaryFiles());
@@ -791,10 +796,16 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalogSlow) {
   shash::Any invalid_clg = h("5739dc30f42525a261b2f4b383b220df3e36f04d",
                              shash::kSuffixCatalog);
 
+  typename TypeParam::Failures expected_failure =
+    (TestFixture::IsHttpObjectFetcher())
+      ? TypeParam::kFailUnknown   // HttpObjectFetcher is used via file://
+      : TypeParam::kFailNotFound; // which doesn't support proper errors
+                                  // TODO(rmeusel): fix me
+
   typename TypeParam::CatalogTN *catalog = NULL;
   typename TypeParam::Failures retval =
     object_fetcher->FetchCatalog(invalid_clg, "", &catalog);
-  EXPECT_EQ(TypeParam::kFailNotFound, retval) << "code: " << Code2Ascii(retval);
+  EXPECT_EQ(expected_failure, retval) << "code: " << Code2Ascii(retval);
   ASSERT_EQ(static_cast<typename TypeParam::CatalogTN*>(NULL), catalog);
 
   if (TestFixture::NeedsFilesystemSandbox()) {
@@ -805,8 +816,7 @@ TYPED_TEST(T_ObjectFetcher, FetchInvalidCatalogSlow) {
   EXPECT_FALSE(catalog_ptr.IsValid());
   typename TypeParam::Failures retval2 =
     object_fetcher->FetchCatalog(invalid_clg, "", &catalog_ptr);
-  EXPECT_EQ(TypeParam::kFailNotFound, retval2) << "code: "
-                                               << Code2Ascii(retval2);
+  EXPECT_EQ(expected_failure, retval2) << "code: " << Code2Ascii(retval2);
   EXPECT_FALSE(catalog_ptr.IsValid());
 
   if (TestFixture::NeedsFilesystemSandbox()) {

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -35,6 +35,9 @@ class T_ObjectFetcher : public ::testing::Test {
   static const std::string  master_key_path;
   static const unsigned int catalog_revision;
 
+  static const shash::Any broken_history_hash;
+  static const shash::Any broken_catalog_hash;
+
   // determined during setup
   static shash::Any root_hash;
   static shash::Any history_hash;
@@ -79,6 +82,9 @@ class T_ObjectFetcher : public ::testing::Test {
 
     // create a catalog
     CreateCatalog(&root_hash, "");
+
+    // create some 'broken' database objects
+    CreateBrokenDatabases();
 
     if (NeedsFilesystemSandbox()) {
       WriteKeychain();
@@ -425,6 +431,11 @@ class T_ObjectFetcher : public ::testing::Test {
     CreateSandboxHistory(content_hash, previous_revision);
   }
 
+  void CreateBrokenDatabases() {
+    MockHistory::RegisterObject(broken_history_hash, NULL);
+    MockCatalog::RegisterObject(broken_catalog_hash, NULL);
+  }
+
   void CreateSandboxHistory(
     shash::Any *content_hash,
     const shash::Any &previous_revision
@@ -605,6 +616,16 @@ const std::string T_ObjectFetcher<ObjectFetcherT>::master_key_path =
 
 template <class ObjectFetcherT>
 const unsigned int T_ObjectFetcher<ObjectFetcherT>::catalog_revision = 1;
+
+template <class ObjectFetcherT>
+const shash::Any T_ObjectFetcher<ObjectFetcherT>::broken_history_hash =
+                                  h("b904b56ffd47ba89f26d5a887063b4a1fbfb9307",
+                                    shash::kSuffixHistory);
+
+template <class ObjectFetcherT>
+const shash::Any T_ObjectFetcher<ObjectFetcherT>::broken_catalog_hash =
+                                  h("c4818243550ae6a46f55602043eb23f8c4f97910",
+                                    shash::kSuffixCatalog);
 
 template <class ObjectFetcherT>
 shash::Any T_ObjectFetcher<ObjectFetcherT>::root_hash;

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -533,11 +533,16 @@ class T_ObjectFetcher : public ::testing::Test {
     const std::string txn_path = CreateTempPath(temp_directory + "/blob", 0600);
     ASSERT_TRUE(zlib::CompressPath2Path(tmp_path, txn_path, content_hash)) <<
       "failed to compress file " << tmp_path << " to " << txn_path;
+    InsertIntoStorage(txn_path, *content_hash);
+  }
+
+  void InsertIntoStorage(const std::string &txn_path,
+                         const shash::Any  &content_hash) {
     const std::string res_path = backend_storage + "/data/" +
-                                 content_hash->MakePath();
+                                 content_hash.MakePath();
     ASSERT_EQ(0, rename(txn_path.c_str(), res_path.c_str())) <<
       "failed to rename() compressed file " << txn_path << " to " << res_path <<
-      " with content hash " << content_hash->ToString() <<
+      " with content hash " << content_hash.ToString() <<
       " (errno: " << errno << ")";
   }
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -362,7 +362,15 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   bool IsHttpObjectFetcher() {
-    return IsHttpObjectFetcher(type<ObjectFetcherT>());
+    return GetObjectFetcherType(type<ObjectFetcherT>()) == "http";
+  }
+
+  bool IsLocalObjectFetcher() {
+    return GetObjectFetcherType(type<ObjectFetcherT>()) == "local";
+  }
+
+  bool IsMockObjectFetcher() {
+    return GetObjectFetcherType(type<ObjectFetcherT>()) == "mock";
   }
 
   typedef std::vector<std::string> DirectoryListing;
@@ -556,14 +564,14 @@ class T_ObjectFetcher : public ::testing::Test {
     return false;
   }
 
-  bool IsHttpObjectFetcher(const type<LocalObjectFetcher<> > type_spec) {
-    return false;
+  std::string GetObjectFetcherType(const type<LocalObjectFetcher<> > spec) {
+    return "local";
   }
-  bool IsHttpObjectFetcher(const type<MockObjectFetcher> type_spec) {
-    return false;
+  std::string GetObjectFetcherType(const type<MockObjectFetcher> spec) {
+    return "mock";
   }
-  bool IsHttpObjectFetcher(const type<HttpObjectFetcher<> > type_spec) {
-    return true;
+  std::string GetObjectFetcherType(const type<HttpObjectFetcher<> > spec) {
+    return "http";
   }
 
  private:

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -425,22 +425,24 @@ catalog::LoadError catalog::MockCatalogManager::LoadCatalog(
 //------------------------------------------------------------------------------
 
 
-manifest::Manifest* MockObjectFetcher::FetchManifest() {
+ MockObjectFetcher::Failures
+ MockObjectFetcher::FetchManifest(manifest::Manifest** manifest) {
   const uint64_t    catalog_size = 0;
   const std::string root_path    = "";
-  manifest::Manifest* manifest = new manifest::Manifest(
+  *manifest = new manifest::Manifest(
       MockCatalog::root_hash,
       catalog_size,
       root_path);
-  manifest->set_history(MockHistory::root_hash);
-  return manifest;
+  (*manifest)->set_history(MockHistory::root_hash);
+  return MockObjectFetcher::kFailOk;
 }
 
-bool MockObjectFetcher::Fetch(const shash::Any &object_hash,
-                              std::string      *file_path) {
+MockObjectFetcher::Failures
+MockObjectFetcher::Fetch(const shash::Any   &object_hash,
+                               std::string  *file_path) {
   assert(file_path != NULL);
   *file_path = object_hash.ToString();
-  return true;
+  return MockObjectFetcher::kFailOk;
 }
 
 

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -442,7 +442,15 @@ MockObjectFetcher::Fetch(const shash::Any   &object_hash,
                                std::string  *file_path) {
   assert(file_path != NULL);
   *file_path = object_hash.ToString();
+  if (!ObjectExists(object_hash)) {
+    return MockObjectFetcher::kFailNotFound;
+  }
   return MockObjectFetcher::kFailOk;
+}
+
+bool MockObjectFetcher::ObjectExists(const shash::Any &object_hash) const {
+  return MockCatalog::Exists(object_hash) ||
+         MockHistory::Exists(object_hash);
 }
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -767,8 +767,11 @@ struct object_fetcher_traits<MockObjectFetcher> {
  */
 class MockObjectFetcher : public AbstractObjectFetcher<MockObjectFetcher> {
  public:
-  manifest::Manifest* FetchManifest();
-  bool Fetch(const shash::Any &object_hash, std::string *file_path);
+  typedef typename AbstractObjectFetcher<MockObjectFetcher>::Failures Failures;
+
+ public:
+  Failures FetchManifest(manifest::Manifest** manifest);
+  Failures Fetch(const shash::Any &object_hash, std::string *file_path);
 };
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -234,6 +234,8 @@ class MockObjectStorage {
  public:
   static std::set<shash::Any> *s_deleted_objects;
 
+  friend class MockObjectFetcher;
+
  public:
   static void Reset() {
     MockObjectStorage::UnregisterObjects();
@@ -630,6 +632,8 @@ class MockHistory : public history::History,
   static const shash::Any  root_hash;
   static unsigned int      instances;
 
+  using MockObjectStorage<MockHistory>::Exists;
+
  public:
   static void ResetGlobalState();
 
@@ -774,6 +778,9 @@ class MockObjectFetcher : public AbstractObjectFetcher<MockObjectFetcher> {
   using BaseTN::FetchManifest; // un-hiding convenience overload
   Failures FetchManifest(manifest::Manifest** manifest);
   Failures Fetch(const shash::Any &object_hash, std::string *file_path);
+
+ private:
+  bool ObjectExists(const shash::Any &object_hash) const;
 };
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -768,8 +768,10 @@ struct object_fetcher_traits<MockObjectFetcher> {
 class MockObjectFetcher : public AbstractObjectFetcher<MockObjectFetcher> {
  public:
   typedef typename AbstractObjectFetcher<MockObjectFetcher>::Failures Failures;
+  typedef AbstractObjectFetcher<MockObjectFetcher>                    BaseTN;
 
  public:
+  using BaseTN::FetchManifest; // un-hiding convenience overload
   Failures FetchManifest(manifest::Manifest** manifest);
   Failures Fetch(const shash::Any &object_hash, std::string *file_path);
 };


### PR DESCRIPTION
This fixes the garbage collection bug described in [CVM-966](https://sft.its.cern.ch/jira/browse/CVM-966) and refactors the `ObjectFetcher` classes for better error reporting.

##### Root cause
The garbage collection needs to ignore catalog load failures to support consecutive GC runs -- at some point the `CatalogTraversal` reaches an already swept root catalog. Furthermore the previous GC run could have crashed, leaving a condemned root catalog whose nested catalogs are only partially swept. Hence, both nested and root catalog load failures must be handled.

Until now, GC was naïvely ignoring any catalog load failure - even if transient (i.e. network glitch, ...). This can lead to data loss in the worst case or potentially also to leaked hard drive space if a catalog is falsely ignored during the preservation or respectively sweeping phase.

##### Solution
The garbage collection routine is now aware of the error-class when a catalog wasn't successfully loaded. Hence, everything but *ENOENT* or 404 does lead to an abortion of the collection process. Otherwise the catalog is considered to be swept by a previous garbage collection run and the system carries on.

##### Refactoring of `ObjectFetcher`
The `ObjectFetcher` class has seen a change in her public API, to forward certain error-classes to both `GarbageCollector` and `CatalogTraversal`. This makes `ObjectFetcher` more suitable for the reuse in other places as a side effect. Along with that, the unit test set `T_ObjectFetcher` needed major adaptions.

Finally integration test **625** does reproduce the data-loss scenario described above as a regression test and also checks certain error detection scenarios of the garbage collection routine.