### PR TITLE
Use "setcap -v" rather than "getcap" to verify capabilities

### DIFF
--- a/test/src/585-xattrs/main
+++ b/test/src/585-xattrs/main
@@ -10,7 +10,6 @@ verify_xattrs() {
   # local attr2=$(attr -qg x /cvmfs/$CVMFS_TEST_REPO/link)
   local attr3=$(attr -qg foo2 /cvmfs/$CVMFS_TEST_REPO/dir/xattr)
   local attr4=$(attr -qg baz /cvmfs/$CVMFS_TEST_REPO/dir)
-  local cap=$(getcap /cvmfs/$CVMFS_TEST_REPO/dir/capabilities)
   if [ "x$attr1" != "xbar" ]; then
     return 20
   fi
@@ -23,9 +22,7 @@ verify_xattrs() {
   if [ "x$attr4" != "xBAZ" ]; then
     return 23
   fi
-  if [ "x$cap" != "x/cvmfs/$CVMFS_TEST_REPO/dir/capabilities = cap_chown+ep" ]; then
-    return 24
-  fi
+  setcap -q -v "cap_chown=ep" /cvmfs/$CVMFS_TEST_REPO/dir/capabilities || return 24
 
   return 0
 }


### PR DESCRIPTION
The format of the output from "getcap" was changed in libcap commit
177cd41 ("A more compact form for the text representation of
capabilities").  Test 585 currently expects the output:

  /cvmfs/test.cern.ch/dir/capabilities = cap_chown+ep

but any version of libcap from version 2.41 onwards will instead
produce:

  /cvmfs/test.cern.ch/dir/capabilities cap_chown=ep

Fix by using "setcap -v" to verify the capability set, since this
method does not depend on the precise "getcap" output format.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>