### PR TITLE
Automatically configure fuse on Debian-derived platforms

### DIFF
--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -2,7 +2,7 @@ Source: cvmfs
 Section: utils
 Priority: extra
 Maintainer: Jakob Blomer <jblomer@cern.ch>
-Build-Depends: debhelper (>= 9), autotools-dev, cmake, libcap-dev, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, libc6-dev, valgrind, libz-dev
+Build-Depends: debhelper (>= 9), config-package-dev, autotools-dev, cmake, libcap-dev, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, libc6-dev, valgrind, libz-dev
 Standards-Version: 3.9.3.1
 Homepage: http://cernvm.cern.ch/portal/filesystem
 
@@ -10,6 +10,8 @@ Package: cvmfs
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
 Depends: cvmfs-config-default | cvmfs-config, bash, coreutils, grep, gawk, sed, perl, psmisc, autofs, fuse, curl, attr, libfuse2, debianutils, libc-bin, sysvinit-utils, zlib1g, gdb, uuid-dev, uuid
+Provides: ${diverted-files}
+Conflicts: ${diverted-files}
 Recommends: autofs (>= 5.1.2)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch

--- a/packaging/debian/cvmfs/cvmfs.transform
+++ b/packaging/debian/cvmfs/cvmfs.transform
@@ -1,0 +1,1 @@
+/etc/fuse.conf.cvmfs sed -e '/user_allow_other/s/^#//g'

--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -76,6 +76,7 @@ binary-arch: build install
 	dh_installinfo
 #        dh_undocumented
 	dh_installchangelogs ChangeLog
+	dh_configpackage
 	dh_link
 #	dh_strip
 	dh_compress

--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -17,7 +17,7 @@ export DH_VERBOSE=1
 #DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 #DEB_CONFIGURE_EXTRA_FLAGS += --libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH)
 
-Makefile: 
+Makefile:
 	dh_testdir
 	dh_auto_configure -- -DBUILD_SERVER=yes -DBUILD_SERVER_DEBUG=yes -DBUILD_UNITTESTS=yes -DINSTALL_UNITTESTS=yes -DINSTALL_PUBLIC_KEYS=no -DBUILD_LIBCVMFS=yes -DBUILD_LIBCVMFS_CACHE=yes -DCMAKE_INSTALL_PREFIX:PATH=/usr
 
@@ -70,7 +70,7 @@ binary-arch: build install
 #       dh_installemacsen
 #       dh_installpam
 #       dh_installmime
-#	dh_installinit -- defaults 21 
+#	dh_installinit -- defaults 21
 	dh_installcron
 	dh_installman
 	dh_installinfo


### PR DESCRIPTION
The debian packaging system features a tool called [config-package-dev](https://debathena.mit.edu/config-packages) which automates common operations on configuration files in a reversible and predictable manner. This pull request causes `/etc/fuse.conf` to be replaced by a symbolic link to `/etc/fuse.conf.cvmfs` which has been transformed from its packaged value by a simple `sed` operation that removes the comment in front of `user_allow_other`.

Additionally, a backup created at `/etc/fuse.conf.cvmfs-orig`; upon removal of the package `/etc/fuse.conf` is replaced by `/etc/fuse.conf.cvmfs-orig` and the latter is deleted.

The only thing to maintain in this package is a single line within`packaging/debian/cvmfs/cvmfs.transform` that modifies `/etc/fuse.conf` as packaged by `fuse` to that as needed by `cvmfs`.

```
thomas.downes@downes-stretch:~/work/cvmfs/ci/cvmfs$ cat /etc/fuse.conf
# /etc/fuse.conf - Configuration file for Filesystem in Userspace (FUSE)

# Set the maximum number of FUSE mounts allowed to non-root users.
# The default is 1000.
#mount_max = 1000

# Allow non-root users to specify the allow_other or allow_root mount options.
#user_allow_other
thomas.downes@downes-stretch:~/work/cvmfs/ci/cvmfs$ sudo dpkg -i /tmp/cvmfs-pkg/cvmfs_2.5.0~1+debian9.4_amd64.deb
Selecting previously unselected package cvmfs.
(Reading database ... 131423 files and directories currently installed.)
Preparing to unpack .../cvmfs_2.5.0~1+debian9.4_amd64.deb ...
Unpacking cvmfs (2.5.0~1+debian9.4) ...
Setting up cvmfs (2.5.0~1+debian9.4) ...
creating cvmfs user/group...
Adding 'diversion of /etc/fuse.conf to /etc/fuse.conf.cvmfs-orig by cvmfs'
Processing triggers for libc-bin (2.24-11+deb9u3) ...
thomas.downes@downes-stretch:~/work/cvmfs$ ls -lh /etc/fuse.conf*
lrwxrwxrwx 1 root root  15 Apr 25 17:12 /etc/fuse.conf -> fuse.conf.cvmfs
-rw-r--r-- 1 root root 279 Apr 25 16:08 /etc/fuse.conf.cvmfs
-rw-r--r-- 1 root root 280 Apr 25 13:49 /etc/fuse.conf.cvmfs-orig
thomas.downes@downes-stretch:~/work/cvmfs$ cat /etc/fuse.conf
# /etc/fuse.conf - Configuration file for Filesystem in Userspace (FUSE)

# Set the maximum number of FUSE mounts allowed to non-root users.
# The default is 1000.
#mount_max = 1000

# Allow non-root users to specify the allow_other or allow_root mount options.
user_allow_other
thomas.downes@downes-stretch:~/work/cvmfs$ sudo apt-get remove cvmfs
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  cvmfs
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 39.0 MB disk space will be freed.
Do you want to continue? [Y/n]
(Reading database ... 131452 files and directories currently installed.)
Removing cvmfs (2.5.0~1+debian9.4) ...
Removing 'diversion of /etc/fuse.conf to /etc/fuse.conf.cvmfs-orig by cvmfs'
removing cvmfs user/group...
Processing triggers for libc-bin (2.24-11+deb9u3) ...
thomas.downes@downes-stretch:~/work/cvmfs$ ls -lh /etc/fuse.conf*
-rw-r--r-- 1 root root 280 Apr 25 13:49 /etc/fuse.conf
-rw-r--r-- 1 root root 279 Apr 25 16:08 /etc/fuse.conf.cvmfs
thomas.downes@downes-stretch:~/work/cvmfs$ cat /etc/fuse.conf
# /etc/fuse.conf - Configuration file for Filesystem in Userspace (FUSE)

# Set the maximum number of FUSE mounts allowed to non-root users.
# The default is 1000.
#mount_max = 1000

# Allow non-root users to specify the allow_other or allow_root mount options.
#user_allow_other
```