### PR TITLE
CVM-1337 Unified logging for storage gateway

### DIFF
--- a/cvmfs/logging.cc
+++ b/cvmfs/logging.cc
@@ -189,6 +189,10 @@ void SetLogSyslogPrefix(const std::string &prefix) {
   }
 }
 
+void SetLogSyslogShowPID(bool flag) {
+  openlog(NULL, flag ? LOG_PID : 0, GetLogSyslogFacility());
+}
+
 /**
  * Set the minimum verbosity level.  By default kLogNormal.
  */

--- a/cvmfs/logging_internal.h
+++ b/cvmfs/logging_internal.h
@@ -90,6 +90,7 @@ void SetLogCustomFile(unsigned id, const std::string &filename);
 void SetLogMicroSyslog(const std::string &filename);
 std::string GetLogMicroSyslog();
 void SetLogSyslogPrefix(const std::string &prefix);
+void SetLogSyslogShowPID(bool flag);
 void SetLogVerbosity(const LogLevels min_level);
 void LogShutdown();
 

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -140,7 +140,7 @@ template <typename RwCatalogMgr, typename RoCatalogMgr>
 bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::CreateNewManifest(
     std::string* new_manifest_path) {
   if (!output_catalog_mgr_->Commit(false, 0, manifest_)) {
-    LogCvmfs(kLogReceiver, kLogCustom1,
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
              "CatalogMergeTool - Could not commit output catalog");
     return false;
   }
@@ -149,7 +149,7 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::CreateNewManifest(
   const std::string new_path = temp_dir + "/new_manifest";
 
   if (!manifest_->Export(new_path)) {
-    LogCvmfs(kLogReceiver, kLogCustom1,
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
              "CatalogMergeTool - Could not export new manifest");
   }
 

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -48,7 +48,7 @@ CommitProcessor::~CommitProcessor() {}
 CommitProcessor::Result CommitProcessor::Process(
     const std::string& lease_path, const shash::Any& old_root_hash,
     const shash::Any& new_root_hash) {
-  LogCvmfs(kLogReceiver, kLogCustom0,
+  LogCvmfs(kLogReceiver, kLogSyslogErr,
            "CommitProcessor - committing: %s, old hash: %s, new hash: %s",
            lease_path.c_str(), old_root_hash.ToString(true).c_str(),
            new_root_hash.ToString(true).c_str());
@@ -78,7 +78,7 @@ CommitProcessor::Result CommitProcessor::Process(
 
   // Current catalog from the gateway machine
   if (!manifest.IsValid()) {
-    LogCvmfs(kLogReceiver, kLogCustom1,
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
              "Could not open repository manifest");
     return kIoError;
   }
@@ -100,7 +100,7 @@ CommitProcessor::Result CommitProcessor::Process(
 
   std::string new_manifest_path;
   if (!merge_tool.Run(params, &new_manifest_path)) {
-    LogCvmfs(kLogReceiver, kLogCustom1, "Catalog merge failed");
+    LogCvmfs(kLogReceiver, kLogSyslogErr, "Catalog merge failed");
     return kMergeError;
   }
 
@@ -117,7 +117,7 @@ CommitProcessor::Result CommitProcessor::Process(
                        params.spooler_configuration, temp_dir, certificate,
                        private_key, repo_name, "", "",
                        "/var/spool/cvmfs/" + repo_name + "/reflog.chksum")) {
-    LogCvmfs(kLogReceiver, kLogCustom1, "Error signing manifest");
+    LogCvmfs(kLogReceiver, kLogSyslogErr, "Error signing manifest");
     return kIoError;
   }
 

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -118,11 +118,8 @@ bool Reactor::Run() {
   do {
     msg_body.clear();
     req = ReadRequest(fdin_, &msg_body);
-    LogCvmfs(kLogReceiver, kLogCustom0,
-             "Reactor - handling request: %d, body: %s.", req,
-             msg_body.c_str());
     if (!HandleRequest(req, msg_body)) {
-      LogCvmfs(kLogReceiver, kLogCustom1,
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
                "Reactor: could not handle request %d. Exiting", req);
       return false;
     }
@@ -232,7 +229,7 @@ bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
       break;
     default:
       // Should not be reached
-      LogCvmfs(kLogReceiver, kLogCustom1,
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
                "Reactor::HandleCheckToken - Unknown value received. Exiting.");
       abort();
   }
@@ -286,7 +283,7 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
       reply_input.push_back(std::make_pair("status", "ok"));
       break;
     default:
-      LogCvmfs(kLogReceiver, kLogCustom1,
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
                "Unknown value of PayloadProcessor::Result encountered.");
       abort();
       break;
@@ -342,7 +339,7 @@ bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
       reply_input.push_back(std::make_pair("reason", "io_error"));
       break;
     default:
-      LogCvmfs(kLogReceiver, kLogCustom1,
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
                "Unknown value of CommitProcessor::Result encountered.");
       abort();
       break;
@@ -369,7 +366,7 @@ bool Reactor::HandleRequest(Request req, const std::string& data) {
       ok = WriteReply(fdout_, "ok");
       break;
     case kEcho:
-      ok = WriteReply(fdout_, data);
+      ok = WriteReply(fdout_, std::string("PID: ") + StringifyUint(getpid()));
       break;
     case kGenerateToken:
       ok &= HandleGenerateToken(data, &reply);
@@ -392,7 +389,7 @@ bool Reactor::HandleRequest(Request req, const std::string& data) {
       ok &= WriteReply(fdout_, reply);
       break;
     case kError:
-      LogCvmfs(kLogReceiver, kLogCustom1,
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
                "Reactor: unknown command received.");
       ok = false;
       break;

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -17,8 +17,6 @@ swissknife::ParameterList MakeParameterList() {
       swissknife::Parameter::Optional('i', "File descriptor to use for input"));
   params.push_back(swissknife::Parameter::Optional(
       'o', "File descriptor to use for output"));
-  params.push_back(
-      swissknife::Parameter::Optional('l', "Base name of the log file to use"));
   return params;
 }
 
@@ -50,10 +48,10 @@ bool ReadCmdLineArguments(int argc, char** argv,
     }
 
     if (!valid_option) {
-      LogCvmfs(kLogReceiver, kLogStdout,
+      LogCvmfs(kLogReceiver, kLogSyslog,
                "CVMFS gateway services receiver component. Usage:");
       for (size_t i = 0; i < params.size(); ++i) {
-        LogCvmfs(kLogReceiver, kLogStdout, "  \"%c\" - %s", params[i].key(),
+        LogCvmfs(kLogReceiver, kLogSyslog, "  \"%c\" - %s", params[i].key(),
                  params[i].description().c_str());
       }
       return false;
@@ -63,7 +61,7 @@ bool ReadCmdLineArguments(int argc, char** argv,
   for (size_t j = 0; j < params.size(); ++j) {
     if (!params[j].optional()) {
       if (arguments->find(params[j].key()) == arguments->end()) {
-        LogCvmfs(kLogReceiver, kLogStderr, "parameter -%c missing",
+        LogCvmfs(kLogReceiver, kLogSyslogErr, "parameter -%c missing",
                  params[j].key());
         return false;
       }
@@ -79,8 +77,9 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  std::string output_log_file = "/tmp/cvmfs_receiver.out";
-  std::string error_log_file = "/tmp/cvmfs_receiver.err";
+  SetLogSyslogFacility(1);
+  SetLogSyslogShowPID(true);
+
   int fdin = 0;
   int fdout = 1;
   if (arguments.find('i') != arguments.end()) {
@@ -89,22 +88,18 @@ int main(int argc, char** argv) {
   if (arguments.find('o') != arguments.end()) {
     fdout = std::atoi(arguments.find('o')->second->c_str());
   }
-  if (arguments.find('l') != arguments.end()) {
-    const std::string base_log_file = *(arguments.find('l')->second);
-    output_log_file = base_log_file + ".out";
-    error_log_file = base_log_file + ".err";
-  }
 
-  SetLogCustomFile(0, output_log_file);
-  SetLogCustomFile(1, error_log_file);
+  LogCvmfs(kLogReceiver, kLogSyslog, "CVMFS receiver started");
 
   receiver::Reactor reactor(fdin, fdout);
 
   if (!reactor.Run()) {
-    LogCvmfs(kLogReceiver, kLogCustom1,
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
              "Error running CVMFS Receiver event loop");
     return 1;
   }
+
+  LogCvmfs(kLogReceiver, kLogSyslog, "CVMFS receiver finished");
 
   return 0;
 }

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -90,7 +90,7 @@ TEST_F(T_Reactor, kEcho_kQuit) {
 
   std::string reply;
   ASSERT_TRUE(Reactor::ReadReply(from_reactor_[0], &reply));
-  ASSERT_EQ("Hey", reply);
+  ASSERT_EQ("PID", reply.substr(0, 3));
 
   ASSERT_TRUE(Reactor::WriteRequest(to_reactor_[1], Reactor::kQuit, ""));
 


### PR DESCRIPTION
This addresses [CVM-1337](https://sft.its.cern.ch/jira/browse/CVM-1337) on the `cvmfs_receiver` side.

`cvmfs_receiver` now does all logging into syslog. The syslog and logrotate configurations for `cvmfs_receiver` are installed by the storage gateway application in its own set up script.