### PR TITLE
Remove mention of libcurl change

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,6 @@
   * Fix race when reloading at the same time as evicting data from the cache
   * Fix cache-control max-age time coming from .cvmfs* files on EL7 (CVM-974)
   * Fix rare deadlock on unmount
-  * Fix ~10% performance hit in download code due to incorrect use of libcurl
   * Fix mistakenly ignoring catalogs during garbage collection (CVM-966)
   * Fix mounting with a read-only cache directory
   * Add user.pubkeys extended attribute


### PR DESCRIPTION
We reverted this change as it caused strange behavior in the CI instances.

(To revisit in next version.)