### PR TITLE
Increase the number of dots in travis

### DIFF
--- a/ci/run_travis.sh
+++ b/ci/run_travis.sh
@@ -31,7 +31,7 @@ print_dots() {
   while true; do
     if [ -f $PRINT_FILE ]; then
       echo -n "."
-      sleep 30
+      sleep 10
     else
       sleep 1
     fi


### PR DESCRIPTION
It's considerably ugly not to see more dots printed in the output. The activity and the "Done" are pretty close. Printing one every 10 seconds instead of 30 would make it prettier