### PR TITLE
Add `cvmfs_server enter` command

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -244,6 +244,7 @@ set (CVMFS_SHRINKWRAP_SOURCES
 
 # TODO(jblomer) Rename to cvmfs_server
 set (CVMFS_PUBLISH_SOURCES
+  backoff.cc
   compression.cc
   directory_entry.cc
   dns.cc

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -315,6 +315,7 @@ set (LIBCVMFS_SERVER_SOURCES
   pack.cc
   publish/except.cc
   publish/repository.cc
+  publish/repository_capabilities.cc
   publish/repository_diff.cc
   publish/repository_managed.cc
   publish/repository_session.cc

--- a/cvmfs/make_cvmfs_server.sh
+++ b/cvmfs/make_cvmfs_server.sh
@@ -35,6 +35,7 @@ COMPONENTS="\
     server/cvmfs_server_common.sh
     server/cvmfs_server_health_check.sh
     server/cvmfs_server_compat.sh
+    server/cvmfs_server_enter.sh
     server/cvmfs_server_transaction.sh
     server/cvmfs_server_abort.sh
     server/cvmfs_server_publish.sh

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -137,6 +137,11 @@ inline bool platform_umount(const char *mountpoint, const bool lazy) {
   return retval == 0;
 }
 
+inline bool platform_umount_lazy(const char *mountpoint) {
+  int retval = umount2(mountpoint, MNT_DETACH);
+  return retval == 0;
+}
+
 /**
  * Spinlocks are not necessarily part of pthread on all platforms.
  */

--- a/cvmfs/platform_osx.h
+++ b/cvmfs/platform_osx.h
@@ -75,6 +75,12 @@ inline bool platform_umount(const char *mountpoint, const bool lazy) {
   return retval == 0;
 }
 
+
+inline int platform_umount_lazy(const char *mountpoint) {
+  int retval = unmount(mountpoint, MNT_FORCE);
+  return retval == 0;
+}
+
 /**
  * Spinlocks on OS X are not in pthread but in OS X specific APIs.
  */

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -13,6 +13,7 @@
 #include <sys/mount.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdio>
 #include <map>
@@ -115,16 +116,156 @@ void CmdEnter::MountOverlayfs(const SettingsPublisher &settings) {
 }
 
 
+void CmdEnter::CreateUnderlay(
+  const std::string &source_dir,
+  const std::string &dest_dir,
+  const std::vector<std::string> &empty_dirs)
+{
+  // For an empty directory /cvmfs/atlas.cern.ch, we are going to store "/cvmfs"
+  std::vector<std::string> empty_toplevel_dirs;
+  for (unsigned i = 0; i < empty_dirs.size(); ++i) {
+    std::string toplevel_dir = empty_dirs[i];
+    while (!GetParentPath(toplevel_dir).empty())
+      toplevel_dir = GetParentPath(toplevel_dir);
+    empty_toplevel_dirs.push_back(toplevel_dir);
+
+    // We create $DEST/cvmfs (top-level dir)
+    std::string dest_empty_dir = dest_dir + "/" + toplevel_dir;
+    bool rv = MkdirDeep(dest_empty_dir, 0700, true /* veryfy_writable */);
+    if (!rv)
+      throw EPublish("cannot create directory " + dest_empty_dir);
+
+    // And recurse into it, i.e.
+    // CreateUnderlay($SOURCE/cvmfs, $DEST/cvmfs, /atlas.cern.ch)
+    std::vector<std::string> empty_sub_dir;
+    empty_sub_dir.push_back(empty_dirs[i].substr(toplevel_dir.length()));
+    if (!empty_sub_dir[0].empty()) {
+      CreateUnderlay(source_dir + "/" + toplevel_dir,
+                     dest_dir + "/" + toplevel_dir,
+                     empty_sub_dir);
+    }
+  }
+
+  std::vector<std::string> names;
+  std::vector<mode_t> modes;
+  // In a recursive call, the source directory might not exist, which is fine
+  if (DirectoryExists(source_dir)) {
+    bool rv = ListDirectory(source_dir, &names, &modes);
+    if (!rv)
+      throw EPublish("cannot list directory " + source_dir);
+  }
+
+  // List the contents of the source directory
+  //   1. Symlinks are created as they are
+  //   2. Directories become empty directories and are bind-mounted
+  //   3. File become empty regular files and are bind-mounted
+  for (unsigned i = 0; i < names.size(); ++i) {
+    if (std::find(empty_toplevel_dirs.begin(), empty_toplevel_dirs.end(),
+        names[i]) != empty_toplevel_dirs.end())
+    {
+      continue;
+    }
+
+    std::string source = source_dir + "/" + names[i];
+    std::string dest = dest_dir + "/" + names[i];
+    if (S_ISLNK(modes[i])) {
+      char buf[PATH_MAX + 1];
+      ssize_t nchars = readlink(source.c_str(), buf, PATH_MAX);
+      if (nchars < 0)
+        throw EPublish("cannot read symlink " + source);
+      buf[nchars] = '\0';
+      SymlinkForced(std::string(buf), dest);
+    } else {
+      if (S_ISDIR(modes[i])) {
+        bool rv = MkdirDeep(dest, 0700, true /* verify_writable */);
+        if (!rv)
+          throw EPublish("cannot create directory " + dest);
+      } else {
+        CreateFile(dest, 0600, false /* ignore_failure */);
+      }
+      bool rv = BindMount(source, dest);
+      if (!rv)
+        throw EPublish("cannot bind mount " + source + " --> " + dest);
+    }
+  }
+}
+
+
 int CmdEnter::Main(const Options &options) {
   std::string fqrn = options.plain_args()[0].value_str;
   sanitizer::RepositorySanitizer sanitizer;
   if (!sanitizer.IsValid(fqrn)) {
     throw EPublish("malformed repository name: " + fqrn);
   }
-  SettingsPublisher settings(fqrn);
 
+  const std::string target = "/cvmfs/" + fqrn;
+
+  // Save context-sensitive directories before switching name spaces
   string cwd = GetCurrentWorkingDirectory();
   string workspace = GetHomeDirectory() + "/.cvmfs/" + fqrn;
+
+  bool retval_b = MkdirDeep(workspace, 0700, true /* verify_writable */);
+  if (!retval_b)
+    throw EPublish("cannot create workspace " + workspace);
+  std::string rootfs = CreateTempDir(workspace + "/session");
+  if (rootfs.empty())
+    throw EPublish("cannot create session directory in " + workspace);
+
+  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
+           "Entering ephemeral writable shell for %s... ", target.c_str());
+  EnterRootContainer();
+  std::vector<std::string> empty_dirs;
+  empty_dirs.push_back(target);
+  CreateUnderlay("/", rootfs, empty_dirs);
+  LogCvmfs(kLogCvmfs, kLogStdout, "done");
+
+
+  //const SettingsSpoolArea &spool_area = settings.transaction().spool_area();
+  //BashOptionsManager options_manager;
+  //options_manager.ParseDefault(settings.fqrn());
+  //options_manager.SetValue("CVMFS_MOUNT_DIR", spool_area.readonly_mnt());
+  //options_manager.SetValue("CVMFS_AUTO_UPDATE", "no");
+  //options_manager.SetValue("CVMFS_NFS_SOURCE", "no");
+  //options_manager.SetValue("CVMFS_HIDE_MAGIC_XATTRS", "yes");
+  //options_manager.SetValue("CVMFS_SERVER_CACHE_MODE", "yes");
+  //options_manager.SetValue("CVMFS_USYSLOG", spool_area.client_log());
+  //options_manager.SetValue("CVMFS_RELOAD_SOCKETS", spool_area.cache_dir());
+  //options_manager.SetValue("CVMFS_WORKSPACE", spool_area.cache_dir());
+  //options_manager.SetValue("CVMFS_CACHE_PRIMARY", "private");
+  //options_manager.SetValue("CVMFS_CACHE_private_TYPE", "posix");
+  //options_manager.SetValue("CVMFS_CACHE_private_BASE", spool_area.cache_dir());
+  //options_manager.SetValue("CVMFS_CACHE_private_SHARED", "on");
+  //options_manager.SetValue("CVMFS_CACHE_private_QUOTA_LIMIT", "4000");
+  //options_manager.SetValue("CVMFS_NFILES", "65538");
+  //options_manager.SetValue("CVMFS_HTTP_PROXY", "DIRECT");
+  //options_manager.SetValue("CVMFS_SERVER_URL", settings.url());
+  //// TODO(jblomer)
+  //options_manager.SetValue("CVMFS_KEYS_DIR", GetCurrentWorkingDirectory());
+//
+  //bool rvb = SafeWriteToFile(options_manager.Dump(), spool_area.client_config(),
+  //                           kPrivateFileMode);
+  //if (!rvb) throw EPublish("cannot write client config");
+//
+  //vector<string> args;
+  //args.push_back("-o");
+  //args.push_back("config=" + spool_area.client_config());
+  //args.push_back(settings.fqrn());
+  //args.push_back(spool_area.readonly_mnt());
+  //int fd_stdin;
+  //int fd_stdout;
+  //int fd_stderr;
+  //pid_t pid_cvmfs;
+  //rvb = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr, cvmfs_binary_, args,
+  //                    false /* double_fork */, &pid_cvmfs);
+  //if (!rvb) throw EPublish("cannot run " + cvmfs_binary_);
+//
+  //int exit_code = WaitForChild(pid_cvmfs);
+  //if (exit_code != 0) throw EPublish("cannot mount cvmfs read-only branch");
+
+  return 0;
+
+
+  SettingsPublisher settings(fqrn);
 
   settings.SetOwner(geteuid(), getegid());
   if (options.Has("stratum0"))
@@ -142,6 +283,8 @@ int CmdEnter::Main(const Options &options) {
            "Entering publish container... ");
   EnterRootContainer();
   LogCvmfs(kLogCvmfs, kLogStdout, "done");
+
+
 
   // TODO(jblomer): set correct paths
   cvmfs_binary_ = "cvmfs2";

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -43,84 +43,25 @@ static void EnterRootContainer() {
   if (!rvb) throw publish::EPublish("cannot create pid namespace");
 }
 
+static void EnsureDirectory(const std::string &path) {
+  bool rv = MkdirDeep(path, 0700, true /* veryfy_writable */);
+  if (!rv)
+    throw publish::EPublish("cannot create directory " + path);
+}
+
 }  // anonymous namespace
 
 
 namespace publish {
-
-void CmdEnter::MountCvmfs(const SettingsPublisher &settings) {
-  const SettingsSpoolArea &spool_area = settings.transaction().spool_area();
-  BashOptionsManager options_manager;
-  options_manager.ParseDefault(settings.fqrn());
-  options_manager.SetValue("CVMFS_MOUNT_DIR", spool_area.readonly_mnt());
-  options_manager.SetValue("CVMFS_AUTO_UPDATE", "no");
-  options_manager.SetValue("CVMFS_NFS_SOURCE", "no");
-  options_manager.SetValue("CVMFS_HIDE_MAGIC_XATTRS", "yes");
-  options_manager.SetValue("CVMFS_SERVER_CACHE_MODE", "yes");
-  options_manager.SetValue("CVMFS_USYSLOG", spool_area.client_log());
-  options_manager.SetValue("CVMFS_RELOAD_SOCKETS", spool_area.cache_dir());
-  options_manager.SetValue("CVMFS_WORKSPACE", spool_area.cache_dir());
-  options_manager.SetValue("CVMFS_CACHE_PRIMARY", "private");
-  options_manager.SetValue("CVMFS_CACHE_private_TYPE", "posix");
-  options_manager.SetValue("CVMFS_CACHE_private_BASE", spool_area.cache_dir());
-  options_manager.SetValue("CVMFS_CACHE_private_SHARED", "on");
-  options_manager.SetValue("CVMFS_CACHE_private_QUOTA_LIMIT", "4000");
-  options_manager.SetValue("CVMFS_NFILES", "65538");
-  options_manager.SetValue("CVMFS_HTTP_PROXY", "DIRECT");
-  options_manager.SetValue("CVMFS_SERVER_URL", settings.url());
-  // TODO(jblomer)
-  options_manager.SetValue("CVMFS_KEYS_DIR", GetCurrentWorkingDirectory());
-
-  bool rvb = SafeWriteToFile(options_manager.Dump(), spool_area.client_config(),
-                             kPrivateFileMode);
-  if (!rvb) throw EPublish("cannot write client config");
-
-  vector<string> args;
-  args.push_back("-o");
-  args.push_back("config=" + spool_area.client_config());
-  args.push_back(settings.fqrn());
-  args.push_back(spool_area.readonly_mnt());
-  int fd_stdin;
-  int fd_stdout;
-  int fd_stderr;
-  pid_t pid_cvmfs;
-  rvb = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr, cvmfs_binary_, args,
-                      false /* double_fork */, &pid_cvmfs);
-  if (!rvb) throw EPublish("cannot run " + cvmfs_binary_);
-
-  int exit_code = WaitForChild(pid_cvmfs);
-  if (exit_code != 0) throw EPublish("cannot mount cvmfs read-only branch");
-}
-
-
-void CmdEnter::MountOverlayfs(const SettingsPublisher &settings) {
-  const SettingsSpoolArea &spool_area = settings.transaction().spool_area();
-  vector<string> args;
-  args.push_back("-o");
-  args.push_back(string("lowerdir=") + spool_area.readonly_mnt() +
-                 ",upperdir=" + spool_area.scratch_dir() +
-                 ",workdir=" + spool_area.ovl_work_dir());
-  args.push_back(spool_area.union_mnt() + "/" + settings.fqrn());
-  int fd_stdin;
-  int fd_stdout;
-  int fd_stderr;
-  pid_t pid_ovl;
-  bool rvb = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr, overlayfs_binary_,
-                           args, false /* double_fork */, &pid_ovl);
-  if (!rvb) EPublish("cannot run " + overlayfs_binary_);
-  int exit_code = WaitForChild(pid_ovl);
-  if (exit_code != 0) EPublish("cannot mount overlay file system");
-
-  rvb = BindMount(spool_area.union_mnt(), "/cvmfs");
-  if (!rvb) throw EPublish("cannot bind mount union file system to /cvmfs");
-}
-
 
 void CmdEnter::CreateUnderlay(
   const std::string &source_dir,
   const std::string &dest_dir,
   const std::vector<std::string> &empty_dirs)
 {
+  LogCvmfs(kLogCvmfs, kLogStdout, "underlay: entry %s --> %s",
+           source_dir.c_str(), dest_dir.c_str());
+
   // For an empty directory /cvmfs/atlas.cern.ch, we are going to store "/cvmfs"
   std::vector<std::string> empty_toplevel_dirs;
   for (unsigned i = 0; i < empty_dirs.size(); ++i) {
@@ -130,18 +71,17 @@ void CmdEnter::CreateUnderlay(
     empty_toplevel_dirs.push_back(toplevel_dir);
 
     // We create $DEST/cvmfs (top-level dir)
-    std::string dest_empty_dir = dest_dir + "/" + toplevel_dir;
-    bool rv = MkdirDeep(dest_empty_dir, 0700, true /* veryfy_writable */);
-    if (!rv)
-      throw EPublish("cannot create directory " + dest_empty_dir);
+    std::string dest_empty_dir = dest_dir + toplevel_dir;
+    LogCvmfs(kLogCvmfs, kLogStdout, "underlay: mkdir %s", dest_empty_dir.c_str());
+    EnsureDirectory(dest_empty_dir);
 
     // And recurse into it, i.e.
     // CreateUnderlay($SOURCE/cvmfs, $DEST/cvmfs, /atlas.cern.ch)
     std::vector<std::string> empty_sub_dir;
     empty_sub_dir.push_back(empty_dirs[i].substr(toplevel_dir.length()));
     if (!empty_sub_dir[0].empty()) {
-      CreateUnderlay(source_dir + "/" + toplevel_dir,
-                     dest_dir + "/" + toplevel_dir,
+      CreateUnderlay(source_dir + toplevel_dir,
+                     dest_dir + toplevel_dir,
                      empty_sub_dir);
     }
   }
@@ -149,10 +89,11 @@ void CmdEnter::CreateUnderlay(
   std::vector<std::string> names;
   std::vector<mode_t> modes;
   // In a recursive call, the source directory might not exist, which is fine
-  if (DirectoryExists(source_dir)) {
-    bool rv = ListDirectory(source_dir, &names, &modes);
+  std::string d = source_dir.empty() ? "/" : source_dir;
+  if (DirectoryExists(d)) {
+    bool rv = ListDirectory(d, &names, &modes);
     if (!rv)
-      throw EPublish("cannot list directory " + source_dir);
+      throw EPublish("cannot list directory " + d);
   }
 
   // List the contents of the source directory
@@ -161,7 +102,7 @@ void CmdEnter::CreateUnderlay(
   //   3. File become empty regular files and are bind-mounted
   for (unsigned i = 0; i < names.size(); ++i) {
     if (std::find(empty_toplevel_dirs.begin(), empty_toplevel_dirs.end(),
-        names[i]) != empty_toplevel_dirs.end())
+        std::string("/") + names[i]) != empty_toplevel_dirs.end())
     {
       continue;
     }
@@ -177,12 +118,12 @@ void CmdEnter::CreateUnderlay(
       SymlinkForced(std::string(buf), dest);
     } else {
       if (S_ISDIR(modes[i])) {
-        bool rv = MkdirDeep(dest, 0700, true /* verify_writable */);
-        if (!rv)
-          throw EPublish("cannot create directory " + dest);
+        EnsureDirectory(dest);
       } else {
         CreateFile(dest, 0600, false /* ignore_failure */);
       }
+      LogCvmfs(kLogCvmfs, kLogStdout, "underlay: %s --> %s",
+               source.c_str(), dest.c_str());
       bool rv = BindMount(source, dest);
       if (!rv)
         throw EPublish("cannot bind mount " + source + " --> " + dest);
@@ -190,119 +131,147 @@ void CmdEnter::CreateUnderlay(
   }
 }
 
+void CmdEnter::WriteCvmfsConfig() {
+  BashOptionsManager options_manager;
+  options_manager.ParseDefault(fqrn_);
+  options_manager.SetValue("CVMFS_MOUNT_DIR", lower_layer_);
+  options_manager.SetValue("CVMFS_AUTO_UPDATE", "no");
+  options_manager.SetValue("CVMFS_NFS_SOURCE", "no");
+  options_manager.SetValue("CVMFS_HIDE_MAGIC_XATTRS", "yes");
+  options_manager.SetValue("CVMFS_SERVER_CACHE_MODE", "yes");
+  options_manager.SetValue("CVMFS_USYSLOG", usyslog_path_);
+  options_manager.SetValue("CVMFS_RELOAD_SOCKETS", cache_dir_);
+  options_manager.SetValue("CVMFS_WORKSPACE", cache_dir_);
+  options_manager.SetValue("CVMFS_CACHE_PRIMARY", "private");
+  options_manager.SetValue("CVMFS_CACHE_private_TYPE", "posix");
+  options_manager.SetValue("CVMFS_CACHE_private_BASE", cache_dir_);
+  options_manager.SetValue("CVMFS_CACHE_private_SHARED", "on");
+  options_manager.SetValue("CVMFS_CACHE_private_QUOTA_LIMIT", "4000");
+
+  bool rv = SafeWriteToFile(options_manager.Dump(), config_path_,
+                            kPrivateFileMode);
+  if (!rv)
+    throw EPublish("cannot write client config to " + config_path_);
+}
+
+
+void CmdEnter::MountCvmfs() {
+  std::vector<std::string> cmdline;
+  cmdline.push_back(cvmfs2_binary_);
+  cmdline.push_back("-o");
+  cmdline.push_back("config=" + config_path_);
+  cmdline.push_back(fqrn_);
+  cmdline.push_back(lower_layer_);
+  std::set<int> preserved_fds;
+  preserved_fds.insert(0);
+  //preserved_fds.insert(1);
+  preserved_fds.insert(2);
+  pid_t pid_child;
+  bool rvb = ManagedExec(cmdline, preserved_fds, std::map<int, int>(),
+                         false /* drop_credentials */, false /* clear_env */,
+                         false /* double_fork */,
+                         &pid_child);
+  if (!rvb) throw EPublish("cannot run " + cvmfs2_binary_);
+  int exit_code = WaitForChild(pid_child);
+  if (exit_code != 0) throw EPublish("cannot mount cvmfs read-only branch");
+}
+
+
+void CmdEnter::MountOverlayfs() {
+  std::vector<std::string> args;
+  args.push_back("-o");
+  args.push_back(string("lowerdir=") + lower_layer_ +
+                 ",upperdir=" + upper_layer_ +
+                 ",workdir=" + ovl_workdir_);
+  args.push_back(rootfs_dir_ + target_dir_);
+  int fd_stdin;
+  int fd_stdout;
+  int fd_stderr;
+  pid_t pid_ovl;
+  bool rvb = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr, overlayfs_binary_,
+                           args, false /* double_fork */, &pid_ovl);
+  if (!rvb) EPublish("cannot run " + overlayfs_binary_);
+  int exit_code = WaitForChild(pid_ovl);
+  if (exit_code != 0) EPublish("cannot mount overlay file system");
+}
+
 
 int CmdEnter::Main(const Options &options) {
-  std::string fqrn = options.plain_args()[0].value_str;
+  fqrn_ = options.plain_args()[0].value_str;
   sanitizer::RepositorySanitizer sanitizer;
-  if (!sanitizer.IsValid(fqrn)) {
-    throw EPublish("malformed repository name: " + fqrn);
+  if (!sanitizer.IsValid(fqrn_)) {
+    throw EPublish("malformed repository name: " + fqrn_);
   }
 
-  const std::string target = "/cvmfs/" + fqrn;
+  if (options.Has("cvmfs2")) {
+    cvmfs2_binary_ = options.GetString("cvmfs2");
+    // Lucky guess: library in the same directory than the binary,
+    // but don't overwrite an explicit setting
+    setenv("CVMFS_LIBRARY_PATH", GetParentPath(cvmfs2_binary_).c_str(), 0);
+  }
+
+  target_dir_ = "/cvmfs/" + fqrn_;
 
   // Save context-sensitive directories before switching name spaces
   string cwd = GetCurrentWorkingDirectory();
-  string workspace = GetHomeDirectory() + "/.cvmfs/" + fqrn;
+  uid_t uid = geteuid();
+  gid_t gid = getegid();
+  string workspace = GetHomeDirectory() + "/.cvmfs/" + fqrn_;
 
-  bool retval_b = MkdirDeep(workspace, 0700, true /* verify_writable */);
-  if (!retval_b)
-    throw EPublish("cannot create workspace " + workspace);
-  std::string rootfs = CreateTempDir(workspace + "/session");
-  if (rootfs.empty())
+  EnsureDirectory(workspace);
+  session_dir_ = CreateTempDir(workspace + "/session");
+  if (session_dir_.empty())
     throw EPublish("cannot create session directory in " + workspace);
+  rootfs_dir_ = session_dir_ + "/rootfs";
+  EnsureDirectory(rootfs_dir_);
+  lower_layer_ = session_dir_ + "/lower_layer";
+  EnsureDirectory(lower_layer_);
+  upper_layer_ = session_dir_ + "/upper_layer";
+  EnsureDirectory(upper_layer_);
+  ovl_workdir_ = session_dir_ + "/ovl_workdir";
+  EnsureDirectory(ovl_workdir_);
+  cache_dir_ = session_dir_ + "/cache";
+  EnsureDirectory(cache_dir_);
+  config_path_ = session_dir_ + "/sysdefault.conf";
+  usyslog_path_ = session_dir_ + "/usyslog";
 
   LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
-           "Entering ephemeral writable shell for %s... ", target.c_str());
+           "Entering ephemeral writable shell for %s... ", target_dir_.c_str());
   EnterRootContainer();
   std::vector<std::string> empty_dirs;
-  empty_dirs.push_back(target);
-  CreateUnderlay("/", rootfs, empty_dirs);
+  empty_dirs.push_back(target_dir_);
+  CreateUnderlay("", rootfs_dir_, empty_dirs);
   LogCvmfs(kLogCvmfs, kLogStdout, "done");
-
-
-  //const SettingsSpoolArea &spool_area = settings.transaction().spool_area();
-  //BashOptionsManager options_manager;
-  //options_manager.ParseDefault(settings.fqrn());
-  //options_manager.SetValue("CVMFS_MOUNT_DIR", spool_area.readonly_mnt());
-  //options_manager.SetValue("CVMFS_AUTO_UPDATE", "no");
-  //options_manager.SetValue("CVMFS_NFS_SOURCE", "no");
-  //options_manager.SetValue("CVMFS_HIDE_MAGIC_XATTRS", "yes");
-  //options_manager.SetValue("CVMFS_SERVER_CACHE_MODE", "yes");
-  //options_manager.SetValue("CVMFS_USYSLOG", spool_area.client_log());
-  //options_manager.SetValue("CVMFS_RELOAD_SOCKETS", spool_area.cache_dir());
-  //options_manager.SetValue("CVMFS_WORKSPACE", spool_area.cache_dir());
-  //options_manager.SetValue("CVMFS_CACHE_PRIMARY", "private");
-  //options_manager.SetValue("CVMFS_CACHE_private_TYPE", "posix");
-  //options_manager.SetValue("CVMFS_CACHE_private_BASE", spool_area.cache_dir());
-  //options_manager.SetValue("CVMFS_CACHE_private_SHARED", "on");
-  //options_manager.SetValue("CVMFS_CACHE_private_QUOTA_LIMIT", "4000");
-  //options_manager.SetValue("CVMFS_NFILES", "65538");
-  //options_manager.SetValue("CVMFS_HTTP_PROXY", "DIRECT");
-  //options_manager.SetValue("CVMFS_SERVER_URL", settings.url());
-  //// TODO(jblomer)
-  //options_manager.SetValue("CVMFS_KEYS_DIR", GetCurrentWorkingDirectory());
-//
-  //bool rvb = SafeWriteToFile(options_manager.Dump(), spool_area.client_config(),
-  //                           kPrivateFileMode);
-  //if (!rvb) throw EPublish("cannot write client config");
-//
-  //vector<string> args;
-  //args.push_back("-o");
-  //args.push_back("config=" + spool_area.client_config());
-  //args.push_back(settings.fqrn());
-  //args.push_back(spool_area.readonly_mnt());
-  //int fd_stdin;
-  //int fd_stdout;
-  //int fd_stderr;
-  //pid_t pid_cvmfs;
-  //rvb = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr, cvmfs_binary_, args,
-  //                    false /* double_fork */, &pid_cvmfs);
-  //if (!rvb) throw EPublish("cannot run " + cvmfs_binary_);
-//
-  //int exit_code = WaitForChild(pid_cvmfs);
-  //if (exit_code != 0) throw EPublish("cannot mount cvmfs read-only branch");
-
-  return 0;
-
-
-  SettingsPublisher settings(fqrn);
-
-  settings.SetOwner(geteuid(), getegid());
-  if (options.Has("stratum0"))
-    settings.SetUrl(options.GetString("stratum0"));
-  settings.GetKeychain()->SetKeychainDir(".");
-  settings.GetTransaction()->GetSpoolArea()->SetSpoolArea(workspace);
-  // TODO(jblomer): Storage configuration must be gateway for the enter command
-  settings.GetStorage()->MakeS3("../s3config",
-                                settings.transaction().spool_area().tmp_dir());
-
-  Publisher publisher(settings);
-  publisher.Transaction();
 
   LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
-           "Entering publish container... ");
-  EnterRootContainer();
+           "Mounting CernVM-FS read-only layer... ");
+  WriteCvmfsConfig();
+  if (options.Has("cvmfs-config"))
+    config_path_ += std::string(":") + options.GetString("cvmfs-config");
+  MountCvmfs();
   LogCvmfs(kLogCvmfs, kLogStdout, "done");
 
-
-
-  // TODO(jblomer): set correct paths
-  cvmfs_binary_ = "cvmfs2";
-  overlayfs_binary_ = "fuse-overlayfs";
-
-  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
-           "Mounting CernVM-FS read-only branch... ");
-  MountCvmfs(settings);
-  LogCvmfs(kLogCvmfs, kLogStdout, "done");
   LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
            "Mounting union file system... ");
-  MountOverlayfs(settings);
+  MountOverlayfs();
   LogCvmfs(kLogCvmfs, kLogStdout, "done");
 
-  bool rvb = CreateUserNamespace(settings.owner_uid(), settings.owner_gid());
-  if (!rvb) throw EPublish("cannot create user namespace");
 
-  int rvi = setenv("CVMFS_PUBLISH", settings.fqrn().c_str(), 1 /*overwrite*/);
+  bool rvb = CreateUserNamespace(uid, gid);
+  if (!rvb) {
+    throw EPublish(std::string("cannot create user namespace (") +
+                   StringifyInt(uid) + ", " + StringifyInt(gid) + ")");
+  }
+
+
+  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
+           "Switching to %s... ", rootfs_dir_.c_str());
+  int rvi = chroot(rootfs_dir_.c_str());
+  LogCvmfs(kLogCvmfs, kLogStdout, "done");
+  // May fail if the working directory was invalid to begin with
+  chdir(cwd.c_str());
+
+  rvi = setenv("CVMFS_PUBLISH", fqrn_.c_str(), 1 /*overwrite*/);
   assert(rvi == 0);
   std::vector<std::string> cmdline;
   cmdline.push_back(GetShell());
@@ -319,11 +288,11 @@ int CmdEnter::Main(const Options &options) {
 
   if (exit_code == 0) {
     LogCvmfs(kLogCvmfs, kLogStdout, "Publishing changeset...");
-    publisher.Publish();
   } else {
     LogCvmfs(kLogCvmfs, kLogStdout, "Aborting transaction...");
-    publisher.Abort();
   }
+
+  LogCvmfs(kLogCvmfs, kLogStdout, "Cleaning out session directory");
 
   return exit_code;
 }

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -64,7 +64,7 @@ void CmdEnter::CreateUnderlay(
   const std::string &dest_dir,
   const std::vector<std::string> &empty_dirs)
 {
-  LogCvmfs(kLogCvmfs, kLogStdout, "underlay: entry %s --> %s",
+  LogCvmfs(kLogCvmfs, kLogDebug, "underlay: entry %s --> %s",
            source_dir.c_str(), dest_dir.c_str());
 
   // For an empty directory /cvmfs/atlas.cern.ch, we are going to store "/cvmfs"
@@ -128,7 +128,7 @@ void CmdEnter::CreateUnderlay(
       } else {
         CreateFile(dest, 0600, false /* ignore_failure */);
       }
-      LogCvmfs(kLogCvmfs, kLogStdout, "underlay: %s --> %s",
+      LogCvmfs(kLogCvmfs, kLogDebug, "underlay: %s --> %s",
                source.c_str(), dest.c_str());
       bool rv = BindMount(source, dest);
       if (!rv)
@@ -163,6 +163,11 @@ void CmdEnter::WriteCvmfsConfig() {
 
 
 void CmdEnter::MountCvmfs() {
+  if (FindExecutable(cvmfs2_binary_).empty()) {
+    throw EPublish("cannot find executable " + cvmfs2_binary_,
+                   EPublish::kFailMissingDependency);
+  }
+
   std::vector<std::string> cmdline;
   cmdline.push_back(cvmfs2_binary_);
   cmdline.push_back("-o");
@@ -190,6 +195,11 @@ void CmdEnter::MountCvmfs() {
 
 
 void CmdEnter::MountOverlayfs() {
+  if (FindExecutable(overlayfs_binary_).empty()) {
+    throw EPublish("cannot find executable " + overlayfs_binary_,
+                   EPublish::kFailMissingDependency);
+  }
+
   std::vector<std::string> args;
   args.push_back("-o");
   args.push_back(string("lowerdir=") + lower_layer_ +

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -51,9 +51,13 @@ struct AnchorPid {
 };
 
 static AnchorPid EnterRootContainer() {
-  bool rvb = CreateUserNamespace(0, 0);
-  if (!rvb) throw publish::EPublish("cannot create root user namespace");
-  rvb = CreateMountNamespace();
+  NamespaceFailures failure = CreateUserNamespace(0, 0);
+  if (failure != kFailNsOk) {
+    throw publish::EPublish("cannot create root user namespace (" +
+      StringifyInt(failure) + " / " + StringifyInt(errno) + ")");
+  }
+
+  bool rvb = CreateMountNamespace();
   if (!rvb) throw publish::EPublish("cannot create mount namespace");
   int fd;
   rvb = CreatePidNamespace(&fd);

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -8,10 +8,14 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/limits.h>
+#include <poll.h>
 #include <sched.h>
 #include <signal.h>
 #include <sys/mount.h>
 #include <unistd.h>
+
+
+#include <sys/wait.h>
 
 #include <algorithm>
 #include <cassert>
@@ -29,6 +33,7 @@
 #include "sanitizer.h"
 #include "util/namespace.h"
 #include "util/posix.h"
+#include "util/string.h"
 
 using namespace std;  // NOLINT
 
@@ -133,6 +138,7 @@ void CmdEnter::CreateUnderlay(
 
 void CmdEnter::WriteCvmfsConfig() {
   BashOptionsManager options_manager;
+  options_manager.set_taint_environment(false);
   options_manager.ParseDefault(fqrn_);
   options_manager.SetValue("CVMFS_MOUNT_DIR", lower_layer_);
   options_manager.SetValue("CVMFS_AUTO_UPDATE", "no");
@@ -196,6 +202,302 @@ void CmdEnter::MountOverlayfs() {
 }
 
 
+
+struct ForkFailures {  // TODO(rmeusel): C++11 (type safe enum)
+  enum Names {
+    kSendPid,
+    kUnknown,
+    kFailDupFd,
+    kFailGetMaxFd,
+    kFailGetFdFlags,
+    kFailSetFdFlags,
+    kFailDropCredentials,
+    kFailExec,
+  };
+
+  static std::string ToString(const Names name) {
+    switch (name) {
+      case kSendPid:
+        return "Sending PID";
+
+      default:
+      case kUnknown:
+        return "Unknown Status";
+      case kFailDupFd:
+        return "Duplicate File Descriptor";
+      case kFailGetMaxFd:
+        return "Read maximal File Descriptor";
+      case kFailGetFdFlags:
+        return "Read File Descriptor Flags";
+      case kFailSetFdFlags:
+        return "Set File Descriptor Flags";
+      case kFailDropCredentials:
+        return "Lower User Permissions";
+      case kFailExec:
+        return "Invoking execvp()";
+    }
+  }
+};
+
+/**
+ * Execve to the given command line, preserving the given file descriptors.
+ * If stdin, stdout, stderr should be preserved, add 0, 1, 2.
+ * File descriptors from the parent process can also be mapped to the new
+ * process (dup2) using map_fildes.  Can be useful for
+ * stdout/in/err redirection.
+ * NOTE: The destination fildes have to be preserved!
+ * Does a double fork to detach child.
+ * The command_line parameter contains the binary at index 0 and the arguments
+ * in the rest of the vector.
+ * Using the optional parameter *pid it is possible to retrieve the process ID
+ * of the spawned process.
+ */
+bool MyExec(const std::vector<std::string>  &command_line,
+                 const std::set<int>        &preserve_fildes,
+                 const std::map<int, int>   &map_fildes,
+                 const bool             drop_credentials,
+                 const bool             clear_env,
+                 const bool             double_fork,
+                       pid_t           *child_pid)
+{
+  assert(command_line.size() >= 1);
+
+  Pipe pipe_fork;
+  pid_t pid = fork();
+  assert(pid >= 0);
+  if (pid == 0) {
+    pid_t pid_grand_child;
+    int max_fd;
+    int fd_flags;
+    ForkFailures::Names failed = ForkFailures::kUnknown;
+
+    if (clear_env) {
+#ifdef __APPLE__
+      environ = NULL;
+#else
+      int retval = clearenv();
+      assert(retval == 0);
+#endif
+    }
+
+    const char *argv[command_line.size() + 1];
+    for (unsigned i = 0; i < command_line.size(); ++i)
+      argv[i] = command_line[i].c_str();
+    argv[command_line.size()] = NULL;
+
+    // Child, map file descriptors
+    for (std::map<int, int>::const_iterator i = map_fildes.begin(),
+         iEnd = map_fildes.end(); i != iEnd; ++i)
+    {
+      int retval = dup2(i->first, i->second);
+      if (retval == -1) {
+        failed = ForkFailures::kFailDupFd;
+        goto fork_failure;
+      }
+    }
+
+    // Child, close file descriptors
+    max_fd = sysconf(_SC_OPEN_MAX);
+    if (max_fd < 0) {
+      failed = ForkFailures::kFailGetMaxFd;
+      goto fork_failure;
+    }
+    for (int fd = 0; fd < max_fd; fd++) {
+      if ((fd != pipe_fork.write_end) && (preserve_fildes.count(fd) == 0)) {
+        close(fd);
+      }
+    }
+
+    // Double fork to disconnect from parent
+    if (double_fork) {
+      pid_grand_child = fork();
+      assert(pid_grand_child >= 0);
+      if (pid_grand_child != 0) _exit(0);
+    }
+
+    fd_flags = fcntl(pipe_fork.write_end, F_GETFD);
+    if (fd_flags < 0) {
+      failed = ForkFailures::kFailGetFdFlags;
+      goto fork_failure;
+    }
+    fd_flags |= FD_CLOEXEC;
+    if (fcntl(pipe_fork.write_end, F_SETFD, fd_flags) < 0) {
+      failed = ForkFailures::kFailSetFdFlags;
+      goto fork_failure;
+    }
+
+#ifdef DEBUGMSG
+    assert(setenv("__CVMFS_DEBUG_MODE__", "yes", 1) == 0);
+#endif
+    if (drop_credentials && !SwitchCredentials(geteuid(), getegid(), false)) {
+      failed = ForkFailures::kFailDropCredentials;
+      goto fork_failure;
+    }
+
+    // retrieve the PID of the new (grand) child process and send it to the
+    // grand father
+    pid_grand_child = getpid();
+    pipe_fork.Write(ForkFailures::kSendPid);
+    pipe_fork.Write(pid_grand_child);
+
+    execvp(command_line[0].c_str(), const_cast<char **>(argv));
+
+    failed = ForkFailures::kFailExec;
+
+   fork_failure:
+    pipe_fork.Write(failed);
+    _exit(1);
+  }
+  if (double_fork) {
+    int statloc;
+    waitpid(pid, &statloc, 0);
+  }
+
+  close(pipe_fork.write_end);
+
+  // Either the PID or a return value is sent
+  ForkFailures::Names status_code;
+  bool retcode = pipe_fork.Read(&status_code);
+  assert(retcode);
+  if (status_code != ForkFailures::kSendPid) {
+    close(pipe_fork.read_end);
+    LogCvmfs(kLogCvmfs, kLogDebug, "managed execve failed (%s)",
+             ForkFailures::ToString(status_code).c_str());
+    return false;
+  }
+
+  // read the PID of the spawned process if requested
+  // (the actual read needs to be done in any case!)
+  pid_t buf_child_pid = 0;
+  retcode = pipe_fork.Read(&buf_child_pid);
+  assert(retcode);
+  if (child_pid != NULL)
+    *child_pid = buf_child_pid;
+  close(pipe_fork.read_end);
+  LogCvmfs(kLogCvmfs, kLogDebug, "execve'd %s (PID: %d)",
+           command_line[0].c_str(),
+           static_cast<int>(buf_child_pid));
+  return true;
+}
+
+
+pid_t MyShell() {
+  std::vector<std::string> cmdline;
+  cmdline.push_back(GetShell());
+  std::set<int> preserved_fds;
+  preserved_fds.insert(0);
+  preserved_fds.insert(1);
+  preserved_fds.insert(2);
+  pid_t pid_child;
+  bool rvb = MyExec(cmdline, preserved_fds, std::map<int, int>(),
+                    false /* drop_credentials */, false /* clear_env */,
+                    false /* double_fork */,
+                    &pid_child);
+  return pid_child;
+}
+
+pid_t CmdEnter::RunInteractiveShell() {
+  int fd_stdin;
+  int fd_stdout;
+  int fd_stderr;
+  std::vector<std::string> args;
+  // We disconnect the terminal and therefore need to force it to be an
+  // interactive shell
+  args.push_back("--norc");
+  args.push_back("-i");
+  pid_t pid;
+
+  setenv("PS1", "[ ] ", 1);
+  bool rv = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr,
+                          GetShell(), args,
+                          false /* double_fork */,
+                          &pid);
+  if (!rv)
+    throw EPublish("cannot start shell " + GetShell());
+
+  //std::string ps1_prefix = std::string("\\e[1;34m(") + fqrn_ + ")\\e[0m  ";
+  //std::string prompt = "PS1='" + ps1_prefix + "'\n";
+  //WritePipe(fd_stdin, prompt.data(), prompt.length());
+  //std::string dummy;
+  //GetLineFd(fd_stdout, &dummy);
+
+  //Block2Nonblock(0);
+  //Block2Nonblock(fd_stdout);
+  //Block2Nonblock(fd_stderr);
+  struct pollfd watch_fds[3];
+  while (true) {
+    char buf[1024];
+
+    watch_fds[0].fd = 0;
+    watch_fds[0].events = POLLIN | POLLPRI;
+    watch_fds[0].revents = 0;
+    watch_fds[1].fd = fd_stdout;
+    watch_fds[1].events = POLLIN | POLLPRI;
+    watch_fds[1].revents = 0;
+    watch_fds[2].fd = fd_stderr;
+    watch_fds[2].events = POLLIN | POLLPRI;
+    watch_fds[2].revents = 0;
+    int rv = poll(watch_fds, 3, -1);
+    printf("POLL %d\n", rv);
+    assert(rv != 0);
+    if (rv < 0) {
+      if (errno == EINTR)
+        continue;
+      break;
+    }
+
+    printf("POLLACT\n");
+
+    if (watch_fds[0].revents) {
+      if (watch_fds[0].revents & (POLLERR | POLLHUP)) {
+        printf("fd 0 error");
+        break;
+      }
+      ssize_t nbytes = read(0, buf, sizeof(buf));
+      printf("GOT %d INPUT\n", nbytes);
+      if (nbytes)
+        WritePipe(fd_stdin, buf, nbytes);
+    }
+
+    if (watch_fds[1].revents) {
+      if (watch_fds[1].revents & (POLLERR | POLLHUP)) {
+        printf("OUT ERR\n");
+        break;
+      }
+
+      //printf(" STDOUT\n");
+      ssize_t nbytes = read(fd_stdout, buf, sizeof(buf));
+      printf("GOT %d OUTPUT\n", nbytes);
+      if (nbytes)
+        WritePipe(1, buf, nbytes);
+    }
+
+    if (watch_fds[2].revents) {
+      if (watch_fds[2].revents & (POLLERR | POLLHUP))
+        break;
+
+      //printf(" STDERR\n");
+      ssize_t nbytes = read(fd_stderr, buf, sizeof(buf));
+      printf("GOT %d ERR\n", nbytes);
+      if (nbytes)
+        WritePipe(2, buf, nbytes);
+    }
+  }
+
+  printf("BYE!\n");
+
+  close(fd_stdin);
+  close(fd_stdout);
+  close(fd_stderr);
+
+  return pid;
+}
+
+
+
+
+
+
 int CmdEnter::Main(const Options &options) {
   fqrn_ = options.plain_args()[0].value_str;
   sanitizer::RepositorySanitizer sanitizer;
@@ -211,6 +513,11 @@ int CmdEnter::Main(const Options &options) {
   }
 
   target_dir_ = "/cvmfs/" + fqrn_;
+
+  //pid_t pid_shell = MyShell();
+  //int code = WaitForChild(pid_shell);
+  //printf("EXIT CODE %d\n", code);
+  //return 0;
 
   // Save context-sensitive directories before switching name spaces
   string cwd = GetCurrentWorkingDirectory();
@@ -235,13 +542,19 @@ int CmdEnter::Main(const Options &options) {
   config_path_ = session_dir_ + "/sysdefault.conf";
   usyslog_path_ = session_dir_ + "/usyslog";
 
-  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
+  LogCvmfs(kLogCvmfs, kLogStdout,
            "Entering ephemeral writable shell for %s... ", target_dir_.c_str());
   EnterRootContainer();
   std::vector<std::string> empty_dirs;
   empty_dirs.push_back(target_dir_);
+  empty_dirs.push_back("/proc");
   CreateUnderlay("", rootfs_dir_, empty_dirs);
-  LogCvmfs(kLogCvmfs, kLogStdout, "done");
+  bool rvb = SymlinkForced(session_dir_, rootfs_dir_ + "/.cvmfsenter");
+  if (!rvb)
+    throw EPublish("cannot create marker file " + rootfs_dir_ + "/.cvmfsenter");
+  rvb = ProcMount(rootfs_dir_ + "/proc");
+  if (!rvb)
+    throw EPublish("cannot mount " + rootfs_dir_ + "/proc");
 
   LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
            "Mounting CernVM-FS read-only layer... ");
@@ -256,23 +569,24 @@ int CmdEnter::Main(const Options &options) {
   MountOverlayfs();
   LogCvmfs(kLogCvmfs, kLogStdout, "done");
 
-
-  bool rvb = CreateUserNamespace(uid, gid);
-  if (!rvb) {
-    throw EPublish(std::string("cannot create user namespace (") +
-                   StringifyInt(uid) + ", " + StringifyInt(gid) + ")");
+  if (!options.Has("root")) {
+    rvb = CreateUserNamespace(uid, gid);
+    if (!rvb) {
+      throw EPublish(std::string("cannot create user namespace (") +
+                     StringifyInt(uid) + ", " + StringifyInt(gid) + ")");
+    }
   }
-
 
   LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
            "Switching to %s... ", rootfs_dir_.c_str());
   int rvi = chroot(rootfs_dir_.c_str());
+  if (rvi != 0)
+    throw EPublish("cannot chroot to " + rootfs_dir_);
   LogCvmfs(kLogCvmfs, kLogStdout, "done");
   // May fail if the working directory was invalid to begin with
   chdir(cwd.c_str());
 
-  rvi = setenv("CVMFS_PUBLISH", fqrn_.c_str(), 1 /*overwrite*/);
-  assert(rvi == 0);
+  //pid_t pid_child = RunInteractiveShell();
   std::vector<std::string> cmdline;
   cmdline.push_back(GetShell());
   std::set<int> preserved_fds;

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -523,7 +523,12 @@ int CmdEnter::Main(const Options &options) {
     }
 
     std::vector<std::string> cmdline;
-    cmdline.push_back(GetShell());
+    // options.plain_args()[0] is the repository name
+    for (unsigned i = 1; i < options.plain_args().size(); ++i) {
+      cmdline.push_back(options.plain_args()[i].value_str);
+    }
+    if (cmdline.empty())
+      cmdline.push_back(GetShell());
     std::set<int> preserved_fds;
     preserved_fds.insert(0);
     preserved_fds.insert(1);

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -374,6 +374,8 @@ int CmdEnter::Main(const Options &options) {
              anchor_pid.parent_pid, rootfs_dir_.c_str(), uid, gid);
   }
 
+  setenv("CVMFS_ENTER_SESSION_DIR", session_dir_.c_str(), 1 /* overwrite */);
+
   std::vector<std::string> cmdline;
   cmdline.push_back(GetShell());
   std::set<int> preserved_fds;

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -424,6 +424,11 @@ int CmdEnter::Main(const Options &options) {
     throw EPublish("malformed repository name: " + fqrn_);
   }
 
+  // We cannot have any capabilities or else we are not allowed to write
+  // to /proc/self/setgroups anc /proc/self/[u|g]id_map when creating a user
+  // namespace
+  Repository::DropCapabilities();
+
   if (options.Has("cvmfs2")) {
     cvmfs2_binary_ = options.GetString("cvmfs2");
     // Lucky guess: library in the same directory than the binary,

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -51,11 +51,13 @@ struct AnchorPid {
 };
 
 static AnchorPid EnterRootContainer() {
+  uid_t euid = geteuid();
+  uid_t egid = getegid();
   NamespaceFailures failure = CreateUserNamespace(0, 0);
   if (failure != kFailNsOk) {
     throw publish::EPublish("cannot create root user namespace (" +
       StringifyInt(failure) + " / " + StringifyInt(errno) + ") [euid=" +
-      StringifyInt(geteuid()) + ", egid=" + StringifyInt(getegid()) + "]");
+      StringifyInt(euid) + ", egid=" + StringifyInt(egid) + "]");
   }
 
   bool rvb = CreateMountNamespace();
@@ -509,7 +511,7 @@ int CmdEnter::Main(const Options &options) {
     if (!options.Has("root")) {
       NamespaceFailures failure = CreateUserNamespace(uid, gid);
       if (failure != kFailNsOk) {
-        throw publish::EPublish("cannot create root user namespace for " +
+        throw publish::EPublish("cannot create user namespace for " +
           StringifyInt(uid) + ":" + StringifyInt(gid) + " (" +
           StringifyInt(failure) + " / " + StringifyInt(errno) + ") [euid=" +
           StringifyInt(geteuid()) + ", egid=" + StringifyInt(getegid()) + "]");

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -170,7 +170,8 @@ void CmdEnter::MountCvmfs() {
   cmdline.push_back(lower_layer_);
   std::set<int> preserved_fds;
   preserved_fds.insert(0);
-  //preserved_fds.insert(1);
+  // TODO: redirect to usyslog
+  preserved_fds.insert(1);
   preserved_fds.insert(2);
   pid_t pid_child;
   bool rvb = ManagedExec(cmdline, preserved_fds, std::map<int, int>(),
@@ -179,7 +180,11 @@ void CmdEnter::MountCvmfs() {
                          &pid_child);
   if (!rvb) throw EPublish("cannot run " + cvmfs2_binary_);
   int exit_code = WaitForChild(pid_child);
-  if (exit_code != 0) throw EPublish("cannot mount cvmfs read-only branch");
+  if (exit_code != 0) {
+    throw EPublish("cannot mount cvmfs read-only branch (" +
+          StringifyInt(exit_code) + ")\n" +
+          "  command: `" + JoinStrings(cmdline, " ").c_str() + "`");
+  }
 }
 
 

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -34,6 +34,7 @@ class CmdEnter : public Command {
       "Path to the cvmfs2 binary"));
     p.push_back(Parameter::Optional("cvmfs-config", 'C', "path",
       "Path to extra configuration for the CernVM-FS client"));
+    p.push_back(Parameter::Switch("root", 'r', "Run as fake root"));
     return p;
   }
   virtual unsigned GetMinPlainArgs() const { return 1; }
@@ -47,6 +48,7 @@ class CmdEnter : public Command {
                       const std::vector<std::string> &empty_dirs);
   void WriteCvmfsConfig();
   void MountCvmfs();
+  pid_t RunInteractiveShell();
 
   std::string fqrn_;
   std::string session_dir_;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -55,11 +55,14 @@ class CmdEnter : public Command {
   void MountCvmfs();
   pid_t RunInteractiveShell();
 
+  void CleanupSession(bool keep_logs);
+
   std::string fqrn_;
   std::string session_dir_;
   std::string target_dir_;
   std::string lower_layer_;
   std::string cvmfs2_binary_;
+  std::string overlayfs_binary_;
   std::string rootfs_dir_;
   std::string config_path_;  ///< CernVM-FS configuration
   std::string usyslog_path_;
@@ -68,8 +71,6 @@ class CmdEnter : public Command {
   std::string cache_dir_;
   std::string upper_layer_;
   std::string ovl_workdir_;
-
-  std::string overlayfs_binary_;
 };
 
 }  // namespace publish

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -6,6 +6,7 @@
 #define CVMFS_PUBLISH_CMD_ENTER_H_
 
 #include <string>
+#include <vector>
 
 #include "publish/command.h"
 
@@ -56,7 +57,7 @@ class CmdEnter : public Command {
   std::string lower_layer_;
   std::string cvmfs2_binary_;
   std::string rootfs_dir_;
-  std::string config_path_; ///< CernVM-FS configuration
+  std::string config_path_;  ///< CernVM-FS configuration
   std::string usyslog_path_;
   std::string cache_dir_;
   std::string upper_layer_;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -61,6 +61,8 @@ class CmdEnter : public Command {
   std::string rootfs_dir_;
   std::string config_path_;  ///< CernVM-FS configuration
   std::string usyslog_path_;
+  std::string stdout_path_;  ///< Logs stdout of background commands
+  std::string stderr_path_;  ///< Logs stdout of background commands
   std::string cache_dir_;
   std::string upper_layer_;
   std::string ovl_workdir_;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -39,6 +39,9 @@ class CmdEnter : public Command {
  private:
   void MountCvmfs(const SettingsPublisher &settings);
   void MountOverlayfs(const SettingsPublisher &settings);
+  void CreateUnderlay(const std::string &source_dir,
+                      const std::string &dest_dir,
+                      const std::vector<std::string> &empty_dirs);
 
   std::string cvmfs_binary_;
   std::string overlayfs_binary_;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -38,6 +38,8 @@ class CmdEnter : public Command {
     p.push_back(Parameter::Switch("root", 'r', "Run as fake root"));
     p.push_back(Parameter::Switch("keep-session", 'k',
       "Do not remove the session directory when the shell exits"));
+    p.push_back(Parameter::Switch("keep-logs", 'l',
+      "Clean the session directory on shell exit except for the logs"));
     return p;
   }
   virtual unsigned GetMinPlainArgs() const { return 1; }

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -35,6 +35,8 @@ class CmdEnter : public Command {
       "Path to the cvmfs2 binary"));
     p.push_back(Parameter::Optional("cvmfs-config", 'C', "path",
       "Path to extra configuration for the CernVM-FS client"));
+    p.push_back(Parameter::Optional("alien-cache", 'a', "cache directory",
+      "Use an unmanaged, shared alien cache directory"));
     p.push_back(Parameter::Switch("root", 'r', "Run as fake root"));
     return p;
   }

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -50,12 +50,14 @@ class CmdEnter : public Command {
   void MountOverlayfs();
   void CreateUnderlay(const std::string &source_dir,
                       const std::string &dest_dir,
-                      const std::vector<std::string> &empty_dirs);
+                      const std::vector<std::string> &empty_dirs,
+                      std::vector<std::string> *new_paths);
   void WriteCvmfsConfig();
   void MountCvmfs();
   pid_t RunInteractiveShell();
 
-  void CleanupSession(bool keep_logs);
+  void CleanupSession(bool keep_logs,
+                      const std::vector<std::string> &new_paths);
 
   std::string fqrn_;
   std::string session_dir_;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -35,9 +35,9 @@ class CmdEnter : public Command {
       "Path to the cvmfs2 binary"));
     p.push_back(Parameter::Optional("cvmfs-config", 'C', "path",
       "Path to extra configuration for the CernVM-FS client"));
-    p.push_back(Parameter::Optional("alien-cache", 'a', "cache directory",
-      "Use an unmanaged, shared alien cache directory"));
     p.push_back(Parameter::Switch("root", 'r', "Run as fake root"));
+    p.push_back(Parameter::Switch("keep-session", 'k',
+      "Do not remove the session directory when the shell exits"));
     return p;
   }
   virtual unsigned GetMinPlainArgs() const { return 1; }

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -25,7 +25,7 @@ class CmdEnter : public Command {
     return "Opens an ephemeral namespace to publish content";
   }
   virtual std::string GetUsage() const {
-    return "[options] <fully qualified repository name>";
+    return "[options] <fully qualified repository name> [-- <command> <parms>]";
   }
   virtual ParameterList GetParams() const {
     ParameterList p;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -16,7 +16,7 @@ class SettingsPublisher;
 class CmdEnter : public Command {
  public:
   CmdEnter()
-    : cvmfs_binary_("/usr/bin/cvmfs2")
+    : cvmfs2_binary_("/usr/bin/cvmfs2")
     , overlayfs_binary_("/usr/bin/fuse-overlayfs")
   { }
   virtual std::string GetName() const { return "enter"; }
@@ -30,6 +30,10 @@ class CmdEnter : public Command {
     ParameterList p;
     p.push_back(Parameter::Optional("stratum0", 'w', "stratum0 url",
       "HTTP endpoint of the authoritative storage"));
+    p.push_back(Parameter::Optional("cvmfs2", 'c', "path",
+      "Path to the cvmfs2 binary"));
+    p.push_back(Parameter::Optional("cvmfs-config", 'C', "path",
+      "Path to extra configuration for the CernVM-FS client"));
     return p;
   }
   virtual unsigned GetMinPlainArgs() const { return 1; }
@@ -37,13 +41,25 @@ class CmdEnter : public Command {
   virtual int Main(const Options &options);
 
  private:
-  void MountCvmfs(const SettingsPublisher &settings);
-  void MountOverlayfs(const SettingsPublisher &settings);
+  void MountOverlayfs();
   void CreateUnderlay(const std::string &source_dir,
                       const std::string &dest_dir,
                       const std::vector<std::string> &empty_dirs);
+  void WriteCvmfsConfig();
+  void MountCvmfs();
 
-  std::string cvmfs_binary_;
+  std::string fqrn_;
+  std::string session_dir_;
+  std::string target_dir_;
+  std::string lower_layer_;
+  std::string cvmfs2_binary_;
+  std::string rootfs_dir_;
+  std::string config_path_; ///< CernVM-FS configuration
+  std::string usyslog_path_;
+  std::string cache_dir_;
+  std::string upper_layer_;
+  std::string ovl_workdir_;
+
   std::string overlayfs_binary_;
 };
 

--- a/cvmfs/publish/command.cc
+++ b/cvmfs/publish/command.cc
@@ -81,7 +81,7 @@ Command::Options Command::ParseOptions(int argc, char **argv) {
       free(longopts);
 
       throw EPublish(GetName() + ": unrecognized parameter '" +
-                     argv[optind - 1] + "'");
+                     argv[optind - 1] + "'", EPublish::kFailInvocation);
     }
   }
 
@@ -93,7 +93,8 @@ Command::Options Command::ParseOptions(int argc, char **argv) {
   for (unsigned i = 0; i < params.size(); ++i) {
     if (!params[i].is_optional && !result.Has(params[i].key)) {
       throw EPublish(
-        GetName() + ": missing mandatory parameter '" + params[i].key + "'");
+        GetName() + ": missing mandatory parameter '" + params[i].key + "'",
+        EPublish::kFailInvocation);
     }
   }
 
@@ -104,7 +105,7 @@ Command::Options Command::ParseOptions(int argc, char **argv) {
   if (result.plain_args().size() < GetMinPlainArgs()) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Usage: %s %s %s",
              progname().c_str(), GetName().c_str(), GetUsage().c_str());
-    throw EPublish(GetName() + ": missing argument");
+    throw EPublish(GetName() + ": missing argument", EPublish::kFailInvocation);
   }
 
   return result;

--- a/cvmfs/publish/except.h
+++ b/cvmfs/publish/except.h
@@ -28,6 +28,7 @@ class EPublish : public std::runtime_error {
     kFailRepositoryNotFound,  // the repository was not found on the machine
     kFailLayoutRevision,      // unsupported layout revision, migrate required
     kFailWhitelistExpired,    //
+    kFailMissingDependency,   // a program or service was not found
   };
 
   explicit EPublish(const std::string& what, EFailures f = kFailUnspecified)

--- a/cvmfs/publish/main.cc
+++ b/cvmfs/publish/main.cc
@@ -99,6 +99,9 @@ int main(int argc, char **argv) {
   } catch (const publish::EPublish& e) {
     if (e.failure() == publish::EPublish::kFailInvocation) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Invocation error: %s", e.msg().c_str());
+    } else if (e.failure() == publish::EPublish::kFailMissingDependency) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Missing dependency: %s", e.msg().c_str());
     } else {
       LogCvmfs(kLogCvmfs, kLogStderr, "(unexpected termination) %s", e.what());
     }

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -78,6 +78,13 @@ class __attribute__((visibility("default"))) Repository : SingleCopy {
   static const char kRawHashSymbol = '@';
 
   static std::string GetFqrnFromUrl(const std::string &url);
+  /**
+   * Depending on the desired course of action, the permitted capabilites of the
+   * binary (cap_dac_read_search, cap_sys_admin) needs to be dropped or gained.
+   * Dropped for creating user namespaces in `enter`, gained for walking through
+   * overlayfs.
+   */
+  static void DropCapabilities();
 
   explicit Repository(const SettingsRepository &settings);
   virtual ~Repository();

--- a/cvmfs/publish/repository_capabilities.cc
+++ b/cvmfs/publish/repository_capabilities.cc
@@ -6,14 +6,25 @@
 #include "repository.h"
 
 #include <sys/capability.h>
+#include <sys/prctl.h>
 
 #include "publish/except.h"
 
 namespace publish {
 
 void Repository::DropCapabilities() {
+  int retval;
+
+  // Because the process has file capabilities, its dumpable state is set to
+  // false, which in turn makes the /proc/self/... files owned by root.  We
+  // need to reset this to have them owned by the effective UID in order to
+  // set, e.g., uid_map/gid_map of user namespaces.
+  retval = prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+  if (retval != 0)
+    throw EPublish("cannot clear dumpable state");
+
   cap_t caps = cap_get_proc();
-  int retval = cap_clear(caps);
+  retval = cap_clear(caps);
   cap_free(caps);
   if (retval != 0)
     throw EPublish("cannot clear process capabilities");

--- a/cvmfs/publish/repository_capabilities.cc
+++ b/cvmfs/publish/repository_capabilities.cc
@@ -1,0 +1,22 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+#include "repository.h"
+
+#include <sys/capability.h>
+
+#include "publish/except.h"
+
+namespace publish {
+
+void Repository::DropCapabilities() {
+  cap_t caps = cap_get_proc();
+  int retval = cap_clear(caps);
+  cap_free(caps);
+  if (retval != 0)
+    throw EPublish("cannot clear process capabilities");
+}
+
+}  // namespace publish

--- a/cvmfs/server/cvmfs_server_enter.sh
+++ b/cvmfs/server/cvmfs_server_enter.sh
@@ -1,0 +1,11 @@
+#
+# This file is part of the CernVM File System
+# This script takes care of creating, removing, and maintaining repositories
+# on a Stratum 0/1 server
+#
+# Implementation of the "cvmfs_server transaction command"
+# Migrated to the new cvmfs_publish command
+
+cvmfs_server_enter() {
+  $(__publish_cmd dbg) enter $@
+}

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1071,9 +1071,9 @@ cvmfs_server_update_geodb() {
 # @return   0 if the command was recognized
 is_subcommand() {
   local subcommand="$1"
-  local supported_commands="mkfs add-replica import publish rollback rmfs alterfs    \
-    resign list info tag list-tags lstags check transaction abort snapshot           \
-    skeleton migrate list-catalogs diff checkout update-geodb gc catalog-chown \
+  local supported_commands="mkfs add-replica import publish rollback rmfs alterfs   \
+    resign list info tag list-tags lstags check transaction enter abort snapshot    \
+    skeleton migrate list-catalogs diff checkout update-geodb gc catalog-chown      \
     eliminate-hardlinks eliminate-bulk-hashes fix-stats update-info update-repoinfo \
     mount fix-permissions masterkeycard ingest merge-stats print-stats"
 

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -88,6 +88,16 @@ bool BindMount(const std::string &from, const std::string &to) {
 }
 
 
+bool ProcMount(const std::string &to) {
+#ifdef __APPLE__
+  return false;
+#else
+  int rvi = mount("proc", to.c_str(), "proc", 0, NULL);
+  return rvi == 0;
+#endif
+}
+
+
 bool CreateMountNamespace() {
 #ifdef CVMFS_HAS_UNSHARE
   std::string cwd = GetCurrentWorkingDirectory();

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -83,7 +83,7 @@ bool BindMount(const std::string &from, const std::string &to) {
 #ifdef __APPLE__
   return false;
 #else
-  int rvi = mount(from.c_str(), to.c_str(), "", MS_BIND | MS_REC | MS_UNBINDABLE, NULL);
+  int rvi = mount(from.c_str(), to.c_str(), "", MS_BIND | MS_REC, NULL);
   return rvi == 0;
 #endif
 }
@@ -124,7 +124,7 @@ static void Reaper(int /*sig*/, siginfo_t * /*siginfo*/, void * /*context*/) {
   }
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 
 /**

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -63,12 +63,12 @@ NamespaceFailures CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
   int rvi = unshare(CLONE_NEWUSER);
   if (rvi != 0) return kFailNsUnshare;
 
-  bool rvb = SafeWriteToFile(StringifyInt(map_uid_to) + " " + uid_str + " 1",
+  bool rvb = SafeWriteToFile(StringifyInt(map_uid_to) + " " + uid_str + " 1\n",
                              "/proc/self/uid_map", kDefaultFileMode);
   if (!rvb) return kFailNsMapUid;
   rvb = SafeWriteToFile("deny", "/proc/self/setgroups", kDefaultFileMode);
   if (!rvb) return kFailNsSetgroups;
-  rvb = SafeWriteToFile(StringifyInt(map_gid_to) + " " + gid_str + " 1",
+  rvb = SafeWriteToFile(StringifyInt(map_gid_to) + " " + gid_str + " 1\n",
                         "/proc/self/gid_map", kDefaultFileMode);
   if (!rvb) return kFailNsMapGid;
 

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -58,7 +58,7 @@ int CheckNamespaceFeatures() {
 bool CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
 #ifdef CVMFS_HAS_UNSHARE
   std::string uid_str = StringifyInt(geteuid());
-  std::string gid_str = StringifyInt(geteuid());
+  std::string gid_str = StringifyInt(getegid());
 
   int rvi = unshare(CLONE_NEWUSER);
   if (rvi != 0) return false;

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -116,7 +116,7 @@ bool CreateMountNamespace() {
 /**
  * The fd_parent file descriptor, if passed, is the read end of a pipe whose
  * write end is connected to the parent process.  This gives the namespace's
- * init process a means to detect when the parent process is terminated.
+ * init process a means to know its pid in the context of the parent namespace.
  */
 bool CreatePidNamespace(int *fd_parent) {
 #ifdef CVMFS_HAS_UNSHARE
@@ -145,8 +145,9 @@ bool CreatePidNamespace(int *fd_parent) {
           close(fd);
       }
 
-      char c = 'x';
-      SafeWrite(pipe_parent[1], &c, 1);
+      pid_t parent_pid = getpid();
+      SafeWrite(pipe_parent[1], &parent_pid, sizeof(parent_pid));
+      SafeWrite(pipe_parent[1], &pid, sizeof(pid));
 
       rvi = waitpid(pid, &status, 0);
       if (rvi >= 0) {

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -55,26 +55,26 @@ int CheckNamespaceFeatures() {
 }
 
 
-bool CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
+NamespaceFailures CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
 #ifdef CVMFS_HAS_UNSHARE
   std::string uid_str = StringifyInt(geteuid());
   std::string gid_str = StringifyInt(getegid());
 
   int rvi = unshare(CLONE_NEWUSER);
-  if (rvi != 0) return false;
+  if (rvi != 0) return kFailNsUnshare;
 
   bool rvb = SafeWriteToFile(StringifyInt(map_uid_to) + " " + uid_str + " 1",
                              "/proc/self/uid_map", kDefaultFileMode);
-  if (!rvb) return false;
+  if (!rvb) return kFailNsMapUid;
   rvb = SafeWriteToFile("deny", "/proc/self/setgroups", kDefaultFileMode);
-  if (!rvb) return false;
+  if (!rvb) return kFailNsSetgroups;
   rvb = SafeWriteToFile(StringifyInt(map_gid_to) + " " + gid_str + " 1",
                         "/proc/self/gid_map", kDefaultFileMode);
-  if (!rvb) return false;
+  if (!rvb) return kFailNsMapGid;
 
-  return true;
+  return kFailNsOk;
 #else
-  return false;
+  return kFailNsUnsuppored;
 #endif
 }
 

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -68,18 +68,18 @@ NamespaceFailures CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
 
   int fd;
   ssize_t nbytes;
+  fd = open("/proc/self/setgroups", O_WRONLY);
+  if (fd < 0) return kFailNsSetgroupsOpen;
+  nbytes = write(fd, "deny", 4);
+  close(fd);
+  if (nbytes != 4) return kFailNsSetgroupsWrite;
+
   fd = open("/proc/self/uid_map", O_WRONLY);
   if (fd < 0) return kFailNsMapUidOpen;
   nbytes = write(fd, uid_map.data(), uid_map.length());
   close(fd);
   if (nbytes != static_cast<ssize_t>(uid_map.length()))
     return kFailNsMapUidWrite;
-
-  fd = open("/proc/self/setgroups", O_WRONLY);
-  if (fd < 0) return kFailNsSetgroupsOpen;
-  nbytes = write(fd, "deny", 4);
-  close(fd);
-  if (nbytes != 4) return kFailNsSetgroupsWrite;
 
   fd = open("/proc/self/gid_map", O_WRONLY);
   if (fd < 0) return kFailNsMapGidOpen;

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -69,22 +69,24 @@ NamespaceFailures CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
   int fd;
   ssize_t nbytes;
   fd = open("/proc/self/uid_map", O_WRONLY);
-  if (fd < 0) return kFailNsMapUid;
+  if (fd < 0) return kFailNsMapUidOpen;
   nbytes = write(fd, uid_map.data(), uid_map.length());
   close(fd);
-  if (nbytes != static_cast<ssize_t>(uid_map.length())) return kFailNsMapUid;
+  if (nbytes != static_cast<ssize_t>(uid_map.length()))
+    return kFailNsMapUidWrite;
 
   fd = open("/proc/self/setgroups", O_WRONLY);
-  if (fd < 0) return kFailNsSetgroups;
+  if (fd < 0) return kFailNsSetgroupsOpen;
   nbytes = write(fd, "deny", 4);
   close(fd);
-  if (nbytes != 4) return kFailNsSetgroups;
+  if (nbytes != 4) return kFailNsSetgroupsWrite;
 
   fd = open("/proc/self/gid_map", O_WRONLY);
-  if (fd < 0) return kFailNsMapGid;
+  if (fd < 0) return kFailNsMapGidOpen;
   nbytes = write(fd, gid_map.data(), gid_map.length());
   close(fd);
-  if (nbytes != static_cast<ssize_t>(gid_map.length())) return kFailNsMapGid;
+  if (nbytes != static_cast<ssize_t>(gid_map.length()))
+    return kFailNsMapGidWrite;
 
   return kFailNsOk;
 #else

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -63,8 +63,8 @@ NamespaceFailures CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to) {
   int rvi = unshare(CLONE_NEWUSER);
   if (rvi != 0) return kFailNsUnshare;
 
-  std::string uid_map = StringifyInt(map_uid_to) + " " + uid_str + " 1\n";
-  std::string gid_map = StringifyInt(map_gid_to) + " " + gid_str + " 1\n";
+  std::string uid_map = StringifyInt(map_uid_to) + " " + uid_str + " 1";
+  std::string gid_map = StringifyInt(map_gid_to) + " " + gid_str + " 1";
 
   int fd;
   ssize_t nbytes;

--- a/cvmfs/util/namespace.cc
+++ b/cvmfs/util/namespace.cc
@@ -83,7 +83,7 @@ bool BindMount(const std::string &from, const std::string &to) {
 #ifdef __APPLE__
   return false;
 #else
-  int rvi = mount(from.c_str(), to.c_str(), "", MS_BIND | MS_REC, NULL);
+  int rvi = mount(from.c_str(), to.c_str(), "", MS_BIND | MS_REC | MS_UNBINDABLE, NULL);
   return rvi == 0;
 #endif
 }

--- a/cvmfs/util/namespace.h
+++ b/cvmfs/util/namespace.h
@@ -24,5 +24,6 @@ bool CreateMountNamespace();
 bool CreatePidNamespace(int *fd_parent);
 
 bool BindMount(const std::string &from, const std::string &to);
+bool ProcMount(const std::string &to);
 
 #endif  // CVMFS_UTIL_NAMESPACE_H_

--- a/cvmfs/util/namespace.h
+++ b/cvmfs/util/namespace.h
@@ -23,7 +23,6 @@ enum NamespaceFailures {
   kFailNsUnshare,
   kFailNsMapUidOpen,
   kFailNsMapUidWrite,
-  kFailNsSetgroups,
   kFailNsSetgroupsOpen,
   kFailNsSetgroupsWrite,
   kFailNsMapGidOpen,

--- a/cvmfs/util/namespace.h
+++ b/cvmfs/util/namespace.h
@@ -19,6 +19,7 @@ const int kNsFeatureUserEnabled   = 0x08;
 
 enum NamespaceFailures {
   kFailNsOk = 0,
+  kFailNsUnsuppored,
   kFailNsUnshare,
   kFailNsMapUid,
   kFailNsSetgroups,

--- a/cvmfs/util/namespace.h
+++ b/cvmfs/util/namespace.h
@@ -17,9 +17,17 @@ const int kNsFeaturePid           = 0x02;
 const int kNsFeatureUserAvailable = 0x04;
 const int kNsFeatureUserEnabled   = 0x08;
 
+enum NamespaceFailures {
+  kFailNsOk = 0,
+  kFailNsUnshare,
+  kFailNsMapUid,
+  kFailNsSetgroups,
+  kFailNsMapGid,
+};
+
 int CheckNamespaceFeatures();
 
-bool CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to);
+NamespaceFailures CreateUserNamespace(uid_t map_uid_to, gid_t map_gid_to);
 bool CreateMountNamespace();
 bool CreatePidNamespace(int *fd_parent);
 

--- a/cvmfs/util/namespace.h
+++ b/cvmfs/util/namespace.h
@@ -21,9 +21,13 @@ enum NamespaceFailures {
   kFailNsOk = 0,
   kFailNsUnsuppored,
   kFailNsUnshare,
-  kFailNsMapUid,
+  kFailNsMapUidOpen,
+  kFailNsMapUidWrite,
   kFailNsSetgroups,
-  kFailNsMapGid,
+  kFailNsSetgroupsOpen,
+  kFailNsSetgroupsWrite,
+  kFailNsMapGidOpen,
+  kFailNsMapGidWrite,
 };
 
 int CheckNamespaceFeatures();

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1674,7 +1674,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
     // grand father
     pid_grand_child = getpid();
     failed = ForkFailures::kSendPid;
-    pipe_fork.Write(failed);
+    pipe_fork.Write(&failed, sizeof(failed));
     pipe_fork.Write(pid_grand_child);
 
     execvp(command_line[0].c_str(), const_cast<char **>(argv));
@@ -1682,7 +1682,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
     failed = ForkFailures::kFailExec;
 
    fork_failure:
-    pipe_fork.Write(failed);
+    pipe_fork.Write(&failed, sizeof(failed));
     _exit(1);
   }
   if (double_fork) {
@@ -1694,7 +1694,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
 
   // Either the PID or a return value is sent
   ForkFailures::Names status_code;
-  bool retcode = pipe_fork.Read(&status_code);
+  bool retcode = pipe_fork.Read(&status_code, sizeof(status_code));
   assert(retcode);
   if (status_code != ForkFailures::kSendPid) {
     close(pipe_fork.read_end);

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1673,7 +1673,8 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
     // retrieve the PID of the new (grand) child process and send it to the
     // grand father
     pid_grand_child = getpid();
-    pipe_fork.Write(ForkFailures::kSendPid);
+    failed = ForkFailures::kSendPid;
+    pipe_fork.Write(failed);
     pipe_fork.Write(pid_grand_child);
 
     execvp(command_line[0].c_str(), const_cast<char **>(argv));

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -111,6 +111,9 @@ std::vector<std::string> FindFilesBySuffix(const std::string &dir,
 std::vector<std::string> FindFilesByPrefix(const std::string &dir,
                                            const std::string &prefix);
 std::vector<std::string> FindDirectories(const std::string &parent_dir);
+bool ListDirectory(const std::string &directory,
+                   std::vector<std::string> *names,
+                   std::vector<mode_t> *modes);
 
 std::string GetUserName();
 std::string GetShell();

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -111,6 +111,7 @@ std::vector<std::string> FindFilesBySuffix(const std::string &dir,
 std::vector<std::string> FindFilesByPrefix(const std::string &dir,
                                            const std::string &prefix);
 std::vector<std::string> FindDirectories(const std::string &parent_dir);
+std::string FindExecutable(const std::string &exe);
 bool ListDirectory(const std::string &directory,
                    std::vector<std::string> *names,
                    std::vector<mode_t> *modes);

--- a/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
@@ -30,6 +30,9 @@ test_s3_pid=$(start_test_s3 $TEST_S3_LOGFILE) || { s3_retval=1; retval=1; echo "
 echo "done ($test_s3_pid)"
 create_test_s3_bucket
 
+# Exclusions
+# 682-enter: missing fuse-overlayfs
+
 if [ $s3_retval -eq 0 ]; then
   echo "running CernVM-FS server test cases against the test S3 provider..."
   CVMFS_TEST_S3_CONFIG=$TEST_S3_CONFIG                                      \
@@ -73,6 +76,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/670-listreflog                           \
                                src/672-publish_stats_hardlinks              \
                                src/673-acl                                  \
+                               src/682-enter                                \
                                --                                           \
                                src/5*                                       \
                                src/6*                                       \

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -56,7 +56,6 @@ install_from_repo wget
 install_from_repo java-1.8.0-openjdk
 install_from_repo redhat-lsb-core
 install_from_repo tree
-install_from_repo fuse-overlayfs
 
 # traffic shaping
 install_from_repo trickle

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -56,6 +56,7 @@ install_from_repo wget
 install_from_repo java-1.8.0-openjdk
 install_from_repo redhat-lsb-core
 install_from_repo tree
+install_from_repo fuse-overlayfs
 
 # traffic shaping
 install_from_repo trickle

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -22,6 +22,9 @@ echo "OK"
 run_unittests --gtest_shuffle \
               --gtest_death_test_use_fork || retval=1
 
+# Exclusions
+# 682-enter: missing fuse-overlayfs
+
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
 CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
@@ -44,6 +47,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/628-pythonwrappedcvmfsserver             \
                                  src/672-publish_stats_hardlinks              \
                                  src/673-acl                                  \
+                                 src/682-enter                                \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/cloud_testing/platforms/centos8_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64_setup.sh
@@ -56,6 +56,7 @@ install_from_repo wget
 install_from_repo java-1.8.0-openjdk
 install_from_repo redhat-lsb-core
 install_from_repo tree
+install_from_repo fuse-overlayfs
 
 # traffic shaping
 # install_from_repo trickle

--- a/test/cloud_testing/platforms/fedora_setup.sh
+++ b/test/cloud_testing/platforms/fedora_setup.sh
@@ -51,6 +51,7 @@ install_from_repo bc
 install_from_repo tree
 install_from_repo sqlite
 install_from_repo bzip2
+install_from_repo fuse-overlayfs
 
 # traffic shaping
 install_from_repo trickle

--- a/test/cloud_testing/platforms/fedora_setup.sh
+++ b/test/cloud_testing/platforms/fedora_setup.sh
@@ -81,3 +81,6 @@ sudo setsebool -P httpd_can_network_connect on
 echo -n "increasing ulimit -n ... "
 set_nofile_limit 65536 || die "fail"
 echo "done"
+
+# Enable user namespaces
+sudo sysctl -w user.max_user_namespaces=10000 || die "fail (enable user namespace)"

--- a/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_s3_test.sh
@@ -78,6 +78,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/647-bearercvmfs                          \
                                src/670-listreflog                           \
                                src/673-acl                                  \
+                               src/682-enter                                \
                                --                                           \
                                src/5*                                       \
                                src/6*                                       \

--- a/test/cloud_testing/platforms/slc6_x86_64_test.sh
+++ b/test/cloud_testing/platforms/slc6_x86_64_test.sh
@@ -44,6 +44,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                               -x src/518-hardlinkstresstest                   \
                                  src/585-xattrs                               \
                                  src/673-acl                                  \
+                                 src/682-enter                                \
                                  src/700-overlayfs_validation                 \
                                  --                                           \
                                  src/5*                                       \

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -27,6 +27,11 @@ if [ "x$ubuntu_release" = "xxenial" ]; then
   CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/682-enter"
 fi
 
+if [ "x$ubuntu_release" = "xbionic" ]; then
+  # Ubuntu 18.04 has no fuse-overlayfs
+  CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/682-enter"
+fi
+
 export CVMFS_TEST_UNIONFS=overlayfs
 
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -87,6 +87,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/670-listreflog                           \
                                src/672-publish_stats_hardlinks              \
                                src/673-acl                                  \
+                               $CVMFS_EXCLUDE                               \
                                --                                           \
                                src/5*                                       \
                                src/6*                                       \

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -22,6 +22,11 @@ CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/628-pythonwrappedcvmfsserver"
 # Hardlinks do not work with overlayfs
 CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/672-publish_stats_hardlinks"
 
+if [ "x$ubuntu_release" = "xxenial" ]; then
+  # Ubuntu 16.04 has no fuse-overlayfs
+  CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/682-enter"
+fi
+
 export CVMFS_TEST_UNIONFS=overlayfs
 
 cd ${SOURCE_DIRECTORY}/test

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -12,6 +12,7 @@ run_unittests --gtest_shuffle \
              --gtest_death_test_use_fork || retval=1
 
 
+ubuntu_release="$(lsb_release -cs)"
 CVMFS_EXCLUDE=
 
 # Kernel sources too old for gcc, TODO

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -87,6 +87,7 @@ if [ "x$ubuntu_release" == "xxenial" ]; then
 fi
 install_from_repo bc                            || die "fail (installing bc)"
 install_from_repo tree                          || die "fail (installing tree)"
+install_from_repo fuse-overlayfs                || die "fail (installing fuse-overlayfs)"
 
 # traffic shaping
 install_from_repo trickle || die "fail (installing trickle)"

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -118,8 +118,10 @@ if [ "x$ubuntu_release" = "xxenial" ]; then
 else
   sudo apt-get install autofs || die "fail (installing autofs on 20.04)"
 
-  # fuse-overlayfs requires Ubuntu 18.04+
-  install_from_repo fuse-overlayfs || die "fail (installing fuse-overlayfs)"
+  # fuse-overlayfs requires Ubuntu 20.04+
+  if [ "x$ubuntu_release" != "xbionic" ]; then
+    install_from_repo fuse-overlayfs || die "fail (installing fuse-overlayfs)"
+  fi
 fi
 
 # On Ubuntu 16.04+ 64bit install the repository gateway

--- a/test/cloud_testing/platforms/ubuntu_setup.sh
+++ b/test/cloud_testing/platforms/ubuntu_setup.sh
@@ -87,7 +87,6 @@ if [ "x$ubuntu_release" == "xxenial" ]; then
 fi
 install_from_repo bc                            || die "fail (installing bc)"
 install_from_repo tree                          || die "fail (installing tree)"
-install_from_repo fuse-overlayfs                || die "fail (installing fuse-overlayfs)"
 
 # traffic shaping
 install_from_repo trickle || die "fail (installing trickle)"
@@ -107,8 +106,8 @@ install_test_s3 || die "fail (installing test S3)"
 # install 'jq'
 install_from_repo jq || die "fail (installing jq)"
 
-# On Ubuntu 16.04 install backported autofs
 if [ "x$ubuntu_release" = "xxenial" ]; then
+  # On Ubuntu 16.04 install backported autofs
   install_from_repo wget || die "fail (installing wget)"
   wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release_2.0-3_all.deb
   sudo dpkg -i cvmfs-release_2.0-3_all.deb || die "fail (installing cvmfs-release)"
@@ -116,8 +115,11 @@ if [ "x$ubuntu_release" = "xxenial" ]; then
   sudo apt-get install autofs || die "fail installing backported autofs"
   sudo cvmfs_config setup || die "re-running cvmfs setup"
   dpkg -s autofs
-elif [ "x$ubuntu_release" = "xfocal" ]; then
+else
   sudo apt-get install autofs || die "fail (installing autofs on 20.04)"
+
+  # fuse-overlayfs requires Ubuntu 18.04+
+  install_from_repo fuse-overlayfs || die "fail (installing fuse-overlayfs)"
 fi
 
 # On Ubuntu 16.04+ 64bit install the repository gateway

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -27,6 +27,16 @@ CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/628-pythonwrappedcvmfsserver"
 # Hardlinks do not work with overlayfs
 CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/672-publish_stats_hardlinks"
 
+if [ "x$ubuntu_release" = "xxenial" ]; then
+  # Ubuntu 16.04 has no fuse-overlayfs
+  CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/682-enter"
+fi
+
+if [ "x$ubuntu_release" = "xbionic" ]; then
+  # Ubuntu 18.04 has no fuse-overlayfs
+  CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/682-enter"
+fi
+
 export CVMFS_TEST_UNIONFS=overlayfs
 
 cd ${SOURCE_DIRECTORY}/test

--- a/test/src/682-enter/main
+++ b/test/src/682-enter/main
@@ -5,10 +5,6 @@ cvmfs_test_suites="quick"
 cvmfs_run_test() {
   logfile=$1
 
-  id -a
-  id -ru
-  id -rg
-  id -rG
   unshare --user --map-root-user id -a || return 1
   id -a
   id -ru

--- a/test/src/682-enter/main
+++ b/test/src/682-enter/main
@@ -5,6 +5,8 @@ cvmfs_test_suites="quick"
 cvmfs_run_test() {
   logfile=$1
 
+  unshare --user --map-root-user id -a || return 1
+
   cvmfs_mount atlas.cern.ch || return 10
   rm -rf $HOME/.cvmfs/atlas.cern.ch || return 11
 

--- a/test/src/682-enter/main
+++ b/test/src/682-enter/main
@@ -1,0 +1,20 @@
+cvmfs_test_name="Enter ephemeral writable subshell"
+cvmfs_test_autofs_on_startup=true
+cvmfs_test_suites="quick"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  cvmfs_mount atlas.cern.ch || return 10
+  rm -rf $HOME/.cvmfs/atlas.cern.ch || return 11
+
+  cvmfs_server enter atlas.cern.ch -- touch /cvmfs/atlas.cern.ch/test || return 20
+  cvmfs_server enter atlas.cern.ch -- touch /cvmfs/cvmfs-config.cern.ch/test && return 30
+  cvmfs_server enter atlas.cern.ch -- false && return 40
+
+  echo "*** checking that session dir properly cleaned up"
+  [ -z "$(ls -A $HOME/.cvmfs/atlas.cern.ch)" ] || return 50
+
+  return 0
+}
+

--- a/test/src/682-enter/main
+++ b/test/src/682-enter/main
@@ -5,7 +5,15 @@ cvmfs_test_suites="quick"
 cvmfs_run_test() {
   logfile=$1
 
+  id -a
+  id -ru
+  id -rg
+  id -rG
   unshare --user --map-root-user id -a || return 1
+  id -a
+  id -ru
+  id -rg
+  id -rG
 
   cvmfs_mount atlas.cern.ch || return 10
   rm -rf $HOME/.cvmfs/atlas.cern.ch || return 11

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -450,6 +450,7 @@ set (CVMFS_TEST_PUBLISH_SOURCES
   ${CVMFS_SOURCE_DIR}/publish/command.cc
   ${CVMFS_SOURCE_DIR}/publish/except.cc
   ${CVMFS_SOURCE_DIR}/publish/repository.cc
+  ${CVMFS_SOURCE_DIR}/publish/repository_capabilities.cc
   ${CVMFS_SOURCE_DIR}/publish/repository_diff.cc
   ${CVMFS_SOURCE_DIR}/publish/repository_managed.cc
   ${CVMFS_SOURCE_DIR}/publish/repository_session.cc

--- a/test/unittests/t_namespace.cc
+++ b/test/unittests/t_namespace.cc
@@ -103,10 +103,10 @@ TEST_F(T_Namespace, UserMountPid) {
   if (!(ns_features_ & kNsFeatureMount)) return;
   if (!(ns_features_ & kNsFeaturePid)) return;
 
-  int pid = fork();
+  pid_t pid = fork();
   ASSERT_GE(pid, 0);
   if (pid > 0) {
-    EXPECT_EQ(0, WaitForChild(0));
+    EXPECT_EQ(0, WaitForChild(pid));
     return;
   }
 
@@ -121,9 +121,15 @@ TEST_F(T_Namespace, UserMountPid) {
   procpid[len] = '\0';
   EXPECT_EQ(StringifyInt(getpid()), std::string(procpid));
   EXPECT_EQ(pid_t(1), getpid());
-  char c = 0;
-  EXPECT_EQ(1, SafeRead(fd_parent, &c, 1));
-  EXPECT_EQ('x', c);
+  pid_t anchor_pid;
+  pid_t init_pid;
+  EXPECT_EQ(static_cast<int>(sizeof(pid_t)),
+            SafeRead(fd_parent, &anchor_pid, sizeof(pid_t)));
+  EXPECT_EQ(static_cast<int>(sizeof(pid_t)),
+            SafeRead(fd_parent, &init_pid, sizeof(pid_t)));
+  close(fd_parent);
+  EXPECT_GT(anchor_pid, 1);
+  EXPECT_GT(init_pid, 1);
 
   exit(testing::Test::HasFailure());
 }

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1056,6 +1056,37 @@ TEST_F(T_Util, FindDirectories) {
 }
 
 
+TEST_F(T_Util, ListDirectory) {
+  std::vector<std::string> names;
+  std::vector<mode_t> modes;
+
+  EXPECT_FALSE(ListDirectory("/no/such/dir", &names, &modes));
+  string dir = sandbox + "/test-listdir";
+  ASSERT_TRUE(MkdirDeep(dir, 0700));
+
+  EXPECT_TRUE(ListDirectory(dir, &names, &modes));
+  EXPECT_TRUE(names.empty());
+  EXPECT_TRUE(modes.empty());
+
+  ASSERT_TRUE(MkdirDeep(dir + "/dir1/sub", 0700));
+  ASSERT_TRUE(MkdirDeep(dir + "/dir2", 0700));
+  EXPECT_TRUE(SymlinkForced(dir + "/dir1", dir + "/dirX"));
+  string temp_file = CreateTempPath(dir + "/tempfile", 0600);
+  ASSERT_FALSE(temp_file.empty());
+
+  EXPECT_TRUE(ListDirectory(dir, &names, &modes));
+  ASSERT_EQ(4U, names.size());
+  EXPECT_EQ("dir1", names[0]);
+  EXPECT_EQ("dir2", names[1]);
+  EXPECT_EQ("dirX", names[2]);
+  EXPECT_EQ(GetFileName(temp_file), names[3]);
+  EXPECT_TRUE(S_ISDIR(modes[0]));
+  EXPECT_TRUE(S_ISDIR(modes[1]));
+  EXPECT_TRUE(S_ISLNK(modes[2]));
+  EXPECT_TRUE(S_ISREG(modes[3]));
+}
+
+
 TEST_F(T_Util, GetUmask) {
   unsigned test_umask = 0755;
   mode_t original_mask = umask(test_umask);

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1087,6 +1087,17 @@ TEST_F(T_Util, ListDirectory) {
 }
 
 
+TEST_F(T_Util, FindExecutable) {
+  std::string ls = FindExecutable("ls");
+  ASSERT_FALSE(ls.empty());
+  EXPECT_EQ('/', ls[0]);
+  std::string ls_abs = FindExecutable(ls);
+  EXPECT_EQ(ls, ls_abs);
+  std::string fail = FindExecutable("no-such-exe");
+  EXPECT_TRUE(fail.empty());
+}
+
+
 TEST_F(T_Util, GetUmask) {
   unsigned test_umask = 0755;
   mode_t original_mask = umask(test_umask);


### PR DESCRIPTION
The `cvmfs_publish enter` command opens a writable subshell given read-only access to a repository.  It does so by

- Creating a user, mount, and pid namespace
- Creating an underlay using the current root file system tree
- Mounting /cvmfs/$repo with fuse-overlayfs

The state of the writable shell is kept in $HOME/.cvmfs

Corresponding ticket: https://sft.its.cern.ch/jira/browse/CVM-1924