### PR TITLE
FIX/RFC: Make Sure that `cvmfs_suid_helper` Runs in Clean Environment

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1092,6 +1092,10 @@ check_lock() {
   __is_valid_lock "${path}" "$ignore_stale"
 }
 
+run_suid_helper() {
+  env -i /usr/bin/cvmfs_suid_helper $@
+}
+
 
 # checks if a repository is currently in a transaction
 #
@@ -1110,7 +1114,7 @@ open_transaction() {
 
   is_stratum0 $name                    || die "Cannot open transaction on Stratum1"
   acquire_lock "$tx_lock" ignore_stale || die "Failed to create transaction lock"
-  cvmfs_suid_helper open  $name        || die "Failed to make /cvmfs/$name writable"
+  run_suid_helper open $name           || die "Failed to make /cvmfs/$name writable"
 
   to_syslog_for_repo $name "opened transaction"
 }
@@ -1136,8 +1140,8 @@ close_transaction() {
 
   # if not explicitly asked, try if umounting works without force
   if [ $use_fd_fallback -eq 0 ]; then
-    if ! cvmfs_suid_helper rw_umount     $name || \
-       ! cvmfs_suid_helper rdonly_umount $name; then
+    if ! run_suid_helper rw_umount     $name || \
+       ! run_suid_helper rdonly_umount $name; then
       use_fd_fallback=1
     fi
   fi
@@ -1152,16 +1156,16 @@ close_transaction() {
       sleep $force_grace_time
       echo "$name is forcefully remounted NOW." | wall 2>/dev/null
     fi
-    cvmfs_suid_helper rw_lazy_umount     $name
-    cvmfs_suid_helper kill_cvmfs         $name
-    cvmfs_suid_helper rdonly_lazy_umount $name
+    run_suid_helper rw_lazy_umount     $name
+    run_suid_helper kill_cvmfs         $name
+    run_suid_helper rdonly_lazy_umount $name
   fi
 
   # continue with the remounting
-  cvmfs_suid_helper clear_scratch $name
+  run_suid_helper clear_scratch $name
   [ ! -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
-  cvmfs_suid_helper rdonly_mount $name > /dev/null
-  cvmfs_suid_helper rw_mount $name
+  run_suid_helper rdonly_mount $name > /dev/null
+  run_suid_helper rw_mount $name
   release_lock "$tx_lock"
 
   local fallback_msg=""
@@ -1185,7 +1189,7 @@ publish_starting() {
   local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
   acquire_lock "$pub_lock" ignore_stale || die "Failed to acquire publishing lock"
   trap "publish_failed $name" EXIT HUP INT TERM
-  cvmfs_suid_helper lock $name
+  run_suid_helper lock $name
   to_syslog_for_repo $name "started publishing"
 }
 
@@ -1195,7 +1199,7 @@ publish_failed() {
   local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
   trap - EXIT HUP INT TERM
   release_lock $pub_lock
-  cvmfs_suid_helper open $name
+  run_suid_helper open $name
   to_syslog_for_repo $name "failed to publish"
 }
 
@@ -1521,19 +1525,19 @@ health_check() {
     if [ $rw_broken -eq 0 ]; then
       echo "Only the lower union file system branch is broken" >&2
       echo -n "Note: Trying to umount /cvmfs/${name}... "
-      cvmfs_suid_helper rw_umount $name && echo "success" || { echo "fail"; exit 1; }
+      run_suid_helper rw_umount $name && echo "success" || { echo "fail"; exit 1; }
       rw_broken=1 # will be fixed downstream
     fi
 
     echo -n "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... "
-    cvmfs_suid_helper rdonly_mount $name > /dev/null && success=true || success=false
+    run_suid_helper rdonly_mount $name > /dev/null && success=true || success=false
     __health_check_syslog_repair_info $name ".../rdonly" $success
     $success && echo "success" || { echo "fail"; exit 1; }
   fi
 
   if [ $rw_broken -eq 1 ]; then
     echo -n "Note: Trying to mount /cvmfs/${name}... "
-    cvmfs_suid_helper rw_mount $name && success=true || success=false
+    run_suid_helper rw_mount $name && success=true || success=false
     __health_check_syslog_repair_info $name "/cvmfs/${name}" $success
     $success && echo "success" || { echo "fail"; exit 1; }
   fi
@@ -1546,11 +1550,11 @@ health_check() {
     __health_check_print_repair_info $name $repair_in_txn
     local published_hash="$(get_published_root_hash $name)"
     echo -n "Note: Trying to remount repository mountpoints to $published_hash... "
-    cvmfs_suid_helper rw_umount     $name                   && \
-    cvmfs_suid_helper rdonly_umount $name                   && \
+    run_suid_helper rw_umount     $name                     && \
+    run_suid_helper rdonly_umount $name                     && \
     set_ro_root_hash                $name "$published_hash" && \
-    cvmfs_suid_helper rdonly_mount  $name > /dev/null       && \
-    cvmfs_suid_helper rw_mount      $name && success=true || success=false
+    run_suid_helper rdonly_mount  $name > /dev/null         && \
+    run_suid_helper rw_mount      $name && success=true || success=false
     __health_check_syslog_repair_info $name "outdated revision" $success
     $success && echo "success" || { echo "fail"; exit 1; }
   fi
@@ -1561,7 +1565,7 @@ health_check() {
       echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
       __health_check_print_repair_info $name $repair_in_txn
       echo -n "Note: Trying to remount /cvmfs/${name} read/write... "
-      cvmfs_suid_helper open $name && success=true || success=false
+      run_suid_helper open $name && success=true || success=false
       __health_check_syslog_repair_info $name "non-writable transaction" $success
       $success && echo "success" || { echo "fail"; exit 1; }
     fi
@@ -1570,7 +1574,7 @@ health_check() {
       echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
       __health_check_print_repair_info $name $repair_in_txn
       echo -n "Note: Trying to remount /cvmfs/${name} read-only... "
-      cvmfs_suid_helper lock $name && success=true || success=false
+      run_suid_helper lock $name && success=true || success=false
       __health_check_syslog_repair_info $name "writable mount point" $success
       $success && echo "success" || { echo "fail"; exit 1; }
     fi
@@ -5460,11 +5464,11 @@ migrate_2_1_7() {
   local remote_hash
   remote_hash=$(get_published_root_hash $name)
 
-  cvmfs_suid_helper rw_umount $name     > /dev/null 2>&1 || die "fail! (unmounting /cvmfs/$name)"
-  cvmfs_suid_helper rdonly_umount $name > /dev/null 2>&1 || die "fail! (unmounting ${CVMFS_SPOOL_DIR}/rdonly)"
+  run_suid_helper rw_umount $name     > /dev/null 2>&1 || die "fail! (unmounting /cvmfs/$name)"
+  run_suid_helper rdonly_umount $name > /dev/null 2>&1 || die "fail! (unmounting ${CVMFS_SPOOL_DIR}/rdonly)"
   set_ro_root_hash $name $remote_hash
-  cvmfs_suid_helper rdonly_mount $name  > /dev/null 2>&1 || die "fail! (mounting ${CVMFS_SPOOL_DIR}/$name)"
-  cvmfs_suid_helper rw_mount $name      > /dev/null 2>&1 || die "fail! (mounting /cvmfs/$name)"
+  run_suid_helper rdonly_mount $name  > /dev/null 2>&1 || die "fail! (mounting ${CVMFS_SPOOL_DIR}/$name)"
+  run_suid_helper rw_mount $name      > /dev/null 2>&1 || die "fail! (mounting /cvmfs/$name)"
 }
 
 # note that this is only run on stratum1s that have local upstream storage


### PR DESCRIPTION
That should make sure to run `cvmfs_suid_helper` always in a fresh environment. Amending  `$LD_LIBRARY_PATH` with a path that points into the CVMFS repository being published might make `cvmfs_suid_helper` pick up shared libraries from there. However, `cvmfs_suid_helper` will then not be able to `umount` the repository because it holds open file descriptors on the mount point itself.

That's sort of a quick fix... Better ideas?