### PR TITLE
FIX: S3 compatibility and GeoIP database download

### DIFF
--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -122,6 +122,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/605-resurrectancientcatalog              \
                                src/607-noapache                             \
                                src/608-infofile                             \
+                               src/610-altpath                              \
                                src/614-geoservice                           \
                                src/622-gracefulrmfs                         \
                                src/626-cacheexpiry                          \

--- a/test/src/578-automaticgarbagecollection/main
+++ b/test/src/578-automaticgarbagecollection/main
@@ -37,8 +37,8 @@ cvmfs_run_test() {
   local root_catalog5=""
   local root_catalog6=""
 
-  local seconds=10
-  local thresh_seconds=20 # Potential Race: Publishing is not supposed to take
+  local seconds=30
+  local thresh_seconds=60 # Potential Race: Publishing is not supposed to take
                           #                 longer than thresh_seconds-seconds !
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging ($(display_timestamp now))"

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -56,14 +56,22 @@ cvmfs_unstash()
   sudo chown ${CVMFS_TEST_595_GEODB_OWNER}:${CVMFS_TEST_595_GEODB_GROUP} $source
 }
 
+recreate_server_hooks_from_stashed_if_needed() {
+  sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS || true
+  if [ ! -z $CVMFS_TEST_595_SERVER_HOOKS_STASH ] && \
+     [   -f $CVMFS_TEST_595_SERVER_HOOKS_STASH ]; then
+    # copying over CVMFS_UPDATEGEO_URLBASE configuration if necessary
+    grep -e 'CVMFS_UPDATEGEO_URLBASE='  $CVMFS_TEST_595_SERVER_HOOKS_STASH | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 50
+    grep -e 'CVMFS_UPDATEGEO_URLBASE6=' $CVMFS_TEST_595_SERVER_HOOKS_STASH | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 51
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
 
   # can't start out as root, it causes some of the tests below to fail
   echo "check if running as root"
   [ $(id -u) != 0 ] || return 1
-
-  echo "environment CVMFS_UPDATEGEO_URLBASE: $CVMFS_UPDATEGEO_URLBASE"
 
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
@@ -79,15 +87,18 @@ cvmfs_run_test() {
   CVMFS_TEST_595_GEODB_OWNER=$(stat --format='%U' $geodb_dir)
   CVMFS_TEST_595_GEODB_GROUP=$(stat --format='%G' $geodb_dir)
 
+  echo "install a disaster cleanup function"
+  trap cleanup EXIT HUP INT TERM || return $?
+
   cvmfs_stash GEODB
   cvmfs_stash GEODB2
   cvmfs_stash SERVER_HOOKS
 
+  echo "create initial $CVMFS_TEST_595_SERVER_HOOKS in necessary"
+  recreate_server_hooks_from_stashed_if_needed || return 50
+
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
-
-  echo "install a disaster cleanup function"
-  trap cleanup EXIT HUP INT TERM || return $?
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -254,7 +265,7 @@ cvmfs_run_test() {
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   echo "removing $CVMFS_TEST_595_SERVER_HOOKS"
-  sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS || return 42
+  recreate_server_hooks_from_stashed_if_needed || return 42
 
   echo "create a stratum1 snapshot (should find database up to date)"
   local snapshot_1_log="snapshot_1.log"

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -108,9 +108,14 @@ chunk_offsets=0,6
 chunk_checksums=c4d871ad13ad00fde9a7bb7ff7ed2543aec54241,9591818c07e900db7e1e0bc4b884c945e6a61b24
 EOF
 
-  mkdir -p /srv/cvmfs/$CVMFS_TEST_REPO/data/{2b,95}
-  echo -n "hello " > /srv/cvmfs/$CVMFS_TEST_REPO/data/c4/d871ad13ad00fde9a7bb7ff7ed2543aec54241P
-  echo "world" >  /srv/cvmfs/$CVMFS_TEST_REPO/data/95/91818c07e900db7e1e0bc4b884c945e6a61b24P
+  local h1=c4d871ad13ad00fde9a7bb7ff7ed2543aec54241P
+  local h2=9591818c07e900db7e1e0bc4b884c945e6a61b24P
+
+  echo -n "hello " > $h1 || return 50
+  echo    "world"  > $h2 || return 51
+
+  upload_into_backend $CVMFS_TEST_REPO $h1 $(make_path $h1)
+  upload_into_backend $CVMFS_TEST_REPO $h2 $(make_path $h2)
 
   publish_repo $CVMFS_TEST_REPO -v || return $?
 

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -21,14 +21,18 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "gather some global information about $CVMFS_TEST_REPO"
+  load_repo_config $CVMFS_TEST_REPO
+  spool_dir="$CVMFS_SPOOL_DIR"
+
   start_transaction $CVMFS_TEST_REPO || return $?
   echo "Hello world" > /cvmfs/$CVMFS_TEST_REPO/file1
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  local hash=$(attr -qg hash /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/file1)
-  local attrval=$(attr -qg compression /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/file1)
+  local hash=$(attr -qg hash ${spool_dir}/rdonly/file1)
+  local attrval=$(attr -qg compression ${spool_dir}/rdonly/file1)
   if [ x"$attrval" != "xzlib" ]; then
     return 22
   fi

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -54,20 +54,20 @@ cvmfs_run_test() {
 
   start_transaction $CVMFS_TEST_REPO || return $?
 
-  # Verify grafting works in sub-catalogs
+  echo "Verify grafting works in sub-catalogs"
   mkdir -p /cvmfs/$CVMFS_TEST_REPO/subdir/
   touch /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfscatalog
   echo "Some other file" > /cvmfs/$CVMFS_TEST_REPO/subdir/file3
   echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file3
   echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file3
 
-  # Verify that symlinks do not graft
+  echo "Verify that symlinks do not graft"
   echo "Some other file" > /cvmfs/$CVMFS_TEST_REPO/subdir/file4
   ln -s /cvmfs/$CVMFS_TEST_REPO/subdir/file4 /cvmfs/$CVMFS_TEST_REPO/subdir/file5
   echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file5
   echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/subdir/.cvmfsgraft-file5
 
-  # Verify that directories do not graft
+  echo "Verify that directories do not graft"
   mkdir /cvmfs/$CVMFS_TEST_REPO/subdir2
   echo "checksum=$hash" > /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-subdir2
   echo "size=12" >> /cvmfs/$CVMFS_TEST_REPO/.cvmfsgraft-subdir2
@@ -93,7 +93,7 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
-  ############### Check chunk grafting ###############
+  echo "############### Check chunk grafting ###############"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -Z none || return $?


### PR DESCRIPTION
This fixes the S3 compatibility of **597** "Grafting" and disables **610** (Alternative Catalog Path) in S3 tests. Furthermore it increases the tested race condition margin in **578**. Furthermore it contains a general fix for **595** that downloaded the GeoIP database from MaxMind instead of ecsft.cern.ch.