### PR TITLE
cvmfs_config - modify checks for OSXFUSE

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -407,6 +407,10 @@ cvmfs_chksetup() {
   fi
 
   # Check that /dev/fuse is read/writable from cvmfs user
+  if [ x"$sys_arch" = x"Darwin" ] && [ ! -d /Library/Filesystems/osxfuse.fs ]; then
+    echo "Error: OSXFUSE is missing."
+    num_errors=$(($num_errors+1))
+  fi
   check_dev_fuse
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
@@ -1601,8 +1605,13 @@ check_dev_fuse() {
   return_code=0
 
   if [ ! -c $charDevice ]; then
-    echo "Error: character device $charDevice does not exist"
-    return_code=$(($return_code+1))
+    if [ x"$sys_arch" = x"Linux" ]; then
+      echo "Error: character device $charDevice does not exist"
+      return_code=$(($return_code+1))
+    elif [ x"$sys_arch" = x"Darwin" ]; then
+      echo -n "Warning: character device $charDevice does not exist. "
+      echo "Please make sure that OSXFUSE is installed."
+    fi
   else
     if ! runascvmfsuser "test -r $charDevice"; then
       echo "Error: $charDevice is not readable by cvmfs user"


### PR DESCRIPTION
Addresses [CVM-1550](https://sft.its.cern.ch/jira/browse/CVM-1550).

* Not finding the /dev/osxfuse0 character device should be a warning not an error
* If /Library/Filesystems/osxfuse.fs doesn't exist, OSXFUSE hasn't been installed. This should be an error.