### PR TITLE
Fix builds with the Ninja generator

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -107,6 +107,43 @@ set (CVMFS_CLIENT_SOURCES
   xattr.cc xattr.h
 )
 
+set (CVMFS_SERVER_SOURCES
+    server/cvmfs_server_sys.sh
+    server/cvmfs_server_prelude.sh
+    server/cvmfs_server_util.sh
+    server/cvmfs_server_ssl.sh
+    server/cvmfs_server_apache.sh
+    server/cvmfs_server_json.sh
+    server/cvmfs_server_common.sh
+    server/cvmfs_server_health_check.sh
+    server/cvmfs_server_compat.sh
+    server/cvmfs_server_transaction.sh
+    server/cvmfs_server_abort.sh
+    server/cvmfs_server_publish.sh
+    server/cvmfs_server_import.sh
+    server/cvmfs_server_mkfs.sh
+    server/cvmfs_server_add_replica.sh
+    server/cvmfs_server_rmfs.sh
+    server/cvmfs_server_resign.sh
+    server/cvmfs_server_list_catalogs.sh
+    server/cvmfs_server_info.sh
+    server/cvmfs_server_tag.sh
+    server/cvmfs_server_deprecated.sh
+    server/cvmfs_server_check.sh
+    server/cvmfs_server_list.sh
+    server/cvmfs_server_rollback.sh
+    server/cvmfs_server_gc.sh
+    server/cvmfs_server_snapshot.sh
+    server/cvmfs_server_migrate.sh
+    server/cvmfs_server_chown.sh
+    server/cvmfs_server_eliminate_hardlinks.sh
+    server/cvmfs_server_update_info.sh
+    server/cvmfs_server_mount.sh
+    server/cvmfs_server_skeleton.sh
+    server/cvmfs_server_fix_permissions.sh
+    server/cvmfs_server_coda.sh
+)
+
 set_source_files_properties(cache.pb.cc cache.pb.h
                             PROPERTIES GENERATED true)
 
@@ -805,12 +842,13 @@ endif (BUILD_PRELOADER)
 #
 # Generate the "cvmfs_server" script using "make_cvmfs_server.sh"
 #
-add_custom_target (
-  cvmfs_server
-  ALL
+add_custom_command (
+  OUTPUT cvmfs_server
   COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ./make_cvmfs_server.sh ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_server
+  DEPENDS ${CVMFS_SERVER_SOURCES}
   COMMENT "Generating the cvmfs_server script"
   )
+add_custom_target (cvmfs_server_build ALL DEPENDS cvmfs_server)
 
 #
 # installation

--- a/externals/tbb/src/CVMFS-CMakeLists.txt
+++ b/externals/tbb/src/CVMFS-CMakeLists.txt
@@ -21,8 +21,7 @@ if (NOT MACOSX)
                                                   ${TBB_DEBUG_LIBRARY_DIRS}/${TBBMALLOC_LIBRARY_DEBUG}.2)
 endif (NOT MACOSX)
 
-list (GET TBB_LIBRARIES 0 TBB_MAIN_LIB)
-register_external_lib (libtbb ${TBB_BUILD_LOCATION} ${TBB_MAIN_LIB})
+register_external_lib (libtbb ${TBB_BUILD_LOCATION} "${TBB_LIBRARIES}")
 
 install (
   FILES          ${TBB_LIBRARIES} ${TBB_DEBUG_LIBRARIES}

--- a/externals/tbb/src/configureHook.sh
+++ b/externals/tbb/src/configureHook.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-# Nothing to do
+# The output directory, `build_release` is created as a symlink by the
+# makefile.
+# However, the Ninja generator will pre-create the output directories,
+# meaning the makeHook.sh can't make it as a symlink.  Hence, we create
+# the output directories here.
+
+make mkdir


### PR DESCRIPTION
[Ninja](https://ninja-build.org/) is an optional CMake generator; ninja focuses on speed and parallelism.  For example, calling `ninja-build` on a fully-built directory (meaning there is no actual buildign to do) returns in 50ms.

This commit allows CVMFS to be built using Ninja with the following changes:

- Ninja requires all dependencies to be declared a-priori.  The libtbb target previously declared it output a single library but had several others created as a side-effect.  `cvmfs_swissknife` dependency on those other libraries, but Ninja didn't know how to create them.  Seems to be stricter than GNU make in this respect.
- Ninja creates output directories that are not already present.  This breaks the TBB build as the output directory is created as a symlink during the libtbb target.
- cvmfs_server dependencies aren't exposed to CMakeLists; this explicitly declares the dependency so the cvmfs_server script doesn't have to be regenerated each time.