### PR TITLE
Feature: Lazy Initialisation of SQL statements

### DIFF
--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -273,15 +273,6 @@ class SqlListContentHashes : public SqlDirent {
 
 
 class SqlLookup : public SqlDirent {
- protected:
-  /**
-   * There are several lookup statements which all share a list of elements to
-   * load.
-   * @return a list of sql fields to query for DirectoryEntry
-   */
-  std::string GetFieldsToSelect(const float schema_version,
-                                const unsigned schema_revision) const;
-
  public:
   /**
    * Retrieves a DirectoryEntry from a freshly performed SqlLookup statement.
@@ -334,6 +325,30 @@ class SqlLookupInode : public SqlLookup {
  public:
   explicit SqlLookupInode(const CatalogDatabase &database);
   bool BindRowId(const uint64_t inode);
+};
+
+
+//------------------------------------------------------------------------------
+
+
+/**
+ * This SQL statement is only used for legacy catalog migrations and has been
+ * moved here as it needs to use a locally defined macro inside catalog_sql.cc
+ *
+ * Queries a single catalog and looks for DirectoryEntrys that have direct
+ * children in the same catalog but are marked as 'nested catalog mountpoints'.
+ * This is an inconsistent situation, since a mountpoint is supposed to be empty
+ * and it's children are stored in the corresponding referenced nested catalog.
+ *
+ * Note: the user code needs to check if there is a corresponding nested catalog
+ *       reference for the found dangling mountpoints. If so, we also have a
+ *       bogus state, but it is not reliably fixable automatically. The child-
+ *       DirectoryEntrys would be masked by the mounting nested catalog but it
+ *       is not clear if we can simply delete them or if this would destroy data.
+ */
+class SqlLookupDanglingMountpoints : public catalog::SqlLookup {
+ public:
+  explicit SqlLookupDanglingMountpoints(const CatalogDatabase &database);
 };
 
 

--- a/cvmfs/history_sql.cc
+++ b/cvmfs/history_sql.cc
@@ -158,9 +158,7 @@ bool SqlInsertTag::BindTag(const History::Tag &tag) {
 
 
 SqlRemoveTag::SqlRemoveTag(const HistoryDatabase *database) {
-  const std::string stmt = "DELETE FROM tags WHERE name = :name;";
-  const bool success = Init(database->sqlite_db(), stmt);
-  assert(success);
+  DeferredInit(database->sqlite_db(), "DELETE FROM tags WHERE name = :name;");
 }
 
 bool SqlRemoveTag::BindName(const std::string &name) {
@@ -208,9 +206,7 @@ bool SqlFindTagByDate::BindTimestamp(const time_t timestamp) {
 
 
 SqlCountTags::SqlCountTags(const HistoryDatabase *database) {
-  const bool success = Init(database->sqlite_db(),
-                            "SELECT count(*) FROM tags;");
-  assert(success);
+  DeferredInit(database->sqlite_db(), "SELECT count(*) FROM tags;");
 }
 
 unsigned SqlCountTags::RetrieveCount() const {
@@ -244,10 +240,8 @@ SqlGetChannelTips::SqlGetChannelTips(const HistoryDatabase *database) {
 }
 
 SqlGetHashes::SqlGetHashes(const HistoryDatabase *database) {
-  const bool success = Init(database->sqlite_db(),
-                            "SELECT DISTINCT hash FROM tags "
-                            "ORDER BY revision ASC");
-  assert(success);
+  DeferredInit(database->sqlite_db(), "SELECT DISTINCT hash FROM tags "
+                                      "ORDER BY revision ASC");
 }
 
 shash::Any SqlGetHashes::RetrieveHash() const {
@@ -293,10 +287,9 @@ bool SqlRecycleBin::CheckSchema(const HistoryDatabase *database) const {
 
 SqlRecycleBinInsert::SqlRecycleBinInsert(const HistoryDatabase *database) {
   assert(CheckSchema(database));
-  const bool success = Init(database->sqlite_db(),
-                            "INSERT OR IGNORE INTO recycle_bin (hash, flags) "
-                            "VALUES (:hash, :flags)");
-  assert(success);
+  DeferredInit(database->sqlite_db(),
+               "INSERT OR IGNORE INTO recycle_bin (hash, flags) "
+               "VALUES (:hash, :flags)");
 }
 
 
@@ -313,9 +306,7 @@ bool SqlRecycleBinInsert::BindTag(const History::Tag &condemned_tag) {
 
 SqlRecycleBinList::SqlRecycleBinList(const HistoryDatabase *database) {
   assert(CheckSchema(database));
-  const bool success = Init(database->sqlite_db(), "SELECT hash, flags "
-                                                   "FROM recycle_bin;");
-  assert(success);
+  DeferredInit(database->sqlite_db(), "SELECT hash, flags FROM recycle_bin;");
 }
 
 
@@ -335,8 +326,7 @@ shash::Any SqlRecycleBinList::RetrieveHash() {
 
 SqlRecycleBinFlush::SqlRecycleBinFlush(const HistoryDatabase *database) {
   assert(CheckSchema(database));
-  const bool success = Init(database->sqlite_db(), "DELETE FROM recycle_bin;");
-  assert(success);
+  DeferredInit(database->sqlite_db(), "DELETE FROM recycle_bin;");
 }
 
 

--- a/cvmfs/history_sql.cc
+++ b/cvmfs/history_sql.cc
@@ -123,18 +123,21 @@ bool HistoryDatabase::UpgradeSchemaRevision_10_2() {
 //------------------------------------------------------------------------------
 
 #define DB_FIELDS_V1R0  "name, hash, revision, timestamp, channel, description"
-#define DB_FIELDS_V1R1  "name, hash, revision, timestamp, channel, description, size"
-#define DB_PLACEHOLDERS ":name, :hash, :revision, :timestamp, :channel, :description, :size"
+#define DB_FIELDS_V1R1  "name, hash, revision, timestamp, channel, " \
+                        "description,  size"
+#define DB_PLACEHOLDERS ":name, :hash, :revision, :timestamp, :channel, " \
+                        ":description, :size"
 #define ROLLBACK_COND   "(revision > :target_rev  OR " \
                         " name     = :target_name)   " \
                         "AND channel  = :target_chan "
 
-#define MAKE_STATEMENT(STMT_TMPL, REV)                         \
-static const std::string REV =                                 \
-  ReplaceAll(                                                  \
-    ReplaceAll(                                                \
-      ReplaceAll(STMT_TMPL, "@DB_FIELDS@", DB_FIELDS_ ## REV), \
-      "@DB_PLACEHOLDERS@", DB_PLACEHOLDERS),                   \
+#define MAKE_STATEMENT(STMT_TMPL, REV)       \
+static const std::string REV =               \
+  ReplaceAll(                                \
+    ReplaceAll(                              \
+      ReplaceAll(STMT_TMPL,                  \
+        "@DB_FIELDS@", DB_FIELDS_ ## REV),   \
+      "@DB_PLACEHOLDERS@", DB_PLACEHOLDERS), \
     "@ROLLBACK_COND@", ROLLBACK_COND)
 
 #define MAKE_STATEMENTS(STMT_TMPL) \

--- a/cvmfs/history_sql.cc
+++ b/cvmfs/history_sql.cc
@@ -122,23 +122,39 @@ bool HistoryDatabase::UpgradeSchemaRevision_10_2() {
 
 //------------------------------------------------------------------------------
 
+#define DB_FIELDS_V1R0  "name, hash, revision, timestamp, channel, description"
+#define DB_FIELDS_V1R1  "name, hash, revision, timestamp, channel, description, size"
+#define DB_PLACEHOLDERS ":name, :hash, :revision, :timestamp, :channel, :description, :size"
+#define ROLLBACK_COND   "(revision > :target_rev  OR " \
+                        " name     = :target_name)   " \
+                        "AND channel  = :target_chan "
 
+#define MAKE_STATEMENT(STMT_TMPL, REV)                         \
+static const std::string REV =                                 \
+  ReplaceAll(                                                  \
+    ReplaceAll(                                                \
+      ReplaceAll(STMT_TMPL, "@DB_FIELDS@", DB_FIELDS_ ## REV), \
+      "@DB_PLACEHOLDERS@", DB_PLACEHOLDERS),                   \
+    "@ROLLBACK_COND@", ROLLBACK_COND)
 
-const std::string SqlHistory::db_fields_v1r0 =
-  "name, hash, revision, timestamp, channel, description";
+#define MAKE_STATEMENTS(STMT_TMPL) \
+  MAKE_STATEMENT(STMT_TMPL, V1R0); \
+  MAKE_STATEMENT(STMT_TMPL, V1R1)
 
-const std::string SqlHistory::db_fields_v1r1 =
-  "name, hash, revision, timestamp, channel, description, size";
+#define DEFERRED_INIT(DB, REV) \
+  DeferredInit((DB)->sqlite_db(), (REV).c_str())
 
-const std::string SqlInsertTag::db_placeholders =
-  ":name, :hash, :revision, :timestamp, :channel, :description, :size";
+#define DEFERRED_INITS(DB) \
+  if ((DB)->IsEqualSchema((DB)->schema_version(), 1.0f) && \
+      (DB)->schema_revision() == 0) {                      \
+    DEFERRED_INIT((DB), V1R0);                             \
+  } else {                                                 \
+    DEFERRED_INIT((DB), V1R1);                             \
+  }
 
 SqlInsertTag::SqlInsertTag(const HistoryDatabase *database) {
-  const std::string stmt =
-    "INSERT INTO tags (" + db_fields(database) + ")"
-    "VALUES (" + db_placeholders + ");";
-  const bool success = Init(database->sqlite_db(), stmt);
-  assert(success);
+  MAKE_STATEMENTS("INSERT INTO tags (@DB_FIELDS@) VALUES (@DB_PLACEHOLDERS@);");
+  DEFERRED_INITS(database);
 }
 
 
@@ -170,10 +186,8 @@ bool SqlRemoveTag::BindName(const std::string &name) {
 
 
 SqlFindTag::SqlFindTag(const HistoryDatabase *database) {
-  const std::string stmt =
-    "SELECT " + db_fields(database) + " FROM tags WHERE name = :name LIMIT 1;";
-  const bool success = Init(database->sqlite_db(), stmt);
-  assert(success);
+  MAKE_STATEMENTS("SELECT @DB_FIELDS@ FROM tags WHERE name = :name LIMIT 1;");
+  DEFERRED_INITS(database);
 }
 
 bool SqlFindTag::BindName(const std::string &name) {
@@ -190,11 +204,10 @@ SqlFindTagByDate::SqlFindTagByDate(const HistoryDatabase *database) {
   // conceptually goes back in the revision history  |  ORDER BY revision DESC
   // and picks the first tag                         |  LIMIT 1
   // that is older than the given timestamp          |  WHICH timestamp <= :ts
-  const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields(database) + " FROM tags "
-                            "WHERE timestamp <= :timestamp "
-                            "ORDER BY revision DESC LIMIT 1;");
-  assert(success);
+  MAKE_STATEMENTS("SELECT @DB_FIELDS@ FROM tags "
+                  "WHERE timestamp <= :timestamp "
+                  "ORDER BY revision DESC LIMIT 1;");
+  DEFERRED_INITS(database);
 }
 
 bool SqlFindTagByDate::BindTimestamp(const time_t timestamp) {
@@ -220,10 +233,8 @@ unsigned SqlCountTags::RetrieveCount() const {
 
 
 SqlListTags::SqlListTags(const HistoryDatabase *database) {
-  const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields(database) + " FROM tags "
-                            "ORDER BY revision DESC;");
-  assert(success);
+  MAKE_STATEMENTS("SELECT @DB_FIELDS@ FROM tags ORDER BY revision DESC;");
+  DEFERRED_INITS(database);
 }
 
 
@@ -231,12 +242,10 @@ SqlListTags::SqlListTags(const HistoryDatabase *database) {
 
 
 SqlGetChannelTips::SqlGetChannelTips(const HistoryDatabase *database) {
-  const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields(database) + ", "
-                            "  MAX(revision) AS max_rev "
-                            "FROM tags "
-                            "GROUP BY channel;");
-  assert(success);
+  MAKE_STATEMENTS("SELECT @DB_FIELDS@, MAX(revision) AS max_rev "
+                  "FROM tags "
+                  "GROUP BY channel;");
+  DEFERRED_INITS(database);
 }
 
 SqlGetHashes::SqlGetHashes(const HistoryDatabase *database) {
@@ -254,10 +263,8 @@ shash::Any SqlGetHashes::RetrieveHash() const {
 
 
 SqlRollbackTag::SqlRollbackTag(const HistoryDatabase *database) {
-  const bool success = Init(database->sqlite_db(),
-                            "DELETE FROM tags WHERE "
-                             + rollback_condition + ";");
-  assert(success);
+  MAKE_STATEMENTS("DELETE FROM tags WHERE @ROLLBACK_COND@;");
+  DEFERRED_INITS(database);
 }
 
 
@@ -265,11 +272,10 @@ SqlRollbackTag::SqlRollbackTag(const HistoryDatabase *database) {
 
 
 SqlListRollbackTags::SqlListRollbackTags(const HistoryDatabase *database) {
-  const bool success = Init(database->sqlite_db(),
-                            "SELECT " + db_fields(database) + " FROM tags "
-                            "WHERE " + rollback_condition + " "
-                            "ORDER BY revision DESC;");
-  assert(success);
+  MAKE_STATEMENTS("SELECT @DB_FIELDS@ FROM tags "
+                  "WHERE @ROLLBACK_COND@ "
+                  "ORDER BY revision DESC;");
+  DEFERRED_INITS(database);
 }
 
 

--- a/cvmfs/history_sql.h
+++ b/cvmfs/history_sql.h
@@ -54,21 +54,7 @@ class HistoryDatabase : public sqlite::Database<HistoryDatabase> {
 //------------------------------------------------------------------------------
 
 
-class SqlHistory : public sqlite::Sql {
- protected:
-  const std::string& db_fields(const HistoryDatabase *database) const {
-    if (database->IsEqualSchema(database->schema_version(), 1.0f) &&
-        database->schema_revision() == 0) {
-      return db_fields_v1r0;
-    } else {
-      return db_fields_v1r1;
-    }
-  }
-
- private:
-  static const std::string db_fields_v1r0;
-  static const std::string db_fields_v1r1;
-};
+class SqlHistory : public sqlite::Sql {};
 
 
 /**

--- a/cvmfs/reflog_sql.h
+++ b/cvmfs/reflog_sql.h
@@ -49,7 +49,6 @@ class SqlReflog : public sqlite::Sql {
   };
 
  protected:
-  std::string db_fields(const ReflogDatabase *database) const;
   shash::Suffix ToSuffix(const ReferenceType type) const;
 };
 

--- a/cvmfs/sql.cc
+++ b/cvmfs/sql.cc
@@ -12,7 +12,12 @@ using namespace std;  // NOLINT
 
 namespace sqlite {
 
-Sql::Sql(sqlite3 *sqlite_db, const std::string &statement) {
+Sql::Sql(sqlite3 *sqlite_db, const std::string &statement)
+  : database_(NULL)
+  , statement_(NULL)
+  , query_string_(NULL)
+  , last_error_code_(0)
+{
   Init(sqlite_db, statement);
 }
 
@@ -34,6 +39,7 @@ Sql::~Sql() {
  * @return true on success otherwise false
  */
 bool Sql::Execute() {
+  LazyInit();
   last_error_code_ = sqlite3_step(statement_);
 #ifdef DEBUGMSG
   if (!Successful()) {
@@ -53,6 +59,7 @@ bool Sql::Execute() {
  * @return true if a new row was fetched otherwise false
  */
 bool Sql::FetchRow() {
+  LazyInit();
   last_error_code_ = sqlite3_step(statement_);
   return SQLITE_ROW == last_error_code_;
 }
@@ -122,27 +129,39 @@ bool Sql::Reset() {
 
 
 bool Sql::Init(const sqlite3 *database, const std::string &statement) {
-  last_error_code_ = sqlite3_prepare_v2(const_cast<sqlite3 *>(database),
-                                        statement.c_str(),
+  database_ = const_cast<sqlite3 *>(database);
+  return Init(statement.c_str());
+}
+
+bool Sql::Init(const char *statement) {
+  assert(NULL == statement_);
+  assert(NULL != database_);
+
+  last_error_code_ = sqlite3_prepare_v2(database_,
+                                        statement,
                                         -1,  // parse until null termination
                                         &statement_,
                                         NULL);
 
   if (!Successful()) {
     LogCvmfs(kLogSql, kLogDebug, "failed to prepare statement '%s' (%d: %s)",
-             statement.c_str(), GetLastError(),
-             sqlite3_errmsg(const_cast<sqlite3 *>(database)));
+             statement, GetLastError(), sqlite3_errmsg(database_));
     return false;
   }
 
   LogCvmfs(kLogSql, kLogDebug, "successfully prepared statement '%s'",
-           statement.c_str());
+           statement);
   return true;
 }
 
+void Sql::DeferredInit(const sqlite3 *database, const char *statement) {
+  assert(NULL == database_);
+  database_     = const_cast<sqlite3 *>(database);
+  query_string_ = statement;
+}
+
 std::string Sql::GetLastErrorMsg() const {
-  sqlite3* db     = sqlite3_db_handle(statement_);
-  std::string msg = sqlite3_errmsg(db);
+  std::string msg = sqlite3_errmsg(database_);
   return msg;
 }
 

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -304,28 +304,34 @@ class Sql {
   std::string GetLastErrorMsg() const;
 
   bool BindBlob(const int index, const void* value, const int size) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_blob(statement_, index, value, size,
                                          SQLITE_STATIC);
     return Successful();
   }
   bool BindBlobTransient(const int index, const void* value, const int size) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_blob(statement_, index, value, size,
                                          SQLITE_TRANSIENT);
     return Successful();
   }
   bool BindDouble(const int index, const double value) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_double(statement_, index, value);
     return Successful();
   }
   bool BindInt(const int index, const int value) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_int(statement_, index, value);
     return Successful();
   }
   bool BindInt64(const int index, const sqlite3_int64 value) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_int64(statement_, index, value);
     return Successful();
   }
   bool BindNull(const int index) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_null(statement_, index);
     return Successful();
   }
@@ -342,6 +348,7 @@ class Sql {
                 const char* value,
                 const int   size,
                 void(*dtor)(void*) = SQLITE_STATIC) {
+    LazyInit();
     last_error_code_ = sqlite3_bind_text(statement_, index, value, size, dtor);
     return Successful();
   }
@@ -394,8 +401,16 @@ class Sql {
   inline T Retrieve(const int index);
 
  protected:
-  Sql() : statement_(NULL), last_error_code_(0) { }
-  bool Init(const sqlite3 *database, const std::string &statement);
+  Sql()
+    : database_(NULL)
+    , statement_(NULL)
+    , query_string_(NULL)
+    , last_error_code_(0) { }
+
+  bool IsInitialized() const { return statement_ != NULL; }
+
+  bool Init(const sqlite3 *database, const std::string  &statement);
+  void DeferredInit(const sqlite3 *database, const char *statement);
 
   /**
    * Checks the last action for success
@@ -407,8 +422,21 @@ class Sql {
            SQLITE_DONE == last_error_code_;
   }
 
-  sqlite3_stmt *statement_;
-  int last_error_code_;
+ private:
+  bool Init(const char *statement);
+  void LazyInit() {
+    if (!IsInitialized()) {
+      assert(NULL != database_);
+      assert(NULL != query_string_);
+      const bool success = Init(query_string_);
+      assert(success);
+    }
+  }
+
+  sqlite3       *database_;
+  sqlite3_stmt  *statement_;
+  const char    *query_string_;
+  int            last_error_code_;
 };
 
 }  // namespace sqlite

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -433,7 +433,7 @@ class Sql {
    * @param statement  the query string to be prepared for execution
    * @return           true on successful statement preparation
    */
-  bool Init(const sqlite3 *database, const std::string  &statement);
+  bool Init(const sqlite3 *database, const std::string &statement);
 
   /**
    * Defers the initialization of the prepared statement to the first usage to


### PR DESCRIPTION
**Work in progress...**

This allows derived `Sql` wrapper classes to opt for lazy initialisation of their prepared statements. We hope to safe memory and CPU cycles this way. For example each catalog opened for writing is preparing 17 SQL statements even though it might only ever need a small subset of them.

Furthermore this changes some low-hanging fruits in *history_sql.cc* to utilise the new `Sql::DeferredInit()` for demoing the API.

More adaptions in other `Sql` subclasses to come...