### PR TITLE
install osxfuse via Travis Homebrew addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ addons:
       - valgrind
       - voms-dev
       - gdb
-
-before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew cask install osxfuse; fi
+  homebrew:
+    casks:
+      - osxfuse
+    update: true
 
 script:
   - ci/run_travis.sh


### PR DESCRIPTION
I noticed that the Travis tests often fail on macOS, so I'd like to suggest to use the recommended approach for installing packages in the macOS test environment, by using the "Homebrew addon", see https://docs.travis-ci.com/user/reference/osx#homebrew and https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos . 