### PR TITLE
Enable GCC 10 to pass version check

### DIFF
--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -38,12 +38,12 @@ set (CVMFS_OPT_FLAGS "-Os")
 if (CMAKE_COMPILER_IS_GNUCC)
   message (STATUS "checking gcc version...")
   execute_process (
-    COMMAND ${CMAKE_C_COMPILER} -dumpfullversion
+    COMMAND ${CMAKE_C_COMPILER} --version
     OUTPUT_VARIABLE CVMFS_GCC_VERSION
     ERROR_VARIABLE  CVMFS_GCC_VERSION
   )
-  STRING(REGEX REPLACE "([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" CVMFS_GCC_MAJOR "${CVMFS_GCC_VERSION}")
-  STRING(REGEX REPLACE "[0-9]+\\.([0-9]+)\\.[0-9]+" "\\1" CVMFS_GCC_MINOR "${CVMFS_GCC_VERSION}")
+  STRING(REGEX REPLACE "[A-Za-z]* \\(GCC\\) ([0-9]+)\\.[0-9]+\\.[0-9]+.*" "\\1" CVMFS_GCC_MAJOR "${CVMFS_GCC_VERSION}")
+  STRING(REGEX REPLACE "[A-Za-z]* \\(GCC\\) [0-9]+\\.([0-9]+)\\.[0-9]+.*" "\\1" CVMFS_GCC_MINOR "${CVMFS_GCC_VERSION}")
   if (${CVMFS_GCC_MAJOR} LESS 4)
     message (FATAL_ERROR "GCC < 4.1 unsupported")
   endif (${CVMFS_GCC_MAJOR} LESS 4)

--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -38,12 +38,12 @@ set (CVMFS_OPT_FLAGS "-Os")
 if (CMAKE_COMPILER_IS_GNUCC)
   message (STATUS "checking gcc version...")
   execute_process (
-    COMMAND ${CMAKE_C_COMPILER} -v
+    COMMAND ${CMAKE_C_COMPILER} -dumpfullversion
     OUTPUT_VARIABLE CVMFS_GCC_VERSION
     ERROR_VARIABLE  CVMFS_GCC_VERSION
   )
-  STRING(REGEX REPLACE ".*([0-9]+)\\.[0-9]+\\.[0-9]+.*" "\\1" CVMFS_GCC_MAJOR "${CVMFS_GCC_VERSION}")
-  STRING(REGEX REPLACE ".*[0-9]+\\.([0-9]+)\\.[0-9]+.*" "\\1" CVMFS_GCC_MINOR "${CVMFS_GCC_VERSION}")
+  STRING(REGEX REPLACE "([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" CVMFS_GCC_MAJOR "${CVMFS_GCC_VERSION}")
+  STRING(REGEX REPLACE "[0-9]+\\.([0-9]+)\\.[0-9]+" "\\1" CVMFS_GCC_MINOR "${CVMFS_GCC_VERSION}")
   if (${CVMFS_GCC_MAJOR} LESS 4)
     message (FATAL_ERROR "GCC < 4.1 unsupported")
   endif (${CVMFS_GCC_MAJOR} LESS 4)

--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -42,8 +42,8 @@ if (CMAKE_COMPILER_IS_GNUCC)
     OUTPUT_VARIABLE CVMFS_GCC_VERSION
     ERROR_VARIABLE  CVMFS_GCC_VERSION
   )
-  STRING(REGEX REPLACE "[A-Za-z]* \\(GCC\\) ([0-9]+)\\.[0-9]+\\.[0-9]+.*" "\\1" CVMFS_GCC_MAJOR "${CVMFS_GCC_VERSION}")
-  STRING(REGEX REPLACE "[A-Za-z]* \\(GCC\\) [0-9]+\\.([0-9]+)\\.[0-9]+.*" "\\1" CVMFS_GCC_MINOR "${CVMFS_GCC_VERSION}")
+  STRING(REGEX REPLACE "[A-Za-z]* \\(.+\\) ([0-9]+)\\.[0-9]+\\.[0-9]+.*" "\\1" CVMFS_GCC_MAJOR "${CVMFS_GCC_VERSION}")
+  STRING(REGEX REPLACE "[A-Za-z]* \\(.+\\) [0-9]+\\.([0-9]+)\\.[0-9]+.*" "\\1" CVMFS_GCC_MINOR "${CVMFS_GCC_VERSION}")
   if (${CVMFS_GCC_MAJOR} LESS 4)
     message (FATAL_ERROR "GCC < 4.1 unsupported")
   endif (${CVMFS_GCC_MAJOR} LESS 4)


### PR DESCRIPTION
The version check wouldn't pass with GCC 10 because the `.*` necessary when using `gcc -v` eats the 1. By using `-dumpfullversion`, the `.*`s can be avoided.