### PR TITLE
change permision for dummy directory from 0705 to 0755

### DIFF
--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -43,8 +43,8 @@ class SyncItemDummyDir : public SyncItemNative {
   }
 
  private:
-  static const mode_t kPermision =
-          S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+  static const mode_t kPermision = S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR |
+                                   S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 };
 
 catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent() const {

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -44,7 +44,7 @@ class SyncItemDummyDir : public SyncItemNative {
 
  private:
   static const mode_t kPermision =
-          S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR | S_IROTH | S_IXOTH;
+          S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 };
 
 catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent() const {


### PR DESCRIPTION
During ingestion this permision are applied when the directory we are ingesting into does not exists yet.

```
cvmfs_server ingest --tarball - --base_dir /foo/bar/fuzz
```

If any of either `foo`, `bar` or `fuzz` don't exist they have applied the permission we are changing now. It makes sense to give to the group at least the same permission level of others.