### PR TITLE
Create container integration tests

### DIFF
--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# source the common platform independent functionality and option parsing
+script_location=$(dirname $(readlink --canonicalize $0))
+. ${script_location}/common_setup.sh
+
+# install CernVM-FS RPM packages
+echo "installing RPM packages... "
+install_rpm "$CONFIG_PACKAGES"
+install_rpm $CLIENT_PACKAGE
+
+# setup environment
+echo -n "setting up CernVM-FS environment..."
+sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"
+sudo mkdir -p /var/log/cvmfs-test                || die "fail (mkdir /var/log/cvmfs-test)"
+sudo chown sftnight:sftnight /var/log/cvmfs-test || die "fail (chown /var/log/cvmfs-test)"
+sudo systemctl start autofs                      || die "fail (systemctl start autofs)"
+sudo cvmfs_config chksetup > /dev/null           || die "fail (cvmfs_config chksetup)"
+echo "done"
+
+# install docker
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+# Docker is not yet supported on RHEL8 (firewalld issues). Need to do a workaround.
+sudo yum install -y --nobest docker-ce
+sudo firewall-cmd --zone=public --add-masquerade --permanent
+sudo firewall-cmd --reload
+sudo systemctl restart docker
+
+disable_systemd_rate_limit

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -45,13 +45,4 @@ sudo systemctl start autofs                      || die "fail (systemctl start a
 sudo cvmfs_config chksetup > /dev/null           || die "fail (cvmfs_config chksetup)"
 echo "done"
 
-# install docker
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-# Docker is not yet supported on RHEL8 (firewalld issues). Need to do a workaround.
-sudo yum install -y --nobest docker-ce
-sudo firewall-cmd --zone=public --add-masquerade --permanent
-sudo firewall-cmd --reload
-sudo systemctl restart docker
-
 disable_systemd_rate_limit

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -17,6 +17,16 @@ install_from_repo epel-release    || die "fail (install epel-release)"
 install_from_repo singularity     || die "fail (install singularity)"
 install_from_repo runc            || die "fail (install runc)"
 install_from_repo fuse-overlayfs  || die "fail (install fuse-overlayfs)"
+install_from_repo podman          || die "fail (install podman)"
+
+sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+sudo dnf install docker-ce --nobest -y || die "fail (install docker-ce)"
+sudo systemctl start docker            || die "fail (starting docker)"
+sudo usermod -aG docker sftnight
+newgrp docker
+docker ps                              || die "fail (accessing docker)"
+
+install_rpm https://ecsft.cern.ch/cvmfs/dist/builddeps/minikube-1.9.2-0.x86_64.rpm || die "fail (install minikube)"
 
 # setup environment
 echo -n "setting up CernVM-FS environment..."

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -23,9 +23,10 @@ sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo dnf install docker-ce --nobest -y || die "fail (install docker-ce)"
 sudo firewall-cmd --zone=public --add-masquerade --permanent
 sudo firewall-cmd --reload
-sudo systemctl start docker            || die "fail (starting docker)"
 sudo usermod -aG docker sftnight
-newgrp docker
+newgrp - docker
+groups
+sudo systemctl start docker            || die "fail (starting docker)"
 docker ps                              || die "fail (accessing docker)"
 
 install_rpm https://ecsft.cern.ch/cvmfs/dist/builddeps/minikube-1.9.2-0.x86_64.rpm || die "fail (install minikube)"

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -23,12 +23,13 @@ sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo dnf install docker-ce --nobest -y || die "fail (install docker-ce)"
 sudo firewall-cmd --zone=public --add-masquerade --permanent
 sudo firewall-cmd --reload
-sudo cat /etc/group
-sudo cat /etc/passwd
-sudo usermod -aG docker sftnight
-newgrp docker
-id
-groups
+
+# Make docker available to sftnight
+sudo mkdir /usr/lib/systemd/system/docker.socket.d
+echo "[Socket]" | sudo tee /usr/lib/systemd/system/docker.socket.d/10-sftnight.conf
+echo "SocketGroup=sftnight" | sudo tee -a /usr/lib/systemd/system/docker.socket.d/10-sftnight.conf
+sudo systemctl daemon-reload
+
 sudo systemctl start docker            || die "fail (starting docker)"
 docker ps                              || die "fail (accessing docker)"
 

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -9,6 +9,15 @@ echo "installing RPM packages... "
 install_rpm "$CONFIG_PACKAGES"
 install_rpm $CLIENT_PACKAGE
 
+# Singularity is in epel
+echo "enabling epel yum repository..."
+install_from_repo epel-release    || die "fail (install epel-release)"
+
+# Container runtimes and tools
+install_from_repo singularity     || die "fail (install singularity)"
+install_from_repo runc            || die "fail (install runc)"
+install_from_repo fuse-overlayfs  || die "fail (install fuse-overlayfs)"
+
 # setup environment
 echo -n "setting up CernVM-FS environment..."
 sudo cvmfs_config setup                          || die "fail (cvmfs_config setup)"

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -33,7 +33,7 @@ sudo systemctl daemon-reload
 sudo systemctl start docker            || die "fail (starting docker)"
 docker ps                              || die "fail (accessing docker)"
 
-install_rpm https://ecsft.cern.ch/cvmfs/dist/builddeps/minikube-1.9.2-0.x86_64.rpm || die "fail (install minikube)"
+install_rpm https://ecsft.cern.ch/dist/cvmfs/builddeps/minikube-1.9.2-0.x86_64.rpm || die "fail (install minikube)"
 
 
 # install packages to deploy CSI driver

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -23,8 +23,11 @@ sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/dock
 sudo dnf install docker-ce --nobest -y || die "fail (install docker-ce)"
 sudo firewall-cmd --zone=public --add-masquerade --permanent
 sudo firewall-cmd --reload
+sudo cat /etc/group
+sudo cat /etc/passwd
 sudo usermod -aG docker sftnight
-newgrp - docker
+newgrp docker
+id
 groups
 sudo systemctl start docker            || die "fail (starting docker)"
 docker ps                              || die "fail (accessing docker)"

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_setup.sh
@@ -21,12 +21,20 @@ install_from_repo podman          || die "fail (install podman)"
 
 sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo dnf install docker-ce --nobest -y || die "fail (install docker-ce)"
+sudo firewall-cmd --zone=public --add-masquerade --permanent
+sudo firewall-cmd --reload
 sudo systemctl start docker            || die "fail (starting docker)"
 sudo usermod -aG docker sftnight
 newgrp docker
 docker ps                              || die "fail (accessing docker)"
 
 install_rpm https://ecsft.cern.ch/cvmfs/dist/builddeps/minikube-1.9.2-0.x86_64.rpm || die "fail (install minikube)"
+
+
+# install packages to deploy CSI driver
+install_from_repo git     || die "fail (install git)"
+install_from_repo golang  || die "fail (install golang)"
+
 
 # setup environment
 echo -n "setting up CernVM-FS environment..."

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_test.sh
@@ -10,7 +10,7 @@ cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS container integration test cases..."
 CVMFS_TEST_CLASS_NAME=ContainerIntegrationTests                               \
 ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
-                                 container/*                                  \
+                                 container/0*                                 \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_test.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# source the common platform independent functionality and option parsing
+script_location=$(cd "$(dirname "$0")"; pwd)
+. ${script_location}/common_test.sh
+
+retval=0
+
+cd ${SOURCE_DIRECTORY}/test
+echo "running CernVM-FS client test cases..."
+CVMFS_TEST_CLASS_NAME=ContainerIntegrationTests                               \
+./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
+                                 container/*                                  \
+                              || retval=1
+
+
+exit $retval

--- a/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-CONTAINER_test.sh
@@ -7,7 +7,7 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 retval=0
 
 cd ${SOURCE_DIRECTORY}/test
-echo "running CernVM-FS client test cases..."
+echo "running CernVM-FS container integration test cases..."
 CVMFS_TEST_CLASS_NAME=ContainerIntegrationTests                               \
 ./run.sh $CLIENT_TEST_LOGFILE -o ${CLIENT_TEST_LOGFILE}${XUNIT_OUTPUT_SUFFIX} \
                                  container/*                                  \

--- a/test/cloud_testing/platforms/common.sh
+++ b/test/cloud_testing/platforms/common.sh
@@ -157,25 +157,6 @@ mount_partition() {
 }
 
 
-is_linux() {
-  [ x"$(uname)" = x"Linux" ]
-}
-
-
-is_macos() {
-  [ x"$(uname)" = x"Darwin" ]
-}
-
-
-get_number_of_cpu_cores() {
-  if is_linux; then
-    cat /proc/cpuinfo | grep -e '^processor' | wc -l
-  elif is_macos; then
-    sysctl -n hw.ncpu
-  else
-    echo "1"
-  fi
-}
 
 # Disable service start rate limiting for apache and autofs
 disable_systemd_rate_limit() {

--- a/test/container/001-unpacked/main
+++ b/test/container/001-unpacked/main
@@ -1,0 +1,13 @@
+cvmfs_test_name="Bind mount /cvmfs into singularity container"
+cvmfs_test_suites="quick"
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+
+  . ${script_location}/../container_common.sh
+
+  ls /cvmfs/unpacked.cern.ch || return 1
+
+  return 0
+}

--- a/test/container/001-unpacked/main
+++ b/test/container/001-unpacked/main
@@ -1,4 +1,4 @@
-cvmfs_test_name="Bind mount /cvmfs into singularity container"
+cvmfs_test_name="Check availability of /cvmfs/unpacked.cern.ch"
 cvmfs_test_suites="quick"
 
 cvmfs_run_test() {
@@ -7,7 +7,8 @@ cvmfs_run_test() {
 
   . ${script_location}/../container_common.sh
 
-  ls /cvmfs/unpacked.cern.ch || return 1
+  cvmfs_mount unpacked.cern.ch || return 1
+  ls /cvmfs/unpacked.cern.ch || return 2
 
   return 0
 }

--- a/test/container/002-singularity/main
+++ b/test/container/002-singularity/main
@@ -1,0 +1,16 @@
+cvmfs_test_name="Start image from singularity"
+cvmfs_test_suites="quick"
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+
+  . ${script_location}/../container_common.sh
+
+  cvmfs_mount unpacked.cern.ch,atlas.cern.ch || return 1
+  singularity exec --bind /cvmfs \
+    /cvmfs/unpacked.cern.ch/registry.hub.docker.com/library/centos\:centos7 \
+    mount && ls -lah /cvmfs/atlas.cern.ch && ls -lah /cvmfs/cms.cern.ch || return 10
+
+  return 0
+}

--- a/test/container/004-runc/main
+++ b/test/container/004-runc/main
@@ -1,0 +1,36 @@
+cvmfs_test_name="Start image from runc"
+cvmfs_test_suites="quick"
+
+CVMFS_TEST_004_MOUNTPOINT=""
+
+cleanup() {
+  echo "running cleanup()"
+
+  if [ ! -z "$CVMFS_TEST_004_MOUNTPOINT" ]; then
+    echo "unmounting $CVMFS_TEST_004_MOUNTPOINT"
+    sudo umount $CVMFS_TEST_004_MOUNTPOINT
+  fi
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+
+  . ${script_location}/../container_common.sh
+
+  cvmfs_mount unpacked.cern.ch || return 1
+  mkdir -p container/rootfs    || return 2
+  cd container                 || return 3
+
+  CVMFS_TEST_004_MOUNTPOINT=$PWD/rootfs
+  # TODO(jblomer): bind mount in user namespace
+  sudo mount --bind \
+    /cvmfs/unpacked.cern.ch/registry.hub.docker.com/library/centos\:centos7 \
+    $CVMFS_TEST_004_MOUNTPOINT || return 10
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  runc spec --rootless || return 20
+  # TODO(jblomer): mount rootfs with fuse-overlayfs
+
+  return 0
+}

--- a/test/container/005-csi/Dockerfile
+++ b/test/container/005-csi/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:7
+LABEL description="CernVM-FS CSI Plugin"
+
+RUN yum install -y http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && \
+    yum install -y cvmfs && yum clean all && rm -rf /var/cache/yum
+
+COPY configs/default.local /etc/cvmfs
+
+COPY bin/csi-cvmfsplugin /csi-cvmfsplugin
+RUN chmod +x /csi-cvmfsplugin
+ENTRYPOINT ["/csi-cvmfsplugin"]

--- a/test/container/005-csi/Dockerfile
+++ b/test/container/005-csi/Dockerfile
@@ -5,6 +5,7 @@ RUN yum install -y http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-l
     yum install -y cvmfs && yum clean all && rm -rf /var/cache/yum
 
 COPY configs/default.local /etc/cvmfs
+RUN echo CVMFS_HTTP_PROXY=DIRECT >> /etc/cvmfs/default.local
 
 COPY bin/csi-cvmfsplugin /csi-cvmfsplugin
 RUN chmod +x /csi-cvmfsplugin

--- a/test/container/005-csi/csi-cvmfsplugin-attacher.yaml
+++ b/test/container/005-csi/csi-cvmfsplugin-attacher.yaml
@@ -1,0 +1,69 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cvmfsplugin-attacher
+  namespace: cvmfs
+  labels:
+    app: csi-cvmfsplugin-attacher
+spec:
+  selector:
+    app: csi-cvmfsplugin-attacher
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: csi-cvmfsplugin-attacher
+  name: csi-cvmfsplugin-attacher
+  namespace: cvmfs
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: csi-cvmfsplugin-attacher
+  serviceName: csi-cvmfsplugin-attacher
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: csi-cvmfsplugin-attacher
+    spec:
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/kubelet/plugins/csi-cvmfsplugin/csi.sock
+        image: quay.io/k8scsi/csi-attacher:v1.0.1
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/plugins/csi-cvmfsplugin
+          name: socket-dir
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cvmfs-attacher
+      serviceAccountName: cvmfs-attacher
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi-cvmfsplugin
+          type: DirectoryOrCreate
+        name: socket-dir
+  updateStrategy:
+    type: OnDelete
+status:
+  replicas: 0

--- a/test/container/005-csi/csi-cvmfsplugin.yaml
+++ b/test/container/005-csi/csi-cvmfsplugin.yaml
@@ -48,13 +48,9 @@ spec:
           name: registration-dir
       - args:
         - --nodeid=$(NODE_ID)
-        - --type=cvmfs
-        - --nodeserver=true
         - --endpoint=$(CSI_ENDPOINT)
         - --v=5
         - --drivername=cvmfs.csi.cern.ch
-        - --metadatastorage=k8s_configmap
-        - --mountcachedir=/mount-cache-dir
         env:
         - name: NODE_ID
           valueFrom:
@@ -98,13 +94,8 @@ spec:
           readOnly: true
         - mountPath: /dev
           name: host-dev
-        - mountPath: /etc/cvmfs-csi-config/
-          name: cvmfs-csi-config
         - mountPath: /tmp/csi/keys
           name: keys-tmp-dir
-        - mountPath: /etc/cvmfs/default.local
-          name: cvmfs-config
-          subPath: cvmfs-override
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always
@@ -144,17 +135,9 @@ spec:
           path: /dev
           type: ""
         name: host-dev
-      - configMap:
-          defaultMode: 420
-          name: cvmfs-csi-config
-        name: cvmfs-csi-config
       - emptyDir:
           medium: Memory
         name: keys-tmp-dir
-      - configMap:
-          defaultMode: 420
-          name: config
-        name: cvmfs-config
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/test/container/005-csi/csi-cvmfsplugin.yaml
+++ b/test/container/005-csi/csi-cvmfsplugin.yaml
@@ -1,0 +1,166 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "0"
+  creationTimestamp: null
+  name: csi-cvmfsplugin
+  namespace: cvmfs
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: csi-cvmfsplugin
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: csi-cvmfsplugin
+    spec:
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/cvmfs.csi.cern.ch/csi.sock
+        env:
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - rm -rf /registration/csi-cvmfsplugin /registration/csi-cvmfsplugin-reg.sock
+        name: driver-registrar
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --nodeid=$(NODE_ID)
+        - --type=cvmfs
+        - --nodeserver=true
+        - --endpoint=$(CSI_ENDPOINT)
+        - --v=5
+        - --drivername=cvmfs.csi.cern.ch
+        - --metadatastorage=k8s_configmap
+        - --mountcachedir=/mount-cache-dir
+        env:
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        image: csi-cvmfsplugin:latest
+        imagePullPolicy: IfNotPresent
+        name: csi-cvmfsplugin
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /mount-cache-dir
+          name: mount-cache-dir
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
+          name: mountpoint-dir
+        - mountPath: /var/lib/kubelet/plugins
+          mountPropagation: Bidirectional
+          name: plugin-dir
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /dev
+          name: host-dev
+        - mountPath: /etc/cvmfs-csi-config/
+          name: cvmfs-csi-config
+        - mountPath: /tmp/csi/keys
+          name: keys-tmp-dir
+        - mountPath: /etc/cvmfs/default.local
+          name: cvmfs-config
+          subPath: cvmfs-override
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: cvmfs-csi-nodeplugin
+      serviceAccountName: cvmfs-csi-nodeplugin
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: mount-cache-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/cvmfs.csi.cern.ch/
+          type: DirectoryOrCreate
+        name: socket-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+        name: registration-dir
+      - hostPath:
+          path: /var/lib/kubelet/pods
+          type: DirectoryOrCreate
+        name: mountpoint-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins
+          type: Directory
+        name: plugin-dir
+      - hostPath:
+          path: /sys
+          type: ""
+        name: host-sys
+      - hostPath:
+          path: /lib/modules
+          type: ""
+        name: lib-modules
+      - hostPath:
+          path: /dev
+          type: ""
+        name: host-dev
+      - configMap:
+          defaultMode: 420
+          name: cvmfs-csi-config
+        name: cvmfs-csi-config
+      - emptyDir:
+          medium: Memory
+        name: keys-tmp-dir
+      - configMap:
+          defaultMode: 420
+          name: config
+        name: cvmfs-config
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0

--- a/test/container/005-csi/csi-provisioner-rbac.yaml
+++ b/test/container/005-csi/csi-provisioner-rbac.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cvmfs-csi-provisioner
+  namespace: cvmfs
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-external-provisioner-runner
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.cvmfs.csi.cern.ch/aggregate-to-cvmfs-external-provisioner-runner: "true"
+rules: []
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-external-provisioner-runner-rules
+  labels:
+    rbac.cvmfs.csi.cern.ch/aggregate-to-cvmfs-external-provisioner-runner: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+   
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-csi-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: cvmfs-csi-provisioner
+    namespace: cvmfs
+roleRef:
+  kind: ClusterRole
+  name: cvmfs-external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: cvmfs
+  name: cvmfs-external-provisioner-cfg
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-csi-provisioner-role-cfg
+  namespace: cvmfs
+subjects:
+  - kind: ServiceAccount
+    name: cvmfs-csi-provisioner
+    namespace: cvmfs
+roleRef:
+  kind: Role
+  name: cvmfs-external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/test/container/005-csi/logs.sh
+++ b/test/container/005-csi/logs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright CERN.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+CONTAINER_NAME=csi-cvmfsplugin
+POD_NAME=$(minikube kubectl -- get pods -A -l app=$CONTAINER_NAME -o=name | head -n 1)
+echo "POD name is $POD_NAME"
+
+function get_pod_status() {
+	echo -n $(minikube kubectl -- get --namespace=cvmfs $POD_NAME -o jsonpath="{.status.phase}")
+}
+
+while [[ "$(get_pod_status)" != "Running" ]]; do
+	sleep 1
+	echo "Waiting for $POD_NAME (status $(get_pod_status))"
+done
+
+minikube kubectl -- logs -f $POD_NAME -c $CONTAINER_NAME

--- a/test/container/005-csi/main
+++ b/test/container/005-csi/main
@@ -3,7 +3,7 @@ cvmfs_test_name="Use k8s CSI driver"
 cleanup() {
   echo "running cleanup()"
 
-  k8s_destroy
+  #k8s_destroy
 }
 
 cvmfs_run_test() {
@@ -30,7 +30,7 @@ cvmfs_run_test() {
   cd cvmfs-csi
   make build || return 21
   eval $(minikube docker-env)
-  docker build -t csi-cvmfsplugin:master -f ${script_location}/Dockerfile .
+  docker build -t csi-cvmfsplugin:latest -f ${script_location}/Dockerfile .
 
   echo "*** deploy cvmfs CSI driver"
   k8s_kubectl create -f deployments/kubernetes/namespace.yaml                   || return 30
@@ -40,14 +40,19 @@ cvmfs_run_test() {
   k8s_kubectl create -f deployments/kubernetes/csi-nodeplugin-rbac.yaml         || return 33
   k8s_kubectl create -f $script_location/csi-cvmfsplugin-attacher.yaml          || return 34
   k8s_kubectl create -f deployments/kubernetes/csi-cvmfsplugin-provisioner.yaml || return 35
-  k8s_kubectl create -f $script_location/csi-cvmfsplugin.yaml                   || return 36
+
+  echo "CVMFS_HTTP_PROXY=DIRECT" > default.local
+  k8s_kubectl create --namespace=cvmfs configmap config \
+    --from-file=cvmfs-override=./default.local   || return 36
+  k8s_kubectl create -f $script_location/csi-cvmfsplugin.yaml   || return 37
   k8s_kubectl get all -A
-  # ${script_location}/logs.sh || return 37
+  k8s_kubectl get ev -A
+  #${script_location}/logs.sh                                    || return 38
 
   echo "*** run demo POD"
-  k8s_kubectl create -f example/storageclass.yaml || return 40
-  k8s_kubectl create -f example/pvc.yaml          || return 41
-  k8s_kubectl create -f example/pod.yaml          || return 42
+  #k8s_kubectl create -f example/storageclass.yaml || return 40
+  #k8s_kubectl create -f example/pvc.yaml          || return 41
+  #k8s_kubectl create -f example/pod.yaml          || return 42
 
   return 0
 }

--- a/test/container/005-csi/main
+++ b/test/container/005-csi/main
@@ -1,0 +1,27 @@
+cvmfs_test_name="Use k8s CSI driver"
+
+cleanup() {
+  echo "running cleanup()"
+
+  if [ ! -z "$CVMFS_TEST_004_MOUNTPOINT" ]; then
+    echo "unmounting $CVMFS_TEST_004_MOUNTPOINT"
+    sudo umount $CVMFS_TEST_004_MOUNTPOINT
+  fi
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+
+  . ${script_location}/../container_common.sh
+
+  if [ `get_number_of_cpu_cores` -lt 2 ]; then
+    echo "requires at least 2 CPUs (available: `get_number_of_cpu_cores`)"
+    return 1
+  fi
+
+  trap cleanup EXIT HUP INT TERM || return $?
+
+
+  return 0
+}

--- a/test/container/005-csi/main
+++ b/test/container/005-csi/main
@@ -3,10 +3,7 @@ cvmfs_test_name="Use k8s CSI driver"
 cleanup() {
   echo "running cleanup()"
 
-  if [ ! -z "$CVMFS_TEST_004_MOUNTPOINT" ]; then
-    echo "unmounting $CVMFS_TEST_004_MOUNTPOINT"
-    sudo umount $CVMFS_TEST_004_MOUNTPOINT
-  fi
+  k8s_destroy
 }
 
 cvmfs_run_test() {
@@ -15,13 +12,42 @@ cvmfs_run_test() {
 
   . ${script_location}/../container_common.sh
 
+  #echo "client package: $CVMFS_CLIENT_PACKAGE"
+  #exit 0
+
   if [ `get_number_of_cpu_cores` -lt 2 ]; then
     echo "requires at least 2 CPUs (available: `get_number_of_cpu_cores`)"
     return 1
   fi
 
+  echo "*** start k8s cluster"
+  k8s_create v1.17.0 || return 10
   trap cleanup EXIT HUP INT TERM || return $?
+  k8s_kubectl get po -A || return 11
 
+  echo "*** build cvmfs CSI driver"
+  git clone https://github.com/cernops/cvmfs-csi || return 20
+  cd cvmfs-csi
+  make build || return 21
+  eval $(minikube docker-env)
+  docker build -t csi-cvmfsplugin:master -f ${script_location}/Dockerfile .
+
+  echo "*** deploy cvmfs CSI driver"
+  k8s_kubectl create -f deployments/kubernetes/namespace.yaml                   || return 30
+  k8s_kubectl create -f deployments/kubernetes/csi-attacher-rbac.yaml           || return 31
+  # TODO(jblomer): use upstream yaml once fixed
+  k8s_kubectl create -f $script_location/csi-provisioner-rbac.yaml              || return 32
+  k8s_kubectl create -f deployments/kubernetes/csi-nodeplugin-rbac.yaml         || return 33
+  k8s_kubectl create -f $script_location/csi-cvmfsplugin-attacher.yaml          || return 34
+  k8s_kubectl create -f deployments/kubernetes/csi-cvmfsplugin-provisioner.yaml || return 35
+  k8s_kubectl create -f $script_location/csi-cvmfsplugin.yaml                   || return 36
+  k8s_kubectl get all -A
+  # ${script_location}/logs.sh || return 37
+
+  echo "*** run demo POD"
+  k8s_kubectl create -f example/storageclass.yaml || return 40
+  k8s_kubectl create -f example/pvc.yaml          || return 41
+  k8s_kubectl create -f example/pod.yaml          || return 42
 
   return 0
 }

--- a/test/container/container_common.sh
+++ b/test/container/container_common.sh
@@ -1,0 +1,14 @@
+# This file is part of the CernVM File System
+
+k8s_create() {
+  local version=${1:=latest}
+  minikube start --kubernetes-version=$version
+}
+
+k8s_destroy() {
+  minikube delete --all
+}
+
+k8s_kubectl() {
+  minikube kubectl -- $@
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -395,6 +395,27 @@ uses_overlayfs() {
 }
 
 
+is_linux() {
+  [ x"$(uname)" = x"Linux" ]
+}
+
+
+is_macos() {
+  [ x"$(uname)" = x"Darwin" ]
+}
+
+
+get_number_of_cpu_cores() {
+  if is_linux; then
+    cat /proc/cpuinfo | grep -e '^processor' | wc -l
+  elif is_macos; then
+    sysctl -n hw.ncpu
+  else
+    echo "1"
+  fi
+}
+
+
 break_hardlink() {
   local path="$1"
   local tmp_file="$(mktemp)"
@@ -2448,7 +2469,7 @@ set_up_repository_gateway() {
 
     echo "  Stopping repository gateway"
     sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
-    
+
     echo "  Cleaning up the repository gateway db"
     sudo rm -rf /var/lib/cvmfs-gateway/*
 


### PR DESCRIPTION
Adds a new EL8 based platform to test various container runtime integration scenarios with a new suite of tests.  This should serve both as a regular integration test suite and as a documentation on how to use cvmfs with containers.