### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: cpp
 
 os:
   - linux
-  - osx
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ compiler:
   - gcc
   - clang
 
-sudo: false
-
 addons:
   apt:
     packages:
@@ -32,6 +30,5 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install         ; fi
 
 script:
-  - cd build
-  - make
+  - cd build && cmake -DBUILD_UNITTESTS=yes .. && make
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
       - selinux-policy-devel
       - hardlink
       - selinux-policy-targeted
+      - libattr-devel
 
 before_script:
   - mkdir -p build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 
 os:
   - linux
+  - osx
 
 compiler:
   - gcc
@@ -31,11 +32,17 @@ addons:
       - lldb
 
 before_script:
+  - ulimit -c unlimited -S
   - mkdir -p build
-  - python --version
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install gdb Caskroom/cask/osxfuse ; fi
 
 script:
-  - cd build && cmake -DBUILD_UNITTESTS=yes -DBUILD_PRELOADER=yes .. && make && test/unittests/cvmfs_unittests --gtest_shuffle --gtest_filter="-*Slow:T_Dns.CaresResolverLocalhost:T_Dns.NormalResolverCombined"
-  - ../ci/run_cpplint.sh
+  - ci/run_cpplint.sh
+  # make -j stresses the memory of travis
+  - cd build && cmake -DBUILD_UNITTESTS=yes -DBUILD_PRELOADER=yes .. && make
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$PWD/externals/build_tbb/build_release ; fi
+  - test/unittests/cvmfs_unittests --gtest_shuffle --gtest_filter="-*Slow:T_Dns.CaresResolverLocalhost:T_Dns.NormalResolverCombined:T_Dns.CaresResolverMany"
 
+
+after_failure:
+  - echo "t a a bt" | gdb -ex run --args test/unittests/cvmfs_unittests --gtest_shuffle --gtest_filter="-*Slow:T_Dns.CaresResolverLocalhost:T_Dns.NormalResolverCombined:T_Dns.CaresResolverMany"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+
+language: cpp
+
+os:
+  - linux
+
+compiler:
+  - gcc
+  - clang
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libuuid-devel
+      - gcc-c++
+      - fuse-devel
+      - libattr-devel
+      - openssl-devel
+      - patch
+      - pkgconfig
+      - python-devel
+      - unzip
+      - checkpolicy
+      - selinux-policy-devel
+      - hardlink
+      - selinux-policy-targeted
+
+before_script:
+  - mkdir -p build
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install         ; fi
+
+script:
+  - cd build
+  - make
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 
 os:
   - linux
+  - osx
 
 compiler:
   - gcc
@@ -31,16 +32,14 @@ addons:
       - lldb
 
 before_script:
-  - ulimit -c unlimited -S
   - mkdir -p build
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install gdb Caskroom/cask/osxfuse ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install Caskroom/cask/osxfuse ; fi
 
 script:
   - ci/run_cpplint.sh
-  # make -j stresses the memory of travis
-  - cd build && cmake -DBUILD_UNITTESTS=yes -DBUILD_PRELOADER=yes .. && make
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$PWD/externals/build_tbb/build_release ; fi
-  - test/unittests/cvmfs_unittests --gtest_shuffle --gtest_filter="-*Slow:T_Dns.CaresResolverLocalhost:T_Dns.NormalResolverCombined:T_Dns.CaresResolverMany"
+  - cd build && cmake -DBUILD_UNITTESTS=yes -DBUILD_PRELOADER=yes .. && make   # make -j stresses the memory of travis
+  # running the unit tests on mac fails because travis osx machines have limited resources
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test/unittests/cvmfs_unittests --gtest_shuffle --gtest_filter="-*Slow:T_Dns.CaresResolverLocalhost:T_Dns.NormalResolverCombined:T_Dns.CaresResolverMany" ; fi
 
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ addons:
 
 before_script:
   - mkdir -p build
+  - sudo apt-get install libattr-devel fuse-devel pkgconfig python-devel
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ compiler:
   - gcc
   - clang
 
+sudo: required
+
 addons:
   apt:
     packages:
@@ -27,7 +29,7 @@ addons:
 
 before_script:
   - mkdir -p build
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install         ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
 
 script:
   - cd build && cmake -DBUILD_UNITTESTS=yes .. && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,29 @@ sudo: required
 addons:
   apt:
     packages:
-      - libuuid-devel
-      - gcc-c++
-      - fuse-devel
-      - libattr-devel
-      - openssl-devel
+      - autotools-dev
+      - libcap-dev
+      - libssl-dev
+      - g++
+      - libfuse-dev
+      - pkg-config
+      - libattr1-dev
       - patch
-      - pkgconfig
-      - python-devel
+      - python-dev
       - unzip
-      - checkpolicy
-      - selinux-policy-devel
-      - hardlink
-      - selinux-policy-targeted
-      - libattr-devel
+      - uuid-dev
+      - libc6-dev
+      - valgrind
+      - voms-dev
+      - gdb
+      - lldb
 
 before_script:
   - mkdir -p build
-  - sudo apt-get install libattr-devel fuse-devel pkgconfig python-devel
+  - python --version
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
 
 script:
-  - cd build && cmake -DBUILD_UNITTESTS=yes .. && make
+  - cd build && cmake -DBUILD_UNITTESTS=yes -DBUILD_PRELOADER=yes .. && make && test/unittests/cvmfs_unittests --gtest_shuffle --gtest_filter="-*Slow:T_Dns.CaresResolverLocalhost:T_Dns.NormalResolverCombined"
+  - ../ci/run_cpplint.sh
 

--- a/ci/run_cpplint.sh
+++ b/ci/run_cpplint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # This script runs the CppLint program and checks the general code style
@@ -42,4 +42,4 @@ SOURCE_DIRS="cvmfs mount test/unittests"
 cd $REPO_ROOT
 FILE_LIST="$(find $SOURCE_DIRS -type f -not -name '\._*' -and \( -name '*.h' -or -name '*.cc' -or -name '*.hpp' -or -name '*.c' \))"
 python $CPPLINT ${FILE_LIST} | tee ${SCRIPT_OUTPUT}
-
+exit ${PIPESTATUS[0]}

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1134,7 +1134,8 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
       "FROM chunks, catalog WHERE "
       "chunks.md5path_1=catalog.md5path_1 AND "
       "chunks.md5path_2=catalog.md5path_2 AND "
-      "(catalog.flags & " + StringifyInt(SqlDirent::kFlagFileExternal) + " = 0)";
+      "(catalog.flags & " + StringifyInt(SqlDirent::kFlagFileExternal) +
+      " = 0)";
   }
   sql += ";";
   Init(database.sqlite_db(), sql);

--- a/test/unittests/t_history.cc
+++ b/test/unittests/t_history.cc
@@ -19,7 +19,7 @@ using history::SqliteHistory;
 template <class HistoryT>
 class T_History : public ::testing::Test {
  protected:
-  static const std::string sandbox;
+  static const char sandbox[];
   static const std::string fqrn;
 
   static const std::string history_v1_r0;
@@ -34,7 +34,8 @@ class T_History : public ::testing::Test {
  protected:
   virtual void SetUp() {
     if (NeedsSandbox()) {
-      ASSERT_TRUE(MkdirDeep(sandbox, 0700)) << "failed to create sandbox";
+      ASSERT_TRUE(MkdirDeep(string(sandbox), 0700))
+                  << "failed to create sandbox";
       PrepareLegacyHistoryDBs();
     }
     prng_.InitSeed(42);
@@ -42,7 +43,7 @@ class T_History : public ::testing::Test {
 
   virtual void TearDown() {
     if (NeedsSandbox()) {
-      const bool retval = RemoveTree(sandbox);
+      const bool retval = RemoveTree(string(sandbox));
       ASSERT_TRUE(retval) << "failed to remove sandbox";
     }
 
@@ -160,7 +161,7 @@ class T_History : public ::testing::Test {
   std::string GetHistoryFilename() const {
     std::string path;
     if (NeedsSandbox()) {
-      path = CreateTempPath(sandbox + "/history", 0600);
+      path = CreateTempPath(string(sandbox) + "/history", 0600);
     } else {
       do {
         path = StringifyInt(prng_.Next(123652348));
@@ -304,18 +305,18 @@ class T_History : public ::testing::Test {
 };
 
 template <class HistoryT>
-const std::string T_History<HistoryT>::sandbox = "./cvmfs_ut_history";
+const char T_History<HistoryT>::sandbox[] = "./cvmfs_ut_history";
 
 template <class HistoryT>
 const std::string T_History<HistoryT>::fqrn    = "test.cern.ch";
 
 template <class HistoryT>
 const std::string T_History<HistoryT>::history_v1_r0_path =
-  T_History<HistoryT>::sandbox + "/history_v1_r0";
+  string(T_History<HistoryT>::sandbox) + "/history_v1_r0";
 
 template <class HistoryT>
 const std::string T_History<HistoryT>::history_v1_r1_path =
-  T_History<HistoryT>::sandbox + "/history_v1_r1";
+  string(T_History<HistoryT>::sandbox) + "/history_v1_r1";
 
 template <class HistoryT>
 const std::string T_History<HistoryT>::history_v1_r0 =

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -21,18 +21,32 @@ using namespace std;  // NOLINT
 
 template <class ObjectFetcherT>
 class T_ObjectFetcher : public ::testing::Test {
+ public:
+  T_ObjectFetcher()
+  : sandbox(GetCurrentWorkingDirectory() + "/cvmfs_ut_object_fetcher"),
+    fqrn("test.cern.ch"),
+    backend_storage(sandbox + "/backend"),
+    backend_storage_dir(sandbox + "/backend/data"),
+    manifest_path(backend_storage + "/.cvmfspublished"),
+    whitelist_path(backend_storage + "/.cvmfswhitelist"),
+    temp_directory(sandbox + "/tmp"),
+    public_key_path(sandbox + "/" + fqrn + ".pub"),
+    private_key_path(sandbox + "/" + fqrn + ".key"),
+    certificate_path(sandbox + "/" + fqrn + ".crt"),
+    master_key_path(sandbox + "/" + fqrn + ".masterkey") { }
+
  protected:
-  static const std::string  sandbox;
-  static const std::string  fqrn;
-  static const std::string  backend_storage;
-  static const std::string  backend_storage_dir;
-  static const std::string  manifest_path;
-  static const std::string  whitelist_path;
-  static const std::string  temp_directory;
-  static const std::string  public_key_path;
-  static const std::string  private_key_path;
-  static const std::string  certificate_path;
-  static const std::string  master_key_path;
+  const std::string  sandbox;
+  const std::string  fqrn;
+  const std::string  backend_storage;
+  const std::string  backend_storage_dir;
+  const std::string  manifest_path;
+  const std::string  whitelist_path;
+  const std::string  temp_directory;
+  const std::string  public_key_path;
+  const std::string  private_key_path;
+  const std::string  certificate_path;
+  const std::string  master_key_path;
   static const unsigned int catalog_revision;
 
   static const shash::Any broken_history_hash;
@@ -589,53 +603,6 @@ class T_ObjectFetcher : public ::testing::Test {
   download::DownloadManager    download_manager_;
   signature::SignatureManager  signature_manager_;
 };
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::sandbox =
-  GetCurrentWorkingDirectory() + "/cvmfs_ut_object_fetcher";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::fqrn = "test.cern.ch";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::backend_storage =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/backend";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::backend_storage_dir =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/backend/data";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::manifest_path =
-  T_ObjectFetcher<ObjectFetcherT>::backend_storage + "/.cvmfspublished";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::whitelist_path =
-  T_ObjectFetcher<ObjectFetcherT>::backend_storage + "/.cvmfswhitelist";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::temp_directory =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/tmp";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::public_key_path =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/" +
-  T_ObjectFetcher<ObjectFetcherT>::fqrn + ".pub";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::private_key_path =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/" +
-  T_ObjectFetcher<ObjectFetcherT>::fqrn + ".key";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::certificate_path =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/" +
-  T_ObjectFetcher<ObjectFetcherT>::fqrn + ".crt";
-
-template <class ObjectFetcherT>
-const std::string T_ObjectFetcher<ObjectFetcherT>::master_key_path =
-  T_ObjectFetcher<ObjectFetcherT>::sandbox + "/" +
-  T_ObjectFetcher<ObjectFetcherT>::fqrn + ".masterkey";
 
 template <class ObjectFetcherT>
 const unsigned int T_ObjectFetcher<ObjectFetcherT>::catalog_revision = 1;

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -526,7 +526,7 @@ class T_Uploaders : public FileSandbox {
         "CVMFS_S3_BUCKET=testbucket\n"
         "CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS=" +
         StringifyInt(parallel_connections) + "\n"
-        "CVMFS_S3_HOST=localhost\n"
+        "CVMFS_S3_HOST=127.0.0.1\n"
         "CVMFS_S3_PORT=" + StringifyInt(CVMFS_S3_TEST_MOCKUP_SERVER_PORT);
 
     fprintf(s3_conf, "%s\n", conf_str.c_str());

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -74,7 +74,7 @@ class UploadCallbacks {
 template <class UploadersT>
 class T_Uploaders : public FileSandbox {
  private:
-  static const std::string sandbox_path;
+  static const char sandbox_path[];
   static const std::string dest_dir;
   static const std::string tmp_dir;
   std::string repo_alias;
@@ -95,7 +95,8 @@ class T_Uploaders : public FileSandbox {
   typedef std::vector<CharBuffer*>                       Buffers;
   typedef std::vector<std::pair<Buffers, StreamHandle> > BufferStreams;
 
-  T_Uploaders() : FileSandbox(T_Uploaders::sandbox_path), uploader_(NULL) {}
+  T_Uploaders() : FileSandbox(string(T_Uploaders::sandbox_path)),
+                  uploader_(NULL) {}
 
  protected:
   AbstractUploader *uploader_;
@@ -593,15 +594,15 @@ template <class UploadersT>
 atomic_int64 T_Uploaders<UploadersT>::gSeed = 0;
 
 template <class UploadersT>
-const std::string T_Uploaders<UploadersT>::sandbox_path = "./cvmfs_ut_uploader";
+const char T_Uploaders<UploadersT>::sandbox_path[] = "./cvmfs_ut_uploader";
 
 template <class UploadersT>
 const std::string T_Uploaders<UploadersT>::tmp_dir =
-    T_Uploaders::sandbox_path + "/tmp";
+    string(T_Uploaders::sandbox_path) + "/tmp";
 
 template <class UploadersT>
 const std::string T_Uploaders<UploadersT>::dest_dir =
-    T_Uploaders::sandbox_path + "/dest";
+    string(T_Uploaders::sandbox_path) + "/dest";
 
 typedef testing::Types<S3Uploader, LocalUploader> UploadTypes;
 TYPED_TEST_CASE(T_Uploaders, UploadTypes);


### PR DESCRIPTION
This PR:
- Includes a .travis.yml file for the synchronization with https://travis-ci.org/ which builds in Linux (Ubuntu 12.04) and OS X (Maveriks) with both gcc and clang. It runs the unit tests only on Linux due to diverse problems on OS X machines.
- Fixes the return value of ci/cpplint.sh in order to stop the build in travis if there are failures.
- Fixes different _static const std::string_ in the unit tests that did not allow the unit tests to pass on travis when compiling with clang