### PR TITLE
Fix crash of cvmfs_receiver when reflog is missing

### DIFF
--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -221,10 +221,10 @@ CommitProcessor::Result CommitProcessor::Process(
            lease_path.c_str());
 
   SigningTool signing_tool(server_tool.weak_ref());
-  SigningTool::Result res = signing_tool.Run(new_manifest_path, params.stratum0,
-                       params.spooler_configuration, temp_dir, certificate,
-                       private_key, repo_name, "", "",
-                       "/var/spool/cvmfs/" + repo_name + "/reflog.chksum");
+  SigningTool::Result res = signing_tool.Run(
+      new_manifest_path, params.stratum0, params.spooler_configuration,
+      temp_dir, certificate, private_key, repo_name, "", "",
+      "/var/spool/cvmfs/" + repo_name + "/reflog.chksum");
   switch (res) {
     case SigningTool::kReflogChecksumMissing:
       LogCvmfs(kLogReceiver, kLogSyslogErr,
@@ -241,7 +241,8 @@ CommitProcessor::Result CommitProcessor::Process(
       return kError;
     case SigningTool::kSuccess:
       LogCvmfs(kLogReceiver, kLogSyslog,
-               "CommitProcessor - lease_path: %s, success.", lease_path.c_str());
+               "CommitProcessor - lease_path: %s, success.",
+               lease_path.c_str());
   }
 
   {

--- a/cvmfs/receiver/commit_processor.h
+++ b/cvmfs/receiver/commit_processor.h
@@ -25,7 +25,7 @@ namespace receiver {
  */
 class CommitProcessor {
  public:
-  enum Result { kSuccess, kMergeError, kIoError };
+  enum Result { kSuccess, kError, kMergeFailure, kMissingReflog};
 
   CommitProcessor();
   virtual ~CommitProcessor();

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -375,13 +375,17 @@ bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
     case CommitProcessor::kSuccess:
       reply_input.push_back(std::make_pair("status", "ok"));
       break;
-    case CommitProcessor::kMergeError:
+    case CommitProcessor::kError:
+      reply_input.push_back(std::make_pair("status", "error"));
+      reply_input.push_back(std::make_pair("reason", "miscellaneous"));
+      break;
+    case CommitProcessor::kMergeFailure:
       reply_input.push_back(std::make_pair("status", "error"));
       reply_input.push_back(std::make_pair("reason", "merge_error"));
       break;
-    case CommitProcessor::kIoError:
+    case CommitProcessor::kMissingReflog:
       reply_input.push_back(std::make_pair("status", "error"));
-      reply_input.push_back(std::make_pair("reason", "io_error"));
+      reply_input.push_back(std::make_pair("reason", "missing_reflog"));
       break;
     default:
       LogCvmfs(kLogReceiver, kLogSyslogErr,

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -43,8 +43,8 @@ class Reflog {
   static void HashDatabase(const std::string &database_path,
                            shash::Any *hash_reflog);
 
-  static shash::Any ReadChecksum(const std::string &path);
-  static void WriteChecksum(const std::string &path, const shash::Any &value);
+  static bool ReadChecksum(const std::string &path, shash::Any* checksum);
+  static bool WriteChecksum(const std::string &path, const shash::Any &value);
 
   bool AddCertificate(const shash::Any &certificate);
   bool AddCatalog(const shash::Any &catalog);

--- a/cvmfs/server_tool_impl.h
+++ b/cvmfs/server_tool_impl.h
@@ -27,20 +27,20 @@ manifest::Reflog *ServerTool::FetchReflog(ObjectFetcherT *object_fetcher,
                "reflog for '%s' not found but reflog.chksum is present; "
                "remove reflog.chksum to recreate the reflog",
                repo_name.c_str());
-      abort();
+      return NULL;
 
     case ObjectFetcherT::kFailBadData:
       LogCvmfs(kLogCvmfs, kLogStderr,
                "data corruption in .cvmfsreflog for %s, remove for automatic "
                "recreation or verify reflog.chksum file",
                repo_name.c_str());
-      abort();
+      return NULL;
 
     default:
       LogCvmfs(kLogCvmfs, kLogStderr,
                "failed loading reflog from '%s' (%d - %s)",
                object_fetcher->GetUrl(reflog_hash).c_str(), f, Code2Ascii(f));
-      abort();
+      return NULL;
   }
 
   assert(reflog != NULL);

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -35,7 +35,10 @@ int SigningTool::Run(const std::string &manifest_path,
                      const bool bootstrap_shortcuts, const bool return_early) {
   shash::Any reflog_hash;
   if (reflog_chksum_path != "") {
-    reflog_hash = manifest::Reflog::ReadChecksum(reflog_chksum_path);
+    if (!manifest::Reflog::ReadChecksum(reflog_chksum_path, &reflog_hash)) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Could not read reflog checksum");
+      return 1;
+    }
   }
 
   UniquePtr<upload::Spooler> spooler;

--- a/cvmfs/signing_tool.h
+++ b/cvmfs/signing_tool.h
@@ -19,18 +19,27 @@ struct SpoolerResult;
 
 class SigningTool {
  public:
+  enum Result {
+    kSuccess,
+    kError,
+    kInitError,
+    kReflogMissing,
+    kReflogChecksumMissing
+  };
+
   explicit SigningTool(ServerTool *server_tool);
   virtual ~SigningTool();
 
-  int Run(const std::string &manifest_path, const std::string &repo_url,
-          const std::string &spooler_definition, const std::string &temp_dir,
-          const std::string &certificate = "", const std::string &priv_key = "",
-          const std::string &repo_name = "", const std::string &pwd = "",
-          const std::string &meta_info = "",
-          const std::string &reflog_chksum_path = "",
-          const bool garbage_collectable = false,
-          const bool bootstrap_shortcuts = false,
-          const bool return_early = false);
+  Result Run(const std::string &manifest_path, const std::string &repo_url,
+             const std::string &spooler_definition, const std::string &temp_dir,
+             const std::string &certificate = "",
+             const std::string &priv_key = "",
+             const std::string &repo_name = "", const std::string &pwd = "",
+             const std::string &meta_info = "",
+             const std::string &reflog_chksum_path = "",
+             const bool garbage_collectable = false,
+             const bool bootstrap_shortcuts = false,
+             const bool return_early = false);
 
  protected:
   void CertificateUploadCallback(const upload::SpoolerResult &result);

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -959,7 +959,11 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
   }
 
   if (!reflog_chksum_path.empty()) {
-    shash::Any reflog_hash = manifest::Reflog::ReadChecksum(reflog_chksum_path);
+    shash::Any reflog_hash;
+    if (!manifest::Reflog::ReadChecksum(reflog_chksum_path, &reflog_hash)) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read reflog checksum");
+      return 1;
+    }
     bool retval = InspectReflog(reflog_hash, manifest);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to verify reflog");

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -51,7 +51,12 @@ int CommandGc::Main(const ArgumentList &args) {
   const std::string &spooler = *args.find('u')->second;
   const std::string &repo_name = *args.find('n')->second;
   const std::string &reflog_chksum_path = *args.find('R')->second;
-  shash::Any reflog_hash = manifest::Reflog::ReadChecksum(reflog_chksum_path);
+  shash::Any reflog_hash;
+  if (!manifest::Reflog::ReadChecksum(reflog_chksum_path, &reflog_hash)) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Could not read reflog checksum");
+    return 1;
+  }
+
   const int64_t revisions = (args.count('h') > 0) ?
     String2Int64(*args.find('h')->second) : GcConfig::kFullHistory;
   const time_t timestamp  = (args.count('z') > 0)

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -547,8 +547,12 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   string reflog_chksum_path;
   if (args.find('R') != args.end()) {
     reflog_chksum_path = *args.find('R')->second;
-    if (!initial_snapshot)
-      reflog_hash = manifest::Reflog::ReadChecksum(reflog_chksum_path);
+    if (!initial_snapshot) {
+      if (!manifest::Reflog::ReadChecksum(reflog_chksum_path, &reflog_hash)) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Could not read reflog checksum");
+        return 1;
+      }
+    }
   }
   if (args.find('Z') != args.end()) {
     timestamp_threshold = String2Int64(*args.find('Z')->second);

--- a/test/src/805-repository_gateway_reflog/main
+++ b/test/src/805-repository_gateway_reflog/main
@@ -1,0 +1,44 @@
+cvmfs_test_name="Repository gateway - missing reflog"
+cvmfs_test_autofs_on_startup=false
+
+
+clean_up() {
+    echo "Cleaning up"
+}
+
+check_status() {
+    echo $(( $1 || 0 ))
+}
+
+run_transactions() {
+    set_up_repository_gateway
+
+    echo "Check transaction with missing reflog"
+    sudo mv /var/spool/cvmfs/test.repo.org/reflog.chksum /tmp
+    cvmfs_server transaction test.repo.org
+
+    local output=$(cvmfs_server publish test.repo.org 2>&1 | grep "missing_reflog")
+
+    if [ x"$output" = x"" ]; then
+        echo -n "Error: the missing reflog should have been reported "
+        echo "as the cause of the publication error"
+
+        cvmfs_server abort -f test.repo.org
+
+        return 1;
+    fi
+
+    cvmfs_server abort -f test.repo.org
+
+    return 0;
+}
+
+cvmfs_run_test() {
+    trap clean_up EXIT HUP INT TERM || return $?
+
+    run_transactions
+    local status=$?
+
+    return $(check_status $status)
+}
+

--- a/test/unittests/t_reflog.cc
+++ b/test/unittests/t_reflog.cc
@@ -124,7 +124,8 @@ TEST(T_Reflog, Checksum) {
   shash::Any content_hash(shash::kSha1);
   content_hash.Randomize();
   manifest::Reflog::WriteChecksum("./reflog.chksum", content_hash);
-  shash::Any read_hash = manifest::Reflog::ReadChecksum("./reflog.chksum");
+  shash::Any read_hash;
+  EXPECT_TRUE(manifest::Reflog::ReadChecksum("./reflog.chksum", &read_hash));
   EXPECT_EQ(content_hash, read_hash);
 }
 


### PR DESCRIPTION
Addresses [CVM-1560](https://sft.its.cern.ch/jira/browse/CVM-1560).

When publishing through a repository gateway, in the case of a missing reflog, the `cvmfs_server publish` command will now return an error and mention the missing reflog, instead of `abort()`-ing.