### PR TITLE
FIX: Missing CVMFS_MOUNT_DIR Parameter

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2154,6 +2154,7 @@ EOF
 CVMFS_CACHE_BASE=$cache_dir
 CVMFS_RELOAD_SOCKETS=$cache_dir
 CVMFS_QUOTA_LIMIT=4000
+CVMFS_MOUNT_DIR=/cvmfs
 CVMFS_SERVER_URL=$stratum0
 CVMFS_HTTP_PROXY=DIRECT
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${name}.pub
@@ -5523,6 +5524,7 @@ migrate_2_1_20() {
   [ -z "$CVMFS_HIDE_MAGIC_XATTRS" ] && echo "CVMFS_HIDE_MAGIC_XATTRS=yes" >> $client_conf
   [ -z "$CVMFS_FOLLOW_REDIRECTS"  ] && echo "CVMFS_FOLLOW_REDIRECTS=yes"  >> $client_conf
   [ -z "$CVMFS_SERVER_CACHE_MODE" ] && echo "CVMFS_SERVER_CACHE_MODE=yes" >> $client_conf
+  [ 0z "$CVMFS_MOUNT_DIR"         ] && echo "CVMFS_MOUNT_DIR=/cvmfs"      >> $client_conf
 
   echo "--> updating /etc/fstab"
   local tmp_fstab=$(mktemp)

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -920,7 +920,8 @@ is_mounted() {
   local mountpoint="$1"
   local regexp="$2"
 
-  local absolute_mnt="$(readlink --canonicalize $mountpoint)"
+  local absolute_mnt=
+  absolute_mnt="$(readlink --canonicalize $mountpoint)" || die "cannot access $mountpoint"
   local mnt_record="$(cat /proc/mounts 2>/dev/null | grep " $absolute_mnt ")"
   if [ x"$mnt_record" = x"" ]; then
     return 1
@@ -5524,7 +5525,7 @@ migrate_2_1_20() {
   [ -z "$CVMFS_HIDE_MAGIC_XATTRS" ] && echo "CVMFS_HIDE_MAGIC_XATTRS=yes" >> $client_conf
   [ -z "$CVMFS_FOLLOW_REDIRECTS"  ] && echo "CVMFS_FOLLOW_REDIRECTS=yes"  >> $client_conf
   [ -z "$CVMFS_SERVER_CACHE_MODE" ] && echo "CVMFS_SERVER_CACHE_MODE=yes" >> $client_conf
-  [ 0z "$CVMFS_MOUNT_DIR"         ] && echo "CVMFS_MOUNT_DIR=/cvmfs"      >> $client_conf
+  [ -z "$CVMFS_MOUNT_DIR"         ] && echo "CVMFS_MOUNT_DIR=/cvmfs"      >> $client_conf
 
   echo "--> updating /etc/fstab"
   local tmp_fstab=$(mktemp)


### PR DESCRIPTION
The `cvmfs_server` script needs to set up `CVMFS_MOUNT_DIR=/cvmfs` for new repositories. Furthermore it has been added to the migration step from 2.1.20 to 2.2.0.