### PR TITLE
Explicit python2 in integration tests

### DIFF
--- a/test/common/mock_services/http_400.py
+++ b/test/common/mock_services/http_400.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import BaseHTTPServer
 import SimpleHTTPServer

--- a/test/common/mock_services/http_server.py
+++ b/test/common/mock_services/http_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import HTTPRangeServer
 import SocketServer

--- a/test/common/mock_services/make_repo.py
+++ b/test/common/mock_services/make_repo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/test/common/mock_services/silent_socket.py
+++ b/test/common/mock_services/silent_socket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import socket
 import SocketServer

--- a/test/migration_tests/001-hotpatch/tarsum
+++ b/test/migration_tests/001-hotpatch/tarsum
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # Copyright (C) 2008-2009 by Guy Rutenberg
 

--- a/test/src/030-missingrootcatalog/main
+++ b/test/src/030-missingrootcatalog/main
@@ -47,7 +47,7 @@ cvmfs_run_test() {
   cd ..
 
   echo "run a simple HTTP server"
-  cmd="python2 -m SimpleHTTPServer 8000"
+  cmd="${CVMFS_PYTHON2} -m SimpleHTTPServer 8000"
   http_pid=$(run_background_service $logfile "$cmd")
   if [ $? -ne 0 ]; then return 9; fi
   echo "simple HTTP server serving empty directory started with PID $http_pid"

--- a/test/src/065-http-400/main
+++ b/test/src/065-http-400/main
@@ -21,7 +21,7 @@ cvmfs_run_test() {
   src_location=$2
 
   local faulty_port="9091"
-  local faulty_server="${src_location}/../../common/mock_services/http_400.py"
+  local faulty_server="${CVMFS_PYTHON2} ${src_location}/../../common/mock_services/http_400.py"
 
   which curl > /dev/null 2>&1 || { echo "curl not found"; return 1; }
   trap "cleanup" EXIT HUP INT TERM

--- a/test/src/081-shrinkwrap/main
+++ b/test/src/081-shrinkwrap/main
@@ -48,7 +48,7 @@ cvmfs_run_test() {
     sudo cat /tmp/cvmfs-$repo.trace.log
 
     echo "*** Creating specification file..."
-    sudo python /usr/libexec/cvmfs/shrinkwrap/spec_builder.py \
+    sudo $CVMFS_PYTHON2 /usr/libexec/cvmfs/shrinkwrap/spec_builder.py \
       --policy=exact \
       --filters opendir lookup -- \
       /tmp/cvmfs-$repo.trace.log \

--- a/test/src/628-pythonwrappedcvmfsserver/main
+++ b/test/src/628-pythonwrappedcvmfsserver/main
@@ -59,7 +59,7 @@ cvmfs_run_test() {
   local scratch_dir=$(pwd)
 
   echo -n "checking for installed python interpreter... "
-  which "python" > /dev/null 2>&1 && echo "done" || die "fail"
+  which "python2" > /dev/null 2>&1 && echo "done" || die "fail"
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -71,7 +71,7 @@ cvmfs_run_test() {
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
 
-  local python_interpreter=$(which python)
+  local python_interpreter=$(which python2)
   echo "copying python interpreter in ${python_interpreter}"
   cp $python_interpreter $repo_dir
   python_interpreter="${repo_dir}/$(basename $python_interpreter)"

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -5,7 +5,7 @@ cvmfs_test_autofs_on_startup=false
 create_socket() {
   socket="$1"
 
-  python -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('$socket')" || return 1
+  $CVMFS_PYTHON2 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('$socket')" || return 1
 }
 
 create_special_files() {

--- a/test/src/647-bearercvmfs/cvmfs-scitokens-helper.py
+++ b/test/src/647-bearercvmfs/cvmfs-scitokens-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 
 # This is a simple echo script

--- a/test/src/647-bearercvmfs/cvmfs_scitoken_helper.py
+++ b/test/src/647-bearercvmfs/cvmfs_scitoken_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 
 # This is a simple echo script

--- a/test/test_functions
+++ b/test/test_functions
@@ -76,6 +76,12 @@ running_on_osx() {
   [ "x$(uname)" == "xDarwin" ]
 }
 
+if running_on_osx; then
+  CVMFS_PYTHON2="python"
+else
+  CVMFS_PYTHON2="python2"
+fi
+
 running_on_s3() {
   [ "x$CVMFS_TEST_S3_CONFIG" != "x" ]
 }
@@ -782,12 +788,12 @@ create_filled_repo() {
 # @param  repo_dir   where to put the dummy dirents
 make_huge_repo() {
   local repo_dir=$1
-  python ${TEST_ROOT}/common/mock_services/make_repo.py \
-    --max-dir-depth        7                     \
-    --num-subdirs          5                     \
-    --num-files-per-dir    5                     \
-    --min-file-size        0                     \
-    --max-file-size     5120                     \
+  $CVMFS_PYTHON2 ${TEST_ROOT}/common/mock_services/make_repo.py \
+    --max-dir-depth        7                                    \
+    --num-subdirs          5                                    \
+    --num-files-per-dir    5                                    \
+    --min-file-size        0                                    \
+    --max-file-size     5120                                    \
     $repo_dir
 }
 
@@ -1009,7 +1015,7 @@ open_silent_port() {
   local cmd
   local mock
 
-  mock="python ${TEST_ROOT}/common/mock_services/silent_socket.py $protocol $port"
+  mock="${CVMFS_PYTHON2} ${TEST_ROOT}/common/mock_services/silent_socket.py $protocol $port"
 
   # Do similar fifo-trick as in run_background_service() to get the PID of the
   # actual silent_socket.py process rather than just the `sudo` around it.
@@ -1033,7 +1039,7 @@ open_http_server() {
   local port="$2"
   local logfile="${3:=/dev/null}"
 
-  local http_server="${TEST_ROOT}/common/mock_services/http_server.py"
+  local http_server="${CVMFS_PYTHON2} ${TEST_ROOT}/common/mock_services/http_server.py"
   local http_pid=
   local http_sentinel="http://localhost:${port}/http_sentinel"
 


### PR DESCRIPTION
Fix shebangs in all related files.
Make a switch between python/python2 for tests
running on macOS, too.