### PR TITLE
Refactor: Eliminate some Code duplications in `Uploaders`

### DIFF
--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -44,6 +44,13 @@ bool AbstractUploader::Initialize() {
 }
 
 
+void AbstractUploader::WorkerThread() {
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread started.");
+  while (PerformJob() != JobStatus::kTerminate);
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread exited.");
+}
+
+
 AbstractUploader::JobStatus::State AbstractUploader::DispatchJob(
                                                          const UploadJob &job) {
   switch (job.type) {

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -70,7 +70,7 @@ int AbstractUploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
 
 void AbstractUploader::WorkerThread() {
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread started.");
-  while (PerformJob() != JobStatus::kTerminate);
+  while (PerformJob() != JobStatus::kTerminate) {}
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread exited.");
 }
 

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -44,6 +44,30 @@ bool AbstractUploader::Initialize() {
 }
 
 
+AbstractUploader::JobStatus::State AbstractUploader::DispatchJob(
+                                                         const UploadJob &job) {
+  switch (job.type) {
+    case UploadJob::Upload:
+      StreamedUpload(job.stream_handle,
+                     job.buffer,
+                     job.callback);
+      return JobStatus::kOk;
+
+    case UploadJob::Commit:
+      FinalizeStreamedUpload(job.stream_handle, job.content_hash);
+      return JobStatus::kOk;
+
+    case UploadJob::Terminate:
+      return JobStatus::kTerminate;
+
+    default:
+      const bool unknown_job_type = false;
+      assert(unknown_job_type);
+      return JobStatus::kTerminate;
+  }
+}
+
+
 void AbstractUploader::TearDown() {
   assert(!torn_down_);
   upload_queue_.push(UploadJob());  // Termination signal

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -371,7 +371,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    * make sure to exit that method if and only if you receive an UploadJob like:
    *   UploadJob.type == UploadJob::Terminate
    */
-  virtual void WorkerThread() = 0;
+  virtual void WorkerThread();
 
 
   /**

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -362,14 +362,11 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
 
   /**
-   * This purely virtual function is called once the AbstractUploader has started
-   * its dedicated writer thread. Overwrite this method to implement your event
-   * loop that is supposed to run in its own thread. In this event loop you are
-   * supposed to pull upload jobs using AbstractUploader::AcquireNewJob().
-   *
-   * If this method returns, AbstractUploader's write thread is terminated, so
-   * make sure to exit that method if and only if you receive an UploadJob like:
-   *   UploadJob.type == UploadJob::Terminate
+   * This virtual function is called once the AbstractUploader has started its
+   * dedicated writer thread. Overwrite this method to implement your own event
+   * loop. You must call AbstractUploader::PerformJob() or ::TryToPerformJob()
+   * in an endless loop until either of those returns JobState::kTerminate.
+   * AbstractUploader's write thread is terminated when this method returns.
    */
   virtual void WorkerThread();
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -13,8 +13,8 @@
 #include <string>
 
 #include "upload_spooler_definition.h"
-#include "util_concurrency.h"
 #include "util/posix.h"
+#include "util_concurrency.h"
 
 namespace upload {
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -8,10 +8,13 @@
 #include <tbb/concurrent_queue.h>
 #include <tbb/tbb_thread.h>
 
+#include <fcntl.h>
+
 #include <string>
 
 #include "upload_spooler_definition.h"
 #include "util_concurrency.h"
+#include "util/posix.h"
 
 namespace upload {
 
@@ -359,6 +362,17 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
       ? DispatchJob(job)
       : JobStatus::kNoJobs;
   }
+
+
+  /**
+   * Creates a temporary file in the backend storage's temporary location
+   * For the LocalUploader this usually is the 'txn' directory of the backend
+   * storage. Otherwise it is some scratch area.
+   *
+   * @param path   pointer to a string that will contain the created file path
+   * @return       a file descriptor to the opened file
+   */
+  int CreateAndOpenTemporaryChunkFile(std::string *path) const;
 
 
   /**

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -42,15 +42,6 @@ unsigned int LocalUploader::GetNumberOfErrors() const {
 }
 
 
-void LocalUploader::WorkerThread() {
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Local WorkerThread started.");
-
-  while (PerformJob() != JobStatus::kTerminate);
-
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Local WorkerThread exited.");
-}
-
-
 void LocalUploader::FileUpload(
   const std::string &local_path,
   const std::string &remote_path,

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -75,8 +75,6 @@ class LocalUploader : public AbstractUploader {
   unsigned int GetNumberOfErrors() const;
 
  protected:
-  void WorkerThread();
-
   int Move(const std::string &local_path,
            const std::string &remote_path) const;
 

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -56,9 +56,9 @@ class LocalUploader : public AbstractUploader {
                   const CallbackTN   *callback = NULL);
 
   UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
-  void Upload(UploadStreamHandle  *handle,
-              CharBuffer          *buffer,
-              const CallbackTN    *callback = NULL);
+  void StreamedUpload(UploadStreamHandle  *handle,
+                      CharBuffer          *buffer,
+                      const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                               const shash::Any    &content_hash);
 

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -78,8 +78,6 @@ class LocalUploader : public AbstractUploader {
   int Move(const std::string &local_path,
            const std::string &remote_path) const;
 
-  int CreateAndOpenTemporaryChunkFile(std::string *path) const;
-
  private:
   // state information
   const std::string    upstream_path_;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -53,9 +53,9 @@ class S3Uploader : public AbstractUploader {
                   const CallbackTN   *callback = NULL);
 
   UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
-  void Upload(UploadStreamHandle  *handle,
-              CharBuffer          *buffer,
-              const CallbackTN    *callback = NULL);
+  void StreamedUpload(UploadStreamHandle  *handle,
+                      CharBuffer          *buffer,
+                      const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                               const shash::Any    &content_hash);
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -72,8 +72,6 @@ class S3Uploader : public AbstractUploader {
  protected:
   void WorkerThread();
 
-  int CreateAndOpenTemporaryChunkFile(std::string *path) const;
-
  private:
   bool ParseSpoolerDefinition(const SpoolerDefinition &spooler_definition);
   bool UploadJobInfo(s3fanout::JobInfo *info);

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -113,9 +113,9 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
     return new MockStreamHandle(callback);
   }
 
-  void Upload(upload::UploadStreamHandle  *handle,
-              upload::CharBuffer          *buffer,
-              const CallbackTN            *callback = NULL) {
+  void StreamedUpload(upload::UploadStreamHandle  *handle,
+                      upload::CharBuffer          *buffer,
+                      const CallbackTN            *callback = NULL) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
     assert(local_handle != NULL);
     local_handle->Append(buffer);
@@ -124,7 +124,7 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
   }
 
   void FinalizeStreamedUpload(upload::UploadStreamHandle *handle,
-                              const shash::Any            content_hash) {
+                              const shash::Any           &content_hash) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
     assert(local_handle != NULL);
 

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -55,9 +55,9 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     return true;
   }
 
-  void Upload(upload::UploadStreamHandle  *abstract_handle,
-              upload::CharBuffer          *buffer,
-              const CallbackTN            *callback = NULL) {
+  void StreamedUpload(upload::UploadStreamHandle  *abstract_handle,
+                      upload::CharBuffer          *buffer,
+                      const CallbackTN            *callback = NULL) {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->uploads++;
@@ -65,7 +65,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
   }
 
   void FinalizeStreamedUpload(upload::UploadStreamHandle *abstract_handle,
-                              const shash::Any            content_hash) {
+                              const shash::Any           &content_hash) {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->commits++;

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -144,27 +144,7 @@ class AbstractMockUploader : public upload::AbstractUploader {
   void WorkerThread() {
     worker_thread_running = true;
 
-    bool running = true;
-    while (running) {
-      UploadJob job = AcquireNewJob();
-      switch (job.type) {
-        case UploadJob::Upload:
-          Upload(job.stream_handle,
-                 job.buffer,
-                 job.callback);
-          break;
-        case UploadJob::Commit:
-          FinalizeStreamedUpload(job.stream_handle,
-                                 job.content_hash);
-          break;
-        case UploadJob::Terminate:
-          running = false;
-          break;
-        default:
-          assert(AbstractMockUploader::not_implemented);
-          break;
-      }
-    }
+    while (PerformJob() != JobStatus::kTerminate);
 
     worker_thread_running = false;
   }
@@ -181,14 +161,14 @@ class AbstractMockUploader : public upload::AbstractUploader {
     return NULL;
   }
 
-  virtual void Upload(upload::UploadStreamHandle  *handle,
-                      upload::CharBuffer          *buffer,
-                      const CallbackTN            *callback = NULL) {
+  virtual void StreamedUpload(upload::UploadStreamHandle  *handle,
+                              upload::CharBuffer          *buffer,
+                              const CallbackTN            *callback = NULL) {
     assert(AbstractMockUploader::not_implemented);
   }
 
   virtual void FinalizeStreamedUpload(upload::UploadStreamHandle *handle,
-                                      const shash::Any            content_hash)
+                                      const shash::Any           &content_hash)
   {
     assert(AbstractMockUploader::not_implemented);
   }

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -144,7 +144,7 @@ class AbstractMockUploader : public upload::AbstractUploader {
   void WorkerThread() {
     worker_thread_running = true;
 
-    while (PerformJob() != JobStatus::kTerminate);
+    AbstractUploader::WorkerThread();
 
     worker_thread_running = false;
   }


### PR DESCRIPTION
This centralises some code paths that have been duplicated in concrete implementations of `AbstractUploader`. Especially handling `Job` acquisition and dispatching, `AbstractUploader` event loop and temporary file handling. This is a spin-off of the implementation of the `LevelDbUploader` class.