### PR TITLE
Add pip and gcovr to slc6_x86_64 docker image

### DIFF
--- a/ci/docker/slc6_x86_64/Dockerfile
+++ b/ci/docker/slc6_x86_64/Dockerfile
@@ -25,7 +25,9 @@ RUN         yum -y update && yum -y install                     \
                                         valgrind-devel          \
                                         voms-devel              \
                                         which                   \
-                                        zlib-devel
+                                        zlib-devel              \
+                                        python-pip              \
+            && pip install --upgrade pip gcovr
 
 RUN         useradd sftnight
 USER        sftnight


### PR DESCRIPTION
Installation of the necessary dependencies for running gcovr for the test coverage.
It might be necessary to also move/modify the run_on_docker.sh script so that it allows more flexibility