### PR TITLE
Tuning: Speed up Catalog Updates during Publish

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -172,13 +172,15 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
 
 
 /**
- * Tries to retrieve the catalog containing the given path
- * This method is just a wrapper around the FindCatalog method of
- * AbstractCatalogManager to provide a direct interface returning
- * WritableCatalog classes.
- * @param path the path to look for
- * @param result the retrieved catalog (as a pointer)
- * @return true if catalog was found, false otherwise
+ * Retrieve the catalog containing the given path.
+ * Other than AbstractCatalogManager::FindCatalog() this mounts nested
+ * catalogs if necessary and returns  WritableCatalog objects.
+ * Furthermore it optionally returns the looked-up DirectoryEntry.
+ *
+ * @param path    the path to look for
+ * @param result  the retrieved catalog (as a pointer)
+ * @param dirent  is set to looked up DirectoryEntry for 'path' if non-NULL
+ * @return        true if catalog was found
  */
 bool WritableCatalogManager::FindCatalog(const string     &path,
                                          WritableCatalog **result,

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -199,7 +199,7 @@ bool WritableCatalogManager::FindCatalog(const string     &path,
   if (NULL == dirent) {
     dirent = &dummy;
   }
-  bool found = LookupPath(ps_path, kLookupSole, dirent);
+  bool found = catalog->LookupPath(ps_path, dirent);
   if (!found || !catalog->IsWritable())
     return false;
 

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -146,7 +146,9 @@ class WritableCatalogManager : public SimpleCatalogManager {
                const std::string     &parent_directory);
 
  private:
-  bool FindCatalog(const std::string &path, WritableCatalog **result);
+  bool FindCatalog(const std::string  &path,
+                   WritableCatalog   **result,
+                   DirectoryEntry     *dirent = NULL);
   void DoBalance();
   void FixWeight(WritableCatalog *catalog);
 


### PR DESCRIPTION
This removes inefficiencies from the catalog update code during publishing. Profiling of these code paths revealed that path lookups and nested catalog discovery happened more often than necessary. Especially for large change sets and many touched nested catalogs we see a significant penalty.

In certain workloads one can expect a 25% speedup for the catalog updates as seen in the chart below (blue = before, green = after). This is meta-data updates per seconds over number of inserted directory entries (measured on my dev machine).

<img width="514" alt="screen shot 2016-04-15 at 14 10 17" src="https://cloud.githubusercontent.com/assets/1562139/14561031/dd24e934-0313-11e6-9700-c4a4a02e2b92.png">

I'll put a more detailed comments into the patch itself.