### PR TITLE
improve overlayfs error messages & allow ext3 scratch filesystem

### DIFF
--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -150,8 +150,8 @@ cvmfs_server_import() {
   [ x"$keys_location" = "x" ] && die "Please provide the location of the repository security keys (-k)"
 
   if [ $unionfs = "overlayfs" ]; then
-    check_overlayfs                 || die "overlayfs kernel module missing"
-    check_overlayfs_version         || die "Your version of OverlayFS is not supported"
+    local msg
+    msg="`check_overlayfs_version`" || die "$msg"
     echo "Warning: CernVM-FS filesystems using overlayfs may not enforce hard link semantics during publishing."
   else
     check_aufs                      || die "aufs kernel module missing"

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -201,8 +201,8 @@ cvmfs_server_mkfs() {
   is_root                           || die "Only root can create a new repository"
   check_upstream_validity $upstream
   if [ $unionfs = "overlayfs" ]; then
-    check_overlayfs                 || die "overlayfs kernel module missing"
-    check_overlayfs_version         || die "Your version of OverlayFS is not supported"
+    local msg
+    msg="`check_overlayfs_version`" || die "$msg"
     echo "Warning: CernVM-FS filesystems using overlayfs may not enforce hard link semantics during publishing."
   else
     check_aufs                      || die "aufs kernel module missing"

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -473,6 +473,7 @@ check_upstream_validity() {
 
 
 # Ensure that the installed overlayfs is viable for CernVM-FS.
+# Note: More details are in CVM-835.
 # @return  0 if overlayfs is installed and viable
 #          1 if it is not viable, and stdout contains a reason
 # This should probably now be called check_overlayfs_viability except
@@ -496,11 +497,11 @@ check_overlayfs_version() {
     echo "Kernel version $krnl_version too old for overlayfs; at least $required_version required"
     return 1
   fi
-  # if the filesystem name is long df will split output into two lines
-  #  so use tail -n +2 to skip first line and echo to combine them
+  # if the mounted filesystem name is long df will split output into two
+  #  lines, so use tail -n +2 to skip first line and echo to combine them
   local scratch_fstype=$(echo $(df -T /var/spool/cvmfs | tail -n +2) | awk {'print $2'})
   if [ "x$scratch_fstype" != "xext3" ] && [ "x$scratch_fstype" != "xext4" ] ; then
-    echo "overlayfs scratch /var/spool/cvmfs is $scratch_fstype, but ext3 or ext4 required"
+    echo "overlayfs scratch /var/spool/cvmfs is type $scratch_fstype, but ext3 or ext4 required"
     return 1
   fi
   return 0

--- a/cvmfs/server/test_cvmfs_server_util.sh
+++ b/cvmfs/server/test_cvmfs_server_util.sh
@@ -54,8 +54,9 @@ mock_kernel_version="3.10.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
 print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 
-mock_kernel_version="3.10.0-493"
 mock_is_redhat=1 # False
+
+mock_kernel_version="3.10.0-493"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
 print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 

--- a/cvmfs/server/test_cvmfs_server_util.sh
+++ b/cvmfs/server/test_cvmfs_server_util.sh
@@ -14,6 +14,10 @@ print_check() {
 
 ### Testing check_overlayfs_version
 
+check_overlayfs() {
+    return 0
+}
+
 cvmfs_sys_uname() {
     echo $mock_kernel_version
 }
@@ -23,41 +27,50 @@ cvmfs_sys_is_redhat() {
     return $mock_is_redhat
 }
 
-mock_kernel_version="4.2.0"
+
 mock_is_redhat=0 # true
+
+mock_kernel_version="4.2.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 0
+print_check $(check_overlayfs_version >/dev/null; echo $?) 0
 
 mock_kernel_version="4.2.0-100"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 0
+print_check $(check_overlayfs_version >/dev/null; echo $?) 0
 
 mock_kernel_version="3.10.0-493"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 0
+print_check $(check_overlayfs_version >/dev/null; echo $?) 0
 
 mock_kernel_version="3.10.0-999"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 0
+print_check $(check_overlayfs_version >/dev/null; echo $?) 0
 
 mock_kernel_version="3.10.0-492"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 1
+print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 
 mock_kernel_version="3.10.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 1
+print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 
 mock_kernel_version="3.10.0-493"
 mock_is_redhat=1 # False
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 1
+print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 
 mock_kernel_version="3.10.0-492"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 1
+print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 
 mock_kernel_version="3.10.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version; echo $?) 1
+print_check $(check_overlayfs_version >/dev/null; echo $?) 1
 
+mock_kernel_version="4.2.0"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+
+mock_kernel_version="4.2.0-100"
+printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
+print_check $(check_overlayfs_version >/dev/null; echo $?) 0


### PR DESCRIPTION
See [CVM-1186](https://sft.its.cern.ch/jira/browse/CVM-1186)

This also applies the filesystem check to non-redhat systems with kernels >= 4.2.0 which I think was the original intention.