### PR TITLE
FIX: Repository Migration Code

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5509,7 +5509,7 @@ migrate_2_1_20() {
 
     echo "--> updating /etc/fstab"
     local tmp_fstab=$(mktemp)
-    awk  "/added by CernVM-FS for $name/"' {
+    awk  "/added by CernVM-FS for $name\$/"' {
             for (i = 1; i <= NF; i++) {
               if (i == 4) $i = $i",noauto";
               printf("%s ", $i);


### PR DESCRIPTION
This fixes a tiny particularity in the migration from CernVM-FS 2.1.20/2.2.0-0 to 2.2.0-1. Namely, when migrating `/etc/fstab` the `awk` script might migrate not only the specified repository but any other whose name starts with the 'specified repository'.
Like: `cvmfs_server migrate test.local` would have also migrated the `/etc/fstab` entry for **test.local.2**.