### PR TITLE
Adding linguist-vendored override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+externals/* linguist-vendored


### PR DESCRIPTION
### Quality-of-life improvement for obsessive compulsives

Fixes the reported language for the repository on GitHub: previously was falsely reported as C due to the large number of C files in the `externals` dir. Explicitly marking `externals` as a directory for vendored dependencies makes the `linguist` tool properly report the project language as C++.