### PR TITLE
Revert: Addition of Manifest Field 'V'

### DIFF
--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -68,7 +68,6 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   bool garbage_collectable = false;
   bool has_alt_catalog_path = false;
   shash::Any meta_info;
-  std::string creator_version;
 
   if ((iter = content.find('B')) != content.end())
     catalog_size = String2Uint64(iter->second);
@@ -92,13 +91,11 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   if ((iter = content.find('M')) != content.end())
     meta_info = MkFromHexPtr(shash::HexPtr(iter->second),
                              shash::kSuffixMetainfo);
-  if ((iter = content.find('V')) != content.end())
-    creator_version = iter->second;
 
   return new Manifest(catalog_hash, catalog_size, root_path, ttl, revision,
                       micro_catalog_hash, repository_name, certificate,
                       history, publish_timestamp, garbage_collectable,
-                      has_alt_catalog_path, meta_info, creator_version);
+                      has_alt_catalog_path, meta_info);
 }
 
 
@@ -127,8 +124,7 @@ string Manifest::ExportString() const {
     "D" + StringifyInt(ttl_) + "\n" +
     "S" + StringifyInt(revision_) + "\n" +
     "G" + StringifyBool(garbage_collectable_) + "\n" +
-    "A" + StringifyBool(has_alt_catalog_path_) + "\n" +
-    "V" + creator_version_ + "\n";
+    "A" + StringifyBool(has_alt_catalog_path_) + "\n";
 
   if (!micro_catalog_hash_.IsNull())
     manifest += "L" + micro_catalog_hash_.ToString() + "\n";

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -38,8 +38,7 @@ class Manifest {
            const uint64_t publish_timestamp,
            const bool garbage_collectable,
            const bool has_alt_catalog_path,
-           const shash::Any &meta_info,
-           const std::string &cvmfs_version)
+           const shash::Any &meta_info)
   : catalog_hash_(catalog_hash)
   , catalog_size_(catalog_size)
   , root_path_(root_path)
@@ -52,8 +51,7 @@ class Manifest {
   , publish_timestamp_(publish_timestamp)
   , garbage_collectable_(garbage_collectable)
   , has_alt_catalog_path_(has_alt_catalog_path)
-  , meta_info_(meta_info)
-  , creator_version_(cvmfs_version) { }
+  , meta_info_(meta_info) { }
 
   std::string ExportString() const;
   bool Export(const std::string &path) const;
@@ -97,9 +95,6 @@ class Manifest {
   void set_root_path(const std::string &root_path) {
     root_path_ = shash::Md5(shash::AsciiPtr(root_path));
   }
-  void set_creator_version(const std::string &cvmfs_version) {
-    creator_version_ = cvmfs_version;
-  }
 
   uint64_t revision() const { return revision_; }
   std::string repository_name() const { return repository_name_; }
@@ -112,7 +107,6 @@ class Manifest {
   bool garbage_collectable() const { return garbage_collectable_; }
   bool has_alt_catalog_path() const { return has_alt_catalog_path_; }
   shash::Any meta_info() const { return meta_info_; }
-  std::string creator_version() const { return creator_version_; }
 
   std::string MakeCatalogPath() const {
     return has_alt_catalog_path_ ? catalog_hash_.MakeAlternativePath() :
@@ -150,8 +144,6 @@ class Manifest {
    * of recommended stratum 1s, ...)
    */
   shash::Any meta_info_;
-
-  std::string creator_version_;
 };  // class Manifest
 
 }  // namespace manifest

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -174,7 +174,6 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
     manifest->set_certificate(certificate_hash);
     manifest->set_repository_name(repo_name);
     manifest->set_publish_timestamp(time(NULL));
-    manifest->set_creator_version(VERSION);
     manifest->set_garbage_collectability(garbage_collectable);
     manifest->set_has_alt_catalog_path(bootstrap_shortcuts);
     if (!metainfo_hash.IsNull()) {


### PR DESCRIPTION
This reverts the changes done in [Feature: Add CernVM-FS Version String to Repository Manifests](https://github.com/cvmfs/cvmfs/pull/1382/files). The [respective ticket](https://sft.its.cern.ch/jira/browse/CVM-817) is pushed to CernVM-FS 2.3.0.