### PR TITLE
FIX: Remove Usage of SSLv3_client_method() in libcurl

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -125,6 +125,7 @@ patch_external "tbb"         "custom_library_suffix.patch"        \
                              "32bit_mock.patch"
 patch_external "vjson"       "missing_include.patch"
 patch_external "sparsehash"  "fix_sl4_compilation.patch"
+patch_external "libcurl"     "disable_sslv3.patch"
 
 replace_in_external "c-ares"      "config.guess.latest" "config.guess"
 replace_in_external "c-ares"      "config.sub.latest" "config.sub"

--- a/externals/libcurl/src/disable_sslv3.patch
+++ b/externals/libcurl/src/disable_sslv3.patch
@@ -1,0 +1,18 @@
+--- lib/vtls/openssl.c	2016-04-06 14:37:31.000000000 +0200
++++ lib/vtls/openssl.c.patched	2016-04-06 14:37:26.000000000 +0200
+@@ -1555,13 +1555,8 @@
+     break;
+ #endif
+   case CURL_SSLVERSION_SSLv3:
+-#ifdef USE_TLS_SRP
+-    if(data->set.ssl.authtype == CURL_TLSAUTH_SRP)
+-      return CURLE_SSL_CONNECT_ERROR;
+-#endif
+-    req_method = SSLv3_client_method();
+-    use_sni(FALSE);
+-    break;
++    failf(data, "libcurl was built without SSLv3 support");
++    return CURLE_NOT_BUILT_IN;
+   }
+ 
+   if(connssl->ctx)


### PR DESCRIPTION
This disables SSLv3 in the `libcurl` version we are currently using. As of OpenSSL 1.0.2g SSLv3 is [disabled on Ubuntu](https://launchpad.net/ubuntu/+source/openssl/1.0.2g-1ubuntu1) 15.10 which prevents a successful build of CernVM-FS. The OpenSSL ABI didn't change, hence this doesn't affect our released binaries. This patch will most likely become obsolete when we update our `libcurl` version.