### PR TITLE
FIX: Cleaning Up and Extending "External Files" Integration Test 

### DIFF
--- a/test/common/mock_services/HTTPRangeServer.py
+++ b/test/common/mock_services/HTTPRangeServer.py
@@ -1,0 +1,220 @@
+"""
+An extension of the Python stdlib SimpleHTTPServer module, to
+support the "Range" header in HTTP requests, as needed by iOS Safari
+to support (some) MP3s.
+
+Some methods are modifications to the original SimpleHTTPServer that is
+part of the Python stdlib.  This uses the versions that ship with Python
+2.7 on Fedora 15.
+
+Licensed under BSD 2-Clause License
+
+
+Copyright (c) 2012, John Smith <code@john-smith.me>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+__version__ = "0.2"
+
+__author__ = "John Smith <code@john-smith.me>"
+
+import os
+import BaseHTTPServer
+import SimpleHTTPServer
+
+# Additions for handling Range: header
+import logging
+import re
+
+class InvalidRangeHeader(Exception):
+    pass
+
+def parse_range_header(range_header, total_length):
+    """
+    Return a 2-element tuple containing the requested range offsets
+    in bytes.
+    - range_header is the HTTP header sans the "Range:" prefix
+    - total_length is the length in bytes of the requested resource
+      (needed to calculate offsets for a 'n bytes from the end' request
+    If no Range explicitly requested, returns (None, None)
+    If Range header could not be parsed, raises InvalidRangeHeader
+    (which could either be handled as a user
+    request failure, or the same as if (None, None) was returned
+    """
+    # range_header = self.headers.getheader("Range")
+    if range_header is None or range_header == "":
+        return (None, None)
+    if not range_header.startswith("bytes="):
+        # logging.error("Don't know how to parse Range: %s [1]" %
+        #                (range_header))
+        raise InvalidRangeHeader("Don't know how to parse non-bytes Range: %s" %
+                                 (range_header))
+    regex = re.compile(r"^bytes=(\d*)\-(\d*)$")
+    rangething = regex.search(range_header)
+    if rangething:
+        r1 = rangething.group(1)
+        r2 = rangething.group(2)
+        logging.debug("Requested range is [%s]-[%s]" % (r1, r2))
+
+        if r1 == "" and r2 == "":
+            # logging.warning("Requested range is meaningless")
+            raise InvalidRangeHeader("Requested range is meaningless")
+
+        if r1 == "":
+            # x bytes from the end of the file
+            try:
+                final_bytes = int(r2)
+            except ValueError:
+                raise InvalidRangeHeader("Invalid trailing range")
+            return (total_length-final_bytes, total_length - 1)
+
+        try:
+            from_val = int(r1)
+        except ValueError:
+            raise InvalidRangeHeader("Invalid starting range value")
+        if r2 != "":
+            try:
+                end_val = int(r2)
+            except ValueError:
+                raise InvalidRangeHeader("Invalid ending range value")
+            return (from_val, end_val)
+        else:
+            return (from_val, total_length - 1)
+    else:
+        raise InvalidRangeHeader("Don't know how to parse Range: %s" %
+                                 (range_header))
+
+
+class HTTPRangeRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+
+    """
+    Extension of SimpleHTTPServer.SimpleHTTPRequestHandler to support
+    the Range header in HTTP requests.  (As needed for serving certain
+    MP3 files to Mobile Safari.
+    """
+
+    server_version = "HTTPRangeServer/" + __version__
+
+    def do_GET(self):
+        """Serve a GET request."""
+        f = self.send_head()
+        if f:
+            if self.range_from is not None and self.range_to is not None:
+                self.copy_chunk(f, self.wfile)
+            else:
+                self.copyfile(f, self.wfile)
+            f.close()
+
+    def copy_chunk(self, in_file, out_file):
+        """
+        Copy a chunk of in_file as dictated by self.range_[from|to]
+        to out_file.
+        NB: range values are inclusive so 0-99 => 100 bytes
+        Neither of the file objects are closed when the
+        function returns.  Assumes that in_file is open
+        for reading, out_file is open for writing.
+        If range_tuple specifies something bigger/outside
+        than the size of in_file, out_file will contain as
+        much content as matches.  e.g. with a 1000 byte input,
+        (500, 2000) will create a 500 byte long file
+        (2000, 3000) will create a zero length output file
+        """
+
+        in_file.seek(self.range_from)
+        # Add 1 because the range is inclusive
+        left_to_copy = 1 + self.range_to - self.range_from
+
+        bytes_copied = 0
+        while bytes_copied < left_to_copy:
+            read_buf = in_file.read(left_to_copy)
+            if len(read_buf) == 0:
+                break
+            out_file.write(read_buf)
+            bytes_copied += len(read_buf)
+        return bytes_copied
+
+
+    def send_head(self):
+        """Common code for GET and HEAD commands.
+
+        This sends the response code and MIME headers.
+
+        Return value is either a file object (which has to be copied
+        to the outputfile by the caller unless the command was HEAD,
+        and must be closed by the caller under all circumstances), or
+        None, in which case the caller has nothing further to do.
+
+        """
+        path = self.translate_path(self.path)
+        f = None
+        if os.path.isdir(path):
+            if not self.path.endswith('/'):
+                # redirect browser - doing basically what apache does
+                self.send_response(301)
+                self.send_header("Location", self.path + "/")
+                self.end_headers()
+                return None
+            for index in "index.html", "index.htm":
+                index = os.path.join(path, index)
+                if os.path.exists(index):
+                    path = index
+                    break
+            else:
+                return self.list_directory(path)
+        ctype = self.guess_type(path)
+        try:
+            # Always read in binary mode. Opening files in text mode may cause
+            # newline translations, making the actual size of the content
+            # transmitted *less* than the content-length!
+            f = open(path, 'rb')
+        except IOError:
+            self.send_error(404, "File not found")
+            return None
+
+        fs = os.fstat(f.fileno())
+        total_length = fs[6]
+        try:
+            self.range_from, self.range_to = parse_range_header(
+                self.headers.getheader("Range"), total_length)
+        except InvalidRangeHeader, e:
+            # Just serve them the whole file, although it's possibly
+            # more correct to return a 4xx error?
+            logging.warning("Range header parsing failed, "
+                            "serving complete file")
+            self.range_from = self.range_to = None
+
+        if self.range_from is not None or self.range_to is not None:
+            self.send_response(206)
+            self.send_header("Accept-Ranges", "bytes")
+        else:
+            self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        if self.range_from is not None or self.range_to is not None:
+            # TODO: Should also check that range is within the file size
+            self.send_header("Content-Range",
+                             "bytes %d-%d/%d" % (self.range_from,
+                                                 self.range_to,
+                                                 total_length))
+            # Add 1 because ranges are inclusive
+            self.send_header("Content-Length",
+                             (1 + self.range_to - self.range_from))
+        else:
+            self.send_header("Content-Length", str(total_length))
+        self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
+        self.end_headers()
+        return f
+
+def test(HandlerClass = HTTPRangeRequestHandler,
+         ServerClass = BaseHTTPServer.HTTPServer):
+    BaseHTTPServer.test(HandlerClass, ServerClass)
+
+if __name__ == '__main__':
+    test()

--- a/test/common/mock_services/http_server.py
+++ b/test/common/mock_services/http_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import SimpleHTTPServer
+import HTTPRangeServer
 import SocketServer
 import sys
 import os
@@ -22,6 +22,6 @@ print "changing directory to" , options.docroot
 os.chdir(options.docroot)
 
 print "start serving..."
-handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+handler = HTTPRangeServer.HTTPRangeRequestHandler
 httpd = SocketServer.TCPServer(("", options.http_port), handler)
 httpd.serve_forever()

--- a/test/src/607-noapache/main
+++ b/test/src/607-noapache/main
@@ -42,36 +42,14 @@ cvmfs_run_test() {
   mkdir -p $s1_location || return 2
   touch ${document_root}/sentinel || return 3
 
-  echo -n "spawning a simple HTTP server (logging to $http_logfile)... "
-  local http_server="${src_location}/../../common/mock_services/http_server.py"
-  local http_pid=
   local http_port=8888
+  echo -n "spawning a simple HTTP server (logging to $http_logfile)... "
+  CVMFS_TEST_607_HTTP_PID="$(open_http_server $document_root $http_port $http_logfile)"
+  kill -0 $CVMFS_TEST_607_HTTP_PID || { echo "fail"; return 4; }
   local http_base_url="http://localhost:${http_port}"
   local s0_http_address="${http_base_url}/cvmfs/${CVMFS_TEST_REPO}"
   local s1_http_address="${http_base_url}/cvmfs/${replica_name}"
-
-  http_pid=$(run_background_service $http_logfile "$http_server -p $http_port -r $document_root")
-  CVMFS_TEST_607_HTTP_PID=$http_pid
-  echo "done (PID: $http_pid)"
-
-  echo -n "waiting for the server to come up..."
-  local timeout=10
-  while ! get_http_response ${http_base_url}/sentinel | grep "200 OK" > /dev/null && \
-        [ $timeout -gt 0 ]; do
-    echo -n "."
-    sleep 1
-    if ! kill -0 $http_pid > /dev/null 2>&1;then
-      echo " broken"
-      return 3
-    fi
-    timeout=$(( $timeout - 1 ))
-  done
-  if [ $timeout -eq 0 ]; then
-    echo " timeout"
-    return 3
-  else
-    echo " done"
-  fi
+  echo "done"
 
   echo "create a repository without apache backend"
   local s0_upstream="local,${s0_location}/data/txn,${s0_location}"

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -134,17 +134,31 @@ cvmfs_run_test() {
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   echo "publish file that is NOT marked as external (cvmfs_server publish -N)"
-  start_transaction $CVMFS_TEST_REPO       || return $?
-  echo "not external" > ${repo_dir}/native || return 60
-  publish_repo $CVMFS_TEST_REPO -v -N      || return $?
+  start_transaction $CVMFS_TEST_REPO                       || return $?
+  echo "not external" > ${repo_dir}/native                 || return 61
+  dd if=/dev/urandom of=chunked_file_native bs=1M count=32 || return 62
+  cp chunked_file_native ${repo_dir}/chunked_file_native   || return 63
+  publish_repo $CVMFS_TEST_REPO -v -N                      || return $?
 
   echo "check that 'native' is NOT external"
-  ! is_external_file ${cvmfs_mnt}/native || return 30
+  ! is_external_file ${cvmfs_mnt}/native              || return 30
+  ! is_external_file ${cvmfs_mnt}/chunked_file_native || return 31
 
   echo "Remove cached and external copy of the file; only copy"
   echo "is in the backend storage, which should not be used."
   mv ${external_storage}/external/file "$object_file" || return 55
   sudo rm -f $cache_object                            || return 56
+
+  echo "disable HTTP server (stop serving external files)"
+  sudo kill $CVMFS_TEST_615_HTTP_PID || return 70
+  CVMFS_TEST_615_HTTP_PID=""
+  sleep 1
+
+  echo "read and validate internal files"
+  [ x"$(cat ${repo_dir}/native)" = x"not external" ] || return 71
+  local chunked_file_native_hash="$(cat chunked_file_native | sha1sum)"
+  local chunked_file_native_hash_cvmfs="$(cat ${repo_dir}/chunked_file_native | sha1sum)"
+  [ x"$chunked_file_native_hash" = x"$chunked_file_native_hash_cvmfs" ] || return 72
 
   echo "Make sure access fails without the external copy."
   if cat ${repo_dir}/external/file; then

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -17,18 +17,35 @@ get_chunk_count() {
   attr -qg chunks "$full_file_path"
 }
 
+CVMFS_TEST_615_HTTP_PID=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_615_HTTP_PID ] || sudo kill $CVMFS_TEST_615_HTTP_PID
+}
+
 cvmfs_run_test() {
   logfile=$1
+  src_location=$2
   local repo_dir="/cvmfs/${CVMFS_TEST_REPO}"
+  local scratch_dir="$(pwd)"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   echo "Note: cvmfs_server mkfs -X --> enabled external files"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -X -Z none || return $?
 
-  echo "get some global base paths"
+  echo "get some global base paths and configs"
   load_repo_config $CVMFS_TEST_REPO
   local cvmfs_mnt="${CVMFS_SPOOL_DIR}/rdonly"
   local cvmfs_cache="${CVMFS_SPOOL_DIR}/cache/$CVMFS_TEST_REPO"
+  local http_port=8615
+  local external_http_base="http://localhost:$http_port"
+  local client_config="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/client.conf"
+
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "configure external data location"
+  echo "CVMFS_EXTERNAL_URL=$external_http_base" | sudo tee --append $client_config
 
   echo "fill repository with some files"
   start_transaction $CVMFS_TEST_REPO                     || return $?
@@ -50,12 +67,36 @@ cvmfs_run_test() {
   [ -f "$object_file" ] || return 7
   echo "File in backend is $object_file"
 
-  local external_storage="$(get_local_repo_storage $CVMFS_TEST_REPO)/external"
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  local external_storage="${scratch_dir}/external_files"
   echo "Creating external storage directory '$external_storage'"
   mkdir -p $external_storage || return 51
 
+  echo "Make sure the file is NOT in the repository storage but instead in the external area"
+  mkdir -p ${external_storage}/external
+  mv "$object_file" ${external_storage}/external/file || return 52
+
+  echo "Check the external file data (should fail to read - external storage not served yet)"
+  is_external_file ${cvmfs_mnt}/external/file || return 20
+  ! cat ${repo_dir}/external/file             || return 22
+
+  echo "start an HTTP server to serve external files"
+  local http_log="${scratch_dir}/http.log"
+  CVMFS_TEST_615_HTTP_PID="$(open_http_server $external_storage $http_port $http_log)"
+  kill -0 $CVMFS_TEST_615_HTTP_PID || { echo "fail"; return 4; }
+  echo "HTTP server running with PID $CVMFS_TEST_615_HTTP_PID"
+
+  echo "Check the external file data"
+  is_external_file ${cvmfs_mnt}/external/file               || return 20
+  [ x"$(cat ${repo_dir}/external/file)" == x"Hello World" ] || return 22
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "copy chunked file into external storage"
+  cp chunked_file "${external_storage}/chunked_file" || return 52
+
   echo "verify chunked files are really properly chunked and readable"
-  cp chunked_file "$(get_local_repo_storage $CVMFS_TEST_REPO)/chunked_file" || return 52
   local chunked_true_hash=$(cat chunked_file | sha1sum | awk '{print $1;}')
   local chunked_cvmfs_hash=$(get_content_hash ${cvmfs_mnt}/chunked_file)
   local chunked_cvmfs_read=$(cat ${repo_dir}/chunked_file | sha1sum | awk '{print $1;}')
@@ -78,12 +119,7 @@ cvmfs_run_test() {
     return 27
   fi
 
-  echo "Make sure the file is NOT in the repository storage but instead in the external area"
-  mv "$object_file" ${external_storage}/file || return 52
-
-  echo "Check the external file data"
-  is_external_file ${cvmfs_mnt}/external/file               || return 20
-  [ x"$(cat ${repo_dir}/external/file)" == x"Hello World" ] ||return 22
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   local cache_object="${cvmfs_cache}/$(get_hash_path $object_hash)"
   echo "Verify the expected file ($cache_object) is in the cache."
@@ -102,8 +138,8 @@ cvmfs_run_test() {
 
   echo "Remove cached and external copy of the file; only copy"
   echo "is in the backend storage, which should not be used."
-  mv ${external_storage}/file "$object_file" || return 55
-  sudo rm -f $cache_object                   || return 56
+  mv ${external_storage}/external/file "$object_file" || return 55
+  sudo rm -f $cache_object                            || return 56
 
   echo "Make sure access fails without the external copy."
   if cat ${repo_dir}/external/file; then

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -2,58 +2,66 @@
 cvmfs_test_name="External data"
 cvmfs_test_autofs_on_startup=false
 
-verify_external_data() {
-  local attr1=$(attr -qg external_file /var/spool/cvmfs/test.cern.ch/rdonly/external/file)
-  if [ "x$attr1" != "x1" ]; then
-    echo "ERROR: External file /var/spool/cvmfs/test.cern.ch/rdonly/external/file not marked as external."
-    return 20
-  fi
-  local contents=$(cat /cvmfs/$CVMFS_TEST_REPO/external/file)
-  if [ "x$contents" != "xHello World" ]; then
-    return 22
-  fi
-  return 0
+is_external_file() {
+  local full_file_path="$1"
+  [ x"$(attr -qg external_file "$full_file_path")" = x"1" ]
+}
+
+get_content_hash() {
+  local full_file_path="$1"
+  attr -qg hash "$full_file_path"
+}
+
+get_chunk_count() {
+  local full_file_path="$1"
+  attr -qg chunks "$full_file_path"
 }
 
 cvmfs_run_test() {
   logfile=$1
-  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local repo_dir="/cvmfs/${CVMFS_TEST_REPO}"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  echo "Note: cvmfs_server mkfs -X --> enabled external files"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -X -Z none || return $?
 
-  start_transaction $CVMFS_TEST_REPO || return $?
-  mkdir -p /cvmfs/$CVMFS_TEST_REPO/external
-  mkdir -p /cvmfs/$CVMFS_TEST_REPO/internal
-  echo "Hello World" > /cvmfs/$CVMFS_TEST_REPO/external/file
-  cp /cvmfs/$CVMFS_TEST_REPO/external/file /cvmfs/$CVMFS_TEST_REPO/internal/file
+  echo "get some global base paths"
+  load_repo_config $CVMFS_TEST_REPO
+  local cvmfs_mnt="${CVMFS_SPOOL_DIR}/rdonly"
+  local cvmfs_cache="${CVMFS_SPOOL_DIR}/cache/$CVMFS_TEST_REPO"
 
-  # Create a large file to be chunked.
-  echo "creating large file to be chunked"
-  dd if=/dev/urandom of=chunked_file bs=1M count=32
-  cp chunked_file /cvmfs/$CVMFS_TEST_REPO/chunked_file
+  echo "fill repository with some files"
+  start_transaction $CVMFS_TEST_REPO                     || return $?
+  mkdir -p ${repo_dir}/external                          || return 1
+  mkdir -p ${repo_dir}/internal                          || return 2
+  echo "Hello World" > ${repo_dir}/external/file         || return 3
+  cp ${repo_dir}/external/file ${repo_dir}/internal/file || return 4
+
+  echo "create a large file to be chunked"
+  dd if=/dev/urandom of=chunked_file bs=1M count=32 || return 5
+  cp chunked_file ${repo_dir}/chunked_file          || return 6
 
   echo "creating CVMFS snapshot"
-  export CVMFS_LOG_LEVEL=4
   publish_repo $CVMFS_TEST_REPO -v || return $?
 
-  local hash=$(attr -qg hash /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/internal/file)
-  local cache_fname=$(echo $hash | cut -b 1-2)/$(echo $hash | cut -b 3-)
-  local cache_file=/srv/cvmfs/$CVMFS_TEST_REPO/data/$cache_fname
-  if [ ! -e "$cache_file" ]; then
-    return 23
-  fi
-  echo "File in cache is $cache_file"
-  mkdir -p /srv/cvmfs/$CVMFS_TEST_REPO/external
+  echo "Locating internal/file in backend storage"
+  local object_hash=$(get_content_hash ${cvmfs_mnt}/internal/file)
+  local object_file="$(get_local_repo_object $CVMFS_TEST_REPO $object_hash)"
+  [ -f "$object_file" ] || return 7
+  echo "File in backend is $object_file"
 
-  # Verify chunked files are really chunked, readable, and have the correct
-  cp chunked_file /srv/cvmfs/$CVMFS_TEST_REPO/chunked_file
+  local external_storage="$(get_local_repo_storage $CVMFS_TEST_REPO)/external"
+  echo "Creating external storage directory '$external_storage'"
+  mkdir -p $external_storage || return 51
+
+  echo "verify chunked files are really properly chunked and readable"
+  cp chunked_file "$(get_local_repo_storage $CVMFS_TEST_REPO)/chunked_file" || return 52
   local chunked_true_hash=$(cat chunked_file | sha1sum | awk '{print $1;}')
-  local chunked_cvmfs_hash=$(attr -qg hash /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/chunked_file)
-  local chunked_cvmfs_read=$(cat /cvmfs/$CVMFS_TEST_REPO/chunked_file | sha1sum | awk '{print $1;}')
-  local chunk_count=$(attr -qg chunks /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/chunked_file)
-  local chunk_external=$(attr -qg external_file /var/spool/cvmfs/test.cern.ch/rdonly/chunked_file)
-  if [ "x$chunk_external" != "x1" ]; then
+  local chunked_cvmfs_hash=$(get_content_hash ${cvmfs_mnt}/chunked_file)
+  local chunked_cvmfs_read=$(cat ${repo_dir}/chunked_file | sha1sum | awk '{print $1;}')
+  local chunk_count=$(get_chunk_count ${cvmfs_mnt}/chunked_file)
+
+  if ! is_external_file ${cvmfs_mnt}/chunked_file; then
     echo "Chunked file is not marked as external."
     return 24
   fi
@@ -70,40 +78,38 @@ cvmfs_run_test() {
     return 27
   fi
 
-  # Make sure file is NOT in the spool area but instead in the external area
-  mv "$cache_file" /srv/cvmfs/$CVMFS_TEST_REPO/external/file
+  echo "Make sure the file is NOT in the repository storage but instead in the external area"
+  mv "$object_file" ${external_storage}/file || return 52
 
-  verify_external_data
-  local verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
+  echo "Check the external file data"
+  is_external_file ${cvmfs_mnt}/external/file               || return 20
+  [ x"$(cat ${repo_dir}/external/file)" == x"Hello World" ] ||return 22
 
-  # Verify the expected file is in the cache.
-  if [ ! -e "/var/spool/cvmfs/test.cern.ch/cache/$CVMFS_TEST_REPO/$cache_fname" ]; then
-    return 25
-  fi
+  local cache_object="${cvmfs_cache}/$(get_hash_path $object_hash)"
+  echo "Verify the expected file ($cache_object) is in the cache."
+  sudo test -f "$cache_object" || return 53
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
-  echo "overwrite default"
-  start_transaction $CVMFS_TEST_REPO || return $?
-  echo "not external" > /cvmfs/$CVMFS_TEST_REPO/native
-  publish_repo $CVMFS_TEST_REPO -v -N || return $?
-  local is_external=$(attr -qg external_file /cvmfs/$CVMFS_TEST_REPO/native)
-  if [ "x$is_external" != "x0" ]; then
-    return 30
+  echo "publish file that is NOT marked as external (cvmfs_server publish -N)"
+  start_transaction $CVMFS_TEST_REPO       || return $?
+  echo "not external" > ${repo_dir}/native || return 60
+  publish_repo $CVMFS_TEST_REPO -v -N      || return $?
+
+  echo "check that 'native' is NOT external"
+  ! is_external_file ${cvmfs_mnt}/native || return 30
+
+  echo "Remove cached and external copy of the file; only copy"
+  echo "is in the backend storage, which should not be used."
+  mv ${external_storage}/file "$object_file" || return 55
+  sudo rm -f $cache_object                   || return 56
+
+  echo "Make sure access fails without the external copy."
+  if cat ${repo_dir}/external/file; then
+    echo "External file ${repo_dir}/external/file appears to be using internal data."
+    return 57
   fi
 
-  # Remove cached and external copy of the file; only copy is in the spool area,
-  # which should not be used.
-  mv /srv/cvmfs/$CVMFS_TEST_REPO/external/file "$cache_file"
-  rm -f /var/spool/cvmfs/test.cern.ch/cache/$CVMFS_TEST_REPO/$cache_fname
-
-  # Make sure access fails without the external copy.
-  cat /cvmfs/$CVMFS_TEST_REPO/external/file || return 0
-  echo "External file /cvmfs/$CVMFS_TEST_REPO/external/file appears to be using internal data."
-  return 24
+  return 0
 }
-

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -93,6 +93,9 @@ cvmfs_run_test() {
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+  echo "Try reading chunked file (should fail - not served by external yet)"
+  cat ${repo_dir}/chunked_file > /dev/null && return 35
+
   echo "copy chunked file into external storage"
   cp chunked_file "${external_storage}/chunked_file" || return 52
 
@@ -127,6 +130,8 @@ cvmfs_run_test() {
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   echo "publish file that is NOT marked as external (cvmfs_server publish -N)"
   start_transaction $CVMFS_TEST_REPO       || return $?

--- a/test/test_functions
+++ b/test/test_functions
@@ -1195,9 +1195,23 @@ remove_apache_config_file() {
 }
 
 
+get_hash_path() {
+  local object_hash="$1"
+  local object_path="$(echo -n $object_hash | sed -e 's/^\(..\)\(.*\)$/\1\/\2/')"
+  echo "${object_path}"
+}
+
 get_local_repo_storage() {
   local repo_name="$1"
   echo "/srv/cvmfs/${repo_name}"
+}
+
+get_local_repo_object() {
+  local repo_name="$1"
+  local object_hash="$2"
+  local repo_storage="$(get_local_repo_storage $repo_name)"
+  local object_path="$(get_hash_path $object_hash)"
+  echo "${repo_storage}/data/${object_path}"
 }
 
 get_local_repo_url() {
@@ -1226,7 +1240,7 @@ get_object_url() {
   local repo_name="$1"
   local object_hash="$2"
   local repo_url="$(get_repo_url $repo_name)"
-  local object_path="$(echo -n $object_hash | sed -e 's/^\(..\)\(.*\)$/\1\/\2/')"
+  local object_path="$(get_hash_path $object_hash)"
   echo "${repo_url}/data/${object_path}"
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -866,6 +866,42 @@ open_silent_port() {
 }
 
 
+# spawns a mocked HTTP server on a given port and document root location
+# Note: The user is responsible to kill the server process once after usage
+#
+# @param document_root  absolute path to be served via HTTP
+# @param port           http port to be used
+# @param logfile        (optional) where to log the HTTP server's status info
+# @return               PID of HTTP server or >0 on error
+open_http_server() {
+  local document_root="$1"
+  local port="$2"
+  local logfile="${3:=/dev/null}"
+
+  local http_server="${TEST_ROOT}/common/mock_services/http_server.py"
+  local http_pid=
+  local http_sentinel="http://localhost:${port}/http_sentinel"
+
+  # spawning the server
+  http_pid=$(run_background_service $logfile "$http_server -p $port -r $document_root")
+  touch ${document_root}/$(basename $http_sentinel)
+
+  # waiting for the server to come up
+  local timeout=15
+  while ! curl -Is $url ${http_sentinel} | head -n1 | grep "200 OK" >> $logfile 2>&1 && \
+        [ $timeout -gt 0 ]; do
+    sleep 1
+    if ! kill -0 $http_pid > /dev/null 2>&1;then
+      return 1
+    fi
+    timeout=$(( $timeout - 1 ))
+  done
+
+  [ $timeout -gt 0 ] || return 2
+  echo "$http_pid"
+}
+
+
 # checks if a nested catalog is part of the current catalog configuration
 # of the repository
 # @param catalog_path  the catalog root path to be checked


### PR DESCRIPTION
Integration test 615 "External Files" failed on all our platforms - mainly because it assumed to run as a privileged user. Furthermore it contained several code smells that I tried to clean up as good as possible, for example:

* hard coding of **test.cern.ch** repository name and storage paths
* wrong "jargon" usage: "spool area" vs. "backend storage" vs. "cache space"
* unclear comments and log messages
* complicated control flow - making the test hard to read and understand
* many things needed to be DRY-ed up

Since those test cases should also serve as a blue-print how specific features are supposed to be used, we should always try to stay concise and readable when writing them.

Furthermore I added some more checks (in particular for native chunked files) and made use of the `CVMFS_EXTERNAL_URL` client parameter. External data is now served by a mocked python HTTP server from a completely different file system location. This required some refactoring in both integration test 607 and `test_functions` for code reuse as well as the addition of `HTTPRangeServer`.