### PR TITLE
Do not consume 100% CPU while waiting for upload jobs to complete

### DIFF
--- a/cvmfs/session_context.h
+++ b/cvmfs/session_context.h
@@ -125,12 +125,11 @@ class SessionContext : public SessionContextBase {
  private:
   static void* UploadLoop(void* data);
 
-  bool ShouldTerminate();
-
   UniquePtr<FifoChannel<UploadJob*> > upload_jobs_;
 
-  atomic_int32 worker_terminate_;
   pthread_t worker_;
+
+  static UploadJob terminator_;
 };
 
 }  // namespace upload

--- a/cvmfs/session_context.h
+++ b/cvmfs/session_context.h
@@ -52,7 +52,7 @@ bool Initialize(const std::string& api_url, const std::string& session_token,
                 const std::string& new_root_hash,
                 const RepositoryTag& tag);
 
-  void WaitForUpload();
+  void WaitForUpload() {};
 
   ObjectPack::BucketHandle NewBucket();
 
@@ -80,8 +80,6 @@ bool Initialize(const std::string& api_url, const std::string& session_token,
   std::string session_token_;
   std::string key_id_;
   std::string secret_;
-
-  FifoChannel<bool> queue_was_flushed_;
 
  private:
   void Dispatch();


### PR DESCRIPTION
The current logic in SessionContext::UploadLoop() degenerates into a
CPU spinloop while waiting for the final upload jobs to complete.

Fix by using an end-of-queue dummy terminator job instead of an atomic
flag, thereby allowing the loop to sleep instead of spinning.

There seems to be no need to use the atomic compare-and-swap in
FinalizeDerived() to guarantee that pthread_join() is called exactly
once, since the surrounding control flow already appears to require
that FinalizeDerived() is called exactly once.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>

Fixes: #2720 