### PR TITLE
FIX: Includes in VOMS

### DIFF
--- a/cvmfs/voms_authz/voms_curl.cc
+++ b/cvmfs/voms_authz/voms_curl.cc
@@ -12,8 +12,10 @@
 #include <openssl/ssl.h>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <cstring>
 


### PR DESCRIPTION
This fixes missing includes in `voms_curl.cc`. Perhaps missed in #1535 ?