### PR TITLE
use default X509_CERT_DIR also if it is empty string

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -928,7 +928,7 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 1L);
   if (url.substr(0, 5) == "https") {
     const char *cadir = getenv("X509_CERT_DIR");
-    if (!cadir) {cadir = "/etc/grid-security/certificates";}
+    if (!cadir || !*cadir) {cadir = "/etc/grid-security/certificates";}
     curl_easy_setopt(curl_handle, CURLOPT_CAPATH, cadir);
     if (info->pid != -1) {
       if (credentials_attachment_ == NULL) {


### PR DESCRIPTION
This isn't easy to test in a regression test because we don't want to assume that /etc/grid-security/certificates exists on the testing machine.  So I think it's fine to just fix the code.
See [CVM-1083](https://sft.its.cern.ch/jira/browse/CVM-1083) for more details.