### PR TITLE
Re-enable integration test suite with S3-backed repositories

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# source the common platform independent functionality and option parsing
+script_location=$(cd "$(dirname "$0")"; pwd)
+. ${script_location}/common_test.sh
+
+retval=0
+
+# allow apache access to the mounted server file system
+echo -n "setting SELinux labels for apache... "
+sudo chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail"
+echo "done"
+
+# start apache
+echo -n "starting apache... "
+sudo systemctl start httpd > /dev/null 2>&1 || die "fail"
+echo "OK"
+
+running unit test suite
+run_unittests --gtest_shuffle \
+              --gtest_death_test_use_fork || retval=1
+
+cd ${SOURCE_DIRECTORY}/test
+
+echo -n "starting the test S3 provider... "
+s3_retval=0
+test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($test_s3_pid)"
+create_test_s3_bucket
+
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against the test S3 provider..."
+  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               --                                           \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/8*                                       \
+                               || retval=1
+
+  echo -n "Stopping the test S3 provider... "
+  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
+fi
+
+exit $retval

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -55,8 +55,8 @@ install_from_repo tree
 # traffic shaping
 install_from_repo trickle
 
-# install ruby gem for FakeS3
-install_ruby_gem fakes3
+# Install the test S3 provider
+install_test_s3
 
 # building preloader
 install_from_repo cmake

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -79,6 +79,6 @@ sudo systemctl restart httpd || die "failure in final Apache restart"
 # Install repository gateway
 echo "Installing repository gateway"
 package_map=pkgmap.cc7_x86_64
-gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
-install_rpm $gateway_package
+download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
+install_rpm $(cat gateway_package)
 sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -75,3 +75,10 @@ echo "done"
 
 # Ensure Apache is up and running after package update
 sudo systemctl restart httpd || die "failure in final Apache restart"
+
+# Install repository gateway
+echo "Installing repository gateway"
+package_map=pkgmap.cc7_x86_64
+gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
+install_rpm $gateway_package
+sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -80,5 +80,5 @@ sudo systemctl restart httpd || die "failure in final Apache restart"
 echo "Installing repository gateway"
 package_map=pkgmap.cc7_x86_64
 download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
-install_rpm $(cat gateway_package)
+install_rpm $(cat gateway_package_name)
 sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -17,42 +17,93 @@ sudo systemctl start httpd > /dev/null 2>&1 || die "fail"
 echo "OK"
 
 # running unit test suite
-run_unittests --gtest_shuffle \
-              --gtest_death_test_use_fork || retval=1
+# run_unittests --gtest_shuffle \
+#               --gtest_death_test_use_fork || retval=1
 
 cd ${SOURCE_DIRECTORY}/test
-echo "running CernVM-FS client test cases..."
-CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
-./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                              -x src/005-asetup                               \
-                                 src/004-davinci                              \
-                                 src/007-testjobs                             \
-                                 --                                           \
-                                 src/0*                                       \
-                              || retval=1
+# echo "running CernVM-FS client test cases..."
+# CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+# ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+#                               -x src/005-asetup                               \
+#                                  src/004-davinci                              \
+#                                  src/007-testjobs                             \
+#                                  --                                           \
+#                                  src/0*                                       \
+#                               || retval=1
 
 
-echo "running CernVM-FS server test cases..."
-CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
-CVMFS_TEST_UNIONFS=overlayfs                                                  \
-./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                              -x src/518-hardlinkstresstest                   \
-                                 src/585-xattrs                               \
-                                 src/600-securecvmfs                          \
-                                 src/602-libcvmfs                             \
-                                 src/628-pythonwrappedcvmfsserver             \
-                                 --                                           \
-                                 src/5*                                       \
-                                 src/6*                                       \
-                                 src/7*                                       \
-                                 src/8*                                       \
-                              || retval=1
+# echo "running CernVM-FS server test cases..."
+# CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+# CVMFS_TEST_UNIONFS=overlayfs                                                  \
+# ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+#                               -x src/518-hardlinkstresstest                   \
+#                                  src/585-xattrs                               \
+#                                  src/600-securecvmfs                          \
+#                                  src/602-libcvmfs                             \
+#                                  src/628-pythonwrappedcvmfsserver             \
+#                                  --                                           \
+#                                  src/5*                                       \
+#                                  src/6*                                       \
+#                                  src/7*                                       \
+#                                  src/8*                                       \
+#                               || retval=1
+
+echo -n "starting the test S3 provider... "
+s3_retval=0
+test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($test_s3_pid)"
+create_test_s3_bucket
+
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against the test S3 provider..."
+  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
+  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               src/700-overlayfsvalidation                  \
+                               --                                           \
+                               src/500*                                     \
+                               || retval=1
+
+  echo -n "Stopping the test S3 provider... "
+  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
+fi
 
 
-echo "running CernVM-FS migration test cases..."
-CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
-./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/*                              \
-                                || retval=1
+# echo "running CernVM-FS migration test cases..."
+# CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+# ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+#                                    migration_tests/*                              \
+#                                 || retval=1
 
-exit $retval
+# exit $retval

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -48,57 +48,6 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/8*                                       \
                               || retval=1
 
-echo -n "starting the test S3 provider... "
-s3_retval=0
-test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-echo "done ($test_s3_pid)"
-create_test_s3_bucket
-
-if [ $s3_retval -eq 0 ]; then
-  echo "running CernVM-FS server test cases against the test S3 provider..."
-  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
-  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
-                            -x src/518-hardlinkstresstest                   \
-                               src/519-importlegacyrepo                     \
-                               src/522-missingchunkfailover                 \
-                               src/523-corruptchunkfailover                 \
-                               src/525-bigrepo                              \
-                               src/528-recreatespoolarea                    \
-                               src/530-recreatespoolarea_defaultkey         \
-                               src/537-symlinkedbackend                     \
-                               src/538-symlinkedstratum1backend             \
-                               src/542-storagescrubbing                     \
-                               src/543-storagescrubbing_scriptable          \
-                               src/550-livemigration                        \
-                               src/563-garbagecollectlegacy                 \
-                               src/568-migratecorruptrepo                   \
-                               src/571-localbackendumask                    \
-                               src/572-proxyfailover                        \
-                               src/583-httpredirects                        \
-                               src/585-xattrs                               \
-                               src/591-importrepo                           \
-                               src/594-backendoverwrite                     \
-                               src/595-geoipdbupdate                        \
-                               src/600-securecvmfs                          \
-                               src/605-resurrectancientcatalog              \
-                               src/607-noapache                             \
-                               src/608-infofile                             \
-                               src/610-altpath                              \
-                               src/614-geoservice                           \
-                               src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
-                               --                                           \
-                               src/5*                                       \
-                               src/6*                                       \
-                               src/8*                                       \
-                               || retval=1
-
-  echo -n "Stopping the test S3 provider... "
-  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
-fi
-
 
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -58,7 +58,6 @@ if [ $s3_retval -eq 0 ]; then
   echo "running CernVM-FS server test cases against the test S3 provider..."
   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
   CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
   ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
                             -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -16,37 +16,37 @@ echo -n "starting apache... "
 sudo systemctl start httpd > /dev/null 2>&1 || die "fail"
 echo "OK"
 
-# running unit test suite
-# run_unittests --gtest_shuffle \
-#               --gtest_death_test_use_fork || retval=1
+running unit test suite
+run_unittests --gtest_shuffle \
+              --gtest_death_test_use_fork || retval=1
 
 cd ${SOURCE_DIRECTORY}/test
-# echo "running CernVM-FS client test cases..."
-# CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
-# ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-#                               -x src/005-asetup                               \
-#                                  src/004-davinci                              \
-#                                  src/007-testjobs                             \
-#                                  --                                           \
-#                                  src/0*                                       \
-#                               || retval=1
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/005-asetup                               \
+                                 src/004-davinci                              \
+                                 src/007-testjobs                             \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
 
 
-# echo "running CernVM-FS server test cases..."
-# CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
-# CVMFS_TEST_UNIONFS=overlayfs                                                  \
-# ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-#                               -x src/518-hardlinkstresstest                   \
-#                                  src/585-xattrs                               \
-#                                  src/600-securecvmfs                          \
-#                                  src/602-libcvmfs                             \
-#                                  src/628-pythonwrappedcvmfsserver             \
-#                                  --                                           \
-#                                  src/5*                                       \
-#                                  src/6*                                       \
-#                                  src/7*                                       \
-#                                  src/8*                                       \
-#                               || retval=1
+echo "running CernVM-FS server test cases..."
+CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+CVMFS_TEST_UNIONFS=overlayfs                                                  \
+./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/518-hardlinkstresstest                   \
+                                 src/585-xattrs                               \
+                                 src/600-securecvmfs                          \
+                                 src/602-libcvmfs                             \
+                                 src/628-pythonwrappedcvmfsserver             \
+                                 --                                           \
+                                 src/5*                                       \
+                                 src/6*                                       \
+                                 src/7*                                       \
+                                 src/8*                                       \
+                              || retval=1
 
 echo -n "starting the test S3 provider... "
 s3_retval=0
@@ -89,9 +89,10 @@ if [ $s3_retval -eq 0 ]; then
                                src/614-geoservice                           \
                                src/622-gracefulrmfs                         \
                                src/626-cacheexpiry                          \
-                               src/700-overlayfsvalidation                  \
                                --                                           \
-                               src/500*                                     \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/8*                                       \
                                || retval=1
 
   echo -n "Stopping the test S3 provider... "
@@ -99,10 +100,10 @@ if [ $s3_retval -eq 0 ]; then
 fi
 
 
-# echo "running CernVM-FS migration test cases..."
-# CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
-# ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-#                                    migration_tests/*                              \
-#                                 || retval=1
+echo "running CernVM-FS migration test cases..."
+CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/*                              \
+                                || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -106,4 +106,4 @@ fi
 #                                    migration_tests/*                              \
 #                                 || retval=1
 
-# exit $retval
+exit $retval

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -322,6 +322,19 @@ set_nofile_limit() {
   echo "root soft nofile $limit_value" | sudo tee --append /etc/security/limits.conf > /dev/null
 }
 
+download_gateway_package() {
+  local gateway_build_url=$1
+  local package_map=$2
+  local package_map_url=$1/pkgmap/$2
+
+  curl -o /tmp/package_map $package_map_url
+  local cvmfs_gateway_package_url=${gateway_build_url}/$(tail -1 package_map | cut -d'=' -f2)
+  local cvmfs_gateway_package_file_name=$(echo $cvmfs_gateway_package_url | awk -F'/' {'print $NF'})
+  curl -o /tmp/$cvmfs_gateway_package_file_name $cvmfs_gateway_package_url
+
+  echo "/tmp/$cvmfs_gateway_package_file_name"
+}
+
 
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -305,8 +305,8 @@ install_homebrew() {
 
 
 install_test_s3() {
-  sudo curl -o /usr/local/bin/minio https://dl.minio.io/server/minio/release/linux-amd64/minio
-  sudo curl -o /usr/local/bin/mc    https://dl.minio.io/client/mc/release/linux-amd64/mc
+  sudo curl -o /usr/local/bin/minio https://ecsft.cern.ch/dist/cvmfs/builddeps/minio
+  sudo curl -o /usr/local/bin/mc    https://ecsft.cern.ch/dist/cvmfs/builddeps/mc
   sudo chmod +x /usr/local/bin/minio
   sudo chmod +x /usr/local/bin/mc
 

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -420,6 +420,7 @@ start_test_s3() {
   sudo mkdir -p $TEST_S3_STORAGE/{config,mc_config,data}    > /dev/null 2>&1 || return 2
   create_test_s3_config                                     > /dev/null 2>&1 || return 3
   run_background_service $logfile "sudo minio server --address :$TEST_S3_PORT --config-dir $TEST_S3_STORAGE/config $TEST_S3_STORAGE/data"
+  sleep 5
 }
 
 

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -337,12 +337,34 @@ download_gateway_package() {
   local package_map_file=$2
   local package_map_url=$gateway_build_url/pkgmap/$package_map_file
 
-  curl -s -o /tmp/package_map $package_map_url
-  local cvmfs_gateway_package_url=${gateway_build_url}/$(tail -1 /tmp/package_map | cut -d'=' -f2)
-  local cvmfs_gateway_package_file_name=$(echo $cvmfs_gateway_package_url | awk -F'/' {'print $NF'})
-  curl -s -o /tmp/$cvmfs_gateway_package_file_name $cvmfs_gateway_package_url
+  echo "Downloading package map from: $package_map_url"
+  curl -s -o gateway_package_map $package_map_url
 
-  echo "/tmp/$cvmfs_gateway_package_file_name"
+  local ret=$?
+
+  if [ "x$ret" != "x0" ]; then
+    echo "Could not download cvmfs-gateway package map"
+    return 1;
+  fi
+
+  local cvmfs_gateway_package_url=${gateway_build_url}/$(tail -1 gateway_package_map | cut -d'=' -f2)
+  local cvmfs_gateway_package_file_name=$(echo $cvmfs_gateway_package_url | awk -F'/' {'print $NF'})
+
+  rm -f gateway_package_map
+
+  echo "Downloading cvmfs-gateway package from: $cvmfs_gateway_package_url"
+  curl -s $cvmfs_gateway_package_url > $cvmfs_gateway_package_file_name
+
+  ret=$?
+
+  if [ "x$ret" != "x0" ]; then
+    echo "Could not download cvmfs-gateway package"
+    return 2;
+  fi
+
+  echo $cvmfs_gateway_package_file_name > gateway_package_name
+
+  return 0;
 }
 
 

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -334,13 +334,13 @@ set_nofile_limit() {
 
 download_gateway_package() {
   local gateway_build_url=$1
-  local package_map=$2
-  local package_map_url=$1/pkgmap/$2
+  local package_map_file=$2
+  local package_map_url=$gateway_build_url/pkgmap/$package_map_file
 
-  curl -o /tmp/package_map $package_map_url
-  local cvmfs_gateway_package_url=${gateway_build_url}/$(tail -1 package_map | cut -d'=' -f2)
+  curl -s -o /tmp/package_map $package_map_url
+  local cvmfs_gateway_package_url=${gateway_build_url}/$(tail -1 /tmp/package_map | cut -d'=' -f2)
   local cvmfs_gateway_package_file_name=$(echo $cvmfs_gateway_package_url | awk -F'/' {'print $NF'})
-  curl -o /tmp/$cvmfs_gateway_package_file_name $cvmfs_gateway_package_url
+  curl -s -o /tmp/$cvmfs_gateway_package_file_name $cvmfs_gateway_package_url
 
   echo "/tmp/$cvmfs_gateway_package_file_name"
 }

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -425,8 +425,8 @@ start_test_s3() {
 
 create_test_s3_bucket() {
   if [ "x$(mc -C $TEST_S3_STORAGE/mc_config ls cvmfs/$TEST_S3_BUCKET)" != "x0" ]; then
-    mc -C $TEST_S3_STORAGE/mc_config mb cvmfs/$TEST_S3_BUCKET
-    mc -C $TEST_S3_STORAGE/mc_config policy public cvmfs/$TEST_S3_BUCKET
+    sudo mc -C $TEST_S3_STORAGE/mc_config mb cvmfs/$TEST_S3_BUCKET
+    sudo mc -C $TEST_S3_STORAGE/mc_config policy public cvmfs/$TEST_S3_BUCKET
   fi
 }
 

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -424,7 +424,7 @@ start_test_s3() {
 
 
 create_test_s3_bucket() {
-  if [ "x$(mc -C $TEST_S3_STORAGE/mc_config ls cvmfs/$TEST_S3_BUCKET)" != "x0" ]; then
+  if [ "x$(sudo mc -C $TEST_S3_STORAGE/mc_config ls cvmfs/$TEST_S3_BUCKET)" != "x0" ]; then
     sudo mc -C $TEST_S3_STORAGE/mc_config mb cvmfs/$TEST_S3_BUCKET
     sudo mc -C $TEST_S3_STORAGE/mc_config policy public cvmfs/$TEST_S3_BUCKET
   fi

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -304,6 +304,16 @@ install_homebrew() {
 }
 
 
+install_test_s3() {
+  sudo curl -o /usr/local/bin/minio https://dl.minio.io/server/minio/release/linux-amd64/minio
+  sudo curl -o /usr/local/bin/mc    https://dl.minio.io/client/mc/release/linux-amd64/mc
+  sudo chmod +x /usr/local/bin/minio
+  sudo chmod +x /usr/local/bin/mc
+
+  return 0
+}
+
+
 attach_user_group() {
   local groupname=$1
   local username
@@ -341,27 +351,61 @@ download_gateway_package() {
 #
 
 
-create_fakes3_config() {
-  [ ! -f $FAKE_S3_CONFIG ] || sudo rm -f $FAKE_S3_CONFIG
-  sudo tee $FAKE_S3_CONFIG > /dev/null << EOF
+create_test_s3_config() {
+  [ ! -f $TEST_S3_CONFIG ] || sudo rm -f $TEST_S3_CONFIG
+  sudo tee $TEST_S3_CONFIG > /dev/null << EOF
 CVMFS_S3_HOST=localhost
-CVMFS_S3_PORT=$FAKE_S3_PORT
+CVMFS_S3_PORT=$TEST_S3_PORT
 CVMFS_S3_ACCESS_KEY=not
 CVMFS_S3_SECRET_KEY=important
 CVMFS_S3_BUCKETS_PER_ACCOUNT=1
 CVMFS_S3_MAX_NUMBER_OF_PARALLEL_CONNECTIONS=10
-CVMFS_S3_BUCKET=$FAKE_S3_BUCKET
+CVMFS_S3_BUCKET=$TEST_S3_BUCKET
 EOF
+
+  sudo tee $TEST_S3_STORAGE/config/config.json > /dev/null << EOF
+{
+	"version": "23",
+	"credential": {
+		"accessKey": "not",
+		"secretKey": "important"
+	}
+}
+EOF
+
+  sudo tee $TEST_S3_STORAGE/mc_config/config.json > /dev/null << EOF
+{
+	"version": "9",
+	"hosts": {
+		"cvmfs": {
+			"url": "http://localhost:13337",
+			"accessKey": "not",
+			"secretKey": "important",
+			"api": "S3v4",
+			"lookup": "auto"
+		}
+	}
+}
+EOF
+
 }
 
 
-start_fakes3() {
+start_test_s3() {
   local logfile=$1
 
-  [ ! -d $FAKE_S3_STORAGE ] || sudo rm -fR $FAKE_S3_STORAGE > /dev/null 2>&1 || return 1
-  sudo mkdir -p $FAKE_S3_STORAGE                            > /dev/null 2>&1 || return 2
-  create_fakes3_config                                      > /dev/null 2>&1 || return 3
-  run_background_service $logfile "sudo fakes3 --port $FAKE_S3_PORT --root $FAKE_S3_STORAGE"
+  [ ! -d $TEST_S3_STORAGE ] || sudo rm -fR $TEST_S3_STORAGE > /dev/null 2>&1 || return 1
+  sudo mkdir -p $TEST_S3_STORAGE/{config,mc_config,data}    > /dev/null 2>&1 || return 2
+  create_test_s3_config                                     > /dev/null 2>&1 || return 3
+  run_background_service $logfile "sudo minio server --address :$TEST_S3_PORT --config-dir $TEST_S3_STORAGE/config $TEST_S3_STORAGE/data"
+}
+
+
+create_test_s3_bucket() {
+  if [ "x$(mc -C $TEST_S3_STORAGE/mc_config ls cvmfs/$TEST_S3_BUCKET)" != "x0" ]; then
+    mc -C $TEST_S3_STORAGE/mc_config mb cvmfs/$TEST_S3_BUCKET
+    mc -C $TEST_S3_STORAGE/mc_config policy public cvmfs/$TEST_S3_BUCKET
+  fi
 }
 
 

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -419,15 +419,16 @@ start_test_s3() {
   [ ! -d $TEST_S3_STORAGE ] || sudo rm -fR $TEST_S3_STORAGE > /dev/null 2>&1 || return 1
   sudo mkdir -p $TEST_S3_STORAGE/{config,mc_config,data}    > /dev/null 2>&1 || return 2
   create_test_s3_config                                     > /dev/null 2>&1 || return 3
-  run_background_service $logfile "sudo minio server --address :$TEST_S3_PORT --config-dir $TEST_S3_STORAGE/config $TEST_S3_STORAGE/data"
+  local service_pid=$(run_background_service $logfile "sudo /usr/local/bin/minio server --address :$TEST_S3_PORT --config-dir $TEST_S3_STORAGE/config $TEST_S3_STORAGE/data")
   sleep 5
+  echo $service_pid
 }
 
 
 create_test_s3_bucket() {
-  if [ "x$(sudo mc -C $TEST_S3_STORAGE/mc_config ls cvmfs/$TEST_S3_BUCKET)" != "x0" ]; then
-    sudo mc -C $TEST_S3_STORAGE/mc_config mb cvmfs/$TEST_S3_BUCKET
-    sudo mc -C $TEST_S3_STORAGE/mc_config policy public cvmfs/$TEST_S3_BUCKET
+  if [ "x$(sudo /usr/local/bin/mc -C $TEST_S3_STORAGE/mc_config ls cvmfs/$TEST_S3_BUCKET)" != "x0" ]; then
+    sudo /usr/local/bin/mc -C $TEST_S3_STORAGE/mc_config mb cvmfs/$TEST_S3_BUCKET
+    sudo /usr/local/bin/mc -C $TEST_S3_STORAGE/mc_config policy public cvmfs/$TEST_S3_BUCKET
   fi
 }
 

--- a/test/cloud_testing/platforms/common_setup.sh
+++ b/test/cloud_testing/platforms/common_setup.sh
@@ -22,6 +22,7 @@ script_location=$(portable_dirname $0)
 #  SOURCE_DIRECTORY      location of the CernVM-FS sources forming above packages
 #  UNITTEST_PACKAGE      location of the CernVM-FS unit test package
 #  LOG_DIRECTORY         location of the test log files to be created
+#  GATEWAY_BUILD_URL     location of the repository gateway build to install
 #
 
 SERVER_PACKAGE=""
@@ -31,9 +32,10 @@ UNITTEST_PACKAGE=""
 CONFIG_PACKAGES=""
 SOURCE_DIRECTORY=""
 LOG_DIRECTORY=""
+GATEWAY_BUILD_URL=""
 
 # parse script parameters (same for all platforms)
-while getopts "s:c:d:k:t:g:l:" option; do
+while getopts "s:c:d:k:t:g:l:w:" option; do
   case $option in
     s)
       SERVER_PACKAGE=$OPTARG
@@ -55,6 +57,9 @@ while getopts "s:c:d:k:t:g:l:" option; do
       ;;
     l)
       LOG_DIRECTORY=$OPTARG
+      ;;
+    w)
+      GATEWAY_BUILD_URL=$OPTARG
       ;;
     ?)
       shift $(($OPTIND-2))

--- a/test/cloud_testing/platforms/common_setup.sh
+++ b/test/cloud_testing/platforms/common_setup.sh
@@ -79,6 +79,7 @@ if [ "x$(uname -s)" != "xDarwin" ]; then
     if [ "x$SERVER_PACKAGE"        = "x" ] ||
        [ "x$CONFIG_PACKAGES"       = "x" ] ||
        [ "x$UNITTEST_PACKAGE"      = "x" ] ||
+       [ "x$GATEWAY_BUILD_URL"     = "x" ] ||
        [ "x$DEVEL_PACKAGE"         = "x" ]; then
       echo "missing parameter(s), cannot run platform dependent test script"
       exit 200

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -22,11 +22,11 @@ script_location=$(portable_dirname $0)
 #    LOG_DIRECTORY         location of the test log files to be created
 #
 # Additionally the following configuration variables will be defined:
-#    FAKE_S3_PORT          network port to communicate with FakeS3
-#    FAKE_S3_STORAGE       storage location of FakeS3
-#    FAKE_S3_CONFIG        location of the S3 config file to be created/used
-#    FAKE_S3_BUCKET        name of the S3 bucket to be used
-#    FAKE_S3_URL           URL to the S3 server
+#    TEST_S3_PORT          network port to communicate with the test S3 provider
+#    TEST_S3_STORAGE       storage location of the test S3 provider
+#    TEST_S3_CONFIG        location of the S3 config file to be created/used
+#    TEST_S3_BUCKET        name of the S3 bucket to be used
+#    TEST_S3_URL           URL to the S3 server
 #
 
 SOURCE_DIRECTORY=""
@@ -35,11 +35,11 @@ CLIENT_PACKAGE=""
 DEVEL_PACKAGE=""
 LOG_DIRECTORY=""
 
-FAKE_S3_PORT=13337
-FAKE_S3_STORAGE=/srv/fakes3
-FAKE_S3_CONFIG=/etc/cvmfs/fakes3.conf
-FAKE_S3_BUCKET=cvmfs_test
-FAKE_S3_URL=http://localhost:${FAKE_S3_PORT}/${FAKE_S3_BUCKET}-1-1
+TEST_S3_PORT=13337
+TEST_S3_STORAGE=/srv/test_s3
+TEST_S3_CONFIG=/etc/cvmfs/test_s3.conf
+TEST_S3_BUCKET=cvmfstest
+TEST_S3_URL=http://localhost:${TEST_S3_PORT}/${TEST_S3_BUCKET}
 
 usage() {
   local msg=$1
@@ -104,8 +104,8 @@ EOF
 
 CLIENT_TEST_LOGFILE="${LOG_DIRECTORY}/test_client.log"
 SERVER_TEST_LOGFILE="${LOG_DIRECTORY}/test_server.log"
-TEST_S3_LOGFILE="${LOG_DIRECTORY}/test_s3.log"
-FAKE_S3_LOGFILE="${LOG_DIRECTORY}/fake_s3.log"
+S3_TEST_LOGFILE="${LOG_DIRECTORY}/test_s3.log"
+TEST_S3_LOGFILE="${LOG_DIRECTORY}/test_s3_instance.log"
 UNITTEST_LOGFILE="${LOG_DIRECTORY}/unittest.log"
 MIGRATIONTEST_LOGFILE="${LOG_DIRECTORY}/migrationtest.log"
 

--- a/test/cloud_testing/platforms/slc5_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc5_x86_64_test.sh
@@ -85,7 +85,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 echo "running CernVM-FS server test cases..."
 # TODO(jblomer): 551-openfds triggers an aufs panic
-CVMFS_TEST_SERVER_CACHE='/srv/cache/server'                                   \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/slc6_x86_64-gcov_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-gcov_setup.sh
@@ -115,8 +115,8 @@ install_from_repo gzip
 # traffic shaping
 install_from_repo trickle
 
-# install ruby gem for FakeS3
-install_ruby_gem fakes3
+# install the test S3 provider
+install_test_s3
 
 # build and install CernVM-FS from source
 cd $SOURCE_DIRECTORY

--- a/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
@@ -24,8 +24,8 @@ done
 
 CLIENT_TEST_LOGFILE="${LOG_DIRECTORY}/test_client.log"
 SERVER_TEST_LOGFILE="${LOG_DIRECTORY}/test_server.log"
-TEST_S3_LOGFILE="${LOG_DIRECTORY}/test_s3.log"
-FAKE_S3_LOGFILE="${LOG_DIRECTORY}/fake_s3.log"
+S3_TEST_LOGFILE="${LOG_DIRECTORY}/test_s3.log"
+TEST_S3_LOGFILE="${LOG_DIRECTORY}/test_s3_instance.log"
 
 XUNIT_OUTPUT_SUFFIX=".xunit.xml"
 
@@ -101,18 +101,18 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               || retval=1
 
 
-# echo -n "starting FakeS3 service... "
+# echo -n "starting the test S3 provider... "
 # s3_retval=0
-# fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-# echo "done ($fakes3_pid)"
+# test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+# echo "done ($test_s3_pid)"
 
 # if [ $s3_retval -eq 0 ]; then
-#   echo "running CernVM-FS server test cases against FakeS3..."
-#   CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
-#   CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
+#   echo "running CernVM-FS server test cases against the test S3 provider..."
+#   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+#   CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
 #   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
 #   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-#   ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+#   ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
 #                             -x src/518-hardlinkstresstest                   \
 #                                src/519-importlegacyrepo                     \
 #                                src/522-missingchunkfailover                 \
@@ -134,8 +134,8 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 #                                --                                           \
 #                                src/5* || retval=1
 
-#   echo -n "killing FakeS3... "
-#   sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
+#   echo -n "Stopping the test S3 provider... "
+#   sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
 # fi
 
 exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64-gcov_test.sh
@@ -89,7 +89,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 
 echo "running CernVM-FS server test cases..."
-CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
@@ -110,7 +109,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 #   echo "running CernVM-FS server test cases against the test S3 provider..."
 #   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
 #   CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-#   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
 #   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
 #   ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
 #                             -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+# source the common platform independent functionality and option parsing
+script_location=$(cd "$(dirname "$0")"; pwd)
+. ${script_location}/common_test.sh
+
+retval=0
+
+# format additional disks with ext4 and many inodes
+echo -n "formatting new disk partitions... "
+disk_to_partition=/dev/vda
+partition_2=$(get_last_partition_number $disk_to_partition)
+partition_1=$(( $partition_2 - 1 ))
+format_partition_ext4 $disk_to_partition$partition_1 || die "fail (formatting partition 1)"
+format_partition_ext4 $disk_to_partition$partition_2 || die "fail (formatting partition 2)"
+echo "done"
+
+# mount additional disk partitions on strategic cvmfs location
+echo -n "mounting new disk partitions into cvmfs specific locations... "
+mount_partition $disk_to_partition$partition_1 /srv             || die "fail (mounting /srv $?)"
+mount_partition $disk_to_partition$partition_2 /var/spool/cvmfs || die "fail (mounting /var/spool/cvmfs $?)"
+echo "done"
+
+# allow apache access to the mounted server file system
+echo -n "setting SELinux labels for apache... "
+sudo chcon -Rv --type=httpd_sys_content_t /srv > /dev/null || die "fail"
+echo "done"
+
+# start apache
+echo -n "starting apache... "
+sudo service httpd start > /dev/null 2>&1 || die "fail"
+echo "OK"
+
+# create the server's client cache directory in /srv (AUFS kernel deadlock workaround)
+echo -n "creating client caches on extra partition... "
+sudo mkdir -p /srv/cache/server || die "fail (cache for server test cases)"
+sudo mkdir -p /srv/cache/client || die "fail (cache for client test cases)"
+echo "done"
+
+echo -n "bind mount client cache to /var/lib/cvmfs... "
+if [ ! -d /var/lib/cvmfs ]; then
+  sudo rm -fR   /var/lib/cvmfs || true
+  sudo mkdir -p /var/lib/cvmfs || die "fail (mkdir /var/lib/cvmfs)"
+fi
+sudo mount --bind /srv/cache/client /var/lib/cvmfs || die "fail (cannot bind mount /var/lib/cvmfs)"
+echo "done"
+
+# reset SELinux context
+echo -n "restoring SELinux context for /var/lib/cvmfs... "
+sudo restorecon -R /var/lib/cvmfs || die "fail"
+echo "done"
+
+# running unit test suite
+run_unittests --gtest_shuffle \
+              --gtest_death_test_use_fork || retval=1
+
+
+cd ${SOURCE_DIRECTORY}/test
+
+echo -n "starting the test S3 provider... "
+s3_retval=0
+test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($test_s3_pid)"
+create_test_s3_bucket
+
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against the test S3 provider..."
+  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               --                                           \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/8*                                       \
+                               || retval=1
+
+  echo -n "Stopping the test S3 provider... "
+  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
+fi
+
+exit $retval

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -111,8 +111,8 @@ echo -n "install x509 helper... "
 sudo rpm -ivh $(basename $x509_helper) > /dev/null || die "install failed"
 echo "OK"
 
-# install ruby gem for FakeS3
-install_ruby_gem fakes3 0.2.0  # latest is 0.2.1 (23.07.2015) that didn't work.
+# install the test S3 provider
+install_test_s3
 
 # increase open file descriptor limits
 echo -n "increasing ulimit -n ... "

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -123,7 +123,7 @@ echo "done"
 echo "Installing repository gateway"
 package_map=pkgmap.slc6_x86_64
 download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
-install_rpm $(cat gateway_package)
+install_rpm $(cat gateway_package_name)
 sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
 
 # rebooting the system (returning 0 value)

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -122,8 +122,8 @@ echo "done"
 # Install repository gateway
 echo "Installing repository gateway"
 package_map=pkgmap.slc6_x86_64
-gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
-install_rpm $gateway_package
+download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
+install_rpm $(cat gateway_package)
 sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
 
 # rebooting the system (returning 0 value)

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -119,6 +119,13 @@ echo -n "increasing ulimit -n ... "
 set_nofile_limit 65536 || die "fail"
 echo "done"
 
+# Install repository gateway
+echo "Installing repository gateway"
+package_map=pkgmap.slc6_x86_64
+gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
+install_rpm $gateway_package
+sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
+
 # rebooting the system (returning 0 value)
 echo "sleep 1 && reboot" > killme.sh
 sudo nohup sh < killme.sh &

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -77,58 +77,6 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               || retval=1
 
 
-echo -n "starting the test S3 provider... "
-s3_retval=0
-test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-echo "done ($test_s3_pid)"
-create_test_s3_bucket
-
-if [ $s3_retval -eq 0 ]; then
-  echo "running CernVM-FS server test cases against the test S3 provider..."
-  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
-  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
-                            -x src/518-hardlinkstresstest                   \
-                               src/519-importlegacyrepo                     \
-                               src/522-missingchunkfailover                 \
-                               src/523-corruptchunkfailover                 \
-                               src/525-bigrepo                              \
-                               src/528-recreatespoolarea                    \
-                               src/530-recreatespoolarea_defaultkey         \
-                               src/537-symlinkedbackend                     \
-                               src/538-symlinkedstratum1backend             \
-                               src/542-storagescrubbing                     \
-                               src/543-storagescrubbing_scriptable          \
-                               src/550-livemigration                        \
-                               src/563-garbagecollectlegacy                 \
-                               src/568-migratecorruptrepo                   \
-                               src/571-localbackendumask                    \
-                               src/572-proxyfailover                        \
-                               src/583-httpredirects                        \
-                               src/585-xattrs                               \
-                               src/591-importrepo                           \
-                               src/594-backendoverwrite                     \
-                               src/595-geoipdbupdate                        \
-                               src/600-securecvmfs                          \
-                               src/605-resurrectancientcatalog              \
-                               src/607-noapache                             \
-                               src/608-infofile                             \
-                               src/610-altpath                              \
-                               src/614-geoservice                           \
-                               src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
-                               --                                           \
-                               src/5*                                       \
-                               src/6*                                       \
-                               src/8*                                       \
-                               || retval=1
-
-  echo -n "Stopping the test S3 provider... "
-  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
-fi
-
-
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests                                              \
 ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -78,18 +78,18 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               || retval=1
 
 
-# echo -n "starting FakeS3 service... "
+# echo -n "starting the test S3 provider... "
 # s3_retval=0
-# fakes3_pid=$(start_fakes3 $FAKE_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-# echo "done ($fakes3_pid)"
+# test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+# echo "done ($test_s3_pid)"
 
 # if [ $s3_retval -eq 0 ]; then
-#   echo "running CernVM-FS server test cases against FakeS3..."
-#   CVMFS_TEST_S3_CONFIG=$FAKE_S3_CONFIG                                      \
-#   CVMFS_TEST_HTTP_BASE=$FAKE_S3_URL                                         \
+#   echo "running CernVM-FS server test cases against the test S3 provider..."
+#   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+#   CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
 #   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
 #   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-#   ./run.sh $TEST_S3_LOGFILE -o ${TEST_S3_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+#   ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
 #                             -x src/518-hardlinkstresstest                   \
 #                                src/519-importlegacyrepo                     \
 #                                src/522-missingchunkfailover                 \
@@ -126,8 +126,8 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 #                                src/7*                                       \
 #                                || retval=1
 
-#   echo -n "killing FakeS3... "
-#   sudo kill -2 $fakes3_pid && echo "done" || echo "fail"
+#   echo -n "Stopping the test S3 provider... "
+#   sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
 # fi
 
 

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -64,7 +64,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 
 
 echo "running CernVM-FS server test cases..."
-CVMFS_TEST_SERVER_CACHE='/srv/cache'                                          \
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -78,57 +78,56 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               || retval=1
 
 
-# echo -n "starting the test S3 provider... "
-# s3_retval=0
-# test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-# echo "done ($test_s3_pid)"
+echo -n "starting the test S3 provider... "
+s3_retval=0
+test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($test_s3_pid)"
+create_test_s3_bucket
 
-# if [ $s3_retval -eq 0 ]; then
-#   echo "running CernVM-FS server test cases against the test S3 provider..."
-#   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
-#   CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-#   CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
-#   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-#   ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
-#                             -x src/518-hardlinkstresstest                   \
-#                                src/519-importlegacyrepo                     \
-#                                src/522-missingchunkfailover                 \
-#                                src/523-corruptchunkfailover                 \
-#                                src/525-bigrepo                              \
-#                                src/528-recreatespoolarea                    \
-#                                src/530-recreatespoolarea_defaultkey         \
-#                                src/537-symlinkedbackend                     \
-#                                src/538-symlinkedstratum1backend             \
-#                                src/542-storagescrubbing                     \
-#                                src/543-storagescrubbing_scriptable          \
-#                                src/550-livemigration                        \
-#                                src/563-garbagecollectlegacy                 \
-#                                src/568-migratecorruptrepo                   \
-#                                src/571-localbackendumask                    \
-#                                src/572-proxyfailover                        \
-#                                src/583-httpredirects                        \
-#                                src/585-xattrs                               \
-#                                src/591-importrepo                           \
-#                                src/594-backendoverwrite                     \
-#                                src/595-geoipdbupdate                        \
-#                                src/600-securecvmfs                          \
-#                                src/605-resurrectancientcatalog              \
-#                                src/607-noapache                             \
-#                                src/608-infofile                             \
-#                                src/610-altpath                              \
-#                                src/614-geoservice                           \
-#                                src/622-gracefulrmfs                         \
-#                                src/626-cacheexpiry                          \
-#                                src/700-overlayfsvalidation                  \
-#                                --                                           \
-#                                src/5*                                       \
-#                                src/6*                                       \
-#                                src/7*                                       \
-#                                || retval=1
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against the test S3 provider..."
+  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               --                                           \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/8*                                       \
+                               || retval=1
 
-#   echo -n "Stopping the test S3 provider... "
-#   sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
-# fi
+  echo -n "Stopping the test S3 provider... "
+  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
+fi
 
 
 echo "running CernVM-FS migration test cases..."

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -1,0 +1,96 @@
+
+
+# source the common platform independent functionality and option parsing
+script_location=$(cd "$(dirname "$0")"; pwd)
+. ${script_location}/common_test.sh
+
+retval=0
+
+running unittests
+run_unittests --gtest_shuffle \
+             --gtest_death_test_use_fork || retval=1
+
+
+CVMFS_EXCLUDE=
+if [ x"$(lsb_release -cs)" = x"xenial" ]; then
+  # Ubuntu 16.04
+  # Kernel sources too old for gcc, TODO
+  CVMFS_EXCLUDE="src/006-buildkernel"
+  # Should work once packages are built on destination platform, TODO
+  CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/602-libcvmfs"
+  # Expected failure, see test case
+  CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/628-pythonwrappedcvmfsserver"
+
+  echo "Ubuntu 16.04... using overlayfs"
+  export CVMFS_TEST_UNIONFS=overlayfs
+fi
+if [ x"$(lsb_release -cs)" = x"trusty" ]; then
+  # Ubuntu 14.04
+  # aufs, expected failure
+  CVMFS_EXCLUDE="src/700-overlayfs_validation src/80*-repository_gateway*"
+
+  echo "Ubuntu 14.04... using aufs instead of overlayfs"
+fi
+if [ x"$(lsb_release -cs)" = x"precise" ]; then
+  # Ubuntu 12.04
+  # aufs, expected failure
+  CVMFS_EXCLUDE="src/614-geoservice src/700-overlayfs_validation src/80*-repository_gateway*"
+
+  echo "Ubuntu 12.04... using aufs instead of overlayfs"
+fi
+
+
+cd ${SOURCE_DIRECTORY}/test
+
+echo -n "starting the test S3 provider... "
+s3_retval=0
+test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($test_s3_pid)"
+create_test_s3_bucket
+
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against the test S3 provider..."
+  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               --                                           \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/8*                                       \
+                               || retval=1
+
+  echo -n "Stopping the test S3 provider... "
+  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
+fi
+
+exit $retval

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -102,6 +102,15 @@ if [ "x$(lsb_release -cs)" = "xxenial" ]; then
   dpkg -s autofs
 fi
 
+# On Ubuntu 16.04 install the repository gateway
+if [ "x$(lsb_release -cs)" = "xxenial" ]; then
+  echo "Installing repository gateway"
+  package_map=pkgmap.pkgmap.ubuntu1604_x86_64
+  gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
+  install_deb $gateway_package
+  sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
+fi
+
 # setting up the AUFS kernel module
 echo -n "loading AUFS kernel module..."
 sudo modprobe aufs || die "fail"

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -109,8 +109,8 @@ fi
 if [ "x$(lsb_release -cs)" = "xxenial" ]; then
   echo "Installing repository gateway"
   package_map=pkgmap.ubuntu1604_x86_64
-  gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
-  install_deb $gateway_package
+  download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
+  install_deb $(cat gateway_package_name)
   sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
 fi
 

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -82,6 +82,9 @@ install_from_repo cmake        || die "fail (installing cmake)"
 install_from_repo libattr1-dev || die "fail (installing libattr1-dev)"
 install_from_repo python-dev   || die "fail (installing python-dev)"
 
+# Install the test S3 provider
+install_test_s3 || die "fail (installing test S3)"
+
 # install 'jq' (on 12.04 this needs the precise-backports repo)
 if [ x"$(lsb_release -cs)" = x"precise" ]; then
   echo -n "enabling precise-backports... "

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -108,7 +108,7 @@ fi
 # On Ubuntu 16.04 install the repository gateway
 if [ "x$(lsb_release -cs)" = "xxenial" ]; then
   echo "Installing repository gateway"
-  package_map=pkgmap.pkgmap.ubuntu1604_x86_64
+  package_map=pkgmap.ubuntu1604_x86_64
   gateway_package=$(download_gateway_package ${GATEWAY_BUILD_URL} $package_map)
   install_deb $gateway_package
   sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -82,7 +82,6 @@ if [ $s3_retval -eq 0 ]; then
   echo "running CernVM-FS server test cases against the test S3 provider..."
   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
   CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
   CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
   ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
                             -x src/518-hardlinkstresstest                   \

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -40,7 +40,7 @@ if [ x"$(lsb_release -cs)" = x"precise" ]; then
 fi
 
 
-# cd ${SOURCE_DIRECTORY}/test
+cd ${SOURCE_DIRECTORY}/test
 # echo "running CernVM-FS client test cases..."
 # CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
 # ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -6,9 +6,9 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 
 retval=0
 
-# running unittests
-# run_unittests --gtest_shuffle \
-#              --gtest_death_test_use_fork || retval=1
+running unittests
+run_unittests --gtest_shuffle \
+             --gtest_death_test_use_fork || retval=1
 
 
 CVMFS_EXCLUDE=
@@ -41,35 +41,35 @@ fi
 
 
 cd ${SOURCE_DIRECTORY}/test
-# echo "running CernVM-FS client test cases..."
-# CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
-# ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-#                               -x src/004-davinci                              \
-#                                  src/005-asetup                               \
-#                                  src/007-testjobs                             \
-#                                  src/024-reload-during-asetup                 \
-#                                  src/050-configrepo                           \
-#                                  $CVMFS_EXCLUDE                               \
-#                                  --                                           \
-#                                  src/0*                                       \
-#                               || retval=1
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                              -x src/004-davinci                              \
+                                 src/005-asetup                               \
+                                 src/007-testjobs                             \
+                                 src/024-reload-during-asetup                 \
+                                 src/050-configrepo                           \
+                                 $CVMFS_EXCLUDE                               \
+                                 --                                           \
+                                 src/0*                                       \
+                              || retval=1
 
 
-# if [ x"$(uname -m)" = x"x86_64" ]; then
-#   echo "running CernVM-FS server test cases..."
-#   CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
-#   ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-#                                 -x src/518-hardlinkstresstest                   \
-#                                    src/585-xattrs                               \
-#                                    src/600-securecvmfs                          \
-#                                    $CVMFS_EXCLUDE                               \
-#                                    --                                           \
-#                                    src/5*                                       \
-#                                    src/6*                                       \
-#                                    src/7*                                       \
-#                                    src/8*                                       \
-#                                 || retval=1
-# fi
+if [ x"$(uname -m)" = x"x86_64" ]; then
+  echo "running CernVM-FS server test cases..."
+  CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+  ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                -x src/518-hardlinkstresstest                   \
+                                   src/585-xattrs                               \
+                                   src/600-securecvmfs                          \
+                                   $CVMFS_EXCLUDE                               \
+                                   --                                           \
+                                   src/5*                                       \
+                                   src/6*                                       \
+                                   src/7*                                       \
+                                   src/8*                                       \
+                                || retval=1
+fi
 
 
 echo -n "starting the test S3 provider... "
@@ -113,9 +113,10 @@ if [ $s3_retval -eq 0 ]; then
                                src/614-geoservice                           \
                                src/622-gracefulrmfs                         \
                                src/626-cacheexpiry                          \
-                               src/700-overlayfsvalidation                  \
                                --                                           \
-                               src/500*                                     \
+                               src/5*                                       \
+                               src/6*                                       \
+                               src/8*                                       \
                                || retval=1
 
   echo -n "Stopping the test S3 provider... "
@@ -123,11 +124,11 @@ if [ $s3_retval -eq 0 ]; then
 fi
 
 
-# # Ubuntu 12.04
-# echo "running CernVM-FS migration test cases..."
-# CVMFS_TEST_CLASS_NAME=MigrationTests \
-# ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-#                                    migration_tests/*                              \
-#                                 || retval=1
+# Ubuntu 12.04
+echo "running CernVM-FS migration test cases..."
+CVMFS_TEST_CLASS_NAME=MigrationTests \
+./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                   migration_tests/*                              \
+                                || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -7,8 +7,8 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 retval=0
 
 # running unittests
-run_unittests --gtest_shuffle \
-              --gtest_death_test_use_fork || retval=1
+# run_unittests --gtest_shuffle \
+#              --gtest_death_test_use_fork || retval=1
 
 
 CVMFS_EXCLUDE=
@@ -40,36 +40,36 @@ if [ x"$(lsb_release -cs)" = x"precise" ]; then
 fi
 
 
-cd ${SOURCE_DIRECTORY}/test
-echo "running CernVM-FS client test cases..."
-CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
-./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                              -x src/004-davinci                              \
-                                 src/005-asetup                               \
-                                 src/007-testjobs                             \
-                                 src/024-reload-during-asetup                 \
-                                 src/050-configrepo                           \
-                                 $CVMFS_EXCLUDE                               \
-                                 --                                           \
-                                 src/0*                                       \
-                              || retval=1
+# cd ${SOURCE_DIRECTORY}/test
+# echo "running CernVM-FS client test cases..."
+# CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
+# ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+#                               -x src/004-davinci                              \
+#                                  src/005-asetup                               \
+#                                  src/007-testjobs                             \
+#                                  src/024-reload-during-asetup                 \
+#                                  src/050-configrepo                           \
+#                                  $CVMFS_EXCLUDE                               \
+#                                  --                                           \
+#                                  src/0*                                       \
+#                               || retval=1
 
 
-if [ x"$(uname -m)" = x"x86_64" ]; then
-  echo "running CernVM-FS server test cases..."
-  CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
-  ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                -x src/518-hardlinkstresstest                   \
-                                   src/585-xattrs                               \
-                                   src/600-securecvmfs                          \
-                                   $CVMFS_EXCLUDE                               \
-                                   --                                           \
-                                   src/5*                                       \
-                                   src/6*                                       \
-                                   src/7*                                       \
-                                   src/8*                                       \
-                                || retval=1
-fi
+# if [ x"$(uname -m)" = x"x86_64" ]; then
+#   echo "running CernVM-FS server test cases..."
+#   CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
+#   ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+#                                 -x src/518-hardlinkstresstest                   \
+#                                    src/585-xattrs                               \
+#                                    src/600-securecvmfs                          \
+#                                    $CVMFS_EXCLUDE                               \
+#                                    --                                           \
+#                                    src/5*                                       \
+#                                    src/6*                                       \
+#                                    src/7*                                       \
+#                                    src/8*                                       \
+#                                 || retval=1
+# fi
 
 
 echo -n "starting the test S3 provider... "
@@ -124,11 +124,11 @@ if [ $s3_retval -eq 0 ]; then
 fi
 
 
-# Ubuntu 12.04
-echo "running CernVM-FS migration test cases..."
-CVMFS_TEST_CLASS_NAME=MigrationTests \
-./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                   migration_tests/*                              \
-                                || retval=1
+# # Ubuntu 12.04
+# echo "running CernVM-FS migration test cases..."
+# CVMFS_TEST_CLASS_NAME=MigrationTests \
+# ./run.sh $MIGRATIONTEST_LOGFILE -o ${MIGRATIONTEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+#                                    migration_tests/*                              \
+#                                 || retval=1
 
 exit $retval

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -71,6 +71,59 @@ if [ x"$(uname -m)" = x"x86_64" ]; then
                                 || retval=1
 fi
 
+
+echo -n "starting the test S3 provider... "
+s3_retval=0
+test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
+echo "done ($test_s3_pid)"
+create_test_s3_bucket
+
+if [ $s3_retval -eq 0 ]; then
+  echo "running CernVM-FS server test cases against the test S3 provider..."
+  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
+  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
+  CVMFS_TEST_SERVER_CACHE='/srv/cache'                                      \
+  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
+  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
+                            -x src/518-hardlinkstresstest                   \
+                               src/519-importlegacyrepo                     \
+                               src/522-missingchunkfailover                 \
+                               src/523-corruptchunkfailover                 \
+                               src/525-bigrepo                              \
+                               src/528-recreatespoolarea                    \
+                               src/530-recreatespoolarea_defaultkey         \
+                               src/537-symlinkedbackend                     \
+                               src/538-symlinkedstratum1backend             \
+                               src/542-storagescrubbing                     \
+                               src/543-storagescrubbing_scriptable          \
+                               src/550-livemigration                        \
+                               src/563-garbagecollectlegacy                 \
+                               src/568-migratecorruptrepo                   \
+                               src/571-localbackendumask                    \
+                               src/572-proxyfailover                        \
+                               src/583-httpredirects                        \
+                               src/585-xattrs                               \
+                               src/591-importrepo                           \
+                               src/594-backendoverwrite                     \
+                               src/595-geoipdbupdate                        \
+                               src/600-securecvmfs                          \
+                               src/605-resurrectancientcatalog              \
+                               src/607-noapache                             \
+                               src/608-infofile                             \
+                               src/610-altpath                              \
+                               src/614-geoservice                           \
+                               src/622-gracefulrmfs                         \
+                               src/626-cacheexpiry                          \
+                               src/700-overlayfsvalidation                  \
+                               --                                           \
+                               src/500*                                     \
+                               || retval=1
+
+  echo -n "Stopping the test S3 provider... "
+  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
+fi
+
+
 # Ubuntu 12.04
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests \

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -72,58 +72,6 @@ if [ x"$(uname -m)" = x"x86_64" ]; then
 fi
 
 
-echo -n "starting the test S3 provider... "
-s3_retval=0
-test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "fail"; }
-echo "done ($test_s3_pid)"
-create_test_s3_bucket
-
-if [ $s3_retval -eq 0 ]; then
-  echo "running CernVM-FS server test cases against the test S3 provider..."
-  CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
-  CVMFS_TEST_HTTP_BASE=$TEST_S3_URL                                         \
-  CVMFS_TEST_CLASS_NAME=S3ServerIntegrationTests                            \
-  ./run.sh $S3_TEST_LOGFILE -o ${S3_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX}     \
-                            -x src/518-hardlinkstresstest                   \
-                               src/519-importlegacyrepo                     \
-                               src/522-missingchunkfailover                 \
-                               src/523-corruptchunkfailover                 \
-                               src/525-bigrepo                              \
-                               src/528-recreatespoolarea                    \
-                               src/530-recreatespoolarea_defaultkey         \
-                               src/537-symlinkedbackend                     \
-                               src/538-symlinkedstratum1backend             \
-                               src/542-storagescrubbing                     \
-                               src/543-storagescrubbing_scriptable          \
-                               src/550-livemigration                        \
-                               src/563-garbagecollectlegacy                 \
-                               src/568-migratecorruptrepo                   \
-                               src/571-localbackendumask                    \
-                               src/572-proxyfailover                        \
-                               src/583-httpredirects                        \
-                               src/585-xattrs                               \
-                               src/591-importrepo                           \
-                               src/594-backendoverwrite                     \
-                               src/595-geoipdbupdate                        \
-                               src/600-securecvmfs                          \
-                               src/605-resurrectancientcatalog              \
-                               src/607-noapache                             \
-                               src/608-infofile                             \
-                               src/610-altpath                              \
-                               src/614-geoservice                           \
-                               src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
-                               --                                           \
-                               src/5*                                       \
-                               src/6*                                       \
-                               src/8*                                       \
-                               || retval=1
-
-  echo -n "Stopping the test S3 provider... "
-  sudo kill -2 $test_s3_pid && echo "done" || echo "fail"
-fi
-
-
 # Ubuntu 12.04
 echo "running CernVM-FS migration test cases..."
 CVMFS_TEST_CLASS_NAME=MigrationTests \

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -5,20 +5,8 @@ cvmfs_test_autofs_on_startup=false
 clean_up() {
     echo "Cleaning up"
 
-    echo "  Stopping repository gateway application"
-    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
-
-    echo "  Removing Mnesia directory"
-    sudo rm -rf /var/lib/cvmfs-gateway
-
-    echo "  Removing test repository"
-    sudo -E cvmfs_server rmfs -f test.repo.org
-
     echo "  Removing output directories"
     rm -rvf /tmp/cvmfs_out_*
-
-    echo "  Removing test directories"
-    rm -rf /tmp/cvmfs_receiver_commit_processor*
 }
 
 check_status() {

--- a/test/src/801-repository_gateway_slow/main
+++ b/test/src/801-repository_gateway_slow/main
@@ -12,18 +12,6 @@ cvmfs_test_autofs_on_startup=false
 clean_up() {
     echo "Cleaning up"
 
-    echo "  Stopping repository gateway application"
-    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
-
-    echo "  Removing Mnesia directory"
-    sudo rm -rf /var/lib/cvmfs-gateway
-
-    echo "  Removing test repository"
-    sudo -E cvmfs_server rmfs -f test.repo.org
-
-    echo "  Removing test directories"
-    rm -rf /tmp/cvmfs_receiver_commit_processor*
-
     echo "  Removing test output data"
     rm -rf /tmp/cvmfs_out
 }

--- a/test/src/802-repository_gateway_nested_catalogs/main
+++ b/test/src/802-repository_gateway_nested_catalogs/main
@@ -7,20 +7,8 @@ cvmfs_test_autofs_on_startup=false
 clean_up() {
     echo "Cleaning up"
 
-    echo "  Stopping repository gateway application"
-    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
-
-    echo "  Removing Mnesia directory"
-    sudo rm -rf /var/lib/cvmfs-gateway
-
-    echo "  Removing test repository"
-    sudo -E cvmfs_server rmfs -f test.repo.org
-
     echo "  Removing output directories"
     rm -rvf /tmp/cvmfs_out_{1,2,3}
-
-    echo "  Removing test directories"
-    rm -rf /tmp/cvmfs_receiver_commit_processor*
 }
 
 check_status() {

--- a/test/src/803-repository_gateway_large_files/main
+++ b/test/src/803-repository_gateway_large_files/main
@@ -7,18 +7,6 @@ cvmfs_test_autofs_on_startup=false
 clean_up() {
     echo "Cleaning up"
 
-    echo "  Stopping repository gateway application"
-    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
-
-    echo "  Removing Mnesia directory"
-    sudo rm -rf /var/lib/cvmfs-gateway
-
-    echo "  Removing test repository"
-    sudo -E cvmfs_server rmfs -f test.repo.org
-
-    echo "  Removing test directories"
-    rm -rf /tmp/cvmfs_receiver_commit_processor*
-
     echo "  Removing test output data"
     rm -rf /tmp/cvmfs_out
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -30,7 +30,6 @@ CVMFS_TEST_HASHALGO=${CVMFS_TEST_HASHALGO:=sha1}
 CVMFS_TEST_S3_CONFIG=${CVMFS_TEST_S3_CONFIG:=}
 CVMFS_TEST_HTTP_BASE=${CVMFS_TEST_HTTP_BASE:=}
 CVMFS_TEST_STRATUM0=${CVMFS_TEST_STRATUM0:=}   # backward compatibility! use CVMFS_TEST_HTTP_BASE instead
-CVMFS_TEST_SERVER_CACHE=${CVMFS_TEST_SERVER_CACHE:=}
 
 # These OPT variables are for the benchmark options under the benchmarks folder
 CVMFS_OPT_WARM_CACHE=${CVMFS_OPT_WARM_CACHE:=yes}
@@ -609,18 +608,6 @@ has_repo() {
 }
 
 
-apply_server_cache_config() {
-  local repo=$1
-  local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
-  [ x"$CVMFS_TEST_SERVER_CACHE" != x"" ] || return 0
-
-  local cache_base=$(echo "$CVMFS_TEST_SERVER_CACHE" | sed 's/\//\\\//g')
-  # will take effect _after_ the first publish operation...
-  sudo sed -i "s/^\(CVMFS_CACHE_BASE\)=.*\$/\1=${cache_base}/"     $client_conf || return 1
-  sudo sed -i "s/^\(CVMFS_RELOAD_SOCKETS\)=.*\$/\1=${cache_base}/" $client_conf || return 2
-}
-
-
 create_repo() {
   local repo=$1
   local uid=$2
@@ -665,7 +652,6 @@ create_repo() {
                             "$@" $repo || return 102
 
   local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
-  apply_server_cache_config $repo || return 103
 
   if [ x$debug_log != x -a x$debug_log != xNO ]; then
     echo "CVMFS_DEBUGLOG=$debug_log" | sudo tee -a $client_conf
@@ -754,8 +740,6 @@ import_repo() {
     unionfs=" -f $CVMFS_TEST_UNIONFS"
   fi
   sudo -E cvmfs_server import -o $uid $unionfs $extra_options $repo || return 102
-
-  apply_server_cache_config $repo || return 103
 }
 
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2387,18 +2387,20 @@ set_up_repository_gateway() {
 }
 EOF'
 
+    echo "  Creating test repo"
+    create_repo test.repo.org `whoami`
+
     echo "  Writing API key file"
     sudo bash -c 'cat <<EOF > /etc/cvmfs/keys/test.repo.org.gw
 plain_text key1 secret1
 EOF'
 
-    echo "  Creating test repo"
-    create_repo test.repo.org `whoami`
-
     echo "  Modifying test repo configuration"
-    sudo sed -i -e 's/local,/gw,/' /etc/cvmfs/repositories.d/test.repo.org/server.conf
-    sudo sed -i -e 's/txn,\/srv\/cvmfs\/test.repo.org/txn,http:\/\/localhost:4929\/api\/v1/g' /etc/cvmfs/repositories.d/test.repo.org/server.conf
-    sudo bash -c 'echo "TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE=local,/srv/cvmfs/test.repo.org/data/txn,/srv/cvmfs/test.repo.org" >> /etc/cvmfs/repositories.d/test.repo.org/server.conf'
+    local repo_server_config=/etc/cvmfs/repositories.d/test.repo.org/server.conf
+    local original_upstream=$(grep CVMFS_UPSTREAM_STORAGE $repo_server_config | cut -d'=' -f2-)
+    sudo sed -i -e 's/local,/gw,/' $repo_server_config
+    sudo sed -i -e 's/txn,\/srv\/cvmfs\/test.repo.org/txn,http:\/\/localhost:4929\/api\/v1/g' $repo_server_config
+    sudo bash -c "echo TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE=$original_upstream >> $repo_server_config"
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 
     echo "  Starting repository gateway"

--- a/test/test_functions
+++ b/test/test_functions
@@ -2361,57 +2361,12 @@ find_or_build_cvmfs_preload() {
 }
 
 
-#####################################
-##### CVMFS Repository Gateway ######
-#####################################
-
-
 # Sets up the CVMFS repository gateway application
 set_up_repository_gateway() {
     echo "Setting up repository gateway"
 
-    local package_url_root=$CVMFS_GATEWAY_URL
-
-    # Choose which package to download and install based on platform
-    if [ -f /etc/debian_version ]; then
-        if [ x"$(lsb_release -cs)" = x"xenial" ]; then
-            package_map_url=${package_url_root}/pkgmap/pkgmap.ubuntu1604_x86_64
-        fi
-    elif is_el6; then
-        package_map_url=${package_url_root}/pkgmap/pkgmap.slc6_x86_64
-    elif is_el7; then
-        package_map_url=${package_url_root}/pkgmap/pkgmap.cc7_x86_64
-    fi
-
-    if [ x"$package_map_url" = x"" ]; then
-        echo "Platform not supported. Exiting"
-        exit 1
-    fi
-
-    echo "  Installing the cvmfs_gateway application"
-    pushd /tmp
-
-    echo "Package map URL: ${package_map_url}"
-    curl -o package_map $package_map_url
-
-    local cvmfs_gateway_package_url=${package_url_root}/$(tail -1 package_map | cut -d'=' -f2)
-    echo "    Using package: $cvmfs_gateway_package_url"
-
-    local cvmfs_gateway_package_file_name=$(echo $cvmfs_gateway_package_url | awk -F'/' {'print $NF'})
-
-    if [ ! -f "/tmp/$cvmfs_gateway_package_file_name" ]; then
-        curl -o $cvmfs_gateway_package_file_name $cvmfs_gateway_package_url
-    fi
-
-    if [ -f /etc/debian_version ]; then
-        if [ x"$(lsb_release -cs)" = x"xenial" ]; then
-            sudo dpkg -i /tmp/$cvmfs_gateway_package_file_name
-        fi
-    else
-        sudo yum install -y /tmp/$cvmfs_gateway_package_file_name
-    fi
-
-    popd
+    echo "  Stopping repository gateway"
+    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
 
     echo "  Writing configuration files"
     sudo bash -c 'cat <<EOF > /etc/cvmfs/gateway/repo.json
@@ -2437,11 +2392,8 @@ EOF'
 plain_text key1 secret1
 EOF'
 
-    echo "  Creating Mnesia schema"
-    sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
-
     echo "  Creating test repo"
-    sudo -E cvmfs_server mkfs -o `whoami` test.repo.org
+    create_repo test.repo.org `whoami`
 
     echo "  Modifying test repo configuration"
     sudo sed -i -e 's/local,/gw,/' /etc/cvmfs/repositories.d/test.repo.org/server.conf
@@ -2449,6 +2401,6 @@ EOF'
     sudo bash -c 'echo "TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE=local,/srv/cvmfs/test.repo.org/data/txn,/srv/cvmfs/test.repo.org" >> /etc/cvmfs/repositories.d/test.repo.org/server.conf'
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 
-    echo "  Starting repository gateway application"
+    echo "  Starting repository gateway"
     sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh start
 }


### PR DESCRIPTION
Addresses [CVM-1554](https://sft.its.cern.ch/jira/browse/CVM-1554).

This PR brings back the server integration tests using S3-backed repository storage. The "fake_s3" Ruby gem was replaced with a real S3 implementation - Minio - which is run on the same node as the tests. 

Also included is a cleanup of the setup phase of the repository gateway integration tests, allowing them to be run with local or S3 storage.

The S3-backed test suite is activated for SCL6, CC7 and Ubuntu x86_64.