### PR TITLE
Feature: Asynchronous Cleanup of Scratch Directory

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -541,6 +541,13 @@ least CernVM-FS $creator to manipulate this repository."
     fi
   fi
 
+  if [ "$creator" = "2.2.0-1" ] || [ "$creator" = "2.2.1-1" ]; then
+    if version_greater_or_equal "2.3.0"; then
+      _repo_is_incompatible "$creator" $nokill
+      return $?
+    fi
+  fi
+
   return 0
 }
 
@@ -5643,6 +5650,47 @@ migrate_2_1_20() {
   load_repo_config $name
 }
 
+migrate_2_2_0() {
+  local name=$1
+  local destination_version="2.3.0-1"
+  local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
+
+  # get repository information
+  load_repo_config $name
+  [ ! -z $CVMFS_SPOOL_DIR     ] || die "\$CVMFS_SPOOL_DIR is not set"
+  [ ! -z $CVMFS_USER          ] || die "\$CVMFS_USER is not set"
+  [ ! -z $CVMFS_UNION_FS_TYPE ] || die "\$CVMFS_UNION_FS_TYPE is not set"
+
+  echo "--> umount repository"
+  run_suid_helper rw_umount $name
+
+  echo "--> updating scratch directory layout"
+  local scratch_dir="${CVMFS_SPOOL_DIR}/scratch"
+  rm -fR   ${scratch_dir}
+  mkdir -p ${scratch_dir}/current
+  mkdir -p ${scratch_dir}/wastebin
+  chown -R $CVMFS_USER ${scratch_dir}
+
+  echo "--> updating /etc/fstab"
+  local tmp_fstab=$(mktemp)
+  local comment="added by CernVM-FS for ${name}"
+  sed -e "s~^\(.*\)\(${scratch_dir}\)\(.*${comment}\)$~\1\2/current\3~" /etc/fstab > $tmp_fstab
+  cat $tmp_fstab > /etc/fstab
+  rm -f $tmp_fstab
+
+  echo "--> remount repository"
+  run_suid_helper rw_mount $name
+
+  echo "--> updating server.conf"
+  sed -i -e "s/^\(CVMFS_CREATOR_VERSION\)=.*/\1=$destination_version/" $server_conf
+
+  echo "--> ensure binary permission settings"
+  ensure_swissknife_suid $CVMFS_UNION_FS_TYPE
+
+  # update repository information
+  load_repo_config $name
+}
+
 migrate() {
   local names
   local retcode=0
@@ -5706,6 +5754,13 @@ migrate() {
          x"$creator" = x"2.2.0-0" ];
     then
       migrate_2_1_20 $name
+    fi
+
+    if [ x"$creator" = x"2.2.0-1" -o   \
+         x"$creator" = x"2.2.1-1" ] && \
+         is_stratum0 $name;
+    then
+      migrate_2_2_0 $name
     fi
 
   done

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5672,11 +5672,8 @@ migrate_2_2_0() {
   chown -R $CVMFS_USER ${scratch_dir}
 
   echo "--> updating /etc/fstab"
-  local tmp_fstab=$(mktemp)
   local comment="added by CernVM-FS for ${name}"
-  sed -e "s~^\(.*\)\(${scratch_dir}\)\(.*${comment}\)$~\1\2/current\3~" /etc/fstab > $tmp_fstab
-  cat $tmp_fstab > /etc/fstab
-  rm -f $tmp_fstab
+  sed -i -e "s~^\(.*\)\(${scratch_dir}\)\(.*${comment}\)$~\1\2/current\3~" /etc/fstab
 
   echo "--> remount repository"
   run_suid_helper rw_mount $name

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2120,7 +2120,7 @@ create_config_files_for_new_repository() {
 
   # other configurations
   local spool_dir="/var/spool/cvmfs/${name}"
-  local scratch_dir="${spool_dir}/scratch"
+  local scratch_dir="${spool_dir}/scratch/current"
   local rdonly_dir="${spool_dir}/rdonly"
   local temp_dir="${spool_dir}/tmp"
   local cache_dir="${spool_dir}/cache"
@@ -2215,13 +2215,19 @@ create_spool_area_for_new_repository() {
   # gather repository information from configuration file
   load_repo_config $name
   local spool_dir=$CVMFS_SPOOL_DIR
-  local scratch_dir="${spool_dir}/scratch"
+  local current_scratch_dir="${spool_dir}/scratch/current"
+  local wastebin_scratch_dir="${spool_dir}/scratch/wastebin"
   local rdonly_dir="${spool_dir}/rdonly"
   local temp_dir="${spool_dir}/tmp"
   local cache_dir="${spool_dir}/cache"
   local ofs_workdir="${spool_dir}/ofs_workdir"
 
-  mkdir -p /cvmfs/$name $scratch_dir $rdonly_dir $temp_dir $cache_dir || return 1
+  mkdir -p /cvmfs/$name          \
+           $current_scratch_dir  \
+           $wastebin_scratch_dir \
+           $rdonly_dir           \
+           $temp_dir             \
+           $cache_dir || return 1
   if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
     mkdir -p $ofs_workdir || return 2
   fi
@@ -2289,7 +2295,7 @@ setup_and_mount_new_repository() {
   # get repository information
   load_repo_config $name
   local rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
-  local scratch_dir="${CVMFS_SPOOL_DIR}/scratch"
+  local scratch_dir="${CVMFS_SPOOL_DIR}/scratch/current"
   local ofs_workdir="${CVMFS_SPOOL_DIR}/ofs_workdir"
 
   local selinux_context=""
@@ -3058,7 +3064,7 @@ mkfs() {
   load_repo_config $name
   local temp_dir="${CVMFS_SPOOL_DIR}/tmp"
   local rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
-  local scratch_dir="${CVMFS_SPOOL_DIR}/scratch"
+  local scratch_dir="${CVMFS_SPOOL_DIR}/scratch/current"
 
   echo -n "Creating Initial Repository... "
   create_whitelist $name $cvmfs_user $upstream $temp_dir > /dev/null
@@ -4481,6 +4487,7 @@ publish() {
     load_repo_config $name
     user=$CVMFS_USER
     spool_dir=$CVMFS_SPOOL_DIR
+    scratch_dir="${spool_dir}/scratch/current"
     stratum0=$CVMFS_STRATUM0
     upstream=$CVMFS_UPSTREAM_STORAGE
     hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
@@ -4532,7 +4539,7 @@ publish() {
       -w $stratum0                                       \
       -t ${spool_dir}/tmp                                \
       -u /cvmfs/${name}                                  \
-      -s ${spool_dir}/scratch                            \
+      -s ${scratch_dir}                                  \
       $verbosity"
 
     local log_level=
@@ -4541,7 +4548,7 @@ publish() {
     local trusted_certs="/etc/cvmfs/repositories.d/${name}/trusted_certs"
     local sync_command="$(__swissknife_cmd dbg) sync \
       -u /cvmfs/$name                                \
-      -s ${spool_dir}/scratch                        \
+      -s ${scratch_dir}                              \
       -c ${spool_dir}/rdonly                         \
       -t ${spool_dir}/tmp                            \
       -b $base_hash                                  \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1159,6 +1159,8 @@ close_transaction() {
   load_repo_config $name
   local tx_lock="${CVMFS_SPOOL_DIR}/in_transaction"
   local tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  local current_scratch_dir="${CVMFS_SPOOL_DIR}/scratch/current"
+  local wastebin_scratch_dir="${CVMFS_SPOOL_DIR}/scratch/wastebin"
   local force_grace_time=60
 
   # if not explicitly asked, try if umounting works without force
@@ -1185,7 +1187,16 @@ close_transaction() {
   fi
 
   # continue with the remounting
-  run_suid_helper clear_scratch $name
+  local async_msg=""
+  if [ x"$CVMFS_ASYNC_SCRATCH_CLEANUP" != x"false" ]; then
+    tmpdir=$(mktemp -d "${wastebin_scratch_dir}/waste.XXXXXX")
+    mv $current_scratch_dir $tmpdir
+    mkdir -p $current_scratch_dir && chown $CVMFS_USER $current_scratch_dir
+    async_msg="(asynchronous scratch cleanup)"
+    run_suid_helper clear_scratch_async $name
+  else
+    run_suid_helper clear_scratch $name
+  fi
   [ ! -z "$tmp_dir" ] && rm -fR "${tmp_dir}"/*
   run_suid_helper rdonly_mount $name > /dev/null
   run_suid_helper rw_mount $name
@@ -1193,7 +1204,7 @@ close_transaction() {
 
   local fallback_msg=""
   [ $use_fd_fallback -eq 0 ] || fallback_msg="(using force)"
-  to_syslog_for_repo $name "closed transaction $fallback_msg"
+  to_syslog_for_repo $name "closed transaction $fallback_msg $async_msg"
 }
 
 # checks if a repository is currently runing a publish procedure
@@ -2152,6 +2163,7 @@ CVMFS_AUTO_TAG=$autotagging
 CVMFS_GARBAGE_COLLECTION=$garbage_collectable
 CVMFS_AUTO_REPAIR_MOUNTPOINT=true
 CVMFS_AUTOCATALOGS=false
+CVMFS_ASYNC_SCRATCH_CLEANUP=true
 EOF
 
   if [ x"$voms_authz" != x"" ]; then

--- a/cvmfs/cvmfs_suid_helper.cc
+++ b/cvmfs/cvmfs_suid_helper.cc
@@ -107,7 +107,7 @@ static void KillCvmfs(const string &fqrn) {
 
 class ScopedWorkingDirectory {
  public:
-  ScopedWorkingDirectory(const string &path)
+  explicit ScopedWorkingDirectory(const string &path)
     : previous_path_(GetCurrentWorkingDirectory())
     , directory_handle_(NULL)
   {
@@ -132,7 +132,7 @@ class ScopedWorkingDirectory {
   bool NextDirectoryEntry(DirectoryEntry *entry) {
     platform_dirent64 *dirent;
     while ((dirent = platform_readdir(directory_handle_)) != NULL &&
-           IsMetaEntry(dirent));
+           IsMetaEntry(dirent)) {}
     if (dirent == NULL) {
       return false;
     }

--- a/cvmfs/cvmfs_suid_helper.cc
+++ b/cvmfs/cvmfs_suid_helper.cc
@@ -132,7 +132,7 @@ class ScopedWorkingDirectory {
   bool NextDirectoryEntry(DirectoryEntry *entry) {
     platform_dirent64 *dirent;
     while ((dirent = platform_readdir(directory_handle_)) != NULL &&
-           IsMetaEntry(dirent)) {}
+           IsDotEntry(dirent)) {}
     if (dirent == NULL) {
       return false;
     }
@@ -160,7 +160,7 @@ class ScopedWorkingDirectory {
     assert(retval == 0);
   }
 
-  bool IsMetaEntry(const platform_dirent64 *dirent) {
+  bool IsDotEntry(const platform_dirent64 *dirent) {
     return (strcmp(dirent->d_name, ".")  == 0) ||
            (strcmp(dirent->d_name, "..") == 0);
   }

--- a/cvmfs/cvmfs_suid_helper.cc
+++ b/cvmfs/cvmfs_suid_helper.cc
@@ -207,6 +207,8 @@ static int DoAsynchronousScratchCleanup(const string &fqrn) {
   pid_t pid;
   int statloc;
   if ((pid = fork()) == 0) {
+    int retval = setsid();
+    assert(retval != -1);
     if ((pid = fork()) == 0) {
       close(0); close(1); close(2);
     } else {


### PR DESCRIPTION
This Pull Request is requesting for comments!

After `cvmfs_server publish`-ing a large change set it might take a significant time to clean-out the scratch directory (i.e. `/var/spool/cvmfs/<fqrn>/scratch`). This allows to run this clean-up asynchronously to allow for quicker publishing round-trips. Setting `CVMFS_ASYNC_SCRATCH_CLEANUP=false` disables this and reverts back to the legacy behaviour.

The general idea of this workflow is:

0. create `current` and `wastebin` inside `/var/spool/cvmfs/<fqrn>/scratch`
1. publish as usual (using `.../scratch/current` as union fs scratch directory)
2. umount `/cvmfs/<fqrn>` and `/var/spool/cvmfs/<fqrn>/rdonly`
3. move `.../scratch/current` into `.../wastebin/waste.XXXXXX/current`
4. create a fresh `.../scratch/current`
5. spawn daemon process asynchronously deleting everything in `.../wastebin`
6. mount `/var/spool/cvmfs/<fqrn>/rdonly` and `/cvmfs/<fqrn>`

Note that there might be multiple concurrent `cvmfs_suid_helper clear_scratch_async` but they should not step on each other's feet. Subject to review: Is this actually true?

Theoretically back-to-back transactions should become quicker but this effect might be mitigated due to the background process stressing the file system with the recursive delete.

Furthermore this requires a repository migration step *2.2.x --> 2.3.0* to be developed.