### PR TITLE
FIX: `cvmfs_server` Open File Descriptor Check relies on `$PATH` for `lsof`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -300,7 +300,7 @@ Supported Commands:
   publish         [-p pause for tweaks] [-n manual revision number] [-v verbose]
                   [-a tag name] [-c tag channel] [-m tag description]
                   [-X (force external data) | -N (force native data)]
-                  [-Z compression algorithm]
+                  [-Z compression algorithm] [-f use force remount if necessary]
                   <fully qualified name>
                   Make a new repository snapshot
   rmfs            [-p(reserve) repo data and keys] [-f don't ask again]
@@ -2380,13 +2380,19 @@ file_descriptor_warning() {
 
 handle_read_only_file_descriptors_on_mount_point() {
   local name=$1
+  local open_fd_dialog=${2:-1}
 
   if [ $(count_rd_only_fds /cvmfs/$name) -eq 0 ]; then
     return 0
-  else
-    file_descriptor_warning_and_question $name # might abort...
-    return 1
   fi
+
+  if [ $open_fd_dialog -eq 1 ]; then
+    file_descriptor_warning_and_question $name # might abort...
+  else
+    file_descriptor_warning $name
+  fi
+
+  return 1
 }
 
 
@@ -4279,6 +4285,7 @@ abort() {
   local user
   local spool_dir
   local force=0
+  local open_fd_dialog=1
   local retcode=0
 
   # optional parameter handling
@@ -4288,6 +4295,7 @@ abort() {
     case $option in
       f)
         force=1
+        open_fd_dialog=0
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -4336,7 +4344,7 @@ abort() {
 
     # check if we have open file descriptors on /cvmfs/<name>
     local use_fd_fallback=0
-    handle_read_only_file_descriptors_on_mount_point $name || use_fd_fallback=1
+    handle_read_only_file_descriptors_on_mount_point $name $open_fd_dialog || use_fd_fallback=1
     sync
 
     to_syslog_for_repo $name "aborting transaction"
@@ -4374,10 +4382,11 @@ publish() {
   local force_native=0
   local force_compression_algorithm=""
   local external_option=""
+  local open_fd_dialog=1
 
   # optional parameter handling
   OPTIND=1
-  while getopts "F:NXZ:pa:c:m:vn:" option
+  while getopts "F:NXZ:pa:c:m:vn:f" option
   do
     case $option in
       p)
@@ -4409,6 +4418,9 @@ publish() {
       ;;
       F)
         authz_file="-F $OPTARG"
+      ;;
+      f)
+        open_fd_dialog=0
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -4585,7 +4597,7 @@ publish() {
 
     # check if we have open file descriptors on /cvmfs/<name>
     local use_fd_fallback=0
-    handle_read_only_file_descriptors_on_mount_point $name || use_fd_fallback=1
+    handle_read_only_file_descriptors_on_mount_point $name $open_fd_dialog || use_fd_fallback=1
 
     # synchronize the repository
     publish_starting $name

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -68,14 +68,14 @@ find_sbin() {
 }
 
 # Path to some useful sbin utilities
-LSOF_BIN="$(find_sbin       lsof)"
-GETENFORCE_BIN="$(find_sbin getenforce)"
-SESTATUS_BIN="$(find_sbin   sestatus)"
-GETCAP_BIN="$(find_sbin     getcap)"
-SETCAP_BIN="$(find_sbin     setcap)"
-MODPROBE_BIN="$(find_sbin   modprobe)"
-PIDOF_BIN="$(find_sbin      pidof)"
-RUNUSER_BIN="$(find_sbin    runuser)"
+LSOF_BIN="$(find_sbin       lsof)"       || true
+GETENFORCE_BIN="$(find_sbin getenforce)" || true
+SESTATUS_BIN="$(find_sbin   sestatus)"   || true
+GETCAP_BIN="$(find_sbin     getcap)"     || true
+SETCAP_BIN="$(find_sbin     setcap)"     || true
+MODPROBE_BIN="$(find_sbin   modprobe)"   || true
+PIDOF_BIN="$(find_sbin      pidof)"      || true
+RUNUSER_BIN="$(find_sbin    runuser)"    || true
 
 # Find out how to deal with Apache
 # (binary name, configuration directory, CLI, WSGI module name, ...)
@@ -1894,10 +1894,10 @@ ensure_swissknife_suid() {
 # an ubuntu machine. This enables these modules on an ubuntu installation
 # Note: this function requires a privileged user
 ensure_enabled_apache_modules() {
-  find_sbin a2enmod    > /dev/null 2>&1 || return 0
-  find_sbin apache2ctl > /dev/null 2>&1 || return 0
-  local a2enmod_bin=$(find_sbin a2enmod)
-  local apache2ctl_bin=$(find_sbin apache2ctl)
+  local a2enmod_bin=
+  local apache2ctl_bin=
+  a2enmod_bin="$(find_sbin    a2enmod)"    || return 0
+  apache2ctl_bin="$(find_sbin apache2ctl)" || return 0
 
   local restart=0
   local retcode=0

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -54,6 +54,16 @@ publish_after_hook() { :; }
 
 [ -f /etc/cvmfs/cvmfs_server_hooks.sh ] && . /etc/cvmfs/cvmfs_server_hooks.sh
 
+# Path to some useful sbin utilities
+LSOF_BIN="/usr/sbin/lsof"
+GETENFORCE_BIN="/usr/sbin/getenforce"
+SESTATUS_BIN="/usr/sbin/sestatus"
+GETCAP_BIN="/usr/sbin/getcap"
+SETCAP_BIN="/usr/sbin/setcap"
+MODPROBE_BIN="/sbin/modprobe"
+PIDOF_BIN="/sbin/pidof"
+RUNUSER_BIN="/sbin/runuser"
+
 # Find out how to deal with Apache
 # (binary name, configuration directory, CLI, WSGI module name, ...)
 if which httpd2 > /dev/null 2>&1; then # SLES/OpenSuSE
@@ -80,10 +90,10 @@ fi
 
 # Find the service binary (or detect systemd)
 minpidof() {
-  pidof $1 | tr " " "\n" | sort --numeric-sort | head -n1
+  $PIDOF_BIN $1 | tr " " "\n" | sort --numeric-sort | head -n1
 }
 SERVICE_BIN="false"
-if ! pidof systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
+if ! $PIDOF_BIN systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
   if [ -x /sbin/service ]; then
     SERVICE_BIN="/sbin/service"
   elif [ -x /usr/sbin/service ]; then
@@ -98,7 +108,7 @@ fi
 # Check if `runuser` is available on this system
 # Note: at least Ubuntu in older versions doesn't provide this command
 HAS_RUNUSER=0
-if which runuser > /dev/null 2>&1; then
+if [ -x $RUNUSER_BIN ]; then
   HAS_RUNUSER=1
 fi
 
@@ -569,7 +579,7 @@ check_multiple_repository_existence() {
 # or if aufs is compiled in
 # @return   0 if the aufs kernel module is loaded
 check_aufs() {
-  /sbin/modprobe -q aufs || test -d /sys/fs/aufs
+  $MODPROBE_BIN -q aufs || test -d /sys/fs/aufs
 }
 
 
@@ -577,7 +587,7 @@ check_aufs() {
 # or if overlayfs is compiled in
 # @return   0 if the overlayfs kernel module is loaded
 check_overlayfs() {
-  /sbin/modprobe -q overlay || test -d /sys/module/overlay
+  $MODPROBE_BIN -q overlay || test -d /sys/module/overlay
 }
 
 
@@ -787,7 +797,7 @@ has_apache_config_file() {
 
 get_fd_modes() {
   local path=$1
-  lsof -Fan 2>/dev/null | grep -B1 -e "^n$path" | grep -e '^a.*'
+  $LSOF_BIN -Fan 2>/dev/null | grep -B1 -e "^n$path" | grep -e '^a.*'
 }
 
 # gets the number of open read-only file descriptors beneath a given path
@@ -886,7 +896,7 @@ get_user_shell() {
     shell_cmd="sh -c"
   elif is_root; then
     if [ $HAS_RUNUSER -ne 0 ]; then
-      shell_cmd="runuser -m $CVMFS_USER -c"
+      shell_cmd="$RUNUSER_BIN -m $CVMFS_USER -c"
     else
       shell_cmd="su -m $CVMFS_USER -c"
     fi
@@ -1224,9 +1234,9 @@ check_user() {
 
 
 has_selinux() {
-  which sestatus   > /dev/null 2>&1 && \
-  which getenforce > /dev/null 2>&1 && \
-  getenforce | grep -qi "enforc" || return 1
+  [ -x $SESTATUS_BIN   ] && \
+  [ -x $GETENFORCE_BIN ] && \
+  $GETENFORCE_BIN | grep -qi "enforc" || return 1
 }
 
 
@@ -1843,9 +1853,9 @@ EOF
 _setcap_if_needed() {
   local binary_path="$1"
   local capability="$2"
-  [ -x $binary_path ]                           || return 0
-  getcap "$binary_path" | grep -q "$capability" && return 0
-  setcap "${capability}+p" "$binary_path"
+  [ -x $binary_path ]                                || return 0
+  $GETCAP_BIN "$binary_path" | grep -q "$capability" && return 0
+  $SETCAP_BIN "${capability}+p" "$binary_path"
 }
 
 # grants CAP_SYS_ADMIN to cvmfs_swissknife if it is necessary
@@ -2334,7 +2344,7 @@ If you go for production, backup you software signing keys in /etc/cvmfs/keys/!"
 
 generate_lsof_report_for_mountpoint() {
   local mountpoint="$1"
-  lsof "$mountpoint" | awk '{print $1,$2,$3,$NF}' | column -t || true
+  $LSOF_BIN "$mountpoint" | awk '{print $1,$2,$3,$NF}' | column -t || true
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -54,6 +54,19 @@ publish_after_hook() { :; }
 
 [ -f /etc/cvmfs/cvmfs_server_hooks.sh ] && . /etc/cvmfs/cvmfs_server_hooks.sh
 
+find_sbin() {
+  local bin_name="$1"
+  local bin_path=""
+  for d in /sbin /usr/sbin /usr/local/sbin /bin /usr/bin /usr/local/bin; do
+    bin_path="${d}/${bin_name}"
+    if [ -x "$bin_path" ]; then
+      echo "$bin_path"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # Path to some useful sbin utilities
 LSOF_BIN="/usr/sbin/lsof"
 GETENFORCE_BIN="/usr/sbin/getenforce"

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -68,14 +68,14 @@ find_sbin() {
 }
 
 # Path to some useful sbin utilities
-LSOF_BIN="/usr/sbin/lsof"
-GETENFORCE_BIN="/usr/sbin/getenforce"
-SESTATUS_BIN="/usr/sbin/sestatus"
-GETCAP_BIN="/usr/sbin/getcap"
-SETCAP_BIN="/usr/sbin/setcap"
-MODPROBE_BIN="/sbin/modprobe"
-PIDOF_BIN="/sbin/pidof"
-RUNUSER_BIN="/sbin/runuser"
+LSOF_BIN="$(find_sbin       lsof)"
+GETENFORCE_BIN="$(find_sbin getenforce)"
+SESTATUS_BIN="$(find_sbin   sestatus)"
+GETCAP_BIN="$(find_sbin     getcap)"
+SETCAP_BIN="$(find_sbin     setcap)"
+MODPROBE_BIN="$(find_sbin   modprobe)"
+PIDOF_BIN="$(find_sbin      pidof)"
+RUNUSER_BIN="$(find_sbin    runuser)"
 
 # Find out how to deal with Apache
 # (binary name, configuration directory, CLI, WSGI module name, ...)

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -79,19 +79,19 @@ RUNUSER_BIN="$(find_sbin    runuser)"
 
 # Find out how to deal with Apache
 # (binary name, configuration directory, CLI, WSGI module name, ...)
-if which httpd2 > /dev/null 2>&1; then # SLES/OpenSuSE
+if find_sbin httpd2 > /dev/null 2>&1; then # SLES/OpenSuSE
   APACHE_CONF="apache2"
-  APACHE_BIN="$(which httpd2)"
+  APACHE_BIN="$(find_sbin httpd2)"
   APACHE_CTL="$APACHE_BIN"
   APACHE_WSGI_MODPKG="apache2-mod_wsgi"
-elif which apache2 > /dev/null 2>&1; then
+elif find_sbin apache2 > /dev/null 2>&1; then
   APACHE_CONF="apache2"
-  APACHE_BIN="$(which apache2)"
-  if which apachectl > /dev/null 2>&1; then # Debian
-    APACHE_CTL="$(which apachectl)"
+  APACHE_BIN="$(find_sbin apache2)"
+  if find_sbin apachectl > /dev/null 2>&1; then # Debian
+    APACHE_CTL="$(find_sbin apachectl)"
     APACHE_WSGI_MODPKG="libapache2-mod-wsgi"
-  elif which apache2ctl > /dev/null 2>&1; then # Gentoo
-    APACHE_CTL="$(which apache2ctl)"
+  elif find_sbin apache2ctl > /dev/null 2>&1; then # Gentoo
+    APACHE_CTL="$(find_sbin apache2ctl)"
     APACHE_WSGI_MODPKG="www-apache/mod_wsgi"
   fi
 else # RedHat based
@@ -1894,16 +1894,18 @@ ensure_swissknife_suid() {
 # an ubuntu machine. This enables these modules on an ubuntu installation
 # Note: this function requires a privileged user
 ensure_enabled_apache_modules() {
-  which a2enmod > /dev/null 2>&1    || return 0
-  which apache2ctl > /dev/null 2>&1 || return 0
+  find_sbin a2enmod    > /dev/null 2>&1 || return 0
+  find_sbin apache2ctl > /dev/null 2>&1 || return 0
+  local a2enmod_bin=$(find_sbin a2enmod)
+  local apache2ctl_bin=$(find_sbin apache2ctl)
 
   local restart=0
   local retcode=0
   local modules="headers expires"
 
   for module in $modules; do
-    apache2ctl -M 2>/dev/null | grep -q "$module" && continue
-    a2enmod $module > /dev/null 2>&1 || { echo "Warning: failed to enable apache2 module $module"; retcode=1; }
+    $apache2ctl_bin -M 2>/dev/null | grep -q "$module" && continue
+    $a2enmod_bin $module > /dev/null 2>&1 || { echo "Warning: failed to enable apache2 module $module"; retcode=1; }
     restart=1
   done
 

--- a/test/src/628-pythonwrappedcvmfsserver/LbCVMFS/Tools.py
+++ b/test/src/628-pythonwrappedcvmfsserver/LbCVMFS/Tools.py
@@ -1,0 +1,73 @@
+
+from contextlib import contextmanager
+import os
+import subprocess
+
+def _getRepoName():
+    repo_name = os.environ.get('CVMFS_TEST_REPO')
+    if not repo_name:
+        raise RuntimeError("environment variable CVMFS_TEST_REPO not set")
+    return repo_name
+
+#
+# CVMFS wrappers
+#
+# Note(rmeusel): This is taken 1-to-1 from the lhcbdev.cern.ch release
+#                manager machine. It is meant to be used for a regression
+#                test for an issue that arose there in March 2016.
+#
+#############################################################################
+
+def cvmfsStart(reponame = None):
+    """ Start a CVMFS transaction """
+    if reponame == None:
+        reponame = _getRepoName()
+
+    rc = subprocess.call(["cvmfs_server", "transaction", reponame])
+    if rc != 0:
+        raise RuntimeError("Could not start CVMFS transaction")
+
+def cvmfsPublish(reponame = None):
+    """ Publish a CVMFS transaction """
+    if reponame == None:
+        reponame = _getRepoName()
+
+    rc = subprocess.call(["cvmfs_server", "publish", reponame])
+    if rc != 0:
+        raise RuntimeError("Could not publish CVMFS transaction")
+
+def cvmfsAbort(reponame = None):
+    """ Abort a CVMFS transaction """
+    if reponame == None:
+        reponame = _getRepoName()
+
+    rc = subprocess.call(["cvmfs_server", "abort", "-f", reponame])
+    if rc != 0:
+        raise RuntimeError("Could not abort CVMFS transaction")
+
+
+@contextmanager
+def cvmfsTransaction(reponame = None, testonly=False):
+    """ Context manager to make sure we always publish or abort """
+    if reponame == None:
+        reponame = _getRepoName()
+
+    import logging
+    if not testonly:
+        logging.info("Starting CVMFS transaction")
+        cvmfsStart(reponame)
+
+    try:
+        # At this point we have a transaction started
+        # we have to abort ib case of problem...
+        yield
+        if not testonly:
+            logging.info("Publishing CVMFS transaction")
+            cvmfsPublish(reponame)
+    except:
+        if not testonly:
+            logging.info("Aborting transaction")
+            cvmfsAbort(reponame)
+        import sys
+        exc_info = sys.exc_info()
+        raise exc_info[0], exc_info[1], exc_info[2]

--- a/test/src/628-pythonwrappedcvmfsserver/LbCVMFS/Tools.py
+++ b/test/src/628-pythonwrappedcvmfsserver/LbCVMFS/Tools.py
@@ -32,7 +32,7 @@ def cvmfsPublish(reponame = None):
     if reponame == None:
         reponame = _getRepoName()
 
-    rc = subprocess.call(["cvmfs_server", "publish", reponame])
+    rc = subprocess.call(["cvmfs_server", "publish", "-f", reponame])
     if rc != 0:
         raise RuntimeError("Could not publish CVMFS transaction")
 

--- a/test/src/628-pythonwrappedcvmfsserver/do_install.py
+++ b/test/src/628-pythonwrappedcvmfsserver/do_install.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from LbCVMFS import Tools
+
+def print_wrapper(msg):
+    print "WRAPPER:" , msg
+
+if __name__ == "__main__":
+    print_wrapper("opening transaction")
+
+    with Tools.cvmfsTransaction():
+        print_wrapper("not installing anything")
+
+    print_wrapper("closed transaction")

--- a/test/src/628-pythonwrappedcvmfsserver/do_install.py
+++ b/test/src/628-pythonwrappedcvmfsserver/do_install.py
@@ -6,9 +6,5 @@ def print_wrapper(msg):
     print "WRAPPER:" , msg
 
 if __name__ == "__main__":
-    print_wrapper("opening transaction")
-
     with Tools.cvmfsTransaction():
         print_wrapper("not installing anything")
-
-    print_wrapper("closed transaction")

--- a/test/src/628-pythonwrappedcvmfsserver/main
+++ b/test/src/628-pythonwrappedcvmfsserver/main
@@ -23,6 +23,28 @@ wait_for_file() {
   return 1
 }
 
+# Regression Test: This issue was seen on the lhcbdev.cern.ch release manager
+#                  machine where a misconfigured environment caused a python
+#                  script to be interpreted with a python interpreter hosted on
+#                  lhcbdev.cern.ch.
+#                  The script was a wrapper around `cvmfs_server` and therefore
+#                  called `cvmfs_server publish` that remounts lhcbdev.cern.ch.
+#                  Since an interpreter from within the repository was used,
+#                  this should have resulted in `cvmfs_server` detecting open
+#                  file descriptors on the mount point and aborting the publish.
+#                  However, it resulted in a failed repository remount and left
+#                  the release manager machine in an undefined state.
+#
+# The issue has been quick-fixed by using a python interpreter outside of the
+# repository. However, it remained unclear why `cvmfs_server` failed to detect
+# the open file descriptor before remounting.
+#
+# It turns out that using `crontab` to invoke the python script was the actual
+# root cause. `crontab` uses a limited $PATH - not including /usr/sbin - so that
+# `cvmfs_server` doesn't find the `lsof` command. Hence, `cvmfs_server` falsely
+# concluded that there are no open files and proceeds to umount the busy
+# mountpoint.
+
 cvmfs_run_test() {
   logfile=$1
   script_location=$2

--- a/test/src/628-pythonwrappedcvmfsserver/main
+++ b/test/src/628-pythonwrappedcvmfsserver/main
@@ -1,6 +1,28 @@
 cvmfs_test_name="Python-wrapped cvmfs_server"
 cvmfs_test_autofs_on_startup=false
 
+CVMFS_TEST_628_PREVIOUS_CRONTAB=
+cleanup() {
+  echo "running cleanup..."
+  [ -z $CVMFS_TEST_628_PREVIOUS_CRONTAB ] || crontab $CVMFS_TEST_628_PREVIOUS_CRONTAB
+}
+
+wait_for_file() {
+  local path=$1
+  local timeout=$2
+
+  while [ $timeout -gt 0 ]; do
+    if [ -f $publish_2 ]; then
+      sleep 10
+      return 0
+    fi
+    sleep 1
+    timeout=$(( $timeout - 1 ))
+  done
+
+  return 1
+}
+
 cvmfs_run_test() {
   logfile=$1
   script_location=$2
@@ -14,6 +36,10 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  local server_conf=/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  echo "disabling wall message"
+  echo "CVMFS_FORCE_REMOUNT_WARNING=false" | sudo tee --append $server_conf
+
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
 
@@ -25,8 +51,57 @@ cvmfs_run_test() {
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  echo "running python wrapper with ${python_interpreter} as interpreter"
-  yes "n" | CVMFS_TEST_REPO=${CVMFS_TEST_REPO} $python_interpreter ${script_location}/do_install.py || return 1
+  local install_wrapper="${scratch_dir}/do_install.sh"
+  echo "dropping $install_wrapper"
+  echo "#!/bin/sh"                                                                               >  $install_wrapper
+  echo "CVMFS_TEST_REPO=${CVMFS_TEST_REPO} $python_interpreter ${script_location}/do_install.py" >> $install_wrapper
+  chmod +x $install_wrapper
+
+  local publish_1="publish_1.log"
+  echo "running python wrapper with ${python_interpreter} as interpreter (logging to $publish_1)"
+  echo "Note: the wrapper uses \`cvmfs_server publish -f\`"
+  $install_wrapper > $publish_1 2>&1 || return 1
+
+  echo "check for error messages"
+  cat $publish_1 | grep -e 'Open file descriptors'    || return 2
+  cat $publish_1 | grep -e 'lsof report'              || return 3
+  cat $publish_1 | grep -e "python.*$CVMFS_TEST_USER" || return 4
+
+  echo "set a trap for system directory cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "stash the current crontab"
+  local stash_crontab="previous_crontab"
+  local crontab_l_stderr="crontab_stderr"
+  crontab -l > $stash_crontab 2> $crontab_l_stderr || true
+  if [ $(cat $crontab_l_stderr | wc -l) -gt 0 ] && \
+         cat $crontab_l_stderr | grep -qv 'no crontab for'; then
+    return 5
+  fi
+
+  echo "----"
+  cat $stash_crontab
+  echo "----"
+
+  local publish_2="${scratch_dir}/publish_2.log"
+  echo "install a crontab to start the publishing process (logging into $publish_2)"
+  local new_crontab="new_crontab"
+  local in_two_minutes=$(date --date '2 minutes' +%M)
+  cp $stash_crontab $new_crontab || return 6
+  echo "$in_two_minutes * * * * $install_wrapper > $publish_2 2>&1" >> $new_crontab
+  CVMFS_TEST_628_PREVIOUS_CRONTAB=$stash_crontab
+  crontab $new_crontab || return 7
+
+  echo "----"
+  cat $new_crontab
+  echo "----"
+
+  echo "waiting until crontab has executed the publish command ($in_two_minutes)"
+  wait_for_file $publish_2 300 || return 8  # wait 5 minutes for publish log to appear
+
+  cat $publish_2 | grep -e 'Open file descriptors'    || return  9
+  cat $publish_2 | grep -e 'lsof report'              || return 10
+  cat $publish_2 | grep -e "python.*$CVMFS_TEST_USER" || return 11
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?

--- a/test/src/628-pythonwrappedcvmfsserver/main
+++ b/test/src/628-pythonwrappedcvmfsserver/main
@@ -1,0 +1,35 @@
+cvmfs_test_name="Python-wrapped cvmfs_server"
+cvmfs_test_autofs_on_startup=false
+
+cvmfs_run_test() {
+  logfile=$1
+  script_location=$2
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  echo -n "checking for installed python interpreter... "
+  which "python" > /dev/null 2>&1 && echo "done" || die "fail"
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local python_interpreter=$(which python)
+  echo "copying python interpreter in ${python_interpreter}"
+  cp $python_interpreter $repo_dir
+  python_interpreter="${repo_dir}/$(basename $python_interpreter)"
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "running python wrapper with ${python_interpreter} as interpreter"
+  yes "n" | CVMFS_TEST_REPO=${CVMFS_TEST_REPO} $python_interpreter ${script_location}/do_install.py || return 1
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  return 0
+}

--- a/test/src/628-pythonwrappedcvmfsserver/main
+++ b/test/src/628-pythonwrappedcvmfsserver/main
@@ -1,4 +1,4 @@
-cvmfs_test_name="Python-wrapped cvmfs_server"
+cvmfs_test_name="Python-wrapped cvmfs_server Invoked Through Crontab"
 cvmfs_test_autofs_on_startup=false
 
 CVMFS_TEST_628_PREVIOUS_CRONTAB=


### PR DESCRIPTION
This fixes an issue in `cvmfs_server` which prevents it from checking for open file descriptors on `cvmfs_server publish` and `cvmfs_server abort` if `lsof` cannot be found in the `$PATH`. In particular this is crucial for `cvmfs_server` commands that are called through `cron`, as it sets the `$PATH` to something like `/bin:/usr/bin:.`.

Along with `lsof` there have been a handful of other commands from `/sbin` and `/usr/sbin` that might have suffered the same issue.

Along with the fix there is a regression test that closely resembles the release manager setup of **lhcbdev.cern.ch** where the problem was initially found. See `526*/main` for more details.

*Note:* This builds on top of [Feature: Add `cvmfs_server publish -f` Disabling Interactive Open File Descriptor Dialog](https://github.com/cvmfs/cvmfs/pull/1528).