### PR TITLE
Handle linkcount == 0 for catalog entries

### DIFF
--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -111,6 +111,21 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
     catalog::DirectoryEntry old_entry = old_listing[i_from];
     catalog::DirectoryEntry new_entry = new_listing[i_to];
 
+    if (old_entry.linkcount() == 0) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+                "CatalogDiffTool - Entry %s in old catalog has linkcount 0. "
+                "Aborting.",
+                old_entry.name().c_str());
+      abort();
+    }
+    if (new_entry.linkcount() == 0) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+                "CatalogDiffTool - Entry %s in new catalog has linkcount 0. "
+                "Aborting.",
+                new_entry.name().c_str());
+      abort();
+    }
+
     // Skip .cvmfs hidden directory
     while (old_entry.IsHidden()) old_entry = old_listing[++i_from];
     while (new_entry.IsHidden()) new_entry = new_listing[++i_to];

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -400,6 +400,13 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
       }  // Hardlink group > 0
     }  // Hardlink found
 
+    // For any kind of entry, the linkcount should be > 0
+    if (entries[i].linkcount() == 0) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Entry %s has linkcount 0.",
+               entries[i].name().c_str());
+      retval = false;
+    }
+
     // Checks depending of entry type
     if (entries[i].IsDirectory()) {
       computed_counters->self.directories++;


### PR DESCRIPTION
Partially addresses [CVM-1549](https://sft.its.cern.ch/jira/browse/CVM-1549).

* `CatalogDiffTool` - abort if any entry with `linkcount == 0` is encountered
*  `swissknife_check` - check that entries have `linkcount > 0`