### PR TITLE
Print statistics about number of files added/removed/changed-stage1

### DIFF
--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -10,6 +10,7 @@
 #include "catalog_virtual.h"
 #include "logging.h"
 #include "manifest.h"
+#include "statistics.h"
 #include "sync_mediator.h"
 #include "sync_union.h"
 #include "sync_union_tarball.h"
@@ -144,7 +145,9 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   sync = new publish::SyncUnionTarball(&mediator, params.dir_rdonly,
                                        params.tar_file, params.base_directory,
                                        params.to_delete);
-  if (!sync->Initialize()) {
+  perf::StatisticsTemplate statistics =
+        perf::StatisticsTemplate("Publish-sync", this->statistics());
+  if (!sync->Initialize(&statistics)) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "Initialization of the synchronisation "
              "engine failed");

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -21,7 +21,10 @@ SyncUnion::SyncUnion(AbstractSyncMediator *mediator,
       mediator_(mediator),
       initialized_(false) {}
 
-bool SyncUnion::Initialize() {
+bool SyncUnion::Initialize(perf::StatisticsTemplate *statistics) {
+  if (statistics != NULL) {
+    counters_ = new Counters(*statistics);
+  }
   mediator_->RegisterUnionEngine(this);
   initialized_ = true;
   return true;
@@ -115,16 +118,25 @@ void SyncUnion::ProcessFile(SharedPtr<SyncItem> entry) {
            entry->filename().c_str());
   if (entry->IsWhiteout()) {
     mediator_->Remove(entry);
+    if (counters_.IsValid()) {
+      Inc(counters_->n_files_removed);
+    }
   } else {
     if (entry->IsNew()) {
       LogCvmfs(kLogUnionFs, kLogVerboseMsg, "processing file [%s] as new (add)",
                entry->filename().c_str());
       mediator_->Add(entry);
+      if (counters_.IsValid()) {
+        Inc(counters_->n_files_added);
+      }
     } else {
       LogCvmfs(kLogUnionFs, kLogVerboseMsg,
                "processing file [%s] as existing (touch)",
                entry->filename().c_str());
       mediator_->Touch(entry);
+      if (counters_.IsValid()) {
+        Inc(counters_->n_files_changed);
+      }
     }
   }
 }
@@ -175,6 +187,13 @@ void SyncUnion::ProcessSocket(const std::string &parent_dir,
            parent_dir.c_str(), filename.c_str());
   SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, filename, kItemSocket);
   ProcessFile(entry);
+}
+
+void SyncUnion::PrintStatistics() {
+  printf("\nStatistics:\n");
+  printf("Files   added: %s\n", counters_->n_files_added->Print().c_str());
+  printf("Files removed: %s\n", counters_->n_files_removed->Print().c_str());
+  printf("Files changed: %s\n", counters_->n_files_changed->Print().c_str());
 }
 
 }  // namespace publish

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -33,10 +33,28 @@
 #include <set>
 #include <string>
 
+#include "statistics.h"
 #include "sync_item.h"
+#include "util/pointer.h"
 #include "util/shared_ptr.h"
 
 namespace publish {
+
+struct Counters {
+  perf::Counter *n_files_added;
+  perf::Counter *n_files_removed;
+  perf::Counter *n_files_changed;
+
+  explicit Counters(perf::StatisticsTemplate statistics) {
+    n_files_added = statistics.RegisterTemplated("n_files_added",
+        "Number of files added");
+    n_files_removed = statistics.RegisterTemplated("n_files_removed",
+        "Number of files removed");
+    n_files_changed = statistics.RegisterTemplated("n_files_changed",
+        "Number of files changed");
+  }
+};  // Counters
+
 
 class AbstractSyncMediator;
 class SyncMediator;
@@ -64,7 +82,7 @@ class SyncUnion {
    * before running anything else.
    * Note: should be up-called!
    */
-  virtual bool Initialize();
+  virtual bool Initialize(perf::StatisticsTemplate* statistics = NULL);
 
   /**
    * Main routine, process scratch space
@@ -129,6 +147,11 @@ class SyncUnion {
 
   bool IsInitialized() const { return initialized_; }
   virtual bool SupportsHardlinks() const { return false; }
+
+  /**
+   * Print number of files added/changed/removed
+   */
+  void PrintStatistics();
 
  protected:
   std::string rdonly_path_;
@@ -229,6 +252,8 @@ class SyncUnion {
 
  private:
   bool initialized_;
+
+  UniquePtr<Counters> counters_;
 };  // class SyncUnion
 
 }  // namespace publish

--- a/cvmfs/sync_union_overlayfs.cc
+++ b/cvmfs/sync_union_overlayfs.cc
@@ -24,10 +24,10 @@ SyncUnionOverlayfs::SyncUnionOverlayfs(SyncMediator *mediator,
     : SyncUnion(mediator, rdonly_path, union_path, scratch_path),
       hardlink_lower_inode_(0) {}
 
-bool SyncUnionOverlayfs::Initialize() {
+bool SyncUnionOverlayfs::Initialize(perf::StatisticsTemplate *statistics) {
   // trying to obtain CAP_SYS_ADMIN to read 'trusted' xattrs in the scratch
   // directory of an OverlayFS installation
-  return ObtainSysAdminCapability() && SyncUnion::Initialize();
+  return ObtainSysAdminCapability() && SyncUnion::Initialize(statistics);
 }
 
 bool ObtainSysAdminCapabilityInternal(cap_t caps) {

--- a/cvmfs/sync_union_overlayfs.h
+++ b/cvmfs/sync_union_overlayfs.h
@@ -28,7 +28,7 @@ class SyncUnionOverlayfs : public SyncUnion {
                      const std::string &union_path,
                      const std::string &scratch_path);
 
-  bool Initialize();
+  bool Initialize(perf::StatisticsTemplate* statistics = NULL);
 
   void Traverse();
   static bool ReadlinkEquals(std::string const &path,

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -42,13 +42,12 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
 
 SyncUnionTarball::~SyncUnionTarball() { delete read_archive_signal_; }
 
-bool SyncUnionTarball::Initialize() {
+bool SyncUnionTarball::Initialize(perf::StatisticsTemplate *statistics) {
   bool result;
-
   // We are just deleting entity from the repo
   if (tarball_path_ == "") {
     assert(NULL == src);
-    return SyncUnion::Initialize();
+    return SyncUnion::Initialize(statistics);
   }
 
   src = archive_read_new();
@@ -68,7 +67,7 @@ bool SyncUnionTarball::Initialize() {
     return false;
   }
 
-  return SyncUnion::Initialize();
+  return SyncUnion::Initialize(statistics);
 }
 
 /*

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -37,7 +37,7 @@ class SyncUnionTarball : public SyncUnion {
   /*
    * Check that the tarball is actually valid and that can be open.
    */
-  bool Initialize();
+  bool Initialize(perf::StatisticsTemplate* statistics = NULL);
 
   /*
    * We start by deleting the entity that we are request to delete.


### PR DESCRIPTION
Addresses [CVM-1566](https://sft.its.cern.ch/jira/browse/CVM-1566).

Print statistics about number of files added/removed/changed by **simple** operations (rm, touch, cp etc) at the end of each publication.

Output example:
```
[ddosaru@phsftpc2r20:~/cvmfs/build]$ sudo -E cvmfs_server publish test.repo.org 
Using auto tag 'generic-2018-06-25T14:19:14Z'
Processing changes...

Statistics:
Files   added: 1
Files removed: 0
Files changed: 0
Waiting for upload of files before committing...
Committing file catalogs...
Wait for all uploads to finish
Exporting repository manifest
Tagging test22.repo.org
Flushing file system buffers
Signing new manifest
Remounting newly created repository revision
```

`rm -rf` or `cp -r` are **not** counted yet.