### PR TITLE
FIX: Logging of S3 Upload Jobs

### DIFF
--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -386,8 +386,8 @@ bool S3Uploader::UploadJobInfo(s3fanout::JobInfo *info) {
            "--> Host:   '%s'\n",
            info->origin_mem.data != NULL ? "buffer" : "file",
            info->object_key.c_str(),
-           info->hostname.c_str(),
-           info->bucket.c_str());
+           info->bucket.c_str(),
+           info->hostname.c_str());
 
   if (s3fanout_mgr_.PushNewJob(info) != 0) {
     LogCvmfs(kLogUploadS3, kLogStderr, "Failed to upload object: %s" ,


### PR DESCRIPTION
This is a fix for a debug print of the S3 uploader. It's simply a scrambled `printf`. Thanks for reporting, Catalin!