### PR TITLE
FIX: Catalog Migration not Updating Catalog Metadata

### DIFF
--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -130,6 +130,7 @@ class CommandMigrate : public Command {
     bool RunMigration(PendingCatalog *data) const { return false; }
 
     bool UpdateNestedCatalogReferences(PendingCatalog *data) const;
+    bool UpdateCatalogMetadata(PendingCatalog *data) const;
     bool CleanupNestedCatalogs(PendingCatalog *data) const;
     bool CollectAndAggregateStatistics(PendingCatalog *data) const;
 

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -98,35 +98,15 @@ change_files_in() {
   popdir
 }
 
-make_clg_path() {
-  local catalog_hash=$1
-  local cas_path="$(echo $catalog_hash | cut --bytes=1,2)"
-  local clg_path="$(echo $catalog_hash | cut --bytes=3-)C"
-  echo "${cas_path}/${clg_path}"
-}
-
-download_catalog() {
-  local base_url=$1
-  local catalog_hash=$2
-  local dest_path=$3
-  local catalog_url
-  catalog_url="${base_url}/data/$(make_clg_path $catalog_hash)"
-  echo "Downloading and Decompressing: $catalog_url into $dest_path"
-  curl --silent --show-error $catalog_url | cvmfs_swissknife zpipe -d > $dest_path
-}
-
 check_chunk_alignment() {
   local repo_name=$1
   local old_clg_hash=$2
   local new_clg_hash=$3
 
-  local old_catalog="old.db"
-  local new_catalog="new.db"
+  local old_catalog="$(download_and_decompress_object $repo_name ${old_clg_hash}C)"
+  local new_catalog="$(download_and_decompress_object $repo_name ${new_clg_hash}C)"
 
   load_repo_config $repo_name
-
-  download_catalog $CVMFS_STRATUM0 $old_clg_hash $old_catalog || return 1
-  download_catalog $CVMFS_STRATUM0 $new_clg_hash $new_catalog || return 2
 
   local big_file="50megabyte" # see change_files_in()
 
@@ -178,9 +158,10 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
-  echo "retrieving name of root catalog for later comparison"
+  echo -n "retrieving name of root catalog for later comparison... "
   load_repo_config $CVMFS_TEST_REPO
-  local old_root_catalog=$(cvmfs_swissknife info -r $CVMFS_STRATUM0 -c)
+  local old_root_catalog="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo $old_root_catalog
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -202,8 +183,9 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
-  echo "retrieving name of new root catalog"
-  local new_root_catalog=$(cvmfs_swissknife info -r $CVMFS_STRATUM0 -c)
+  echo -n "retrieving name of new root catalog... "
+  local new_root_catalog="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo $new_root_catalog
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -47,6 +47,19 @@ cvmfs_run_test() {
     -s                                               \
     -g || return 4
 
+  echo -n "get root catalog hash after migration... "
+  local root_clg_after="$(get_current_root_catalog $legacy_repo_name)"
+  echo "$root_clg_after"
+
+  echo "download catalog $root_clg_after and check its previous pointer"
+  local root_clg_after_db=$(get_and_decompress_root_catalog $legacy_repo_name)
+  local prev_ptr="$(sqlite3 $root_clg_after_db "SELECT value FROM properties WHERE key = 'previous_revision';")"
+  local root_clg_legacy="07df6f3a10a70ca17df82370ca3845e82ca6a9af"
+  echo "  legacy:   $root_clg_legacy"
+  echo "  after:    $root_clg_after"
+  echo "  prev_ptr: $prev_ptr"
+  [ x"$prev_ptr" = x"$root_clg_legacy" ] || return 101
+
   echo "list newly generated repository under /cvmfs/${legacy_repo_name}"
   ls -lisa /cvmfs/${legacy_repo_name} || return 5
 

--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -10,18 +10,6 @@ get_catalog_file_size() {
 }
 
 
-get_and_decompress_root_catalog() {
-  local repo_name="$1"
-  local root_catalog="$(get_current_root_catalog $repo_name)C"
-  local object_url="$(get_object_url $repo_name $root_catalog)"
-  local sqlite_db="${root_catalog}.uncompressed"
-
-  wget --quiet $object_url                                             || return 1
-  cat $(basename $object_url) | cvmfs_swissknife zpipe -d > $sqlite_db || return 2
-  echo $sqlite_db
-}
-
-
 get_wasted_row_ids_in_root_catalog() {
   local repo_name="$1"
   local root_clg="$(get_and_decompress_root_catalog $repo_name)"
@@ -35,8 +23,8 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local scratch_dir=$(pwd)
 
-  echo -n "checking for wget... "
-  which wget > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }
+  echo -n "checking for curl... "
+  which curl > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }
 
   echo -n "checking for sqlite3 utility... "
   which sqlite3 > /dev/null 2>&1 && echo "done" || { echo "not found"; return 1; }

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -95,13 +95,15 @@ cvmfs_run_test() {
   echo "run a first garbage collection to delete all revision except the last 4"
   cvmfs_server gc -r 3 -f $legacy_repo_name || return 11
 
-  echo "check if some 2.0 catalogs are gone (5 expected)"
+  local expected_1=5
+  uses_overlayfs $legacy_repo_name && expected_1=$(( $expected_1 + 1 ))
+  echo "check if some 2.0 catalogs are gone ($expected_1 expected)"
   local not_available_catalogs=0
   for hash in $last_legacy_catalogs; do
     peek_backend $legacy_repo_name "${hash}C" || not_available_catalogs=$(( $not_available_catalogs + 1 ))
   done
   echo "$not_available_catalogs are not available"
-  [ $not_available_catalogs -eq 5 ] || return 12
+  [ $not_available_catalogs -eq $expected_1 ] || return 12
 
   echo "check if the right 2.0 catalogs are gone"
   local condemned_catalogs="713ca8a74dd20682338da781e314ac2b8ce883e4

--- a/test/src/589-catalogchown/main
+++ b/test/src/589-catalogchown/main
@@ -380,6 +380,12 @@ cvmfs_run_test() {
   mkdir reference_dir
   local reference_dir=$scratch_dir/reference_dir
 
+  echo -n "checking for sqlite3... "
+  which sqlite3 > /dev/null 2>&1 && echo "done" || die "not found"
+
+  echo -n "checking for curl... "
+  which curl > /dev/null 2>&1 && echo "done" || die "not found"
+
   echo "creating some dummy UIDs and GIDs"
   local uid_1=$(find_next_free_uid 300)
   local uid_2=$(find_next_free_uid $uid_1)
@@ -485,6 +491,10 @@ EOF
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  echo -n "get root catalog hash of newly created repository... "
+  local root_clg_new="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo $root_clg_new
+
   echo "get spool and rdonly directory"
   load_repo_config $CVMFS_TEST_REPO
   local rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
@@ -515,8 +525,25 @@ EOF
 
   # ============================================================================
 
+  echo -n "get root catalog hash before catalog-chown... "
+  local root_clg_before="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo $root_clg_before
+
   echo "run the chown on catalog level"
   sudo cvmfs_server catalog-chown -u $uid_map_1 -g $gid_map_1 $CVMFS_TEST_REPO || return 3
+
+  echo -n "get root catalog hash after catalog-chown... "
+  local root_clg_after="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo "$root_clg_after"
+
+  echo "download catalog $root_clg_after and check its previous pointer"
+  local root_clg_after_db=$(get_and_decompress_root_catalog $CVMFS_TEST_REPO)
+  local prev_ptr="$(sqlite3 $root_clg_after_db "SELECT value FROM properties WHERE key = 'previous_revision';")"
+  echo "  new:      $root_clg_new"
+  echo "  before:   $root_clg_before"
+  echo "  after:    $root_clg_after"
+  echo "  prev_ptr: $prev_ptr"
+  [ x"$prev_ptr" = x"$root_clg_before" ] || return 101
 
   echo "apply the same UID and GID changes to the reference directory"
   apply_uid_gid_map_1_to $reference_dir $uid_1 $uid_2 $uid_3 $gid_1 $gid_2 $gid_3 || return 4

--- a/test/src/599-removehardlinks/main
+++ b/test/src/599-removehardlinks/main
@@ -76,6 +76,9 @@ cvmfs_run_test() {
   local root_clg_imported="$(get_current_root_catalog $legacy_repo_name)"
   echo "$root_clg_imported"
 
+  local root_clg_imported_db=$(get_and_decompress_root_catalog $legacy_repo_name)
+  local rev_no_imported="$(sqlite3 $root_clg_imported_db "SELECT value FROM properties WHERE key = 'revision';")"
+
   local uid_map=uid.map
   local gid_map=gid.map
   echo "* $(id -u $CVMFS_TEST_USER)" > $uid_map
@@ -86,6 +89,9 @@ cvmfs_run_test() {
   echo -n "get root catalog hash after catalog-chown... "
   local root_clg_chowned="$(get_current_root_catalog $legacy_repo_name)"
   echo "$root_clg_chowned"
+
+  local root_clg_chowned_db=$(get_and_decompress_root_catalog $legacy_repo_name)
+  local rev_no_chowned="$(sqlite3 $root_clg_chowned_db "SELECT value FROM properties WHERE key = 'revision';")"
 
   echo "check if repostory is sane"
   check_repository $legacy_repo_name -i || return 3
@@ -114,11 +120,13 @@ cvmfs_run_test() {
   echo "download catalog $root_clg_after and check its previous pointer"
   local root_clg_after_db=$(get_and_decompress_root_catalog $legacy_repo_name)
   local prev_ptr="$(sqlite3 $root_clg_after_db "SELECT value FROM properties WHERE key = 'previous_revision';")"
-  echo "  imported: $root_clg_imported"
-  echo "  chowned:  $root_clg_chowned"
-  echo "  after:    $root_clg_after"
+  local rev_no_after="$(sqlite3 $root_clg_after_db "SELECT value FROM properties WHERE key = 'revision';")"
+  echo "  imported: $root_clg_imported | $rev_no_imported"
+  echo "  chowned:  $root_clg_chowned | $rev_no_chowned"
+  echo "  after:    $root_clg_after | $rev_no_after"
   echo "  prev_ptr: $prev_ptr"
-  [ x"$prev_ptr" = x"$root_clg_chowned" ] || return 101
+  [ x"$prev_ptr" = x"$root_clg_chowned"        ] || return 101
+  [ $(( $rev_no_after - 1 )) = $rev_no_chowned ] || return 102
 
   echo "check if repostory is still sane"
   check_repository $legacy_repo_name -i || return 6

--- a/test/src/599-removehardlinks/main
+++ b/test/src/599-removehardlinks/main
@@ -72,12 +72,20 @@ cvmfs_run_test() {
   TEST599_NEW_REPO_NAME="$legacy_repo_name"
   import_repo $legacy_repo_name $CVMFS_TEST_USER -g > $import_log 2>&1 || return 2
 
+  echo -n "get root catalog hash after import... "
+  local root_clg_imported="$(get_current_root_catalog $legacy_repo_name)"
+  echo "$root_clg_imported"
+
   local uid_map=uid.map
   local gid_map=gid.map
   echo "* $(id -u $CVMFS_TEST_USER)" > $uid_map
   echo "* $(id -g $CVMFS_TEST_USER)" > $gid_map
   echo "chown the repository contents on catalog level ($uid_map | $gid_map)"
   sudo cvmfs_server catalog-chown -u $uid_map -g $gid_map $legacy_repo_name || return 100
+
+  echo -n "get root catalog hash after catalog-chown... "
+  local root_clg_chowned="$(get_current_root_catalog $legacy_repo_name)"
+  echo "$root_clg_chowned"
 
   echo "check if repostory is sane"
   check_repository $legacy_repo_name -i || return 3
@@ -98,6 +106,19 @@ cvmfs_run_test() {
   local migration_log_1="migration_1.log"
   echo "run the repository migration (logging into ${migration_log_1})"
   sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name > $migration_log_1 2>&1 || return 5
+
+  echo -n "get root catalog hash after migration... "
+  local root_clg_after="$(get_current_root_catalog $legacy_repo_name)"
+  echo "$root_clg_after"
+
+  echo "download catalog $root_clg_after and check its previous pointer"
+  local root_clg_after_db=$(get_and_decompress_root_catalog $legacy_repo_name)
+  local prev_ptr="$(sqlite3 $root_clg_after_db "SELECT value FROM properties WHERE key = 'previous_revision';")"
+  echo "  imported: $root_clg_imported"
+  echo "  chowned:  $root_clg_chowned"
+  echo "  after:    $root_clg_after"
+  echo "  prev_ptr: $prev_ptr"
+  [ x"$prev_ptr" = x"$root_clg_chowned" ] || return 101
 
   echo "check if repostory is still sane"
   check_repository $legacy_repo_name -i || return 6

--- a/test/test_functions
+++ b/test/test_functions
@@ -1024,6 +1024,19 @@ get_current_root_catalog() {
   get_manifest_field $repo_name "C"
 }
 
+# downloads and decompresses the root catalog of a given repository for deeper
+# inspection
+# @param repo_name   the repository to download the root catalog from
+# @param object_hash the object to be downloaded and decompressed
+# @return            prints the file name of the extracted catalog to stdout
+get_and_decompress_root_catalog() {
+  local repo_name=$1
+  local catalog_hash="$(get_current_root_catalog $repo_name)C"
+  download_and_decompress_object $repo_name $catalog_hash
+}
+
+
+
 # uses `cvmfs_server check` to check the integrity of the catalog structure
 # additionally it might check the backend storage integrity as well when
 # provided with -i
@@ -1548,6 +1561,24 @@ upload_into_backend() {
                           -o $remote_path            \
                           -r $CVMFS_UPSTREAM_STORAGE \
                           -a $CVMFS_HASH_ALGORITHM
+}
+
+
+# downloads and decompresses a backend object from a given repository
+# @param repo_name   the repository to download the root catalog from
+# @param object_hash the object to be downloaded and decompressed
+# @return            prints the file name of the extracted catalog to stdout
+download_and_decompress_object() {
+  local repo_name="$1"
+  local object_hash="$2"
+  local object_url="$(get_object_url $repo_name $object_hash)"
+  local destination="${object_hash}.uncompressed"
+
+  curl --silent                 \
+       --show-error $object_url \
+    | cvmfs_swissknife zpipe -d > $destination || return 1
+
+  echo $destination
 }
 
 


### PR DESCRIPTION
Turns out that all but the CernVM-FS 2.0.x catalog migrations didn't update the catalog meta information (i.e. previous revision pointer, revision number and last modified timestamp). Hence, catalog revisions generated by `cvmfs_swissknife migrate -v [2.1.7 | chown | hardlink]` logically "replaced" their base revision instead of creating an identical new catalog revision.

Unfortunately this is a bug that made it into production (at least at CERN we've been using `cvmfs_server catalog-chown` when moving to new release manager machines). As far as I can tell, this should not be critical though (apart from a catalog revision that is not garbage collectable anymore). I found this bug by chance when writing an integration test for `Reflog`.

This integrates a few regression checks in integration tests 519, 589 and 599 and fixes the problem. Furthermore the integration test ~~629 introduced~~ 563 as changed [here](https://github.com/cvmfs/cvmfs/pull/1547) is sensitive to this bug when using OverlayFS.