### PR TITLE
DownloadManager fix: switch hosts after redirect

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -952,8 +952,10 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   if (!opt_dns_server_.empty())
     curl_easy_setopt(curl_handle, CURLOPT_DNS_SERVERS, opt_dns_server_.c_str());
 
-  if (info->probe_hosts && opt_host_chain_)
+  if (info->probe_hosts && opt_host_chain_) {
     url_prefix = (*opt_host_chain_)[opt_host_chain_current_];
+    info->current_host_chain_index = opt_host_chain_current_;
+  }
 
   string url = url_prefix + *(info->url);
 
@@ -2030,16 +2032,12 @@ void DownloadManager::SwitchHost(JobInfo *info) {
   }
 
   if (info) {
-    char *effective_url;
-    curl_easy_getinfo(info->curl_handle, CURLINFO_EFFECTIVE_URL,
-                      &effective_url);
-    if (!HasPrefix(string(effective_url) + "/",
-                   (*opt_host_chain_)[opt_host_chain_current_] + "/", true)) {
+    if (info->current_host_chain_index != opt_host_chain_current_) {
       do_switch = false;
       LogCvmfs(kLogDownload, kLogDebug,
                "don't switch host, "
-               "effective url: %s, current host: %s",
-               effective_url,
+               "last used host: %s, current host: %s",
+               (*opt_host_chain_)[info->current_host_chain_index].c_str(),
                (*opt_host_chain_)[opt_host_chain_current_].c_str());
     }
   }

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -203,6 +203,7 @@ struct JobInfo {
     error_code = kFailOther;
     num_used_proxies = num_used_hosts = num_retries = 0;
     backoff_ms = 0;
+    current_host_chain_index = 0;
 
     range_offset = -1;
     range_size = -1;
@@ -283,6 +284,7 @@ struct JobInfo {
   unsigned char num_used_hosts;
   unsigned char num_retries;
   unsigned backoff_ms;
+  unsigned int current_host_chain_index;
 };  // JobInfo
 
 

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -285,23 +285,23 @@ TEST_F(T_Download, RemoteFileSwitchHosts) {
   EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
 }
 
-// TEST_F(T_Download, RemoteFileSwitchHostsAfterRedirect) {
-//   string src_path = GetSmallFile();
-//   string src_content = GetFileContents(src_path);
+TEST_F(T_Download, RemoteFileSwitchHostsAfterRedirect) {
+  string src_path = GetSmallFile();
+  string src_content = GetFileContents(src_path);
 
-//   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8084");
-//   MockFileServer file_server(8082, sandbox_path_);
+  MockRedirectServer redirect_server(8083, "http://127.0.0.1:8084");
+  MockFileServer file_server(8082, sandbox_path_);
 
-//   download_mgr.EnableRedirects();
-//   download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
-//   string url = "/" + GetFileName(src_path);
-//   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL);
-//   download_mgr.Fetch(&info);
-  // ASSERT_EQ(info.num_used_hosts, 2);
-//   ASSERT_EQ(info.error_code, kFailOk);
-//   ASSERT_EQ(info.destination_mem.pos, src_content.length());
-//   EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
-// }
+  download_mgr.EnableRedirects();
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  string url = "/" + GetFileName(src_path);
+  JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL);
+  download_mgr.Fetch(&info);
+  ASSERT_EQ(info.num_used_hosts, 2);
+  ASSERT_EQ(info.error_code, kFailOk);
+  ASSERT_EQ(info.destination_mem.pos, src_content.length());
+  EXPECT_STREQ(info.destination_mem.data, src_content.c_str());
+}
 
 TEST_F(T_Download, RemoteFileSwitchProxies) {
   string src_path = GetSmallFile();


### PR DESCRIPTION
When a host redirects to another failing URL, DownloadManager
incorrectly does not switch to next host. This is caused by
assuming that CURLINFO_EFFECTIVE_URL variable does not change
after a redirect, when it actually does.

Rewrite the 'do_switch' condition in SwitchHost() without the
help of CURLINFO_EFFECTIVE_URL variable.