### PR TITLE
Integration tests: removing ephemereal storage for Ubuntu 12.04

### DIFF
--- a/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu1204_x86_64_test.sh
@@ -4,16 +4,6 @@
 script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common_test.sh
 
-# look for the ephemeral storage mount point
-dev="\/dev\/vdb" # mind the escape!
-ephemeral=$(sed -e "s/^$dev \(\/[^ ]*\) .*$/\1/;tx;d;:x" /proc/mounts)
-[ ! -z $ephemeral ] || die "no ephemeral storage found on $dev"
-
-# configure the ephemeral storage
-custom_cache_dir="${ephemeral}/cvmfs_server_cache"
-sudo chmod a+w "$ephemeral" || die "couldn't chmod storage at $ephemeral"
-mkdir "$custom_cache_dir"   || die "couldn't create cache dir $custom_cache_dir"
-
 retval=0
 
 # running unittests
@@ -36,7 +26,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 
 echo "running CernVM-FS server test cases..."
-CVMFS_TEST_SERVER_CACHE="$custom_cache_dir"                                   \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \


### PR DESCRIPTION
Fixes the integration test setup on Ubuntu 12.04. The VM image that we are using no longer has `/dev/vdb`.