### PR TITLE
Generate systemd mount unit on the fly if necessary

### DIFF
--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1132,13 +1132,6 @@ EOF
 
   mount $rdonly_dir > /dev/null || return 1
   mount /cvmfs/$name
-
-  # Make sure the systemd mount unit exists
-  if is_systemd; then
-    /usr/lib/systemd/system-generators/systemd-fstab-generator \
-      /run/systemd/generator '' '' 2>/dev/null
-    systemctl daemon-reload
-  fi
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -205,7 +205,18 @@ is_valid_branch_name() {
 
 
 run_suid_helper() {
-  env -i /usr/bin/cvmfs_suid_helper $@
+  if is_systemd && [ "x$1" == "xrdonly_mount" ]; then
+    env -i /usr/bin/cvmfs_suid_helper $@ 2>/dev/null
+    if [ $? -ne 0 ]; then
+      # Generate mount unit from /etc/fstab if necessary
+      /usr/lib/systemd/system-generators/systemd-fstab-generator \
+        /run/systemd/generator '' '' 2>/dev/null
+      systemctl daemon-reload
+      env -i /usr/bin/cvmfs_suid_helper $@
+    fi
+  else
+    env -i /usr/bin/cvmfs_suid_helper $@
+  fi
 }
 
 


### PR DESCRIPTION
While working on #2098 I figured that the change introduced in #2089 would make `cvmfs_suid_helper rdonly_mount` not generate the systemd unit under certain circumstances.  This patch recreates the unit on the fly if necessary.