### PR TITLE
Script for submitting publisher statistics to a Carbon server

### DIFF
--- a/python/send_stats_to_graphite.py
+++ b/python/send_stats_to_graphite.py
@@ -10,27 +10,31 @@ import sys
 import time
 from calendar import timegm
 
+
 def get_data_publish_stats(last_timestamp, db_file):
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
 
     # order DESC by id ---> first element of the list has the last start_time
-    c.execute('SELECT start_time, files_added, files_removed, files_changed, duplicated_files, directories_added, \
-                      directories_removed, directories_changed, sz_bytes_added, sz_bytes_removed, sz_bytes_uploaded \
+    c.execute('SELECT start_time, files_added, files_removed, files_changed, \
+                    duplicated_files, directories_added, directories_removed, \
+                    directories_changed, sz_bytes_added, sz_bytes_removed, \
+                    sz_bytes_uploaded \
                 FROM publish_statistics \
                 WHERE start_time > ("%s") \
                 ORDER BY publish_id DESC' % last_timestamp)
-    return c.fetchall() 
+    return c.fetchall()
 
 
 def get_data_gc_stats(last_timestamp, db_file):
     conn = sqlite3.connect(db_file)
     c = conn.cursor()
-    c.execute('SELECT start_time, n_preserved_catalogs, n_condemned_catalogs, n_condemned_objects, sz_condemned_bytes \
+    c.execute('SELECT start_time, n_preserved_catalogs, n_condemned_catalogs,\
+                    n_condemned_objects, sz_condemned_bytes \
                 FROM gc_statistics \
                 WHERE start_time > ("%s") \
-                ORDER BY gc_id DESC' % last_timestamp )
-    return c.fetchall() 
+                ORDER BY gc_id DESC' % last_timestamp)
+    return c.fetchall()
 
 
 def run(sock, db_file):
@@ -40,21 +44,23 @@ def run(sock, db_file):
     # the following file must have two timestamps (one per line):
     # last_start_time_sent_for_publish_statistics
     # last_start_time_sent_for_gc_statistics
-    f=open("aux.txt", "r+") # todo: change path to `/var/spool/cvmfs/<REPO>/last_timestamp_sent`
+
+    # todo: change path to `/var/spool/cvmfs/<REPO>/last_timestamp_sent`
+    f = open("aux.txt", "r+")
 
     # read first two lines
-    publish_timestamp = f.readline()[:-1] # delete the newline character
+    publish_timestamp = f.readline()[:-1]  # delete the newline character
     gc_timestamp = f.readline()
-    
-    f.truncate() # delete file content
-    f.seek(0)    # move file cursor
+
+    f.truncate()  # delete file content
+    f.seek(0)     # move file cursor
 
     publish_stats = get_data_publish_stats(publish_timestamp, db_file)
     gc_stats = get_data_gc_stats(gc_timestamp, db_file)
 
     if len(publish_stats) > 0:
         publish_timestamp = publish_stats[0][0]
-        for x in xrange(0,len(publish_stats)):
+        for x in xrange(0, len(publish_stats)):
             time_obj = time.strptime(publish_stats[x][0], "%Y-%m-%d %H:%M:%S")
             timestamp_epoch = timegm(time_obj)
             tuples.append(('cvmfs.publish.files_added', (timestamp_epoch, publish_stats[x][1])))
@@ -80,8 +86,8 @@ def run(sock, db_file):
             # lines.append("cvmfs.publish.sz_bytes_uploaded %s %s" % (publish_stats[x][10], publish_stats[x][0]))
 
     if len(gc_stats) > 0:
-        gc_timestamp=gc_stats[0][0]
-        for x in xrange(0,len(gc_stats)):
+        gc_timestamp = gc_stats[0][0]
+        for x in xrange(0, len(gc_stats)):
             time_obj = time.strptime(gc_stats[x][0], "%Y-%m-%d %H:%M:%S")
             timestamp_epoch = timegm(time_obj)
             tuples.append(('cvmfs.gc.n_preserved_catalogs', (timestamp_epoch, gc_stats[x][1])))
@@ -93,7 +99,7 @@ def run(sock, db_file):
             # lines.append("cvmfs.gc.n_condemned_catalogs %s %s" % (gc_stats[x][2], gc_stats[x][0]))
             # lines.append("cvmfs.gc.n_condemned_objects %s %s" % (gc_stats[x][3], gc_stats[x][0]))
             # lines.append("cvmfs.gc.sz_condemned_bytes %s %s" % (gc_stats[x][3], gc_stats[x][0]))
-    
+
     # #just for DBG
     # message = '\n'.join(lines) + '\n' #all lines must end in a newline
     # print("sending message")
@@ -107,9 +113,10 @@ def run(sock, db_file):
     sock.sendall(package)
 
     # write the last finished_time into a file
-    f.write(publish_timestamp + "\n") # write puclish_statistics last finished_timestamp
-    f.write(gc_timestamp) # write gc_statistics last finished_timestamp
+    f.write(publish_timestamp + "\n")  # write last publish start_time
+    f.write(gc_timestamp)              # write last gc start_time
     f.close()
+
 
 def main():
     parser = argparse.ArgumentParser(description='Send stats to carbon server using pickle.')
@@ -121,16 +128,16 @@ def main():
                         help='carbon pickle port')
 
     args = parser.parse_args()
-    db_file=args.db_file
+    db_file = args.db_file
     CARBON_SERVER_IP = args.CARBON_SERVER_IP
     CARBON_PICKLE_PORT = args.CARBON_PICKLE_PORT
 
     # connect to graphite
     sock = socket.socket()
     try:
-        sock.connect( (CARBON_SERVER_IP, CARBON_PICKLE_PORT) )
+        sock.connect((CARBON_SERVER_IP, CARBON_PICKLE_PORT))
     except socket.error:
-        raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % { 'server':CARBON_SERVER_IP, 'port':CARBON_PICKLE_PORT })
+        raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % {'server': CARBON_SERVER_IP, 'port': CARBON_PICKLE_PORT})
 
     # send new stats to carbon server if available
     try:
@@ -138,6 +145,7 @@ def main():
     except KeyboardInterrupt:
         sys.stderr.write("\nExiting on CTRL-c\n")
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/send_stats_to_graphite.py
+++ b/send_stats_to_graphite.py
@@ -43,7 +43,7 @@ def run(sock, db_file):
     # the following file must have two timestamps (one per line):
     # last_start_time_sent_for_publish_statistics
     # last_start_time_sent_for_gc_statistics
-    f=open("aux.txt", "r+") # todo: change path
+    f=open("aux.txt", "r+") # todo: change path to `/var/spool/cvmfs/<REPO>/last_timestamp_sent`
 
     # read first two lines
     publish_timestamp = f.readline()[:-1] # delete the newline character

--- a/send_stats_to_graphite.py
+++ b/send_stats_to_graphite.py
@@ -1,11 +1,5 @@
 #!/usr/bin/python
 
-# usage:
-# python example-pickle-client.py [<NR_SECONDS_FOR_DELAY>]
-# the stats.db SQLite local file should be in the same directory
-
-# this is script is made to run continuously, at NR_SECONDS_FOR_DELAY interval (default 10s)
-
 import argparse
 import pickle
 import re
@@ -16,13 +10,11 @@ import sys
 import time
 from calendar import timegm
 
-
-
 def get_data_publish_stats(last_timestamp):
     # check in server.conf if CVMFS_STATISTICS_DB variable is set
     conn = sqlite3.connect('stats.db') # change path
     c = conn.cursor()
-    print "Last publish submitted:" + last_timestamp
+
     # order DESC by id ---> first element of the list has the last start_time
     c.execute('SELECT start_time, files_added, files_removed, files_changed \
                 FROM publish_statistics \
@@ -35,8 +27,6 @@ def get_data_gc_stats(last_timestamp):
     # check in server.conf if CVMFS_STATISTICS_DB variable is set
     conn = sqlite3.connect('stats.db') # change path
     c = conn.cursor()
-
-    print "Last gc submitted:" + last_timestamp
 
     # order DESC by id ---> first element of the list has the last start_time
     c.execute('SELECT start_time, n_preserved_catalogs, n_condemned_catalogs, n_condemned_objects, sz_condemned_bytes \
@@ -53,62 +43,59 @@ def run(sock):
     # the following file must have two timestamps (one per line):
     # last_start_time_sent_for_publish_statistics
     # last_start_time_sent_for_gc_statistics
-    
     f=open("aux.txt", "r+") # todo: change path
 
     # read first two lines
     publish_timestamp = f.readline()[:-1] # delete the newline character
     gc_timestamp = f.readline()
     
-    
     f.truncate() # delete file content
     f.seek(0)    # move file cursor
 
-    print publish_timestamp
-    print gc_timestamp
+    # # for debug
+    # print publish_timestamp
+    # print gc_timestamp
 
     publish_stats = get_data_publish_stats(publish_timestamp)
     gc_stats = get_data_gc_stats(gc_timestamp)
-    print "length stats publish=%d " % len(publish_stats)
-    print "length   stats    gc=%d " % len(gc_stats)
+
+    # # for debug
+    # print "length stats publish=%d " % len(publish_stats)
+    # print "length   stats    gc=%d " % len(gc_stats)
 
     if len(publish_stats) > 0:
         publish_timestamp = publish_stats[0][0]
         for x in xrange(0,len(publish_stats)):
-            print "x = %d" % x
-            print publish_stats[x][0]
             time_obj = time.strptime(publish_stats[x][0], "%Y-%m-%d %H:%M:%S")
             timestamp_epoch = timegm(time_obj)
             tuples.append(('cvmfs.publish.files_added', (timestamp_epoch, publish_stats[x][1])))
             tuples.append(('cvmfs.publish.files_removed', (timestamp_epoch, publish_stats[x][2])))
             tuples.append(('cvmfs.publish.files_changed', (timestamp_epoch, publish_stats[x][3])))
-            #just for DBG
-            lines.append("cvmfs.publish.files_added %s %s" % (publish_stats[x][1], publish_stats[x][0]))
-            lines.append("cvmfs.publish.files_removed %s %s" % (publish_stats[x][2], publish_stats[x][0]))
-            lines.append("cvmfs.publish.files_changed %s %s" % (publish_stats[x][3], publish_stats[x][0]))
+            # #just for DBG
+            # lines.append("cvmfs.publish.files_added %s %s" % (publish_stats[x][1], publish_stats[x][0]))
+            # lines.append("cvmfs.publish.files_removed %s %s" % (publish_stats[x][2], publish_stats[x][0]))
+            # lines.append("cvmfs.publish.files_changed %s %s" % (publish_stats[x][3], publish_stats[x][0]))
 
     if len(gc_stats) > 0:
         gc_timestamp=gc_stats[0][0]
         for x in xrange(0,len(gc_stats)):
-            print "x = %d" % x
-            print gc_stats[x][0]
             time_obj = time.strptime(gc_stats[x][0], "%Y-%m-%d %H:%M:%S")
             timestamp_epoch = timegm(time_obj)
             tuples.append(('cvmfs.gc.n_preserved_catalogs', (timestamp_epoch, gc_stats[x][1])))
             tuples.append(('cvmfs.gc.n_condemned_catalogs', (timestamp_epoch, gc_stats[x][2])))
             tuples.append(('cvmfs.gc.n_condemned_objects', (timestamp_epoch, gc_stats[x][3])))
             tuples.append(('cvmfs.gc.sz_condemned_bytes', (timestamp_epoch, gc_stats[x][4])))
-            #just for DBG
-            lines.append("cvmfs.gc.n_preserved_catalogs %s %s" % (gc_stats[x][1], gc_stats[x][0]))
-            lines.append("cvmfs.gc.n_condemned_catalogs %s %s" % (gc_stats[x][2], gc_stats[x][0]))
-            lines.append("cvmfs.gc.n_condemned_objects %s %s" % (gc_stats[x][3], gc_stats[x][0]))
-            lines.append("cvmfs.gc.sz_condemned_bytes %s %s" % (gc_stats[x][3], gc_stats[x][0]))
+            # #just for DBG
+            # lines.append("cvmfs.gc.n_preserved_catalogs %s %s" % (gc_stats[x][1], gc_stats[x][0]))
+            # lines.append("cvmfs.gc.n_condemned_catalogs %s %s" % (gc_stats[x][2], gc_stats[x][0]))
+            # lines.append("cvmfs.gc.n_condemned_objects %s %s" % (gc_stats[x][3], gc_stats[x][0]))
+            # lines.append("cvmfs.gc.sz_condemned_bytes %s %s" % (gc_stats[x][3], gc_stats[x][0]))
     
-    #just for DBG
-    message = '\n'.join(lines) + '\n' #all lines must end in a newline
-    print("sending message")
-    print('-' * 80)
-    print(message)
+    # #just for DBG
+    # message = '\n'.join(lines) + '\n' #all lines must end in a newline
+    # print("sending message")
+    # print('-' * 80)
+    # print(message)
 
     # build the package
     package = pickle.dumps(tuples, 1)
@@ -139,7 +126,7 @@ def main():
     except socket.error:
         raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % { 'server':CARBON_SERVER_IP, 'port':CARBON_PICKLE_PORT })
 
-    # send data
+    # send new stats to carbon server if available
     try:
         run(sock)
     except KeyboardInterrupt:

--- a/send_stats_to_graphite.py
+++ b/send_stats_to_graphite.py
@@ -6,19 +6,15 @@
 
 # this is script is made to run continuously, at NR_SECONDS_FOR_DELAY interval (default 10s)
 
-
-import re
-import sys
-import time
-import socket
+import argparse
 import pickle
+import re
+import socket
 import struct
 import sqlite3
+import sys
+import time
 from calendar import timegm
-
-CARBON_SERVER = '127.0.0.1'
-CARBON_PICKLE_PORT = 2004
-DELAY = 10
 
 def get_data_publish_stats():
     # check in server.conf if CVMFS_STATISTICS_DB variable is set
@@ -26,7 +22,7 @@ def get_data_publish_stats():
     c = conn.cursor()
 
     c.execute('SELECT finished_time, files_added, files_removed, files_changed FROM publish_statistics ORDER BY publish_id DESC')
-    return c.fetchmany(100)
+    return c.fetchmany(10)
 
 
 def get_data_gc_stats():
@@ -39,57 +35,57 @@ def get_data_gc_stats():
     return c.fetchmany(10)
 
 
-def run(sock, delay):
-    while True:
-        tuples = ([])
-        lines = []
+def run(sock):
+    tuples = ([])
+    lines = []
 
-        data = get_data_publish_stats()
+    data = get_data_publish_stats()
 
-        # do this for the last 10 entries? # I will change this
-        for x in xrange(1,100):
-            time_obj = time.strptime(data[x][0], "%Y-%m-%d %H:%M:%S")
-            timestamp_epoch = timegm(time_obj)
-            tuples.append(('cvmfs.publish.files_added', (timestamp_epoch, data[x][1])))
-            tuples.append(('cvmfs.publish.files_removed', (timestamp_epoch, data[x][2])))
-            tuples.append(('cvmfs.publish.files_changed', (timestamp_epoch, data[x][3])))
-            #just for DBG
-            lines.append("cvmfs.publish.files_added %s %s" % (data[x][1], data[x][0]))
-            lines.append("cvmfs.publish.files_removed %s %s" % (data[x][2], data[x][0]))
-            lines.append("cvmfs.publish.files_changed %s %s" % (data[x][3], data[x][0]))
-        
+    # do this for the last 10 entries? # I will change this
+    for x in xrange(1,10):
+        time_obj = time.strptime(data[x][0], "%Y-%m-%d %H:%M:%S")
+        timestamp_epoch = timegm(time_obj)
+        tuples.append(('cvmfs.publish.files_added', (timestamp_epoch, data[x][1])))
+        tuples.append(('cvmfs.publish.files_removed', (timestamp_epoch, data[x][2])))
+        tuples.append(('cvmfs.publish.files_changed', (timestamp_epoch, data[x][3])))
         #just for DBG
-        message = '\n'.join(lines) + '\n' #all lines must end in a newline
-        print("sending message")
-        print('-' * 80)
-        print(message)
+        lines.append("cvmfs.publish.files_added %s %s" % (data[x][1], data[x][0]))
+        lines.append("cvmfs.publish.files_removed %s %s" % (data[x][2], data[x][0]))
+        lines.append("cvmfs.publish.files_changed %s %s" % (data[x][3], data[x][0]))
+    
+    #just for DBG
+    message = '\n'.join(lines) + '\n' #all lines must end in a newline
+    print("sending message")
+    print('-' * 80)
+    print(message)
 
-        # build the package
-        package = pickle.dumps(tuples, 1)
-        size = struct.pack('!L', len(package))
-        sock.sendall(size)
-        sock.sendall(package)
-        # wait delay seconds and than take another measure
-        time.sleep(delay)
+    # build the package
+    package = pickle.dumps(tuples, 1)
+    size = struct.pack('!L', len(package))
+    sock.sendall(size)
+    sock.sendall(package)
 
 def main():
-    delay = DELAY
-    if len(sys.argv) > 1:
-        arg = sys.argv[1]
-        if arg.isdigit():
-            delay = int(arg)
-        else:
-            sys.stderr.write("Ignoring non-integer argument. Using default: %ss\n" % delay)
+    parser = argparse.ArgumentParser(description='Send stats to carbon server using pickle.')
+    parser.add_argument('CARBON_SERVER_IP', metavar='<IP>', type=str,
+                        help='carbon server ip')
+    parser.add_argument('CARBON_PICKLE_PORT', metavar='<PORT>', type=int,
+                        help='carbon pickle port')
+
+    args = parser.parse_args()
+    CARBON_SERVER_IP = args.CARBON_SERVER_IP
+    CARBON_PICKLE_PORT = args.CARBON_PICKLE_PORT
+
     # connect to graphite
     sock = socket.socket()
     try:
-        sock.connect( (CARBON_SERVER, CARBON_PICKLE_PORT) )
+        sock.connect( (CARBON_SERVER_IP, CARBON_PICKLE_PORT) )
     except socket.error:
-        raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % { 'server':CARBON_SERVER, 'port':CARBON_PICKLE_PORT })
+        raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % { 'server':CARBON_SERVER_IP, 'port':CARBON_PICKLE_PORT })
 
     # send data continuously
     try:
-        run(sock, delay)
+        run(sock)
     except KeyboardInterrupt:
         sys.stderr.write("\nExiting on CTRL-c\n")
         sys.exit(0)

--- a/send_stats_to_graphite.py
+++ b/send_stats_to_graphite.py
@@ -16,6 +16,8 @@ import sys
 import time
 from calendar import timegm
 
+
+
 def get_data_publish_stats():
     # check in server.conf if CVMFS_STATISTICS_DB variable is set
     conn = sqlite3.connect('stats.db') # change path
@@ -40,9 +42,12 @@ def run(sock):
     lines = []
 
     data = get_data_publish_stats()
+    f=open("info.txt","w+") # todo: change path
 
     # do this for the last 10 entries? # I will change this
-    for x in xrange(1,10):
+    for x in xrange(0,9):
+        print x
+        print data[x][0]
         time_obj = time.strptime(data[x][0], "%Y-%m-%d %H:%M:%S")
         timestamp_epoch = timegm(time_obj)
         tuples.append(('cvmfs.publish.files_added', (timestamp_epoch, data[x][1])))
@@ -65,6 +70,10 @@ def run(sock):
     sock.sendall(size)
     sock.sendall(package)
 
+    # write the last finished_time into a file
+    f.write(data[0][0]+"\n") # write puclish_statistics last finished_timestamp
+    f.write("alt timestamp\n") # write gc_statistics last finished_timestamp
+
 def main():
     parser = argparse.ArgumentParser(description='Send stats to carbon server using pickle.')
     parser.add_argument('CARBON_SERVER_IP', metavar='<IP>', type=str,
@@ -83,7 +92,7 @@ def main():
     except socket.error:
         raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % { 'server':CARBON_SERVER_IP, 'port':CARBON_PICKLE_PORT })
 
-    # send data continuously
+    # send data
     try:
         run(sock)
     except KeyboardInterrupt:

--- a/send_stats_to_graphite.py
+++ b/send_stats_to_graphite.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+# usage:
+# python example-pickle-client.py [<NR_SECONDS_FOR_DELAY>]
+# the stats.db SQLite local file should be in the same directory
+
+# this is script is made to run continuously, at NR_SECONDS_FOR_DELAY interval (default 10s)
+
+
+import re
+import sys
+import time
+import socket
+import pickle
+import struct
+import sqlite3
+from calendar import timegm
+
+CARBON_SERVER = '127.0.0.1'
+CARBON_PICKLE_PORT = 2004
+DELAY = 10
+
+def get_data_from_stats():
+    conn = sqlite3.connect('stats.db') # change path
+    c = conn.cursor()
+
+    c.execute('SELECT finished_time, files_added, files_removed, files_changed FROM publish_statistics ORDER BY publish_id DESC')
+    return c.fetchmany(10)
+
+
+
+def run(sock, delay):
+    while True:
+        tuples = ([])
+        lines = []
+
+        data = get_data_from_stats()
+
+        # do this for the last 10 entries? # I will change this
+        for x in xrange(1,10):
+            time_obj = time.strptime(data[x][0], "%Y-%m-%d %H:%M:%S")
+            timestamp_epoch = timegm(time_obj)
+            tuples.append(('cvmfs.publish.files_added', (timestamp_epoch, data[x][1])))
+            tuples.append(('cvmfs.publish.files_removed', (timestamp_epoch, data[x][2])))
+            tuples.append(('cvmfs.publish.files_changed', (timestamp_epoch, data[x][3])))
+            #just for DBG
+            lines.append("cvmfs.publish.files_added %s %s" % (data[x][1], data[x][0]))
+            lines.append("cvmfs.publish.files_removed %s %s" % (data[x][2], data[x][0]))
+            lines.append("cvmfs.publish.files_changed %s %s" % (data[x][2], data[x][0]))
+        
+        #just for DBG
+        message = '\n'.join(lines) + '\n' #all lines must end in a newline
+        print("sending message")
+        print('-' * 80)
+        print(message)
+
+        # build the package
+        package = pickle.dumps(tuples, 1)
+        size = struct.pack('!L', len(package))
+        sock.sendall(size)
+        sock.sendall(package)
+        # wait delay seconds and than take another measure
+        time.sleep(delay)
+
+def main():
+    delay = DELAY
+    if len(sys.argv) > 1:
+        arg = sys.argv[1]
+        if arg.isdigit():
+            delay = int(arg)
+        else:
+            sys.stderr.write("Ignoring non-integer argument. Using default: %ss\n" % delay)
+    # connect to graphite
+    sock = socket.socket()
+    try:
+        sock.connect( (CARBON_SERVER, CARBON_PICKLE_PORT) )
+    except socket.error:
+        raise SystemExit("Couldn't connect to %(server)s on port %(port)d, is graphite running in a docker environment?" % { 'server':CARBON_SERVER, 'port':CARBON_PICKLE_PORT })
+
+    # send data continuously
+    try:
+        run(sock, delay)
+    except KeyboardInterrupt:
+        sys.stderr.write("\nExiting on CTRL-c\n")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Addresses [CVM-1571](https://sft.its.cern.ch/jira/browse/CVM-1571).

This script sends stats to a carbon server ([graphite](https://graphiteapp.org/)) using the [pickle protocol](https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-pickle-protocol) .

Usage: `send_stats_to_graphite.py [-h] <db_file> <carbon_server_IP> <carbon_server_PORT>`

This script uses  `last_timestamp_sent` file to send only the new stats data form the `db_file`.
Format of the `last_timestamp_sent` file:
- First line: last start_time sent for publish_statistics table
- Second line: last start_time sent for gc_statistics table

If the `last_timestamp_sent` file does not exist in the same directory as `db_file`, this script will create one and it will write the current UTC timestamp in the it.
