### PR TITLE
Use "cvmfs2" as the FUSE fsname option

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -758,6 +758,12 @@ int FuseMain(int argc, char *argv[]) {
     options_manager->ParseDefault(*repository_name_);
   }
 
+  // Use "cvmfs2" as the fsname for the mount point device, to prevent
+  // systemd from inferring a non-functional dependency on the
+  // (non-existent) dev-fuse.device unit
+  string fsname = "-ofsname=cvmfs2";
+  fuse_opt_add_arg(mount_options, fsname.c_str());
+
 #ifdef __APPLE__
   string volname = "-ovolname=" + *repository_name_;
   fuse_opt_add_arg(mount_options, volname.c_str());


### PR DESCRIPTION
When neither fsname nor FUSE subtype is specified, libfuse will
default to using "/dev/fuse" as the underlying device for a mounted
FUSE filesystem.

This can cause some versions of systemd to infer a dependency upon the
dev-fuse.device unit, which is itself non-functional since the default
systemd udev rules do not set the "systemd" tag for the /dev/fuse
device node (see https://github.com/systemd/systemd/pull/20236).  On
Fedora 34, this causes all CVMFS mounts to fail due to a timeout
waiting for the underlying dev-fuse.device unit.

Some code paths (e.g. in mount/mount.cvmfs.cc) already specify
"-ofsname=cvmfs2".  Add this to cvmfs/loader.cc so that the option is
used consistently for all CVMFS mounts.

This changes the entry in /proc/mounts from e.g.

  /dev/fuse on /var/spool/cvmfs/test.repo.org/rdonly type fuse

to

  cvmfs2 on /var/spool/cvmfs/test.repo.org/rdonly type fuse

and results in systemd no longer inferring a (broken) dependency
upon dev-fuse.device.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>