### PR TITLE
Turn failure to set requested CVMFS_NFILES into a warning

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -814,10 +814,14 @@ int FuseMain(int argc, char *argv[]) {
     if (retval == -2) {
       LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: running under valgrind");
     } else if (retval == -1) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to set maximum number of open files, "
-               "insufficient permissions");
-      return kFailPermission;
+      unsigned soft_limit, hard_limit;
+      GetLimitNoFile(&soft_limit, &hard_limit);
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogWarn,
+               "Failed to set requested number of open files, "
+               "using maximum number %u", hard_limit);
+      if (hard_limit > soft_limit) {
+        (void) SetLimitNoFile(hard_limit);
+      }
     }
   }
 

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -827,7 +827,7 @@ int FuseMain(int argc, char *argv[]) {
       }
       unsigned soft_limit, hard_limit;
       GetLimitNoFile(&soft_limit, &hard_limit);
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogWarn,
+      LogCvmfs(kLogCvmfs, kLogStdout | kLogSyslogWarn,
                "Failed to set requested number of open files, "
                "using maximum number %u", hard_limit);
       if (hard_limit > soft_limit) {

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -479,6 +479,7 @@ int main(int argc, char **argv) {
   }
 #endif
 
+  AddMountOption("system_mount", &mount_options);
   AddMountOption("fsname=cvmfs2", &mount_options);
   AddMountOption("allow_other", &mount_options);
   AddMountOption("grab_mountpoint", &mount_options);


### PR DESCRIPTION
Something like this is needed along with pr #2361 in order for an unprivileged user to not have to select a specific CVMFS_NFILES matching their ulimit -Hn.