### PR TITLE
Instance-based cache manager configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 // Place your settings in this file to overwrite default and user settings.
 {
     "C_Cpp.clang_format_fallbackStyle": "Google",
-    "C_Cpp.clang_format_formatOnSave": true
-}
+    "C_Cpp.clang_format_formatOnSave": true,
+    "files.associations": {}
+  }

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -146,6 +146,11 @@ class CacheManager : SingleCopy {
   }
 
   virtual CacheManagerIds id() = 0;
+  /**
+   * Return a human readable description of the cache instance.  Used in
+   * cvmfs_talk.
+   */
+  virtual std::string Describe() = 0;
 
   virtual bool AcquireQuotaManager(QuotaManager *quota_mgr) = 0;
 

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -282,6 +282,11 @@ void ExternalCacheManager::CtrlTxn(
 }
 
 
+string ExternalCacheManager::Describe() {
+  return "External cache manager\n";
+}
+
+
 int ExternalCacheManager::DoOpen(const shash::Any &id) {
   int fd = -1;
   {

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -58,6 +58,7 @@ class ExternalCacheManager : public CacheManager {
   virtual ~ExternalCacheManager();
 
   virtual CacheManagerIds id() { return kExternalCacheManager; }
+  virtual std::string Describe();
   virtual bool AcquireQuotaManager(QuotaManager *quota_mgr);
 
   virtual int Open(const BlessedObject &object);

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -474,14 +474,12 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
       num_slots & mask_64,
       ComparableHash(hash_empty),
       hasher_any,
-      &statistics_,
-      "objects_all");
+      perf::StatisticsTemplate("objects_all", &statistics_));
     objects_volatile_ = new lru::LruCache<ComparableHash, ObjectHeader *>(
       num_slots & mask_64,
       ComparableHash(hash_empty),
       hasher_any,
-      &statistics_,
-      "objects_volatile");
+      perf::StatisticsTemplate("objects_volatile", &statistics_));
   }
 
   /**

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -280,6 +280,11 @@ void PosixCacheManager::CtrlTxn(
 }
 
 
+string PosixCacheManager::Describe() {
+  return "Posix cache manager (cache directory: " + cache_path_ + ")\n";
+}
+
+
 int PosixCacheManager::Dup(int fd) {
   int new_fd = dup(fd);
   if (new_fd < 0)

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -60,6 +60,7 @@ class PosixCacheManager : public CacheManager {
   static const uint64_t kBigFile;
 
   virtual CacheManagerIds id() { return kPosixCacheManager; }
+  virtual std::string Describe();
 
   static PosixCacheManager *Create(const std::string &cache_path,
                                    const bool alien_cache,

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -13,11 +13,17 @@
 #include "kvstore.h"
 #include "logging.h"
 #include "util/posix.h"
+#include "util/string.h"
 #include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
 const shash::Any RamCacheManager::kInvalidHandle;
+
+string RamCacheManager::Describe() {
+  return "Internal in-memory cache manager (size " +
+         StringifyInt(max_size_ / (1024 * 1024)) + "MB)\n";
+}
 
 
 RamCacheManager::RamCacheManager(

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -24,22 +24,20 @@ RamCacheManager::RamCacheManager(
   uint64_t max_size,
   unsigned max_entries,
   MemoryKvStore::MemoryAllocator alloc,
-  perf::Statistics *statistics)
+  perf::StatisticsTemplate statistics)
   : max_size_(max_size)
   , fd_table_(max_entries, ReadOnlyHandle())
   // TODO(jblomer): the number of slots in the kv-stores should _not_ be the
   // number of open files.
   , regular_entries_(max_entries,
-                     "RamCache.regular",
                      alloc,
                      max_size,
-                     statistics)
+                     perf::StatisticsTemplate("kv.regular", statistics))
   , volatile_entries_(max_entries,
-                      "RamCache.volatile",
                       alloc,
                       max_size,
-                      statistics)
-  , counters_(statistics, "RamCache")
+                      perf::StatisticsTemplate("kv.volatile", statistics))
+  , counters_(statistics)
 {
   int retval = pthread_rwlock_init(&rwlock_, NULL);
   assert(retval == 0);

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -101,6 +101,7 @@ class RamCacheManager : public CacheManager {
   };
 
   virtual CacheManagerIds id() { return kRamCacheManager; }
+  virtual std::string Describe();
 
   RamCacheManager(
     uint64_t max_size,

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -62,7 +62,7 @@ class RamCacheManager : public CacheManager {
     perf::Counter *n_full;
     perf::Counter *n_realloc;
 
-    Counters(perf::StatisticsTemplate statistics) {
+    explicit Counters(perf::StatisticsTemplate statistics) {
       n_getsize = statistics.RegisterTemplated("n_getsize",
         "Number of GetSize calls");
       n_close = statistics.RegisterTemplated("n_close",

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -62,41 +62,41 @@ class RamCacheManager : public CacheManager {
     perf::Counter *n_full;
     perf::Counter *n_realloc;
 
-    Counters(perf::Statistics *statistics, const std::string &name) {
-      n_getsize = statistics->Register(name + ".n_getsize",
-        "Number of GetSize calls for " + name);
-      n_close = statistics->Register(name + ".n_close",
-        "Number of Close calls for " + name);
-      n_pread = statistics->Register(name + ".n_pread",
-        "Number of Pread calls for " + name);
-      n_dup = statistics->Register(name + ".n_dup",
-        "Number of Dup calls for " + name);
-      n_readahead = statistics->Register(name + ".n_readahead",
-        "Number of ReadAhead calls for " + name);
-      n_starttxn = statistics->Register(name + ".n_starttxn",
-        "Number of StartTxn calls for " + name);
-      n_write = statistics->Register(name + ".n_write",
-        "Number of Write calls for " + name);
-      n_reset = statistics->Register(name + ".n_reset",
-        "Number of Reset calls for " + name);
-      n_aborttxn = statistics->Register(name + ".n_aborttxn",
-        "Number of AbortTxn calls for " + name);
-      n_committxn = statistics->Register(name + ".n_committxn",
-        "Number of Commit calls for " + name);
-      n_enfile = statistics->Register(name + ".n_enfile",
-        "Number of times " + name + " reached the limit on handles");
-      n_openregular = statistics->Register(name + ".n_openregular",
-        "Number of opens from the regular cache for " + name);
-      n_openvolatile = statistics->Register(name + ".n_openvolatile",
-        "Number of opens from the volatile cache for " + name);
-      n_openmiss = statistics->Register(name + ".n_openmiss",
-        "Number of missed opens for " + name);
-      n_realloc = statistics->Register(name + ".n_realloc",
-        "Number of reallocs for " + name);
-      n_overrun = statistics->Register(name + ".n_overrun",
-        "Number of cache limit overruns for " + name);
-      n_full = statistics->Register(name + ".n_full",
-        "Number of overruns that could not be resolved for " + name);
+    Counters(perf::StatisticsTemplate statistics) {
+      n_getsize = statistics.RegisterTemplated("n_getsize",
+        "Number of GetSize calls");
+      n_close = statistics.RegisterTemplated("n_close",
+        "Number of Close calls");
+      n_pread = statistics.RegisterTemplated("n_pread",
+        "Number of Pread calls");
+      n_dup = statistics.RegisterTemplated("n_dup",
+        "Number of Dup calls");
+      n_readahead = statistics.RegisterTemplated("n_readahead",
+        "Number of ReadAhead calls");
+      n_starttxn = statistics.RegisterTemplated("n_starttxn",
+        "Number of StartTxn calls");
+      n_write = statistics.RegisterTemplated("n_write",
+        "Number of Write calls");
+      n_reset = statistics.RegisterTemplated("n_reset",
+        "Number of Reset calls");
+      n_aborttxn = statistics.RegisterTemplated("n_aborttxn",
+        "Number of AbortTxn calls");
+      n_committxn = statistics.RegisterTemplated("n_committxn",
+        "Number of Commit calls");
+      n_enfile = statistics.RegisterTemplated("n_enfile",
+        "Number of times the limit on handles was reached");
+      n_openregular = statistics.RegisterTemplated("n_openregular",
+        "Number of opens from the regular cache");
+      n_openvolatile = statistics.RegisterTemplated("n_openvolatile",
+        "Number of opens from the volatile cache");
+      n_openmiss = statistics.RegisterTemplated("n_openmiss",
+        "Number of missed opens");
+      n_realloc = statistics.RegisterTemplated("n_realloc",
+        "Number of reallocs");
+      n_overrun = statistics.RegisterTemplated("n_overrun",
+        "Number of cache limit overruns");
+      n_full = statistics.RegisterTemplated("n_full",
+        "Number of overruns that could not be resolved");
     }
   };
 
@@ -106,7 +106,7 @@ class RamCacheManager : public CacheManager {
     uint64_t max_size,
     unsigned max_entries,
     MemoryKvStore::MemoryAllocator alloc,
-    perf::Statistics *statistics);
+    perf::StatisticsTemplate statistics);
 
   virtual ~RamCacheManager();
 

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -11,6 +11,14 @@
 
 #include "platform.h"
 
+
+std::string TieredCacheManager::Describe() {
+  return "Tiered Cache\n"
+    "  - upper layer: " + upper_->Describe() + "\n"
+    "  - lower layer: " + lower_->Describe() + "\n";
+}
+
+
 int TieredCacheManager::Open(const BlessedObject &object) {
   int fd = upper_->Open(object);
   if ((fd >= 0) || (fd != -ENOENT)) {return fd;}

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "cache.h"
+#include "gtest/gtest_prod.h"
 
 /**
  * Cache manager implementation that provides a hierarchical cache.
@@ -23,6 +24,8 @@
  * The quota manager is only applied to the upper cache.
  */
 class TieredCacheManager : public CacheManager {
+  FRIEND_TEST(T_MountPoint, TieredCacheMgr);
+
  public:
   virtual CacheManagerIds id() { return kTieredCacheManager; }
 

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -29,6 +29,7 @@ class TieredCacheManager : public CacheManager {
 
  public:
   virtual CacheManagerIds id() { return kTieredCacheManager; }
+  virtual std::string Describe();
 
   static CacheManager *Create(CacheManager *upper_cache,
                               CacheManager *lower_cache)

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -25,6 +25,7 @@
  */
 class TieredCacheManager : public CacheManager {
   FRIEND_TEST(T_MountPoint, TieredCacheMgr);
+  FRIEND_TEST(T_MountPoint, TieredComplex);
 
  public:
   virtual CacheManagerIds id() { return kTieredCacheManager; }

--- a/cvmfs/cvmfs_talk
+++ b/cvmfs/cvmfs_talk
@@ -23,6 +23,7 @@ sub usage {
   print "\n";
   print "Commands:                                                         \n";
   print "  tracebuffer flush      flushes the trace buffer to disk         \n";
+  print "  cache instance         describes the active cache manager       \n";
   print "  cache size             gets current size of file cache          \n";
   print "  cache list             gets files in cache                      \n";
   print "  cache list pinned      gets pinned file catalogs in cache       \n";

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1544,8 +1544,7 @@ void DownloadManager::FiniHeaders() {
 
 void DownloadManager::Init(const unsigned max_pool_handles,
                            const bool use_system_proxy,
-                           perf::Statistics *statistics,
-                           const string &name)
+                           perf::StatisticsTemplate statistics)
 {
   atomic_init32(&multi_threaded_);
   int retval = curl_global_init(CURL_GLOBAL_ALL);
@@ -1564,7 +1563,7 @@ void DownloadManager::Init(const unsigned max_pool_handles,
   opt_host_chain_current_ = 0;
   opt_ip_preference_ = dns::kIpPreferSystem;
 
-  counters_ = new Counters(statistics, name);
+  counters_ = new Counters(statistics);
 
   user_agent_ = NULL;
   InitHeaders();
@@ -2683,12 +2682,9 @@ void DownloadManager::EnableRedirects() {
  * Creates a copy of the existing download manager.  Must only be called in
  * single-threaded stage because it calls curl_global_init().
  */
-DownloadManager *DownloadManager::Clone(
-  perf::Statistics *statistics,
-  const string &name)
-{
+DownloadManager *DownloadManager::Clone(perf::StatisticsTemplate statistics) {
   DownloadManager *clone = new DownloadManager();
-  clone->Init(pool_max_handles_, use_system_proxy_, statistics, name);
+  clone->Init(pool_max_handles_, use_system_proxy_, statistics);
   if (resolver_) {
     clone->SetDnsParameters(resolver_->retries(), resolver_->timeout_ms());
     clone->SetMaxIpaddrPerProxy(resolver_->throttle());

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -96,7 +96,7 @@ struct Counters {
   perf::Counter *n_proxy_failover;
   perf::Counter *n_host_failover;
 
-  Counters(perf::StatisticsTemplate statistics) {
+  explicit Counters(perf::StatisticsTemplate statistics) {
     sz_transferred_bytes = statistics.RegisterTemplated("sz_transferred_bytes",
         "Number of transferred bytes");
     sz_transfer_time = statistics.RegisterTemplated("sz_transfer_time",

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -96,17 +96,17 @@ struct Counters {
   perf::Counter *n_proxy_failover;
   perf::Counter *n_host_failover;
 
-  Counters(perf::Statistics *statistics, const std::string &name) {
-    sz_transferred_bytes = statistics->Register(name + ".sz_transferred_bytes",
+  Counters(perf::StatisticsTemplate statistics) {
+    sz_transferred_bytes = statistics.RegisterTemplated("sz_transferred_bytes",
         "Number of transferred bytes");
-    sz_transfer_time = statistics->Register(name + ".sz_transfer_time",
+    sz_transfer_time = statistics.RegisterTemplated("sz_transfer_time",
         "Transfer time (miliseconds)");
-    n_requests = statistics->Register(name + ".n_requests",
+    n_requests = statistics.RegisterTemplated("n_requests",
         "Number of requests");
-    n_retries = statistics->Register(name + ".n_retries", "Number of retries");
-    n_proxy_failover = statistics->Register(name + ".n_proxy_failover",
+    n_retries = statistics.RegisterTemplated("n_retries", "Number of retries");
+    n_proxy_failover = statistics.RegisterTemplated("n_proxy_failover",
         "Number of proxy failovers");
-    n_host_failover = statistics->Register(name + ".n_host_failover",
+    n_host_failover = statistics.RegisterTemplated("n_host_failover",
         "Number of host failovers");
   }
 };  // Counters
@@ -355,11 +355,12 @@ class DownloadManager {
 
   static int ParseHttpCode(const char digits[3]);
 
-  void Init(const unsigned max_pool_handles, const bool use_system_proxy,
-      perf::Statistics *statistics, const std::string &name = "download");
+  void Init(const unsigned max_pool_handles,
+            const bool use_system_proxy,
+            perf::StatisticsTemplate statistics);
   void Fini();
   void Spawn();
-  DownloadManager *Clone(perf::Statistics *statistics, const std::string &name);
+  DownloadManager *Clone(perf::StatisticsTemplate statistics);
   Failures Fetch(JobInfo *info);
 
   void SetCredentialsAttachment(CredentialsAttachment *ca);

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -194,8 +194,7 @@ Fetcher::Fetcher(
   CacheManager *cache_mgr,
   download::DownloadManager *download_mgr,
   BackoffThrottle *backoff_throttle,
-  perf::Statistics *statistics,
-  const std::string &name,
+  perf::StatisticsTemplate statistics,
   bool external)
   : external_(external)
   , lock_queues_download_(NULL)
@@ -215,7 +214,7 @@ Fetcher::Fetcher(
     smalloc(sizeof(pthread_mutex_t)));
   retval = pthread_mutex_init(lock_tls_blocks_, NULL);
   assert(retval == 0);
-  n_downloads = statistics->Register(name + ".n_downloads",
+  n_downloads = statistics.RegisterTemplated("n_downloads",
     "overall number of downloaded files (incl. catalogs, chunks)");
 }
 

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -70,8 +70,7 @@ class Fetcher : SingleCopy {
   Fetcher(CacheManager *cache_mgr,
           download::DownloadManager *download_mgr,
           BackoffThrottle *backoff_throttle,
-          perf::Statistics *statistics,
-          const std::string &name = "fetch",
+          perf::StatisticsTemplate statistics,
           bool external_data = false);
   ~Fetcher();
   // TODO(jblomer): reduce number of arguments

--- a/cvmfs/kvstore.cc
+++ b/cvmfs/kvstore.cc
@@ -34,18 +34,17 @@ const double MemoryKvStore::kCompactThreshold = 0.8;
 
 MemoryKvStore::MemoryKvStore(
   unsigned int cache_entries,
-  const string &name,
   MemoryAllocator alloc,
   unsigned alloc_size,
-  perf::Statistics *statistics)
+  perf::StatisticsTemplate statistics)
   : allocator_(alloc)
   , used_bytes_(0)
   , entry_count_(0)
   , max_entries_(cache_entries)
   , entries_(cache_entries, shash::Any(), hasher_any,
-      statistics, name)
+             perf::StatisticsTemplate("lru", statistics))
   , heap_(NULL)
-  , counters_(statistics, name + ".lru")
+  , counters_(statistics)
 {
   int retval = pthread_rwlock_init(&rwlock_, NULL);
   assert(retval == 0);

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -85,7 +85,7 @@ class MemoryKvStore : SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
     perf::Counter *sz_deleted;
     perf::Counter *sz_shrunk;
 
-    Counters(perf::StatisticsTemplate statistics) {
+    explicit Counters(perf::StatisticsTemplate statistics) {
       sz_size = statistics.RegisterTemplated("sz_size", "Total size");
       n_getsize = statistics.RegisterTemplated("n_getsize",
         "Number of GetSize calls");

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -85,41 +85,36 @@ class MemoryKvStore : SingleCopy, public Callbackable<MallocHeap::BlockPtr> {
     perf::Counter *sz_deleted;
     perf::Counter *sz_shrunk;
 
-    Counters(perf::Statistics *statistics, const std::string &name) {
-      sz_size = statistics->Register(name + ".sz_size", "Size for " + name);
-      n_getsize = statistics->Register(name + ".n_getsize",
-        "Number of GetSize calls for " + name);
-      n_getrefcount = statistics->Register(name + ".n_getrefcount",
-        "Number of GetRefcount calls for " + name);
-      n_incref = statistics->Register(name + ".n_incref",
-        "Number of IncRef calls for " + name);
-      n_unref = statistics->Register(name + ".n_unref",
-        "Number of Unref calls for " + name);
-      n_read = statistics->Register(name + ".n_read",
-        "Number of Read calls for " + name);
-      n_commit = statistics->Register(name + ".n_commit",
-        "Number of Commit calls for " + name);
-      n_delete = statistics->Register(name + ".n_delete",
-        "Number of Delete calls for " + name);
-      n_shrinkto = statistics->Register(name + ".n_shrinkto",
-        "Number of ShrinkTo calls for " + name);
-      sz_read = statistics->Register(name + ".sz_read",
-        "Bytes read for " + name);
-      sz_committed = statistics->Register(name + ".sz_committed",
-        "Bytes committed for " + name);
-      sz_deleted = statistics->Register(name + ".sz_deleted",
-        "Bytes deleted for " + name);
-      sz_shrunk = statistics->Register(name + ".sz_shrunk",
-        "Bytes shrunk for " + name);
+    Counters(perf::StatisticsTemplate statistics) {
+      sz_size = statistics.RegisterTemplated("sz_size", "Total size");
+      n_getsize = statistics.RegisterTemplated("n_getsize",
+        "Number of GetSize calls");
+      n_getrefcount = statistics.RegisterTemplated("n_getrefcount",
+        "Number of GetRefcount calls");
+      n_incref = statistics.RegisterTemplated("n_incref",
+        "Number of IncRef calls");
+      n_unref = statistics.RegisterTemplated("n_unref",
+        "Number of Unref calls");
+      n_read = statistics.RegisterTemplated("n_read", "Number of Read calls");
+      n_commit = statistics.RegisterTemplated("n_commit",
+        "Number of Commit calls");
+      n_delete = statistics.RegisterTemplated("n_delete",
+        "Number of Delete calls");
+      n_shrinkto = statistics.RegisterTemplated("n_shrinkto",
+        "Number of ShrinkTo calls");
+      sz_read = statistics.RegisterTemplated("sz_read", "Bytes read");
+      sz_committed = statistics.RegisterTemplated("sz_committed",
+        "Bytes committed");
+      sz_deleted = statistics.RegisterTemplated("sz_deleted", "Bytes deleted");
+      sz_shrunk = statistics.RegisterTemplated("sz_shrunk", "Bytes shrunk");
     }
   };
 
   MemoryKvStore(
     unsigned int cache_entries,
-    const string &name,
     MemoryAllocator alloc,
     unsigned alloc_size,
-    perf::Statistics *statistics);
+    perf::StatisticsTemplate statistics);
 
   ~MemoryKvStore();
 

--- a/cvmfs/libcvmfs_legacy.cc
+++ b/cvmfs/libcvmfs_legacy.cc
@@ -407,9 +407,11 @@ SimpleOptionsParser *cvmfs_options_init_legacy(char const *legacy_options) {
   if (!global_opts.alien_cachedir.empty()) {
     options_mgr->SetValue("CVMFS_ALIEN_CACHE", global_opts.alien_cachedir);
   }
-  if (global_opts.change_to_cache_directory) {
-    options_mgr->SetValue("CVMFS_CWD_CACHE", "on");
-  }
+  // Note: as of version 2.4 CVMFS_CWD_CACHE support was dropped due to
+  // disproportional large complexity in the FileSystem class
+  // if (global_opts.change_to_cache_directory) {
+  //  options_mgr->SetValue("CVMFS_CWD_CACHE", "on");
+  // }
   options_mgr->SetValue("CVMFS_SYSLOG_LEVEL",
                         StringifyInt(global_opts.log_syslog_level));
   if (!global_opts.log_prefix.empty()) {

--- a/cvmfs/lru.h
+++ b/cvmfs/lru.h
@@ -75,7 +75,7 @@ struct Counters {
   perf::Counter *n_drop;
   perf::Counter *sz_allocated;
 
-  Counters(perf::StatisticsTemplate statistics) {
+  explicit Counters(perf::StatisticsTemplate statistics) {
     sz_size = statistics.RegisterTemplated("sz_size", "Total size");
     num_collisions = 0;
     max_collisions = 0;

--- a/cvmfs/lru.h
+++ b/cvmfs/lru.h
@@ -75,29 +75,24 @@ struct Counters {
   perf::Counter *n_drop;
   perf::Counter *sz_allocated;
 
-  Counters(perf::Statistics *statistics, const std::string &name) {
-    sz_size = statistics->Register(name + ".sz_size", "Size for " + name);
+  Counters(perf::StatisticsTemplate statistics) {
+    sz_size = statistics.RegisterTemplated("sz_size", "Total size");
     num_collisions = 0;
     max_collisions = 0;
-    n_hit = statistics->Register(name + ".n_hit", "Number of hits for " + name);
-    n_miss = statistics->Register(name + ".n_miss",
-        "Number of misses for " + name);
-    n_insert = statistics->Register(name + ".n_insert",
-        "Number of inserts for " + name);
-    n_insert_negative = statistics->Register(name + ".n_insert_negative",
-        "Number of negative inserts for " + name);
-    n_update = statistics->Register(name + ".n_update",
-        "Number of updates for " + name);
-    n_update_value = statistics->Register(name + ".n_update_value",
-        "Number of value changes for " + name);
-    n_replace = statistics->Register(name + ".n_replace",
-        "Number of replaces for " + name);
-    n_forget = statistics->Register(name + ".n_forget",
-        "Number of forgets for " + name);
-    n_drop = statistics->Register(name + ".n_drop",
-        "Number of drops for " + name);
-    sz_allocated = statistics->Register(name + ".sz_allocated",
-        "Number of allocated bytes for " + name);
+    n_hit = statistics.RegisterTemplated("n_hit", "Number of hits");
+    n_miss = statistics.RegisterTemplated("n_miss", "Number of misses");
+    n_insert = statistics.RegisterTemplated("n_insert", "Number of inserts");
+    n_insert_negative = statistics.RegisterTemplated("n_insert_negative",
+        "Number of negative inserts");
+    n_update = statistics.RegisterTemplated("n_update",
+        "Number of updates");
+    n_update_value = statistics.RegisterTemplated("n_update_value",
+        "Number of value changes");
+    n_replace = statistics.RegisterTemplated("n_replace", "Number of replaces");
+    n_forget = statistics.RegisterTemplated("n_forget", "Number of forgets");
+    n_drop = statistics.RegisterTemplated("n_drop", "Number of drops");
+    sz_allocated = statistics.RegisterTemplated("sz_allocated",
+        "Number of allocated bytes ");
   }
 };
 
@@ -514,9 +509,8 @@ class LruCache : SingleCopy {
   LruCache(const unsigned   cache_size,
            const Key       &empty_key,
            uint32_t (*hasher)(const Key &key),
-           perf::Statistics *statistics,
-           const std::string &name) :
-    counters_(statistics, name),
+           perf::StatisticsTemplate statistics) :
+    counters_(statistics),
     pause_(false),
     cache_gauge_(0),
     cache_size_(cache_size),

--- a/cvmfs/lru_md.h
+++ b/cvmfs/lru_md.h
@@ -44,7 +44,8 @@ class InodeCache : public LruCache<fuse_ino_t, catalog::DirectoryEntry>
  public:
   explicit InodeCache(unsigned int cache_size, perf::Statistics *statistics) :
     LruCache<fuse_ino_t, catalog::DirectoryEntry>(
-      cache_size, fuse_ino_t(-1), hasher_inode, statistics, "inode_cache")
+      cache_size, fuse_ino_t(-1), hasher_inode,
+      perf::StatisticsTemplate("inode_cache", statistics))
   {
   }
 
@@ -77,7 +78,7 @@ class PathCache : public LruCache<fuse_ino_t, PathString> {
  public:
   explicit PathCache(unsigned int cache_size, perf::Statistics *statistics) :
     LruCache<fuse_ino_t, PathString>(cache_size, fuse_ino_t(-1), hasher_inode,
-        statistics, "path_cache")
+      perf::StatisticsTemplate("path_cache", statistics))
   {
   }
 
@@ -112,8 +113,8 @@ class Md5PathCache :
  public:
   explicit Md5PathCache(unsigned int cache_size, perf::Statistics *statistics) :
     LruCache<shash::Md5, catalog::DirectoryEntry>(
-      cache_size, shash::Md5(shash::AsciiPtr("!")), hasher_md5, statistics,
-      "md5_path_cache")
+      cache_size, shash::Md5(shash::AsciiPtr("!")), hasher_md5,
+      perf::StatisticsTemplate("md5_path_cache", statistics))
   {
     dirent_negative_ = catalog::DirectoryEntry(catalog::kDirentNegative);
   }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -715,34 +715,15 @@ bool FileSystem::SetupCwd() {
     return true;
   }
 
-  // Libcvmfs: change to cache directory (not workspace) if requested,
-  // otherwise don't touch current working directory.  We also need to create
-  // the cache directory.  This has to happen before we setup the crash guard
-  // or any other file where we remember the path.
-  // TODO(jblomer): can this be simplified?
-  /*string optarg;
-  if (options_mgr_->GetValue("CVMFS_CWD_CACHE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
-    const int mode = (cache_mode_ & kCacheAlien) ? 0770 : 0700;
-    if (!MkdirDeep(cache_dir_, mode, false)) {
-      boot_error_ = "cannot create cache directory " + cache_dir_;
-      boot_status_ = loader::kFailCacheDir;
-      return false;
-    }
-    if (workspace_ == cache_dir_) {
-      workspace_ = ".";
-    } else {
-      workspace_ = GetAbsolutePath(workspace_);
-    }
-    int retval = chdir(cache_dir_.c_str());
-    if (retval != 0) {
-      boot_error_ = "cache directory " + cache_dir_ + " is unavailable";
-      boot_status_ = loader::kFailCacheDir;
-      return false;
-    }
-    cache_dir_ = ".";
-  }*/
+  // Note: as of version 2.4 support for CVMFS_CWD_CACHE is dropped due to
+  // disproportionate large complexity to configure correctly.  This affects
+  // only libcvmfs, mostly the legacy part.
+  // string optarg;
+  // if (options_mgr_->GetValue("CVMFS_CWD_CACHE", &optarg) &&
+  //    options_mgr_->IsOn(optarg))
+  // {
+  //  ...
+  // }
   return true;
 }
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -629,7 +629,8 @@ CacheManager *FileSystem::SetupRamCacheMgr(const string &instance) {
       return NULL;
     }
   }
-  sz_cache_bytes = RoundUp8(std::max(static_cast<uint64_t>(200 * 1024 * 1024),                                     sz_cache_bytes));
+  sz_cache_bytes = RoundUp8(std::max(static_cast<uint64_t>(200 * 1024 * 1024),
+                                     sz_cache_bytes));
   RamCacheManager *cache_mgr = new RamCacheManager(
         sz_cache_bytes,
         nfiles,

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1137,7 +1137,8 @@ bool MountPoint::CreateDownloadManagers() {
   string optarg;
   download_mgr_ = new download::DownloadManager();
   const bool use_system_proxy = false;
-  download_mgr_->Init(kDefaultNumConnections, use_system_proxy, statistics_);
+  download_mgr_->Init(kDefaultNumConnections, use_system_proxy,
+                      perf::StatisticsTemplate("download", statistics_));
   download_mgr_->SetCredentialsAttachment(authz_attachment_);
 
   if (options_mgr_->GetValue("CVMFS_SERVER_URL", &optarg)) {
@@ -1183,15 +1184,14 @@ void MountPoint::CreateFetchers() {
     file_system_->cache_mgr(),
     download_mgr_,
     backoff_throttle_,
-    statistics_);
+    perf::StatisticsTemplate("fetch", statistics_));
 
   const bool is_external_data = true;
   external_fetcher_ = new cvmfs::Fetcher(
     file_system_->cache_mgr(),
     external_download_mgr_,
     backoff_throttle_,
-    statistics_,
-    "fetch-external",
+    perf::StatisticsTemplate("fetch-external", statistics_),
     is_external_data);
 }
 
@@ -1574,7 +1574,8 @@ void MountPoint::SetupDnsTuning(download::DownloadManager *manager) {
 bool MountPoint::SetupExternalDownloadMgr() {
   string optarg;
   external_download_mgr_ =
-    download_mgr_->Clone(statistics_, "download-external");
+    download_mgr_->Clone(perf::StatisticsTemplate("download-external",
+      statistics_));
 
   unsigned timeout;
   unsigned timeout_direct;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -520,7 +520,8 @@ CacheManager *FileSystem::SetupCacheMgr(const string &instance) {
   } else if (instance_type == "external") {
     return SetupExternalCacheMgr(instance);
   } else {
-    boot_error_ = "invalid cache manager type: " + instance_type;
+    boot_error_ = "invalid cache manager type for '" + instance +  "':" +
+      instance_type;
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -84,10 +84,10 @@ const char *FileSystem::kDefaultCacheMgrInstance = "default";
 bool FileSystem::CheckInstanceName(const std::string &instance) {
   if (instance.length() > 24)
     return false;
-  sanitizer::AlphaNumSanitizer instance_sanitizer;
+  sanitizer::CacheInstanceSanitizer instance_sanitizer;
   if (!instance_sanitizer.IsValid(instance)) {
     boot_error_ = "invalid instance name (" + instance + "), " +
-                  "only characters a-z, A-Z, 0-9 are allowed";
+                  "only characters a-z, A-Z, 0-9, _ are allowed";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -626,7 +626,7 @@ CacheManager *FileSystem::SetupRamCacheMgr(const string &instance) {
         sz_cache_bytes,
         nfiles,
         alloc,
-        statistics_);
+        perf::StatisticsTemplate("cache." + instance, statistics_));
   if (cache_mgr == NULL) {
     boot_error_ = "failed to create ram cache manager for " + instance;
     boot_status_ = loader::kFailCacheDir;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -580,7 +580,7 @@ CacheManager *FileSystem::SetupPosixCacheMgr(const string &instance) {
     boot_error_ = "Failed to setup posix cache '" + instance + "' in " +
                   settings.cache_path + ": " + strerror(errno);
     boot_status_ = loader::kFailCacheDir;
-    return false;
+    return NULL;
   }
 
   // Sentinel file for future use
@@ -590,7 +590,7 @@ CacheManager *FileSystem::SetupPosixCacheMgr(const string &instance) {
 
   if (settings.is_managed) {
     if (!SetupPosixQuotaMgr(settings, cache_mgr))
-      return false;
+      return NULL;
   }
   return cache_mgr.Release();
 }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -74,27 +74,48 @@ using namespace std;  // NOLINT
 
 bool FileSystem::g_alive = false;
 const char *FileSystem::kDefaultCacheBase = "/var/lib/cvmfs";
+const char *FileSystem::kDefaultCacheMgrInstance = "default";
+
+
+/**
+ * A cache instance name is part of a bash parameter and can only contain
+ * certain characters.
+ */
+bool FileSystem::CheckInstanceName(const std::string &instance) {
+  if (instance.length() > 24)
+    return false;
+  sanitizer::AlphaNumSanitizer instance_sanitizer;
+  if (!instance_sanitizer.IsValid(instance)) {
+    boot_error_ = "invalid instance name (" + instance + "), " +
+                  "only characters a-z, A-Z, 0-9 are allowed";
+    boot_status_ = loader::kFailCacheDir;
+    return false;
+  }
+  return true;
+}
 
 
 /**
  * Not all possible combinations of cache flags / modes are valid.
  */
-bool FileSystem::CheckCacheMode() {
-  if ((cache_mode_ & kCacheAlien) && (cache_mode_ & kCacheShared)) {
+bool FileSystem::CheckPosixCacheSettings(
+  const FileSystem::PosixCacheSettings &settings)
+{
+  if (settings.is_alien && settings.is_shared) {
     boot_error_ = "Failure: shared local disk cache and alien cache mutually "
-                  "exclusive. Turn off shared local disk cache.";
+                  "exclusive. Please turn off shared local disk cache.";
     boot_status_ = loader::kFailOptions;
     return false;
   }
-  if ((cache_mode_ & kCacheAlien) && (cache_mode_ & kCacheManaged)) {
+  if (settings.is_alien && settings.is_managed) {
     boot_error_ = "Failure: quota management and alien cache mutually "
-                  "exclusive. Turn off quota limit.";
+                  "exclusive. Please turn off quota limit.";
     boot_status_ = loader::kFailOptions;
     return false;
   }
 
   if (type_ == kFsLibrary) {
-    if (cache_mode_ & (kCacheShared | kCacheNfs | kCacheManaged)) {
+    if (settings.is_shared || settings.is_managed) {
       boot_error_ = "Failure: libcvmfs supports only unmanaged exclusive cache "
                     "or alien cache.";
       boot_status_ = loader::kFailOptions;
@@ -102,9 +123,7 @@ bool FileSystem::CheckCacheMode() {
     }
   }
 
-  if (options_mgr_->IsDefined("CVMFS_CACHE_BASE") &&
-      options_mgr_->IsDefined("CVMFS_CACHE_DIR"))
-  {
+  if (settings.cache_base_defined && settings.cache_dir_defined) {
     boot_error_ =
       "'CVMFS_CACHE_BASE' and 'CVMFS_CACHE_DIR' are mutually exclusive";
     boot_status_ = loader::kFailOptions;
@@ -129,11 +148,8 @@ FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
 
   file_system->CreateStatistics();
   file_system->SetupSqlite();
-
-  file_system->DetermineCacheMode();
-  if (!file_system->CheckCacheMode())
+  if (!file_system->DetermineNfsMode())
     return file_system.Release();
-  file_system->DetermineCacheDirs();
   if (!file_system->SetupWorkspace())
     return file_system.Release();
 
@@ -145,7 +161,7 @@ FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
            "%s",
            file_system->workspace_.c_str());
 
-  if (!file_system->CreateCache())
+  if (!file_system->TriageCacheMgr())
     return file_system.Release();
   file_system->SetupUuid();
   if (!file_system->SetupNfsMaps())
@@ -161,148 +177,6 @@ FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
 
   file_system->boot_status_ = loader::kFailOk;
   return file_system.Release();
-}
-
-
-/**
- * Initialize the cache directory and start the quota manager.
- */
-bool FileSystem::CreateCache() {
-  string optarg;
-  uint64_t nfiles;
-  uint64_t cache_bytes;
-  MemoryKvStore::MemoryAllocator alloc = MemoryKvStore::kMallocHeap;
-  CacheManager *second_cache_mgr = NULL;
-  CacheManager *tiered_cache_mgr = NULL;
-
-  cache_mgr_type_ = kPosixCacheManager;
-  if (options_mgr_->GetValue("CVMFS_CACHE_PRIMARY", &optarg)) {
-    LogCvmfs(kLogCache, kLogDebug, "requested cache type %s", optarg.c_str());
-    if (optarg == "posix") {
-      cache_mgr_type_ = kPosixCacheManager;
-    } else if (optarg == "ram") {
-      cache_mgr_type_ = kRamCacheManager;
-    } else if (optarg == "tiered") {
-      cache_mgr_type_ = kTieredCacheManager;
-    } else if (optarg == "external") {
-      cache_mgr_type_ = kExternalCacheManager;
-    } else {
-      cache_mgr_type_ = kUnknownCacheManager;
-    }
-  }
-
-  switch (cache_mgr_type_) {
-    case kExternalCacheManager: {
-      unsigned nfiles = 1024;
-      if (options_mgr_->GetValue("CVMFS_NFILES", &optarg))
-        nfiles = String2Uint64(optarg);
-      vector<string> cmd_line;
-      if (options_mgr_->GetValue("CVMFS_CACHE_EXTERNAL_CMDLINE", &optarg))
-        cmd_line = SplitString(optarg, ',');
-      if (!options_mgr_->GetValue("CVMFS_CACHE_EXTERNAL_LOCATOR", &optarg)) {
-        boot_error_ = "CVMFS_CACHE_EXTERNAL_LOCATOR missing";
-        boot_status_ = loader::kFailCacheDir;
-        return false;
-      }
-
-      UniquePtr<ExternalCacheManager::PluginHandle> plugin_handle(
-        ExternalCacheManager::CreatePlugin(optarg, cmd_line));
-      if (!plugin_handle->IsValid()) {
-        boot_error_ = plugin_handle->error_msg();
-        boot_status_ = loader::kFailCacheDir;
-        return false;
-      }
-      cache_mgr_ = ExternalCacheManager::Create(
-        plugin_handle->fd_connection(), nfiles, name_);
-      assert(cache_mgr_ != NULL);
-      break;
-    }
-    case kPosixCacheManager:
-    case kTieredCacheManager:
-      cache_mgr_ = PosixCacheManager::Create(
-                     cache_dir_,
-                     cache_mode_ & FileSystem::kCacheAlien,
-                     cache_mode_ & FileSystem::kCacheNoRename);
-      if (cache_mgr_ == NULL) {
-        boot_error_ = "Failed to setup cache in " + cache_dir_ + ": " +
-                      strerror(errno);
-        boot_status_ = loader::kFailCacheDir;
-        return false;
-      }
-      if (cache_mgr_type_ == kPosixCacheManager)
-        break;
-
-      second_cache_mgr = PosixCacheManager::Create(
-                           second_cache_dir_,
-                           second_cache_mode_ & FileSystem::kCacheAlien,
-                           second_cache_mode_ & FileSystem::kCacheNoRename);
-        if (second_cache_mgr == NULL) {
-          boot_error_ = "Failed to setup secondary cache in " +
-                        second_cache_dir_ + ": " + strerror(errno);
-          boot_status_ = loader::kFailCacheDir;
-          return false;
-        }
-
-      tiered_cache_mgr =
-        TieredCacheManager::Create(cache_mgr_, second_cache_mgr);
-      if (tiered_cache_mgr == NULL) {
-        boot_error_ = "Failed to setup tiered cache manager.";
-        boot_status_ = loader::kFailCacheDir;
-        return false;
-      }
-      cache_mgr_ = tiered_cache_mgr;
-      break;
-
-    case kRamCacheManager:
-      if (options_mgr_->GetValue("CVMFS_NFILES", &optarg)) {
-        nfiles = String2Uint64(optarg);
-      } else {
-        nfiles = 8192;
-      }
-      if (options_mgr_->GetValue("CVMFS_CACHE_RAM_SIZE", &optarg)) {
-        if (HasSuffix(optarg, "%", false)) {
-          cache_bytes = platform_memsize() * String2Uint64(optarg)/100;
-        } else {
-          cache_bytes = String2Uint64(optarg)*1024*1024;
-        }
-      } else {
-        cache_bytes = platform_memsize() >> 5;  // ~3%
-      }
-      if (options_mgr_->GetValue("CVMFS_CACHE_RAM_MALLOC", &optarg)) {
-        if (optarg == "libc") {
-          alloc = MemoryKvStore::kMallocLibc;
-        } else if (optarg == "heap") {
-          alloc = MemoryKvStore::kMallocHeap;
-        } else {
-          boot_error_ = "Failure: unknown malloc";
-          boot_status_ = loader::kFailOptions;
-          return false;
-        }
-      }
-      cache_bytes = RoundUp8(max((uint64_t) 200*1024*1024, cache_bytes));
-      cache_mgr_ = new RamCacheManager(
-        cache_bytes,
-        nfiles,
-        alloc,
-        statistics_);
-      break;
-
-    case kUnknownCacheManager:
-      boot_error_ = "Failure: unknown primary cache";
-      boot_status_ = loader::kFailOptions;
-      return false;
-  }
-
-  // Sentinel file for future use
-  const bool ignore_failure = IsAlienCache();  // Might be a read-only cache
-  CreateFile(cache_dir_ + "/.cvmfscache", 0600, ignore_failure);
-
-  if (cache_mode_ & FileSystem::kCacheManaged) {
-    if (!SetupQuotaMgmt())
-      return false;
-  }
-
-  return true;
 }
 
 
@@ -342,83 +216,91 @@ void FileSystem::CreateStatistics() {
 
 
 /**
- * Depending on the cache mode and other parameters, figure out the actual
- * path to the cache directory and set the workspace directory along the way.
+ * Figure out mode of operation and cache directory.  Checking options for
+ * sanity is in a separate method.
  */
-void FileSystem::DetermineCacheDirs() {
+FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
+  const string &instance
+) {
   string optarg;
+  PosixCacheSettings settings;
 
-  cache_dir_ = kDefaultCacheBase;
-  if (options_mgr_->GetValue("CVMFS_CACHE_BASE", &optarg))
-    cache_dir_ = MakeCanonicalPath(optarg);
-  if (options_mgr_->GetValue("CVMFS_SECOND_CACHE_DIR", &optarg))
-    second_cache_dir_ = MakeCanonicalPath(optarg);
-
-  if (cache_mode_ & kCacheShared) {
-    cache_dir_ += "/shared";
-  } else {
-    cache_dir_ += "/" + name_;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SHARED", instance),
+                             &optarg)
+      && options_mgr_->IsOn(optarg))
+  {
+    settings.is_shared = true;
   }
-  if (second_cache_mode_ & kCacheShared) {
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogStderr,
-             "Secondary cache cannot be shared.");
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SERVER_MODE", instance),
+                             &optarg)
+      && options_mgr_->IsOn(optarg))
+  {
+    settings.avoid_rename = true;
+  }
+
+  if (type_ == kFsFuse)
+    settings.quota_limit = kDefaultQuotaLimit;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_QUOTA_LIMIT", instance),
+                             &optarg))
+  {
+    settings.quota_limit = String2Int64(optarg) * 1024 * 1024;
+  }
+  if (settings.quota_limit > 0)
+    settings.is_managed = true;
+
+  settings.cache_path = kDefaultCacheBase;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_BASE", instance),
+                             &optarg))
+  {
+    settings.cache_path = MakeCanonicalPath(optarg);
+    settings.cache_base_defined = true;
+  }
+  if (settings.is_shared) {
+    settings.cache_path += "/shared";
+  } else {
+    settings.cache_path += "/" + name_;
   }
 
   // CheckCacheMode makes sure that CVMFS_CACHE_DIR and CVMFS_CACHE_BASE are
   // not set at the same time.
-  if (options_mgr_->GetValue("CVMFS_CACHE_DIR", &optarg))
-    cache_dir_ = optarg;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_DIR", instance),
+                             &optarg))
+  {
+    settings.cache_dir_defined = true;
+    settings.cache_path = optarg;
+  }
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_ALIEN", instance),
+                             &optarg))
+  {
+    settings.is_alien = true;
+    settings.cache_path = optarg;
+  }
+  if (settings.cache_path == workspace_fullpath_)
+    settings.cache_path = ".";
 
-  workspace_ = cache_dir_;
-  // Used by libcvmfs
-  if (options_mgr_->GetValue("CVMFS_WORKSPACE", &optarg))
-    workspace_ = optarg;
-
-  if (options_mgr_->GetValue("CVMFS_ALIEN_CACHE", &optarg))
-    cache_dir_ = optarg;
-
-  nfs_maps_dir_ = workspace_;
-  if (options_mgr_->GetValue("CVMFS_NFS_SHARED", &optarg))
-    nfs_maps_dir_ = optarg;
+  return settings;
 }
 
 
-void FileSystem::DetermineCacheMode() {
+bool FileSystem::DetermineNfsMode() {
   string optarg;
-
-  if (options_mgr_->GetValue("CVMFS_SHARED_CACHE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
-    cache_mode_ = kCacheShared;
-  } else {
-    cache_mode_ = kCacheExclusive;
-  }
-
-  if (options_mgr_->GetValue("CVMFS_ALIEN_CACHE", &optarg)) {
-    cache_mode_ |= kCacheAlien;
-  }
 
   if (options_mgr_->GetValue("CVMFS_NFS_SOURCE", &optarg) &&
       options_mgr_->IsOn(optarg))
   {
-    cache_mode_ |= kCacheNfs;
+    nfs_mode_ |= kNfsMaps;
     if (options_mgr_->GetValue("CVMFS_NFS_SHARED", &optarg)) {
-      cache_mode_ |= kCacheNfsHa;
+      nfs_mode_ |= kNfsMapsHa;
+      nfs_maps_dir_ = optarg;
     }
   }
-  if (options_mgr_->GetValue("CVMFS_SERVER_CACHE_MODE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
-    cache_mode_ |= kCacheNoRename;
+
+  if ((type_ == kFsLibrary) && (nfs_mode_ != kNfsNone)) {
+    boot_error_ = "Failure: libcvmfs does not support NFS export.";
+    boot_status_ = loader::kFailOptions;
+    return false;
   }
-
-  if (options_mgr_->GetValue("CVMFS_QUOTA_LIMIT", &optarg))
-    quota_limit_ = String2Int64(optarg) * 1024 * 1024;
-  if (quota_limit_ > 0)
-    cache_mode_ |= kCacheManaged;
-
-  if (options_mgr_->IsDefined("CVMFS_SECOND_CACHE_DIR"))
-    second_cache_mode_ = kCacheAlien | kCacheNoRename;
+  return true;
 }
 
 
@@ -443,14 +325,11 @@ FileSystem::FileSystem(const FileSystem::FileSystemInfo &fs_info)
   , statistics_(NULL)
   , fd_workspace_lock_(-1)
   , found_previous_crash_(false)
-  , cache_mode_(0)
-  , second_cache_mode_(0)
-  , quota_limit_((fs_info.type == kFsLibrary) ? 0 : kDefaultQuotaLimit)
+  , nfs_mode_(kNfsNone)
   , cache_mgr_(NULL)
   , uuid_cache_(NULL)
   , has_nfs_maps_(false)
   , has_custom_sqlitevfs_(false)
-  , cache_mgr_type_(kUnknownCacheManager)
 {
   assert(!g_alive);
   g_alive = true;
@@ -458,8 +337,10 @@ FileSystem::FileSystem(const FileSystem::FileSystemInfo &fs_info)
   g_gid = getegid();
 
   string optarg;
-  if (options_mgr_->GetValue("CVMFS_SERVER_CACHE_MODE", &optarg) &&
-      options_mgr_->IsOn(optarg))
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SERVER_CACHE",
+                                         kDefaultCacheMgrInstance),
+                             &optarg)
+      && options_mgr_->IsOn(optarg))
   {
     g_raw_symlinks = true;
   }
@@ -565,8 +446,227 @@ void FileSystem::LogSqliteError(
 }
 
 
+/**
+ * Creates the cache parameter for a specific instance of the cache.  Injects
+ * the instance name such that CVMFS_CACHE_FOO_BAR becomes
+ * CVMFS_CACHE_<INSTANCE>_FOO_BAR
+ */
+string FileSystem::MkCacheParm(
+  const string &generic_parameter,
+  const string &instance)
+{
+  assert(HasPrefix(generic_parameter, "CVMFS_CACHE_", false));
+
+  if (instance == kDefaultCacheMgrInstance) {
+    // Compatibility parameter names
+    if ((generic_parameter == "CVMFS_CACHE_SHARED") &&
+        !options_mgr_->IsDefined(generic_parameter))
+    {
+      return "CVMFS_SHARED_CACHE";
+    }
+    if ((generic_parameter == "CVMFS_CACHE_ALIEN") &&
+        !options_mgr_->IsDefined(generic_parameter))
+    {
+      return "CVMFS_ALIEN_CACHE";
+    }
+    if ((generic_parameter == "CVMFS_CACHE_SERVER_MODE") &&
+        !options_mgr_->IsDefined(generic_parameter))
+    {
+      return "CVMFS_SERVER_CACHE_MODE";
+    }
+    if ((generic_parameter == "CVMFS_CACHE_QUOTA_LIMIT") &&
+        !options_mgr_->IsDefined(generic_parameter))
+    {
+      return "CVMFS_QUOTA_LIMIT";
+    }
+    return generic_parameter;
+  }
+
+  return "CVMFS_CACHE_" + instance + "_" + generic_parameter.substr(12);
+}
+
+
 void FileSystem::ResetErrorCounters() {
   n_io_error_->Set(0);
+}
+
+
+/**
+ * Can be recursive for the tiered cache manager.
+ */
+CacheManager *FileSystem::SetupCacheMgr(const string &instance) {
+  LogCvmfs(kLogCvmfs, kLogDebug, "setting up cache manager instance %s",
+           instance.c_str());
+  string instance_type;
+  if (instance == kDefaultCacheMgrInstance) {
+    instance_type = "posix";
+  } else {
+    options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_TYPE", instance),
+                           &instance_type);
+  }
+  if (instance_type == "posix") {
+    return SetupPosixCacheMgr(instance);
+  } else if (instance_type == "ram") {
+    return SetupRamCacheMgr(instance);
+  } else if (instance_type == "tiered") {
+    return SetupTieredCacheMgr(instance);
+  } else if (instance_type == "external") {
+    return SetupExternalCacheMgr(instance);
+  } else {
+    boot_error_ = "invalid cache manager type: " + instance_type;
+    boot_status_ = loader::kFailCacheDir;
+    return false;
+  }
+}
+
+
+CacheManager *FileSystem::SetupExternalCacheMgr(const string &instance) {
+  string optarg;
+  unsigned nfiles = kDefaultNfiles;
+  if (options_mgr_->GetValue("CVMFS_NFILES", &optarg))
+    nfiles = String2Uint64(optarg);
+  vector<string> cmd_line;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_CMDLINE", instance),
+      &optarg))
+  {
+    cmd_line = SplitString(optarg, ',');
+  }
+
+  if (!options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_LOCATOR", instance),
+      &optarg))
+  {
+    boot_error_ = MkCacheParm("CVMFS_CACHE_LOCATOR", instance) + " missing";
+    boot_status_ = loader::kFailCacheDir;
+    return NULL;
+  }
+
+  UniquePtr<ExternalCacheManager::PluginHandle> plugin_handle(
+    ExternalCacheManager::CreatePlugin(optarg, cmd_line));
+  if (!plugin_handle->IsValid()) {
+    boot_error_ = plugin_handle->error_msg();
+    boot_status_ = loader::kFailCacheDir;
+    return NULL;
+  }
+  ExternalCacheManager *cache_mgr = ExternalCacheManager::Create(
+    plugin_handle->fd_connection(), nfiles, name_ + ":" + instance);
+  if (cache_mgr == NULL) {
+    boot_error_ = "failed to create external cache manager for " + instance;
+    boot_status_ = loader::kFailCacheDir;
+    return NULL;
+  }
+  cache_mgr->AcquireQuotaManager(ExternalQuotaManager::Create(cache_mgr));
+  return cache_mgr;
+}
+
+
+CacheManager *FileSystem::SetupPosixCacheMgr(const string &instance) {
+  PosixCacheSettings settings = DeterminePosixCacheSettings(instance);
+  if (!CheckPosixCacheSettings(settings))
+    return NULL;
+
+  UniquePtr<PosixCacheManager> cache_mgr(PosixCacheManager::Create(
+    settings.cache_path,
+    settings.is_alien,
+    settings.avoid_rename));
+  if (!cache_mgr.IsValid()) {
+    boot_error_ = "Failed to setup posix cache '" + instance + "' in " +
+                  settings.cache_path + ": " + strerror(errno);
+    boot_status_ = loader::kFailCacheDir;
+    return false;
+  }
+
+  // Sentinel file for future use
+  // Might be a read-only cache
+  const bool ignore_failure = settings.is_alien;
+  CreateFile(settings.cache_path + "/.cvmfscache", 0600, ignore_failure);
+
+  if (settings.is_managed) {
+    if (!SetupPosixQuotaMgr(settings, cache_mgr))
+      return false;
+  }
+  return cache_mgr.Release();
+}
+
+
+CacheManager *FileSystem::SetupRamCacheMgr(const string &instance) {
+  string optarg;
+  unsigned nfiles = kDefaultNfiles;
+  if (options_mgr_->GetValue("CVMFS_NFILES", &optarg)) {
+    nfiles = String2Uint64(optarg);
+  }
+  uint64_t sz_cache_bytes;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SIZE", instance),
+                             &optarg))
+  {
+    if (HasSuffix(optarg, "%", false)) {
+      sz_cache_bytes = platform_memsize() * String2Uint64(optarg)/100;
+    } else {
+      sz_cache_bytes = String2Uint64(optarg) * 1024 * 1024;
+    }
+  } else {
+    sz_cache_bytes = platform_memsize() >> 5;  // ~3%
+  }
+  MemoryKvStore::MemoryAllocator alloc = MemoryKvStore::kMallocHeap;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_MALLOC", instance),
+                             &optarg))
+  {
+    if (optarg == "libc") {
+      alloc = MemoryKvStore::kMallocLibc;
+    } else if (optarg == "heap") {
+      alloc = MemoryKvStore::kMallocHeap;
+    } else {
+      boot_error_ = "Failure: unknown malloc " +
+                    MkCacheParm("CVMFS_CACHE_MALLOC", instance) + "=" + optarg;
+      boot_status_ = loader::kFailOptions;
+      return NULL;
+    }
+  }
+  sz_cache_bytes = RoundUp8(std::max(static_cast<uint64_t>(200 * 1024 * 1024),                                     sz_cache_bytes));
+  RamCacheManager *cache_mgr = new RamCacheManager(
+        sz_cache_bytes,
+        nfiles,
+        alloc,
+        statistics_);
+  if (cache_mgr == NULL) {
+    boot_error_ = "failed to create ram cache manager for " + instance;
+    boot_status_ = loader::kFailCacheDir;
+    return NULL;
+  }
+  cache_mgr->AcquireQuotaManager(new NoopQuotaManager());
+  return cache_mgr;
+}
+
+
+CacheManager *FileSystem::SetupTieredCacheMgr(const string &instance) {
+  string optarg;
+  if (!options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_UPPER", instance),
+                              &optarg))
+  {
+    boot_error_ = MkCacheParm("CVMFS_CACHE_UPPER", instance) + " missing";
+    boot_status_ = loader::kFailOptions;
+    return NULL;
+  }
+  UniquePtr<CacheManager> upper(SetupCacheMgr(optarg));
+  if (!upper.IsValid())
+    return NULL;
+
+  if (!options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_LOWER", instance),
+                              &optarg))
+  {
+    boot_error_ = MkCacheParm("CVMFS_CACHE_LOWER", instance) + " missing";
+    boot_status_ = loader::kFailOptions;
+    return NULL;
+  }
+  UniquePtr<CacheManager> lower(SetupCacheMgr(optarg));
+
+  CacheManager *tiered =
+    TieredCacheManager::Create(upper.Release(), lower.Release());
+  if (tiered == NULL) {
+    boot_error_ = "Failed to setup tiered cache manager " + instance;
+    boot_status_ = loader::kFailCacheDir;
+    return NULL;
+  }
+  return tiered;
 }
 
 
@@ -576,11 +676,8 @@ bool FileSystem::SetupCrashGuard() {
   int retval = platform_stat(path_crash_guard_.c_str(), &info);
   if (retval == 0) {
     found_previous_crash_ = true;
-    string msg = "looks like cvmfs has been crashed previously";
-    if (cache_mode_ & kCacheManaged) {
-      msg += ", rebuilding cache database";
-    }
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn, "%s", msg.c_str());
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
+             "looks like cvmfs has been crashed previously");
   }
   retval = open(path_crash_guard_.c_str(), O_RDONLY | O_CREAT, 0600);
   if (retval < 0) {
@@ -604,8 +701,6 @@ bool FileSystem::SetupCwd() {
       boot_status_ = loader::kFailCacheDir;
       return false;
     }
-    if (workspace_ == cache_dir_)
-      cache_dir_ = ".";
     workspace_ = ".";
     return true;
   }
@@ -615,7 +710,7 @@ bool FileSystem::SetupCwd() {
   // the cache directory.  This has to happen before we setup the crash guard
   // or any other file where we remember the path.
   // TODO(jblomer): can this be simplified?
-  string optarg;
+  /*string optarg;
   if (options_mgr_->GetValue("CVMFS_CWD_CACHE", &optarg) &&
       options_mgr_->IsOn(optarg))
   {
@@ -637,7 +732,7 @@ bool FileSystem::SetupCwd() {
       return false;
     }
     cache_dir_ = ".";
-  }
+  }*/
   return true;
 }
 
@@ -662,23 +757,42 @@ void FileSystem::SetupLogging() {
 
 bool FileSystem::SetupNfsMaps() {
 #ifdef CVMFS_NFS_SUPPORT
-  string no_nfs_sentinel = cache_dir_ + "/no_nfs_maps." + name_;
+  if (!IsHaNfsSource())
+    nfs_maps_dir_ = workspace_;
 
-  if (!IsNfsSource()) {
-    const bool ignore_failure = IsAlienCache();  // Might be a read-only cache
-    CreateFile(no_nfs_sentinel, 0600, ignore_failure);
+  string no_nfs_sentinel;
+  if (cache_mgr_->id() == kPosixCacheManager) {
+    PosixCacheManager *posix_cache_mgr =
+        reinterpret_cast<PosixCacheManager *>(cache_mgr_);
+    no_nfs_sentinel = posix_cache_mgr->cache_path() + "/no_nfs_maps." + name_;
+    if (!IsNfsSource()) {
+      // Might be a read-only cache
+      const bool ignore_failure = posix_cache_mgr->alien_cache();
+      CreateFile(no_nfs_sentinel, 0600, ignore_failure);
+      return true;
+    }
+  } else {
+    if (IsNfsSource()) {
+      boot_error_ = "NFS source only works with POSIX cache manager.";
+      boot_status_ = loader::kFailNfsMaps;
+      return false;
+    }
     return true;
   }
 
-  // nfs maps need to be protected by workspace lock
-  assert(cache_dir_ == workspace_);
-
-  if (FileExists(no_nfs_sentinel)) {
+  assert(cache_mgr_->id() == kPosixCacheManager);
+  assert(IsNfsSource());
+  if (!no_nfs_sentinel.empty() && FileExists(no_nfs_sentinel)) {
     boot_error_ = "Cache was used without NFS maps before. "
                   "It has to be wiped out.";
     boot_status_ = loader::kFailNfsMaps;
     return false;
   }
+
+  // nfs maps need to be protected by workspace lock
+  PosixCacheManager *posix_cache_mgr =
+        reinterpret_cast<PosixCacheManager *>(cache_mgr_);
+  assert(posix_cache_mgr->cache_path() == workspace_);
 
   string inode_cache_dir = nfs_maps_dir_ + "/nfs_maps." + name_;
   if (!MkdirDeep(inode_cache_dir, 0700)) {
@@ -692,7 +806,7 @@ bool FileSystem::SetupNfsMaps() {
     nfs_maps::Init(inode_cache_dir,
                    catalog::ClientCatalogManager::kInodeOffset + 1,
                    found_previous_crash_,
-                   cache_mode_ & FileSystem::kCacheNfsHa);
+                   IsHaNfsSource());
   if (!retval) {
     boot_error_ = "Failed to initialize NFS maps";
     boot_status_ = loader::kFailNfsMaps;
@@ -706,26 +820,19 @@ bool FileSystem::SetupNfsMaps() {
 }
 
 
-bool FileSystem::SetupQuotaMgmt() {
-  if (cache_mgr_type_ == kRamCacheManager) {
-    cache_mgr_->AcquireQuotaManager(new NoopQuotaManager());
-    return true;
-  }
-  if (cache_mgr_type_ == kExternalCacheManager) {
-    cache_mgr_->AcquireQuotaManager(ExternalQuotaManager::Create(
-      reinterpret_cast<ExternalCacheManager *>(cache_mgr_)));
-    return true;
-  }
-
-  assert(quota_limit_ >= 0);
-  int64_t quota_threshold = quota_limit_ / 2;
+bool FileSystem::SetupPosixQuotaMgr(
+  const FileSystem::PosixCacheSettings &settings,
+  CacheManager *cache_mgr
+) {
+  assert(settings.quota_limit >= 0);
+  int64_t quota_threshold = settings.quota_limit / 2;
   PosixQuotaManager *quota_mgr;
 
-  if (cache_mode_ & FileSystem::kCacheShared) {
+  if (settings.is_shared) {
     quota_mgr = PosixQuotaManager::CreateShared(
                   exe_path_,
-                  cache_dir_,
-                  quota_limit_,
+                  settings.cache_path,
+                  settings.quota_limit,
                   quota_threshold,
                   foreground_);
     if (quota_mgr == NULL) {
@@ -735,10 +842,10 @@ bool FileSystem::SetupQuotaMgmt() {
     }
   } else {
     // Cache database should to be protected by workspace lock
-    assert(workspace_ == cache_dir_);
+    assert(workspace_ == settings.cache_path);
     quota_mgr = PosixQuotaManager::Create(
-                  cache_dir_,
-                  quota_limit_,
+                  settings.cache_path,
+                  settings.quota_limit,
                   quota_threshold,
                   found_previous_crash_);
     if (quota_mgr == NULL) {
@@ -761,7 +868,7 @@ bool FileSystem::SetupQuotaMgmt() {
     }
   }
 
-  int retval = cache_mgr_->AcquireQuotaManager(quota_mgr);
+  int retval = cache_mgr->AcquireQuotaManager(quota_mgr);
   assert(retval);
   LogCvmfs(kLogCvmfs, kLogDebug,
            "CernVM-FS: quota initialized, current size %luMB",
@@ -788,10 +895,37 @@ void FileSystem::SetupSqlite() {
 
 
 bool FileSystem::SetupWorkspace() {
+  string optarg;
+  // This is very similar to "determine cache dir".  It's for backward
+  // compatibility with classic cache configuration where there was no
+  // distinction between workspace and cache.
+  // Complicated cache configurations should explicitly set CVMFS_WORKSPACE.
+  workspace_ = kDefaultCacheBase;
+  if (options_mgr_->GetValue("CVMFS_CACHE_BASE", &optarg))
+    workspace_ = MakeCanonicalPath(optarg);
+  if (options_mgr_->GetValue("CVMFS_SHARED_CACHE", &optarg) &&
+      options_mgr_->IsOn(optarg))
+  {
+    workspace_ += "/shared";
+  } else {
+    workspace_ += "/" + name_;
+  }
+  if (options_mgr_->GetValue("CVMFS_CACHE_DIR", &optarg)) {
+    if (options_mgr_->IsDefined("CVMFS_CACHE_BASE")) {
+      boot_error_ =
+        "'CVMFS_CACHE_BASE' and 'CVMFS_CACHE_DIR' are mutually exclusive";
+      boot_status_ = loader::kFailOptions;
+      return false;
+    }
+    workspace_ = optarg;
+  }
+  if (options_mgr_->GetValue("CVMFS_WORKSPACE", &optarg))
+    workspace_ = optarg;
+  workspace_fullpath_ = workspace_;
+
   // If workspace and alien cache are the same directory, we need to open
   // permission now to 0770 to avoid a race when fixing it later
-  const int mode = ((cache_mode_ & kCacheAlien) && (workspace_ == cache_dir_)) ?
-                   0770 : 0700;
+  const int mode = 0770;
   if (!MkdirDeep(workspace_, mode, false)) {
     boot_error_ = "cannot create workspace directory " + workspace_;
     boot_status_ = loader::kFailCacheDir;
@@ -810,23 +944,10 @@ bool FileSystem::SetupWorkspace() {
 
 
 void FileSystem::SetupUuid() {
-  // Create or load from cache, used as id by the download manager when the
-  // proxy template is replaced
-  switch (cache_mgr_type_) {
-    case kPosixCacheManager:
-    case kTieredCacheManager:
-      uuid_cache_ = cvmfs::Uuid::Create(cache_dir_ + "/uuid");
-      break;
-    case kRamCacheManager:
-    case kExternalCacheManager:
-      uuid_cache_ = cvmfs::Uuid::Create("");
-      break;
-    case kUnknownCacheManager:
-      abort();
-  }
+  uuid_cache_ = cvmfs::Uuid::Create(workspace_ + "/uuid");
   if (uuid_cache_ == NULL) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-             "failed to load/store %s/uuid", cache_dir_.c_str());
+             "failed to load/store %s/uuid", workspace_.c_str());
     uuid_cache_ = cvmfs::Uuid::Create("");
     assert(uuid_cache_ != NULL);
   }
@@ -847,6 +968,22 @@ void FileSystem::TearDown2ReadOnly() {
   unlink(path_crash_guard_.c_str());
   LogCvmfs(kLogCache, kLogSyslog, "switch to read-only cache mode");
   SetLogMicroSyslog("");
+}
+
+
+bool FileSystem::TriageCacheMgr() {
+  cache_mgr_instance_ = kDefaultCacheMgrInstance;
+  string instance;
+  if (options_mgr_->GetValue("CVMFS_CACHE_PRIMARY", &instance) &&
+      !instance.empty())
+  {
+    if (!CheckInstanceName(instance))
+      return false;
+    cache_mgr_instance_ = instance;
+  }
+
+  cache_mgr_ = SetupCacheMgr(cache_mgr_instance_);
+  return cache_mgr_ != NULL;
 }
 
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include <ctime>
+#include <set>
 #include <string>
 
 #include "cache.h"
@@ -306,6 +307,11 @@ class FileSystem : SingleCopy, public BootFactory {
    * is specified.
    */
   std::string cache_mgr_instance_;
+  /**
+   * Keep track of all the cache instances to detect circular definitions with
+   * the tiered cache.
+   */
+  std::set<std::string> constructed_instances_;
   std::string nfs_maps_dir_;
   /**
    * Combination of kNfs... flags

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "cache.h"
+#include "gtest/gtest_prod.h"
 #include "hash.h"
 #include "loader.h"
 #include "util/pointer.h"
@@ -85,6 +86,11 @@ class BootFactory {
  * object and one MountPoint object.
  */
 class FileSystem : SingleCopy, public BootFactory {
+  FRIEND_TEST(T_MountPoint, MkCacheParm);
+  FRIEND_TEST(T_MountPoint, CacheSettings);
+  FRIEND_TEST(T_MountPoint, CheckInstanceName);
+  FRIEND_TEST(T_MountPoint, CheckPosixCacheSettings);
+
  public:
   enum Type {
     kFsFuse = 0,
@@ -137,46 +143,28 @@ class FileSystem : SingleCopy, public BootFactory {
   };
 
   /**
-   * Local hard disk cache, no shared quota manager.
+   * No NFS maps.
    */
-  static const unsigned kCacheExclusive  = 0x01;
+  static const unsigned kNfsNone = 0x00;
   /**
-   * Connect to the quota manager process for a shared local hard disk cache.
+   * Normal NFS maps by leveldb
    */
-  static const unsigned kCacheShared     = 0x02;
+  static const unsigned kNfsMaps = 0x01;
   /**
-   * Unmanaged cache (no cleanup), cache directory writable
-   * for owner uid _and_ gid
+   * NFS maps maintained by sqlite so that they can reside on an NFS mount
    */
-  static const unsigned kCacheAlien      = 0x04;
-  /**
-   * Whether to use a quota manager or not.
-   */
-  static const unsigned kCacheManaged    = 0x08;
-  /**
-   * Use NFS maps to persistently map paths to inodes.
-   */
-  static const unsigned kCacheNfs        = 0x10;
-  /**
-   * Store NFS maps on an NFS volume.
-   */
-  static const unsigned kCacheNfsHa      = 0x20;
-  /**
-   * Avoid rename() calls in the cache directory (replaced by link+unlink)
-   */
-  static const unsigned kCacheNoRename   = 0x40;
+  static const unsigned kNfsMapsHa = 0x02;
 
   static FileSystem *Create(const FileSystemInfo &fs_info);
   ~FileSystem();
 
-  bool IsNfsSource() { return cache_mode_ & kCacheNfs; }
-  bool IsAlienCache() { return cache_mode_ & kCacheAlien; }
+  bool IsNfsSource() { return nfs_mode_ & kNfsMaps; }
+  bool IsHaNfsSource() { return nfs_mode_ & kNfsMapsHa; }
   void ResetErrorCounters();
   void TearDown2ReadOnly();
 
-  std::string cache_dir() { return cache_dir_; }
   CacheManager *cache_mgr() { return cache_mgr_; }
-  int cache_mode() { return cache_mode_; }
+  std::string cache_mgr_instance() { return cache_mgr_instance_; }
   std::string exe_path() { return exe_path_; }
   bool found_previous_crash() { return found_previous_crash_; }
   perf::Counter *n_fs_dir_open() { return n_fs_dir_open_; }
@@ -188,13 +176,9 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_fs_readlink() { return n_fs_readlink_; }
   perf::Counter *n_fs_stat() { return n_fs_stat_; }
   perf::Counter *n_io_error() { return n_io_error_; }
-  std::string nfs_maps_dir() { return nfs_maps_dir_; }
   perf::Counter *no_open_dirs() { return no_open_dirs_; }
   perf::Counter *no_open_files() { return no_open_files_; }
   OptionsManager *options_mgr() { return options_mgr_; }
-  int64_t quota_limit() { return quota_limit_; }
-  std::string second_cache_dir() { return second_cache_dir_; }
-  int second_cache_mode() { return cache_mode_; }
   perf::Statistics *statistics() { return statistics_; }
   Type type() { return type_; }
   cvmfs::Uuid *uuid_cache() { return uuid_cache_; }
@@ -207,6 +191,28 @@ class FileSystem : SingleCopy, public BootFactory {
   static bool g_alive;
   static const char *kDefaultCacheBase;  // /var/lib/cvmfs
   static const unsigned kDefaultQuotaLimit = 1024 * 1024 * 1024;  // 1GB
+  static const unsigned kDefaultNfiles = 8192;  // if CVMFS_NFILES is unset
+  static const char *kDefaultCacheMgrInstance;  // "default"
+
+  struct PosixCacheSettings {
+    PosixCacheSettings() :
+      is_shared(false), is_alien(false), is_managed(false),
+      avoid_rename(false), cache_base_defined(false), cache_dir_defined(false),
+      quota_limit(0)
+      { }
+    bool is_shared;
+    bool is_alien;
+    bool is_managed;
+    bool avoid_rename;
+    bool cache_base_defined;
+    bool cache_dir_defined;
+    /**
+     * Soft limit in bytes for the cache.  The quota manager removes half the
+     * cache when the limit is exceeded.
+     */
+    int64_t quota_limit;
+    std::string cache_path;
+  };
 
   static void LogSqliteError(void *user_data __attribute__((unused)),
                              int sqlite_extended_error,
@@ -217,19 +223,27 @@ class FileSystem : SingleCopy, public BootFactory {
   void SetupLogging();
   void CreateStatistics();
   void SetupSqlite();
+  bool DetermineNfsMode();
   bool SetupWorkspace();
   bool SetupCwd();
   bool LockWorkspace();
   bool SetupCrashGuard();
-  bool CreateCache();
-  bool SetupQuotaMgmt();
   bool SetupNfsMaps();
   void SetupUuid();
 
-  bool CheckCacheMode();
-  void DetermineCacheMode();
-  void DetermineCacheDirs();
-  void DetermineMountpoint();
+  std::string MkCacheParm(const std::string &generic_parameter,
+                          const std::string &instance);
+  bool CheckInstanceName(const std::string &instance);
+  bool TriageCacheMgr();
+  CacheManager *SetupCacheMgr(const std::string &instance);
+  CacheManager *SetupPosixCacheMgr(const std::string &instance);
+  CacheManager *SetupRamCacheMgr(const std::string &instance);
+  CacheManager *SetupTieredCacheMgr(const std::string &instance);
+  CacheManager *SetupExternalCacheMgr(const std::string &instance);
+  PosixCacheSettings DeterminePosixCacheSettings(const std::string &instance);
+  bool CheckPosixCacheSettings(const PosixCacheSettings &settings);
+  bool SetupPosixQuotaMgr(const PosixCacheSettings &settings,
+                          CacheManager *cache_mgr);
 
   // See FileSystemInfo for the following fields
   std::string name_;
@@ -262,6 +276,12 @@ class FileSystem : SingleCopy, public BootFactory {
    * FileSystem instances if their name is different.
    */
   std::string workspace_;
+  /**
+   * During setup, the fuse module changes its working directory to workspace.
+   * Afterwards, workspace_ is ".".  Store the original one in
+   * workspace_fullpath_
+   */
+  std::string workspace_fullpath_;
   int fd_workspace_lock_;
   std::string path_workspace_lock_;
 
@@ -281,22 +301,16 @@ class FileSystem : SingleCopy, public BootFactory {
    * location.
    */
   std::string mountpoint_;
-  std::string cache_dir_;
-  std::string second_cache_dir_;
+  /**
+   * The user-provided name of the parimay cache manager or 'default' if none
+   * is specified.
+   */
+  std::string cache_mgr_instance_;
   std::string nfs_maps_dir_;
   /**
-   * Combination of kCache... flags
+   * Combination of kNfs... flags
    */
-  int cache_mode_;
-  /**
-   * The lower cache tier currently can only be
-   */
-  int second_cache_mode_;
-  /**
-   * Soft limit in bytes for the cache.  The quota manager removes half the
-   * cache when the limit is exceeded.
-   */
-  int64_t quota_limit_;
+  unsigned nfs_mode_;
   CacheManager *cache_mgr_;
   /**
    * Persistent for the cache directory + name combination.  It is used in the
@@ -313,11 +327,6 @@ class FileSystem : SingleCopy, public BootFactory {
    * down.
    */
   bool has_custom_sqlitevfs_;
-
-  /**
-   * Indicates which type of cache to use
-   */
-  CacheManagerIds cache_mgr_type_;
 };
 
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -224,6 +224,7 @@ class FileSystem : SingleCopy, public BootFactory {
   bool CreateCache();
   bool SetupQuotaMgmt();
   bool SetupNfsMaps();
+  void SetupUuid();
 
   bool CheckCacheMode();
   void DetermineCacheMode();

--- a/cvmfs/sanitizer.h
+++ b/cvmfs/sanitizer.h
@@ -61,6 +61,12 @@ class UuidSanitizer : public InputSanitizer {
 };
 
 
+class CacheInstanceSanitizer : public InputSanitizer {
+ public:
+  CacheInstanceSanitizer() : InputSanitizer("az AZ 09 _") { }
+};
+
+
 class RepositorySanitizer : public InputSanitizer {
  public:
   RepositorySanitizer() : InputSanitizer("az AZ 09 - _ .") { }

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -90,6 +90,36 @@ class Statistics {
 
 
 /**
+ * Allows multiple instance of the same class to use the same Statistics
+ * instance.  The "name_major" part is used to contruct counter names in the
+ * form name_major.<provided name>
+ */
+class StatisticsTemplate {
+ public:
+  StatisticsTemplate(const std::string &name_major, Statistics *statistics)
+    : name_major_(name_major), statistics_(statistics)
+  { }
+  StatisticsTemplate(const std::string &name_sub,
+                     const StatisticsTemplate &statistics)
+    : name_major_(statistics.name_major_ + "." + name_sub)
+    , statistics_(statistics.statistics_)
+  { }
+
+  Counter *RegisterTemplated(const std::string &name_minor,
+                             const std::string &desc)
+  {
+    return statistics_->Register(name_major_ + "." + name_minor, desc);
+  }
+
+  Statistics *statistics() { return statistics_; }
+
+ private:
+  std::string name_major_;
+  Statistics *statistics_;
+};
+
+
+/**
  * Keeps track of events over time.  Can be used to query the number of events
  * between now and a point in time in the past.  The time range should be
  * smaller than capacity_s seconds.  Uses a monotonic clock.  Not thread-safe.

--- a/cvmfs/swissknife.cc
+++ b/cvmfs/swissknife.cc
@@ -42,7 +42,8 @@ bool Command::InitDownloadManager(const bool     follow_redirects,
 
   download_manager_ = new download::DownloadManager();
   assert(download_manager_);
-  download_manager_->Init(max_pool_handles, use_system_proxy, statistics());
+  download_manager_->Init(max_pool_handles, use_system_proxy,
+                          perf::StatisticsTemplate("download", statistics()));
 
   download_manager_->SetTimeout(kDownloadTimeout, kDownloadTimeout);
   download_manager_->SetRetryParameters(kDownloadRetries, 500, 2000);

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -497,7 +497,7 @@ void *TalkManager::MainResponder(void *data) {
       result += "\nDrainout Mode: " + StringifyBool(drainout_mode) + "\n";
       result += "Maintenance Mode: " + StringifyBool(maintenance_mode) + "\n";
 
-      if (file_system->cache_mode() & FileSystem::kCacheNfs) {
+      if (file_system->IsNfsSource()) {
         result += "\nNFS Map Statistics:\n";
         result += nfs_maps::GetStatistics();
       }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -197,6 +197,8 @@ void *TalkManager::MainResponder(void *data) {
           StringifyInt(size_pinned) + " Bytes)\n";
         talk_mgr->Answer(con_fd, size_str);
       }
+    } else if (line == "cache instance") {
+      talk_mgr->Answer(con_fd, file_system->cache_mgr()->Describe());
     } else if (line == "cache list") {
       QuotaManager *quota_mgr = file_system->cache_mgr()->quota_mgr();
       if (!quota_mgr->HasCapability(QuotaManager::kCapList)) {

--- a/cvmfs/wpad.cc
+++ b/cvmfs/wpad.cc
@@ -238,7 +238,7 @@ int MainResolveProxyDescription(int argc, char **argv) {
   string host_list = argv[3];
 
   DownloadManager download_manager;
-  download_manager.Init(1, false, &statistics);
+  download_manager.Init(1, false, perf::StatisticsTemplate("pac", &statistics));
   download_manager.SetHostChain(host_list);
   string resolved_proxies = ResolveProxyDescription(proxy_configuration,
                                                     &download_manager);

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -231,6 +231,7 @@ class TestCacheManager : public CacheManager {
     quota_mgr_ = new TestQuotaManager();
   }
   virtual CacheManagerIds id() { return kUnknownCacheManager; }
+  virtual std::string Describe() { return "test\n"; }
   virtual bool AcquireQuotaManager(QuotaManager *qm) { return false; }
   virtual int Open(const BlessedObject &object) {
     return open("/dev/null", O_RDONLY);

--- a/test/unittests/t_cache_ram.cc
+++ b/test/unittests/t_cache_ram.cc
@@ -25,7 +25,7 @@ class T_RamCacheManager : public ::testing::Test {
     : ramcache_(4*alloc_size,
                 cache_size,
                 MemoryKvStore::kMallocLibc,
-                &statistics_) {
+                perf::StatisticsTemplate("test", &statistics_)) {
     a_.digest[1] = 1;
   }
 

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -63,7 +63,7 @@ TEST_F(T_TieredCacheManager, CopyUp) {
   int fd = tiered_cache_->Open(CacheManager::Bless(
     hash_one_, CacheManager::kTypeVolatile));
   EXPECT_GE(fd, 0);
-  EXPECT_EQ(1, stats_upper_.Lookup("RamCache.n_openvolatile")->Get());
+  EXPECT_EQ(1, stats_upper_.Lookup("test.n_openvolatile")->Get());
 
   int fd_upper = upper_cache_->Open(CacheManager::Bless(hash_one_));
   EXPECT_GE(fd_upper, 0);

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -16,9 +16,11 @@ class T_TieredCacheManager : public ::testing::Test {
  protected:
   virtual void SetUp() {
     upper_cache_ =
-      new RamCacheManager(1024, 128, MemoryKvStore::kMallocLibc, &stats_upper_);
+      new RamCacheManager(1024, 128, MemoryKvStore::kMallocLibc,
+                          perf::StatisticsTemplate("test", &stats_upper_));
     lower_cache_ =
-      new RamCacheManager(1024, 128, MemoryKvStore::kMallocLibc, &stats_lower_);
+      new RamCacheManager(1024, 128, MemoryKvStore::kMallocLibc,
+                          perf::StatisticsTemplate("test", &stats_lower_));
     tiered_cache_ = TieredCacheManager::Create(upper_cache_, lower_cache_);
     buf_ = 'x';
     hash_one_.digest[1] = 1;

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -25,7 +25,7 @@ class T_Download : public ::testing::Test {
  protected:
   virtual void SetUp() {
     download_mgr.Init(8, false, /* use_system_proxy */
-        &statistics);
+      perf::StatisticsTemplate("test", &statistics));
     ffoo = CreateTemporaryFile(&foo_path);
     assert(ffoo);
     foo_url = "file://" + foo_path;
@@ -98,7 +98,8 @@ TEST_F(T_Download, File) {
 
 
 TEST_F(T_Download, Clone) {
-  DownloadManager *download_mgr_cloned = download_mgr.Clone(&statistics, "x");
+  DownloadManager *download_mgr_cloned = download_mgr.Clone(
+    perf::StatisticsTemplate("x", &statistics));
 
   string dest_path;
   FILE *fdest = CreateTemporaryFile(&dest_path);
@@ -119,7 +120,7 @@ TEST_F(T_Download, Clone) {
 
   // Don't crash
   DownloadManager *dm = new DownloadManager();
-  download_mgr_cloned = dm->Clone(&statistics, "y");
+  download_mgr_cloned = dm->Clone(perf::StatisticsTemplate("y", &statistics));
   delete dm;
   delete download_mgr_cloned;
 }
@@ -132,7 +133,8 @@ TEST_F(T_Download, Multiple) {
   UnlinkGuard unlink_guard(dest_path);
 
   DownloadManager second_mgr;
-  second_mgr.Init(8, false, /* use_system_proxy */ &statistics, "second");
+  second_mgr.Init(8, false, /* use_system_proxy */
+    perf::StatisticsTemplate("second", &statistics));
 
   JobInfo info(&foo_url, false /* compressed */, false /* probe hosts */,
                fdest,  NULL);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -124,6 +124,7 @@ class BuggyCacheManager : public CacheManager {
     atomic_init32(&continue_ctrltxn);
   }
   virtual CacheManagerIds id() { return kUnknownCacheManager; }
+  virtual std::string Describe() { return "test\n"; }
   virtual bool AcquireQuotaManager(QuotaManager *qm) { return false; }
   virtual int Open(const BlessedObject &object) {
     if (!allow_open) {

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -70,14 +70,16 @@ class T_Fetcher : public ::testing::Test {
     ASSERT_TRUE(cache_mgr_ != NULL);
 
     download_mgr_ = new download::DownloadManager();
-    download_mgr_->Init(8, false, /* use_system_proxy */ &statistics_);
+    download_mgr_->Init(8, false, /* use_system_proxy */
+      perf::StatisticsTemplate("test", &statistics_));
     download_mgr_->SetHostChain("file://" + tmp_path_);
 
     fetcher_ = new Fetcher(
-      cache_mgr_, download_mgr_, &backoff_throttle_, &statistics_);
+      cache_mgr_, download_mgr_, &backoff_throttle_,
+      perf::StatisticsTemplate("fetch", &statistics_));
     external_fetcher_ = new Fetcher(
-      cache_mgr_, download_mgr_, &backoff_throttle_, &statistics_,
-      "fetch-external", true);
+      cache_mgr_, download_mgr_, &backoff_throttle_,
+      perf::StatisticsTemplate("fetch-external", &statistics_), true);
   }
 
   virtual void TearDown() {
@@ -323,7 +325,8 @@ TEST_F(T_Fetcher, FetchTransactionFailures) {
   // OpenFromTxn fails
   perf::Statistics statistics;
   BuggyCacheManager bcm;
-  Fetcher f(&bcm, download_mgr_, &backoff_throttle_, &statistics);
+  Fetcher f(&bcm, download_mgr_, &backoff_throttle_,
+    perf::StatisticsTemplate("fetch", &statistics));
   EXPECT_EQ(-EBADF,
     f.Fetch(hash_catalog_, CacheManager::kSizeUnknown, "cat",
             zlib::kZlibDefault, CacheManager::kTypeCatalog));
@@ -386,7 +389,8 @@ TEST_F(T_Fetcher, FetchCollapse) {
   perf::Statistics statistics;
   BuggyCacheManager bcm;
   bcm.open_2nd_try = true;
-  Fetcher f(&bcm, download_mgr_, &backoff_throttle_, &statistics);
+  Fetcher f(&bcm, download_mgr_, &backoff_throttle_,
+    perf::StatisticsTemplate("fetch", &statistics));
   int fd = f.Fetch(hash_catalog_, CacheManager::kSizeUnknown, "cat",
                    zlib::kZlibDefault, CacheManager::kTypeCatalog);
   EXPECT_GE(fd, 0);

--- a/test/unittests/t_kvstore.cc
+++ b/test/unittests/t_kvstore.cc
@@ -23,10 +23,9 @@ class T_MemoryKvStore : public ::testing::Test {
  public:
   T_MemoryKvStore()
     : store_(cache_size,
-             "T_MemoryKvStore",
              MemoryKvStore::kMallocLibc,
              128*malloc_size,
-             &statistics_)
+             perf::StatisticsTemplate("test", &statistics_))
     , m1_(shash::AsciiPtr("!"))
     , a1_(m1_.algorithm, m1_.digest, m1_.suffix)
     , m2_(shash::AsciiPtr("i"))

--- a/test/unittests/t_lru.cc
+++ b/test/unittests/t_lru.cc
@@ -23,7 +23,7 @@ const std::string name = "lru_cache";
 TEST(T_LruCache, Initialize) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 }
@@ -32,7 +32,7 @@ TEST(T_LruCache, Initialize) {
 TEST(T_LruCache, Insert) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -54,7 +54,7 @@ TEST(T_LruCache, Insert) {
 TEST(T_LruCache, UpdateValue) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
 
   EXPECT_TRUE(cache.Insert(1, "one"));
   EXPECT_TRUE(cache.Insert(2, "two"));
@@ -84,7 +84,7 @@ TEST(T_LruCache, UpdateValue) {
 TEST(T_LruCache, UpdateOnly) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
 
   EXPECT_TRUE(cache.Insert(1, "one"));
   EXPECT_TRUE(cache.Insert(2, "two"));
@@ -113,7 +113,7 @@ TEST(T_LruCache, UpdateOnly) {
 TEST(T_LruCache, Drop) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -165,7 +165,7 @@ TEST(T_LruCache, Drop) {
 TEST(T_LruCache, Lookup) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -228,7 +228,7 @@ TEST(T_LruCache, Lookup) {
 TEST(T_LruCache, Update) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -293,7 +293,7 @@ TEST(T_LruCache, Update) {
 TEST(T_LruCache, Forget) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -360,7 +360,7 @@ TEST(T_LruCache, Forget) {
 TEST(T_LruCache, FillCompletely) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -389,7 +389,7 @@ TEST(T_LruCache, FillCompletely) {
 TEST(T_LruCache, LeastRecentlyUsedReplacementSlow) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 
@@ -456,7 +456,7 @@ TEST(T_LruCache, LeastRecentlyUsedReplacementSlow) {
 TEST(T_LruCache, PauseAndResume) {
   perf::Statistics statistics;
   LruCache<int, std::string> cache(cache_size, -1, hasher_int,
-      &statistics, name);
+      perf::StatisticsTemplate(name, &statistics));
   EXPECT_TRUE(cache.IsEmpty());
   EXPECT_FALSE(cache.IsFull());
 

--- a/test/unittests/t_mountpoint.cc
+++ b/test/unittests/t_mountpoint.cc
@@ -438,6 +438,12 @@ TEST_F(T_MountPoint, TieredCacheMgr) {
     EXPECT_EQ("tiered", fs->cache_mgr_instance());
     EXPECT_EQ(kTieredCacheManager, fs->cache_mgr()->id());
   }
+
+  options_mgr_.SetValue("CVMFS_CACHE_tiered_LOWER", "tiered");
+  {
+    UniquePtr<FileSystem> fs(FileSystem::Create(fs_info_));
+    EXPECT_EQ(loader::kFailCacheDir, fs->boot_status());
+  }
 }
 
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -346,7 +346,8 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void InitializeExternalManagers() {
-    download_manager_.Init(1, true, &statistics_);
+    download_manager_.Init(1, true,
+      perf::StatisticsTemplate("test", &statistics_));
     signature_manager_.Init();
     ASSERT_TRUE(signature_manager_.LoadPublicRsaKeys(public_key_path));
   }

--- a/test/unittests/t_statistics.cc
+++ b/test/unittests/t_statistics.cc
@@ -80,6 +80,21 @@ TEST(T_Statistics, Fork) {
 }
 
 
+TEST(T_Statistics, StatisticsTemplate) {
+  Statistics statistics;
+  StatisticsTemplate stat_template1("template1", &statistics);
+  StatisticsTemplate stat_template2("template2", &statistics);
+  StatisticsTemplate stat_sub("sub", stat_template1);
+
+  Counter *cnt1 = stat_template1.RegisterTemplated("value", "a test counter");
+  Counter *cnt2 = stat_template2.RegisterTemplated("value", "a test counter");
+  Counter *cnt_sub = stat_sub.RegisterTemplated("value", "test");
+  EXPECT_EQ(cnt1, statistics.Lookup("template1.value"));
+  EXPECT_EQ(cnt2, statistics.Lookup("template2.value"));
+  EXPECT_EQ(cnt_sub, statistics.Lookup("template1.sub.value"));
+}
+
+
 TEST(T_Statistics, RecorderConstruct) {
   Recorder recorder(5, 10);
   EXPECT_EQ(10U, recorder.capacity_s());


### PR DESCRIPTION
Allows for declaring named cache instances in the cvmfs configuration files.  A concrete instance is selected like

    CVMFS_CACHE_PRIMARY=myInstanceName
    CVMFS_CACHE_myInstanceName_TYPE=posix

Multiple instances can thus be safely defined but only one is selected when the mountpoint is constructed. This allows to defined tiered caches with multiple underlying cache instances.  The change is backwards compatible.  Regular cache configuration syntax is automatically mapped to the `CVMFS_CACHE_default_...` instance.  In order to store all cache related settings in parameters prefixed by `CVMFS_CACHE_`, there is also a mapping from legacy cache options

    CVMFS_SHARED_CACHE --> CVMFS_CACHE_<name>_SHARED
    CVMFS_ALIEN_CACHE --> CVMFS_CACHE_<name>_ALIEN
    CVMFS_SERVER_CACHE_MODE --> CVMFS_CACHE_<name>_SERVER_MODE
    CVMFS_QUOTA_LIMIT --> CVMFS_CACHE_<name>_QUOTA_LIMIT

If both legacy and new names are defined, the new name as precedence.

Since multiple cache manager objects of the same type can exist, it was also necessary to prefix their statistics counters by the cache instance name.  This triggered resolving [CVM-913](https://sft.its.cern.ch/jira/browse/CVM-913).

Support for `CVMFS_CWD_CACHE` (used by libcvmfs) needed to be dropped because in general there is no single well-defined cache directory anymore.

Another commit will add a `cvmfs_talk` command to show the effective cache manager(s).