### PR TITLE
Use repository name as the fsname option for read-only mount points

### DIFF
--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1130,7 +1130,7 @@ setup_and_mount_new_repository() {
   if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
     echo -n "(overlayfs) "
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 overlay_$name /cvmfs/$name overlay upperdir=${scratch_dir},lowerdir=${rdonly_dir},workdir=$ofs_workdir,noauto,nodev,ro 0 0 # added by CernVM-FS for $name
 EOF
   else
@@ -1139,7 +1139,7 @@ EOF
       selinux_context=",context=\"system_u:object_r:default_t:s0\""
     fi
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,noauto,nodev,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   fi


### PR DESCRIPTION
When neither fsname nor FUSE subtype is specified, libfuse will
default to using "/dev/fuse" as the underlying device name for a
mounted FUSE filesystem.

This can cause some versions of systemd to infer a dependency upon the
dev-fuse.device unit, which is itself non-functional since the default
systemd udev rules do not set the "systemd" tag for the /dev/fuse
device node (see https://github.com/systemd/systemd/pull/20236).  On
Fedora 34, this causes CVMFS mounts to fail due to a timeout waiting
for the underlying dev-fuse.device unit.

When using /sbin/mount.cvmfs, the code in mount/mount.cvmfs.cc will
specify "-ofsname=cvmfs2" (as a means of differentiating "private
mounts" from "system mounts").  This happens to avoid triggering the
systemd bug, since it prevents libfuse from falling back to using
"/dev/fuse" as the underlying device name.

Extend the fstab entries generated for the read-only branch of
server-side mounts to include the fsname option, using the repository
name rather than "cvmfs2" in order to maintain the differentiation
between "private mounts" and "system mounts".  This changes the entry
in /proc/mounts from e.g.

  /dev/fuse on /var/spool/cvmfs/test.repo.org/rdonly type fuse

to

  test.repo.org on /var/spool/cvmfs/test.repo.org/rdonly type fuse

and results in systemd no longer inferring a (broken) dependency upon
dev-fuse.device for these mount points.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>