### PR TITLE
Block Repository Migration in Transaction

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5868,13 +5868,20 @@ cvmfs_server_migrate() {
 
     # get repository information
     load_repo_config $name
+    creator="$(repository_creator_version $name)"
 
     # more sanity checks
     is_owner_or_root $name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }
     check_repository_compatibility $name "nokill" && { echo "Repository '$name' is already up-to-date."; continue; }
     health_check -r $name
 
-    creator="$(repository_creator_version $name)"
+    if is_stratum0 $name && is_in_transaction $name; then
+      echo "Repository '$name' is currently in a transaction - migrating might"
+      echo "result in data loss. Please abort or publish this transaction with"
+      echo "the CernVM-FS version ($creator) that opened it."
+      retcode=1
+      continue
+    fi
 
     # do the migrations...
     if [ x"$creator" = x"2.1.6" ]; then

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -541,7 +541,8 @@ least CernVM-FS $creator to manipulate this repository."
     fi
   fi
 
-  if [ "$creator" = "2.2.0-1" ] || [ "$creator" = "2.2.1-1" ]; then
+  if [ "$creator" = "2.2.0-1" ] || [ "$creator" = "2.2.1-1" ] || \
+     [ "$creator" = "2.2.2-1" ]; then
     if version_greater_or_equal "2.3.0"; then
       _repo_is_incompatible "$creator" $nokill
       return $?
@@ -5923,7 +5924,8 @@ cvmfs_server_migrate() {
     fi
 
     if [ x"$creator" = x"2.2.0-1" -o   \
-         x"$creator" = x"2.2.1-1" ] && \
+         x"$creator" = x"2.2.1-1" -o   \
+         x"$creator" = x"2.2.2-1" ] && \
          is_stratum0 $name;
     then
       _migrate_2_2_0 $name

--- a/packaging/debian/cvmfs/cvmfs-server.preinst
+++ b/packaging/debian/cvmfs/cvmfs-server.preinst
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+CVMFS_INSTALL_ACTION=$1
+CVMFS_SPOOL_DIR_BASE="/var/spool/cvmfs"
+CVMFS_CONFIG_DIR_BASE="/etc/cvmfs/repositories.d"
+CVMFS_OPEN_TXN=0
+
+#DEBHELPER#
+
+# check that the expected CernVM-FS repo infrastructure is in place
+[ -d "$CVMFS_SPOOL_DIR_BASE"  ] || exit 0
+[ -d "$CVMFS_CONFIG_DIR_BASE" ] || exit 0
+
+# count open transactions in Stratum0 repositories
+for repo in ${CVMFS_SPOOL_DIR_BASE}/*; do
+  [   -d $repo ]                                                   || continue
+  [ ! -f ${CVMFS_CONFIG_DIR_BASE}/$(basename $repo)/replica.conf ] || continue
+
+  # CernVM-FS 2.2.0+          --> 'in_transaction.lock' file
+  # CernVM-FS 2.1.18 - 2.1.20 --> 'in_transaction' lock directory
+  # CernVM-FS 2.1.0  - 2.1.17 --> 'in_transaction' lock file
+  if [ -f ${repo}/in_transaction.lock ] || \
+     [ -d ${repo}/in_transaction      ] || \
+     [ -f ${repo}/in_transaction      ]; then
+    CVMFS_OPEN_TXN=$(( $CVMFS_OPEN_TXN + 1 ))
+  fi
+done
+
+# check if there are any open transactions
+if [ $CVMFS_OPEN_TXN -gt 0 ]; then
+  echo "     Found $CVMFS_OPEN_TXN open CernVM-FS repository transactions." >&2
+  echo "     Please abort or publish them before updating CernVM-FS."       >&2
+  exit 1
+fi
+
+exit 0

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -222,6 +222,24 @@ done
 popd
 %endif
 
+%pretrans server
+[ -d "/var/spool/cvmfs"  ]          || exit 0
+[ -d "/etc/cvmfs/repositories.d/" ] || exit 0
+
+for repo in /var/spool/cvmfs/*; do
+  [ -d $repo ] && [ ! -f /etc/cvmfs/repositories.d/$(basename $repo)/replica.conf ] || continue
+
+  if [ -f ${repo}/in_transaction.lock ] || \
+     [ -d ${repo}/in_transaction      ] || \
+     [ -f ${repo}/in_transaction      ]; then
+    echo "     Found open CernVM-FS repository transactions."           >&2
+    echo "     Please abort or publish them before updating CernVM-FS." >&2
+    exit 1
+  fi
+done
+
+exit 0
+
 %pre
 %if 0%{?suse_version}
   /usr/bin/getent group cvmfs >/dev/null
@@ -404,6 +422,8 @@ fi
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog
+* Thu Apr 07 2016 Rene Meusel <rene.meusel@cern.ch> - 2.3.0
+- Check for open repo transactions before updating server package
 * Sat Jan 23 2016 Brian Bockelman <bbockelm@cse.unl.edu> - 2.2.0
 - Build with VOMS support
 * Thu Jan 21 2016 Jakob Blomer <jblomer@cern.ch> - 2.2.0


### PR DESCRIPTION
This prevents a `cvmfs_server migrate` to run on a repository that is in a transaction. If a user runs into this situation he probably updated the CernVM-FS server software with an open transaction from the previous version. That might result in data loss, depending on what actions the `cvmfs_server migrate` performs (see 2.2.0 --> 2.3.0 step for example).

Furthermore this adds a pre-install check to both RPM and debian package that prevents their install if an open transaction on one of the hosted Stratum0s is detected.

Finally this adds the upcoming CernVM-FS 2.2.2 release version to the migration paths.

