### PR TITLE
Do not consume 100% CPU while waiting for S3 upload jobs to complete

### DIFF
--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -205,7 +205,8 @@ class S3FanoutManager : SingleCopy {
   void Spawn();
 
   void PushNewJob(JobInfo *info);
-  int PopCompletedJobs(std::vector<s3fanout::JobInfo*> *jobs);
+  void PushCompletedJob(JobInfo *info);
+  JobInfo *PopCompletedJob();
 
   const Statistics &GetStatistics();
 
@@ -220,8 +221,6 @@ class S3FanoutManager : SingleCopy {
   static void *MainUpload(void *data);
   std::vector<s3fanout::JobInfo*> jobs_todo_;
   pthread_mutex_t *jobs_todo_lock_;
-  std::vector<s3fanout::JobInfo*> jobs_completed_;
-  pthread_mutex_t *jobs_completed_lock_;
   pthread_mutex_t *curl_handle_lock_;
 
   CURL *AcquireCurlHandle() const;
@@ -302,6 +301,10 @@ class S3FanoutManager : SingleCopy {
   // S3FanoutManager writes a JobInfo* pointer. MainUpload then reads the
   // pointer and processes the job.
   int pipe_jobs_[2];
+  // A pipe used to collect completed jobs.  MainUpload writes in the
+  // pointer to the completed job.  PopCompletedJob() used to
+  // retrieve pointer.
+  int pipe_completed_[2];
 
   bool opt_ipv4_only_;
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -130,10 +130,6 @@ class S3Uploader : public AbstractUploader {
 
   const std::string temporary_path_;
   mutable atomic_int32 io_errors_;
-  /**
-   * Signals the CollectResults thread to quit
-   */
-  atomic_int32 terminate_;
   pthread_t thread_collect_results_;
 };  // S3Uploader
 


### PR DESCRIPTION
The current logic in S3Uploader::MainCollectResults() is a pure CPU
spinloop that lasts for the duration of any S3 upload.  The call to
sched_yield() ensures that other threads are allowed to execute, but
produces no blocking behaviour that will prevent the mostly-idle
thread from consuming 100% of a CPU core.

Fix by extending the existing pipe-based pointer queue in
S3FanoutManager to add a queue of pointers to completed jobs that can
be retrieved by S3Uploader::MainCollectResults(), with a NULL pointer
used to request termination of the thread.

Fixes: #2726 

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>