### PR TITLE
FIX: race when reloading at the same time as evicting data from the cache

### DIFF
--- a/cvmfs/quota.cc
+++ b/cvmfs/quota.cc
@@ -505,6 +505,11 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       pid_t pid;
       int statloc;
       if ((pid = fork()) == 0) {
+#ifndef DEBUGMSG
+        int max_fd = sysconf(_SC_OPEN_MAX);
+        for (int i = 0; i < max_fd; ++i)
+          close(i);
+#endif
         if (fork() == 0) {
           for (unsigned i = 0, iEnd = trash.size(); i < iEnd; ++i) {
             LogCvmfs(kLogQuota, kLogDebug, "unlink %s", trash[i].c_str());

--- a/cvmfs/quota.cc
+++ b/cvmfs/quota.cc
@@ -505,6 +505,9 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       pid_t pid;
       int statloc;
       if ((pid = fork()) == 0) {
+        // TODO(jblomer): eviciting files in the cache should perhaps become a
+        // thread.  This would also allow to block the chunks and prevent the
+        // race with re-insertion.  Then again, a thread can block umount.
 #ifndef DEBUGMSG
         int max_fd = sysconf(_SC_OPEN_MAX);
         for (int i = 0; i < max_fd; ++i)


### PR DESCRIPTION
This problem can explain the hang during the migration test.