### PR TITLE
Fix location of posix quota manager locks with CVMFS_WORKSPACE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,8 @@
       "condition_variable": "cpp",
       "future": "cpp",
       "cassert": "cpp",
-      "functional": "cpp"
+      "functional": "cpp",
+      "mutex": "cpp"
     }
   }
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -32,7 +32,7 @@
   * Fix handling of file:// url in CVMFS_SERVER_URL
 
 2.3.5:
-  * Lep RPM drop patch configuration for CVM-1200 where necessary
+  * Let RPM drop patch configuration for CVM-1200 where necessary
 
 2.3.4:
   * Unlink empty files during cache db rebuild (CVM-1113)

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -260,6 +260,7 @@ PosixCacheManager *PosixCacheManager::Create(
       return NULL;
   }
 
+  // TODO(jblomer): we might not need to look anymore for cvmfs 2.0 relicts
   if (FileExists(cache_path + "/cvmfscatalog.cache")) {
     LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
              "Not mounting on cvmfs 2.0.X cache");

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -275,6 +275,9 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
     settings.is_alien = true;
     settings.cache_path = optarg;
   }
+  // We already changed the cwd to the workspace
+  if (settings.cache_path == workspace_fullpath_)
+    settings.cache_path = ".";
 
   // The cache workspace usually is the cache directory, unless explicitly
   // set otherwise

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -275,8 +275,17 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
     settings.is_alien = true;
     settings.cache_path = optarg;
   }
-  if (settings.cache_path == workspace_fullpath_)
-    settings.cache_path = ".";
+
+  // The cache workspace usually is the cache directory, unless explicitly
+  // set otherwise
+  settings.workspace = settings.cache_path;
+  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_WORKSPACE", instance),
+                             &optarg) ||
+      options_mgr_->GetValue("CVMFS_WORKSPACE", &optarg))
+  {
+    // Used for the shared quota manager
+    settings.workspace = optarg;
+  }
 
   return settings;
 }
@@ -820,12 +829,19 @@ bool FileSystem::SetupPosixQuotaMgr(
 ) {
   assert(settings.quota_limit >= 0);
   int64_t quota_threshold = settings.quota_limit / 2;
+  string cache_workspace = settings.cache_path;
+  if (settings.cache_path != settings.workspace) {
+    LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
+             "using workspace %s to protect cache database in %s",
+             settings.workspace.c_str(), settings.cache_path.c_str());
+    cache_workspace += ":" + settings.workspace;
+  }
   PosixQuotaManager *quota_mgr;
 
   if (settings.is_shared) {
     quota_mgr = PosixQuotaManager::CreateShared(
                   exe_path_,
-                  settings.cache_path,
+                  cache_workspace,
                   settings.quota_limit,
                   quota_threshold,
                   foreground_);
@@ -835,16 +851,8 @@ bool FileSystem::SetupPosixQuotaMgr(
       return false;
     }
   } else {
-    // Cache database should to be protected by workspace lock
-    if (workspace_ != settings.cache_path) {
-      // Can happen for a tiered POSIX cache
-      boot_error_ = "Cannot start managed cache in " + settings.cache_path +
-                    ", which is not protected by workspace in " + workspace_;
-      boot_status_ = loader::kFailQuota;
-      return false;
-    }
     quota_mgr = PosixQuotaManager::Create(
-                  settings.cache_path,
+                  cache_workspace,
                   settings.quota_limit,
                   quota_threshold,
                   found_previous_crash_);

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -214,6 +214,11 @@ class FileSystem : SingleCopy, public BootFactory {
      */
     int64_t quota_limit;
     std::string cache_path;
+    /**
+     * Different from cache_path only if CVMFS_WORKSPACE or
+     * CVMFS_CACHE_WORKSPACE is set.
+     */
+    std::string workspace;
   };
 
   static void LogSqliteError(void *user_data __attribute__((unused)),

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -40,12 +40,12 @@ class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, MakeReturnPipe);
 
  public:
-  static PosixQuotaManager *Create(const std::string &cache_dir,
+  static PosixQuotaManager *Create(const std::string &cache_workspace,
     const uint64_t limit, const uint64_t cleanup_threshold,
     const bool rebuild_database);
   static PosixQuotaManager *CreateShared(
     const std::string &exe_path,
-    const std::string &cache_dir,
+    const std::string &cache_workspace,
     const uint64_t limit,
     const uint64_t cleanup_threshold,
     bool foreground);
@@ -228,8 +228,11 @@ class PosixQuotaManager : public QuotaManager {
   void GetSharedStatus(uint64_t *gauge, uint64_t *pinned);
   void GetLimits(uint64_t *limit, uint64_t *cleanup_threshold);
 
+  static void ParseDirectories(const std::string cache_workspace,
+                               std::string *cache_dir,
+                               std::string *workspace_dir);
   PosixQuotaManager(const uint64_t limit, const uint64_t cleanup_threshold,
-                    const std::string &cache_dir);
+                    const std::string &cache_workspace);
 
   /**
    * Indicates if the cache manager is a shared process or a thread within the
@@ -273,6 +276,13 @@ class PosixQuotaManager : public QuotaManager {
    * Should match the directory given to the cache manager.
    */
   std::string cache_dir_;
+
+  /**
+   * Directory for the database lock (shared manager) and the pipes (also
+   * shared manager).  Usually the same as cache_dir_.  Can be different if
+   * CVMFS_WORKSPACE or CVMFS_CACHE_WORKSPACE is set.
+   */
+  std::string workspace_dir_;
 
   /**
    * Pinned content hashes and their size.

--- a/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-NFS_test.sh
@@ -30,6 +30,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/001-chksetup                             \
                                  src/026-tightcache                           \
+				 src/032-workspace                            \
                                  src/041-rocache                              \
                                  src/043-highinodes                           \
                                  --                                           \

--- a/test/src/032-workspace/main
+++ b/test/src/032-workspace/main
@@ -1,0 +1,40 @@
+
+cvmfs_test_name="CVMFS_WORKSPACE"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  local cache_dir=$(get_cvmfs_cachedir grid.cern.ch)
+  local workspace="$(dirname $cache_dir)/workspace"
+  echo "*** cache directory is $cache_dir"
+  echo "*** workspace is $workspace"
+
+  echo "*** start clean, even without cvmfs-config repository"
+  cvmfs_clean || return 50
+
+  cvmfs_mount grid.cern.ch "CVMFS_WORKSPACE=$workspace" || return 3
+  cat /cvmfs/grid.cern.ch/README || return 4
+  cvmfs_mount atlas.cern.ch "CVMFS_WORKSPACE=$workspace" || return 5
+  cat /cvmfs/atlas.cern.ch/.cvmfsdirtab || return 6
+
+  sudo cvmfs_talk -p $workspace/cvmfs_io.atlas.cern.ch cache list || return 10
+
+  local num_lock_files=$(sudo find $cache_dir -name 'lock*' | wc -l)
+  local num_pipe_files=$(sudo find $cache_dir -name 'pipe*' | wc -l)
+  if [ $num_lock_files -ne 0 ]; then
+    sudo ls $cache_dir
+    return 20
+  fi
+  if [ $num_pipe_files -ne 0 ]; then
+    sudo ls $cache_dir
+    return 21
+  fi
+  num_lock_files=$(sudo find $workspace -name 'lock*' | wc -l)
+  if [ $num_lock_files -eq 0 ]; then
+    sudo ls $workspace
+    return 22
+  fi
+
+  return 0
+}
+


### PR DESCRIPTION
Used for "exotic" settings where the cache directory is not an alien cache but might not support sockets, named pipes, or POSIX locks.  `CVMFS_WORKSPACE` is a dangerous setting as it allows to circumvent necessary locking around access to a cache directory.