### PR TITLE
Fix out-of-bounds SEGV

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -2032,7 +2032,7 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
 
   // Request ordered list via Geo-API
   bool success = false;
-  unsigned max_attempts = std::min(servers->size(), size_t(3));
+  unsigned max_attempts = std::min(host_chain_shuffled.size(), size_t(3));
   vector<uint64_t> geo_order(servers->size());
   for (unsigned i = 0; i < max_attempts; ++i) {
     string url = host_chain_shuffled[i] + "/api/v1.0/geo/@proxy@/" + host_list;


### PR DESCRIPTION
The refactored `GeoSortServers` function looked at the incorrect vector size (those being sorted instead of those being queried) when determining the number of attempts to perform, leading to a SEGV due to an out-of-bounds access.

Found when testing a `CVMFS_EXTERNAL_URL` with 5 entries but `CVMFS_SERVER_URL` of 1 entry.