### PR TITLE
Refactor: Health Check and Namespacing in `cvmfs_server`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1517,8 +1517,10 @@ __hc_print_status_report() {
 
 __hc_transition() {
   local name="$1"
-  local transition="$2"
+  local quiet="$2"
+  local transition="$3"
   local msg=""
+  local stdout_msg=""
   local retcode=0
 
   case $transition in
@@ -1531,12 +1533,15 @@ __hc_transition() {
     *)             exit 2                                            ;;
   esac
 
-  echo -n "Note: ${msg}... " >&2
-  if run_suid_helper $transition $name; then
-    echo "success" >&2
+  stdout_msg="Note: ${msg}... "
+  [ $quiet = 0 ] && echo -n "$stdout_msg" >&2
+
+  if run_suid_helper $transition $name > /dev/null; then
+    [ $quiet = 0 ] && echo "success" >&2
     to_syslog_for_repo $name "${msg}... success"
   else
-    echo "fail" >&2
+    [ $quiet = 0 ] || echo -n "${stdout_msg}" >&2 # error messages are not quiet
+    echo "fail"                               >&2
     to_syslog_for_repo $name "${msg}... fail"
     exit 1
   fi
@@ -1624,11 +1629,15 @@ health_check() {
     return 0
   fi
 
-  __hc_print_status_report $name $rdonly_broken       \
-                                 $rdonly_outdated     \
-                                 $rw_broken           \
-                                 $rw_should_be_rdonly \
-                                 $rw_should_be_rw
+  # should we print the found status?
+  if [ $quiet = 0 ]; then
+    __hc_print_status_report $name $rdonly_broken       \
+                                   $rdonly_outdated     \
+                                   $rw_broken           \
+                                   $rw_should_be_rdonly \
+                                   $rw_should_be_rw
+  fi
+
 
   # check if we are allowed to attempt a repair
   if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
@@ -1665,12 +1674,12 @@ health_check() {
   #      2.2. remount the rw mountpoint as read-write (rw_should_be_rw --> 0)
   if [ $rdonly_outdated -eq 1 ]; then
     if [ $rw_broken -eq 0 ]; then
-      __hc_transition $name rw_umount
+      __hc_transition $name $quiet "rw_umount"
       rw_broken=1 # ... remount happens downstream
     fi
 
     if [ $rdonly_broken -eq 0 ]; then
-      __hc_transition $name rdonly_umount
+      __hc_transition $name $quiet "rdonly_umount"
       rdonly_broken=1 # ... remount happens downstream
     fi
 
@@ -1680,27 +1689,27 @@ health_check() {
 
   if [ $rdonly_broken -eq 1 ]; then
     if [ $rw_broken -eq 0 ]; then
-      __hc_transition $name rw_umount
+      __hc_transition $name $quiet "rw_umount"
       rw_broken=1 # ... remount happens downstream
     fi
 
-    __hc_transition $name rdonly_mount > /dev/null
+    __hc_transition $name $quiet "rdonly_mount" > /dev/null
     rdonly_broken=0 # ... rdonly is repaired
   fi
 
   if [ $rw_broken -eq 1 ]; then
-    __hc_transition $name rw_mount
+    __hc_transition $name $quiet "rw_mount"
     rw_broken=0           # ... rw is repaired
     rw_should_be_rdonly=0 # ... and already mounted read-only by default
   fi
 
   if [ $rw_should_be_rw -eq 1 ]; then
-    __hc_transition $name open
+    __hc_transition $name $quiet "open"
     rw_should_be_rw=0 # ... rw is repaired
   fi
 
   if [ $rw_should_be_rdonly -eq 1 ]; then
-    __hc_transition $name lock
+    __hc_transition $name $quiet "lock"
     rw_should_be_rdonly=0 # ... rw is repaired
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1500,7 +1500,7 @@ foreclose_legacy_cvmfs() {
 }
 
 
-__hc_print_repair_info() {
+__hc_print_status_report() {
   local name="$1"
   local rdonly_broken=$2
   local rdonly_outdated=$3
@@ -1513,8 +1513,6 @@ __hc_print_repair_info() {
   [ $rw_broken           -eq 0 ] || echo "/cvmfs/$name is not mounted properly."                                >&2
   [ $rw_should_be_rdonly -eq 0 ] || echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
   [ $rw_should_be_rw     -eq 0 ] || echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
-
-  to_syslog_for_repo $name "attempting mountpoint repair ($rdonly_broken $rdonly_outdated $rw_broken $rw_should_be_rdonly $rw_should_be_rw)"
 }
 
 __hc_transition() {
@@ -1605,6 +1603,12 @@ health_check() {
     return 0
   fi
 
+  __hc_print_status_report $name $rdonly_broken       \
+                                 $rdonly_outdated     \
+                                 $rw_broken           \
+                                 $rw_should_be_rdonly \
+                                 $rw_should_be_rw
+
   # check if we are allowed to attempt a repair
   if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
     echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT = false)" >&2
@@ -1617,11 +1621,7 @@ health_check() {
     exit 1
   fi
 
-  __hc_print_repair_info $name $rdonly_broken       \
-                               $rdonly_outdated     \
-                               $rw_broken           \
-                               $rw_should_be_rdonly \
-                               $rw_should_be_rw
+  to_syslog_for_repo $name "attempting mountpoint repair ($rdonly_broken $rdonly_outdated $rw_broken $rw_should_be_rdonly $rw_should_be_rw)"
 
   # consecutively bring the mountpoints into a sane state by working bottom up:
   #   1. solve problems with the rdonly mountpoint

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4353,12 +4353,18 @@ cvmfs_server_list() {
       fi
     fi
 
+    # check if the repository is healthy
+    local health_info=""
+    if ! health_check -q $name; then
+      health_info=" - unhealthy"
+    fi
+
     # get the storage type of the repository
     local storage_type=""
     storage_type=$(get_upstream_type $CVMFS_UPSTREAM_STORAGE)
 
     # print out repository information list
-    echo "$name ($CVMFS_REPOSITORY_TYPE / $storage_type$transaction_info$whitelist_info) $stratum1_info $version_info"
+    echo "$name ($CVMFS_REPOSITORY_TYPE / $storage_type$transaction_info$whitelist_info$health_info) $stratum1_info $version_info"
     CVMFS_CREATOR_VERSION=""
   done
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -212,8 +212,8 @@ cvmfs_mkfqrn() {
 # @return   0 if the command was recognized
 is_subcommand() {
   local subcommand="$1"
-  local supported_commands="mkfs add-replica import publish rollback rmfs alterfs \
-    resign list info tag list-tags lstags check transaction abort snapshot \
+  local supported_commands="mkfs add-replica import publish rollback rmfs alterfs    \
+    resign list info tag list-tags lstags check transaction abort snapshot           \
     skeleton migrate list-catalogs update-geodb gc catalog-chown eliminate-hardlinks \
     update-info update-repoinfo"
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1606,7 +1606,7 @@ health_check() {
     echo -n "Note: Trying to remount repository mountpoints to $published_hash... "
     run_suid_helper rw_umount     $name                     && \
     run_suid_helper rdonly_umount $name                     && \
-    set_ro_root_hash                $name "$published_hash" && \
+    set_ro_root_hash              $name   "$published_hash" && \
     run_suid_helper rdonly_mount  $name > /dev/null         && \
     run_suid_helper rw_mount      $name && success=true || success=false
     __health_check_syslog_repair_info $name "outdated revision" $success

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1519,6 +1519,7 @@ __hc_transition() {
   local name="$1"
   local transition="$2"
   local msg=""
+  local retcode=0
 
   case $transition in
     rw_umount)     msg="Trying to umount /cvmfs/${name}"             ;;
@@ -1530,11 +1531,13 @@ __hc_transition() {
     *)             exit 2                                            ;;
   esac
 
-  echo -n "Note: ${msg}... "
+  echo -n "Note: ${msg}... " >&2
   if run_suid_helper $transition $name; then
-    echo "success"
+    echo "success" >&2
+    to_syslog_for_repo $name "${msg}... success"
   else
-    echo "fail"
+    echo "fail" >&2
+    to_syslog_for_repo $name "${msg}... fail"
     exit 1
   fi
 }

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1650,12 +1650,12 @@ health_check() {
   fi
 
   if is_publishing $name; then
-    echo "WARNING: The repository $name is currently publishing and should not"
-    echo "be touched. If you are absolutely sure, that this is _not_ the case,"
-    echo "please run the following command and retry:"
-    echo
-    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing.lock"
-    echo
+    echo "WARNING: The repository $name is currently publishing and should not" >&2
+    echo "be touched. If you are absolutely sure, that this is _not_ the case," >&2
+    echo "please run the following command and retry:"                          >&2
+    echo                                                                        >&2
+    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing.lock"                      >&2
+    echo                                                                        >&2
     exit 1
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5805,7 +5805,7 @@ _migrate_2_1_20() {
   load_repo_config $name
 }
 
-migrate_2_2_0() {
+_migrate_2_2_0() {
   local name=$1
   local destination_version="2.3.0-1"
   local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
@@ -5912,7 +5912,7 @@ cvmfs_server_migrate() {
          x"$creator" = x"2.2.1-1" ] && \
          is_stratum0 $name;
     then
-      migrate_2_2_0 $name
+      _migrate_2_2_0 $name
     fi
 
   done

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1545,12 +1545,34 @@ __hc_transition() {
 # checks and warns in inconsistent repository states or unfavorable configs.
 #
 # @param name           the FQRN of the repository to be checked
-# @param quiet          disable printing of warnings (default: no)
-# @param repair_in_txn  repair even if currently in a transaction (default: no)
 health_check() {
-  local name=$1
-  local quiet=${2-0}
-  local repair_in_txn=${3-0}
+  local name=""
+  local quiet=0
+  local repair=0
+  local repair_in_txn=0
+
+  while getopts "qrt" option; do
+    case $option in
+      q)
+        quiet=1
+      ;;
+      r)
+        repair=1
+      ;;
+      t)
+        repair=1
+        repair_in_txn=1
+      ;;
+      ?)
+        shift $(($OPTIND-2))
+        die "health_check: Unrecognized option: $1"
+      ;;
+    esac
+  done
+  shift $(($OPTIND-1))
+
+  [ $# -eq 1 ] || die "health_check: No repository name provided"
+  name="$1"
 
   local rdonly_broken=0
   local rw_broken=0
@@ -3184,7 +3206,7 @@ cvmfs_server_mkfs() {
     cvmfs_server_alterfs -m on $name
   fi
 
-  health_check $name
+  health_check $name || die "fail! (health check after mount)"
 
   echo -n "Initial commit... "
   cvmfs_server_transaction $name > /dev/null || die "fail (transaction)"
@@ -3835,8 +3857,8 @@ cvmfs_server_resign() {
   for name in $names; do
 
     # sanity checks
-    is_stratum0 $name || { echo "Repository $name is not a stratum 0 repository"; retcode=1; continue; }
-    health_check $name
+    is_stratum0 $name  || { echo "Repository $name is not a stratum 0 repository"; retcode=1; continue; }
+    health_check $name || { echo "Repository $name is not healthy"; retcode=1; continue; }
 
     # get repository information
     load_repo_config $name
@@ -3861,7 +3883,6 @@ cvmfs_server_resign() {
 cvmfs_server_list_catalogs() {
   local name
   local param_list="-t"
-  local silence_warnings=0
 
   # optional parameter handling
   OPTIND=1
@@ -3879,7 +3900,6 @@ cvmfs_server_list_catalogs() {
       ;;
       x)
         param_list=$(echo "$param_list" | sed 's/-t\s\?//')
-        silence_warnings=1
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -3901,7 +3921,7 @@ cvmfs_server_list_catalogs() {
 
   # more sanity checks
   is_owner_or_root $name || die "Permission denied: Repository $name is owned by $CVMFS_USER"
-  health_check $name $silence_warnings
+  health_check     $name || die "Repository $name is not healthy"
 
   # check if repository is compatible to the installed CernVM-FS version
   check_repository_compatibility $name
@@ -4042,7 +4062,7 @@ cvmfs_server_tag() {
   is_owner_or_root $name           || die "Permission denied: Repository $name is owned by $CVMFS_USER"
   is_stratum0 $name                || die "This is not a stratum 0 repository"
   ! is_publishing $name            || die "Repository is currently publishing"
-  health_check $name $silence_warnings
+  health_check -r $name
 
   local base_hash="$(get_mounted_root_hash $name)"
   local user_shell="$(get_user_shell $name)"
@@ -4212,7 +4232,7 @@ cvmfs_server_check() {
 
   # more sanity checks
   is_owner_or_root $name || die "Permission denied: Repository $name is owned by $CVMFS_USER"
-  health_check $name
+  health_check -r $name
 
   # check if repository is compatible to the installed CernVM-FS version
   check_repository_compatibility $name
@@ -4363,7 +4383,7 @@ cvmfs_server_transaction() {
 
     # sanity checks
     is_stratum0 $name || { echo "Repository $name is not a stratum 0 repository"; retcode=1; continue; }
-    health_check $name
+    health_check -r $name
 
     # get repository information
     load_repo_config $name
@@ -4452,9 +4472,7 @@ cvmfs_server_abort() {
     fi
 
     # do a health check (might also repair out-of-sync in_transaction repos)
-    local silence_warnings=0
-    local repair_in_txn=1
-    health_check $name $silence_warnings $repair_in_txn
+    health_check -rt $name
 
     # check if we have open file descriptors on /cvmfs/<name>
     local use_fd_fallback=0
@@ -4564,7 +4582,7 @@ cvmfs_server_publish() {
     # sanity checks
     is_stratum0 $name   || die "This is not a stratum 0 repository"
     is_publishing $name && die "Another publish process is active for $name"
-    health_check $name
+    health_check -r $name
 
     # get repository information
     load_repo_config $name
@@ -4810,7 +4828,7 @@ cvmfs_server_rollback() {
   check_repository_existence $name || die "The repository $name does not exist"
   is_stratum0 $name                || die "This is not a stratum 0 repository"
   is_publishing $name              && die "Repository $name is currently being published"
-  health_check $name
+  health_check -r $name
 
   # get repository information
   load_repo_config $name
@@ -5821,7 +5839,7 @@ cvmfs_server_migrate() {
     # more sanity checks
     is_owner_or_root $name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }
     check_repository_compatibility $name "nokill" && { echo "Repository '$name' is already up-to-date."; continue; }
-    health_check $name
+    health_check -r $name
 
     creator="$(repository_creator_version $name)"
 
@@ -5890,7 +5908,7 @@ _run_catalog_migration() {
   is_stratum0 $name       || die "This is not a stratum 0 repository"
   is_root                 || die "Permission denied: Only root can do that"
   is_in_transaction $name && die "Repository is already in a transaction"
-  health_check $name
+  health_check -r $name
 
   # all following commands need an open repository transaction and are supposed
   # to commit or abort it after performing the catalog migration.
@@ -6072,7 +6090,7 @@ cvmfs_server_update_repoinfo() {
   is_owner_or_root $name           || die "Permission denied: Repository $name is owned by $CVMFS_USER"
   is_stratum0 $name                || die "This is not a stratum 0 repository"
   ! is_publishing $name            || die "Repository is currently publishing"
-  health_check $name $silence_warnings
+  health_check -r $name
   is_in_transaction $name && die "Cannot edit repository meta info while in a transaction"
   [ x"$json_file" = x"" ] || [ -f "$json_file" ] || die "Provided file '$json_file' doesn't exist"
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -2048,9 +2048,9 @@ migrate_legacy_dirtab() {
   local tmp_dirtab=$(mktemp)
 
   cp -f "$dirtab_path" "$tmp_dirtab"                           || return 1
-  transaction $name > /dev/null                                || return 2
+  cvmfs_server_transaction $name > /dev/null                   || return 2
   cat "$tmp_dirtab" | sed -e 's/\(.*\)/\1\/\*/' > $dirtab_path || return 3
-  publish $name > /dev/null                                    || return 4
+  cvmfs_server_publish $name > /dev/null                       || return 4
   rm -f "$tmp_dirtab"                                          || return 5
 }
 
@@ -2822,14 +2822,14 @@ _update_geodb() {
   _update_geodb_install && echo "done" || { echo "fail"; return 3; }
 }
 
-update_geodb() {
+cvmfs_server_update_geodb() {
   _update_geodb $@
 }
 
 ################################################################################
 
 
-alterfs() {
+cvmfs_server_alterfs() {
   local master_replica=-1
   local name
 
@@ -2897,7 +2897,7 @@ alterfs() {
 ################################################################################
 
 
-mkfs() {
+cvmfs_server_mkfs() {
   local name
   local stratum0
   local upstream
@@ -3131,16 +3131,16 @@ mkfs() {
   echo "done"
 
   if [ $replicable -eq 1 ]; then
-    alterfs -m on $name
+    cvmfs_server_alterfs -m on $name
   fi
 
   health_check $name
 
   echo -n "Initial commit... "
-  transaction $name > /dev/null  || die "fail (transaction)"
+  cvmfs_server_transaction $name > /dev/null || die "fail (transaction)"
   echo "New CernVM-FS repository for $name" > /cvmfs/${name}/new_repository
   chown $cvmfs_user /cvmfs/${name}/new_repository
-  publish $name > /dev/null      || die "fail (publish)"
+  cvmfs_server_publish $name > /dev/null || die "fail (publish)"
   # When publishing an external repository, it is the user's responsibility to
   # stage the actual data files to the web server - not the publication function.
   # Hence, the following is guaranteed to not work.
@@ -3158,7 +3158,7 @@ mkfs() {
 ################################################################################
 
 
-add_replica() {
+cvmfs_server_add_replica() {
   local name
   local alias_name
   local stratum0
@@ -3370,7 +3370,7 @@ _import_desaster_cleanup() {
 }
 
 
-import() {
+cvmfs_server_import() {
   local name
   local stratum0
   local keys_location="/etc/cvmfs/keys"
@@ -3633,7 +3633,7 @@ import() {
 
   # make stratum0 repository replicable if requested
   if [ $replicable -eq 1 ]; then
-    alterfs -m on $name
+    cvmfs_server_alterfs -m on $name
   fi
 
   echo -n "Updating global JSON information... "
@@ -3660,7 +3660,7 @@ import() {
 ################################################################################
 
 
-rmfs() {
+cvmfs_server_rmfs() {
   local names
   local force=0
   local preserve_data=0
@@ -3770,7 +3770,7 @@ rmfs() {
 ################################################################################
 
 
-resign() {
+cvmfs_server_resign() {
   local names
   local retcode=0
 
@@ -3808,7 +3808,7 @@ resign() {
 ################################################################################
 
 
-list_catalogs() {
+cvmfs_server_list_catalogs() {
   local name
   local param_list="-t"
   local silence_warnings=0
@@ -3872,7 +3872,7 @@ list_catalogs() {
 ################################################################################
 
 
-info() {
+cvmfs_server_info() {
   local name
   local stratum0
 
@@ -3916,7 +3916,7 @@ Copy /etc/cvmfs/keys/${name}.pub to the client"
 ################################################################################
 
 
-tag() {
+cvmfs_server_tag() {
   local name
   local tag_name=""
   local action_add=0
@@ -4101,13 +4101,13 @@ tag() {
 ################################################################################
 
 
-lstags() {
-  tag -l "$@" # backward compatibility alias
+cvmfs_server_lstags() {
+  cvmfs_server_tag -l "$@" # backward compatibility alias
   echo "NOTE: cvmfs_server lstags is deprecated! Use cvmfs_server tag instead" 1>&2
 }
 
-list_tags() {
-  tag -l "$@" # backward compatibility alias
+cvmfs_server_list_tags() {
+  cvmfs_server_tag -l "$@" # backward compatibility alias
   echo "NOTE: cvmfs_server list-tags is deprecated! Use cvmfs_server tag instead" 1>&2
 }
 
@@ -4115,7 +4115,7 @@ list_tags() {
 ################################################################################
 
 
-check() {
+cvmfs_server_check() {
   local name
   local upstream
   local storage_dir
@@ -4212,7 +4212,7 @@ check() {
 ################################################################################
 
 
-list() {
+cvmfs_server_list() {
   for repository in /etc/cvmfs/repositories.d/*; do
     if [ "x$repository" = "x/etc/cvmfs/repositories.d/*" ]; then
       return 0
@@ -4277,7 +4277,7 @@ list() {
 ################################################################################
 
 
-transaction() {
+cvmfs_server_transaction() {
   local names
   local spool_dir
   local stratum0
@@ -4344,7 +4344,7 @@ transaction() {
 ################################################################################
 
 
-abort() {
+cvmfs_server_abort() {
   local names
   local user
   local spool_dir
@@ -4426,7 +4426,7 @@ abort() {
 ################################################################################
 
 
-publish() {
+cvmfs_server_publish() {
   local names
   local user
   local spool_dir
@@ -4722,7 +4722,7 @@ publish() {
 ################################################################################
 
 
-rollback() {
+cvmfs_server_rollback() {
   local name
   local user
   local spool_dir
@@ -4834,7 +4834,7 @@ rollback() {
 ################################################################################
 
 
-gc() {
+cvmfs_server_gc() {
   local names
   local list_deleted_objects=0
   local dry_run=0
@@ -5407,7 +5407,7 @@ EOF
   done
 }
 
-snapshot() {
+cvmfs_server_snapshot() {
   local alias_names
   local retcode=0
   local abort_on_conflict=0
@@ -5749,7 +5749,7 @@ migrate_2_2_0() {
   load_repo_config $name
 }
 
-migrate() {
+cvmfs_server_migrate() {
   local names
   local retcode=0
 
@@ -5877,7 +5877,7 @@ _run_catalog_migration() {
 ################################################################################
 
 
-catalog_chown() {
+cvmfs_server_catalog_chown() {
   local uid_map
   local gid_map
 
@@ -5926,7 +5926,7 @@ catalog_chown() {
 ################################################################################
 
 
-eliminate_hardlinks() {
+cvmfs_server_eliminate_hardlinks() {
   local name=
   local force=0
 
@@ -5994,7 +5994,7 @@ _update_repoinfo_cleanup() {
   close_transaction $repo_name 0
 }
 
-update_repoinfo() {
+cvmfs_server_update_repoinfo() {
   local name
   local json_file
 
@@ -6064,7 +6064,7 @@ _update_info_cleanup() {
   rm -f $tmp_file > /dev/null 2>&1
 }
 
-update_info() {
+cvmfs_server_update_info() {
   local configure_apache=1
   local edit_meta_info=1
 
@@ -6127,7 +6127,7 @@ update_info() {
 ################################################################################
 
 
-skeleton() {
+cvmfs_server_skeleton() {
   local skeleton_dir
   local skeleton_user
 
@@ -6203,7 +6203,7 @@ if is_subcommand $subcommand; then
   done
 
   # replace a dash (-) by an underscore (_) and call the requested sub-command
-  eval "$(echo $subcommand | sed 's/-/_/g') $args"
+  eval "cvmfs_server_$(echo $subcommand | sed 's/-/_/g') $args"
 else
   usage "Unrecognized command: $subcommand"
 fi

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1565,17 +1565,6 @@ health_check() {
     return 0
   fi
 
-  # health check cannot deal with repositories currently being published
-  if [ $quiet -eq 0 ] && is_publishing $name; then
-    echo "WARNING: The repository $name is currently publishing and should not"
-    echo "be touched. If you are absolutely sure, that this is _not_ the case,"
-    echo "please run the following command and retry:"
-    echo
-    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing.lock"
-    echo
-    exit 1
-  fi
-
   # check mounted read-only cvmfs client
   if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
     rdonly_broken=1
@@ -1622,6 +1611,16 @@ health_check() {
   # check if we are allowed to attempt a repair
   if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
     echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT = false)" >&2
+    exit 1
+  fi
+
+  if is_publishing $name; then
+    echo "WARNING: The repository $name is currently publishing and should not"
+    echo "be touched. If you are absolutely sure, that this is _not_ the case,"
+    echo "please run the following command and retry:"
+    echo
+    echo "   rm -fR ${CVMFS_SPOOL_DIR}/is_publishing.lock"
+    echo
     exit 1
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1638,6 +1638,10 @@ health_check() {
                                    $rw_should_be_rw
   fi
 
+  # should we try a repair?
+  if [ $repair = 0 ]; then
+    return 1
+  fi
 
   # check if we are allowed to attempt a repair
   if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1682,6 +1682,8 @@ health_check() {
     __hc_transition $name lock
     rw_should_be_rdonly=0 # ... rw is repaired
   fi
+
+  to_syslog_for_repo $name "finished mountpoint repair ($rdonly_broken $rdonly_outdated $rw_broken $rw_should_be_rdonly $rw_should_be_rw)"
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5465,7 +5465,7 @@ cvmfs_server_snapshot() {
 ################################################################################
 
 
-migrate_2_1_6() {
+_migrate_2_1_6() {
   local name=$1
   local destination_version="2.1.7"
 
@@ -5533,7 +5533,7 @@ EOF
 }
 
 
-migrate_2_1_7() {
+_migrate_2_1_7() {
   local name=$1
   local destination_version="2.1.15"
 
@@ -5603,7 +5603,7 @@ migrate_2_1_7() {
 }
 
 # note that this is only run on stratum1s that have local upstream storage
-migrate_2_1_15() {
+_migrate_2_1_15() {
   local name=$1
   local destination_version="2.1.20"
   local conf_file
@@ -5654,7 +5654,7 @@ migrate_2_1_15() {
   load_repo_config $name
 }
 
-migrate_2_1_20() {
+_migrate_2_1_20() {
   local name=$1
   local destination_version="2.2.0-1"
   local creator=$(repository_creator_version $name)
@@ -5777,7 +5777,7 @@ cvmfs_server_migrate() {
 
     # do the migrations...
     if [ x"$creator" = x"2.1.6" ]; then
-      migrate_2_1_6 $name
+      _migrate_2_1_6 $name
     fi
 
     if [ x"$creator" = x"2.1.7" -o  \
@@ -5789,7 +5789,7 @@ cvmfs_server_migrate() {
          x"$creator" = x"2.1.13" -o \
          x"$creator" = x"2.1.14" ];
     then
-      migrate_2_1_7 $name
+      _migrate_2_1_7 $name
     fi
 
     if [ x"$creator" = x"2.1.15" -o   \
@@ -5800,7 +5800,7 @@ cvmfs_server_migrate() {
          is_stratum1 $name         && \
          is_local_upstream $CVMFS_UPSTREAM_STORAGE;
     then
-      migrate_2_1_15 $name
+      _migrate_2_1_15 $name
     fi
 
     if [ x"$creator" = x"2.1.15" -o \
@@ -5811,7 +5811,7 @@ cvmfs_server_migrate() {
          x"$creator" = x"2.1.20" -o \
          x"$creator" = x"2.2.0-0" ];
     then
-      migrate_2_1_20 $name
+      _migrate_2_1_20 $name
     fi
 
     if [ x"$creator" = x"2.2.0-1" -o   \

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1650,6 +1650,7 @@ health_check() {
       rdonly_broken=1 # ... remount happens downstream
     fi
 
+    set_ro_root_hash $name "$(get_published_root_hash $name)" || die "failed to update root hash"
     rdonly_outdated=0 # ... remount will mount the latest revision
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1584,6 +1584,13 @@ health_check() {
   # check mounted union file system
   if ! is_mounted "/cvmfs/$name"; then
     rw_broken=1
+    if is_in_transaction $name; then
+      rw_should_be_rw=1
+      rw_should_be_ro=0
+    else
+      rw_should_be_rw=0
+      rw_should_be_ro=1
+    fi
   else
     if ! is_in_transaction $name && \
          is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1704,7 +1704,7 @@ health_check() {
       rw_broken=1 # ... remount happens downstream
     fi
 
-    __hc_transition $name $quiet "rdonly_mount" > /dev/null
+    __hc_transition $name $quiet "rdonly_mount"
     rdonly_broken=0 # ... rdonly is repaired
   fi
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1500,47 +1500,62 @@ foreclose_legacy_cvmfs() {
 }
 
 
-__health_check_print_repair_info() {
-  local name=$1
-  local repair_in_txn=$2
+__hc_print_repair_info() {
+  local name="$1"
+  local rdonly_broken=$2
+  local rdonly_outdated=$3
+  local rw_broken=$4
+  local rw_should_be_rdonly=$5
+  local rw_should_be_rw=$6
 
-  load_repo_config $name
+  [ $rdonly_broken       -eq 0 ] || echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly."                   >&2
+  [ $rdonly_outdated     -eq 0 ] || echo "$name is not based on the newest published revision"                  >&2
+  [ $rw_broken           -eq 0 ] || echo "/cvmfs/$name is not mounted properly."                                >&2
+  [ $rw_should_be_rdonly -eq 0 ] || echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
+  [ $rw_should_be_rw     -eq 0 ] || echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
 
-  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
-    echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT = false)" >&2
-    exit 1
-  fi
-
-  if is_in_transaction $name && [ $repair_in_txn = 0 ]; then
-    echo "Repository $name is in a transaction and cannot be repaired." >&2
-    echo "--> Run \`cvmfs_server abort $name\` to revert and repair."   >&2
-    exit 1
-  fi
+  to_syslog_for_repo $name "attempting mountpoint repair ($rdonly_broken $rdonly_outdated $rw_broken $rw_should_be_rdonly $rw_should_be_rw)"
 }
 
-__health_check_syslog_repair_info() {
+__hc_transition() {
   local name="$1"
-  local reason="$2"
-  local success="$3"
-  if $success; then
-    to_syslog_for_repo $name "repaired mounts ($reason)"
+  local transition="$2"
+  local msg=""
+
+  case $transition in
+    rw_umount)     msg="Trying to umount /cvmfs/${name}"             ;;
+    rdonly_umount) msg="Trying to umount ${CVMFS_SPOOL_DIR}/rdonly"  ;;
+    rw_mount)      msg="Trying to mount /cvmfs/${name}"              ;;
+    rdonly_mount)  msg="Trying to mount ${CVMFS_SPOOL_DIR}/rdonly"   ;;
+    open)          msg="Trying to remount /cvmfs/${name} read/write" ;;
+    lock)          msg="Trying to remount /cvmfs/${name} read-only"  ;;
+    *)             exit 2                                            ;;
+  esac
+
+  echo -n "Note: ${msg}... "
+  if run_suid_helper $transition $name; then
+    echo "success"
   else
-    to_syslog_for_repo $name "failed to repair mounts ($reason)"
+    echo "fail"
+    exit 1
   fi
 }
 
 # checks and warns in inconsistent repository states or unfavorable configs.
 #
 # @param name           the FQRN of the repository to be checked
-# @param quiet          disable printing of warnings
-# @param repair_in_txn  repair even if currently in a transaction
+# @param quiet          disable printing of warnings (default: no)
+# @param repair_in_txn  repair even if currently in a transaction (default: no)
 health_check() {
   local name=$1
   local quiet=${2-0}
   local repair_in_txn=${3-0}
+
   local rdonly_broken=0
   local rw_broken=0
-  local success=false
+  local rw_should_be_rdonly=0
+  local rw_should_be_rw=0
+  local rdonly_outdated=0
 
   load_repo_config $name
 
@@ -1562,76 +1577,99 @@ health_check() {
 
   # check mounted read-only cvmfs client
   if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
-    echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly." >&2
-    __health_check_print_repair_info $name $repair_in_txn
     rdonly_broken=1
+  elif [ x"$(get_mounted_root_hash $name)"      != \
+         x"$(get_published_root_hash $name)" ]; then
+    rdonly_outdated=1
   fi
 
   # check mounted union file system
   if ! is_mounted "/cvmfs/$name"; then
-    echo "/cvmfs/$name is not mounted properly." >&2
-    __health_check_print_repair_info $name $repair_in_txn
     rw_broken=1
+  else
+    if ! is_in_transaction $name && \
+         is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
+      rw_should_be_rdonly=1
+    elif is_in_transaction $name && \
+         is_mounted "/cvmfs/$name" "^.* ro[, ].*$"; then
+      rw_should_be_rw=1
+    fi
   fi
 
-  # try to repair the mountpoints
-  if [ $rdonly_broken -eq 1 ]; then
+  # did we detect any kind of problem?
+  if [ $((   $rdonly_broken       \
+           + $rdonly_outdated     \
+           + $rw_broken           \
+           + $rw_should_be_rdonly \
+           + $rw_should_be_rw )) -eq 0 ]; then
+    return 0
+  fi
+
+  # check if we are allowed to attempt a repair
+  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
+    echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT = false)" >&2
+    exit 1
+  fi
+
+  if is_in_transaction $name && [ $repair_in_txn = 0 ]; then
+    echo "Repository $name is in a transaction and cannot be repaired." >&2
+    echo "--> Run \`cvmfs_server abort $name\` to revert and repair."   >&2
+    exit 1
+  fi
+
+  __hc_print_repair_info $name $rdonly_broken       \
+                               $rdonly_outdated     \
+                               $rw_broken           \
+                               $rw_should_be_rdonly \
+                               $rw_should_be_rw
+
+  # consecutively bring the mountpoints into a sane state by working bottom up:
+  #   1. solve problems with the rdonly mountpoint
+  #      Note: this might require to 'break' the rw mountpoint (rw_broken --> 1)
+  #      1.1. solve outdated rdonly mountpoint (rdonly_outdated --> 0)
+  #      1.2. remount rdonly mountpoint        (rdonly_broken   --> 0)
+  #   2. solve problems with the rw mountpoint
+  #      2.1. mount the rw mountpoint as read-only    (rw_broken       --> 0)
+  #      2.2. remount the rw mountpoint as read-only  (rw_should_be_ro --> 0)
+  #      2.2. remount the rw mountpoint as read-write (rw_should_be_rw --> 0)
+  if [ $rdonly_outdated -eq 1 ]; then
     if [ $rw_broken -eq 0 ]; then
-      echo "Only the lower union file system branch is broken" >&2
-      echo -n "Note: Trying to umount /cvmfs/${name}... "
-      run_suid_helper rw_umount $name && echo "success" || { echo "fail"; exit 1; }
-      rw_broken=1 # will be fixed downstream
+      __hc_transition $name rw_umount
+      rw_broken=1 # ... remount happens downstream
     fi
 
-    echo -n "Note: Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... "
-    run_suid_helper rdonly_mount $name > /dev/null && success=true || success=false
-    __health_check_syslog_repair_info $name ".../rdonly" $success
-    $success && echo "success" || { echo "fail"; exit 1; }
+    if [ $rdonly_broken -eq 0 ]; then
+      __hc_transition $name rdonly_umount
+      rdonly_broken=1 # ... remount happens downstream
+    fi
+
+    rdonly_outdated=0 # ... remount will mount the latest revision
+  fi
+
+  if [ $rdonly_broken -eq 1 ]; then
+    if [ $rw_broken -eq 0 ]; then
+      __hc_transition $name rw_umount
+      rw_broken=1 # ... remount happens downstream
+    fi
+
+    __hc_transition $name rdonly_mount > /dev/null
+    rdonly_broken=0 # ... rdonly is repaired
   fi
 
   if [ $rw_broken -eq 1 ]; then
-    echo -n "Note: Trying to mount /cvmfs/${name}... "
-    run_suid_helper rw_mount $name && success=true || success=false
-    __health_check_syslog_repair_info $name "/cvmfs/${name}" $success
-    $success && echo "success" || { echo "fail"; exit 1; }
+    __hc_transition $name rw_mount
+    rw_broken=0           # ... rw is repaired
+    rw_should_be_rdonly=0 # ... and already mounted read-only by default
   fi
 
-  # check mounted CVMFS revision against published one
-  # Note: this needs to repaired first, so that the consecutive checks can put
-  #       the union mountpoint in the right state afterwards
-  if [ x"$(get_mounted_root_hash $name)" != x"$(get_published_root_hash $name)" ]; then
-    echo "$name is not based on the newest published revision" >&2
-    __health_check_print_repair_info $name $repair_in_txn
-    local published_hash="$(get_published_root_hash $name)"
-    echo -n "Note: Trying to remount repository mountpoints to $published_hash... "
-    run_suid_helper rw_umount     $name                     && \
-    run_suid_helper rdonly_umount $name                     && \
-    set_ro_root_hash              $name   "$published_hash" && \
-    run_suid_helper rdonly_mount  $name > /dev/null         && \
-    run_suid_helper rw_mount      $name && success=true || success=false
-    __health_check_syslog_repair_info $name "outdated revision" $success
-    $success && echo "success" || { echo "fail"; exit 1; }
+  if [ $rw_should_be_rw -eq 1 ]; then
+    __hc_transition $name open
+    rw_should_be_rw=0 # ... rw is repaired
   fi
 
-  # check transaction status
-  if is_in_transaction $name; then
-    if ! is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
-      echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
-      __health_check_print_repair_info $name $repair_in_txn
-      echo -n "Note: Trying to remount /cvmfs/${name} read/write... "
-      run_suid_helper open $name && success=true || success=false
-      __health_check_syslog_repair_info $name "non-writable transaction" $success
-      $success && echo "success" || { echo "fail"; exit 1; }
-    fi
-  else
-    if ! is_mounted "/cvmfs/$name" "^.* ro[, ].*$"; then
-      echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
-      __health_check_print_repair_info $name $repair_in_txn
-      echo -n "Note: Trying to remount /cvmfs/${name} read-only... "
-      run_suid_helper lock $name && success=true || success=false
-      __health_check_syslog_repair_info $name "writable mount point" $success
-      $success && echo "success" || { echo "fail"; exit 1; }
-    fi
+  if [ $rw_should_be_rdonly -eq 1 ]; then
+    __hc_transition $name lock
+    rw_should_be_rdonly=0 # ... rw is repaired
   fi
 }
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1547,9 +1547,16 @@ __hc_transition() {
   fi
 }
 
-# checks and warns in inconsistent repository states or unfavorable configs.
+# Checks for inconsistent repository states or unfavorable configs. Can repair
+# inconsistent repository mount states (-r)
+# Parameters:
+#   -q    silence notifications to stdout/stderr (syslog messages stay in place)
+#   -r    try to repair detected inconsistencies (non-zero exit on failure)
+#   -t    repair even if the repository is in a transaction
 #
-# @param name           the FQRN of the repository to be checked
+# @param name   the FQRN of the repository to be checked
+# @return       0 if repository is healthy (or has been successfully repaired)
+#               otherwise 1 (or abort when -r is given and repair fails)
 health_check() {
   local name=""
   local quiet=0

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -141,7 +141,6 @@ cvmfs_run_test() {
 
   echo "check the error and warning messages"
   cat $check_log_2_1 | grep -e "${CVMFS_TEST_REPO}/rdonly is not mounted"    || return 110
-  cat $check_log_2_1 | grep -e "Only.*lower.*branch is broken"               || return 111
   cat $check_log_2_1 | grep -e "Trying.*umount.* /cvmfs/${CVMFS_TEST_REPO}"  || return 112
   cat $check_log_2_1 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly" || return 113
   cat $check_log_2_1 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"   || return 114
@@ -283,7 +282,10 @@ cvmfs_run_test() {
 
   echo "check the error and warning messages"
   cat $check_log_9 | grep -e "${CVMFS_TEST_REPO} .* not based on .* published revision" || return 48
-  cat $check_log_9 | grep -e "Trying to remount .* to $current_root_hash"               || return 49
+  cat $check_log_9 | grep -e "Trying to umount /cvmfs/${CVMFS_TEST_REPO}"               || return 49
+  cat $check_log_9 | grep -e "Trying to umount .*${CVMFS_TEST_REPO}/rdonly"             || return 150
+  cat $check_log_9 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly"              || return 151
+  cat $check_log_9 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"                || return 152
 
   echo "add a couple of files"
   do_some_changes_to $repo_dir || return 50
@@ -333,7 +335,10 @@ cvmfs_run_test() {
 
   echo "check error and warning messages"
   cat $check_log_11 | grep -e "${CVMFS_TEST_REPO} .* not based on .* published revision"         || return 61
-  cat $check_log_11 | grep -e "Trying to remount .* to $current_root_hash"                       || return 62
+  cat $check_log_11 | grep -e "Trying to umount /cvmfs/${CVMFS_TEST_REPO}"                       || return 62
+  cat $check_log_11 | grep -e "Trying to umount .*${CVMFS_TEST_REPO}/rdonly"                     || return 163
+  cat $check_log_11 | grep -e "Trying to mount .*${CVMFS_TEST_REPO}/rdonly"                      || return 164
+  cat $check_log_11 | grep -e "Trying to mount /cvmfs/${CVMFS_TEST_REPO}"                        || return 165
   cat $check_log_11 | grep -e "${CVMFS_TEST_REPO} .* in a transaction .* not mounted read/write" || return 63
   cat $check_log_11 | grep -e "Trying to remount .* read/write"                                  || return 64
 

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -92,8 +92,8 @@ cvmfs_run_test() {
   echo "unmount union file system mountpoint"
   sudo umount $repo_dir || return 3
 
-  echo "check the repository"
-  local check_log_1="check_1.log"
+  local check_log_1="${scratch_dir}/check_1.log"
+  echo "check the repository (log: ${check_log_1})"
   cvmfs_server check $CVMFS_TEST_REPO > $check_log_1 2>&1 || return 4
 
   echo "check the error and warning messages"
@@ -111,8 +111,8 @@ cvmfs_run_test() {
   echo "unmount read-only cvmfs branch"
   sudo umount $rd_only || return 8
 
-  echo "check the repository"
-  local check_log_2="check_2.log"
+  local check_log_2="${scratch_dir}/check_2.log"
+  echo "check the repository (log: ${check_log_2})"
   cvmfs_server check $CVMFS_TEST_REPO > $check_log_2 2>&1 || return 9
 
   echo "check the error and warning messages"
@@ -135,8 +135,8 @@ cvmfs_run_test() {
   echo "mount the union file system again (without CVMFS mounted underneath)"
   sudo mount $repo_dir || return 108
 
-  echo "check the repository"
-  local check_log_2_1="check_2.1.log"
+  local check_log_2_1="${scratch_dir}/check_2.1.log"
+  echo "check the repository (log: ${check_log_2_1})"
   cvmfs_server check $CVMFS_TEST_REPO > $check_log_2_1 2>&1 || return 109
 
   echo "check the error and warning messages"
@@ -154,8 +154,8 @@ cvmfs_run_test() {
   echo "remount union file system read/write"
   sudo mount -o remount,rw $repo_dir || return 14
 
-  echo "open transaction"
-  local check_log_3="check_3.log"
+  local check_log_3="${scratch_dir}/check_3.log"
+  echo "open transaction (log: ${check_log_3})"
   start_transaction $CVMFS_TEST_REPO > $check_log_3 2>&1 || return 15
 
   echo "check the error and warning messages"
@@ -170,8 +170,8 @@ cvmfs_run_test() {
   echo "remount union file system read-only"
   sudo mount -o remount,ro $repo_dir || return 19
 
-  echo "publish transaction (should fail)"
-  local check_log_4="check_4.log"
+  local check_log_4="${scratch_dir}/check_4.log"
+  echo "publish transaction (should fail | log: ${check_log_4})"
   publish_repo $CVMFS_TEST_REPO > $check_log_4 2>&1 && return 20
 
   echo "check the error and warning messages"
@@ -183,8 +183,8 @@ cvmfs_run_test() {
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
-  echo "run abort to bring the repository back in shape"
-  local check_log_5="check_5.log"
+  local check_log_5="${scratch_dir}/check_5.log"
+  echo "run abort to bring the repository back in shape (log: ${check_log_5})"
   abort_transaction $CVMFS_TEST_REPO > $check_log_5 2>&1 || return 24
 
   echo "check the error and warning messages"
@@ -220,8 +220,8 @@ cvmfs_run_test() {
   sudo umount $repo_dir || return 30
   sudo umount $rd_only  || return 31
 
-  echo "publish transaction (should fail)"
-  local check_log_6="check_6.log"
+  local check_log_6="${scratch_dir}/check_6.log"
+  echo "publish transaction (should fail | log: ${check_log_6})"
   publish_repo $CVMFS_TEST_REPO > $check_log_6 2>&1 && return 32
 
   echo "check the error and warning messages"
@@ -230,8 +230,8 @@ cvmfs_run_test() {
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
-  echo "run abort to bring the repository back in shape"
-  local check_log_7="check_7.log"
+  local check_log_7="${scratch_dir}/check_7.log"
+  echo "run abort to bring the repository back in shape (log: ${check_log_7})"
   abort_transaction $CVMFS_TEST_REPO > $check_log_7 2>&1 || return 35
 
   echo "check the error and warning messages"
@@ -260,8 +260,8 @@ cvmfs_run_test() {
   echo "open transaction"
   start_transaction $CVMFS_TEST_REPO || return 44
 
-  echo "publish transaction"
-  local check_log_8="check_8.log"
+  local check_log_8="${scratch_dir}/check_8.log"
+  echo "publish transaction (log: ${check_log_8})"
   publish_repo $CVMFS_TEST_REPO > $check_log_8 2>&1 || return 45
 
   # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
@@ -277,8 +277,8 @@ cvmfs_run_test() {
   local tampered_root_hash="$(attr -qg root_hash $rd_only)"
   [ x"$tampered_root_hash" = x"$old_root_hash" ] || return 46
 
-  echo "open a transaction (should remount the repository)"
-  local check_log_9="check_9.log"
+  local check_log_9="${scratch_dir}/check_9.log"
+  echo "open a transaction (should remount the repository | log: ${check_log_9})"
   start_transaction $CVMFS_TEST_REPO > $check_log_9 2>&1 || return 47
 
   echo "check the error and warning messages"
@@ -316,8 +316,8 @@ cvmfs_run_test() {
   echo "create a manipulated client.local file with '$old_root_hash' and remount"
   mount_old_root_hash $CVMFS_TEST_REPO $old_root_hash || return $?
 
-  echo "publish repository (should fail)"
-  local check_log_10="check_10.log"
+  local check_log_10="${scratch_dir}/check_10.log"
+  echo "publish repository (should fail | log: ${check_log_10})"
   publish_repo $CVMFS_TEST_REPO > $check_log_10 2>&1 && return 56
 
   echo "check error and warning messages"
@@ -327,8 +327,8 @@ cvmfs_run_test() {
   echo "check if transaction is still open"
   [ -e ${CVMFS_SPOOL_DIR}/in_transaction.lock ] || return 59
 
-  echo "run abort to bring the repository back in shape"
-  local check_log_11="check_11.log"
+  local check_log_11="${scratch_dir}/check_11.log"
+  echo "run abort to bring the repository back in shape (log: ${check_log_11})"
   abort_transaction $CVMFS_TEST_REPO > $check_log_11 2>&1 || return 60
 
   echo "check error and warning messages"


### PR DESCRIPTION
This introduces several refactorings to `cvmfs_server` preparing for the integration of the `cvmfs_server mount` command. In detail:

* namespace the `cvmfs_server` command functions (i.e. `mkfs()` --> `cvmfs_server_mkfs()`) to avoid clashes with standard system functions (i.e. `mount()`).
* minor cosmetic fixes and protected methods (i.e. `_migrate_<base>()`)
* Restructuring of `health_check()` to disentangle *status discovery*, *status message printing* and *mount point repairs*
* `health_check()` takes proper command line parameters
* mount point repair must be explicitly requested with `health_check -r`
* Add status messages to syslog
  - `Trying to umount /cvmfs/${name}... [success|fail]`
  - `Trying to umount ${CVMFS_SPOOL_DIR}/rdonly... [success|fail]`
  - `Trying to mount /cvmfs/${name}... [success|fail]`
  - `Trying to mount ${CVMFS_SPOOL_DIR}/rdonly... [success|fail]`
  - `Trying to remount /cvmfs/${name} read/write... [success|fail]`
  - `Trying to remount /cvmfs/${name} read-only... [success|fail]`
  - `attempting mountpoint repair (<problem vector>)`
  - `finished mountpoint repair (<solved problem vector>)`

The `<problem vector>` currently consists of five binary flags. Those are meant for debugging, thus they are not translated into human-readable outputs. In contrast the status messages printed to `stderr` are human readable (see `__hc_print_status_report()`).

The `<problem vector>` flags indicate (in this order):
* Read-only mount point broken (CernVM-FS at `.../spool/.../rdonly` not mounted)
* Read-only mount point outdated ( `.../spool/.../rdonly` reflects outdated root catalog)
* Union file system mount point broken
* Union file system mount point should be read-only but is not
* Union file system mount point should be read/write but is not

Since there are some minor changes in the printed status messages, the pull request contains some updates to the associated integration test 582.

~~**Note:** [Feature: Asynchronous Cleanup of Scratch Directory](https://github.com/cvmfs/cvmfs/pull/1541) infrastructure migration step needs to be updated accordingly to reflect the `protected` cosmetics introduced here (i.e. `migrate_2_2_0()` --> `_migrate_2_2_0()`).~~