### PR TITLE
invalidate kernel cache on the correct side of the pipeline

### DIFF
--- a/cvmfs/ingestion/task_read.cc
+++ b/cvmfs/ingestion/task_read.cc
@@ -82,6 +82,9 @@ void TaskRead::Process(FileItem *item) {
     }
   } while (nbytes > 0);
 
+  // tell to the OS that we are not going to access the file again in the
+  // foreaseable future.
+  (void)platform_invalidate_kcache(fd, 0, 0);
   close(fd);
 }
 

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -11,7 +11,6 @@
 
 #include "compression.h"
 #include "logging.h"
-#include "platform.h"
 #include "util/posix.h"
 
 namespace upload {
@@ -98,18 +97,6 @@ void LocalUploader::StreamedUpload(UploadStreamHandle *handle,
                                    const CallbackTN *callback) {
   LocalStreamHandle *local_handle = static_cast<LocalStreamHandle *>(handle);
 
-  const off_t offset = lseek(local_handle->file_descriptor, 0, SEEK_CUR);
-  if (offset < 0) {
-    int seek_err = errno;
-    LogCvmfs(kLogSpooler, kLogVerboseMsg,
-             "failed to seek in '%s' (errno: %d)",
-             local_handle->temporary_path.c_str(), seek_err);
-    atomic_inc32(&copy_errors_);
-    Respond(callback,
-            UploaderResults(UploaderResults::kBufferUpload, seek_err));
-    return;
-  }
-
   const size_t bytes_written =
       write(local_handle->file_descriptor, buffer.data, buffer.size);
   if (bytes_written != buffer.size) {
@@ -124,11 +111,6 @@ void LocalUploader::StreamedUpload(UploadStreamHandle *handle,
             UploaderResults(UploaderResults::kBufferUpload, cpy_errno));
     return;
   }
-
-  // Tell kernel to evict written pages from the page cache.  We don't care if
-  // it succeeds or not.
-  (void)platform_invalidate_kcache(local_handle->file_descriptor, offset,
-                                   bytes_written);
 
   Respond(callback, UploaderResults(UploaderResults::kBufferUpload, 0));
 }


### PR DESCRIPTION
Asked in #2297 