### PR TITLE
Fix reallocations by small deltas

### DIFF
--- a/cvmfs/sqlitemem.cc
+++ b/cvmfs/sqlitemem.cc
@@ -339,6 +339,9 @@ void SqliteMemoryManager::xFree(void *ptr) {
  */
 void *SqliteMemoryManager::xRealloc(void *ptr, int new_size) {
   int old_size = xSize(ptr);
+  if (old_size >= new_size)
+    return ptr;
+
   void *new_ptr = xMalloc(new_size);
   memcpy(new_ptr, ptr, old_size);
   xFree(ptr);

--- a/cvmfs/sqlitemem.h
+++ b/cvmfs/sqlitemem.h
@@ -36,6 +36,7 @@ class SqliteMemoryManager {
   FRIEND_TEST(T_Sqlitemem, LookasideBuffer);
   FRIEND_TEST(T_Sqlitemem, Malloc);
   FRIEND_TEST(T_Sqlitemem, Realloc);
+  FRIEND_TEST(T_Sqlitemem, ReallocStress);
 
  public:
   /**

--- a/test/unittests/t_sqlitemem.cc
+++ b/test/unittests/t_sqlitemem.cc
@@ -280,3 +280,20 @@ TEST_F(T_Sqlitemem, Realloc) {
   EXPECT_EQ(0,
             memcmp(reinterpret_cast<char *>(p2) + 1024, pattern_one_1kb, 1016));
 }
+
+
+TEST_F(T_Sqlitemem, ReallocStress) {
+  Prng prng;
+  prng.InitSeed(42);
+  vector<void *> ptrs;
+  for (unsigned i = 0; i < 20000; ++i) {
+    void *p = mem_mgr_->GetMemory(100 + prng.Next(50));
+    ASSERT_TRUE(p != NULL);
+    ptrs.push_back(p);
+  }
+  vector<void *> shuffled_ptrs = Shuffle(ptrs, &prng);
+  for (unsigned i = 0; i < shuffled_ptrs.size(); ++i) {
+    void *p = mem_mgr_->xRealloc(shuffled_ptrs[i], 150 + prng.Next(10));
+    ASSERT_TRUE(p != NULL);
+  }
+}


### PR DESCRIPTION
There is an obvious, even better solution than `std::min(new_size, old_size)`.  If the old size can accomodate the new size, we don't need to do anything.

The new `xRealloc` stress test could trigger the segfault pretty quickly.