### PR TITLE
check for files that start with `./` and remove the prefix

### DIFF
--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -177,6 +177,12 @@ void SyncUnionTarball::Traverse() {
 
 void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
   std::string archive_file_path(archive_entry_pathname(entry));
+  if (archive_file_path.length() >= 2) {
+    if (archive_file_path[0] == '.' && archive_file_path[1] == '/') {
+      archive_file_path = archive_file_path.erase(0, 2);
+    }
+  }
+
   std::string complete_path =
       MakeCanonicalPath(base_directory_ + "/" + archive_file_path);
 

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -177,7 +177,8 @@ void SyncUnionTarball::Traverse() {
 
 void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
   std::string archive_file_path(archive_entry_pathname(entry));
-  SanitizePath(archive_file_path);
+  archive_file_path = SanitizePath(archive_file_path);
+
   std::string complete_path =
       MakeCanonicalPath(base_directory_ + "/" + archive_file_path);
 
@@ -248,12 +249,15 @@ void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
   }
 }
 
-void SyncUnionTarball::SanitizePath(std::string &path) {
+std::string SyncUnionTarball::SanitizePath(const std::string &path) {
   if (path.length() >= 2) {
     if (path[0] == '.' && path[1] == '/') {
-      path = path.erase(0, 2);
+      std::string to_return(path);
+      to_return.erase(0, 2);
+      return to_return;
     }
   }
+  return path;
 }
 
 void SyncUnionTarball::PostUpload() {

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -177,12 +177,7 @@ void SyncUnionTarball::Traverse() {
 
 void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
   std::string archive_file_path(archive_entry_pathname(entry));
-  if (archive_file_path.length() >= 2) {
-    if (archive_file_path[0] == '.' && archive_file_path[1] == '/') {
-      archive_file_path = archive_file_path.erase(0, 2);
-    }
-  }
-
+  SanitizePath(archive_file_path);
   std::string complete_path =
       MakeCanonicalPath(base_directory_ + "/" + archive_file_path);
 
@@ -250,6 +245,14 @@ void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
     LogCvmfs(kLogUnionFs, kLogStderr,
              "Fatal error found unexpected file: \n%s\n", filename.c_str());
     abort();
+  }
+}
+
+void SyncUnionTarball::SanitizePath(std::string &path) {
+  if (path.length() >= 2) {
+    if (path[0] == '.' && path[1] == '/') {
+      path = path.erase(0, 2);
+    }
   }
 }
 

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -104,7 +104,7 @@ class SyncUnionTarball : public SyncUnion {
    */
   void CreateDirectories(const std::string &target);
   void ProcessArchiveEntry(struct archive_entry *entry);
-  void SanitizePath(std::string &path);
+  std::string SanitizePath(const std::string &path);
 };  // class SyncUnionTarball
 
 }  // namespace publish

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -104,6 +104,7 @@ class SyncUnionTarball : public SyncUnion {
    */
   void CreateDirectories(const std::string &target);
   void ProcessArchiveEntry(struct archive_entry *entry);
+  void SanitizePath(std::string &path);
 };  // class SyncUnionTarball
 
 }  // namespace publish


### PR DESCRIPTION
Some docker layers have this peculiar structure of having the whole content inside the `.` folder.

Basically the `.` folder is the root of the tarball, and inside it, the filesystem tree develops.

This shows up as two characters `./` prefix when we are working with the file path that breaks some ingestion.

This PR fix the issue by removing the two char if present.

Given the semantic of the two particular characters, I believe that there would no issues. But I could be wrong.
