### PR TITLE
FIX: Several Issues with Server Tests on Fedora 23

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2294,8 +2294,10 @@ unmount_and_teardown_repository() {
   local name=$1
   load_repo_config $name
   sed -i -e "/added by CernVM-FS for ${name}/d" /etc/fstab
-  is_mounted "/cvmfs/$name"              && umount /cvmfs/$name
-  is_mounted "${CVMFS_SPOOL_DIR}/rdonly" && umount ${CVMFS_SPOOL_DIR}/rdonly
+  local rw_mnt="/cvmfs/$name"
+  local rdonly_mnt="${CVMFS_SPOOL_DIR}/rdonly"
+  is_mounted "$rw_mnt"     && ( umount $rw_mnt     || return 1; )
+  is_mounted "$rdonly_mnt" && ( umount $rdonly_mnt || return 2; )
   return 0
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3351,6 +3351,7 @@ import() {
   check_autofs_on_cvmfs             && die "Autofs on /cvmfs has to be disabled"
   check_apache                      || die "Apache must be installed and running"
   is_local_upstream $upstream       || die "Import only works locally for the moment"
+  ensure_swissknife_suid $unionfs   || die "Need CAP_SYS_ADMIN for cvmfs_swissknife"
   lower_hardlink_restrictions
   ensure_enabled_apache_modules
   [ x"$keys_location" = "x" ] && die "Please provide the location of the repository security keys (-k)"

--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -92,7 +92,7 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   if ((iter = content.find('M')) != content.end())
     meta_info = MkFromHexPtr(shash::HexPtr(iter->second),
                              shash::kSuffixMetainfo);
-  if ((iter = content.find('V')) == content.end())
+  if ((iter = content.find('V')) != content.end())
     creator_version = iter->second;
 
   return new Manifest(catalog_hash, catalog_size, root_path, ttl, revision,

--- a/test/src/030-missingrootcatalog/main
+++ b/test/src/030-missingrootcatalog/main
@@ -16,6 +16,9 @@ cvmfs_run_test() {
   local retval=0
   local stratum1="http://cvmfs-stratum-one.cern.ch/opt"
 
+  echo -n "checking for wget... "
+  which wget > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }
+
   echo "restarting autofs"
   autofs_switch off || return 10
   autofs_switch on  || return 11

--- a/test/src/508-cvmfsdevelopment/main
+++ b/test/src/508-cvmfsdevelopment/main
@@ -199,6 +199,9 @@ cvmfs_run_test() {
   mkdir reference_dir
   local reference_dir=$scratch_dir/reference_dir
 
+  echo -n "checking for wget... "
+  which wget > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }
+
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -48,8 +48,9 @@ cvmfs_run_test() {
   echo "putting exactly the same stuff in the scratch space for comparison"
   produce_files_in $reference_dir || return 4
 
-  echo "creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO || return $?
+  local publish_log_1="publish_1.log"
+  echo "creating CVMFS snapshot (logging to $publish_log_1)"
+  publish_repo $CVMFS_TEST_REPO > $publish_log_1 2>&1 || return $?
 
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir || return $?

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -232,11 +232,12 @@ cvmfs_run_test() {
   local big_sha1="$(cat $big_file | sha1sum | head -c40)"
   [ x"181e8566ef9ef4063a00e56ec82cc99682ac795c" = x"$big_sha1" ] || return 22
 
-  echo "run a new transaction"
-  start_transaction "$legacy_repo_name"  || return 23
-  cp_bin /cvmfs/${legacy_repo_name}/dir7 || return 24
-  touch $big_file                        || return 25
-  publish_repo "$legacy_repo_name"       || return 26
+  local publish_log_1="publish_1.log"
+  echo "run a new transaction (logging to $publish_log_1)"
+  start_transaction "$legacy_repo_name"                  || return 23
+  cp_bin /cvmfs/${legacy_repo_name}/dir7                 || return 24
+  touch $big_file                                        || return 25
+  publish_repo "$legacy_repo_name" > $publish_log_1 2>&1 || return 26
 
   echo "check if big file is still the same content hash (now it should be chunked)"
   local big_sha1_2="$(cat $big_file | sha1sum | head -c40)"

--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -35,8 +35,11 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local scratch_dir=$(pwd)
 
-  echo "check for sqlite3 utility"
-  which sqlite3 || return 1
+  echo -n "checking for wget... "
+  which wget > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }
+
+  echo -n "checking for sqlite3 utility... "
+  which sqlite3 > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }
 
   echo "create test repository"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/test_functions
+++ b/test/test_functions
@@ -1075,15 +1075,11 @@ get_apache_version() {
 # figure out apache config file mode
 #
 # @return   apache config mode (stdout) (see globals below)
-APACHE_CONF_MODE_OLD=1 # *.conf goes to ${APACHE_CONF}/conf.d
-APACHE_CONF_MODE_NEW=2 # *.conf goes to ${APACHE_CONF}/conf-available
+APACHE_CONF_MODE_CONFD=1     # *.conf goes to ${APACHE_CONF}/conf.d
+APACHE_CONF_MODE_CONFAVAIL=2 # *.conf goes to ${APACHE_CONF}/conf-available
 get_apache_conf_mode() {
-  local minor_apache_version=$(version_minor "$(get_apache_version)")
-  if [ $minor_apache_version -ge 4 ] || [ -d /etc/${APACHE_CONF}/conf-available ]; then
-    echo $APACHE_CONF_MODE_NEW
-  else
-    echo $APACHE_CONF_MODE_OLD
-  fi
+  [ -d /etc/${APACHE_CONF}/conf-available ] && echo $APACHE_CONF_MODE_CONFAVAIL \
+                                            || echo $APACHE_CONF_MODE_CONFD
 }
 
 
@@ -1092,8 +1088,10 @@ get_apache_conf_mode() {
 # @return   the location of apache configuration files (stdout)
 get_apache_conf_path() {
   local res_path="/etc/${APACHE_CONF}"
-  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_NEW" ]; then
+  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_CONFAVAIL" ]; then
     echo "${res_path}/conf-available"
+  elif [ -d "${res_path}/modules.d" ]; then
+    echo "${res_path}/modules.d"
   else
     echo "${res_path}/conf.d"
   fi
@@ -1105,7 +1103,8 @@ get_apache_conf_path() {
 #
 # @return   a configuration snippet to allow s'th from all hosts (stdout)
 get_compatible_apache_allow_from_all_config() {
-  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_NEW" ]; then
+  local minor_apache_version=$(version_minor "$(get_apache_version)")
+  if [ $minor_apache_version -ge 4 ]; then
     echo "Require all granted"
   else
     local nl='
@@ -1131,7 +1130,7 @@ create_apache_config_file() {
   cat - | sudo tee ${conf_path}/${file_name} > /dev/null || return 1
 
   # the new apache requires the enable the config afterwards
-  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_NEW" ]; then
+  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_CONFAVAIL" ]; then
     sudo a2enconf $file_name > /dev/null || return 2
   fi
 
@@ -1150,7 +1149,7 @@ remove_apache_config_file() {
   conf_path="$(get_apache_conf_path)/${file_name}"
 
   # disable configuration on newer apache versions
-  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_NEW" ]; then
+  if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_CONFAVAIL" ]; then
     sudo a2disconf $file_name > /dev/null 2>&1 || return 1
   fi
 


### PR DESCRIPTION
This fixes some problems found while running the server integration tests on Fedora 23 (with OverlayFS). One of them was introduced with #1382, causing `manifest::Fetch()` to die with a SEGFAULT when reading pre 2.2.0 manifests. Ooops...