### PR TITLE
MockHTTPServer & new tests for DownloadManager

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -261,6 +261,7 @@ set (CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/xattr.cc
 
   cache.pb.cc cache.pb.h
+  c_http_server.cc
 )
 
 # Lower optimization level for this file. Xcode 9.3+ gives different results in Os and above

--- a/test/unittests/c_file_sandbox.h
+++ b/test/unittests/c_file_sandbox.h
@@ -6,6 +6,7 @@
 #define TEST_UNITTESTS_C_FILE_SANDBOX_H_
 
 #include <errno.h>
+#include <fcntl.h>
 
 #include <cstring>
 #include <string>
@@ -58,6 +59,14 @@ class FileSandbox : public ::testing::Test {
     LazilyCreateDummyFile(sandbox_path_, 100*1024, &huge_zero_file_,
                           uint64_t(-1));
     return huge_zero_file_;
+  }
+
+  std::string GetFileContents(std::string path) {
+    int fd = open(path.c_str(), O_RDONLY);
+    std::string content;
+    SafeReadToString(fd, &content);
+    close(fd);
+    return content;
   }
 
   template <class VectorT>

--- a/test/unittests/c_http_server.cc
+++ b/test/unittests/c_http_server.cc
@@ -1,0 +1,248 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "c_http_server.h"
+
+HTTPRequestParser::HTTPRequestParser() {
+  state_ = kBegin;
+  body_bytes_read_ = 0;
+}
+
+bool HTTPRequestParser::Parse(char c) {
+  switch (state_) {
+    case kBegin:
+      buffer_ += c;
+      state_ = kMethod;
+      break;
+    case kMethod:
+      if (c == ' ') {
+        request_.method = buffer_;
+        buffer_.clear();
+        state_ = kPath;
+      } else {
+        buffer_ += c;
+      }
+      break;
+    case kPath:
+      if (c == ' ') {
+        request_.path = buffer_;
+        buffer_.clear();
+        state_ = kProtocol;
+      } else {
+        buffer_ += c;
+      }
+      break;
+    case kProtocol:
+      if (c == '\r') {
+        request_.protocol = buffer_;
+        buffer_.clear();
+        state_ = kCRFirst;
+      } else if (c == '\n') {
+        request_.protocol = buffer_;
+        buffer_.clear();
+        state_ = kLFFirst;
+      } else {
+        buffer_ += c;
+      }
+      break;
+    case kHeaderKey:
+      if (c == ':') {
+        state_ = kSpacePreHeaderVal;
+      } else {
+        headerKeyBuffer_ += c;
+      }
+      break;
+    case kSpacePreHeaderVal:
+      assert(c == ' ');
+      state_ = kHeaderVal;
+      break;
+    case kHeaderVal:
+      if (c == '\n') {
+        PushHeaderField();
+        state_ = kLFFirst;
+      } else if (c == '\r') {
+        PushHeaderField();
+        state_ = kCRFirst;
+      } else {
+        buffer_ += c;
+      }
+      break;
+    case kCRFirst:
+      assert(c == '\n');
+      state_ = kCRLFFirst;
+      break;
+    case kCRLFFirst:
+      assert(c != '\n');
+      if (c == '\r') {
+        state_ = kCRSecond;
+      } else {
+        headerKeyBuffer_ += c;
+        state_ = kHeaderKey;
+      }
+      break;
+    case kLFFirst:
+      assert(c != '\r');
+      if (c == '\n') {
+        FillContentLength();
+        if (request_.content_length) {
+          state_ = kBody;
+        } else {
+          state_ = kFinished;
+          return true;
+        }
+      } else {
+        headerKeyBuffer_ += c;
+        state_ = kHeaderKey;
+      }
+      break;
+    case kCRSecond:
+      assert(c == '\n');
+      FillContentLength();
+      if (request_.content_length) {
+        state_ = kBody;
+      } else {
+        state_ = kFinished;
+        return true;
+      }
+      break;
+    case kBody:
+      if (body_bytes_read_ < request_.content_length) {
+        buffer_ += c;
+        body_bytes_read_++;
+      }
+      if (body_bytes_read_ == request_.content_length) {
+        request_.body = buffer_;
+        state_ = kFinished;
+        return true;
+      }
+      break;
+    case kFinished:
+      assert(false);  // Parse() should not be called after parsing is finished
+      break;
+  }
+  return false;
+}
+
+const HTTPRequest &HTTPRequestParser::GetParsedRequest() const {
+  assert(state_ == kFinished);
+  return request_;
+}
+
+void HTTPRequestParser::PushHeaderField() {
+  request_.headers.push_back(
+    std::pair<std::string, std::string>(headerKeyBuffer_, buffer_));
+  headerKeyBuffer_.clear();
+  buffer_.clear();
+}
+
+void HTTPRequestParser::FillContentLength() {
+  HTTPHeaderList::iterator it = request_.headers.begin();
+  HTTPHeaderList::iterator itend = request_.headers.end();
+  for (; it != itend; ++it) {
+    if (it->first == "Content-Length") {
+      request_.content_length = String2Uint64(it->second);
+      return;
+    }
+  }
+  request_.content_length = 0;
+}
+
+MockHTTPServer::MockHTTPServer(int port) {
+  atomic_init32(&running_);
+  atomic_init32(&server_thread_ready_);
+  server_port_ = port;
+}
+
+MockHTTPServer::~MockHTTPServer() {
+  if (atomic_read32(&running_)) {
+    Stop();
+  }
+}
+
+bool MockHTTPServer::Start() {
+  if (atomic_read32(&running_)) return false;
+  atomic_write32(&running_, 1);
+  pthread_create(&server_thread_, NULL, Main, this);
+  // wait for server thread to open the socket
+  while (!atomic_read32(&server_thread_ready_)) {}
+  return true;
+}
+
+
+bool MockHTTPServer::Stop() {
+  if (!atomic_read32(&running_)) return false;
+  atomic_write32(&running_, 0);
+  pthread_join(server_thread_, NULL);
+  return true;
+}
+
+bool MockHTTPServer::SetResponseCallback(
+  HTTPResponse (*callback_func)(const HTTPRequest &, void*),
+  void *data) {
+  if (atomic_read32(&running_)) return false;
+  callback_func_ = callback_func;
+  callback_data_ = data;
+  return true;
+}
+
+void *MockHTTPServer::Main(void *data) {
+  MockHTTPServer *server = static_cast<MockHTTPServer *>(data);
+  const int kReadBufferSize = 1000;
+  int listen_sockfd = -1, accept_sockfd = -1;
+  socklen_t clilen;
+  struct sockaddr_in cli_addr;
+  char buffer[kReadBufferSize];
+  int retval = 0;
+
+  // Listen incoming connections
+  listen_sockfd = MakeTcpEndpoint("", server->server_port_);
+  assert(listen_sockfd >= 0);
+  listen(listen_sockfd, 5);
+
+  clilen = sizeof(cli_addr);
+
+  struct timeval select_timeout;
+  select_timeout.tv_sec = 0;
+  select_timeout.tv_usec = 2000;  // 2 ms
+  fd_set rfds;
+  atomic_inc32(&(server->server_thread_ready_));
+  while (atomic_read32(&(server->running_))) {
+    // Wait for traffic
+    FD_ZERO(&rfds);
+    FD_SET(listen_sockfd, &rfds);
+    retval = select(listen_sockfd+1, &rfds, NULL, NULL, &select_timeout);
+    assert(retval >= 0);
+    if (retval == 0)  // Timeout
+      continue;
+
+    accept_sockfd = accept(listen_sockfd,
+                            (struct sockaddr *) &cli_addr,
+                            &clilen);
+    bzero(buffer, kReadBufferSize);
+    int bytes_read = 0;
+    HTTPRequestParser parser;
+    bool finished = false;
+    while (!finished &&
+           (bytes_read = read(accept_sockfd, buffer, kReadBufferSize))) {
+      for (int i = 0; i < bytes_read; ++i) {
+        if (parser.Parse(buffer[i])) {
+          finished = true;
+          break;
+        }
+      }
+    }
+    const HTTPRequest &req = parser.GetParsedRequest();
+    assert(server->callback_func_ != NULL);
+    HTTPResponse response = server->callback_func_(req, server->callback_data_);
+    // Mandatory since the connection is closed after replying
+    response.AddHeader("Connection", "close");
+    std::string reply = response.ToString();
+    int bytes_written = write(accept_sockfd, reply.c_str(), reply.length());
+    assert(bytes_written >= 0);
+    assert((uint64_t) bytes_written == reply.length());
+    close(accept_sockfd);
+  }
+  close(listen_sockfd);
+  return NULL;
+}

--- a/test/unittests/c_http_server.h
+++ b/test/unittests/c_http_server.h
@@ -1,0 +1,303 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef TEST_UNITTESTS_C_HTTP_SERVER_H_
+#define TEST_UNITTESTS_C_HTTP_SERVER_H_
+
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "atomic.h"
+#include "duplex_curl.h"
+#include "util/posix.h"
+#include "util/string.h"
+
+typedef std::vector< std::pair<std::string, std::string> > HTTPHeaderList;
+
+struct HTTPRequest {
+  std::string ToString() const {
+    std::string result;
+    result += method + " " + path + " " + protocol + "\r\n";
+    HTTPHeaderList::const_iterator it = headers.begin();
+    HTTPHeaderList::const_iterator itend = headers.end();
+    for (; it != itend; ++it) {
+      result += it->first + ": " + it->second + "\r\n";
+    }
+    result += "\r\n";
+    result += body;
+    return result;
+  }
+  std::string method;
+  std::string path;
+  std::string protocol;
+  uint64_t content_length;
+  HTTPHeaderList headers;
+  std::string body;
+};
+
+struct HTTPResponse {
+  HTTPResponse() {
+    protocol = "HTTP/1.1";
+    code = 200;
+    reason = "OK";
+    raw = false;
+  }
+  std::string ToString() const {
+    if (raw) return body;
+    std::string result;
+    result += protocol + " " + StringifyInt(code) + " " + reason + "\r\n";
+    HTTPHeaderList::const_iterator it = headers.begin();
+    HTTPHeaderList::const_iterator itend = headers.end();
+    for (; it != itend; ++it) {
+      result += it->first + ": " + it->second + "\r\n";
+    }
+    if (body.length())
+      result += "Content-Length: " + StringifyUint(body.length()) + "\r\n";
+    result += "\r\n";
+    result += body;
+    return result;
+  }
+  void AddHeader(std::string key, std::string value) {
+    headers.push_back(std::pair<std::string, std::string>(key, value));
+  }
+  std::string protocol;
+  int code;
+  std::string reason;
+  HTTPHeaderList headers;
+  std::string body;
+
+  // If true, the whole request is stored in body and other variables
+  // will not be used in the reply
+  bool raw;
+};
+
+// Class for parsing HTTP request. Create one instance per one request.
+// Works in a state-machine-like manner. Function Parse() parses characters
+// one by one, changing the state of the parser and gradually filling the
+// HTTPResponse object when needed.
+class HTTPRequestParser {
+ public:
+  HTTPRequestParser();
+  // Parses one character of the HTTP request.
+  // Call this function repeatedly, providing single characters
+  // in a sequential order.
+  // Returns true if parsing is finished,
+  // false if more characters need to be parsed.
+  bool Parse(char c);
+  // Returns complete HTTPResponse object. Can be called
+  // only after parsing has been finished.
+  const HTTPRequest &GetParsedRequest() const;
+
+ protected:
+  void PushHeaderField();
+  void FillContentLength();
+
+  enum States {
+    kBegin = 0,
+    kMethod,
+    kPath,
+    kProtocol,
+    kHeaderKey,
+    kSpacePreHeaderVal,
+    kHeaderVal,
+    kCRFirst,
+    kCRLFFirst,
+    kCRSecond,
+    kCRLFSecond,
+    kLFFirst,
+    kLFSecond,
+    kBody,
+    kFinished
+  };
+  int state_;
+  std::string buffer_;
+  std::string headerKeyBuffer_;
+  uint64_t body_bytes_read_;
+  HTTPRequest request_;
+};
+
+
+// A class providing HTTP server running on localhost
+class MockHTTPServer {
+ public:
+  explicit MockHTTPServer(int port);
+  ~MockHTTPServer();
+  // Start function spawns the main thread. A custom response callback needs
+  // to be set by SetResponseCallback before starting the HTTP server.
+  bool Start();
+  bool Stop();
+  // Set a callback function which implements specific behavior of the server.
+  // The function needs to accept an HTTPRequest object and a pointer to
+  // custom persistent data, which can be used by the function to remember
+  // the state. The function needs to return an HTTPResponse object, which
+  // is then used by the server to respond to given HTTP request.
+  bool SetResponseCallback(
+    HTTPResponse (*callback_func)(const HTTPRequest &, void*),
+    void *data = NULL);
+
+ protected:
+  // Main function of the server.
+  // Handles the entire communication in one event loop.
+  static void *Main(void *data);
+
+  atomic_int32 running_;
+  atomic_int32 server_thread_ready_;
+  int server_port_;
+
+  void *callback_data_ = NULL;
+  HTTPResponse (*callback_func_)(const HTTPRequest &, void*) = NULL;
+
+  pthread_t server_thread_;
+};
+
+class MockFileServer {
+ public:
+  explicit MockFileServer(int port, std::string root_dir) {
+    port_ = port;
+    root_dir_ = root_dir;
+    server_ = new MockHTTPServer(port);
+    server_->SetResponseCallback(FileServerHandler, this);
+    assert(server_->Start());
+  }
+  ~MockFileServer() {
+    delete server_;
+  }
+
+ protected:
+  static HTTPResponse FileServerHandler(const HTTPRequest &req, void *data) {
+    MockFileServer *file_server = static_cast<MockFileServer *>(data);
+    HTTPResponse response;
+    if (req.method == "GET") {
+      bool host_header = false;
+      HeaderList::const_iterator it = req.headers.begin();
+      HeaderList::const_iterator itend = req.headers.end();
+      for (; it != itend; ++it) {
+        if (it->first == "Host") {
+          host_header = true;
+          break;
+        }
+      }
+      std::string local_path = file_server->root_dir_;
+      if (host_header) {
+        local_path += "/" + req.path;
+      } else {
+        local_path += "/" + req.path.substr(req.path.find("/") + 1);
+      }
+      if (FileExists(local_path)) {
+        int fd = open(local_path.c_str(), O_RDONLY);
+        assert(fd >= 0);
+        SafeReadToString(fd, &response.body);
+        close(fd);
+      } else {
+        response.code = 404;
+        response.reason = "Not Found";
+      }
+    }
+    return response;
+  }
+  std::string root_dir_;
+  int port_;
+  MockHTTPServer *server_;
+};
+
+class MockProxyServer {
+ public:
+  explicit MockProxyServer(int port) {
+    port_ = port;
+    server_ = new MockHTTPServer(port);
+    server_->SetResponseCallback(ProxyServerHandler, this);
+    assert(server_->Start());
+  }
+  ~MockProxyServer() {
+    delete server_;
+  }
+ 
+ protected:
+  static size_t ProxyServerWriteCallback(char *ptr, size_t size, size_t nmemb,
+                                         void* userdata) {
+    std::string *response = static_cast<std::string *>(userdata);
+    (*response) += std::string(ptr, size*nmemb);
+    return size*nmemb;
+  }
+
+  static HTTPResponse ProxyServerHandler(const HTTPRequest &req, void *data) {
+    // MockProxyServer *proxy_server = static_cast<MockProxyServer *>(data);    
+    HTTPResponse response;
+    CURL* handle = curl_easy_init();
+    curl_easy_setopt(handle, CURLOPT_HEADER, 1);
+    curl_easy_setopt(handle, CURLOPT_URL, req.path.c_str());
+    curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, req.method.c_str());
+
+    std::string destination_response;
+    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, ProxyServerWriteCallback);
+    curl_easy_setopt(handle, CURLOPT_WRITEDATA, &destination_response);
+
+    struct curl_slist *header_list = NULL;
+    HeaderList::const_iterator it = req.headers.begin();
+    HeaderList::const_iterator itend = req.headers.end();
+    for (; it != itend; ++it) {
+      std::string header = it->first + ": " + it->second;
+      header_list = curl_slist_append(header_list, header.c_str());
+    }
+    curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header_list);
+
+    if (req.body.length()) {
+      curl_easy_setopt(handle, CURLOPT_POSTFIELDS, req.body.c_str());
+      curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, req.body.length());
+    }
+    curl_easy_perform(handle);
+    curl_easy_cleanup(handle);
+    curl_slist_free_all(header_list);
+    response.raw = true;
+    response.body = destination_response;
+    return response;
+  }
+
+  int port_;
+  MockHTTPServer *server_;
+};
+
+class MockRedirectServer {
+ public:
+  explicit MockRedirectServer(int port, std::string redirect_destination) {
+    port_ = port;
+    server_ = new MockHTTPServer(port);
+    redirect_destination_ = redirect_destination;
+    server_->SetResponseCallback(RedirectServerHandler, this);
+    assert(server_->Start());
+  }
+  ~MockRedirectServer() {
+    delete server_;
+  }
+
+ protected:
+  static HTTPResponse RedirectServerHandler(const HTTPRequest &req,
+                                            void *data) {
+    MockRedirectServer *redirect_server = static_cast<MockRedirectServer *>(data);    
+    HTTPResponse response;
+    response.code = 301;
+    response.reason = "Moved Permanently";
+    response.AddHeader("Location",
+                       redirect_server->redirect_destination_ + req.path);
+    return response;
+  }
+
+  int port_;
+  std::string redirect_destination_;
+  MockHTTPServer *server_;
+};
+
+#endif  // TEST_UNITTESTS_C_HTTP_SERVER_H_

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -6,8 +6,11 @@
 
 #include <unistd.h>
 
+#include <cassert>
 #include <cstdio>
 
+#include "c_file_sandbox.h"
+#include "c_http_server.h"
 #include "compression.h"
 #include "download.h"
 #include "hash.h"
@@ -21,20 +24,24 @@ using namespace std;  // NOLINT
 
 namespace download {
 
-class T_Download : public ::testing::Test {
+class T_Download : public FileSandbox {
+ public:
+  T_Download() : FileSandbox(string(tmp_path) + "/server_dir") {}
+
  protected:
   virtual void SetUp() {
     download_mgr.Init(8, false, /* use_system_proxy */
       perf::StatisticsTemplate("test", &statistics));
-    ffoo = CreateTemporaryFile(&foo_path);
-    assert(ffoo);
-    foo_url = "file://" + foo_path;
+
+    CreateSandbox();
+  }
+
+  virtual void TearDown() {
+    RemoveSandbox();
   }
 
   virtual ~T_Download() {
     download_mgr.Fini();
-    fclose(ffoo);
-    unlink(foo_path.c_str());
   }
 
   FILE *CreateTemporaryFile(std::string *path) const {
@@ -42,13 +49,13 @@ class T_Download : public ::testing::Test {
                           0600, "w+", path);
   }
 
+  static const char tmp_path[];
+
   perf::Statistics statistics;
   DownloadManager download_mgr;
-  FILE *ffoo;
-  string foo_path;
-  string foo_url;
 };
 
+const char T_Download::tmp_path[] = "./cvmfs_ut_download";
 
 class TestSink : public cvmfs::Sink {
  public:
@@ -83,19 +90,40 @@ class TestSink : public cvmfs::Sink {
 //------------------------------------------------------------------------------
 
 
-TEST_F(T_Download, File) {
+TEST_F(T_Download, LocalFile) {
   string dest_path;
   FILE *fdest = CreateTemporaryFile(&dest_path);
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
 
-  JobInfo info(&foo_url, false /* compressed */, false /* probe hosts */,
+  string src_path = GetAbsolutePath(GetSmallFile());
+  string src_url = "file://" + src_path;
+
+  JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                fdest,  NULL);
   download_mgr.Fetch(&info);
   EXPECT_EQ(info.error_code, kFailOk);
   fclose(fdest);
 }
 
+TEST_F(T_Download, RemoteFile) {
+  string dest_path;
+  FILE *fdest = CreateTemporaryFile(&dest_path);
+  ASSERT_TRUE(fdest != NULL);
+  UnlinkGuard unlink_guard(dest_path);
+
+  MockFileServer file_server(8082, sandbox_path_);
+
+  string src_path = GetSmallFile();
+  string src_url = "http://127.0.0.1:8082/" + GetFileName(src_path);
+
+  JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
+               fdest,  NULL);
+  download_mgr.Fetch(&info);
+  EXPECT_EQ(file_server.num_processed_requests(), 1);
+  EXPECT_EQ(info.error_code, kFailOk);
+  fclose(fdest);
+}
 
 TEST_F(T_Download, Clone) {
   DownloadManager *download_mgr_cloned = download_mgr.Clone(
@@ -132,13 +160,16 @@ TEST_F(T_Download, Multiple) {
   ASSERT_TRUE(fdest != NULL);
   UnlinkGuard unlink_guard(dest_path);
 
+  string src_path = GetAbsolutePath(GetSmallFile());
+  string src_url = "file://" + src_path;
+
   DownloadManager second_mgr;
   second_mgr.Init(8, false, /* use_system_proxy */
     perf::StatisticsTemplate("second", &statistics));
 
-  JobInfo info(&foo_url, false /* compressed */, false /* probe hosts */,
+  JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                fdest,  NULL);
-  JobInfo info2(&foo_url, false /* compressed */, false /* probe hosts */,
+  JobInfo info2(&src_url, false /* compressed */, false /* probe hosts */,
                 fdest,  NULL);
   download_mgr.Fetch(&info);
   second_mgr.Fetch(&info2);
@@ -149,23 +180,164 @@ TEST_F(T_Download, Multiple) {
 }
 
 
-TEST_F(T_Download, LocalFile2Mem) {
-  string dest_path;
-  FILE *fdest = CreateTemporaryFile(&dest_path);
-  ASSERT_TRUE(fdest != NULL);
-  UnlinkGuard unlink_guard(dest_path);
-  char buf = '1';
-  fwrite(&buf, 1, 1, fdest);
-  fclose(fdest);
+TEST_F(T_Download, RemoteFile2Mem) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
 
-  string url = "file://" + dest_path;
+  MockFileServer file_server(8082, sandbox_path_);
+
+  string url = "http://127.0.0.1:8082/" + GetFileName(src_path);
+  JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
+
+
+TEST_F(T_Download, RemoteFileRedirect) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
+
+  MockFileServer file_server(8082, sandbox_path_);
+  MockRedirectServer redirect_server(8083, "http://127.0.0.1:8082");
+
+  string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
+
+  download_mgr.EnableRedirects();
+  JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(redirect_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
+
+TEST_F(T_Download, RemoteFileSimpleProxy) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
+
+  MockProxyServer proxy_server(8083);
+  MockFileServer file_server(8082, sandbox_path_);
+
+  download_mgr.SetProxyChain("http://127.0.0.1:8083", "",
+                             DownloadManager::kSetProxyRegular);
+  string url = "http://127.0.0.1:8082/" + GetFileName(src_path);
+  JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(proxy_server.num_processed_requests(), 1);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
+
+TEST_F(T_Download, RemoteFileProxyRedirect) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
+
+  MockProxyServer proxy_server(8084);
+  MockRedirectServer redirect_server(8083, "http://127.0.0.1:8082");
+  MockFileServer file_server(8082, sandbox_path_);
+
+  download_mgr.SetProxyChain("http://127.0.0.1:8084", "",
+                             DownloadManager::kSetProxyRegular);
+  download_mgr.EnableRedirects();
+  string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
+  JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(proxy_server.num_processed_requests(), 2);
+  ASSERT_EQ(redirect_server.num_processed_requests(), 1);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.num_used_hosts, 1);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
+
+TEST_F(T_Download, LocalFile2Mem) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
+
+  string url = "file://" + GetAbsolutePath(src_path);
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL);
   download_mgr.Fetch(&info);
   ASSERT_EQ(info.error_code, kFailOk);
-  ASSERT_EQ(info.destination_mem.pos, 1U);
-  EXPECT_EQ(info.destination_mem.data[0], '1');
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
 }
 
+TEST_F(T_Download, RemoteFileSwitchHosts) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
+
+  MockFileServer file_server(8082, sandbox_path_);
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  string url = "/" + GetFileName(src_path);
+  JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.num_used_hosts, 2);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
+
+// TEST_F(T_Download, RemoteFileSwitchHostsAfterRedirect) {
+//   string src_path = GetSmallFile();
+//   string src_content = GetFileContents(src_path);
+
+//   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8084");
+//   MockFileServer file_server(8082, sandbox_path_);
+
+//   download_mgr.EnableRedirects();
+//   download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+//   string url = "/" + GetFileName(src_path);
+//   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL);
+//   download_mgr.Fetch(&info);
+  // ASSERT_EQ(info.num_used_hosts, 2);
+//   ASSERT_EQ(info.error_code, kFailOk);
+//   ASSERT_EQ(info.destination_mem.pos, src_content.length());
+//   EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+// }
+
+TEST_F(T_Download, RemoteFileSwitchProxies) {
+  string src_path = GetSmallFile();
+  int src_fd = open(src_path.c_str(), O_RDONLY);
+  string src_content;
+  SafeReadToString(src_fd, &src_content);
+  close(src_fd);
+
+  MockFileServer file_server(8082, sandbox_path_);
+  MockProxyServer proxy_server(8083);
+  download_mgr.SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
+                             "", DownloadManager::kSetProxyRegular);
+
+  string src_url = "http://127.0.0.1:8082/" + GetFileName(src_path);
+  JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(proxy_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.num_used_proxies, 2);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
+
+TEST_F(T_Download, RemoteFileEmpty) {
+  string src_path = GetEmptyFile();
+
+  MockFileServer file_server(8082, sandbox_path_);
+
+  string src_url = "http://127.0.0.1:8082/" + GetFileName(src_path);
+  JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(file_server.num_processed_requests(), 1);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, 0U);
+}
 
 TEST_F(T_Download, LocalFile2Sink) {
   string dest_path;


### PR DESCRIPTION
Implement a simple HTTP server class. Then use this class to implement simple mock HTTP servers (proxy, redirect, file serving) in t_download.cc. These will be further used for writing additional tests for DownloadManager.

WIP: rewrite t_download.cc using FileSandbox and write more tests.