### PR TITLE
Build fix for macOS Mojave

### DIFF
--- a/externals/c-ares/src/configureHook.sh
+++ b/externals/c-ares/src/configureHook.sh
@@ -4,7 +4,12 @@
 #              Please install XCode and run `xcode-select --install` afterwards.
 #              Also remember to start XCode at least once and agree to the EULA.
 
-sh configure LDFLAGS="$LDFLAGS -rdynamic" \
+FIX_COMP=""
+if [ x"$(uname)" == x"Darwin" ]; then
+  FIX_COMP="CC=/usr/bin/clang CXX=/usr/bin/clang++"
+fi
+
+sh configure $FIX_COMP LDFLAGS="$LDFLAGS -rdynamic" \
              CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \
              CFLAGS="$CFLAGS $CVMFS_BASE_C_FLAGS -fPIC" \
              --enable-shared=no \

--- a/externals/libcurl/src/configureHook.sh
+++ b/externals/libcurl/src/configureHook.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
 curl_ssl_config="--with-ssl"
+FIX_COMP=""
 if [ x"$(uname)" = x"Darwin" ]; then
     curl_ssl_config="--with-ssl=$EXTERNALS_INSTALL_LOCATION"
+  FIX_COMP="CC=/usr/bin/clang CXX=/usr/bin/clang++"
 fi
 
-sh configure CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \
+sh configure $FIX_COMP CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \
   LDFLAGS="$LDFLAGS -rdynamic" \
   CFLAGS="$CFLAGS $CVMFS_BASE_C_FLAGS -fvisibility=hidden -fPIC" \
   $CVMFS_ZLIB --enable-warnings \

--- a/externals/pacparser/src/makeHook.sh
+++ b/externals/pacparser/src/makeHook.sh
@@ -4,10 +4,15 @@ set -e
 
 static_result_dir=src/static
 
+FIX_COMP=""
+if [ x"$(uname)" == x"Darwin" ]; then
+  FIX_COMP="CC=/usr/bin/clang CXX=/usr/bin/clang++"
+fi
+
 echo "make clean && make for libpacparser (omitting test execution)..."
 [ -d $static_result_dir ] && rm -fR $static_result_dir
 make -C src clean
-make CVMFS_BASE_C_FLAGS="$CVMFS_BASE_C_FLAGS" -j1 -C src pacparser.o libjs.a # default target runs tests!
+make $FIX_COMP CVMFS_BASE_C_FLAGS="$CVMFS_BASE_C_FLAGS" -j1 -C src pacparser.o libjs.a # default target runs tests!
 echo "finished internal build of libpacparser"
 
 echo "creating static link library for libpacparser..."


### PR DESCRIPTION
This fixes compilation issue on macOS Mojave, without requiring the extra header package to be installed (` /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`)

Ensure /usr/bin/clang is used for c-ares,curl,pacparser. The way it works is that `/usr/bin/clang` will call the compiler from the current active toolchain (either Xcode or Xcode Commandline Tools) with the proper include and library paths for the system SDK.

A bug in the configuration scripts of c-ares, curl and pacparser require forcing the use of `/usr/bin/clang`.