### PR TITLE
Fix use of EXPECT_DEATH()

### DIFF
--- a/cvmfs/sql.cc
+++ b/cvmfs/sql.cc
@@ -18,7 +18,8 @@ Sql::Sql(sqlite3 *sqlite_db, const std::string &statement)
   , query_string_(NULL)
   , last_error_code_(0)
 {
-  Init(sqlite_db, statement);
+  const bool success = Init(sqlite_db, statement);
+  assert(success);
 }
 
 

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -498,9 +498,10 @@ void CatalogTestTool::CreateHistory(
   manifest::Manifest *manifest,
   shash::Any *history_hash
 ) {
+  const string history_path = CreateTempPath(repo_path_ + "/history", 0600);
   {
     UniquePtr<history::SqliteHistory> history(
-      history::SqliteHistory::Create(repo_path_ + "/history",
+      history::SqliteHistory::Create(history_path,
                                      "keys.cern.ch"));
     ASSERT_TRUE(history.IsValid());
     history::History::Tag tag;
@@ -510,10 +511,10 @@ void CatalogTestTool::CreateHistory(
     ASSERT_TRUE(history->Insert(tag));
   }
   history_hash->suffix = shash::kSuffixHistory;
-  ASSERT_TRUE(zlib::CompressPath2Null(repo_path_ + "/history", history_hash));
+  ASSERT_TRUE(zlib::CompressPath2Null(history_path, history_hash));
   ASSERT_TRUE(
     zlib::CompressPath2Path(
-      repo_path_ + "/history",
+      history_path,
       repo_path_ + "/data/" + history_hash->MakePath()));
 }
 


### PR DESCRIPTION
The `EXPECT_DEATH()` macro will currently give false positive results on any catalog tests, since the act of running a catalog test via `EXPECT_DEATH()` will unconditionally die due to a failure to create the test catalog history database (rather than due to the expected failure).

This fix has the side benefit of making the `EXPECT_DEATH()` regexp argument usable, which allows the test to verify that the death occurred for the expected reason.

Fixes: #2717 