### PR TITLE
Do not include deprecated attr/xattr.h on Linux

### DIFF
--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -9,9 +9,6 @@
 
 #include <sys/types.h>  // contains ssize_t needed inside <attr/xattr.h>
 #include <sys/xattr.h>
-#ifdef HAVE_ATTR_XATTR_H
-#include <attr/xattr.h>  // NOLINT(build/include_alpha)
-#endif
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Fixes the warning below:
```
/usr/include/attr/xattr.h:5:2: warning:
  #warning "Please change your <attr/xattr.h> includes to <sys/xattr.h>" [-Wcpp]
```
This may not be possible if old supported systems still do not have `<sys/xattr.h>`, though.
Hopefully CI can tell.