### PR TITLE
FIX: False-Positive `lsof` Output

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2330,7 +2330,7 @@ If you go for production, backup you software signing keys in /etc/cvmfs/keys/!"
 
 generate_lsof_report_for_mountpoint() {
   local mountpoint="$1"
-  lsof | grep $mountpoint | awk '{print $1,$2,$3,$NF}' | column -t || true
+  lsof "$mountpoint" | awk '{print $1,$2,$3,$NF}' | column -t || true
 }
 
 


### PR DESCRIPTION
This fixes the `lsof` output shown to the user if file descriptors are detected by `cvmfs_server publish`. The `lsof` log was also containing open files in directories with a similar name as the repository's mount point (see below):

```
WARNING! There are open read-only file descriptors in /cvmfs/lhcbdev.cern.ch
  --> This is potentially harmful and might cause problems later on.
      We can anyway perform the requested operation, but this will most likely
      break other processes with open file descriptors on /cvmfs/lhcbdev.cern.ch!

      The following lsof report might show the processes with open file handles

bash       6666   cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
bash       7217   cvlhcbdev  /cvmfs/lhcbdev.cern.ch   # <<== ONLY THAT ONE IS VIABLE
bash       9386   cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev/logs
less       9727   cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev/logs
less       9727   cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev/logs/manager.log
bash       10311  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
cvmfs_ser  11257  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
lsof       11547  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
grep       11548  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
awk        11549  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
column     11550  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
lsof       11551  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
bash       29288  cvlhcbdev  /var/spool/cvmfs/lhcbdev.cern.ch/cvlhcbdev
```

Note however, that is a pure UX fix, the actual check for open files is not affected.