### PR TITLE
Fix generation of JSON snippets

### DIFF
--- a/cvmfs/json_document.cc
+++ b/cvmfs/json_document.cc
@@ -15,29 +15,6 @@
 
 using namespace std;  // NOLINT
 
-bool ToJsonString(const JsonStringInput &input, std::string *output) {
-  if (!output) {
-    return false;
-  }
-
-  output->clear();
-  *output = "{";
-  for (size_t i = 0u; i < input.entries.size(); ++i) {
-    *output += string("\"") + input.entries[i].key + "\":";
-    if (input.entries[i].quoted) {
-      *output += string("\"") + input.entries[i].val + "\"";
-    } else {
-      *output += input.entries[i].val;
-    }
-    if (i < input.entries.size() - 1) {
-      *output += ',';
-    }
-  }
-  *output += string("}");
-
-  return true;
-}
-
 JsonDocument *JsonDocument::Create(const string &text) {
   UniquePtr<JsonDocument> json(new JsonDocument());
   bool retval = json->Parse(text);

--- a/cvmfs/json_document.h
+++ b/cvmfs/json_document.h
@@ -12,36 +12,9 @@
 #include "json.h"
 #include "util/single_copy.h"
 
+#include "json_document_write.h"
+
 typedef struct json_value JSON;
-
-// This class is used for marshalling JSON objects to strings.
-// When adding an object, use quoted = true for strings and
-// quoted = false for numbers, nested objects, etc.
-
-struct JsonStringInput {
-  struct JsonStringEntry {
-    std::string key;
-    std::string val;
-    bool quoted;
-
-    JsonStringEntry() {
-      quoted = true;
-    }
-  };
-
-  void PushBack(std::string key, std::string val, bool quoted = true) {
-    JsonStringEntry entry;
-    entry.key = key;
-    entry.val = val;
-    entry.quoted = quoted;
-    entries.push_back(entry);
-  }
-
-
-  std::vector<JsonStringEntry> entries;
-};
-
-bool ToJsonString(const JsonStringInput &input, std::string *output);
 
 class JsonDocument : SingleCopy {
  public:

--- a/cvmfs/json_document.h
+++ b/cvmfs/json_document.h
@@ -12,8 +12,6 @@
 #include "json.h"
 #include "util/single_copy.h"
 
-#include "json_document_write.h"
-
 typedef struct json_value JSON;
 
 class JsonDocument : SingleCopy {

--- a/cvmfs/json_document_write.h
+++ b/cvmfs/json_document_write.h
@@ -23,20 +23,12 @@ class JsonStringGenerator {
   };
 
  public:
-  void PushBackQuoted(std::string key, std::string val) {
-    this->PushBack(key, val, true);
+  void AddQuoted(std::string key, std::string val) {
+    this->Add(key, val, true);
   }
 
-  void PushBackUnquoted(std::string key, std::string val) {
-    this->PushBack(key, val, false);
-  }
-
-  void PushBack(std::string key, std::string val, bool quoted = true) {
-    JsonStringEntry entry;
-    entry.key = key;
-    entry.val = val;
-    entry.is_quoted = quoted;
-    entries.push_back(entry);
+  void AddUnquoted(std::string key, std::string val) {
+    this->Add(key, val, false);
   }
 
   std::string GenerateString() const {
@@ -59,6 +51,14 @@ class JsonStringGenerator {
   }
 
  private:
+  void Add(std::string key, std::string val, bool quoted = true) {
+    JsonStringEntry entry;
+    entry.key = key;
+    entry.val = val;
+    entry.is_quoted = quoted;
+    entries.push_back(entry);
+  }
+
   std::vector<JsonStringEntry> entries;
 };
 

--- a/cvmfs/json_document_write.h
+++ b/cvmfs/json_document_write.h
@@ -1,0 +1,55 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_JSON_DOCUMENT_WRITE_H_
+#define CVMFS_JSON_DOCUMENT_WRITE_H_
+
+// This class is used for marshalling JSON objects to strings.
+// When adding an object, use quoted = true for strings and
+// quoted = false for numbers, nested objects, etc.
+
+class JsonStringGenerator {
+  struct JsonStringEntry {
+    std::string key;
+    std::string val;
+    bool quoted;
+
+    JsonStringEntry() {
+      quoted = true;
+    }
+  };
+
+ public:
+  void PushBack(std::string key, std::string val, bool quoted = true) {
+    JsonStringEntry entry;
+    entry.key = key;
+    entry.val = val;
+    entry.quoted = quoted;
+    entries.push_back(entry);
+  }
+
+  std::string GenerateString() const {
+    std::string output;
+
+    output += "{";
+    for (size_t i = 0u; i < this->entries.size(); ++i) {
+      output += std::string("\"") + this->entries[i].key + "\":";
+      if (this->entries[i].quoted) {
+        output += std::string("\"") + this->entries[i].val + "\"";
+      } else {
+        output += this->entries[i].val;
+      }
+      if (i < this->entries.size() - 1) {
+        output += ',';
+      }
+    }
+    output += std::string("}");
+    return output;
+  }
+
+ private:
+  std::vector<JsonStringEntry> entries;
+};
+
+#endif  // CVMFS_JSON_DOCUMENT_H_

--- a/cvmfs/json_document_write.h
+++ b/cvmfs/json_document_write.h
@@ -5,6 +5,9 @@
 #ifndef CVMFS_JSON_DOCUMENT_WRITE_H_
 #define CVMFS_JSON_DOCUMENT_WRITE_H_
 
+#include <string>
+#include <vector>
+
 // This class is used for marshalling JSON objects to strings.
 // When adding an object, use quoted = true for strings and
 // quoted = false for numbers, nested objects, etc.
@@ -52,4 +55,4 @@ class JsonStringGenerator {
   std::vector<JsonStringEntry> entries;
 };
 
-#endif  // CVMFS_JSON_DOCUMENT_H_
+#endif  // CVMFS_JSON_DOCUMENT_WRITE_H_

--- a/cvmfs/json_document_write.h
+++ b/cvmfs/json_document_write.h
@@ -8,27 +8,34 @@
 #include <string>
 #include <vector>
 
-// This class is used for marshalling JSON objects to strings.
-// When adding an object, use quoted = true for strings and
-// quoted = false for numbers, nested objects, etc.
-
+/**
+ * This class is used for marshalling JSON objects to strings.
+ * When adding an object, use the Quoted variant when adding a
+ * string and the Unquoted variant when adding anything else.
+ */
 class JsonStringGenerator {
   struct JsonStringEntry {
     std::string key;
     std::string val;
-    bool quoted;
+    bool is_quoted;
 
-    JsonStringEntry() {
-      quoted = true;
-    }
+    JsonStringEntry() : is_quoted(true) {}
   };
 
  public:
+  void PushBackQuoted(std::string key, std::string val) {
+    this->PushBack(key, val, true);
+  }
+
+  void PushBackUnquoted(std::string key, std::string val) {
+    this->PushBack(key, val, false);
+  }
+
   void PushBack(std::string key, std::string val, bool quoted = true) {
     JsonStringEntry entry;
     entry.key = key;
     entry.val = val;
-    entry.quoted = quoted;
+    entry.is_quoted = quoted;
     entries.push_back(entry);
   }
 
@@ -38,7 +45,7 @@ class JsonStringGenerator {
     output += "{";
     for (size_t i = 0u; i < this->entries.size(); ++i) {
       output += std::string("\"") + this->entries[i].key + "\":";
-      if (this->entries[i].quoted) {
+      if (this->entries[i].is_quoted) {
         output += std::string("\"") + this->entries[i].val + "\"";
       } else {
         output += this->entries[i].val;

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -218,9 +218,9 @@ bool Reactor::HandleGenerateToken(const std::string& req, std::string* reply) {
   }
 
   JsonStringGenerator input;
-  input.PushBack("token", session_token.c_str());
-  input.PushBack("id", public_token_id.c_str());
-  input.PushBack("secret", token_secret.c_str());
+  input.AddQuoted("token", session_token.c_str());
+  input.AddQuoted("id", public_token_id.c_str());
+  input.AddQuoted("secret", token_secret.c_str());
   std::string json = input.GenerateString();
   *reply = json;
 
@@ -235,11 +235,11 @@ bool Reactor::HandleGetTokenId(const std::string& req, std::string* reply) {
   std::string token_id;
   JsonStringGenerator input;
   if (!GetTokenPublicId(req, &token_id)) {
-    input.PushBack("status", "error");
-    input.PushBack("reason", "invalid_token");
+    input.AddQuoted("status", "error");
+    input.AddQuoted("reason", "invalid_token");
   } else {
-    input.PushBack("status", "ok");
-    input.PushBack("id", token_id);
+    input.AddQuoted("status", "ok");
+    input.AddQuoted("id", token_id);
   }
   std::string json = input.GenerateString();
   *reply = json;
@@ -277,18 +277,18 @@ bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
   switch (ret) {
     case kExpired:
       // Expired token
-      input.PushBack("status", "error");
-      input.PushBack("reason", "expired_token");
+      input.AddQuoted("status", "error");
+      input.AddQuoted("reason", "expired_token");
       break;
     case kInvalid:
       // Invalid token
-      input.PushBack("status", "error");
-      input.PushBack("reason", "invalid_token");
+      input.AddQuoted("status", "error");
+      input.AddQuoted("reason", "invalid_token");
       break;
     case kValid:
       // All ok
-      input.PushBack("status", "ok");
-      input.PushBack("path", path);
+      input.AddQuoted("status", "ok");
+      input.AddQuoted("path", path);
       break;
     default:
       // Should not be reached
@@ -343,19 +343,19 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
 
   switch (res) {
     case PayloadProcessor::kPathViolation:
-      reply_input.PushBack("status", "error");
-      reply_input.PushBack("reason", "path_violation");
+      reply_input.AddQuoted("status", "error");
+      reply_input.AddQuoted("reason", "path_violation");
       break;
     case PayloadProcessor::kOtherError:
-      reply_input.PushBack("status", "error");
-      reply_input.PushBack("reason", "other_error");
+      reply_input.AddQuoted("status", "error");
+      reply_input.AddQuoted("reason", "other_error");
       break;
     case PayloadProcessor::kUploaderError:
-      reply_input.PushBack("status", "error");
-      reply_input.PushBack("reason", "uploader_error");
+      reply_input.AddQuoted("status", "error");
+      reply_input.AddQuoted("reason", "uploader_error");
       break;
     case PayloadProcessor::kSuccess:
-      reply_input.PushBack("status", "ok");
+      reply_input.AddQuoted("status", "ok");
       break;
     default:
       PANIC(kLogSyslogErr,
@@ -366,7 +366,7 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
 
   // HandleSubmitPayload sends partial statistics back to the gateway
   std::string stats_json = statistics.PrintJSON();
-  reply_input.PushBack("statistics", stats_json, false);
+  reply_input.AddUnquoted("statistics", stats_json);
 
   std::string json = reply_input.GenerateString();
   *reply = json;
@@ -431,19 +431,19 @@ bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
   JsonStringGenerator reply_input;
   switch (res) {
     case CommitProcessor::kSuccess:
-      reply_input.PushBack("status", "ok");
+      reply_input.AddQuoted("status", "ok");
       break;
     case CommitProcessor::kError:
-      reply_input.PushBack("status", "error");
-      reply_input.PushBack("reason", "miscellaneous");
+      reply_input.AddQuoted("status", "error");
+      reply_input.AddQuoted("reason", "miscellaneous");
       break;
     case CommitProcessor::kMergeFailure:
-      reply_input.PushBack("status", "error");
-      reply_input.PushBack("reason", "merge_error");
+      reply_input.AddQuoted("status", "error");
+      reply_input.AddQuoted("reason", "merge_error");
       break;
     case CommitProcessor::kMissingReflog:
-      reply_input.PushBack("status", "error");
-      reply_input.PushBack("reason", "missing_reflog");
+      reply_input.AddQuoted("status", "error");
+      reply_input.AddQuoted("reason", "missing_reflog");
       break;
     default:
       PANIC(kLogSyslogErr,

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -222,7 +222,7 @@ bool Reactor::HandleGenerateToken(const std::string& req, std::string* reply) {
   input.PushBack("id", public_token_id.c_str());
   input.PushBack("secret", token_secret.c_str());
   std::string json = input.GenerateString();
-  reply->assign(json);
+  *reply = json;
 
   return true;
 }
@@ -242,7 +242,7 @@ bool Reactor::HandleGetTokenId(const std::string& req, std::string* reply) {
     input.PushBack("id", token_id);
   }
   std::string json = input.GenerateString();
-  reply->assign(json);
+  *reply = json;
 
   return true;
 }
@@ -297,7 +297,7 @@ bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
   }
 
   std::string json = input.GenerateString();
-  reply->assign(json);
+  *reply = json;
 
   return true;
 }
@@ -369,7 +369,7 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
   reply_input.PushBack("statistics", stats_json, false);
 
   std::string json = reply_input.GenerateString();
-  reply->assign(json);
+  *reply = json;
 
   return true;
 }
@@ -452,7 +452,7 @@ bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
   }
 
   std::string json = reply_input.GenerateString();
-  reply->assign(json);
+  *reply = json;
 
   return true;
 }

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -222,8 +222,8 @@ bool Reactor::HandleGenerateToken(const std::string& req, std::string* reply) {
   input.PushBack("id", public_token_id.c_str());
   input.PushBack("secret", token_secret.c_str());
   std::string json = input.GenerateString();
+  reply->assign(json);
 
-  reply = &json;
   return true;
 }
 
@@ -242,8 +242,8 @@ bool Reactor::HandleGetTokenId(const std::string& req, std::string* reply) {
     input.PushBack("id", token_id);
   }
   std::string json = input.GenerateString();
+  reply->assign(json);
 
-  reply = &json;
   return true;
 }
 
@@ -297,7 +297,8 @@ bool Reactor::HandleCheckToken(const std::string& req, std::string* reply) {
   }
 
   std::string json = input.GenerateString();
-  reply = &json;
+  reply->assign(json);
+
   return true;
 }
 
@@ -368,7 +369,8 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string& req,
   reply_input.PushBack("statistics", stats_json, false);
 
   std::string json = reply_input.GenerateString();
-  reply = &json;
+  reply->assign(json);
+
   return true;
 }
 
@@ -450,7 +452,7 @@ bool Reactor::HandleCommit(const std::string& req, std::string* reply) {
   }
 
   std::string json = reply_input.GenerateString();
-  reply = &json;
+  reply->assign(json);
 
   return true;
 }

--- a/cvmfs/receiver/reactor.h
+++ b/cvmfs/receiver/reactor.h
@@ -56,12 +56,12 @@ class Reactor {
  protected:
   // NOTE: These methods are virtual such that they can be mocked for the
   // purpose of unit testing
-  virtual bool HandleGenerateToken(const std::string& req, std::string* reply);
-  virtual bool HandleGetTokenId(const std::string& req, std::string* reply);
-  virtual bool HandleCheckToken(const std::string& req, std::string* reply);
+  virtual bool HandleGenerateToken(const std::string& req, std::string& reply);
+  virtual bool HandleGetTokenId(const std::string& req, std::string& reply);
+  virtual bool HandleCheckToken(const std::string& req, std::string& reply);
   virtual bool HandleSubmitPayload(int fdin, const std::string& req,
-                                   std::string* reply);
-  virtual bool HandleCommit(const std::string& req, std::string* reply);
+                                   std::string& reply);
+  virtual bool HandleCommit(const std::string& req, std::string& reply);
 
   virtual PayloadProcessor* MakePayloadProcessor();
   virtual CommitProcessor* MakeCommitProcessor();

--- a/cvmfs/receiver/reactor.h
+++ b/cvmfs/receiver/reactor.h
@@ -56,12 +56,12 @@ class Reactor {
  protected:
   // NOTE: These methods are virtual such that they can be mocked for the
   // purpose of unit testing
-  virtual bool HandleGenerateToken(const std::string& req, std::string& reply);
-  virtual bool HandleGetTokenId(const std::string& req, std::string& reply);
-  virtual bool HandleCheckToken(const std::string& req, std::string& reply);
+  virtual bool HandleGenerateToken(const std::string& req, std::string* reply);
+  virtual bool HandleGetTokenId(const std::string& req, std::string* reply);
+  virtual bool HandleCheckToken(const std::string& req, std::string* reply);
   virtual bool HandleSubmitPayload(int fdin, const std::string& req,
-                                   std::string& reply);
-  virtual bool HandleCommit(const std::string& req, std::string& reply);
+                                   std::string* reply);
+  virtual bool HandleCommit(const std::string& req, std::string* reply);
 
   virtual PayloadProcessor* MakePayloadProcessor();
   virtual CommitProcessor* MakeCommitProcessor();

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -290,11 +290,11 @@ bool SessionContext::Commit(const std::string& old_root_hash,
                             const std::string& new_root_hash,
                             const RepositoryTag& tag) {
   JsonStringGenerator request_input;
-  request_input.PushBack("old_root_hash", old_root_hash);
-  request_input.PushBack("new_root_hash", new_root_hash);
-  request_input.PushBack("tag_name", tag.name_);
-  request_input.PushBack("tag_channel", tag.channel_);
-  request_input.PushBack("tag_description", tag.description_);
+  request_input.AddQuoted("old_root_hash", old_root_hash);
+  request_input.AddQuoted("new_root_hash", new_root_hash);
+  request_input.AddQuoted("tag_name", tag.name_);
+  request_input.AddQuoted("tag_channel", tag.channel_);
+  request_input.AddQuoted("tag_description", tag.description_);
   std::string request = request_input.GenerateString();
   CurlBuffer buffer;
   return MakeEndRequest("POST", key_id_, secret_, session_token_, api_url_,

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -11,6 +11,7 @@
 #include "cvmfs_config.h"
 #include "gateway_util.h"
 #include "json_document.h"
+#include "json_document_write.h"
 #include "swissknife_lease_curl.h"
 #include "util/exception.h"
 #include "util/string.h"
@@ -288,14 +289,13 @@ bool SessionContext::FinalizeDerived() {
 bool SessionContext::Commit(const std::string& old_root_hash,
                             const std::string& new_root_hash,
                             const RepositoryTag& tag) {
-  std::string request;
-  JsonStringInput request_input;
+  JsonStringGenerator request_input;
   request_input.PushBack("old_root_hash", old_root_hash);
   request_input.PushBack("new_root_hash", new_root_hash);
   request_input.PushBack("tag_name", tag.name_);
   request_input.PushBack("tag_channel", tag.channel_);
   request_input.PushBack("tag_description", tag.description_);
-  ToJsonString(request_input, &request);
+  std::string request = request_input.GenerateString();
   CurlBuffer buffer;
   return MakeEndRequest("POST", key_id_, secret_, session_token_, api_url_,
                         request, &buffer);

--- a/cvmfs/statistics.cc
+++ b/cvmfs/statistics.cc
@@ -98,7 +98,7 @@ string Statistics::PrintJSON() {
   for (map<string, CounterInfo *>::const_iterator i = counters_.begin(),
                                                   iEnd = counters_.end();
        i != iEnd; ++i) {
-    json_generator.PushBack(i->first, i->second->counter.ToString(), false);
+    json_generator.AddUnquoted(i->first, i->second->counter.ToString());
   }
 
   return json_generator.GenerateString();

--- a/cvmfs/statistics.cc
+++ b/cvmfs/statistics.cc
@@ -98,7 +98,7 @@ string Statistics::PrintJSON() {
   for (map<string, CounterInfo *>::const_iterator i = counters_.begin(),
                                                   iEnd = counters_.end();
        i != iEnd; ++i) {
-    json_generator.PushBack(i->first, i->second->counter.ToString());
+    json_generator.PushBack(i->first, i->second->counter.ToString(), false);
   }
 
   return json_generator.GenerateString();

--- a/test/unittests/t_json.cc
+++ b/test/unittests/t_json.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "json_document.h"
+#include "json_document_write.h"
 #include "util/pointer.h"
 
 TEST(T_Json, Empty) {

--- a/test/unittests/t_json.cc
+++ b/test/unittests/t_json.cc
@@ -69,7 +69,7 @@ TEST(T_Json, GenerateValidJsonString) {
   input.AddQuoted("f1", "v1");
   input.AddQuoted("f2", "v2");
   input.AddQuoted("f3", "v3");
-  input.AddUnquoted("interger", "12");
+  input.AddUnquoted("integer", "12");
 
   std::string output = input.GenerateString();
 

--- a/test/unittests/t_json.cc
+++ b/test/unittests/t_json.cc
@@ -73,7 +73,8 @@ TEST(T_Json, GenerateValidJsonString) {
 
   std::string output = input.GenerateString();
 
-  ASSERT_EQ("{\"f1\":\"v1\",\"f2\":\"v2\",\"f3\":\"v3\",\"integer\":12}", output);
+  ASSERT_EQ("{\"f1\":\"v1\",\"f2\":\"v2\",\"f3\":\"v3\",\"integer\":12}",
+            output);
 
   UniquePtr<JsonDocument> json(JsonDocument::Create(output));
   ASSERT_TRUE(json.IsValid());

--- a/test/unittests/t_json.cc
+++ b/test/unittests/t_json.cc
@@ -63,14 +63,13 @@ TEST(T_Json, SearchInObject) {
   EXPECT_EQ(NULL, result);
 }
 
-TEST(T_Json, ToJsonString) {
-  JsonStringInput input;
+TEST(T_Json, GenerateValidJsonString) {
+  JsonStringGenerator input;
   input.PushBack("f1", "v1");
   input.PushBack("f2", "v2");
   input.PushBack("f3", "v3");
 
-  std::string output;
-  ASSERT_TRUE(ToJsonString(input, &output));
+  std::string output = input.GenerateString();
 
   ASSERT_EQ("{\"f1\":\"v1\",\"f2\":\"v2\",\"f3\":\"v3\"}", output);
 

--- a/test/unittests/t_json.cc
+++ b/test/unittests/t_json.cc
@@ -66,13 +66,14 @@ TEST(T_Json, SearchInObject) {
 
 TEST(T_Json, GenerateValidJsonString) {
   JsonStringGenerator input;
-  input.PushBack("f1", "v1");
-  input.PushBack("f2", "v2");
-  input.PushBack("f3", "v3");
+  input.AddQuoted("f1", "v1");
+  input.AddQuoted("f2", "v2");
+  input.AddQuoted("f3", "v3");
+  input.AddUnquoted("interger", "12");
 
   std::string output = input.GenerateString();
 
-  ASSERT_EQ("{\"f1\":\"v1\",\"f2\":\"v2\",\"f3\":\"v3\"}", output);
+  ASSERT_EQ("{\"f1\":\"v1\",\"f2\":\"v2\",\"f3\":\"v3\",\"integer\":12}", output);
 
   UniquePtr<JsonDocument> json(JsonDocument::Create(output));
   ASSERT_TRUE(json.IsValid());

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -176,8 +176,8 @@ TEST_F(T_Reactor, FullCycle) {
 
   // Check the token validity
   JsonStringGenerator request_terms;
-  request_terms.PushBack("token", &token[0]);
-  request_terms.PushBack("secret", &secret[0]);
+  request_terms.AddQuoted("token", &token[0]);
+  request_terms.AddQuoted("secret", &secret[0]);
 
   std::string request = request_terms.GenerateString();
   ASSERT_TRUE(

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -174,12 +174,11 @@ TEST_F(T_Reactor, FullCycle) {
   }
 
   // Check the token validity
-  JsonStringInput request_terms;
+  JsonStringGenerator request_terms;
   request_terms.PushBack("token", &token[0]);
   request_terms.PushBack("secret", &secret[0]);
 
-  std::string request;
-  ASSERT_TRUE(ToJsonString(request_terms, &request));
+  std::string request = request_terms.GenerateString();
   ASSERT_TRUE(
       Reactor::WriteRequest(to_reactor_[1], Reactor::kCheckToken, request));
 

--- a/test/unittests/t_reactor.cc
+++ b/test/unittests/t_reactor.cc
@@ -6,6 +6,7 @@
 
 #include <logging.h>
 #include "json_document.h"
+#include "json_document_write.h"
 #include "pack.h"
 #include "receiver/payload_processor.h"
 #include "receiver/reactor.h"

--- a/test/unittests/t_statistics.cc
+++ b/test/unittests/t_statistics.cc
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 
 #include "json_document.h"
+#include "json_document_write.h"
 #include "platform.h"
 #include "statistics.h"
 #include "util/pointer.h"

--- a/test/unittests/t_statistics.cc
+++ b/test/unittests/t_statistics.cc
@@ -4,8 +4,10 @@
 
 #include "gtest/gtest.h"
 
+#include "json_document.h"
 #include "platform.h"
 #include "statistics.h"
+#include "util/pointer.h"
 
 using namespace std;  // NOLINT
 
@@ -169,6 +171,14 @@ TEST(T_Statistics, MultiRecorder) {
   recorder.Tick();
   EXPECT_EQ(1U, recorder.GetNoTicks(1));
   EXPECT_EQ(1U, recorder.GetNoTicks(uint32_t(-1)));
+}
+
+TEST(T_Statistics, GenerateCorrectJsonEvenWithoutInput) {
+  Statistics stats;
+  std::string output = stats.PrintJSON();
+
+  UniquePtr<JsonDocument> json(JsonDocument::Create(output));
+  ASSERT_TRUE(json.IsValid());
 }
 
 }  // namespace perf


### PR DESCRIPTION
The gateway tests showed a small mistake on the statistics manager. It didn't handle correctly the case of no statistics while generating the JSON.

The JSON was generated by hand, but we do have an interface to generate valid JSON, hence I decided to let the statistics use the already present interface.

In doing so, however I would have introduced some dependencies (`util/pointer.cc` and `json_document.cc`) to  all the code that use the statistic class.

So I refactor our own JSON generation in a separate, header only, file.

I transition from a struct + function to a simple class, and rename in what I believe is more appropriate.

Also I modified the interface in something more ergonomic.

In modifying the interface, however, I broke the `receiver/reactor.h` interface. It was relying on raw pointer and checking them. I am not sure I understand why.

Hence I also re-work the interface of the reactor in something that seems better.

Overall, this PR fix a small error, add a test, make some interface more ergonomics in -7 lines of code! Yeaaah! :)

@janpriessnitz does it LGTY? Are the JSON code equivalent?

@jblomer I am making some mistake in refactoring the reactor to accept a reference to a string instead of a raw pointer? I really don't understand why that choice was made.