### PR TITLE
Feature: Check OverlayFS version in cvmfs_server

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -580,6 +580,18 @@ check_overlayfs() {
   /sbin/modprobe -q overlay || test -d /sys/module/overlay
 }
 
+
+# ensure that the installed overlayfs is viable for CernVM-FS. Namely, it must
+# be part of the upstream kernel (since 3.18) and recent enough (kernel 4.2)
+# Note: More details are in CVM-835.
+# @return  0 if overlayfs is installed and viable
+check_overlayfs_version() {
+  [ -z "$CVMFS_DONT_CHECK_OVERLAYFS_VERSION" ] || return 0
+  local krnl_version=$(uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+')
+  compare_versions "$krnl_version" -ge "4.2.0"
+}
+
+
 # check if at least one of the supported union file systems is available
 # currently AUFS get preference over OverlayFS if both are available
 #
@@ -2902,6 +2914,7 @@ mkfs() {
   check_upstream_validity $upstream
   if [ $unionfs = "overlayfs" ]; then
     check_overlayfs                 || die "overlayfs kernel module missing"
+    check_overlayfs_version         || die "Your version of OverlayFS is not supported"
     echo "Warning: CernVM-FS filesystems using overlayfs may not enforce hard link semantics during publishing."
   else
     check_aufs                      || die "aufs kernel module missing"
@@ -3361,6 +3374,7 @@ import() {
 
   if [ $unionfs = "overlayfs" ]; then
     check_overlayfs                 || die "overlayfs kernel module missing"
+    check_overlayfs_version         || die "Your version of OverlayFS is not supported"
     echo "Warning: CernVM-FS filesystems using overlayfs may not enforce hard link semantics during publishing."
   else
     check_aufs                      || die "aufs kernel module missing"

--- a/test/test_functions
+++ b/test/test_functions
@@ -569,12 +569,12 @@ create_repo() {
     echo "  UnionFS: $CVMFS_TEST_UNIONFS"
     unionfs=" -f $CVMFS_TEST_UNIONFS"
   fi
-  sudo cvmfs_server mkfs -o $uid -m                \
-                         -a ${CVMFS_TEST_HASHALGO} \
-                         $s3_config                \
-                         $stratum0                 \
-                         $unionfs                  \
-                         $extra_options $repo || return 102
+  sudo -E cvmfs_server mkfs -o $uid -m                \
+                            -a ${CVMFS_TEST_HASHALGO} \
+                            $s3_config                \
+                            $stratum0                 \
+                            $unionfs                  \
+                            $extra_options $repo || return 102
 
   local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
   apply_server_cache_config $repo || return 103
@@ -666,7 +666,7 @@ import_repo() {
     echo "  UnionFS: $CVMFS_TEST_UNIONFS"
     unionfs=" -f $CVMFS_TEST_UNIONFS"
   fi
-  sudo cvmfs_server import -o $uid $unionfs $extra_options $repo || return 102
+  sudo -E cvmfs_server import -o $uid $unionfs $extra_options $repo || return 102
 
   apply_server_cache_config $repo || return 103
 }


### PR DESCRIPTION
This checks the version of OverlayFS when it is used in `cvmfs_server`. That is to exclude unsupported incarnations of OverlayFS. Either because it was manually compiled into the kernel (before 3.18) or it's not recent enough and still contains bugs (Details in [CVM-835](https://sft.its.cern.ch/jira/browse/CVM-835)). This explicitly excludes the OverlayFS in CentOS 7.x as it is not viable for CernVM-FS, (yet).

For **testing purposes** this check can be overridden by setting the `CVMFS_DONT_CHECK_OVERLAYFS_VERSION` environment variable.