### PR TITLE
Fix test functions setup repo services

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -2366,7 +2366,7 @@ set_up_repository_services() {
     local package_url_root=$CVMFS_SERVICES_URL
 
     # Choose which package to download and install based on platform
-    if [ -f /etc/lsb-release ]; then
+    if [ -f /etc/debian_version ]; then
         if [ x"$(lsb_release -cs)" = x"xenial" ]; then
             package_map_url=${package_url_root}/pkgmap/pkgmap.ubuntu1604_x86_64
         fi

--- a/test/test_functions
+++ b/test/test_functions
@@ -2370,13 +2370,10 @@ set_up_repository_services() {
         if [ x"$(lsb_release -cs)" = x"xenial" ]; then
             package_map_url=${package_url_root}/pkgmap/pkgmap.ubuntu1604_x86_64
         fi
-    elif is_redhat; then
-        rhver=$(cat /etc/redhat-release | awk {'print $(NF-1)'} | cut -d'.' -f1)
-        if [ x"$rhver" = x6 ]; then
-            package_map_url=${package_url_root}/pkgmap/pkgmap.slc6_x86_64
-        elif [ x"$rhver" = x7 ]; then
-            package_map_url=${package_url_root}/pkgmap/pkgmap.cc7_x86_64
-        fi
+    elif is_el6; then
+        package_map_url=${package_url_root}/pkgmap/pkgmap.slc6_x86_64
+    elif is_el7; then
+        package_map_url=${package_url_root}/pkgmap/pkgmap.cc7_x86_64
     fi
 
     if [ x"$package_map_url" = x"" ]; then


### PR DESCRIPTION
This PR (finally) fixes the platform distro detection part of the `set_up_repository_services` function in `test/test_functions`.

The gateway service integration test are now run during the integration tests, on Ubuntu 16.04, SLC6 and CC7, all on x86_64.

[Integration test results with this PR](https://epsft-jenkins.cern.ch/view/CVMFS/job/CvmfsCloudTesting/218/).