### PR TITLE
FIX: Handle Manifest Committing as Updates

### DIFF
--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -121,8 +121,9 @@ class WritableCatalogManager : public SimpleCatalogManager {
 
   void SetTTL(const uint64_t new_ttl);
   bool SetVOMSAuthz(const std::string &voms_authz);
-  manifest::Manifest *Commit(const bool     stop_for_tweaks,
-                             const uint64_t manual_revision);
+  bool Commit(const bool           stop_for_tweaks,
+              const uint64_t       manual_revision,
+              manifest::Manifest  *manifest);
   void Balance() {
       if (IsBalanceable()) {
           DoBalance();

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4506,9 +4506,6 @@ publish() {
     if [ "x$CVMFS_REPOSITORY_TTL" != "x" ]; then
       sync_command="$sync_command -T $CVMFS_REPOSITORY_TTL"
     fi
-    if [ "x$CVMFS_GARBAGE_COLLECTION" = "xtrue" ]; then
-      sync_command="$sync_command -g"
-    fi
     if [ "x$CVMFS_MAXIMAL_CONCURRENT_WRITES" != "x" ]; then
       sync_command="$sync_command -q $CVMFS_MAXIMAL_CONCURRENT_WRITES"
     fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4455,6 +4455,7 @@ publish() {
     local log_level=
     [ "x$CVMFS_LOG_LEVEL" != x ] && log_level="-z $CVMFS_LOG_LEVEL"
 
+    local trusted_certs="/etc/cvmfs/repositories.d/${name}/trusted_certs"
     local sync_command="$(__swissknife_cmd dbg) sync \
       -u /cvmfs/$name                                \
       -s ${spool_dir}/scratch                        \
@@ -4466,6 +4467,9 @@ publish() {
       -o $manifest                                   \
       -e $hash_algorithm                             \
       -Z $compression_alg                            \
+      -C $trusted_certs                              \
+      -N $name                                       \
+      -K $CVMFS_PUBLIC_KEY                           \
       $(get_follow_http_redirects_flag)              \
       $authz_file                                    \
       $log_level $tweaks_option $external_option $verbosity"

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -92,6 +92,9 @@ class Manifest {
   void set_meta_info(const shash::Any &meta_info) {
     meta_info_ = meta_info;
   }
+  void set_root_path(const std::string &root_path) {
+    root_path_ = shash::Md5(shash::AsciiPtr(root_path));
+  }
 
   uint64_t revision() const { return revision_; }
   std::string repository_name() const { return repository_name_; }

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -73,6 +73,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   }
 
   // Load private key
+  // TODO(rmeusel): eliminiate code duplication with swissknife_letter.cc
   if (priv_key == "") {
     LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
              "Enter file name of private key file to your certificate []: ");

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -493,6 +493,9 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   params.manifest_path = *args.find('o')->second;
   params.spooler_definition = *args.find('r')->second;
 
+  params.public_keys = *args.find('K')->second;
+  params.repo_name = *args.find('N')->second;
+
   if (args.find('f') != args.end())
     params.union_fs_type = *args.find('f')->second;
   if (args.find('A') != args.end()) params.is_balanced = true;
@@ -539,6 +542,10 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   if (args.find('Z') != args.end()) {
     params.compression_alg =
       zlib::ParseCompressionAlgorithm(*args.find('Z')->second);
+  }
+
+  if (args.find('C') != args.end()) {
+    params.trusted_certs = *args.find('C')->second;
   }
 
   if (args.find('j') != args.end()) {

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -504,7 +504,6 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   if (args.find('m') != args.end()) params.mucatalogs = true;
   if (args.find('i') != args.end()) params.ignore_xdir_hardlinks = true;
   if (args.find('d') != args.end()) params.stop_for_catalog_tweaks = true;
-  if (args.find('g') != args.end()) params.garbage_collectable = true;
   if (args.find('V') != args.end()) params.voms_authz = true;
   if (args.find('F') != args.end()) params.authz_file = *args.find('F')->second;
   if (args.find('k') != args.end()) params.include_xattrs = true;
@@ -668,18 +667,13 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     catalog_manager.SetVOMSAuthz(new_authz);
   }
 
-  LogCvmfs(kLogCvmfs, kLogStdout, "Exporting repository manifest");
   if (!mediator.Commit(manifest.weak_ref())) {
     PrintError("something went wrong during sync");
     return 5;
   }
 
-  LogCvmfs(kLogCvmfs, kLogStdout, "Exporting repository manifest");
-  const bool needs_bootstrap_shortcuts = params.voms_authz;
-  manifest->set_garbage_collectability(params.garbage_collectable);
-  manifest->set_has_alt_catalog_path(needs_bootstrap_shortcuts);
-
   // finalize the spooler
+  LogCvmfs(kLogCvmfs, kLogStdout, "Exporting repository manifest");
   params.spooler->WaitForUpload();
   delete params.spooler;
 

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -46,6 +46,7 @@ struct SyncParameters {
     min_weight(kDefaultMinWeight) {}
 
   upload::Spooler *spooler;
+  std::string      repo_name;
   std::string      dir_union;
   std::string      dir_scratch;
   std::string      dir_rdonly;
@@ -55,6 +56,8 @@ struct SyncParameters {
   std::string      manifest_path;
   std::string      spooler_definition;
   std::string      union_fs_type;
+  std::string      public_keys;
+  std::string      trusted_certs;
   std::string      authz_file;
   bool             print_changeset;
   bool             dry_run;
@@ -224,6 +227,8 @@ class CommandSync : public Command {
     r.push_back(Parameter::Mandatory('t', "directory for tee"));
     r.push_back(Parameter::Mandatory('u', "union volume"));
     r.push_back(Parameter::Mandatory('w', "stratum 0 base url"));
+    r.push_back(Parameter::Mandatory('K', "public key(s) for repo"));
+    r.push_back(Parameter::Mandatory('N', "fully qualified repository name"));
 
     r.push_back(Parameter::Optional('a', "desired average chunk size (bytes)"));
     r.push_back(Parameter::Optional('e', "hash algorithm (default: SHA-1)"));
@@ -234,6 +239,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Optional('q', "number of concurrent write jobs"));
     r.push_back(Parameter::Optional('v', "manual revision number"));
     r.push_back(Parameter::Optional('z', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Optional('C', "trusted certificates"));
     r.push_back(Parameter::Optional('F', "Authz file listing (default: none)"));
     r.push_back(Parameter::Optional('M', "minimum weight of the autocatalogs"));
     r.push_back(Parameter::Optional('T', "Root catalog TTL in seconds"));

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -216,46 +216,46 @@ class CommandSync : public Command {
   }
   ParameterList GetParams() {
     ParameterList r;
-    r.push_back(Parameter::Mandatory('u', "union volume"));
-    r.push_back(Parameter::Mandatory('s', "scratch directory"));
-    r.push_back(Parameter::Mandatory('c', "r/o volume"));
-    r.push_back(Parameter::Mandatory('t', "directory for tee"));
     r.push_back(Parameter::Mandatory('b', "base hash"));
-    r.push_back(Parameter::Mandatory('w', "stratum 0 base url"));
+    r.push_back(Parameter::Mandatory('c', "r/o volume"));
     r.push_back(Parameter::Mandatory('o', "manifest output file"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
-    r.push_back(Parameter::Switch('A', "autocatalog enabled/disabled"));
+    r.push_back(Parameter::Mandatory('s', "scratch directory"));
+    r.push_back(Parameter::Mandatory('t', "directory for tee"));
+    r.push_back(Parameter::Mandatory('u', "union volume"));
+    r.push_back(Parameter::Mandatory('w', "stratum 0 base url"));
+
+    r.push_back(Parameter::Optional('a', "desired average chunk size (bytes)"));
+    r.push_back(Parameter::Optional('e', "hash algorithm (default: SHA-1)"));
+    r.push_back(Parameter::Optional('f', "union filesystem type"));
+    r.push_back(Parameter::Optional('h', "maximal file chunk size in bytes"));
+    r.push_back(Parameter::Optional('j', "catalog entry warning threshold"));
+    r.push_back(Parameter::Optional('l', "minimal file chunk size in bytes"));
+    r.push_back(Parameter::Optional('q', "number of concurrent write jobs"));
+    r.push_back(Parameter::Optional('v', "manual revision number"));
+    r.push_back(Parameter::Optional('z', "log level (0-4, default: 2)"));
+    r.push_back(Parameter::Optional('F', "Authz file listing (default: none)"));
+    r.push_back(Parameter::Optional('M', "minimum weight of the autocatalogs"));
+    r.push_back(Parameter::Optional('T', "Root catalog TTL in seconds"));
+    r.push_back(Parameter::Optional('X', "maximum weight of the autocatalogs"));
+    r.push_back(Parameter::Optional('Z', "compression algorithm "
+                                         "(default: zlib)"));
+
+    r.push_back(Parameter::Switch('d', "pause publishing to allow for catalog "
+                                       "tweaks"));
+    r.push_back(Parameter::Switch('g', "repo is garbage collectable"));
+    r.push_back(Parameter::Switch('i', "ignore x-directory hardlinks"));
+    r.push_back(Parameter::Switch('k', "include extended attributes"));
+    r.push_back(Parameter::Switch('m', "create micro catalogs"));
     r.push_back(Parameter::Switch('n', "create new repository"));
+    r.push_back(Parameter::Switch('p', "enable file chunking"));
     r.push_back(Parameter::Switch('x', "print change set"));
     r.push_back(Parameter::Switch('y', "dry run"));
+    r.push_back(Parameter::Switch('A', "autocatalog enabled/disabled"));
     r.push_back(Parameter::Switch('L', "enable HTTP redirects"));
-    r.push_back(Parameter::Switch('m', "create micro catalogs"));
-    r.push_back(Parameter::Switch('i', "ignore x-directory hardlinks"));
-    r.push_back(Parameter::Switch('d', "pause publishing to allow for "
-                                          "catalog tweaks"));
-    r.push_back(Parameter::Switch('g', "repo is garbage collectable"));
-    r.push_back(Parameter::Switch('p', "enable file chunking"));
-    r.push_back(Parameter::Switch('k', "include extended attributes"));
-    r.push_back(Parameter::Optional('z', "log level (0-4, default: 2)"));
-    r.push_back(Parameter::Optional('a',
-      "desired average chunk size in bytes"));
-    r.push_back(Parameter::Optional('l', "minimal file chunk size in bytes"));
-    r.push_back(Parameter::Optional('h', "maximal file chunk size in bytes"));
-    r.push_back(Parameter::Optional('f', "union filesystem type"));
-    r.push_back(Parameter::Optional('e', "hash algorithm (default: SHA-1)"));
-    r.push_back(Parameter::Optional('j', "catalog entry warning threshold"));
-    r.push_back(Parameter::Optional('v', "manual revision number"));
-    r.push_back(Parameter::Optional('q', "number of concurrent write jobs"));
-    r.push_back(Parameter::Switch('Y', "enable external data"));
-    r.push_back(Parameter::Optional('X', "maximum weight of the autocatalogs"));
-    r.push_back(Parameter::Optional('M', "minimum weight of the autocatalogs"));
-    r.push_back(Parameter::Optional(
-      'Z', "compression algorithm (default: zlib)"));
     r.push_back(Parameter::Switch('V', "Publish format compatible with "
                                        "authenticated repos"));
-    r.push_back(Parameter::Optional('F', "Authz file listing "
-                                         "(default: none)"));
-    r.push_back(Parameter::Optional('T', "Root catalog TTL in seconds"));
+    r.push_back(Parameter::Switch('Y', "enable external data"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -29,7 +29,6 @@ struct SyncParameters {
     use_file_chunking(false),
     ignore_xdir_hardlinks(false),
     stop_for_catalog_tweaks(false),
-    garbage_collectable(false),
     include_xattrs(false),
     external_data(false),
     voms_authz(false),
@@ -65,7 +64,6 @@ struct SyncParameters {
   bool             use_file_chunking;
   bool             ignore_xdir_hardlinks;
   bool             stop_for_catalog_tweaks;
-  bool             garbage_collectable;
   bool             include_xattrs;
   bool             external_data;
   bool             voms_authz;
@@ -249,7 +247,6 @@ class CommandSync : public Command {
 
     r.push_back(Parameter::Switch('d', "pause publishing to allow for catalog "
                                        "tweaks"));
-    r.push_back(Parameter::Switch('g', "repo is garbage collectable"));
     r.push_back(Parameter::Switch('i', "ignore x-directory hardlinks"));
     r.push_back(Parameter::Switch('k', "include extended attributes"));
     r.push_back(Parameter::Switch('m', "create micro catalogs"));

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -244,7 +244,7 @@ manifest::Manifest *SyncMediator::Commit() {
   LogCvmfs(kLogPublish, kLogStdout, "Committing file catalogs...");
   if (params_->spooler->GetNumberOfErrors() > 0) {
     LogCvmfs(kLogPublish, kLogStderr, "failed to commit files");
-    return NULL;
+    return false;
   }
 
   if (catalog_manager_->IsBalanceable()) {
@@ -252,7 +252,8 @@ manifest::Manifest *SyncMediator::Commit() {
   }
   catalog_manager_->PrecalculateListings();
   return catalog_manager_->Commit(params_->stop_for_catalog_tweaks,
-                                  params_->manual_revision);
+                                  params_->manual_revision,
+                                  manifest);
 }
 
 

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -106,7 +106,7 @@ class SyncMediator {
   void EnterDirectory(const SyncItem &entry);
   void LeaveDirectory(const SyncItem &entry);
 
-  manifest::Manifest *Commit();
+  bool Commit(manifest::Manifest *manifest);
 
   // The sync union engine uses this information to create properly initialized
   // sync items


### PR DESCRIPTION
**Note:** This builds on [Refactor: Manifest, Download- and SignatureManager handing in `cvmfs_swissknife`](https://github.com/cvmfs/cvmfs/pull/1380).

This changes the handling strategy of the `Manifest` (i.e. `.cvmfspublished) by using the previous `.cvmfspublished` as an update basis, instead of recreating it from scratch for every `cvmfs_swissknife sync`. The advantage being, that "passive" manifest fields are just carried over and don't need to be recreated every time. It makes the addition of those fields less error prone (see [here](https://github.com/cvmfs/cvmfs/pull/1372) for example).