### PR TITLE
Feature heapcache

### DIFF
--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -219,7 +219,7 @@ int64_t RamCacheManager::Write(const void *buf, uint64_t size, void *txn) {
     if (transaction->expected_size == kSizeUnknown) {
       perf::Inc(counters_.n_realloc);
       size_t new_size = max(2*transaction->buffer.size,
-        size + transaction->pos);
+        (size_t) (size + transaction->pos));
       LogCvmfs(kLogCache, kLogDebug, "reallocate transaction for %s to %u B",
                transaction->buffer.id.ToString().c_str(),
                transaction->buffer.size);

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -54,9 +54,9 @@ int RamCacheManager::DoOpen(const shash::Any &id) {
   bool is_volatile;
   MemoryBuffer buf;
 
-  if (regular_entries_.GetBuffer(id, &buf)) {
+  if (regular_entries_.Contains(id)) {
     is_volatile = false;
-  } else if (volatile_entries_.GetBuffer(id, &buf)) {
+  } else if (volatile_entries_.Contains(id)) {
     is_volatile = true;
   } else {
     LogCvmfs(kLogCache, kLogDebug, "miss for %s",

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -41,9 +41,9 @@ static const shash::Any kInvalidHandle;
  * RAM cache size defaults to ~3% of the system memory.
  * The minimum cache size is 200 MB.
  *
- * RamCacheManager can also use a custom arena allocator rather than
- * the default libc @p malloc(). To enable this feature, set
- * @p CVMFS_CACHE_RAM_MALLOC=arena
+ * RamCacheManager uses a custom heap allocator rather than
+ * the system's libc @p malloc(). To switch to libc malloc, set
+ * @p CVMFS_CACHE_RAM_MALLOC=libc
  */
 class RamCacheManager : public CacheManager {
  public:

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -270,12 +270,10 @@ class RamCacheManager : public CacheManager {
     Transaction()
       : buffer()
       , expected_size(0)
-      , pos(0)
-      , allocated(false) { }
+      , pos(0) { }
     MemoryBuffer buffer;
     uint64_t expected_size;
     uint64_t pos;
-    bool allocated;
     std::string description;
   };
 

--- a/cvmfs/kvstore.cc
+++ b/cvmfs/kvstore.cc
@@ -51,9 +51,7 @@ MemoryKvStore::~MemoryKvStore() {
   for (size_t i = 0; i < malloc_arenas_.size(); ++i) {
     delete malloc_arenas_[i];
   }
-  if (heap_) {
-    delete heap_;
-  }
+  delete heap_;
   pthread_rwlock_destroy(&rwlock_);
 }
 

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -13,7 +13,6 @@
 
 #include "cache.h"
 #include "lru.h"
-#include "malloc_arena.h"
 #include "malloc_heap.h"
 #include "statistics.h"
 
@@ -213,7 +212,6 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
   MallocHeap *heap_;
   pthread_rwlock_t rwlock_;
   Counters counters_;
-  vector<MallocArena *> malloc_arenas_;
 };
 
 #endif  // CVMFS_KVSTORE_H_

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -21,6 +21,14 @@ using namespace std;  // NOLINT
 
 static const size_t kArenaSize = 512*1024*1024;
 
+struct AllocHeader {
+  AllocHeader()
+  : version(0)
+  , id() {}
+  uint8_t version;
+  shash::Any id;
+};
+
 struct MemoryBuffer {
   MemoryBuffer()
     : address(NULL)
@@ -49,7 +57,6 @@ struct MemoryBuffer {
 class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
  public:
   enum MemoryAllocator {
-    kMallocArena,
     kMallocLibc,
     kMallocHeap,
   };

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -213,23 +213,6 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
   bool ShrinkTo(size_t size);
 
   /**
-   * Allocate a new buffer using the KvStore's memory allocator.
-   * @returns -errno on failure
-   */
-  int MallocBuffer(MemoryBuffer *buf);
-
-  /**
-   * Resize the given buffer using the KvStore's memory allocator.
-   * @returns -errno on failure
-   */
-  int ReallocBuffer(MemoryBuffer *buf, size_t size);
-
-  /**
-   * Frees the given buffer, returning the space to the KvStore's memory allocator.
-   */
-  void FreeBuffer(MemoryBuffer *buf);
-
-  /**
    * Get the memory buffer describing the entry at id
    * @param id The hash key
    * @returns True iff the entry is present
@@ -249,18 +232,6 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
    */
   size_t GetUsed() { return used_bytes_; }
 
-  /**
-   * Advise the KvStore to free up any available memory.
-   * Depending on the allocator in use, this might be a no op. Callers should
-   * advise the KvStore to clean up if they have already run out of space and
-   * done what they can to make room. The KvStore is free to decide whether
-   * any cleanup operations are a good idea. Note that callers should assume
-   * that Cleanup could block the entire cache for an unspecified amount of
-   * time, so frequent, unnecessary calls are likely to hurt performance.
-   * Cleanup returns true if any cleanup happened.
-   */
-  bool Cleanup();
-
  private:
   bool DoDelete(const shash::Any &id);
   int DoMalloc(MemoryBuffer *buf);
@@ -269,6 +240,7 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
   bool DoCommit(const MemoryBuffer &buf);
   size_t GetBufferSize(MemoryBuffer *buf);
   void OnBlockMove(const MallocHeap::BlockPtr &ptr);
+  bool Cleanup();
 
   MemoryAllocator allocator_;
   size_t used_bytes_;

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -56,8 +56,6 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
 
   struct Counters {
     perf::Counter *sz_size;
-    perf::Counter *n_getbuffer;
-    perf::Counter *n_popbuffer;
     perf::Counter *n_getsize;
     perf::Counter *n_getrefcount;
     perf::Counter *n_incref;
@@ -73,10 +71,6 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
 
     Counters(perf::Statistics *statistics, const std::string &name) {
       sz_size = statistics->Register(name + ".sz_size", "Size for " + name);
-      n_getbuffer = statistics->Register(name + ".n_getbuffer",
-        "Number of GetBuffer calls for " + name);
-      n_popbuffer = statistics->Register(name + ".n_popbuffer",
-        "Number of PopBuffer calls for " + name);
       n_getsize = statistics->Register(name + ".n_getsize",
         "Number of GetSize calls for " + name);
       n_getrefcount = statistics->Register(name + ".n_getrefcount",
@@ -145,6 +139,13 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
   }
 
   /**
+   * Check for the existence of an entry
+   * @param id The hash key
+   * @returns True iff the entry exists
+   */
+  bool Contains(const shash::Any &id);
+
+  /**
    * Get the size in bytes of the entry at id
    * @param id The hash key
    * @returns The entry's size
@@ -211,21 +212,6 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
    * @returns True iff the shrink succeeds
    */
   bool ShrinkTo(size_t size);
-
-  /**
-   * Get the memory buffer describing the entry at id
-   * @param id The hash key
-   * @returns True iff the entry is present
-   */
-  bool GetBuffer(const shash::Any &id, MemoryBuffer *buf);
-
-  /**
-   * Get the memory buffer describing the entry at id as in @ref GetBuffer,
-   * and remove the entry *without* freeing the associated memory
-   * @param id The hash key
-   * @returns True iff the entry is present
-   */
-  bool PopBuffer(const shash::Any &id, MemoryBuffer *buf);
 
   /**
    * Get the total space used for data

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -103,40 +103,9 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
     const string &name,
     MemoryAllocator alloc,
     unsigned alloc_size,
-    perf::Statistics *statistics)
-    : allocator_(alloc)
-    , used_bytes_(0)
-    , idx_last_arena_(0)
-    , entry_count_(0)
-    , max_entries_(cache_entries)
-    , entries_(cache_entries, shash::Any(), lru::hasher_any,
-        statistics, name)
-    , heap_(NULL)
-    , counters_(statistics, name + ".lru") {
-    int retval = pthread_rwlock_init(&rwlock_, NULL);
-    assert(retval == 0);
-    switch (alloc) {
-    case kMallocArena:
-      malloc_arenas_.push_back(new MallocArena(kArenaSize));
-      break;
-    case kMallocHeap:
-      heap_ = new MallocHeap(alloc_size,
-          this->MakeCallback(&MemoryKvStore::OnBlockMove, this));
-      break;
-    default:
-      break;
-    }
-  }
+    perf::Statistics *statistics);
 
-  ~MemoryKvStore() {
-    for (size_t i = 0; i < malloc_arenas_.size(); ++i) {
-      delete malloc_arenas_[i];
-    }
-    if (heap_) {
-      delete heap_;
-    }
-    pthread_rwlock_destroy(&rwlock_);
-  }
+  ~MemoryKvStore();
 
   /**
    * Check for the existence of an entry

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -249,6 +249,18 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
    */
   size_t GetUsed() { return used_bytes_; }
 
+  /**
+   * Advise the KvStore to free up any available memory.
+   * Depending on the allocator in use, this might be a no op. Callers should
+   * advise the KvStore to clean up if they have already run out of space and
+   * done what they can to make room. The KvStore is free to decide whether
+   * any cleanup operations are a good idea. Note that callers should assume
+   * that Cleanup could block the entire cache for an unspecified amount of
+   * time, so frequent, unnecessary calls are likely to hurt performance.
+   * Cleanup returns true if any cleanup happened.
+   */
+  bool Cleanup();
+
  private:
   bool DoDelete(const shash::Any &id);
   int DoMalloc(MemoryBuffer *buf);

--- a/cvmfs/malloc_arena.h
+++ b/cvmfs/malloc_arena.h
@@ -93,14 +93,6 @@ class MallocArena {
   uint32_t GetSize(void *ptr) const;
   bool IsEmpty() const { return no_reserved_ == 0; }
 
-  /**
-   * Round up size to the next larger multiple of 8.  This is used
-   * to force 8-byte alignment.
-   */
-  static inline uint32_t RoundUp8(const uint32_t size) {
-    return (size + 7) & ~7;
-  }
-
  private:
   static const char kTagAvail = 0;
   static const char kTagReserved = 1;

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -105,9 +105,8 @@ MallocHeap::MallocHeap(uint64_t capacity, CallbackPtr callback_ptr)
   assert(capacity_ > kMinCapacity);
   // Ensure 8-byte alignment
   assert((capacity_ % 8) == 0);
-  heap_ = reinterpret_cast<unsigned char *>(sxmmap(capacity + 7));
-  uintptr_t head = uintptr_t(heap_) % 8;
-  heap_ += head;
+  heap_ = reinterpret_cast<unsigned char *>(sxmmap(capacity));
+  assert(uintptr_t(heap_) % 8 == 0);
 }
 
 

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -107,12 +107,7 @@ MallocHeap::MallocHeap(uint64_t capacity, CallbackPtr callback_ptr)
   assert((capacity_ % 8) == 0);
   heap_ = reinterpret_cast<unsigned char *>(sxmmap(capacity + 7));
   uintptr_t head = uintptr_t(heap_) % 8;
-  if (head > 0)
-    sxunmap(heap_, head);
   heap_ += head;
-  uintptr_t tail = 7 - head;
-  if (tail > 0)
-    sxunmap(heap_ + capacity, tail);
 }
 
 

--- a/cvmfs/malloc_heap.h
+++ b/cvmfs/malloc_heap.h
@@ -92,14 +92,6 @@ class MallocHeap {
   };
 
   /**
-   * Round up size to the next larger multiple of 8.  This is used to enforce
-   * 8-byte alignment.
-   */
-  static inline uint64_t RoundUp8(const uint64_t size) {
-    return (size + 7) & ~static_cast<uint64_t>(7);
-  }
-
-  /**
    * Invoked when a block is moved during compact.
    */
   CallbackPtr callback_ptr_;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -167,7 +167,7 @@ bool FileSystem::CreateCache() {
   string optarg;
   uint64_t nfiles;
   uint64_t cache_bytes;
-  MemoryKvStore::MemoryAllocator alloc = MemoryKvStore::kMallocLibc;
+  MemoryKvStore::MemoryAllocator alloc = MemoryKvStore::kMallocHeap;
 
   cache_mgr_type_ = cache::kPosixCacheManager;
   if (options_mgr_->GetValue("CVMFS_CACHE_PRIMARY", &optarg)) {
@@ -212,8 +212,8 @@ bool FileSystem::CreateCache() {
     if (options_mgr_->GetValue("CVMFS_CACHE_RAM_MALLOC", &optarg)) {
       if (optarg == "arena") {
         alloc = MemoryKvStore::kMallocArena;
-      } else if (optarg == "heap") {
-        alloc = MemoryKvStore::kMallocHeap;
+      } else if (optarg == "libc") {
+        alloc = MemoryKvStore::kMallocLibc;
       }
     }
     cache_bytes = RoundUp8(max((uint64_t) 200*1024*1024, cache_bytes));

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -216,11 +216,7 @@ bool FileSystem::CreateCache() {
         alloc = MemoryKvStore::kMallocHeap;
       }
     }
-    if (cache_bytes % 8 != 0) {
-      // Ensure 8-byte alignment for heap allocator
-      cache_bytes += 8 - (cache_bytes % 8);
-    }
-    cache_bytes = max((uint64_t) 200*1024*1024, cache_bytes);
+    cache_bytes = RoundUp8(max((uint64_t) 200*1024*1024, cache_bytes));
     cache_mgr_ = new cache::RamCacheManager(
       cache_bytes,
       nfiles,

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -210,10 +210,14 @@ bool FileSystem::CreateCache() {
       cache_bytes = platform_memsize() >> 5;  // ~3%
     }
     if (options_mgr_->GetValue("CVMFS_CACHE_RAM_MALLOC", &optarg)) {
-      if (optarg == "arena") {
-        alloc = MemoryKvStore::kMallocArena;
-      } else if (optarg == "libc") {
+      if (optarg == "libc") {
         alloc = MemoryKvStore::kMallocLibc;
+      } else if (optarg == "heap") {
+        alloc = MemoryKvStore::kMallocHeap;
+      } else {
+        boot_error_ = "Failure: unknown malloc";
+        boot_status_ = loader::kFailOptions;
+        return false;
       }
     }
     cache_bytes = RoundUp8(max((uint64_t) 200*1024*1024, cache_bytes));

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -216,6 +216,10 @@ bool FileSystem::CreateCache() {
         alloc = MemoryKvStore::kMallocHeap;
       }
     }
+    if (cache_bytes % 8 != 0) {
+      // Ensure 8-byte alignment for heap allocator
+      cache_bytes += 8 - (cache_bytes % 8);
+    }
     cache_bytes = max((uint64_t) 200*1024*1024, cache_bytes);
     cache_mgr_ = new cache::RamCacheManager(
       cache_bytes,

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -212,6 +212,8 @@ bool FileSystem::CreateCache() {
     if (options_mgr_->GetValue("CVMFS_CACHE_RAM_MALLOC", &optarg)) {
       if (optarg == "arena") {
         alloc = MemoryKvStore::kMallocArena;
+      } else if (optarg == "heap") {
+        alloc = MemoryKvStore::kMallocHeap;
       }
     }
     cache_bytes = max((uint64_t) 200*1024*1024, cache_bytes);

--- a/cvmfs/smalloc.h
+++ b/cvmfs/smalloc.h
@@ -30,6 +30,14 @@ namespace CVMFS_NAMESPACE_GUARD {
 // Checkerboard marker (binary 101010...)
 const uint32_t kMemMarker = 0xAAAAAAAA;
 
+/**
+ * Round up size to the next larger multiple of 8.  This is used to enforce
+ * 8-byte alignment.
+ */
+static inline uint64_t RoundUp8(const uint64_t size) {
+  return (size + 7) & ~static_cast<uint64_t>(7);
+}
+
 static inline void * __attribute__((used)) smalloc(size_t size) {
   void *mem = malloc(size);
   assert(mem && "Out Of Memory");

--- a/cvmfs/sqlitemem.cc
+++ b/cvmfs/sqlitemem.cc
@@ -120,7 +120,7 @@ int SqliteMemoryManager::xSize(void *ptr) {
 
 
 int SqliteMemoryManager::xRoundup(int size) {
-  return MallocArena::RoundUp8(size);
+  return RoundUp8(size);
 }
 
 

--- a/test/unittests/t_cache_ram.cc
+++ b/test/unittests/t_cache_ram.cc
@@ -161,8 +161,6 @@ TEST_F(T_RamCacheManager, Eviction) {
 
   a_.digest[1] = 1;
   EXPECT_EQ(-ENOENT, ramcache_.Open(a_));
-
-  EXPECT_EQ(0, ramcache_.AbortTxn(txn5));
 }
 
 TEST_F(T_RamCacheManager, OpenEntries) {

--- a/test/unittests/t_kvstore.cc
+++ b/test/unittests/t_kvstore.cc
@@ -62,21 +62,6 @@ TEST_F(T_MemoryKvStore, Commit) {
   free(buf_.address);
 }
 
-TEST_F(T_MemoryKvStore, PopBuffer) {
-  EXPECT_EQ(0, (int64_t) store_.GetUsed());
-  buf_.id = a1_;
-  EXPECT_TRUE(store_.Commit(buf_));
-  EXPECT_EQ(malloc_size, store_.GetUsed());
-  memset(buf_.address, 42, malloc_size);
-  MemoryBuffer out;
-  EXPECT_FALSE(store_.PopBuffer(shash::Any(), &out));
-  EXPECT_TRUE(store_.PopBuffer(a1_, &out));
-  EXPECT_EQ(out.address, buf_.address);
-  EXPECT_EQ(0, (int64_t) store_.GetUsed());
-  memset(out.address, 24, malloc_size);
-  free(out.address);
-}
-
 TEST_F(T_MemoryKvStore, Delete) {
   EXPECT_EQ(0, (int64_t) store_.GetUsed());
   buf_.id = a1_;


### PR DESCRIPTION
I added another allocator for the RAM cache, and can run the ATLAS benchmark on it. The config key is

    CVMFS_CACHE_RAM_MALLOC=heap

It uses the log-structured allocator @jblomer recently added. Since the new allocator needs to have id headers and know about **all** pointers to allocations, making the transactions call into the `KvStore`'s allocator was proving troublesome. This PR makes a clean separation between the scratch memory for transactions (obtained via libc's `malloc`) and the `KvStore` allocated memory. Since transactions should either succeed or fail quickly, lingering allocations that other allocators address shouldn't be a problem. For a shared cache, this separation also fits, since it might not be possible to directly allocate memory through the `KvStore`.