### PR TITLE
Refactor: swissknife::InitSignatureManager()

### DIFF
--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -97,7 +97,6 @@ bool Command::InitSigningSignatureManager(
   }
 
   // Load private key
-  // TODO(rmeusel): eliminiate code duplication with swissknife_letter.cc
   if (!signature_manager_->LoadPrivateKeyPath(private_key_path,
                                               private_key_password)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to load private key '%s' (%s)",

--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -51,8 +51,8 @@ bool Command::InitDownloadManager(const bool     follow_redirects,
   return true;
 }
 
-bool Command::InitSignatureManager(const std::string pubkey_path,
-                                   const std::string trusted_certs) {
+bool Command::InitVerifyingSignatureManager(const std::string &pubkey_path,
+                                            const std::string &trusted_certs) {
   if (signature_manager_.IsValid()) {
     return true;
   }

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -87,6 +87,9 @@ class Command {
                            const bool     use_system_proxy = true);
   bool InitVerifyingSignatureManager(const std::string &pubkey_path,
                                      const std::string &trusted_certs = "");
+  bool InitSigningSignatureManager(const std::string &certificate_path,
+                                   const std::string &private_key_path,
+                                   const std::string &private_key_password);
 
   manifest::Manifest* OpenLocalManifest(const std::string path) const;
   manifest::Failures  FetchRemoteManifestEnsemble(

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -85,8 +85,8 @@ class Command {
   bool InitDownloadManager(const bool     follow_redirects,
                            const unsigned max_pool_handles = 1,
                            const bool     use_system_proxy = true);
-  bool InitSignatureManager(const std::string pubkey_path,
-                            const std::string trusted_certs = "");
+  bool InitVerifyingSignatureManager(const std::string &pubkey_path,
+                                     const std::string &trusted_certs = "");
 
   manifest::Manifest* OpenLocalManifest(const std::string path) const;
   manifest::Failures  FetchRemoteManifestEnsemble(

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -687,7 +687,7 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
       return 1;
     }
 
-    if (!this->InitSignatureManager(pubkey_path, trusted_certs)) {
+    if (!this->InitVerifyingSignatureManager(pubkey_path, trusted_certs)) {
       return 1;
     }
   }

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -82,7 +82,7 @@ int CommandGc::Main(const ArgumentList &args) {
 
   const bool follow_redirects = false;
   if (!this->InitDownloadManager(follow_redirects) ||
-      !this->InitSignatureManager(repo_keys)) {
+      !this->InitVerifyingSignatureManager(repo_keys)) {
     LogCvmfs(kLogCatalog, kLogStderr, "failed to init repo connection");
     return 1;
   }

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -121,7 +121,7 @@ CommandTag::Environment* CommandTag::InitializeEnvironment(
 
   // initialize the (swissknife global) signature manager (if possible)
   if (!pubkey_path.empty() &&
-      !this->InitSignatureManager(pubkey_path, trusted_certs)) {
+      !this->InitVerifyingSignatureManager(pubkey_path, trusted_certs)) {
     return NULL;
   }
 

--- a/cvmfs/swissknife_lsrepo.cc
+++ b/cvmfs/swissknife_lsrepo.cc
@@ -47,7 +47,7 @@ int CommandListCatalogs::Main(const ArgumentList &args) {
   if (IsHttpUrl(repo_url)) {
     const bool follow_redirects = false;
     if (!this->InitDownloadManager(follow_redirects) ||
-        !this->InitSignatureManager(repo_keys)) {
+        !this->InitVerifyingSignatureManager(repo_keys)) {
       LogCvmfs(kLogCatalog, kLogStderr, "Failed to init remote connection");
       return 1;
     }

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -141,7 +141,7 @@ int CommandMigrate::Main(const ArgumentList &args) {
 
     const bool follow_redirects = false;
     if (!this->InitDownloadManager(follow_redirects) ||
-        !this->InitSignatureManager(repo_keys)) {
+        !this->InitVerifyingSignatureManager(repo_keys)) {
       LogCvmfs(kLogCatalog, kLogStderr, "Failed to init repo connection");
       return 1;
     }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -534,7 +534,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
-  if (!this->InitSignatureManager(master_keys, trusted_certs)) {
+  if (!this->InitVerifyingSignatureManager(master_keys, trusted_certs)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to initalize CVMFS signatures");
     return 1;
   } else {

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -592,7 +592,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     return 3;
   }
 
-  if (!this->InitSignatureManager(params.public_keys, params.trusted_certs)) {
+  if (!this->InitVerifyingSignatureManager(params.public_keys,
+                                           params.trusted_certs)) {
     return 3;
   }
 


### PR DESCRIPTION
This moves the initialisation of `SignatureManager`s used for signing (rather than verification) to a central place in `cvmfs_swissknife`. Somewhat this is a continuation of a [cleanup campaign a month ago](https://github.com/cvmfs/cvmfs/pull/1380) and DRYs up some code duplications. It is a preparation for further refactorings to introduce a full-featured garbage collection.

Amendment: I've replaced `Spooler*` and `Manifest*` by respective `UniquePtr<>`s to get rid of the `goto fail`.