### PR TITLE
Enable the use of the CVMFS gateway services with S3 storage backend

### DIFF
--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -110,7 +110,8 @@ CommitProcessor::Result CommitProcessor::Process(
     return kIoError;
   }
 
-  const std::string spooler_temp_dir = GetSpoolerTempDir(params.spooler_configuration);
+  const std::string spooler_temp_dir =
+      GetSpoolerTempDir(params.spooler_configuration);
   assert(!spooler_temp_dir.empty());
   const std::string temp_dir_root = spooler_temp_dir + "/commit_processor";
 
@@ -118,9 +119,9 @@ CommitProcessor::Result CommitProcessor::Process(
 
   CatalogMergeTool<catalog::WritableCatalogManager,
                    catalog::SimpleCatalogManager>
-      merge_tool(params.stratum0, old_root_hash, new_root_hash, relative_lease_path,
-                 temp_dir_root, server_tool->download_manager(),
-                 manifest.weak_ref());
+      merge_tool(params.stratum0, old_root_hash, new_root_hash,
+                 relative_lease_path, temp_dir_root,
+                 server_tool->download_manager(), manifest.weak_ref());
   if (!merge_tool.Init()) {
     LogCvmfs(kLogReceiver, kLogSyslogErr,
              "Error: Could not initialize the catalog merge tool");

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -38,12 +38,6 @@ PathString RemoveRepoName(const PathString& lease_path) {
   }
 }
 
-std::string GetSpoolerTempDir(const std::string& spooler_config) {
-  const std::vector<std::string> tokens = SplitString(spooler_config, ',');
-  assert(tokens.size() == 3);
-  return tokens[1];
-}
-
 }  // namespace
 
 namespace receiver {

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -38,6 +38,12 @@ PathString RemoveRepoName(const PathString& lease_path) {
   }
 }
 
+std::string GetSpoolerTempDir(const std::string& spooler_config) {
+  const std::vector<std::string> tokens = SplitString(spooler_config, ',');
+  assert(tokens.size() == 3);
+  return tokens[1];
+}
+
 }  // namespace
 
 namespace receiver {
@@ -110,8 +116,9 @@ CommitProcessor::Result CommitProcessor::Process(
     return kIoError;
   }
 
-  const std::string temp_dir_root =
-      "/srv/cvmfs/" + repo_name + "/data/txn/commit_processor";
+  const std::string spooler_temp_dir = GetSpoolerTempDir(params.spooler_configuration);
+  assert(!spooler_temp_dir.empty());
+  const std::string temp_dir_root = spooler_temp_dir + "/commit_processor";
 
   const PathString relative_lease_path = RemoveRepoName(PathString(lease_path));
 

--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -52,15 +52,6 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
                "CVMFS_UPSTREAM_STORAGE");
       return false;
     }
-
-    // Note: if upstream is gateway, we change it to local. This should be made to
-    // abort, but it's useful for testing on a single machine
-    if (HasPrefix(params->spooler_configuration, "gw", false)) {
-      std::vector<std::string> tokens = SplitString(repo_name, '/');
-      const std::string rname = tokens.back();
-      params->spooler_configuration =
-          "local,/srv/cvmfs/" + rname + "/data/txn,/srv/cvmfs/" + rname;
-    }
   }
 
 

--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -23,6 +23,13 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
     return false;
   }
 
+  if (!parser.GetValue("CVMFS_STRATUM0", &params->stratum0)) {
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
+             "Missing parameter %s in repository configuration file.",
+             "CVMFS_STRATUM0");
+    return false;
+  }
+
   // Note: TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE is used to provide an
   //       an overriding value for CVMFS_UPSTREAM_STORAGE, to be used
   //       only by the cvmfs_receiver application. Useful for testing

--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -23,22 +23,33 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
     return false;
   }
 
-  if (!parser.GetValue("CVMFS_UPSTREAM_STORAGE",
-                       &params->spooler_configuration)) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "Missing parameter %s in repository configuration file.",
-             "CVMFS_UPSTREAM_STORAGE");
-    return false;
+  // Note: TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE is used to provide an
+  //       an overriding value for CVMFS_UPSTREAM_STORAGE, to be used
+  //       only by the cvmfs_receiver application. Useful for testing
+  //       when the release manager and the repository gateway are
+  //       running on the same machine.
+  if (parser.IsDefined("TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE")) {
+    parser.GetValue("TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE",
+                    &params->spooler_configuration);
+  } else {
+    if (!parser.GetValue("CVMFS_UPSTREAM_STORAGE",
+                         &params->spooler_configuration)) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "Missing parameter %s in repository configuration file.",
+               "CVMFS_UPSTREAM_STORAGE");
+      return false;
+    }
+
+    // Note: if upstream is gateway, we change it to local. This should be made to
+    // abort, but it's useful for testing on a single machine
+    if (HasPrefix(params->spooler_configuration, "gw", false)) {
+      std::vector<std::string> tokens = SplitString(repo_name, '/');
+      const std::string rname = tokens.back();
+      params->spooler_configuration =
+          "local,/srv/cvmfs/" + rname + "/data/txn,/srv/cvmfs/" + rname;
+    }
   }
 
-  // Note: if upstream is gateway, we change it to local. This should be made to
-  // abort, but it's useful for testing on a single machine
-  if (HasPrefix(params->spooler_configuration, "gw", false)) {
-    std::vector<std::string> tokens = SplitString(repo_name, '/');
-    const std::string rname = tokens.back();
-    params->spooler_configuration =
-        "local,/srv/cvmfs/" + rname + "/data/txn,/srv/cvmfs/" + rname;
-  }
 
   std::string hash_algorithm_str;
   if (!parser.GetValue("CVMFS_HASH_ALGORITHM", &hash_algorithm_str)) {

--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -11,6 +11,12 @@
 
 namespace receiver {
 
+std::string GetSpoolerTempDir(const std::string& spooler_config) {
+  const std::vector<std::string> tokens = SplitString(spooler_config, ',');
+  assert(tokens.size() == 3);
+  return tokens[1];
+}
+
 bool GetParamsFromFile(const std::string& repo_name, Params* params) {
   const std::string repo_config_file =
       "/etc/cvmfs/repositories.d/" + repo_name + "/server.conf";

--- a/cvmfs/receiver/params.h
+++ b/cvmfs/receiver/params.h
@@ -12,6 +12,8 @@
 
 namespace receiver {
 
+std::string GetSpoolerTempDir(const std::string& spooler_config);
+
 struct Params {
   std::string stratum0;
   std::string spooler_configuration;

--- a/cvmfs/receiver/params.h
+++ b/cvmfs/receiver/params.h
@@ -13,6 +13,7 @@
 namespace receiver {
 
 struct Params {
+  std::string stratum0;
   std::string spooler_configuration;
   shash::Algorithms hash_alg;
   zlib::Algorithms compression_alg;

--- a/cvmfs/receiver/payload_processor.cc
+++ b/cvmfs/receiver/payload_processor.cc
@@ -11,8 +11,8 @@
 #include "logging.h"
 #include "params.h"
 #include "util/posix.h"
-#include "util/string.h"
 #include "util/raii_temp_dir.h"
+#include "util/string.h"
 
 namespace receiver {
 
@@ -35,16 +35,18 @@ PayloadProcessor::Result PayloadProcessor::Process(
     return kOtherError;
   }
 
-  const std::string spooler_temp_dir = GetSpoolerTempDir(params.spooler_configuration);
+  const std::string spooler_temp_dir =
+      GetSpoolerTempDir(params.spooler_configuration);
   assert(!spooler_temp_dir.empty());
-  UniquePtr<RaiiTempDir> raii_temp_dir(RaiiTempDir::Create(spooler_temp_dir + "/payload_processor"));
+  UniquePtr<RaiiTempDir> raii_temp_dir(
+      RaiiTempDir::Create(spooler_temp_dir + "/payload_processor"));
   temp_dir_ = raii_temp_dir->dir();
 
   upload::SpoolerDefinition definition(
-    params.spooler_configuration, params.hash_alg, params.compression_alg,
-    params.generate_legacy_bulk_chunks, params.use_file_chunking,
-    params.min_chunk_size, params.avg_chunk_size, params.max_chunk_size,
-    "dummy_token", "dummy_key");
+      params.spooler_configuration, params.hash_alg, params.compression_alg,
+      params.generate_legacy_bulk_chunks, params.use_file_chunking,
+      params.min_chunk_size, params.avg_chunk_size, params.max_chunk_size,
+      "dummy_token", "dummy_key");
 
   spooler_.Destroy();
   spooler_ = upload::Spooler::Construct(definition);

--- a/cvmfs/receiver/payload_processor.cc
+++ b/cvmfs/receiver/payload_processor.cc
@@ -81,6 +81,8 @@ PayloadProcessor::Result PayloadProcessor::Process(
 
   assert(pending_files_.empty());
 
+  spooler_->WaitForUpload();
+
   return kSuccess;
 }
 

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <map>
+#include "upload.h"
 #include <string>
 
 #include "pack.h"
@@ -53,6 +54,8 @@ class PayloadProcessor {
   typedef std::map<shash::Any, FileInfo>::iterator FileIterator;
   std::map<shash::Any, FileInfo> pending_files_;
   std::string current_repo_;
+  UniquePtr<upload::Spooler> spooler_;
+  std::string spooler_temp_dir_;
   int num_errors_;
 };
 

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -55,7 +55,7 @@ class PayloadProcessor {
   std::map<shash::Any, FileInfo> pending_files_;
   std::string current_repo_;
   UniquePtr<upload::Spooler> spooler_;
-  std::string spooler_temp_dir_;
+  std::string temp_dir_;
   int num_errors_;
 };
 

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -11,6 +11,7 @@
 
 #include "pack.h"
 #include "upload.h"
+#include "util/raii_temp_dir.h"
 
 namespace receiver {
 
@@ -57,7 +58,7 @@ class PayloadProcessor {
   std::map<shash::Any, FileInfo> pending_files_;
   std::string current_repo_;
   UniquePtr<upload::Spooler> spooler_;
-  std::string temp_dir_;
+  UniquePtr<RaiiTempDir> temp_dir_;
   int num_errors_;
 };
 

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -7,10 +7,10 @@
 
 #include <stdint.h>
 #include <map>
-#include "upload.h"
 #include <string>
 
 #include "pack.h"
+#include "upload.h"
 
 namespace receiver {
 

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -46,9 +46,11 @@ class PayloadProcessor {
  protected:
   // NOTE: These methods are made virtual such that they can be mocked for
   //       the purpose of unit testing
+  virtual Result Initialize();
+  virtual void Finalize();
+  virtual void Upload(const std::string& source,
+                      const std::string& dest);
   virtual bool WriteFile(int fd, const void* const buf, size_t buf_size);
-  virtual int RenameFile(const std::string& old_name,
-                         const std::string& new_name);
 
  private:
   typedef std::map<shash::Any, FileInfo>::iterator FileIterator;

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -64,12 +64,6 @@ GatewayUploader::GatewayUploader(const SpoolerDefinition& spooler_definition)
   }
 
   atomic_init32(&num_errors_);
-
-  LogCvmfs(kLogUploadGateway, kLogStderr,
-           "HTTP uploader configuration:\n"
-           "  API URL: %s\n"
-           "  Session token file: %s\n",
-           config_.api_url.c_str(), config_.session_token_file.c_str());
 }
 
 GatewayUploader::~GatewayUploader() {

--- a/test/test_functions
+++ b/test/test_functions
@@ -2425,10 +2425,11 @@ EOF'
     echo "  Modifying test repo configuration"
     sudo sed -i -e 's/local,/gw,/' /etc/cvmfs/repositories.d/test.repo.org/server.conf
     sudo sed -i -e 's/txn,\/srv\/cvmfs\/test.repo.org/txn,http:\/\/localhost:8080\/api\/v1/g' /etc/cvmfs/repositories.d/test.repo.org/server.conf
+    sudo bash -c 'echo "TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE=local,/srv/cvmfs/test.repo.org/data/txn,/srv/cvmfs/test.repo.org" >> /etc/cvmfs/repositories.d/test.repo.org/server.conf'
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 
     echo "  Starting repository services application"
-    RUNNER_LOG_DIR=/tmp /opt/cvmfs_services/bin/cvmfs_services start
+    /opt/cvmfs_services/scripts/run_cvmfs_services.sh start
 
     # Waiting here is necessary in order to give the cvmfs_services application enough time to boot
     wait_for_app_start

--- a/test/unittests/t_payload_processor.cc
+++ b/test/unittests/t_payload_processor.cc
@@ -16,6 +16,13 @@ class MockPayloadProcessor : public PayloadProcessor {
   MockPayloadProcessor() : PayloadProcessor(), num_files_received_(0) {}
   virtual ~MockPayloadProcessor() {}
 
+  virtual Result Initialize() { return kSuccess; }
+
+  virtual void Finalize() {}
+
+  virtual void Upload(const std::string& source,
+                      const std::string& dest) {}
+
   virtual void ConsumerEventCallback(const ObjectPackBuild::Event& /*event*/) {
     num_files_received_++;
   }

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -32,6 +32,9 @@ class MockedPayloadProcessor : public PayloadProcessor {
     // NO OP
     return true;
   }
+
+  virtual void ConsumerEventCallback(
+    const ObjectPackBuild::Event& /*event*/) {}
 };
 
 class MockedReactor : public Reactor {

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -20,15 +20,17 @@ class MockedPayloadProcessor : public PayloadProcessor {
   MockedPayloadProcessor() : PayloadProcessor() {}
 
  protected:
+  virtual Result Initialize() { return kSuccess; }
+
+  virtual void Finalize() {}
+
+  virtual void Upload(const std::string& source,
+                      const std::string& dest) {}
+
   virtual bool WriteFile(int /*fd*/, const void* const /*buf*/,
                          size_t /*buf_size*/) {
     // NO OP
     return true;
-  }
-  virtual int RenameFile(const std::string& /*old_name*/,
-                         const std::string& /*new_name*/) {
-    // NO OP
-    return 0;
   }
 };
 


### PR DESCRIPTION
Addresses [CVM-1264](https://sft.its.cern.ch/jira/browse/CVM-1264).

Removes all hardcoded values for temporary directories (i.e. /srv/cvmfs/<REPO_NAME>/data/txn) and Stratum0 URL from the `cvmfs_receiver` application. All values are now read from the repo's `server.conf` file and all files are transfered to/from the repository upstream storage using the appropriate objects (`DownloadManager`, `Uploader` etc.).

The `cvmfs_receiver` tool now also responds to an optional configuration parameter in `server.conf`: `TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE` - this is only useful for integration tests where the release manager and the gateway are running on the same machine, and allows specifying the upstream storage string for the `cvmfs_receiver` (in this test configuration, `cvmfs_server` needs to see an upstream storage of type "gw", while `cvmfs_receiver` needs to use "local" or "S3").