### PR TITLE
Simplify the use of cvmfs_server {abort,publish} with repository gateway

### DIFF
--- a/cvmfs/server/cvmfs_server_abort.sh
+++ b/cvmfs/server/cvmfs_server_abort.sh
@@ -38,8 +38,8 @@ cvmfs_server_abort() {
 
   for name in $names; do
 
-    # Check if the repo name contains a subpath for locking, e.g. repo.cern.ch/sub/path/for/locking
-    local subpath=$(echo $name | cut -d'/' -f2- -s)
+    # Ignore any subpath appended to the repository e.g. repo.cern.ch/sub/path/for/locking
+    # Providing a subpath for the "cvmfs_server abort" command is no longer needed.
     name=$(echo $name | cut -d'/' -f1)
 
     # sanity checks
@@ -86,7 +86,7 @@ cvmfs_server_abort() {
     # the cvmfs_swissknife lease command needs to be used to drop the active lease
     if [ x"$upstream_type" = xgw ]; then
         local repo_services_url=$(echo $upstream_storage | cut -d',' -f3)
-        __swissknife lease -a drop -u $repo_services_url -k $gw_key_file -p $name"/"$subpath || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; }
+        __swissknife lease -a drop -u $repo_services_url -k $gw_key_file -p $name || { echo "Could not drop active lease or lease does not exist for repository $name"; retcode=1; }
     fi
     close_transaction $name $use_fd_fallback
 

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -83,8 +83,8 @@ cvmfs_server_publish() {
       check_tag_existence $name "$tag_name" && die "Tag name '$tag_name' is already in use."
     fi
 
-    # Check if the repo name contains a subpath for locking, e.g. repo.cern.ch/sub/path/for/locking
-    local subpath=$(echo $name | cut -d'/' -f2- -s)
+    # Ignore any subpath appended to the repository e.g. repo.cern.ch/sub/path/for/locking
+    # Providing a subpath for the "cvmfs_server publish" command is no longer needed.
     name=$(echo $name | cut -d'/' -f1)
 
     load_repo_config $name
@@ -210,12 +210,11 @@ cvmfs_server_publish() {
       sync_command="$sync_command -J $tag_description"
     fi
 
-    # If the upstream type is "gw", we need to pass additional parameters
-    # to the `cvmfs_swissknife sync` command: the username and the
-    # subpath of the active lease
+    # If the upstream type is "gw", we need to additionally pass
+    # the names of the file containing the gateway key and of the
+    # one containing the session token
     if [ x"$upstream_type" = xgw ]; then
-      local session_token_file="/var/spool/cvmfs/$name/session_token_$(echo $subpath | sed -e "s:/:_:g")"
-      sync_command="$sync_command -P ${session_token_file} -H $gw_key_file"
+      sync_command="$sync_command -H $gw_key_file -P ${spool_dir}/session_token"
     fi
     if [ "x$CVMFS_UNION_FS_TYPE" != "x" ]; then
       sync_command="$sync_command -f $CVMFS_UNION_FS_TYPE"

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -61,11 +61,6 @@ int CommandLease::Main(const ArgumentList& args) {
   std::vector<std::string> tokens = SplitString(params.lease_path, '/');
   const std::string lease_fqdn = tokens.front();
 
-  // Remove the fqdn from the list of tokens and join them with "_" to make the
-  // token file suffix
-  tokens.erase(tokens.begin());
-  params.token_file_suffix = JoinStrings(tokens, "_");
-
   if (!CheckParams(params)) {
     return kLeaseParamError;
   }
@@ -93,9 +88,9 @@ int CommandLease::Main(const ArgumentList& args) {
         // Save session token to
         // /var/spool/cvmfs/<REPO_NAME>/session_token_<SUBPATH>
         // TODO(radu): Is there a special way to access the scratch directory?
-        const std::string token_file_name = "/var/spool/cvmfs/" + lease_fqdn +
-                                            "/session_token_" +
-                                            params.token_file_suffix;
+        const std::string token_file_name =
+            "/var/spool/cvmfs/" + lease_fqdn + "/session_token";
+
         if (!SafeWriteToFile(session_token, token_file_name, 0600)) {
           LogCvmfs(kLogCvmfs, kLogStderr, "Error opening file: %s",
                    std::strerror(errno));
@@ -110,8 +105,8 @@ int CommandLease::Main(const ArgumentList& args) {
   } else if (params.action == "drop") {
     // Try to read session token from repository scratch directory
     std::string session_token;
-    std::string token_file_name = "/var/spool/cvmfs/" + lease_fqdn +
-                                  "/session_token_" + params.token_file_suffix;
+    std::string token_file_name =
+        "/var/spool/cvmfs/" + lease_fqdn + "/session_token";
     FILE* token_file = std::fopen(token_file_name.c_str(), "r");
     if (token_file) {
       GetLineFile(token_file, &session_token);

--- a/cvmfs/swissknife_lease.h
+++ b/cvmfs/swissknife_lease.h
@@ -32,7 +32,6 @@ class CommandLease : public Command {
     std::string action;
     std::string key_file;
     std::string lease_path;
-    std::string token_file_suffix;
   };
 };
 

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -140,7 +140,7 @@ run_transactions() {
     echo "New file" > /cvmfs/test.repo.org/new/c/another_file.txt
 
     echo "  Publishing changes 6"
-    cvmfs_server publish test.repo.org/new/c
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"
@@ -153,7 +153,7 @@ run_transactions() {
     echo "New file" > /cvmfs/test.repo.org/new/invalid_file.txt
 
     echo "  Publishing changes 7"
-    cvmfs_server publish test.repo.org/new/c
+    cvmfs_server publish test.repo.org
     cvmfs_server check test.repo.org
 
     echo "  Copy the contents of the repository"


### PR DESCRIPTION
Addresses [CVM-1601](https://sft.its.cern.ACch/jira/browse/CVM-1601).

In the presence of a repository gateway, the lease subpath
(i.e. repo.cern.ch/some/path/to/lock) only needs to be given to the
cvmfs_server transaction command. The abort and publish commands
can find and use the session token of the current lease.

This PR allows the following workflow:
```
$ cvmfs_server transaction repo.cern.ch/some/path
$ cvmfs_server publish repo.cern.ch
or
$ cvmfs_server abort repo.cern.ch
```
As per the existing convention, if there is a single repository configured on the machine, even the repository name can be omitted.