### PR TITLE
Turn cvmfs-config into Debian virtual package, default cvmfs-config-default

### DIFF
--- a/packaging/debian/config-default/control
+++ b/packaging/debian/config-default/control
@@ -12,6 +12,7 @@ Replaces: cvmfs-keys
 Conflicts: cvmfs-keys
 Breaks: cvmfs-keys, cvmfs (<< 2.1.20), cvmfs-server (<< 2.1.20)
 Provides: cvmfs-config
+Conflicts: cvmfs-config
 Description: CernVM File System Default Configuration
  Defaulf configuration and public keys for mounting common CernVM-FS
  repositories.

--- a/packaging/debian/config-none/control
+++ b/packaging/debian/config-none/control
@@ -10,6 +10,7 @@ Package: cvmfs-config-none
 Architecture: all
 Breaks: cvmfs (<< 2.1.20), cvmfs-server (<< 2.1.20)
 Provides: cvmfs-config
+Conflicts: cvmfs-config
 Description:  CernVM File System Empty Configuration
  Empty package to fulfill the "cvmfs-config" dependency of cvmfs.  Can be used
  to provide custom configuration to CernVM-FS.

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -9,7 +9,7 @@ Homepage: http://cernvm.cern.ch/portal/filesystem
 Package: cvmfs
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: cvmfs-config, bash, coreutils, grep, gawk, sed, perl, psmisc, autofs, fuse, curl, attr, libfuse2, debianutils, libc-bin, sysvinit-utils, zlib1g, gdb, uuid-dev, uuid
+Depends: cvmfs-config-default | cvmfs-config, bash, coreutils, grep, gawk, sed, perl, psmisc, autofs, fuse, curl, attr, libfuse2, debianutils, libc-bin, sysvinit-utils, zlib1g, gdb, uuid-dev, uuid
 Recommends: autofs (>= 5.1.2)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch


### PR DESCRIPTION
https://sft.its.cern.ch/jira/browse/CVM-1420

I have tested this on my Debian machine with cvmfs-config-default and cvmfs-config-none in a local apt repository, works as expected.