### PR TITLE
FIX: Several Issues from the latest Cloud Test Run

### DIFF
--- a/cvmfs/cvmfs_preload
+++ b/cvmfs/cvmfs_preload
@@ -3,7 +3,7 @@ export TMPDIR=`mktemp -d /tmp/cvmfs_preload_selfextracted.XXXXXX`
 
 ARCHIVE=`awk '/^__ARCHIVE_BELOW__/ {print NR + 1; exit 0; }' $0`
 
-tail -n+"$ARCHIVE" "$0" | base64 -d | tar xz -C "$TMPDIR" || echo "Couldn't extract the tar file"
+tail -n+"$ARCHIVE" "$0" | base64 -d -i | tar xz -C "$TMPDIR" || echo "Couldn't extract the tar file"
 
 # execute the command
 LD_LIBRARY_PATH="$TMPDIR" $TMPDIR/cvmfs_preload_bin $@

--- a/cvmfs/cvmfs_preload
+++ b/cvmfs/cvmfs_preload
@@ -3,7 +3,12 @@ export TMPDIR=`mktemp -d /tmp/cvmfs_preload_selfextracted.XXXXXX`
 
 ARCHIVE=`awk '/^__ARCHIVE_BELOW__/ {print NR + 1; exit 0; }' $0`
 
-tail -n+"$ARCHIVE" "$0" | base64 -d -i | tar xz -C "$TMPDIR" || echo "Couldn't extract the tar file"
+if ! tail -n+"$ARCHIVE" "$0" | base64 -d -i | tar xz -C "$TMPDIR"; then
+  echo "Couldn't extract the tar file" >&2
+  rm -f "${TMPDIR}"/*
+  rmdir "$TMPDIR"
+  exit 1
+fi
 
 # execute the command
 LD_LIBRARY_PATH="$TMPDIR" $TMPDIR/cvmfs_preload_bin $@

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2447,6 +2447,7 @@ _write_info_file() {
   cat - > $tmp_file
   chmod 0644 $tmp_file
   mv -f $tmp_file $info_file_path
+  set_selinux_httpd_context_if_needed $info_file_dir
 }
 
 
@@ -2521,6 +2522,8 @@ create_global_info_skeleton() {
 
   mkdir -p $info_path                               || return 1
   mkdir -p $info_v1_path                            || return 2
+  set_selinux_httpd_context_if_needed $info_path    || return 3
+  set_selinux_httpd_context_if_needed $info_v1_path || return 4
 
   _check_info_file "repositories" || echo "{}" | _write_info_file "repositories"
   _check_info_file "meta" || _write_info_file "meta" << EOF

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2266,6 +2266,7 @@ remove_repository_storage() {
 
 setup_and_mount_new_repository() {
   local name=$1
+  local http_timeout=15
 
   # get repository information
   load_repo_config $name
@@ -2301,6 +2302,18 @@ EOF
   fi
   local user_shell="$(get_user_shell $name)"
   $user_shell "touch ${CVMFS_SPOOL_DIR}/client.local"
+
+  # avoid racing against apache
+  local waiting=0
+  while ! curl -sIf ${CVMFS_STRATUM0}/.cvmfspublished > /dev/null && \
+        [ $http_timeout -gt 0 ]; do
+    [ $waiting -eq 1 ] || echo -n "waiting for apache... "
+    waiting=1
+    http_timeout=$(( $http_timeout - 1 ))
+    sleep 1
+  done
+  [ $http_timeout -gt 0 ] || return 1
+
   mount $rdonly_dir > /dev/null || return 1
   mount /cvmfs/$name
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -714,6 +714,14 @@ get_apache_conf_mode() {
 }
 
 
+set_selinux_httpd_context_if_needed() {
+  local directory="$1"
+  if has_selinux; then
+    chcon -Rv --type=httpd_sys_content_t ${directory}/ > /dev/null
+  fi
+}
+
+
 # find location of apache configuration files
 #
 # @return   the location of apache configuration files (stdout)
@@ -1916,9 +1924,7 @@ create_repository_skeleton() {
   if [ x$(id -un) != x$user ]; then
     chown -R $user ${directory}/
   fi
-  if has_selinux; then
-    chcon -Rv --type=httpd_sys_content_t ${directory}/ > /dev/null
-  fi
+  set_selinux_httpd_context_if_needed $directory
   echo "done"
 }
 
@@ -3493,9 +3499,7 @@ import() {
   if [ $chown_backend -ne 0 ]; then
     echo -n "Importing CernVM-FS storage... "
     chown -R $cvmfs_user $storage_location || die "fail!"
-    if has_selinux; then
-      chcon -Rv --type=httpd_sys_content_t $storage_location > /dev/null || die "fail!"
-    fi
+    set_selinux_httpd_context_if_needed $storage_location || die "fail!"
     echo "done"
   fi
 
@@ -5364,9 +5368,7 @@ migrate_2_1_6() {
     local tmp_dir=${storage_path}/data/txn
     mkdir $tmp_dir > /dev/null 2>&1 || echo "Warning: not able to create $tmp_dir"
     chown -R $CVMFS_USER $tmp_dir > /dev/null 2>&1 || echo "Warning: not able to chown $tmp_dir to $CVMFS_USER"
-    if has_selinux; then
-      chcon -Rv --type=httpd_sys_content_t $tmp_dir > /dev/null 2>&1 || echo "Warning: not able to chcon $tmp_dir to httpd_sys_content_t"
-    fi
+    set_selinux_httpd_context_if_needed $tmp_dir || echo "Warning: not able to chcon $tmp_dir to httpd_sys_content_t"
 
     echo "--> updating server.conf"
     mv /etc/cvmfs/repositories.d/${name}/server.conf /etc/cvmfs/repositories.d/${name}/server.conf.old

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2429,14 +2429,19 @@ has_file_descriptors_on_mount_point() {
 
 
 get_global_info_path() {
-  # TODO(rmeusel): make this a bit more flexible
-  echo "${DEFAULT_LOCAL_STORAGE}/info/v${LATEST_JSON_INFO_SCHEMA}"
+  echo "${DEFAULT_LOCAL_STORAGE}/info"
+}
+
+
+get_global_info_v1_path() {
+  echo "$(get_global_info_path)/v${LATEST_JSON_INFO_SCHEMA}"
 }
 
 
 _write_info_file() {
   local info_file="$1"
-  local info_file_path="$(get_global_info_path)/${info_file}"
+  local info_file_dir="$(get_global_info_v1_path)"
+  local info_file_path="${info_file_dir}/${info_file}"
   local tmp_file=$(mktemp)
 
   cat - > $tmp_file
@@ -2447,7 +2452,7 @@ _write_info_file() {
 
 _check_info_file() {
   local info_file="$1"
-  [ -f "$(get_global_info_path)/${info_file}" ]
+  [ -f "$(get_global_info_v1_path)/${info_file}" ]
 }
 
 
@@ -2506,13 +2511,16 @@ _render_info_file() {
 
 
 has_global_info_path() {
-  [ -d $(get_global_info_path) ]
+  [ -d $(get_global_info_path) ] && [ -d $(get_global_info_v1_path) ]
 }
 
 
 create_global_info_skeleton() {
   local info_path="$(get_global_info_path)"
-  mkdir -p $info_path
+  local info_v1_path="$(get_global_info_v1_path)"
+
+  mkdir -p $info_path                               || return 1
+  mkdir -p $info_v1_path                            || return 2
 
   _check_info_file "repositories" || echo "{}" | _write_info_file "repositories"
   _check_info_file "meta" || _write_info_file "meta" << EOF
@@ -3028,7 +3036,7 @@ mkfs() {
   # create storage area
   if is_local_upstream $upstream; then
     echo -n "Creating Backend Storage... "
-    create_global_info_skeleton
+    create_global_info_skeleton     || die "fail"
     create_repository_storage $name || die "fail"
     echo "done"
   fi
@@ -5931,7 +5939,7 @@ update_info() {
     # copy the meta information file for editing
     tmp_file=$(mktemp)
     trap "_update_info_cleanup $tmp_file" EXIT HUP INT TERM
-    cp -f "$(get_global_info_path)/meta" $tmp_file
+    cp -f "$(get_global_info_v1_path)/meta" $tmp_file
 
     edit_json_until_valid $tmp_file || die "Aborting..."
   fi

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -261,7 +261,7 @@ bool ObtainSysAdminCapabilityInternal(cap_t caps) {
   }
 
   if (cap_state == CAP_SET) {
-    LogCvmfs(kLogUnionFs, kLogStderr, "CAP_SYS_ADMIN is already effective");
+    LogCvmfs(kLogUnionFs, kLogDebug, "CAP_SYS_ADMIN is already effective");
     return true;
   }
 

--- a/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
@@ -44,6 +44,8 @@ install_from_repo python
 install_from_repo nc
 install_from_repo wget
 install_from_repo bc
+
+# install build dependencies for `libcvmfs`
 install_from_repo openssl-devel
 install_from_repo libuuid-devel
 

--- a/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
@@ -47,6 +47,11 @@ install_from_repo bc
 install_from_repo openssl-devel
 install_from_repo libuuid-devel
 
+# install stuff necessary to build `cvmfs_preload`
+install_from_repo cmake
+install_from_repo patch
+install_from_repo libattr-devel
+
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "
 set_nofile_limit 65536 || die "fail"

--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -65,7 +65,13 @@ install_from_repo gcc            || die "fail (installing gcc)"
 install_from_repo gcc-c++        || die "fail (installing gcc-c++)"
 install_from_repo python-sqlite2 || die "fail (installing python-sqlite2)"
 install_from_repo java           || die "fail (installing java)"
+
+# install `libcvmfs` build dependencies
 install_from_repo openssl-devel  || die "fail (installing openssl-devel)"
+
+# install `cvmfs_preload` build dependencies
+install_from_repo cmake
+install_from_repo libattr-devel
 
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "

--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -70,8 +70,8 @@ install_from_repo java           || die "fail (installing java)"
 install_from_repo openssl-devel  || die "fail (installing openssl-devel)"
 
 # install `cvmfs_preload` build dependencies
-install_from_repo cmake
-install_from_repo libattr-devel
+install_from_repo cmake          || die "fail (installing cmake)"
+install_from_repo libattr-devel  || die "fail (installing libattr-devel)"
 
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -86,7 +86,6 @@ install_from_repo libuuid-devel || die "fail (installing libuuid-devel)"
 install_from_repo cmake         || die "fail (installing cmake)"
 install_from_repo libattr-devel || die "fail (installing libattr-devel)"
 
-
 # install ruby gem for FakeS3
 install_ruby_gem fakes3 0.2.0  # latest is 0.2.1 (23.07.2015) that didn't work.
 

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -77,7 +77,15 @@ install_from_repo gcc           || die "fail (installing gcc)"
 install_from_repo gcc-c++       || die "fail (installing gcc-c++)"
 install_from_repo rubygems      || die "fail (installing rubygems)"
 install_from_repo java          || die "fail (installing java)"
+
+# install `libcvmfs` build dependencies
 install_from_repo openssl-devel || die "fail (installing openssl-devel)"
+install_from_repo libuuid-devel || die "fail (installing libuuid-devel)"
+
+# install `cvmfs_preload` build dependencies
+install_from_repo cmake         || die "fail (installing cmake)"
+install_from_repo libattr-devel || die "fail (installing libattr-devel)"
+
 
 # install ruby gem for FakeS3
 install_ruby_gem fakes3 0.2.0  # latest is 0.2.1 (23.07.2015) that didn't work.

--- a/test/src/596-catalogbalancer/main
+++ b/test/src/596-catalogbalancer/main
@@ -19,10 +19,10 @@ add_catalog() {
 
 cvmfs_run_test() {
   apache_switch on
-  local repo="test.local"
+  local repo="$CVMFS_TEST_REPO"
   local repo_dir="/cvmfs/$repo"
 
-  create_repo "$repo" $(whoami)
+  create_repo "$repo" $CVMFS_TEST_USER
 
   sudo bash -c "echo 'CVMFS_AUTOCATALOGS=true
   CVMFS_AUTOCATALOGS_MAX_WEIGHT=20

--- a/test/src/596-catalogbalancer/main
+++ b/test/src/596-catalogbalancer/main
@@ -53,7 +53,7 @@ cvmfs_run_test() {
   start_transaction "$repo"
   add_files "$repo_dir/dir/dir30" 30
   for i in $(ls "$repo_dir" | grep "file"); do
-    rm "$repo_dir/$i"
+    rm -f "$repo_dir/$i"
   done
   publish_repo "$repo"
 
@@ -100,7 +100,7 @@ cvmfs_run_test() {
 
   start_transaction "$repo"
   for i in $(ls $repo_dir/dir60 | grep "file"); do
-    rm "$repo_dir/dir60/$i"
+    rm -f "$repo_dir/dir60/$i"
   done
   add_files "$repo_dir/dir60" 1
   publish_repo "$repo"
@@ -197,7 +197,7 @@ cvmfs_run_test() {
 
   start_transaction "$repo"
   for i in $(ls $repo_dir/dir/dir30/dir/dir11 | grep "file"); do
-    rm "$repo_dir/dir/dir30/dir/dir11/$i"
+    rm -f "$repo_dir/dir/dir30/dir/dir11/$i"
   done
   add_files "$repo_dir/dir/dir30/dir/dir11" 5  # this should provoke an underflow
   touch "$repo_dir/dir/dir30/dir/dir7/file8"  # with this extra file $repo_dir/dir/dir30/dir/dir7 could be a catalog
@@ -236,6 +236,5 @@ cvmfs_run_test() {
     [ -f "$repo_dir/dir/dir30/dir/dir7/.cvmfsautocatalog" ]      || return 134
   if ! check_catalog_presence "/dir/dir30/dir/dir7" "$repo"; then return 135; fi
 
-
-  destroy_repo "$repo"
+  return 0
 }

--- a/test/src/596-catalogbalancer/main
+++ b/test/src/596-catalogbalancer/main
@@ -22,19 +22,19 @@ cvmfs_run_test() {
   local repo="$CVMFS_TEST_REPO"
   local repo_dir="/cvmfs/$repo"
 
-  create_repo "$repo" $CVMFS_TEST_USER
+  create_repo "$repo" $CVMFS_TEST_USER || return 1
 
   sudo bash -c "echo 'CVMFS_AUTOCATALOGS=true
   CVMFS_AUTOCATALOGS_MAX_WEIGHT=20
   CVMFS_AUTOCATALOGS_MIN_WEIGHT=9' >> /etc/cvmfs/repositories.d/$repo/server.conf"
 
-  start_transaction "$repo"
+  start_transaction "$repo" || return 2
   add_files "$repo_dir" 25
   add_files "$repo_dir/dir100" 100
   add_files "$repo_dir/dir3" 3
   add_files "$repo_dir/dir4" 4
   add_catalog "$repo_dir/dir4"
-  publish_repo "$repo"
+  publish_repo "$repo" || return 3
 
   echo "Checking first iteration"
   ! [ -f "$repo_dir/dir3/.cvmfscatalog" ]                     || return 1

--- a/test/src/598-partialpreload/main
+++ b/test/src/598-partialpreload/main
@@ -24,28 +24,6 @@ produce_files_in() {
   popdir
 }
 
-build_preload() {
-  local source_dir="$1"
-  local build_dir="$2"
-
-  mkdir -p $build_dir || return 1
-  pushdir $build_dir  || return 2
-
-  cmake -DBUILD_PRELOADER=yes      \
-        -DBUILD_SERVER=no          \
-        -DBUILD_SERVER_DEBUG=no    \
-        -DBUILD_CVMFS=no           \
-        -DBUILD_UNITTESTS=no       \
-        -DBUILD_UNITTESTS_DEBUG=no \
-        -DBUILD_LIBCVMFS=no        \
-        -DINSTALL_MOUNT_SCRIPTS=no \
-        -DBUILD_DOCUMENTATION=no   \
-        $source_dir || return 3
-  make -j || return 4
-
-  popdir
-}
-
 CVMFS_TEST_598_MNT=""
 cleanup() {
   echo "running cleanup()"
@@ -63,27 +41,12 @@ cvmfs_run_test() {
   local preload_dir="$working_dir/preloadcache"
   local tmpdir="$preload_dir/tmpdir"
 
-  local PRELOAD=
-
   echo -n "checking if cvmfs_preload is available... "
-  if ! which cvmfs_preload >/dev/null 2>&1; then
-    echo "not found"
-
-    local source_tree="$(dirname $(dirname $(dirname $script_location)))"
-    local build_dir="${working_dir}/preload_build"
-    local build_log="preload_build.log"
-    echo -n "building from source ($source_tree) (logging to $build_log)... "
-    build_preload $source_tree $build_dir > $build_log 2>&1 && echo "done" || { echo "fail"; return 1; }
-
-    echo -n "extracting cvmfs_preload from build directory... "
-    [ $(find $build_dir -type f -name cvmfs_preload | wc -l) -eq 1 ] || { echo "fail"; return 2; }
-
-    PRELOAD="$(find $build_dir -type f -name cvmfs_preload)"
-    echo "found ($PRELOAD)"
-  else
-    PRELOAD=$(which cvmfs_preload)
-    echo "found ($PRELOAD)"
-  fi
+  local source_tree="$(dirname $(dirname $(dirname $script_location)))"
+  local PRELOAD=
+  PRELOAD=$(find_or_build_cvmfs_preload $source_tree)
+  [ -x "$PRELOAD" ] || { echo "fail"; return 1; }
+  echo "found ($PRELOAD)"
 
   echo "prepare environment"
   mkdir -p "$tmpdir"      || return 2

--- a/test/src/620-pullmixedrepo/main
+++ b/test/src/620-pullmixedrepo/main
@@ -80,6 +80,7 @@ check_stratum1_tmp_dir_emptiness() {
 
 cvmfs_run_test() {
   logfile=$1
+  local script_location=$2
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   local scratch_dir=$(pwd)
@@ -88,6 +89,13 @@ cvmfs_run_test() {
 
   local mnt_point="$(pwd)/mountpount"
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  echo -n "checking if cvmfs_preload is available... "
+  local source_tree="$(dirname $(dirname $(dirname $script_location)))"
+  local PRELOAD=
+  PRELOAD=$(find_or_build_cvmfs_preload $source_tree)
+  [ -x "$PRELOAD" ] || { echo "fail"; return 1; }
+  echo "found ($PRELOAD)"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -175,7 +183,7 @@ cvmfs_run_test() {
 
   echo "preloading a cache"
   local preload_dir=/srv/cvmfs/${CVMFS_TEST_REPO}/preloaded
-  cvmfs_preload -u "http://localhost/cvmfs/$CVMFS_TEST_REPO" \
+  $PRELOAD -u "http://localhost/cvmfs/$CVMFS_TEST_REPO" \
     -r $preload_dir \
     -k "/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub" \
     -m "$CVMFS_TEST_REPO" || return $?

--- a/test/src/620-pullmixedrepo/main
+++ b/test/src/620-pullmixedrepo/main
@@ -61,12 +61,12 @@ EOF
   cvmfs_swissknife zpipe -d < /srv/cvmfs/${repo}/external_file > ${reference_dir}/external_file
 }
 
-desaster_cleanup() {
-  local mountpoint=$1
-  local replica_name=$2
-
-  sudo umount $mountpoint > /dev/null 2>&1
-  sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
+CVMFS_TEST_620_MOUNTPOINT=
+CVMFS_TEST_620_REPLICA=
+cleanup() {
+  echo "running cleanup()..."
+  [ -z $CVMFS_TEST_620_MOUNTPOINT ] || sudo umount $CVMFS_TEST_620_MOUNTPOINT            > /dev/null 2>&1
+  [ -z $CVMFS_TEST_620_REPLICA    ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_620_REPLICA > /dev/null 2>&1
 }
 
 check_stratum1_tmp_dir_emptiness() {
@@ -146,13 +146,17 @@ cvmfs_run_test() {
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
   echo "create Stratum1 repository on the same machine"
+  CVMFS_TEST_620_REPLICA=$replica_name
   load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \
                   /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
-    || { desaster_cleanup $mnt_point $replica_name; return 7; }
+    || return 7
 
   echo -n "get Stratum 1 spool directory: "
   load_repo_config $replica_name
@@ -161,22 +165,24 @@ cvmfs_run_test() {
   echo "$s1_spool_tmp_dir"
 
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
-  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+  sudo cvmfs_server snapshot $replica_name || return 9
 
   echo "copy external file"
   cp /srv/cvmfs/${CVMFS_TEST_REPO}/external_file /srv/cvmfs/$replica_name/
 
   echo "check that Stratum1 spooler tmp dir is empty"
-  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || { desaster_cleanup $mnt_point $replica_name; return 101; }
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || return 101
 
   echo "mount the Stratum1 repository on a local mountpoint"
-  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || { desaster_cleanup $mnt_point $replica_name; return 10; }
+  CVMFS_TEST_620_MOUNTPOINT=$mnt_point
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || return 10
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
-  compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $replica_name; return 11; }
+  compare_directories $mnt_point $reference_dir || return 11
 
   echo "unmount the Stratum1 repository"
-  sudo umount $mnt_point || { desaster_cleanup $mnt_point $replica_name; return 12; }
+  sudo umount $mnt_point || return 12
+  CVMFS_TEST_620_MOUNTPOINT=""
 
   echo "clean up"
   sudo cvmfs_server rmfs -f $replica_name
@@ -201,14 +207,13 @@ CVMFS_HTTP_PROXY=NOAVAIL
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub
 EOF
 
-  echo "Mount the repository in $REPO_MOUNTPOINT to verify it"
-  REPO_MOUNTPOINT="$(pwd)/mnt"
+  echo "Mount the repository in $mnt_point to verify it"
   local retval=0
+  CVMFS_TEST_620_MOUNTPOINT=$mnt_point
   do_local_mount $mnt_point $CVMFS_TEST_REPO XXX $local_conf || retval=41
 
   ls $mnt_point || retval=42
   diff $mnt_point/large $reference_dir/large || retval=43
-  desaster_cleanup $mnt_point $replica_name
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -121,6 +121,10 @@ normalize_version() {
   echo "$version_string"
 }
 
+to_syslog() {
+  logger -t cvmfs_test $1
+}
+
 version_major() { echo $1 | cut --delimiter=. --fields=1; }
 version_minor() { echo $1 | cut --delimiter=. --fields=2; }
 version_patch() { echo $1 | cut --delimiter=. --fields=3; }

--- a/test/test_functions
+++ b/test/test_functions
@@ -2025,3 +2025,56 @@ cat_syslog() {
 
   return $cat_retval
 }
+
+
+# look for the `cvmfs_preload` binary both installed in $PATH and
+# pre-built in /tmp. If both lookups fail, try to build it from
+# the provided source tree
+#
+# @param cvmfs_source_dir  absolute path to a CernVM-FS source tree
+# @return                  location of `cvmfs_preload` or retval 1
+find_or_build_cvmfs_preload() {
+  local cvmfs_source_dir="$1"
+  local cvmfs_preload_build_dir="/tmp/cvmfs_test_preload_build"
+  local cvmfs_preload_build_log="${cvmfs_preload_build_dir}/build.log"
+  local cvmfs_preload_path=
+
+  # check if cvmfs_preload is readily available (i.e. installed in $PATH)
+  if which cvmfs_preload > /dev/null 2>&1; then
+    which cvmfs_preload
+    return 0
+  fi
+
+  # check if cvmfs_preload has been built before
+  if [ -x ${cvmfs_preload_build_dir}/cvmfs/cvmfs_preload ]; then
+    echo "${cvmfs_preload_build_dir}/cvmfs/cvmfs_preload"
+    return 0
+  fi
+
+  # build cvmfs_preload from source $cvmfs_source_dir
+  rm -fR   $cvmfs_preload_build_dir > /dev/null 2>&1 || return 1
+  mkdir -p $cvmfs_preload_build_dir > /dev/null 2>&1 || return 2
+  pushdir  $cvmfs_preload_build_dir > /dev/null 2>&1 || return 3
+
+  cmake -DBUILD_PRELOADER=yes      \
+        -DBUILD_SERVER=no          \
+        -DBUILD_SERVER_DEBUG=no    \
+        -DBUILD_CVMFS=no           \
+        -DBUILD_UNITTESTS=no       \
+        -DBUILD_UNITTESTS_DEBUG=no \
+        -DBUILD_LIBCVMFS=no        \
+        -DINSTALL_MOUNT_SCRIPTS=no \
+        -DBUILD_DOCUMENTATION=no   \
+        $cvmfs_source_dir > $cvmfs_preload_build_log 2>&1 || return 4
+  make -j                 > $cvmfs_preload_build_log 2>&1 || return 5
+
+  popdir > /dev/null 2>&1
+
+  # check (again) if cvmfs_preload has been built properly and return
+  if [ -x ${cvmfs_preload_build_dir}/cvmfs/cvmfs_preload ]; then
+    echo "${cvmfs_preload_build_dir}/cvmfs/cvmfs_preload"
+    return 0
+  fi
+
+  return 1
+}

--- a/vagrant/provision_fedora.sh
+++ b/vagrant/provision_fedora.sh
@@ -20,7 +20,7 @@ dnf -y install libuuid-devel gcc gcc-c++ glibc-common cmake fuse fuse-devel  \
                shadow-utils util-linux-ng selinux-policy checkpolicy         \
                selinux-policy-devel hardlink selinux-policy-targeted         \
                python-devel initscripts bash coreutils grep sed sudo psmisc  \
-               curl attr httpd libcap-devel mod_wsgi rpm-build
+               curl attr httpd libcap-devel mod_wsgi rpm-build java wget
 
 # install convenience packages for development
 dnf -y install git tig iftop htop jq rubygems rubygem-bundler ruby-devel \


### PR DESCRIPTION
This fixes several things found during tonights cloud testing run:

* `/cvmfs/info/...` API wasn't compliant to SELinux
* improved opportunistic building of `cvmfs_preload` in tests **598** and **620** (dependencies and code-reuse)
* `cvmfs_preload` didn't properly extract on EL5
* race condition in `cvmfs_server mkfs` leading to 5-10% failed server tests using OverlayFS
* other mainly cosmetic changes