### PR TITLE
Avoid diff recursion outside of the lease path during a catalog merge

### DIFF
--- a/cvmfs/catalog_diff_tool.h
+++ b/cvmfs/catalog_diff_tool.h
@@ -52,6 +52,41 @@ class CatalogDiffTool {
   bool Run(const PathString& path);
 
  protected:
+  /**
+   * Check if a path (and, by implication, any subpath) should be
+   * ignored and not considered for comparison purposes.
+   *
+   * This can be used to avoid unnecessary work by avoiding recursion
+   * into paths that will not be of interest (e.g. paths that are
+   * neither above nor within the lease path, when using a gateway).
+   */
+  virtual bool IsIgnoredPath(const PathString& path) { return false; }
+
+  /**
+   * Check if a difference found on a path should be reported via
+   * ReportAddition(), ReportRemoval(), or ReportModification().
+   *
+   * This can be used to filter out differences that are not of
+   * interest (e.g. paths that are not within the lease path, when
+   * using a gateway).
+   *
+   * Note that an ignored path must necessarily be a non-reportable
+   * path, since an ignored path will never even be compared (and so
+   * can never be reported upon).  However, there do exist paths that
+   * are neither ignored nor reportable: when using a gateway, a
+   * parent of the lease path is not reportable (since it is not
+   * within the lease path) but must not be ignored (since we need to
+   * recurse into the parent path in order to reach the lease path).
+   *
+   * As a concrete example, with a lease path of /foo/bar:
+   *
+   * /foo             <-  not ignored, not reportable
+   * /foo/bar         <-  not ignored      reportable
+   * /foo/bar/thing   <-  not ignored      reportable
+   * /foo/baz         <-      ignored (and therefore not reportable)
+   */
+  virtual bool IsReportablePath(const PathString& path) { return true; }
+
   virtual void ReportAddition(const PathString& path,
                               const catalog::DirectoryEntry& entry,
                               const XattrList& xattrs,

--- a/cvmfs/receiver/catalog_merge_tool.h
+++ b/cvmfs/receiver/catalog_merge_tool.h
@@ -93,6 +93,9 @@ class CatalogMergeTool : public CatalogDiffTool<RoCatalogMgr> {
            uint64_t *final_rev);
 
  protected:
+  virtual bool IsIgnoredPath(const PathString& path);
+  virtual bool IsReportablePath(const PathString& path);
+
   virtual void ReportAddition(const PathString& path,
                               const catalog::DirectoryEntry& entry,
                               const XattrList& xattrs,

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -86,20 +86,31 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::Run(
 }
 
 template <typename RwCatalogMgr, typename RoCatalogMgr>
+bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::IsIgnoredPath(
+    const PathString& path) {
+  const PathString rel_path = MakeRelative(path);
+
+  // Ignore any paths that are not either within the lease path or
+  // above the lease path
+  return !(IsSubPath(lease_path_, rel_path) ||
+           IsSubPath(rel_path, lease_path_));
+}
+
+template <typename RwCatalogMgr, typename RoCatalogMgr>
+bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::IsReportablePath(
+    const PathString& path) {
+  const PathString rel_path = MakeRelative(path);
+
+  // Do not report any changes occurring outside the lease path (which
+  // will be due to other concurrent writers)
+  return IsSubPath(lease_path_, rel_path);
+}
+
+template <typename RwCatalogMgr, typename RoCatalogMgr>
 void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportAddition(
     const PathString& path, const catalog::DirectoryEntry& entry,
     const XattrList& xattrs, const FileChunkList& chunks) {
   const PathString rel_path = MakeRelative(path);
-
-  /*
-   * Note: If the addition of a file or directory outside of the lease
-   *       path is encountered here, this means that the item was deleted
-   *       by another writer running concurrently.
-   *       The correct course of action is to ignore this change here.
-   * */
-  if (!IsSubPath(lease_path_, rel_path)) {
-    return;
-  }
 
   const std::string parent_path =
       std::strchr(rel_path.c_str(), '/') ? GetParentPath(rel_path).c_str() : "";
@@ -135,16 +146,6 @@ void CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportRemoval(
     const PathString& path, const catalog::DirectoryEntry& entry) {
   const PathString rel_path = MakeRelative(path);
 
-  /*
-   * Note: If the removal of a file or directory outside of the lease
-   *       path is encountered here, this means that the item was created
-   *       by another writer running concurrently.
-   *       The correct course of action is to ignore this change here.
-   * */
-  if (!IsSubPath(lease_path_, rel_path)) {
-    return;
-  }
-
   if (entry.IsDirectory()) {
     if (entry.IsNestedCatalogMountpoint()) {
       output_catalog_mgr_->RemoveNestedCatalog(std::string(rel_path.c_str()),
@@ -172,19 +173,6 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::ReportModification(
     const catalog::DirectoryEntry& entry2, const XattrList& xattrs,
     const FileChunkList& chunks) {
   const PathString rel_path = MakeRelative(path);
-
-  /*
-   * Note: If the modification of a file or directory outside of the lease
-   *       path is encountered here, this means that the item was modified
-   *       by another writer running concurrently.
-   *       The correct course of action is to ignore this change here.
-   * */
-  if (!IsSubPath(lease_path_, rel_path)) {
-    // If the current path is not a parent of the lease path, then all
-    // child paths will similarly be outside of the lease path, and so
-    // there is no need to recurse any further.
-    return IsSubPath(rel_path, lease_path_);
-  }
 
   const std::string parent_path =
       std::strchr(rel_path.c_str(), '/') ? GetParentPath(rel_path).c_str() : "";

--- a/test/src/813-repository_gateway_convoluted/main
+++ b/test/src/813-repository_gateway_convoluted/main
@@ -87,5 +87,33 @@ cvmfs_run_test() {
   echo "verify files"
   verify_sha1sum ${repodir}/tree2/branch1/test.txt d231feb3b7963bd26a6b12db5fa5c4fb93beff04 || return 45
 
+  echo "start transaction 5"
+  cvmfs_server transaction ${reponame}/tree2/branch3 || return 51
+
+  echo "modify files above lease path"
+  echo "Above lease path" > ${repodir}/above.txt
+  echo "Above lease path" > ${repodir}/tree2/above.txt
+
+  echo "modify files within lease path"
+  echo "Within lease path" > ${repodir}/tree2/branch3/within.txt
+
+  echo "modify files outside lease path"
+  echo "Outside lease path" > ${repodir}/tree1/branch1/outside.txt
+  echo "Outside lease path" > ${repodir}/tree2/branch2/outside.txt
+
+  echo "publish and check 5"
+  cvmfs_server publish -v ${reponame} || return 52
+  cvmfs_server check -i ${reponame} || return 53
+
+  echo "verify nested catalog count"
+  [ $(get_catalog_count ${reponame}) -eq 40 ] || return 54
+
+  echo "verify files"
+  [ -e ${repodir}/above.txt ] && return 55
+  [ -e ${repodir}/tree2/above.txt ] && return 56
+  verify_sha1sum ${repodir}/tree2/branch3/within.txt 5c0427c65ae080a35f780a6d78db3db7fad8079e || return 57
+  [ -e ${repodir}/tree1/branch1/outside.txt ] && return 58
+  [ -e ${repodir}/tree1/branch1/outside.txt ] && return 59
+
   return 0
 }


### PR DESCRIPTION
The existing logic allows for recursion to be terminated early upon
encountering a reported modification that lies outside of the lease
path, in order to avoid wasting time comparing subdirectories that can
never be of interest.

Generalise this to terminate recursion as soon as any path that lies
outside of the lease path is encountered, even if such a path does not
contain a modification.

This generalisation requires centralising the concept of an ignored
path into the DiffRec() function.  For the sake of consistency, also
centralise the related concept of a reportable path, and test for
reportability prior to calling ReportModification() et al.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>