### PR TITLE
Fixing pkgmap names in test_functions::set_up_repository_services

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -2372,9 +2372,9 @@ set_up_repository_services() {
         fi
     elif is_redhat; then
         rhver=$(cat /etc/redhat-release | awk {'print $(NF-1)'} | cut -d'.' -f1)
-        if [ $((rhver == 6)) ]; then
-           package_map_url=${package_url_root}/pkgmap/pkgmap.slc6_x86_64
-        elif [ $((rhver == 7)) ]; then
+        if [ x"$rhver" = x6 ]; then
+            package_map_url=${package_url_root}/pkgmap/pkgmap.slc6_x86_64
+        elif [ x"$rhver" = x7 ]; then
             package_map_url=${package_url_root}/pkgmap/pkgmap.cc7_x86_64
         fi
     fi
@@ -2387,6 +2387,7 @@ set_up_repository_services() {
     echo "  Installing the cvmfs_services application"
     pushd /tmp
 
+    echo "Package map URL: ${package_map_url}"
     curl -o package_map $package_map_url
 
     local cvmfs_services_package_url=${package_url_root}/$(tail -1 package_map | cut -d'=' -f2)

--- a/test/test_functions
+++ b/test/test_functions
@@ -2370,10 +2370,12 @@ set_up_repository_services() {
         if [ x"$(lsb_release -cs)" = x"xenial" ]; then
             package_map_url=${package_url_root}/pkgmap/pkgmap.ubuntu1604_x86_64
         fi
-    elif [ -f /etc/redhat-release ]; then
+    elif is_redhat; then
         rhver=$(cat /etc/redhat-release | awk {'print $(NF-1)'} | cut -d'.' -f1)
-        if [ $((rhver == 6)) -o $((rhver == 7)) ]; then
-            package_map_url=${package_url_root}/pkgmap/pkgmap.centos${rhver}_x86_64
+        if [ $((rhver == 6)) ]; then
+           package_map_url=${package_url_root}/pkgmap/pkgmap.slc6_x86_64
+        elif [ $((rhver == 7)) ]; then
+            package_map_url=${package_url_root}/pkgmap/pkgmap.cc7_x86_64
         fi
     fi
 
@@ -2389,7 +2391,7 @@ set_up_repository_services() {
 
     local cvmfs_services_package_url=${package_url_root}/$(tail -1 package_map | cut -d'=' -f2)
     echo "    Using package: $cvmfs_services_package_url"
-    
+
     local cvmfs_services_package_file_name=$(echo $cvmfs_services_package_url | awk -F'/' {'print $NF'})
 
     if [ ! -f "/tmp/$cvmfs_services_package_file_name" ]; then


### PR DESCRIPTION
This fixes the GW services integration tests on RedHat platforms.