### PR TITLE
Refurbish client remount code, use active cache eviction with modern fuse

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,10 @@
       "string": "cpp",
       "vector": "cpp",
       "slist": "cpp",
-      "regex": "cpp"
+      "regex": "cpp",
+      "condition_variable": "cpp",
+      "future": "cpp",
+      "cassert": "cpp"
     }
   }
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,8 @@
       "regex": "cpp",
       "condition_variable": "cpp",
       "future": "cpp",
-      "cassert": "cpp"
+      "cassert": "cpp",
+      "functional": "cpp"
     }
   }
 

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -38,6 +38,7 @@ set (CVMFS_CLIENT_SOURCES
   directory_entry.cc
   dns.cc
   download.cc
+  fetch.cc
   file_chunk.cc
   globals.cc
   glue_buffer.cc
@@ -91,7 +92,7 @@ set (CVMFS2_DEBUG_SOURCES
   auto_umount.cc
   compat.cc
   cvmfs.cc
-  fetch.cc
+  fuse_evict.cc
   nfs_maps.cc
   nfs_shared_maps.cc
   quota_listener.cc
@@ -105,7 +106,6 @@ set (CVMFS2_SOURCES
 set (LIBCVMFS_SOURCES
   ${CVMFS_CLIENT_SOURCES}
 
-  fetch.cc
   libcvmfs.cc
   libcvmfs_int.cc
   libcvmfs_legacy.cc

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -93,6 +93,7 @@ set (CVMFS2_DEBUG_SOURCES
   compat.cc
   cvmfs.cc
   fuse_evict.cc
+  fuse_remount.cc
   nfs_maps.cc
   nfs_shared_maps.cc
   quota_listener.cc

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1982,8 +1982,11 @@ static int Init(const loader::LoaderExports *loader_exports) {
   LogCvmfs(kLogCvmfs, kLogDebug, "fuse inode size is %d bits",
            sizeof(fuse_ino_t) * 8);
 
+  struct fuse_chan **channel = NULL;
+  if (loader_exports->version >= 4)
+    channel = loader_exports->fuse_channel;
   cvmfs::fuse_invalidator_ =
-    new FuseInvalidator(cvmfs::mount_point_->inode_tracker());
+    new FuseInvalidator(cvmfs::mount_point_->inode_tracker(), channel);
 
   // Monitor, check for maximum number of open files
   if (cvmfs::UseWatchdog()) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -80,6 +80,7 @@
 #include "fetch.h"
 #include "file_chunk.h"
 #include "fuse_evict.h"
+#include "fuse_inode_gen.h"
 #include "globals.h"
 #include "glue_buffer.h"
 #include "hash.h"
@@ -120,24 +121,7 @@ TalkManager *talk_mgr_ = NULL;
 Watchdog *watchdog_ = NULL;
 FuseInvalidator *fuse_invalidator_ = NULL;
 
-/**
- * Stores the initial catalog revision (in order to detect overflows) and
- * the incarnation (number of reloads) of the Fuse module
- */
-struct InodeGenerationInfo {
-  InodeGenerationInfo() {
-    version = 2;
-    initial_revision = 0;
-    incarnation = 0;
-    overflow_counter = 0;
-    inode_generation = 0;
-  }
-  unsigned version;
-  uint64_t initial_revision;
-  uint32_t incarnation;
-  uint32_t overflow_counter;  // not used any more
-  uint64_t inode_generation;
-};
+
 InodeGenerationInfo inode_generation_info_;
 
 /**

--- a/cvmfs/cvmfs.h
+++ b/cvmfs/cvmfs.h
@@ -19,7 +19,6 @@ extern pid_t pid_;
 
 bool Evict(const std::string &path);
 bool Pin(const std::string &path);
-catalog::LoadError RemountStart();
 void GetReloadStatus(bool *drainout_mode, bool *maintenance_mode);
 std::string PrintInodeGeneration();
 void UnregisterQuotaListener();

--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -7,6 +7,7 @@
 
 #ifdef CVMFS_LIBCVMFS
 // Unit tests
+#define FUSE_VERSION 29
 #define FUSE_ROOT_ID 1
 extern "C" {
 struct fuse_chan {};

--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_DUPLEX_FUSE_H_
+#define CVMFS_DUPLEX_FUSE_H_
+
+#ifdef CVMFS_LIBCVMFS
+// Unit tests
+#define FUSE_ROOT_ID 1
+extern "C" {
+struct fuse_chan {};
+// Defined in t_fuse_evict.cc
+extern unsigned fuse_lowlevel_notify_inval_entry_cnt;
+static int __attribute__((used)) fuse_lowlevel_notify_inval_entry(
+  void *, unsigned long, const char *, size_t)
+{
+  fuse_lowlevel_notify_inval_entry_cnt++;
+  return -1;
+}
+}
+#else
+#include <fuse/fuse_lowlevel.h>
+#endif
+
+#endif  // CVMFS_DUPLEX_FUSE_H_

--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -14,7 +14,7 @@ struct fuse_chan {};
 // Defined in t_fuse_evict.cc
 extern unsigned fuse_lowlevel_notify_inval_entry_cnt;
 static int __attribute__((used)) fuse_lowlevel_notify_inval_entry(
-  void *, unsigned long, const char *, size_t)
+  void *, unsigned long, const char *, size_t)  // NOLINT (ulong from fuse)
 {
   fuse_lowlevel_notify_inval_entry_cnt++;
   return -1;

--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -23,6 +23,16 @@ static int __attribute__((used)) fuse_lowlevel_notify_inval_entry(
 #else
 #define FUSE_USE_VERSION 26
 #include <fuse/fuse_lowlevel.h>
+#if(FUSE_VERSION < 28)
+#include <cstdlib>
+extern "C" {
+static int __attribute__((used)) fuse_lowlevel_notify_inval_entry(
+  void *, unsigned long, const char *, size_t)  // NOLINT
+{
+  abort();
+}
+}
+#endif
 #endif
 
 #endif  // CVMFS_DUPLEX_FUSE_H_

--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -21,6 +21,7 @@ static int __attribute__((used)) fuse_lowlevel_notify_inval_entry(
 }
 }
 #else
+#define FUSE_USE_VERSION 26
 #include <fuse/fuse_lowlevel.h>
 #endif
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -36,7 +36,7 @@ FuseInvalidator::Handle::~Handle() {
 
 
 void FuseInvalidator::Handle::WaitFor() {
-  while (!IsDone()) SafeSleepMs(100);
+  while (!IsDone()) SafeSleepMs(FuseInvalidator::kCheckTimeoutFreqMs);
 }
 
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -1,0 +1,60 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+#include "fuse_evict.h"
+
+#include <cassert>
+
+#include "logging.h"
+#include "glue_buffer.h"
+#include "util/posix.h"
+
+using namespace std;  // NOLINT
+
+FuseInvalidator::FuseInvalidator(glue::InodeTracker *inode_tracker)
+ : inode_tracker_(inode_tracker)
+ , spawned_(false)
+{
+  MakePipe(pipe_ctrl_);
+}
+
+
+FuseInvalidator::~FuseInvalidator() {
+  if (spawned_) {
+    char c = 'Q';
+    WritePipe(pipe_ctrl_[1], &c, 1);
+  }
+  ClosePipe(pipe_ctrl_);
+}
+
+
+void FuseInvalidator::Invalidate() {
+  char c = 'I';
+  WritePipe(pipe_ctrl_[1], &c, 1);
+}
+
+
+void *FuseInvalidator::MainInvalidator(void *data) {
+  FuseInvalidator *invalidator = reinterpret_cast<FuseInvalidator *>(data);
+  LogCvmfs(kLogCvmfs, kLogDebug, "starting dentry invalidator thread");
+
+  char c;
+  while (true) {
+    ReadPipe(invalidator->pipe_ctrl_[0], &c, 1);
+    if (c == 'Q')
+      break;
+  }
+
+  LogCvmfs(kLogCvmfs, kLogDebug, "stopping dentry invalidator thread");
+  return NULL;
+}
+
+
+void FuseInvalidator::Spawn() {
+  int retval;
+  retval = pthread_create(&thread_invalidator_, NULL, MainInvalidator, this);
+  assert(retval == 0);
+  spawned_ = true;
+}

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -2,26 +2,61 @@
  * This file is part of the CernVM File System.
  */
 
+#define __STDC_FORMAT_MACROS
+
 #include "cvmfs_config.h"
 #include "fuse_evict.h"
 
+#include <inttypes.h>
+#include <stdint.h>
+
 #include <cassert>
+#include <cstdlib>
 
 #include "logging.h"
 #include "glue_buffer.h"
+#include "platform.h"
+#include "shortstring.h"
+#include "smalloc.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
 
-FuseInvalidator::FuseInvalidator(glue::InodeTracker *inode_tracker)
+FuseInvalidator::Handle::Handle(unsigned timeout_s)
+  : timeout_s_(timeout_s)
+{
+  status_ = reinterpret_cast<atomic_int32 *>(smalloc(sizeof(atomic_int32)));
+  atomic_init32(status_);
+}
+
+
+FuseInvalidator::Handle::~Handle() {
+  free(status_);
+}
+
+
+void FuseInvalidator::Handle::WaitFor() {
+  while (!IsDone()) SafeSleepMs(100);
+}
+
+
+//------------------------------------------------------------------------------
+
+
+FuseInvalidator::FuseInvalidator(
+  glue::InodeTracker *inode_tracker,
+  struct fuse_chan **fuse_channel)
  : inode_tracker_(inode_tracker)
+ , fuse_channel_(fuse_channel)
  , spawned_(false)
 {
   MakePipe(pipe_ctrl_);
+  atomic_init32(&terminated_);
 }
 
 
 FuseInvalidator::~FuseInvalidator() {
+  atomic_cas32(&terminated_, 0, 1);
   if (spawned_) {
     char c = 'Q';
     WritePipe(pipe_ctrl_[1], &c, 1);
@@ -30,9 +65,11 @@ FuseInvalidator::~FuseInvalidator() {
 }
 
 
-void FuseInvalidator::Invalidate() {
+void FuseInvalidator::InvalidateDentries(Handle *handle) {
+  assert(handle != NULL);
   char c = 'I';
   WritePipe(pipe_ctrl_[1], &c, 1);
+  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
 }
 
 
@@ -41,10 +78,67 @@ void *FuseInvalidator::MainInvalidator(void *data) {
   LogCvmfs(kLogCvmfs, kLogDebug, "starting dentry invalidator thread");
 
   char c;
+  Handle *handle;
   while (true) {
     ReadPipe(invalidator->pipe_ctrl_[0], &c, 1);
     if (c == 'Q')
       break;
+
+    assert(c == 'I');
+    ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
+    LogCvmfs(kLogCvmfs, kLogDebug, "invalidating kernel caches, timeout %u",
+             handle->timeout_s_);
+
+    uint64_t deadline =
+      platform_monotonic_time() + handle->timeout_s_ + kTimeoutSafetyMarginSec;
+
+    // Fallback: drainout by timeout
+    if (invalidator->fuse_channel_ == NULL) {
+      while (platform_monotonic_time() <= deadline) {
+        SafeSleepMs(kCheckTimeoutFreqMs);
+        if (atomic_read32(&invalidator->terminated_) == 1) {
+          LogCvmfs(kLogCvmfs, kLogDebug,
+                   "cancel cache eviction due to termination");
+          break;
+        }
+      }
+      handle->SetDone();
+      continue;
+    }
+
+    uint64_t inode;
+    NameString name;
+    glue::InodeTracker::Cursor cursor(
+      invalidator->inode_tracker_->BeginEnumerate());
+    unsigned i = 0;
+    while (invalidator->inode_tracker_->Next(&cursor, &inode, &name)) {
+      if (inode == 0)
+        inode = FUSE_ROOT_ID;
+      // Can return non-zero value if parent entry was already evicted
+      fuse_lowlevel_notify_inval_entry(
+        *invalidator->fuse_channel_,
+        inode,
+        name.GetChars(),
+        name.GetLength()
+      );
+      LogCvmfs(kLogCvmfs, kLogDebug, "evicting <%" PRIu64 ">/%s",
+               inode, name.c_str());
+
+      if ((++i % kCheckTimeoutFreqOps) == 0) {
+        if (platform_monotonic_time() >= deadline) {
+          LogCvmfs(kLogCvmfs, kLogDebug,
+                   "cancel cache eviction after %u entries due to timeout", i);
+          break;
+        }
+        if (atomic_read32(&invalidator->terminated_) == 1) {
+          LogCvmfs(kLogCvmfs, kLogDebug,
+                   "cancel cache eviction due to termination");
+          break;
+        }
+      }
+    }
+    invalidator->inode_tracker_->EndEnumerate(&cursor);
+    handle->SetDone();
   }
 
   LogCvmfs(kLogCvmfs, kLogDebug, "stopping dentry invalidator thread");

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -13,8 +13,8 @@
 #include <cassert>
 #include <cstdlib>
 
-#include "logging.h"
 #include "glue_buffer.h"
+#include "logging.h"
 #include "platform.h"
 #include "shortstring.h"
 #include "smalloc.h"
@@ -66,9 +66,9 @@ bool FuseInvalidator::HasFuseNotifyInval() {
 FuseInvalidator::FuseInvalidator(
   glue::InodeTracker *inode_tracker,
   struct fuse_chan **fuse_channel)
- : inode_tracker_(inode_tracker)
- , fuse_channel_(fuse_channel)
- , spawned_(false)
+  : inode_tracker_(inode_tracker)
+  , fuse_channel_(fuse_channel)
+  , spawned_(false)
 {
   MakePipe(pipe_ctrl_);
   atomic_init32(&terminated_);
@@ -139,8 +139,7 @@ void *FuseInvalidator::MainInvalidator(void *data) {
         *invalidator->fuse_channel_,
         inode,
         name.GetChars(),
-        name.GetLength()
-      );
+        name.GetLength());
       LogCvmfs(kLogCvmfs, kLogDebug, "evicting <%" PRIu64 ">/%s",
                inode, name.c_str());
 

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -45,6 +45,7 @@ class FuseInvalidator : SingleCopy {
     explicit Handle(unsigned timeout_s);
     ~Handle();
     bool IsDone() const { return atomic_read32(status_) == 1; }
+    void Reset() { atomic_write32(status_, 0); }
     void WaitFor();
 
    private:

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -1,0 +1,37 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_FUSE_EVICT_H_
+#define CVMFS_FUSE_EVICT_H_
+
+#include <pthread.h>
+
+#include "util/single_copy.h"
+
+namespace glue {
+class InodeTracker;
+}
+
+/**
+ * This class can poke all known dentries out of the kernel caches.  This allows
+ * for faster remount/reload of the fuse module because caches don't need to
+ * drain out by timeout.
+ */
+class FuseInvalidator : SingleCopy {
+ public:
+  explicit FuseInvalidator(glue::InodeTracker *inode_tracker);
+  ~FuseInvalidator();
+  void Spawn();
+  void Invalidate();
+
+ private:
+  static void *MainInvalidator(void *data);
+
+  glue::InodeTracker *inode_tracker_;
+  bool spawned_;
+  int pipe_ctrl_[2];
+  pthread_t thread_invalidator_;
+};  // class FuseInvalidator
+
+#endif  // CVMFS_FUSE_EVICT_H_

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -5,10 +5,11 @@
 #ifndef CVMFS_FUSE_EVICT_H_
 #define CVMFS_FUSE_EVICT_H_
 
-#include <fuse/fuse_lowlevel.h>
 #include <pthread.h>
 
 #include "atomic.h"
+#include "duplex_fuse.h"
+#include "gtest/gtest_prod.h"
 #include "util/single_copy.h"
 
 namespace glue {
@@ -25,6 +26,10 @@ class InodeTracker;
  * avoid a deadlock in the fuse callbacks (see Fuse documenatation).
  */
 class FuseInvalidator : SingleCopy {
+  FRIEND_TEST(T_FuseInvalidator, StartStop);
+  FRIEND_TEST(T_FuseInvalidator, InvalidateTimeout);
+  FRIEND_TEST(T_FuseInvalidator, InvalidateOps);
+
  public:
   /**
    * Used to track the progress of an "invalidation" request.  The invalidator
@@ -59,16 +64,16 @@ class FuseInvalidator : SingleCopy {
   /**
    * Add one second to the caller-provided timeout to be on the safe side.
    */
-  static const unsigned kTimeoutSafetyMarginSec = 1;
+  static const unsigned kTimeoutSafetyMarginSec;  // = 1;
   /**
    * If caches are drained out by timeout, set a polling interval.
    */
-  static const unsigned kCheckTimeoutFreqMs = 100;
+  static const unsigned kCheckTimeoutFreqMs;  // = 100;
   /**
    * If caches are actively drained out, check every so many operations if the
    * caches are anyway drained out by timeout.
    */
-  static const unsigned kCheckTimeoutFreqOps = 256;
+  static const unsigned kCheckTimeoutFreqOps;  // = 256
 
   static void *MainInvalidator(void *data);
 

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -31,6 +31,8 @@ class FuseInvalidator : SingleCopy {
   FRIEND_TEST(T_FuseInvalidator, InvalidateOps);
 
  public:
+  static bool HasFuseNotifyInval();
+
   /**
    * Used to track the progress of an "invalidation" request.  The invalidator
    * will evict cache entries for a duration given by the timeout.  For very
@@ -77,7 +79,6 @@ class FuseInvalidator : SingleCopy {
   static const unsigned kCheckTimeoutFreqOps;  // = 256
 
   static void *MainInvalidator(void *data);
-  static bool HasFuseNotifyInval();
 
   glue::InodeTracker *inode_tracker_;
   struct fuse_chan **fuse_channel_;

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -5,8 +5,10 @@
 #ifndef CVMFS_FUSE_EVICT_H_
 #define CVMFS_FUSE_EVICT_H_
 
+#include <fuse/fuse_lowlevel.h>
 #include <pthread.h>
 
+#include "atomic.h"
 #include "util/single_copy.h"
 
 namespace glue {
@@ -16,22 +18,70 @@ class InodeTracker;
 /**
  * This class can poke all known dentries out of the kernel caches.  This allows
  * for faster remount/reload of the fuse module because caches don't need to
- * drain out by timeout.
+ * drain out by timeout.  If the fuse library doesn't provide
+ * fuse_lowlevel_notify_inval_entry, it falls back to waiting for drainout.
+ *
+ * Evicting entries from the cache must be done from a separate thread to
+ * avoid a deadlock in the fuse callbacks (see Fuse documenatation).
  */
 class FuseInvalidator : SingleCopy {
  public:
-  explicit FuseInvalidator(glue::InodeTracker *inode_tracker);
+  /**
+   * Used to track the progress of an "invalidation" request.  The invalidator
+   * will evict cache entries for a duration given by the timeout.  For very
+   * large caches, active eviction can take longer than the timeout.
+   *
+   * The caller needs to keep Handle active until IsDone() is true;
+   */
+  class Handle : SingleCopy {
+    friend class FuseInvalidator;
+
+   public:
+    explicit Handle(unsigned timeout_s);
+    ~Handle();
+    bool IsDone() const { return atomic_read32(status_) == 1; }
+    void WaitFor();
+
+   private:
+    void SetDone() { atomic_cas32(status_, 0, 1); }
+
+    unsigned timeout_s_;
+    atomic_int32 *status_;
+  };
+
+  FuseInvalidator(glue::InodeTracker *inode_tracker,
+                  struct fuse_chan **fuse_channel);
   ~FuseInvalidator();
   void Spawn();
-  void Invalidate();
+  void InvalidateDentries(Handle *handle);
 
  private:
+  /**
+   * Add one second to the caller-provided timeout to be on the safe side.
+   */
+  static const unsigned kTimeoutSafetyMarginSec = 1;
+  /**
+   * If caches are drained out by timeout, set a polling interval.
+   */
+  static const unsigned kCheckTimeoutFreqMs = 100;
+  /**
+   * If caches are actively drained out, check every so many operations if the
+   * caches are anyway drained out by timeout.
+   */
+  static const unsigned kCheckTimeoutFreqOps = 256;
+
   static void *MainInvalidator(void *data);
 
   glue::InodeTracker *inode_tracker_;
+  struct fuse_chan **fuse_channel_;
   bool spawned_;
   int pipe_ctrl_[2];
   pthread_t thread_invalidator_;
+  /**
+   * An invalidation run can take some time.  Allow for early cancelation if
+   * thread should be shut down.
+   */
+  atomic_int32 terminated_;
 };  // class FuseInvalidator
 
 #endif  // CVMFS_FUSE_EVICT_H_

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -76,6 +76,7 @@ class FuseInvalidator : SingleCopy {
   static const unsigned kCheckTimeoutFreqOps;  // = 256
 
   static void *MainInvalidator(void *data);
+  static bool HasFuseNotifyInval();
 
   glue::InodeTracker *inode_tracker_;
   struct fuse_chan **fuse_channel_;

--- a/cvmfs/fuse_inode_gen.h
+++ b/cvmfs/fuse_inode_gen.h
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_INODE_GEN_H_
+#define CVMFS_INODE_GEN_H_
+
+#include <stdint.h>
+
+namespace cvmfs {
+
+/**
+ * Stores the initial catalog revision (in order to detect overflows) and
+ * the incarnation (number of reloads) of the Fuse module
+ */
+struct InodeGenerationInfo {
+  InodeGenerationInfo() {
+    version = 2;
+    initial_revision = 0;
+    incarnation = 0;
+    overflow_counter = 0;
+    inode_generation = 0;
+  }
+  unsigned version;
+  uint64_t initial_revision;
+  uint32_t incarnation;
+  uint32_t overflow_counter;  // not used any more
+  uint64_t inode_generation;
+};
+
+}  // namespace cvmfs
+
+#endif  // CVMFS_INODE_GEN_H_

--- a/cvmfs/fuse_inode_gen.h
+++ b/cvmfs/fuse_inode_gen.h
@@ -2,8 +2,8 @@
  * This file is part of the CernVM File System.
  */
 
-#ifndef CVMFS_INODE_GEN_H_
-#define CVMFS_INODE_GEN_H_
+#ifndef CVMFS_FUSE_INODE_GEN_H_
+#define CVMFS_FUSE_INODE_GEN_H_
 
 #include <stdint.h>
 
@@ -30,4 +30,4 @@ struct InodeGenerationInfo {
 
 }  // namespace cvmfs
 
-#endif  // CVMFS_INODE_GEN_H_
+#endif  // CVMFS_FUSE_INODE_GEN_H_

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -92,8 +92,8 @@ FuseRemounter::Status FuseRemounter::CheckSynchronously() {
 
 
 void FuseRemounter::EnterMaintenanceMode() {
-  atomic_cas32(&maintenance_mode_, 0, 1);
   fence_maintenance_.Drain();
+  atomic_cas32(&maintenance_mode_, 0, 1);
   fence_maintenance_.Open();
 
   // All running Check() and TryFinish() methods returned.  Both methods now

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -262,7 +262,7 @@ void FuseRemounter::TryFinish() {
   mountpoint_->path_cache()->Resume();
   mountpoint_->md5path_cache()->Resume();
 
-  atomic_xadd32(&drainout_mode_, 2);  // 2 --> 0, end of drainout mode
+  atomic_xadd32(&drainout_mode_, -2);  // 2 --> 0, end of drainout mode
 
   if ((retval == catalog::kLoadFail) || (retval == catalog::kLoadNoSpace) ||
       mountpoint_->catalog_mgr()->offline_mode())

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -1,0 +1,8 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+#include "fuse_remount.h"
+
+using namespace std;  // NOLINT

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -1,0 +1,15 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_FUSE_REMOUNT_H_
+#define CVMFS_FUSE_REMOUNT_H_
+
+#include "util/single_copy.h"
+
+class FuseRemounter : SingleCopy {
+ public:
+ private:
+};  // class FuseRemounter
+
+#endif  // CVMFS_FUSE_REMOUNT_H_

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -16,7 +16,7 @@
 #include "util/single_copy.h"
 
 namespace cvmfs {
-class InodeGenerationInfo;
+struct InodeGenerationInfo;
 }
 class MountPoint;
 

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -75,7 +75,6 @@ class FuseRemounter : SingleCopy {
   }
   void LeaveCriticalSection() { atomic_dec32(&critical_section_); /* 1 -> 0 */ }
 
-  bool spawned_;
   MountPoint *mountpoint_;  ///< Not owned
   cvmfs::InodeGenerationInfo *inode_generation_info_;  ///< Not owned
   FuseInvalidator *invalidator_;

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -100,8 +100,9 @@ class FuseRemounter : SingleCopy {
    */
   int pipe_remount_trigger_[2];
   /**
-   * Stores when the alarm signal fires next time.  Can be
-   * MountPoint::kIndefiniteDeadline if a fixed root catalog is used
+   * Stores the deadline after which the remount trigger will look again for
+   * an updated version.  Can be MountPoint::kIndefiniteDeadline if a fixed root
+   * catalog is used.  Only for information purposes ('expires' xattr).
    * TODO(jblomer): access to this field should be locked
    */
   time_t catalogs_valid_until_;

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -51,9 +51,15 @@ class FuseRemounter : SingleCopy {
   Status Check();
   void TryFinish();
   void EnterMaintenanceMode();
+  bool IsCaching() {
+    return (atomic_read32(&maintenance_mode_) == 0) &&
+           (atomic_read32(&drainout_mode_) == 0);
+  }
+  bool IsInDrainoutMode() { return atomic_read32(&drainout_mode_) == 2; }
+  bool IsInMaintenanceMode() { return atomic_read32(&maintenance_mode_) == 1; }
 
   Fence *fence() { return fence_; }
-  time_t catalog_valid_until() { return catalogs_valid_until_; }
+  time_t catalogs_valid_until() { return catalogs_valid_until_; }
 
  private:
   static void *MainRemountTrigger(void *data);
@@ -61,12 +67,10 @@ class FuseRemounter : SingleCopy {
   bool HasRemountTrigger() { return pipe_remount_trigger_[0] >= 0; }
   void SetAlarm(int timeout);
 
-  bool EnterCriticalSection()  {
+  bool EnterCriticalSection() {
     return atomic_cas32(&critical_section_, 0, 1);
   }
   void LeaveCriticalSection() { atomic_dec32(&critical_section_); /* 1 -> 0 */ }
-  bool IsInDrainoutMode() { return atomic_read32(&drainout_mode_) == 2; }
-  bool IsInMaintenanceMode() { return atomic_read32(&maintenance_mode_) == 1; }
 
   bool spawned_;
   MountPoint *mountpoint_;  ///< Not owned

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -5,11 +5,117 @@
 #ifndef CVMFS_FUSE_REMOUNT_H_
 #define CVMFS_FUSE_REMOUNT_H_
 
+#include <pthread.h>
+
+#include <ctime>
+
+#include "atomic.h"
+#include "duplex_fuse.h"
+#include "fence.h"
+#include "fuse_evict.h"
 #include "util/single_copy.h"
 
+namespace cvmfs {
+class InodeGenerationInfo;
+}
+class MountPoint;
+
+/**
+ * Orchestrates an orderly remount of a new snapshot revision in the Fuse
+ * module.  Remounting always happens as a result of calling Check().  The
+ * Check() method is either called from a fuse callback function or from
+ * the remount trigger thread as a result of an alarm signal (to remount even
+ * when cvmfs is idle).
+ *
+ * Remounting is inherently asynchronous because the kernel caches need to be
+ * flushed.  We do this through the FuseInvalidator.  Once the FuseInvalidor
+ * is ready (either by waiting or by active eviction), we flush all user-level
+ * caches and reload a new root catalog.
+ */
 class FuseRemounter : SingleCopy {
  public:
+  explicit FuseRemounter(MountPoint *mountpoint,
+                         cvmfs::InodeGenerationInfo *inode_generation_info,
+                         struct fuse_chan **fuse_channel);
+  ~FuseRemounter();
+  void Spawn();
+
+  void Check();
+
+  bool IsInDrainoutMode() { return atomic_read32(&drainout_mode_) == 2; }
+  bool IsInMaintenanceMode() { return atomic_read32(&maintenance_mode_) == 1; }
+  bool IsCatalogsExpired() { return atomic_read32(&catalogs_expired_) == 1; }
+
+  Fence *fence() { return fence_; }
+  time_t catalog_valid_until() { return catalogs_valid_until_; }
+
  private:
+  static void *MainRemountTrigger(void *data);
+
+  void Finish();
+
+  bool HasRemountTrigger() { return pipe_remount_trigger_[0] >= 0; }
+  void SetAlarm(int timeout);
+  void SetCatalogsExpired() { atomic_cas32(&catalogs_expired_, 0, 1); }
+  bool EnterCriticalSection()  {
+    return atomic_cas32(&critical_section_, 0, 1);
+  }
+  void LeaveCriticalSection() { atomic_dec32(&critical_section_); /* 1 -> 0 */ }
+  void SetMaintenanceMode();
+
+  bool spawned_;
+  MountPoint *mountpoint_;  ///< Not owned
+  cvmfs::InodeGenerationInfo *inode_generation_info_;  ///< Not owned
+  FuseInvalidator *invalidator_;
+  /**
+   * Used to query when the kernel cache invalidation is done.
+   */
+  FuseInvalidator::Handle invalidator_handle_;
+  /**
+   * Ensures that within a fuse callback all operations take place on the same
+   * catalog revision.
+   */
+  Fence *fence_;
+  pthread_t thread_remount_trigger_;
+  /**
+   * The thread that triggers the reload of the root catalog is informed through
+   * this pipe by the alarm signal handler when the TTL expires.
+   */
+  int pipe_remount_trigger_[2];
+  /**
+   * Stores when the alarm signal fires next time.  Can be
+   * MountPoint::kIndefiniteDeadline if a fixed root catalog is used
+   * TODO(jblomer): access to this field should be locked
+   */
+  time_t catalogs_valid_until_;
+  /**
+   * In drainout mode, the fuse module sets the timeout of meta data replys to
+   * zero.  If supported by Fuse, the FuseInvalidator will evict all active
+   * entries from the kernel cache.  Drainout mode is left only once the new
+   * root catalog is active (after Finish()).
+   *
+   * Moving into drainout mode is a two-steps procedure.  Going from zero to one
+   * the handle of the FuseInvalidator is prepared, from one to two is the
+   * actual move into drainout mode.
+   */
+  atomic_int32 drainout_mode_;
+  /**
+   * in maintenance mode, cache timeout is 0 and catalogs are not reloaded.
+   * Maintenance mode is entered when the fuse module gets reloaded.
+   */
+  atomic_int32 maintenance_mode_;
+  /**
+   * This flag is set by the alarm timer (or by a forced check) to indicate that
+   * the root catalog TTL is expired, hence cvmfs should check upstream for an
+   * updated copy.
+   */
+  atomic_int32 catalogs_expired_;
+  /**
+   * Only one thread must perform the actual remount (stopping user-level
+   * caches, loading new catalog, etc.).  This is used to protect Finish() from
+   * concurrent execution.
+   */
+  atomic_int32 critical_section_;
 };  // class FuseRemounter
 
 #endif  // CVMFS_FUSE_REMOUNT_H_

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -49,6 +49,7 @@ class FuseRemounter : SingleCopy {
   void Spawn();
 
   Status Check();
+  Status CheckSynchronously();
   void TryFinish();
   void EnterMaintenanceMode();
   bool IsCaching() {

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -379,9 +379,6 @@ char *cvmfs_statistics_format(cvmfs_context *ctx) {
 
 
 int cvmfs_remount(LibContext *ctx) {
-  catalog::LoadError retval = ctx->RemountStart();
-  if (retval == catalog::kLoadNew || retval == catalog::kLoadUp2Date) {
-    return 0;
-  }
+  // not implemented
   return -1;
 }

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -542,8 +542,3 @@ int LibContext::Close(int fd) {
   }
   return 0;
 }
-
-
-catalog::LoadError cvmfs_context::RemountStart() {
-  return catalog::kLoadNew;
-}

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -104,8 +104,6 @@ class LibContext : SingleCopy {
   int64_t Pread(int fd, void *buf, uint64_t size, uint64_t off);
   int Close(int fd);
 
-  catalog::LoadError RemountStart();
-
   MountPoint *mount_point() { return mount_point_; }
   void set_options_mgr(OptionsManager *value) { options_mgr_ = value; }
 

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -818,6 +818,9 @@ int main(int argc, char *argv[]) {
   delete options_manager;
   options_manager = NULL;
 
+  struct fuse_chan *channel;
+  loader_exports_->fuse_channel = &channel;
+
   // Load and initialize cvmfs library
   LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
            "CernVM-FS: loading Fuse module... ");
@@ -855,7 +858,6 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  struct fuse_chan *channel;
   channel = fuse_mount(mount_point_->c_str(), mount_options);
   if (!channel) {
     LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -145,10 +145,11 @@ typedef std::vector<LoadEvent *> EventList;
  *
  * CernVM-FS 2.1.8 --> Version 2
  * CernVM-FS 2.2.0 --> Version 3
+ * CernVM-FS 2.4.0 --> Version 4
  */
 struct LoaderExports {
   LoaderExports() :
-    version(3),
+    version(4),
     size(sizeof(LoaderExports)), boot_time(0), foreground(false),
     disable_watchdog(false), simple_options_parsing(false) {}
 
@@ -174,6 +175,9 @@ struct LoaderExports {
 
   // added with CernVM-FS 2.2.0 (LoaderExports Version: 3)
   bool simple_options_parsing;
+
+  // added with CernVM-FS 2.4.0 (LoaderExports Version: 4)
+  struct fuse_chan **fuse_channel;
 };
 
 

--- a/cvmfs/talk.h
+++ b/cvmfs/talk.h
@@ -15,6 +15,7 @@
 namespace download {
 class DownloadManager;
 }
+class FuseRemounter;
 class MountPoint;
 class OptionsManager;
 
@@ -26,7 +27,8 @@ class OptionsManager;
 class TalkManager : SingleCopy {
  public:
   static TalkManager *Create(const std::string &socket_path,
-                             MountPoint *mount_point);
+                             MountPoint *mount_point,
+                             FuseRemounter *remounter);
   ~TalkManager();
 
   void Spawn();
@@ -37,7 +39,9 @@ class TalkManager : SingleCopy {
    */
   static const unsigned kMaxCommandSize = 512;
 
-  TalkManager(const std::string &socket_path, MountPoint *mount_point);
+  TalkManager(const std::string &socket_path,
+              MountPoint *mount_point,
+              FuseRemounter *remounter);
   static void *MainResponder(void *data);
   void Answer(int con_fd, const std::string &msg);
   void AnswerStringList(int con_fd, const std::vector<std::string> &list);
@@ -47,6 +51,7 @@ class TalkManager : SingleCopy {
   std::string socket_path_;
   int socket_fd_;
   MountPoint *mount_point_;
+  FuseRemounter *remounter_;
   pthread_t thread_talk_;
   bool spawned_;
 };

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -85,7 +85,7 @@ wait_for_revision() {
   local revision=0
   local interval=5
 
-  echo -n "waiting for revision $expected_revision to become picked up by $mountpoint ..."
+  echo -n "*** waiting for revision $expected_revision to become picked up by $mountpoint ..."
   while [ $waited -lt $TEST550_MAX_WAITING_TIMEOUT ] && [ $revision -ne $expected_revision ]; do
     ls $mountpoint > /dev/null 2>&1 || return 2
     revision="$(get_xattr revision $mountpoint)"
@@ -132,23 +132,23 @@ cvmfs_run_test() {
   local s0_mnt="$(pwd)/s0"
   local s1_mnt="$(pwd)/s1"
 
-  echo "make sure there are no legacy repo leftovers from previous tests"
+  echo "*** make sure there are no legacy repo leftovers from previous tests"
   cleanup_legacy_repo_leftovers "$legacy_repo_name"
 
-  echo "set a trap for desaster cleanup"
+  echo "*** set a trap for desaster cleanup"
   trap cleanup EXIT HUP INT TERM
 
-  echo -n "resurrect legacy repository... "
+  echo -n "*** resurrect legacy repository... "
   TEST550_LEGACY_STORAGE="$legacy_repo_storage"
   plant_tarball "${guinea_pig_location}/keys.tar.gz"                                              || return $?
   plant_legacy_repository_revision "${guinea_pig_location}/revision-2.tar.gz" "$legacy_repo_name" || return $?
   echo "done"
 
-  echo "start apache to serve the legacy repository"
+  echo "*** start apache to serve the legacy repository"
   TEST550_APACHE_CONF=$(get_apache_config_filename $legacy_repo_name)
   mock_apache_access_to_legacy_repo "$legacy_repo_name"
 
-  echo "creating a stratum1 replication"
+  echo "*** creating a stratum1 replication"
   TEST550_REPLICA_NAME="$replica_name"
   create_stratum1 $replica_name                           \
                   $CVMFS_TEST_USER                        \
@@ -156,46 +156,46 @@ cvmfs_run_test() {
                   ${key_location}/${legacy_repo_name}.pub \
     || return 2
 
-  echo "create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
+  echo "*** create a Snapshot of the Stratum0 repository in the just created Stratum1 replica"
   sudo cvmfs_server snapshot $replica_name || return 3
 
-  echo "mount the stratum0 and the stratum1 repository on local mountpoints"
+  echo "*** mount the stratum0 and the stratum1 repository on local mountpoints"
   TEST550_S0_MOUNTPOINT="$s0_mnt"
   do_local_mount $s0_mnt $legacy_repo_name $legacy_repo_url || return 4
   TEST550_S1_MOUNTPOINT="$s1_mnt"
   do_local_mount $s1_mnt $legacy_repo_name $replica_url     || return 5
 
-  echo "try a listing"
+  echo "*** try a listing"
   ls -lisa $s0_mnt $s1_mnt || return 6
 
-  echo "publish revision 3"
+  echo "*** publish revision 3"
   plant_legacy_repository_revision "${guinea_pig_location}/revision-3.tar.gz" "$legacy_repo_name" || return $?
 
-  echo "snapshot the new revision"
+  echo "*** snapshot the new revision"
   sudo cvmfs_server snapshot $replica_name || return 7
 
-  echo "trigger the clients to apply the new revision"
+  echo "*** trigger the clients to apply the new revision"
   initiate_reload "$s0_mnt" "$legacy_repo_name" || return 8
   initiate_reload "$s1_mnt" "$legacy_repo_name" || return 9
 
-  echo "wait for the clients to pick up revision 3"
+  echo "*** wait for the clients to pick up revision 3"
   wait_for_revision "$s0_mnt" "$legacy_repo_name" 3 || return 10
   wait_for_revision "$s1_mnt" "$legacy_repo_name" 3 || return 11
 
-  echo "try another listing"
+  echo "*** try another listing"
   ls -lisa $s0_mnt $s1_mnt || return 12
   [ -d ${s0_mnt}/dir1 ] && [ -d ${s0_mnt}/dir2 ] && [ -d ${s0_mnt}/dir3 ] && \
   [ -d ${s0_mnt}/dir4 ] && [ -d ${s0_mnt}/dir5 ] && [ -d ${s0_mnt}/dir6 ] && \
   [ -d ${s1_mnt}/dir1 ] && [ -d ${s1_mnt}/dir2 ] && [ -d ${s1_mnt}/dir3 ] && \
   [ -d ${s1_mnt}/dir4 ] && [ -d ${s1_mnt}/dir5 ] && [ -d ${s1_mnt}/dir6 ] || return 12
 
-  echo "stop serving the old repository - migration imminent"
+  echo "*** stop serving the old repository - migration imminent"
   stop_mocked_apache_access "$legacy_repo_name"
 
-  echo "fast forward to revision 6"
+  echo "*** fast forward to revision 6"
   plant_legacy_repository_revision "${guinea_pig_location}/revision-6.tar.gz" "$legacy_repo_name" || return $?
 
-  echo "run the repository migration"
+  echo "*** run the repository migration"
   TEST550_NEW_REPO_NAME="$legacy_repo_name"
   sudo mv $legacy_repo_storage/pub/data $legacy_repo_storage         || return 13
   sudo ln -s $legacy_repo_storage/data $legacy_repo_storage/pub/data || return 13
@@ -208,18 +208,18 @@ cvmfs_run_test() {
     -s                                           \
     -g || return 14
 
-  echo "list newly generated repository under /cvmfs/${legacy_repo_name}"
+  echo "*** list newly generated repository under /cvmfs/${legacy_repo_name}"
   ls -lisa /cvmfs/${legacy_repo_name} || return 15
 
   if uses_overlayfs $legacy_repo_name; then
-    echo "we are running on OverlayFS. We need to erase all hardlinks now..."
+    echo "*** we are running on OverlayFS. We need to erase all hardlinks now..."
     sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 101
   fi
 
-  echo "do a snapshot on stratum 1 that spans from CernVM-FS 2.1.x to 2.0"
+  echo "*** do a snapshot on stratum 1 that spans from CernVM-FS 2.1.x to 2.0"
   sudo cvmfs_server snapshot $replica_name || return 16
 
-  echo "trigger the clients to apply the new (2.1.x) revision"
+  echo "*** trigger the clients to apply the new (2.1.x) revision"
   initiate_reload "$s0_mnt" "$legacy_repo_name" || return 17
   initiate_reload "$s1_mnt" "$legacy_repo_name" || return 18
 
@@ -227,11 +227,11 @@ cvmfs_run_test() {
   if uses_overlayfs $legacy_repo_name; then
     migrate_revision=8
   fi
-  echo "wait for the clients to pick up revision $migrate_revision"
+  echo "*** wait for the clients to pick up revision $migrate_revision"
   wait_for_revision "$s0_mnt" "$legacy_repo_name" $migrate_revision || return 19
   wait_for_revision "$s1_mnt" "$legacy_repo_name" $migrate_revision || return 20
 
-  echo "try a final listing"
+  echo "*** try a final listing"
   ls -lisa $s0_mnt $s1_mnt || return 21
   [ -d ${s0_mnt}/dir1 ] && [ -d ${s0_mnt}/dir2 ] && [ -d ${s0_mnt}/dir3 ] && \
   [ -d ${s0_mnt}/dir4 ] && [ -d ${s0_mnt}/dir5 ] && [ -d ${s0_mnt}/dir6 ] && \
@@ -244,13 +244,13 @@ cvmfs_run_test() {
   [ x"181e8566ef9ef4063a00e56ec82cc99682ac795c" = x"$big_sha1" ] || return 22
 
   local publish_log_1="publish_1.log"
-  echo "run a new transaction (logging to $publish_log_1)"
+  echo "*** run a new transaction (logging to $publish_log_1)"
   start_transaction "$legacy_repo_name"                  || return 23
   cp_bin /cvmfs/${legacy_repo_name}/dir7                 || return 24
   touch $big_file                                        || return 25
   publish_repo "$legacy_repo_name" > $publish_log_1 2>&1 || return 26
 
-  echo "check if big file is still the same content hash (now it should be chunked)"
+  echo "*** check if big file is still the same content hash (now it should be chunked)"
   local big_sha1_2="$(cat $big_file | sha1sum | head -c40)"
   [ x"$big_sha1" = x"$big_sha1_2" ] || return 27
 

--- a/test/src/633-changedfiles/main
+++ b/test/src/633-changedfiles/main
@@ -13,7 +13,7 @@ private_mount() {
                  "$CVMFS_TEST_REPO" \
                  "http://localhost/cvmfs/$CVMFS_TEST_REPO" \
                  "" \
-                 "CVMFS_KCACHE_TIMEOUT=5" || return 1
+                 "CVMFS_KCACHE_TIMEOUT=20" || return 1
 }
 
 private_unmount() {
@@ -42,15 +42,15 @@ cvmfs_run_test() {
   local script_location=$2
   local scratch_dir=$(pwd)
 
-  echo "set a trap for system directory cleanup"
+  echo "*** set a trap for system directory cleanup"
   trap cleanup EXIT HUP INT TERM
 
-  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   local md5_small_orig
   local md5_large_orig
-  echo "put a small file and a large file into $CVMFS_TEST_REPO"
+  echo "*** put a small file and a large file into $CVMFS_TEST_REPO"
   start_transaction $CVMFS_TEST_REPO                              || return $?
   mkdir /cvmfs/$CVMFS_TEST_REPO/dir                               || return 3
   echo "Hello World" > /cvmfs/$CVMFS_TEST_REPO/dir/small          || return 3
@@ -63,41 +63,39 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
   local mntpnt="${scratch_dir}/private_mnt"
-  echo "mount private mount point"
+  echo "*** mount private mount point"
   private_mount $mntpnt || return 20
 
   local revision_old=$(get_xattr revision ${mntpnt}) || return 25
-  echo "revision is $revision_old"
+  echo "*** revision is $revision_old"
 
-  echo "verify that large file is chunked"
+  echo "*** verify that large file is chunked"
   local no_chunks=$(get_xattr chunks ${mntpnt}/dir/large) || return 21
   [ $no_chunks -gt 1 ] || return 22
 
-  echo "open file descriptors"
+  echo "*** open file descriptors"
   tail -f ${mntpnt}/dir/small &
   TEST633_TAIL_SMALL=$!
   tail -f ${mntpnt}/dir/large &
   TEST633_TAIL_LARGE=$!
 
-  echo "add contents to files in repository"
+  echo "*** add contents to files in repository"
   start_transaction $CVMFS_TEST_REPO                    || return $?
   echo "modified" >> /cvmfs/$CVMFS_TEST_REPO/dir/small  || return 30
   echo "modified" >> /cvmfs/$CVMFS_TEST_REPO/dir/large  || return 30
   publish_repo $CVMFS_TEST_REPO -v                      || return $?
 
-  echo "remount private mount point"
-  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount || return 40
-  echo "waiting for kernel caches to drain out"
-  sleep 10
+  echo "*** remount private mount point"
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 40
   local revision_new=$(get_xattr revision ${mntpnt}) || return 41
   echo "revision is now $revision_new"
   [ $revision_new -gt $revision_old ] || return 42
 
-  echo "verify new content"
+  echo "*** verify new content"
   [ "x$(tail -n 1 ${mntpnt}/dir/small)" = "xmodified" ] || return 50
   [ "x$(tail -n 1 ${mntpnt}/dir/large)" = "xmodified" ] || return 51
 
-  echo "verify that our open tail processes did acutally run"
+  echo "*** verify that our open tail processes did acutally run"
   /bin/kill -TERM $TEST633_TAIL_SMALL || return 60
   TEST633_TAIL_SMALL=
   /bin/kill -TERM $TEST633_TAIL_LARGE || return 61

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(CVMFS_UNITTEST_FILES
   t_file_processing.cc
   t_file_sandbox.cc
   t_fs_traversal.cc
+  t_fuse_evict.cc
   t_garbage_collector.cc
   t_glue_buffer.cc
   t_hash_filters.cc
@@ -147,6 +148,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/file_processing/file_processor.cc
   ${CVMFS_SOURCE_DIR}/file_processing/io_dispatcher.cc
   ${CVMFS_SOURCE_DIR}/file_processing/processor.cc
+  ${CVMFS_SOURCE_DIR}/fuse_evict.cc
   ${CVMFS_SOURCE_DIR}/gateway_util.cc
   ${CVMFS_SOURCE_DIR}/globals.cc
   ${CVMFS_SOURCE_DIR}/glue_buffer.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(CVMFS_UNITTEST_FILES
   t_file_sandbox.cc
   t_fs_traversal.cc
   t_garbage_collector.cc
+  t_glue_buffer.cc
   t_hash_filters.cc
   t_header_lists.cc
   t_history.cc

--- a/test/unittests/t_fuse_evict.cc
+++ b/test/unittests/t_fuse_evict.cc
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fuse_evict.h"
+#include "glue_buffer.h"
+#include "util/string.h"
+
+extern "C" {
+unsigned fuse_lowlevel_notify_inval_entry_cnt = 0;
+}
+
+class T_FuseInvalidator : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    invalidator_ = new FuseInvalidator(&inode_tracker_, NULL);
+    invalidator_->Spawn();
+  }
+
+  virtual void TearDown () {
+    delete invalidator_;
+  }
+
+ protected:
+  glue::InodeTracker inode_tracker_;
+  FuseInvalidator *invalidator_;
+};
+
+
+TEST_F(T_FuseInvalidator, StartStop) {
+  FuseInvalidator *idle_invalidator =
+    new FuseInvalidator(&inode_tracker_, NULL);
+  EXPECT_FALSE(idle_invalidator->spawned_);
+  delete idle_invalidator;
+
+  FuseInvalidator *noop_invalidator =
+    new FuseInvalidator(&inode_tracker_, NULL);
+  noop_invalidator->Spawn();
+  EXPECT_TRUE(noop_invalidator->spawned_);
+  EXPECT_GE(noop_invalidator->pipe_ctrl_[0], 0);
+  EXPECT_GE(noop_invalidator->pipe_ctrl_[1], 0);
+  delete noop_invalidator;
+}
+
+
+TEST_F(T_FuseInvalidator, InvalidateTimeout) {
+  FuseInvalidator::Handle handle(0);
+  EXPECT_FALSE(handle.IsDone());
+  invalidator_->InvalidateDentries(&handle);
+  handle.WaitFor();
+  EXPECT_TRUE(handle.IsDone());
+
+  invalidator_->terminated_ = 1;
+  FuseInvalidator::Handle handle2(1000000);
+  EXPECT_FALSE(handle2.IsDone());
+  invalidator_->InvalidateDentries(&handle2);
+  handle2.WaitFor();
+  EXPECT_TRUE(handle2.IsDone());
+}
+
+
+TEST_F(T_FuseInvalidator, InvalidateOps) {
+  invalidator_->fuse_channel_ = reinterpret_cast<struct fuse_chan **>(this);
+  inode_tracker_.VfsGet(1, PathString(""));
+  for (unsigned i = 2; i <= 1024; ++i) {
+    inode_tracker_.VfsGet(i, PathString("/" + StringifyInt(i)));
+  }
+
+  FuseInvalidator::Handle handle(0);
+  EXPECT_FALSE(handle.IsDone());
+  invalidator_->InvalidateDentries(&handle);
+  handle.WaitFor();
+  EXPECT_TRUE(handle.IsDone());
+  EXPECT_EQ(FuseInvalidator::kCheckTimeoutFreqOps,
+            fuse_lowlevel_notify_inval_entry_cnt);
+
+  FuseInvalidator::Handle handle2(1000000);
+  EXPECT_FALSE(handle2.IsDone());
+  invalidator_->InvalidateDentries(&handle2);
+  handle2.WaitFor();
+  EXPECT_TRUE(handle2.IsDone());
+  EXPECT_EQ(FuseInvalidator::kCheckTimeoutFreqOps + 1024,
+            fuse_lowlevel_notify_inval_entry_cnt);
+
+  invalidator_->terminated_ = 1;
+  FuseInvalidator::Handle handle3(1000000);
+  EXPECT_FALSE(handle3.IsDone());
+  invalidator_->InvalidateDentries(&handle3);
+  handle3.WaitFor();
+  EXPECT_TRUE(handle3.IsDone());
+  EXPECT_EQ((2 * FuseInvalidator::kCheckTimeoutFreqOps) + 1024,
+            fuse_lowlevel_notify_inval_entry_cnt);
+}

--- a/test/unittests/t_fuse_evict.cc
+++ b/test/unittests/t_fuse_evict.cc
@@ -19,7 +19,7 @@ class T_FuseInvalidator : public ::testing::Test {
     invalidator_->Spawn();
   }
 
-  virtual void TearDown () {
+  virtual void TearDown() {
     delete invalidator_;
   }
 

--- a/test/unittests/t_fuse_evict.cc
+++ b/test/unittests/t_fuse_evict.cc
@@ -85,11 +85,11 @@ TEST_F(T_FuseInvalidator, InvalidateOps) {
             fuse_lowlevel_notify_inval_entry_cnt);
 
   invalidator_->terminated_ = 1;
-  FuseInvalidator::Handle handle3(1000000);
-  EXPECT_FALSE(handle3.IsDone());
-  invalidator_->InvalidateDentries(&handle3);
-  handle3.WaitFor();
-  EXPECT_TRUE(handle3.IsDone());
+  handle2.Reset();
+  EXPECT_FALSE(handle2.IsDone());
+  invalidator_->InvalidateDentries(&handle2);
+  handle2.WaitFor();
+  EXPECT_TRUE(handle2.IsDone());
   EXPECT_EQ((2 * FuseInvalidator::kCheckTimeoutFreqOps) + 1024,
             fuse_lowlevel_notify_inval_entry_cnt);
 }

--- a/test/unittests/t_glue_buffer.cc
+++ b/test/unittests/t_glue_buffer.cc
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "glue_buffer.h"
+#include "shortstring.h"
+
+namespace glue {
+
+class T_GlueBuffer : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+
+ protected:
+  InodeTracker inode_tracker_;
+};
+
+
+TEST_F(T_GlueBuffer, InodeTracker) {
+  uint64_t inode = 0;
+  NameString name;
+  InodeTracker::Cursor cursor = inode_tracker_.BeginEnumerate();
+  EXPECT_FALSE(inode_tracker_.Next(&cursor, &inode, &name));
+  EXPECT_FALSE(inode_tracker_.Next(&cursor, &inode, &name));
+  inode_tracker_.EndEnumerate(&cursor);
+
+  inode_tracker_.VfsGet(1, PathString(""));
+  inode_tracker_.VfsGet(2, PathString("/foo"));
+  inode_tracker_.VfsGet(4, PathString("/foo/bar"));
+  cursor = inode_tracker_.BeginEnumerate();
+  int bitset = 0;
+  for (unsigned i = 0; i < 3; ++i) {
+    EXPECT_TRUE(inode_tracker_.Next(&cursor, &inode, &name));
+    switch (inode) {
+      case 0:
+        EXPECT_EQ("", name.ToString());
+        bitset |= 1;
+        break;
+      case 1:
+        EXPECT_EQ("foo", name.ToString());
+        bitset |= 2;
+        break;
+      case 2:
+        EXPECT_EQ("bar", name.ToString());
+        bitset |= 4;
+        break;
+      default:
+        EXPECT_FALSE(true);
+    }
+  }
+  EXPECT_EQ(7, bitset);
+  EXPECT_FALSE(inode_tracker_.Next(&cursor, &inode, &name));
+  inode_tracker_.EndEnumerate(&cursor);
+}
+
+}  // namespace glue


### PR DESCRIPTION
This PR moves the code for applying new file system snapshots from the fuse main module into a `FuseRemounter` class.  Things are a little bit better documented now and partially unit tested.  We also get rid of the `alarm()` signal handling code.

Invalidating the kernel caches is now being done by a `FuseInvalidator`, which, on modern fuse (2.9 / EL7 and newer), will actively kick out entries from the kernel caches.  In most cases, this gets rid of 1 minute waiting time and results in immediate application of the new file system snapshot.  Along with it, there is a new command `cvmfs_talk remount sync` which only returns once the new file system snapshot is available.