### PR TITLE
Do not truncate recursion for a modification above the lease pat

### DIFF
--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -97,7 +97,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportAddition(
    *       by another writer running concurrently.
    *       The correct course of action is to ignore this change here.
    * */
-  if (!IsPathInLease(lease_path_, rel_path)) {
+  if (!IsSubPath(lease_path_, rel_path)) {
     return;
   }
 
@@ -141,7 +141,7 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportRemoval(
    *       by another writer running concurrently.
    *       The correct course of action is to ignore this change here.
    * */
-  if (!IsPathInLease(lease_path_, rel_path)) {
+  if (!IsSubPath(lease_path_, rel_path)) {
     return;
   }
 
@@ -179,7 +179,7 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
    *       by another writer running concurrently.
    *       The correct course of action is to ignore this change here.
    * */
-  if (!IsPathInLease(lease_path_, rel_path)) {
+  if (!IsSubPath(lease_path_, rel_path)) {
     // All child paths will similarly be outside of the lease path,
     // and so there is no need to recurse any further.
     return false;

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -180,9 +180,10 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
    *       The correct course of action is to ignore this change here.
    * */
   if (!IsSubPath(lease_path_, rel_path)) {
-    // All child paths will similarly be outside of the lease path,
-    // and so there is no need to recurse any further.
-    return false;
+    // If the current path is not a parent of the lease path, then all
+    // child paths will similarly be outside of the lease path, and so
+    // there is no need to recurse any further.
+    return IsSubPath(rel_path, lease_path_);
   }
 
   const std::string parent_path =

--- a/cvmfs/receiver/lease_path_util.cc
+++ b/cvmfs/receiver/lease_path_util.cc
@@ -7,26 +7,19 @@
 namespace receiver {
 
 bool IsPathInLease(const PathString& lease, const PathString& path) {
-  // If lease is "", any path falls within item
-  if (!strcmp(lease.c_str(), "")) {
+
+  // If lease is "", then any path is a subpath
+  if (lease.GetLength() == 0) {
     return true;
   }
 
-  // Is the lease string is the prefix of the path string and the next
-  // character of the path string is a "/".
-  if (path.StartsWith(lease) && path.GetChars()[lease.GetLength()] == '/') {
-    return true;
-  }
-
-  // The lease is a prefix of the path and the last char of the lease is a "/"
+  // If the lease string is the prefix of the path string and either
+  // the strings are identical or the separator character is a "/",
+  // then the path is a subpath
   if (path.StartsWith(lease) &&
-      lease.GetChars()[lease.GetLength() - 1] == '/') {
-    return true;
-  }
-
-  // If the path string is exactly the lease path return true (allow the
-  // creation of the leased directory during the lease itself)
-  if (lease == path) {
+      ((path.GetLength() == lease.GetLength()) ||
+       (path.GetChars()[lease.GetLength()] == '/') ||
+       (path.GetChars()[lease.GetLength() - 1] == '/'))) {
     return true;
   }
 

--- a/cvmfs/receiver/lease_path_util.cc
+++ b/cvmfs/receiver/lease_path_util.cc
@@ -6,20 +6,20 @@
 
 namespace receiver {
 
-bool IsPathInLease(const PathString& lease, const PathString& path) {
+bool IsSubPath(const PathString& parent, const PathString& path) {
 
-  // If lease is "", then any path is a subpath
-  if (lease.GetLength() == 0) {
+  // If parent is "", then any path is a subpath
+  if (parent.GetLength() == 0) {
     return true;
   }
 
-  // If the lease string is the prefix of the path string and either
+  // If the parent string is the prefix of the path string and either
   // the strings are identical or the separator character is a "/",
   // then the path is a subpath
-  if (path.StartsWith(lease) &&
-      ((path.GetLength() == lease.GetLength()) ||
-       (path.GetChars()[lease.GetLength()] == '/') ||
-       (path.GetChars()[lease.GetLength() - 1] == '/'))) {
+  if (path.StartsWith(parent) &&
+      ((path.GetLength() == parent.GetLength()) ||
+       (path.GetChars()[parent.GetLength()] == '/') ||
+       (path.GetChars()[parent.GetLength() - 1] == '/'))) {
     return true;
   }
 

--- a/cvmfs/receiver/lease_path_util.h
+++ b/cvmfs/receiver/lease_path_util.h
@@ -9,7 +9,7 @@
 
 namespace receiver {
 
-bool IsPathInLease(const PathString& lease, const PathString& path);
+bool IsSubPath(const PathString& parent, const PathString& path);
 
 }
 

--- a/test/src/813-repository_gateway_convoluted/main
+++ b/test/src/813-repository_gateway_convoluted/main
@@ -1,0 +1,58 @@
+cvmfs_test_name="Repository gateway convoluted setups"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+verify_sha1sum() {
+  local filename=$1
+  local expected=$2
+  local actual=$(sha1sum ${filename} | cut -d' ' -f1)
+  if [ "${actual}" != "${expected}" ]; then
+    echo "Checksum mismatch for ${filename}: expected ${expected} actual ${actual}"
+    return 101
+  fi
+}
+
+cvmfs_run_test() {
+  local reponame=test.repo.org
+  local repodir=/cvmfs/${reponame}
+
+  echo "set up gateway"
+  set_up_repository_gateway || return 1
+
+  echo "start transaction 1"
+  cvmfs_server transaction ${reponame} || return 11
+
+  echo "create nested catalog structure"
+  for tree in tree1 tree2 tree3 ; do
+    mkdir ${repodir}/${tree}
+    touch ${repodir}/${tree}/.cvmfscatalog
+    for branch in branch1 branch2 branch3 ; do
+      mkdir ${repodir}/${tree}/${branch}
+      touch ${repodir}/${tree}/${branch}/.cvmfscatalog
+      for leaf in leaf1 leaf2 leaf3 ; do
+        mkdir ${repodir}/${tree}/${branch}/${leaf}
+        touch ${repodir}/${tree}/${branch}/${leaf}/.cvmfscatalog
+        echo "Hello world" > ${repodir}/${tree}/${branch}/hw.txt
+      done
+    done
+  done
+
+  echo "publish and check 1"
+  cvmfs_server publish -v ${reponame} || return 12
+  cvmfs_server check -i ${reponame} || return 13
+
+  echo "start transaction 2"
+  cvmfs_server transaction ${reponame}/tree1/branch1 || return 21
+
+  echo "create file in deeply nested catalog"
+  echo "Very nested" > ${repodir}/tree1/branch1/leaf1/nested.txt
+
+  echo "publish and check 2"
+  cvmfs_server publish -v ${reponame} || return 22
+  cvmfs_server check -i ${reponame} || return 23
+
+  echo "verify files"
+  verify_sha1sum ${repodir}/tree1/branch1/leaf1/nested.txt 0f5117db205e0f5e7314de1db0b1f07d64ba16a0 || return 24
+
+  return 0
+}

--- a/test/unittests/t_lease_path_util.cc
+++ b/test/unittests/t_lease_path_util.cc
@@ -15,16 +15,16 @@ TEST_F(T_LeasePathUtil, RootLease) {
   const PathString path2("a");
   const PathString path3("b");
 
-  ASSERT_TRUE(receiver::IsPathInLease(lease, path1));
-  ASSERT_TRUE(receiver::IsPathInLease(lease, path2));
-  ASSERT_TRUE(receiver::IsPathInLease(lease, path3));
+  ASSERT_TRUE(receiver::IsSubPath(lease, path1));
+  ASSERT_TRUE(receiver::IsSubPath(lease, path2));
+  ASSERT_TRUE(receiver::IsSubPath(lease, path3));
 }
 
 TEST_F(T_LeasePathUtil, Identical) {
   const PathString lease("lease-dir");
   const PathString path("lease-dir");
 
-  ASSERT_TRUE(receiver::IsPathInLease(lease, path));
+  ASSERT_TRUE(receiver::IsSubPath(lease, path));
 }
 
 TEST_F(T_LeasePathUtil, SubPathLease) {
@@ -36,10 +36,10 @@ TEST_F(T_LeasePathUtil, SubPathLease) {
 
   const PathString path_above_lease("sub");
 
-  ASSERT_TRUE(receiver::IsPathInLease(lease, path1));
-  ASSERT_FALSE(receiver::IsPathInLease(lease, path2));
-  ASSERT_FALSE(receiver::IsPathInLease(lease, path3));
-  ASSERT_FALSE(receiver::IsPathInLease(lease, empty_path));
+  ASSERT_TRUE(receiver::IsSubPath(lease, path1));
+  ASSERT_FALSE(receiver::IsSubPath(lease, path2));
+  ASSERT_FALSE(receiver::IsSubPath(lease, path3));
+  ASSERT_FALSE(receiver::IsSubPath(lease, empty_path));
 
-  ASSERT_FALSE(receiver::IsPathInLease(lease, path_above_lease));
+  ASSERT_FALSE(receiver::IsSubPath(lease, path_above_lease));
 }


### PR DESCRIPTION
Commit e9df405 ("Avoid recursing into paths outside the lease when
performing a merge") introduced a bug by omitting to consider the case
of a modification detected in a directory that is a parent of the
lease path.  Such a path is not within the lease path, but a child
path may still lie within the lease path.

Fix by continuing recursion if the current path is a parent of the
lease path, and add a test case that covers this scenario.
