### PR TITLE
Limit lsof to searching only the specified mountpoint

### DIFF
--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -806,7 +806,7 @@ If you go for production, backup your masterkey from /etc/cvmfs/keys/!"
 
 get_fd_modes() {
   local path=$1
-  $LSOF_BIN -Fan 2>/dev/null | grep -B1 -e "^n$path" | grep -e '^a.*'
+  $LSOF_BIN -Fan +f -- $path 2>/dev/null | grep -B1 -e "^n$path" | grep -e '^a.*'
 }
 
 # gets the number of open read-only file descriptors beneath a given path


### PR DESCRIPTION
When performing an operation such as "cvmfs_server publish", a
substantial length of time (around 10-30 seconds on a typical system)
is spent in the invocation of lsof.

Use the "+f -- <path>" option to limit lsof to listing only the
specified mountpoint, rather than listing every open file handle in
the system.  Experimentation shows that this cuts the execution time
for "lsof" by around 95%.

A side benefit is that any integration tests that involve publishing a
repository will also complete substantially faster.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>