### PR TITLE
Do not escape '@' in URI strings

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -70,6 +70,7 @@ static inline bool EscapeUrlChar(char input, char output[3]) {
       ((input >= 'A') && (input <= 'Z')) ||
       ((input >= 'a') && (input <= 'z')) ||
       (input == '/') || (input == ':') || (input == '.') ||
+      (input == '@') ||
       (input == '+') || (input == '-') ||
       (input == '_') || (input == '~') ||
       (input == '[') || (input == ']') || (input == ','))


### PR DESCRIPTION
RFC 3986 section 3.2.1 defines inline user information within a URI in
the form of "user:password@host".

The '@' character is currently escaped unconditionally when setting
CURLOPT_URL in DownloadManager::SetUrlOptions().  This causes any such
URIs to be treated as invalid and hence requests will eventually fail
with kFailBadUrl.

Fix by adding '@' to the list of characters that do not require URI
escaping.  The '@' character has no special meaning outside of the
user information field, and so this will not alter the interpretation
of any other part of the URI.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>