### PR TITLE
BUGFIX: div by 0 in generate_stats_plots.C ROOT macro

### DIFF
--- a/cvmfs/server/generate_stats_plots.C
+++ b/cvmfs/server/generate_stats_plots.C
@@ -266,6 +266,9 @@ std::set<std::string> speed_cols =
 
 // returns number of operations/bytes per second
 double getSpeed(Long64_t count, double duration_days) {
+  if (duration_days == 0) {
+    duration_days += 1.f/2.f/86400.f; // add 0.5 sec if start_time == finish_time
+  }
   return count/duration_days/86400;
 }
 


### PR DESCRIPTION
`start_time` and `finish_time` fields in statistics database are precise to one second. If the operation takes less than one second, the duration (`finish_time` - `start_time`) would be 0. If this happens, add 0.5 second so we do not divide by 0. 