### PR TITLE
FIX: Last Second Fixes

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -140,8 +140,8 @@ cvmfs_config_usage() {
 }
 
 has_selinux() {
-  which sestatus   > /dev/null 2>&1 && \
   which getenforce > /dev/null 2>&1 && \
+  which semodule   > /dev/null 2>&1 && \
   getenforce | grep -qi "enforc" || return 1
 }
 
@@ -422,8 +422,7 @@ cvmfs_chksetup() {
   fi
 
   # Check SELinux label of cache directory
-  if has_selinux && which semodule > /dev/null 2>&1 && \
-     semodule --list-modules 2> /dev/null | grep -q cvmfs; then
+  if has_selinux && semodule --list-modules 2> /dev/null | grep -q cvmfs; then
     local expected_label="cvmfs_cache_t"
     local cache_ctx="$(stat --format='%C' $CVMFS_CACHE_BASE)"
     if [ $? -ne 0 ]; then

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -139,6 +139,11 @@ cvmfs_config_usage() {
  echo "  bugreport"
 }
 
+has_selinux() {
+  which sestatus   > /dev/null 2>&1 && \
+  which getenforce > /dev/null 2>&1 && \
+  getenforce | grep -qi "enforc" || return 1
+}
 
 cvmfs_setup() {
   local nouser
@@ -417,7 +422,8 @@ cvmfs_chksetup() {
   fi
 
   # Check SELinux label of cache directory
-  if [ -f /selinux/enforce ] && [ $(cat /selinux/enforce) -ne 0 ]; then
+  if has_selinux && which semodule > /dev/null 2>&1 && \
+     semodule --list-modules 2> /dev/null | grep -q cvmfs; then
     local expected_label="cvmfs_cache_t"
     local cache_ctx="$(stat --format='%C' $CVMFS_CACHE_BASE)"
     if [ $? -ne 0 ]; then

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -24,6 +24,8 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/0*                                       \
                               || retval=1
 
+echo -n "make sure apache is running... "
+sudo systemctl start httpd > /dev/null && echo "done" || echo "fail"
 
 echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -24,6 +24,8 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/0*                                       \
                               || retval=1
 
+echo -n "make sure apache is running... "
+sudo systemctl start httpd > /dev/null && echo "done" || echo "fail"
 
 echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \


### PR DESCRIPTION
Fixes the integration test runs on Fedora (in particular 22) by starting Apache up-front. Furthermore this updates the SELinux sanity check in `cvmfs_config chksetup` to skip on EL5 and work on Fedora.