### PR TITLE
Added a case for large files ('P' suffix)

### DIFF
--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -228,6 +228,7 @@ struct Digest {
   }
 
   bool HasSuffix() const { return suffix != kSuffixNone; }
+  Suffix GetSuffix() const { return suffix; }
   void set_suffix(const Suffix s) { suffix = s; }
 
   /**

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -228,7 +228,6 @@ struct Digest {
   }
 
   bool HasSuffix() const { return suffix != kSuffixNone; }
-  Suffix GetSuffix() const { return suffix; }
   void set_suffix(const Suffix s) { suffix = s; }
 
   /**

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -167,7 +167,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
     }
-    if (!content_hash.HasSuffix()) {  // count only data, not metadata
+    if (!content_hash.HasSuffix() || content_hash.GetSuffix() == 'P') {
       CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
     }
   } else {

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -167,7 +167,8 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
     }
-    if (!content_hash.HasSuffix() || content_hash.GetSuffix() == 'P') {
+    if (!content_hash.HasSuffix()
+        || content_hash.suffix == shash::kSuffixPartial) {
       CountUploadedBytes(GetFileSize(upstream_path_ + "/" + final_path));
     }
   } else {


### PR DESCRIPTION
Count uploaded_bytes for large files splitted into smaller pieces with 'P' suffix.