### PR TITLE
Fix reading of chunked files in libcvmfs

### DIFF
--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -20,7 +20,7 @@
 // 17: apply new classes around the cache manager
 // 18: add cvmfs_pread and support for chunked files
 // 19: CernVM-FS 2.2.0
-// 20: CernVM-FS 2.3.0
+// 20: fix reading of chunked files
 #define LIBCVMFS_REVISION 20
 
 #include <sys/stat.h>
@@ -112,7 +112,7 @@ int cvmfs_open(cvmfs_context *ctx, const char *path);
 
 /**
  * Reads from a file descriptor returned by cvmfs_open.  File descriptors that
- * have bit 31 set indicate chunked files.
+ * have bit 30 set indicate chunked files.
  */
 ssize_t cvmfs_pread(cvmfs_context *ctx,
                     int fd, void *buf, size_t size, off_t off);

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -689,15 +689,8 @@ int64_t cvmfs_context::Pread(
       ChunkFd *chunk_fd = open_chunks.chunk_fd;
       if ((chunk_fd->fd == -1) || (chunk_fd->chunk_idx != chunk_idx)) {
         if (chunk_fd->fd != -1) fetcher_->cache_mgr()->Close(chunk_fd->fd);
-        if (!open_chunks.chunk_reflist.external_data) {
+        if (open_chunks.chunk_reflist.external_data) {
           chunk_fd->fd = external_fetcher_->Fetch(
-            chunk_list->AtPtr(chunk_idx)->content_hash(),
-            chunk_list->AtPtr(chunk_idx)->size(),
-            "no path info",
-            compression_alg,
-            cache::CacheManager::kTypeRegular);
-        } else {
-          chunk_fd->fd = fetcher_->Fetch(
             chunk_list->AtPtr(chunk_idx)->content_hash(),
             chunk_list->AtPtr(chunk_idx)->size(),
             "no path info",
@@ -705,6 +698,13 @@ int64_t cvmfs_context::Pread(
             cache::CacheManager::kTypeRegular,
             open_chunks.chunk_reflist.path.ToString(),
             chunk_list->AtPtr(chunk_idx)->offset());
+        } else {
+          chunk_fd->fd = fetcher_->Fetch(
+            chunk_list->AtPtr(chunk_idx)->content_hash(),
+            chunk_list->AtPtr(chunk_idx)->size(),
+            "no path info",
+            compression_alg,
+            cache::CacheManager::kTypeRegular);
         }
         if (chunk_fd->fd < 0) {
           chunk_fd->fd = -1;

--- a/test/src/602-libcvmfs/main
+++ b/test/src/602-libcvmfs/main
@@ -1,20 +1,20 @@
 cvmfs_test_name="Libcvmfs test"
 cvmfs_test_autofs_on_startup=false
 
-CVMFS_TEST_597_REPO_COUNT=0
-CVMFS_TEST_597_REPO_PREFIX="test.cern.ch.libcvmfs_"
+CVMFS_TEST_602_REPO_COUNT=0
+CVMFS_TEST_602_REPO_PREFIX="test.cern.ch.libcvmfs_"
 cleanup() {
   echo "running cleanup()"
-  for i in $(seq 1 $CVMFS_TEST_597_REPO_COUNT); do
-    destroy_repo "$CVMFS_TEST_597_REPO_PREFIX$i"
-  done
+  #for i in $(seq 1 $CVMFS_TEST_602_REPO_COUNT); do
+  #  destroy_repo "$CVMFS_TEST_602_REPO_PREFIX$i"
+  #done
 }
 
 cvmfs_run_test() {
   local workdir="$2"
-  local bin_name="597-test"
-  local num_repos=5
-  local base_name="$CVMFS_TEST_597_REPO_PREFIX"
+  local bin_name="602-test"
+  local num_repos=2
+  local base_name="$CVMFS_TEST_602_REPO_PREFIX"
 
   echo "compiling libcvmfs test binary..."
   g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs -pthread -ldl -lssl -lcrypto -luuid -lrt || return 1
@@ -27,7 +27,7 @@ cvmfs_run_test() {
     local repo_name="$base_name$i"
     local repo_dir="/cvmfs/$repo_name"
 
-    CVMFS_TEST_597_REPO_COUNT=$(( $CVMFS_TEST_597_REPO_COUNT + 1 ))
+    CVMFS_TEST_602_REPO_COUNT=$(( $CVMFS_TEST_602_REPO_COUNT + 1 ))
     create_empty_repo "$repo_name" $CVMFS_TEST_USER || return 2
     start_transaction "$repo_name"                  || return 3
 
@@ -38,6 +38,9 @@ cvmfs_run_test() {
     for j in $(seq 1 $i); do
       touch "$repo_dir/list/file$j" || return 7
     done
+
+    # 20MB file (should get chunked)
+    dd if=/dev/urandom of=$repo_dir/large bs=1024 count=20000
 
     publish_repo "$repo_name" || return 8
   done


### PR DESCRIPTION
The problem was introduced by confusing the external fetcher with the native fetcher in libcvmfs.  Integration test coverage added.