### PR TITLE
Add dac_read_search capability to publish forbidden files

### DIFF
--- a/cvmfs/server/cvmfs_server_fix_permissions.sh
+++ b/cvmfs/server/cvmfs_server_fix_permissions.sh
@@ -15,6 +15,8 @@ cvmfs_server_fix_permissions() {
     -exec grep "CVMFS_UNION_FS_TYPE=overlayfs" {} \; | wc -l)
   if [ $num_overlayfs -gt 0 ]; then
     ensure_swissknife_suid overlayfs
+  else
+    ensure_swissknife_suid other
   fi
 }
 

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -488,9 +488,9 @@ bool swissknife::CommandSync::ReadFileChunkingArgs(
 
 bool swissknife::CommandSync::ObtainDacReadSearchCapability() {
   cap_value_t cap = CAP_DAC_READ_SEARCH;
-  #ifdef CAP_IS_SUPPORTED
-  assert (CAP_IS_SUPPORTED(cap));
-  #endif
+#ifdef CAP_IS_SUPPORTED
+  assert(CAP_IS_SUPPORTED(cap));
+#endif
 
   cap_t caps_proc = cap_get_proc();
   assert(caps_proc != NULL);

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -313,6 +313,7 @@ class CommandSync : public Command {
   bool ReadFileChunkingArgs(const swissknife::ArgumentList &args,
                             SyncParameters *params);
   bool CheckParams(const SyncParameters &p);
+  bool ObtainDacReadSearchCapability();
 };
 
 }  // namespace swissknife

--- a/test/src/649-zeropermission/main
+++ b/test/src/649-zeropermission/main
@@ -1,0 +1,32 @@
+cvmfs_test_name="Publish files that forbid being read"
+cvmfs_test_autofs_on_startup=false
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "*** create file with permission 000"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  mkdir /cvmfs/$CVMFS_TEST_REPO/dir || return 10
+  echo "secret" > /cvmfs/$CVMFS_TEST_REPO/dir/hidden || return 10
+  echo "content" > /cvmfs/$CVMFS_TEST_REPO/shadow || return 10
+  chmod 000 /cvmfs/$CVMFS_TEST_REPO/shadow || return 11
+  chmod 000 /cvmfs/$CVMFS_TEST_REPO/dir || return 11
+  if [ $(id -u) -ne 0 ]; then
+    cat /cvmfs/$CVMFS_TEST_REPO/shadow && return 12
+    cat /cvmfs/$CVMFS_TEST_REPO/dir/hidden && return 12
+  fi
+  publish_repo $CVMFS_TEST_REPO || return 13
+  check_repository $CVMFS_TEST_REPO -i  || return $?
+
+  if [ $(id -u) -ne 0 ]; then
+    cat /cvmfs/$CVMFS_TEST_REPO/shadow && return 20
+    cat /cvmfs/$CVMFS_TEST_REPO/dir/hidden && return 20
+  fi
+
+  return 0
+}
+


### PR DESCRIPTION
The CAP_DAC_READ_SEARCH capability is necessary to publish containers, in particular the /etc/shadow files in containers with mode 000.