### PR TITLE
Fix some issues discovered during large publications with GW backend

### DIFF
--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -132,6 +132,9 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
       continue;
     } else if (IsSmaller(old_entry, new_entry)) {
       i_from++;
+      if (old_entry.IsDirectory()) {
+        DiffRec(old_path);
+      }
       ReportRemoval(old_path, old_entry);
       continue;
     }

--- a/cvmfs/server/cvmfs_server_abort.sh
+++ b/cvmfs/server/cvmfs_server_abort.sh
@@ -94,7 +94,7 @@ cvmfs_server_abort() {
     # the cvmfs_swissknife lease command needs to be used to drop the active lease
     if [ x"$upstream_type" = xgw ]; then
         local repo_services_url=$(echo $upstream_storage | cut -d',' -f3)
-        __swissknife lease -a drop -u $repo_services_url -k $gw_key_file -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; continue; }
+        __swissknife lease -a drop -u $repo_services_url -k $gw_key_file -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; }
     fi
     close_transaction $name $use_fd_fallback
 

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -124,7 +124,8 @@ int CommandLease::Main(const ArgumentList& args) {
         if (!buffer.data.empty() && ParseDropReply(buffer)) {
           std::fclose(token_file);
           if (unlink(token_file_name.c_str())) {
-            LogCvmfs(kLogCvmfs, kLogStderr, "Warning - Could not delete session token file.");
+            LogCvmfs(kLogCvmfs, kLogStderr,
+                     "Warning - Could not delete session token file.");
           }
           return kLeaseSuccess;
         } else {

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -29,14 +29,14 @@ bool CheckParams(const swissknife::CommandLease::Parameters& p) {
 namespace swissknife {
 
 enum LeaseError {
-  kLeaseSuccess = 0,
-  kLeaseUnused = 1,
-  kLeaseParamError = 2,
-  kLeaseCurlInitError = 3,
-  kLeaseFileOpenError = 4,
-  kLeaseFileDeleteError = 5,
-  kLeaseParseError = 6,
-  kLeaseCurlReqError = 7,
+  kLeaseSuccess,
+  kLeaseUnused,
+  kLeaseParamError,
+  kLeaseKeyParseError,
+  kLeaseCurlInitError,
+  kLeaseFileOpenError,
+  kLeaseParseError,
+  kLeaseCurlReqError,
 };
 
 CommandLease::~CommandLease() {}
@@ -80,7 +80,7 @@ int CommandLease::Main(const ArgumentList& args) {
   if (!gateway::ReadKeys(params.key_file, &key_id, &secret)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Error reading key file %s.",
              params.key_file.c_str());
-    return 1;
+    return kLeaseKeyParseError;
   }
 
   LeaseError ret = kLeaseSuccess;
@@ -121,13 +121,12 @@ int CommandLease::Main(const ArgumentList& args) {
       CurlBuffer buffer;
       if (MakeEndRequest("DELETE", key_id, secret, session_token,
                          params.repo_service_url, "", &buffer)) {
-        if (buffer.data.size() > 0 && ParseDropReply(buffer)) {
+        if (!buffer.data.empty() && ParseDropReply(buffer)) {
           std::fclose(token_file);
           if (unlink(token_file_name.c_str())) {
-            LogCvmfs(kLogCvmfs, kLogStderr,
-                     "Error deleting session token file");
-            ret = kLeaseFileDeleteError;
+            LogCvmfs(kLogCvmfs, kLogStderr, "Warning - Could not delete session token file.");
           }
+          return kLeaseSuccess;
         } else {
           LogCvmfs(kLogCvmfs, kLogStderr, "Could not drop active lease");
           ret = kLeaseParseError;
@@ -137,7 +136,7 @@ int CommandLease::Main(const ArgumentList& args) {
         ret = kLeaseCurlReqError;
       }
 
-      fclose(token_file);
+      std::fclose(token_file);
     } else {
       LogCvmfs(kLogCvmfs, kLogStderr, "Error reading session token from file");
       ret = kLeaseFileOpenError;

--- a/test/src/800-repository_services/main
+++ b/test/src/800-repository_services/main
@@ -46,6 +46,18 @@ save_repo_contents() {
 run_transactions() {
     set_up_repository_services
 
+    echo "Pre-checks"
+
+    ## Pre-checks: starting and aborting transactions should leave no trace
+    cvmfs_server transaction -e test.repo.org
+    cvmfs_server abort -f -e test.repo.org
+    cvmfs_server check test.repo.org
+
+    cvmfs_server transaction -e test.repo.org
+    cp -r /usr/bin /cvmfs/test.repo.org
+    cvmfs_server abort -f -e test.repo.org
+    cvmfs_server check test.repo.org
+
     echo "Checking transaction + publish"
 
     ## Transaction 1 (Modifying existing file and creating a new one)

--- a/test/src/800-repository_services/main
+++ b/test/src/800-repository_services/main
@@ -61,6 +61,7 @@ run_transactions() {
 
     echo "  Publishing changes 1"
     cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_1
@@ -77,6 +78,7 @@ run_transactions() {
 
     echo "  Publishing changes 2"
     cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_2
@@ -91,6 +93,7 @@ run_transactions() {
 
     echo "  Publishing changes 3"
     cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_3
@@ -107,6 +110,7 @@ run_transactions() {
 
     echo "  Publishing changes 4"
     cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_4
@@ -123,6 +127,7 @@ run_transactions() {
 
     echo "  Publishing changes 5"
     cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_5
@@ -135,6 +140,7 @@ run_transactions() {
 
     echo "  Publishing changes 6"
     cvmfs_server publish -e test.repo.org/new/c
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_6
@@ -147,6 +153,7 @@ run_transactions() {
 
     echo "  Publishing changes 7"
     cvmfs_server publish -e test.repo.org/new/c
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_7

--- a/test/src/801-repository_services_slow/main
+++ b/test/src/801-repository_services_slow/main
@@ -61,7 +61,7 @@ run_transactions() {
     echo "  Copying the payload into repository"
     rm -v /cvmfs/test.repo.org/new_repository
     if [ ! -d /tmp/linux-4.12.8 ]; then
-        curl -o /tmp/linux.tar.xz https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.12.8.tar.xz
+        curl -o /tmp/linux.tar.xz http://ecsft.cern.ch/dist/cvmfs/test-data/linux-4.12.8.tar.xz
         cd /tmp/
         tar xf linux.tar.xz
         cd

--- a/test/src/801-repository_services_slow/main
+++ b/test/src/801-repository_services_slow/main
@@ -75,7 +75,21 @@ run_transactions() {
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out
 
+    ## Transaction 2 (remove all the files from the repo)
+
+    echo "  Starting transaction 2"
+    cvmfs_server transaction -e test.repo.org
+
+    echo "  Removing all the files from the repository"
+    rm -rf /cvmfs/test.repo.org/*
+
+    echo "  Publishing changes 2"
+    cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
+
     ## Check results with a poor man's Merkle tree
+    echo "Checking results"
+
     local hash_in=$(compute_root_hash /tmp/linux-4.12.8)
     local hash_out=$(compute_root_hash /tmp/cvmfs_out/linux-4.12.8)
     echo "Input hash  : $hash_in"

--- a/test/src/801-repository_services_slow/main
+++ b/test/src/801-repository_services_slow/main
@@ -70,6 +70,7 @@ run_transactions() {
 
     echo "  Publishing changes 1"
     cvmfs_server publish -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out

--- a/test/src/801-repository_services_slow/main
+++ b/test/src/801-repository_services_slow/main
@@ -2,12 +2,12 @@ cvmfs_test_name="Repository services Slow"
 cvmfs_test_autofs_on_startup=false
 
 # A "stress test" variant of test #800 for the repository services application
-# The contents of /usr/bin are copied are published to a new CVMFS repository
+# The sources of the Linux kernel are published to a new CVMFS repository
 # configured with the GW backend. The contents are copied back out of the
 # repository into /tmp/cvmfs_out.
 # To do an integrity check, the SHA1 digest of each file is computed as well
 # as the SHA1 digest of the list of file digests - a root hash.
-# The root hash, thus computed, of /usr/bin and /tmp/cvmfs_out are compared.
+# The root hashes, thus computed, of the input and /tmp/cvmfs_out are compared.
 
 clean_up() {
     echo "Cleaning up"
@@ -58,9 +58,15 @@ run_transactions() {
     echo "  Starting transaction 1"
     cvmfs_server transaction -e test.repo.org
 
-    echo "  Copying the contents of /usr/bin into repository"
+    echo "  Copying the payload into repository"
     rm -v /cvmfs/test.repo.org/new_repository
-    cp -rv /usr/bin/* /cvmfs/test.repo.org/
+    if [ ! -d /tmp/linux-4.12.8 ]; then
+        curl -o /tmp/linux.tar.xz https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.12.8.tar.xz
+        cd /tmp/
+        tar xf linux.tar.xz
+        cd
+    fi
+    cp -r /tmp/linux-4.12.8 /cvmfs/test.repo.org/
 
     echo "  Publishing changes 1"
     cvmfs_server publish -e test.repo.org
@@ -69,8 +75,8 @@ run_transactions() {
     save_repo_contents /tmp/cvmfs_out
 
     ## Check results with a poor man's Merkle tree
-    local hash_in=$(compute_root_hash /usr/bin)
-    local hash_out=$(compute_root_hash /tmp/cvmfs_out)
+    local hash_in=$(compute_root_hash /tmp/linux-4.12.8)
+    local hash_out=$(compute_root_hash /tmp/cvmfs_out/linux-4.12.8)
     echo "Input hash  : $hash_in"
     echo "Output hash : $hash_out"
     if [ "$hash_in" != "$hash_out" ]; then

--- a/test/src/802-repository_services_nested_catalogs/main
+++ b/test/src/802-repository_services_nested_catalogs/main
@@ -61,6 +61,7 @@ run_transactions() {
 
     echo "  Publishing changes 1"
     cvmfs_server publish -v -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_1
@@ -86,6 +87,7 @@ run_transactions() {
 
     echo "  Publishing changes 2"
     cvmfs_server publish -v -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_2
@@ -109,6 +111,7 @@ run_transactions() {
 
     echo "  Publishing changes 3"
     cvmfs_server publish -v -e test.repo.org
+    cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
     save_repo_contents /tmp/cvmfs_out_3


### PR DESCRIPTION
This addresses [CVM-1359](https://sft.its.cern.ch/jira/browse/CVM-1359).

* Fixes memory error in swissknife_lease.cc causing crash during `cvmfs_server abort`.
* Fixes recursion bug in `CatalogDiffTool` causing catalog corruption when directories were deleted
* Adds more tests cases and checks to the repository service integrations tests.