### PR TITLE
Improve syslog messages for HTTP failures.

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1245,12 +1245,18 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     case CURLE_COULDNT_RESOLVE_HOST:
       info->error_code = kFailHostResolve;
       break;
-    case CURLE_COULDNT_CONNECT:
     case CURLE_OPERATION_TIMEDOUT:
+      info->error_code = (info->proxy == "DIRECT") ?
+                         kFailHostTooSlow : kFailProxyTooSlow;
+      break;
     case CURLE_PARTIAL_FILE:
     case CURLE_GOT_NOTHING:
     case CURLE_RECV_ERROR:
+      info->error_code = (info->proxy == "DIRECT") ?
+                         kFailHostShortTransfer : kFailProxyShortTransfer;
+      break;
     case CURLE_FILE_COULDNT_READ_FILE:
+    case CURLE_COULDNT_CONNECT:
       if (info->proxy != "DIRECT")
         // This is a guess.  Fail-over can still change to switching host
         info->error_code = kFailProxyConnection;

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -50,6 +50,10 @@ enum Failures {
   kFailTooBig,
   kFailOther,
   kFailUnsupportedProtocol,
+  kFailProxyTooSlow,
+  kFailHostTooSlow,
+  kFailProxyShortTransfer,
+  kFailHostShortTransfer,
 
   kFailNumEntries
 };  // Failures
@@ -71,7 +75,11 @@ inline const char *Code2Ascii(const Failures error) {
   texts[11] = "resource too big to download";
   texts[12] = "unknown network error";
   texts[13] = "Unsupported URL in protocol";
-  texts[14] = "no text";
+  texts[14] = "proxy serving data too slowly";
+  texts[15] = "host serving data too slowly";
+  texts[16] = "proxy data transfer cut short";
+  texts[17] = "host data transfer cut short";
+  texts[18] = "no text";
   return texts[error];
 }
 


### PR DESCRIPTION
This splits the source of "host connection error" into three:

1.  Actual connection errors to the host.
2.  Timeouts from the download.
3.  Host responds with insufficient data.

This should hopefully improve our ability to debug failures; the tweaked log messages were immensely useful for figuring out some issues with the LIGO repository.