### PR TITLE
Host failover after no-cache attempt on corrupted data

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1349,7 +1349,9 @@ waitfor() {
 
 
 list_mounts() {
-  mount -t $fuse_fs_type | grep "^cvmfs2[[:space:]]"
+  # Fix for CernVM: /cvmfs is a bind mountpoint from /mnt/.rw/cvmfs
+  mount -t $fuse_fs_type | grep "^cvmfs2[[:space:]]" \
+    | grep -v "[[:space:]]/mnt/.rw/cvmfs/"
 }
 
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1349,9 +1349,7 @@ waitfor() {
 
 
 list_mounts() {
-  # Fix for CernVM: /cvmfs is a bind mountpoint from /mnt/.rw/cvmfs
-  mount -t $fuse_fs_type | grep "^cvmfs2[[:space:]]" \
-    | grep -v "[[:space:]]/mnt/.rw/cvmfs/"
+  mount -t $fuse_fs_type | grep "^cvmfs2[[:space:]]"
 }
 
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1139,7 +1139,7 @@ cvmfs_umount() {
     umount $m 2>/dev/null
     if [ $? -ne 0 ]; then
       RETVAL=1
-      if [ "x$silent" != "x" ]; then
+      if [ "x$silent" = "x" ]; then
         echo "Failed!"
         $fuser -m -a -v $m
       fi

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1147,6 +1147,20 @@ void DownloadManager::SetNocache(JobInfo *info) {
 
 
 /**
+ * Reverse operation of SetNocache. Makes sure that "no-cache" header
+ * disappears from the list of headers to let proxies work normally.
+ */
+void DownloadManager::SetRegularCache(JobInfo *info) {
+  if (info->nocache == false)
+    return;
+  header_lists_->CutHeader("Pragma: no-cache", &(info->headers));
+  header_lists_->CutHeader("Cache-Control: no-cache", &(info->headers));
+  curl_easy_setopt(info->curl_handle, CURLOPT_HTTPHEADER, info->headers);
+  info->nocache = false;
+}
+
+
+/**
  * Checks the result of a curl download and implements the failure logic, such
  * as changing the proxy server.  Takes care of cleanup.
  *

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -639,6 +639,30 @@ void HeaderLists::AppendHeader(curl_slist *slist, const char *header) {
 }
 
 
+/**
+ * Ensures that a certain header string is _not_ part of slist on return.
+ * Note that if the first header element matches, the returned slist points
+ * to a different value.
+ */
+void HeaderLists::CutHeader(const char *header, curl_slist **slist) {
+  assert(slist);
+  curl_slist head;
+  head.next = *slist;
+  curl_slist *prev = &head;
+  curl_slist *rover = *slist;
+  while (rover) {
+    if (strcmp(rover->data, header) == 0) {
+      prev->next = rover->next;
+      Put(rover);
+      rover = prev;
+    }
+    prev = rover;
+    rover = rover->next;
+  }
+  *slist = head.next;
+}
+
+
 void HeaderLists::PutList(curl_slist *slist) {
   while (slist) {
     curl_slist *next = slist->next;

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -423,6 +423,7 @@ class DownloadManager {
   bool CanRetry(const JobInfo *info);
   void Backoff(JobInfo *info);
   void SetNocache(JobInfo *info);
+  void SetRegularCache(JobInfo *info);
   bool VerifyAndFinalize(const int curl_error, JobInfo *info);
   void InitHeaders();
   void FiniHeaders();

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -270,6 +270,7 @@ class HeaderLists {
   curl_slist *GetList(const char *header);
   curl_slist *DuplicateList(curl_slist *slist);
   void AppendHeader(curl_slist *slist, const char *header);
+  void CutHeader(const char *header, curl_slist **slist);
   void PutList(curl_slist *slist);
   std::string Print(curl_slist *slist);
 

--- a/cvmfs/loader_talk.cc
+++ b/cvmfs/loader_talk.cc
@@ -141,7 +141,7 @@ int MainReload(const std::string &socket_path, const bool stop_and_go) {
   retval = read(socket_fd, &result, sizeof(result));
   if ((retval != 0) || (result != kFailOk)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Reload FAILED! "
-             "CernVM-FS mountpoints unusuable.");
+             "CernVM-FS mountpoints unusuable. [%d, %d]", retval, result);
   }
 
   return result;

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -31,7 +31,6 @@ echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -31,7 +31,6 @@ echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/600-securecvmfs                          \
                                  --                                           \

--- a/test/cloud_testing/platforms/fedora24_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora24_x86_64_test.sh
@@ -31,7 +31,6 @@ echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/600-securecvmfs                          \
                                  --                                           \

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -88,7 +88,6 @@ CVMFS_TEST_SERVER_CACHE='/srv/cache/server'                                   \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/551-openfds                              \
                                  src/585-xattrs                               \

--- a/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
@@ -93,7 +93,6 @@ CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/525-bigrepo                              \
                                  src/577-garbagecollecthiddenstratum1revision \
@@ -118,7 +117,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 #                             -x src/518-hardlinkstresstest                   \
 #                                src/519-importlegacyrepo                     \
 #                                src/522-missingchunkfailover                 \
-#                                src/523-corruptchunkfailover                 \
 #                                src/524-corruptmanifestfailover              \
 #                                src/525-bigrepo                              \
 #                                src/528-recreatespoolarea                    \

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -68,7 +68,6 @@ CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
                                  src/700-overlayfsvalidation                  \
@@ -94,7 +93,6 @@ if [ $s3_retval -eq 0 ]; then
                             -x src/518-hardlinkstresstest                   \
                                src/519-importlegacyrepo                     \
                                src/522-missingchunkfailover                 \
-                               src/523-corruptchunkfailover                 \
                                src/524-corruptmanifestfailover              \
                                src/525-bigrepo                              \
                                src/528-recreatespoolarea                    \

--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -40,7 +40,6 @@ CVMFS_TEST_SERVER_CACHE="$custom_cache_dir"                                   \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -30,7 +30,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 CVMFS_TEST_UNIONFS=overlayfs                                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \

--- a/test/cloud_testing/platforms/ubuntu1604_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1604_x86_64_test.sh
@@ -30,7 +30,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 CVMFS_TEST_UNIONFS=overlayfs                                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
-                                 src/523-corruptchunkfailover                 \
                                  src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -27,8 +27,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                              -x src/523-corruptchunkfailover                 \
-                                 src/524-corruptmanifestfailover              \
+                              -x src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
                                  src/600-securecvmfs                          \
                                  --                                           \

--- a/test/unittests/t_header_lists.cc
+++ b/test/unittests/t_header_lists.cc
@@ -50,4 +50,35 @@ TEST_F(T_HeaderLists, Intrinsics) {
   delete header_lists;
 }
 
+
+TEST_F(T_HeaderLists, CutHeader) {
+  curl_slist *headers = NULL;
+  header_lists->CutHeader("Cut: Me", &headers);
+  EXPECT_EQ(NULL, headers);
+
+  headers = header_lists->GetList("Cut: Me");
+  header_lists->CutHeader("Cut: Me", &headers);
+  EXPECT_EQ(NULL, headers);
+
+  headers = header_lists->GetList("Cut: Me");
+  header_lists->CutHeader("Cut: Me", &headers);
+  EXPECT_EQ(NULL, headers);
+
+  headers = header_lists->GetList("Key: Value");
+  header_lists->AppendHeader(headers, "Cut: Me");
+  header_lists->AppendHeader(headers, "Key: Value");
+  header_lists->AppendHeader(headers, "Cut: Me");
+  header_lists->AppendHeader(headers, "Key: Value");
+  header_lists->CutHeader("Cut: Me", &headers);
+  EXPECT_EQ("Key: Value\nKey: Value\nKey: Value\n",
+            header_lists->Print(headers));
+  header_lists->PutList(headers);
+
+  headers = header_lists->GetList("Key: Value");
+  header_lists->AppendHeader(headers, "A: Nother");
+  header_lists->CutHeader("Cut: Me", &headers);
+  EXPECT_EQ("Key: Value\nA: Nother\n", header_lists->Print(headers));
+  header_lists->PutList(headers);
+}
+
 }  // namespace download


### PR DESCRIPTION
Aimed at better resilience against rogue stratum 1s.  Includes also two minor fixes for `cvmfs_config umount`