### PR TITLE
Refactor: Rename catalog::Sql to catalog::SqlCatalog

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -170,7 +170,7 @@ bool Catalog::OpenDatabase(const string &db_path) {
   }
 
   // Find out the maximum row id of this database file
-  Sql sql_max_row_id(database(), "SELECT MAX(rowid) FROM catalog;");
+  SqlCatalog sql_max_row_id(database(), "SELECT MAX(rowid) FROM catalog;");
   if (!sql_max_row_id.FetchRow()) {
     LogCvmfs(kLogCatalog, kLogDebug,
              "Cannot retrieve maximal row id for database file %s "
@@ -470,7 +470,7 @@ uint64_t Catalog::GetNumEntries() const {
   const string sql = "SELECT count(*) FROM catalog;";
 
   pthread_mutex_lock(lock_);
-  Sql stmt(database(), sql);
+  SqlCatalog stmt(database(), sql);
   const uint64_t result = (stmt.FetchRow()) ? stmt.RetrieveInt64(0) : 0;
   pthread_mutex_unlock(lock_);
 

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -79,7 +79,8 @@ bool CatalogDatabase::LiveSchemaUpgradeIfNecessary() {
   if (IsEqualSchema(schema_version(), 2.5) && (schema_revision() == 0)) {
     LogCvmfs(kLogCatalog, kLogDebug, "upgrading schema revision (0 --> 1)");
 
-    SqlCatalog sql_upgrade(*this, "ALTER TABLE nested_catalogs ADD size INTEGER;");
+    SqlCatalog sql_upgrade(*this, "ALTER TABLE nested_catalogs "
+                                  "ADD size INTEGER;");
     if (!sql_upgrade.Execute()) {
       LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade nested_catalogs");
       return false;

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -75,17 +75,16 @@ class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
  * Base class for all SQL statement classes.  It wraps a single SQL statement
  * and all neccessary calls of the sqlite3 API to deal with this statement.
  */
-class Sql : public sqlite::Sql {
+class SqlCatalog : public sqlite::Sql {
  public:
   /**
    * Basic constructor to use this class for a specific statement.
    * @param database the database to use the query on
    * @param statement the statement to prepare
    */
-  Sql(const CatalogDatabase &database, const std::string &statement) {
+  SqlCatalog(const CatalogDatabase &database, const std::string &statement) {
     Init(database.sqlite_db(), statement);
   }
-  virtual ~Sql() { /* Done by super class */ }
 
   /**
    * Wrapper for retrieving MD5-ified path names.
@@ -161,7 +160,7 @@ class Sql : public sqlite::Sql {
   }
 
  protected:
-  Sql() : sqlite::Sql() { }
+  SqlCatalog() : sqlite::Sql() {}
 };
 
 
@@ -171,7 +170,7 @@ class Sql : public sqlite::Sql {
 /**
  * Common ancestor of SQL statemnts that deal with directory entries.
  */
-class SqlDirent : public Sql {
+class SqlDirent : public SqlCatalog {
  public:
   // Definition of bit positions for the flags field of a DirectoryEntry
   // All other bit positions are unused
@@ -348,7 +347,7 @@ class SqlLookupInode : public SqlLookup {
  *       DirectoryEntryBase objects, which are restricted to file system meta
  *       data.
  */
-class SqlDirentTouch : public Sql {
+class SqlDirentTouch : public SqlCatalog {
  public:
   explicit SqlDirentTouch(const CatalogDatabase &database);
 
@@ -360,7 +359,7 @@ class SqlDirentTouch : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlNestedCatalogLookup : public Sql {
+class SqlNestedCatalogLookup : public SqlCatalog {
  public:
   explicit SqlNestedCatalogLookup(const CatalogDatabase &database);
   bool BindSearchPath(const PathString &path);
@@ -372,7 +371,7 @@ class SqlNestedCatalogLookup : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlNestedCatalogListing : public Sql {
+class SqlNestedCatalogListing : public SqlCatalog {
  public:
   explicit SqlNestedCatalogListing(const CatalogDatabase &database);
   PathString GetMountpoint() const;
@@ -409,7 +408,7 @@ class SqlDirentUpdate : public SqlDirentWrite {
 //------------------------------------------------------------------------------
 
 
-class SqlDirentUnlink : public Sql {
+class SqlDirentUnlink : public SqlCatalog {
  public:
   explicit SqlDirentUnlink(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);
@@ -422,7 +421,7 @@ class SqlDirentUnlink : public Sql {
 /**
  * Changes the linkcount for all files in a hardlink group.
  */
-class SqlIncLinkcount : public Sql {
+class SqlIncLinkcount : public SqlCatalog {
  public:
   explicit SqlIncLinkcount(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);
@@ -433,7 +432,7 @@ class SqlIncLinkcount : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlChunkInsert : public Sql {
+class SqlChunkInsert : public SqlCatalog {
  public:
   explicit SqlChunkInsert(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);
@@ -444,7 +443,7 @@ class SqlChunkInsert : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlChunksRemove : public Sql {
+class SqlChunksRemove : public SqlCatalog {
  public:
   explicit SqlChunksRemove(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);
@@ -454,7 +453,7 @@ class SqlChunksRemove : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlChunksListing : public Sql {
+class SqlChunksListing : public SqlCatalog {
  public:
   explicit SqlChunksListing(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);
@@ -465,7 +464,7 @@ class SqlChunksListing : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlChunksCount : public Sql {
+class SqlChunksCount : public SqlCatalog {
  public:
   explicit SqlChunksCount(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);
@@ -476,7 +475,7 @@ class SqlChunksCount : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlMaxHardlinkGroup : public Sql {
+class SqlMaxHardlinkGroup : public SqlCatalog {
  public:
   explicit SqlMaxHardlinkGroup(const CatalogDatabase &database);
   uint32_t GetMaxGroupId() const;
@@ -486,7 +485,7 @@ class SqlMaxHardlinkGroup : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlGetCounter : public Sql {
+class SqlGetCounter : public SqlCatalog {
  public:
   explicit SqlGetCounter(const CatalogDatabase &database);
   bool BindCounter(const std::string &counter);
@@ -499,7 +498,7 @@ class SqlGetCounter : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlUpdateCounter : public Sql {
+class SqlUpdateCounter : public SqlCatalog {
  public:
   explicit SqlUpdateCounter(const CatalogDatabase &database);
   bool BindCounter(const std::string &counter);
@@ -510,7 +509,7 @@ class SqlUpdateCounter : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlCreateCounter : public Sql {
+class SqlCreateCounter : public SqlCatalog {
  public:
   explicit SqlCreateCounter(const CatalogDatabase &database);
   bool BindCounter(const std::string &counter);
@@ -521,7 +520,7 @@ class SqlCreateCounter : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlAllChunks : public Sql {
+class SqlAllChunks : public SqlCatalog {
  public:
   explicit SqlAllChunks(const CatalogDatabase &database);
   bool Open();
@@ -533,7 +532,7 @@ class SqlAllChunks : public Sql {
 //------------------------------------------------------------------------------
 
 
-class SqlLookupXattrs : public Sql {
+class SqlLookupXattrs : public SqlCatalog {
  public:
   explicit SqlLookupXattrs(const CatalogDatabase &database);
   bool BindPathHash(const shash::Md5 &hash);

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -71,7 +71,7 @@ static void Error(const std::string                     &message,
 
 
 static void Error(const std::string                     &message,
-                  const catalog::Sql                    &statement,
+                  const catalog::SqlCatalog             &statement,
                   const CommandMigrate::PendingCatalog  *catalog) {
   const std::string err_msg =
     message + "\n"
@@ -627,7 +627,7 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::
     (data->HasNew()) ? data->new_catalog : data->old_catalog;
   const catalog::CatalogDatabase &writable = new_catalog->database();
 
-  catalog::Sql add_nested_catalog(writable,
+  catalog::SqlCatalog add_nested_catalog(writable,
     "INSERT OR REPLACE INTO nested_catalogs (path,   sha1,  size) "
     "                VALUES                 (:path, :sha1, :size);");
 
@@ -678,7 +678,7 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::
   bool retval;
 
   // Find out the discrepancy between MAX(rowid) and COUNT(*)
-  catalog::Sql wasted_inodes(writable,
+  catalog::SqlCatalog wasted_inodes(writable,
     "SELECT COUNT(*), MAX(rowid) FROM catalog;");
   retval = wasted_inodes.FetchRow();
   if (!retval) {
@@ -836,7 +836,7 @@ bool CommandMigrate::MigrationWorker_20x::AttachOldCatalogDatabase(
   const catalog::CatalogDatabase &old_catalog = data->old_catalog->database();
   const catalog::CatalogDatabase &new_catalog = data->new_catalog->database();
 
-  catalog::Sql sql_attach_new(new_catalog,
+  catalog::SqlCatalog sql_attach_new(new_catalog,
     "ATTACH '" + old_catalog.filename() + "' AS old;");
   bool retval = sql_attach_new.Execute();
 
@@ -879,7 +879,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
   //     groupid   : this group id can be used for the new catalog schema
   //     inode     : the inodes that were part of a hardlink group before
   //     linkcount : the linkcount for hardlink group id members
-  catalog::Sql sql_create_hardlinks_table(writable,
+  catalog::SqlCatalog sql_create_hardlinks_table(writable,
     "CREATE TEMPORARY TABLE hardlinks "
     "  (  hardlink_group_id  INTEGER PRIMARY KEY AUTOINCREMENT, "
     "     inode              INTEGER, "
@@ -897,7 +897,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
   // in the old style catalogs. The new catalog schema asks for this specific
   // linkcount. Directory linkcount analysis results will be put into this
   // temporary table
-  catalog::Sql sql_create_linkcounts_table(writable,
+  catalog::SqlCatalog sql_create_linkcounts_table(writable,
     "CREATE TEMPORARY TABLE dir_linkcounts "
     "  (  inode      INTEGER PRIMARY KEY, "
     "     linkcount  INTEGER  );");
@@ -927,7 +927,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
   //       check the number of containing directories. They are defined in a the
   //       linked nested catalog and need to be added later on.
   //       (see: MigrateNestedCatalogMountPoints() for details)
-  catalog::Sql sql_dir_linkcounts(writable,
+  catalog::SqlCatalog sql_dir_linkcounts(writable,
     "INSERT INTO dir_linkcounts "
     "  SELECT c1.inode as inode, "
     "         SUM(IFNULL(MIN(c2.inode,1),0)) + 2 as linkcount "
@@ -958,7 +958,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
   //
   // Note: nested catalog mountpoints still need to be treated separately
   //       (see MigrateNestedCatalogMountPoints() for details)
-  catalog::Sql migrate_file_meta_data(writable,
+  catalog::SqlCatalog migrate_file_meta_data(writable,
     "INSERT INTO catalog "
     "  SELECT md5path_1, md5path_2, "
     "         parent_1, parent_2, "
@@ -1015,7 +1015,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
   // Note: The 'schema' is explicitly not copied to the new catalog.
   //       Each catalog contains a revision, which is also copied here and that
   //       is later updated by calling catalog->IncrementRevision()
-  catalog::Sql copy_properties(writable,
+  catalog::SqlCatalog copy_properties(writable,
     "INSERT OR REPLACE INTO properties "
     "  SELECT key, value "
     "  FROM old.properties "
@@ -1057,7 +1057,7 @@ bool CommandMigrate::MigrationWorker_20x::AnalyzeFileLinkcounts(
   //       supported hardlink groups.
   //       Unsupported hardlink groups will be be treated as normal files with
   //       the same content
-  catalog::Sql sql_create_hardlinks_scratch_table(writable,
+  catalog::SqlCatalog sql_create_hardlinks_scratch_table(writable,
     "CREATE TEMPORARY TABLE hl_scratch AS "
     "  SELECT c1.inode AS inode, c1.md5path_1, c1.md5path_2, "
     "         c1.parent_1 as c1p1, c1.parent_2 as c1p2, "
@@ -1078,7 +1078,7 @@ bool CommandMigrate::MigrationWorker_20x::AnalyzeFileLinkcounts(
   // transferred into the new catalog as so called hardlink groups. Unsupported
   // hardlinks need to be discarded and treated as normal files containing the
   // exact same data
-  catalog::Sql fill_linkcount_table_for_files(writable,
+  catalog::SqlCatalog fill_linkcount_table_for_files(writable,
     "INSERT INTO hardlinks (inode, linkcount)"
     "  SELECT inode, count(*) as linkcount "
     "  FROM ( "
@@ -1121,7 +1121,8 @@ bool CommandMigrate::MigrationWorker_20x::AnalyzeFileLinkcounts(
 
   // The file linkcount and hardlink analysis is finished and the scratch table
   // can be deleted...
-  catalog::Sql drop_hardlink_scratch_space(writable, "DROP TABLE hl_scratch;");
+  catalog::SqlCatalog drop_hardlink_scratch_space(writable,
+                                                  "DROP TABLE hl_scratch;");
   retval = drop_hardlink_scratch_space.Execute();
   if (!retval) {
     Error("Failed to remove file linkcount analysis scratch table",
@@ -1131,7 +1132,7 @@ bool CommandMigrate::MigrationWorker_20x::AnalyzeFileLinkcounts(
 
   // Do some statistics if asked for...
   if (collect_catalog_statistics_) {
-    catalog::Sql count_hardlinks(writable,
+    catalog::SqlCatalog count_hardlinks(writable,
       "SELECT count(*), sum(linkcount) FROM hardlinks;");
     retval = count_hardlinks.FetchRow();
     if (!retval) {
@@ -1156,7 +1157,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateNestedCatalogMountPoints(
   bool retval;
 
   // preparing the SQL statement for nested catalog mountpoint update
-  catalog::Sql update_mntpnt_linkcount(writable,
+  catalog::SqlCatalog update_mntpnt_linkcount(writable,
     "UPDATE catalog "
     "SET hardlinks = :linkcount "
     "WHERE md5path_1 = :md5_1 AND md5path_2 = :md5_2;");
@@ -1462,15 +1463,15 @@ bool CommandMigrate::MigrationWorker_20x::GenerateCatalogStatistics(
 
   // Count various directory entry types in the catalog to fill up the catalog
   // statistics counters introduced in the current catalog schema
-  catalog::Sql count_regular_files(writable,
+  catalog::SqlCatalog count_regular_files(writable,
     "SELECT count(*) FROM catalog "
     "                WHERE  flags & :flag_file "
     "                       AND NOT flags & :flag_link;");
-  catalog::Sql count_symlinks(writable,
+  catalog::SqlCatalog count_symlinks(writable,
     "SELECT count(*) FROM catalog WHERE flags & :flag_link;");
-  catalog::Sql count_directories(writable,
+  catalog::SqlCatalog count_directories(writable,
     "SELECT count(*) FROM catalog WHERE flags & :flag_dir;");
-  catalog::Sql aggregate_file_size(writable,
+  catalog::SqlCatalog aggregate_file_size(writable,
     "SELECT sum(size) FROM catalog WHERE  flags & :flag_file "
     "                                     AND NOT flags & :flag_link");
 
@@ -1567,7 +1568,7 @@ bool CommandMigrate::MigrationWorker_20x::DetachOldCatalogDatabase(
 {
   assert(data->HasNew());
   const catalog::CatalogDatabase &writable = data->new_catalog->database();
-  catalog::Sql detach_old_catalog(writable, "DETACH old;");
+  catalog::SqlCatalog detach_old_catalog(writable, "DETACH old;");
   const bool retval = detach_old_catalog.Execute();
   if (!retval) {
     Error("Failed to detach old catalog database.", detach_old_catalog, data);
@@ -1646,12 +1647,12 @@ bool CommandMigrate::MigrationWorker_217::GenerateNewStatisticsCounters
 
   // Count various directory entry types in the catalog to fill up the catalog
   // statistics counters introduced in the current catalog schema
-  catalog::Sql count_chunked_files(writable,
+  catalog::SqlCatalog count_chunked_files(writable,
     "SELECT count(*), sum(size) FROM catalog "
     "                WHERE flags & :flag_chunked_file;");
-  catalog::Sql count_file_chunks(writable,
+  catalog::SqlCatalog count_file_chunks(writable,
     "SELECT count(*) FROM chunks;");
-  catalog::Sql aggregate_file_size(writable,
+  catalog::SqlCatalog aggregate_file_size(writable,
     "SELECT sum(size) FROM catalog WHERE  flags & :flag_file "
     "                                     AND NOT flags & :flag_link;");
 
@@ -1709,7 +1710,7 @@ bool CommandMigrate::MigrationWorker_217::UpdateCatalogSchema
   assert(!data->HasNew());
   const catalog::CatalogDatabase &writable =
     GetWritable(data->old_catalog)->database();
-  catalog::Sql update_schema_version(writable,
+  catalog::SqlCatalog update_schema_version(writable,
     "UPDATE properties SET value = :schema_version WHERE key = 'schema';");
 
   const bool retval =
@@ -1762,13 +1763,13 @@ bool CommandMigrate::ChownMigrationWorker::ApplyPersonaMappings(
     return false;
   }
 
-  catalog::Sql uid_sql(db, uid_map_statement_);
+  catalog::SqlCatalog uid_sql(db, uid_map_statement_);
   if (!uid_sql.Execute()) {
     Error("Failed to update UIDs", uid_sql, data);
     return false;
   }
 
-  catalog::Sql gid_sql(db, gid_map_statement_);
+  catalog::SqlCatalog gid_sql(db, gid_map_statement_);
   if (!gid_sql.Execute()) {
     Error("Failed to update GIDs", gid_sql, data);
     return false;
@@ -1871,7 +1872,7 @@ bool CommandMigrate::HardlinkRemovalMigrationWorker::BreakUpHardlinks(
                            "SET hardlinks = 1 "
                            "WHERE flags & :file_flag "
                            "  AND hardlinks > 1;";
-  catalog::Sql hardlink_removal_sql(db, stmt);
+  catalog::SqlCatalog hardlink_removal_sql(db, stmt);
   hardlink_removal_sql.BindInt64(1, catalog::SqlDirent::kFlagFile);
   hardlink_removal_sql.Execute();
 


### PR DESCRIPTION
This fixes a severe code smell. Namely we've had two implementations of `class Sql`, one residing in the namespace `sqlite` and one (that actually directly inherited from the first) in namespace `catalog`. This renames the latter one to `catalog::SqlCatalog` for clarity and consistency with `history::SqlHistory` and `manifest::SqlReflog` (to come [here](https://github.com/cvmfs/cvmfs/pull/1511)).