### PR TITLE
Added scan mode and updated stats

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -190,6 +190,7 @@ set (CVMFS_SHRINKWRAP_SOURCES
   shrinkwrap/posix/garbage_collector.cc
   shrinkwrap/posix/helpers.cc
   shrinkwrap/posix/interface.cc
+  shrinkwrap/scan/interface.cc
   shrinkwrap/shrinkwrap.cc
   shrinkwrap/spec_tree.cc
   shrinkwrap/util.cc

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -697,7 +697,7 @@ int SyncInit(
   unsigned parallel,
   int stat_period) {
   num_parallel_ = parallel;
-  if (!strcmp(dest->context_->type,"scan")) {
+  if (!strcmp(dest->context_->type, "scan")) {
     scan_ = true;
   }
   stat_update_period_ = stat_period;

--- a/cvmfs/shrinkwrap/fs_traversal.h
+++ b/cvmfs/shrinkwrap/fs_traversal.h
@@ -11,12 +11,17 @@
 #include "fs_traversal_interface.h"
 #include "statistics.h"
 
-#define SHRINKWRAP_STAT_BYTE_COUNT "byteCnt"
-#define SHRINKWRAP_STAT_FILE_COUNT "fileCnt"
-#define SHRINKWRAP_STAT_SRC_ENTRIES "srcEntries"
-#define SHRINKWRAP_STAT_DEST_ENTRIES "destEntries"
-#define SHRINKWRAP_STAT_DEDUPED_FILES "dedupedFiles"
-#define SHRINKWRAP_STAT_DEDUPED_BYTES "dedupedBytes"
+
+#define SHRINKWRAP_STAT_COUNT_FILE "cntFile"
+#define SHRINKWRAP_STAT_COUNT_DIR "cntDir"
+#define SHRINKWRAP_STAT_COUNT_SYMLINK "cntSymlink"
+#define SHRINKWRAP_STAT_COUNT_BYTE "cntByte"
+#define SHRINKWRAP_STAT_ENTRIES_SRC "entriesSrc"
+#define SHRINKWRAP_STAT_ENTRIES_DEST "entriesDest"
+#define SHRINKWRAP_STAT_DATA_FILES "dataFiles"
+#define SHRINKWRAP_STAT_DATA_BYTES "dataBytes"
+#define SHRINKWRAP_STAT_DATA_FILES_DEDUPED "dataFilesDeduped"
+#define SHRINKWRAP_STAT_DATA_BYTES_DEDUPED "dataBytesDeduped"
 
 namespace shrinkwrap {
 
@@ -27,7 +32,7 @@ int SyncInit(struct fs_traversal *src,
              const char *base,
              const char *spec,
              unsigned parallel,
-             unsigned retries);
+             int stat_period);
 
 int GarbageCollect(struct fs_traversal *fs);
 
@@ -35,7 +40,8 @@ int GarbageCollect(struct fs_traversal *fs);
 bool SyncFull(
   struct fs_traversal *src,
   struct fs_traversal *dest,
-  perf::Statistics *pstats);
+  perf::Statistics *pstats,
+  time_t last_print_time);
 
 // Exported for testing purposes:
 perf::Statistics *GetSyncStatTemplate();

--- a/cvmfs/shrinkwrap/fs_traversal_interface.h
+++ b/cvmfs/shrinkwrap/fs_traversal_interface.h
@@ -11,6 +11,7 @@
 struct fs_traversal_context {
   uint64_t version;
   uint64_t size;
+  char *type;
 
   char *repo;
   char *base;

--- a/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
+++ b/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
@@ -162,6 +162,7 @@ struct fs_traversal_context *libcvmfs_initialize(
 
   struct fs_traversal_context *result = new struct fs_traversal_context;
   result->version = 1;
+  result->type = strdup("libcvmfs");
   char* major = reinterpret_cast<char *>(smalloc(MAX_INTEGER_DIGITS));
   snprintf(major, MAX_INTEGER_DIGITS, "%d", LIBCVMFS_VERSION_MAJOR);
   char* minor = reinterpret_cast<char *>(smalloc(MAX_INTEGER_DIGITS));

--- a/cvmfs/shrinkwrap/posix/interface.cc
+++ b/cvmfs/shrinkwrap/posix/interface.cc
@@ -469,6 +469,7 @@ void *posix_get_handle(struct fs_traversal_context *ctx,
   const char *identifier) {
   struct posix_file_handle *file_ctx = new struct posix_file_handle;
   file_ctx->path = BuildHiddenPath(ctx, identifier);
+  file_ctx->fd = NULL;
 
   return file_ctx;
 }
@@ -691,6 +692,7 @@ struct fs_traversal_context *posix_initialize(
   fs_traversal_context *result = new struct fs_traversal_context;
   result->version = 1;
   result->lib_version = strdup("1.0");
+  result->type = strdup("posix");
   struct fs_traversal_posix_context *posix_ctx
     = new struct fs_traversal_posix_context;
   posix_ctx->num_threads = num_threads;

--- a/cvmfs/shrinkwrap/scan/interface.cc
+++ b/cvmfs/shrinkwrap/scan/interface.cc
@@ -6,13 +6,13 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <set>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <utime.h>
 
 #include <map>
+#include <set>
 #include <string>
 
 #include "hash.h"

--- a/cvmfs/shrinkwrap/scan/interface.cc
+++ b/cvmfs/shrinkwrap/scan/interface.cc
@@ -1,0 +1,359 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+#include "interface.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <set>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <utime.h>
+
+#include <map>
+#include <string>
+
+#include "hash.h"
+#include "libcvmfs.h"
+#include "logging.h"
+#include "shrinkwrap/fs_traversal_interface.h"
+#include "shrinkwrap/util.h"
+#include "smalloc.h"
+#include "string.h"
+#include "xattr.h"
+
+const char kDirLevels = 2;
+const char kDigitsPerDirLevel = 2;
+
+struct scan_file_handle {
+  std::string path;
+};
+
+
+/*
+ * BASIC FS OPERATIONS
+ */
+void scan_list_dir(struct fs_traversal_context *ctx, const char *dir,
+  char ***buf, size_t *len);
+
+int scan_get_stat(struct fs_traversal_context *ctx,
+  const char *path, struct cvmfs_attr *stat_result, bool get_hash);
+
+int scan_set_meta(struct fs_traversal_context *ctx,
+  const char *path, const struct cvmfs_attr *stat_info);
+
+char *scan_get_identifier(struct fs_traversal_context *ctx,
+  const struct cvmfs_attr *stat);
+
+bool scan_has_file(struct fs_traversal_context *ctx,
+  const char *ident);
+
+int scan_do_unlink(struct fs_traversal_context *ctx,
+  const char *path);
+
+int scan_do_rmdir(struct fs_traversal_context *ctx,
+  const char *path);
+
+int scan_do_link(struct fs_traversal_context *ctx,
+  const char *path, const char *identifier);
+
+int scan_do_mkdir(struct fs_traversal_context *ctx, const char *path,
+  const struct cvmfs_attr *stat_info);
+
+int scan_do_symlink(struct fs_traversal_context *ctx, const char *src,
+  const char *dest, const struct cvmfs_attr *stat_info);
+
+int scan_touch(struct fs_traversal_context *ctx,
+  const struct cvmfs_attr *stat_info);
+
+bool scan_is_hash_consistent(struct fs_traversal_context *ctx,
+  const struct cvmfs_attr *stat_info);
+
+/*
+ * FILE OPERATIONS
+ */
+
+void *scan_get_handle(struct fs_traversal_context *ctx,
+  const char *identifier);
+
+int scan_do_fopen(void *file_ctx, fs_open_type op_mode);
+
+int scan_do_fclose(void *file_ctx);
+
+int scan_do_fread(void *file_ctx, char *buff, size_t len, size_t *read_len);
+
+int scan_do_fwrite(void *file_ctx, const char *buff, size_t len);
+
+void scan_do_ffree(void *file_ctx);
+
+
+/*
+ * ARCHIVE PROVENANCE INFORMATION
+ */
+bool scan_archive_config(
+  std::string config_name,
+  std::string prov_name
+);
+
+void scan_write_provenance_info(
+  struct fs_traversal_context *ctx,
+  const char *info_file
+);
+
+void scan_archive_provenance(
+  struct fs_traversal_context *src,
+  struct fs_traversal_context *dest);
+
+/*
+ * INITIALIZATION
+ */
+
+struct fs_traversal_context *scan_initialize(
+  const char *repo,
+  const char *base,
+  const char *data,
+  const char *config,
+  int num_threads);
+
+void scan_finalize(struct fs_traversal_context *ctx);
+
+struct fs_traversal *scan_get_interface() {
+  struct fs_traversal *result = new struct fs_traversal;
+  result->initialize = scan_initialize;
+  result->finalize = scan_finalize;
+  result->archive_provenance = scan_archive_provenance;
+  result->list_dir = scan_list_dir;
+  result->get_stat = scan_get_stat;
+  result->is_hash_consistent = scan_is_hash_consistent;
+  result->set_meta = scan_set_meta;
+  result->has_file = scan_has_file;
+  result->get_identifier = scan_get_identifier;
+  result->do_link = scan_do_link;
+  result->do_unlink = scan_do_unlink;
+  result->do_mkdir = scan_do_mkdir;
+  result->do_rmdir = scan_do_rmdir;
+  result->touch = scan_touch;
+  result->get_handle = scan_get_handle;
+  result->do_symlink = scan_do_symlink;
+  result->do_fopen = scan_do_fopen;
+  result->do_fclose = scan_do_fclose;
+  result->do_fread = scan_do_fread;
+  result->do_fwrite = scan_do_fwrite;
+  result->do_ffree = scan_do_ffree;
+
+  return result;
+}
+
+/**
+ * INTERFACE FUNCTION IMPLEMENTATIONS
+ */
+
+void scan_list_dir(struct fs_traversal_context *ctx,
+  const char *dir,
+  char ***buf,
+  size_t *len) {
+  return;
+}
+
+int scan_get_stat(struct fs_traversal_context *ctx,
+  const char *path, struct cvmfs_attr *stat_result, bool get_hash) {
+  return 0;
+}
+
+int scan_set_meta(struct fs_traversal_context *ctx,
+  const char *path, const struct cvmfs_attr *stat_info) {
+  return 0;
+}
+
+char *scan_get_identifier(struct fs_traversal_context *ctx,
+  const struct cvmfs_attr *stat) {
+  shash::Any content_hash =
+    shash::MkFromHexPtr(shash::HexPtr(stat->cvm_checksum));
+  shash::Any meta_hash = HashMeta(stat);
+  std::string path = (
+    content_hash.MakePathExplicit(kDirLevels, kDigitsPerDirLevel, '.')
+    + meta_hash.ToString());
+  char *res = strdup(path.c_str());
+  return res;
+}
+
+bool scan_has_file(struct fs_traversal_context *ctx,
+  const char *ident) {
+  struct fs_traversal_scan_context *scan_ctx
+    =  reinterpret_cast<struct fs_traversal_scan_context*>(ctx->ctx);
+  std::string identifier = ident;
+  return (scan_ctx->data_dir.find(identifier) != scan_ctx->data_dir.end());
+}
+
+int scan_do_unlink(struct fs_traversal_context *ctx,
+  const char *path) {
+  return 0;
+}
+
+int scan_do_rmdir(struct fs_traversal_context *ctx,
+  const char *path) {
+  return 0;
+}
+
+int scan_do_link(struct fs_traversal_context *ctx,
+  const char *path,
+  const char *identifier) {
+  return 0;
+}
+
+int scan_do_mkdir(struct fs_traversal_context *ctx,
+  const char *path,
+  const struct cvmfs_attr *stat_info) {
+  return 0;
+}
+
+int scan_do_symlink(struct fs_traversal_context *ctx,
+  const char *src,
+  const char *dest,
+  const struct cvmfs_attr *stat_info) {
+  return 0;
+}
+
+int scan_touch(struct fs_traversal_context *ctx,
+  const struct cvmfs_attr *stat_info) {
+  // NOTE(steuber): creat is only atomic on non-NFS paths!
+  char *identifier = scan_get_identifier(ctx, stat_info);
+
+  std::string ident = identifier;
+  if (scan_has_file(ctx, identifier)) {
+    free(identifier);
+    errno = EEXIST;
+    return -1;
+  }
+  struct fs_traversal_scan_context *scan_ctx
+    =  reinterpret_cast<struct fs_traversal_scan_context*>(ctx->ctx);
+  scan_ctx->data_dir.insert(scan_ctx->data_dir.end(), ident);
+  free(identifier);
+  return 0;
+}
+
+bool scan_is_hash_consistent(struct fs_traversal_context *ctx,
+  const struct cvmfs_attr *stat_info) {
+  return false;
+}
+
+void *scan_get_handle(struct fs_traversal_context *ctx,
+  const char *identifier) {
+  struct scan_file_handle *file_ctx = new struct scan_file_handle;
+  file_ctx->path = identifier;
+
+  return file_ctx;
+}
+
+int scan_do_fopen(void *file_ctx, fs_open_type op_mode) {
+  return 0;
+}
+
+int scan_do_fclose(void *file_ctx) {
+  return 0;
+}
+
+int scan_do_fread(void *file_ctx, char *buff, size_t len, size_t *read_len) {
+  return 0;
+}
+
+int scan_do_fwrite(void *file_ctx, const char *buff, size_t len) {
+  return 0;
+}
+
+void scan_do_ffree(void *file_ctx) {
+  struct scan_file_handle *handle =
+    reinterpret_cast<scan_file_handle *>(file_ctx);
+  delete handle;
+}
+
+bool scan_archive_config(
+  std::string config_name,
+  std::string prov_name
+) {
+  return true;
+}
+
+void scan_write_provenance_info(
+  struct fs_traversal_context *ctx,
+  const char *info_file
+) {
+  return;
+}
+
+void scan_archive_provenance(
+  struct fs_traversal_context *src,
+  struct fs_traversal_context *dest)
+{
+  return;
+}
+
+struct fs_traversal_context *scan_initialize(
+  const char *repo,
+  const char *base,
+  const char *data,
+  const char *config,
+  int num_threads) {
+  fs_traversal_context *result = new struct fs_traversal_context;
+  result->version = 1;
+  result->lib_version = strdup("1.0");
+  result->type = strdup("scan");
+  struct fs_traversal_scan_context *scan_ctx
+    = new struct fs_traversal_scan_context;
+  result->ctx = scan_ctx;
+
+  LogCvmfs(kLogCvmfs, kLogStdout,
+      "Initializing scan interface with its directory structure");
+
+  // Retrieve base directory for traversal
+  if (!base) {
+    result->base = strdup("/tmp/cvmfs/");
+  } else {
+    if  (base[strlen(base)-1] != '/') {
+      size_t len = 2 + strlen(base);
+      char *base_dir = reinterpret_cast<char *>(smalloc(len*sizeof(char)));
+      snprintf(base_dir, len, "%s/",  base);
+      result->base = strdup(base_dir);
+      free(base_dir);
+    } else {
+      result->base = strdup(base);
+    }
+  }
+
+  // Retrieve repository (inside base directory) for traversal
+  if (!repo) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+      "Repository name must be specified");
+    return NULL;
+  }
+  result->repo = strdup(repo);
+
+  // Retrieve data directory (for hidden dedup directory)
+  if (!data) {
+    size_t len = 6 + strlen(result->base);
+    char *def_data = reinterpret_cast<char *>(smalloc(len*sizeof(char)));
+    snprintf(def_data, len, "%s.data",  result->base);
+    result->data = strdup(def_data);
+    free(def_data);
+  } else {
+    result->data = strdup(data);
+  }
+
+  result->config = NULL;
+
+  return result;
+}
+
+void scan_finalize(struct fs_traversal_context *ctx) {
+  free(ctx->repo);
+  free(ctx->base);
+  free(ctx->data);
+  free(ctx->config);
+  free(ctx->lib_version);
+  struct fs_traversal_scan_context *scan_ctx
+    =  reinterpret_cast<struct fs_traversal_scan_context*>(ctx->ctx);
+  delete scan_ctx;
+  delete ctx;
+}

--- a/cvmfs/shrinkwrap/scan/interface.h
+++ b/cvmfs/shrinkwrap/scan/interface.h
@@ -1,0 +1,18 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+#ifndef CVMFS_SHRINKWRAP_SCAN_INTERFACE_H_
+#define CVMFS_SHRINKWRAP_SCAN_INTERFACE_H_
+
+#include <set>
+#include <string>
+
+struct fs_traversal_scan_context {
+  std::set<std::string> data_dir;
+};
+
+
+
+struct fs_traversal *scan_get_interface();
+
+#endif  // CVMFS_SHRINKWRAP_SCAN_INTERFACE_H_

--- a/cvmfs/shrinkwrap/shrinkwrap.cc
+++ b/cvmfs/shrinkwrap/shrinkwrap.cc
@@ -94,7 +94,7 @@ void Usage() {
         " -z --dest-config Dest config\n"
         " -t --spec-file   Specification file [default=$REPO.spec]\n"
         " -j --threads     Number of concurrent copy threads [default:2*CPUs]\n"
-        " -p --stat-period Time period between stat prints, 0 disables [default:10]\n"
+        " -p --stat-period Frequency of stat prints, 0 disables [default:10]\n"
         " -g --gc          Perform garbage collection on destination\n",
            VERSION);
 }

--- a/cvmfs/shrinkwrap/shrinkwrap.cc
+++ b/cvmfs/shrinkwrap/shrinkwrap.cc
@@ -22,7 +22,7 @@ namespace {
 
 struct Params {
   bool CheckType(const std::string &type) {
-    if ((type == "cvmfs") || (type == "posix")) return true;
+    if ((type == "cvmfs") || (type == "posix") || (type == "scan")) return true;
     LogCvmfs(kLogCvmfs, kLogStderr, "Unknown type: %s", type.c_str());
     return false;
   }
@@ -56,7 +56,7 @@ struct Params {
     , dst_data_dir()
     , spec_trace_path()
     , num_parallel(0)
-    , retries(0)
+    , stat_period(10)
     , do_garbage_collection(false)
   { }
 
@@ -71,7 +71,7 @@ struct Params {
   std::string dst_data_dir;
   std::string spec_trace_path;
   unsigned num_parallel;
-  unsigned retries;
+  unsigned stat_period;
   bool do_garbage_collection;
 };
 
@@ -81,7 +81,7 @@ void Usage() {
        "This tool takes a cvmfs repository and outputs\n"
        "to a destination files system.\n"
        "Usage: cvmfs_shrinkwrap "
-       "[-r][-sbcf][-dxyz][-t|b][-jrg]\n"
+       "[-r][-sbcf][-dxyz][-t][-jrg]\n"
         "Options:\n"
         " -r --repo        Repository name [required]\n"
         " -s --src-type    Source filesystem type [default:cvmfs]\n"
@@ -94,7 +94,7 @@ void Usage() {
         " -z --dest-config Dest config\n"
         " -t --spec-file   Specification file [default=$REPO.spec]\n"
         " -j --threads     Number of concurrent copy threads [default:2*CPUs]\n"
-        " -r --retries     Number of retries on copying file [default:0]\n"
+        " -p --stat-period Time period between stat prints, 0 disables [default:10]\n"
         " -g --gc          Perform garbage collection on destination\n",
            VERSION);
 }
@@ -119,12 +119,12 @@ int main(int argc, char **argv) {
       {"dest-config", required_argument, 0, 'z'},
       {"spec-file",   required_argument, 0, 't'},
       {"threads",     required_argument, 0, 'j'},
-      {"retries",     required_argument, 0, 'n'},
+      {"stat-period", required_argument, 0, 'p'},
       {"gc",          no_argument, 0, 'g'},
       {0, 0, 0, 0}
     };
 
-  static const char short_opts[] = "hb:s:r:c:f:d:x:y:t:j:n:g";
+  static const char short_opts[] = "hb:s:r:c:f:d:x:y:t:j:p:g";
 
   while ((c = getopt_long(argc, argv, short_opts, long_opts, NULL)) >= 0) {
     switch (c) {
@@ -164,11 +164,11 @@ int main(int argc, char **argv) {
       case 'j':
         params.num_parallel = atoi(optarg);
         break;
-      case 'n':
-        params.retries = atoi(optarg);
-        break;
       case 'g':
         params.do_garbage_collection = true;
+        break;
+      case 'p':
+        params.stat_period = atoi(optarg);
         break;
       case '?':
       default:
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
     "", /* spec_base_dir, unused */
     params.spec_trace_path.c_str(),
     params.num_parallel,
-    params.retries);
+    params.stat_period);
 
   src->finalize(src->context_);
   if (params.do_garbage_collection) {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -392,6 +392,7 @@ set (CVMFS_TEST_SHRINKWRAP_SOURCES
   ${CVMFS_SOURCE_DIR}/shrinkwrap/posix/garbage_collector.cc
   ${CVMFS_SOURCE_DIR}/shrinkwrap/posix/helpers.cc
   ${CVMFS_SOURCE_DIR}/shrinkwrap/posix/interface.cc
+  ${CVMFS_SOURCE_DIR}/shrinkwrap/scan/interface.cc
   ${CVMFS_SOURCE_DIR}/shrinkwrap/fs_traversal_libcvmfs.cc
   ${CVMFS_SOURCE_DIR}/shrinkwrap/util.cc
 

--- a/test/unittests/shrinkwrap/t_fs_traversal_interface.cc
+++ b/test/unittests/shrinkwrap/t_fs_traversal_interface.cc
@@ -631,14 +631,14 @@ TEST_P(T_FsInterface, TransferPosixToPosix) {
 
   perf::Statistics *statistics = shrinkwrap::GetSyncStatTemplate();
 
-  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics));
+  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics, time(NULL)));
 
   dest->finalize(dest->context_);
   context = dest->initialize(
     dest_name.c_str(), repo_name.c_str(), dest_data.c_str(), NULL, 4);
   dest->context_ = context;
 
-  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics));
+  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics, time(NULL)));
   EXPECT_TRUE(DiffTree(repo_name + "/" + dest_name,
                        repo_name + "/" + src_name));
 


### PR DESCRIPTION
Added scan feature (used to track expected package size).

Updated stats for added clarity of data files vs file tree. This included changes to count and size tracking for accuracy and clarity.

Moved print loop into main traversal loop and wait loop(loop after traversal is done, but copy is not). The print loop was originally in copy thread, which leads to no or limited printing when updating large images with only a few changes.

Let me know if there are any changes and I will watch to see that formatting and unit tests still pass.