### PR TITLE
Disable VOMS checks.

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -505,13 +505,13 @@ static bool CheckVoms(const fuse_ctx &fctx) {
   // Get VOMS information, if any.  If VOMS authz is present and VOMS is
   // not compiled in, then deny authorization.
   if ((fctx.uid != 0) && voms_authz_->size()) {
-#ifdef VOMS_AUTHZ
-    return CheckVOMSAuthz(&fctx, *voms_authz_);
-#else
+//#ifdef VOMS_AUTHZ
+//    return CheckVOMSAuthz(&fctx, *voms_authz_);
+//#else
     LogCvmfs(kLogCvmfs, kLogSyslogWarn | kLogDebug,  "VOMS requirements found "
               "in catalog but client compiled without VOMS support");
     return false;
-#endif
+//#endif
   }
   return true;
 }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -505,13 +505,13 @@ static bool CheckVoms(const fuse_ctx &fctx) {
   // Get VOMS information, if any.  If VOMS authz is present and VOMS is
   // not compiled in, then deny authorization.
   if ((fctx.uid != 0) && voms_authz_->size()) {
-//#ifdef VOMS_AUTHZ
-//    return CheckVOMSAuthz(&fctx, *voms_authz_);
-//#else
+//  #ifdef VOMS_AUTHZ
+//      return CheckVOMSAuthz(&fctx, *voms_authz_);
+//  #else
     LogCvmfs(kLogCvmfs, kLogSyslogWarn | kLogDebug,  "VOMS requirements found "
               "in catalog but client compiled without VOMS support");
     return false;
-//#endif
+//  #endif
   }
   return true;
 }


### PR DESCRIPTION
Unfortunately, libvomsapi doesn't do all the validation we need
for this to function correctly.  For now, we disable VOMS checks and
always assume they fail - we'll fix this up in the next devel series.

This does allow HTTPS to be used for URLs as we blindly pass the
client credential to the remote host and don't need to validate it
in the client.