### PR TITLE
FIX: Don't update Reflog on Garbage Collection Dry-Run

### DIFF
--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -99,6 +99,7 @@ class GarbageCollector {
 
   void CheckAndSweep(const shash::Any &hash);
   void Sweep(const shash::Any &hash);
+  bool RemoveCatalogFromReflog(const shash::Any &catalog);
 
   void PrintCatalogTreeEntry(const unsigned int  tree_level,
                              const CatalogTN    *catalog) const;

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -142,6 +142,16 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
 
 
 template <class CatalogTraversalT, class HashFilterT>
+bool GarbageCollector<CatalogTraversalT, HashFilterT>::
+  RemoveCatalogFromReflog(const shash::Any &catalog)
+{
+  return (configuration_.dry_run)
+    ? true
+    : configuration_.reflog->RemoveCatalog(catalog);
+}
+
+
+template <class CatalogTraversalT, class HashFilterT>
 bool GarbageCollector<CatalogTraversalT, HashFilterT>::Collect() {
   return AnalyzePreservedCatalogTree() &&
          CheckPreservedRevisions()     &&

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -197,7 +197,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
     LogCvmfs(kLogGc, kLogStdout, "Sweeping Reference Logs");
   }
 
-  ReflogTN *reflog = configuration_.reflog;
+  const ReflogTN *reflog = configuration_.reflog;
   std::vector<shash::Any> catalogs;
   if (NULL == reflog || !reflog->ListCatalogs(&catalogs)) {
     LogCvmfs(kLogGc, kLogStderr, "Failed to list catalog reference log");
@@ -219,7 +219,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
       success =
         success                                         &&
         traversal_.TraverseRevision(*i, traversal_type) &&
-        reflog->RemoveCatalog(*i);
+        RemoveCatalogFromReflog(*i);
     }
   }
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -171,11 +171,15 @@ int CommandGc::Main(const ArgumentList &args) {
 
   reflog->CommitTransaction();
   const std::string reflog_db = reflog->CloseAndReturnDatabaseFile();
-  uploader->Upload(reflog_db, ".cvmfsreflog");
-  uploader->WaitForUpload();
+
+  if (!dry_run) {
+    uploader->Upload(reflog_db, ".cvmfsreflog");
+    uploader->WaitForUpload();
+  }
+
   unlink(reflog_db.c_str());
 
-  if (uploader->GetNumberOfErrors() > 0) {
+  if (uploader->GetNumberOfErrors() > 0 && !dry_run) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload updated Reflog");
     uploader->TearDown();
     return 1;


### PR DESCRIPTION
When running a dry-run, `cvmfs_server gc` was updating the `Reflog` database (deleting catalog references) without deleting the actual `Catalog` (it's a dry-run after all). Oops!

Fortunately integration test 560 revealed that.