### PR TITLE
FIX: runuser detection / proper shell quotation

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -121,7 +121,7 @@ fi
 # Check if `runuser` is available on this system
 # Note: at least Ubuntu in older versions doesn't provide this command
 HAS_RUNUSER=0
-if [ -x $RUNUSER_BIN ]; then
+if [ -x "$RUNUSER_BIN" ]; then
   HAS_RUNUSER=1
 fi
 


### PR DESCRIPTION
On Ubuntu 14.04 `cvmfs_server` detected the availability of `runuser` even though it wasn't there.