### PR TITLE
Fix unittests on newly tested platforms

### DIFF
--- a/cvmfs/webapi/test_cvmfs_geo.py
+++ b/cvmfs/webapi/test_cvmfs_geo.py
@@ -26,6 +26,9 @@ CERNgeo = {
 }
 CERNname = 'cvmfs-stratum-one.cern.ch'
 CERNaddrs = getaddrs(CERNname, socket.AF_INET6)
+if len(CERNaddrs) == 0:  # fallback on IPv4-only systems
+    CERNaddrs = getaddrs(CERNname, socket.AF_INET)
+
 FNALgeo = {
     'latitude': 41.7768,
     'longitude': -88.4604
@@ -44,6 +47,9 @@ RALgeo = {
 }
 RALname = 'cernvmfs.gridpp.rl.ac.uk'
 RALaddrs = getaddrs(RALname, socket.AF_INET6)
+if len(RALaddrs) == 0:  # fallback on IPv4-only systems
+    RALaddrs = getaddrs(RALname, socket.AF_INET)
+
 
 class giTestDb():
     def get(self, addr):

--- a/test/unittests/t_mountpoint.cc
+++ b/test/unittests/t_mountpoint.cc
@@ -170,6 +170,7 @@ TEST_F(T_MountPoint, TriageCacheMgr) {
 TEST_F(T_MountPoint, RamCacheMgr) {
   options_mgr_.SetValue("CVMFS_CACHE_PRIMARY", "ram");
   options_mgr_.SetValue("CVMFS_CACHE_ram_TYPE", "ram");
+  options_mgr_.SetValue("CVMFS_CACHE_ram_SIZE", "75");
   {
     UniquePtr<FileSystem> fs(FileSystem::Create(fs_info_));
     EXPECT_EQ(loader::kFailOk, fs->boot_status());
@@ -247,7 +248,9 @@ TEST_F(T_MountPoint, TieredComplex) {
   options_mgr_.SetValue("CVMFS_CACHE_tiered_upper_UPPER", "uu_ram");
   options_mgr_.SetValue("CVMFS_CACHE_tiered_upper_LOWER", "ul_ram");
   options_mgr_.SetValue("CVMFS_CACHE_uu_ram_TYPE", "ram");
+  options_mgr_.SetValue("CVMFS_CACHE_uu_ram_SIZE", "75");
   options_mgr_.SetValue("CVMFS_CACHE_ul_ram_TYPE", "ram");
+  options_mgr_.SetValue("CVMFS_CACHE_ul_ram_SIZE", "75");
   options_mgr_.SetValue("CVMFS_CACHE_tiered_LOWER", "tiered_lower");
   options_mgr_.SetValue("CVMFS_CACHE_tiered_lower_TYPE", "tiered");
   options_mgr_.SetValue("CVMFS_CACHE_tiered_lower_UPPER", "lu_posix");


### PR DESCRIPTION
- 32-bit images on 64-bit hosts: T_MountPoint: explicit RAM cache size
- SLES11, SLES12: geoapi unittests: IPv4 fallback on old systems