### PR TITLE
Feature: Non-Interactive `cvmfs_server update-repoinfo`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -351,7 +351,8 @@ Supported Commands:
                   Updates the geo-IP database
   update-info     [-p no apache config] [-e don't edit /info/meta]
                   Open meta info JSON file for editing
-  update-repoinfo <fully qualified name>
+  update-repoinfo [-f path to JSON file]
+                  <fully qualified name>
                   Open repository meta info JSON file for editing
 "
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5770,20 +5770,38 @@ eliminate_hardlinks() {
 ################################################################################
 
 _update_repoinfo_cleanup() {
+  local repo_name="$1"
+  shift 1
+
   while [ $# -gt 0 ]; do
     rm -f $1 > /dev/null 2>&1
     shift 1
   done
+
+  close_transaction $repo_name 0
 }
 
 update_repoinfo() {
   local name
-  local tmp_file
+  local json_file
+
+  OPTIND=1
+  while getopts "f:" option; do
+    case $option in
+      f)
+        json_file=$OPTARG
+      ;;
+      ?)
+        shift $(($OPTIND-2))
+        usage "Command update-repoinfo: Unrecognized option: $1"
+      ;;
+    esac
+  done
+  shift $(($OPTIND-1))
 
   # get repository name
-  shift $(($OPTIND-1))
   check_parameter_count_with_guessing $#
-  name=$(get_or_guess_repository_name $1)
+  name=$(get_or_guess_repository_name $@)
 
   # sanity checks
   check_repository_existence $name || die "The repository $name does not exist"
@@ -5792,14 +5810,14 @@ update_repoinfo() {
   is_stratum0 $name                || die "This is not a stratum 0 repository"
   ! is_publishing $name            || die "Repository is currently publishing"
   health_check $name $silence_warnings
+  is_in_transaction $name && die "Cannot edit repository meta info while in a transaction"
+  [ x"$json_file" = x"" ] || [ -f "$json_file" ] || die "Provided file '$json_file' doesn't exist"
 
   tmp_file_info=$(mktemp)
   tmp_file_manifest=$(mktemp)
-  chown $CVMFS_USER $tmp_file_info $tmp_file_manifest || \
-    die "Cannot change ownership of temporary files"
-  is_in_transaction $name && die "Cannot edit repository meta info while in a transaction"
-  trap "_update_repoinfo_cleanup $tmp_file_info $tmp_file_manifest; \
-    close_transaction $name 0" EXIT HUP INT TERM
+  chown $CVMFS_USER $tmp_file_info $tmp_file_manifest || die "Cannot change ownership of temporary files"
+
+  trap "_update_repoinfo_cleanup $name $tmp_file_info $tmp_file_manifest" EXIT HUP INT TERM
   open_transaction $name || die "Failed to open transaction for meta info editing"
 
   get_repo_info -M > $tmp_file_info || \
@@ -5807,11 +5825,21 @@ update_repoinfo() {
   get_repo_info -R > $tmp_file_manifest || \
     die "Failed getting repository manifest for $name"
 
-  if [ -f $tmp_file_info ] && [ ! -s $tmp_file_info ]; then
-    create_repometa_skeleton $tmp_file_info
+  if [ x"$json_file" = x"" ]; then
+    if [ -f $tmp_file_info ] && [ ! -s $tmp_file_info ]; then
+      create_repometa_skeleton $tmp_file_info
+    fi
+
+    edit_json_until_valid $tmp_file_info
+  else
+    local jq_output
+    if ! jq_output="$(validate_json $json_file)"; then
+      die "The provided JSON file is invalid. See below:\n${jq_output}"
+    fi
+
+    cat $json_file > $tmp_file_info
   fi
 
-  edit_json_until_valid $tmp_file_info
   sign_manifest $name $tmp_file_manifest $tmp_file_info
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2544,6 +2544,17 @@ check_jq() {
 }
 
 
+validate_json() {
+  local json_file="$1"
+
+  if ! which jq > /dev/null 2>&1; then
+    return 0 # no jq -> assume JSON is valid
+  fi
+
+  jq '.' $json_file 2>&1
+}
+
+
 edit_json_until_valid() {
   local json_file="$1"
   local editor=$(get_editor)
@@ -2556,7 +2567,7 @@ edit_json_until_valid() {
 
     local jq_output=""
     local retry=""
-    if ! jq_output=$(jq '.' $json_file 2>&1); then
+    if ! jq_output=$(validate_json $json_file); then
       echo
       echo "Your JSON file is invalid, please check again:"
       echo "$jq_output"

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -34,5 +34,19 @@ cvmfs_run_test() {
   cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded || return 50
   diff reference downloaded || return 51
 
+  local json_file="test_json_file.json"
+  cat >> $json_file << EOF
+{
+  "administrator" : "Rene Meusel",
+  "email"         : "dont.send.me.spam@cern.ch",
+  "organisation"  : "CERN",
+  "description"   : "This is just a test repository"
+}
+EOF
+
+  cvmfs_server update-repoinfo -f $json_file $CVMFS_TEST_REPO || return 60
+  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded1 || return 61
+  diff $json_file downloaded1 || return 62
+
   return 0
 }

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -27,9 +27,9 @@ cvmfs_run_test() {
   if [ $retval -ne 0 ]; then
     return 21
   fi
-  grep -a "^M" /srv/cvmfs/${CVMFS_TEST_REPO}/.cvmfspublished || return 20
+  curl -q "$(get_repo_url $CVMFS_TEST_REPO)/.cvmfspublished" | grep -a "^M" || return 20
 
-  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded || return 30
+  cvmfs_swissknife info -r $(get_repo_url $CVMFS_TEST_REPO) -M > downloaded || return 30
   diff reference downloaded || return 40
 
   echo "create a revision in the repository" # Regression test: used to lose the
@@ -37,7 +37,7 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return 41
   publish_repo      $CVMFS_TEST_REPO || return 42
 
-  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded || return 50
+  cvmfs_swissknife info -r $(get_repo_url $CVMFS_TEST_REPO) -M > downloaded || return 50
   diff reference downloaded || return 51
 
 
@@ -57,7 +57,7 @@ cvmfs_run_test() {
   sudo cvmfs_server snapshot $replica_name || return 56
 
   echo "check if the meta information was pulled along with the repository"
-  cvmfs_swissknife info -r http://localhost/cvmfs/${replica_name} -M > downloaded1 || return 57
+  cvmfs_swissknife info -r $(get_repo_url $replica_name) -M > downloaded1 || return 57
   diff reference downloaded1 || return 58
 
   local json_file="test_json_file.json"
@@ -72,18 +72,18 @@ EOF
 
   echo "update repo info on Stratum 0"
   cvmfs_server update-repoinfo -f $json_file $CVMFS_TEST_REPO || return 60
-  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded2 || return 61
+  cvmfs_swissknife info -r $(get_repo_url $CVMFS_TEST_REPO) -M > downloaded2 || return 61
   diff $json_file downloaded2 || return 62
 
   echo "check that the metainfo on Stratum1 lacks behind"
-  cvmfs_swissknife info -r http://localhost/cvmfs/${replica_name} -M > downloaded3 || return 65
+  cvmfs_swissknife info -r $(get_repo_url $replica_name) -M > downloaded3 || return 65
   diff $json_file downloaded3 && return 66
 
   echo "create a snapshot of the Stratum0"
   sudo cvmfs_server snapshot $replica_name || return 56
 
   echo "check that the metainfo on Stratum1 has updated"
-  cvmfs_swissknife info -r http://localhost/cvmfs/${replica_name} -M > downloaded4 || return 70
+  cvmfs_swissknife info -r $(get_repo_url $replica_name) -M > downloaded4 || return 70
   diff $json_file downloaded4 || return 71
 
   return 0

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -1,6 +1,12 @@
 cvmfs_test_name="Repository meta info JSON file"
 cvmfs_test_autofs_on_startup=false
 
+CVMFS_TEST_618_REPLICA_NAME=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_618_REPLICA_NAME ] || destroy_repo $CVMFS_TEST_618_REPLICA_NAME
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -34,6 +40,26 @@ cvmfs_run_test() {
   cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded || return 50
   diff reference downloaded || return 51
 
+
+  echo "set a trap for desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "create Stratum1 repository on the same machine"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+  CVMFS_TEST_618_REPLICA_NAME=$replica_name
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name    \
+                  $CVMFS_TEST_USER \
+                  $CVMFS_STRATUM0  \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 55
+
+  echo "create a snapshot of the Stratum0"
+  sudo cvmfs_server snapshot $replica_name || return 56
+
+  echo "check if the meta information was pulled along with the repository"
+  cvmfs_swissknife info -r http://localhost/cvmfs/${replica_name} -M > downloaded1 || return 57
+  diff reference downloaded1 || return 58
+
   local json_file="test_json_file.json"
   cat >> $json_file << EOF
 {
@@ -44,9 +70,21 @@ cvmfs_run_test() {
 }
 EOF
 
+  echo "update repo info on Stratum 0"
   cvmfs_server update-repoinfo -f $json_file $CVMFS_TEST_REPO || return 60
-  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded1 || return 61
-  diff $json_file downloaded1 || return 62
+  cvmfs_swissknife info -r http://localhost/cvmfs/${CVMFS_TEST_REPO} -M > downloaded2 || return 61
+  diff $json_file downloaded2 || return 62
+
+  echo "check that the metainfo on Stratum1 lacks behind"
+  cvmfs_swissknife info -r http://localhost/cvmfs/${replica_name} -M > downloaded3 || return 65
+  diff $json_file downloaded3 && return 66
+
+  echo "create a snapshot of the Stratum0"
+  sudo cvmfs_server snapshot $replica_name || return 56
+
+  echo "check that the metainfo on Stratum1 has updated"
+  cvmfs_swissknife info -r http://localhost/cvmfs/${replica_name} -M > downloaded4 || return 70
+  diff $json_file downloaded4 || return 71
 
   return 0
 }


### PR DESCRIPTION
This adds `cvmfs_server update-repoinfo -f` that allows for non-interactive updates of the repository's JSON meta data. Simply pass a JSON file path with the `-f`. If `cvmfs_server` finds `jq` in the system, it uses it to validate the passed in JSON file. Furthermore this updates integration test 618 to also use this code path.