### PR TITLE
Clear authz session cache when upstream membership requirement changes

### DIFF
--- a/cvmfs/authz/authz_session.cc
+++ b/cvmfs/authz/authz_session.cc
@@ -60,6 +60,14 @@ AuthzSessionManager::~AuthzSessionManager() {
 }
 
 
+void AuthzSessionManager::ClearSessionCache() {
+  LockMutex(&lock_session2cred_);
+  session2cred_.Clear();
+  no_session_->Set(0);
+  UnlockMutex(&lock_session2cred_);
+}
+
+
 AuthzSessionManager *AuthzSessionManager::Create(
   AuthzFetcher *authz_fetcher,
   perf::Statistics *statistics)

--- a/cvmfs/authz/authz_session.h
+++ b/cvmfs/authz/authz_session.h
@@ -48,6 +48,13 @@ class AuthzSessionManager : SingleCopy {
   AuthzToken *GetTokenCopy(const pid_t pid, const std::string &membership);
   bool IsMemberOf(const pid_t pid, const std::string &membership);
 
+  /**
+   * When the membership string in the root file catalog changes, all entries in
+   * the cache become invalid because they only vouch for the previous
+   * membership entry. This function is called by MountPoint::ReEvaluateAuthz.
+   */
+  void ClearSessionCache();
+
  private:
   /**
    * Sweep caches from old entries not more often than every 5 seconds.

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1599,8 +1599,12 @@ MountPoint::~MountPoint() {
 
 
 void MountPoint::ReEvaluateAuthz() {
+  string old_membership_req = membership_req_;
   has_membership_req_ = catalog_mgr_->GetVOMSAuthz(&membership_req_);
-  authz_attachment_->set_membership(membership_req_);
+  if (old_membership_req != membership_req_) {
+    authz_session_mgr_->ClearSessionCache();
+    authz_attachment_->set_membership(membership_req_);
+  }
 }
 
 


### PR DESCRIPTION
Replaces #2263 
@DrDaveD Can you test whether this change behaves as expected?