### PR TITLE
Remove a nested catalog's subtree in constant time

### DIFF
--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -138,7 +138,7 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
       continue;
     } else if (IsSmaller(old_entry, new_entry)) {
       i_from++;
-      if (old_entry.IsDirectory()) {
+      if (old_entry.IsDirectory() && !old_entry.IsNestedCatalogMountpoint()) {
         DiffRec(old_path);
       }
       ReportRemoval(old_path, old_entry);

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -660,13 +660,18 @@ void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
 
 
 /**
- * Remove a nested catalog.
- * When you remove a nested catalog all entries currently held by it
- * will be merged into its parent catalog.
- * @param mountpoint the path of the nested catalog to be removed
- * @return true on success, false otherwise
+ * Remove a nested catalog
+ *
+ * If the merged parameter is true, when you remove a nested catalog
+ * all entries currently held by it will be merged into its parent
+ * catalog.
+ * @param mountpoint - the path of the nested catalog to be removed
+ * @param merge - merge the subtree associated with the nested catalog
+ *                into its parent catalog
+ * @return - true on success, false otherwise
  */
-void WritableCatalogManager::RemoveNestedCatalog(const string &mountpoint) {
+void WritableCatalogManager::RemoveNestedCatalog(const string &mountpoint,
+                                                 const bool merge) {
   const string nested_root_path = MakeRelativePath(mountpoint);
 
   SyncLock();
@@ -683,8 +688,10 @@ void WritableCatalogManager::RemoveNestedCatalog(const string &mountpoint) {
   assert(!nested_catalog->IsRoot() &&
          (nested_catalog->mountpoint().ToString() == nested_root_path));
 
-  // Merge all data from the nested catalog into it's parent
-  nested_catalog->MergeIntoParent();
+  if (merge) {
+    // Merge all data from the nested catalog into it's parent
+    nested_catalog->MergeIntoParent();
+  }
 
   // Delete the catalog database file from the working copy
   if (unlink(nested_catalog->database_path().c_str()) != 0) {

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -691,6 +691,8 @@ void WritableCatalogManager::RemoveNestedCatalog(const string &mountpoint,
   if (merge) {
     // Merge all data from the nested catalog into it's parent
     nested_catalog->MergeIntoParent();
+  } else {
+    nested_catalog->RemoveFromParent();
   }
 
   // Delete the catalog database file from the working copy

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -121,7 +121,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
 
   // Nested catalog handling
   void CreateNestedCatalog(const std::string &mountpoint);
-  void RemoveNestedCatalog(const std::string &mountpoint);
+  void RemoveNestedCatalog(const std::string &mountpoint, const bool merge = true);
   bool IsTransitionPoint(const std::string &mountpoint);
   WritableCatalog *GetHostingCatalog(const std::string &path);
 

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -121,7 +121,8 @@ class WritableCatalogManager : public SimpleCatalogManager {
 
   // Nested catalog handling
   void CreateNestedCatalog(const std::string &mountpoint);
-  void RemoveNestedCatalog(const std::string &mountpoint, const bool merge = true);
+  void RemoveNestedCatalog(const std::string &mountpoint,
+                           const bool merge = true);
   bool IsTransitionPoint(const std::string &mountpoint);
   WritableCatalog *GetHostingCatalog(const std::string &path);
 

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -647,6 +647,26 @@ void WritableCatalog::MergeIntoParent() {
 }
 
 
+void WritableCatalog::RemoveFromParent() {
+  assert(!IsRoot() && HasParent());
+  WritableCatalog *parent = GetWritableParent();
+
+  // Remove the nested catalog reference for this nested catalog.
+  // From now on this catalog will be dangling!
+  Catalog* child_catalog;
+  parent->RemoveNestedCatalog(this->mountpoint().ToString(), &child_catalog);
+
+  const Counters& child_counters = child_catalog->GetCounters();
+
+  parent->delta_counters_.subtree.directories = -1;
+  parent->delta_counters_.subtree.file_size =
+      -1 * child_counters.self.file_size;
+  parent->delta_counters_.subtree.regular_files =
+      -1 * child_counters.self.regular_files;
+  parent->delta_counters_.subtree.symlinks = -1 * child_counters.self.symlinks;
+}
+
+
 void WritableCatalog::CopyCatalogsToParent() {
   WritableCatalog *parent = GetWritableParent();
 

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -658,12 +658,11 @@ void WritableCatalog::RemoveFromParent() {
 
   const Counters& child_counters = child_catalog->GetCounters();
 
-  parent->delta_counters_.subtree.directories = -1;
-  parent->delta_counters_.subtree.file_size =
-      -1 * child_counters.self.file_size;
-  parent->delta_counters_.subtree.regular_files =
-      -1 * child_counters.self.regular_files;
-  parent->delta_counters_.subtree.symlinks = -1 * child_counters.self.symlinks;
+  parent->delta_counters_.subtree.directories -= 1;
+  parent->delta_counters_.subtree.file_size -= child_counters.self.file_size;
+  parent->delta_counters_.subtree.regular_files -=
+      child_counters.self.regular_files;
+  parent->delta_counters_.subtree.symlinks -= child_counters.self.symlinks;
 }
 
 

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -77,6 +77,7 @@ class WritableCatalog : public Catalog {
   // Creation and removal of catalogs
   void Partition(WritableCatalog *new_nested_catalog);
   void MergeIntoParent();
+  void RemoveFromParent();
 
   // Nested catalog references
   void InsertNestedCatalog(const std::string &mountpoint,

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -112,7 +112,8 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportRemoval(
 
   if (entry.IsDirectory()) {
     if (entry.IsNestedCatalogMountpoint()) {
-      output_catalog_mgr_->RemoveNestedCatalog(std::string(rel_path.c_str()));
+      output_catalog_mgr_->RemoveNestedCatalog(std::string(rel_path.c_str()),
+                                               false);
     }
     output_catalog_mgr_->RemoveDirectory(rel_path.c_str());
   } else if (entry.IsRegular() || entry.IsLink()) {


### PR DESCRIPTION
Addresses [CVM-1405](https://sft.its.cern.ch/jira/browse/CVM-1405).

Performance optimization.

Adds a parameter to the `WritableCatalogManager::RemoveNestedCatalog` function to allow removing the nested catalog including its contents. By default, the behaviour of the function is unchanged (i.e. the nested catalog is removed and its contents are merged into its parent).

For the moment, the new functionality is only be used on the repository gateway, in the `CatalogMergeTool` class.

Nested catalog handling in  `CatalogMergeTool` is already tested in the integration test `802-repository_services_nested_catalogs`.