### PR TITLE
Add GC metrics to release manager statistics

### DIFF
--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -92,8 +92,7 @@ class GarbageCollector {
   unsigned int preserved_catalog_count() const { return preserved_catalogs_; }
   unsigned int condemned_catalog_count() const { return condemned_catalogs_; }
   unsigned int condemned_objects_count() const { return condemned_objects_;  }
-  uint64_t condemned_data_bytes_count() const { return condemned_data_bytes_;  }
-  uint64_t condemned_data_objects_count() const { return condemned_data_objects_;  }
+  uint64_t condemned_bytes_count() const { return condemned_bytes_;  }
   uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }
 
  protected:
@@ -149,8 +148,7 @@ class GarbageCollector {
   unsigned int          condemned_catalogs_;
 
   unsigned int          condemned_objects_;
-  unsigned int          condemned_data_objects_;
-  uint64_t              condemned_data_bytes_;
+  uint64_t              condemned_bytes_;
 };
 
 #include "garbage_collector_impl.h"

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -68,7 +68,8 @@ class GarbageCollector {
       , dry_run(false)
       , verbose(false)
       , deleted_objects_logfile(NULL)
-      , statistics(NULL) {}
+      , statistics(NULL)
+      , extended_stats(false) {}
 
     bool has_deletion_log() const { return deleted_objects_logfile != NULL; }
 
@@ -81,6 +82,7 @@ class GarbageCollector {
     bool                       verbose;
     FILE                      *deleted_objects_logfile;
     perf::Statistics          *statistics;
+    bool                       extended_stats;
   };
 
  public:

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -92,7 +92,8 @@ class GarbageCollector {
   unsigned int preserved_catalog_count() const { return preserved_catalogs_; }
   unsigned int condemned_catalog_count() const { return condemned_catalogs_; }
   unsigned int condemned_objects_count() const { return condemned_objects_;  }
-  uint64_t condemned_bytes_count() const { return condemned_bytes_;  }
+  uint64_t condemned_data_bytes_count() const { return condemned_data_bytes_;  }
+  uint64_t condemned_data_objects_count() const { return condemned_data_objects_;  }
   uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }
 
  protected:
@@ -148,7 +149,8 @@ class GarbageCollector {
   unsigned int          condemned_catalogs_;
 
   unsigned int          condemned_objects_;
-  uint64_t              condemned_bytes_;
+  unsigned int          condemned_data_objects_;
+  uint64_t              condemned_data_bytes_;
 };
 
 #include "garbage_collector_impl.h"

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -34,7 +34,6 @@
 
 #include <inttypes.h>
 
-#include <string>
 #include <vector>
 
 #include "catalog_traversal.h"
@@ -69,8 +68,7 @@ class GarbageCollector {
       , dry_run(false)
       , verbose(false)
       , deleted_objects_logfile(NULL)
-      , statistics(NULL)
-      , repo_name("") {}
+      , statistics(NULL) {}
 
     bool has_deletion_log() const { return deleted_objects_logfile != NULL; }
 
@@ -83,7 +81,6 @@ class GarbageCollector {
     bool                       verbose;
     FILE                      *deleted_objects_logfile;
     perf::Statistics          *statistics;
-    std::string                repo_name;
   };
 
  public:

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -92,6 +92,7 @@ class GarbageCollector {
   unsigned int preserved_catalog_count() const { return preserved_catalogs_; }
   unsigned int condemned_catalog_count() const { return condemned_catalogs_; }
   unsigned int condemned_objects_count() const { return condemned_objects_;  }
+  uint64_t condemned_bytes_count() const { return condemned_bytes_;  }
   uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }
 
  protected:
@@ -147,6 +148,7 @@ class GarbageCollector {
   unsigned int          condemned_catalogs_;
 
   unsigned int          condemned_objects_;
+  uint64_t              condemned_bytes_;
 };
 
 #include "garbage_collector_impl.h"

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -34,6 +34,7 @@
 
 #include <inttypes.h>
 
+#include <string>
 #include <vector>
 
 #include "catalog_traversal.h"
@@ -68,7 +69,8 @@ class GarbageCollector {
       , dry_run(false)
       , verbose(false)
       , deleted_objects_logfile(NULL)
-      , statistics(NULL) {}
+      , statistics(NULL)
+      , repo_name("") {}
 
     bool has_deletion_log() const { return deleted_objects_logfile != NULL; }
 
@@ -81,6 +83,7 @@ class GarbageCollector {
     bool                       verbose;
     FILE                      *deleted_objects_logfile;
     perf::Statistics          *statistics;
+    std::string                     repo_name;
   };
 
  public:

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -83,7 +83,7 @@ class GarbageCollector {
     bool                       verbose;
     FILE                      *deleted_objects_logfile;
     perf::Statistics          *statistics;
-    std::string                     repo_name;
+    std::string                repo_name;
   };
 
  public:

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -157,6 +157,8 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   if (last_char != 'C') {    // if is not a catalog file
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
     if (condemned_bytes > 0) {
+      printf("condemned ------ %s\n", hash.MakePath().c_str());
+      printf("condemned size - %ld\n", condemned_bytes);
       condemned_bytes_ += condemned_bytes;
     }
   }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -153,7 +153,7 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
                                                        const shash::Any &hash) {
   ++condemned_objects_;
 
-  if (!hash.HasSuffix()) {  // Count only data, not metadata
+  if (!hash.HasSuffix() || hash.suffix == shash::kSuffixPartial) {
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
     if (condemned_bytes > 0) {
       condemned_bytes_ += condemned_bytes;

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -157,8 +157,6 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   if (last_char != 'C') {    // if is not a catalog file
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
     if (condemned_bytes > 0) {
-      printf("condemned ------ %s\n", hash.MakePath().c_str());
-      printf("condemned size - %ld\n", condemned_bytes);
       condemned_bytes_ += condemned_bytes;
     }
   }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -41,8 +41,7 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(
   , preserved_catalogs_(0)
   , condemned_catalogs_(0)
   , condemned_objects_(0)
-  , condemned_data_objects_(0)
-  , condemned_data_bytes_(0)
+  , condemned_bytes_(0)
 {
   assert(configuration_.uploader != NULL);
 }
@@ -157,9 +156,7 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   if (!hash.HasSuffix()) {  // Count only data, not metadata
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
     if (condemned_bytes > 0) {
-      ++condemned_data_objects_;
-      printf("condemned %ld %s\n", condemned_bytes, hash.MakePath().c_str());
-      condemned_data_bytes_ += condemned_bytes;
+      condemned_bytes_ += condemned_bytes;
     }
   }
 
@@ -272,17 +269,13 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
     perf::Counter *ctr_condemned_objects =
       configuration_.statistics->Register(
         "gc.n_condemned_objects", "number of deleted objects");
-    perf::Counter *ctr_condemned_data_objects =
+    perf::Counter *ctr_condemned_bytes =
       configuration_.statistics->Register(
-        "gc.n_condemned_data_objects", "number of deleted data objects");
-    perf::Counter *ctr_condemned_data_bytes =
-      configuration_.statistics->Register(
-        "gc.sz_condemned_data_bytes", "number of deleted bytes");
+        "gc.sz_condemned_bytes", "number of deleted bytes");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());
-    ctr_condemned_data_bytes->Set(condemned_data_bytes_count());
-    ctr_condemned_data_objects->Set(condemned_data_objects_count());
+    ctr_condemned_bytes->Set(condemned_bytes_count());
   }
 
   configuration_.uploader->WaitForUpload();

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -157,6 +157,11 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   if (configuration_.dry_run) {
     return;
   }
+  std::string file_path = hash.MakePath();
+  printf("---------------- hash_file:%s\n", file_path.c_str());
+  // Change reponame
+  printf("---------------- size = %ld bytes\n",
+          GetFileSize("/srv/cvmfs/test.repo.org/data/" + file_path));
 
   configuration_.uploader->RemoveAsync(hash);
 }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -157,12 +157,13 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   if (configuration_.dry_run) {
     return;
   }
-  std::string file_path = hash.MakePath();
-  printf("---------------- hash_file:%s\n", file_path.c_str());
-  // Change reponame
-  printf("---------------- size = %ld bytes\n",
-          GetFileSize("/srv/cvmfs/test.repo.org/data/" + file_path));
 
+  std::string absolute_path = "/srv/cvmfs/" + configuration_.repo_name +
+                              "/data/" + hash.MakePath();
+  printf("---------------- hash_file:%s\n", absolute_path.c_str());
+  printf("---------------- size = %ld bytes\n", GetFileSize(absolute_path));
+
+  condemned_bytes_ += GetFileSize(absolute_path);
   configuration_.uploader->RemoveAsync(hash);
 }
 

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -167,7 +167,7 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
     if (deleted_bytes > 0) {
       condemned_bytes_ += deleted_bytes;
     } else {
-      printf(" --------------- %ld for %s\n", deleted_bytes, absolute_path.c_str());
+      printf(" ----- %ld for %s\n", deleted_bytes, absolute_path.c_str());
     }
   }
   configuration_.uploader->RemoveAsync(hash);

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -156,7 +156,6 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   char last_char = file_name[file_name.length() - 1];
   if (last_char != 'C') {    // if is not a catalog file
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
-    printf("........................ condemned_bytes_ %ld \n", condemned_bytes);
     if (condemned_bytes > 0) {
       condemned_bytes_ += condemned_bytes;
     }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -249,7 +249,9 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
   }
 
   traversal_.UnregisterListener(callback);
-
+  printf("SweepReflog -- %d %d %d \n", preserved_catalog_count(),
+                                       condemned_catalog_count(),
+                                       condemned_objects_count());
   // TODO(jblomer): turn current counters into perf::Counters
   if (configuration_.statistics) {
     perf::Counter *ctr_preserved_catalogs =

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -41,6 +41,7 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(
   , preserved_catalogs_(0)
   , condemned_catalogs_(0)
   , condemned_objects_(0)
+  , condemned_bytes_(0)
 {
   assert(configuration_.uploader != NULL);
 }
@@ -249,9 +250,10 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
   }
 
   traversal_.UnregisterListener(callback);
-  printf("SweepReflog -- %d %d %d \n", preserved_catalog_count(),
+  printf("SweepReflog -- %d %d %d bytes: %ld \n", preserved_catalog_count(),
                                        condemned_catalog_count(),
-                                       condemned_objects_count());
+                                       condemned_objects_count(),
+                                       condemned_bytes_count());
   // TODO(jblomer): turn current counters into perf::Counters
   if (configuration_.statistics) {
     perf::Counter *ctr_preserved_catalogs =
@@ -263,9 +265,13 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
     perf::Counter *ctr_condemned_objects =
       configuration_.statistics->Register(
         "gc.n_condemned_objects", "number of deleted objects");
+    perf::Counter *ctr_condemned_bytes =
+      configuration_.statistics->Register(
+        "gc.sz_condemned_objects", "number of deleted bytez");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());
+    ctr_condemned_bytes->Set(condemned_bytes_count());
   }
 
   configuration_.uploader->WaitForUpload();

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -41,7 +41,8 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(
   , preserved_catalogs_(0)
   , condemned_catalogs_(0)
   , condemned_objects_(0)
-  , condemned_bytes_(0)
+  , condemned_data_objects_(0)
+  , condemned_data_bytes_(0)
 {
   assert(configuration_.uploader != NULL);
 }
@@ -156,7 +157,9 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
   if (!hash.HasSuffix()) {  // Count only data, not metadata
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
     if (condemned_bytes > 0) {
-      condemned_bytes_ += condemned_bytes;
+      ++condemned_data_objects_;
+      printf("condemned %ld %s\n", condemned_bytes, hash.MakePath().c_str());
+      condemned_data_bytes_ += condemned_bytes;
     }
   }
 
@@ -269,13 +272,17 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
     perf::Counter *ctr_condemned_objects =
       configuration_.statistics->Register(
         "gc.n_condemned_objects", "number of deleted objects");
-    perf::Counter *ctr_condemned_bytes =
+    perf::Counter *ctr_condemned_data_objects =
       configuration_.statistics->Register(
-        "gc.sz_condemned_bytes", "number of deleted bytes");
+        "gc.n_condemned_data_objects", "number of deleted data objects");
+    perf::Counter *ctr_condemned_data_bytes =
+      configuration_.statistics->Register(
+        "gc.sz_condemned_data_bytes", "number of deleted bytes");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());
-    ctr_condemned_bytes->Set(condemned_bytes_count());
+    ctr_condemned_data_bytes->Set(condemned_data_bytes_count());
+    ctr_condemned_data_objects->Set(condemned_data_objects_count());
   }
 
   configuration_.uploader->WaitForUpload();

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -160,18 +160,14 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
 
   std::string file_name = hash.MakePath();
   char last_char = file_name[file_name.length() - 1];
-  if (last_char != 'C') {    // if is not a CATALOG file
+  if (last_char != 'C') {    // if is not a catalog file
     std::string absolute_path = "/srv/cvmfs/" + configuration_.repo_name +
                             "/data/" + file_name;
-    printf("---------------- hash_file:%s\n", absolute_path.c_str());
-    printf("---------------- size = %ld bytes\n", GetFileSize(absolute_path));
     int64_t deleted_bytes = GetFileSize(absolute_path);
     if (deleted_bytes > 0) {
       condemned_bytes_ += deleted_bytes;
     }
   }
-
-
   configuration_.uploader->RemoveAsync(hash);
 }
 
@@ -264,10 +260,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
   }
 
   traversal_.UnregisterListener(callback);
-  printf("SweepReflog -- %d %d %d bytes: %ld \n", preserved_catalog_count(),
-                                       condemned_catalog_count(),
-                                       condemned_objects_count(),
-                                       condemned_bytes_count());
+
   // TODO(jblomer): turn current counters into perf::Counters
   if (configuration_.statistics) {
     perf::Counter *ctr_preserved_catalogs =

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -166,6 +166,8 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
     int64_t deleted_bytes = GetFileSize(absolute_path);
     if (deleted_bytes > 0) {
       condemned_bytes_ += deleted_bytes;
+    } else {
+      printf(" --------------- %ld for %s\n", deleted_bytes, absolute_path.c_str());
     }
   }
   configuration_.uploader->RemoveAsync(hash);
@@ -274,7 +276,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
         "gc.n_condemned_objects", "number of deleted objects");
     perf::Counter *ctr_condemned_bytes =
       configuration_.statistics->Register(
-        "gc.sz_condemned_objects", "number of deleted bytes");
+        "gc.sz_condemned_bytes", "number of deleted bytes");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -152,9 +152,8 @@ template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
                                                        const shash::Any &hash) {
   ++condemned_objects_;
-  std::string file_name = hash.MakePath();
-  char last_char = file_name[file_name.length() - 1];
-  if (last_char != 'C') {    // if is not a catalog file
+
+  if (!hash.HasSuffix()) {  // Count only data, not metadata
     int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
     if (condemned_bytes > 0) {
       condemned_bytes_ += condemned_bytes;

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -152,11 +152,12 @@ template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
                                                        const shash::Any &hash) {
   ++condemned_objects_;
-
-  if (!hash.HasSuffix() || hash.suffix == shash::kSuffixPartial) {
-    int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
-    if (condemned_bytes > 0) {
-      condemned_bytes_ += condemned_bytes;
+  if (configuration_.extended_stats) {
+    if (!hash.HasSuffix() || hash.suffix == shash::kSuffixPartial) {
+      int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
+      if (condemned_bytes > 0) {
+        condemned_bytes_ += condemned_bytes;
+      }
     }
   }
 

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -173,7 +173,7 @@ bool StatisticsDatabase::CreateEmptyDatabase() {
     "n_preserved_catalogs INTEGER,"
     "n_condemned_catalogs INTEGER,"
     "n_condemned_objects INTEGER,"
-    "sz_condemned_objects INTEGER);").Execute();
+    "sz_condemned_bytes INTEGER);").Execute();
   return ret1 & ret2;
 }
 
@@ -245,6 +245,7 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
 
   printf("--------- 4 \n");
   if (!insert.Execute()) {
+  printf("--------- 4.1 \n");
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "insert.Execute failed!");
     return -2;
   }

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -96,7 +96,7 @@ std::string PrepareStatement(const perf::Statistics *statistics,
 
 bool StatisticsDatabase::CreateEmptyDatabase() {
   ++create_empty_db_calls;
-  return sqlite::Sql(sqlite_db(),
+  bool ret1 = sqlite::Sql(sqlite_db(),
     "CREATE TABLE publish_statistics ("
     "publish_id INTEGER PRIMARY KEY,"
     "start_time TEXT,"
@@ -111,6 +111,16 @@ bool StatisticsDatabase::CreateEmptyDatabase() {
     "sz_bytes_added INTEGER,"
     "sz_bytes_removed INTEGER,"
     "sz_bytes_uploaded INTEGER);").Execute();
+  bool ret2 = sqlite::Sql(sqlite_db(),
+    "CREATE TABLE gc_statistics ("
+    "gc_id INTEGER PRIMARY KEY,"
+    "start_time TEXT,"
+    "finished_time TEXT,"
+    "n_preserved_catalogs INTEGER,"
+    "n_condemned_catalogs INTEGER,"
+    "n_condemned_objects INTEGER,"
+    "sz_condemned_objects INTEGER);").Execute();
+  return ret1 & ret2;
 }
 
 

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -122,10 +122,6 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
                             const std::string start_time,
                             const std::string finished_time) {
   struct GcStats stats = GcStats(statistics);
-  printf("---------- %s %s %s %s\n", stats.n_preserved_catalogs.c_str(),
-                                     stats.n_condemned_catalogs.c_str(),
-                                     stats.n_condemned_objects.c_str(),
-                                     stats.sz_condemned_bytes.c_str());
   std::string insert_statement =
     "INSERT INTO gc_statistics ("
     "start_time,"
@@ -141,7 +137,6 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
     stats.n_condemned_catalogs +","+
     stats.n_condemned_objects + "," +
     stats.sz_condemned_bytes + ");";
-    printf("%s\n", insert_statement.c_str());
   return insert_statement;
 }
 
@@ -223,7 +218,6 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
                                         const std::string finished_time,
                                         const std::string command_name) {
   std::string insert_statement;
-  printf("--------- 1 \n");
   if (command_name == "ingest" || command_name == "sync") {
     insert_statement = PrepareStatementIntoPublish(statistics, start_time,
                                                                finished_time);
@@ -233,30 +227,24 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
   } else {
     return -5;
   }
-  printf("--------- 2 \n");
-  printf("insert_statement = %s\n", insert_statement.c_str());
+
   sqlite::Sql insert(this->sqlite_db(), insert_statement);
-  printf("--------- 3 \n");
 
   if (!this->BeginTransaction()) {
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "BeginTransaction failed!");
     return -1;
   }
 
-  printf("--------- 4 \n");
   if (!insert.Execute()) {
-  printf("--------- 4.1 \n");
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "insert.Execute failed!");
     return -2;
   }
 
-  printf("--------- 5 \n");
   if (!insert.Reset()) {
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "insert.Reset() failed!");
     return -3;
   }
 
-  printf("--------- 6 \n");
   if (!this->CommitTransaction()) {
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "CommitTransaction failed!");
     return -4;

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -113,36 +113,6 @@ std::string PrepareStatementIntoPublish(const perf::Statistics *statistics,
 
 
 /**
-  * Check if the CVMFS_EXTENDED_GC_STATS is ON or not
-  *
-  * @param repo_name fully qualified name of the repository
-  * @return true if CVMFS_EXTENDED_GC_STATS is ON
-  */
-bool GcExtendedStats(const std::string &repo_name) {
-  SimpleOptionsParser parser;
-  std::string param_value = "";
-  const std::string repo_config_file =
-      "/etc/cvmfs/repositories.d/" + repo_name + "/server.conf";
-
-  if (!parser.TryParsePath(repo_config_file)) {
-    LogCvmfs(kLogCvmfs, kLogSyslogErr,
-             "Could not parse repository configuration: %s.",
-             repo_config_file.c_str());
-    return false;
-  }
-  if (!parser.GetValue("CVMFS_EXTENDED_GC_STATS", &param_value)) {
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
-             "Parameter %s was not set in the repository configuration file. "
-             "condemned_bytes were not counted.",
-             "CVMFS_EXTENDED_GC_STATS");
-  } else if (parser.IsOn(param_value)) {
-    return true;
-  }
-  return false;
-}
-
-
-/**
   * Build the insert statement into gc_statistics table.
   *
   * @param stats a struct with values stored in strings
@@ -157,7 +127,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
                             const std::string &repo_name) {
   struct GcStats stats = GcStats(statistics);
   std::string insert_statement = "";
-  if (GcExtendedStats(repo_name)) {
+  if (StatisticsDatabase::GcExtendedStats(repo_name)) {
     insert_statement =
       "INSERT INTO gc_statistics ("
       "start_time,"
@@ -342,6 +312,36 @@ std::string StatisticsDatabase::GetDBPath(const std::string &repo_name) {
   }
 
   return statistics_db;
+}
+
+
+/**
+  * Check if the CVMFS_EXTENDED_GC_STATS is ON or not
+  *
+  * @param repo_name fully qualified name of the repository
+  * @return true if CVMFS_EXTENDED_GC_STATS is ON
+  */
+bool StatisticsDatabase::GcExtendedStats(const std::string &repo_name) {
+  SimpleOptionsParser parser;
+  std::string param_value = "";
+  const std::string repo_config_file =
+      "/etc/cvmfs/repositories.d/" + repo_name + "/server.conf";
+
+  if (!parser.TryParsePath(repo_config_file)) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr,
+             "Could not parse repository configuration: %s.",
+             repo_config_file.c_str());
+    return false;
+  }
+  if (!parser.GetValue("CVMFS_EXTENDED_GC_STATS", &param_value)) {
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
+             "Parameter %s was not set in the repository configuration file. "
+             "condemned_bytes were not counted.",
+             "CVMFS_EXTENDED_GC_STATS");
+  } else if (parser.IsOn(param_value)) {
+    return true;
+  }
+  return false;
 }
 
 

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -78,8 +78,8 @@ struct GcStats {
   * @return the insert statement
   */
 std::string PrepareStatementIntoPublish(const perf::Statistics *statistics,
-                            const std::string start_time,
-                            const std::string finished_time) {
+                            const std::string &start_time,
+                            const std::string &finished_time) {
   struct PublishStats stats = PublishStats(statistics);
   std::string insert_statement =
     "INSERT INTO publish_statistics ("
@@ -119,9 +119,9 @@ std::string PrepareStatementIntoPublish(const perf::Statistics *statistics,
   * @return the insert statement
   */
 std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
-                            const std::string start_time,
-                            const std::string finished_time,
-                            const std::string dry_run) {
+                            const std::string &start_time,
+                            const std::string &finished_time,
+                            const std::string &dry_run) {
   struct GcStats stats = GcStats(statistics);
   std::string insert_statement =
     "INSERT INTO gc_statistics ("
@@ -218,9 +218,9 @@ StatisticsDatabase::~StatisticsDatabase() {
 
 
 int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
-                                        const std::string start_time,
-                                        const std::string finished_time,
-                                        const std::string command_name,
+                                        const std::string &start_time,
+                                        const std::string &finished_time,
+                                        const std::string &command_name,
                                         const swissknife::ArgumentList &args) {
   std::string insert_statement;
   if (command_name == "ingest" || command_name == "sync") {
@@ -265,7 +265,7 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
 }
 
 
-std::string StatisticsDatabase::GetDBPath(const std::string repo_name) {
+std::string StatisticsDatabase::GetDBPath(const std::string &repo_name) {
   // default location
   const std::string db_default_path =
       "/var/spool/cvmfs/" + repo_name + "/stats.db";

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -56,8 +56,7 @@ struct GcStats {
   std::string n_preserved_catalogs;
   std::string n_condemned_catalogs;
   std::string n_condemned_objects;
-  std::string n_condemned_data_objects;
-  std::string sz_condemned_data_bytes;
+  std::string sz_condemned_bytes;
 
   explicit GcStats(const perf::Statistics *statistics):
     n_preserved_catalogs(statistics->
@@ -66,10 +65,8 @@ struct GcStats {
                     Lookup("gc.n_condemned_catalogs")->ToString()),
     n_condemned_objects(statistics->
                     Lookup("gc.n_condemned_objects")->ToString()),
-    n_condemned_data_objects(statistics->
-                    Lookup("gc.n_condemned_data_objects")->ToString()),
-    sz_condemned_data_bytes(statistics->
-                    Lookup("gc.sz_condemned_data_bytes")->ToString()) {
+    sz_condemned_bytes(statistics->
+                    Lookup("gc.sz_condemned_bytes")->ToString()) {
   }
 };
 
@@ -134,8 +131,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
     "n_preserved_catalogs,"
     "n_condemned_catalogs,"
     "n_condemned_objects,"
-    "n_condemned_data_objects,"
-    "sz_condemned_data_bytes)"
+    "sz_condemned_bytes)"
     " VALUES("
     "'" + start_time + "'," +
     "'" + finished_time + "'," +
@@ -143,8 +139,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
     stats.n_preserved_catalogs + "," +
     stats.n_condemned_catalogs + ","+
     stats.n_condemned_objects + "," +
-    stats.n_condemned_data_objects + "," +
-    stats.sz_condemned_data_bytes + ");";
+    stats.sz_condemned_bytes + ");";
   return insert_statement;
 }
 
@@ -177,8 +172,7 @@ bool StatisticsDatabase::CreateEmptyDatabase() {
     "n_preserved_catalogs INTEGER,"
     "n_condemned_catalogs INTEGER,"
     "n_condemned_objects INTEGER,"
-    "n_condemned_data_objects INTEGER,"
-    "sz_condemned_data_bytes INTEGER);").Execute();
+    "sz_condemned_bytes INTEGER);").Execute();
   return ret1 & ret2;
 }
 
@@ -228,7 +222,6 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
                                         const std::string &finished_time,
                                         const std::string &command_name,
                                         const swissknife::ArgumentList &args) {
-
   std::string insert_statement;
   if (command_name == "ingest" || command_name == "sync") {
     insert_statement = PrepareStatementIntoPublish(statistics, start_time,
@@ -245,6 +238,7 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
   } else {
     return -5;
   }
+
   sqlite::Sql insert(this->sqlite_db(), insert_statement);
 
   if (!this->BeginTransaction()) {

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -216,8 +216,7 @@ StatisticsDatabase::~StatisticsDatabase() {
 int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
                                         const std::string &start_time,
                                         const std::string &finished_time,
-                                        const std::string &command_name,
-                                        const swissknife::ArgumentList &args) {
+                                        const std::string &command_name) {
   std::string insert_statement;
   if (command_name == "ingest" || command_name == "sync") {
     insert_statement = PrepareStatementIntoPublish(statistics, start_time,

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -120,14 +120,12 @@ std::string PrepareStatementIntoPublish(const perf::Statistics *statistics,
   */
 std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
                             const std::string &start_time,
-                            const std::string &finished_time,
-                            const std::string &dry_run) {
+                            const std::string &finished_time) {
   struct GcStats stats = GcStats(statistics);
   std::string insert_statement =
     "INSERT INTO gc_statistics ("
     "start_time,"
     "finished_time,"
-    "dry_run,"
     "n_preserved_catalogs,"
     "n_condemned_catalogs,"
     "n_condemned_objects,"
@@ -135,7 +133,6 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
     " VALUES("
     "'" + start_time + "'," +
     "'" + finished_time + "'," +
-    dry_run + "," +
     stats.n_preserved_catalogs + "," +
     stats.n_condemned_catalogs + ","+
     stats.n_condemned_objects + "," +
@@ -168,7 +165,6 @@ bool StatisticsDatabase::CreateEmptyDatabase() {
     "gc_id INTEGER PRIMARY KEY,"
     "start_time TEXT,"
     "finished_time TEXT,"
-    "dry_run INTEGER,"
     "n_preserved_catalogs INTEGER,"
     "n_condemned_catalogs INTEGER,"
     "n_condemned_objects INTEGER,"
@@ -227,14 +223,8 @@ int StatisticsDatabase::StoreStatistics(const perf::Statistics *statistics,
     insert_statement = PrepareStatementIntoPublish(statistics, start_time,
                                                                finished_time);
   } else if (command_name == "gc") {
-    std::string dry_run_ = "0";
-    const bool dry_run = (args.count('d') > 0);
-    if (dry_run) {
-      dry_run_ = "1";
-    }
     insert_statement = PrepareStatementIntoGc(statistics, start_time,
-                                                          finished_time,
-                                                          dry_run_);
+                                                      finished_time);
   } else {
     return -5;
   }

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -70,6 +70,14 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   * @return path to store database file
   */
   static std::string GetDBPath(const std::string &repo_name);
+
+  /**
+  * Check if the CVMFS_EXTENDED_GC_STATS is ON or not
+  *
+  * @param repo_name fully qualified name of the repository
+  * @return true if CVMFS_EXTENDED_GC_STATS is ON, false otherwise
+  */
+  static bool GcExtendedStats(const std::string &repo_name);
 };
 
 

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -57,9 +57,9 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   * @return 0 if no error occured or a negative integer if errors occurred
   */
   int StoreStatistics(const perf::Statistics *statistics,
-                      const std::string start_time,
-                      const std::string finished_time,
-                      const std::string command_name,
+                      const std::string &start_time,
+                      const std::string &finished_time,
+                      const std::string &command_name,
                       const swissknife::ArgumentList &args);
 
 /**
@@ -70,7 +70,7 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   * @param repo_name Fully qualified name of the repository
   * @return path to store database file
   */
-  static std::string GetDBPath(const std::string repo_name);
+  static std::string GetDBPath(const std::string &repo_name);
 };
 
 

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -11,7 +11,6 @@
 #include "options.h"
 #include "sql.h"
 #include "statistics.h"
-#include "swissknife.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -59,8 +58,7 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   int StoreStatistics(const perf::Statistics *statistics,
                       const std::string &start_time,
                       const std::string &finished_time,
-                      const std::string &command_name,
-                      const swissknife::ArgumentList &args);
+                      const std::string &command_name);
 
 /**
   * Get the path for the database file

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -11,6 +11,7 @@
 #include "options.h"
 #include "sql.h"
 #include "statistics.h"
+#include "swissknife.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -58,7 +59,8 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   int StoreStatistics(const perf::Statistics *statistics,
                       const std::string start_time,
                       const std::string finished_time,
-                      const std::string command_name);
+                      const std::string command_name,
+                      const swissknife::ArgumentList &args);
 
 /**
   * Get the path for the database file

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -58,7 +58,8 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   int StoreStatistics(const perf::Statistics *statistics,
                       const std::string &start_time,
                       const std::string &finished_time,
-                      const std::string &command_name);
+                      const std::string &command_name,
+                      const std::string &repo_name);
 
 /**
   * Get the path for the database file

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -57,7 +57,8 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   */
   int StoreStatistics(const perf::Statistics *statistics,
                       const std::string start_time,
-                      const std::string finished_time);
+                      const std::string finished_time,
+                      const std::string command_name);
 
 /**
   * Get the path for the database file

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -151,7 +151,6 @@ int CommandGc::Main(const ArgumentList &args) {
   config.reflog                  = reflog.weak_ref();
   config.deleted_objects_logfile = deletion_log_file;
   config.statistics              = statistics();
-  config.repo_name               = repo_name;
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -151,6 +151,7 @@ int CommandGc::Main(const ArgumentList &args) {
   config.reflog                  = reflog.weak_ref();
   config.deleted_objects_logfile = deletion_log_file;
   config.statistics              = statistics();
+  config.repo_name               = repo_name;
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -14,8 +14,8 @@
 #include "garbage_collection/gc_aux.h"
 #include "garbage_collection/hash_filter.h"
 #include "manifest.h"
-#include "options.h"
 #include "reflog.h"
+#include "statistics_database.h"
 #include "upload_facility.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -140,23 +140,7 @@ int CommandGc::Main(const ArgumentList &args) {
     }
   }
 
-  SimpleOptionsParser parser;
-  bool extended_stats = false;
-  std::string param_value = "";
-  const std::string repo_config_file =
-      "/etc/cvmfs/repositories.d/" + repo_name + "/server.conf";
-  if (!parser.TryParsePath(repo_config_file)) {
-    LogCvmfs(kLogCvmfs, kLogStderr,
-             "Could not parse repository configuration: %s.",
-             repo_config_file.c_str());
-  } else if (!parser.GetValue("CVMFS_EXTENDED_GC_STATS", &param_value)) {
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
-             "Parameter %s was not set in the repository configuration file. "
-             "Do not count condemned_bytes.",
-             "CVMFS_EXTENDED_GC_STATS");
-  } else if (parser.IsOn(param_value)) {
-    extended_stats = true;
-  }
+  bool extended_stats = StatisticsDatabase::GcExtendedStats(repo_name);
 
   reflog->BeginTransaction();
 

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -204,13 +204,14 @@ int main(int argc, char **argv) {
 
     string repo_name;
     if (args.find('N') != args.end()) {
-      string repo_name = *args.find('N')->second;
+      repo_name = *args.find('N')->second;
     } else if (args.find('n') != args.end()) {
-      string repo_name = *args.find('n')->second;
+      repo_name = *args.find('n')->second;
     }
 
     string db_file_path = StatisticsDatabase::GetDBPath(repo_name);
 
+    LogCvmfs(kLogCvmfs, kLogStdout, "^^^^^^^^^^ %s", db_file_path.c_str());
     if (FileExists(db_file_path)) {
       db = StatisticsDatabase::Open(db_file_path,
                                     StatisticsDatabase::kOpenReadWrite);

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -211,7 +211,6 @@ int main(int argc, char **argv) {
 
     string db_file_path = StatisticsDatabase::GetDBPath(repo_name);
 
-    LogCvmfs(kLogCvmfs, kLogStdout, "^^^^^^^^^^ %s", db_file_path.c_str());
     if (FileExists(db_file_path)) {
       db = StatisticsDatabase::Open(db_file_path,
                                     StatisticsDatabase::kOpenReadWrite);

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -227,7 +227,8 @@ int main(int argc, char **argv) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr,
               "Couldn't create StatisticsDatabase object!");
     } else if (db->StoreStatistics(command->statistics(), start_time,
-                                   finished_time, command->GetName()) != 0) {
+                                   finished_time, command->GetName(),
+                                                                args) != 0) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr,
             "Couldn't store statistics in %s!",
             db_file_path.c_str());

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -228,7 +228,8 @@ int main(int argc, char **argv) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr,
                 "Couldn't create StatisticsDatabase object!");
       } else if (db->StoreStatistics(command->statistics(), start_time,
-                                     finished_time, command->GetName()) != 0) {
+                                     finished_time, command->GetName(),
+                                                             repo_name) != 0) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr,
               "Couldn't store statistics in %s!",
               db_file_path.c_str());

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -201,14 +201,12 @@ int main(int argc, char **argv) {
   if (command->GetName() == "sync" || command->GetName() == "ingest"
                                    || command->GetName() == "gc") {
     UniquePtr<StatisticsDatabase> db;
-
     string repo_name;
     if (args.find('N') != args.end()) {
       repo_name = *args.find('N')->second;
     } else if (args.find('n') != args.end()) {
       repo_name = *args.find('n')->second;
     }
-
     string db_file_path = StatisticsDatabase::GetDBPath(repo_name);
 
     if (FileExists(db_file_path)) {

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -198,7 +198,8 @@ int main(int argc, char **argv) {
              ->PrintList(perf::Statistics::kPrintHeader).c_str());
   }
 
-  if (command->GetName() == "sync" || command->GetName() == "ingest") {
+  if (command->GetName() == "sync" || command->GetName() == "ingest"
+                                   || command->GetName() == "gc") {
     UniquePtr<StatisticsDatabase> db;
     string repo_name = *args.find('N')->second;
     string db_file_path = StatisticsDatabase::GetDBPath(repo_name);

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -201,7 +201,14 @@ int main(int argc, char **argv) {
   if (command->GetName() == "sync" || command->GetName() == "ingest"
                                    || command->GetName() == "gc") {
     UniquePtr<StatisticsDatabase> db;
-    string repo_name = *args.find('N')->second;
+
+    string repo_name;
+    if (args.find('N') != args.end()) {
+      string repo_name = *args.find('N')->second;
+    } else if (args.find('n') != args.end()) {
+      string repo_name = *args.find('n')->second;
+    }
+
     string db_file_path = StatisticsDatabase::GetDBPath(repo_name);
 
     if (FileExists(db_file_path)) {
@@ -221,8 +228,8 @@ int main(int argc, char **argv) {
     if (!db.IsValid()) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr,
               "Couldn't create StatisticsDatabase object!");
-    } else if (db->StoreStatistics(command->statistics(),
-                                    start_time, finished_time) != 0) {
+    } else if (db->StoreStatistics(command->statistics(), start_time,
+                                   finished_time, command->GetName()) != 0) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr,
             "Couldn't store statistics in %s!",
             db_file_path.c_str());

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
   }
 
   if (command->GetName() == "sync" || command->GetName() == "ingest"
-                                   || command->GetName() == "gc") {
+      || (command->GetName() == "gc" && !(args.count('d') > 0))) {
     UniquePtr<StatisticsDatabase> db;
     string repo_name = "";
     if (args.find('N') != args.end()) {

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -228,8 +228,7 @@ int main(int argc, char **argv) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr,
                 "Couldn't create StatisticsDatabase object!");
       } else if (db->StoreStatistics(command->statistics(), start_time,
-                                     finished_time, command->GetName(),
-                                                                  args) != 0) {
+                                     finished_time, command->GetName()) != 0) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr,
               "Couldn't store statistics in %s!",
               db_file_path.c_str());

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -865,7 +865,6 @@ void SyncMediator::AddFile(SharedPtr<SyncItem> entry) {
   // publish statistics counting for new file
   if (entry->IsNew()) {
     perf::Inc(counters_->n_files_added);
-    printf("Adding ------------- %s\n", entry->relative_parent_path().c_str());
     perf::Xadd(counters_->sz_added_bytes, entry->GetScratchSize());
   }
 }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -865,6 +865,7 @@ void SyncMediator::AddFile(SharedPtr<SyncItem> entry) {
   // publish statistics counting for new file
   if (entry->IsNew()) {
     perf::Inc(counters_->n_files_added);
+    printf("Adding ------------- %s\n", entry->relative_parent_path().c_str());
     perf::Xadd(counters_->sz_added_bytes, entry->GetScratchSize());
   }
 }

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -252,6 +252,15 @@ class AbstractUploader
   }
 
   /**
+   * Get object size based on its content hash
+   *
+   * @param hash  the content hash of a file
+   */
+  int64_t GetObjectSize(const shash::Any &hash) {
+    return GetObjectSize("data/" + hash.MakePath());
+  }
+
+  /**
    * Checks if a file is already present in the backend storage. This might be a
    * synchronous operation.
    *
@@ -324,6 +333,8 @@ class AbstractUploader
 
 
   virtual void DoRemoveAsync(const std::string &file_to_delete) = 0;
+
+  virtual int64_t GetObjectSize(const std::string &file) = 0;
 
   /**
    * This notifies the callback that is associated to a finishing job. Please

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -257,7 +257,7 @@ class AbstractUploader
    * @param hash  the content hash of a file
    */
   int64_t GetObjectSize(const shash::Any &hash) {
-    return GetObjectSize("data/" + hash.MakePath());
+    return DoGetObjectSize("data/" + hash.MakePath());
   }
 
   /**
@@ -334,7 +334,7 @@ class AbstractUploader
 
   virtual void DoRemoveAsync(const std::string &file_to_delete) = 0;
 
-  virtual int64_t GetObjectSize(const std::string &file) = 0;
+  virtual int64_t DoGetObjectSize(const std::string &file) = 0;
 
   /**
    * This notifies the callback that is associated to a finishing job. Please

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -334,7 +334,7 @@ class AbstractUploader
 
   virtual void DoRemoveAsync(const std::string &file_to_delete) = 0;
 
-  virtual int64_t DoGetObjectSize(const std::string &file) = 0;
+  virtual int64_t DoGetObjectSize(const std::string &file_name) = 0;
 
   /**
    * This notifies the callback that is associated to a finishing job. Please

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -231,7 +231,7 @@ bool GatewayUploader::ReadKey(const std::string& key_file, std::string* key_id,
   return gateway::ReadKeys(key_file, key_id, secret);
 }
 
-int64_t GatewayUploader::GetObjectSize(const std::string &file_name) {
+int64_t GatewayUploader::DoGetObjectSize(const std::string &file_name) {
   return 0;
 }
 

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -231,6 +231,10 @@ bool GatewayUploader::ReadKey(const std::string& key_file, std::string* key_id,
   return gateway::ReadKeys(key_file, key_id, secret);
 }
 
+int64_t GatewayUploader::GetObjectSize(const std::string &file_name) {
+  return 0;
+}
+
 void GatewayUploader::BumpErrors() const { atomic_inc32(&num_errors_); }
 
 }  // namespace upload

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -232,7 +232,7 @@ bool GatewayUploader::ReadKey(const std::string& key_file, std::string* key_id,
 }
 
 int64_t GatewayUploader::DoGetObjectSize(const std::string &file_name) {
-  return 0;
+  return -EOPNOTSUPP;
 }
 
 void GatewayUploader::BumpErrors() const { atomic_inc32(&num_errors_); }

--- a/cvmfs/upload_gateway.h
+++ b/cvmfs/upload_gateway.h
@@ -85,6 +85,8 @@ class GatewayUploader : public AbstractUploader {
   virtual bool ReadKey(const std::string& key_file, std::string* key_id,
                        std::string* secret);
 
+  virtual int64_t GetObjectSize(const std::string &file_name);
+
  private:
   void BumpErrors() const;
 

--- a/cvmfs/upload_gateway.h
+++ b/cvmfs/upload_gateway.h
@@ -85,7 +85,7 @@ class GatewayUploader : public AbstractUploader {
   virtual bool ReadKey(const std::string& key_file, std::string* key_id,
                        std::string* secret);
 
-  virtual int64_t GetObjectSize(const std::string &file_name);
+  virtual int64_t DoGetObjectSize(const std::string &file_name);
 
  private:
   void BumpErrors() const;

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -239,7 +239,7 @@ int LocalUploader::Move(const std::string &local_path,
   return retcode;
 }
 
-int64_t LocalUploader::GetObjectSize(const std::string &file_name) {
+int64_t LocalUploader::DoGetObjectSize(const std::string &file_name) {
   int64_t size = GetFileSize(upstream_path_ + "/" + file_name);
   printf("********** file %s \nsize = %ld\n",
           (upstream_path_ + "/" + file_name).c_str(), size);

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -240,10 +240,7 @@ int LocalUploader::Move(const std::string &local_path,
 }
 
 int64_t LocalUploader::DoGetObjectSize(const std::string &file_name) {
-  int64_t size = GetFileSize(upstream_path_ + "/" + file_name);
-  printf("********** file %s \nsize = %ld\n",
-          (upstream_path_ + "/" + file_name).c_str(), size);
-  return size;
+  return GetFileSize(upstream_path_ + "/" + file_name);
 }
 
 }  // namespace upload

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -167,9 +167,6 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
     }
-    if (!content_hash.HasSuffix()) {  // count only data, not metadata
-      CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
-    }
     if (!content_hash.HasSuffix()
         || content_hash.suffix == shash::kSuffixPartial) {
       CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -166,7 +166,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
       Respond(handle->commit_callback,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
-    }  
+    }
     if (!content_hash.HasSuffix()) {  // count only data, not metadata
       CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
     }

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -166,6 +166,12 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
       Respond(handle->commit_callback,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
+    }  
+    if (!content_hash.HasSuffix()) {  // count only data, not metadata
+      CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
+      printf("Added ------ %ld %s \n",
+                  GetFileSize(upstream_path_ + "/" + final_path),
+                  (upstream_path_ + "/" + final_path).c_str());
     }
     if (!content_hash.HasSuffix()
         || content_hash.suffix == shash::kSuffixPartial) {

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -239,4 +239,10 @@ int LocalUploader::Move(const std::string &local_path,
   return retcode;
 }
 
+int64_t LocalUploader::GetObjectSize(const std::string &file_name) {
+  int64_t size = GetFileSize(upstream_path_ + "/" + file_name);
+  printf("********** file %s \nsize = %ld\n", (upstream_path_ + "/" + file_name).c_str(), size);
+  return size;
+}
+
 }  // namespace upload

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -241,7 +241,8 @@ int LocalUploader::Move(const std::string &local_path,
 
 int64_t LocalUploader::GetObjectSize(const std::string &file_name) {
   int64_t size = GetFileSize(upstream_path_ + "/" + file_name);
-  printf("********** file %s \nsize = %ld\n", (upstream_path_ + "/" + file_name).c_str(), size);
+  printf("********** file %s \nsize = %ld\n",
+          (upstream_path_ + "/" + file_name).c_str(), size);
   return size;
 }
 

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -169,9 +169,6 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
     }  
     if (!content_hash.HasSuffix()) {  // count only data, not metadata
       CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
-      printf("Added ------ %ld %s \n",
-                  GetFileSize(upstream_path_ + "/" + final_path),
-                  (upstream_path_ + "/" + final_path).c_str());
     }
     if (!content_hash.HasSuffix()
         || content_hash.suffix == shash::kSuffixPartial) {

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -71,7 +71,7 @@ class LocalUploader : public AbstractUploader {
    */
   unsigned int GetNumberOfErrors() const;
 
-  int64_t GetObjectSize(const std::string &file_name);
+  int64_t DoGetObjectSize(const std::string &file_name);
 
  protected:
   int Move(const std::string &local_path, const std::string &remote_path) const;

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -71,6 +71,8 @@ class LocalUploader : public AbstractUploader {
    */
   unsigned int GetNumberOfErrors() const;
 
+  int64_t GetObjectSize(const std::string &file_name);
+
  protected:
   int Move(const std::string &local_path, const std::string &remote_path) const;
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -399,8 +399,6 @@ bool S3Uploader::PlaceBootstrappingShortcut(const shash::Any &object) const {
 }
 
 
-int64_t S3Uploader::DoGetObjectSize(const std::string &file_name) {
-  return 0;
-}
+int64_t S3Uploader::DoGetObjectSize(const std::string &file_name) { return 0; }
 
 }  // namespace upload

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -399,6 +399,8 @@ bool S3Uploader::PlaceBootstrappingShortcut(const shash::Any &object) const {
 }
 
 
-int64_t S3Uploader::DoGetObjectSize(const std::string &file_name) { return 0; }
+int64_t S3Uploader::DoGetObjectSize(const std::string &file_name) {
+  return -EOPNOTSUPP;  // TODO(dosarudaniel): use a head request for byte count
+}
 
 }  // namespace upload

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -398,4 +398,9 @@ bool S3Uploader::PlaceBootstrappingShortcut(const shash::Any &object) const {
   return false;  // TODO(rmeusel): implement
 }
 
+
+int64_t S3Uploader::GetObjectSize(const std::string &file_name) {
+  return 0;
+}
+
 }  // namespace upload

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -399,7 +399,7 @@ bool S3Uploader::PlaceBootstrappingShortcut(const shash::Any &object) const {
 }
 
 
-int64_t S3Uploader::GetObjectSize(const std::string &file_name) {
+int64_t S3Uploader::DoGetObjectSize(const std::string &file_name) {
   return 0;
 }
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -68,6 +68,7 @@ class S3Uploader : public AbstractUploader {
   virtual bool PlaceBootstrappingShortcut(const shash::Any &object) const;
 
   virtual unsigned int GetNumberOfErrors() const;
+  int64_t GetObjectSize(const std::string &file_name);
 
  private:
   static const unsigned kDefaultPort = 80;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -68,7 +68,7 @@ class S3Uploader : public AbstractUploader {
   virtual bool PlaceBootstrappingShortcut(const shash::Any &object) const;
 
   virtual unsigned int GetNumberOfErrors() const;
-  int64_t GetObjectSize(const std::string &file_name);
+  int64_t DoGetObjectSize(const std::string &file_name);
 
  private:
   static const unsigned kDefaultPort = 80;

--- a/test/src/660-store_publish_statistics/main
+++ b/test/src/660-store_publish_statistics/main
@@ -14,7 +14,6 @@ CVMFS_TEST_660_ERROR_DIR_CHANGED=107
 CVMFS_TEST_660_ERROR_BYTES_ADDED=108
 CVMFS_TEST_660_ERROR_BYTES_REMOVED=109
 CVMFS_TEST_660_ERROR_BYTES_UPLOADED=110
-CVMFS_TEST_660_ERROR_MERGE_TOOL=111
 CVMFS_TEST_660_TAR_FILE=tarfile.tar
 CVMFS_TEST_660_TAR_DIR=newTarDir
 CVMFS_TEST_660_OLD_DB=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats_old.db
@@ -125,33 +124,6 @@ cvmfs_run_test() {
   cvmfs_server ingest -t $tar_file_path -b $CVMFS_TEST_660_TAR_DIR $CVMFS_TEST_REPO || return $?
   # get the last inserted data
   sqlite3 $CVMFS_TEST_660_DB_PATH 'select * from publish_statistics' | tail -1 > test_660_4
-
-  # ====================== Test5 - merge tool ======================
-
-  # make a copy of old db file
-  cp -v $CVMFS_TEST_660_DB_PATH $CVMFS_TEST_660_OLD_DB
-  # remove old db file
-  rm -v $CVMFS_TEST_660_DB_PATH
-
-  # create a fresh db file at the default location $CVMFS_TEST_660_DB_PATH
-  echo "*** starting transaction to edit repository"
-  start_transaction $CVMFS_TEST_REPO || return $?
-
-  echo "*** Test 5 - putting some stuff in the new repository"
-  test1 $repo_dir || return 5
-
-  echo "*** creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO || return $?
-
-  # merge old db file with the new db file
-  cvmfs_server merge-stats -o $CVMFS_TEST_660_MERGED_DB $CVMFS_TEST_660_OLD_DB $CVMFS_TEST_660_DB_PATH
-
-  local nr_entries="$(sqlite3 $CVMFS_TEST_660_MERGED_DB "select count(*) from publish_statistics;")"
-
-  if [ "x$nr_entries" != "x7" ]; then
-    echo "*** Test 5 FAILED nr_entries expected = 7, received $nr_entries!"
-    return $CVMFS_TEST_660_ERROR_MERGE_TOOL
-  fi
 
   # =========================================================================================================
 

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -42,6 +42,7 @@ cvmfs_run_test() {
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
   create_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+  sudo bash -c "echo CVMFS_EXTENDED_GC_STATS=true >> /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf"
 
   echo "*** disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -3,7 +3,6 @@ cvmfs_test_name="Gather garbage collector statistics"
 cvmfs_test_autofs_on_startup=false
 
 CVMFS_TEST_661_ERROR_BYTES=101
-CVMFS_TEST_661_ERROR_OBJECTS=102
 CVMFS_TEST_661_DB_PATH=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats.db
 
 add_content() {
@@ -32,35 +31,23 @@ remove_content() {
   local working_dir=$1
   pushdir $working_dir
 
-  rm -v ./f*
+  rm -v *
 
   popdir
 }
 
 cvmfs_run_test() {
-  logfile=$1
   local logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
-  local scratch_dir=$(pwd)
-  local gc_log="/tmp/gc.log"
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+  create_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
 
   echo "*** disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
-  # echo "*** delete stats.db files"
-  # rm -v $CVMFS_TEST_662_DB_PATH
-  # rm -v $CVMFS_TEST_662_OLD_DB
-  # rm -v $CVMFS_TEST_662_MERGED_DB
-
-  echo "*** Empty publish"
-  start_transaction $CVMFS_TEST_REPO || return $?
-  publish_repo $CVMFS_TEST_REPO || return $?
-
-  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
-  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4  
+  echo "*** delete older stats.db files:"
+  rm -vf $CVMFS_TEST_662_DB_PATH
 
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
@@ -83,30 +70,19 @@ cvmfs_run_test() {
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  echo "*** make an empty publish"
+  echo "*** empty publish"
   start_transaction $CVMFS_TEST_REPO || return $?
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
-  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4
+  echo "*** perform basic garbage collection"
+  cvmfs_server gc -r1 -f $CVMFS_TEST_REPO || return 4
 
   # ====================== Test gc stats ======================
-  local sz_condemned_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_condemned_data_bytes) FROM gc_statistics")"
+  local sz_condemned_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_condemned_bytes) FROM gc_statistics")"
   local uploaded_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_bytes_uploaded) FROM publish_statistics")"
-  local n_condemned_data_objects="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(n_condemned_data_objects) FROM gc_statistics")"
-  local n_files_added="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(files_added) FROM publish_statistics")"
-  local duplicated_files="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(duplicated_files) FROM publish_statistics")"
-  local expected_condemned_data_objects=$n_files_added - $duplicated_files;
+
   if [ "x$sz_condemned_bytes" != "x$uploaded_bytes" ]; then
     echo "*** Test FAILED sz_condemned_bytes not equal to uploaded_bytes: $sz_condemned_bytes vs $uploaded_bytes."
     return $CVMFS_TEST_661_ERROR_BYTES
   fi
-
-  # just for small files
-  if [ "x$n_condemned_data_objects" != "x$($n_files_added - $duplicated_files)" ]; then
-    echo "*** Test FAILED n_condemned_data_objects not equal to n_files_added - duplicated_files: $n_condemned_data_objects vs ${$n_files_added - $duplicated_files}."
-    return $CVMFS_TEST_661_ERROR_BYTES
-  fi
-
-
 }

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -2,12 +2,47 @@
 cvmfs_test_name="Gather garbage collector statistics"
 cvmfs_test_autofs_on_startup=false
 
+CVMFS_TEST_661_ERROR_BYTES=101
+CVMFS_TEST_661_ERROR_OBJECTS=102
+CVMFS_TEST_661_DB_PATH=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats.db
+
+add_content() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  echo "meaningless file content" > f1
+  echo "more clever file content" > f2
+  echo "abc123"                   > f3
+  echo "1234abcd"                 > f4
+  echo "1234abcd1"                > f5
+
+  popdir
+}
+
+add_duplicate() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  echo "meaningless file content" > f1_copy
+
+  popdir
+}
+
+remove_content() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  rm -v ./f*
+
+  popdir
+}
 
 cvmfs_run_test() {
   logfile=$1
+  local logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local scratch_dir=$(pwd)
-  local gc_log="${scratch_dir}/gc.log"
+  local gc_log="/tmp/gc.log"
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
@@ -15,7 +50,63 @@ cvmfs_run_test() {
   echo "*** disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
-  # TODO
-  # echo "perform basic garbage collection (logging deletions to $gc_log)"
-  # cvmfs_server gc -r0 -fL "$gc_log" $CVMFS_TEST_REPO || return 11
+  # echo "*** delete stats.db files"
+  # rm -v $CVMFS_TEST_662_DB_PATH
+  # rm -v $CVMFS_TEST_662_OLD_DB
+  # rm -v $CVMFS_TEST_662_MERGED_DB
+
+  echo "*** Empty publish"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
+  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4  
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "*** putting some stuff in the repository"
+  add_content $repo_dir || return 1
+  echo "*** creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "*** putting a duplicated file in the repository"
+  add_duplicate $repo_dir || return 2
+  echo "*** creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "*** delete all stuff from the repository"
+  remove_content $repo_dir || return 3
+  echo "*** creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** make an empty publish"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
+  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4
+
+  # ====================== Test gc stats ======================
+  local sz_condemned_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_condemned_data_bytes) FROM gc_statistics")"
+  local uploaded_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_bytes_uploaded) FROM publish_statistics")"
+  local n_condemned_data_objects="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(n_condemned_data_objects) FROM gc_statistics")"
+  local n_files_added="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(files_added) FROM publish_statistics")"
+  local duplicated_files="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(duplicated_files) FROM publish_statistics")"
+  local expected_condemned_data_objects=$n_files_added - $duplicated_files;
+  if [ "x$sz_condemned_bytes" != "x$uploaded_bytes" ]; then
+    echo "*** Test FAILED sz_condemned_bytes not equal to uploaded_bytes: $sz_condemned_bytes vs $uploaded_bytes."
+    return $CVMFS_TEST_661_ERROR_BYTES
+  fi
+
+  # just for small files
+  if [ "x$n_condemned_data_objects" != "x$($n_files_added - $duplicated_files)" ]; then
+    echo "*** Test FAILED n_condemned_data_objects not equal to n_files_added - duplicated_files: $n_condemned_data_objects vs ${$n_files_added - $duplicated_files}."
+    return $CVMFS_TEST_661_ERROR_BYTES
+  fi
+
+
 }

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -1,0 +1,21 @@
+# This file 
+cvmfs_test_name="Gather garbage collector statistics"
+cvmfs_test_autofs_on_startup=false
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+  local gc_log="${scratch_dir}/gc.log"
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+
+  echo "*** disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
+  # TODO
+  # echo "perform basic garbage collection (logging deletions to $gc_log)"
+  # cvmfs_server gc -r0 -fL "$gc_log" $CVMFS_TEST_REPO || return 11
+}

--- a/test/src/662-merge_stats_tool/main
+++ b/test/src/662-merge_stats_tool/main
@@ -8,16 +8,23 @@ CVMFS_TEST_662_DB_PATH=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats.db
 CVMFS_TEST_662_OLD_DB=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats_old.db
 CVMFS_TEST_662_MERGED_DB=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats_merged.db
 
-
 add_content() {
   local working_dir=$1
   pushdir $working_dir
 
   echo "meaningless file content" > f1
-  echo "meaningless file content" > f1_copy
   echo "more clever file content" > f2
   echo "abc123"                   > f3
   echo "1234abcd"                 > f4
+
+  popdir
+}
+
+add_duplicate() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  echo "meaningless file content" > f1_copy
 
   popdir
 }
@@ -48,10 +55,6 @@ cvmfs_run_test() {
   rm -v $CVMFS_TEST_662_OLD_DB
   rm -v $CVMFS_TEST_662_MERGED_DB
 
-  echo "*** make an empty publish"
-  start_transaction $CVMFS_TEST_REPO || return $?
-  publish_repo $CVMFS_TEST_REPO || return $?
-
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
   echo "*** putting some stuff in the repository"
@@ -61,8 +64,15 @@ cvmfs_run_test() {
 
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
+  echo "*** putting a duplicated file in the repository"
+  add_duplicate $repo_dir || return 2
+  echo "*** creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
   echo "*** delete all stuff from the repository"
-  remove_content $repo_dir || return 2
+  remove_content $repo_dir || return 3
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
@@ -76,7 +86,10 @@ cvmfs_run_test() {
   rm -v $CVMFS_TEST_662_DB_PATH
 
   echo "*** perform basic garbage collection (logging deletions to $gc_log)"
-  cvmfs_server gc -r0 -fL "$gc_log" $CVMFS_TEST_REPO || return 11
+  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4
+
+  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
+  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 5
 
   # ====================== Test - merge tool ======================
 
@@ -91,9 +104,9 @@ cvmfs_run_test() {
     echo "***   expected = 4, received $nr_entries_publish!"
     return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
   fi
-  if [ "x$nr_entries_gc" != "x1" ]; then
+  if [ "x$nr_entries_gc" != "x2" ]; then
     echo "*** Test FAILED nr_entries in gc_statistics table:"
-    echo "***   expected = 1, received $nr_entries_gc!"
+    echo "***   expected = 2, received $nr_entries_gc!"
     return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
   fi
 }

--- a/test/src/662-merge_stats_tool/main
+++ b/test/src/662-merge_stats_tool/main
@@ -1,0 +1,99 @@
+# This file contains $NR_OF_TESTS tests for checking the store publish statistics feature (checking the database integrity)
+cvmfs_test_name="Merge two database files"
+cvmfs_test_autofs_on_startup=false
+
+CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE=101
+CVMFS_TEST_662_ERROR_MERGE_GC_TABLE=102
+CVMFS_TEST_662_DB_PATH=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats.db
+CVMFS_TEST_662_OLD_DB=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats_old.db
+CVMFS_TEST_662_MERGED_DB=/var/spool/cvmfs/$CVMFS_TEST_REPO/stats_merged.db
+
+
+add_content() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  echo "meaningless file content" > f1
+  echo "meaningless file content" > f1_copy
+  echo "more clever file content" > f2
+  echo "abc123"                   > f3
+  echo "1234abcd"                 > f4
+
+  popdir
+}
+
+remove_content() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  rm -rf ./*
+
+  popdir
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+  local gc_log="${scratch_dir}/gc.log"
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+
+  echo "*** disable automatic garbage collection"
+  disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
+
+  echo "*** delete stats.db files"
+  rm -v $CVMFS_TEST_662_DB_PATH
+  rm -v $CVMFS_TEST_662_OLD_DB
+  rm -v $CVMFS_TEST_662_MERGED_DB
+
+  echo "*** make an empty publish"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "*** putting some stuff in the repository"
+  add_content $repo_dir || return 1
+  echo "*** creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "*** delete all stuff from the repository"
+  remove_content $repo_dir || return 2
+  echo "*** creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** make an empty publish"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  # make a copy of old db file
+  cp -v $CVMFS_TEST_662_DB_PATH $CVMFS_TEST_662_OLD_DB
+  # remove old db file
+  rm -v $CVMFS_TEST_662_DB_PATH
+
+  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
+  cvmfs_server gc -r0 -fL "$gc_log" $CVMFS_TEST_REPO || return 11
+
+  # ====================== Test - merge tool ======================
+
+  # merge old db file with the new db file
+  cvmfs_server merge-stats -o $CVMFS_TEST_662_MERGED_DB $CVMFS_TEST_662_OLD_DB $CVMFS_TEST_662_DB_PATH
+
+  local nr_entries_publish="$(sqlite3 $CVMFS_TEST_662_MERGED_DB "select count(*) from publish_statistics;")"
+  local nr_entries_gc="$(sqlite3 $CVMFS_TEST_662_MERGED_DB "select count(*) from gc_statistics;")"
+
+  if [ "x$nr_entries_publish" != "x4" ]; then
+    echo "*** Test FAILED nr_entries in publish_statistics table:"
+    echo "***   expected = 4, received $nr_entries_publish!"
+    return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
+  fi
+  if [ "x$nr_entries_gc" != "x1" ]; then
+    echo "*** Test FAILED nr_entries in gc_statistics table:"
+    echo "***   expected = 1, received $nr_entries_gc!"
+    return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
+  fi
+}

--- a/test/src/662-merge_stats_tool/main
+++ b/test/src/662-merge_stats_tool/main
@@ -42,26 +42,22 @@ remove_content() {
 cvmfs_run_test() {
   local logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
-  local scratch_dir=$(pwd)
-  local gc_log="/tmp/gc.log"
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
+  create_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
 
   echo "*** disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
-  # echo "*** delete stats.db files"
-  # rm -v $CVMFS_TEST_662_DB_PATH
-  # rm -v $CVMFS_TEST_662_OLD_DB
-  # rm -v $CVMFS_TEST_662_MERGED_DB
+  echo "*** delete stats.db files"
+  rm -vf $CVMFS_TEST_662_DB_PATH
 
-  echo "*** Empty publish"
+  echo "*** Empty publish 1"
   start_transaction $CVMFS_TEST_REPO || return $?
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
-  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4  
+  echo "*** perform basic garbage collection"
+  cvmfs_server gc -r1 -f $CVMFS_TEST_REPO || return 4  
 
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
@@ -84,20 +80,20 @@ cvmfs_run_test() {
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
 
-  echo "*** make an empty publish"
-  start_transaction $CVMFS_TEST_REPO || return $?
-  publish_repo $CVMFS_TEST_REPO || return $?
-
   # make a copy of old db file
   cp -v $CVMFS_TEST_662_DB_PATH $CVMFS_TEST_662_OLD_DB
   # remove old db file
   rm -v $CVMFS_TEST_662_DB_PATH
 
-  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
-  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4
+  echo "*** Empty publish 2"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  publish_repo $CVMFS_TEST_REPO || return $?
 
-  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
-  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 5
+  echo "*** perform basic garbage collection 1 "
+  cvmfs_server gc -r1 -f $CVMFS_TEST_REPO || return 4
+
+  echo "*** perform basic garbage collection 2 "
+  cvmfs_server gc -r1 -f $CVMFS_TEST_REPO || return 5
 
   # ====================== Test - merge tool ======================
 
@@ -107,8 +103,8 @@ cvmfs_run_test() {
   local nr_entries_publish="$(sqlite3 $CVMFS_TEST_662_MERGED_DB "select count(*) from publish_statistics;")"
   local nr_entries_gc="$(sqlite3 $CVMFS_TEST_662_MERGED_DB "select count(*) from gc_statistics;")"
 
-  local expeted_nr_entries_publish=7
-  local expeted_nr_entries_gc=4
+  local expeted_nr_entries_publish=5
+  local expeted_nr_entries_gc=3
 
   if [ "x$nr_entries_publish" != "x$expeted_nr_entries_publish" ]; then
     echo "*** Test FAILED nr_entries in publish_statistics table:"
@@ -118,6 +114,6 @@ cvmfs_run_test() {
   if [ "x$nr_entries_gc" != "x$expeted_nr_entries_gc" ]; then
     echo "*** Test FAILED nr_entries in gc_statistics table:"
     echo "***   expected = $expeted_nr_entries_gc, received $nr_entries_gc!"
-    return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
+    return $CVMFS_TEST_662_ERROR_MERGE_GC_TABLE
   fi
 }

--- a/test/src/662-merge_stats_tool/main
+++ b/test/src/662-merge_stats_tool/main
@@ -16,6 +16,7 @@ add_content() {
   echo "more clever file content" > f2
   echo "abc123"                   > f3
   echo "1234abcd"                 > f4
+  echo "1234abcd1"                > f5
 
   popdir
 }
@@ -33,7 +34,7 @@ remove_content() {
   local working_dir=$1
   pushdir $working_dir
 
-  rm -rf ./*
+  rm -v *
 
   popdir
 }
@@ -42,7 +43,7 @@ cvmfs_run_test() {
   local logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   local scratch_dir=$(pwd)
-  local gc_log="${scratch_dir}/gc.log"
+  local gc_log="/tmp/gc.log"
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
@@ -50,10 +51,17 @@ cvmfs_run_test() {
   echo "*** disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
-  echo "*** delete stats.db files"
-  rm -v $CVMFS_TEST_662_DB_PATH
-  rm -v $CVMFS_TEST_662_OLD_DB
-  rm -v $CVMFS_TEST_662_MERGED_DB
+  # echo "*** delete stats.db files"
+  # rm -v $CVMFS_TEST_662_DB_PATH
+  # rm -v $CVMFS_TEST_662_OLD_DB
+  # rm -v $CVMFS_TEST_662_MERGED_DB
+
+  echo "*** Empty publish"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** perform basic garbage collection (logging deletions to $gc_log)"
+  cvmfs_server gc -r1 -fL "$gc_log" $CVMFS_TEST_REPO || return 4  
 
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
@@ -99,14 +107,17 @@ cvmfs_run_test() {
   local nr_entries_publish="$(sqlite3 $CVMFS_TEST_662_MERGED_DB "select count(*) from publish_statistics;")"
   local nr_entries_gc="$(sqlite3 $CVMFS_TEST_662_MERGED_DB "select count(*) from gc_statistics;")"
 
-  if [ "x$nr_entries_publish" != "x4" ]; then
+  local expeted_nr_entries_publish=7
+  local expeted_nr_entries_gc=4
+
+  if [ "x$nr_entries_publish" != "x$expeted_nr_entries_publish" ]; then
     echo "*** Test FAILED nr_entries in publish_statistics table:"
-    echo "***   expected = 4, received $nr_entries_publish!"
+    echo "***   expected = $expeted_nr_entries_publish, received $nr_entries_publish!"
     return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
   fi
-  if [ "x$nr_entries_gc" != "x2" ]; then
+  if [ "x$nr_entries_gc" != "x$expeted_nr_entries_gc" ]; then
     echo "*** Test FAILED nr_entries in gc_statistics table:"
-    echo "***   expected = 2, received $nr_entries_gc!"
+    echo "***   expected = $expeted_nr_entries_gc, received $nr_entries_gc!"
     return $CVMFS_TEST_662_ERROR_MERGE_PUBLISH_TABLE
   fi
 }

--- a/test/unittests/c_mock_uploader.h
+++ b/test/unittests/c_mock_uploader.h
@@ -117,6 +117,8 @@ class IngestionMockUploader
             upload::UploaderResults(upload::UploaderResults::kChunkCommit, 0));
   }
 
+  virtual int64_t DoGetObjectSize(const std::string &file) { return 0;}
+
   Results results;
 };
 

--- a/test/unittests/c_mock_uploader.h
+++ b/test/unittests/c_mock_uploader.h
@@ -117,7 +117,7 @@ class IngestionMockUploader
             upload::UploaderResults(upload::UploaderResults::kChunkCommit, 0));
   }
 
-  virtual int64_t DoGetObjectSize(const std::string &file) { return 0;}
+  virtual int64_t DoGetObjectSize(const std::string &file_name) { return 0;}
 
   Results results;
 };

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -54,7 +54,9 @@ class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
   }
 
   virtual unsigned GetNumberOfErrors() const { return 0; }
-  virtual int64_t DoGetObjectSize(const std::string &file_name) { return 0;}
+  virtual int64_t DoGetObjectSize(const std::string &file_name) {
+    return -EOPNOTSUPP;
+  }
 
   bool HasDeleted(const shash::Any &hash) const {
     return deleted_hashes.find(hash) != deleted_hashes.end();

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -54,7 +54,7 @@ class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
   }
 
   virtual unsigned GetNumberOfErrors() const { return 0; }
-  virtual int64_t DoGetObjectSize(const std::string &file) { return 0;}
+  virtual int64_t DoGetObjectSize(const std::string &file_name) { return 0;}
 
   bool HasDeleted(const shash::Any &hash) const {
     return deleted_hashes.find(hash) != deleted_hashes.end();

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -54,6 +54,7 @@ class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
   }
 
   virtual unsigned GetNumberOfErrors() const { return 0; }
+  virtual int64_t DoGetObjectSize(const std::string &file) { return 0;}
 
   bool HasDeleted(const shash::Any &hash) const {
     return deleted_hashes.find(hash) != deleted_hashes.end();

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -75,7 +75,7 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     Respond(callback, UploaderResults(UploaderResults::kChunkCommit, 0));
   }
 
-  virtual int64_t DoGetObjectSize(const std::string &file) { return 0;}
+  virtual int64_t DoGetObjectSize(const std::string &file_name) { return 0;}
 
  public:
   static upload::AbstractUploader::UploadBuffer last_buffer;

--- a/test/unittests/t_upload_facility.cc
+++ b/test/unittests/t_upload_facility.cc
@@ -75,6 +75,8 @@ class UF_MockUploader : public AbstractMockUploader<UF_MockUploader> {
     Respond(callback, UploaderResults(UploaderResults::kChunkCommit, 0));
   }
 
+  virtual int64_t DoGetObjectSize(const std::string &file) { return 0;}
+
  public:
   static upload::AbstractUploader::UploadBuffer last_buffer;
   static unsigned last_offset;


### PR DESCRIPTION
Addresses [CVM-1569](https://sft.its.cern.ch/jira/browse/CVM-1569).

- Added one counter for gc: `sz_condemned_bytes` which is used only if `CVMFS_EXTENDED_GC_STATS` variable is set to on/true/yes/1 value in `server.conf` file.
- Write garbage collector counters values in database statistics file into `gc_statistics` table
- Added two new integration tests: `662-merge_stats_tool` and `661-garbage_collector_statistics`
- Check if `repo_name` was found. (`swissknife_main.cc`)




