### PR TITLE
Add plugin for in-memory cache

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -182,6 +182,11 @@ set (CVMFS_CACHE_NULL_SOURCES
   cache_plugin/cvmfs_cache_null.cc
 )
 
+set (CVMFS_CACHE_RAM_SOURCES
+  cache_plugin/libcvmfs_cache.h
+  cache_plugin/cvmfs_cache_ram.cc
+)
+
 set (CVMFS_FSCK_SOURCES
   atomic.h
   compression.cc compression.h
@@ -541,6 +546,12 @@ if (BUILD_LIBCVMFS_CACHE)
                         ${CMAKE_CURRENT_BINARY_DIR}/libcvmfs_cache.a
                         ${OPENSSL_LIBRARIES} ${RT_LIBRARY} pthread)
   add_dependencies (cvmfs_cache_null libcvmfs_cache)
+
+  add_executable(cvmfs_cache_ram ${CVMFS_CACHE_RAM_SOURCES})
+  target_link_libraries(cvmfs_cache_ram
+                        ${CMAKE_CURRENT_BINARY_DIR}/libcvmfs_cache.a
+                        ${OPENSSL_LIBRARIES} ${RT_LIBRARY} pthread)
+  add_dependencies (cvmfs_cache_ram libcvmfs_cache)
 endif (BUILD_LIBCVMFS_CACHE)
 
 

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -162,6 +162,7 @@ set (LIBCVMFS_CACHE_SOURCES
   hash.h hash.cc
   logging.cc logging.h logging_internal.h
   murmur.h
+  monitor.cc monitor.h
   options.h options.cc
   platform.h platform_linux.h platform_osx.h
   prng.h

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -68,7 +68,7 @@ set (CVMFS_CLIENT_SOURCES
   kvstore.h kvstore.cc
   loader.h
   logging.cc logging.h logging_internal.h
-  lru.h
+  lru.h lru_md.h
   malloc_arena.cc malloc_arena.h
   malloc_heap.cc malloc_heap.h
   manifest.cc manifest.h
@@ -183,8 +183,22 @@ set (CVMFS_CACHE_NULL_SOURCES
 )
 
 set (CVMFS_CACHE_RAM_SOURCES
+  atomic.h
   cache_plugin/libcvmfs_cache.h
   cache_plugin/cvmfs_cache_ram.cc
+  logging.cc logging.h logging_internal.h
+  lru.h
+  malloc_heap.cc malloc_heap.h
+  murmur.h
+  platform.h platform_linux.h platform_osx.h
+  prng.h
+  smallhash.h
+  smalloc.h
+  statistics.h statistics.cc
+  util_concurrency.cc util_concurrency.h util_concurrency_impl.h
+  util/async.h
+  util/single_copy.h
+  util/string.cc util/string.h
 )
 
 set (CVMFS_FSCK_SOURCES

--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -31,7 +31,8 @@ option optimize_for = LITE_RUNTIME;
 // Unrecognized enum constants are mapped to the first enum constant by the
 // protobuf deserialization.
 
-// Then enum definitions are mirrored in libcvmfs.h
+// Then enum definitions are mirrored in libcvmfs.h.  Error messages for the
+// codes are defined in cache_transport.h.
 
 enum EnumStatus {
   STATUS_UNKNOWN     = 0;

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -16,6 +16,7 @@
 #ifdef __APPLE__
 #include <cstdlib>
 #endif
+#include <map>
 #include <new>
 #include <set>
 #include <string>

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -246,8 +246,14 @@ ExternalCacheManager::PluginHandle *ExternalCacheManager::CreatePlugin(
   const std::vector<std::string> &cmd_line)
 {
   UniquePtr<PluginHandle> plugin_handle(new PluginHandle());
+  unsigned num_attempts = 0;
   bool try_again = false;
   do {
+    num_attempts++;
+    if (num_attempts > 2) {
+      // Prevent violate busy loops
+      SafeSleepMs(1000);
+    }
     plugin_handle->fd_connection_ = ConnectLocator(locator);
     if (plugin_handle->IsValid()) {
       break;

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -5,6 +5,7 @@
 #include "cache_extern.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <sys/socket.h>
@@ -16,6 +17,7 @@
 #include <cstdlib>
 #endif
 #include <new>
+#include <set>
 #include <string>
 
 #include "atomic.h"
@@ -244,12 +246,20 @@ ExternalCacheManager::PluginHandle *ExternalCacheManager::CreatePlugin(
   const std::vector<std::string> &cmd_line)
 {
   UniquePtr<PluginHandle> plugin_handle(new PluginHandle());
-  plugin_handle->fd_connection_ = ConnectLocator(locator);
-  if (plugin_handle->fd_connection_ == -EINVAL) {
-    plugin_handle->error_msg_ = "Invalid locator: " + locator;
-  } else if (plugin_handle->fd_connection_ == -EIO) {
-    plugin_handle->error_msg_ = "Failed to connect to external cache manager";
-  }
+  bool try_again = false;
+  do {
+    plugin_handle->fd_connection_ = ConnectLocator(locator);
+    if (plugin_handle->IsValid()) {
+      break;
+    } else if (plugin_handle->fd_connection_ == -EINVAL) {
+      plugin_handle->error_msg_ = "Invalid locator: " + locator;
+    } else {
+      plugin_handle->error_msg_ = "Failed to connect to external cache manager";
+    }
+
+    try_again = SpawnPlugin(cmd_line);
+  } while (try_again);
+
   return plugin_handle.Release();
 }
 
@@ -588,6 +598,69 @@ void ExternalCacheManager::Spawn() {
   int retval = pthread_create(&thread_read_, NULL, MainRead, this);
   assert(retval == 0);
   spawned_ = true;
+}
+
+
+/**
+ * Returns true if the plugin could be spawned or was spawned by another
+ * process.
+ */
+bool ExternalCacheManager::SpawnPlugin(const vector<string> &cmd_line) {
+  if (cmd_line.empty())
+    return false;
+
+  int pipe_ready[2];
+  MakePipe(pipe_ready);
+  set<int> preserve_filedes;
+  preserve_filedes.insert(pipe_ready[1]);
+
+  int fd_null_read = open("/dev/null", O_RDONLY);
+  int fd_null_write = open("/dev/null", O_WRONLY);
+  assert((fd_null_read >= 0) && (fd_null_write >= 0));
+  map<int, int> map_fildes;
+  map_fildes[fd_null_read] = 0;
+  map_fildes[fd_null_write] = 1;
+  map_fildes[fd_null_write] = 2;
+
+  pid_t child_pid;
+  int retval = setenv(CacheTransport::kEnvReadyNotifyFd,
+                      StringifyInt(pipe_ready[1]).c_str(), 1);
+  assert(retval == 0);
+  retval = ManagedExec(cmd_line,
+                       preserve_filedes,
+                       map_fildes,
+                       false,  // drop_credentials
+                       true,   // double fork
+                       &child_pid);
+  unsetenv(CacheTransport::kEnvReadyNotifyFd);
+  close(fd_null_read);
+  close(fd_null_write);
+  if (!retval) {
+    LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
+             "failed to start cache plugin '%s'",
+             JoinStrings(cmd_line, " ").c_str());
+    ClosePipe(pipe_ready);
+    return false;
+  }
+
+  LogCvmfs(kLogCache, kLogDebug | kLogSyslog,
+           "started cache plugin '%s' (pid %d), waiting for it to become ready",
+           JoinStrings(cmd_line, " ").c_str(), child_pid);
+  close(pipe_ready[1]);
+  char buf;
+  if (read(pipe_ready[0], &buf, 1) != 1) {
+    close(pipe_ready[0]);
+    LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
+             "cache plugin did not start properly");
+    return false;
+  }
+  close(pipe_ready[0]);
+
+  if (buf == CacheTransport::kReadyNotification)
+    return true;
+  LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
+           "cache plugin failed to create an endpoint");
+  return false;
 }
 
 

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -169,7 +169,8 @@ int ExternalCacheManager::CommitTxn(void *txn) {
 
 ExternalCacheManager *ExternalCacheManager::Create(
   int fd_connection,
-  unsigned max_open_fds)
+  unsigned max_open_fds,
+  const string &ident)
 {
   UniquePtr<ExternalCacheManager> cache_mgr(
     new ExternalCacheManager(fd_connection, max_open_fds));
@@ -177,6 +178,7 @@ ExternalCacheManager *ExternalCacheManager::Create(
 
   cvmfs::MsgHandshake msg_handshake;
   msg_handshake.set_protocol_version(kPbProtocolVersion);
+  msg_handshake.set_name(ident);
   CacheTransport::Frame frame_send(&msg_handshake);
   cache_mgr->transport_.SendFrame(&frame_send);
 

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -27,7 +27,9 @@ class ExternalCacheManager : public CacheManager {
  public:
   static const unsigned kPbProtocolVersion = 1;
 
-  static ExternalCacheManager *Create(int fd_connection, unsigned max_open_fds);
+  static ExternalCacheManager *Create(int fd_connection,
+                                      unsigned max_open_fds,
+                                      const std::string &ident);
   virtual ~ExternalCacheManager();
 
   virtual CacheManagerIds id() { return kExternalCacheManager; }

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -248,6 +248,7 @@ class ExternalCacheManager : public CacheManager {
 
   static void *MainRead(void *data);
   static int ConnectLocator(const std::string &locator);
+  static bool SpawnPlugin(const std::vector<std::string> &cmd_line);
 
   explicit ExternalCacheManager(int fd_connection, unsigned max_open_fds);
   int64_t NextRequestId() { return atomic_xadd64(&next_request_id_, 1); }

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -19,13 +19,38 @@
 #include "fd_table.h"
 #include "hash.h"
 #include "quota.h"
+#include "util/single_copy.h"
 #include "util_concurrency.h"
+
 
 class ExternalCacheManager : public CacheManager {
   friend class ExternalQuotaManager;
 
  public:
   static const unsigned kPbProtocolVersion = 1;
+  /**
+   * Used for race-free startup of an external cache plugin.
+   */
+  class PluginHandle {
+    friend class ExternalCacheManager;
+   public:
+    PluginHandle() : fd_connection_(-1) { }
+    bool IsValid() const { return fd_connection_ >= 0; }
+    int fd_connection() const { return fd_connection_; }
+    std::string error_msg() const { return error_msg_; }
+
+   private:
+    /**
+     * The connected file descriptor to pass to Create()
+     */
+    int fd_connection_;
+
+    std::string error_msg_;
+  };
+
+  static PluginHandle *CreatePlugin(
+    const std::string &locator,
+    const std::vector<std::string> &cmd_line);
 
   static ExternalCacheManager *Create(int fd_connection,
                                       unsigned max_open_fds,
@@ -222,6 +247,7 @@ class ExternalCacheManager : public CacheManager {
   };
 
   static void *MainRead(void *data);
+  static int ConnectLocator(const std::string &locator);
 
   explicit ExternalCacheManager(int fd_connection, unsigned max_open_fds);
   int64_t NextRequestId() { return atomic_xadd64(&next_request_id_, 1); }

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -231,7 +231,7 @@ bool CachePlugin::HandleRequest(int fd_con) {
   bool retval = transport.RecvFrame(&frame_recv);
   if (!retval) {
     LogCvmfs(kLogCache, kLogSyslogErr | kLogDebug,
-             "failed to reveive request from connection (%d)", errno);
+             "failed to receive request from connection (%d)", errno);
     return false;
   }
 

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -16,9 +16,8 @@
 #include "hash.h"
 #include "murmur.h"
 #include "smallhash.h"
-#include "util/single_copy.h"
 
-class CachePlugin : SingleCopy {
+class CachePlugin {
  public:
   static const unsigned kPbProtocolVersion = 1;
   static const uint64_t kSizeUnknown;

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -47,6 +47,9 @@ class CachePlugin {
   bool Listen(const std::string &locator);
   virtual ~CachePlugin();
   void ProcessRequests(unsigned num_workers);
+  bool IsRunning();
+  void Terminate();
+  void WaitFor();
   void AskToDetach();
 
   unsigned max_object_size() const { return max_object_size_; }
@@ -142,7 +145,7 @@ class CachePlugin {
 
   uint64_t capabilities_;
   int fd_socket_;
-  bool running_;
+  atomic_int32 running_;
   unsigned num_workers_;
   unsigned max_object_size_;
   std::string name_;

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <map>
 #include <set>
 #include <string>
 
@@ -117,7 +118,8 @@ class CachePlugin {
   }
 
   bool HandleRequest(int fd_con);
-  void HandleHandshake(CacheTransport *transport);
+  void HandleHandshake(cvmfs::MsgHandshake *msg_req,
+                       CacheTransport *transport);
   void HandleRefcount(cvmfs::MsgRefcountReq *msg_req,
                       CacheTransport *transport);
   void HandleObjectInfo(cvmfs::MsgObjectInfoReq *msg_req,
@@ -134,6 +136,10 @@ class CachePlugin {
   void HandleList(cvmfs::MsgListReq *msg_req, CacheTransport *transport);
   void SendDetachRequests();
 
+  void LogSessionError(uint64_t session_id,
+                       cvmfs::EnumStatus status,
+                       const std::string &msg);
+
   uint64_t capabilities_;
   int fd_socket_;
   bool running_;
@@ -145,6 +151,7 @@ class CachePlugin {
   atomic_int64 next_lst_id_;
   SmallHashDynamic<UniqueRequest, uint64_t> txn_ids_;
   std::set<int> connections_;
+  std::map<uint64_t, std::string> sessions_;
   pthread_t thread_io_;
   int pipe_ctrl_[2];
 };  // class CachePlugin

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -139,12 +139,15 @@ class CachePlugin {
   void HandleList(cvmfs::MsgListReq *msg_req, CacheTransport *transport);
   void SendDetachRequests();
 
+  void NotifySupervisor(char signal);
+
   void LogSessionError(uint64_t session_id,
                        cvmfs::EnumStatus status,
                        const std::string &msg);
 
   uint64_t capabilities_;
   int fd_socket_;
+  int fd_socket_lock_;
   atomic_int32 running_;
   unsigned num_workers_;
   unsigned max_object_size_;

--- a/cvmfs/cache_plugin/cvmfs_cache_null.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_null.cc
@@ -143,6 +143,7 @@ static int null_commit_txn(uint64_t txn_id) {
   TxnInfo txn = transactions[txn_id];
   ComparableHash h(txn.id);
   storage[h] = txn.partial_object;
+  transactions.erase(txn_id);
   return CVMCACHE_STATUS_OK;
 }
 

--- a/cvmfs/cache_plugin/cvmfs_cache_null.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_null.cc
@@ -285,6 +285,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  cvmcache_spawn_watchdog(NULL);
+
   struct cvmcache_callbacks callbacks;
   memset(&callbacks, 0, sizeof(callbacks));
   callbacks.cvmcache_chrefcnt = null_chrefcnt;
@@ -323,5 +325,6 @@ int main(int argc, char **argv) {
   printf("  ... good bye\n");
   cvmcache_options_free(locator);
   cvmcache_options_fini(options);
+  cvmcache_terminate_watchdog();
   return 0;
 }

--- a/cvmfs/cache_plugin/cvmfs_cache_null.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_null.cc
@@ -307,7 +307,10 @@ int main(int argc, char **argv) {
 
   ctx = cvmcache_init(&callbacks);
   int retval = cvmcache_listen(ctx, locator);
-  assert(retval);
+  if (!retval) {
+    fprintf(stderr, "failed to listen on %s\n", locator);
+    return 1;
+  }
   printf("Listening for cvmfs clients on %s\n", locator);
   printf("NOTE: this process needs to run as user cvmfs\n\n");
 

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -14,15 +14,21 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
 
 #include "cache_plugin/libcvmfs_cache.h"
+#include "logging.h"
 #include "lru.h"
 #include "malloc_heap.h"
+#include "murmur.h"
 #include "platform.h"
 #include "smallhash.h"
+#include "smalloc.h"
+#include "util_concurrency.h"
+#include "util/string.h"
 
 using namespace std;  // NOLINT
 
@@ -32,14 +38,17 @@ using namespace std;  // NOLINT
  */
 struct ObjectHeader {
   ObjectHeader() {
-    memset(&id, 0, sizeof(id));
+    txn_id = uint64_t(-1);
     size_data = 0;
     size_desc = 0;
     refcnt = 0;
     type = CVMCACHE_OBJECT_REGULAR;
+    memset(&id, 0, sizeof(id));
   }
 
   char *GetDescription() {
+    if (size_desc == 0)
+      return NULL;
     return reinterpret_cast<char *>(this) + sizeof(ObjectHeader);
   }
 
@@ -51,13 +60,11 @@ struct ObjectHeader {
   }
 
   unsigned char *GetData() {
-    if (size_desc == 0)
-      return NULL;
     return reinterpret_cast<unsigned char *>(this) +
            sizeof(ObjectHeader) + size_desc;
   }
 
-  struct cvmcache_hash id;
+  uint64_t txn_id;
   uint32_t size_data;
   uint32_t size_desc;
   // During a transaction, neg_nbytes_written is used to track the number of
@@ -67,6 +74,7 @@ struct ObjectHeader {
     int32_t neg_nbytes_written;
   };
   cvmcache_object_type type;
+  struct cvmcache_hash id;
 };
 
 
@@ -84,6 +92,10 @@ struct ComparableHash {
     return cvmcache_hash_cmp(const_cast<cvmcache_hash *>(&(this->hash)),
                              const_cast<cvmcache_hash *>(&(other.hash))) == 0;
   }
+  bool operator !=(const ComparableHash &other) const {
+    return cvmcache_hash_cmp(const_cast<cvmcache_hash *>(&(this->hash)),
+                             const_cast<cvmcache_hash *>(&(other.hash))) != 0;
+  }
   bool operator <(const ComparableHash &other) const {
     return cvmcache_hash_cmp(const_cast<cvmcache_hash *>(&(this->hash)),
                              const_cast<cvmcache_hash *>(&(other.hash))) < 0;
@@ -97,294 +109,419 @@ struct ComparableHash {
 };
 
 
-uint64_t g_max_objects;
-perf::Statistics *g_statistics;
-lru::LruCache<ComparableHash, ObjectHeader *> *g_objects_all;
-lru::LruCache<ComparableHash, ObjectHeader *> *g_objects_volatile;
-SmallHashDynamic<uint64_t, ObjectHeader *> *g_transactions;
-SmallHashDynamic<uint64_t, Listing *> *g_listings;
-MallocHeap *g_storage;
-struct cvmcache_info *g_cache_info;
+namespace {
 
-struct cvmcache_context *ctx;
+static inline uint32_t hasher_uint64(const uint64_t &key) {
+  return MurmurHash2(&key, sizeof(key), 0x07387a4f);
+}
 
+static inline uint32_t hasher_any(const ComparableHash &key) {
+  return (uint32_t) *(reinterpret_cast<const uint32_t *>(&key.hash));
+}
 
-static void TryFreeSpace(uint64_t bytes_required);
+}  // anonymous namespace
 
 
-static int ram_chrefcnt(struct cvmcache_hash *id, int32_t change_by) {
-  ComparableHash h(*id);
-  ObjectHeader *object;
-  if (!g_objects_all->Lookup(h, &object))
-    return CVMCACHE_STATUS_NOENTRY;
+/**
+ * Singleton
+ */
+class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
+ public:
+  static PluginRamCache *Create(const string &mem_size_str) {
+    assert(instance_ == NULL);
 
-  if (object->type == CVMCACHE_OBJECT_VOLATILE)
-    g_objects_volatile->Update(h);
+    uint64_t mem_size_bytes;
+    if (HasSuffix(mem_size_str, "%", false)) {
+      mem_size_bytes = platform_memsize() * String2Uint64(mem_size_str) / 100;
+    } else {
+      mem_size_bytes = String2Uint64(mem_size_str) * 1024 * 1024;
+    }
+    instance_ = new PluginRamCache(mem_size_bytes);
+    return instance_;
+  }
 
-  if (change_by == 0)
+  ~PluginRamCache() {
+    delete storage_;
+    delete objects_all_;
+    delete objects_volatile_;
+    instance_ = NULL;
+  }
+
+  static int ram_chrefcnt(struct cvmcache_hash *id, int32_t change_by) {
+    ComparableHash h(*id);
+    ObjectHeader *object;
+    if (!Me()->objects_all_->Lookup(h, &object))
+      return CVMCACHE_STATUS_NOENTRY;
+
+    if (object->type == CVMCACHE_OBJECT_VOLATILE)
+      Me()->objects_volatile_->Update(h);
+
+    if (change_by == 0)
+      return CVMCACHE_STATUS_OK;
+    if ((object->refcnt + change_by) < 0)
+      return CVMCACHE_STATUS_BADCOUNT;
+
+    if (object->refcnt == 0)
+      Me()->cache_info_.pinned_bytes += object->size_data;
+    object->refcnt += change_by;
+    if (object->refcnt == 0)
+      Me()->cache_info_.pinned_bytes -= object->size_data;
     return CVMCACHE_STATUS_OK;
-  if ((object->refcnt + change_by) < 0)
-    return CVMCACHE_STATUS_BADCOUNT;
-
-  if (object->refcnt == 0)
-    g_cache_info->pinned_bytes += object->size_data;
-  object->refcnt += change_by;
-  if (object->refcnt == 0)
-    g_cache_info->pinned_bytes -= object->size_data;
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_obj_info(
-  struct cvmcache_hash *id,
-  struct cvmcache_object_info *info)
-{
-  ComparableHash h(*id);
-  ObjectHeader *object;
-  if (!g_objects_all->Lookup(h, &object, false))
-    return CVMCACHE_STATUS_NOENTRY;
-
-  info->size = object->size_data;
-  info->type = object->type;
-  info->pinned = object->refcnt > 0;
-  info->description = strdup(object->GetDescription());
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_pread(struct cvmcache_hash *id,
-                    uint64_t offset,
-                    uint32_t *size,
-                    unsigned char *buffer)
-{
-  ComparableHash h(*id);
-  ObjectHeader *object;
-  bool retval = g_objects_all->Lookup(h, &object, false);
-  assert(retval);
-  if (offset > object->size_data)
-    return CVMCACHE_STATUS_OUTOFBOUNDS;
-  unsigned nbytes =
-    std::min(*size, static_cast<uint32_t>(object->size_data - offset));
-  memcpy(buffer, object->GetData() + offset, nbytes);
-  *size = nbytes;
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_start_txn(
-  struct cvmcache_hash *id,
-  uint64_t txn_id,
-  struct cvmcache_object_info *info)
-{
-  ObjectHeader object_header;
-  object_header.id = *id;
-  if (info->size != CVMCACHE_SIZE_UNKNOWN)
-    object_header.size_data = info->size;
-  else
-    object_header.size_data = 4096;
-  char *description = NULL;
-  if (info->description != 0) {
-    description = strdupa(info->description);
-    object_header.size_desc = strlen(info->description) + 1;
-  }
-  object_header.refcnt = 1;
-  object_header.type = info->type;
-
-  uint32_t total_size = sizeof(object_header) +
-                        object_header.size_desc + object_header.size_data;
-  TryFreeSpace(total_size);
-  ObjectHeader *allocd_object = reinterpret_cast<ObjectHeader *>(
-    g_storage->Allocate(total_size, &object_header, sizeof(object_header)));
-  if (allocd_object == NULL)
-    return CVMCACHE_STATUS_NOSPACE;
-
-  allocd_object->SetDescription(description);
-  g_transactions->Insert(txn_id, allocd_object);
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_write_txn(
-  uint64_t txn_id,
-  unsigned char *buffer,
-  uint32_t size)
-{
-  ObjectHeader *txn_object;
-  int retval = g_transactions->Lookup(txn_id, &txn_object);
-  assert(retval);
-  assert(size > 0);
-
-  if (txn_object->neg_nbytes_written > 0)
-    txn_object->neg_nbytes_written = 0;
-  if ((size - txn_object->neg_nbytes_written) > txn_object->size_data) {
-    uint32_t new_size = std::max(
-      size - txn_object->neg_nbytes_written,
-      uint32_t(txn_object->size_data * 0.25));
-    TryFreeSpace(new_size);
-    txn_object = reinterpret_cast<ObjectHeader *>(
-      g_storage->Expand(txn_object, new_size));
-    if (txn_object == NULL)
-      return CVMCACHE_STATUS_NOSPACE;
-    g_transactions->Insert(txn_id, txn_object);
   }
 
-  memcpy(txn_object->GetData() - txn_object->neg_nbytes_written, buffer, size);
-  txn_object->neg_nbytes_written -= size;
-  return CVMCACHE_STATUS_OK;
-}
 
-
-static int ram_commit_txn(uint64_t txn_id) {
-  ObjectHeader *txn_object;
-  int retval = g_transactions->Lookup(txn_id, &txn_object);
-  assert(retval);
-  TryFreeSpace(0);
-  if (g_objects_all->IsFull())
-    return CVMCACHE_STATUS_NOSPACE;
-
-  g_transactions->Erase(txn_id);
-  txn_object->size_data = -(txn_object->neg_nbytes_written);
-  txn_object->refcnt = 1;
-  g_cache_info->used_bytes += txn_object->size_data;
-  g_cache_info->pinned_bytes += txn_object->size_data;
-  ComparableHash h(txn_object->id);
-  g_objects_all->Insert(h, txn_object);
-  if (txn_object->type == CVMCACHE_OBJECT_VOLATILE) {
-    assert(!g_objects_volatile->IsFull());
-    g_objects_volatile->Insert(h, txn_object);
-  }
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_abort_txn(uint64_t txn_id) {
-  ObjectHeader *txn_object;
-  int retval = g_transactions->Lookup(txn_id, &txn_object);
-  assert(retval);
-  g_storage->MarkFree(txn_object);
-  g_transactions->Erase(txn_id);
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_info(struct cvmcache_info *info) {
-  *info = *g_cache_info;
-  return CVMCACHE_STATUS_OK;
-}
-
-
-static int ram_shrink(uint64_t shrink_to, uint64_t *used) {
-  *used = g_cache_info->used_bytes;
-  if (g_cache_info->used_bytes <= shrink_to)
-    return CVMCACHE_STATUS_OK;
-
-  ComparableHash h;
-  ObjectHeader *object;
-
-  g_objects_volatile->FilterBegin();
-  while (g_objects_volatile->FilterNext()) {
-    g_objects_volatile->FilterGet(&h, &object);
-    if (object->refcnt != 0)
-      continue;
-    g_cache_info->used_bytes -= object->size_data;
-    g_storage->MarkFree(object);
-    g_objects_volatile->FilterDelete();
-    g_objects_all->Forget(h);
-    if (g_cache_info->used_bytes <= shrink_to)
-      break;
-  }
-  g_objects_volatile->FilterEnd();
-
-  g_objects_all->FilterBegin();
-  while ((g_cache_info->used_bytes > shrink_to) &&
-         g_objects_all->FilterNext())
+  static int ram_obj_info(
+    struct cvmcache_hash *id,
+    struct cvmcache_object_info *info)
   {
-    g_objects_all->FilterGet(&h, &object);
-    if (object->refcnt != 0)
-      continue;
-    assert(object->type != CVMCACHE_OBJECT_VOLATILE);
-    g_cache_info->used_bytes -= object->size_data;
-    g_storage->MarkFree(object);
-    g_objects_all->FilterDelete();
+    ComparableHash h(*id);
+    ObjectHeader *object;
+    if (!Me()->objects_all_->Lookup(h, &object, false))
+      return CVMCACHE_STATUS_NOENTRY;
+
+    info->size = object->size_data;
+    info->type = object->type;
+    info->pinned = object->refcnt > 0;
+    info->description = (object->GetDescription() == NULL)
+                        ? NULL
+                        : strdup(object->GetDescription());
+    return CVMCACHE_STATUS_OK;
   }
-  g_objects_all->FilterEnd();
-
-  g_storage->Compact();
-  g_cache_info->no_shrink++;
-  *used = g_cache_info->used_bytes;
-  return (*used <= shrink_to) ? CVMCACHE_STATUS_OK : CVMCACHE_STATUS_PARTIAL;
-}
 
 
-static int ram_listing_begin(
-  uint64_t lst_id,
-  enum cvmcache_object_type type)
-{
-  Listing *lst = new Listing();
-  g_objects_all->FilterBegin();
-  while (g_objects_all->FilterNext()) {
+  static int ram_pread(struct cvmcache_hash *id,
+                      uint64_t offset,
+                      uint32_t *size,
+                      unsigned char *buffer)
+  {
+    ComparableHash h(*id);
+    ObjectHeader *object;
+    bool retval = Me()->objects_all_->Lookup(h, &object, false);
+    assert(retval);
+    if (offset > object->size_data)
+      return CVMCACHE_STATUS_OUTOFBOUNDS;
+    unsigned nbytes =
+      std::min(*size, static_cast<uint32_t>(object->size_data - offset));
+    memcpy(buffer, object->GetData() + offset, nbytes);
+    *size = nbytes;
+    return CVMCACHE_STATUS_OK;
+  }
+
+
+  static int ram_start_txn(
+    struct cvmcache_hash *id,
+    uint64_t txn_id,
+    struct cvmcache_object_info *info)
+  {
+    ObjectHeader object_header;
+    object_header.txn_id = txn_id;
+    if (info->size != CVMCACHE_SIZE_UNKNOWN)
+      object_header.size_data = info->size;
+    else
+      object_header.size_data = 4096;
+    if (info->description != NULL)
+      object_header.size_desc = strlen(info->description) + 1;
+    object_header.refcnt = 1;
+    object_header.type = info->type;
+    object_header.id = *id;
+
+    uint32_t total_size = sizeof(object_header) +
+                          object_header.size_desc + object_header.size_data;
+    Me()->TryFreeSpace(total_size);
+    ObjectHeader *allocd_object = reinterpret_cast<ObjectHeader *>(
+      Me()->storage_->Allocate(total_size,
+                               &object_header, sizeof(object_header)));
+    if (allocd_object == NULL)
+      return CVMCACHE_STATUS_NOSPACE;
+
+    allocd_object->SetDescription(info->description);
+    Me()->transactions_.Insert(txn_id, allocd_object);
+    return CVMCACHE_STATUS_OK;
+  }
+
+
+  static int ram_write_txn(
+    uint64_t txn_id,
+    unsigned char *buffer,
+    uint32_t size)
+  {
+    ObjectHeader *txn_object;
+    int retval = Me()->transactions_.Lookup(txn_id, &txn_object);
+    assert(retval);
+    assert(size > 0);
+
+    if (txn_object->neg_nbytes_written > 0)
+      txn_object->neg_nbytes_written = 0;
+    if ((size - txn_object->neg_nbytes_written) > txn_object->size_data) {
+      uint32_t new_size = std::max(
+        size - txn_object->neg_nbytes_written,
+        uint32_t(txn_object->size_data * kObjectExpandFactor));
+      bool did_compact = Me()->TryFreeSpace(new_size);
+      if (did_compact) {
+        retval = Me()->transactions_.Lookup(txn_id, &txn_object);
+        assert(retval);
+      }
+      txn_object = reinterpret_cast<ObjectHeader *>(
+        Me()->storage_->Expand(txn_object, new_size));
+      if (txn_object == NULL)
+        return CVMCACHE_STATUS_NOSPACE;
+      Me()->transactions_.Insert(txn_id, txn_object);
+    }
+
+    memcpy(txn_object->GetData() - txn_object->neg_nbytes_written,
+           buffer, size);
+    txn_object->neg_nbytes_written -= size;
+    return CVMCACHE_STATUS_OK;
+  }
+
+
+  static int ram_commit_txn(uint64_t txn_id) {
+    Me()->TryFreeSpace(0);
+    if (Me()->objects_all_->IsFull())
+      return CVMCACHE_STATUS_NOSPACE;
+
+    ObjectHeader *txn_object;
+    int retval = Me()->transactions_.Lookup(txn_id, &txn_object);
+    assert(retval);
+
+    Me()->transactions_.Erase(txn_id);
+    ComparableHash h(txn_object->id);
+    ObjectHeader *existing_object;
+    if (Me()->objects_all_->Lookup(h, &existing_object)) {
+      // Concurrent addition of same objects, drop the one at hand and
+      // increase ref count of existing copy
+      Me()->storage_->MarkFree(txn_object);
+      if (existing_object->refcnt == 0)
+        Me()->cache_info_.pinned_bytes += existing_object->size_data;
+      existing_object->refcnt++;
+    } else {
+      txn_object->txn_id = uint64_t(-1);
+      if (txn_object->neg_nbytes_written > 0)
+        txn_object->neg_nbytes_written = 0;
+      txn_object->size_data = -(txn_object->neg_nbytes_written);
+      txn_object->refcnt = 1;
+      Me()->cache_info_.used_bytes += txn_object->size_data;
+      Me()->cache_info_.pinned_bytes += txn_object->size_data;
+      Me()->objects_all_->Insert(h, txn_object);
+      if (txn_object->type == CVMCACHE_OBJECT_VOLATILE) {
+        assert(!Me()->objects_volatile_->IsFull());
+        Me()->objects_volatile_->Insert(h, txn_object);
+      }
+    }
+    return CVMCACHE_STATUS_OK;
+  }
+
+
+  static int ram_abort_txn(uint64_t txn_id) {
+    ObjectHeader *txn_object;
+    int retval = Me()->transactions_.Lookup(txn_id, &txn_object);
+    assert(retval);
+    Me()->transactions_.Erase(txn_id);
+    Me()->storage_->MarkFree(txn_object);
+    return CVMCACHE_STATUS_OK;
+  }
+
+
+  static int ram_info(struct cvmcache_info *info) {
+    *info = Me()->cache_info_;
+    return CVMCACHE_STATUS_OK;
+  }
+
+
+  static int ram_shrink(uint64_t shrink_to, uint64_t *used) {
+    *used = Me()->cache_info_.used_bytes;
+    if (*used <= shrink_to)
+      return CVMCACHE_STATUS_OK;
+
     ComparableHash h;
     ObjectHeader *object;
-    g_objects_all->FilterGet(&h, &object);
-    if (object->type != type)
-      continue;
 
-    struct cvmcache_object_info item;
-    item.id = h.hash;
-    item.size = object->size_data;
-    item.type = type;
-    item.pinned = object->refcnt != 0;
-    item.description = (object->size_desc > 0)
-                       ? strdup(object->GetDescription())
-                       : NULL;
-    lst->elems.push_back(item);
+    Me()->objects_volatile_->FilterBegin();
+    while (Me()->objects_volatile_->FilterNext()) {
+      Me()->objects_volatile_->FilterGet(&h, &object);
+      if (object->refcnt != 0)
+        continue;
+      Me()->cache_info_.used_bytes -= object->size_data;
+      Me()->storage_->MarkFree(object);
+      Me()->objects_volatile_->FilterDelete();
+      Me()->objects_all_->Forget(h);
+      if (Me()->cache_info_.used_bytes <= shrink_to)
+        break;
+    }
+    Me()->objects_volatile_->FilterEnd();
+
+    Me()->objects_all_->FilterBegin();
+    while ((Me()->cache_info_.used_bytes > shrink_to) &&
+           Me()->objects_all_->FilterNext())
+    {
+      Me()->objects_all_->FilterGet(&h, &object);
+      if (object->refcnt != 0)
+        continue;
+      assert(object->type != CVMCACHE_OBJECT_VOLATILE);
+      Me()->cache_info_.used_bytes -= object->size_data;
+      Me()->storage_->MarkFree(object);
+      Me()->objects_all_->FilterDelete();
+    }
+    Me()->objects_all_->FilterEnd();
+
+    Me()->storage_->Compact();
+    Me()->cache_info_.no_shrink++;
+    *used = Me()->cache_info_.used_bytes;
+    return (*used <= shrink_to) ? CVMCACHE_STATUS_OK : CVMCACHE_STATUS_PARTIAL;
   }
-  g_objects_all->FilterEnd();
-
-  g_listings->Insert(lst_id, lst);
-  return CVMCACHE_STATUS_OK;
-}
 
 
-static int ram_listing_next(
-  int64_t listing_id,
-  struct cvmcache_object_info *item)
-{
-  Listing *lst;
-  bool retval = g_listings->Lookup(listing_id, &lst);
-  assert(retval);
-  if (lst->pos >= lst->elems.size())
-    return CVMCACHE_STATUS_OUTOFBOUNDS;
-  *item = lst->elems[lst->pos];
-  lst->pos++;
-  return CVMCACHE_STATUS_OK;
-}
+  static int ram_listing_begin(
+    uint64_t lst_id,
+    enum cvmcache_object_type type)
+  {
+    Listing *lst = new Listing();
+    Me()->objects_all_->FilterBegin();
+    while (Me()->objects_all_->FilterNext()) {
+      ComparableHash h;
+      ObjectHeader *object;
+      Me()->objects_all_->FilterGet(&h, &object);
+      if (object->type != type)
+        continue;
 
+      struct cvmcache_object_info item;
+      item.id = object->id;
+      item.size = object->size_data;
+      item.type = type;
+      item.pinned = object->refcnt != 0;
+      item.description = (object->size_desc > 0)
+                         ? strdup(object->GetDescription())
+                         : NULL;
+      lst->elems.push_back(item);
+    }
+    Me()->objects_all_->FilterEnd();
 
-static int ram_listing_end(int64_t listing_id) {
-  Listing *lst;
-  bool retval = g_listings->Lookup(listing_id, &lst);
-  assert(retval);
-
-  for (unsigned i = 0; i < lst->elems.size(); ++i) {
-    free(lst->elems[i].description);
+    Me()->listings_.Insert(lst_id, lst);
+    return CVMCACHE_STATUS_OK;
   }
-  delete lst;
-  g_listings->Erase(listing_id);
-  return CVMCACHE_STATUS_OK;
-}
 
 
-static void TryFreeSpace(uint64_t bytes_required) {
-  if (!g_objects_all->IsFull() && g_storage->HasSpaceFor(bytes_required))
-    return;
+  static int ram_listing_next(
+    int64_t listing_id,
+    struct cvmcache_object_info *item)
+  {
+    Listing *lst;
+    bool retval = Me()->listings_.Lookup(listing_id, &lst);
+    assert(retval);
+    if (lst->pos >= lst->elems.size())
+      return CVMCACHE_STATUS_OUTOFBOUNDS;
+    *item = lst->elems[lst->pos];
+    lst->pos++;
+    return CVMCACHE_STATUS_OK;
+  }
 
-  uint64_t shrink_to = std::min(
-    g_storage->capacity() - (bytes_required + 8),
-    uint64_t(g_storage->used_bytes() * 0.75));
-  uint64_t used;
-  ram_shrink(shrink_to, &used);
-}
+
+  static int ram_listing_end(int64_t listing_id) {
+    Listing *lst;
+    bool retval = Me()->listings_.Lookup(listing_id, &lst);
+    assert(retval);
+
+    // Don't free description strings, done by the library
+    delete lst;
+    Me()->listings_.Erase(listing_id);
+    return CVMCACHE_STATUS_OK;
+  }
+
+ private:
+  static const uint64_t kMinSize;  // 100 * 1024 * 1024;
+  static const double kShrinkFactor;  //  = 0.75;
+  static const double kObjectExpandFactor;  // = 0.25;
+  static const double kSlotFraction;  // = 0.04;
+
+  static PluginRamCache *instance_;
+  static PluginRamCache *Me() {
+    return instance_;
+  }
+  explicit PluginRamCache(uint64_t mem_size) {
+    uint64_t heap_size = RoundUp8(
+      std::max(kMinSize, uint64_t(mem_size * (1.0 - kSlotFraction))));
+    memset(&cache_info_, 0, sizeof(cache_info_));
+    cache_info_.size_bytes = heap_size;
+    storage_ = new MallocHeap(
+      heap_size, this->MakeCallback(&PluginRamCache::OnBlockMove, this));
+
+    struct cvmcache_hash hash_empty;
+    memset(&hash_empty, 0, sizeof(hash_empty));
+
+    transactions_.Init(64, uint64_t(-1), hasher_uint64);
+    listings_.Init(8, uint64_t(-1), hasher_uint64);
+
+    double slot_size =
+      lru::LruCache<ComparableHash, ObjectHeader *>::GetEntrySize();
+    uint64_t num_slots = uint64_t((heap_size * kSlotFraction) /
+                         (2.0 * slot_size));
+    const unsigned mask_64 = ~((1 << 6) - 1);
+
+    LogCvmfs(kLogCvmfs, kLogStdout, "allocating %" PRIu64 "MB of memory "
+             "for up to %" PRIu64 " objects",
+             heap_size / (1024 * 1024), num_slots & mask_64);
+
+    // Number of cache entries must be a multiple of 64
+    objects_all_ = new lru::LruCache<ComparableHash, ObjectHeader *>(
+      num_slots & mask_64,
+      ComparableHash(hash_empty),
+      hasher_any,
+      &statistics_,
+      "objects_all");
+    objects_volatile_ = new lru::LruCache<ComparableHash, ObjectHeader *>(
+      num_slots & mask_64,
+      ComparableHash(hash_empty),
+      hasher_any,
+      &statistics_,
+      "objects_volatile");
+  }
+
+  bool TryFreeSpace(uint64_t bytes_required) {
+    if (!objects_all_->IsFull() && storage_->HasSpaceFor(bytes_required))
+      return false;
+
+    uint64_t shrink_to = std::min(
+      storage_->capacity() - (bytes_required + 8),
+      uint64_t(storage_->used_bytes() * kShrinkFactor));
+    uint64_t used;
+    ram_shrink(shrink_to, &used);
+    return true;
+  }
+
+  void OnBlockMove(const MallocHeap::BlockPtr &ptr) {
+    assert(ptr.pointer);
+    ObjectHeader *object = reinterpret_cast<ObjectHeader *>(ptr.pointer);
+    ComparableHash h(object->id);
+    if (object->txn_id == uint64_t(-1)) {
+      bool retval = objects_all_->UpdateValue(h, object);
+      assert(retval);
+      if (object->type == CVMCACHE_OBJECT_VOLATILE) {
+        retval = objects_volatile_->UpdateValue(h, object);
+        assert(retval);
+      }
+    } else {
+      uint64_t old_size = transactions_.size();
+      transactions_.Insert(object->txn_id, object);
+      assert(old_size == transactions_.size());
+    }
+  }
+
+
+  struct cvmcache_info cache_info_;
+  perf::Statistics statistics_;
+  SmallHashDynamic<uint64_t, ObjectHeader *> transactions_;
+  SmallHashDynamic<uint64_t, Listing *> listings_;
+  lru::LruCache<ComparableHash, ObjectHeader *> *objects_all_;
+  lru::LruCache<ComparableHash, ObjectHeader *> *objects_volatile_;
+  MallocHeap *storage_;
+};  // class PluginRamCache
+
+PluginRamCache *PluginRamCache::instance_ = NULL;
+const uint64_t PluginRamCache::kMinSize = 100 * 1024 * 1024;
+const double PluginRamCache::kShrinkFactor = 0.75;
+const double PluginRamCache::kObjectExpandFactor = 0.25;
+const double PluginRamCache::kSlotFraction = 0.04;
+
 
 static void Usage(const char *progname) {
   printf("%s <config file>\n", progname);
@@ -408,23 +545,32 @@ int main(int argc, char **argv) {
     cvmcache_options_fini(options);
     return 1;
   }
+  char *mem_size = cvmcache_options_get(options, "CVMFS_CACHE_EXTERNAL_SIZE");
+  if (mem_size == NULL) {
+    printf("CVMFS_CACHE_EXTERNAL_SIZE missing\n");
+    cvmcache_options_fini(options);
+    return 1;
+  }
+
+  PluginRamCache *plugin = PluginRamCache::Create(mem_size);
 
   struct cvmcache_callbacks callbacks;
   memset(&callbacks, 0, sizeof(callbacks));
-  callbacks.cvmcache_chrefcnt = ram_chrefcnt;
-  callbacks.cvmcache_obj_info = ram_obj_info;
-  callbacks.cvmcache_pread = ram_pread;
-  callbacks.cvmcache_start_txn = ram_start_txn;
-  callbacks.cvmcache_write_txn = ram_write_txn;
-  callbacks.cvmcache_commit_txn = ram_commit_txn;
-  callbacks.cvmcache_abort_txn = ram_abort_txn;
-  callbacks.cvmcache_info = ram_info;
-  callbacks.cvmcache_shrink = ram_shrink;
-  callbacks.cvmcache_listing_begin = ram_listing_begin;
-  callbacks.cvmcache_listing_next = ram_listing_next;
-  callbacks.cvmcache_listing_end = ram_listing_end;
+  callbacks.cvmcache_chrefcnt = plugin->ram_chrefcnt;
+  callbacks.cvmcache_obj_info = plugin->ram_obj_info;
+  callbacks.cvmcache_pread = plugin->ram_pread;
+  callbacks.cvmcache_start_txn = plugin->ram_start_txn;
+  callbacks.cvmcache_write_txn = plugin->ram_write_txn;
+  callbacks.cvmcache_commit_txn = plugin->ram_commit_txn;
+  callbacks.cvmcache_abort_txn = plugin->ram_abort_txn;
+  callbacks.cvmcache_info = plugin->ram_info;
+  callbacks.cvmcache_shrink = plugin->ram_shrink;
+  callbacks.cvmcache_listing_begin = plugin->ram_listing_begin;
+  callbacks.cvmcache_listing_next = plugin->ram_listing_next;
+  callbacks.cvmcache_listing_end = plugin->ram_listing_end;
   callbacks.capabilities = CVMCACHE_CAP_ALL;
 
+  struct cvmcache_context *ctx;
   ctx = cvmcache_init(&callbacks);
   int retval = cvmcache_listen(ctx, locator);
   assert(retval);
@@ -445,6 +591,7 @@ int main(int argc, char **argv) {
     }
   }
   printf("  ... good bye\n");
+  cvmcache_options_free(mem_size);
   cvmcache_options_free(locator);
   cvmcache_options_fini(options);
   return 0;

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -602,6 +602,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  cvmcache_spawn_watchdog(NULL);
   PluginRamCache *plugin = PluginRamCache::Create(mem_size);
 
   struct cvmcache_callbacks callbacks;
@@ -643,5 +644,6 @@ int main(int argc, char **argv) {
   cvmcache_options_free(mem_size);
   cvmcache_options_free(locator);
   cvmcache_options_fini(options);
+  cvmcache_terminate_watchdog();
   return 0;
 }

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -27,8 +27,8 @@
 #include "platform.h"
 #include "smallhash.h"
 #include "smalloc.h"
-#include "util_concurrency.h"
 #include "util/string.h"
+#include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
@@ -552,7 +552,8 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
   }
 
   bool IsInDangerZone() {
-    return double(cache_info_.pinned_bytes) / double(cache_info_.size_bytes) >
+    return (static_cast<double>(cache_info_.pinned_bytes) /
+            static_cast<double>(cache_info_.size_bytes)) >
            kDangerZoneThreshold;
   }
 

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -1,0 +1,326 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * A demo external cache plugin.  All data is stored in std::string.  Feature-
+ * complete but quite inefficient.
+ */
+
+#define __STDC_FORMAT_MACROS
+
+#include <alloca.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "libcvmfs_cache.h"
+
+using namespace std;  // NOLINT
+
+struct Object {
+  struct cvmcache_hash id;
+  string data;
+  cvmcache_object_type type;
+  int32_t refcnt;
+  string description;
+};
+
+struct TxnInfo {
+  struct cvmcache_hash id;
+  Object partial_object;
+};
+
+struct Listing {
+  Listing() : pos(0) { }
+  cvmcache_object_type type;
+  uint64_t pos;
+  vector<Object> *elems;
+};
+
+struct ComparableHash {
+  ComparableHash() { }
+  explicit ComparableHash(const struct cvmcache_hash &h) : hash(h) { }
+  struct cvmcache_hash hash;
+  bool operator <(const ComparableHash &other) const {
+    return cvmcache_hash_cmp(const_cast<cvmcache_hash *>(&(this->hash)),
+                             const_cast<cvmcache_hash *>(&(other.hash))) < 0;
+  }
+};
+
+map<uint64_t, TxnInfo> transactions;
+map<ComparableHash, Object> storage;
+map<uint64_t, Listing> listings;
+
+struct cvmcache_context *ctx;
+
+static int ram_chrefcnt(struct cvmcache_hash *id, int32_t change_by) {
+  ComparableHash h(*id);
+  if (storage.find(h) == storage.end())
+    return CVMCACHE_STATUS_NOENTRY;
+
+  Object obj = storage[h];
+  obj.refcnt += change_by;
+  if (obj.refcnt < 0)
+    return CVMCACHE_STATUS_BADCOUNT;
+  storage[h] = obj;
+  return CVMCACHE_STATUS_OK;
+}
+
+
+static int ram_obj_info(
+  struct cvmcache_hash *id,
+  struct cvmcache_object_info *info)
+{
+  ComparableHash h(*id);
+  if (storage.find(h) == storage.end())
+    return CVMCACHE_STATUS_NOENTRY;
+
+  Object obj = storage[h];
+  info->size = obj.data.length();
+  info->type = obj.type;
+  info->pinned = obj.refcnt > 0;
+  info->description = strdup(obj.description.c_str());
+  return CVMCACHE_STATUS_OK;
+}
+
+
+static int ram_pread(struct cvmcache_hash *id,
+                    uint64_t offset,
+                    uint32_t *size,
+                    unsigned char *buffer)
+{
+  ComparableHash h(*id);
+  string data = storage[h].data;
+  if (offset > data.length())
+    return CVMCACHE_STATUS_OUTOFBOUNDS;
+  unsigned nbytes =
+    std::min(*size, static_cast<uint32_t>(data.length() - offset));
+  memcpy(buffer, data.data() + offset, nbytes);
+  *size = nbytes;
+  return CVMCACHE_STATUS_OK;
+}
+
+
+static int ram_start_txn(
+  struct cvmcache_hash *id,
+  uint64_t txn_id,
+  struct cvmcache_object_info *info)
+{
+  Object partial_object;
+  partial_object.id = *id;
+  partial_object.type = info->type;
+  partial_object.refcnt = 1;
+  if (info->description != NULL)
+    partial_object.description = string(info->description);
+  TxnInfo txn;
+  txn.id = *id;
+  txn.partial_object = partial_object;
+  transactions[txn_id] = txn;
+  return CVMCACHE_STATUS_OK;
+}
+
+
+static int ram_write_txn(
+  uint64_t txn_id,
+  unsigned char *buffer,
+  uint32_t size)
+{
+  TxnInfo txn = transactions[txn_id];
+  txn.partial_object.data += string(reinterpret_cast<char *>(buffer), size);
+  transactions[txn_id] = txn;
+  return CVMCACHE_STATUS_OK;
+}
+
+
+static int ram_commit_txn(uint64_t txn_id) {
+  TxnInfo txn = transactions[txn_id];
+  ComparableHash h(txn.id);
+  storage[h] = txn.partial_object;
+  return CVMCACHE_STATUS_OK;
+}
+
+static int ram_abort_txn(uint64_t txn_id) {
+  transactions.erase(txn_id);
+  return CVMCACHE_STATUS_OK;
+}
+
+static int ram_info(struct cvmcache_info *info) {
+  info->size_bytes = uint64_t(-1);
+  info->used_bytes = info->pinned_bytes = 0;
+  for (map<ComparableHash, Object>::const_iterator i = storage.begin(),
+       i_end = storage.end(); i != i_end; ++i)
+  {
+    info->used_bytes += i->second.data.length();
+    if (i->second.refcnt > 0)
+      info->pinned_bytes += i->second.data.length();
+  }
+  info->no_shrink = 0;
+  return CVMCACHE_STATUS_OK;
+}
+
+static int ram_shrink(uint64_t shrink_to, uint64_t *used) {
+  struct cvmcache_info info;
+  ram_info(&info);
+  *used = info.used_bytes;
+  if (info.used_bytes <= shrink_to)
+    return CVMCACHE_STATUS_OK;
+
+  // Volatile objects
+  for (map<ComparableHash, Object>::iterator i = storage.begin(),
+       i_end = storage.end(); i != i_end; )
+  {
+    if ((i->second.refcnt > 0) || (i->second.type != CVMCACHE_OBJECT_VOLATILE))
+    {
+      ++i;
+      continue;
+    }
+    unsigned length = i->second.data.length();
+    map<ComparableHash, Object>::iterator delete_me = i++;
+    storage.erase(delete_me);
+    info.used_bytes -= length;
+    if (info.used_bytes <= shrink_to) {
+      *used = info.used_bytes;
+      return CVMCACHE_STATUS_OK;
+    }
+  }
+  // All other objects
+  for (map<ComparableHash, Object>::iterator i = storage.begin(),
+       i_end = storage.end(); i != i_end; )
+  {
+    if (i->second.refcnt > 0) {
+      ++i;
+      continue;
+    }
+    unsigned length = i->second.data.length();
+    map<ComparableHash, Object>::iterator delete_me = i++;
+    storage.erase(delete_me);
+    info.used_bytes -= length;
+    if (info.used_bytes <= shrink_to) {
+      *used = info.used_bytes;
+      return CVMCACHE_STATUS_OK;
+    }
+  }
+
+  *used = info.used_bytes;
+  return CVMCACHE_STATUS_PARTIAL;
+}
+
+static int ram_listing_begin(
+  uint64_t lst_id,
+  enum cvmcache_object_type type)
+{
+  Listing lst;
+  lst.type = type;
+  lst.elems = new vector<Object>();
+  for (map<ComparableHash, Object>::const_iterator i = storage.begin(),
+       i_end = storage.end(); i != i_end; ++i)
+  {
+    lst.elems->push_back(i->second);
+  }
+  listings[lst_id] = lst;
+  return CVMCACHE_STATUS_OK;
+}
+
+static int ram_listing_next(
+  int64_t listing_id,
+  struct cvmcache_object_info *item)
+{
+  Listing lst = listings[listing_id];
+  do {
+    if (lst.pos >= lst.elems->size())
+      return CVMCACHE_STATUS_OUTOFBOUNDS;
+
+    vector<Object> *elems = lst.elems;
+    if ((*elems)[lst.pos].type == lst.type) {
+      item->id = (*elems)[lst.pos].id;
+      item->size = (*elems)[lst.pos].data.length();
+      item->type = (*elems)[lst.pos].type;
+      item->pinned = (*elems)[lst.pos].refcnt > 0;
+      item->description = (*elems)[lst.pos].description.empty()
+                          ? NULL
+                          : strdup((*elems)[lst.pos].description.c_str());
+      break;
+    }
+    lst.pos++;
+  } while (true);
+  lst.pos++;
+  listings[listing_id] = lst;
+  return CVMCACHE_STATUS_OK;
+}
+
+static int ram_listing_end(int64_t listing_id) {
+  delete listings[listing_id].elems;
+  listings.erase(listing_id);
+  return CVMCACHE_STATUS_OK;
+}
+
+static void Usage(const char *progname) {
+  printf("%s <config file>\n", progname);
+}
+
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    Usage(argv[0]);
+    return 1;
+  }
+
+  cvmcache_option_map *options = cvmcache_options_init();
+  if (cvmcache_options_parse(options, argv[1]) != 0) {
+    printf("cannot parse options file %s\n", argv[1]);
+    return 1;
+  }
+  char *locator = cvmcache_options_get(options, "CVMFS_CACHE_EXTERNAL_LOCATOR");
+  if (locator == NULL) {
+    printf("CVMFS_CACHE_EXTERNAL_LOCATOR missing\n");
+    cvmcache_options_fini(options);
+    return 1;
+  }
+
+  struct cvmcache_callbacks callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.cvmcache_chrefcnt = ram_chrefcnt;
+  callbacks.cvmcache_obj_info = ram_obj_info;
+  callbacks.cvmcache_pread = ram_pread;
+  callbacks.cvmcache_start_txn = ram_start_txn;
+  callbacks.cvmcache_write_txn = ram_write_txn;
+  callbacks.cvmcache_commit_txn = ram_commit_txn;
+  callbacks.cvmcache_abort_txn = ram_abort_txn;
+  callbacks.cvmcache_info = ram_info;
+  callbacks.cvmcache_shrink = ram_shrink;
+  callbacks.cvmcache_listing_begin = ram_listing_begin;
+  callbacks.cvmcache_listing_next = ram_listing_next;
+  callbacks.cvmcache_listing_end = ram_listing_end;
+  callbacks.capabilities = CVMCACHE_CAP_ALL;
+
+  ctx = cvmcache_init(&callbacks);
+  int retval = cvmcache_listen(ctx, locator);
+  assert(retval);
+  printf("Listening for cvmfs clients on %s\n", locator);
+  printf("NOTE: this process needs to run as user cvmfs\n\n");
+  printf("Press <R ENTER> to ask clients to release nested catalogs\n");
+  printf("Press <Ctrl+D> to quit\n");
+
+  cvmcache_process_requests(ctx, 0);
+  while (true) {
+    char buf;
+    retval = read(fileno(stdin), &buf, 1);
+    if (retval != 1)
+      break;
+    if (buf == 'R') {
+      printf("  ... asking clients to release nested catalogs\n");
+      cvmcache_ask_detach(ctx);
+    }
+  }
+  printf("  ... good bye\n");
+  cvmcache_options_free(locator);
+  cvmcache_options_fini(options);
+  return 0;
+}

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "cache_plugin/channel.h"
+#include "cache_transport.h"
 #include "hash.h"
 #include "monitor.h"
 #include "util/pointer.h"
@@ -257,6 +258,14 @@ char *cvmcache_hash_print(struct cvmcache_hash *h) {
 }
 
 
+void cvmcache_init_global() { }
+
+
+void cvmcache_cleanup_global() { }
+
+int cvmcache_is_supervised() {
+  return getenv(CacheTransport::kEnvReadyNotifyFd) != NULL;
+}
 
 struct cvmcache_context *cvmcache_init(struct cvmcache_callbacks *callbacks) {
   return new cvmcache_context(new ForwardCachePlugin(callbacks));
@@ -275,8 +284,13 @@ void cvmcache_ask_detach(struct cvmcache_context *ctx) {
   ctx->plugin->AskToDetach();
 }
 
-void cvmcache_terminate(struct cvmcache_context *ctx) {
+void cvmcache_wait_for(struct cvmcache_context *ctx) {
+  ctx->plugin->WaitFor();
   delete ctx;
+}
+
+void cvmcache_terminate(struct cvmcache_context *ctx) {
+  ctx->plugin->Terminate();
 }
 
 uint32_t cvmcache_max_object_size(struct cvmcache_context *ctx) {

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -16,6 +16,7 @@
 
 #include "cache_plugin/channel.h"
 #include "hash.h"
+#include "monitor.h"
 #include "util/pointer.h"
 
 using namespace std;  // NOLINT
@@ -228,6 +229,8 @@ class ForwardCachePlugin : public CachePlugin {
   struct cvmcache_callbacks callbacks_;
 };
 
+Watchdog *g_watchdog = NULL;
+
 }  // anonymous namespace
 
 
@@ -278,4 +281,19 @@ void cvmcache_terminate(struct cvmcache_context *ctx) {
 
 uint32_t cvmcache_max_object_size(struct cvmcache_context *ctx) {
   return ctx->plugin->max_object_size();
+}
+
+void cvmcache_spawn_watchdog(const char *crash_dump_file) {
+  if (g_watchdog != NULL)
+    return;
+  g_watchdog = Watchdog::Create((crash_dump_file != NULL)
+                                ? string(crash_dump_file)
+                                : "");
+  assert(g_watchdog != NULL);
+  g_watchdog->Spawn();
+}
+
+void cvmcache_terminate_watchdog() {
+  delete g_watchdog;
+  g_watchdog = NULL;
 }

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -171,6 +171,15 @@ void cvmcache_terminate(struct cvmcache_context *ctx);
 
 uint32_t cvmcache_max_object_size(struct cvmcache_context *ctx);
 
+/**
+ * Can be used at to spawn a second process that superwises the cache plugin.
+ * The watchdog can use gdb/lldb to generate stack traces.  Must be closed by
+ * a call to cvmcache_close_watchdog(), otherwise the main process will be
+ * reported has having died unexpectedly.
+ */
+void cvmcache_spawn_watchdog(const char *crash_dump_file);
+void cvmcache_terminate_watchdog();
+
 
 // Options parsing from libcvmfs without legacy support
 

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -151,6 +151,14 @@ struct cvmcache_callbacks {
   int capabilities;
 };
 
+void cvmcache_init_global();
+void cvmcache_cleanup_global();
+/**
+ * True if the plugin was started from a cvmfs mountpoint and thus will
+ * terminate by itself when the last mount point disconnects.
+ */
+int cvmcache_is_supervised();
+
 struct cvmcache_context *cvmcache_init(struct cvmcache_callbacks *callbacks);
 /**
  * The locator is either a UNIX domain socket (unix=/path/to/socket) or a
@@ -167,12 +175,20 @@ void cvmcache_process_requests(struct cvmcache_context *ctx, unsigned nworkers);
  * objects in the cache become unpinned.
  */
 void cvmcache_ask_detach(struct cvmcache_context *ctx);
+/**
+ * Stops the processing thread.
+ */
 void cvmcache_terminate(struct cvmcache_context *ctx);
-
+/**
+ * Blocks until the processing thread finishes.  Can either happen due to a call
+ * to cvmcache_terminate or -- when the plugin is started from cvmfs -- when
+ * the last repository is unmounted.  Invalidates the context object.
+ */
+void cvmcache_wait_for(struct cvmcache_context *ctx);
 uint32_t cvmcache_max_object_size(struct cvmcache_context *ctx);
 
 /**
- * Can be used at to spawn a second process that superwises the cache plugin.
+ * Can be used to spawn a second process that superwises the cache plugin.
  * The watchdog can use gdb/lldb to generate stack traces.  Must be closed by
  * a call to cvmcache_close_watchdog(), otherwise the main process will be
  * reported has having died unexpectedly.

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -121,11 +121,14 @@ struct cvmcache_callbacks {
                         uint64_t offset,
                         uint32_t *size,
                         unsigned char *buffer);
+  /**
+   * The same object might be uploaded concurrently by multiple users.
+   */
   int (*cvmcache_start_txn)(struct cvmcache_hash *id,
                             uint64_t txn_id,
                             struct cvmcache_object_info *info);
   /**
-   * A full block is appended expect possibly for the file's last block
+   * A full block is appended except possibly for the file's last block
    */
   int (*cvmcache_write_txn)(uint64_t txn_id,
                             unsigned char *buffer,
@@ -151,7 +154,14 @@ struct cvmcache_callbacks {
   int capabilities;
 };
 
+/**
+ * Should be called before any other cvmcache_... function.
+ */
 void cvmcache_init_global();
+/**
+ * Deletes global state, afterwards no further calls to cvmcache_... functions
+ * should take place.
+ */
 void cvmcache_cleanup_global();
 /**
  * True if the plugin was started from a cvmfs mountpoint and thus will
@@ -197,7 +207,7 @@ void cvmcache_spawn_watchdog(const char *crash_dump_file);
 void cvmcache_terminate_watchdog();
 
 
-// Options parsing from libcvmfs without legacy support
+// Options parsing from libcvmfs without "libcvmfs legacy" support
 
 cvmcache_option_map *cvmcache_options_init();
 /**

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -66,6 +66,7 @@ enum cvmcache_capabilities {
   CVMCACHE_CAP_ALL         = 31
 };
 
+#define CVMCACHE_SIZE_UNKNOWN (uint64_t(-1))
 
 struct cvmcache_hash {
   unsigned char digest[20];

--- a/cvmfs/cache_plugin/libcvmfs_cache_public_syms.txt
+++ b/cvmfs/cache_plugin/libcvmfs_cache_public_syms.txt
@@ -12,6 +12,8 @@ cvmcache_process_requests
 cvmcache_ask_detach
 cvmcache_terminate
 cvmcache_max_object_size
+cvmcache_spawn_watchdog
+cvmcache_terminate_watchdog
 cvmcache_options_init
 cvmcache_options_fini
 cvmcache_options_set

--- a/cvmfs/cache_plugin/libcvmfs_cache_public_syms.txt
+++ b/cvmfs/cache_plugin/libcvmfs_cache_public_syms.txt
@@ -6,10 +6,14 @@ __i686.get_pc_thunk.bx
 __i686.get_pc_thunk.cx
 cvmcache_hash_cmp
 cvmcache_hash_print
+cvmcache_init_global
+cvmcache_cleanup_global
+cvmcache_is_supervised
 cvmcache_init
 cvmcache_listen
 cvmcache_process_requests
 cvmcache_ask_detach
+cvmcache_wait_for
 cvmcache_terminate
 cvmcache_max_object_size
 cvmcache_spawn_watchdog

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -27,6 +27,8 @@ RamCacheManager::RamCacheManager(
   perf::Statistics *statistics)
   : max_size_(max_size)
   , fd_table_(max_entries, ReadOnlyHandle())
+  // TODO(jblomer): the number of slots in the kv-stores should _not_ be the
+  // number of open files.
   , regular_entries_(max_entries,
                      "RamCache.regular",
                      alloc,

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -22,6 +22,9 @@
 
 using namespace std;  // NOLINT
 
+const char *CacheTransport::kEnvReadyNotifyFd =
+  "__CVMFS_CACHE_EXTERNAL_PIPE_READY__";
+
 /**
  * Called on the sender side to wrap a message into a MsgRpc message for wire
  * transfer.

--- a/cvmfs/cache_transport.h
+++ b/cvmfs/cache_transport.h
@@ -16,6 +16,28 @@ namespace shash {
 struct Any;
 }
 
+inline const char *CacheTransportCode2Ascii(const cvmfs::EnumStatus code) {
+  switch (code) {
+    case cvmfs::STATUS_UNKNOWN: return "unknown cache protocol error";
+    case cvmfs::STATUS_OK: return "OK";
+    case cvmfs::STATUS_NOSUPPORT:
+      return "operation not implemented by cache plugin";
+    case cvmfs::STATUS_FORBIDDEN: return "cache plugin denied the operation";
+    case cvmfs::STATUS_NOSPACE: return "no space in cache";
+    case cvmfs::STATUS_NOENTRY: return "object not found in cache";
+    case cvmfs::STATUS_MALFORMED: return "malformed cache protocol message";
+    case cvmfs::STATUS_IOERR: return "I/O error";
+    case cvmfs::STATUS_CORRUPTED: return "corrupted data detected";
+    case cvmfs::STATUS_TIMEOUT: return "multipart request timed out";
+    case cvmfs::STATUS_BADCOUNT:
+      return "invalid attempt to set negative reference count";
+    case cvmfs::STATUS_OUTOFBOUNDS: return "out of bounds";
+    case cvmfs::STATUS_PARTIAL:
+      return "cache could not be cleaned up to the given limit";
+    default: return "unexpected cache protocol error";
+  }
+}
+
 /**
  * Sending and receiving with a file descriptor. Does _not_ take the ownership
  * of the file descriptor.

--- a/cvmfs/cache_transport.h
+++ b/cvmfs/cache_transport.h
@@ -45,6 +45,12 @@ inline const char *CacheTransportCode2Ascii(const cvmfs::EnumStatus code) {
 class CacheTransport {
  public:
   /**
+   * When this environment variable is set, the plugin will notify a cvmfs
+   * client once it is ready to accept connections.
+   */
+  static const char *kEnvReadyNotifyFd;  // __CVMFS_CACHE_EXTERNAL_PIPE_READY__
+  static const char kReadyNotification = 'C';
+  /**
    * Version of the wire protocol.  The effective protocol version is negotiated
    * through the handshake.
    */

--- a/cvmfs/cache_transport.h
+++ b/cvmfs/cache_transport.h
@@ -50,6 +50,7 @@ class CacheTransport {
    */
   static const char *kEnvReadyNotifyFd;  // __CVMFS_CACHE_EXTERNAL_PIPE_READY__
   static const char kReadyNotification = 'C';
+  static const char kFailureNotification = 'F';
   /**
    * Version of the wire protocol.  The effective protocol version is negotiated
    * through the handshake.

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -85,7 +85,7 @@
 #include "history_sqlite.h"
 #include "loader.h"
 #include "logging.h"
-#include "lru.h"
+#include "lru_md.h"
 #include "manifest_fetch.h"
 #include "monitor.h"
 #include "mountpoint.h"

--- a/cvmfs/kvstore.cc
+++ b/cvmfs/kvstore.cc
@@ -19,6 +19,16 @@
 
 using namespace std;  // NOLINT
 
+namespace {
+
+static inline uint32_t hasher_any(const shash::Any &key) {
+  // We'll just do the same thing as hasher_md5, since every hash is at
+  // least as large.
+  return (uint32_t) *(reinterpret_cast<const uint32_t *>(key.digest) + 1);
+}
+
+}  // anonymous namespace
+
 const double MemoryKvStore::kCompactThreshold = 0.8;
 
 
@@ -32,7 +42,7 @@ MemoryKvStore::MemoryKvStore(
   , used_bytes_(0)
   , entry_count_(0)
   , max_entries_(cache_entries)
-  , entries_(cache_entries, shash::Any(), lru::hasher_any,
+  , entries_(cache_entries, shash::Any(), hasher_any,
       statistics, name)
   , heap_(NULL)
   , counters_(statistics, name + ".lru")

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -15,6 +15,8 @@
 #include "lru.h"
 #include "malloc_heap.h"
 #include "statistics.h"
+#include "util/async.h"
+#include "util/single_copy.h"
 
 using namespace std;  // NOLINT
 
@@ -25,9 +27,7 @@ using namespace std;  // NOLINT
  * the allocations.
  */
 struct AllocHeader {
-  AllocHeader()
-  : version(0)
-  , id() {}
+  AllocHeader() : version(0), id() { }
   uint8_t version;
   shash::Any id;
 };
@@ -63,7 +63,7 @@ struct MemoryBuffer {
  * can attempt to reduce its size by removing the least recently used
  * entries without any outstanding references.
  */
-class MemoryKvStore :SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
+class MemoryKvStore : SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
  public:
   enum MemoryAllocator {
     kMallocLibc,

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -59,7 +59,7 @@
 #include "hash.h"
 #include "libcvmfs.h"
 #include "logging.h"
-#include "lru.h"
+#include "lru_md.h"
 #include "murmur.h"
 #include "platform.h"
 #include "quota.h"

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -65,7 +65,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[6] = "cannot run FUSE event loop";
   texts[7] = "failed to load shared library";
   texts[8] = "incompatible library version";
-  texts[9] = "cache directory problem";
+  texts[9] = "cache directory/plugin problem";
   texts[10] = "peering problem";
   texts[11] = "NFS maps init failure";
   texts[12] = "quota init failure";

--- a/cvmfs/lru.h
+++ b/cvmfs/lru.h
@@ -36,16 +36,9 @@
 #ifndef CVMFS_LRU_H_
 #define CVMFS_LRU_H_
 
-#define FUSE_USE_VERSION 26
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 // If defined the cache is secured by a posix mutex
 #define LRU_CACHE_THREAD_SAFE
 
-#include <fuse/fuse_lowlevel.h>
-#include <inttypes.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -56,12 +49,7 @@
 #include <string>
 
 #include "atomic.h"
-#include "directory_entry.h"
-#include "hash.h"
-#include "logging.h"
-#include "murmur.h"
 #include "platform.h"
-#include "shortstring.h"
 #include "smallhash.h"
 #include "smalloc.h"
 #include "statistics.h"
@@ -871,145 +859,6 @@ class LruCache : SingleCopy {
   pthread_mutex_t lock_;  /**< Mutex to make cache thread safe. */
 #endif
 };  // class LruCache
-
-// Hash functions
-static inline uint32_t hasher_md5(const shash::Md5 &key) {
-  // Don't start with the first bytes, because == is using them as well
-  return (uint32_t) *(reinterpret_cast<const uint32_t *>(key.digest) + 1);
-}
-
-static inline uint32_t hasher_any(const shash::Any &key) {
-  // We'll just do the same thing as hasher_md5, since every hash is at
-  // least as large.
-  return (uint32_t) *(reinterpret_cast<const uint32_t *>(key.digest) + 1);
-}
-
-
-static inline uint32_t hasher_inode(const fuse_ino_t &inode) {
-  return MurmurHash2(&inode, sizeof(inode), 0x07387a4f);
-}
-// uint32_t hasher_md5(const shash::Md5 &key);
-// uint32_t hasher_inode(const fuse_ino_t &inode);
-
-
-class InodeCache : public LruCache<fuse_ino_t, catalog::DirectoryEntry>
-{
- public:
-  explicit InodeCache(unsigned int cache_size, perf::Statistics *statistics) :
-    LruCache<fuse_ino_t, catalog::DirectoryEntry>(
-      cache_size, fuse_ino_t(-1), hasher_inode, statistics, "inode_cache")
-  {
-  }
-
-  bool Insert(const fuse_ino_t &inode, const catalog::DirectoryEntry &dirent) {
-    LogCvmfs(kLogLru, kLogDebug, "insert inode --> dirent: %u -> '%s'",
-             inode, dirent.name().c_str());
-    const bool result =
-      LruCache<fuse_ino_t, catalog::DirectoryEntry>::Insert(inode, dirent);
-    return result;
-  }
-
-  bool Lookup(const fuse_ino_t &inode, catalog::DirectoryEntry *dirent,
-              bool update_lru = true)
-  {
-    const bool result =
-      LruCache<fuse_ino_t, catalog::DirectoryEntry>::Lookup(inode, dirent);
-    LogCvmfs(kLogLru, kLogDebug, "lookup inode --> dirent: %u (%s)",
-             inode, result ? "hit" : "miss");
-    return result;
-  }
-
-  void Drop() {
-    LogCvmfs(kLogLru, kLogDebug, "dropping inode cache");
-    LruCache<fuse_ino_t, catalog::DirectoryEntry>::Drop();
-  }
-};  // InodeCache
-
-
-class PathCache : public LruCache<fuse_ino_t, PathString> {
- public:
-  explicit PathCache(unsigned int cache_size, perf::Statistics *statistics) :
-    LruCache<fuse_ino_t, PathString>(cache_size, fuse_ino_t(-1), hasher_inode,
-        statistics, "path_cache")
-  {
-  }
-
-  bool Insert(const fuse_ino_t &inode, const PathString &path) {
-    LogCvmfs(kLogLru, kLogDebug, "insert inode --> path %u -> '%s'",
-             inode, path.c_str());
-    const bool result =
-      LruCache<fuse_ino_t, PathString>::Insert(inode, path);
-    return result;
-  }
-
-  bool Lookup(const fuse_ino_t &inode, PathString *path,
-              bool update_lru = true)
-  {
-    const bool found =
-      LruCache<fuse_ino_t, PathString>::Lookup(inode, path);
-    LogCvmfs(kLogLru, kLogDebug, "lookup inode --> path: %u (%s)",
-             inode, found ? "hit" : "miss");
-    return found;
-  }
-
-  void Drop() {
-    LogCvmfs(kLogLru, kLogDebug, "dropping path cache");
-    LruCache<fuse_ino_t, PathString>::Drop();
-  }
-};  // PathCache
-
-
-class Md5PathCache :
-  public LruCache<shash::Md5, catalog::DirectoryEntry>
-{
- public:
-  explicit Md5PathCache(unsigned int cache_size, perf::Statistics *statistics) :
-    LruCache<shash::Md5, catalog::DirectoryEntry>(
-      cache_size, shash::Md5(shash::AsciiPtr("!")), hasher_md5, statistics,
-      "md5_path_cache")
-  {
-    dirent_negative_ = catalog::DirectoryEntry(catalog::kDirentNegative);
-  }
-
-  bool Insert(const shash::Md5 &hash, const catalog::DirectoryEntry &dirent) {
-    LogCvmfs(kLogLru, kLogDebug, "insert md5 --> dirent: %s -> '%s'",
-             hash.ToString().c_str(), dirent.name().c_str());
-    const bool result =
-      LruCache<shash::Md5, catalog::DirectoryEntry>::Insert(hash, dirent);
-    return result;
-  }
-
-  bool InsertNegative(const shash::Md5 &hash) {
-    const bool result = Insert(hash, dirent_negative_);
-    if (result)
-      perf::Inc(counters_.n_insert_negative);
-    return result;
-  }
-
-  bool Lookup(const shash::Md5 &hash, catalog::DirectoryEntry *dirent,
-              bool update_lru = true)
-  {
-    const bool result =
-      LruCache<shash::Md5, catalog::DirectoryEntry>::Lookup(hash, dirent);
-    LogCvmfs(kLogLru, kLogDebug, "lookup md5 --> dirent: %s (%s)",
-             hash.ToString().c_str(), result ? "hit" : "miss");
-    return result;
-  }
-
-  bool Forget(const shash::Md5 &hash) {
-    LogCvmfs(kLogLru, kLogDebug, "forget md5: %s",
-             hash.ToString().c_str());
-    return LruCache<shash::Md5, catalog::DirectoryEntry>::Forget(hash);
-  }
-
-  void Drop() {
-    LogCvmfs(kLogLru, kLogDebug, "dropping md5path cache");
-    LruCache<shash::Md5, catalog::DirectoryEntry>::Drop();
-  }
-
- private:
-  catalog::DirectoryEntry dirent_negative_;
-};  // Md5PathCache
 
 }  // namespace lru
 

--- a/cvmfs/lru.h
+++ b/cvmfs/lru.h
@@ -595,6 +595,23 @@ class LruCache : SingleCopy {
 
 
   /**
+   * Updates object and moves back to the end of the list.  The object must be
+   * present.
+   */
+  virtual void Update(const Key &key) {
+    Lock();
+    // Is not called from the client, only from the cache plugin
+    assert(!pause_);
+    CacheEntry entry;
+    bool retval = DoLookup(key, &entry);
+    assert(retval);
+    perf::Inc(counters_.n_update);
+    Touch(entry);
+    Unlock();
+  }
+
+
+  /**
    * Changes the value of an entry in the LRU cache without updating the LRU
    * order.
    */

--- a/cvmfs/lru_md.h
+++ b/cvmfs/lru_md.h
@@ -1,0 +1,163 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * Provides the LRU sub classes used for the file system client meta-data cache
+ */
+
+#ifndef CVMFS_LRU_MD_H_
+#define CVMFS_LRU_MD_H_
+
+#define FUSE_USE_VERSION 26
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <fuse/fuse_lowlevel.h>
+#include <stdint.h>
+
+#include "atomic.h"
+#include "directory_entry.h"
+#include "hash.h"
+#include "logging.h"
+#include "lru.h"
+#include "murmur.h"
+#include "shortstring.h"
+
+
+namespace lru {
+
+// Hash functions
+static inline uint32_t hasher_md5(const shash::Md5 &key) {
+  // Don't start with the first bytes, because == is using them as well
+  return (uint32_t) *(reinterpret_cast<const uint32_t *>(key.digest) + 1);
+}
+
+static inline uint32_t hasher_inode(const fuse_ino_t &inode) {
+  return MurmurHash2(&inode, sizeof(inode), 0x07387a4f);
+}
+// uint32_t hasher_md5(const shash::Md5 &key);
+// uint32_t hasher_inode(const fuse_ino_t &inode);
+
+
+class InodeCache : public LruCache<fuse_ino_t, catalog::DirectoryEntry>
+{
+ public:
+  explicit InodeCache(unsigned int cache_size, perf::Statistics *statistics) :
+    LruCache<fuse_ino_t, catalog::DirectoryEntry>(
+      cache_size, fuse_ino_t(-1), hasher_inode, statistics, "inode_cache")
+  {
+  }
+
+  bool Insert(const fuse_ino_t &inode, const catalog::DirectoryEntry &dirent) {
+    LogCvmfs(kLogLru, kLogDebug, "insert inode --> dirent: %u -> '%s'",
+             inode, dirent.name().c_str());
+    const bool result =
+      LruCache<fuse_ino_t, catalog::DirectoryEntry>::Insert(inode, dirent);
+    return result;
+  }
+
+  bool Lookup(const fuse_ino_t &inode, catalog::DirectoryEntry *dirent,
+              bool update_lru = true)
+  {
+    const bool result =
+      LruCache<fuse_ino_t, catalog::DirectoryEntry>::Lookup(inode, dirent);
+    LogCvmfs(kLogLru, kLogDebug, "lookup inode --> dirent: %u (%s)",
+             inode, result ? "hit" : "miss");
+    return result;
+  }
+
+  void Drop() {
+    LogCvmfs(kLogLru, kLogDebug, "dropping inode cache");
+    LruCache<fuse_ino_t, catalog::DirectoryEntry>::Drop();
+  }
+};  // InodeCache
+
+
+class PathCache : public LruCache<fuse_ino_t, PathString> {
+ public:
+  explicit PathCache(unsigned int cache_size, perf::Statistics *statistics) :
+    LruCache<fuse_ino_t, PathString>(cache_size, fuse_ino_t(-1), hasher_inode,
+        statistics, "path_cache")
+  {
+  }
+
+  bool Insert(const fuse_ino_t &inode, const PathString &path) {
+    LogCvmfs(kLogLru, kLogDebug, "insert inode --> path %u -> '%s'",
+             inode, path.c_str());
+    const bool result =
+      LruCache<fuse_ino_t, PathString>::Insert(inode, path);
+    return result;
+  }
+
+  bool Lookup(const fuse_ino_t &inode, PathString *path,
+              bool update_lru = true)
+  {
+    const bool found =
+      LruCache<fuse_ino_t, PathString>::Lookup(inode, path);
+    LogCvmfs(kLogLru, kLogDebug, "lookup inode --> path: %u (%s)",
+             inode, found ? "hit" : "miss");
+    return found;
+  }
+
+  void Drop() {
+    LogCvmfs(kLogLru, kLogDebug, "dropping path cache");
+    LruCache<fuse_ino_t, PathString>::Drop();
+  }
+};  // PathCache
+
+
+class Md5PathCache :
+  public LruCache<shash::Md5, catalog::DirectoryEntry>
+{
+ public:
+  explicit Md5PathCache(unsigned int cache_size, perf::Statistics *statistics) :
+    LruCache<shash::Md5, catalog::DirectoryEntry>(
+      cache_size, shash::Md5(shash::AsciiPtr("!")), hasher_md5, statistics,
+      "md5_path_cache")
+  {
+    dirent_negative_ = catalog::DirectoryEntry(catalog::kDirentNegative);
+  }
+
+  bool Insert(const shash::Md5 &hash, const catalog::DirectoryEntry &dirent) {
+    LogCvmfs(kLogLru, kLogDebug, "insert md5 --> dirent: %s -> '%s'",
+             hash.ToString().c_str(), dirent.name().c_str());
+    const bool result =
+      LruCache<shash::Md5, catalog::DirectoryEntry>::Insert(hash, dirent);
+    return result;
+  }
+
+  bool InsertNegative(const shash::Md5 &hash) {
+    const bool result = Insert(hash, dirent_negative_);
+    if (result)
+      perf::Inc(counters_.n_insert_negative);
+    return result;
+  }
+
+  bool Lookup(const shash::Md5 &hash, catalog::DirectoryEntry *dirent,
+              bool update_lru = true)
+  {
+    const bool result =
+      LruCache<shash::Md5, catalog::DirectoryEntry>::Lookup(hash, dirent);
+    LogCvmfs(kLogLru, kLogDebug, "lookup md5 --> dirent: %s (%s)",
+             hash.ToString().c_str(), result ? "hit" : "miss");
+    return result;
+  }
+
+  bool Forget(const shash::Md5 &hash) {
+    LogCvmfs(kLogLru, kLogDebug, "forget md5: %s",
+             hash.ToString().c_str());
+    return LruCache<shash::Md5, catalog::DirectoryEntry>::Forget(hash);
+  }
+
+  void Drop() {
+    LogCvmfs(kLogLru, kLogDebug, "dropping md5path cache");
+    LruCache<shash::Md5, catalog::DirectoryEntry>::Drop();
+  }
+
+ private:
+  catalog::DirectoryEntry dirent_negative_;
+};  // Md5PathCache
+
+}  // namespace lru
+
+#endif  // CVMFS_LRU_MD_H_

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -76,6 +76,16 @@ void MallocHeap::Compact() {
 }
 
 
+void *MallocHeap::Expand(void *block, uint64_t new_size) {
+  uint64_t old_size = GetSize(block);
+  assert(old_size <= new_size);
+  void *new_block = Allocate(new_size, block, old_size);
+  if (new_block != NULL)
+    MarkFree(block);
+  return new_block;
+}
+
+
 bool MallocHeap::HasSpaceFor(uint64_t nbytes) {
   return RoundUp8(gauge_ + nbytes + sizeof(Tag)) <= capacity_;
 }

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -76,6 +76,11 @@ void MallocHeap::Compact() {
 }
 
 
+bool MallocHeap::HasSpaceFor(uint64_t nbytes) {
+  return RoundUp8(gauge_ + nbytes + sizeof(Tag)) <= capacity_;
+}
+
+
 void MallocHeap::MarkFree(void *block) {
   Tag *tag = reinterpret_cast<Tag *>(block) - 1;
   assert(tag->size > 0);

--- a/cvmfs/malloc_heap.h
+++ b/cvmfs/malloc_heap.h
@@ -26,7 +26,7 @@
  * Note that during a Compact() not even reading from any of the pointers is
  * allowed!
  *
- * MallocHeap is used  by the in-memory object cache.  The header is the
+ * MallocHeap is used by the in-memory object cache.  The header is the
  * object's content hash, so the cache manager can identify any block in its
  * hash table and move the pointers when MallocHeap runs a garbage collection.
  *
@@ -56,9 +56,11 @@ class MallocHeap {
   inline uint64_t num_blocks() { return num_blocks_; }
   inline uint64_t used_bytes() { return gauge_; }
   inline uint64_t stored_bytes() { return stored_; }
+  inline uint64_t capacity() { return capacity_; }
   inline double utilization() {
     return static_cast<double>(stored_) / static_cast<double>(gauge_);
   }
+  bool HasSpaceFor(uint64_t nbytes);
 
  private:
   /**

--- a/cvmfs/malloc_heap.h
+++ b/cvmfs/malloc_heap.h
@@ -49,6 +49,7 @@ class MallocHeap {
   ~MallocHeap();
 
   void *Allocate(uint64_t size, void *header, unsigned header_size);
+  void *Expand(void *block, uint64_t new_size);
   void MarkFree(void *block);
   uint64_t GetSize(void *block);
   void Compact();

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -35,11 +35,14 @@
 #include <string>
 #include <vector>
 
+#ifndef CVMFS_LIBCVMFS
 #include "cvmfs.h"
+#endif
 #include "logging.h"
 #include "platform.h"
 #include "smalloc.h"
 #include "util/posix.h"
+#include "util/string.h"
 
 // Used for address offset calculation
 #ifndef CVMFS_LIBCVMFS

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -279,7 +279,7 @@ string Watchdog::ReportStacktrace() {
 }
 
 
-void Watchdog::SendTrace(int sig, siginfo_t *siginfo,void *context) {
+void Watchdog::SendTrace(int sig, siginfo_t *siginfo, void *context) {
   int send_errno = errno;
   if (platform_spinlock_trylock(&Me()->lock_handler_) != 0) {
     // Concurrent call, wait for the first one to exit the process

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -5,21 +5,85 @@
 #ifndef CVMFS_MONITOR_H_
 #define CVMFS_MONITOR_H_
 
+#include <signal.h>
 #include <sys/types.h>
+#include <unistd.h>
+
+#include <map>
 #include <string>
 
+#include "platform.h"
+
+class Pipe;
+
+/**
+ * This class can fork a watchdog process that listens on a pipe and prints a
+ * stackstrace into syslog, when cvmfs fails.  The crash dump is also appended
+ * to the crash dump file, if the path is not empty.  Singleton.
+ */
+class Watchdog {
+ public:
+  static Watchdog *Create(const std::string &crash_dump_path);
+  static pid_t GetPid();
+  ~Watchdog();
+  void Spawn();
+  void RegisterOnCrash(void (*CleanupOnCrash)(void));
+
+ private:
+  typedef std::map<int, struct sigaction> SigactionMap;
+
+  struct CrashData {
+    int signal;
+    int sys_errno;
+    pid_t pid;
+  };
+
+  struct ControlFlow {
+    enum Flags {
+      kProduceStacktrace = 0,
+      kQuit,
+      kUnknown,
+    };
+  };
+
+  /**
+   * Preallocated memory block to make sure that signal handler don't run into
+   * stack overflows.
+   */
+  static const unsigned kSignalHandlerStacksize = 2 * 1024 * 1024;  // 2 MB
+  /**
+   * If the GDB/LLDB method of generating a stack trace fails, fall back to
+   * libc's backtrace with a maximum depth.
+   */
+  static const unsigned kMaxBacktrace = 64;
+
+  static Watchdog *instance_;
+  static Watchdog *Me() { return instance_; }
+
+  static void SendTrace(int sig, siginfo_t *siginfo, void *context);
+
+  explicit Watchdog(const std::string &crash_dump_path);
+  SigactionMap SetSignalHandlers(const SigactionMap &signal_handlers);
+  void Supervise();
+  void LogEmergency(std::string msg);
+  std::string ReportStacktrace();
+  std::string GenerateStackTrace(const std::string &exe_path, pid_t pid);
+  std::string ReadUntilGdbPrompt(int fd_pipe);
+
+  bool spawned_;
+  std::string crash_dump_path_;
+  std::string exe_path_;
+  pid_t watchdog_pid_;
+  Pipe *pipe_watchdog_;
+  void (*on_crash_)(void);
+  platform_spinlock lock_handler_;
+  stack_t sighandler_stack_;
+  SigactionMap old_signal_handlers_;
+};
+
 namespace monitor {
-
-bool Init(const std::string &cache_dir, const std::string &process_name,
-          const bool check_max_open_files);
-void Fini();
-void Spawn();
-void RegisterOnCrash(void (*CleanupOnCrash)(void));
-
-pid_t GetPid();
-
+// TODO(jblomer): move me
 unsigned GetMaxOpenFiles();
-
 }  // namespace monitor
 
 #endif  // CVMFS_MONITOR_H_

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -48,7 +48,7 @@
 #include "history.h"
 #include "history_sqlite.h"
 #include "logging.h"
-#include "lru.h"
+#include "lru_md.h"
 #include "manifest.h"
 #include "manifest_fetch.h"
 #ifdef CVMFS_NFS_SUPPORT

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -222,7 +222,7 @@ bool FileSystem::CreateCache() {
         boot_status_ = loader::kFailCacheDir;
         return false;
       }
-      cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles);
+      cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles, name_);
       assert(cache_mgr_ != NULL);
       break;
     }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -193,6 +193,9 @@ bool FileSystem::CreateCache() {
       unsigned nfiles = 1024;
       if (options_mgr_->GetValue("CVMFS_NFILES", &optarg))
         nfiles = String2Uint64(optarg);
+      vector<string> cmd_line;
+      if (options_mgr_->GetValue("CVMFS_CACHE_EXTERNAL_CMDLINE", &optarg))
+        cmd_line = SplitString(optarg, ',');
       if (!options_mgr_->GetValue("CVMFS_CACHE_EXTERNAL_LOCATOR", &optarg)) {
         boot_error_ = "CVMFS_CACHE_EXTERNAL_LOCATOR missing";
         boot_status_ = loader::kFailCacheDir;
@@ -200,7 +203,7 @@ bool FileSystem::CreateCache() {
       }
 
       UniquePtr<ExternalCacheManager::PluginHandle> plugin_handle(
-        ExternalCacheManager::CreatePlugin(optarg, vector<string>()));
+        ExternalCacheManager::CreatePlugin(optarg, cmd_line));
       if (!plugin_handle->IsValid()) {
         boot_error_ = plugin_handle->error_msg();
         boot_status_ = loader::kFailCacheDir;

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -51,6 +51,7 @@
 #include "platform.h"
 #include "smalloc.h"
 #include "statistics.h"
+#include "util/pointer.h"
 #include "util/posix.h"
 #include "util_concurrency.h"
 
@@ -917,9 +918,9 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
   LogCvmfs(kLogQuota, kLogDebug, "starting quota manager");
   int retval;
 
-  retval = monitor::Init(".", "cachemgr", false);
-  assert(retval);
-  monitor::Spawn();
+  UniquePtr<Watchdog> watchdog(Watchdog::Create("./stacktrace.cachemgr"));
+  assert(watchdog.IsValid());
+  watchdog->Spawn();
 
   PosixQuotaManager shared_manager(0, 0, "");
   shared_manager.shared_ = true;
@@ -1039,8 +1040,6 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
     sqlite3_free(sqlite3_temp_directory);
     sqlite3_temp_directory = NULL;
   }
-
-  monitor::Fini();
 
   return 0;
 }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -38,7 +38,6 @@
 #include "glue_buffer.h"
 #include "loader.h"
 #include "logging.h"
-#include "lru.h"
 #include "monitor.h"
 #include "mountpoint.h"
 #include "nfs_maps.h"

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -553,7 +553,7 @@ void *TalkManager::MainResponder(void *data) {
         StringifyInt(file_system->cache_mgr()->quota_mgr()->GetPid()) + "\n";
       talk_mgr->Answer(con_fd, pid_str);
     } else if (line == "pid watchdog") {
-      const string pid_str = StringifyInt(monitor::GetPid()) + "\n";
+      const string pid_str = StringifyInt(Watchdog::GetPid()) + "\n";
       talk_mgr->Answer(con_fd, pid_str);
     } else if (line == "parameters") {
       talk_mgr->Answer(con_fd, file_system->options_mgr()->Dump());

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -27,7 +27,7 @@ class T_CachePlugin : public ::testing::Test {
   virtual void SetUp() {
     int fd_client = Connect();
     ASSERT_GE(fd_client, 0);
-    cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles);
+    cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles, "test");
     ASSERT_TRUE(cache_mgr_ != NULL);
     quota_mgr_ = ExternalQuotaManager::Create(cache_mgr_);
     ASSERT_TRUE(cache_mgr_ != NULL);
@@ -69,7 +69,7 @@ TEST_F(T_CachePlugin, Connection) {
   int fd_second = Connect();
   ASSERT_GE(fd_second, 0);
   ExternalCacheManager *cache_mgr_second =
-    ExternalCacheManager::Create(fd_second, nfiles);
+    ExternalCacheManager::Create(fd_second, nfiles, "test 2nd");
   ASSERT_TRUE(cache_mgr_second != NULL);
   EXPECT_GE(cache_mgr_second->session_id(), 0);
 

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -209,9 +209,9 @@ TEST_F(T_CachePlugin, TransactionAbort) {
   HashString(content, &id);
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   EXPECT_EQ(0, cache_mgr_->StartTxn(id, content.length(), txn));
-  //EXPECT_EQ(0, cache_mgr_->Reset(txn));
-  //EXPECT_EQ(2, cache_mgr_->Write(content.data(), 2, txn));
-  //EXPECT_EQ(0, cache_mgr_->Reset(txn));
+  EXPECT_EQ(0, cache_mgr_->Reset(txn));
+  EXPECT_EQ(2, cache_mgr_->Write(content.data(), 2, txn));
+  EXPECT_EQ(0, cache_mgr_->Reset(txn));
   EXPECT_EQ(3, cache_mgr_->Write(content.data(), 3, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -303,7 +303,6 @@ TEST_F(T_CachePlugin, Shrink) {
     return;
   }
 
-  // TODO(jblomer): do it with open transaction
   EXPECT_TRUE(quota_mgr_->Cleanup(0));
   EXPECT_TRUE(quota_mgr_->Cleanup(0));
   shash::Any id_vol(shash::kSha1);

--- a/test/unittests/main.cc
+++ b/test/unittests/main.cc
@@ -10,14 +10,14 @@
 #include "monitor.h"
 
 int main(int argc, char **argv) {
-  bool retval = monitor::Init("/tmp", "cvmfs_unittests", false);
-  assert(retval);
-  // monitor::Spawn();
+  Watchdog *watchdog = Watchdog::Create("/tmp/stacktrace.cvmfs_unittests");
+  assert(watchdog != NULL);
+  // watchdog->Spawn();
   CvmfsEnvironment* env = new CvmfsEnvironment(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ::testing::AddGlobalTestEnvironment(env);
   int result = RUN_ALL_TESTS();
-  monitor::Fini();
+  delete watchdog;
   return result;
 }

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -204,7 +204,7 @@ class T_ExternalCacheManager : public ::testing::Test {
 
     fd_client = ConnectSocket(socket_path_);
     ASSERT_GE(fd_client, 0);
-    cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles);
+    cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles, "test");
     ASSERT_TRUE(cache_mgr_ != NULL);
     quota_mgr_ = ExternalQuotaManager::Create(cache_mgr_);
     ASSERT_TRUE(cache_mgr_ != NULL);

--- a/test/unittests/t_lru.cc
+++ b/test/unittests/t_lru.cc
@@ -81,6 +81,35 @@ TEST(T_LruCache, UpdateValue) {
 }
 
 
+TEST(T_LruCache, UpdateOnly) {
+  perf::Statistics statistics;
+  LruCache<int, std::string> cache(cache_size, -1, hasher_int,
+      &statistics, name);
+
+  EXPECT_TRUE(cache.Insert(1, "one"));
+  EXPECT_TRUE(cache.Insert(2, "two"));
+
+  int key;
+  std::string value;
+  cache.FilterBegin();
+  EXPECT_TRUE(cache.FilterNext());
+  cache.FilterGet(&key, &value);
+  EXPECT_EQ(1, key);
+  cache.FilterEnd();
+
+  cache.Update(1);
+  cache.FilterBegin();
+  EXPECT_TRUE(cache.FilterNext());
+  cache.FilterGet(&key, &value);
+  EXPECT_EQ(2, key);
+  cache.FilterEnd();
+
+  EXPECT_DEATH(cache.Update(3), ".*");
+  cache.Pause();
+  EXPECT_DEATH(cache.Update(1), ".*");
+}
+
+
 TEST(T_LruCache, Drop) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,

--- a/test/unittests/t_malloc_heap.cc
+++ b/test/unittests/t_malloc_heap.cc
@@ -15,6 +15,7 @@
 #include "malloc_heap.h"
 #include "murmur.h"
 #include "prng.h"
+#include "smalloc.h"
 #include "util/async.h"
 
 using namespace std;  // NOLINT
@@ -32,10 +33,6 @@ class T_MallocHeap : public ::testing::Test {
 
   static uint32_t MemChecksum(void *p, uint32_t size) {
     return MurmurHash2(p, size, 0x07387a4f);
-  }
-
-  static inline uint32_t RoundUp8(const uint32_t size) {
-    return (size + 7) & ~7;
   }
 
   void FillRandomly(void *ptr, unsigned nbytes, Prng *prng) {
@@ -188,4 +185,30 @@ TEST_F(T_MallocHeap, Fill) {
   }
   ptr = M.Allocate(4096, &num_elems, sizeof(num_elems));
   EXPECT_EQ(NULL, ptr);
+}
+
+
+TEST_F(T_MallocHeap, HasSpaceFor) {
+  IntMap int_map;
+  MallocHeap M(kSmallArena,
+               int_map.MakeCallback(&IntMap::OnBlockMove, &int_map));
+  EXPECT_TRUE(M.HasSpaceFor(1));
+  EXPECT_FALSE(M.HasSpaceFor(kSmallArena));
+  EXPECT_TRUE(M.HasSpaceFor(kSmallArena - 8));
+
+  unsigned elem_size = 4096 - 8;
+  unsigned num_elems = kSmallArena / 4096;
+
+  for (unsigned i = 0; i < num_elems; ++i) {
+    EXPECT_TRUE(M.HasSpaceFor(elem_size));
+    void *ptr = M.Allocate(elem_size, &i, sizeof(i));
+    EXPECT_TRUE(ptr != NULL);
+    int_map.mem_digest[i] = IntMap::Info(ptr, 0);
+  }
+  EXPECT_FALSE(M.HasSpaceFor(elem_size));
+
+  M.MarkFree(int_map.mem_digest[0].ptr);
+  EXPECT_FALSE(M.HasSpaceFor(elem_size));
+  M.Compact();
+  EXPECT_TRUE(M.HasSpaceFor(elem_size));
 }

--- a/test/unittests/t_malloc_heap.cc
+++ b/test/unittests/t_malloc_heap.cc
@@ -212,3 +212,25 @@ TEST_F(T_MallocHeap, HasSpaceFor) {
   M.Compact();
   EXPECT_TRUE(M.HasSpaceFor(elem_size));
 }
+
+
+TEST_F(T_MallocHeap, Expand) {
+  IntMap int_map;
+  MallocHeap M(kSmallArena,
+               int_map.MakeCallback(&IntMap::OnBlockMove, &int_map));
+  unsigned i = 0;
+  void *ptr = M.Allocate(8, &i, sizeof(i));
+  EXPECT_TRUE(ptr != NULL);
+
+  void *ptr2 = M.Expand(ptr, 8);
+  EXPECT_TRUE(ptr2 != NULL);
+  EXPECT_NE(ptr, ptr2);
+  EXPECT_EQ(0, memcmp(ptr, ptr2, 8));
+
+  void *ptr3 = M.Expand(ptr2, 16);
+  EXPECT_TRUE(ptr3 != NULL);
+  EXPECT_NE(ptr2, ptr3);
+  EXPECT_EQ(0, memcmp(ptr2, ptr3, 8));
+
+  EXPECT_DEATH(M.Expand(ptr, 4), ".*");
+}


### PR DESCRIPTION
Uses the new cache plugin system for an (efficient) RAM cache.  Similar to the RamCacheManager.

Also

- Several fixes to the cache plugin infrastructure and small adjustments to the cache plugin API
- Add possibility to spawn shared cache plugins from client (`CVMFS_CACHE_EXTERNAL_CMDLINE`)
- Improves logging of the cache plugin
- Code cleanup: the watchdog became a class