### PR TITLE
Enable creation of nested catalogs during ingestion

### DIFF
--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -167,7 +167,7 @@ class SyncItem {
   }
 
   virtual IngestionSource *CreateIngestionSource() const = 0;
-  virtual void IsPlaceholderDirectory() const = 0;
+  virtual void MakePlaceholderDirectory() const = 0;
   void SetCatalogMarker() { has_catalog_marker_ = true; }
 
   bool operator==(const SyncItem &other) const {
@@ -312,7 +312,7 @@ class SyncItemNative : public SyncItem {
   friend class SyncUnion;
   virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
   virtual IngestionSource *CreateIngestionSource() const;
-  virtual void IsPlaceholderDirectory() const { assert(false); }
+  virtual void MakePlaceholderDirectory() const { assert(false); }
   virtual SyncItemType GetScratchFiletype() const;
   virtual bool IsType(const SyncItemType expected_type) const;
   virtual void StatScratch(const bool refresh = false) const {

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -25,7 +25,7 @@ class SyncItemDummyDir : public SyncItemNative {
  public:
   catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
   SyncItemType GetScratchFiletype() const;
-  virtual void IsPlaceholderDirectory() const { rdonly_type_ = kItemDir; }
+  virtual void MakePlaceholderDirectory() const { rdonly_type_ = kItemDir; }
 
  protected:
   SyncItemDummyDir(const std::string &relative_parent_path,

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -25,6 +25,7 @@ class SyncItemDummyDir : public SyncItemNative {
  public:
   catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
   SyncItemType GetScratchFiletype() const;
+  virtual void IsPlaceholderDirectory() const { rdonly_type_ = kItemDir; }
 
  protected:
   SyncItemDummyDir(const std::string &relative_parent_path,

--- a/cvmfs/sync_item_tar.h
+++ b/cvmfs/sync_item_tar.h
@@ -24,7 +24,7 @@ class SyncItemTar : public SyncItem {
  public:
   virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
   virtual IngestionSource *CreateIngestionSource() const;
-  virtual void IsPlaceholderDirectory() const { rdonly_type_ = kItemDir; }
+  virtual void MakePlaceholderDirectory() const { rdonly_type_ = kItemDir; }
   virtual SyncItemType GetScratchFiletype() const;
   virtual bool IsType(const SyncItemType expected_type) const;
   virtual void StatScratch(const bool refresh = false) const;

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -153,7 +153,7 @@ void SyncUnionTarball::Traverse() {
           SharedPtr<SyncItem> to_mark = dirs_[*dir];
           assert(to_mark->IsDirectory());
           to_mark->SetCatalogMarker();
-          to_mark->IsPlaceholderDirectory();
+          to_mark->MakePlaceholderDirectory();
           ProcessDirectory(to_mark);
         }
         return;  // Only successful exit point
@@ -235,7 +235,7 @@ void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
 
   if (sync_entry->IsDirectory()) {
     if (know_directories_.find(complete_path) != know_directories_.end()) {
-      sync_entry->IsPlaceholderDirectory();
+      sync_entry->MakePlaceholderDirectory();
     }
     ProcessUnmaterializedDirectory(sync_entry);
     dirs_[complete_path] = sync_entry;

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -170,7 +170,9 @@ void SyncUnionTarball::Traverse() {
       case ARCHIVE_OK: {
         if (first_iteration && create_catalog_on_root_) {
           struct archive_entry *catalog = archive_entry_new();
-          archive_entry_set_pathname(catalog, base_directory_.c_str());
+          std::string catalog_path = ".cvmfscatalog";
+          archive_entry_set_pathname(catalog, catalog_path.c_str());
+          archive_entry_set_size(catalog, 0);
           archive_entry_set_filetype(catalog, AE_IFREG);
           archive_entry_set_perm(catalog, kDefaultFileMode);
           archive_entry_set_gid(catalog, getgid());
@@ -336,6 +338,7 @@ void SyncUnionTarball::CreateDirectories(const std::string &target) {
       new SyncItemDummyDir(dirname, filename, this, kItemDir));
 
   ProcessUnmaterializedDirectory(dummy);
+  dirs_[target] = dummy;
   know_directories_.insert(target);
 }
 

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -222,7 +222,7 @@ cvmfs_run_test() {
   fi
 
   echo "*** Checking that we have create a new catalog in the base dir"
-  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir" || return 18
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir$" || return 18
 
   return 0
 }


### PR DESCRIPTION
The first important fix is about the test.
The final `$` is necessary to tell grep to match a new line. Without it,
grep match the few catalogs that have been normally added in the test.
(The catalog under /a and /a/b)

Then we simply fix the logic, adding a new empty file called
.cvmfscatalog into the repository. Earlier it was a file called as the
base_directory where the tar is ingested.... No idea why, but the
failure of the test I believe was shadowing the error.

Finally to make everything work I had to implement a method on the
DummyDirectory. Without the implementation it would call a method in a
base class that simply assert(false), it is not bad to implement that
method for the Dummy, otherwise we would have too re-structure a lot of
code for benefits that I fail to see.

Also address: #1163