### PR TITLE
Log to syslog when session authorization disappears

### DIFF
--- a/cvmfs/authz/authz_session.cc
+++ b/cvmfs/authz/authz_session.cc
@@ -122,7 +122,8 @@ bool AuthzSessionManager::GetPidInfo(pid_t pid, PidKey *pid_key) {
 
   FILE *fp_stat = fopen(pid_path, "r");
   if (fp_stat == NULL) {
-    LogCvmfs(kLogAuthz, kLogDebug, "Failed to open status file.");
+    LogCvmfs(kLogAuthz, kLogDebug, "Failed to open status file /proc/%d/stat: (errno=%d) %s", pid, errno, strerror(errno));
+    LogCvmfs(kLogAuthz, kLogSyslogWarn | kLogDebug, "Authorization for session %d disappeared", pid);
     return false;
   }
 
@@ -281,7 +282,7 @@ bool AuthzSessionManager::LookupSessionKey(
     return true;
   }
 
-  // Not found in cache, get session information from OS
+  LogCvmfs(kLogAuthz, kLogDebug, "Session key not found in cache, getting information from OS");
   PidKey sid_key;
   if (!GetPidInfo(pid_key->sid, &sid_key))
     return false;

--- a/cvmfs/authz/authz_session.cc
+++ b/cvmfs/authz/authz_session.cc
@@ -13,6 +13,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 #include "authz/authz_fetch.h"
@@ -122,7 +123,8 @@ bool AuthzSessionManager::GetPidInfo(pid_t pid, PidKey *pid_key) {
 
   FILE *fp_stat = fopen(pid_path, "r");
   if (fp_stat == NULL) {
-    LogCvmfs(kLogAuthz, kLogDebug, "Failed to open status file /proc/%d/stat: (errno=%d) %s", pid, errno, strerror(errno));
+    LogCvmfs(kLogAuthz, kLogDebug, "Failed to open status file /proc/%d/stat: (errno=%d) %s",
+             pid, errno, strerror(errno));
     LogCvmfs(kLogAuthz, kLogSyslogWarn | kLogDebug, "Authorization for session %d disappeared", pid);
     return false;
   }

--- a/cvmfs/authz/authz_session.cc
+++ b/cvmfs/authz/authz_session.cc
@@ -123,10 +123,10 @@ bool AuthzSessionManager::GetPidInfo(pid_t pid, PidKey *pid_key) {
 
   FILE *fp_stat = fopen(pid_path, "r");
   if (fp_stat == NULL) {
-    LogCvmfs(kLogAuthz, kLogDebug, 
+    LogCvmfs(kLogAuthz, kLogDebug,
              "Failed to open status file /proc/%d/stat: (errno=%d) %s",
              pid, errno, strerror(errno));
-    LogCvmfs(kLogAuthz, kLogSyslogWarn | kLogDebug, 
+    LogCvmfs(kLogAuthz, kLogSyslogWarn | kLogDebug,
              "Authorization for session %d disappeared", pid);
     return false;
   }
@@ -286,7 +286,7 @@ bool AuthzSessionManager::LookupSessionKey(
     return true;
   }
 
-  LogCvmfs(kLogAuthz, kLogDebug, 
+  LogCvmfs(kLogAuthz, kLogDebug,
            "Session key not found in cache, getting information from OS");
   PidKey sid_key;
   if (!GetPidInfo(pid_key->sid, &sid_key))

--- a/cvmfs/authz/authz_session.cc
+++ b/cvmfs/authz/authz_session.cc
@@ -123,9 +123,11 @@ bool AuthzSessionManager::GetPidInfo(pid_t pid, PidKey *pid_key) {
 
   FILE *fp_stat = fopen(pid_path, "r");
   if (fp_stat == NULL) {
-    LogCvmfs(kLogAuthz, kLogDebug, "Failed to open status file /proc/%d/stat: (errno=%d) %s",
+    LogCvmfs(kLogAuthz, kLogDebug, 
+             "Failed to open status file /proc/%d/stat: (errno=%d) %s",
              pid, errno, strerror(errno));
-    LogCvmfs(kLogAuthz, kLogSyslogWarn | kLogDebug, "Authorization for session %d disappeared", pid);
+    LogCvmfs(kLogAuthz, kLogSyslogWarn | kLogDebug, 
+             "Authorization for session %d disappeared", pid);
     return false;
   }
 
@@ -284,7 +286,8 @@ bool AuthzSessionManager::LookupSessionKey(
     return true;
   }
 
-  LogCvmfs(kLogAuthz, kLogDebug, "Session key not found in cache, getting information from OS");
+  LogCvmfs(kLogAuthz, kLogDebug, 
+           "Session key not found in cache, getting information from OS");
   PidKey sid_key;
   if (!GetPidInfo(pid_key->sid, &sid_key))
     return false;


### PR DESCRIPTION
See [CVM-1658](https://sft.its.cern.ch/jira/browse/CVM-1658)