### PR TITLE
Fix reloading of the fuse module with external and tiered cache managers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
     "C_Cpp.clang_format_formatOnSave": true,
     "editor.formatOnSave": true,
     "clang-format.style": "Google",
-    "files.associations": {}
-}
+    "files.associations": {
+      "random": "cpp",
+      "array": "cpp"
+    }
+  }
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,21 @@
     "clang-format.style": "Google",
     "files.associations": {
       "random": "cpp",
-      "array": "cpp"
+      "array": "cpp",
+      "dense_hash_map": "cpp",
+      "dense_hash_set": "cpp",
+      "sparse_hash_map": "cpp",
+      "sparse_hash_set": "cpp",
+      "sparsetable": "cpp",
+      "*.ipp": "cpp",
+      "hash_map": "cpp",
+      "hash_set": "cpp",
+      "*.tcc": "cpp",
+      "deque": "cpp",
+      "string": "cpp",
+      "vector": "cpp",
+      "slist": "cpp",
+      "regex": "cpp"
     }
   }
 

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -17,6 +17,7 @@
 #include "hash.h"
 #include "quota.h"
 #include "smalloc.h"
+#include "util/posix.h"
 
 using namespace std;  // NOLINT
 
@@ -96,6 +97,20 @@ bool CacheManager::CommitFromMem(
 }
 
 
+void CacheManager::FreeState(const int fd_progress, void *data) {
+  State *state = reinterpret_cast<State *>(data);
+  SendMsg2Socket(fd_progress, "Releasing saved open files table\n");
+  assert(state->version == kStateVersion);
+  assert(state->manager_type == id());
+  bool result = DoFreeState(state->concrete_state);
+  if (!result) {
+    SendMsg2Socket(fd_progress, "   *** Releasing open files table failed!\n");
+    abort();
+  }
+  delete state;
+}
+
+
 /**
  * Tries to open a file and copies its contents into a newly malloc'd
  * memory area.  User of the function has to free buffer (if successful).
@@ -169,4 +184,41 @@ int CacheManager::OpenPinned(
     }
   }
   return fd;
+}
+
+
+void CacheManager::RestoreState(const int fd_progress, void *data) {
+  State *state = reinterpret_cast<State *>(data);
+  SendMsg2Socket(fd_progress, "Restoring open files table... ");
+  if (state->version != kStateVersion) {
+    SendMsg2Socket(fd_progress, "unsupported state version!\n");
+    abort();
+  }
+  if (state->manager_type != id()) {
+    SendMsg2Socket(fd_progress, "switching cache manager unsupported!\n");
+    abort();
+  }
+  bool result = DoRestoreState(state->concrete_state);
+  if (!result) {
+    SendMsg2Socket(fd_progress, "FAILED!\n");
+    abort();
+  }
+  SendMsg2Socket(fd_progress, "done\n");
+}
+
+
+/**
+ * The actual work is done in the concrete cache managers.
+ */
+void *CacheManager::SaveState(const int fd_progress) {
+  SendMsg2Socket(fd_progress, "Saving open files table\n");
+  State *state = new State();
+  state->manager_type = id();
+  state->concrete_state = DoSaveState();
+  if (state->concrete_state == NULL) {
+    SendMsg2Socket(fd_progress,
+                   "  *** This cache manager does not support saving state!\n");
+    abort();
+  }
+  return state;
 }

--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -78,7 +78,7 @@ enum EnumCapabilities {
   CAP_INFO        = 8;   // cache plugin knows about its size and fill level
   CAP_SHRINK_RATE = 16;   // cache knows number of cleanup operations
   CAP_LIST        = 32;  // cache can return a list of objects
-  CAP_ALL         = 63;
+  CAP_ALL_V1      = 63;
 }
 
 

--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -135,8 +135,16 @@ message MsgHandshakeAck {
 message MsgQuit {
   // The connection identifier from the handshake acknowledgement
   required uint64 session_id = 1;
-  // The client can express its interest to reconnect soon (e.g. during reload)
-  optional bool temporary    = 2;
+}
+
+// Send from the client to the plugin to steer the connection handling
+message MsgIoctl {
+  required uint64 session_id = 1;
+  // When there are no more open connections, the cache plugin can shutdown
+  // itself.  During client reloads, this is unwanted.  Before the reload, the
+  // client tells the plugin to artifically increase the connection counter.
+  // Once reloading has finished, the connection counter is decreased again.
+  optional sint32 conncnt_change_by  = 2;
 }
 
 
@@ -324,5 +332,7 @@ message MsgRpc {
     MsgListReply msg_list_reply              = 24;
 
     MsgDetach msg_detach                     = 25;
+
+    MsgIoctl msg_ioctl                       = 26;
   }
 }

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -322,11 +322,21 @@ bool ExternalCacheManager::DoRestoreState(void *data) {
   FdTable<ReadOnlyHandle> *other =
     reinterpret_cast<FdTable<ReadOnlyHandle> *>(data);
   fd_table_.AssignFrom(*other);
+  cvmfs::MsgIoctl msg_ioctl;
+  msg_ioctl.set_session_id(session_id_);
+  msg_ioctl.set_conncnt_change_by(-1);
+  CacheTransport::Frame frame(&msg_ioctl);
+  transport_.SendFrame(&frame);
   return true;
 }
 
 
 void *ExternalCacheManager::DoSaveState() {
+  cvmfs::MsgIoctl msg_ioctl;
+  msg_ioctl.set_session_id(session_id_);
+  msg_ioctl.set_conncnt_change_by(1);
+  CacheTransport::Frame frame(&msg_ioctl);
+  transport_.SendFrame(&frame);
   return fd_table_.Clone();
 }
 

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -287,6 +287,14 @@ string ExternalCacheManager::Describe() {
 }
 
 
+bool ExternalCacheManager::DoFreeState(void *data) {
+  FdTable<ReadOnlyHandle> *fd_table =
+    reinterpret_cast<FdTable<ReadOnlyHandle> *>(data);
+  delete fd_table;
+  return true;
+}
+
+
 int ExternalCacheManager::DoOpen(const shash::Any &id) {
   int fd = -1;
   {
@@ -307,6 +315,19 @@ int ExternalCacheManager::DoOpen(const shash::Any &id) {
   int retval = fd_table_.CloseFd(fd);
   assert(retval == 0);
   return status_refcnt;
+}
+
+
+bool ExternalCacheManager::DoRestoreState(void *data) {
+  FdTable<ReadOnlyHandle> *other =
+    reinterpret_cast<FdTable<ReadOnlyHandle> *>(data);
+  fd_table_.AssignFrom(*other);
+  return true;
+}
+
+
+void *ExternalCacheManager::DoSaveState() {
+  return fd_table_.Clone();
 }
 
 

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -91,6 +91,11 @@ class ExternalCacheManager : public CacheManager {
   uint32_t max_object_size() const { return max_object_size_; }
   uint64_t capabilities() const { return capabilities_; }
 
+ protected:
+  virtual void *DoSaveState();
+  virtual bool DoRestoreState(void *data);
+  virtual bool DoFreeState(void *data);
+
  private:
   /**
    * The null hash (hashed output is all null bytes) serves as a marker for an

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -137,6 +137,7 @@ class CachePlugin {
   void HandleInfo(cvmfs::MsgInfoReq *msg_req, CacheTransport *transport);
   void HandleShrink(cvmfs::MsgShrinkReq *msg_req, CacheTransport *transport);
   void HandleList(cvmfs::MsgListReq *msg_req, CacheTransport *transport);
+  void HandleIoctl(cvmfs::MsgIoctl *msg_req);
   void SendDetachRequests();
 
   void NotifySupervisor(char signal);
@@ -144,6 +145,7 @@ class CachePlugin {
   void LogSessionError(uint64_t session_id,
                        cvmfs::EnumStatus status,
                        const std::string &msg);
+  void LogSessionInfo(uint64_t session_id, const std::string &msg);
 
   uint64_t capabilities_;
   int fd_socket_;
@@ -151,6 +153,11 @@ class CachePlugin {
   atomic_int32 running_;
   unsigned num_workers_;
   unsigned max_object_size_;
+  /**
+   * Number of clients undergoing a reload, i.e. they promise to come back
+   * and open a new connection soon.
+   */
+  uint64_t num_inlimbo_clients_;
   std::string name_;
   atomic_int64 next_session_id_;
   atomic_int64 next_txn_id_;

--- a/cvmfs/cache_plugin/cvmfs_cache_null.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_null.cc
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
   callbacks.cvmcache_listing_begin = null_listing_begin;
   callbacks.cvmcache_listing_next = null_listing_next;
   callbacks.cvmcache_listing_end = null_listing_end;
-  callbacks.capabilities = CVMCACHE_CAP_ALL;
+  callbacks.capabilities = CVMCACHE_CAP_ALL_V1;
 
   ctx = cvmcache_init(&callbacks);
   int retval = cvmcache_listen(ctx, locator);

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -622,7 +622,7 @@ int main(int argc, char **argv) {
   callbacks.cvmcache_listing_begin = plugin->ram_listing_begin;
   callbacks.cvmcache_listing_next = plugin->ram_listing_next;
   callbacks.cvmcache_listing_end = plugin->ram_listing_end;
-  callbacks.capabilities = CVMCACHE_CAP_ALL;
+  callbacks.capabilities = CVMCACHE_CAP_ALL_V1;
 
   ctx = cvmcache_init(&callbacks);
   int retval = cvmcache_listen(ctx, locator);

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -67,7 +67,7 @@ enum cvmcache_capabilities {
   CVMCACHE_CAP_INFO        = 8,   // cache plugin knows about its fill level
   CVMCACHE_CAP_SHRINK_RATE = 16,   // cache knows number of cleanup operations
   CVMCACHE_CAP_LIST        = 32,  // cache can return a list of objects
-  CVMCACHE_CAP_ALL         = 63
+  CVMCACHE_CAP_ALL_V1      = 63
 };
 
 #define CVMCACHE_SIZE_UNKNOWN (uint64_t(-1))

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -285,6 +285,32 @@ string PosixCacheManager::Describe() {
 }
 
 
+/**
+ * Nothing to do, the kernel keeps the state of open file descriptors.  Return
+ * a dummy memory location.
+ */
+void *PosixCacheManager::DoSaveState() {
+  char *c = reinterpret_cast<char *>(smalloc(1));
+  *c = '\0';
+  return c;
+}
+
+
+bool PosixCacheManager::DoRestoreState(void *data) {
+  assert(data);
+  char *c = reinterpret_cast<char *>(data);
+  assert(*c == '\0');
+  return true;
+}
+
+
+bool PosixCacheManager::DoFreeState(void *data) {
+  free(data);
+  return true;
+}
+
+
+
 int PosixCacheManager::Dup(int fd) {
   int new_fd = dup(fd);
   if (new_fd < 0)

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -93,6 +93,11 @@ class PosixCacheManager : public CacheManager {
   bool alien_cache() { return alien_cache_; }
   std::string cache_path() { return cache_path_; }
 
+ protected:
+  virtual void *DoSaveState();
+  virtual bool DoRestoreState(void *data);
+  virtual bool DoFreeState(void *data);
+
  private:
   struct Transaction {
     Transaction(const shash::Any &id, const std::string &final_path)

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -20,6 +20,31 @@ std::string TieredCacheManager::Describe() {
 }
 
 
+bool TieredCacheManager::DoFreeState(void *data) {
+  SavedState *state = reinterpret_cast<SavedState *>(data);
+  upper_->FreeState(-1, state->state_upper);
+  lower_->FreeState(-1, state->state_lower);
+  delete state;
+  return true;
+}
+
+
+bool TieredCacheManager::DoRestoreState(void *data) {
+  SavedState *state = reinterpret_cast<SavedState *>(data);
+  upper_->RestoreState(-1, state->state_upper);
+  lower_->RestoreState(-1, state->state_lower);
+  return true;
+}
+
+
+void *TieredCacheManager::DoSaveState() {
+  SavedState *state = new SavedState();
+  state->state_upper = upper_->SaveState(-1);
+  state->state_lower = lower_->SaveState(-1);
+  return state;
+}
+
+
 int TieredCacheManager::Open(const BlessedObject &object) {
   int fd = upper_->Open(object);
   if ((fd >= 0) || (fd != -ENOENT)) {return fd;}

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -63,8 +63,19 @@ class TieredCacheManager : public CacheManager {
   virtual int CommitTxn(void *txn);
   virtual void Spawn();
 
+ protected:
+  virtual void *DoSaveState();
+  virtual bool DoRestoreState(void *data);
+  virtual bool DoFreeState(void *data);
+
  private:
   static const unsigned kCopyBufferSize = 64 * 1024;  // 64kB
+
+  struct SavedState {
+    SavedState() : state_upper(NULL), state_lower(NULL) { }
+    void *state_upper;
+    void *state_lower;
+  };
 
   // NOTE: TieredCacheManager takes ownership of both caches passed.
   TieredCacheManager(CacheManager *upper_cache,

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -120,6 +120,7 @@ void CacheTransport::Frame::Release() {
   msg_rpc_.release_msg_handshake();
   msg_rpc_.release_msg_handshake_ack();
   msg_rpc_.release_msg_quit();
+  msg_rpc_.release_msg_ioctl();
   msg_rpc_.release_msg_info_req();
   msg_rpc_.release_msg_info_reply();
   msg_rpc_.release_msg_shrink_req();
@@ -151,6 +152,9 @@ void CacheTransport::Frame::WrapMsg() {
   } else if (msg_typed_->GetTypeName() == "cvmfs.MsgQuit") {
     msg_rpc_.set_allocated_msg_quit(
       reinterpret_cast<cvmfs::MsgQuit *>(msg_typed_));
+  } else if (msg_typed_->GetTypeName() == "cvmfs.MsgIoctl") {
+    msg_rpc_.set_allocated_msg_ioctl(
+      reinterpret_cast<cvmfs::MsgIoctl *>(msg_typed_));
   } else if (msg_typed_->GetTypeName() == "cvmfs.MsgRefcountReq") {
     msg_rpc_.set_allocated_msg_refcount_req(
       reinterpret_cast<cvmfs::MsgRefcountReq *>(msg_typed_));
@@ -212,6 +216,8 @@ void CacheTransport::Frame::UnwrapMsg() {
     msg_typed_ = msg_rpc_.mutable_msg_handshake_ack();
   } else if (msg_rpc_.has_msg_quit()) {
     msg_typed_ = msg_rpc_.mutable_msg_quit();
+  } else if (msg_rpc_.has_msg_ioctl()) {
+    msg_typed_ = msg_rpc_.mutable_msg_ioctl();
   } else if (msg_rpc_.has_msg_refcount_req()) {
     msg_typed_ = msg_rpc_.mutable_msg_refcount_req();
   } else if (msg_rpc_.has_msg_refcount_reply()) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2204,7 +2204,7 @@ static bool SaveState(const int fd_progress, loader::StateList *saved_states) {
   ChunkTables *saved_chunk_tables = new ChunkTables(
     *cvmfs::mount_point_->chunk_tables());
   loader::SavedState *state_chunk_tables = new loader::SavedState();
-  state_chunk_tables->state_id = loader::kStateOpenFilesV4;
+  state_chunk_tables->state_id = loader::kStateOpenChunksV4;
   state_chunk_tables->state = saved_chunk_tables;
   saved_states->push_back(state_chunk_tables);
 
@@ -2294,7 +2294,7 @@ static bool RestoreState(const int fd_progress,
 
     ChunkTables *chunk_tables = cvmfs::mount_point_->chunk_tables();
 
-    if (saved_states[i]->state_id == loader::kStateOpenFiles) {
+    if (saved_states[i]->state_id == loader::kStateOpenChunks) {
       SendMsg2Socket(fd_progress, "Migrating chunk tables (v1 to v4)... ");
       compat::chunk_tables::ChunkTables *saved_chunk_tables =
         (compat::chunk_tables::ChunkTables *)saved_states[i]->state;
@@ -2303,7 +2303,7 @@ static bool RestoreState(const int fd_progress,
         StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
     }
 
-    if (saved_states[i]->state_id == loader::kStateOpenFilesV2) {
+    if (saved_states[i]->state_id == loader::kStateOpenChunksV2) {
       SendMsg2Socket(fd_progress, "Migrating chunk tables (v2 to v4)... ");
       compat::chunk_tables_v2::ChunkTables *saved_chunk_tables =
         (compat::chunk_tables_v2::ChunkTables *)saved_states[i]->state;
@@ -2312,7 +2312,7 @@ static bool RestoreState(const int fd_progress,
         StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
     }
 
-    if (saved_states[i]->state_id == loader::kStateOpenFilesV3) {
+    if (saved_states[i]->state_id == loader::kStateOpenChunksV3) {
       SendMsg2Socket(fd_progress, "Migrating chunk tables (v3 to v4)... ");
       compat::chunk_tables_v3::ChunkTables *saved_chunk_tables =
         (compat::chunk_tables_v3::ChunkTables *)saved_states[i]->state;
@@ -2321,7 +2321,7 @@ static bool RestoreState(const int fd_progress,
         StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
     }
 
-    if (saved_states[i]->state_id == loader::kStateOpenFilesV4) {
+    if (saved_states[i]->state_id == loader::kStateOpenChunksV4) {
       SendMsg2Socket(fd_progress, "Restoring chunk tables... ");
       delete chunk_tables;
       ChunkTables *saved_chunk_tables = reinterpret_cast<ChunkTables *>(
@@ -2396,22 +2396,22 @@ static void FreeSavedState(const int fd_progress,
         SendMsg2Socket(fd_progress, "Releasing saved glue buffer\n");
         delete static_cast<glue::InodeTracker *>(saved_states[i]->state);
         break;
-      case loader::kStateOpenFiles:
+      case loader::kStateOpenChunks:
         SendMsg2Socket(fd_progress, "Releasing chunk tables (version 1)\n");
         delete static_cast<compat::chunk_tables::ChunkTables *>(
           saved_states[i]->state);
         break;
-      case loader::kStateOpenFilesV2:
+      case loader::kStateOpenChunksV2:
         SendMsg2Socket(fd_progress, "Releasing chunk tables (version 2)\n");
         delete static_cast<compat::chunk_tables_v2::ChunkTables *>(
           saved_states[i]->state);
         break;
-      case loader::kStateOpenFilesV3:
+      case loader::kStateOpenChunksV3:
         SendMsg2Socket(fd_progress, "Releasing chunk tables (version 3)\n");
         delete static_cast<compat::chunk_tables_v3::ChunkTables *>(
           saved_states[i]->state);
         break;
-      case loader::kStateOpenFilesV4:
+      case loader::kStateOpenChunksV4:
         SendMsg2Socket(fd_progress, "Releasing chunk tables\n");
         delete static_cast<ChunkTables *>(saved_states[i]->state);
         break;

--- a/cvmfs/fd_table.h
+++ b/cvmfs/fd_table.h
@@ -43,6 +43,35 @@ class FdTable : SingleCopy {
   }
 
   /**
+   * Used to restore the state.
+   */
+  void AssignFrom(const FdTable<HandleT> &other) {
+    invalid_handle_ = other.invalid_handle_;
+    fd_pivot_ = other.fd_pivot_;
+    fd_index_.resize(other.fd_index_.size());
+    open_fds_.resize(other.open_fds_.size(), FdWrapper(invalid_handle_, 0));
+    for (unsigned i = 0; i < fd_index_.size(); ++i) {
+      fd_index_[i] = other.fd_index_[i];
+      open_fds_[i] = other.open_fds_[i];
+    }
+  }
+
+  /**
+   * Used to save the state.
+   */
+  FdTable<HandleT> *Clone() {
+    FdTable<HandleT> *result =
+      new FdTable<HandleT>(open_fds_.size(), invalid_handle_);
+    result->fd_pivot_ = fd_pivot_;
+    for (unsigned i = 0; i < fd_index_.size(); ++i) {
+      result->fd_index_[i] = fd_index_[i];
+      result->open_fds_[i] = open_fds_[i];
+    }
+    return result;
+  }
+
+
+  /**
    * Registeres fd with a currently unused number.  If the table is full,
    * returns -ENFILE;
    */

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -99,6 +99,7 @@ enum StateId {
   kStateOpenChunksV2,       // >= 2.1.20
   kStateOpenChunksV3,       // >= 2.2.0
   kStateOpenChunksV4,       // >= 2.2.3
+  kStateOpenFiles           // >= 2.4
 
   // Note: kStateOpenFilesXXX was renamed to kStateOpenChunksXXX as of 2.4
 };

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -89,16 +89,18 @@ inline const char *Code2Ascii(const Failures error) {
 enum StateId {
   kStateUnknown = 0,
   kStateOpenDirs,           // >= 2.1.4
-  kStateOpenFiles,          // >= 2.1.4, used as of 2.1.15
+  kStateOpenChunks,         // >= 2.1.4, used as of 2.1.15
   kStateGlueBuffer,         // >= 2.1.9
   kStateInodeGeneration,    // >= 2.1.9
   kStateOpenFilesCounter,   // >= 2.1.9
   kStateGlueBufferV2,       // >= 2.1.10
   kStateGlueBufferV3,       // >= 2.1.15
   kStateGlueBufferV4,       // >= 2.1.20
-  kStateOpenFilesV2,        // >= 2.1.20
-  kStateOpenFilesV3,        // >= 2.2.0
-  kStateOpenFilesV4,        // >= 2.2.3
+  kStateOpenChunksV2,       // >= 2.1.20
+  kStateOpenChunksV3,       // >= 2.2.0
+  kStateOpenChunksV4,       // >= 2.2.3
+
+  // Note: kStateOpenFilesXXX was renamed to kStateOpenChunksXXX as of 2.4
 };
 
 

--- a/test/src/070-tieredcache/main
+++ b/test/src/070-tieredcache/main
@@ -33,6 +33,7 @@ cvmfs_run_test() {
 
   echo "*** remount without network and trigger copyup"
   cvmfs_mount atlas.cern.ch \
+    "CVMFS_KCACHE_TIMEOUT=5" \
     "CVMFS_CACHE_PRIMARY=custom" \
     "CVMFS_CACHE_custom_TYPE=tiered" \
     "CVMFS_CACHE_custom_UPPER=default" \
@@ -46,6 +47,10 @@ cvmfs_run_test() {
   sudo cvmfs_talk -i atlas.cern.ch cache list | grep cvmfsdirtab || return 43
   local checksum_2="$(md5sum $test_file)"
   [ "$checksum_1" = "$checksum_2" ] || return 44
+
+  echo "*** reloading fuse module"
+  sudo cvmfs_config reload atlas.cern.ch || return 45
+  cat $test_file || return 46
 
   echo "*** Alternative configuration: RAMCache on top of regular one"
   cvmfs_umount atlas.cern.ch || return 50

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -888,6 +888,7 @@ TEST_F(T_CacheManager, WriteCompare) {
 TEST_F(T_CacheManager, SaveState) {
   TestCacheManager test_cache;
   int fd_progress = open("/dev/null", O_WRONLY);
+  ASSERT_GE(fd_progress, 0);
   ASSERT_DEATH(test_cache.SaveState(fd_progress), ".*");
   test_cache.state = &test_cache;
   void *data = test_cache.SaveState(fd_progress);
@@ -900,5 +901,11 @@ TEST_F(T_CacheManager, SaveState) {
   test_cache.type = kUnknownCacheManager;
   // should not crash
   test_cache.FreeState(fd_progress, data);
+
+  // Again, should not crash
+  data = cache_mgr_->SaveState(fd_progress);
+  cache_mgr_->RestoreState(fd_progress, data);
+  cache_mgr_->FreeState(fd_progress, data);
+
   close(fd_progress);
 }

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -36,8 +36,8 @@ class MockCachePlugin : public CachePlugin {
   static const unsigned kMockListingNitems;
 
   MockCachePlugin(const string &socket_path, bool read_only)
-    : CachePlugin(read_only ? (cvmfs::CAP_ALL & ~cvmfs::CAP_WRITE)
-                            : cvmfs::CAP_ALL)
+    : CachePlugin(read_only ? (cvmfs::CAP_ALL_V1 & ~cvmfs::CAP_WRITE)
+                            : cvmfs::CAP_ALL_V1)
   {
     bool retval = Listen("unix=" + socket_path);
     assert(retval);

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <alloca.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -582,4 +583,32 @@ TEST_F(T_ExternalCacheManager, MultiThreaded) {
   }
 
   free(large_buffer);
+}
+
+
+TEST_F(T_ExternalCacheManager, SaveState) {
+  // Should not crash
+  void *data = cache_mgr_->SaveState(-1);
+  cache_mgr_->RestoreState(-1, data);
+  cache_mgr_->FreeState(-1, data);
+
+  // Now with a new cache manager
+  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  EXPECT_GE(fd, 0);
+  data = cache_mgr_->SaveState(-1);
+  delete cache_mgr_;
+  fd_client = ConnectSocket(socket_path_);
+  ASSERT_GE(fd_client, 0);
+  cache_mgr_ = ExternalCacheManager::Create(fd_client, nfiles, "test");
+  ASSERT_TRUE(cache_mgr_ != NULL);
+  quota_mgr_ = ExternalQuotaManager::Create(cache_mgr_);
+  ASSERT_TRUE(cache_mgr_ != NULL);
+  cache_mgr_->AcquireQuotaManager(quota_mgr_);
+  cache_mgr_->RestoreState(-1, data);
+  cache_mgr_->FreeState(-1, data);
+  char buffer[64];
+  int64_t len = cache_mgr_->Pread(fd, buffer, 64, 0);
+  EXPECT_EQ(static_cast<int>(mock_plugin_->known_object_content.length()), len);
+  EXPECT_EQ(mock_plugin_->known_object_content, string(buffer, len));
+  EXPECT_EQ(0, cache_mgr_->Close(fd));
 }


### PR DESCRIPTION
The state of external and tiered cache managers is rescued during fuse module reload.  Also, a supervised plugin does not shutdown itself during the short period where there might be no active connections.