### PR TITLE
FIX: `grep` Treating Whitelist as Binary Data

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1649,9 +1649,9 @@ create_whitelist() {
 
 
 get_expiry_from_string() {
-  local whitelist_string="$1"
+  local whitelist="$1"
 
-  local expires=$(echo "$whitelist_string" | grep -e '^E[0-9]\{14\}$' | tr -d E)
+  local expires=$(echo "$whitelist" | grep --text -e '^E[0-9]\{14\}$' | tr -d E)
   if echo "$expires" | grep -q -E --invert-match '^[0-9]{14}$'; then
     echo -1
     return 1


### PR DESCRIPTION
We use `grep` to parse the expiry date of a downloaded whitelist. In some environments `grep` treats the whitelist as binary data (because of the attached binary signature) and produces bogus output.