### PR TITLE
Feature: `cvmfs_server mount [-a]` retrofitted to CernVM-FS 2.2

### DIFF
--- a/cvmfs/bash_completion/cvmfs.bash_completion
+++ b/cvmfs/bash_completion/cvmfs.bash_completion
@@ -94,7 +94,7 @@ _cvmfs_server()
 
   local -r cmds="mkfs add-replica import publish rollback rmfs \
     resign list info tag check transaction abort snapshot migrate \
-    list-catalogs update-info update-repoinfo"
+    list-catalogs update-info update-repoinfo mount"
 
   if [ $COMP_CWORD -le 1 ]; then
     COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )
@@ -179,6 +179,11 @@ _cvmfs_server()
       ;;
 
     update-repoinfo)
+      COMPREPLY=( $(compgen -W "$(__hosted_repos '/stratum0/')" ${cur}) )
+      return 0
+      ;;
+
+    mount)
       COMPREPLY=( $(compgen -W "$(__hosted_repos '/stratum0/')" ${cur}) )
       return 0
       ;;

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -6054,6 +6054,11 @@ if is_subcommand $subcommand; then
     shift 1
   done
 
+  # CernVM-FS 2.3.0 cherry-picking workaround: "mount" --> "cvmfs_server_mount"
+  #  --> The next release will prefix all "$subcommand"s with 'cvmfs_server_'
+  #      but we didn't want to pull this refactoring into a bugfix release
+  subcommand=$(echo "$subcommand" | sed 's/^mount$/cvmfs_server_mount/')
+
   # replace a dash (-) by an underscore (_) and call the requested sub-command
   eval "$(echo $subcommand | sed 's/-/_/g') $args"
 else

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -192,7 +192,7 @@ is_subcommand() {
   local supported_commands="mkfs add-replica import publish rollback rmfs alterfs \
     resign list info tag list-tags lstags check transaction abort snapshot \
     skeleton migrate list-catalogs update-geodb gc catalog-chown eliminate-hardlinks \
-    update-info update-repoinfo"
+    update-info update-repoinfo mount"
 
   for possible_command in $supported_commands; do
     if [ x"$possible_command" = x"$subcommand" ]; then
@@ -5930,6 +5930,49 @@ update_info() {
     update_global_meta_info "$tmp_file" || die "fail (update meta info)"
   fi
   echo "done"
+}
+
+
+################################################################################
+
+
+cvmfs_server_mount() {
+  local names=""
+  local mount_all=0
+  local retval=0
+
+  OPTIND=1
+  while getopts "a" option; do
+    case $option in
+      a)
+        mount_all=1
+      ;;
+      ?)
+        shift $(($OPTIND-2))
+        usage "Command mount: Unrecognized option: $1"
+      ;;
+    esac
+  done
+  shift $(($OPTIND-1))
+
+  if [ $mount_all -eq 1 ]; then
+    # sanity checks
+    is_root || die "Permission Denied: need root to mount all repositories"
+    names="$(ls /etc/cvmfs/repositories.d)"
+  else
+    # get repository name
+    check_parameter_count_for_multiple_repositories $#
+    names=$(get_or_guess_multiple_repository_names $@)
+    check_multiple_repository_existence "$names"
+  fi
+
+  for name in $names; do
+    is_stratum0        $name || continue
+    is_owner_or_root   $name || { echo "Permission Denied: $name is owned by $CVMFS_USER" >&2; retval=1; continue; }
+    health_check -rftq $name || { echo "Failed to mount $name"                            >&2; retval=1; continue; }
+  done
+
+  return $retval
 }
 
 

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1428,10 +1428,12 @@ foreclose_legacy_cvmfs() {
 __health_check_print_repair_info() {
   local name=$1
   local repair_in_txn=$2
+  local force_repair=$3
 
   load_repo_config $name
 
-  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ]; then
+  if [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" = x"false" ] && \
+     [ $force_repair -eq 0 ]; then
     echo "Auto-Repair is disabled (CVMFS_AUTO_REPAIR_MOUNTPOINT = false)" >&2
     exit 1
   fi
@@ -1456,13 +1458,18 @@ __health_check_syslog_repair_info() {
 
 # checks and warns in inconsistent repository states or unfavorable configs.
 #
+# Note: the 'force_repair' parameter is a retrofit for the CernVM-FS 2.2.2 bug
+#       fix release of refactorings done to `health_check()` in CernVM-FS 2.3.0
+#
 # @param name           the FQRN of the repository to be checked
 # @param quiet          disable printing of warnings
 # @param repair_in_txn  repair even if currently in a transaction
+# @param force_repair   override CVMFS_AUTO_REPAIR_MOUNTPOINT=false
 health_check() {
   local name=$1
   local quiet=${2-0}
   local repair_in_txn=${3-0}
+  local force_repair=${4-0}
   local rdonly_broken=0
   local rw_broken=0
   local success=false
@@ -1488,14 +1495,14 @@ health_check() {
   # check mounted read-only cvmfs client
   if ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
     echo "${CVMFS_SPOOL_DIR}/rdonly is not mounted properly." >&2
-    __health_check_print_repair_info $name $repair_in_txn
+    __health_check_print_repair_info $name $repair_in_txn $force_repair
     rdonly_broken=1
   fi
 
   # check mounted union file system
   if ! is_mounted "/cvmfs/$name"; then
     echo "/cvmfs/$name is not mounted properly." >&2
-    __health_check_print_repair_info $name $repair_in_txn
+    __health_check_print_repair_info $name $repair_in_txn $force_repair
     rw_broken=1
   fi
 
@@ -1526,7 +1533,7 @@ health_check() {
   #       the union mountpoint in the right state afterwards
   if [ x"$(get_mounted_root_hash $name)" != x"$(get_published_root_hash $name)" ]; then
     echo "$name is not based on the newest published revision" >&2
-    __health_check_print_repair_info $name $repair_in_txn
+    __health_check_print_repair_info $name $repair_in_txn $force_repair
     local published_hash="$(get_published_root_hash $name)"
     echo -n "Note: Trying to remount repository mountpoints to $published_hash... "
     cvmfs_suid_helper rw_umount     $name                   && \
@@ -1542,7 +1549,7 @@ health_check() {
   if is_in_transaction $name; then
     if ! is_mounted "/cvmfs/$name" "^.* rw[, ].*$"; then
       echo "$name is in a transaction but /cvmfs/$name is not mounted read/write" >&2
-      __health_check_print_repair_info $name $repair_in_txn
+      __health_check_print_repair_info $name $repair_in_txn $force_repair
       echo -n "Note: Trying to remount /cvmfs/${name} read/write... "
       cvmfs_suid_helper open $name && success=true || success=false
       __health_check_syslog_repair_info $name "non-writable transaction" $success
@@ -1551,7 +1558,7 @@ health_check() {
   else
     if ! is_mounted "/cvmfs/$name" "^.* ro[, ].*$"; then
       echo "$name is not in a transaction but /cvmfs/$name is mounted read/write" >&2
-      __health_check_print_repair_info $name $repair_in_txn
+      __health_check_print_repair_info $name $repair_in_txn $force_repair
       echo -n "Note: Trying to remount /cvmfs/${name} read-only... "
       cvmfs_suid_helper lock $name && success=true || success=false
       __health_check_syslog_repair_info $name "writable mount point" $success
@@ -5969,7 +5976,11 @@ cvmfs_server_mount() {
   for name in $names; do
     is_stratum0        $name || continue
     is_owner_or_root   $name || { echo "Permission Denied: $name is owned by $CVMFS_USER" >&2; retval=1; continue; }
-    health_check -rftq $name || { echo "Failed to mount $name"                            >&2; retval=1; continue; }
+
+    local quiet=0
+    local repair_in_txn=1
+    local force_repair=1
+    health_check $name $quiet $repair_in_txn $force_repair || { echo "Failed to mount $name" >&2; retval=1; continue; }
   done
 
   return $retval

--- a/test/src/630-servermount/main
+++ b/test/src/630-servermount/main
@@ -1,0 +1,286 @@
+cvmfs_test_name="Server Infrastructure Mounting"
+cvmfs_test_autofs_on_startup=false
+
+set_auto_repair() {
+  local name="$1"
+  local value="$2"
+
+  local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
+  if cat $server_conf | grep -q "CVMFS_AUTO_REPAIR_MOUNTPOINT"; then
+    sudo sed -i -e \
+      "s/^\(CVMFS_AUTO_REPAIR_MOUNTPOINT\)=.*$/\1=${value}/" $server_conf
+  else
+    echo "CVMFS_AUTO_REPAIR_MOUNTPOINT=${value}" \
+      | sudo tee --append $server_conf
+  fi
+}
+
+disable_auto_repair() {
+  local name="$1"
+  set_auto_repair $name "false"
+}
+
+enable_auto_repair() {
+  local name="$1"
+  set_auto_repair $name "true"
+}
+
+CVMFS_TEST_630_REPLICA_NAME=
+CVMFS_TEST_630_REPO2_NAME=
+cleanup() {
+  echo "running cleanup()..."
+  [ -z $CVMFS_TEST_630_REPLICA_NAME ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_630_REPLICA_NAME
+  [ -z $CVMFS_TEST_630_REPO2_NAME   ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_630_REPO2_NAME
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "pull in repository configuration"
+  load_repo_config $CVMFS_TEST_REPO || return 1
+  local rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
+
+  echo "make sure that CVMFS_AUTO_REPAIR_MOUNTPOINT=true"
+  [ x"$CVMFS_AUTO_REPAIR_MOUNTPOINT" != x"false" ] || return 100
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Check standard mount of unmounted repository outside of transaction
+
+  echo "Unmount $CVMFS_TEST_REPO"
+  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 2
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 3
+
+  echo "Check that the repository is properly unmounted"
+  cat /proc/mounts | grep -e " $repo_dir "   && return 4
+  cat /proc/mounts | grep -e " $rdonly_dir " && return 5
+
+  echo "Mount the repository using cvmfs_server"
+  cvmfs_server mount $CVMFS_TEST_REPO || return 6
+
+  echo "Check that the repository is properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "   || return 7
+  cat /proc/mounts | grep -e " $rdonly_dir " || return 8
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Check mount of unmounted repository during transaction
+
+  echo "open transaction"
+  start_transaction $CVMFS_TEST_REPO || return 9
+
+  echo "Unmount $CVMFS_TEST_REPO"
+  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 10
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 11
+
+  echo "Check that the repository is properly unmounted"
+  cat /proc/mounts | grep -e " $repo_dir "   && return 12
+  cat /proc/mounts | grep -e " $rdonly_dir " && return 13
+
+  echo "Mount the repository using cvmfs_server"
+  cvmfs_server mount $CVMFS_TEST_REPO || return 14
+
+  echo "Check that the repository is properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "          || return 15
+  cat /proc/mounts | grep -e " $rdonly_dir "        || return 16
+  cat /proc/mounts | grep -e " ${repo_dir}.*rw[ ,]" || return 17
+
+  echo "publish repository"
+  publish_repo $CVMFS_TEST_REPO || return 18
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Check mounting rdonly-branch of repository during transaction
+
+  echo "open transaction"
+  start_transaction $CVMFS_TEST_REPO || return 19
+
+  echo "Unmount $CVMFS_TEST_REPO (rdonly only)"
+  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 20
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 21
+  cvmfs_suid_helper rw_mount      $CVMFS_TEST_REPO || return 22
+
+  echo "Check that the repository is properly unmounted"
+  cat /proc/mounts | grep -e " $repo_dir "   || return 23
+  cat /proc/mounts | grep -e " $rdonly_dir " && return 24
+
+  echo "Mount the repository using cvmfs_server"
+  cvmfs_server mount $CVMFS_TEST_REPO || return 25
+
+  echo "Check that the repository is properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "          || return 26
+  cat /proc/mounts | grep -e " $rdonly_dir "        || return 27
+  cat /proc/mounts | grep -e " ${repo_dir}.*rw[ ,]" || return 28
+
+  echo "publish repository"
+  publish_repo $CVMFS_TEST_REPO || return 29
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Check mounting repository with CVMFS_AUTO_REPAIR_MOUNTPOINT=false
+
+  echo "set CVMFS_AUTO_REPAIR_MOUNTPOINT=false"
+  disable_auto_repair $CVMFS_TEST_REPO || return 31
+
+  echo "Unmount $CVMFS_TEST_REPO"
+  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 32
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 33
+
+  echo "Check that the repository is properly unmounted"
+  cat /proc/mounts | grep -e " $repo_dir "   && return 34
+  cat /proc/mounts | grep -e " $rdonly_dir " && return 35
+
+  echo "Mount the repository using cvmfs_server"
+  cvmfs_server mount $CVMFS_TEST_REPO || return 36
+
+  echo "Check that the repository is properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "   || return 37
+  cat /proc/mounts | grep -e " $rdonly_dir " || return 38
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "set CVMFS_AUTO_REPAIR_MOUNTPOINT=true"
+  enable_auto_repair $CVMFS_TEST_REPO || return 39
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Create more repositories and Stratum1s to check `cvmfs_server mount -a`
+
+  echo "install a cleanup function"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "create Stratum1 repository on the same machine"
+  load_repo_config $CVMFS_TEST_REPO
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+  CVMFS_TEST_630_REPLICA_NAME=$replica_name
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 40
+
+  echo "initial snapshot into $replica_name"
+  cvmfs_server snapshot $replica_name || return 41
+
+  local repo2="${CVMFS_TEST_REPO}.$(date +%s%N | sha1sum | head -c6)"
+  echo "create a second Stratum0 ($repo2) owned by $CVMFS_TEST_USER"
+  CVMFS_TEST_630_REPO2_NAME=$repo2
+  create_repo $repo2 $CVMFS_TEST_USER || return 42
+
+  echo "pull in repository configuration for $repo2"
+  load_repo_config $repo2 || return 43
+  local repo2_repo_dir="/cvmfs/${repo2}"
+  local repo2_rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
+
+  echo -n "check if there are more repositories than expected... "
+  local repo_count=$(cvmfs_server list | wc -l)
+  if [ $repo_count -eq 3 ]; then
+    echo "no"
+  else
+    echo "yes ($repo_count repos found)"
+    cvmfs_server list
+    echo "WARNING: THIS MIGHT AFFECT THE OUTCOME OF THE NEXT TESTS..."
+    CVMFS_GENERAL_WARNING_FLAG=1
+  fi
+
+  echo "Check that the repositories are properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "         || return 44
+  cat /proc/mounts | grep -e " $rdonly_dir "       || return 45
+  cat /proc/mounts | grep -e " $repo2_repo_dir "   || return 46
+  cat /proc/mounts | grep -e " $repo2_rdonly_dir " || return 47
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Run `cvmfs_server mount -a` with all repos properly mounted
+
+  if [ x"$(whoami)" != x"root" ]; then
+    local mount_log_1="$(pwd)/mount_1.log"
+    echo "run \`cvmfs_server mount -a\` without necessity and as non-root (log: $mount_log_1)"
+    cvmfs_server mount -a > $mount_log_1 2>&1 && return 48
+
+    echo "check error message"
+    cat $mount_log_1 | grep 'need root to mount all' || return 49
+  else
+    echo "WARNING: cannot test non-root behaviour of \`cvmfs_server mount -a\` as root"
+    CVMFS_GENERAL_WARNING_FLAG=1
+  fi
+
+  echo "do \`cvmfs_server mount -a\` without necessity"
+  sudo cvmfs_server mount -a || return 50
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Run `cvmfs_server mount -a` with mount problems in the repositories
+
+  echo "break mounts for the repositories (umount rdonly for $CVMFS_TEST_REPO)"
+  cvmfs_suid_helper rw_umount     $CVMFS_TEST_REPO || return 51
+  cvmfs_suid_helper rdonly_umount $CVMFS_TEST_REPO || return 52
+  cvmfs_suid_helper rw_mount      $CVMFS_TEST_REPO || return 53
+
+  echo "open transaction for $repo2"
+  start_transaction $repo2 || return 54
+
+  echo "break mounts for the repositories (umount rdonly for $repo2 and make union read-only)"
+  cvmfs_suid_helper rw_umount     $repo2 || return 55
+  cvmfs_suid_helper rdonly_umount $repo2 || return 56
+  cvmfs_suid_helper rw_mount      $repo2 || return 57
+
+  echo "Check that the repositories are not properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "         || return 58
+  cat /proc/mounts | grep -e " $rdonly_dir "       && return 59
+  cat /proc/mounts | grep -e " $repo2_repo_dir "   || return 60
+  cat /proc/mounts | grep -e " $repo2_rdonly_dir " && return 61
+
+  echo "do \`cvmfs_server mount -a\` to bring all repositories back into proper shape"
+  sudo cvmfs_server mount -a || return 62
+
+  echo "Check that the repositories are properly mounted"
+  cat /proc/mounts | grep -e " $repo_dir "         || return 63
+  cat /proc/mounts | grep -e " $rdonly_dir "       || return 64
+  cat /proc/mounts | grep -e " $repo2_repo_dir "   || return 65
+  cat /proc/mounts | grep -e " $repo2_rdonly_dir " || return 66
+
+  echo "publish $repo2"
+  publish_repo $repo2 || return 67
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Provoke a mount failure for a multi-repo `cvmfs_server mount`
+
+  echo "break union fs mount point of ${CVMFS_TEST_REPO} and ${repo2}"
+  cvmfs_suid_helper rw_umount $CVMFS_TEST_REPO || return 68
+  cvmfs_suid_helper rw_umount $repo2           || return 69
+
+  echo "remove ${repo_dir} to provoke failed mount call"
+  sudo rm -fR $repo_dir || return 70
+
+  echo "check that both $repo_dir and $repo2_repo_dir are not mounted"
+  cat /proc/mounts | grep -e " $repo_dir "         && return 71
+  cat /proc/mounts | grep -e " $repo2_repo_dir "   && return 72
+
+  local mount_log_2="$(pwd)/mount_2.log"
+  echo "try to mount ${CVMFS_TEST_REPO} and $repo2 (should fail | log: ${mount_log_2})"
+  cvmfs_server mount $CVMFS_TEST_REPO $repo2 > $mount_log_2 2>&1 && return 73
+
+  echo "check that an error message was printed"
+  cat $mount_log_2 | grep 'Trying to mount.*fail' || return 74
+
+  echo "check that $repo_dir is still not mounted but $repo2_repo_dir is"
+  cat /proc/mounts | grep -e " $repo_dir "         && return 75
+  cat /proc/mounts | grep -e " $repo2_repo_dir "   || return 76
+
+  echo "repair the mount point"
+  sudo mkdir -p $repo_dir || return 77
+
+  echo "try to mount again (should work now)"
+  cvmfs_server mount $CVMFS_TEST_REPO || return 78
+
+  return 0
+}
+

--- a/test/src/630-servermount/main
+++ b/test/src/630-servermount/main
@@ -269,7 +269,14 @@ cvmfs_run_test() {
   cvmfs_server mount $CVMFS_TEST_REPO $repo2 > $mount_log_2 2>&1 && return 73
 
   echo "check that an error message was printed"
-  cat $mount_log_2 | grep 'Trying to mount.*fail' || return 74
+  # retrofit for CernVM-FS 2.2.2 bugfix release:
+  #  --> we didn't pull in a refactoring of `cvmfs_server health_check()` at the
+  #      expense of less concise status/error logging
+  #
+  # '... does not exist' --> OverlayFS
+  # '... No such file'   --> AUFS
+  cat $mount_log_2 | grep 'Trying to mount.*does not exist' || \
+  cat $mount_log_2 | grep 'Trying to mount.*No such file'   || return 74
 
   echo "check that $repo_dir is still not mounted but $repo2_repo_dir is"
   cat /proc/mounts | grep -e " $repo_dir "         && return 75


### PR DESCRIPTION
That retrofits the `cvmfs_server mount [-a]` feature to CernVM-FS 2.2. Refactoring of `health_check()` is omitted and the `mount` name clash is worked around rather than doing full `cvmfs_server` subcommand namespacing (#1549). This happens at the expense of a verbose and less concise status/error logging when running `cvmfs_server mount`.

Note that this also cherry-picks and adapts integration test 630 as well as the bash completion.