### PR TITLE
X509 Authentication Fixes

### DIFF
--- a/cvmfs/authz/authz_curl.cc
+++ b/cvmfs/authz/authz_curl.cc
@@ -315,7 +315,7 @@ void AuthzAttachment::ReleaseCurlHandle(CURL *curl_handle, void *info_data) {
     delete token;
 
   } else if (token->type == kTokenX509) {
-    sslctx_info *p = static_cast<sslctx_info *>(info_data);
+    sslctx_info *p = static_cast<sslctx_info *>(token->data);
     STACK_OF(X509) *chain = p->chain;
     EVP_PKEY *pkey = p->pkey;
     p->chain = NULL;


### PR DESCRIPTION
This PR fixes a segfault introduced by @djw8605 in the SciTokens patch - the wrong `void*` was being cast to an `sslctx_info` pointer.

Additionally, I took the opportunity to free up X509 data structures as soon as we hand them off to OpenSSL.