### PR TITLE
Improve shrinkwrap statistics output

### DIFF
--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -92,14 +92,13 @@ class RecDir {
 
 unsigned             num_parallel_ = 0;
 bool                 recursive = true;
+int                  stat_update_period_ = 10;
 int                  pipe_chunks[2];
 // required for concurrent reading
 pthread_mutex_t      lock_pipe = PTHREAD_MUTEX_INITIALIZER;
 atomic_int64         copy_queue;
 
 vector<RecDir*>      dirs_;
-
-unsigned             retries_ = 0;
 
 SpecTree             *spec_tree_ = new SpecTree('*');
 
@@ -164,10 +163,11 @@ bool copyFile(
   const char *dest_name,
   perf::Statistics *pstats
 ) {
-  int retval;
+  int retval = 0;
   bool status = true;
   size_t bytes_transferred = 0;
 
+  // Get file handles from each respective filesystem
   void *src  = src_fs->get_handle(src_fs->context_, src_name);
   void *dest = dest_fs->get_handle(dest_fs->context_, dest_name);
 
@@ -214,7 +214,8 @@ bool copyFile(
       break;
     }
   }
-  pstats->Lookup(SHRINKWRAP_STAT_BYTE_COUNT)->Xadd(bytes_transferred);
+
+  pstats->Lookup(SHRINKWRAP_STAT_DATA_BYTES)->Xadd(bytes_transferred);
 
   retval = src_fs->do_fclose(src);
   if (retval != 0) {
@@ -300,9 +301,21 @@ bool getNext(
     return false;
   }
   if (is_src) {
-    pstats->Lookup(SHRINKWRAP_STAT_SRC_ENTRIES)->Inc();
+    pstats->Lookup(SHRINKWRAP_STAT_ENTRIES_SRC)->Inc();
+    switch ((*st)->st_mode & S_IFMT) {
+      case S_IFREG:
+        pstats->Lookup(SHRINKWRAP_STAT_COUNT_FILE)->Inc();
+        pstats->Lookup(SHRINKWRAP_STAT_COUNT_BYTE)->Xadd((*st)->st_size);
+        break;
+      case S_IFDIR:
+        pstats->Lookup(SHRINKWRAP_STAT_COUNT_DIR)->Inc();
+        break;
+      case S_IFLNK:
+        pstats->Lookup(SHRINKWRAP_STAT_COUNT_SYMLINK)->Inc();
+        break;
+    }
   } else {
-    pstats->Lookup(SHRINKWRAP_STAT_DEST_ENTRIES)->Inc();
+    pstats->Lookup(SHRINKWRAP_STAT_ENTRIES_DEST)->Inc();
   }
   return true;
 }
@@ -349,12 +362,12 @@ bool handle_file(
         errno = 0;
         result = false;
       }
-      pstats->Lookup(SHRINKWRAP_STAT_FILE_COUNT)->Inc();
     }
+    pstats->Lookup(SHRINKWRAP_STAT_DATA_FILES)->Inc();
     free(src_ident);
   } else {
-    pstats->Lookup(SHRINKWRAP_STAT_DEDUPED_FILES)->Inc();
-    pstats->Lookup(SHRINKWRAP_STAT_DEDUPED_BYTES)->Xadd(src_st->st_size);
+    pstats->Lookup(SHRINKWRAP_STAT_DATA_FILES_DEDUPED)->Inc();
+    pstats->Lookup(SHRINKWRAP_STAT_DATA_BYTES_DEDUPED)->Xadd(src_st->st_size);
   }
 
   // The target alway exists (either previously existed or just created).
@@ -448,7 +461,7 @@ bool Sync(
               &dest_st, false, false, pstats);
     } else {
       // A destination entry was added
-      pstats->Lookup(SHRINKWRAP_STAT_DEST_ENTRIES)->Inc();
+      pstats->Lookup(SHRINKWRAP_STAT_ENTRIES_DEST)->Inc();
     }
 
     // All entries in both have been visited
@@ -550,7 +563,8 @@ bool Sync(
 bool SyncFull(
   struct fs_traversal *src,
   struct fs_traversal *dest,
-  perf::Statistics *pstats) {
+  perf::Statistics *pstats,
+  time_t last_print_time) {
   if (dirs_.empty()) {
     dirs_.push_back(new RecDir("", true));
   }
@@ -562,6 +576,13 @@ bool SyncFull(
       LogCvmfs(kLogCvmfs, kLogStderr,
         "File %s failed to copy\n", next_dir->dir);
       return false;
+    }
+
+    if (time(NULL)-last_print_time > stat_update_period_) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+        "%s",
+        pstats->PrintList(perf::Statistics::kPrintSimple).c_str());
+      last_print_time = time(NULL);
     }
 
     delete next_dir;
@@ -585,19 +606,9 @@ static void *MainWorker(void *data) {
   MainWorkerSpecificContext *sc = static_cast<MainWorkerSpecificContext*>(data);
   MainWorkerContext *mwc = sc->mwc;
   perf::Counter *files_transferred
-    = mwc->pstats->Lookup(SHRINKWRAP_STAT_FILE_COUNT);
-  time_t last_print_time = 0;
-  if (sc->num_thread == 0) {
-    last_print_time = time(NULL);
-  }
+    = mwc->pstats->Lookup(SHRINKWRAP_STAT_COUNT_FILE);
 
   while (1) {
-    if (sc->num_thread == 0 && time(NULL)-last_print_time > 10) {
-      LogCvmfs(kLogCvmfs, kLogStdout,
-        "%s",
-        mwc->pstats->PrintList(perf::Statistics::kPrintSimple).c_str());
-      last_print_time = time(NULL);
-    }
     FileCopy next_copy;
     pthread_mutex_lock(&lock_pipe);
     ReadPipe(pipe_chunks[0], &next_copy, sizeof(next_copy));
@@ -627,18 +638,26 @@ static void *MainWorker(void *data) {
 
 perf::Statistics *GetSyncStatTemplate() {
   perf::Statistics *result = new perf::Statistics();
-  result->Register(SHRINKWRAP_STAT_BYTE_COUNT,
-    "The number of bytes transfered from the source to the destination");
-  result->Register(SHRINKWRAP_STAT_FILE_COUNT,
-    "The number of files transfered from the source to the destination");
-  result->Register(SHRINKWRAP_STAT_SRC_ENTRIES,
-    "The number of file system entries processed in the source");
-  result->Register(SHRINKWRAP_STAT_DEST_ENTRIES,
-    "The number of file system entries processed in the destination");
-  result->Register(SHRINKWRAP_STAT_DEDUPED_FILES,
-    "The number of files not copied thanks to deduplication");
-  result->Register(SHRINKWRAP_STAT_DEDUPED_BYTES,
-    "The number of bytes not copied thanks to deduplication");
+  result->Register(SHRINKWRAP_STAT_COUNT_FILE,
+    "Number of files from source repository");
+  result->Register(SHRINKWRAP_STAT_COUNT_DIR,
+    "Number of directories from source repository");
+  result->Register(SHRINKWRAP_STAT_COUNT_SYMLINK,
+    "Number of symlinks from source repository");
+  result->Register(SHRINKWRAP_STAT_COUNT_BYTE,
+    "Byte count of projected repository");
+  result->Register(SHRINKWRAP_STAT_ENTRIES_SRC,
+    "Number of file system entries processed in the source");
+  result->Register(SHRINKWRAP_STAT_ENTRIES_DEST,
+    "Number of file system entries processed in the destination");
+  result->Register(SHRINKWRAP_STAT_DATA_FILES,
+    "Number of data files transfered from source to destination");
+  result->Register(SHRINKWRAP_STAT_DATA_BYTES,
+    "Bytes transfered from source to destination");
+  result->Register(SHRINKWRAP_STAT_DATA_FILES_DEDUPED,
+    "Number of files not copied due to deduplication");
+  result->Register(SHRINKWRAP_STAT_DATA_BYTES_DEDUPED,
+    "Number of bytes not copied due to deduplication");
   return result;
 }
 
@@ -648,9 +667,9 @@ int SyncInit(
   const char *base,
   const char *spec,
   unsigned parallel,
-  unsigned retries) {
+  int stat_period) {
   num_parallel_ = parallel;
-  retries_ = retries;
+  stat_update_period_ = stat_period;
 
   perf::Statistics *pstats = GetSyncStatTemplate();
 
@@ -694,10 +713,18 @@ int SyncInit(
     spec_tree_ = SpecTree::Create(spec);
   }
 
+  time_t last_print_time = 0;
   add_dir_for_sync(base, recursive);
-  int result = !SyncFull(src, dest, pstats);
+  int result = !SyncFull(src, dest, pstats, last_print_time);
 
   while (atomic_read64(&copy_queue) != 0) {
+    if (time(NULL)-last_print_time > stat_update_period_) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+        "%s",
+        pstats->PrintList(perf::Statistics::kPrintSimple).c_str());
+      last_print_time = time(NULL);
+    }
+
     SafeSleepMs(100);
   }
 

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -578,7 +578,8 @@ bool SyncFull(
       return false;
     }
 
-    if (time(NULL)-last_print_time > stat_update_period_) {
+    if (stat_update_period_ > 0 &&
+        time(NULL)-last_print_time > stat_update_period_) {
       LogCvmfs(kLogCvmfs, kLogStdout,
         "%s",
         pstats->PrintList(perf::Statistics::kPrintSimple).c_str());

--- a/cvmfs/shrinkwrap/fs_traversal.h
+++ b/cvmfs/shrinkwrap/fs_traversal.h
@@ -11,12 +11,17 @@
 #include "fs_traversal_interface.h"
 #include "statistics.h"
 
-#define SHRINKWRAP_STAT_BYTE_COUNT "byteCnt"
-#define SHRINKWRAP_STAT_FILE_COUNT "fileCnt"
-#define SHRINKWRAP_STAT_SRC_ENTRIES "srcEntries"
-#define SHRINKWRAP_STAT_DEST_ENTRIES "destEntries"
-#define SHRINKWRAP_STAT_DEDUPED_FILES "dedupedFiles"
-#define SHRINKWRAP_STAT_DEDUPED_BYTES "dedupedBytes"
+
+#define SHRINKWRAP_STAT_COUNT_FILE "cntFile"
+#define SHRINKWRAP_STAT_COUNT_DIR "cntDir"
+#define SHRINKWRAP_STAT_COUNT_SYMLINK "cntSymlink"
+#define SHRINKWRAP_STAT_COUNT_BYTE "cntByte"
+#define SHRINKWRAP_STAT_ENTRIES_SRC "entriesSrc"
+#define SHRINKWRAP_STAT_ENTRIES_DEST "entriesDest"
+#define SHRINKWRAP_STAT_DATA_FILES "dataFiles"
+#define SHRINKWRAP_STAT_DATA_BYTES "dataBytes"
+#define SHRINKWRAP_STAT_DATA_FILES_DEDUPED "dataFilesDeduped"
+#define SHRINKWRAP_STAT_DATA_BYTES_DEDUPED "dataBytesDeduped"
 
 namespace shrinkwrap {
 
@@ -27,7 +32,7 @@ int SyncInit(struct fs_traversal *src,
              const char *base,
              const char *spec,
              unsigned parallel,
-             unsigned retries);
+             int stat_period);
 
 int GarbageCollect(struct fs_traversal *fs);
 
@@ -35,7 +40,8 @@ int GarbageCollect(struct fs_traversal *fs);
 bool SyncFull(
   struct fs_traversal *src,
   struct fs_traversal *dest,
-  perf::Statistics *pstats);
+  perf::Statistics *pstats,
+  time_t last_print_time);
 
 // Exported for testing purposes:
 perf::Statistics *GetSyncStatTemplate();

--- a/cvmfs/shrinkwrap/fs_traversal.h
+++ b/cvmfs/shrinkwrap/fs_traversal.h
@@ -31,8 +31,8 @@ int SyncInit(struct fs_traversal *src,
              struct fs_traversal *dest,
              const char *base,
              const char *spec,
-             unsigned parallel,
-             int stat_period);
+             uint64_t parallel,
+             uint64_t stat_period);
 
 int GarbageCollect(struct fs_traversal *fs);
 
@@ -41,7 +41,7 @@ bool SyncFull(
   struct fs_traversal *src,
   struct fs_traversal *dest,
   perf::Statistics *pstats,
-  time_t last_print_time);
+  uint64_t last_print_time);
 
 // Exported for testing purposes:
 perf::Statistics *GetSyncStatTemplate();

--- a/cvmfs/shrinkwrap/shrinkwrap.cc
+++ b/cvmfs/shrinkwrap/shrinkwrap.cc
@@ -56,7 +56,7 @@ struct Params {
     , dst_data_dir()
     , spec_trace_path()
     , num_parallel(0)
-    , retries(0)
+    , stat_period(10)
     , do_garbage_collection(false)
   { }
 
@@ -71,7 +71,7 @@ struct Params {
   std::string dst_data_dir;
   std::string spec_trace_path;
   unsigned num_parallel;
-  unsigned retries;
+  unsigned stat_period;
   bool do_garbage_collection;
 };
 
@@ -81,7 +81,7 @@ void Usage() {
        "This tool takes a cvmfs repository and outputs\n"
        "to a destination files system.\n"
        "Usage: cvmfs_shrinkwrap "
-       "[-r][-sbcf][-dxyz][-t|b][-jrg]\n"
+       "[-r][-sbcf][-dxyz][-t][-jrg]\n"
         "Options:\n"
         " -r --repo        Repository name [required]\n"
         " -s --src-type    Source filesystem type [default:cvmfs]\n"
@@ -94,7 +94,7 @@ void Usage() {
         " -z --dest-config Dest config\n"
         " -t --spec-file   Specification file [default=$REPO.spec]\n"
         " -j --threads     Number of concurrent copy threads [default:2*CPUs]\n"
-        " -r --retries     Number of retries on copying file [default:0]\n"
+        " -p --stat-period Frequency of stat prints, 0 disables [default:10]\n"
         " -g --gc          Perform garbage collection on destination\n",
            VERSION);
 }
@@ -119,12 +119,12 @@ int main(int argc, char **argv) {
       {"dest-config", required_argument, 0, 'z'},
       {"spec-file",   required_argument, 0, 't'},
       {"threads",     required_argument, 0, 'j'},
-      {"retries",     required_argument, 0, 'n'},
+      {"stat-period", required_argument, 0, 'p'},
       {"gc",          no_argument, 0, 'g'},
       {0, 0, 0, 0}
     };
 
-  static const char short_opts[] = "hb:s:r:c:f:d:x:y:t:j:n:g";
+  static const char short_opts[] = "hb:s:r:c:f:d:x:y:t:j:p:g";
 
   while ((c = getopt_long(argc, argv, short_opts, long_opts, NULL)) >= 0) {
     switch (c) {
@@ -164,11 +164,11 @@ int main(int argc, char **argv) {
       case 'j':
         params.num_parallel = atoi(optarg);
         break;
-      case 'n':
-        params.retries = atoi(optarg);
-        break;
       case 'g':
         params.do_garbage_collection = true;
+        break;
+      case 'p':
+        params.stat_period = atoi(optarg);
         break;
       case '?':
       default:
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
     "", /* spec_base_dir, unused */
     params.spec_trace_path.c_str(),
     params.num_parallel,
-    params.retries);
+    params.stat_period);
 
   src->finalize(src->context_);
   if (params.do_garbage_collection) {

--- a/cvmfs/shrinkwrap/shrinkwrap.cc
+++ b/cvmfs/shrinkwrap/shrinkwrap.cc
@@ -70,8 +70,8 @@ struct Params {
   std::string dst_base_dir;
   std::string dst_data_dir;
   std::string spec_trace_path;
-  unsigned num_parallel;
-  unsigned stat_period;
+  uint64_t num_parallel;
+  uint64_t stat_period;
   bool do_garbage_collection;
 };
 
@@ -105,6 +105,8 @@ int main(int argc, char **argv) {
   Params params;
 
   int c;
+  char *endptr = NULL;
+  long long tmp_value = 0; // NOLINT
   static struct option long_opts[] = {
       /* All of the options require an argument */
       {"help",        no_argument, 0, 'h'},
@@ -162,13 +164,43 @@ int main(int argc, char **argv) {
         params.spec_trace_path = optarg;
         break;
       case 'j':
-        params.num_parallel = atoi(optarg);
+        errno = 0;
+        endptr = NULL;
+        tmp_value = strtoll(optarg, &endptr, 10);
+        if ((strlen(optarg) == 0) || (endptr != (optarg + strlen(optarg))) ||
+             (tmp_value < 0)) {
+          errno = EINVAL;
+        }
+        if (errno != 0) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+            "Invalid value passed to 'j': %s : only non-negative integers",
+             optarg);
+          Usage();
+          return 1;
+        } else {
+          params.num_parallel = tmp_value;
+        }
         break;
       case 'g':
         params.do_garbage_collection = true;
         break;
       case 'p':
-        params.stat_period = atoi(optarg);
+        errno = 0;
+        endptr = NULL;
+        tmp_value = strtoll(optarg, &endptr, 10);
+        if ((strlen(optarg) == 0) || (endptr != (optarg + strlen(optarg))) ||
+             (tmp_value < 0)) {
+          errno = EINVAL;
+        }
+        if (errno != 0) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+            "Invalid value passed to 'p': %s : only non-negative integers",
+             optarg);
+          Usage();
+          return 1;
+        } else {
+          params.stat_period = tmp_value;
+        }
         break;
       case '?':
       default:

--- a/cvmfs/shrinkwrap/shrinkwrap.cc
+++ b/cvmfs/shrinkwrap/shrinkwrap.cc
@@ -164,42 +164,24 @@ int main(int argc, char **argv) {
         params.spec_trace_path = optarg;
         break;
       case 'j':
-        errno = 0;
-        endptr = NULL;
-        tmp_value = strtoll(optarg, &endptr, 10);
-        if ((strlen(optarg) == 0) || (endptr != (optarg + strlen(optarg))) ||
-             (tmp_value < 0)) {
-          errno = EINVAL;
-        }
-        if (errno != 0) {
+        if (!String2Uint64Parse(optarg, &params.num_parallel)) {
           LogCvmfs(kLogCvmfs, kLogStderr,
             "Invalid value passed to 'j': %s : only non-negative integers",
              optarg);
           Usage();
           return 1;
-        } else {
-          params.num_parallel = tmp_value;
         }
         break;
       case 'g':
         params.do_garbage_collection = true;
         break;
       case 'p':
-        errno = 0;
-        endptr = NULL;
-        tmp_value = strtoll(optarg, &endptr, 10);
-        if ((strlen(optarg) == 0) || (endptr != (optarg + strlen(optarg))) ||
-             (tmp_value < 0)) {
-          errno = EINVAL;
-        }
-        if (errno != 0) {
+        if (!String2Uint64Parse(optarg, &params.stat_period)) {
           LogCvmfs(kLogCvmfs, kLogStderr,
             "Invalid value passed to 'p': %s : only non-negative integers",
              optarg);
           Usage();
           return 1;
-        } else {
-          params.stat_period = tmp_value;
         }
         break;
       case '?':

--- a/test/unittests/shrinkwrap/t_fs_traversal_interface.cc
+++ b/test/unittests/shrinkwrap/t_fs_traversal_interface.cc
@@ -10,9 +10,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <ctime>
-
 #include "libcvmfs.h"
+#include "platform.h"
 #include "statistics.h"
 #include "util/posix.h"
 #include "xattr.h"
@@ -631,14 +630,16 @@ TEST_P(T_FsInterface, TransferPosixToPosix) {
 
   perf::Statistics *statistics = shrinkwrap::GetSyncStatTemplate();
 
-  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics, time(NULL)));
+  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics,
+                                   platform_monotonic_time()));
 
   dest->finalize(dest->context_);
   context = dest->initialize(
     dest_name.c_str(), repo_name.c_str(), dest_data.c_str(), NULL, 4);
   dest->context_ = context;
 
-  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics, time(NULL)));
+  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics,
+                                   platform_monotonic_time()));
   EXPECT_TRUE(DiffTree(repo_name + "/" + dest_name,
                        repo_name + "/" + src_name));
 

--- a/test/unittests/shrinkwrap/t_fs_traversal_interface.cc
+++ b/test/unittests/shrinkwrap/t_fs_traversal_interface.cc
@@ -631,14 +631,14 @@ TEST_P(T_FsInterface, TransferPosixToPosix) {
 
   perf::Statistics *statistics = shrinkwrap::GetSyncStatTemplate();
 
-  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics));
+  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics, time(NULL)));
 
   dest->finalize(dest->context_);
   context = dest->initialize(
     dest_name.c_str(), repo_name.c_str(), dest_data.c_str(), NULL, 4);
   dest->context_ = context;
 
-  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics));
+  EXPECT_TRUE(shrinkwrap::SyncFull(src, dest, statistics, time(NULL)));
   EXPECT_TRUE(DiffTree(repo_name + "/" + dest_name,
                        repo_name + "/" + src_name));
 


### PR DESCRIPTION
Add/clarify several stat fields for Shrinkwrap. 

The stat print cycle was move to the main loop to avoid unresponsive periods when retraversing existing repositories.

Also removed unused retries option/variable.