### PR TITLE
Remove all abort

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -106,6 +106,7 @@
 #include "statistics.h"
 #include "talk.h"
 #include "tracer.h"
+#include "util/exception.h"
 #include "util_concurrency.h"
 #include "uuid.h"
 #include "wpad.h"
@@ -1804,18 +1805,16 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
   if (mount_point_->enforce_acls()) {
 #ifdef FUSE_CAP_POSIX_ACL
     if ((conn->capable & FUSE_CAP_POSIX_ACL) == 0) {
-      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-               "ACL support requested but missing fuse kernel support, "
-               "aborting");
-      abort();
+      PANIC(kLogDebug | kLogSyslogErr,
+            "ACL support requested but missing fuse kernel support, "
+            "aborting");
     }
     conn->want |= FUSE_CAP_POSIX_ACL;
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog, "enforcing ACLs");
 #else
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-             "ACL support requested but not available in this version of "
-             "libfuse, aborting");
-    abort();
+    PANIC(kLogDebug | kLogSyslogErr,
+          "ACL support requested but not available in this version of "
+          "libfuse, aborting");
 #endif
   }
 }

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -21,6 +21,7 @@
 #include "mountpoint.h"
 #include "platform.h"
 #include "statistics.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -180,9 +181,8 @@ void *FuseRemounter::MainRemountTrigger(void *data) {
         }
         continue;
       }
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "remount trigger connection failure (%d)", errno);
-      abort();
+      PANIC(kLogSyslogErr | kLogDebug,
+            "remount trigger connection failure (%d)", errno);
     }
 
     if (retval == 0) {

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -41,9 +41,8 @@ FuseRemounter::Status FuseRemounter::Check() {
   if (mountpoint_->ReloadBlacklists() &&
       mountpoint_->catalog_mgr()->IsRevisionBlacklisted())
   {
-    LogCvmfs(kLogCatalog, kLogDebug | kLogSyslogErr,
-            "repository revision blacklisted, aborting");
-    abort();
+    PANIC(kLogDebug | kLogSyslogErr,
+          "repository revision blacklisted, aborting");
   }
 
   LogCvmfs(kLogCvmfs, kLogDebug, "remounting root catalog");

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -47,6 +47,7 @@
 #include "options.h"
 #include "platform.h"
 #include "sanitizer.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -397,8 +398,8 @@ static int ParseFuseOptions(void *data __attribute__((unused)), const char *arg,
       parse_options_only_ = true;
       return 0;
     default:
-      LogCvmfs(kLogCvmfs, kLogStderr, "internal option parsing error");
-      abort();
+      PANIC(kLogStderr, "internal option parsing error");
+      return 0;
   }
 }
 
@@ -782,9 +783,8 @@ int FuseMain(int argc, char *argv[]) {
   }
   if (suid_mode_) {
     if (getuid() != 0) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "must be root to mount with suid option");
-      abort();
+      PANIC(kLogStderr | kLogSyslogErr,
+            "must be root to mount with suid option");
     }
     fuse_opt_add_arg(mount_options, "-osuid");
     LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: running with suid support");
@@ -1137,4 +1137,3 @@ static void __attribute__((destructor)) LibraryExit() {
   delete g_cvmfs_stub_exports;
   g_cvmfs_stub_exports = NULL;
 }
-

--- a/cvmfs/loader_talk.cc
+++ b/cvmfs/loader_talk.cc
@@ -16,6 +16,7 @@
 #include "loader.h"
 #include "logging.h"
 #include "platform.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -75,10 +76,10 @@ static void *MainTalk(void *data __attribute__((unused))) {
       SendMsg2Socket(con_fd, "~");
       (void)send(con_fd, &retval, sizeof(retval), MSG_NOSIGNAL);
       if (retval != kFailOk) {
-        LogCvmfs(kLogCvmfs, kLogSyslogErr, "reloading Fuse module failed "
-                                           "(%d - %s)",
-                 retval, Code2Ascii(static_cast<Failures>(retval)));
-        abort();
+        PANIC(kLogSyslogErr,
+              "reloading Fuse module failed "
+              "(%d - %s)",
+              retval, Code2Ascii(static_cast<Failures>(retval)));
       }
       SetLogMicroSyslog("");
     }

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -11,6 +11,7 @@
 
 #include "platform.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/string.h"
 #include "util_concurrency.h"
 
@@ -45,9 +46,7 @@ void AppendItemToHeader(ObjectPack::BucketContentType object_type,
       line_prefix = "C ";
       break;
     default:
-      LogCvmfs(kLogCvmfs, kLogStderr,
-               "Unknown object pack type to be added to header.");
-      abort();
+      PANIC(kLogStderr, "Unknown object pack type to be added to header.");
   }
   if (header) {
     *header += line_prefix + hash_str + " " + StringifyInt(object_size) +

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -12,6 +12,7 @@
 #include "server_tool.h"
 #include "upload.h"
 #include "util/pointer.h"
+#include "util/exception.h"
 
 namespace {
 
@@ -230,8 +231,7 @@ SigningTool::Result SigningTool::Run(
       reinterpret_cast<const unsigned char *>(published_hash.ToString().data()),
       published_hash.GetHexSize(), &sig, &sig_size);
   if (!manifest_was_signed) {
-    abort();
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to sign manifest");
+    PANIC(kLogStderr, "Failed to sign manifest");
     return kError;
   }
 

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -329,18 +329,6 @@ static int VfsRdOnlyAccess(
     return SQLITE_OK;
   }
 
-  /*int amode = 0;
-  switch (flags) {
-    case SQLITE_ACCESS_EXISTS:
-      amode = F_OK;
-      break;
-    case SQLITE_ACCESS_READ:
-      amode = R_OK;
-      break;
-    default:
-      assert(false);
-  }
-  *pResOut = (access(zPath, amode) == 0);*/
   // This VFS deals with file descriptors, we know the files are there
   *pResOut = 0;
   perf::Inc(reinterpret_cast<VfsRdOnly *>(vfs->pAppData)->n_access);

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -29,6 +29,7 @@
 #include "reflog.h"
 #include "sanitizer.h"
 #include "shortstring.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 
@@ -170,14 +171,12 @@ string CommandCheck::FetchPath(const string &path) {
     download::JobInfo download_job(&url, false, false, f, NULL);
     download::Failures retval = download_manager()->Fetch(&download_job);
     if (retval != download::kFailOk) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read %s", url.c_str());
-      abort();
+      PANIC(kLogStderr, "failed to read %s", url.c_str());
     }
   } else {
     bool retval = CopyPath2File(url, f);
     if (!retval) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read %s", url.c_str());
-      abort();
+      PANIC(kLogStderr, "failed to read %s", url.c_str());
     }
   }
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -16,6 +16,7 @@
 #include "ingestion/ingestion_source.h"
 #include "sync_mediator.h"
 #include "sync_union.h"
+#include "util/exception.h"
 
 using namespace std;  // NOLINT
 
@@ -67,10 +68,11 @@ SyncItemType SyncItem::GetGenericFiletype(const SyncItem::EntryStat &stat) const
 {
   const SyncItemType type = stat.GetSyncItemType();
   if (type == kItemUnknown) {
-    PrintWarning("'" + GetRelativePath() + "' has an unsupported file type "
-                 "(st_mode: " + StringifyInt(stat.stat.st_mode) +
-                 " errno: " + StringifyInt(stat.error_code) + ")");
-    abort();
+    PANIC(kLogStderr, ("[WARNING] '" + GetRelativePath() +
+                       "' has an unsupported file type (st_mode: " +
+                       StringifyInt(stat.stat.st_mode) +
+                       " errno: " + StringifyInt(stat.error_code) + ")")
+                          .c_str());
   }
   return type;
 }
@@ -94,9 +96,10 @@ SyncItemType SyncItem::GetRdOnlyFiletype() const {
 SyncItemType SyncItemNative::GetScratchFiletype() const {
   StatScratch();
   if (scratch_stat_.error_code != 0) {
-    PrintWarning("Failed to stat() '" + GetRelativePath() + "' in scratch. "
-                 "(errno: " + StringifyInt(scratch_stat_.error_code) + ")");
-    abort();
+    PANIC(kLogStderr, ("[WARNING] Failed to stat() '" + GetRelativePath() +
+                       "' in scratch. (errno: " +
+                       StringifyInt(scratch_stat_.error_code) + ")")
+                          .c_str());
   }
 
   return GetGenericFiletype(scratch_stat_);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -21,6 +21,7 @@
 #include "smalloc.h"
 #include "sync_union.h"
 #include "upload.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 #include "util_concurrency.h"
@@ -115,8 +116,8 @@ void SyncMediator::EnsureAllowed(SharedPtr<SyncItem> entry) {
                   string(catalog::VirtualCatalog::kVirtualPath) + "/",
                   ignore_case_setting)) )
   {
-    PrintError("invalid attempt to modify '" + relative_path + "'");
-    abort();
+    PANIC(kLogStderr, "[ERROR] invalid attempt to modify '",
+          relative_path.c_str(), "'");
   }
 }
 

--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -19,6 +19,7 @@ set (CVMFS_STRESS_SOURCES
   ${CVMFS_SOURCE_DIR}/upload_local.cc
   ${CVMFS_SOURCE_DIR}/upload_s3.cc
   ${CVMFS_SOURCE_DIR}/upload_spooler_definition.cc
+  ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/mmap_file.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc


### PR DESCRIPTION
I looked up for `abort()` and `assert(false)` in the codebase and I replace all the calls to:

```
LogCvmfs(kLogCvmfs, mask, message);
abort()
```
with a PANIC call.

There are more files that follow a similar schema:
```
LogCvmfs(**something_else**, mask, message);
abort()
```

do I replace them as well?

Those files are:

```
abort():
cache_plugin/channel.cc
quota_posix.cc
sync_mediator.cc
catalog_mgr_rw.cc
cache_transport.cc
s3fanout.cc
hash.cc
receiver/reactor.cc
receiver/catalog_merge_tool_impl.h
fuse_remount.cc
monitor.cc
sync_union_tarball.cc
sync_union_overlayfs.cc
authz/authz_fetch.cc
nfs_maps_sqlite.cc
quota_listener.cc
ingestion/task_write.cc
nfs_maps_leveldb.cc
session_context.cc
cache_extern.cc
fs_traversal.h

assert(false):
catalog_mgr_rw.cc
catalog_rw.cc
compression.cc
catalog_mgr_ro.cc
```
