### PR TITLE
Update cvmfs-config-default's list of cern.ch stratum 1s to use port 8000

### DIFF
--- a/mount/domain.d/cern.ch.conf
+++ b/mount/domain.d/cern.ch.conf
@@ -15,6 +15,6 @@
 # Use cvmfs_config showconfig to get the effective parameters.
 #
 
-CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk/cvmfs/@fqrn@;http://cvmfs.racf.bnl.gov/cvmfs/@fqrn@;http://cvmfs.fnal.gov/cvmfs/@fqrn@;http://cvmfs02.grid.sinica.edu.tw/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs.racf.bnl.gov:8000/cvmfs/@fqrn@;http://cvmfs.fnal.gov:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/cern.ch
 CVMFS_USE_GEOAPI=yes

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -1,7 +1,7 @@
 Summary: CernVM File System Default Configuration and Public Keys
 Name: cvmfs-config-default
-Version: 1.2
-Release: 2
+Version: 1.3
+Release: 1
 Source0: cern.ch.pub
 Source1: cern-it1.cern.ch.pub
 Source2: cern-it2.cern.ch.pub
@@ -75,6 +75,10 @@ done
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
+* Fri Dec 30 2016 Dave Dykstra <dwd@fnal.gov> - 1.3-1
+- Add port 8000 to the cern.ch stratum 1s, and change the name of the
+  Tiawan stratum 1 from cvmfs02 to cvmfsrep.
+
 * Fri May 22 2015 Dave Dykstra <dwd@fnal.gov> - 1.2-2
 - Change Obsoletes/Conflicts on cvmfs-keys and cvmfs-init-scripts to
   Obsoletes/Provides with specific version numbers, according to Fedora

--- a/test/src/054-geoapi/main
+++ b/test/src/054-geoapi/main
@@ -15,7 +15,7 @@ cvmfs_run_test() {
   # Make sure that the stratum 1s have large geographical distance
   #   between them.  Use cvmfs.fnal.gov as one of them because it is
   #   a high-availability system.
-  sudo sh -c 'echo "CVMFS_SERVER_URL=\"http://cvmfs02.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs.fnal.gov:8000/cvmfs/@fqrn@\"" > /etc/cvmfs/config.d/grid.cern.ch.local' || return 100
+  sudo sh -c 'echo "CVMFS_SERVER_URL=\"http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cvmfs.fnal.gov:8000/cvmfs/@fqrn@\"" > /etc/cvmfs/config.d/grid.cern.ch.local' || return 100
   sudo sh -c 'echo "CVMFS_HTTP_PROXY=DIRECT" >> /etc/cvmfs/config.d/grid.cern.ch.local' || return 101
   sudo sh -c 'echo "CVMFS_FALLBACK_PROXY=" >> /etc/cvmfs/config.d/grid.cern.ch.local' || return 102
   cvmfs_mount grid.cern.ch || return 1
@@ -36,11 +36,11 @@ cvmfs_run_test() {
   esac
 
   if [ "$country" = "ch" ]; then
-    if [ "$geo_probe" != "http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch;http://cvmfs.fnal.gov:8000/cvmfs/grid.cern.ch;http://cvmfs02.grid.sinica.edu.tw:8000/cvmfs/grid.cern.ch" ]; then
+    if [ "$geo_probe" != "http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch;http://cvmfs.fnal.gov:8000/cvmfs/grid.cern.ch;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/grid.cern.ch" ]; then
       return 20;
     fi
   elif [ "$country" = "us" ]; then
-    if [ "$geo_probe" != "http://cvmfs.fnal.gov:8000/cvmfs/grid.cern.ch;http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch;http://cvmfs02.grid.sinica.edu.tw:8000/cvmfs/grid.cern.ch" ]; then
+    if [ "$geo_probe" != "http://cvmfs.fnal.gov:8000/cvmfs/grid.cern.ch;http://cvmfs-stratum-one.cern.ch/cvmfs/grid.cern.ch;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/grid.cern.ch" ]; then
       return 21;
     fi
   else


### PR DESCRIPTION
Also change Taiwan stratum 1's name from cvmfs02 to the cvmfsrep alias used for egi.eu and opensciencegrid.org.  See [CVM-1147](https://sft.its.cern.ch/jira/browse/CVM-1147).

After merging, please build new cvmfs-config-default.  Although I'd like it to be released a least as soon as cvmfs-2.3.3, I don't know if there's any reason to port this back to the cvmfs-2.3 branch.