### PR TITLE
Update existing manifest/history on catalog migrate

### DIFF
--- a/cvmfs/history_sqlite.h
+++ b/cvmfs/history_sqlite.h
@@ -146,6 +146,7 @@ class SqliteHistory : public History {
   bool OwnsDatabaseFile() const {
     return database_.IsValid() && database_->OwnsFile();
   }
+  std::string filename() const { return database_->filename(); }
 
  protected:
   static SqliteHistory* Open(const std::string &file_name,

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -8,12 +8,16 @@
 #include "swissknife_migrate.h"
 
 #include <sys/resource.h>
+#include <unistd.h>
 
 #include "catalog_rw.h"
 #include "catalog_sql.h"
 #include "catalog_virtual.h"
+#include "compression.h"
 #include "hash.h"
 #include "logging.h"
+#include "swissknife_history.h"
+#include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
@@ -292,6 +296,79 @@ bool CommandMigrate::ReadPersonaMaps(const std::string &uid_map_path,
 }
 
 
+void CommandMigrate::UploadHistoryClosure(
+  const upload::SpoolerResult &result,
+  Future<shash::Any> *hash)
+{
+  assert(!result.IsChunked());
+  if (result.return_code != 0) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to upload history database (%d)",
+             result.return_code);
+    hash->Set(shash::Any());
+  } else {
+    hash->Set(result.content_hash);
+  }
+}
+
+
+bool CommandMigrate::UpdateUndoTags(
+  PendingCatalog *root_catalog,
+  unsigned revision,
+  time_t timestamp,
+  shash::Any *history_hash)
+{
+  string filename_old = history_upstream_->filename();
+  string filename_new = filename_old + ".new";
+  bool retval = CopyPath2Path(filename_old, filename_new);
+  if (!retval) return false;
+  UniquePtr<history::SqliteHistory> history(
+    history::SqliteHistory::OpenWritable(filename_new));
+  history->TakeDatabaseFileOwnership();
+
+  history::History::Tag tag_trunk;
+  bool exists = history->GetByName(CommandTag::kHeadTag, &tag_trunk);
+  if (exists) {
+    retval = history->Remove(CommandTag::kHeadTag);
+    if (!retval) return false;
+
+    history::History::Tag tag_trunk_previous = tag_trunk;
+    tag_trunk_previous.name = CommandTag::kPreviousHeadTag;
+    tag_trunk_previous.description = CommandTag::kPreviousHeadTagDescription;
+    history->Remove(CommandTag::kPreviousHeadTag);
+
+    tag_trunk.root_hash = root_catalog->new_catalog_hash;
+    tag_trunk.size = root_catalog->new_catalog_size;
+    tag_trunk.revision = root_catalog->new_catalog_size;
+    tag_trunk.revision = revision;
+    tag_trunk.timestamp = timestamp;
+
+    retval = history->Insert(tag_trunk_previous);
+    if (!retval) return false;
+    retval = history->Insert(tag_trunk);
+    if (!retval) return false;
+  }
+
+  history->SetPreviousRevision(manifest_upstream_->history());
+  history->DropDatabaseFileOwnership();
+  history.Destroy();
+
+  Future<shash::Any> history_hash_new;
+  upload::Spooler::CallbackPtr callback = spooler_->RegisterListener(
+    &CommandMigrate::UploadHistoryClosure, this, &history_hash_new);
+  spooler_->ProcessHistory(filename_new);
+  spooler_->WaitForUpload();
+  spooler_->UnregisterListener(callback);
+  unlink(filename_new.c_str());
+  *history_hash = history_hash_new.Get();
+  if (history_hash->IsNull()) {
+    Error("failed to upload tag database");
+    return false;
+  }
+
+  return true;
+}
+
+
 template <class MigratorT>
 bool CommandMigrate::DoMigrationAndCommit(
   const std::string                   &manifest_path,
@@ -315,6 +392,7 @@ bool CommandMigrate::DoMigrationAndCommit(
   ConvertCatalogsRecursively(root_catalog, &concurrent_migration);
   concurrent_migration.WaitForEmptyQueue();
   spooler_->WaitForUpload();
+  spooler_->UnregisterListeners();
   migration_stopwatch_.Stop();
 
   // check for possible errors during the migration process
@@ -329,19 +407,35 @@ bool CommandMigrate::DoMigrationAndCommit(
   }
 
   if (root_catalog->was_updated.Get()) {
-    // Commit the new (migrated) repository revision...
     LogCvmfs(kLogCatalog, kLogStdout,
              "\nCommitting migrated repository revision...");
-    const shash::Any  &root_catalog_hash = root_catalog->new_catalog_hash;
-    const std::string &root_catalog_path = root_catalog->root_path();
-    const size_t root_catalog_size = root_catalog->new_catalog_size;
-    manifest::Manifest manifest(root_catalog_hash, root_catalog_size,
-                                root_catalog_path);
+    manifest::Manifest manifest = *manifest_upstream_;
+    manifest.set_catalog_hash(root_catalog->new_catalog_hash);
+    manifest.set_catalog_size(root_catalog->new_catalog_size);
+    manifest.set_root_path(root_catalog->root_path());
     const catalog::Catalog* new_catalog = (root_catalog->HasNew())
                                           ? root_catalog->new_catalog
                                           : root_catalog->old_catalog;
     manifest.set_ttl(new_catalog->GetTTL());
     manifest.set_revision(new_catalog->GetRevision());
+
+    // Commit the new (migrated) repository revision...
+    if (history_upstream_.IsValid()) {
+      shash::Any history_hash(manifest_upstream_->history());
+      LogCvmfs(kLogCatalog, kLogStdout | kLogNoLinebreak,
+               "Updating repository tag database... ");
+      if (!UpdateUndoTags(root_catalog,
+                          new_catalog->GetRevision(),
+                          new_catalog->GetLastModified(),
+                          &history_hash))
+      {
+        Error("Updateing tag database failed.\nAborting...");
+        return false;
+      }
+      manifest.set_history(history_hash);
+      LogCvmfs(kLogCvmfs, kLogStdout, "%s", history_hash.ToString().c_str());
+    }
+
     if (!manifest.Export(manifest_path)) {
       Error("Manifest export failed.\nAborting...");
       return false;

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -15,9 +15,13 @@
 #include "catalog.h"
 #include "catalog_traversal.h"
 #include "hash.h"
+#include "history_sqlite.h"
+#include "logging.h"
+#include "manifest.h"
 #include "uid_map.h"
 #include "upload.h"
 #include "util/algorithm.h"
+#include "util/pointer.h"
 #include "util_concurrency.h"
 
 namespace catalog {
@@ -294,6 +298,22 @@ class CommandMigrate : public Command {
   bool LoadCatalogs(const shash::Any &manual_root_hash,
                     ObjectFetcherT *object_fetcher)
   {
+    ObjectFetcherFailures::Failures retval;
+    retval = object_fetcher->FetchManifest(&manifest_upstream_);
+    if (retval != ObjectFetcherFailures::kFailOk) {
+      LogCvmfs(kLogCvmfs, kLogStdout, "could not get manifest (%d)", retval);
+      return false;
+    }
+
+    if (!manifest_upstream_->history().IsNull()) {
+      retval = object_fetcher->FetchHistory(
+        &history_upstream_, manifest_upstream_->history());
+      if (retval != ObjectFetcherFailures::kFailOk) {
+        LogCvmfs(kLogCvmfs, kLogStdout, "could not get history (%d)", retval);
+        return false;
+      }
+    }
+
     typename CatalogTraversal<ObjectFetcherT>::Parameters params;
     const bool generate_full_catalog_tree = true;
     params.no_close       = generate_full_catalog_tree;
@@ -347,6 +367,8 @@ class CommandMigrate : public Command {
   std::string                     nested_catalog_marker_tmp_path_;
   static catalog::DirectoryEntry  nested_catalog_marker_;
 
+  UniquePtr<manifest::Manifest> manifest_upstream_;
+  UniquePtr<history::SqliteHistory> history_upstream_;
   catalog::Catalog const*     root_catalog_;
   UniquePtr<upload::Spooler>  spooler_;
   PendingCatalogMap           pending_catalogs_;

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -353,6 +353,13 @@ class CommandMigrate : public Command {
   bool GenerateNestedCatalogMarkerChunk();
   void CreateNestedCatalogMarkerDirent(const shash::Any &content_hash);
 
+  void UploadHistoryClosure(const upload::SpoolerResult &result,
+                            Future<shash::Any> *hash);
+  bool UpdateUndoTags(PendingCatalog *root_catalog,
+                      unsigned revision,
+                      time_t timestamp,
+                      shash::Any *history_hash);
+
  private:
   unsigned int           file_descriptor_limit_;
   CatalogStatisticsList  catalog_statistics_list_;

--- a/test/src/653-migratemanifest/main
+++ b/test/src/653-migratemanifest/main
@@ -1,0 +1,60 @@
+cvmfs_test_name="Ensure healthy manifest after catalog migration"
+cvmfs_test_autofs_on_startup=false
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  cat > uid_map << EOF
+# map $CVMFS_TEST_USER to root
+$(id -ru $CVMFS_TEST_USER) 0
+EOF
+
+  cat > gid_map << EOF
+# map ${CVMFS_TEST_USER}'s group to root
+$(id -rg $CVMFS_TEST_USER) 0
+EOF
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "*** publish repository with tag mytag"
+  publish_repo $CVMFS_TEST_REPO -a mytag || return $?
+
+  echo "*** check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "*** check tag list"
+  cvmfs_server tag -lx $CVMFS_TEST_REPO
+  local mytag_before="$(cvmfs_server tag -lx $CVMFS_TEST_REPO | grep mytag)"
+  local trunk_before="$(cvmfs_server tag -lx $CVMFS_TEST_REPO | grep HEAD)"
+
+  echo -n "*** get root catalog hash before catalog-chown... "
+  local root_clg_before="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo "--> $root_clg_before"
+
+  echo "*** run the chown on catalog level"
+  sudo cvmfs_server catalog-chown -u uid_map -g gid_map $CVMFS_TEST_REPO || return 3
+
+  echo -n "*** get root catalog hash after catalog-chown... "
+  local root_clg_after="$(get_current_root_catalog $CVMFS_TEST_REPO)"
+  echo "--> $root_clg_after"
+
+  [ "x$root_clg_before" != "x$root_clg_after" ] || return 20
+
+  echo "*** check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "*** check tag list"
+  cvmfs_server tag -lx $CVMFS_TEST_REPO
+  local mytag_after="$(cvmfs_server tag -lx $CVMFS_TEST_REPO | grep mytag)"
+  local trunk_after="$(cvmfs_server tag -lx $CVMFS_TEST_REPO | grep HEAD)"
+  [ x"$mytag_before" = x"$mytag_after" ] || return 30
+  [ x"$trunk_before" != x"$trunk_after" ] || return 31
+
+  return 0
+}

--- a/test/src/653-migratemanifest/main
+++ b/test/src/653-migratemanifest/main
@@ -59,8 +59,14 @@ EOF
   local timestamp_before=$(cvmfs_swissknife info -t -r $(get_repo_url $CVMFS_TEST_REPO))
   echo "--> $timestamp_before"
 
+  echo "*** manifest before"
+  cvmfs_swissknife info -R -r $(get_repo_url $CVMFS_TEST_REPO)
+
   echo "*** run the chown on catalog level"
   sudo cvmfs_server catalog-chown -u uid_map -g gid_map $CVMFS_TEST_REPO || return 3
+
+  echo "*** manifest after"
+  cvmfs_swissknife info -R -r $(get_repo_url $CVMFS_TEST_REPO)
 
   echo -n "*** get root catalog hash after catalog-chown... "
   local root_clg_after="$(get_current_root_catalog $CVMFS_TEST_REPO)"
@@ -79,7 +85,7 @@ EOF
   echo -n "*** check timestamp... "
   local timestamp_after=$(cvmfs_swissknife info -t -r $(get_repo_url $CVMFS_TEST_REPO))
   echo "--> $timestamp_after"
-  [ $timestamp_after -gt $timestamp_before ] || return 38
+  [ $timestamp_after -ge $timestamp_before ] || return 38
 
   echo "*** check meta-info"
   cvmfs_swissknife info -r $(get_repo_url $CVMFS_TEST_REPO) -M > meta-info.after || return 35

--- a/test/src/653-migratemanifest/main
+++ b/test/src/653-migratemanifest/main
@@ -33,9 +33,31 @@ EOF
   local mytag_before="$(cvmfs_server tag -lx $CVMFS_TEST_REPO | grep mytag)"
   local trunk_before="$(cvmfs_server tag -lx $CVMFS_TEST_REPO | grep HEAD)"
 
+  echo "*** add meta-info"
+  local json_file="meta-info.json"
+  cat >> $json_file << EOF
+{
+  "administrator" : "CernVM Admin",
+  "email"         : "dont.send.me.spam@cern.ch",
+  "organisation"  : "CERN",
+  "description"   : "This is just a test repository"
+}
+EOF
+  cvmfs_server update-repoinfo -f $json_file $CVMFS_TEST_REPO || return 40
+  cvmfs_swissknife info -r $(get_repo_url $CVMFS_TEST_REPO) -M > meta-info.before || return 41
+  diff $json_file meta-info.before || return 42
+
   echo -n "*** get root catalog hash before catalog-chown... "
   local root_clg_before="$(get_current_root_catalog $CVMFS_TEST_REPO)"
   echo "--> $root_clg_before"
+
+  echo -n "*** get revision before catalog-chown... "
+  local revision_before=$(cvmfs_swissknife info -v -r $(get_repo_url $CVMFS_TEST_REPO))
+  echo "--> $revision_before"
+
+  echo -n "*** get timestamp before catalog-chown... "
+  local timestamp_before=$(cvmfs_swissknife info -t -r $(get_repo_url $CVMFS_TEST_REPO))
+  echo "--> $timestamp_before"
 
   echo "*** run the chown on catalog level"
   sudo cvmfs_server catalog-chown -u uid_map -g gid_map $CVMFS_TEST_REPO || return 3
@@ -48,6 +70,20 @@ EOF
 
   echo "*** check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo -n "*** check revision... "
+  local revision_after=$(cvmfs_swissknife info -v -r $(get_repo_url $CVMFS_TEST_REPO))
+  echo "--> $revision_after"
+  [ $revision_after -gt $revision_before ] || return 37
+
+  echo -n "*** check timestamp... "
+  local timestamp_after=$(cvmfs_swissknife info -t -r $(get_repo_url $CVMFS_TEST_REPO))
+  echo "--> $timestamp_after"
+  [ $timestamp_after -gt $timestamp_before ] || return 38
+
+  echo "*** check meta-info"
+  cvmfs_swissknife info -r $(get_repo_url $CVMFS_TEST_REPO) -M > meta-info.after || return 35
+  diff meta-info.after meta-info.before || return 36
 
   echo "*** check tag list"
   cvmfs_server tag -lx $CVMFS_TEST_REPO


### PR DESCRIPTION
Fixes a long-standing bug where catalog migration (including chown, eliminate-hardlinks) would create a new minimal manifest and ignore the existing manifest and history.