### PR TITLE
Remove raw mutex and use MutexLockGuards

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -291,7 +291,7 @@ bool Catalog::LookupEntry(const shash::Md5 &md5path, const bool expand_symlink,
 {
   assert(IsInitialized());
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   sql_lookup_md5path_->BindPathHash(md5path);
   bool found = sql_lookup_md5path_->FetchRow();
   if (found && (dirent != NULL)) {
@@ -299,7 +299,6 @@ bool Catalog::LookupEntry(const shash::Md5 &md5path, const bool expand_symlink,
     FixTransitionPoint(md5path, dirent);
   }
   sql_lookup_md5path_->Reset();
-  pthread_mutex_unlock(lock_);
 
   return found;
 }
@@ -335,14 +334,13 @@ bool Catalog::LookupXattrsMd5Path(
 {
   assert(IsInitialized());
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   sql_lookup_xattrs_->BindPathHash(md5path);
   bool found = sql_lookup_xattrs_->FetchRow();
   if (found && (xattrs != NULL)) {
     *xattrs = sql_lookup_xattrs_->GetXattrs();
   }
   sql_lookup_xattrs_->Reset();
-  pthread_mutex_unlock(lock_);
 
   return found;
 }
@@ -362,7 +360,7 @@ bool Catalog::ListingMd5PathStat(const shash::Md5 &md5path,
   DirectoryEntry dirent;
   StatEntry entry;
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   sql_listing_->BindPathHash(md5path);
   while (sql_listing_->FetchRow()) {
     dirent = sql_listing_->GetDirent(this);
@@ -374,7 +372,6 @@ bool Catalog::ListingMd5PathStat(const shash::Md5 &md5path,
     listing->PushBack(entry);
   }
   sql_listing_->Reset();
-  pthread_mutex_unlock(lock_);
 
   return true;
 }
@@ -394,7 +391,8 @@ bool Catalog::ListingMd5Path(const shash::Md5 &md5path,
 {
   assert(IsInitialized());
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
+
   sql_listing_->BindPathHash(md5path);
   while (sql_listing_->FetchRow()) {
     DirectoryEntry dirent = sql_listing_->GetDirent(this, expand_symlink);
@@ -402,7 +400,6 @@ bool Catalog::ListingMd5Path(const shash::Md5 &md5path,
     listing->push_back(dirent);
   }
   sql_listing_->Reset();
-  pthread_mutex_unlock(lock_);
 
   return true;
 }
@@ -435,13 +432,13 @@ bool Catalog::ListMd5PathChunks(const shash::Md5  &md5path,
 {
   assert(IsInitialized() && chunks->IsEmpty());
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
+
   sql_chunks_listing_->BindPathHash(md5path);
   while (sql_chunks_listing_->FetchRow()) {
     chunks->PushBack(sql_chunks_listing_->GetFileChunk(interpret_hashes_as));
   }
   sql_chunks_listing_->Reset();
-  pthread_mutex_unlock(lock_);
 
   return true;
 }
@@ -482,25 +479,20 @@ void Catalog::DropDatabaseFileOwnership() {
 
 
 uint64_t Catalog::GetTTL() const {
-  pthread_mutex_lock(lock_);
-  const uint64_t result =
-    database().GetPropertyDefault<uint64_t>("TTL", kDefaultTTL);
-  pthread_mutex_unlock(lock_);
-  return result;
+  MutexLockGuard m(lock_);
+  return database().GetPropertyDefault<uint64_t>("TTL", kDefaultTTL);
 }
 
 
 bool Catalog::HasExplicitTTL() const {
-  pthread_mutex_lock(lock_);
-  const bool result = database().HasProperty("TTL");
-  pthread_mutex_unlock(lock_);
-  return result;
+  MutexLockGuard m(lock_);
+  return database().HasProperty("TTL");
 }
 
 
 bool Catalog::GetVOMSAuthz(string *authz) const {
   bool result;
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   if (voms_authz_status_ == kVomsPresent) {
     if (authz) {*authz = voms_authz_;}
     result = true;
@@ -516,18 +508,13 @@ bool Catalog::GetVOMSAuthz(string *authz) const {
     }
     result = (voms_authz_status_ == kVomsPresent);
   }
-  pthread_mutex_unlock(lock_);
   return result;
 }
 
 uint64_t Catalog::GetRevision() const {
-  pthread_mutex_lock(lock_);
-  const uint64_t result =
-    database().GetPropertyDefault<uint64_t>("revision", 0);
-  pthread_mutex_unlock(lock_);
-  return result;
+  MutexLockGuard m(lock_);
+  return database().GetPropertyDefault<uint64_t>("revision", 0);
 }
-
 
 uint64_t Catalog::GetLastModified() const {
   const std::string prop_name = "last_modified";
@@ -545,20 +532,16 @@ uint64_t Catalog::GetNumChunks() const {
 uint64_t Catalog::GetNumEntries() const {
   const string sql = "SELECT count(*) FROM catalog;";
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   SqlCatalog stmt(database(), sql);
-  const uint64_t result = (stmt.FetchRow()) ? stmt.RetrieveInt64(0) : 0;
-  pthread_mutex_unlock(lock_);
-
-  return result;
+  return (stmt.FetchRow()) ? stmt.RetrieveInt64(0) : 0;
 }
 
 
 shash::Any Catalog::GetPreviousRevision() const {
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   const std::string hash_string =
     database().GetPropertyDefault<std::string>("previous_revision", "");
-  pthread_mutex_unlock(lock_);
   return (!hash_string.empty())
     ? shash::MkFromHexPtr(shash::HexPtr(hash_string), shash::kSuffixCatalog)
     : shash::Any();
@@ -567,9 +550,10 @@ shash::Any Catalog::GetPreviousRevision() const {
 
 string Catalog::PrintMemStatistics() const {
   sqlite::MemStatistics stats;
-  pthread_mutex_lock(lock_);
-  database().GetMemStatistics(&stats);
-  pthread_mutex_unlock(lock_);
+  {
+    MutexLockGuard m(lock_);
+    database().GetMemStatistics(&stats);
+  }
   return string(mountpoint().GetChars(), mountpoint().GetLength()) + ": " +
     StringifyInt(stats.lookaside_slots_used) + " / " +
       StringifyInt(stats.lookaside_slots_max) + " slots -- " +
@@ -630,7 +614,7 @@ inode_t Catalog::GetMangledInode(const uint64_t row_id,
  * @return  a list of all nested catalog and bind mountpoints.
  */
 const Catalog::NestedCatalogList& Catalog::ListNestedCatalogs() const {
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
 
   if (nested_catalog_cache_dirty_) {
     LogCvmfs(kLogCatalog, kLogDebug, "refreshing nested catalog cache of '%s'",
@@ -646,7 +630,6 @@ const Catalog::NestedCatalogList& Catalog::ListNestedCatalogs() const {
     nested_catalog_cache_dirty_ = false;
   }
 
-  pthread_mutex_unlock(lock_);
   return nested_catalog_cache_;
 }
 
@@ -659,7 +642,7 @@ const Catalog::NestedCatalogList& Catalog::ListNestedCatalogs() const {
 const Catalog::NestedCatalogList Catalog::ListOwnNestedCatalogs() const {
   NestedCatalogList result;
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
 
   while (sql_own_list_nested_->FetchRow()) {
     NestedCatalog nested;
@@ -669,8 +652,6 @@ const Catalog::NestedCatalogList Catalog::ListOwnNestedCatalogs() const {
     result.push_back(nested);
   }
   sql_own_list_nested_->Reset();
-
-  pthread_mutex_unlock(lock_);
 
   return result;
 }
@@ -695,7 +676,7 @@ void Catalog::ResetNestedCatalogCacheUnprotected() {
 bool Catalog::FindNested(const PathString &mountpoint,
                          shash::Any *hash, uint64_t *size) const
 {
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   PathString normalized_mountpoint = NormalizePath2(mountpoint);
   sql_lookup_nested_->BindSearchPath(normalized_mountpoint);
   bool found = sql_lookup_nested_->FetchRow();
@@ -704,7 +685,6 @@ bool Catalog::FindNested(const PathString &mountpoint,
     *size = sql_lookup_nested_->GetSize();
   }
   sql_lookup_nested_->Reset();
-  pthread_mutex_unlock(lock_);
 
   return found;
 }
@@ -715,12 +695,11 @@ bool Catalog::FindNested(const PathString &mountpoint,
  * The annotation object is not owned by the catalog.
  */
 void Catalog::SetInodeAnnotation(InodeAnnotation *new_annotation) {
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   // Since annotated inodes could come back to the catalog in order to
   // get stripped, exchanging the annotation is not allowed
   assert((inode_annotation_ == NULL) || (inode_annotation_ == new_annotation));
   inode_annotation_ = new_annotation;
-  pthread_mutex_unlock(lock_);
 }
 
 
@@ -737,10 +716,9 @@ void Catalog::SetOwnerMaps(const OwnerMap *uid_map, const OwnerMap *gid_map) {
 void Catalog::AddChild(Catalog *child) {
   assert(NULL == FindChild(child->mountpoint()));
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   children_[child->mountpoint()] = child;
   child->set_parent(this);
-  pthread_mutex_unlock(lock_);
 }
 
 
@@ -751,23 +729,21 @@ void Catalog::AddChild(Catalog *child) {
 void Catalog::RemoveChild(Catalog *child) {
   assert(NULL != FindChild(child->mountpoint()));
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   child->set_parent(NULL);
   children_.erase(child->mountpoint());
-  pthread_mutex_unlock(lock_);
 }
 
 
 CatalogList Catalog::GetChildren() const {
   CatalogList result;
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   for (NestedCatalogMap::const_iterator i = children_.begin(),
        iEnd = children_.end(); i != iEnd; ++i)
   {
     result.push_back(i->second);
   }
-  pthread_mutex_unlock(lock_);
 
   return result;
 }
@@ -818,11 +794,10 @@ Catalog* Catalog::FindSubtree(const PathString &path) const {
 Catalog* Catalog::FindChild(const PathString &mountpoint) const {
   NestedCatalogMap::const_iterator nested_iter;
 
-  pthread_mutex_lock(lock_);
+  MutexLockGuard m(lock_);
   nested_iter = children_.find(mountpoint);
   Catalog* result =
     (nested_iter == children_.end()) ? NULL : nested_iter->second;
-  pthread_mutex_unlock(lock_);
 
   return result;
 }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1025,7 +1025,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 
     // Lock chunk handle
     pthread_mutex_t *handle_lock = chunk_tables->Handle2Lock(chunk_handle);
-    LockMutex(handle_lock);
+    MutexLockGuard m(handle_lock);
     chunk_tables->Lock();
     retval = chunk_tables->handle2fd.Lookup(chunk_handle, &chunk_fd);
     assert(retval);
@@ -1064,7 +1064,6 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
           chunk_tables->Lock();
           chunk_tables->handle2fd.Insert(chunk_handle, chunk_fd);
           chunk_tables->Unlock();
-          UnlockMutex(handle_lock);
           fuse_reply_err(req, EIO);
           return;
         }
@@ -1091,7 +1090,6 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
         chunk_tables->Lock();
         chunk_tables->handle2fd.Insert(chunk_handle, chunk_fd);
         chunk_tables->Unlock();
-        UnlockMutex(handle_lock);
         fuse_reply_err(req, -bytes_fetched);
         return;
       }
@@ -1107,7 +1105,6 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     chunk_tables->Lock();
     chunk_tables->handle2fd.Insert(chunk_handle, chunk_fd);
     chunk_tables->Unlock();
-    UnlockMutex(handle_lock);
     LogCvmfs(kLogCvmfs, kLogDebug, "released chunk file descriptor %d",
              chunk_fd.fd);
   } else {

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -30,6 +30,7 @@
 #include "platform.h"
 #include "smalloc.h"
 #include "util/posix.h"
+#include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
@@ -82,56 +83,57 @@ static void Usage() {
 static bool GetNextFile(string *relative_path, string *hash_name) {
   platform_dirent64 *d = NULL;
 
-  pthread_mutex_lock(&g_lock_traverse);
- get_next_file_again:
-  while (g_DIRP_current && ((d = platform_readdir(g_DIRP_current)) != NULL)) {
-    const string name = d->d_name;
-    if ((name == ".") || (name == "..")) continue;
+  {
+    MutexLockGuard m(&g_lock_traverse);
+  get_next_file_again:
+    while (g_DIRP_current && ((d = platform_readdir(g_DIRP_current)) != NULL)) {
+      const string name = d->d_name;
+      if ((name == ".") || (name == "..")) continue;
 
-    platform_stat64 info;
-    *relative_path = *g_current_dir + "/" + name;
-    *hash_name = *g_current_dir + name;
-    const string path = *g_cache_dir + "/" + *relative_path;
-    if (platform_lstat(relative_path->c_str(), &info) != 0) {
-      LogCvmfs(kLogCvmfs, kLogStdout, "Warning: failed to stat() %s (%d)",
-               path.c_str(), errno);
-      continue;
-    }
-
-    if (!S_ISREG(info.st_mode)) {
-      LogCvmfs(kLogCvmfs, kLogStdout, "Warning: %s is not a regular file",
-               path.c_str());
-      continue;
-    }
-
-    break;
-  }
-
-  if (!d) {
-    if (g_DIRP_current) {
-      closedir(g_DIRP_current);
-      g_DIRP_current = NULL;
-    }
-    g_num_dirs++;
-    if (g_num_dirs < 256) {
-      char hex[3];
-      snprintf(hex, sizeof(hex), "%02x", g_num_dirs);
-      *g_current_dir = string(hex, 2);
-
-      if (g_verbose)
-        LogCvmfs(kLogCvmfs, kLogStdout, "Entering %s", g_current_dir->c_str());
-      if ((g_DIRP_current = opendir(hex)) == NULL) {
-        LogCvmfs(kLogCvmfs, kLogStderr,
-                 "Invalid cache directory, %s/%s does not exist",
-                 g_cache_dir->c_str(), g_current_dir->c_str());
-        pthread_mutex_unlock(&g_lock_traverse);
-        exit(kErrorUnfixed);
+      platform_stat64 info;
+      *relative_path = *g_current_dir + "/" + name;
+      *hash_name = *g_current_dir + name;
+      const string path = *g_cache_dir + "/" + *relative_path;
+      if (platform_lstat(relative_path->c_str(), &info) != 0) {
+        LogCvmfs(kLogCvmfs, kLogStdout, "Warning: failed to stat() %s (%d)",
+                 path.c_str(), errno);
+        continue;
       }
-      goto get_next_file_again;
+
+      if (!S_ISREG(info.st_mode)) {
+        LogCvmfs(kLogCvmfs, kLogStdout, "Warning: %s is not a regular file",
+                 path.c_str());
+        continue;
+      }
+
+      break;
+    }
+
+    if (!d) {
+      if (g_DIRP_current) {
+        closedir(g_DIRP_current);
+        g_DIRP_current = NULL;
+      }
+      g_num_dirs++;
+      if (g_num_dirs < 256) {
+        char hex[3];
+        snprintf(hex, sizeof(hex), "%02x", g_num_dirs);
+        *g_current_dir = string(hex, 2);
+
+        if (g_verbose)
+          LogCvmfs(kLogCvmfs, kLogStdout, "Entering %s",
+                   g_current_dir->c_str());
+        if ((g_DIRP_current = opendir(hex)) == NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+                   "Invalid cache directory, %s/%s does not exist",
+                   g_cache_dir->c_str(), g_current_dir->c_str());
+          pthread_mutex_unlock(&g_lock_traverse);
+          exit(kErrorUnfixed);
+        }
+        goto get_next_file_again;
+      }
     }
   }
-  pthread_mutex_unlock(&g_lock_traverse);
-
   if (d)
     return true;
 

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -2588,7 +2588,6 @@ void DownloadManager::GetProxyInfo(vector< vector<ProxyInfo> > *proxy_chain,
     *current_group = opt_proxy_groups_current_;
   if (fallback_group != NULL)
     *fallback_group = opt_proxy_groups_fallback_;
-
 }
 
 string DownloadManager::GetProxyList() {
@@ -2644,7 +2643,6 @@ void DownloadManager::SwitchProxyGroup() {
   //          "switching proxy from %s to %s (manual group change)",
   //          old_proxy.c_str(),
   //          (*opt_proxy_groups_)[opt_proxy_groups_current_][0].c_str());
-
 }
 
 

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -58,6 +58,7 @@
 #include "util/algorithm.h"
 #include "util/posix.h"
 #include "util/string.h"
+#include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
@@ -862,7 +863,7 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   CURL *curl_handle = info->curl_handle;
   string url_prefix;
 
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   // Check if proxy group needs to be reset from backup to primary
   if (opt_timestamp_backup_proxies_ > 0) {
     const time_t now = time(NULL);
@@ -1010,7 +1011,6 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
              replacement.c_str());
     url = ReplaceAll(url, "@proxy@", replacement);
   }
-  pthread_mutex_unlock(lock_options_);
 
   if ((info->destination == kDestinationMem) &&
       (info->destination_mem.size == 0) &&
@@ -1113,15 +1113,16 @@ void DownloadManager::UpdateStatistics(CURL *handle) {
  * Retry if possible if not on no-cache and if not already done too often.
  */
 bool DownloadManager::CanRetry(const JobInfo *info) {
-  pthread_mutex_lock(lock_options_);
-  unsigned max_retries = opt_max_retries_;
-  pthread_mutex_unlock(lock_options_);
+  unsigned max_retries = 0;
+  {
+    MutexLockGuard m(lock_options_);
+    max_retries = opt_max_retries_;
+  }
 
   return !info->nocache && (info->num_retries < max_retries) &&
-    (IsProxyTransferError(info->error_code) ||
-     IsHostTransferError(info->error_code));
+         (IsProxyTransferError(info->error_code) ||
+          IsHostTransferError(info->error_code));
 }
-
 
 /**
  * Backoff for retry to introduce a jitter into a cluster of requesting
@@ -1131,10 +1132,13 @@ bool DownloadManager::CanRetry(const JobInfo *info) {
  * \return true if backoff has been performed, false otherwise
  */
 void DownloadManager::Backoff(JobInfo *info) {
-  pthread_mutex_lock(lock_options_);
-  unsigned backoff_init_ms = opt_backoff_init_ms_;
-  unsigned backoff_max_ms = opt_backoff_max_ms_;
-  pthread_mutex_unlock(lock_options_);
+  unsigned backoff_init_ms = 0;
+  unsigned backoff_max_ms = 0;
+  {
+    MutexLockGuard m(lock_options_);
+    backoff_init_ms = opt_backoff_init_ms_;
+    backoff_max_ms = opt_backoff_max_ms_;
+  }
 
   info->num_retries++;
   perf::Inc(counters_->n_retries);
@@ -1143,13 +1147,11 @@ void DownloadManager::Backoff(JobInfo *info) {
   } else {
     info->backoff_ms *= 2;
   }
-  if (info->backoff_ms > backoff_max_ms)
-    info->backoff_ms = backoff_max_ms;
+  if (info->backoff_ms > backoff_max_ms) info->backoff_ms = backoff_max_ms;
 
   LogCvmfs(kLogDownload, kLogDebug, "backing off for %d ms", info->backoff_ms);
   SafeSleepMs(info->backoff_ms);
 }
-
 
 void DownloadManager::SetNocache(JobInfo *info) {
   if (info->nocache)
@@ -1304,7 +1306,7 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
   bool try_again = false;
   bool same_url_retry = CanRetry(info);
   if (info->error_code != kFailOk) {
-    pthread_mutex_lock(lock_options_);
+    MutexLockGuard m(lock_options_);
     if (info->error_code == kFailBadData) {
       if (!info->nocache) {
         try_again = true;
@@ -1370,7 +1372,6 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
         }
       }  // Make a proxy failure a host failure
     }  // Proxy failure assumed
-    pthread_mutex_unlock(lock_options_);
   }
 
   if (try_again) {
@@ -1741,7 +1742,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
     ReadPipe(info->wait_at[0], &result, sizeof(result));
     // LogCvmfs(kLogDownload, kLogDebug, "got result %d", result);
   } else {
-    pthread_mutex_lock(lock_synchronous_mode_);
+    MutexLockGuard l(lock_synchronous_mode_);
     CURL *handle = AcquireCurlHandle();
     InitializeRequest(info, handle);
     SetUrlOptions(info);
@@ -1756,7 +1757,6 @@ Failures DownloadManager::Fetch(JobInfo *info) {
     } while (VerifyAndFinalize(retval, info));
     result = info->error_code;
     ReleaseCurlHandle(info->curl_handle);
-    pthread_mutex_unlock(lock_synchronous_mode_);
   }
 
   if (result != kFailOk) {
@@ -1782,9 +1782,8 @@ Failures DownloadManager::Fetch(JobInfo *info) {
  * manager.
  */
 void DownloadManager::SetCredentialsAttachment(CredentialsAttachment *ca) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   credentials_attachment_ = ca;
-  pthread_mutex_unlock(lock_options_);
 }
 
 /**
@@ -1799,7 +1798,7 @@ std::string DownloadManager::GetDnsServer() const {
  * default.
  */
 void DownloadManager::SetDnsServer(const string &address) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   if (!address.empty()) {
     opt_dns_server_ = address;
     assert(!opt_dns_server_.empty());
@@ -1809,7 +1808,6 @@ void DownloadManager::SetDnsServer(const string &address) {
     bool retval = resolver_->SetResolvers(servers);
     assert(retval);
   }
-  pthread_mutex_unlock(lock_options_);
   LogCvmfs(kLogDownload, kLogSyslog, "set nameserver to %s", address.c_str());
 }
 
@@ -1821,11 +1819,10 @@ void DownloadManager::SetDnsParameters(
   const unsigned retries,
   const unsigned timeout_ms)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   if ((resolver_->retries() == retries) &&
       (resolver_->timeout_ms() == timeout_ms))
   {
-    pthread_mutex_unlock(lock_options_);
     return;
   }
   delete resolver_;
@@ -1833,7 +1830,6 @@ void DownloadManager::SetDnsParameters(
   resolver_ =
     dns::NormalResolver::Create(opt_ipv4_only_, retries, timeout_ms);
   assert(resolver_);
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1841,17 +1837,15 @@ void DownloadManager::SetDnsTtlLimits(
   const unsigned min_seconds,
   const unsigned max_seconds)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   resolver_->set_min_ttl(min_seconds);
   resolver_->set_max_ttl(max_seconds);
-  pthread_mutex_unlock(lock_options_);
 }
 
 
 void DownloadManager::SetIpPreference(dns::IpPreference preference) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_ip_preference_ = preference;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1863,10 +1857,9 @@ void DownloadManager::SetIpPreference(dns::IpPreference preference) {
 void DownloadManager::SetTimeout(const unsigned seconds_proxy,
                                  const unsigned seconds_direct)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_timeout_proxy_ = seconds_proxy;
   opt_timeout_direct_ = seconds_direct;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1876,9 +1869,8 @@ void DownloadManager::SetTimeout(const unsigned seconds_proxy,
  * consider it to be too slow and abort.  Only effective for new connections.
  */
 void DownloadManager::SetLowSpeedLimit(const unsigned low_speed_limit) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_low_speed_limit_ = low_speed_limit;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1888,10 +1880,9 @@ void DownloadManager::SetLowSpeedLimit(const unsigned low_speed_limit) {
 void DownloadManager::GetTimeout(unsigned *seconds_proxy,
                                  unsigned *seconds_direct)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   *seconds_proxy = opt_timeout_proxy_;
   *seconds_direct = opt_timeout_direct_;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1905,7 +1896,7 @@ void DownloadManager::SetHostChain(const string &host_list) {
 
 
 void DownloadManager::SetHostChain(const std::vector<std::string> &host_list) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_timestamp_backup_host_ = 0;
   delete opt_host_chain_;
   delete opt_host_chain_rtt_;
@@ -1914,7 +1905,6 @@ void DownloadManager::SetHostChain(const std::vector<std::string> &host_list) {
   if (host_list.empty()) {
     opt_host_chain_ = NULL;
     opt_host_chain_rtt_ = NULL;
-    pthread_mutex_unlock(lock_options_);
     return;
   }
 
@@ -1923,7 +1913,6 @@ void DownloadManager::SetHostChain(const std::vector<std::string> &host_list) {
     new vector<int>(opt_host_chain_->size(), kProbeUnprobed);
   // LogCvmfs(kLogDownload, kLogSyslog, "using host %s",
   //          (*opt_host_chain_)[0].c_str());
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1935,13 +1924,12 @@ void DownloadManager::SetHostChain(const std::vector<std::string> &host_list) {
 void DownloadManager::GetHostInfo(vector<string> *host_chain, vector<int> *rtt,
                                   unsigned *current_host)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   if (opt_host_chain_) {
     if (current_host) {*current_host = opt_host_chain_current_;}
     if (host_chain) {*host_chain = *opt_host_chain_;}
     if (rtt) {*rtt = *opt_host_chain_rtt_;}
   }
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1953,16 +1941,14 @@ void DownloadManager::GetHostInfo(vector<string> *host_chain, vector<int> *rtt,
  * by info, otherwise another transfer has already done the switch.
  */
 void DownloadManager::SwitchProxy(JobInfo *info) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
 
   if (!opt_proxy_groups_) {
-    pthread_mutex_unlock(lock_options_);
     return;
   }
   if (info &&
       ((*opt_proxy_groups_)[opt_proxy_groups_current_][0].url != info->proxy))
   {
-    pthread_mutex_unlock(lock_options_);
     return;
   }
 
@@ -2027,8 +2013,6 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
            old_proxy.c_str(), (*group)[0].url.c_str());
   LogCvmfs(kLogDownload, kLogDebug, "%d proxies remain in group",
            group_size - opt_proxy_groups_current_burned_);
-
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -2038,11 +2022,10 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
  * has already done the switch.
  */
 void DownloadManager::SwitchHost(JobInfo *info) {
+  MutexLockGuard m(lock_options_);
   bool do_switch = true;
 
-  pthread_mutex_lock(lock_options_);
   if (!opt_host_chain_ || (opt_host_chain_->size() == 1)) {
-    pthread_mutex_unlock(lock_options_);
     return;
   }
 
@@ -2051,20 +2034,20 @@ void DownloadManager::SwitchHost(JobInfo *info) {
     curl_easy_getinfo(info->curl_handle, CURLINFO_EFFECTIVE_URL,
                       &effective_url);
     if (!HasPrefix(string(effective_url) + "/",
-                   (*opt_host_chain_)[opt_host_chain_current_] + "/",
-                   true))
-    {
+                   (*opt_host_chain_)[opt_host_chain_current_] + "/", true)) {
       do_switch = false;
-      LogCvmfs(kLogDownload, kLogDebug, "don't switch host, "
-               "effective url: %s, current host: %s", effective_url,
+      LogCvmfs(kLogDownload, kLogDebug,
+               "don't switch host, "
+               "effective url: %s, current host: %s",
+               effective_url,
                (*opt_host_chain_)[opt_host_chain_current_].c_str());
     }
   }
 
   if (do_switch) {
     string old_host = (*opt_host_chain_)[opt_host_chain_current_];
-    opt_host_chain_current_ = (opt_host_chain_current_+1) %
-    opt_host_chain_->size();
+    opt_host_chain_current_ =
+        (opt_host_chain_current_ + 1) % opt_host_chain_->size();
     perf::Inc(counters_->n_host_failover);
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
              "switching host from %s to %s", old_host.c_str(),
@@ -2080,9 +2063,7 @@ void DownloadManager::SwitchHost(JobInfo *info) {
       }
     }
   }
-  pthread_mutex_unlock(lock_options_);
 }
-
 
 void DownloadManager::SwitchHost() {
   SwitchHost(NULL);
@@ -2134,15 +2115,15 @@ void DownloadManager::ProbeHosts() {
     if (host_rtt[i] == INT_MAX) host_rtt[i] = kProbeDown;
   }
 
-  pthread_mutex_lock(lock_options_);
-  delete opt_host_chain_;
-  delete opt_host_chain_rtt_;
-  opt_host_chain_ = new vector<string>(host_chain);
-  opt_host_chain_rtt_ = new vector<int>(host_rtt);
-  opt_host_chain_current_ = 0;
-  pthread_mutex_unlock(lock_options_);
+  {
+    MutexLockGuard m(lock_options_);
+    delete opt_host_chain_;
+    delete opt_host_chain_rtt_;
+    opt_host_chain_ = new vector<string>(host_chain);
+    opt_host_chain_rtt_ = new vector<int>(host_rtt);
+    opt_host_chain_current_ = 0;
+  }
 }
-
 
 bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
                     std::vector<uint64_t> *output_order) {
@@ -2166,12 +2147,13 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
   }
   std::string host_list = JoinStrings(server_dns_names, ",");
 
-  // Protect against concurrent access to prng_
-  pthread_mutex_lock(lock_options_);
-  // Determine random hosts for the Geo-API query
-  vector<string> host_chain_shuffled = Shuffle(host_chain, &prng_);
-  pthread_mutex_unlock(lock_options_);
-
+  vector<string> host_chain_shuffled;
+  {
+    // Protect against concurrent access to prng_
+    MutexLockGuard m(lock_options_);
+    // Determine random hosts for the Geo-API query
+    host_chain_shuffled = Shuffle(host_chain, &prng_);
+  }
   // Request ordered list via Geo-API
   bool success = false;
   unsigned max_attempts = std::min(host_chain_shuffled.size(), size_t(3));
@@ -2279,64 +2261,67 @@ bool DownloadManager::ProbeGeo() {
   }
 
   // Re-install host chain and proxy chain
-  pthread_mutex_lock(lock_options_);
-  delete opt_host_chain_;
-  opt_num_proxies_ = 0;
-  opt_host_chain_ = new vector<string>(host_chain.size());
+  {
+    MutexLockGuard m(lock_options_);
+    delete opt_host_chain_;
+    opt_num_proxies_ = 0;
+    opt_host_chain_ = new vector<string>(host_chain.size());
 
-  // It's possible that opt_proxy_groups_fallback_ might have changed while the
-  // lock wasn't held
-  vector< vector< ProxyInfo> > *proxy_groups =
-        new vector< vector<ProxyInfo> > (
-            opt_proxy_groups_fallback_ + proxy_chain.size() - fallback_group);
-  // First copy the non-fallback part of the current proxy chain
-  for (unsigned i = 0; i < opt_proxy_groups_fallback_; ++i) {
-    (*proxy_groups)[i] = (*opt_proxy_groups_)[i];
-    opt_num_proxies_ += (*opt_proxy_groups_)[i].size();
-  }
-
-  // Copy the host chain and fallback proxies by geo order.  Array indices
-  // in geo_order that are smaller than last_geo_host refer to a stratum 1,
-  // and those indices greater than or equal to first_geo_fallback refer to
-  // a fallback proxy.
-  unsigned hosti = 0;
-  unsigned proxyi = opt_proxy_groups_fallback_;
-  for (unsigned i = 0; i < geo_order.size(); ++i) {
-    uint64_t orderval = geo_order[i];
-    if (orderval < (uint64_t) last_geo_host) {
-      // LogCvmfs(kLogCvmfs, kLogSyslog, "this is orderval %u at host index %u",
-      //          orderval, hosti);
-      (*opt_host_chain_)[hosti++] = host_chain[orderval];
-    } else if (orderval >= (uint64_t) first_geo_fallback) {
-      // LogCvmfs(kLogCvmfs, kLogSyslog,
-      //   "this is orderval %u at proxy index %u, using proxy_chain index %u",
-      //   orderval, proxyi, fallback_group + orderval - first_geo_fallback);
-      (*proxy_groups)[proxyi] = proxy_chain[
-            fallback_group + orderval - first_geo_fallback];
-      opt_num_proxies_ += (*proxy_groups)[proxyi].size();
-      proxyi++;
+    // It's possible that opt_proxy_groups_fallback_ might have changed while
+    // the
+    // lock wasn't held
+    vector<vector<ProxyInfo> > *proxy_groups = new vector<vector<ProxyInfo> >(
+        opt_proxy_groups_fallback_ + proxy_chain.size() - fallback_group);
+    // First copy the non-fallback part of the current proxy chain
+    for (unsigned i = 0; i < opt_proxy_groups_fallback_; ++i) {
+      (*proxy_groups)[i] = (*opt_proxy_groups_)[i];
+      opt_num_proxies_ += (*opt_proxy_groups_)[i].size();
     }
-  }
 
-  delete opt_proxy_groups_;
-  opt_proxy_groups_ = proxy_groups;
-  // In pathological cases, opt_proxy_groups_current_ can be larger now when
-  // proxies changed in-between.
-  if (opt_proxy_groups_current_ > opt_proxy_groups_->size()) {
-    if (opt_proxy_groups_->size() == 0) {
-      opt_proxy_groups_current_ = 0;
-    } else {
-      opt_proxy_groups_current_ = opt_proxy_groups_->size() - 1;
+    // Copy the host chain and fallback proxies by geo order.  Array indices
+    // in geo_order that are smaller than last_geo_host refer to a stratum 1,
+    // and those indices greater than or equal to first_geo_fallback refer to
+    // a fallback proxy.
+    unsigned hosti = 0;
+    unsigned proxyi = opt_proxy_groups_fallback_;
+    for (unsigned i = 0; i < geo_order.size(); ++i) {
+      uint64_t orderval = geo_order[i];
+      if (orderval < (uint64_t)last_geo_host) {
+        // LogCvmfs(kLogCvmfs, kLogSyslog, "this is orderval %u at host index
+        // %u",
+        //          orderval, hosti);
+        (*opt_host_chain_)[hosti++] = host_chain[orderval];
+      } else if (orderval >= (uint64_t)first_geo_fallback) {
+        // LogCvmfs(kLogCvmfs, kLogSyslog,
+        //   "this is orderval %u at proxy index %u, using proxy_chain index
+        //   %u",
+        //   orderval, proxyi, fallback_group + orderval - first_geo_fallback);
+        (*proxy_groups)[proxyi] =
+            proxy_chain[fallback_group + orderval - first_geo_fallback];
+        opt_num_proxies_ += (*proxy_groups)[proxyi].size();
+        proxyi++;
+      }
     }
-    opt_proxy_groups_current_burned_ = 0;
+
+    delete opt_proxy_groups_;
+    opt_proxy_groups_ = proxy_groups;
+    // In pathological cases, opt_proxy_groups_current_ can be larger now when
+    // proxies changed in-between.
+    if (opt_proxy_groups_current_ > opt_proxy_groups_->size()) {
+      if (opt_proxy_groups_->size() == 0) {
+        opt_proxy_groups_current_ = 0;
+      } else {
+        opt_proxy_groups_current_ = opt_proxy_groups_->size() - 1;
+      }
+      opt_proxy_groups_current_burned_ = 0;
+    }
+
+    delete opt_host_chain_rtt_;
+    opt_host_chain_rtt_ = new vector<int>(host_chain.size(), kProbeGeo);
+    opt_host_chain_current_ = 0;
+
+    return true;
   }
-
-  delete opt_host_chain_rtt_;
-  opt_host_chain_rtt_ = new vector<int>(host_chain.size(), kProbeGeo);
-  opt_host_chain_current_ = 0;
-  pthread_mutex_unlock(lock_options_);
-
-  return true;
 }
 
 
@@ -2432,7 +2417,7 @@ void DownloadManager::SetProxyChain(
   const string &fallback_proxy_list,
   const ProxySetModes set_mode)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
 
   opt_timestamp_backup_proxies_ = 0;
   opt_timestamp_failover_proxies_ = 0;
@@ -2471,7 +2456,6 @@ void DownloadManager::SetProxyChain(
     opt_proxy_groups_current_burned_ = 0;
     opt_proxy_groups_fallback_ = 0;
     opt_num_proxies_ = 0;
-    pthread_mutex_unlock(lock_options_);
     return;
   }
 
@@ -2572,8 +2556,6 @@ void DownloadManager::SetProxyChain(
     // LogCvmfs(kLogDownload, kLogSyslog, "using proxy %s",
     //          (*opt_proxy_groups_)[0][0].c_str());
   }
-
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -2588,11 +2570,10 @@ void DownloadManager::GetProxyInfo(vector< vector<ProxyInfo> > *proxy_chain,
                                    unsigned *fallback_group)
 {
   assert(proxy_chain != NULL);
+  MutexLockGuard m(lock_options_);
 
-  pthread_mutex_lock(lock_options_);
 
   if (!opt_proxy_groups_) {
-    pthread_mutex_unlock(lock_options_);
     vector< vector<ProxyInfo> > empty_chain;
     *proxy_chain = empty_chain;
     if (current_group != NULL)
@@ -2608,7 +2589,6 @@ void DownloadManager::GetProxyInfo(vector< vector<ProxyInfo> > *proxy_chain,
   if (fallback_group != NULL)
     *fallback_group = opt_proxy_groups_fallback_;
 
-  pthread_mutex_unlock(lock_options_);
 }
 
 string DownloadManager::GetProxyList() {
@@ -2639,9 +2619,8 @@ void DownloadManager::RebalanceProxiesUnlocked() {
 
 
 void DownloadManager::RebalanceProxies() {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   RebalanceProxiesUnlocked();
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -2649,10 +2628,9 @@ void DownloadManager::RebalanceProxies() {
  * Switches to the next load-balancing group of proxy servers.
  */
 void DownloadManager::SwitchProxyGroup() {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
 
   if (!opt_proxy_groups_ || (opt_proxy_groups_->size() < 2)) {
-    pthread_mutex_unlock(lock_options_);
     return;
   }
 
@@ -2667,28 +2645,25 @@ void DownloadManager::SwitchProxyGroup() {
   //          old_proxy.c_str(),
   //          (*opt_proxy_groups_)[opt_proxy_groups_current_][0].c_str());
 
-  pthread_mutex_unlock(lock_options_);
 }
 
 
 void DownloadManager::SetProxyGroupResetDelay(const unsigned seconds) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_proxy_groups_reset_after_ = seconds;
   if (opt_proxy_groups_reset_after_ == 0) {
     opt_timestamp_backup_proxies_ = 0;
     opt_timestamp_failover_proxies_ = 0;
   }
-  pthread_mutex_unlock(lock_options_);
 }
 
 
 void DownloadManager::SetHostResetDelay(const unsigned seconds)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_host_reset_after_ = seconds;
   if (opt_host_reset_after_ == 0)
     opt_timestamp_backup_host_ = 0;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -2696,18 +2671,16 @@ void DownloadManager::SetRetryParameters(const unsigned max_retries,
                                          const unsigned backoff_init_ms,
                                          const unsigned backoff_max_ms)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_max_retries_ = max_retries;
   opt_backoff_init_ms_ = backoff_init_ms;
   opt_backoff_max_ms_ = backoff_max_ms;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
 void DownloadManager::SetMaxIpaddrPerProxy(unsigned limit) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   resolver_->set_throttle(limit);
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -2715,10 +2688,9 @@ void DownloadManager::SetProxyTemplates(
   const std::string &direct,
   const std::string &forced)
 {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   proxy_template_direct_ = direct;
   proxy_template_forced_ = forced;
-  pthread_mutex_unlock(lock_options_);
 }
 
 

--- a/cvmfs/nfs_maps_sqlite.cc
+++ b/cvmfs/nfs_maps_sqlite.cc
@@ -29,6 +29,7 @@
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
+#include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
@@ -236,16 +237,17 @@ uint64_t NfsMapsSqlite::RetryGetInode(const PathString &path, int attempt) {
   }
 
   uint64_t inode;
-  pthread_mutex_lock(lock_);
-  inode = FindInode(path);
-  if (inode) {
-    perf::Inc(n_db_path_found_);
-    pthread_mutex_unlock(lock_);
-    return inode;
+  {
+    MutexLockGuard m(lock_);
+    inode = FindInode(path);
+    if (inode) {
+      perf::Inc(n_db_path_found_);
+      pthread_mutex_unlock(lock_);
+      return inode;
+    }
+    // Inode not found, issue a new one
+    inode = IssueInode(path);
   }
-  // Inode not found, issue a new one
-  inode = IssueInode(path);
-  pthread_mutex_unlock(lock_);
   if (!inode) {
     inode = RetryGetInode(path, attempt + 1);
   }
@@ -269,27 +271,28 @@ uint64_t NfsMapsSqlite::GetInode(const PathString &path) {
  */
 bool NfsMapsSqlite::GetPath(const uint64_t inode, PathString *path) {
   int sqlite_state;
-  pthread_mutex_lock(lock_);
-  sqlite_state = sqlite3_bind_int64(stmt_get_path_, 1, inode);
-  assert(sqlite_state == SQLITE_OK);
-  sqlite_state = sqlite3_step(stmt_get_path_);
-  if (sqlite_state == SQLITE_DONE) {
-    // Success, but inode not found!
+  {
+    MutexLockGuard m(lock_);
+    sqlite_state = sqlite3_bind_int64(stmt_get_path_, 1, inode);
+    assert(sqlite_state == SQLITE_OK);
+    sqlite_state = sqlite3_step(stmt_get_path_);
+    if (sqlite_state == SQLITE_DONE) {
+      // Success, but inode not found!
+      sqlite3_reset(stmt_get_path_);
+      pthread_mutex_unlock(lock_);
+      return false;
+    }
+    if (sqlite_state != SQLITE_ROW) {
+      LogCvmfs(kLogNfsMaps, kLogSyslogErr,
+               "Failed to execute SQL for GetPath (%" PRIu64 "): %s", inode,
+               sqlite3_errmsg(db_));
+      pthread_mutex_unlock(lock_);
+      abort();
+    }
+    const char *raw_path = (const char *)sqlite3_column_text(stmt_get_path_, 0);
+    path->Assign(raw_path, strlen(raw_path));
     sqlite3_reset(stmt_get_path_);
-    pthread_mutex_unlock(lock_);
-    return false;
   }
-  if (sqlite_state != SQLITE_ROW) {
-    LogCvmfs(kLogNfsMaps, kLogSyslogErr,
-             "Failed to execute SQL for GetPath (%" PRIu64 "): %s",
-             inode, sqlite3_errmsg(db_));
-    pthread_mutex_unlock(lock_);
-    abort();
-  }
-  const char *raw_path = (const char *)sqlite3_column_text(stmt_get_path_, 0);
-  path->Assign(raw_path, strlen(raw_path));
-  sqlite3_reset(stmt_get_path_);
-  pthread_mutex_unlock(lock_);
   perf::Inc(n_db_inode_found_);
   return true;
 }

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -242,14 +242,14 @@ void *S3FanoutManager::MainUpload(void *data) {
 
   while (s3fanout_mgr->thread_upload_run_) {
     JobInfo *info = NULL;
-    pthread_mutex_lock(s3fanout_mgr->jobs_todo_lock_);
-    if (!s3fanout_mgr->jobs_todo_.empty() &&
-        (jobs_in_flight < s3fanout_mgr->pool_max_handles_))
     {
-      info = s3fanout_mgr->jobs_todo_.back();
-      s3fanout_mgr->jobs_todo_.pop_back();
+      MutexLockGuard m(s3fanout_mgr->jobs_todo_lock_);
+      if (!s3fanout_mgr->jobs_todo_.empty() &&
+          (jobs_in_flight < s3fanout_mgr->pool_max_handles_)) {
+        info = s3fanout_mgr->jobs_todo_.back();
+        s3fanout_mgr->jobs_todo_.pop_back();
+      }
     }
-    pthread_mutex_unlock(s3fanout_mgr->jobs_todo_lock_);
 
     if (info != NULL) {
       CURL *handle = s3fanout_mgr->AcquireCurlHandle();
@@ -348,9 +348,10 @@ void *S3FanoutManager::MainUpload(void *data) {
           s3fanout_mgr->ReleaseCurlHandle(info, easy_handle);
           s3fanout_mgr->available_jobs_->Decrement();
 
-          pthread_mutex_lock(s3fanout_mgr->jobs_completed_lock_);
-          s3fanout_mgr->jobs_completed_.push_back(info);
-          pthread_mutex_unlock(s3fanout_mgr->jobs_completed_lock_);
+          {
+            MutexLockGuard m(s3fanout_mgr->jobs_completed_lock_);
+            s3fanout_mgr->jobs_completed_.push_back(info);
+          }
         }
       }
     }
@@ -945,10 +946,12 @@ void S3FanoutManager::SetUrlOptions(JobInfo *info) const {
   CURL *curl_handle = info->curl_handle;
   CURLcode retval;
 
-  pthread_mutex_lock(lock_options_);
-  retval = curl_easy_setopt(curl_handle, CURLOPT_CONNECTTIMEOUT, opt_timeout_);
-  assert(retval == CURLE_OK);
-  pthread_mutex_unlock(lock_options_);
+  {
+    MutexLockGuard m(lock_options_);
+    retval =
+        curl_easy_setopt(curl_handle, CURLOPT_CONNECTTIMEOUT, opt_timeout_);
+    assert(retval == CURLE_OK);
+  }
 
   string url = MkUrl(info->hostname, info->bucket, (info->object_key));
   retval = curl_easy_setopt(curl_handle, CURLOPT_URL, url.c_str());
@@ -971,9 +974,11 @@ void S3FanoutManager::UpdateStatistics(CURL *handle) {
  * Retry if possible and if not already done too often.
  */
 bool S3FanoutManager::CanRetry(const JobInfo *info) {
-  pthread_mutex_lock(lock_options_);
-  unsigned max_retries = opt_max_retries_;
-  pthread_mutex_unlock(lock_options_);
+  unsigned max_retries = 0;
+  {
+    MutexLockGuard m(lock_options_);
+    max_retries = opt_max_retries_;
+  }
 
   return
       (info->error_code == kFailHostConnection ||
@@ -990,10 +995,13 @@ bool S3FanoutManager::CanRetry(const JobInfo *info) {
  * \return true if backoff has been performed, false otherwise
  */
 void S3FanoutManager::Backoff(JobInfo *info) {
-  pthread_mutex_lock(lock_options_);
-  unsigned backoff_init_ms = opt_backoff_init_ms_;
-  unsigned backoff_max_ms = opt_backoff_max_ms_;
-  pthread_mutex_unlock(lock_options_);
+  unsigned backoff_init_ms = 0;
+  unsigned backoff_max_ms = 0;
+  {
+    MutexLockGuard m(lock_options_);
+    backoff_init_ms = opt_backoff_init_ms_;
+    backoff_max_ms = opt_backoff_max_ms_;
+  }
 
   if (info->error_code != kFailRetry)
     info->num_retries++;
@@ -1324,9 +1332,8 @@ void S3FanoutManager::Spawn() {
  * DNS, HTTP connect, etc.
  */
 void S3FanoutManager::SetTimeout(const unsigned seconds) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_timeout_ = seconds;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1334,9 +1341,8 @@ void S3FanoutManager::SetTimeout(const unsigned seconds) {
  * Receives the currently active timeout value.
  */
 void S3FanoutManager::GetTimeout(unsigned *seconds) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   *seconds = opt_timeout_;
-  pthread_mutex_unlock(lock_options_);
 }
 
 
@@ -1348,25 +1354,23 @@ const Statistics &S3FanoutManager::GetStatistics() {
 void S3FanoutManager::SetRetryParameters(const unsigned max_retries,
                                          const unsigned backoff_init_ms,
                                          const unsigned backoff_max_ms) {
-  pthread_mutex_lock(lock_options_);
+  MutexLockGuard m(lock_options_);
   opt_max_retries_ = max_retries;
   opt_backoff_init_ms_ = backoff_init_ms;
   opt_backoff_max_ms_ = backoff_max_ms;
-  pthread_mutex_unlock(lock_options_);
 }
 
 /**
  * Get completed jobs, so they can be cleaned and deleted properly.
  */
 int S3FanoutManager::PopCompletedJobs(std::vector<s3fanout::JobInfo*> *jobs) {
-  pthread_mutex_lock(jobs_completed_lock_);
+  MutexLockGuard m(jobs_completed_lock_);
   std::vector<JobInfo*>::iterator             it    = jobs_completed_.begin();
   const std::vector<JobInfo*>::const_iterator itend = jobs_completed_.end();
   for (; it != itend; ++it) {
     jobs->push_back(*it);
   }
   jobs_completed_.clear();
-  pthread_mutex_unlock(jobs_completed_lock_);
 
   return 0;
 }
@@ -1377,9 +1381,8 @@ int S3FanoutManager::PopCompletedJobs(std::vector<s3fanout::JobInfo*> *jobs) {
 void S3FanoutManager::PushNewJob(JobInfo *info) {
   available_jobs_->Increment();
 
-  pthread_mutex_lock(jobs_todo_lock_);
+  MutexLockGuard m(jobs_todo_lock_);
   jobs_todo_.push_back(info);
-  pthread_mutex_unlock(jobs_todo_lock_);
 }
 
 

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -24,6 +24,7 @@
 #include "statistics.h"
 #include "util/posix.h"
 #include "util/string.h"
+#include "util_concurrency.h"
 
 using namespace std; //NOLINT
 
@@ -599,9 +600,10 @@ static void *MainWorker(void *data) {
       last_print_time = time(NULL);
     }
     FileCopy next_copy;
-    pthread_mutex_lock(&lock_pipe);
-    ReadPipe(pipe_chunks[0], &next_copy, sizeof(next_copy));
-    pthread_mutex_unlock(&lock_pipe);
+    {
+      MutexLockGuard m(&lock_pipe);
+      ReadPipe(pipe_chunks[0], &next_copy, sizeof(next_copy));
+    }
     if (next_copy.IsTerminateJob())
       break;
 
@@ -740,4 +742,3 @@ int GarbageCollect(struct fs_traversal *fs) {
 }
 
 }  // namespace shrinkwrap
-

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -39,6 +39,7 @@
 #include "util/posix.h"
 #include "util/shared_ptr.h"
 #include "util/string.h"
+#include "util_concurrency.h"
 
 using namespace std;  // NOLINT
 
@@ -260,9 +261,10 @@ static void *MainWorker(void *data) {
 
   while (1) {
     ChunkJob next_chunk;
-    pthread_mutex_lock(&lock_pipe);
-    ReadPipe(pipe_chunks[0], &next_chunk, sizeof(next_chunk));
-    pthread_mutex_unlock(&lock_pipe);
+    {
+      MutexLockGuard m(&lock_pipe);
+      ReadPipe(pipe_chunks[0], &next_chunk, sizeof(next_chunk));
+    }
     if (next_chunk.IsTerminateJob())
       break;
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -854,10 +854,11 @@ void SyncMediator::AddFile(SharedPtr<SyncItem> entry) {
              "Error: nested catalog marker in root directory");
     abort();
   } else {
-    // Push the file to the spooler, remember the entry for the path
-    pthread_mutex_lock(&lock_file_queue_);
-    file_queue_[entry->GetUnionPath()] = entry;
-    pthread_mutex_unlock(&lock_file_queue_);
+    {
+      // Push the file to the spooler, remember the entry for the path
+      MutexLockGuard m(&lock_file_queue_);
+      file_queue_[entry->GetUnionPath()] = entry;
+    }
     // Spool the file
     params_->spooler->Process(entry->CreateIngestionSource());
   }

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -217,12 +217,11 @@ class PolymorphicConstructionImpl {
     //   fully initialized!
     // See StackOverflow: http://stackoverflow.com/questions/8097439/lazy-initialized-caching-how-do-i-make-it-thread-safe
     if (atomic_read32(&needs_init_)) {
-      pthread_mutex_lock(&init_mutex_);
+      MutexLockGuard m(&init_mutex_);
       if (atomic_read32(&needs_init_)) {
         AbstractProductT::RegisterPlugins();
         atomic_dec32(&needs_init_);
       }
-      pthread_mutex_unlock(&init_mutex_);
     }
 
     assert(!registered_plugins_.empty());

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "atomic.h"
+#include "util_concurrency.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -48,6 +48,8 @@
 #include "logging.h"
 #include "platform.h"
 
+#include "util_concurrency.h"
+
 //using namespace std;  // NOLINT
 
 #ifdef CVMFS_NAMESPACE_GUARD
@@ -564,18 +566,6 @@ void SendMsg2Socket(const int fd, const std::string &msg) {
 }
 
 
-void LockMutex(pthread_mutex_t *mutex) {
-  int retval = pthread_mutex_lock(mutex);
-  assert(retval == 0);
-}
-
-
-void UnlockMutex(pthread_mutex_t *mutex) {
-  int retval = pthread_mutex_unlock(mutex);
-  assert(retval == 0);
-}
-
-
 /**
  * set(e){g/u}id wrapper.
  */
@@ -1071,10 +1061,9 @@ bool GetGidOf(const std::string &groupname, gid_t *gid) {
  *       this function and beware of scalability bottlenecks
  */
 mode_t GetUmask() {
-  LockMutex(&getumask_mutex);
+  MutexLockGuard m(&getumask_mutex);
   const mode_t my_umask = umask(0);
   umask(my_umask);
-  UnlockMutex(&getumask_mutex);
   return my_umask;
 }
 

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -60,8 +60,6 @@ bool DiffTree(const std::string &path_a, const std::string &path_b);
 void Nonblock2Block(int filedes);
 void Block2Nonblock(int filedes);
 void SendMsg2Socket(const int fd, const std::string &msg);
-void LockMutex(pthread_mutex_t *mutex);
-void UnlockMutex(pthread_mutex_t *mutex);
 
 bool SwitchCredentials(const uid_t uid, const gid_t gid,
                        const bool temporarily);

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -712,11 +712,6 @@ TEST_F(T_Util, TcpEndpoints) {
 }
 
 
-TEST_F(T_Util, Mutex) {
-  ASSERT_DEATH(LockMutex(static_cast<pthread_mutex_t*>(NULL)), ".*");
-  ASSERT_DEATH(UnlockMutex(static_cast<pthread_mutex_t*>(NULL)), ".*");
-}
-
 TEST_F(T_Util, SwitchCredentials) {
   // if I am root
   if (getuid() == 0) {


### PR DESCRIPTION
Trying to address https://sft.its.cern.ch/jira/projects/CVM/issues/CVM-694?filter=allopenissues&orderby=cf%5B11250%5D+ASC%2C+priority+DESC%2C+updated+DESC

All almost done, the raw locks that are in the code base are better to leave in. IMHO.

The only file that I was not able to clean up is: cvmfs/logging.cc

It gives some problem when importing "util_concurrency.h" and it necessitate more investigation, nevertheless I would suggest to merge it.

