### PR TITLE
Fixed log message if missing parameter CVMFS_STATISTICS_DB

### DIFF
--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -194,8 +194,9 @@ std::string StatisticsDatabase::GetDBPath(const std::string repo_name) {
   std::string statistics_db = "";
   if (!parser.GetValue("CVMFS_STATISTICS_DB", &statistics_db)) {
     LogCvmfs(kLogCvmfs, kLogSyslog,
-             "Missing parameter %s in repository configuration file.",
-             "CVMFS_STATISTICS_DB");
+             "Parameter %s was not set in repository configuration file. "
+             "Using default value: %s",
+             "CVMFS_STATISTICS_DB", db_default_path.c_str());
     return db_default_path;
   }
 

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -193,7 +193,7 @@ std::string StatisticsDatabase::GetDBPath(const std::string repo_name) {
 
   std::string statistics_db = "";
   if (!parser.GetValue("CVMFS_STATISTICS_DB", &statistics_db)) {
-    LogCvmfs(kLogCvmfs, kLogSyslogErr,
+    LogCvmfs(kLogCvmfs, kLogSyslog,
              "Missing parameter %s in repository configuration file.",
              "CVMFS_STATISTICS_DB");
     return db_default_path;

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -193,8 +193,8 @@ std::string StatisticsDatabase::GetDBPath(const std::string repo_name) {
 
   std::string statistics_db = "";
   if (!parser.GetValue("CVMFS_STATISTICS_DB", &statistics_db)) {
-    LogCvmfs(kLogCvmfs, kLogSyslog,
-             "Parameter %s was not set in repository configuration file. "
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
+             "Parameter %s was not set in the repository configuration file. "
              "Using default value: %s",
              "CVMFS_STATISTICS_DB", db_default_path.c_str());
     return db_default_path;


### PR DESCRIPTION
If `CVMFS_STATISTICS_DB` is not set then `Missing parameter %s in repository configuration file.` message should **not** be printed in `kLogSyslogErr` because `CVMFS_STATISTICS_DB` is an **optional** parameter.