### PR TITLE
Make Signal multi shot

### DIFF
--- a/cvmfs/util_concurrency.cc
+++ b/cvmfs/util_concurrency.cc
@@ -47,6 +47,7 @@ void Signal::Wait() {
     int retval = pthread_cond_wait(&signal_, &lock_);
     assert(retval == 0);
   }
+  fired_ = false;
 }
 
 


### PR DESCRIPTION
Signal is now SingleShot.

Once Wakeup is called, every successive call to Wait will simply not wait.

Wakeup set fired_ to true and the next invocation of Wait will acquire the lock but it will not enter the main loop.

This PR reset the Wait to false so that we are forced to have a sequence of Wait -> Wakeup -> Wait -> Wakeup

 I believe we could discuss if we want another class that has the MultiShot behaviour and leaving signal SingleShot, however, this one, is a quite tricky API to manage and I figure out this SingleShot behaviour only by chance...