### PR TITLE
Fix uploaded bytes count

### DIFF
--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -167,7 +167,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
     }
-    if (!content_hash.HasSuffix()) { // count only data, not metadata
+    if (!content_hash.HasSuffix()) {  // count only data, not metadata
       CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
     }
   } else {

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -126,7 +126,6 @@ void LocalUploader::StreamedUpload(UploadStreamHandle *handle,
     return;
   }
 
-  CountUploadedBytes(bytes_written);
   // Tell kernel to evict written pages from the page cache.  We don't care if
   // it succeeds or not.
   (void)platform_invalidate_kcache(local_handle->file_descriptor, offset,
@@ -167,6 +166,9 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
       Respond(handle->commit_callback,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
+    }
+    if (!content_hash.HasSuffix()) { // count only data, not metadata
+      CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
     }
   } else {
     const int retval = unlink(local_handle->temporary_path.c_str());

--- a/test/src/659-print_publish_statistics/main
+++ b/test/src/659-print_publish_statistics/main
@@ -142,7 +142,7 @@ cvmfs_run_test() {
   test_results[3,7]=0
   test_results[3,8]=65
   test_results[3,9]=0
-  test_results[3,10]=103
+  test_results[3,10]=0
   # test 4
   test_results[4,1]=0
   test_results[4,2]=0
@@ -153,7 +153,7 @@ cvmfs_run_test() {
   test_results[4,7]=0
   test_results[4,8]=0
   test_results[4,9]=0
-  test_results[4,10]=103
+  test_results[4,10]=0
 
   # check publish statistics
   for i in `seq 1 $CVMFS_TEST_659_NR_OF_TESTS`;

--- a/test/src/660-store_publish_statistics/main
+++ b/test/src/660-store_publish_statistics/main
@@ -192,7 +192,7 @@ cvmfs_run_test() {
   test_results[3,7]=0
   test_results[3,8]=65
   test_results[3,9]=0
-  test_results[3,10]=103
+  test_results[3,10]=0
   # test 4
   test_results[4,1]=0
   test_results[4,2]=0
@@ -203,7 +203,7 @@ cvmfs_run_test() {
   test_results[4,7]=0
   test_results[4,8]=0
   test_results[4,9]=0
-  test_results[4,10]=103
+  test_results[4,10]=0
 
 
   # check publish statistics


### PR DESCRIPTION
I noticed that I was counting uploaded_bytes for duplicated files too, so I fixed it:

In `StreamedUpload()` I was using the `bytes_written` variable, but I couldn't tell if those bytes were actually duplicated or not.
In `FinalizeStreamedUpload()` function I can count only the real uploaded bytes, but I have to use a system call - `stat`.

I need to make this change for [#2180](https://github.com/cvmfs/cvmfs/pull/2180)'s integration tests.