### PR TITLE
FIX: Several minor issues of tonight's cloud test run

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -566,8 +566,8 @@ if (BUILD_PRELOADER)
   add_dependencies (cvmfs_preload_bin libvjson)
 
   target_link_libraries(cvmfs_preload_bin ${SQLITE3_LIBRARY} ${CARES_LIBRARIES}
-                        ${CURL_LIBRARIES} ${ZLIB_LIBRARIES} ${OPENSSL_LIBRARIES}
-                        ${LIBCURL_ARCHIVE} ${CARES_ARCHIVE} ${SQLITE3_ARCHIVE}
+                        ${CURL_LIBRARIES} ${LIBCURL_ARCHIVE} ${ZLIB_LIBRARIES}
+                        ${OPENSSL_LIBRARIES} ${CARES_ARCHIVE} ${SQLITE3_ARCHIVE}
                         ${ZLIB_ARCHIVE} ${TBB_LIBRARIES} ${RT_LIBRARY}
                         ${VJSON_ARCHIVE} ${SHA2_ARCHIVE} ${SHA3_ARCHIVE}
                         pthread dl)

--- a/test/cloud_testing/platforms/fedora22_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_setup.sh
@@ -43,8 +43,15 @@ install_from_repo java
 install_from_repo nc
 install_from_repo wget
 install_from_repo bc
+
+# install build dependencies for `libcvmfs`
 install_from_repo openssl-devel
 install_from_repo libuuid-devel
+
+# install stuff necessary to build `cvmfs_preload`
+install_from_repo cmake
+install_from_repo patch
+install_from_repo libattr-devel
 
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -30,6 +30,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
+                                 src/570-remountrace                          \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -26,6 +26,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+CVMFS_TEST_UNIONFS=overlayfs                                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -28,7 +28,8 @@ echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 CVMFS_TEST_UNIONFS=overlayfs                                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                              -x src/523-corruptchunkfailover                 \
+                              -x src/518-hardlinkstresstest                   \
+                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \

--- a/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
@@ -64,6 +64,10 @@ install_from_repo make                          || die "fail (installing make)"
 install_from_repo sqlite3                       || die "fail (installing sqlite3)"
 install_from_repo linux-image-extra-$(uname -r) || die "fail (installing AUFS)"
 
+# install 'cvmfs_preload' build dependencies
+install_from_repo cmake        || die "fail (installing cmake)"
+install_from_repo libattr1-dev || die "fail (installing libattr1-dev)"
+
 # setting up the AUFS kernel module
 echo -n "loading AUFS kernel module..."
 sudo modprobe aufs || die "fail"

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -15,6 +15,12 @@ get_apache_config_filename() {
   echo "${repo_name}.conf"
 }
 
+set_selinux_httpd_context_if_needed() {
+  local directory="$1"
+  if has_selinux; then
+    sudo chcon -Rv --type=httpd_sys_content_t ${directory}/ > /dev/null
+  fi
+}
 
 mock_apache_access_to_legacy_repo() {
   local legacy_repo_name="$1"
@@ -41,6 +47,7 @@ Alias /cvmfs/${legacy_repo_name} ${legacy_repo_storage}/pub/catalogs
   ExpiresByType application/x-cvmfs "access plus 1 minutes"
 </Directory>
 EOF
+  set_selinux_httpd_context_if_needed $legacy_repo_storage
   apache_switch off > /dev/null
   apache_switch on  > /dev/null
   curl --output /dev/null --silent --head --fail "$legacy_repo_url/.cvmfspublished" || die "fail (404 on .cvmfspublished)"
@@ -103,6 +110,7 @@ TEST550_S0_MOUNTPOINT=""
 TEST550_S1_MOUNTPOINT=""
 TEST550_NEW_REPO_NAME=""
 cleanup() {
+  echo "running cleanup()"
   [ -z "$TEST550_LEGACY_STORAGE" ] || sudo rm -fR $TEST550_LEGACY_STORAGE
   [ -z "$TEST550_APACHE_CONF" ]    || remove_apache_config_file $TEST550_APACHE_CONF
   [ -z "$TEST550_REPLICA_NAME" ]   || sudo cvmfs_server rmfs -f $TEST550_REPLICA_NAME

--- a/test/test_functions
+++ b/test/test_functions
@@ -382,7 +382,9 @@ cvmfs_umount() {
 
 
 has_selinux() {
-  [ -f /selinux/enforce ] && [ $(cat /selinux/enforce) -ne 0 ]
+  which sestatus   > /dev/null 2>&1 && \
+  which getenforce > /dev/null 2>&1 && \
+  getenforce | grep -qi "enforc" || return 1
 }
 
 


### PR DESCRIPTION
This mainly fixes things in the test infrastructure for some failed tests. The only 'actual' production fix is the wrong link order of `cvmfs_preload_bin` that becomes apparent on Ubuntu.