### PR TITLE
Implement retry support for "cvmfs_server transaction"

### DIFF
--- a/cvmfs/server/cvmfs_server_transaction.sh
+++ b/cvmfs/server/cvmfs_server_transaction.sh
@@ -22,7 +22,7 @@ cvmfs_server_transaction() {
   local retry=0
   local init_retry_delay=5 # seconds
   local max_retry_delay=300 # seconds
-  local num_retries=50
+  local num_retries=100
 
   # optional parameter handling
   OPTIND=1

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1079,7 +1079,11 @@ Supported Commands:
                   [-r repair reflog problems]
                   <fully qualified name>
                   Checks if the repository is sane
-  transaction     <fully qualified name>
+  transaction     [-r (retry if unable to acquire lease]
+                  [-i INT (initial retry delay seconds)]
+                  [-m INT (max retry delay seconds)]
+                  [-n INT (max number of retries)]
+                  <fully qualified name>
                   Start to edit a repository
   snapshot        [-t fail if other snapshot is in progress]
                   <fully qualified name>


### PR DESCRIPTION
Addresses [CVM-1611](https://sft.its.cern.ch/jira/browse/CVM-1611).

Allow setting the initial and max retry delays, and the maximum
number of retries.

The retry loop starts with the initial delay and doubles it at each
retry, until the max delay is reached.