### PR TITLE
Remove kvstore realloc

### DIFF
--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -374,16 +374,16 @@ int64_t RamCacheManager::CommitToKvStore(Transaction *transaction) {
     return -ENOSPC;
   }
 
-  if (store->Commit(transaction->buffer)) {
-    LogCvmfs(kLogCache, kLogDebug, "committed %s to cache",
-             transaction->buffer.id.ToString().c_str());
-    return 0;
-  } else {
+  int rc = store->Commit(transaction->buffer);
+  if (rc < 0) {
     LogCvmfs(kLogCache, kLogDebug,
              "commit on %s failed",
              transaction->buffer.id.ToString().c_str());
-    return -EIO;
+    return rc;
   }
+  LogCvmfs(kLogCache, kLogDebug, "committed %s to cache",
+           transaction->buffer.id.ToString().c_str());
+  return 0;
 }
 
 }  // namespace cache

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -176,12 +176,13 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
     size_t offset);
 
   /**
-   * Insert a new memory buffer. The KvStore takes ownership of the referred memory, so
-   * callers must not free() it themselves
+   * Insert a new memory buffer. The KvStore copies the referred memory, so
+   * callers may free() their buffers after Commit returns
    * @param buf The memory buffer to insert
-   * @returns True iff the commit succeeds
+   * @returns -ENFILE if too many file handles are in use
+   * @returns -EIO if memory allocation fails
    */
-  bool Commit(const MemoryBuffer &buf);
+  int Commit(const MemoryBuffer &buf);
 
   /**
    * Delete an entry, free()ing its memory. Note that the entry not have any references
@@ -209,9 +210,8 @@ class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
 
   bool DoDelete(const shash::Any &id);
   int DoMalloc(MemoryBuffer *buf);
-  int DoRealloc(MemoryBuffer *buf, size_t size);
   void DoFree(MemoryBuffer *buf);
-  bool DoCommit(const MemoryBuffer &buf);
+  int DoCommit(const MemoryBuffer &buf);
   void OnBlockMove(const MallocHeap::BlockPtr &ptr);
   bool CompactMemory();
 

--- a/test/unittests/t_kvstore.cc
+++ b/test/unittests/t_kvstore.cc
@@ -55,9 +55,9 @@ TEST_F(T_MemoryKvStore, Commit) {
   EXPECT_EQ(-ENOENT, store_.GetSize(a1_));
   EXPECT_EQ(0, (int64_t) store_.GetUsed());
   buf_.id = a1_;
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ((int64_t) malloc_size, store_.GetSize(a1_));
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ(malloc_size, store_.GetUsed());
   free(buf_.address);
 }
@@ -65,12 +65,12 @@ TEST_F(T_MemoryKvStore, Commit) {
 TEST_F(T_MemoryKvStore, Delete) {
   EXPECT_EQ(0, (int64_t) store_.GetUsed());
   buf_.id = a1_;
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ(malloc_size, store_.GetUsed());
   EXPECT_FALSE(store_.Delete(a2_));
   buf_.address = malloc(malloc_size);
   buf_.id = a2_;
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ(2*malloc_size, store_.GetUsed());
   memset(buf_.address, 42, malloc_size);
   EXPECT_TRUE(store_.Delete(a1_));
@@ -89,7 +89,7 @@ TEST_F(T_MemoryKvStore, Read) {
 
   EXPECT_EQ(0, (int64_t) store_.GetUsed());
   buf_.id = a1_;
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ(malloc_size, store_.GetUsed());
 
   EXPECT_EQ((int64_t) malloc_size, store_.Read(a1_, out, malloc_size, 0));
@@ -114,7 +114,7 @@ TEST_F(T_MemoryKvStore, Refcount) {
   EXPECT_FALSE(store_.Unref(a1_));
   EXPECT_EQ(0, (int64_t) store_.GetUsed());
   buf_.id = a1_;
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ(malloc_size, store_.GetUsed());
 
   EXPECT_EQ(0, store_.GetRefcount(a1_));
@@ -139,7 +139,7 @@ TEST_F(T_MemoryKvStore, ShrinkTo) {
   buf_.refcount = 1;
   EXPECT_EQ(0, (int64_t) store_.GetUsed());
   buf_.id = a1_;
-  EXPECT_TRUE(store_.Commit(buf_));
+  EXPECT_EQ(0, store_.Commit(buf_));
   EXPECT_EQ(malloc_size, store_.GetUsed());
   buf_.refcount = 0;
   for (int i = 0; i < 99; i++) {


### PR DESCRIPTION
Since `KvStore` doesn't expose memory allocation directly to callers anymore, there's no strong reason to include logic for `realloc`. See comments in #1685