### PR TITLE
Gateway API cleanup

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -177,6 +177,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
   file_processing/file_processor.cc
   file_processing/io_dispatcher.cc
   file_processing/processor.cc
+  gateway_util.cc
   globals.cc
   hash.cc
   history_sql.cc

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -263,6 +263,7 @@ set (CVMFS_PRELOADER_SOURCES
   file_processing/file_processor.cc
   file_processing/io_dispatcher.cc
   file_processing/processor.cc
+  gateway_util.cc
   globals.cc
   hash.cc
   history_sql.cc

--- a/cvmfs/gateway_util.cc
+++ b/cvmfs/gateway_util.cc
@@ -31,7 +31,7 @@ bool ReadKeys(const std::string& key_file_name, std::string* key_id,
   fclose(key_file_fd);
 
   std::vector<std::string> tokens = SplitString(line, ' ');
-  if (tokens.size() != 3) {
+  if (tokens.size() < 2) {
     return false;
   }
 

--- a/cvmfs/gateway_util.cc
+++ b/cvmfs/gateway_util.cc
@@ -4,10 +4,14 @@
 
 #include "gateway_util.h"
 
+#include <vector>
+
 #include "logging.h"
 #include "util/string.h"
 
 namespace gateway {
+
+int APIVersion() { return 1; }
 
 bool ReadKeys(const std::string& key_file_name, std::string* key_id,
               std::string* secret) {
@@ -40,4 +44,5 @@ bool ReadKeys(const std::string& key_file_name, std::string* key_id,
 
   return true;
 }
-}
+
+}  // namespace gateway

--- a/cvmfs/gateway_util.cc
+++ b/cvmfs/gateway_util.cc
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "gateway_util.h"
+
+#include "logging.h"
+#include "util/string.h"
+
+namespace gateway {
+
+bool ReadKeys(const std::string& key_file_name, std::string* key_id,
+              std::string* secret) {
+  if (!(key_id && secret)) {
+    return false;
+  }
+
+  FILE* key_file_fd = std::fopen(key_file_name.c_str(), "r");
+  if (!key_file_fd) {
+    return false;
+  }
+
+  std::string line;
+  if (!GetLineFile(key_file_fd, &line)) {
+    return false;
+  }
+  fclose(key_file_fd);
+
+  std::vector<std::string> tokens = SplitString(line, ' ');
+  if (tokens.size() != 3) {
+    return false;
+  }
+
+  if (tokens[0] == "test") {
+    *key_id = tokens[1];
+    *secret = tokens[2];
+  } else {
+    return false;
+  }
+
+  return true;
+}
+}

--- a/cvmfs/gateway_util.h
+++ b/cvmfs/gateway_util.h
@@ -9,8 +9,11 @@
 
 namespace gateway {
 
+int APIVersion();
+
 bool ReadKeys(const std::string& key_file_name, std::string* key_id,
               std::string* secret);
-}
+
+}  // namespace gateway
 
 #endif  // CVMFS_GATEWAY_UTIL_H_

--- a/cvmfs/gateway_util.h
+++ b/cvmfs/gateway_util.h
@@ -1,0 +1,16 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_GATEWAY_UTIL_H_
+#define CVMFS_GATEWAY_UTIL_H_
+
+#include <string>
+
+namespace gateway {
+
+bool ReadKeys(const std::string& key_file_name, std::string* key_id,
+              std::string* secret);
+}
+
+#endif  // CVMFS_GATEWAY_UTIL_H_

--- a/cvmfs/server/cvmfs_server_abort.sh
+++ b/cvmfs/server/cvmfs_server_abort.sh
@@ -57,7 +57,7 @@ cvmfs_server_abort() {
     # get repository information
     load_repo_config $name
     user=$CVMFS_USER
-    key_file=$CVMFS_GATEWAY_KEY
+    key_file=$CVMFS_GATEWAY_KEYS
     spool_dir=$CVMFS_SPOOL_DIR
     local upstream_storage=$CVMFS_UPSTREAM_STORAGE
     local upstream_type=$(get_upstream_type $upstream_storage)

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -104,7 +104,7 @@ cvmfs_server_publish() {
     # get repository information
     load_repo_config $name
     user=$CVMFS_USER
-    key_file=$CVMFS_GATEWAY_KEY
+    key_file=$CVMFS_GATEWAY_KEYS
     spool_dir=$CVMFS_SPOOL_DIR
     scratch_dir="${spool_dir}/scratch/current"
     stratum0=$CVMFS_STRATUM0

--- a/cvmfs/server/cvmfs_server_transaction.sh
+++ b/cvmfs/server/cvmfs_server_transaction.sh
@@ -69,7 +69,7 @@ cvmfs_server_transaction() {
     local upstream_storage=$CVMFS_UPSTREAM_STORAGE
     local upstream_type=$(get_upstream_type $upstream_storage)
     user=$CVMFS_USER
-    key_file=$CVMFS_GATEWAY_KEY
+    key_file=$CVMFS_GATEWAY_KEYS
 
     # more sanity checks
     is_owner_or_root $name || { echo "Permission denied: Repository $name is owned by $user"; retcode=1; continue; }

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -8,6 +8,7 @@
 
 #include "curl/curl.h"
 #include "cvmfs_config.h"
+#include "gateway_util.h"
 #include "util/string.h"
 
 namespace {
@@ -236,9 +237,10 @@ bool SessionContext::DoUpload(const SessionContext::UploadJob* job) {
 
   shash::Any payload_digest(shash::kSha1);
   serializer.GetDigest(&payload_digest);
-  const std::string json_body = "{\"session_token\" : \"" + session_token_ +
-                                "\", \"payload_digest\" : \"" +
-                                Base64(payload_digest.ToString(false)) + "\"}";
+  const std::string json_body =
+      "{\"session_token\" : \"" + session_token_ +
+      "\", \"payload_digest\" : \"" + Base64(payload_digest.ToString(false)) +
+      "\", \"api_version\" : \"" + StringifyInt(gateway::APIVersion()) + "\"}";
 
   // Compute HMAC
   shash::Any hmac(shash::kSha1);

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -7,10 +7,10 @@
 #include <algorithm>
 #include <vector>
 
+#include "gateway_util.h"
+#include "logging.h"
 #include "swissknife_lease_curl.h"
 #include "swissknife_lease_json.h"
-
-#include "logging.h"
 #include "util/string.h"
 
 namespace {
@@ -19,24 +19,6 @@ bool CheckParams(const swissknife::CommandLease::Parameters& p) {
   if (p.action != "acquire" && p.action != "drop") {
     return false;
   }
-
-  return true;
-}
-
-bool ReadKeys(const std::string& key_file_name, std::string* key_id,
-              std::string* secret) {
-  if (!(key_id && secret)) {
-    return false;
-  }
-
-  FILE* key_file_fd = std::fopen(key_file_name.c_str(), "r");
-  if (!key_file_fd) {
-    return false;
-  }
-
-  GetLineFile(key_file_fd, key_id);
-  GetLineFile(key_file_fd, secret);
-  fclose(key_file_fd);
 
   return true;
 }
@@ -94,7 +76,7 @@ int CommandLease::Main(const ArgumentList& args) {
 
   std::string key_id;
   std::string secret;
-  if (!ReadKeys(params.key_file, &key_id, &secret)) {
+  if (!gateway::ReadKeys(params.key_file, &key_id, &secret)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Error reading key file %s.",
              params.key_file.c_str());
     return 1;

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -6,6 +6,7 @@
 
 #include "cvmfs_config.h"
 
+#include "gateway_util.h"
 #include "hash.h"
 #include "logging.h"
 #include "util/string.h"
@@ -49,7 +50,9 @@ bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
     return false;
   }
 
-  const std::string payload = "{\"path\" : \"" + repo_path + "\"}";
+  const std::string payload = "{\"path\" : \"" + repo_path +
+                              "\", \"api_version\" : \"" +
+                              StringifyInt(gateway::APIVersion()) + "\"}";
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(secret, payload, &hmac);

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "file_processing/char_buffer.h"
+#include "gateway_util.h"
 #include "util/string.h"
 
 namespace upload {
@@ -228,20 +229,7 @@ bool GatewayUploader::ReadSessionTokenFile(const std::string& token_file_name,
 
 bool GatewayUploader::ReadKey(const std::string& key_file, std::string* key_id,
                               std::string* secret) {
-  FILE* key_file_fd = std::fopen(key_file.c_str(), "r");
-  if (!key_file_fd) {
-    return false;
-  }
-
-  if (!(key_id && secret)) {
-    return false;
-  }
-
-  GetLineFile(key_file_fd, key_id);
-  GetLineFile(key_file_fd, secret);
-  fclose(key_file_fd);
-
-  return true;
+  return gateway::ReadKeys(key_file, key_id, secret);
 }
 
 void GatewayUploader::BumpErrors() const { atomic_inc32(&num_errors_); }

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -146,6 +146,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/file_processing/file_processor.cc
   ${CVMFS_SOURCE_DIR}/file_processing/io_dispatcher.cc
   ${CVMFS_SOURCE_DIR}/file_processing/processor.cc
+  ${CVMFS_SOURCE_DIR}/gateway_util.cc
   ${CVMFS_SOURCE_DIR}/globals.cc
   ${CVMFS_SOURCE_DIR}/glue_buffer.cc
   ${CVMFS_SOURCE_DIR}/hash.cc


### PR DESCRIPTION
This PR brings some improvements to the gateway API:

1. Gateway key handling is now done in a forward compatible manner, which will allow supporting multiple types of keys:

The file with the configuration of the gateway keys of a repo is listed in the `CVMFS_GATEWAY_KEYS` variable, in the repo's `server.conf`. The file mentioned here can have multiple key definitions, one per line, as follows:

`<KEY_TYPE> <KEY_DEFINITION>`

where `<KEY_TYPE>` and `<KEY_DEFINITION>` are separated by a space.

Currently the only key type recognized is:

`test <KEY_ID> <SECRET>`

2. Adding version information to all the gateway API requests.

The API request for a new lease now must include the `api_version` field in the JSON body. In its reply, the gateway services will include the `max_api_version` field, equal to the minimum of the client and the gateway API versions.