### PR TITLE
Feature: Add CernVM-FS Version String to Repository Manifests

### DIFF
--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -39,6 +39,7 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   // Required keys
   shash::Any catalog_hash;
   shash::Md5 root_path;
+  std::string creator_version;
   uint32_t ttl;
   uint64_t revision;
 
@@ -56,6 +57,10 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   if ((iter = content.find('S')) == content.end())
     return NULL;
   revision = String2Uint64(iter->second);
+  if ((iter = content.find('V')) == content.end())
+    return NULL;
+  creator_version = iter->second;
+
 
   // Optional keys
   uint64_t catalog_size = 0;
@@ -94,7 +99,7 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   return new Manifest(catalog_hash, catalog_size, root_path, ttl, revision,
                       micro_catalog_hash, repository_name, certificate,
                       history, publish_timestamp, garbage_collectable,
-                      has_alt_catalog_path, meta_info);
+                      has_alt_catalog_path, meta_info, creator_version);
 }
 
 
@@ -123,7 +128,8 @@ string Manifest::ExportString() const {
     "D" + StringifyInt(ttl_) + "\n" +
     "S" + StringifyInt(revision_) + "\n" +
     "G" + StringifyBool(garbage_collectable_) + "\n" +
-    "A" + StringifyBool(has_alt_catalog_path_) + "\n";
+    "A" + StringifyBool(has_alt_catalog_path_) + "\n" +
+    "V" + creator_version_ + "\n";
 
   if (!micro_catalog_hash_.IsNull())
     manifest += "L" + micro_catalog_hash_.ToString() + "\n";

--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -39,7 +39,6 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   // Required keys
   shash::Any catalog_hash;
   shash::Md5 root_path;
-  std::string creator_version;
   uint32_t ttl;
   uint64_t revision;
 
@@ -57,9 +56,6 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   if ((iter = content.find('S')) == content.end())
     return NULL;
   revision = String2Uint64(iter->second);
-  if ((iter = content.find('V')) == content.end())
-    return NULL;
-  creator_version = iter->second;
 
 
   // Optional keys
@@ -72,6 +68,7 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   bool garbage_collectable = false;
   bool has_alt_catalog_path = false;
   shash::Any meta_info;
+  std::string creator_version;
 
   if ((iter = content.find('B')) != content.end())
     catalog_size = String2Uint64(iter->second);
@@ -95,6 +92,8 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   if ((iter = content.find('M')) != content.end())
     meta_info = MkFromHexPtr(shash::HexPtr(iter->second),
                              shash::kSuffixMetainfo);
+  if ((iter = content.find('V')) == content.end())
+    creator_version = iter->second;
 
   return new Manifest(catalog_hash, catalog_size, root_path, ttl, revision,
                       micro_catalog_hash, repository_name, certificate,

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -38,20 +38,20 @@ class Manifest {
            const uint64_t publish_timestamp,
            const bool garbage_collectable,
            const bool has_alt_catalog_path,
-           const shash::Any &meta_info) :
-    catalog_hash_(catalog_hash),
-    catalog_size_(catalog_size),
-    root_path_(root_path),
-    ttl_(ttl),
-    revision_(revision),
-    micro_catalog_hash_(micro_catalog_hash),
-    repository_name_(repository_name),
-    certificate_(certificate),
-    history_(history),
-    publish_timestamp_(publish_timestamp),
-    garbage_collectable_(garbage_collectable),
-    has_alt_catalog_path_(has_alt_catalog_path),
-    meta_info_(meta_info) { }
+           const shash::Any &meta_info)
+  : catalog_hash_(catalog_hash)
+  , catalog_size_(catalog_size)
+  , root_path_(root_path)
+  , ttl_(ttl)
+  , revision_(revision)
+  , micro_catalog_hash_(micro_catalog_hash)
+  , repository_name_(repository_name)
+  , certificate_(certificate)
+  , history_(history)
+  , publish_timestamp_(publish_timestamp)
+  , garbage_collectable_(garbage_collectable)
+  , has_alt_catalog_path_(has_alt_catalog_path)
+  , meta_info_(meta_info) { }
 
   std::string ExportString() const;
   bool Export(const std::string &path) const;

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -38,7 +38,8 @@ class Manifest {
            const uint64_t publish_timestamp,
            const bool garbage_collectable,
            const bool has_alt_catalog_path,
-           const shash::Any &meta_info)
+           const shash::Any &meta_info,
+           const std::string &cvmfs_version)
   : catalog_hash_(catalog_hash)
   , catalog_size_(catalog_size)
   , root_path_(root_path)
@@ -51,7 +52,8 @@ class Manifest {
   , publish_timestamp_(publish_timestamp)
   , garbage_collectable_(garbage_collectable)
   , has_alt_catalog_path_(has_alt_catalog_path)
-  , meta_info_(meta_info) { }
+  , meta_info_(meta_info)
+  , creator_version_(cvmfs_version) { }
 
   std::string ExportString() const;
   bool Export(const std::string &path) const;
@@ -95,6 +97,9 @@ class Manifest {
   void set_root_path(const std::string &root_path) {
     root_path_ = shash::Md5(shash::AsciiPtr(root_path));
   }
+  void set_creator_version(const std::string &cvmfs_version) {
+    creator_version_ = cvmfs_version;
+  }
 
   uint64_t revision() const { return revision_; }
   std::string repository_name() const { return repository_name_; }
@@ -107,6 +112,7 @@ class Manifest {
   bool garbage_collectable() const { return garbage_collectable_; }
   bool has_alt_catalog_path() const { return has_alt_catalog_path_; }
   shash::Any meta_info() const { return meta_info_; }
+  std::string creator_version() const { return creator_version_; }
 
   std::string MakeCatalogPath() const {
     return has_alt_catalog_path_ ? catalog_hash_.MakeAlternativePath() :
@@ -144,6 +150,8 @@ class Manifest {
    * of recommended stratum 1s, ...)
    */
   shash::Any meta_info_;
+
+  std::string creator_version_;
 };  // class Manifest
 
 }  // namespace manifest

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -172,6 +172,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
     manifest->set_certificate(certificate_hash);
     manifest->set_repository_name(repo_name);
     manifest->set_publish_timestamp(time(NULL));
+    manifest->set_creator_version(VERSION);
     if (!metainfo_hash.IsNull())
       manifest->set_meta_info(metainfo_hash);
 


### PR DESCRIPTION
This adds the CernVM-FS version string in the `.cvmfspublished` manifest for the rationale described in [CVM-817](https://sft.its.cern.ch/jira/browse/CVM-817). The field name will be `V` and is set during manifest signing.

**Note:** This contains [Refactor: Manifest, Download- and SignatureManager handing in `cvmfs_swissknife`](https://github.com/cvmfs/cvmfs/pull/1380/files) and [FIX: Handle Manifest Committing as Updates](https://github.com/cvmfs/cvmfs/pull/1381).