### PR TITLE
Fixing integration test 641-diff

### DIFF
--- a/test/src/641-diff/main
+++ b/test/src/641-diff/main
@@ -80,6 +80,8 @@ S N 1
 M[TN] D /dir2
 A F /dir2/.cvmfscatalog
 A D /dir3
+A F /dir3/new_file
+A F /dir3/.cvmfscatalog
 M[STC] F /file
 R S /symlink
 M[T] D /directory


### PR DESCRIPTION
The output of the `cvmfs_server diff` command has changed and the output
expected in the test was out of date.