### PR TITLE
TEST: Enable 577 and 579 in Cloud Tests

### DIFF
--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -33,8 +33,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  --                                           \

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -33,8 +33,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  --                                           \

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -90,8 +90,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  src/608-infofile                             \

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -73,8 +73,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  --                                           \
                                  src/5*                                       \
@@ -111,8 +109,6 @@ if [ $s3_retval -eq 0 ]; then
                                src/568-migratecorruptrepo                   \
                                src/571-localbackendumask                    \
                                src/572-proxyfailover                        \
-                               src/577-garbagecollecthiddenstratum1revision \
-                               src/579-garbagecollectstratum1legacytag      \
                                src/583-httpredirects                        \
                                src/585-xattrs                               \
                                src/591-importrepo                           \

--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -41,8 +41,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  --                                           \

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -31,8 +31,6 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  src/602-libcvmfs                             \

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -28,8 +28,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
-                                 src/577-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollectstratum1legacytag      \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  --                                           \


### PR DESCRIPTION
After [this](https://github.com/cvmfs/cvmfs/pull/1547) has been merged the integration tests 577 and 579 should work properly using `.cvmfsreflog`.