### PR TITLE
[S3] Handle HTTP 429 replies

### DIFF
--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -6,6 +6,7 @@
 
 #include <pthread.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <utility>
 

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -49,6 +49,7 @@ enum Failures {
   kFailHostConnection,
   kFailNotFound,
   kFailServiceUnavailable,
+  kFailRetry,
   kFailOther,
 
   kFailNumEntries
@@ -66,6 +67,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[6] = "S3: not found";
   texts[7] = "S3: service not available";
   texts[8] = "S3: unknown service error, perhaps wrong authentication protocol";
+  texts[8] = "S3: too many requests, service asks for backoff and retry";
   texts[9] = "no text";
   return texts[error];
 }
@@ -239,6 +241,8 @@ class S3FanoutManager : SingleCopy {
   // Reflects the default Apache configuration of the local backend
   static const char *kCacheControlCas;  // Cache-Control: max-age=259200
   static const char *kCacheControlDotCvmfs;  // Cache-Control: max-age=61
+  // 250ms pause after HTTP 429 "Too Many Retries"
+  static const unsigned kDefault429BackoffMs = 250;
 
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -79,12 +79,14 @@ struct Statistics {
   double transfer_time;
   uint64_t num_requests;
   uint64_t num_retries;
+  uint64_t ms_throttled;  // Total waiting time imposed by HTTP 429 replies
 
   Statistics() {
     transferred_bytes = 0.0;
     transfer_time = 0.0;
     num_requests = 0;
     num_retries = 0;
+    ms_throttled = 0;
   }
 
   std::string Print() const;
@@ -186,6 +188,7 @@ struct JobInfo {
     http_error = 0;
     num_retries = 0;
     backoff_ms = 0;
+    throttle_ms = 0;
     origin = kOriginPath;
   }
   ~JobInfo() {}
@@ -198,7 +201,10 @@ struct JobInfo {
   Failures error_code;
   int http_error;
   unsigned char num_retries;
+  // Exponential backoff with cutoff in case of errors
   unsigned backoff_ms;
+  // Throttle imposed by HTTP 429 reply; mutually exclusive with backoff_ms
+  unsigned throttle_ms;
 };  // JobInfo
 
 struct S3FanOutDnsEntry {
@@ -218,6 +224,15 @@ class S3FanoutManager : SingleCopy {
   typedef SynchronizingCounter<uint32_t> Semaphore;
 
  public:
+  // 250ms pause after HTTP 429 "Too Many Retries"
+  static const unsigned kDefault429ThrottleMs;
+  // Don't throttle for more than a few seconds
+  static const unsigned kMax429ThrottleMs;
+  // Report throttle operations only every so often
+  static const unsigned kThrottleReportIntervalSec;
+
+  static void DetectThrottleIndicator(const std::string &header, JobInfo *info);
+
   S3FanoutManager();
   ~S3FanoutManager();
 
@@ -241,8 +256,6 @@ class S3FanoutManager : SingleCopy {
   // Reflects the default Apache configuration of the local backend
   static const char *kCacheControlCas;  // Cache-Control: max-age=259200
   static const char *kCacheControlDotCvmfs;  // Cache-Control: max-age=61
-  // 250ms pause after HTTP 429 "Too Many Retries"
-  static const unsigned kDefault429BackoffMs = 250;
 
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);
@@ -327,6 +340,9 @@ class S3FanoutManager : SingleCopy {
   // Writes and reads should be atomic because reading happens in a different
   // thread than writing.
   Statistics *statistics_;
+
+  // Report not every occurance of throtteling but only every so often
+  uint64_t timestamp_last_throttle_report_;
 };  // S3FanoutManager
 
 }  // namespace s3fanout

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -189,6 +189,7 @@ struct JobInfo {
     num_retries = 0;
     backoff_ms = 0;
     throttle_ms = 0;
+    throttle_timestamp = 0;
     origin = kOriginPath;
   }
   ~JobInfo() {}
@@ -205,6 +206,8 @@ struct JobInfo {
   unsigned backoff_ms;
   // Throttle imposed by HTTP 429 reply; mutually exclusive with backoff_ms
   unsigned throttle_ms;
+  // Remember when the 429 reply came in to only throttle if still necessary
+  uint64_t throttle_timestamp;
 };  // JobInfo
 
 struct S3FanOutDnsEntry {

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -69,6 +69,9 @@ class S3Uploader : public AbstractUploader {
 
   virtual unsigned int GetNumberOfErrors() const;
 
+  // Only for testing
+  s3fanout::S3FanoutManager *GetS3FanoutManager() { return &s3fanout_mgr_; }
+
  private:
   static const unsigned kDefaultPort = 80;
   static const unsigned kDefaultNumParallelUploads = 16;

--- a/test/unittests/t_s3fanout.cc
+++ b/test/unittests/t_s3fanout.cc
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "duplex_ssl.h"
+#include "s3fanout.h"
 
 using namespace std;  // NOLINT
 
@@ -15,5 +16,31 @@ TEST(T_S3Fanout, Init) {
   printf("Skipping!\n");
 #else
 #endif
+}
+
+TEST(T_S3Fanout, DetectThrottleIndicator) {
+  s3fanout::JobInfo info(
+    "", "", s3fanout::kAuthzAwsV2, "", "", "", "", NULL, "");
+  info.throttle_ms = 1;
+
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("", &info);
+  EXPECT_EQ(1U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("retry-after", &info);
+  EXPECT_EQ(1U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("retry-after:", &info);
+  EXPECT_EQ(1U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("x-retry-in:", &info);
+  EXPECT_EQ(1U, info.throttle_ms);
+
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("retry-after: 1", &info);
+  EXPECT_EQ(1000U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("retry-after:5", &info);
+  EXPECT_EQ(5000U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("retry-after:42", &info);
+  EXPECT_EQ(10000U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("x-retry-in:2", &info);
+  EXPECT_EQ(2000U, info.throttle_ms);
+  s3fanout::S3FanoutManager::DetectThrottleIndicator("x-retry-in:0", &info);
+  EXPECT_EQ(2000U, info.throttle_ms);
 }
 

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -12,6 +12,7 @@
 #include "atomic.h"
 #include "c_file_sandbox.h"
 #include "hash.h"
+#include "logging.h"
 #include "testutil.h"
 #include "upload_facility.h"
 #include "upload_local.h"
@@ -629,6 +630,9 @@ TYPED_TEST_CASE(T_Uploaders, UploadTypes);
 
 //------------------------------------------------------------------------------
 
+static void LogSupress(const LogSource source, const int mask, const char *msg)
+{
+}
 
 TYPED_TEST(T_Uploaders, RetrySlow) {
   if (!TestFixture::IsS3()) {
@@ -641,6 +645,7 @@ TYPED_TEST(T_Uploaders, RetrySlow) {
 
   upload::S3Uploader *s3uploader =
     static_cast<upload::S3Uploader *>(this->uploader_);
+  SetAltLogFunc(LogSupress);
   EXPECT_EQ(0U, s3uploader->GetS3FanoutManager()->GetStatistics().num_retries);
   this->uploader_->Upload(small_file_path, dest_name,
                           AbstractUploader::MakeClosure(
@@ -648,6 +653,7 @@ TYPED_TEST(T_Uploaders, RetrySlow) {
                               &this->delegate_,
                               UploaderResults(0, small_file_path)));
   this->uploader_->WaitForUpload();
+  SetAltLogFunc(NULL);
 
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
   EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));


### PR DESCRIPTION
Throttles the S3 uploader for a maximum of 10 seconds on HTTP 429.  The default are 250ms, but if exists, the values of `retry-after` and `x-retry-in` headers are applied.  The last header wins.  Currently only supports only second values in these headers.