### PR TITLE
Allow for pruning pf previous catalogs during pull

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -1041,6 +1041,18 @@ is_garbage_collectable() {
   fi
 }
 
+
+# checks if the (corresponding) stratum 0 is garbage collectable
+#
+# @param name  the name of the stratum1/stratum0 repository to be checked
+# @return      0 if it is garbage collectable
+is_stratum0_garbage_collectable() {
+  local name=$1
+  load_repo_config $name
+  [ x"$(get_repo_info_from_url $CVMFS_STRATUM0 -g)" = x"yes" ]
+}
+
+
 # checks if a manifest ist present
 #
 # @param name  the name of the repository to be checked
@@ -5520,11 +5532,14 @@ __do_snapshot() {
     # do the actual snapshot actions
     local with_history=""
     local with_reflog=""
+    local timestamp_threshold=""
     [ $initial_snapshot -ne 1 ] && with_history="-p"
     [ $initial_snapshot -eq 1 ] && \
       with_reflog="-R $(get_reflog_checksum $alias_name)"
     has_reflog_checksum $alias_name && \
       with_reflog="-R $(get_reflog_checksum $alias_name)"
+    is_stratum0_garbage_collectable $alias_name &&
+      timestamp_threshold="-Z $gc_timespan"
     $user_shell "$(__swissknife_cmd dbg) pull -m $name \
         -u $stratum0                                   \
         -w $stratum1                                   \
@@ -5533,7 +5548,8 @@ __do_snapshot() {
         -k $public_key                                 \
         -n $num_workers                                \
         -t $timeout                                    \
-        -a $retries $with_history $with_reflog $initial_snapshot_flag $log_level"
+        -a $retries $with_history $with_reflog         \
+           $initial_snapshot_flag $timestamp_threshold $log_level"
 
     local last_snapshot_tmp="${spool_dir}/tmp/last_snapshot"
     $user_shell "date --utc > $last_snapshot_tmp"

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -41,6 +41,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional('t', "timeout (s)"));
     r.push_back(Parameter::Optional('a', "number of retries"));
     r.push_back(Parameter::Optional('d', "directory for path specification"));
+    r.push_back(Parameter::Optional('Z', "pull revisions younger than <Z>"));
     r.push_back(Parameter::Switch('p', "pull catalog history, too"));
     r.push_back(Parameter::Switch('i', "mark as an 'initial snapshot'"));
     r.push_back(Parameter::Switch('c', "preload cache instead of stratum 1"));

--- a/test/src/637-snapshottimespan/main
+++ b/test/src/637-snapshottimespan/main
@@ -1,0 +1,61 @@
+cvmfs_test_name="Apply timestamp threshold to replication of gc-enabled repos"
+cvmfs_test_autofs_on_startup=false
+
+CVMFS_TEST637_REPLICA_NAME=
+
+cleanup() {
+  sudo cvmfs_server rmfs -f $CVMFS_TEST637_REPLICA_NAME > /dev/null 2>&1
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  CVMFS_TEST637_REPLICA_NAME="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  echo "*** create a gc-enabled repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -z -g || return $?
+  start_transaction $CVMFS_TEST_REPO
+  mkdir /cvmfs/$CVMFS_TEST_REPO/nested
+  touch /cvmfs/$CVMFS_TEST_REPO/nested/.cvmfscatalog
+  publish_repo $CVMFS_TEST_REPO
+
+  echo "*** setup cleanup trap"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "*** create Stratum1 repository on the same machine"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $CVMFS_TEST637_REPLICA_NAME            \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+    || return 10
+
+  echo "*** Set GC threshold to 'next week'"
+  echo "CVMFS_AUTO_GC_TIMESPAN='next week'" | sudo tee -a \
+    /etc/cvmfs/repositories.d/$CVMFS_TEST637_REPLICA_NAME/server.conf || return 11
+
+  echo "*** create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
+  sudo cvmfs_server snapshot $CVMFS_TEST637_REPLICA_NAME || return 20
+  check_repository $CVMFS_TEST637_REPLICA_NAME -i || return 21
+
+  echo "*** publish three times on stratum 0"
+  start_transaction $CVMFS_TEST_REPO
+  publish_repo $CVMFS_TEST_REPO
+  local hidden_hash=$(get_xattr root_hash /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly)
+  start_transaction $CVMFS_TEST_REPO
+  publish_repo $CVMFS_TEST_REPO -a "abc"
+  start_transaction $CVMFS_TEST_REPO
+  publish_repo $CVMFS_TEST_REPO
+  echo "*** hidden root hash is $hidden_hash"
+
+  echo "*** snapshot again"
+  sudo cvmfs_server snapshot $CVMFS_TEST637_REPLICA_NAME || return 30
+  check_repository $CVMFS_TEST637_REPLICA_NAME -i || return 31
+  check_repository $CVMFS_TEST637_REPLICA_NAME -i -t abc || return 32
+
+  echo "*** ensure that hidden hash got pruned"
+  peek_backend $CVMFS_TEST637_REPLICA_NAME "${hidden_hash}C" && return 40
+
+  return 0
+}
+


### PR DESCRIPTION
For garbage-collectable repos, stops replicating the "previous root catalog" chain once the catalogs are older than the GC grace period.  Solves one point from the race described in CVM-844.