### PR TITLE
Feature: Concurrent Catalog Committing and Snapshotting

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -585,12 +585,13 @@ const Catalog::NestedCatalogList& Catalog::ListNestedCatalogs() const {
 /**
  * Drops the nested catalog cache. Usually this is only useful in subclasses
  * that implement writable catalogs.
+ *
+ * Note: this action is _not_ secured by the catalog's mutex. If serialisation
+ *       is required the subclass needs to ensure that.
  */
-void Catalog::ResetNestedCatalogCache() {
-  pthread_mutex_lock(lock_);
+void Catalog::ResetNestedCatalogCacheUnprotected() {
   nested_catalog_cache_.clear();
   nested_catalog_cache_dirty_ = true;
-  pthread_mutex_unlock(lock_);
 }
 
 

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -219,6 +219,8 @@ class Catalog : public SingleCopy {
   typedef std::map<uint64_t, inode_t> HardlinkGroupMap;
   mutable HardlinkGroupMap hardlink_groups_;
 
+  pthread_mutex_t *lock_;
+
   bool InitStandalone(const std::string &database_file);
   bool ReadCatalogCounters();
 
@@ -244,7 +246,7 @@ class Catalog : public SingleCopy {
   inline       CatalogDatabase &database()       { return *database_; }
   inline void set_parent(Catalog *catalog) { parent_ = catalog; }
 
-  void ResetNestedCatalogCache();
+  void ResetNestedCatalogCacheUnprotected();
 
  private:
   typedef std::map<PathString, Catalog*> NestedCatalogMap;
@@ -266,7 +268,6 @@ class Catalog : public SingleCopy {
   bool LookupEntry(const shash::Md5 &md5path, const bool expand_symlink,
                    DirectoryEntry *dirent) const;
   CatalogDatabase *database_;
-  pthread_mutex_t *lock_;
 
   const shash::Any catalog_hash_;
   PathString root_prefix_;

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -819,6 +819,9 @@ void WritableCatalogManager::FinalizeCatalog(WritableCatalog *catalog,
 
   // update the previous catalog revision pointer
   if (catalog->IsRoot()) {
+    LogCvmfs(kLogCatalog, kLogVerboseMsg, "setting '%s' as previous revision "
+                                          "for root catalog",
+             base_hash().ToStringWithSuffix().c_str());
     catalog->SetPreviousRevision(base_hash());
   } else {
     shash::Any hash_previous;
@@ -827,6 +830,10 @@ void WritableCatalogManager::FinalizeCatalog(WritableCatalog *catalog,
       catalog->parent()->FindNested(catalog->path(),
                                     &hash_previous, &size_previous);
     assert(retval);
+    LogCvmfs(kLogCatalog, kLogVerboseMsg, "found '%s' as previous revision "
+                                          "for nested catalog '%s'",
+             hash_previous.ToStringWithSuffix().c_str(),
+             catalog->path().c_str());
     catalog->SetPreviousRevision(hash_previous);
   }
   catalog->Commit();

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -51,12 +51,18 @@ WritableCatalogManager::WritableCatalogManager(
     reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
   int retval = pthread_mutex_init(sync_lock_, NULL);
   assert(retval == 0);
+  catalog_processing_lock_ =
+    reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+  retval = pthread_mutex_init(catalog_processing_lock_, NULL);
+  assert(retval == 0);
 }
 
 
 WritableCatalogManager::~WritableCatalogManager() {
   pthread_mutex_destroy(sync_lock_);
   free(sync_lock_);
+  pthread_mutex_destroy(catalog_processing_lock_);
+  free(catalog_processing_lock_);
 }
 
 
@@ -703,129 +709,85 @@ bool WritableCatalogManager::SetVOMSAuthz(const std::string &voms_authz) {
 bool WritableCatalogManager::Commit(const bool           stop_for_tweaks,
                                     const uint64_t       manual_revision,
                                     manifest::Manifest  *manifest) {
-  reinterpret_cast<WritableCatalog *>(GetRootCatalog())->SetDirty();
-  WritableCatalogList catalogs_to_snapshot;
-  GetModifiedCatalogs(&catalogs_to_snapshot);
+  WritableCatalog *root_catalog =
+    reinterpret_cast<WritableCatalog *>(GetRootCatalog());
+  root_catalog->SetDirty();
 
-  spooler_->RegisterListener(
-    &WritableCatalogManager::CatalogUploadCallback, this);
-
-  for (WritableCatalogList::iterator i = catalogs_to_snapshot.begin(),
-       iEnd = catalogs_to_snapshot.end(); i != iEnd; ++i)
-  {
-    (*i)->Commit();
-    if (stop_for_tweaks) {
-      LogCvmfs(kLogCatalog, kLogStdout, "Allowing for tweaks in %s at %s "
-               "(hit return to continue)",
-               (*i)->database_path().c_str(), (*i)->path().c_str());
-      int read_char = getchar();
-      assert(read_char != EOF);
-    }
-
-    if ((*i)->IsRoot() && manual_revision > 0) {
-      const uint64_t revision = (*i)->GetRevision();
-      if (revision >= manual_revision) {
-        LogCvmfs(kLogCatalog, kLogStderr, "Manual revision (%d) must not be "
-                                          "smaller than the current root "
-                                          "catalog's (%d). Skipped!",
-                                          manual_revision, revision);
-      } else {
-        // Gets incremented by SnapshotCatalog() afterwards!
-        (*i)->SetRevision(manual_revision - 1);
-      }
-    }
-    shash::Any hash = SnapshotCatalog(*i);
-
-    if ((*i)->GetCounters().GetSelfEntries() > catalog_entry_warn_threshold_) {
-      LogCvmfs(kLogCatalog, kLogStdout,
-               "WARNING: catalog at %s has more than %d entries (%d). "
-               "Please consider to split it into nested catalogs.",
-               ((*i)->IsRoot()) ? "/" : (*i)->path().c_str(),
-               catalog_entry_warn_threshold_,
-               (*i)->GetCounters().GetSelfEntries());
-    }
-
-    if ((*i)->IsRoot()) {
-      set_base_hash(hash);
-      LogCvmfs(kLogCatalog, kLogVerboseMsg, "waiting for upload of catalogs");
-      spooler_->WaitForUpload();
-      if (spooler_->GetNumberOfErrors() > 0) {
-        LogCvmfs(kLogCatalog, kLogStderr, "failed to commit catalogs");
-        return false;
-      }
-
-      // .cvmfspublished
-      int64_t catalog_size = GetFileSize((*i)->database_path());
-      if (catalog_size < 0)
-        return false;
-      LogCvmfs(kLogCatalog, kLogVerboseMsg, "Committing repository manifest");
-      manifest->set_catalog_hash(hash);
-      manifest->set_catalog_size(catalog_size);
-      manifest->set_root_path("");
-      manifest->set_ttl((*i)->GetTTL());
-      manifest->set_revision((*i)->GetRevision());
+  // set root catalog revision to manually provided number if available
+  if (manual_revision > 0) {
+    const uint64_t revision = root_catalog->GetRevision();
+    if (revision >= manual_revision) {
+      LogCvmfs(kLogCatalog, kLogStderr, "Manual revision (%d) must not be "
+                                        "smaller than the current root "
+                                        "catalog's (%d). Skipped!",
+                                        manual_revision, revision);
+    } else {
+      // Gets incremented by FinalizeCatalog() afterwards!
+      root_catalog->SetRevision(manual_revision - 1);
     }
   }
 
-  spooler_->UnregisterListeners();
+  // do the actual catalog snapshotting and upload
+  CatalogInfo root_catalog_info = SnapshotCatalogs(stop_for_tweaks);
+  if (spooler_->GetNumberOfErrors() > 0) {
+    LogCvmfs(kLogCatalog, kLogStderr, "failed to commit catalogs");
+    return false;
+  }
+
+  // .cvmfspublished export
+  LogCvmfs(kLogCatalog, kLogVerboseMsg, "Committing repository manifest");
+  set_base_hash(root_catalog_info.content_hash);
+
+  manifest->set_catalog_hash(root_catalog_info.content_hash);
+  manifest->set_catalog_size(root_catalog_info.size);
+  manifest->set_root_path("");
+  manifest->set_ttl(root_catalog_info.ttl);
+  manifest->set_revision(root_catalog_info.revision);
+
   return true;
 }
 
 
-int WritableCatalogManager::GetModifiedCatalogsRecursively(
-  const Catalog *catalog,
-  WritableCatalogList *result) const
-{
-  // A catalog must be snapshot, if itself or one of it's descendants is dirty.
-  // So we traverse the catalog tree recursively and look for dirty catalogs
-  // on the way.
+WritableCatalogManager::CatalogInfo WritableCatalogManager::SnapshotCatalogs(
+                                                   const bool stop_for_tweaks) {
+  Future<CatalogInfo>  root_catalog_info_future;
+  CatalogUploadContext upload_context;
+  upload_context.root_catalog_info = &root_catalog_info_future;
+  upload_context.stop_for_tweaks   = stop_for_tweaks;
 
-  const WritableCatalog *wr_catalog =
-    static_cast<const WritableCatalog *>(catalog);
-  // This variable will contain the number of dirty catalogs in the sub tree
-  // with *catalog as it's root.
-  int dirty_catalogs = (wr_catalog->IsDirty()) ? 1 : 0;
+  spooler_->RegisterListener(
+    &WritableCatalogManager::CatalogUploadCallback, this, upload_context);
 
-  // Look for dirty catalogs in the descendants of *catalog
-  CatalogList children = wr_catalog->GetChildren();
-  for (CatalogList::const_iterator i = children.begin(), iEnd = children.end();
-       i != iEnd; ++i)
-  {
-    dirty_catalogs += GetModifiedCatalogsRecursively(*i, result);
+  WritableCatalogList leafs_to_snapshot;
+  GetModifiedCatalogLeafs(&leafs_to_snapshot);
+
+        WritableCatalogList::const_iterator i    = leafs_to_snapshot.begin();
+  const WritableCatalogList::const_iterator iend = leafs_to_snapshot.end();
+  for (; i != iend; ++i) {
+    FinalizeCatalog(*i, stop_for_tweaks);
+    ScheduleCatalogProcessing(*i);
   }
 
-  // If we found a dirty catalog in the checked sub tree, the root (*catalog)
-  // must be snapshot and ends up in the result list
-  if (dirty_catalogs > 0)
-    result->push_back(const_cast<WritableCatalog *>(wr_catalog));
+  LogCvmfs(kLogCatalog, kLogVerboseMsg, "waiting for upload of catalogs");
+  CatalogInfo& root_catalog_info = root_catalog_info_future.Get();
+  spooler_->WaitForUpload();
 
-  // tell the upper layer about number of catalogs
-  return dirty_catalogs;
+  spooler_->UnregisterListeners();
+  return root_catalog_info;
 }
 
 
-/**
- * Makes a new catalog revision.  Compresses and uploads catalog.  Returns
- * content hash.
- */
-shash::Any WritableCatalogManager::SnapshotCatalog(WritableCatalog *catalog)
-  const
-{
+void WritableCatalogManager::FinalizeCatalog(WritableCatalog *catalog,
+                                             const bool stop_for_tweaks) {
+  // update meta information of this catalog
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "creating snapshot of catalog '%s'",
            catalog->path().c_str());
 
-  catalog->Transaction();
   catalog->UpdateCounters();
-  if (catalog->parent()) {
-    catalog->delta_counters_.PopulateToParent(
-      &catalog->GetWritableParent()->delta_counters_);
-  }
-  catalog->delta_counters_.SetZero();
-
   catalog->UpdateLastModified();
   catalog->IncrementRevision();
 
-  // Previous revision
+  // update the previous catalog revision pointer
   if (catalog->IsRoot()) {
     catalog->SetPreviousRevision(base_hash());
   } else {
@@ -839,34 +801,119 @@ shash::Any WritableCatalogManager::SnapshotCatalog(WritableCatalog *catalog)
   }
   catalog->Commit();
 
+  // print warning if catalog is considered too large
+  if (catalog->GetCounters().GetSelfEntries() > catalog_entry_warn_threshold_) {
+    LogCvmfs(kLogCatalog, kLogStdout,
+             "WARNING: catalog at %s has more than %d entries (%d). "
+             "Please consider to split it into nested catalogs.",
+             (catalog->IsRoot()) ? "/" : catalog->path().c_str(),
+             catalog_entry_warn_threshold_,
+             catalog->GetCounters().GetSelfEntries());
+  }
+
+  // allow for manual adjustments in the catalog
+  if (stop_for_tweaks) {
+    LogCvmfs(kLogCatalog, kLogStdout, "Allowing for tweaks in %s at %s "
+                                      "(hit return to continue)",
+             catalog->database_path().c_str(), catalog->path().c_str());
+    int read_char = getchar();
+    assert(read_char != EOF);
+  }
+
+  // compaction of bloated catalogs (usually after high database churn)
   catalog->VacuumDatabaseIfNecessary();
+}
 
-  uint64_t catalog_size = GetFileSize(catalog->database_path());
-  assert(catalog_size > 0);
 
-  // Compress catalog
-  shash::Any hash_catalog(spooler_->GetHashAlgorithm(), shash::kSuffixCatalog);
-  if (!zlib::CompressPath2Path(catalog->database_path(),
-                               catalog->database_path() + ".compressed",
-                               &hash_catalog))
-  {
-    PrintError("could not compress catalog " + catalog->path().ToString());
+void WritableCatalogManager::ScheduleCatalogProcessing(
+                                                     WritableCatalog *catalog) {
+  MutexLockGuard guard(catalog_processing_lock_);
+  catalog_processing_map_[catalog->database_path()] = catalog;
+  spooler_->ProcessCatalog(catalog->database_path());
+}
+
+
+void WritableCatalogManager::CatalogUploadCallback(
+                          const upload::SpoolerResult &result,
+                          const CatalogUploadContext   catalog_upload_context) {
+  if (result.return_code != 0) {
+    LogCvmfs(kLogCatalog, kLogStderr, "failed to upload '%s' (retval: %d)",
+             result.local_path.c_str(), result.return_code);
     assert(false);
   }
 
-  // Upload catalog
-  spooler_->Upload(catalog->database_path() + ".compressed",
-                   "data/" + hash_catalog.MakePath());
-
-  // Update registered catalog hash in nested catalog
-  if (catalog->HasParent()) {
-    LogCvmfs(kLogCatalog, kLogVerboseMsg, "updating nested catalog link");
-    WritableCatalog *parent = static_cast<WritableCatalog *>(catalog->parent());
-    parent->UpdateNestedCatalog(catalog->path().ToString(), hash_catalog,
-                                catalog_size);
+  WritableCatalog *catalog = NULL;
+  {
+    MutexLockGuard guard(catalog_processing_lock_);
+    std::map<std::string, WritableCatalog*>::iterator c =
+      catalog_processing_map_.find(result.local_path);
+    assert(c != catalog_processing_map_.end());
+    catalog = c->second;
   }
 
-  return hash_catalog;
+  uint64_t catalog_size = GetFileSize(result.local_path);
+  assert(catalog_size > 0);
+
+  if (!catalog->HasParent()) {
+    CatalogInfo root_catalog_info;
+    root_catalog_info.size         = catalog_size;
+    root_catalog_info.ttl          = catalog->GetTTL();
+    root_catalog_info.content_hash = result.content_hash;
+    root_catalog_info.revision     = catalog->GetRevision();
+    catalog_upload_context.root_catalog_info->Set(root_catalog_info);
+    return;
+  }
+
+  LogCvmfs(kLogCatalog, kLogVerboseMsg, "updating nested catalog link");
+  WritableCatalog *parent = catalog->GetWritableParent();
+
+  parent->UpdateNestedCatalog(catalog->path().ToString(), result.content_hash,
+                              catalog_size, catalog->delta_counters_);
+  catalog->delta_counters_.SetZero();
+
+  const int remaining_dirty_children =
+    catalog->GetWritableParent()->DecrementDirtyChildren();
+
+  // continuation of the dirty catalog tree traversal
+  // see WritableCatalogManager::Commit()
+  if (remaining_dirty_children == 0) {
+    FinalizeCatalog(parent, catalog_upload_context.stop_for_tweaks);
+    ScheduleCatalogProcessing(parent);
+  }
+}
+
+
+bool WritableCatalogManager::GetModifiedCatalogLeafsRecursively(
+  Catalog             *catalog,
+  WritableCatalogList *result) const
+{
+  // A catalog must be snapshot, if itself or one of it's descendants is dirty.
+  // So we traverse the catalog tree recursively and look for dirty catalogs
+  // on the way.
+
+  WritableCatalog *wr_catalog = static_cast<WritableCatalog *>(catalog);
+
+  // Look for dirty catalogs in the descendants of *catalog
+  int dirty_children = 0;
+  CatalogList children = wr_catalog->GetChildren();
+        CatalogList::const_iterator i    = children.begin();
+  const CatalogList::const_iterator iend = children.end();
+  for (; i != iend; ++i) {
+    if(GetModifiedCatalogLeafsRecursively(*i, result)) {
+      ++dirty_children;
+    }
+  }
+
+  // a catalog is dirty if itself or one of its children has changed
+  // a leaf catalog doesn't have any dirty children
+  wr_catalog->set_dirty_children(dirty_children);
+  const bool is_dirty = wr_catalog->IsDirty() || dirty_children > 0;
+  const bool is_leaf  = dirty_children == 0;
+  if (is_dirty && is_leaf) {
+    result->push_back(const_cast<WritableCatalog *>(wr_catalog));
+  }
+
+  return is_dirty;
 }
 
 void WritableCatalogManager::DoBalance() {
@@ -896,17 +943,6 @@ void WritableCatalogManager::FixWeight(WritableCatalog* catalog) {
     CatalogBalancer<WritableCatalogManager> catalog_balancer(this);
     catalog_balancer.Balance(catalog);
   }
-}
-
-void WritableCatalogManager::CatalogUploadCallback(
-                                          const upload::SpoolerResult &result) {
-  if (result.return_code != 0) {
-    LogCvmfs(kLogCatalog, kLogStderr, "failed to upload '%s' (retval: %d)",
-             result.local_path.c_str(), result.return_code);
-    assert(false);
-  }
-
-  unlink(result.local_path.c_str());
 }
 
 }  // namespace catalog

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -951,7 +951,7 @@ bool WritableCatalogManager::GetModifiedCatalogLeafsRecursively(
         CatalogList::const_iterator i    = children.begin();
   const CatalogList::const_iterator iend = children.end();
   for (; i != iend; ++i) {
-    if(GetModifiedCatalogLeafsRecursively(*i, result)) {
+    if (GetModifiedCatalogLeafsRecursively(*i, result)) {
       ++dirty_children;
     }
   }

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -38,6 +38,7 @@
 #include "catalog_mgr_ro.h"
 #include "catalog_rw.h"
 #include "upload_spooler_result.h"
+#include "util_concurrency.h"
 #include "xattr.h"
 
 class XattrList;
@@ -124,6 +125,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   bool Commit(const bool           stop_for_tweaks,
               const uint64_t       manual_revision,
               manifest::Manifest  *manifest);
+
   void Balance() {
       if (IsBalanceable()) {
           DoBalance();
@@ -150,21 +152,40 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void DoBalance();
   void FixWeight(WritableCatalog *catalog);
 
+  struct CatalogInfo {
+    uint64_t     ttl;
+    size_t       size;
+    shash::Any   content_hash;
+    unsigned int revision;
+  };
+
+  struct CatalogUploadContext {
+    Future<CatalogInfo>* root_catalog_info;
+    bool                 stop_for_tweaks;
+  };
+
+  CatalogInfo SnapshotCatalogs(const bool stop_for_tweaks);
+  void FinalizeCatalog(WritableCatalog *catalog,
+                       const bool stop_for_tweaks);
+  void ScheduleCatalogProcessing(WritableCatalog *catalog);
+
   /**
    * Traverses all open catalogs and determines which catalogs need updated
-   * snapshots.
-   * @param[out] result the list of catalogs to snapshot
+   * snapshots. Only the leafs (i.e. the catalogs without dirty decendants) are
+   * returned.
+   *
+   * @param[out] result  the list of leaf catalogs to snapshot
    */
-  void GetModifiedCatalogs(WritableCatalogList *result) const {
-    const unsigned int number_of_dirty_catalogs =
-      GetModifiedCatalogsRecursively(GetRootCatalog(), result);
-    assert(number_of_dirty_catalogs <= result->size());
+  void GetModifiedCatalogLeafs(WritableCatalogList *result) const {
+    const bool dirty = GetModifiedCatalogLeafsRecursively(GetRootCatalog(),
+                                                          result);
+    assert(dirty);
   }
-  int GetModifiedCatalogsRecursively(const Catalog *catalog,
-                                     WritableCatalogList *result) const;
+  bool GetModifiedCatalogLeafsRecursively(Catalog             *catalog,
+                                          WritableCatalogList *result) const;
 
-  shash::Any SnapshotCatalog(WritableCatalog *catalog) const;
-  void CatalogUploadCallback(const upload::SpoolerResult &result);
+  void CatalogUploadCallback(const upload::SpoolerResult &result,
+                             const CatalogUploadContext   clg_upload_context);
 
  private:
   inline void SyncLock() { pthread_mutex_lock(sync_lock_); }
@@ -176,6 +197,9 @@ class WritableCatalogManager : public SimpleCatalogManager {
   // private lock of WritableCatalogManager
   pthread_mutex_t *sync_lock_;
   upload::Spooler *spooler_;
+
+  pthread_mutex_t                         *catalog_processing_lock_;
+  std::map<std::string, WritableCatalog*>  catalog_processing_map_;
 
   uint64_t catalog_entry_warn_threshold_;
 

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -169,13 +169,6 @@ class WritableCatalogManager : public SimpleCatalogManager {
                        const bool stop_for_tweaks);
   void ScheduleCatalogProcessing(WritableCatalog *catalog);
 
-  /**
-   * Traverses all open catalogs and determines which catalogs need updated
-   * snapshots. Only the leafs (i.e. the catalogs without dirty decendants) are
-   * returned.
-   *
-   * @param[out] result  the list of leaf catalogs to snapshot
-   */
   void GetModifiedCatalogLeafs(WritableCatalogList *result) const {
     const bool dirty = GetModifiedCatalogLeafsRecursively(GetRootCatalog(),
                                                           result);

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -32,6 +32,7 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <map>
 #include <set>
 #include <string>
 

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -38,10 +38,6 @@ WritableCatalog::WritableCatalog(const string      &path,
   dirty_(false)
 {
   atomic_init32(&dirty_children_);
-  writable_lock_ =
-    reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
-  int retval = pthread_mutex_init(writable_lock_, NULL);
-  assert(retval == 0);
 }
 
 
@@ -64,8 +60,6 @@ WritableCatalog *WritableCatalog::AttachFreely(const string      &root_path,
 WritableCatalog::~WritableCatalog() {
   // CAUTION HOT!
   // (see Catalog.h - near the definition of FinalizePreparedStatements)
-  pthread_mutex_destroy(writable_lock_);
-  free(writable_lock_);
   FinalizePreparedStatements();
 }
 

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -503,7 +503,7 @@ void WritableCatalog::InsertNestedCatalog(const string &mountpoint,
   if (attached_reference != NULL)
     AddChild(attached_reference);
 
-  ResetNestedCatalogCache();
+  ResetNestedCatalogCacheUnprotected();
 
   delta_counters_.self.nested_catalogs++;
 }
@@ -543,7 +543,7 @@ void WritableCatalog::RemoveNestedCatalog(const string &mountpoint,
   if (attached_reference != NULL)
     *attached_reference = child;
 
-  ResetNestedCatalogCache();
+  ResetNestedCatalogCacheUnprotected();
 
   delta_counters_.self.nested_catalogs--;
 }
@@ -560,7 +560,7 @@ void WritableCatalog::UpdateNestedCatalog(const std::string   &path,
                                           const shash::Any    &hash,
                                           const uint64_t       size,
                                           const DeltaCounters &child_counters) {
-  MutexLockGuard guard(writable_lock_);
+  MutexLockGuard guard(lock_);
 
   child_counters.PopulateToParent(&delta_counters_);
 
@@ -575,7 +575,7 @@ void WritableCatalog::UpdateNestedCatalog(const std::string   &path,
     stmt.BindText(3, path) &&
     stmt.Execute();
 
-  ResetNestedCatalogCache();
+  ResetNestedCatalogCacheUnprotected();
 
   assert(retval);
 }

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -153,7 +153,6 @@ class WritableCatalog : public Catalog {
   DeltaCounters delta_counters_;
 
   // parallel commit state
-  pthread_mutex_t *writable_lock_;
   mutable atomic_int32 dirty_children_;
 
   inline void SetDirty() {

--- a/test/src/631-nestedstresstest/main
+++ b/test/src/631-nestedstresstest/main
@@ -1,0 +1,96 @@
+
+cvmfs_test_name="Create a Plethora of Nested Catalogs"
+cvmfs_test_autofs_on_startup=false
+
+create_nested_catalogs() {
+  local subdir="$1"
+  shift 1
+
+  [ $# -gt 0 ] || return 0
+
+  local nested_clgs=$1
+  shift 1
+
+  mkdir -p "$subdir" || return 1
+  local subsubdir
+  while [ $nested_clgs -gt 0 ]; do
+    subsubdir="${subdir}/$(printf "%04x" ${nested_clgs})"
+    mkdir -p "$subsubdir"                  || return 2
+    touch "${subsubdir}/.cvmfscatalog"     || return 3
+    create_nested_catalogs "$subsubdir" $@ || return 4
+    nested_clgs=$(( $nested_clgs - 1 ))
+  done
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  local needed_ofiles=25000
+  echo -n "check if enough files (${needed_ofiles}) can be opened... "
+  if [ $(ulimit -n) -lt $needed_ofiles ]; then
+    echo "no"
+    return 100
+  else
+    echo "yes"
+  fi
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local subdir1="${repo_dir}/test1"
+  echo "generate many nested catalogs in ${subdir1}"
+  create_nested_catalogs $subdir1 10 10 || return 1
+
+  local publish_log_1="${scratch_dir}/publish_1.log"
+  echo "creating CVMFS snapshot (logging to ${publish_log_1})"
+  publish_repo $CVMFS_TEST_REPO > $publish_log_1 2>&1 || return $?
+
+  local inspect_log_1="${scratch_dir}/inspect_1.log"
+  echo "check catalog and data integrity (logging to ${inspect_log_1})"
+  check_repository $CVMFS_TEST_REPO -i > $inspect_log_1 2>&1 || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local subdir2="${repo_dir}/test2"
+  echo "generate many nested catalogs in ${subdir2}"
+  create_nested_catalogs $subdir2 10 100 || return 2
+
+  local publish_log_2="${scratch_dir}/publish_2.log"
+  echo "creating CVMFS snapshot (logging to ${publish_log_2})"
+  publish_repo $CVMFS_TEST_REPO > $publish_log_2 2>&1 || return $?
+
+  local inspect_log_2="${scratch_dir}/inspect_2.log"
+  echo "check catalog and data integrity (logging to ${inspect_log_2})"
+  check_repository $CVMFS_TEST_REPO -i > $inspect_log_2 2>&1 || return $?
+
+  # ============================================================================
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  local subdir3="${repo_dir}/test3"
+  echo "generate many nested catalogs in ${subdir3}"
+  create_nested_catalogs $subdir3 10 1000 || return 3
+
+  local publish_log_3="${scratch_dir}/publish_3.log"
+  echo "creating CVMFS snapshot (logging to ${publish_log_3})"
+  publish_repo $CVMFS_TEST_REPO > $publish_log_3 2>&1 || return $?
+
+  local inspect_log_3="${scratch_dir}/inspect_3.log"
+  echo "check catalog and data integrity (logging to ${inspect_log_3})"
+  check_repository $CVMFS_TEST_REPO -i > $inspect_log_3 2>&1 || return $?
+
+  return 0
+}
+


### PR DESCRIPTION
This parallelises the catalog committing code that is part of `cvmfs_server publish`. Depending on the size of the published change set and the number of modified catalogs, this can potentially increase the publishing speed significantly.