### PR TITLE
Cache proxy settings in workspace directory

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1157,7 +1157,10 @@ bool MountPoint::CreateDownloadManagers() {
   string proxies;
   if (options_mgr_->GetValue("CVMFS_HTTP_PROXY", &optarg))
     proxies = optarg;
-  proxies = download::ResolveProxyDescription(proxies, download_mgr_);
+  proxies = download::ResolveProxyDescription(
+    proxies,
+    file_system_->workspace() + "/proxies" + GetUniqFileSuffix(),
+    download_mgr_);
   if (proxies == "") {
     boot_error_ = "failed to discover HTTP proxy servers";
     boot_status_ = loader::kFailWpad;
@@ -1418,6 +1421,15 @@ unsigned MountPoint::GetMaxTtlMn() {
 }
 
 
+/**
+ * Files in the workspace from different file systems / mountpoints need to
+ * have different names.  Used, for example, for caching proxy settings.
+ */
+string MountPoint::GetUniqFileSuffix() {
+  return "." + file_system_->name() + "-" + fqrn_;
+}
+
+
 MountPoint::MountPoint(
   const string &fqrn,
   FileSystem *file_system,
@@ -1595,7 +1607,10 @@ bool MountPoint::SetupExternalDownloadMgr() {
 
   string proxies = "DIRECT";
   if (options_mgr_->GetValue("CVMFS_EXTERNAL_HTTP_PROXY", &optarg)) {
-    proxies = download::ResolveProxyDescription(optarg, external_download_mgr_);
+    proxies = download::ResolveProxyDescription(
+      optarg,
+      file_system_->workspace() + "/proxies-external" + GetUniqFileSuffix(),
+      external_download_mgr_);
     if (proxies == "") {
       boot_error_ = "failed to discover external HTTP proxy servers";
       boot_status_ = loader::kFailWpad;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -177,6 +177,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_fs_readlink() { return n_fs_readlink_; }
   perf::Counter *n_fs_stat() { return n_fs_stat_; }
   perf::Counter *n_io_error() { return n_io_error_; }
+  std::string name() { return name_; }
   perf::Counter *no_open_dirs() { return no_open_dirs_; }
   perf::Counter *no_open_files() { return no_open_files_; }
   OptionsManager *options_mgr() { return options_mgr_; }
@@ -468,6 +469,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool DetermineRootHash(shash::Any *root_hash);
   bool FetchHistory(std::string *history_path);
   std::string ReplaceHosts(std::string hosts);
+  std::string GetUniqFileSuffix();
 
   std::string fqrn_;
   cvmfs::Uuid *uuid_;

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -404,7 +404,7 @@ void *TalkManager::MainResponder(void *data) {
       } else {
         string proxies = line.substr(10);
         proxies =
-          download::ResolveProxyDescription(proxies,
+          download::ResolveProxyDescription(proxies, "",
                                             mount_point->download_mgr());
         if (proxies == "") {
             talk_mgr->Answer(con_fd, "Failed, no valid proxies\n");

--- a/cvmfs/wpad.h
+++ b/cvmfs/wpad.h
@@ -21,6 +21,7 @@ std::string AutoProxy(DownloadManager *download_manager);
  * Uses AutoProxy to replace any "auto" proxy by the proxies from the PAC file
  */
 std::string ResolveProxyDescription(const std::string &cvmfs_proxies,
+                                    const std::string &path_fallback_cache,
                                     DownloadManager *download_manager);
 
 int MainResolveProxyDescription(int argc, char **argv);

--- a/test/src/031-cacheautoproxy/main
+++ b/test/src/031-cacheautoproxy/main
@@ -15,7 +15,17 @@ EOF
   cvmfs_mount grid.cern.ch || return 11
   cvmfs_umount grid.cern.ch || return 12
 
+  echo "*** auto without network or cached proxy should fail"
   cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_EXTERNAL_HTTP_PROXY=auto" \
+    "CVMFS_PAC_URLS=file:///no/such/file" && return 13
+
+  echo "*** restarting autofs"
+  autofs_switch off || return 14
+  autofs_switch on  || return 15
+
+  cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_EXTERNAL_HTTP_PROXY=auto" \
     "CVMFS_PAC_URLS=file://$wpad_file" || return 20
   proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
   echo "*** proxy is $proxy"
@@ -25,12 +35,40 @@ EOF
   cvmfs_umount grid.cern.ch
 
   cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_EXTERNAL_HTTP_PROXY=auto" \
     "CVMFS_PAC_URLS=file:///no/such/file" || return 30
   proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
   echo "*** proxy is $proxy"
   if [ x"$proxy" != x"http://no-such-proxy.cern.ch:3128" ]; then
     return 31
   fi
+  cvmfs_umount grid.cern.ch
+
+  echo "*** changing proxy settings"
+  cat > $wpad_file << EOF
+  function FindProxyForURL(url, host) {
+    return "PROXY http://no-such-other-proxy.cern.ch:3128"
+  }
+EOF
+  cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_EXTERNAL_HTTP_PROXY=auto" \
+    "CVMFS_PAC_URLS=file://$wpad_file" || return 40
+  proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
+  echo "*** proxy is $proxy"
+  if [ x"$proxy" != x"http://no-such-other-proxy.cern.ch:3128" ]; then
+    return 41
+  fi
+  cvmfs_umount grid.cern.ch
+
+  cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_EXTERNAL_HTTP_PROXY=auto" \
+    "CVMFS_PAC_URLS=file:///no/such/file" || return 50
+  proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
+  echo "*** proxy is $proxy"
+  if [ x"$proxy" != x"http://no-such-other-proxy.cern.ch:3128" ]; then
+    return 51
+  fi
+
 
   return 0
 }

--- a/test/src/031-cacheautoproxy/main
+++ b/test/src/031-cacheautoproxy/main
@@ -1,0 +1,37 @@
+
+cvmfs_test_name="Cache result of proxy auto discovery"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  local wpad_file="$(pwd)/wpad"
+  cat > $wpad_file << EOF
+  function FindProxyForURL(url, host) {
+    return "PROXY http://no-such-proxy.cern.ch:3128"
+  }
+EOF
+  chmod 666 $wpad_file || return 10
+
+  cvmfs_mount grid.cern.ch || return 11
+  cvmfs_umount grid.cern.ch || return 12
+
+  cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_PAC_URLS=file://$wpad_file" || return 20
+  proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
+  echo "*** proxy is $proxy"
+  if [ x"$proxy" != x"http://no-such-proxy.cern.ch:3128" ]; then
+    return 21
+  fi
+  cvmfs_umount grid.cern.ch
+
+  cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
+    "CVMFS_PAC_URLS=file:///no/such/file" || return 30
+  proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
+  echo "*** proxy is $proxy"
+  if [ x"$proxy" != x"http://no-such-proxy.cern.ch:3128" ]; then
+    return 31
+  fi
+
+  return 0
+}
+

--- a/test/src/031-cacheautoproxy/main
+++ b/test/src/031-cacheautoproxy/main
@@ -24,6 +24,17 @@ EOF
   autofs_switch off || return 14
   autofs_switch on  || return 15
 
+  echo "*** 'auto;DIRECT' should always succeed"
+  cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY='auto;DIRECT'" \
+    "CVMFS_EXTERNAL_HTTP_PROXY='auto;DIRECT'" \
+    "CVMFS_PAC_URLS=file:///no/such/file" || return 16
+  proxy="$(get_xattr proxy /cvmfs/grid.cern.ch)"
+  echo "*** proxy is $proxy"
+  if [ x"$proxy" != x"DIRECT" ]; then
+    return 17
+  fi
+  cvmfs_umount grid.cern.ch
+
   cvmfs_mount grid.cern.ch "CVMFS_HTTP_PROXY=auto" \
     "CVMFS_EXTERNAL_HTTP_PROXY=auto" \
     "CVMFS_PAC_URLS=file://$wpad_file" || return 20


### PR DESCRIPTION
If resolving auto proxies fails, use last known good configuration from cache.