### PR TITLE
FIX: 32bit compile of libcvmfs on Fedora 23

### DIFF
--- a/cvmfs/libcvmfs_public_syms.txt
+++ b/cvmfs/libcvmfs_public_syms.txt
@@ -1,3 +1,6 @@
+__x86.get_pc_thunk.ax
+__x86.get_pc_thunk.bx
+__x86.get_pc_thunk.dx
 __i686.get_pc_thunk.bx
 __i686.get_pc_thunk.cx
 cvmfs_init


### PR DESCRIPTION
This adds three new symbols to `libcvmfs_public_syms.txt`. I have no idea what I'm doing here, but apparently something similar was necessary in mid 2013 to make it compile on 32bit. Google says that `get_pc_thunk` style stuff is used to get the location of the code in relocatable binaries. Frankly I find it a bit troublesome that these "obviously private" symbols need to be declared public to make it link successfully. O.O