### PR TITLE
CVM-1735: add milliseconds accurracy to tag from gateways

### DIFF
--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -336,6 +336,13 @@ inline uint64_t platform_monotonic_time_ns() {
   return static_cast<uint64_t>(tp.tv_sec*1e9 + tp.tv_nsec);
 }
 
+inline uint64_t platform_time() {
+  struct timespec tp;
+  int retval = clock_gettime(CLOCK_REALTIME, &tp);
+  assert(retval == 0);
+  return static_cast<uint64_t>(tp.tv_sec*1e9 + tp.tv_nsec);
+}
+
 inline uint64_t platform_memsize() {
   return static_cast<uint64_t>(sysconf(_SC_PHYS_PAGES)) *
          static_cast<uint64_t>(sysconf(_SC_PAGE_SIZE));

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -256,7 +256,7 @@ inline uint64_t platform_monotonic_time() {
   return val_ns * 1e-9;
 }
 
-inline double platform_monotonic_time_ns() {
+inline uint64_t platform_monotonic_time_ns() {
   uint64_t val_abs = mach_absolute_time();
   // Doing the conversion every time is slow but thread-safe
   mach_timebase_info_data_t info;
@@ -264,6 +264,8 @@ inline double platform_monotonic_time_ns() {
   uint64_t val_ns = val_abs * (info.numer / info.denom);
   return val_ns;
 }
+
+inline uint64_t platform_time() { return platform_monotonic_time_ns(); }
 
 /**
  * strdupa does not exist on OSX

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1630,6 +1630,14 @@ bool SafeWriteToFile(const std::string &content,
   return retval;
 }
 
+/**
+ * Returns current time in nanoseconds
+ * It is not guarantee to be monotomic increasing
+ */
+uint64_t GetTime() {
+  return platform_time();
+}
+
 #ifdef CVMFS_NAMESPACE_GUARD
 }  // namespace CVMFS_NAMESPACE_GUARD
 #endif

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -132,6 +132,8 @@ bool SafeReadToString(int fd, std::string *final_result);
 bool SafeWriteToFile(const std::string &content,
                      const std::string &path, int mode);
 
+// Return the current time in nanoseconds
+uint64_t GetTime();
 
 struct Pipe : public SingleCopy {
   Pipe() {


### PR DESCRIPTION
This PR adds milliseconds accuracy to the generic tag generated by gateways.

It actually sidestep the possible problem in [CVM-1735](https://sft.its.cern.ch/jira/projects/CVM/issues/CVM-1735)