### PR TITLE
Build with VOMS on relevant platforms.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 2.2.0:
+  * Add VOMS as a build dependency on platforms where it is available.
   * Detect missing 'http:// proxy prefix in chksetup (CVM-979)
   * Remove sudo dependency from Linux packages
   * Fix race when reloading at the same time as evicting data from the cache

--- a/ci/docker/cc7_x86_64/Dockerfile
+++ b/ci/docker/cc7_x86_64/Dockerfile
@@ -22,6 +22,7 @@ RUN         yum -y update && yum -y install                     \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         sysvinit-tools          \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/fedora21_i386/Dockerfile
+++ b/ci/docker/fedora21_i386/Dockerfile
@@ -21,6 +21,7 @@ RUN         yum -y update && yum -y install                     \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         sysvinit-tools          \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/fedora21_x86_64/Dockerfile
+++ b/ci/docker/fedora21_x86_64/Dockerfile
@@ -21,6 +21,7 @@ RUN         yum -y update && yum -y install                     \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         sysvinit-tools          \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/fedora22_i386/Dockerfile
+++ b/ci/docker/fedora22_i386/Dockerfile
@@ -24,6 +24,7 @@ RUN         dnf -y update && dnf -y install                     \
                                         selinux-policy-targeted \
                                         sudo                    \
                                         tree                    \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/fedora22_x86_64/Dockerfile
+++ b/ci/docker/fedora22_x86_64/Dockerfile
@@ -25,6 +25,7 @@ RUN         dnf -y update && dnf -y install                     \
                                         selinux-policy-targeted \
                                         sudo                    \
                                         tree                    \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/fedora23_i386/Dockerfile
+++ b/ci/docker/fedora23_i386/Dockerfile
@@ -25,6 +25,7 @@ RUN         dnf -y update && dnf -y install                     \
                                         selinux-policy-targeted \
                                         sudo                    \
                                         tree                    \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/fedora23_x86_64/Dockerfile
+++ b/ci/docker/fedora23_x86_64/Dockerfile
@@ -25,6 +25,7 @@ RUN         dnf -y update && dnf -y install                     \
                                         selinux-policy-targeted \
                                         sudo                    \
                                         tree                    \
+                                        voms-devel              \
                                         which                   \
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/slc4_i386/Dockerfile
+++ b/ci/docker/slc4_i386/Dockerfile
@@ -53,6 +53,7 @@ RUN        yum -y update && yum -y install                      \
                                         shadow-utils            \
                                         SysVinit                \
                                         unzip                   \
+                                        voms-devel              \
                                         which                   \
                                         zlib
 

--- a/ci/docker/slc5_i386/Dockerfile
+++ b/ci/docker/slc5_i386/Dockerfile
@@ -22,6 +22,7 @@ RUN         yum -y update && yum -y install                     \
                                         SysVinit                \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
+                                        voms-devel              \
                                         which                   \ 
                                         valgrind-devel          \
                                         zlib-devel

--- a/ci/docker/slc5_x86_64/Dockerfile
+++ b/ci/docker/slc5_x86_64/Dockerfile
@@ -23,6 +23,7 @@ RUN         yum -y update && yum -y install                     \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         which                   \
+                                        voms-devel              \
                                         valgrind-devel          \
                                         zlib-devel
 

--- a/ci/docker/slc6_i386/Dockerfile
+++ b/ci/docker/slc6_i386/Dockerfile
@@ -21,8 +21,9 @@ RUN         yum -y update && yum -y install                     \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         sysvinit-tools          \
-                                        which                   \
                                         valgrind-devel          \
+                                        voms-devel              \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/slc6_x86_64/Dockerfile
+++ b/ci/docker/slc6_x86_64/Dockerfile
@@ -22,8 +22,9 @@ RUN         yum -y update && yum -y install                     \
                                         selinux-policy-devel    \
                                         selinux-policy-targeted \
                                         sysvinit-tools          \
-                                        which                   \
                                         valgrind-devel          \
+                                        voms-devel              \
+                                        which                   \
                                         zlib-devel
 
 RUN         useradd sftnight

--- a/ci/docker/ubuntu1204_i386/Dockerfile
+++ b/ci/docker/ubuntu1204_i386/Dockerfile
@@ -18,4 +18,5 @@ RUN         apt-get -y update && apt-get -y install         \
                                               python-dev    \
                                               unzip         \
                                               uuid-dev      \
-                                              valgrind
+                                              valgrind      \
+                                              voms-dev

--- a/ci/docker/ubuntu1204_x86_64/Dockerfile
+++ b/ci/docker/ubuntu1204_x86_64/Dockerfile
@@ -18,4 +18,5 @@ RUN         apt-get -y update && apt-get -y install         \
                                               python-dev    \
                                               unzip         \
                                               uuid-dev      \
-                                              valgrind
+                                              valgrind      \
+                                              voms-dev

--- a/ci/docker/ubuntu1404_i386/Dockerfile
+++ b/ci/docker/ubuntu1404_i386/Dockerfile
@@ -18,4 +18,5 @@ RUN         apt-get -y update && apt-get -y install         \
                                               python-dev    \
                                               unzip         \
                                               uuid-dev      \
-                                              valgrind
+                                              valgrind      \
+                                              voms-dev

--- a/ci/docker/ubuntu1404_x86_64/Dockerfile
+++ b/ci/docker/ubuntu1404_x86_64/Dockerfile
@@ -18,4 +18,5 @@ RUN         apt-get -y update && apt-get -y install         \
                                               python-dev    \
                                               unzip         \
                                               uuid-dev      \
-                                              valgrind
+                                              valgrind      \
+                                              voms-dev

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -2,7 +2,7 @@ Source: cvmfs
 Section: utils
 Priority: extra
 Maintainer: Jakob Blomer <jblomer@cern.ch>
-Build-Depends: debhelper (>= 9), autotools-dev, cmake, libcap-dev, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, libc6-dev, valgrind
+Build-Depends: debhelper (>= 9), autotools-dev, cmake, libcap-dev, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, libc6-dev, valgrind, voms-dev
 Standards-Version: 3.9.3.1
 Homepage: http://cernvm.cern.ch/portal/filesystem
 

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -33,7 +33,11 @@ License: BSD
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 # Build with voms-devel on Fedora / RHEL derivatives.
-%if 0%{?el5} || 0%{?el6} || 0%{?el7} || 0%{?fedora}
+# Note that we *load* VOMS at runtime, not link against it; this means that
+# the produced RPM will not depend on VOMS.
+%if 0%{?suse_version}
+# TODO(bbockelm): figure out solution for VOMS on SUSE.
+%else
 BuildRequires: voms-devel
 %endif
 

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -404,6 +404,8 @@ fi
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog
+* Sat Jan 23 2016 Brian Bockelman <bbockelm@cse.unl.edu> - 2.2.0
+- Build with VOMS support
 * Thu Jan 21 2016 Jakob Blomer <jblomer@cern.ch> - 2.2.0
 - Remove sudo dependency
 * Fri Jan 15 2016 Jakob Blomer <jblomer@cern.ch> - 2.2.0

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -32,6 +32,11 @@ Group: Applications/System
 License: BSD
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+# Build with voms-devel on Fedora / RHEL derivatives.
+%if 0%{?el5} || 0%{?el6} || 0%{?el7} || 0%{?fedora}
+BuildRequires: voms-devel
+%endif
+
 %if 0%{?el5}
 BuildRequires: buildsys-macros
 %endif


### PR DESCRIPTION
We should build with VOMS on platforms where VOMS should be available (definitely RHEL and Fedora; not sure about SUSE).  Otherwise, all the secure CVMFS stuff is disabled.

*Note*: I don't know much about the build environment for the nightlies; something else in the package might need to be adjusted to make sure `voms-devel` is available.