### PR TITLE
Cvmfs server platform functions

### DIFF
--- a/cvmfs/make_cvmfs_server.sh
+++ b/cvmfs/make_cvmfs_server.sh
@@ -26,6 +26,7 @@ echo '
 
 # List the components that make up the resulting file
 COMPONENTS="\
+    server/cvmfs_server_sys.sh
     server/cvmfs_server_prelude.sh
     server/cvmfs_server_util.sh
     server/cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -51,7 +51,7 @@ The required package is called ${APACHE_WSGI_MODPKG}."
   if is_redhat; then
     case "`cat /etc/redhat-release`" in
       *"release 5."*)
-        if [ -f /etc/httpd/conf.d/wsgi.conf ]; then
+        if cvmfs_sys_is_regular_file /etc/httpd/conf.d/wsgi.conf ; then
           # older el5 epel versions didn't automatically enable it
           echo "To enable the module, see instructions in /etc/httpd/conf.d/wsgi.conf"
         else
@@ -192,7 +192,7 @@ has_apache_config_file() {
   local file_name=$1
   local conf_path
   conf_path="$(get_apache_conf_path)/${file_name}"
-  [ -f $conf_path ]
+  cvmfs_sys_is_regular_file $conf_path
 }
 
 

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -48,7 +48,7 @@ check_wsgi_module() {
 
   echo "The apache wsgi module must be installed and enabled.
 The required package is called ${APACHE_WSGI_MODPKG}."
-  if is_redhat; then
+  if cvmfs_sys_is_redhat; then
     case "`cat /etc/redhat-release`" in
       *"release 5."*)
         if cvmfs_sys_is_regular_file /etc/httpd/conf.d/wsgi.conf ; then

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -51,7 +51,7 @@ The required package is called ${APACHE_WSGI_MODPKG}."
   if cvmfs_sys_is_redhat; then
     case "`cat /etc/redhat-release`" in
       *"release 5."*)
-        if cvmfs_sys_is_regular_file /etc/httpd/conf.d/wsgi.conf ; then
+        if cvmfs_sys_file_is_regular /etc/httpd/conf.d/wsgi.conf ; then
           # older el5 epel versions didn't automatically enable it
           echo "To enable the module, see instructions in /etc/httpd/conf.d/wsgi.conf"
         else
@@ -192,7 +192,7 @@ has_apache_config_file() {
   local file_name=$1
   local conf_path
   conf_path="$(get_apache_conf_path)/${file_name}"
-  cvmfs_sys_is_regular_file $conf_path
+  cvmfs_sys_file_is_regular $conf_path
 }
 
 

--- a/cvmfs/server/cvmfs_server_chown.sh
+++ b/cvmfs/server/cvmfs_server_chown.sh
@@ -37,8 +37,8 @@ cvmfs_server_catalog_chown() {
   check_repository_existence "$name"
 
   # sanity checks
-  [ x"$uid_map" != x"" ] && [ -f $uid_map ] || die "UID map file not found (-u)"
-  [ x"$gid_map" != x"" ] && [ -f $gid_map ] || die "GID map file not found (-g)"
+  [ x"$uid_map" != x"" ] && cvmfs_sys_is_regular_file $uid_map || die "UID map file not found (-u)"
+  [ x"$gid_map" != x"" ] && cvmfs_sys_file_eixsts $gid_map || die "GID map file not found (-g)"
 
   load_repo_config $name
 

--- a/cvmfs/server/cvmfs_server_chown.sh
+++ b/cvmfs/server/cvmfs_server_chown.sh
@@ -37,7 +37,7 @@ cvmfs_server_catalog_chown() {
   check_repository_existence "$name"
 
   # sanity checks
-  [ x"$uid_map" != x"" ] && cvmfs_sys_is_regular_file $uid_map || die "UID map file not found (-u)"
+  [ x"$uid_map" != x"" ] && cvmfs_sys_file_is_regular $uid_map || die "UID map file not found (-u)"
   [ x"$gid_map" != x"" ] && cvmfs_sys_file_eixsts $gid_map || die "GID map file not found (-g)"
 
   load_repo_config $name

--- a/cvmfs/server/cvmfs_server_chown.sh
+++ b/cvmfs/server/cvmfs_server_chown.sh
@@ -38,7 +38,7 @@ cvmfs_server_catalog_chown() {
 
   # sanity checks
   [ x"$uid_map" != x"" ] && cvmfs_sys_file_is_regular $uid_map || die "UID map file not found (-u)"
-  [ x"$gid_map" != x"" ] && cvmfs_sys_file_eixsts $gid_map || die "GID map file not found (-g)"
+  [ x"$gid_map" != x"" ] && cvmfs_sys_file_is_regular $gid_map || die "GID map file not found (-g)"
 
   load_repo_config $name
 

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -31,7 +31,7 @@ abort_after_hook() { :; }
 publish_before_hook() { :; }
 publish_after_hook() { :; }
 
-cvmfs_sys_is_regular_file /etc/cvmfs/cvmfs_server_hooks.sh && . /etc/cvmfs/cvmfs_server_hooks.sh
+cvmfs_sys_file_is_regular /etc/cvmfs/cvmfs_server_hooks.sh && . /etc/cvmfs/cvmfs_server_hooks.sh
 
 # Path to some useful sbin utilities
 LSOF_BIN="$(find_sbin       lsof)"       || true
@@ -106,7 +106,7 @@ CVMFS_SERVER_SWISSKNIFE_DEBUG=$CVMFS_SERVER_SWISSKNIFE
 
 # enable the debug mode?
 if [ $CVMFS_SERVER_DEBUG -ne 0 ]; then
-  if cvmfs_sys_is_regular_file /usr/bin/cvmfs_swissknife_debug ; then
+  if cvmfs_sys_file_is_regular /usr/bin/cvmfs_swissknife_debug ; then
     case $CVMFS_SERVER_DEBUG in
       1)
         # in case something breaks we are provided with a GDB prompt.

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -31,7 +31,7 @@ abort_after_hook() { :; }
 publish_before_hook() { :; }
 publish_after_hook() { :; }
 
-[ -f /etc/cvmfs/cvmfs_server_hooks.sh ] && . /etc/cvmfs/cvmfs_server_hooks.sh
+cvmfs_sys_is_regular_file /etc/cvmfs/cvmfs_server_hooks.sh && . /etc/cvmfs/cvmfs_server_hooks.sh
 
 # Path to some useful sbin utilities
 LSOF_BIN="$(find_sbin       lsof)"       || true
@@ -106,7 +106,7 @@ CVMFS_SERVER_SWISSKNIFE_DEBUG=$CVMFS_SERVER_SWISSKNIFE
 
 # enable the debug mode?
 if [ $CVMFS_SERVER_DEBUG -ne 0 ]; then
-  if [ -f /usr/bin/cvmfs_swissknife_debug ]; then
+  if cvmfs_sys_is_regular_file /usr/bin/cvmfs_swissknife_debug ; then
     case $CVMFS_SERVER_DEBUG in
       1)
         # in case something breaks we are provided with a GDB prompt.

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -69,11 +69,11 @@ fi
 
 SERVICE_BIN="false"
 if ! $PIDOF_BIN systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
-  if [ -x /sbin/service ]; then
+  if cvmfs_sys_file_is_executable /sbin/service ; then
     SERVICE_BIN="/sbin/service"
-  elif [ -x /usr/sbin/service ]; then
+  elif cvmfs_sys_file_is_executable /usr/sbin/service ; then
     SERVICE_BIN="/usr/sbin/service" # Ubuntu
-  elif [ -x /sbin/rc-service ]; then
+  elif cvmfs_sys_file_is_executable /sbin/rc-service ; then
     SERVICE_BIN="/sbin/rc-service" # OpenRC
   else
     die "Neither systemd nor service binary detected"
@@ -83,7 +83,7 @@ fi
 # Check if `runuser` is available on this system
 # Note: at least Ubuntu in older versions doesn't provide this command
 HAS_RUNUSER=0
-if [ -x "$RUNUSER_BIN" ]; then
+if cvmfs_sys_file_is_executable "$RUNUSER_BIN" ; then
   HAS_RUNUSER=1
 fi
 

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -955,7 +955,7 @@ get_or_guess_repository_name() {
 foreclose_legacy_cvmfs() {
   local found_something=0
 
-  if [ -f /etc/cvmfs/server.conf ] || [ -f /etc/cvmfs/replica.conf ]; then
+  if cvmfs_sys_is_regular_file /etc/cvmfs/server.conf || cvmfs_sys_is_regular_file /etc/cvmfs/replica.conf ; then
     echo "found legacy configuration files in /etc/cvmfs" 1>&2
     found_something=1
   fi
@@ -970,7 +970,7 @@ foreclose_legacy_cvmfs() {
     found_something=1
   fi
 
-  if [ -f /lib/modules/*/extra/cvmfsflt/cvmfsflt.ko ]; then
+  if cvmfs_sys_is_regular_file /lib/modules/*/extra/cvmfsflt/cvmfsflt.ko ; then
     echo "found CernVM-FS 2.0.x kernel module" 1>&2
     found_something=1
   fi

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -955,7 +955,7 @@ get_or_guess_repository_name() {
 foreclose_legacy_cvmfs() {
   local found_something=0
 
-  if cvmfs_sys_is_regular_file /etc/cvmfs/server.conf || cvmfs_sys_is_regular_file /etc/cvmfs/replica.conf ; then
+  if cvmfs_sys_file_is_regular /etc/cvmfs/server.conf || cvmfs_sys_file_is_regular /etc/cvmfs/replica.conf ; then
     echo "found legacy configuration files in /etc/cvmfs" 1>&2
     found_something=1
   fi
@@ -970,7 +970,7 @@ foreclose_legacy_cvmfs() {
     found_something=1
   fi
 
-  if cvmfs_sys_is_regular_file /lib/modules/*/extra/cvmfsflt/cvmfsflt.ko ; then
+  if cvmfs_sys_file_is_regular /lib/modules/*/extra/cvmfsflt/cvmfsflt.ko ; then
     echo "found CernVM-FS 2.0.x kernel module" 1>&2
     found_something=1
   fi

--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -189,11 +189,11 @@ cvmfs_server_import() {
 
   # check whitelist expiry date
   if [ $recreate_whitelist -eq 0 ]; then
-    [ -f "${storage_location}/.cvmfswhitelist" ] || die "didn't find ${storage_location}/.cvmfswhitelist"
+    cvmfs_sys_is_regular_file "${storage_location}/.cvmfswhitelist" || die "didn't find ${storage_location}/.cvmfswhitelist"
     local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
     [ $expiry -gt 0 ] || die "Repository whitelist expired (use -r maybe?)"
   else
-    [ -f ${keys_location}/${master_key} ] || die "no master key found for whitelist recreation"
+    cvmfs_sys_is_regular_file ${keys_location}/${master_key} || die "no master key found for whitelist recreation"
   fi
 
   # set up desaster cleanup
@@ -221,7 +221,7 @@ cvmfs_server_import() {
 
   # import the old repository security keys
   echo -n "Importing the given key files... "
-  if [ -f ${keys_location}/${master_key} ]; then
+  if cvmfs_sys_is_regular_file ${keys_location}/${master_key} ; then
     keys="$keys $master_key"
   fi
   import_keychain $name "$keys_location" $cvmfs_user "$keys" > /dev/null || die "fail!"
@@ -234,7 +234,7 @@ cvmfs_server_import() {
   echo "done"
 
   # create reflog checksum
-  if [ -f ${storage_location}/.cvmfsreflog ]; then
+  if cvmfs_sys_is_regular_file ${storage_location}/.cvmfsreflog ; then
     echo -n "Re-creating reflog content hash... "
     local reflog_hash=$(cat ${storage_location}/.cvmfsreflog | cvmfs_swissknife hash -a sha1)
     echo -n $reflog_hash > "${CVMFS_SPOOL_DIR}/reflog.chksum"
@@ -315,7 +315,7 @@ cvmfs_server_import() {
   echo "done"
 
   # the .cvmfsdirtab semantics might need an update
-  if [ $is_legacy -ne 0 ] && [ -f /cvmfs/${name}/.cvmfsdirtab ]; then
+  if [ $is_legacy -ne 0 ] && cvmfs_sys_is_regular_file /cvmfs/${name}/.cvmfsdirtab ; then
     echo -n "Migrating .cvmfsdirtab... "
     migrate_legacy_dirtab $name || die "fail!"
     echo "done"

--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -189,11 +189,11 @@ cvmfs_server_import() {
 
   # check whitelist expiry date
   if [ $recreate_whitelist -eq 0 ]; then
-    cvmfs_sys_is_regular_file "${storage_location}/.cvmfswhitelist" || die "didn't find ${storage_location}/.cvmfswhitelist"
+    cvmfs_sys_file_is_regular "${storage_location}/.cvmfswhitelist" || die "didn't find ${storage_location}/.cvmfswhitelist"
     local expiry=$(get_expiry_from_string "$(cat "${storage_location}/.cvmfswhitelist")")
     [ $expiry -gt 0 ] || die "Repository whitelist expired (use -r maybe?)"
   else
-    cvmfs_sys_is_regular_file ${keys_location}/${master_key} || die "no master key found for whitelist recreation"
+    cvmfs_sys_file_is_regular ${keys_location}/${master_key} || die "no master key found for whitelist recreation"
   fi
 
   # set up desaster cleanup
@@ -221,7 +221,7 @@ cvmfs_server_import() {
 
   # import the old repository security keys
   echo -n "Importing the given key files... "
-  if cvmfs_sys_is_regular_file ${keys_location}/${master_key} ; then
+  if cvmfs_sys_file_is_regular ${keys_location}/${master_key} ; then
     keys="$keys $master_key"
   fi
   import_keychain $name "$keys_location" $cvmfs_user "$keys" > /dev/null || die "fail!"
@@ -234,7 +234,7 @@ cvmfs_server_import() {
   echo "done"
 
   # create reflog checksum
-  if cvmfs_sys_is_regular_file ${storage_location}/.cvmfsreflog ; then
+  if cvmfs_sys_file_is_regular ${storage_location}/.cvmfsreflog ; then
     echo -n "Re-creating reflog content hash... "
     local reflog_hash=$(cat ${storage_location}/.cvmfsreflog | cvmfs_swissknife hash -a sha1)
     echo -n $reflog_hash > "${CVMFS_SPOOL_DIR}/reflog.chksum"
@@ -315,7 +315,7 @@ cvmfs_server_import() {
   echo "done"
 
   # the .cvmfsdirtab semantics might need an update
-  if [ $is_legacy -ne 0 ] && cvmfs_sys_is_regular_file /cvmfs/${name}/.cvmfsdirtab ; then
+  if [ $is_legacy -ne 0 ] && cvmfs_sys_file_is_regular /cvmfs/${name}/.cvmfsdirtab ; then
     echo -n "Migrating .cvmfsdirtab... "
     migrate_legacy_dirtab $name || die "fail!"
     echo "done"

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -35,7 +35,7 @@ _write_info_file() {
 
 _check_info_file() {
   local info_file="${1}.json"
-  cvmfs_sys_is_regular_file "$(get_global_info_v1_path)/${info_file}"
+  cvmfs_sys_file_is_regular "$(get_global_info_v1_path)/${info_file}"
 }
 
 

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -35,7 +35,7 @@ _write_info_file() {
 
 _check_info_file() {
   local info_file="${1}.json"
-  [ -f "$(get_global_info_v1_path)/${info_file}" ]
+  cvmfs_sys_is_regular_file "$(get_global_info_v1_path)/${info_file}"
 }
 
 

--- a/cvmfs/server/cvmfs_server_list.sh
+++ b/cvmfs/server/cvmfs_server_list.sh
@@ -16,7 +16,7 @@ cvmfs_server_list() {
     if [ "x$repository" = "x/etc/cvmfs/repositories.d/*" ]; then
       return 0
     fi
-    if [ -f $repository ]; then
+    if cvmfs_sys_is_regular_file $repository ; then
       echo "Warning: unexpected file '$repository' in directory /etc/cvmfs/repositories.d/"
       continue
     fi

--- a/cvmfs/server/cvmfs_server_list.sh
+++ b/cvmfs/server/cvmfs_server_list.sh
@@ -16,7 +16,7 @@ cvmfs_server_list() {
     if [ "x$repository" = "x/etc/cvmfs/repositories.d/*" ]; then
       return 0
     fi
-    if cvmfs_sys_is_regular_file $repository ; then
+    if cvmfs_sys_file_is_regular $repository ; then
       echo "Warning: unexpected file '$repository' in directory /etc/cvmfs/repositories.d/"
       continue
     fi

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -165,7 +165,7 @@ _migrate_2_1_15() {
   fi
   # else apache is currently stopped, add-replica may have been run with -a
 
-  if [ -f "$conf_file" ]; then
+  if cvmfs_sys_is_regular_file "$conf_file" ; then
     echo "--> updating $conf_file"
     (echo "# Created by cvmfs_server.  Don't touch."
      cat_wsgi_config $name
@@ -241,7 +241,7 @@ _migrate_2_1_20() {
     fi
   fi
 
-  if is_local_upstream $CVMFS_UPSTREAM_STORAGE && [ -f "$apache_conf" ]; then
+  if is_local_upstream $CVMFS_UPSTREAM_STORAGE && cvmfs_sys_is_regular_file "$apache_conf" ; then
     echo "--> updating apache config ($(basename $apache_conf))"
     local storage_dir=$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)
     local wsgi=""

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -165,7 +165,7 @@ _migrate_2_1_15() {
   fi
   # else apache is currently stopped, add-replica may have been run with -a
 
-  if cvmfs_sys_is_regular_file "$conf_file" ; then
+  if cvmfs_sys_file_is_regular "$conf_file" ; then
     echo "--> updating $conf_file"
     (echo "# Created by cvmfs_server.  Don't touch."
      cat_wsgi_config $name
@@ -241,7 +241,7 @@ _migrate_2_1_20() {
     fi
   fi
 
-  if is_local_upstream $CVMFS_UPSTREAM_STORAGE && cvmfs_sys_is_regular_file "$apache_conf" ; then
+  if is_local_upstream $CVMFS_UPSTREAM_STORAGE && cvmfs_sys_file_is_regular "$apache_conf" ; then
     echo "--> updating apache config ($(basename $apache_conf))"
     local storage_dir=$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)
     local wsgi=""

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -219,7 +219,7 @@ cvmfs_server_mkfs() {
   local keys="${name}.masterkey ${name}.key ${name}.crt ${name}.pub"
   local keys_are_there=0
   for k in $keys; do
-    if cvmfs_sys_is_regular_file "${keys_location}/${k}"; then
+    if cvmfs_sys_file_is_regular "${keys_location}/${k}"; then
       keys_are_there=1
       break
     fi

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -219,7 +219,7 @@ cvmfs_server_mkfs() {
   local keys="${name}.masterkey ${name}.key ${name}.crt ${name}.pub"
   local keys_are_there=0
   for k in $keys; do
-    if [ -f "${keys_location}/${k}" ]; then
+    if cvmfs_sys_is_regular_file "${keys_location}/${k}"; then
       keys_are_there=1
       break
     fi

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -268,7 +268,7 @@ cvmfs_server_publish() {
     # synchronize the repository
     publish_starting $name
     $user_shell "$sync_command" || { publish_failed $name; die "Synchronization failed\n\nExecuted Command:\n$sync_command";   }
-    cvmfs_sys_is_regular_file $manifest            || { publish_failed $name; die "Manifest creation failed\n\nExecuted Command:\n$sync_command"; }
+    cvmfs_sys_file_is_regular $manifest            || { publish_failed $name; die "Manifest creation failed\n\nExecuted Command:\n$sync_command"; }
     local trunk_hash=$(grep "^C" $manifest | tr -d C)
 
     # Remove outdated automatically created tags

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -268,7 +268,7 @@ cvmfs_server_publish() {
     # synchronize the repository
     publish_starting $name
     $user_shell "$sync_command" || { publish_failed $name; die "Synchronization failed\n\nExecuted Command:\n$sync_command";   }
-    [ -f $manifest ]            || { publish_failed $name; die "Manifest creation failed\n\nExecuted Command:\n$sync_command"; }
+    cvmfs_sys_is_regular_file $manifest            || { publish_failed $name; die "Manifest creation failed\n\nExecuted Command:\n$sync_command"; }
     local trunk_hash=$(grep "^C" $manifest | tr -d C)
 
     # Remove outdated automatically created tags

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -270,7 +270,7 @@ EOF
     if is_local_upstream $upstream; then
       local storage_dir=$(get_upstream_config $upstream)
       local snapshot_file=$storage_dir/.cvmfs_last_snapshot
-      if cvmfs_sys_is_regular_file $snapshot_file ; then
+      if cvmfs_sys_file_is_regular $snapshot_file ; then
         snapshot_time="$(stat --format='%Y' $snapshot_file)"
       elif [ $skip_noninitial -eq 1 ]; then
         continue

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -270,7 +270,7 @@ EOF
     if is_local_upstream $upstream; then
       local storage_dir=$(get_upstream_config $upstream)
       local snapshot_file=$storage_dir/.cvmfs_last_snapshot
-      if [ -f $snapshot_file ]; then
+      if cvmfs_sys_is_regular_file $snapshot_file ; then
         snapshot_time="$(stat --format='%Y' $snapshot_file)"
       elif [ $skip_noninitial -eq 1 ]; then
         continue

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# This file is part of the CernVM File System
+# This script takes care of creating, removing, and maintaining repositories
+# on a Stratum 0/1 server
+
+# This file should implement all platform specific functions. The other components of the
+# cvmfs_server script should interact with the underlying system only through the functions
+# defined here. This allows simple(r) unit testing of the "cvmfs_server" script
+
+cvmfs_sys_uname() {
+    uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+'
+}
+

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -29,3 +29,8 @@ cvmfs_sys_file_is_executable() {
 cvmfs_sys_is_redhat() {
   cvmfs_sys_is_regular_file /etc/redhat-release
 }
+
+
+cvmfs_sys_get_fstype() {
+  echo $(df -T /var/spool/cvmfs | tail -1 | awk {'print $2'})
+}

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -14,7 +14,7 @@ cvmfs_sys_uname() {
 }
 
 
-cvmfs_sys_is_regular_file() {
+cvmfs_sys_file_is_regular() {
     [ -f $1 ]
     echo $?
 }
@@ -27,7 +27,7 @@ cvmfs_sys_file_is_executable() {
 
 
 cvmfs_sys_is_redhat() {
-  cvmfs_sys_is_regular_file /etc/redhat-release
+  cvmfs_sys_file_is_regular /etc/redhat-release
 }
 
 

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -8,8 +8,9 @@
 # cvmfs_server script should interact with the underlying system only through the functions
 # defined here. This allows simple(r) unit testing of the "cvmfs_server" script
 
+# Returns the major.minor.patch-build kernel version string
 cvmfs_sys_uname() {
-    uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+'
+    uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+-*[0-9]*'
 }
 
 cvmfs_sys_is_regular_file() {

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -17,3 +17,7 @@ cvmfs_sys_is_regular_file() {
     echo $?
 }
 
+cvmfs_sys_file_is_executable() {
+    [ -x $1 ]
+    echo $?
+}

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -13,12 +13,19 @@ cvmfs_sys_uname() {
     uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+-*[0-9]*'
 }
 
+
 cvmfs_sys_is_regular_file() {
     [ -f $1 ]
     echo $?
 }
 
+
 cvmfs_sys_file_is_executable() {
     [ -x $1 ]
     echo $?
+}
+
+
+cvmfs_sys_is_redhat() {
+  cvmfs_sys_is_regular_file /etc/redhat-release
 }

--- a/cvmfs/server/cvmfs_server_sys.sh
+++ b/cvmfs/server/cvmfs_server_sys.sh
@@ -12,3 +12,8 @@ cvmfs_sys_uname() {
     uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+'
 }
 
+cvmfs_sys_is_regular_file() {
+    [ -f $1 ]
+    echo $?
+}
+

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -464,7 +464,13 @@ check_upstream_validity() {
 check_overlayfs_version() {
   [ -z "$CVMFS_DONT_CHECK_OVERLAYFS_VERSION" ] || return 0
   local krnl_version=$(cvmfs_sys_uname)
-  compare_versions "$krnl_version" -ge "4.2.0"
+  if compare_versions "$krnl_version" -ge "4.2.0" ; then
+      return 0
+  elif cvmfs_sys_is_redhat && $(compare_versions "$krnl_version" -ge "3.10.0-493") ; then
+      return 0
+  else
+      return 1
+  fi
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -463,7 +463,7 @@ check_upstream_validity() {
 # @return  0 if overlayfs is installed and viable
 check_overlayfs_version() {
   [ -z "$CVMFS_DONT_CHECK_OVERLAYFS_VERSION" ] || return 0
-  local krnl_version=$(uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+')
+  local krnl_version=$(cvmfs_sys_uname)
   compare_versions "$krnl_version" -ge "4.2.0"
 }
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -122,7 +122,7 @@ check_autofs_on_cvmfs() {
 # @return       0 if it is a stratum 0 repository
 is_stratum0() {
   local name=$1
-  ! cvmfs_sys_is_regular_file /etc/cvmfs/repositories.d/$name/replica.conf
+  ! cvmfs_sys_file_is_regular /etc/cvmfs/repositories.d/$name/replica.conf
 }
 
 
@@ -266,7 +266,7 @@ __is_valid_lock() {
   local ignore_stale="$2"
 
   local lock_file="${path}.lock"
-  cvmfs_sys_is_regular_file $lock_file || return 1 # lock doesn't exist
+  cvmfs_sys_file_is_regular $lock_file || return 1 # lock doesn't exist
   [ -z "$ignore_stale" ] || return 0 # lock is there (skip the stale test)
 
   local stale_pid=$(cat $lock_file 2>/dev/null)
@@ -486,7 +486,7 @@ check_cvmfs2_client() {
 # allows AUFS to properly whiteout files without root privileges
 # Note: this function requires a privileged user
 lower_hardlink_restrictions() {
-  if cvmfs_sys_is_regular_file /proc/sys/kernel/yama/protected_nonaccess_hardlinks && \
+  if cvmfs_sys_file_is_regular /proc/sys/kernel/yama/protected_nonaccess_hardlinks && \
      [ $(cat /proc/sys/kernel/yama/protected_nonaccess_hardlinks) -ne 0 ]; then
     # disable hardlink restrictions at runtime
     sysctl -w kernel.yama.protected_nonaccess_hardlinks=0 > /dev/null 2>&1 || return 1
@@ -722,7 +722,7 @@ get_reflog_checksum() {
 has_reflog_checksum() {
   local name=$1
 
-  cvmfs_sys_is_regular_file $(get_reflog_checksum $name)
+  cvmfs_sys_file_is_regular $(get_reflog_checksum $name)
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -541,11 +541,6 @@ find_sbin() {
 }
 
 
-is_redhat() {
-  cvmfs_sys_is_regular_file /etc/redhat-release
-}
-
-
 # whenever you print the version string you should use this function since
 # a repository created before CernVM-FS 2.1.7 cannot be fingerprinted
 # correctly...

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -122,7 +122,7 @@ check_autofs_on_cvmfs() {
 # @return       0 if it is a stratum 0 repository
 is_stratum0() {
   local name=$1
-  ! [ -f /etc/cvmfs/repositories.d/$name/replica.conf ]
+  ! cvmfs_sys_is_regular_file /etc/cvmfs/repositories.d/$name/replica.conf
 }
 
 
@@ -266,7 +266,7 @@ __is_valid_lock() {
   local ignore_stale="$2"
 
   local lock_file="${path}.lock"
-  [ -f $lock_file ]      || return 1 # lock doesn't exist
+  cvmfs_sys_is_regular_file $lock_file || return 1 # lock doesn't exist
   [ -z "$ignore_stale" ] || return 0 # lock is there (skip the stale test)
 
   local stale_pid=$(cat $lock_file 2>/dev/null)
@@ -480,7 +480,7 @@ check_cvmfs2_client() {
 # allows AUFS to properly whiteout files without root privileges
 # Note: this function requires a privileged user
 lower_hardlink_restrictions() {
-  if [ -f /proc/sys/kernel/yama/protected_nonaccess_hardlinks ] && \
+  if cvmfs_sys_is_regular_file /proc/sys/kernel/yama/protected_nonaccess_hardlinks && \
      [ $(cat /proc/sys/kernel/yama/protected_nonaccess_hardlinks) -ne 0 ]; then
     # disable hardlink restrictions at runtime
     sysctl -w kernel.yama.protected_nonaccess_hardlinks=0 > /dev/null 2>&1 || return 1
@@ -542,7 +542,7 @@ find_sbin() {
 
 
 is_redhat() {
-  [ -f /etc/redhat-release ]
+  cvmfs_sys_is_regular_file /etc/redhat-release
 }
 
 
@@ -721,7 +721,7 @@ get_reflog_checksum() {
 has_reflog_checksum() {
   local name=$1
 
-  [ -f $(get_reflog_checksum $name) ]
+  cvmfs_sys_is_regular_file $(get_reflog_checksum $name)
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -472,7 +472,7 @@ check_overlayfs_version() {
 #
 # @return  0 if cvmfs2 client is installed
 check_cvmfs2_client() {
-  [ -x /usr/bin/cvmfs2 ]
+  cvmfs_sys_file_is_executable /usr/bin/cvmfs2
 }
 
 
@@ -502,7 +502,7 @@ EOF
 _setcap_if_needed() {
   local binary_path="$1"
   local capability="$2"
-  [ -x $binary_path ]                                || return 0
+  cvmfs_sys_file_is_executable $binary_path                                || return 0
   $GETCAP_BIN "$binary_path" | grep -q "$capability" && return 0
   $SETCAP_BIN "${capability}+p" "$binary_path"
 }
@@ -532,7 +532,7 @@ find_sbin() {
   local bin_path=""
   for d in /sbin /usr/sbin /usr/local/sbin /bin /usr/bin /usr/local/bin; do
     bin_path="${d}/${bin_name}"
-    if [ -x "$bin_path" ]; then
+    if cvmfs_sys_file_is_executable "$bin_path" ; then
       echo "$bin_path"
       return 0
     fi
@@ -598,8 +598,8 @@ get_upstream_config() {
 
 
 has_selinux() {
-  [ -x $SESTATUS_BIN   ] && \
-  [ -x $GETENFORCE_BIN ] && \
+  cvmfs_sys_file_is_executable $SESTATUS_BIN && \
+  cvmfs_sys_file_is_executable $GETENFORCE_BIN && \
   $GETENFORCE_BIN | grep -qi "enforc" || return 1
 }
 

--- a/cvmfs/server/test_cvmfs_server_util.sh
+++ b/cvmfs/server/test_cvmfs_server_util.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# This file is part of the CernVM File System
+# This script takes care of creating, removing, and maintaining repositories
+# on a Stratum 0/1 server
+#
+# Tests for "cvmfs_server_util.sh"
+
+. ./cvmfs_server_util.sh
+
+### check_overlayfs_version
+
+mock_kernel_version="4.2.0"
+cvmfs_sys_uname() {
+    echo $mock_kernel_version
+}
+
+res=$(check_overlayfs_version; echo $?)
+printf "Kernel version: %s; Calling check_overlayfs_version: %s\n" $mock_kernel_version $res
+
+mock_kernel_version="4.1.1"
+
+res=$(check_overlayfs_version; echo $?)
+printf "Kernel version: %s; Calling check_overlayfs_version: %s\n" $mock_kernel_version $res
+

--- a/cvmfs/server/test_cvmfs_server_util.sh
+++ b/cvmfs/server/test_cvmfs_server_util.sh
@@ -8,18 +8,56 @@
 
 . ./cvmfs_server_util.sh
 
-### check_overlayfs_version
+print_check() {
+    echo "Got: $1 Expected: $2"
+}
 
-mock_kernel_version="4.2.0"
+### Testing check_overlayfs_version
+
 cvmfs_sys_uname() {
     echo $mock_kernel_version
 }
 
-res=$(check_overlayfs_version; echo $?)
-printf "Kernel version: %s; Calling check_overlayfs_version: %s\n" $mock_kernel_version $res
+# check_overlayfs_version will call cvmfs_sys_is_redhat
+cvmfs_sys_is_redhat() {
+    return $mock_is_redhat
+}
 
-mock_kernel_version="4.1.1"
+mock_kernel_version="4.2.0"
+mock_is_redhat=0 # true
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 0
 
-res=$(check_overlayfs_version; echo $?)
-printf "Kernel version: %s; Calling check_overlayfs_version: %s\n" $mock_kernel_version $res
+mock_kernel_version="4.2.0-100"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 0
+
+mock_kernel_version="3.10.0-493"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 0
+
+mock_kernel_version="3.10.0-999"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 0
+
+mock_kernel_version="3.10.0-492"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 1
+
+mock_kernel_version="3.10.0"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 1
+
+mock_kernel_version="3.10.0-493"
+mock_is_redhat=1 # False
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 1
+
+mock_kernel_version="3.10.0-492"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 1
+
+mock_kernel_version="3.10.0"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version; echo $?) 1
 


### PR DESCRIPTION
Some refactoring to the cvmfs_server scripts for better maintainability:

1. Split platform dependent functions to `cvmfs_server_sys.sh`, for example: calling the `uname` command, checking for files etc.
2. Updated the rest of the `cvmfs_server_*****` scripts to call the encapsulated functions (instead of calling `uname` directly, call `cmvfs_sys_uname` ...)
3. Added example test script for the `check_overlayfs_version` function, using mocking
4. Updated the `cvmfs_overlay_version` function to accept kernel 3.10.0-493 or newer, on RedHat. This change is required for ticket CVM-835 and will be backported there.

* [x] Missing: Also need to check if CVMFS scratch is on ext4