### PR TITLE
Remove Experimental Warning From `cvmfs_server gc`

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5001,12 +5001,6 @@ cvmfs_server_gc() {
     preserve_revisions=0
   fi
 
-  # print a warning to scare off people that might not know what they are doing
-  echo
-  echo 'WARNING: `cvmfs_server gc` is an internal command and will be subject to change'
-  echo '         in future versions of CernVM-FS. Please do not use it manually!'
-  echo
-
   for name in $names; do
     if ! has_reference_log $name; then
       reconstruct_reflog=1

--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -5094,17 +5094,22 @@ cvmfs_server_gc() {
 
     to_syslog_for_repo $name "started manual garbage collection"
 
+    local reconstruct_this_reflog=0
+    if ! has_reference_log $name; then
+      reconstruct_this_reflog=1
+    fi
+
     # run the garbage collection
     local reflog_reconstruct_msg=""
-    [ $reconstruct_reflog -ne 0 ] && reflog_reconstruct_msg="(reconstructing reference logs)"
+    [ $reconstruct_this_reflog -ne 0 ] && reflog_reconstruct_msg="(reconstructing reference logs)"
     echo "Running Garbage Collection $reflog_reconstruct_msg"
-    __run_gc "$name"               \
-             "$repository_url"     \
-             "$dry_run"            \
-             "$manifest"           \
-             "$base_hash"          \
-             "$deletion_log"       \
-             "$reconstruct_reflog" \
+    __run_gc "$name"                    \
+             "$repository_url"          \
+             "$dry_run"                 \
+             "$manifest"                \
+             "$base_hash"               \
+             "$deletion_log"            \
+             "$reconstruct_this_reflog" \
              $additional_switches || die "Fail ($?)!"
 
     # sign the result


### PR DESCRIPTION
This fixes a minor issue with the opportunistic `Reflog` generation when more than one repository is garbage collected simultaneously. Furthermore it removes the *experimental warning* from `cvmfs_server gc`, allowing users to run garbage collection manually whenever it suits them.