### PR TITLE
Fix deprecation warnings for OSSpinLock on macOS 10.12+

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,2 +1,0 @@
-((c++-mode
-  (eval add-hook 'before-save-hook #'clang-format-buffer nil t)))

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -7,6 +7,8 @@
 #ifndef CVMFS_PLATFORM_LINUX_H_
 #define CVMFS_PLATFORM_LINUX_H_
 
+#include <sys/types.h>  // contains ssize_t needed inside <attr/xattr.h>
+#include <sys/xattr.h>
 #include <attr/xattr.h>  // NOLINT(build/include_alpha)
 #include <dirent.h>
 #include <errno.h>
@@ -20,9 +22,7 @@
 #include <sys/prctl.h>
 #include <sys/select.h>
 #include <sys/stat.h>
-#include <sys/types.h>  // contains ssize_t needed inside <attr/xattr.h>
 #include <sys/utsname.h>
-#include <sys/xattr.h>
 #include <unistd.h>
 
 #include <cassert>

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -7,8 +7,6 @@
 #ifndef CVMFS_PLATFORM_LINUX_H_
 #define CVMFS_PLATFORM_LINUX_H_
 
-#include <sys/types.h>  // contains ssize_t needed inside <attr/xattr.h>
-#include <sys/xattr.h>
 #include <attr/xattr.h>  // NOLINT(build/include_alpha)
 #include <dirent.h>
 #include <errno.h>
@@ -22,7 +20,9 @@
 #include <sys/prctl.h>
 #include <sys/select.h>
 #include <sys/stat.h>
+#include <sys/types.h>  // contains ssize_t needed inside <attr/xattr.h>
 #include <sys/utsname.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include <cassert>
@@ -41,7 +41,6 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 #define platform_sighandler_t sighandler_t
 
-
 inline std::vector<std::string> platform_mountlist() {
   std::vector<std::string> result;
   FILE *fmnt = setmntent("/proc/mounts", "r");
@@ -53,12 +52,11 @@ inline std::vector<std::string> platform_mountlist() {
   return result;
 }
 
-
 // glibc < 2.11
 #ifndef MNT_DETACH
 #define MNT_DETACH 0x00000002
 #endif
-inline bool platform_umount(const char* mountpoint, const bool lazy) {
+inline bool platform_umount(const char *mountpoint, const bool lazy) {
   struct stat64 mtab_info;
   int retval = lstat64(_PATH_MOUNTED, &mtab_info);
   // If /etc/mtab exists and is not a symlink to /proc/mount
@@ -67,8 +65,7 @@ inline bool platform_umount(const char* mountpoint, const bool lazy) {
     // crash unmount handlers
     std::string lockfile = std::string(_PATH_MOUNTED) + ".cvmfslock";
     const int fd_lockfile = open(lockfile.c_str(), O_RDONLY | O_CREAT, 0600);
-    if (fd_lockfile < 0)
-      return false;
+    if (fd_lockfile < 0) return false;
     int timeout = 10;
     while ((flock(fd_lockfile, LOCK_EX | LOCK_NB) != 0) && (timeout > 0)) {
       if (errno != EWOULDBLOCK) {
@@ -92,10 +89,8 @@ inline bool platform_umount(const char* mountpoint, const bool lazy) {
       return false;
     }
     FILE *fmntnew = setmntent(mntnew.c_str(), "w+");
-    if (!fmntnew &&
-        (chmod(mntnew.c_str(), mtab_info.st_mode) != 0) &&
-        (chown(mntnew.c_str(), mtab_info.st_uid, mtab_info.st_gid) != 0))
-    {
+    if (!fmntnew && (chmod(mntnew.c_str(), mtab_info.st_mode) != 0) &&
+        (chown(mntnew.c_str(), mtab_info.st_uid, mtab_info.st_gid) != 0)) {
       endmntent(fmntold);
       flock(fd_lockfile, LOCK_UN);
       close(fd_lockfile);
@@ -123,18 +118,16 @@ inline bool platform_umount(const char* mountpoint, const bool lazy) {
     flock(fd_lockfile, LOCK_UN);
     close(fd_lockfile);
     unlink(lockfile.c_str());
-    if (retval != 0)
-      return false;
+    if (retval != 0) return false;
     // Best effort
-    (void) chmod(_PATH_MOUNTED, mtab_info.st_mode);
-    (void) chown(_PATH_MOUNTED, mtab_info.st_uid, mtab_info.st_gid);
+    (void)chmod(_PATH_MOUNTED, mtab_info.st_mode);
+    (void)chown(_PATH_MOUNTED, mtab_info.st_uid, mtab_info.st_gid);
   }
 
   int flags = lazy ? MNT_DETACH : 0;
   retval = umount2(mountpoint, flags);
   return retval == 0;
 }
-
 
 /**
  * Spinlocks are not necessarily part of pthread on all platforms.
@@ -153,14 +146,14 @@ inline int platform_spinlock_trylock(platform_spinlock *lock) {
   return pthread_spin_trylock(lock);
 }
 
+inline void platform_spinlock_unlock(platform_spinlock *lock) {
+  pthread_spin_unlock(lock);
+}
 
 /**
  * pthread_self() is not necessarily an unsigned long.
  */
-inline pthread_t platform_gettid() {
-  return pthread_self();
-}
-
+inline pthread_t platform_gettid() { return pthread_self(); }
 
 inline int platform_sigwait(const int signum) {
   sigset_t sigset;
@@ -171,7 +164,6 @@ inline int platform_sigwait(const int signum) {
   retval = sigwaitinfo(&sigset, NULL);
   return retval;
 }
-
 
 /**
  * Grants a PID capabilites for ptrace() usage
@@ -195,7 +187,6 @@ inline bool platform_allow_ptrace(const pid_t pid) {
   return true;
 #endif
 }
-
 
 /**
  * File system functions, ensure 64bit versions.
@@ -222,8 +213,7 @@ inline int platform_fstat(int filedes, platform_stat64 *buf) {
 
 // TODO(jblomer): the translation from C to C++ should be done elsewhere
 inline bool platform_getxattr(const std::string &path, const std::string &name,
-                              std::string *value)
-{
+                              std::string *value) {
   int size = 0;
   void *buffer = NULL;
   int retval;
@@ -247,31 +237,21 @@ inline bool platform_getxattr(const std::string &path, const std::string &name,
 }
 
 // TODO(jblomer): the translation from C to C++ should be done elsewhere
-inline bool platform_setxattr(
-  const std::string &path,
-  const std::string &name,
-  const std::string &value)
-{
-  int retval = setxattr(
-    path.c_str(), name.c_str(), value.c_str(), value.size(), 0);
+inline bool platform_setxattr(const std::string &path, const std::string &name,
+                              const std::string &value) {
+  int retval =
+      setxattr(path.c_str(), name.c_str(), value.c_str(), value.size(), 0);
   return retval == 0;
 }
 
-
-inline ssize_t platform_lgetxattr(
-  const char *path,
-  const char *name,
-  void *value,
-  size_t size
-) {
+inline ssize_t platform_lgetxattr(const char *path, const char *name,
+                                  void *value, size_t size) {
   return lgetxattr(path, name, value, size);
 }
-
 
 inline ssize_t platform_llistxattr(const char *path, char *list, size_t size) {
   return llistxattr(path, list, size);
 }
-
 
 inline void platform_disable_kcache(int filedes) {
   (void)posix_fadvise(filedes, 0, 0, POSIX_FADV_RANDOM | POSIX_FADV_NOREUSE);
@@ -304,8 +284,7 @@ inline int platform_readahead(int filedes) {
  * @param offset  start offset of the pages to be evicted
  * @param length  number of bytes to be evicted
  */
-inline int platform_invalidate_kcache(const int    fd,
-                                      const off_t  offset,
+inline int platform_invalidate_kcache(const int fd, const off_t offset,
                                       const size_t length) {
   return posix_fadvise(fd, offset, length, POSIX_FADV_DONTNEED);
 }
@@ -314,18 +293,16 @@ inline std::string platform_libname(const std::string &base_name) {
   return "lib" + base_name + ".so";
 }
 
-
-inline const char* platform_getexepath() {
+inline const char *platform_getexepath() {
   static char buf[PATH_MAX] = {0};
   if (strlen(buf) == 0) {
     int ret = readlink("/proc/self/exe", buf, PATH_MAX);
     if (ret > 0 && ret < static_cast<int>(PATH_MAX)) {
-       buf[ret] = 0;
+      buf[ret] = 0;
     }
   }
   return buf;
 }
-
 
 inline uint64_t platform_monotonic_time() {
   struct timespec tp;

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -10,10 +10,16 @@
 #include <alloca.h>
 #include <dirent.h>
 #include <fcntl.h>
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+    __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+#include <os/lock.h>
+#else
 #include <libkern/OSAtomic.h>
+#endif  //  defined(__MAC_OS_X_VERSION_MIN_REQUIRED) &&
+        //  __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+#include <mach-o/dyld.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>
-#include <mach-o/dyld.h>
 #include <signal.h>
 #include <sys/mount.h>
 #include <sys/param.h>
@@ -52,7 +58,6 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 #define platform_sighandler_t sig_t
 
-
 inline std::vector<std::string> platform_mountlist() {
   std::vector<std::string> result;
   struct statfs *mntbufp;
@@ -63,17 +68,30 @@ inline std::vector<std::string> platform_mountlist() {
   return result;
 }
 
-
 inline bool platform_umount(const char *mountpoint, const bool lazy) {
   const int flags = lazy ? MNT_FORCE : 0;
   int retval = unmount(mountpoint, flags);
   return retval == 0;
 }
 
-
 /**
  * Spinlocks on OS X are not in pthread but in OS X specific APIs.
  */
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+    __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+typedef os_unfair_lock platform_spinlock;
+
+inline int platform_spinlock_init(platform_spinlock *lock, int pshared) {
+  *lock = OS_UNFAIR_LOCK_INIT;
+  return 0;
+}
+
+inline int platform_spinlock_destroy(platform_spinlock *lock) { return 0; }
+
+inline int platform_spinlock_trylock(platform_spinlock *lock) {
+  return os_unfair_lock_trylock(lock) ? 0 : -1;
+}
+#else
 typedef OSSpinLock platform_spinlock;
 
 inline int platform_spinlock_init(platform_spinlock *lock, int pshared) {
@@ -86,15 +104,12 @@ inline int platform_spinlock_destroy(platform_spinlock *lock) { return 0; }
 inline int platform_spinlock_trylock(platform_spinlock *lock) {
   return (OSSpinLockTry(lock)) ? 0 : -1;
 }
-
+#endif
 
 /**
  * pthread_self() is not necessarily an unsigned long.
  */
-inline thread_port_t platform_gettid() {
-  return mach_thread_self();
-}
-
+inline thread_port_t platform_gettid() { return mach_thread_self(); }
 
 inline int platform_sigwait(const int signum) {
   sigset_t sigset;
@@ -115,7 +130,6 @@ inline bool platform_allow_ptrace(const pid_t pid) {
   // No-op on Mac OS X
   return true;
 }
-
 
 /**
  * File system functions, Mac OS X has 64bit functions by default.
@@ -139,8 +153,7 @@ inline int platform_fstat(int filedes, platform_stat64 *buf) {
 }
 
 inline bool platform_getxattr(const std::string &path, const std::string &name,
-                              std::string *value)
-{
+                              std::string *value) {
   int size = 0;
   void *buffer = NULL;
   int retval;
@@ -163,39 +176,28 @@ inline bool platform_getxattr(const std::string &path, const std::string &name,
   return true;
 }
 
-inline bool platform_setxattr(
-  const std::string &path,
-  const std::string &name,
-  const std::string &value)
-{
-  int retval = setxattr(
-    path.c_str(), name.c_str(), value.c_str(), value.size(), 0, 0);
+inline bool platform_setxattr(const std::string &path, const std::string &name,
+                              const std::string &value) {
+  int retval =
+      setxattr(path.c_str(), name.c_str(), value.c_str(), value.size(), 0, 0);
   return retval == 0;
 }
 
-
-inline ssize_t platform_lgetxattr(
-  const char *path,
-  const char *name,
-  void *value,
-  size_t size
-) {
+inline ssize_t platform_lgetxattr(const char *path, const char *name,
+                                  void *value, size_t size) {
   return getxattr(path, name, value, size, 0 /* position */, XATTR_NOFOLLOW);
 }
-
 
 inline ssize_t platform_llistxattr(const char *path, char *list, size_t size) {
   return listxattr(path, list, size, XATTR_NOFOLLOW);
 }
-
 
 inline void platform_disable_kcache(int filedes) {
   fcntl(filedes, F_RDAHEAD, 0);
   fcntl(filedes, F_NOCACHE, 1);
 }
 
-inline void platform_invalidate_kcache(const int    fd,
-                                       const off_t  offset,
+inline void platform_invalidate_kcache(const int fd, const off_t offset,
                                        const size_t length) {
   // NOOP
   // TODO(rmeusel): implement
@@ -207,8 +209,8 @@ inline int platform_readahead(int filedes) {
 }
 
 inline bool read_line(FILE *f, std::string *line) {
-  char   *buffer_line = NULL;
-  size_t  buffer_size = 0;
+  char *buffer_line = NULL;
+  size_t buffer_size = 0;
   const int res = getline(&buffer_line, &buffer_size, f);
   if (res < 0) {
     free(buffer_line);
@@ -221,7 +223,6 @@ inline bool read_line(FILE *f, std::string *line) {
   return true;
 }
 
-
 inline uint64_t platform_monotonic_time() {
   uint64_t val_abs = mach_absolute_time();
   // Doing the conversion every time is slow but thread-safe
@@ -231,20 +232,19 @@ inline uint64_t platform_monotonic_time() {
   return val_ns * 1e-9;
 }
 
-
 /**
  * strdupa does not exist on OSX
  */
-#define strdupa(s) strcpy(/* NOLINT(runtime/printf) */\
-  reinterpret_cast<char *>(alloca(strlen((s)) + 1)), (s))
-
+#define strdupa(s)                    \
+  strcpy(/* NOLINT(runtime/printf) */ \
+         reinterpret_cast<char *>(alloca(strlen((s)) + 1)), (s))
 
 inline std::string platform_libname(const std::string &base_name) {
   return "lib" + base_name + ".dylib";
 }
 
-inline const char* platform_getexepath() {
-  static const char* path = _dyld_get_image_name(0);
+inline const char *platform_getexepath() {
+  static const char *path = _dyld_get_image_name(0);
   return path;
 }
 

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -12,13 +12,13 @@
 #include <fcntl.h>
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
     __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
-#include <os/lock.h>
+#include <os/lock.h>  // NOLINT
 #else
 #include <libkern/OSAtomic.h>
 #endif  //  defined(__MAC_OS_X_VERSION_MIN_REQUIRED) &&
         //  __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
 #include <mach-o/dyld.h>
-#include <mach/mach.h>
+#include <mach/mach.h>  // NOLINT
 #include <mach/mach_time.h>
 #include <signal.h>
 #include <sys/mount.h>

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -81,29 +81,39 @@ inline bool platform_umount(const char *mountpoint, const bool lazy) {
     __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
 typedef os_unfair_lock platform_spinlock;
 
-inline int platform_spinlock_init(platform_spinlock *lock, int pshared) {
+inline int platform_spinlock_init(platform_spinlock *lock, int /*pshared*/) {
   *lock = OS_UNFAIR_LOCK_INIT;
   return 0;
 }
 
-inline int platform_spinlock_destroy(platform_spinlock *lock) { return 0; }
+inline int platform_spinlock_destroy(platform_spinlock * /*lock*/) { return 0; }
 
 inline int platform_spinlock_trylock(platform_spinlock *lock) {
   return os_unfair_lock_trylock(lock) ? 0 : -1;
 }
+
+inline void platform_spinlock_unlock(platform_spinlock *lock) {
+  os_unfair_lock_unlock(lock);
+}
+
 #else
 typedef OSSpinLock platform_spinlock;
 
-inline int platform_spinlock_init(platform_spinlock *lock, int pshared) {
+inline int platform_spinlock_init(platform_spinlock *lock, int /*pshared*/) {
   *lock = 0;
   return 0;
 }
 
-inline int platform_spinlock_destroy(platform_spinlock *lock) { return 0; }
+inline int platform_spinlock_destroy(platform_spinlock * /*lock*/) { return 0; }
 
 inline int platform_spinlock_trylock(platform_spinlock *lock) {
-  return (OSSpinLockTry(lock)) ? 0 : -1;
+  return OSSpinLockTry(lock) ? 0 : -1;
 }
+
+inline void platform_spinlock_unlock(platform_spinlock *lock) {
+  OSSpinLockUnlock(lock);
+}
+
 #endif
 
 /**

--- a/test/unittests/t_platforms.cc
+++ b/test/unittests/t_platforms.cc
@@ -8,3 +8,14 @@
 
 // TODO(Radu): Could add some unit tests for all the functions in
 //             platform_{linux,osx}.h
+
+class T_Platform : public ::testing::Test {};
+
+TEST_F(T_Platform, Spinlock) {
+  platform_spinlock lock;
+  platform_spinlock_init(&lock, PTHREAD_PROCESS_PRIVATE);
+  ASSERT_EQ(0, platform_spinlock_trylock(&lock));
+  ASSERT_EQ(-1, platform_spinlock_trylock(&lock));
+  platform_spinlock_unlock(&lock);
+  ASSERT_EQ(0, platform_spinlock_trylock(&lock));
+}

--- a/test/unittests/t_platforms.cc
+++ b/test/unittests/t_platforms.cc
@@ -15,7 +15,7 @@ TEST_F(T_Platform, Spinlock) {
   platform_spinlock lock;
   platform_spinlock_init(&lock, PTHREAD_PROCESS_PRIVATE);
   ASSERT_EQ(0, platform_spinlock_trylock(&lock));
-  ASSERT_EQ(-1, platform_spinlock_trylock(&lock));
+  ASSERT_NE(0, platform_spinlock_trylock(&lock));
   platform_spinlock_unlock(&lock);
   ASSERT_EQ(0, platform_spinlock_trylock(&lock));
 }


### PR DESCRIPTION
Addresses [CVM-1185](https://sft.its.cern.ch/jira/browse/CVM-1185).

Fixes the warning about the deprecation of `OSSpinLock` on macOS 10.12+. On this version of macOS and newer, `os_unfair_lock` is used instead.