### PR TITLE
Add option to create pass-through replicas

### DIFF
--- a/cvmfs/server/cvmfs_server_add_replica.sh
+++ b/cvmfs/server/cvmfs_server_add_replica.sh
@@ -172,8 +172,10 @@ CVMFS_UPSTREAM_STORAGE=$upstream
 CVMFS_SNAPSHOT_GROUP=$snapshot_group
 EOF
   if [ $is_passthrough -eq 1 ]; then
-    echo "CVMFS_PASSTHROUGH=true" >> /etc/cvmfs/repositories.d/${alias_name}/server.conf
-    echo "# Pass-through" > /etc/cvmfs/repositories.d/${alias_name}/replica.conf
+    cat > /etc/cvmfs/repositories.d/${alias_name}/replica.conf << EOF
+# Created by cvmfs_server.
+CVMFS_PASSTHROUGH=true
+EOF
   else
     cat > /etc/cvmfs/repositories.d/${alias_name}/replica.conf << EOF
 # Created by cvmfs_server.

--- a/cvmfs/server/cvmfs_server_add_replica.sh
+++ b/cvmfs/server/cvmfs_server_add_replica.sh
@@ -204,7 +204,12 @@ EOF
     if [ $configure_apache -eq 1 ]; then
       echo -n "Update Apache configuration... "
       ensure_enabled_apache_modules
-      create_apache_config_for_endpoint $alias_name $storage_dir "with wsgi"
+      if [ $is_passthrough -eq 1 ]; then
+        check_proxy_module
+        create_apache_proxy_config_for_endpoint $alias_name $stratum0 "with wsgi"
+      else
+        create_apache_config_for_endpoint $alias_name $storage_dir "with wsgi"
+      fi
       create_apache_config_for_global_info
       reload_apache > /dev/null
       if [ $is_passthrough -eq 0 ]; then

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -101,6 +101,16 @@ The required package is called ${APACHE_WSGI_MODPKG}."
   exit 1
 }
 
+# checks if proxy apache module is installed and enabled
+check_proxy_module() {
+  if check_apache_module "proxy_module"; then
+    return 0
+  fi
+
+  echo "The apache proxy module must be installed and enabled."
+  exit 1
+}
+
 
 # retrieves the apache version string
 get_apache_version() {
@@ -287,6 +297,36 @@ Alias /cvmfs/${name} ${storage_dir}
     ExpiresByType application/x-cvmfs "access plus 61 seconds"
     ExpiresByType application/json    "access plus 61 seconds"
 </Directory>
+EOF
+
+  if [ x"$with_wsgi" != x"" ]; then
+    create_apache_config_for_webapi
+  fi
+}
+
+
+# creates an Apache proxy-pass configuration file for a pass-through repository
+#
+# @param name         the name of the endpoint to be served
+# @param storage_dir  the storage location of the data
+# @param with_wsgi    whether or not to enable WSGI api functions
+create_apache_proxy_config_for_endpoint() {
+  local name=$1
+  local pt_url=$2
+  local with_wsgi="$3"
+
+  create_apache_config_file "$(get_apache_conf_filename $name)" << EOF
+# Created by cvmfs_server.  Don't touch.
+
+KeepAlive On
+AddType application/json .json
+
+# Do not ProxyPass GeoAPI requests
+ProxyPass /cvmfs/${name}/api/ !
+
+# ProxyPass data requests
+ProxyPass /cvmfs/${name} $pt_url
+ProxyPassReverse /cvmfs/${name} $pt_url
 EOF
 
   if [ x"$with_wsgi" != x"" ]; then

--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -221,11 +221,16 @@ __do_gc_cmd()
 
   # leave extra layer of indent for now to better show diff with previous
 
+    CVMFS_PASSTHROUGH=false
     load_repo_config $name
 
     # sanity checks
     check_repository_compatibility $name
     check_url "${CVMFS_STRATUM0}/.cvmfspublished" 20 || die "Repository unavailable under $CVMFS_STRATUM0"
+    if [ x"$CVMFS_PASSTHROUGH" = x"true" ]; then
+      echo "Repository $name is a pass-through repository, nothing to do"
+      return 0
+    fi
     if is_empty_repository $name; then
       echo "Repository $name is empty, nothing to do"
       return 0

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -60,12 +60,16 @@ _render_repos() {
   local i=$#
 
   for repo in $@; do
+    CVMFS_PASSTHROUGH=false
     load_repo_config $repo
 
     echo '    {'
     echo '      "name"  : "'$CVMFS_REPOSITORY_NAME'",'
     if [ x"$CVMFS_REPOSITORY_NAME" != x"$repo" ]; then
       echo '      "alias" : "'$repo'",'
+    fi
+    if [ x"$CVMFS_PASSTHROUGH" = x"true" ]; then
+      echo '      "pass-through" : true,'
     fi
     echo '      "url"   : "/cvmfs/'$repo'"'
     echo -n '    }'

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -56,6 +56,7 @@ __do_snapshot() {
     is_stratum1 $alias_name || { echo "Repository $alias_name is not a stratum 1 repository"; retcode=1; continue; }
 
     # get repository information
+    CVMFS_PASSTHROUGH=false
     load_repo_config $alias_name
     name=$CVMFS_REPOSITORY_NAME
     user=$CVMFS_USER
@@ -86,6 +87,11 @@ __do_snapshot() {
     if is_local_upstream $upstream; then
         # try to update the geodb, but continue if it doesn't work
         _update_geodb -l || true
+    fi
+
+    if [ x"$CVMFS_PASSTHROUGH" = x"true" ]; then
+      echo "Pass-through repository, skipping snapshot"
+      continue
     fi
 
     if ! acquire_update_lock $alias_name snapshot $abort_on_conflict; then

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1109,7 +1109,7 @@ Supported Commands:
   add-replica     [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
                   [-a silence apache warning] [-z enable garbage collection]
                   [-n alias name] [-s S3 config file] [-p no apache config]
-                  [-g snapshot group]
+                  [-g snapshot group] [-P pass-through repository]
                   <stratum 0 url> <public key | keys directory>
                   Creates a Stratum 1 replica of a Stratum 0 repository
   import          [-w stratum0 url] [-o owner] [-u upstream storage]

--- a/test/src/621-snapshotallgcall/main
+++ b/test/src/621-snapshotallgcall/main
@@ -30,13 +30,18 @@ cvmfs_run_test() {
 
   local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
 
-  CVMFS_TEST_621_REPLICA_NAMES="${replica_name}-1 ${replica_name}-2 ${replica_name}-3 ${replica_name}-4 ${replica_name}-5"
+  CVMFS_TEST_621_REPLICA_NAMES="${replica_name}-0 ${replica_name}-1 ${replica_name}-2 ${replica_name}-3 ${replica_name}-4 ${replica_name}-5"
   echo "*** install a cleanup function"
   trap cleanup EXIT HUP INT TERM || return $?
 
-  echo "*** create 5 Stratum1 replicas on the same machine"
+  echo "*** create 6 Stratum1 replicas on the same machine"
   load_repo_config $CVMFS_TEST_REPO
 
+  # First replica is pass-through
+  create_passthrough_stratum1 ${replica_name}-0    \
+                              $CVMFS_TEST_USER     \
+                              $CVMFS_STRATUM0      \
+                              || return 9
   for num in 1 2 3 4 5; do
     local groupopt
     groupopt=""
@@ -63,32 +68,34 @@ cvmfs_run_test() {
   rm -f /var/log/cvmfs/snapshots.log /var/log/cvmfs/gc.log
 
   echo "*** running cvmfs_server snapshot -a"
-  cvmfs_server snapshot -an || return 5
+  cvmfs_server snapshot -an || return 10
 
-  echo "*** download manifests of stratum 0 and replica 1 and 5"
-  curl -so mr1 "$(get_repo_url ${replica_name}-1)/.cvmfspublished" || return 6
-  curl -so mr5 "$(get_repo_url ${replica_name}-5)/.cvmfspublished" || return 7
-  curl -so ms0 "$(get_repo_url $CVMFS_TEST_REPO)/.cvmfspublished"  || return 8
+  echo "*** download manifests of stratum 0 and replica 0, 1 and 5"
+  curl -so mr0 "$(get_repo_url ${replica_name}-0)/.cvmfspublished" || return 11
+  curl -so mr1 "$(get_repo_url ${replica_name}-1)/.cvmfspublished" || return 12
+  curl -so mr5 "$(get_repo_url ${replica_name}-5)/.cvmfspublished" || return 13
+  curl -so ms0 "$(get_repo_url $CVMFS_TEST_REPO)/.cvmfspublished"  || return 14
 
-  echo "*** checking if snapshot worked on replicas 1 and 5"
-  cmp ms0 mr1 || return  9
-  cmp ms0 mr5 || return 10
+  echo "*** checking if snapshot worked on replicas 0, 1 and 5"
+  cmp ms0 mr0 || return 15
+  cmp ms0 mr1 || return 16
+  cmp ms0 mr5 || return 17
 
   echo "*** checking if replica 2 was skipped"
-  curl -f -sI "$(get_repo_url ${replica_name}-2)/.cvmfspublished" && return 11
+  curl -f -sI "$(get_repo_url ${replica_name}-2)/.cvmfspublished" && return 20
   echo "*** checking if replica 3 detected an error"
-  curl -f -sI "$(get_repo_url ${replica_name}-3)/.cvmfs_last_snapshot" && return 12
+  curl -f -sI "$(get_repo_url ${replica_name}-3)/.cvmfs_last_snapshot" && return 21
   echo "*** checking if replica 4 was skipped"
-  curl -f -sI "$(get_repo_url ${replica_name}-4)/.cvmfspublished" && return 13
+  curl -f -sI "$(get_repo_url ${replica_name}-4)/.cvmfspublished" && return 22
 
   echo "*** running cvmfs_server snapshot -a -g other"
-  cvmfs_server snapshot -an -g other || return 14
+  cvmfs_server snapshot -an -g other || return 30
 
   echo "*** download manifest of replica 4"
-  curl -so mr4 "$(get_repo_url ${replica_name}-5)/.cvmfspublished" || return 15
+  curl -so mr4 "$(get_repo_url ${replica_name}-5)/.cvmfspublished" || return 31
 
   echo "*** checking if snapshot worked on replica 4"
-  cmp ms0 mr4 || return  16
+  cmp ms0 mr4 || return  32
 
   echo "*** restoring replica 3's download URL"
   sudo $SHELL -c "sed -i 's,Bogus,,' /etc/cvmfs/repositories.d/${replica_name}-3/server.conf"
@@ -96,34 +103,40 @@ cvmfs_run_test() {
   echo '*** checking snapshot wildcard "*-?"'
   # make sure wildcard expansion does not happen in current working dir
   touch "afilewithadash-1"
-  cvmfs_server snapshot "*-?" || return 17
+  cvmfs_server snapshot "*-?" || return 40
 
   echo "*** checking that replicas 2 & 3 worked this time"
   # the wildcard does not look at CVMFS_REPLICA_ACTIVE
-  curl -f -sI "$(get_repo_url ${replica_name}-2)/.cvmfspublished" || return 18
-  curl -f -sI "$(get_repo_url ${replica_name}-3)/.cvmfs_last_snapshot" || return 19
+  curl -f -sI "$(get_repo_url ${replica_name}-2)/.cvmfspublished" || return 41
+  curl -f -sI "$(get_repo_url ${replica_name}-3)/.cvmfs_last_snapshot" || return 42
 
   echo "*** corrupting third replica's download URL again"
   sudo $SHELL -c "sed -i 's,^\(CVMFS_STRATUM0=.*\),\1Bogus,' /etc/cvmfs/repositories.d/${replica_name}-3/server.conf"
 
   echo "*** remove evidence of initial repo gc"
-  ! has_jq || delete_from_backend $CVMFS_TEST_REPO .cvmfs_status.json || return 20
+  ! has_jq || delete_from_backend $CVMFS_TEST_REPO .cvmfs_status.json || return 43
 
   echo "*** running cvmfs_server gc -af"
-  cvmfs_server gc -af || return 21
+  cvmfs_server gc -af || return 44
 
   if ! has_jq; then
     return 0
   fi
 
   echo "*** checking if gc worked on test repo and replicas 1 and 4"
-  curl -f -s "$(get_repo_url $CVMFS_TEST_REPO)/.cvmfs_status.json"|grep last_gc  || return 22
-  curl -f -s "$(get_repo_url ${replica_name}-1)/.cvmfs_status.json"|grep last_gc || return 23
-  curl -f -s "$(get_repo_url ${replica_name}-4)/.cvmfs_status.json"|grep last_gc || return 24
+  curl -f -s "$(get_repo_url $CVMFS_TEST_REPO)/.cvmfs_status.json"|grep last_gc  || return 50
+  curl -f -s "$(get_repo_url ${replica_name}-1)/.cvmfs_status.json"|grep last_gc || return 51
+  curl -f -s "$(get_repo_url ${replica_name}-4)/.cvmfs_status.json"|grep last_gc || return 52
 
   echo "*** verifying gc did not work on replicas 2 and 3"
-  curl -f -s "$(get_repo_url ${replica_name}-2)/.cvmfs_status.json"|grep last_gc && return 25
-  curl -f -s "$(get_repo_url ${replica_name}-3)/.cvmfs_status.json"|grep last_gc && return 26
+  curl -f -s "$(get_repo_url ${replica_name}-2)/.cvmfs_status.json"|grep last_gc && return 53
+  curl -f -s "$(get_repo_url ${replica_name}-3)/.cvmfs_status.json"|grep last_gc && return 54
+
+  echo "*** checking if (only) replica 0 is marked as pass-through"
+  curl -f -s "$(get_local_repo_url info)/v1/repositories.json" | \
+    jq ".replicas[] | select(.alias == \"${replica_name}-0\")" | grep pass-through || return 55
+  curl -f -s "$(get_local_repo_url info)/v1/repositories.json" | \
+    jq ".replicas[] | select(.alias == \"${replica_name}-1\")" | grep pass-through && return 56
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -832,6 +832,33 @@ create_stratum1() {
                                    $stratum0_pub
 }
 
+# creates a repository replica as a pass-through to a stratum 0
+# @param replica_name  the name of the new replica
+# @param replica_owner the owner of the new replica
+# @param stratum0_url  the url for the source repository
+create_passthrough_stratum1() {
+  local replica_name=$1
+  local replica_owner=$2
+  local stratum0_url=$3
+  shift 3
+  local additional_parameters="$*"
+  local s3_config=""
+  if [ x"$CVMFS_TEST_S3_CONFIG" != x"" ]; then
+    local stratum1_url="$CVMFS_TEST_HTTP_BASE"
+    [ ! -z "$stratum1_url" ] || die "\$CVMFS_TEST_HTTP_BASE needs to be set for S3 tests to work!"
+    echo "  S3 Config: $CVMFS_TEST_S3_CONFIG"
+    echo "  Stratum1:  $stratum1_url"
+    s3_config=" -s $CVMFS_TEST_S3_CONFIG -w $stratum1_url -a"
+  fi
+  sudo -E cvmfs_server add-replica -P \
+                                   -o $replica_owner      \
+                                   -n $replica_name       \
+                                   $s3_config             \
+                                   $additional_parameters \
+                                   $stratum0_url
+}
+
+
 # creates a big file at a given location with a given size
 # @param path  the location of the new file
 # @param size  the desired size in megabytes


### PR DESCRIPTION
The new `cvmfs_server replica -P` command to create a proxy passed replica.  Such a replica will be marked by `CVMFS_PASSTHROUGH=true` in the replica.conf file and by the `pass-through` boolean flag in the repositories.json