### PR TITLE
Support for repository names up to 60 characters

### DIFF
--- a/cvmfs/sanitizer.cc
+++ b/cvmfs/sanitizer.cc
@@ -36,7 +36,19 @@ bool CharRange::InRange(const char c) const {
 //------------------------------------------------------------------------------
 
 
-InputSanitizer::InputSanitizer(const string &whitelist) {
+InputSanitizer::InputSanitizer(const string &whitelist) : max_length_(-1) {
+  InitValidRanges(whitelist);
+}
+
+
+InputSanitizer::InputSanitizer(const string &whitelist, int max_length)
+  : max_length_(max_length)
+{
+  InitValidRanges(whitelist);
+}
+
+
+void InputSanitizer::InitValidRanges(const std::string &whitelist) {
   // Parse the whitelist
   const unsigned length = whitelist.length();
   unsigned pickup_pos = 0;
@@ -64,12 +76,19 @@ bool InputSanitizer::Sanitize(
                           std::string::const_iterator   begin,
                           std::string::const_iterator   end,
                           std::string                  *filtered_output) const {
+  int pos = 0;
   bool is_sane = true;
   for (; begin != end; ++begin) {
-    if (CheckRanges(*begin))
+    if (CheckRanges(*begin)) {
+      if ((max_length_ >= 0) && (pos >= max_length_)) {
+        is_sane = false;
+        break;
+      }
       filtered_output->push_back(*begin);
-    else
+      pos++;
+    } else {
       is_sane = false;
+    }
   }
   return is_sane;
 }

--- a/cvmfs/sanitizer.h
+++ b/cvmfs/sanitizer.h
@@ -30,6 +30,7 @@ class InputSanitizer {
   // whitelist is of the form "az AZ _ - 09"
   // Any other format will abort the program
   explicit InputSanitizer(const std::string &whitelist);
+  InputSanitizer(const std::string &whitelist, int max_length);
   virtual ~InputSanitizer() { }
 
   std::string Filter(const std::string &input) const;
@@ -45,6 +46,9 @@ class InputSanitizer {
   bool CheckRanges(const char chr) const;
 
  private:
+  void InitValidRanges(const std::string &whitelist);
+
+  int max_length_;
   std::vector<CharRange> valid_ranges_;
 };
 
@@ -69,7 +73,7 @@ class CacheInstanceSanitizer : public InputSanitizer {
 
 class RepositorySanitizer : public InputSanitizer {
  public:
-  RepositorySanitizer() : InputSanitizer("az AZ 09 - _ .") { }
+  RepositorySanitizer() : InputSanitizer("az AZ 09 - _ .", 60) { }
 };
 
 

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -166,6 +166,9 @@ cvmfs_server_mkfs() {
   check_parameter_count 1 $#
   name=$(get_repository_name $1)
 
+  [ $(echo -n "$name" | wc -c) -gt 60 ] && \
+    die "repository name longer than 60 characters"
+
   # default values
   [ x"$unionfs"   = x"" ] && unionfs="$(get_available_union_fs)"
   [ x"$hash_algo" = x"" ] && hash_algo=sha1

--- a/cvmfs/server/cvmfs_server_ssl.sh
+++ b/cvmfs/server/cvmfs_server_ssl.sh
@@ -32,8 +32,14 @@ create_cert() {
   local crt; crt="/etc/cvmfs/keys/$name.crt"
 
   # Create self-signed certificate
+  local cn="$name"
+  if [ $(echo -n "$cn" | wc -c) -gt 30 ]; then
+    cn="$(echo -n "$cn" | head -c 30)[...]"
+  fi
+  cn="$cn CernVM-FS Release Managers"
   openssl genrsa -out $key 2048 > /dev/null 2>&1
-  openssl req -new -subj "/C=/ST=/L=/O=/OU=/CN=$name CernVM-FS Release Managers" -key $key -out $csr > /dev/null 2>&1
+  openssl req -new -subj "/C=/ST=/L=/O=/OU=/CN=$cn" \
+    -key $key -out $csr > /dev/null 2>&1
   openssl x509 -req -days 365 -in $csr -signkey $key -out $crt > /dev/null 2>&1
   rm -f $csr
   chmod 444 $crt

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -1,6 +1,8 @@
 cvmfs_test_name="Populate Repository"
 cvmfs_test_autofs_on_startup=false
 
+CVMFS_TEST500_LONG_REPONAME=
+
 produce_files_in() {
 	local working_dir=$1
 
@@ -19,6 +21,12 @@ produce_files_in() {
 	ln -s clever symlinkToClever
 
 	popdir
+}
+
+cleanup() {
+  if [ "x$CVMFS_TEST500_LONG_REPONAME" != "x" ]; then
+    destroy_repo testrepo.osg-software-2580-el7-cvmfs-stratum-0.novalocal.crt
+  fi
 }
 
 cvmfs_run_test() {
@@ -49,6 +57,17 @@ cvmfs_run_test() {
 
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  echo "*** Maximum repository name with 60 characters (CVM-1173)"
+  CVMFS_TEST500_LONG_REPONAME=testrepo.osg-software-2580-el7-cvmfs-stratum-0.novalocal.crt
+  trap cleanup TERM HUP INT EXIT
+  create_empty_repo $CVMFS_TEST500_LONG_REPONAME $CVMFS_TEST_USER || return $?
+
+  echo "*** Too long name should not pass"
+  create_empty_repo "X$CVMFS_TEST500_LONG_REPONAME" $CVMFS_TEST_USER && return 10
+
+  destroy_repo $CVMFS_TEST500_LONG_REPONAME || return $?
+  CVMFS_TEST500_LONG_REPONAME=
 
   return 0
 }

--- a/test/unittests/t_sanitizer.cc
+++ b/test/unittests/t_sanitizer.cc
@@ -94,3 +94,17 @@ TEST_F(T_Sanitizer, Uuid) {
   EXPECT_FALSE(test_sanitizer.IsValid("abcABC-012/+_"));
   EXPECT_FALSE(test_sanitizer.IsValid("abcABCXYZ"));
 }
+
+TEST_F(T_Sanitizer, Length) {
+  sanitizer::InputSanitizer length0_sanitizer("az", 0);
+  EXPECT_TRUE(length0_sanitizer.IsValid(""));
+  EXPECT_FALSE(length0_sanitizer.IsValid("a"));
+  EXPECT_EQ("", length0_sanitizer.Filter("a"));
+
+  sanitizer::InputSanitizer length3_sanitizer("az", 3);
+  EXPECT_TRUE(length3_sanitizer.IsValid(""));
+  EXPECT_TRUE(length3_sanitizer.IsValid("abc"));
+  EXPECT_FALSE(length3_sanitizer.IsValid("abca"));
+  EXPECT_EQ("abc", length3_sanitizer.Filter("aZXbc"));
+  EXPECT_EQ("abc", length3_sanitizer.Filter("aZXbcYa"));
+}


### PR DESCRIPTION
Fixes two issues with long repository names:

- CN in X.509 certificate
- Unix domain sockets with long paths

Enforce a limit of 60 characters.