### PR TITLE
Include ObjectPack digest when submitting payload.

### DIFF
--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -234,8 +234,11 @@ bool SessionContext::DoUpload(const SessionContext::UploadJob* job) {
   // Set up the object pack serializer
   ObjectPackProducer serializer(job->pack);
 
-  const std::string json_body =
-      "{\"session_token\" : \"" + session_token_ + "\"}";
+  shash::Any payload_digest(shash::kSha1);
+  serializer.GetDigest(&payload_digest);
+  const std::string json_body = "{\"session_token\" : \"" + session_token_ +
+                                "\", \"payload_digest\" : \"" +
+                                Base64(payload_digest.ToString(false)) + "\"}";
 
   // Compute HMAC
   shash::Any hmac(shash::kSha1);


### PR DESCRIPTION
This is just a small tweak:

When submitting a payload, include the digest of the
payload (ObjectPack) as an additional field of the JSON message
body. The digest can be used to verify the correct transfer of the
payload to the gateway services.