### PR TITLE
Make `true` to be a valid boolean option.

### DIFF
--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -363,7 +363,8 @@ bool OptionsManager::GetSource(const string &key, string *value) {
 
 bool OptionsManager::IsOn(const std::string &param_value) {
   const string uppercase = ToUpper(param_value);
-  return ((uppercase == "YES") || (uppercase == "ON") || (uppercase == "1"));
+  return ((uppercase == "YES") || (uppercase == "ON") || (uppercase == "1") ||
+          (uppercase == "TRUE"));
 }
 
 

--- a/test/unittests/t_raii_temp_dir.cc
+++ b/test/unittests/t_raii_temp_dir.cc
@@ -19,7 +19,8 @@ static bool DirExists(const std::string& dir) {
 class T_RaiiTempDir : public ::testing::Test {};
 
 TEST_F(T_RaiiTempDir, Basic) {
-  UniquePtr<RaiiTempDir> temp_dir(RaiiTempDir::Create(GetCurrentWorkingDirectory() + "/test_dir"));
+  UniquePtr<RaiiTempDir> temp_dir(
+      RaiiTempDir::Create(GetCurrentWorkingDirectory() + "/test_dir"));
   ASSERT_TRUE(temp_dir.IsValid());
 
   const std::string temp_path = temp_dir->dir();
@@ -30,7 +31,8 @@ TEST_F(T_RaiiTempDir, Basic) {
 }
 
 TEST_F(T_RaiiTempDir, DeletedExternally) {
-  UniquePtr<RaiiTempDir> temp_dir(RaiiTempDir::Create(GetCurrentWorkingDirectory() + "/test_dir"));
+  UniquePtr<RaiiTempDir> temp_dir(
+      RaiiTempDir::Create(GetCurrentWorkingDirectory() + "/test_dir"));
   ASSERT_TRUE(temp_dir.IsValid());
 
   const std::string temp_path = temp_dir->dir();

--- a/test/unittests/t_raii_temp_dir.cc
+++ b/test/unittests/t_raii_temp_dir.cc
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
-#include <util/pointer.h>
-#include <util/raii_temp_dir.h>
+#include "util/pointer.h"
+#include "util/raii_temp_dir.h"
 
 #include "platform.h"
 #include "util/posix.h"
@@ -19,7 +19,7 @@ static bool DirExists(const std::string& dir) {
 class T_RaiiTempDir : public ::testing::Test {};
 
 TEST_F(T_RaiiTempDir, Basic) {
-  UniquePtr<RaiiTempDir> temp_dir(RaiiTempDir::Create("/tmp/test_dir"));
+  UniquePtr<RaiiTempDir> temp_dir(RaiiTempDir::Create(GetCurrentWorkingDirectory() + "/test_dir"));
   ASSERT_TRUE(temp_dir.IsValid());
 
   const std::string temp_path = temp_dir->dir();
@@ -30,7 +30,7 @@ TEST_F(T_RaiiTempDir, Basic) {
 }
 
 TEST_F(T_RaiiTempDir, DeletedExternally) {
-  UniquePtr<RaiiTempDir> temp_dir(RaiiTempDir::Create("/tmp/test_dir"));
+  UniquePtr<RaiiTempDir> temp_dir(RaiiTempDir::Create(GetCurrentWorkingDirectory() + "/test_dir"));
   ASSERT_TRUE(temp_dir.IsValid());
 
   const std::string temp_path = temp_dir->dir();


### PR DESCRIPTION
Currently, `YES`, `ON`, or `1` indicate truth for a boolean option; this also allows `TRUE`.