### PR TITLE
cvmfs_config: remove call to load_osxfusefs

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1554,8 +1554,6 @@ check_dev_fuse() {
       charDevice=/dev/fuse ;;
 
     Darwin )
-      #load osxfuse kernel extension
-      /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs
       charDevice=/dev/osxfuse0 ;;
 
     * )


### PR DESCRIPTION
Same as #1759, this time on `devel`