### PR TITLE
Fix CURL flags

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -527,7 +527,7 @@ void *DownloadManager::MainDownload(void *data) {
         if (download_mgr->watch_fds_[i].revents & (POLLIN | POLLPRI))
           ev_bitmask |= CURL_CSELECT_IN;
         if (download_mgr->watch_fds_[i].revents & (POLLOUT | POLLWRBAND))
-          ev_bitmask |= CURL_CSELECT_IN;
+          ev_bitmask |= CURL_CSELECT_OUT;
         if (download_mgr->watch_fds_[i].revents &
             (POLLERR | POLLHUP | POLLNVAL))
         {


### PR DESCRIPTION
When a file descriptor is ready for _writing_ (POLLOUT), it was incorrectly being marked as ready for _reading_ in `libcurl`.  This caused busy wait loops in the download thread, where `libcurl` would try to read from a specified descriptor and keep getting EAGAIN.

In testing, this gave a respectable 10% speedup in downloads.