### PR TITLE
FIX: Integration Test 610

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1732,7 +1732,7 @@ sign_manifest() {
     sign_command="$sign_command -g"
   fi
   if [ x"$CVMFS_CATALOG_ALT_PATHS" = x"true" ]; then
-    sign_command="$sign_command -V"
+    sign_command="$sign_command -A"
   fi
 
   $user_shell "$sign_command" > /dev/null

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -921,7 +921,7 @@ is_mounted() {
   local regexp="$2"
 
   local absolute_mnt=
-  absolute_mnt="$(readlink --canonicalize $mountpoint)" || die "cannot access $mountpoint"
+  absolute_mnt="$(readlink --canonicalize $mountpoint)" || die "failed to access $mountpoint"
   local mnt_record="$(cat /proc/mounts 2>/dev/null | grep " $absolute_mnt ")"
   if [ x"$mnt_record" = x"" ]; then
     return 1

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1718,12 +1718,12 @@ sign_manifest() {
   local user_shell="$(get_user_shell $name)"
 
   local sign_command="$(__swissknife_cmd) sign \
-    -c /etc/cvmfs/keys/${name}.crt       \
-    -k /etc/cvmfs/keys/${name}.key       \
-    -n $name                             \
-    -m $unsigned_manifest                \
-    -t ${CVMFS_SPOOL_DIR}/tmp            \
-    -r $CVMFS_UPSTREAM_STORAGE"
+          -c /etc/cvmfs/keys/${name}.crt       \
+          -k /etc/cvmfs/keys/${name}.key       \
+          -n $name                             \
+          -m $unsigned_manifest                \
+          -t ${CVMFS_SPOOL_DIR}/tmp            \
+          -r $CVMFS_UPSTREAM_STORAGE"
 
   if [ x"$metainfo_file" != x"" ]; then
     sign_command="$sign_command -M $metainfo_file"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1731,7 +1731,7 @@ sign_manifest() {
   if [ x"$CVMFS_GARBAGE_COLLECTION" = x"true" ]; then
     sign_command="$sign_command -g"
   fi
-  if [ x"${CVMFS_VOMS_AUTHZ}" != x"" ]; then
+  if [ x"$CVMFS_CATALOG_ALT_PATHS" = x"true" ]; then
     sign_command="$sign_command -V"
   fi
 
@@ -2138,6 +2138,7 @@ EOF
 
   if [ x"$voms_authz" != x"" ]; then
     echo "CVMFS_VOMS_AUTHZ=$voms_authz" >> $server_conf
+    echo "CVMFS_CATALOG_ALT_PATHS=true" >> $server_conf
   fi
 
   # append GC specific configuration

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2098,6 +2098,7 @@ create_config_files_for_new_repository() {
   local configure_apache=$9
   local compression_alg=${10}
   local external_data=${11}
+  local voms_authz=${12}
 
   # other configurations
   local spool_dir="/var/spool/cvmfs/${name}"
@@ -2134,6 +2135,10 @@ CVMFS_GARBAGE_COLLECTION=$garbage_collectable
 CVMFS_AUTO_REPAIR_MOUNTPOINT=true
 CVMFS_AUTOCATALOGS=false
 EOF
+
+  if [ x"$voms_authz" != x"" ]; then
+    echo "CVMFS_VOMS_AUTHZ=$voms_authz" >> $server_conf
+  fi
 
   # append GC specific configuration
   if [ x"$garbage_collectable" = x"true" ]; then
@@ -2976,7 +2981,8 @@ mkfs() {
                                          "$garbage_collectable" \
                                          "$configure_apache"    \
                                          "$compression_alg"     \
-                                         "$external_data" || die "fail"
+                                         "$external_data"       \
+                                         "$voms_authz" || die "fail"
   if is_local_upstream $upstream && [ $configure_apache -eq 1 ]; then
     reload_apache > /dev/null
   fi
@@ -3035,7 +3041,6 @@ mkfs() {
   if [ "x$voms_authz" != "x" ]; then
     echo -n "(repository will be accessible with VOMS credentials $voms_authz)... "
     create_cmd="$create_cmd -V $voms_authz"
-    echo "CVMFS_VOMS_AUTHZ=$voms_authz" >> /etc/cvmfs/repositories.d/$name/server.conf
   fi
   $user_shell "$create_cmd" > /dev/null                       || die "fail! (cannot init repo)"
   sign_manifest $name ${temp_dir}/new_manifest $repoinfo_file || die "fail! (cannot sign repo)"
@@ -3438,17 +3443,18 @@ import() {
   # create the configuration for the new repository
   # TODO(jblomer): make a better guess for hash and compression algorithm
   echo -n "Creating configuration files... "
-  create_config_files_for_new_repository "$name"       \
-                                         "$upstream"   \
-                                         "$stratum0"   \
-                                         "$cvmfs_user" \
-                                         "$unionfs"    \
-                                         "sha1"        \
-                                         "true"        \
-                                         "false"       \
+  create_config_files_for_new_repository "$name"             \
+                                         "$upstream"         \
+                                         "$stratum0"         \
+                                         "$cvmfs_user"       \
+                                         "$unionfs"          \
+                                         "sha1"              \
+                                         "true"              \
+                                         "false"             \
                                          "$configure_apache" \
-                                         "default"     \
-                                         "false" || die "fail!"
+                                         "default"           \
+                                         "false"             \
+                                         "" || die "fail!"
   echo "done"
 
   # import the old repository security keys

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -49,7 +49,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   if (args.find('M') != args.end()) meta_info = *args.find('M')->second;
   upload::Spooler *spooler = NULL;
   const bool garbage_collectable = (args.count('g') > 0);
-  const bool bootstrap_shortcuts = (args.count('V') > 0);
+  const bool bootstrap_shortcuts = (args.count('A') > 0);
 
   if (!DirectoryExists(temp_dir)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "%s does not exist", temp_dir.c_str());

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -37,7 +37,7 @@ class CommandSign : public Command {
     r.push_back(Parameter::Switch('b', "generate symlinks for VOMS-secured "
                                        "repo backends"));
     r.push_back(Parameter::Switch('g', "repository is garbage collectible"));
-    r.push_back(Parameter::Switch('V', "repository has bootstrap shortcuts"));
+    r.push_back(Parameter::Switch('A', "repository has bootstrap shortcuts"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -20,7 +20,11 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER "NO" "-V xyz" || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "configure repository to provide bootstrapping shortcuts"
+  local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
+  echo "CVMFS_CATALOG_ALT_PATHS=true" | sudo tee --append $server_conf || return 1
 
   echo "Open transaction to put some files into repository"
   start_transaction $CVMFS_TEST_REPO || return $?

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -22,17 +22,27 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER "NO" "-V xyz" || return $?
 
+  echo "Open transaction to put some files into repository"
   start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "put some files into repository"
   produce_files_in $repo_dir || return 3
+
+  echo "publish repository"
   publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "check repository consistency"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
   local backend_dir="/srv/cvmfs/$CVMFS_TEST_REPO"
 
-  local f
+  echo "unmount both union fs and cvmfs"
   cvmfs_suid_helper rw_umount $CVMFS_TEST_REPO || return 10
   cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 11
   sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
+
+  echo "replace .cvmfsalt symlinks by the actual backend files"
+  local f
   for l in $(find $backend_dir -maxdepth 1 -type l); do
     f="$backend_dir/$(readlink $l)"
     sudo rm -f $l
@@ -40,21 +50,21 @@ cvmfs_run_test() {
   done
   sudo sh -c "echo CVMFS_ALT_ROOT_PATH=yes >> /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
 
-  # Mount with fixed root hash
+  echo "Mount with fixed root hash"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return 12
 
-  # Force failed mount
+  echo "Force failed mount"
   cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 30
   sudo sh -c "echo CVMFS_ALT_ROOT_PATH=no >> /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
   sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO && return 31
 
-  # Mount latest
+  echo "Mount latest"
   sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
   sudo rm -f "/var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return 14
 
-  # Detect missing alternative paths
+  echo "Detect missing alternative paths"
   destroy_repo $CVMFS_TEST_REPO || return $?
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER "NO" "-V xyz" || return $?
   sudo find $backend_dir -maxdepth 1 -type l -exec rm -f {} \;

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -18,6 +18,8 @@ produce_files_in() {
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+  local backend_dir="/srv/cvmfs/$CVMFS_TEST_REPO"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -38,7 +40,20 @@ cvmfs_run_test() {
   echo "check repository consistency"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
-  local backend_dir="/srv/cvmfs/$CVMFS_TEST_REPO"
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "hide .cvmfsalt- symlinks"
+  local stash="${scratch_dir}/cvmfsalt-stash"
+  mkdir -p $stash || return 50
+  sudo find $backend_dir -maxdepth 1 -type l -exec mv -f {} $stash \; || return 51
+
+  echo "check that missing .cvmfsalt- symlinks are detected"
+  check_repository $CVMFS_TEST_REPO -i && return 20
+
+  echo "put .cvmfsalt- symlinks back in place"
+  sudo find $stash -maxdepth 1 -type l -exec mv -f {} $backend_dir \; || return 52
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   echo "unmount both union fs and cvmfs"
   cvmfs_suid_helper rw_umount $CVMFS_TEST_REPO || return 10
@@ -67,12 +82,6 @@ cvmfs_run_test() {
   sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
   sudo rm -f "/var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return 14
-
-  echo "Detect missing alternative paths"
-  destroy_repo $CVMFS_TEST_REPO || return $?
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER "NO" "-V xyz" || return $?
-  sudo find $backend_dir -maxdepth 1 -type l -exec rm -f {} \;
-  check_repository $CVMFS_TEST_REPO -i && return 20
 
   return 0
 }


### PR DESCRIPTION
This fixes integration test 610 (Alternative catalog path) by separating the creation of `.cvmfsalt-` bootstrapping shortcut symlinks from the `CVMFS_VOMS_AUTHZ` server parameter.

Furthermore it does a small refactoring in `cvmfs_server mkfs` moving the creation of  `CVMFS_VOMS_AUTHZ` to `create_config_files_for_new_repository`. Rationale is, that *all* configuration parameters for new repositories are done there centrally.