### PR TITLE
Only assume workspace is cwd if in FUSE

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -277,8 +277,10 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
     settings.cache_path = optarg;
   }
   // We already changed the cwd to the workspace
-  if (settings.cache_path == workspace_fullpath_)
+  // Which is only done if using FUSE
+  if ((type_ == kFsFuse) && (settings.cache_path == workspace_fullpath_)) {
     settings.cache_path = ".";
+  }
 
   // The cache workspace usually is the cache directory, unless explicitly
   // set otherwise


### PR DESCRIPTION
When setting up a cache workspace we set the cache_path to the cwd as it is assumed we had moved to the directory earlier in setup. This only occurs if the type is Fuse, but if the type is Library we don't `chdir`. This checks if the type is Fuse before assuming we are in the cwd for the cache.
