### PR TITLE
Update cvmfs-gateway install dirs in integration tests

### DIFF
--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -6,10 +6,10 @@ clean_up() {
     echo "Cleaning up"
 
     echo "  Stopping repository gateway application"
-    sudo /opt/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
 
     echo "  Removing Mnesia directory"
-    sudo rm -rf /opt/cvmfs_mnesia
+    sudo rm -rf /var/lib/cvmfs-gateway
 
     echo "  Removing test repository"
     sudo -E cvmfs_server rmfs -f test.repo.org

--- a/test/src/801-repository_gateway_slow/main
+++ b/test/src/801-repository_gateway_slow/main
@@ -13,10 +13,10 @@ clean_up() {
     echo "Cleaning up"
 
     echo "  Stopping repository gateway application"
-    sudo /opt/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
 
     echo "  Removing Mnesia directory"
-    sudo rm -rf /opt/cvmfs_mnesia
+    sudo rm -rf /var/lib/cvmfs-gateway
 
     echo "  Removing test repository"
     sudo -E cvmfs_server rmfs -f test.repo.org

--- a/test/src/802-repository_gateway_nested_catalogs/main
+++ b/test/src/802-repository_gateway_nested_catalogs/main
@@ -8,10 +8,10 @@ clean_up() {
     echo "Cleaning up"
 
     echo "  Stopping repository gateway application"
-    sudo /opt/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
 
     echo "  Removing Mnesia directory"
-    sudo rm -rf /opt/cvmfs_mnesia
+    sudo rm -rf /var/lib/cvmfs-gateway
 
     echo "  Removing test repository"
     sudo -E cvmfs_server rmfs -f test.repo.org

--- a/test/src/803-repository_gateway_large_files/main
+++ b/test/src/803-repository_gateway_large_files/main
@@ -8,10 +8,10 @@ clean_up() {
     echo "Cleaning up"
 
     echo "  Stopping repository gateway application"
-    sudo /opt/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
 
     echo "  Removing Mnesia directory"
-    sudo rm -rf /opt/cvmfs_mnesia
+    sudo rm -rf /var/lib/cvmfs-gateway
 
     echo "  Removing test repository"
     sudo -E cvmfs_server rmfs -f test.repo.org

--- a/test/test_functions
+++ b/test/test_functions
@@ -2414,7 +2414,7 @@ set_up_repository_gateway() {
     popd
 
     echo "  Writing configuration files"
-    sudo bash -c 'cat <<EOF > /opt/cvmfs-gateway/etc/repo.json
+    sudo bash -c 'cat <<EOF > /etc/cvmfs/gateway/repo.json
 {
     "repos" : [
         {
@@ -2438,7 +2438,7 @@ plain_text key1 secret1
 EOF'
 
     echo "  Creating Mnesia schema"
-    sudo /opt/cvmfs-gateway/scripts/setup.sh
+    sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
 
     echo "  Creating test repo"
     sudo -E cvmfs_server mkfs -o `whoami` test.repo.org
@@ -2450,5 +2450,5 @@ EOF'
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 
     echo "  Starting repository gateway application"
-    sudo /opt/cvmfs-gateway/scripts/run_cvmfs_gateway.sh start
+    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh start
 }


### PR DESCRIPTION
The `cvmfs-gateway` application is now installed into `/usr/libexec/cvmfs-gateway` and its database into `/var/lib/cvmfs-gateway`.

This PR updates the integration tests scripts, which were still referencing the old installation prefix (`/opt/cvmfs-gateway`).