### PR TITLE
Treat HTTP 503 Service Unavailable as a possible proxy error

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -261,6 +261,17 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
   } else if (HasPrefix(header_line, "LOCATION:", true)) {
     // This comes along with redirects
     LogCvmfs(kLogDownload, kLogDebug, "%s", header_line.c_str());
+  } else if (HasPrefix(header_line, "X-SQUID-ERROR:", true)) {
+    // Reinterpret host error as proxy error
+    if (info->error_code == kFailHostHttp) {
+      info->error_code = kFailProxyHttp;
+    }
+  } else if (HasPrefix(header_line, "PROXY-STATUS:", true)) {
+    // Reinterpret host error as proxy error if applicable
+    if ((info->error_code == kFailHostHttp) &&
+        (header_line.find("error=") != string::npos)) {
+      info->error_code = kFailProxyHttp;
+    }
   }
 
   return num_bytes;

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -217,8 +217,8 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
       // libcurl will handle this because of CURLOPT_FOLLOWLOCATION
       return num_bytes;
     } else {
-      LogCvmfs(kLogDownload, kLogDebug, "http status error code: %s",
-               header_line.c_str());
+      LogCvmfs(kLogDownload, kLogDebug, "http status error code: %s [%d]",
+               header_line.c_str(), info->http_code);
       if (((info->http_code / 100) == 5) ||
           (info->http_code == 400) || (info->http_code == 404))
       {


### PR DESCRIPTION
Proxy servers such as Squid or Varnish will typically return an HTTP
503 Service Unavailable error when they are unable to connect to the
origin server.  CVMFS will currently treat HTTP 503 as a host error,
which will prevent the client from failing over to the next available
proxy server.

Fix by treating an HTTP 503 as a potential proxy error (as is
currently done for any unrecognised HTTP 4XX errors).
