### PR TITLE
Fix integration tests

### DIFF
--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -19,7 +19,7 @@ Description: CernVM File System
 Package: cvmfs-server
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: insserv, initscripts, bash, coreutils, grep, sed, psmisc, curl, gzip, attr, openssl, apache2, libcap2, lsof, rsync, jq, usbutils
+Depends: insserv, initscripts, bash, coreutils, grep, sed, psmisc, curl, gzip, attr, openssl, apache2, libcap2, libcap2-bin, lsof, rsync, jq, usbutils
 Conflicts: cvmfs-server (< 2.1)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -27,14 +27,14 @@ fi
 if [ x"$(lsb_release -cs)" = x"trusty" ]; then
   # Ubuntu 14.04
   # aufs, expected failure
-  CVMFS_EXCLUDE="src/700-overlayfs_validation src/80*-repository_gateway"
+  CVMFS_EXCLUDE="src/700-overlayfs_validation src/80*-repository_gateway*"
 
   echo "Ubuntu 14.04... using aufs instead of overlayfs"
 fi
 if [ x"$(lsb_release -cs)" = x"precise" ]; then
   # Ubuntu 12.04
   # aufs, expected failure
-  CVMFS_EXCLUDE="src/614-geoservice src/700-overlayfs_validation src/80*-repository_gateway"
+  CVMFS_EXCLUDE="src/614-geoservice src/700-overlayfs_validation src/80*-repository_gateway*"
 
   echo "Ubuntu 12.04... using aufs instead of overlayfs"
 fi

--- a/test/src/641-diff/main
+++ b/test/src/641-diff/main
@@ -78,16 +78,16 @@ S S 1
 S D 1
 S N 1
 M[N] D /dir2
-A F /dir2/.cvmfscatalog
-A D /dir3
-A F /dir3/new_file
-A F /dir3/.cvmfscatalog
+A F /dir2/.cvmfscatalog +0
+A D /dir3 +4096
+A F /dir3/new_file +0
+A F /dir3/.cvmfscatalog +0
 M[SC] F /file
-R S /symlink
+R S /symlink -4
 M[SMLC] FS /directory/foo
 M[N] D /directory/nested
-R F /directory/nested/.cvmfscatalog
-A S /other-symlink
+R F /directory/nested/.cvmfscatalog -0
+A S /other-symlink +4
 EOF
   cvmfs_server diff -im $CVMFS_TEST_REPO > forward.output || return 21
   diff forward.reference forward.output || return 22
@@ -99,14 +99,14 @@ S S -1
 S D -1
 S N -1
 M[N] D /dir2
-R F /dir2/.cvmfscatalog
-R D /dir3
+R F /dir2/.cvmfscatalog -0
+R D /dir3 -4096
 M[SC] F /file
-A S /symlink
+A S /symlink +4
 M[SMLC] SF /directory/foo
 M[N] D /directory/nested
-A F /directory/nested/.cvmfscatalog
-R S /other-symlink
+A F /directory/nested/.cvmfscatalog +0
+R S /other-symlink -4
 EOF
   cvmfs_server diff -im -s trunk -d trunk-previous $CVMFS_TEST_REPO \
     > reverse.output || return 31

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -173,7 +173,7 @@ run_transactions() {
     ## Transaction 8 (Check creation of auto-tag)
 
     echo "  Starting transaction 8"
-    num_tags_before=$(cvmfs_server tag -l test.repo.org | grep generic | wc -l)
+    num_tags_before=$(cvmfs_server tag -l test.repo.org | grep -a generic | wc -l)
     cvmfs_server transaction test.repo.org
     echo "New file" > /cvmfs/test.repo.org/marker
 
@@ -182,7 +182,7 @@ run_transactions() {
     cvmfs_server check test.repo.org
 
     echo "  Get list of tags"
-    num_tags_after=$(cvmfs_server tag -l test.repo.org | grep generic | wc -l)
+    num_tags_after=$(cvmfs_server tag -l test.repo.org | grep -a generic | wc -l)
     num_generic_tags_created=$((num_tags_after - num_tags_before))
 
     ## Transaction 8 (Check creation of named tag)


### PR DESCRIPTION
Fixing integration tests:
* 641: `cvmfs_server diff` output has changed
* 800: Force the grep command to interpret the output of "cvmfs_server tag -l" as text
* Make the `cvmfs-server` package depend on `libcap2-bin` on Ubuntu/Debian. This package wasn't previously installed on Ubuntu 12.04, causing all the server integration tests to fail due to `setcap` not being available.
* Fix the list of excluded integration tests for Ubuntu 12.04 and 14.04