### PR TITLE
cvmfs_server mkfs - don't try to import private repo keys in GW config

### DIFF
--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -224,9 +224,11 @@ cvmfs_server_mkfs() {
   local keys_location="/etc/cvmfs/keys"
   mkdir -p $keys_location
   local upstream_type=$(get_upstream_type $upstream)
-  local keys="${name}.key ${name}.crt ${name}.pub"
+  local keys="${name}.crt ${name}.pub"
   if [ x"$upstream_type" = xgw ]; then
       keys="$keys ${name}.gw"
+  else
+      keys="$keys ${name}.key"
   fi
   if [ $require_masterkeycard -eq 1 ]; then
       local reason
@@ -234,7 +236,9 @@ cvmfs_server_mkfs() {
   elif masterkeycard_cert_available >/dev/null; then
       require_masterkeycard=1
   else
-      keys="${name}.masterkey $keys"
+      if [ x"$upstream_type" != xgw ]; then
+          keys="${name}.masterkey $keys"
+      fi
   fi
   local keys_are_there=0
   for k in $keys; do


### PR DESCRIPTION
Addresses [CVM-1503](https://sft.its.cern.ch/jira/browse/CVM-1503).

The private repository keys aren't needed on the release manager when the upstream is a repository gateway.