### PR TITLE
FIX: Test 600

### DIFF
--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -93,6 +93,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/577-garbagecollecthiddenstratum1revision \
                                  src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
                                  src/608-infofile                             \
                                  src/609-metainfofile                         \
                                  --                                           \

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -93,6 +93,7 @@ install_from_repo libattr-devel || die "fail (installing libattr-devel)"
 install_from_repo compat-expat1 || die "fail (installing compat-expat1)"
 install_from_repo openssl098e   || die "fail (installing openssl098e)"
 install_from_repo gridsite      || die "fail (installing gridsite)"
+install_from_repo voms          || die "fail (installing voms)"
 
 # install ruby gem for FakeS3
 install_ruby_gem fakes3 0.2.0  # latest is 0.2.1 (23.07.2015) that didn't work.

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -181,11 +181,12 @@ cvmfs_run_test() {
   ls $TEST600_GRID_MOUNTPOINT
 
   echo "Generating certificates"
+  local vomsproxy=$(pwd)/certs/vomsproxy.pem
   generate_certs $script_location || return 4
-  cat $X509_USER_PROXY            || return 5
+  cat $vomsproxy                  || return 5
 
   echo "use vomsproxy certificate"
-  export X509_USER_PROXY=$(pwd)/certs/vomsproxy.pem
+  export X509_USER_PROXY=$vomsproxy
 
   echo "make '$TEST600_GRID_SECURITY_DIR' available as /etc/grid-security"
   sudo mkdir -p /etc/grid-security                                || return 20


### PR DESCRIPTION
Fixing the "Secure CVMFS" test case on SLC6 and disabling it on SLC5. On the latter platform `voms-proxy-fake` crashes with "stack smashing detected". On SLC6 it was missing the `voms` package.