### PR TITLE
Require valgrind-devel in RPM build

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -55,6 +55,7 @@ BuildRequires: patch
 BuildRequires: pkgconfig
 BuildRequires: python-devel
 BuildRequires: unzip
+BuildRequires: valgrind-devel
 
 Requires: bash
 Requires: coreutils


### PR DESCRIPTION
This allows the resulting RPM-based binaries to be run underneath valgrind.

Note this might break the build on some platforms: I don't have the full range of RPM distros to test on locally.  Any breakage should be relatively easy to fix.