### PR TITLE
Allow use of proxy server by publisher and gateway machines

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1538,7 +1538,6 @@ DownloadManager::DownloadManager() {
   enable_info_header_ = false;
   opt_ipv4_only_ = false;
   follow_redirects_ = false;
-  use_system_proxy_ = false;
 
   resolver_ = NULL;
 
@@ -1592,7 +1591,6 @@ void DownloadManager::FiniHeaders() {
 
 
 void DownloadManager::Init(const unsigned max_pool_handles,
-                           const bool use_system_proxy,
                            perf::StatisticsTemplate statistics)
 {
   atomic_init32(&multi_threaded_);
@@ -1637,16 +1635,6 @@ void DownloadManager::Init(const unsigned max_pool_handles,
   resolver_ = dns::NormalResolver::Create(opt_ipv4_only_,
     kDnsDefaultRetries, kDnsDefaultTimeoutMs);
   assert(resolver_);
-
-  // Parsing environment variables
-  if (use_system_proxy) {
-    use_system_proxy_ = true;
-    if (getenv("http_proxy") == NULL) {
-      SetProxyChain("", "", kSetProxyRegular);
-    } else {
-      SetProxyChain(string(getenv("http_proxy")), "", kSetProxyRegular);
-    }
-  }
 }
 
 
@@ -2726,7 +2714,7 @@ void DownloadManager::UseSystemCertificatePath() {
  */
 DownloadManager *DownloadManager::Clone(perf::StatisticsTemplate statistics) {
   DownloadManager *clone = new DownloadManager();
-  clone->Init(pool_max_handles_, use_system_proxy_, statistics);
+  clone->Init(pool_max_handles_, statistics);
   if (resolver_) {
     clone->SetDnsParameters(resolver_->retries(), resolver_->timeout_ms());
     clone->SetDnsTtlLimits(resolver_->min_ttl(), resolver_->max_ttl());

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -397,7 +397,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   static int ParseHttpCode(const char digits[3]);
 
   void Init(const unsigned max_pool_handles,
-            const bool use_system_proxy,
             perf::StatisticsTemplate statistics);
   void Fini();
   void Spawn();
@@ -515,7 +514,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool enable_info_header_;
   bool opt_ipv4_only_;
   bool follow_redirects_;
-  bool use_system_proxy_;
 
   // Host list
   std::vector<std::string> *opt_host_chain_;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1259,8 +1259,7 @@ bool MountPoint::CreateCatalogManager() {
 bool MountPoint::CreateDownloadManagers() {
   string optarg;
   download_mgr_ = new download::DownloadManager();
-  const bool use_system_proxy = false;
-  download_mgr_->Init(kDefaultNumConnections, use_system_proxy,
+  download_mgr_->Init(kDefaultNumConnections,
                       perf::StatisticsTemplate("download", statistics_));
   download_mgr_->SetCredentialsAttachment(authz_attachment_);
 

--- a/cvmfs/notify/cmd_pub.cc
+++ b/cvmfs/notify/cmd_pub.cc
@@ -23,7 +23,6 @@ const LogFacilities& kLogInfo = DefaultLogging::info;
 const LogFacilities& kLogError = DefaultLogging::error;
 
 const int kMaxPoolHandles = 1;
-const bool kUseSystemProxy = true;
 const unsigned kDownloadTimeout = 60;  // 1 minute
 const unsigned kDownloadRetries = 1;   // 2 attempts in total
 
@@ -51,7 +50,7 @@ int DoPublish(const std::string& server_url, const std::string& repository_url,
     UniquePtr<download::DownloadManager> download_manager(
         new download::DownloadManager());
     assert(download_manager.IsValid());
-    download_manager->Init(kMaxPoolHandles, kUseSystemProxy,
+    download_manager->Init(kMaxPoolHandles,
                            perf::StatisticsTemplate("download", &stats));
 
     download_manager->SetTimeout(kDownloadTimeout, kDownloadTimeout);

--- a/cvmfs/notify/cmd_sub.cc
+++ b/cvmfs/notify/cmd_sub.cc
@@ -24,7 +24,6 @@ const LogFacilities& kLogInfo = DefaultLogging::info;
 const LogFacilities& kLogError = DefaultLogging::error;
 
 const int kMaxPoolHandles = 1;
-const bool kUseSystemProxy = true;
 
 class SwissknifeSubscriber : public notify::SubscriberSSE {
  public:
@@ -54,7 +53,7 @@ class SwissknifeSubscriber : public notify::SubscriberSSE {
       return false;
     }
 
-    dl_mgr_->Init(kMaxPoolHandles, kUseSystemProxy,
+    dl_mgr_->Init(kMaxPoolHandles,
                   perf::StatisticsTemplate("download", &stats_));
 
     std::string arg;

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -91,7 +91,7 @@ Repository::Repository(const SettingsRepository &settings)
       throw EPublish("cannot set X509_CERT_BUNDLE environment variable");
   }
   download_mgr_ = new download::DownloadManager();
-  download_mgr_->Init(16, false,
+  download_mgr_->Init(16,
                       perf::StatisticsTemplate("download", statistics_));
   download_mgr_->UseSystemCertificatePath();
 

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -94,6 +94,12 @@ Repository::Repository(const SettingsRepository &settings)
   download_mgr_->Init(16, false,
                       perf::StatisticsTemplate("download", statistics_));
   download_mgr_->UseSystemCertificatePath();
+
+  if (settings.proxy() != "") {
+    download_mgr_->SetProxyChain(settings.proxy(), "",
+                                 download::DownloadManager::kSetProxyBoth);
+  }
+
   try {
     DownloadRootObjects(settings.url(), settings.fqrn(), settings.tmp_dir());
   } catch (const EPublish& e) {

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -280,6 +280,7 @@ SettingsRepository::SettingsRepository(
   const SettingsPublisher &settings_publisher)
   : fqrn_(settings_publisher.fqrn())
   , url_(settings_publisher.url())
+  , proxy_(settings_publisher.proxy())
   , tmp_dir_(settings_publisher.transaction().spool_area().tmp_dir())
   , keychain_(settings_publisher.fqrn())
 {
@@ -290,6 +291,11 @@ SettingsRepository::SettingsRepository(
 void SettingsRepository::SetUrl(const std::string &url) {
   // TODO(jblomer): sanitiation, check availability
   url_ = url;
+}
+
+
+void SettingsRepository::SetProxy(const std::string &proxy) {
+  proxy_ = proxy;
 }
 
 
@@ -313,6 +319,7 @@ SettingsPublisher::SettingsPublisher(
   const SettingsRepository &settings_repository)
   : fqrn_(settings_repository.fqrn())
   , url_(settings_repository.url())
+  , proxy_(settings_repository.proxy())
   , owner_uid_(0)
   , owner_gid_(0)
   , whitelist_validity_days_(kDefaultWhitelistValidity)
@@ -329,6 +336,11 @@ SettingsPublisher::SettingsPublisher(
 void SettingsPublisher::SetUrl(const std::string &url) {
   // TODO(jblomer): sanitiation, check availability
   url_ = url;
+}
+
+
+void SettingsPublisher::SetProxy(const std::string &proxy) {
+  proxy_ = proxy;
 }
 
 
@@ -448,6 +460,8 @@ SettingsRepository SettingsBuilder::CreateSettingsRepository(
     settings.GetKeychain()->SetKeychainDir(arg);
   if (options_mgr_->GetValue("CVMFS_STRATUM0", &arg))
     settings.SetUrl(arg);
+  if (options_mgr_->GetValue("CVMFS_SERVER_PROXY", &arg))
+    settings.SetProxy(arg);
   // For a replica, the stratum 1 url is the "local" location, hence it takes
   // precedence over the stratum 0 url
   if (options_mgr_->GetValue("CVMFS_STRATUM1", &arg))
@@ -492,6 +506,8 @@ SettingsPublisher* SettingsBuilder::CreateSettingsPublisherFromSession() {
 
   std::string arg;
   settings_publisher->SetUrl(settings_publisher->GetReadOnlyXAttr("user.host"));
+  settings_publisher->SetProxy(
+    settings_publisher->GetReadOnlyXAttr("user.proxy"));
   if (omgr.GetValue("CVMFS_KEYS_DIR", &arg))
     settings_publisher->GetKeychain()->SetKeychainDir(arg);
   settings_publisher->GetTransaction()->SetLayoutRevision(

--- a/cvmfs/publish/settings.h
+++ b/cvmfs/publish/settings.h
@@ -354,17 +354,20 @@ class SettingsRepository {
   explicit SettingsRepository(const std::string &fqrn)
     : fqrn_(fqrn)
     , url_(std::string("http://localhost/cvmfs/") + fqrn_())
+    , proxy_("")
     , tmp_dir_("/tmp")
     , keychain_(fqrn)
   {}
   explicit SettingsRepository(const SettingsPublisher &settings_publisher);
 
   void SetUrl(const std::string &url);
+  void SetProxy(const std::string &proxy);
   void SetTmpDir(const std::string &tmp_dir);
   void SetCertBundle(const std::string &cert_bundle);
 
   std::string fqrn() const { return fqrn_(); }
   std::string url() const { return url_(); }
+  std::string proxy() const { return proxy_(); }
   std::string tmp_dir() const { return tmp_dir_(); }
   std::string cert_bundle() const { return cert_bundle_(); }
 
@@ -374,6 +377,7 @@ class SettingsRepository {
  private:
   Setting<std::string> fqrn_;
   Setting<std::string> url_;
+  Setting<std::string> proxy_;
   Setting<std::string> tmp_dir_;
   // Currently only used for testing, steered by X509_CERT_BUNDLE
   // in /etc/cvmfs/server.local
@@ -393,6 +397,7 @@ class SettingsPublisher {
   explicit SettingsPublisher(const std::string &fqrn)
     : fqrn_(fqrn)
     , url_(std::string("http://localhost/cvmfs/") + fqrn)
+    , proxy_("")
     , owner_uid_(0)
     , owner_gid_(0)
     , whitelist_validity_days_(kDefaultWhitelistValidity)
@@ -405,6 +410,7 @@ class SettingsPublisher {
   explicit SettingsPublisher(const SettingsRepository &settings_repository);
 
   void SetUrl(const std::string &url);
+  void SetProxy(const std::string &proxy);
   void SetOwner(const std::string &user_name);
   void SetOwner(uid_t uid, gid_t gid);
   void SetIsSilent(bool value);
@@ -414,6 +420,7 @@ class SettingsPublisher {
 
   std::string fqrn() const { return fqrn_(); }
   std::string url() const { return url_(); }
+  std::string proxy() const { return proxy_(); }
   unsigned whitelist_validity_days() const {
     return whitelist_validity_days_();
   }
@@ -432,6 +439,7 @@ class SettingsPublisher {
  private:
   Setting<std::string> fqrn_;
   Setting<std::string> url_;
+  Setting<std::string> proxy_;
   Setting<uid_t> owner_uid_;
   Setting<gid_t> owner_gid_;
   Setting<unsigned> whitelist_validity_days_;

--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -37,6 +37,10 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
     return false;
   }
 
+  if (parser.IsDefined("CVMFS_SERVER_PROXY")) {
+    parser.GetValue("CVMFS_SERVER_PROXY", &params->proxy);
+  }
+
   // Note: TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE is used to provide an
   //       an overriding value for CVMFS_UPSTREAM_STORAGE, to be used
   //       only by the cvmfs_receiver application. Useful for testing

--- a/cvmfs/receiver/params.h
+++ b/cvmfs/receiver/params.h
@@ -16,6 +16,7 @@ std::string GetSpoolerTempDir(const std::string& spooler_config);
 
 struct Params {
   std::string stratum0;
+  std::string proxy;
   std::string spooler_configuration;
   shash::Algorithms hash_alg;
   std::string hash_alg_str;

--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -1002,6 +1002,9 @@ void S3FanoutManager::SetUrlOptions(JobInfo *info) const {
   string url = MkUrl(info->object_key);
   retval = curl_easy_setopt(curl_handle, CURLOPT_URL, url.c_str());
   assert(retval == CURLE_OK);
+
+  retval = curl_easy_setopt(curl_handle, CURLOPT_PROXY, config_.proxy.c_str());
+  assert(retval == CURLE_OK);
 }
 
 

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -206,6 +206,7 @@ class S3FanoutManager : SingleCopy {
     unsigned opt_max_retries;
     unsigned opt_backoff_init_ms;
     unsigned opt_backoff_max_ms;
+    std::string proxy;
   };
 
   static void DetectThrottleIndicator(const std::string &header, JobInfo *info);

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -50,7 +50,7 @@ wait_for_apache() {
   local now=$(date +%s)
   local deadline=$(($now + 60))
   while [ $now -lt $deadline ]; do
-    if curl -f -I --max-time 10 $(get_x509_cert_settings) \
+    if curl -f -I --max-time 10 $(get_curl_proxy) $(get_x509_cert_settings) \
        $(get_follow_http_redirects_flag) "$url" >/dev/null 2>&1;
     then
       return 0
@@ -70,7 +70,7 @@ check_url() {
 
   curl -f -I --max-time $timeout \
     --retry 2 --retry-delay 5 \
-    $(get_x509_cert_settings) \
+    $(get_curl_proxy) $(get_x509_cert_settings) \
     $(get_follow_http_redirects_flag) "$url" >/dev/null 2>&1
 }
 

--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -147,7 +147,7 @@ __check_repair_reflog() {
   if $user_shell "$(__swissknife_cmd) peek -d .cvmfsreflog -r $CVMFS_UPSTREAM_STORAGE" >/dev/null; then
     has_reflog=1
     local url="$repository_url/.cvmfsreflog"
-    local rehash_cmd="curl -sS --fail --connect-timeout 10 --max-time 300 $url \
+    local rehash_cmd="curl -sS --fail --connect-timeout 10 --max-time 300 $(get_curl_proxy) $url \
       | cvmfs_publish hash -a ${CVMFS_HASH_ALGORITHM:-sha1}"
     computed_checksum="$($user_shell "$rehash_cmd")"
     echo "Info: found $url with content hash $computed_checksum"

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -503,21 +503,15 @@ is_due_auto_garbage_collection() {
 # download a given file from the backend storage
 # @param name  the name of the repository to download from
 # @param url   the url to download from
-# @param noproxy  (optional)
 get_item() {
   local name="$1"
   local url="$2"
-  local noproxy="$3"
 
   load_repo_config $name
 
-  if [ x"$noproxy" != x"" ]; then
-    unset http_proxy && curl -f $(get_x509_cert_settings) \
-      $(get_follow_http_redirects_flag) "$url" 2>/dev/null | tr -d '\0'
-  else
-    curl -f $(get_x509_cert_settings) $(get_follow_http_redirects_flag) \
-      "$url" 2>/dev/null | tr -d '\0'
-  fi
+  curl -f -H "Cache-Control: max-age=0" \
+       $(get_x509_cert_settings) $(get_follow_http_redirects_flag) \
+       "$url" 2>/dev/null | tr -d '\0'
 }
 
 # read an item from local or backend repository storage to stdout
@@ -534,9 +528,9 @@ read_repo_item() {
   if is_local_upstream $CVMFS_UPSTREAM_STORAGE; then
     cat $(get_upstream_config $CVMFS_UPSTREAM_STORAGE)/"$item" 2>/dev/null
   elif is_stratum0 $name; then
-    get_item $name $CVMFS_STRATUM0/"$item" noproxy
+    get_item $name $CVMFS_STRATUM0/"$item"
   else
-    get_item $name $CVMFS_STRATUM1/"$item" noproxy
+    get_item $name $CVMFS_STRATUM1/"$item"
   fi
 }
 
@@ -587,7 +581,7 @@ get_expiry_from_string() {
 get_expiry() {
   local name=$1
   local stratum0=$2
-  get_expiry_from_string "$(get_item $name $stratum0/.cvmfswhitelist 'noproxy')"
+  get_expiry_from_string "$(get_item $name $stratum0/.cvmfswhitelist)"
 }
 
 

--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -66,10 +66,11 @@ cvmfs_server_import() {
   local configure_apache=1
   local recreate_repo_key=0
   local require_masterkeycard=0
+  local proxy_url
 
   # parameter handling
   OPTIND=1
-  while getopts "w:o:c:u:k:lsmgf:rptR" option; do
+  while getopts "w:o:c:u:k:lsmgf:rptRx:" option; do
     case $option in
       w)
         stratum0=$OPTARG
@@ -113,6 +114,9 @@ cvmfs_server_import() {
       R)
         recreate_whitelist=1
         require_masterkeycard=1
+      ;;
+      x)
+        proxy_url=$OPTARG
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -222,7 +226,8 @@ cvmfs_server_import() {
                                          "default"           \
                                          "false"             \
                                          ""                  \
-                                         "" || die "fail!"
+                                         ""                  \
+                                         "$proxy_url" || die "fail!"
   echo "done"
 
   # import the old repository security keys

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -103,10 +103,11 @@ cvmfs_server_mkfs() {
 
   local configure_apache=1
   local voms_authz=""
+  local proxy_url
 
   # parameter handling
   OPTIND=1
-  while getopts "Xw:u:o:mf:vgG:a:zs:k:pRV:Z:" option; do
+  while getopts "Xw:u:o:mf:vgG:a:zs:k:pRV:Z:x:" option; do
     case $option in
       X)
         external_data=true
@@ -158,6 +159,9 @@ cvmfs_server_mkfs() {
       ;;
       V)
         voms_authz=$OPTARG
+      ;;
+      x)
+        proxy_url=$OPTARG
       ;;
       ?)
         shift $(($OPTIND-2))
@@ -276,7 +280,8 @@ cvmfs_server_mkfs() {
                                          "$compression_alg"     \
                                          "$external_data"       \
                                          "$voms_authz"          \
-                                         "$auto_tag_timespan" || die "fail"
+                                         "$auto_tag_timespan"   \
+                                         "$proxy_url" || die "fail"
   echo "done"
 
   # create or import security keys and certificates

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -205,6 +205,7 @@ cvmfs_server_publish() {
         -N $name                                       \
         -K $CVMFS_PUBLIC_KEY                           \
         $(get_follow_http_redirects_flag)              \
+        $(get_swissknife_proxy)                        \
         $authz_file                                    \
         $log_level $tweaks_option $external_option $direct_io_option $verbosity"
 
@@ -309,6 +310,7 @@ cvmfs_server_publish() {
       -p /etc/cvmfs/keys/${name}.pub                    \
       -f $name                                          \
       -e $hash_algorithm                                \
+      $(get_swissknife_proxy)                           \
       $(get_follow_http_redirects_flag)"
     if ! is_checked_out $name; then
       # enables magic undo tag handling

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1125,6 +1125,7 @@ Supported Commands:
                   [-k path to existing keychain] [-p no apache config]
                   [-R require masterkeycard key ]
                   [-V VOMS authorization] [-X (external data)]
+                  [-x proxy url]
                   <fully qualified repository name>
                   Creates a new repository with a given name
   add-replica     [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
@@ -1139,6 +1140,7 @@ Supported Commands:
                   [-k path to keys] [-g chown backend] [-r recreate whitelist]
                   [-p no apache config] [-t recreate repo key and certificate]
                   [ -R recreate whitelist and require masterkeycard ]
+                  [-x proxy url]
                   <fully qualified repository name>
                   Imports an old CernVM-FS repository into a fresh repo
   publish         [-p pause for tweaks] [-n manual revision number] [-v verbose]

--- a/cvmfs/server_tool.cc
+++ b/cvmfs/server_tool.cc
@@ -19,6 +19,7 @@ ServerTool::~ServerTool() {
 }
 
 bool ServerTool::InitDownloadManager(const bool follow_redirects,
+                                     const std::string &proxy,
                                      const unsigned max_pool_handles,
                                      const bool use_system_proxy) {
   if (download_manager_.IsValid()) {
@@ -33,6 +34,11 @@ bool ServerTool::InitDownloadManager(const bool follow_redirects,
   download_manager_->SetTimeout(kDownloadTimeout, kDownloadTimeout);
   download_manager_->SetRetryParameters(kDownloadRetries, 2000, 5000);
   download_manager_->UseSystemCertificatePath();
+
+  if (proxy != "") {
+    download_manager_->SetProxyChain(proxy, "",
+                                     download::DownloadManager::kSetProxyBoth);
+  }
 
   if (follow_redirects) {
     download_manager_->EnableRedirects();

--- a/cvmfs/server_tool.cc
+++ b/cvmfs/server_tool.cc
@@ -20,15 +20,14 @@ ServerTool::~ServerTool() {
 
 bool ServerTool::InitDownloadManager(const bool follow_redirects,
                                      const std::string &proxy,
-                                     const unsigned max_pool_handles,
-                                     const bool use_system_proxy) {
+                                     const unsigned max_pool_handles) {
   if (download_manager_.IsValid()) {
     return true;
   }
 
   download_manager_ = new download::DownloadManager();
   assert(download_manager_.IsValid());
-  download_manager_->Init(max_pool_handles, use_system_proxy,
+  download_manager_->Init(max_pool_handles,
                           perf::StatisticsTemplate("download", statistics()));
 
   download_manager_->SetTimeout(kDownloadTimeout, kDownloadTimeout);

--- a/cvmfs/server_tool.h
+++ b/cvmfs/server_tool.h
@@ -20,6 +20,7 @@ class ServerTool {
   virtual ~ServerTool();
 
   bool InitDownloadManager(const bool follow_redirects,
+                           const std::string &proxy = "",
                            const unsigned max_pool_handles = 1,
                            const bool use_system_proxy = true);
   bool InitVerifyingSignatureManager(const std::string &pubkey_path,

--- a/cvmfs/server_tool.h
+++ b/cvmfs/server_tool.h
@@ -21,8 +21,7 @@ class ServerTool {
 
   bool InitDownloadManager(const bool follow_redirects,
                            const std::string &proxy = "",
-                           const unsigned max_pool_handles = 1,
-                           const bool use_system_proxy = true);
+                           const unsigned max_pool_handles = 1);
   bool InitVerifyingSignatureManager(const std::string &pubkey_path,
                                      const std::string &trusted_certs = "");
   bool InitSigningSignatureManager(const std::string &certificate_path,

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -30,6 +30,7 @@ SigningTool::Result SigningTool::Run(
     const std::string &certificate, const std::string &priv_key,
     const std::string &repo_name, const std::string &pwd,
     const std::string &meta_info, const std::string &reflog_chksum_path,
+    const std::string &proxy,
     const bool garbage_collectable, const bool bootstrap_shortcuts,
     const bool return_early, const std::vector<shash::Any> reflog_catalogs) {
   shash::Any reflog_hash;
@@ -50,7 +51,7 @@ SigningTool::Result SigningTool::Run(
 
   // prepare global manager modules
   const bool follow_redirects = false;
-  if (!server_tool_->InitDownloadManager(follow_redirects) ||
+  if (!server_tool_->InitDownloadManager(follow_redirects, proxy) ||
       !server_tool_->InitSigningSignatureManager(certificate, priv_key, pwd)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to init repo connection");
     return kInitError;

--- a/cvmfs/signing_tool.h
+++ b/cvmfs/signing_tool.h
@@ -38,6 +38,7 @@ class SigningTool {
              const std::string &repo_name = "", const std::string &pwd = "",
              const std::string &meta_info = "",
              const std::string &reflog_chksum_path = "",
+             const std::string &proxy = "",
              const bool garbage_collectable = false,
              const bool bootstrap_shortcuts = false,
              const bool return_early = false,

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -39,6 +39,7 @@ static void InsertCommonParameters(ParameterList *r) {
       Parameter::Optional('e', "hash algorithm to use (default SHA1)"));
   r->push_back(Parameter::Switch('L', "follow HTTP redirects"));
   r->push_back(Parameter::Optional('P', "session_token_file"));
+  r->push_back(Parameter::Optional('@', "proxy url"));
 }
 
 CommandTag::Environment *CommandTag::InitializeEnvironment(
@@ -120,7 +121,9 @@ CommandTag::Environment *CommandTag::InitializeEnvironment(
 
   // initialize the (swissknife global) download manager
   const bool follow_redirects = (args.count('L') > 0);
-  if (!this->InitDownloadManager(follow_redirects)) {
+  const std::string &proxy = (args.count('@') > 0) ?
+                              *args.find('@')->second : "";
+  if (!this->InitDownloadManager(follow_redirects, proxy)) {
     return NULL;
   }
 

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -49,6 +49,7 @@ ParameterList CommandInfo::GetParams() const {
   r.push_back(Parameter::Mandatory('r', "repository directory / url"));
   r.push_back(Parameter::Optional('u', "repository mount point"));
   r.push_back(Parameter::Optional('l', "log level (0-4, default: 2)"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   r.push_back(Parameter::Switch('c', "show root catalog hash"));
   r.push_back(Parameter::Switch('C', "show mounted root catalog hash"));
   r.push_back(Parameter::Switch('n', "show fully qualified repository name"));
@@ -96,7 +97,9 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
 
   if (IsRemote(repository)) {
     const bool follow_redirects = args.count('L') > 0;
-    if (!this->InitDownloadManager(follow_redirects)) {
+    const string proxy =
+      (args.find('@') != args.end()) ? *args.find('@')->second : "";
+    if (!this->InitDownloadManager(follow_redirects, proxy)) {
       return 1;
     }
   }

--- a/cvmfs/swissknife_letter.cc
+++ b/cvmfs/swissknife_letter.cc
@@ -126,7 +126,9 @@ int swissknife::CommandLetter::Main(const swissknife::ArgumentList &args) {
 
     const bool     follow_redirects = false;
     const unsigned max_pool_handles = 2;
-    if (!this->InitDownloadManager(follow_redirects, max_pool_handles)) {
+    const string proxy =
+      (args.find('@') != args.end()) ? *args.find('@')->second : "";
+    if (!this->InitDownloadManager(follow_redirects, proxy, max_pool_handles)) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to init repo connection");
       return 2;
     }

--- a/cvmfs/swissknife_letter.h
+++ b/cvmfs/swissknife_letter.h
@@ -32,6 +32,7 @@ class CommandLetter : public Command {
     r.push_back(Parameter::Optional('r', "repository url"));
     r.push_back(Parameter::Switch('e', "Erlang mode (stay active)"));
     r.push_back(Parameter::Optional('t', "text to sign or verify"));
+    r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Mandatory('f', "fully qualified repository name"));
     return r;
   }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -581,8 +581,10 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
 
   const bool     follow_redirects = false;
   const unsigned max_pool_handles = num_parallel+1;
+  const string proxy =
+      (args.find('@') != args.end()) ? *args.find('@')->second : "";
 
-  if (!this->InitDownloadManager(follow_redirects, max_pool_handles)) {
+  if (!this->InitDownloadManager(follow_redirects, proxy, max_pool_handles)) {
     return 1;
   }
 

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -42,6 +42,7 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional('a', "number of retries"));
     r.push_back(Parameter::Optional('d', "directory for path specification"));
     r.push_back(Parameter::Optional('Z', "pull revisions younger than <Z>"));
+    r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Switch('p', "pull catalog history, too"));
     r.push_back(Parameter::Switch('i', "mark as an 'initial snapshot'"));
     r.push_back(Parameter::Switch('c', "preload cache instead of stratum 1"));

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -51,6 +51,8 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   if (args.find('s') != args.end()) pwd = *args.find('s')->second;
   string meta_info = "";
   if (args.find('M') != args.end()) meta_info = *args.find('M')->second;
+  string proxy = "";
+  if (args.find('@') != args.end()) proxy = *args.find('@')->second;
   const bool garbage_collectable = (args.count('g') > 0);
   const bool bootstrap_shortcuts = (args.count('A') > 0);
   const bool return_early = (args.count('e') > 0);
@@ -64,6 +66,6 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   SigningTool signing_tool(this);
   return signing_tool.Run(manifest_path, repo_url, spooler_definition, temp_dir,
                           certificate, priv_key, repo_name, pwd, meta_info,
-                          reflog_chksum_path, garbage_collectable,
+                          reflog_chksum_path, proxy, garbage_collectable,
                           bootstrap_shortcuts, return_early);
 }

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -34,6 +34,7 @@ class CommandSign : public Command {
     r.push_back(Parameter::Optional('s', "password for the private key"));
     r.push_back(Parameter::Optional('n', "repository name"));
     r.push_back(Parameter::Optional('M', "repository meta info file"));
+    r.push_back(Parameter::Optional('@', "proxy URL"));
     r.push_back(Parameter::Switch('b',
                                   "generate symlinks for VOMS-secured "
                                   "repo backends"));

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -758,7 +758,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   if (!spooler_catalogs.IsValid()) return 3;
 
   const bool follow_redirects = (args.count('L') > 0);
-  if (!InitDownloadManager(follow_redirects)) {
+  const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+  if (!InitDownloadManager(follow_redirects, proxy)) {
     return 3;
   }
 

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -315,6 +315,7 @@ class CommandSync : public Command {
 
     r.push_back(Parameter::Optional('P', "session_token_file"));
     r.push_back(Parameter::Optional('H', "key file for HTTP API"));
+    r.push_back(Parameter::Optional('@', "proxy URL"));
 
     return r;
   }

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -39,6 +39,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   , authz_method_(s3fanout::kAuthzAwsV2)
   , peek_before_put_(true)
   , use_https_(false)
+  , proxy_("")
   , temporary_path_(spooler_definition.temporary_path)
 {
   assert(spooler_definition.IsValid() &&
@@ -69,6 +70,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   } else {
     s3config.protocol = "http";
   }
+  s3config.proxy = proxy_;
 
   s3fanout_mgr_ = new s3fanout::S3FanoutManager(s3config);
   s3fanout_mgr_->Spawn();
@@ -173,6 +175,10 @@ bool S3Uploader::ParseSpoolerDefinition(
     host_name_port_ = host_name_ + ":" + parameter;
   } else {
     host_name_port_ = host_name_;
+  }
+
+  if (options_manager.IsDefined("CVMFS_S3_PROXY")) {
+    options_manager.GetValue("CVMFS_S3_PROXY", &proxy_);
   }
 
   return true;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -131,6 +131,7 @@ class S3Uploader : public AbstractUploader {
   s3fanout::AuthzMethods authz_method_;
   bool peek_before_put_;
   bool use_https_;
+  std::string proxy_;
 
   const std::string temporary_path_;
   mutable atomic_int32 io_errors_;

--- a/cvmfs/wpad.cc
+++ b/cvmfs/wpad.cc
@@ -279,7 +279,7 @@ int MainResolveProxyDescription(int argc, char **argv) {
   string host_list = argv[3];
 
   DownloadManager download_manager;
-  download_manager.Init(1, false, perf::StatisticsTemplate("pac", &statistics));
+  download_manager.Init(1, perf::StatisticsTemplate("pac", &statistics));
   download_manager.SetHostChain(host_list);
   string resolved_proxies = ResolveProxyDescription(proxy_configuration, "",
                                                     &download_manager);

--- a/test/src/685-mkfs_proxy/main
+++ b/test/src/685-mkfs_proxy/main
@@ -1,0 +1,69 @@
+cvmfs_test_name="Create repository with a server-side proxy"
+cvmfs_test_autofs_on_startup=false
+
+cleanup() {
+  echo "running cleanup"
+
+  echo "remove proxy"
+  local apache_config_file="$(get_apache_config_filename mkfs_proxy)"
+  remove_apache_config_file "$apache_config_file"
+  apache_switch off > /dev/null
+  apache_switch on  > /dev/null
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+
+  local reponame=test.repo.org
+  local repodir=/cvmfs/${reponame}
+  local repoconf=/etc/cvmfs/repositories.d/${reponame}/server.conf
+
+  echo "register cleanup trap"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "create proxy"
+  local apache_config_file="$(get_apache_config_filename mkfs_proxy)"
+  create_apache_config_file $apache_config_file << 'EOF'
+# Created by test case 685.  Don't touch.
+Listen 127.0.0.1:8081
+<VirtualHost 127.0.0.1:8081>
+  ProxyRequests On
+  <Proxy "*">
+  </Proxy>
+</VirtualHost>
+EOF
+  apache_switch off > /dev/null
+  apache_switch on  > /dev/null
+
+  echo "create repository"
+  create_repo ${reponame} $(whoami) ${logfile} -x http://127.0.0.1:8081 || return 10
+
+  echo "start transaction"
+  cvmfs_server transaction ${reponame} || return 21
+
+  echo "create test files"
+  echo "hello world" > ${repodir}/hw.txt
+
+  echo "publish and check"
+  cvmfs_server publish -v ${reponame} || return 22
+  cvmfs_server check -i ${reponame} || return 23
+
+  echo "break proxy"
+  create_apache_config_file $apache_config_file << 'EOF'
+# Created by test case 685.  Don't touch.
+Listen 127.0.0.1:8081
+<VirtualHost 127.0.0.1:8081>
+  ProxyRequests On
+  <Proxy "*">
+    Require all denied
+  </Proxy>
+</VirtualHost>
+EOF
+  apache_switch off > /dev/null
+  apache_switch on  > /dev/null
+
+  echo "attempt transaction via broken proxy"
+  cvmfs_server transaction ${reponame} && return 31
+
+  return 0
+}

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -30,7 +30,7 @@ class T_Download : public FileSandbox {
 
  protected:
   virtual void SetUp() {
-    download_mgr.Init(8, false, /* use_system_proxy */
+    download_mgr.Init(8,
       perf::StatisticsTemplate("test", &statistics));
 
     CreateSandbox();
@@ -164,7 +164,7 @@ TEST_F(T_Download, Multiple) {
   string src_url = "file://" + src_path;
 
   DownloadManager second_mgr;
-  second_mgr.Init(8, false, /* use_system_proxy */
+  second_mgr.Init(8,
     perf::StatisticsTemplate("second", &statistics));
 
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -70,7 +70,7 @@ class T_Fetcher : public ::testing::Test {
     ASSERT_TRUE(cache_mgr_ != NULL);
 
     download_mgr_ = new download::DownloadManager();
-    download_mgr_->Init(8, false, /* use_system_proxy */
+    download_mgr_->Init(8,
       perf::StatisticsTemplate("test", &statistics_));
     download_mgr_->SetHostChain("file://" + tmp_path_);
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -346,7 +346,7 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void InitializeExternalManagers() {
-    download_manager_.Init(1, true,
+    download_manager_.Init(1,
       perf::StatisticsTemplate("test", &statistics_));
     signature_manager_.Init();
     ASSERT_TRUE(signature_manager_.LoadPublicRsaKeys(public_key_path));


### PR DESCRIPTION
This patch series adds the ability to specify a proxy server to be used by a publisher or gateway machine in order to download files from the Stratum 0 repository.

This is particularly useful when the Stratum 0 files are held in cloud storage such as AWS S3: it allows for the use of an authenticating proxy (to avoid exposing the S3 reader credentials directly to every client) and opens up the possibility of using the proxy to cache files uploaded by a publisher so that the gateway does not need to waste time immediately re-downloading those same files from the cloud storage.
