### PR TITLE
Extend ObjectPack classes

### DIFF
--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -28,24 +28,24 @@ void InitializeHeader(const int version, const int num_objects,
   }
 }
 
-void AppendItemToHeader(ObjectPack::BucketContentType item_type,
-                        const std::string &hash_str, const size_t offset,
-                        const std::string &item_name, std::string *header) {
+void AppendItemToHeader(ObjectPack::BucketContentType object_type,
+                        const std::string &hash_str, const size_t object_size,
+                        const std::string &object_name, std::string *header) {
   // If the item type is kName, the "item_name" parameter should not be empty
-  assert((item_type == ObjectPack::kCas) ||
-         ((item_type == ObjectPack::kNamed) && (!item_name.empty())));
+  assert((object_type == ObjectPack::kCas) ||
+         ((object_type == ObjectPack::kNamed) && (!object_name.empty())));
   std::string line_prefix = "";
   std::string line_suffix = "";
-  if (item_type == ObjectPack::kNamed) {
+  if (object_type == ObjectPack::kNamed) {
     line_prefix = "N ";
-    line_suffix = std::string(" ") + Base64Url(item_name);
-  } else if (item_type == ObjectPack::kCas) {
+    line_suffix = std::string(" ") + Base64Url(object_name);
+  } else if (object_type == ObjectPack::kCas) {
     line_prefix = "C ";
   } else {  // item_type == kEmpty
     return;
   }
   if (header) {
-    *header += line_prefix + hash_str + " " + StringifyInt(offset) +
+    *header += line_prefix + hash_str + " " + StringifyInt(object_size) +
                line_suffix + "\n";
   }
 }

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -36,12 +36,15 @@ void AppendItemToHeader(ObjectPack::BucketContentType object_type,
          ((object_type == ObjectPack::kNamed) && (!object_name.empty())));
   std::string line_prefix = "";
   std::string line_suffix = "";
-  if (object_type == ObjectPack::kNamed) {
+  switch (object_type) {
+  case ObjectPack::kNamed:
     line_prefix = "N ";
     line_suffix = std::string(" ") + Base64Url(object_name);
-  } else if (object_type == ObjectPack::kCas) {
+    break;
+  case ObjectPack::kCas:
     line_prefix = "C ";
-  } else {  // item_type == kEmpty
+    break;
+  default:
     return;
   }
   if (header) {

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -17,15 +17,12 @@
 using namespace std;  // NOLINT
 
 ObjectPack::Bucket::Bucket()
-  : content(reinterpret_cast<unsigned char *>(smalloc(kInitialSize)))
-  , size(0)
-  , capacity(kInitialSize)
-{ }
-
+    : content(reinterpret_cast<unsigned char *>(smalloc(kInitialSize))),
+      size(0),
+      capacity(kInitialSize) {}
 
 void ObjectPack::Bucket::Add(const void *buf, const uint64_t buf_size) {
-  if (buf_size == 0)
-    return;
+  if (buf_size == 0) return;
 
   while (size + buf_size > capacity) {
     capacity *= 2;
@@ -35,85 +32,32 @@ void ObjectPack::Bucket::Add(const void *buf, const uint64_t buf_size) {
   size += buf_size;
 }
 
-
-ObjectPack::Bucket::~Bucket() {
-  free(content);
-}
-
+ObjectPack::Bucket::~Bucket() { free(content); }
 
 //------------------------------------------------------------------------------
-
-
-void ObjectPack::AddToBucket(
-  const void *buf,
-  const uint64_t size,
-  const ObjectPack::BucketHandle handle)
-{
-  handle->Add(buf, size);
-}
-
-
-/**
- * Can only fail due to insufficient remaining space in the ObjectPack.
- */
-bool ObjectPack::CommitBucket(
-  const shash::Any &id,
-  const ObjectPack::BucketHandle handle)
-{
-  handle->id = id;
-
-  MutexLockGuard mutex_guard(lock_);
-  if (buckets_.size() >= kMaxObjects)
-    return false;
-  if (size_ + handle->size > limit_)
-    return false;
-  open_buckets_.erase(handle);
-  buckets_.push_back(handle);
-  size_ += handle->size;
-  return true;
-}
-
-
-void ObjectPack::DiscardBucket(const BucketHandle handle) {
-  MutexLockGuard mutex_guard(lock_);
-  open_buckets_.erase(handle);
-  delete handle;
-}
-
-
-void ObjectPack::InitLock() {
-  lock_ =
-    reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
-  int retval = pthread_mutex_init(lock_, NULL);
-  assert(retval == 0);
-}
-
-
-ObjectPack::ObjectPack() : limit_(kDefaultLimit), size_(0) {
-  InitLock();
-}
-
 
 ObjectPack::ObjectPack(const uint64_t limit) : limit_(limit), size_(0) {
   InitLock();
 }
 
-
 ObjectPack::~ObjectPack() {
   for (std::set<BucketHandle>::const_iterator i = open_buckets_.begin(),
-       iEnd = open_buckets_.end(); i != iEnd; ++i)
-  {
+                                              iEnd = open_buckets_.end();
+       i != iEnd; ++i) {
     delete *i;
   }
 
-  for (unsigned i = 0; i < buckets_.size(); ++i)
-    delete buckets_[i];
+  for (unsigned i = 0; i < buckets_.size(); ++i) delete buckets_[i];
   pthread_mutex_destroy(lock_);
   free(lock_);
 }
 
+void ObjectPack::AddToBucket(const void *buf, const uint64_t size,
+                             const ObjectPack::BucketHandle handle) {
+  handle->Add(buf, size);
+}
 
-ObjectPack::BucketHandle ObjectPack::OpenBucket() {
+ObjectPack::BucketHandle ObjectPack::NewBucket() {
   BucketHandle handle = new Bucket();
 
   MutexLockGuard mutex_guard(lock_);
@@ -121,23 +65,61 @@ ObjectPack::BucketHandle ObjectPack::OpenBucket() {
   return handle;
 }
 
+/**
+ * Can only fail due to insufficient remaining space in the ObjectPack.
+ */
+bool ObjectPack::CommitBucket(const shash::Any &id,
+                              const ObjectPack::BucketHandle handle) {
+  handle->id = id;
+
+  MutexLockGuard mutex_guard(lock_);
+  if (buckets_.size() >= kMaxObjects) return false;
+  if (size_ + handle->size > limit_) return false;
+  open_buckets_.erase(handle);
+  buckets_.push_back(handle);
+  size_ += handle->size;
+  return true;
+}
+
+void ObjectPack::DiscardBucket(const BucketHandle handle) {
+  MutexLockGuard mutex_guard(lock_);
+  open_buckets_.erase(handle);
+  delete handle;
+}
+
+void ObjectPack::InitLock() {
+  lock_ = reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+  int retval = pthread_mutex_init(lock_, NULL);
+  assert(retval == 0);
+}
 
 /**
  * If a commit failed, an open Bucket can be transferred to another ObjectPack
  * with more space.
  */
-void ObjectPack::TransferBucket(
-  const ObjectPack::BucketHandle handle,
-  ObjectPack *other)
-{
+void ObjectPack::TransferBucket(const ObjectPack::BucketHandle handle,
+                                ObjectPack *other) {
   MutexLockGuard mutex_guard(lock_);
   open_buckets_.erase(handle);
   other->open_buckets_.insert(handle);
 }
 
+unsigned char *ObjectPack::BucketContent(size_t idx) const {
+  assert(idx < buckets_.size());
+  return buckets_[idx]->content;
+}
+
+uint64_t ObjectPack::BucketSize(size_t idx) const {
+  assert(idx < buckets_.size());
+  return buckets_[idx]->size;
+}
+
+const shash::Any &ObjectPack::BucketId(size_t idx) const {
+  assert(idx < buckets_.size());
+  return buckets_[idx]->id;
+}
 
 //------------------------------------------------------------------------------
-
 
 /**
  * Hash over the header.  The hash algorithm needs to be provided by hash.
@@ -147,40 +129,28 @@ void ObjectPackProducer::GetDigest(shash::Any *hash) {
   shash::HashString(header_, hash);
 }
 
-
 ObjectPackProducer::ObjectPackProducer(ObjectPack *pack)
-  : pack_(pack)
-  , big_file_(NULL)
-  , pos_(0)
-  , idx_(0)
-  , pos_in_bucket_(0)
-{
-  unsigned N = pack->buckets_.size();
+    : pack_(pack), big_file_(NULL), pos_(0), idx_(0), pos_in_bucket_(0) {
+  unsigned N = pack->GetNoObjects();
   // rough guess, most likely a little too much
   header_.reserve(30 + N * (2 * shash::kMaxDigestSize + 5));
 
   header_ = "V1\n";
-  header_ += "S" + StringifyInt(pack->size_) + "\n";
+  header_ += "S" + StringifyInt(pack->size()) + "\n";
   header_ += "N" + StringifyInt(N) + "\n";
   header_ += "--\n";
 
   const bool with_suffix = true;
   for (unsigned i = 0; i < N; ++i) {
-    header_ += pack->buckets_[i]->id.ToString(with_suffix);
+    header_ += pack->BucketId(i).ToString(with_suffix);
     header_ += " ";
-    header_ += StringifyInt(pack->buckets_[i]->size);
+    header_ += StringifyInt(pack->BucketSize(i));
     header_ += "\n";
   }
 }
 
-
 ObjectPackProducer::ObjectPackProducer(const shash::Any &id, FILE *big_file)
-  : pack_(NULL)
-  , big_file_(big_file)
-  , pos_(0)
-  , idx_(0)
-  , pos_in_bucket_(0)
-{
+    : pack_(NULL), big_file_(big_file), pos_(0), idx_(0), pos_in_bucket_(0) {
   int fd = fileno(big_file_);
   assert(fd >= 0);
   platform_stat64 info;
@@ -199,17 +169,14 @@ ObjectPackProducer::ObjectPackProducer(const shash::Any &id, FILE *big_file)
   rewind(big_file);
 }
 
-
 /**
  * Copies as many bytes as possible into buf.  If the returned number of bytes
  * is shorter than buf_size, everything has been produced.
  */
-unsigned ObjectPackProducer::ProduceNext(
-  const unsigned buf_size,
-  unsigned char *buf)
-{
+unsigned ObjectPackProducer::ProduceNext(const unsigned buf_size,
+                                         unsigned char *buf) {
   const unsigned remaining_in_header =
-    (pos_ < header_.size()) ? (header_.size() - pos_) : 0;
+      (pos_ < header_.size()) ? (header_.size() - pos_) : 0;
   const unsigned nbytes_header = std::min(remaining_in_header, buf_size);
   if (nbytes_header) {
     memcpy(buf, header_.data() + pos_, nbytes_header);
@@ -217,23 +184,21 @@ unsigned ObjectPackProducer::ProduceNext(
   }
 
   unsigned remaining_in_buf = buf_size - nbytes_header;
-  if (remaining_in_buf == 0)
-    return nbytes_header;
+  if (remaining_in_buf == 0) return nbytes_header;
   unsigned nbytes_payload = 0;
 
   if (big_file_) {
     size_t nbytes = fread(buf + nbytes_header, 1, remaining_in_buf, big_file_);
     nbytes_payload = nbytes;
     pos_ += nbytes_payload;
-  } else if (idx_ < pack_->buckets_.size()) {
+  } else if (idx_ < pack_->GetNoObjects()) {
     // Copy a few buckets more
-    while ((remaining_in_buf) > 0 && (idx_ < pack_->buckets_.size())) {
+    while ((remaining_in_buf) > 0 && (idx_ < pack_->GetNoObjects())) {
       const unsigned remaining_in_bucket =
-        pack_->buckets_[idx_]->size - pos_in_bucket_;
+          pack_->BucketSize(idx_) - pos_in_bucket_;
       const unsigned nbytes = std::min(remaining_in_buf, remaining_in_bucket);
       memcpy(buf + nbytes_header + nbytes_payload,
-             pack_->buckets_[idx_]->content + pos_in_bucket_,
-             nbytes);
+             pack_->BucketContent(idx_) + pos_in_bucket_, nbytes);
 
       pos_in_bucket_ += nbytes;
       nbytes_payload += nbytes;
@@ -248,22 +213,18 @@ unsigned ObjectPackProducer::ProduceNext(
   return nbytes_header + nbytes_payload;
 }
 
-
 //------------------------------------------------------------------------------
 
-
-ObjectPackConsumer::ObjectPackConsumer(
-  const shash::Any &expected_digest,
-  const unsigned expected_header_size)
-  : expected_digest_(expected_digest)
-  , expected_header_size_(expected_header_size)
-  , pos_(0)
-  , idx_(0)
-  , pos_in_object_(0)
-  , pos_in_accu_(0)
-  , state_(kStateContinue)
-  , size_(0)
-{
+ObjectPackConsumer::ObjectPackConsumer(const shash::Any &expected_digest,
+                                       const unsigned expected_header_size)
+    : expected_digest_(expected_digest),
+      expected_header_size_(expected_header_size),
+      pos_(0),
+      idx_(0),
+      pos_in_object_(0),
+      pos_in_accu_(0),
+      state_(kStateContinue),
+      size_(0) {
   // Upper limit of 100B per entry
   if (expected_header_size > (100 * ObjectPack::kMaxObjects)) {
     state_ = kStateHeaderTooBig;
@@ -278,28 +239,23 @@ ObjectPackConsumer::ObjectPackConsumer(
  * the buffer contains trailing garbage bytes.
  */
 ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumeNext(
-  const unsigned buf_size,
-  const unsigned char *buf)
-{
-  if (buf_size == 0)
-    return state_;
+    const unsigned buf_size, const unsigned char *buf) {
+  if (buf_size == 0) return state_;
   if (state_ == kStateDone) {
     state_ = kStateTrailingBytes;
     return state_;
   }
-  if (state_ != kStateContinue)
-    return state_;
+  if (state_ != kStateContinue) return state_;
 
   const unsigned remaining_in_header =
-    (pos_ < expected_header_size_) ? (expected_header_size_ - pos_) : 0;
+      (pos_ < expected_header_size_) ? (expected_header_size_ - pos_) : 0;
   const unsigned nbytes_header = std::min(remaining_in_header, buf_size);
   if (nbytes_header) {
     raw_header_ += string(reinterpret_cast<const char *>(buf), nbytes_header);
     pos_ += nbytes_header;
   }
 
-  if (pos_ < expected_header_size_)
-    return kStateContinue;
+  if (pos_ < expected_header_size_) return kStateContinue;
 
   // This condition can only be true once through the lifetime of the Consumer.
   if (nbytes_header && (pos_ == expected_header_size_)) {
@@ -330,7 +286,6 @@ ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumeNext(
   return ConsumePayload(remaining_in_buf, payload);
 }
 
-
 /**
  * Informs listeners for small complete objects.  For large objects, buffers the
  * input into reasonably sized chunks.  buf can contain both a chunk of data
@@ -339,9 +294,7 @@ ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumeNext(
  * unnecessary memory copies.
  */
 ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumePayload(
-  const unsigned buf_size,
-  const unsigned char *buf)
-{
+    const unsigned buf_size, const unsigned char *buf) {
   uint64_t pos_in_buf = 0;
   while ((pos_in_buf < buf_size) && (idx_ < index_.size())) {
     // Fill the accumulator or process next small object
@@ -354,8 +307,7 @@ ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumePayload(
     // small piece of data of a larger object.
     nbytes = std::min(remaining_in_object, remaining_in_buf);
     if ((pos_in_accu_ > 0) ||
-        ((remaining_in_buf < remaining_in_object) && is_small_rest))
-    {
+        ((remaining_in_buf < remaining_in_object) && is_small_rest)) {
       const uint64_t remaining_in_accu = kAccuSize - pos_in_accu_;
       nbytes = std::min(remaining_in_accu, nbytes);
       memcpy(accumulator_ + pos_in_accu_, buf + pos_in_buf, nbytes);
@@ -366,8 +318,8 @@ ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumePayload(
         pos_in_accu_ = 0;
       }
     } else {  // directly trigger listeners using buf
-      NotifyListeners(BuildEvent(index_[idx_].id, index_[idx_].size,
-                                 nbytes, buf + pos_in_buf));
+      NotifyListeners(BuildEvent(index_[idx_].id, index_[idx_].size, nbytes,
+                                 buf + pos_in_buf));
     }
 
     pos_in_buf += nbytes;
@@ -387,51 +339,43 @@ ObjectPackConsumerBase::BuildState ObjectPackConsumer::ConsumePayload(
   return state_;
 }
 
-
 bool ObjectPackConsumer::ParseHeader() {
   map<char, string> header;
-  const unsigned char *data = reinterpret_cast<const unsigned char *>(
-    raw_header_.data());
+  const unsigned char *data =
+      reinterpret_cast<const unsigned char *>(raw_header_.data());
   ParseKeyvalMem(data, raw_header_.size(), &header);
-  if (header.find('V') == header.end())
-    return false;
-  if (header['V'] != "1")
-    return false;
+  if (header.find('V') == header.end()) return false;
+  if (header['V'] != "1") return false;
   size_ = String2Uint64(header['S']);
   unsigned nobjects = String2Uint64(header['N']);
 
-  if (nobjects == 0)
-    return true;
+  if (nobjects == 0) return true;
 
   // Build the object index
   size_t separator_idx = raw_header_.find("--\n");
-  if (separator_idx == string::npos)
-    return false;
+  if (separator_idx == string::npos) return false;
   unsigned index_idx = separator_idx + 3;
-  if (index_idx >= raw_header_.size())
-    return false;
+  if (index_idx >= raw_header_.size()) return false;
 
   uint64_t sum_size = 0;
   do {
     const unsigned remaining_in_header = raw_header_.size() - index_idx;
     string line =
-      GetLineMem(raw_header_.data() + index_idx, remaining_in_header);
-    if (line == "")
-      break;
+        GetLineMem(raw_header_.data() + index_idx, remaining_in_header);
+    if (line == "") break;
 
     // We could use SplitString but we can have many lines so we do something
     // more efficient here
     separator_idx = line.find_first_of(' ');
-    if ( (separator_idx == 0) || (separator_idx == string::npos) ||
-         (separator_idx == (line.size() - 1)) )
-    {
+    if ((separator_idx == 0) || (separator_idx == string::npos) ||
+        (separator_idx == (line.size() - 1))) {
       return false;
     }
     uint64_t size = String2Uint64(line.substr(separator_idx + 1));
     sum_size += size;
-    const IndexEntry index_entry(
-      shash::MkFromSuffixedHexPtr(shash::HexPtr(line.substr(0, separator_idx))),
-      size);
+    const IndexEntry index_entry(shash::MkFromSuffixedHexPtr(shash::HexPtr(
+                                     line.substr(0, separator_idx))),
+                                 size);
     index_.push_back(index_entry);
 
     index_idx += line.size() + 1;

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -422,7 +422,7 @@ bool ObjectPackConsumer::ParseHeader() {
 
 bool ObjectPackConsumer::ParseItem(const std::string &line,
                                    ObjectPackConsumer::IndexEntry *entry,
-                                   size_t *sum_size) {
+                                   uint64_t *sum_size) {
   if (!entry || !sum_size) {
     return false;
   }

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -37,15 +37,15 @@ void AppendItemToHeader(ObjectPack::BucketContentType object_type,
   std::string line_prefix = "";
   std::string line_suffix = "";
   switch (object_type) {
-  case ObjectPack::kNamed:
-    line_prefix = "N ";
-    line_suffix = std::string(" ") + Base64Url(object_name);
-    break;
-  case ObjectPack::kCas:
-    line_prefix = "C ";
-    break;
-  default:
-    return;
+    case ObjectPack::kNamed:
+      line_prefix = "N ";
+      line_suffix = std::string(" ") + Base64Url(object_name);
+      break;
+    case ObjectPack::kCas:
+      line_prefix = "C ";
+      break;
+    default:
+      return;
   }
   if (header) {
     *header += line_prefix + hash_str + " " + StringifyInt(object_size) +

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -137,13 +137,21 @@ class ObjectPack : SingleCopy {
  */
 namespace ObjectPackBuild {
 struct Event {
-  Event(const shash::Any &id, uint64_t size, unsigned buf_size, const void *buf)
-      : id(id), size(size), buf_size(buf_size), buf(buf) {}
+  Event(const shash::Any &id, uint64_t size, unsigned buf_size, const void *buf,
+        ObjectPack::BucketContentType type, const std::string &name)
+      : id(id),
+        size(size),
+        buf_size(buf_size),
+        buf(buf),
+        object_type(type),
+        object_name(name) {}
 
   shash::Any id;
   uint64_t size;
   unsigned buf_size;
   const void *buf;
+  ObjectPack::BucketContentType object_type;
+  std::string object_name;
 };
 
 enum State {
@@ -233,13 +241,19 @@ class ObjectPackConsumer : public Observable<ObjectPackBuild::Event> {
   static const unsigned kAccuSize = 128 * 1024;
 
   struct IndexEntry {
-    IndexEntry(const shash::Any &id, const uint64_t size)
-        : id(id), size(size) {}
+    IndexEntry() : id(), size(), entry_type(), entry_name() {}
+    IndexEntry(const shash::Any &id, const uint64_t size,
+               ObjectPack::BucketContentType type, const std::string &name)
+        : id(id), size(size), entry_type(type), entry_name(name) {}
     shash::Any id;
     uint64_t size;
+    ObjectPack::BucketContentType entry_type;
+    std::string entry_name;
   };
 
   bool ParseHeader();
+  bool ParseItem(const std::string &line, IndexEntry *entry, size_t *sum_size);
+
   ObjectPackBuild::State ConsumePayload(const unsigned buf_size,
                                         const unsigned char *buf);
 

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -252,7 +252,7 @@ class ObjectPackConsumer : public Observable<ObjectPackBuild::Event> {
   };
 
   bool ParseHeader();
-  bool ParseItem(const std::string &line, IndexEntry *entry, size_t *sum_size);
+  bool ParseItem(const std::string &line, IndexEntry *entry, uint64_t *sum_size);
 
   ObjectPackBuild::State ConsumePayload(const unsigned buf_size,
                                         const unsigned char *buf);

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -162,9 +162,14 @@ enum State {
  *
  * The serialized format has a global, human readable header which has lines of
  * character keys and string values (like the cvmfs manifest) follwed by a "--"
- * separator line followed by the index of objects.  This index is a list of
- * hash digest (hex) and object size (decimal) tuples, separated by line
- * breaks.
+ * separator line followed by the index of objects. The index contains one line
+ * for each item in the pack. Each line contains the following space-separated
+ * tokens:
+ * 1. object type identifier ('N' for named files, 'C' for CAS blobs)
+ * 2. hash digest (hex)
+ * 3. object size (decimal)
+ * 4. object name - base64 encoding of the object name (optional - only if the
+ *                  object type is 'N')
  */
 class ObjectPackProducer {
  public:

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -43,6 +43,15 @@ class ObjectPack : SingleCopy {
  public:
   typedef Bucket *BucketHandle;
 
+  /**
+   * This is used to identify the content type of different buckets. Initially,
+   * the contents of a bucket are identified as kEmpty. When committing a
+   * bucket, this is set to either kNamed - if the bucket holds the contents of
+   * a named file - or kCas - if the bucket holds the contents of a content
+   * addressable buffer.
+   */
+  enum BucketContentType { kEmpty, kNamed, kCas };
+
   static const uint64_t kDefaultLimit = 200 * 1024 * 1024;  // 200MB
 
   /**
@@ -60,7 +69,9 @@ class ObjectPack : SingleCopy {
 
   BucketHandle NewBucket();
 
-  bool CommitBucket(const shash::Any &id, const BucketHandle handle);
+  bool CommitBucket(const BucketContentType type, const shash::Any &id,
+                    const BucketHandle handle, const std::string &name = "");
+
   void DiscardBucket(const BucketHandle handle);
   void TransferBucket(const BucketHandle handle, ObjectPack *other);
 
@@ -90,6 +101,8 @@ class ObjectPack : SingleCopy {
     uint64_t size;
     uint64_t capacity;
     shash::Any id;
+    BucketContentType content_type;
+    std::string name;
   };
 
   void InitLock();

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -252,7 +252,8 @@ class ObjectPackConsumer : public Observable<ObjectPackBuild::Event> {
   };
 
   bool ParseHeader();
-  bool ParseItem(const std::string &line, IndexEntry *entry, uint64_t *sum_size);
+  bool ParseItem(const std::string &line, IndexEntry *entry,
+                 uint64_t *sum_size);
 
   ObjectPackBuild::State ConsumePayload(const unsigned buf_size,
                                         const unsigned char *buf);

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -154,7 +154,7 @@ enum State {
   kStateHeaderTooBig,
   kStateTrailingBytes,
 };
-}
+}  // namespace ObjectPackBuild
 
 /**
  * Serializes ObjectPacks.  It can also serialize a single large file as an

--- a/test/unittests/t_pack.cc
+++ b/test/unittests/t_pack.cc
@@ -347,6 +347,23 @@ TEST_F(T_Pack, ConsumerEmpty) {
   EXPECT_EQ(ObjectPackBuild::kStateDone, consumer_two.ConsumeNext(0, NULL));
 }
 
+TEST_F(T_Pack, ConsumerOfProducerFromFile) {
+  const std::string file_name = "the_file_name";
+  ObjectPackProducer producer(hash_null_, ffoo_, file_name);
+  shash::Any digest(shash::kShake128);
+  producer.GetDigest(&digest);
+  ObjectPackConsumer consumer(digest, producer.GetHeaderSize());
+
+  ConsumerCallbacks callbacks;
+  consumer.RegisterListener(&ConsumerCallbacks::OnEvent, &callbacks);
+
+  unsigned char buf[8192];
+  unsigned nbytes = producer.ProduceNext(8192, buf);
+  EXPECT_EQ(ObjectPackBuild::kStateDone, consumer.ConsumeNext(nbytes, buf));
+  EXPECT_EQ(1U, callbacks.total_objects);
+  EXPECT_EQ(foo_content_.size(), callbacks.total_size);
+}
+
 TEST_F(T_Pack, RealWorld) { RealWorld(); }
 
 TEST_F(T_Pack, RealWorldSlow) {

--- a/test/unittests/t_pack.cc
+++ b/test/unittests/t_pack.cc
@@ -61,9 +61,9 @@ class T_Pack : public ::testing::Test {
     ObjectPack::BucketHandle handle_one = pack_of_three_.NewBucket();
     ObjectPack::BucketHandle handle_two = pack_of_three_.NewBucket();
     ObjectPack::BucketHandle handle_three = pack_of_three_.NewBucket();
-    pack_of_three_.AddToBucket(buf, 4096, handle_one);
+    ObjectPack::AddToBucket(buf, 4096, handle_one);
     buf[0] = '1';
-    pack_of_three_.AddToBucket(buf, 1, handle_three);
+    ObjectPack::AddToBucket(buf, 1, handle_three);
     EXPECT_TRUE(pack_of_three_.CommitBucket(hash_null_, handle_one));
     EXPECT_TRUE(pack_of_three_.CommitBucket(hash_partial_, handle_two));
     EXPECT_TRUE(pack_of_three_.CommitBucket(hash_null_, handle_three));
@@ -151,8 +151,8 @@ TEST_F(T_Pack, ObjectPack) {
   EXPECT_EQ(0U, pack_.size_);
 
   char buf = '0';
-  pack_.AddToBucket(&buf, 1, handle_one);
-  pack_.AddToBucket(&buf, 1, handle_one);
+  ObjectPack::AddToBucket(&buf, 1, handle_one);
+  ObjectPack::AddToBucket(&buf, 1, handle_one);
 
   EXPECT_TRUE(pack_.CommitBucket(shash::Any(hash_null_), handle_one));
   EXPECT_EQ(1U, pack_.open_buckets_.size());
@@ -163,7 +163,7 @@ TEST_F(T_Pack, ObjectPack) {
   ObjectPack::BucketHandle handle_three = pack_.NewBucket();
   EXPECT_EQ(2U, pack_.open_buckets_.size());
   EXPECT_EQ(1U, pack_.buckets_.size());
-  pack_.AddToBucket(&buf, 1, handle_three);
+  ObjectPack::AddToBucket(&buf, 1, handle_three);
   EXPECT_TRUE(pack_.CommitBucket(shash::Any(hash_null_), handle_three));
   EXPECT_EQ(1U, pack_.open_buckets_.size());
   ASSERT_EQ(2U, pack_.buckets_.size());
@@ -171,7 +171,7 @@ TEST_F(T_Pack, ObjectPack) {
   EXPECT_EQ(1U, pack_.buckets_[1]->size);
   EXPECT_EQ(3U, pack_.size_);
 
-  pack_.AddToBucket(&buf, 1, handle_two);
+  ObjectPack::AddToBucket(&buf, 1, handle_two);
   pack_.DiscardBucket(handle_two);
   EXPECT_EQ(0U, pack_.open_buckets_.size());
   EXPECT_EQ(2U, pack_.buckets_.size());
@@ -182,17 +182,17 @@ TEST_F(T_Pack, ObjectPackOverflow) {
 
   ObjectPack::BucketHandle handle_one = small_pack.NewBucket();
   char buf = '0';
-  small_pack.AddToBucket(&buf, 1, handle_one);
+  ObjectPack::AddToBucket(&buf, 1, handle_one);
   EXPECT_TRUE(small_pack.CommitBucket(shash::Any(hash_null_), handle_one));
 
   ObjectPack::BucketHandle handle_two = small_pack.NewBucket();
-  small_pack.AddToBucket(&buf, 1, handle_two);
-  small_pack.AddToBucket(&buf, 1, handle_two);
+  ObjectPack::AddToBucket(&buf, 1, handle_two);
+  ObjectPack::AddToBucket(&buf, 1, handle_two);
   EXPECT_FALSE(small_pack.CommitBucket(shash::Any(hash_null_), handle_two));
   small_pack.DiscardBucket(handle_two);
 
   ObjectPack::BucketHandle handle_three = small_pack.NewBucket();
-  small_pack.AddToBucket(&buf, 1, handle_three);
+  ObjectPack::AddToBucket(&buf, 1, handle_three);
   EXPECT_TRUE(small_pack.CommitBucket(shash::Any(hash_null_), handle_three));
 
   // Fail due to too many objects


### PR DESCRIPTION
Addresses JIRA ticket CVM-1131

This PR brings some improvement and extensions to the ObjectPack classes, such that they can be used for file serialization with the HttpUploader spooler backend.

* API cleanup of the classes `ObjectPack`, `ObjectPackProducer`, `ObjectPackConsumer`
* Adding support for named files in the object packs, not only content addressed binary blobs.
* Updating producer and consumer classes to serialize/deserialize named files
* Updating unit tests