### PR TITLE
FIX: missing __STDC_FORMAT_MACROS and #include <inttypes.h>

### DIFF
--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -5,7 +5,9 @@
 #ifndef CVMFS_CATALOG_MGR_IMPL_H_
 #define CVMFS_CATALOG_MGR_IMPL_H_
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 #include "cvmfs_config.h"
 

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -18,11 +18,14 @@
 
 #define _FILE_OFFSET_BITS 64
 
+#define __STDC_FORMAT_MACROS
+
 #include "cvmfs_config.h"
 #include "swissknife_sync.h"
 
 #include <fcntl.h>
 #include <glob.h>
+#include <inttypes.h>
 
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
This failed the build on the old SLC 32bit platforms.