### PR TITLE
Add support for cvfmsbundles file

### DIFF
--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -93,7 +93,7 @@ class SyncItem {
            WasType(kItemFifo) ||
            WasType(kItemSocket);
   }
-  inline bool isBundleSpec() const {
+  inline bool IsBundleSpec() const {
     return filename_ == ".cvmfsbundles";
   }
   inline bool wasBundleSpec() const {

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -96,7 +96,7 @@ class SyncItem {
   inline bool IsBundleSpec() const {
     return filename_ == ".cvmfsbundles";
   }
-  inline bool wasBundleSpec() const {
+  inline bool WasBundleSpec() const {
     return filename_ == ".cvmfsbundles";
   }
 

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -93,6 +93,12 @@ class SyncItem {
            WasType(kItemFifo) ||
            WasType(kItemSocket);
   }
+  inline bool isBundleSpec() const {
+    return filename_ == ".cvmfsbundles";
+    //if(strstr(filename_, ".cvmfsbundles") != NULL) {
+      //return true;
+    //}
+  }
 
   inline unsigned int GetRdevMajor()     const {
     assert(IsSpecialFile());

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -95,9 +95,9 @@ class SyncItem {
   }
   inline bool isBundleSpec() const {
     return filename_ == ".cvmfsbundles";
-    //if(strstr(filename_, ".cvmfsbundles") != NULL) {
-      //return true;
-    //}
+  }
+  inline bool wasBundleSpec() const {
+    return filename_ == ".cvmfsbundles";
   }
 
   inline unsigned int GetRdevMajor()     const {

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -103,7 +103,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
 
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);
     if(fd >= 0) {
-      if(SafeReadToString(fd, &json_string)) {
+      if (SafeReadToString(fd, &json_string)) {
         printf("creating JSON\n");
         JsonDocument* json = JsonDocument::Create(json_string);
         printf("content found:\n");

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -96,7 +96,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   }
   
   // .cvmfsbundles file type
-  if (entry->isBundleSpec()) {
+  if (entry->IsBundleSpec()) {
     printf("cvmfsbundles file found. filename: %s\n",
         (entry->GetRelativePath()).c_str());
 
@@ -228,7 +228,7 @@ void SyncMediator::Remove(SharedPtr<SyncItem> entry) {
     return;
   }
   
-  if (entry->wasBundleSpec()) {
+  if (entry->WasBundleSpec()) {
     printf("found a cvmfsbundles file to remove: filename: %s\n", (entry->GetRelativePath()).c_str());
     // for now remove using RemoveFile()
     RemoveFile(entry);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -96,7 +96,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   }
   
   // .cvmfsbundles file type
-  if(entry->isBundleSpec()){
+  if (entry->isBundleSpec()) {
     printf("cvmfsbundles file found. filename: %s\n", (entry->GetRelativePath()).c_str());
 
     std::string json_string;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -122,6 +122,11 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     return;
   }
 
+  // .cvmfsbundles file type
+  if(entry->isBundlesFile()){
+    printf("cvmfsbundles file found\n");
+  }
+  
   PrintWarning("'" + entry->GetRelativePath() +
                "' cannot be added. Unrecognized file type.");
 }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -98,6 +98,12 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   // .cvmfsbundles file type
   if (entry->IsBundleSpec() && entry->IsRegularFile() &&
       !entry->HasHardlinks()) {
+    std::string parent_path = GetParentPath(entry->GetUnionPath());
+    if (!IsMountPoint(parent_path)) {
+      PANIC(kLogStderr, "Error: .cvmfsbundles file must be in the root"
+            " directory of the repository. Found in %s", parent_path.c_str());
+    }
+
     std::string json_string;
 
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -96,8 +96,14 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   }
 
   // .cvmfsbundles file type
-  if (entry->IsBundleSpec() && entry->IsRegularFile() &&
-      !entry->HasHardlinks()) {
+  if (entry->IsBundleSpec()) {
+    if (!entry->IsRegularFile()) {
+      PANIC(kLogStderr, "Error: .cvmfsbundles file must be a regular file");
+    }
+    if (entry->HasHardlinks()) {
+      PANIC(kLogStderr, "Error: .cvmfsbundles file must not be a hard link");
+    }
+
     std::string parent_path = GetParentPath(entry->GetUnionPath());
     if (!IsMountPoint(parent_path)) {
       PANIC(kLogStderr, "Error: .cvmfsbundles file must be in the root"

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -94,7 +94,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     AddDirectoryRecursively(entry);
     return;
   }
-  
+
   // .cvmfsbundles file type
   if (entry->IsBundleSpec()) {
     printf("cvmfsbundles file found. filename: %s\n",

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -204,6 +204,13 @@ void SyncMediator::Remove(SharedPtr<SyncItem> entry) {
     RemoveDirectoryRecursively(entry);
     return;
   }
+  
+  if(entry->wasBundleSpec()) {
+    printf("found a cvmfsbundles file to remove: filename: %s\n", (entry->GetRelativePath()).c_str());
+    // for now remove using RemoveFile()
+    RemoveFile(entry);
+    return;
+  }
 
   if (entry->WasRegularFile() || entry->WasSymlink() ||
       entry->WasSpecialFile()) {

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -101,7 +101,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
 
     std::string json_string;
 
-    int fd = open (entry->GetUnionPath().c_str(), O_RDONLY);
+    int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);
     if(fd >= 0) {
       if(SafeReadToString(fd, &json_string)) {
         printf("creating JSON\n");

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -123,7 +123,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   }
 
   // .cvmfsbundles file type
-  if(entry->isBundlesFile()){
+  if(entry->isBundleSpec()){
     printf("cvmfsbundles file found\n");
   }
   

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -97,6 +97,9 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
 
   // .cvmfsbundles file type
   if (entry->IsBundleSpec()) {
+    PrintWarning(".cvmfsbundles file encountered. "
+                 "Bundles is currently an experimental feature.");
+
     if (!entry->IsRegularFile()) {
       PANIC(kLogStderr, "Error: .cvmfsbundles file must be a regular file");
     }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -1015,6 +1015,12 @@ void SyncMediator::AddUnmaterializedDirectory(SharedPtr<SyncItem> entry) {
 }
 
 void SyncMediator::AddDirectory(SharedPtr<SyncItem> entry) {
+  if (entry->filename() == ".cvmfsbundles") {
+    PANIC(kLogStderr, "Illegal directory name: .cvmfsbundles (%s). "
+          ".cvmfsbundles is reserved for bundles specification files",
+          entry->GetUnionPath().c_str());
+  }
+
   reporter_->OnAdd(entry->GetUnionPath(), catalog::DirectoryEntry());
 
   perf::Inc(counters_->n_directories_added);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -97,9 +97,6 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
 
   // .cvmfsbundles file type
   if (entry->IsBundleSpec()) {
-    printf("cvmfsbundles file found. filename: %s\n",
-        (entry->GetRelativePath()).c_str());
-
     std::string json_string;
 
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);
@@ -108,10 +105,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
           entry->GetUnionPath().c_str());
     } else {
       if (SafeReadToString(fd, &json_string)) {
-        printf("creating JSON\n");
         JsonDocument* json = JsonDocument::Create(json_string);
-        printf("content found:\n");
-        printf("%s\n", (json->PrintPretty()).c_str());
       } else {
         PANIC(kLogStderr, "Could not read contents of file: %s", 
             entry->GetUnionPath().c_str());

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -105,7 +105,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     }
 
     std::string parent_path = GetParentPath(entry->GetUnionPath());
-    if (!IsMountPoint(parent_path)) {
+    if (parent_path != union_engine_->union_path()) {
       PANIC(kLogStderr, "Error: .cvmfsbundles file must be in the root"
             " directory of the repository. Found in %s", parent_path.c_str());
     }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -223,7 +223,6 @@ void SyncMediator::Remove(SharedPtr<SyncItem> entry) {
   }
   
   if (entry->WasBundleSpec()) {
-    printf("found a cvmfsbundles file to remove: filename: %s\n", (entry->GetRelativePath()).c_str());
     // for now remove using RemoveFile()
     RemoveFile(entry);
     return;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -97,6 +97,8 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   // .cvmfsbundles file type
   if(entry->isBundleSpec()){
     printf("cvmfsbundles file found. filename: %s\n", (entry->GetRelativePath()).c_str());
+    // for now using AddFile()
+    AddFile(entry);
     return;
   }
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -93,6 +93,12 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     AddDirectoryRecursively(entry);
     return;
   }
+  
+  // .cvmfsbundles file type
+  if(entry->isBundleSpec()){
+    printf("cvmfsbundles file found. filename: %s\n", (entry->GetRelativePath()).c_str());
+    return;
+  }
 
   if (entry->IsRegularFile() || entry->IsSymlink()) {
     // A file is a hard link if the link count is greater than 1
@@ -120,11 +126,6 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
         AddFile(entry);
     }
     return;
-  }
-
-  // .cvmfsbundles file type
-  if(entry->isBundleSpec()){
-    printf("cvmfsbundles file found\n");
   }
   
   PrintWarning("'" + entry->GetRelativePath() +

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -102,10 +102,10 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);
     if (fd < 0) {
       PANIC(kLogStderr, "Could not open file: %s",
-          entry->GetUnionPath().c_str());
+            entry->GetUnionPath().c_str());
     } else {
       if (SafeReadToString(fd, &json_string)) {
-        JsonDocument* json = JsonDocument::Create(json_string);
+        JsonDocument *json = JsonDocument::Create(json_string);
       } else {
         PANIC(kLogStderr, "Could not read contents of file: %s",
             entry->GetUnionPath().c_str());

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -96,7 +96,8 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   }
 
   // .cvmfsbundles file type
-  if (entry->IsBundleSpec()) {
+  if (entry->IsBundleSpec() && entry->IsRegularFile() &&
+      !entry->HasHardlinks()) {
     std::string json_string;
 
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -1014,7 +1014,7 @@ void SyncMediator::AddUnmaterializedDirectory(SharedPtr<SyncItem> entry) {
 }
 
 void SyncMediator::AddDirectory(SharedPtr<SyncItem> entry) {
-  if (entry->filename() == ".cvmfsbundles") {
+  if (entry->IsBundleSpec()) {
     PANIC(kLogStderr, "Illegal directory name: .cvmfsbundles (%s). "
           ".cvmfsbundles is reserved for bundles specification files",
           entry->GetUnionPath().c_str());

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -97,21 +97,25 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   
   // .cvmfsbundles file type
   if (entry->isBundleSpec()) {
-    printf("cvmfsbundles file found. filename: %s\n", (entry->GetRelativePath()).c_str());
+    printf("cvmfsbundles file found. filename: %s\n",
+        (entry->GetRelativePath()).c_str());
 
     std::string json_string;
 
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);
-    if(fd >= 0) {
+    if(fd < 0) {
+      PANIC(kLogStderr, "Could not open file: %s", 
+          entry->GetUnionPath().c_str());
+    } else {
       if (SafeReadToString(fd, &json_string)) {
         printf("creating JSON\n");
         JsonDocument* json = JsonDocument::Create(json_string);
         printf("content found:\n");
         printf("%s\n", (json->PrintPretty()).c_str());
+      } else {
+        PANIC(kLogStderr, "Could not read contents of file: %s", 
+            entry->GetUnionPath().c_str());
       }
-    }
-    else{
-      printf("Could not open file: %s\n", entry->GetUnionPath().c_str());
     }
 
     // for now using AddFile()
@@ -146,7 +150,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     }
     return;
   }
-  
+
   PrintWarning("'" + entry->GetRelativePath() +
                "' cannot be added. Unrecognized file type.");
 }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -19,6 +19,7 @@
 #include "directory_entry.h"
 #include "fs_traversal.h"
 #include "hash.h"
+#include "json_document.h"
 #include "publish/repository.h"
 #include "smalloc.h"
 #include "sync_union.h"
@@ -97,6 +98,22 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
   // .cvmfsbundles file type
   if(entry->isBundleSpec()){
     printf("cvmfsbundles file found. filename: %s\n", (entry->GetRelativePath()).c_str());
+
+    std::string json_string;
+
+    int fd = open (entry->GetUnionPath().c_str(), O_RDONLY);
+    if(fd >= 0) {
+      if(SafeReadToString(fd, &json_string)) {
+        printf("creating JSON\n");
+        JsonDocument* json = JsonDocument::Create(json_string);
+        printf("content found:\n");
+        printf("%s\n", (json->PrintPretty()).c_str());
+      }
+    }
+    else{
+      printf("Could not open file: %s\n", entry->GetUnionPath().c_str());
+    }
+
     // for now using AddFile()
     AddFile(entry);
     return;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -100,14 +100,14 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     std::string json_string;
 
     int fd = open(entry->GetUnionPath().c_str(), O_RDONLY);
-    if(fd < 0) {
-      PANIC(kLogStderr, "Could not open file: %s", 
+    if (fd < 0) {
+      PANIC(kLogStderr, "Could not open file: %s",
           entry->GetUnionPath().c_str());
     } else {
       if (SafeReadToString(fd, &json_string)) {
         JsonDocument* json = JsonDocument::Create(json_string);
       } else {
-        PANIC(kLogStderr, "Could not read contents of file: %s", 
+        PANIC(kLogStderr, "Could not read contents of file: %s",
             entry->GetUnionPath().c_str());
       }
     }
@@ -221,7 +221,7 @@ void SyncMediator::Remove(SharedPtr<SyncItem> entry) {
     RemoveDirectoryRecursively(entry);
     return;
   }
-  
+
   if (entry->WasBundleSpec()) {
     // for now remove using RemoveFile()
     RemoveFile(entry);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -124,7 +124,7 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
       PANIC(kLogStderr, "Could not read contents of file: %s",
             entry->GetUnionPath().c_str());
     }
-    JsonDocument *json = JsonDocument::Create(json_string);
+    UniquePtr<JsonDocument> json(JsonDocument::Create(json_string));
 
     AddFile(entry);
     return;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -126,7 +126,6 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     }
     JsonDocument *json = JsonDocument::Create(json_string);
 
-    // for now using AddFile()
     AddFile(entry);
     return;
   }

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -103,14 +103,12 @@ void SyncMediator::Add(SharedPtr<SyncItem> entry) {
     if (fd < 0) {
       PANIC(kLogStderr, "Could not open file: %s",
             entry->GetUnionPath().c_str());
-    } else {
-      if (SafeReadToString(fd, &json_string)) {
-        JsonDocument *json = JsonDocument::Create(json_string);
-      } else {
-        PANIC(kLogStderr, "Could not read contents of file: %s",
-            entry->GetUnionPath().c_str());
-      }
     }
+    if (!SafeReadToString(fd, &json_string)) {
+      PANIC(kLogStderr, "Could not read contents of file: %s",
+            entry->GetUnionPath().c_str());
+    }
+    JsonDocument *json = JsonDocument::Create(json_string);
 
     // for now using AddFile()
     AddFile(entry);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -224,7 +224,7 @@ void SyncMediator::Remove(SharedPtr<SyncItem> entry) {
     return;
   }
   
-  if(entry->wasBundleSpec()) {
+  if (entry->wasBundleSpec()) {
     printf("found a cvmfsbundles file to remove: filename: %s\n", (entry->GetRelativePath()).c_str());
     // for now remove using RemoveFile()
     RemoveFile(entry);

--- a/test/src/684-cvmfsbundles/main
+++ b/test/src/684-cvmfsbundles/main
@@ -41,5 +41,24 @@ cvmfs_run_test() {
     abort_transaction $CVMFS_TEST_REPO || return 14
   fi
 
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Test for failure in case a .cvmfsbundles directory is found in the
+  # repository
+
+  echo "*** Create a .cvmfsbundles directory in the repository"
+  start_transaction $CVMFS_TEST_REPO || return 15
+  mkdir /cvmfs/$CVMFS_TEST_REPO/.cvmfsbundles || return 16
+
+  echo "*** Publish repository"
+  publish_repo $CVMFS_TEST_REPO
+  if [ $? -eq 0 ]
+  then
+    return 17
+  else
+    echo "*** Abort transaction"
+    abort_transaction $CVMFS_TEST_REPO || return 18
+  fi
+
   return 0
 }

--- a/test/src/684-cvmfsbundles/main
+++ b/test/src/684-cvmfsbundles/main
@@ -20,5 +20,26 @@ cvmfs_run_test() {
   rm -f /cvmfs/$CVMFS_TEST_REPO/.cvmfsbundles || return 7
   publish_repo $CVMFS_TEST_REPO || return 8
 
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+  # Test for failure in case a .cvmfsbundles file is found in a subdirectory
+  # of a repository
+
+  echo "*** Create a .cvmfsbundles file in a subdirectory"
+  start_transaction $CVMFS_TEST_REPO || return 9
+  mkdir /cvmfs/$CVMFS_TEST_REPO/test_dir || return 10
+  touch /cvmfs/$CVMFS_TEST_REPO/test_dir/.cvmfsbundles || return 11
+  echo "{}" > /cvmfs/$CVMFS_TEST_REPO/test_dir/.cvmfsbundles || return 12
+
+  echo "*** Publish repository"
+  publish_repo $CVMFS_TEST_REPO
+  if [ $? -eq 0 ]
+  then
+    return 13
+  else
+    echo "*** Abort transaction"
+    abort_transaction $CVMFS_TEST_REPO || return 14
+  fi
+
   return 0
 }

--- a/test/src/684-cvmfsbundles/main
+++ b/test/src/684-cvmfsbundles/main
@@ -9,9 +9,6 @@ cvmfs_run_test() {
   echo "*** Create a new repository"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
 
-  echo "*** Create a new repository"
-  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
-
   echo "*** Create and edit a .cvmfsbundles file"
   start_transaction $CVMFS_TEST_REPO || return 2
   touch /cvmfs/$CVMFS_TEST_REPO/.cvmfsbundles || return 3

--- a/test/src/684-cvmfsbundles/main
+++ b/test/src/684-cvmfsbundles/main
@@ -9,7 +9,19 @@ cvmfs_run_test() {
   echo "*** Create a new repository"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
 
+  echo "*** Create a new repository"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
 
+  echo "*** Create and edit a .cvmfsbundles file"
+  start_transaction $CVMFS_TEST_REPO || return 2
+  touch /cvmfs/$CVMFS_TEST_REPO/.cvmfsbundles || return 3
+  echo "{}" > /cvmfs/$CVMFS_TEST_REPO/.cvmfsbundles || return 4
+  publish_repo $CVMFS_TEST_REPO || return 5
+
+  echo "*** Remove a .cvmfsbundles file"
+  start_transaction $CVMFS_TEST_REPO || return 6
+  rm -f /cvmfs/$CVMFS_TEST_REPO/.cvmfsbundles || return 7
+  publish_repo $CVMFS_TEST_REPO || return 8
 
   return 0
-} 
+}

--- a/test/src/684-cvmfsbundles/main
+++ b/test/src/684-cvmfsbundles/main
@@ -1,0 +1,15 @@
+cvmfs_test_name="cvmfsbundles"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+
+cvmfs_run_test() {
+  logfile=$1
+
+  echo "*** Create a new repository"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
+
+
+
+  return 0
+} 


### PR DESCRIPTION
Support for .cvmfsbundles files

To improve cold cache loading, a new content type, bundle, is introduced
([PR 2741](https://github.com/cvmfs/cvmfs/pull/2741)). The bundle has a binary format of an object pack

A bundle specification file, named `.cvmfsbundles`, allows the creation of such
bundles on the server-side. The `.cvfmsbundles` file is maintained by the
repository owners. During publication, the bundles are created and
stored according to the contents of this file.

This PR will
 * allow recognition of the bundle specification files on the server-side.
 * enforce the requirement that such files must be regular and not a hard link.
     Additionally, ensure that the file is in the root directory of a repository.
 * reserve the filename, `.cvmfsbundles`, for the bundle specification files. 

Corresponding JIRA issue: [CVM-1886](https://sft.its.cern.ch/jira/browse/CVM-1886)