### PR TITLE
Add feature to clone directory subtrees

### DIFF
--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -146,7 +146,11 @@ class AbstractCatalogManager : public SingleCopy {
   bool ListCatalogSkein(const PathString &path,
                         std::vector<PathString> *result_list);
 
-  bool Listing(const PathString &path, DirectoryEntryList *listing);
+  bool Listing(const PathString &path, DirectoryEntryList *listing,
+               const bool expand_symlink);
+  bool Listing(const PathString &path, DirectoryEntryList *listing) {
+    return Listing(path, listing, true);
+  }
   bool Listing(const std::string &path, DirectoryEntryList *listing) {
     PathString p;
     p.Assign(&path[0], path.length());

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -477,7 +477,8 @@ bool AbstractCatalogManager<CatalogT>::LookupXattrs(
  */
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::Listing(const PathString &path,
-                                     DirectoryEntryList *listing)
+                                     DirectoryEntryList *listing,
+                                     const bool expand_symlink)
 {
   EnforceSqliteMemLimit();
   bool result;
@@ -499,7 +500,7 @@ bool AbstractCatalogManager<CatalogT>::Listing(const PathString &path,
   }
 
   perf::Inc(statistics_.n_listing);
-  result = catalog->ListingPath(path, listing);
+  result = catalog->ListingPath(path, listing, expand_symlink);
 
   Unlock();
   return result;

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -328,6 +328,119 @@ void WritableCatalogManager::Clone(const std::string destination,
   this->AddFile(destination_dirent, empty_xattrs, destination_dirname);
 }
 
+
+/**
+ * Copies an entire directory tree from the exisitng from_dir to the
+ * non-existing to_dir. The destination's parent directory must exist. On the
+ * catalog level, the new entries will be identical to the old ones except
+ * for their path hash fields.
+ */
+void WritableCatalogManager::CloneTree(const std::string &from_dir,
+                                       const std::string &to_dir)
+{
+  // Sanitize input paths
+  if (from_dir.empty() || to_dir.empty())
+    PANIC(kLogStderr, "clone tree from or to root impossible");
+
+  const std::string relative_source = MakeRelativePath(from_dir);
+  const std::string relative_dest = MakeRelativePath(to_dir);
+
+  if (HasPrefix(relative_dest, relative_source + "/", false /*ignore_case*/)) {
+    PANIC(kLogStderr,
+          "cannot clone tree into sub directory of source '%s' --> '%s'",
+          from_dir.c_str(), to_dir.c_str());
+  }
+
+  DirectoryEntry source_dirent;
+  if (!LookupPath(relative_source, kLookupSole, &source_dirent)) {
+    PANIC(kLogStderr, "path '%s' cannot be found, aborting", from_dir.c_str());
+  }
+  if (!source_dirent.IsDirectory()) {
+    PANIC(kLogStderr, "CloneTree: source '%s' not a directory, aborting",
+          from_dir.c_str());
+  }
+
+  DirectoryEntry dest_dirent;
+  if (LookupPath(relative_dest, kLookupSole, &dest_dirent)) {
+    PANIC(kLogStderr, "destination '%s' exists, aborting", to_dir.c_str());
+  }
+
+  const std::string dest_parent = GetParentPath(relative_dest);
+  DirectoryEntry dest_parent_dirent;
+  if (!LookupPath(dest_parent, kLookupSole, &dest_parent_dirent)) {
+    PANIC(kLogStderr, "destination '%s' not on a known path, aborting",
+          to_dir.c_str());
+  }
+
+  CloneTreeImpl(PathString(relative_source),
+                dest_parent,
+                NameString(GetFileName(relative_source)));
+}
+
+
+/**
+ * Called from CloneTree(), assumes that from_dir and to_dir are sufficiently
+ * sanitized
+ */
+void WritableCatalogManager::CloneTreeImpl(
+  const PathString &source_dir,
+  const std::string &dest_parent_dir,
+  const NameString &dest_name)
+{
+  DirectoryEntry source_dirent;
+  bool retval = LookupPath(source_dir, kLookupSole, &source_dirent);
+  assert(retval);
+
+  DirectoryEntry dest_dirent(source_dirent);
+  dest_dirent.name_.Assign(dest_name);
+
+  XattrList xattrs;
+  if (source_dirent.HasXattrs()) {
+    retval = LookupXattrs(source_dir, &xattrs);
+    assert(retval);
+  }
+  AddDirectory(dest_dirent, xattrs, dest_parent_dir);
+
+  std::string dest_dir = dest_parent_dir + "/" + dest_name.ToString();
+  if (source_dirent.IsNestedCatalogRoot()) {
+    CreateNestedCatalog(dest_dir);
+  }
+
+  DirectoryEntryList ls;
+  retval = Listing(source_dir, &ls);
+  assert(retval);
+  for (unsigned i = 0; i < ls.size(); ++i) {
+    PathString sub_path(source_dir);
+    sub_path.Append("/", 1);
+    sub_path.Append(ls[i].name().GetChars(), ls[i].name().GetLength());
+
+    if (ls[i].IsDirectory()) {
+      CloneTreeImpl(sub_path, dest_dir, ls[i].name());
+      continue;
+    }
+
+    // We break hard-links during cloning
+    ls[i].set_hardlink_group(0);
+    ls[i].set_linkcount(1);
+
+    xattrs.Clear();
+    if (ls[i].HasXattrs()) {
+      retval = LookupXattrs(sub_path, &xattrs);
+      assert(retval);
+    }
+
+    if (ls[i].IsChunkedFile()) {
+      FileChunkList chunks;
+      retval = ListFileChunks(sub_path, ls[i].hash_algorithm(), &chunks);
+      assert(retval);
+      AddChunkedFile(ls[i], xattrs, dest_dir, chunks);
+    } else {
+      AddFile(ls[i], xattrs, dest_dir);
+    }
+  }
+}
+
+
 /**
  * Add a new directory to the catalogs.
  * @param entry a DirectoryEntry structure describing the new directory
@@ -353,7 +466,6 @@ void WritableCatalogManager::AddDirectory(const DirectoryEntryBase &entry,
 
   DirectoryEntry fixed_hardlink_count(entry);
   fixed_hardlink_count.set_linkcount(2);
-  // No support for extended attributes on directories yet
   catalog->AddEntry(fixed_hardlink_count, xattrs,
                     directory_path, parent_path);
 

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -448,7 +448,9 @@ void WritableCatalogManager::CloneTreeImpl(
 
     if (ls[i].IsChunkedFile()) {
       FileChunkList chunks;
-      retval = ListFileChunks(sub_path, ls[i].hash_algorithm(), &chunks);
+      std::string relative_sub_path = MakeRelativePath(sub_path.ToString());
+      retval = ListFileChunks(
+        PathString(relative_sub_path), ls[i].hash_algorithm(), &chunks);
       assert(retval);
       AddChunkedFile(ls[i], xattrs, dest_dir, chunks);
     } else {

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -113,7 +113,9 @@ class WritableCatalogManager : public SimpleCatalogManager {
                       const XattrList &xattrs,
                       const std::string &directory_path);
   void RemoveDirectory(const std::string &directory_path);
+
   void Clone(const std::string from, const std::string to);
+  void CloneTree(const std::string &from_dir, const std::string &to_dir);
 
   // Hardlink group handling
   void AddHardlinkGroup(const DirectoryEntryBaseList &entries,
@@ -168,6 +170,10 @@ class WritableCatalogManager : public SimpleCatalogManager {
                    DirectoryEntry     *dirent = NULL);
   void DoBalance();
   void FixWeight(WritableCatalog *catalog);
+
+  void CloneTreeImpl(const PathString &source_dir,
+                     const std::string &dest_parent_dir,
+                     const NameString &dest_name);
 
   struct CatalogInfo {
     uint64_t     ttl;

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -38,6 +38,7 @@ class XattrList {
   bool Set(const std::string &key, const std::string &value);
   bool Remove(const std::string &key);
   bool IsEmpty() const { return xattrs_.empty(); }
+  void Clear() { xattrs_.clear(); }
 
   void Serialize(unsigned char **outbuf, unsigned *size,
                  const std::vector<std::string> *blacklist = NULL) const;

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -284,9 +284,11 @@ bool CatalogTestTool::Init() {
 // original,
 //       empty repository.
 bool CatalogTestTool::Apply(const std::string& id, const DirSpec& spec) {
+  statistics_ = new perf::Statistics();
   catalog_mgr_ =
     CreateCatalogMgr(history_.front().second, "file://" + stratum0_,
-                     temp_dir_, spooler_, download_manager(), &statistics_);
+                     temp_dir_, spooler_, download_manager(),
+                     statistics_.weak_ref());
   if (!catalog_mgr_.IsValid()) {
     return false;
   }
@@ -315,9 +317,10 @@ bool CatalogTestTool::ApplyAtRootHash(
   const shash::Any& root_hash,
   const DirSpec& spec
 ) {
+  statistics_ = new perf::Statistics();
   catalog_mgr_ =
     CreateCatalogMgr(root_hash, "file://" + stratum0_, temp_dir_, spooler_,
-                     download_manager(), &statistics_);
+                     download_manager(), statistics_.weak_ref());
   if (!catalog_mgr_.IsValid()) {
     return false;
   }

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -66,9 +66,7 @@ DirSpec::DirSpec() : items_(), dirs_() {
 bool DirSpec::AddFile(const std::string& name, const std::string& parent,
                       const std::string& digest, const size_t size,
                       const XattrList& xattrs, shash::Suffix suffix) {
-  shash::Any hash = shash::Any(
-      shash::kSha1, reinterpret_cast<const unsigned char*>(digest.c_str()),
-      suffix);
+  shash::Any hash = shash::MkFromHexPtr(shash::HexPtr(digest), suffix);
   if (!HasDir(parent)) {
     return false;
   }
@@ -260,7 +258,6 @@ bool CatalogTestTool::Init() {
     return false;
   }
 
-  perf::Statistics stats;
   manifest_ = CreateRepository(temp_dir_, spooler_);
 
   if (!manifest_.IsValid()) {
@@ -287,12 +284,10 @@ bool CatalogTestTool::Init() {
 // original,
 //       empty repository.
 bool CatalogTestTool::Apply(const std::string& id, const DirSpec& spec) {
-  perf::Statistics stats;
-  UniquePtr<catalog::WritableCatalogManager> catalog_mgr(
-      CreateCatalogMgr(history_.front().second, "file://" + stratum0_,
-                       temp_dir_, spooler_, download_manager(), &stats));
-
-  if (!catalog_mgr.IsValid()) {
+  catalog_mgr_ =
+    CreateCatalogMgr(history_.front().second, "file://" + stratum0_,
+                     temp_dir_, spooler_, download_manager(), &statistics_);
+  if (!catalog_mgr_.IsValid()) {
     return false;
   }
 
@@ -300,14 +295,14 @@ bool CatalogTestTool::Apply(const std::string& id, const DirSpec& spec) {
        it != spec.items().end(); ++it) {
     const DirSpecItem& item = it->second;
     if (item.entry_.IsRegular() || item.entry_.IsLink()) {
-      catalog_mgr->AddFile(item.entry_base(), item.xattrs(), item.parent());
+      catalog_mgr_->AddFile(item.entry_base(), item.xattrs(), item.parent());
     } else if (item.entry_.IsDirectory()) {
-      catalog_mgr->AddDirectory(
+      catalog_mgr_->AddDirectory(
         item.entry_base(), item.xattrs(), item.parent());
     }
   }
 
-  if (!catalog_mgr->Commit(false, 0, manifest_)) {
+  if (!catalog_mgr_->Commit(false, 0, manifest_)) {
     return false;
   }
 
@@ -320,12 +315,10 @@ bool CatalogTestTool::ApplyAtRootHash(
   const shash::Any& root_hash,
   const DirSpec& spec
 ) {
-  perf::Statistics stats;
-  UniquePtr<catalog::WritableCatalogManager> catalog_mgr(
-      CreateCatalogMgr(root_hash, "file://" + stratum0_, temp_dir_, spooler_,
-                       download_manager(), &stats));
-
-  if (!catalog_mgr.IsValid()) {
+  catalog_mgr_ =
+    CreateCatalogMgr(root_hash, "file://" + stratum0_, temp_dir_, spooler_,
+                     download_manager(), &statistics_);
+  if (!catalog_mgr_.IsValid()) {
     return false;
   }
 
@@ -333,9 +326,9 @@ bool CatalogTestTool::ApplyAtRootHash(
        it != spec.items().end(); ++it) {
     const DirSpecItem& item = it->second;
     if (item.entry_.IsRegular() || item.entry_.IsLink()) {
-      catalog_mgr->AddFile(item.entry_base(), item.xattrs(), item.parent());
+      catalog_mgr_->AddFile(item.entry_base(), item.xattrs(), item.parent());
     } else if (item.entry_.IsDirectory()) {
-      catalog_mgr->AddDirectory(
+      catalog_mgr_->AddDirectory(
         item.entry_base(), item.xattrs(), item.parent());
     }
   }
@@ -343,10 +336,10 @@ bool CatalogTestTool::ApplyAtRootHash(
   DirSpec::NestedCatalogList::const_iterator it;
   for (it = spec.nested_catalogs().begin();
        it != spec.nested_catalogs().end(); ++it) {
-    catalog_mgr->CreateNestedCatalog(*it);
+    catalog_mgr_->CreateNestedCatalog(*it);
   }
 
-  if (!catalog_mgr->Commit(false, 0, manifest_)) {
+  if (!catalog_mgr_->Commit(false, 0, manifest_)) {
     return false;
   }
 

--- a/test/common/catalog_test_tools.h
+++ b/test/common/catalog_test_tools.h
@@ -5,6 +5,7 @@
 #ifndef TEST_COMMON_CATALOG_TEST_TOOLS_H_
 #define TEST_COMMON_CATALOG_TEST_TOOLS_H_
 
+#include <cassert>
 #include <map>
 #include <set>
 #include <string>
@@ -154,6 +155,14 @@ class CatalogTestTool : public ServerTool {
 
   std::string repo_name() { return stratum0_; }
   std::string public_key() { return public_key_; }
+  catalog::WritableCatalogManager *catalog_mgr() {
+    assert(catalog_mgr_.IsValid());
+    return catalog_mgr_.weak_ref();
+  }
+
+  // Necessary for libcvmfs unit tests in order to avoid clash of sqlite
+  // configurations
+  void DestroyCatalogManager() { catalog_mgr_.Destroy(); }
 
  private:
   static upload::Spooler* CreateSpooler(const std::string& config);
@@ -179,9 +188,10 @@ class CatalogTestTool : public ServerTool {
   std::string public_key_;
   std::string temp_dir_;
 
+  perf::Statistics statistics_;
   UniquePtr<manifest::Manifest> manifest_;
-  UniquePtr<catalog::WritableCatalogManager> catalog_mgr_;
   UniquePtr<upload::Spooler> spooler_;
+  UniquePtr<catalog::WritableCatalogManager> catalog_mgr_;
   History history_;
 };
 

--- a/test/common/catalog_test_tools.h
+++ b/test/common/catalog_test_tools.h
@@ -188,7 +188,7 @@ class CatalogTestTool : public ServerTool {
   std::string public_key_;
   std::string temp_dir_;
 
-  perf::Statistics statistics_;
+  UniquePtr<perf::Statistics> statistics_;
   UniquePtr<manifest::Manifest> manifest_;
   UniquePtr<upload::Spooler> spooler_;
   UniquePtr<catalog::WritableCatalogManager> catalog_mgr_;

--- a/test/common/testutil.cc
+++ b/test/common/testutil.cc
@@ -363,7 +363,8 @@ bool MockCatalog::LookupPath(const PathString &path,
 }
 
 bool MockCatalog::ListingPath(const PathString &path,
-                 catalog::DirectoryEntryList *listing) const {
+                 catalog::DirectoryEntryList *listing,
+                 const bool /* expand_symlink */) const {
   unsigned initial_size = listing->size();
   shash::Md5 path_hash(path.GetChars(), path.GetLength());
   for (unsigned i = 0; i < files_.size(); ++i) {

--- a/test/common/testutil.h
+++ b/test/common/testutil.h
@@ -458,7 +458,8 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
   bool LookupPath(const PathString &path,
                   catalog::DirectoryEntry *dirent) const;
   bool ListingPath(const PathString &path,
-                   catalog::DirectoryEntryList *listing) const;
+                   catalog::DirectoryEntryList *listing,
+                   const bool expand_symlink) const;
 
   bool GetVOMSAuthz(std::string *authz) { return false; }
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(CVMFS_UNITTEST_FILES
   t_catalog_counters.cc
   t_catalog_merge_tool.cc
   t_catalog_mgr.cc
+  t_catalog_mgr_rw.cc
   t_catalog_sql.cc
   t_catalog_traversal.cc
   t_catalog_virtual.cc

--- a/test/unittests/t_catalog_merge_tool.cc
+++ b/test/unittests/t_catalog_merge_tool.cc
@@ -11,12 +11,12 @@
 #include "xattr.h"
 
 namespace {
-const char* hashes[] = {"b026324c6904b2a9cb4b88d6d61c81d1000000",
-                        "26ab0db90d72e28ad0ba1e22ee510510000000",
-                        "6d7fce9fee471194aa8b5b6e47267f03000000",
-                        "48a24b70a0b376535542b996af517398000000",
-                        "1dcca23355272056f04fe8bf20edfce0000000",
-                        "11111111111111111111111111111111111111"};
+const char* hashes[] = {"b026324c6904b2a9cb4b88d6d61c81d100000000",
+                        "26ab0db90d72e28ad0ba1e22ee51051000000000",
+                        "6d7fce9fee471194aa8b5b6e47267f0300000000",
+                        "48a24b70a0b376535542b996af51739800000000",
+                        "1dcca23355272056f04fe8bf20edfce000000000",
+                        "1111111111111111111111111111111111111111"};
 
 DirSpec MakeBaseSpec() {
   DirSpec spec;

--- a/test/unittests/t_catalog_mgr_rw.cc
+++ b/test/unittests/t_catalog_mgr_rw.cc
@@ -1,0 +1,121 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "catalog_mgr_rw.h"
+#include "catalog_test_tools.h"
+#include "download.h"
+#include "statistics.h"
+#include "upload.h"
+
+using namespace std;  // NOLINT
+
+namespace {
+
+// Create some default hashes for DirSpec
+const char* g_hashes[] = {"b026324c6904b2a9cb4b88d6d61c81d100000000",
+                          "26ab0db90d72e28ad0ba1e22ee51051000000000",
+                          "6d7fce9fee471194aa8b5b6e47267f0300000000",
+                          "48a24b70a0b376535542b996af51739800000000",
+                          "1dcca23355272056f04fe8bf20edfce000000000",
+                          "1111111111111111111111111111111111111111"};
+
+const size_t g_file_size = 4096;
+
+// Create directory specification for later repositories
+DirSpec MakeBaseSpec() {
+  DirSpec spec;
+
+  // adding "/dir"
+  EXPECT_TRUE(spec.AddDirectory("dir", "", g_file_size));
+
+  // adding "/dir/file1"
+  EXPECT_TRUE(spec.AddFile("file1", "dir", g_hashes[0], g_file_size));
+
+  // adding "/dir/dir"
+  EXPECT_TRUE(spec.AddDirectory("dir",  "dir", g_file_size));
+  EXPECT_TRUE(spec.AddDirectory("dir2", "dir", g_file_size));
+  EXPECT_TRUE(spec.AddDirectory("dir3", "dir", g_file_size));
+
+  // adding "/file3"
+  EXPECT_TRUE(spec.AddFile("file3", "", g_hashes[2], g_file_size));
+
+  // adding "/dir/dir/file2"
+  EXPECT_TRUE(spec.AddFile("file2", "dir/dir", g_hashes[1], g_file_size));
+
+  // adding "/dir/dir2/file2"
+  EXPECT_TRUE(spec.AddFile("file2", "dir/dir2", g_hashes[3], g_file_size));
+
+  // adding "/dir/dir3/file2"
+  EXPECT_TRUE(spec.AddFile("file2", "dir/dir3", g_hashes[4], g_file_size));
+
+  // Adding Deeply nested catalog
+  EXPECT_TRUE(spec.AddDirectory("dir",  "dir/dir", g_file_size));
+  EXPECT_TRUE(spec.AddDirectory("dir",  "dir/dir/dir", g_file_size));
+  EXPECT_TRUE(
+    spec.AddFile("file1",  "dir/dir/dir/dir", g_hashes[0], g_file_size));
+  EXPECT_TRUE(spec.AddNestedCatalog("dir/dir/dir"));
+
+  return spec;
+}
+
+}  // anonymous namespace
+
+
+namespace catalog {
+
+class T_CatalogMgrRw : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+};
+
+
+
+TEST_F(T_CatalogMgrRw, CloneTreeFailSlow) {
+  CatalogTestTool tester("clone_tree_fail_slow");
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+
+  catalog::WritableCatalogManager *catalog_mgr = tester.catalog_mgr();
+  EXPECT_DEATH(catalog_mgr->CloneTree("", ""), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("", "clone"), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("dir", ""), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("dir", "dir"), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("dir", "dir/clone"), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("void", "clone"), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("dir/file1", "clone"), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("dir", "void/clone"), ".*");
+  EXPECT_DEATH(catalog_mgr->CloneTree("dir/dir", "dir/dir2"), ".*");
+}
+
+
+TEST_F(T_CatalogMgrRw, CloneTree) {
+  CatalogTestTool tester("clone_tree");
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+
+  catalog::WritableCatalogManager *catalog_mgr = tester.catalog_mgr();
+  catalog_mgr->CloneTree("dir", "clone");
+
+  DirectoryEntry dirent;
+  EXPECT_TRUE(catalog_mgr->LookupPath("/clone/dir/dir/dir/file1",
+                                      kLookupSole, &dirent));
+  EXPECT_STREQ(g_hashes[0], dirent.checksum().ToString().c_str());
+  EXPECT_EQ(g_file_size, dirent.size());
+
+  EXPECT_TRUE(catalog_mgr->LookupPath("/clone/dir/dir",
+                                      kLookupSole, &dirent));
+  EXPECT_TRUE(dirent.IsNestedCatalogRoot());
+}
+
+}  // namespace catalog

--- a/test/unittests/t_dns.cc
+++ b/test/unittests/t_dns.cc
@@ -639,7 +639,7 @@ TEST_F(T_Dns, CaresResolverMany) {
   names.push_back("l.root-servers.net");
   names.push_back("m.root-servers.net");
   names.push_back("127.0.0.1");
-  names.push_back("nemo.root-servers.net");
+  names.push_back("nemo.example.com");
   vector<Host> hosts;
   default_resolver->ResolveMany(names, &hosts);
   ASSERT_EQ(hosts.size(), names.size());

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -278,12 +278,12 @@ TEST_F(T_Libcvmfs, TemplatingSlow) {
 
 namespace {
 // Create some default hashes for DirSpec
-const char* g_hashes[] = {"b026324c6904b2a9cb4b88d6d61c81d1000000",
-                         "26ab0db90d72e28ad0ba1e22ee510510000000",
-                         "6d7fce9fee471194aa8b5b6e47267f03000000",
-                         "48a24b70a0b376535542b996af517398000000",
-                         "1dcca23355272056f04fe8bf20edfce0000000",
-                         "11111111111111111111111111111111111111"};
+const char* g_hashes[] = {"b026324c6904b2a9cb4b88d6d61c81d100000000",
+                          "26ab0db90d72e28ad0ba1e22ee51051000000000",
+                          "6d7fce9fee471194aa8b5b6e47267f0300000000",
+                          "48a24b70a0b376535542b996af51739800000000",
+                          "1dcca23355272056f04fe8bf20edfce000000000",
+                          "1111111111111111111111111111111111111111"};
 
 const size_t g_file_size = 4096;
 }  // anonymous namespace
@@ -336,6 +336,7 @@ TEST_F(T_Libcvmfs, Stat) {
   // Create file structure
   DirSpec spec1 = MakeBaseSpec();
   EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+  tester.DestroyCatalogManager();
 
   // Find directory entry for use later
   catalog::DirectoryEntry entry;
@@ -395,6 +396,7 @@ TEST_F(T_Libcvmfs, Attr) {
   DirSpec spec = MakeBaseSpec();
   EXPECT_TRUE(spec.LinkFile("link", "dir", "file1", g_file_size));
   EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+  tester.DestroyCatalogManager();
 
   // Find directory entry for use later
   catalog::DirectoryEntry entry;
@@ -485,6 +487,7 @@ TEST_F(T_Libcvmfs, Listdir) {
 
   // Apply the created DirSpec
   EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+  tester.DestroyCatalogManager();
 
   // Set CVMFS options to reflect created repository
   cvmfs_options_set(opts,
@@ -544,6 +547,7 @@ TEST_F(T_Libcvmfs, StatNestedCatalog) {
 
   // Apply the created DirSpec
   EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+  tester.DestroyCatalogManager();
   char *d0_hash = strdup(tester.manifest()->catalog_hash().ToString().c_str());
 
   // Find the hash of the newly added Nested Catalog for comparison
@@ -629,6 +633,7 @@ TEST_F(T_Libcvmfs, ListNestedCatalogs) {
   // Apply created DirSpec
   EXPECT_TRUE(
     tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+  tester.DestroyCatalogManager();
 
   // Set CVMFS options to reflect created repository
   cvmfs_options_set(opts,


### PR DESCRIPTION
Adds a `CloneTree()` method to the catalog manager that can copy an entire subtree to a new location. This is a meta-data only operation.  A first test with cloning /cvmfs/cms.cern.ch/slc7_ppc64le_gcc530 results in at least 50k file system entries per second.

Cloning is supposed to provide the core functionality for "fast flattening" of container images. Given that the chain directory for layers 1..n-1 already exists, one can create the chain for layers 1..n by cloning the chain[1..n-1] and then publishing only the last delta layer. See CVM-1801