### PR TITLE
FIX: Test 584 + Refactor 065

### DIFF
--- a/test/src/065-http-400/main
+++ b/test/src/065-http-400/main
@@ -7,6 +7,14 @@ cleanup() {
   [ -z $CVMFS_TEST_065_FAULTY_PID ] || sudo kill $CVMFS_TEST_065_FAULTY_PID
 }
 
+faulty_server_running() {
+  local pid=$1
+  local port=$2
+
+  kill -0 $pid                                                   || return 1
+  curl -I "http://localhost:${port}" 2>&1 | grep -e '^HTTP.*400' || return 1
+}
+
 cvmfs_run_test() {
   logfile=$1
   src_location=$2
@@ -22,8 +30,14 @@ cvmfs_run_test() {
   CVMFS_TEST_065_FAULTY_PID=$(run_background_service $faulty_server_log "$faulty_server -p $faulty_port")
   if [ $? -ne 0 ]; then return 9; fi
 
-  echo "check that $faulty_port actually returns HTTP 400"
-  curl -I "http://localhost:${faulty_port}" 2>&1 | grep -e '^HTTP.*400' || return 2
+  echo "wait that $faulty_port actually returns HTTP 400"
+  sleep 1
+  local timeout=10
+  while ! faulty_server_running $CVMFS_TEST_065_FAULTY_PID $faulty_port && \
+        [ $timeout -gt 0 ]; do
+    timeout=$(( $timeout - 1 ))
+  done
+  [ $timeout -gt 0 ] || return 50
 
   sudo tee /etc/cvmfs/config.d/grid.cern.ch.conf << EOF
 CVMFS_SERVER_URL="http://localhost:${faulty_port}/cvmfs/grid.cern.ch;http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch"

--- a/test/test_functions
+++ b/test/test_functions
@@ -792,7 +792,6 @@ run_background_service() {
   rm -f $fifo
 
   # check if the background process is running
-  sleep 1
   if ! sudo kill -0 $srv_pid > /dev/null 2>&1; then
     return 4
   fi


### PR DESCRIPTION
This fixes a problem with integration test 584 which uses `run_background_service` to start a `cvmfs_server snapshot`. Unfortunately the `sleep 1` [introduced recently](https://github.com/cvmfs/cvmfs/pull/1397) is stepping in the way here. Therefore this implements a proper waiting loop in integration test 065 and removes the `sleep 1` again.