### PR TITLE
Fix initialization of super class in swissknife::DiffTool

### DIFF
--- a/cvmfs/swissknife_diff_tool.cc
+++ b/cvmfs/swissknife_diff_tool.cc
@@ -23,8 +23,9 @@ DiffTool::DiffTool(const std::string &repo_path,
                    const std::string &temp_dir,
                    download::DownloadManager *download_manager,
                    bool machine_readable)
-    : CatalogDiffTool(repo_path, old_tag.root_hash, new_tag.root_hash, temp_dir,
-                      download_manager),
+    : CatalogDiffTool<catalog::SimpleCatalogManager>(
+          repo_path, old_tag.root_hash, new_tag.root_hash, temp_dir,
+          download_manager),
       old_tag_(old_tag),
       new_tag_(new_tag),
       machine_readable_(machine_readable) {}


### PR DESCRIPTION
This should fix the build on SLES 4,5,6, SUSE 11 and 12 etc.

As far as I can tell, the newer compilers are less strict when it comes to the initialization of a super class which is an instantiation of a ckass template.