### PR TITLE
Allow garbage collection on repository gateway

### DIFF
--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -272,6 +272,15 @@ CommitProcessor::Result CommitProcessor::Process(
              manifest->catalog_hash().ToString(false).c_str());
   }
 
+  // Ensure CVMFS_ROOT_HASH is not set in
+  // /var/spool/cvmfs/<REPO_NAME>/client.local
+  const std::string fname = "/var/spool/cvmfs/" + repo_name + "/client.local";
+  if (truncate(fname.c_str(), 0) < 0) {
+    LogCvmfs(kLogReceiver, kLogSyslogErr, "Could not truncate %s\n",
+             fname.c_str());
+    return kError;
+  }
+
   return kSuccess;
 }
 

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -219,7 +219,8 @@ CommitProcessor::Result CommitProcessor::Process(
   SigningTool::Result res = signing_tool.Run(
       new_manifest_path, params.stratum0, params.spooler_configuration,
       temp_dir, certificate, private_key, repo_name, "", "",
-      "/var/spool/cvmfs/" + repo_name + "/reflog.chksum");
+      "/var/spool/cvmfs/" + repo_name + "/reflog.chksum",
+      params.garbage_collection);
   switch (res) {
     case SigningTool::kReflogChecksumMissing:
       LogCvmfs(kLogReceiver, kLogSyslogErr,

--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -90,16 +90,7 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
              "CVMFS_USE_FILE_CHUNKING");
     return false;
   }
-  if (use_chunking_str == "true") {
-    params->use_file_chunking = true;
-  } else if (use_chunking_str == "false") {
-    params->use_file_chunking = false;
-  } else {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "Invalid value of repository parameter %s: %s",
-             "CVMFS_USE_FILE_CHUNKING", use_chunking_str.c_str());
-    return false;
-  }
+  params->use_file_chunking = parser.IsOn(use_chunking_str);
 
   std::string min_chunk_size_str;
   if (!parser.GetValue("CVMFS_MIN_CHUNK_SIZE", &min_chunk_size_str)) {
@@ -128,6 +119,15 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
   }
   params->max_chunk_size = String2Uint64(max_chunk_size_str);
 
+  std::string garbage_collection_str;
+  if (!parser.GetValue("CVMFS_GARBAGE_COLLECTION", &garbage_collection_str)) {
+    LogCvmfs(kLogReceiver, kLogSyslogErr,
+             "Missing parameter %s in repository configuration file.",
+             "CVMFS_GARBAGE_COLLECTION");
+    return false;
+  }
+  params->garbage_collection = parser.IsOn(garbage_collection_str);
+
   std::string use_autocatalogs_str;
   if (!parser.GetValue("CVMFS_AUTOCATALOGS", &use_autocatalogs_str)) {
     LogCvmfs(kLogReceiver, kLogSyslogErr,
@@ -135,16 +135,7 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
              "CVMFS_AUTOCATALOGS");
     return false;
   }
-  if (use_autocatalogs_str == "true") {
-    params->use_autocatalogs = true;
-  } else if (use_autocatalogs_str == "false") {
-    params->use_autocatalogs = false;
-  } else {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "Invalid value of repository parameter %s: %s.",
-             "CVMFS_AUTOCATALOGS", use_autocatalogs_str.c_str());
-    return false;
-  }
+  params->use_autocatalogs = parser.IsOn(use_autocatalogs_str);
 
   std::string max_weight_str;
   if (parser.GetValue("CVMFS_AUTOCATALOGS_MAX_WEIGHT", &max_weight_str)) {
@@ -156,12 +147,9 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
     params->min_weight = String2Uint64(min_weight_str);
   }
 
-  params->enforce_limits = false;
   std::string enforce_limits_str;
   if (parser.GetValue("CVMFS_ENFORCE_LIMITS", &enforce_limits_str)) {
-    if (enforce_limits_str == "true") {
-      params->enforce_limits = true;
-    }
+    params->enforce_limits = parser.IsOn(enforce_limits_str);
   }
 
   // TODO(dwd): the next 3 limit variables should take defaults from

--- a/cvmfs/receiver/params.h
+++ b/cvmfs/receiver/params.h
@@ -29,6 +29,7 @@ struct Params {
   size_t nested_kcatalog_limit;
   size_t root_kcatalog_limit;
   size_t file_mbyte_limit;
+  bool garbage_collection;
   bool use_autocatalogs;
   size_t max_weight;
   size_t min_weight;


### PR DESCRIPTION
Addresses [CVM-1705](https://sft.its.cern.ch/jira/browse/CVM-1705).

* Fixes an issue in the manifest generation on the repository gateway, that made it impossible to run garbage collection on the gateway.
* Ensures that no root hash is written in `/var/spool/cvmfs/<REPO_NAME>/client.local` on the gateway after each commit. Without this change, the mount on the gateway was locked to the earlier revision.
