### PR TITLE
Fix cache control headers for S3 backend

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 2.5.2:
+  * Fix cache control headers for objects pushed to S3 (CVM-1606)
   * Fix building on macOS 10.14
   * Fix potential memory corruption in catalog traversal
   * Reimplement cvmfs_talk in C++ to improve efficiency

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -20,6 +20,10 @@ using namespace std;  // NOLINT
 
 namespace s3fanout {
 
+const char *S3FanoutManager::kCacheControlData =
+  "Cache-Control: max-age=259200";
+const char *S3FanoutManager::kCacheControlMutable = "Cache-Control: max-age=61";
+
 /**
  * Called by curl for every HTTP header. Not called for file:// transfers.
  */
@@ -836,9 +840,11 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
     }
 
     if (info->request == JobInfo::kReqPutNoCache) {
-      std::string cache_control = "Cache-Control: no-cache";
       info->http_headers =
-          curl_slist_append(info->http_headers, cache_control.c_str());
+          curl_slist_append(info->http_headers, kCacheControlMutable);
+    } else {
+      info->http_headers =
+          curl_slist_append(info->http_headers, kCacheControlData);
     }
   }
 

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -234,6 +234,10 @@ class S3FanoutManager : SingleCopy {
   bool DoSingleJob(JobInfo *info) const;
 
  private:
+  // Reflects the default Apache configuration of the local backend
+  static const char *kCacheControlData;  // Cache-Control: max-age=259200
+  static const char *kCacheControlMutable;  // Cache-Control: max-age=61
+
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);
   static void *MainUpload(void *data);

--- a/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
@@ -59,6 +59,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/600-securecvmfs                          \
                                src/605-resurrectancientcatalog              \
                                src/607-noapache                             \
+                               src/608-infofile                             \
                                src/609-metainfofile                         \
                                src/610-altpath                              \
                                src/614-geoservice                           \

--- a/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
@@ -63,7 +63,6 @@ if [ $s3_retval -eq 0 ]; then
                                src/610-altpath                              \
                                src/614-geoservice                           \
                                src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
                                --                                           \
                                src/5*                                       \
                                src/6*                                       \

--- a/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
@@ -94,6 +94,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/600-securecvmfs                          \
                                src/605-resurrectancientcatalog              \
                                src/607-noapache                             \
+                               src/608-infofile                             \
                                src/609-metainfofile                         \
                                src/610-altpath                              \
                                src/614-geoservice                           \

--- a/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
@@ -98,7 +98,6 @@ if [ $s3_retval -eq 0 ]; then
                                src/610-altpath                              \
                                src/614-geoservice                           \
                                src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
                                --                                           \
                                src/5*                                       \
                                src/6*                                       \

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -79,6 +79,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/600-securecvmfs                          \
                                src/605-resurrectancientcatalog              \
                                src/607-noapache                             \
+                               src/608-infofile                             \
                                src/609-metainfofile                         \
                                src/610-altpath                              \
                                src/614-geoservice                           \

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -83,7 +83,6 @@ if [ $s3_retval -eq 0 ]; then
                                src/610-altpath                              \
                                src/614-geoservice                           \
                                src/622-gracefulrmfs                         \
-                               src/626-cacheexpiry                          \
                                --                                           \
                                src/5*                                       \
                                src/6*                                       \

--- a/test/src/608-infofile/main
+++ b/test/src/608-infofile/main
@@ -81,15 +81,12 @@ cvmfs_run_test() {
   ! repo_is_registered $CVMFS_TEST_REPO                || return 11
   replica_is_registered $CVMFS_TEST_REPO $replica_name || return 12
 
-  # TODO(jblomer) re-enable after CVM-980 (see also below)
-  if ! running_on_s3; then
-    echo "import $CVMFS_TEST_REPO again"
-    import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 13
+  echo "import $CVMFS_TEST_REPO again"
+  import_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 13
 
-    echo "check that both $CVMFS_TEST_REPO and $replica_name are registered"
-    repo_is_registered $CVMFS_TEST_REPO                  || return 14
-    replica_is_registered $CVMFS_TEST_REPO $replica_name || return 15
-  fi
+  echo "check that both $CVMFS_TEST_REPO and $replica_name are registered"
+  repo_is_registered $CVMFS_TEST_REPO                  || return 14
+  replica_is_registered $CVMFS_TEST_REPO $replica_name || return 15
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -98,7 +95,7 @@ cvmfs_run_test() {
   CVMFS_TEST_608_REPLICA_NAME=""
 
   echo "check that $CVMFS_TEST_REPO is registerd but $replica_name is gone"
-  running_on_s3 || repo_is_registered $CVMFS_TEST_REPO   || return 17
+  repo_is_registered $CVMFS_TEST_REPO   || return 17
   ! replica_is_registered $CVMFS_TEST_REPO $replica_name || return 18
 
   return 0


### PR DESCRIPTION
Actively set the cache-control header for immutable content-addressed objects under data to 3 days (previously: no setting) and for the .cvmfs... files to 61 seconds to avoid running into the Squid bug where "no cache" objects are cached forever.