### PR TITLE
Avoid potential SIGPIPE when downloading via HTTPS

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -923,6 +923,12 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
       ConfigureCurlHandle(curl_handle, info->pid, info->uid, info->gid,
                           &info->cred_fname, &info->cred_data);
     }
+    // The download manager disables signal handling in the curl library;
+    // as OpenSSL's implementation of TLS will generate a sigpipe in some
+    // error paths, we must explicitly disable SIGPIPE here.  Since SIGPIPE
+    // only appears to happen with HTTPS, we only do this on VOMS builds.
+    signal(SIGPIPE, SIG_IGN);
+
 #endif
   }
 


### PR DESCRIPTION
When downloading via HTTPS, there are a few error paths (particularly, when the remote side closes the socket unexpectedly) that can result in a SIGPIPE.

As we instruct curl to not touch our signal handlers, we should explicitly make sure we've disabled SIGPIPE in this thread.

Without this, a user on the host may be able to crash the FUSE process.