### PR TITLE
Add support for handling special files when using OverlayFS

### DIFF
--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -70,12 +70,12 @@ class SyncItem {
     return IsCharacterDevice() || IsBlockDevice();
   }
 
-  inline unsigned int GetMajor()     const {
+  inline unsigned int GetRdevMajor()     const {
     assert(IsSpecialFile());
     StatUnion(true); return major(union_stat_.stat.st_rdev);
   }
 
-  inline unsigned int GetMinor()     const {
+  inline unsigned int GetRdevMinor()     const {
     assert(IsSpecialFile());
     StatUnion(true); return minor(union_stat_.stat.st_rdev);
   }

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -21,6 +21,7 @@ enum SyncItemType {
   kItemFile,
   kItemSymlink,
   kItemCharacterDevice,
+  kItemBlockDevice,
   kItemNew,
   kItemMarker,
   kItemUnknown
@@ -57,12 +58,27 @@ class SyncItem {
   inline bool WasSymlink()        const { return WasType(kItemSymlink);        }
   inline bool IsNew()             const { return WasType(kItemNew);            }
   inline bool IsCharacterDevice() const { return IsType(kItemCharacterDevice); }
+  inline bool IsBlockDevice()     const { return IsType(kItemBlockDevice);     }
   inline bool IsGraftMarker()     const { return IsType(kItemMarker);          }
   inline bool IsExternalData()    const { return external_data_;               }
 
   inline bool IsWhiteout()        const { return whiteout_;                    }
   inline bool IsCatalogMarker()   const { return filename_ == ".cvmfscatalog"; }
   inline bool IsOpaqueDirectory() const { return IsDirectory() && opaque_;     }
+
+  inline bool IsSpecialFile()     const {
+    return IsCharacterDevice() || IsBlockDevice();
+  }
+
+  inline unsigned int GetMajor()     const {
+    assert(IsSpecialFile());
+    StatUnion(true); return major(union_stat_.stat.st_rdev);
+  }
+
+  inline unsigned int GetMinor()     const {
+    assert(IsSpecialFile());
+    StatUnion(true); return minor(union_stat_.stat.st_rdev);
+  }
 
   bool HasCatalogMarker()         const { return has_catalog_marker_;          }
   bool HasGraftMarker()           const { return graft_marker_present_;        }
@@ -195,9 +211,10 @@ class SyncItem {
     inline SyncItemType GetSyncItemType() const {
       assert(obtained);
       if (S_ISDIR(stat.st_mode)) return kItemDir;
+      if (S_ISCHR(stat.st_mode)) return kItemCharacterDevice;
+      if (S_ISBLK(stat.st_mode)) return kItemBlockDevice;
       if (S_ISREG(stat.st_mode)) return kItemFile;
       if (S_ISLNK(stat.st_mode)) return kItemSymlink;
-      if (S_ISCHR(stat.st_mode)) return kItemCharacterDevice;
       return kItemUnknown;
     }
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -76,7 +76,8 @@ void SyncMediator::Add(const SyncItem &entry) {
   }
 
   if (entry.IsSpecialFile() && !entry.IsWhiteout()) {
-    PrintWarning("'" + entry.GetRelativePath() + "' is a special file, ignoring.");
+    PrintWarning("'" + entry.GetRelativePath() + "' "
+                 "is a special file, ignoring.");
     return;
   }
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -75,6 +75,9 @@ void SyncMediator::Add(const SyncItem &entry) {
     return;  // Ignore markers.
   }
 
+  // In OverlayFS whiteouts can be represented as character devices with major
+  // and minor numbers equal to 0. Special files will be ignored except if they
+  // are whiteout files.
   if (entry.IsSpecialFile() && !entry.IsWhiteout()) {
     PrintWarning("'" + entry.GetRelativePath() + "' "
                  "is a special file, ignoring.");

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -75,6 +75,11 @@ void SyncMediator::Add(const SyncItem &entry) {
     return;  // Ignore markers.
   }
 
+  if (entry.IsSpecialFile() && !entry.IsWhiteout()) {
+    PrintWarning("'" + entry.GetRelativePath() + "' is a special file, ignoring.");
+    return;
+  }
+
   PrintWarning("'" + entry.GetRelativePath() + "' cannot be added. "
                "Unrecognized file type.");
 }
@@ -353,6 +358,8 @@ void SyncMediator::AddDirectoryRecursively(const SyncItem &entry) {
   traversal.fn_new_symlink    = &SyncMediator::AddSymlinkCallback;
   traversal.fn_new_dir_prefix = &SyncMediator::AddDirectoryCallback;
   traversal.fn_ignore_file    = &SyncMediator::IgnoreFileCallback;
+  traversal.fn_new_character_dev = &SyncMediator::AddCharacterDeviceCallback;
+  traversal.fn_new_block_dev = &SyncMediator::AddBlockDeviceCallback;
   traversal.Recurse(entry.GetScratchPath());
 }
 
@@ -373,6 +380,20 @@ void SyncMediator::AddFileCallback(const std::string &parent_dir,
   Add(entry);
 }
 
+
+void SyncMediator::AddCharacterDeviceCallback(const std::string &parent_dir,
+                                    const std::string &file_name)
+{
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemCharacterDevice);
+  Add(entry);
+}
+
+void SyncMediator::AddBlockDeviceCallback(const std::string &parent_dir,
+                                    const std::string &file_name)
+{
+  SyncItem entry = CreateSyncItem(parent_dir, file_name, kItemBlockDevice);
+  Add(entry);
+}
 
 void SyncMediator::AddSymlinkCallback(const std::string &parent_dir,
                                       const std::string &link_name)

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -146,6 +146,10 @@ class SyncMediator {
                             const std::string &dir_name);
   void AddFileCallback(const std::string &parent_dir,
                        const std::string &file_name);
+  void AddCharacterDeviceCallback(const std::string &parent_dir,
+                       const std::string &file_name);
+  void AddBlockDeviceCallback(const std::string &parent_dir,
+                       const std::string &file_name);
   void AddSymlinkCallback(const std::string &parent_dir,
                           const std::string &link_name);
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -444,7 +444,7 @@ bool SyncUnionOverlayfs::IsWhiteoutEntry(const SyncItem &entry) const {
    * 1. whiteouts are 'character device' files
    * 2. whiteouts are symlinks pointing to '(overlay-whiteout)'
    */
-  return (entry.IsCharacterDevice() && entry.Major() == 0 && entry.Minor() == 0) ||
+  return (entry.IsCharacterDevice() && entry.GetMajor() == 0 && entry.GetMinor() == 0) ||
         (entry.IsSymlink() && IsWhiteoutSymlinkPath(entry.GetScratchPath()));
 }
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -117,7 +117,6 @@ void SyncUnion::ProcessSymlink(const string &parent_dir,
 void SyncUnion::ProcessFile(const SyncItem &entry) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessFile(%s)",
            entry.filename().c_str());
-
   if (entry.IsWhiteout()) {
     mediator_->Remove(entry);
   } else {
@@ -343,7 +342,6 @@ void SyncUnionOverlayfs::CheckForBrokenHardlink(const SyncItem &entry) const {
 }
 
 void SyncUnionOverlayfs::MaskFileHardlinks(SyncItem *entry) const {
-  LogCvmfs(kLogCvmfs, kLogDebug, "masking: %s", entry->GetRelativePath().c_str());
   assert(entry->IsRegularFile() || entry->IsSymlink());
   if (entry->GetUnionLinkcount() > 1) {
     LogCvmfs(kLogPublish, kLogStderr, "Warning: Found file with linkcount > 1 "
@@ -444,8 +442,13 @@ bool SyncUnionOverlayfs::IsWhiteoutEntry(const SyncItem &entry) const {
    * 1. whiteouts are 'character device' files
    * 2. whiteouts are symlinks pointing to '(overlay-whiteout)'
    */
-  return (entry.IsCharacterDevice() && entry.GetMajor() == 0 && entry.GetMinor() == 0) ||
-        (entry.IsSymlink() && IsWhiteoutSymlinkPath(entry.GetScratchPath()));
+  bool is_chardev_whiteout = entry.IsCharacterDevice() &&
+    entry.GetMajor() == 0 && entry.GetMinor() == 0;
+
+  bool is_symlink_whiteout = entry.IsSymlink() &&
+    IsWhiteoutSymlinkPath(entry.GetScratchPath());
+
+  return is_chardev_whiteout || is_symlink_whiteout;
 }
 
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -443,7 +443,7 @@ bool SyncUnionOverlayfs::IsWhiteoutEntry(const SyncItem &entry) const {
    * 2. whiteouts are symlinks pointing to '(overlay-whiteout)'
    */
   bool is_chardev_whiteout = entry.IsCharacterDevice() &&
-    entry.GetMajor() == 0 && entry.GetMinor() == 0;
+    entry.GetRdevMajor() == 0 && entry.GetRdevMinor() == 0;
 
   bool is_symlink_whiteout = entry.IsSymlink() &&
     IsWhiteoutSymlinkPath(entry.GetScratchPath());

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -257,6 +257,8 @@ class SyncUnionOverlayfs : public SyncUnion {
 
   void ProcessCharacterDevice(const std::string &parent_dir,
                               const std::string &filename);
+  void ProcessBlockDevice(const std::string &parent_dir,
+                              const std::string &filename);
   std::string UnwindWhiteoutFilename(const SyncItem &entry) const;
   std::set<std::string> GetIgnoreFilenames() const;
 

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -1,0 +1,118 @@
+cvmfs_test_name="Handling special files"
+
+export CVMFS_TEST_UNIONFS="overlayfs"
+
+_setup() {
+    create_repo "$CVMFS_TEST_REPO" "$CVMFS_TEST_USER" "/tmp/debug.log" 1>/dev/null
+}
+
+_cleanup() {
+    destroy_repo "$CVMFS_TEST_REPO" 1>/dev/null
+}
+
+# check character device with major-minor other than 0-0 in alredy existing dir
+test_chrdev_basic() {
+    local filename="chardev_10_20"
+
+    _setup
+    start_transaction "$CVMFS_TEST_REPO" || return 1
+    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/$filename" c 10 20 || return 2
+
+    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
+    [ $? = 0 ] || return 3
+
+    # assert 1: check the old message
+    echo "$publish_output" | grep -i "'$filename' should be deleted"
+    local status1=$(( $? == 1 ))
+
+    # assert 2: check the new message
+    echo  "$publish_output" | grep -i "'$filename'.*ignoring"
+    local status2=$?
+
+    _cleanup
+
+    return $(( $status1 == 0 && $status2 == 0 ))
+}
+
+# check block device in an alredy existing dir
+test_blkdev_basic() {
+    local filename="blockdev_10_20"
+
+    _setup
+    start_transaction "$CVMFS_TEST_REPO" || return 1
+
+    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/$filename" b 10 20 || return 2
+    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
+    [ $? = 0 ] || return 3
+
+    echo "$publish_output" | grep -i "$filename.*ignoring"
+    local status1=$?
+
+    _cleanup
+
+    return $status1
+}
+
+# check character device with major-minor other than 0-0 in a new dir
+test_chrdev_newdir() {
+    local filename="chardev_10_20"
+
+    _setup
+    start_transaction "$CVMFS_TEST_REPO" || return 1
+    mkdir "/cvmfs/$CVMFS_TEST_REPO/dev"
+    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/dev/$filename" c 10 20 || return 2
+
+    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
+    local status0=$?
+    [ $status0 = 0 ] || return 3
+
+    echo "$publish_output" | grep -i "$filename.*ignoring"
+    local status1=$?
+
+    _cleanup
+
+    return $status1
+}
+
+# check block device with major-minor other than 0-0 in a new dir
+test_blkdev_newdir() {
+    local filename="blockdev_10_20"
+
+    _setup
+    start_transaction "$CVMFS_TEST_REPO" || return 1
+    mkdir "/cvmfs/$CVMFS_TEST_REPO/dev"
+    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/dev/$filename" b 10 20 || return 2
+
+    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
+    local status0=$?
+    [ $status0 = 0 ] || return 3
+
+    echo "$publish_output" | grep -i "$filename.*ignoring"
+    local status1=$?
+
+    _cleanup
+
+    return $status1
+}
+
+cvmfs_run_test() {
+    logfile=$1
+
+    test_chrdev_basic
+    local status1=$?
+    [ $status1 = 0 ] || echo "Check 1 Failed with err code: $status1"
+
+    test_blkdev_basic
+    local status2=$?
+    [ $status2 = 0 ] || echo "Check 2 Failed with err code: $status2"
+
+    test_chrdev_newdir
+    local status3=$?
+    [ $status3 = 0 ] || echo "Check 3 Failed with err code: $status3"
+
+    test_blkdev_newdir
+    local status4=$?
+    [ $status4 = 0 ] || echo "Check 4 Failed with err code: $status4"
+
+    return $(($status1 || $status2 || $status3 || $status4))
+}


### PR DESCRIPTION
This commit fixes the problem with publishing a transaction
when there are special files added to the repository
and OverlayFS is used as a UnionFS driver.

Whiteout files in OverlayFS are represented as character devices
with both major and minor numbers 0. OverlayFS driver doesn't allow
users to create such files.

Both block and character devices will be ignored with a warning message
printed out.

A new SyncItemType is introduced: kBlockDevice

SyncItem has 4 new methods:
 - GetMajor
 - GetMinor
 - IsBlockDevice
 - IsSpecialFile

Handling special files may change in future in the following ways:
 - fail by default, enable explicitly in config to ignore with warning
 - add special files to the repo