### PR TITLE
Fixing error in cvmfs_config re: load_osxfusefs

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1552,8 +1552,6 @@ check_dev_fuse() {
       charDevice=/dev/fuse ;;
 
     Darwin )
-      #load osxfuse kernel extension
-      /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs
       charDevice=/dev/osxfuse0 ;;
 
     * )


### PR DESCRIPTION
Fixes error in `cvmfs_config` when calling `load_osxfusefs`. This file no longer exists in more recent versions of OSXFUSE. The `KextManager` API is used instead.

Fixes CVM-1101.