### PR TITLE
macOS 10.12 - Fixes client failure due to OS version string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode7.1
+
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
       - gdb
 
 before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install Caskroom/cask/osxfuse ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew cask install osxfuse && brew install cmake; fi
 
 script:
   - ci/run_travis.sh

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -325,16 +325,6 @@ inline const char* platform_getexepath() {
 }
 
 
-inline void platform_get_os_version(int32_t *major,
-                                    int32_t *minor,
-                                    int32_t *patch) {
-  struct utsname uts_info;
-  const int res = uname(&uts_info);
-  assert(res == 0);
-  const int matches = sscanf(uts_info.release, "%u.%u.%u", major, minor, patch);
-  assert(matches == 3 && "failed to read version string");
-}
-
 inline uint64_t platform_monotonic_time() {
   struct timespec tp;
 #ifdef CLOCK_MONOTONIC_COARSE

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -219,46 +219,6 @@ inline bool read_line(FILE *f, std::string *line) {
   return true;
 }
 
-inline void platform_get_os_version(int32_t *major,
-                                    int32_t *minor,
-                                    int32_t *patch) {
-  const std::string plist = "/System/Library/CoreServices/SystemVersion.plist";
-  const std::string plist_key = "ProductVersion";
-
-  FILE *plist_file = fopen(plist.c_str(), "r");
-  assert(plist_file != NULL && "couldn't open SystemVersion.plist");
-
-  std::string line;
-  bool found_key = false;
-  while (read_line(plist_file, &line) && !found_key) {
-    if (line.find(plist_key) != std::string::npos) {
-      found_key = true;
-      break;
-    }
-  }
-  assert(found_key && "didn't find key in SystemVersion.plist");
-
-  const std::string start_tag = "<string>";
-  const std::string end_tag   = "</string>";
-  size_t start, end;
-  bool found_value = false;
-  while (read_line(plist_file, &line) && !found_value) {
-    start = line.find(start_tag);
-    end   = line.find(end_tag);
-    if (start != std::string::npos && end != std::string::npos) {
-      found_value = true;
-      break;
-    }
-  }
-  assert(found_value && "didn't find value in SystemVersion.plist");
-  fclose(plist_file);
-
-  start = start + start_tag.length();
-  const std::string version = line.substr(start, end - start);
-  const int matches = sscanf(version.c_str(), "%u.%u.%u", major, minor, patch);
-  assert(matches == 3 && "failed to read OS X version string");
-}
-
 
 inline uint64_t platform_monotonic_time() {
   uint64_t val_abs = mach_absolute_time();

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -223,13 +223,9 @@ static std::string GetCvmfsBinary() {
   paths.push_back("/usr/bin");
 
 #ifdef __APPLE__
-  int major, minor, patch;
-  platform_get_os_version(&major, &minor, &patch);
   // OS X El Capitan came with SIP, forcing us to become relocatable. CVMFS
   // 2.2.0+ installs into /usr/local always
-  if (major == 10 && minor >= 9) {
-    paths.push_back("/usr/local/bin");
-  }
+  paths.push_back("/usr/local/bin");
 #endif
 
   // TODO(reneme): C++11 range based for loop

--- a/test/unittests/t_platforms.cc
+++ b/test/unittests/t_platforms.cc
@@ -6,13 +6,5 @@
 
 #include "platform.h"
 
-TEST(T_Platforms, OsVersion) {
-  int major = -1;
-  int minor = -1;
-  int patch = -1;
-  platform_get_os_version(&major, &minor, &patch);
-
-  EXPECT_GT(major, 0);
-  EXPECT_GE(minor, 0);
-  EXPECT_GE(patch, 0);
-}
+// TODO(Radu): Could add some unit tests for all the functions in
+//             platform_{linux,osx}.h


### PR DESCRIPTION
* Remove conditional code based on major.minor.path version string
  since it's no longer needed for supported versions of macOS
  (10.11 and 10.12)
* Removing platform_get_os_version function and its unit test