### PR TITLE
Debian Packaging: Only recommend apache2

### DIFF
--- a/packaging/debian/cvmfs/control.in
+++ b/packaging/debian/cvmfs/control.in
@@ -21,7 +21,8 @@ Description: CernVM File System
 Package: cvmfs-server
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: psmisc, curl, attr, openssl, apache2, libcap2, libcap2-bin, lsof, rsync, jq, usbutils, sqlite3, ${misc:Depends}
+Depends: psmisc, curl, attr, openssl, libcap2, libcap2-bin, lsof, rsync, jq, usbutils, sqlite3, ${misc:Depends}
+Recommends: apache2
 Conflicts: cvmfs-server (<< 2.1)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -51,7 +51,8 @@ install_deb $UNITTEST_PACKAGE
 install_deb $SHRINKWRAP_PACKAGE
 
 # installing WSGI apache module
-echo "installing python WSGI module..."
+echo "installing apache2 and python WSGI module..."
+install_from_repo apache2                || die "fail (installing apache2)"
 install_from_repo libapache2-mod-wsgi    || die "fail (installing libapache2-mod-wsgi)"
 install_from_repo default-jre            || die "fail (installing default-jre)"
 sudo service apache2 restart > /dev/null || die "fail (restarting apache)"


### PR DESCRIPTION
cvmfs-server currently strictly depends on apache2.
On a publisher node, one does not need apache2.
So turn the "Depends: apache2" into a "Recommends: apache2".

Recommends means "You really should install this. If you don't, expect missing functionality". Which fits very well: If one does not install apache2, one can't run a stratum-0.