### PR TITLE
Fixes for compiler flags

### DIFF
--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -53,7 +53,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
   endif (${CVMFS_GCC_MAJOR} EQUAL 4)
 endif (CMAKE_COMPILER_IS_GNUCC)
 message (STATUS "using compiler opt flag ${CVMFS_OPT_FLAGS}")
-set (CVMFS_BASE_C_FLAGS "${CVMFS_OPT_FLAGS} -g -fno-strict-aliasing -fasynchronous-unwind-tables -fno-omit-frame-pointer -fvisibility=hidden -Wall")
+set (CVMFS_BASE_C_FLAGS "${CVMFS_OPT_FLAGS} -g -fno-strict-aliasing -fasynchronous-unwind-tables -fno-omit-frame-pointer -fvisibility=hidden -fwrapv -Wall")
 if (APPLE)
   if (${CMAKE_SYSTEM_VERSION} GREATER 14.5.0)
     set(CVMFS_BASE_C_FLAGS "${CVMFS_BASE_C_FLAGS} -mmacosx-version-min=10.11")
@@ -64,12 +64,6 @@ if (NOT USING_CLANG)
   set (CVMFS_BASE_C_FLAGS "${CVMFS_BASE_C_FLAGS} -fno-optimize-sibling-calls")
   set (CVMFS_BASE_CXX_FLAGS "${CVMFS_BASE_CXX_FLAGS} -fno-optimize-sibling-calls")
 endif (NOT USING_CLANG)
-if (ARM AND NOT IS_64_BIT)
-  #
-  # Fix TBB on the Raspberry Pi
-  #
-  set (CVMFS_BASE_CXX_FLAGS "${CVMFS_BASE_CXX_FLAGS} -DTBB_USE_GCC_BUILTINS=1 -D__TBB_64BIT_ATOMICS=0")
-endif (ARM AND NOT IS_64_BIT)
 set (CVMFS_BASE_DEFINES "-D_REENTRANT -D__EXTENSIONS__ -D_LARGEFILE64_SOURCE -D__LARGE64_FILES")
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CVMFS_BASE_C_FLAGS} ${CVMFS_BASE_DEFINES}")
@@ -84,15 +78,6 @@ if (BUILD_COVERAGE AND NOT USING_CLANG)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage -fPIC")
 endif (BUILD_COVERAGE AND NOT USING_CLANG)
-
-# Check for a potentially buggy Xcode version
-if(NOT CMAKE_CXX_COMPILER_VERSION) # work around for cmake versions smaller than 2.8.10
-  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE CMAKE_CXX_COMPILER_VERSION)
-endif()
-if (APPLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 9.1.0.0)
-  message("Xcode version 9.3 or newer detected")
-  set (CVMFS_BUGGY_XCODE ON)
-endif()
 
 # Check for old Linux version that don't have a complete inotify implementation
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -270,11 +270,6 @@ set (CVMFS_SWISSKNIFE_SOURCES
   xattr.cc
 )
 
-# Lower optimization level for this file. Xcode 9.3+ gives different results in Os and above
-if (CVMFS_BUGGY_XCODE)
-  set_property(SOURCE ingestion/chunk_detector.cc PROPERTY COMPILE_FLAGS -O0)
-endif(CVMFS_BUGGY_XCODE)
-
 set (CVMFS_SWISSKNIFE_DEBUG_SOURCES
   ${CVMFS_SWISSKNIFE_SOURCES}
 )


### PR DESCRIPTION
Removes unnecessary compiler flag fixes and adds `-fwrapv` to avoid optimizations to change the Xor32 chunk detector behavior.