### PR TITLE
FIX: Missing Quotes in `to_syslog()` Helper Function

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -160,7 +160,7 @@ __swissknife() {
 
 
 to_syslog() {
-  logger -t cvmfs_server $1 > /dev/null 2>&1 || return 0
+  logger -t cvmfs_server "$1" > /dev/null 2>&1 || return 0
 }
 
 to_syslog_for_repo() {

--- a/test/test_functions
+++ b/test/test_functions
@@ -122,7 +122,7 @@ normalize_version() {
 }
 
 to_syslog() {
-  logger -t cvmfs_test $1
+  logger -t cvmfs_test "$1"
 }
 
 version_major() { echo $1 | cut --delimiter=. --fields=1; }


### PR DESCRIPTION
Fix a minor problem in `to_syslog()` helper function both in `cvmfs_server` and `test_functions`. The missing quotation marks caused the `logger` utility to choke on certain input strings.