### PR TITLE
Fix service container config

### DIFF
--- a/mount/default.d/42-container.conf
+++ b/mount/default.d/42-container.conf
@@ -2,3 +2,4 @@
 
 CVMFS_USYSLOG=/var/log/cvmfs.log
 CVMFS_CLAIM_OWNERSHIP=no
+CVMFS_USE_CDN=yes


### PR DESCRIPTION
@DrDaveD As discussed at the workshop, this fix makes OpenHTC servers the default for the service container