### PR TITLE
Fix integration test setup script on CentOS 7

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -18,7 +18,8 @@ sudo mkdir /media/ext4_volume || die "fail (mkdir /media/ext4_volume)"
 sudo mount -o loop $HOME/ext4_volume /media/ext4_volume || die "fail (mount -o loop $HOME/ext4_volume /media/ext4_volume)"
 
 # Symlink the new ext4 volume into /var/spool/cvmfs and continue
-sudo rm -r /var/spool/cvmfs || die "fail (rm -r /var/spool/cvmfs)"
+sudo rm -rf /var/spool/cvmfs || die "fail (rm -rf /var/spool/cvmfs)"
+sudo mkdir -p /var/spool/cvmfs || die "fail (mkdir -p /var/spool/cvmfs)"
 sudo ln -s /media/ext4_volume /var/spool/cvmfs || die "fail (ln -s /media/ext4_volume /var/spool/cvmfs)"
 
 # install CernVM-FS RPM packages


### PR DESCRIPTION
Same as #1772 , but applied to the `cvmfs-2.3` branch.