### PR TITLE
TBB install fixes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -143,7 +143,7 @@ build_lib() {
 
       rm -rf $externals_build_dir/build_c-ares
       do_extract "c-ares" "c-ares-${CARES_VERSION}.tar.gz"
-      do_build "c-ares"      
+      do_build "c-ares"
 
       do_extract "libcurl" "curl-${CURL_VERSION}.tar.gz"
       patch_external "libcurl" "reenable_poll_darwin.patch"
@@ -193,11 +193,13 @@ build_lib() {
       fi
       ;;
     tbb)
-      do_extract "tbb"          "tbb-${TBB_VERSION}.tar.gz"
-      patch_external "tbb"         "custom_library_suffix.patch"        \
-                                  "symlink_to_build_directories.patch" \
-                                  "32bit_mock.patch"
-      do_build "tbb"
+      if [ x"BUILD_SERVER" != x"" ]; then
+        do_extract "tbb"          "tbb-${TBB_VERSION}.tar.gz"
+        patch_external "tbb"         "custom_library_suffix.patch"        \
+                                    "symlink_to_build_directories.patch" \
+                                    "32bit_mock.patch"
+        do_build "tbb"
+      fi
       ;;
     protobuf)
       do_extract "protobuf"     "protobuf-${PROTOBUF_VERSION}.tar.bz2"

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -713,7 +713,7 @@ if (BUILD_SERVER)
   # If we built the third-party libraries ourselves, we should also install the TBB libraries
   if (BUILTIN_EXTERNALS)
     install(
-      FILES ${TBB_LIBRARIES}
+      FILES ${EXTERNALS_INSTALL_LOCATION}/lib/libtbb_cvmfs.so.2 ${EXTERNALS_INSTALL_LOCATION}/lib/libtbbmalloc_cvmfs.so.2
       DESTINATION ${CMAKE_INSTALL_LIBDIR}
       )
   endif (BUILTIN_EXTERNALS)


### PR DESCRIPTION
* The CMake install command for TBB wasn't installing the libraries with the full name (i.e. `libtbb_cvmfs.so.2` and `libtbbmalloc_cvmfs.so.2`).
* (optimization) Don't build the TBB dependency in `bootstrap.sh` unless `BUILD_SERVER` is enabled.