### PR TITLE
Fixing failing unittest on macOS

### DIFF
--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1386,7 +1386,11 @@ TEST_F(T_Util, WaitForChild) {
         close(fd);
       char *argv[1];
       argv[0] = NULL;
+#ifdef __APPLE__
+      execvp("/usr/bin/true", argv);
+#else
       execvp("/bin/true", argv);
+#endif
       exit(1);
     }
     default:


### PR DESCRIPTION
T_Util WaitForChild was failing on macOS due to the following call: `execvp("/bin/true", argv)`. On macOS, the correct path is `/usr/bin/true`.