### PR TITLE
Add extended cvmfs stat call to libcvmfs

### DIFF
--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -205,16 +205,22 @@ class DirectoryEntryBase {
   inline struct cvmfs_stat GetCVMFSStatStructure() const {
     struct cvmfs_stat s;
     memset(&s, 0, sizeof(s));
-    s.version = 1;
-    s.struct_size = sizeof(s);
-    s.inode = inode_;
-    s.mode = mode_;
-    s.linkcount = linkcount();
-    s.uid = uid();
-    s.gid = gid();
-    s.size = size();
+    s.version  = 1;
+    s.size     = sizeof(s);
+    s.st_ino   = inode_;
+    s.st_mode  = mode_;
+    s.st_nlink = linkcount();
+    s.st_uid   = uid();
+    s.st_gid   = gid();
+    s.st_rdev  = rdev();
+    s.st_size  = size();
+    s.st_blksize = 4096;  // will be ignored by Fuse
+    s.st_blocks = 1 + size() / 512;
     s.mtime = mtime_;
-    s.checksum = (const void *)&checksum_;
+    s.cvm_checksum = (const void *)&checksum_;
+    s.cvm_symlink  = symlink_.ToString().c_str();
+    s.cvm_name     = name_.ToString().c_str();
+    s.cvm_has_xattr = has_xattrs_;
     return s;
   }
 

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -220,7 +220,7 @@ class DirectoryEntryBase {
     s.cvm_checksum = (const void *)&checksum_;
     s.cvm_symlink  = symlink_.ToString().c_str();
     s.cvm_name     = name_.ToString().c_str();
-    s.cvm_has_xattr = has_xattrs_;
+    s.cvm_xattrs   = NULL;
     return s;
   }
 

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -202,26 +202,23 @@ class DirectoryEntryBase {
    * information such as hash.
    * @return the struct cvmfs_stat for this DirectoryEntry
    */
-  inline struct cvmfs_stat GetCVMFSStatStructure() const {
-    struct cvmfs_stat s;
-    memset(&s, 0, sizeof(s));
-    s.version  = 1;
-    s.size     = sizeof(s);
-    s.st_ino   = inode_;
-    s.st_mode  = mode_;
-    s.st_nlink = linkcount();
-    s.st_uid   = uid();
-    s.st_gid   = gid();
-    s.st_rdev  = rdev();
-    s.st_size  = size();
-    s.st_blksize = 4096;  // will be ignored by Fuse
-    s.st_blocks = 1 + size() / 512;
-    s.mtime = mtime_;
-    s.cvm_checksum = (const void *)&checksum_;
-    s.cvm_symlink  = symlink_.ToString().c_str();
-    s.cvm_name     = name_.ToString().c_str();
-    s.cvm_xattrs   = NULL;
-    return s;
+  inline void GetCVMFSStatStructure(struct cvmfs_attr *attr) const {
+    attr->version  = 1;
+    attr->size     = sizeof(*attr);
+    attr->st_ino   = inode_;
+    attr->st_mode  = mode_;
+    attr->st_nlink = linkcount();
+    attr->st_uid   = uid();
+    attr->st_gid   = gid();
+    attr->st_rdev  = rdev();
+    attr->st_size  = size();
+    attr->mtime    = mtime_;
+    attr->st_blksize = 4096;  // will be ignored by Fuse
+    attr->st_blocks  = 1 + size() / 512;
+    attr->cvm_checksum = strdup(checksum_.ToString().c_str());
+    attr->cvm_symlink  = strdup(symlink_.ToString().c_str());
+    attr->cvm_name     = strdup(name_.ToString().c_str());
+    attr->cvm_xattrs   = NULL;
   }
 
   Differences CompareTo(const DirectoryEntryBase &other) const;

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -18,7 +18,6 @@
 #include "bigvector.h"
 #include "compression.h"
 #include "hash.h"
-#include "libcvmfs.h"
 #include "platform.h"
 #include "shortstring.h"
 
@@ -194,31 +193,6 @@ class DirectoryEntryBase {
     s.st_mtime = mtime_;
     s.st_ctime = mtime_;
     return s;
-  }
-
-  /**
-   * Converts to a cvmfs_stat struct. This provides the
-   * information provided by stat, but also CVMFS specific
-   * information such as hash.
-   * @return the struct cvmfs_stat for this DirectoryEntry
-   */
-  inline void GetCVMFSStatStructure(struct cvmfs_attr *attr) const {
-    attr->version  = 1;
-    attr->size     = sizeof(*attr);
-    attr->st_ino   = inode_;
-    attr->st_mode  = mode_;
-    attr->st_nlink = linkcount();
-    attr->st_uid   = uid();
-    attr->st_gid   = gid();
-    attr->st_rdev  = rdev();
-    attr->st_size  = size();
-    attr->mtime    = mtime_;
-    attr->st_blksize = 4096;  // will be ignored by Fuse
-    attr->st_blocks  = 1 + size() / 512;
-    attr->cvm_checksum = strdup(checksum_.ToString().c_str());
-    attr->cvm_symlink  = strdup(symlink_.ToString().c_str());
-    attr->cvm_name     = strdup(name_.ToString().c_str());
-    attr->cvm_xattrs   = NULL;
   }
 
   Differences CompareTo(const DirectoryEntryBase &other) const;

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -18,6 +18,7 @@
 #include "bigvector.h"
 #include "compression.h"
 #include "hash.h"
+#include "libcvmfs.h"
 #include "platform.h"
 #include "shortstring.h"
 
@@ -192,6 +193,28 @@ class DirectoryEntryBase {
     s.st_atime = mtime_;
     s.st_mtime = mtime_;
     s.st_ctime = mtime_;
+    return s;
+  }
+
+  /**
+   * Converts to a cvmfs_stat struct. This provides the
+   * information provided by stat, but also CVMFS specific
+   * information such as hash.
+   * @return the struct cvmfs_stat for this DirectoryEntry
+   */
+  inline struct cvmfs_stat GetCVMFSStatStructure() const {
+    struct cvmfs_stat s;
+    memset(&s, 0, sizeof(s));
+    s.version = 1;
+    s.struct_size = sizeof(s);
+    s.inode = inode_;
+    s.mode = mode_;
+    s.linkcount = linkcount();
+    s.uid = uid();
+    s.gid = gid();
+    s.size = size();
+    s.mtime = mtime_;
+    s.checksum = (const void *)&checksum_;
     return s;
   }
 

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -37,6 +37,8 @@ struct cvmfs_attr* cvmfs_attr_init()
 {
   struct cvmfs_attr *attr;
   attr = reinterpret_cast<cvmfs_attr *>(calloc(1, sizeof(*attr)));
+  attr->version  = 1;
+  attr->size     = sizeof(*attr);
   return attr;
 }
 

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -33,7 +33,7 @@ using namespace std;  // NOLINT
  * Create the cvmfs_attr struct which contains the same information
  * as a stat, but also has pointers to the hash, symlink, and name.
  */
-struct cvmfs_attr* cvmfs_attr_create()
+struct cvmfs_attr* cvmfs_attr_init()
 {
   struct cvmfs_attr *attr;
   attr = reinterpret_cast<cvmfs_attr *>(calloc(1, sizeof(*attr)));
@@ -45,7 +45,7 @@ struct cvmfs_attr* cvmfs_attr_create()
  * Destroy the cvmfs_attr struct and frees the checksum, symlink,
  * name, and xattrs.
  */
-void cvmfs_attr_destroy(struct cvmfs_attr *attr)
+void cvmfs_attr_free(struct cvmfs_attr *attr)
 {
   if (attr) {
     free(attr->cvm_checksum);

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -71,7 +71,7 @@ void cvmfs_nc_attr_free(struct cvmfs_nc_attr *nc_attr)
     free(nc_attr->hash);
   }
   free(nc_attr);
-
+}
 
 
 /**

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -25,6 +25,7 @@
 #include "smalloc.h"
 #include "statistics.h"
 #include "util/posix.h"
+#include "xattr.h"
 
 using namespace std;  // NOLINT
 
@@ -41,8 +42,8 @@ struct cvmfs_attr* cvmfs_attr_create()
 
 
 /**
- * Destroy the cvmfs_attr struct and frees the checksum, symlink
- * and name. It does not free xattrs.
+ * Destroy the cvmfs_attr struct and frees the checksum, symlink,
+ * name, and xattrs.
  */
 void cvmfs_attr_destroy(struct cvmfs_attr *attr)
 {
@@ -51,6 +52,7 @@ void cvmfs_attr_destroy(struct cvmfs_attr *attr)
     free(attr->cvm_symlink);
     free(attr->cvm_name);
     /* xattrs is a shallow pointer and not deleted */
+    delete reinterpret_cast<XattrList *>(attr->cvm_xattrs);
   }
   free(attr);
 }

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -331,7 +331,7 @@ int cvmfs_stat_attr(
 ) {
   string lpath;
   int rc;
-  rc = expand_path(0, ctx, path, &lpath);
+  rc = expand_ppath(ctx, path, &lpath);
   if (rc < 0) {
     return -1;
   }

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -294,6 +294,24 @@ int cvmfs_lstat(LibContext *ctx, const char *path, struct stat *st) {
 }
 
 
+int cvmfs_ext_stat(LibContext *ctx, const char *path, struct cvmfs_stat *cst) {
+  string lpath;
+  int rc;
+  rc = expand_path(0, ctx, path, &lpath);
+  if (rc < 0) {
+    return -1;
+  }
+  path = lpath.c_str();
+
+  rc = ctx->GetExtAttr(path, cst);
+  if (rc < 0) {
+    errno = -rc;
+    return -1;
+  }
+  return 0;
+}
+
+
 int cvmfs_listdir(
   LibContext *ctx,
   const char *path,

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -51,7 +51,6 @@ void cvmfs_attr_destroy(struct cvmfs_attr *attr)
     free(attr->cvm_checksum);
     free(attr->cvm_symlink);
     free(attr->cvm_name);
-    /* xattrs is a shallow pointer and not deleted */
     delete reinterpret_cast<XattrList *>(attr->cvm_xattrs);
   }
   free(attr);

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -37,7 +37,6 @@
 
 #include <stdint.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <unistd.h>
 
 // Legacy error codes

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -136,8 +136,6 @@ struct cvmfs_attr {
   gid_t     st_gid;
   dev_t     st_rdev;
   off_t     st_size;
-  blksize_t st_blksize;
-  blkcnt_t  st_blocks;
   time_t    mtime;
 
   /* CVMFS related content */

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -140,7 +140,7 @@ struct cvmfs_stat {
   uint64_t st_blocks;
   time_t   mtime;
 
-  // Actual contents of stat, mapped from DirectoryEntry
+  // CVMFS related content
   const void * cvm_checksum;
   const char * cvm_symlink;
   const char * cvm_name;

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -122,30 +122,45 @@ struct cvmfs_nc_attr* cvmfs_nc_attr_init();
  */
 void cvmfs_nc_attr_free(struct cvmfs_nc_attr *nc_attr);
 
-struct cvmfs_stat {
-  // Struct definition information
+struct cvmfs_attr {
+  /* Struct definition information */
   unsigned version;
   uint64_t size;
 
-  // Actual contents of stat, mapped from DirectoryEntry
-  uint64_t st_ino;
-  unsigned int st_mode;
-  uint32_t st_nlink;
-  uid_t    st_uid;
-  gid_t    st_gid;
-  dev_t    st_rdev;
-  uint64_t st_size;
-  uint64_t st_blksize;
-  uint64_t st_blocks;
-  time_t   mtime;
+  /* Contents of stat, mapped from DirectoryEntry */
+  dev_t     st_dev;
+  ino_t     st_ino;
+  mode_t    st_mode;
+  nlink_t   st_nlink;
+  uid_t     st_uid;
+  gid_t     st_gid;
+  dev_t     st_rdev;
+  off_t     st_size;
+  blksize_t st_blksize;
+  blkcnt_t  st_blocks;
+  time_t    mtime;
 
-  // CVMFS related content
-  const void * cvm_checksum;
-  const char * cvm_symlink;
-  const char * cvm_name;
-  void *       cvm_xattrs;
+  /* CVMFS related content */
+  /* This information is allocated and should be freed */
+  char * cvm_checksum;
+  char * cvm_symlink;
+  char * cvm_name;
+  void * cvm_xattrs;
 };
 
+/**
+ * Create the cvmfs_attr struct which contains the same information
+ * as a stat, but also has pointers to the hash, symlink, and name.
+ * \Return pointer to a cvmfs_attr struct
+ */
+struct cvmfs_attr* cvmfs_attr_create();
+
+/**
+ * Destroy the cvmfs_attr struct and frees the checksum, symlink
+ * and name. It does not free xattrs.
+ * @param attr, pointer to a cvmfs_attr struct to be deleted.
+ */
+void cvmfs_attr_destroy(struct cvmfs_attr *attr);
 
 /**
  * Send syslog and debug messages to log_fn instead.  This may (and probably
@@ -354,13 +369,13 @@ int cvmfs_lstat(cvmfs_context *ctx, const char *path, struct stat *st);
  *
  *
  * @param[in] path, path of file (e.g. /dir/file, not /cvmfs/repo/dir/file)
- * @param[out] cst, cvmfs_stat buffer in which to write the result
+ * @param[out] attr, cvmfs_attr struct in which to write the result
  * \return 0 on success, -1 on failure
  */
-int cvmfs_ext_stat(
+int cvmfs_stat_attr(
   cvmfs_context *ctx,
   const char *path,
-  struct cvmfs_stat *cst);
+  struct cvmfs_attr *attr);
 
 /**
  * Get list of directory contents.  The directory contents includes "." and

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdint.h>
 
 // Legacy error codes
 #define LIBCVMFS_FAIL_OK         0
@@ -121,6 +122,25 @@ struct cvmfs_nc_attr* cvmfs_nc_attr_init();
  * @param[in] nc_attr, pointer the cvmfs_nc_attr to be destroyed
  */
 void cvmfs_nc_attr_free(struct cvmfs_nc_attr *nc_attr);
+
+struct cvmfs_stat { 
+  // Struct definition information
+  unsigned version;
+  uint64_t struct_size;
+
+  // Actual contents of stat, mapped from DirectoryEntry
+  uint64_t inode;
+  unsigned int mode;
+  uid_t uid;
+  gid_t gid;
+  uint64_t size;
+  time_t mtime;
+  uint32_t linkcount;
+  bool has_xattrs;
+  bool is_external_file;
+  const void *checksum;
+};
+
 
 /**
  * Send syslog and debug messages to log_fn instead.  This may (and probably
@@ -322,6 +342,17 @@ int cvmfs_stat(cvmfs_context *ctx, const char *path, struct stat *st);
  * \return 0 on success, -1 on failure (sets errno)
  */
 int cvmfs_lstat(cvmfs_context *ctx, const char *path, struct stat *st);
+
+/**
+ * Get the extended CVMFS information about a file. If the file is a symlink
+ * return info about the file it points to, not the symlink itself.
+ *
+ *
+ * @param[in] path, path of file (e.g. /dir/file, not /cvmfs/repo/dir/file)
+ * @param[out] cst, cvmfs_stat buffer in which to write the result
+ * \return 0 on success, -1 on failure
+ */
+int cvmfs_ext_stat(cvmfs_context *ctx, const char *path, struct cvmfs_stat *cst);
 
 /**
  * Get list of directory contents.  The directory contents includes "." and

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -37,8 +37,8 @@
 
 #include <stdint.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
-#include <stdint.h>
 
 // Legacy error codes
 #define LIBCVMFS_FAIL_OK         0
@@ -123,22 +123,28 @@ struct cvmfs_nc_attr* cvmfs_nc_attr_init();
  */
 void cvmfs_nc_attr_free(struct cvmfs_nc_attr *nc_attr);
 
-struct cvmfs_stat { 
+struct cvmfs_stat {
   // Struct definition information
   unsigned version;
-  uint64_t struct_size;
+  uint64_t size;
 
   // Actual contents of stat, mapped from DirectoryEntry
-  uint64_t inode;
-  unsigned int mode;
-  uid_t uid;
-  gid_t gid;
-  uint64_t size;
-  time_t mtime;
-  uint32_t linkcount;
-  bool has_xattrs;
-  bool is_external_file;
-  const void *checksum;
+  uint64_t st_ino;
+  unsigned int st_mode;
+  uint32_t st_nlink;
+  uid_t    st_uid;
+  gid_t    st_gid;
+  dev_t    st_rdev;
+  uint64_t st_size;
+  uint64_t st_blksize;
+  uint64_t st_blocks;
+  time_t   mtime;
+
+  // Actual contents of stat, mapped from DirectoryEntry
+  const void * cvm_checksum;
+  const char * cvm_symlink;
+  const char * cvm_name;
+  bool         cvm_has_xattr;
 };
 
 
@@ -352,7 +358,10 @@ int cvmfs_lstat(cvmfs_context *ctx, const char *path, struct stat *st);
  * @param[out] cst, cvmfs_stat buffer in which to write the result
  * \return 0 on success, -1 on failure
  */
-int cvmfs_ext_stat(cvmfs_context *ctx, const char *path, struct cvmfs_stat *cst);
+int cvmfs_ext_stat(
+  cvmfs_context *ctx,
+  const char *path,
+  struct cvmfs_stat *cst);
 
 /**
  * Get list of directory contents.  The directory contents includes "." and

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -153,14 +153,14 @@ struct cvmfs_attr {
  * as a stat, but also has pointers to the hash, symlink, and name.
  * \Return pointer to a cvmfs_attr struct
  */
-struct cvmfs_attr* cvmfs_attr_create();
+struct cvmfs_attr* cvmfs_attr_init();
 
 /**
  * Destroy the cvmfs_attr struct and frees the checksum, symlink,
  * name, and xattrs.
  * @param attr, pointer to a cvmfs_attr struct to be deleted.
  */
-void cvmfs_attr_destroy(struct cvmfs_attr *attr);
+void cvmfs_attr_free(struct cvmfs_attr *attr);
 
 /**
  * Send syslog and debug messages to log_fn instead.  This may (and probably

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -156,8 +156,8 @@ struct cvmfs_attr {
 struct cvmfs_attr* cvmfs_attr_create();
 
 /**
- * Destroy the cvmfs_attr struct and frees the checksum, symlink
- * and name. It does not free xattrs.
+ * Destroy the cvmfs_attr struct and frees the checksum, symlink,
+ * name, and xattrs.
  * @param attr, pointer to a cvmfs_attr struct to be deleted.
  */
 void cvmfs_attr_destroy(struct cvmfs_attr *attr);

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -362,9 +362,8 @@ int cvmfs_stat(cvmfs_context *ctx, const char *path, struct stat *st);
 int cvmfs_lstat(cvmfs_context *ctx, const char *path, struct stat *st);
 
 /**
- * Get the extended CVMFS information about a file. If the file is a symlink
- * return info about the file it points to, not the symlink itself.
- *
+ * Get the extended CVMFS information about a file. If the file is a symlink,
+ * return info about the link, not the file it points to.
  *
  * @param[in] path, path of file (e.g. /dir/file, not /cvmfs/repo/dir/file)
  * @param[out] attr, cvmfs_attr struct in which to write the result

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -143,7 +143,7 @@ struct cvmfs_stat {
   const void * cvm_checksum;
   const char * cvm_symlink;
   const char * cvm_name;
-  bool         cvm_has_xattr;
+  void *       cvm_xattrs;
 };
 
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -73,6 +73,7 @@
 #include "sqlitevfs.h"
 #include "util/posix.h"
 #include "util/string.h"
+#include "xattr.h"
 
 using namespace std;  // NOLINT
 
@@ -311,6 +312,11 @@ int LibContext::GetExtAttr(const char *c_path, struct cvmfs_stat *info) {
   }
 
   *info = dirent.GetCVMFSStatStructure();
+  if(dirent.HasXattrs()){
+    XattrList xattrs = XattrList();
+    mount_point_->catalog_mgr()->LookupXattrs(p, &xattrs);
+    info->cvm_xattrs = &xattrs;
+  }
   return 0;
 }
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -313,9 +313,9 @@ int LibContext::GetExtAttr(const char *c_path, struct cvmfs_attr *info) {
 
   dirent.GetCVMFSStatStructure(info);
   if (dirent.HasXattrs()) {
-    XattrList xattrs = XattrList();
-    mount_point_->catalog_mgr()->LookupXattrs(p, &xattrs);
-    info->cvm_xattrs = &xattrs;
+    XattrList *xattrs = new XattrList();
+    mount_point_->catalog_mgr()->LookupXattrs(p, xattrs);
+    info->cvm_xattrs = xattrs;
   }
   return 0;
 }

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -312,7 +312,7 @@ int LibContext::GetExtAttr(const char *c_path, struct cvmfs_stat *info) {
   }
 
   *info = dirent.GetCVMFSStatStructure();
-  if(dirent.HasXattrs()){
+  if ( dirent.HasXattrs() ) {
     XattrList xattrs = XattrList();
     mount_point_->catalog_mgr()->LookupXattrs(p, &xattrs);
     info->cvm_xattrs = &xattrs;

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -297,8 +297,6 @@ void LibContext::CvmfsAttrFromDirent(
   catalog::DirectoryEntry dirent,
   struct cvmfs_attr *attr
 ) {
-  attr->version  = 1;
-  attr->size     = sizeof(*attr);
   attr->st_ino   = dirent.inode();
   attr->st_mode  = dirent.mode();
   attr->st_nlink = dirent.linkcount();

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -50,6 +50,7 @@
 #include "cache_posix.h"
 #include "catalog.h"
 #include "catalog_mgr_client.h"
+#include "catalog.h"
 #include "clientctx.h"
 #include "compression.h"
 #include "directory_entry.h"
@@ -289,6 +290,26 @@ int LibContext::GetAttr(const char *c_path, struct stat *info) {
   }
 
   *info = dirent.GetStatStructure();
+  return 0;
+}
+
+
+int LibContext::GetExtAttr(const char *c_path, struct cvmfs_stat *info) {
+  ClientCtxGuard ctxg(geteuid(), getegid(), getpid());
+
+  LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_getattr (stat) for path: %s", c_path);
+
+  PathString p;
+  p.Assign(c_path, strlen(c_path));
+
+  catalog::DirectoryEntry dirent;
+  const bool found = GetDirentForPath(p, &dirent);
+
+  if (!found) {
+    return -ENOENT;
+  }
+
+  *info = dirent.GetCVMFSStatStructure();
   return 0;
 }
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -296,7 +296,7 @@ int LibContext::GetAttr(const char *c_path, struct stat *info) {
 }
 
 
-int LibContext::GetExtAttr(const char *c_path, struct cvmfs_stat *info) {
+int LibContext::GetExtAttr(const char *c_path, struct cvmfs_attr *info) {
   ClientCtxGuard ctxg(geteuid(), getegid(), getpid());
 
   LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_getattr (stat) for path: %s", c_path);
@@ -311,8 +311,8 @@ int LibContext::GetExtAttr(const char *c_path, struct cvmfs_stat *info) {
     return -ENOENT;
   }
 
-  *info = dirent.GetCVMFSStatStructure();
-  if ( dirent.HasXattrs() ) {
+  dirent.GetCVMFSStatStructure(info);
+  if (dirent.HasXattrs()) {
     XattrList xattrs = XattrList();
     mount_point_->catalog_mgr()->LookupXattrs(p, &xattrs);
     info->cvm_xattrs = &xattrs;

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -294,7 +294,7 @@ int LibContext::GetAttr(const char *c_path, struct stat *info) {
 }
 
 void LibContext::CvmfsAttrFromDirent(
-  catalog::DirectoryEntry dirent,
+  const catalog::DirectoryEntry dirent,
   struct cvmfs_attr *attr
 ) {
   attr->st_ino   = dirent.inode();
@@ -306,8 +306,8 @@ void LibContext::CvmfsAttrFromDirent(
   attr->st_size  = dirent.size();
   attr->mtime    = dirent.mtime();
   attr->cvm_checksum = strdup(dirent.checksum().ToString().c_str());
-  attr->cvm_symlink  = strdup(dirent.symlink().ToString().c_str());
-  attr->cvm_name     = strdup(dirent.name().ToString().c_str());
+  attr->cvm_symlink  = strdup(dirent.symlink().c_str());
+  attr->cvm_name     = strdup(dirent.name().c_str());
   attr->cvm_xattrs   = NULL;
 }
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -51,6 +51,7 @@
 #include "catalog.h"
 #include "catalog_mgr_client.h"
 #include "catalog.h"
+#include "catalog_mgr_client.h"
 #include "clientctx.h"
 #include "compression.h"
 #include "directory_entry.h"

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -104,6 +104,7 @@ class LibContext : SingleCopy {
   int64_t Pread(int fd, void *buf, uint64_t size, uint64_t off);
   int Close(int fd);
 
+  int GetExtAttr(const char *c_path, struct cvmfs_stat *info);
   int GetNestedCatalogAttr(const char *c_path, struct cvmfs_nc_attr *nc_attr);
   int ListNestedCatalogs(const char *path, char ***buf, size_t *buflen);
 

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -128,6 +128,8 @@ class LibContext : SingleCopy {
                           size_t       *buflen);
   bool GetDirentForPath(const PathString         &path,
                         catalog::DirectoryEntry  *dirent);
+  void CvmfsAttrFromDirent(catalog::DirectoryEntry dirent,
+                           struct cvmfs_attr *attr);
 
   /**
    * Only non-NULL if cvmfs_attache_repo is used for initialization.  In this

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -128,7 +128,7 @@ class LibContext : SingleCopy {
                           size_t       *buflen);
   bool GetDirentForPath(const PathString         &path,
                         catalog::DirectoryEntry  *dirent);
-  void CvmfsAttrFromDirent(catalog::DirectoryEntry dirent,
+  void CvmfsAttrFromDirent(const catalog::DirectoryEntry dirent,
                            struct cvmfs_attr *attr);
 
   /**

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -104,7 +104,7 @@ class LibContext : SingleCopy {
   int64_t Pread(int fd, void *buf, uint64_t size, uint64_t off);
   int Close(int fd);
 
-  int GetExtAttr(const char *c_path, struct cvmfs_stat *info);
+  int GetExtAttr(const char *c_path, struct cvmfs_attr *info);
   int GetNestedCatalogAttr(const char *c_path, struct cvmfs_nc_attr *nc_attr);
   int ListNestedCatalogs(const char *path, char ***buf, size_t *buflen);
 

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -81,6 +81,17 @@ bool DirSpec::AddFile(const std::string& name, const std::string& parent,
   return true;
 }
 
+bool DirSpec::LinkFile(const std::string& name, const std::string& parent,
+                         const std::string& symlink, const size_t size,
+                         const XattrList& xattrs, shash::Suffix suffix) {
+  const catalog::DirectoryEntry entry =
+    catalog::DirectoryEntryTestFactory::Symlink(name, size, symlink);
+  const std::string full_path = entry.GetFullPath(parent);
+  items_.insert(std::make_pair(full_path,
+                               DirSpecItem(entry, xattrs, parent)));
+  return true;
+}
+
 bool DirSpec::AddDirectory(const std::string& name, const std::string& parent,
                            const size_t size) {
   if (!HasDir(parent)) {
@@ -288,7 +299,7 @@ bool CatalogTestTool::Apply(const std::string& id, const DirSpec& spec) {
   for (DirSpec::ItemList::const_iterator it = spec.items().begin();
        it != spec.items().end(); ++it) {
     const DirSpecItem& item = it->second;
-    if (item.entry_.IsRegular()) {
+    if (item.entry_.IsRegular() || item.entry_.IsLink()) {
       catalog_mgr->AddFile(item.entry_base(), item.xattrs(), item.parent());
     } else if (item.entry_.IsDirectory()) {
       catalog_mgr->AddDirectory(item.entry_base(), item.parent());
@@ -320,7 +331,7 @@ bool CatalogTestTool::ApplyAtRootHash(
   for (DirSpec::ItemList::const_iterator it = spec.items().begin();
        it != spec.items().end(); ++it) {
     const DirSpecItem& item = it->second;
-    if (item.entry_.IsRegular()) {
+    if (item.entry_.IsRegular() || item.entry_.IsLink()) {
       catalog_mgr->AddFile(item.entry_base(), item.xattrs(), item.parent());
     } else if (item.entry_.IsDirectory()) {
       catalog_mgr->AddDirectory(item.entry_base(), item.parent());

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -378,7 +378,11 @@ bool CatalogTestTool::LookupNestedCatalogHash(
   return true;
 }
 
-bool CatalogTestTool::FindEntry(const shash::Any& root_hash, const std::string& path, catalog::DirectoryEntry *entry) {
+bool CatalogTestTool::FindEntry(
+  const shash::Any& root_hash,
+  const std::string& path,
+  catalog::DirectoryEntry *entry
+) {
   perf::Statistics stats;
   UniquePtr<catalog::WritableCatalogManager> catalog_mgr(
       CreateCatalogMgr(root_hash, "file://" + stratum0_, temp_dir_, spooler_,

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -378,6 +378,25 @@ bool CatalogTestTool::LookupNestedCatalogHash(
   return true;
 }
 
+bool CatalogTestTool::FindEntry(const shash::Any& root_hash, const std::string& path, catalog::DirectoryEntry *entry) {
+  perf::Statistics stats;
+  UniquePtr<catalog::WritableCatalogManager> catalog_mgr(
+      CreateCatalogMgr(root_hash, "file://" + stratum0_, temp_dir_, spooler_,
+                       download_manager(), &stats));
+  if (!catalog_mgr.IsValid()) {
+    return false;
+  }
+
+  if (!catalog_mgr->LookupPath(path, catalog::kLookupSole, entry)) {
+    LogCvmfs(kLogCatalog, kLogStderr,
+             "catalog for directory '%s' cannot be found",
+             path.c_str());
+    return false;
+  }
+
+  return true;
+}
+
 bool CatalogTestTool::DirSpecAtRootHash(const shash::Any& root_hash,
                                         DirSpec* spec) {
   perf::Statistics stats;

--- a/test/common/catalog_test_tools.h
+++ b/test/common/catalog_test_tools.h
@@ -68,6 +68,12 @@ class DirSpec {
                const size_t size,
                const XattrList& xattrs = XattrList(),
                shash::Suffix suffix = shash::kSha1);
+  bool LinkFile(const std::string& name,
+                const std::string& parent,
+                const std::string& symlink,
+                const size_t size,
+                const XattrList& xattrs = XattrList(),
+                shash::Suffix suffix = shash::kSha1);
   bool AddDirectory(const std::string& name,
                     const std::string& parent,
                     const size_t size);

--- a/test/common/catalog_test_tools.h
+++ b/test/common/catalog_test_tools.h
@@ -133,6 +133,7 @@ class CatalogTestTool : public ServerTool {
   bool Init();
   bool Apply(const std::string& id, const DirSpec& spec);
   bool ApplyAtRootHash(const shash::Any& root_hash, const DirSpec& spec);
+  bool FindEntry(const shash::Any& root_hash, const std::string& path, catalog::DirectoryEntry *entry);
   bool LookupNestedCatalogHash(const shash::Any& root_hash,
                                const std::string& path,
                                char **nc_hash);

--- a/test/common/catalog_test_tools.h
+++ b/test/common/catalog_test_tools.h
@@ -133,7 +133,9 @@ class CatalogTestTool : public ServerTool {
   bool Init();
   bool Apply(const std::string& id, const DirSpec& spec);
   bool ApplyAtRootHash(const shash::Any& root_hash, const DirSpec& spec);
-  bool FindEntry(const shash::Any& root_hash, const std::string& path, catalog::DirectoryEntry *entry);
+  bool FindEntry(const shash::Any& root_hash,
+                 const std::string& path,
+                 catalog::DirectoryEntry *entry);
   bool LookupNestedCatalogHash(const shash::Any& root_hash,
                                const std::string& path,
                                char **nc_hash);

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -16,6 +16,8 @@
 #include "libcvmfs.h"
 #include "options.h"
 #include "util/posix.h"
+#include "catalog_test_tools.h"
+#include "options.h"
 
 using namespace std;  // NOLINT
 
@@ -76,6 +78,16 @@ class T_Libcvmfs : public ::testing::Test {
   string alien_path_;
   string opt_cache_;
   FILE *fdevnull_;
+
+  int fd_cwd_;
+  unsigned used_fds_;
+
+  /**
+   * Initialize libuuid / open file descriptor on /dev/urandom
+   */
+
+
+
 };
 
 bool T_Libcvmfs::first_test = true;
@@ -321,6 +333,86 @@ DirSpec MakeBaseSpec() {
 }
 
 
+TEST_F(T_Libcvmfs, Stat) {
+
+  cvmfs_option_map *opts = cvmfs_options_init();
+  
+  CatalogTestTool tester("stat");
+
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec1 = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+
+  cvmfs_options_set(opts,"CVMFS_ROOT_HASH",
+                        tester.manifest()->catalog_hash().ToString().c_str());
+  cvmfs_options_set(opts,"CVMFS_SERVER_URL", ("file://" + tester.repo_name()).c_str());
+  cvmfs_options_set(opts,"CVMFS_HTTP_PROXY", "DIRECT");
+  cvmfs_options_set(opts,"CVMFS_PUBLIC_KEY", tester.public_key().c_str());
+  cvmfs_options_set(opts, "CVMFS_CACHE_DIR", (tester.repo_name()+"/data/txn").c_str());
+  cvmfs_options_set(opts, "CVMFS_MOUNT_DIR", ("/cvmfs" + tester.repo_name()).c_str());
+
+
+  ASSERT_EQ(LIBCVMFS_ERR_OK, cvmfs_init_v2(opts));
+
+  cvmfs_context *ctx;
+  EXPECT_EQ(LIBCVMFS_ERR_OK, cvmfs_attach_repo_v2((tester.repo_name().c_str()), opts, &ctx));
+
+  struct stat st;
+  int retval = cvmfs_stat(ctx, "dir/file1", &st);
+  EXPECT_EQ(0, retval);
+  EXPECT_TRUE(st.st_mode & S_IFREG);
+  retval = cvmfs_stat(ctx, "dir/dir", &st);
+  EXPECT_EQ(0, retval);
+  EXPECT_TRUE(st.st_mode & S_IFDIR);
+  retval = cvmfs_stat(ctx, "dir/file4", &st);
+  EXPECT_EQ(-1, retval);
+
+  // Finalize and close repo and options
+  cvmfs_detach_repo(ctx);
+  cvmfs_fini();
+  cvmfs_options_fini(opts);
+}
+
+
+TEST_F(T_Libcvmfs, StatExt) {
+
+  cvmfs_option_map *opts = cvmfs_options_init();
+  
+  CatalogTestTool tester("ext-stat");
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec1 = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+
+  catalog::DirectoryEntry entry;
+  EXPECT_TRUE(tester.FindEntry(tester.manifest()->catalog_hash(), "/dir/file1", &entry));
+
+  cvmfs_options_set(opts,"CVMFS_ROOT_HASH",
+                        tester.manifest()->catalog_hash().ToString().c_str());
+  cvmfs_options_set(opts,"CVMFS_SERVER_URL", ("file://" + tester.repo_name()).c_str());
+  cvmfs_options_set(opts,"CVMFS_HTTP_PROXY", "DIRECT");
+  cvmfs_options_set(opts,"CVMFS_PUBLIC_KEY", tester.public_key().c_str());
+  cvmfs_options_set(opts, "CVMFS_CACHE_DIR", (tester.repo_name()+"/data/txn").c_str());
+  cvmfs_options_set(opts, "CVMFS_MOUNT_DIR", ("/cvmfs" + tester.repo_name()).c_str());
+
+
+  ASSERT_EQ(LIBCVMFS_ERR_OK, cvmfs_init_v2(opts));
+
+  cvmfs_context *ctx;
+  EXPECT_EQ(LIBCVMFS_ERR_OK, cvmfs_attach_repo_v2((tester.repo_name().c_str()), opts, &ctx));
+  
+  struct cvmfs_stat st;
+  int retval = cvmfs_ext_stat(ctx, "/dir/file1", &st);
+  EXPECT_EQ(0, retval);
+  EXPECT_TRUE(!strcmp(((shash::Any *)st.checksum)->ToString().c_str(), entry.checksum().ToString().c_str()));
+  EXPECT_EQ(st.size, file_size);
+
+  cvmfs_fini();
+  cvmfs_options_fini(opts);
+}
+
+
 TEST_F(T_Libcvmfs, Listdir) {
   // Initialize options
   cvmfs_option_map *opts = cvmfs_options_init();
@@ -376,6 +468,7 @@ TEST_F(T_Libcvmfs, Listdir) {
   cvmfs_fini();
   cvmfs_options_fini(opts);
 }
+
 
 TEST_F(T_Libcvmfs, StatNestedCatalog) {
   // Initialize options

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -396,19 +396,20 @@ TEST_F(T_Libcvmfs, Attr) {
   catalog::DirectoryEntry entry;
   EXPECT_TRUE(
     tester.FindEntry(tester.manifest()->catalog_hash(), "/dir/file1", &entry));
+  char *file1_hash = strdup(entry.checksum().ToString().c_str());
 
-  /* Set CVMFS options to reflect created repository */
-  cvmfs_options_set(opts, "CVMFS_ROOT_HASH",
-                        tester.manifest()->catalog_hash().ToString().c_str());
-  cvmfs_options_set(opts, "CVMFS_SERVER_URL",
-                        ("file://" + tester.repo_name()).c_str());
+  // Set CVMFS options to reflect created repository
+  cvmfs_options_set(opts,
+    "CVMFS_ROOT_HASH", tester.manifest()->catalog_hash().ToString().c_str());
+  cvmfs_options_set(opts,
+    "CVMFS_SERVER_URL", ("file://" + tester.repo_name()).c_str());
   cvmfs_options_set(opts, "CVMFS_HTTP_PROXY", "DIRECT");
-  cvmfs_options_set(opts, "CVMFS_PUBLIC_KEY",
-                        tester.public_key().c_str());
-  cvmfs_options_set(opts, "CVMFS_CACHE_DIR",
-                        (tester.repo_name()+"/data/txn").c_str());
-  cvmfs_options_set(opts, "CVMFS_MOUNT_DIR",
-                        ("/cvmfs" + tester.repo_name()).c_str());
+  cvmfs_options_set(opts,
+    "CVMFS_PUBLIC_KEY", tester.public_key().c_str());
+  cvmfs_options_set(opts,
+    "CVMFS_CACHE_DIR", (tester.repo_name()+"/data/txn").c_str());
+  cvmfs_options_set(opts,
+    "CVMFS_MOUNT_DIR", ("/cvmfs" + tester.repo_name()).c_str());
 
   /* Initialize client repo based on options */
   ASSERT_EQ(LIBCVMFS_ERR_OK, cvmfs_init_v2(opts));
@@ -423,13 +424,13 @@ TEST_F(T_Libcvmfs, Attr) {
   /* Find file1 */
   int retval = cvmfs_stat_attr(ctx, "/dir/file1", attr);
   EXPECT_EQ(0, retval);
-  const char *rw_hash = entry.checksum().ToString().c_str();
   /* Compare hash and size */
-  retval = strcmp(rw_hash, attr->cvm_checksum);
+  retval = strcmp(file1_hash, attr->cvm_checksum);
   EXPECT_FALSE(retval);
   EXPECT_EQ(attr->st_size, file_size);
   EXPECT_FALSE(attr->cvm_xattrs);
   cvmfs_attr_free(attr);
+  free(file1_hash);
 
   /* Lookup non-existent file */
   attr = cvmfs_attr_init();

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -430,6 +430,7 @@ TEST_F(T_Libcvmfs, StatExt) {
   /* Compare hash and size */
   EXPECT_TRUE(!strcmp(rw_hash, lib_hash));
   EXPECT_EQ(st.st_size, file_size);
+  EXPECT_TRUE(!st.cvm_xattrs);
 
   /* Finalize and close repo and options */
   cvmfs_fini();

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -422,7 +422,7 @@ TEST_F(T_Libcvmfs, Attr) {
     cvmfs_attach_repo_v2((tester.repo_name().c_str()), opts, &ctx));
 
   struct cvmfs_attr *attr;
-  attr = cvmfs_attr_create();
+  attr = cvmfs_attr_init();
   /* Find file1 */
   int retval = cvmfs_stat_attr(ctx, "/dir/file1", attr);
   EXPECT_EQ(0, retval);
@@ -432,13 +432,13 @@ TEST_F(T_Libcvmfs, Attr) {
   EXPECT_FALSE(retval);
   EXPECT_EQ(attr->st_size, file_size);
   EXPECT_FALSE(attr->cvm_xattrs);
-  cvmfs_attr_destroy(attr);
+  cvmfs_attr_free(attr);
 
   /* Lookup non-existent file */
-  attr = cvmfs_attr_create();
+  attr = cvmfs_attr_init();
   retval = cvmfs_stat_attr(ctx, "/dir/file40", attr);
   EXPECT_EQ(-1, retval);
-  cvmfs_attr_destroy(attr);
+  cvmfs_attr_free(attr);
 
   /* Finalize and close repo and options */
   cvmfs_fini();

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -390,7 +390,7 @@ TEST_F(T_Libcvmfs, Attr) {
 
   // Create file structure
   DirSpec spec = MakeBaseSpec();
-  EXPECT_TRUE(spec.LinkFile("link", "dir", "../file1", file_size));
+  EXPECT_TRUE(spec.LinkFile("link", "dir", "file1", file_size));
   EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
 
   // Find directory entry for use later
@@ -446,7 +446,7 @@ TEST_F(T_Libcvmfs, Attr) {
   retval = cvmfs_stat_attr(ctx, "/dir/link", attr);
   EXPECT_EQ(0, retval);
   // Compare link path
-  EXPECT_FALSE(strcmp("../file1", attr->cvm_symlink));
+  EXPECT_FALSE(strcmp("file1", attr->cvm_symlink));
   // Link checksum is different than the linked file
   EXPECT_FALSE(strcmp(link_hash, attr->cvm_checksum));
   EXPECT_TRUE(strcmp(file1_hash, attr->cvm_checksum));

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -381,22 +381,28 @@ TEST_F(T_Libcvmfs, Stat) {
 
 
 TEST_F(T_Libcvmfs, Attr) {
-  /* Initialize options */
+  // Initialize options
   cvmfs_option_map *opts = cvmfs_options_init();
 
-  /* Create and initialize repository named "attr" */
+  // Create and initialize repository named "attr"
   CatalogTestTool tester("attr");
   EXPECT_TRUE(tester.Init());
 
-  /* Create file structure */
-  DirSpec spec1 = MakeBaseSpec();
-  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+  // Create file structure
+  DirSpec spec = MakeBaseSpec();
+  EXPECT_TRUE(spec.LinkFile("link", "dir", "../file1", file_size));
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
 
-  /* Find directory entry for use later */
+  // Find directory entry for use later
   catalog::DirectoryEntry entry;
   EXPECT_TRUE(
     tester.FindEntry(tester.manifest()->catalog_hash(), "/dir/file1", &entry));
   char *file1_hash = strdup(entry.checksum().ToString().c_str());
+
+  catalog::DirectoryEntry link;
+  EXPECT_TRUE(
+    tester.FindEntry(tester.manifest()->catalog_hash(), "/dir/link", &link));
+  char *link_hash = strdup(link.checksum().ToString().c_str());
 
   // Set CVMFS options to reflect created repository
   cvmfs_options_set(opts,
@@ -411,26 +417,42 @@ TEST_F(T_Libcvmfs, Attr) {
   cvmfs_options_set(opts,
     "CVMFS_MOUNT_DIR", ("/cvmfs" + tester.repo_name()).c_str());
 
-  /* Initialize client repo based on options */
+  // Initialize client repo based on options
   ASSERT_EQ(LIBCVMFS_ERR_OK, cvmfs_init_v2(opts));
 
-  /* Attach to client repo */
+  // Attach to client repo
   cvmfs_context *ctx;
   EXPECT_EQ(LIBCVMFS_ERR_OK,
     cvmfs_attach_repo_v2((tester.repo_name().c_str()), opts, &ctx));
 
   struct cvmfs_attr *attr;
+  int retval;
+
   attr = cvmfs_attr_init();
-  /* Find file1 */
-  int retval = cvmfs_stat_attr(ctx, "/dir/file1", attr);
+  // Find file1
+  retval = cvmfs_stat_attr(ctx, "/dir/file1", attr);
   EXPECT_EQ(0, retval);
-  /* Compare hash and size */
+  // Compare hash and size
   retval = strcmp(file1_hash, attr->cvm_checksum);
   EXPECT_FALSE(retval);
-  EXPECT_EQ(attr->st_size, file_size);
+  // Verify the file size
+  EXPECT_EQ(file_size, attr->st_size);
   EXPECT_FALSE(attr->cvm_xattrs);
   cvmfs_attr_free(attr);
   free(file1_hash);
+
+  attr = cvmfs_attr_init();
+  // Find link
+  retval = cvmfs_stat_attr(ctx, "/dir/link", attr);
+  EXPECT_EQ(0, retval);
+  // Compare link path
+  EXPECT_FALSE(strcmp("../file1", attr->cvm_symlink));
+  // Link checksum is different than the linked file
+  EXPECT_FALSE(strcmp(link_hash, attr->cvm_checksum));
+  EXPECT_TRUE(strcmp(file1_hash, attr->cvm_checksum));
+  // Link size is small, not eq to file_size
+  EXPECT_FALSE(attr->cvm_xattrs);
+  cvmfs_attr_free(attr);
 
   /* Lookup non-existent file */
   attr = cvmfs_attr_init();

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -428,6 +428,11 @@ TEST_F(T_Libcvmfs, StatExt) {
   const char *rw_hash = entry.checksum().ToString().c_str();
   const char *lib_hash = ((shash::Any *)st.cvm_checksum)->ToString().c_str();
   /* Compare hash and size */
+  retval = strcmp(rw_hash, lib_hash);
+  if ( retval ) {
+    printf("Tester   : %s\n", rw_hash);
+    printf("Libcvmfs : %s\n", lib_hash);
+  }
   EXPECT_TRUE(!strcmp(rw_hash, lib_hash));
   EXPECT_EQ(st.st_size, file_size);
   EXPECT_TRUE(!st.cvm_xattrs);

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -76,9 +76,6 @@ class T_Libcvmfs : public ::testing::Test {
   string alien_path_;
   string opt_cache_;
   FILE *fdevnull_;
-
-  int fd_cwd_;
-  unsigned used_fds_;
 };
 
 bool T_Libcvmfs::first_test = true;
@@ -441,6 +438,7 @@ TEST_F(T_Libcvmfs, Attr) {
   cvmfs_attr_free(attr);
 
   /* Finalize and close repo and options */
+  cvmfs_detach_repo(ctx);
   cvmfs_fini();
   cvmfs_options_fini(opts);
 }


### PR DESCRIPTION
This addition to libcvmfs provides a functions for retrieving not only the stat information, but also information specific to CVMFS like checksum and the stored names. This also adds tests for stat and ext_stat in t_libcvmfs.

Note: this coincides with #2155 so one will need to be rebased off the other prior to merging.