### PR TITLE
RFC: Opportunistically Retry umount with Force

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1133,14 +1133,22 @@ close_transaction() {
   local tx_lock="${CVMFS_SPOOL_DIR}/in_transaction"
   local tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
 
+  # if not explicitly asked, try if umounting works without force
+  if [ $use_fd_fallback -eq 0 ]; then
+    if ! cvmfs_suid_helper rw_umount     $name || \
+       ! cvmfs_suid_helper rdonly_umount $name; then
+      use_fd_fallback=1
+    fi
+  fi
+
+  # if explicitly asked for or the normal umount failed we apply more force
   if [ $use_fd_fallback -ne 0 ]; then
     cvmfs_suid_helper rw_lazy_umount     $name
     cvmfs_suid_helper kill_cvmfs         $name
     cvmfs_suid_helper rdonly_lazy_umount $name
-  else
-    cvmfs_suid_helper rw_umount $name
-    cvmfs_suid_helper rdonly_umount $name
   fi
+
+  # continue with the remounting
   cvmfs_suid_helper clear_scratch $name
   [ ! -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
   cvmfs_suid_helper rdonly_mount $name > /dev/null

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1132,6 +1132,7 @@ close_transaction() {
   load_repo_config $name
   local tx_lock="${CVMFS_SPOOL_DIR}/in_transaction"
   local tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  local force_grace_time=60
 
   # if not explicitly asked, try if umounting works without force
   if [ $use_fd_fallback -eq 0 ]; then
@@ -1143,6 +1144,14 @@ close_transaction() {
 
   # if explicitly asked for or the normal umount failed we apply more force
   if [ $use_fd_fallback -ne 0 ]; then
+    if [ x"$CVMFS_FORCE_REMOUNT_WARNING" != x"false" ]; then
+      (
+        echo "$name is forcefully remounted in $force_grace_time seconds."
+        echo "Please close files on /cvmfs/$name"
+      ) | wall 2>/dev/null
+      sleep $force_grace_time
+      echo "$name is forcefully remounted NOW." | wall 2>/dev/null
+    fi
     cvmfs_suid_helper rw_lazy_umount     $name
     cvmfs_suid_helper kill_cvmfs         $name
     cvmfs_suid_helper rdonly_lazy_umount $name

--- a/test/src/570-remountrace/main
+++ b/test/src/570-remountrace/main
@@ -42,6 +42,9 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo "disable force remount wall-warnings"
+  echo "CVMFS_FORCE_REMOUNT_WARNING=false" | sudo tee -a /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf
+
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
   echo "starting transaction (1)"


### PR DESCRIPTION
This is a request for comment!

Recently on **lhcbdev.cern.ch** and a while ago in **geant4.cern.ch** we've been seeing release manager machines in an inconsistent state. The transaction is committed successfully but uounting of `/cvmfs/lhcbdev.cern.ch` fails with 'device busy'. This locks up the release manager machine in an inconsistent state requiring to do the following:

```bash
cvmfs_suid_helper rw_umount lhcbdev.cern.ch
cvmfs_suid_helper rdonly_umount lhcbdev.cern.ch
cvmfs_server abort -f lhcbdev.cern.ch
```

The installed version there is CernVM-FS 2.1.20 but the code path in question has not been touched significantly since then, as far as I can see. I can't tell yet what exactly locks up the mountpoint, unfortunately. Also, there are checks for open file descriptors right before the remount happens (using `lsof`). There is a potential race between the check and the actual action of course, but it should be rather short. 

This proposes to apply the 'forced remount' not only if the file descriptor check detected something before, but also if the 'graceful remount' failed. Anything I might be missing out?

Side note: This fix might actually also work around the OverlayFS `/proc/<PID>/fd` bug in 4.x kernels to a certain extend.

