### PR TITLE
Optimisation: Create/Remove Nested Catalogs

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -656,7 +656,9 @@ void WritableCatalogManager::RemoveNestedCatalog(const string &mountpoint) {
 /**
  * Checks if a nested catalog starts at this path.  The path must be valid.
  */
-bool WritableCatalogManager::IsTransitionPoint(const string &path) {
+bool WritableCatalogManager::IsTransitionPoint(const string &mountpoint) {
+  const string path = MakeRelativePath(mountpoint);
+
   SyncLock();
   WritableCatalog *catalog;
   if (!FindCatalog(path, &catalog)) {

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -111,7 +111,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   // Nested catalog handling
   void CreateNestedCatalog(const std::string &mountpoint);
   void RemoveNestedCatalog(const std::string &mountpoint);
-  bool IsTransitionPoint(const std::string &path);
+  bool IsTransitionPoint(const std::string &mountpoint);
 
   inline bool IsBalanceable() const { return is_balanceable_; }
   /**

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -49,8 +49,7 @@ SyncItem::SyncItem(const string       &relative_parent_path,
   compression_algorithm_(zlib::kZlibDefault)
 {
   content_hash_.algorithm = shash::kAny;
-  // Note: graft marker for non-regular files are silently ignored
-  if (IsRegularFile()) {CheckGraft();}
+  CheckMarkerFiles();
 }
 
 
@@ -214,6 +213,12 @@ std::string SyncItem::GetScratchPath() const {
   const string relative_path = GetRelativePath().empty() ?
                                "" : "/" + GetRelativePath();
   return union_engine_->scratch_path() + relative_path;
+}
+
+void SyncItem::CheckMarkerFiles() {
+  if (IsRegularFile()) {
+    CheckGraft();
+  }
 }
 
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -20,6 +20,7 @@ SyncItem::SyncItem() :
   whiteout_(false),
   opaque_(false),
   masked_hardlink_(false),
+  has_catalog_marker_(false),
   valid_graft_(false),
   graft_marker_present_(false),
   external_data_(false),
@@ -37,6 +38,7 @@ SyncItem::SyncItem(const string       &relative_parent_path,
   whiteout_(false),
   opaque_(false),
   masked_hardlink_(false),
+  has_catalog_marker_(false),
   valid_graft_(false),
   graft_marker_present_(false),
   external_data_(false),
@@ -218,7 +220,13 @@ std::string SyncItem::GetScratchPath() const {
 void SyncItem::CheckMarkerFiles() {
   if (IsRegularFile()) {
     CheckGraft();
+  } else if (IsDirectory()) {
+    CheckCatalogMarker();
   }
+}
+
+void SyncItem::CheckCatalogMarker() {
+  has_catalog_marker_ = FileExists(GetUnionPath() + "/.cvmfscatalog");
 }
 
 

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -58,7 +58,7 @@ class SyncItem {
   inline bool IsNew()             const { return WasType(kItemNew);            }
   inline bool IsCharacterDevice() const { return IsType(kItemCharacterDevice); }
   inline bool IsGraftMarker()     const { return IsType(kItemMarker);          }
-  inline bool IsExternalData()    const { return external_data_;              }
+  inline bool IsExternalData()    const { return external_data_;               }
 
   inline bool IsWhiteout()        const { return whiteout_;                    }
   inline bool IsCatalogMarker()   const { return filename_ == ".cvmfscatalog"; }

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -207,6 +207,8 @@ class SyncItem {
 
   SyncItemType GetGenericFiletype(const EntryStat &stat) const;
 
+  void CheckMarkerFiles();
+
   std::string GetGraftMarkerPath() const;
   void CheckGraft();
 

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -64,6 +64,7 @@ class SyncItem {
   inline bool IsCatalogMarker()   const { return filename_ == ".cvmfscatalog"; }
   inline bool IsOpaqueDirectory() const { return IsDirectory() && opaque_;     }
 
+  bool HasCatalogMarker()         const { return has_catalog_marker_;          }
   bool HasGraftMarker()           const { return graft_marker_present_;        }
   bool IsValidGraft()             const { return valid_graft_;                 }
   bool IsChunkedGraft()           const { return graft_chunklist_;             }
@@ -209,6 +210,8 @@ class SyncItem {
 
   void CheckMarkerFiles();
 
+  void CheckCatalogMarker();
+
   std::string GetGraftMarkerPath() const;
   void CheckGraft();
 
@@ -221,6 +224,7 @@ class SyncItem {
   bool whiteout_;                     /**< SyncUnion marked this as whiteout  */
   bool opaque_;                       /**< SyncUnion marked this as opaque dir*/
   bool masked_hardlink_;              /**< SyncUnion masked out the linkcount */
+  bool has_catalog_marker_;           /**< directory containing .cvmfscatalog */
   bool valid_graft_;                  /**< checksum and size in graft marker */
   bool graft_marker_present_;         /**< .cvmfsgraft-$filename exists */
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -535,18 +535,11 @@ void SyncMediator::PublishHardlinksCallback(
 
 
 void SyncMediator::CreateNestedCatalog(const SyncItem &directory) {
-  const std::string directory_path = directory.GetRelativePath();
-  if (directory_path == "") {
-    LogCvmfs(kLogPublish, kLogStderr,
-             "Error: nested catalog marker in root directory");
-    abort();
-  }
-
   const std::string notice = "Nested catalog at " + directory.GetUnionPath();
   PrintChangesetNotice(kAddCatalog, notice);
 
   if (!params_->dry_run) {
-    catalog_manager_->CreateNestedCatalog(directory_path);
+    catalog_manager_->CreateNestedCatalog(directory.GetRelativePath());
   }
 }
 
@@ -629,6 +622,10 @@ void SyncMediator::AddFile(const SyncItem &entry) {
                entry.GetRelativePath().c_str());
       abort();
     }
+  } else if (entry.relative_parent_path().empty() && entry.IsCatalogMarker()) {
+    LogCvmfs(kLogPublish, kLogStderr,
+             "Error: nested catalog marker in root directory");
+    abort();
   } else {
     // Push the file to the spooler, remember the entry for the path
     pthread_mutex_lock(&lock_file_queue_);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -664,7 +664,7 @@ void SyncMediator::AddDirectory(const SyncItem &entry) {
   }
 
   if (entry.HasCatalogMarker() &&
-      !catalog_manager_->IsTransitionPoint("/" + entry.GetRelativePath())) {
+      !catalog_manager_->IsTransitionPoint(entry.GetRelativePath())) {
     CreateNestedCatalog(entry);
   }
 }
@@ -678,7 +678,7 @@ void SyncMediator::AddDirectory(const SyncItem &entry) {
 void SyncMediator::RemoveDirectory(const SyncItem &entry) {
   const std::string directory_path = entry.GetRelativePath();
 
-  if (catalog_manager_->IsTransitionPoint("/" + directory_path)) {
+  if (catalog_manager_->IsTransitionPoint(directory_path)) {
     RemoveNestedCatalog(entry);
   }
 
@@ -699,11 +699,11 @@ void SyncMediator::TouchDirectory(const SyncItem &entry) {
   }
 
   if (entry.HasCatalogMarker() &&
-      !catalog_manager_->IsTransitionPoint("/" + directory_path))
+      !catalog_manager_->IsTransitionPoint(directory_path))
   {
     CreateNestedCatalog(entry);
   } else if (!entry.HasCatalogMarker() &&
-             catalog_manager_->IsTransitionPoint("/" + directory_path))
+             catalog_manager_->IsTransitionPoint(directory_path))
   {
     RemoveNestedCatalog(entry);
   }

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -132,8 +132,8 @@ class SyncMediator {
   void RemoveDirectory(const SyncItem &entry);
   void TouchDirectory(const SyncItem &entry);
 
-  void CreateNestedCatalog(const SyncItem &requestFile);
-  void RemoveNestedCatalog(const SyncItem &requestFile);
+  void CreateNestedCatalog(const SyncItem &directory);
+  void RemoveNestedCatalog(const SyncItem &directory);
 
   // Called by file system traversal
   void EnterAddedDirectoryCallback(const std::string &parent_dir,

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -64,6 +64,12 @@ void SyncUnion::PreprocessSyncItem(SyncItem *entry) const {
 }
 
 
+bool SyncUnion::IgnoreFilePredicate(const std::string &parent_dir,
+                                    const std::string &filename) {
+  return false;
+}
+
+
 bool SyncUnion::ProcessDirectory(const string &parent_dir,
                                  const string &dir_name)
 {
@@ -205,7 +211,8 @@ string SyncUnionAufs::UnwindWhiteoutFilename(const SyncItem &entry) const {
 bool SyncUnionAufs::IgnoreFilePredicate(const string &parent_dir,
                                         const string &filename)
 {
-  return (ignore_filenames_.find(filename) != ignore_filenames_.end());
+  return SyncUnion::IgnoreFilePredicate(parent_dir, filename) ||
+         (ignore_filenames_.find(filename) != ignore_filenames_.end());
 }
 
 
@@ -470,14 +477,6 @@ bool SyncUnionOverlayfs::IsOpaqueDirPath(const string &path) const {
 
 string SyncUnionOverlayfs::UnwindWhiteoutFilename(const SyncItem &entry) const {
   return entry.filename();
-}
-
-
-bool SyncUnionOverlayfs::IgnoreFilePredicate(const string &parent_dir,
-                                             const string &filename)
-{
-  // no files need to be ignored for OverlayFS
-  return false;
 }
 
 void SyncUnionOverlayfs::ProcessCharacterDevice(const std::string &parent_dir,

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -121,12 +121,13 @@ class SyncUnion {
   /**
    * Union file systems may use some special files for bookkeeping.
    * They must not show up in to repository and are ignored by the recursion.
+   * Note: This needs to be up-called!
    * @param parent directory in which file resides
    * @param filename to decide whether to ignore or not
    * @return true if file should be ignored, othewise false
    */
   virtual bool IgnoreFilePredicate(const std::string &parent_dir,
-                                   const std::string &filename) = 0;
+                                   const std::string &filename);
 
   bool IsInitialized() const { return initialized_; }
   virtual bool SupportsHardlinks() const { return false; }
@@ -254,8 +255,6 @@ class SyncUnionOverlayfs : public SyncUnion {
   bool IsOpaqueDirectory(const SyncItem &directory) const;
   bool IsWhiteoutSymlinkPath(const std::string &path) const;
 
-  bool IgnoreFilePredicate(const std::string &parent_dir,
-                           const std::string &filename);
   void ProcessCharacterDevice(const std::string &parent_dir,
                               const std::string &filename);
   std::string UnwindWhiteoutFilename(const SyncItem &entry) const;

--- a/test/src/629-earlynestedcreation/main
+++ b/test/src/629-earlynestedcreation/main
@@ -40,5 +40,38 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "starting transaction to create several nested catalogs recursively"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local dir_2="nested_2"
+  echo "setting up a new nested catalog ($dir_2)"
+  mkdir ${repo_dir}/${dir_2}               || return 10
+  for d in $(seq 1 5); do
+    mkdir ${repo_dir}/${dir_2}/${d}
+    touch ${repo_dir}/${dir_2}/${d}/.cvmfscatalog
+    local j=1024
+    while [ $j -gt 0 ]; do
+      local f=$(head -c10 /dev/urandom | md5sum | cut -d' ' -f1)
+      head -c1024 /dev/urandom > ${repo_dir}/${dir_2}/${d}/${f} || return 11
+      j=$(( $j - 1 ))
+    done
+  done
+
+  local log_2="publish_2.log"
+  echo "creating CVMFS snapshot (logging into $log_2)"
+  publish_repo $CVMFS_TEST_REPO -v > $log_2 2>&1 || return $?
+
+  echo "check if the catalogs have been created properly"
+  for d in $(seq 1 5); do
+    cat $log_2 | grep -A1 -e "^\[add\] /.*${dir_2}/${d}\$" | tail -n1 | grep -e "^\[add\] Nested catalog" || return 12
+    cat $log_2 | grep -A2 -e "^\[add\] /.*${dir_2}/${d}\$" | tail -n1 | grep -e "\.cvmfscatalog$"         || return 13
+    check_catalog_presence "/${dir_2}/${d}" $CVMFS_TEST_REPO                                              || return 14
+  done
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
   return 0
 }

--- a/test/src/629-earlynestedcreation/main
+++ b/test/src/629-earlynestedcreation/main
@@ -151,5 +151,29 @@ cvmfs_run_test() {
     check_catalog_presence "/${dir_3}/${d}" $CVMFS_TEST_REPO                                              || return 37
   done
 
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "starting transaction to update some nested catalogs in ${dir_3}"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  rm -f ${repo_dir}/${dir_3}/1/.cvmfscatalog || return 40
+  rm -f ${repo_dir}/${dir_3}/3/.cvmfscatalog || return 41
+  touch ${repo_dir}/${dir_3}/.cvmfscatalog   || return 42
+
+  local log_6="publish_6.log"
+  echo "creating CVMFS snapshot (logging into $log_6)"
+  publish_repo $CVMFS_TEST_REPO -v > $log_6 2>&1 || return $?
+
+  echo "check the catalog modification sequence ($log_6)"
+  cat $log_6 | grep -A1 -e "^\[tou\] /.*${dir_3}/1\$" | tail -n1 | grep -e "^\[rem\] Nested catalog.*${dir_3}/1\$" || return 43
+  cat $log_6 | grep -A1 -e "^\[tou\] /.*${dir_3}/3\$" | tail -n1 | grep -e "^\[rem\] Nested catalog.*${dir_3}/3\$" || return 44
+  cat $log_6 | grep -A1 -e "^\[tou\] /.*${dir_3}\$"   | tail -n1 | grep -e "^\[add\] Nested catalog.*${dir_3}\$"   || return 45
+
+  echo "check that the right catalogs are present"
+  check_catalog_presence "/${dir_3}/2" $CVMFS_TEST_REPO || return 46
+  check_catalog_presence "/${dir_3}/4" $CVMFS_TEST_REPO || return 47
+  check_catalog_presence "/${dir_3}/5" $CVMFS_TEST_REPO || return 48
+  check_catalog_presence "/${dir_3}"   $CVMFS_TEST_REPO || return 49
+
   return 0
 }

--- a/test/src/629-earlynestedcreation/main
+++ b/test/src/629-earlynestedcreation/main
@@ -73,5 +73,28 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "starting transaction to remove several nested catalogs recursively"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "remove directory $dir_2 and the contained nested catalogs"
+  rm -fR ${repo_dir}/$dir_2 || return 20
+
+  local log_3="publish_3.log"
+  echo "creating CVMFS snapshot (logging into $log_3)"
+  publish_repo $CVMFS_TEST_REPO -v > $log_3 2>&1 || return $?
+
+  echo "check if the catalogs have been removed properly"
+  for d in $(seq 1 5); do
+    cat $log_3 | grep -A1 -e "^\[rem\] Nested catalog.*/${dir_2}/${d}\$" \
+               | tail -n1                                                \
+               | grep -e "^\[rem\] /.*${dir_2}/${d}\$"       || return 21
+    check_catalog_presence "/${dir_2}/${d}" $CVMFS_TEST_REPO && return 22
+  done
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
   return 0
 }

--- a/test/src/629-earlynestedcreation/main
+++ b/test/src/629-earlynestedcreation/main
@@ -1,0 +1,44 @@
+cvmfs_test_name="Early Creation of Nested Catalogs"
+cvmfs_test_autofs_on_startup=false
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to create a single nested catalog"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local dir_1="nested_1"
+  echo "setting up a new nested catalog ($dir_1)"
+  mkdir ${repo_dir}/${dir_1}               || return 1
+  touch ${repo_dir}/${dir_1}/.cvmfscatalog || return 2
+  local i=1024
+  while [ $i -gt 0 ]; do
+    local f=$(head -c10 /dev/urandom | md5sum | cut -d' ' -f1)
+    head -c1024 /dev/urandom > ${repo_dir}/${dir_1}/${f} || return 3
+    i=$(( $i - 1 ))
+  done
+
+  local log_1="publish_1.log"
+  echo "creating CVMFS snapshot (logging into $log_1)"
+  publish_repo $CVMFS_TEST_REPO -v > $log_1 2>&1 || return $?
+
+  echo "check if the nested catalog was created first"
+  # 1st: the containing directory is added
+  # 2nd: the nested catalog is created in this directory
+  cat $log_1 | grep -e '^\[add\] ' | head -n1 | grep -e "$dir_1\$"                           || return 4
+  cat $log_1 | grep -e '^\[add\] ' | head -n2 | tail -n1 | grep -e "^\[add\] Nested catalog" || return 5
+
+  echo "check if all catalogs are there"
+  check_catalog_presence "/${dir_1}" $CVMFS_TEST_REPO || return 6
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  return 0
+}

--- a/test/src/629-earlynestedcreation/main
+++ b/test/src/629-earlynestedcreation/main
@@ -96,5 +96,60 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  echo "starting transaction to create several directories"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local dir_3="nested_3"
+  echo "setting up a new testbed ($dir_3)"
+  mkdir ${repo_dir}/${dir_3} || return 30
+  for d in $(seq 1 5); do
+    mkdir ${repo_dir}/${dir_3}/${d}
+    local j=1024
+    while [ $j -gt 0 ]; do
+      local f=$(head -c10 /dev/urandom | md5sum | cut -d' ' -f1)
+      head -c1024 /dev/urandom > ${repo_dir}/${dir_3}/${d}/${f} || return 31
+      j=$(( $j - 1 ))
+    done
+  done
+
+  local log_4="publish_4.log"
+  echo "creating CVMFS snapshot (logging into $log_4)"
+  publish_repo $CVMFS_TEST_REPO -v > $log_4 2>&1 || return $?
+
+  echo "check that no catalogs are created yet"
+  for d in $(seq 1 5); do
+    check_catalog_presence "/${dir_3}/${d}" && return 32
+  done
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "starting transaction to retrofit nested catalogs inside ($dir_3)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "touch .cvmfscatalog files inside ${dir_3}"
+  for d in $(seq 1 5); do
+    touch ${repo_dir}/${dir_3}/${d}/.cvmfscatalog || return 33
+    local j=1024
+    while [ $j -gt 0 ]; do
+      local f=$(head -c10 /dev/urandom | md5sum | cut -d' ' -f1)
+      head -c1024 /dev/urandom > ${repo_dir}/${dir_3}/${d}/${f} || return 34
+      j=$(( $j - 1 ))
+    done
+  done
+
+  local log_5="publish_5.log"
+  echo "publish to create catalogs (logging into $log_5)"
+  publish_repo $CVMFS_TEST_REPO -v > $log_5 2>&1 || return 34
+
+  echo "check if the catalogs have been created properly"
+  for d in $(seq 1 5); do
+    cat $log_5 | grep -A1 -e "^\[tou\] /.*${dir_3}/${d}\$" | tail -n1 | grep -e "^\[add\] Nested catalog" || return 35
+    cat $log_5 | grep -A2 -e "^\[tou\] /.*${dir_3}/${d}\$" | tail -n1 | grep -e "\.cvmfscatalog$"         || return 36
+    check_catalog_presence "/${dir_3}/${d}" $CVMFS_TEST_REPO                                              || return 37
+  done
+
   return 0
 }

--- a/test/src/629-earlynestedcreation/main
+++ b/test/src/629-earlynestedcreation/main
@@ -66,8 +66,7 @@ cvmfs_run_test() {
   echo "check if the catalogs have been created properly"
   for d in $(seq 1 5); do
     cat $log_2 | grep -A1 -e "^\[add\] /.*${dir_2}/${d}\$" | tail -n1 | grep -e "^\[add\] Nested catalog" || return 12
-    cat $log_2 | grep -A2 -e "^\[add\] /.*${dir_2}/${d}\$" | tail -n1 | grep -e "\.cvmfscatalog$"         || return 13
-    check_catalog_presence "/${dir_2}/${d}" $CVMFS_TEST_REPO                                              || return 14
+    check_catalog_presence "/${dir_2}/${d}" $CVMFS_TEST_REPO                                              || return 13
   done
 
   echo "check catalog and data integrity"
@@ -147,8 +146,7 @@ cvmfs_run_test() {
   echo "check if the catalogs have been created properly"
   for d in $(seq 1 5); do
     cat $log_5 | grep -A1 -e "^\[tou\] /.*${dir_3}/${d}\$" | tail -n1 | grep -e "^\[add\] Nested catalog" || return 35
-    cat $log_5 | grep -A2 -e "^\[tou\] /.*${dir_3}/${d}\$" | tail -n1 | grep -e "\.cvmfscatalog$"         || return 36
-    check_catalog_presence "/${dir_3}/${d}" $CVMFS_TEST_REPO                                              || return 37
+    check_catalog_presence "/${dir_3}/${d}" $CVMFS_TEST_REPO                                              || return 36
   done
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
This was on my list since a long time: Disentangling the management of nested catalogs from the processing of `.cvmfscatalog` in `SyncMediator`. This might speed up snapshotting significantly in certain situations.

Up to now, a nested catalog was created as soon as `cvmfs_server publish` hit a `.cvmfscatalog` file, and removed when it found a deleted `.cvmfscatalog` file. Conceptually that is fine, but it might lead to *many* unnecessary catalog updates. 

For example: Imagine a user adds a new directory `release` and marks it a nested catalog (i.e. `release/.cvmfscatalog`), furthermore she adds 150.000 files to this new directory. In the worst case, `cvmfs_server publish` would traverse all 150.000 files, adding them to the father catalog of `release`. Only in the end it would find `.cvmfscatalog` which forced `cvmfs_server publish` to split the father at `release` and copying all 150.000 entries to the new nested catalog.

Similarly this could happen when `cvmfs_server publish` first finds a deleted `.cvmfscatalog` file and copys-up all entries into the father just before removing all of them, because actually the entire directory was deleted.

That patch disentangles the creation of nested catalogs from the processing of `.cvmfscatalog` in `cvmfs_server publish`. That simplifies the code and also allows to do the catalog creation smarter. I.e. a newly created directory containing a `.cvmfspublished` file will immediate result in a new (and empty) catalog that gets filled right afterwards. Similarly a removed directory containing `.cvmfspublished` is deleting an empty catalog and avoids an expensive and useless copy-up.

TODO: In the latter case, it would be even better to just remove the catalog and not even bother deleting all the entries first. But with our main use case directory deletion doesn't happen too often...

Furthermore this adds a test-case to verify the catalog creation/deletion sequencing.
