### PR TITLE
CommitProcessor: add intermediary root catalog to reflog

### DIFF
--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -232,12 +232,17 @@ CommitProcessor::Result CommitProcessor::Process(
            "CommitProcessor - lease_path: %s, signing manifest",
            lease_path.c_str());
 
+  // Add C_N root catalog hash to reflog through SigningTool,
+  // so garbage collector can later delete it.
+  std::vector<shash::Any> reflog_catalogs;
+  reflog_catalogs.push_back(new_root_hash);
+
   SigningTool signing_tool(server_tool.weak_ref());
   SigningTool::Result res = signing_tool.Run(
       new_manifest_path, params.stratum0, params.spooler_configuration,
       temp_dir, certificate, private_key, repo_name, "", "",
       "/var/spool/cvmfs/" + repo_name + "/reflog.chksum",
-      params.garbage_collection);
+      params.garbage_collection, false, false, reflog_catalogs);
   switch (res) {
     case SigningTool::kReflogChecksumMissing:
       LogCvmfs(kLogReceiver, kLogSyslogErr,

--- a/cvmfs/signing_tool.h
+++ b/cvmfs/signing_tool.h
@@ -6,6 +6,7 @@
 #define CVMFS_SIGNING_TOOL_H_
 
 #include <string>
+#include <vector>
 
 #include "hash.h"
 #include "server_tool.h"
@@ -39,7 +40,9 @@ class SigningTool {
              const std::string &reflog_chksum_path = "",
              const bool garbage_collectable = false,
              const bool bootstrap_shortcuts = false,
-             const bool return_early = false);
+             const bool return_early = false,
+             const std::vector<shash::Any> reflog_catalogs =
+              std::vector<shash::Any>());
 
  protected:
   void CertificateUploadCallback(const upload::SpoolerResult &result);

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -240,6 +240,17 @@ run_transactions() {
 
     check_repo_integrity test.repo.org || return 1
 
+    local reflog_url="$(get_repo_url test.repo.org)/.cvmfsreflog"
+    curl -s $reflog_url > reflog.db
+    sqlite3 reflog.db "select hash from refs where type=0;" | sort | uniq > reflog_catalogs.txt
+    if running_on_s3 ; then
+        local repo_storage=${CVMFS_TEST_S3_STORAGE}/test.repo.org
+    else
+        local repo_storage=$(get_local_repo_storage test.repo.org)
+    fi
+    find ${repo_storage}/data -type f -name *C 2>/dev/null | rev | cut -d"/" -f 1-2 | rev | tr -d "/C" | sort | uniq > actual_catalogs.txt
+    diff reflog_catalogs.txt actual_catalogs.txt || return 1
+
     clean_up
     return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -669,6 +669,15 @@ destroy_repo() {
     sudo rm -rf "${CVMFS_TEST_S3_STORAGE}/${repo}"
   fi
 
+  load_repo_config $repo
+  if [ x"$TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE" != x"" ]; then
+    # It is possible to have publisher and gateway on the same machine for testing purposes.
+    # However, `cvmfs_server rmfs` then incorrectly does not delete the repository backend storage.
+    # Let's do it here instead.
+    echo "Wiping local repository storage in gateway setup /srv/cvmfs/${repo}"
+    sudo rm -rf /srv/cvmfs/${repo}
+  fi
+
   sudo cvmfs_server rmfs -f $additional_flags $repo || return 100
 }
 


### PR DESCRIPTION
New (intermediary) root catalog should also be added to reflog,
so the catalog tree can be garbage collected as well.