### PR TITLE
Remove raw aborts

### DIFF
--- a/cvmfs/fs_traversal.h
+++ b/cvmfs/fs_traversal.h
@@ -19,6 +19,7 @@
 #include "logging.h"
 #include "platform.h"
 #include "util/async.h"
+#include "util/posix.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -151,10 +152,9 @@ class FileSystemTraversal {
              path.c_str(), parent_path.c_str(), dir_name.c_str());
     dip = opendir(path.c_str());
     if (!dip) {
-      LogCvmfs(kLogFsTraversal, kLogStderr, "Failed to open %s (%d).\n"
+      Panic(kLogFsTraversal, kLogStderr, "Failed to open %s (%d).\n"
                "Please check directory permissions.",
                path.c_str(), errno);
-      abort();
     }
     Notify(fn_enter_dir, parent_path, dir_name);
 

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -127,6 +127,15 @@ bool SafeReadToString(int fd, std::string *final_result);
 bool SafeWriteToFile(const std::string &content,
                      const std::string &path, int mode);
 
+// Abort the process or throwh an execption, depending on the compilation flags
+void Panic();
+// Most likely useless at this stage
+// void Panic(const char *msg, ...);
+//
+// The first argument, `source` should have type LogSource, which should be
+// imported by `logging.h`, unfortunately it seems like import `logging.h` break
+// the compilation process. To investigate further.
+void Panic(const int source, const int mask, const char *format, ...);
 
 struct Pipe : public SingleCopy {
   Pipe() {

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -21,6 +21,7 @@
 #include "shortstring.h"
 #include "util/pointer.h"
 #include "util/single_copy.h"
+#include "logging_internal.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -135,7 +136,7 @@ void Panic();
 // The first argument, `source` should have type LogSource, which should be
 // imported by `logging.h`, unfortunately it seems like import `logging.h` break
 // the compilation process. To investigate further.
-void Panic(const int source, const int mask, const char *format, ...);
+void Panic(const LogSource source, const int mask, const char *format, ...);
 
 struct Pipe : public SingleCopy {
   Pipe() {


### PR DESCRIPTION
 Draft for switching to raw abort() to the possible use of throw.

The switch is necessary since we want to create a library `libcvmfs_server.so` where a raw aborting is not desiderable. However we would like to keep the original behaviour in the binaries.
The first idea was to have a much simpler function that using pre-compilation condition would either simply `abort()` (for the binaries) or throw an exception string (for the library).
This approach would imply to find good descriptive string for all the abort in the code. Some abort do not have any message associate with (implying that we don't expect them to ever been called), other are preceded by a log (implying that we are facing a known error condition).
Overall it seems complex to find reasonable string messages for all the panics and to format those messages correctly.

The proposed approach will allow to automatically replace either the call to plain `abort(void)` with a call to `Panic(void)` or the call to `LogCvmfs(source, mask, format, ...)` to a call to `Panic(source, mask, format, ...)` leaving untouched the original semantic of the calls.

Downside of this approach is the problem in compilation phase annotate in the comment.
`Panic/3+` should be defined taking as first argument `const LogSource source` while now it is just `const int source` (it is correctly defined in the .cc file). Indeed including `logging.h` break the compilation process, this should be investigate and understood correctly