### PR TITLE
Include reflog checksum in the repository manifest

### DIFF
--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -68,6 +68,7 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   bool garbage_collectable = false;
   bool has_alt_catalog_path = false;
   shash::Any meta_info;
+  shash::Any reflog_checksum;
 
   if ((iter = content.find('B')) != content.end())
     catalog_size = String2Uint64(iter->second);
@@ -91,11 +92,14 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   if ((iter = content.find('M')) != content.end())
     meta_info = MkFromHexPtr(shash::HexPtr(iter->second),
                              shash::kSuffixMetainfo);
+  if ((iter = content.find('Y')) != content.end()) {
+    reflog_checksum = MkFromHexPtr(shash::HexPtr(iter->second));
+  }
 
   return new Manifest(catalog_hash, catalog_size, root_path, ttl, revision,
                       micro_catalog_hash, repository_name, certificate,
                       history, publish_timestamp, garbage_collectable,
-                      has_alt_catalog_path, meta_info);
+                      has_alt_catalog_path, meta_info, reflog_checksum);
 }
 
 
@@ -138,6 +142,9 @@ string Manifest::ExportString() const {
     manifest += "T" + StringifyInt(publish_timestamp_) + "\n";
   if (!meta_info_.IsNull())
     manifest += "M" + meta_info_.ToString() + "\n";
+  if (!reflog_checksum_.IsNull()) {
+    manifest += "Y" + reflog_checksum_.ToString() + "\n";
+  }
   // Reserved: Z -> for identification of channel tips
 
   return manifest;

--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -68,7 +68,7 @@ Manifest *Manifest::Load(const map<char, string> &content) {
   bool garbage_collectable = false;
   bool has_alt_catalog_path = false;
   shash::Any meta_info;
-  shash::Any reflog_checksum;
+  shash::Any reflog_hash;
 
   if ((iter = content.find('B')) != content.end())
     catalog_size = String2Uint64(iter->second);
@@ -93,13 +93,13 @@ Manifest *Manifest::Load(const map<char, string> &content) {
     meta_info = MkFromHexPtr(shash::HexPtr(iter->second),
                              shash::kSuffixMetainfo);
   if ((iter = content.find('Y')) != content.end()) {
-    reflog_checksum = MkFromHexPtr(shash::HexPtr(iter->second));
+    reflog_hash = MkFromHexPtr(shash::HexPtr(iter->second));
   }
 
   return new Manifest(catalog_hash, catalog_size, root_path, ttl, revision,
                       micro_catalog_hash, repository_name, certificate,
                       history, publish_timestamp, garbage_collectable,
-                      has_alt_catalog_path, meta_info, reflog_checksum);
+                      has_alt_catalog_path, meta_info, reflog_hash);
 }
 
 
@@ -142,8 +142,8 @@ string Manifest::ExportString() const {
     manifest += "T" + StringifyInt(publish_timestamp_) + "\n";
   if (!meta_info_.IsNull())
     manifest += "M" + meta_info_.ToString() + "\n";
-  if (!reflog_checksum_.IsNull()) {
-    manifest += "Y" + reflog_checksum_.ToString() + "\n";
+  if (!reflog_hash_.IsNull()) {
+    manifest += "Y" + reflog_hash_.ToString() + "\n";
   }
   // Reserved: Z -> for identification of channel tips
 

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -39,7 +39,7 @@ class Manifest {
            const bool garbage_collectable,
            const bool has_alt_catalog_path,
            const shash::Any &meta_info,
-           const shash::Any &reflog_checksum)
+           const shash::Any &reflog_hash)
   : catalog_hash_(catalog_hash)
   , catalog_size_(catalog_size)
   , root_path_(root_path)
@@ -53,7 +53,7 @@ class Manifest {
   , garbage_collectable_(garbage_collectable)
   , has_alt_catalog_path_(has_alt_catalog_path)
   , meta_info_(meta_info)
-  , reflog_checksum_(reflog_checksum) {}
+  , reflog_hash_(reflog_hash) {}
 
   std::string ExportString() const;
   bool Export(const std::string &path) const;
@@ -97,8 +97,8 @@ class Manifest {
   void set_root_path(const std::string &root_path) {
     root_path_ = shash::Md5(shash::AsciiPtr(root_path));
   }
-  void set_reflog_checksum(const shash::Any& checksum) {
-    reflog_checksum_ = checksum;
+  void set_reflog_hash(const shash::Any& checksum) {
+    reflog_hash_ = checksum;
   }
 
   uint64_t revision() const { return revision_; }
@@ -112,7 +112,7 @@ class Manifest {
   bool garbage_collectable() const { return garbage_collectable_; }
   bool has_alt_catalog_path() const { return has_alt_catalog_path_; }
   shash::Any meta_info() const { return meta_info_; }
-  shash::Any reflog_checksum() const { return reflog_checksum_; }
+  shash::Any reflog_hash() const { return reflog_hash_; }
 
   std::string MakeCatalogPath() const {
     return has_alt_catalog_path_ ? catalog_hash_.MakeAlternativePath() :
@@ -154,7 +154,7 @@ class Manifest {
   /**
    * Hash of the reflog file
    */
-  shash::Any reflog_checksum_;
+  shash::Any reflog_hash_;
 };  // class Manifest
 
 }  // namespace manifest

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -38,7 +38,8 @@ class Manifest {
            const uint64_t publish_timestamp,
            const bool garbage_collectable,
            const bool has_alt_catalog_path,
-           const shash::Any &meta_info)
+           const shash::Any &meta_info,
+           const shash::Any &reflog_checksum)
   : catalog_hash_(catalog_hash)
   , catalog_size_(catalog_size)
   , root_path_(root_path)
@@ -51,7 +52,8 @@ class Manifest {
   , publish_timestamp_(publish_timestamp)
   , garbage_collectable_(garbage_collectable)
   , has_alt_catalog_path_(has_alt_catalog_path)
-  , meta_info_(meta_info) { }
+  , meta_info_(meta_info)
+  , reflog_checksum_(reflog_checksum) {}
 
   std::string ExportString() const;
   bool Export(const std::string &path) const;
@@ -95,6 +97,9 @@ class Manifest {
   void set_root_path(const std::string &root_path) {
     root_path_ = shash::Md5(shash::AsciiPtr(root_path));
   }
+  void set_reflog_checksum(const shash::Any& checksum) {
+    reflog_checksum_ = checksum;
+  }
 
   uint64_t revision() const { return revision_; }
   std::string repository_name() const { return repository_name_; }
@@ -107,6 +112,7 @@ class Manifest {
   bool garbage_collectable() const { return garbage_collectable_; }
   bool has_alt_catalog_path() const { return has_alt_catalog_path_; }
   shash::Any meta_info() const { return meta_info_; }
+  shash::Any reflog_checksum() const { return reflog_checksum_; }
 
   std::string MakeCatalogPath() const {
     return has_alt_catalog_path_ ? catalog_hash_.MakeAlternativePath() :
@@ -144,6 +150,11 @@ class Manifest {
    * of recommended stratum 1s, ...)
    */
   shash::Any meta_info_;
+
+  /**
+   * Hash of the reflog file
+   */
+  shash::Any reflog_checksum_;
 };  // class Manifest
 
 }  // namespace manifest

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -70,7 +70,7 @@ SigningTool::Result SigningTool::Run(
   // reflog_chksum_path wasn't given, the reflog checksum can possibly be
   // obtained from the manifest
   if (reflog_chksum_path.empty() || reflog_hash.IsNull()) {
-    reflog_hash = manifest->reflog_checksum();
+    reflog_hash = manifest->reflog_hash();
   }
 
   // Connect to the spooler
@@ -195,7 +195,7 @@ SigningTool::Result SigningTool::Run(
     manifest->set_meta_info(metainfo_hash);
   }
   if (!reflog_hash.IsNull()) {
-    manifest->set_reflog_checksum(reflog_hash);
+    manifest->set_reflog_hash(reflog_hash);
   }
 
   std::string signed_manifest = manifest->ExportString();

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -67,8 +67,8 @@ SigningTool::Result SigningTool::Run(
     return kError;
   }
 
-  // reflog_chksum_path wasn't given, the reflog checksum can possibly be obtained
-  // from the manifest
+  // reflog_chksum_path wasn't given, the reflog checksum can possibly be
+  // obtained from the manifest
   if (reflog_chksum_path.empty() || reflog_hash.IsNull()) {
     reflog_hash = manifest->reflog_checksum();
   }

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -67,6 +67,12 @@ SigningTool::Result SigningTool::Run(
     return kError;
   }
 
+  // reflog_chksum_path wasn't given, the reflog checksum can possibly be obtained
+  // from the manifest
+  if (reflog_chksum_path.empty() || reflog_hash.IsNull()) {
+    reflog_hash = manifest->reflog_checksum();
+  }
+
   // Connect to the spooler
   const upload::SpoolerDefinition sd(spooler_definition,
                                      manifest->GetHashAlgorithm());
@@ -187,6 +193,9 @@ SigningTool::Result SigningTool::Run(
   manifest->set_has_alt_catalog_path(bootstrap_shortcuts);
   if (!metainfo_hash.IsNull()) {
     manifest->set_meta_info(metainfo_hash);
+  }
+  if (!reflog_hash.IsNull()) {
+    manifest->set_reflog_checksum(reflog_hash);
   }
 
   std::string signed_manifest = manifest->ExportString();

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -953,7 +953,7 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
 
   // If there is a reflog, we want to check it
   if (Exists(".cvmfsreflog") && reflog_chksum_path.empty() &&
-      manifest->reflog_checksum().IsNull()) {
+      manifest->reflog_hash().IsNull()) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              ".cvmfsreflog present but no checksum provided, aborting");
     return 1;
@@ -966,7 +966,7 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
       return 1;
     }
   } else {
-    reflog_hash = manifest->reflog_checksum();
+    reflog_hash = manifest->reflog_hash();
   }
 
   // The reflog hash is null here if the reflog doesn't exit, so this does not

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -931,13 +931,6 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     }
   }
 
-  // If there is a reflog, we want to check it
-  if (reflog_chksum_path.empty() && Exists(".cvmfsreflog")) {
-    LogCvmfs(kLogCvmfs, kLogStderr,
-             ".cvmfsreflog present but no checksum provided, aborting");
-    return 1;
-  }
-
   // Load Manifest
   UniquePtr<manifest::Manifest> manifest;
   bool successful = true;
@@ -958,12 +951,27 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
+  // If there is a reflog, we want to check it
+  if (Exists(".cvmfsreflog") && reflog_chksum_path.empty() &&
+      manifest->reflog_checksum().IsNull()) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             ".cvmfsreflog present but no checksum provided, aborting");
+    return 1;
+  }
+
+  shash::Any reflog_hash;
   if (!reflog_chksum_path.empty()) {
-    shash::Any reflog_hash;
     if (!manifest::Reflog::ReadChecksum(reflog_chksum_path, &reflog_hash)) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read reflog checksum");
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read reflog checksum file");
       return 1;
     }
+  } else {
+    reflog_hash = manifest->reflog_checksum();
+  }
+
+  // The reflog hash is null here if the reflog doesn't exit, so this does not
+  // represent an error
+  if (!reflog_hash.IsNull()) {
     bool retval = InspectReflog(reflog_hash, manifest);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to verify reflog");

--- a/test/src/805-repository_gateway_reflog/main
+++ b/test/src/805-repository_gateway_reflog/main
@@ -10,25 +10,45 @@ check_status() {
     echo $(( $1 || 0 ))
 }
 
-run_transactions() {
+run_tests() {
     set_up_repository_gateway
 
-    echo "Check transaction with missing reflog"
-    sudo mv /var/spool/cvmfs/test.repo.org/reflog.chksum /tmp
-    cvmfs_server transaction test.repo.org
+    local test_repo="test.repo.org"
 
-    local output=$(cvmfs_server publish test.repo.org 2>&1 | grep "missing_reflog")
+    echo "Check transaction with missing reflog"
+    sudo mv /var/spool/cvmfs/${test_repo}/reflog.chksum /tmp
+    cvmfs_server transaction ${test_repo}
+
+    local output=$(cvmfs_server publish ${test_repo} 2>&1 | grep "missing_reflog")
 
     if [ x"$output" = x"" ]; then
         echo -n "Error: the missing reflog should have been reported "
         echo "as the cause of the publication error"
 
-        cvmfs_server abort -f test.repo.org
+        cvmfs_server abort -f ${test_repo}
 
         return 1;
     fi
 
-    cvmfs_server abort -f test.repo.org
+    cvmfs_server abort -f ${test_repo}
+
+    # Run repository check
+    cvmfs_server check ${test_repo}
+    if [ $? -ne 0 ]; then
+        echo "Repository integrity check failed with \"reflog.chksum\" present"
+        return 1;
+    fi
+
+    # Move reflog.chksum out of the way to reproduce the environment of a
+    # publisher running on a separate machine
+    mv /var/spool/cvmfs/${test_repo}/reflog.chksum /tmp/
+
+    # Re-run repository check
+    cvmfs_server check ${test_repo}
+    if [ $? -ne 0 ]; then
+        echo "Repository integrity check failed with \"reflog.chksum\" missing"
+        return 1;
+    fi
 
     return 0;
 }
@@ -36,7 +56,7 @@ run_transactions() {
 cvmfs_run_test() {
     trap clean_up EXIT HUP INT TERM || return $?
 
-    run_transactions
+    run_tests
     local status=$?
 
     return $(check_status $status)


### PR DESCRIPTION
Addresses [CVM-1732](https://sft.its.cern.ch/jira/browse/CVM-1732).

* This PR makes the hash of the repository reflog available as an optional member of the manifest. This is needed for cases where `/var/spool/cvmfs/<REPO>/reflog.chksum` is not available, such as on publisher machines connected to a repository gateway.
* The manifest signing tool (`signing_tool.cc`) now obtains the reflog hash from the manifest, if the name of a file on disk containing the hash is not given.
* The `cvmfs_server check` command now falls back to the reflog hash contained in the manifest, if the "reflog.chksum" file is not present, for validating the reflog.