### PR TITLE
prevent external server url from inheriting regular server url

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1629,6 +1629,8 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
       download_mgr_->GeoSortServers(&host_chain);
       external_download_mgr_->SetHostChain(host_chain);
     }
+  } else {
+    external_download_mgr_->SetHostChain("");
   }
 
   string proxies = "DIRECT";


### PR DESCRIPTION
See [CVM-1322](https://sft.its.cern.ch/jira/browse/CVM-1322)

It was easy to prevent the inheritance, but now if somebody attempts to use an external server it says "malformed URL" instead of "host returned HTTP error".  It's slightly more informative, but not a lot.  I would like to add an error message saying that the external url was not set, but I can't figure out exactly where to put it.  The debug log shows "failed to fetch Part of ..." but it isn't clear to me where the external fetcher is called from nor how easy it is to check inside of Fetcher::Fetch() for this condition.