### PR TITLE
Allow for user information in DNS-resolved URI strings

### DIFF
--- a/cvmfs/dns.cc
+++ b/cvmfs/dns.cc
@@ -68,10 +68,22 @@ static void PinpointHostSubstr(
     }
   }
 
+  // Search '@' within the hostname part and jump behind if present
+  if (*pos_begin > 0) {
+    for (i = *pos_begin; i < len; ++i) {
+      if (url[i] == '/') {
+        break;
+      } else if (url[i] == '@') {
+        *pos_begin = ++i;
+        break;
+      }
+    }
+  }
+
   // Find the end of the hostname part
   if (*pos_begin > 0) {
-    bool in_ipv6 = (url[i] == '[');
-    for (; i < len; ++i) {
+    bool in_ipv6 = (url[*pos_begin] == '[');
+    for (i = *pos_begin; i < len; ++i) {
       if (in_ipv6) {
         if (url[i] != ']')
           continue;

--- a/test/unittests/t_dns.cc
+++ b/test/unittests/t_dns.cc
@@ -235,6 +235,11 @@ TEST_F(T_Dns, ExtractHost) {
   EXPECT_EQ(ExtractHost("http://:"), "");
   EXPECT_EQ(ExtractHost("http://["), "");
   EXPECT_EQ(ExtractHost("http://[]"), "[]");
+  EXPECT_EQ(ExtractHost("http://user:pw@localhost:3128"), "localhost");
+  EXPECT_EQ(ExtractHost("http://user:pw@[::1]:3128"), "[::1]");
+  EXPECT_EQ(ExtractHost("http://user:pw@localhost/path"), "localhost");
+  EXPECT_EQ(ExtractHost("http://user:pw@localhost/p@th"), "localhost");
+  EXPECT_EQ(ExtractHost("http://user:pw@"), "");
 }
 
 


### PR DESCRIPTION
RFC 3986 section 3.2.1 defines inline user information within a URI in
the form of "user:password@host".

The host name extraction logic in dns::PinpointHostSubstr() does not
currently understand inline user information, and will therefore end
up taking the username as the hostname.

Fix by searching for and skipping inline user information before
extracting the hostname.

This allows the CVMFS_HTTP_PROXY list to include proxies that require
authentication via the Proxy-Authorization header.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>