### PR TITLE
CVM-1130 code review suggestions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+...

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((c++-mode
+  (eval add-hook 'before-save-hook #'clang-format-buffer nil t)))

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "C_Cpp.clang_format_fallbackStyle": "Google",
+    "C_Cpp.clang_format_formatOnSave": true
+}

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -27,14 +27,14 @@ bool CheckParams(const swissknife::CommandLease::Parameters& p) {
 namespace swissknife {
 
 enum LeaseError {
-  LEASE_SUCCESS           = 0,
-  LEASE_UNUSED            = 1,
-  LEASE_PARAM_ERROR       = 2,
-  LEASE_CURL_INIT_ERROR   = 3,
-  LEASE_FILE_OPEN_ERROR   = 4,
-  LEASE_FILE_DELETE_ERROR = 5,
-  LEASE_PARSE_ERROR       = 6,
-  LEASE_CURL_REQ_ERROR    = 7,
+  kLeaseSuccess           = 0,
+  kLeaseUnused            = 1,
+  kLeaseParamError        = 2,
+  kLeaseCurlInitError     = 3,
+  kLeaseFileOpenError     = 4,
+  kLeaseFileDeleteError   = 5,
+  kLeaseParseError        = 6,
+  kLeaseCurlReqError      = 7,
 };
 
 CommandLease::~CommandLease() {
@@ -58,15 +58,15 @@ int CommandLease::Main(const ArgumentList& args) {
   params.lease_fqdn = *(args.find('p')->second);
 
   if (!CheckParams(params)) {
-    return LEASE_PARAM_ERROR;
+    return kLeaseParamError;
   }
 
   // Initialize curl
   if (curl_global_init(CURL_GLOBAL_ALL)) {
-    return LEASE_CURL_INIT_ERROR;
+    return kLeaseCurlInitError;
   }
 
-  LeaseError ret = LEASE_SUCCESS;
+  LeaseError ret = kLeaseSuccess;
   if (params.action == "acquire") {
     CurlBuffer buffer;
     if (MakeAcquireRequest(params.user_name,
@@ -87,13 +87,13 @@ int CommandLease::Main(const ArgumentList& args) {
                    kLogStderr,
                    "Error opening file: %s",
                    std::strerror(errno));
-          ret = LEASE_FILE_OPEN_ERROR;
+          ret = kLeaseFileOpenError;
         }
       } else {
-        ret = LEASE_PARSE_ERROR;
+        ret = kLeaseParseError;
       }
     } else {
-      ret = LEASE_CURL_REQ_ERROR;
+      ret = kLeaseCurlReqError;
     }
   } else if (params.action == "drop") {
     // Try to read session token from repository scratch directory
@@ -117,21 +117,21 @@ int CommandLease::Main(const ArgumentList& args) {
           success = true;
         } else {
           LogCvmfs(kLogCvmfs, kLogStderr, "Could not drop active lease");
-          ret = LEASE_PARSE_ERROR;
+          ret = kLeaseParseError;
         }
       } else {
         LogCvmfs(kLogCvmfs, kLogStderr, "Error making DELETE request");
-        ret = LEASE_CURL_REQ_ERROR;
+        ret = kLeaseCurlReqError;
       }
     } else {
       LogCvmfs(kLogCvmfs, kLogStderr, "Error reading session token from file");
-      ret = LEASE_FILE_OPEN_ERROR;
+      ret = kLeaseFileOpenError;
     }
 
     token_file.close();
     if (success && std::remove(token_file_name.c_str())) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Error deleting session token file");
-      ret = LEASE_FILE_DELETE_ERROR;
+      ret = kLeaseFileDeleteError;
     }
   }
 

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -81,7 +81,7 @@ int CommandLease::Main(const ArgumentList& args) {
     if (MakeAcquireRequest(params.user_name, params.lease_fqdn,
                            params.repo_service_url, &buffer)) {
       std::string session_token;
-      if (ParseAcquireReply(buffer, &session_token)) {
+      if (buffer.data.size() > 0 && ParseAcquireReply(buffer, &session_token)) {
         // Save session token to
         // /var/spool/cvmfs/<REPO_NAME>/session_token_<SUBPATH>
         // TODO(radu): Is there a special way to access the scratch directory?
@@ -122,7 +122,7 @@ int CommandLease::Main(const ArgumentList& args) {
 
       CurlBuffer buffer;
       if (MakeDeleteRequest(session_token, params.repo_service_url, &buffer)) {
-        if (ParseDropReply(buffer)) {
+        if (buffer.data.size() > 0 && ParseDropReply(buffer)) {
           success = true;
         } else {
           LogCvmfs(kLogCvmfs, kLogStderr, "Could not drop active lease");

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -5,6 +5,7 @@
 #include "swissknife_lease.h"
 
 #include <algorithm>
+#include <vector>
 
 #include "swissknife_lease_curl.h"
 #include "swissknife_lease_json.h"

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -77,7 +77,7 @@ int CommandLease::Main(const ArgumentList& args) {
       if (ParseAcquireReply(buffer, &session_token)) {
         // Save session token to /var/spool/cvmfs/<REPO_NAME>
         // TODO(radu): Is there a special way to access the scratch directory?
-        std::string token_file_name = "/var/spool/cvmfs/" +
+        const std::string token_file_name = "/var/spool/cvmfs/" +
             params.lease_fqdn + "/session_token";
         std::ofstream token_file(token_file_name.c_str(), std::ios_base::out);
         if (token_file.is_open()) {

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -117,7 +117,7 @@ int CommandLease::Main(const ArgumentList& args) {
       if (MakeDeleteRequest(session_token, params.repo_service_url, &buffer)) {
         if (buffer.data.size() > 0 && ParseDropReply(buffer)) {
           std::fclose(token_file);
-          if (std::remove(token_file_name.c_str())) {
+          if (unlink(token_file_name.c_str())) {
             LogCvmfs(kLogCvmfs, kLogStderr,
                      "Error deleting session token file");
             ret = kLeaseFileDeleteError;

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -25,17 +25,14 @@ class CommandLease : public Command {
   virtual int Main(const ArgumentList &args);
 
   struct Parameters {
-    Parameters() :
-        repo_service_url(""),
-        action(""),
-        user_name(""),
-        lease_fqdn("")
-    {}
+    Parameters()
+        : repo_service_url(""), action(""), user_name(""), lease_fqdn("") {}
 
     std::string repo_service_url;
     std::string action;
     std::string user_name;
     std::string lease_fqdn;
+    std::string lease_subpath;
   };
 };
 

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -32,7 +32,7 @@ class CommandLease : public Command {
     std::string action;
     std::string user_name;
     std::string lease_fqdn;
-    std::string lease_subpath;
+    std::string token_file_suffix;
   };
 };
 

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -50,8 +50,9 @@ bool MakeAcquireRequest(const std::string& user_name,
       "{\"user\" : \"" + user_name + "\", \"path\" : \"" + lease_fqdn + "\"}";
 
   // Make request to acquire lease from repo services
-  curl_easy_setopt(h_curl, CURLOPT_URL,
-                   (repo_service_url + "/api/leases").c_str());
+  curl_easy_setopt(
+      h_curl, CURLOPT_URL,
+      (repo_service_url + REPO_SERVICES_API_ROOT + "/leases").c_str());
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(payload.length()));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
@@ -75,8 +76,10 @@ bool MakeDeleteRequest(const std::string& session_token,
   if (!h_curl) {
     return false;
   }
-  curl_easy_setopt(h_curl, CURLOPT_URL,
-                   (repo_service_url + "/api/leases/" + session_token).c_str());
+  curl_easy_setopt(
+      h_curl, CURLOPT_URL,
+      (repo_service_url + REPO_SERVICES_API_ROOT + "/leases/" + session_token)
+          .c_str());
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(0));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, 0);

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -6,7 +6,7 @@
 
 #include <iostream>
 
-size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp) {
+size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {
   CurlBuffer* my_buffer = static_cast<CurlBuffer*>(userp);
 
   if (size * nmemb < 1) {
@@ -39,31 +39,29 @@ bool MakeAcquireRequest(const std::string& user_name,
   CURLcode ret = static_cast<CURLcode>(0);
 
   CURL* h_curl = PrepareCurl("POST");
-  if (h_curl) {
-    // Prepare payload
-    std::string payload = "{\"user\" : \"" + user_name +
-        "\", \"path\" : \"" + lease_fqdn + "\"}";
-
-    // Make request to acquire lease from repo services
-    curl_easy_setopt(h_curl,
-                     CURLOPT_URL,
-                     (repo_service_url + "/api/leases").c_str());
-    curl_easy_setopt(h_curl,
-                     CURLOPT_POSTFIELDSIZE_LARGE,
-                     static_cast<curl_off_t>(payload.length()));
-    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
-    curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
-    curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, buffer);
-
-    ret = curl_easy_perform(h_curl);
-
-    curl_easy_cleanup(h_curl);
-    h_curl = NULL;
-
-    return !ret;
+  if (!h_curl) {
+    return false;
   }
 
-  return false;
+  // Prepare payload
+  const std::string payload =
+      "{\"user\" : \"" + user_name + "\", \"path\" : \"" + lease_fqdn + "\"}";
+
+  // Make request to acquire lease from repo services
+  curl_easy_setopt(h_curl, CURLOPT_URL,
+                   (repo_service_url + "/api/leases").c_str());
+  curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
+                   static_cast<curl_off_t>(payload.length()));
+  curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
+  curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
+  curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, buffer);
+
+  ret = curl_easy_perform(h_curl);
+
+  curl_easy_cleanup(h_curl);
+  h_curl = NULL;
+
+  return !ret;
 }
 
 bool MakeDeleteRequest(const std::string& session_token,
@@ -72,28 +70,21 @@ bool MakeDeleteRequest(const std::string& session_token,
   CURLcode ret = static_cast<CURLcode>(0);
 
   CURL* h_curl = PrepareCurl("DELETE");
-  if (h_curl) {
-    curl_easy_setopt(h_curl,
-                     CURLOPT_URL,
-                     (repo_service_url +
-                      "/api/leases/" +
-                      session_token).c_str());
-    curl_easy_setopt(h_curl,
-                     CURLOPT_POSTFIELDSIZE_LARGE,
-                     static_cast<curl_off_t>(0));
-    curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, 0);
-    curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
-    curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, buffer);
-
-    ret = curl_easy_perform(h_curl);
-
-    curl_easy_cleanup(h_curl);
-    h_curl = NULL;
-
-    return !ret;
+  if (!h_curl) {
+    return false;
   }
+  curl_easy_setopt(h_curl, CURLOPT_URL,
+                   (repo_service_url + "/api/leases/" + session_token).c_str());
+  curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
+                   static_cast<curl_off_t>(0));
+  curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, 0);
+  curl_easy_setopt(h_curl, CURLOPT_WRITEFUNCTION, RecvCB);
+  curl_easy_setopt(h_curl, CURLOPT_WRITEDATA, buffer);
 
-  return false;
+  ret = curl_easy_perform(h_curl);
+
+  curl_easy_cleanup(h_curl);
+  h_curl = NULL;
+
+  return !ret;
 }
-
-

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -4,8 +4,6 @@
 
 #include "swissknife_lease_curl.h"
 
-#include <iostream>
-
 #include "cvmfs_config.h"
 
 size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -21,7 +21,7 @@ size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {
 }
 
 CURL* PrepareCurl(const char* method) {
-  const std::string user_agent_string = "cvmfs/" + VERSION;
+  const char* user_agent_string = "cvmfs/" VERSION;
 
   CURL* h_curl = curl_easy_init();
 

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -6,6 +6,8 @@
 
 #include <iostream>
 
+#include "cvmfs_config.h"
+
 size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {
   CurlBuffer* my_buffer = static_cast<CurlBuffer*>(userp);
 
@@ -19,11 +21,13 @@ size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {
 }
 
 CURL* PrepareCurl(const char* method) {
+  const std::string user_agent_string = "cvmfs/" + VERSION;
+
   CURL* h_curl = curl_easy_init();
 
   if (h_curl) {
     curl_easy_setopt(h_curl, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(h_curl, CURLOPT_USERAGENT, "curl/7.47.0");
+    curl_easy_setopt(h_curl, CURLOPT_USERAGENT, user_agent_string);
     curl_easy_setopt(h_curl, CURLOPT_MAXREDIRS, 50L);
     curl_easy_setopt(h_curl, CURLOPT_CUSTOMREQUEST, method);
     curl_easy_setopt(h_curl, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -9,21 +9,22 @@
 
 #include "curl/curl.h"
 
+#define REPO_SERVICES_API_ROOT "/api/v1"
+
 struct CurlBuffer {
   std::string data;
 };
 
-size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp);
+size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp);
 
 CURL* PrepareCurl(const char* method);
 
 bool MakeAcquireRequest(const std::string& user_name,
-                          const std::string& lease_fqdn,
-                          const std::string& repo_service_url,
-                          CurlBuffer* buffer);
+                        const std::string& lease_fqdn,
+                        const std::string& repo_service_url,
+                        CurlBuffer* buffer);
 
 bool MakeDeleteRequest(const std::string& session_token,
-                         const std::string& repo_service_url,
-                         CurlBuffer* buffer);
+                       const std::string& repo_service_url, CurlBuffer* buffer);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_CURL_H_

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -11,8 +11,12 @@
 #include "logging.h"
 
 bool ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
+  if (buffer.data.size() == 0 || session_token == NULL) {
+    return false;
+  }
+
   const UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
-  if (!reply->IsValid()) {
+  if (!reply || !reply->IsValid()) {
     return false;
   }
 
@@ -53,8 +57,12 @@ bool ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
 }
 
 bool ParseDropReply(const CurlBuffer &buffer) {
+  if (buffer.data.size() == 0) {
+    return false;
+  }
+
   const UniquePtr<const JsonDocument> reply(JsonDocument::Create(buffer.data));
-  if (!reply->IsValid()) {
+  if (!reply || !reply->IsValid()) {
     return false;
   }
 

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -10,86 +10,74 @@
 
 #include "logging.h"
 
-bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token) {
+bool ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
   const UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
-  if (reply->IsValid()) {
-    const JSON* result = JsonDocument::SearchInObject(reply->root(),
-                                                      "status",
-                                                      JSON_STRING);
-    if (result != NULL) {
-      const std::string status = result->string_value;
-      if (status == "ok") {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
-        const JSON* token = JsonDocument::SearchInObject(reply->root(),
-                                                         "session_token",
-                                                         JSON_STRING);
-        if (token != NULL) {
-          LogCvmfs(kLogCvmfs,
-                   kLogStderr,
-                   "Session token: %s",
-                   token->string_value);
-          *session_token = token->string_value;
-          return true;
-        }
-      } else if (status == "path_busy") {
-        const JSON* time_remaining = JsonDocument::SearchInObject(
-            reply->root(),
-            "time_remaining",
-            JSON_INT);
-        if (time_remaining != NULL) {
-          LogCvmfs(kLogCvmfs,
-                   kLogStderr,
-                   "Path busy. Time remaining = %d",
-                   time_remaining->int_value);
-        }
-      } else if (status == "error") {
-        const JSON* reason = JsonDocument::SearchInObject(reply->root(),
-                                                          "reason",
-                                                          JSON_STRING);
-        if (reason != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
-        }
-      } else {
-        LogCvmfs(kLogCvmfs,
-                 kLogStderr,
-                 "Unknown reply. Status: %s",
-                 status.c_str());
-      }
-    }
+  if (!reply->IsValid()) {
+    return false;
   }
 
-  return false;
-}
-
-bool ParseDropReply(const CurlBuffer& buffer) {
-  const UniquePtr<const JsonDocument> reply(JsonDocument::Create(buffer.data));
-  if (reply->IsValid()) {
-    const JSON* result = JsonDocument::SearchInObject(reply->root(),
-                                                      "status",
-                                                      JSON_STRING);
-    if (result != NULL) {
-      const std::string status = result->string_value;
-      if (status == "ok") {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+  const JSON *result =
+      JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+  if (result != NULL) {
+    const std::string status = result->string_value;
+    if (status == "ok") {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+      const JSON *token = JsonDocument::SearchInObject(
+          reply->root(), "session_token", JSON_STRING);
+      if (token != NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s",
+                 token->string_value);
+        *session_token = token->string_value;
         return true;
-      } else if (status == "invalid_token") {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Error: invalid session token");
-      } else if (status == "error") {
-        const JSON* reason = JsonDocument::SearchInObject(reply->root(),
-                                                          "reason",
-                                                          JSON_STRING);
-        if (reason != NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
-        }
-      } else {
-        LogCvmfs(kLogCvmfs,
-                 kLogStderr,
-                 "Unknown reply. Status: %s",
-                 status.c_str());
       }
+    } else if (status == "path_busy") {
+      const JSON *time_remaining = JsonDocument::SearchInObject(
+          reply->root(), "time_remaining", JSON_INT);
+      if (time_remaining != NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d",
+                 time_remaining->int_value);
+      }
+    } else if (status == "error") {
+      const JSON *reason =
+          JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+      if (reason != NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+      }
+    } else {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s",
+               status.c_str());
     }
   }
 
   return false;
 }
 
+bool ParseDropReply(const CurlBuffer &buffer) {
+  const UniquePtr<const JsonDocument> reply(JsonDocument::Create(buffer.data));
+  if (!reply->IsValid()) {
+    return false;
+  }
+
+  const JSON *result =
+      JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+  if (result != NULL) {
+    const std::string status = result->string_value;
+    if (status == "ok") {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+      return true;
+    } else if (status == "invalid_token") {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Error: invalid session token");
+    } else if (status == "error") {
+      const JSON *reason =
+          JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+      if (reason != NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+      }
+    } else {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s",
+               status.c_str());
+    }
+  }
+
+  return false;
+}

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -11,18 +11,18 @@
 #include "logging.h"
 
 bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token) {
-  UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
+  const UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
   if (reply->IsValid()) {
-    JSON* result = JsonDocument::SearchInObject(reply->root(),
-                                                "status",
-                                                JSON_STRING);
+    const JSON* result = JsonDocument::SearchInObject(reply->root(),
+                                                      "status",
+                                                      JSON_STRING);
     if (result != NULL) {
-      std::string status = result->string_value;
+      const std::string status = result->string_value;
       if (status == "ok") {
         LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
-        JSON* token = JsonDocument::SearchInObject(reply->root(),
-                                                   "session_token",
-                                                   JSON_STRING);
+        const JSON* token = JsonDocument::SearchInObject(reply->root(),
+                                                         "session_token",
+                                                         JSON_STRING);
         if (token != NULL) {
           LogCvmfs(kLogCvmfs,
                    kLogStderr,
@@ -32,9 +32,10 @@ bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token) {
           return true;
         }
       } else if (status == "path_busy") {
-        JSON* time_remaining = JsonDocument::SearchInObject(reply->root(),
-                                                            "time_remaining",
-                                                            JSON_INT);
+        const JSON* time_remaining = JsonDocument::SearchInObject(
+            reply->root(),
+            "time_remaining",
+            JSON_INT);
         if (time_remaining != NULL) {
           LogCvmfs(kLogCvmfs,
                    kLogStderr,
@@ -42,9 +43,9 @@ bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token) {
                    time_remaining->int_value);
         }
       } else if (status == "error") {
-        JSON* reason = JsonDocument::SearchInObject(reply->root(),
-                                                    "reason",
-                                                    JSON_STRING);
+        const JSON* reason = JsonDocument::SearchInObject(reply->root(),
+                                                          "reason",
+                                                          JSON_STRING);
         if (reason != NULL) {
           LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
         }
@@ -61,22 +62,22 @@ bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token) {
 }
 
 bool ParseDropReply(const CurlBuffer& buffer) {
-  UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
+  const UniquePtr<const JsonDocument> reply(JsonDocument::Create(buffer.data));
   if (reply->IsValid()) {
-    JSON* result = JsonDocument::SearchInObject(reply->root(),
-                                                "status",
-                                                JSON_STRING);
+    const JSON* result = JsonDocument::SearchInObject(reply->root(),
+                                                      "status",
+                                                      JSON_STRING);
     if (result != NULL) {
-      std::string status = result->string_value;
+      const std::string status = result->string_value;
       if (status == "ok") {
         LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
         return true;
       } else if (status == "invalid_token") {
         LogCvmfs(kLogCvmfs, kLogStderr, "Error: invalid session token");
       } else if (status == "error") {
-        JSON* reason = JsonDocument::SearchInObject(reply->root(),
-                                                    "reason",
-                                                    JSON_STRING);
+        const JSON* reason = JsonDocument::SearchInObject(reply->root(),
+                                                          "reason",
+                                                          JSON_STRING);
         if (reason != NULL) {
           LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
         }

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -84,6 +84,7 @@ set(CVMFS_UNITTEST_FILES
   t_sqlite_database.cc
   t_sqlitemem.cc
   t_statistics.cc
+  t_swissknife_lease.cc
   t_synchronizing_counter.cc
   t_test_utils.cc
   t_tracer.cc
@@ -199,6 +200,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/swissknife_assistant.cc ${CVMFS_SOURCE_DIR}/swissknife_assistant.h
   ${CVMFS_SOURCE_DIR}/swissknife_history.cc ${CVMFS_SOURCE_DIR}/swissknife_history.h
   ${CVMFS_SOURCE_DIR}/swissknife_sync.h
+  ${CVMFS_SOURCE_DIR}/swissknife_lease_json.cc
   ${CVMFS_SOURCE_DIR}/tracer.cc ${CVMFS_SOURCE_DIR}/tracer.h
   ${CVMFS_SOURCE_DIR}/uid_map.h
   ${CVMFS_SOURCE_DIR}/upload.cc ${CVMFS_SOURCE_DIR}/upload.h

--- a/test/unittests/t_swissknife_lease.cc
+++ b/test/unittests/t_swissknife_lease.cc
@@ -1,0 +1,74 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "swissknife_lease.h"
+#include "swissknife_lease_json.h"
+
+class T_SwissknifeLeaseJson : public ::testing::Test {
+ protected:
+  void SetUp() {}
+
+  CurlBuffer buffer_;
+  std::string session_token_;
+};
+
+TEST_F(T_SwissknifeLeaseJson, ParseAcquireOk) {
+  buffer_.data = "{ \"status\" : \"ok\", \"session_token\" : \"ABCD\"}";
+  EXPECT_TRUE(ParseAcquireReply(buffer_, &session_token_));
+  EXPECT_EQ(session_token_, "ABCD");
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseAcquireBusy) {
+  buffer_.data =
+      "{ \"status\" : \"path_busy\", \"time_remaining\" : \"1234\" }";
+  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseAcquireError) {
+  buffer_.data =
+      "{ \"status\" : \"error\", \"reason\" : \"reason_for_failure\" }";
+  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseAcquireInvalidReply) {
+  buffer_.data = "-----------------------------";
+  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseAcquireNullPtr) {
+  EXPECT_FALSE(ParseAcquireReply(buffer_, NULL));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseAcquireEmptyReply) {
+  buffer_.data.clear();
+  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseDropOk) {
+  buffer_.data = "{ \"status\" : \"ok\" }";
+  EXPECT_TRUE(ParseDropReply(buffer_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseDropInvalidSessionToken) {
+  buffer_.data = "{ \"status\" : \"invalid_token\" }";
+  EXPECT_FALSE(ParseDropReply(buffer_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseDropError) {
+  buffer_.data =
+      "{ \"status\" : \"error\", \"reason\" : \"reason_for_failure\" }";
+  EXPECT_FALSE(ParseDropReply(buffer_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseDropInvalidReply) {
+  buffer_.data = "-----------------------------";
+  EXPECT_FALSE(ParseDropReply(buffer_));
+}
+
+TEST_F(T_SwissknifeLeaseJson, ParseDropEmptyReply) {
+  buffer_.data.clear();
+  EXPECT_FALSE(ParseDropReply(buffer_));
+}


### PR DESCRIPTION
This contains the implementation of the suggestions from PR #1730.

* Unit tests for JSON parsing (from `swissknife_lease_json.cc`)
* Remove the use of C++ streams
* Use a unique identifier suffix for session token files
* Use "cvmfs" as Curl user agent string
* Repository services API versioning
* Minor additions and fixes