### PR TITLE
Improve reflog repair when zombie hash is present in the manifest

### DIFF
--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -76,10 +76,10 @@ cvmfs_server_check() {
   # do it!
   if [ $check_integrity -ne 0 ]; then
     if ! is_local_upstream $upstream; then
-      echo "Storage Integrity Check only works locally. skipping."
+      echo "Storage integrity check only works locally. skipping."
     else
       echo
-      echo "Checking Storage Integrity of $name ... (may take a while)"
+      echo "Checking storage integrity of $name ... (may take a while)"
       storage_dir=$(get_upstream_config $upstream)
       __swissknife scrub -r ${storage_dir}/data || die "FAIL!"
     fi
@@ -135,19 +135,22 @@ __check_repair_reflog() {
   local stored_checksum=
   has_reflog_checksum $name && stored_checksum="$(cat $(get_reflog_checksum $name))"
 
+  local repository_url=
+  if is_stratum0 $name; then
+    repository_url="$CVMFS_STRATUM0"
+  else
+    repository_url="$CVMFS_STRATUM1"
+  fi
+
   local has_reflog=0
   local computed_checksum=
   if $user_shell "$(__swissknife_cmd) peek -d .cvmfsreflog -r $CVMFS_UPSTREAM_STORAGE" >/dev/null; then
     has_reflog=1
-    local url=
-    if is_stratum0 $name; then
-      url="${CVMFS_STRATUM0}/.cvmfsreflog"
-    else
-      url="${CVMFS_STRATUM1}/.cvmfsreflog"
-    fi
+    local url="$repository_url/.cvmfsreflog"
     local rehash_cmd="curl -sS --fail --connect-timeout 10 --max-time 300 $url \
       | cvmfs_publish hash -a ${CVMFS_HASH_ALGORITHM:-sha1}"
     computed_checksum="$($user_shell "$rehash_cmd")"
+    echo "Info: found $url with content hash $computed_checksum"
   fi
 
   if has_reflog_checksum $name; then
@@ -165,6 +168,31 @@ __check_repair_reflog() {
     if [ $has_reflog -eq 1 ]; then
       $user_shell "echo $computed_checksum > $(get_reflog_checksum $name)"
       echo "Warning: re-created missing reflog checksum as $computed_checksum"
+    fi
+  fi
+
+  # At this point we either have no .cvmfsreflog and no local reflog.chksum or
+  # we have both files properly in sync.
+
+  # Remaining case: a reflog is registered in the manifest but the
+  # .cvmfsreflog file is missing.  In this case, we recreate the reflog.
+
+  if get_repo_info -R | grep -q ^Y; then
+    echo "Warning: a reflog hash is registered in the manifest, re-creating missing reflog"
+    to_syslog_for_repo $name "reference log reconstruction started"
+    local repository_url
+
+    local reflog_reconstruct_command="$(__swissknife_cmd dbg) reconstruct_reflog \
+                                                  -r $repository_url             \
+                                                  -u $CVMFS_UPSTREAM_STORAGE     \
+                                                  -n $CVMFS_REPOSITORY_NAME      \
+                                                  -t ${CVMFS_SPOOL_DIR}/tmp/     \
+                                                  -k $CVMFS_PUBLIC_KEY           \
+                                                  -R $(get_reflog_checksum $name)"
+    if ! $user_shell "$reflog_reconstruct_command"; then
+      to_syslog_for_repo $name "failed to reconstruction reference log"
+    else
+      to_syslog_for_repo $name "successfully reconstructed reference log"
     fi
   fi
 }

--- a/cvmfs/server_tool_impl.h
+++ b/cvmfs/server_tool_impl.h
@@ -24,15 +24,16 @@ manifest::Reflog *ServerTool::FetchReflog(ObjectFetcherT *object_fetcher,
 
     case ObjectFetcherT::kFailNotFound:
       LogCvmfs(kLogCvmfs, kLogStderr,
-               "reflog for '%s' not found but reflog.chksum is present; "
-               "remove reflog.chksum to recreate the reflog",
+               "reflog for '%s' not found but reflog checksum is present "
+               "(either in the manifest key 'Y' or in the reflog.chksum file); "
+               "run `cvmfs_server check -r` to fix.",
                repo_name.c_str());
       return NULL;
 
     case ObjectFetcherT::kFailBadData:
       LogCvmfs(kLogCvmfs, kLogStderr,
-               "data corruption in .cvmfsreflog for %s, remove for automatic "
-               "recreation or verify reflog.chksum file",
+               "data corruption in .cvmfsreflog for %s, run "
+               "`cvmfs_server check -r` to fix",
                repo_name.c_str());
       return NULL;
 

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -87,8 +87,7 @@ SigningTool::Result SigningTool::Run(
   if (!reflog_hash.IsNull()) {
     reflog = server_tool_->FetchReflog(&object_fetcher, repo_name, reflog_hash);
     if (!reflog.IsValid()) {
-      LogCvmfs(kLogCvmfs, kLogStderr,
-               "reflog hash specified but reflog not present");
+      LogCvmfs(kLogCvmfs, kLogStderr, "reflog missing");
       return kReflogMissing;
     }
   } else {

--- a/test/src/634-reflogchecksum/main
+++ b/test/src/634-reflogchecksum/main
@@ -146,5 +146,24 @@ cvmfs_run_test() {
   check_repository $CVMFS_TEST_REPO -r || return 116
   check_repository $CVMFS_TEST634_REPLICA_NAME -r || return 116
 
+  echo "*** check repairing missing reflog with a zombie hash registered in the manifest"
+  delete_from_backend $CVMFS_TEST_REPO ".cvmfsreflog" || return 30
+  delete_from_backend $CVMFS_TEST634_REPLICA_NAME ".cvmfsreflog" || return 30
+  rm -f $checksum $replica_checksum
+  start_transaction $CVMFS_TEST_REPO || return $?
+  # Note: in this situation, gc on the S0 recreates the reflog automatically
+  # and thus does not fail (libcvmfs_server should handle the reflog more consistently)
+  publish_repo $CVMFS_TEST_REPO && return 31
+  check_repository $CVMFS_TEST_REPO -r || return 32
+  publish_repo $CVMFS_TEST_REPO || return 32
+  cvmfs_server gc -f $CVMFS_TEST_REPO || return 33
+  # Note: swissknife_pull looks only that reflog.chksum file (not in the manifest)
+  # Therefore, it would continue to work
+  # libcvmfs_server should handle the reflog more consistently
+  # cvmfs_server gc -f $CVMFS_TEST634_REPLICA_NAME && return 34
+  check_repository $CVMFS_TEST634_REPLICA_NAME -r || return 35
+  sudo cvmfs_server snapshot $CVMFS_TEST634_REPLICA_NAME || return 36
+  cvmfs_server gc -f $CVMFS_TEST634_REPLICA_NAME || return 36
+
   return 0
 }


### PR DESCRIPTION
Better deals with the situation where .cvmfsreflog and reflog.chksum are missing but the `Y` key is set in the manifest.