### PR TITLE
FIX: Overhauling Integration Test 600 (Secure CVMFS)

### DIFF
--- a/cvmfs/voms_authz/voms_authz.cc
+++ b/cvmfs/voms_authz/voms_authz.cc
@@ -347,14 +347,20 @@ GenerateVOMSData(const struct fuse_ctx *ctx)
 
   struct vomsdata *voms_ptr = (*g_VOMS_Init)(NULL, NULL);
   int error = 0;
-  if (!(*g_VOMS_RetrieveFromFile)(fp, RECURSE_CHAIN, voms_ptr, &error)) {
+
+  const int retval = (*g_VOMS_RetrieveFromFile)(fp, RECURSE_CHAIN,
+                                                voms_ptr, &error);
+  fclose(fp);
+
+  if (!retval) {
     char *err_str = (*g_VOMS_ErrorMessage)(voms_ptr, error, NULL, 0);
     LogCvmfs(kLogVoms, kLogDebug, "Unable to parse VOMS file: %s\n",
              err_str);
     free(err_str);
     (*g_VOMS_Destroy)(voms_ptr);
-    return NULL;
+    voms_ptr = NULL;
   }
+
   return voms_ptr;
 }
 

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -35,6 +35,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -34,6 +34,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/cloud_testing/platforms/slc5_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_setup.sh
@@ -76,6 +76,9 @@ install_from_repo openssl-devel  || die "fail (installing openssl-devel)"
 install_from_repo cmake          || die "fail (installing cmake)"
 install_from_repo libattr-devel  || die "fail (installing libattr-devel)"
 
+# install test dependency for 600
+install_from_repo gridsite || die "fail (installing gridsite)"
+
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "
 set_nofile_limit 65536 || die "fail"

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -89,6 +89,11 @@ install_from_repo libuuid-devel || die "fail (installing libuuid-devel)"
 install_from_repo cmake         || die "fail (installing cmake)"
 install_from_repo libattr-devel || die "fail (installing libattr-devel)"
 
+# install test dependency for 600
+install_from_repo compat-expat1 || die "fail (installing compat-expat1)"
+install_from_repo openssl098e   || die "fail (installing openssl098e)"
+install_from_repo gridsite      || die "fail (installing gridsite)"
+
 # install ruby gem for FakeS3
 install_ruby_gem fakes3 0.2.0  # latest is 0.2.1 (23.07.2015) that didn't work.
 

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -2,6 +2,8 @@
 cvmfs_test_name="Test CVMFS over HTTPS with VOMS authentication"
 cvmfs_test_autofs_on_startup=false
 
+
+# TODO(rmeusel): make this multi-platform
 TEST600_HTTPS_CONFIG=/etc/httpd/conf.d/test600.cvmfs.secure.conf
 # Set later to the scratch dir
 TEST600_HOSTCERT=
@@ -21,19 +23,26 @@ TEST600_GRID_CACHE=
 TEST600_CERTS_DIR=
 # Bind mount to /etc/grid-security active
 TEST600_GRID_SECURITY_TAINTED=
+# local mount for testing
+TEST600_PRIVATE_MOUNT=
+TEST600_HOSTNAME=
+TEST600_SELINUX_DISABLED=
 
 cleanup() {
   echo "running cleanup()..."
   sudo umount ${TEST600_GRID_MOUNTPOINT}
   [ "x$TEST600_GRID_SECURITY_TAINTED" = "xyes" ] && sudo umount /etc/grid-security
-  [ -z "$TEST600_HTTPS_CONFIG" ] || sudo rm -f $TEST600_HTTPS_CONFIG
-  [ -z "$TEST600_HOSTCERT" ] || sudo rm -f $TEST600_HOSTCERT
-  [ -z "$TEST600_HOSTKEY" ] || sudo rm -f $TEST600_HOSTKEY
-  [ -z "$TEST600_VOMSDIR" ] || sudo rm -fR $TEST600_VOMSDIR
-  [ -z "$TEST600_TESTCA" ] || sudo rm -f $TEST600_TESTCA
-  [ -z "$TEST600_TESTCRL" ] || sudo rm -f $TEST600_TESTCRL
-  [ -z "$TEST600_TESTCA_HASH" ] || sudo rm -f $TEST600_TESTCA_HASH
-  [ -z "$TEST600_TESTCRL_HASH" ] || sudo rm -f $TEST600_TESTCRL_HASH
+  [ -z "$TEST600_HTTPS_CONFIG"                 ] || sudo rm -f $TEST600_HTTPS_CONFIG
+  [ -z "$TEST600_HOSTCERT"                     ] || sudo rm -f $TEST600_HOSTCERT
+  [ -z "$TEST600_HOSTKEY"                      ] || sudo rm -f $TEST600_HOSTKEY
+  [ -z "$TEST600_VOMSDIR"                      ] || sudo rm -fR $TEST600_VOMSDIR
+  [ -z "$TEST600_TESTCA"                       ] || sudo rm -f $TEST600_TESTCA
+  [ -z "$TEST600_TESTCRL"                      ] || sudo rm -f $TEST600_TESTCRL
+  [ -z "$TEST600_TESTCA_HASH"                  ] || sudo rm -f $TEST600_TESTCA_HASH
+  [ -z "$TEST600_TESTCRL_HASH"                 ] || sudo rm -f $TEST600_TESTCRL_HASH
+  [ -z "$TEST600_PRIVATE_MOUNT"                ] || sudo umount $TEST600_PRIVATE_MOUNT
+  [ -z "$TEST600_HOSTNAME"                     ] || sudo sed -i -e "/$TEST600_HOSTNAME/d" /etc/hosts
+  [ -z "$TEST600_SELINUX_DISABLED"             ] || sudo setenforce 1
 }
 
 mount_cvmfs_grid() {
@@ -60,31 +69,43 @@ EOF
 generate_certs() {
   local script_location=$1
   mkdir -p $TEST600_CERTS_DIR $TEST600_GRID_CACHE $TEST600_GRID_MOUNTPOINT
-  local voms_path=${TEST600_GRID_MOUNTPOINT}/emi-ui-2.10.4-1_sl5v1
-  if [ ! -e "$voms_path" ]; then
-    voms_path="/"
+  local voms_path=
+
+  if is_el5; then
+    voms_path="${TEST600_GRID_MOUNTPOINT}/emi-ui-2.10.4-1_sl5v1"
+  elif is_el6; then
+    voms_path="${TEST600_GRID_MOUNTPOINT}/emi-ui-2.10.4-1_sl5v1"
+    # TODO(rmeusel): use that once the world stopped burning...
+    #                removes a couple of compat* depedencies
+    # voms_path="${TEST600_GRID_MOUNTPOINT}/emi-ui-3.17.1-1_sl6v1"
+  else
+    echo "didn't find voms path for this platform"
+    return 10
   fi
 
+  echo "using VOMS path: '$voms_path'"
   cp $script_location/ca-generate-certs $TEST600_CERTS_DIR/
   cp $script_location/openssl-usercert-extensions.conf $TEST600_CERTS_DIR/
   cp $script_location/openssl-cert-extensions-template.conf $TEST600_CERTS_DIR/
   cp $script_location/openssl.config $TEST600_CERTS_DIR/
 
-  pushd $TEST600_CERTS_DIR
-  ./ca-generate-certs $HOSTNAME
+
+  echo "generating vomsproxy.pem"
+  pushdir $TEST600_CERTS_DIR
+  ./ca-generate-certs ${TEST600_HOSTNAME}
   result=$?
   LD_LIBRARY_PATH=${voms_path}/usr/lib64 \
      ${voms_path}/usr/bin/voms-proxy-fake -certdir ${TEST600_GRID_SECURITY_DIR}/certificates \
       -cert usercert.pem -key userkey.pem -out vomsproxy.pem -rfc \
       -hostcert hostcert.pem -hostkey hostkey.pem -fqan /cvmfs/Role=NULL \
-      -voms cvmfs -uri $HOSTNAME:15000
-  popd
+      -voms cvmfs -uri ${TEST600_HOSTNAME}:15000 || return 1
+  popdir
 
   mkdir -p ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs
 
   set -x
-  echo "/DC=org/DC=Open Science Grid/O=OSG Test/OU=Services/CN=$HOSTNAME" > ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs/$HOSTNAME.lsc
-  echo "/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA" >> ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs/$HOSTNAME.lsc
+  echo "/DC=org/DC=Open Science Grid/O=OSG Test/OU=Services/CN=${TEST600_HOSTNAME}" > ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs/${TEST600_HOSTNAME}.lsc
+  echo "/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA" >> ${TEST600_GRID_SECURITY_DIR}/vomsdir/cvmfs/${TEST600_HOSTNAME}.lsc
 
   LD_LIBRARY_PATH=${voms_path}/usr/lib64 X509_CERT_DIR=${TEST600_GRID_SECURITY_DIR}/certificates \
     ${voms_path}/usr/bin/voms-proxy-info -file $TEST600_CERTS_DIR/vomsproxy.pem \
@@ -131,94 +152,100 @@ cvmfs_run_test() {
 
   # Generate repo first - check will fail after apache change below until we
   # change the default URL.
-  [ -z "$TEST600_HTTPS_CONFIG" ] || sudo rm -f $TEST600_HTTPS_CONFIG
-  echo "restarting apache"
-  apache_switch off
-  apache_switch on
+  if [ -f "$TEST600_HTTPS_CONFIG" ]; then
+    sudo rm -f $TEST600_HTTPS_CONFIG
+    echo "restarting apache"
+    apache_switch off
+    apache_switch on
+  fi
+
+  echo "set a trap for system directory cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "setting a dummy host name"
+  TEST600_HOSTNAME='test-600-dummyhost'
+  echo "127.0.0.1 $TEST600_HOSTNAME" | sudo tee --append /etc/hosts
+
+  if has_selinux; then
+    echo "make sure that SELinux does not interfere"
+    TEST600_SELINUX_DISABLED=1
+    sudo setenforce 0 || return 1
+  fi
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "create VOMS certificate for $CVMFS_TEST_USER"
+
+  echo "mount grid.cern.ch"
+  mount_cvmfs_grid $TEST600_GRID_MOUNTPOINT $TEST600_GRID_CACHE
+  ls $TEST600_GRID_MOUNTPOINT
+
+  echo "Generating certificates"
+  generate_certs $script_location || return 4
+  cat $X509_USER_PROXY            || return 5
+
+  echo "use vomsproxy certificate"
+  export X509_USER_PROXY=$(pwd)/certs/vomsproxy.pem
+
+  echo "make '$TEST600_GRID_SECURITY_DIR' available as /etc/grid-security"
+  sudo mkdir -p /etc/grid-security                                || return 20
+  sudo mount --bind $TEST600_GRID_SECURITY_DIR /etc/grid-security || return 21
+  TEST600_GRID_SECURITY_TAINTED="yes"
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -V cvmfs:/cvmfs || return $?
 
   echo "gather information about the just created repo"
   load_repo_config $CVMFS_TEST_REPO
   local spool_dir="$CVMFS_SPOOL_DIR"
   local cache_base="$CVMFS_CACHE_BASE"
 
+  echo "put some stuff into $CVMFS_TEST_REPO"
   start_transaction $CVMFS_TEST_REPO                       || return $?
   echo "Hello World" > /cvmfs/$CVMFS_TEST_REPO/hello_world || return 3
   publish_repo $CVMFS_TEST_REPO -v                         || return $?
 
-  # ( . ${script_location}/../../common/migration_tests/common.sh; install_packages gridsite voms-clients-cpp )
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-  echo "set a trap for system directory cleanup"
-  trap cleanup EXIT HUP INT TERM
-
-  # Allow mount of grid.cern.ch to fail; this is just used for grid tools
-  mount_cvmfs_grid $TEST600_GRID_MOUNTPOINT $TEST600_GRID_CACHE
-  ls $TEST600_GRID_MOUNTPOINT
-  echo "Generating certificates"
-  generate_certs $script_location
   # requires mod_gridsite from the gridsite package
   echo "Setting up apache configuration"
-  cp $script_location/test600.cvmfs.secure.conf $TEST600_HTTPS_CONFIG
-  sed -i "s/@REPONAME@/$CVMFS_TEST_REPO/" $TEST600_HTTPS_CONFIG
-  sed -i "s,@GRIDSECURITYDIR@,$TEST600_GRID_SECURITY_DIR," $TEST600_HTTPS_CONFIG
-  cp $script_location/gacl $(get_local_repo_storage $CVMFS_TEST_REPO)/data/.gacl
+  sudo cp $script_location/test600.cvmfs.secure.conf $TEST600_HTTPS_CONFIG            || return 60
+  sudo sed -i "s/@REPONAME@/$CVMFS_TEST_REPO/" $TEST600_HTTPS_CONFIG                  || return 61
+  sudo sed -i "s,@GRIDSECURITYDIR@,$TEST600_GRID_SECURITY_DIR," $TEST600_HTTPS_CONFIG || return 62
+  cp $script_location/gacl $(get_local_repo_storage $CVMFS_TEST_REPO)/data/.gacl      || return 63
+
   echo "restarting apache"
   apache_switch off
   apache_switch on
 
-  echo "Setting CVMFS_SERVER_URL to https://"
-  sed -i "s|CVMFS_SERVER_URL=$(get_repo_url $CVMFS_TEST_REPO)|CVMFS_SERVER_URL=https://$HOSTNAME:8443/cvmfs/$CVMFS_TEST_REPO|" /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf
-  echo "X509_CERT_DIR=${TEST600_GRID_SECURITY_DIR}/certificates" >> /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-  # TODO(jblomer): Fixed catalogs with alternative path should be properly solved
-  echo "reset CVMFS_ROOT_HASH"
-  sed -i -e '/^CVMFS_ROOT_HASH=/d' ${spool_dir}/client.local
+  local mntpnt="${scratch_dir}/secure_mnt"
+  TEST600_PRIVATE_MOUNT="$mntpnt"
+  do_local_mount_as_root "$mntpnt"          \
+                         "$CVMFS_TEST_REPO" \
+                         "https://${TEST600_HOSTNAME}:8443/cvmfs/$CVMFS_TEST_REPO" || return 19
 
-  echo "umount repository mountpoints to connect via https"
-  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 40
-  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 41
+  echo "copy vomsproxy for 'nobody'"
+  local nobody_vomsproxy="$(pwd)/certs/vomsproxy.pem.nobody"
+  cp $(pwd)/certs/vomsproxy.pem $nobody_vomsproxy || return 20
+  sudo chown nobody:            $nobody_vomsproxy || return 21
 
-  echo "Remove any cached files to make sure we reload over https."
-  rm -rf ${cache_base}/$CVMFS_TEST_REPO || return 50
+  echo "This should work"
+  sudo -u nobody /bin/sh -c "export X509_USER_PROXY=$nobody_vomsproxy; cat ${mntpnt}/hello_world" > /dev/null || return 30
 
-  echo "remount repository mount points"
-  cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return $?
-  cvmfs_suid_helper rw_mount     $CVMFS_TEST_REPO || return $?
+  echo "This should work because the above and below are in the same session id."
+  sudo -u nobody /bin/sh -c "cat ${mntpnt}/hello_world" || return 31
 
-  export X509_USER_PROXY=$(pwd)/certs/vomsproxy.pem
-  cp $(pwd)/certs/vomsproxy.pem $(pwd)/certs/vomsproxy.pem.nobody
-  chown nobody: $(pwd)/certs/vomsproxy.pem.nobody
-  cat $X509_USER_PROXY
-  sudo mkdir -p /etc/grid-security || return 20
-  sudo mount --bind $TEST600_GRID_SECURITY_DIR /etc/grid-security || return 21
-  TEST600_GRID_SECURITY_TAINTED="yes"
-  sudo -u nobody /bin/sh -c "X509_USER_PROXY=$PWD/certs/vomsproxy.pem.nobody cat /cvmfs/$CVMFS_TEST_REPO/hello_world" > /dev/null || return 30
-  # This should work because the above and below are in the same session id.
-  sudo -u nobody /bin/sh -c "cat /cvmfs/$CVMFS_TEST_REPO/hello_world" || return 31
-  sudo -u nobody setsid /bin/sh -c "env && cat /cvmfs/$CVMFS_TEST_REPO/hello_world"
-  # Last line should have resulted in an IO error.
-  if [ $? -eq 0 ]; then
-    return 40
-  fi
+  echo "This should not work"
+  sudo -u nobody setsid /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 32
 
-  # Check authz attr
-  if [ x"`attr -qg authz ${spool_dir}/rdonly`" != "xcvmfs:/cvmfs" ]; then
-    return 41
-  fi
-
-  # Change authz attr and make sure it is reflected.
-  start_transaction $CVMFS_TEST_REPO || return $?
-  cat << EOF > new_authz
-cvmfs:/cvmfs
-foo
-EOF
-  set -x
-  # TODO(bbockelm) Need to change test apache configuration to re-publish.
-  # publish_repo $CVMFS_TEST_REPO -F new_authz
-  # $(attr -qg authz ${spool_dir}/rdonly | grep -q foo) || return 42
-
+  echo "Check authz attr"
+  local authz_attr=
+  authz_attr="$(attr -qg authz $mntpnt)" || return 41
+  [ x"$authz_attr" = x"cvmfs:/cvmfs" ]   || return 42
 
   return 0
 }

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -137,7 +137,7 @@ cvmfs_run_test() {
   apache_switch on
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -V cvmfs:/cvmfs || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO || return $?
 
   echo "gather information about the just created repo"
   load_repo_config $CVMFS_TEST_REPO
@@ -168,16 +168,25 @@ cvmfs_run_test() {
   apache_switch off
   apache_switch on
 
+  echo "Setting CVMFS_SERVER_URL to https://"
   sed -i "s|CVMFS_SERVER_URL=$(get_repo_url $CVMFS_TEST_REPO)|CVMFS_SERVER_URL=https://$HOSTNAME:8443/cvmfs/$CVMFS_TEST_REPO|" /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf
   echo "X509_CERT_DIR=${TEST600_GRID_SECURITY_DIR}/certificates" >> /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf
+
   # TODO(jblomer): Fixed catalogs with alternative path should be properly solved
+  echo "reset CVMFS_ROOT_HASH"
   sed -i -e '/^CVMFS_ROOT_HASH=/d' ${spool_dir}/client.local
-  cvmfs_suid_helper rw_umount $CVMFS_TEST_REPO
-  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO
-  # Remove any cached files to make sure we reload over https.
-  rm -rf ${cache_base}/$CVMFS_TEST_REPO
+
+  echo "umount repository mountpoints to connect via https"
+  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 40
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 41
+
+  echo "Remove any cached files to make sure we reload over https."
+  rm -rf ${cache_base}/$CVMFS_TEST_REPO || return 50
+
+  echo "remount repository mount points"
   cvmfs_suid_helper rdonly_mount $CVMFS_TEST_REPO || return $?
-  cvmfs_suid_helper rw_mount $CVMFS_TEST_REPO || return $?
+  cvmfs_suid_helper rw_mount     $CVMFS_TEST_REPO || return $?
+
   export X509_USER_PROXY=$(pwd)/certs/vomsproxy.pem
   cp $(pwd)/certs/vomsproxy.pem $(pwd)/certs/vomsproxy.pem.nobody
   chown nobody: $(pwd)/certs/vomsproxy.pem.nobody

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -107,7 +107,7 @@ cvmfs_run_test() {
   local script_location=$2
   local scratch_dir=$(pwd)
 
-  if [ -z $CVMFS_TEST_S3_CONFIG ]; then
+  if [ ! -z $CVMFS_TEST_S3_CONFIG ]; then
     echo "This is not yet implemented for S3"
     return 1
   fi

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -23,6 +23,7 @@ TEST600_CERTS_DIR=
 TEST600_GRID_SECURITY_TAINTED=
 
 cleanup() {
+  echo "running cleanup()..."
   sudo umount ${TEST600_GRID_MOUNTPOINT}
   [ "x$TEST600_GRID_SECURITY_TAINTED" = "xyes" ] && sudo umount /etc/grid-security
   [ -z "$TEST600_HTTPS_CONFIG" ] || sudo rm -f $TEST600_HTTPS_CONFIG
@@ -48,6 +49,7 @@ CVMFS_RELOAD_SOCKETS=$cache_dir
 CVMFS_CLAIM_OWNERSHIP=yes
 CVMFS_SERVER_URL=http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch
 CVMFS_HTTP_PROXY="${CVMFS_TEST_PROXY}"
+CVMFS_KEYS_DIR=/etc/cvmfs/keys/cern.ch
 EOF
   cat ${cache_dir}/client.conf
 
@@ -142,9 +144,9 @@ cvmfs_run_test() {
   local spool_dir="$CVMFS_SPOOL_DIR"
   local cache_base="$CVMFS_CACHE_BASE"
 
-  start_transaction $CVMFS_TEST_REPO || return $?
-  echo "Hello World" > /cvmfs/$CVMFS_TEST_REPO/hello_world
-  publish_repo $CVMFS_TEST_REPO -v || return $?
+  start_transaction $CVMFS_TEST_REPO                       || return $?
+  echo "Hello World" > /cvmfs/$CVMFS_TEST_REPO/hello_world || return 3
+  publish_repo $CVMFS_TEST_REPO -v                         || return $?
 
   # ( . ${script_location}/../../common/migration_tests/common.sh; install_packages gridsite voms-clients-cpp )
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -95,6 +95,25 @@ is_systemd() {
   [ x"$SERVICE_BIN" = x"false" ]
 }
 
+is_redhat() {
+  [ -e /etc/redhat-release ]
+}
+
+is_el7() {
+  is_redhat && which lsb_release > /dev/null 2>&1 && \
+  [ x"$(lsb_release -rs | cut -f1 -d'.')" = x"7" ]
+}
+
+is_el6() {
+  is_redhat && which lsb_release > /dev/null 2>&1 && \
+  [ x"$(lsb_release -rs | cut -f1 -d'.')" = x"6" ]
+}
+
+is_el5() {
+  is_redhat && which lsb_release > /dev/null 2>&1 && \
+  [ x"$(lsb_release -rs | cut -f1 -d'.')" = x"5" ]
+}
+
 # find the name of the httpd service
 
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2020,12 +2020,14 @@ get_cache_directory() {
   echo "${mountpoint}c"
 }
 
-do_local_mount() {
-  local mountpoint="$1"
-  local repo_name="$2"
-  local repo_url="$3"
-  local config_file="$4"
-  local extra_option="$5"
+__do_local_mount() {
+  local as_root="$1"
+  local mountpoint="$2"
+  local repo_name="$3"
+  local repo_url="$4"
+  local config_file="$5"
+  local extra_option="$6"
+
   local cache="$(get_cache_directory $mountpoint)"
   local config="$(mktemp ${mountpoint}.conf.XXXXX)"
   local output="$(mktemp ${mountpoint}.log.XXXXX)"
@@ -2049,7 +2051,19 @@ EOF
   echo "  *** local mount config:"
   cat "$config"
 
-  cvmfs2 -d -o config=$config $repo_name $mountpoint >> $output 2>&1
+  if [ x"$as_root" != x"" ]; then
+    sudo cvmfs2 -d -o allow_other,config=$config $repo_name $mountpoint >> $output 2>&1
+  else
+    cvmfs2 -d -o allow_other,config=$config $repo_name $mountpoint >> $output 2>&1
+  fi
+}
+
+do_local_mount() {
+  __do_local_mount "" $@
+}
+
+do_local_mount_as_root() {
+  __do_local_mount "sudo" $@
 }
 
 remove_local_mount() {

--- a/test/test_functions
+++ b/test/test_functions
@@ -581,6 +581,7 @@ create_repo() {
 
   if [ x$debug_log != x -a x$debug_log != xNO ]; then
     echo "CVMFS_DEBUGLOG=$debug_log" | sudo tee -a $client_conf
+    sudo sed -i.bak -e "s/^\(cvmfs2#$repo.*\)\(allow_other.*\)/\1debug,\2/" /etc/fstab
   fi
 }
 

--- a/vagrant/provision_slc6.sh
+++ b/vagrant/provision_slc6.sh
@@ -49,7 +49,8 @@ yum -y install libuuid-devel gcc gcc-c++ glibc-common cmake fuse fuse-devel  \
                curl attr httpd libcap-devel voms-devel
 
 # install convenience packages for development
-yum -y install git tig iftop htop jq rubygems screen nc python-unittest2
+yum -y install git tig iftop htop jq rubygems screen nc python-unittest2 \
+               policycoreutils-python
 gem install fakes3 --version 0.2.0
 
 # setup and run a FakeS3 server


### PR DESCRIPTION
This fixes integration test 600 by changing it's logic slightly and adding some bells and whistles here and there. Also fixes a file descriptor leak in the associated production implementation. Furthermore the test is disabled on all platforms but SL5 and 6.