### PR TITLE
Refactored version checks between gateway and release manager

### DIFF
--- a/cvmfs/gateway_util.cc
+++ b/cvmfs/gateway_util.cc
@@ -11,7 +11,7 @@
 
 namespace gateway {
 
-int APIVersion() { return 1; }
+int APIVersion() { return 2; }
 
 bool ReadKeys(const std::string& key_file_name, std::string* key_id,
               std::string* secret) {

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -10,14 +10,14 @@
 
 #include "logging.h"
 
-bool ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
+LeaseReply ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
   if (buffer.data.size() == 0 || session_token == NULL) {
-    return false;
+    return kLeaseReplyFailure;
   }
 
   const UniquePtr<JsonDocument> reply(JsonDocument::Create(buffer.data));
   if (!reply || !reply->IsValid()) {
-    return false;
+    return kLeaseReplyFailure;
   }
 
   const JSON *result =
@@ -25,45 +25,46 @@ bool ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
   if (result != NULL) {
     const std::string status = result->string_value;
     if (status == "ok") {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
+      LogCvmfs(kLogCvmfs, kLogStdout, "Gateway reply: ok");
       const JSON *token = JsonDocument::SearchInObject(
           reply->root(), "session_token", JSON_STRING);
       if (token != NULL) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Session token: %s",
+        LogCvmfs(kLogCvmfs, kLogDebug, "Session token: %s",
                  token->string_value);
         *session_token = token->string_value;
-        return true;
+        return kLeaseReplySuccess;
       }
     } else if (status == "path_busy") {
       const JSON *time_remaining = JsonDocument::SearchInObject(
           reply->root(), "time_remaining", JSON_INT);
       if (time_remaining != NULL) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Path busy. Time remaining = %d",
+        LogCvmfs(kLogCvmfs, kLogStdout, "Path busy. Time remaining = %d",
                  time_remaining->int_value);
+        return kLeaseReplyBusy;
       }
     } else if (status == "error") {
       const JSON *reason =
           JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
       if (reason != NULL) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+        LogCvmfs(kLogCvmfs, kLogStdout, "Error: %s", reason->string_value);
       }
     } else {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s",
+      LogCvmfs(kLogCvmfs, kLogStdout, "Unknown reply. Status: %s",
                status.c_str());
     }
   }
 
-  return false;
+  return kLeaseReplyFailure;
 }
 
-bool ParseDropReply(const CurlBuffer &buffer) {
+LeaseReply ParseDropReply(const CurlBuffer &buffer) {
   if (buffer.data.size() == 0) {
-    return false;
+    return kLeaseReplyFailure;
   }
 
   const UniquePtr<const JsonDocument> reply(JsonDocument::Create(buffer.data));
   if (!reply || !reply->IsValid()) {
-    return false;
+    return kLeaseReplyFailure;
   }
 
   const JSON *result =
@@ -71,21 +72,21 @@ bool ParseDropReply(const CurlBuffer &buffer) {
   if (result != NULL) {
     const std::string status = result->string_value;
     if (status == "ok") {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Status: ok");
-      return true;
+      LogCvmfs(kLogCvmfs, kLogStdout, "Gateway reply: ok");
+      return kLeaseReplySuccess;
     } else if (status == "invalid_token") {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Error: invalid session token");
+      LogCvmfs(kLogCvmfs, kLogStdout, "Error: invalid session token");
     } else if (status == "error") {
       const JSON *reason =
           JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
       if (reason != NULL) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Error: %s", reason->string_value);
+        LogCvmfs(kLogCvmfs, kLogStdout, "Error: %s", reason->string_value);
       }
     } else {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Unknown reply. Status: %s",
+      LogCvmfs(kLogCvmfs, kLogStdout, "Unknown reply. Status: %s",
                status.c_str());
     }
   }
 
-  return false;
+  return kLeaseReplyFailure;
 }

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -10,7 +10,8 @@
 
 #include "logging.h"
 
-LeaseReply ParseAcquireReply(const CurlBuffer &buffer, std::string *session_token) {
+LeaseReply ParseAcquireReply(const CurlBuffer &buffer,
+                             std::string *session_token) {
   if (buffer.data.size() == 0 || session_token == NULL) {
     return kLeaseReplyFailure;
   }

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -15,7 +15,8 @@ enum LeaseReply {
   kLeaseReplyFailure
 };
 
-LeaseReply ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token);
+LeaseReply ParseAcquireReply(const CurlBuffer& buffer,
+                             std::string* session_token);
 LeaseReply ParseDropReply(const CurlBuffer& buffer);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_JSON_H_

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -9,7 +9,13 @@
 
 #include <string>
 
-bool ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token);
-bool ParseDropReply(const CurlBuffer& buffer);
+enum LeaseReply {
+  kLeaseReplySuccess,
+  kLeaseReplyBusy,
+  kLeaseReplyFailure
+};
+
+LeaseReply ParseAcquireReply(const CurlBuffer& buffer, std::string* session_token);
+LeaseReply ParseDropReply(const CurlBuffer& buffer);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_JSON_H_

--- a/test/unittests/t_swissknife_lease.cc
+++ b/test/unittests/t_swissknife_lease.cc
@@ -17,58 +17,58 @@ class T_SwissknifeLeaseJson : public ::testing::Test {
 
 TEST_F(T_SwissknifeLeaseJson, ParseAcquireOk) {
   buffer_.data = "{ \"status\" : \"ok\", \"session_token\" : \"ABCD\"}";
-  EXPECT_TRUE(ParseAcquireReply(buffer_, &session_token_));
+  EXPECT_EQ(kLeaseReplySuccess, ParseAcquireReply(buffer_, &session_token_));
   EXPECT_EQ(session_token_, "ABCD");
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseAcquireBusy) {
   buffer_.data =
-      "{ \"status\" : \"path_busy\", \"time_remaining\" : \"1234\" }";
-  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+      "{ \"status\" : \"path_busy\", \"time_remaining\" : 1234 }";
+  EXPECT_EQ(kLeaseReplyBusy, ParseAcquireReply(buffer_, &session_token_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseAcquireError) {
   buffer_.data =
       "{ \"status\" : \"error\", \"reason\" : \"reason_for_failure\" }";
-  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseAcquireReply(buffer_, &session_token_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseAcquireInvalidReply) {
   buffer_.data = "-----------------------------";
-  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseAcquireReply(buffer_, &session_token_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseAcquireNullPtr) {
-  EXPECT_FALSE(ParseAcquireReply(buffer_, NULL));
+  EXPECT_EQ(kLeaseReplyFailure, ParseAcquireReply(buffer_, NULL));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseAcquireEmptyReply) {
   buffer_.data.clear();
-  EXPECT_FALSE(ParseAcquireReply(buffer_, &session_token_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseAcquireReply(buffer_, &session_token_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseDropOk) {
   buffer_.data = "{ \"status\" : \"ok\" }";
-  EXPECT_TRUE(ParseDropReply(buffer_));
+  EXPECT_EQ(kLeaseReplySuccess, ParseDropReply(buffer_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseDropInvalidSessionToken) {
   buffer_.data = "{ \"status\" : \"invalid_token\" }";
-  EXPECT_FALSE(ParseDropReply(buffer_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseDropReply(buffer_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseDropError) {
   buffer_.data =
       "{ \"status\" : \"error\", \"reason\" : \"reason_for_failure\" }";
-  EXPECT_FALSE(ParseDropReply(buffer_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseDropReply(buffer_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseDropInvalidReply) {
   buffer_.data = "-----------------------------";
-  EXPECT_FALSE(ParseDropReply(buffer_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseDropReply(buffer_));
 }
 
 TEST_F(T_SwissknifeLeaseJson, ParseDropEmptyReply) {
   buffer_.data.clear();
-  EXPECT_FALSE(ParseDropReply(buffer_));
+  EXPECT_EQ(kLeaseReplyFailure, ParseDropReply(buffer_));
 }


### PR DESCRIPTION
Addresses [CVM-1626](https://sft.its.cern.ch/jira/browse/CVM-1626).

* Refactor error reporting in "cvmfs_swissknife lease".
* Bumping API version number to 2, matching the one used by cvmfs-gateway 0.3.1.