### PR TITLE
Allow nested catalog to be swapped even if already attached

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -913,30 +913,43 @@ void WritableCatalogManager::SwapNestedCatalog(const string &mountpoint,
           nested_root_path.c_str(), parent_path.c_str());
   }
 
-  // Get old catalog hash
-  shash::Any old_hash;
-  uint64_t old_size;
-  const bool old_found = parent->FindNested(nested_root_ps, &old_hash,
-                                            &old_size);
-  if (!old_found) {
-    PANIC(kLogStderr,
-          "failed to swap nested catalog '%s': not found in parent",
-          nested_root_path.c_str());
-  }
+  // Get old nested catalog counters
+  Catalog *old_attached_catalog = parent->FindChild(nested_root_ps);
+  Counters old_counters;
+  if (old_attached_catalog) {
 
-  // Check that old catalog was not already attached
-  if (parent->FindChild(nested_root_ps)) {
-    PANIC(kLogStderr,
-          "failed to swap nested catalog '%s': already attached",
-          nested_root_path.c_str());
-  }
+    // Old catalog was already attached (e.g. as a child catalog
+    // attached by a prior call to CreateNestedCatalog()).  Ensure
+    // that it has not been modified, get counters, and detach it.
+    WritableCatalogList list;
+    if (GetModifiedCatalogLeafsRecursively(old_attached_catalog, &list)) {
+      PANIC(kLogStderr,
+            "failed to swap nested catalog '%s': already modified",
+            nested_root_path.c_str());
+    }
+    old_counters = old_attached_catalog->GetCounters();
+    DetachSubtree(old_attached_catalog);
 
-  // Load freely attached old catalog
-  UniquePtr<Catalog> old_catalog(LoadFreeCatalog(nested_root_ps, old_hash));
-  if (!old_catalog) {
-    PANIC(kLogStderr,
-          "failed to swap nested catalog '%s': failed to load old catalog",
-          nested_root_path.c_str());
+  } else {
+
+    // Old catalog was not attached.  Download a freely attached
+    // version and get counters.
+    shash::Any old_hash;
+    uint64_t old_size;
+    const bool old_found = parent->FindNested(nested_root_ps, &old_hash,
+                                              &old_size);
+    if (!old_found) {
+      PANIC(kLogStderr,
+            "failed to swap nested catalog '%s': not found in parent",
+            nested_root_path.c_str());
+    }
+    UniquePtr<Catalog> old_free_catalog(LoadFreeCatalog(nested_root_ps, old_hash));
+    if (!old_free_catalog) {
+      PANIC(kLogStderr,
+            "failed to swap nested catalog '%s': failed to load old catalog",
+            nested_root_path.c_str());
+    }
+    old_counters = old_free_catalog->GetCounters();
   }
 
   // Load freely attached new catalog
@@ -977,7 +990,7 @@ void WritableCatalogManager::SwapNestedCatalog(const string &mountpoint,
   parent->TouchEntry(dirent, xattrs, nested_root_path);
 
   // Update counters
-  DeltaCounters delta = Counters::Diff(old_catalog->GetCounters(),
+  DeltaCounters delta = Counters::Diff(old_counters,
                                        new_catalog->GetCounters());
   delta.PopulateToParent(&parent->delta_counters_);
 

--- a/test/src/813-repository_gateway_convoluted/main
+++ b/test/src/813-repository_gateway_convoluted/main
@@ -41,6 +41,9 @@ cvmfs_run_test() {
   cvmfs_server publish -v ${reponame} || return 12
   cvmfs_server check -i ${reponame} || return 13
 
+  echo "verify nested catalog count"
+  [ $(get_catalog_count ${reponame}) -eq 40 ] || return 14
+
   echo "start transaction 2"
   cvmfs_server transaction ${reponame}/tree1/branch1 || return 21
 
@@ -53,6 +56,36 @@ cvmfs_run_test() {
 
   echo "verify files"
   verify_sha1sum ${repodir}/tree1/branch1/leaf1/nested.txt 0f5117db205e0f5e7314de1db0b1f07d64ba16a0 || return 24
+
+  echo "start transaction 3"
+  cvmfs_server transaction ${reponame} || return 31
+
+  echo "remove a containing nested catalog"
+  rm ${repodir}/tree2/.cvmfscatalog
+
+  echo "publish and check 3"
+  cvmfs_server publish -v ${reponame} || return 32
+  cvmfs_server check -i ${reponame} || return 33
+
+  echo "verify nested catalog count"
+  [ $(get_catalog_count ${reponame}) -eq 39 ] || return 34
+
+  echo "start transaction 4"
+  cvmfs_server transaction ${reponame} || return 41
+
+  echo "recreate containing nested catalog and modify subcatalog"
+  touch ${repodir}/tree2/.cvmfscatalog
+  echo "Modified in subcatalog of newly created catalog" > ${repodir}/tree2/branch1/test.txt
+
+  echo "publish and check 4"
+  cvmfs_server publish -v ${reponame} || return 42
+  cvmfs_server check -i ${reponame} || return 43
+
+  echo "verify nested catalog count"
+  [ $(get_catalog_count ${reponame}) -eq 40 ] || return 44
+
+  echo "verify files"
+  verify_sha1sum ${repodir}/tree2/branch1/test.txt d231feb3b7963bd26a6b12db5fa5c4fb93beff04 || return 45
 
   return 0
 }


### PR DESCRIPTION
There exist situations in which SwapNestedCatalog() may encounter a catalog that has already been attached.  For example: if a directory is converted into a nested catalog then any child catalogs will be attached during the call to CreateNestedCatalog() on that directory.  A subsequent call to SwapNestedCatalog() for one of the child catalogs will currently hit an assertion failure due to the old catalog having already been attached.

Fix by calling RemoveNestedCatalog() to cleanly handle the removal of the old catalog whatever its current state, and then adding the new catalog as before.

Convert SyncLock() to a recursive lock, to allow for calling RemoveNestedCatalog() from within SwapNestedCatalog().

Add a test case to cover the issue as described in #2737 

Fixes: #2737 

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>
