### PR TITLE
Remove "-e" parameter from cvmfs_server {transaction,publish,abort} (GW)

### DIFF
--- a/cvmfs/server/cvmfs_server_abort.sh
+++ b/cvmfs/server/cvmfs_server_abort.sh
@@ -10,7 +10,6 @@ cvmfs_server_abort() {
   local user
   local gw_key_file
   local spool_dir
-  local exact=0
   local force=0
   local open_fd_dialog=1
   local retcode=0
@@ -24,9 +23,6 @@ cvmfs_server_abort() {
         force=1
         open_fd_dialog=0
       ;;
-      e) # Need this mode if passing repository subpaths: cvmfs_server transaction myrepo.cern.ch/some/subpath
-        exact=1
-      ;;
       ?)
         shift $(($OPTIND-2))
         usage "Command abort: Unrecognized option: $1"
@@ -37,12 +33,8 @@ cvmfs_server_abort() {
   shift $(($OPTIND-1))
   check_parameter_count_for_multiple_repositories $#
   # get repository names
-  if [ $exact -eq 0 ]; then
-      names=$(get_or_guess_multiple_repository_names "$@")
-      check_multiple_repository_existence "$names"
-  else
-      names=$@
-  fi
+  names=$(get_or_guess_multiple_repository_names "$@")
+  check_multiple_repository_existence "$names"
 
   for name in $names; do
 

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -136,9 +136,12 @@ check_multiple_repository_existence() {
   local no_kill=$2
 
   for name in $given_names; do
-    if ! check_repository_existence $name; then
+    # If "name" contains a subpath (i.e. repo.cern.ch/sub/path) only
+    # the repository name should be kept
+    local repo_name=$(echo $name | cut -d'/' -f1)
+    if ! check_repository_existence $repo_name; then
       if [ x"$no_kill" = x"" ]; then
-        die "The repository $name does not exist."
+        die "The repository $repo_name does not exist."
       else
         return 1
       fi

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -1,7 +1,6 @@
 cvmfs_server_publish() {
   local names
   local user
-  local exact=0
   local gw_key_file
   local spool_dir
   local stratum0
@@ -60,9 +59,6 @@ cvmfs_server_publish() {
       f)
         open_fd_dialog=0
       ;;
-      e)
-        exact=1
-      ;;
       ?)
         shift $(($OPTIND-2))
         usage "Command publish: Unrecognized option: $1"
@@ -77,12 +73,8 @@ cvmfs_server_publish() {
   shift $(($OPTIND-1))
   check_parameter_count_for_multiple_repositories $#
   # get repository names
-  if [ $exact -eq 0 ]; then
-    names=$(get_or_guess_multiple_repository_names "$@")
-    check_multiple_repository_existence "$names"
-  else
-    names=$@
-  fi
+  names=$(get_or_guess_multiple_repository_names "$@")
+  check_multiple_repository_existence "$names"
 
   for name in $names; do
     # sanity checks

--- a/cvmfs/server/cvmfs_server_transaction.sh
+++ b/cvmfs/server/cvmfs_server_transaction.sh
@@ -16,7 +16,6 @@ cvmfs_server_transaction() {
   local gw_key_file
   local spool_dir
   local stratum0
-  local exact=0
   local force=0
   local retcode=0
 
@@ -28,9 +27,6 @@ cvmfs_server_transaction() {
       f)
         force=1
       ;;
-      e) # Need this mode if passing repository subpaths: cvmfs_server transaction myrepo.cern.ch/some/subpath
-        exact=1
-      ;;
       ?)
         shift $(($OPTIND-2))
         usage "Command transaction: Unrecognized option: $1"
@@ -40,13 +36,8 @@ cvmfs_server_transaction() {
 
   shift $(($OPTIND-1))
   check_parameter_count_for_multiple_repositories $#
-  # get repository names
-  if [ $exact -eq 0 ]; then
-      names=$(get_or_guess_multiple_repository_names "$@")
-      check_multiple_repository_existence "$names"
-  else
-      names=$@
-  fi
+  names=$(get_or_guess_multiple_repository_names "$@")
+  check_multiple_repository_existence "$names"
 
   # sanity checks
   check_autofs_on_cvmfs && die "Autofs on /cvmfs has to be disabled"

--- a/test/src/800-repository_services/main
+++ b/test/src/800-repository_services/main
@@ -49,13 +49,13 @@ run_transactions() {
     echo "Pre-checks"
 
     ## Pre-checks: starting and aborting transactions should leave no trace
-    cvmfs_server transaction -e test.repo.org
-    cvmfs_server abort -f -e test.repo.org
+    cvmfs_server transaction test.repo.org
+    cvmfs_server abort -f test.repo.org
     cvmfs_server check test.repo.org
 
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
     cp -r /usr/bin /cvmfs/test.repo.org
-    cvmfs_server abort -f -e test.repo.org
+    cvmfs_server abort -f test.repo.org
     cvmfs_server check test.repo.org
 
     echo "Checking transaction + publish"
@@ -63,7 +63,7 @@ run_transactions() {
     ## Transaction 1 (Modifying existing file and creating a new one)
 
     echo "  Starting transaction 1"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Writing to a new file"
     echo "test" >> /cvmfs/test.repo.org/new_file.txt
@@ -72,7 +72,7 @@ run_transactions() {
     echo "test" >> /cvmfs/test.repo.org/new_repository
 
     echo "  Publishing changes 1"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -81,7 +81,7 @@ run_transactions() {
     ## Transaction 2 (Deleting a file and creating a new directory with the same name)
 
     echo "  Starting transaction 2"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Replacing a file with a directory"
     rm -v /cvmfs/test.repo.org/new_repository
@@ -89,7 +89,7 @@ run_transactions() {
     echo "test" >> /cvmfs/test.repo.org/new_repository/another_file.txt
 
     echo "  Publishing changes 2"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -98,13 +98,13 @@ run_transactions() {
     ## Transaction 3 (Deleting the directory created in the previous transaction)
 
     echo "  Starting transaction 3"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Deleting a directory"
     rm -rv /cvmfs/test.repo.org/new_repository
 
     echo "  Publishing changes 3"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -113,7 +113,7 @@ run_transactions() {
     ## Transaction 4 (Creating a new deep directory sub-tree)
 
     echo "  Starting transaction 4"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Create a deep directory hierarchy"
     mkdir -p /cvmfs/test.repo.org/a/b
@@ -121,7 +121,7 @@ run_transactions() {
     echo "New file" > /cvmfs/test.repo.org/new
 
     echo "  Publishing changes 4"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -130,7 +130,7 @@ run_transactions() {
     ## Transaction 5 (Creating a new deep directory sub-tree in place of a former file)
 
     echo "  Starting transaction 5"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Create a deep directory hierarchy"
     rm -rv /cvmfs/test.repo.org/new
@@ -138,7 +138,7 @@ run_transactions() {
     echo "New file" > /cvmfs/test.repo.org/new/c/d/new_file.txt
 
     echo "  Publishing changes 5"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -147,11 +147,11 @@ run_transactions() {
     ## Transaction 6 (Lease on a subpath - valid changes)
 
     echo "  Starting transaction 6"
-    cvmfs_server transaction -e test.repo.org/new/c
+    cvmfs_server transaction test.repo.org/new/c
     echo "New file" > /cvmfs/test.repo.org/new/c/another_file.txt
 
     echo "  Publishing changes 6"
-    cvmfs_server publish -e test.repo.org/new/c
+    cvmfs_server publish test.repo.org/new/c
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -160,11 +160,11 @@ run_transactions() {
     ## Transaction 7 (Lease on a subpath - changes outside of lease)
 
     echo "  Starting transaction 7"
-    cvmfs_server transaction -e test.repo.org/new/c
+    cvmfs_server transaction test.repo.org/new/c
     echo "New file" > /cvmfs/test.repo.org/new/invalid_file.txt
 
     echo "  Publishing changes 7"
-    cvmfs_server publish -e test.repo.org/new/c
+    cvmfs_server publish test.repo.org/new/c
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -174,11 +174,11 @@ run_transactions() {
 
     echo "  Starting transaction 8"
     num_tags_before=$(cvmfs_server tag -l test.repo.org | grep generic | wc -l)
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
     echo "New file" > /cvmfs/test.repo.org/marker
 
     echo "  Publishing changes 8"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Get list of tags"
@@ -188,11 +188,11 @@ run_transactions() {
     ## Transaction 8 (Check creation of named tag)
 
     echo "  Starting transaction 9"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
     echo "New file" > /cvmfs/test.repo.org/marker
 
     echo "  Publishing changes 9"
-    cvmfs_server publish -a specialtag -e test.repo.org
+    cvmfs_server publish -a specialtag test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Check that the named tag has been created"

--- a/test/src/801-repository_services_slow/main
+++ b/test/src/801-repository_services_slow/main
@@ -56,7 +56,7 @@ run_transactions() {
     ## Transaction 1
 
     echo "  Starting transaction 1"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Copying the payload into repository"
     rm -v /cvmfs/test.repo.org/new_repository
@@ -69,7 +69,7 @@ run_transactions() {
     cp -r /tmp/linux-4.12.8 /cvmfs/test.repo.org/
 
     echo "  Publishing changes 1"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -78,13 +78,13 @@ run_transactions() {
     ## Transaction 2 (remove all the files from the repo)
 
     echo "  Starting transaction 2"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Removing all the files from the repository"
     rm -rf /cvmfs/test.repo.org/*
 
     echo "  Publishing changes 2"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     ## Check results with a poor man's Merkle tree

--- a/test/src/802-repository_services_nested_catalogs/main
+++ b/test/src/802-repository_services_nested_catalogs/main
@@ -52,7 +52,7 @@ run_transactions() {
 
     ## Transaction 1
     echo "  Starting transaction 1 (Creating a deep directory tree which is assigned to a sub-catalog)"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Create a deep directory hierarchy"
     mkdir -p /cvmfs/test.repo.org/a
@@ -60,7 +60,7 @@ run_transactions() {
     touch /cvmfs/test.repo.org/a/.cvmfscatalog
 
     echo "  Publishing changes 1"
-    cvmfs_server publish -v -e test.repo.org
+    cvmfs_server publish -v test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -77,7 +77,7 @@ run_transactions() {
 
     ## Transaction 2
     echo "  Starting transaction 2 (Replace a file with a directory tree, which is assigned to a sub-catalog)"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Create a deep directory hierarchy"
     rm -v /cvmfs/test.repo.org/a/b
@@ -86,7 +86,7 @@ run_transactions() {
     touch /cvmfs/test.repo.org/a/b/.cvmfscatalog
 
     echo "  Publishing changes 2"
-    cvmfs_server publish -v -e test.repo.org
+    cvmfs_server publish -v test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -103,14 +103,14 @@ run_transactions() {
 
     ## Transaction 3
     echo "  Starting transaction 3 (Remove nested catalogs)"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Remove all the nested catalogs and have their contents merged into the root catalog"
     rm -v /cvmfs/test.repo.org/a/.cvmfscatalog
     rm -v /cvmfs/test.repo.org/a/b/.cvmfscatalog
 
     echo "  Publishing changes 3"
-    cvmfs_server publish -v -e test.repo.org
+    cvmfs_server publish -v test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -134,7 +134,7 @@ run_transactions() {
 
     ## Transaction 4
     echo "  Starting transaction 4 (Create nested catalogs with .cvmfsdirtab)"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Add .cvmfsdirtab file"
     echo "/dir1" >> /cvmfs/test.repo.org/.cvmfsdirtab
@@ -144,9 +144,9 @@ run_transactions() {
     mkdir -p /cvmfs/test.repo.org/dir{1,2}
     echo "New file" > /cvmfs/test.repo.org/dir1/a.txt
     echo "New file" > /cvmfs/test.repo.org/dir2/b.txt
-    
+
     echo "  Publishing changes 4"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Checking results 4"
@@ -165,7 +165,7 @@ run_transactions() {
 
     ## Transaction 5
     echo "  Starting transaction 5 (Remove .cvmfsdirtab)"
-    cvmfs_server transaction -e test.repo.org
+    cvmfs_server transaction test.repo.org
 
     echo "  Remove .cvmfsdirtab and .cvmfscatalog files"
     rm -f /cvmfs/test.repo.org/.cvmfsdirtab
@@ -173,7 +173,7 @@ run_transactions() {
     rm -f /cvmfs/test.repo.org/dir2/.cvmfscatalog
 
     echo "  Publishing changes 5"
-    cvmfs_server publish -e test.repo.org
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Checking results 5"


### PR DESCRIPTION
Addresses [CVM-1445](https://sft.its.cern.ch/jira/browse/CVM-1445).

With these changes, you no longer need to supply the "-e" parameter for `cvmfs_server {transaction,publish,abort}` when working with a repository gateway upstream.