### PR TITLE
Add breadcrumb abstraction for .cvmfschecksum files

### DIFF
--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "hash.h"
+#include "manifest.h"
 #include "util/pointer.h"
 
 
@@ -209,7 +210,12 @@ class CacheManager : SingleCopy {
    * cached manifest copy, the cvmfschecksum.$reponame file. This is important
    * to make pre-loaded alien caches work, even in a tiered setup.
    */
-  virtual std::string GetBackingDirectory() { return ""; }
+  virtual manifest::Breadcrumb LoadBreadcrumb(const std::string & /*fqrn*/) {
+    return manifest::Breadcrumb();
+  }
+  virtual bool StoreBreadcrumb(const manifest::Manifest &/*manifest*/) {
+    return false;
+  }
 
  protected:
   CacheManager();

--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -24,6 +24,7 @@ option optimize_for = LITE_RUNTIME;
 
 // # Protocol changelog
 // Version 1: First version
+//   2019-05-27: add breadcrumb handling
 
 
 //------------------------------------------------------------------------------
@@ -76,9 +77,11 @@ enum EnumCapabilities {
   CAP_REFCOUNT    = 2;
   CAP_SHRINK      = 4;   // clients can ask the cache to shrink
   CAP_INFO        = 8;   // cache plugin knows about its size and fill level
-  CAP_SHRINK_RATE = 16;   // cache knows number of cleanup operations
+  CAP_SHRINK_RATE = 16;  // cache knows number of cleanup operations
   CAP_LIST        = 32;  // cache can return a list of objects
   CAP_ALL_V1      = 63;
+  CAP_BREADCRUMB  = 64;  // cache can load and store breadcrumps
+  CAP_ALL_V2      = 127;
 }
 
 
@@ -94,6 +97,13 @@ message MsgListRecord {
   required MsgHash hash       = 1;
   optional bool pinned        = 2;
   optional string description = 3;
+}
+
+// Contents of the local .cvmfschecksum file
+message MsgBreadcrumb {
+  required string fqrn      = 1;
+  required MsgHash hash     = 2;
+  required uint64 timestamp = 3;
 }
 
 
@@ -297,6 +307,26 @@ message MsgListReply {
   repeated MsgListRecord list_record = 5;
 }
 
+// Request to store and load .cvmfschecksum file
+message MsgBreadcrumbStoreReq {
+  required uint64 session_id         = 1;
+  required uint64 req_id             = 2;
+  required MsgBreadcrumb breadcrumb  = 3;
+}
+
+message MsgBreadcrumbLoadReq {
+  required uint64 session_id         = 1;
+  required uint64 req_id             = 2;
+  required string fqrn               = 3;
+}
+
+message MsgBreadcrumbReply {
+  required uint64 req_id             = 1;
+  required EnumStatus status         = 2;
+  // Only set for successful load request
+  optional MsgBreadcrumb breadcrumb  = 3;
+}
+
 
 //------------------------------------------------------------------------------
 // # RPC Wrapper
@@ -305,36 +335,40 @@ message MsgListReply {
 message MsgRpc {
   oneof message_type {
     // Frequent and performance-critical calls
-    MsgRefcountReq msg_refcount_req          = 1;
-    MsgRefcountReply msg_refcount_reply      = 2;
+    MsgRefcountReq msg_refcount_req                = 1;
+    MsgRefcountReply msg_refcount_reply            = 2;
 
-    MsgReadReq msg_read_req                  = 3;
-    MsgReadReply msg_read_reply              = 4;
+    MsgReadReq msg_read_req                        = 3;
+    MsgReadReply msg_read_reply                    = 4;
 
-    MsgObjectInfoReq msg_object_info_req     = 5;
-    MsgObjectInfoReply msg_object_info_reply = 6;
+    MsgObjectInfoReq msg_object_info_req           = 5;
+    MsgObjectInfoReply msg_object_info_reply       = 6;
 
-    MsgStoreReq msg_store_req                = 7;
-    MsgStoreAbortReq msg_store_abort_req     = 8;
-    MsgStoreReply msg_store_reply            = 9;
+    MsgStoreReq msg_store_req                      = 7;
+    MsgStoreAbortReq msg_store_abort_req           = 8;
+    MsgStoreReply msg_store_reply                  = 9;
 
 
     // Rare RPCs
-    MsgHandshake msg_handshake               = 16;
-    MsgHandshakeAck msg_handshake_ack        = 17;
-    MsgQuit msg_quit                         = 18;
+    MsgHandshake msg_handshake                     = 16;
+    MsgHandshakeAck msg_handshake_ack              = 17;
+    MsgQuit msg_quit                               = 18;
 
-    MsgInfoReq msg_info_req                  = 19;
-    MsgInfoReply msg_info_reply              = 20;
+    MsgInfoReq msg_info_req                        = 19;
+    MsgInfoReply msg_info_reply                    = 20;
 
-    MsgShrinkReq msg_shrink_req              = 21;
-    MsgShrinkReply msg_shrink_reply          = 22;
+    MsgShrinkReq msg_shrink_req                    = 21;
+    MsgShrinkReply msg_shrink_reply                = 22;
 
-    MsgListReq msg_list_req                  = 23;
-    MsgListReply msg_list_reply              = 24;
+    MsgListReq msg_list_req                        = 23;
+    MsgListReply msg_list_reply                    = 24;
 
-    MsgDetach msg_detach                     = 25;
+    MsgDetach msg_detach                           = 25;
 
-    MsgIoctl msg_ioctl                       = 26;
+    MsgIoctl msg_ioctl                             = 26;
+
+    MsgBreadcrumbStoreReq msg_breadcrumb_store_req = 27;
+    MsgBreadcrumbLoadReq msg_breadcrumb_load_req   = 28;
+    MsgBreadcrumbReply msg_breadcrumb_reply        = 29;
   }
 }

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -90,6 +90,9 @@ class ExternalCacheManager : public CacheManager {
   virtual int OpenFromTxn(void *txn);
   virtual int CommitTxn(void *txn);
 
+  virtual manifest::Breadcrumb LoadBreadcrumb(const std::string &fqrn);
+  virtual bool StoreBreadcrumb(const manifest::Manifest &manifest);
+
   virtual void Spawn();
 
   int64_t session_id() const { return session_id_; }
@@ -182,6 +185,10 @@ class ExternalCacheManager : public CacheManager {
       : req_id_(msg->req_id()), part_nr_(0), msg_req_(msg), frame_send_(msg) { }
     explicit RpcJob(cvmfs::MsgListReq *msg)
       : req_id_(msg->req_id()), part_nr_(0), msg_req_(msg), frame_send_(msg) { }
+    explicit RpcJob(cvmfs::MsgBreadcrumbLoadReq *msg)
+      : req_id_(msg->req_id()), part_nr_(0), msg_req_(msg), frame_send_(msg) { }
+    explicit RpcJob(cvmfs::MsgBreadcrumbStoreReq *msg)
+      : req_id_(msg->req_id()), part_nr_(0), msg_req_(msg), frame_send_(msg) { }
 
     void set_attachment_send(void *data, unsigned size) {
       frame_send_.set_attachment(data, size);
@@ -234,6 +241,13 @@ class ExternalCacheManager : public CacheManager {
     cvmfs::MsgListReply *msg_list_reply() {
       cvmfs::MsgListReply *m = reinterpret_cast<cvmfs::MsgListReply *>(
         frame_recv_.GetMsgTyped());
+      assert(m->req_id() == req_id_);
+      return m;
+    }
+    cvmfs::MsgBreadcrumbReply *msg_breadcrumb_reply() {
+      cvmfs::MsgBreadcrumbReply *m =
+        reinterpret_cast<cvmfs::MsgBreadcrumbReply *>(
+          frame_recv_.GetMsgTyped());
       assert(m->req_id() == req_id_);
       return m;
     }

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -17,6 +17,7 @@
 #include "cache.pb.h"
 #include "cache_transport.h"
 #include "hash.h"
+#include "manifest.h"
 #include "murmur.h"
 #include "smallhash.h"
 #include "util/single_copy.h"
@@ -130,6 +131,11 @@ class CachePlugin {
                                         ObjectInfo *item) = 0;
   virtual cvmfs::EnumStatus ListingEnd(int64_t lst_id) = 0;
 
+  virtual cvmfs::EnumStatus LoadBreadcrumb(
+    const std::string &fqrn, manifest::Breadcrumb *breadcrumb) = 0;
+  virtual cvmfs::EnumStatus StoreBreadcrumb(
+    const std::string &fqrn, const manifest::Breadcrumb &breadcrumb) = 0;
+
  private:
   static const unsigned kDefaultMaxObjectSize = 256 * 1024;  // 256kB
   static const unsigned kListingSize = 4 * 1024 * 1024;  // 4MB
@@ -225,6 +231,10 @@ class CachePlugin {
   void HandleInfo(cvmfs::MsgInfoReq *msg_req, CacheTransport *transport);
   void HandleShrink(cvmfs::MsgShrinkReq *msg_req, CacheTransport *transport);
   void HandleList(cvmfs::MsgListReq *msg_req, CacheTransport *transport);
+  void HandleBreadcrumbStore(cvmfs::MsgBreadcrumbStoreReq *msg_req,
+                             CacheTransport *transport);
+  void HandleBreadcrumbLoad(cvmfs::MsgBreadcrumbLoadReq *msg_req,
+                            CacheTransport *transport);
   void HandleIoctl(cvmfs::MsgIoctl *msg_req);
   void SendDetachRequests();
 

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -11,7 +11,9 @@
 //   - Add CVMCACHE_CAP_WRITE capability, adjust other capability constants
 // 2 --> 3:
 //   - Add cvmcache_get_session()
-#define LIBCVMFS_CACHE_REVISION 3
+// 3 --> 4:
+//   - Add breadcrumb management
+#define LIBCVMFS_CACHE_REVISION 4
 
 #include <stdint.h>
 
@@ -67,9 +69,11 @@ enum cvmcache_capabilities {
   CVMCACHE_CAP_REFCOUNT    = 2,
   CVMCACHE_CAP_SHRINK      = 4,   // clients can ask the cache to shrink
   CVMCACHE_CAP_INFO        = 8,   // cache plugin knows about its fill level
-  CVMCACHE_CAP_SHRINK_RATE = 16,   // cache knows number of cleanup operations
+  CVMCACHE_CAP_SHRINK_RATE = 16,  // cache knows number of cleanup operations
   CVMCACHE_CAP_LIST        = 32,  // cache can return a list of objects
-  CVMCACHE_CAP_ALL_V1      = 63
+  CVMCACHE_CAP_ALL_V1      = 63,
+  CVMCACHE_CAP_BREADCRUMB  = 64, // cache can load and store breadcrumps
+  CVMCACHE_CAP_ALL_V2      = 127,
 };
 
 #define CVMCACHE_SIZE_UNKNOWN (uint64_t(-1))
@@ -100,6 +104,11 @@ struct cvmcache_session {
   uint64_t id;
   char *repository_name;
   char *client_instance;
+};
+
+struct cvmcache_breadcrumb {
+  struct cvmcache_hash catalog_hash;
+  uint64_t timestamp;
 };
 
 /**
@@ -162,6 +171,11 @@ struct cvmcache_callbacks {
   int (*cvmcache_listing_next)(int64_t lst_id,
                                struct cvmcache_object_info *item);
   int (*cvmcache_listing_end)(int64_t lst_id);
+
+  int (*cvmcache_breadcrumb_store)(const char *fqrn,
+                                   const cvmcache_breadcrumb *breadcrumb);
+  int (*cvmcache_breadcrumb_load)(const char *fqrn,
+                                  cvmcache_breadcrumb *breadcrumb);
 
   int capabilities;
 };

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -72,7 +72,7 @@ enum cvmcache_capabilities {
   CVMCACHE_CAP_SHRINK_RATE = 16,  // cache knows number of cleanup operations
   CVMCACHE_CAP_LIST        = 32,  // cache can return a list of objects
   CVMCACHE_CAP_ALL_V1      = 63,
-  CVMCACHE_CAP_BREADCRUMB  = 64, // cache can load and store breadcrumps
+  CVMCACHE_CAP_BREADCRUMB  = 64,  // cache can load and store breadcrumps
   CVMCACHE_CAP_ALL_V2      = 127,
 };
 

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -527,6 +527,17 @@ int PosixCacheManager::StartTxn(
 }
 
 
+manifest::Breadcrumb PosixCacheManager::LoadBreadcrumb(const std::string &fqrn)
+{
+  return manifest::Manifest::ReadBreadcrumb(fqrn, cache_path_);
+}
+
+
+bool PosixCacheManager::StoreBreadcrumb(const manifest::Manifest &manifest) {
+  return manifest.ExportBreadcrumb(cache_path_, 0600);
+}
+
+
 void PosixCacheManager::TearDown2ReadOnly() {
   cache_mode_ = kCacheReadOnly;
   while (atomic_read32(&no_inflight_txns_) != 0)

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -95,7 +95,8 @@ class PosixCacheManager : public CacheManager {
 
   virtual void Spawn() { }
 
-  virtual std::string GetBackingDirectory() { return cache_path_; }
+  virtual manifest::Breadcrumb LoadBreadcrumb(const std::string &fqrn);
+  virtual bool StoreBreadcrumb(const manifest::Manifest &manifest);
 
   void TearDown2ReadOnly();
   CacheModes cache_mode() { return cache_mode_; }

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -63,7 +63,8 @@ class TieredCacheManager : public CacheManager {
   virtual int CommitTxn(void *txn);
   virtual void Spawn();
 
-  virtual std::string GetBackingDirectory() { return backing_directory_; }
+  virtual manifest::Breadcrumb LoadBreadcrumb(const std::string &fqrn);
+  virtual bool StoreBreadcrumb(const manifest::Manifest &manifest);
 
  protected:
   virtual void *DoSaveState();
@@ -87,7 +88,6 @@ class TieredCacheManager : public CacheManager {
   CacheManager *upper_;
   CacheManager *lower_;
   bool lower_readonly_;
-  std::string backing_directory_;
 };  // class TieredCacheManager
 
 #endif  // CVMFS_CACHE_TIERED_H_

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -128,6 +128,9 @@ void CacheTransport::Frame::Release() {
   msg_rpc_.release_msg_list_req();
   msg_rpc_.release_msg_list_reply();
   msg_rpc_.release_msg_detach();
+  msg_rpc_.release_msg_breadcrumb_store_req();
+  msg_rpc_.release_msg_breadcrumb_load_req();
+  msg_rpc_.release_msg_breadcrumb_reply();
 }
 
 
@@ -200,6 +203,15 @@ void CacheTransport::Frame::WrapMsg() {
   } else if (msg_typed_->GetTypeName() == "cvmfs.MsgListReply") {
     msg_rpc_.set_allocated_msg_list_reply(
       reinterpret_cast<cvmfs::MsgListReply *>(msg_typed_));
+  } else if (msg_typed_->GetTypeName() == "cvmfs.MsgBreadcrumbStoreReq") {
+    msg_rpc_.set_allocated_msg_breadcrumb_store_req(
+      reinterpret_cast<cvmfs::MsgBreadcrumbStoreReq *>(msg_typed_));
+  } else if (msg_typed_->GetTypeName() == "cvmfs.MsgBreadcrumbLoadReq") {
+    msg_rpc_.set_allocated_msg_breadcrumb_load_req(
+      reinterpret_cast<cvmfs::MsgBreadcrumbLoadReq *>(msg_typed_));
+  } else if (msg_typed_->GetTypeName() == "cvmfs.MsgBreadcrumbReply") {
+    msg_rpc_.set_allocated_msg_breadcrumb_reply(
+      reinterpret_cast<cvmfs::MsgBreadcrumbReply *>(msg_typed_));
   } else if (msg_typed_->GetTypeName() == "cvmfs.MsgDetach") {
     msg_rpc_.set_allocated_msg_detach(
       reinterpret_cast<cvmfs::MsgDetach *>(msg_typed_));
@@ -251,6 +263,12 @@ void CacheTransport::Frame::UnwrapMsg() {
     msg_typed_ = msg_rpc_.mutable_msg_list_req();
   } else if (msg_rpc_.has_msg_list_reply()) {
     msg_typed_ = msg_rpc_.mutable_msg_list_reply();
+  } else if (msg_rpc_.has_msg_breadcrumb_store_req()) {
+    msg_typed_ = msg_rpc_.mutable_msg_breadcrumb_store_req();
+  } else if (msg_rpc_.has_msg_breadcrumb_load_req()) {
+    msg_typed_ = msg_rpc_.mutable_msg_breadcrumb_load_req();
+  } else if (msg_rpc_.has_msg_breadcrumb_reply()) {
+    msg_typed_ = msg_rpc_.mutable_msg_breadcrumb_reply();
   } else if (msg_rpc_.has_msg_detach()) {
     msg_typed_ = msg_rpc_.mutable_msg_detach();
     is_msg_out_of_band_ = true;

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -138,15 +138,11 @@ LoadError ClientCatalogManager::LoadCatalog(
   }
 
   // Happens only on init/remount, i.e. quota won't delete a cached catalog
-  string checksum_dir = fetcher_->cache_mgr()->GetBackingDirectory();
-  if (checksum_dir.empty())
-    checksum_dir = ".";
   shash::Any cache_hash(shash::kSha1, shash::kSuffixCatalog);
   uint64_t cache_last_modified = 0;
 
-  manifest::Breadcrumb breadcrumb;
-  retval = manifest::Manifest::ReadBreadcrumb(
-    repo_name_, checksum_dir, &breadcrumb);
+  manifest::Breadcrumb breadcrumb =
+    fetcher_->cache_mgr()->LoadBreadcrumb(repo_name_);
   if (retval) {
     cache_hash = breadcrumb.catalog_hash;
     cache_last_modified = breadcrumb.timestamp;
@@ -234,7 +230,7 @@ LoadError ClientCatalogManager::LoadCatalog(
   fetcher_->cache_mgr()->CommitFromMem(ensemble.manifest->certificate(),
                                        ensemble.cert_buf, ensemble.cert_size,
                                        "certificate for " + repo_name_);
-  ensemble.manifest->ExportBreadcrumb(workspace_, 0600);
+  fetcher_->cache_mgr()->StoreBreadcrumb(*ensemble.manifest);
   return catalog::kLoadNew;
 }
 

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -144,9 +144,12 @@ LoadError ClientCatalogManager::LoadCatalog(
   shash::Any cache_hash(shash::kSha1, shash::kSuffixCatalog);
   uint64_t cache_last_modified = 0;
 
-  retval = manifest::Manifest::ReadChecksum(
-    repo_name_, checksum_dir, &cache_hash, &cache_last_modified);
+  manifest::Breadcrumb breadcrumb;
+  retval = manifest::Manifest::ReadBreadcrumb(
+    repo_name_, checksum_dir, &breadcrumb);
   if (retval) {
+    cache_hash = breadcrumb.catalog_hash;
+    cache_last_modified = breadcrumb.timestamp;
     LogCvmfs(kLogCache, kLogDebug, "cached copy publish date %s (hash %s)",
              StringifyTime(cache_last_modified, true).c_str(),
              cache_hash.ToString().c_str());
@@ -231,7 +234,7 @@ LoadError ClientCatalogManager::LoadCatalog(
   fetcher_->cache_mgr()->CommitFromMem(ensemble.manifest->certificate(),
                                        ensemble.cert_buf, ensemble.cert_size,
                                        "certificate for " + repo_name_);
-  ensemble.manifest->ExportChecksum(workspace_, 0600);
+  ensemble.manifest->ExportBreadcrumb(workspace_, 0600);
   return catalog::kLoadNew;
 }
 

--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -235,23 +235,21 @@ bool Manifest::ExportBreadcrumb(const string &directory, const int mode) const {
  * Read the hash and the last-modified time stamp from the
  * cvmfschecksum.$repository file in the given directory.
  */
-bool Manifest::ReadBreadcrumb(
+Breadcrumb Manifest::ReadBreadcrumb(
   const std::string &repo_name,
-  const std::string &directory,
-  Breadcrumb *breadcrumb)
+  const std::string &directory)
 {
-  bool result = false;
+  Breadcrumb breadcrumb;
   const string breadcrumb_path = directory + "/cvmfschecksum." + repo_name;
   FILE *fbreadcrumb = fopen(breadcrumb_path.c_str(), "r");
   char tmp[128];
   int read_bytes;
   if (fbreadcrumb && (read_bytes = fread(tmp, 1, 128, fbreadcrumb)) > 0) {
-    *breadcrumb = Breadcrumb(std::string(tmp, read_bytes));
-    result = breadcrumb->IsValid();
+    breadcrumb = Breadcrumb(std::string(tmp, read_bytes));
   }
   if (fbreadcrumb) fclose(fbreadcrumb);
 
-  return result;
+  return breadcrumb;
 }
 
 }  // namespace manifest

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -75,9 +75,8 @@ class Manifest {
   std::string ExportString() const;
   bool Export(const std::string &path) const;
   bool ExportBreadcrumb(const std::string &directory, const int mode) const;
-  static bool ReadBreadcrumb(const std::string &repo_name,
-                             const std::string &directory,
-                             Breadcrumb *breadcrumb);
+  static Breadcrumb ReadBreadcrumb(const std::string &repo_name,
+                                   const std::string &directory);
 
   shash::Algorithms GetHashAlgorithm() const { return catalog_hash_.algorithm; }
 

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -16,6 +16,23 @@
 namespace manifest {
 
 /**
+ * The breadcrumb stores the catalog root hash and a time stamp.  It is used
+ * to store the last known copy of the catalog in the cache.
+ */
+struct Breadcrumb {
+  Breadcrumb() : catalog_hash(), timestamp(0) {}
+  Breadcrumb(const shash::Any &h, uint64_t t) : catalog_hash(h), timestamp(t) {}
+  explicit Breadcrumb(const std::string &from_string);
+
+  std::string ToString() const;
+  bool IsValid() const { return !catalog_hash.IsNull() && (timestamp > 0); }
+
+  shash::Any catalog_hash;
+  uint64_t timestamp;
+};
+
+
+/**
  * The Manifest is the bootstrap snippet for a repository.  It is stored in
  * .cvmfspublished.
  */
@@ -57,11 +74,10 @@ class Manifest {
 
   std::string ExportString() const;
   bool Export(const std::string &path) const;
-  bool ExportChecksum(const std::string &directory, const int mode) const;
-  static bool ReadChecksum(const std::string &repo_name,
-                           const std::string &directory,
-                           shash::Any *hash,
-                           uint64_t *last_modified);
+  bool ExportBreadcrumb(const std::string &directory, const int mode) const;
+  static bool ReadBreadcrumb(const std::string &repo_name,
+                             const std::string &directory,
+                             Breadcrumb *breadcrumb);
 
   shash::Algorithms GetHashAlgorithm() const { return catalog_hash_.algorithm; }
 

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -882,7 +882,8 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     }
 
     if (preload_cache) {
-      bool retval = ensemble.manifest->ExportChecksum(*preload_cachedir, 0660);
+      bool retval =
+        ensemble.manifest->ExportBreadcrumb(*preload_cachedir, 0660);
       assert(retval);
     } else {
       // pkcs#7 structure contains content + certificate + signature

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -298,6 +298,7 @@ set (CVMFS_TEST_CACHE_SOURCES
   ${CVMFS_SOURCE_DIR}/compression.cc
   ${CVMFS_SOURCE_DIR}/hash.cc
   ${CVMFS_SOURCE_DIR}/logging.cc
+  ${CVMFS_SOURCE_DIR}/manifest.cc
   ${CVMFS_SOURCE_DIR}/quota.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -406,3 +406,27 @@ TEST_F(T_CachePlugin, List) {
     EXPECT_EQ(0, cache_mgr_->Close(*i));
   }
 }
+
+
+TEST_F(T_CachePlugin, Breadcrumbs) {
+  if (!(cache_mgr_->capabilities() & cvmfs::CAP_BREADCRUMB)) {
+    printf("Skipping\n");
+    return;
+  }
+
+  manifest::Breadcrumb breadcrumb;
+  breadcrumb = cache_mgr_->LoadBreadcrumb("test");
+  EXPECT_FALSE(breadcrumb.IsValid());
+
+  shash::Any hash(shash::kShake128);
+  hash.Randomize();
+  manifest::Manifest manifest(hash, 1, "");
+  manifest.set_repository_name("test");
+  manifest.set_publish_timestamp(1);
+  EXPECT_TRUE(cache_mgr_->StoreBreadcrumb(manifest));
+
+  breadcrumb = cache_mgr_->LoadBreadcrumb("test");
+  EXPECT_TRUE(breadcrumb.IsValid());
+  EXPECT_EQ(hash, breadcrumb.catalog_hash);
+  EXPECT_EQ(1U, breadcrumb.timestamp);
+}

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -251,7 +251,7 @@ const unsigned T_ExternalCacheManager::nfiles = 128;
 TEST_F(T_ExternalCacheManager, Connection) {
   EXPECT_GE(cache_mgr_->session_id(), 0);
   EXPECT_EQ(getpid(), cache_mgr_->quota_mgr()->GetPid());
-  EXPECT_TRUE(cache_mgr_->GetBackingDirectory().empty());
+  EXPECT_FALSE(cache_mgr_->LoadBreadcrumb("").IsValid());
 
   // Invalid query for session information outside callback
   uint64_t id;

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ class MockCachePlugin : public CachePlugin {
 
   MockCachePlugin(const string &socket_path, bool read_only)
     : CachePlugin(read_only ? (cvmfs::CAP_ALL_V1 & ~cvmfs::CAP_WRITE)
-                            : cvmfs::CAP_ALL_V1)
+                            : cvmfs::CAP_ALL_V2)
   {
     bool retval = Listen("unix=" + socket_path);
     assert(retval);
@@ -74,6 +75,7 @@ class MockCachePlugin : public CachePlugin {
   uint64_t last_id;
   char *last_reponame;
   char *last_client_instance;
+  std::map<std::string, manifest::Breadcrumb> breadcrumbs;
 
  protected:
   virtual cvmfs::EnumStatus ChangeRefcount(
@@ -208,6 +210,24 @@ class MockCachePlugin : public CachePlugin {
   virtual cvmfs::EnumStatus ListingEnd(int64_t lst_id) {
     return cvmfs::STATUS_OK;
   }
+
+  virtual cvmfs::EnumStatus LoadBreadcrumb(
+    const std::string &fqrn, manifest::Breadcrumb *breadcrumb)
+  {
+    map<std::string, manifest::Breadcrumb>::const_iterator itr =
+      breadcrumbs.find(fqrn);
+    if (itr == breadcrumbs.end())
+      return cvmfs::STATUS_NOENTRY;
+    *breadcrumb = itr->second;
+    return cvmfs::STATUS_OK;
+  }
+
+  virtual cvmfs::EnumStatus StoreBreadcrumb(
+    const std::string &fqrn, const manifest::Breadcrumb &breadcrumb)
+  {
+    breadcrumbs[fqrn] = breadcrumb;
+    return cvmfs::STATUS_OK;
+  }
 };
 
 const unsigned MockCachePlugin::kMockCacheSize = 10 * 1024 * 1024;
@@ -251,7 +271,6 @@ const unsigned T_ExternalCacheManager::nfiles = 128;
 TEST_F(T_ExternalCacheManager, Connection) {
   EXPECT_GE(cache_mgr_->session_id(), 0);
   EXPECT_EQ(getpid(), cache_mgr_->quota_mgr()->GetPid());
-  EXPECT_FALSE(cache_mgr_->LoadBreadcrumb("").IsValid());
 
   // Invalid query for session information outside callback
   uint64_t id;
@@ -554,6 +573,24 @@ TEST_F(T_ExternalCacheManager, Listing) {
   EXPECT_EQ(empty, quota_mgr_->ListCatalogs());
   EXPECT_EQ(empty, quota_mgr_->ListVolatile());
   EXPECT_EQ(empty, quota_mgr_->ListPinned());
+}
+
+TEST_F(T_ExternalCacheManager, Breadcrumbs) {
+  manifest::Breadcrumb breadcrumb;
+  breadcrumb = cache_mgr_->LoadBreadcrumb("test");
+  EXPECT_FALSE(breadcrumb.IsValid());
+
+  shash::Any hash(shash::kShake128);
+  hash.Randomize();
+  manifest::Manifest manifest(hash, 1, "");
+  manifest.set_repository_name("test");
+  manifest.set_publish_timestamp(1);
+  EXPECT_TRUE(cache_mgr_->StoreBreadcrumb(manifest));
+
+  breadcrumb = cache_mgr_->LoadBreadcrumb("test");
+  EXPECT_TRUE(breadcrumb.IsValid());
+  EXPECT_EQ(hash, breadcrumb.catalog_hash);
+  EXPECT_EQ(1U, breadcrumb.timestamp);
 }
 
 namespace {

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -22,7 +22,7 @@ class T_TieredCacheManager : public ::testing::Test {
       new RamCacheManager(1024, 128, MemoryKvStore::kMallocLibc,
                           perf::StatisticsTemplate("test", &stats_lower_));
     tiered_cache_ = TieredCacheManager::Create(upper_cache_, lower_cache_);
-    EXPECT_TRUE(tiered_cache_->GetBackingDirectory().empty());
+    EXPECT_FALSE(tiered_cache_->LoadBreadcrumb("test").IsValid());
     buf_ = 'x';
     hash_one_.digest[1] = 1;
   }

--- a/test/unittests/t_manifest.cc
+++ b/test/unittests/t_manifest.cc
@@ -35,6 +35,7 @@ class T_Manifest : public ::testing::Test {
 
 
 TEST_F(T_Manifest, Breadcrumb) {
+  EXPECT_FALSE(Breadcrumb().IsValid());
   EXPECT_FALSE(Breadcrumb(shash::Any(shash::kSha1), 0).IsValid());
   EXPECT_FALSE(Breadcrumb(shash::Any(shash::kShake128), 1).IsValid());
   shash::Any rnd_hash(shash::kRmd160);
@@ -57,27 +58,28 @@ TEST_F(T_Manifest, Breadcrumb) {
 
 
 TEST_F(T_Manifest, ReadBreadcrumb) {
-  Breadcrumb breadcrumb;
-  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_).IsValid());
 
   shash::Any rnd_hash(shash::kRmd160);
   rnd_hash.Randomize();
   FILE *f = fopen((tmp_path_ + "/cvmfschecksum.test").c_str(), "w");
   ASSERT_TRUE(f != NULL);
 
-  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_).IsValid());
 
   fwrite(rnd_hash.ToString().data(), 1, rnd_hash.ToString().length(), f);
   fflush(f);
-  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_).IsValid());
 
   fwrite("T", 1, 1, f);
   fflush(f);
-  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_).IsValid());
 
   fwrite("42", 2, 1, f);
   fflush(f);
-  EXPECT_TRUE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
+
+  Breadcrumb breadcrumb = Manifest::ReadBreadcrumb("test", tmp_path_);
+  EXPECT_TRUE(breadcrumb.IsValid());
   EXPECT_TRUE(breadcrumb.IsValid());
   EXPECT_EQ(rnd_hash, breadcrumb.catalog_hash);
   EXPECT_EQ(42U, breadcrumb.timestamp);

--- a/test/unittests/t_manifest.cc
+++ b/test/unittests/t_manifest.cc
@@ -34,36 +34,53 @@ class T_Manifest : public ::testing::Test {
 };
 
 
-TEST_F(T_Manifest, ReadChecksum) {
-  shash::Any retrieved_hash;
-  uint64_t last_modified = 0;
+TEST_F(T_Manifest, Breadcrumb) {
+  EXPECT_FALSE(Breadcrumb(shash::Any(shash::kSha1), 0).IsValid());
+  EXPECT_FALSE(Breadcrumb(shash::Any(shash::kShake128), 1).IsValid());
+  shash::Any rnd_hash(shash::kRmd160);
+  rnd_hash.Randomize();
+  EXPECT_FALSE(Breadcrumb(rnd_hash, 0).IsValid());
+  EXPECT_TRUE(Breadcrumb(rnd_hash, 1).IsValid());
+
+  EXPECT_FALSE(Breadcrumb("").IsValid());
+  EXPECT_FALSE(Breadcrumb("0").IsValid());
+  EXPECT_FALSE(Breadcrumb("T").IsValid());
+  EXPECT_FALSE(Breadcrumb("TTT").IsValid());
+  EXPECT_FALSE(Breadcrumb("T0").IsValid());
+  EXPECT_FALSE(Breadcrumb("T1").IsValid());
+  EXPECT_FALSE(Breadcrumb("0T").IsValid());
+  EXPECT_TRUE(
+    Breadcrumb("0000000000000000000000000000000000000001T1").IsValid());
   EXPECT_FALSE(
-    Manifest::ReadChecksum("test", tmp_path_, &retrieved_hash, &last_modified));
+    Breadcrumb("0000000000000000000000000000000000000001T0").IsValid());
+}
+
+
+TEST_F(T_Manifest, ReadBreadcrumb) {
+  Breadcrumb breadcrumb;
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
 
   shash::Any rnd_hash(shash::kRmd160);
   rnd_hash.Randomize();
   FILE *f = fopen((tmp_path_ + "/cvmfschecksum.test").c_str(), "w");
   ASSERT_TRUE(f != NULL);
 
-  EXPECT_FALSE(
-    Manifest::ReadChecksum("test", tmp_path_, &retrieved_hash, &last_modified));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
 
   fwrite(rnd_hash.ToString().data(), 1, rnd_hash.ToString().length(), f);
   fflush(f);
-  EXPECT_FALSE(
-    Manifest::ReadChecksum("test", tmp_path_, &retrieved_hash, &last_modified));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
 
   fwrite("T", 1, 1, f);
   fflush(f);
-  EXPECT_FALSE(
-    Manifest::ReadChecksum("test", tmp_path_, &retrieved_hash, &last_modified));
+  EXPECT_FALSE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
 
   fwrite("42", 2, 1, f);
   fflush(f);
-  EXPECT_TRUE(
-    Manifest::ReadChecksum("test", tmp_path_, &retrieved_hash, &last_modified));
-  EXPECT_EQ(rnd_hash, retrieved_hash);
-  EXPECT_EQ(42U, last_modified);
+  EXPECT_TRUE(Manifest::ReadBreadcrumb("test", tmp_path_, &breadcrumb));
+  EXPECT_TRUE(breadcrumb.IsValid());
+  EXPECT_EQ(rnd_hash, breadcrumb.catalog_hash);
+  EXPECT_EQ(42U, breadcrumb.timestamp);
 
   fclose(f);
 }


### PR DESCRIPTION
The .cvmfschecksum files are used to remember the last good root catalog in a local cache.  This is now wrapped in the Breadcrumb abstraction and part of the cache manager interface.  It should fix various corner cases with uncommon cache manager configurations, where previously it was unclear where to store/load the .cvmfschecksum data.