### PR TITLE
Ensure that filesystem is really mounted when using systemctl

### DIFF
--- a/cvmfs/cvmfs_suid_helper.cc
+++ b/cvmfs/cvmfs_suid_helper.cc
@@ -94,7 +94,7 @@ static void Mount(const string &path) {
       }
       systemd_unit = cvmfs_suid::EscapeSystemdUnit(resolved_path);
     }
-    ExecAsRoot("/bin/systemctl", "start", systemd_unit.c_str(), NULL);
+    ExecAsRoot("/bin/systemctl", "restart", systemd_unit.c_str(), NULL);
   } else {
     ExecAsRoot("/bin/mount", path.c_str(), NULL, NULL);
   }


### PR DESCRIPTION
On some versions of systemd (observed with systemd 248 on Fedora 34),
the systemd mount unit activity status seems not to track the mount
state.  In particular, the following sequence of events:

  - systemctl start cvmfs-repo.name.mount
  - umount /cvmfs/repo.name
  - systemctl start cvmfs-repo.name.mount

will fail to remount the filesystem, since systemd believe that the
mount unit is still in the active state after the manual "umount".

Work around this problem by using "systemctl restart" instead of
"systemctl start" in cvmfs_suid_helper.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>