### PR TITLE
Fix compilation on SL4 and SLC5

### DIFF
--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -94,3 +94,12 @@ if (APPLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER
   set (CVMFS_BUGGY_XCODE ON)
 endif()
 
+# Check for old Linux version that don't have a complete inotify implementation
+execute_process(
+  COMMAND ${PROJECT_SOURCE_DIR}/get_redhat_version.sh
+  OUTPUT_VARIABLE REDHAT_VERSION
+  ERROR_VARIABLE REDHAT_ERROR
+)
+if((NOT (${REDHAT_VERSION} STREQUAL "NOT_REDHAT")) AND (${REDHAT_VERSION} VERSION_LESS 6.0))
+  set(CVMFS_DISABLE_INOTIFY ON)
+endif()

--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -95,11 +95,10 @@ if (APPLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER
 endif()
 
 # Check for old Linux version that don't have a complete inotify implementation
-execute_process(
-  COMMAND ${PROJECT_SOURCE_DIR}/get_redhat_version.sh
-  OUTPUT_VARIABLE REDHAT_VERSION
-  ERROR_VARIABLE REDHAT_ERROR
-)
-if((NOT (${REDHAT_VERSION} STREQUAL "NOT_REDHAT")) AND (${REDHAT_VERSION} VERSION_LESS 6.0))
-  set(CVMFS_DISABLE_INOTIFY ON)
-endif()
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  try_compile(HAS_INOTIFY_INIT1 ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/check_inotify_init1.c)
+  if(HAS_INOTIFY_INIT1)
+    message("Enable inotify support")
+    set(CVMFS_ENABLE_INOTIFY ON)
+  endif(HAS_INOTIFY_INIT1)
+endif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/cmake/check_inotify_init1.c
+++ b/cmake/check_inotify_init1.c
@@ -1,0 +1,6 @@
+#include <sys/inotify.h>
+
+int main() {
+    int ret = inotify_init1(IN_NONBLOCK);
+    return 0;
+}

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -79,7 +79,10 @@ set (CVMFS_CLIENT_SOURCES
 if (APPLE)
   list(APPEND CVMFS_CLIENT_SOURCES file_watcher_kqueue.cc)
 else(APPLE)
-  list(APPEND CVMFS_CLIENT_SOURCES file_watcher_inotify.cc)
+  if (CVMFS_ENABLE_INOTIFY)
+    list(APPEND CVMFS_CLIENT_SOURCES file_watcher_inotify.cc)
+    add_definitions(-DCVMFS_ENABLE_INOTIFY)
+  endif(CVMFS_ENABLE_INOTIFY)
 endif (APPLE)
 
 # First .h then .cc is important to avoid races during the build process

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -33,7 +33,11 @@
 #include <string>
 #include <vector>
 
+#ifdef CVMFS_ENABLE_INOTIFY
 #include "file_watcher_inotify.h"
+#else  // CVMFS_ENABLE_INOTIFY
+#include "file_watcher.h"
+#endif  // CVMFS_ENABLE_INOTIFY
 #include "smalloc.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
@@ -323,7 +327,11 @@ inline uint64_t platform_memsize() {
 }
 
 inline file_watcher::FileWatcher* platform_file_watcher() {
+#ifdef CVMFS_ENABLE_INOTIFY
   return new file_watcher::FileWatcherInotify();
+#else  // CVMFS_ENABLE_INOTIFY
+  return NULL;
+#endif  // CVMFS_ENABLE_INOTIFY
 }
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/get_redhat_version.sh
+++ b/get_redhat_version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -f /etc/redhat-release ]; then
+  printf $(cat /etc/redhat-release | grep -o -E '[0-9].[0-9]+')
+else
+  printf NOT_REDHAT
+fi

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -54,7 +54,6 @@ set(CVMFS_UNITTEST_FILES
   t_file_chunk.cc
   t_file_guard.cc
   t_file_sandbox.cc
-  t_file_watcher.cc
   t_fs_traversal.cc
   t_fuse_evict.cc
   t_garbage_collector.cc
@@ -251,10 +250,14 @@ if (CVMFS_BUGGY_XCODE)
   set_property(SOURCE ${CVMFS_SOURCE_DIR}/ingestion/chunk_detector.cc PROPERTY COMPILE_FLAGS -O0)
 endif(CVMFS_BUGGY_XCODE)
 
+# The FileWatcher unit test only makes sense on macOS or on Linux versions which support inotify (inotify)
 if (APPLE)
-  list(APPEND CVMFS_UNITTEST_SOURCES ${CVMFS_SOURCE_DIR}/file_watcher_kqueue.cc)
+  list(APPEND CVMFS_UNITTEST_SOURCES ${CVMFS_SOURCE_DIR}/file_watcher_kqueue.cc t_file_watcher.cc)
 else (APPLE)
-  list(APPEND CVMFS_UNITTEST_SOURCES ${CVMFS_SOURCE_DIR}/file_watcher_inotify.cc)
+  if (CVMFS_ENABLE_INOTIFY)
+    list(APPEND CVMFS_UNITTEST_SOURCES ${CVMFS_SOURCE_DIR}/file_watcher_inotify.cc t_file_watcher.cc)
+    add_definitions(-DCVMFS_ENABLE_INOTIFY)
+  endif(CVMFS_ENABLE_INOTIFY)
 endif(APPLE)
 
 set (CVMFS_UNITTEST_DEBUG_SOURCES ${CVMFS_UNITTEST_SOURCES})


### PR DESCRIPTION
This patch selectively enables the `FileWatcherInotify` class and its associated tests based on the availability of `inotify_init1`.

Jenkins build is green:
https://epsft-jenkins.cern.ch/job/CvmfsFullBuildDocker/663/