### PR TITLE
FIX: ignore failing `dnf -y update`

### DIFF
--- a/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_setup.sh
@@ -6,7 +6,7 @@ script_location=$(dirname $(readlink --canonicalize $0))
 
 # update packages installed on the system
 echo "updating installed RPM packages..."
-sudo dnf -y update || die "fail (dnf update)"
+sudo dnf -y update || echo "---- WARNING: dnf reported non-zero status code"
 
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "


### PR DESCRIPTION
On Fedora 23 `dnf -y update` during platform setup is failing from time to time... apparently due to missing locale warnings. I suppose that we can ignore this and rely on downstream failures.