### PR TITLE
FIX: Minimal Test Setup Changes after Tonight's Cloud Test Run

### DIFF
--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -17,6 +17,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/004-davinci                              \
                                  src/005-asetup                               \
+                                 src/006-buildkernel                          \
                                  src/007-testjobs                             \
                                  src/024-reload-during-asetup                 \
                                  --                                           \

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -17,6 +17,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/004-davinci                              \
                                  src/005-asetup                               \
+                                 src/006-buildkernel                          \
                                  src/007-testjobs                             \
                                  src/024-reload-during-asetup                 \
                                  --                                           \

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -17,6 +17,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/004-davinci                              \
                                  src/005-asetup                               \
+                                 src/006-buildkernel                          \
                                  src/007-testjobs                             \
                                  src/024-reload-during-asetup                 \
                                  src/045-oasis                                \

--- a/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_setup.sh
@@ -51,7 +51,9 @@ echo -n "setting up CernVM-FS environment... "
 sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"
 sudo mkdir -p /var/log/cvmfs-test                || die "fail (mkdir /var/log/cvmfs-test)"
 sudo chown sftnight:sftnight /var/log/cvmfs-test || die "fail (chown /var/log/cvmfs-test)"
-attach_user_group fuse                           || die "fail (add fuse group to user)"
+if getent group fuse > /dev/null 2>&1; then
+  attach_user_group fuse                         || die "fail (add fuse group to user)"
+fi
 sudo service autofs restart > /dev/null          || die "fail (restart autofs)"
 sudo cvmfs_config chksetup > /dev/null           || die "fail (cvmfs_config chksetup)"
 echo "done"


### PR DESCRIPTION
* Add `sftnight` user opportunistically to `fuse` group on Ubuntu
* Disable `006-buildkernel` on newer platforms (FC22, FC23, Ubuntu 15.10)