### PR TITLE
ci/run_cpplint.py: trivial bugfix

### DIFF
--- a/ci/run_cpplint.sh
+++ b/ci/run_cpplint.sh
@@ -50,5 +50,5 @@ SOURCE_DIRS="cvmfs mount test/unittests test/micro-benchmarks test/stress"
 
 cd $REPO_ROOT
 FILE_LIST="$(find $SOURCE_DIRS -type f -not -name '\._*' -and \( -name '*.h' -or -name '*.cc' -or -name '*.hpp' -or -name '*.c' \))"
-$PYTHON $CPPLINT ${FILE_LIST} | tee ${SCRIPT_OUTPUT}
+$PYTHON $CPPLINT ${FILE_LIST} 2>&1 | tee ${SCRIPT_OUTPUT}
 exit ${PIPESTATUS[0]}


### PR DESCRIPTION
cpplint.py outputs its result to stderr.
To save the results to a file, stderr needs to be
captured (stdout is blank in this case).