### PR TITLE
FIX: Tonight's Integration Test run

### DIFF
--- a/test/cloud_testing/platforms/fedora22_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_setup.sh
@@ -8,11 +8,6 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo "updating installed RPM packages..."
 sudo dnf -y update || die "fail (dnf update)"
 
-# disable SELinux (OverlayFS doesn't support it)
-echo -n "set SELinux into permissive mode..."
-sudo setenforce 0 || die "fail"
-echo "done"
-
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/fedora22_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_setup.sh
@@ -56,3 +56,8 @@ install_from_repo libattr-devel
 echo -n "increasing ulimit -n ... "
 set_nofile_limit 65536 || die "fail"
 echo "done"
+
+# rebooting the system (returning 0 value)
+echo "sleep 1 && reboot" > killme.sh
+sudo nohup sh < killme.sh &
+exit 0

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -31,7 +31,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/570-remountrace                          \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \

--- a/test/common/mock_services/wiremock_wrapper.sh
+++ b/test/common/mock_services/wiremock_wrapper.sh
@@ -18,7 +18,9 @@ install_wiremock() {
   local wiremock_launcher_install_path="/usr/bin/wiremock"
 
   echo -n "Downloading wiremock... "
-  wget --quiet $CVMFS_WIREMOCK_JAR_LOCATION || { echo "fail"; return 1; }
+  wget --quiet                \
+       --no-check-certificate \
+       $CVMFS_WIREMOCK_JAR_LOCATION || { echo "fail"; return 1; }
   echo "done"
 
   echo -n "Installing wiremock... "

--- a/test/src/614-geoservice/main
+++ b/test/src/614-geoservice/main
@@ -117,7 +117,7 @@ cvmfs_run_test() {
 
   if [ -n "$ipv6addr" ]; then
     echo "checking direct IPv6"
-    result="`curl -s http://$ipv6addr/$api/x/$fnal,$asgc,$cern|head -5`"
+    result="`curl -s -g http://[$ipv6addr]/$api/x/$fnal,$asgc,$cern|head -5`"
     cvmfs_check_georesult "$result" $me fnal,asgc,cern || return 8
   fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2059,11 +2059,11 @@ EOF
 }
 
 do_local_mount() {
-  __do_local_mount "" $@
+  __do_local_mount "" "$@"
 }
 
 do_local_mount_as_root() {
-  __do_local_mount "sudo" $@
+  __do_local_mount "sudo" "$@"
 }
 
 remove_local_mount() {

--- a/test/test_functions
+++ b/test/test_functions
@@ -844,6 +844,8 @@ run_background_service() {
   rm -f $fifo
 
   # check if the background process is running
+  # TODO(rmeusel): Fix this race. If the background service is a short living
+  #                process it might have successfully terminated at this point.
   if ! sudo kill -0 $srv_pid > /dev/null 2>&1; then
     return 4
   fi


### PR DESCRIPTION
Fixing a quotation quirk [introduced yesterday](https://github.com/cvmfs/cvmfs/pull/1479) and failing both **616** and **620**. Fedora 22 is back as a test platform (broken cloud image) and reboots after the setup script - enabling OverlayFS server tests on FC22. Furthermore adds `--no-check-certificate` to the wiremock download (because SLC5 isn't able to verify the SSL certificate of ecsft.cern.ch) and fixing a `curl` particularity in **614**.

Let's cross our fingers.