### PR TITLE
Reactivate integration tests for CVMFS Repository Services

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -45,6 +45,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/5*                                       \
                                  src/6*                                       \
                                  src/7*                                       \
+                                 src/8*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -74,6 +74,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/5*                                       \
                                  src/6*                                       \
                                  src/7*                                       \
+                                 src/8*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -67,6 +67,7 @@ if [ x"$(uname -m)" = x"x86_64" ]; then
                                    src/5*                                       \
                                    src/6*                                       \
                                    src/7*                                       \
+                                   src/8*                                       \
                                 || retval=1
 fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2363,29 +2363,33 @@ find_or_build_cvmfs_preload() {
 set_up_repository_services() {
     echo "Setting up repository services"
 
-    local package_url_root=http://ecsft.cern.ch/dist/cvmfs/cvmfs-services/cvmfs_services-$CVMFS_SERVICES_VERSION
-    local cvmfs_services_package_url=""
+    local package_url_root=$CVMFS_SERVICES_URL
+
     # Choose which package to download and install based on platform
     if [ -f /etc/lsb-release ]; then
         if [ x"$(lsb_release -cs)" = x"xenial" ]; then
-            cvmfs_services_package_url=${package_url_root}-ubuntu1604-x86_64.tar.gz
-            echo "Using package: $cvmfs_services_package_url"
+            package_map_url=${package_url_root}/pkgmap/pkgmap.ubuntu1604_x86_64
         fi
     elif [ -f /etc/redhat-release ]; then
         rhver=$(cat /etc/redhat-release | awk {'print $(NF-1)'} | cut -d'.' -f1)
         if [ $((rhver == 6)) -o $((rhver == 7)) ]; then
-            cvmfs_services_package_url=${package_url_root}-centos${rhver}-x86_64.tar.gz
-            echo "Using package: $cvmfs_services_package_url"
+            package_map_url=${package_url_root}/pkgmap/pkgmap.centos${rhver}_x86_64
         fi
     fi
 
-    if [ x"$cvmfs_services_package_url" = x"" ]; then
+    if [ x"$package_map_url" = x"" ]; then
         echo "Platform not supported. Exiting"
         exit 1
     fi
 
     echo "  Installing the cvmfs_services application"
     pushd /tmp
+
+    curl -o package_map $package_map_url
+
+    local cvmfs_services_package_url=${package_url_root}/$(tail -1 package_map | cut -d'=' -f2)
+    echo "    Using package: $cvmfs_services_package_url"
+    
     local cvmfs_services_package_file_name=$(echo $cvmfs_services_package_url | awk -F'/' {'print $NF'})
 
     if [ ! -f "/tmp/$cvmfs_services_package_file_name" ]; then


### PR DESCRIPTION
Addresses [CVM-1354](https://sft.its.cern.ch/jira/browse/CVM-1354).

This can be merged after the 2.4.0 release is branched.

Reactivates the integration tests for the repository services application, now that building the repo services tarball has been integrated with Jenkins CI.

* Update integration test scripts to pick up the repo services tarball from it's new location (where it is placed by the CvmfsBuildRepoServices Jenkins job)
* Re-enable integrations tests 80x for Ubuntu 1604, SLC6, CC7