### PR TITLE
Minor fixups from debugging external cache plugins.

### DIFF
--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -185,8 +185,16 @@ int ExternalCacheManager::ConnectLocator(const std::string &locator) {
   } else {
     return -EINVAL;
   }
-  if (result < 0)
+  if (result < 0) {
+    if (errno) {
+      LogCvmfs(kLogCache, kLogDebug | kLogStderr,
+               "Failed to connect to socket: %s", strerror(errno));
+    } else {
+      LogCvmfs(kLogCache, kLogDebug | kLogStderr,
+               "Failed to connect to socket (unknown error)");
+    }
     return -EIO;
+  }
   LogCvmfs(kLogCache, kLogDebug | kLogSyslog,
            "connected to cache plugin at %s", locator.c_str());
   return result;
@@ -262,8 +270,14 @@ ExternalCacheManager::PluginHandle *ExternalCacheManager::CreatePlugin(
     if (plugin_handle->IsValid()) {
       break;
     } else if (plugin_handle->fd_connection_ == -EINVAL) {
+      LogCvmfs(kLogCache, kLogDebug | kLogSyslog,
+               "Invalid locator: %s", locator.c_str());
       plugin_handle->error_msg_ = "Invalid locator: " + locator;
+      break;
     } else {
+      if (num_attempts > 1) LogCvmfs(kLogCache, kLogDebug | kLogStderr,
+                                     "Failed to connect to external cache manager: %d",
+                                     plugin_handle->fd_connection_);
       plugin_handle->error_msg_ = "Failed to connect to external cache manager";
     }
 
@@ -677,7 +691,7 @@ bool ExternalCacheManager::SpawnPlugin(const vector<string> &cmd_line) {
   retval = ManagedExec(cmd_line,
                        preserve_filedes,
                        map_fildes,
-                       false,  // drop_credentials
+                       true,   // drop_credentials
                        true,   // double fork
                        &child_pid);
   unsetenv(CacheTransport::kEnvReadyNotifyFd);

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -24,7 +24,7 @@ using namespace std;  // NOLINT
 
 namespace {
 
-static shash::Any Chash2Cpphash(struct cvmcache_hash *h) {
+static shash::Any Chash2Cpphash(const struct cvmcache_hash *h) {
   shash::Any hash;
   memcpy(hash.digest, h->digest, sizeof(h->digest));
   hash.algorithm = static_cast<shash::Algorithms>(h->algorithm);
@@ -266,7 +266,7 @@ int cvmcache_hash_cmp(struct cvmcache_hash *a, struct cvmcache_hash *b) {
     return 1;
 }
 
-char *cvmcache_hash_print(struct cvmcache_hash *h) {
+char *cvmcache_hash_print(const struct cvmcache_hash *h) {
   const shash::Any hash = Chash2Cpphash(h);
   return strdup(hash.ToString().c_str());
 }

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -101,7 +101,7 @@ int cvmcache_hash_cmp(struct cvmcache_hash *a, struct cvmcache_hash *b);
 /**
  * The caller has to free the resulting string
  */
-char *cvmcache_hash_print(struct cvmcache_hash *h);
+char *cvmcache_hash_print(const struct cvmcache_hash *h);
 
 /**
  * According to capabilities, some of the callbacks can be NULL


### PR DESCRIPTION
For the most part, this just adds a few logging messages to make misconfigurations more obvious.  

Two significant changes:
- Make an invalid locator string a fatal error (instead of indefinitely retrying it).
- Launch the external plugin as the `cvmfs` user.