### PR TITLE
Fix potential file descriptor mix-up of external cache manager

### DIFF
--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -191,7 +191,7 @@ int CacheManager::OpenPinned(
 }
 
 
-void CacheManager::RestoreState(const int fd_progress, void *data) {
+int CacheManager::RestoreState(const int fd_progress, void *data) {
   State *state = reinterpret_cast<State *>(data);
   if (fd_progress >= 0)
     SendMsg2Socket(fd_progress, "Restoring open files table... ");
@@ -205,12 +205,13 @@ void CacheManager::RestoreState(const int fd_progress, void *data) {
       SendMsg2Socket(fd_progress, "switching cache manager unsupported!\n");
     abort();
   }
-  bool result = DoRestoreState(state->concrete_state);
-  if (!result) {
+  int new_root_fd = DoRestoreState(state->concrete_state);
+  if (new_root_fd < -1) {
     if (fd_progress >= 0) SendMsg2Socket(fd_progress, "FAILED!\n");
     abort();
   }
   if (fd_progress >= 0) SendMsg2Socket(fd_progress, "done\n");
+  return new_root_fd;
 }
 
 

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -201,7 +201,13 @@ class CacheManager : SingleCopy {
   // POSIX cache, nothing needs to be done because the table is keep in the
   // kernel for the process.  Other cache managers need to do it manually.
   void *SaveState(const int fd_progress);
-  void RestoreState(const int fd_progress, void *state);
+  /**
+   * When RestoreState is called, the cache has already exactly one file
+   * descriptor open: the root file catalog. This file descriptor might be
+   * remapped to another number. A return value of -1 means no action needs
+   * to take place. A smaller value inidicates an error.
+   */
+  int RestoreState(const int fd_progress, void *state);
   void FreeState(const int fd_progress, void *state);
 
   /**
@@ -222,7 +228,7 @@ class CacheManager : SingleCopy {
 
   // Unless overwritten, Saving/Restoring states will crash the Fuse module
   virtual void *DoSaveState() { return NULL; }
-  virtual bool DoRestoreState(void *data) { return false; }
+  virtual int DoRestoreState(void *data) { return false; }
   virtual bool DoFreeState(void *data) { return false; }
 
   /**

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -102,7 +102,7 @@ class ExternalCacheManager : public CacheManager {
 
  protected:
   virtual void *DoSaveState();
-  virtual bool DoRestoreState(void *data);
+  virtual int DoRestoreState(void *data);
   virtual bool DoFreeState(void *data);
 
  private:

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -463,7 +463,7 @@ void CachePlugin::HandleRefcount(
     msg_reply.set_status(status);
     if ((status != cvmfs::STATUS_OK) && (status != cvmfs::STATUS_NOENTRY)) {
       LogSessionError(msg_req->session_id(), status,
-                      "failed to open/close object");
+                      "failed to open/close object " + object_id.ToString());
     }
   }
   transport->SendFrame(&frame_send);

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -308,11 +308,11 @@ void *PosixCacheManager::DoSaveState() {
 }
 
 
-bool PosixCacheManager::DoRestoreState(void *data) {
+int PosixCacheManager::DoRestoreState(void *data) {
   assert(data);
   char *c = reinterpret_cast<char *>(data);
   assert(*c == '\0');
-  return true;
+  return -1;
 }
 
 

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -105,7 +105,7 @@ class PosixCacheManager : public CacheManager {
 
  protected:
   virtual void *DoSaveState();
-  virtual bool DoRestoreState(void *data);
+  virtual int DoRestoreState(void *data);
   virtual bool DoFreeState(void *data);
 
  private:

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -30,11 +30,13 @@ bool TieredCacheManager::DoFreeState(void *data) {
 }
 
 
-bool TieredCacheManager::DoRestoreState(void *data) {
+int TieredCacheManager::DoRestoreState(void *data) {
   SavedState *state = reinterpret_cast<SavedState *>(data);
-  upper_->RestoreState(-1, state->state_upper);
-  lower_->RestoreState(-1, state->state_lower);
-  return true;
+  int new_root_fd = upper_->RestoreState(-1, state->state_upper);
+  // The lower cache layer does not keep the root catalog open
+  int retval = lower_->RestoreState(-1, state->state_lower);
+  assert(retval = -1);
+  return new_root_fd;
 }
 
 

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -35,7 +35,7 @@ int TieredCacheManager::DoRestoreState(void *data) {
   int new_root_fd = upper_->RestoreState(-1, state->state_upper);
   // The lower cache layer does not keep the root catalog open
   int retval = lower_->RestoreState(-1, state->state_lower);
-  assert(retval = -1);
+  assert(retval == -1);
   return new_root_fd;
 }
 

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -68,7 +68,7 @@ class TieredCacheManager : public CacheManager {
 
  protected:
   virtual void *DoSaveState();
-  virtual bool DoRestoreState(void *data);
+  virtual int DoRestoreState(void *data);
   virtual bool DoFreeState(void *data);
 
  private:

--- a/cvmfs/fd_table.h
+++ b/cvmfs/fd_table.h
@@ -122,6 +122,8 @@ class FdTable : SingleCopy {
     return 0;
   }
 
+  unsigned GetMaxFds() const { return fd_index_.size(); }
+
  private:
   struct FdWrapper {
     FdWrapper(HandleT h, unsigned i) : handle(h), index(i) { }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1045,6 +1045,11 @@ void FileSystem::TearDown2ReadOnly() {
 }
 
 
+void FileSystem::RemapCatalogFd(int from, int to) {
+  sqlite::RegisterFdMapping(from, to);
+}
+
+
 bool FileSystem::TriageCacheMgr() {
   cache_mgr_instance_ = kDefaultCacheMgrInstance;
   string instance;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -168,6 +168,7 @@ class FileSystem : SingleCopy, public BootFactory {
   bool IsHaNfsSource() { return nfs_mode_ & kNfsMapsHa; }
   void ResetErrorCounters();
   void TearDown2ReadOnly();
+  void RemapCatalogFd(int from, int to);
 
   CacheManager *cache_mgr() { return cache_mgr_; }
   std::string cache_mgr_instance() { return cache_mgr_instance_; }

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -29,6 +29,7 @@
 #include <climits>
 #include <cstring>
 #include <ctime>
+#include <vector>
 
 #include "cache.h"
 #include "duplex_sqlite3.h"
@@ -84,11 +85,32 @@ struct VfsRdOnlyFile {
   uint64_t size;
 };
 
+/**
+ * File descriptor mappings
+ */
+std::vector<int> *fd_from_ = NULL;
+std::vector<int> *fd_to_ = NULL;
+
 }  // anonymous namespace
+
+static void ApplyFdMap(VfsRdOnlyFile *pFile) {
+  unsigned N = fd_from_->size();
+  for (unsigned i = 0; i < N; ++i) {
+    if (pFile->fd == (*fd_from_)[i]) {
+      LogCvmfs(kLogSql, kLogDebug, "map fd %d --> %d",
+               (*fd_from_)[i], (*fd_to_)[i]);
+      pFile->fd = (*fd_to_)[i];
+      fd_from_->erase(fd_from_->begin() + i);
+      fd_to_->erase(fd_to_->begin() + i);
+      return;
+    }
+  }
+}
 
 
 static int VfsRdOnlyClose(sqlite3_file *pFile) {
   VfsRdOnlyFile *p = reinterpret_cast<VfsRdOnlyFile *>(pFile);
+  ApplyFdMap(p);
   int retval = p->vfs_rdonly->cache_mgr->Close(p->fd);
   if (retval == 0) {
     perf::Dec(p->vfs_rdonly->no_open);
@@ -109,6 +131,7 @@ static int VfsRdOnlyRead(
   sqlite_int64 iOfst
 ) {
   VfsRdOnlyFile *p = reinterpret_cast<VfsRdOnlyFile *>(pFile);
+  ApplyFdMap(p);
   ssize_t got = p->vfs_rdonly->cache_mgr->Pread(p->fd, zBuf, iAmt, iOfst);
   perf::Inc(p->vfs_rdonly->n_read);
   if (got == iAmt) {
@@ -444,6 +467,9 @@ bool RegisterVfsRdOnly(
   perf::Statistics *statistics,
   const VfsOptions options)
 {
+  fd_from_ = new std::vector<int>();
+  fd_to_ = new std::vector<int>();
+
   sqlite3_vfs *vfs = reinterpret_cast<sqlite3_vfs *>(
     smalloc(sizeof(sqlite3_vfs)));
   memset(vfs, 0, sizeof(sqlite3_vfs));
@@ -515,7 +541,18 @@ bool UnregisterVfsRdOnly() {
 
   delete reinterpret_cast<VfsRdOnly *>(vfs->pAppData);
   free(vfs);
+
+  delete fd_from_;
+  delete fd_to_;
+  fd_from_ = NULL;
+  fd_to_ = NULL;
+
   return true;
+}
+
+void RegisterFdMapping(int from, int to) {
+  fd_from_->push_back(from);
+  fd_to_->push_back(to);
 }
 
 }  // namespace sqlite

--- a/cvmfs/sqlitevfs.h
+++ b/cvmfs/sqlitevfs.h
@@ -24,6 +24,12 @@ bool RegisterVfsRdOnly(CacheManager *cache_mgr,
                        const VfsOptions options);
 bool UnregisterVfsRdOnly();
 
+/**
+ * After a reload, existing file catalog file dscriptors might need a remap
+ * to the fd in the context of the restored cache manager.
+ */
+void RegisterFdMapping(int from, int to);
+
 }  // namespace sqlite
 
 #endif  // CVMFS_SQLITEVFS_H_

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -270,7 +270,10 @@ class TestCacheManager : public CacheManager {
   virtual void Spawn() { }
 
   virtual void *DoSaveState() { return state; }
-  virtual bool DoRestoreState(void *data) { return data == this; }
+  virtual int DoRestoreState(void *data) {
+    if (data == this) return -1;
+    return -2;
+  }
   virtual bool DoFreeState(void *data) { return data == this; }
 
   void *state;


### PR DESCRIPTION
As discovered in the integration tests, the external cache manager can mix-up file catalog file descriptors if

- the file system client gets reloaded
- after the root file catalog got updated/remounted

This is due to the fact that during reload and restore of the previous cache manager file system table, the file descriptor for the newly attached root file catalog is lost. With this fix, the root catalog's file descriptor gets remapped into the restored file descriptor table.