### PR TITLE
Fix T_SuidUtil on Mac

### DIFF
--- a/test/unittests/t_suid_util.cc
+++ b/test/unittests/t_suid_util.cc
@@ -33,9 +33,9 @@ TEST(T_SuidUtil, PathExists) {
 
 
 TEST(T_SuidUtil, ResolvePath) {
-  EXPECT_EQ("/etc", ResolvePath("/etc"));
-  EXPECT_EQ("/etc", ResolvePath("/etc/"));
-  EXPECT_EQ("/etc", ResolvePath("/etc/../etc/./"));
+  EXPECT_EQ("/usr", ResolvePath("/usr"));
+  EXPECT_EQ("/usr", ResolvePath("/usr/"));
+  EXPECT_EQ("/usr", ResolvePath("/usr/../usr/./"));
 }
 
 


### PR DESCRIPTION
Using `/usr` for testing `ResolvePath`, since `/etc` is a symlink to `/private/etc` on macOS