### PR TITLE
FIX: Reflog Update During Snapshotting

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5161,6 +5161,7 @@ __do_snapshot() {
     [ $initial_snapshot -ne 1 ] && with_history="-p"
     $user_shell "$(__swissknife_cmd dbg) pull -m $name \
         -u $stratum0                                   \
+        -w $stratum1                                   \
         -r ${upstream}                                 \
         -x ${spool_dir}/tmp                            \
         -k $public_key                                 \

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -121,6 +121,7 @@ int CommandGc::Main(const ArgumentList &args) {
     if (NULL == deletion_log_file) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to open deletion log file "
                                       "(errno: %d)", errno);
+      uploader->TearDown();
       return 1;
     }
   }
@@ -144,12 +145,14 @@ int CommandGc::Main(const ArgumentList &args) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to write to deletion log '%s' "
                                       "(errno: %d)",
                                       deletion_log_path.c_str(), errno);
+      uploader->TearDown();
       return 1;
     }
   }
 
   GC collector(config);
   const bool success = collector.Collect();
+  uploader->TearDown();
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -34,6 +34,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Mandatory('k', "repository master key(s)"));
     r.push_back(Parameter::Optional('y', "trusted certificate directories"));
     r.push_back(Parameter::Mandatory('x', "directory for temporary files"));
+    r.push_back(Parameter::Optional('w', "repository stratum1 url"));
     r.push_back(Parameter::Optional('n', "number of download threads"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Optional('t', "timeout (s)"));

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -19,6 +19,25 @@ create_revision() {
   echo "$(get_current_root_catalog $repo_name)C"
 }
 
+print_reflog() {
+  local repo_name=$1
+  local reflog_tmp="$(mktemp ./reflog.XXXXXX)"
+  download_from_backend $repo_name ".cvmfsreflog" $reflog_tmp || return 1
+  sqlite3 $reflog_tmp "SELECT hash || 'C' FROM refs WHERE type = 0 ORDER BY hash;"
+  rm -f $reflog_tmp
+}
+
+check_reflog() {
+  local repo=$1
+  local needle_hash=$2
+  if print_reflog $repo | grep -q $needle_hash; then
+    echo "Reflog: $needle_hash found"
+  else
+    echo "Reflog: $needle_hash not found"
+    return 1
+  fi
+}
+
 snapshot_repo() {
   local replica_name=$1
 
@@ -94,6 +113,15 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 12
   peek_backend $replica_name    $catalog4 && return 13
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog2 || return 201
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 202
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 203
+
+  check_reflog $replica_name    $catalog2 && return 204
+  check_reflog $replica_name    $catalog3 && return 205
+  check_reflog $replica_name    $catalog4 && return 206
+
   echo "list repository tags"
   cvmfs_server tag -l $CVMFS_TEST_REPO || return 14
 
@@ -112,6 +140,17 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog2 && return 21 # not replicated yet
   peek_backend $replica_name    $catalog3 && return 22 # not replicated yet
   peek_backend $replica_name    $catalog4 && return 23 # not replicated yet
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 206
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 207
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 208
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 209
+
+  check_reflog $replica_name    $catalog1 || return 210
+  check_reflog $replica_name    $catalog2 && return 211
+  check_reflog $replica_name    $catalog3 && return 212
+  check_reflog $replica_name    $catalog4 && return 213
 
   # ============================================================================
 
@@ -132,6 +171,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 33 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 34 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 214
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 215
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 216
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 217
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 218
+
+  check_reflog $replica_name    $catalog1 || return 219
+  check_reflog $replica_name    $catalog2 && return 220
+  check_reflog $replica_name    $catalog3 || return 221
+  check_reflog $replica_name    $catalog4 || return 222
+  check_reflog $replica_name    $catalog5 || return 223
+
   # ============================================================================
 
   echo "run garbage collection on stratum 0"
@@ -150,6 +202,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 44 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 45 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 224
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 225
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 226
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 227
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 228
+
+  check_reflog $replica_name    $catalog1 || return 229
+  check_reflog $replica_name    $catalog2 && return 230
+  check_reflog $replica_name    $catalog3 || return 231
+  check_reflog $replica_name    $catalog4 || return 232
+  check_reflog $replica_name    $catalog5 || return 233
+
   # ============================================================================
 
   echo "run garbage collection on stratum 1"
@@ -167,6 +232,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 54 # deleted by GC
   peek_backend $replica_name    $catalog4 || return 55 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 56 # trunk
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 234
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 235
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 236
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 237
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 238
+
+  check_reflog $replica_name    $catalog1 && return 239
+  check_reflog $replica_name    $catalog2 && return 240
+  check_reflog $replica_name    $catalog3 && return 241
+  check_reflog $replica_name    $catalog4 || return 242
+  check_reflog $replica_name    $catalog5 || return 243
 
   return 0
 }

--- a/test/src/627-reflog/main
+++ b/test/src/627-reflog/main
@@ -224,7 +224,7 @@ EOF
   cvmfs_server snapshot $replica_name || return 37
 
   echo "check Reflog from Stratum1"
-  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_4 $history_2 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
+  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
 
   return 0
 }


### PR DESCRIPTION
This fixes several issues with the `Reflog` updates during `cvmfs_server snapshot`. In detail:
* legacy `Reflog` was mistakenly downloaded from `Stratum0` instead of `Stratum1`
* missed call to `Uploader::TearDown()` resulting in `assert()`
* `Catalog`s downloaded via *previous*-pointer were not registered

This adds regression checks to the integration test case 577.