### PR TITLE
FIX: Manifest Updates Need to Propagate

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1715,18 +1715,25 @@ sign_manifest() {
   load_repo_config $name
   local user_shell="$(get_user_shell $name)"
 
-  local metainfo=
-  if [ "x$metainfo_file" != "x" ]; then
-    metainfo="-M $metainfo_file"
+  local sign_command="$(__swissknife_cmd) sign \
+    -c /etc/cvmfs/keys/${name}.crt       \
+    -k /etc/cvmfs/keys/${name}.key       \
+    -n $name                             \
+    -m $unsigned_manifest                \
+    -t ${CVMFS_SPOOL_DIR}/tmp            \
+    -r $CVMFS_UPSTREAM_STORAGE"
+
+  if [ x"$metainfo_file" != x"" ]; then
+    sign_command="$sign_command -M $metainfo_file"
+  fi
+  if [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]; then
+    sign_command="$sign_command -g"
+  fi
+  if [ x"${CVMFS_VOMS_AUTHZ}" != x"" ]; then
+    sign_command="$sign_command -V"
   fi
 
-  $user_shell "$(__swissknife_cmd) sign \
-    -c /etc/cvmfs/keys/${name}.crt      \
-    -k /etc/cvmfs/keys/${name}.key      \
-    -n $name                            \
-    -m $unsigned_manifest               \
-    -t ${CVMFS_SPOOL_DIR}/tmp           \
-    -r $CVMFS_UPSTREAM_STORAGE $metainfo" > /dev/null
+  $user_shell "$sign_command" > /dev/null
 }
 
 

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -48,6 +48,8 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   string meta_info = "";
   if (args.find('M') != args.end()) meta_info = *args.find('M')->second;
   upload::Spooler *spooler = NULL;
+  const bool garbage_collectable = (args.count('g') > 0);
+  const bool bootstrap_shortcuts = (args.count('V') > 0);
 
   if (!DirectoryExists(temp_dir)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "%s does not exist", temp_dir.c_str());
@@ -173,8 +175,11 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
     manifest->set_repository_name(repo_name);
     manifest->set_publish_timestamp(time(NULL));
     manifest->set_creator_version(VERSION);
-    if (!metainfo_hash.IsNull())
+    manifest->set_garbage_collectability(garbage_collectable);
+    manifest->set_has_alt_catalog_path(bootstrap_shortcuts);
+    if (!metainfo_hash.IsNull()) {
       manifest->set_meta_info(metainfo_hash);
+    }
 
     string signed_manifest = manifest->ExportString();
     shash::Any published_hash(manifest->GetHashAlgorithm());

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -33,9 +33,11 @@ class CommandSign : public Command {
     r.push_back(Parameter::Optional('k', "private key of the certificate"));
     r.push_back(Parameter::Optional('s', "password for the private key"));
     r.push_back(Parameter::Optional('n', "repository name"));
+    r.push_back(Parameter::Optional('M', "repository meta info file"));
     r.push_back(Parameter::Switch('b', "generate symlinks for VOMS-secured "
                                        "repo backends"));
-    r.push_back(Parameter::Optional('M', "repository meta info file"));
+    r.push_back(Parameter::Switch('g', "repository is garbage collectible"));
+    r.push_back(Parameter::Switch('V', "repository has bootstrap shortcuts"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -92,7 +92,7 @@ cvmfs_run_test() {
     peek_backend $legacy_repo_name $hash || return 10
   done
 
-  echo "run a first garbage collection to delete all revision execept the last 4"
+  echo "run a first garbage collection to delete all revision except the last 4"
   cvmfs_server gc -r 3 -f $legacy_repo_name || return 11
 
   echo "check if some 2.0 catalogs are gone (5 expected)"


### PR DESCRIPTION
Contrary to what I stated in #1381, we need to propagate the state of both `CVMFS_GARBAGE_COLLECTION` and `CVMFS_VOMS_AUTHZ` to `cvmfs_swissknife` so that it can update `.cvmfspublished` accordingly. Thus, I needed to revert the removal of the flags `cvmfs_swissknife sync -g -V` from #1381. However, now they are attached to `cvmfs_swissknife sign` so that any manifest signing operation can trigger the update of those flags, not only `cvmfs_server publish`.