### PR TITLE
Fix issues with char device and overlayfs

### DIFF
--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -89,6 +89,7 @@ platform_stat64 SyncItemTar::GetStatFromTar() const {
   tar_stat_.st_mode = entry_stat->st_mode;
   tar_stat_.st_uid = entry_stat->st_uid;
   tar_stat_.st_gid = entry_stat->st_gid;
+  tar_stat_.st_rdev = entry_stat->st_rdev;
   tar_stat_.st_size = entry_stat->st_size;
   tar_stat_.st_mtime = entry_stat->st_mtime;
   tar_stat_.st_nlink = entry_stat->st_nlink;
@@ -132,7 +133,7 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
   }
 
   if (this->IsCharacterDevice() || this->IsBlockDevice()) {
-    dirent.size_ = makedev(GetRdevMajor(), GetRdevMinor());
+    dirent.size_ = makedev(major(tar_stat_.st_rdev), minor(tar_stat_.st_rdev));
   }
 
   assert(dirent.IsRegular() || dirent.IsDirectory() || dirent.IsLink() ||

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -1,5 +1,6 @@
 
 cvmfs_test_name="Ingest weird and complex files"
+cvmfs_test_suites="quick"
 cvmfs_test_autofs_on_startup=false
 
 produce_tarball() {


### PR DESCRIPTION
Overlayfs use char devices with number 0/0 to mark whiteouts.

In the previous implementation, every char device was assigned 0/0 as number.

I fix the issue assigning the correct dev numbers.

Still running the tests.