### PR TITLE
Do not include an explicit default port number within S3 upload URI

### DIFF
--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -120,7 +120,7 @@ bool S3Uploader::ParseSpoolerDefinition(
   if (options_manager.GetValue("CVMFS_S3_PORT", &parameter)) {
     host_name_port_ = host_name_ + ":" + parameter;
   } else {
-    host_name_port_ = host_name_ + ":" + StringifyInt(kDefaultPort);
+    host_name_port_ = host_name_;
   }
 
   if (!options_manager.GetValue("CVMFS_S3_ACCESS_KEY", &access_key_)) {


### PR DESCRIPTION
The S3 uploader will currently always include an explicit port number
within URIs (e.g. "http://mybucket.s3.us-east-1.amazonaws.com:80")
even when using the default HTTP port 80.

This is not incorrect, but unfortunately triggers a bug within libcurl
(see https://github.com/curl/curl/issues/6769) that causes it to
construct requests that will be rejected if they happen to pass
through HAProxy.

Work around this libcurl bug by omitting an explicit port number from
the constructed URI when the default port is used.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>