### PR TITLE
Ducc gc better version

### DIFF
--- a/ducc/cmd/garbage_collection.go
+++ b/ducc/cmd/garbage_collection.go
@@ -96,7 +96,7 @@ var garbageCollectionCmd = &cobra.Command{
 			modTime := stat.ModTime()
 			thirtyDays := 30 * 24 * time.Hour
 			if modTime.Add(thirtyDays).After(today) {
-				llog(lib.Log()).WithFields(log.Fields{"path": path, "grace period": "30 days", "path mod time": modTime}).Warning("Path still in it's grace period")
+				llog(lib.Log()).WithFields(log.Fields{"path": path, "grace period": "30 days", "path mod time": modTime}).Warning("Path still in its grace period")
 				return false
 			}
 			return true

--- a/ducc/cmd/garbage_collection.go
+++ b/ducc/cmd/garbage_collection.go
@@ -22,6 +22,24 @@ var garbageCollectionCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 
+		// tried already to make them in parallel, we don't gain much
+		// from ~1min to ~30 sec
+		imagesUsed, _ := lib.FindAllUsedFlatImages("unpacked.cern.ch")
+		imagesAll, _ := lib.FindAllFlatImages("unpacked.cern.ch")
+		layersUsed, _ := lib.FindAllUsedLayers("unpacked.cern.ch")
+		layersAll, _ := lib.FindAllLayers("unpacked.cern.ch")
+		/*
+			toPrintUsed, _ := json.MarshalIndent(imagesUsed, "", "  ")
+			fmt.Print(string(toPrintUsed))
+			imagesAll, _ := lib.FindAllUsedLayers("unpacked.cern.ch")
+			toPrintAll, _ := json.MarshalIndent(imagesAll, "", "  ")
+			fmt.Print(string(toPrintAll))
+
+			//fmt.Printf("imagesUsed: %d\nimagesAll: %d", len(imagesUsed), len(imagesAll))
+		*/
+		fmt.Printf("\nimagesUsed: %d\nimagesAll: %d\nlayersUsed: %d\nlayersAll: %d\n", len(imagesUsed), len(imagesAll), len(layersUsed), len(layersAll))
+		os.Exit(1)
+
 		fmt.Println("Start")
 		repo := args[0]
 		llog := func(l *log.Entry) *log.Entry {

--- a/ducc/cmd/garbage_collection.go
+++ b/ducc/cmd/garbage_collection.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -11,7 +12,16 @@ import (
 	"github.com/cvmfs/ducc/lib"
 )
 
+const (
+	deleteBatch = 50
+)
+
+var (
+	dryRun bool
+)
+
 func init() {
+	garbageCollectionCmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Dry run the garbage collection")
 	rootCmd.AddCommand(garbageCollectionCmd)
 }
 
@@ -21,58 +31,103 @@ var garbageCollectionCmd = &cobra.Command{
 	Aliases: []string{"gc"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		CVMFSRepo := args[0]
 
-		// tried already to make them in parallel, we don't gain much
-		// from ~1min to ~30 sec
-		imagesUsed, _ := lib.FindAllUsedFlatImages("unpacked.cern.ch")
-		imagesAll, _ := lib.FindAllFlatImages("unpacked.cern.ch")
-		layersUsed, _ := lib.FindAllUsedLayers("unpacked.cern.ch")
-		layersAll, _ := lib.FindAllLayers("unpacked.cern.ch")
-		/*
-			toPrintUsed, _ := json.MarshalIndent(imagesUsed, "", "  ")
-			fmt.Print(string(toPrintUsed))
-			imagesAll, _ := lib.FindAllUsedLayers("unpacked.cern.ch")
-			toPrintAll, _ := json.MarshalIndent(imagesAll, "", "  ")
-			fmt.Print(string(toPrintAll))
-
-			//fmt.Printf("imagesUsed: %d\nimagesAll: %d", len(imagesUsed), len(imagesAll))
-		*/
-		fmt.Printf("\nimagesUsed: %d\nimagesAll: %d\nlayersUsed: %d\nlayersAll: %d\n", len(imagesUsed), len(imagesAll), len(layersUsed), len(layersAll))
-		os.Exit(1)
-
-		fmt.Println("Start")
-		repo := args[0]
 		llog := func(l *log.Entry) *log.Entry {
 			return l.WithFields(log.Fields{"action": "garbage collect",
-				"repo": repo,
+				"repo": CVMFSRepo,
 			})
 		}
 
-		manifestToRemove, err := lib.FindImageToGarbageCollect(repo)
-		if err != nil {
-			llog(lib.LogE(err)).Warning(
-				"Error in finding the image to remove from the scheduler, goin on...")
-		}
-		images2layers := make(map[string][]string)
+		// tried already to make them in parallel, we don't gain much
+		// from ~1min to ~30 sec
+		llog(lib.Log()).Info("Scanning images to delete")
+		imagesUsed, _ := lib.FindAllUsedFlatImages(CVMFSRepo)
+		imagesAll, _ := lib.FindAllFlatImages(CVMFSRepo)
 
-		for _, manifest := range manifestToRemove {
-			digest := strings.Split(manifest.Config.Digest, ":")[1]
-			for _, layerStruct := range manifest.Layers {
-				layerName := strings.Split(layerStruct.Digest, ":")[1]
-				images2layers[digest] = append(images2layers[digest], layerName)
+		llog(lib.Log()).Info("Scanning layers to delete")
+		layersUsed, _ := lib.FindAllUsedLayers(CVMFSRepo)
+		layersAll, _ := lib.FindAllLayers(CVMFSRepo)
+
+		llog(lib.Log()).Info("Scanning completed. Computing paths to delete.")
+
+		// we first figure out all the unique paths that are used
+		imagesUsedMap := make(map[string]bool)
+		for _, image := range imagesUsed {
+			imagesUsedMap[image] = true
+		}
+		layersUsedMap := make(map[string]bool)
+		for _, layer := range layersUsed {
+			layersUsedMap[layer] = true
+		}
+
+		// we figure out what path is not necessary anymore
+		imagesToDelete := make([]string, 0)
+		for _, candidateDelete := range imagesAll {
+			if imagesUsedMap[candidateDelete] {
+				continue
+			}
+			imagesToDelete = append(imagesToDelete, candidateDelete)
+		}
+		layersToDelete := make([]string, 0)
+		for _, candidateDelete := range layersAll {
+			if layersUsedMap[candidateDelete] {
+				continue
+			}
+			layersToDelete = append(layersToDelete, candidateDelete)
+		}
+
+		// we remove the prefix to the paths and we accumulate them in a single array
+		// we remove the prefix to pass them to `cvmfs_server ingest --delete $path_with_no_prefix CVMFSRepo`
+		prefix := filepath.Join("/", "cvmfs", CVMFSRepo) + "/"
+		pathsToDelete := make([]string, 0)
+		for _, path := range imagesToDelete {
+			if strings.HasPrefix(path, prefix) {
+				pathsToDelete = append(pathsToDelete, strings.TrimPrefix(path, prefix))
+			} else {
+				llog(lib.Log()).WithFields(log.Fields{"path": path, "prefix": prefix}).Warning("Path does not have the expected prefix")
+			}
+		}
+		for _, path := range layersToDelete {
+			if strings.HasPrefix(path, prefix) {
+				pathsToDelete = append(pathsToDelete, strings.TrimPrefix(path, prefix))
+			} else {
+				llog(lib.Log()).WithFields(log.Fields{"path": path, "prefix": prefix}).Warning("Path does not have the expected prefix")
 			}
 		}
 
-		for image, layers := range images2layers {
-			for _, layer := range layers {
-				err = lib.GarbageCollectSingleLayer(repo, image, layer)
-				if err != nil {
-					llog(lib.LogE(err)).Warning(
-						"Error in removing a single layer from the repository, going on...")
-				}
+		llog(lib.Log()).WithFields(log.Fields{"num. of path to delete": len(pathsToDelete)}).Info("Ready to delete paths")
+
+		// we send 50 folder to deletion at the time
+		commandPrefix := []string{"cvmfs_server", "ingest"}
+		commands := make([][]string, 0)
+		command := commandPrefix
+		j := 0
+		for i, path := range pathsToDelete {
+			j = i
+			if i%deleteBatch == 0 && i > 0 {
+				command = append(command, CVMFSRepo)
+				commands = append(commands, command)
+				command = commandPrefix
+				continue
 			}
+			command = append(command, "--delete", path)
+		}
+		if j%deleteBatch != 0 && j > 0 {
+			command = append(command, CVMFSRepo)
+			commands = append(commands, command)
 		}
 
-		os.Exit(0)
+		if dryRun {
+			fmt.Printf("Dry run for garbage collection\n")
+			fmt.Printf("It would execute the following commands:\n\n")
+		}
+		for _, cmd := range commands {
+			if dryRun {
+				fmt.Printf("%v\n", cmd)
+			} else {
+				lib.ExecCommand(cmd...).Start()
+			}
+		}
 	},
 }

--- a/ducc/docker-api/util.go
+++ b/ducc/docker-api/util.go
@@ -49,9 +49,6 @@ func MakeThinImage(m Manifest, layersMapping map[string]string, origin string) (
 
 	url_base := "cvmfs://"
 
-	fmt.Println(layersMapping)
-	fmt.Println(m.Layers)
-
 	for i, layer := range m.Layers {
 		digest := strings.Split(layer.Digest, ":")[1]
 		location, ok := layersMapping[layer.Digest]

--- a/ducc/lib/garbage_collection.go
+++ b/ducc/lib/garbage_collection.go
@@ -17,6 +17,11 @@ func FindAllUsedFlatImages(CVMFSRepo string) ([]string, error) {
 	root_components := strings.Split(root, string(os.PathSeparator))
 	result := make([]string, 0)
 	walker := func(path string, info os.FileInfo, err error) error {
+		// some kind of error, we don't really care and we just move on.
+		if err != nil {
+			LogE(err).WithFields(log.Fields{"path": path}).Warning("Error in opening the path, moving on.")
+			return nil
+		}
 		components := strings.Split(path, string(os.PathSeparator))
 		// first root directory, not sure if this ever happen
 		if len(components) == len(root_components) {
@@ -52,6 +57,10 @@ func FindAllFlatImages(CVMFSRepo string) ([]string, error) {
 	root_components := strings.Split(root, string(os.PathSeparator))
 	result := make([]string, 0)
 	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			LogE(err).WithFields(log.Fields{"path": path}).Warning("Error in opening the path, moving on.")
+			return nil
+		}
 		components := strings.Split(path, string(os.PathSeparator))
 		if len(components) == len(root_components)+2 && info.IsDir() {
 			result = append(result, path)
@@ -75,6 +84,10 @@ func FindAllLayers(CVMFSRepo string) ([]string, error) {
 	root_components := strings.Split(root, string(os.PathSeparator))
 	result := make([]string, 0)
 	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			LogE(err).WithFields(log.Fields{"path": path}).Warning("Error in opening the path, moving on.")
+			return nil
+		}
 		components := strings.Split(path, string(os.PathSeparator))
 		if len(components) == len(root_components)+2 && info.IsDir() {
 			result = append(result, path)
@@ -97,6 +110,10 @@ func FindAllUsedLayers(CVMFSRepo string) ([]string, error) {
 	root := filepath.Join("/", "cvmfs", CVMFSRepo, ".metadata")
 	result := make([]string, 0)
 	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			LogE(err).WithFields(log.Fields{"path": path}).Warning("Error in opening the path, moving on.")
+			return nil
+		}
 		if info.Name() == "manifest.json" {
 			bytes, err := ioutil.ReadFile(path)
 			if err != nil {


### PR DESCRIPTION
A rewrite of the GC in DUCC.

The new version is a little less smart than the old one, however it is much simpler and more complete in functionality.

It scans the whole tree and delete the layers and paths that are not in use anymore.


An upgrade to this would be to provide a grace period before to eliminate the files.

A possible implementation of this grace period would be to touch a `.last_used` file in the metadata folders of the layers and of the images once a day.

Eventually we would delete only the layers/images whose `.last_used` file is older than the grace period.
