### PR TITLE
Avoid starting autofs for tests that require autofs to be disabled

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -137,17 +137,18 @@ setup_environment() {
   # if we are not inside a docker
   if [ x"$CVMFS_TEST_DOCKER" = xno ] && ! running_on_osx; then
     # configure autofs to the test's needs
-    service_switch autofs restart || true
-    local timeout=10 # wait until autofs restarts (possible race >.<)
-    while [ $timeout -gt 0 ] && ! autofs_check; do
-      timeout=$(( $timeout - 1))
-      sleep 1
-    done
-    if [ $timeout -eq 0 ]; then
-      echo "failed to restart autofs"
-      return 103
-    fi
-    if ! $autofs_demand; then
+    if $autofs_demand; then
+      service_switch autofs restart || true
+      local timeout=10 # wait until autofs restarts (possible race >.<)
+      while [ $timeout -gt 0 ] && ! autofs_check; do
+        timeout=$(( $timeout - 1))
+        sleep 1
+      done
+      if [ $timeout -eq 0 ]; then
+        echo "failed to restart autofs"
+        return 103
+      fi
+    else
       if ! autofs_switch off; then
         echo "failed to switch off autofs"
         return 104


### PR DESCRIPTION
The current logic in setup_environment() will always restart the
autofs service, and will then stop it if the test specifies
cvmfs_test_autofs_on_startup=false.  This causes a test failure if the
autofs service cannot be started (e.g. because the service has been
deliberately masked), even though autofs is not required for the test
to run.

Fix by attempting to restart autofs only if autofs is required by the
test being performed.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>