### PR TITLE
Fixes some issues encountered in the benchmark with multiple release managers

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -345,6 +345,7 @@ set (CVMFS_STRATUM_AGENT_SOURCES
 if(BUILD_RECEIVER)
   set (CVMFS_RECEIVER_SOURCES
     receiver/commit_processor.cc
+    receiver/lease_path_util.cc
     receiver/params.cc
     receiver/payload_processor.cc
     receiver/reactor.cc

--- a/cvmfs/receiver/catalog_merge_tool.h
+++ b/cvmfs/receiver/catalog_merge_tool.h
@@ -41,7 +41,6 @@ class CatalogMergeTool : public CatalogDiffTool<RoCatalogMgr> {
         repo_path_(""),
         lease_path_(lease_path),
         temp_dir_prefix_(temp_dir_prefix),
-        invalid_path_encountered_(false),
         download_manager_(NULL),
         manifest_(manifest),
         output_catalog_mgr_(output_catalog_mgr),
@@ -57,7 +56,6 @@ class CatalogMergeTool : public CatalogDiffTool<RoCatalogMgr> {
         repo_path_(repo_path),
         lease_path_(lease_path),
         temp_dir_prefix_(temp_dir_prefix),
-        invalid_path_encountered_(false),
         download_manager_(download_manager),
         manifest_(manifest),
         needs_setup_(true) {}
@@ -74,7 +72,6 @@ class CatalogMergeTool : public CatalogDiffTool<RoCatalogMgr> {
         repo_path_(repo_path),
         lease_path_(lease_path),
         temp_dir_prefix_(temp_dir_prefix),
-        invalid_path_encountered_(false),
         download_manager_(download_manager),
         manifest_(manifest),
         needs_setup_(true) {}
@@ -101,8 +98,6 @@ class CatalogMergeTool : public CatalogDiffTool<RoCatalogMgr> {
 
   PathString lease_path_;
   std::string temp_dir_prefix_;
-
-  bool invalid_path_encountered_;
 
   download::DownloadManager* download_manager_;
 

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -9,12 +9,15 @@
 
 #include "catalog.h"
 #include "hash.h"
+#include "lease_path_util.h"
 #include "logging.h"
 #include "manifest.h"
 #include "options.h"
 #include "upload.h"
 #include "util/posix.h"
 #include "util/raii_temp_dir.h"
+
+namespace {
 
 inline PathString MakeRelative(const PathString& path) {
   std::string rel_path;
@@ -26,6 +29,8 @@ inline PathString MakeRelative(const PathString& path) {
   }
   return PathString(rel_path);
 }
+
+}  // namespace
 
 namespace receiver {
 
@@ -72,7 +77,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportAddition(
    *       by another writer running concurrently.
    *       The correct course of action is to ignore this change here.
    * */
-  if (!rel_path.StartsWith(lease_path_)) {
+  if (!IsPathInLease(lease_path_, rel_path)) {
     return;
   }
 
@@ -102,7 +107,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportRemoval(
    *       by another writer running concurrently.
    *       The correct course of action is to ignore this change here.
    * */
-  if (!rel_path.StartsWith(lease_path_)) {
+  if (!IsPathInLease(lease_path_, rel_path)) {
     return;
   }
 
@@ -128,7 +133,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
    *       by another writer running concurrently.
    *       The correct course of action is to ignore this change here.
    * */
-  if (!rel_path.StartsWith(lease_path_)) {
+  if (!IsPathInLease(lease_path_, rel_path)) {
     return;
   }
 

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -17,8 +17,6 @@
 #include "util/posix.h"
 #include "util/raii_temp_dir.h"
 
-namespace {
-
 inline PathString MakeRelative(const PathString& path) {
   std::string rel_path;
   std::string abs_path = path.ToString();
@@ -29,8 +27,6 @@ inline PathString MakeRelative(const PathString& path) {
   }
   return PathString(rel_path);
 }
-
-}  // namespace
 
 namespace receiver {
 

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -53,14 +53,6 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::Run(
 
   bool ret = CatalogDiffTool<RoCatalogMgr>::Run(PathString(""));
 
-  ret &= !invalid_path_encountered_;
-
-  if (invalid_path_encountered_) {
-    LogCvmfs(
-        kLogReceiver, kLogSyslogErr,
-        "CatalogMergeTool - Invalid path encountered for current lease path");
-  }
-
   ret &= CreateNewManifest(new_manifest_path);
 
   output_catalog_mgr_.Destroy();
@@ -74,12 +66,14 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportAddition(
     const XattrList& xattrs) {
   const PathString rel_path = MakeRelative(path);
 
-  invalid_path_encountered_ = !rel_path.StartsWith(lease_path_);
-  if (invalid_path_encountered_) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "CatalogMergeTool::ReportAddition - Invalid path %s, for lease "
-             "path: %s",
-             path.c_str(), lease_path_.c_str());
+  /*
+   * Note: If the addition of a file or directory outside of the lease
+   *       path is encountered here, this means that the item was deleted
+   *       by another writer running concurrently.
+   *       The correct course of action is to ignore this change here.
+   * */
+  if (!rel_path.StartsWith(lease_path_)) {
+    return;
   }
 
   const std::string parent_path =
@@ -102,12 +96,14 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportRemoval(
     const PathString& path, const catalog::DirectoryEntry& entry) {
   const PathString rel_path = MakeRelative(path);
 
-  invalid_path_encountered_ = !rel_path.StartsWith(lease_path_);
-  if (invalid_path_encountered_) {
-    LogCvmfs(
-        kLogReceiver, kLogSyslogErr,
-        "CatalogMergeTool::ReportRemoval - Invalid path %s, for lease path: %s",
-        path.c_str(), lease_path_.c_str());
+  /*
+   * Note: If the removal of a file or directory outside of the lease
+   *       path is encountered here, this means that the item was created
+   *       by another writer running concurrently.
+   *       The correct course of action is to ignore this change here.
+   * */
+  if (!rel_path.StartsWith(lease_path_)) {
+    return;
   }
 
   if (entry.IsDirectory()) {
@@ -126,12 +122,14 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
     const catalog::DirectoryEntry& entry2, const XattrList& xattrs) {
   const PathString rel_path = MakeRelative(path);
 
-  invalid_path_encountered_ = !rel_path.StartsWith(lease_path_);
-  if (invalid_path_encountered_) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "CatalogMergeTool::ReportModification - Invalid path %s, for "
-             "lease path: %s",
-             path.c_str(), lease_path_.c_str());
+  /*
+   * Note: If the modification of a file or directory outside of the lease
+   *       path is encountered here, this means that the item was modified
+   *       by another writer running concurrently.
+   *       The correct course of action is to ignore this change here.
+   * */
+  if (!rel_path.StartsWith(lease_path_)) {
+    return;
   }
 
   const std::string parent_path =

--- a/cvmfs/receiver/lease_path_util.cc
+++ b/cvmfs/receiver/lease_path_util.cc
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "lease_path_util.h"
+
+namespace receiver {
+
+bool IsPathInLease(const PathString& lease, const PathString& path) {
+  // If lease is "", any path falls within item
+  if (!strcmp(lease.c_str(),"")) {
+    return true;
+  }
+
+  // Is the lease string is the prefix of the path string and the next
+  // character of the path string is a "/".
+  if (path.StartsWith(lease) && path.GetChars()[lease.GetLength()] == '/') {
+    return true;
+  }
+
+  // If the path string is exactly the lease path return true (allow the creation
+  // of the leased directory during the lease itself)
+  if (lease == path) {
+    return true;
+  }
+
+  return false;
+}
+
+}
+

--- a/cvmfs/receiver/lease_path_util.cc
+++ b/cvmfs/receiver/lease_path_util.cc
@@ -8,7 +8,7 @@ namespace receiver {
 
 bool IsPathInLease(const PathString& lease, const PathString& path) {
   // If lease is "", any path falls within item
-  if (!strcmp(lease.c_str(),"")) {
+  if (!strcmp(lease.c_str(), "")) {
     return true;
   }
 
@@ -18,8 +18,8 @@ bool IsPathInLease(const PathString& lease, const PathString& path) {
     return true;
   }
 
-  // If the path string is exactly the lease path return true (allow the creation
-  // of the leased directory during the lease itself)
+  // If the path string is exactly the lease path return true (allow the
+  // creation of the leased directory during the lease itself)
   if (lease == path) {
     return true;
   }
@@ -27,5 +27,4 @@ bool IsPathInLease(const PathString& lease, const PathString& path) {
   return false;
 }
 
-}
-
+}  // namespace receiver

--- a/cvmfs/receiver/lease_path_util.h
+++ b/cvmfs/receiver/lease_path_util.h
@@ -1,0 +1,16 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_RECEIVER_LEASE_PATH_UTIL_H_
+#define CVMFS_RECEIVER_LEASE_PATH_UTIL_H_
+
+#include "shortstring.h"
+
+namespace receiver {
+
+bool IsPathInLease(const PathString& lease, const PathString& path);
+
+}
+
+#endif  // CVMFS_RECEIVER_LEASE_PATH_UTIL_H_

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -646,7 +646,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     return 3;
   }
 
-  bool with_gateway = spooler_definition.driver_type == upload::SpoolerDefinition::Gateway;
+  bool with_gateway = spooler_definition.driver_type
+      == upload::SpoolerDefinition::Gateway;
   /*
    * Note: If the upstream is of type gateway, due to the possibility of concurrent
    *       release managers, it's possible to have a different local and remote root

--- a/test/quickcheck/CMakeLists.txt
+++ b/test/quickcheck/CMakeLists.txt
@@ -60,6 +60,7 @@ set (CVMFS_QC_SOURCES
   ${CVMFS_SOURCE_DIR}/monitor.cc
   ${CVMFS_SOURCE_DIR}/options.cc
   ${CVMFS_SOURCE_DIR}/pack.cc
+  ${CVMFS_SOURCE_DIR}/receiver/lease_path_util.cc
   ${CVMFS_SOURCE_DIR}/reflog.cc
   ${CVMFS_SOURCE_DIR}/reflog_sql.cc
   ${CVMFS_SOURCE_DIR}/upload_facility.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(CVMFS_UNITTEST_FILES
   t_history.cc
   t_json.cc
   t_kvstore.cc
+  t_lease_path_util.cc
   t_libcvmfs.cc
   t_logging.cc
   t_lru.cc
@@ -189,6 +190,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/quota.cc
   ${CVMFS_SOURCE_DIR}/quota_posix.cc
   ${CVMFS_SOURCE_DIR}/receiver/commit_processor.cc
+  ${CVMFS_SOURCE_DIR}/receiver/lease_path_util.cc
   ${CVMFS_SOURCE_DIR}/receiver/params.cc
   ${CVMFS_SOURCE_DIR}/receiver/payload_processor.cc
   ${CVMFS_SOURCE_DIR}/receiver/reactor.cc

--- a/test/unittests/t_lease_path_util.cc
+++ b/test/unittests/t_lease_path_util.cc
@@ -1,0 +1,45 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "receiver/lease_path_util.h"
+#include "shortstring.h"
+
+class T_LeasePathUtil : public ::testing::Test {};
+
+TEST_F(T_LeasePathUtil, RootLease) {
+  const PathString lease("");
+  const PathString path1("");
+  const PathString path2("a");
+  const PathString path3("b");
+
+  ASSERT_TRUE(receiver::IsPathInLease(lease, path1));
+  ASSERT_TRUE(receiver::IsPathInLease(lease, path2));
+  ASSERT_TRUE(receiver::IsPathInLease(lease, path3));
+}
+
+TEST_F(T_LeasePathUtil, Identical) {
+  const PathString lease("lease-dir");
+  const PathString path("lease-dir");
+
+  ASSERT_TRUE(receiver::IsPathInLease(lease, path));
+}
+
+TEST_F(T_LeasePathUtil, SubPathLease) {
+  const PathString lease("sub/path");
+  const PathString path1("sub/path/subdir");
+  const PathString path2("sub/path_with_same_prefix");
+  const PathString path3("sub_path_with_similar_prefix");
+  const PathString empty_path("");
+
+  const PathString path_above_lease("sub");
+
+  ASSERT_TRUE(receiver::IsPathInLease(lease, path1));
+  ASSERT_FALSE(receiver::IsPathInLease(lease, path2));
+  ASSERT_FALSE(receiver::IsPathInLease(lease, path3));
+  ASSERT_FALSE(receiver::IsPathInLease(lease, empty_path));
+
+  ASSERT_FALSE(receiver::IsPathInLease(lease, path_above_lease));
+}


### PR DESCRIPTION
Addresses [CVM-1393](https://sft.its.cern.ch/jira/browse/CVM-1393).

* Corrects the sanity checks in the `CatalogMergeTool` class.
* When publishing to a repository with a gateway upstream, do not trigger an error when local and remote root hashes differ.