### PR TITLE
Feature: Reflog cleanup on Garbage Collection

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5161,6 +5161,7 @@ __do_snapshot() {
     [ $initial_snapshot -ne 1 ] && with_history="-p"
     $user_shell "$(__swissknife_cmd dbg) pull -m $name \
         -u $stratum0                                   \
+        -w $stratum1                                   \
         -r ${upstream}                                 \
         -x ${spool_dir}/tmp                            \
         -k $public_key                                 \

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -200,14 +200,16 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
         this);
 
   bool success = true;
+  const typename CatalogTraversalT::TraversalType traversal_type =
+                                        CatalogTraversalT::kDepthFirstTraversal;
         std::vector<shash::Any>::const_iterator i    = catalogs.begin();
   const std::vector<shash::Any>::const_iterator iend = catalogs.end();
   for (; i != iend && success; ++i) {
     if (!hash_filter_.Contains(*i)) {
       success =
-        success &&
-        traversal_.TraverseRevision(*i,
-                                    CatalogTraversalT::kDepthFirstTraversal);
+        success                                         &&
+        traversal_.TraverseRevision(*i, traversal_type) &&
+        reflog->RemoveCatalog(*i);
     }
   }
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -121,6 +121,7 @@ int CommandGc::Main(const ArgumentList &args) {
     if (NULL == deletion_log_file) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to open deletion log file "
                                       "(errno: %d)", errno);
+      uploader->TearDown();
       return 1;
     }
   }
@@ -144,12 +145,14 @@ int CommandGc::Main(const ArgumentList &args) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to write to deletion log '%s' "
                                       "(errno: %d)",
                                       deletion_log_path.c_str(), errno);
+      uploader->TearDown();
       return 1;
     }
   }
 
   GC collector(config);
   const bool success = collector.Collect();
+  uploader->TearDown();
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -34,6 +34,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Mandatory('k', "repository master key(s)"));
     r.push_back(Parameter::Optional('y', "trusted certificate directories"));
     r.push_back(Parameter::Mandatory('x', "directory for temporary files"));
+    r.push_back(Parameter::Optional('w', "repository stratum1 url"));
     r.push_back(Parameter::Optional('n', "number of download threads"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Optional('t', "timeout (s)"));

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -19,6 +19,25 @@ create_revision() {
   echo "$(get_current_root_catalog $repo_name)C"
 }
 
+print_reflog() {
+  local repo_name=$1
+  local reflog_tmp="$(mktemp ./reflog.XXXXXX)"
+  download_from_backend $repo_name ".cvmfsreflog" $reflog_tmp || return 1
+  sqlite3 $reflog_tmp "SELECT hash || 'C' FROM refs WHERE type = 0 ORDER BY hash;"
+  rm -f $reflog_tmp
+}
+
+check_reflog() {
+  local repo=$1
+  local needle_hash=$2
+  if print_reflog $repo | grep -q $needle_hash; then
+    echo "Reflog: $needle_hash found"
+  else
+    echo "Reflog: $needle_hash not found"
+    return 1
+  fi
+}
+
 snapshot_repo() {
   local replica_name=$1
 
@@ -94,6 +113,15 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 12
   peek_backend $replica_name    $catalog4 && return 13
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog2 || return 201
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 202
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 203
+
+  check_reflog $replica_name    $catalog2 && return 204
+  check_reflog $replica_name    $catalog3 && return 205
+  check_reflog $replica_name    $catalog4 && return 206
+
   echo "list repository tags"
   cvmfs_server tag -l $CVMFS_TEST_REPO || return 14
 
@@ -112,6 +140,17 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog2 && return 21 # not replicated yet
   peek_backend $replica_name    $catalog3 && return 22 # not replicated yet
   peek_backend $replica_name    $catalog4 && return 23 # not replicated yet
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 206
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 207
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 208
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 209
+
+  check_reflog $replica_name    $catalog1 || return 210
+  check_reflog $replica_name    $catalog2 && return 211
+  check_reflog $replica_name    $catalog3 && return 212
+  check_reflog $replica_name    $catalog4 && return 213
 
   # ============================================================================
 
@@ -132,6 +171,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 33 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 34 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 214
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 215
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 216
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 217
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 218
+
+  check_reflog $replica_name    $catalog1 || return 219
+  check_reflog $replica_name    $catalog2 && return 220
+  check_reflog $replica_name    $catalog3 || return 221
+  check_reflog $replica_name    $catalog4 || return 222
+  check_reflog $replica_name    $catalog5 || return 223
+
   # ============================================================================
 
   echo "run garbage collection on stratum 0"
@@ -150,6 +202,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 44 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 45 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 224
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 225
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 226
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 227
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 228
+
+  check_reflog $replica_name    $catalog1 || return 229
+  check_reflog $replica_name    $catalog2 && return 230
+  check_reflog $replica_name    $catalog3 || return 231
+  check_reflog $replica_name    $catalog4 || return 232
+  check_reflog $replica_name    $catalog5 || return 233
+
   # ============================================================================
 
   echo "run garbage collection on stratum 1"
@@ -167,6 +232,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 54 # deleted by GC
   peek_backend $replica_name    $catalog4 || return 55 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 56 # trunk
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 234
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 235
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 236
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 237
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 238
+
+  check_reflog $replica_name    $catalog1 && return 239
+  check_reflog $replica_name    $catalog2 && return 240
+  check_reflog $replica_name    $catalog3 && return 241
+  check_reflog $replica_name    $catalog4 || return 242
+  check_reflog $replica_name    $catalog5 || return 243
 
   return 0
 }

--- a/test/src/627-reflog/main
+++ b/test/src/627-reflog/main
@@ -224,7 +224,7 @@ EOF
   cvmfs_server snapshot $replica_name || return 37
 
   echo "check Reflog from Stratum1"
-  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_4 $history_2 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
+  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
 
   return 0
 }

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -959,7 +959,8 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(5u, upl->deleted_hashes.size());
   EXPECT_EQ(14u, gc2.preserved_catalog_count());
-  EXPECT_EQ(2u, gc2.condemned_catalog_count());
+  EXPECT_EQ(0u, gc2.condemned_catalog_count());  // Reflog doesn't contain
+                                                 // deleted catalogs anymore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -968,7 +969,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc3.Collect());
 
   EXPECT_EQ(14u, gc3.preserved_catalog_count());
-  EXPECT_EQ(2u, gc3.condemned_catalog_count());
+  EXPECT_EQ(0u, gc3.condemned_catalog_count());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -977,7 +978,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc4.Collect());
 
   EXPECT_EQ(11u, gc4.preserved_catalog_count());
-  EXPECT_EQ(5u, gc4.condemned_catalog_count());
+  EXPECT_EQ(3u, gc4.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(1, "00")]->hash()));
@@ -1066,7 +1067,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc5.Collect());
 
   EXPECT_EQ(11u, gc5.preserved_catalog_count());
-  EXPECT_EQ(5u, gc5.condemned_catalog_count());
+  EXPECT_EQ(0u, gc5.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1076,7 +1077,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc6.Collect());
 
   EXPECT_EQ(11u, gc6.preserved_catalog_count());
-  EXPECT_EQ(5u, gc6.condemned_catalog_count());
+  EXPECT_EQ(0u, gc6.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1086,7 +1087,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc7.Collect());
 
   EXPECT_EQ(7u, gc7.preserved_catalog_count());
-  EXPECT_EQ(9u, gc7.condemned_catalog_count());
+  EXPECT_EQ(4u, gc7.condemned_catalog_count());
   EXPECT_EQ(29u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(4, "00")]->hash()));


### PR DESCRIPTION
This cleans out `Reflog` entries as soon as they are swept by the garbage collection. Note that this is based on [FIX: Reflog Update During Snapshotting](https://github.com/cvmfs/cvmfs/pull/1544).