### PR TITLE
Add configuration variable to enable ignoring special files

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -4897,6 +4897,10 @@ cvmfs_server_publish() {
     if [ "x${CVMFS_VOMS_AUTHZ}" != x ]; then
       sync_command="$sync_command -V"
     fi
+    if [ "x$CVMFS_IGNORE_SPECIAL_FILES" = "xtrue" ]; then
+      sync_command="$sync_command -g"
+    fi
+
     local tag_command="$(__swissknife_cmd dbg) tag_create \
       -r $upstream                                        \
       -w $stratum0                                        \

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -582,6 +582,10 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     params.ttl_seconds = String2Uint64(*args.find('T')->second);
   }
 
+  if (args.find('g') != args.end()) {
+    params.ignore_special_files = true;
+  }
+
   if (!CheckParams(params)) return 2;
 
   // Start spooler

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -32,6 +32,7 @@ struct SyncParameters {
     include_xattrs(false),
     external_data(false),
     voms_authz(false),
+    ignore_special_files(false),
     compression_alg(zlib::kZlibDefault),
     catalog_entry_warn_threshold(kDefaultEntryWarnThreshold),
     min_file_chunk_size(kDefaultMinFileChunkSize),
@@ -67,6 +68,7 @@ struct SyncParameters {
   bool             include_xattrs;
   bool             external_data;
   bool             voms_authz;
+  bool             ignore_special_files;
   zlib::Algorithms compression_alg;
   uint64_t         catalog_entry_warn_threshold;
   size_t           min_file_chunk_size;
@@ -250,6 +252,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Switch('d', "pause publishing to allow for catalog "
                                        "tweaks"));
     r.push_back(Parameter::Switch('i', "ignore x-directory hardlinks"));
+    r.push_back(Parameter::Switch('g', "ignore special files"));
     r.push_back(Parameter::Switch('k', "include extended attributes"));
     r.push_back(Parameter::Switch('m', "create micro catalogs"));
     r.push_back(Parameter::Switch('n', "create new repository"));

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -79,12 +79,12 @@ void SyncMediator::Add(const SyncItem &entry) {
   // and minor numbers equal to 0. Special files will be ignored except if they
   // are whiteout files.
   if (entry.IsSpecialFile() && !entry.IsWhiteout()) {
-    if (params_->ignore_special_files == true) {
+    if (params_->ignore_special_files) {
       PrintWarning("'" + entry.GetRelativePath() + "' "
                   "is a special file, ignoring.");
       return;
     } else {
-      PrintWarning("'" + entry.GetRelativePath() + "' "
+      PrintError("'" + entry.GetRelativePath() + "' "
                    "is a special file, stopping. "
                    "Enable CVMFS_IGNORE_SPECIAL_FILES in the cvmfs config.");
       abort();

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -79,9 +79,16 @@ void SyncMediator::Add(const SyncItem &entry) {
   // and minor numbers equal to 0. Special files will be ignored except if they
   // are whiteout files.
   if (entry.IsSpecialFile() && !entry.IsWhiteout()) {
-    PrintWarning("'" + entry.GetRelativePath() + "' "
-                 "is a special file, ignoring.");
-    return;
+    if (params_->ignore_special_files == true) {
+      PrintWarning("'" + entry.GetRelativePath() + "' "
+                  "is a special file, ignoring.");
+      return;
+    } else {
+      PrintWarning("'" + entry.GetRelativePath() + "' "
+                   "is a special file, stopping. "
+                   "Enable CVMFS_IGNORE_SPECIAL_FILES in the cvmfs config.");
+      abort();
+    }
   }
 
   PrintWarning("'" + entry.GetRelativePath() + "' cannot be added. "

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -191,6 +191,21 @@ class SyncUnion {
   virtual void LeaveDirectory(const std::string &parent_dir,
                               const std::string &dir_name);
 
+  /**
+   *Callback when a character device is found
+   * @param parent_dir the relative directory path
+   * @param filename the filename
+   */
+  void ProcessCharacterDevice(const std::string &parent_dir,
+                              const std::string &filename);
+
+  /**
+   *Callback when a block device is found
+   * @param parent_dir the relative directory path
+   * @param filename the filename
+   */
+  void ProcessBlockDevice(const std::string &parent_dir,
+                          const std::string &filename);
 
   /**
    * Called to actually process the file entry.
@@ -255,10 +270,6 @@ class SyncUnionOverlayfs : public SyncUnion {
   bool IsOpaqueDirectory(const SyncItem &directory) const;
   bool IsWhiteoutSymlinkPath(const std::string &path) const;
 
-  void ProcessCharacterDevice(const std::string &parent_dir,
-                              const std::string &filename);
-  void ProcessBlockDevice(const std::string &parent_dir,
-                              const std::string &filename);
   std::string UnwindWhiteoutFilename(const SyncItem &entry) const;
   std::set<std::string> GetIgnoreFilenames() const;
 

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -1,34 +1,37 @@
 cvmfs_test_name="Handling special files"
 
-test_repo_config="/etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf"
+CVMFS_TEST639_TESTREPOCONFIG="/etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf"
 
-filename=""
-publish_output=""
+CVMFS_TEST639_FILENAME=""
+CVMFS_TEST639_PUBLISHOUTPUT=""
 
-unionfs="overlayfs"
-ignore_special_files="true"
-dev_type="c"
-newdir="false"
+CVMFS_TEST639_CVMFS_TEST639_UNIONFS="overlayfs"
+CVMFS_TEST639_IGNORE_SPECIAL_FILES="true"
+CVMFS_TEST639_DEVTYPE="c"
+CVMFS_TEST639_NEWDIR="false"
 
 _setup() {
-    export CVMFS_TEST_UNIONFS="$unionfs"
+    local filepath=""
 
-    create_repo "$CVMFS_TEST_REPO" "$CVMFS_TEST_USER" "/tmp/debug.log" 1>/dev/null
+    create_repo "$CVMFS_TEST_REPO" "$CVMFS_TEST_USER" "/tmp/debug.log"
 
-    if [ $ignore_special_files = "true" ]; then
-        echo "CVMFS_IGNORE_SPECIAL_FILES=$ignore_special_files" | sudo tee -a $test_repo_config
+    if [ $CVMFS_TEST639_IGNORE_SPECIAL_FILES = "true" ]; then
+        local l="CVMFS_IGNORE_SPECIAL_FILES=$CVMFS_TEST639_IGNORE_SPECIAL_FILES"
+        echo "$l" | sudo tee -a $CVMFS_TEST639_TESTREPOCONFIG
     fi
 
     start_transaction "$CVMFS_TEST_REPO" || return 1
 
-    if [ $newdir = "true" ]; then
+    if [ $CVMFS_TEST639_NEWDIR = "true" ]; then
         sudo mkdir "/cvmfs/$CVMFS_TEST_REPO/dev"
-        sudo mknod "/cvmfs/$CVMFS_TEST_REPO/dev/$filename" "$dev_type" 10 20 || return 2
+        filepath="/cvmfs/$CVMFS_TEST_REPO/dev/$CVMFS_TEST639_FILENAME"
     else
-        sudo mknod "/cvmfs/$CVMFS_TEST_REPO/$filename" "$dev_type" 10 20 || return 2
+        filepath="/cvmfs/$CVMFS_TEST_REPO/$CVMFS_TEST639_FILENAME"
     fi
 
-    publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)" || return 3
+    sudo mknod "$filepath" "$CVMFS_TEST639_DEVTYPE" 10 20 || return 2
+
+    CVMFS_TEST639_PUBLISHOUTPUT="$(publish_repo $CVMFS_TEST_REPO 2>&1)" || return 3
 
     return 0
 }
@@ -39,18 +42,18 @@ _cleanup() {
 
 # check character device with major-minor other than 0-0 in alredy existing dir
 test_chrdev_basic() {
-    filename="chardev_10_20"
-    dev_type="c"
-    newdir="false"
-    ignore_special_files="true"
+    CVMFS_TEST639_FILENAME="chardev_10_20"
+    CVMFS_TEST639_DEVTYPE="c"
+    CVMFS_TEST639_NEWDIR="false"
+    CVMFS_TEST639_IGNORE_SPECIAL_FILES="true"
     _setup || return $?
 
     # assert 1: check the old message
-    echo "$publish_output" | grep -i "'$filename' should be deleted"
+    echo "$CVMFS_TEST639_PUBLISHOUTPUT" | grep -i "'$CVMFS_TEST639_FILENAME' should be deleted"
     local status1=$(( $? == 1 ))
 
     # assert 2: check the new message
-    echo  "$publish_output" | grep -i "'$filename'.*ignoring"
+    echo  "$CVMFS_TEST639_PUBLISHOUTPUT" | grep -i "'$CVMFS_TEST639_FILENAME'.*ignoring"
     local status2=$?
 
     _cleanup
@@ -60,13 +63,13 @@ test_chrdev_basic() {
 
 # check block device in an alredy existing dir
 test_blkdev_basic() {
-    filename="blockdev_10_20"
-    dev_type="b"
-    newdir="false"
-    ignore_special_files="true"
+    CVMFS_TEST639_FILENAME="blockdev_10_20"
+    CVMFS_TEST639_DEVTYPE="b"
+    CVMFS_TEST639_NEWDIR="false"
+    CVMFS_TEST639_IGNORE_SPECIAL_FILES="true"
     _setup || return $?
 
-    echo "$publish_output" | grep -i "$filename.*ignoring"
+    echo "$CVMFS_TEST639_PUBLISHOUTPUT" | grep -i "$CVMFS_TEST639_FILENAME.*ignoring"
     local status1=$?
 
     _cleanup
@@ -76,13 +79,13 @@ test_blkdev_basic() {
 
 # check character device with major-minor other than 0-0 in a new dir
 test_chrdev_newdir() {
-    filename="chardev_10_20"
-    dev_type="c"
-    newdir="true"
-    ignore_special_files="true"
+    CVMFS_TEST639_FILENAME="chardev_10_20"
+    CVMFS_TEST639_DEVTYPE="c"
+    CVMFS_TEST639_NEWDIR="true"
+    CVMFS_TEST639_IGNORE_SPECIAL_FILES="true"
     _setup || return $?
 
-    echo "$publish_output" | grep -i "$filename.*ignoring"
+    echo "$CVMFS_TEST639_PUBLISHOUTPUT" | grep -i "$CVMFS_TEST639_FILENAME.*ignoring"
     local status1=$?
 
     _cleanup
@@ -92,13 +95,13 @@ test_chrdev_newdir() {
 
 # check block device with major-minor other than 0-0 in a new dir
 test_blkdev_newdir() {
-    filename="blockdev_10_20"
-    dev_type="b"
-    newdir="true"
-    ignore_special_files="true"
+    CVMFS_TEST639_FILENAME="blockdev_10_20"
+    CVMFS_TEST639_DEVTYPE="b"
+    CVMFS_TEST639_NEWDIR="true"
+    CVMFS_TEST639_IGNORE_SPECIAL_FILES="true"
     _setup || return $?
 
-    echo "$publish_output" | grep -i "$filename.*ignoring"
+    echo "$CVMFS_TEST639_PUBLISHOUTPUT" | grep -i "$CVMFS_TEST639_FILENAME.*ignoring"
     local status1=$?
 
     _cleanup
@@ -107,19 +110,19 @@ test_blkdev_newdir() {
 }
 
 test_fail_chrdev() {
-    filename="chardev_10_20"
-    dev_type="c"
-    newdir="false"
-    ignore_special_files="false"
+    CVMFS_TEST639_FILENAME="chardev_10_20"
+    CVMFS_TEST639_DEVTYPE="c"
+    CVMFS_TEST639_NEWDIR="false"
+    CVMFS_TEST639_IGNORE_SPECIAL_FILES="false"
     _setup
     return $?
 }
 
 test_fail_blkdev() {
-    filename="blkdev_10_20"
-    dev_type="b"
-    newdir="false"
-    ignore_special_files="false"
+    CVMFS_TEST639_FILENAME="blkdev_10_20"
+    CVMFS_TEST639_DEVTYPE="b"
+    CVMFS_TEST639_NEWDIR="false"
+    CVMFS_TEST639_IGNORE_SPECIAL_FILES="false"
     _setup
     return $?
 }
@@ -155,13 +158,13 @@ run_tests_base() {
 }
 
 run_aufs_tests() {
-    unionfs="aufs"
+    CVMFS_TEST639_CVMFS_TEST639_UNIONFS="aufs"
     run_tests_base
     return $?
 }
 
 run_overlayfs_tests() {
-    unionfs="overlayfs"
+    CVMFS_TEST639_CVMFS_TEST639_UNIONFS="overlayfs"
     run_tests_base
     return $?
 }

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -1,10 +1,12 @@
 cvmfs_test_name="Handling special files"
 
 export CVMFS_TEST_UNIONFS="overlayfs"
-export CVMFS_IGNORE_SPECIAL_FILES="true"
+# export CVMFS_IGNORE_SPECIAL_FILES="true"
+test_repo_config="/etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf"
 
 _setup() {
     create_repo "$CVMFS_TEST_REPO" "$CVMFS_TEST_USER" "/tmp/debug.log" 1>/dev/null
+    echo "CVMFS_IGNORE_SPECIAL_FILES=true" | sudo tee -a $test_repo_config
 }
 
 _cleanup() {

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -1,6 +1,7 @@
 cvmfs_test_name="Handling special files"
 
 export CVMFS_TEST_UNIONFS="overlayfs"
+export CVMFS_IGNORE_SPECIAL_FILES="true"
 
 _setup() {
     create_repo "$CVMFS_TEST_REPO" "$CVMFS_TEST_USER" "/tmp/debug.log" 1>/dev/null

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -1,12 +1,36 @@
 cvmfs_test_name="Handling special files"
 
-export CVMFS_TEST_UNIONFS="overlayfs"
-# export CVMFS_IGNORE_SPECIAL_FILES="true"
 test_repo_config="/etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf"
 
+filename=""
+publish_output=""
+
+unionfs="overlayfs"
+ignore_special_files="true"
+dev_type="c"
+newdir="false"
+
 _setup() {
+    export CVMFS_TEST_UNIONFS="$unionfs"
+
     create_repo "$CVMFS_TEST_REPO" "$CVMFS_TEST_USER" "/tmp/debug.log" 1>/dev/null
-    echo "CVMFS_IGNORE_SPECIAL_FILES=true" | sudo tee -a $test_repo_config
+
+    if [ $ignore_special_files = "true" ]; then
+        echo "CVMFS_IGNORE_SPECIAL_FILES=$ignore_special_files" | sudo tee -a $test_repo_config
+    fi
+
+    start_transaction "$CVMFS_TEST_REPO" || return 1
+
+    if [ $newdir = "true" ]; then
+        sudo mkdir "/cvmfs/$CVMFS_TEST_REPO/dev"
+        sudo mknod "/cvmfs/$CVMFS_TEST_REPO/dev/$filename" "$dev_type" 10 20 || return 2
+    else
+        sudo mknod "/cvmfs/$CVMFS_TEST_REPO/$filename" "$dev_type" 10 20 || return 2
+    fi
+
+    publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)" || return 3
+
+    return 0
 }
 
 _cleanup() {
@@ -15,14 +39,11 @@ _cleanup() {
 
 # check character device with major-minor other than 0-0 in alredy existing dir
 test_chrdev_basic() {
-    local filename="chardev_10_20"
-
-    _setup
-    start_transaction "$CVMFS_TEST_REPO" || return 1
-    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/$filename" c 10 20 || return 2
-
-    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
-    [ $? = 0 ] || return 3
+    filename="chardev_10_20"
+    dev_type="c"
+    newdir="false"
+    ignore_special_files="true"
+    _setup || return $?
 
     # assert 1: check the old message
     echo "$publish_output" | grep -i "'$filename' should be deleted"
@@ -39,14 +60,11 @@ test_chrdev_basic() {
 
 # check block device in an alredy existing dir
 test_blkdev_basic() {
-    local filename="blockdev_10_20"
-
-    _setup
-    start_transaction "$CVMFS_TEST_REPO" || return 1
-
-    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/$filename" b 10 20 || return 2
-    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
-    [ $? = 0 ] || return 3
+    filename="blockdev_10_20"
+    dev_type="b"
+    newdir="false"
+    ignore_special_files="true"
+    _setup || return $?
 
     echo "$publish_output" | grep -i "$filename.*ignoring"
     local status1=$?
@@ -58,16 +76,11 @@ test_blkdev_basic() {
 
 # check character device with major-minor other than 0-0 in a new dir
 test_chrdev_newdir() {
-    local filename="chardev_10_20"
-
-    _setup
-    start_transaction "$CVMFS_TEST_REPO" || return 1
-    mkdir "/cvmfs/$CVMFS_TEST_REPO/dev"
-    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/dev/$filename" c 10 20 || return 2
-
-    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
-    local status0=$?
-    [ $status0 = 0 ] || return 3
+    filename="chardev_10_20"
+    dev_type="c"
+    newdir="true"
+    ignore_special_files="true"
+    _setup || return $?
 
     echo "$publish_output" | grep -i "$filename.*ignoring"
     local status1=$?
@@ -79,16 +92,11 @@ test_chrdev_newdir() {
 
 # check block device with major-minor other than 0-0 in a new dir
 test_blkdev_newdir() {
-    local filename="blockdev_10_20"
-
-    _setup
-    start_transaction "$CVMFS_TEST_REPO" || return 1
-    mkdir "/cvmfs/$CVMFS_TEST_REPO/dev"
-    sudo mknod "/cvmfs/$CVMFS_TEST_REPO/dev/$filename" b 10 20 || return 2
-
-    local publish_output="$(publish_repo $CVMFS_TEST_REPO 2>&1)"
-    local status0=$?
-    [ $status0 = 0 ] || return 3
+    filename="blockdev_10_20"
+    dev_type="b"
+    newdir="true"
+    ignore_special_files="true"
+    _setup || return $?
 
     echo "$publish_output" | grep -i "$filename.*ignoring"
     local status1=$?
@@ -98,9 +106,25 @@ test_blkdev_newdir() {
     return $status1
 }
 
-cvmfs_run_test() {
-    logfile=$1
+test_fail_chrdev() {
+    filename="chardev_10_20"
+    dev_type="c"
+    newdir="false"
+    ignore_special_files="false"
+    _setup
+    return $?
+}
 
+test_fail_blkdev() {
+    filename="blkdev_10_20"
+    dev_type="b"
+    newdir="false"
+    ignore_special_files="false"
+    _setup
+    return $?
+}
+
+run_tests_base() {
     test_chrdev_basic
     local status1=$?
     [ $status1 = 0 ] || echo "Check 1 Failed with err code: $status1"
@@ -117,5 +141,37 @@ cvmfs_run_test() {
     local status4=$?
     [ $status4 = 0 ] || echo "Check 4 Failed with err code: $status4"
 
-    return $(($status1 || $status2 || $status3 || $status4))
+    test_fail_chrdev
+    test $? -gt 0
+    local status5=$?
+    [ $status5 = 0 ] || echo "Check 5 Failed with err code: $status5"
+
+    test_fail_blkdev
+    test $? -gt 0
+    local status6=$?
+    [ $status6 = 0 ] || echo "Check 6 Failed with err code: $status6"
+
+    return $(($status1 || $status2 || $status3 || $status4 || $status5 || $status6))
+}
+
+run_aufs_tests() {
+    unionfs="aufs"
+    run_tests_base
+    return $?
+}
+
+run_overlayfs_tests() {
+    unionfs="overlayfs"
+    run_tests_base
+    return $?
+}
+
+cvmfs_run_test() {
+    run_aufs_tests
+    local status1=$?
+
+    run_overlayfs_tests
+    local status2=$?
+
+    return $(($status1 || $status2))
 }


### PR DESCRIPTION
This change preserves old behavior for working with special files (stop publishing by default).
The configuration variable CVMFS_IGNORE_SPECIAL_FILES is introduced.

When this variable is set to true, special files will be ignored with and a warning message will be printed for each of them.
Otherwise, on first encounter of a special file (which is not a whiteout) a warning message will also be printed, but publishing will stop.