### PR TITLE
Check XFS ftype parameter in cvmfs_server_util.sh

### DIFF
--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -502,7 +502,7 @@ check_overlayfs_version() {
         return 0
       fi
       if [ "x$scratch_fstype" = "xxfs" ] ; then
-        if [ "x$(xfs_info /var/spool/cvmfs | grep ftype=1)" != "x" ] ; then
+        if [ "x$(xfs_info /var/spool/cvmfs 2>/dev/null | grep ftype=1)" != "x" ] ; then
           return 0
         else
           echo "XFS with ftype=0 is not supported for /var/spool/cvmfs. XFS with ftype=1 is required"

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -501,7 +501,15 @@ check_overlayfs_version() {
       if [ "x$scratch_fstype" = "xext3" ] || [ "x$scratch_fstype" = "xext4" ] ; then
         return 0
       fi
-      echo "overlayfs scratch /var/spool/cvmfs is type $scratch_fstype, but ext3 or ext4 required"
+      if [ "x$scratch_fstype" = "xxfs" ] ; then
+        if [ "x$(xfs_info /var/spool/cvmfs | grep ftype=1)" != "x" ] ; then
+          return 0
+        else
+          echo "XFS with ftype=0 is not supported for /var/spool/cvmfs. XFS with ftype=1 is required"
+          return 1
+        fi
+      fi
+      echo "overlayfs scratch /var/spool/cvmfs is type $scratch_fstype, but ext3, ext4 or xfs(ftype=1) required"
       return 1
     fi
   fi


### PR DESCRIPTION
Addresses [CVM-1385](https://sft.its.cern.ch/jira/browse/CVM-1385).

Add check for the value of the ftype parameter, when /var/spool/cvmfs is
located on an XFS partition. "ftype=1" is supported. If "ftype=0" error
out and warn user.