### PR TITLE
Handle zero-length uncompressed objects in object pack consumer

### DIFF
--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -338,7 +338,8 @@ ObjectPackBuild::State ObjectPackConsumer::ConsumeNext(
 ObjectPackBuild::State ObjectPackConsumer::ConsumePayload(
     const unsigned buf_size, const unsigned char *buf) {
   uint64_t pos_in_buf = 0;
-  while ((pos_in_buf < buf_size) && (idx_ < index_.size())) {
+  while ((idx_ < index_.size()) &&
+         ((pos_in_buf < buf_size) || (index_[idx_].size == 0))) {
     // Fill the accumulator or process next small object
     uint64_t nbytes;  // How many bytes are consumed in this iteration
     const uint64_t remaining_in_buf = buf_size - pos_in_buf;

--- a/test/src/812-repository_gateway_uncompressed/main
+++ b/test/src/812-repository_gateway_uncompressed/main
@@ -1,0 +1,44 @@
+cvmfs_test_name="Uncompressed files via gateway"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+verify_compression() {
+  local filename=$1
+  local expected=$2
+  local actual=$(attr -qg compression ${filename})
+  if [ "${actual}" != "${expected}" ] ; then
+    echo "Compression mismatch for ${filename}: expected ${expected} actual ${actual}"
+    return 101
+  fi
+}
+
+cvmfs_run_test() {
+  local reponame=test.repo.org
+  local repodir=/cvmfs/${reponame}
+
+  echo "set up gateway"
+  set_up_repository_gateway || return 1
+
+  echo "parse configuration"
+  load_repo_config ${reponame}
+  local spooldir=${CVMFS_SPOOL_DIR}
+
+  echo "start transaction"
+  cvmfs_server transaction ${reponame} || return 11
+
+  echo "create test files"
+  echo "Hello world!" > ${repodir}/file1
+  touch ${repodir}/file2
+
+  echo "publish (uncompressed) and check"
+  cvmfs_server publish -Z none ${reponame} || return 12
+  cvmfs_server check -i ${reponame} || return 13
+
+  echo "verify files"
+  [ -f ${repodir}/file1 -a -s ${repodir}/file1 ] || return 14
+  [ -f ${repodir}/file2 -a ! -s ${repodir}/file2 ] || return 15
+  verify_compression ${spooldir}/rdonly/file1 none || return $?
+  verify_compression ${spooldir}/rdonly/file2 none || return $?
+
+  return 0
+}


### PR DESCRIPTION
The current logic in ObjectPackConsumer::ConsumePayload() behaves
incorrectly in the case of a zero-length object at the end of the
buffer: the loop terminates prematurely since the end of the buffer
has been reached, but the method then returns kStateContinue since not
all objects have been processed.  This causes the receiver to
erroneously wait for further data that will never arrive.

Fix by ensuring that the loop continues until either all objects have
been processed or an incomplete object is encountered.

Note that a zero-length object can occur only when using uncompressed
objects, since even a zero-length object will have a non-zero length
after compression.

Fixes: #2730

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>