### PR TITLE
Fix garbage collection of idle repositories

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -200,9 +200,6 @@ __do_gc_cmd()
     is_owner_or_root       $name || die "Permission denied: Repository $name is owned by $user"
     is_in_transaction      $name && die "Cannot run garbage collection while in a transaction"
 
-    local head_timestamp="$(get_repo_info -t)"
-    [ $head_timestamp -gt $preserve_timestamp ] || die "Latest repository revision is older than given timestamp"
-
     # figure out the URL of the repository
     local repository_url="$CVMFS_STRATUM0"
     if is_stratum1 $name; then

--- a/test/src/652-gctimespan/main
+++ b/test/src/652-gctimespan/main
@@ -1,0 +1,26 @@
+cvmfs_test_name="Garbage collect idle repositoriess"
+cvmfs_test_autofs_on_startup=false
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+
+  echo "*** generate garbage"
+  start_transaction $CVMFS_TEST_REPO || return 10
+  publish_repo $CVMFS_TEST_REPO || return 11
+  echo "*** sleeping 5 seconds"
+  sleep 5
+  echo "*** garbage collect all content older than 'now'"
+  cvmfs_server gc -f -l -t now $CVMFS_TEST_REPO || return 12
+
+  echo "*** ensure that HEAD revision is still there"
+  start_transaction $CVMFS_TEST_REPO || return 20
+  publish_repo $CVMFS_TEST_REPO || return 21
+  check_repository $CVMFS_TEST_REPO -i  || return 22
+
+  return 0
+}
+


### PR DESCRIPTION
This check [has been introduced](https://github.com/cvmfs/cvmfs/commit/2b053d996570044239c46d56296e93e5d474fc72) for the old, time-based garbage collection.  It is not necessary anymore for the reflog based garbage collection.