### PR TITLE
Feature: Upload to LevelDB

### DIFF
--- a/add-ons/leveldb_reader.py
+++ b/add-ons/leveldb_reader.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import plyvel
+import shlex
+import hashlib
+import struct
+
+class CvmfsLevelDB:
+    """ Allows read access to a CernVM-FS LevelDB hive given a CernVM-FS
+        LevelDB configuration file.
+
+        Example of a typical CernVM-FS LevelDB configuration file:
+
+        ::
+
+            CVMFS_LEVELDB_STORAGE=/tmp/lvldb  # base storage directory
+            CVMFS_LEVELDB_COUNT=5             # number of LevelDB shards
+            CVMFS_LEVELDB_COMPRESSION="none"  # compression algorithm used
+    """
+
+    _mandatory_config_variables = [ "CVMFS_LEVELDB_STORAGE",
+                                    "CVMFS_LEVELDB_COUNT" ]
+    _optional_config_variables = [ "CVMFS_LEVELDB_COMPRESSION" ]
+
+    def __init__(self, configuration):
+        """ Connects to a CernVM-FS LevelDB hive
+
+            :param configuration:  path to the configuration file to use
+        """
+        self.config    = self._parse_config(configuration)
+        self.databases = []
+        self._verify_config()
+        self._open_databases()
+
+    def get(self, key):
+        """ Gets the data for a key from the CernVM-FS LevelDB hive
+
+            :param key:  the key whose data is to be fetched
+            :return:     the data or None if key doesn't exist
+        """
+        database = self._get_database_for_key(key)
+        return database.get(key)
+
+    def _open_databases(self):
+        for i in range(int(self.config["CVMFS_LEVELDB_COUNT"])):
+            db_name = "%s/lvldb%03d" % (self.config["CVMFS_LEVELDB_STORAGE"], i)
+            db = plyvel.DB(db_name, create_if_missing=False)
+            self.databases.append(db)
+
+    def _parse_config(self, configuration):
+        with open(configuration) as config_file:
+            lexer = shlex.shlex(config_file)
+            lexer.wordchars = ("!$%&()*+,-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRS"
+                               "TUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~")
+
+            config = {}
+            while True:
+                cfg_var = lexer.get_token()
+                equal   = lexer.get_token()
+                value   = lexer.get_token()
+
+                if not cfg_var or not equal or not value:
+                    break
+
+                if cfg_var not in self._mandatory_config_variables and \
+                   cfg_var not in self._optional_config_variables:
+                    raise Exception("unknown config variable " + cfg_var +
+                                    " in " + configuration)
+
+                if equal != "=":
+                    raise Exception("expected = in " + configuration + " : " +
+                                    lexer.lineno)
+
+                if value.startswith('"')  and value.endswith('"') or \
+                   value.startswith('\'') and value.endswith('\''):
+                    value = value[1:-1]
+
+                config[cfg_var] = value
+
+        return config
+
+    def _verify_config(self):
+        for mandatory in self._mandatory_config_variables:
+            if mandatory not in self.config:
+                raise Exception(mandatory + " config variable not set")
+
+    def _get_database_for_key(self, key):
+        h = hashlib.md5(key)
+        shash = struct.unpack("I", h.digest()[0:4])[0]
+        return self.databases[shash % int(self.config["CVMFS_LEVELDB_COUNT"])]

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -523,6 +523,10 @@ if (BUILD_SERVER)
     add_dependencies (cvmfs_swissknife libtbb)
   endif (TBB_PRIVATE_LIB)
 
+  if (LEVELDB_BUILTIN)
+    add_dependencies (cvmfs_swissknife libleveldb)
+  endif (LEVELDB_BUILTIN)
+
   add_dependencies (cvmfs_swissknife libsha3)
 
   set_target_properties (cvmfs_swissknife PROPERTIES COMPILE_FLAGS "${CVMFS_SWISSKNIFE_CFLAGS}" LINK_FLAGS "${CVMFS_SWISSKNIFE_LD_FLAGS}")
@@ -533,7 +537,8 @@ if (BUILD_SERVER)
                          ${CARES_LIBRARIES} ${CARES_ARCHIVE} ${TBB_LIBRARIES}
                          ${ZLIB_LIBRARIES} ${ZLIB_ARCHIVE} ${OPENSSL_LIBRARIES}
                          ${SQLITE3_ARCHIVE} ${RT_LIBRARY} ${VJSON_ARCHIVE}
-                         ${SHA3_ARCHIVE} ${CAP_LIBRARIES} pthread dl)
+                         ${SHA3_ARCHIVE} ${CAP_LIBRARIES} ${LEVELDB_LIBRARIES}
+                         ${LEVELDB_ARCHIVE} pthread dl)
 
   if (BUILD_SERVER_DEBUG)
     add_executable (cvmfs_swissknife_debug ${CVMFS_SWISSKNIFE_DEBUG_SOURCES})
@@ -554,6 +559,10 @@ if (BUILD_SERVER)
       add_dependencies (cvmfs_swissknife_debug libtbb)
     endif (TBB_PRIVATE_LIB)
 
+    if (LEVELDB_BUILTIN)
+      add_dependencies (cvmfs_swissknife_debug libleveldb)
+    endif (LEVELDB_BUILTIN)
+
     add_dependencies (cvmfs_swissknife_debug libsha3)
 
     set_target_properties (cvmfs_swissknife_debug PROPERTIES COMPILE_FLAGS "${CVMFS_SWISSKNIFE_DEBUG_CFLAGS}" LINK_FLAGS "${CVMFS_SWISSKNIFE_DEBUG_LD_FLAGS}")
@@ -568,7 +577,8 @@ if (BUILD_SERVER)
                            ${CARES_LIBRARIES} ${CARES_ARCHIVE} ${TBB_DEBUG_LIBRARIES}
                            ${ZLIB_LIBRARIES} ${ZLIB_ARCHIVE} ${OPENSSL_LIBRARIES}
                            ${SQLITE3_ARCHIVE} ${RT_LIBRARY} ${VJSON_ARCHIVE}
-                           ${SHA3_ARCHIVE} ${CAP_LIBRARIES} pthread dl)
+                           ${SHA3_ARCHIVE} ${CAP_LIBRARIES} ${LEVELDB_LIBRARIES}
+                           ${LEVELDB_ARCHIVE} pthread dl)
   endif (BUILD_SERVER_DEBUG)
 endif (BUILD_SERVER)
 

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -310,6 +310,7 @@ set (CVMFS_PRELOADER_SOURCES
   upload_facility.cc upload_facility.h
   upload_local.cc upload_local.h
   upload_s3.cc upload_s3.h
+  upload_leveldb.cc upload_leveldb.h
   upload_spooler_definition.cc upload_spooler_definition.h
   util/algorithm.cc util/algorithm.h
   util/buffer.h
@@ -614,6 +615,10 @@ if (BUILD_PRELOADER)
     add_dependencies (cvmfs_preload_bin libtbb)
   endif (TBB_PRIVATE_LIB)
 
+  if (LEVELDB_BUILTIN)
+    add_dependencies (cvmfs_preload_bin libleveldb)
+  endif (LEVELDB_BUILTIN)
+
   add_dependencies (cvmfs_preload_bin libsha3)
   add_dependencies (cvmfs_preload_bin libvjson)
 
@@ -621,8 +626,8 @@ if (BUILD_PRELOADER)
                         ${CURL_LIBRARIES} ${LIBCURL_ARCHIVE} ${ZLIB_LIBRARIES}
                         ${OPENSSL_LIBRARIES} ${CARES_ARCHIVE} ${SQLITE3_ARCHIVE}
                         ${ZLIB_ARCHIVE} ${TBB_LIBRARIES} ${RT_LIBRARY}
-                        ${VJSON_ARCHIVE} ${SHA3_ARCHIVE}
-                        pthread dl)
+                        ${VJSON_ARCHIVE} ${SHA3_ARCHIVE} ${LEVELDB_LIBRARIES}
+                        ${LEVELDB_ARCHIVE} pthread dl)
 endif (BUILD_PRELOADER)
 
 #

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -230,6 +230,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
   upload_facility.cc upload_facility.h
   upload_local.cc upload_local.h
   upload_s3.cc upload_s3.h
+  upload_leveldb.cc upload_leveldb.h
   upload_spooler_definition.cc upload_spooler_definition.h
   upload_spooler_result.h
   util/algorithm.cc util/algorithm.h

--- a/cvmfs/logging.cc
+++ b/cvmfs/logging.cc
@@ -51,7 +51,7 @@ const char *module_names[] = { "unknown", "cache", "catalog", "sql", "cvmfs",
   "fuse stub", "signature", "fs traversal", "catalog traversal",
   "nfs maps", "publish", "spooler", "concurrency", "utility", "glue buffer",
   "history", "unionfs", "pathspec", "upload s3", "s3fanout", "gc", "dns",
-  "voms", "reflog" };
+  "voms", "reflog", "upload leveldb" };
 int syslog_facility = LOG_USER;
 int syslog_level = LOG_NOTICE;
 char *syslog_prefix = NULL;

--- a/cvmfs/logging_internal.h
+++ b/cvmfs/logging_internal.h
@@ -70,7 +70,8 @@ enum LogSource {
   kLogGc,
   kLogDns,
   kLogVoms,
-  kLogReflog
+  kLogReflog,
+  kLogUploadLevelDb
 };
 
 const int kLogVerboseMsg = kLogStdout | kLogShowSource | kLogVerbose;

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -44,6 +44,13 @@ bool AbstractUploader::Initialize() {
 }
 
 
+void AbstractUploader::WorkerThread() {
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread started.");
+  while (PerformJob() != JobStatus::kTerminate);
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread exited.");
+}
+
+
 AbstractUploader::JobStatus::State AbstractUploader::DispatchJob(
                                                          const UploadJob &job) {
   switch (job.type) {

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -44,6 +44,30 @@ bool AbstractUploader::Initialize() {
 }
 
 
+AbstractUploader::JobStatus::State AbstractUploader::DispatchJob(
+                                                         const UploadJob &job) {
+  switch (job.type) {
+    case UploadJob::Upload:
+      StreamedUpload(job.stream_handle,
+                     job.buffer,
+                     job.callback);
+      return JobStatus::kOk;
+
+    case UploadJob::Commit:
+      FinalizeStreamedUpload(job.stream_handle, job.content_hash);
+      return JobStatus::kOk;
+
+    case UploadJob::Terminate:
+      return JobStatus::kTerminate;
+
+    default:
+      const bool unknown_job_type = false;
+      assert(unknown_job_type);
+      return JobStatus::kTerminate;
+  }
+}
+
+
 void AbstractUploader::TearDown() {
   assert(!torn_down_);
   upload_queue_.push(UploadJob());  // Termination signal

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -6,12 +6,14 @@
 
 #include <cassert>
 
+#include "upload_leveldb.h"
 #include "upload_local.h"
 #include "upload_s3.h"
 
 namespace upload {
 
 void AbstractUploader::RegisterPlugins() {
+  RegisterPlugin<LevelDbUploader>();
   RegisterPlugin<LocalUploader>();
   RegisterPlugin<S3Uploader>();
 }

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -72,7 +72,7 @@ int AbstractUploader::CreateAndOpenTemporaryChunkFile(std::string *path) const {
 
 void AbstractUploader::WorkerThread() {
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread started.");
-  while (PerformJob() != JobStatus::kTerminate);
+  while (PerformJob() != JobStatus::kTerminate) {}
   LogCvmfs(kLogSpooler, kLogVerboseMsg, "Uploader WorkerThread exited.");
 }
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -371,7 +371,7 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
    * make sure to exit that method if and only if you receive an UploadJob like:
    *   UploadJob.type == UploadJob::Terminate
    */
-  virtual void WorkerThread() = 0;
+  virtual void WorkerThread();
 
 
   /**

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -5,16 +5,16 @@
 #ifndef CVMFS_UPLOAD_FACILITY_H_
 #define CVMFS_UPLOAD_FACILITY_H_
 
+#include <fcntl.h>
+
 #include <tbb/concurrent_queue.h>
 #include <tbb/tbb_thread.h>
-
-#include <fcntl.h>
 
 #include <string>
 
 #include "upload_spooler_definition.h"
-#include "util_concurrency.h"
 #include "util/posix.h"
+#include "util_concurrency.h"
 
 namespace upload {
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -362,14 +362,11 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
 
 
   /**
-   * This purely virtual function is called once the AbstractUploader has started
-   * its dedicated writer thread. Overwrite this method to implement your event
-   * loop that is supposed to run in its own thread. In this event loop you are
-   * supposed to pull upload jobs using AbstractUploader::AcquireNewJob().
-   *
-   * If this method returns, AbstractUploader's write thread is terminated, so
-   * make sure to exit that method if and only if you receive an UploadJob like:
-   *   UploadJob.type == UploadJob::Terminate
+   * This virtual function is called once the AbstractUploader has started its
+   * dedicated writer thread. Overwrite this method to implement your own event
+   * loop. You must call AbstractUploader::PerformJob() or ::TryToPerformJob()
+   * in an endless loop until either of those returns JobState::kTerminate.
+   * AbstractUploader's write thread is terminated when this method returns.
    */
   virtual void WorkerThread();
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -8,10 +8,13 @@
 #include <tbb/concurrent_queue.h>
 #include <tbb/tbb_thread.h>
 
+#include <fcntl.h>
+
 #include <string>
 
 #include "upload_spooler_definition.h"
 #include "util_concurrency.h"
+#include "util/posix.h"
 
 namespace upload {
 
@@ -359,6 +362,17 @@ class AbstractUploader : public PolymorphicConstruction<AbstractUploader,
       ? DispatchJob(job)
       : JobStatus::kNoJobs;
   }
+
+
+  /**
+   * Creates a temporary file in the backend storage's temporary location
+   * For the LocalUploader this usually is the 'txn' directory of the backend
+   * storage. Otherwise it is some scratch area.
+   *
+   * @param path   pointer to a string that will contain the created file path
+   * @return       a file descriptor to the opened file
+   */
+  int CreateAndOpenTemporaryChunkFile(std::string *path) const;
 
 
   /**

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -234,8 +234,19 @@ void LevelDbUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
 }
 
 
-bool LevelDbUploader::Remove(const std::string& file_to_delete) {
-  return false;
+bool LevelDbUploader::Remove(const std::string& path) {
+  LevelDbHandle& handle = GetDatabaseForPath(path);
+
+  leveldb::WriteOptions write_options;
+  leveldb::Status status = handle->Delete(write_options, path);
+
+  if (!status.ok()) {
+    LogCvmfs(kLogUploadLevelDb, kLogStderr, "failed to delete '%s' in LevelDB",
+             path.c_str());
+    return false;
+  }
+
+  return true;
 }
 
 

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -284,7 +284,8 @@ bool LevelDbUploader::Peek(const std::string& path) const {
 }
 
 
-bool LevelDbUploader::PlaceBootstrappingShortcut(const shash::Any &object) const {
+bool LevelDbUploader::PlaceBootstrappingShortcut(const shash::Any &object) const
+{
   return false;
 }
 

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -66,6 +66,22 @@ bool LevelDbUploader::ParseConfiguration(const std::string &config_path) {
     return false;
   }
 
+  std::string compression;
+  if (!options_manager.GetValue("CVMFS_LEVELDB_COMPRESSION", &compression)) {
+    compression = "none";  // default
+  }
+
+  if (compression == "none") {
+    compression_ = leveldb::kNoCompression;
+  } else if (compression == "snappy") {
+    compression_ = leveldb::kSnappyCompression;
+  } else {
+    LogCvmfs(kLogUploadLevelDb, kLogStderr,
+             "unknown compression method '%s' in CVMFS_LEVELDB_COMPRESSION",
+             compression.c_str());
+    return false;
+  }
+
   return true;
 }
 

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -216,14 +216,14 @@ UploadStreamHandle* LevelDbUploader::InitStreamedUpload(
 
 
 void LevelDbUploader::Upload(UploadStreamHandle  *handle,
-                           CharBuffer          *buffer,
-                           const CallbackTN    *callback) {
+                             CharBuffer          *buffer,
+                             const CallbackTN    *callback) {
   Respond(callback, UploaderResults(1, buffer));
 }
 
 
 void LevelDbUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
-                                           const shash::Any    &content_hash) {
+                                             const shash::Any    &content_hash) {
   LevelDbStreamHandle *leveldb_handle =
                                       static_cast<LevelDbStreamHandle*>(handle);
   const CallbackTN *callback = handle->commit_callback;

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -134,7 +134,8 @@ void LevelDbUploader::CloseDatabases() {
 }
 
 
-LevelDbHandle& LevelDbUploader::GetDatabaseForPath(const std::string &path) {
+LevelDbHandle& LevelDbUploader::GetDatabaseForPath(
+                                                const std::string &path) const {
   shash::Any h(shash::kMd5);
   HashString(path, &h);
   const uint32_t shorthash = *reinterpret_cast<uint32_t*>(h.digest);

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -148,36 +148,6 @@ unsigned int LevelDbUploader::GetNumberOfErrors() const {
 }
 
 
-void LevelDbUploader::WorkerThread() {
-  bool running = true;
-
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "LevelDb WorkerThread started.");
-
-  while (running) {
-    UploadJob job = AcquireNewJob();
-    switch (job.type) {
-      case UploadJob::Upload:
-        Upload(job.stream_handle,
-               job.buffer,
-               job.callback);
-        break;
-      case UploadJob::Commit:
-        FinalizeStreamedUpload(job.stream_handle, job.content_hash);
-        break;
-      case UploadJob::Terminate:
-        running = false;
-        break;
-      default:
-        const bool unknown_job_type = false;
-        assert(unknown_job_type);
-        break;
-    }
-  }
-
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "LevelDb WorkerThread exited.");
-}
-
-
 void LevelDbUploader::FileUpload(
   const std::string &local_path,
   const std::string &remote_path,
@@ -216,9 +186,9 @@ UploadStreamHandle* LevelDbUploader::InitStreamedUpload(
 }
 
 
-void LevelDbUploader::Upload(UploadStreamHandle  *handle,
-                             CharBuffer          *buffer,
-                             const CallbackTN    *callback) {
+void LevelDbUploader::StreamedUpload(UploadStreamHandle  *handle,
+                                     CharBuffer          *buffer,
+                                     const CallbackTN    *callback) {
   Respond(callback, UploaderResults(1, buffer));
 }
 

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -7,9 +7,9 @@
 #include "file_processing/char_buffer.h"
 #include "hash.h"
 #include "options.h"
+#include "util/mmap_file.h"
 #include "util/posix.h"
 #include "util/string.h"
-#include "util/mmap_file.h"
 
 namespace upload {
 

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -1,0 +1,104 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "upload_leveldb.h"
+
+namespace upload {
+
+LevelDbUploader::LevelDbUploader(const SpoolerDefinition &spooler_definition) :
+  AbstractUploader(spooler_definition)
+{
+  assert(spooler_definition.IsValid() &&
+         spooler_definition.driver_type == SpoolerDefinition::LevelDb);
+}
+
+bool LevelDbUploader::WillHandle(const SpoolerDefinition &spooler_definition) {
+  return spooler_definition.driver_type == SpoolerDefinition::LevelDb;
+}
+
+
+unsigned int LevelDbUploader::GetNumberOfErrors() const {
+  return 0;  // TODO(rmeusel): implement me
+}
+
+
+void LevelDbUploader::WorkerThread() {
+  bool running = true;
+
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "LevelDb WorkerThread started.");
+
+  while (running) {
+    UploadJob job = AcquireNewJob();
+    switch (job.type) {
+      case UploadJob::Upload:
+        Upload(job.stream_handle,
+               job.buffer,
+               job.callback);
+        break;
+      case UploadJob::Commit:
+        FinalizeStreamedUpload(job.stream_handle, job.content_hash);
+        break;
+      case UploadJob::Terminate:
+        running = false;
+        break;
+      default:
+        const bool unknown_job_type = false;
+        assert(unknown_job_type);
+        break;
+    }
+  }
+
+  LogCvmfs(kLogSpooler, kLogVerboseMsg, "LevelDb WorkerThread exited.");
+}
+
+
+void LevelDbUploader::FileUpload(
+  const std::string &local_path,
+  const std::string &remote_path,
+  const CallbackTN   *callback
+) {
+  Respond(callback, UploaderResults(1, local_path));
+}
+
+
+UploadStreamHandle* LevelDbUploader::InitStreamedUpload(
+                                                   const CallbackTN *callback) {
+  return new LevelDbStreamHandle(callback);
+}
+
+
+void LevelDbUploader::Upload(UploadStreamHandle  *handle,
+                           CharBuffer          *buffer,
+                           const CallbackTN    *callback) {
+  Respond(callback, UploaderResults(1, buffer));
+}
+
+
+void LevelDbUploader::FinalizeStreamedUpload(UploadStreamHandle  *handle,
+                                           const shash::Any    &content_hash) {
+  LevelDbStreamHandle *leveldb_handle =
+                                      static_cast<LevelDbStreamHandle*>(handle);
+  const CallbackTN *callback = handle->commit_callback;
+  delete leveldb_handle;
+
+  Respond(callback, UploaderResults(1));
+}
+
+
+bool LevelDbUploader::Remove(const std::string& file_to_delete) {
+  return false;
+}
+
+
+bool LevelDbUploader::Peek(const std::string& path) const {
+  return false;
+}
+
+
+bool LevelDbUploader::PlaceBootstrappingShortcut(const shash::Any &object) const {
+  return false;
+}
+
+
+}  // namespace upload

--- a/cvmfs/upload_leveldb.cc
+++ b/cvmfs/upload_leveldb.cc
@@ -240,7 +240,20 @@ bool LevelDbUploader::Remove(const std::string& file_to_delete) {
 
 
 bool LevelDbUploader::Peek(const std::string& path) const {
-  return false;
+  LevelDbHandle& handle = GetDatabaseForPath(path);
+
+  leveldb::ReadOptions read_options;
+  read_options.fill_cache = false;
+  std::string buffer;
+  leveldb::Status status = handle->Get(read_options, path, &buffer);
+
+  if (!status.ok() && !status.IsNotFound()) {
+    LogCvmfs(kLogUploadLevelDb, kLogStderr, "failed to peek '%s' in LevelDB",
+             path.c_str());
+    return false;
+  }
+
+  return status.ok();
 }
 
 

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -59,9 +59,9 @@ class LevelDbUploader : public AbstractUploader {
                   const CallbackTN   *callback = NULL);
 
   UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
-  void Upload(UploadStreamHandle  *handle,
-              CharBuffer          *buffer,
-              const CallbackTN    *callback = NULL);
+  void StreamedUpload(UploadStreamHandle  *handle,
+                      CharBuffer          *buffer,
+                      const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                               const shash::Any    &content_hash);
 
@@ -76,9 +76,6 @@ class LevelDbUploader : public AbstractUploader {
    * well as in the Upload() command.
    */
   unsigned int GetNumberOfErrors() const;
-
- protected:
-  void WorkerThread();
 
  private:
   bool ParseConfiguration(const std::string &config_path);

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -65,7 +65,7 @@ class LevelDbUploader : public AbstractUploader {
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                               const shash::Any    &content_hash);
 
-  bool Remove(const std::string &file_to_delete);
+  bool Remove(const std::string &path);
 
   bool Peek(const std::string& path) const;
 

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -8,11 +8,11 @@
 #include <sys/stat.h>
 
 #include <string>
-
-#include <leveldb/db.h>
-#include <leveldb/options.h>
+#include <vector>
 
 #include "atomic.h"
+#include "leveldb/db.h"
+#include "leveldb/options.h"
 #include "upload_facility.h"
 #include "util_concurrency.h"
 

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -31,6 +31,8 @@ class LevelDbUploader : public AbstractUploader {
   explicit LevelDbUploader(const SpoolerDefinition &spooler_definition);
   static bool WillHandle(const SpoolerDefinition &spooler_definition);
 
+  bool Initialize();
+
   inline std::string name() const { return "LevelDB"; }
 
   void FileUpload(const std::string  &local_path,
@@ -58,6 +60,13 @@ class LevelDbUploader : public AbstractUploader {
 
  protected:
   void WorkerThread();
+
+ private:
+  bool ParseConfiguration(const std::string &config_path);
+
+ private:
+  std::string base_path_;
+  unsigned    database_count_;
 };
 
 }  // namespace upload

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -1,0 +1,65 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_UPLOAD_LEVELDB_H_
+#define CVMFS_UPLOAD_LEVELDB_H_
+
+#include <sys/stat.h>
+
+#include <string>
+
+#include "atomic.h"
+#include "upload_facility.h"
+#include "util_concurrency.h"
+
+namespace upload {
+
+struct LevelDbStreamHandle : public UploadStreamHandle {
+  LevelDbStreamHandle(const CallbackTN *commit_callback) :
+    UploadStreamHandle(commit_callback) {}
+};
+
+/**
+ * The LevelDbUploader implements the AbstractUploader interface to push files
+ * into one or multiple LevelDB.
+ * For a detailed description of the classes interface please have a look into
+ * the AbstractUploader base class.
+ */
+class LevelDbUploader : public AbstractUploader {
+ public:
+  explicit LevelDbUploader(const SpoolerDefinition &spooler_definition);
+  static bool WillHandle(const SpoolerDefinition &spooler_definition);
+
+  inline std::string name() const { return "LevelDB"; }
+
+  void FileUpload(const std::string  &local_path,
+                  const std::string  &remote_path,
+                  const CallbackTN   *callback = NULL);
+
+  UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
+  void Upload(UploadStreamHandle  *handle,
+              CharBuffer          *buffer,
+              const CallbackTN    *callback = NULL);
+  void FinalizeStreamedUpload(UploadStreamHandle  *handle,
+                              const shash::Any    &content_hash);
+
+  bool Remove(const std::string &file_to_delete);
+
+  bool Peek(const std::string& path) const;
+
+  bool PlaceBootstrappingShortcut(const shash::Any &object) const;
+
+  /**
+   * Determines the number of failed jobs in the LocalCompressionWorker as
+   * well as in the Upload() command.
+   */
+  unsigned int GetNumberOfErrors() const;
+
+ protected:
+  void WorkerThread();
+};
+
+}  // namespace upload
+
+#endif  // CVMFS_UPLOAD_LEVELDB_H_

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -32,7 +32,7 @@ struct LevelDbStreamHandle : public UploadStreamHandle {
 
 class LevelDbHandle {
  public:
-  LevelDbHandle(leveldb::DB *database) : database_(database) { }
+  explicit LevelDbHandle(leveldb::DB *database) : database_(database) { }
 
   void Close() { delete database_; database_ = NULL; }
   leveldb::DB* operator->() const { return database_; }

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -85,7 +85,7 @@ class LevelDbUploader : public AbstractUploader {
   bool OpenDatabases();
   void CloseDatabases();
 
-  LevelDbHandle& GetDatabaseForPath(const std::string &path);
+  LevelDbHandle& GetDatabaseForPath(const std::string &path) const;
 
   friend class LevelDbUploaderTestWrapper;
 
@@ -94,7 +94,7 @@ class LevelDbUploader : public AbstractUploader {
   unsigned                  database_count_;
   leveldb::CompressionType  compression_;
 
-  LevelDbHandles            databases_;
+  mutable LevelDbHandles    databases_;
 };
 
 

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -87,12 +87,27 @@ class LevelDbUploader : public AbstractUploader {
 
   LevelDbHandle& GetDatabaseForPath(const std::string &path);
 
+  friend class LevelDbUploaderTestWrapper;
+
  private:
   std::string               base_path_;
   unsigned                  database_count_;
   leveldb::CompressionType  compression_;
 
   LevelDbHandles            databases_;
+};
+
+
+/**
+ * For unit-testing purposes only!
+ */
+class LevelDbUploaderTestWrapper {
+ public:
+  static LevelDbHandle& GetLevelDbHandleForPath(LevelDbUploader    *uploader,
+                                                const std::string  &remote_path)
+  {
+    return uploader->GetDatabaseForPath(remote_path);
+  }
 };
 
 }  // namespace upload

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -83,6 +83,7 @@ class LevelDbUploader : public AbstractUploader {
   void CloseDatabases();
 
   LevelDbHandle& GetDatabaseForPath(const std::string &path) const;
+  int PutFile(const std::string &local_path, const std::string &remote_path);
 
   friend class LevelDbUploaderTestWrapper;
 

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -9,6 +9,8 @@
 
 #include <string>
 
+#include <leveldb/options.h>
+
 #include "atomic.h"
 #include "upload_facility.h"
 #include "util_concurrency.h"
@@ -65,8 +67,9 @@ class LevelDbUploader : public AbstractUploader {
   bool ParseConfiguration(const std::string &config_path);
 
  private:
-  std::string base_path_;
-  unsigned    database_count_;
+  std::string               base_path_;
+  unsigned                  database_count_;
+  leveldb::CompressionType  compression_;
 };
 
 }  // namespace upload

--- a/cvmfs/upload_leveldb.h
+++ b/cvmfs/upload_leveldb.h
@@ -19,8 +19,15 @@
 namespace upload {
 
 struct LevelDbStreamHandle : public UploadStreamHandle {
-  LevelDbStreamHandle(const CallbackTN *commit_callback) :
-    UploadStreamHandle(commit_callback) {}
+  LevelDbStreamHandle(const CallbackTN   *commit_callback,
+                      const int           tmp_fd,
+                      const std::string  &tmp_path)
+    : UploadStreamHandle(commit_callback)
+    , file_descriptor(tmp_fd)
+    , temporary_path(tmp_path) {}
+
+  const int         file_descriptor;
+  const std::string temporary_path;
 };
 
 class LevelDbHandle {

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -42,15 +42,6 @@ unsigned int LocalUploader::GetNumberOfErrors() const {
 }
 
 
-void LocalUploader::WorkerThread() {
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Local WorkerThread started.");
-
-  while (PerformJob() != JobStatus::kTerminate);
-
-  LogCvmfs(kLogSpooler, kLogVerboseMsg, "Local WorkerThread exited.");
-}
-
-
 void LocalUploader::FileUpload(
   const std::string &local_path,
   const std::string &remote_path,

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -75,8 +75,6 @@ class LocalUploader : public AbstractUploader {
   unsigned int GetNumberOfErrors() const;
 
  protected:
-  void WorkerThread();
-
   int Move(const std::string &local_path,
            const std::string &remote_path) const;
 

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -56,9 +56,9 @@ class LocalUploader : public AbstractUploader {
                   const CallbackTN   *callback = NULL);
 
   UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
-  void Upload(UploadStreamHandle  *handle,
-              CharBuffer          *buffer,
-              const CallbackTN    *callback = NULL);
+  void StreamedUpload(UploadStreamHandle  *handle,
+                      CharBuffer          *buffer,
+                      const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                               const shash::Any    &content_hash);
 

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -78,8 +78,6 @@ class LocalUploader : public AbstractUploader {
   int Move(const std::string &local_path,
            const std::string &remote_path) const;
 
-  int CreateAndOpenTemporaryChunkFile(std::string *path) const;
-
  private:
   // state information
   const std::string    upstream_path_;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -53,9 +53,9 @@ class S3Uploader : public AbstractUploader {
                   const CallbackTN   *callback = NULL);
 
   UploadStreamHandle* InitStreamedUpload(const CallbackTN *callback = NULL);
-  void Upload(UploadStreamHandle  *handle,
-              CharBuffer          *buffer,
-              const CallbackTN    *callback = NULL);
+  void StreamedUpload(UploadStreamHandle  *handle,
+                      CharBuffer          *buffer,
+                      const CallbackTN    *callback = NULL);
   void FinalizeStreamedUpload(UploadStreamHandle  *handle,
                               const shash::Any    &content_hash);
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -72,8 +72,6 @@ class S3Uploader : public AbstractUploader {
  protected:
   void WorkerThread();
 
-  int CreateAndOpenTemporaryChunkFile(std::string *path) const;
-
  private:
   bool ParseSpoolerDefinition(const SpoolerDefinition &spooler_definition);
   bool UploadJobInfo(s3fanout::JobInfo *info);

--- a/cvmfs/upload_spooler_definition.cc
+++ b/cvmfs/upload_spooler_definition.cc
@@ -50,6 +50,8 @@ SpoolerDefinition::SpoolerDefinition(
     driver_type = Local;
   } else if (upstream[0] == "S3") {
     driver_type = S3;
+  } else if (upstream[0] == "leveldb") {
+    driver_type = LevelDb;
   } else if (upstream[0] == "mock") {
     driver_type = Mock;  // for unit testing purpose only!
   } else {

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -23,6 +23,7 @@ struct SpoolerDefinition {
   enum DriverType {
     S3,
     Local,
+    LevelDb,
     Mock,
     Unknown
   };

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -447,6 +448,19 @@ string ReplaceAll(const string &haystack, const string &needle,
 
   while ((pos = result.find(needle, pos)) != string::npos)
     result.replace(pos, needle_size, replace_by);
+  return result;
+}
+
+
+std::string PaddingLeft(const std::string &input, const unsigned length,
+                        char padding_character) {
+  assert(input.size() <= length);
+  if (length == input.size()) {
+    return input;
+  }
+
+  std::string result(length, padding_character);
+  result.replace(length - input.size(), input.size(), input);
   return result;
 }
 

--- a/cvmfs/util/string.h
+++ b/cvmfs/util/string.h
@@ -55,6 +55,8 @@ std::string Trim(const std::string &raw);
 std::string ToUpper(const std::string &mixed_case);
 std::string ReplaceAll(const std::string &haystack, const std::string &needle,
                        const std::string &replace_by);
+std::string PaddingLeft(const std::string &input, const unsigned length,
+                        char padding_character);
 
 std::string Base64(const std::string &data);
 bool Debase64(const std::string &data, std::string *decoded);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -241,6 +241,10 @@ if (BUILD_UNITTESTS)
   if (TBB_PRIVATE_LIB)
     add_dependencies (${PROJECT_TEST_NAME} libtbb)
   endif (TBB_PRIVATE_LIB)
+
+  if (LEVELDB_BUILTIN)
+    add_dependencies (${PROJECT_TEST_NAME} libleveldb)
+  endif (LEVELDB_BUILTIN)
 endif (BUILD_UNITTESTS)
 
 if (BUILD_UNITTESTS_DEBUG)
@@ -264,6 +268,10 @@ if (BUILD_UNITTESTS_DEBUG)
     add_dependencies (${PROJECT_TEST_DEBUG_NAME} libtbb)
   endif (TBB_PRIVATE_LIB)
 
+  if (LEVELDB_BUILTIN)
+    add_dependencies (${PROJECT_TEST_DEBUG_NAME} libleveldb)
+  endif (LEVELDB_BUILTIN)
+
   add_dependencies (${PROJECT_TEST_DEBUG_NAME} libsha3)
 endif (BUILD_UNITTESTS_DEBUG)
 
@@ -283,8 +291,8 @@ set (UNITTEST_LINK_LIBRARIES ${GTEST_LIBRARIES} ${GOOGLETEST_ARCHIVE} ${OPENSSL_
                              ${LIBCURL_ARCHIVE} ${CARES_LIBRARIES} ${CARES_ARCHIVE} ${OPENSSL_LIBRARIES}
                              ${SQLITE3_LIBRARY} ${SQLITE3_ARCHIVE} ${TBB_LIBRARIES}
                              ${ZLIB_LIBRARIES} ${ZLIB_ARCHIVE} ${RT_LIBRARY} ${UUID_LIBRARIES}
-                             ${SHA3_ARCHIVE} ${PACPARSER_LIBRARIES} ${PACPARSER_ARCHIVE}
-                             pthread dl)
+                             ${SHA3_ARCHIVE} ${PACPARSER_LIBRARIES} ${PACPARSER_ARCHIVE} ${LEVELDB_LIBRARIES}
+                             ${LEVELDB_ARCHIVE} pthread dl)
 
 target_link_libraries (${PROJECT_TEST_NAME} ${UNITTEST_LINK_LIBRARIES})
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -159,6 +159,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/tracer.cc ${CVMFS_SOURCE_DIR}/tracer.h
   ${CVMFS_SOURCE_DIR}/uid_map.h
   ${CVMFS_SOURCE_DIR}/upload_facility.cc
+  ${CVMFS_SOURCE_DIR}/upload_leveldb.cc
   ${CVMFS_SOURCE_DIR}/upload_local.cc
   ${CVMFS_SOURCE_DIR}/upload_s3.cc
   ${CVMFS_SOURCE_DIR}/upload_spooler_definition.cc

--- a/test/unittests/t_file_processing.cc
+++ b/test/unittests/t_file_processing.cc
@@ -113,9 +113,9 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
     return new MockStreamHandle(callback);
   }
 
-  void Upload(upload::UploadStreamHandle  *handle,
-              upload::CharBuffer          *buffer,
-              const CallbackTN            *callback = NULL) {
+  void StreamedUpload(upload::UploadStreamHandle  *handle,
+                      upload::CharBuffer          *buffer,
+                      const CallbackTN            *callback = NULL) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
     assert(local_handle != NULL);
     local_handle->Append(buffer);
@@ -124,7 +124,7 @@ class FP_MockUploader : public AbstractMockUploader<FP_MockUploader> {
   }
 
   void FinalizeStreamedUpload(upload::UploadStreamHandle *handle,
-                              const shash::Any            content_hash) {
+                              const shash::Any           &content_hash) {
     MockStreamHandle *local_handle = dynamic_cast<MockStreamHandle*>(handle);
     assert(local_handle != NULL);
 

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -55,9 +55,9 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     return true;
   }
 
-  void Upload(upload::UploadStreamHandle  *abstract_handle,
-              upload::CharBuffer          *buffer,
-              const CallbackTN            *callback = NULL) {
+  void StreamedUpload(upload::UploadStreamHandle  *abstract_handle,
+                      upload::CharBuffer          *buffer,
+                      const CallbackTN            *callback = NULL) {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->uploads++;
@@ -65,7 +65,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
   }
 
   void FinalizeStreamedUpload(upload::UploadStreamHandle *abstract_handle,
-                              const shash::Any            content_hash) {
+                              const shash::Any           &content_hash) {
     UF_MockStreamHandle* handle =
                              static_cast<UF_MockStreamHandle*>(abstract_handle);
     handle->commits++;

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -16,6 +16,7 @@
 #include "hash.h"
 #include "testutil.h"
 #include "upload_facility.h"
+#include "upload_leveldb.h"
 #include "upload_local.h"
 #include "upload_s3.h"
 #include "upload_spooler_definition.h"
@@ -120,6 +121,11 @@ class T_Uploaders : public FileSandbox {
   }
 
 
+  virtual void SetUp(const type<upload::LevelDbUploader> type_specifier) {
+    // Empty, no specific needs
+  }
+
+
   virtual void SetUp(const type<upload::S3Uploader> type_specifier) {
     repo_alias = "testdata";
     CreateTempS3ConfigFile(10, 10);
@@ -140,6 +146,11 @@ class T_Uploaders : public FileSandbox {
 
 
   virtual void TearDown(const type<upload::LocalUploader> type_specifier) {
+    // Empty, no specific needs
+  }
+
+
+  virtual void TearDown(const type<upload::LevelDbUploader> type_specifier) {
     // Empty, no specific needs
   }
 
@@ -190,6 +201,16 @@ class T_Uploaders : public FileSandbox {
   std::string GetSpoolerDefinition(
       const type<upload::LocalUploader> type_specifier) const {
     const std::string spl_type   = "local";
+    const std::string spl_tmp    = T_Uploaders::tmp_dir;
+    const std::string spl_cfg    = T_Uploaders::dest_dir;
+    const std::string definition = spl_type + "," + spl_tmp + "," + spl_cfg;
+    return definition;
+  }
+
+
+  std::string GetSpoolerDefinition(
+      const type<upload::LevelDbUploader> type_specifier) const {
+    const std::string spl_type   = "leveldb";
     const std::string spl_tmp    = T_Uploaders::tmp_dir;
     const std::string spl_cfg    = T_Uploaders::dest_dir;
     const std::string definition = spl_type + "," + spl_tmp + "," + spl_cfg;
@@ -627,7 +648,7 @@ template <class UploadersT>
 const std::string T_Uploaders<UploadersT>::dest_dir =
     string(T_Uploaders::sandbox_path) + "/dest";
 
-typedef testing::Types<S3Uploader, LocalUploader> UploadTypes;
+typedef testing::Types<S3Uploader, LocalUploader, LevelDbUploader> UploadTypes;
 TYPED_TEST_CASE(T_Uploaders, UploadTypes);
 
 

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -392,6 +392,7 @@ class T_Uploaders : public FileSandbox {
 
 
   bool IsS3() const;
+  bool IsLevelDB() const;
 
  private:
   void CreateS3Mockup() {
@@ -691,6 +692,16 @@ bool T_Uploaders<T>::IsS3() const {
 
 template <>
 bool T_Uploaders<S3Uploader>::IsS3() const {
+  return true;
+}
+
+template <typename T>
+bool T_Uploaders<T>::IsLevelDB() const {
+  return false;
+}
+
+template <>
+bool T_Uploaders<LevelDbUploader>::IsLevelDB() const {
   return true;
 }
 
@@ -1021,9 +1032,9 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
 
 
 TYPED_TEST(T_Uploaders, PlaceBootstrappingShortcut) {
-  if (TestFixture::IsS3()) {
+  if (TestFixture::IsS3() || TestFixture::IsLevelDB()) {
     SUCCEED();  // TODO(rmeusel): enable this as soon as the feature is
-    return;     //                implemented for the S3Uploader
+    return;     //                implemented for the LevelDB and S3Uploaders
   }
 
   const std::string big_file_path = TestFixture::GetBigFile();

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -79,6 +79,7 @@ class T_Uploaders : public FileSandbox {
   static const std::string tmp_dir;
   std::string repo_alias;
   std::string s3_conf_path;
+  std::string leveldb_conf_path;
   template<typename> struct type {};
 
  public:
@@ -122,7 +123,7 @@ class T_Uploaders : public FileSandbox {
 
 
   virtual void SetUp(const type<upload::LevelDbUploader> type_specifier) {
-    // Empty, no specific needs
+    CreateTempLevelDbConfigFile(5);
   }
 
 
@@ -212,7 +213,7 @@ class T_Uploaders : public FileSandbox {
       const type<upload::LevelDbUploader> type_specifier) const {
     const std::string spl_type   = "leveldb";
     const std::string spl_tmp    = T_Uploaders::tmp_dir;
-    const std::string spl_cfg    = T_Uploaders::dest_dir;
+    const std::string spl_cfg    = T_Uploaders::leveldb_conf_path;
     const std::string definition = spl_type + "," + spl_tmp + "," + spl_cfg;
     return definition;
   }
@@ -574,6 +575,21 @@ class T_Uploaders : public FileSandbox {
 
     fprintf(s3_conf, "%s\n", conf_str.c_str());
     fclose(s3_conf);
+  }
+
+
+  void CreateTempLevelDbConfigFile(int database_count) {
+    ASSERT_GE(database_count, 1);
+    ASSERT_LE(database_count, 255);
+    FILE *leveldb_conf = CreateTempFile(T_Uploaders::tmp_dir + "/leveldb.conf",
+                                        0660, "w", &leveldb_conf_path);
+    ASSERT_TRUE(leveldb_conf != NULL);
+    std::string conf_str =
+        "CVMFS_LEVELDB_STORAGE=" + T_Uploaders::dest_dir + "\n" +
+        "CVMFS_LEVELDB_COUNT=" + StringifyInt(database_count);
+
+    fprintf(leveldb_conf, "%s\n", conf_str.c_str());
+    fclose(leveldb_conf);
   }
 
 

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -816,7 +816,7 @@ TYPED_TEST(T_Uploaders, UploadEmptyFile) {
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
   EXPECT_EQ(1u, this->delegate_.simple_upload_invocations);
   TestFixture::CompareFileContents(empty_file_path, dest_name);
-  EXPECT_EQ(0, GetFileSize(TestFixture::AbsoluteDestinationPath(dest_name)));
+  EXPECT_EQ(0u, TestFixture::GetBackendFileSize(dest_name));
 }
 
 

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -111,14 +111,13 @@ class T_Uploaders : public FileSandbox {
 
     SetUp(type<UploadersT>());
 
-    InitializeStorageBackend();
     uploader_ = AbstractUploader::Construct(GetSpoolerDefinition());
     ASSERT_NE(static_cast<AbstractUploader*>(NULL), uploader_);
   }
 
 
   virtual void SetUp(const type<upload::LocalUploader> type_specifier) {
-    // Empty, no specific needs
+    InitializeStorageBackend();
   }
 
 
@@ -131,6 +130,7 @@ class T_Uploaders : public FileSandbox {
     repo_alias = "testdata";
     CreateTempS3ConfigFile(10, 10);
     CreateS3Mockup();
+    InitializeStorageBackend();
   }
 
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1468,3 +1468,14 @@ TEST_F(T_Util, MemoryMappedFile) {
   EXPECT_TRUE(mf.IsMapped());
   mf.Unmap();
 }
+
+TEST_F(T_Util, PaddingLeft) {
+  string foobar = "foobar";
+  string padded_foobar = PaddingLeft(foobar, 10, 'A');
+  EXPECT_EQ("AAAAfoobar", padded_foobar);
+  string same_foobar = PaddingLeft(foobar, 6, 'B');
+  EXPECT_EQ("foobar", same_foobar);
+  int leet = 1337;
+  string padded_leet = PaddingLeft(StringifyInt(leet), 6, '0');
+  EXPECT_EQ("001337", padded_leet);
+}

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -144,27 +144,7 @@ class AbstractMockUploader : public upload::AbstractUploader {
   void WorkerThread() {
     worker_thread_running = true;
 
-    bool running = true;
-    while (running) {
-      UploadJob job = AcquireNewJob();
-      switch (job.type) {
-        case UploadJob::Upload:
-          Upload(job.stream_handle,
-                 job.buffer,
-                 job.callback);
-          break;
-        case UploadJob::Commit:
-          FinalizeStreamedUpload(job.stream_handle,
-                                 job.content_hash);
-          break;
-        case UploadJob::Terminate:
-          running = false;
-          break;
-        default:
-          assert(AbstractMockUploader::not_implemented);
-          break;
-      }
-    }
+    while (PerformJob() != JobStatus::kTerminate);
 
     worker_thread_running = false;
   }
@@ -181,14 +161,14 @@ class AbstractMockUploader : public upload::AbstractUploader {
     return NULL;
   }
 
-  virtual void Upload(upload::UploadStreamHandle  *handle,
-                      upload::CharBuffer          *buffer,
-                      const CallbackTN            *callback = NULL) {
+  virtual void StreamedUpload(upload::UploadStreamHandle  *handle,
+                              upload::CharBuffer          *buffer,
+                              const CallbackTN            *callback = NULL) {
     assert(AbstractMockUploader::not_implemented);
   }
 
   virtual void FinalizeStreamedUpload(upload::UploadStreamHandle *handle,
-                                      const shash::Any            content_hash)
+                                      const shash::Any           &content_hash)
   {
     assert(AbstractMockUploader::not_implemented);
   }

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -144,7 +144,7 @@ class AbstractMockUploader : public upload::AbstractUploader {
   void WorkerThread() {
     worker_thread_running = true;
 
-    while (PerformJob() != JobStatus::kTerminate);
+    AbstractUploader::WorkerThread();
 
     worker_thread_running = false;
   }


### PR DESCRIPTION
This is a first step to allow storage of CernVM-FS repositories inside one (or many) LevelDB databases. For the moment, it should be seen as a proof of concept. Note: This builds on top of [Refactor: Eliminate some Code duplications in `Uploaders`](https://github.com/cvmfs/cvmfs/pull/1562).

Some details:
- adds `AbstractUploader` implementation: `LevelDbUploader`
- new `SpoolerDefinition` for `LevelDB` of the form: `leveldb,<tmp path>,<config file>`
- understood `LevelDB` configuration variables:
  - `CVMFS_LEVELDB_STORAGE` - base path where the LevelDB(s) are stored
  - `CVMFS_LEVELDB_COUNT` - number of LevelDBs to shard object files into
  - `CVMFS_LEVELDB_COMPRESSION` - either `snappy` or `none` by default

TODO:
- [ ] error handling through `AbstractUploader::GetNumberOfErrors()`
- [ ] `AbstractUploader::PlaceBootstrappingShortcuts()` not implemented (`.cvmfsalt-...`)
- [ ] Apache-based read-end
