### PR TITLE
Fix integration tests for gateway key subpath permissions

### DIFF
--- a/cvmfs/gateway_util.cc
+++ b/cvmfs/gateway_util.cc
@@ -37,7 +37,7 @@ bool ReadKeys(const std::string& key_file_name, std::string* key_id,
     return false;
   }
 
-  if (tokens[0] == "test") {
+  if (tokens[0] == "plain_text") {
     *key_id = tokens[1];
     *secret = tokens[2];
   } else {

--- a/test/test_functions
+++ b/test/test_functions
@@ -2402,7 +2402,7 @@ set_up_repository_services() {
     echo "  Writing configuration files"
     sudo bash -c 'cat <<EOF > /opt/cvmfs_services/etc/repo.config
 {repos, [{<<"test.repo.org">>, [<<"key1">>]}]}.
-{keys, [{file, "/etc/cvmfs/keys/test.repo.org.gw"}]}.
+{keys, [{file, <<"/etc/cvmfs/keys/test.repo.org.gw">>, <<"/">>}]}.
 EOF'
 
     echo "  Writing API key file"

--- a/test/test_functions
+++ b/test/test_functions
@@ -2407,7 +2407,7 @@ EOF'
 
     echo "  Writing API key file"
     sudo bash -c 'cat <<EOF > /etc/cvmfs/keys/test.repo.org.gw
-test key1 secret1
+plain_text key1 secret1
 EOF'
 
     echo "  Creating Mnesia schema"


### PR DESCRIPTION
Related to [CVM-1427](https://sft.its.cern.ch/jira/browse/CVM-1427).

Only modifies the set up function of the repository gateway integration tests.