### PR TITLE
FIX: Increase time margin for integration test 603

### DIFF
--- a/test/src/603-automaticgarbagecollectionrace/main
+++ b/test/src/603-automaticgarbagecollectionrace/main
@@ -70,6 +70,8 @@ cvmfs_run_test() {
   local seconds=30
   local thresh_seconds=60 # Potential Race: Publishing is not supposed to take
                           #                 longer than thresh_seconds-seconds !
+                          #
+                          # Note: thresh_seconds should be 2 * seconds
 
   echo "create the culprit file"
   echo "I was pre-maturely deleted by 2.1.20 and 2.2.0-prerelease" > $culprit

--- a/test/src/603-automaticgarbagecollectionrace/main
+++ b/test/src/603-automaticgarbagecollectionrace/main
@@ -67,8 +67,8 @@ cvmfs_run_test() {
   local root_catalog3=""
   local root_catalog4=""
 
-  local seconds=10
-  local thresh_seconds=20 # Potential Race: Publishing is not supposed to take
+  local seconds=30
+  local thresh_seconds=60 # Potential Race: Publishing is not supposed to take
                           #                 longer than thresh_seconds-seconds !
 
   echo "create the culprit file"


### PR DESCRIPTION
The test 603 this a regression test for [CVM-942](https://sft.its.cern.ch/jira/browse/CVM-942) - thus it tries to exploit a race condition. Turns out that we've lost the race several times when running it on OpenStack. This is supposed to increase the available time margin by a factor of 3.