### PR TITLE
Fix null-pointer-deref

### DIFF
--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -432,7 +432,7 @@ template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::GetVOMSAuthz(std::string *authz) const {
   ReadLock();
   const bool has_authz = has_authz_cache_;
-  if (has_authz)
+  if (has_authz && authz)
     *authz = authz_cache_;
   Unlock();
   return has_authz;


### PR DESCRIPTION
This can be triggered by simply doing `attr -l /cvmfs/foo.example.com/file`.  Do we not have an integration test that does this?