### PR TITLE
Avoid use-after-free in OpenSSL.

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1116,12 +1116,10 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     info->cred_fname = NULL;
     curl_easy_setopt(info->curl_handle, CURLOPT_SSLCERT, NULL);
     curl_easy_setopt(info->curl_handle, CURLOPT_SSLKEY, NULL);
-    curl_easy_setopt(info->curl_handle, CURLOPT_FRESH_CONNECT, 0);
-    curl_easy_setopt(info->curl_handle, CURLOPT_FORBID_REUSE, 0);
   }
   if (info->cred_data) {
 #ifdef VOMS_AUTHZ
-    ::ReleaseCurlHandle(info->cred_data);
+    ::ReleaseCurlHandle(info->curl_handle, info->cred_data);
 #endif
     info->cred_data = NULL;
   }

--- a/cvmfs/voms_authz/voms_authz.h
+++ b/cvmfs/voms_authz/voms_authz.h
@@ -18,7 +18,7 @@ bool CheckVOMSAuthz(const struct fuse_ctx *ctx, const std::string &);
 
 bool ConfigureCurlHandle(void *curl_handle, pid_t pid, uid_t uid, gid_t gid,
                          char **fname, void **data);
-void ReleaseCurlHandle(void *data);
+void ReleaseCurlHandle(void *curl_handle, void *data);
 
 FILE *GetProxyFile(pid_t pid, uid_t uid, gid_t gid);
 


### PR DESCRIPTION
In the case where a user with a X509 proxy accesses a file
then deletes the proxy and tries to download a second file, the
value of CURLOPT_SSL_CTX_DATA would not be overwritten when the
curl handle object was reused.  The X509 chain in-memory *would*
be deleted, however.

On the second use, the OpenSSL context would be given the invalid
pointer to the X509 chain by libcurl, resulting in a segfault.