### PR TITLE
FIX: Always disable SIGPIPE.

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -932,13 +932,11 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
       ConfigureCurlHandle(curl_handle, info->pid, info->uid, info->gid,
                           &info->cred_fname, &info->cred_data);
     }
+#endif
     // The download manager disables signal handling in the curl library;
     // as OpenSSL's implementation of TLS will generate a sigpipe in some
-    // error paths, we must explicitly disable SIGPIPE here.  Since SIGPIPE
-    // only appears to happen with HTTPS, we only do this on VOMS builds.
+    // error paths, we must explicitly disable SIGPIPE here.
     signal(SIGPIPE, SIG_IGN);
-
-#endif
   }
 
   if (url.find("@proxy@") != string::npos) {


### PR DESCRIPTION
OpenSSL-induced SIGPIPE can occur on non-VOMS builds if HTTPS is
specified for the CVMFS_EXTERNAL_URL.  So, it must be ignored
unconditionally.