### PR TITLE
FIX: query for osx in integration tests

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -127,7 +127,7 @@ setup_environment() {
   fi
 
   # if we are not inside a docker
-  if [ x"$CVMFS_TEST_DOCKER" = xno ] && ! [ running_on_osx ]; then
+  if [ x"$CVMFS_TEST_DOCKER" = xno ] && ! running_on_osx; then
     # configure autofs to the test's needs
     service_switch autofs restart || true
     local timeout=10 # wait until autofs restarts (possible race >.<)

--- a/test/test_functions
+++ b/test/test_functions
@@ -84,7 +84,7 @@ if ! pidof systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
     SERVICE_BIN="/usr/sbin/service" # Ubuntu
   elif [ -x /sbin/rc-service ]; then
     SERVICE_BIN="/sbin/rc-service" # OpenRC
-  elif [ running_on_osx ]; then
+  elif running_on_osx; then
     SERVICE_BIN="false" # we don't need to run any service on mac
   else
     die "Neither systemd nor service binary detected"


### PR DESCRIPTION
This bug prevented the autofs restart between test cases, so test cases could screw up with their successors.