### PR TITLE
Tiered cache txn should succeed if upper tier txn does.

### DIFF
--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -187,7 +187,13 @@ int TieredCacheManager::CommitTxn(void *txn) {
     lower_result = lower_->CommitTxn(txn2);
   }
 
-  return (upper_result < 0) ? upper_result : lower_result;
+  // Transaction is successful as long as the storage was successful
+  // in the upper cache (which may have already handed out a FD via
+  // OpenFromTxn).
+  //
+  // If there wasn't the OpenFromTxn semantics, we could have this
+  // call succeed if *either* transaction was successful.
+  return upper_result;
 }
 
 

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "logging.h"
 #include "platform.h"
 #include "quota.h"
 
@@ -193,6 +194,10 @@ int TieredCacheManager::CommitTxn(void *txn) {
   //
   // If there wasn't the OpenFromTxn semantics, we could have this
   // call succeed if *either* transaction was successful.
+  if (!upper_result && lower_result) {
+    LogCvmfs(kLogCache, kLogSyslogWarn | kLogDebug, "Commit of transaction "
+             "failed in lower cache but succeeded in upper cache.");
+  }
   return upper_result;
 }
 


### PR DESCRIPTION
Previously, the tiered cache counted a transaction as successful if *both* caches had a successful transaction.  Thus, the reliability of the tiered cache was the _AND_ of both caches -- i.e., slightly decreased.

This changes the success metric so the transaction commit succeeds if and only if the upper cache transaction works (the upper cache *must* work because we may have handed out a FD to the cache via OpenFromTxn already).

@jblomer - will you merge `cvmfs-2.4` into `devel`?  Or should I do a separate PR?