### PR TITLE
FIX: Tonight's Integration Test run

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -34,7 +34,7 @@ CVMFS_UPDATEGEO_HOUR=10 # First hour of day for update, 0-23, default 10am
 CVMFS_UPDATEGEO_MINDAYS=25 # Minimum days between update attempts
 CVMFS_UPDATEGEO_MAXDAYS=100 # Maximum days old before considering it an error
 
-CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:=http://geolite.maxmind.com/download/geoip/database}"
+CVMFS_UPDATEGEO_URLBASE="http://geolite.maxmind.com/download/geoip/database"
 CVMFS_UPDATEGEO_URLBASE6="${CVMFS_UPDATEGEO_URLBASE}/GeoLiteCityv6-beta"
 CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo"
 CVMFS_UPDATEGEO_DAT="GeoLiteCity.dat"

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -33,9 +33,6 @@ FAKE_S3_CONFIG=/etc/cvmfs/fakes3.conf
 FAKE_S3_BUCKET=cvmfs_test
 FAKE_S3_URL=http://localhost:${FAKE_S3_PORT}/${FAKE_S3_BUCKET}-1-1
 
-# download GeoIP database from a copy at CERN instead of directly from MaxMind
-export CVMFS_UPDATEGEO_URLBASE="https://ecsft.cern.ch/dist/cvmfs/geodb"
-
 usage() {
   local msg=$1
 
@@ -85,6 +82,12 @@ if [ x$SOURCE_DIRECTORY      = "x" ] ||
   echo "missing parameter(s), cannot run platform dependent test script"
   exit 100
 fi
+
+sudo tee /etc/cvmfs/cvmfs_server_hooks.sh << EOF
+# download GeoIP database from a copy at CERN instead of directly from MaxMind
+CVMFS_UPDATEGEO_URLBASE="https://ecsft.cern.ch/dist/cvmfs/geodb"
+CVMFS_UPDATEGEO_URLBASE6="${CVMFS_UPDATEGEO_URLBASE}/GeoLiteCityv6-beta"
+EOF
 
 CLIENT_TEST_LOGFILE="${LOG_DIRECTORY}/test_client.log"
 SERVER_TEST_LOGFILE="${LOG_DIRECTORY}/test_server.log"

--- a/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
@@ -8,11 +8,6 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo "updating installed RPM packages..."
 sudo dnf -y update || die "fail (dnf update)"
 
-# disable SELinux (OverlayFS doesn't support it)
-echo -n "set SELinux into permissive mode..."
-sudo setenforce 0 || die "fail"
-echo "done"
-
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -35,6 +35,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
+                                 src/602-libcvmfs                             \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -165,7 +165,7 @@ cvmfs_run_test() {
 
   # mount a repository
   echo "mounting sft.cern.ch and cernvm-prod.cern.ch"
-  cvmfs_mount sft.cern.ch,cernvm-prod.cern.ch "CVMFS_KCACHE_TIMEOUT=10" "CVMFS_DEBUGLOG=/tmp/hotpatch_test.log" || return 7
+  cvmfs_mount sft.cern.ch,cernvm-prod.cern.ch "CVMFS_KCACHE_TIMEOUT=10" || return 7
 
   # do some hammering on the file system (without interruption)
   echo "tar $src_dir (without interruption)"

--- a/test/src/529-ripemd160/main
+++ b/test/src/529-ripemd160/main
@@ -52,14 +52,14 @@ cvmfs_run_test() {
 
   echo "checking repository health after recreating nested catalog structure"
   check_repository $CVMFS_TEST_REPO -i || return $?
+  load_repo_config $CVMFS_TEST_REPO
 
   find /cvmfs/$CVMFS_TEST_REPO -type f -exec cat {} \; >/dev/null || return 10
-  sudo find /var/spool/cvmfs/$CVMFS_TEST_REPO/cache -type f | grep rmd160 || return 11
+  sudo find $CVMFS_CACHE_BASE -type f | grep rmd160 || return 11
 
   local mnt_point="$(pwd)/mountpoint"
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   echo "create Stratum1 repository on the same machine"
-  load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \

--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -24,10 +24,12 @@ produce_files_in() {
 
 CVMFS_TEST_537_REPO_CREATED=0
 CVMFS_TEST_537_SELINUX_DISABLED=0
+CVMFS_TEST_537_ALT_BACKEND=
 cleanup() {
   echo "running cleanup..."
   [ $CVMFS_TEST_537_REPO_CREATED     -eq 0 ] || destroy_repo $CVMFS_TEST_REPO
   [ $CVMFS_TEST_537_SELINUX_DISABLED -eq 0 ] || sudo setenforce 1
+  [ -z $CVMFS_TEST_537_ALT_BACKEND         ] || sudo rm -fR $CVMFS_TEST_537_ALT_BACKEND
 }
 
 cvmfs_run_test() {
@@ -40,7 +42,8 @@ cvmfs_run_test() {
   local reference_dir=$scratch_dir/reference_dir
 
   local backend_dir="/srv/cvmfs/${CVMFS_TEST_REPO}"
-  local symlink_destination="${scratch_dir}/backend"
+  local alternative_backend="/opt/cvmfs"
+  local symlink_destination="${alternative_backend}/${CVMFS_TEST_REPO}"
 
   echo "create a symlink for the backend storage of $CVMFS_TEST_REPO"
   destroy_repo $CVMFS_TEST_REPO && echo "-> removed previous $CVMFS_TEST_REPO"
@@ -49,7 +52,9 @@ cvmfs_run_test() {
     sudo rm -fR $backend_dir || { echo "fail!"; return 1; }
     echo "done"
   fi
-  mkdir $symlink_destination || return 2
+  CVMFS_TEST_537_ALT_BACKEND="$alternative_backend"
+  sudo mkdir -p $symlink_destination || return 2
+  sudo chown $CVMFS_TEST_USER:$CVMFS_TEST_USER $symlink_destination || return 2
   sudo ln --symbolic $symlink_destination $backend_dir || return 3
 
   echo "register cleanup trap"

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -14,11 +14,13 @@ produce_files_in() {
 CVMFS_TEST_538_SELINUX_DISABLED=0
 CVMFS_TEST_538_S1_NAME=
 CVMFS_TEST_538_MOUNTPOINT=
+CVMFS_TEST_538_ALT_BACKEND=
 cleanup() {
   echo "running cleanup..."
   [ $CVMFS_TEST_538_SELINUX_DISABLED -eq 0 ] || sudo setenforce 1
   [ -z $CVMFS_TEST_538_S1_NAME ]             || sudo cvmfs_server rmfs -f $CVMFS_TEST_538_S1_NAME
   [ -z $CVMFS_TEST_538_MOUNTPOINT ]          || sudo umount $CVMFS_TEST_538_MOUNTPOINT
+  [ -z $CVMFS_TEST_538_ALT_BACKEND         ] || sudo rm -fR $CVMFS_TEST_538_ALT_BACKEND
 }
 
 cvmfs_run_test() {
@@ -34,7 +36,8 @@ cvmfs_run_test() {
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
 
   local backend_dir="/srv/cvmfs/${replica_name}"
-  local symlink_destination="${scratch_dir}/backend"
+  local alternative_backend="/opt/cvmfs"
+  local symlink_destination="${alternative_backend}/${replica_name}"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -66,7 +69,9 @@ cvmfs_run_test() {
     sudo rm -fR $backend_dir || { echo "fail!"; return 5; }
     echo "done"
   fi
-  mkdir $symlink_destination || return 6
+  CVMFS_TEST_538_ALT_BACKEND="$alternative_backend"
+  sudo mkdir -p $symlink_destination || return 6
+  sudo chown $CVMFS_TEST_USER:$CVMFS_TEST_USER $symlink_destination || return 6
   sudo ln --symbolic $symlink_destination $backend_dir || return 7
 
   echo "register cleanup trap"

--- a/test/src/588-sha256/main
+++ b/test/src/588-sha256/main
@@ -55,15 +55,15 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "checking repository health after recreating nested catalog structure"
+  load_repo_config $CVMFS_TEST_REPO
   check_repository $CVMFS_TEST_REPO -i || return $?
 
   find /cvmfs/$CVMFS_TEST_REPO -type f -exec cat {} \; >/dev/null || return 10
-  sudo find /var/spool/cvmfs/$CVMFS_TEST_REPO/cache -type f | grep sha256 || return 11
+  sudo find $CVMFS_CACHE_BASE -type f | grep sha256 || return 11
 
   local mnt_point="$(pwd)/mountpoint"
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   echo "create Stratum1 repository on the same machine"
-  load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \

--- a/test/src/601-shake128/main
+++ b/test/src/601-shake128/main
@@ -51,15 +51,15 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "checking repository health after recreating nested catalog structure"
+  load_repo_config $CVMFS_TEST_REPO
   check_repository $CVMFS_TEST_REPO -i || return $?
 
   find /cvmfs/$CVMFS_TEST_REPO -type f -exec cat {} \; >/dev/null || return 10
-  sudo find /var/spool/cvmfs/$CVMFS_TEST_REPO/cache -type f | grep shake128 || return 11
+  sudo find $CVMFS_CACHE_BASE -type f | grep shake128 || return 11
 
   local mnt_point="$(pwd)/mountpoint"
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   echo "create Stratum1 repository on the same machine"
-  load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -55,10 +55,15 @@ cvmfs_run_test() {
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+  echo "load repository config to find the repository's cache location"
+  load_repo_config $CVMFS_TEST_REPO
+  local cache_location="${CVMFS_CACHE_BASE}/${CVMFS_TEST_REPO}"
+  echo "cache is at '${cache_location}'"
+
   echo "unmount both union fs and cvmfs"
   cvmfs_suid_helper rw_umount $CVMFS_TEST_REPO || return 10
   cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 11
-  sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
+  sudo rm -rf "$cache_location"
 
   echo "replace .cvmfsalt symlinks by the actual backend files"
   local f
@@ -67,20 +72,20 @@ cvmfs_run_test() {
     sudo rm -f $l
     sudo mv $f $l
   done
-  sudo sh -c "echo CVMFS_ALT_ROOT_PATH=yes >> /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
+  sudo sh -c "echo CVMFS_ALT_ROOT_PATH=yes >> ${CVMFS_SPOOL_DIR}/client.local"
 
   echo "Mount with fixed root hash"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return 12
 
   echo "Force failed mount"
   cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 30
-  sudo sh -c "echo CVMFS_ALT_ROOT_PATH=no >> /var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local" || return 51
-  sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"                   || return 52
+  sudo sh -c "echo CVMFS_ALT_ROOT_PATH=no >> ${CVMFS_SPOOL_DIR}/client.local" || return 51
+  sudo rm -rf "$cache_location"                                               || return 52
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO && return 31
 
   echo "Mount latest"
-  sudo rm -rf "/var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO}"
-  sudo rm -f "/var/spool/cvmfs/${CVMFS_TEST_REPO}/client.local"
+  sudo rm -rf "$cache_location"
+  sudo rm -f "${CVMFS_SPOOL_DIR}/client.local"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return 14
 
   return 0

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -36,7 +36,7 @@ cvmfs_run_test() {
   echo "get some global base paths and configs"
   load_repo_config $CVMFS_TEST_REPO
   local cvmfs_mnt="${CVMFS_SPOOL_DIR}/rdonly"
-  local cvmfs_cache="${CVMFS_SPOOL_DIR}/cache/$CVMFS_TEST_REPO"
+  local cvmfs_cache="${CVMFS_CACHE_BASE}/$CVMFS_TEST_REPO"
   local http_port=8615
   local external_http_base="http://localhost:$http_port"
   local client_config="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/client.conf"

--- a/test/src/617-uncompressed/main
+++ b/test/src/617-uncompressed/main
@@ -66,7 +66,8 @@ cvmfs_run_test() {
   compare_directories $repo_dir $reference_dir $CVMFS_TEST_REPO || return $?
 
   echo "validating the cvmfs cache"
-  sudo cvmfs_fsck /var/spool/cvmfs/${CVMFS_TEST_REPO}/cache/${CVMFS_TEST_REPO} || return 30
+  load_repo_config $CVMFS_TEST_REPO
+  sudo cvmfs_fsck ${CVMFS_CACHE_BASE}/${CVMFS_TEST_REPO} || return 30
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?

--- a/test/src/619-sha3/main
+++ b/test/src/619-sha3/main
@@ -55,15 +55,15 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   echo "checking repository health after recreating nested catalog structure"
+  load_repo_config $CVMFS_TEST_REPO
   check_repository $CVMFS_TEST_REPO -i || return $?
 
   find /cvmfs/$CVMFS_TEST_REPO -type f -exec cat {} \; >/dev/null || return 10
-  sudo find /var/spool/cvmfs/$CVMFS_TEST_REPO/cache -type f | grep sha3 || return 11
+  sudo find $CVMFS_CACHE_BASE -type f | grep sha3 || return 11
 
   local mnt_point="$(pwd)/mountpoint"
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
   echo "create Stratum1 repository on the same machine"
-  load_repo_config $CVMFS_TEST_REPO
   create_stratum1 $replica_name                          \
                   $CVMFS_TEST_USER                       \
                   $CVMFS_STRATUM0                        \


### PR DESCRIPTION
Adapting the `CVMFS_UPDATEGEO_URLBASE` injection, for less intrusive testing. Removing the debug log from the migration test. Fix 537 and 538 on Fedora (Apache cannot access `/tmp` for "a reason"). Switching on SELinux on Fedora 23 (and hoping that we can properly cope with it). Fixing 610 and 615 on platforms with a modified server client-cache (hard coded stuff always bites you... always!).