### PR TITLE
Add support for attaching mount to an existing fuse module

### DIFF
--- a/cvmfs/cvmfs.h
+++ b/cvmfs/cvmfs.h
@@ -22,6 +22,7 @@ bool Pin(const std::string &path);
 void GetReloadStatus(bool *drainout_mode, bool *maintenance_mode);
 std::string PrintInodeGeneration();
 void UnregisterQuotaListener();
+bool SendFuseFd(const std::string &socket_path);
 
 }  // namespace cvmfs
 

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -294,6 +294,18 @@ void *TalkManager::MainResponder(void *data) {
         talk_mgr->Answer(con_fd, cvmfs::loader_exports_->device_id + "\n");
       else
         talk_mgr->Answer(con_fd, "0:0\n");
+    } else if (line.substr(0, 13) == "send mount fd") {
+      // Hidden command intended to be used only by the cvmfs mount helper
+      if (line.length() < 15) {
+        talk_mgr->Answer(con_fd, "EINVAL\n");
+      } else {
+        std::string socket_path = line.substr(14);
+        bool retval = cvmfs::SendFuseFd(socket_path);
+        talk_mgr->Answer(con_fd, retval ? "OK\n" : "Failed\n");
+        LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
+                 "Transfer fuse connection to new mount (via %s): %s",
+                 socket_path.c_str(), retval ? "success" : "failure");
+      }
     } else if (line.substr(0, 7) == "remount") {
       FuseRemounter::Status status;
       if (line == "remount sync")

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -95,6 +95,8 @@ bool DiffTree(const std::string &path_a, const std::string &path_b);
 void Nonblock2Block(int filedes);
 void Block2Nonblock(int filedes);
 void SendMsg2Socket(const int fd, const std::string &msg);
+bool SendFd2Socket(int socket_fd, int passing_fd);
+int RecvFdFromSocket(int msg_fd);
 
 bool SwitchCredentials(const uid_t uid, const gid_t gid,
                        const bool temporarily);

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -318,6 +318,11 @@ static std::string GetCvmfsBinary() {
 }
 
 static int AttachMount(const std::string &mountpoint, int fuse_fd) {
+#ifdef __APPLE__
+  (void) mountpoint;
+  (void) fuse_fd;
+  return 1;
+#else
   platform_stat64 info;
   int retval = platform_stat(mountpoint.c_str(), &info);
   if (retval != 0)
@@ -336,6 +341,7 @@ static int AttachMount(const std::string &mountpoint, int fuse_fd) {
     return 1;
   }
   return 0;
+#endif
 }
 
 

--- a/test/cloud_testing/platforms/centos7_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-EXCLCACHE_test.sh
@@ -23,6 +23,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/082-shrinkwrap-cms                       \
                                  src/084-premounted                           \
                                  src/089-external_cache_plugin                \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/centos7_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-FUSE3_test.sh
@@ -16,6 +16,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                               -x src/005-asetup                               \
                                  src/004-davinci                              \
                                  src/007-testjobs                             \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/centos7_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-NFS_test.sh
@@ -28,6 +28,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/082-shrinkwrap-cms                       \
                                  src/084-premounted                           \
                                  src/089-external_cache_plugin                \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/centos7_x86_64-RAMCACHE_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-RAMCACHE_test.sh
@@ -31,6 +31,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/082-shrinkwrap-cms                       \
                                  src/084-premounted                           \
                                  src/089-external_cache_plugin                \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -34,6 +34,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/004-davinci                              \
                                  src/007-testjobs                             \
                                  src/084-premounted                           \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/centos8_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-FUSE3_test.sh
@@ -19,6 +19,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/004-davinci                              \
                                  src/007-testjobs                             \
                                  src/084-premounted                           \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/centos8_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64_test.sh
@@ -32,6 +32,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/007-testjobs                             \
                                  src/056-lowspeedlimit                        \
                                  src/084-premounted                           \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/fedora_test.sh
+++ b/test/cloud_testing/platforms/fedora_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CVMFS_PLATFORM_NAME="fedora$(. /etc/os-release && echo "$VERSION_ID")-$(uname -m)" 
+export CVMFS_PLATFORM_NAME="fedora$(. /etc/os-release && echo "$VERSION_ID")-$(uname -m)"
 export CVMFS_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # source the common platform independent functionality and option parsing
@@ -23,6 +23,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/006-buildkernel                          \
                                  src/007-testjobs                             \
                                  src/024-reload-during-asetup                 \
+                                 src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
                               || retval=1

--- a/test/cloud_testing/platforms/macos_test.sh
+++ b/test/cloud_testing/platforms/macos_test.sh
@@ -43,6 +43,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests
                                    src/083-suid                                 \
                                    src/084-premounted                           \
                                    src/089-external_cache_plugin                \
+                                   src/094-attachmount                          \
                                    --                                           \
                                    src/0*
 

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -50,6 +50,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/007-testjobs                             \
                                  src/024-reload-during-asetup                 \
                                  src/084-premounted                           \
+                                 src/094-attachmount                          \
                                  $CVMFS_EXCLUDE                               \
                                  --                                           \
                                  src/0*                                       \

--- a/test/src/094-attachmount/main
+++ b/test/src/094-attachmount/main
@@ -1,0 +1,62 @@
+cvmfs_test_name="Attach mount to a 'zombie' fuse module"
+cvmfs_test_suites="quick"
+# We disable autofs for this test to get the output from the mount helper
+cvmfs_test_autofs_on_startup=false
+
+CVMFS_TEST094_PID_NAMESPACE=
+
+cleanup() {
+  if [ ! -z $CVMFS_TEST094_PID_NAMESPACE ]; then
+    echo "*** Kill namespaced process $CVMFS_TEST094_PID_NAMESPACE"
+    sudo kill -9 $CVMFS_TEST094_PID_NAMESPACE
+  fi
+  # If the test fails, return to a sane state
+  sudo cvmfs_config killall
+  sudo rmdir /cvmfs/cvmfs-config.cern.ch /cvmfs/cernvm-prod.cern.ch
+}
+
+cvmfs_run_test() {
+  logfile=$1
+
+  echo "*** mount cernvm-prod.cern.ch"
+  cvmfs_mount cernvm-prod.cern.ch || return 1
+
+  local fuse_pid=$(sudo cvmfs_talk -i cernvm-prod.cern.ch pid)
+  echo "*** Fuse PID is $fuse_pid"
+
+  echo "*** Detach mount namespace"
+  sudo unshare -m bash -c 'cd /cvmfs/cernvm-prod.cern.ch && sleep 10000' &
+  CVMFS_TEST094_PID_NAMESPACE=$!
+  trap cleanup HUP EXIT TERM INT
+
+  kill -0 $CVMFS_TEST094_PID_NAMESPACE || return 10
+  echo "*** PID of process in mount namespace is $CVMFS_TEST094_PID_NAMESPACE"
+  ls -lah /proc/self/ns/mnt
+  sudo ls -lah /proc/$CVMFS_TEST094_PID_NAMESPACE/ns/mnt
+
+  echo "*** unmount system-wide mount"
+  cvmfs_umount cernvm-prod.cern.ch || return 20
+  cat /proc/mounts
+  ps -eaf | grep cvmfs2
+
+  if [ "x$(sudo cvmfs_talk -i cernvm-prod.cern.ch pid)" != "x$fuse_pid" ]; then
+    echo "Fuse daemon should have stayed alive"
+    sudo cvmfs_talk -i cernvm-prod.cern.ch pid
+    return 21
+  fi
+
+  echo "*** try to remount system-wide mount"
+  sudo mount -t cvmfs cernvm-prod.cern.ch /cvmfs/cernvm-prod.cern.ch
+  if [ $? -ne 0 ]; then
+    cat_syslog | tail -n 32
+    return 30
+  fi
+
+  if [ "x$(sudo cvmfs_talk -i cernvm-prod.cern.ch pid)" != "x$fuse_pid" ]; then
+    echo "Fuse daemon should have stayed the same"
+    sudo cvmfs_talk -i cernvm-prod.cern.ch pid
+    return 31
+  fi
+
+  return 0
+}

--- a/test/src/094-attachmount/main
+++ b/test/src/094-attachmount/main
@@ -8,7 +8,7 @@ CVMFS_TEST094_PID_NAMESPACE=
 cleanup() {
   if [ ! -z $CVMFS_TEST094_PID_NAMESPACE ]; then
     echo "*** Kill namespaced process $CVMFS_TEST094_PID_NAMESPACE"
-    sudo kill -9 $CVMFS_TEST094_PID_NAMESPACE
+    sudo pkill -P $CVMFS_TEST094_PID_NAMESPACE
   fi
   # If the test fails, return to a sane state
   sudo cvmfs_config killall
@@ -20,6 +20,9 @@ cvmfs_run_test() {
 
   echo "*** mount cernvm-prod.cern.ch"
   cvmfs_mount cernvm-prod.cern.ch || return 1
+
+  cat /proc/mounts | grep fuse
+  cat /proc/self/mountinfo | grep fuse
 
   local fuse_pid=$(sudo cvmfs_talk -i cernvm-prod.cern.ch pid)
   echo "*** Fuse PID is $fuse_pid"
@@ -36,7 +39,8 @@ cvmfs_run_test() {
 
   echo "*** unmount system-wide mount"
   cvmfs_umount cernvm-prod.cern.ch || return 20
-  cat /proc/mounts
+  cat /proc/mounts | grep fuse
+  cat /proc/self/mountinfo | grep fuse
   ps -eaf | grep cvmfs2
 
   if [ "x$(sudo cvmfs_talk -i cernvm-prod.cern.ch pid)" != "x$fuse_pid" ]; then
@@ -48,15 +52,35 @@ cvmfs_run_test() {
   echo "*** try to remount system-wide mount"
   sudo mount -t cvmfs cernvm-prod.cern.ch /cvmfs/cernvm-prod.cern.ch
   if [ $? -ne 0 ]; then
-    cat_syslog | tail -n 32
+    cat_syslog | grep -e '(cernvm-prod.cern.ch)' | tail -n 8
     return 30
   fi
+
+  ls -lah /cvmfs/cernvm-prod.cern.ch/|| return 31
+  cat /proc/mounts | grep fuse
+  cat /proc/self/mountinfo | grep fuse
 
   if [ "x$(sudo cvmfs_talk -i cernvm-prod.cern.ch pid)" != "x$fuse_pid" ]; then
     echo "Fuse daemon should have stayed the same"
     sudo cvmfs_talk -i cernvm-prod.cern.ch pid
-    return 31
+    return 32
   fi
+
+  echo "*** Unmount system mount"
+  cvmfs_umount cernvm-prod.cern.ch || return 40
+
+  echo "*** Stop namespace'd process"
+  sudo kill -0 $CVMFS_TEST094_PID_NAMESPACE || return 41
+  sudo pkill -P $CVMFS_TEST094_PID_NAMESPACE || return 42
+  while sudo kill -0 $CVMFS_TEST094_PID_NAMESPACE; do
+    :
+  done
+  CVMFS_TEST094_PID_NAMESPACE=
+
+  # Last one turns out the lights (failure caught be timeout)
+  while sudo cvmfs_talk -i cernvm-prod.cern.ch pid; do
+    sleep 1
+  done
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -507,6 +507,9 @@ cvmfs_mount() {
   if running_on_osx; then
     cvmfs_mount_direct $repositories
   fi
+  if [ "x$cvmfs_test_autofs_on_startup" = "xfalse" ]; then
+    cvmfs_mount_direct $repositories
+  fi
 
   $proberunner cvmfs_config probe > /dev/null 2>&1 || return 101
 
@@ -517,7 +520,7 @@ cvmfs_mount() {
 _cvmfs_mount_manually() {
   local repository=$1
   cvmfs_config status | grep -q "/cvmfs/$repository" && return 0
-  mkdir -p "/cvmfs/$repository" || sudo mkdir -p "/cvmfs/$repository"
+  mkdir -p "/cvmfs/$repository" 2>/dev/null || sudo mkdir -p "/cvmfs/$repository"
   sudo mount -t cvmfs "$repository" "/cvmfs/$repository" >/dev/null 2>&1
 }
 


### PR DESCRIPTION
Allows the mount helper to ask an existing fuse module for its /dev/fuse file descriptor and use it to attach the mountpoint. That helps when the fuse module serves a process with another mount namespace and has been unmounted from the system-wide mount namespace.

It requires a [kernel patch](https://sourceforge.net/p/fuse/mailman/message/37317340/).