### PR TITLE
Avoid busy-wait when downloading files

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -477,7 +477,12 @@ void *DownloadManager::MainDownload(void *data) {
   while (true) {
     int timeout;
     if (still_running) {
-      timeout = 1;
+      // Specify a timeout for polling in ms; this allows us to return
+      // to libcurl once a second so it can look for internal operations
+      // which timed out.  libcurl has a more elaborate mechanism
+      // (CURLMOPT_TIMERFUNCTION) that would inform us of the next potential
+      // timeout.  TODO(bbockelm) we should switch to that in the future.
+      timeout = 1 * 1000;
     } else {
       timeout = -1;
       gettimeofday(&timeval_stop, NULL);

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -482,7 +482,7 @@ void *DownloadManager::MainDownload(void *data) {
       // which timed out.  libcurl has a more elaborate mechanism
       // (CURLMOPT_TIMERFUNCTION) that would inform us of the next potential
       // timeout.  TODO(bbockelm) we should switch to that in the future.
-      timeout = 1 * 1000;
+      timeout = 100;
     } else {
       timeout = -1;
       gettimeofday(&timeval_stop, NULL);


### PR DESCRIPTION
CVMFS currently wakes up once a millisecond to check if libcurl has any ongoing transfers which have timed out.  As the granularity of our timeouts is in seconds, this is overkill: we can back off and save system CPU time.

libcurl actually provides a callback interface where it will inform CVMFS when the next upcoming library timeout will occur.  However, due to the proximity of the release, I simply increase the granularity.