### PR TITLE
FIX: Tonight's Integration Test run

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2449,7 +2449,7 @@ _write_info_file() {
   local info_file="${1}.json"
   local info_file_dir="$(get_global_info_v1_path)"
   local info_file_path="${info_file_dir}/${info_file}"
-  local tmp_file=$(mktemp)
+  local tmp_file="${info_file_dir}/${info_file}.txn.$(date +%s)"
 
   cat - > $tmp_file
   chmod 0644 $tmp_file

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5689,7 +5689,7 @@ _run_catalog_migration() {
 
   # more sanity checks
   is_stratum0 $name       || die "This is not a stratum 0 repository"
-  is_root $name           || die "Permission denied: Only root can do that"
+  is_root                 || die "Permission denied: Only root can do that"
   is_in_transaction $name && die "Repository is already in a transaction"
   health_check $name
 
@@ -5803,7 +5803,7 @@ eliminate_hardlinks() {
 
   load_repo_config $name
 
-  is_root $name || die "Permission denied: Only root can do that"
+  is_root || die "Permission denied: Only root can do that"
 
   if [ $force -ne 1 ]; then
     echo "This will break up all hardlink relationships that are currently"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2057,6 +2057,7 @@ create_apache_config_for_endpoint() {
 $(cat_wsgi_config $name $with_wsgi)
 
 KeepAlive On
+AddType application/json .json
 # Translation URL to real pathname
 Alias /cvmfs/${name} ${storage_dir}
 <Directory "${storage_dir}">

--- a/test/common/mock_services/HTTPRangeServer.py
+++ b/test/common/mock_services/HTTPRangeServer.py
@@ -208,7 +208,14 @@ class HTTPRangeRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                              (1 + self.range_to - self.range_from))
         else:
             self.send_header("Content-Length", str(total_length))
-        self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
+
+        mtime = None
+        try:
+            mtime = self.date_time_string(fs.st_mtime)
+        except TypeError:
+            mtime = self.date_time_string()  # HOTFIX: for Python <= 2.4 without
+                                             #         the timestamp parameter
+        self.send_header("Last-Modified", mtime)
         self.end_headers()
         return f
 

--- a/test/common/mock_services/silent_socket.py
+++ b/test/common/mock_services/silent_socket.py
@@ -27,8 +27,6 @@ def print_msg(msg):
 class SilentHandler(SocketServer.BaseRequestHandler):
 	def handle(self):
 		print_msg("(" + str(datetime.datetime.now()) + ") incoming connection: " + str(self.client_address))
-		data = self.request[0].strip()
-		print "   * " + data;
 		time.sleep(100000000)
 
 class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):

--- a/test/src/017-dnstimeout/main
+++ b/test/src/017-dnstimeout/main
@@ -15,6 +15,13 @@ do_faulty_mount() {
               "CVMFS_MAX_RETRIES=0" $@
 }
 
+CVMFS_TEST_017_SILENT_PID=""
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_017_SILENT_PID ] || sudo kill $CVMFS_TEST_017_SILENT_PID
+}
+
+
 cvmfs_run_test() {
   local logfile=$1
 
@@ -32,10 +39,13 @@ cvmfs_run_test() {
   echo "unmounting and cleaning"
   cvmfs_clean || return 2
 
-  echo "starting mocked and silent DNS server"
-  server_pid=$(open_silent_port UDP 53 $logfile)
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
 
-  echo "silent DNS server running as PID $server_pid"
+  echo "run a silent DNS server"
+  CVMFS_TEST_017_SILENT_PID=$(open_silent_port UDP 53 $logfile)
+  if [ $? -ne 0 ]; then return 3; fi
+  echo "silent server started with PID $CVMFS_TEST_017_SILENT_PID"
 
   echo "trying to mount again with unresponsive DNS"
   local milliseconds
@@ -55,7 +65,7 @@ cvmfs_run_test() {
     echo "timeout was too short: $milliseconds (expected at leat $expected_min)"
     retcode=19
   fi
-  
+
   echo "restarting autofs"
   autofs_switch off || return 10
   autofs_switch on  || return 11
@@ -74,9 +84,6 @@ cvmfs_run_test() {
     echo "timeout was too short: $milliseconds (expected at least $expected_min)"
     retcode=20
   fi
-
-  echo "killing the mocked DNS server"
-  sudo kill $server_pid || retcode=6
 
   return $retcode
 }

--- a/test/src/019-httptimeout/main
+++ b/test/src/019-httptimeout/main
@@ -10,12 +10,19 @@ do_faulty_mount() {
               "CVMFS_MAX_RETRIES=0"
 }
 
+CVMFS_TEST_019_SILENT_PID=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_019_SILENT_PID ] || sudo kill $CVMFS_TEST_019_SILENT_PID
+}
+
 cvmfs_run_test() {
   logfile=$1
   local scratch_dir=$(pwd)
   local retcode=0
   local seconds=100
   local http_pid=0
+  local http_port=8019
   local retval=0
 
   echo "restarting autofs"
@@ -23,12 +30,15 @@ cvmfs_run_test() {
   autofs_switch on  || return 11
 
   echo "configure cvmfs with an unreachable and an unresponsive host"
-  sudo sh -c "echo \"CVMFS_SERVER_URL=\\\"http://127.0.1.2:8080;http://127.0.0.1:8000/@org@;http://cvmfs-stratum-one.cern.ch/opt/@org@\\\"\" > /etc/cvmfs/domain.d/cern.ch.local" || return 1
+  sudo sh -c "echo \"CVMFS_SERVER_URL=\\\"http://127.0.1.2:8080;http://127.0.0.1:${http_port}/@org@;http://cvmfs-stratum-one.cern.ch/opt/@org@\\\"\" > /etc/cvmfs/domain.d/cern.ch.local" || return 1
+
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
 
   echo "run a silent HTTP server"
-  http_pid=$(open_silent_port TCP 8000 $logfile)
+  CVMFS_TEST_019_SILENT_PID=$(open_silent_port TCP $http_port $logfile)
   if [ $? -ne 0 ]; then return 2; fi
-  echo "mocked HTTP server started with PID $http_pid"
+  echo "silent server started with PID $CVMFS_TEST_019_SILENT_PID"
 
   echo "try to mount cvmfs"
   milliseconds=$(stop_watch do_faulty_mount)
@@ -44,8 +54,6 @@ cvmfs_run_test() {
   sudo cvmfs_talk -i atlas.cern.ch host info | grep 127.0.0.1 | grep -q "host down"
   local h2=$?
   sudo cvmfs_talk -i atlas.cern.ch host info
-
-  sudo kill $http_pid
 
   [ $h1 -eq 0 ] && [ $h2 -eq 0 ] || retval=5
 

--- a/test/src/020-emptyrepofailover/main
+++ b/test/src/020-emptyrepofailover/main
@@ -8,6 +8,13 @@ do_faulty_mount() {
               "CVMFS_HTTP_PROXY=DIRECT"
 }
 
+
+CVMFS_TEST_020_HTTP_PID=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_020_HTTP_PID ] || sudo kill $CVMFS_TEST_020_HTTP_PID
+}
+
 cvmfs_run_test() {
   logfile=$1
   local scratch_dir=$(pwd)
@@ -19,18 +26,24 @@ cvmfs_run_test() {
   autofs_switch off || return 10
   autofs_switch on  || return 11
 
+  local http_log="${scratch_dir}/http.log"
+  local http_port=8020
+  local http_url="http://127.0.0.1:$http_port"
+
   echo "configure cvmfs with a host serving an empty directory"
-  sudo sh -c "echo \"CVMFS_SERVER_URL=\\\"http://127.0.0.1:8000/@org@;http://cvmfs-stratum-one.cern.ch/opt/@org@\\\"\" > /etc/cvmfs/domain.d/cern.ch.local" || return 1
+  sudo sh -c "echo \"CVMFS_SERVER_URL=\\\"${http_url}/@org@;http://cvmfs-stratum-one.cern.ch/opt/@org@\\\"\" > /etc/cvmfs/domain.d/cern.ch.local" || return 1
 
   echo "create the empty directory to be served"
   mkdir -p empty || return 1
   cd empty       || return 2
 
-  echo "run a simple HTTP server"
-  cmd="python -m SimpleHTTPServer 8000"
-  http_pid=$(run_background_service $logfile "$cmd")
-  if [ $? -ne 0 ]; then return 3; fi
-  echo "simple HTTP server serving empty directory started with PID $http_pid"
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "start an HTTP server to serve external files (logging to $http_log)"
+  CVMFS_TEST_020_HTTP_PID="$(open_http_server ${scratch_dir}/empty $http_port $http_log)"
+  [ ! -z $CVMFS_TEST_020_HTTP_PID ] || kill -0 $CVMFS_TEST_020_HTTP_PID || { echo "fail"; return 3; }
+  echo "HTTP server running with PID $CVMFS_TEST_020_HTTP_PID"
 
   echo "try to mount cvmfs"
   local milliseconds=$(stop_watch do_faulty_mount)
@@ -43,10 +56,6 @@ cvmfs_run_test() {
   sudo cvmfs_talk -i atlas.cern.ch host info | grep 127.0.0.1 | grep -q "host down"
   local h1=$?
   sudo cvmfs_talk -i atlas.cern.ch host info
-
-  echo "killing simple HTTP server"
-  sudo kill $http_pid || retval=5
-
   [ $h1 -eq 0 ] || retval=6
 
   sudo rm -f /etc/cvmfs/domain.d/cern.ch.local || retval=7

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -74,8 +74,8 @@ cvmfs_run_test() {
 
   echo "Force failed mount"
   cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 30
-  sudo sh -c "echo CVMFS_ALT_ROOT_PATH=no >> /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
-  sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
+  sudo sh -c "echo CVMFS_ALT_ROOT_PATH=no >> /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local" || return 51
+  sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"                   || return 52
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO && return 31
 
   echo "Mount latest"

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -85,10 +85,10 @@ cvmfs_run_test() {
   is_external_file ${cvmfs_mnt}/external/file || return 20
   ! cat ${repo_dir}/external/file             || return 22
 
-  echo "start an HTTP server to serve external files"
   local http_log="${scratch_dir}/http.log"
+  echo "start an HTTP server to serve external files (logging to $http_log)"
   CVMFS_TEST_615_HTTP_PID="$(open_http_server $external_storage $http_port $http_log)"
-  kill -0 $CVMFS_TEST_615_HTTP_PID || { echo "fail"; return 4; }
+  [ ! -z $CVMFS_TEST_615_HTTP_PID ] || kill -0 $CVMFS_TEST_615_HTTP_PID || { echo "fail"; return 4; }
   echo "HTTP server running with PID $CVMFS_TEST_615_HTTP_PID"
 
   echo "Check the external file data"

--- a/test/src/620-pullmixedrepo/main
+++ b/test/src/620-pullmixedrepo/main
@@ -45,13 +45,13 @@ EOF
 }
 
 graft_external() {
-  local repo=$1
-  local cvmfs_dir=$2
-  local reference_dir=$3
+  local cvmfs_dir=$1
+  local reference_dir=$2
+  local external_storage=$3
 
-  echo "I'm external" | cvmfs_swissknife zpipe > /srv/cvmfs/${repo}/external_file
-  local hash=$(cat /srv/cvmfs/${repo}/external_file | cvmfs_swissknife hash -a shake128)
-  local size=$(cat /srv/cvmfs/${repo}/external_file | cvmfs_swissknife zpipe -d | wc -c)
+  echo "I'm external" | cvmfs_swissknife zpipe > ${external_storage}/external_file
+  local hash=$(cat ${external_storage}/external_file | cvmfs_swissknife hash -a shake128)
+  local size=$(cat ${external_storage}/external_file | cvmfs_swissknife zpipe -d | wc -c)
   touch ${cvmfs_dir}/external_file
   cat > ${cvmfs_dir}/.cvmfsgraft-external_file << EOF
 checksum=$hash
@@ -60,15 +60,17 @@ EOF
 
   ls -lah $cvmfs_dir
 
-  cvmfs_swissknife zpipe -d < /srv/cvmfs/${repo}/external_file > ${reference_dir}/external_file
+  cvmfs_swissknife zpipe -d < ${external_storage}/external_file > ${reference_dir}/external_file
 }
 
 CVMFS_TEST_620_MOUNTPOINT=
 CVMFS_TEST_620_REPLICA=
+CVMFS_TEST_620_HTTP_PID=
 cleanup() {
   echo "running cleanup()..."
   [ -z $CVMFS_TEST_620_MOUNTPOINT ] || sudo umount $CVMFS_TEST_620_MOUNTPOINT            > /dev/null 2>&1
   [ -z $CVMFS_TEST_620_REPLICA    ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_620_REPLICA > /dev/null 2>&1
+  [ -z $CVMFS_TEST_620_HTTP_PID   ] || sudo kill $CVMFS_TEST_620_HTTP_PID                > /dev/null 2>&1
 }
 
 check_stratum1_tmp_dir_emptiness() {
@@ -99,8 +101,28 @@ cvmfs_run_test() {
   [ -x "$PRELOAD" ] || { echo "fail"; return 1; }
   echo "found ($PRELOAD)"
 
+  local external_storage="${scratch_dir}/external_files"
+  echo "Creating external storage directory '$external_storage'"
+  mkdir -p $external_storage || return 51
+
+  local http_log="${scratch_dir}/http.log"
+  local http_port=8620
+  local external_http_base="http://localhost:$http_port"
+  local client_config="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/client.conf"
+
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "start an HTTP server to serve external files (logging to $http_log)"
+  CVMFS_TEST_620_HTTP_PID="$(open_http_server $external_storage $http_port $http_log)"
+  [ ! -z $CVMFS_TEST_620_HTTP_PID ] || kill -0 $CVMFS_TEST_620_HTTP_PID || { echo "fail"; return 41; }
+  echo "HTTP server running with PID $CVMFS_TEST_620_HTTP_PID"
+
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "configure external data location"
+  echo "CVMFS_EXTERNAL_URL=$external_http_base" | sudo tee --append $client_config
 
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
@@ -122,7 +144,7 @@ cvmfs_run_test() {
 
   echo "graft external file"
   start_transaction $CVMFS_TEST_REPO || return $?
-  graft_external $CVMFS_TEST_REPO $repo_dir $reference_dir || return 20
+  graft_external $repo_dir $reference_dir $external_storage || return 20
   publish_repo $CVMFS_TEST_REPO -X || return $?
 
   echo "compare the results of cvmfs to our reference copy"
@@ -148,9 +170,6 @@ cvmfs_run_test() {
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  echo "install a desaster cleanup"
-  trap cleanup EXIT HUP INT TERM
-
   echo "create Stratum1 repository on the same machine"
   CVMFS_TEST_620_REPLICA=$replica_name
   load_repo_config $CVMFS_TEST_REPO
@@ -169,15 +188,12 @@ cvmfs_run_test() {
   echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || return 9
 
-  echo "copy external file"
-  cp /srv/cvmfs/${CVMFS_TEST_REPO}/external_file /srv/cvmfs/$replica_name/
-
   echo "check that Stratum1 spooler tmp dir is empty"
   check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || return 101
 
   echo "mount the Stratum1 repository on a local mountpoint"
   CVMFS_TEST_620_MOUNTPOINT=$mnt_point
-  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) || return 10
+  do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $replica_name) "" "CVMFS_EXTERNAL_URL=$external_http_base" || return 10
 
   echo "check if the Stratum1 repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || return 11
@@ -187,14 +203,14 @@ cvmfs_run_test() {
   CVMFS_TEST_620_MOUNTPOINT=""
 
   echo "clean up"
-  sudo cvmfs_server rmfs -f $replica_name
+  sudo cvmfs_server rmfs -f $replica_name || return 13
 
   echo "preloading a cache"
-  local preload_dir=/srv/cvmfs/${CVMFS_TEST_REPO}/preloaded
-  $PRELOAD -u "http://localhost/cvmfs/$CVMFS_TEST_REPO" \
-    -r $preload_dir \
-    -k "/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub" \
-    -m "$CVMFS_TEST_REPO" || return $?
+  local preload_dir=${scratch_dir}/preloaded
+  $PRELOAD -u "$(get_repo_url $CVMFS_TEST_REPO)"     \
+           -r $preload_dir                           \
+           -k "/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub" \
+           -m "$CVMFS_TEST_REPO" || return $?
 
   local local_conf=$(pwd)/local.conf
   echo "Create a local configuration file in $local_conf"
@@ -207,6 +223,7 @@ CVMFS_ALIEN_CACHE=$preload_dir
 CVMFS_SERVER_URL=NOAVAIL
 CVMFS_HTTP_PROXY=NOAVAIL
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/$CVMFS_TEST_REPO.pub
+CVMFS_EXTERNAL_URL=$external_http_base
 EOF
 
   echo "Mount the repository in $mnt_point to verify it"

--- a/test/src/624-chunkedexternalgraft/main
+++ b/test/src/624-chunkedexternalgraft/main
@@ -2,9 +2,16 @@
 cvmfs_test_name="Chunked, grafted, uncompressed, external files"
 cvmfs_test_autofs_on_startup=false
 
+CVMFS_TEST_624_HTTP_PID=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_624_HTTP_PID ] || sudo kill $CVMFS_TEST_624_HTTP_PID
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir="$(pwd)"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -X -Z none || return $?
@@ -13,6 +20,26 @@ cvmfs_run_test() {
   dd if=/dev/urandom of=chunks count=16 bs=1M
   local correct_sha1=$(sha1sum chunks | awk '{print $1;}')
 
+  local external_storage="${scratch_dir}/external_files"
+  echo "Creating external storage directory '$external_storage'"
+  mkdir -p $external_storage || return 51
+
+  local http_log="${scratch_dir}/http.log"
+  local http_port=8624
+  local external_http_base="http://localhost:$http_port"
+  local client_config="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/client.conf"
+
+  echo "install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "start an HTTP server to serve external files (logging to $http_log)"
+  CVMFS_TEST_624_HTTP_PID="$(open_http_server $external_storage $http_port $http_log)"
+  [ ! -z $CVMFS_TEST_624_HTTP_PID ] || kill -0 $CVMFS_TEST_624_HTTP_PID || { echo "fail"; return 4; }
+  echo "HTTP server running with PID $CVMFS_TEST_624_HTTP_PID"
+
+  echo "configure external data location"
+  echo "CVMFS_EXTERNAL_URL=$external_http_base" | sudo tee --append $client_config
+
   start_transaction $CVMFS_TEST_REPO || return $?
   cvmfs_swissknife graft -i chunks -o /cvmfs/$CVMFS_TEST_REPO/chunks -c 1
   echo "----- START GRAFT -----"
@@ -20,13 +47,11 @@ cvmfs_run_test() {
   echo "----- END GRAFT -----"
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  # Verify we have an external file.
-  if `sha1sum /cvmfs/$CVMFS_TEST_REPO/chunks > /dev/null`; then
-    return 1
-  fi
+  echo "Verify we have an external file that is not (yet) accessible."
+  sha1sum /cvmfs/$CVMFS_TEST_REPO/chunks > /dev/null && return 1
 
-  # Now the file should be available.
-  cp chunks /srv/cvmfs/$CVMFS_TEST_REPO/chunks
+  echo "Now the file should become available."
+  cp chunks ${external_storage}/chunks || return 2
 
   local chunks=$(attr -qg chunks /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/chunks)
   if [ "$chunks" -ne 16 ]; then

--- a/test/src/626-cacheexpiry/main
+++ b/test/src/626-cacheexpiry/main
@@ -139,10 +139,10 @@ cvmfs_run_test() {
 
   echo "check HTTP headers for /cvmfs/info/v1/meta.json"
   local imurl="${url}/v1/meta.json"
-  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $imurl) ] || return 47
-  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $imurl) ] || return 48
-  [ $(get_max_age $imurl)    -eq $jsonmaxage               ] || return 49
-  [ x"$(get_header $imurl "Content-Type")" = x"$jsontype"  ] || return 50
+  [ $(get_epoch "1 minutes") -lt $(get_expiry_time $imurl) ] || return 51
+  [ $(get_epoch "3 minutes") -gt $(get_expiry_time $imurl) ] || return 52
+  [ $(get_max_age $imurl)    -eq $jsonmaxage               ] || return 53
+  [ x"$(get_header $imurl "Content-Type")" = x"$jsontype"  ] || return 54
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -849,20 +849,18 @@ open_silent_port() {
   local protocol=$1
   local port=$2
   local logfile=$3
-  local pid
   local cmd
-  local retcode
+  local mock
 
-  cmd="sudo python ${TEST_ROOT}/common/mock_services/silent_socket.py $protocol $port"
-  pid=$(run_background_service $logfile "$cmd")
-  retcode=$?
+  mock="python ${TEST_ROOT}/common/mock_services/silent_socket.py $protocol $port"
 
-  if [ $retcode -ne 0 ]; then
-    return $retcode
-  fi
-
-  echo $pid
-  return $retcode
+  # Do similar fifo-trick as in run_background_service() to get the PID of the
+  # actual silent_socket.py process rather than just the `sudo` around it.
+  local fifo="pid_silent_port_fifo"
+  mkfifo $fifo || return 1
+  cmd="sudo sh -c \"echo \\\$\\\$ > $fifo; exec $mock\""
+  run_background_service $logfile "$cmd" > /dev/null 2>&1 || return $?
+  cat $fifo # return the PID of the `python silent_socket.py`
 }
 
 


### PR DESCRIPTION
A problem with SELinux contexts on EL5 (repo meta info files). Furthermore EL5 doesn't know about the mime-type **application/json**, yet. Both fixed in `cvmfs_server`.

Other than that, again mainly test infrastructure improvements, fixes and S3 generalisations. The mock service `silent_socket.py` was producing stack traces and wasn't always cleaned up properly. As a result certain port numbers might have been kept occupied.