### PR TITLE
Updated OverlayFS for RedHat 7 (CVM-835)

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -632,8 +632,15 @@ check_overlayfs() {
 # @return  0 if overlayfs is installed and viable
 check_overlayfs_version() {
   [ -z "$CVMFS_DONT_CHECK_OVERLAYFS_VERSION" ] || return 0
-  local krnl_version=$(uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+')
-  compare_versions "$krnl_version" -ge "4.2.0"
+  local scratch_fstype=$(df -T /var/spool/cvmfs | tail -1 | awk {'print $2'})
+  local krnl_version=$(uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+-*[0-9]*')
+  if compare_versions "$krnl_version" -ge "4.2.0" ; then
+      return 0
+  elif is_redhat && $(compare_versions "$krnl_version" -ge "3.10.0-493") && [ "x$scratch_fstype" = "xext4" ] ; then
+      return 0
+  else
+      return 1
+  fi
 }
 
 

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -8,6 +8,19 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo "enabling epel yum repository..."
 install_from_repo epel-release
 
+# Create an ext4 partition to use for /var/spool/cvmfs
+# Create a 32GB file...
+sudo dd if=/dev/zero of=$HOME/ext4_volume bs=1 count=0 seek=5GB || die "fail (dd if=/dev/zero of=$HOME/ext4_volume bs=1 count=0 seek=5GB)"
+# format it with ext4...
+sudo yes | sudo mkfs -t ext4 $HOME/ext4_volume || die "fail (yes | sudo mkfs -t ext4 $HOME/ext4_volume)"
+# and mount it
+sudo mkdir /media/ext4_volume || die "fail (mkdir /media/ext4_volume)"
+sudo mount -o loop $HOME/ext4_volume /media/ext4_volume || die "fail (mount -o loop $HOME/ext4_volume /media/ext4_volume)"
+
+# Symlink the new ext4 volume into /var/spool/cvmfs and continue
+sudo rm -r /var/spool/cvmfs || die "fail (rm -r /var/spool/cvmfs)"
+sudo ln -s /media/ext4_volume /var/spool/cvmfs || die "fail (ln -s /media/ext4_volume /var/spool/cvmfs)"
+
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -43,6 +43,23 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                               || retval=1
 
 
+echo "running CernVM-FS server test cases..."
+CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+CVMFS_TEST_UNIONFS=overlayfs                                                  \
+./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/518-hardlinkstresstest                   \
+                                 src/524-corruptmanifestfailover              \
+                                 src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
+                                 src/602-libcvmfs                             \
+                                 src/628-pythonwrappedcvmfsserver             \
+                                 --                                           \
+                                 src/5*                                       \
+                                 src/6*                                       \
+                                 src/7*                                       \
+                              || retval=1
+
+
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \

--- a/test/cloud_testing/platforms/fedora22_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora22_x86_64_test.sh
@@ -37,6 +37,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/fedora23_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora23_x86_64_test.sh
@@ -37,6 +37,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/fedora24_x86_64_test.sh
+++ b/test/cloud_testing/platforms/fedora24_x86_64_test.sh
@@ -37,6 +37,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -99,6 +99,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -73,10 +73,66 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/524-corruptmanifestfailover              \
                                  src/585-xattrs                               \
+                                 src/700-overlayfsvalidation                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
+
+
+echo -n "starting FakeS3 service... "
+s3_retval=0
+fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($fakes3_pid)"
+
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against FakeS3..."
+  CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
+  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/524-corruptmanifestfailover              \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               src/700-overlayfsvalidation                  \
+                               --                                           \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/7*                                       \
+                               || retval=1
+
+  echo -n "killing FakeS3... "
+  sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
+fi
 
 
 echo "running CernVM-FS migration test cases..."

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -81,58 +81,58 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               || retval=1
 
 
-echo -n "starting FakeS3 service... "
-s3_retval=0
-fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-echo "done ($fakes3_pid)"
+# echo -n "starting FakeS3 service... "
+# s3_retval=0
+# fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+# echo "done ($fakes3_pid)"
 
-if [ $s3_retval -eq 0 ]; then
-  echo "running CernVM-FS server test cases against FakeS3..."
-  CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
-  CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
-  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
-  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-  ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
-                            -x src/518-hardlinkstresstest                   \
-                               src/519-importlegacyrepo                     \
-                               src/522-missingchunkfailover                 \
-                               src/523-corruptchunkfailover                 \
-                               src/524-corruptmanifestfailover              \
-                               src/525-bigrepo                              \
-                               src/528-recreatespoolarea                    \
-                               src/530-recreatespoolarea_defaultkey         \
-                               src/537-symlinkedbackend                     \
-                               src/538-symlinkedstratum1backend             \
-                               src/542-storagescrubbing                     \
-                               src/543-storagescrubbing_scriptable          \
-                               src/550-livemigration                        \
-                               src/563-garbagecollectlegacy                 \
-                               src/568-migratecorruptrepo                   \
-                               src/571-localbackendumask                    \
-                               src/572-proxyfailover                        \
-                               src/583-httpredirects                        \
-                               src/585-xattrs                               \
-                               src/591-importrepo                           \
-                               src/594-backendoverwrite                     \
-                               src/595-geoipdbupdate                        \
-                               src/600-securecvmfs                          \
-                               src/605-resurrectancientcatalog              \
-                               src/607-noapache                             \
-                               src/608-infofile                             \
-                               src/610-altpath                              \
-                               src/614-geoservice                           \
-                               src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
-                               src/700-overlayfsvalidation                  \
-                               --                                           \
-                               src/5*                                       \
-                               src/6*                                       \
-                               src/7*                                       \
-                               || retval=1
+# if [ $s3_retval -eq 0 ]; then
+#   echo "running CernVM-FS server test cases against FakeS3..."
+#   CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
+#   CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
+#   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
+#   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+#   ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+#                             -x src/518-hardlinkstresstest                   \
+#                                src/519-importlegacyrepo                     \
+#                                src/522-missingchunkfailover                 \
+#                                src/523-corruptchunkfailover                 \
+#                                src/524-corruptmanifestfailover              \
+#                                src/525-bigrepo                              \
+#                                src/528-recreatespoolarea                    \
+#                                src/530-recreatespoolarea_defaultkey         \
+#                                src/537-symlinkedbackend                     \
+#                                src/538-symlinkedstratum1backend             \
+#                                src/542-storagescrubbing                     \
+#                                src/543-storagescrubbing_scriptable          \
+#                                src/550-livemigration                        \
+#                                src/563-garbagecollectlegacy                 \
+#                                src/568-migratecorruptrepo                   \
+#                                src/571-localbackendumask                    \
+#                                src/572-proxyfailover                        \
+#                                src/583-httpredirects                        \
+#                                src/585-xattrs                               \
+#                                src/591-importrepo                           \
+#                                src/594-backendoverwrite                     \
+#                                src/595-geoipdbupdate                        \
+#                                src/600-securecvmfs                          \
+#                                src/605-resurrectancientcatalog              \
+#                                src/607-noapache                             \
+#                                src/608-infofile                             \
+#                                src/610-altpath                              \
+#                                src/614-geoservice                           \
+#                                src/622-gracefulrmfs                         \
+#                                src/626-cacheexpiry                          \
+#                                src/700-overlayfsvalidation                  \
+#                                --                                           \
+#                                src/5*                                       \
+#                                src/6*                                       \
+#                                src/7*                                       \
+#                                || retval=1
 
-  echo -n "killing FakeS3... "
-  sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
-fi
+#   echo -n "killing FakeS3... "
+#   sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
+# fi
 
 
 echo "running CernVM-FS migration test cases..."

--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -46,6 +46,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -46,7 +46,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
-                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1510_x86_64_test.sh
@@ -37,6 +37,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu1604_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1604_x86_64_test.sh
@@ -38,6 +38,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -33,6 +33,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
+                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/src/700-overlayfsvalidation/main
+++ b/test/src/700-overlayfsvalidation/main
@@ -22,7 +22,7 @@ clean_work_dir() {
 }
 
 check_status() {
-    echo $(( $1 != $2 ))
+    echo $(( $1 || 0 ))
 }
 
 # 1. Delete files in the lower read-only branch of the union fs
@@ -44,7 +44,7 @@ delete_file_in_lower_branch() {
     # Cleaning up
     clean_work_dir
 
-    return $(check_status $status 1)
+    return $(check_status $status)
 }
 
 # 2. Open file paths in /proc/\$PID/fd
@@ -63,10 +63,10 @@ check_file_path() {
     local status=$?
 
     # Cleaning up
-    kill -9 $tail_pid
+    kill $tail_pid
     clean_work_dir
 
-    return $(check_status $status 0)
+    return $(check_status $status)
 }
 
 # 3. Delete directories in the lower read-only branch of the union fs
@@ -85,7 +85,7 @@ delete_dir_in_lower_branch () {
     # Cleaning up
     clean_work_dir
 
-    return $(check_status $status 0)
+    return $(check_status $status)
 }
 
 # 4. Clear suid or sgid bits during writes on overlayfs
@@ -114,7 +114,7 @@ clear_suid_sgid_during_write () {
     # Cleaning up
     clean_work_dir
 
-    return $(check_status $(( $status1 && $status2 )) 0)
+    return $(check_status $(( $status1 && $status2 )))
 }
 
 cvmfs_run_test() {
@@ -129,6 +129,6 @@ cvmfs_run_test() {
     clear_suid_sgid_during_write
     local status4=$?
 
-    return $(check_status $(( $status1 || $status2 || $status3 || $status4 )) 0)
+    return $(check_status $(( $status1 || $status2 || $status3 || $status4 )))
 }
 

--- a/test/src/700-overlayfsvalidation/main
+++ b/test/src/700-overlayfsvalidation/main
@@ -108,6 +108,50 @@ delete_dir_in_lower_branch () {
     return 0
 }
 
+# 4. Clear suid or sgid bits during writes on overlayfs
+clear_suid_sgid_during_write () {
+    echo "Check suid or sgid bits during writes on overlayfs"
+
+    root_dir=$(pwd)
+    read_only=$root_dir/read_only
+    read_write=$root_dir/read_write
+    work_dir=$root_dir/work_dir
+    union=$root_dir/union
+
+    # preparation
+    mkdir -p $read_only $read_write $work_dir $union
+    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+
+    echo "  Clear suid during write"
+    touch $work_dir/test.file
+    chmod u+s $work_dir/test.file
+    dd if=/dev/zero of=$work_dir/test.file bs=1M count=1024 &
+    pid=$!
+    chmod u-s $work_dir/test.file
+    local status1=$?
+    wait $pid
+
+    echo "  Clear sgid during write"
+    rm $work_dir/test.file
+    touch $work_dir/test.file
+    chmod g+s $work_dir/test.file
+    dd if=/dev/zero of=$work_dir/test.file bs=1M count=1024 &
+    pid=$!
+    chmod g-s $work_dir/test.file
+    local status2=$?
+    wait $pid
+
+
+    # Cleaning up
+    sudo umount test_ofs
+    sudo rm -r $root_dir
+
+    if [ "$status1" != 0 -o "$status2" != 0 ]; then
+        return 1;
+    fi
+    return 0
+}
+
 cvmfs_run_test() {
     delete_file_in_lower_branch
     local status1=$?
@@ -115,8 +159,10 @@ cvmfs_run_test() {
     local status2=$?
     delete_dir_in_lower_branch
     local status3=$?
+    clear_suid_sgid_during_write
+    local status4=$?
 
-    if [ "$status1" != 0 -o "$status2" != 0 -o "$status3" != 0 ]; then
+    if [ "$status1" != 0 -o "$status2" != 0 -o "$status3" != 0 -o "$status4" != 0 ]; then
         return 1;
     fi
     return 0;

--- a/test/src/700-overlayfsvalidation/main
+++ b/test/src/700-overlayfsvalidation/main
@@ -63,7 +63,7 @@ check_file_path() {
     local status=$?
 
     # Cleaning up
-    kill $tail_pid
+    kill -9 $tail_pid
     clean_work_dir
 
     return $(check_status $status)
@@ -128,6 +128,11 @@ cvmfs_run_test() {
     local status3=$?
     clear_suid_sgid_during_write
     local status4=$?
+
+    echo "Check deleting files in the lower read-only branch of the union fs: Status $status1"
+    echo "Check open file paths in /proc/$PID/fd: Status $status2"
+    echo "Check deleting directories in the lower read-only branch of the union fs: Status $status3"
+    echo "Check suid or sgid bits during writes on overlayfs: Status $status4"
 
     return $(check_status $(( $status1 || $status2 || $status3 || $status4 )))
 }

--- a/test/src/700-overlayfsvalidation/main
+++ b/test/src/700-overlayfsvalidation/main
@@ -22,7 +22,7 @@ clean_work_dir() {
 }
 
 check_status() {
-    echo $(( $1 || 0 ))
+    echo $(( $1 != $2 ))
 }
 
 # 1. Delete files in the lower read-only branch of the union fs
@@ -44,7 +44,7 @@ delete_file_in_lower_branch() {
     # Cleaning up
     clean_work_dir
 
-    return $(check_status $status)
+    return $(check_status $status 1)
 }
 
 # 2. Open file paths in /proc/\$PID/fd
@@ -63,10 +63,10 @@ check_file_path() {
     local status=$?
 
     # Cleaning up
-    kill $tail_pid
+    kill -9 $tail_pid
     clean_work_dir
 
-    return $(check_status $status)
+    return $(check_status $status 0)
 }
 
 # 3. Delete directories in the lower read-only branch of the union fs
@@ -85,7 +85,7 @@ delete_dir_in_lower_branch () {
     # Cleaning up
     clean_work_dir
 
-    return $(check_status $status)
+    return $(check_status $status 0)
 }
 
 # 4. Clear suid or sgid bits during writes on overlayfs
@@ -114,7 +114,7 @@ clear_suid_sgid_during_write () {
     # Cleaning up
     clean_work_dir
 
-    return $(check_status $(( $status1 && $status2 )))
+    return $(check_status $(( $status1 && $status2 )) 0)
 }
 
 cvmfs_run_test() {
@@ -129,6 +129,6 @@ cvmfs_run_test() {
     clear_suid_sgid_during_write
     local status4=$?
 
-    return $(check_status $(( $status1 || $status2 || $status3 || $status4 )))
+    return $(check_status $(( $status1 || $status2 || $status3 || $status4 )) 0)
 }
 

--- a/test/src/700-overlayfsvalidation/main
+++ b/test/src/700-overlayfsvalidation/main
@@ -1,0 +1,123 @@
+
+cvmfs_test_name="OverlayFS Validation"
+cvmfs_test_autofs_on_startup=false
+
+# 1. Delete files in the lower read-only branch of the union fs
+delete_file_in_lower_branch() {
+    echo "Check deleting files in the lower read-only branch of the union fs"
+
+    root_dir=$(pwd)
+    read_only=$root_dir/read_only
+    read_write=$root_dir/read_write
+    work_dir=$root_dir/work_dir
+    union=$root_dir/union
+
+    # preparation
+    echo "Creating overlay fs"
+    mkdir -p $read_only $read_write $work_dir $union
+    echo "foobar" > $read_only/foobar
+    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+
+    # reproduction
+    echo "Delete file from read-only layer"
+    rm -f $union/foobar
+
+    # ls produces obviously bogus output
+    ls -lisa $union
+
+    # cat encounters ENOENT as expected
+    cat $union/foobar
+    local status=$?
+
+    # Cleaning up
+    sudo umount test_ofs
+    sudo rm -r $root_dir
+
+    if [ "$status" != 0 ]; then
+        return 1;
+    fi
+    return 0
+}
+
+# 2. Open file paths in /proc/\$PID/fd
+check_file_path() {
+    printf "\nCheck open file paths in /proc/\$PID/fd\n"
+
+    root_dir=$(pwd)
+    read_only=$root_dir/read_only
+    read_write=$root_dir/read_write
+    work_dir=$root_dir/work_dir
+    union=$root_dir/union
+
+    # preparation
+    echo "Creating overlay fs"
+    mkdir -p $read_only $read_write $work_dir $union
+    echo foobar > $read_only/foobar
+    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+
+    # open a file on OverlayFS
+    tail -f $union/foobar &
+    tail_pid=$!
+
+    # ls produces obviously bogus output
+    echo "Check /proc/\$PID/fd"
+    ls -lisa /proc/$tail_pid/fd
+    local status=$?
+
+    # Cleaning up
+    kill $tail_pid
+    sudo umount test_ofs
+    sudo rm -r $root_dir
+
+    if [ "$status" != 0 ]; then
+        return 1;
+    fi
+    return 0
+}
+
+# 3. Delete directories in the lower read-only branch of the union fs
+delete_dir_in_lower_branch () {
+    echo "Check deleting directories in the lower read-only branch of the union fs"
+
+    root_dir=$(pwd)
+    read_only=$root_dir/read_only
+    read_write=$root_dir/read_write
+    work_dir=$root_dir/work_dir
+    union=$root_dir/union
+
+    # preparation
+    mkdir -p $read_only $read_write $work_dir $union
+    mkdir $read_only/foo
+    echo foobar > $read_only/foo/foobar
+    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+
+    # reproduction
+    rm -fR $union/foo
+
+    # ls shows that 'foo' is still there
+    ls -lisa $union
+    local status=$?
+
+    # Cleaning up
+    sudo umount test_ofs
+    sudo rm -r $root_dir
+
+    if [ "$status" != 0 ]; then
+        return 1;
+    fi
+    return 0
+}
+
+cvmfs_run_test() {
+    delete_file_in_lower_branch
+    local status1=$?
+    check_file_path
+    local status2=$?
+    delete_dir_in_lower_branch
+    local status3=$?
+
+    if [ "$status1" != 0 -o "$status2" != 0 -o "$status3" != 0 ]; then
+        return 1;
+    fi
+    return 0;
+}

--- a/test/src/700-overlayfsvalidation/main
+++ b/test/src/700-overlayfsvalidation/main
@@ -2,10 +2,7 @@
 cvmfs_test_name="OverlayFS Validation"
 cvmfs_test_autofs_on_startup=false
 
-# 1. Delete files in the lower read-only branch of the union fs
-delete_file_in_lower_branch() {
-    echo "Check deleting files in the lower read-only branch of the union fs"
-
+set_up_work_dir() {
     root_dir=$(pwd)
     read_only=$root_dir/read_only
     read_write=$root_dir/read_write
@@ -17,8 +14,23 @@ delete_file_in_lower_branch() {
     mkdir -p $read_only $read_write $work_dir $union
     echo "foobar" > $read_only/foobar
     sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+}
 
-    # reproduction
+clean_work_dir() {
+    sudo umount -f test_ofs
+    sudo rm -fr $root_dir
+}
+
+check_status() {
+    echo $(( $1 || 0 ))
+}
+
+# 1. Delete files in the lower read-only branch of the union fs
+delete_file_in_lower_branch() {
+    echo "Check deleting files in the lower read-only branch of the union fs"
+
+    set_up_work_dir
+
     echo "Delete file from read-only layer"
     rm -f $union/foobar
 
@@ -30,30 +42,16 @@ delete_file_in_lower_branch() {
     local status=$?
 
     # Cleaning up
-    sudo umount test_ofs
-    sudo rm -r $root_dir
+    clean_work_dir
 
-    if [ "$status" != 0 ]; then
-        return 1;
-    fi
-    return 0
+    return $(check_status $status)
 }
 
 # 2. Open file paths in /proc/\$PID/fd
 check_file_path() {
     printf "\nCheck open file paths in /proc/\$PID/fd\n"
 
-    root_dir=$(pwd)
-    read_only=$root_dir/read_only
-    read_write=$root_dir/read_write
-    work_dir=$root_dir/work_dir
-    union=$root_dir/union
-
-    # preparation
-    echo "Creating overlay fs"
-    mkdir -p $read_only $read_write $work_dir $union
-    echo foobar > $read_only/foobar
-    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+    set_up_work_dir
 
     # open a file on OverlayFS
     tail -f $union/foobar &
@@ -66,30 +64,16 @@ check_file_path() {
 
     # Cleaning up
     kill $tail_pid
-    sudo umount test_ofs
-    sudo rm -r $root_dir
+    clean_work_dir
 
-    if [ "$status" != 0 ]; then
-        return 1;
-    fi
-    return 0
+    return $(check_status $status)
 }
 
 # 3. Delete directories in the lower read-only branch of the union fs
 delete_dir_in_lower_branch () {
     echo "Check deleting directories in the lower read-only branch of the union fs"
 
-    root_dir=$(pwd)
-    read_only=$root_dir/read_only
-    read_write=$root_dir/read_write
-    work_dir=$root_dir/work_dir
-    union=$root_dir/union
-
-    # preparation
-    mkdir -p $read_only $read_write $work_dir $union
-    mkdir $read_only/foo
-    echo foobar > $read_only/foo/foobar
-    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+    set_up_work_dir
 
     # reproduction
     rm -fR $union/foo
@@ -99,28 +83,16 @@ delete_dir_in_lower_branch () {
     local status=$?
 
     # Cleaning up
-    sudo umount test_ofs
-    sudo rm -r $root_dir
+    clean_work_dir
 
-    if [ "$status" != 0 ]; then
-        return 1;
-    fi
-    return 0
+    return $(check_status $status)
 }
 
 # 4. Clear suid or sgid bits during writes on overlayfs
 clear_suid_sgid_during_write () {
     echo "Check suid or sgid bits during writes on overlayfs"
 
-    root_dir=$(pwd)
-    read_only=$root_dir/read_only
-    read_write=$root_dir/read_write
-    work_dir=$root_dir/work_dir
-    union=$root_dir/union
-
-    # preparation
-    mkdir -p $read_only $read_write $work_dir $union
-    sudo mount -t overlay -o rw,lowerdir=$read_only,upperdir=$read_write,workdir=$work_dir test_ofs $union
+    set_up_work_dir
 
     echo "  Clear suid during write"
     touch $work_dir/test.file
@@ -132,8 +104,6 @@ clear_suid_sgid_during_write () {
     wait $pid
 
     echo "  Clear sgid during write"
-    rm $work_dir/test.file
-    touch $work_dir/test.file
     chmod g+s $work_dir/test.file
     dd if=/dev/zero of=$work_dir/test.file bs=1M count=1024 &
     pid=$!
@@ -141,18 +111,15 @@ clear_suid_sgid_during_write () {
     local status2=$?
     wait $pid
 
-
     # Cleaning up
-    sudo umount test_ofs
-    sudo rm -r $root_dir
+    clean_work_dir
 
-    if [ "$status1" != 0 -o "$status2" != 0 ]; then
-        return 1;
-    fi
-    return 0
+    return $(check_status $(( $status1 && $status2 )))
 }
 
 cvmfs_run_test() {
+    trap clean_work_dir EXIT HUP INT TERM || return $?
+
     delete_file_in_lower_branch
     local status1=$?
     check_file_path
@@ -162,8 +129,6 @@ cvmfs_run_test() {
     clear_suid_sgid_during_write
     local status4=$?
 
-    if [ "$status1" != 0 -o "$status2" != 0 -o "$status3" != 0 -o "$status4" != 0 ]; then
-        return 1;
-    fi
-    return 0;
+    return $(check_status $(( $status1 || $status2 || $status3 || $status4 )))
 }
+


### PR DESCRIPTION
This branch:
* [x] Updates the function `check_overlayfs_version` in `cvmfs_server`. The new success condition is either kernel 4.2.0 or newer on all Linux distributions, or, if running RedHat, kernel 3.10.0-493 or newer AND /var/spool/cvmfs should be located on an ext4 partition.
* [x] Updates the integration test scripts to run the server tests on RedHat (CentOS) 7, setting up `/var/spool/cvmfs` on an ext4 partition. 