### PR TITLE
Report modified nested catalog hashes as modifications when diffing

### DIFF
--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -178,7 +178,7 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
       if (id_nested_from == id_nested_to) continue;
     }
 
-    if (old_entry.CompareTo(new_entry) > 0) {
+    if (diff != catalog::DirectoryEntryBase::Difference::kIdentical) {
       FileChunkList chunks;
       if (new_entry.IsChunkedFile()) {
         new_catalog_mgr_->ListFileChunks(new_path, new_entry.hash_algorithm(),

--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -178,7 +178,9 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
       if (id_nested_from == id_nested_to) continue;
     }
 
-    if (diff != catalog::DirectoryEntryBase::Difference::kIdentical) {
+    if ((diff != catalog::DirectoryEntryBase::Difference::kIdentical) ||
+        old_entry.IsNestedCatalogMountpoint()) {
+      // Modified directory entry, or nested catalog with modified hash
       FileChunkList chunks;
       if (new_entry.IsChunkedFile()) {
         new_catalog_mgr_->ListFileChunks(new_path, new_entry.hash_algorithm(),


### PR DESCRIPTION
A change in a nested catalog hash value is not detected as a
difference via DirectoryEntry::CompareTo(), as exemplified by the
logic in CatalogDiffTool::DiffRec() to detect identical nested
catalogs.

The current logic will therefore not call ReportModification() for a
change in a nested catalog hash value unless there is some other
modification (e.g. mtime) to the corresponding directory entry.

Fix by treating a modified hash as a modification that should be
reported via ReportModification().

This ensures that any nested catalog swapping always occurs at the
highest possible level within the tree, thereby avoiding unnecessary
recursion.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>
