### PR TITLE
Add option to create catalog during ingestion.

### DIFF
--- a/cvmfs/catalog_balancer.h
+++ b/cvmfs/catalog_balancer.h
@@ -41,6 +41,17 @@ namespace catalog {
  *
  * c) The number of entries of the catalog is lesser than min_weight_: the
  * catalog gets merged with its father (except the root catalog, obviously).
+ *
+ * Notes: Originally the CatalogBalancer class had only a single function,
+ * Balance, then it is been necessary to expose also the function
+ * AddCatalogMarker.
+ * One of the biggest risk, when working with any kind of interface is to,
+ * eventually, make them too wide, and having too wide interfaces is as good
+ * as not having interfaces at all.
+ * This is what is happening in this class.
+ * From a pragmatic point of view I believe that we are still striking a good
+ * --not ideal-- balance, but if it will ever be necessary to expose another
+ * function, then it may be worth to re-factor the whole class.
  */
 template <class CatalogMgrT>
 class CatalogBalancer {
@@ -77,6 +88,12 @@ class CatalogBalancer {
    * in the WritableCatalogManager
    */
   void Balance(catalog_t *catalog);
+
+  /**
+   * This function is necessary to programmatically add catalogs inside the
+   * repository, please refer to the Notes above
+   */
+  void AddCatalogMarker(std::string path);
 
  private:
  /**
@@ -128,7 +145,6 @@ class CatalogBalancer {
   typedef typename CatalogBalancer<CatalogMgrT>::VirtualNode virtual_node_t;
 
   void PartitionOptimally(VirtualNode *virtual_node);
-  void AddCatalogMarker(std::string path);
   DirectoryEntryBase MakeEmptyDirectoryEntryBase(std::string name,
                                                  uid_t uid,
                                                  gid_t gid);
@@ -143,4 +159,3 @@ class CatalogBalancer {
 #include "catalog_balancer_impl.h"
 
 #endif  // CVMFS_CATALOG_BALANCER_H_
-

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -18,6 +18,7 @@ cvmfs_server_ingest() {
   local tar_file=""
   local to_delete="" # directories or file to delete before the extraction
   local name="" #repository name
+  local create_catalog=false
 
   local force_native=0
   local force_external=0
@@ -38,6 +39,9 @@ cvmfs_server_ingest() {
         else
           to_delete=$to_delete:$2
         fi
+        ;;
+      -c | --catalog )
+        create_catalog=true
         ;;
     esac
     shift
@@ -196,6 +200,10 @@ cvmfs_server_ingest() {
 
   if [ ! x"$to_delete" = "x" ]; then
     ingest_command="$ingest_command -D $to_delete"
+  fi
+
+  if [ "$create_catalog" = true ]; then
+    ingest_command="$ingest_command -C true"
   fi
 
   if [ "x$CVMFS_PRINT_STATISTICS" = "xtrue" ]; then

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "catalog_balancer.h"
 #include "catalog_virtual.h"
 #include "logging.h"
 #include "manifest.h"
@@ -63,10 +64,6 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   if (args.find('Z') != args.end()) {
     params.compression_alg =
         zlib::ParseCompressionAlgorithm(*args.find('Z')->second);
-  }
-
-  if (args.find('C') != args.end()) {
-    printf("\n\n Create new catalog \n\n");
   }
 
   params.nested_kcatalog_limit = SyncParameters::kDefaultNestedKcatalogLimit;
@@ -158,6 +155,12 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
     return 4;
   }
 
+  if (args.find('C') != args.end()) {
+    if (*args.find('C')->second == "true") {
+      mediator.AddCatalog(params.base_directory);
+    }
+  }
+
   sync->Traverse();
 
   if (!params.authz_file.empty()) {
@@ -191,7 +194,6 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
     PrintError("something went wrong during sync");
     return 5;
   }
-
   // finalize the spooler
   LogCvmfs(kLogCvmfs, kLogStdout, "Wait for all uploads to finish");
   params.spooler->WaitForUpload();

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -65,6 +65,10 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
         zlib::ParseCompressionAlgorithm(*args.find('Z')->second);
   }
 
+  if (args.find('C') != args.end()) {
+    printf("\n\n Create new catalog \n\n");
+  }
+
   params.nested_kcatalog_limit = SyncParameters::kDefaultNestedKcatalogLimit;
   params.root_kcatalog_limit = SyncParameters::kDefaultRootKcatalogLimit;
   params.file_mbyte_limit = SyncParameters::kDefaultFileMbyteLimit;

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -35,6 +35,8 @@ class Ingest : public Command {
         'B', "base directory where to extract the tarfile"));
     r.push_back(Parameter::Optional(
         'D', "entity to delete before to extract the tar"));
+    r.push_back(Parameter::Optional(
+        'C', "create a new catalog where the tar file is extracted"));
 
     return r;
   }

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -86,6 +86,17 @@ class AbstractSyncMediator {
   virtual void EnterDirectory(SharedPtr<SyncItem> entry) = 0;
   virtual void LeaveDirectory(SharedPtr<SyncItem> entry) = 0;
 
+  /* This function allow to programmatically add a catalog in the respository
+   * even if there is not a .cvmfscatalog file.
+   * It is a different route than adding the catalogs placing the .cvmfscatalog
+   * file inside the repository and should only be used when we need to
+   * programmatically add catalogs, it is been introduced for adding catalogs
+   * during the ingestion of tar files, we cannot expect the tar files to have
+   * a .cvmfscatalog inside, but on the other hand, those tar can contains a
+   * lot of files, especially if we consider docker images.
+   */
+  virtual void AddCatalog(const std::string location) = 0;
+
   virtual bool Commit(manifest::Manifest *manifest) = 0;
 
   virtual bool IsExternalData() const = 0;
@@ -127,6 +138,8 @@ class SyncMediator : public virtual AbstractSyncMediator {
 
   void EnterDirectory(SharedPtr<SyncItem> entry);
   void LeaveDirectory(SharedPtr<SyncItem> entry);
+
+  void AddCatalog(const std::string path);
 
   bool Commit(manifest::Manifest *manifest);
 
@@ -271,6 +284,11 @@ class SyncMediator : public virtual AbstractSyncMediator {
    */
   XattrList default_xattrs;
   UniquePtr<Counters> counters_;
+
+  /**
+   * This set will contains the path of (sub-)catalog to add to the repository.
+   */
+  std::set<std::string> catalog_to_add_;
 };  // class SyncMediator
 
 }  // namespace publish

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -68,7 +68,7 @@ cvmfs_run_test() {
   produce_tarball $tarfile
 
   echo "*** ingesting the tarball in the directory $dir"
-  cvmfs_server ingest --base_dir $dir --tar_file $tarfile $CVMFS_TEST_REPO || return $?
+  cvmfs_server ingest --catalog --base_dir $dir --tar_file $tarfile $CVMFS_TEST_REPO || return $?
 
   echo "*** check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -221,6 +221,8 @@ cvmfs_run_test() {
     echo "*** Found also blockdevice $blockdevice"
   fi
 
+  echo "*** Checking that we have create a new catalog in the base dir"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir" || return 18
 
   return 0
 }

--- a/test/unittests/mock/m_sync_mediator.h
+++ b/test/unittests/mock/m_sync_mediator.h
@@ -41,6 +41,7 @@ class MockSyncMediator : public AbstractSyncMediator {
   MOCK_METHOD1(AddUnmaterializedDirectory, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(EnterDirectory, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(LeaveDirectory, void(SharedPtr<SyncItem> entry));
+  MOCK_METHOD1(AddCatalog, void(const std::string location));
   MOCK_METHOD1(Commit, bool(manifest::Manifest *manifest));
   MOCK_CONST_METHOD0(IsExternalData, bool());
   MOCK_CONST_METHOD0(GetCompressionAlgorithm, zlib::Algorithms());


### PR DESCRIPTION
This pull request add a flag (-c, short for --catalog) that allow to
automagically add a (sub-)catalog when ingesting a tar file.
The catalog is added in the base dir, where the tar is "uncompressed".

I am not so sure about this implementation.
It is not a very clean design, we borrow a method from a nice interface
(AddCatalogMarker from CatalogBalancer), similarly when we are actually
adding the catalog (in SyncMediator::Commit) we are basically repeating
what is happening inside the CatalogBalancer.

However I believe that the implementation is quite reasonable and strike
a balance between functionality added and extremelly clean design.