### PR TITLE
Eliminate the following Debian packaging warnings or errors

### DIFF
--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -2,14 +2,14 @@ Source: cvmfs
 Section: utils
 Priority: extra
 Maintainer: Jakob Blomer <jblomer@cern.ch>
-Build-Depends: debhelper (>= 9), autotools-dev, cmake, libcap-dev, libssl-dev, make, gcc, g++, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, libc6-dev, valgrind, libz-dev
-Standards-Version: 3.9.3.1
+Build-Depends: debhelper (>= 9), autotools-dev, cmake, libcap-dev, libssl-dev, libfuse-dev, pkg-config, libattr1-dev, patch, python-dev, unzip, uuid-dev, valgrind, libz-dev
+Standards-Version: 3.9.6.1
 Homepage: http://cernvm.cern.ch/portal/filesystem
 
 Package: cvmfs
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: cvmfs-config-default | cvmfs-config, bash, coreutils, grep, gawk, sed, perl, psmisc, autofs, fuse, curl, attr, libfuse2, debianutils, libc-bin, sysvinit-utils, zlib1g, gdb, uuid-dev, uuid
+Depends: cvmfs-config-default | cvmfs-config, gawk, perl, psmisc, autofs, fuse, curl, attr, libfuse2, zlib1g, gdb, uuid-dev, uuid, adduser, ${misc:Depends}
 Recommends: autofs (>= 5.1.2)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch
@@ -19,8 +19,8 @@ Description: CernVM File System
 Package: cvmfs-server
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: insserv, initscripts, bash, coreutils, grep, sed, psmisc, curl, gzip, attr, openssl, apache2, libcap2, libcap2-bin, lsof, rsync, jq, usbutils
-Conflicts: cvmfs-server (< 2.1)
+Depends: insserv, initscripts, psmisc, curl, attr, openssl, apache2, libcap2, libcap2-bin, lsof, rsync, jq, usbutils, ${misc:Depends}
+Conflicts: cvmfs-server (<< 2.1)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System Server
@@ -29,7 +29,7 @@ Description: CernVM File System Server
 Package: cvmfs-dev
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: openssl
+Depends: openssl, ${misc:Depends}
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System Server
@@ -38,7 +38,7 @@ Description: CernVM File System Server
 Package: cvmfs-unittests
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: libssl-dev, uuid-dev
+Depends: libssl-dev, uuid-dev, ${misc:Depends}
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System Unit Tests

--- a/packaging/debian/cvmfs/copyright
+++ b/packaging/debian/cvmfs/copyright
@@ -11,7 +11,7 @@ Upstream Author(s):
 Copyright:
 
     Copyright (c) 2009, CERN.
-    
+
 License:
 
     Distributed unter the BSD License.
@@ -20,7 +20,29 @@ The Debian packaging is:
 
     Copyright (C) 2011 Frederik Wagner <Frederik.Wagner@lmu.de>
 
-You are free to distribute this software under the terms of
-the BSD License.
-On Debian systems, the complete text of the BSD License can be 
-found in the file `/usr/share/common-licenses/BSD'.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/packaging/debian/cvmfs/cvmfs.lintian-overrides
+++ b/packaging/debian/cvmfs/cvmfs.lintian-overrides
@@ -1,0 +1,5 @@
+cvmfs: file-in-unusual-dir usr/libexec/cvmfs/authz/cvmfs_allow_helper
+cvmfs: file-in-unusual-dir usr/libexec/cvmfs/authz/cvmfs_deny_helper
+cvmfs: file-in-unusual-dir usr/libexec/cvmfs/auto.cvmfs
+cvmfs: file-in-unusual-dir usr/libexec/cvmfs/cache/cvmfs_cache_ram
+cvmfs: non-standard-dir-in-usr usr/libexec/

--- a/packaging/debian/cvmfs/cvmfs.postinst
+++ b/packaging/debian/cvmfs/cvmfs.postinst
@@ -26,7 +26,7 @@ case "$1" in
         getent group cvmfs >/dev/null || getent passwd cvmfs > /dev/null || \
         adduser --system --group --no-create-home --home /cvmfs cvmfs
         if [ -d /var/run/cvmfs ]; then
-          /usr/bin/cvmfs_config reload
+          cvmfs_config reload
         fi
     ;;
 

--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -17,7 +17,7 @@ export DH_VERBOSE=1
 #DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 #DEB_CONFIGURE_EXTRA_FLAGS += --libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH)
 
-Makefile: 
+Makefile:
 	dh_testdir
 	dh_auto_configure -- -DBUILD_SERVER=yes -DBUILD_SERVER_DEBUG=yes -DBUILD_UNITTESTS=yes -DINSTALL_UNITTESTS=yes -DINSTALL_PUBLIC_KEYS=no -DBUILD_LIBCVMFS=yes -DBUILD_LIBCVMFS_CACHE=yes -DCMAKE_INSTALL_PREFIX:PATH=/usr
 
@@ -70,7 +70,7 @@ binary-arch: build install
 #       dh_installemacsen
 #       dh_installpam
 #       dh_installmime
-#	dh_installinit -- defaults 21 
+#	dh_installinit -- defaults 21
 	dh_installcron
 	dh_installman
 	dh_installinfo


### PR DESCRIPTION
I'd like to spend a little time cleaning up the Debian packaging process to better conform with [Debian policy](https://packages.debian.org/search?keywords=debian-policy). I have updated the policy for the `cvmfs` package (but not others) to identify itself as in compliance with 3.9.6.1, which corresponds to Debian 8 and has the effect of eliminating the warning `W: cvmfs source: ancient-standards-version 3.9.3.1 (current is 3.9.8)`.

I have rebuilt the package successfully and believe the changes I have made are harmless. I'm happy to go through all the other packages and make similarly harmless modifications if you accept this pull request.

At that point, there will be some real issues to consider. For example, [static compilation of zlib](https://lintian.debian.org/tags/embedded-library.html):

```
E: cvmfs: embedded-library usr/lib/libcvmfs_fuse.so.2.5.0: zlib
```
This pull request includes an example of how to "override" a warning when you know the action to be OK. This is discouraged for obvious reasons, but it's there as a tool when necessary. My example overrides the Debian policy manual's refusal to adopt the [FHS 3.0 standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html).

Warnings/errors eliminated:
```
E: cvmfs source: depends-on-build-essential-package-without-using-version g++ [build-depends: g++]
E: cvmfs source: depends-on-build-essential-package-without-using-version gcc [build-depends: gcc]
E: cvmfs source: depends-on-build-essential-package-without-using-version libc6-dev [build-depends: libc6-dev]
E: cvmfs source: depends-on-build-essential-package-without-using-version make [build-depends: make]
E: cvmfs source: obsolete-relation-form-in-source in cvmfs-server conflicts: cvmfs-server (< 2.1)
E: cvmfs: depends-on-essential-package-without-using-version depends: bash
E: cvmfs: depends-on-essential-package-without-using-version depends: coreutils
E: cvmfs: depends-on-essential-package-without-using-version depends: debianutils
E: cvmfs: depends-on-essential-package-without-using-version depends: grep
E: cvmfs: depends-on-essential-package-without-using-version depends: libc-bin
E: cvmfs: depends-on-essential-package-without-using-version depends: sed
E: cvmfs: depends-on-essential-package-without-using-version depends: sysvinit-utils
W: cvmfs source: ancient-standards-version 3.9.3.1 (current is 3.9.8)
W: cvmfs source: debhelper-but-no-misc-depends cvmfs
W: cvmfs source: debhelper-but-no-misc-depends cvmfs-dev
W: cvmfs source: debhelper-but-no-misc-depends cvmfs-server
W: cvmfs source: debhelper-but-no-misc-depends cvmfs-unittests
W: cvmfs: maintainer-script-needs-depends-on-adduser postinst
W: cvmfs: non-standard-dir-in-usr usr/libexec/
```