### PR TITLE
Hardlink handling in CatalogMergeTool

### DIFF
--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -28,6 +28,25 @@ inline PathString MakeRelative(const PathString& path) {
   return PathString(rel_path);
 }
 
+inline void SplitHardlink(catalog::DirectoryEntry* entry) {
+  if (entry->linkcount() > 1) {
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
+              "CatalogMergeTool - Hardlink found: %s. Hardlinks are not "
+              "supported when publishing through repository gateway and "
+              "will be split.", entry->name().c_str());
+    entry->set_linkcount(1);
+  }
+}
+
+inline void AbortIfHardlinked(const catalog::DirectoryEntry& entry) {
+  if (entry.linkcount() > 1) {
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
+              "CatalogMergeTool - Removal of file %s with linkcount > 1 is "
+              "not supported. Aborting", entry.name().c_str());
+    abort();
+  }
+}
+
 namespace receiver {
 
 template <typename RwCatalogMgr, typename RoCatalogMgr>
@@ -86,8 +105,10 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportAddition(
       output_catalog_mgr_->CreateNestedCatalog(std::string(rel_path.c_str()));
     }
   } else if (entry.IsRegular() || entry.IsLink()) {
+    catalog::DirectoryEntry modified_entry = entry;
+    SplitHardlink(&modified_entry);
     const catalog::DirectoryEntryBase* base_entry =
-        static_cast<const catalog::DirectoryEntryBase*>(&entry);
+        static_cast<const catalog::DirectoryEntryBase*>(&modified_entry);
     if (entry.IsChunkedFile()) {
       assert(!chunks.IsEmpty());
       output_catalog_mgr_->AddChunkedFile(*base_entry, xattrs, parent_path,
@@ -120,6 +141,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportRemoval(
     }
     output_catalog_mgr_->RemoveDirectory(rel_path.c_str());
   } else if (entry.IsRegular() || entry.IsLink()) {
+    AbortIfHardlinked(entry);
     output_catalog_mgr_->RemoveFile(rel_path.c_str());
   }
 }
@@ -158,6 +180,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
     }
   } else if ((entry1.IsRegular() || entry1.IsLink()) && entry2.IsDirectory()) {
     // From file to directory
+    AbortIfHardlinked(entry1);
     output_catalog_mgr_->RemoveFile(rel_path.c_str());
     output_catalog_mgr_->AddDirectory(entry2, parent_path);
     if (entry2.IsNestedCatalogMountpoint()) {
@@ -166,8 +189,10 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
 
   } else if (entry1.IsDirectory() && (entry2.IsRegular() || entry2.IsLink())) {
     // From directory to file
+    catalog::DirectoryEntry modified_entry = entry2;
+    SplitHardlink(&modified_entry);
     const catalog::DirectoryEntryBase* base_entry =
-        static_cast<const catalog::DirectoryEntryBase*>(&entry2);
+        static_cast<const catalog::DirectoryEntryBase*>(&modified_entry);
     output_catalog_mgr_->RemoveDirectory(rel_path.c_str());
     if (entry2.IsChunkedFile()) {
       assert(!chunks.IsEmpty());
@@ -180,8 +205,11 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
   } else if ((entry1.IsRegular() || entry1.IsLink()) &&
              (entry2.IsRegular() || entry2.IsLink())) {
     // From file to file
+    AbortIfHardlinked(entry1);
+    catalog::DirectoryEntry modified_entry = entry2;
+    SplitHardlink(&modified_entry);
     const catalog::DirectoryEntryBase* base_entry =
-        static_cast<const catalog::DirectoryEntryBase*>(&entry2);
+        static_cast<const catalog::DirectoryEntryBase*>(&modified_entry);
     output_catalog_mgr_->RemoveFile(rel_path.c_str());
     if (entry2.IsChunkedFile()) {
       assert(!chunks.IsEmpty());


### PR DESCRIPTION
Addresses [CVM-1542](https://sft.its.cern.ch/jira/browse/CVM-1542).

When using the repository gateway:

* For new files, linkcount is always set to 1 (hardlinks are split).

* Removing files with linkcount > 1 is not supported.
  The cvmfs_receiver will abort in this case.