### PR TITLE
Work around autofs bug in CentOS 7 systemd unit

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -376,6 +376,15 @@ cvmfs_chksetup() {
       echo "Error: /etc/auto.cvmfs is not executable"
       num_errors=$(($num_errors+1))
     fi
+
+    # Check autofs' kill mode when systemd managed
+    if [ -e /usr/bin/systemctl ]; then
+      if ! /usr/bin/systemctl show -p KillMode autofs.service | grep -q process;
+      then
+        echo "Warning: autofs kill mode is not 'process', busy CernVM-FS mount points are likely to be forcefully killed when autofs is restarted"
+        num_warnings=$(($num_warnings+1))
+      fi
+    fi
   fi
 
   # Check that cvmfs user exists
@@ -1257,7 +1266,7 @@ cvmfs_bugreport() {
                  'cat /etc/auto.master' 'cat /etc/autofs/auto.master' 'cat /etc/sysconfig/autofs' \
                  'cat /etc/default/autofs' 'cat /etc/conf.d/autofs' 'journalctl -almu autofs.service' \
                  'cat /etc/fstab' 'cat /etc/exports' 'cat /proc/mounts' 'cat /proc/cpuinfo' \
-                 'cat /etc/hosts' 'free -m' )
+                 'cat /etc/hosts' 'free -m' 'systemctl show autofs.service')
       ;;
 
     Darwin )
@@ -1683,6 +1692,20 @@ configure_autofs() {
         num_errors=$(($num_errors+1))
         AUTOMASTER=/dev/null
       fi
+      # Fix 'systemctl restart autofs' on CentOS 7 (CVM-1200)
+      if [ -e /usr/bin/systemctl ]; then
+        if /usr/bin/systemctl show -p KillMode autofs.service | \
+           grep -q control-group;
+        then
+          mkdir -p /etc/systemd/system/autofs.service.d
+          cat > /etc/systemd/system/autofs.service.d/cvmfs-autosetup.conf << EOF
+[Service]
+KillMode=process
+EOF
+          /usr/bin/systemctl daemon-reload
+        fi
+      fi
+
       sed -i "/^\/mnt\/cvmfs \/etc\/auto.cvmfs/d" $AUTOMASTER # Still needed or needs to be adjusted?
       local cvmfs_map="$CVMFS_MOUNT_DIR /etc/auto.cvmfs"
       if ! grep -q "^$cvmfs_map" $AUTOMASTER; then

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -345,11 +345,11 @@ fi
 
 %postun
 if [ $1 -eq 0 ]; then
-   #sed -i "/^\/mnt\/cvmfs \/etc\/auto.cvmfs/d" /etc/auto.master
    [ -f /var/lock/subsys/autofs ] && /sbin/service autofs reload >/dev/null
    if [ -e /etc/fuse.conf ]; then
      sed -i "/added by CernVM-FS/d" /etc/fuse.conf
    fi
+   rm -f /etc/systemd/system/autofs.service.d/cvmfs-autosetup.conf
 fi
 
 %if 0%{?selinux_cvmfs}
@@ -426,6 +426,8 @@ fi
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog
+* Mon Mar 06 2017 Jakob Blomer <jblomer@cern.ch> - 2.3.4
+- Remove systemd bugfix configuration file if necessary
 * Mon Aug 22 2016 Jakob Blomer <jblomer@cern.ch> - 2.3.1
 - Reset cvmfs_swissknife capability if overlayfs is used
 * Wed Aug 10 2016 Dave Dykstra <dwd@fnal.gov> - 2.3.1


### PR DESCRIPTION
Uses `cvmfs_config setup` to work around dodgy kill mode in autofs systemd unit on CentOS 7.  See CVM-1200.