### PR TITLE
BUGFIX: GW SessionContext: more flexible GW reply JSON evaluation

### DIFF
--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -375,7 +375,11 @@ bool SessionContext::DoUpload(const SessionContext::UploadJob* job) {
              ret);
   }
 
-  const bool ok = (reply == "{\"status\":\"ok\"}");
+  JsonDocument *reply_json = JsonDocument::Create(reply);
+  const JSON *reply_status =
+    JsonDocument::SearchInObject(reply_json->root(), "status", JSON_STRING);
+  const bool ok = (reply_status != NULL &&
+                   std::string(reply_status->string_value) == "ok");
   if (!ok) {
     LogCvmfs(kLogUploadGateway, kLogStderr,
              "SessionContext::DoUpload - error reply: %s",


### PR DESCRIPTION
Instead of comparing the reply JSON to a hardcoded value,
decode the reply and look for the "status" field value.