### PR TITLE
FIX: Pull Retry Logic

### DIFF
--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -272,16 +272,12 @@ static void *MainWorker(void *data) {
       download::JobInfo download_chunk(&url_chunk, false, false, fchunk,
                                        &chunk_hash);
 
-      unsigned attempts = 0;
-      download::Failures retval;
-      do {
-        retval = download_manager->Fetch(&download_chunk);
-        if (retval != download::kFailOk) {
-          ReportDownloadError(chunk_hash, retval);
-          abort();
-        }
-        attempts++;
-      } while (attempts < retries);
+      const download::Failures download_result =
+                                       download_manager->Fetch(&download_chunk);
+      if (download_result != download::kFailOk) {
+        ReportDownloadError(chunk_hash, download_result);
+        abort();
+      }
       fclose(fchunk);
       Store(tmp_file, chunk_hash,
             (compression_alg == zlib::kZlibDefault) ? true : false);


### PR DESCRIPTION
This fixes a problem in the retry logic of `cvmfs_server snapshot` that was introduced because of a misunderstood coverity issue.

<img width="833" alt="screen shot 2016-04-20 at 10 16 54" src="https://cloud.githubusercontent.com/assets/1562139/14667752/17518f1a-06e1-11e6-9a15-9563e912cf28.png">

Some code forensics for the sake of it:

Once upon a time in the old days of CernVM-FS in 2012 @jblomer [implemented some retry logic](https://github.com/cvmfs/cvmfs/commit/f24dd750f14b8c50fe054d06cea82e8f7862744e#diff-cbafdfe20a34afd8120380f2a30f2663R99) (all together with backoff and timeout) directly in `cvmfs_swissknife pull`.
 This was [superseded by a retry logic implementation](https://github.com/cvmfs/cvmfs/commit/76bb985aa89743c203b15b19f01289680565bdaf#diff-cbafdfe20a34afd8120380f2a30f2663R104) in an ancient "download module" while leaving parts of the old hard-coded logic in place. Later the "download module" was [replaced by a local `DownloadManager` object](https://github.com/cvmfs/cvmfs/commit/b124865d6d4060e2ff0ed198f08affe40106dc90#diff-cbafdfe20a34afd8120380f2a30f2663R104) but this brave piece of retry logic survived. While the years were passing the `DownloadManager` object [moved from `cvmfs_swissknife pull` scope into global](https://github.com/cvmfs/cvmfs/commit/1a8aa632a47b2dd21a349d2e91732087ae568cac#diff-cbafdfe20a34afd8120380f2a30f2663R102) and later [became managed by the `swissknife::Command` base class](https://github.com/cvmfs/cvmfs/commit/7d6b3f3eabab7c2028e50111c0004b289bdc0439#diff-cbafdfe20a34afd8120380f2a30f2663R272), but the little piece of code stayed with us in silence.

It didn't do anything useful since the beginning of 2013, but after I blindly removed the "logically dead" condition "that could never be true", Coverity was talking about, the remainings of the little hard-coded retry logic unleashed its power and downloaded each and every file three times. Fortunately this was never released, but it tells the tale of KISS.

Thanks for reading.