### PR TITLE
FIX: `cvmfs_server::die()` prints -e Prefix on Dash

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -11,7 +11,7 @@ set -e # ESSENTIAL! Don't remove this!
        # the scratch area, giving us a chance to fix and retry the process.
 
 die() {
-  echo -e $1 >&2
+  ( [ x"$(echo -n -e)" = x"-e" ] && echo $1 >&2 || echo -e $1 ) >&2
   exit 1
 }
 


### PR DESCRIPTION
This is an annoyance on Ubuntu since practically forever. O.o Finally got down to fix it... I can haz better solution?