### PR TITLE
Feature: Regenerate Reflog from Available Catalog and History Chains

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -217,6 +217,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
   swissknife_main.cc
   swissknife_migrate.cc swissknife_migrate.h
   swissknife_pull.cc swissknife_pull.h
+  swissknife_reflog.cc swissknife_reflog.h
   swissknife_scrub.cc swissknife_scrub.h
   swissknife_sign.cc swissknife_sign.h
   swissknife_sync.cc swissknife_sync.h

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1017,6 +1017,19 @@ is_garbage_collectable() {
   fi
 }
 
+# checks if a repository contains a reference log that is necessary to run
+# garbage collections
+#
+# @param name  the name of the repository to be checked
+# @return      0 if it contains a reference log
+has_reference_log() {
+  local name=$1
+  local url=""
+  load_repo_config $name
+  is_stratum0 $name && url="$CVMFS_STRATUM0" || url="$CVMFS_STRATUM1"
+  [ x"$(get_repo_info_from_url "$url" -o)" = x"true" ]
+}
+
 # checks if a repository has automatic garbage collection enabled
 #
 # @param name  the name of the repository to be checked

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5000,7 +5000,7 @@ __run_gc() {
                                             $additional_switches"
 
   if ! $user_shell "$gc_command"; then
-    to_syslog_for_repo $name "failed to garbage collect"
+    [ $dry_run -ne 0 ] || to_syslog_for_repo $name "failed to garbage collect"
     return 6
   fi
 
@@ -5021,7 +5021,7 @@ __run_gc() {
     fi
   fi
 
-  to_syslog_for_repo $name "successfully finished garbage collection"
+  [ $dry_run -ne 0 ] || to_syslog_for_repo $name "successfully finished garbage collection"
 
   return 0
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4960,7 +4960,9 @@ gc() {
     to_syslog_for_repo $name "started manual garbage collection"
 
     # run the garbage collection
-    echo "Running Garbage Collection"
+    local reflog_reconstruct_msg=""
+    [ $reconstruct_reflog -ne 0 ] && reflog_reconstruct_msg="(reconstructing reference logs)"
+    echo "Running Garbage Collection $reflog_reconstruct_msg"
     __run_gc "$name"               \
              "$repository_url"     \
              "$dry_run"            \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5161,6 +5161,7 @@ __do_snapshot() {
     [ $initial_snapshot -ne 1 ] && with_history="-p"
     $user_shell "$(__swissknife_cmd dbg) pull -m $name \
         -u $stratum0                                   \
+        -w $stratum1                                   \
         -r ${upstream}                                 \
         -x ${spool_dir}/tmp                            \
         -k $public_key                                 \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4816,6 +4816,7 @@ gc() {
   local timestamp_threshold=""
   local force=0
   local deletion_log=""
+  local reconstruct_reflog="0"
 
   # optional parameter handling
   OPTIND=1
@@ -4870,6 +4871,18 @@ gc() {
   echo '         in future versions of CernVM-FS. Please do not use it manually!'
   echo
 
+  for name in $names; do
+    if ! has_reference_log $name; then
+      reconstruct_reflog=1
+    fi
+  done
+
+  # sanity checks
+  if [ $dry_run -ne 0 ] && [ $reconstruct_reflog -ne 0 ]; then
+    die "Reflog reconstruction needed. Cannot do a dry-run."
+  fi
+
+  # safety user confirmation
   if [ $force -eq 0 ] && [ $dry_run -eq 0 ]; then
     echo "YOU ARE ABOUT TO DELETE DATA! Are you sure you want to do the following:"
   fi
@@ -4877,8 +4890,12 @@ gc() {
   local dry_run_msg="no"
   if [ $dry_run -eq 1 ]; then dry_run_msg="yes"; fi
 
+  local reflog_reconstruct_msg="no"
+  if [ $reconstruct_reflog -eq 1 ]; then reflog_reconstruct_msg="yes"; fi
+
   echo "Affected Repositories:         $names"
   echo "Dry Run (no actual deletion):  $dry_run_msg"
+  echo "Needs Reflog reconstruction:   $reflog_reconstruct_msg"
   if [ $preserve_revisions -ge 0 ]; then
     echo "Preserved Legacy Revisions:    $preserve_revisions"
   fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -3074,6 +3074,7 @@ mkfs() {
   local create_cmd="$(__swissknife_cmd) create  \
     -t $temp_dir                                \
     -r $upstream                                \
+    -n $name                                    \
     -a $hash_algo $volatile_opt                 \
     -o ${temp_dir}/new_manifest"
   if $garbage_collectable; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4667,6 +4667,7 @@ publish() {
                $manifest   \
                $trunk_hash \
                ""          \
+               "0"         \
                -z $gc_timespan      || { local err=$?; publish_failed $name; die "Garbage collection failed ($err)"; }
       sign_manifest $name $manifest || { publish_failed $name; die "Signing failed"; }
     fi
@@ -4960,12 +4961,13 @@ gc() {
 
     # run the garbage collection
     echo "Running Garbage Collection"
-    __run_gc "$name"           \
-             "$repository_url" \
-             "$dry_run"        \
-             "$manifest"       \
-             "$base_hash"      \
-             "$deletion_log"   \
+    __run_gc "$name"               \
+             "$repository_url"     \
+             "$dry_run"            \
+             "$manifest"           \
+             "$base_hash"          \
+             "$deletion_log"       \
+             "$reconstruct_reflog" \
              $additional_switches || die "Fail ($?)!"
 
     # sign the result
@@ -4993,7 +4995,8 @@ __run_gc() {
   local manifest="$4"
   local base_hash="$5"
   local deletion_log="$6"
-  shift 6
+  local reconstruct_reflog="$7"
+  shift 7
   local additional_switches="$*"
 
   load_repo_config $name
@@ -5003,11 +5006,17 @@ __run_gc() {
   [ x"$repository_url" != x"" ] || return 2
   if [ $dry_run -eq 0 ]; then
     is_in_transaction $name || is_stratum1 $name || return 3
+  else
+    [ $reconstruct_reflog -eq 0 ] || return 8
   fi
 
   if is_stratum0 $name; then
     [ x"$manifest"  != x"" ] || return 4
     [ x"$base_hash" != x"" ] || return 5
+  fi
+
+  if ! has_reference_log $name && [ $reconstruct_reflog -eq 0 ]; then
+    return 9
   fi
 
   # handle a configured deletion log (manually passed log has precedence)
@@ -5219,6 +5228,7 @@ __do_snapshot() {
                ""            \
                ""            \
                ""            \
+               "0"           \
                -z $gc_timespan || die "Garbage collection failed ($?)"
     fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5027,9 +5027,24 @@ __run_gc() {
   fi
 
   # do it!
-  [ $dry_run -ne 0 ] || to_syslog_for_repo $name "started garbage collection"
-
   local user_shell="$(get_user_shell $name)"
+
+  if [ $reconstruct_reflog -ne 0 ]; then
+    to_syslog_for_repo $name "reference log reconstruction started"
+    local reflog_reconstruct_command="$(__swissknife_cmd dbg) reconstruct_reflog \
+                                                  -r $repository_url             \
+                                                  -u $CVMFS_UPSTREAM_STORAGE     \
+                                                  -n $CVMFS_REPOSITORY_NAME      \
+                                                  -t ${CVMFS_SPOOL_DIR}/tmp/     \
+                                                  -k $CVMFS_PUBLIC_KEY"
+    if ! $user_shell "$reflog_reconstruct_command"; then
+      to_syslog_for_repo $name "failed to reconstruction reference log"
+    else
+      to_syslog_for_repo $name "successfully reconstructed reference log"
+    fi
+  fi
+
+  [ $dry_run -ne 0 ] || to_syslog_for_repo $name "started garbage collection"
   local gc_command="$(__swissknife_cmd dbg) gc                         \
                                             -r $repository_url         \
                                             -u $CVMFS_UPSTREAM_STORAGE \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5110,8 +5110,10 @@ __do_snapshot() {
     fi
 
     local initial_snapshot=0
+    local initial_snapshot_flag=""
     if $user_shell "$(__swissknife_cmd) peek -d .cvmfs_last_snapshot -r ${upstream}" | grep -v -q "available"; then
       initial_snapshot=1
+      initial_snapshot_flag="-i"
     fi
 
     # check for other snapshots in progress
@@ -5168,7 +5170,7 @@ __do_snapshot() {
         -k $public_key                                 \
         -n $num_workers                                \
         -t $timeout                                    \
-        -a $retries $with_history $log_level"
+        -a $retries $with_history $initial_snapshot_flag $log_level"
 
     local last_snapshot_tmp="${spool_dir}/tmp/last_snapshot"
     $user_shell "date --utc > $last_snapshot_tmp"

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -200,14 +200,16 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
         this);
 
   bool success = true;
+  const typename CatalogTraversalT::TraversalType traversal_type =
+                                        CatalogTraversalT::kDepthFirstTraversal;
         std::vector<shash::Any>::const_iterator i    = catalogs.begin();
   const std::vector<shash::Any>::const_iterator iend = catalogs.end();
   for (; i != iend && success; ++i) {
     if (!hash_filter_.Contains(*i)) {
       success =
-        success &&
-        traversal_.TraverseRevision(*i,
-                                    CatalogTraversalT::kDepthFirstTraversal);
+        success                                         &&
+        traversal_.TraverseRevision(*i, traversal_type) &&
+        reflog->RemoveCatalog(*i);
     }
   }
 

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -368,7 +368,8 @@ class LocalObjectFetcher :
     FILE *f = CreateTempFile(tmp_path, 0600, "w", file_path);
     if (NULL == f) {
       LogCvmfs(kLogDownload, kLogStderr,
-               "failed to create temp file (errno: %d)", errno);
+               "failed to create temp file '%s' (errno: %d)",
+               tmp_path.c_str(), errno);
       return BaseTN::kFailLocalIO;
     }
 
@@ -537,7 +538,8 @@ class HttpObjectFetcher :
     FILE *f = CreateTempFile(tmp_path, 0600, "w", file_path);
     if (NULL == f) {
       LogCvmfs(kLogDownload, kLogStderr,
-               "failed to create temp file (errno: %d)", errno);
+               "failed to create temp file '%s' (errno: %d)",
+               tmp_path.c_str(), errno);
       return BaseTN::kFailLocalIO;
     }
 

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -35,6 +35,11 @@ class Reflog {
 
   bool RemoveCatalog(const shash::Any &hash);
 
+  bool ContainsCertificate(const shash::Any &certificate) const;
+  bool ContainsCatalog(const shash::Any &catalog) const;
+  bool ContainsHistory(const shash::Any &history) const;
+  bool ContainsMetainfo(const shash::Any &metainfo) const;
+
   void BeginTransaction();
   void CommitTransaction();
 
@@ -50,6 +55,8 @@ class Reflog {
  protected:
   bool AddReference(const shash::Any               &hash,
                     const SqlReflog::ReferenceType  type);
+  bool ContainsReference(const shash::Any               &hash,
+                         const SqlReflog::ReferenceType  type) const;
 
  private:
   bool CreateDatabase(const std::string &database_path,
@@ -59,12 +66,13 @@ class Reflog {
   void PrepareQueries();
 
  private:
-  UniquePtr<ReflogDatabase>      database_;
+  UniquePtr<ReflogDatabase>       database_;
 
-  UniquePtr<SqlInsertReference>  insert_reference_;
-  UniquePtr<SqlCountReferences>  count_references_;
-  UniquePtr<SqlListReferences>   list_references_;
-  UniquePtr<SqlRemoveReference>  remove_reference_;
+  UniquePtr<SqlInsertReference>   insert_reference_;
+  UniquePtr<SqlCountReferences>   count_references_;
+  UniquePtr<SqlListReferences>    list_references_;
+  UniquePtr<SqlRemoveReference>   remove_reference_;
+  UniquePtr<SqlContainsReference> contains_reference_;
 };
 
 }  // namespace manifest

--- a/cvmfs/reflog_sql.cc
+++ b/cvmfs/reflog_sql.cc
@@ -150,3 +150,26 @@ bool SqlRemoveReference::BindReference(const shash::Any    &reference_hash,
     BindTextTransient(1, reference_hash.ToString()) &&
     BindInt64(2, static_cast<uint64_t>(type));
 }
+
+
+//------------------------------------------------------------------------------
+
+
+SqlContainsReference::SqlContainsReference(const ReflogDatabase *database) {
+  DeferredInit(database->sqlite_db(), "SELECT count(*) as answer FROM refs "
+                                      "WHERE type = :type "
+                                      "  AND hash = :hash");
+}
+
+bool SqlContainsReference::BindReference(const shash::Any    &reference_hash,
+                                         const ReferenceType  type) {
+  return
+    BindInt64(1, static_cast<uint64_t>(type)) &&
+    BindTextTransient(2, reference_hash.ToString());
+}
+
+bool SqlContainsReference::RetrieveAnswer() {
+  const int64_t count = RetrieveInt64(0);
+  assert(count == 0 || count == 1);
+  return count > 0;
+}

--- a/cvmfs/reflog_sql.h
+++ b/cvmfs/reflog_sql.h
@@ -84,4 +84,13 @@ class SqlRemoveReference : public SqlReflog {
                      const ReferenceType  type);
 };
 
+
+class SqlContainsReference : public SqlReflog {
+ public:
+  explicit SqlContainsReference(const ReflogDatabase *database);
+  bool BindReference(const shash::Any    &reference_hash,
+                     const ReferenceType  type);
+  bool RetrieveAnswer();
+};
+
 #endif  // CVMFS_REFLOG_SQL_H_

--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -194,4 +194,17 @@ manifest::Manifest* Command::FetchRemoteManifest(
   return manifest.Release();
 }
 
+
+manifest::Reflog* swissknife::Command::CreateEmptyReflog(
+                                              const std::string &temp_directory,
+                                              const std::string &repo_name) {
+  // create a new Reflog if there was none found yet
+  const std::string tmp_path_prefix = temp_directory + "/new_reflog";
+  const std::string tmp_path = CreateTempPath(tmp_path_prefix, 0600);
+
+  LogCvmfs(kLogCvmfs, kLogDebug, "creating new reflog '%s' for %s",
+                                 tmp_path.c_str(), repo_name.c_str());
+  return manifest::Reflog::Create(tmp_path, repo_name);
+}
+
 }  // namespace swissknife

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -109,6 +109,9 @@ class Command {
   manifest::Reflog* GetOrIgnoreReflog(ObjectFetcherT    *object_fetcher,
                                       const std::string &repo_name);
 
+  manifest::Reflog* CreateEmptyReflog(const std::string &temp_directory,
+                                      const std::string &repo_name);
+
   download::DownloadManager*   download_manager()  const;
   signature::SignatureManager* signature_manager() const;
   perf::Statistics*            statistics() { return &statistics_; }

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -105,6 +105,10 @@ class Command {
   manifest::Reflog* GetOrCreateReflog(ObjectFetcherT    *object_fetcher,
                                       const std::string &repo_name);
 
+  template <class ObjectFetcherT>
+  manifest::Reflog* GetOrIgnoreReflog(ObjectFetcherT    *object_fetcher,
+                                      const std::string &repo_name);
+
   download::DownloadManager*   download_manager()  const;
   signature::SignatureManager* signature_manager() const;
   perf::Statistics*            statistics() { return &statistics_; }

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -106,8 +106,8 @@ class Command {
                                       const std::string &repo_name);
 
   template <class ObjectFetcherT>
-  manifest::Reflog* GetOrIgnoreReflog(ObjectFetcherT    *object_fetcher,
-                                      const std::string &repo_name);
+  manifest::Reflog* FetchReflog(ObjectFetcherT    *object_fetcher,
+                                const std::string &repo_name);
 
   manifest::Reflog* CreateEmptyReflog(const std::string &temp_directory,
                                       const std::string &repo_name);

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -102,10 +102,6 @@ class Command {
                              const shash::Any  &base_hash = shash::Any()) const;
 
   template <class ObjectFetcherT>
-  manifest::Reflog* GetOrCreateReflog(ObjectFetcherT    *object_fetcher,
-                                      const std::string &repo_name);
-
-  template <class ObjectFetcherT>
   manifest::Reflog* FetchReflog(ObjectFetcherT    *object_fetcher,
                                 const std::string &repo_name);
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -176,8 +176,8 @@ int CommandGc::Main(const ArgumentList &args) {
   unlink(reflog_db.c_str());
 
   if (uploader->GetNumberOfErrors() > 0) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload updated Reflog "
-                                    "(not critical)");
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload updated Reflog");
+    success = false;
   }
 
   uploader->TearDown();

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -170,8 +170,16 @@ int CommandGc::Main(const ArgumentList &args) {
   }
 
   reflog->CommitTransaction();
-  uploader->Upload(reflog->CloseAndReturnDatabaseFile(), ".cvmfsreflog");
+  const std::string reflog_db = reflog->CloseAndReturnDatabaseFile();
+  uploader->Upload(reflog_db, ".cvmfsreflog");
   uploader->WaitForUpload();
+  unlink(reflog_db.c_str());
+
+  if (uploader->GetNumberOfErrors() > 0) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload updated Reflog "
+                                    "(not critical)");
+  }
+
   uploader->TearDown();
 
   return success ? 0 : 1;

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -177,7 +177,8 @@ int CommandGc::Main(const ArgumentList &args) {
 
   if (uploader->GetNumberOfErrors() > 0) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload updated Reflog");
-    success = false;
+    uploader->TearDown();
+    return 1;
   }
 
   uploader->TearDown();

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -99,9 +99,9 @@ int CommandGc::Main(const ArgumentList &args) {
   }
 
   UniquePtr<manifest::Reflog> reflog;
-  reflog = GetOrCreateReflog(&object_fetcher, repo_name);
+  reflog = FetchReflog(&object_fetcher, repo_name);
   if (!reflog.IsValid()) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load or create Reflog");
+    LogCvmfs(kLogCvmfs, kLogStderr, "no Reflog found, cannot garbage collect");
     return 1;
   }
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -121,6 +121,7 @@ int CommandGc::Main(const ArgumentList &args) {
     if (NULL == deletion_log_file) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to open deletion log file "
                                       "(errno: %d)", errno);
+      uploader->TearDown();
       return 1;
     }
   }
@@ -144,12 +145,14 @@ int CommandGc::Main(const ArgumentList &args) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to write to deletion log '%s' "
                                       "(errno: %d)",
                                       deletion_log_path.c_str(), errno);
+      uploader->TearDown();
       return 1;
     }
   }
 
   GC collector(config);
   const bool success = collector.Collect();
+  uploader->TearDown();
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -10,7 +10,7 @@
 #include "util/posix.h"
 
 template <class ObjectFetcherT>
-manifest::Reflog* swissknife::Command::GetOrIgnoreReflog(
+manifest::Reflog* swissknife::Command::FetchReflog(
                                               ObjectFetcherT    *object_fetcher,
                                               const std::string &repo_name) {
   // try to fetch the Reflog from the backend storage first

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -38,19 +38,4 @@ manifest::Reflog* swissknife::Command::FetchReflog(
   return reflog;
 }
 
-
-template <class ObjectFetcherT>
-manifest::Reflog* swissknife::Command::GetOrCreateReflog(
-                                              ObjectFetcherT    *object_fetcher,
-                                              const std::string &repo_name) {
-  manifest::Reflog *reflog = GetOrIgnoreReflog(object_fetcher, repo_name);
-
-  if (reflog == NULL) {
-    const std::string tmp_dir = object_fetcher->temporary_directory();
-    reflog = CreateEmptyReflog(tmp_dir, repo_name);
-  }
-
-  return reflog;
-}
-
 #endif  // CVMFS_SWISSKNIFE_IMPL_H_

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -44,18 +44,13 @@ manifest::Reflog* swissknife::Command::GetOrCreateReflog(
                                               ObjectFetcherT    *object_fetcher,
                                               const std::string &repo_name) {
   manifest::Reflog *reflog = GetOrIgnoreReflog(object_fetcher, repo_name);
-  if (reflog != NULL) {
-    return reflog;
+
+  if (reflog == NULL) {
+    const std::string tmp_dir = object_fetcher->temporary_directory();
+    reflog = CreateEmptyReflog(tmp_dir, repo_name);
   }
 
-  // create a new Reflog if there was none found yet
-  const std::string tmp_path_prefix = object_fetcher->temporary_directory() +
-                                      "/new_reflog";
-  const std::string tmp_path = CreateTempPath(tmp_path_prefix, 0600);
-
-  LogCvmfs(kLogCvmfs, kLogDebug, "creating new reflog '%s' for %s",
-                                 tmp_path.c_str(), repo_name.c_str());
-  return manifest::Reflog::Create(tmp_path, repo_name);
+  return reflog;
 }
 
 #endif  // CVMFS_SWISSKNIFE_IMPL_H_

--- a/cvmfs/swissknife_impl.h
+++ b/cvmfs/swissknife_impl.h
@@ -17,18 +17,22 @@ manifest::Reflog* swissknife::Command::GetOrIgnoreReflog(
   manifest::Reflog *reflog = NULL;
   typename ObjectFetcherT::Failures f = object_fetcher->FetchReflog(&reflog);
 
-  if (f == ObjectFetcherT::kFailOk) {
-    LogCvmfs(kLogCvmfs, kLogDebug, "fetched reflog '%s' from backend storage",
+  switch (f) {
+    case ObjectFetcherT::kFailOk:
+      LogCvmfs(kLogCvmfs, kLogDebug, "fetched reflog '%s' from backend storage",
                                    reflog->database_file().c_str());
-  } else if (f == ObjectFetcherT::kFailNotFound) {
-    LogCvmfs(kLogCvmfs, kLogDebug, "reflog for '%s' not found",
-                                   repo_name.c_str());
-    reflog = NULL;
-  } else {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load reflog for '%s' (%d - %s)",
-                                    repo_name.c_str(),
-                                    f, Code2Ascii(f));
-    abort();
+      break;
+
+    case ObjectFetcherT::kFailNotFound:
+      LogCvmfs(kLogCvmfs, kLogDebug, "reflog for '%s' not found",
+                                     repo_name.c_str());
+      reflog = NULL;
+      break;
+
+    default:
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed loading reflog in '%s' (%d - %s)",
+                                          repo_name.c_str(), f, Code2Ascii(f));
+      abort();
   }
 
   return reflog;

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -56,6 +56,8 @@ ParameterList CommandInfo::GetParams() {
   r.push_back(Parameter::Switch('v', "repository revision number"));
   r.push_back(Parameter::Switch('g', "check if repository is garbage "
                                         "collectable"));
+  r.push_back(Parameter::Switch('o', "check if the repository maintains a "
+                                     "reference log file"));
   r.push_back(Parameter::Switch('h', "print results in human readable form"));
   r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
   r.push_back(Parameter::Switch('X', "show whether external data is supported "
@@ -215,6 +217,12 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
     LogCvmfs(kLogCvmfs, kLogStdout, "%s%s",
              (human_readable) ? "Garbage Collectable:             " : "",
              (StringifyBool(manifest->garbage_collectable())).c_str());
+  }
+
+  if (args.count('o') > 0) {
+    LogCvmfs(kLogCvmfs, kLogStdout, "%s%s",
+             (human_readable) ? "Maintains Reference Log:         " : "",
+             (Exists(repository, ".cvmfsreflog")) ? "true" : "false");
   }
 
   if (args.count('M') > 0) {

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -19,6 +19,7 @@
 #include "swissknife_lsrepo.h"
 #include "swissknife_migrate.h"
 #include "swissknife_pull.h"
+#include "swissknife_reflog.h"
 #include "swissknife_scrub.h"
 #include "swissknife_sign.h"
 #include "swissknife_sync.h"
@@ -91,6 +92,7 @@ int main(int argc, char **argv) {
   command_list.push_back(new swissknife::CommandMigrate());
   command_list.push_back(new swissknife::CommandScrub());
   command_list.push_back(new swissknife::CommandGc());
+  command_list.push_back(new swissknife::CommandBootstrapReflog());
 
   if (argc < 2) {
     Usage();

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
   command_list.push_back(new swissknife::CommandMigrate());
   command_list.push_back(new swissknife::CommandScrub());
   command_list.push_back(new swissknife::CommandGc());
-  command_list.push_back(new swissknife::CommandBootstrapReflog());
+  command_list.push_back(new swissknife::CommandReconstructReflog());
 
   if (argc < 2) {
     Usage();

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -634,7 +634,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
                                             download_manager(),
                                             signature_manager());
 
-      reflog = GetOrIgnoreReflog(&object_fetcher_stratum1, repository_name);
+      reflog = FetchReflog(&object_fetcher_stratum1, repository_name);
       if (reflog == NULL) {
         LogCvmfs(kLogCvmfs, kLogVerboseMsg, "failed to get Reflog (ignoring)");
       }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -622,12 +622,12 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
                                           download_manager(),
                                           signature_manager());
 
-    reflog = GetOrCreateReflog(&object_fetcher_stratum1, repository_name);
+    reflog = GetOrIgnoreReflog(&object_fetcher_stratum1, repository_name);
     if (reflog == NULL) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to get or construct a Reflog");
-      goto fini;
+      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "failed to get a Reflog (ignoring)");
+    } else {
+      reflog->BeginTransaction();
     }
-    reflog->BeginTransaction();
   }
 
   // Get meta info
@@ -771,7 +771,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     }
 
     // upload Reflog database
-    if (!preload_cache) {
+    if (!preload_cache && reflog != NULL) {
       reflog->CommitTransaction();
       spooler->UploadReflog(reflog->CloseAndReturnDatabaseFile());
       spooler->WaitForUpload();

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -41,6 +41,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional('a', "number of retries"));
     r.push_back(Parameter::Optional('d', "directory for path specification"));
     r.push_back(Parameter::Switch('p', "pull catalog history, too"));
+    r.push_back(Parameter::Switch('i', "mark as an 'initial snapshot'"));
     r.push_back(Parameter::Switch('c', "preload cache instead of stratum 1"));
     // Required for preloading client cache with a dirtab.  If the dirtab
     // changes, the existence of a catalog does not anymore indicate if

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -34,6 +34,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Mandatory('k', "repository master key(s)"));
     r.push_back(Parameter::Optional('y', "trusted certificate directories"));
     r.push_back(Parameter::Mandatory('x', "directory for temporary files"));
+    r.push_back(Parameter::Optional('w', "repository stratum1 url"));
     r.push_back(Parameter::Optional('n', "number of download threads"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Optional('t', "timeout (s)"));

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -40,7 +40,7 @@ int CommandBootstrapReflog::Main(const ArgumentList &args) {
   const std::string &repo_url  = *args.find('r')->second;
   const std::string &spooler   = *args.find('u')->second;
   const std::string &repo_name = *args.find('n')->second;
-  const std::string &tmp_dir   = *args.find('n')->second;
+  const std::string &tmp_dir   = *args.find('t')->second;
   const std::string &repo_keys = *args.find('k')->second;
 
   const bool follow_redirects = false;

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -4,7 +4,16 @@
 
 #include "swissknife_reflog.h"
 
+#include <string>
+
+#include "object_fetcher.h"
+#include "manifest.h"
+#include "upload_facility.h"
+
+
 namespace swissknife {
+
+typedef HttpObjectFetcher<> ObjectFetcher;
 
 CommandBootstrapReflog::CommandBootstrapReflog() {
 
@@ -17,11 +26,55 @@ CommandBootstrapReflog::~CommandBootstrapReflog() {
 
 
 ParameterList CommandBootstrapReflog::GetParams() {
-  return ParameterList();
+  ParameterList r;
+  r.push_back(Parameter::Mandatory('r', "repository url"));
+  r.push_back(Parameter::Mandatory('u', "spooler definition string"));
+  r.push_back(Parameter::Mandatory('n', "fully qualified repository name"));
+  r.push_back(Parameter::Mandatory('t', "temporary directory"));
+  r.push_back(Parameter::Mandatory('k', "repository keychain"));
+  return r;
 }
 
 
 int CommandBootstrapReflog::Main(const ArgumentList &args) {
+  const std::string &repo_url  = *args.find('r')->second;
+  const std::string &spooler   = *args.find('u')->second;
+  const std::string &repo_name = *args.find('n')->second;
+  const std::string &tmp_dir   = *args.find('n')->second;
+  const std::string &repo_keys = *args.find('k')->second;
+
+  const bool follow_redirects = false;
+  if (!this->InitDownloadManager(follow_redirects) ||
+      !this->InitVerifyingSignatureManager(repo_keys)) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to init repo connection");
+    return 1;
+  }
+
+  ObjectFetcher object_fetcher(repo_name,
+                               repo_url,
+                               tmp_dir,
+                               download_manager(),
+                               signature_manager());
+
+  UniquePtr<manifest::Manifest> manifest;
+  ObjectFetcher::Failures retval = object_fetcher.FetchManifest(&manifest);
+  if (retval != ObjectFetcher::kFailOk) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to load repository manifest "
+                                    "(%d - %s)",
+                                    retval, Code2Ascii(retval));
+    return 1;
+  }
+
+  const upload::SpoolerDefinition spooler_definition(spooler, shash::kAny);
+  UniquePtr<upload::AbstractUploader> uploader(
+                       upload::AbstractUploader::Construct(spooler_definition));
+
+  if (!uploader.IsValid()) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to initialize spooler for '%s'",
+             spooler.c_str());
+    return 1;
+  }
+
   return 0;
 }
 

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -121,8 +121,11 @@ int CommandReconstructReflog::Main(const ArgumentList &args) {
 
   LogCvmfs(kLogCvmfs, kLogStdout, "found %d entries", reflog->CountEntries());
 
-  uploader->Upload(reflog->CloseAndReturnDatabaseFile(), ".cvmfsreflog");
+  const std::string reflog_db = reflog->CloseAndReturnDatabaseFile();
+  uploader->Upload(reflog_db, ".cvmfsreflog");
   uploader->WaitForUpload();
+  unlink(reflog_db.c_str());
+
   const int errors = uploader->GetNumberOfErrors();
   if (errors > 0) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload generated Reflog");

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -9,8 +9,8 @@
 #include <string>
 #include <vector>
 
-#include "object_fetcher.h"
 #include "manifest.h"
+#include "object_fetcher.h"
 #include "upload_facility.h"
 
 
@@ -209,7 +209,6 @@ void RootChainWalker::WalkHistories(const shash::Any &history_hash) {
 
 
 void RootChainWalker::WalkCatalogsInHistory(const HistoryTN *history) {
-
   CatalogList tag_hashes;
   const bool list_success = history->GetHashes(&tag_hashes);
   assert(list_success);

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -58,7 +58,7 @@ class RootChainWalker {
 };
 
 
-ParameterList CommandBootstrapReflog::GetParams() {
+ParameterList CommandReconstructReflog::GetParams() {
   ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository url"));
   r.push_back(Parameter::Mandatory('u', "spooler definition string"));
@@ -69,7 +69,7 @@ ParameterList CommandBootstrapReflog::GetParams() {
 }
 
 
-int CommandBootstrapReflog::Main(const ArgumentList &args) {
+int CommandReconstructReflog::Main(const ArgumentList &args) {
   const std::string &repo_url  = *args.find('r')->second;
   const std::string &spooler   = *args.find('u')->second;
   const std::string &repo_name = *args.find('n')->second;
@@ -134,7 +134,7 @@ int CommandBootstrapReflog::Main(const ArgumentList &args) {
 }
 
 
-void CommandBootstrapReflog::AddStaticManifestObjects(
+void CommandReconstructReflog::AddStaticManifestObjects(
                                           manifest::Reflog    *reflog,
                                           manifest::Manifest  *manifest) const {
   const shash::Any certificate = manifest->certificate();

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "swissknife_reflog.h"
+
+namespace swissknife {
+
+CommandBootstrapReflog::CommandBootstrapReflog() {
+
+}
+
+
+CommandBootstrapReflog::~CommandBootstrapReflog() {
+
+}
+
+
+ParameterList CommandBootstrapReflog::GetParams() {
+  return ParameterList();
+}
+
+
+int CommandBootstrapReflog::Main(const ArgumentList &args) {
+  return 0;
+}
+
+}  // namespace swissknife

--- a/cvmfs/swissknife_reflog.h
+++ b/cvmfs/swissknife_reflog.h
@@ -7,6 +7,11 @@
 
 #include "swissknife.h"
 
+namespace manifest {
+  class Reflog;
+  class Manifest;
+}
+
 namespace swissknife {
 
 class CommandBootstrapReflog : public Command {
@@ -20,6 +25,10 @@ class CommandBootstrapReflog : public Command {
   }
   ParameterList GetParams();
   int Main(const ArgumentList &args);
+
+ protected:
+  void AddStaticManifestObjects(manifest::Reflog    *reflog,
+                                manifest::Manifest  *manifest) const;
 };
 
 };  // namespace swissknife

--- a/cvmfs/swissknife_reflog.h
+++ b/cvmfs/swissknife_reflog.h
@@ -16,8 +16,6 @@ namespace swissknife {
 
 class CommandBootstrapReflog : public Command {
  public:
-  CommandBootstrapReflog();
-  ~CommandBootstrapReflog();
   std::string GetName() { return "bootstrap_reflog"; }
   std::string GetDescription() {
     return "Bootstraps a Reference Log from Catalog and History chains. This "

--- a/cvmfs/swissknife_reflog.h
+++ b/cvmfs/swissknife_reflog.h
@@ -7,9 +7,11 @@
 
 #include "swissknife.h"
 
+#include <string>
+
 namespace manifest {
-  class Reflog;
-  class Manifest;
+class Reflog;
+class Manifest;
 }
 
 namespace swissknife {

--- a/cvmfs/swissknife_reflog.h
+++ b/cvmfs/swissknife_reflog.h
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_SWISSKNIFE_REFLOG_H_
+#define CVMFS_SWISSKNIFE_REFLOG_H_
+
+#include "swissknife.h"
+
+namespace swissknife {
+
+class CommandBootstrapReflog : public Command {
+ public:
+  CommandBootstrapReflog();
+  ~CommandBootstrapReflog();
+  std::string GetName() { return "bootstrap_reflog"; }
+  std::string GetDescription() {
+    return "Bootstraps a Reference Log from Catalog and History chains. This "
+           "is used for both legacy repository migration and repairs.";
+  }
+  ParameterList GetParams();
+  int Main(const ArgumentList &args);
+};
+
+};  // namespace swissknife
+
+#endif  // CVMFS_SWISSKNIFE_REFLOG_H_

--- a/cvmfs/swissknife_reflog.h
+++ b/cvmfs/swissknife_reflog.h
@@ -14,9 +14,9 @@ namespace manifest {
 
 namespace swissknife {
 
-class CommandBootstrapReflog : public Command {
+class CommandReconstructReflog : public Command {
  public:
-  std::string GetName() { return "bootstrap_reflog"; }
+  std::string GetName() { return "reconstruct_reflog"; }
   std::string GetDescription() {
     return "Bootstraps a Reference Log from Catalog and History chains. This "
            "is used for both legacy repository migration and repairs.";

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -93,7 +93,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   }
 
   UniquePtr<manifest::Reflog> reflog;
-  reflog = GetOrIgnoreReflog(&object_fetcher, repo_name);
+  reflog = FetchReflog(&object_fetcher, repo_name);
   if (!reflog) {
     LogCvmfs(kLogCvmfs, kLogVerboseMsg, "failed to fetch Reflog (ignoring)");
   }

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -92,6 +92,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
   const string manifest_path = *args.find('o')->second;
   const string dir_temp = *args.find('t')->second;
   const string spooler_definition = *args.find('r')->second;
+  const string repo_name = *args.find('n')->second;
   if (args.find('l') != args.end()) {
     unsigned log_level =
       1 << (kLogLevel0 + String2Uint64(*args.find('l')->second));
@@ -133,6 +134,13 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
+  UniquePtr<manifest::Reflog> reflog(CreateEmptyReflog(dir_temp, repo_name));
+  if (!reflog.IsValid()) {
+    PrintError("Failed to create fresh Reflog");
+    return 1;
+  }
+
+  spooler->UploadReflog(reflog->CloseAndReturnDatabaseFile());
   spooler->WaitForUpload();
   delete spooler;
 

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -99,6 +99,7 @@ class CommandCreate : public Command {
     r.push_back(Parameter::Mandatory('o', "manifest output file"));
     r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
+    r.push_back(Parameter::Mandatory('n', "repository name"));
     r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
     r.push_back(Parameter::Optional('a', "hash algorithm (default: SHA-1)"));
     r.push_back(Parameter::Optional('V', "VOMS authz requirement "

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -49,10 +49,18 @@ cvmfs_run_test() {
     -l                                           \
     -s                                           \
     -g > $import_log 2>&1 || return 4
+  local cvmfs21_root_clgs=""
+  local root_clg_after_import="$(get_current_root_catalog $legacy_repo_name)"
+  cvmfs21_root_clgs="$cvmfs21_root_clgs $root_clg_after_import"
+  echo "root catalog after import: $root_clg_after_import"
 
   if uses_overlayfs $legacy_repo_name; then
     echo "we are running on OverlayFS. We need to erase all hardlinks now..."
     sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 101
+
+    local root_clg_after_hardlink_elimination="$(get_current_root_catalog $legacy_repo_name)"
+    cvmfs21_root_clgs="$cvmfs21_root_clgs $root_clg_after_hardlink_elimination"
+    echo "root catalog after hardlink elimination: $root_clg_after_hardlink_elimination"
   fi
 
   echo "get all data chunks in the legacy repository"
@@ -77,7 +85,10 @@ cvmfs_run_test() {
   rm -fR /cvmfs/${legacy_repo_name}/dir3 /cvmfs/${legacy_repo_name}/dir7 || return 6
 
   echo "publish the new revision"
-  publish_repo $legacy_repo_name      || return 7
+  publish_repo $legacy_repo_name || return 7
+  local root_clg_after_deletion_commit="$(get_current_root_catalog $legacy_repo_name)"
+  cvmfs21_root_clgs="$cvmfs21_root_clgs $root_clg_after_deletion_commit"
+  echo "root catalog after emptying repo: $root_clg_after_deletion_commit"
 
   echo "check migrated catalogs and data chunks"
   check_repository $legacy_repo_name || return 8
@@ -92,8 +103,26 @@ cvmfs_run_test() {
     peek_backend $legacy_repo_name $hash || return 10
   done
 
-  echo "run a first garbage collection to delete all revision except the last 4"
-  cvmfs_server gc -r 3 -f $legacy_repo_name || return 11
+  local gc_log_1="${scratch_dir}/gc_1.log"
+  echo "run a first garbage collection to delete all revision except the last 4 (logging to $gc_log_1)"
+  cvmfs_server gc -r 3 -f $legacy_repo_name > $gc_log_1 2>&1 || return 11
+
+  echo "check that the Reflog was properly reconstructed"
+  cat $gc_log_1 | grep 'reconstructing reference log'                          || return 101
+  cat $gc_log_1 | grep 'Certificate: bd46e502db6e41c972be183eb2bbac2110515e1f' || return 102
+
+  local cvmfs20_root_clgs="07df6f3a10a70ca17df82370ca3845e82ca6a9af
+758959a24e43d3c59c4c8c33783730475aaa139d
+d75c0a16673229c02491660e05bdd214620943d5
+e1db87c42de2501a3999b6fbbfdf9674ad968e71
+713ca8a74dd20682338da781e314ac2b8ce883e4
+1b027e59f09fa69514a29811bcc22427fac3cad3"
+  local all_reflog_entries_found=1
+  for clg in $cvmfs20_root_clgs $cvmfs21_root_clgs; do
+    echo -n "looking for ${clg}... "
+    cat $gc_log_1 | grep -q "Catalog: $clg" && echo "found" || { echo "not found"; all_reflog_entries_found=0; }
+  done
+  [ $all_reflog_entries_found -eq 1 ] || return 103
 
   echo "check if some 2.0 catalogs are gone (5 expected)"
   local not_available_catalogs=0

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -19,6 +19,25 @@ create_revision() {
   echo "$(get_current_root_catalog $repo_name)C"
 }
 
+print_reflog() {
+  local repo_name=$1
+  local reflog_tmp="$(mktemp ./reflog.XXXXXX)"
+  download_from_backend $repo_name ".cvmfsreflog" $reflog_tmp || return 1
+  sqlite3 $reflog_tmp "SELECT hash || 'C' FROM refs WHERE type = 0 ORDER BY hash;"
+  rm -f $reflog_tmp
+}
+
+check_reflog() {
+  local repo=$1
+  local needle_hash=$2
+  if print_reflog $repo | grep -q $needle_hash; then
+    echo "Reflog: $needle_hash found"
+  else
+    echo "Reflog: $needle_hash not found"
+    return 1
+  fi
+}
+
 snapshot_repo() {
   local replica_name=$1
 
@@ -94,6 +113,15 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 12
   peek_backend $replica_name    $catalog4 && return 13
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog2 || return 201
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 202
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 203
+
+  check_reflog $replica_name    $catalog2 && return 204
+  check_reflog $replica_name    $catalog3 && return 205
+  check_reflog $replica_name    $catalog4 && return 206
+
   echo "list repository tags"
   cvmfs_server tag -l $CVMFS_TEST_REPO || return 14
 
@@ -112,6 +140,17 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog2 && return 21 # not replicated yet
   peek_backend $replica_name    $catalog3 && return 22 # not replicated yet
   peek_backend $replica_name    $catalog4 && return 23 # not replicated yet
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 206
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 207
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 208
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 209
+
+  check_reflog $replica_name    $catalog1 || return 210
+  check_reflog $replica_name    $catalog2 && return 211
+  check_reflog $replica_name    $catalog3 && return 212
+  check_reflog $replica_name    $catalog4 && return 213
 
   # ============================================================================
 
@@ -132,6 +171,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 33 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 34 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 214
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 215
+  check_reflog $CVMFS_TEST_REPO $catalog3 || return 216
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 217
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 218
+
+  check_reflog $replica_name    $catalog1 || return 219
+  check_reflog $replica_name    $catalog2 && return 220
+  check_reflog $replica_name    $catalog3 || return 221
+  check_reflog $replica_name    $catalog4 || return 222
+  check_reflog $replica_name    $catalog5 || return 223
+
   # ============================================================================
 
   echo "run garbage collection on stratum 0"
@@ -150,6 +202,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog4 || return 44 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 45 # trunk
 
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 224
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 225
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 226
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 227
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 228
+
+  check_reflog $replica_name    $catalog1 || return 229
+  check_reflog $replica_name    $catalog2 && return 230
+  check_reflog $replica_name    $catalog3 || return 231
+  check_reflog $replica_name    $catalog4 || return 232
+  check_reflog $replica_name    $catalog5 || return 233
+
   # ============================================================================
 
   echo "run garbage collection on stratum 1"
@@ -167,6 +232,19 @@ cvmfs_run_test() {
   peek_backend $replica_name    $catalog3 && return 54 # deleted by GC
   peek_backend $replica_name    $catalog4 || return 55 # trunk-previous
   peek_backend $replica_name    $catalog5 || return 56 # trunk
+
+  echo "check if the new catalogs are in the reflogs"
+  check_reflog $CVMFS_TEST_REPO $catalog1 && return 234
+  check_reflog $CVMFS_TEST_REPO $catalog2 && return 235
+  check_reflog $CVMFS_TEST_REPO $catalog3 && return 236
+  check_reflog $CVMFS_TEST_REPO $catalog4 || return 237
+  check_reflog $CVMFS_TEST_REPO $catalog5 || return 238
+
+  check_reflog $replica_name    $catalog1 && return 239
+  check_reflog $replica_name    $catalog2 && return 240
+  check_reflog $replica_name    $catalog3 && return 241
+  check_reflog $replica_name    $catalog4 || return 242
+  check_reflog $replica_name    $catalog5 || return 243
 
   return 0
 }

--- a/test/src/627-reflog/main
+++ b/test/src/627-reflog/main
@@ -224,7 +224,7 @@ EOF
   cvmfs_server snapshot $replica_name || return 37
 
   echo "check Reflog from Stratum1"
-  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_4 $history_2 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
+  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
 
   return 0
 }

--- a/test/src/629-reflogrecreation/main
+++ b/test/src/629-reflogrecreation/main
@@ -7,11 +7,11 @@ cleanup() {
   [ -z $CVMFS_TEST_627_REPLICA_NAME ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_627_REPLICA_NAME
 }
 
-check_stratum1_tmp_dir_emptiness() {
+check_tmp_dir_emptiness() {
   local tmp_dir="$1"
   local tmp_dir_entries
   echo "check stratum1 tmp directory"
-  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  tmp_dir_entries=$(ls -a $tmp_dir | grep -v '^\.\+$' | wc -l)
   echo "$tmp_dir contains: $tmp_dir_entries"
   [ $tmp_dir_entries -eq 0 ]
 }
@@ -52,6 +52,11 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g || return $?
 
+  echo -n "get Stratum 0 spool directory: "
+  load_repo_config $CVMFS_TEST_REPO
+  local s0_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  echo "$s0_spool_tmp_dir"
+
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   echo "install a cleanup function"
@@ -75,7 +80,7 @@ cvmfs_run_test() {
   sudo cvmfs_server snapshot $replica_name || return 2
 
   echo "check that Stratum1 spooler tmp dir is empty"
-  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || return 3
+  check_tmp_dir_emptiness $s1_spool_tmp_dir || return 3
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -107,6 +112,9 @@ cvmfs_run_test() {
   cvmfs_server tag -a "foobar"                          \
                    -m "new tag to create a new history" \
                    -h "$root_hash_1" $CVMFS_TEST_REPO || return 6
+
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 120
 
   echo "extracting root hashes from Stratum0"
   local root_hash_2=$(get_manifest_field $CVMFS_TEST_REPO 'C')
@@ -145,6 +153,9 @@ EOF
 
   cvmfs_server update-repoinfo -f $json_file $CVMFS_TEST_REPO || return 13
 
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 121
+
   echo "extracting root hashes from Stratum0"
   local root_hash_3=$(get_manifest_field $CVMFS_TEST_REPO 'C')
   local history_3=$(get_manifest_field $CVMFS_TEST_REPO 'H')
@@ -174,6 +185,9 @@ EOF
   start_transaction $CVMFS_TEST_REPO || return 20
   publish_repo $CVMFS_TEST_REPO      || return 21
 
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 122
+
   echo "extracting root hashes from Stratum0"
   local root_hash_4=$(get_manifest_field $CVMFS_TEST_REPO 'C')
   local history_4=$(get_manifest_field $CVMFS_TEST_REPO 'H')
@@ -201,6 +215,9 @@ EOF
   echo "Update revision in Stratum0"
   start_transaction $CVMFS_TEST_REPO || return 28
   publish_repo $CVMFS_TEST_REPO      || return 29
+
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 123
 
   echo "extracting root hashes from Stratum0"
   local root_hash_5=$(get_manifest_field $CVMFS_TEST_REPO 'C')
@@ -238,6 +255,9 @@ EOF
   toggle_gc         $CVMFS_TEST_REPO || return 38
   start_transaction $CVMFS_TEST_REPO || return 39
   publish_repo      $CVMFS_TEST_REPO || return 40
+
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 124
 
   echo "extracting root hashes from Stratum0"
   local root_hash_6=$(get_manifest_field $CVMFS_TEST_REPO 'C')

--- a/test/src/629-reflogrecreation/main
+++ b/test/src/629-reflogrecreation/main
@@ -1,0 +1,294 @@
+cvmfs_test_name="Missing Reference Log Ignore and On-Demand Recreation"
+cvmfs_test_autofs_on_startup=false
+
+
+CVMFS_TEST_627_REPLICA_NAME=
+cleanup() {
+  [ -z $CVMFS_TEST_627_REPLICA_NAME ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_627_REPLICA_NAME
+}
+
+check_stratum1_tmp_dir_emptiness() {
+  local tmp_dir="$1"
+  local tmp_dir_entries
+  echo "check stratum1 tmp directory"
+  tmp_dir_entries=$(ls $tmp_dir | wc -l)
+  echo "$tmp_dir contains: $tmp_dir_entries"
+  [ $tmp_dir_entries -eq 0 ]
+}
+
+check_reflog_contains() {
+  local repo_name="$1"
+  local needles="$2"
+  local sqlite_file=$(mktemp "${repo_name}.sqlite.XXXXXX")
+  download_from_backend $repo_name ".cvmfsreflog" $sqlite_file || return 1
+  local refs="$(sqlite3 $sqlite_file "SELECT hash FROM refs")" || return 2
+  local found_all=0
+  for n in $needles; do
+    echo -n "checking ${n}... "
+    if ! contains "$refs" "$n"; then
+      echo "not found"
+      found_all=1
+    else
+      echo "found"
+    fi
+  done
+  return $found_all
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  mkdir reference_dir
+  local reference_dir=$scratch_dir/reference_dir
+
+  local mnt_point="$(pwd)/mountpount"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  echo -n "check that we have 'sqlite3'... "
+  which sqlite3 > /dev/null 2>&1 && echo "done" || { echo "fail"; return 1; }
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g || return $?
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "install a cleanup function"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "create Stratum1 repository on the same machine"
+  load_repo_config $CVMFS_TEST_REPO
+  CVMFS_TEST_627_REPLICA_NAME=$replica_name
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 1
+
+  echo -n "get Stratum 1 spool directory: "
+  load_repo_config $replica_name
+  local s1_spool_tmp_dir="${CVMFS_SPOOL_DIR}/tmp"
+  load_repo_config $CVMFS_TEST_REPO
+  echo "$s1_spool_tmp_dir"
+
+  echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
+  sudo cvmfs_server snapshot $replica_name || return 2
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_stratum1_tmp_dir_emptiness $s1_spool_tmp_dir || return 3
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_1=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_1=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_1=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_1=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_1"
+  echo "H: $history_1"
+  echo "M: $meta_info_1"
+  echo "X: $certificate_1"
+
+  echo "check Reflog from Stratum0"
+  check_reflog_contains $CVMFS_TEST_REPO "$root_hash_1 $history_1 $meta_info_1 $certificate_1" || return 4
+
+  echo "check Reflog from Stratum1"
+  check_reflog_contains $replica_name "$root_hash_1 $history_1 $meta_info_1 $certificate_1" || return 5
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "check that Reflog is available on Stratum0"
+  peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" || return 71
+
+  echo "removing Reflog from Stratum0"
+  delete_from_backend $CVMFS_TEST_REPO ".cvmfsreflog" || return 72
+
+  echo "creating a tag in Stratum0"
+  cvmfs_server tag -a "foobar"                          \
+                   -m "new tag to create a new history" \
+                   -h "$root_hash_1" $CVMFS_TEST_REPO || return 6
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_2=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_2=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_2=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_2=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_2"
+  echo "H: $history_2"
+  echo "M: $meta_info_2"
+  echo "X: $certificate_2"
+
+  echo "check hash sanity"
+  [ x"$root_hash_2"    = x"$root_hash_1"   ] || return  7
+  [ x"$history_2"     != x"$history_1"     ] || return  8
+  [ x"$meta_info_2"    = x"$meta_info_1"   ] || return  9
+  [ x"$certificate_2"  = x"$certificate_1" ] || return 10
+
+  echo "check that Reflog is gone on Stratum0"
+  peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" && return 11
+
+  echo "check that Reflog from Stratum1 doesn't contain new history"
+  check_reflog_contains $replica_name "$history_2" && return 12
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "Update metainfo in Stratum 0"
+  local json_file="test_json_file.json"
+  cat >> $json_file << EOF
+{
+  "administrator" : "Rene Meusel",
+  "email"         : "dont.send.me.spam@cern.ch",
+  "organisation"  : "CERN",
+  "description"   : "This is just a test repository"
+}
+EOF
+
+  cvmfs_server update-repoinfo -f $json_file $CVMFS_TEST_REPO || return 13
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_3=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_3=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_3=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_3=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_3"
+  echo "H: $history_3"
+  echo "M: $meta_info_3"
+  echo "X: $certificate_3"
+
+  echo "check hash sanity"
+  [ x"$root_hash_3"    = x"$root_hash_1"   ] || return 13
+  [ x"$history_3"     != x"$history_1"     ] || return 14
+  [ x"$history_3"      = x"$history_2"     ] || return 15
+  [ x"$meta_info_3"   != x"$meta_info_1"   ] || return 16
+  [ x"$certificate_3"  = x"$certificate_1" ] || return 17
+
+  echo "check that Reflog is still gone on Stratum0"
+  peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" && return 18
+
+  echo "check that Reflog from Stratum1 doesn't contain new meta info"
+  check_reflog_contains $replica_name "$meta_info_3" && return 19
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "Update revision in Stratum0"
+  start_transaction $CVMFS_TEST_REPO || return 20
+  publish_repo $CVMFS_TEST_REPO      || return 21
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_4=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_4=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_4=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_4=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_4"
+  echo "H: $history_4"
+  echo "M: $meta_info_4"
+  echo "X: $certificate_4"
+
+  echo "check hash sanity"
+  [ x"$root_hash_4"   != x"$root_hash_1"   ] || return 22
+  [ x"$history_4"     != x"$history_3"     ] || return 23
+  [ x"$meta_info_3"    = x"$meta_info_3"   ] || return 24
+  [ x"$certificate_4"  = x"$certificate_1" ] || return 25
+
+  echo "check that Reflog is still gone on Stratum0"
+  peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" && return 26
+
+  echo "check that Reflog from Stratum1 doesn't contain new root catalog"
+  check_reflog_contains $replica_name "$root_hash_4" && return 27
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "Update revision in Stratum0"
+  start_transaction $CVMFS_TEST_REPO || return 28
+  publish_repo $CVMFS_TEST_REPO      || return 29
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_5=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_5=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_5=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_5=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_5"
+  echo "H: $history_5"
+  echo "M: $meta_info_5"
+  echo "X: $certificate_5"
+
+  echo "check hash sanity"
+  [ x"$root_hash_5"   != x"$root_hash_4"   ] || return 30
+  [ x"$history_5"     != x"$history_4"     ] || return 31
+  [ x"$meta_info_5"    = x"$meta_info_3"   ] || return 32
+  [ x"$certificate_5"  = x"$certificate_1" ] || return 33
+
+  echo "check that Reflog is still gone on Stratum0"
+  peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" && return 34
+
+  echo "check that Reflog from Stratum1 doesn't contain new root catalog"
+  check_reflog_contains $replica_name "$root_hash_5" && return 35
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "create a snapshot in Stratum1"
+  cvmfs_server snapshot $replica_name || return 37
+
+  echo "check Reflog from Stratum1"
+  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "enable garbage collection for Stratum0"
+  toggle_gc         $CVMFS_TEST_REPO || return 38
+  start_transaction $CVMFS_TEST_REPO || return 39
+  publish_repo      $CVMFS_TEST_REPO || return 40
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_6=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_6=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_6=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_6=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_6"
+  echo "H: $history_6"
+  echo "M: $meta_info_6"
+  echo "X: $certificate_6"
+
+  echo "check hash sanity"
+  [ x"$root_hash_6"   != x"$root_hash_5"   ] || return 41
+  [ x"$history_6"     != x"$history_5"     ] || return 42
+  [ x"$meta_info_6"    = x"$meta_info_3"   ] || return 43
+  [ x"$certificate_6"  = x"$certificate_1" ] || return 44
+
+  local gc_log_1="${scratch_dir}/gc_s0_1.log"
+  echo "run garbage collection on Stratum0 (deleting as much as possible | logging to: $gc_log_1)"
+  cvmfs_server gc -fL "$gc_log_1" $CVMFS_TEST_REPO || return 45
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_7=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_7=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_7=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_7=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_7"
+  echo "H: $history_7"
+  echo "M: $meta_info_7"
+  echo "X: $certificate_7"
+
+  echo "check hash sanity"
+  [ x"$root_hash_7"    = x"$root_hash_6"   ] || return 46
+  [ x"$history_7"     != x"$history_6"     ] || return 47
+  [ x"$meta_info_7"    = x"$meta_info_3"   ] || return 48
+  [ x"$certificate_7"  = x"$certificate_1" ] || return 49
+
+  echo "check that Reflog is recreated on Stratum0"
+  peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" || return 50
+
+  # TODO(rmeusel): check GC results and Reflog contents
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "create a Stratum1 snapshot"
+  cvmfs_server snapshot $replica_name || return 51
+
+  echo "check Reflog from Stratum1"
+  check_reflog_contains $replica_name "$root_hash_6 $root_hash_5 $root_hash_4 $root_hash_1 $history_7 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 52
+
+  # TODO(rmeusel): enable GC on Stratum1 and run GC with current reflog
+
+  return 0
+}

--- a/test/src/629-reflogrecreation/main
+++ b/test/src/629-reflogrecreation/main
@@ -243,14 +243,6 @@ EOF
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  echo "create a snapshot in Stratum1"
-  cvmfs_server snapshot $replica_name || return 37
-
-  echo "check Reflog from Stratum1"
-  check_reflog_contains $replica_name "$root_hash_5 $root_hash_4 $root_hash_1 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 38
-
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
   echo "enable garbage collection for Stratum0"
   toggle_gc         $CVMFS_TEST_REPO || return 38
   start_transaction $CVMFS_TEST_REPO || return 39
@@ -275,9 +267,11 @@ EOF
   [ x"$meta_info_6"    = x"$meta_info_3"   ] || return 43
   [ x"$certificate_6"  = x"$certificate_1" ] || return 44
 
-  local gc_log_1="${scratch_dir}/gc_s0_1.log"
-  echo "run garbage collection on Stratum0 (deleting as much as possible | logging to: $gc_log_1)"
-  cvmfs_server gc -fL "$gc_log_1" $CVMFS_TEST_REPO || return 45
+  echo "remove repo tag 'foobar' (creating a new history db)"
+  cvmfs_server tag -fr "foobar" $CVMFS_TEST_REPO || return 80
+
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 125
 
   echo "extracting root hashes from Stratum0"
   local root_hash_7=$(get_manifest_field $CVMFS_TEST_REPO 'C')
@@ -290,25 +284,89 @@ EOF
   echo "X: $certificate_7"
 
   echo "check hash sanity"
-  [ x"$root_hash_7"    = x"$root_hash_6"   ] || return 46
-  [ x"$history_7"     != x"$history_6"     ] || return 47
-  [ x"$meta_info_7"    = x"$meta_info_3"   ] || return 48
-  [ x"$certificate_7"  = x"$certificate_1" ] || return 49
+  [ x"$root_hash_7"    = x"$root_hash_6"   ] || return 81
+  [ x"$history_7"     != x"$history_6"     ] || return 82
+  [ x"$meta_info_7"    = x"$meta_info_3"   ] || return 83
+  [ x"$certificate_7"  = x"$certificate_1" ] || return 84
+
+  local gc_log_1="${scratch_dir}/gc_s0_1.log"
+  local gc_stdout_log_1="${scratch_dir}/gc_s0_stdout_1.log"
+  echo "run garbage collection on Stratum0 (deleting as much as possible | logging to: $gc_log_1 and $gc_stdout_log_1)"
+  cvmfs_server gc -fL "$gc_log_1" $CVMFS_TEST_REPO > $gc_stdout_log_1 2>&1 || return 45
+
+  echo "check that Stratum0 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s0_spool_tmp_dir || return 126
+
+  echo "extracting root hashes from Stratum0"
+  local root_hash_8=$(get_manifest_field $CVMFS_TEST_REPO 'C')
+  local history_8=$(get_manifest_field $CVMFS_TEST_REPO 'H')
+  local meta_info_8=$(get_manifest_field $CVMFS_TEST_REPO 'M')
+  local certificate_8=$(get_manifest_field $CVMFS_TEST_REPO 'X')
+  echo "C: $root_hash_8"
+  echo "H: $history_8"
+  echo "M: $meta_info_8"
+  echo "X: $certificate_8"
+
+  echo "check hash sanity"
+  [ x"$root_hash_8"    = x"$root_hash_6"   ] || return 46
+  [ x"$history_8"     != x"$history_7"     ] || return 47
+  [ x"$meta_info_8"    = x"$meta_info_7"   ] || return 48
+  [ x"$certificate_8"  = x"$certificate_7" ] || return 49
 
   echo "check that Reflog is recreated on Stratum0"
   peek_backend_raw $CVMFS_TEST_REPO ".cvmfsreflog" || return 50
 
-  # TODO(rmeusel): check GC results and Reflog contents
+  echo "check garbage collection log output"
+  cat $gc_stdout_log_1 | grep 'Needs Reflog reconstruct.*yes' || return 51
+  cat $gc_stdout_log_1 | grep 'reconstructing reference log'  || return 52
+
+  echo "check that the reflog contains sane entries"
+  check_reflog_contains $CVMFS_TEST_REPO "$root_hash_6 $root_hash_5 $history_8 $history_7 $history_6 $history_5 $history_4 $history_3 $history_2 $history_1 $meta_info_3 $certificate_1" || return 53
+
+  echo "check that the deletion log contains sane entries"
+  cat $gc_log_1 | grep "$root_hash_4" || return 54
+  cat $gc_log_1 | grep "$root_hash_1" || return 55
+
+  echo "check that the right root catalogs are in Stratum0"
+  peek_backend $CVMFS_TEST_REPO ${root_hash_1}C && return 90
+  peek_backend $CVMFS_TEST_REPO ${root_hash_4}C && return 91
+  peek_backend $CVMFS_TEST_REPO ${root_hash_5}C || return 92
+  peek_backend $CVMFS_TEST_REPO ${root_hash_6}C || return 93
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   echo "create a Stratum1 snapshot"
-  cvmfs_server snapshot $replica_name || return 51
+  cvmfs_server snapshot $replica_name || return 56
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s1_spool_tmp_dir || return 127
 
   echo "check Reflog from Stratum1"
-  check_reflog_contains $replica_name "$root_hash_6 $root_hash_5 $root_hash_4 $root_hash_1 $history_7 $history_5 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 52
+  check_reflog_contains $replica_name "$root_hash_6 $root_hash_5 $root_hash_1 $history_8 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 52
 
-  # TODO(rmeusel): enable GC on Stratum1 and run GC with current reflog
+  echo "enable garbage collection on Stratum1"
+  toggle_gc $replica_name || return 57
+
+  local gc_log_2="${scratch_dir}/gc_s1_2.log"
+  local gc_stdout_log_2="${scratch_dir}/gc_s1_stdout_2.log"
+  echo "run garbage collection on Stratum1 (deleting as much as possible | logging to: $gc_log_2 and $gc_stdout_log_2)"
+  cvmfs_server gc -fL "$gc_log_2" $replica_name > $gc_stdout_log_2 2>&1 || return 58
+
+  echo "check that Stratum1 spooler tmp dir is empty"
+  check_tmp_dir_emptiness $s1_spool_tmp_dir || return 128
+
+  echo "check that the reflog was not recreated"
+  cat $gc_stdout_log_2 | grep    'Needs Reflog reconstruct.*no' || return 59
+  cat $gc_stdout_log_2 | grep -v 'reconstructing reference log' || return 60
+
+  echo "check that the right root catalogs are in Stratum1"
+  peek_backend $replica_name ${root_hash_1}C && return 100
+  peek_backend $replica_name ${root_hash_4}C && return 101
+  peek_backend $replica_name ${root_hash_5}C || return 102
+  peek_backend $replica_name ${root_hash_6}C || return 103
+
+  echo "check Reflog from Stratum1"
+  check_reflog_contains $replica_name "$root_hash_6 $root_hash_5 $history_8 $history_1 $meta_info_3 $meta_info_1 $certificate_1" || return 52
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -1486,6 +1486,15 @@ make_path() {
 }
 
 
+peek_backend_raw() {
+  local repo_name="$1"
+  local remote_path="$2"
+
+  load_repo_config $repo_name
+  cvmfs_swissknife peek -d $remote_path -r $CVMFS_UPSTREAM_STORAGE
+}
+
+
 # peeks in the upstream storage to find a given content hash
 #
 # @param repository     the repository name to be queried
@@ -1494,10 +1503,8 @@ make_path() {
 peek_backend() {
   local repo_name="$1"
   local content_hash="$2"
-  local remote_path=$(make_path $content_hash)
 
-  load_repo_config $repo_name
-  cvmfs_swissknife peek -d $remote_path -r $CVMFS_UPSTREAM_STORAGE
+  peek_backend_raw $repo_name $(make_path $content_hash)
 }
 
 

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -959,7 +959,8 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(5u, upl->deleted_hashes.size());
   EXPECT_EQ(14u, gc2.preserved_catalog_count());
-  EXPECT_EQ(2u, gc2.condemned_catalog_count());
+  EXPECT_EQ(0u, gc2.condemned_catalog_count());  // Reflog doesn't contain
+                                                 // deleted catalogs anymore
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -968,7 +969,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc3.Collect());
 
   EXPECT_EQ(14u, gc3.preserved_catalog_count());
-  EXPECT_EQ(2u, gc3.condemned_catalog_count());
+  EXPECT_EQ(0u, gc3.condemned_catalog_count());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -977,7 +978,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc4.Collect());
 
   EXPECT_EQ(11u, gc4.preserved_catalog_count());
-  EXPECT_EQ(5u, gc4.condemned_catalog_count());
+  EXPECT_EQ(3u, gc4.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(1, "00")]->hash()));
@@ -1066,7 +1067,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc5.Collect());
 
   EXPECT_EQ(11u, gc5.preserved_catalog_count());
-  EXPECT_EQ(5u, gc5.condemned_catalog_count());
+  EXPECT_EQ(0u, gc5.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1076,7 +1077,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc6.Collect());
 
   EXPECT_EQ(11u, gc6.preserved_catalog_count());
-  EXPECT_EQ(5u, gc6.condemned_catalog_count());
+  EXPECT_EQ(0u, gc6.condemned_catalog_count());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1086,7 +1087,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc7.Collect());
 
   EXPECT_EQ(7u, gc7.preserved_catalog_count());
-  EXPECT_EQ(9u, gc7.condemned_catalog_count());
+  EXPECT_EQ(4u, gc7.condemned_catalog_count());
   EXPECT_EQ(29u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(4, "00")]->hash()));

--- a/test/unittests/t_reflog.cc
+++ b/test/unittests/t_reflog.cc
@@ -240,3 +240,83 @@ TYPED_TEST(T_Reflog, RemoveCatalog) {
 
   TestFixture::CloseReflog(rl2);
 }
+
+
+TYPED_TEST(T_Reflog, ContainsObject) {
+  const std::string rp = TestFixture::GetReflogFilename();
+  typedef TypeParam Reflog;
+
+  Reflog *rl1 = TestFixture::CreateReflog(rp);
+  ASSERT_NE(static_cast<Reflog*>(NULL), rl1);
+  EXPECT_EQ(TestFixture::fqrn, rl1->fqrn());
+
+  rl1->AddCatalog(h("b99a789dcdffff8f95b977cc8e2037fcd3960b5b",
+                    shash::kSuffixCatalog));
+  rl1->AddCatalog(h("c5501bd0142cad45c4f0957cbf307e184ac1f661",
+                    shash::kSuffixCatalog));
+  rl1->AddCertificate(h("b778b910390254b37ec66366aeef04f034c51941",
+                        shash::kSuffixCertificate));
+  rl1->AddMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76b",
+                     shash::kSuffixMetainfo));
+  rl1->AddHistory(h("cab790100c3b10afd7e755b3c93eaeda6a0db9ab",
+                     shash::kSuffixHistory));
+
+  EXPECT_TRUE(
+    rl1->ContainsCatalog(h("b99a789dcdffff8f95b977cc8e2037fcd3960b5b",
+                           shash::kSuffixCatalog)));
+  EXPECT_FALSE(
+    rl1->ContainsCatalog(h("abcde89dcdffff8f95b977cc8e2037fcd3960b5b",
+                           shash::kSuffixCatalog)));
+  EXPECT_TRUE(
+    rl1->ContainsCertificate(h("b778b910390254b37ec66366aeef04f034c51941",
+                               shash::kSuffixCertificate)));
+  EXPECT_FALSE(
+    rl1->ContainsCertificate(h("abcde910390254b37ec66366aeef04f034c51941",
+                               shash::kSuffixCertificate)));
+  EXPECT_TRUE(
+    rl1->ContainsMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76b",
+                            shash::kSuffixMetainfo)));
+  EXPECT_FALSE(
+    rl1->ContainsMetainfo(h("abcde8cbd611ce225d62341698b9408a47edf76b",
+                            shash::kSuffixMetainfo)));
+  EXPECT_TRUE(
+    rl1->ContainsHistory(h("cab790100c3b10afd7e755b3c93eaeda6a0db9ab",
+                           shash::kSuffixHistory)));
+  EXPECT_FALSE(
+    rl1->ContainsHistory(h("abcde0100c3b10afd7e755b3c93eaeda6a0db9ab",
+                           shash::kSuffixHistory)));
+
+  TestFixture::CloseReflog(rl1);
+
+  Reflog *rl2 = TestFixture::OpenReflog(rp);
+  ASSERT_NE(static_cast<Reflog*>(NULL), rl2);
+  EXPECT_EQ(TestFixture::fqrn, rl2->fqrn());
+  EXPECT_EQ(5u, rl2->CountEntries());
+
+  EXPECT_TRUE(
+    rl1->ContainsCatalog(h("c5501bd0142cad45c4f0957cbf307e184ac1f661",
+                           shash::kSuffixCatalog)));
+  EXPECT_FALSE(
+    rl1->ContainsCatalog(h("abcdef01422cad45c4f0957cbf307e184ac1f661",
+                           shash::kSuffixCatalog)));
+  EXPECT_TRUE(
+    rl1->ContainsCertificate(h("b778b910390254b37ec66366aeef04f034c51941",
+                               shash::kSuffixCertificate)));
+  EXPECT_FALSE(
+    rl1->ContainsCertificate(h("abcde910390254b37ec66366aeef04f034c51941",
+                               shash::kSuffixCertificate)));
+  EXPECT_TRUE(
+    rl1->ContainsMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76b",
+                            shash::kSuffixMetainfo)));
+  EXPECT_FALSE(
+    rl1->ContainsMetainfo(h("abcde8cbd611ce225d62341698b9408a47edf76b",
+                            shash::kSuffixMetainfo)));
+  EXPECT_TRUE(
+    rl1->ContainsHistory(h("cab790100c3b10afd7e755b3c93eaeda6a0db9ab",
+                           shash::kSuffixHistory)));
+  EXPECT_FALSE(
+    rl1->ContainsHistory(h("abcde0100c3b10afd7e755b3c93eaeda6a0db9ab",
+                           shash::kSuffixHistory)));
+
+  TestFixture::CloseReflog(rl2);
+}

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -729,3 +729,19 @@ bool MockReflog::RemoveCatalog(const shash::Any &catalog) {
   references_.erase(catalog);
   return true;
 }
+
+bool MockReflog::ContainsCertificate(const shash::Any &certificate) const {
+  return references_.count(certificate) == 1;
+}
+
+bool MockReflog::ContainsCatalog(const shash::Any &catalog) const {
+  return references_.count(catalog) == 1;
+}
+
+bool MockReflog::ContainsHistory(const shash::Any &history) const {
+  return references_.count(history) == 1;
+}
+
+bool MockReflog::ContainsMetainfo(const shash::Any &metainfo) const {
+  return references_.count(metainfo) == 1;
+}

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -825,6 +825,11 @@ class MockReflog : public MockObjectStorage<MockReflog> {
 
   bool RemoveCatalog(const shash::Any &catalog);
 
+  bool ContainsCertificate(const shash::Any &certificate) const;
+  bool ContainsCatalog(const shash::Any &catalog) const;
+  bool ContainsHistory(const shash::Any &history) const;
+  bool ContainsMetainfo(const shash::Any &metainfo) const;
+
   void TakeDatabaseFileOwnership() { owns_database_file_ = true;  }
   void DropDatabaseFileOwnership() { owns_database_file_ = false; }
   bool OwnsDatabaseFile() const    { return owns_database_file_;  }


### PR DESCRIPTION
This should be the final building block of the `Reflog` business. It introduces a new `cvmfs_swissknife` command (i.e. `recreate_reflog`) that walks as much of the root `Catalog` and `History` chains as possible to reconstruct the `Reflog`.

The use case is two fold: **1st** it allows for an easy transition from the old-style garbage collection to the `Reflog` driven version and **2nd** it serves as a failure recovery mechanism in case the original `Reflog` has been corrupted. We cannot guarantee that a full `Reflog` is reconstructable from the stored `Catalog` and `History` chains but this gives some best-effort.

Furthermore this contains a [minor syslog logging fix](https://github.com/cvmfs/cvmfs/commit/87bdd4aeb3526c4f5395a6b7307d144da0640374) which I was too lazy to extract. Also it adapts integration test 563 "Garbage Collection After Legacy Repository Import" to specifically check for the new feature along with CernVM-FS 2.0.x catalogs.

Note: This builds on top of [FIX: Reflog Update During Snapshotting](https://github.com/cvmfs/cvmfs/pull/1544), [Feature: Reflog cleanup on Garbage Collection](https://github.com/cvmfs/cvmfs/pull/1545) and [Feature: Swissknife Ignores Missing Reflog](https://github.com/cvmfs/cvmfs/pull/1546).