### PR TITLE
Add CMake option to enable AddressSanitizer

### DIFF
--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -83,6 +83,10 @@ if (BUILD_COVERAGE AND NOT USING_CLANG)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage -fPIC")
 endif (BUILD_COVERAGE AND NOT USING_CLANG)
 
+if (ENABLE_ASAN)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+endif (ENABLE_ASAN)
+
 # Check for old Linux version that don't have a complete inotify implementation
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   try_compile(HAS_INOTIFY_INIT1 ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/check_inotify_init1.c)

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -23,6 +23,9 @@ option (BUILD_QC_TESTS          "Build the QuickCheck property random tests"    
 option (BUILD_DOCUMENTATION     "Build the CerVM-FS documentation using Doxygen"                   OFF)
 option (BUILD_COVERAGE          "Compile to collect code coverage reports"                         OFF)
 option (BUILD_ALL               "Build client, server, lib, preload, octopus, unit tests"          OFF)
+
+option (ENABLE_ASAN             "Enable the Address Sanitizer"                                     OFF)
+
 option (INSTALL_UNITTESTS       "Install the unit test binary (mainly for packaging)"              OFF)
 option (INSTALL_UNITTESTS_DEBUG "Install the unit test debug binary"                               OFF)
 option (INSTALL_MOUNT_SCRIPTS   "Install CernVM-FS mount tools in /etc and /sbin (/usr/bin)"       ON)

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -45,26 +45,20 @@ bool CreateNewTag(const RepositoryTag& repo_tag, const std::string& repo_name,
                   const std::string& manifest_path,
                   const std::string& public_key_path) {
   swissknife::ArgumentList args;
-  args['r'] = new std::string(params.spooler_configuration);
-  args['w'] = new std::string(params.stratum0);
-  args['t'] = new std::string(temp_dir);
-  args['m'] = new std::string(manifest_path);
-  args['p'] = new std::string(public_key_path);
-  args['f'] = new std::string(repo_name);
-  args['e'] = new std::string(params.hash_alg_str);
-  args['a'] = new std::string(repo_tag.name_);
-  args['c'] = new std::string(repo_tag.channel_);
-  args['D'] = new std::string(repo_tag.description_);
-  args['x'] = NULL;
+  args['r'].Reset(new std::string(params.spooler_configuration));
+  args['w'].Reset(new std::string(params.stratum0));
+  args['t'].Reset(new std::string(temp_dir));
+  args['m'].Reset(new std::string(manifest_path));
+  args['p'].Reset(new std::string(public_key_path));
+  args['f'].Reset(new std::string(repo_name));
+  args['e'].Reset(new std::string(params.hash_alg_str));
+  args['a'].Reset(new std::string(repo_tag.name_));
+  args['c'].Reset(new std::string(repo_tag.channel_));
+  args['D'].Reset(new std::string(repo_tag.description_));
 
   UniquePtr<swissknife::CommandEditTag> edit_cmd(
       new swissknife::CommandEditTag());
   const int ret = edit_cmd->Main(args);
-
-  for (swissknife::ArgumentList::iterator it = args.begin(); it != args.end();
-       ++it) {
-    delete it->second;
-  }
 
   if (ret) {
     LogCvmfs(kLogReceiver, kLogSyslogErr, "Error %d creating tag: %s", ret,

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -38,11 +38,10 @@ bool ReadCmdLineArguments(int argc, char** argv,
     for (unsigned j = 0; j < params.size(); ++j) {
       if (c == params[j].key()) {
         valid_option = true;
-        std::string* argument = NULL;
+        (*arguments)[c].Reset();
         if (!params[j].switch_only()) {
-          argument = new std::string(optarg);
+          (*arguments)[c].Reset(new std::string(optarg));
         }
-        (*arguments)[c] = argument;
         break;
       }
     }

--- a/cvmfs/swissknife.h
+++ b/cvmfs/swissknife.h
@@ -16,6 +16,7 @@
 #include "server_tool.h"
 #include "signature.h"
 #include "statistics.h"
+#include "util/shared_ptr.h"
 
 namespace download {
 class DownloadManager;
@@ -68,7 +69,7 @@ class Parameter {
 };
 
 typedef std::vector<Parameter> ParameterList;
-typedef std::map<char, std::string *> ArgumentList;
+typedef std::map<char, SharedPtr<std::string> > ArgumentList;
 
 class Command : public ServerTool {
  public:

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -152,11 +152,10 @@ int main(int argc, char **argv) {
       if (c == params[j].key()) {
         assert(c != swissknife::Command::kGenericParam);
         valid_option = true;
-        string *argument = NULL;
+        args[c].Reset();
         if (!params[j].switch_only()) {
-          argument = new string(optarg);
+          args[c].Reset(new string(optarg));
         }
-        args[c] = argument;
         break;
       }
     }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -37,6 +37,7 @@
 #include "smalloc.h"
 #include "upload.h"
 #include "util/posix.h"
+#include "util/shared_ptr.h"
 #include "util/string.h"
 
 using namespace std;  // NOLINT
@@ -94,9 +95,9 @@ static void SpoolerOnUpload(const upload::SpoolerResult &result) {
   }
 }
 
-string              *stratum0_url = NULL;
-string              *stratum1_url = NULL;
-string              *temp_dir = NULL;
+SharedPtr<string>    stratum0_url;
+SharedPtr<string>    stratum1_url;
+SharedPtr<string>    temp_dir;
 unsigned             num_parallel = 1;
 bool                 pull_history = false;
 bool                 apply_timestamp_threshold = false;


### PR DESCRIPTION
* Adds a new CMake option `ENABLE_ASAN`
* Fixes a memory leak in `cvmfs_swissknife` parameter handling. This memory leak was reported by ASAN, but is benign, as `cvmfs_swissknife` commands are not long running.