### PR TITLE
FIX: Rename Meta Info Files

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2439,7 +2439,7 @@ get_global_info_v1_path() {
 
 
 _write_info_file() {
-  local info_file="$1"
+  local info_file="${1}.json"
   local info_file_dir="$(get_global_info_v1_path)"
   local info_file_path="${info_file_dir}/${info_file}"
   local tmp_file=$(mktemp)
@@ -2452,7 +2452,7 @@ _write_info_file() {
 
 
 _check_info_file() {
-  local info_file="$1"
+  local info_file="${1}.json"
   [ -f "$(get_global_info_v1_path)/${info_file}" ]
 }
 
@@ -5942,7 +5942,7 @@ update_info() {
     # copy the meta information file for editing
     tmp_file=$(mktemp)
     trap "_update_info_cleanup $tmp_file" EXIT HUP INT TERM
-    cp -f "$(get_global_info_v1_path)/meta" $tmp_file
+    cp -f "$(get_global_info_v1_path)/meta.json" $tmp_file
 
     edit_json_until_valid $tmp_file || die "Aborting..."
   fi

--- a/test/src/608-infofile/main
+++ b/test/src/608-infofile/main
@@ -34,7 +34,7 @@ cvmfs_run_test() {
   local scratch_dir=$(pwd)
 
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
-  local info_url="$(get_local_repo_url info)/v1/repositories"
+  local info_url="$(get_local_repo_url info)/v1/repositories.json"
 
   echo "check if the jq utility is installed"
   which jq > /dev/null 2>&1 || return 1

--- a/test/src/609-metainfofile/main
+++ b/test/src/609-metainfofile/main
@@ -16,8 +16,8 @@ cvmfs_run_test() {
   local scratch_dir=$(pwd)
 
   local info_dir=/srv/cvmfs/info
-  local info_file=/srv/cvmfs/info/v1/meta
-  local info_url="$(get_local_repo_url info)/v1/meta"
+  local info_file=/srv/cvmfs/info/v1/meta.json
+  local info_url="$(get_local_repo_url info)/v1/meta.json"
 
   echo "check if the jq utility is installed"
   which jq > /dev/null 2>&1 || return 1


### PR DESCRIPTION
This changes the meta-info API endpoints to:
* `/cvmfs/info/v1/repositories.json`
* `/cvmfs/info/v1/meta.json`

Essentially only adding a .json suffix.