### PR TITLE
Move kernel cache on the correct side of the pipeline

### DIFF
--- a/cvmfs/ingestion/ingestion_source.h
+++ b/cvmfs/ingestion/ingestion_source.h
@@ -75,6 +75,11 @@ class FileIngestionSource : public IngestionSource {
 
   bool Close() {
     if (fd_ == -1) return true;
+
+    // tell to the OS that we are not going to access the file again in the
+    // foreaseable future.
+    (void)platform_invalidate_kcache(fd_, 0, 0);
+
     int ret = close(fd_);
     fd_ = -1;
     return (ret == 0);


### PR DESCRIPTION
Moving the removal of the cache invalidation on the correct side of the pipeline.

Performances tests are coming.