### PR TITLE
Ducc temp directory

### DIFF
--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -19,13 +19,14 @@ var (
 )
 
 var (
-	convertAgain, overwriteLayer, convertSingularity bool
+	convertAgain, overwriteLayer, convertDocker, convertSingularity bool
 )
 
 func init() {
 	convertCmd.Flags().BoolVarP(&overwriteLayer, "overwrite-layers", "f", false, "overwrite the layer if they are already inside the CVMFS repository")
 	convertCmd.Flags().BoolVarP(&convertAgain, "convert-again", "g", false, "convert again images that are already successfull converted")
 	convertCmd.Flags().BoolVarP(&convertSingularity, "convert-singularity", "s", true, "also create a singularity images")
+	convertCmd.Flags().BoolVarP(&convertDocker, "convert-docker", "d", true, "unpacking the layers into the repository")
 	rootCmd.AddCommand(convertCmd)
 }
 
@@ -67,9 +68,11 @@ var convertCmd = &cobra.Command{
 				"repository":   wish.CvmfsRepo,
 				"output image": wish.OutputName}
 			lib.Log().WithFields(fields).Info("Start conversion of wish")
-			err = lib.ConvertWishDocker(wish, convertAgain, overwriteLayer)
-			if err != nil {
-				lib.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
+			if convertDocker {
+				err = lib.ConvertWishDocker(wish, convertAgain, overwriteLayer)
+				if err != nil {
+					lib.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
+				}
 			}
 			if convertSingularity {
 				err = lib.ConvertWishSingularity(wish)

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -16,6 +16,7 @@ func init() {
 	loopCmd.Flags().BoolVarP(&overwriteLayer, "overwrite-layers", "f", false, "overwrite the layer if they are already inside the CVMFS repository")
 	loopCmd.Flags().BoolVarP(&convertAgain, "convert-again", "g", false, "convert again images that are already successfull converted")
 	loopCmd.Flags().BoolVarP(&convertSingularity, "convert-singularity", "s", true, "also create a singularity images")
+	loopCmd.Flags().BoolVarP(&convertDocker, "convert-docker", "d", true, "unpacking the layers into the repository")
 	rootCmd.AddCommand(loopCmd)
 }
 
@@ -65,9 +66,11 @@ var loopCmd = &cobra.Command{
 					"repository":   wish.CvmfsRepo,
 					"output image": wish.OutputName}
 				lib.Log().WithFields(fields).Info("Start conversion of wish")
-				err = lib.ConvertWishDocker(wish, convertAgain, overwriteLayer)
-				if err != nil {
-					lib.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
+				if convertDocker {
+					err = lib.ConvertWishDocker(wish, convertAgain, overwriteLayer)
+					if err != nil {
+						lib.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
+					}
 				}
 				if convertSingularity {
 					err = lib.ConvertWishSingularity(wish)

--- a/ducc/cmd/root.go
+++ b/ducc/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -10,6 +11,9 @@ import (
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&lib.TemporaryBaseDir, "temporary-dir", "t", "", "Temporary directory to store files necessary during the conversion of images, it can grow large ~1G. If not set we use the standard of the system $TMP, usually /tmp")
+	if lib.TemporaryBaseDir == "" {
+		lib.TemporaryBaseDir = os.Getenv("DUCC_TMP_DIR")
+	}
 }
 
 var rootCmd = &cobra.Command{

--- a/ducc/cmd/root.go
+++ b/ducc/cmd/root.go
@@ -8,6 +8,10 @@ import (
 	"github.com/cvmfs/ducc/lib"
 )
 
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&lib.TemporaryBaseDir, "temporary-dir", "t", "", "Temporary directory to store files necessary during the conversion of images, it can grow large ~1G. If not set we use the standard of the system $TMP, usually /tmp")
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "repository-manager",
 	Short: "Show the several commands available.",

--- a/ducc/go.mod
+++ b/ducc/go.mod
@@ -40,3 +40,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+go 1.13

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -33,11 +33,12 @@ const (
 var subDirInsideRepo = ".layers"
 
 func ConvertWishSingularity(wish WishFriendly) (err error) {
-	tmpDir, err := ioutil.TempDir("", "conversion")
+	tmpDir, err := UserDefinedTempDir("", "conversion")
 	if err != nil {
 		LogE(err).Error("Error when creating tmp singularity directory")
 		return
 	}
+	defer os.RemoveAll(tmpDir)
 	inputImage, err := ParseImage(wish.InputName)
 	var singularity Singularity
 	singularity, err = inputImage.DownloadSingularityDirectory(tmpDir)
@@ -209,7 +210,7 @@ func ConvertWishDocker(wish WishFriendly, convertAgain, forceDownload bool) (err
 		Log().Info("Finished pushing the layers into CVMFS")
 	}()
 	// we create a temp directory for all the files needed, when this function finish we can remove the temp directory cleaning up
-	tmpDir, err := ioutil.TempDir("", "conversion")
+	tmpDir, err := UserDefinedTempDir("", "conversion")
 	if err != nil {
 		LogE(err).Error("Error in creating a temporary direcotry for all the files")
 		return

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -40,13 +40,12 @@ func ConvertWishSingularity(wish WishFriendly) (err error) {
 	}
 	defer os.RemoveAll(tmpDir)
 	inputImage, err := ParseImage(wish.InputName)
-	var singularity Singularity
-	singularity, err = inputImage.DownloadSingularityDirectory(tmpDir)
+	singularity, err := inputImage.DownloadSingularityDirectory(tmpDir)
+	defer os.RemoveAll(singularity.TempDirectory)
 	if err != nil {
 		LogE(err).Error("Error in dowloading the singularity image")
 		return
 	}
-	defer os.RemoveAll(singularity.TempDirectory)
 
 	err = singularity.IngestIntoCVMFS(wish.CvmfsRepo)
 	if err != nil {

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -241,10 +241,8 @@ func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity
 	if err != nil {
 		LogE(err).Error("Error in creating temporary directory for singularity")
 		return
-
 	}
-	defer os.RemoveAll(dir)
-	singularityTempCache, err := UserDefinedTempDir("", "tempDirSingularityCache")
+	singularityTempCache, err := UserDefinedTempDir(rootPath, "tempDirSingularityCache")
 	if err != nil {
 		LogE(err).Error("Error in creating temporary directory for singularity cache")
 		return

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -237,13 +237,14 @@ type Singularity struct {
 }
 
 func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity, err error) {
-	dir, err := ioutil.TempDir(rootPath, "singularity_buffer")
+	dir, err := UserDefinedTempDir(rootPath, "singularity_buffer")
 	if err != nil {
 		LogE(err).Error("Error in creating temporary directory for singularity")
 		return
 
 	}
-	singularityTempCache, err := ioutil.TempDir("", "tempDirSingularityCache")
+	defer os.RemoveAll(dir)
+	singularityTempCache, err := UserDefinedTempDir("", "tempDirSingularityCache")
 	if err != nil {
 		LogE(err).Error("Error in creating temporary directory for singularity cache")
 		return

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -248,7 +248,7 @@ func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity
 		return
 	}
 	defer os.RemoveAll(singularityTempCache)
-	err = ExecCommand("singularity", "build", "--force", "--sandbox", dir, img.GetSingularityLocation()).Env(
+	err = ExecCommand("singularity", "build", "--force", "--fix-perms", "--sandbox", dir, img.GetSingularityLocation()).Env(
 		"SINGULARITY_CACHEDIR", singularityTempCache).Env("PATH", os.Getenv("PATH")).Start()
 	if err != nil {
 		LogE(err).Error("Error in downloading the singularity image")

--- a/ducc/lib/utils.go
+++ b/ducc/lib/utils.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"io/ioutil"
 	"path"
+	"strings"
 )
 
 // this flag is populated in the main `rootCmd` (cmd/root.go)
@@ -11,5 +12,8 @@ var (
 )
 
 func UserDefinedTempDir(dir, prefix string) (name string, err error) {
+	if strings.HasPrefix(dir, TemporaryBaseDir) {
+		return ioutil.TempDir(dir, prefix)
+	}
 	return ioutil.TempDir(path.Join(TemporaryBaseDir, dir), prefix)
 }

--- a/ducc/lib/utils.go
+++ b/ducc/lib/utils.go
@@ -1,0 +1,15 @@
+package lib
+
+import (
+	"io/ioutil"
+	"path"
+)
+
+// this flag is populated in the main `rootCmd` (cmd/root.go)
+var (
+	TemporaryBaseDir string
+)
+
+func UserDefinedTempDir(dir, prefix string) (name string, err error) {
+	return ioutil.TempDir(path.Join(TemporaryBaseDir, dir), prefix)
+}

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -234,6 +234,7 @@ CernVM-FS unit tests binary.  This RPM is not required except for testing.
 Summary: ducc: Daemon Unpacking Containers in CVMFS
 Group: Application/System
 BuildRequires: golang >= 1.11.4
+Requires: singularity >= 3.5
 %description ducc
 Daemon to automatically unpack and expose containers images into CernVM-FS
 %endif

--- a/test/src/400-ducc-ingest_images/main
+++ b/test/src/400-ducc-ingest_images/main
@@ -140,13 +140,11 @@ EOL
 CVMFS_REPOSITORIES=$CVMFS_TEST400_REPOSITORY
 CVMFS_HTTP_PROXY="DIRECT"
 EOL'
-    #sudo chown $USER /etc/cvmfs/default.local
 
     sudo -E CVMFS_TEST400_REPOSITORY="$CVMFS_TEST400_REPOSITORY" bash -c 'cat > /etc/cvmfs/config.d/$CVMFS_TEST400_REPOSITORY.local << EOL
 CVMFS_SERVER_URL=http://localhost/cvmfs/$CVMFS_TEST400_REPOSITORY/
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/$CVMFS_TEST400_REPOSITORY.pub
 EOL'
-    #sudo chown $USER /etc/cvmfs/config.d/$CVMFS_TEST400_REPOSITORY.local
     echo "done"
 
     # start by running the docker registry on localhost

--- a/test/src/400-ducc-ingest_images/main
+++ b/test/src/400-ducc-ingest_images/main
@@ -23,10 +23,10 @@ ducc_test_400_clean_up() {
     rm $CVMFS_TEST400_DUCC_LOG
     rm $CVMFS_TEST400_DUCC_ERR
 
-    rm /etc/cvmfs/default.local
+    sudo rm /etc/cvmfs/default.local
     if [ -f /etc/cvmfs/default.local.bk ]
     then
-        mv /etc/cvmfs/default.local.bk /etc/cvmfs/default.local
+        sudo mv /etc/cvmfs/default.local.bk /etc/cvmfs/default.local
     fi
 
     # stop and delete the registry container
@@ -47,15 +47,17 @@ ducc_test_400_clean_up() {
 
     if [ $CVMFS_TEST400_DISABLE_STORAGE -eq 1 ]
     then
-	mv -f /etc/docker/daemon.json.bk /etc/docker/daemon.json
-    fi
-    
-    if [ $CVMFS_TEST400_REMOVE_JSON -eq 1 ]
-    then
-	rm /etc/docker/daemon.json
+	sudo mv -f /etc/docker/daemon.json.bk /etc/docker/daemon.json
     fi
 
-    systemctl restart docker.service
+    if [ $CVMFS_TEST400_REMOVE_JSON -eq 1 ]
+    then
+	sudo rm /etc/docker/daemon.json
+    fi
+
+    sudo systemctl restart docker.service
+
+    sudo cvmfs_server rmfs -f $CVMFS_TEST_USER
 
     echo "done"
 }
@@ -89,14 +91,14 @@ cvmfs_run_test() {
 	if [ ! -f /etc/docker/daemon.json ]
 	then
 	    CVMFS_TEST400_REMOVE_JSON=1
-            mkdir -p /etc/docker
-	    touch /etc/docker/daemon.json
+            sudo mkdir -p /etc/docker
+	    sudo touch /etc/docker/daemon.json
 	fi
 
-	mv /etc/docker/daemon.json /etc/docker/daemon.json.bk
+	sudo mv /etc/docker/daemon.json /etc/docker/daemon.json.bk
 
 	# change configuration file
-        cat > /etc/docker/daemon.json << EOL
+        sudo bash -c 'cat > /etc/docker/daemon.json << EOL
 {
   "experimental": true,
   "storage-driver": "cvmfs/graphdriver",
@@ -104,11 +106,11 @@ cvmfs_run_test() {
     "overlay2.override_kernel_check=true"
   ]
 }
-EOL
+EOL'
     fi
 
-    systemctl restart docker.service || return 151
-        
+    sudo systemctl restart docker.service || return 151
+
     # create a simple recipe file for the repository manager in the local dir
     echo -n "*** Creating recipe file..."
     cat > $CVMFS_TEST400_RECIPE  << EOL
@@ -129,20 +131,22 @@ EOL
     echo -n "*** Creating CVMFS repo..."
     create_empty_repo $CVMFS_TEST400_REPOSITORY $USER || return $?
     echo "done"
-   
+
     echo -n "*** Changing configuration to read the new repo..."
     # setting the configuration for the repo
-    mv /etc/cvmfs/default.local /etc/cvmfs/default.local.bk
- 
-    cat > /etc/cvmfs/default.local << EOL
+    sudo mv /etc/cvmfs/default.local /etc/cvmfs/default.local.bk
+
+    sudo -E CVMFS_TEST400_REPOSITORY="$CVMFS_TEST400_REPOSITORY" bash -c 'cat > /etc/cvmfs/default.local << EOL
 CVMFS_REPOSITORIES=$CVMFS_TEST400_REPOSITORY
 CVMFS_HTTP_PROXY="DIRECT"
-EOL
+EOL'
+    #sudo chown $USER /etc/cvmfs/default.local
 
-    cat > /etc/cvmfs/config.d/$CVMFS_TEST400_REPOSITORY.local << EOL
+    sudo -E CVMFS_TEST400_REPOSITORY="$CVMFS_TEST400_REPOSITORY" bash -c 'cat > /etc/cvmfs/config.d/$CVMFS_TEST400_REPOSITORY.local << EOL
 CVMFS_SERVER_URL=http://localhost/cvmfs/$CVMFS_TEST400_REPOSITORY/
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/$CVMFS_TEST400_REPOSITORY.pub
-EOL
+EOL'
+    #sudo chown $USER /etc/cvmfs/config.d/$CVMFS_TEST400_REPOSITORY.local
     echo "done"
 
     # start by running the docker registry on localhost
@@ -166,19 +170,19 @@ EOL
 
     echo "*** Check integrity of the repository..."
     check_repository $CVMFS_TEST400_REPOSITORY -i || return 102
-    
+
     echo "*** Repository checked successfully"
 
     singularity exec /cvmfs/$CVMFS_TEST400_REPOSITORY/registry.hub.docker.com/library/ubuntu\:latest/ echo token-abc | grep "token-abc" || return 103
     singularity exec /cvmfs/$CVMFS_TEST400_REPOSITORY/registry.hub.docker.com/library/centos\:centos6/ echo token-xyz | grep "token-xyz" || return 104
-    
+
     echo "*** Singularity conversion worked fine"
 
-    systemctl restart docker.service || return 111
+    sudo systemctl restart docker.service || return 111
 
     docker run "localhost:5000/mock/library/ubuntu:latest" /bin/echo "token-123" | grep "token-123" || return 105
     docker run "localhost:5000/mock/library/centos:centos6" /bin/echo "token-321" | grep "token-321" || return 106
-    
+
     echo "*** Docker conversion worked fine"
 
     # add other possible tests

--- a/test/src/401-ducc-convert_singularity/main
+++ b/test/src/401-ducc-convert_singularity/main
@@ -4,10 +4,15 @@ cvmfs_test_suites="ducc"
 
 DOCKER_TEST_IMAGE="https://registry.hub.docker.com/library/centos:centos7"
 
+ducc_test_401_clean_up() {
+  sudo cvmfs_server rmfs -f $CVMFS_TEST_REPO
+}
 
 cvmfs_run_test() {
+  trap ducc_test_401_clean_up EXIT HUP INT TERM
+
   echo "*** creating empty repo ***"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
+  create_empty_repo $CVMFS_TEST_REPO $USER || return 1
 
   echo "*** converting image to singularity ***"
   cvmfs_ducc convert-singularity-image -r $CVMFS_TEST_REPO $DOCKER_TEST_IMAGE || return 2

--- a/test/src/402-ducc-ingest-temp-dir/main
+++ b/test/src/402-ducc-ingest-temp-dir/main
@@ -1,0 +1,98 @@
+cvmfs_test_name="DUCC container ingestion"
+cvmfs_test_autofs_on_startup=true
+cvmfs_test_suites="ducc"
+
+CVMFS_TEST402_REGISTRY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+CVMFS_TEST402_RECIPE="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).yaml"
+CVMFS_TEST402_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).cern.ch"
+CVMFS_TEST402_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
+
+CVMFS_TEST402_TMP_DIR="$(mktemp -d $(pwd)/temp402.XXXXX)"
+
+
+ducc_test_400_clean_up() {
+    echo -n "Cleaning up..."
+
+    export DUCC_DOCKER_REGISTRY_PASS=""
+
+    # delete the recipe file
+    rm $CVMFS_TEST402_RECIPE
+    # delete the logs and error from ducc
+    rm $CVMFS_TEST402_DUCC_ERR
+    rm -r $CVMFS_TEST402_TMP_DIR
+
+    # stop and delete the registry container
+    echo -n "Stopping and deleting docker registry..."
+    docker stop $CVMFS_TEST402_REGISTRY >> /dev/null
+    docker rm $CVMFS_TEST402_REGISTRY >> /dev/null
+    echo "done"
+
+    sudo cvmfs_server rmfs -f $CVMFS_TEST_USER
+
+    echo "done"
+}
+
+cvmfs_run_test() {
+    trap ducc_test_400_clean_up EXIT HUP INT TERM
+
+    # create a simple recipe file for the repository manager in the local dir
+    echo -n "*** Creating recipe file..."
+    cat > $CVMFS_TEST402_RECIPE  << EOL
+version: 1
+user: mock_user
+cvmfs_repo: '$CVMFS_TEST402_REPOSITORY'
+output_format: '\$(scheme)://localhost:5000/mock/\$(image)'
+input:
+    - 'https://registry.hub.docker.com/library/ubuntu:latest'
+    - 'https://registry.hub.docker.com/library/centos:centos6'
+EOL
+    echo "done"
+
+    # set the password to access the docker hub
+    export DUCC_DOCKER_REGISTRY_PASS=mock_pass
+
+    # crete the repository where to store the content
+    echo -n "*** Creating CVMFS repo..."
+    create_empty_repo $CVMFS_TEST402_REPOSITORY $USER || return $?
+    echo "done"
+    
+    # start by running the docker registry on localhost
+    echo -n "*** Starting docker registry for tests..."
+    docker run -d -p 5000:5000 --name $CVMFS_TEST402_REGISTRY registry:2 >> /dev/null || return 3
+    echo "done"
+
+    echo "*** Starting test."
+
+    echo "*** Converting recipe..."
+    echo "cvmfs_ducc --temporary-dir $CVMFS_TEST402_TMP_DIR convert $CVMFS_TEST402_RECIPE 2> $CVMFS_TEST402_DUCC_ERR"
+    cvmfs_ducc --temporary-dir $CVMFS_TEST402_TMP_DIR convert $CVMFS_TEST402_RECIPE 2> $CVMFS_TEST402_DUCC_ERR || return 101
+    grep -q "level=error" $CVMFS_TEST402_DUCC_ERR
+    while [ $? -ne 1 ]
+    do
+        echo -n "*** Some error during conversion, let's do it again. Converting recipe..."
+        rm $CVMFS_TEST402_DUCC_ERR
+        cvmfs_ducc convert $CVMFS_TEST402_RECIPE 2> $CVMFS_TEST402_DUCC_ERR || return 101
+        grep -q "level=error" $CVMFS_TEST402_DUCC_ERR
+    done
+    echo "*** Convert recipe successfully"
+
+    echo "*** Check integrity of the repository..."
+    check_repository $CVMFS_TEST402_REPOSITORY -i || return 102
+
+    echo "*** Repository checked successfully"
+
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/registry.hub.docker.com/library/ubuntu\:latest/ || return 111
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/registry.hub.docker.com/library/centos\:centos6/ || return 112
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/.layers || return 113
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/.metadata || return 114
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/.flat || return 115
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/.metadata/registry.hub.docker.com/library/ubuntu:latest || return 116
+    ls /cvmfs/$CVMFS_TEST402_REPOSITORY/.metadata/registry.hub.docker.com/library/centos:centos6 || return 117
+
+    # add other possible tests
+
+    echo "*** Test successful"
+
+    return 0
+}
+


### PR DESCRIPTION
This PR add the possibility to specify a temporary directory that DUCC can use in lieu of /tmp.

There are some other minor changes as well addressing: https://sft.its.cern.ch/jira/projects/CVM/issues/CVM-1840

