### PR TITLE
Disable travis on osx (cvmfs-2.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: cpp
 
 os:
   - linux
-  - osx
-
-osx_image: xcode7.1
 
 compiler:
   - gcc


### PR DESCRIPTION
Disable the Travis-CI check on Mac OS X for this branch, since we are no longer able to compile `cvmfs-2.3` on any of the Mac OS X images offered by Travis.