### PR TITLE
Disable integration test 539 on Fedora

### DIFF
--- a/test/cloud_testing/platforms/fedora_test.sh
+++ b/test/cloud_testing/platforms/fedora_test.sh
@@ -31,6 +31,7 @@ echo "running CernVM-FS server test cases..."
 CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
 ./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                               -x src/518-hardlinkstresstest                   \
+                                 src/539-symlinkedvarspoolcvmfs               \
                                  src/600-securecvmfs                          \
                                  --                                           \
                                  src/5*                                       \


### PR DESCRIPTION
Disable the integration test involving a symlinked `/var/spool/cvmfs` directory on Fedora.