### PR TITLE
S3fanout: a few improvements + refactor

### DIFF
--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -211,7 +211,7 @@ class S3FanoutManager : SingleCopy {
   const std::string access_key_;
   const std::string secret_key_;
   const AuthzMethods authz_method_;
-  const std::string hostname_;
+  const std::string complete_hostname_;
   const std::string region_;
   const std::string bucket_;
   const bool dns_buckets_;
@@ -277,13 +277,20 @@ class S3FanoutManager : SingleCopy {
                  std::vector<std::string> *headers) const;
   bool MkV4Authz(const JobInfo &info,
                  std::vector<std::string> *headers) const;
-  std::string MkUrl(const std::string &host,
-                    const std::string &bucket,
-                    const std::string &objkey2) const {
+  std::string MkUrl(const std::string &objkey) const {
     if (dns_buckets_) {
-      return "http://" + bucket + "." + host + "/" + objkey2;
+      return "http://" + complete_hostname_ + "/" + objkey;
     } else {
-      return "http://" + host + "/" + bucket + "/" + objkey2;
+      return "http://" + complete_hostname_ + "/" + bucket_ + "/" + objkey;
+    }
+  }
+  static std::string MkCompleteHostname(const std::string &hostname,
+                                        const std::string &bucket,
+                                        const bool &dns_buckets) {
+    if (dns_buckets) {
+      return bucket + "." + hostname;
+    } else {
+      return hostname;
     }
   }
 

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -257,6 +257,7 @@ class S3FanoutManager : SingleCopy {
 
   CURL *AcquireCurlHandle() const;
   void ReleaseCurlHandle(JobInfo *info, CURL *handle) const;
+  void InitPipeWatchFds();
   int InitializeDnsSettings(CURL *handle,
                             std::string remote_host) const;
   void InitializeDnsSettingsCurl(CURL *handle, CURLSH *sharehandle,
@@ -316,13 +317,15 @@ class S3FanoutManager : SingleCopy {
   mutable std::map<std::string, std::string> signing_keys_;
 
   pthread_t thread_upload_;
-  bool thread_upload_run_;
   atomic_int32 multi_threaded_;
 
   struct pollfd *watch_fds_;
   uint32_t watch_fds_size_;
   uint32_t watch_fds_inuse_;
   uint32_t watch_fds_max_;
+
+  int pipe_terminate_[2];
+  int pipe_jobs_[2];
 
   pthread_mutex_t *lock_options_;
   unsigned opt_timeout_;

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -206,39 +206,42 @@ class S3FanoutManager : SingleCopy {
   static const unsigned kThrottleReportIntervalSec;
   static const unsigned kDefaultHTTPPort;
 
+  struct S3Config {
+    S3Config() {
+      authz_method = kAuthzAwsV2;
+      dns_buckets = true;
+      pool_max_handles = 0;
+      opt_timeout_sec = 20;
+      opt_max_retries = 3;
+      opt_backoff_init_ms = 100;
+      opt_backoff_max_ms = 2000;
+    }
+    std::string access_key;
+    std::string secret_key;
+    std::string hostname_port;
+    AuthzMethods authz_method;
+    std::string region;
+    std::string bucket;
+    bool dns_buckets;
+    uint32_t pool_max_handles;
+    unsigned opt_timeout_sec;
+    unsigned opt_max_retries;
+    unsigned opt_backoff_init_ms;
+    unsigned opt_backoff_max_ms;
+  };
+
   static void DetectThrottleIndicator(const std::string &header, JobInfo *info);
 
-  const std::string access_key_;
-  const std::string secret_key_;
-  const AuthzMethods authz_method_;
-  const std::string complete_hostname_;
-  const std::string region_;
-  const std::string bucket_;
-  const bool dns_buckets_;
-
-  S3FanoutManager(const std::string access_key,
-                  const std::string secret_key,
-                  const AuthzMethods authz_method,
-                  const std::string hostname,
-                  const std::string region,
-                  const std::string bucket,
-                  bool dns_buckets);
+  explicit S3FanoutManager(const S3Config &config);
 
   ~S3FanoutManager();
 
-  void Init(const unsigned max_pool_handles);
-  void Fini();
   void Spawn();
 
   void PushNewJob(JobInfo *info);
   int PopCompletedJobs(std::vector<s3fanout::JobInfo*> *jobs);
 
   const Statistics &GetStatistics();
-  void SetTimeout(const unsigned seconds);
-  void GetTimeout(unsigned *seconds);
-  void SetRetryParameters(const unsigned max_retries,
-                          const unsigned backoff_init_ms,
-                          const unsigned backoff_max_ms);
 
  private:
   // Reflects the default Apache configuration of the local backend
@@ -279,21 +282,23 @@ class S3FanoutManager : SingleCopy {
   bool MkV4Authz(const JobInfo &info,
                  std::vector<std::string> *headers) const;
   std::string MkUrl(const std::string &objkey) const {
-    if (dns_buckets_) {
+    if (config_.dns_buckets) {
       return "http://" + complete_hostname_ + "/" + objkey;
     } else {
-      return "http://" + complete_hostname_ + "/" + bucket_ + "/" + objkey;
+      return "http://" + complete_hostname_ + "/" + config_.bucket +
+             "/" + objkey;
     }
   }
-  static std::string MkCompleteHostname(const std::string &hostname,
-                                        const std::string &bucket,
-                                        const bool &dns_buckets) {
-    if (dns_buckets) {
-      return bucket + "." + hostname;
+  std::string MkCompleteHostname() {
+    if (config_.dns_buckets) {
+      return config_.bucket + "." + config_.hostname_port;
     } else {
-      return hostname;
+      return config_.hostname_port;
     }
   }
+
+  const S3Config config_;
+  std::string complete_hostname_;
 
   Prng prng_;
   /**
@@ -306,15 +311,14 @@ class S3FanoutManager : SingleCopy {
   std::set<S3FanOutDnsEntry *> *sharehandles_;
   std::map<CURL *, S3FanOutDnsEntry *> *curl_sharehandles_;
   dns::CaresResolver *resolver_;
-  uint32_t pool_max_handles_;
   CURLM *curl_multi_;
   std::string *user_agent_;
 
   /**
    * AWS4 signing keys are derived from the secret key, a region and a date.
-   * They can be cached.
+   * The signing key for current day can be cached.
    */
-  mutable std::map<std::string, std::string> signing_keys_;
+  mutable std::pair<std::string, std::string> last_signing_key_;
 
   pthread_t thread_upload_;
   atomic_int32 multi_threaded_;
@@ -324,15 +328,14 @@ class S3FanoutManager : SingleCopy {
   uint32_t watch_fds_inuse_;
   uint32_t watch_fds_max_;
 
+  // A pipe used to signal termination from S3FanoutManager to MainUpload
+  // thread. Anything written into it results in MainUpload thread exit.
   int pipe_terminate_[2];
+  // A pipe to used to push jobs from S3FanoutManager to MainUpload thread.
+  // S3FanoutManager writes a JobInfo* pointer. MainUpload then reads the
+  // pointer and processes the job.
   int pipe_jobs_[2];
 
-  pthread_mutex_t *lock_options_;
-  unsigned opt_timeout_;
-
-  unsigned opt_max_retries_;
-  unsigned opt_backoff_init_ms_;
-  unsigned opt_backoff_max_ms_;
   bool opt_ipv4_only_;
 
   unsigned int max_available_jobs_;

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -73,7 +73,7 @@ struct UploadStreamHandle;
 class AbstractUploader
   : public PolymorphicConstruction<AbstractUploader, SpoolerDefinition>
   , public Callbackable<UploaderResults>
-{
+  , public SingleCopy {
   friend class TaskUpload;
 
  public:

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -398,7 +398,7 @@ void S3Uploader::DoRemoveAsync(const std::string& file_to_delete) {
 }
 
 
-void S3Uploader::OnPeekCopmlete(
+void S3Uploader::OnPeekComplete(
   const upload::UploaderResults &results,
   PeekCtrl *ctrl)
 {
@@ -416,7 +416,7 @@ bool S3Uploader::Peek(const std::string& path) {
   MakePipe(peek_ctrl.pipe_wait);
   info->request = s3fanout::JobInfo::kReqHeadOnly;
   info->callback = const_cast<void*>(static_cast<void const*>(MakeClosure(
-    &S3Uploader::OnPeekCopmlete, this, &peek_ctrl)));
+    &S3Uploader::OnPeekComplete, this, &peek_ctrl)));
 
   IncJobsInFlight();
   UploadJobInfo(info);

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -44,11 +44,18 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
     abort();
   }
 
-  s3fanout_mgr_.Init(num_parallel_uploads_, dns_buckets_);
-  s3fanout_mgr_.SetTimeout(timeout_sec_);
-  s3fanout_mgr_.SetRetryParameters(
+  s3fanout_mgr_ = new s3fanout::S3FanoutManager(access_key_,
+                                                secret_key_,
+                                                authz_method_,
+                                                host_name_port_,
+                                                region_,
+                                                bucket_,
+                                                dns_buckets_);
+  s3fanout_mgr_->Init(num_parallel_uploads_);
+  s3fanout_mgr_->SetTimeout(timeout_sec_);
+  s3fanout_mgr_->SetRetryParameters(
     num_retries_, kDefaultBackoffInitMs, kDefaultBackoffMaxMs);
-  s3fanout_mgr_.Spawn();
+  s3fanout_mgr_->Spawn();
 
   int retval = pthread_create(
     &thread_collect_results_, NULL, MainCollectResults, this);
@@ -57,9 +64,10 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
 
 
 S3Uploader::~S3Uploader() {
-  s3fanout_mgr_.Fini();
+  s3fanout_mgr_->Fini();
   atomic_inc32(&terminate_);
   pthread_join(thread_collect_results_, NULL);
+  delete s3fanout_mgr_;
 }
 
 
@@ -168,7 +176,7 @@ void *S3Uploader::MainCollectResults(void *data) {
   std::vector<s3fanout::JobInfo *> jobs;
   while (atomic_read32(&uploader->terminate_) == 0) {
     jobs.clear();
-    uploader->s3fanout_mgr_.PopCompletedJobs(&jobs);
+    uploader->s3fanout_mgr_->PopCompletedJobs(&jobs);
     for (unsigned i = 0; i < jobs.size(); ++i) {
       // Report completed job
       s3fanout::JobInfo *info = jobs[i];
@@ -230,13 +238,7 @@ void S3Uploader::FileUpload(
   const CallbackTN  *callback
 ) {
   s3fanout::JobInfo *info =
-    new s3fanout::JobInfo(access_key_,
-                          secret_key_,
-                          authz_method_,
-                          host_name_port_,
-                          region_,
-                          bucket_,
-                          repository_alias_ + "/" + remote_path,
+    new s3fanout::JobInfo(repository_alias_ + "/" + remote_path,
                           const_cast<void*>(
                               static_cast<void const*>(callback)),
                           local_path);
@@ -264,10 +266,10 @@ void S3Uploader::UploadJobInfo(s3fanout::JobInfo *info) {
            "--> Host:   '%s'\n",
            info->origin_mem.data != NULL ? "buffer" : "file",
            info->object_key.c_str(),
-           info->bucket.c_str(),
-           info->hostname.c_str());
+           bucket_.c_str(),
+           host_name_port_.c_str());
 
-  s3fanout_mgr_.PushNewJob(info);
+  s3fanout_mgr_->PushNewJob(info);
 }
 
 
@@ -352,13 +354,7 @@ void S3Uploader::FinalizeStreamedUpload(
     repository_alias_ + "/data/" + content_hash.MakePath());
 
   s3fanout::JobInfo *info =
-      new s3fanout::JobInfo(access_key_,
-                            secret_key_,
-                            authz_method_,
-                            host_name_port_,
-                            region_,
-                            bucket_,
-                            final_path,
+      new s3fanout::JobInfo(final_path,
                             const_cast<void*>(
                                 static_cast<void const*>(
                                     handle->commit_callback)),
@@ -382,13 +378,7 @@ void S3Uploader::FinalizeStreamedUpload(
 
 
 s3fanout::JobInfo *S3Uploader::CreateJobInfo(const std::string& path) const {
-  return new s3fanout::JobInfo(access_key_,
-                               secret_key_,
-                               authz_method_,
-                               host_name_port_,
-                               region_,
-                               bucket_,
-                               path,
+  return new s3fanout::JobInfo(path,
                                NULL,
                                NULL,
                                NULL,
@@ -403,8 +393,8 @@ void S3Uploader::DoRemoveAsync(const std::string& file_to_delete) {
   info->request = s3fanout::JobInfo::kReqDelete;
 
   LogCvmfs(kLogUploadS3, kLogDebug, "Asynchronously removing %s/%s",
-           info->bucket.c_str(), info->object_key.c_str());
-  s3fanout_mgr_.PushNewJob(info);
+           bucket_.c_str(), info->object_key.c_str());
+  s3fanout_mgr_->PushNewJob(info);
 }
 
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -88,7 +88,7 @@ class S3Uploader : public AbstractUploader {
     int pipe_wait[2];
   };
 
-  void OnPeekCopmlete(const upload::UploaderResults &results, PeekCtrl *ctrl);
+  void OnPeekComplete(const upload::UploaderResults &results, PeekCtrl *ctrl);
 
   static void *MainCollectResults(void *data);
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -71,7 +71,7 @@ class S3Uploader : public AbstractUploader {
   int64_t DoGetObjectSize(const std::string &file_name);
 
   // Only for testing
-  s3fanout::S3FanoutManager *GetS3FanoutManager() { return &s3fanout_mgr_; }
+  s3fanout::S3FanoutManager *GetS3FanoutManager() { return s3fanout_mgr_; }
 
  private:
   static const unsigned kDefaultPort = 80;
@@ -97,7 +97,7 @@ class S3Uploader : public AbstractUploader {
 
   s3fanout::JobInfo *CreateJobInfo(const std::string &path) const;
 
-  s3fanout::S3FanoutManager s3fanout_mgr_;
+  s3fanout::S3FanoutManager *s3fanout_mgr_;
   std::string repository_alias_;
   std::string host_name_port_;
   std::string host_name_;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -14,6 +14,7 @@
 #include "atomic.h"
 #include "s3fanout.h"
 #include "upload_facility.h"
+#include "util/pointer.h"
 
 namespace upload {
 
@@ -97,7 +98,7 @@ class S3Uploader : public AbstractUploader {
 
   s3fanout::JobInfo *CreateJobInfo(const std::string &path) const;
 
-  s3fanout::S3FanoutManager *s3fanout_mgr_;
+  UniquePtr<s3fanout::S3FanoutManager> s3fanout_mgr_;
   std::string repository_alias_;
   std::string host_name_port_;
   std::string host_name_;

--- a/test/unittests/t_s3fanout.cc
+++ b/test/unittests/t_s3fanout.cc
@@ -19,8 +19,7 @@ TEST(T_S3Fanout, Init) {
 }
 
 TEST(T_S3Fanout, DetectThrottleIndicator) {
-  s3fanout::JobInfo info(
-    "", "", s3fanout::kAuthzAwsV2, "", "", "", "", NULL, "");
+  s3fanout::JobInfo info("", NULL, "");
   info.throttle_ms = 1;
 
   s3fanout::S3FanoutManager::DetectThrottleIndicator("", &info);


### PR DESCRIPTION
Refactor:
- move S3 server info (hostname, port, bucket, ...) from JobInfo into S3Fanout
- construct DNS-style bucket hostname in constructor of S3Fanout 

Improvements:
- use pipes instead of jobs_todo_ and thread_upload_run_ variables to communicate jobs and termination between S3Uploader and S3Fanout
- in poll function, use timeout suggested by curl instead of default 100ms