### PR TITLE
Add support for direct I/O files

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -437,6 +437,8 @@ unsigned SqlDirent::CreateDatabaseFlags(const DirectoryEntry &entry) const {
       database_flags |= kFlagFileChunk;
     if (entry.IsExternalFile())
       database_flags |= kFlagFileExternal;
+    if (entry.IsDirectIo())
+      database_flags |= kFlagDirectIo;
   }
 
   if (!entry.checksum_ptr()->IsNull() || entry.IsChunkedFile())
@@ -444,8 +446,6 @@ unsigned SqlDirent::CreateDatabaseFlags(const DirectoryEntry &entry) const {
 
   if (entry.IsHidden())
     database_flags |= kFlagHidden;
-  if (entry.IsDirectIo())
-    database_flags |= kFlagDirectIo;
 
   return database_flags;
 }

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -75,7 +75,9 @@ const float CatalogDatabase::kLatestSupportedSchema = 2.5;  // + 1.X (r/o)
 //   4 --> 5: (Dec 07 2017):
 //            * add kFlagFileSpecial (rebranded unused kFlagFileStat)
 //            * add self_special and subtree_special statistics counters
-const unsigned CatalogDatabase::kLatestSchemaRevision = 5;
+//   5 --> 6: (Jul 01 2021):
+//            * Add kFlagDirectIo
+const unsigned CatalogDatabase::kLatestSchemaRevision = 6;
 
 bool CatalogDatabase::CheckSchemaCompatibility() {
   return !( (schema_version() >= 2.0-kSchemaEpsilon)                   &&
@@ -190,6 +192,17 @@ bool CatalogDatabase::LiveSchemaUpgradeIfNecessary() {
     }
 
     set_schema_revision(5);
+    if (!StoreSchemaRevision()) {
+      LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade schema revision");
+      return false;
+    }
+  }
+
+
+  if (IsEqualSchema(schema_version(), 2.5) && (schema_revision() == 5)) {
+    LogCvmfs(kLogCatalog, kLogDebug, "upgrading schema revision (5 --> 6)");
+
+    set_schema_revision(6);
     if (!StoreSchemaRevision()) {
       LogCvmfs(kLogCatalog, kLogDebug, "failed to upgrade schema revision");
       return false;
@@ -431,6 +444,8 @@ unsigned SqlDirent::CreateDatabaseFlags(const DirectoryEntry &entry) const {
 
   if (entry.IsHidden())
     database_flags |= kFlagHidden;
+  if (entry.IsDirectIo())
+    database_flags |= kFlagDirectIo;
 
   return database_flags;
 }
@@ -709,6 +724,7 @@ DirectoryEntry SqlLookup::GetDirent(const Catalog *catalog,
     result.is_bind_mountpoint_ = (database_flags & kFlagDirBindMountpoint);
     result.is_chunked_file_    = (database_flags & kFlagFileChunk);
     result.is_hidden_          = (database_flags & kFlagHidden);
+    result.is_direct_io_       = (database_flags & kFlagDirectIo);
     result.is_external_file_   = (database_flags & kFlagFileExternal);
     result.has_xattrs_         = RetrieveInt(15) != 0;
     result.checksum_           =

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -209,6 +209,10 @@ class SqlDirent : public SqlCatalog {
    * directory.
    */
   static const int kFlagHidden              = 0x8000;  // 2^15
+  /**
+   * For regular files, indicates that the file should be opened with direct I/O
+   */
+  static const int kFlagDirectIo            = 0x10000;  // 2^16
 
 
  protected:

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -998,6 +998,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
                                         unique_inode);
     // The same inode can refer to different revisions of a path.  Don't cache.
     fi->keep_cache = 0;
+    fi->direct_io = dirent.IsDirectIo();
     fi->fh = static_cast<uint64_t>(-chunk_tables->next_handle);
     ++chunk_tables->next_handle;
     chunk_tables->Unlock();
@@ -1025,6 +1026,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
                path.c_str(), fd);
       // The same inode can refer to different revisions of a path. Don't cache.
       fi->keep_cache = 0;
+      fi->direct_io = dirent.IsDirectIo();
       fi->fh = fd;
       fuse_reply_open(req, fi);
       return;

--- a/cvmfs/directory_entry.cc
+++ b/cvmfs/directory_entry.cc
@@ -63,6 +63,9 @@ DirectoryEntryBase::Differences DirectoryEntry::CompareTo(
   if (IsHidden() != other.IsHidden()) {
     result |= Difference::kHiddenFlag;
   }
+  if (IsDirectIo() != other.IsDirectIo()) {
+    result |= Difference::kDirectIoFlag;
+  }
 
   return result;
 }

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -95,7 +95,7 @@ class DirectoryEntryBase {
     static const unsigned int kExternalFileFlag             = 0x800;
     static const unsigned int kBindMountpointFlag           = 0x1000;
     static const unsigned int kHiddenFlag                   = 0x2000;
-    static const unsigned int kDirectIo                     = 0x4000;
+    static const unsigned int kDirectIoFlag                 = 0x4000;
   };
   typedef unsigned int Differences;
 

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -95,6 +95,7 @@ class DirectoryEntryBase {
     static const unsigned int kExternalFileFlag             = 0x800;
     static const unsigned int kBindMountpointFlag           = 0x1000;
     static const unsigned int kHiddenFlag                   = 0x2000;
+    static const unsigned int kDirectIo                     = 0x4000;
   };
   typedef unsigned int Differences;
 
@@ -273,6 +274,7 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_bind_mountpoint_(false)
     , is_chunked_file_(false)
     , is_hidden_(false)
+    , is_direct_io_(false)
     , is_negative_(false) { }
 
   inline DirectoryEntry()
@@ -282,6 +284,7 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_bind_mountpoint_(false)
     , is_chunked_file_(false)
     , is_hidden_(false)
+    , is_direct_io_(false)
     , is_negative_(false) { }
 
   inline explicit DirectoryEntry(SpecialDirents special_type)
@@ -291,6 +294,7 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_bind_mountpoint_(false)
     , is_chunked_file_(false)
     , is_hidden_(false)
+    , is_direct_io_(false)
     , is_negative_(true) { assert(special_type == kDirentNegative); }
 
   inline SpecialDirents GetSpecial() const {
@@ -313,6 +317,7 @@ class DirectoryEntry : public DirectoryEntryBase {
   inline bool IsBindMountpoint() const { return is_bind_mountpoint_; }
   inline bool IsChunkedFile() const { return is_chunked_file_; }
   inline bool IsHidden() const { return is_hidden_; }
+  inline bool IsDirectIo() const { return is_direct_io_; }
   inline uint32_t hardlink_group() const { return hardlink_group_; }
 
   inline void set_hardlink_group(const uint32_t group) {
@@ -333,6 +338,9 @@ class DirectoryEntry : public DirectoryEntryBase {
   inline void set_is_hidden(const bool val) {
     is_hidden_ = val;
   }
+  inline void set_is_direct_io(const bool val) {
+    is_direct_io_ = val;
+  }
 
  private:
   /**
@@ -347,6 +355,7 @@ class DirectoryEntry : public DirectoryEntryBase {
   bool is_bind_mountpoint_;
   bool is_chunked_file_;
   bool is_hidden_;
+  bool is_direct_io_;
   bool is_negative_;
 };
 

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -112,6 +112,7 @@ class DirectoryEntryBase {
     , linkcount_(1)  // generally a normal file has linkcount 1 -> default
     , has_xattrs_(false)
     , is_external_file_(false)
+    , is_direct_io_(false)
     , compression_algorithm_(zlib::kZlibDefault)
     { }
 
@@ -126,6 +127,7 @@ class DirectoryEntryBase {
     return IsFifo() || IsSocket() || IsCharDev() || IsBlockDev();
   }
   inline bool IsExternalFile() const            { return is_external_file_; }
+  inline bool IsDirectIo() const                { return is_direct_io_; }
   inline bool HasXattrs() const                 { return has_xattrs_;    }
 
   inline inode_t inode() const                  { return inode_; }
@@ -230,6 +232,7 @@ class DirectoryEntryBase {
   shash::Any checksum_;
 
   bool is_external_file_;
+  bool is_direct_io_;
 
   // The compression algorithm
   zlib::Algorithms compression_algorithm_;
@@ -274,7 +277,6 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_bind_mountpoint_(false)
     , is_chunked_file_(false)
     , is_hidden_(false)
-    , is_direct_io_(false)
     , is_negative_(false) { }
 
   inline DirectoryEntry()
@@ -284,7 +286,6 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_bind_mountpoint_(false)
     , is_chunked_file_(false)
     , is_hidden_(false)
-    , is_direct_io_(false)
     , is_negative_(false) { }
 
   inline explicit DirectoryEntry(SpecialDirents special_type)
@@ -294,7 +295,6 @@ class DirectoryEntry : public DirectoryEntryBase {
     , is_bind_mountpoint_(false)
     , is_chunked_file_(false)
     , is_hidden_(false)
-    , is_direct_io_(false)
     , is_negative_(true) { assert(special_type == kDirentNegative); }
 
   inline SpecialDirents GetSpecial() const {
@@ -317,7 +317,6 @@ class DirectoryEntry : public DirectoryEntryBase {
   inline bool IsBindMountpoint() const { return is_bind_mountpoint_; }
   inline bool IsChunkedFile() const { return is_chunked_file_; }
   inline bool IsHidden() const { return is_hidden_; }
-  inline bool IsDirectIo() const { return is_direct_io_; }
   inline uint32_t hardlink_group() const { return hardlink_group_; }
 
   inline void set_hardlink_group(const uint32_t group) {
@@ -338,9 +337,6 @@ class DirectoryEntry : public DirectoryEntryBase {
   inline void set_is_hidden(const bool val) {
     is_hidden_ = val;
   }
-  inline void set_is_direct_io(const bool val) {
-    is_direct_io_ = val;
-  }
 
  private:
   /**
@@ -355,7 +351,6 @@ class DirectoryEntry : public DirectoryEntryBase {
   bool is_bind_mountpoint_;
   bool is_chunked_file_;
   bool is_hidden_;
-  bool is_direct_io_;
   bool is_negative_;
 };
 

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -55,6 +55,7 @@ MagicXattrManager::MagicXattrManager(MountPoint *mountpoint,
   Register("user.chunk_list", new ChunkListMagicXattr());
   Register("user.chunks", new ChunksMagicXattr());
   Register("user.compression", new CompressionMagicXattr());
+  Register("user.direct_io", new DirectIoMagicXattr());
   Register("user.external_file", new ExternalFileMagicXattr());
 
   Register("user.rawlink", new RawlinkMagicXattr());
@@ -217,6 +218,14 @@ bool CompressionMagicXattr::PrepareValueFenced() {
 
 std::string CompressionMagicXattr::GetValue() {
   return zlib::AlgorithmName(dirent_->compression_algorithm());
+}
+
+bool DirectIoMagicXattr::PrepareValueFenced() {
+  return dirent_->IsRegular();
+}
+
+std::string DirectIoMagicXattr::GetValue() {
+  return dirent_->IsDirectIo() ? "1" : "0";
 }
 
 bool ExternalFileMagicXattr::PrepareValueFenced() {

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -185,6 +185,11 @@ class CompressionMagicXattr : public RegularMagicXattr {
   virtual std::string GetValue();
 };
 
+class DirectIoMagicXattr : public RegularMagicXattr {
+  virtual bool PrepareValueFenced();
+  virtual std::string GetValue();
+};
+
 class ExternalFileMagicXattr : public RegularMagicXattr {
   virtual bool PrepareValueFenced();
   virtual std::string GetValue();

--- a/cvmfs/publish/cmd_diff.cc
+++ b/cvmfs/publish/cmd_diff.cc
@@ -177,6 +177,8 @@ class DiffReporter : public publish::DiffListener {
       result_list.push_back(machine_readable_ ? "B" : "bind-mountpoint");
     if (diff & catalog::DirectoryEntryBase::Difference::kHiddenFlag)
       result_list.push_back(machine_readable_ ? "H" : "hidden");
+    if (diff & catalog::DirectoryEntryBase::Difference::kDirectIoFlag)
+      result_list.push_back(machine_readable_ ? "D" : "direct-io");
 
     return machine_readable_ ? ("[" + JoinStrings(result_list, "") + "]")
                              : (" [" + JoinStrings(result_list, ", ") + "]");

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -17,13 +17,15 @@ cvmfs_server_publish() {
   local authz_file=""
   local force_external=0
   local force_native=0
+  local force_direct_io=0
   local force_compression_algorithm=""
   local external_option=""
+  local direct_io_option=""
   local open_fd_dialog=1
 
   # optional parameter handling
   OPTIND=1
-  while getopts "F:NXZ:pa:c:m:vn:fe" option
+  while getopts "F:NXZ:pa:c:m:vn:fed" option
   do
     case $option in
       p)
@@ -55,6 +57,9 @@ cvmfs_server_publish() {
       ;;
       F)
         authz_file="-F $OPTARG"
+      ;;
+      d)
+        force_direct_io=1
       ;;
       f)
         open_fd_dialog=0
@@ -117,6 +122,9 @@ cvmfs_server_publish() {
       if [ $force_native -eq 0 ]; then
         external_option="-Y"
       fi
+    fi
+    if [ $force_direct_io -eq 1 ]; then
+      direct_io_option="-W"
     fi
 
     # more sanity checks
@@ -198,7 +206,7 @@ cvmfs_server_publish() {
         -K $CVMFS_PUBLIC_KEY                           \
         $(get_follow_http_redirects_flag)              \
         $authz_file                                    \
-        $log_level $tweaks_option $external_option $verbosity"
+        $log_level $tweaks_option $external_option $direct_io_option $verbosity"
 
     if [ ! -z "$tag_name" ]; then
       sync_command="$sync_command -D $tag_name"

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -413,6 +413,13 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
     }
 
     // Checks depending of entry type
+    if (!entries[i].IsRegular()) {
+      if (entries[i].IsDirectIo()) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "invalid direct i/o flag found: %s",
+                 full_path.c_str());
+        retval = false;
+      }
+    }
     if (entries[i].IsDirectory()) {
       computed_counters->self.directories++;
       num_subdirs++;

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -858,7 +858,7 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::CleanupNestedCatalogs(
  * both the catalog management and migration classes get updated.
  */
 const float    CommandMigrate::MigrationWorker_20x::kSchema         = 2.5;
-const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 5;
+const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 6;
 
 
 template<class DerivedT>

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -608,6 +608,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   if (args.find('F') != args.end()) params.authz_file = *args.find('F')->second;
   if (args.find('k') != args.end()) params.include_xattrs = true;
   if (args.find('Y') != args.end()) params.external_data = true;
+  if (args.find('W') != args.end()) params.direct_io = true;
   if (args.find('S') != args.end()) {
     bool retval = catalog::VirtualCatalog::ParseActions(
         *args.find('S')->second, &params.virtual_dir_actions);

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -36,6 +36,7 @@ struct SyncParameters {
         stop_for_catalog_tweaks(false),
         include_xattrs(false),
         external_data(false),
+        direct_io(false),
         voms_authz(false),
         virtual_dir_actions(0),
         ignore_special_files(false),
@@ -85,6 +86,7 @@ struct SyncParameters {
   bool stop_for_catalog_tweaks;
   bool include_xattrs;
   bool external_data;
+  bool direct_io;
   bool voms_authz;
   unsigned virtual_dir_actions;  // bit field
   bool ignore_special_files;
@@ -307,6 +309,7 @@ class CommandSync : public Command {
                                   "Publish format compatible with "
                                   "authenticated repos"));
     r.push_back(Parameter::Switch('Y', "enable external data"));
+    r.push_back(Parameter::Switch('W', "set direct I/O for regular files"));
     r.push_back(Parameter::Switch('B', "branched catalog (no manifest)"));
     r.push_back(Parameter::Switch('I', "upload updated statistics DB file"));
 

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -34,6 +34,7 @@ SyncItem::SyncItem() :
   valid_graft_(false),
   graft_marker_present_(false),
   external_data_(false),
+  direct_io_(false),
   graft_chunklist_(NULL),
   compression_algorithm_(zlib::kZlibDefault),
   has_compression_algorithm_(false) {}
@@ -54,6 +55,7 @@ SyncItem::SyncItem(const std::string  &relative_parent_path,
   valid_graft_(false),
   graft_marker_present_(false),
   external_data_(false),
+  direct_io_(false),
   relative_parent_path_(relative_parent_path),
   graft_chunklist_(NULL),
   compression_algorithm_(zlib::kZlibDefault),
@@ -209,14 +211,15 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
   // (i.e. on setups using OverlayFS)
   dirent.linkcount_      = HasHardlinks() ? this->GetUnionStat().st_nlink : 1;
 
-  dirent.mode_           = this->GetUnionStat().st_mode;
-  dirent.uid_            = this->GetUnionStat().st_uid;
-  dirent.gid_            = this->GetUnionStat().st_gid;
-  dirent.size_           = graft_size_ > -1 ? graft_size_ :
-                           this->GetUnionStat().st_size;
-  dirent.mtime_          = this->GetUnionStat().st_mtime;
-  dirent.checksum_       = this->GetContentHash();
+  dirent.mode_             = this->GetUnionStat().st_mode;
+  dirent.uid_              = this->GetUnionStat().st_uid;
+  dirent.gid_              = this->GetUnionStat().st_gid;
+  dirent.size_             = graft_size_ > -1 ? graft_size_ :
+                             this->GetUnionStat().st_size;
+  dirent.mtime_            = this->GetUnionStat().st_mtime;
+  dirent.checksum_         = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
+  dirent.is_direct_io_     = this->IsDirectIo();
   dirent.compression_algorithm_ = this->GetCompressionAlgorithm();
 
   dirent.name_.Assign(filename().data(), filename().length());

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -79,6 +79,7 @@ class SyncItem {
   inline bool IsSocket()          const { return IsType(kItemSocket);          }
   inline bool IsGraftMarker()     const { return IsType(kItemMarker);          }
   inline bool IsExternalData()    const { return external_data_;               }
+  inline bool IsDirectIo()        const { return direct_io_;                   }
 
   inline bool IsWhiteout()        const { return whiteout_;                    }
   inline bool IsCatalogMarker()   const { return filename_ == ".cvmfscatalog"; }
@@ -115,6 +116,7 @@ class SyncItem {
   inline void SetContentHash(const shash::Any &hash) { content_hash_ = hash; }
   inline bool HasContentHash() const { return !content_hash_.IsNull(); }
   void SetExternalData(bool val) {external_data_ = val;}
+  void SetDirectIo(bool val) {direct_io_ = val;}
 
   inline zlib::Algorithms GetCompressionAlgorithm() const {
     return compression_algorithm_;
@@ -288,6 +290,7 @@ class SyncItem {
   bool graft_marker_present_;         /**< .cvmfsgraft-$filename exists */
 
   bool external_data_;
+  bool direct_io_;
   std::string relative_parent_path_;
 
   /**

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -129,6 +129,7 @@ class AbstractSyncMediator {
   virtual bool Commit(manifest::Manifest *manifest) = 0;
 
   virtual bool IsExternalData() const = 0;
+  virtual bool IsDirectIo() const = 0;
   virtual zlib::Algorithms GetCompressionAlgorithm() const = 0;
 };
 
@@ -173,6 +174,7 @@ class SyncMediator : public virtual AbstractSyncMediator {
   // The sync union engine uses this information to create properly initialized
   // sync items
   bool IsExternalData() const { return params_->external_data; }
+  bool IsDirectIo() const { return params_->direct_io; }
   zlib::Algorithms GetCompressionAlgorithm() const {
     return params_->compression_alg;
   }

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -36,6 +36,7 @@ SharedPtr<SyncItem> SyncUnion::CreateSyncItem(
   PreprocessSyncItem(entry);
   if (entry_type == kItemFile) {
     entry->SetExternalData(mediator_->IsExternalData());
+    entry->SetDirectIo(mediator_->IsDirectIo());
     if (!(entry->IsValidGraft() && entry->HasCompressionAlgorithm())) {
       entry->SetCompressionAlgorithm(mediator_->GetCompressionAlgorithm());
     }

--- a/test/src/633-changedfiles/main
+++ b/test/src/633-changedfiles/main
@@ -63,6 +63,10 @@ cvmfs_run_test() {
      | awk '{print $1}')                                          || return 3
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
+  local directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
+  echo "*** directio: $directio"
+  [ "x$directio" = "x0" ] || return 70
+
   local mntpnt="${scratch_dir}/private_mnt"
   echo "*** mount private mount point"
   private_mount $mntpnt || return 20

--- a/test/src/633-changedfiles/main
+++ b/test/src/633-changedfiles/main
@@ -65,7 +65,14 @@ cvmfs_run_test() {
 
   local directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
   echo "*** directio: $directio"
-  [ "x$directio" = "x0" ] || return 70
+  [ "x$directio" = "x0" ]                 || return 70
+  start_transaction $CVMFS_TEST_REPO      || return $?
+  touch /cvmfs/$CVMFS_TEST_REPO/dir/small || return 71
+  touch /cvmfs/$CVMFS_TEST_REPO/dir/large || return 71
+  publish_repo $CVMFS_TEST_REPO -d        || return 72
+  directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
+  echo "*** directio: $directio"
+  [ "x$directio" = "x1" ]                 || return 73
 
   local mntpnt="${scratch_dir}/private_mnt"
   echo "*** mount private mount point"

--- a/test/unittests/mock/m_sync_mediator.h
+++ b/test/unittests/mock/m_sync_mediator.h
@@ -43,6 +43,7 @@ class MockSyncMediator : public AbstractSyncMediator {
   MOCK_METHOD1(LeaveDirectory, void(SharedPtr<SyncItem> entry));
   MOCK_METHOD1(Commit, bool(manifest::Manifest *manifest));
   MOCK_CONST_METHOD0(IsExternalData, bool());
+  MOCK_CONST_METHOD0(IsDirectIo, bool());
   MOCK_CONST_METHOD0(GetCompressionAlgorithm, zlib::Algorithms());
 };  // class MockSyncMediator
 

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -783,8 +783,6 @@ TEST_F(T_Libcvmfs, Remount) {
     // Initialize client repo based on options
     ASSERT_EQ(LIBCVMFS_ERR_OK, cvmfs_init_v2(opts));
 
-    printf("NAME: %s\n", tester.repo_name().c_str());
-
     // Attach to client repo
     cvmfs_context *ctx;
     EXPECT_EQ(LIBCVMFS_ERR_OK,


### PR DESCRIPTION
Allows to mark files as "direct I/O" during publish.  This can be a workaround for files that are known to be subject to in-place updates (see CVM-2001) at the cost of a performance penalty.  Also adds the `direct_io` extended attribute.