### PR TITLE
revert change of klei.nikhef.nl to cvmfs01.nikhef.nl

### DIFF
--- a/mount/domain.d/egi.eu.conf
+++ b/mount/domain.d/egi.eu.conf
@@ -1,6 +1,6 @@
 # Don't edit here.  Create /etc/cvmfs/domain.d/egi.eu.local
 # As a rule of thumb, overwrite only parameters you find in here.
 
-CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/egi.eu
 CVMFS_USE_GEOAPI=yes

--- a/mount/domain.d/opensciencegrid.org.conf
+++ b/mount/domain.d/opensciencegrid.org.conf
@@ -1,6 +1,6 @@
 # Don't edit here.  Create /etc/cvmfs/domain.d/opensciencegrid.org.local
 # As a rule of thumb, overwrite only parameters you find in here.
 
-CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs01.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR=/etc/cvmfs/keys/opensciencegrid.org
 CVMFS_USE_GEOAPI=yes

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -74,9 +74,6 @@ done
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
-#For next release:
-#- Changed NIKHEF alias from klei.nikhef.nl to cvmfs01.nikhef.nl
-
 * Fri May 25 2018 Dave Dykstra <dwd@fnal.gov> - 1.7-1
 - Skipped versions 1.5 and 1.6 because debian packages with those 
   versions already exist


### PR DESCRIPTION
Revert #2403 which thankfully had not been released in a cvmfs-config-default rpm.  The problem with the change is that frontier-squid hasn't yet added cvmfs01.nikhef.nl to its acl list of known CVMFS stratum 1s.  Once that has changed, it will take a while until all the squids that are using the acl list are updated.