### PR TITLE
Handling hardlink inside tarballs.

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -287,6 +287,31 @@ void WritableCatalogManager::RemoveDirectory(const std::string &path) {
   SyncUnlock();
 }
 
+/**
+ * Clone the file called `source` changing its name into `destination`, the
+ * source file is keep intact
+ * @params destination, the name of the new file, complete path
+ * @params source, the name of the file to clone, which must be already in the
+ * repository
+ * @return void
+ */
+void WritableCatalogManager::Clone(const std::string destination,
+                                   const std::string source) {
+  const std::string parent = MakeRelativePath(source);
+
+  std::string destination_dirname;
+  std::string destination_filename;
+  SplitPath(destination, &destination_dirname, &destination_filename);
+
+  DirectoryEntry to_dirent;
+  LookupPath(parent, kLookupSole, &to_dirent);
+
+  DirectoryEntry destination_dirent(to_dirent);
+  destination_dirent.name_.Assign(
+      NameString(destination_filename.c_str(), destination_filename.length()));
+
+  this->AddFile(destination_dirent, empty_xattrs, destination_dirname);
+}
 
 /**
  * Add a new directory to the catalogs.

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -111,6 +111,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void TouchDirectory(const DirectoryEntryBase &entry,
                       const std::string &directory_path);
   void RemoveDirectory(const std::string &directory_path);
+  void Clone(const std::string from, const std::string to);
 
   // Hardlink group handling
   void AddHardlinkGroup(const DirectoryEntryBaseList &entries,

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -176,6 +176,9 @@ void SyncMediator::Replace(SharedPtr<SyncItem> entry) {
   Add(entry);
 }
 
+void SyncMediator::Clone(const std::string from, const std::string to) {
+  catalog_manager_->Clone(from, to);
+}
 
 void SyncMediator::EnterDirectory(SharedPtr<SyncItem> entry) {
   if (!handle_hardlinks_) {
@@ -257,6 +260,8 @@ bool SyncMediator::Commit(manifest::Manifest *manifest) {
       AddHardlinkGroup(*i);
     }
   }
+
+  union_engine_->PostUpload();
 
   params_->spooler->UnregisterListeners();
 

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -77,6 +77,7 @@ class AbstractSyncMediator {
   virtual void Touch(SharedPtr<SyncItem> entry) = 0;
   virtual void Remove(SharedPtr<SyncItem> entry) = 0;
   virtual void Replace(SharedPtr<SyncItem> entry) = 0;
+  virtual void Clone(const std::string from, const std::string to) = 0;
 
   virtual void AddUnmaterializedDirectory(SharedPtr<SyncItem> entry) = 0;
 
@@ -117,6 +118,7 @@ class SyncMediator : public virtual AbstractSyncMediator {
   void Touch(SharedPtr<SyncItem> entry);
   void Remove(SharedPtr<SyncItem> entry);
   void Replace(SharedPtr<SyncItem> entry);
+  void Clone(const std::string from, const std::string to);
 
   void AddUnmaterializedDirectory(SharedPtr<SyncItem> entry);
 

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -71,6 +71,8 @@ class SyncUnion {
    */
   virtual void Traverse() = 0;
 
+  virtual void PostUpload() {};
+
   /**
    * This produces a SyncItem and initialises it accordingly. This is the only
    * way client code can generate SyncItems to make sure it is always set up

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -71,7 +71,7 @@ class SyncUnion {
    */
   virtual void Traverse() = 0;
 
-  virtual void PostUpload() {};
+  virtual void PostUpload() {}
 
   /**
    * This produces a SyncItem and initialises it accordingly. This is the only

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -13,10 +13,10 @@
 
 #include <pthread.h>
 
+#include <list>
 #include <map>
 #include <set>
 #include <string>
-#include <list>
 
 #include "duplex_libarchive.h"
 #include "util_concurrency.h"

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -21,6 +21,8 @@ produce_tarball() {
   dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/c/2.txt
   dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/c/3.txt
 
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/d/1.txt
+
   dd bs=1024 count=5 2>/dev/null  </dev/urandom >tarball_foo/d/e/f/foo.txt
 
   touch tarball_foo/empty_file.txt
@@ -33,6 +35,9 @@ produce_tarball() {
   ln -s a/b/c/4_change_owner.txt tarball_foo/to_different_owner.txt
 
   mkfifo tarball_foo/fifo
+
+  ln tarball_foo/empty_file.txt tarball_foo/to_empty_hardlink.txt
+  ln tarball_foo/d/1.txt tarball_foo/d_1_hardlink.txt
 
   echo "*** Generating a tarball in $tarball_name"
   tar -cvf $tarball_name tarball_foo/

--- a/test/unittests/mock/m_sync_mediator.h
+++ b/test/unittests/mock/m_sync_mediator.h
@@ -9,6 +9,8 @@
 
 #include <gmock/gmock.h>
 
+#include <string>
+
 #include "hash.h"
 #include "sync_mediator.h"
 #include "util/shared_ptr.h"

--- a/test/unittests/mock/m_sync_mediator.h
+++ b/test/unittests/mock/m_sync_mediator.h
@@ -35,6 +35,7 @@ class MockSyncMediator : public AbstractSyncMediator {
   MOCK_METHOD1(Touch, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(Remove, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(Replace, void(SharedPtr<SyncItem> entry));
+  MOCK_METHOD2(Clone, void(const std::string from, const std::string to));
   MOCK_METHOD1(AddUnmaterializedDirectory, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(EnterDirectory, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(LeaveDirectory, void(SharedPtr<SyncItem> entry));


### PR DESCRIPTION
Was necessary to remembering every single hardlink we found in an
appropriate data structure and, after all the normal files have been
spooled and register in the catalog, add the hardlinks.

It was implemented a new functionality in the WritableCatalogManager,
Clone, that clone a file changing just its name.

Supersedes #2142 