### PR TITLE
Add quantiles computation to Log2Histogram

### DIFF
--- a/cvmfs/cvmfs_talk.cc
+++ b/cvmfs/cvmfs_talk.cc
@@ -202,6 +202,8 @@ static void Usage(const std::string &exe) {
     "  version patchlevel     gets cvmfs patchlevel                    \n"
     "  open catalogs          shows information about currently        \n"
     "                         loaded catalogs (_not_ all cached ones)  \n"
+    "  latency                show the latencies of different fuse     \n"
+    "                         calls (requires CVMFS_INSTRUMENT_FUSE)   \n"
     "\n",
     exe.c_str(), exe.c_str());
 }

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -416,7 +416,7 @@ class MountPoint : SingleCopy, public BootFactory {
   }
   cvmfs::Fetcher *fetcher() { return fetcher_; }
   bool fixed_catalog() { return fixed_catalog_; }
-  std::string fqrn() { return fqrn_; }
+  std::string fqrn() const { return fqrn_; }
   cvmfs::Fetcher *external_fetcher() { return external_fetcher_; }
   FileSystem *file_system() { return file_system_; }
   bool has_membership_req() { return has_membership_req_; }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -672,8 +672,23 @@ string TalkManager::FormatLatencies(const MountPoint &mount_point,
   const unsigned int bufSize = 300;
   char buffer[bufSize];
 
-  vector<float> qs{.1,  .2, .25, .3,  .4,  .5,   .6,   .7,
-                   .75, .8, .9,  .95, .99, .995, .999, 0.9999};
+  vector<float> qs;
+  qs.push_back(.1);
+  qs.push_back(.2);
+  qs.push_back(.25);
+  qs.push_back(.3);
+  qs.push_back(.4);
+  qs.push_back(.5);
+  qs.push_back(.6);
+  qs.push_back(.7);
+  qs.push_back(.75);
+  qs.push_back(.8);
+  qs.push_back(.9);
+  qs.push_back(.95);
+  qs.push_back(.99);
+  qs.push_back(.999);
+  qs.push_back(.9999);
+
   string repo(mount_point.fqrn());
 
   unsigned int format_index =

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -655,6 +655,9 @@ void *TalkManager::MainResponder(void *data) {
         file_system->TearDown2ReadOnly();
         talk_mgr->Answer(con_fd, "In read-only mode\n");
       }
+    } else if (line == "latency") {
+      string result = talk_mgr->FormatLatencies(*mount_point, file_system);
+      talk_mgr->Answer(con_fd, result);
     } else {
       talk_mgr->Answer(con_fd, "unknown command\n");
     }
@@ -663,6 +666,74 @@ void *TalkManager::MainResponder(void *data) {
   return NULL;
 }
 
+string TalkManager::FormatLatencies(const MountPoint &mount_point,
+                                    FileSystem *file_system) {
+  string result;
+  const unsigned int bufSize = 300;
+  char buffer[bufSize];
+
+  vector<float> qs{.1,  .2, .25, .3,  .4,  .5,   .6,   .7,
+                   .75, .8, .9,  .95, .99, .995, .999, 0.9999};
+  string repo(mount_point.fqrn());
+
+  unsigned int format_index =
+      snprintf(buffer, bufSize, "\"%s\",\"%s\",\"%s\",\"%s\"", "repository",
+               "action", "total_count", "time_unit");
+  for (unsigned int i = 0; i < qs.size(); i++) {
+    format_index += snprintf(buffer + format_index, bufSize - format_index,
+                             ",%0.5f", qs[i]);
+  }
+  format_index += snprintf(buffer + format_index, bufSize - format_index, "\n");
+  assert(format_index < bufSize);
+
+  result += buffer;
+  memset(buffer, 0, sizeof(buffer));
+  format_index = 0;
+
+  vector<Log2Histogram *> hist;
+  vector<string> names;
+  hist.push_back(file_system->hist_fs_lookup());
+  names.push_back("lookup");
+  hist.push_back(file_system->hist_fs_forget());
+  names.push_back("forget");
+  hist.push_back(file_system->hist_fs_forget_multi());
+  names.push_back("forget_multi");
+  hist.push_back(file_system->hist_fs_getattr());
+  names.push_back("getattr");
+  hist.push_back(file_system->hist_fs_readlink());
+  names.push_back("readlink");
+  hist.push_back(file_system->hist_fs_opendir());
+  names.push_back("opendir");
+  hist.push_back(file_system->hist_fs_releasedir());
+  names.push_back("releasedir");
+  hist.push_back(file_system->hist_fs_readdir());
+  names.push_back("readdir");
+  hist.push_back(file_system->hist_fs_open());
+  names.push_back("open");
+  hist.push_back(file_system->hist_fs_read());
+  names.push_back("read");
+  hist.push_back(file_system->hist_fs_release());
+  names.push_back("release");
+
+  for (unsigned int j = 0; j < hist.size(); j++) {
+    Log2Histogram *h = hist[j];
+    unsigned int format_index =
+        snprintf(buffer, bufSize, "\"%s\",\"%s\",%ld,\"%s\"", repo.c_str(),
+                 names[j].c_str(), h->N(), "nanoseconds");
+    for (unsigned int i = 0; i < qs.size(); i++) {
+      format_index += snprintf(buffer + format_index, bufSize - format_index,
+                               ",%d", h->GetQuantile(qs[i]));
+    }
+    format_index +=
+        snprintf(buffer + format_index, bufSize - format_index, "\n");
+    assert(format_index < bufSize);
+
+    result += buffer;
+    memset(buffer, 0, sizeof(buffer));
+    format_index = 0;
+  }
+  return result;
+}
 
 TalkManager::TalkManager(
   const string &socket_path,

--- a/cvmfs/talk.h
+++ b/cvmfs/talk.h
@@ -15,6 +15,7 @@
 namespace download {
 class DownloadManager;
 }
+class FileSystem;
 class FuseRemounter;
 class MountPoint;
 class OptionsManager;
@@ -47,6 +48,8 @@ class TalkManager : SingleCopy {
   void AnswerStringList(int con_fd, const std::vector<std::string> &list);
   std::string FormatHostInfo(download::DownloadManager *download_mgr);
   std::string FormatProxyInfo(download::DownloadManager *download_mgr);
+  std::string FormatLatencies(const MountPoint &mount_point,
+                              FileSystem *file_system);
 
   std::string socket_path_;
   int socket_fd_;

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -105,31 +105,28 @@ std::vector<atomic_int32> UTLog2Histogram::GetBins(const Log2Histogram &h) {
   return h.bins_;
 }
 
-unsigned int Log2Histogram::q(float n) {
-  // we start by counting all the elements of the array, we include the overflow
-  uint64_t total = 0;
+unsigned int Log2Histogram::GetQuantile(float n) {
+  uint64_t total = this->N();
+  // pivot is the index of the element corresponding to the requested quantile
+  uint64_t pivot = total * n;
+  float normalized_pivot = 0.0;
+  // now we iterate through all the bins
+  // note that we _exclude_ the overflow bin
   unsigned int i = 0;
-  for (i = 0; i <= this->bins_.size() - 1; i++) {
-    total += (unsigned int)atomic_read32(&(this->bins_[i]));
-  }
-  // now we found the index of the element we want
-  uint64_t index = total * n;
-  float normalized_index = 0.0;
-  // now we iterate through all the bins (excluding the overflow)
   for (i = 1; 1 <= this->bins_.size() - 1; i++) {
     unsigned int bin_value = (unsigned int)atomic_read32(&(this->bins_[i]));
-    if (index <= bin_value) {
-      normalized_index = static_cast<float>(index) / bin_value;
+    if (pivot <= bin_value) {
+      normalized_pivot = static_cast<float>(pivot) / bin_value;
       break;
     }
-    index -= bin_value;
+    pivot -= bin_value;
   }
-  // now i store the index of the bin we want
-  // and normal_index is the element we want inside the bin
+  // now i stores the index of the bin corresponding to the requested quantile
+  // and normalized_pivot is the element we want inside the bin
   unsigned int min_value = this->boundary_values_[i - 1];
   unsigned int max_value = this->boundary_values_[i];
   // and we return the linear interpolation
-  return min_value + ((max_value - min_value) * normalized_index);
+  return min_value + ((max_value - min_value) * normalized_pivot);
 }
 
 std::string Log2Histogram::ToString() {
@@ -251,24 +248,19 @@ std::string Log2Histogram::ToString() {
                   .75, .8, .9,  .95, .99, .995, .999};
   snprintf(buffer, kBufSize,
            "\n\nQuantiles\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
-           "q,%0.2f,%d\n"
+           "%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,%0.4f,"
+           "%0.4f,%0.4f,%0.4f,%0.4f\n"
+           "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n"
            "End Quantiles"
            "\n-----------------------\n",
-           qs[0], q(qs[0]), qs[1], q(qs[1]), qs[2], q(qs[2]), qs[3], q(qs[3]),
-           qs[4], q(qs[4]), qs[5], q(qs[5]), qs[6], q(qs[6]), qs[7], q(qs[7]),
-           qs[8], q(qs[8]), qs[9], q(qs[9]), qs[10], q(qs[10]), qs[11],
-           q(qs[11]));
+           qs[0], qs[1], qs[2], qs[3], qs[4], qs[5], qs[6], qs[7], qs[8], qs[9],
+           qs[10], qs[11], qs[12], qs[13], qs[14], GetQuantile(qs[0]),
+           GetQuantile(qs[1]), GetQuantile(qs[2]), GetQuantile(qs[3]),
+           GetQuantile(qs[4]), GetQuantile(qs[5]), GetQuantile(qs[6]),
+           GetQuantile(qs[7]), GetQuantile(qs[8]), GetQuantile(qs[9]),
+           GetQuantile(qs[10]), GetQuantile(qs[11]), GetQuantile(qs[12]),
+           GetQuantile(qs[13]), GetQuantile(qs[14]));
+
   result_string += buffer;
   memset(buffer, 0, sizeof(buffer));
 

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -107,19 +107,19 @@ std::vector<atomic_int32> UTLog2Histogram::GetBins(const Log2Histogram &h) {
 
 unsigned int Log2Histogram::q(float n) {
   // we start by counting all the elements of the array, we include the overflow
-  unsigned long int total = 0;
+  uint64_t total = 0;
   unsigned int i = 0;
-  for (i = 0; i<= this->bins_.size() - 1; i++) {
+  for (i = 0; i <= this->bins_.size() - 1; i++) {
     total += (unsigned int)atomic_read32(&(this->bins_[i]));
   }
   // now we found the index of the element we want
-  unsigned long int index = total * n;
+  uint64_t index = total * n;
   float normalized_index = 0.0;
   // now we iterate through all the bins (excluding the overflow)
-  for (i = 1; 1 <= this->bins_.size() - 1; i++ ) {
+  for (i = 1; 1 <= this->bins_.size() - 1; i++) {
     unsigned int bin_value = (unsigned int)atomic_read32(&(this->bins_[i]));
     if (index <= bin_value) {
-      normalized_index = (float)index / bin_value;
+      normalized_index = static_cast<float>(index) / bin_value;
       break;
     }
     index -= bin_value;
@@ -247,7 +247,8 @@ std::string Log2Histogram::ToString() {
   result_string += buffer;
   memset(buffer, 0, sizeof(buffer));
 
-  float qs[15] = {.1, .2, .25, .3, .4, .5, .6, .7, .75, .8, .9, .95, .99, .995, .999};
+  float qs[15] = {.1,  .2, .25, .3,  .4,  .5,   .6,  .7,
+                  .75, .8, .9,  .95, .99, .995, .999};
   snprintf(buffer, kBufSize,
            "\n\nQuantiles\n"
            "q,%0.2f,%d\n"

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -141,6 +141,9 @@ friend class UTLog2Histogram;
     atomic_inc32(&(this->bins_[0]));  // add to overflow bin.
   }
 
+  //compute the quantile of order n
+  unsigned int q(float n);
+
   std::string ToString();
 
   void PrintLog2Histogram();

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -142,9 +142,21 @@ friend class UTLog2Histogram;
   }
 
   /**
+   * Returns the total number of elements in the histogram
+   */
+  inline uint64_t N() {
+    uint64_t n = 0;
+    unsigned int i;
+    for (i = 0; i <= this->bins_.size() - 1; i++) {
+      n += (unsigned int)atomic_read32(&(this->bins_[i]));
+    }
+    return n;
+  }
+
+  /**
    * compute the quantile of order n
    */
-  unsigned int q(float n);
+  unsigned int GetQuantile(float n);
 
   std::string ToString();
 

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -141,7 +141,9 @@ friend class UTLog2Histogram;
     atomic_inc32(&(this->bins_[0]));  // add to overflow bin.
   }
 
-  //compute the quantile of order n
+  /**
+   * compute the quantile of order n
+   */
   unsigned int q(float n);
 
   std::string ToString();

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1850,7 +1850,7 @@ TEST(Log2Histogram, 3Bins) {
 
 TEST(Log2Histogram, Quantiles) {
   int N = 16;
-  long unsigned max = 1 << N;
+  int64_t max = 1 << N;
   // this start to fail with tollerance ~0.001
   // we add a safe factor of 50
   float tollerance = 0.05;
@@ -1860,11 +1860,12 @@ TEST(Log2Histogram, Quantiles) {
   rng.InitLocaltime();
 
   // we are oversampling to test the quantiles
-  long int i = 1 << (N + 4);
+  int64_t i = 1 << (N + 4);
   for (; i >= 0; i--) {
     log2hist.Add(rng.Next(max));
   }
-  float qs[12] = {0.15, 0.20, 0.3, 0.5, 0.75, 0.9, 0.95, 0.99, 0.995, 0.999, 0.9995, 0.9999};
+  float qs[12] = {0.15, 0.20, 0.3,   0.5,   0.75,   0.9,
+                  0.95, 0.99, 0.995, 0.999, 0.9995, 0.9999};
   for (int i = 0; i < 12; i++) {
     double expected = max * qs[i];
     double max_difference = expected * tollerance;

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1851,11 +1851,12 @@ TEST(Log2Histogram, 3Bins) {
 TEST(Log2Histogram, Quantiles) {
   int N = 16;
   int64_t max = 1 << N;
-  // this start to fail with tollerance ~0.001
-  // we add a safe factor of 50
-  float tollerance = 0.05;
   Log2Histogram log2hist(N + 1);
-  // so we can store values up to 2^N
+
+  // the quantile computation to fail with tolerance ~0.001 (~0.1%) we add a
+  // safety factor of 50 (~5%)
+  float tolerance = 0.05;
+
   Prng rng = Prng();
   rng.InitLocaltime();
 
@@ -1868,8 +1869,8 @@ TEST(Log2Histogram, Quantiles) {
                   0.95, 0.99, 0.995, 0.999, 0.9995, 0.9999};
   for (int i = 0; i < 12; i++) {
     double expected = max * qs[i];
-    double max_difference = expected * tollerance;
-    unsigned int q = log2hist.q(qs[i]);
+    double max_difference = expected * tolerance;
+    unsigned int q = log2hist.GetQuantile(qs[i]);
     EXPECT_NEAR(q, expected, max_difference);
   }
 }


### PR DESCRIPTION
Quantiles are useful for performance and regression tests on the
client side.

This was suppose to be one of the first tasks of the summer student. Nevertheless I believe it is important to keep this development line open as well.

It would be interesting to have a command to spit out just this numbers so that we can compare the performance on the client programmatically from different installation and user bases.

At the moment the output produced is somehow like this:

```
Readdir                                                                                                                                  
                    nsec |   count |           distribution |                                                                            
         0 ->          1 :       0 |                        |                                                                            
         2 ->          3 :       0 |                        |                                                                            
         4 ->          7 :       0 |                        |                                                                            
         8 ->         15 :       0 |                        |                                                                            
        16 ->         31 :       0 |                        |                                                                            
        32 ->         63 :       0 |                        |                                                                            
        64 ->        127 :       0 |                        |                                                                            
       128 ->        255 :       0 |                        |                                                                            
       256 ->        511 :       0 |                        |                                                                            
       512 ->       1023 :       0 |                        |                                                                            
      1024 ->       2047 :       8 |                        |                                                                            
      2048 ->       4095 :     748 | ********************** |                                                                            
      4096 ->       8191 :     242 |                ******* |                                                                            
      8192 ->      16383 :      48 |                      * |                                                                            
     16384 ->      32767 :     188 |                  ***** |                                                                            
     32768 ->      65535 :       1 |                        |                                                                            
     65536 ->     131071 :       1 |                        |                                                                            
    131072 ->     262143 :       2 |                        |                                                                            
    262144 ->     524287 :       0 |                        |                                                                            
    524288 ->    1048575 :       0 |                        |                                                                            
   1048576 ->    2097151 :       0 |                        |                                                                            
   2097152 ->    4194303 :       0 |                        |                                                                            
   4194304 ->    8388607 :       0 |                        |                                                                            
   8388608 ->   16777215 :       0 |                        |                                                                            
  16777216 ->   33554431 :       0 |                        |                                                                            
  33554432 ->   67108863 :       0 |                        |                                                                            
  67108864 ->  134217727 :       0 |                        |                                                                            
 134217728 ->  268435455 :       0 |                        |                                                                            
 268435456 ->  536870911 :       0 |                        |
 536870912 -> 1073741823 :       0 |                        |
                overflow :       0 |                        |
                   total :    1238


Quantiles
q,0.10,2362
q,0.20,2702
q,0.25,2872
q,0.30,3041
q,0.40,3381
q,0.50,3720
q,0.60,4057
q,0.70,5957
q,0.75,7007
q,0.80,8056
q,0.90,22310
q,0.95,27713
End Quantiles
-----------------------
```

From `cvmfs_talk internal affairs`

Maybe it is worth to release this on 2.7.2 if you guys agree.