### PR TITLE
Restart authz_helper process after a cool-off period.

### DIFF
--- a/cvmfs/authz/authz_fetch.h
+++ b/cvmfs/authz/authz_fetch.h
@@ -157,6 +157,8 @@ class AuthzExternalFetcher : public AuthzFetcher, SingleCopy {
   bool ParseRevision(JSON *json_authz, AuthzExternalMsg *binary_msg);
   bool ParsePermit(JSON *json_authz, AuthzExternalMsg *binary_msg);
 
+  void ReapHelper();
+
   /**
    * The fully qualified repository name, e.g. atlas.cern.ch
    */
@@ -202,6 +204,12 @@ class AuthzExternalFetcher : public AuthzFetcher, SingleCopy {
    * The send-receive cycle is atomic.
    */
   pthread_mutex_t lock_;
+
+  /**
+   * After the helper process fails, this is set to the time when it should
+   * be restarted.
+   */
+  uint64_t next_start_;
 };
 
 #endif  // CVMFS_AUTHZ_AUTHZ_FETCH_H_

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -86,6 +86,23 @@ cvmfs_run_test() {
   secure_mount $mntpnt || return 70
   echo "Repo has open membership, this should work"
   sudo -u nobody /bin/sh -c "cat ${mntpnt}/hello_world" || return 71
+
+  echo "kill and restart secure mount"
+  local secure_mnt_pid=$(get_xattr pid $mntpnt)
+  echo "secure mount point has pid $secure_mnt_pid"
+  local authz_helper_pid=$(pgrep -P $secure_mnt_pid cvmfs_allow)
+  echo "authz helper has pid $authz_helper_pid; killing it."
+  sudo kill -SEGV $authz_helper_pid
+  echo "authz helper has died, access should fail"
+  sudo -u nobody setsid /bin/sh -c "cat ${mntpnt}/hello_world" && return 74
+  echo "Waiting for rate-limit timeout to pass"
+  sleep 11
+  echo "authz helper should be restarted on access"
+  sudo -u nobody setsid /bin/sh -c "cat ${mntpnt}/hello_world" || return 75
+  local authz_helper_pid_new=$(pgrep -P $secure_mnt_pid cvmfs_allow)
+  echo "new authz helper pid $authz_helper_pid_new"
+  [ "x$authz_helper_pid_new" = "x" ] && return 76
+  [ "x$authz_helper_pid" = "x$authz_helper_pid_new" ] && return 77
   
   echo "checking authz attribute"
   attr -l $mntpnt || return 72


### PR DESCRIPTION
Although I haven't quite figured out why, we have a few crashing `cvmfs_x509_helper` processes on one of the OSG sites.

In order to avoid permanent black-hole nodes, this allows the CVMFS authz helper to restart after `kChildTimeout` seconds (I considered an immediate restart, but I am worried about continuously churning processes).