### PR TITLE
Fix overlayfs check centos7

### DIFF
--- a/cvmfs/cvmfs_server
+++ b/cvmfs/cvmfs_server
@@ -646,10 +646,11 @@ check_overlayfs() {
 # @return  0 if overlayfs is installed and viable
 check_overlayfs_version() {
   [ -z "$CVMFS_DONT_CHECK_OVERLAYFS_VERSION" ] || return 0
+  local scratch_fstype=$(df -T /var/spool/cvmfs | tail -1 | awk {'print $2'})
   local krnl_version=$(uname -r | grep -oe '^[0-9]\+\.[0-9]\+.[0-9]\+-*[0-9]*')
   if compare_versions "$krnl_version" -ge "4.2.0" ; then
       return 0
-  elif is_redhat && $(compare_versions "$krnl_version" -ge "3.10.0-493") ; then
+  elif is_redhat && $(compare_versions "$krnl_version" -ge "3.10.0-493") && [ "x$scratch_fstype" = "xext4" ] ; then
       return 0
   else
       return 1

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -4,11 +4,17 @@
 script_location=$(dirname $(readlink --canonicalize $0))
 . ${script_location}/common_setup.sh
 
-# Place the overlay directories on ftype=1 16GB xfs partition
-sudo dd if=/dev/zero of=/xfs-backend bs=$((1024*1024)) count=$((16*1024))
-sudo mkfs.xfs -n ftype=1 /xfs-backend
+# # Place the overlay directories on ftype=1 16GB xfs partition
+# sudo dd if=/dev/zero of=/xfs-backend bs=$((1024*1024)) count=$((16*1024))
+# sudo mkfs.xfs -n ftype=1 /xfs-backend
+# sudo mkdir -p /var/spool/cvmfs
+# sudo mount /xfs-backend /var/spool/cvmfs
+
+# Place the overlay directories on 16GB ext4 partition
+sudo dd if=/dev/zero of=/ext4-backend bs=$((1024*1024)) count=$((16*1024))
+sudo yes | sudo mkfs.ext4 /ext4-backend
 sudo mkdir -p /var/spool/cvmfs
-sudo mount /xfs-backend /var/spool/cvmfs
+sudo mount /ext4-backend /var/spool/cvmfs
 
 # CernVM-FS server needs 'jq' from epel
 echo "enabling epel yum repository..."


### PR DESCRIPTION
* Re-enable the check that `/var/spool/cvmfs` is located on an EXT4 partition, when running on CentOS 7.
* In the CentOS 7 integration test setup script, place the `/var/spool/cvmfs` directory on an EXT4 partition.