### PR TITLE
Add Bash Completion for `cvmfs_server mount`

### DIFF
--- a/cvmfs/bash_completion/cvmfs.bash_completion
+++ b/cvmfs/bash_completion/cvmfs.bash_completion
@@ -94,7 +94,7 @@ _cvmfs_server()
 
   local -r cmds="mkfs add-replica import publish rollback rmfs \
     resign list info tag check transaction abort snapshot migrate \
-    list-catalogs update-info update-repoinfo"
+    list-catalogs update-info update-repoinfo mount"
 
   if [ $COMP_CWORD -le 1 ]; then
     COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )
@@ -179,6 +179,11 @@ _cvmfs_server()
       ;;
 
     update-repoinfo)
+      COMPREPLY=( $(compgen -W "$(__hosted_repos '/stratum0/')" ${cur}) )
+      return 0
+      ;;
+
+    mount)
       COMPREPLY=( $(compgen -W "$(__hosted_repos '/stratum0/')" ${cur}) )
       return 0
       ;;


### PR DESCRIPTION
This is a follow up for "[Feature: `cvmfs_server mount [-a]`](https://github.com/cvmfs/cvmfs/pull/1551)" and adds bash completion accordingly.