### PR TITLE
Fix checking whether doc target exists

### DIFF
--- a/cmake/Modules/UseDoxygen.cmake
+++ b/cmake/Modules/UseDoxygen.cmake
@@ -136,8 +136,7 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file("${DOXYFILE_IN}" "${DOXYFILE}" @ONLY)
 
-	get_target_property(DOC_TARGET doc TYPE)
-	if(NOT DOC_TARGET)
+	if(NOT TARGET doc)
 		add_custom_target(doc)
 	endif()
 


### PR DESCRIPTION
Fixes the error shown below:

```
-- Generating Doxygen configuration ...
CMake Error at cmake/Modules/UseDoxygen.cmake:139 (get_target_property):
  get_target_property() called with non-existent target "doc".
Call Stack (most recent call first):
  CMakeLists.txt:515 (include)
```