### PR TITLE
FIX: Docker Images on Ubuntu 12.04

### DIFF
--- a/ci/docker/ubuntu1204_i386/build.sh
+++ b/ci/docker/ubuntu1204_i386/build.sh
@@ -8,6 +8,6 @@ SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 SYSTEM_NAME="ubuntu1204"
 BASE_ARCH="i386"
 REPO_BASE_URL="http://archive.ubuntu.com/ubuntu/"
-UBUNTU_RELEASE="trusty"
+UBUNTU_RELEASE="precise"
 
 . ${SCRIPT_LOCATION}/../ubuntu_common/build.sh

--- a/ci/docker/ubuntu1204_x86_64/build.sh
+++ b/ci/docker/ubuntu1204_x86_64/build.sh
@@ -8,6 +8,6 @@ SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 SYSTEM_NAME="ubuntu1204"
 BASE_ARCH="x86_64"
 REPO_BASE_URL="http://archive.ubuntu.com/ubuntu/"
-UBUNTU_RELEASE="trusty"
+UBUNTU_RELEASE="precise"
 
 . ${SCRIPT_LOCATION}/../ubuntu_common/build.sh


### PR DESCRIPTION
Sigh! Didn't update the right field. Hence the image was called Ubuntu 12.04 but internally it was a 14.04.