### PR TITLE
make blacklist match prevent mount

### DIFF
--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -49,6 +49,7 @@ enum LoadError {
   kLoadUp2Date,
   kLoadNoSpace,
   kLoadFail,
+  kLoadBlacklisted,
 
   kLoadNumEntries
 };
@@ -59,7 +60,8 @@ inline const char *Code2Ascii(const LoadError error) {
   texts[1] = "catalog was up to date";
   texts[2] = "not enough space to load catalog";
   texts[3] = "failed to load catalog";
-  texts[4] = "no text";
+  texts[4] = "certificate blacklisted";
+  texts[5] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -169,6 +169,9 @@ LoadError ClientCatalogManager::LoadCatalog(
     LogCvmfs(kLogCache, kLogDebug, "failed to fetch manifest (%d - %s)",
              manifest_failure, manifest::Code2Ascii(manifest_failure));
 
+    if (manifest_failure == manifest::kFailBlacklisted) {
+      return catalog::kLoadBlacklisted;
+    }
     if (catalog_path) {
       LoadError error =
         LoadCatalogCas(cache_hash, cvmfs_path, "", catalog_path);

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -617,7 +617,9 @@ CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
   shash::Any catalog_hash;
   const LoadError retval =
     LoadCatalog(mountpoint, hash, &catalog_path, &catalog_hash);
-  if ((retval == kLoadFail) || (retval == kLoadNoSpace)) {
+  if ((retval == kLoadFail) ||
+      (retval == kLoadNoSpace) ||
+      (retval == kLoadBlacklisted)) {
     LogCvmfs(kLogCatalog, kLogDebug, "failed to load catalog '%s' (%d - %s)",
              mountpoint.c_str(), retval, Code2Ascii(retval));
     return NULL;

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -501,6 +501,9 @@ least CernVM-FS $creator to manipulate this repository."
   #     -> CVMFS_AUTO_REPAIR_MOUNTPOINT=true becomes the enforced default
   #     -> Apache configuration updated
   #
+  #   2.2.0-1+ -> 2.3.0-1
+  #     -> new scratch directory layout (which also effects /etc/fstab)
+  #
   # Note: I tried to make this code as verbose as possible
   #
   if [ "$creator" = "2.1.6" ] && version_greater_or_equal "2.1.7"; then
@@ -543,7 +546,8 @@ least CernVM-FS $creator to manipulate this repository."
   fi
 
   if [ "$creator" = "2.2.0-1" ] || [ "$creator" = "2.2.1-1" ] || \
-     [ "$creator" = "2.2.2-1" ]; then
+     [ "$creator" = "2.2.2-1" ] || [ "$creator" = "2.2.3-1" ] && \
+     is_stratum0 $name; then
     if version_greater_or_equal "2.3.0"; then
       _repo_is_incompatible "$creator" $nokill
       return $?
@@ -5868,7 +5872,7 @@ _migrate_2_1_20() {
   load_repo_config $name
 }
 
-_migrate_2_2_0() {
+_migrate_2_2() {
   local name=$1
   local destination_version="2.3.0-1"
   local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
@@ -5980,10 +5984,11 @@ cvmfs_server_migrate() {
 
     if [ x"$creator" = x"2.2.0-1" -o   \
          x"$creator" = x"2.2.1-1" -o   \
-         x"$creator" = x"2.2.2-1" ] && \
+         x"$creator" = x"2.2.2-1" -o   \
+         x"$creator" = x"2.2.3-1" ] && \
          is_stratum0 $name;
     then
-      _migrate_2_2_0 $name
+      _migrate_2_2 $name
     fi
 
   done

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -396,7 +396,7 @@ int LibContext::Open(const char *c_path) {
              path.c_str());
 
     FileChunkList *chunks = new FileChunkList();
-    if (mount_point_->catalog_mgr()->ListFileChunks(
+    if (!mount_point_->catalog_mgr()->ListFileChunks(
           path, dirent.hash_algorithm(), chunks) ||
         chunks->IsEmpty())
     {

--- a/cvmfs/manifest_fetch.cc
+++ b/cvmfs/manifest_fetch.cc
@@ -82,10 +82,6 @@ Failures Fetch(const std::string &base_url, const std::string &repository_name,
     goto cleanup;
   }
 
-  // Quick way out: hash matches base catalog
-  if (base_catalog && (ensemble->manifest->catalog_hash() == *base_catalog))
-    return kFailOk;
-
   // Load certificate
   certificate_hash = ensemble->manifest->certificate();
   ensemble->FetchCertificate(certificate_hash);
@@ -106,6 +102,15 @@ Failures Fetch(const std::string &base_url, const std::string &repository_name,
     result = kFailBadCertificate;
     goto cleanup;
   }
+
+  if (signature_manager->CertificateBlacklisted()) {
+    result = kFailBlacklisted;
+    goto cleanup;
+  }
+
+  // Quick way out: hash matches base catalog
+  if (base_catalog && (ensemble->manifest->catalog_hash() == *base_catalog))
+    return kFailOk;
 
   // Verify manifest
   retval_b = signature_manager->VerifyLetter(ensemble->raw_manifest_buf,

--- a/cvmfs/manifest_fetch.h
+++ b/cvmfs/manifest_fetch.h
@@ -36,6 +36,7 @@ enum Failures {
   kFailBadWhitelist,
   kFailInvalidCertificate,
   kFailUnknown,
+  kFailBlacklisted,
 
   kFailNumEntries
 };
@@ -53,7 +54,8 @@ inline const char *Code2Ascii(const Failures error) {
   texts[8] = "bad whitelist";
   texts[9] = "invalid certificate";
   texts[10] = "unknown error";
-  texts[11] = "no text";
+  texts[11] = "certificate blacklisted";
+  texts[12] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -359,8 +359,17 @@ bool SignatureManager::LoadBlacklist(
 }
 
 
-vector<string> SignatureManager::GetBlacklistedCertificates() {
-  return blacklisted_certificates_;
+bool SignatureManager::CertificateBlacklisted() {
+  for (unsigned i = 0; i < blacklisted_certificates_.size(); ++i) {
+    shash::Any this_hash = MkFromFingerprint(blacklisted_certificates_[i]);
+    if (this_hash.IsNull())
+      continue;
+
+    shash::Algorithms algorithm = this_hash.algorithm;
+    if (this_hash == HashCertificate(algorithm))
+      return true;
+  }
+  return false;
 }
 
 

--- a/cvmfs/signature.h
+++ b/cvmfs/signature.h
@@ -46,7 +46,7 @@ class SignatureManager {
 
   bool LoadPublicRsaKeys(const std::string &path_list);
   bool LoadBlacklist(const std::string &path_blacklist, bool append);
-  std::vector<std::string> GetBlacklistedCertificates();
+  bool CertificateBlacklisted();
 
   bool LoadTrustedCaCrl(const std::string &path_list);
 

--- a/cvmfs/whitelist.cc
+++ b/cvmfs/whitelist.cc
@@ -59,18 +59,6 @@ bool Whitelist::IsExpired() const {
 Failures Whitelist::VerifyLoadedCertificate() const {
   assert(status_ == kStAvailable);
 
-  vector<string> blacklist = signature_manager_->GetBlacklistedCertificates();
-  for (unsigned i = 0; i < blacklist.size(); ++i) {
-    shash::Any this_hash =
-      signature::SignatureManager::MkFromFingerprint(blacklist[i]);
-    if (this_hash.IsNull())
-      continue;
-
-    shash::Algorithms algorithm = this_hash.algorithm;
-    if (this_hash == signature_manager_->HashCertificate(algorithm))
-      return kFailBlacklisted;
-  }
-
   for (unsigned i = 0; i < fingerprints_.size(); ++i) {
     shash::Algorithms algorithm = fingerprints_[i].algorithm;
     if (signature_manager_->HashCertificate(algorithm) == fingerprints_[i]) {

--- a/cvmfs/whitelist.h
+++ b/cvmfs/whitelist.h
@@ -39,7 +39,6 @@ enum Failures {
   kFailBadPkcs7,
   kFailBadCaChain,
   kFailNotListed,
-  kFailBlacklisted,
 
   kFailNumEntries
 };
@@ -61,8 +60,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[11] = "invalid whitelist (pkcs7)";
   texts[12] = "failed to verify CA chain";
   texts[13] = "certificate not on whitelist";
-  texts[14] = "certificate blacklisted";
-  texts[15] = "no text";
+  texts[14] = "no text";
   return texts[error];
 }
 


### PR DESCRIPTION
This pull request is for comment at this point.  I have not yet included an update to the automated test.

One thing I don't like is that there's not a way to pass a different kind of error back through MountCatalog() and Init() in catalog_mgr_impl.h.  So the caller in cvmfs.cc's Init() just reports a generic "Failed to initialize root catalog" to /var/log/messages.