### PR TITLE
fix help for the ingest command

### DIFF
--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1108,7 +1108,7 @@ Supported Commands:
                   <fully qualified name>
                   Extract the content of the tarfile inside the base directory,
                   in the same transaction it also delete the required folders.
-                  Use '--' as -t argument to read the tarball from STDIN.
+                  Use '-' as -t argument to read the tarball from STDIN.
 "
 
 


### PR DESCRIPTION
Reading tarball from STDIN works only with a single '-' after -t