### PR TITLE
PayloadProcessor - check for Spooler upload errors

### DIFF
--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -32,7 +32,7 @@ struct FileInfo {
  */
 class PayloadProcessor {
  public:
-  enum Result { kSuccess, kPathViolation, kOtherError };
+  enum Result { kSuccess, kPathViolation, kSpoolerError, kOtherError };
 
   PayloadProcessor();
   virtual ~PayloadProcessor();
@@ -48,7 +48,7 @@ class PayloadProcessor {
   // NOTE: These methods are made virtual such that they can be mocked for
   //       the purpose of unit testing
   virtual Result Initialize();
-  virtual void Finalize();
+  virtual Result Finalize();
   virtual void Upload(const std::string& source,
                       const std::string& dest);
   virtual bool WriteFile(int fd, const void* const buf, size_t buf_size);

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -302,6 +302,10 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
       reply_input.push_back(std::make_pair("status", "error"));
       reply_input.push_back(std::make_pair("reason", "other_error"));
       break;
+    case PayloadProcessor::kSpoolerError:
+      reply_input.push_back(std::make_pair("status", "error"));
+      reply_input.push_back(std::make_pair("reason", "spooler_error"));
+      break;
     case PayloadProcessor::kSuccess:
       reply_input.push_back(std::make_pair("status", "ok"));
       break;

--- a/test/unittests/t_payload_processor.cc
+++ b/test/unittests/t_payload_processor.cc
@@ -18,7 +18,7 @@ class MockPayloadProcessor : public PayloadProcessor {
 
   virtual Result Initialize() { return kSuccess; }
 
-  virtual void Finalize() {}
+  virtual Result Finalize() { return kSuccess; }
 
   virtual void Upload(const std::string& source,
                       const std::string& dest) {}

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -22,7 +22,7 @@ class MockedPayloadProcessor : public PayloadProcessor {
  protected:
   virtual Result Initialize() { return kSuccess; }
 
-  virtual void Finalize() {}
+  virtual Result Finalize() { return kSuccess; }
 
   virtual void Upload(const std::string& source,
                       const std::string& dest) {}


### PR DESCRIPTION
Addresses [CVM-1545](https://sft.its.cern.ch/jira/browse/CVM-1545).

The PayloadProcessor should detect any Spooler errors and return an error code. The cvmfs_receiver worker process can notify its supervisor process (the cvmfs-gateway application) of this error and the publication process is stopped, without going forward with the commit phase.