### PR TITLE
Cache SSL context info.

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -921,7 +921,7 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
 #ifdef VOMS_AUTHZ
     if (info->pid != -1) {
       ConfigureCurlHandle(curl_handle, info->pid, info->uid, info->gid,
-                          info->cred_fname);
+                          &info->cred_fname, &info->cred_data);
     }
 #endif
   }
@@ -1103,6 +1103,12 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     curl_easy_setopt(info->curl_handle, CURLOPT_SSLKEY, NULL);
     curl_easy_setopt(info->curl_handle, CURLOPT_FRESH_CONNECT, 0);
     curl_easy_setopt(info->curl_handle, CURLOPT_FORBID_REUSE, 0);
+  }
+  if (info->cred_data) {
+#ifdef VOMS_AUTHZ
+    ::ReleaseCurlHandle(info->cred_data);
+#endif
+    info->cred_data = NULL;
   }
 
   // Verification and error classification

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -123,7 +123,9 @@ struct JobInfo {
   pid_t pid;
   uid_t uid;
   gid_t gid;
-  char *cred_fname;  ///< TODO(jblomer): transfer credentials in memory
+  char *cred_fname;  // TODO(bbockelm): This is a fallback method -
+                     // can we eliminate?
+  void *cred_data;  // Per-transfer credential data
   Destination destination;
   struct {
     size_t size;
@@ -151,6 +153,7 @@ struct JobInfo {
     uid = -1;
     gid = -1;
     cred_fname = NULL;
+    cred_data = NULL;
     destination = kDestinationNone;
     destination_mem.size = destination_mem.pos = 0;
     destination_mem.data = NULL;

--- a/cvmfs/voms_authz/voms_authz.h
+++ b/cvmfs/voms_authz/voms_authz.h
@@ -16,9 +16,9 @@ struct fuse_ctx;
 
 bool CheckVOMSAuthz(const struct fuse_ctx *ctx, const std::string &);
 
-// TODO(jblomer): change type of fname
 bool ConfigureCurlHandle(void *curl_handle, pid_t pid, uid_t uid, gid_t gid,
-                         char *&fname);  // NOLINT
+                         char **fname, void **data);
+void ReleaseCurlHandle(void *data);
 
 FILE *GetProxyFile(pid_t pid, uid_t uid, gid_t gid);
 


### PR DESCRIPTION
Have the download job cache a pointer the proxy data used by the
SSL context.  Since the SSL context will need to be re-created
after a redirect, we cannot give the memory to the context object
itself - we must manage it explicitly.

Without this, the SSL context created for the redirection target
will drop the user proxy and end up unauthenticated.

Verified use of OpenSSL memory algorithms by running cvmfs2 under valgrind and looking for errors.

@jblomer @reneme @djw8605 @DrDaveD - without this, secure CVMFS breaks on redirection.  Ouch.