### PR TITLE
WIP: [CVM-1696] Addressing trailing slash problem

### DIFF
--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -94,25 +94,25 @@ RoCatalogMgr* CatalogDiffTool<RoCatalogMgr>::OpenCatalogManager(
 
 template <typename RoCatalogMgr>
 void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
-  LogCvmfs(kLogCvmfs, kLogSyslog,
-                "CatalogDiffTool - DiffRec on %s",
-                path.ToString().c_str());
+  LogCvmfs(kLogCvmfs, kLogSyslog, "CatalogDiffTool - DiffRec on %s",
+           path.ToString().c_str());
   // This function is recursive at the very end, let's keep this in mind.
 
   // A directory entry is some layer of abstraction above a C struct dirent.
-  // Nothing more than the type of file in the directory (can be another directory),
-  // the name itself and the inode
+  // Nothing more than the type of file in the directory (can be another
+  // directory), the name itself and the inode
   catalog::DirectoryEntryList old_listing;
   AppendFirstEntry(&old_listing);
   // We start allocating the DirectoryEntryList and we AppendFirstEntry to it.
-  // It is nothing more than a vector where the first and the last entries are marker.
+  // It is nothing more than a vector where the first and the last entries are
+  // marker.
   old_catalog_mgr_->Listing(path, &old_listing);
   // here we list the content of path into the old_listing DirectoryEntry.
   // I believe that this listing is not recursive, but I could be wrong here.
   // Non recursive listing may explain the recursiveness of this function.
   sort(old_listing.begin(), old_listing.end(), IsSmaller);
-  // obvious, the IsSmaller just compares the names of the DirectoryEntriy-ies being
-  // careful with the inode.
+  // obvious, the IsSmaller just compares the names of the DirectoryEntriy-ies
+  // being careful with the inode.
   AppendLastEntry(&old_listing);
   // We mark the old_listing as over.
 
@@ -121,33 +121,37 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
   new_catalog_mgr_->Listing(path, &new_listing);
   sort(new_listing.begin(), new_listing.end(), IsSmaller);
   AppendLastEntry(&new_listing);
-  // Here we repeat what we did above, excatly the same, but this time we use the new_catalog_manager
+  // Here we repeat what we did above, excatly the same, but this time we use
+  // the new_catalog_manager
 
   // At this point we have two DirectoryEntryList (vectors), that are sorted.
-  // Both of them contains the files that are under the directory `path` (the arguments)
-  // but at different points in times, before and after the transaction.
+  // Both of them contains the files that are under the directory `path` (the
+  // arguments) but at different points in times, before and after the
+  // transaction.
 
-  // Now we are starting the loop inside of which we call this same function recursively
+  // Now we are starting the loop inside of which we call this same function
+  // recursively
   unsigned i_from = 0, size_from = old_listing.size();
   unsigned i_to = 0, size_to = new_listing.size();
   while ((i_from < size_from) || (i_to < size_to)) {
-    // the loops goes on as long as we don't have visited all the entries in both lists
+    // the loops goes on as long as we don't have visited all the entries in
+    // both lists
     catalog::DirectoryEntry old_entry = old_listing[i_from];
     catalog::DirectoryEntry new_entry = new_listing[i_to];
 
     // some sanity check
     if (old_entry.linkcount() == 0) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                "CatalogDiffTool - Entry %s in old catalog has linkcount 0. "
-                "Aborting.",
-                old_entry.name().c_str());
+               "CatalogDiffTool - Entry %s in old catalog has linkcount 0. "
+               "Aborting.",
+               old_entry.name().c_str());
       abort();
     }
     if (new_entry.linkcount() == 0) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                "CatalogDiffTool - Entry %s in new catalog has linkcount 0. "
-                "Aborting.",
-                new_entry.name().c_str());
+               "CatalogDiffTool - Entry %s in new catalog has linkcount 0. "
+               "Aborting.",
+               new_entry.name().c_str());
       abort();
     }
 
@@ -195,15 +199,17 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
       continue;
     }
 
-    // if we arrived here the dirent are the same, but the content could have change
+    // if we arrived here the dirent are the same, but the content could have
+    // change
     assert(old_path == new_path);
-    // let's not forget to upgrade our counters, later it will be more difficult.
+    // let's not forget to upgrade our counters, later it will be more
+    // difficult.
     i_from++;
     i_to++;
 
     // we are computing the differences between two entries
-    // a diff of kIdentical (which is equal to zero), means that there are no differences
-    // between the two entries.
+    // a diff of kIdentical (which is equal to zero), means that there are no
+    // differences between the two entries.
     catalog::DirectoryEntryBase::Differences diff =
         old_entry.CompareTo(new_entry);
     if ((diff == catalog::DirectoryEntryBase::Difference::kIdentical) &&

--- a/cvmfs/receiver/lease_path_util.cc
+++ b/cvmfs/receiver/lease_path_util.cc
@@ -18,6 +18,12 @@ bool IsPathInLease(const PathString& lease, const PathString& path) {
     return true;
   }
 
+  // The lease is a prefix of the path and the last char of the lease is a "/"
+  if (path.StartsWith(lease) &&
+      lease.GetChars()[lease.GetLength() - 1] == '/') {
+    return true;
+  }
+
   // If the path string is exactly the lease path return true (allow the
   // creation of the leased directory during the lease itself)
   if (lease == path) {

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -10,10 +10,6 @@ clean_up() {
     rm -rvf /tmp/cvmfs_out_*
 }
 
-check_status() {
-    echo $(( $1 || 0 ))
-}
-
 compare_file_checksum() {
     local file_name=$1
     local target_checksum=$2
@@ -195,21 +191,21 @@ run_transactions() {
         return 1
     fi
 
-    compare_file_checksum /tmp/cvmfs_out_1/new_file.txt d8e8fca2dc0f896fd7cb4cb0031ba249
-    compare_file_checksum /tmp/cvmfs_out_1/new_repository e5747677debcb10cabe17d87a40e7fa4
+    compare_file_checksum /tmp/cvmfs_out_1/new_file.txt d8e8fca2dc0f896fd7cb4cb0031ba249 || return 101
+    compare_file_checksum /tmp/cvmfs_out_1/new_repository e5747677debcb10cabe17d87a40e7fa4 || return 102
 
-    compare_file_checksum /tmp/cvmfs_out_2/new_repository/another_file.txt d8e8fca2dc0f896fd7cb4cb0031ba249
+    compare_file_checksum /tmp/cvmfs_out_2/new_repository/another_file.txt d8e8fca2dc0f896fd7cb4cb0031ba249 || return 103
 
     if [ -d /tmp/cvmfs_out_3/new_repository ]; then
         echo "/cvmfs/test.repo.org/new_repository should have been deleted in transaction 3"
         return 1
     fi
 
-    compare_file_checksum /tmp/cvmfs_out_4/a/b/new_file.txt f1885b1a57c71cacbd923fc5e9aefef3
+    compare_file_checksum /tmp/cvmfs_out_4/a/b/new_file.txt f1885b1a57c71cacbd923fc5e9aefef3 || return 104
 
-    compare_file_checksum /tmp/cvmfs_out_5/new/c/d/new_file.txt f1885b1a57c71cacbd923fc5e9aefef3
+    compare_file_checksum /tmp/cvmfs_out_5/new/c/d/new_file.txt f1885b1a57c71cacbd923fc5e9aefef3 || return 105
 
-    compare_file_checksum /tmp/cvmfs_out_6/new/c/another_file.txt f1885b1a57c71cacbd923fc5e9aefef3
+    compare_file_checksum /tmp/cvmfs_out_6/new/c/another_file.txt f1885b1a57c71cacbd923fc5e9aefef3 || return 106
 
     if [ -f /tmp/cvmfs_out_7/new/invalid_file.txt ]; then
         echo "/cvmfs/test.repo.org/new/invalid_file.txt should not have been create in transaction 7"
@@ -227,6 +223,7 @@ run_transactions() {
     fi
 
     clean_up
+    return 0
 }
 
 cvmfs_run_test() {
@@ -235,6 +232,6 @@ cvmfs_run_test() {
     run_transactions
     local status=$?
 
-    return $(check_status $status)
+    return $status
 }
 

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -170,7 +170,7 @@ run_transactions() {
     num_tags_after=$(cvmfs_server tag -l test.repo.org | grep -a generic | wc -l)
     num_generic_tags_created=$((num_tags_after - num_tags_before))
 
-    ## Transaction 8 (Check creation of named tag)
+    ## Transaction 9 (Check creation of named tag)
 
     echo "  Starting transaction 9"
     cvmfs_server transaction test.repo.org
@@ -183,6 +183,20 @@ run_transactions() {
 
     echo "  Check that the named tag has been created"
     specialtag_line=$(cvmfs_server tag -l test.repo.org | grep specialtag)
+
+    ## Transaction 10 (Lease on a subpath with trailing slash)
+    ## Very similar to transaction 6, but note the trailing slash after the
+    ## directory
+    echo "  Starting transaction 10"
+    cvmfs_server transaction test.repo.org/new/c/
+    echo "New file" > /cvmfs/test.repo.org/new/c/another_file_trailing.txt
+
+    echo "  Publishing changes 10"
+    cvmfs_server publish test.repo.org
+    cvmfs_server check test.repo.org
+
+    echo "  Copy the contents of the repository"
+    save_repo_contents /tmp/cvmfs_out_10
 
     ## Check results
 
@@ -206,6 +220,8 @@ run_transactions() {
     compare_file_checksum /tmp/cvmfs_out_5/new/c/d/new_file.txt f1885b1a57c71cacbd923fc5e9aefef3 || return 105
 
     compare_file_checksum /tmp/cvmfs_out_6/new/c/another_file.txt f1885b1a57c71cacbd923fc5e9aefef3 || return 106
+
+    compare_file_checksum /tmp/cvmfs_out_10/new/c/another_file_trailing.txt f1885b1a57c71cacbd923fc5e9aefef3 || return 107
 
     if [ -f /tmp/cvmfs_out_7/new/invalid_file.txt ]; then
         echo "/cvmfs/test.repo.org/new/invalid_file.txt should not have been create in transaction 7"

--- a/test/src/807-nested_new_directories_gateway_ingest/main
+++ b/test/src/807-nested_new_directories_gateway_ingest/main
@@ -1,0 +1,112 @@
+cvmfs_test_name="Repository gateway nested catalogs"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+# This test covers the creation of subdirectories that don't yet exists when the reporitory upstream is of type GW.
+# Refers to [CVM-1696](https://sft.its.cern.ch/jira/projects/CVM/issues/CVM-1696)
+#
+# Basically it makes sure that 
+# `cvmfs_server transaction test.repo.org/DIR/SUBDIR` 
+# works even if both DIR and SUBDIR don't exists yet.
+
+clean_up() {
+    echo "Cleaning up"
+
+    echo "  Removing output directories"
+    rm -rvf /tmp/cvmfs_out_{1,2,3}
+}
+
+check_status() {
+    echo $(( $1 || 0 ))
+}
+
+compare_file_checksum() {
+    local file_name=$1
+    local target_checksum=$2
+    local checksum=$(md5sum $file_name | cut -d' ' -f1)
+    echo "Checksum of $file_name is $checksum"
+    if [ "$checksum" != "$target_checksum" ]; then
+        echo "Checksum mismatch for $file_name. Expected $target_checksum. Found $checksum"
+        return 1
+    fi
+}
+
+save_repo_contents() {
+    local dest=$1
+    rm -rf $dest
+    mkdir -p $dest
+    cp -r /cvmfs/test.repo.org/* $dest/
+}
+
+run_transactions() {
+    set_up_repository_gateway
+
+    echo "Checking transaction + publish"
+
+    ## Transaction 1
+    echo "  Starting transaction 1 (Creating a deep directory tree which is assigned to a sub-catalog)"
+    cvmfs_server transaction test.repo.org
+
+    echo "  Create a deep directory hierarchy"
+    mkdir -p /cvmfs/test.repo.org/a
+    echo "New file" > /cvmfs/test.repo.org/a/b
+    touch /cvmfs/test.repo.org/a/.cvmfscatalog
+
+    echo "  Publishing changes 1"
+    cvmfs_server publish -v test.repo.org
+    cvmfs_server check test.repo.org
+
+    echo "  Checking results 1"
+    compare_file_checksum /tmp/cvmfs_out_1/a/b f1885b1a57c71cacbd923fc5e9aefef3
+    if [ x"$(cvmfs_server check test.repo.org | grep /a)" = x"" ]; then
+        echo "Nested catalog not created at /a"
+        return 1
+    else
+        echo "Nested catalog was successfully created at /a"
+    fi
+
+    echo "  Copy the contents of the repository"
+    save_repo_contents /tmp/cvmfs_out_1
+
+    echo "  Checking results 1"
+    compare_file_checksum /tmp/cvmfs_out_1/a/b f1885b1a57c71cacbd923fc5e9aefef3
+    if [ x"$(cvmfs_server check test.repo.org | grep /a)" = x"" ]; then
+        echo "Nested catalog not created at /a"
+        return 1
+    else
+        echo "Nested catalog was successfully created at /a"
+    fi
+
+
+    echo "  Getting lease on subdirectory that does not exists yet"
+    cvmfs_server transaction test.repo.org/foo/bar/
+
+    mkdir -p /cvmfs/test.repo.org/foo/bar/baz/
+    touch /cvmfs/test.repo.org/foo/bar/baz/.cvmfscatalog
+    touch /cvmfs/test.repo.org/foo/bar/nested_file
+    echo "Nested file" > /cvmfs/test.repo.org/foo/bar/nested_file
+    
+    echo "  Publishing changes"
+    cvmfs_server publish -v test.repo.org
+    cvmfs_server check test.repo.org
+
+    tree /cvmfs/test.repo.org
+
+    if [ x"$(tree /cvmfs/test.repo.org | grep nested_file)" = x"" ]; then
+        echo "File nested_file not found"
+        return 2
+    fi
+
+    clean_up
+}
+
+cvmfs_run_test() {
+    trap clean_up EXIT HUP INT TERM || return $?
+
+    run_transactions
+    local status=$?
+
+    return $(check_status $status)
+}
+
+


### PR DESCRIPTION
The first part of this PR address the trailing slash problem when using the gateway.

The first step was to actually make the test fails if the ingestion of the gateway didn't work out.
The we added a test for checking that the ingestion work also with a trailing slash: [setup](https://github.com/cvmfs/cvmfs/compare/CVM-1696?expand=1#diff-a4ea05080469eebcea0ecbeaf73c7d95R187-R200) and [check](https://github.com/cvmfs/cvmfs/compare/CVM-1696?expand=1#diff-a4ea05080469eebcea0ecbeaf73c7d95R223-R224)

Finally we correct how we check [if a lease is in path](https://github.com/cvmfs/cvmfs/commit/ba4bd30155dead1fa9040e00a162b1666f5df184).

This is still a work in progress, but I am quite unsure on commit https://github.com/cvmfs/cvmfs/commit/d5adde80eb99dd58779123b54a7ca73c172d7b6b which does nothing but heavily annotate the function DiffRec, very useful during debugging, but maybe too heavy on the annotation.

The work is also being documented in this [gist](https://gist.github.com/siscia/df86c59b00de6905ea4606af83e6d1b5)