### PR TITLE
FIX: Test Infrastructure Scripts

### DIFF
--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -21,7 +21,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 
 echo "running CernVM-FS server test cases..."
-CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -31,6 +31,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
+                                 src/6*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -21,7 +21,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 
 echo "running CernVM-FS server test cases..."
-CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -31,6 +31,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
+                                 src/6*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -95,6 +95,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
+                                 src/6*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -78,6 +78,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
+                                 src/6*                                       \
                               || retval=1
 
 
@@ -118,7 +119,9 @@ if [ $s3_retval -eq 0 ]; then
                                src/594-backendoverwrite                     \
                                src/595-geoipdbupdate                        \
                                --                                           \
-                               src/5* || retval=1
+                               src/5*                                       \
+                               src/6*                                       \
+                               || retval=1
 
   echo -n "killing FakeS3... "
   sudo kill -2 $fakes3_pid && echo "done" || echo "fail"

--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -48,6 +48,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \
+                                 src/6*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -36,6 +36,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \
+                                 src/6*                                       \
                               || retval=1
 
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -112,8 +112,10 @@ setup_environment() {
   local workdir=$2
 
   # make sure the environment is clean
-  if ! cvmfs_clean; then
-    echo "failed to clean environment"
+  local clean_retval=0
+  cvmfs_clean || clean_retval=$?
+  if [ $clean_retval -ne 0 ]; then
+    echo "failed to clean environment (retval: $clean_retval)"
     return 101
   fi
 
@@ -214,8 +216,10 @@ do
   fi
 
   # configure the environment for the test
-  if ! setup_environment $cvmfs_test_autofs_on_startup $workdir >> $logfile 2>&1; then
-    report_failure "failed to setup environment" >> $logfile
+  setup_retval=0
+  setup_environment $cvmfs_test_autofs_on_startup $workdir >> $logfile 2>&1 || setup_retval=$?
+  if [ $setup_retval -ne 0 ]; then
+    report_failure "failed to setup environment (retval: $setup_retval)" >> $logfile
     echo "Failed! (setup)"
     echo "0"         > ${scratchdir}/elapsed
     echo "102"       > ${scratchdir}/retval

--- a/test/run.sh
+++ b/test/run.sh
@@ -217,7 +217,10 @@ do
   if ! setup_environment $cvmfs_test_autofs_on_startup $workdir >> $logfile 2>&1; then
     report_failure "failed to setup environment" >> $logfile
     echo "Failed! (setup)"
-    echo "102" > ${scratchdir}/retval
+    echo "0"         > ${scratchdir}/elapsed
+    echo "102"       > ${scratchdir}/retval
+    wc -l < $logfile > ${scratchdir}/log_end
+    touch              ${scratchdir}/failure
     continue
   fi
 

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -15,7 +15,7 @@ cvmfs_run_test() {
   sudo sh -c "echo 'echo reference' >> $tty_bin" || return 12
   sudo chmod +x $tty_bin || return 13
   touch reference
-  EDITOR="cat" cvmfs_server update-repoinfo $CVMFS_TEST_REPO
+  yes | EDITOR="cat" cvmfs_server update-repoinfo $CVMFS_TEST_REPO
   local retval=$?
   sudo mv ${tty_bin}.disabled $tty_bin || return 14
   if [ $retval -ne 0 ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -263,16 +263,16 @@ break_hardlink() {
 
 
 cvmfs_clean() {
-  sudo cvmfs_config umount > /dev/null || return 100
-  sudo sh -c "rm -rf /var/lib/cvmfs/*"
-  sudo rm -f /etc/cvmfs/default.local
-  sudo sh -c "rm -f /etc/cvmfs/config.d/*"
-  sudo sh -c "cat /dev/null > $CVMFS_TEST_SYSLOG_TARGET"
+  sudo cvmfs_config umount > /dev/null                   || return 100
+  sudo sh -c "rm -rf /var/lib/cvmfs/*"                   || return 101
+  sudo rm -f /etc/cvmfs/default.local                    || return 102
+  sudo sh -c "rm -f /etc/cvmfs/config.d/*"               || return 103
+  sudo sh -c "cat /dev/null > $CVMFS_TEST_SYSLOG_TARGET" || return 104
 
   local timeout=60
   while $(pgrep -u cvmfs cvmfs2 > /dev/null); do
     if [ $timeout -eq 0 ]; then
-      return 101
+      return 99
     fi
     timeout=$(($timeout-1))
     sleep 1


### PR DESCRIPTION
Repair some issues after the first full iteration of cloud tests.
Most notable:

* enable server integration tests >= 600
* fix server cache directory on fedora