### PR TITLE
Feature o1 fds

### DIFF
--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -52,38 +52,37 @@ int RamCacheManager::Open(const shash::Any &id) {
 
 int RamCacheManager::DoOpen(const shash::Any &id) {
   bool ok;
+  bool is_volatile;
   MemoryBuffer buf;
-  MemoryKvStore *store;
 
   if (regular_entries_.GetBuffer(id, &buf)) {
-    store = &regular_entries_;
+    is_volatile = false;
   } else if (volatile_entries_.GetBuffer(id, &buf)) {
-    store = &volatile_entries_;
+    is_volatile = true;
   } else {
     LogCvmfs(kLogCache, kLogDebug, "miss for %s",
              id.ToString().c_str());
     perf::Inc(counters_.n_openmiss);
     return -ENOENT;
   }
-
-  int fd = AddFd(ReadOnlyFd(id, 0));
+  int fd = AddFd(ReadOnlyFd(id));
   if (fd < 0) {
     LogCvmfs(kLogCache, kLogDebug, "error while opening %s: %s",
              id.ToString().c_str(), strerror(-fd));
     return fd;
   }
-  open_fds_[fd].store = store;
-  ok = store->IncRef(id);
-  assert(ok);
-  if (store == &regular_entries_) {
-    LogCvmfs(kLogCache, kLogDebug, "hit in regular entries for %s",
-             id.ToString().c_str());
-    perf::Inc(counters_.n_openregular);
-  } else {
+  open_fds_[fd].is_volatile = is_volatile;
+  if (is_volatile) {
     LogCvmfs(kLogCache, kLogDebug, "hit in volatile entries for %s",
              id.ToString().c_str());
     perf::Inc(counters_.n_openvolatile);
+  } else {
+    LogCvmfs(kLogCache, kLogDebug, "hit in regular entries for %s",
+             id.ToString().c_str());
+    perf::Inc(counters_.n_openregular);
   }
+  ok = GetStore(open_fds_[fd])->IncRef(id);
+  assert(ok);
   return fd;
 }
 
@@ -94,9 +93,8 @@ int64_t RamCacheManager::GetSize(int fd) {
     LogCvmfs(kLogCache, kLogDebug, "bad fd %d on GetSize", fd);
     return -EBADF;
   }
-  assert(open_fds_[fd].store);
   perf::Inc(counters_.n_getsize);
-  return open_fds_[fd].store->GetSize(open_fds_[fd].handle);
+  return GetStore(open_fds_[fd])->GetSize(open_fds_[fd].handle);
 }
 
 
@@ -108,8 +106,7 @@ int RamCacheManager::Close(int fd) {
     LogCvmfs(kLogCache, kLogDebug, "bad fd %d on Close", fd);
     return -EBADF;
   }
-  assert(open_fds_[fd].store);
-  rc = open_fds_[fd].store->Unref(open_fds_[fd].handle);
+  rc = GetStore(open_fds_[fd])->Unref(open_fds_[fd].handle);
   assert(rc);
   open_fds_[fd].handle = kInvalidHandle;
 
@@ -144,9 +141,8 @@ int64_t RamCacheManager::Pread(
     LogCvmfs(kLogCache, kLogDebug, "bad fd %d on Pread", fd);
     return -EBADF;
   }
-  assert(open_fds_[fd].store);
   perf::Inc(counters_.n_pread);
-  return open_fds_[fd].store->Read(open_fds_[fd].handle, buf, size, offset);
+  return GetStore(open_fds_[fd])->Read(open_fds_[fd].handle, buf, size, offset);
 }
 
 
@@ -158,10 +154,9 @@ int RamCacheManager::Dup(int fd) {
     LogCvmfs(kLogCache, kLogDebug, "bad fd %d on Dup", fd);
     return -EBADF;
   }
-  assert(open_fds_[fd].store);
   rc = AddFd(open_fds_[fd]);
   if (rc < 0) return rc;
-  ok = open_fds_[fd].store->IncRef(open_fds_[fd].handle);
+  ok = GetStore(open_fds_[fd])->IncRef(open_fds_[fd].handle);
   assert(ok);
   LogCvmfs(kLogCache, kLogDebug, "dup fd %d", fd);
   perf::Inc(counters_.n_dup);

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -112,7 +112,7 @@ int RamCacheManager::Close(int fd) {
 
   size_t index = open_fds_[fd].index;
   assert(index < fd_index_.size());
-  assert(fd_pivot_ < fd_index_.size());
+  assert(fd_pivot_ <= fd_index_.size());
   assert(fd_pivot_ > 0);
   --fd_pivot_;
   if (index < fd_pivot_) {

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -30,12 +30,12 @@ int RamCacheManager::AddFd(const ReadOnlyFd &fd) {
       return i;
     }
   }
-  if (open_fds_.size() < kMaxHandles) {
+  if (open_fds_.size() < max_entries_) {
     open_fds_.push_back(fd);
     // LogCvmfs(kLogCache, kLogDebug, "adding fd %u", i);
     return i;
   } else {
-    LogCvmfs(kLogCache, kLogDebug, "too many open files (%u)", kMaxHandles);
+    LogCvmfs(kLogCache, kLogDebug, "too many open files (%u)", max_entries_);
     perf::Inc(counters_.n_enfile);
     return -ENFILE;
   }

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -27,8 +27,8 @@ int RamCacheManager::AddFd(const ReadOnlyFd &fd) {
     perf::Inc(counters_.n_enfile);
     return -ENFILE;
   }
-  int next_fd = fd_index_[fd_pivot_];
-  assert(next_fd < static_cast<int>(open_fds_.size()));
+  size_t next_fd = fd_index_[fd_pivot_];
+  assert(next_fd < open_fds_.size());
   assert(open_fds_[next_fd].handle == kInvalidHandle);
   open_fds_[next_fd] = fd;
   open_fds_[next_fd].index = fd_pivot_;
@@ -116,9 +116,8 @@ int RamCacheManager::Close(int fd) {
   assert(fd_pivot_ > 0);
   --fd_pivot_;
   if (index < fd_pivot_) {
-    int other = fd_index_[fd_pivot_];
-    assert(other >= 0);
-    assert(other < static_cast<int>(open_fds_.size()));
+    size_t other = fd_index_[fd_pivot_];
+    assert(other < open_fds_.size());
     assert(open_fds_[other].handle != kInvalidHandle);
     open_fds_[other].index = index;
     fd_index_[index] = other;

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -240,8 +240,14 @@ class RamCacheManager : public CacheManager {
 
  private:
   struct ReadOnlyFd {
-    ReadOnlyFd() : handle(kInvalidHandle) { }
-    explicit ReadOnlyFd(const shash::Any &h) : handle(h) { }
+    ReadOnlyFd()
+      : handle(kInvalidHandle)
+      , is_volatile(false)
+      , index(0) {}
+    explicit ReadOnlyFd(const shash::Any &h)
+      : handle(h)
+      , is_volatile(false)
+      , index(0) {}
     shash::Any handle;
     bool is_volatile;
     size_t index;

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -284,7 +284,7 @@ class RamCacheManager : public CacheManager {
   uint64_t max_size_;
   size_t fd_pivot_;
   std::vector<ReadOnlyFd> open_fds_;
-  std::vector<int> fd_index_;
+  std::vector<size_t> fd_index_;
   pthread_rwlock_t rwlock_;
   MemoryKvStore regular_entries_;
   MemoryKvStore volatile_entries_;

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -23,8 +23,6 @@ namespace cache {
 // an invalid handle
 static const shash::Any kInvalidHandle;
 
-static const unsigned kMaxHandles = 8192;
-
 /**
  * The @p RamCacheManager class provides a cache backend that operates
  * entirely from the host's RAM. This backend does not require any
@@ -109,6 +107,7 @@ class RamCacheManager : public CacheManager {
     unsigned max_entries,
     perf::Statistics *statistics)
     : max_size_(max_size)
+    , max_entries_(max_entries)
     , regular_entries_(max_entries/2, "RamCache.regular", statistics)
     , volatile_entries_(max_entries/2, "RamCache.volatile", statistics)
     , counters_(statistics, "RamCache") {
@@ -274,6 +273,7 @@ class RamCacheManager : public CacheManager {
   virtual int DoOpen(const shash::Any &id);
 
   uint64_t max_size_;
+  uint64_t max_entries_;
   std::vector<ReadOnlyFd> open_fds_;
   pthread_rwlock_t rwlock_;
   MemoryKvStore regular_entries_;


### PR DESCRIPTION
I changed the routines for opening/closing file descriptors in the RAM cache to O(1) and switched to fixed allocation of fds. An index of used/free fds is necessary, and each `ReadOnlyFd` needs to know its position in the fd index, increasing the memory use by ~2 `int`s/fd. I was also able to remove some unneeded fields from `ReadOnlyFd`.