### PR TITLE
Add 'device id' talk command

### DIFF
--- a/cvmfs/cvmfs_talk.cc
+++ b/cvmfs/cvmfs_talk.cc
@@ -160,6 +160,8 @@ static void Usage(const std::string &exe) {
     "  evict <path>           removes <path> from the cache            \n"
     "  pin <path>             pins <path> in the cache                 \n"
     "  mountpoint             returns the mount point                  \n"
+    "  device id              returns major:minor virtual device id    \n"
+    "                         on Linux and 0:0 on macOS                \n"
     "  remount [sync]         look for new catalogs                    \n"
     "  revision               gets the repository revision             \n"
     "  max ttl info           gets the maximum ttl                     \n"

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -150,10 +150,11 @@ typedef std::vector<LoadEvent *> EventList;
  * CernVM-FS 2.2.0 --> Version 3
  * CernVM-FS 2.4.0 --> Version 4
  * CernVM-FS 2.7.0 --> Version 4, fuse_channel --> fuse_channel_or_session
+ * CernVM-FS 2.9.0 --> Version 5, add device_id
  */
 struct LoaderExports {
   LoaderExports() :
-    version(4),
+    version(5),
     size(sizeof(LoaderExports)),
     boot_time(0),
     foreground(false),
@@ -191,6 +192,11 @@ struct LoaderExports {
   // void **fuse_channel_or_session
   // in order to work with both libfuse2 and libfuse3
   void **fuse_channel_or_session;
+
+  // Linux only, stores the major:minor internal mountpoint identifier
+  // The identifier is read just after mount from /proc/self/mountinfo
+  // If it cannot be determined (e.g. on macOS), device_id is "0:0".
+  std::string device_id;
 };
 
 

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -289,6 +289,11 @@ void *TalkManager::MainResponder(void *data) {
       }
     } else if (line == "mountpoint") {
       talk_mgr->Answer(con_fd, cvmfs::loader_exports_->mount_point + "\n");
+    } else if (line == "device id") {
+      if (cvmfs::loader_exports_->version >= 5)
+        talk_mgr->Answer(con_fd, cvmfs::loader_exports_->device_id + "\n");
+      else
+        talk_mgr->Answer(con_fd, "0:0\n");
     } else if (line.substr(0, 7) == "remount") {
       FuseRemounter::Status status;
       if (line == "remount sync")

--- a/test/src/093-deviceid/main
+++ b/test/src/093-deviceid/main
@@ -9,6 +9,9 @@ cvmfs_run_test() {
 
   local device_id=$(sudo cvmfs_talk -i cernvm-prod.cern.ch device id)
   echo "*** Device id: $device_id"
+  echo "*** Mountinfo:"
+  cat /proc/self/mountinfo
+  echo "***"
 
   if running_on_osx; then
     [ "x$device_id" = "x0:0" ] || return 10

--- a/test/src/093-deviceid/main
+++ b/test/src/093-deviceid/main
@@ -16,7 +16,7 @@ cvmfs_run_test() {
   if running_on_osx; then
     [ "x$device_id" = "x0:0" ] || return 10
   else
-    [ "x$device_id" != "x$(cat /proc/self/mountinfo | grep cernvm-prod.cern.ch | cut -d ' ' -f3)" ] || return 11
+    [ "x$device_id" = "x$(cat /proc/self/mountinfo | grep cernvm-prod.cern.ch | cut -d ' ' -f3)" ] || return 11
   fi
 
   return 0

--- a/test/src/093-deviceid/main
+++ b/test/src/093-deviceid/main
@@ -1,0 +1,20 @@
+cvmfs_test_name="Report device id"
+cvmfs_test_suites="quick"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  echo "*** mount cernvm-prod.cern.ch normally"
+  cvmfs_mount cernvm-prod.cern.ch || return 1
+
+  local device_id=$(sudo cvmfs_talk -i cernvm-prod.cern.ch device id)
+  echo "*** Device id: $device_id"
+
+  if running_on_osx; then
+    [ "x$device_id" = "x0:0" ] || return 10
+  else
+    [ "x$device_id" != "x$(cat /proc/self/mountinfo | grep cernvm-prod.cern.ch | cut -d ' ' -f3)" ] || return 11
+  fi
+
+  return 0
+}


### PR DESCRIPTION
The device ID is stable across mount namespaces and thus allows to identify a mountpoint system-wide. It can be used to find "zombie" fuse modules that are only active in child mount namespaces (see [CVM-2004](https://sft.its.cern.ch/jira/browse/CVM-2004))