### PR TITLE
use different channels for layers and flat conversion

### DIFF
--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -84,7 +84,7 @@ func ConvertWishSingularity(wish WishFriendly) (err error) {
 	}
 	defer os.RemoveAll(tmpDir)
 	var firstError error
-	for inputImage := range wish.ExpandedTagImages {
+	for inputImage := range wish.ExpandedTagImagesFlat {
 		// we want to check if we have already ingested the Singularity image
 		// Several cases are possible
 		// Image not ingested, neither pubSymPath nor privatePath are present
@@ -104,6 +104,13 @@ func ConvertWishSingularity(wish WishFriendly) (err error) {
 		completeSingularityPriPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, singularityPrivatePath)
 		priDirInfo, errPri := os.Stat(completeSingularityPriPath)
 
+		Log().WithFields(log.Fields{
+			"image":                  inputImage.GetSimpleName(),
+			"public path":            completePubSymPath,
+			"err stats pubblic path": errPub,
+			"private path":           completeSingularityPriPath,
+			"err stats private path": errPri,
+		}).Info("Checking if images links are up to date.")
 		// no error in stating both directories
 		// either the image is up to date or the image became stale
 		if errPub == nil && errPri == nil {
@@ -198,7 +205,7 @@ func ConvertWishDocker(wish WishFriendly, convertAgain, forceDownload, createThi
 	}
 
 	var firstError error
-	for expandedImgTag := range wish.ExpandedTagImages {
+	for expandedImgTag := range wish.ExpandedTagImagesLayer {
 		tag := expandedImgTag.Tag
 		outputWithTag := *outputImage
 		if inputImage.TagWildcard {

--- a/ducc/lib/wish.go
+++ b/ducc/lib/wish.go
@@ -14,16 +14,17 @@ type Wish struct {
 }
 
 type WishFriendly struct {
-	Id                int
-	InputName         string
-	OutputName        string
-	CvmfsRepo         string
-	Converted         bool
-	UserInput         string
-	UserOutput        string
-	InputImage        *Image
-	OutputImage       *Image
-	ExpandedTagImages <-chan *Image
+	Id                     int
+	InputName              string
+	OutputName             string
+	CvmfsRepo              string
+	Converted              bool
+	UserInput              string
+	UserOutput             string
+	InputImage             *Image
+	OutputImage            *Image
+	ExpandedTagImagesLayer <-chan *Image
+	ExpandedTagImagesFlat  <-chan *Image
 }
 
 func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string) (wish WishFriendly, err error) {
@@ -59,7 +60,7 @@ func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string
 		err = errI
 		return
 	}
-	expandedTagImages, errEx := iImage.ExpandWildcard()
+	expandedTagImagesLayer, expandedTagImagesFlat, errEx := iImage.ExpandWildcard()
 	if errEx != nil {
 		err = errEx
 		LogE(err).WithFields(log.Fields{
@@ -67,7 +68,8 @@ func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string
 			Error("Error in retrieving all the tags from the image")
 		return
 	}
-	wish.ExpandedTagImages = expandedTagImages
+	wish.ExpandedTagImagesLayer = expandedTagImagesLayer
+	wish.ExpandedTagImagesFlat = expandedTagImagesFlat
 
 	oImage, errO := ParseImage(wish.OutputName)
 	wish.OutputImage = &oImage


### PR DESCRIPTION
A channel can be read from only once, so while we try to read
from the same channel twice (once for the layer conversion and
another time for the flat conversion) the second read will be
empty.

Different solutions might work but I find simpler to just use
two different channels.