### PR TITLE
Use systemctl to unmount filesystems when available

### DIFF
--- a/cvmfs/cvmfs_suid_helper.cc
+++ b/cvmfs/cvmfs_suid_helper.cc
@@ -302,20 +302,20 @@ int main(int argc, char *argv[]) {
   const string command = argv[1];
   const string fqrn = argv[2];
 
-  // Verify if repository exists
-  platform_stat64 info;
-  retval = platform_lstat((string(kSpoolArea) + "/" + fqrn).c_str(), &info);
-  if (retval != 0) {
-    fprintf(stderr, "unknown repository: %s\n", fqrn.c_str());
-    return 1;
-  }
-  repository_uid = info.st_uid;
-
-  // Verify if caller uid matches
-  if ((calling_uid != 0) && (calling_uid != repository_uid)) {
-    fprintf(stderr, "called as %d, repository owned by %d\n",
-            calling_uid, repository_uid);
-    return 1;
+  // Verify if caller uid matches (or is root)
+  if (calling_uid != 0) {
+    platform_stat64 info;
+    retval = platform_lstat((string(kSpoolArea) + "/" + fqrn).c_str(), &info);
+    if (retval != 0) {
+      fprintf(stderr, "unknown repository: %s\n", fqrn.c_str());
+      return 1;
+    }
+    repository_uid = info.st_uid;
+    if (calling_uid != repository_uid) {
+      fprintf(stderr, "called as %d, repository owned by %d\n",
+              calling_uid, repository_uid);
+      return 1;
+    }
   }
 
   if (command == "lock") {

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1258,11 +1258,14 @@ get_auto_tags_timespan() {
 unmount_and_teardown_repository() {
   local name=$1
   load_repo_config $name
-  sed -i -e "/added by CernVM-FS for ${name}/d" /etc/fstab
   local rw_mnt="/cvmfs/$name"
   local rdonly_mnt="${CVMFS_SPOOL_DIR}/rdonly"
-  is_mounted "$rw_mnt"     && ( umount $rw_mnt     || return 1; )
-  is_mounted "$rdonly_mnt" && ( umount $rdonly_mnt || return 2; )
+  is_mounted "$rw_mnt"     && ( run_suid_helper rw_umount $name || return 1; )
+  is_mounted "$rdonly_mnt" && ( run_suid_helper rdonly_umount $name || return 2; )
+  sed -i -e "/added by CernVM-FS for ${name}/d" /etc/fstab
+  if is_systemd; then
+    systemctl daemon-reload
+  fi
   return 0
 }
 


### PR DESCRIPTION
When systemctl is available, cvmfs_suid_helper will use it to mount
filesystems in order to prevent the cvmfs2 process from being
terminated unexpectedly by systemd (see CVM-1398 for details).

Generalise this logic to use systemctl for unmounting as well as
mounting, to avoid ending up in a situation in which the systemd mount
unit is still marked as active even though cvmfs_suid_helper has
unmounted the corresponding filesystem.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>