### PR TITLE
fix panic macro

### DIFF
--- a/cvmfs/util/exception.h
+++ b/cvmfs/util/exception.h
@@ -20,9 +20,9 @@ class ECvmfsException : std::runtime_error {
       : std::runtime_error(what_arg) {}
 };
 
-#define S1(x) #x
-#define S2(x) S1(x)
-#define __LOCATION__ "PANIC: " __FILE__ " : " S2(__LINE__)
+#define __CVMFS_S1(x) #x
+#define __CVMFS_S2(x) __CVMFS_S1(x)
+#define __LOCATION__ "PANIC: " __FILE__ " : " __CVMFS_S2(__LINE__)
 #define PANIC(...) Panic(__LOCATION__, kLogCvmfs, __VA_ARGS__);
 
 __attribute__((noreturn))

--- a/cvmfs/util/exception.h
+++ b/cvmfs/util/exception.h
@@ -20,7 +20,10 @@ class ECvmfsException : std::runtime_error {
       : std::runtime_error(what_arg) {}
 };
 
-#define PANIC(...) Panic("PANIC: __FILE__ : __LINE__", kLogCvmfs, __VA_ARGS__);
+#define S1(x) #x
+#define S2(x) S1(x)
+#define __LOCATION__ "PANIC: " __FILE__ " : " S2(__LINE__)
+#define PANIC(...) Panic(__LOCATION__, kLogCvmfs, __VA_ARGS__);
 
 __attribute__((noreturn))
 void Panic(const char *coordinates, const LogSource source, const int mask,


### PR DESCRIPTION
it use to print the literal __FILE__ and __LINE__ instead of the
actual file and line of the panic.
Double macro from: https://stackoverflow.com/questions/19343205/c-concatenating-file-and-line-macros

Found this while working on the GC