### PR TITLE
Add missing header util_concurrency.h

### DIFF
--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -121,6 +121,7 @@
 #include "upload_spooler_definition.h"
 #include "upload_spooler_result.h"
 #include "util/pointer.h"
+#include "util_concurrency.h"
 
 namespace upload {
 


### PR DESCRIPTION
`util_concurrency.h` define `Observable` which is the public parent of
the `Spooler` the main class of the file.