### PR TITLE
FIX: Tonight's Integration Test Run - Hopefully the Last

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1277,23 +1277,6 @@ try_mount_remount_cycle_aufs() {
   return 0
 }
 
-# test the mount, remount, unmount cycle (overlayfs version)
-# @returns  0 if the whole cycle worked as expected
-try_mount_remount_cycle_overlayfs() {
-  local tmpdir
-  local overlayfs_name
-  tmpdir=$(mktemp -d)
-  overlayfs_name="$(get_overlayfs_name)"
-  mkdir ${tmpdir}/a ${tmpdir}/b ${tmpdir}/c ${tmpdir}/d
-  mount -t $overlayfs_name \
-    -o upperdir=${tmpdir}/b,lowerdir=${tmpdir}/a,workdir=${tmpdir}/c,ro,context=system_u:object_r:default_t:s0 \
-    try_remount_overlayfs ${tmpdir}/d  > /dev/null 2>&1 || return 1
-  mount -o remount,rw ${tmpdir}/d > /dev/null 2>&1 || { _cleanup_tmrc $tmpdir; return 2; }
-  mount -o remount,ro ${tmpdir}/d > /dev/null 2>&1 || { _cleanup_tmrc $tmpdir; return 3; }
-  _cleanup_tmrc $tmpdir
-  return 0
-}
-
 
 # download a given file from the backend storage
 # @param noproxy  (optional)
@@ -2291,9 +2274,6 @@ setup_and_mount_new_repository() {
   if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
     local overlayfs_name="$(get_overlayfs_name)"
     echo -n "($overlayfs_name) "
-    if has_selinux && try_mount_remount_cycle_overlayfs; then
-      selinux_context=",context=\"system_u:object_r:default_t:s0\""
-    fi
     if [ x"$(get_overlayfs_type)" = x"$OFS_POST_V22" ]; then
       ofs_workdir=",workdir=${ofs_workdir}"
     else
@@ -2301,7 +2281,7 @@ setup_and_mount_new_repository() {
     fi
     cat >> /etc/fstab << EOF
 cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
-${overlayfs_name}_$name /cvmfs/$name $overlayfs_name upperdir=${scratch_dir},lowerdir=${rdonly_dir}$ofs_workdir,noauto,ro$selinux_context 0 0 # added by CernVM-FS for $name
+${overlayfs_name}_$name /cvmfs/$name $overlayfs_name upperdir=${scratch_dir},lowerdir=${rdonly_dir}$ofs_workdir,noauto,ro 0 0 # added by CernVM-FS for $name
 EOF
   else
     echo -n "(aufs) "

--- a/cvmfs/voms_authz/voms_authz.cc
+++ b/cvmfs/voms_authz/voms_authz.cc
@@ -442,7 +442,7 @@ bool CheckVOMSAuthz(const struct fuse_ctx *ctx, const std::string & authz) {
     LogCvmfs(kLogVoms, kLogDebug, "Using cached VOMS credentials.");
   }
   if (!voms_ptr) {
-    LogCvmfs(kLogVoms, , kLogSyslog | kLogDebug,
+    LogCvmfs(kLogVoms, kLogSyslog | kLogDebug,
              "ERROR: Failed to generate VOMS data.");
     return false;
   }

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -86,7 +86,7 @@ fi
 sudo tee /etc/cvmfs/cvmfs_server_hooks.sh << EOF
 # download GeoIP database from a copy at CERN instead of directly from MaxMind
 CVMFS_UPDATEGEO_URLBASE="https://ecsft.cern.ch/dist/cvmfs/geodb"
-CVMFS_UPDATEGEO_URLBASE6="${CVMFS_UPDATEGEO_URLBASE}/GeoLiteCityv6-beta"
+CVMFS_UPDATEGEO_URLBASE6="https://ecsft.cern.ch/dist/cvmfs/geodb/GeoLiteCityv6-beta"
 EOF
 
 CLIENT_TEST_LOGFILE="${LOG_DIRECTORY}/test_client.log"

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -44,6 +44,10 @@ respawn_repository() {
   sudo cp -R ${repo_backend}/* $(get_local_repo_storage) || return 1
   sudo chown -R $user $(get_local_repo_storage $name)    || return 2
 
+  if has_selinux; then
+    chcon -Rv --type=httpd_sys_content_t $(get_local_repo_storage $name) > /dev/null || return 8
+  fi
+
   if [ x"$repo_keychain" != x"" ]; then
     sudo cp ${repo_keychain}/${CVMFS_TEST_REPO}.pub       /etc/cvmfs/keys || return 3
     sudo cp ${repo_keychain}/${CVMFS_TEST_REPO}.crt       /etc/cvmfs/keys || return 4

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -40,12 +40,15 @@ respawn_repository() {
   local user=$2
   local repo_backend=$3
   local repo_keychain="$4"
+  local dont_fix_permissions="$5"
 
   sudo cp -R ${repo_backend}/* $(get_local_repo_storage) || return 1
-  sudo chown -R $user $(get_local_repo_storage $name)    || return 2
 
-  if has_selinux; then
-    chcon -Rv --type=httpd_sys_content_t $(get_local_repo_storage $name) > /dev/null || return 8
+  if [ x"$dont_fix_permissions" = x"" ]; then
+    sudo chown -R $user $(get_local_repo_storage $name)    || return 2
+    if has_selinux; then
+      chcon -Rv --type=httpd_sys_content_t $(get_local_repo_storage $name) > /dev/null || return 8
+    fi
   fi
 
   if [ x"$repo_keychain" != x"" ]; then
@@ -150,6 +153,23 @@ cvmfs_run_test() {
 
   echo "importing repository with a provided keychain"
   import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -k $(pwd)/$repo_keychain || return 11
+
+  echo "compare the results of cvmfs to our reference copy"
+  compare_directories $repo_dir $reference_dir || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # ============================================================================
+
+  echo "removing repository"
+  destroy_repo $CVMFS_TEST_REPO || return 50
+
+  echo "planting repository backend and keychain again (not fixing any permissions)"
+  respawn_repository $CVMFS_TEST_REPO $CVMFS_TEST_USER $repo_backend $repo_keychain DONT_FIX_PERMISSIONS || return $?
+
+  echo "importing repository to recreate the backend infrastructure (enable permission fixing)"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER -g || return 51
 
   echo "compare the results of cvmfs to our reference copy"
   compare_directories $repo_dir $reference_dir || return $?

--- a/test/test_functions
+++ b/test/test_functions
@@ -648,7 +648,6 @@ import_repo() {
   fi
   sudo cvmfs_server import -o $uid $unionfs $extra_options $repo || return 102
 
-  local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
   apply_server_cache_config $repo || return 103
 }
 


### PR DESCRIPTION
Fixing tonights regressions (global `cvmfs_server_hooks.sh` with bogus `CVMFS_UPDATEGEO_URLBASE6`) killing practically all Stratum1 related tests. Remove `try_mount_remount_cycle_overlayfs()` since it makes problems and is not necessary. Furthermore fixing integration test **591** showing an SELinux problem in Fedora 23.