### PR TITLE
WIP: add test for looking at file before kcache timeout

### DIFF
--- a/test/src/611-idleclient/main
+++ b/test/src/611-idleclient/main
@@ -91,6 +91,23 @@ cvmfs_run_test() {
     return 21
   fi
 
+  echo "starting transaction to update repository again"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "add another new file"
+  touch $repo_dir/newfile || return 31
+
+  echo "attempt to access the file before publishing, expect missing"
+  stat $TEST_611_MOUNTPOINT/newfile && return 32
+
+  echo "creating CVMFS snapshot"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  sleep_time=3
+  echo "sleeping $sleep_time seconds to let ttl expire but not kernel cache"
+  ls -l $TEST_611_MOUNTPOINT || return 33
+  stat $TEST_611_MOUNTPOINT/newfile || return 34
+
   return 0
 }
 

--- a/test/src/611-idleclient/main
+++ b/test/src/611-idleclient/main
@@ -105,6 +105,7 @@ cvmfs_run_test() {
 
   sleep_time=3
   echo "sleeping $sleep_time seconds to let ttl expire but not kernel cache"
+  sleep $sleep_time
   ls -l $TEST_611_MOUNTPOINT || return 33
   stat $TEST_611_MOUNTPOINT/newfile || return 34
 


### PR DESCRIPTION
This test addition demonstrates the failure reported in [CVM-1759](https://sft.its.cern.ch/jira/browse/CVM-1759)