### PR TITLE
CentOS 7 integration tests - remove ext4 check

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -646,11 +646,10 @@ check_overlayfs() {
 # @return  0 if overlayfs is installed and viable
 check_overlayfs_version() {
   [ -z "$CVMFS_DONT_CHECK_OVERLAYFS_VERSION" ] || return 0
-  local scratch_fstype=$(df -T /var/spool/cvmfs | tail -1 | awk {'print $2'})
   local krnl_version=$(uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+-*[0-9]*')
   if compare_versions "$krnl_version" -ge "4.2.0" ; then
       return 0
-  elif is_redhat && $(compare_versions "$krnl_version" -ge "3.10.0-493") && [ "x$scratch_fstype" = "xext4" ] ; then
+  elif is_redhat && $(compare_versions "$krnl_version" -ge "3.10.0-493") ; then
       return 0
   else
       return 1


### PR DESCRIPTION
Removing the check in `cvmfs_server` for the file system type of `/var/spool/cvmfs`. Previously, only ext4 was allowed, but we should also allow XFS.

I've run the first 10 server integration tests in a CentOS 7 VM. Attached the log file, since there are a few failures.

[integration_log.txt](https://github.com/cvmfs/cvmfs/files/738866/integration_log.txt)

