### PR TITLE
FIX: Version Handling and Migration

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -204,6 +204,17 @@ is_subcommand() {
 }
 
 
+# makes sure that a version is always of the form x.y.z-b
+normalize_version() {
+  local version_string="$1"
+  while [ $(echo "$version_string" | grep -o '\.' | wc -l) -lt 2 ]; do
+    version_string="${version_string}.0"
+  done
+  while [ $(echo "$version_string" | grep -o '-' | wc -l) -lt 1 ]; do
+    version_string="${version_string}-1"
+  done
+  echo "$version_string"
+}
 # returns the version string of the current cvmfs installation
 cvmfs_version_string() {
   local version_string
@@ -215,18 +226,7 @@ cvmfs_version_string() {
   else
     version_string=$(__swissknife --version)
   fi
-  echo $version_string
-}
-# makes sure that a version is always of the form x.y.z-b
-normalize_version() {
-  local version_string="$1"
-  while [ $(echo "$version_string" | grep -o '\.' | wc -l) -lt 2 ]; do
-    version_string="${version_string}.0"
-  done
-  while [ $(echo "$version_string" | grep -o '-' | wc -l) -lt 1 ]; do
-    version_string="${version_string}-1"
-  done
-  echo "$version_string"
+  echo $(normalize_version $version_string)
 }
 version_major() { echo $1 | cut --delimiter=. --fields=1 | grep -oe '^[0-9]\+'; }
 version_minor() { echo $1 | cut --delimiter=. --fields=2 | grep -oe '^[0-9]\+'; }
@@ -395,12 +395,10 @@ repository_creator_version() {
                     # version... therefore this has to be handled as "<= 2.1.6"
                     # Note: see also `mangle_version_string()`
   elif [ x"$version" = x"2.2.0" ]; then
-    if [ -z "$CVMFS_SERVER_CACHE_MODE" ]; then
-      version="2.2.0-0" # CVMFS 2.2.0-0 was a server-only pre-release which did
-                        # not have some new mandatory config parameters yet
-    else
-      version="2.2.0-1"
-    fi
+    version="2.2.0-0" # CernVM-FS 2.2.0-0 was a server-only pre-release which is
+                      # incompatible with 2.2.0-1
+                      # 2.2.0-0 marks itself as CVMFS_CREATOR_VERSION=2.2.0
+                      # while 2.2.0-1 features  CVMFS_CREATOR_VERSION=2.2.0-1
   fi
   echo $version
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5549,8 +5549,10 @@ migrate_2_1_15() {
 
 migrate_2_1_20() {
   local name=$1
-  local destination_version="2.2.0"
+  local destination_version="2.2.0-1"
   local creator=$(repository_creator_version $name)
+  local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
+  local apache_conf="$(get_apache_conf_path)/$(get_apache_conf_filename $name)"
 
   # get repository information
   load_repo_config $name
@@ -5580,7 +5582,6 @@ migrate_2_1_20() {
     rm -f $tmp_fstab
 
     echo "--> updating server.conf"
-    local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
     if ! grep -q "CVMFS_AUTO_REPAIR_MOUNTPOINT" $server_conf; then
       echo "CVMFS_AUTO_REPAIR_MOUNTPOINT=true" >> $server_confg
     else
@@ -5588,12 +5589,11 @@ migrate_2_1_20() {
     fi
   fi
 
-  local apache_conf="$(get_apache_conf_path)/$(get_apache_conf_filename $name)"
-  if is_local_upstream $name && [ -f "$apache_conf" ]; then
+  if is_local_upstream $CVMFS_UPSTREAM_STORAGE && [ -f "$apache_conf" ]; then
     echo "--> updating apache config ($(basename $apache_conf))"
     local storage_dir=$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)
     local wsgi=""
-    [ is_stratum1 $name ] && wsgi="enabled"
+    is_stratum1 $name && wsgi="enabled"
     create_apache_config_for_endpoint $name $storage_dir $wsgi
     reload_apache > /dev/null
   fi
@@ -5658,13 +5658,13 @@ migrate() {
       migrate_2_1_15 $name
     fi
 
-    if [ x"$creator" = x"2.1.15" -o                                   \
-         x"$creator" = x"2.1.16" -o                                   \
-         x"$creator" = x"2.1.17" -o                                   \
-         x"$creator" = x"2.1.18" -o                                   \
-         x"$creator" = x"2.1.19" -o                                   \
-         x"$creator" = x"2.1.20" ]                                 || \
-       [ x"$creator" = x"2.2.0-0" -a -z "$CVMFS_SERVER_CACHE_MODE" ];
+    if [ x"$creator" = x"2.1.15" -o \
+         x"$creator" = x"2.1.16" -o \
+         x"$creator" = x"2.1.17" -o \
+         x"$creator" = x"2.1.18" -o \
+         x"$creator" = x"2.1.19" -o \
+         x"$creator" = x"2.1.20" -o \
+         x"$creator" = x"2.2.0-0" ];
     then
       migrate_2_1_20 $name
     fi


### PR DESCRIPTION
Fix an issue with the server migration code and version handling that was [introduced yesterday evening](https://github.com/cvmfs/cvmfs/pull/1430). Newly created Stratum1 repositories were detected as 'incompatible', breaking all Stratum1 related test cases.

This changes the `CVMFS_CREATOR_VERSION` schema in `server.conf` (before: `x.y.z` now `x.y.z-k`) to be able to distinguish between the incompatible versions CernVM-FS 2.2.0-0 and 2.2.0-1. For both Stratum0 and Stratum1 repositories this version jump requires a migration run.

TIL: One does not simply quick-fix something just before calling it a day... :-1: 