### PR TITLE
Explicitly specify python2 in webapi/cvmfs-api.py shebang

### DIFF
--- a/cvmfs/webapi/cvmfs-api.wsgi
+++ b/cvmfs/webapi/cvmfs-api.wsgi
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 
 import os, sys, re
 import cvmfs_api


### PR DESCRIPTION
As of Fedora 30, shebangs with unspecified python versions are
forbidden. Let's explicitly set the shebang to python2