### PR TITLE
Parallel catalog traversal in GC

### DIFF
--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -80,59 +80,12 @@ class CatalogTraversalInfoShim {
 
 
 /**
- * This class traverses the catalog hierarchy of a CVMFS repository recursively.
- * Also historic catalog trees can be traversed. The user needs to specify a
- * callback which is called for each catalog on the way.
- *
- * CatalogTraversal<> can be configured and used in various ways:
- *   -> Historic catalog traversal
- *   -> Prune catalogs below a certain history level
- *   -> Prune catalogs older than a certain threshold timestamp
- *   -> Never traverse a certain catalog twice
- *   -> Breadth First Traversal or Depth First Traversal
- *   -> Optional catalog memory management (no_close)
- *   -> Use all Named Snapshots of a repository as traversal entry point
- *   -> Traverse starting from a provided catalog
- *   -> Traverse catalogs that were previously skipped
- *   -> Produce various flavours of catalogs (writable, mocked, ...)
- *
- * Breadth First Traversal Strategy
- *   Catalogs are handed out to the user identical as they are traversed.
- *   Say: From top to buttom. When you would simply print each received catalog
- *        the result would be a nice representation of the catalog tree.
- *   This method is more efficient, because catalogs are opened, processed and
- *   thrown away directly afterwards.
- *
- * Depth First Traversal Strategy
- *   The user gets the catalog tree starting from the leaf nodes.
- *   Say: From bottom to top. A user can assume that he got all children or
- *        historical ancestors of a catalog before.
- *   This method climbs down the full catalog tree and hands it out 'in reverse
- *   order'. Thus, catalogs on the way are opened, checked for their descendants
- *   and closed. Once all children and historical ancestors are processed, it is
- *   re-opened and handed out to the user.
- *   Note: This method needs more disk space to temporarily store downloaded but
- *         not yet processed catalogs.
- *
- * Note: Since all CVMFS catalog files together can grow to several gigabytes in
- *       file size, each catalog is loaded, processed and removed immediately
- *       afterwards. Except if no_close is specified, which allows the user to
- *       choose when a catalog should be closed. Keep in mind, that a user is
- *       responsible for both deletion of the delivered catalog objects as well
- *       as unlinking of the catalog database file.
- *
- *
- * @param ObjectFetcherT  Strategy Pattern implementation that defines how to
- *                        retrieve catalogs from various backend storage types.
- *                        Furthermore the ObjectFetcherT::CatalogTN is the type
- *                        of catalog to be instantiated by CatalogTraversal<>.
- *
- * CAUTION: the CatalogTN* pointer passed into the callback becomes invalid
- *          directly after the callback method returns, unless you create the
- *          CatalogTraversal object with no_close = true.
+ * A base class for CatalogTraversal and CatalogTraversalParallel implementing
+ * common functionality. Actual traversal classes inherit this class.
+ * 
  */
-template<class ObjectFetcherT>
-class CatalogTraversal
+template <class ObjectFetcherT>
+class CatalogTraversalBase
   : public Observable<CatalogTraversalData<typename ObjectFetcherT::CatalogTN> >
 {
  public:
@@ -141,7 +94,7 @@ class CatalogTraversal
   typedef typename ObjectFetcherT::HistoryTN  HistoryTN;
   typedef CatalogTraversalData<CatalogTN>     CallbackDataTN;
 
-  /**
+   /**
    * @param repo_url             the path to the repository to be traversed:
    *                             -> either absolute path to the local catalogs
    *                             -> or an URL to a remote repository
@@ -163,6 +116,19 @@ class CatalogTraversal
    * @param quiet                silence messages that would go to stderr
    * @param tmp_dir              path to the temporary directory to be used
    *                             (default: /tmp)
+   * 
+   * ONLY FOR CatalogTraversalParallel
+   * @param num_threads           number of threads concurrently traversing
+   *                              the catalog trees; hint: set up based on
+   *                              CPU utilization and optimal number of
+   *                              download threads
+   *                              (default: 8)
+   *
+   * @param serialize_callbacks   do not call multiple catalog callbacks
+   *                              concurrently; ensures safe access to shared
+   *                              variables inside the callback; turn off if
+   *                              the registered callback is thread-safe
+   *                              (default: true)
    */
   struct Parameters {
     Parameters()
@@ -172,7 +138,9 @@ class CatalogTraversal
       , no_repeat_history(false)
       , no_close(false)
       , ignore_load_failure(false)
-      , quiet(false) {}
+      , quiet(false)
+      , num_threads(8)
+      , serialize_callbacks(true) {}
 
     static const unsigned int kFullHistory;
     static const unsigned int kNoHistory;
@@ -186,19 +154,120 @@ class CatalogTraversal
     bool            no_close;
     bool            ignore_load_failure;
     bool            quiet;
+    // These parameters only apply for CatalogTraversalParallel
+    unsigned int    num_threads;
+    bool            serialize_callbacks;
   };
 
- public:
   enum TraversalType {
-    kBreadthFirstTraversal,
-    kDepthFirstTraversal
+    kBreadthFirst,
+    kDepthFirst
   };
+
+  explicit CatalogTraversalBase(const Parameters &params)
+    : object_fetcher_(params.object_fetcher)
+    , catalog_info_shim_(&catalog_info_default_shim_)
+    , default_history_depth_(params.history)
+    , default_timestamp_threshold_(params.timestamp)
+    , no_close_(params.no_close)
+    , ignore_load_failure_(params.ignore_load_failure)
+    , no_repeat_history_(params.no_repeat_history)
+    , error_sink_((params.quiet) ? kLogDebug : kLogStderr)
+  {
+    assert(object_fetcher_ != NULL);
+  }
+
+  /**
+   * Starts the traversal process.
+   * After calling this methods CatalogTraversal will go through all catalogs
+   * and call the registered callback methods for each found catalog.
+   * If something goes wrong in the process, the traversal will be cancelled.
+   *
+   * @param type   breadths or depth first traversal
+   * @return       true, when all catalogs were successfully processed. On
+   *               failure the traversal is cancelled and false is returned.
+   */
+  virtual bool Traverse(const TraversalType type = kBreadthFirst) = 0;
+
+  /**
+   * Starts the traversal process at the catalog pointed to by the given hash
+   *
+   * @param root_catalog_hash  the entry point into the catalog traversal
+   * @param type               breadths or depth first traversal
+   * @return                   true when catalogs were successfully traversed
+   */
+  virtual bool Traverse(const shash::Any &root_catalog_hash,
+                        const TraversalType type = kBreadthFirst) = 0;
+
+  /**
+   * Traverse a list of revisions represented by root catalogs from first
+   * to last. DO NOT traverse previous revisions based on history and
+   * timestamp threshold settings.
+   * 
+   * @param catalog_list  list of root catalog hashes
+   * @param type          breadth- or depth- first traversal
+   * @return              true on success
+   */
+  virtual bool TraverseList(const std::vector<shash::Any> &catalog_list,
+    const TraversalType type = kBreadthFirst) = 0;
+
+  /**
+   * Starts the traversal process at the catalog pointed to by the given hash
+   * but doesn't traverse into predecessor catalog revisions. This overrides the
+   * TraversalParameter settings provided at construction.
+   *
+   * @param root_catalog_hash  the entry point into the catalog traversal
+   * @param type               breadths or depth first traversal
+   * @return                   true when catalogs were successfully traversed
+   */
+  virtual bool TraverseRevision(const shash::Any     &root_catalog_hash,
+                        const TraversalType type = kBreadthFirst) = 0;
+
+  /**
+   * Figures out all named tags in a repository and uses all of them as entry
+   * points into the traversal process.
+   *
+   * @param type  breadths or depth first traversal
+   * @return      true when catalog traversal successfully finished
+   */
+  virtual bool TraverseNamedSnapshots(
+    const TraversalType type = kBreadthFirst)
+  {
+    typedef std::vector<shash::Any> HashList;
+
+    UniquePtr<HistoryTN> tag_db;
+    const typename ObjectFetcherT::Failures retval =
+                                         object_fetcher_->FetchHistory(&tag_db);
+    switch (retval) {
+      case ObjectFetcherT::kFailOk:
+        break;
+
+      case ObjectFetcherT::kFailNotFound:
+        LogCvmfs(kLogCatalogTraversal, kLogDebug,
+                 "didn't find a history database to traverse");
+        return true;
+
+      default:
+        LogCvmfs(kLogCatalogTraversal, kLogStderr,
+                 "failed to download history database (%d - %s)",
+                 retval, Code2Ascii(retval));
+        return false;
+    }
+
+    HashList root_hashes;
+    bool success = tag_db->GetHashes(&root_hashes);
+    assert(success);
+    return TraverseList(root_hashes, type);
+  }
+
+  void SetCatalogInfoShim(CatalogTraversalInfoShim<CatalogTN> *shim) {
+    catalog_info_shim_ = shim;
+  }
 
  protected:
   typedef std::set<shash::Any> HashSet;
 
- protected:
-  /**
+   /**
    * This struct keeps information about a catalog that still needs to be
    * traversed by a currently running catalog traversal process.
    */
@@ -242,249 +311,7 @@ class CatalogTraversal
     bool          postponed;
   };
 
-  typedef std::stack<CatalogJob> CatalogJobStack;
-
-  /**
-   * This struct represents a catalog traversal context. It needs to be re-
-   * created for each catalog traversal process and contains information to this
-   * specific catalog traversal run.
-   *
-   * @param history_depth   the history traversal threshold
-   * @param traversal_type  either breadth or depth first traversal strategy
-   * @param catalog_stack   the call stack for catalogs to be traversed
-   * @param callback_stack  used in depth first traversal for deferred yielding
-   */
-  struct TraversalContext {
-    TraversalContext(const unsigned       history_depth,
-                     const time_t         timestamp_threshold,
-                     const TraversalType  traversal_type) :
-      history_depth(history_depth),
-      timestamp_threshold(timestamp_threshold),
-      traversal_type(traversal_type) {}
-
-    const unsigned       history_depth;
-    const time_t         timestamp_threshold;
-    const TraversalType  traversal_type;
-    CatalogJobStack      catalog_stack;
-    CatalogJobStack      callback_stack;
-  };
-
- public:
-  /**
-   * Constructs a new catalog traversal engine based on the construction
-   * parameters described in struct ConstructionParams.
-   */
-  explicit CatalogTraversal(const Parameters &params)
-    : object_fetcher_(params.object_fetcher)
-    , catalog_info_shim_(&catalog_info_default_shim_)
-    , no_close_(params.no_close)
-    , ignore_load_failure_(params.ignore_load_failure)
-    , no_repeat_history_(params.no_repeat_history)
-    , default_history_depth_(params.history)
-    , default_timestamp_threshold_(params.timestamp)
-    , error_sink_((params.quiet) ? kLogDebug : kLogStderr)
-  {
-    assert(object_fetcher_ != NULL);
-  }
-
-
-  void SetCatalogInfoShim(CatalogTraversalInfoShim<CatalogTN> *shim) {
-    catalog_info_shim_ = shim;
-  }
-
-
-  /**
-   * Starts the traversal process.
-   * After calling this methods CatalogTraversal will go through all catalogs
-   * and call the registered callback methods for each found catalog.
-   * If something goes wrong in the process, the traversal will be cancelled.
-   *
-   * @param type   breadths or depth first traversal
-   * @return       true, when all catalogs were successfully processed. On
-   *               failure the traversal is cancelled and false is returned.
-   */
-  bool Traverse(const TraversalType type = kBreadthFirstTraversal) {
-    TraversalContext ctx(default_history_depth_,
-                         default_timestamp_threshold_,
-                         type);
-    const shash::Any root_catalog_hash = GetRepositoryRootCatalogHash();
-    if (root_catalog_hash.IsNull()) {
-      return false;
-    }
-    Push(root_catalog_hash, &ctx);
-    return DoTraverse(&ctx);
-  }
-
-  /**
-   * Starts the traversal process at the catalog pointed to by the given hash
-   *
-   * @param root_catalog_hash  the entry point into the catalog traversal
-   * @param type               breadths or depth first traversal
-   * @return                   true when catalogs were successfully traversed
-   */
-  bool Traverse(const shash::Any     &root_catalog_hash,
-                const TraversalType   type = kBreadthFirstTraversal) {
-    // add the root catalog of the repository as the first element on the job
-    // stack
-    TraversalContext ctx(default_history_depth_,
-                         default_timestamp_threshold_,
-                         type);
-    Push(root_catalog_hash, &ctx);
-    return DoTraverse(&ctx);
-  }
-
-  /**
-   * Starts the traversal process at the catalog pointed to by the given hash
-   * but doesn't traverse into predecessor catalog revisions. This overrides the
-   * TraversalParameter settings provided at construction.
-   *
-   * @param root_catalog_hash  the entry point into the catalog traversal
-   * @param type               breadths or depth first traversal
-   * @return                   true when catalogs were successfully traversed
-   */
-  bool TraverseRevision(const shash::Any     &root_catalog_hash,
-                        const TraversalType   type = kBreadthFirstTraversal) {
-    // add the given root catalog as the first element on the job stack
-    TraversalContext ctx(Parameters::kNoHistory,
-                         Parameters::kNoTimestampThreshold,
-                         type);
-    Push(root_catalog_hash, &ctx);
-    return DoTraverse(&ctx);
-  }
-
-  /**
-   * Figures out all named tags in a repository and uses all of them as entry
-   * points into the traversal process.
-   *
-   * @param type  breadths or depth first traversal
-   * @return      true when catalog traversal successfully finished
-   */
-  bool TraverseNamedSnapshots(
-    const TraversalType type = kBreadthFirstTraversal)
-  {
-    typedef std::vector<shash::Any> HashList;
-
-    TraversalContext ctx(Parameters::kNoHistory,
-                         Parameters::kNoTimestampThreshold,
-                         type);
-    UniquePtr<HistoryTN> tag_db;
-    const typename ObjectFetcherT::Failures retval =
-                                         object_fetcher_->FetchHistory(&tag_db);
-    switch (retval) {
-      case ObjectFetcherT::kFailOk:
-        break;
-
-      case ObjectFetcherT::kFailNotFound:
-        LogCvmfs(kLogCatalogTraversal, kLogDebug,
-                 "didn't find a history database to traverse");
-        return true;
-
-      default:
-        LogCvmfs(kLogCatalogTraversal, kLogStderr,
-                 "failed to download history database (%d - %s)",
-                 retval, Code2Ascii(retval));
-        return false;
-    }
-
-    HashList root_hashes;
-    bool success = tag_db->GetHashes(&root_hashes);
-    assert(success);
-
-    // traversing referenced named root hashes in reverse chronological order
-    // to make sure that overlapping history traversals don't leave out catalog
-    // revisions accidentially
-          HashList::const_reverse_iterator i    = root_hashes.rbegin();
-    const HashList::const_reverse_iterator iend = root_hashes.rend();
-    for (; i != iend; ++i) {
-      Push(*i, &ctx);
-    }
-
-    return DoTraverse(&ctx);
-  }
-
- protected:
-  /**
-   * This controls the actual traversal. Using a stack to traverse down the
-   * catalog hierarchy. This method implements the traversal itself, but not
-   * in which way catalogs are handed out to the user code.
-   *
-   * Each catalog is processed in these steps:
-   *  1.) Pop the next catalog from the stack
-   *        Catalogs are always traversed from latest to oldest revision and
-   *        from root to leaf nested catalogs
-   *  2.) Prepare the catalog for traversing
-   *    2.1.) Check if it was visited before
-   *    2.2.) Fetch the catalog database from the backend storage
-   *            This might fail and produce an error. For root catalogs this
-   *            error can be ignored (might be garbage collected before)
-   *    2.3.) Open the catalog database
-   *    2.4.) Check if the catalog is older than the timestamp threshold
-   *        After these steps the catalog is opened either opened and ready for
-   *        the traversal to continue, or it was marked for ignore (job.ignore)
-   *  3.) Check if the catalog is marked to be ignored
-   *        Catalog might not be loadable (sweeped root catalog) or is too old
-   *        Note: ignored catalogs can still trigger postponed yields
-   *  4.) Mark the catalog as visited to be able to skip it later on
-   *  5.) Find and push referencing catalogs
-   *        This pushes all descendents of the current catalog onto the stack.
-   *        Note that this is dependent on the strategy (depth or breadth first)
-   *        and on the history threshold (see history_depth).
-   *  6.) Hand the catalog out to the user code
-   *        Depending on the traversal strategy (depth of breadths first) this
-   *        might immediately yield zero to N catalogs to the user code.
-   *
-   * Note: If anything unexpected goes wrong during the traversal process, it
-   *       is aborted immediately.
-   *
-   * @param ctx   the traversal context that steers the whole traversal process
-   * @return      true on successful traversal and false on abort
-   */
-  bool DoTraverse(TraversalContext *ctx) {
-    assert(ctx->callback_stack.empty());
-
-    while (!ctx->catalog_stack.empty()) {
-      // Get the top most catalog for the next processing step
-      CatalogJob job = Pop(ctx);
-
-      // download and open the catalog for processing
-      if (!PrepareCatalog(*ctx, &job)) {
-        return false;
-      }
-
-      // ignored catalogs don't need to be processed anymore but they might
-      // release postponed yields
-      if (job.ignore) {
-        if (!HandlePostponedYields(job, ctx)) {
-          return false;
-        }
-        continue;
-      }
-
-      // push catalogs referenced by the current catalog (onto stack)
-      MarkAsVisited(job);
-      PushReferencedCatalogs(&job, ctx);
-
-      // notify listeners
-      if (!YieldToListeners(&job, ctx)) {
-        return false;
-      }
-    }
-
-    // invariant: after the traversal finshed, there should be no more catalogs
-    //            to traverse or to yield!
-    assert(ctx->catalog_stack.empty());
-    assert(ctx->callback_stack.empty());
-    return true;
-  }
-
-
-  bool PrepareCatalog(const TraversalContext &ctx, CatalogJob *job) {
-    // skipping duplicate catalogs might also yield postponed catalogs
-    if (ShouldBeSkipped(*job)) {
-      job->ignore = true;
-      return true;
-    }
-
+  bool PrepareCatalog(CatalogJob *job) {
     const typename ObjectFetcherT::Failures retval =
       object_fetcher_->FetchCatalog(job->hash,
                                     job->path,
@@ -558,6 +385,22 @@ class CatalogTraversal
     return true;
   }
 
+  shash::Any GetRepositoryRootCatalogHash() {
+    // get the manifest of the repository to learn about the entry point or the
+    // root catalog of the repository to be traversed
+    UniquePtr<manifest::Manifest> manifest;
+    const typename ObjectFetcherT::Failures retval =
+                                      object_fetcher_->FetchManifest(&manifest);
+    if (retval != ObjectFetcherT::kFailOk) {
+      LogCvmfs(kLogCatalogTraversal, kLogStderr, "failed to load manifest "
+                                                 "(%d - %s)",
+                                                 retval, Code2Ascii(retval));
+      return shash::Any();
+    }
+
+    assert(manifest.IsValid());
+    return manifest->catalog_hash();
+  }
 
   /**
    * Checks if a root catalog is below one of the pruning thresholds.
@@ -570,26 +413,260 @@ class CatalogTraversal
    */
   bool IsBelowPruningThresholds(
     const CatalogJob &job,
-    const TraversalContext &ctx
+    const unsigned history_depth,
+    const time_t timestamp_threshold
   ) {
     assert(job.IsRootCatalog());
     assert(job.catalog != NULL);
 
-    const bool h = job.history_depth >= ctx.history_depth;
-    assert(ctx.timestamp_threshold >= 0);
+    const bool h = job.history_depth >= history_depth;
+    assert(timestamp_threshold >= 0);
     const bool t =
       catalog_info_shim_->GetLastModified(job.catalog) <
-      unsigned(ctx.timestamp_threshold);
+      unsigned(timestamp_threshold);
 
     return t || h;
   }
 
+  ObjectFetcherT         *object_fetcher_;
+  CatalogTraversalInfoShim<CatalogTN> catalog_info_default_shim_;
+  CatalogTraversalInfoShim<CatalogTN> *catalog_info_shim_;
+  const unsigned int      default_history_depth_;
+  const time_t            default_timestamp_threshold_;
+  const bool              no_close_;
+  const bool              ignore_load_failure_;
+  const bool              no_repeat_history_;
+  LogFacilities           error_sink_;
+};
+
+/**
+ * This class traverses the catalog hierarchy of a CVMFS repository recursively.
+ * Also historic catalog trees can be traversed. The user needs to specify a
+ * callback which is called for each catalog on the way.
+ *
+ * CatalogTraversal<> can be configured and used in various ways:
+ *   -> Historic catalog traversal
+ *   -> Prune catalogs below a certain history level
+ *   -> Prune catalogs older than a certain threshold timestamp
+ *   -> Never traverse a certain catalog twice
+ *   -> Breadth First Traversal or Depth First Traversal
+ *   -> Optional catalog memory management (no_close)
+ *   -> Use all Named Snapshots of a repository as traversal entry point
+ *   -> Traverse starting from a provided catalog
+ *   -> Traverse catalogs that were previously skipped
+ *   -> Produce various flavours of catalogs (writable, mocked, ...)
+ *
+ * Breadth First Traversal Strategy
+ *   Catalogs are handed out to the user identical as they are traversed.
+ *   Say: From top to buttom. When you would simply print each received catalog
+ *        the result would be a nice representation of the catalog tree.
+ *   This method is more efficient, because catalogs are opened, processed and
+ *   thrown away directly afterwards.
+ *
+ * Depth First Traversal Strategy
+ *   The user gets the catalog tree starting from the leaf nodes.
+ *   Say: From bottom to top. A user can assume that he got all children or
+ *        historical ancestors of a catalog before.
+ *   This method climbs down the full catalog tree and hands it out 'in reverse
+ *   order'. Thus, catalogs on the way are opened, checked for their descendants
+ *   and closed. Once all children and historical ancestors are processed, it is
+ *   re-opened and handed out to the user.
+ *   Note: This method needs more disk space to temporarily store downloaded but
+ *         not yet processed catalogs.
+ *
+ * Note: Since all CVMFS catalog files together can grow to several gigabytes in
+ *       file size, each catalog is loaded, processed and removed immediately
+ *       afterwards. Except if no_close is specified, which allows the user to
+ *       choose when a catalog should be closed. Keep in mind, that a user is
+ *       responsible for both deletion of the delivered catalog objects as well
+ *       as unlinking of the catalog database file.
+ *
+ *
+ * @param ObjectFetcherT  Strategy Pattern implementation that defines how to
+ *                        retrieve catalogs from various backend storage types.
+ *                        Furthermore the ObjectFetcherT::CatalogTN is the type
+ *                        of catalog to be instantiated by CatalogTraversal<>.
+ *
+ * CAUTION: the CatalogTN* pointer passed into the callback becomes invalid
+ *          directly after the callback method returns, unless you create the
+ *          CatalogTraversal object with no_close = true.
+ */
+template<class ObjectFetcherT>
+class CatalogTraversal
+  : public CatalogTraversalBase<ObjectFetcherT>
+{
+ public:
+  typedef CatalogTraversalBase<ObjectFetcherT> Base;
+  typedef ObjectFetcherT                      ObjectFetcherTN;
+  typedef typename ObjectFetcherT::CatalogTN  CatalogTN;
+  typedef typename ObjectFetcherT::HistoryTN  HistoryTN;
+  typedef CatalogTraversalData<CatalogTN>     CallbackDataTN;
+  typedef typename Base::Parameters           Parameters;
+  typedef typename Base::TraversalType        TraversalType;
+  typedef typename Base::CatalogJob           CatalogJob;
+
+ protected:
+  typedef std::set<shash::Any> HashSet;
+  typedef std::stack<CatalogJob> CatalogJobStack;
+
+  /**
+   * This struct represents a catalog traversal context. It needs to be re-
+   * created for each catalog traversal process and contains information to this
+   * specific catalog traversal run.
+   *
+   * @param history_depth   the history traversal threshold
+   * @param traversal_type  either breadth or depth first traversal strategy
+   * @param catalog_stack   the call stack for catalogs to be traversed
+   * @param callback_stack  used in depth first traversal for deferred yielding
+   */
+  struct TraversalContext {
+    TraversalContext(const unsigned       history_depth,
+                     const time_t         timestamp_threshold,
+                     const TraversalType  traversal_type) :
+      history_depth(history_depth),
+      timestamp_threshold(timestamp_threshold),
+      traversal_type(traversal_type) {}
+
+    const unsigned       history_depth;
+    const time_t         timestamp_threshold;
+    const TraversalType  traversal_type;
+    CatalogJobStack      catalog_stack;
+    CatalogJobStack      callback_stack;
+  };
+
+ public:
+  /**
+   * Constructs a new catalog traversal engine based on the construction
+   * parameters described in struct ConstructionParams.
+   */
+  explicit CatalogTraversal(const Parameters &params)
+    : CatalogTraversalBase<ObjectFetcherT>(params)
+  { }
+
+  bool Traverse(const TraversalType type = Base::kBreadthFirst) {
+    const shash::Any root_catalog_hash = this->GetRepositoryRootCatalogHash();
+    if (root_catalog_hash.IsNull()) {
+      return false;
+    }
+    return Traverse(root_catalog_hash, type);
+  }
+
+  bool Traverse(const shash::Any     &root_catalog_hash,
+                const TraversalType   type = Base::kBreadthFirst) {
+    // add the root catalog of the repository as the first element on the job
+    // stack
+    TraversalContext ctx(this->default_history_depth_,
+                         this->default_timestamp_threshold_,
+                         type);
+    Push(root_catalog_hash, &ctx);
+    return DoTraverse(&ctx);
+  }
+
+  bool TraverseList(const std::vector<shash::Any> &catalog_list,
+                    const TraversalType type = Base::kBreadthFirst) {
+    std::vector<shash::Any>::const_iterator i = catalog_list.begin();
+    const std::vector<shash::Any>::const_iterator iend = catalog_list.end();
+    bool success = true;
+    for (; i != iend; ++i) {
+      success = success && TraverseRevision(*i, type);
+    }
+    return success;
+  }
+
+  bool TraverseRevision(
+    const shash::Any     &root_catalog_hash,
+    const TraversalType type = Base::kBreadthFirst)
+  {
+    // add the given root catalog as the first element on the job stack
+    TraversalContext ctx(Parameters::kNoHistory,
+                         Parameters::kNoTimestampThreshold,
+                         type);
+    Push(root_catalog_hash, &ctx);
+    return DoTraverse(&ctx);
+  }
+
+ protected:
+  /**
+   * This controls the actual traversal. Using a stack to traverse down the
+   * catalog hierarchy. This method implements the traversal itself, but not
+   * in which way catalogs are handed out to the user code.
+   *
+   * Each catalog is processed in these steps:
+   *  1.) Pop the next catalog from the stack
+   *        Catalogs are always traversed from latest to oldest revision and
+   *        from root to leaf nested catalogs
+   *  2.) Prepare the catalog for traversing
+   *    2.1.) Check if it was visited before
+   *    2.2.) Fetch the catalog database from the backend storage
+   *            This might fail and produce an error. For root catalogs this
+   *            error can be ignored (might be garbage collected before)
+   *    2.3.) Open the catalog database
+   *    2.4.) Check if the catalog is older than the timestamp threshold
+   *        After these steps the catalog is opened either opened and ready for
+   *        the traversal to continue, or it was marked for ignore (job.ignore)
+   *  3.) Check if the catalog is marked to be ignored
+   *        Catalog might not be loadable (sweeped root catalog) or is too old
+   *        Note: ignored catalogs can still trigger postponed yields
+   *  4.) Mark the catalog as visited to be able to skip it later on
+   *  5.) Find and push referencing catalogs
+   *        This pushes all descendents of the current catalog onto the stack.
+   *        Note that this is dependent on the strategy (depth or breadth first)
+   *        and on the history threshold (see history_depth).
+   *  6.) Hand the catalog out to the user code
+   *        Depending on the traversal strategy (depth of breadths first) this
+   *        might immediately yield zero to N catalogs to the user code.
+   *
+   * Note: If anything unexpected goes wrong during the traversal process, it
+   *       is aborted immediately.
+   *
+   * @param ctx   the traversal context that steers the whole traversal process
+   * @return      true on successful traversal and false on abort
+   */
+  bool DoTraverse(TraversalContext *ctx) {
+    assert(ctx->callback_stack.empty());
+
+    while (!ctx->catalog_stack.empty()) {
+      // Get the top most catalog for the next processing step
+      CatalogJob job = Pop(ctx);
+
+      if (ShouldBeSkipped(job)) {
+        job.ignore = true;
+      // download and open the catalog for processing
+      } else if (!this->PrepareCatalog(&job)) {
+        return false;
+      }
+
+      // ignored catalogs don't need to be processed anymore but they might
+      // release postponed yields
+      if (job.ignore) {
+        if (!HandlePostponedYields(job, ctx)) {
+          return false;
+        }
+        continue;
+      }
+
+      // push catalogs referenced by the current catalog (onto stack)
+      this->MarkAsVisited(job);
+      PushReferencedCatalogs(&job, ctx);
+
+      // notify listeners
+      if (!YieldToListeners(&job, ctx)) {
+        return false;
+      }
+    }
+
+    // invariant: after the traversal finshed, there should be no more catalogs
+    //            to traverse or to yield!
+    assert(ctx->catalog_stack.empty());
+    assert(ctx->callback_stack.empty());
+    return true;
+  }
 
   void PushReferencedCatalogs(CatalogJob *job, TraversalContext *ctx) {
     assert(!job->ignore);
     assert(job->catalog != NULL);
-    assert(ctx->traversal_type == kBreadthFirstTraversal ||
-           ctx->traversal_type == kDepthFirstTraversal);
+    assert(ctx->traversal_type == Base::kBreadthFirst ||
+           ctx->traversal_type == Base::kDepthFirst);
 
     // this differs, depending on the traversal strategy.
     //
@@ -602,7 +679,8 @@ class CatalogTraversal
     //   Catalogs are traversed from oldest revision (depends on the configured
     //   maximal history depth) to the HEAD revision and from bottom (leafs) to
     //   top (root catalogs)
-    job->referenced_catalogs = (ctx->traversal_type == kBreadthFirstTraversal)
+    job->referenced_catalogs =
+      (ctx->traversal_type == Base::kBreadthFirst)
       ? PushPreviousRevision(*job, ctx) + PushNestedCatalogs(*job, ctx)
       : PushNestedCatalogs(*job, ctx) + PushPreviousRevision(*job, ctx);
   }
@@ -628,7 +706,8 @@ class CatalogTraversal
     // check if the next deeper history level is actually requested
     // Note: if the current catalog is below the timestamp threshold it will be
     //       traversed and only its ancestor revision will not be pushed anymore
-    if (IsBelowPruningThresholds(job, *ctx)) {
+    if (this->IsBelowPruningThresholds(job, ctx->history_depth,
+                                       ctx->timestamp_threshold)) {
       return 0;
     }
 
@@ -650,7 +729,7 @@ class CatalogTraversal
     typename NestedCatalogList::const_iterator i    = nested.begin();
     typename NestedCatalogList::const_iterator iend = nested.end();
     for (; i != iend; ++i) {
-      CatalogTN* parent = (no_close_) ? job.catalog : NULL;
+      CatalogTN* parent = (this->no_close_) ? job.catalog : NULL;
       const CatalogJob new_job(i->mountpoint.ToString(),
                                i->hash,
                                job.tree_level + 1,
@@ -666,22 +745,21 @@ class CatalogTraversal
     Push(CatalogJob("", root_catalog_hash, 0, 0), ctx);
   }
 
-
   bool YieldToListeners(CatalogJob *job, TraversalContext *ctx) {
     assert(!job->ignore);
     assert(job->catalog != NULL);
-    assert(ctx->traversal_type == kBreadthFirstTraversal ||
-           ctx->traversal_type == kDepthFirstTraversal);
+    assert(ctx->traversal_type == Base::kBreadthFirst ||
+           ctx->traversal_type == Base::kDepthFirst);
 
     // in breadth first search mode, every catalog is simply handed out once
     // it is visited. No extra magic required...
-    if (ctx->traversal_type == kBreadthFirstTraversal) {
+    if (ctx->traversal_type == Base::kBreadthFirst) {
       return Yield(job);
     }
 
     // in depth first search mode, catalogs might need to wait until all of
     // their referenced catalogs are yielded (ctx.callback_stack)...
-    assert(ctx->traversal_type == kDepthFirstTraversal);
+    assert(ctx->traversal_type == Base::kDepthFirst);
     if (job->referenced_catalogs > 0) {
       PostponeYield(job, ctx);
       return true;
@@ -691,6 +769,22 @@ class CatalogTraversal
     return Yield(job) && HandlePostponedYields(*job, ctx);
   }
 
+  /**
+   * Checks the traversal history if the given catalog was traversed or at least
+   * seen before. If 'no_repeat_history' is not set this is always 'false'.
+   *
+   * @param job   the job to be checked against the traversal history
+   * @return      true if the specified catalog was hit before
+   */
+  bool ShouldBeSkipped(const CatalogJob &job) {
+    return this->no_repeat_history_ && (visited_catalogs_.count(job.hash) > 0);
+  }
+
+  void MarkAsVisited(const CatalogJob &job) {
+    if (this->no_repeat_history_) {
+      visited_catalogs_.insert(job.hash);
+    }
+  }
 
  private:
   /**
@@ -705,7 +799,7 @@ class CatalogTraversal
     // catalog was pushed on ctx.callback_stack before, it might need to be re-
     // opened. If CatalogTraversal<> is configured with no_close, it was not
     // closed before, hence does not need a re-open.
-    if (job->postponed && !no_close_ && !ReopenCatalog(job)) {
+    if (job->postponed && !this->no_close_ && !this->ReopenCatalog(job)) {
       return false;
     }
 
@@ -716,13 +810,13 @@ class CatalogTraversal
     // skip the catalog closing procedure if asked for
     // Note: In this case it is the user's responsibility to both delete the
     //       yielded catalog object and the underlying database temp file
-    if (no_close_) {
+    if (this->no_close_) {
       return true;
     }
 
     // we can close the catalog here and delete the temporary file
     const bool unlink_db = true;
-    return CloseCatalog(unlink_db, job);
+    return this->CloseCatalog(unlink_db, job);
   }
 
 
@@ -734,9 +828,9 @@ class CatalogTraversal
     assert(job->referenced_catalogs > 0);
 
     job->postponed = true;
-    if (!no_close_) {
+    if (!this->no_close_) {
       const bool unlink_db = false;  // will reopened just before yielding
-      CloseCatalog(unlink_db, job);
+      this->CloseCatalog(unlink_db, job);
     }
     ctx->callback_stack.push(*job);
   }
@@ -753,11 +847,11 @@ class CatalogTraversal
    * @return      true on successful execution
    */
   bool HandlePostponedYields(const CatalogJob &job, TraversalContext *ctx) {
-    if (ctx->traversal_type == kBreadthFirstTraversal) {
+    if (ctx->traversal_type == Base::kBreadthFirst) {
       return true;
     }
 
-    assert(ctx->traversal_type == kDepthFirstTraversal);
+    assert(ctx->traversal_type == Base::kDepthFirst);
     assert(job.referenced_catalogs == 0);
 
     // walk through the callback_stack and yield all catalogs that have no un-
@@ -790,65 +884,22 @@ class CatalogTraversal
     return job;
   }
 
-  void MarkAsVisited(const CatalogJob &job) {
-    if (no_repeat_history_) {
-      visited_catalogs_.insert(job.hash);
-    }
-  }
-
-  /**
-   * Checks the traversal history if the given catalog was traversed or at least
-   * seen before. If 'no_repeat_history' is not set this is always 'false'.
-   *
-   * @param job   the job to be checked against the traversal history
-   * @return      true if the specified catalog was hit before
-   */
-  bool ShouldBeSkipped(const CatalogJob &job) {
-    return no_repeat_history_ && (visited_catalogs_.count(job.hash) > 0);
-  }
-
-  shash::Any GetRepositoryRootCatalogHash() {
-    // get the manifest of the repository to learn about the entry point or the
-    // root catalog of the repository to be traversed
-    UniquePtr<manifest::Manifest> manifest;
-    const typename ObjectFetcherT::Failures retval =
-                                      object_fetcher_->FetchManifest(&manifest);
-    if (retval != ObjectFetcherT::kFailOk) {
-      LogCvmfs(kLogCatalogTraversal, kLogStderr, "failed to load manifest "
-                                                 "(%d - %s)",
-                                                 retval, Code2Ascii(retval));
-      return shash::Any();
-    }
-
-    assert(manifest.IsValid());
-    return manifest->catalog_hash();
-  }
-
- private:
-  ObjectFetcherT         *object_fetcher_;
-  CatalogTraversalInfoShim<CatalogTN> catalog_info_default_shim_;
-  CatalogTraversalInfoShim<CatalogTN> *catalog_info_shim_;
-  const bool              no_close_;
-  const bool              ignore_load_failure_;
-  const bool              no_repeat_history_;
-  const unsigned int      default_history_depth_;
-  const time_t            default_timestamp_threshold_;
+ protected:
   HashSet                 visited_catalogs_;
-  LogFacilities           error_sink_;
 };
 
 template <class ObjectFetcherT>
 const unsigned int
-  CatalogTraversal<ObjectFetcherT>::Parameters::kFullHistory =
+  CatalogTraversalBase<ObjectFetcherT>::Parameters::kFullHistory =
     std::numeric_limits<unsigned int>::max();
 
 template <class ObjectFetcherT>
 const unsigned int
-  CatalogTraversal<ObjectFetcherT>::Parameters::kNoHistory = 0;
+  CatalogTraversalBase<ObjectFetcherT>::Parameters::kNoHistory = 0;
 
 template <class ObjectFetcherT>
 const time_t
-  CatalogTraversal<ObjectFetcherT>::Parameters::kNoTimestampThreshold = 0;
+  CatalogTraversalBase<ObjectFetcherT>::Parameters::kNoTimestampThreshold = 0;
 
 }  // namespace swissknife
 

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -1,0 +1,415 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_CATALOG_TRAVERSAL_PARALLEL_H_
+#define CVMFS_CATALOG_TRAVERSAL_PARALLEL_H_
+
+#include <stack>
+#include <string>
+#include <vector>
+
+#include "catalog_traversal.h"
+#include "ingestion/tube.h"
+#include "util/exception.h"
+
+namespace swissknife {
+
+/**
+ * This class implements the same functionality as CatalogTraversal, but in parallel.
+ * For common functionality, see the documentation of CatalogTraversal.
+ * Differences:
+ * - can choose number of threads
+ *
+ *  - traversal types change meaning:
+ * - depth-first -> parallelized post-order traversal (parents are processed
+ * after all children are finished)
+ * - breadth-first -> same as original, but parallelized
+ */
+template<class ObjectFetcherT>
+class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
+ public:
+  typedef CatalogTraversalBase<ObjectFetcherT> Base;
+  typedef ObjectFetcherT                      ObjectFetcherTN;
+  typedef typename ObjectFetcherT::CatalogTN  CatalogTN;
+  typedef typename ObjectFetcherT::HistoryTN  HistoryTN;
+  typedef CatalogTraversalData<CatalogTN>     CallbackDataTN;
+  typedef typename CatalogTN::NestedCatalogList NestedCatalogList;
+  typedef typename Base::Parameters Parameters;
+  typedef typename Base::TraversalType TraversalType;
+  typedef std::vector<shash::Any> HashList;
+
+  explicit CatalogTraversalParallel(const Parameters &params)
+    : CatalogTraversalBase<ObjectFetcherT>(params)
+    , num_threads_(params.num_threads)
+    , serialize_callbacks_(params.serialize_callbacks) {
+    atomic_init32(&num_errors_);
+    shash::Any null_hash;
+    null_hash.SetNull();
+    catalogs_processing_.Init(1024, null_hash, hasher);
+    catalogs_done_.Init(1024, null_hash, hasher);
+    pthread_mutex_init(&catalog_callback_lock_, NULL);
+    pthread_mutex_init(&catalogs_lock_, NULL);
+    effective_history_depth_ = this->default_history_depth_;
+    effective_timestamp_threshold_ = this->default_timestamp_threshold_;
+  }
+
+ protected:
+  struct CatalogJob : public CatalogTraversal<ObjectFetcherT>::CatalogJob,
+                      public Observable<int> {
+    explicit CatalogJob(const std::string &path,
+                        const shash::Any &hash,
+                        const unsigned tree_level,
+                        const unsigned history_depth,
+                        CatalogTN *parent = NULL) :
+      CatalogTraversal<ObjectFetcherT>::CatalogJob(path, hash, tree_level,
+                                                   history_depth, parent) {
+      atomic_init32(&children_unprocessed);
+    }
+
+    void WakeParents() {
+      this->NotifyListeners(0);
+    }
+
+    atomic_int32 children_unprocessed;
+  };
+
+ public:
+  /**
+   * Starts the traversal process.
+   * After calling this methods CatalogTraversal will go through all catalogs
+   * and call the registered callback methods for each found catalog.
+   * If something goes wrong in the process, the traversal will be cancelled.
+   *
+   * @return       true, when all catalogs were successfully processed. On
+   *               failure the traversal is cancelled and false is returned.
+   */
+  bool Traverse(const TraversalType type = Base::kBreadthFirst) {
+    const shash::Any root_catalog_hash = this->GetRepositoryRootCatalogHash();
+    if (root_catalog_hash.IsNull()) {
+      return false;
+    }
+    return Traverse(root_catalog_hash, type);
+  }
+
+  /**
+   * Starts the traversal process at the catalog pointed to by the given hash
+   *
+   * @param root_catalog_hash  the entry point into the catalog traversal
+   * @return                   true when catalogs were successfully traversed
+   */
+  bool Traverse(const shash::Any &root_catalog_hash,
+                const TraversalType type = Base::kBreadthFirst) {
+    // add the root catalog of the repository as the first element on the job
+    // stack
+    if (this->no_repeat_history_ &&
+        catalogs_done_.Contains(root_catalog_hash)) {
+      return true;
+    }
+    effective_traversal_type_ = type;
+    CatalogJob *root_job = new CatalogJob("", root_catalog_hash, 0, 0);
+    PushJob(root_job);
+    return DoTraverse();
+  }
+
+/**
+ * Start the traversal process from a list of root catalogs. Same as 
+ * TraverseRevision function, TraverseList does not traverse into predecessor
+ * catalog revisions and ignores TraversalParameter settings.
+ */
+  bool TraverseList(const HashList &root_catalog_list,
+                    const TraversalType type = Base::kBreadthFirst) {
+    // Push in reverse order for CatalogTraversal-like behavior
+    HashList::const_reverse_iterator i = root_catalog_list.rbegin();
+    const HashList::const_reverse_iterator iend = root_catalog_list.rend();
+    bool has_pushed = false;
+    {
+      MutexLockGuard m(&catalogs_lock_);
+      for (; i != iend; ++i) {
+        if (this->no_repeat_history_ && catalogs_done_.Contains(*i)) {
+          continue;
+        }
+
+        CatalogJob *root_job = new CatalogJob("", *i, 0, 0);
+        PushJobUnlocked(root_job);
+        has_pushed = true;
+      }
+    }
+    // noop: no catalogs to traverse
+    if (!has_pushed) {
+      return true;
+    }
+    effective_traversal_type_ = type;
+    effective_history_depth_ = Parameters::kNoHistory;
+    effective_timestamp_threshold_ = Parameters::kNoTimestampThreshold;
+    bool result = DoTraverse();
+    effective_history_depth_ = this->default_history_depth_;
+    effective_timestamp_threshold_ = this->default_timestamp_threshold_;
+    return result;
+  }
+
+  /**
+   * Starts the traversal process at the catalog pointed to by the given hash
+   * but doesn't traverse into predecessor catalog revisions. This overrides the
+   * TraversalParameter settings provided at construction.
+   *
+   * @param root_catalog_hash  the entry point into the catalog traversal
+   * @return                   true when catalogs were successfully traversed
+   */
+  bool TraverseRevision(
+    const shash::Any &root_catalog_hash,
+    const TraversalType type = Base::kBreadthFirst)
+  {
+    effective_history_depth_ = Parameters::kNoHistory;
+    effective_timestamp_threshold_ = Parameters::kNoTimestampThreshold;
+    bool result = Traverse(root_catalog_hash, type);
+    effective_history_depth_ = this->default_history_depth_;
+    effective_timestamp_threshold_ = this->default_timestamp_threshold_;
+    return result;
+  }
+
+ protected:
+  static uint32_t hasher(const shash::Any &key) {
+    // Don't start with the first bytes, because == is using them as well
+    return (uint32_t) *(reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  }
+
+  bool DoTraverse() {
+    // Optimal number of threads is yet to be determined. The main event loop
+    // contains a spin-lock, so it should not be more than number of cores.
+    threads_process_ = reinterpret_cast<pthread_t *>
+                        (smalloc(sizeof(pthread_t)*num_threads_));
+    for (unsigned int i = 0; i < num_threads_; ++i) {
+      int retval = pthread_create(&threads_process_[i], NULL,
+                                  MainProcessQueue, this);
+      if (retval != 0) PANIC(kLogStderr, "failed to create thread");
+    }
+
+    for (unsigned int i = 0; i < num_threads_; ++i) {
+      assert(pthread_join(threads_process_[i], NULL) == 0);
+    }
+    free(threads_process_);
+
+    if (atomic_read32(&num_errors_))
+      return false;
+
+    assert(catalogs_processing_.size() == 0);
+    assert(job_queue_.IsEmpty());
+    return true;
+  }
+
+  static void *MainProcessQueue(void *data) {
+    CatalogTraversalParallel<ObjectFetcherT> *traversal =
+      reinterpret_cast<CatalogTraversalParallel<ObjectFetcherT> *>(data);
+    CatalogJob *current_job;
+    while (true) {
+      current_job = traversal->job_queue_.Pop();
+      // NULL means the master thread tells us to finish
+      if (current_job->hash.IsNull()) {
+        delete current_job;
+        break;
+      }
+      traversal->ProcessJobPre(current_job);
+    }
+    return NULL;
+  }
+
+  void NotifyFinished() {
+    shash::Any null_hash;
+    null_hash.SetNull();
+    for (unsigned i = 0; i < num_threads_; ++i) {
+      CatalogJob *job = new CatalogJob("", null_hash, 0, 0);
+      job_queue_.EnqueueFront(job);
+    }
+  }
+
+  void PushJob(CatalogJob *job) {
+    MutexLockGuard m(&catalogs_lock_);
+    PushJobUnlocked(job);
+  }
+
+  void PushJobUnlocked(CatalogJob *job) {
+    catalogs_processing_.Insert(job->hash, job);
+    job_queue_.EnqueueFront(job);
+  }
+
+  void ProcessJobPre(CatalogJob *job) {
+    if (!this->PrepareCatalog(job)) {
+      atomic_inc32(&num_errors_);
+      NotifyFinished();
+      return;
+    }
+    if (job->ignore) {
+      FinalizeJob(job);
+      return;
+    }
+    NestedCatalogList catalog_list = job->catalog->ListOwnNestedCatalogs();
+    unsigned int num_children;
+    // Ensure that pushed children won't call ProcessJobPost on this job
+    // before this function finishes
+    {
+      MutexLockGuard m(&catalogs_lock_);
+      if (effective_traversal_type_ == Base::kBreadthFirst) {
+        num_children = PushPreviousRevision(job) +
+                      PushNestedCatalogs(job, catalog_list);
+      } else {
+        num_children = PushNestedCatalogs(job, catalog_list) +
+                      PushPreviousRevision(job);
+        atomic_write32(&job->children_unprocessed, num_children);
+      }
+      if (!this->CloseCatalog(false, job)) {
+        atomic_inc32(&num_errors_);
+        NotifyFinished();
+      }
+    }
+
+    // breadth-first: can post-process immediately
+    // depth-first: no children -> can post-process immediately
+    if (effective_traversal_type_ == Base::kBreadthFirst ||
+        num_children == 0) {
+      ProcessJobPost(job);
+      return;
+    }
+  }
+
+  unsigned int PushNestedCatalogs(CatalogJob *job,
+                                  const NestedCatalogList &catalog_list) {
+    typename NestedCatalogList::const_iterator i = catalog_list.begin();
+    typename NestedCatalogList::const_iterator iend = catalog_list.end();
+    unsigned int num_children = 0;
+    for (; i != iend; ++i) {
+      if (this->no_repeat_history_ && catalogs_done_.Contains(i->hash)) {
+        continue;
+      }
+
+      CatalogJob *child;
+      if (!this->no_repeat_history_ ||
+          !catalogs_processing_.Lookup(i->hash, &child)) {
+        CatalogTN *parent = (this->no_close_) ? job->catalog : NULL;
+        child = new CatalogJob(i->mountpoint.ToString(),
+                               i->hash,
+                               job->tree_level + 1,
+                               job->history_depth,
+                               parent);
+        PushJobUnlocked(child);
+      }
+
+      if (effective_traversal_type_ == Base::kDepthFirst) {
+        child->RegisterListener(&CatalogTraversalParallel::OnChildFinished,
+                                this, job);
+      }
+      ++num_children;
+    }
+    return num_children;
+  }
+
+  /**
+   * Pushes the previous revision of a root catalog.
+   * @return  the number of catalogs pushed on the processing stack
+   */
+  unsigned int PushPreviousRevision(CatalogJob *job) {
+    // only root catalogs are used for entering a previous revision (graph)
+    if (!job->catalog->IsRoot()) {
+      return 0;
+    }
+
+    const shash::Any previous_revision = job->catalog->GetPreviousRevision();
+    if (previous_revision.IsNull()) {
+      return 0;
+    }
+
+    // check if the next deeper history level is actually requested
+    if (this->IsBelowPruningThresholds(*job, effective_history_depth_,
+                                       effective_timestamp_threshold_)) {
+      return 0;
+    }
+
+    if (this->no_repeat_history_ &&
+        catalogs_done_.Contains(previous_revision)) {
+      return 0;
+    }
+
+    CatalogJob *prev_job;
+    if (!this->no_repeat_history_ ||
+        !catalogs_processing_.Lookup(previous_revision, &prev_job)) {
+      prev_job =
+        new CatalogJob("", previous_revision, 0, job->history_depth + 1);
+      PushJobUnlocked(prev_job);
+    }
+
+    if (effective_traversal_type_ == Base::kDepthFirst) {
+      prev_job->RegisterListener(&CatalogTraversalParallel::OnChildFinished,
+                              this, job);
+    }
+    return 1;
+  }
+
+  void ProcessJobPost(CatalogJob *job) {
+    // Save time by keeping catalog open when suitable
+    if (job->catalog == NULL) {
+      if (!this->ReopenCatalog(job)) {
+        atomic_inc32(&num_errors_);
+        NotifyFinished();
+        return;
+      }
+    }
+    if (serialize_callbacks_) {
+      MutexLockGuard m(&catalog_callback_lock_);
+      this->NotifyListeners(job->GetCallbackData());
+    } else {
+      this->NotifyListeners(job->GetCallbackData());
+    }
+    if (!this->no_close_) {
+      if (!this->CloseCatalog(true, job)) {
+        atomic_inc32(&num_errors_);
+        NotifyFinished();
+        return;
+      }
+    }
+    FinalizeJob(job);
+  }
+
+  void FinalizeJob(CatalogJob *job) {
+    {
+      MutexLockGuard m(&catalogs_lock_);
+      catalogs_processing_.Erase(job->hash);
+      catalogs_done_.Insert(job->hash, true);
+      // No more catalogs to process -> finish
+      if (catalogs_processing_.size() == 0 && job_queue_.IsEmpty()) {
+        NotifyFinished();
+      }
+    }
+    if (effective_traversal_type_ == Base::kDepthFirst) {
+      job->WakeParents();
+    }
+    delete job;
+  }
+
+  void OnChildFinished(const int &a, CatalogJob *job) {
+    // atomic_xadd32 returns value before subtraction -> needs to equal 1
+    if (atomic_xadd32(&job->children_unprocessed, -1) == 1) {
+      ProcessJobPost(job);
+    }
+  }
+
+  unsigned int num_threads_;
+  bool serialize_callbacks_;
+
+  unsigned int effective_history_depth_;
+  time_t effective_timestamp_threshold_;
+  TraversalType effective_traversal_type_;
+
+  pthread_t *threads_process_;
+  atomic_int32 num_errors_;
+
+  Tube<CatalogJob> job_queue_;
+  SmallHashDynamic<shash::Any, CatalogJob *> catalogs_processing_;
+  SmallHashDynamic<shash::Any, bool> catalogs_done_;
+  pthread_mutex_t catalogs_lock_;
+
+  pthread_mutex_t catalog_callback_lock_;
+};
+
+}  // namespace swissknife
+
+#endif  // CVMFS_CATALOG_TRAVERSAL_PARALLEL_H_

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -36,7 +36,6 @@
 
 #include <vector>
 
-// #include "catalog_traversal.h"
 #include "catalog_traversal_parallel.h"
 #include "garbage_collection/hash_filter.h"
 #include "statistics.h"
@@ -70,7 +69,8 @@ class GarbageCollector {
       , verbose(false)
       , deleted_objects_logfile(NULL)
       , statistics(NULL)
-      , extended_stats(false) {}
+      , extended_stats(false)
+      , num_threads(8) {}
 
     bool has_deletion_log() const { return deleted_objects_logfile != NULL; }
 
@@ -84,6 +84,7 @@ class GarbageCollector {
     FILE                      *deleted_objects_logfile;
     perf::Statistics          *statistics;
     bool                       extended_stats;
+    unsigned int               num_threads;
   };
 
  public:

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -36,7 +36,8 @@
 
 #include <vector>
 
-#include "catalog_traversal.h"
+// #include "catalog_traversal.h"
+#include "catalog_traversal_parallel.h"
 #include "garbage_collection/hash_filter.h"
 #include "statistics.h"
 #include "upload_facility.h"

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -67,6 +67,7 @@ typename GarbageCollector<CatalogTraversalT, HashFilterT>::TraversalParameters
   params.no_repeat_history   = true;
   params.ignore_load_failure = true;
   params.quiet               = !config.verbose;
+  params.num_threads         = config.num_threads;
   return params;
 }
 
@@ -250,21 +251,22 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
        &GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects,
         this);
 
-  bool success = true;
-  const typename CatalogTraversalT::TraversalType traversal_type =
-                                        CatalogTraversalT::kDepthFirstTraversal;
-        std::vector<shash::Any>::const_iterator i    = catalogs.begin();
-  const std::vector<shash::Any>::const_iterator iend = catalogs.end();
-  for (; i != iend && success; ++i) {
+  std::vector<shash::Any> to_sweep;
+  std::vector<shash::Any>::const_iterator i    = catalogs.begin();
+  std::vector<shash::Any>::const_iterator iend = catalogs.end();
+  for (; i != iend; ++i) {
     if (!hash_filter_.Contains(*i)) {
-      success =
-        success                                         &&
-        traversal_.TraverseRevision(*i, traversal_type) &&
-        RemoveCatalogFromReflog(*i);
+      to_sweep.push_back(*i);
     }
   }
-
+  bool success = traversal_.TraverseList(to_sweep);
   traversal_.UnregisterListener(callback);
+
+  i = to_sweep.begin();
+  iend = to_sweep.end();
+  for (; i != iend; ++i) {
+    success = success && RemoveCatalogFromReflog(*i);
+  }
 
   // TODO(jblomer): turn current counters into perf::Counters
   if (configuration_.statistics) {

--- a/cvmfs/ingestion/tube.h
+++ b/cvmfs/ingestion/tube.h
@@ -66,6 +66,7 @@ class Tube : SingleCopy {
    * Push an item to the back of the queue.  Block if queue is currently full.
    */
   Link *Enqueue(ItemT *item) {
+    assert(item != NULL);
     MutexLockGuard lock_guard(&lock_);
     while (size_ == limit_)
       pthread_cond_wait(&cond_capacious_, &lock_);
@@ -85,6 +86,7 @@ class Tube : SingleCopy {
    * Push an item to the front of the queue. Block if queue currently full.
    */
   Link *EnqueueFront(ItemT *item) {
+    assert(item != NULL);
     MutexLockGuard lock_guard(&lock_);
     while (size_ == limit_)
       pthread_cond_wait(&cond_capacious_, &lock_);

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -41,6 +41,7 @@ ParameterList CommandGc::GetParams() const {
   r.push_back(Parameter::Optional('k', "repository master key(s) / dir"));
   r.push_back(Parameter::Optional('t', "temporary directory"));
   r.push_back(Parameter::Optional('L', "path to deletion log file"));
+  r.push_back(Parameter::Optional('N', "number of threads to use"));
   r.push_back(Parameter::Switch('d', "dry run"));
   r.push_back(Parameter::Switch('l', "list objects to be removed"));
   r.push_back(Parameter::Switch('I', "upload updated statistics DB file"));
@@ -77,6 +78,8 @@ int CommandGc::Main(const ArgumentList &args) {
   const std::string deletion_log_path = (args.count('L') > 0) ?
     *args.find('L')->second : "";
   const bool upload_statsdb = (args.count('I') > 0);
+  const unsigned int num_threads = (args.count('N') > 0) ?
+    String2Uint64(*args.find('N')->second) : 8;
 
   if (revisions < 0) {
     LogCvmfs(kLogCvmfs, kLogStderr,
@@ -159,6 +162,7 @@ int CommandGc::Main(const ArgumentList &args) {
   config.deleted_objects_logfile = deletion_log_file;
   config.statistics              = statistics();
   config.extended_stats          = extended_stats;
+  config.num_threads             = num_threads;
 
   if (deletion_log_file != NULL) {
     const int bytes_written = fprintf(deletion_log_file,

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -23,7 +23,7 @@
 namespace swissknife {
 
 typedef HttpObjectFetcher<> ObjectFetcher;
-typedef CatalogTraversal<ObjectFetcher> ReadonlyCatalogTraversal;
+typedef CatalogTraversalParallel<ObjectFetcher> ReadonlyCatalogTraversal;
 typedef SmallhashFilter HashFilter;
 typedef GarbageCollector<ReadonlyCatalogTraversal, HashFilter> GC;
 typedef GarbageCollectorAux<ReadonlyCatalogTraversal, HashFilter> GCAux;

--- a/cvmfs/swissknife_list_reflog.cc
+++ b/cvmfs/swissknife_list_reflog.cc
@@ -115,7 +115,7 @@ bool CommandListReflog::Run(ObjectFetcherT *object_fetcher, string repo_name,
   const vector<shash::Any>::const_iterator iend = catalogs.end();
   for (; i != iend && success; i++) {
     success &= traversal.TraverseRevision(*i,
-                CatalogTraversal<ObjectFetcherT>::kBreadthFirstTraversal);
+                CatalogTraversal<ObjectFetcherT>::kBreadthFirst);
   }
 
   if (!success) {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(CVMFS_UNITTEST_FILES
   t_history.cc
   t_ingestion.cc
   t_ingestion_stress.cc
+  t_ingestion_tube.cc
   t_json.cc
   t_kvstore.cc
   t_lease_path_util.cc

--- a/test/unittests/t_ingestion_tube.cc
+++ b/test/unittests/t_ingestion_tube.cc
@@ -12,11 +12,17 @@ using namespace std;  // NOLINT
 
 class T_Ingestion_Tube : public ::testing::Test {
  protected:
+  virtual void SetUp() {
+    s1 = "s1";
+    s2 = "s2";
+    s3 = "s3";
+    s4 = "s4";
+  }
   Tube<string> tube_;
-  string s1 = "s1";
-  string s2 = "s2";
-  string s3 = "s3";
-  string s4 = "s4";
+  string s1;
+  string s2;
+  string s3;
+  string s4;
 };
 
 TEST_F(T_Ingestion_Tube, Queue) {

--- a/test/unittests/t_ingestion_tube.cc
+++ b/test/unittests/t_ingestion_tube.cc
@@ -1,0 +1,121 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "gtest/gtest.h"
+
+#include <string>
+
+#include "ingestion/tube.h"
+
+using namespace std;  // NOLINT
+
+class T_Ingestion_Tube : public ::testing::Test {
+ protected:
+  Tube<string> tube_;
+  string s1 = "s1";
+  string s2 = "s2";
+  string s3 = "s3";
+  string s4 = "s4";
+};
+
+TEST_F(T_Ingestion_Tube, Queue) {
+  tube_.Enqueue(&s1);
+  tube_.Enqueue(&s2);
+  EXPECT_EQ(&s1, tube_.Pop());
+  tube_.Enqueue(&s3);
+  tube_.Enqueue(&s2);
+  EXPECT_EQ(3U, tube_.size());
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_EQ(&s3, tube_.Pop());
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_TRUE(tube_.IsEmpty());
+  tube_.Enqueue(&s4);
+  tube_.Enqueue(&s1);
+  EXPECT_EQ(&s4, tube_.Pop());
+  EXPECT_EQ(&s1, tube_.Pop());
+  EXPECT_TRUE(tube_.IsEmpty());
+}
+
+TEST_F(T_Ingestion_Tube, InvertedQueue) {
+  tube_.EnqueueFront(&s1);
+  tube_.EnqueueFront(&s2);
+  EXPECT_EQ(&s1, tube_.PopBack());
+  tube_.EnqueueFront(&s3);
+  tube_.EnqueueFront(&s2);
+  EXPECT_EQ(3U, tube_.size());
+  EXPECT_EQ(&s2, tube_.PopBack());
+  EXPECT_EQ(&s3, tube_.PopBack());
+  EXPECT_EQ(&s2, tube_.PopBack());
+  EXPECT_TRUE(tube_.IsEmpty());
+  tube_.EnqueueFront(&s4);
+  tube_.EnqueueFront(&s1);
+  EXPECT_EQ(&s4, tube_.PopBack());
+  EXPECT_EQ(&s1, tube_.PopBack());
+  EXPECT_TRUE(tube_.IsEmpty());
+}
+
+TEST_F(T_Ingestion_Tube, Stack) {
+  tube_.EnqueueFront(&s1);
+  tube_.EnqueueFront(&s2);
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_EQ(&s1, tube_.Pop());
+  EXPECT_TRUE(tube_.IsEmpty());
+  tube_.EnqueueFront(&s3);
+  tube_.EnqueueFront(&s2);
+  tube_.EnqueueFront(&s4);
+  EXPECT_EQ(&s4, tube_.Pop());
+  tube_.EnqueueFront(&s1);
+  EXPECT_EQ(3U, tube_.size());
+  EXPECT_EQ(&s1, tube_.Pop());
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_EQ(&s3, tube_.Pop());
+  EXPECT_TRUE(tube_.IsEmpty());
+}
+
+TEST_F(T_Ingestion_Tube, InvertedStack) {
+  tube_.Enqueue(&s1);
+  tube_.Enqueue(&s2);
+  EXPECT_EQ(&s2, tube_.PopBack());
+  EXPECT_EQ(&s1, tube_.PopBack());
+  EXPECT_TRUE(tube_.IsEmpty());
+  tube_.Enqueue(&s3);
+  tube_.Enqueue(&s2);
+  tube_.Enqueue(&s4);
+  EXPECT_EQ(&s4, tube_.PopBack());
+  tube_.Enqueue(&s1);
+  EXPECT_EQ(3U, tube_.size());
+  EXPECT_EQ(&s1, tube_.PopBack());
+  EXPECT_EQ(&s2, tube_.PopBack());
+  EXPECT_EQ(&s3, tube_.PopBack());
+  EXPECT_TRUE(tube_.IsEmpty());
+}
+
+TEST_F(T_Ingestion_Tube, Deque) {
+  tube_.Enqueue(&s3);
+  tube_.Enqueue(&s2);
+  tube_.EnqueueFront(&s2);
+  tube_.Enqueue(&s1);
+  tube_.EnqueueFront(&s1);
+  EXPECT_EQ(5U, tube_.size());
+  EXPECT_EQ(&s1, tube_.Pop());
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_EQ(&s1, tube_.PopBack());
+  EXPECT_EQ(&s3, tube_.Pop());
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_TRUE(tube_.IsEmpty());
+}
+
+TEST_F(T_Ingestion_Tube, QueueDeferItem) {
+  tube_.Enqueue(&s1);
+  tube_.Enqueue(&s2);
+  Tube<string>::Link *to_defer = tube_.Enqueue(&s3);
+  tube_.Enqueue(&s4);
+  EXPECT_EQ(&s1, tube_.Pop());
+  EXPECT_EQ(&s3, tube_.Slice(to_defer));
+  tube_.Enqueue(&s3);
+  EXPECT_EQ(&s2, tube_.Pop());
+  EXPECT_EQ(&s4, tube_.Pop());
+  EXPECT_EQ(&s3, tube_.Pop());
+  EXPECT_TRUE(tube_.IsEmpty());
+}


### PR DESCRIPTION
Implement CatalogTraversalParallel, a child of CatalogTraversal
class, which offers the functionality, but traverses the catalog
tree in parallel using multiple threads.
The interface of CatalogTraversalParallel is almost identical to
the one of CatalogTraversal and the two classes can be used almost
interchangeably.

Use CatalogTraversalParallel in garbage collection.