### PR TITLE
Forbid golang compiler to download dependencies

### DIFF
--- a/ducc/CMakeLists.txt
+++ b/ducc/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_target(
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc  
-  COMMAND ${GO_COMPILER} build -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc
+  COMMAND ${GO_COMPILER} build -mod=vendor -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*
   COMMENT "Build ducc using the Go Compiler"


### PR DESCRIPTION
The `-mod=vendor` flags force the go compiler to use only dependencies from the `vendor/` folder.