### PR TITLE
Fail readconfig when parsing config fails

### DIFF
--- a/mount/config.sh
+++ b/mount/config.sh
@@ -28,6 +28,10 @@ cvmfs_readconfig() {
   local domain; domain=`cvmfs_getdomain $fqrn`
 
   CVMFS_PARMS=$(cvmfs2 -o parse "$fqrn" /)
+  local ret=$?
+  if [ $ret != 0 ]; then
+    return $ret
+  fi
   unset CVMFS_CACHE_DIR
   eval "$CVMFS_PARMS"
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -490,9 +490,13 @@ cvmfs_mount() {
   sudo sh -c "echo CVMFS_REPOSITORY_TAG=TESTING > /etc/cvmfs/config.d/cvmfs-config.cern.ch.local" || return 100
 
   # add additional parameters
+  local proberunner
   while [ $# -gt 0 ]; do
     local param="$1"
-    sudo sh -c "echo \"$1\" >> /etc/cvmfs/default.local" || return 100
+    if [ "$param" = "CVMFS_SUID=yes" ]; then
+      proberunner="sudo"
+    fi
+    sudo sh -c "echo \"$param\" >> /etc/cvmfs/default.local" || return 100
     shift 1
   done
 
@@ -504,7 +508,7 @@ cvmfs_mount() {
     cvmfs_mount_direct $repositories
   fi
 
-  cvmfs_config probe > /dev/null 2>&1 || return 101
+  $proberunner cvmfs_config probe > /dev/null 2>&1 || return 101
 
   return 0
 }


### PR DESCRIPTION
I noticed that if there's any problem parsing a repository's configuration, cvmfs_config showconfig does show a failure but instead shows a bunch of empty variables.  This changes the cvmfs_readconfig function to return an error if cvmfs2 -o  parse returns an error.