### PR TITLE
Statistics DB: prune old records

### DIFF
--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -380,7 +380,9 @@ StatisticsDatabase *StatisticsDatabase::OpenStandardDB(
   const std::string repo_name)
 {
   StatisticsDatabase *db;
-  std::string db_file_path = GetDBPath(repo_name);
+  std::string db_file_path;
+  uint32_t days_to_keep;
+  GetDBParams(repo_name, &db_file_path, &days_to_keep);
   if (FileExists(db_file_path)) {
     db = StatisticsDatabase::Open(db_file_path, kOpenReadWrite);
     if (db == NULL) {
@@ -388,6 +390,9 @@ StatisticsDatabase *StatisticsDatabase::OpenStandardDB(
     } else if (db->GetProperty<std::string>("repo_name") != repo_name) {
       PANIC(kLogSyslogErr, "'repo_name' property of the statistics database %s "
             "is incorrect. Please fix the database.", db_file_path.c_str());
+    }
+    if (!db->Prune(days_to_keep)) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr, "Failed to prune statistics database");
     }
   } else {
     db = StatisticsDatabase::Create(db_file_path);
@@ -432,20 +437,48 @@ bool StatisticsDatabase::StoreGCStatistics(
 bool StatisticsDatabase::StoreEntry(const std::string &insert_statement) {
   sqlite::Sql insert(this->sqlite_db(), insert_statement);
 
-  std::string error_message = "";
   if (!insert.Execute()) {
-    error_message = "insert.Execute failed!";
-  } else if (!insert.Reset()) {
-    error_message = "insert.Reset() failed!";
-  } else {
-    LogCvmfs(kLogCvmfs, kLogStdout, "Statistics stored at: %s",
-             this->filename().c_str());
-    return true;
+    LogCvmfs(kLogCvmfs, kLogSyslogErr,
+      "Couldn't store statistics in %s: insert.Execute failed!",
+      this->filename().c_str());
+    return false;
   }
 
-  LogCvmfs(kLogCvmfs, kLogSyslogErr, "Couldn't store statistics in %s: %s",
-          this->filename().c_str(), error_message.c_str());
-  return false;
+  LogCvmfs(kLogCvmfs, kLogStdout, "Statistics stored at: %s",
+            this->filename().c_str());
+  return true;
+}
+
+
+bool StatisticsDatabase::Prune(uint32_t days) {
+  if (days == 0) return true;
+
+  std::string publish_stmt =
+    "DELETE FROM publish_statistics WHERE "
+    "julianday('now','start of day')-julianday(start_time) > " +
+    StringifyUint(days) + ";";
+
+  std::string gc_stmt =
+    "DELETE FROM gc_statistics WHERE "
+    "julianday('now','start of day')-julianday(start_time) > " +
+    StringifyUint(days) + ";";
+
+  sqlite::Sql publish_sql(this->sqlite_db(), publish_stmt);
+  sqlite::Sql gc_sql(this->sqlite_db(), gc_stmt);
+  if (!publish_sql.Execute() || !gc_sql.Execute()) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr,
+      "Couldn't prune statistics DB %s: SQL Execute() failed!",
+      this->filename().c_str());
+    return false;
+  }
+  if (!this->Vacuum()) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr,
+      "Couldn't prune statistics DB %s: Vacuum() failed!",
+      this->filename().c_str());
+    return false;
+  }
+
+  return true;
 }
 
 
@@ -490,7 +523,10 @@ bool StatisticsDatabase::UploadStatistics(
 }
 
 
-std::string StatisticsDatabase::GetDBPath(const std::string &repo_name) {
+void StatisticsDatabase::GetDBParams(const std::string &repo_name,
+                                     std::string *path,
+                                     uint32_t *days_to_keep)
+{
   // default location
   const std::string db_default_path =
       "/var/spool/cvmfs/" + repo_name + "/stats.db";
@@ -502,7 +538,9 @@ std::string StatisticsDatabase::GetDBPath(const std::string &repo_name) {
     LogCvmfs(kLogCvmfs, kLogSyslogErr,
              "Could not parse repository configuration: %s.",
              repo_config_file.c_str());
-    return db_default_path;
+    *path = db_default_path;
+    *days_to_keep = kDefaultDaysToKeep;
+    return;
   }
 
   std::string statistics_db = "";
@@ -511,20 +549,32 @@ std::string StatisticsDatabase::GetDBPath(const std::string &repo_name) {
              "Parameter %s was not set in the repository configuration file. "
              "Using default value: %s",
              "CVMFS_STATISTICS_DB", db_default_path.c_str());
-    return db_default_path;
+    *path = db_default_path;
+  } else {
+    std::string dirname = GetParentPath(statistics_db);
+    int mode = S_IRUSR | S_IWUSR | S_IXUSR |
+               S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;  // 755
+    if (!MkdirDeep(dirname, mode, true)) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr,
+        "Couldn't write statistics at the specified path %s.",
+        statistics_db.c_str());
+      *path = db_default_path;
+    } else {
+      *path = statistics_db;
+    }
   }
 
-  std::string dirname = GetParentPath(statistics_db);
-  int mode = S_IRUSR | S_IWUSR | S_IXUSR |
-             S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;  // 755
-  if (!MkdirDeep(dirname, mode, true)) {
-    LogCvmfs(kLogCvmfs, kLogSyslogErr,
-      "Couldn't write statistics at the specified path %s.",
-      statistics_db.c_str());
-    return db_default_path;
+  std::string days_to_keep_str = "";
+  if (!parser.GetValue("CVMFS_STATS_DB_DAYS_TO_KEEP", &statistics_db)) {
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
+             "Parameter %s was not set in the repository configuration file. "
+             "Using default value: %s",
+             "CVMFS_STATS_DB_DAYS_TO_KEEP",
+             StringifyUint(kDefaultDaysToKeep).c_str());
+    *days_to_keep = kDefaultDaysToKeep;
+  } else {
+    *days_to_keep = static_cast<uint32_t> (String2Uint64(days_to_keep_str));
   }
-
-  return statistics_db;
 }
 
 
@@ -566,3 +616,5 @@ StatisticsDatabase::StatisticsDatabase(const std::string  &filename,
 {
   ++StatisticsDatabase::instances;
 }
+
+const uint32_t StatisticsDatabase::kDefaultDaysToKeep = 365;

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -27,6 +27,13 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
 
   bool StoreEntry(const std::string &insert_statement);
 
+/**
+ * Prune the statistics DB (delete records older than certain threshhold)
+ * @param days number of days of records to keep, 0 means no pruning
+ * @return true on success, false otherwise
+ */
+  bool Prune(uint32_t days);
+
  public:
   // not const - needs to be adaptable!
   static float        kLatestSchema;
@@ -93,14 +100,23 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
                         std::string local_path = "");
 
 /**
-  * Get the path for the database file
-  * user can specify it in the server.conf
-  * by default: /var/spool/cvmfs/$repo_name/stats.db
+  * Get the parameters for the database file
+  * user can specify them in the server.conf
+  * DB file path:
+  *   key: CVMFS_STATISTICS_DB
+  *   default: /var/spool/cvmfs/$repo_name/stats.db
+  * maximum age (in days) of records to keep when pruning
+  * (zero means keep forever)
+  *   key: CVMFS_STATS_DB_DAYS_TO_KEEP
+  *   deafult: 365
   *
   * @param repo_name Fully qualified name of the repository
-  * @return path to store database file
+  * @param path pointer to save the db path in
+  * @param days_to_keep pointer to save the number of days
   */
-  static std::string GetDBPath(const std::string &repo_name);
+  static void GetDBParams(const std::string &repo_name,
+                          std::string *path,
+                          uint32_t *days_to_keep);
 
   /**
   * Check if the CVMFS_EXTENDED_GC_STATS is ON or not
@@ -109,6 +125,9 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   * @return true if CVMFS_EXTENDED_GC_STATS is ON, false otherwise
   */
   static bool GcExtendedStats(const std::string &repo_name);
+
+ private:
+  static const uint32_t kDefaultDaysToKeep;
 };
 
 


### PR DESCRIPTION
Delete old records to keep the statistics DB small.
Maximum age of records to keep can be configured by
CVMFS_STATS_DB_DAYS_TO_KEEP and is 365 by default.