### PR TITLE
Add option to create catalog during ingestion using a fake file

### DIFF
--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -18,6 +18,7 @@ cvmfs_server_ingest() {
   local tar_file=""
   local to_delete="" # directories or file to delete before the extraction
   local name="" #repository name
+  local create_catalog=false
 
   local force_native=0
   local force_external=0
@@ -38,6 +39,9 @@ cvmfs_server_ingest() {
         else
           to_delete=$to_delete:$2
         fi
+        ;;
+      -c | --catalog )
+        create_catalog=true
         ;;
     esac
     shift
@@ -196,6 +200,10 @@ cvmfs_server_ingest() {
 
   if [ ! x"$to_delete" = "x" ]; then
     ingest_command="$ingest_command -D $to_delete"
+  fi
+
+  if [ "$create_catalog" = true ]; then
+    ingest_command="$ingest_command -C true"
   fi
 
   if [ "x$CVMFS_PRINT_STATISTICS" = "xtrue" ]; then

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -65,6 +65,10 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
         zlib::ParseCompressionAlgorithm(*args.find('Z')->second);
   }
 
+  if (args.find('C') != args.end()) {
+    printf("\n\n Create new catalog \n\n");
+  }
+
   params.nested_kcatalog_limit = SyncParameters::kDefaultNestedKcatalogLimit;
   params.root_kcatalog_limit = SyncParameters::kDefaultRootKcatalogLimit;
   params.file_mbyte_limit = SyncParameters::kDefaultFileMbyteLimit;

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -65,9 +65,7 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
         zlib::ParseCompressionAlgorithm(*args.find('Z')->second);
   }
 
-  if (args.find('C') != args.end()) {
-    printf("\n\n Create new catalog \n\n");
-  }
+  bool create_catalog = args.find('C') != args.end();
 
   params.nested_kcatalog_limit = SyncParameters::kDefaultNestedKcatalogLimit;
   params.root_kcatalog_limit = SyncParameters::kDefaultRootKcatalogLimit;
@@ -150,7 +148,7 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
 
   sync = new publish::SyncUnionTarball(&mediator, params.dir_rdonly,
                                        params.tar_file, params.base_directory,
-                                       params.to_delete);
+                                       params.to_delete, create_catalog);
   if (!sync->Initialize()) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "Initialization of the synchronisation "

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -35,6 +35,8 @@ class Ingest : public Command {
         'B', "base directory where to extract the tarfile"));
     r.push_back(Parameter::Optional(
         'D', "entity to delete before to extract the tar"));
+    r.push_back(Parameter::Optional(
+        'C', "create a new catalog where the tar file is extracted"));
 
     return r;
   }

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -175,6 +175,8 @@ void SyncUnionTarball::Traverse() {
           archive_entry_set_pathname(catalog, root.c_str());
           archive_entry_set_filetype(catalog, AE_IFREG);
           ProcessArchiveEntry(catalog);
+          // The ProcessArchiveEntry does call Wakeup on the signal, in this
+          // particular corner case we need to re-wait for it.
           read_archive_signal_->Wait();
         }
         first_iteration = false;

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -175,6 +175,7 @@ void SyncUnionTarball::Traverse() {
           archive_entry_set_pathname(catalog, root.c_str());
           archive_entry_set_filetype(catalog, AE_IFREG);
           ProcessArchiveEntry(catalog);
+          archive_entry_free(catalog);
           // The ProcessArchiveEntry does call Wakeup on the signal, in this
           // particular corner case we need to re-wait for it.
           read_archive_signal_->Wait();

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -32,14 +32,15 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
                                    const std::string &rdonly_path,
                                    const std::string &tarball_path,
                                    const std::string &base_directory,
-                                   const std::string &to_delete)
+                                   const std::string &to_delete,
+                                   const bool create_catalog_on_root)
     : SyncUnion(mediator, rdonly_path, "", ""),
       src(NULL),
       tarball_path_(tarball_path),
       base_directory_(base_directory),
       to_delete_(to_delete),
-      read_archive_signal_(new Signal) {
-}
+      create_catalog_on_root_(create_catalog_on_root),
+      read_archive_signal_(new Signal) {}
 
 SyncUnionTarball::~SyncUnionTarball() { delete read_archive_signal_; }
 
@@ -86,6 +87,13 @@ bool SyncUnionTarball::Initialize() {
  * not reading data anymore from there.
  * This whole process is not necessary for directories since we don't
  * actually need to read data from them.
+ *
+ * It may be needed to add a catalog as a root of the archive.
+ * A possible way to do it is by creating an virtual `.cvmfscatalog` file and
+ * push it into the usual pipeline.
+ * This operation must be done only once, and it seems like a good idea to do
+ * it at the first iteration of the loop, hence this logic is managed by the
+ * `first_iteration` boolean flag.
  */
 void SyncUnionTarball::Traverse() {
   read_archive_signal_->Wakeup();
@@ -112,6 +120,7 @@ void SyncUnionTarball::Traverse() {
   // we are simplying deleting entity from  the repo
   if (NULL == src) return;
 
+  bool first_iteration = true;
   struct archive_entry *entry = archive_entry_new();
   while (true) {
     // Get the lock, wait if lock is not available yet
@@ -158,6 +167,18 @@ void SyncUnionTarball::Traverse() {
       }
 
       case ARCHIVE_OK: {
+        if (first_iteration && create_catalog_on_root_) {
+          std::string root =
+              GetRoot(std::string(archive_entry_pathname(entry)));
+          root = root + "/.cvmfscatalog";
+          struct archive_entry *catalog = archive_entry_clone(entry);
+          archive_entry_set_pathname(catalog, root.c_str());
+          archive_entry_set_filetype(catalog, AE_IFREG);
+          ProcessArchiveEntry(catalog);
+          read_archive_signal_->Wait();
+        }
+        first_iteration = false;
+
         ProcessArchiveEntry(entry);
         break;
       }
@@ -263,6 +284,20 @@ std::string SyncUnionTarball::SanitizePath(const std::string &path) {
     }
   }
   return path;
+}
+
+std::string SyncUnionTarball::GetRoot(const std::string &path) {
+  assert("" != path);
+  // it is called iterator since it "iterate" from directory to direrctory
+  std::string path_iterator = path;
+  std::string dir;
+  std::string filename;
+  do {
+    SplitPath(path_iterator, &dir, &filename);
+    path_iterator = dir;
+  } while ("." != dir);
+
+  return filename;
 }
 
 void SyncUnionTarball::PostUpload() {

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -107,13 +107,6 @@ class SyncUnionTarball : public SyncUnion {
   void CreateDirectories(const std::string &target);
   void ProcessArchiveEntry(struct archive_entry *entry);
   std::string SanitizePath(const std::string &path);
-  /**
-   * GetRoot returns the root of a path, it panics if the input is empty,
-   * Given "" => panic
-   * Given "/foo" => "foo"
-   * Given "/a/b/c/" => "a"
-   */
-  std::string GetRoot(const std::string &path);
 };  // class SyncUnionTarball
 
 }  // namespace publish

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -31,7 +31,8 @@ class SyncUnionTarball : public SyncUnion {
                    const std::string &rdonly_path,
                    const std::string &tarball_path,
                    const std::string &base_directory,
-                   const std::string &to_delete);
+                   const std::string &to_delete,
+                   const bool create_catalog_on_root);
 
   ~SyncUnionTarball();
 
@@ -63,6 +64,7 @@ class SyncUnionTarball : public SyncUnion {
   const std::string tarball_path_;
   const std::string base_directory_;
   const std::string to_delete_;  ///< entity to delete before to extract the tar
+  const bool create_catalog_on_root_;
   std::set<std::string>
       know_directories_;  ///< directory that we know already exist
 
@@ -105,6 +107,13 @@ class SyncUnionTarball : public SyncUnion {
   void CreateDirectories(const std::string &target);
   void ProcessArchiveEntry(struct archive_entry *entry);
   std::string SanitizePath(const std::string &path);
+  /**
+   * GetRoot returns the root of a path, it panics if the input is empty,
+   * Given "" => panic
+   * Given "/foo" => "foo"
+   * Given "/a/b/c/" => "a"
+   */
+  std::string GetRoot(const std::string &path);
 };  // class SyncUnionTarball
 
 }  // namespace publish

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -68,7 +68,7 @@ cvmfs_run_test() {
   produce_tarball $tarfile
 
   echo "*** ingesting the tarball in the directory $dir"
-  cvmfs_server ingest --base_dir $dir --tar_file $tarfile $CVMFS_TEST_REPO || return $?
+  cvmfs_server ingest --catalog --base_dir $dir --tar_file $tarfile $CVMFS_TEST_REPO || return $?
 
   echo "*** check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
@@ -221,6 +221,8 @@ cvmfs_run_test() {
     echo "*** Found also blockdevice $blockdevice"
   fi
 
+  echo "*** Checking that we have create a new catalog in the base dir"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir" || return 18
 
   return 0
 }

--- a/test/unittests/t_sync_union_tarball.cc
+++ b/test/unittests/t_sync_union_tarball.cc
@@ -67,7 +67,7 @@ class T_SyncUnionTarball : public ::testing::Test {
 TEST_F(T_SyncUnionTarball, Init) {
   std::string tar_filename = CreateTarFile("tar.tar", simple_tar);
   publish::SyncUnionTarball sync_union(m_sync_mediator_, "", tar_filename,
-                                       "/tmp/lala", "");
+                                       "/tmp/lala", "", false);
 
   EXPECT_CALL(*m_sync_mediator_, RegisterUnionEngine(_)).Times(1);
   EXPECT_TRUE(sync_union.Initialize());


### PR DESCRIPTION
Following the discussion on https://github.com/cvmfs/cvmfs/pull/2215 here is another implementation.

It use a fake file `$tarball_root/.cvmfscatalog` that is piped into the regular process.

 