### PR TITLE
FIX: Logging while Publishing

### DIFF
--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -650,14 +650,13 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     catalog_manager.SetVOMSAuthz(new_authz);
   }
 
-  LogCvmfs(kLogCvmfs, kLogStdout, "Exporting repository manifest");
   UniquePtr<manifest::Manifest> manifest(mediator.Commit());
-
   if (!manifest.IsValid()) {
     PrintError("something went wrong during sync");
     return 5;
   }
 
+  LogCvmfs(kLogCvmfs, kLogStdout, "Exporting repository manifest");
   const bool needs_bootstrap_shortcuts = params.voms_authz;
   manifest->set_garbage_collectability(params.garbage_collectable);
   manifest->set_has_alt_catalog_path(needs_bootstrap_shortcuts);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -187,7 +187,7 @@ void SyncMediator::LeaveDirectory(const SyncItem &entry)
  * To be called after change set traversal is finished.
  */
 manifest::Manifest *SyncMediator::Commit() {
-  if (!params_->print_changeset) {
+  if (!params_->print_changeset && changed_items_ >= processing_dot_interval) {
     // line break the 'progress bar', see SyncMediator::PrintChangesetNotice()
     LogCvmfs(kLogPublish, kLogStdout, "");
   }


### PR DESCRIPTION
This fixes a minor but (to my mind) annoying issue with the publishing output. I.e. placing the newline at the wrong location.

```text
Using auto tag 'generic-2016-01-08T15:40:25Z'
Processing changes...
........Exporting repository manifest

Waiting for upload of files before committing...
Committing file catalogs...
Tagging test.local
Flushing file system buffers
Signing new manifest
Remounting newly created repository revision
```