### PR TITLE
FIX: Repository Migration Code

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2076,7 +2076,6 @@ Alias /cvmfs/${name} ${storage_dir}
 
     ExpiresActive On
     ExpiresDefault "access plus 3 days"
-    ExpiresByType text/html "access plus 5 minutes"
     ExpiresByType application/x-cvmfs "access plus 2 minutes"
     ExpiresByType application/json    "access plus 2 minutes"
 </Directory>

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5589,12 +5589,12 @@ migrate_2_1_20() {
   fi
 
   local apache_conf="$(get_apache_conf_path)/$(get_apache_conf_filename $name)"
-  local old_line='AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist'
-  if [ -f "$apache_conf" ] && \
-     grep -q "$old_line" "$apache_conf"; then
+  if [ -f "$apache_conf" ]; then
     echo "--> updating apache config ($(basename $apache_conf))"
-    sed -i -e "s/$old_line/<FilesMatch \"^\\\\.cvmfs\">\n        ForceType application\/x-cvmfs\n    <\/FilesMatch>/" \
-      $apache_conf
+    local storage_dir=$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)
+    local wsgi=""
+    [ is_stratum1 $name ] && wsgi="enabled"
+    create_apache_config_for_endpoint $name $storage_dir $wsgi
     reload_apache > /dev/null
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2062,7 +2062,9 @@ Alias /cvmfs/${name} ${storage_dir}
     EnableMMAP Off
     EnableSendFile Off
 
-    AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist
+    <FilesMatch "^\.cvmfs">
+        ForceType application/x-cvmfs
+    </FilesMatch>
 
     Header unset Last-Modified
     FileETag None

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -477,6 +477,7 @@ least CernVM-FS $creator to manipulate this repository."
   #     -> new (mandatory) parameters in client.conf (Stratum 0)
   #     -> adjustments in /etc/fstab
   #     -> CVMFS_AUTO_REPAIR_MOUNTPOINT=true becomes the enforced default
+  #     -> Apache configuration updated
   #
   # Note: I tried to make this code as verbose as possible
   #
@@ -513,8 +514,7 @@ least CernVM-FS $creator to manipulate this repository."
      [ "$creator" = "2.1.19"  ] || [ "$creator" = "2.1.20"  ] || \
      [ "$creator" = "2.2.0-0" ];
   then
-    if version_greater_or_equal "2.2.0" && \
-       is_stratum0 $name; then
+    if version_greater_or_equal "2.2.0"; then
       _repo_is_incompatible "$creator" $nokill
       return $?
     fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2078,6 +2078,7 @@ Alias /cvmfs/${name} ${storage_dir}
     ExpiresDefault "access plus 3 days"
     ExpiresByType text/html "access plus 5 minutes"
     ExpiresByType application/x-cvmfs "access plus 2 minutes"
+    ExpiresByType application/json    "access plus 2 minutes"
 </Directory>
 EOF
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5588,6 +5588,16 @@ migrate_2_1_20() {
     sed -i -e "s/^\(CVMFS_AUTO_REPAIR_MOUNTPOINT\)=.*/\1=true/" $server_conf
   fi
 
+  local apache_conf="$(get_apache_conf_path)/$(get_apache_conf_filename $name)"
+  local old_line='AddType application/x-cvmfs .cvmfspublished .cvmfswhitelist'
+  if [ -f "$apache_conf" ] && \
+     grep -q "$old_line" "$apache_conf"; then
+    echo "--> updating apache config ($(basename $apache_conf))"
+    sed -i -e "s/$old_line/<FilesMatch \"^\\\\.cvmfs\">\n        ForceType application\/x-cvmfs\n    <\/FilesMatch>/" \
+      $apache_conf
+    reload_apache > /dev/null
+  fi
+
   sed -i -e "s/^\(CVMFS_CREATOR_VERSION\)=.*/\1=$destination_version/" $server_conf
 
   # update repository information

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -703,6 +703,11 @@ get_apache_version() {
   ${APACHE_BIN} -v | head -n1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+'
 }
 
+get_apache_conf_filename() {
+  local name=$1
+  echo "cvmfs.${name}.conf"
+}
+
 # figure out apache config file mode
 #
 # @return   apache config mode (stdout) (see globals below)
@@ -2047,7 +2052,7 @@ create_apache_config_for_endpoint() {
   local storage_dir=$2
   local with_wsgi="$3"
 
-  create_apache_config_file "cvmfs.${name}.conf" << EOF
+  create_apache_config_file "$(get_apache_conf_filename $name)" << EOF
 # Created by cvmfs_server.  Don't touch.
 $(cat_wsgi_config $name $with_wsgi)
 
@@ -2078,8 +2083,7 @@ EOF
 }
 
 has_apache_config_for_global_info() {
-  local conf_file="cvmfs.info.conf"
-  has_apache_config_file $conf_file
+  has_apache_config_file $(get_apache_conf_filename "info")
 }
 
 create_apache_config_for_global_info() {
@@ -2159,7 +2163,7 @@ EOF
   if [ $configure_apache -eq 1 ] && is_local_upstream $upstream; then
     local repository_dir=$(get_upstream_config $upstream)
     # make sure that the config file does not exist, yet
-    remove_apache_config_file "cvmfs.${name}.conf" || true
+    remove_apache_config_file "$(get_apache_conf_filename $name)" || true
     create_apache_config_for_endpoint $name $repository_dir
     create_apache_config_for_global_info
   fi
@@ -2189,7 +2193,7 @@ remove_config_files() {
   local name=$1
   load_repo_config $name
 
-  local apache_conf_file_name="cvmfs.${name}.conf"
+  local apache_conf_file_name="$(get_apache_conf_filename $name)"
   if is_local_upstream $CVMFS_UPSTREAM_STORAGE &&
      has_apache_config_file "$apache_conf_file_name"; then
     remove_apache_config_file "$apache_conf_file_name"
@@ -5498,7 +5502,7 @@ migrate_2_1_15() {
   local name=$1
   local destination_version="2.1.20"
   local conf_file
-  conf_file="$(get_apache_conf_path)/cvmfs.${name}.conf"
+  conf_file="$(get_apache_conf_path)/$(get_apache_conf_filename $name)"
 
   # get repository information
   load_repo_config $name

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5559,37 +5559,39 @@ migrate_2_1_20() {
 
   echo "Migrating repository '$name' from CernVM-FS $(mangle_version_string $CVMFS_CREATOR_VERSION) to $(mangle_version_string $destination_version)"
 
-  echo "--> updating client.conf"
-  local client_conf="/etc/cvmfs/repositories.d/${name}/client.conf"
-  [ -z "$CVMFS_HIDE_MAGIC_XATTRS" ] && echo "CVMFS_HIDE_MAGIC_XATTRS=yes" >> $client_conf
-  [ -z "$CVMFS_FOLLOW_REDIRECTS"  ] && echo "CVMFS_FOLLOW_REDIRECTS=yes"  >> $client_conf
-  [ -z "$CVMFS_SERVER_CACHE_MODE" ] && echo "CVMFS_SERVER_CACHE_MODE=yes" >> $client_conf
-  [ -z "$CVMFS_MOUNT_DIR"         ] && echo "CVMFS_MOUNT_DIR=/cvmfs"      >> $client_conf
+  if is_stratum0 $name; then
+    echo "--> updating client.conf"
+    local client_conf="/etc/cvmfs/repositories.d/${name}/client.conf"
+    [ -z "$CVMFS_HIDE_MAGIC_XATTRS" ] && echo "CVMFS_HIDE_MAGIC_XATTRS=yes" >> $client_conf
+    [ -z "$CVMFS_FOLLOW_REDIRECTS"  ] && echo "CVMFS_FOLLOW_REDIRECTS=yes"  >> $client_conf
+    [ -z "$CVMFS_SERVER_CACHE_MODE" ] && echo "CVMFS_SERVER_CACHE_MODE=yes" >> $client_conf
+    [ -z "$CVMFS_MOUNT_DIR"         ] && echo "CVMFS_MOUNT_DIR=/cvmfs"      >> $client_conf
 
-  echo "--> updating /etc/fstab"
-  local tmp_fstab=$(mktemp)
-  awk  "/added by CernVM-FS for $name/"' {
-          for (i = 1; i <= NF; i++) {
-            if (i == 4) $i = $i",noauto";
-            printf("%s ", $i);
-          }
-          print "";
-          next;
-        };
-        { print $0 }' /etc/fstab > $tmp_fstab
-  cat $tmp_fstab > /etc/fstab
-  rm -f $tmp_fstab
+    echo "--> updating /etc/fstab"
+    local tmp_fstab=$(mktemp)
+    awk  "/added by CernVM-FS for $name/"' {
+            for (i = 1; i <= NF; i++) {
+              if (i == 4) $i = $i",noauto";
+              printf("%s ", $i);
+            }
+            print "";
+            next;
+          };
+          { print $0 }' /etc/fstab > $tmp_fstab
+    cat $tmp_fstab > /etc/fstab
+    rm -f $tmp_fstab
 
-  echo "--> updating server.conf"
-  local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
-  if ! grep -q "CVMFS_AUTO_REPAIR_MOUNTPOINT" $server_conf; then
-    echo "CVMFS_AUTO_REPAIR_MOUNTPOINT=true" >> $server_confg
-  else
-    sed -i -e "s/^\(CVMFS_AUTO_REPAIR_MOUNTPOINT\)=.*/\1=true/" $server_conf
+    echo "--> updating server.conf"
+    local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
+    if ! grep -q "CVMFS_AUTO_REPAIR_MOUNTPOINT" $server_conf; then
+      echo "CVMFS_AUTO_REPAIR_MOUNTPOINT=true" >> $server_confg
+    else
+      sed -i -e "s/^\(CVMFS_AUTO_REPAIR_MOUNTPOINT\)=.*/\1=true/" $server_conf
+    fi
   fi
 
   local apache_conf="$(get_apache_conf_path)/$(get_apache_conf_filename $name)"
-  if [ -f "$apache_conf" ]; then
+  if is_local_upstream $name && [ -f "$apache_conf" ]; then
     echo "--> updating apache config ($(basename $apache_conf))"
     local storage_dir=$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)
     local wsgi=""
@@ -5664,8 +5666,7 @@ migrate() {
          x"$creator" = x"2.1.18" -o                                   \
          x"$creator" = x"2.1.19" -o                                   \
          x"$creator" = x"2.1.20" ]                                 || \
-       [ x"$creator" = x"2.2.0-0" -a -z "$CVMFS_SERVER_CACHE_MODE" ] && \
-         is_stratum0 $name;
+       [ x"$creator" = x"2.2.0-0" -a -z "$CVMFS_SERVER_CACHE_MODE" ];
     then
       migrate_2_1_20 $name
     fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -771,7 +771,7 @@ create_apache_config_file() {
   conf_path="$(get_apache_conf_path)"
 
   # create (or append) the conf file
-  cat - >> ${conf_path}/${file_name} || return 1
+  cat - > ${conf_path}/${file_name} || return 1
 
   # the new apache requires the enable the config afterwards
   if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_CONFAVAIL" ]; then

--- a/test/src/626-cacheexpiry/main
+++ b/test/src/626-cacheexpiry/main
@@ -124,6 +124,26 @@ cvmfs_run_test() {
   [ $(get_epoch "3 days  1 hour") -gt $(get_expiry_time $rurl) ] || return 45
   [ $(get_max_age $rurl)          -eq $default_maxage          ] || return 46
 
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  url=$(get_repo_url info)
+  local jsontype="application/json"
+  local jsonmaxage=120
+
+  echo "check HTTP headers for /cvmfs/info/v1/repositories.json"
+  local irurl="${url}/v1/repositories.json"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $irurl) ] || return 47
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $irurl) ] || return 48
+  [ $(get_max_age $irurl)    -eq $jsonmaxage               ] || return 49
+  [ x"$(get_header $irurl "Content-Type")" = x"$jsontype"  ] || return 50
+
+  echo "check HTTP headers for /cvmfs/info/v1/meta.json"
+  local imurl="${url}/v1/meta.json"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $imurl) ] || return 47
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $imurl) ] || return 48
+  [ $(get_max_age $imurl)    -eq $jsonmaxage               ] || return 49
+  [ x"$(get_header $imurl "Content-Type")" = x"$jsontype"  ] || return 50
+
   return 0
 }
 

--- a/test/src/626-cacheexpiry/main
+++ b/test/src/626-cacheexpiry/main
@@ -1,0 +1,75 @@
+cvmfs_test_name="HTTP headers for cache expiry"
+cvmfs_test_autofs_on_startup=false
+
+get_header() {
+  local url="$1"
+  local header="$2"
+
+  local content="$(curl -sI "$url" | grep -e "^$header" | sed -e "s/^$header: \(.*\)\r\+$/\1/")"
+  echo -n "$content"
+}
+
+get_epoch() {
+  local date_string="$1"
+  date --date "$date_string" \
+       --utc                 \
+       +"%s"
+}
+
+get_expiry_time() {
+  local url="$1"
+  get_epoch "$(get_header $url 'Expires')"
+}
+
+get_max_age() {
+  local url="$1"
+  get_header "$url" "Cache-Control" | sed -e 's/^max-age=\([0-9]*\)$/\1/'
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+
+  echo -n "check for 'curl' utility... "
+  which curl > /dev/null 2>&1 || { echo "not found"; return 1; }
+  echo "found"
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+  local url="$(get_repo_url $CVMFS_TEST_REPO)"
+  local xcvmfs="application/x-cvmfs"
+  local xcvmfs_maxage=120     # 2 minutes
+  local default_maxage=259200 # 3 days
+
+  echo "check HTTP headers for .cvmfspublished"
+  local murl="${url}/.cvmfspublished"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $murl) ] || return  2
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $murl) ] || return  3
+  [ $(get_max_age $murl)     -eq $xcvmfs_maxage           ] || return  4
+  [ x"$(get_header $murl "Content-Type")" = x"$xcvmfs"    ] || return  5
+
+  echo "check HTTP headers for .cvmfswhitelist"
+  local wurl="${url}/.cvmfswhitelist"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $wurl) ] || return  6
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $wurl) ] || return  7
+  [ $(get_max_age $wurl)     -eq $xcvmfs_maxage           ] || return  8
+  [ x"$(get_header $wurl "Content-Type")" = x"$xcvmfs"    ] || return  9
+
+  echo "check HTTP headers for .cvmfs_master_replica"
+  local surl="${url}/.cvmfs_master_replica"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $surl) ] || return 10
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $surl) ] || return 11
+  [ $(get_max_age $surl)     -eq $xcvmfs_maxage           ] || return 12
+  [ x"$(get_header $surl "Content-Type")" = x"$xcvmfs"    ] || return 13
+
+  local root_clg="$(get_current_root_catalog $CVMFS_TEST_REPO)C"
+  echo "check HTTP headers for root catalog ($root_clg)"
+  local rurl="$(get_object_url $CVMFS_TEST_REPO $root_clg)"
+  [ $(get_epoch "2 days 23 hour") -lt $(get_expiry_time $rurl) ] || return 14
+  [ $(get_epoch "3 days  1 hour") -gt $(get_expiry_time $rurl) ] || return 15
+  [ $(get_max_age $rurl)          -eq $default_maxage          ] || return 16
+
+  return 0
+}
+

--- a/test/src/626-cacheexpiry/main
+++ b/test/src/626-cacheexpiry/main
@@ -26,6 +26,15 @@ get_max_age() {
   get_header "$url" "Cache-Control" | sed -e 's/^max-age=\([0-9]*\)$/\1/'
 }
 
+
+CVMFS_TEST_626_REPLICA_NAME=""
+cleanup() {
+  echo "running cleanup()"
+  if [ ! -z $CVMFS_TEST_626_REPLICA_NAME ]; then
+    sudo cvmfs_server rmfs -f $CVMFS_TEST_626_REPLICA_NAME
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -69,6 +78,51 @@ cvmfs_run_test() {
   [ $(get_epoch "2 days 23 hour") -lt $(get_expiry_time $rurl) ] || return 14
   [ $(get_epoch "3 days  1 hour") -gt $(get_expiry_time $rurl) ] || return 15
   [ $(get_max_age $rurl)          -eq $default_maxage          ] || return 16
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "install a desaster cleanup function"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "create Stratum1 repository on the same machine"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+  CVMFS_TEST_626_REPLICA_NAME="$replica_name"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 30
+  url=$(get_repo_url $replica_name)
+
+  echo "do a snapshot"
+  cvmfs_server snapshot $replica_name || return 31
+
+  echo "check HTTP headers for .cvmfspublished"
+  murl="${url}/.cvmfspublished"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $murl) ] || return 32
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $murl) ] || return 33
+  [ $(get_max_age $murl)     -eq $xcvmfs_maxage           ] || return 34
+  [ x"$(get_header $murl "Content-Type")" = x"$xcvmfs"    ] || return 35
+
+  echo "check HTTP headers for .cvmfswhitelist"
+  wurl="${url}/.cvmfswhitelist"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $wurl) ] || return 36
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $wurl) ] || return 37
+  [ $(get_max_age $wurl)     -eq $xcvmfs_maxage           ] || return 38
+  [ x"$(get_header $wurl "Content-Type")" = x"$xcvmfs"    ] || return 39
+
+  echo "check HTTP headers for .cvmfs_last_snapshot"
+  surl="${url}/.cvmfs_last_snapshot"
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $surl) ] || return 40
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $surl) ] || return 41
+  [ $(get_max_age $surl)     -eq $xcvmfs_maxage           ] || return 42
+  [ x"$(get_header $surl "Content-Type")" = x"$xcvmfs"    ] || return 43
+
+  echo "check HTTP headers for root catalog ($root_clg)"
+  rurl="$(get_object_url $replica_name $root_clg)"
+  [ $(get_epoch "2 days 23 hour") -lt $(get_expiry_time $rurl) ] || return 44
+  [ $(get_epoch "3 days  1 hour") -gt $(get_expiry_time $rurl) ] || return 45
+  [ $(get_max_age $rurl)          -eq $default_maxage          ] || return 46
 
   return 0
 }


### PR DESCRIPTION
This is adding additional migration routines and adding Stratum1s to the migration paths from 2.1.20 (and 2.2.0-0 - prerelease) to 2.2.0. I'll need to give that a [manual dry-run](https://sft.its.cern.ch/jira/browse/CVM-950) as there is no automatic testing for this functionality.

**Note:** This is based on [FIX: Cache Expiry HTTP Headers](https://github.com/cvmfs/cvmfs/pull/1425).