### PR TITLE
Allow to ingest tarballs with hardlink multiple times

### DIFF
--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -133,7 +133,7 @@ uint32_t WritableCatalog::GetMaxLinkId() const {
 
 
 /**
- * Adds a direcotry entry.
+ * Adds a directory entry.
  * @param entry the DirectoryEntry to add to the catalog
  * @param entry_path the full path of the DirectoryEntry to add
  * @param parent_path the full path of the containing directory

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -188,7 +188,7 @@ void SyncMediator::Touch(SharedPtr<SyncItem> entry) {
   }
 
   PrintWarning("'" + entry->GetRelativePath() +
-               "' cannot be touched. Unrecognied file type.");
+               "' cannot be touched. Unrecognized file type.");
 }
 
 


### PR DESCRIPTION
This fix is necessary when we are ingesting a tarball with hardlinks, if
there are already file with the same name and content of the hardlink
(basically only when we are ingesting twice the same tarball) we would
try to add twice the same unique hash, which produce a runtime error
violating the UNIQUE constraint in SQLite.

With this PR we simply check if the file is already there and if it is,
we eliminate it.