### PR TITLE
File descriptor wrapper class

### DIFF
--- a/cvmfs/util.h
+++ b/cvmfs/util.h
@@ -68,9 +68,8 @@ class FileDescriptor : SingleCopy {
   FileDescriptor() : fd_(-1) { }
   explicit FileDescriptor(int fd) : fd_(fd) { }
   virtual ~FileDescriptor() { if (IsValid()) close(fd_); }
-  inline FileDescriptor& operator=(int fd) { fd_ = fd; return *this; }
+  inline void Assign(int fd) { fd_ = fd; }
   inline operator int() const { return fd_; }
-  inline operator int*() { return &fd_; }
   inline bool operator ==(const int other_fd) const { return fd_ == other_fd; }
   inline bool operator !=(const int other_fd) const { return fd_ != other_fd; }
   inline bool IsValid() const  { return fd_ >= 0; }
@@ -87,7 +86,6 @@ class FileDescriptor : SingleCopy {
 
 class Socket : public FileDescriptor {
  public:
-  using FileDescriptor::operator=;
   using FileDescriptor::operator int;
   Socket() : FileDescriptor() { }
   explicit Socket(int fd) : FileDescriptor(fd) { }
@@ -120,8 +118,8 @@ struct Pipe : public SingleCopy {
   Pipe() {
     int pipe_fd[2];
     MakePipe(pipe_fd);
-    read_end = pipe_fd[0];
-    write_end = pipe_fd[1];
+    read_end.Assign(pipe_fd[0]);
+    write_end.Assign(pipe_fd[1]);
   }
 
   Pipe(const int fd_read, const int fd_write) :

--- a/test/unittests/t_pipe.cc
+++ b/test/unittests/t_pipe.cc
@@ -17,11 +17,6 @@ class T_Pipe : public ::testing::Test {
   }
 
 
-  virtual void TearDown() {
-    pipe.Close();
-  }
-
-
   struct Foo {
     Foo() : integer(42), character('T'), floating_point(13.37) {}
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -400,9 +400,11 @@ TEST_F(T_Util, MakeSocket) {
   Socket socket_2;
 
   ASSERT_DEATH(MakeSocket(long_path, 0600), ".*");
-  EXPECT_NE(-1, socket_1 = MakeSocket(socket_address, 0777));
+  socket_1.Assign(MakeSocket(socket_address, 0777));
+  EXPECT_NE(-1, socket_1);
   // the second time it should work as well (non socket-alrady-in-use error)
-  EXPECT_NE(-1, socket_2 = MakeSocket(socket_address, 0777));
+  socket_2.Assign(MakeSocket(socket_address, 0777));
+  EXPECT_NE(-1, socket_2);
 }
 
 TEST_F(T_Util, ConnectSocket) {

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1325,7 +1325,6 @@ TEST_F(T_Util, ManagedExecExecuteBinaryDoubleFork) {
   const char *quit = "quit\n";
   retval = shell_pipe.Write(quit, strlen(quit));
   EXPECT_TRUE(retval);
-  shell_pipe.Close();
   close(fd_stderr);
 
   // wait for the child process to terminate
@@ -1371,7 +1370,6 @@ TEST_F(T_Util, ManagedExecExecuteBinaryAsChild) {
   const char *quit = "quit\n";
   retval = shell_pipe.Write(quit, strlen(quit));
   EXPECT_TRUE(retval);
-  shell_pipe.Close();
   close(fd_stderr);
 
   // wait for the child process to terminate


### PR DESCRIPTION
- Creates FileDescriptor and Socket utility classes
- It helps closing the file descriptors when the container object is destroyed, so shielding the resource management under eventual error cases / programmer mistakes
- Extra functionality to read, write, accept connections and listen to connections