### PR TITLE
Introduce cache "backing directory" for checksum

### DIFF
--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -201,6 +201,14 @@ class CacheManager : SingleCopy {
   void RestoreState(const int fd_progress, void *state);
   void FreeState(const int fd_progress, void *state);
 
+  /**
+   * While not strictly necessary, cache managers often have a directory
+   * associated with them. This directory is currently used to find the
+   * cached manifest copy, the cvmfschecksum.$reponame file. This is important
+   * to make pre-loaded alien caches work, even in a tiered setup.
+   */
+  virtual std::string GetBackingDirectory() { return ""; }
+
  protected:
   CacheManager();
 

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -95,6 +95,8 @@ class PosixCacheManager : public CacheManager {
 
   virtual void Spawn() { }
 
+  virtual std::string GetBackingDirectory() { return cache_path_; }
+
   void TearDown2ReadOnly();
   CacheModes cache_mode() { return cache_mode_; }
   bool alien_cache() { return alien_cache_; }

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -63,6 +63,8 @@ class TieredCacheManager : public CacheManager {
   virtual int CommitTxn(void *txn);
   virtual void Spawn();
 
+  virtual std::string GetBackingDirectory() { return backing_directory_; }
+
  protected:
   virtual void *DoSaveState();
   virtual bool DoRestoreState(void *data);
@@ -85,6 +87,7 @@ class TieredCacheManager : public CacheManager {
   CacheManager *upper_;
   CacheManager *lower_;
   bool lower_readonly_;
+  std::string backing_directory_;
 };  // class TieredCacheManager
 
 #endif  // CVMFS_CACHE_TIERED_H_

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -140,16 +140,9 @@ LoadError ClientCatalogManager::LoadCatalog(
   }
 
   // Happens only on init/remount, i.e. quota won't delete a cached catalog
-  string checksum_dir = ".";
-  // TODO(jblomer): find a way to remove this hack
-  if (!FileExists("cvmfschecksum." + repo_name_)) {
-    if (fetcher_->cache_mgr()->id() == kPosixCacheManager) {
-      PosixCacheManager *cache_mgr =
-        reinterpret_cast<PosixCacheManager *>(fetcher_->cache_mgr());
-      if (cache_mgr->alien_cache())
-        checksum_dir = cache_mgr->cache_path();
-    }
-  }
+  string checksum_dir = fetcher_->cache_mgr()->GetBackingDirectory();
+  if (checksum_dir.empty())
+    checksum_dir = ".";
   shash::Any cache_hash(shash::kSha1, shash::kSuffixCatalog);
   uint64_t cache_last_modified = 0;
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1261,9 +1261,10 @@ bool MountPoint::CreateSignatureManager() {
     public_keys = optarg;
   } else if (options_mgr_->GetValue("CVMFS_KEYS_DIR", &optarg)) {
     // Collect .pub files from CVMFS_KEYS_DIR
-    public_keys = JoinStrings(FindFiles(optarg, ".pub"), ":");
+    public_keys = JoinStrings(FindFilesBySuffix(optarg, ".pub"), ":");
   } else {
-    public_keys = JoinStrings(FindFiles("/etc/cvmfs/keys", ".pub"), ":");
+    public_keys =
+      JoinStrings(FindFilesBySuffix("/etc/cvmfs/keys", ".pub"), ":");
   }
 
   if (!signature_mgr_->LoadPublicRsaKeys(public_keys)) {

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -268,7 +268,8 @@ void OptionsManager::ParseDefault(const string &fqrn) {
   protected_parameters_.clear();
 
   ParsePath("/etc/cvmfs/default.conf", false);
-  vector<string> dist_defaults = FindFiles("/etc/cvmfs/default.d", ".conf");
+  vector<string> dist_defaults =
+    FindFilesBySuffix("/etc/cvmfs/default.d", ".conf");
   for (unsigned i = 0; i < dist_defaults.size(); ++i) {
     ParsePath(dist_defaults[i], false);
   }

--- a/cvmfs/stratum_agent/stratum_agent.cc
+++ b/cvmfs/stratum_agent/stratum_agent.cc
@@ -199,7 +199,7 @@ static void ReadConfigurations() {
     signature_mgr->Init();
     options_mgr->GetValue("CVMFS_PUBLIC_KEY", &optarg);
     if (DirectoryExists(optarg))
-      optarg = JoinStrings(FindFiles(optarg, ".pub"), ":");
+      optarg = JoinStrings(FindFilesBySuffix(optarg, ".pub"), ":");
     if (!signature_mgr->LoadPublicRsaKeys(optarg)) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
                "(%s) could not load public key %s",

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -866,7 +866,7 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
   if (args.find('k') != args.end())
     pubkey_path = *args.find('k')->second;
   if (DirectoryExists(pubkey_path))
-    pubkey_path = JoinStrings(FindFiles(pubkey_path, ".pub"), ":");
+    pubkey_path = JoinStrings(FindFilesBySuffix(pubkey_path, ".pub"), ":");
   if (args.find('z') != args.end())
     trusted_certs = *args.find('z')->second;
   if (args.find('N') != args.end())

--- a/cvmfs/swissknife_diff.cc
+++ b/cvmfs/swissknife_diff.cc
@@ -57,7 +57,7 @@ int swissknife::CommandDiff::Main(const swissknife::ArgumentList &args) {
   const bool follow_redirects = args.count('L') > 0;
   string pubkey_path = *args.find('k')->second;
   if (DirectoryExists(pubkey_path))
-    pubkey_path = JoinStrings(FindFiles(pubkey_path, ".pub"), ":");
+    pubkey_path = JoinStrings(FindFilesBySuffix(pubkey_path, ".pub"), ":");
   string tagname_from = "trunk-previous";
   string tagname_to = "trunk";
   if (args.count('s') > 0) tagname_from = *args.find('s')->second;

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -60,7 +60,7 @@ int CommandGc::Main(const ArgumentList &args) {
   std::string repo_keys = (args.count('k') > 0) ?
     *args.find('k')->second : "";
   if (DirectoryExists(repo_keys))
-    repo_keys = JoinStrings(FindFiles(repo_keys, ".pub"), ":");
+    repo_keys = JoinStrings(FindFilesBySuffix(repo_keys, ".pub"), ":");
   const bool dry_run = (args.count('d') > 0);
   const bool list_condemned_objects = (args.count('l') > 0);
   const std::string temp_directory = (args.count('t') > 0) ?

--- a/cvmfs/swissknife_lsrepo.cc
+++ b/cvmfs/swissknife_lsrepo.cc
@@ -47,7 +47,7 @@ int CommandListCatalogs::Main(const ArgumentList &args) {
   std::string repo_keys =
     (args.count('k') > 0) ? *args.find('k')->second : "";
   if (DirectoryExists(repo_keys))
-    repo_keys = JoinStrings(FindFiles(repo_keys, ".pub"), ":");
+    repo_keys = JoinStrings(FindFilesBySuffix(repo_keys, ".pub"), ":");
   const std::string &tmp_dir   =
     (args.count('l') > 0) ? *args.find('l')->second : "/tmp";
   if (args.count('h') > 0) {

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -520,7 +520,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   }
   string master_keys = *args.find('k')->second;
   if (DirectoryExists(master_keys))
-    master_keys = JoinStrings(FindFiles(master_keys, ".pub"), ":");
+    master_keys = JoinStrings(FindFilesBySuffix(master_keys, ".pub"), ":");
   const string repository_name = *args.find('m')->second;
   string trusted_certs;
   if (args.find('y') != args.end())

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -865,6 +865,30 @@ vector<string> FindFilesBySuffix(const string &dir, const string &suffix) {
 
 
 /**
+ * Returns ls $dir/$prefixGLOB
+ */
+vector<string> FindFilesByPrefix(const string &dir, const string &prefix) {
+  vector<string> result;
+  DIR *dirp = opendir(dir.c_str());
+  if (!dirp)
+    return result;
+
+  platform_dirent64 *dirent;
+  while ((dirent = platform_readdir(dirp))) {
+    const string name(dirent->d_name);
+    if ((name.length() >= prefix.length()) &&
+        (name.substr(0, prefix.length()) == prefix))
+    {
+      result.push_back(dir + "/" + name);
+    }
+  }
+  closedir(dirp);
+  sort(result.begin(), result.end());
+  return result;
+}
+
+
+/**
  * Finds all direct subdirectories under parent_dir (except ., ..).  Used,
  * for instance, to parse /etc/cvmfs/repositories.d/<reponoame>
  */

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -843,7 +843,7 @@ bool RemoveTree(const string &path) {
 /**
  * Returns ls $dir/GLOB$suffix
  */
-vector<string> FindFiles(const string &dir, const string &suffix) {
+vector<string> FindFilesBySuffix(const string &dir, const string &suffix) {
   vector<string> result;
   DIR *dirp = opendir(dir.c_str());
   if (!dirp)

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -85,6 +85,8 @@ void UnlockFile(const int filedes);
 bool RemoveTree(const std::string &path);
 std::vector<std::string> FindFilesBySuffix(const std::string &dir,
                                            const std::string &suffix);
+std::vector<std::string> FindFilesByPrefix(const std::string &dir,
+                                           const std::string &prefix);
 std::vector<std::string> FindDirectories(const std::string &parent_dir);
 
 bool GetUidOf(const std::string &username, uid_t *uid, gid_t *main_gid);

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -83,8 +83,8 @@ int LockFile(const std::string &path);
 int WritePidFile(const std::string &path);
 void UnlockFile(const int filedes);
 bool RemoveTree(const std::string &path);
-std::vector<std::string> FindFiles(const std::string &dir,
-                                   const std::string &suffix);
+std::vector<std::string> FindFilesBySuffix(const std::string &dir,
+                                           const std::string &suffix);
 std::vector<std::string> FindDirectories(const std::string &parent_dir);
 
 bool GetUidOf(const std::string &username, uid_t *uid, gid_t *main_gid);

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -251,6 +251,7 @@ const unsigned T_ExternalCacheManager::nfiles = 128;
 TEST_F(T_ExternalCacheManager, Connection) {
   EXPECT_GE(cache_mgr_->session_id(), 0);
   EXPECT_EQ(getpid(), cache_mgr_->quota_mgr()->GetPid());
+  EXPECT_TRUE(cache_mgr_->GetBackingDirectory().empty());
 
   // Invalid query for session information outside callback
   uint64_t id;

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -22,6 +22,7 @@ class T_TieredCacheManager : public ::testing::Test {
       new RamCacheManager(1024, 128, MemoryKvStore::kMallocLibc,
                           perf::StatisticsTemplate("test", &stats_lower_));
     tiered_cache_ = TieredCacheManager::Create(upper_cache_, lower_cache_);
+    EXPECT_TRUE(tiered_cache_->GetBackingDirectory().empty());
     buf_ = 'x';
     hash_one_.digest[1] = 1;
   }

--- a/test/unittests/t_mountpoint.cc
+++ b/test/unittests/t_mountpoint.cc
@@ -428,6 +428,7 @@ TEST_F(T_MountPoint, TieredCacheMgr) {
       fs->cache_mgr())->upper_->id());
     EXPECT_EQ(kPosixCacheManager, reinterpret_cast<TieredCacheManager *>(
       fs->cache_mgr())->lower_->id());
+    EXPECT_EQ(".", fs->cache_mgr()->GetBackingDirectory());
   }
 
   options_mgr_.SetValue("CVMFS_CACHE_tiered_LOWER", "ram_lower");
@@ -448,6 +449,7 @@ TEST_F(T_MountPoint, TieredCacheMgr) {
 
 
 TEST_F(T_MountPoint, TieredComplex) {
+  options_mgr_.SetValue("CVMFS_WORKSPACE", ".");
   options_mgr_.SetValue("CVMFS_CACHE_PRIMARY", "tiered");
   options_mgr_.SetValue("CVMFS_CACHE_tiered_TYPE", "tiered");
   options_mgr_.SetValue("CVMFS_CACHE_tiered_UPPER", "tiered_upper");
@@ -481,6 +483,16 @@ TEST_F(T_MountPoint, TieredComplex) {
     EXPECT_EQ(kRamCacheManager, upper->lower_->id());
     EXPECT_EQ(kPosixCacheManager, lower->upper_->id());
     EXPECT_EQ(kPosixCacheManager, lower->lower_->id());
+    EXPECT_EQ(tmp_path_ + "/lu/unit-test",
+              fs->cache_mgr()->GetBackingDirectory());
+  }
+
+  CreateFile(tmp_path_ + "/ll/unit-test/cvmfschecksum.unit-test", 0600);
+  {
+    UniquePtr<FileSystem> fs(FileSystem::Create(fs_info_));
+    EXPECT_EQ(loader::kFailOk, fs->boot_status()) << fs->boot_error();
+    EXPECT_EQ(tmp_path_ + "/ll/unit-test",
+              fs->cache_mgr()->GetBackingDirectory());
   }
 }
 
@@ -524,6 +536,7 @@ TEST_F(T_MountPoint, CacheSettings) {
     EXPECT_EQ(tmp_path_ + "/alien",
               reinterpret_cast<PosixCacheManager *>(
                 fs->cache_mgr())->cache_path());
+    EXPECT_EQ(tmp_path_ + "/alien", fs->cache_mgr()->GetBackingDirectory());
   }
 
   fs_info_.type = FileSystem::kFsFuse;
@@ -534,6 +547,7 @@ TEST_F(T_MountPoint, CacheSettings) {
     EXPECT_EQ(tmp_path_ + "/alien",
               reinterpret_cast<PosixCacheManager *>(
                 fs->cache_mgr())->cache_path());
+    EXPECT_EQ(tmp_path_ + "/alien", fs->cache_mgr()->GetBackingDirectory());
   }
 
   RemoveTree(tmp_path_ + "/unit-test");
@@ -549,6 +563,7 @@ TEST_F(T_MountPoint, CacheSettings) {
       fs->cache_mgr())->cache_path());
     EXPECT_EQ(".", fs->workspace());
     EXPECT_EQ(tmp_path_ + "/nfs", fs->nfs_maps_dir_);
+    EXPECT_EQ(".", fs->cache_mgr()->GetBackingDirectory());
   }
 
   options_mgr_.SetValue("CVMFS_CACHE_DIR", tmp_path_ + "/cachedir_direct");
@@ -560,6 +575,7 @@ TEST_F(T_MountPoint, CacheSettings) {
   {
     UniquePtr<FileSystem> fs(FileSystem::Create(fs_info_));
     EXPECT_EQ(loader::kFailOk, fs->boot_status());
+    EXPECT_EQ(".", fs->cache_mgr()->GetBackingDirectory());
   }
 }
 

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -284,7 +284,7 @@ TEST_F(T_QuotaManager, Workspace) {
   string workspace = "./cvmfs_ut_quota_workspace";
   string cache_workspace = tmp_path_ + ":" + workspace;
   ASSERT_TRUE(MkdirDeep(workspace, 0700));
-  vector<string> dir_entries = FindFiles(workspace, "");
+  vector<string> dir_entries = FindFilesBySuffix(workspace, "");
   // Only ., ..
   EXPECT_EQ(2U, dir_entries.size());
   delete quota_mgr_;

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -936,30 +936,30 @@ TEST_F(T_Util, CreateTempDir) {
   EXPECT_TRUE(DirectoryExists(directory)) << errno;
 }
 
-TEST_F(T_Util, FindFiles) {
+TEST_F(T_Util, FindFilesBySuffix) {
   vector<string> result;
   string files[] = { "file1.txt", "file2.txt", "file3.conf" };
   const unsigned size = 3;
   for (unsigned i = 0; i < size; ++i)
     CreateFileWithContent(files[i], files[i]);
 
-  result = FindFiles("/fakepath/fakedir", "");
+  result = FindFilesBySuffix("/fakepath/fakedir", "");
   EXPECT_TRUE(result.empty());
 
-  result = FindFiles(sandbox, "");  // find them all
+  result = FindFilesBySuffix(sandbox, "");  // find them all
   // FindFiles includes . and .. and the precreated large directory
   EXPECT_EQ(size + 3, result.size());
   for (unsigned i = 0; i < size; ++i)
     EXPECT_EQ(sandbox + "/" + files[i], result[i + 2]);
 
-  result = FindFiles(sandbox, ".fake");
+  result = FindFilesBySuffix(sandbox, ".fake");
   EXPECT_EQ(0u, result.size());
 
-  result = FindFiles(sandbox, ".conf");
+  result = FindFilesBySuffix(sandbox, ".conf");
   EXPECT_EQ(1u, result.size());
   EXPECT_EQ(sandbox + "/" + files[2], result[0]);
 
-  result = FindFiles(sandbox, ".txt");
+  result = FindFilesBySuffix(sandbox, ".txt");
   EXPECT_EQ(2u, result.size());
   EXPECT_EQ(sandbox + "/" + files[0], result[0]);
   EXPECT_EQ(sandbox + "/" + files[1], result[1]);

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -966,6 +966,39 @@ TEST_F(T_Util, FindFilesBySuffix) {
 }
 
 
+TEST_F(T_Util, FindFilesByPrefix) {
+  vector<string> result;
+  string files[] = { "file.txt", "file.conf", "foo.conf" };
+  const unsigned size = 3;
+  for (unsigned i = 0; i < size; ++i)
+    CreateFileWithContent(files[i], files[i]);
+
+  result = FindFilesByPrefix("/fakepath/fakedir", "");
+  EXPECT_TRUE(result.empty());
+
+  result = FindFilesByPrefix(sandbox, "");  // find them all
+  // FindFiles includes . and .. and the precreated large directory
+  EXPECT_EQ(size + 3, result.size());
+  EXPECT_EQ(sandbox + "/" + files[1], result[2]);
+  EXPECT_EQ(sandbox + "/" + files[0], result[3]);
+  EXPECT_EQ(sandbox + "/" + files[2], result[4]);
+
+  result = FindFilesByPrefix(sandbox, "none");
+  EXPECT_EQ(0u, result.size());
+
+  result = FindFilesByPrefix(sandbox, "file.");
+  EXPECT_EQ(2u, result.size());
+  EXPECT_EQ(sandbox + "/" + files[1], result[0]);
+  EXPECT_EQ(sandbox + "/" + files[0], result[1]);
+
+  result = FindFilesByPrefix(sandbox, "f");
+  EXPECT_EQ(3u, result.size());
+  EXPECT_EQ(sandbox + "/" + files[1], result[0]);
+  EXPECT_EQ(sandbox + "/" + files[0], result[1]);
+  EXPECT_EQ(sandbox + "/" + files[2], result[2]);
+}
+
+
 TEST_F(T_Util, FindDirectories) {
   string parent = sandbox + "/test-find-directories";
   ASSERT_TRUE(MkdirDeep(parent, 0700));


### PR DESCRIPTION
A cache manager can now indicate a backing directory, which is currently only used for the cvmfschecksum file.  It could be used for other, non CAS objects which are tightly coupled to the cache.

There is not yet a means for cache plugins to pass a backing directory back to the client.