### PR TITLE
Fix integration tests centos7

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -8,20 +8,6 @@ script_location=$(dirname $(readlink --canonicalize $0))
 echo "enabling epel yum repository..."
 install_from_repo epel-release
 
-# Create an ext4 partition to use for /var/spool/cvmfs
-# Create a 32GB file...
-sudo dd if=/dev/zero of=$HOME/ext4_volume bs=1 count=0 seek=5GB || die "fail (dd if=/dev/zero of=$HOME/ext4_volume bs=1 count=0 seek=5GB)"
-# format it with ext4...
-sudo yes | sudo mkfs -t ext4 $HOME/ext4_volume || die "fail (yes | sudo mkfs -t ext4 $HOME/ext4_volume)"
-# and mount it
-sudo mkdir /media/ext4_volume || die "fail (mkdir /media/ext4_volume)"
-sudo mount -o loop $HOME/ext4_volume /media/ext4_volume || die "fail (mount -o loop $HOME/ext4_volume /media/ext4_volume)"
-
-# Symlink the new ext4 volume into /var/spool/cvmfs and continue
-sudo rm -rf /var/spool/cvmfs || die "fail (rm -rf /var/spool/cvmfs)"
-sudo mkdir -p /var/spool/cvmfs || die "fail (mkdir -p /var/spool/cvmfs)"
-sudo ln -s /media/ext4_volume /var/spool/cvmfs || die "fail (ln -s /media/ext4_volume /var/spool/cvmfs)"
-
 # install CernVM-FS RPM packages
 echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -4,16 +4,6 @@
 script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
-# look for the ephemeral storage mount point
-dev="\/dev\/vdb" # mind the escape!
-ephemeral=$(sed -e "s/^$dev \(\/[^ ]*\) .*$/\1/;tx;d;:x" /proc/mounts)
-[ ! -z $ephemeral ] || die "no ephemeral storage found on $dev"
-
-# configure the ephemeral storage
-custom_cache_dir="${ephemeral}/cvmfs_server_cache"
-sudo chmod a+w "$ephemeral" || die "couldn't chmod storage at $ephemeral"
-mkdir "$custom_cache_dir"   || die "couldn't create cache dir $custom_cache_dir"
-
 retval=0
 
 # allow apache access to the mounted server file system


### PR DESCRIPTION
This addresses the most recent failures of the integration tests on CentOS 7.

* Don't try to create ephemereal storage for the CVMFS cache on a second block device (`/dev/vdb`). The new flavour of CentOS 7 VM doesn't not have this device.
* Don't create an EXT4 partition for `/var/spool/cvmfs`. The default XFS root partition can be used.