### PR TITLE
Fix off-by-one error for chunk size.

### DIFF
--- a/cvmfs/swissknife_graft.cc
+++ b/cvmfs/swissknife_graft.cc
@@ -89,7 +89,7 @@ bool swissknife::CommandGraft::ChecksumFdWithChunks(
     }
 
     // Start a new hash if current one is above threshold
-    if (do_chunk && (*file_size - chunk_offsets->back() > chunk_size_)) {
+    if (do_chunk && (*file_size - chunk_offsets->back() >= chunk_size_)) {
       shash::Final(chunk_hash_context, &chunk_hash);
       chunk_offsets->push_back(*file_size);
       chunk_checksums->push_back(chunk_hash);


### PR DESCRIPTION
Previously, a new chunk would be emitted after `N+(buffer size)` bytes when the user requested N bytes for chunk size.  So, if the user wanted a 24MB chunk, CVMFS would create `24MB+16KB` chunks.

This corrects the issue; 24MB chunks are created when 24MB chunks are requested for grafts.

(cherry picked from commit 6ea4d9504e2bf313e9740b9d824b01e5d22958ef; backport of #1962)