### PR TITLE
FIX: Do not replicate external chunks.

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1133,7 +1133,8 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
       ", " + flags2hash + "," + flags2compression +
       "FROM chunks, catalog WHERE "
       "chunks.md5path_1=catalog.md5path_1 AND "
-      "chunks.md5path_2=catalog.md5path_2";
+      "chunks.md5path_2=catalog.md5path_2 AND "
+      "(catalog.flags & " + StringifyInt(SqlDirent::kFlagFileExternal) + " = 0)";
   }
   sql += ";";
   Init(database.sqlite_db(), sql);


### PR DESCRIPTION
Currently, `cvmfs_swissknife pull` tries to replicate all chunks: this causes a failure if the chunk is part of an external file.