### PR TITLE
Add support for WSL2

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -129,27 +129,64 @@ compare_versions() {
 }
 
 cvmfs_config_usage() {
- echo "Common configuration tasks for CernVM-FS"
- echo "Usage: $0 <command>"
- echo "Commands are"
- echo "  setup [nouser] [nocfgmod] [nostart]"
- echo "  chksetup"
- echo "  showconfig [-s(hort output, only non-empty parameters)] [<repository>]"
- echo "  stat [-v | <repository>]"
- echo "  status"
- echo "  probe [<repository list>]"
- echo "  fsck [<cvmfs_fsck options>]"
- echo "  reload [-c | <repository>]"
- echo "  umount"
- echo "  wipecache"
- echo "  killall"
- echo "  bugreport"
+  echo "Common configuration tasks for CernVM-FS"
+  echo "Usage: $0 <command>"
+  echo "Commands are"
+  echo "  setup [nouser] [nocfgmod] [nostart]"
+  if is_wsl2; then
+    echo "  wsl2_start"
+  fi
+  echo "  chksetup"
+  echo "  showconfig [-s(hort output, only non-empty parameters)] [<repository>]"
+  echo "  stat [-v | <repository>]"
+  echo "  status"
+  echo "  probe [<repository list>]"
+  echo "  fsck [<cvmfs_fsck options>]"
+  echo "  reload [-c | <repository>]"
+  echo "  umount"
+  echo "  wipecache"
+  echo "  killall"
+  echo "  bugreport"
 }
 
 has_selinux() {
   which getenforce > /dev/null 2>&1 && \
   which semodule   > /dev/null 2>&1 && \
   getenforce | grep -qi "enforc" || return 1
+}
+
+is_wsl2() {
+  # Another possibility is looking for the /run/WSL directory
+  grep -q microsoft-standard /proc/version 2>/dev/null
+}
+
+cvmfs_wsl2_start() {
+  is_wsl2 || die "WSL2 not detected, exiting"
+  [ $(id -u) -eq 0 ] || die "root privileges required"
+  if $pidof automount >/dev/null; then
+    echo "[WSL2] automounter already running"
+    exit 0
+  fi
+
+  local automounter="/usr/sbin/automount"
+  local automount_config=
+  if [ -f /etc/sysconfig/autofs ]; then
+    automount_config=/etc/sysconfig/autofs
+  elif [ -f /etc/default/autofs ]; then
+    automount_config=/etc/default/autofs
+  fi
+
+  local automounter=/usr/sbin/automount
+  echo "[WSL2] starting automounter"
+  $(
+    if [ -n $automount_config ]; then
+      . $automount_config
+    fi
+    $automounter $OPTIONS --pid-file /var/run/autofs.pid
+  )
+
+  # return value: process found
+  $pidof automount >/dev/null
 }
 
 cvmfs_setup() {
@@ -399,7 +436,7 @@ cvmfs_chksetup() {
     fi
 
     # Check autofs' kill mode when systemd managed
-    if [ -e /usr/bin/systemctl ]; then
+    if [ -e /usr/bin/systemctl -a ! is_wsl2 ]; then
       if ! /usr/bin/systemctl show -p KillMode autofs.service | grep -q process;
       then
         echo "Warning: autofs kill mode is not 'process', busy CernVM-FS mount points are likely to be forcefully killed when autofs is restarted"
@@ -1350,7 +1387,6 @@ cvmfs_bugreport() {
                  'ls -lR /var/run/cvmfs' 'grep cvmfs /var/log/messages' 'grep cvmfs /var/log/syslog' \
                  'journalctl -alm /usr/bin/cvmfs2' \
                  'journalctl -alm /usr/libexec/cvmfs/cache/cvmfs_cache_ram' \
-                 'journalctl -alm /usr/libexec/cvmfs/cache/cvmfs_cache_posix' \
                  "eval find ${CVMFS_CACHE_BASE} -maxdepth 1 -exec ls -lah \{\} \;" \
                  'cvmfs_config probe' 'mount' 'df -h' 'ps -ef' \
                  'cvmfs_config status' 'cvmfs_config showconfig' \
@@ -1712,6 +1748,12 @@ activate_service() {
 
   case $sys_arch in
     Linux )
+      if is_wsl2; then
+        echo "[WSL2] skipping activation of $1"
+	echo "[WSL2] start CernVM-FS with 'sudo cvmfs_config wsl2_start'"
+        exit 0
+      fi
+
       if [ -e /usr/bin/systemctl ]; then
         /usr/bin/systemctl start -q ${svc}.service
         /usr/bin/systemctl enable -q ${svc}.service
@@ -1753,6 +1795,14 @@ reload_service() {
 
   case $sys_arch in
     Linux )
+      if is_wsl2; then
+        [ "$svc" == "autofs" ] || die "[WSL2] internal error, expected autofs service ('$svc')"
+	echo -n "WSL2 automounter "
+	local autofs_pid=$(cat /var/run/autofs.pid)
+	/usr/bin/kill -HUP $autofs_pid
+	return 0
+      fi
+
       if [ -e /usr/bin/systemctl ]; then
         /usr/bin/systemctl reload -q ${svc}.service
       elif [ -e /sbin/service -o -e /usr/sbin/service ]; then
@@ -1799,7 +1849,7 @@ configure_autofs() {
         fi
       done
       # Fix 'systemctl restart autofs' on CentOS 7 (CVM-1200)
-      if [ -e /usr/bin/systemctl ]; then
+      if [ -e /usr/bin/systemctl -a ! is_wsl2 ]; then
         if /usr/bin/systemctl show -p KillMode autofs.service | \
            grep -q control-group;
         then
@@ -2174,6 +2224,12 @@ case "$1" in
      fi
      shift 1
      cvmfs_bugreport $@
+     RETVAL=$?
+     ;;
+
+   wsl2_start)
+     shift 1
+     cvmfs_wsl2_start $@
      RETVAL=$?
      ;;
 


### PR DESCRIPTION
Version 2 of the Windows sub sytem for Linux starts a full, virtualized Linux kernel with fuse and autofs support.  Therefore, cvmfs can be used on the available distributions almost like on their native counterparts.  One difference is that the WSL2 Linux starts like being in singe-user mode.  The /init process is not systemd but a custom one.  So systemd, even though available as a binary, cannot be used as service manager.  This patch adds a `cvmfs_config wsl2_start` command to manually start the automounter.  Whenever opening a WSL2 Linux terminal, one needs to write `sudo cvmfs_config wsl2_start` to find the normal autofs-managed /cvmfs area.

Tested on Ubuntu 20.04 / WSL2.