### PR TITLE
write checksum to computed checksum dir

### DIFF
--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -220,7 +220,7 @@ LoadError ClientCatalogManager::LoadCatalog(
   fetcher_->cache_mgr()->CommitFromMem(ensemble.manifest->certificate(),
                                        ensemble.cert_buf, ensemble.cert_size,
                                        "certificate for " + repo_name_);
-  ensemble.manifest->ExportChecksum(".", 0600);
+  ensemble.manifest->ExportChecksum(checksum_dir, 0600);
   return catalog::kLoadNew;
 }
 


### PR DESCRIPTION
Using parrot, we found that the repository checksums were being written to the current working directory, rather than the usual temp directory. I believe this is because the checksum_dir was not being used when writing the file.

Doing an strace, it seems that first libcvmfs does try to read the checksum from the temp dir, but then it writes it in the current directory:

open("/tmp/parrot.196886/cvmfs/cvmfschecksum.cms.cern.ch", O_RDONLY) = -1 ENOENT (No such file or directory)
open("./cvmfschecksum.cms.cern.ch.wObQ37", O_RDWR|O_CREAT|O_EXCL, 0600) = 9
rename("./cvmfschecksum.cms.cern.ch.wObQ37", "./cvmfschecksum.cms.cern.ch") = 0

