### PR TITLE
Integration test setup: don't run GW setup script if not needed

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -81,4 +81,3 @@ echo "Installing repository gateway"
 package_map=pkgmap.cc7_x86_64
 download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
 install_rpm $(cat gateway_package_name)
-sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh

--- a/test/cloud_testing/platforms/slc6_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_setup.sh
@@ -124,7 +124,6 @@ echo "Installing repository gateway"
 package_map=pkgmap.slc6_x86_64
 download_gateway_package ${GATEWAY_BUILD_URL} $package_map || die "fail (downloading cvmfs-gateway)"
 install_rpm $(cat gateway_package_name)
-sudo /usr/libexec/cvmfs-gateway/scripts/setup.sh
 
 # rebooting the system (returning 0 value)
 echo "sleep 1 && reboot" > killme.sh


### PR DESCRIPTION
When installing the cvmfs-gateway-0.3.0 RPM packages, the setup script no longer needs to be run, since it's been integrated into the pre/post install/uninstall phases of the RPM package.