### PR TITLE
Performance improvements for modern fuse/libfuse

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -499,6 +499,39 @@ static void cvmfs_forget(
 }
 
 
+#if (FUSE_VERSION >= 29)
+static void cvmfs_forget_multi(
+  fuse_req_t req,
+  size_t count,
+  struct fuse_forget_data *forgets
+) {
+  HighPrecisionTimer guard_timer(file_system_->hist_fs_forget_multi());
+
+  perf::Xadd(file_system_->n_fs_forget(), count);
+  if (file_system_->IsNfsSource()) {
+    fuse_reply_none(req);
+    return;
+  }
+
+  fuse_remounter_->fence()->Enter();
+  for (size_t i = 0; i < count; ++i) {
+    if (forgets[i].ino == FUSE_ROOT_ID) {
+      continue;
+    }
+
+    uint64_t ino = mount_point_->catalog_mgr()->MangleInode(forgets[i].ino);
+    LogCvmfs(kLogCvmfs, kLogDebug, "forget on inode %" PRIu64 " by %" PRIu64,
+             ino, forgets[i].nlookup);
+
+    mount_point_->inode_tracker()->VfsPut(ino, forgets[i].nlookup);
+  }
+  fuse_remounter_->fence()->Leave();
+
+  fuse_reply_none(req);
+}
+#endif  // FUSE_VERSION >= 29
+
+
 /**
  * Looks into dirent to decide if this is an EIO negative reply or an
  * ENOENT negative reply.  We do not need to store the reply in the negative
@@ -1791,22 +1824,25 @@ static void SetCvmfsOperations(struct fuse_lowlevel_ops *cvmfs_operations) {
   memset(cvmfs_operations, 0, sizeof(*cvmfs_operations));
 
   // Init/Fini
-  cvmfs_operations->init     = cvmfs_init;
-  cvmfs_operations->destroy  = cvmfs_destroy;
+  cvmfs_operations->init         = cvmfs_init;
+  cvmfs_operations->destroy      = cvmfs_destroy;
 
-  cvmfs_operations->lookup      = cvmfs_lookup;
-  cvmfs_operations->getattr     = cvmfs_getattr;
-  cvmfs_operations->readlink    = cvmfs_readlink;
-  cvmfs_operations->open        = cvmfs_open;
-  cvmfs_operations->read        = cvmfs_read;
-  cvmfs_operations->release     = cvmfs_release;
-  cvmfs_operations->opendir     = cvmfs_opendir;
-  cvmfs_operations->readdir     = cvmfs_readdir;
-  cvmfs_operations->releasedir  = cvmfs_releasedir;
-  cvmfs_operations->statfs      = cvmfs_statfs;
-  cvmfs_operations->getxattr    = cvmfs_getxattr;
-  cvmfs_operations->listxattr   = cvmfs_listxattr;
-  cvmfs_operations->forget      = cvmfs_forget;
+  cvmfs_operations->lookup       = cvmfs_lookup;
+  cvmfs_operations->getattr      = cvmfs_getattr;
+  cvmfs_operations->readlink     = cvmfs_readlink;
+  cvmfs_operations->open         = cvmfs_open;
+  cvmfs_operations->read         = cvmfs_read;
+  cvmfs_operations->release      = cvmfs_release;
+  cvmfs_operations->opendir      = cvmfs_opendir;
+  cvmfs_operations->readdir      = cvmfs_readdir;
+  cvmfs_operations->releasedir   = cvmfs_releasedir;
+  cvmfs_operations->statfs       = cvmfs_statfs;
+  cvmfs_operations->getxattr     = cvmfs_getxattr;
+  cvmfs_operations->listxattr    = cvmfs_listxattr;
+  cvmfs_operations->forget       = cvmfs_forget;
+#if (FUSE_VERSION >= 29)
+  cvmfs_operations->forget_multi = cvmfs_forget_multi;
+#endif
 }
 
 // Called by cvmfs_talk when switching into read-only cache mode

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -763,6 +763,12 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
   perf::Inc(file_system_->n_fs_dir_open());
   perf::Inc(file_system_->no_open_dirs());
 
+#if (FUSE_VERSION >= 32)
+  // This affects only reads on the same open directory handle (e.g. multiple
+  // reads with rewinddir() between them).  A new opendir on the same directory
+  // will trigger readdir calls independently of this setting.
+  fi->cache_readdir = 1;
+#endif
   fuse_reply_open(req, fi);
 }
 

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -198,6 +198,9 @@ struct LoaderExports {
  * This contains the public interface of the cvmfs fuse module.
  * Whenever something changes, change the version number.
  * A global CvmfsExports struct is looked up by the loader via dlsym.
+ *
+ * Note: as of cvmfs version 2.8, we set cvmfs_operations.forget_multi on new
+ * enough fuse
  */
 struct CvmfsExports {
   CvmfsExports() {

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -225,6 +225,7 @@ void FileSystem::CreateStatistics() {
 
   hist_fs_lookup_ = new Log2Histogram(30);
   hist_fs_forget_ = new Log2Histogram(30);
+  hist_fs_forget_multi_ = new Log2Histogram(30);
   hist_fs_getattr_ = new Log2Histogram(30);
   hist_fs_readlink_ = new Log2Histogram(30);
   hist_fs_opendir_ = new Log2Histogram(30);
@@ -408,6 +409,7 @@ FileSystem::~FileSystem() {
   SqliteMemoryManager::CleanupInstance();
 
   delete hist_fs_lookup_;
+  delete hist_fs_forget_multi_;
   delete hist_fs_forget_;
   delete hist_fs_getattr_;
   delete hist_fs_readlink_;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -176,6 +176,7 @@ class FileSystem : SingleCopy, public BootFactory {
   bool found_previous_crash() { return found_previous_crash_; }
   Log2Histogram *hist_fs_lookup() { return hist_fs_lookup_; }
   Log2Histogram *hist_fs_forget() { return hist_fs_forget_; }
+  Log2Histogram *hist_fs_forget_multi() { return hist_fs_forget_multi_; }
   Log2Histogram *hist_fs_getattr() { return hist_fs_getattr_; }
   Log2Histogram *hist_fs_readlink() { return hist_fs_readlink_; }
   Log2Histogram *hist_fs_opendir() { return hist_fs_opendir_; }
@@ -296,6 +297,7 @@ class FileSystem : SingleCopy, public BootFactory {
 
   Log2Histogram *hist_fs_lookup_;
   Log2Histogram *hist_fs_forget_;
+  Log2Histogram *hist_fs_forget_multi_;
   Log2Histogram *hist_fs_getattr_;
   Log2Histogram *hist_fs_readlink_;
   Log2Histogram *hist_fs_opendir_;

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -572,6 +572,8 @@ void *TalkManager::MainResponder(void *data) {
 
       result += "Lookup\n" + file_system->hist_fs_lookup()->ToString();
       result += "Forget\n" + file_system->hist_fs_forget()->ToString();
+      result += "Multi-Forget\n"
+                + file_system->hist_fs_forget_multi()->ToString();
       result += "Getattr\n" + file_system->hist_fs_getattr()->ToString();
       result += "Readlink\n" + file_system->hist_fs_readlink()->ToString();
       result += "Opendir\n" + file_system->hist_fs_opendir()->ToString();

--- a/test_mount.sh
+++ b/test_mount.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+REPO=$1
+CVMFS_BUILD_DIR=${CVMFS_BUILD_DIR:-$PWD}
+CVMFS_SOURCE_DIR=$(grep CernVM-FS_SOURCE_DIR "${CVMFS_BUILD_DIR}/CMakeCache.txt" | cut -d= -f2)
+CVMFS_TEST_WORKSPACE=${CVMFS_TEST_WORKSPACE:-/tmp/cvmfs-test}
+FS_OPTIONS=${FS_OPTIONS:-}
+CVMFS_ARGS=${CVMFS_ARGS:-}
+CVMFS_SERVER_URL=${CVMFS_SERVER_URL:-http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@}
+
+export CVMFS_LIBRARY_PATH=${CVMFS_BUILD_DIR}/cvmfs
+
+mkdir -p "${CVMFS_TEST_WORKSPACE}/mnt/$REPO" \
+  "${CVMFS_TEST_WORKSPACE}/cache" \
+  "${CVMFS_TEST_WORKSPACE}/workspace" \
+  "${CVMFS_TEST_WORKSPACE}/conf"
+
+cat << EOF > "${CVMFS_TEST_WORKSPACE}/conf/default.conf"
+CVMFS_WORKSPACE=${CVMFS_TEST_WORKSPACE}/workspace
+CVMFS_CACHE_BASE=${CVMFS_TEST_WORKSPACE}/cache
+CVMFS_CLAIM_OWNERSHIP=yes
+CVMFS_KEYS_DIR=${CVMFS_SOURCE_DIR}/mount/keys
+CVMFS_USYSLOG=${CVMFS_TEST_WORKSPACE}/cvmfs.log
+CVMFS_SERVER_URL=${CVMFS_SERVER_URL}
+CVMFS_PAC_URLS=http://cernvm-wpad.cern.ch/wpad.dat
+CVMFS_HTTP_PROXY=auto
+CVMFS_RELOAD_SOCKETS=${CVMFS_TEST_WORKSPACE}/workspace
+CVMFS_INSTRUMENT_FUSE=yes
+EOF
+touch "${CVMFS_TEST_WORKSPACE}/conf/default.local"
+
+if [ "x$FS_OPTIONS" != "x" ]; then
+  FS_OPTIONS="${FS_OPTIONS},"
+fi
+
+${CVMFS_BUILD_DIR}/cvmfs/cvmfs2 $CVMFS_ARGS \
+  -o ${FS_OPTIONS}config=${CVMFS_TEST_WORKSPACE}/conf/default.conf:${CVMFS_TEST_WORKSPACE}/conf/default.local \
+  $REPO "${CVMFS_TEST_WORKSPACE}/mnt/$REPO"


### PR DESCRIPTION
- Make use of batch forget (libfuse >= 29, e.g. EL7)
- Cache readdir results on the same directory handle (fuse3, kernel >= 4.20)