### PR TITLE
Use HMAC for signing HTTP gateway API requests

### DIFF
--- a/cvmfs/server/cvmfs_server_abort.sh
+++ b/cvmfs/server/cvmfs_server_abort.sh
@@ -8,6 +8,7 @@
 cvmfs_server_abort() {
   local names
   local user
+  local key_id
   local spool_dir
   local exact=0
   local force=0
@@ -56,6 +57,7 @@ cvmfs_server_abort() {
     # get repository information
     load_repo_config $name
     user=$CVMFS_USER
+    key_id=$CVMFS_KEY_ID
     spool_dir=$CVMFS_SPOOL_DIR
     local upstream_storage=$CVMFS_UPSTREAM_STORAGE
     local upstream_type=$(get_upstream_type $upstream_storage)
@@ -90,7 +92,7 @@ cvmfs_server_abort() {
     # the cvmfs_swissknife lease command needs to be used to drop the active lease
     if [ x"$upstream_type" = xgw ]; then
         local repo_services_url=$(echo $upstream_storage | cut -d',' -f3)
-        __swissknife lease -a drop -u $repo_services_url -n $user -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; continue; }
+        __swissknife lease -a drop -u $repo_services_url -k $key_id -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; continue; }
     fi
     close_transaction $name $use_fd_fallback
 

--- a/cvmfs/server/cvmfs_server_abort.sh
+++ b/cvmfs/server/cvmfs_server_abort.sh
@@ -8,7 +8,7 @@
 cvmfs_server_abort() {
   local names
   local user
-  local key_id
+  local key_file
   local spool_dir
   local exact=0
   local force=0
@@ -57,7 +57,7 @@ cvmfs_server_abort() {
     # get repository information
     load_repo_config $name
     user=$CVMFS_USER
-    key_id=$CVMFS_KEY_ID
+    key_file=$CVMFS_KEY
     spool_dir=$CVMFS_SPOOL_DIR
     local upstream_storage=$CVMFS_UPSTREAM_STORAGE
     local upstream_type=$(get_upstream_type $upstream_storage)
@@ -92,7 +92,7 @@ cvmfs_server_abort() {
     # the cvmfs_swissknife lease command needs to be used to drop the active lease
     if [ x"$upstream_type" = xgw ]; then
         local repo_services_url=$(echo $upstream_storage | cut -d',' -f3)
-        __swissknife lease -a drop -u $repo_services_url -k $key_id -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; continue; }
+        __swissknife lease -a drop -u $repo_services_url -k $key_file -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; continue; }
     fi
     close_transaction $name $use_fd_fallback
 

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -2,6 +2,7 @@ cvmfs_server_publish() {
   local names
   local user
   local exact=0
+  local key_file
   local spool_dir
   local stratum0
   local upstream
@@ -103,6 +104,7 @@ cvmfs_server_publish() {
     # get repository information
     load_repo_config $name
     user=$CVMFS_USER
+    key_file=$CVMFS_KEY
     spool_dir=$CVMFS_SPOOL_DIR
     scratch_dir="${spool_dir}/scratch/current"
     stratum0=$CVMFS_STRATUM0
@@ -188,7 +190,7 @@ cvmfs_server_publish() {
     # to the `cvmfs_swissknife sync` command: the username and the
     # subpath of the active lease
     if [ x"$upstream_type" = xgw ]; then
-      sync_command="$sync_command -P /var/spool/cvmfs/$name/session_token_$subpath"
+      sync_command="$sync_command -P /var/spool/cvmfs/$name/session_token_$subpath -H $key_file"
     fi
     if [ "x$CVMFS_UNION_FS_TYPE" != "x" ]; then
       sync_command="$sync_command -f $CVMFS_UNION_FS_TYPE"

--- a/cvmfs/server/cvmfs_server_transaction.sh
+++ b/cvmfs/server/cvmfs_server_transaction.sh
@@ -13,6 +13,7 @@
 
 cvmfs_server_transaction() {
   local names
+  local key_id
   local spool_dir
   local stratum0
   local exact=0
@@ -68,6 +69,7 @@ cvmfs_server_transaction() {
     local upstream_storage=$CVMFS_UPSTREAM_STORAGE
     local upstream_type=$(get_upstream_type $upstream_storage)
     user=$CVMFS_USER
+    key_id=$CVMFS_KEY_ID
 
     # more sanity checks
     is_owner_or_root $name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }
@@ -84,7 +86,7 @@ cvmfs_server_transaction() {
     # the cvmfs_swissknife lease command needs to be used to acquire a new lease
     if [ x"$upstream_type" = xgw ]; then
         local repo_services_url=$(echo $upstream_storage | cut -d',' -f3)
-        __swissknife lease -a acquire -u $repo_services_url -n $user -p $name"/"$subpath || { echo "Could not acquire a new lease for repository $name"; retcode=1; continue; }
+        __swissknife lease -a acquire -u $repo_services_url -k $key_id -p $name"/"$subpath || { echo "Could not acquire a new lease for repository $name"; retcode=1; continue; }
     fi
     open_transaction $name $
 

--- a/cvmfs/server/cvmfs_server_transaction.sh
+++ b/cvmfs/server/cvmfs_server_transaction.sh
@@ -13,7 +13,7 @@
 
 cvmfs_server_transaction() {
   local names
-  local key_id
+  local key_file
   local spool_dir
   local stratum0
   local exact=0
@@ -69,7 +69,7 @@ cvmfs_server_transaction() {
     local upstream_storage=$CVMFS_UPSTREAM_STORAGE
     local upstream_type=$(get_upstream_type $upstream_storage)
     user=$CVMFS_USER
-    key_id=$CVMFS_KEY_ID
+    key_file=$CVMFS_KEY
 
     # more sanity checks
     is_owner_or_root $name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }
@@ -86,7 +86,7 @@ cvmfs_server_transaction() {
     # the cvmfs_swissknife lease command needs to be used to acquire a new lease
     if [ x"$upstream_type" = xgw ]; then
         local repo_services_url=$(echo $upstream_storage | cut -d',' -f3)
-        __swissknife lease -a acquire -u $repo_services_url -k $key_id -p $name"/"$subpath || { echo "Could not acquire a new lease for repository $name"; retcode=1; continue; }
+        __swissknife lease -a acquire -u $repo_services_url -k $key_file -p $name"/"$subpath || { echo "Could not acquire a new lease for repository $name"; retcode=1; continue; }
     fi
     open_transaction $name $
 

--- a/cvmfs/session_context.h
+++ b/cvmfs/session_context.h
@@ -32,6 +32,7 @@ class SessionContextBase {
   virtual ~SessionContextBase();
 
   bool Initialize(const std::string& api_url, const std::string& session_token,
+                  const std::string& key_id, const std::string& secret,
                   bool drop_lease = true,
                   uint64_t max_pack_size = ObjectPack::kDefaultLimit);
   bool Finalize();
@@ -60,6 +61,8 @@ class SessionContextBase {
 
   std::string api_url_;
   std::string session_token_;
+  std::string key_id_;
+  std::string secret_;
   bool drop_lease_;
 
   FifoChannel<bool> queue_was_flushed_;

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -44,7 +44,7 @@ ParameterList CommandLease::GetParams() const {
   ParameterList r;
   r.push_back(Parameter::Mandatory('u', "repo service url"));
   r.push_back(Parameter::Mandatory('a', "action (acquire or drop)"));
-  r.push_back(Parameter::Mandatory('n', "user name"));
+  r.push_back(Parameter::Mandatory('k', "key id"));
   r.push_back(Parameter::Mandatory('p', "lease path"));
   return r;
 }
@@ -54,7 +54,7 @@ int CommandLease::Main(const ArgumentList& args) {
 
   params.repo_service_url = *(args.find('u')->second);
   params.action = *(args.find('a')->second);
-  params.user_name = *(args.find('n')->second);
+  params.key_id = *(args.find('k')->second);
 
   params.lease_path = *(args.find('p')->second);
   std::vector<std::string> tokens = SplitString(params.lease_path, '/');
@@ -77,7 +77,7 @@ int CommandLease::Main(const ArgumentList& args) {
   LeaseError ret = kLeaseSuccess;
   if (params.action == "acquire") {
     CurlBuffer buffer;
-    if (MakeAcquireRequest(params.user_name, params.lease_path,
+    if (MakeAcquireRequest(params.key_id, params.lease_path,
                            params.repo_service_url, &buffer)) {
       std::string session_token;
       if (buffer.data.size() > 0 && ParseAcquireReply(buffer, &session_token)) {

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -44,7 +44,7 @@ ParameterList CommandLease::GetParams() const {
   ParameterList r;
   r.push_back(Parameter::Mandatory('u', "repo service url"));
   r.push_back(Parameter::Mandatory('a', "action (acquire or drop)"));
-  r.push_back(Parameter::Mandatory('k', "key id"));
+  r.push_back(Parameter::Mandatory('k', "key file"));
   r.push_back(Parameter::Mandatory('p', "lease path"));
   return r;
 }
@@ -54,7 +54,7 @@ int CommandLease::Main(const ArgumentList& args) {
 
   params.repo_service_url = *(args.find('u')->second);
   params.action = *(args.find('a')->second);
-  params.key_id = *(args.find('k')->second);
+  params.key_file = *(args.find('k')->second);
 
   params.lease_path = *(args.find('p')->second);
   std::vector<std::string> tokens = SplitString(params.lease_path, '/');
@@ -77,7 +77,7 @@ int CommandLease::Main(const ArgumentList& args) {
   LeaseError ret = kLeaseSuccess;
   if (params.action == "acquire") {
     CurlBuffer buffer;
-    if (MakeAcquireRequest(params.key_id, params.lease_path,
+    if (MakeAcquireRequest(params.key_file, params.lease_path,
                            params.repo_service_url, &buffer)) {
       std::string session_token;
       if (buffer.data.size() > 0 && ParseAcquireReply(buffer, &session_token)) {
@@ -110,7 +110,8 @@ int CommandLease::Main(const ArgumentList& args) {
                session_token.c_str());
 
       CurlBuffer buffer;
-      if (MakeDeleteRequest(session_token, params.repo_service_url, &buffer)) {
+      if (MakeDeleteRequest(params.key_file, session_token,
+                            params.repo_service_url, &buffer)) {
         if (buffer.data.size() > 0 && ParseDropReply(buffer)) {
           std::fclose(token_file);
           if (unlink(token_file_name.c_str())) {

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -26,11 +26,11 @@ class CommandLease : public Command {
 
   struct Parameters {
     Parameters()
-        : repo_service_url(""), action(""), user_name(""), lease_path("") {}
+        : repo_service_url(""), action(""), key_id(""), lease_path("") {}
 
     std::string repo_service_url;
     std::string action;
-    std::string user_name;
+    std::string key_id;
     std::string lease_path;
     std::string token_file_suffix;
   };

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -26,11 +26,11 @@ class CommandLease : public Command {
 
   struct Parameters {
     Parameters()
-        : repo_service_url(""), action(""), key_id(""), lease_path("") {}
+        : repo_service_url(""), action(""), key_file(""), lease_path("") {}
 
     std::string repo_service_url;
     std::string action;
-    std::string key_id;
+    std::string key_file;
     std::string lease_path;
     std::string token_file_suffix;
   };

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -38,23 +38,11 @@ CURL* PrepareCurl(const char* method) {
   return h_curl;
 }
 
-bool MakeAcquireRequest(const std::string& key_file,
+bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
                         const std::string& repo_path,
                         const std::string& repo_service_url,
                         CurlBuffer* buffer) {
   CURLcode ret = static_cast<CURLcode>(0);
-
-  // Prepare payload
-  FILE* key_file_fd = std::fopen(key_file.c_str(), "r");
-  if (!key_file_fd) {
-    return false;
-  }
-
-  std::string key_id;
-  std::string secret;
-  GetLineFile(key_file_fd, &key_id);
-  GetLineFile(key_file_fd, &secret);
-  fclose(key_file_fd);
 
   CURL* h_curl = PrepareCurl("POST");
   if (!h_curl) {
@@ -88,22 +76,11 @@ bool MakeAcquireRequest(const std::string& key_file,
   return !ret;
 }
 
-bool MakeDeleteRequest(const std::string& key_file,
+bool MakeDeleteRequest(const std::string& key_id, const std::string& secret,
                        const std::string& session_token,
                        const std::string& repo_service_url,
                        CurlBuffer* buffer) {
   CURLcode ret = static_cast<CURLcode>(0);
-
-  FILE* key_file_fd = std::fopen(key_file.c_str(), "r");
-  if (!key_file_fd) {
-    return false;
-  }
-
-  std::string key_id;
-  std::string secret;
-  GetLineFile(key_file_fd, &key_id);
-  GetLineFile(key_file_fd, &secret);
-  fclose(key_file_fd);
 
   CURL* h_curl = PrepareCurl("DELETE");
   if (!h_curl) {

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -34,8 +34,7 @@ CURL* PrepareCurl(const char* method) {
   return h_curl;
 }
 
-bool MakeAcquireRequest(const std::string& user_name,
-                        const std::string& repo_path,
+bool MakeAcquireRequest(const std::string& key_id, const std::string& repo_path,
                         const std::string& repo_service_url,
                         CurlBuffer* buffer) {
   CURLcode ret = static_cast<CURLcode>(0);
@@ -47,7 +46,7 @@ bool MakeAcquireRequest(const std::string& user_name,
 
   // Prepare payload
   const std::string payload =
-      "{\"user\" : \"" + user_name + "\", \"path\" : \"" + repo_path + "\"}";
+      "{\"key_id\" : \"" + key_id + "\", \"path\" : \"" + repo_path + "\"}";
 
   // Make request to acquire lease from repo services
   curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/leases").c_str());

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -6,6 +6,10 @@
 
 #include "cvmfs_config.h"
 
+#include "hash.h"
+#include "logging.h"
+#include "util/string.h"
+
 size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {
   CurlBuffer* my_buffer = static_cast<CurlBuffer*>(userp);
 
@@ -34,19 +38,39 @@ CURL* PrepareCurl(const char* method) {
   return h_curl;
 }
 
-bool MakeAcquireRequest(const std::string& key_id, const std::string& repo_path,
+bool MakeAcquireRequest(const std::string& key_file,
+                        const std::string& repo_path,
                         const std::string& repo_service_url,
                         CurlBuffer* buffer) {
   CURLcode ret = static_cast<CURLcode>(0);
+
+  // Prepare payload
+  FILE* key_file_fd = std::fopen(key_file.c_str(), "r");
+  if (!key_file_fd) {
+    return false;
+  }
+
+  std::string key_id;
+  std::string secret;
+  GetLineFile(key_file_fd, &key_id);
+  GetLineFile(key_file_fd, &secret);
+  fclose(key_file_fd);
 
   CURL* h_curl = PrepareCurl("POST");
   if (!h_curl) {
     return false;
   }
 
-  // Prepare payload
-  const std::string payload =
-      "{\"key_id\" : \"" + key_id + "\", \"path\" : \"" + repo_path + "\"}";
+  const std::string payload = "{\"path\" : \"" + repo_path + "\"}";
+
+  shash::Any hmac(shash::kSha1);
+  shash::HmacString(secret, payload, &hmac);
+
+  const std::string header_str = std::string("Authorization: ") + key_id + " " +
+                                 Base64(hmac.ToString(false));
+  struct curl_slist* auth_header = NULL;
+  auth_header = curl_slist_append(auth_header, header_str.c_str());
+  curl_easy_setopt(h_curl, CURLOPT_HTTPHEADER, auth_header);
 
   // Make request to acquire lease from repo services
   curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/leases").c_str());
@@ -64,15 +88,37 @@ bool MakeAcquireRequest(const std::string& key_id, const std::string& repo_path,
   return !ret;
 }
 
-bool MakeDeleteRequest(const std::string& session_token,
+bool MakeDeleteRequest(const std::string& key_file,
+                       const std::string& session_token,
                        const std::string& repo_service_url,
                        CurlBuffer* buffer) {
   CURLcode ret = static_cast<CURLcode>(0);
+
+  FILE* key_file_fd = std::fopen(key_file.c_str(), "r");
+  if (!key_file_fd) {
+    return false;
+  }
+
+  std::string key_id;
+  std::string secret;
+  GetLineFile(key_file_fd, &key_id);
+  GetLineFile(key_file_fd, &secret);
+  fclose(key_file_fd);
 
   CURL* h_curl = PrepareCurl("DELETE");
   if (!h_curl) {
     return false;
   }
+
+  shash::Any hmac(shash::kSha1);
+  shash::HmacString(secret, session_token, &hmac);
+
+  const std::string header_str = std::string("Authorization: ") + key_id + " " +
+                                 Base64(hmac.ToString(false));
+  struct curl_slist* auth_header = NULL;
+  auth_header = curl_slist_append(auth_header, header_str.c_str());
+  curl_easy_setopt(h_curl, CURLOPT_HTTPHEADER, auth_header);
+
   curl_easy_setopt(h_curl, CURLOPT_URL,
                    (repo_service_url + "/leases/" + session_token).c_str());
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -17,12 +17,12 @@ size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp);
 
 CURL* PrepareCurl(const char* method);
 
-bool MakeAcquireRequest(const std::string& key_file,
+bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
                         const std::string& repo_path,
                         const std::string& repo_service_url,
                         CurlBuffer* buffer);
 
-bool MakeDeleteRequest(const std::string& key_file,
+bool MakeDeleteRequest(const std::string& key_id, const std::string& secret,
                        const std::string& session_token,
                        const std::string& repo_service_url, CurlBuffer* buffer);
 

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -17,8 +17,7 @@ size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp);
 
 CURL* PrepareCurl(const char* method);
 
-bool MakeAcquireRequest(const std::string& user_name,
-                        const std::string& repo_path,
+bool MakeAcquireRequest(const std::string& key_id, const std::string& repo_path,
                         const std::string& repo_service_url,
                         CurlBuffer* buffer);
 

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -17,11 +17,13 @@ size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp);
 
 CURL* PrepareCurl(const char* method);
 
-bool MakeAcquireRequest(const std::string& key_id, const std::string& repo_path,
+bool MakeAcquireRequest(const std::string& key_file,
+                        const std::string& repo_path,
                         const std::string& repo_service_url,
                         CurlBuffer* buffer);
 
-bool MakeDeleteRequest(const std::string& session_token,
+bool MakeDeleteRequest(const std::string& key_file,
+                       const std::string& session_token,
                        const std::string& repo_service_url, CurlBuffer* buffer);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_CURL_H_

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -592,6 +592,10 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     params.session_token_file = *args.find('P')->second;
   }
 
+  if (args.find('H') != args.end()) {
+    params.key_file = *args.find('H')->second;
+  }
+
   if (!CheckParams(params)) return 2;
 
   // Start spooler
@@ -599,7 +603,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
       params.spooler_definition, hash_algorithm, params.compression_alg,
       params.use_file_chunking, params.min_file_chunk_size,
       params.avg_file_chunk_size, params.max_file_chunk_size,
-      params.session_token_file);
+      params.session_token_file, params.key_file);
   if (params.max_concurrent_write_jobs > 0) {
     spooler_definition.number_of_concurrent_uploads =
         params.max_concurrent_write_jobs;

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -45,7 +45,8 @@ struct SyncParameters {
         is_balanced(false),
         max_weight(kDefaultMaxWeight),
         min_weight(kDefaultMinWeight),
-        session_token_file() {}
+        session_token_file(),
+        key_file() {}
 
   upload::Spooler *spooler;
   std::string repo_name;
@@ -86,6 +87,7 @@ struct SyncParameters {
 
   // Parameters for when upstream type is HTTP
   std::string session_token_file;
+  std::string key_file;
 };
 
 namespace catalog {
@@ -274,6 +276,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Switch('Y', "enable external data"));
 
     r.push_back(Parameter::Optional('P', "session_token_file"));
+    r.push_back(Parameter::Optional('H', "key file for HTTP API"));
 
     return r;
   }

--- a/cvmfs/upload_gateway.h
+++ b/cvmfs/upload_gateway.h
@@ -25,10 +25,14 @@ struct GatewayStreamHandle : public UploadStreamHandle {
 class GatewayUploader : public AbstractUploader {
  public:
   struct Config {
-    Config() : session_token_file(), api_url() {}
-    Config(const std::string& session_token_file, const std::string& api_url)
-        : session_token_file(session_token_file), api_url(api_url) {}
+    Config() : session_token_file(), key_file(), api_url() {}
+    Config(const std::string& session_token_file, const std::string& key_file,
+           const std::string& api_url)
+        : session_token_file(session_token_file),
+          key_file(key_file),
+          api_url(api_url) {}
     std::string session_token_file;
+    std::string key_file;
     std::string api_url;
   };
 
@@ -74,6 +78,9 @@ class GatewayUploader : public AbstractUploader {
  protected:
   virtual bool ReadSessionTokenFile(const std::string& token_file_name,
                                     std::string* token);
+
+  virtual bool ReadKey(const std::string& key_file, std::string* key_id,
+                       std::string* secret);
 
  private:
   void BumpErrors() const;

--- a/cvmfs/upload_spooler_definition.cc
+++ b/cvmfs/upload_spooler_definition.cc
@@ -17,7 +17,8 @@ SpoolerDefinition::SpoolerDefinition(
     const shash::Algorithms hash_algorithm,
     const zlib::Algorithms compression_algorithm, const bool use_file_chunking,
     const size_t min_file_chunk_size, const size_t avg_file_chunk_size,
-    const size_t max_file_chunk_size, const std::string& session_token_file)
+    const size_t max_file_chunk_size, const std::string& session_token_file,
+    const std::string& key_file)
     : driver_type(Unknown),
       hash_algorithm(hash_algorithm),
       compression_alg(compression_algorithm),
@@ -28,6 +29,7 @@ SpoolerDefinition::SpoolerDefinition(
       number_of_threads(tbb::task_scheduler_init::default_num_threads()),
       number_of_concurrent_uploads(number_of_threads * 100),
       session_token_file(session_token_file),
+      key_file(key_file),
       valid_(false) {
   // check if given file chunking values are sane
   if (use_file_chunking && (min_file_chunk_size >= avg_file_chunk_size ||

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -39,7 +39,8 @@ struct SpoolerDefinition {
       const size_t min_file_chunk_size = 0,
       const size_t avg_file_chunk_size = 0,
       const size_t max_file_chunk_size = 0,
-      const std::string& session_token_file = "");
+      const std::string& session_token_file = "",
+      const std::string& key_file = "");
 
   bool IsValid() const { return valid_; }
 
@@ -71,6 +72,7 @@ struct SpoolerDefinition {
 
   // The session_token_file parameter is only used for the HTTP driver
   std::string session_token_file;
+  std::string key_file;
 
   bool valid_;
 };

--- a/test/unittests/t_gateway_uploader.cc
+++ b/test/unittests/t_gateway_uploader.cc
@@ -27,6 +27,16 @@ class GatewayUploaderMocked : public upload::GatewayUploader {
     *token = "ThisIsAFakeToken";
     return true;
   }
+  virtual bool ReadKey(const std::string& /*key_file_name*/,
+                       std::string* key_id, std::string* secret) {
+    if (!(key_id && secret)) {
+      return false;
+    }
+
+    *key_id = "fake_id";
+    *secret = "fake_secret";
+    return true;
+  }
 };
 
 class T_GatewayUploaderConfig : public ::testing::Test {
@@ -46,7 +56,7 @@ TEST_F(T_GatewayUploaderConfig, ParseSpoolerDefinitionBadArgs) {
   upload::SpoolerDefinition definition(
       "gw,/local/temp/dir,http://my.repo.address:8080/api/v1", shash::kSha1,
       zlib::kZlibDefault, false, 0, 0, 0,
-      "/var/spool/cvmfs/test.cern.ch/session_token_some_path");
+      "/var/spool/cvmfs/test.cern.ch/session_token_some_path", "some_key_file");
   EXPECT_FALSE(
       upload::GatewayUploader::ParseSpoolerDefinition(definition, NULL));
 }
@@ -55,7 +65,7 @@ TEST_F(T_GatewayUploaderConfig, ParseSpoolerDefinitionGoodConfigString) {
   upload::SpoolerDefinition definition(
       "gw,/local/temp/dir,http://my.repo.address:8080/api/v1", shash::kSha1,
       zlib::kZlibDefault, false, 0, 0, 0,
-      "/var/spool/cvmfs/test.cern.ch/session_token_some_path");
+      "/var/spool/cvmfs/test.cern.ch/session_token_some_path", "some_key_file");
 
   EXPECT_TRUE(
       upload::GatewayUploader::ParseSpoolerDefinition(definition, &config));
@@ -78,7 +88,7 @@ TEST_F(T_GatewayUploader, Construct) {
   upload::SpoolerDefinition definition(
       "gw,/local/temp/dir,http://my.repo.address:8080/api/v1", shash::kSha1,
       zlib::kZlibDefault, false, 0, 0, 0,
-      "/var/spool/cvmfs/test.cern.ch/session_token_some_path");
+      "/var/spool/cvmfs/test.cern.ch/session_token_some_path", "some_key_file");
   GatewayUploaderMocked uploader(definition);
   EXPECT_TRUE(uploader.Initialize());
   EXPECT_TRUE(uploader.FinalizeSession());

--- a/test/unittests/t_session_context.cc
+++ b/test/unittests/t_session_context.cc
@@ -31,7 +31,8 @@ class T_SessionContext : public ::testing::Test {};
 TEST_F(T_SessionContext, BasicLifeCycle) {
   SessionContextMocked ctx;
   EXPECT_TRUE(ctx.Initialize("http://my.repo.address:8080/api/v1",
-                             "/path/to/the/session_file"));
+                             "/path/to/the/session_file", "some_key_id",
+                             "some_secret"));
   EXPECT_EQ(ctx.num_jobs_dispatched_, 0);
   EXPECT_EQ(ctx.num_jobs_finished_, 0);
 
@@ -52,7 +53,8 @@ TEST_F(T_SessionContext, BasicLifeCycle) {
 TEST_F(T_SessionContext, MultipleFiles) {
   SessionContextMocked ctx;
   EXPECT_TRUE(ctx.Initialize("http://my.repo.address:8080/api/v1",
-                             "/path/to/the/session_file", false, 20000));
+                             "/path/to/the/session_file", "some_key_id",
+                             "some_secret", false, 20000));
   EXPECT_EQ(ctx.num_jobs_dispatched_, 0);
   EXPECT_EQ(ctx.num_jobs_finished_, 0);
 
@@ -75,7 +77,8 @@ TEST_F(T_SessionContext, MultipleFiles) {
 TEST_F(T_SessionContext, MultipleFilesForcedDispatchLast) {
   SessionContextMocked ctx;
   EXPECT_TRUE(ctx.Initialize("http://my.repo.address:8080/api/v1",
-                             "/path/to/the/session_file", false, 20000));
+                             "/path/to/the/session_file", "some_key_id",
+                             "some_secret", false, 20000));
   EXPECT_EQ(ctx.num_jobs_dispatched_, 0);
   EXPECT_EQ(ctx.num_jobs_finished_, 0);
 
@@ -99,7 +102,8 @@ TEST_F(T_SessionContext, MultipleFilesForcedDispatchLast) {
 TEST_F(T_SessionContext, MultipleFilesForcedDispatchEach) {
   SessionContextMocked ctx;
   EXPECT_TRUE(ctx.Initialize("http://my.repo.address:8080/api/v1",
-                             "/path/to/the/session_file", false, 20000));
+                             "/path/to/the/session_file", "some_key_id",
+                             "some_secret", false, 20000));
   EXPECT_EQ(ctx.num_jobs_dispatched_, 0);
   EXPECT_EQ(ctx.num_jobs_finished_, 0);
 
@@ -122,7 +126,8 @@ TEST_F(T_SessionContext, MultipleFilesForcedDispatchEach) {
 TEST_F(T_SessionContext, FirstAddAllThenCommit) {
   SessionContextMocked ctx;
   EXPECT_TRUE(ctx.Initialize("http://my.repo.address:8080/api/v1",
-                             "/path/to/the/session_file", false, 20000));
+                             "/path/to/the/session_file", "some_key_id",
+                             "some_secret", false, 20000));
   EXPECT_EQ(ctx.num_jobs_dispatched_, 0);
   EXPECT_EQ(ctx.num_jobs_finished_, 0);
 


### PR DESCRIPTION
Addresses [CVM-1191](https://sft.its.cern.ch/jira/browse/CVM-1191) and [CVM-1193](https://sft.its.cern.ch/jira/browse/CVM-1193).

* All the requests (new lease, drop lease, submit payload) made to the HTTP gateway API are now signed with an HMAC computed with a pre-shared secret key.
* The shared key is configured through the `CVMFS_KEY` configuration option, written in the server onfiguration file (`server.conf`) of the repository. Right now the key has a test format - first line is the public key id, second line is the secret - but this can be updated in the future to use standard key formats.
* The gateway services (`cvmfs_services`) checks the HMAC added to all the requests.
