### PR TITLE
Last minute integration test fixes

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -48,6 +48,7 @@ install_from_repo gcc
 install_from_repo gcc-c++
 install_from_repo rubygems
 install_from_repo wget
+install_from_repo java-1.8.0-openjdk
 install_from_repo redhat-lsb-core
 
 # traffic shaping

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -33,7 +33,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
-#                                 src/7*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_x86_64_test.sh
@@ -33,7 +33,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \
-                                 src/7*                                       \
+#                                 src/7*                                       \
                               || retval=1
 
 


### PR DESCRIPTION
* Install `java-1.8.0-openjdk` on CC7 to fix proxy failover integration test
* Disable overlayfs validation test on Ubuntu 14.04: the OS image needs to be update run Linux 3.18+ in order to support overlayfs. Currently running 3.13.