### PR TITLE
Feature: Swissknife Ignores Missing Reflog

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5161,6 +5161,7 @@ __do_snapshot() {
     [ $initial_snapshot -ne 1 ] && with_history="-p"
     $user_shell "$(__swissknife_cmd dbg) pull -m $name \
         -u $stratum0                                   \
+        -w $stratum1                                   \
         -r ${upstream}                                 \
         -x ${spool_dir}/tmp                            \
         -k $public_key                                 \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3074,6 +3074,7 @@ mkfs() {
   local create_cmd="$(__swissknife_cmd) create  \
     -t $temp_dir                                \
     -r $upstream                                \
+    -n $name                                    \
     -a $hash_algo $volatile_opt                 \
     -o ${temp_dir}/new_manifest"
   if $garbage_collectable; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5110,8 +5110,10 @@ __do_snapshot() {
     fi
 
     local initial_snapshot=0
+    local initial_snapshot_flag=""
     if $user_shell "$(__swissknife_cmd) peek -d .cvmfs_last_snapshot -r ${upstream}" | grep -v -q "available"; then
       initial_snapshot=1
+      initial_snapshot_flag="-i"
     fi
 
     # check for other snapshots in progress
@@ -5168,7 +5170,7 @@ __do_snapshot() {
         -k $public_key                                 \
         -n $num_workers                                \
         -t $timeout                                    \
-        -a $retries $with_history $log_level"
+        -a $retries $with_history $initial_snapshot_flag $log_level"
 
     local last_snapshot_tmp="${spool_dir}/tmp/last_snapshot"
     $user_shell "date --utc > $last_snapshot_tmp"

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -200,14 +200,16 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
         this);
 
   bool success = true;
+  const typename CatalogTraversalT::TraversalType traversal_type =
+                                        CatalogTraversalT::kDepthFirstTraversal;
         std::vector<shash::Any>::const_iterator i    = catalogs.begin();
   const std::vector<shash::Any>::const_iterator iend = catalogs.end();
   for (; i != iend && success; ++i) {
     if (!hash_filter_.Contains(*i)) {
       success =
-        success &&
-        traversal_.TraverseRevision(*i,
-                                    CatalogTraversalT::kDepthFirstTraversal);
+        success                                         &&
+        traversal_.TraverseRevision(*i, traversal_type) &&
+        reflog->RemoveCatalog(*i);
     }
   }
 

--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -194,4 +194,17 @@ manifest::Manifest* Command::FetchRemoteManifest(
   return manifest.Release();
 }
 
+
+manifest::Reflog* swissknife::Command::CreateEmptyReflog(
+                                              const std::string &temp_directory,
+                                              const std::string &repo_name) {
+  // create a new Reflog if there was none found yet
+  const std::string tmp_path_prefix = temp_directory + "/new_reflog";
+  const std::string tmp_path = CreateTempPath(tmp_path_prefix, 0600);
+
+  LogCvmfs(kLogCvmfs, kLogDebug, "creating new reflog '%s' for %s",
+                                 tmp_path.c_str(), repo_name.c_str());
+  return manifest::Reflog::Create(tmp_path, repo_name);
+}
+
 }  // namespace swissknife

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -109,6 +109,9 @@ class Command {
   manifest::Reflog* GetOrIgnoreReflog(ObjectFetcherT    *object_fetcher,
                                       const std::string &repo_name);
 
+  manifest::Reflog* CreateEmptyReflog(const std::string &temp_directory,
+                                      const std::string &repo_name);
+
   download::DownloadManager*   download_manager()  const;
   signature::SignatureManager* signature_manager() const;
   perf::Statistics*            statistics() { return &statistics_; }

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -105,6 +105,10 @@ class Command {
   manifest::Reflog* GetOrCreateReflog(ObjectFetcherT    *object_fetcher,
                                       const std::string &repo_name);
 
+  template <class ObjectFetcherT>
+  manifest::Reflog* GetOrIgnoreReflog(ObjectFetcherT    *object_fetcher,
+                                      const std::string &repo_name);
+
   download::DownloadManager*   download_manager()  const;
   signature::SignatureManager* signature_manager() const;
   perf::Statistics*            statistics() { return &statistics_; }

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -106,8 +106,8 @@ class Command {
                                       const std::string &repo_name);
 
   template <class ObjectFetcherT>
-  manifest::Reflog* GetOrIgnoreReflog(ObjectFetcherT    *object_fetcher,
-                                      const std::string &repo_name);
+  manifest::Reflog* FetchReflog(ObjectFetcherT    *object_fetcher,
+                                const std::string &repo_name);
 
   manifest::Reflog* CreateEmptyReflog(const std::string &temp_directory,
                                       const std::string &repo_name);

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -102,10 +102,6 @@ class Command {
                              const shash::Any  &base_hash = shash::Any()) const;
 
   template <class ObjectFetcherT>
-  manifest::Reflog* GetOrCreateReflog(ObjectFetcherT    *object_fetcher,
-                                      const std::string &repo_name);
-
-  template <class ObjectFetcherT>
   manifest::Reflog* FetchReflog(ObjectFetcherT    *object_fetcher,
                                 const std::string &repo_name);
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -99,9 +99,9 @@ int CommandGc::Main(const ArgumentList &args) {
   }
 
   UniquePtr<manifest::Reflog> reflog;
-  reflog = GetOrCreateReflog(&object_fetcher, repo_name);
+  reflog = FetchReflog(&object_fetcher, repo_name);
   if (!reflog.IsValid()) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load or create Reflog");
+    LogCvmfs(kLogCvmfs, kLogStderr, "no Reflog found, cannot garbage collect");
     return 1;
   }
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -121,6 +121,7 @@ int CommandGc::Main(const ArgumentList &args) {
     if (NULL == deletion_log_file) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to open deletion log file "
                                       "(errno: %d)", errno);
+      uploader->TearDown();
       return 1;
     }
   }
@@ -144,12 +145,14 @@ int CommandGc::Main(const ArgumentList &args) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to write to deletion log '%s' "
                                       "(errno: %d)",
                                       deletion_log_path.c_str(), errno);
+      uploader->TearDown();
       return 1;
     }
   }
 
   GC collector(config);
   const bool success = collector.Collect();
+  uploader->TearDown();
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -10,7 +10,7 @@
 #include "util/posix.h"
 
 template <class ObjectFetcherT>
-manifest::Reflog* swissknife::Command::GetOrIgnoreReflog(
+manifest::Reflog* swissknife::Command::FetchReflog(
                                               ObjectFetcherT    *object_fetcher,
                                               const std::string &repo_name) {
   // try to fetch the Reflog from the backend storage first

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -38,19 +38,4 @@ manifest::Reflog* swissknife::Command::FetchReflog(
   return reflog;
 }
 
-
-template <class ObjectFetcherT>
-manifest::Reflog* swissknife::Command::GetOrCreateReflog(
-                                              ObjectFetcherT    *object_fetcher,
-                                              const std::string &repo_name) {
-  manifest::Reflog *reflog = GetOrIgnoreReflog(object_fetcher, repo_name);
-
-  if (reflog == NULL) {
-    const std::string tmp_dir = object_fetcher->temporary_directory();
-    reflog = CreateEmptyReflog(tmp_dir, repo_name);
-  }
-
-  return reflog;
-}
-
 #endif  // CVMFS_SWISSKNIFE_IMPL_H_

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -44,18 +44,13 @@ manifest::Reflog* swissknife::Command::GetOrCreateReflog(
                                               ObjectFetcherT    *object_fetcher,
                                               const std::string &repo_name) {
   manifest::Reflog *reflog = GetOrIgnoreReflog(object_fetcher, repo_name);
-  if (reflog != NULL) {
-    return reflog;
+
+  if (reflog == NULL) {
+    const std::string tmp_dir = object_fetcher->temporary_directory();
+    reflog = CreateEmptyReflog(tmp_dir, repo_name);
   }
 
-  // create a new Reflog if there was none found yet
-  const std::string tmp_path_prefix = object_fetcher->temporary_directory() +
-                                      "/new_reflog";
-  const std::string tmp_path = CreateTempPath(tmp_path_prefix, 0600);
-
-  LogCvmfs(kLogCvmfs, kLogDebug, "creating new reflog '%s' for %s",
-                                 tmp_path.c_str(), repo_name.c_str());
-  return manifest::Reflog::Create(tmp_path, repo_name);
+  return reflog;
 }
 
 #endif  // CVMFS_SWISSKNIFE_IMPL_H_

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -17,18 +17,22 @@ manifest::Reflog* swissknife::Command::GetOrIgnoreReflog(
   manifest::Reflog *reflog = NULL;
   typename ObjectFetcherT::Failures f = object_fetcher->FetchReflog(&reflog);
 
-  if (f == ObjectFetcherT::kFailOk) {
-    LogCvmfs(kLogCvmfs, kLogDebug, "fetched reflog '%s' from backend storage",
+  switch (f) {
+    case ObjectFetcherT::kFailOk:
+      LogCvmfs(kLogCvmfs, kLogDebug, "fetched reflog '%s' from backend storage",
                                    reflog->database_file().c_str());
-  } else if (f == ObjectFetcherT::kFailNotFound) {
-    LogCvmfs(kLogCvmfs, kLogDebug, "reflog for '%s' not found",
-                                   repo_name.c_str());
-    reflog = NULL;
-  } else {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load reflog for '%s' (%d - %s)",
-                                    repo_name.c_str(),
-                                    f, Code2Ascii(f));
-    abort();
+      break;
+
+    case ObjectFetcherT::kFailNotFound:
+      LogCvmfs(kLogCvmfs, kLogDebug, "reflog for '%s' not found",
+                                     repo_name.c_str());
+      reflog = NULL;
+      break;
+
+    default:
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed loading reflog in '%s' (%d - %s)",
+                                          repo_name.c_str(), f, Code2Ascii(f));
+      abort();
   }
 
   return reflog;

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -634,7 +634,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
                                             download_manager(),
                                             signature_manager());
 
-      reflog = GetOrIgnoreReflog(&object_fetcher_stratum1, repository_name);
+      reflog = FetchReflog(&object_fetcher_stratum1, repository_name);
       if (reflog == NULL) {
         LogCvmfs(kLogCvmfs, kLogVerboseMsg, "failed to get Reflog (ignoring)");
       }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -622,12 +622,12 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
                                           download_manager(),
                                           signature_manager());
 
-    reflog = GetOrCreateReflog(&object_fetcher_stratum1, repository_name);
+    reflog = GetOrIgnoreReflog(&object_fetcher_stratum1, repository_name);
     if (reflog == NULL) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to get or construct a Reflog");
-      goto fini;
+      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "failed to get a Reflog (ignoring)");
+    } else {
+      reflog->BeginTransaction();
     }
-    reflog->BeginTransaction();
   }
 
   // Get meta info
@@ -771,7 +771,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     }
 
     // upload Reflog database
-    if (!preload_cache) {
+    if (!preload_cache && reflog != NULL) {
       reflog->CommitTransaction();
       spooler->UploadReflog(reflog->CloseAndReturnDatabaseFile());
       spooler->WaitForUpload();

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -41,6 +41,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional('a', "number of retries"));
     r.push_back(Parameter::Optional('d', "directory for path specification"));
     r.push_back(Parameter::Switch('p', "pull catalog history, too"));
+    r.push_back(Parameter::Switch('i', "mark as an 'initial snapshot'"));
     r.push_back(Parameter::Switch('c', "preload cache instead of stratum 1"));
     // Required for preloading client cache with a dirtab.  If the dirtab
     // changes, the existence of a catalog does not anymore indicate if

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -34,6 +34,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Mandatory('k', "repository master key(s)"));
     r.push_back(Parameter::Optional('y', "trusted certificate directories"));
     r.push_back(Parameter::Mandatory('x', "directory for temporary files"));
+    r.push_back(Parameter::Optional('w', "repository stratum1 url"));
     r.push_back(Parameter::Optional('n', "number of download threads"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Optional('t', "timeout (s)"));

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -93,7 +93,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   }
 
   UniquePtr<manifest::Reflog> reflog;
-  reflog = GetOrIgnoreReflog(&object_fetcher, repo_name);
+  reflog = FetchReflog(&object_fetcher, repo_name);
   if (!reflog) {
     LogCvmfs(kLogCvmfs, kLogVerboseMsg, "failed to fetch Reflog (ignoring)");
   }

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -92,6 +92,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
   const string manifest_path = *args.find('o')->second;
   const string dir_temp = *args.find('t')->second;
   const string spooler_definition = *args.find('r')->second;
+  const string repo_name = *args.find('n')->second;
   if (args.find('l') != args.end()) {
     unsigned log_level =
       1 << (kLogLevel0 + String2Uint64(*args.find('l')->second));
@@ -133,6 +134,13 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
+  UniquePtr<manifest::Reflog> reflog(CreateEmptyReflog(dir_temp, repo_name));
+  if (!reflog.IsValid()) {
+    PrintError("Failed to create fresh Reflog");
+    return 1;
+  }
+
+  spooler->UploadReflog(reflog->CloseAndReturnDatabaseFile());
   spooler->WaitForUpload();
   delete spooler;
 

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -99,6 +99,7 @@ class CommandCreate : public Command {
     r.push_back(Parameter::Mandatory('o', "manifest output file"));
     r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Mandatory('n', "repository name"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Optional('a', "hash algorithm (default: SHA-1)"));
     r.push_back(Parameter::Optional('V', "VOMS authz requirement "

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -19,6 +19,25 @@ create_revision() {
   echo "$(get_current_root_catalog $repo_name)C"
 }
 
+print_reflog() {
+  local repo_name=$1
+  local reflog_tmp="$(mktemp ./reflog.XXXXXX)"
+  download_from_backend $repo_name ".cvmfsreflog" $reflog_tmp || return 1
+  sqlite3 $reflog_tmp "SELECT hash || 'C' FROM refs WHERE type = 0 ORDER BY hash;"
+  rm -f $reflog_tmp
+}
+
+check_reflog() {
+  local repo=$1
+  local needle_hash=$2
+  if print_reflog $repo | grep -q $needle_hash; then
+    echo "Reflog: $needle_hash found"
+  else
+    echo "Reflog: $needle_hash not found"
+    return 1
+  fi
+}
+
 snapshot_repo() {
   local replica_name=$1
 
@@ -94,6 +113,15 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 12
   peek_backend $replica_name    $catalog4 && return 13
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog2 || return 201
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 202
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 203
+
+  check_reflog $replica_name    $catalog2 && return 204
+  check_reflog $replica_name    $catalog3 && return 205
+  check_reflog $replica_name    $catalog4 && return 206
+
   echo "list repository tags"
   cvmfs_server tag -l $CVMFS_TEST_REPO || return 14
 
@@ -112,6 +140,17 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog2 && return 21 # not replicated yet
   peek_backend $replica_name    $catalog3 && return 22 # not replicated yet
   peek_backend $replica_name    $catalog4 && return 23 # not replicated yet
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 206
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 207
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 208
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 209
+
+  check_reflog $replica_name    $catalog1 || return 210
+  check_reflog $replica_name    $catalog2 && return 211
+  check_reflog $replica_name    $catalog3 && return 212
+  check_reflog $replica_name    $catalog4 && return 213
 
   # ============================================================================
 
@@ -132,6 +171,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 33 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 34 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 214
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 215
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 216
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 217
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 218
+
+  check_reflog $replica_name    $catalog1 || return 219
+  check_reflog $replica_name    $catalog2 && return 220
+  check_reflog $replica_name    $catalog3 || return 221
+  check_reflog $replica_name    $catalog4 || return 222
+  check_reflog $replica_name    $catalog5 || return 223
+
   # ============================================================================
 
   echo "run garbage collection on stratum 0"
@@ -150,6 +202,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 44 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 45 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 224
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 225
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 226
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 227
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 228
+
+  check_reflog $replica_name    $catalog1 || return 229
+  check_reflog $replica_name    $catalog2 && return 230
+  check_reflog $replica_name    $catalog3 || return 231
+  check_reflog $replica_name    $catalog4 || return 232
+  check_reflog $replica_name    $catalog5 || return 233
+
   # ============================================================================
 
   echo "run garbage collection on stratum 1"
@@ -167,6 +232,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 54 # deleted by GC
   peek_backend $replica_name    $catalog4 || return 55 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 56 # trunk
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 234
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 235
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 236
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 237
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 238
+
+  check_reflog $replica_name    $catalog1 && return 239
+  check_reflog $replica_name    $catalog2 && return 240
+  check_reflog $replica_name    $catalog3 && return 241
+  check_reflog $replica_name    $catalog4 || return 242
+  check_reflog $replica_name    $catalog5 || return 243
 
   return 0
 }

--- a/test/src/627-reflog/main
+++ b/test/src/627-reflog/main
@@ -224,7 +224,7 @@ EOF
   cvmfs_server snapshot $replica_name || return 37
 
   echo "check Reflog from Stratum1"
-  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_4 $history_2 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
+  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -1486,6 +1486,15 @@ make_path() {
 }
 
 
+peek_backend_raw() {
+  local repo_name="$1"
+  local remote_path="$2"
+
+  load_repo_config $repo_name
+  cvmfs_swissknife peek -d $remote_path -r $CVMFS_UPSTREAM_STORAGE
+}
+
+
 # peeks in the upstream storage to find a given content hash
 #
 # @param repository     the repository name to be queried
@@ -1494,10 +1503,8 @@ make_path() {
 peek_backend() {
   local repo_name="$1"
   local content_hash="$2"
-  local remote_path=$(make_path $content_hash)
 
-  load_repo_config $repo_name
-  cvmfs_swissknife peek -d $remote_path -r $CVMFS_UPSTREAM_STORAGE
+  peek_backend_raw $repo_name $(make_path $content_hash)
 }
 
 

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -959,7 +959,8 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(5u, upl->deleted_hashes.size());
   EXPECT_EQ(14u, gc2.preserved_catalog_count());
-  EXPECT_EQ(2u, gc2.condemned_catalog_count());
+  EXPECT_EQ(0u, gc2.condemned_catalog_count());  // Reflog doesn't contain
+                                                 // deleted catalogs anymore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -968,7 +969,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc3.Collect());
 
   EXPECT_EQ(14u, gc3.preserved_catalog_count());
-  EXPECT_EQ(2u, gc3.condemned_catalog_count());
+  EXPECT_EQ(0u, gc3.condemned_catalog_count());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -977,7 +978,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc4.Collect());
 
   EXPECT_EQ(11u, gc4.preserved_catalog_count());
-  EXPECT_EQ(5u, gc4.condemned_catalog_count());
+  EXPECT_EQ(3u, gc4.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(1, "00")]->hash()));
@@ -1066,7 +1067,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc5.Collect());
 
   EXPECT_EQ(11u, gc5.preserved_catalog_count());
-  EXPECT_EQ(5u, gc5.condemned_catalog_count());
+  EXPECT_EQ(0u, gc5.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1076,7 +1077,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc6.Collect());
 
   EXPECT_EQ(11u, gc6.preserved_catalog_count());
-  EXPECT_EQ(5u, gc6.condemned_catalog_count());
+  EXPECT_EQ(0u, gc6.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1086,7 +1087,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc7.Collect());
 
   EXPECT_EQ(7u, gc7.preserved_catalog_count());
-  EXPECT_EQ(9u, gc7.condemned_catalog_count());
+  EXPECT_EQ(4u, gc7.condemned_catalog_count());
   EXPECT_EQ(29u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(4, "00")]->hash()));


### PR DESCRIPTION
This changes the `Reflog` handling so that a missing `Reflog` can be ignored by most of the `cvmfs_swissknife` commands. In order to do garbage collection, a `Reflog` must be constructed from the available `Catalog` and `History` chains first (TODO).

Both `cvmfs_server mkfs` and an initial `cvmfs_server snapshot` will drop an empty `Reflog` to be filled opportunistically for new repositories and replicas.