### PR TITLE
Garbage collection fixes

### DIFF
--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -32,6 +32,8 @@
 #ifndef CVMFS_GARBAGE_COLLECTION_GARBAGE_COLLECTOR_H_
 #define CVMFS_GARBAGE_COLLECTION_GARBAGE_COLLECTOR_H_
 
+#include <inttypes.h>
+
 #include <vector>
 
 #include "garbage_collection/hash_filter.h"
@@ -85,6 +87,7 @@ class GarbageCollector {
   unsigned int preserved_catalog_count() const { return preserved_catalogs_; }
   unsigned int condemned_catalog_count() const { return condemned_catalogs_; }
   unsigned int condemned_objects_count() const { return condemned_objects_;  }
+  uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }
 
  protected:
   static TraversalParameters GetTraversalParams(
@@ -110,6 +113,14 @@ class GarbageCollector {
   CatalogTraversalT     traversal_;
   HashFilterT           hash_filter_;
 
+  /**
+   * A marker for the garbage collection grace period, the time span that is
+   * walked back from the current head catalog.  There can be named snapshots
+   * older than this snapshot.  The oldest_trunk_catalog_ is used as a marker
+   * for when to remove auxiliary files (meta info, history, ...).
+   */
+  uint64_t              oldest_trunk_catalog_;
+  bool                  oldest_trunk_catalog_found_;
   unsigned int          preserved_catalogs_;
   unsigned int          condemned_catalogs_;
 

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -205,7 +205,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
 
   const ReflogTN *reflog = configuration_.reflog;
   std::vector<shash::Any> catalogs;
-  if (NULL == reflog || !reflog->ListCatalogs(&catalogs)) {
+  if (NULL == reflog || !reflog->List(SqlReflog::kRefCatalog, &catalogs)) {
     LogCvmfs(kLogGc, kLogStderr, "Failed to list catalog reference log");
     return false;
   }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -150,9 +150,10 @@ template <class CatalogTraversalT, class HashFilterT>
 bool GarbageCollector<CatalogTraversalT, HashFilterT>::
   RemoveCatalogFromReflog(const shash::Any &catalog)
 {
+  assert(catalog.suffix == shash::kSuffixCatalog);
   return (configuration_.dry_run)
     ? true
-    : configuration_.reflog->RemoveCatalog(catalog);
+    : configuration_.reflog->Remove(catalog);
 }
 
 
@@ -200,7 +201,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::CheckPreservedRevisions()
 template <class CatalogTraversalT, class HashFilterT>
 bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
   if (configuration_.verbose) {
-    LogCvmfs(kLogGc, kLogStdout, "Sweeping Reference Logs");
+    LogCvmfs(kLogGc, kLogStdout, "Sweeping reference logs");
   }
 
   const ReflogTN *reflog = configuration_.reflog;

--- a/cvmfs/garbage_collection/gc_aux.h
+++ b/cvmfs/garbage_collection/gc_aux.h
@@ -1,0 +1,56 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_GARBAGE_COLLECTION_GC_AUX_H_
+#define CVMFS_GARBAGE_COLLECTION_GC_AUX_H_
+
+#include <string>
+
+#include "garbage_collection/garbage_collector.h"
+#include "reflog_sql.h"
+
+/**
+ * Garbage collection for auxiliary files is much simpler than for catalogs.
+ * Auxiliary files are the tag database, meta info, and the certificate.  These
+ * objects do not reference other objects.  Also, they are not referenced from
+ * catalogs but from the manifest.  Thus they become garbage immediately on
+ * publishing of a new revision with different objects (we still apply a
+ * grace period before deletion).
+ *
+ * The reference log can provide a time-sorted list of object hashes. Since the
+ * hashes are unique (primary key), it is sufficient to walk through the list
+ * and remove all auxiliary objects older than X.  In addition, we keep the
+ * versions of all auxiliary files provided through a hash filter.  This is
+ * usually the objects referenced by the current manifest.
+ *
+ * The timestamp X comes from the catalog garbage collection, which, as part of
+ * the catalog traversal, figures out the oldest catalog from the "previous
+ * catalog" chain that needs to be preserved (named snapshots can be older).
+ * Auxiliary files produced during publish are at least as young as their
+ * corresponding root catalog.
+ */
+template<class CatalogTraversalT, class HashFilterT>
+class GarbageCollectorAux {
+  typedef typename CatalogTraversalT::ObjectFetcherTN ObjectFetcherTN;
+  typedef typename ObjectFetcherTN::ReflogTN          ReflogTN;
+  typedef typename
+    GarbageCollector<CatalogTraversalT, HashFilterT>::Configuration
+    ConfigurationTN;
+
+ public:
+  explicit GarbageCollectorAux(const ConfigurationTN &config);
+
+  bool CollectOlderThan(uint64_t timestamp,
+                        const HashFilterT &preserved_objects);
+
+ private:
+  std::string PrintAuxType(SqlReflog::ReferenceType type);
+  bool Sweep(const shash::Any &hash);
+
+  const ConfigurationTN config_;
+};  // class GarbageCollectorAux
+
+#include "gc_aux_impl.h"
+
+#endif  // CVMFS_GARBAGE_COLLECTION_GC_AUX_H_

--- a/cvmfs/garbage_collection/gc_aux_impl.h
+++ b/cvmfs/garbage_collection/gc_aux_impl.h
@@ -26,8 +26,8 @@ bool GarbageCollectorAux<CatalogTraversalT, HashFilterT>::CollectOlderThan(
   const HashFilterT &preserved_objects)
 {
   if (config_.verbose) {
-    LogCvmfs(kLogGc, kLogStdout, "Sweeping auxiliary objects older than %s (%u)",
-             StringifyTime(timestamp, true).c_str(), timestamp);
+    LogCvmfs(kLogGc, kLogStdout, "Sweeping auxiliary objects older than %s",
+             StringifyTime(timestamp, true).c_str());
   }
   std::vector<SqlReflog::ReferenceType> aux_types;
   aux_types.push_back(SqlReflog::kRefCertificate);
@@ -43,7 +43,7 @@ bool GarbageCollectorAux<CatalogTraversalT, HashFilterT>::CollectOlderThan(
       return 1;
     }
     if (config_.verbose) {
-      LogCvmfs(kLogGc, kLogStdout, "Looking at %u %s objects",
+      LogCvmfs(kLogGc, kLogStdout, "Scanning %u %s objects",
                hashes.size(), PrintAuxType(aux_types[i]).c_str());
     }
 

--- a/cvmfs/garbage_collection/gc_aux_impl.h
+++ b/cvmfs/garbage_collection/gc_aux_impl.h
@@ -1,0 +1,118 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_GARBAGE_COLLECTION_GC_AUX_IMPL_H_
+#define CVMFS_GARBAGE_COLLECTION_GC_AUX_IMPL_H_
+
+#include <cstdio>
+#include <vector>
+
+#include "logging.h"
+#include "util/string.h"
+
+template <class CatalogTraversalT, class HashFilterT>
+GarbageCollectorAux<CatalogTraversalT, HashFilterT>::GarbageCollectorAux(
+  const ConfigurationTN &config)
+  : config_(config)
+{
+  assert(config_.uploader != NULL);
+}
+
+
+template <class CatalogTraversalT, class HashFilterT>
+bool GarbageCollectorAux<CatalogTraversalT, HashFilterT>::CollectOlderThan(
+  uint64_t timestamp,
+  const HashFilterT &preserved_objects)
+{
+  if (config_.verbose) {
+    LogCvmfs(kLogGc, kLogStdout, "Sweeping auxiliary objects older than %s (%u)",
+             StringifyTime(timestamp, true).c_str(), timestamp);
+  }
+  std::vector<SqlReflog::ReferenceType> aux_types;
+  aux_types.push_back(SqlReflog::kRefCertificate);
+  aux_types.push_back(SqlReflog::kRefHistory);
+  aux_types.push_back(SqlReflog::kRefMetainfo);
+  for (unsigned i = 0; i < aux_types.size(); ++i) {
+    std::vector<shash::Any> hashes;
+    bool retval =
+      config_.reflog->ListOlderThan(aux_types[i], timestamp, &hashes);
+    if (!retval) {
+      LogCvmfs(kLogGc, kLogStderr, "failed to enumerate %s objects",
+               PrintAuxType(aux_types[i]).c_str());
+      return 1;
+    }
+    if (config_.verbose) {
+      LogCvmfs(kLogGc, kLogStdout, "Looking at %u %s objects",
+               hashes.size(), PrintAuxType(aux_types[i]).c_str());
+    }
+
+    for (unsigned iter = 0; iter < hashes.size(); ++iter) {
+      if (preserved_objects.Contains(hashes[iter])) {
+        if (config_.verbose) {
+          LogCvmfs(kLogGc, kLogStdout, "  preserving: %s",
+                   hashes[iter].ToStringWithSuffix().c_str());
+        }
+        continue;
+      }
+
+      if (!Sweep(hashes[iter]))
+        return false;
+    }
+  }
+
+  return true;
+}
+
+
+template <class CatalogTraversalT, class HashFilterT>
+std::string GarbageCollectorAux<CatalogTraversalT, HashFilterT>::PrintAuxType(
+  SqlReflog::ReferenceType type)
+{
+  switch (type) {
+    case SqlReflog::kRefCatalog:
+      return "file catalog";
+    case SqlReflog::kRefCertificate:
+      return "certificate";
+    case SqlReflog::kRefHistory:
+      return "tag database";
+    case SqlReflog::kRefMetainfo:
+      return "repository meta information";
+  }
+  // Never here
+  return "UNKNOWN";
+}
+
+
+template <class CatalogTraversalT, class HashFilterT>
+bool GarbageCollectorAux<CatalogTraversalT, HashFilterT>::Sweep(
+  const shash::Any &hash)
+{
+  if (config_.verbose) {
+    LogCvmfs(kLogGc, kLogStdout,
+             "  sweep: %s", hash.ToStringWithSuffix().c_str());
+  }
+
+  if (!config_.dry_run) {
+    config_.uploader->Remove(hash);
+    bool retval = config_.reflog->Remove(hash);
+    if (!retval) {
+      LogCvmfs(kLogGc, kLogStderr, "failed to remove %s from reference log",
+               hash.ToStringWithSuffix().c_str());
+      return false;
+    }
+  }
+
+  if (config_.has_deletion_log()) {
+    const int written = fprintf(config_.deleted_objects_logfile,
+                                "%s\n", hash.ToStringWithSuffix().c_str());
+    if (written < 0) {
+      LogCvmfs(kLogGc, kLogStderr, "failed to write to deleted objects log");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#endif  // CVMFS_GARBAGE_COLLECTION_GC_AUX_IMPL_H_

--- a/cvmfs/garbage_collection/gc_aux_impl.h
+++ b/cvmfs/garbage_collection/gc_aux_impl.h
@@ -6,6 +6,7 @@
 #define CVMFS_GARBAGE_COLLECTION_GC_AUX_IMPL_H_
 
 #include <cstdio>
+#include <string>
 #include <vector>
 
 #include "logging.h"

--- a/cvmfs/reflog.cc
+++ b/cvmfs/reflog.cc
@@ -144,12 +144,23 @@ bool Reflog::List(
   SqlReflog::ReferenceType type,
   std::vector<shash::Any> *hashes) const
 {
+  return ListOlderThan(type, static_cast<uint64_t>(-1), hashes);
+}
+
+
+bool Reflog::ListOlderThan(
+  SqlReflog::ReferenceType type,
+  uint64_t timestamp,
+  std::vector<shash::Any> *hashes) const
+{
   assert(database_);
   assert(NULL != hashes);
 
   hashes->clear();
 
-  const bool success_bind = list_references_->BindType(type);
+  bool success_bind = list_references_->BindType(type);
+  assert(success_bind);
+  success_bind = list_references_->BindOlderThan(timestamp);
   assert(success_bind);
   while (list_references_->FetchRow()) {
     hashes->push_back(list_references_->RetrieveHash());

--- a/cvmfs/reflog.cc
+++ b/cvmfs/reflog.cc
@@ -170,12 +170,30 @@ bool Reflog::ListOlderThan(
 }
 
 
-bool Reflog::RemoveCatalog(const shash::Any &hash) {
+bool Reflog::Remove(const shash::Any &hash) {
   assert(database_);
 
+  SqlReflog::ReferenceType type;
+  switch (hash.suffix) {
+    case shash::kSuffixCatalog:
+      type = SqlReflog::kRefCatalog;
+      break;
+    case shash::kSuffixHistory:
+      type = SqlReflog::kRefHistory;
+      break;
+    case shash::kSuffixCertificate:
+      type = SqlReflog::kRefCertificate;
+      break;
+    case shash::kSuffixMetainfo:
+      type = SqlReflog::kRefMetainfo;
+      break;
+    default:
+      return false;
+  }
+
   return
-    remove_reference_->BindReference(hash, SqlReflog::kRefCatalog) &&
-    remove_reference_->Execute()                                   &&
+    remove_reference_->BindReference(hash, type) &&
+    remove_reference_->Execute()                 &&
     remove_reference_->Reset();
 }
 

--- a/cvmfs/reflog.cc
+++ b/cvmfs/reflog.cc
@@ -140,13 +140,16 @@ uint64_t Reflog::CountEntries() {
 }
 
 
-bool Reflog::ListCatalogs(std::vector<shash::Any> *hashes) const {
+bool Reflog::List(
+  SqlReflog::ReferenceType type,
+  std::vector<shash::Any> *hashes) const
+{
   assert(database_);
   assert(NULL != hashes);
 
   hashes->clear();
 
-  const bool success_bind = list_references_->BindType(SqlReflog::kRefCatalog);
+  const bool success_bind = list_references_->BindType(type);
   assert(success_bind);
   while (list_references_->FetchRow()) {
     hashes->push_back(list_references_->RetrieveHash());

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -54,6 +54,9 @@ class Reflog {
   uint64_t CountEntries();
   bool List(SqlReflog::ReferenceType type,
             std::vector<shash::Any> *hashes) const;
+  bool ListOlderThan(SqlReflog::ReferenceType type,
+                     uint64_t timestamp,
+                     std::vector<shash::Any> *hashes) const;
 
   bool RemoveCatalog(const shash::Any &hash);
 

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -52,7 +52,8 @@ class Reflog {
   bool AddMetainfo(const shash::Any &metainfo);
 
   uint64_t CountEntries();
-  bool ListCatalogs(std::vector<shash::Any> *hashes) const;
+  bool List(SqlReflog::ReferenceType type,
+            std::vector<shash::Any> *hashes) const;
 
   bool RemoveCatalog(const shash::Any &hash);
 

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -58,7 +58,7 @@ class Reflog {
                      uint64_t timestamp,
                      std::vector<shash::Any> *hashes) const;
 
-  bool RemoveCatalog(const shash::Any &hash);
+  bool Remove(const shash::Any &hash);
 
   bool ContainsCertificate(const shash::Any &certificate) const;
   bool ContainsCatalog(const shash::Any &catalog) const;

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -65,6 +65,9 @@ class Reflog {
   bool ContainsHistory(const shash::Any &history) const;
   bool ContainsMetainfo(const shash::Any &metainfo) const;
 
+  bool GetCatalogTimestamp(const shash::Any &catalog,
+                           uint64_t *timestamp) const;
+
   void BeginTransaction();
   void CommitTransaction();
 
@@ -82,6 +85,9 @@ class Reflog {
                     const SqlReflog::ReferenceType  type);
   bool ContainsReference(const shash::Any               &hash,
                          const SqlReflog::ReferenceType  type) const;
+  bool GetReferenceTimestamp(const shash::Any               &hash,
+                             const SqlReflog::ReferenceType  type,
+                             uint64_t *timestamp) const;
 
  private:
   bool CreateDatabase(const std::string &database_path,
@@ -98,6 +104,7 @@ class Reflog {
   UniquePtr<SqlListReferences>    list_references_;
   UniquePtr<SqlRemoveReference>   remove_reference_;
   UniquePtr<SqlContainsReference> contains_reference_;
+  UniquePtr<SqlGetTimestamp>      get_timestamp_;
 };
 
 }  // namespace manifest

--- a/cvmfs/reflog_sql.cc
+++ b/cvmfs/reflog_sql.cc
@@ -183,3 +183,24 @@ bool SqlContainsReference::RetrieveAnswer() {
   assert(count == 0 || count == 1);
   return count > 0;
 }
+
+
+//------------------------------------------------------------------------------
+
+
+SqlGetTimestamp::SqlGetTimestamp(const ReflogDatabase *database) {
+  DeferredInit(database->sqlite_db(), "SELECT timestamp FROM refs "
+                                      "WHERE type = :type "
+                                      "  AND hash = :hash");
+}
+
+bool SqlGetTimestamp::BindReference(const shash::Any    &reference_hash,
+                                    const ReferenceType  type) {
+  return
+    BindInt64(1, static_cast<uint64_t>(type)) &&
+    BindTextTransient(2, reference_hash.ToString());
+}
+
+uint64_t SqlGetTimestamp::RetrieveTimestamp() {
+  return RetrieveInt64(0);
+}

--- a/cvmfs/reflog_sql.cc
+++ b/cvmfs/reflog_sql.cc
@@ -90,7 +90,7 @@ shash::Suffix SqlReflog::ToSuffix(const ReferenceType type) const {
 
 
 SqlInsertReference::SqlInsertReference(const ReflogDatabase *database) {
-  MAKE_STATEMENTS("INSERT OR IGNORE INTO refs (@DB_FIELDS@) "
+  MAKE_STATEMENTS("INSERT OR REPLACE INTO refs (@DB_FIELDS@) "
                   "VALUES (@DB_PLACEHOLDERS@);");
   DEFERRED_INITS(database);
 }

--- a/cvmfs/reflog_sql.cc
+++ b/cvmfs/reflog_sql.cc
@@ -70,7 +70,7 @@ static const std::string REV =               \
   DEFERRED_INIT((DB), V1R0)
 
 
-shash::Suffix SqlReflog::ToSuffix(const ReferenceType type) const {
+shash::Suffix SqlReflog::ToSuffix(const ReferenceType type) {
   switch (type) {
     case kRefCatalog:
       return shash::kSuffixCatalog;

--- a/cvmfs/reflog_sql.h
+++ b/cvmfs/reflog_sql.h
@@ -93,4 +93,13 @@ class SqlContainsReference : public SqlReflog {
   bool RetrieveAnswer();
 };
 
+
+class SqlGetTimestamp : public SqlReflog {
+ public:
+  explicit SqlGetTimestamp(const ReflogDatabase *database);
+  bool BindReference(const shash::Any    &reference_hash,
+                     const ReferenceType  type);
+  uint64_t RetrieveTimestamp();
+};
+
 #endif  // CVMFS_REFLOG_SQL_H_

--- a/cvmfs/reflog_sql.h
+++ b/cvmfs/reflog_sql.h
@@ -49,8 +49,7 @@ class SqlReflog : public sqlite::Sql {
     kRefMetainfo
   };
 
- protected:
-  shash::Suffix ToSuffix(const ReferenceType type) const;
+  static shash::Suffix ToSuffix(const ReferenceType type);
 };
 
 

--- a/cvmfs/reflog_sql.h
+++ b/cvmfs/reflog_sql.h
@@ -72,6 +72,7 @@ class SqlListReferences : public SqlReflog {
  public:
   explicit SqlListReferences(const ReflogDatabase *database);
   bool BindType(const ReferenceType type);
+  bool BindOlderThan(const uint64_t timestamp);
   shash::Any RetrieveHash() const;
 };
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -158,6 +158,7 @@ int CommandGc::Main(const ArgumentList &args) {
 
   // File catalogs
   GC collector(config);
+  collector.UseReflogTimestamps();
   bool success = collector.Collect();
 
   if (!success) {

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -179,8 +179,8 @@ int CommandGc::Main(const ArgumentList &args) {
 
   if (!dry_run) {
     uploader->Upload(reflog_db, ".cvmfsreflog");
-    uploader->WaitForUpload();
     manifest::Reflog::HashDatabase(reflog_db, &reflog_hash);
+    uploader->WaitForUpload();
     manifest::Reflog::WriteChecksum(reflog_chksum_path, reflog_hash);
   }
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "garbage_collection/garbage_collector.h"
+#include "garbage_collection/gc_aux.h"
 #include "garbage_collection/hash_filter.h"
 #include "manifest.h"
 #include "reflog.h"
@@ -20,7 +21,9 @@ namespace swissknife {
 
 typedef HttpObjectFetcher<> ObjectFetcher;
 typedef CatalogTraversal<ObjectFetcher> ReadonlyCatalogTraversal;
-typedef GarbageCollector<ReadonlyCatalogTraversal, SimpleHashFilter> GC;
+typedef SmallhashFilter HashFilter;
+typedef GarbageCollector<ReadonlyCatalogTraversal, HashFilter> GC;
+typedef GarbageCollectorAux<ReadonlyCatalogTraversal, HashFilter> GCAux;
 typedef GC::Configuration GcConfig;
 
 
@@ -153,11 +156,27 @@ int CommandGc::Main(const ArgumentList &args) {
     }
   }
 
+  // File catalogs
   GC collector(config);
-  const bool success = collector.Collect();
+  bool success = collector.Collect();
 
   if (!success) {
     LogCvmfs(kLogCvmfs, kLogStderr, "garbage collection failed");
+    uploader->TearDown();
+    return 1;
+  }
+
+  // Tag databases, meta infos, certificates
+  HashFilter preserved_objects;
+  preserved_objects.Fill(manifest->certificate());
+  preserved_objects.Fill(manifest->history());
+  preserved_objects.Fill(manifest->meta_info());
+  GCAux collector_aux(config);
+  success = collector_aux.CollectOlderThan(
+    collector.oldest_trunk_catalog(), preserved_objects);
+  if (!success) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "garbage collection of auxiliary files failed");
     uploader->TearDown();
     return 1;
   }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -728,6 +728,8 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
 
     LogCvmfs(kLogCvmfs, kLogStdout, "Found %u named snapshots",
              historic_tags.size());
+    // TODO(jblomer): We should repliacte the previous history dbs, too,
+    // in order to avoid races on fail-over between non-synchronized stratum 1s
     LogCvmfs(kLogCvmfs, kLogStdout, "Uploading history database");
     Store(history_path, history_hash);
     WaitForStorage();

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -785,11 +785,11 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
       StoreBuffer(ensemble.cert_buf,
                   ensemble.cert_size,
                   ensemble.manifest->certificate(), true);
-      if (reflog != NULL &&
-          !reflog->AddCertificate(ensemble.manifest->certificate())) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Failed to add certificate to Reflog.");
-        goto fini;
-      }
+    }
+    if (reflog != NULL &&
+        !reflog->AddCertificate(ensemble.manifest->certificate())) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to add certificate to Reflog.");
+      goto fini;
     }
     if (!meta_info_hash.IsNull()) {
       const unsigned char *info = reinterpret_cast<const unsigned char *>(

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -129,7 +129,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   }
 
   // Safe repository meta info file
-  shash::Any metainfo_hash;
+  shash::Any metainfo_hash = manifest->meta_info();
   if (!meta_info.empty()) {
     upload::Spooler::CallbackPtr callback =
       spooler->RegisterListener(&CommandSign::MetainfoUploadCallback, this);

--- a/test/src/637-gcaux/main
+++ b/test/src/637-gcaux/main
@@ -7,10 +7,6 @@ cleanup() {
   sudo cvmfs_server rmfs -f $CVMFS_TEST637_REPLICA_NAME > /dev/null 2>&1
 }
 
-
-
-
-
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -77,24 +73,30 @@ cvmfs_run_test() {
   local metainfo_t2=$(get_object_from_manifest $CVMFS_TEST_REPO M)
   echo "--> new meta info: $metainfo_t2"
 
-  echo "*** run snapshot"
-  sudo cvmfs_server snapshot $CVMFS_TEST637_REPLICA_NAME || return 51
+  echo "*** now the catalog in s0 reflog is newer than on s1 reflog,"
+  echo "    republish before snapshotting to restore space and time"
+  start_transaction $CVMFS_TEST_REPO || return 51
+  publish_repo $CVMFS_TEST_REPO || return 52
+  local history_t2=$(get_object_from_manifest $CVMFS_TEST_REPO H)
+  echo "--> latest history: $history_t2"
 
-  echo "*** another gc run"
+  echo "*** run snapshot"
+  sudo cvmfs_server snapshot $CVMFS_TEST637_REPLICA_NAME || return 53
+
+  echo "*** another gc run should remove old meta info objects (time `date`)"
   cvmfs_server gc -f -r0 -l -L log_s0 $CVMFS_TEST_REPO || return 60
   cvmfs_server gc -f -r0 -l -L log_s1 $CVMFS_TEST637_REPLICA_NAME || return 61
   peek_backend $CVMFS_TEST_REPO $certificate_t0 || return 62
   peek_backend $CVMFS_TEST_REPO $metainfo_t0 && return 63
   peek_backend $CVMFS_TEST_REPO $metainfo_t2 || return 64
   peek_backend $CVMFS_TEST637_REPLICA_NAME $certificate_t0 || return 65
-  peek_backend $CVMFS_TEST637_REPLICA_NAME $history_t1 || return 66
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $history_t2 || return 66
   peek_backend $CVMFS_TEST637_REPLICA_NAME $metainfo_t0 && return 67
   peek_backend $CVMFS_TEST637_REPLICA_NAME $metainfo_t2 || return 68
 
   echo "*** checking deletion logs"
   grep 'M$' log_s0 || return 70
-  grep 'M$' log_s1 || return 70
+  grep 'M$' log_s1 || return 71
 
   return 0
 }
-

--- a/test/src/637-gcaux/main
+++ b/test/src/637-gcaux/main
@@ -1,0 +1,100 @@
+cvmfs_test_name="Garbage collection of auxiliary objects"
+cvmfs_test_autofs_on_startup=false
+
+CVMFS_TEST637_REPLICA_NAME=
+
+cleanup() {
+  sudo cvmfs_server rmfs -f $CVMFS_TEST637_REPLICA_NAME > /dev/null 2>&1
+}
+
+
+
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  echo "*** create a gc-enabled repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -z -g || return 10
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return 11
+  check_repository $CVMFS_TEST_REPO -i  || return 12
+
+  echo "*** gathering initial aux hashes"
+  local certificate_t0=$(get_object_from_manifest $CVMFS_TEST_REPO X)
+  local history_t0=$(get_object_from_manifest $CVMFS_TEST_REPO H)
+  local metainfo_t0=$(get_object_from_manifest $CVMFS_TEST_REPO M)
+  echo "--> certificate: $certificate_t0"
+  echo "--> history: $history_t0"
+  echo "--> meta info: $metainfo_t0"
+
+  echo "*** wait for the clock moving forward"
+  sleep 5
+
+  echo "*** run a transaction"
+  start_transaction $CVMFS_TEST_REPO || return 13
+  publish_repo $CVMFS_TEST_REPO || return 14
+  local history_t1=$(get_object_from_manifest $CVMFS_TEST_REPO H)
+  echo "--> new history: $history_t1"
+
+  echo "*** set stratum 1 cleanup trap"
+  CVMFS_TEST637_REPLICA_NAME="$(get_stratum1_name $CVMFS_TEST_REPO)"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "*** snapshot initial repository revision"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $CVMFS_TEST637_REPLICA_NAME            \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 20
+  sudo cvmfs_server snapshot $CVMFS_TEST637_REPLICA_NAME || return 21
+  check_repository $CVMFS_TEST637_REPLICA_NAME -i || return 22
+
+  echo "*** check presence of initial aux objects"
+  peek_backend $CVMFS_TEST_REPO $certificate_t0 || return 30
+  peek_backend $CVMFS_TEST_REPO $history_t0 || return 31
+  peek_backend $CVMFS_TEST_REPO $metainfo_t0 || return 32
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $certificate_t0 || return 33
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $history_t1 || return 34
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $metainfo_t0 || return 35
+
+  echo "*** remove old history"
+  cvmfs_server gc -f -r0 -l $CVMFS_TEST_REPO || return 40
+  cvmfs_server gc -f -r0 -l $CVMFS_TEST637_REPLICA_NAME || return 41
+  peek_backend $CVMFS_TEST_REPO $certificate_t0 || return 42
+  peek_backend $CVMFS_TEST_REPO $history_t0 && return 43
+  peek_backend $CVMFS_TEST_REPO $metainfo_t0 || return 44
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $certificate_t0 || return 45
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $history_t1 || return 46
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $metainfo_t0 || return 47
+
+  echo "*** wait for the clock moving forward (again)"
+  sleep 5
+
+  echo "*** change meta info"
+  echo '{}' > meta-info
+  cvmfs_server update-repoinfo -f meta-info $CVMFS_TEST_REPO || return 50
+  local metainfo_t2=$(get_object_from_manifest $CVMFS_TEST_REPO M)
+  echo "--> new meta info: $metainfo_t2"
+
+  echo "*** run snapshot"
+  sudo cvmfs_server snapshot $CVMFS_TEST637_REPLICA_NAME || return 51
+
+  echo "*** another gc run"
+  cvmfs_server gc -f -r0 -l -L log_s0 $CVMFS_TEST_REPO || return 60
+  cvmfs_server gc -f -r0 -l -L log_s1 $CVMFS_TEST637_REPLICA_NAME || return 61
+  peek_backend $CVMFS_TEST_REPO $certificate_t0 || return 62
+  peek_backend $CVMFS_TEST_REPO $metainfo_t0 && return 63
+  peek_backend $CVMFS_TEST_REPO $metainfo_t2 || return 64
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $certificate_t0 || return 65
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $history_t1 || return 66
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $metainfo_t0 && return 67
+  peek_backend $CVMFS_TEST637_REPLICA_NAME $metainfo_t2 || return 68
+
+  echo "*** checking deletion logs"
+  grep 'M$' log_s0 || return 70
+  grep 'M$' log_s1 || return 70
+
+  return 0
+}
+

--- a/test/test_functions
+++ b/test/test_functions
@@ -1626,6 +1626,16 @@ toggle_gc() {
 }
 
 
+get_object_from_manifest() {
+  local name=$1
+  local type=$2
+
+  local url="http://localhost/cvmfs/$name"
+  hash=$(cvmfs_swissknife info -r $url -R | grep "^$type" | tr -d $type)
+  echo "${hash}${type}"
+}
+
+
 set_auto_tag_timespan() {
   local name=$1
   local timespan="$2"

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -1162,6 +1162,19 @@ TEST_F(T_GarbageCollector, KeepOnlyFutureRevisions) {
 }
 
 
+TEST_F(T_GarbageCollector, UseReflogTimestamps) {
+  GcConfiguration config = GetStandardGarbageCollectorConfiguration();
+  config.keep_history_timestamp = t(24, 12, 2004) - 1;  // just before rev 3
+  config.keep_history_depth     = GcConfiguration::kFullHistory;
+
+  MyGarbageCollector gc(config);
+  gc.UseReflogTimestamps();
+  EXPECT_TRUE(gc.Collect());
+  EXPECT_EQ(16u, gc.preserved_catalog_count());
+  EXPECT_EQ(0u, gc.condemned_catalog_count());
+}
+
+
 TEST_F(T_GarbageCollector, NamedTagsInRecycleBin) {
   GcConfiguration config = GetStandardGarbageCollectorConfiguration();
   config.keep_history_depth = 0;

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -488,6 +488,7 @@ TEST_F(T_GarbageCollector, InitializeGarbageCollector) {
   MyGarbageCollector gc(config);
   EXPECT_EQ(0u, gc.preserved_catalog_count());
   EXPECT_EQ(0u, gc.condemned_catalog_count());
+  EXPECT_GT(gc.oldest_trunk_catalog(), 0U);
 }
 
 
@@ -502,6 +503,7 @@ TEST_F(T_GarbageCollector, KeepEverything) {
   EXPECT_EQ(16u, gc.preserved_catalog_count());
   EXPECT_EQ(0u, gc.condemned_catalog_count());
   EXPECT_EQ(0u, gc.condemned_objects_count());
+  EXPECT_EQ(t(27, 11, 1987), gc.oldest_trunk_catalog());
 }
 
 
@@ -514,6 +516,7 @@ TEST_F(T_GarbageCollector, KeepLastRevision) {
   EXPECT_TRUE(gc1);
   EXPECT_EQ(11u, gc.preserved_catalog_count());
   EXPECT_EQ(5u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc.oldest_trunk_catalog());
 
   GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
   RevisionMap     &c   = catalogs_;
@@ -589,6 +592,7 @@ TEST_F(T_GarbageCollector, KeepLastThreeRevisions) {
   EXPECT_TRUE(gc1);
   EXPECT_EQ(14u, gc.preserved_catalog_count());
   EXPECT_EQ(2u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(24, 12, 2004), gc.oldest_trunk_catalog());
 
   GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
   RevisionMap     &c   = catalogs_;
@@ -664,6 +668,7 @@ TEST_F(T_GarbageCollector, KeepOnlyNamedSnapshots) {
   EXPECT_TRUE(gc1);
   EXPECT_EQ(11u, gc.preserved_catalog_count());
   EXPECT_EQ(5u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc.oldest_trunk_catalog());
 
   GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
   RevisionMap     &c   = catalogs_;
@@ -731,6 +736,7 @@ TEST_F(T_GarbageCollector, KeepNamedSnapshotsWithAlreadySweepedRevisions) {
   EXPECT_TRUE(gc1);
   EXPECT_EQ(11u, gc.preserved_catalog_count());
   EXPECT_EQ(0u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), gc.oldest_trunk_catalog());
 }
 
 
@@ -757,6 +763,7 @@ TEST_F(T_GarbageCollector, UnreachableNestedCatalog) {
   EXPECT_EQ(8u, gc.preserved_catalog_count());
   // Note: should be 8 but (3,"10") was already gone!
   EXPECT_EQ(7u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), gc.oldest_trunk_catalog());
 
   GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
 
@@ -852,6 +859,7 @@ TEST_F(T_GarbageCollector, OnTheFlyDeletionOfCatalogs) {
 
   EXPECT_EQ(11u, gc.preserved_catalog_count());
   EXPECT_EQ(5u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc.oldest_trunk_catalog());
 
   EXPECT_FALSE(upl->HasDeleted(h("b52945d780f8cc16711d4e670d82499dad99032d")));
   EXPECT_FALSE(upl->HasDeleted(h("d650d325d59ea9ca754f9b37293cd08d0b12584c")));
@@ -922,6 +930,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_TRUE(gc1.Collect());
   EXPECT_EQ(14u, gc1.preserved_catalog_count());
   EXPECT_EQ(2u, gc1.condemned_catalog_count());
+  EXPECT_EQ(t(3, 3, 2000), gc1.oldest_trunk_catalog());
 
   GC_MockUploader *upl = static_cast<GC_MockUploader*>(config.uploader);
   RevisionMap     &c   = catalogs_;
@@ -960,6 +969,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
   EXPECT_EQ(14u, gc2.preserved_catalog_count());
   EXPECT_EQ(0u, gc2.condemned_catalog_count());  // Reflog doesn't contain
                                                  // deleted catalogs anymore
+  EXPECT_EQ(t(3, 3, 2000), gc2.oldest_trunk_catalog());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -969,6 +979,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(14u, gc3.preserved_catalog_count());
   EXPECT_EQ(0u, gc3.condemned_catalog_count());
+  EXPECT_EQ(t(24, 12, 2004), gc3.oldest_trunk_catalog());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -978,6 +989,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(11u, gc4.preserved_catalog_count());
   EXPECT_EQ(3u, gc4.condemned_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), gc4.oldest_trunk_catalog());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(1, "00")]->hash()));
@@ -1067,6 +1079,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(11u, gc5.preserved_catalog_count());
   EXPECT_EQ(0u, gc5.condemned_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), gc5.oldest_trunk_catalog());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1077,6 +1090,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(11u, gc6.preserved_catalog_count());
   EXPECT_EQ(0u, gc6.condemned_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), gc6.oldest_trunk_catalog());
   EXPECT_EQ(11u, upl->deleted_hashes.size());
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1087,6 +1101,7 @@ TEST_F(T_GarbageCollector, KeepRevisionsBasedOnTimestamp) {
 
   EXPECT_EQ(7u, gc7.preserved_catalog_count());
   EXPECT_EQ(4u, gc7.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc7.oldest_trunk_catalog());
   EXPECT_EQ(29u, upl->deleted_hashes.size());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(4, "00")]->hash()));
@@ -1143,6 +1158,7 @@ TEST_F(T_GarbageCollector, KeepOnlyFutureRevisions) {
   EXPECT_FALSE(upl->HasDeleted(c[mp(5, "10")]->hash()));
   EXPECT_FALSE(upl->HasDeleted(c[mp(5, "11")]->hash()));
   EXPECT_FALSE(upl->HasDeleted(c[mp(5, "20")]->hash()));
+  EXPECT_EQ(t(26, 12, 2004), gc1.oldest_trunk_catalog());
 }
 
 
@@ -1162,6 +1178,7 @@ TEST_F(T_GarbageCollector, NamedTagsInRecycleBin) {
 
   EXPECT_EQ(11u, gc1.preserved_catalog_count());
   EXPECT_EQ(5u, gc1.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc1.oldest_trunk_catalog());
 
   EXPECT_FALSE(upl->HasDeleted(c[mp(2, "00")]->hash()));
   EXPECT_FALSE(upl->HasDeleted(c[mp(2, "10")]->hash()));
@@ -1207,6 +1224,7 @@ TEST_F(T_GarbageCollector, NamedTagsInRecycleBin) {
 
   EXPECT_EQ(8u, gc2.preserved_catalog_count());
   EXPECT_EQ(3u, gc2.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc2.oldest_trunk_catalog());
 
   EXPECT_TRUE(upl->HasDeleted(c[mp(2, "00")]->hash()));
   EXPECT_TRUE(upl->HasDeleted(c[mp(2, "10")]->hash()));
@@ -1239,6 +1257,7 @@ TEST_F(T_GarbageCollector, LogDeletionToFile) {
   EXPECT_TRUE(gc1);
   EXPECT_EQ(11u, gc.preserved_catalog_count());
   EXPECT_EQ(5u, gc.condemned_catalog_count());
+  EXPECT_EQ(t(26, 12, 2004), gc.oldest_trunk_catalog());
 
   RevisionMap     &c   = catalogs_;
 
@@ -1337,6 +1356,7 @@ TEST_F(T_GarbageCollector, FindAndSweepOrphanedNamedSnapshot) {
   const bool gc1 = gc.Collect();
   EXPECT_TRUE(gc1);
 
+
   EXPECT_FALSE(upl->HasDeleted(c[mp(5, "00")]->hash()));
   EXPECT_FALSE(upl->HasDeleted(c[mp(5, "10")]->hash()));
   EXPECT_FALSE(upl->HasDeleted(c[mp(5, "11")]->hash()));
@@ -1356,6 +1376,7 @@ TEST_F(T_GarbageCollector, FindAndSweepOrphanedNamedSnapshot) {
   EXPECT_TRUE(upl->HasDeleted(c[mp(1, "10")]->hash()));
 
   EXPECT_EQ(11u, gc.preserved_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), gc.oldest_trunk_catalog());
 
   // mock a history database chain that contains the information of the deleted
   // snapshot "Revision2" in its recycle bin and remove it entirely from the
@@ -1403,4 +1424,5 @@ TEST_F(T_GarbageCollector, FindAndSweepOrphanedNamedSnapshot) {
   EXPECT_TRUE(upl->HasDeleted(c[mp(1, "10")]->hash()));
 
   EXPECT_EQ(8u, new_gc.preserved_catalog_count());
+  EXPECT_EQ(t(25, 12, 2004), new_gc.oldest_trunk_catalog());
 }

--- a/test/unittests/t_reflog.cc
+++ b/test/unittests/t_reflog.cc
@@ -185,7 +185,7 @@ TYPED_TEST(T_Reflog, InsertAndCountReferences) {
 }
 
 
-TYPED_TEST(T_Reflog, ListCatalogs) {
+TYPED_TEST(T_Reflog, List) {
   const std::string rp = TestFixture::GetReflogFilename();
   typedef TypeParam Reflog;
 
@@ -199,7 +199,17 @@ TYPED_TEST(T_Reflog, ListCatalogs) {
                     shash::kSuffixCatalog));
   rl1->AddCertificate(h("b778b910390254b37ec66366aeef04f034c51941",
                         shash::kSuffixCertificate));
+  rl1->AddCertificate(h("b778b910390254b37ec66366aeef04f034c51942",
+                        shash::kSuffixCertificate));
+  rl1->AddCertificate(h("b778b910390254b37ec66366aeef04f034c51943",
+                        shash::kSuffixCertificate));
   rl1->AddMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76b",
+                     shash::kSuffixMetainfo));
+  rl1->AddMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76c",
+                     shash::kSuffixMetainfo));
+  rl1->AddMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76d",
+                     shash::kSuffixMetainfo));
+  rl1->AddMetainfo(h("8de3e8cbd611ce225d62341698b9408a47edf76e",
                      shash::kSuffixMetainfo));
   rl1->AddHistory(h("cab790100c3b10afd7e755b3c93eaeda6a0db9ab",
                      shash::kSuffixHistory));
@@ -208,11 +218,23 @@ TYPED_TEST(T_Reflog, ListCatalogs) {
   Reflog *rl2 = TestFixture::OpenReflog(rp);
   ASSERT_NE(static_cast<Reflog*>(NULL), rl2);
   EXPECT_EQ(TestFixture::fqrn, rl2->fqrn());
-  EXPECT_EQ(5u, rl2->CountEntries());
+  EXPECT_EQ(10u, rl2->CountEntries());
 
   std::vector<shash::Any> catalog_hashes;
-  ASSERT_TRUE(rl2->ListCatalogs(&catalog_hashes));
+  ASSERT_TRUE(rl2->List(SqlReflog::kRefCatalog, &catalog_hashes));
   EXPECT_EQ(2u, catalog_hashes.size());
+
+  std::vector<shash::Any> certificate_hashes;
+  ASSERT_TRUE(rl2->List(SqlReflog::kRefCertificate, &certificate_hashes));
+  EXPECT_EQ(3u, certificate_hashes.size());
+
+  std::vector<shash::Any> metainfo_hashes;
+  ASSERT_TRUE(rl2->List(SqlReflog::kRefMetainfo, &metainfo_hashes));
+  EXPECT_EQ(4u, metainfo_hashes.size());
+
+  std::vector<shash::Any> history_hashes;
+  ASSERT_TRUE(rl2->List(SqlReflog::kRefHistory, &history_hashes));
+  EXPECT_EQ(1u, history_hashes.size());
 
   TestFixture::CloseReflog(rl2);
 }

--- a/test/unittests/t_reflog.cc
+++ b/test/unittests/t_reflog.cc
@@ -271,7 +271,7 @@ TYPED_TEST(T_Reflog, ListOlderThan) {
 }
 
 
-TYPED_TEST(T_Reflog, RemoveCatalog) {
+TYPED_TEST(T_Reflog, Remove) {
   const std::string rp = TestFixture::GetReflogFilename();
   typedef TypeParam Reflog;
 
@@ -296,9 +296,18 @@ TYPED_TEST(T_Reflog, RemoveCatalog) {
   EXPECT_EQ(TestFixture::fqrn, rl2->fqrn());
   EXPECT_EQ(5u, rl2->CountEntries());
 
-  ASSERT_TRUE(rl2->RemoveCatalog(h("c5501bd0142cad45c4f0957cbf307e184ac1f661",
-                                 shash::kSuffixCatalog)));
+  ASSERT_TRUE(rl2->Remove(h("c5501bd0142cad45c4f0957cbf307e184ac1f661",
+                            shash::kSuffixCatalog)));
   EXPECT_EQ(4u, rl2->CountEntries());
+  ASSERT_TRUE(rl2->Remove(h("b778b910390254b37ec66366aeef04f034c51941",
+                            shash::kSuffixCertificate)));
+  EXPECT_EQ(3u, rl2->CountEntries());
+  ASSERT_TRUE(rl2->Remove(h("8de3e8cbd611ce225d62341698b9408a47edf76b",
+                            shash::kSuffixMetainfo)));
+  EXPECT_EQ(2u, rl2->CountEntries());
+  ASSERT_TRUE(rl2->Remove(h("cab790100c3b10afd7e755b3c93eaeda6a0db9ab",
+                            shash::kSuffixHistory)));
+  EXPECT_EQ(1u, rl2->CountEntries());
 
   TestFixture::CloseReflog(rl2);
 }

--- a/test/unittests/t_reflog.cc
+++ b/test/unittests/t_reflog.cc
@@ -391,3 +391,30 @@ TYPED_TEST(T_Reflog, ContainsObject) {
 
   TestFixture::CloseReflog(rl2);
 }
+
+
+TYPED_TEST(T_Reflog, GetTimestamp) {
+  const std::string rp = TestFixture::GetReflogFilename();
+  typedef TypeParam Reflog;
+
+  Reflog *rl = TestFixture::CreateReflog(rp);
+  ASSERT_NE(static_cast<Reflog*>(NULL), rl);
+
+  uint64_t t1 = time(NULL);
+  rl->AddCatalog(h("b99a789dcdffff8f95b977cc8e2037fcd3960b5b",
+                   shash::kSuffixCatalog));
+  rl->AddCertificate(h("b778b910390254b37ec66366aeef04f034c51941",
+                       shash::kSuffixCertificate));
+  uint64_t t2 = time(NULL);
+
+  uint64_t timestamp;
+  EXPECT_FALSE(rl->GetCatalogTimestamp(
+                     h("1234567812345678123456781234567812345678",
+                     shash::kSuffixCatalog), &timestamp));
+  EXPECT_TRUE(rl->GetCatalogTimestamp(
+                    h("b99a789dcdffff8f95b977cc8e2037fcd3960b5b",
+                    shash::kSuffixCatalog), &timestamp));
+
+  EXPECT_LE(t1, timestamp);
+  EXPECT_LE(timestamp, t2);
+}

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -756,10 +756,13 @@ bool MockReflog::AddMetainfo(const shash::Any &metainfo) {
   return true;
 }
 
-bool MockReflog::ListCatalogs(std::vector<shash::Any> *hashes) const {
+bool MockReflog::List(
+  SqlReflog::ReferenceType type,
+  std::vector<shash::Any> *hashes) const
+{
   // TODO(rmeusel): C++11 use std::copy_if
   hashes->clear();
-  ReferenceTypeFilter predicate(shash::kSuffixCatalog, true /* inverse */);
+  ReferenceTypeFilter predicate(SqlReflog::ToSuffix(type), true /* inverse */);
   std::remove_copy_if(references_.begin(),
                       references_.end(),
                       std::back_inserter(*hashes),

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -783,6 +783,19 @@ bool MockReflog::ListOlderThan(
   return true;
 }
 
+bool MockReflog::GetCatalogTimestamp(
+  const shash::Any &catalog,
+  uint64_t *timestamp)
+{
+  std::map<shash::Any, uint64_t>::const_iterator iter =
+    references_.find(catalog);
+  if (iter == references_.end())
+    return false;
+  *timestamp = iter->second;
+  return true;
+}
+
+
 bool MockReflog::Remove(const shash::Any &hash) {
   references_.erase(hash);
   return true;

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -737,22 +737,22 @@ MockReflog::MockReflog(const std::string fqrn)
   , fqrn_(fqrn) {}
 
 bool MockReflog::AddCertificate(const shash::Any &certificate) {
-  references_.insert(certificate);
+  references_[certificate] = time(NULL);
   return true;
 }
 
 bool MockReflog::AddCatalog(const shash::Any &catalog) {
-  references_.insert(catalog);
+  references_[catalog] = time(NULL);
   return true;
 }
 
 bool MockReflog::AddHistory(const shash::Any &history) {
-  references_.insert(history);
+  references_[history] = time(NULL);
   return true;
 }
 
 bool MockReflog::AddMetainfo(const shash::Any &metainfo) {
-  references_.insert(metainfo);
+  references_[metainfo] = time(NULL);
   return true;
 }
 
@@ -760,13 +760,26 @@ bool MockReflog::List(
   SqlReflog::ReferenceType type,
   std::vector<shash::Any> *hashes) const
 {
-  // TODO(rmeusel): C++11 use std::copy_if
+  return ListOlderThan(type, static_cast<uint64_t>(-1), hashes);
+}
+
+bool MockReflog::ListOlderThan(
+  SqlReflog::ReferenceType type,
+  uint64_t timestamp,
+  std::vector<shash::Any> *hashes) const
+{
   hashes->clear();
-  ReferenceTypeFilter predicate(SqlReflog::ToSuffix(type), true /* inverse */);
-  std::remove_copy_if(references_.begin(),
-                      references_.end(),
-                      std::back_inserter(*hashes),
-                      predicate);
+  for (map<shash::Any, uint64_t>::const_iterator i = references_.begin(),
+       i_end = references_.end(); i != i_end; ++i)
+  {
+    if ((i->first.suffix == SqlReflog::ToSuffix(type)) &&
+        (i->second < timestamp))
+    {
+      hashes->push_back(i->first);
+    }
+  }
+  std::sort(hashes->begin(), hashes->end());
+
   return true;
 }
 

--- a/test/unittests/testutil.cc
+++ b/test/unittests/testutil.cc
@@ -783,8 +783,8 @@ bool MockReflog::ListOlderThan(
   return true;
 }
 
-bool MockReflog::RemoveCatalog(const shash::Any &catalog) {
-  references_.erase(catalog);
+bool MockReflog::Remove(const shash::Any &hash) {
+  references_.erase(hash);
   return true;
 }
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -822,6 +822,8 @@ class MockReflog : public MockObjectStorage<MockReflog> {
                      uint64_t timestamp,
                      std::vector<shash::Any> *hashes) const;
 
+  bool GetCatalogTimestamp(const shash::Any &catalog, uint64_t *timestamp);
+
   bool Remove(const shash::Any &hash);
 
   bool ContainsCertificate(const shash::Any &certificate) const;

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -800,18 +800,6 @@ class MockHistory : public history::History,
 
 class MockReflog : public MockObjectStorage<MockReflog> {
  protected:
-  struct ReferenceTypeFilter {
-    explicit ReferenceTypeFilter(const shash::Suffix suffix,
-                                 const bool          inverse)
-      : suffix_(suffix)
-      , inverse_(inverse) { }
-    bool operator()(const shash::Any &hash) const {
-      return (hash.suffix == suffix_) ^ inverse_;
-    }
-    const shash::Suffix suffix_;
-    const bool          inverse_;
-  };
-
   MockReflog* Clone() const;
 
  public:
@@ -830,6 +818,9 @@ class MockReflog : public MockObjectStorage<MockReflog> {
   uint64_t CountEntries() { return references_.size(); }
   bool List(SqlReflog::ReferenceType type,
             std::vector<shash::Any> *hashes) const;
+  bool ListOlderThan(SqlReflog::ReferenceType type,
+                     uint64_t timestamp,
+                     std::vector<shash::Any> *hashes) const;
 
   bool RemoveCatalog(const shash::Any &catalog);
 
@@ -850,7 +841,7 @@ class MockReflog : public MockObjectStorage<MockReflog> {
  private:
   bool                  owns_database_file_;
   const std::string     fqrn_;
-  std::set<shash::Any>  references_;
+  std::map<shash::Any, uint64_t>  references_;
 };
 
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -828,7 +828,8 @@ class MockReflog : public MockObjectStorage<MockReflog> {
   bool AddMetainfo(const shash::Any &metainfo);
 
   uint64_t CountEntries() { return references_.size(); }
-  bool ListCatalogs(std::vector<shash::Any> *hashes) const;
+  bool List(SqlReflog::ReferenceType type,
+            std::vector<shash::Any> *hashes) const;
 
   bool RemoveCatalog(const shash::Any &catalog);
 

--- a/test/unittests/testutil.h
+++ b/test/unittests/testutil.h
@@ -822,7 +822,7 @@ class MockReflog : public MockObjectStorage<MockReflog> {
                      uint64_t timestamp,
                      std::vector<shash::Any> *hashes) const;
 
-  bool RemoveCatalog(const shash::Any &catalog);
+  bool Remove(const shash::Any &hash);
 
   bool ContainsCertificate(const shash::Any &certificate) const;
   bool ContainsCatalog(const shash::Any &catalog) const;


### PR DESCRIPTION
- Sweep auxiliary files (history, meta info, certificate)
- Use reflog timestamp instead of catalog-inherent one