### PR TITLE
Updating the set up function for the repository gateway integration tests

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -2437,10 +2437,7 @@ plain_text key1 secret1
 EOF'
 
     echo "  Creating Mnesia schema"
-    sudo mkdir -p /opt/cvmfs_mnesia
-    sudo chown `whoami`:`whoami` /opt/cvmfs_mnesia
-    cd /opt/cvmfs_gateway
-    ./scripts/setup.sh
+    sudo /opt/cvmfs_gateway/scripts/setup.sh
 
     echo "  Creating test repo"
     sudo -E cvmfs_server mkfs -o `whoami` test.repo.org
@@ -2452,24 +2449,5 @@ EOF'
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 
     echo "  Starting repository gateway application"
-    /opt/cvmfs_gateway/scripts/run_cvmfs_gateway.sh start
-
-    # Waiting here is necessary in order to give the cvmfs_gateway application enough time to boot
-    wait_for_app_start
+    sudo /opt/cvmfs_gateway/scripts/run_cvmfs_gateway.sh start
 }
-
-wait_for_app_start() {
-    local reply=$(/opt/cvmfs_gateway/bin/cvmfs_gateway ping | awk {'print $1'})
-    local num_iter=1
-    while [ $reply != "pong" ]; do
-        sleep 1
-        reply=$(/opt/cvmfs_gateway/bin/cvmfs_gateway ping | awk {'print $1'})
-        echo "Num iter: $num_iter"
-        num_iter=$((num_iter + 1))
-        if [ $num_iter -eq 10 ]; then
-            break;
-        fi
-    done
-    echo $reply
-}
-


### PR DESCRIPTION
The repository gateway is simpler to set up after the changes to `cvmfs_gateway` introduced in  [PR #47](https://github.com/cvmfs/cvmfs_gateway/pull/47).