### PR TITLE
Fix catalog processing and uploading with gateway backend

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -1128,15 +1128,16 @@ WritableCatalogManager::SnapshotCatalogsSerialized(
     // Compress and upload catalog
     shash::Any hash_catalog(spooler_->GetHashAlgorithm(),
                             shash::kSuffixCatalog);
+    const std::string temp_compressed_path = (*i)->database_path() + ".compressed";
     if (!zlib::CompressPath2Path((*i)->database_path(),
-                                 (*i)->database_path() + ".compressed",
+                                 temp_compressed_path,
                                  &hash_catalog))
     {
       PrintError("could not compress catalog " + (*i)->mountpoint().ToString());
       assert(false);
     }
-    spooler_->Upload((*i)->database_path() + ".compressed",
-                     "data/" + hash_catalog.MakePath());
+    unlink(temp_compressed_path.c_str());
+    spooler_->ProcessCatalog((*i)->database_path());
 
     uint64_t catalog_size = GetFileSize((*i)->database_path());
     assert(catalog_size > 0);

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -1128,15 +1128,12 @@ WritableCatalogManager::SnapshotCatalogsSerialized(
     // Compress and upload catalog
     shash::Any hash_catalog(spooler_->GetHashAlgorithm(),
                             shash::kSuffixCatalog);
-    const std::string temp_compressed_path = (*i)->database_path() + ".compressed";
-    if (!zlib::CompressPath2Path((*i)->database_path(),
-                                 temp_compressed_path,
+    if (!zlib::CompressPath2Null((*i)->database_path(),
                                  &hash_catalog))
     {
       PrintError("could not compress catalog " + (*i)->mountpoint().ToString());
       assert(false);
     }
-    unlink(temp_compressed_path.c_str());
     spooler_->ProcessCatalog((*i)->database_path());
 
     uint64_t catalog_size = GetFileSize((*i)->database_path());


### PR DESCRIPTION
Addresses [CVM-1364](https://sft.its.cern.ch/jira/browse/CVM-1364).

Spooler::ProcessCatalog should be used to submit catalogs, instead of Spooler::Upload, to ensure that the catalogs are properly handled as content-addressed files by the receiver process on the gateway.