### PR TITLE
FIX: recursive include

### DIFF
--- a/cvmfs/catalog_balancer_impl.h
+++ b/cvmfs/catalog_balancer_impl.h
@@ -5,7 +5,6 @@
 #ifndef CVMFS_CATALOG_BALANCER_IMPL_H_
 #define CVMFS_CATALOG_BALANCER_IMPL_H_
 
-#include "catalog_balancer.h"
 
 #include <inttypes.h>
 


### PR DESCRIPTION
Thanks to coverity (http://coverity.cern.ch/reports.htm#v12693/p10002/fileInstanceId=746946182&defectInstanceId=389602431&mergedDefectId=63573) I found this recursive include