### PR TITLE
add permission for other to read and execute files

### DIFF
--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -42,7 +42,8 @@ class SyncItemDummyDir : public SyncItemNative {
   }
 
  private:
-  static const mode_t kPermision = S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR;
+  static const mode_t kPermision =
+          S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR | S_IROTH | S_IXOTH;
 };
 
 catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent() const {


### PR DESCRIPTION
When ingesting a tarball we allow the user to ingest it into a specific directory, suppose `tar/foo`

Unfortunately, with the current permission, only the same owner of the repository will be able to see what files have been ingested, which is not very ergonomic.

I believe we should allow everybody to see the content of those folders.