### PR TITLE
Fix Libcvmfs test for Fedora and Ubuntu

### DIFF
--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -360,8 +360,9 @@ TEST_F(T_Libcvmfs, Listdir) {
   char **buf = NULL;
   size_t buflen = 0;
   cvmfs_listdir(ctx, "/dir/dir", &buf, &buflen);
-  // The buf length should be at least 3
-  EXPECT_LE(3, buflen);
+  // The buf length should be at least 4
+  size_t expected = 4;
+  EXPECT_LE(expected, buflen);
   // Check that listed info matches specified dir
   EXPECT_FALSE(strcmp(".", buf[0]));
   EXPECT_FALSE(strcmp("..", buf[1]));
@@ -439,7 +440,8 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
   EXPECT_FALSE(strcmp(d0_hash, nc_attr->hash));
   EXPECT_FALSE(strcmp("", nc_attr->mountpoint));
   // Size of root catalog is 0 as a Nested Catalog
-  EXPECT_EQ(nc_attr->size, 0);
+  size_t expected = 0;
+  EXPECT_EQ(nc_attr->size, expected);
   cvmfs_nc_attr_free(nc_attr);
   free(d0_hash);
 

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -361,8 +361,7 @@ TEST_F(T_Libcvmfs, Listdir) {
   size_t buflen = 0;
   cvmfs_listdir(ctx, "/dir/dir", &buf, &buflen);
   // The buf length should be at least 4
-  size_t expected = 4;
-  EXPECT_LE(expected, buflen);
+  EXPECT_LE(4U, buflen);
   // Check that listed info matches specified dir
   EXPECT_FALSE(strcmp(".", buf[0]));
   EXPECT_FALSE(strcmp("..", buf[1]));
@@ -440,8 +439,7 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
   EXPECT_FALSE(strcmp(d0_hash, nc_attr->hash));
   EXPECT_FALSE(strcmp("", nc_attr->mountpoint));
   // Size of root catalog is 0 as a Nested Catalog
-  size_t expected = 0;
-  EXPECT_EQ(nc_attr->size, expected);
+  EXPECT_EQ(0U, nc_attr->size);
   cvmfs_nc_attr_free(nc_attr);
   free(d0_hash);
 

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -392,6 +392,7 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
 
   // Apply the created DirSpec
   EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+  char *d0_hash = strdup(tester.manifest()->catalog_hash().ToString().c_str());
 
   // Find the hash of the newly added Nested Catalog for comparison
   char *d2_hash;
@@ -423,8 +424,6 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
   EXPECT_EQ(LIBCVMFS_ERR_OK,
     cvmfs_attach_repo_v2((tester.repo_name().c_str()), opts, &ctx));
 
-  const char *orig_nc = NULL;
-
   // stat nested catalog using client repo
   struct cvmfs_nc_attr *nc_attr;
   nc_attr = cvmfs_nc_attr_init();
@@ -432,18 +431,17 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
   EXPECT_FALSE(strcmp(d4_hash, nc_attr->hash));
   EXPECT_FALSE(strcmp("/dir/dir/dir/dir", nc_attr->mountpoint));
   cvmfs_nc_attr_free(nc_attr);
-
+  free(d4_hash);
 
   // stat nested catalog using client repo
   nc_attr = cvmfs_nc_attr_init();
   EXPECT_FALSE(cvmfs_stat_nc(ctx, "/dir", nc_attr));
-  orig_nc = tester.manifest()->catalog_hash().ToString().c_str();
-  EXPECT_FALSE(strcmp(orig_nc, nc_attr->hash));
+  EXPECT_FALSE(strcmp(d0_hash, nc_attr->hash));
   EXPECT_FALSE(strcmp("", nc_attr->mountpoint));
   // Size of root catalog is 0 as a Nested Catalog
   EXPECT_EQ(nc_attr->size, 0);
   cvmfs_nc_attr_free(nc_attr);
-
+  free(d0_hash);
 
   // stat nested catalog using client repo
   nc_attr = cvmfs_nc_attr_init();
@@ -451,6 +449,7 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
   EXPECT_FALSE(strcmp(d2_hash, nc_attr->hash));
   EXPECT_FALSE(strcmp("/dir/dir", nc_attr->mountpoint));
   cvmfs_nc_attr_free(nc_attr);
+  free(d2_hash);
 
   // Finalize and close repo and options
   cvmfs_detach_repo(ctx);


### PR DESCRIPTION
The issue appears to be that the tester instance was being destructed, leaving the d0_hash pointing to nothing. This could be resolved in a number of ways (strdup the c_str, keep a reference of d0_hash as a shash::Any or string). To make it more uniform with the other two hash lookup, strdup was used. This also added some code to remove warnings about comparing signed and unsigned values for length.

I think that this only occurred on some of the systems depending on how aggressive the garbage collector is.

@jblomer take a look when you get a chance. This was tested on Fedora 26, Fedora 27, and Ubuntu 16.04 using docker.