### PR TITLE
Use default OS X image on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ os:
   - linux
   - osx
 
-osx_image: xcode6.4
-
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
On the `devel` branch, we are no longer tied to a specific version of Mac OS X. We can use the default image provided by Travis.