### PR TITLE
Make fast check for images

### DIFF
--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -58,15 +58,11 @@ var convertCmd = &cobra.Command{
 			lib.LogE(err).Error("Impossible to parse the recipe file")
 			os.Exit(ParseRecipeFileError)
 		}
-		if len(recipe.Wishes) == 0 {
-			lib.Log().Info("No recipe to convert")
-			os.Exit(0)
-		}
-		if !lib.RepositoryExists(recipe.Wishes[0].CvmfsRepo) {
+		if !lib.RepositoryExists(recipe.Repo) {
 			lib.LogE(err).Error("The repository does not seems to exists.")
 			os.Exit(RepoNotExistsError)
 		}
-		for _, wish := range recipe.Wishes {
+		for wish := range recipe.Wishes {
 			fields := log.Fields{"input image": wish.InputName,
 				"repository":   wish.CvmfsRepo,
 				"output image": wish.OutputName}

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -59,11 +58,11 @@ var loopCmd = &cobra.Command{
 				lib.LogE(err).Fatal("Impossible to parse the recipe file")
 				os.Exit(1)
 			}
-			if len(recipe.Wishes) == 0 {
-				lib.Log().Warn("No wishes to convert.")
-				time.Sleep(30 * time.Second)
+			if !lib.RepositoryExists(recipe.Repo) {
+				lib.LogE(err).Error("The repository does not seems to exists.")
+				os.Exit(RepoNotExistsError)
 			}
-			for _, wish := range recipe.Wishes {
+			for wish := range recipe.Wishes {
 				fields := log.Fields{"input image": wish.InputName,
 					"repository":   wish.CvmfsRepo,
 					"output image": wish.OutputName}

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -59,7 +59,7 @@ var loopCmd = &cobra.Command{
 				os.Exit(1)
 			}
 			if !lib.RepositoryExists(recipe.Repo) {
-				lib.LogE(err).Error("The repository does not seems to exists.")
+				lib.LogE(err).Error("The repository does not exists.")
 				os.Exit(RepoNotExistsError)
 			}
 			for wish := range recipe.Wishes {

--- a/ducc/lib/cvmfs.go
+++ b/ducc/lib/cvmfs.go
@@ -232,7 +232,7 @@ func getBacklinkFromLayer(CVMFSRepo, layerDigest string) (backlink Backlink, err
 	return
 }
 
-func SaveLayersBacklink(CVMFSRepo string, img Image, layerDigest []string) error {
+func SaveLayersBacklink(CVMFSRepo string, img *Image, layerDigest []string) error {
 	llog := func(l *log.Entry) *log.Entry {
 		return l.WithFields(log.Fields{"action": "save backlink",
 			"repo":  CVMFSRepo,

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -40,7 +40,7 @@ type Image struct {
 	Manifest    *da.Manifest
 }
 
-func (i Image) GetSimpleName() string {
+func (i *Image) GetSimpleName() string {
 	name := fmt.Sprintf("%s/%s", i.Registry, i.Repository)
 	if i.Tag == "" {
 		return name
@@ -49,7 +49,7 @@ func (i Image) GetSimpleName() string {
 	}
 }
 
-func (i Image) WholeName() string {
+func (i *Image) WholeName() string {
 	root := fmt.Sprintf("%s://%s/%s", i.Scheme, i.Registry, i.Repository)
 	if i.Tag != "" {
 		root = fmt.Sprintf("%s:%s", root, i.Tag)
@@ -60,7 +60,7 @@ func (i Image) WholeName() string {
 	return root
 }
 
-func (i Image) GetManifestUrl() string {
+func (i *Image) GetManifestUrl() string {
 	url := fmt.Sprintf("%s://%s/v2/%s/manifests/", i.Scheme, i.Registry, i.Repository)
 	if i.Digest != "" {
 		url = fmt.Sprintf("%s%s", url, i.Digest)
@@ -70,7 +70,7 @@ func (i Image) GetManifestUrl() string {
 	return url
 }
 
-func (i Image) GetReference() string {
+func (i *Image) GetReference() string {
 	if i.Digest == "" && i.Tag != "" {
 		return ":" + i.Tag
 	}
@@ -83,7 +83,7 @@ func (i Image) GetReference() string {
 	panic("Image wrong format, missing both tag and digest")
 }
 
-func (i Image) GetSimpleReference() string {
+func (i *Image) GetSimpleReference() string {
 	if i.Tag != "" {
 		return i.Tag
 	}
@@ -93,7 +93,7 @@ func (i Image) GetSimpleReference() string {
 	panic("Image wrong format, missing both tag and digest")
 }
 
-func (img Image) PrintImage(machineFriendly, csv_header bool) {
+func (img *Image) PrintImage(machineFriendly, csv_header bool) {
 	if machineFriendly {
 		if csv_header {
 			fmt.Printf("name,user,scheme,registry,repository,tag,digest,is_thin\n")
@@ -125,7 +125,7 @@ func (img Image) PrintImage(machineFriendly, csv_header bool) {
 	}
 }
 
-func (img Image) GetManifest() (da.Manifest, error) {
+func (img *Image) GetManifest() (da.Manifest, error) {
 	if img.Manifest != nil {
 		return *img.Manifest, nil
 	}
@@ -145,7 +145,7 @@ func (img Image) GetManifest() (da.Manifest, error) {
 	return manifest, nil
 }
 
-func (img Image) GetChanges() (changes []string, err error) {
+func (img *Image) GetChanges() (changes []string, err error) {
 	user := img.User
 	pass, err := GetPassword()
 	if err != nil {
@@ -214,18 +214,26 @@ func (img Image) GetChanges() (changes []string, err error) {
 	return
 }
 
-func (img Image) GetSingularityLocation() string {
+func (img *Image) GetSingularityLocation() string {
 	return fmt.Sprintf("docker://%s/%s%s", img.Registry, img.Repository, img.GetReference())
 }
 
-func (img Image) GetTagListUrl() string {
+func (img *Image) GetTagListUrl() string {
 	return fmt.Sprintf("%s://%s/v2/%s/tags/list", img.Scheme, img.Registry, img.Repository)
 }
 
-func (img Image) ExpandWildcard() ([]Image, error) {
-	var result []Image
+func (img *Image) ExpandWildcard() (<-chan *Image, error) {
+	result := make(chan *Image, 500)
+	var wg sync.WaitGroup
+	defer func() {
+		go func() {
+			wg.Wait()
+			close(result)
+		}()
+	}()
 	if !img.TagWildcard {
-		result = append(result, img)
+		img.GetManifest()
+		result <- img
 		return result, nil
 	}
 	var tagsList struct {
@@ -272,10 +280,16 @@ func (img Image) ExpandWildcard() ([]Image, error) {
 		return result, nil
 	}
 	for _, tag := range filteredTags {
-		taggedImg := img
-		taggedImg.Tag = tag
-		result = append(result, taggedImg)
+		wg.Add(1)
+		go func(tag string) {
+			defer wg.Done()
+			taggedImg := *img
+			taggedImg.Tag = tag
+			taggedImg.GetManifest()
+			result <- &taggedImg
+		}(tag)
 	}
+
 	return result, nil
 }
 
@@ -305,7 +319,7 @@ func GetSingularityPathFromManifest(manifest da.Manifest) string {
 }
 
 // here is where in the FS we are going to store the singularity image
-func (img Image) GetSingularityPath() (string, error) {
+func (img *Image) GetSingularityPath() (string, error) {
 	manifest, err := img.GetManifest()
 	if err != nil {
 		LogE(err).Error("Error in getting the manifest to figureout the singularity path")
@@ -319,7 +333,7 @@ type Singularity struct {
 	TempDirectory string
 }
 
-func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity, err error) {
+func (img *Image) DownloadSingularityDirectory(rootPath string) (sing Singularity, err error) {
 	dir, err := UserDefinedTempDir(rootPath, "singularity_buffer")
 	if err != nil {
 		LogE(err).Error("Error in creating temporary directory for singularity")
@@ -344,7 +358,7 @@ func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity
 		Start()
 	if err == nil {
 		Log().Info("Successfully download the singularity image")
-		return Singularity{Image: &img, TempDirectory: dir}, nil
+		return Singularity{Image: img, TempDirectory: dir}, nil
 	}
 	if user != "" || pass != "" {
 		Log().Info("Detected error in downloading image with credentials, trying without.")
@@ -355,7 +369,7 @@ func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity
 			Start()
 		if err == nil {
 			Log().Info("Successfully download the singularity image")
-			return Singularity{Image: &img, TempDirectory: dir}, nil
+			return Singularity{Image: img, TempDirectory: dir}, nil
 		}
 	}
 	LogE(err).Error("Error in downloading the singularity image")
@@ -365,7 +379,7 @@ func (img Image) DownloadSingularityDirectory(rootPath string) (sing Singularity
 
 // the one that the user see, without the /cvmfs/$repo.cern.ch prefix
 // used mostly by Singularity
-func (i Image) GetPublicSymlinkPath() string {
+func (i *Image) GetPublicSymlinkPath() string {
 	return filepath.Join(i.Registry, i.Repository+":"+i.GetSimpleReference())
 }
 
@@ -412,7 +426,7 @@ func (s Singularity) IngestIntoCVMFS(CVMFSRepo string) error {
 	return nil
 }
 
-func (img Image) getByteManifest() ([]byte, error) {
+func (img *Image) getByteManifest() ([]byte, error) {
 	pass, err := GetPassword()
 	if err != nil {
 		LogE(err).Warning("Unable to retrieve the password, trying to get the manifest anonymously.")
@@ -421,15 +435,15 @@ func (img Image) getByteManifest() ([]byte, error) {
 	return img.getManifestWithPassword(pass)
 }
 
-func (img Image) getAnonymousManifest() ([]byte, error) {
+func (img *Image) getAnonymousManifest() ([]byte, error) {
 	return getManifestWithUsernameAndPassword(img, "", "")
 }
 
-func (img Image) getManifestWithPassword(password string) ([]byte, error) {
+func (img *Image) getManifestWithPassword(password string) ([]byte, error) {
 	return getManifestWithUsernameAndPassword(img, img.User, password)
 }
 
-func getManifestWithUsernameAndPassword(img Image, user, pass string) ([]byte, error) {
+func getManifestWithUsernameAndPassword(img *Image, user, pass string) ([]byte, error) {
 
 	url := img.GetManifestUrl()
 
@@ -502,7 +516,7 @@ func firstRequestForAuth(url, user, pass string) (token string, err error) {
 	return "", err
 }
 
-func getLayerUrl(img Image, layer da.Layer) string {
+func getLayerUrl(img *Image, layer da.Layer) string {
 	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
 		img.Scheme, img.Registry, img.Repository, layer.Digest)
 }
@@ -512,7 +526,7 @@ type downloadedLayer struct {
 	Path io.ReadCloser
 }
 
-func (img Image) GetLayers(layersChan chan<- downloadedLayer, manifestChan chan<- string, stopGettingLayers <-chan bool, rootPath string) error {
+func (img *Image) GetLayers(layersChan chan<- downloadedLayer, manifestChan chan<- string, stopGettingLayers <-chan bool, rootPath string) error {
 	defer close(layersChan)
 	defer close(manifestChan)
 
@@ -606,7 +620,7 @@ func (img Image) GetLayers(layersChan chan<- downloadedLayer, manifestChan chan<
 	}
 }
 
-func (img Image) downloadLayer(layer da.Layer, token, rootPath string) (toSend downloadedLayer, err error) {
+func (img *Image) downloadLayer(layer da.Layer, token, rootPath string) (toSend downloadedLayer, err error) {
 	user := img.User
 	pass, err := GetPassword()
 	if err != nil {

--- a/ducc/lib/recipe.go
+++ b/ducc/lib/recipe.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"strings"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 
@@ -17,30 +18,42 @@ type YamlRecipeV1 struct {
 }
 
 type Recipe struct {
-	Wishes []WishFriendly
+	Repo   string
+	Wishes chan WishFriendly
 }
 
 func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 	recipeYamlV1 := YamlRecipeV1{}
 	err := yaml.Unmarshal(data, &recipeYamlV1)
-	if err != nil {
-		return Recipe{}, err
-	}
 	recipe := Recipe{}
+	recipe.Repo = recipeYamlV1.CVMFSRepo
+	recipe.Wishes = make(chan WishFriendly, 500)
+	var wg sync.WaitGroup
+	defer func() {
+		go func() {
+			wg.Wait()
+			close(recipe.Wishes)
+		}()
+	}()
+	if err != nil {
+		return recipe, err
+	}
 	for _, inputImage := range recipeYamlV1.Input {
-		input, err := ParseImage(inputImage)
-		if err != nil {
-			LogE(err).WithFields(log.Fields{"image": inputImage}).Warning("Impossible to parse the image")
-			continue
-		}
-		output := formatOutputImage(recipeYamlV1.OutputFormat, input)
-		wish, err := CreateWish(inputImage, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
-		if err != nil {
-			LogE(err).Warning("Error in creating the wish")
-			continue
-		} else {
-			recipe.Wishes = append(recipe.Wishes, wish)
-		}
+		wg.Add(1)
+		go func(inputImage string) {
+			defer wg.Done()
+			input, err := ParseImage(inputImage)
+			if err != nil {
+				LogE(err).WithFields(log.Fields{"image": inputImage}).Warning("Impossible to parse the image")
+			}
+			output := formatOutputImage(recipeYamlV1.OutputFormat, input)
+			wish, err := CreateWish(inputImage, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
+			if err != nil {
+				LogE(err).Warning("Error in creating the wish")
+			} else {
+				recipe.Wishes <- wish
+			}
+		}(inputImage)
 	}
 	return recipe, nil
 }

--- a/ducc/lib/wish.go
+++ b/ducc/lib/wish.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"fmt"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type Wish struct {
@@ -12,13 +14,16 @@ type Wish struct {
 }
 
 type WishFriendly struct {
-	Id         int
-	InputName  string
-	OutputName string
-	CvmfsRepo  string
-	Converted  bool
-	UserInput  string
-	UserOutput string
+	Id                int
+	InputName         string
+	OutputName        string
+	CvmfsRepo         string
+	Converted         bool
+	UserInput         string
+	UserOutput        string
+	InputImage        *Image
+	OutputImage       *Image
+	ExpandedTagImages <-chan *Image
 }
 
 func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string) (wish WishFriendly, err error) {
@@ -45,5 +50,33 @@ func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string
 	wish.CvmfsRepo = cvmfsRepo
 	wish.UserInput = userInput
 	wish.UserOutput = userOutput
+
+	iImage, errI := ParseImage(wish.InputName)
+	wish.InputImage = &iImage
+	wish.InputImage.User = wish.UserInput
+	if errI != nil {
+		wish.InputImage = nil
+		err = errI
+		return
+	}
+	expandedTagImages, errEx := iImage.ExpandWildcard()
+	if errEx != nil {
+		err = errEx
+		LogE(err).WithFields(log.Fields{
+			"input image": inputImage}).
+			Error("Error in retrieving all the tags from the image")
+		return
+	}
+	wish.ExpandedTagImages = expandedTagImages
+
+	oImage, errO := ParseImage(wish.OutputName)
+	wish.OutputImage = &oImage
+	wish.OutputImage.User = wish.UserOutput
+	if errO != nil {
+		wish.OutputImage = nil
+		err = errO
+		return
+	}
+
 	return
 }


### PR DESCRIPTION
Checking if an image is already in DUCC / unpacked is an IO bound task.

We need to fetch the manifest from the registry.
Before this PR the fetch of manifest was done sequentially, in a synchronous way.

Now we pre-fetch the manifest asynchronously.

We replace a standard vector with a go channel and we use goroutines to actually get the manifests.

Improvements in time are significant, from ~5min to ~20second.