### PR TITLE
FIX: Disable Repo Transaction Check doesn't work on EL4

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -222,7 +222,8 @@ done
 popd
 %endif
 
-%if 0%{?redhat_major} > 4
+%if 0%{?el4}
+%else
 %pretrans server
 [ -d "/var/spool/cvmfs"  ]          || exit 0
 [ -d "/etc/cvmfs/repositories.d/" ] || exit 0

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -222,6 +222,7 @@ done
 popd
 %endif
 
+%if 0%{?redhat_major} > 4
 %pretrans server
 [ -d "/var/spool/cvmfs"  ]          || exit 0
 [ -d "/etc/cvmfs/repositories.d/" ] || exit 0
@@ -239,6 +240,7 @@ for repo in /var/spool/cvmfs/*; do
 done
 
 exit 0
+%endif
 
 %pre
 %if 0%{?suse_version}
@@ -422,6 +424,8 @@ fi
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog
+* Mon Apr 11 2016 Rene Meusel <rene.meusel@cern.ch> - 2.3.0
+- Disable open repo transaction check in EL4
 * Thu Apr 07 2016 Rene Meusel <rene.meusel@cern.ch> - 2.3.0
 - Check for open repo transactions before updating server package
 * Sat Jan 23 2016 Brian Bockelman <bbockelm@cse.unl.edu> - 2.2.0


### PR DESCRIPTION
This disables the repository open transaction check on EL4 for the `cvmfs-server` RPM. Apparently `%pretrans` is not available on this platform. Since we do not run any CernVM-FS servers on EL4 anyway, this shouldn't hurt, though.