### PR TITLE
Improved temporary file handling in PayloadProcessor

### DIFF
--- a/cvmfs/receiver/payload_processor.cc
+++ b/cvmfs/receiver/payload_processor.cc
@@ -13,6 +13,12 @@
 #include "util/posix.h"
 #include "util/string.h"
 
+namespace {
+
+const size_t kConsumerBuffer = 10 * 1024 * 1024; //  10 MB
+
+}
+
 namespace receiver {
 
 PayloadProcessor::PayloadProcessor()
@@ -49,9 +55,8 @@ PayloadProcessor::Result PayloadProcessor::Process(
 
   int nb = 0;
   ObjectPackBuild::State consumer_state = ObjectPackBuild::kStateContinue;
+  std::vector<unsigned char> buffer(kConsumerBuffer, 0);
   do {
-    std::vector<unsigned char> buffer(4096, 0);
-
     nb = read(fdin, &buffer[0], buffer.size());
     consumer_state = deserializer.ConsumeNext(nb, &buffer[0]);
     if (consumer_state != ObjectPackBuild::kStateContinue &&

--- a/cvmfs/receiver/payload_processor.cc
+++ b/cvmfs/receiver/payload_processor.cc
@@ -15,7 +15,7 @@
 
 namespace {
 
-const size_t kConsumerBuffer = 10 * 1024 * 1024; //  10 MB
+const size_t kConsumerBuffer = 10 * 1024 * 1024;  // 10 MB
 
 }
 

--- a/cvmfs/receiver/payload_processor.cc
+++ b/cvmfs/receiver/payload_processor.cc
@@ -138,7 +138,7 @@ void PayloadProcessor::ConsumerEventCallback(
   info.current_size += event.buf_size;
 
   if (info.current_size == info.total_size) {
-    shash::Any file_hash(shash::kSha1);
+    shash::Any file_hash(event.id.algorithm);
     shash::HashFile(info.temp_path, &file_hash);
 
     if (file_hash != event.id) {

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "pack.h"
 #include "upload.h"

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -19,6 +19,7 @@ struct FileInfo {
   std::string temp_path;
   size_t total_size;
   size_t current_size;
+  bool skip;
 };
 
 /**

--- a/cvmfs/receiver/payload_processor.h
+++ b/cvmfs/receiver/payload_processor.h
@@ -16,9 +16,16 @@
 namespace receiver {
 
 struct FileInfo {
+  FileInfo();
+  explicit FileInfo(const ObjectPackBuild::Event& event);
+  FileInfo(const FileInfo& other);
+  FileInfo& operator=(const FileInfo& other);
+
   std::string temp_path;
   size_t total_size;
   size_t current_size;
+  shash::ContextPtr hash_context;
+  std::vector<unsigned char> hash_buffer;
   bool skip;
 };
 


### PR DESCRIPTION
Addresses [CVM-1548](https://sft.its.cern.ch/jira/browse/CVM-1548).

* Make use of `Spooler::Peek` in `PayloadProcessor` to avoid redundant writes into the repository storage
* Use a larger buffer for `ObjectPack` consumers
* Use incremental hashing of payload to avoid re-reading temporary files.