### PR TITLE
FileWatcher background thread should be spawned after process fork

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1864,6 +1864,7 @@ static void Spawn() {
 
   cvmfs::mount_point_->download_mgr()->Spawn();
   cvmfs::mount_point_->external_download_mgr()->Spawn();
+  cvmfs::mount_point_->resolv_conf_watcher()->Spawn();
   QuotaManager *quota_mgr = cvmfs::file_system_->cache_mgr()->quota_mgr();
   quota_mgr->Spawn();
   if (quota_mgr->HasCapability(QuotaManager::kCapListeners)) {

--- a/cvmfs/file_watcher.cc
+++ b/cvmfs/file_watcher.cc
@@ -32,7 +32,7 @@ void FileWatcher::RegisterHandler(const std::string& file_path,
   handler_map_[file_path] = handler;
 }
 
-bool FileWatcher::Start() {
+bool FileWatcher::Spawn() {
   if (started_) {
     return false;
   }

--- a/cvmfs/file_watcher.h
+++ b/cvmfs/file_watcher.h
@@ -56,7 +56,7 @@ class FileWatcher {
   void RegisterHandler(const std::string& file_path,
                        EventHandler* handler);
 
-  bool Start();
+  bool Spawn();
 
   void Stop();
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1252,7 +1252,6 @@ bool MountPoint::CreateResolvConfWatcher() {
       ResolvConfEventHandler *handler =
           new ResolvConfEventHandler(download_mgr_, external_download_mgr_);
       resolv_conf_watcher_->RegisterHandler("/etc/resolv.conf", handler);
-      resolv_conf_watcher_->Start();
     }
   } else {
     LogCvmfs(kLogCvmfs, kLogDebug,

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -381,6 +381,9 @@ class MountPoint : SingleCopy, public BootFactory {
   download::DownloadManager *external_download_mgr() {
     return external_download_mgr_;
   }
+  file_watcher::FileWatcher* resolv_conf_watcher() {
+    return resolv_conf_watcher_;
+  }
   cvmfs::Fetcher *fetcher() { return fetcher_; }
   bool fixed_catalog() { return fixed_catalog_; }
   std::string fqrn() { return fqrn_; }

--- a/test/unittests/t_file_watcher.cc
+++ b/test/unittests/t_file_watcher.cc
@@ -61,7 +61,7 @@ TEST_F(T_FileWatcher, kModifiedEvent) {
     TestEventHandler* hd(new TestEventHandler(&counters_, channel_.weak_ref()));
     watcher->RegisterHandler(watched_file_name, hd);
 
-    EXPECT_TRUE(watcher->Start());
+    EXPECT_TRUE(watcher->Spawn());
 
     SafeWriteToFile("test", watched_file_name, 0600);
 
@@ -87,7 +87,7 @@ TEST_F(T_FileWatcher, kDeletedEvent) {
     TestEventHandler* hd(new TestEventHandler(&counters_, channel_.weak_ref()));
     watcher->RegisterHandler(watched_file_name, hd);
 
-    EXPECT_TRUE(watcher->Start());
+    EXPECT_TRUE(watcher->Spawn());
 
     unlink(watched_file_name.c_str());
 
@@ -114,7 +114,7 @@ TEST_F(T_FileWatcher, kModifiedThenDeletedEvent) {
     hd->clear_ = false;
     watcher->RegisterHandler(watched_file_name, hd);
 
-    EXPECT_TRUE(watcher->Start());
+    EXPECT_TRUE(watcher->Spawn());
 
     SafeWriteToFile("test", watched_file_name, 0600);
 


### PR DESCRIPTION
Related to [CVM-496](https://sft.its.cern.ch/jira/browse/CVM-496).

This addresses the issue where the background thread of the `FileWatcher` object responsible for reacting to changes in the `/etc/resolv.conf` file was spawned too early, before the main client process forks to background.