### PR TITLE
FIX: Clean up all old tarballs

### DIFF
--- a/ci/build_cvmfs_sourcetarball.sh
+++ b/ci/build_cvmfs_sourcetarball.sh
@@ -33,12 +33,13 @@ else
   echo "Creating release tarball $tarball"
 fi
 
-echo "cleaning left-over tarballs..."
-[ ! -f ${CVMFS_RESULT_LOCATION}/${tarball}    ] || rm -f ${CVMFS_RESULT_LOCATION}/${tarball}
-[ ! -f ${CVMFS_RESULT_LOCATION}/source.tar.gz ] || rm -f ${CVMFS_RESULT_LOCATION}/source.tar.gz
+echo "create a source tarball build location..."
+CVMFS_TARBALL_RESULT_LOCATION="${CVMFS_RESULT_LOCATION}/cvmfs_source_tarball"
+[ ! -d ${CVMFS_TARBALL_RESULT_LOCATION} ] || rm -fR ${CVMFS_TARBALL_RESULT_LOCATION}
+mkdir -p $CVMFS_TARBALL_RESULT_LOCATION
 
 echo "creating source tar ball '$tarball'..."
 create_cvmfs_source_tarball ${CVMFS_SOURCE_LOCATION} \
-                            ${CVMFS_RESULT_LOCATION}/${tarball}
-cp ${CVMFS_RESULT_LOCATION}/${tarball} ${CVMFS_RESULT_LOCATION}/source.tar.gz
-
+                            ${CVMFS_TARBALL_RESULT_LOCATION}/${tarball}
+cp ${CVMFS_TARBALL_RESULT_LOCATION}/${tarball}
+   ${CVMFS_TARBALL_RESULT_LOCATION}/source.tar.gz


### PR DESCRIPTION
Jenkins (and ecsft.cern.ch/dist/cvmfs) were overflowing with outdated tarballs. This should clean them up properly after each build.