### PR TITLE
Expose statistics counters from libcvmfs

### DIFF
--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -370,7 +370,7 @@ void cvmfs_set_log_fn(void (*log_fn)(const char *msg))
 }
 
 
-char *cvmfs_format_statistics(cvmfs_context *ctx) {
+char *cvmfs_statistics_format(cvmfs_context *ctx) {
   assert(ctx != NULL);
   std::string stats = ctx->mount_point()->statistics()
     ->PrintList(perf::Statistics::kPrintHeader);

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -370,6 +370,14 @@ void cvmfs_set_log_fn(void (*log_fn)(const char *msg))
 }
 
 
+char *cvmfs_format_statistics(cvmfs_context *ctx) {
+  assert(ctx != NULL);
+  std::string stats = ctx->mount_point()->statistics()
+    ->PrintList(perf::Statistics::kPrintHeader);
+  return strdup(stats.c_str());
+}
+
+
 int cvmfs_remount(LibContext *ctx) {
   catalog::LoadError retval = ctx->RemountStart();
   if (retval == catalog::kLoadNew || retval == catalog::kLoadUp2Date) {

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -96,6 +96,13 @@ typedef enum {
  */
 void cvmfs_set_log_fn( void (*log_fn)(const char *msg) );
 
+/**
+ * Get runtime statistics formatted as a string.  The raw counters
+ * are also available via @p cvmfs_talk when using the FUSE module.
+ * @p cvmfs_statistics() allocates a new string, which the caller must free.
+ * Returns NULL if insufficient  memory  was  available.
+ */
+char *cvmfs_format_statistics(cvmfs_context *ctx);
 
 /**
  * An option map must be created an populated before calling cvmfs_init_v2().

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -102,7 +102,7 @@ void cvmfs_set_log_fn( void (*log_fn)(const char *msg) );
  * @p cvmfs_statistics() allocates a new string, which the caller must free.
  * Returns NULL if insufficient  memory  was  available.
  */
-char *cvmfs_format_statistics(cvmfs_context *ctx);
+char *cvmfs_statistics_format(cvmfs_context *ctx);
 
 /**
  * An option map must be created an populated before calling cvmfs_init_v2().

--- a/cvmfs/libcvmfs_public_syms.txt
+++ b/cvmfs/libcvmfs_public_syms.txt
@@ -23,7 +23,7 @@ cvmfs_adopt_options
 cvmfs_detach_repo
 cvmfs_remount
 cvmfs_set_log_fn
-cvmfs_format_statistics
+cvmfs_statistics_format
 cvmfs_open
 cvmfs_pread
 cvmfs_close

--- a/cvmfs/libcvmfs_public_syms.txt
+++ b/cvmfs/libcvmfs_public_syms.txt
@@ -23,6 +23,7 @@ cvmfs_adopt_options
 cvmfs_detach_repo
 cvmfs_remount
 cvmfs_set_log_fn
+cvmfs_format_statistics
 cvmfs_open
 cvmfs_pread
 cvmfs_close


### PR DESCRIPTION
I'd like to be able to get statistics when using libcvmfs via Parrot. Per discussion with @jblomer, this PR adds a library function to get counters reported by `cvmfs_talk`