### PR TITLE
Do nothing in snapshot -a if there are no replicas

### DIFF
--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -242,6 +242,11 @@ EOF
     local repodir="${replica%/*}"
     repo="${repodir##*/}"
 
+    if [ "$repo" = "*" ]; then
+      # no replica.conf files were found
+      continue
+    fi
+
     if is_inactive_replica $repo; then
       continue
     fi


### PR DESCRIPTION
Currently it attempts to do snapshot on all files in the current working directory, expanding '*'.