### PR TITLE
New `swissknife_lease` command to work with repository leases

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -281,6 +281,8 @@ set (CVMFS_SWISSKNIFE_SOURCES
   swissknife_sync.cc swissknife_sync.h
   swissknife_zpipe.cc swissknife_zpipe.h
   swissknife_lease.cc
+  swissknife_lease_curl.cc
+  swissknife_lease_json.cc
   sync_item.cc sync_item.h
   sync_mediator.cc sync_mediator.h
   sync_union.cc sync_union.h

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -280,6 +280,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
   swissknife_sign.cc swissknife_sign.h
   swissknife_sync.cc swissknife_sync.h
   swissknife_zpipe.cc swissknife_zpipe.h
+  swissknife_lease.cc
   sync_item.cc sync_item.h
   sync_mediator.cc sync_mediator.h
   sync_union.cc sync_union.h

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -76,9 +76,9 @@ class Command {
  public:
   Command() { }
   virtual ~Command();
-  virtual std::string GetName() = 0;
-  virtual std::string GetDescription() = 0;
-  virtual ParameterList GetParams() = 0;
+  virtual std::string GetName() const = 0;
+  virtual std::string GetDescription() const = 0;
+  virtual ParameterList GetParams() const = 0;
   virtual int Main(const ArgumentList &args) = 0;
 
  protected:

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -27,13 +27,13 @@ class CommandCheck : public Command {
     : check_chunks_(false)
     , is_remote_(false) {}
   ~CommandCheck() { }
-  std::string GetName() { return "check"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "check"; }
+  virtual std::string GetDescription() const {
     return "CernVM File System repository sanity checker\n"
       "This command checks the consisteny of the file catalogs of a "
         "cvmfs repository.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('r', "repository directory / url"));
     r.push_back(Parameter::Optional('n', "check specific repository tag"));

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -27,7 +27,7 @@ typedef GarbageCollectorAux<ReadonlyCatalogTraversal, HashFilter> GCAux;
 typedef GC::Configuration GcConfig;
 
 
-ParameterList CommandGc::GetParams() {
+ParameterList CommandGc::GetParams() const {
   ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository url"));
   r.push_back(Parameter::Mandatory('u', "spooler definition string"));

--- a/cvmfs/swissknife_gc.h
+++ b/cvmfs/swissknife_gc.h
@@ -15,11 +15,11 @@ namespace swissknife {
 class CommandGc : public Command {
  public:
   ~CommandGc() { }
-  std::string GetName() { return "gc"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "gc"; }
+  virtual std::string GetDescription() const {
     return "Garbage Collect a CernVM-FS repository.";
   }
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 };
 

--- a/cvmfs/swissknife_graft.h
+++ b/cvmfs/swissknife_graft.h
@@ -20,11 +20,11 @@ namespace swissknife {
 class CommandGraft : public Command {
  public:
   ~CommandGraft() { }
-  std::string GetName() { return "graft"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "graft"; }
+  virtual std::string GetDescription() const {
     return "Creates a graft file for publishing in CVMFS.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('i', "Input file to process "
                                        "('-' for reading from stdin)"));

--- a/cvmfs/swissknife_hash.h
+++ b/cvmfs/swissknife_hash.h
@@ -14,11 +14,11 @@ namespace swissknife {
 class CommandHash : public Command {
  public:
   ~CommandHash() { }
-  std::string GetName() { return "hash"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "hash"; }
+  virtual std::string GetDescription() const {
     return "Hashes stdin and prints out the result on stdout.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('a', "hash algorithm"));
     r.push_back(Parameter::Switch('f', "print in fingerprint representation"));

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -27,7 +27,7 @@ const std::string CommandTag::kPreviousHeadTagDescription =
   "default undo target";
 
 
-void CommandTag::InsertCommonParameters(ParameterList *r) {
+static void InsertCommonParameters(ParameterList *r) {
   r->push_back(Parameter::Mandatory('w', "repository directory / url"));
   r->push_back(Parameter::Mandatory('t', "temporary scratch directory"));
   r->push_back(Parameter::Optional('p', "public key of the repository"));
@@ -456,7 +456,7 @@ bool CommandTag::IsUndoTagName(const std::string &tag_name) const {
 //------------------------------------------------------------------------------
 
 
-ParameterList CommandEditTag::GetParams() {
+ParameterList CommandEditTag::GetParams() const {
   ParameterList r;
   InsertCommonParameters(&r);
 
@@ -769,7 +769,7 @@ int CommandEditTag::RemoveTags(const ArgumentList &args, Environment *env) {
 //------------------------------------------------------------------------------
 
 
-ParameterList CommandListTags::GetParams() {
+ParameterList CommandListTags::GetParams() const {
   ParameterList r;
   InsertCommonParameters(&r);
   r.push_back(Parameter::Switch('x', "machine readable output"));
@@ -882,7 +882,7 @@ int CommandListTags::Main(const ArgumentList &args) {
 //------------------------------------------------------------------------------
 
 
-ParameterList CommandInfoTag::GetParams() {
+ParameterList CommandInfoTag::GetParams() const {
   ParameterList r;
   InsertCommonParameters(&r);
 
@@ -961,7 +961,7 @@ int CommandInfoTag::Main(const ArgumentList &args) {
 //------------------------------------------------------------------------------
 
 
-ParameterList CommandRollbackTag::GetParams() {
+ParameterList CommandRollbackTag::GetParams() const {
   ParameterList r;
   InsertCommonParameters(&r);
 
@@ -1104,7 +1104,7 @@ void CommandRollbackTag::PrintDeletedTagList(const TagList &tags) const {
 //------------------------------------------------------------------------------
 
 
-ParameterList CommandEmptyRecycleBin::GetParams() {
+ParameterList CommandEmptyRecycleBin::GetParams() const {
   ParameterList r;
   InsertCommonParameters(&r);
   return r;

--- a/cvmfs/swissknife_history.h
+++ b/cvmfs/swissknife_history.h
@@ -59,8 +59,6 @@ class CommandTag : public Command {
   };
 
 
-  void InsertCommonParameters(ParameterList *parameters);
-
   Environment* InitializeEnvironment(const ArgumentList &args,
                                      const bool read_write);
   bool CloseAndPublishHistory(Environment *environment);
@@ -107,12 +105,12 @@ class CommandTag : public Command {
  */
 class CommandEditTag : public CommandTag {
  public:
-  std::string GetName() { return "tag_edit"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "tag_edit"; }
+  virtual std::string GetDescription() const {
     return "Create a tag and/or remove tags.";
   }
 
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
  protected:
@@ -136,12 +134,12 @@ class CommandEditTag : public CommandTag {
 
 class CommandListTags : public CommandTag {
  public:
-  std::string GetName() { return "tag_list"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "tag_list"; }
+  virtual std::string GetDescription() const {
     return "List tags in the tag database.";
   }
 
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
  protected:
@@ -155,12 +153,12 @@ class CommandListTags : public CommandTag {
 
 class CommandInfoTag : public CommandTag {
  public:
-  std::string GetName() { return "tag_info"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "tag_info"; }
+  virtual std::string GetDescription() const {
     return "Obtain detailed information about a tag.";
   }
 
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
  protected:
@@ -174,12 +172,12 @@ class CommandInfoTag : public CommandTag {
 
 class CommandRollbackTag : public CommandTag {
  public:
-  std::string GetName() { return "tag_rollback"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "tag_rollback"; }
+  virtual std::string GetDescription() const {
     return "Rollback repository to a given tag.";
   }
 
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
  protected:
@@ -192,12 +190,12 @@ class CommandRollbackTag : public CommandTag {
 
 class CommandEmptyRecycleBin : public CommandTag {
  public:
-  std::string GetName() { return "tag_empty_bin"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "tag_empty_bin"; }
+  virtual std::string GetDescription() const {
     return "Empty the internal recycle bin of the history database.";
   }
 
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 };
 

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -42,7 +42,7 @@ bool CommandInfo::Exists(const string &repository, const string &file) const {
   }
 }
 
-ParameterList CommandInfo::GetParams() {
+ParameterList CommandInfo::GetParams() const {
   swissknife::ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository directory / url"));
   r.push_back(Parameter::Optional('u', "repository mount point"));

--- a/cvmfs/swissknife_info.h
+++ b/cvmfs/swissknife_info.h
@@ -14,13 +14,13 @@ namespace swissknife {
 class CommandInfo : public Command {
  public:
   ~CommandInfo() { }
-  std::string GetName() { return "info"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "info"; }
+  virtual std::string GetDescription() const {
     return "CernVM File System repository information retrieval\n"
       "This command reads the content of a .cvmfspublished file and exposes it "
       "to the user.";
   }
-  ParameterList GetParams();
+  ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
  protected:
@@ -30,9 +30,9 @@ class CommandInfo : public Command {
 class CommandVersion : public Command {
  public:
   ~CommandVersion() { }
-  std::string GetName()        { return "version";                         }
-  std::string GetDescription() { return "Prints the version of CernVM-FS"; }
-  ParameterList GetParams()    { return ParameterList();                   }
+  virtual std::string GetName()        const { return "version";                         }
+  virtual std::string GetDescription() const { return "Prints the version of CernVM-FS"; }
+  ParameterList GetParams() const { return ParameterList();                   }
   int Main(const ArgumentList &args);
 };
 

--- a/cvmfs/swissknife_info.h
+++ b/cvmfs/swissknife_info.h
@@ -30,9 +30,15 @@ class CommandInfo : public Command {
 class CommandVersion : public Command {
  public:
   ~CommandVersion() { }
-  virtual std::string GetName()        const { return "version";                         }
-  virtual std::string GetDescription() const { return "Prints the version of CernVM-FS"; }
-  ParameterList GetParams() const { return ParameterList();                   }
+  virtual std::string GetName()        const {
+    return "version";
+  }
+  virtual std::string GetDescription() const {
+    return "Prints the version of CernVM-FS";
+  }
+  ParameterList GetParams() const {
+    return ParameterList();
+  }
   int Main(const ArgumentList &args);
 };
 

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -23,26 +23,26 @@ bool CheckParams(const swissknife::CommandLease::Parameters& p) {
 namespace swissknife {
 
 enum LeaseError {
-  LEASE_SUCCESS = 0,
-  LEASE_UNUSED = 1,
-  LEASE_PARAM_ERROR = 2,
-  LEASE_CURL_INIT_ERROR = 3,
-  LEASE_FILE_OPEN_ERROR = 4,
+  LEASE_SUCCESS           = 0,
+  LEASE_UNUSED            = 1,
+  LEASE_PARAM_ERROR       = 2,
+  LEASE_CURL_INIT_ERROR   = 3,
+  LEASE_FILE_OPEN_ERROR   = 4,
   LEASE_FILE_DELETE_ERROR = 5,
-  LEASE_PARSE_ERROR = 6,
-  LEASE_CURL_REQ_ERROR = 7,
+  LEASE_PARSE_ERROR       = 6,
+  LEASE_CURL_REQ_ERROR    = 7,
 };
 
 CommandLease::~CommandLease() {
 }
 
 ParameterList CommandLease::GetParams() const {
-    ParameterList r;
-    r.push_back(Parameter::Mandatory('u', "repo service url"));
-    r.push_back(Parameter::Mandatory('a', "action (acquire or drop)"));
-    r.push_back(Parameter::Mandatory('n', "user name"));
-    r.push_back(Parameter::Mandatory('p', "lease path"));
-    return r;
+  ParameterList r;
+  r.push_back(Parameter::Mandatory('u', "repo service url"));
+  r.push_back(Parameter::Mandatory('a', "action (acquire or drop)"));
+  r.push_back(Parameter::Mandatory('n', "user name"));
+  r.push_back(Parameter::Mandatory('p', "lease path"));
+  return r;
 }
 
 int CommandLease::Main(const ArgumentList& args) {

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -1,0 +1,51 @@
+#include "swissknife_lease.h"
+
+#include "curl/curl.h"
+
+static bool CheckParams(const swissknife::CommandLease::Parameters& p) {
+  if (p.action != "acquire" && p.action != "drop") {
+    return false;
+  }
+
+  return true;
+}
+
+namespace swissknife {
+
+CommandLease::~CommandLease() {
+}
+
+ParameterList CommandLease::GetParams() const {
+    ParameterList r;
+    r.push_back(Parameter::Mandatory('u', "repo service url"));
+    r.push_back(Parameter::Mandatory('a', "action (acquire or drop)"));
+    r.push_back(Parameter::Mandatory('n', "user name"));
+    r.push_back(Parameter::Mandatory('p', "lease path"));
+    return r;
+}
+
+int CommandLease::Main(const ArgumentList& args) {
+  Parameters params;
+
+  params.repo_service_url = *(args.find('u')->second);
+  params.action = *(args.find('a')->second);
+  params.user_name = *(args.find('n')->second);
+  params.lease_path = *(args.find('p')->second);
+
+  if (!CheckParams(params)) return 2;
+
+  // Initialize curl
+  if (curl_global_init(CURL_GLOBAL_ALL)) {
+    return 1;
+  }
+
+  if (params.action == "acquire") {
+    // Acquire lease from repo services
+  } else if (params.action == "drop") {
+    // Drop the current lease
+  }
+
+  return 0;
+}
+
+}

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -1,11 +1,12 @@
 #include "swissknife_lease.h"
 
-#include "util/pointer.h"
-#include "json_document.h"
-#include "json.h"
+#include "swissknife_lease_curl.h"
+#include "swissknife_lease_json.h"
+
 #include "logging.h"
 
-#include "curl/curl.h"
+#include <fstream>
+#include <sstream>
 
 namespace {
 
@@ -15,102 +16,6 @@ bool CheckParams(const swissknife::CommandLease::Parameters& p) {
   }
 
   return true;
-}
-
-/*size_t SendCB(void *buffer, size_t size, size_t nmemb, void *userp) {
-}*/
-
-struct CurlBuffer {
-  std::string data;
-};
-
-size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp) {
-  CurlBuffer* my_buffer = (CurlBuffer*)userp;
-
-  if (size * nmemb < 1) {
-    return 0;
-  }
-
-  my_buffer->data = static_cast<char*>(buffer);
-
-  return my_buffer->data.size();
-}
-
-CURL* PrepareCurl() {
-  CURL* h_curl = curl_easy_init();
-
-  if (h_curl) {
-    curl_easy_setopt(h_curl, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(h_curl, CURLOPT_USERAGENT, "curl/7.47.0");
-    curl_easy_setopt(h_curl, CURLOPT_MAXREDIRS, 50L);
-    curl_easy_setopt(h_curl, CURLOPT_CUSTOMREQUEST, "POST");
-    curl_easy_setopt(h_curl, CURLOPT_TCP_KEEPALIVE, 1L);
-  }
-
-  return h_curl;
-}
-
-bool MakeAcquireReq(const std::string& user_name,
-                    const std::string& lease_fqdn,
-                    const std::string& repo_service_url,
-                    CurlBuffer& buffer) {
-  CURLcode ret = static_cast<CURLcode>(0);
-
-  CURL* h_curl = PrepareCurl();
-  if (h_curl) {
-    // Prepare payload
-    std::string payload = "{\"user\" : \"" + user_name + "\", \"path\" : \"" + lease_fqdn + "\"}";
-
-    // Make request to acquire lease from repo services
-    curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/api/leases").c_str());
-    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.length()));
-    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
-    curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
-    curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, &buffer);
-
-    ret = curl_easy_perform(h_curl);
-
-    curl_easy_cleanup(h_curl);
-    h_curl = NULL;
-
-    return ! ret;
-  }
-
-  return false;
-}
-
-bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token) {
-  //Parse reply
-  UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
-  if (reply->IsValid()) {
-    JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
-    if (result != NULL) {
-      std::string status = result->string_value;
-      if (status == "ok") {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
-        JSON* token = JsonDocument::SearchInObject(reply->root(), "session_token", JSON_STRING);
-        if (token != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s", token->string_value);
-          session_token = token->string_value;
-          return true;
-        }
-      } else if (status == "path_busy") {
-        JSON* time_remaining = JsonDocument::SearchInObject(reply->root(), "time_remaining", JSON_INT);
-        if (time_remaining != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d", time_remaining->int_value);
-        }
-      } else if (status == "error") {
-        JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
-        if (reason != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
-        }
-      } else {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
-      }
-    }
-  }
-
-  return false;
 }
 
 }
@@ -149,16 +54,15 @@ int CommandLease::Main(const ArgumentList& args) {
   int ret = 0;
   if (params.action == "acquire") {
     CurlBuffer buffer;
-    if (MakeAcquireReq(params.user_name, params.lease_fqdn, params.repo_service_url, buffer)) {
+    if (MakeAcquireRequest(params.user_name, params.lease_fqdn, params.repo_service_url, buffer)) {
       std::string session_token;
       if (ParseAcquireReply(buffer, session_token)) {
         // Save session token to /var/spool/cvmfs/<REPO_NAME>
         // TODO: Is there a special way to access the scratch directory?
         std::string token_file_name = "/var/spool/cvmfs/" + params.lease_fqdn + "/session_token";
-        FILE* token_file = std::fopen(token_file_name.c_str(), "w");
-        if (token_file != NULL) {
-          std::fprintf(token_file, "%s", session_token.c_str());
-          std::fclose(token_file);
+        std::ofstream token_file(token_file_name.c_str(), std::ios_base::out);
+        if (token_file.is_open()) {
+          token_file << session_token;
         } else {
           LogCvmfs(kLogCvmfs, kLogStderr, "Error opening file: %s", std::strerror(errno));
           ret = 4;
@@ -170,7 +74,39 @@ int CommandLease::Main(const ArgumentList& args) {
       ret = 6;
     }
   } else if (params.action == "drop") {
-    // Drop the current lease
+    // Try to read session token from repository scratch directory
+    std::string session_token;
+    std::string token_file_name = "/var/spool/cvmfs/" + params.lease_fqdn + "/session_token";
+    std::ifstream token_file(token_file_name.c_str(), std::ios_base::in);
+    bool success = false;
+    if (token_file.is_open()) {
+      std::stringstream sstr;
+      sstr << token_file.rdbuf();
+      session_token = sstr.str();
+      LogCvmfs(kLogCvmfs, kLogStderr, "Read session token from file: %s", session_token.c_str());
+
+      CurlBuffer buffer;
+      if (MakeDeleteRequest(session_token, params.repo_service_url, buffer)) {
+        if (ParseDropReply(buffer)) {
+          success = true;
+        } else {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Could not drop active lease");
+          ret = 7;
+        }
+      } else {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Error making DELETE request");
+        ret = 8;
+      }
+    } else {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Error reading session token from file");
+      ret = 9;
+    }
+
+    token_file.close();
+    if (success && std::remove(token_file_name.c_str())) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Error deleting session token file");
+      ret = 10;
+    }
   }
 
   return ret;

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -1,13 +1,41 @@
 #include "swissknife_lease.h"
 
+#include "util/pointer.h"
+#include "json_document.h"
+#include "json.h"
+#include "logging.h"
+
 #include "curl/curl.h"
 
-static bool CheckParams(const swissknife::CommandLease::Parameters& p) {
+namespace {
+
+bool CheckParams(const swissknife::CommandLease::Parameters& p) {
   if (p.action != "acquire" && p.action != "drop") {
     return false;
   }
 
   return true;
+}
+
+/*size_t SendCB(void *buffer, size_t size, size_t nmemb, void *userp) {
+}*/
+
+struct CurlBuffer {
+  std::string data;
+};
+
+size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp) {
+  CurlBuffer* my_buffer = (CurlBuffer*)userp;
+
+  if (size * nmemb < 1) {
+    return 0;
+  }
+
+  my_buffer->data = static_cast<char*>(buffer);
+
+  return my_buffer->data.size();
+}
+
 }
 
 namespace swissknife {
@@ -39,13 +67,82 @@ int CommandLease::Main(const ArgumentList& args) {
     return 1;
   }
 
-  if (params.action == "acquire") {
-    // Acquire lease from repo services
-  } else if (params.action == "drop") {
-    // Drop the current lease
+  CURL* h_curl = curl_easy_init();
+  CURLcode ret = static_cast<CURLcode>(0);
+  if (h_curl) {
+    if (params.action == "acquire") {
+      // Prepare payload
+      std::string payload = "{\"user\" : \"" + params.user_name + "\", \"path\" : \"" + params.lease_path + "\"}";
+
+      // Make request to acquire lease from repo services
+      curl_easy_setopt(h_curl, CURLOPT_URL, (params.repo_service_url + "/api/leases").c_str());
+      curl_easy_setopt(h_curl, CURLOPT_NOPROGRESS, 1L);
+      curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
+      curl_easy_setopt(h_curl,
+                       CURLOPT_POSTFIELDSIZE_LARGE,
+                       static_cast<curl_off_t>(payload.length()));
+      curl_easy_setopt(h_curl, CURLOPT_USERAGENT, "curl/7.47.0");
+      curl_easy_setopt(h_curl, CURLOPT_MAXREDIRS, 50L);
+      curl_easy_setopt(h_curl, CURLOPT_CUSTOMREQUEST, "POST");
+      curl_easy_setopt(h_curl, CURLOPT_TCP_KEEPALIVE, 1L);
+
+      CurlBuffer buffer;
+
+      curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
+      curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, &buffer);
+
+      ret = curl_easy_perform(h_curl);
+
+      curl_easy_cleanup(h_curl);
+      h_curl = NULL;
+
+      //Parse reply
+      UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
+      if (reply->IsValid()) {
+        JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+        if (result != NULL) {
+          std::string status = result->string_value;
+          if (status == "ok") {
+            LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+            JSON* token = JsonDocument::SearchInObject(reply->root(), "session_token", JSON_STRING);
+            if (token != NULL) {
+              LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s", token->string_value);
+              std::string session_token = token->string_value;
+              // Save session token to /var/spool/cvmfs/<REPO_NAME>
+              // TODO: Is there a special way to access the scratch directory?
+              std::string token_file_name = "/var/spool/cvmfs/" + params.lease_path + "/session_token";
+              FILE* token_file = std::fopen(token_file_name.c_str(), "w");
+              if (token_file != NULL) {
+                std::fprintf(token_file, "%s", session_token.c_str());
+                std::fclose(token_file);
+              } else {
+                LogCvmfs(kLogCvmfs, kLogStderr, "Error opening file: %s", std::strerror(errno));
+              }
+            }
+          } else if (status == "path_busy") {
+            JSON* time_remaining = JsonDocument::SearchInObject(reply->root(), "time_remaining", JSON_INT);
+            if (time_remaining != NULL) {
+              LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d", time_remaining->int_value);
+            }
+          } else if (status == "error") {
+            JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+            if (reason != NULL) {
+              LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+            }
+          } else {
+            LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
+          }
+        }
+      }
+
+    } else if (params.action == "drop") {
+      // Drop the current lease
+    }
+  } else {
+    return 1;
   }
 
-  return 0;
+  return ret;
 }
 
 }

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -36,6 +36,83 @@ size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp) {
   return my_buffer->data.size();
 }
 
+CURL* PrepareCurl() {
+  CURL* h_curl = curl_easy_init();
+
+  if (h_curl) {
+    curl_easy_setopt(h_curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(h_curl, CURLOPT_USERAGENT, "curl/7.47.0");
+    curl_easy_setopt(h_curl, CURLOPT_MAXREDIRS, 50L);
+    curl_easy_setopt(h_curl, CURLOPT_CUSTOMREQUEST, "POST");
+    curl_easy_setopt(h_curl, CURLOPT_TCP_KEEPALIVE, 1L);
+  }
+
+  return h_curl;
+}
+
+bool MakeAcquireReq(const std::string& user_name,
+                    const std::string& lease_fqdn,
+                    const std::string& repo_service_url,
+                    CurlBuffer& buffer) {
+  CURLcode ret = static_cast<CURLcode>(0);
+
+  CURL* h_curl = PrepareCurl();
+  if (h_curl) {
+    // Prepare payload
+    std::string payload = "{\"user\" : \"" + user_name + "\", \"path\" : \"" + lease_fqdn + "\"}";
+
+    // Make request to acquire lease from repo services
+    curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/api/leases").c_str());
+    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.length()));
+    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
+    curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, &buffer);
+
+    ret = curl_easy_perform(h_curl);
+
+    curl_easy_cleanup(h_curl);
+    h_curl = NULL;
+
+    return ! ret;
+  }
+
+  return false;
+}
+
+bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token) {
+  //Parse reply
+  UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
+  if (reply->IsValid()) {
+    JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+    if (result != NULL) {
+      std::string status = result->string_value;
+      if (status == "ok") {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+        JSON* token = JsonDocument::SearchInObject(reply->root(), "session_token", JSON_STRING);
+        if (token != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s", token->string_value);
+          session_token = token->string_value;
+          return true;
+        }
+      } else if (status == "path_busy") {
+        JSON* time_remaining = JsonDocument::SearchInObject(reply->root(), "time_remaining", JSON_INT);
+        if (time_remaining != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d", time_remaining->int_value);
+        }
+      } else if (status == "error") {
+        JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+        if (reason != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+        }
+      } else {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
+      }
+    }
+  }
+
+  return false;
+}
+
 }
 
 namespace swissknife {
@@ -58,88 +135,42 @@ int CommandLease::Main(const ArgumentList& args) {
   params.repo_service_url = *(args.find('u')->second);
   params.action = *(args.find('a')->second);
   params.user_name = *(args.find('n')->second);
-  params.lease_path = *(args.find('p')->second);
+  params.lease_fqdn = *(args.find('p')->second);
 
-  if (!CheckParams(params)) return 2;
+  if (!CheckParams(params)) {
+    return 2;
+  }
 
   // Initialize curl
   if (curl_global_init(CURL_GLOBAL_ALL)) {
-    return 1;
+    return 3;
   }
 
-  CURL* h_curl = curl_easy_init();
-  CURLcode ret = static_cast<CURLcode>(0);
-  if (h_curl) {
-    if (params.action == "acquire") {
-      // Prepare payload
-      std::string payload = "{\"user\" : \"" + params.user_name + "\", \"path\" : \"" + params.lease_path + "\"}";
-
-      // Make request to acquire lease from repo services
-      curl_easy_setopt(h_curl, CURLOPT_URL, (params.repo_service_url + "/api/leases").c_str());
-      curl_easy_setopt(h_curl, CURLOPT_NOPROGRESS, 1L);
-      curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
-      curl_easy_setopt(h_curl,
-                       CURLOPT_POSTFIELDSIZE_LARGE,
-                       static_cast<curl_off_t>(payload.length()));
-      curl_easy_setopt(h_curl, CURLOPT_USERAGENT, "curl/7.47.0");
-      curl_easy_setopt(h_curl, CURLOPT_MAXREDIRS, 50L);
-      curl_easy_setopt(h_curl, CURLOPT_CUSTOMREQUEST, "POST");
-      curl_easy_setopt(h_curl, CURLOPT_TCP_KEEPALIVE, 1L);
-
-      CurlBuffer buffer;
-
-      curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
-      curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, &buffer);
-
-      ret = curl_easy_perform(h_curl);
-
-      curl_easy_cleanup(h_curl);
-      h_curl = NULL;
-
-      //Parse reply
-      UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
-      if (reply->IsValid()) {
-        JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
-        if (result != NULL) {
-          std::string status = result->string_value;
-          if (status == "ok") {
-            LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
-            JSON* token = JsonDocument::SearchInObject(reply->root(), "session_token", JSON_STRING);
-            if (token != NULL) {
-              LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s", token->string_value);
-              std::string session_token = token->string_value;
-              // Save session token to /var/spool/cvmfs/<REPO_NAME>
-              // TODO: Is there a special way to access the scratch directory?
-              std::string token_file_name = "/var/spool/cvmfs/" + params.lease_path + "/session_token";
-              FILE* token_file = std::fopen(token_file_name.c_str(), "w");
-              if (token_file != NULL) {
-                std::fprintf(token_file, "%s", session_token.c_str());
-                std::fclose(token_file);
-              } else {
-                LogCvmfs(kLogCvmfs, kLogStderr, "Error opening file: %s", std::strerror(errno));
-              }
-            }
-          } else if (status == "path_busy") {
-            JSON* time_remaining = JsonDocument::SearchInObject(reply->root(), "time_remaining", JSON_INT);
-            if (time_remaining != NULL) {
-              LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d", time_remaining->int_value);
-            }
-          } else if (status == "error") {
-            JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
-            if (reason != NULL) {
-              LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
-            }
-          } else {
-            LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
-          }
+  int ret = 0;
+  if (params.action == "acquire") {
+    CurlBuffer buffer;
+    if (MakeAcquireReq(params.user_name, params.lease_fqdn, params.repo_service_url, buffer)) {
+      std::string session_token;
+      if (ParseAcquireReply(buffer, session_token)) {
+        // Save session token to /var/spool/cvmfs/<REPO_NAME>
+        // TODO: Is there a special way to access the scratch directory?
+        std::string token_file_name = "/var/spool/cvmfs/" + params.lease_fqdn + "/session_token";
+        FILE* token_file = std::fopen(token_file_name.c_str(), "w");
+        if (token_file != NULL) {
+          std::fprintf(token_file, "%s", session_token.c_str());
+          std::fclose(token_file);
+        } else {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Error opening file: %s", std::strerror(errno));
+          ret = 4;
         }
+      } else {
+        ret = 5;
       }
-
-    } else if (params.action == "drop") {
-      // Drop the current lease
+    } else {
+      ret = 6;
     }
-  } else {
-    return 1;
+  } else if (params.action == "drop") {
+    // Drop the current lease
   }
 
   return ret;

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -1,12 +1,16 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
 #include "swissknife_lease.h"
+
+#include <fstream>
+#include <sstream>
 
 #include "swissknife_lease_curl.h"
 #include "swissknife_lease_json.h"
 
 #include "logging.h"
-
-#include <fstream>
-#include <sstream>
 
 namespace {
 
@@ -18,7 +22,7 @@ bool CheckParams(const swissknife::CommandLease::Parameters& p) {
   return true;
 }
 
-}
+}  // namespace
 
 namespace swissknife {
 
@@ -65,17 +69,24 @@ int CommandLease::Main(const ArgumentList& args) {
   LeaseError ret = LEASE_SUCCESS;
   if (params.action == "acquire") {
     CurlBuffer buffer;
-    if (MakeAcquireRequest(params.user_name, params.lease_fqdn, params.repo_service_url, buffer)) {
+    if (MakeAcquireRequest(params.user_name,
+                           params.lease_fqdn,
+                           params.repo_service_url,
+                           &buffer)) {
       std::string session_token;
-      if (ParseAcquireReply(buffer, session_token)) {
+      if (ParseAcquireReply(buffer, &session_token)) {
         // Save session token to /var/spool/cvmfs/<REPO_NAME>
-        // TODO: Is there a special way to access the scratch directory?
-        std::string token_file_name = "/var/spool/cvmfs/" + params.lease_fqdn + "/session_token";
+        // TODO(radu): Is there a special way to access the scratch directory?
+        std::string token_file_name = "/var/spool/cvmfs/" +
+            params.lease_fqdn + "/session_token";
         std::ofstream token_file(token_file_name.c_str(), std::ios_base::out);
         if (token_file.is_open()) {
           token_file << session_token;
         } else {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Error opening file: %s", std::strerror(errno));
+          LogCvmfs(kLogCvmfs,
+                   kLogStderr,
+                   "Error opening file: %s",
+                   std::strerror(errno));
           ret = LEASE_FILE_OPEN_ERROR;
         }
       } else {
@@ -87,17 +98,21 @@ int CommandLease::Main(const ArgumentList& args) {
   } else if (params.action == "drop") {
     // Try to read session token from repository scratch directory
     std::string session_token;
-    std::string token_file_name = "/var/spool/cvmfs/" + params.lease_fqdn + "/session_token";
+    std::string token_file_name = "/var/spool/cvmfs/" +
+        params.lease_fqdn + "/session_token";
     std::ifstream token_file(token_file_name.c_str(), std::ios_base::in);
     bool success = false;
     if (token_file.is_open()) {
       std::stringstream sstr;
       sstr << token_file.rdbuf();
       session_token = sstr.str();
-      LogCvmfs(kLogCvmfs, kLogStderr, "Read session token from file: %s", session_token.c_str());
+      LogCvmfs(kLogCvmfs,
+               kLogStderr,
+               "Read session token from file: %s",
+               session_token.c_str());
 
       CurlBuffer buffer;
-      if (MakeDeleteRequest(session_token, params.repo_service_url, buffer)) {
+      if (MakeDeleteRequest(session_token, params.repo_service_url, &buffer)) {
         if (ParseDropReply(buffer)) {
           success = true;
         } else {
@@ -123,4 +138,4 @@ int CommandLease::Main(const ArgumentList& args) {
   return ret;
 }
 
-}
+}  // namespace swissknife

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -27,13 +27,13 @@ public:
         repo_service_url(""),
         action(""),
         user_name(""),
-        lease_path("")
+        lease_fqdn("")
     {}
 
     std::string repo_service_url;
     std::string action;
     std::string user_name;
-    std::string lease_path;
+    std::string lease_fqdn;
   };
 };
 

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -1,0 +1,42 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_SWISSKNIFE_LEASE_H_
+#define CVMFS_SWISSKNIFE_LEASE_H_
+
+#include <string>
+
+#include "swissknife.h"
+
+namespace swissknife {
+
+class CommandLease : public Command {
+public:
+  virtual ~CommandLease();
+
+  virtual std::string GetName() const { return "lease"; }
+  virtual std::string GetDescription() const { return "Acquire a lease on a repository sub-path"; }
+
+  virtual ParameterList GetParams() const;
+
+  virtual int Main(const ArgumentList &args);
+
+  struct Parameters {
+    Parameters() :
+        repo_service_url(""),
+        action(""),
+        user_name(""),
+        lease_path("")
+    {}
+
+    std::string repo_service_url;
+    std::string action;
+    std::string user_name;
+    std::string lease_path;
+  };
+};
+
+}
+
+#endif  // CVMFS_SWISSKNIFE_LEASE_H_

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -12,11 +12,13 @@
 namespace swissknife {
 
 class CommandLease : public Command {
-public:
+ public:
   virtual ~CommandLease();
 
   virtual std::string GetName() const { return "lease"; }
-  virtual std::string GetDescription() const { return "Acquire a lease on a repository sub-path"; }
+  virtual std::string GetDescription() const {
+    return "Acquire a lease on a repository sub-path";
+  }
 
   virtual ParameterList GetParams() const;
 
@@ -37,6 +39,6 @@ public:
   };
 };
 
-}
+}  // namespace swissknife
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_H_

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "swissknife_lease_curl.h"
+
+#include <iostream>
+
+size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp) {
+  CurlBuffer* my_buffer = (CurlBuffer*)userp;
+
+  if (size * nmemb < 1) {
+    return 0;
+  }
+
+  my_buffer->data = static_cast<char*>(buffer);
+
+  return my_buffer->data.size();
+}
+
+CURL* PrepareCurl(const char* method) {
+  CURL* h_curl = curl_easy_init();
+
+  if (h_curl) {
+    curl_easy_setopt(h_curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(h_curl, CURLOPT_USERAGENT, "curl/7.47.0");
+    curl_easy_setopt(h_curl, CURLOPT_MAXREDIRS, 50L);
+    curl_easy_setopt(h_curl, CURLOPT_CUSTOMREQUEST, method);
+    curl_easy_setopt(h_curl, CURLOPT_TCP_KEEPALIVE, 1L);
+  }
+
+  return h_curl;
+}
+
+bool MakeAcquireRequest(const std::string& user_name,
+                        const std::string& lease_fqdn,
+                        const std::string& repo_service_url,
+                        CurlBuffer& buffer) {
+  CURLcode ret = static_cast<CURLcode>(0);
+
+  CURL* h_curl = PrepareCurl("POST");
+  if (h_curl) {
+    // Prepare payload
+    std::string payload = "{\"user\" : \"" + user_name + "\", \"path\" : \"" + lease_fqdn + "\"}";
+
+    // Make request to acquire lease from repo services
+    curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/api/leases").c_str());
+    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.length()));
+    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
+    curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, &buffer);
+
+    ret = curl_easy_perform(h_curl);
+
+    curl_easy_cleanup(h_curl);
+    h_curl = NULL;
+
+    return ! ret;
+  }
+
+  return false;
+}
+
+bool MakeDeleteRequest(const std::string& session_token,
+                     const std::string& repo_service_url,
+                     CurlBuffer& buffer) {
+  CURLcode ret = static_cast<CURLcode>(0);
+
+  CURL* h_curl = PrepareCurl("DELETE");
+  if (h_curl) {
+
+    curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/api/leases/" + session_token).c_str());
+    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(0));
+    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, 0);
+    curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
+    curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, &buffer);
+
+    ret = curl_easy_perform(h_curl);
+
+    curl_easy_cleanup(h_curl);
+    h_curl = NULL;
+
+    std::cout << "CURL ret: " << ret << std::endl;
+    return ! ret;
+  }
+
+  return false;
+}
+
+

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -80,7 +80,6 @@ bool MakeDeleteRequest(const std::string& session_token,
     curl_easy_cleanup(h_curl);
     h_curl = NULL;
 
-    std::cout << "CURL ret: " << ret << std::endl;
     return ! ret;
   }
 

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -62,8 +62,8 @@ bool MakeAcquireRequest(const std::string& user_name,
 }
 
 bool MakeDeleteRequest(const std::string& session_token,
-                     const std::string& repo_service_url,
-                     CurlBuffer& buffer) {
+                       const std::string& repo_service_url,
+                       CurlBuffer& buffer) {
   CURLcode ret = static_cast<CURLcode>(0);
 
   CURL* h_curl = PrepareCurl("DELETE");

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_SWISSKNIFE_LEASE_CURL_H_
+#define CVMFS_SWISSKNIFE_LEASE_CURL_H_
+
+#include "curl/curl.h"
+
+#include <string>
+
+struct CurlBuffer {
+  std::string data;
+};
+
+size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp);
+
+CURL* PrepareCurl(const char* method);
+
+bool MakeAcquireRequest(const std::string& user_name,
+                          const std::string& lease_fqdn,
+                          const std::string& repo_service_url,
+                          CurlBuffer& buffer);
+
+bool MakeDeleteRequest(const std::string& session_token,
+                         const std::string& repo_service_url,
+                         CurlBuffer& buffer);
+
+#endif  // CVMFS_SWISSKNIFE_LEASE_CURL_H_

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -5,9 +5,9 @@
 #ifndef CVMFS_SWISSKNIFE_LEASE_CURL_H_
 #define CVMFS_SWISSKNIFE_LEASE_CURL_H_
 
-#include "curl/curl.h"
-
 #include <string>
+
+#include "curl/curl.h"
 
 struct CurlBuffer {
   std::string data;
@@ -20,10 +20,10 @@ CURL* PrepareCurl(const char* method);
 bool MakeAcquireRequest(const std::string& user_name,
                           const std::string& lease_fqdn,
                           const std::string& repo_service_url,
-                          CurlBuffer& buffer);
+                          CurlBuffer* buffer);
 
 bool MakeDeleteRequest(const std::string& session_token,
                          const std::string& repo_service_url,
-                         CurlBuffer& buffer);
+                         CurlBuffer* buffer);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_CURL_H_

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -4,39 +4,55 @@
 
 #include "swissknife_lease_json.h"
 
-#include "util/pointer.h"
-#include "json_document.h"
 #include "json.h"
+#include "json_document.h"
+#include "util/pointer.h"
 
 #include "logging.h"
 
-bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token) {
-  //Parse reply
+bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token) {
   UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
   if (reply->IsValid()) {
-    JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+    JSON* result = JsonDocument::SearchInObject(reply->root(),
+                                                "status",
+                                                JSON_STRING);
     if (result != NULL) {
       std::string status = result->string_value;
       if (status == "ok") {
         LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
-        JSON* token = JsonDocument::SearchInObject(reply->root(), "session_token", JSON_STRING);
+        JSON* token = JsonDocument::SearchInObject(reply->root(),
+                                                   "session_token",
+                                                   JSON_STRING);
         if (token != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s", token->string_value);
-          session_token = token->string_value;
+          LogCvmfs(kLogCvmfs,
+                   kLogStderr,
+                   "Session token: %s",
+                   token->string_value);
+          *session_token = token->string_value;
           return true;
         }
       } else if (status == "path_busy") {
-        JSON* time_remaining = JsonDocument::SearchInObject(reply->root(), "time_remaining", JSON_INT);
+        JSON* time_remaining = JsonDocument::SearchInObject(reply->root(),
+                                                            "time_remaining",
+                                                            JSON_INT);
         if (time_remaining != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d", time_remaining->int_value);
+          LogCvmfs(kLogCvmfs,
+                   kLogStderr,
+                   "Path busy. Time remaining = %d",
+                   time_remaining->int_value);
         }
       } else if (status == "error") {
-        JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+        JSON* reason = JsonDocument::SearchInObject(reply->root(),
+                                                    "reason",
+                                                    JSON_STRING);
         if (reason != NULL) {
           LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
         }
       } else {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
+        LogCvmfs(kLogCvmfs,
+                 kLogStderr,
+                 "Unknown reply. Status: %s",
+                 status.c_str());
       }
     }
   }
@@ -47,7 +63,9 @@ bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token) {
 bool ParseDropReply(const CurlBuffer& buffer) {
   UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
   if (reply->IsValid()) {
-    JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+    JSON* result = JsonDocument::SearchInObject(reply->root(),
+                                                "status",
+                                                JSON_STRING);
     if (result != NULL) {
       std::string status = result->string_value;
       if (status == "ok") {
@@ -56,12 +74,17 @@ bool ParseDropReply(const CurlBuffer& buffer) {
       } else if (status == "invalid_token") {
         LogCvmfs(kLogCvmfs, kLogStderr, "Error: invalid session token");
       } else if (status == "error") {
-        JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+        JSON* reason = JsonDocument::SearchInObject(reply->root(),
+                                                    "reason",
+                                                    JSON_STRING);
         if (reason != NULL) {
           LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
         }
       } else {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
+        LogCvmfs(kLogCvmfs,
+                 kLogStderr,
+                 "Unknown reply. Status: %s",
+                 status.c_str());
       }
     }
   }

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -1,0 +1,71 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "swissknife_lease_json.h"
+
+#include "util/pointer.h"
+#include "json_document.h"
+#include "json.h"
+
+#include "logging.h"
+
+bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token) {
+  //Parse reply
+  UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
+  if (reply->IsValid()) {
+    JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+    if (result != NULL) {
+      std::string status = result->string_value;
+      if (status == "ok") {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+        JSON* token = JsonDocument::SearchInObject(reply->root(), "session_token", JSON_STRING);
+        if (token != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s", token->string_value);
+          session_token = token->string_value;
+          return true;
+        }
+      } else if (status == "path_busy") {
+        JSON* time_remaining = JsonDocument::SearchInObject(reply->root(), "time_remaining", JSON_INT);
+        if (time_remaining != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d", time_remaining->int_value);
+        }
+      } else if (status == "error") {
+        JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+        if (reason != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+        }
+      } else {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
+      }
+    }
+  }
+
+  return false;
+}
+
+bool ParseDropReply(const CurlBuffer& buffer) {
+  UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
+  if (reply->IsValid()) {
+    JSON* result = JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+    if (result != NULL) {
+      std::string status = result->string_value;
+      if (status == "ok") {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+        return true;
+      } else if (status == "invalid_token") {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Error: invalid session token");
+      } else if (status == "error") {
+        JSON* reason = JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+        if (reason != NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+        }
+      } else {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s", status.c_str());
+      }
+    }
+  }
+
+  return false;
+}
+

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -1,0 +1,13 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_SWISSKNIFE_LEASE_JSON_H_
+#define CVMFS_SWISSKNIFE_LEASE_JSON_H_
+
+#include "swissknife_lease_curl.h"
+
+bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token);
+bool ParseDropReply(const CurlBuffer& buffer);
+
+#endif  // CVMFS_SWISSKNIFE_LEASE_JSON_H_

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -7,7 +7,9 @@
 
 #include "swissknife_lease_curl.h"
 
-bool ParseAcquireReply(const CurlBuffer& buffer, std::string& session_token);
+#include <string>
+
+bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token);
 bool ParseDropReply(const CurlBuffer& buffer);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_JSON_H_

--- a/cvmfs/swissknife_letter.h
+++ b/cvmfs/swissknife_letter.h
@@ -14,11 +14,11 @@ namespace swissknife {
 class CommandLetter : public Command {
  public:
   ~CommandLetter() { }
-  std::string GetName() { return "letter"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "letter"; }
+  virtual std::string GetDescription() const {
     return "Signs arbitrary text with the repository certificate.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Switch('s', "sign text"));
     r.push_back(Parameter::Optional('a', "hash algorithm"));

--- a/cvmfs/swissknife_lsrepo.cc
+++ b/cvmfs/swissknife_lsrepo.cc
@@ -14,7 +14,7 @@ CommandListCatalogs::CommandListCatalogs() :
   print_entries_(false) {}
 
 
-ParameterList CommandListCatalogs::GetParams() {
+ParameterList CommandListCatalogs::GetParams() const {
   ParameterList r;
   r.push_back(Parameter::Mandatory(
               'r', "repository URL (absolute local path or remote URL)"));

--- a/cvmfs/swissknife_lsrepo.h
+++ b/cvmfs/swissknife_lsrepo.h
@@ -22,13 +22,13 @@ class CommandListCatalogs : public Command {
  public:
   CommandListCatalogs();
   ~CommandListCatalogs() { }
-  std::string GetName() { return "lsrepo"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "lsrepo"; }
+  virtual std::string GetDescription() const {
     return "CernVM File System Repository Traversal\n"
       "This command lists the nested catalog tree that builds up a "
       "cvmfs repository structure.";
   }
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
 
   int Main(const ArgumentList &args);
 

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -24,6 +24,7 @@
 #include "swissknife_sign.h"
 #include "swissknife_sync.h"
 #include "swissknife_zpipe.h"
+#include "swissknife_lease.h"
 
 
 using namespace std;  // NOLINT
@@ -92,6 +93,7 @@ int main(int argc, char **argv) {
   command_list.push_back(new swissknife::CommandScrub());
   command_list.push_back(new swissknife::CommandGc());
   command_list.push_back(new swissknife::CommandReconstructReflog());
+  command_list.push_back(new swissknife::CommandLease());
 
   if (argc < 2) {
     Usage();

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -15,6 +15,7 @@
 #include "swissknife_hash.h"
 #include "swissknife_history.h"
 #include "swissknife_info.h"
+#include "swissknife_lease.h"
 #include "swissknife_letter.h"
 #include "swissknife_lsrepo.h"
 #include "swissknife_migrate.h"
@@ -24,7 +25,6 @@
 #include "swissknife_sign.h"
 #include "swissknife_sync.h"
 #include "swissknife_zpipe.h"
-#include "swissknife_lease.h"
 
 
 using namespace std;  // NOLINT

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -32,7 +32,7 @@ CommandMigrate::CommandMigrate() :
 }
 
 
-ParameterList CommandMigrate::GetParams() {
+ParameterList CommandMigrate::GetParams() const {
   ParameterList r;
   r.push_back(Parameter::Mandatory('v',
     "migration base version ( 2.0.x | 2.1.7 | chown | hardlink )"));

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -275,12 +275,12 @@ class CommandMigrate : public Command {
  public:
   CommandMigrate();
   ~CommandMigrate() { }
-  std::string GetName() { return "migrate"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "migrate"; }
+  virtual std::string GetDescription() const {
     return "CernVM-FS catalog repository migration \n"
       "This command migrates the whole catalog structure of a given repository";
   }
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
 
   int Main(const ArgumentList &args);
 

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -22,11 +22,11 @@ namespace swissknife {
 class CommandPull : public Command {
  public:
   ~CommandPull() { }
-  std::string GetName() { return "pull"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "pull"; }
+  virtual std::string GetDescription() const {
     return "Makes a Stratum 1 replica of a Stratum 0 repository.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('u', "repository url"));
     r.push_back(Parameter::Mandatory('m', "repository name"));

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -58,7 +58,7 @@ class RootChainWalker {
 };
 
 
-ParameterList CommandReconstructReflog::GetParams() {
+ParameterList CommandReconstructReflog::GetParams() const {
   ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository url"));
   r.push_back(Parameter::Mandatory('u', "spooler definition string"));

--- a/cvmfs/swissknife_reflog.h
+++ b/cvmfs/swissknife_reflog.h
@@ -18,12 +18,12 @@ namespace swissknife {
 
 class CommandReconstructReflog : public Command {
  public:
-  std::string GetName() { return "reconstruct_reflog"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "reconstruct_reflog"; }
+  virtual std::string GetDescription() const {
     return "Bootstraps a Reference Log from Catalog and History chains. This "
            "is used for both legacy repository migration and repairs.";
   }
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
  protected:

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -85,7 +85,7 @@ tbb::task* CommandScrub::StoredFileScrubbingTask::execute() {
 
 
 
-swissknife::ParameterList CommandScrub::GetParams() {
+swissknife::ParameterList CommandScrub::GetParams() const {
   swissknife::ParameterList r;
   r.push_back(Parameter::Mandatory('r', "repository directory"));
   r.push_back(Parameter::Switch('m', "machine readable output"));

--- a/cvmfs/swissknife_scrub.h
+++ b/cvmfs/swissknife_scrub.h
@@ -74,13 +74,13 @@ class CommandScrub : public Command {
  public:
   CommandScrub();
   ~CommandScrub();
-  std::string GetName() { return "scrub"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "scrub"; }
+  virtual std::string GetDescription() const {
     return "CernVM File System repository file storage checker. Finds silent "
            "disk corruptions by recomputing all file content checksums in the "
            "backend file storage.";
   }
-  ParameterList GetParams();
+  virtual ParameterList GetParams() const;
   int Main(const ArgumentList &args);
 
 

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -20,11 +20,11 @@ namespace swissknife {
 class CommandSign : public Command {
  public:
   ~CommandSign() { }
-  std::string GetName() { return "sign"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "sign"; }
+  virtual std::string GetDescription() const {
     return "Adds a signature to the repository manifest.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('m', "manifest file"));
     r.push_back(Parameter::Mandatory('u', "repository URL"));

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -94,11 +94,11 @@ namespace swissknife {
 class CommandCreate : public Command {
  public:
   ~CommandCreate() { }
-  std::string GetName() { return "create"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "create"; }
+  virtual std::string GetDescription() const {
     return "Bootstraps a fresh repository.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('o', "manifest output file"));
     r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
@@ -123,11 +123,11 @@ class CommandCreate : public Command {
 class CommandUpload : public Command {
  public:
   ~CommandUpload() { }
-  std::string GetName() { return "upload"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "upload"; }
+  virtual std::string GetDescription() const {
     return "Uploads a local file to the repository.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('i', "local file"));
     r.push_back(Parameter::Mandatory('o', "destination path"));
@@ -142,11 +142,11 @@ class CommandUpload : public Command {
 class CommandPeek : public Command {
  public:
   ~CommandPeek() { }
-  std::string GetName() { return "peek"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "peek"; }
+  virtual std::string GetDescription() const {
     return "Checks whether a file exists in the repository.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('d', "destination path"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
@@ -159,11 +159,11 @@ class CommandPeek : public Command {
 class CommandRemove : public Command {
  public:
   ~CommandRemove() { }
-  std::string GetName() { return "remove"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "remove"; }
+  virtual std::string GetDescription() const {
     return "Removes a file in the repository storage.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('o', "path to file"));
     r.push_back(Parameter::Mandatory('r', "spooler definition"));
@@ -177,11 +177,11 @@ class CommandApplyDirtab : public Command {
  public:
   CommandApplyDirtab() : verbose_(false) { }
   ~CommandApplyDirtab() { }
-  std::string GetName() { return "dirtab"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "dirtab"; }
+  virtual std::string GetDescription() const {
     return "Parses the dirtab file and produces nested catalog markers.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('d', "path to dirtab file"));
     r.push_back(Parameter::Mandatory('u', "union volume"));
@@ -217,11 +217,11 @@ class CommandApplyDirtab : public Command {
 class CommandSync : public Command {
  public:
   ~CommandSync() { }
-  std::string GetName() { return "sync"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "sync"; }
+  virtual std::string GetDescription() const {
     return "Pushes changes from scratch area back to the repository.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Mandatory('b', "base hash"));
     r.push_back(Parameter::Mandatory('c', "r/o volume"));

--- a/cvmfs/swissknife_zpipe.h
+++ b/cvmfs/swissknife_zpipe.h
@@ -14,17 +14,17 @@ namespace swissknife {
 class CommandZpipe : public Command {
  public:
   ~CommandZpipe() { }
-  std::string GetName() { return "zpipe"; }
-  std::string GetDescription() {
+  virtual std::string GetName() const { return "zpipe"; }
+  virtual std::string GetDescription() const {
     return "Compresses or decompresses a file using the DEFLATE algorithm.\n"
       "Input comes on stdin, output goes to stdout.";
   }
-  ParameterList GetParams() {
+  virtual ParameterList GetParams() const {
     ParameterList r;
     r.push_back(Parameter::Switch('d', "decompress file"));
     return r;
   }
-  int Main(const ArgumentList &args);
+  virtual int Main(const ArgumentList &args);
 };
 
 }  // namespace swissknife


### PR DESCRIPTION
This PR implements the resolution to JIRA ticket [CVM-1130](https://sft.its.cern.ch/jira/browse/CVM-1130).

The new `swissknife_lease` command is used to acquire a new repository lease from a running instance of the CVMFS repository services and also to drop an existing repository lease.

When a new lease is obtained, the session token associated with the lease is written in the file `/var/spool/cvmfs/<REPO_NAME>/session_token`. This session token is used for all future requests associated with this lease.