### PR TITLE
Remove log on different source

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -6,6 +6,7 @@
 set (CVMFS2_BINARY_SOURCES
   fuse_main.cc
   logging.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
 )
@@ -20,6 +21,7 @@ set (CVMFS_STUB_SOURCES
   options.cc
   sanitizer.cc
   statistics.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
 )
@@ -162,6 +164,7 @@ set (LIBCVMFS_CACHE_SOURCES
   monitor.cc
   options.cc
   sanitizer.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
   util_concurrency.cc
@@ -177,6 +180,7 @@ set (CVMFS_CACHE_RAM_SOURCES
   malloc_heap.cc
   statistics.cc
   util_concurrency.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
 )
@@ -190,6 +194,7 @@ set (CVMFS_CACHE_POSIX_SOURCES
   logging.cc
   manifest.cc
   quota.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
 )
@@ -200,6 +205,7 @@ set (CVMFS_FSCK_SOURCES
   hash.cc
   logging.cc
   statistics.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
 )
@@ -209,6 +215,7 @@ set (CVMFS_TALK_SOURCES
   logging.cc
   options.cc
   sanitizer.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
 )
@@ -227,6 +234,7 @@ set (CVMFS_SHRINKWRAP_SOURCES
   shrinkwrap/spec_tree.cc
   shrinkwrap/util.cc
   statistics.cc
+  util/exception.cc
   util/posix.cc
   util/string.cc
   util_concurrency.cc

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -455,10 +455,7 @@ set (CVMFS_SWISSKNIFE_SOURCES
 set (CVMFS_SUID_HELPER_SOURCES
   cvmfs_suid_helper.cc
   cvmfs_suid_util.cc
-  logging.cc
   sanitizer.cc
-  util/exception.cc
-  util/posix.cc
 )
 
 set (CVMFS_PRELOADER_SOURCES

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -932,7 +932,6 @@ if (BUILD_SERVER)
                          ${OPENSSL_LIBRARIES} ${RT_LIBRARY} ${VJSON_LIBRARIES}
                          ${SHA3_LIBRARIES} ${CAP_LIBRARIES} ${LibArchive_LIBRARY}
                          pthread dl)
-  target_link_libraries (cvmfs_suid_helper pthread)
   target_link_libraries (cvmfs_server ${LIBCVMFS_SERVER_LIBS} ${LIBCVMFS_SERVER_LINK_LIBRARIES})
   target_link_libraries (cvmfs_publish cvmfs_server)
   if (BUILD_SERVER_DEBUG)

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -455,7 +455,10 @@ set (CVMFS_SWISSKNIFE_SOURCES
 set (CVMFS_SUID_HELPER_SOURCES
   cvmfs_suid_helper.cc
   cvmfs_suid_util.cc
+  logging.cc
   sanitizer.cc
+  util/exception.cc
+  util/posix.cc
 )
 
 set (CVMFS_PRELOADER_SOURCES
@@ -932,6 +935,7 @@ if (BUILD_SERVER)
                          ${OPENSSL_LIBRARIES} ${RT_LIBRARY} ${VJSON_LIBRARIES}
                          ${SHA3_LIBRARIES} ${CAP_LIBRARIES} ${LibArchive_LIBRARY}
                          pthread dl)
+  target_link_libraries (cvmfs_suid_helper pthread)
   target_link_libraries (cvmfs_server ${LIBCVMFS_SERVER_LIBS} ${LIBCVMFS_SERVER_LINK_LIBRARIES})
   target_link_libraries (cvmfs_publish cvmfs_server)
   if (BUILD_SERVER_DEBUG)

--- a/cvmfs/authz/authz_fetch.cc
+++ b/cvmfs/authz/authz_fetch.cc
@@ -171,8 +171,9 @@ void AuthzExternalFetcher::ExecHelper() {
       close(fd);
 
     execve(argv0, argv, &envp[0]);
-    PANIC(kLogStdout | kLogStderr, "failed to start authz helper %s (%d)",
-          argv0, errno);
+    syslog(LOG_USER | LOG_ERR, "failed to start authz helper %s (%d)",
+           argv0, errno);
+    abort();
   }
   assert(pid > 0);
   close(pipe_send[0]);

--- a/cvmfs/authz/authz_fetch.cc
+++ b/cvmfs/authz/authz_fetch.cc
@@ -21,6 +21,7 @@
 #include "platform.h"
 #include "sanitizer.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -170,9 +171,8 @@ void AuthzExternalFetcher::ExecHelper() {
       close(fd);
 
     execve(argv0, argv, &envp[0]);
-    syslog(LOG_USER | LOG_ERR, "failed to start authz helper %s (%d)",
-           argv0, errno);
-    abort();
+    PANIC(kLogStdout | kLogStderr, "failed to start authz helper %s (%d)",
+          argv0, errno);
   }
   assert(pid > 0);
   close(pipe_send[0]);

--- a/cvmfs/authz/authz_fetch.cc
+++ b/cvmfs/authz/authz_fetch.cc
@@ -21,7 +21,6 @@
 #include "platform.h"
 #include "sanitizer.h"
 #include "smalloc.h"
-#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -29,6 +29,7 @@
 #ifdef __APPLE__
 #include "smalloc.h"
 #endif
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -536,9 +537,8 @@ void *ExternalCacheManager::MainRead(void *data) {
       cache_mgr->quota_mgr_->BroadcastBackchannels("R");
       continue;
     } else {
-      LogCvmfs(kLogCache, kLogSyslogErr | kLogDebug, "unexpected message %s",
-               msg->GetTypeName().c_str());
-      abort();
+      PANIC(kLogSyslogErr | kLogDebug, "unexpected message %s",
+            msg->GetTypeName().c_str());
     }
 
     RpcInFlight rpc_inflight;
@@ -564,9 +564,8 @@ void *ExternalCacheManager::MainRead(void *data) {
   }
 
   if (!cache_mgr->terminated_) {
-    LogCvmfs(kLogCache, kLogSyslogErr | kLogDebug,
-             "connection to external cache manager broken (%d)", errno);
-    abort();
+    PANIC(kLogSyslogErr | kLogDebug,
+          "connection to external cache manager broken (%d)", errno);
   }
   LogCvmfs(kLogCache, kLogDebug, "stopping external cache reader thread");
   return NULL;

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -18,6 +18,7 @@
 #include "logging.h"
 #include "platform.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -800,9 +801,8 @@ void *CachePlugin::MainProcessRequests(void *data) {
     if (retval < 0) {
       if (errno == EINTR)
         continue;
-      LogCvmfs(kLogCache, kLogSyslogErr | kLogDebug,
-               "cache plugin connection failure (%d)", errno);
-      abort();
+      PANIC(kLogSyslogErr | kLogDebug, "cache plugin connection failure (%d)",
+            errno);
     }
 
     // Termination or detach

--- a/cvmfs/catalog_counters.cc
+++ b/cvmfs/catalog_counters.cc
@@ -5,6 +5,7 @@
 #include "catalog_counters.h"
 
 #include "directory_entry.h"
+#include "util/exception.h"
 
 namespace catalog {
 
@@ -27,7 +28,7 @@ void DeltaCounters::ApplyDelta(const DirectoryEntry &dirent, const int delta) {
   } else if (dirent.IsDirectory()) {
     self.directories += delta;
   } else {
-    assert(false);
+    PANIC(NULL);
   }
   if (dirent.HasXattrs()) {
     self.xattrs += delta;

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -33,8 +33,8 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
   FILE *fcatalog = CreateTempFile(dir_temp_ + "/catalog", 0666, "w",
                                   catalog_path);
   if (!fcatalog) {
-    PANIC(kLogStderr,
-             "failed to create temp file when loading %s", url.c_str());
+    PANIC(kLogStderr, "failed to create temp file when loading %s",
+          url.c_str());
   }
 
   download::JobInfo download_catalog(&url, true, false, fcatalog,
@@ -44,9 +44,8 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
 
   if (retval != download::kFailOk) {
     unlink(catalog_path->c_str());
-    PANIC(kLogStderr,
-             "failed to load %s from Stratum 0 (%d - %s)", url.c_str(),
-             retval, download::Code2Ascii(retval));
+    PANIC(kLogStderr, "failed to load %s from Stratum 0 (%d - %s)", url.c_str(),
+          retval, download::Code2Ascii(retval));
   }
 
   *catalog_hash = effective_hash;

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -7,6 +7,7 @@
 
 #include "compression.h"
 #include "download.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -32,9 +33,8 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
   FILE *fcatalog = CreateTempFile(dir_temp_ + "/catalog", 0666, "w",
                                   catalog_path);
   if (!fcatalog) {
-    LogCvmfs(kLogCatalog, kLogStderr,
+    PANIC(kLogStderr,
              "failed to create temp file when loading %s", url.c_str());
-    assert(false);
   }
 
   download::JobInfo download_catalog(&url, true, false, fcatalog,
@@ -43,11 +43,10 @@ LoadError SimpleCatalogManager::LoadCatalog(const PathString  &mountpoint,
   fclose(fcatalog);
 
   if (retval != download::kFailOk) {
-    LogCvmfs(kLogCatalog, kLogStderr,
+    unlink(catalog_path->c_str());
+    PANIC(kLogStderr,
              "failed to load %s from Stratum 0 (%d - %s)", url.c_str(),
              retval, download::Code2Ascii(retval));
-    unlink(catalog_path->c_str());
-    assert(false);
   }
 
   *catalog_hash = effective_hash;

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -299,11 +299,11 @@ void WritableCatalogManager::Clone(const std::string destination,
 
   DirectoryEntry source_dirent;
   if (!LookupPath(relative_source, kLookupSole, &source_dirent)) {
-    PANIC(kLogStderr, "catalog for file '%s' cannot be found aborting",
+    PANIC(kLogStderr, "catalog for file '%s' cannot be found, aborting",
           source.c_str());
   }
   if (source_dirent.IsDirectory()) {
-    PANIC(kLogStderr, "Trying to clone a directory: '%s' aborting",
+    PANIC(kLogStderr, "Trying to clone a directory: '%s', aborting",
           source.c_str());
   }
 

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -11,6 +11,7 @@
 #include <cstdlib>
 
 #include "logging.h"
+#include "util/exception.h"
 #include "util_concurrency.h"
 #include "xattr.h"
 
@@ -800,9 +801,7 @@ void WritableCatalog::VacuumDatabaseIfNecessary() {
              ratio * 100.0,
              reason.c_str());
     if (!db.Vacuum()) {
-      LogCvmfs(kLogCatalog, kLogStderr, "failed (SQLite: %s)",
-               db.GetLastErrorMsg().c_str());
-      assert(false);
+      PANIC(kLogStderr, "failed (SQLite: %s)", db.GetLastErrorMsg().c_str());
     }
     LogCvmfs(kLogCatalog, kLogStdout, "done");
   }

--- a/cvmfs/compression.cc
+++ b/cvmfs/compression.cc
@@ -23,6 +23,7 @@
 #include "logging.h"
 #include "platform.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -149,9 +150,9 @@ Algorithms ParseCompressionAlgorithm(const std::string &algorithm_option) {
     return kZlibDefault;
   if (algorithm_option == "none")
     return kNoCompression;
-  LogCvmfs(kLogCompress, kLogStderr, "unknown compression algorithms: %s",
-           algorithm_option.c_str());
-  assert(false);
+  PANIC(kLogStderr, "unknown compression algorithms: %s",
+        algorithm_option.c_str());
+  return kNoCompression;  // avoid compilation warning
 }
 
 

--- a/cvmfs/compression.cc
+++ b/cvmfs/compression.cc
@@ -152,7 +152,6 @@ Algorithms ParseCompressionAlgorithm(const std::string &algorithm_option) {
     return kNoCompression;
   PANIC(kLogStderr, "unknown compression algorithms: %s",
         algorithm_option.c_str());
-  return kNoCompression;  // avoid compilation warning
 }
 
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -106,6 +106,7 @@
 #include "statistics.h"
 #include "talk.h"
 #include "tracer.h"
+#include "util/exception.h"
 #include "util_concurrency.h"
 #include "uuid.h"
 #include "wpad.h"
@@ -1804,18 +1805,16 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
   if (mount_point_->enforce_acls()) {
 #ifdef FUSE_CAP_POSIX_ACL
     if ((conn->capable & FUSE_CAP_POSIX_ACL) == 0) {
-      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-               "ACL support requested but missing fuse kernel support, "
-               "aborting");
-      abort();
+      PANIC(kLogDebug | kLogSyslogErr,
+            "ACL support requested but missing fuse kernel support, "
+            "aborting");
     }
     conn->want |= FUSE_CAP_POSIX_ACL;
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog, "enforcing ACLs");
 #else
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-             "ACL support requested but not available in this version of "
-             "libfuse, aborting");
-    abort();
+    PANIC(kLogDebug | kLogSyslogErr,
+          "ACL support requested but not available in this version of "
+          "libfuse, aborting");
 #endif
   }
 }

--- a/cvmfs/dns.cc
+++ b/cvmfs/dns.cc
@@ -37,6 +37,7 @@
 #include "logging.h"
 #include "sanitizer.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/string.h"
 
 using namespace std;  // NOLINT
@@ -562,7 +563,7 @@ static void CallbackCares(
           break;
         default:
           // Never here.
-          abort();
+          PANIC(NULL);
       }
       info->status = retval;
       break;
@@ -790,7 +791,7 @@ CaresResolver *CaresResolver::Create(
       }
       default:
         // Never here.
-        abort();
+        PANIC(NULL);
     }
     iter = iter->next;
   }
@@ -995,7 +996,7 @@ void CaresResolver::WaitOnCares() {
       if (nfds == -1) {
         // poll must not fail for other reasons
         if ((errno != EAGAIN) && (errno != EINTR))
-          abort();
+          PANIC(NULL);
       }
     } while (nfds == -1);
   }

--- a/cvmfs/dns.cc
+++ b/cvmfs/dns.cc
@@ -1233,7 +1233,7 @@ bool HostfileResolver::SetSearchDomains(const vector<string> &domains) {
 
 void HostfileResolver::SetSystemSearchDomains() {
   // TODO(jblomer)
-  assert(false);
+  PANIC(NULL);
 }
 
 

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -56,6 +56,7 @@
 #include "sanitizer.h"
 #include "smalloc.h"
 #include "util/algorithm.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 #include "util_concurrency.h"
@@ -832,7 +833,7 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
                  "%" PRId64 "-%" PRId64,
                  range_lower, range_upper) == 100)
     {
-      abort();  // Should be impossible given limits on offset size.
+      PANIC(NULL);  // Should be impossible given limits on offset size.
     }
     curl_easy_setopt(handle, CURLOPT_RANGE, byte_range_array);
   } else {
@@ -1438,7 +1439,7 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
             switch_host = true;
         } else {
           // No other errors expected when retrying
-          abort();
+          PANIC(NULL);
         }
     }
     if (switch_proxy) {

--- a/cvmfs/encrypt.cc
+++ b/cvmfs/encrypt.cc
@@ -19,6 +19,7 @@
 #include "hash.h"
 #include "platform.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/string.h"
 #include "util_concurrency.h"
@@ -161,7 +162,7 @@ Cipher *Cipher::Create(const Algorithms a) {
     case kNone:
       return new CipherNone();
     default:
-      abort();
+      PANIC(NULL);
   }
   // Never here
 }

--- a/cvmfs/fs_traversal.h
+++ b/cvmfs/fs_traversal.h
@@ -19,6 +19,7 @@
 #include "logging.h"
 #include "platform.h"
 #include "util/async.h"
+#include "util/exception.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -151,10 +152,10 @@ class FileSystemTraversal {
              path.c_str(), parent_path.c_str(), dir_name.c_str());
     dip = opendir(path.c_str());
     if (!dip) {
-      LogCvmfs(kLogFsTraversal, kLogStderr, "Failed to open %s (%d).\n"
-               "Please check directory permissions.",
-               path.c_str(), errno);
-      abort();
+      PANIC(kLogStderr,
+            "Failed to open %s (%d).\n"
+            "Please check directory permissions.",
+            path.c_str(), errno);
     }
     Notify(fn_enter_dir, parent_path, dir_name);
 
@@ -179,9 +180,8 @@ class FileSystemTraversal {
       platform_stat64 info;
       int retval = platform_lstat((path + "/" + dit->d_name).c_str(), &info);
       if (retval != 0) {
-        LogCvmfs(kLogFsTraversal, kLogStderr, "failed to lstat '%s' errno: %d",
-                 (path + "/" + dit->d_name).c_str(), errno);
-        abort();
+        PANIC(kLogStderr, "failed to lstat '%s' errno: %d",
+              (path + "/" + dit->d_name).c_str(), errno);
       }
       if (S_ISDIR(info.st_mode)) {
         LogCvmfs(kLogFsTraversal, kLogVerboseMsg, "passing directory %s/%s",

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -85,7 +85,6 @@ FuseRemounter::Status FuseRemounter::Check() {
     }
     default:
       PANIC(NULL);
-      return kStatusUp2Date;  // only to suppress compilation warning
   }
 }
 

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -21,6 +21,7 @@
 #include "mountpoint.h"
 #include "platform.h"
 #include "statistics.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -180,9 +181,8 @@ void *FuseRemounter::MainRemountTrigger(void *data) {
         }
         continue;
       }
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "remount trigger connection failure (%d)", errno);
-      abort();
+      PANIC(kLogSyslogErr | kLogDebug,
+            "remount trigger connection failure (%d)", errno);
     }
 
     if (retval == 0) {

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -41,9 +41,8 @@ FuseRemounter::Status FuseRemounter::Check() {
   if (mountpoint_->ReloadBlacklists() &&
       mountpoint_->catalog_mgr()->IsRevisionBlacklisted())
   {
-    LogCvmfs(kLogCatalog, kLogDebug | kLogSyslogErr,
-            "repository revision blacklisted, aborting");
-    abort();
+    PANIC(kLogDebug | kLogSyslogErr,
+          "repository revision blacklisted, aborting");
   }
 
   LogCvmfs(kLogCvmfs, kLogDebug, "remounting root catalog");

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -84,7 +84,8 @@ FuseRemounter::Status FuseRemounter::Check() {
       return kStatusUp2Date;
     }
     default:
-      abort();
+      PANIC(NULL);
+      return kStatusUp2Date;  // only to suppress compilation warning
   }
 }
 

--- a/cvmfs/hash.cc
+++ b/cvmfs/hash.cc
@@ -156,9 +156,9 @@ unsigned GetContextSize(const Algorithms algorithm) {
     case kShake128:
       return sizeof(Keccak_HashInstance);
     default:
-      LogCvmfs(kLogHash, kLogDebug | kLogSyslogErr, "tried to generate hash "
-               "context for unspecified hash. Aborting...");
-      abort();  // Undefined hash
+      PANIC(kLogDebug | kLogSyslogErr,
+            "tried to generate hash context for unspecified hash. Aborting...");
+      return 0;
   }
 }
 

--- a/cvmfs/hash.cc
+++ b/cvmfs/hash.cc
@@ -158,7 +158,6 @@ unsigned GetContextSize(const Algorithms algorithm) {
     default:
       PANIC(kLogDebug | kLogSyslogErr,
             "tried to generate hash context for unspecified hash. Aborting...");
-      return 0;
   }
 }
 

--- a/cvmfs/hash.cc
+++ b/cvmfs/hash.cc
@@ -18,7 +18,9 @@
 #include <cstring>
 
 #include "duplex_ssl.h"
+#include "util/exception.h"
 #include "KeccakHash.h"
+
 
 using namespace std;  // NOLINT
 
@@ -182,7 +184,7 @@ void Init(ContextPtr context) {
       assert(keccak_result == SUCCESS);
       break;
     default:
-      abort();  // Undefined hash
+      PANIC(NULL);  // Undefined hash
   }
 }
 
@@ -213,7 +215,7 @@ void Update(const unsigned char *buffer, const unsigned buffer_length,
       assert(keccak_result == SUCCESS);
       break;
     default:
-      abort();  // Undefined hash
+      PANIC(NULL);  // Undefined hash
   }
 }
 
@@ -245,7 +247,7 @@ void Final(ContextPtr context, Any *any_digest) {
           context.buffer), any_digest->digest, kDigestSizes[kShake128] * 8);
       break;
     default:
-      abort();  // Undefined hash
+      PANIC(NULL);  // Undefined hash
   }
   any_digest->algorithm = context.algorithm;
 }
@@ -410,7 +412,7 @@ static string HexFromSha256(unsigned char digest[SHA256_DIGEST_LENGTH]) {
 
 string Sha256File(const string &filename) {
 #ifdef OPENSSL_API_INTERFACE_V09
-  abort();
+  PANIC(NULL);
 #else
   int fd = open(filename.c_str(), O_RDONLY);
   if (fd < 0)
@@ -440,7 +442,7 @@ string Sha256File(const string &filename) {
 
 string Sha256Mem(const unsigned char *buffer, const unsigned buffer_size) {
 #ifdef OPENSSL_API_INTERFACE_V09
-  abort();
+  PANIC(NULL);
 #else
   unsigned char digest[SHA256_DIGEST_LENGTH];
   SHA256(buffer, buffer_size, digest);
@@ -460,7 +462,7 @@ std::string Hmac256(
   bool raw_output)
 {
 #ifdef OPENSSL_API_INTERFACE_V09
-  abort();
+  PANIC(NULL);
 #else
   unsigned char digest[SHA256_DIGEST_LENGTH];
   const unsigned block_size = 64;

--- a/cvmfs/ingestion/item_mem.cc
+++ b/cvmfs/ingestion/item_mem.cc
@@ -7,9 +7,8 @@
 #include <cassert>
 #include <cstdlib>
 
-#include "util_concurrency.h"
 #include "util/exception.h"
-
+#include "util_concurrency.h"
 
 atomic_int64 ItemAllocator::total_allocated_ = 0;
 

--- a/cvmfs/ingestion/item_mem.cc
+++ b/cvmfs/ingestion/item_mem.cc
@@ -8,6 +8,7 @@
 #include <cstdlib>
 
 #include "util_concurrency.h"
+#include "util/exception.h"
 
 
 atomic_int64 ItemAllocator::total_allocated_ = 0;
@@ -29,7 +30,7 @@ void ItemAllocator::Free(void *ptr) {
         return;
       }
     }
-    assert(false);
+    PANIC(NULL);
   }
 }
 

--- a/cvmfs/ingestion/pipeline.cc
+++ b/cvmfs/ingestion/pipeline.cc
@@ -17,6 +17,7 @@
 #include "platform.h"
 #include "upload_facility.h"
 #include "upload_spooler_definition.h"
+#include "util/exception.h"
 #include "util/string.h"
 #include "util_concurrency.h"
 
@@ -178,7 +179,7 @@ void TaskScrubbingCallback::Process(BlockItem *block_item) {
       break;
 
     default:
-      abort();
+      PANIC(NULL);
   }
 }
 

--- a/cvmfs/ingestion/task_chunk.cc
+++ b/cvmfs/ingestion/task_chunk.cc
@@ -7,6 +7,7 @@
 #include <cassert>
 
 #include "ingestion/task_chunk.h"
+#include "util/exception.h"
 
 /**
  * The tags from the read stage in the pipeline and the tags given in the
@@ -149,7 +150,7 @@ void TaskChunk::Process(BlockItem *input_block) {
       break;
 
     default:
-      abort();
+      PANIC(NULL);
   }
 
   delete input_block;

--- a/cvmfs/ingestion/task_hash.cc
+++ b/cvmfs/ingestion/task_hash.cc
@@ -8,6 +8,7 @@
 #include <cstdlib>
 
 #include "hash.h"
+#include "util/exception.h"
 
 
 void TaskHash::Process(BlockItem *input_block) {
@@ -23,7 +24,7 @@ void TaskHash::Process(BlockItem *input_block) {
       shash::Final(chunk->hash_ctx(), chunk->hash_ptr());
       break;
     default:
-      abort();
+      PANIC(NULL);
   }
 
   tubes_out_->Dispatch(input_block);

--- a/cvmfs/ingestion/task_write.cc
+++ b/cvmfs/ingestion/task_write.cc
@@ -17,9 +17,7 @@ void TaskWrite::OnBlockComplete(
   BlockItem *block_item)
 {
   if (results.return_code != 0) {
-    LogCvmfs(kLogSpooler, kLogStderr, "block upload failed (code: %d)",
-      results.return_code);
-    abort();
+    PANIC(kLogStderr, "block upload failed (code: %d)", results.return_code);
   }
 
   delete block_item;
@@ -31,9 +29,7 @@ void TaskWrite::OnChunkComplete(
   ChunkItem *chunk_item)
 {
   if (results.return_code != 0) {
-    LogCvmfs(kLogSpooler, kLogStderr, "chunk upload failed (code: %d)",
-             results.return_code);
-    abort();
+    PANIC(kLogStderr, "chunk upload failed (code: %d)", results.return_code);
   }
 
   FileItem *file_item = chunk_item->file_item();

--- a/cvmfs/ingestion/task_write.cc
+++ b/cvmfs/ingestion/task_write.cc
@@ -8,6 +8,7 @@
 #include <cstdlib>
 
 #include "logging.h"
+#include "util/exception.h"
 #include "upload_facility.h"
 
 
@@ -80,6 +81,6 @@ void TaskWrite::Process(BlockItem *input_block) {
       delete input_block;
       break;
     default:
-      abort();
+      PANIC(NULL);
   }
 }

--- a/cvmfs/ingestion/task_write.cc
+++ b/cvmfs/ingestion/task_write.cc
@@ -8,8 +8,8 @@
 #include <cstdlib>
 
 #include "logging.h"
-#include "util/exception.h"
 #include "upload_facility.h"
+#include "util/exception.h"
 
 
 void TaskWrite::OnBlockComplete(

--- a/cvmfs/json_document.cc
+++ b/cvmfs/json_document.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include "logging.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/string.h"
 
@@ -200,7 +201,7 @@ std::string JsonDocument::PrintValue(JSON *value, PrintOptions print_options) {
       result += value->int_value ? "true" : "false";
       break;
     default:
-      abort();
+      PANIC(NULL);
   }
   return result;
 }

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -399,7 +399,6 @@ static int ParseFuseOptions(void *data __attribute__((unused)), const char *arg,
       return 0;
     default:
       PANIC(kLogStderr, "internal option parsing error");
-      return 0;
   }
 }
 

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -47,6 +47,7 @@
 #include "options.h"
 #include "platform.h"
 #include "sanitizer.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -397,8 +398,8 @@ static int ParseFuseOptions(void *data __attribute__((unused)), const char *arg,
       parse_options_only_ = true;
       return 0;
     default:
-      LogCvmfs(kLogCvmfs, kLogStderr, "internal option parsing error");
-      abort();
+      PANIC(kLogStderr, "internal option parsing error");
+      return 0;
   }
 }
 
@@ -782,9 +783,8 @@ int FuseMain(int argc, char *argv[]) {
   }
   if (suid_mode_) {
     if (getuid() != 0) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "must be root to mount with suid option");
-      abort();
+      PANIC(kLogStderr | kLogSyslogErr,
+            "must be root to mount with suid option");
     }
     fuse_opt_add_arg(mount_options, "-osuid");
     LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: running with suid support");
@@ -1137,4 +1137,3 @@ static void __attribute__((destructor)) LibraryExit() {
   delete g_cvmfs_stub_exports;
   g_cvmfs_stub_exports = NULL;
 }
-

--- a/cvmfs/loader_talk.cc
+++ b/cvmfs/loader_talk.cc
@@ -16,6 +16,7 @@
 #include "loader.h"
 #include "logging.h"
 #include "platform.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -75,10 +76,10 @@ static void *MainTalk(void *data __attribute__((unused))) {
       SendMsg2Socket(con_fd, "~");
       (void)send(con_fd, &retval, sizeof(retval), MSG_NOSIGNAL);
       if (retval != kFailOk) {
-        LogCvmfs(kLogCvmfs, kLogSyslogErr, "reloading Fuse module failed "
-                                           "(%d - %s)",
-                 retval, Code2Ascii(static_cast<Failures>(retval)));
-        abort();
+        PANIC(kLogSyslogErr,
+              "reloading Fuse module failed "
+              "(%d - %s)",
+              retval, Code2Ascii(static_cast<Failures>(retval)));
       }
       SetLogMicroSyslog("");
     }

--- a/cvmfs/loader_talk.cc
+++ b/cvmfs/loader_talk.cc
@@ -76,10 +76,8 @@ static void *MainTalk(void *data __attribute__((unused))) {
       SendMsg2Socket(con_fd, "~");
       (void)send(con_fd, &retval, sizeof(retval), MSG_NOSIGNAL);
       if (retval != kFailOk) {
-        PANIC(kLogSyslogErr,
-              "reloading Fuse module failed "
-              "(%d - %s)",
-              retval, Code2Ascii(static_cast<Failures>(retval)));
+        PANIC(kLogSyslogErr, "reloading Fuse module failed (%d - %s)", retval,
+              Code2Ascii(static_cast<Failures>(retval)));
       }
       SetLogMicroSyslog("");
     }

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -42,6 +42,7 @@
 #include "logging.h"
 #include "platform.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -356,7 +357,7 @@ Watchdog::SigactionMap Watchdog::SetSignalHandlers(
   for (; i != iend; ++i) {
     struct sigaction old_signal_handler;
     if (sigaction(i->first, &i->second, &old_signal_handler) != 0) {
-      abort();
+      PANIC(NULL);
     }
     old_signal_handlers[i->first] = old_signal_handler;
   }
@@ -378,7 +379,7 @@ void Watchdog::Spawn() {
   int max_fd = sysconf(_SC_OPEN_MAX);
   assert(max_fd >= 0);
   switch (pid = fork()) {
-    case -1: abort();
+    case -1: PANIC(NULL);
     case 0:
       // Double fork to avoid zombie
       switch (fork()) {
@@ -414,8 +415,8 @@ void Watchdog::Spawn() {
     default:
       close(pipe_watchdog_->read_end);
       close(pipe_listener_->write_end);
-      if (waitpid(pid, &statloc, 0) != pid) abort();
-      if (!WIFEXITED(statloc) || WEXITSTATUS(statloc)) abort();
+      if (waitpid(pid, &statloc, 0) != pid) PANIC(NULL);
+      if (!WIFEXITED(statloc) || WEXITSTATUS(statloc)) PANIC(NULL);
   }
 
   // retrieve the watchdog PID from the pipe
@@ -437,7 +438,7 @@ void Watchdog::Spawn() {
   sighandler_stack_.ss_size = stack_size;
   sighandler_stack_.ss_flags = 0;
   if (sigaltstack(&sighandler_stack_, NULL) != 0)
-    abort();
+    PANIC(NULL);
 
   // define our crash signal handler
   struct sigaction sa;
@@ -492,11 +493,10 @@ void *Watchdog::MainWatchdogListener(void *data) {
           (watch_fds[0].revents & POLLHUP) ||
           (watch_fds[0].revents & POLLNVAL))
       {
-        LogCvmfs(kLogMonitor, kLogDebug | kLogSyslogErr,
+        PANIC(kLogDebug | kLogSyslogErr,
                  "watchdog disappeared, aborting");
-        abort();
       }
-      assert(false);
+      PANIC(NULL);
     }
   }
   close(watchdog->pipe_listener_->read_end);

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -493,8 +493,7 @@ void *Watchdog::MainWatchdogListener(void *data) {
           (watch_fds[0].revents & POLLHUP) ||
           (watch_fds[0].revents & POLLNVAL))
       {
-        PANIC(kLogDebug | kLogSyslogErr,
-                 "watchdog disappeared, aborting");
+        PANIC(kLogDebug | kLogSyslogErr, "watchdog disappeared, aborting");
       }
       PANIC(NULL);
     }

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -27,6 +27,7 @@
 #include "logging.h"
 #include "smalloc.h"
 #include "statistics.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util_concurrency.h"
@@ -47,10 +48,8 @@ void NfsMapsLeveldb::ForkAwareEnv::StartThread(void (*f)(void*), void* a) {
     leveldb::Env::Default()->StartThread(f, a);
     return;
   }
-  LogCvmfs(kLogNfsMaps, kLogDebug,
-           "single threaded leveldb::StartThread called");
+  PANIC(kLogDebug, "single threaded leveldb::StartThread called");
   // Unclear how to handle this because caller assumes that thread is started
-  abort();
 }
 
 
@@ -200,10 +199,8 @@ uint64_t NfsMapsLeveldb::FindInode(const shash::Md5 &path) {
 
   status = db_path2inode_->Get(leveldb::ReadOptions(), key, &result);
   if (!status.ok() && !status.IsNotFound()) {
-    LogCvmfs(kLogNfsMaps, kLogSyslogErr,
-             "failed to read from path2inode db (path %s): %s",
-             path.ToString().c_str(), status.ToString().c_str());
-    abort();
+    PANIC(kLogSyslogErr, "failed to read from path2inode db (path %s): %s",
+          path.ToString().c_str(), status.ToString().c_str());
   }
 
   if (status.IsNotFound()) {
@@ -261,10 +258,9 @@ bool NfsMapsLeveldb::GetPath(const uint64_t inode, PathString *path) {
     return false;
   }
   if (!status.ok()) {
-    LogCvmfs(kLogNfsMaps, kLogSyslogErr,
-             "failed to read from inode2path db inode %" PRIu64 ": %s",
-             inode, status.ToString().c_str());
-    abort();
+    PANIC(kLogSyslogErr,
+          "failed to read from inode2path db inode %" PRIu64 ": %s", inode,
+          status.ToString().c_str());
   }
 
   path->Assign(result.data(), result.length());
@@ -336,10 +332,9 @@ void NfsMapsLeveldb::PutInode2Path(
 
   status = db_inode2path_->Put(leveldb::WriteOptions(), key, value);
   if (!status.ok()) {
-    LogCvmfs(kLogNfsMaps, kLogSyslogErr,
-             "failed to write inode2path entry (%" PRIu64 " --> %s): %s",
-             inode, path.c_str(), status.ToString().c_str());
-    abort();
+    PANIC(kLogSyslogErr,
+          "failed to write inode2path entry (%" PRIu64 " --> %s): %s", inode,
+          path.c_str(), status.ToString().c_str());
   }
   LogCvmfs(kLogNfsMaps, kLogDebug, "stored inode %" PRIu64 " --> path %s",
            inode, path.c_str());
@@ -357,10 +352,9 @@ void NfsMapsLeveldb::PutPath2Inode(
 
   status = db_path2inode_->Put(leveldb::WriteOptions(), key, value);
   if (!status.ok()) {
-    LogCvmfs(kLogNfsMaps, kLogSyslogErr,
-             "failed to write path2inode entry (%s --> %" PRIu64 "): %s",
-             path.ToString().c_str(), inode, status.ToString().c_str());
-    abort();
+    PANIC(kLogSyslogErr,
+          "failed to write path2inode entry (%s --> %" PRIu64 "): %s",
+          path.ToString().c_str(), inode, status.ToString().c_str());
   }
   LogCvmfs(kLogNfsMaps, kLogDebug, "stored path %s --> inode %" PRIu64,
            path.ToString().c_str(), inode);

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -48,7 +48,8 @@ void NfsMapsLeveldb::ForkAwareEnv::StartThread(void (*f)(void*), void* a) {
     leveldb::Env::Default()->StartThread(f, a);
     return;
   }
-  PANIC(kLogDebug, "single threaded leveldb::StartThread called");
+  PANIC(kLogDebug | kLogSyslogErr,
+        "single threaded leveldb::StartThread called");
   // Unclear how to handle this because caller assumes that thread is started
 }
 

--- a/cvmfs/nfs_maps_sqlite.cc
+++ b/cvmfs/nfs_maps_sqlite.cc
@@ -26,6 +26,7 @@
 #include "prng.h"
 #include "smalloc.h"
 #include "statistics.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -154,10 +155,8 @@ NfsMapsSqlite *NfsMapsSqlite::Create(
     sqlite3_bind_int64(stmt, 1, root_inode);
     assert(retval == SQLITE_OK);
     if (sqlite3_step(stmt) != SQLITE_DONE) {
-      LogCvmfs(kLogNfsMaps, kLogDebug | kLogSyslogErr,
-               "Failed to execute CreateRoot: %s",
-               sqlite3_errmsg(maps->db_));
-      abort();
+      PANIC(kLogDebug | kLogSyslogErr, "Failed to execute CreateRoot: %s",
+            sqlite3_errmsg(maps->db_));
     }
     sqlite3_finalize(stmt);
   }
@@ -282,10 +281,8 @@ bool NfsMapsSqlite::GetPath(const uint64_t inode, PathString *path) {
     return false;
   }
   if (sqlite_state != SQLITE_ROW) {
-    LogCvmfs(kLogNfsMaps, kLogSyslogErr,
-             "Failed to execute SQL for GetPath (%" PRIu64 "): %s", inode,
-             sqlite3_errmsg(db_));
-    abort();
+    PANIC(kLogSyslogErr, "Failed to execute SQL for GetPath (%" PRIu64 "): %s",
+          inode, sqlite3_errmsg(db_));
   }
   const char *raw_path = (const char *)sqlite3_column_text(stmt_get_path_, 0);
   path->Assign(raw_path, strlen(raw_path));

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -20,6 +20,7 @@
 
 #include "logging.h"
 #include "sanitizer.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -153,7 +154,7 @@ void BashOptionsManager::ParsePath(const string &config_file,
     MakePipe(pipe_quit);
     switch (pid_child = fork()) {
       case -1:
-        abort();
+        PANIC(NULL);
       case 0: {  // Child
         close(pipe_open[0]);
         close(pipe_quit[1]);

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -11,6 +11,7 @@
 
 #include "platform.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/string.h"
 #include "util_concurrency.h"
 
@@ -45,9 +46,7 @@ void AppendItemToHeader(ObjectPack::BucketContentType object_type,
       line_prefix = "C ";
       break;
     default:
-      LogCvmfs(kLogCvmfs, kLogStderr,
-               "Unknown object pack type to be added to header.");
-      abort();
+      PANIC(kLogStderr, "Unknown object pack type to be added to header.");
   }
   if (header) {
     *header += line_prefix + hash_str + " " + StringifyInt(object_size) +

--- a/cvmfs/quota_listener.cc
+++ b/cvmfs/quota_listener.cc
@@ -14,6 +14,7 @@
 #include "logging.h"
 #include "quota.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util/posix.h"
 
 using namespace std;  // NOLINT
@@ -101,9 +102,7 @@ static void *MainWatchdogListener(void *data) {
           (watch_fds[1].revents & POLLHUP) ||
           (watch_fds[1].revents & POLLNVAL))
       {
-        LogCvmfs(kLogQuota, kLogDebug | kLogSyslogErr,
-                 "cache manager disappeared, aborting");
-        abort();
+        PANIC(kLogDebug | kLogSyslogErr, "cache manager disappeared, aborting");
       }
       // Clean the pipe
       watch_fds[1].revents = 0;

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -14,6 +14,7 @@
 #include "manifest.h"
 #include "options.h"
 #include "upload.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/raii_temp_dir.h"
 
@@ -40,10 +41,10 @@ inline void SplitHardlink(catalog::DirectoryEntry* entry) {
 
 inline void AbortIfHardlinked(const catalog::DirectoryEntry& entry) {
   if (entry.linkcount() > 1) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-              "CatalogMergeTool - Removal of file %s with linkcount > 1 is "
-              "not supported. Aborting", entry.name().c_str());
-    abort();
+    PANIC(kLogSyslogErr,
+          "CatalogMergeTool - Removal of file %s with linkcount > 1 is "
+          "not supported. Aborting",
+          entry.name().c_str());
   }
 }
 

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -17,6 +17,7 @@
 #include "payload_processor.h"
 #include "repository_tag.h"
 #include "session_token.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -131,9 +132,7 @@ bool Reactor::Run() {
 
 bool Reactor::HandleGenerateToken(const std::string& req, std::string* reply) {
   if (reply == NULL) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "HandleGenerateToken: Invalid reply pointer.");
-    abort();
+    PANIC(kLogSyslogErr, "HandleGenerateToken: Invalid reply pointer.");
   }
 
   UniquePtr<JsonDocument> req_json(JsonDocument::Create(req));
@@ -180,9 +179,7 @@ bool Reactor::HandleGenerateToken(const std::string& req, std::string* reply) {
 
 bool Reactor::HandleGetTokenId(const std::string& req, std::string* reply) {
   if (reply == NULL) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "HandleGetTokenId: Invalid reply pointer.");
-    abort();
+    PANIC(kLogSyslogErr, "HandleGetTokenId: Invalid reply pointer.");
   }
 
   std::string token_id;
@@ -201,9 +198,7 @@ bool Reactor::HandleGetTokenId(const std::string& req, std::string* reply) {
 
 bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
   if (reply == NULL) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "HandleCheckToken: Invalid reply pointer.");
-    abort();
+    PANIC(kLogSyslogErr, "HandleCheckToken: Invalid reply pointer.");
   }
 
   UniquePtr<JsonDocument> req_json(JsonDocument::Create(req));
@@ -246,9 +241,8 @@ bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
       break;
     default:
       // Should not be reached
-      LogCvmfs(kLogReceiver, kLogSyslogErr,
-               "HandleCheckToken: Unknown value received. Exiting.");
-      abort();
+      PANIC(kLogSyslogErr,
+            "HandleCheckToken: Unknown value received. Exiting.");
   }
 
   ToJsonString(input, reply);
@@ -260,9 +254,7 @@ bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
 bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
                                   std::string* reply) {
   if (!reply) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "HandleSubmitPayload: Invalid reply pointer.");
-    abort();
+    PANIC(kLogSyslogErr, "HandleSubmitPayload: Invalid reply pointer.");
   }
 
   // Extract the Path (used for verification), Digest and DigestSize from the
@@ -310,10 +302,9 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
       reply_input.push_back(std::make_pair("status", "ok"));
       break;
     default:
-      LogCvmfs(kLogReceiver, kLogSyslogErr,
-               "HandleSubmitPayload: Unknown value of PayloadProcessor::Result "
-               "encountered.");
-      abort();
+      PANIC(kLogSyslogErr,
+            "HandleSubmitPayload: Unknown value of PayloadProcessor::Result "
+            "encountered.");
       break;
   }
 
@@ -324,9 +315,7 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
 
 bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
   if (!reply) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "HandleCommit: Invalid reply pointer.");
-    abort();
+    PANIC(kLogSyslogErr, "HandleCommit: Invalid reply pointer.");
   }
 
   // Extract the Path from the request JSON.
@@ -388,9 +377,8 @@ bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
       reply_input.push_back(std::make_pair("reason", "missing_reflog"));
       break;
     default:
-      LogCvmfs(kLogReceiver, kLogSyslogErr,
-               "Unknown value of CommitProcessor::Result encountered.");
-      abort();
+      PANIC(kLogSyslogErr,
+            "Unknown value of CommitProcessor::Result encountered.");
       break;
   }
 

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -285,16 +285,14 @@ void *S3FanoutManager::MainUpload(void *data) {
       ReadPipe(s3fanout_mgr->pipe_jobs_[0], &info, sizeof(info));
       CURL *handle = s3fanout_mgr->AcquireCurlHandle();
       if (handle == NULL) {
-        LogCvmfs(kLogS3Fanout, kLogStderr, "Failed to acquire CURL handle.");
-        assert(handle != NULL);
+        PANIC(kLogStderr, "Failed to acquire CURL handle handle == NULL.");
       }
       s3fanout::Failures init_failure =
         s3fanout_mgr->InitializeRequest(info, handle);
       if (init_failure != s3fanout::kFailOk) {
-        LogCvmfs(kLogS3Fanout, kLogStderr,
-                "Failed to initialize CURL handle (error: %d - %s | errno: %d)",
-                 init_failure, Code2Ascii(init_failure), errno);
-        abort();
+        PANIC(kLogStderr,
+              "Failed to initialize CURL handle (error: %d - %s | errno: %d)",
+              init_failure, Code2Ascii(init_failure), errno);
       }
       s3fanout_mgr->SetUrlOptions(info);
 
@@ -1129,10 +1127,10 @@ bool S3FanoutManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
                                                         info->curl_handle);
 
     if (init_failure != s3fanout::kFailOk) {
-      LogCvmfs(kLogS3Fanout, kLogStderr, "Failed to initialize CURL handle "
-                                         "(error: %d - %s | errno: %d)",
-               init_failure, Code2Ascii(init_failure), errno);
-      abort();
+      PANIC(kLogStderr,
+            "Failed to initialize CURL handle "
+            "(error: %d - %s | errno: %d)",
+            init_failure, Code2Ascii(init_failure), errno);
     }
     SetUrlOptions(info);
     // Reset origin

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -285,7 +285,7 @@ void *S3FanoutManager::MainUpload(void *data) {
       ReadPipe(s3fanout_mgr->pipe_jobs_[0], &info, sizeof(info));
       CURL *handle = s3fanout_mgr->AcquireCurlHandle();
       if (handle == NULL) {
-        PANIC(kLogStderr, "Failed to acquire CURL handle handle == NULL.");
+        PANIC(kLogStderr, "Failed to acquire CURL handle.");
       }
       s3fanout::Failures init_failure =
         s3fanout_mgr->InitializeRequest(info, handle);

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -14,6 +14,7 @@
 #include "platform.h"
 #include "s3fanout.h"
 #include "upload_facility.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 #include "util_concurrency.h"
@@ -231,7 +232,7 @@ int S3FanoutManager::CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
       }
       break;
     default:
-      abort();
+      PANIC(NULL);
   }
 
   return 0;
@@ -734,7 +735,7 @@ bool S3FanoutManager::MkPayloadHash(const JobInfo &info, string *hex_hash)
           "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         break;
       default:
-        abort();
+        PANIC(NULL);
     }
     return true;
   }
@@ -758,7 +759,7 @@ bool S3FanoutManager::MkPayloadHash(const JobInfo &info, string *hex_hash)
             shash::Sha256Mem(info.origin_mem.data, info.origin_mem.size);
           return true;
         default:
-          abort();
+          PANIC(NULL);
       }
     case kOriginPath:
       switch (config_.authz_method) {
@@ -784,10 +785,10 @@ bool S3FanoutManager::MkPayloadHash(const JobInfo &info, string *hex_hash)
           }
           return true;
         default:
-          abort();
+          PANIC(NULL);
       }
     default:
-      abort();
+      PANIC(NULL);
   }
 }
 
@@ -808,7 +809,7 @@ bool S3FanoutManager::MkPayloadSize(const JobInfo &info, uint64_t *size) const {
       *size = file_size;
       return true;
     default:
-      abort();
+      PANIC(NULL);
   }
 }
 
@@ -825,7 +826,7 @@ string S3FanoutManager::GetRequestString(const JobInfo &info) const {
     case JobInfo::kReqDelete:
       return "DELETE";
     default:
-      abort();
+      PANIC(NULL);
   }
 }
 
@@ -843,7 +844,7 @@ string S3FanoutManager::GetContentType(const JobInfo &info) const {
     case JobInfo::kReqPutBucket:
       return "text/xml";
     default:
-      abort();
+      PANIC(NULL);
   }
 }
 
@@ -929,7 +930,7 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
       retval_b = MkV4Authz(*info, &authz_headers);
       break;
     default:
-      abort();
+      PANIC(NULL);
   }
   if (!retval_b)
     return kFailLocalIO;

--- a/cvmfs/sanitizer.cc
+++ b/cvmfs/sanitizer.cc
@@ -65,7 +65,7 @@ void InputSanitizer::InitValidRanges(const std::string &whitelist) {
           valid_ranges_.push_back(CharRange(range[0], range[1]));
           break;
         default:
-          PANIC(NULL);
+          assert(false);
       }
       ++i;
       pickup_pos = i+1;

--- a/cvmfs/sanitizer.cc
+++ b/cvmfs/sanitizer.cc
@@ -5,6 +5,7 @@
  */
 
 #include "cvmfs_config.h"
+#include "util/exception.h"
 #include "sanitizer.h"
 
 #include <cassert>
@@ -63,7 +64,7 @@ void InputSanitizer::InitValidRanges(const std::string &whitelist) {
           valid_ranges_.push_back(CharRange(range[0], range[1]));
           break;
         default:
-          assert(false);
+          PANIC(NULL);
       }
       ++i;
       pickup_pos = i+1;

--- a/cvmfs/sanitizer.cc
+++ b/cvmfs/sanitizer.cc
@@ -4,11 +4,12 @@
  * Provides input data sanitizer in the form of whitelist of character ranges.
  */
 
-#include "cvmfs_config.h"
-#include "util/exception.h"
 #include "sanitizer.h"
 
 #include <cassert>
+
+#include "cvmfs_config.h"
+#include "util/exception.h"
 
 using namespace std;  // NOLINT
 

--- a/cvmfs/sanitizer.cc
+++ b/cvmfs/sanitizer.cc
@@ -4,12 +4,10 @@
  * Provides input data sanitizer in the form of whitelist of character ranges.
  */
 
+#include "cvmfs_config.h"
 #include "sanitizer.h"
 
 #include <cassert>
-
-#include "cvmfs_config.h"
-#include "util/exception.h"
 
 using namespace std;  // NOLINT
 

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -12,6 +12,7 @@
 #include "gateway_util.h"
 #include "json_document.h"
 #include "swissknife_lease_curl.h"
+#include "util/exception.h"
 #include "util/string.h"
 
 namespace {
@@ -396,9 +397,8 @@ void* SessionContext::UploadLoop(void* data) {
     while (jobs_processed < ctx->NumJobsSubmitted()) {
       UploadJob* job = ctx->upload_jobs_->Dequeue();
       if (!ctx->DoUpload(job)) {
-        LogCvmfs(kLogUploadGateway, kLogStderr,
-                 "SessionContext: could not submit payload. Aborting.");
-        abort();
+        PANIC(kLogStderr,
+              "SessionContext: could not submit payload. Aborting.");
       }
       job->result->Set(true);
       delete job->pack;

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -12,6 +12,7 @@
 #include "server_tool.h"
 #include "upload.h"
 #include "util/pointer.h"
+#include "util/exception.h"
 
 namespace {
 
@@ -230,8 +231,7 @@ SigningTool::Result SigningTool::Run(
       reinterpret_cast<const unsigned char *>(published_hash.ToString().data()),
       published_hash.GetHexSize(), &sig, &sig_size);
   if (!manifest_was_signed) {
-    abort();
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to sign manifest");
+    PANIC(kLogStderr, "Failed to sign manifest");
     return kError;
   }
 

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -11,8 +11,8 @@
 #include "reflog.h"
 #include "server_tool.h"
 #include "upload.h"
-#include "util/pointer.h"
 #include "util/exception.h"
+#include "util/pointer.h"
 
 namespace {
 

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -232,7 +232,6 @@ SigningTool::Result SigningTool::Run(
       published_hash.GetHexSize(), &sig, &sig_size);
   if (!manifest_was_signed) {
     PANIC(kLogStderr, "Failed to sign manifest");
-    return kError;
   }
 
   // Write new manifest

--- a/cvmfs/sqlitemem.cc
+++ b/cvmfs/sqlitemem.cc
@@ -14,6 +14,7 @@
 
 #include "malloc_arena.h"
 #include "smalloc.h"
+#include "util/exception.h"
 #include "util_concurrency.h"
 
 using namespace std;  // NOLINT
@@ -285,7 +286,7 @@ void SqliteMemoryManager::PutLookasideBuffer(void *buffer) {
       return;
     }
   }
-  assert(false);
+  PANIC(NULL);
 }
 
 
@@ -305,7 +306,7 @@ void SqliteMemoryManager::PutMemory(void *ptr) {
         return;
       }
     }
-    assert(false);
+    PANIC(NULL);
   }
 }
 

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -329,18 +329,6 @@ static int VfsRdOnlyAccess(
     return SQLITE_OK;
   }
 
-  /*int amode = 0;
-  switch (flags) {
-    case SQLITE_ACCESS_EXISTS:
-      amode = F_OK;
-      break;
-    case SQLITE_ACCESS_READ:
-      amode = R_OK;
-      break;
-    default:
-      assert(false);
-  }
-  *pResOut = (access(zPath, amode) == 0);*/
   // This VFS deals with file descriptors, we know the files are there
   *pResOut = 0;
   perf::Inc(reinterpret_cast<VfsRdOnly *>(vfs->pAppData)->n_access);

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -29,6 +29,7 @@
 #include "reflog.h"
 #include "sanitizer.h"
 #include "shortstring.h"
+#include "util/exception.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 
@@ -170,14 +171,12 @@ string CommandCheck::FetchPath(const string &path) {
     download::JobInfo download_job(&url, false, false, f, NULL);
     download::Failures retval = download_manager()->Fetch(&download_job);
     if (retval != download::kFailOk) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read %s", url.c_str());
-      abort();
+      PANIC(kLogStderr, "failed to read %s", url.c_str());
     }
   } else {
     bool retval = CopyPath2File(url, f);
     if (!retval) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "failed to read %s", url.c_str());
-      abort();
+      PANIC(kLogStderr, "failed to read %s", url.c_str());
     }
   }
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -68,11 +68,9 @@ SyncItemType SyncItem::GetGenericFiletype(const SyncItem::EntryStat &stat) const
 {
   const SyncItemType type = stat.GetSyncItemType();
   if (type == kItemUnknown) {
-    PANIC(kLogStderr, ("[WARNING] '" + GetRelativePath() +
-                       "' has an unsupported file type (st_mode: " +
-                       StringifyInt(stat.stat.st_mode) +
-                       " errno: " + StringifyInt(stat.error_code) + ")")
-                          .c_str());
+   PANIC(kLogStderr,
+          "[WARNING] '%s' has an unsupported file type (st_mode: %d errno: %d)",
+          GetRelativePath().c_str(), stat.stat.st_mode, stat.error_code);
   }
   return type;
 }
@@ -96,10 +94,8 @@ SyncItemType SyncItem::GetRdOnlyFiletype() const {
 SyncItemType SyncItemNative::GetScratchFiletype() const {
   StatScratch();
   if (scratch_stat_.error_code != 0) {
-    PANIC(kLogStderr, ("[WARNING] Failed to stat() '" + GetRelativePath() +
-                       "' in scratch. (errno: " +
-                       StringifyInt(scratch_stat_.error_code) + ")")
-                          .c_str());
+    PANIC(kLogStderr, "[WARNING] Failed to stat() '%s' in scratch. (errno: %s)",
+          GetRelativePath().c_str(), scratch_stat_.error_code);
   }
 
   return GetGenericFiletype(scratch_stat_);

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -16,6 +16,7 @@
 #include "ingestion/ingestion_source.h"
 #include "sync_mediator.h"
 #include "sync_union.h"
+#include "util/exception.h"
 
 using namespace std;  // NOLINT
 
@@ -67,10 +68,11 @@ SyncItemType SyncItem::GetGenericFiletype(const SyncItem::EntryStat &stat) const
 {
   const SyncItemType type = stat.GetSyncItemType();
   if (type == kItemUnknown) {
-    PrintWarning("'" + GetRelativePath() + "' has an unsupported file type "
-                 "(st_mode: " + StringifyInt(stat.stat.st_mode) +
-                 " errno: " + StringifyInt(stat.error_code) + ")");
-    abort();
+    PANIC(kLogStderr, ("[WARNING] '" + GetRelativePath() +
+                       "' has an unsupported file type (st_mode: " +
+                       StringifyInt(stat.stat.st_mode) +
+                       " errno: " + StringifyInt(stat.error_code) + ")")
+                          .c_str());
   }
   return type;
 }
@@ -94,9 +96,10 @@ SyncItemType SyncItem::GetRdOnlyFiletype() const {
 SyncItemType SyncItemNative::GetScratchFiletype() const {
   StatScratch();
   if (scratch_stat_.error_code != 0) {
-    PrintWarning("Failed to stat() '" + GetRelativePath() + "' in scratch. "
-                 "(errno: " + StringifyInt(scratch_stat_.error_code) + ")");
-    abort();
+    PANIC(kLogStderr, ("[WARNING] Failed to stat() '" + GetRelativePath() +
+                       "' in scratch. (errno: " +
+                       StringifyInt(scratch_stat_.error_code) + ")")
+                          .c_str());
   }
 
   return GetGenericFiletype(scratch_stat_);

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -68,7 +68,7 @@ SyncItemType SyncItem::GetGenericFiletype(const SyncItem::EntryStat &stat) const
 {
   const SyncItemType type = stat.GetSyncItemType();
   if (type == kItemUnknown) {
-   PANIC(kLogStderr,
+    PANIC(kLogStderr,
           "[WARNING] '%s' has an unsupported file type (st_mode: %d errno: %d)",
           GetRelativePath().c_str(), stat.stat.st_mode, stat.error_code);
   }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -727,9 +727,8 @@ void SyncMediator::PublishFilesCallback(const upload::SpoolerResult &result) {
            result.file_chunks.size(),
            result.return_code);
   if (result.return_code != 0) {
-    LogCvmfs(kLogPublish, kLogStderr, "Spool failure for %s (%d)",
-             result.local_path.c_str(), result.return_code);
-    abort();
+    PANIC(kLogStderr, "Spool failure for %s (%d)", result.local_path.c_str(),
+          result.return_code);
   }
 
   SyncItemList::iterator itr;
@@ -777,9 +776,8 @@ void SyncMediator::PublishHardlinksCallback(
            result.content_hash.ToString().c_str(),
            result.return_code);
   if (result.return_code != 0) {
-    LogCvmfs(kLogPublish, kLogStderr, "Spool failure for %s (%d)",
-             result.local_path.c_str(), result.return_code);
-    abort();
+    PANIC(kLogStderr, "Spool failure for %s (%d)", result.local_path.c_str(),
+          result.return_code);
   }
 
   bool found = false;
@@ -890,18 +888,15 @@ void SyncMediator::AddFile(SharedPtr<SyncItem> entry) {
       // Unlike with regular files, grafted files can be "unpublishable" - i.e.,
       // the graft file is missing information.  It's not clear that continuing
       // forward with the publish is the correct thing to do; abort for now.
-      LogCvmfs(kLogPublish, kLogStderr,
-               "Encountered a grafted file (%s) with "
-               "invalid grafting information; check contents of .cvmfsgraft-*"
-               " file.  Aborting publish.",
-               entry->GetRelativePath().c_str());
-      abort();
+      PANIC(kLogStderr,
+            "Encountered a grafted file (%s) with "
+            "invalid grafting information; check contents of .cvmfsgraft-*"
+            " file.  Aborting publish.",
+            entry->GetRelativePath().c_str());
     }
   } else if (entry->relative_parent_path().empty() &&
              entry->IsCatalogMarker()) {
-    LogCvmfs(kLogPublish, kLogStderr,
-             "Error: nested catalog marker in root directory");
-    abort();
+    PANIC(kLogStderr, "Error: nested catalog marker in root directory");
   } else {
     {
       // Push the file to the spooler, remember the entry for the path
@@ -1035,7 +1030,7 @@ void SyncMediator::AddLocalHardlinkGroups(const HardlinkGroupMap &hardlinks) {
       LogCvmfs(kLogPublish, kLogStdout, "Hardlinks across directories (%s)",
                i->second.master->GetUnionPath().c_str());
       if (!params_->ignore_xdir_hardlinks)
-        abort();
+        PANIC(NULL);
     }
 
     if (params_->print_changeset) {

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -116,8 +116,8 @@ void SyncMediator::EnsureAllowed(SharedPtr<SyncItem> entry) {
                   string(catalog::VirtualCatalog::kVirtualPath) + "/",
                   ignore_case_setting)) )
   {
-    PANIC(kLogStderr, "[ERROR] invalid attempt to modify '",
-          relative_path.c_str(), "'");
+    PANIC(kLogStderr, "[ERROR] invalid attempt to modify %s",
+          relative_path.c_str());
   }
 }
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -21,6 +21,7 @@
 #include "smalloc.h"
 #include "sync_union.h"
 #include "upload.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 #include "util_concurrency.h"
@@ -115,8 +116,8 @@ void SyncMediator::EnsureAllowed(SharedPtr<SyncItem> entry) {
                   string(catalog::VirtualCatalog::kVirtualPath) + "/",
                   ignore_case_setting)) )
   {
-    PrintError("invalid attempt to modify '" + relative_path + "'");
-    abort();
+    PANIC(kLogStderr, "[ERROR] invalid attempt to modify '",
+          relative_path.c_str(), "'");
   }
 }
 

--- a/cvmfs/sync_union_overlayfs.cc
+++ b/cvmfs/sync_union_overlayfs.cc
@@ -13,6 +13,7 @@
 
 #include "fs_traversal.h"
 #include "sync_mediator.h"
+#include "util/exception.h"
 #include "util/shared_ptr.h"
 
 namespace publish {
@@ -124,17 +125,16 @@ void SyncUnionOverlayfs::CheckForBrokenHardlink(
     SharedPtr<SyncItem> entry) const {
   if (!entry->IsNew() && !entry->WasDirectory() &&
       entry->GetRdOnlyLinkcount() > 1) {
-    LogCvmfs(kLogPublish, kLogStderr,
-             "OverlayFS has copied-up a file (%s) "
-             "with existing hardlinks in lowerdir "
-             "(linkcount %d). OverlayFS cannot handle "
-             "hardlinks and would produce "
-             "inconsistencies. \n\n"
-             "Consider running this command: \n"
-             "  cvmfs_server eliminate-hardlinks\n\n"
-             "Aborting...",
-             entry->GetUnionPath().c_str(), entry->GetRdOnlyLinkcount());
-    abort();
+    PANIC(kLogStderr,
+          "OverlayFS has copied-up a file (%s) "
+          "with existing hardlinks in lowerdir "
+          "(linkcount %d). OverlayFS cannot handle "
+          "hardlinks and would produce "
+          "inconsistencies. \n\n"
+          "Consider running this command: \n"
+          "  cvmfs_server eliminate-hardlinks\n\n"
+          "Aborting...",
+          entry->GetUnionPath().c_str(), entry->GetRdOnlyLinkcount());
   }
 }
 

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -9,6 +9,7 @@
 #include "upload_gateway.h"
 #include "upload_local.h"
 #include "upload_s3.h"
+#include "util/exception.h"
 
 namespace upload {
 
@@ -155,7 +156,7 @@ void TaskUpload::Process(AbstractUploader::UploadJob *upload_job) {
       break;
 
     default:
-      abort();
+      PANIC(NULL);
   }
 
   delete upload_job;

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -61,7 +61,7 @@ GatewayUploader::GatewayUploader(const SpoolerDefinition& spooler_definition)
          spooler_definition.driver_type == SpoolerDefinition::Gateway);
 
   if (!ParseSpoolerDefinition(spooler_definition, &config_)) {
-    PANIC(NULL);
+    PANIC(kLogStderr, "Error in parsing the spooler definition");
   }
 
   atomic_init32(&num_errors_);

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -9,6 +9,7 @@
 
 #include "gateway_util.h"
 #include "logging.h"
+#include "util/exception.h"
 #include "util/string.h"
 
 namespace upload {
@@ -60,7 +61,7 @@ GatewayUploader::GatewayUploader(const SpoolerDefinition& spooler_definition)
          spooler_definition.driver_type == SpoolerDefinition::Gateway);
 
   if (!ParseSpoolerDefinition(spooler_definition, &config_)) {
-    abort();
+    PANIC(NULL);
   }
 
   atomic_init32(&num_errors_);

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -50,7 +50,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   atomic_init32(&terminate_);
 
   if (!ParseSpoolerDefinition(spooler_definition)) {
-    PANIC(NULL);
+    PANIC(kLogStderr, "Error in parsing the spooler definition");
   }
 
   s3fanout::S3FanoutManager::S3Config s3config;

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -19,6 +19,7 @@
 #include "logging.h"
 #include "options.h"
 #include "s3fanout.h"
+#include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -49,7 +50,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   atomic_init32(&terminate_);
 
   if (!ParseSpoolerDefinition(spooler_definition)) {
-    abort();
+    PANIC(NULL);
   }
 
   s3fanout::S3FanoutManager::S3Config s3config;

--- a/cvmfs/util/exception.cc
+++ b/cvmfs/util/exception.cc
@@ -49,12 +49,7 @@ void Panic(const char* coordinates, const LogSource source, const int mask,
 
 void Panic(const char* coordinates, const LogSource _source, const int _mask) {
   assert(_mask == 0);
-#ifdef LIBCVMFS_SERVER
-  throw ECvmfsException(coordinates);
-#else
-  LogCvmfs(kLogCvmfs, kLogDebug | kLogStdout | kLogStderr, coordinates);
-  abort();
-#endif
+  Panic(coordinates, _source, _mask, "");
 }
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/util/exception.cc
+++ b/cvmfs/util/exception.cc
@@ -47,6 +47,16 @@ void Panic(const char* coordinates, const LogSource source, const int mask,
 #endif
 }
 
+void Panic(const char* coordinates, const LogSource _source, const int _mask) {
+  assert(_mask == 0);
+#ifdef LIBCVMFS_SERVER
+  throw ECvmfsException(coordinates);
+#else
+  LogCvmfs(kLogCvmfs, kLogDebug | kLogStdout | kLogStderr, coordinates);
+  abort();
+#endif
+}
+
 #ifdef CVMFS_NAMESPACE_GUARD
 }  // namespace CVMFS_NAMESPACE_GUARD
 #endif

--- a/cvmfs/util/exception.h
+++ b/cvmfs/util/exception.h
@@ -24,6 +24,7 @@ class ECvmfsException : std::runtime_error {
 
 void Panic(const char *coordinates, const LogSource source, const int mask,
            const char *format, ...);
+void Panic(const char *coordinates, const LogSource source, const int mast);
 
 #ifdef CVMFS_NAMESPACE_GUARD
 }  // namespace CVMFS_NAMESPACE_GUARD

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1234,7 +1234,7 @@ int WaitForChild(pid_t pid) {
     if (retval == -1) {
       if (errno == EINTR)
         continue;
-      assert(false);
+      PANIC(NULL);
     }
     assert(retval == pid);
     break;

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -48,6 +48,7 @@
 #include "logging.h"
 #include "platform.h"
 
+#include "util/exception.h"
 #include "util_concurrency.h"
 
 //using namespace std;  // NOLINT
@@ -180,7 +181,7 @@ bool IsHttpUrl(const std::string &path) {
 
 
 /**
- * By default abort() on failure
+ * By default PANIC(NULL) on failure
  */
 void CreateFile(
   const std::string &path,
@@ -194,7 +195,7 @@ void CreateFile(
   }
   if (ignore_failure)
     return;
-  assert(false);
+  PANIC(NULL);
 }
 
 

--- a/mount/CMakeLists.txt
+++ b/mount/CMakeLists.txt
@@ -3,6 +3,7 @@ set (CVMFS_MOUNT_SOURCES
   ${CVMFS_SOURCE_DIR}/logging.cc
   ${CVMFS_SOURCE_DIR}/options.cc
   ${CVMFS_SOURCE_DIR}/sanitizer.cc
+  ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc
   mount.cvmfs.cc

--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -30,6 +30,7 @@ set (CVMFS_S3_MOCK_SERVER_SOURCES
   ${CVMFS_SOURCE_DIR}/malloc_arena.cc
   ${CVMFS_SOURCE_DIR}/malloc_heap.cc
   ${CVMFS_SOURCE_DIR}/util/algorithm.cc
+  ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc
 )

--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -19,6 +19,7 @@ set (CVMFS_STRESS_SOURCES
   ${CVMFS_SOURCE_DIR}/upload_local.cc
   ${CVMFS_SOURCE_DIR}/upload_s3.cc
   ${CVMFS_SOURCE_DIR}/upload_spooler_definition.cc
+  ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/mmap_file.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -311,6 +311,7 @@ set (CVMFS_TEST_CACHE_SOURCES
   ${CVMFS_SOURCE_DIR}/logging.cc
   ${CVMFS_SOURCE_DIR}/manifest.cc
   ${CVMFS_SOURCE_DIR}/quota.cc
+  ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc
   ${CVMFS_SOURCE_DIR}/util_concurrency.cc
@@ -370,6 +371,7 @@ set (CVMFS_CLIENT_SOURCES
   ${CVMFS_SOURCE_DIR}/tracer.cc
   ${CVMFS_SOURCE_DIR}/uuid.cc
   ${CVMFS_SOURCE_DIR}/util/algorithm.cc
+  ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc
   ${CVMFS_SOURCE_DIR}/util_concurrency.cc

--- a/test/unittests/t_panic.cc
+++ b/test/unittests/t_panic.cc
@@ -23,3 +23,12 @@ TEST(T_Panic, Call) {
   EXPECT_TRUE(FileExists("cvmfs_test_panic"));
   unlink("cvmfs_test_panic");
 }
+
+TEST(T_Panic, CallNullPANIC) {
+  EXPECT_FALSE(FileExists("cvmfs_test_panic"));
+  SetAltLogFunc(LogPanic);
+  EXPECT_DEATH(PANIC(NULL), ".*");
+  SetAltLogFunc(NULL);
+  EXPECT_TRUE(FileExists("cvmfs_test_panic"));
+  unlink("cvmfs_test_panic");
+}


### PR DESCRIPTION
This is the very last PR, built on top of #2467 

Here we use PANIC also for logs that are not directed to `kLogCvmfs`.

This completely address [CVM-1697](https://sft.its.cern.ch/jira/projects/CVM/issues/CVM-1697)

There is this line here: https://github.com/cvmfs/cvmfs/blob/devel/cvmfs/options.cc#L194 where I would like a second opinion.

I believe it is fine as it is, without need to be modified.
