### PR TITLE
Custom allocator for in-memory object cache

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -65,6 +65,7 @@ set (CVMFS_CLIENT_SOURCES
   logging.cc logging.h logging_internal.h
   lru.h
   malloc_arena.cc malloc_arena.h
+  malloc_heap.cc malloc_heap.h
   manifest.cc manifest.h
   manifest_fetch.cc manifest_fetch.h
   monitor.cc monitor.h

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -76,13 +76,13 @@ void MallocHeap::Compact() {
 }
 
 
-void MallocHeap::Free(void *block) {
+void MallocHeap::MarkFree(void *block) {
   Tag *tag = reinterpret_cast<Tag *>(block) - 1;
   assert(tag->size > 0);
   tag->size = -(tag->size);
   stored_ -= tag->GetSize();
   num_blocks_--;
-  // TODO(jblomer): if Free() takes place at the top of the heap, one could
+  // TODO(jblomer): if MarkFree() takes place at the top of the heap, one could
   // move back the gauge_ pointer.  If this is an optimiziation or unnecessary
   // extra work depends on how the MallocHeap is used.
 }

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -1,0 +1,10 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+#include "malloc_heap.h"
+
+#include "smalloc.h"
+
+using namespace std;  // NOLINT

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -5,6 +5,110 @@
 #include "cvmfs_config.h"
 #include "malloc_heap.h"
 
+#include <cassert>
+#include <cstring>
+#include <new>
+
 #include "smalloc.h"
 
 using namespace std;  // NOLINT
+
+void *MallocHeap::Allocate(
+  uint64_t size,
+  unsigned char *header,
+  unsigned header_size)
+{
+  assert(size > 0);
+  assert(header_size <= size);
+  uint64_t rounded_size = RoundUp8(size);
+  int64_t real_size = rounded_size + sizeof(Tag);
+  if (gauge_ + real_size > capacity_)
+    return NULL;
+
+  unsigned char *new_block = heap_ + gauge_;
+  new (new_block) Tag(rounded_size);
+  new_block += sizeof(Tag);
+  memcpy(new_block, header, header_size);
+  gauge_ += real_size;
+  return new_block;
+}
+
+
+void MallocHeap::Compact() {
+  if (gauge_ == 0)
+    return;
+
+  // Not really a tag, just the top memory address
+  Tag *heap_top = reinterpret_cast<Tag *>(heap_ + gauge_);
+  Tag *current_tag = reinterpret_cast<Tag *>(heap_);
+  Tag *next_tag = current_tag->JumpToNext();
+  // Move a sliding window of two blocks over the heap and compact where
+  // possible
+  while (next_tag < heap_top) {
+    if (current_tag->IsFree()) {
+      if (next_tag->IsFree()) {
+        // Adjacent free blocks, merge and try again
+        current_tag->size -= sizeof(Tag) + next_tag->GetSize();
+        next_tag = next_tag->JumpToNext();
+      } else {
+        // Free block followed by a reserved block, move memory and create a
+        // new free tag at the end of the moved block
+        int64_t free_space = current_tag->size;
+        current_tag->size = next_tag->size;
+        memmove(current_tag->GetBlock(),
+                next_tag->GetBlock(), next_tag->GetSize());
+        (*callback_ptr_)(current_tag->GetBlock());
+        next_tag = current_tag->JumpToNext();
+        next_tag->size = free_space;
+      }
+    } else {
+      // Current block allocated, move on
+      current_tag = next_tag;
+      next_tag = next_tag->JumpToNext();
+    }
+  }
+
+  gauge_ = (reinterpret_cast<unsigned char *>(current_tag) - heap_);
+  if (!current_tag->IsFree())
+    gauge_ += sizeof(Tag) + current_tag->GetSize();
+}
+
+
+void MallocHeap::Free(void *block) {
+  Tag *tag = reinterpret_cast<Tag *>(block) - 1;
+  assert(tag->size > 0);
+  tag->size = -(tag->size);
+  // TODO(jblomer): if Free() takes place at the top of the heap, one could
+  // move back the gauge_ pointer.  If this is an optimiziation or unnecessary
+  // extra work depends on how the MallocHeap is used.
+}
+
+
+uint64_t MallocHeap::GetSize(void *block) {
+  Tag *tag = reinterpret_cast<Tag *>(block) - 1;
+  assert(tag->size > 0);
+  return tag->size;
+}
+
+
+MallocHeap::MallocHeap(uint64_t capacity, CallbackPtr callback_ptr)
+  : callback_ptr_(callback_ptr)
+  , capacity_(capacity)
+  , gauge_(0)
+{
+  assert(capacity_ > kMinCapacity);
+  // Ensure 8-byte alignment
+  assert((capacity_ % 8) == 0);
+  heap_ = reinterpret_cast<unsigned char *>(sxmmap(capacity + 7));
+  uintptr_t head = capacity - (uintptr_t(heap_) % 8);
+  sxunmap(heap_, head);
+  heap_ += head;
+  uintptr_t tail = capacity - head;
+  if (tail > 0)
+    sxunmap(heap_ + capacity, tail);
+}
+
+
+MallocHeap::~MallocHeap() {
+  sxunmap(heap_, capacity_);
+}

--- a/cvmfs/malloc_heap.h
+++ b/cvmfs/malloc_heap.h
@@ -8,26 +8,70 @@
 #include <inttypes.h>
 #include <stdint.h>
 
-#include <cassert>
+#include "util/async.h"
 
 /**
+ * Fills an ever-growing heap.  Free calls simply mark a block as free but
+ * allocation continues to take place at the top of the heap.  Hence Realloc()
+ * is inefficient.  For the common pattern of doubling a buffer with realloc,
+ * twice the final buffer size is required.
  *
+ * The allocator is copying and can "garbage collect".  In order to react on the
+ * move of a block, a callback can be registered that gets called with the new
+ * pointer address.  The user of the MallocHeap has to make sure to identify
+ * any block based on the first bytes.  Therefore, allocation requires these
+ * first bytes, a user-defined "header" if you will.
+ * Note that during a Compact() not even reading from any of the pointers is
+ * allowed!
+ *
+ * MallocHeap is used  by the in-memory object cache.  The header is the
+ * object's content hash, so the cache manager can identify any block in its
+ * hash table and move the pointers when MallocHeap runs a garbage collection.
+ *
+ * All memory blocks are 8-byte aligned and they have an 8-byte header
+ * containing their size.  The size is negative for free blocks.
  */
 class MallocHeap {
  public:
-  explicit MallocHeap(uint64_t capacity);
+  // Pointer to the callback method invoked for each memory block that gets
+  // compacted.
+  typedef Callbackable<void *>::CallbackTN* CallbackPtr;
+
+  MallocHeap(uint64_t capacity, CallbackPtr callback_ptr);
   ~MallocHeap();
 
   void *Allocate(uint64_t size, unsigned char *header, unsigned header_size);
   void Free(void *block);
   uint64_t GetSize(void *block);
-  uint64_t GetSizeInRam(void *block) { return RoundUp8(GetSize(block)); }
   void Compact();
 
  private:
+  /**
+   * Minimum number of bytes of the heap.
+   */
+  static const unsigned kMinCapacity = 1024;
+
+  /**
+   * Prepends every block.  The size does not include the size of the tag.  The
+   * size of the Tag structure has to be a multiple of 8 for alignment.
+   */
   struct Tag {
+    Tag() : size(0) { }
+    explicit Tag(int64_t s) : size(s) { }
+    inline uint64_t GetSize() {
+      if (size < 0) return -size;
+      return size;
+    }
+    inline bool IsFree() { return size < 0; }
+    inline Tag *JumpToNext() {
+      return reinterpret_cast<Tag *>(
+        reinterpret_cast<unsigned char *>(this) + sizeof(Tag) + GetSize());
+    }
+    inline unsigned char *GetBlock() {
+      return reinterpret_cast<unsigned char *>(this) + sizeof(Tag);
+    }
     /**
-     * Positive for reserved blocks, negative for free blocks
+     * Positive for reserved blocks, negative for free blocks.
      */
     int64_t size;
   };
@@ -41,6 +85,10 @@ class MallocHeap {
   }
 
   /**
+   * Invoked when a block is moved during compact.
+   */
+  CallbackPtr callback_ptr_;
+  /**
    * Total size of mmap'd arena.
    */
   uint64_t capacity_;
@@ -48,6 +96,10 @@ class MallocHeap {
    * End of the area of reserved blocks, used for the next allocation.
    */
   uint64_t gauge_;
+  /**
+   * The big mmap'd memory block used to serve allocation requests.
+   */
+  unsigned char *heap_;
 };  // class MallocHeap
 
 #endif  // CVMFS_MALLOC_HEAP_H_

--- a/cvmfs/malloc_heap.h
+++ b/cvmfs/malloc_heap.h
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_MALLOC_HEAP_H_
+#define CVMFS_MALLOC_HEAP_H_
+
+#include <inttypes.h>
+#include <stdint.h>
+
+#include <cassert>
+
+/**
+ *
+ */
+class MallocHeap {
+ public:
+  explicit MallocHeap(uint64_t capacity);
+  ~MallocHeap();
+
+  void *Allocate(uint64_t size, unsigned char *header, unsigned header_size);
+  void Free(void *block);
+  uint64_t GetSize(void *block);
+  uint64_t GetSizeInRam(void *block) { return RoundUp8(GetSize(block)); }
+  void Compact();
+
+ private:
+  struct Tag {
+    /**
+     * Positive for reserved blocks, negative for free blocks
+     */
+    int64_t size;
+  };
+
+  /**
+   * Round up size to the next larger multiple of 8.  This is used to enforce
+   * 8-byte alignment.
+   */
+  static inline uint32_t RoundUp8(const uint32_t size) {
+    return (size + 7) & ~7;
+  }
+
+  /**
+   * Total size of mmap'd arena.
+   */
+  uint64_t capacity_;
+  /**
+   * End of the area of reserved blocks, used for the next allocation.
+   */
+  uint64_t gauge_;
+};  // class MallocHeap
+
+#endif  // CVMFS_MALLOC_HEAP_H_

--- a/cvmfs/malloc_heap.h
+++ b/cvmfs/malloc_heap.h
@@ -49,7 +49,7 @@ class MallocHeap {
   ~MallocHeap();
 
   void *Allocate(uint64_t size, void *header, unsigned header_size);
-  void Free(void *block);
+  void MarkFree(void *block);
   uint64_t GetSize(void *block);
   void Compact();
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -154,6 +154,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/libcvmfs_options.cc
   ${CVMFS_SOURCE_DIR}/logging.cc ${CVMFS_SOURCE_DIR}/logging.h ${CVMFS_SOURCE_DIR}/logging_internal.h
   ${CVMFS_SOURCE_DIR}/malloc_arena.cc ${CVMFS_SOURCE_DIR}/malloc_arena.h
+  ${CVMFS_SOURCE_DIR}/malloc_heap.cc ${CVMFS_SOURCE_DIR}/malloc_heap.h
   ${CVMFS_SOURCE_DIR}/manifest.cc ${CVMFS_SOURCE_DIR}/manifest.h
   ${CVMFS_SOURCE_DIR}/manifest_fetch.cc ${CVMFS_SOURCE_DIR}/manifest_fetch.h
   ${CVMFS_SOURCE_DIR}/monitor.cc ${CVMFS_SOURCE_DIR}/monitor.h

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CVMFS_UNITTEST_FILES
   t_lru.cc
   t_macaroon.cc
   t_malloc_arena.cc
+  t_malloc_heap.cc
   t_manifest.cc
   t_mountpoint.cc
   t_object_fetcher.cc

--- a/test/unittests/t_malloc_heap.cc
+++ b/test/unittests/t_malloc_heap.cc
@@ -1,0 +1,155 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <inttypes.h>
+#include <stdint.h>
+
+#include <cassert>
+#include <cstring>
+#include <map>
+#include <vector>
+
+#include "malloc_heap.h"
+#include "murmur.h"
+#include "prng.h"
+#include "util/async.h"
+
+using namespace std;  // NOLINT
+
+class T_MallocHeap : public ::testing::Test {
+ protected:
+  static const unsigned kSmallArena = 8 * 1024 * 1024;
+  static const unsigned kBigArena = 512 * 1024 * 1024;  // 512MB RAM Cache arena
+
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+  static uint32_t MemChecksum(void *p, uint32_t size) {
+    return MurmurHash2(p, size, 0x07387a4f);
+  }
+
+  static inline uint32_t RoundUp8(const uint32_t size) {
+    return (size + 7) & ~7;
+  }
+
+  void FillRandomly(void *ptr, unsigned nbytes, Prng *prng) {
+    assert(nbytes >= sizeof(uint32_t));
+    nbytes -= sizeof(uint32_t);
+    for (uint32_t i = 0; i <= nbytes; i += sizeof(uint32_t)) {
+      uint32_t *target = reinterpret_cast<uint32_t *>(
+        reinterpret_cast<unsigned char *>(ptr) + i);
+      *target = prng->Next(0xFFFFFFFF);
+    }
+  }
+
+  class CallbackNull : public Callbackable<MallocHeap::BlockPtr> {
+   public:
+    void Ignore(const MallocHeap::BlockPtr &ptr) { };
+  };
+
+  class IntMap : public Callbackable<MallocHeap::BlockPtr> {
+   public:
+    IntMap() : num_moves(0) { }
+
+    struct Info {
+      Info() : ptr(NULL), checksum(0) { }
+      Info(void *p, uint32_t c) : ptr(p), checksum(c) { }
+      void *ptr;
+      uint32_t checksum;
+    };
+
+    void OnBlockMove(const MallocHeap::BlockPtr &new_ptr) {
+      unsigned id = *reinterpret_cast<unsigned *>(new_ptr.pointer);
+      mem_digest[id].ptr = new_ptr.pointer;
+      num_moves++;
+    };
+
+    unsigned num_moves;
+    map<unsigned, Info> mem_digest;
+  };
+};
+
+
+TEST_F(T_MallocHeap, Basic) {
+  CallbackNull cb_null;
+  MallocHeap M(kSmallArena,
+               cb_null.MakeCallback(&CallbackNull::Ignore, &cb_null));
+  M.Compact();
+
+  vector<void *> pointers;
+
+  const unsigned N = 1000;
+  for (unsigned i = 1; i <= N; ++i) {
+    unsigned header = i;
+    void *p = M.Allocate(i + sizeof(header), &header, sizeof(header));
+    EXPECT_TRUE(p != NULL);
+    pointers.push_back(p);
+  }
+  uint64_t stored_bytes = M.stored_bytes();
+  uint64_t used_bytes = M.used_bytes();
+  EXPECT_GE(stored_bytes, (N * (N-1) / 2) + (N * sizeof(unsigned)));
+  EXPECT_GT(used_bytes, stored_bytes);
+  M.Compact();
+  EXPECT_EQ(stored_bytes, M.stored_bytes());
+  EXPECT_EQ(used_bytes, M.used_bytes());
+
+  for (unsigned i = 1; i <= N; ++i)
+    M.Free(pointers[i-1]);
+  M.Compact();
+  EXPECT_EQ(0U, M.used_bytes());
+  EXPECT_EQ(0U, M.stored_bytes());
+}
+
+
+TEST_F(T_MallocHeap, Stress) {
+  IntMap int_map;
+  MallocHeap M(kBigArena,
+               int_map.MakeCallback(&IntMap::OnBlockMove, &int_map));
+  Prng prng;
+  //prng.InitLocaltime();
+  prng.InitSeed(52);
+  // 512M can host ~100000 4k + 8 bytes blocks
+  unsigned N = 100000;
+  unsigned max_size = 4096;
+  for (unsigned i = 0; i < N; ++i) {
+    unsigned size = prng.Next(max_size - 16) + 16;
+    size = RoundUp8(size);
+    void *ptr = M.Allocate(size, &i, sizeof(i));
+    ASSERT_TRUE(ptr != NULL);
+    FillRandomly(reinterpret_cast<unsigned char *>(ptr) + sizeof(i),
+                 size - sizeof(i), &prng);
+    int_map.mem_digest[i] = IntMap::Info(ptr, MemChecksum(ptr, size));
+  }
+
+  // Create random holes
+  for (unsigned i = 0; i < N; ++i) {
+    uint32_t coin = prng.Next(512);
+    if (coin < 256)
+      continue;
+    M.Free(int_map.mem_digest[i].ptr);
+    int_map.mem_digest.erase(i);
+  }
+  EXPECT_LT(0, M.num_blocks());
+  EXPECT_LT(M.num_blocks(), N);
+
+  M.Compact();
+  EXPECT_EQ(int_map.mem_digest.size(), M.num_blocks());
+  EXPECT_GT(int_map.num_moves, 0);
+  EXPECT_LE(int_map.num_moves, int_map.mem_digest.size());
+
+  // Verify survivor blocks
+  map<unsigned, IntMap::Info>::const_iterator iter =
+    int_map.mem_digest.begin();
+  map<unsigned, IntMap::Info>::const_iterator i_end =
+    int_map.mem_digest.end();
+  for (; iter != i_end; ++iter) {
+    EXPECT_EQ(MemChecksum(iter->second.ptr, M.GetSize(iter->second.ptr)),
+              iter->second.checksum);
+  }
+}

--- a/test/unittests/t_malloc_heap.cc
+++ b/test/unittests/t_malloc_heap.cc
@@ -50,7 +50,7 @@ class T_MallocHeap : public ::testing::Test {
 
   class CallbackNull : public Callbackable<MallocHeap::BlockPtr> {
    public:
-    void Ignore(const MallocHeap::BlockPtr &ptr) { };
+    void Ignore(const MallocHeap::BlockPtr &ptr) { }
   };
 
   class IntMap : public Callbackable<MallocHeap::BlockPtr> {
@@ -68,7 +68,7 @@ class T_MallocHeap : public ::testing::Test {
       unsigned id = *reinterpret_cast<unsigned *>(new_ptr.pointer);
       mem_digest[id].ptr = new_ptr.pointer;
       num_moves++;
-    };
+    }
 
     unsigned num_moves;
     map<unsigned, Info> mem_digest;


### PR DESCRIPTION
A "heap allocator" for the RAM cache.  It mmap's one large chunk on construction and stays within this chunk.  It is copying (compacting), i.e. when the cache gets cleaned up, the surviving blocks will be compacted.  In effect, this allocator is  supposed to provide optimal utilization.

The cost is that every blocks needs to be prepended with an identifier that allows the user of this allocator to fix the pointers when it comes to a `Compact()`.  For the RAM cache, it means that both content hash and content need to be stored in memory.  For average object sizes of 4k, the waste is still below the percent level.