### PR TITLE
Fix gateway integration tests with S3 backend

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -2413,8 +2413,7 @@ EOF'
     echo "  Modifying test repo configuration"
     local repo_server_config=/etc/cvmfs/repositories.d/test.repo.org/server.conf
     local original_upstream=$(grep CVMFS_UPSTREAM_STORAGE $repo_server_config | cut -d'=' -f2-)
-    sudo sed -i -e 's/local,/gw,/' $repo_server_config
-    sudo sed -i -e 's/txn,\/srv\/cvmfs\/test.repo.org/txn,http:\/\/localhost:4929\/api\/v1/g' $repo_server_config
+    sudo bash -c "echo CVMFS_UPSTREAM_STORAGE=gw,/srv/cvmfs/test.repo.org/txn,http://localhost:4929/api/v1 >> $repo_server_config"
     sudo bash -c "echo TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE=$original_upstream >> $repo_server_config"
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 


### PR DESCRIPTION
This fixes a configuration error in the gateway integration tests with S3 backend: the CVMFS server tools were not configured with the gateway upstream address, but directly the S3 backend.

Most tests were finishing correctly, except the ones which involve acquiring a lease on a repository subpath. Trying to write files outside of this subpath should fail when a gateway is mediating the transaction, but succeeds when publishing directly to the backend, which doesn't have the concept of lease.