### PR TITLE
[ducc] Fix authenticated requests to registries

### DIFF
--- a/ducc/CMakeLists.txt
+++ b/ducc/CMakeLists.txt
@@ -8,12 +8,12 @@ endif()
 
 add_custom_target(
   cvmfs_ducc ALL
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc  
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc
 )
 
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc  
-  COMMAND ${GO_COMPILER} build -mod=vendor -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc
+  COMMAND ${GO_COMPILER} build -mod=vendor -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc -ldflags='-X github.com/cvmfs/ducc/cmd.Version=${CernVM-FS_VERSION_STRING}'
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*
   COMMENT "Build ducc using the Go Compiler"

--- a/ducc/README.md
+++ b/ducc/README.md
@@ -16,7 +16,7 @@ common examples are:
 
 **Repository** This specifies a class of images, each image will be indexed,
 then by tag or digest. Common examples are:
- 
+
     * library/redis
     * library/ubuntu
 
@@ -101,7 +101,7 @@ input:
 **version**: indicate what version of recipe we are using, at the moment only
 `1` is supported.
 **user**: the user that will push the thin docker images into the registry,
-the password must be stored in the `DUCC_DOCKER_REGISTRY_PASS`
+the password must be stored in the `DUCC_OUTPUT_REGISTRY_PASS`
 environment variable.
 **cvmfs_repo**: in which CVMFS repository store the layers and the singularity
 images.
@@ -176,7 +176,7 @@ This section explains how this utility is intended to be used.
 
 Internally this utility invokes `cvmfs_server`, `docker` and `singularity`
 commands, so it is necessary to use it in a stratum0 that also have docker
-installed. 
+installed.
 
 The conversion is quite straightforward, we first download the input image, we
 store each layer on the cvmfs repository, we create the output image and unpack
@@ -186,7 +186,7 @@ It does not support dowloading images that are not public.
 
 In order to publish images to a registry is necessary to sign up in the
 docker hub. It will use the user from the recipe, while it will read the
-password from the `DUCC_DOCKER_REGISTRY_PASS` environment variable.
+password from the `DUCC_OUTPUT_REGISTRY_PASS` environment variable.
 
 ## Run as daemon
 
@@ -196,12 +196,12 @@ daemon DUCC will run the `loop` command.
 Environmental variables are used in order to provide input for DUCC. Two
 variables need to be set:
 1. `$DUCC_RECIPE_FILE`
-2. `$DUCC_DOCKER_REGISTRY_PASS`
+2. `$DUCC_OUTPUT_REGISTRY_PASS`
 
 The `$RECIPE_FILE` variable need to point to the recipe.yaml file that you want
 to convert.
 
-The `$DUCC_DOCKER_REGISTRY_PASS` is the variable described
+The `$DUCC_OUTPUT_REGISTRY_PASS` is the variable described
 above. It needs to be set to the password of the docker registry that DUCC will
 use to publish the docker images.
 
@@ -214,5 +214,5 @@ And then edit like the following:
 ```unit
 [Service]
 Environment="DUCC_RECIPE_FILE=UPDATE-ME.yaml"
-Environment="DUCC_DOCKER_REGISTRY_PASS=UPDATE-ME"
+Environment="DUCC_OUTPUT_REGISTRY_PASS=UPDATE-ME"
 ```

--- a/ducc/cmd/version.go
+++ b/ducc/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "2.8.0"
+var Version = "development"
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
@@ -17,6 +17,6 @@ var versionCmd = &cobra.Command{
 	Short:   "Print the version of ducc",
 	Aliases: []string{"v"},
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version)
+		fmt.Println(Version)
 	},
 }

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -629,7 +629,7 @@ func AlreadyConverted(manifestPath, reference string) ConversionResult {
 }
 
 func GetPassword() (string, error) {
-	envVar := "DUCC_DOCKER_REGISTRY_PASS"
+	envVar := "DUCC_OUTPUT_REGISTRY_PASS"
 	pass := os.Getenv(envVar)
 	if pass == "" {
 		err := fmt.Errorf(

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -633,7 +633,7 @@ func GetPassword() (string, error) {
 	pass := os.Getenv(envVar)
 	if pass == "" {
 		err := fmt.Errorf(
-			"Env variable (%s) storing the password to access the docker registry is not set", envVar)
+			"Env variable (%s) storing the password to push thin images is not set", envVar)
 		return "", err
 	}
 	return pass, nil

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -156,15 +156,6 @@ func (img *Image) GetOCIImage() (config image.Image, err error) {
 		return *img.OCIImage, nil
 	}
 
-	user := img.User
-	fmt.Printf("GetOCIImage %s\n", user)
-	pass, err := GetPassword()
-	if err != nil {
-		l.LogE(err).Warning("Unable to get the credential for downloading the configuration blog, trying anonymously")
-		user = ""
-		pass = ""
-	}
-
 	manifest, err := img.GetManifest()
 	if err != nil {
 		l.LogE(err).Warning("Impossible to retrieve the manifest of the image, not changes set")
@@ -172,7 +163,7 @@ func (img *Image) GetOCIImage() (config image.Image, err error) {
 	}
 	configUrl := fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
 		img.Scheme, img.Registry, img.Repository, manifest.Config.Digest)
-	token, err := firstRequestForAuth(configUrl, user, pass)
+	token, err := firstRequestForAuth(configUrl)
 	if err != nil {
 		l.LogE(err).Warning("Impossible to retrieve the token for getting the changes from the repository, not changes set")
 		return
@@ -265,15 +256,8 @@ func (img *Image) ExpandWildcard() (<-chan *Image, <-chan *Image, error) {
 	var tagsList struct {
 		Tags []string
 	}
-	fmt.Printf("ExpandWildcard %s\n", img.User)
-	pass, err := GetPassword()
-	if err != nil {
-		l.LogE(err).Warning("Unable to retrieve the password, trying to get the manifest anonymously.")
-		pass = ""
-	}
-	user := img.User
 	url := img.GetTagListUrl()
-	token, err := firstRequestForAuth(url, user, pass)
+	token, err := firstRequestForAuth(url)
 	if err != nil {
 		errF := fmt.Errorf("Error in authenticating for retrieving the tags: %s", err)
 		l.LogE(err).Error(errF)
@@ -371,28 +355,9 @@ func (i *Image) GetPublicSymlinkPath() string {
 }
 
 func (img *Image) getByteManifest() ([]byte, error) {
-	fmt.Printf("getByteManifest %s\n", img.User);
-	pass, err := GetPassword()
-	if err != nil {
-		l.LogE(err).Warning("Unable to retrieve the password, trying to get the manifest anonymously.")
-		return img.getAnonymousManifest()
-	}
-	return img.getManifestWithPassword(pass)
-}
-
-func (img *Image) getAnonymousManifest() ([]byte, error) {
-	return getManifestWithUsernameAndPassword(img, "", "")
-}
-
-func (img *Image) getManifestWithPassword(password string) ([]byte, error) {
-	return getManifestWithUsernameAndPassword(img, img.User, password)
-}
-
-func getManifestWithUsernameAndPassword(img *Image, user, pass string) ([]byte, error) {
-
 	url := img.GetManifestUrl()
 
-	token, err := firstRequestForAuth(url, user, pass)
+	token, err := firstRequestForAuth(url)
 	if err != nil {
 		l.LogE(err).Error("Error in getting the authentication token")
 		return nil, err
@@ -427,55 +392,35 @@ type Credentials struct {
 	password string
 }
 
-func getCredentialsFromEnv(user, pass string) (Credentials, error) {
-	fmt.Printf("getCredentialsFromEnv %s %s\n", user, pass);
-	u := os.Getenv(user)
-	p := os.Getenv(pass)
-	c := Credentials{u, p}
-	err := error(nil)
-	if user == "" || pass == "" {
-		err = fmt.Errorf("missing either username ($%s) or password ($%s) or both for accessing the docker registry", user, pass)
-	}
-	return c, err
-
-}
-
-func getDockerHubCredentials() (Credentials, error) {
-	fmt.Printf("getDockerHubCredentials\n")
-	return getCredentialsFromEnv("DUCC_DOCKERHUB_USER", "DUCC_DOCKERHUB_PASS")
-}
-
-func getGitlabContainersCredentials() (Credentials, error) {
-	fmt.Printf("getGitlabContainersCredentials\n")
-	return getCredentialsFromEnv("DUCC_GITLAB_REGISTRY_USER", "DUCC_GITLAB_REGISTRY_PASS")
-}
-
 func GetAuthToken(url string, credentials []Credentials) (token string, err error) {
-	if strings.Contains(url, "gitlab-registry.cern.ch") {
-		gitlab, err := getGitlabContainersCredentials()
-		if err == nil {
-			credentials = []Credentials{gitlab}
+	regs := os.Getenv("DUCC_AUTH_REGISTRIES")
+	for _, r := range strings.Split(regs, ",") {
+		if r == "" {
+			continue
 		}
-	}
-	if strings.Contains(url, "registry.hub.docker.com") {
-		docker, err := getDockerHubCredentials()
-		if err == nil {
-			credentials = []Credentials{docker}
+
+		iEnv := "DUCC_" + r + "_IDENT"
+		uEnv := "DUCC_" + r + "_USER"
+		uPass := "DUCC_" + r + "_PASS"
+		ident := os.Getenv(iEnv)
+		user := os.Getenv(uEnv)
+		pass := os.Getenv(uPass)
+		if user == "" || pass == "" || ident == "" {
+			err = fmt.Errorf("missing either $%s or $%s or $%s", uEnv, uPass, iEnv)
+			return "", err;
 		}
-	}
-	for _, c := range credentials {
-		fmt.Printf("Tryeing internal request with %s %s: %s\n", c.username, c.password, url)
-		token, err = firstRequestForAuth_internal(url, c.username, c.password)
-		if err == nil {
-			return token, err
+
+		if (!strings.Contains(url, ident)) {
+			continue
 		}
+
+		return firstRequestForAuth_internal(url, user, pass)
 	}
-	return token, err
+	return firstRequestForAuth_internal(url, "", "")
 }
 
-func firstRequestForAuth(url, user, pass string) (token string, err error) {
-	c := Credentials{user, pass}
-	credentials := []Credentials{c}
+func firstRequestForAuth(url string) (token string, err error) {
+	credentials := []Credentials{}
 	return GetAuthToken(url, credentials)
 }
 
@@ -675,17 +620,9 @@ func (img *Image) GetLayers(layersChan chan<- downloadedLayer, manifestChan chan
 }
 
 func (img *Image) downloadLayer(layer da.Layer, token string) (toSend downloadedLayer, err error) {
-	user := img.User
-	fmt.Printf("downloadLayer %s\n", user);
-	pass, err := GetPassword()
-	if err != nil {
-		l.LogE(err).Warning("Unable to retrieve the password, trying to get the layers anonymously.")
-		user = ""
-		pass = ""
-	}
 	layerUrl := getLayerUrl(img, layer.Digest)
 	if token == "" {
-		token, err = firstRequestForAuth(layerUrl, user, pass)
+		token, err = firstRequestForAuth(layerUrl)
 		if err != nil {
 			return
 		}
@@ -723,7 +660,7 @@ func (img *Image) downloadLayer(layer da.Layer, token string) (toSend downloaded
 			l.LogE(err).Warning("Received status code ", resp.StatusCode)
 			if resp.StatusCode == 401 {
 				// try to get the token again
-				newToken, errToken := firstRequestForAuth(layerUrl, user, pass)
+				newToken, errToken := firstRequestForAuth(layerUrl)
 				if errToken != nil {
 					l.LogE(errToken).Warning("Error in refreshing the token")
 				} else {
@@ -825,18 +762,10 @@ func (ld *LayerDownloader) getToken() (token string, err error) {
 	if err != nil {
 		return
 	}
-	user := ld.image.User
-	fmt.Printf("getToken %s\n", user);
-	pass, err := GetPassword()
-	if err != nil {
-		l.LogE(err).Warning("Unable to retrieve the password, trying to get the layers anonymously.")
-		user = ""
-		pass = ""
-	}
 
 	firstLayer := manifest.Layers[0]
 	layerUrl := getLayerUrl(ld.image, firstLayer.Digest)
-	token, err = firstRequestForAuth(layerUrl, user, pass)
+	token, err = firstRequestForAuth(layerUrl)
 	if err != nil {
 		return
 	}

--- a/ducc/lib/podman_store.go
+++ b/ducc/lib/podman_store.go
@@ -327,19 +327,10 @@ func (img *Image) CreateConfigFile(CVMFSRepo string) (err error) {
 	imageID := strings.Split(manifest.Config.Digest, ":")[1]
 	configFilePath := filepath.Join(rootPath, imageMetadataDir, imageID, fname)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
-		user := img.User
-		fmt.Printf("CreateConfigFile/podman %s", user);
-		pass, err := GetPassword()
-		if err != nil {
-			l.LogE(err).Warning("Unable to get the credential for downloading the configuration blob, trying anonymously")
-			user = ""
-			pass = ""
-		}
-
 		configUrl := fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
 			img.Scheme, img.Registry, img.Repository, manifest.Config.Digest)
 
-		token, err := firstRequestForAuth(configUrl, user, pass)
+		token, err := firstRequestForAuth(configUrl)
 		if err != nil {
 			l.LogE(err).Warning("Unable to retrieve the token for downloading config file")
 			return err

--- a/ducc/lib/podman_store.go
+++ b/ducc/lib/podman_store.go
@@ -328,6 +328,7 @@ func (img *Image) CreateConfigFile(CVMFSRepo string) (err error) {
 	configFilePath := filepath.Join(rootPath, imageMetadataDir, imageID, fname)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
 		user := img.User
+		fmt.Printf("CreateConfigFile/podman %s", user);
 		pass, err := GetPassword()
 		if err != nil {
 			l.LogE(err).Warning("Unable to get the credential for downloading the configuration blob, trying anonymously")

--- a/ducc/unitfiles/cvmfs_ducc.service.in
+++ b/ducc/unitfiles/cvmfs_ducc.service.in
@@ -5,7 +5,7 @@ Requires=dockerd.service
 
 [Service]
 Environment="DUCC_RECIPE_FILE=UPDATE-ME.yaml"
-Environment="DUCC_DOCKER_REGISTRY_PASS=UPDATE-ME"
+Environment="DUCC_OUTPUT_REGISTRY_PASS=UPDATE-ME"
 
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/cvmfs_ducc loop $RECIPE_FILE
 


### PR DESCRIPTION
Rename `DUCC_DOCKER_REGISTRY_PASS` --> `DUCC_OUTPUT_REGISTRY_PASS`.

Introduces `DUCC_AUTH_REGISTRIES=val1,val2,...` environment variable to
specify names of registries requiring user name and password. For each
$name from the list, there needs to be 3 environment variables

    DUCC_$name_USER
    DUCC_$name_PASS
    DUCC_$name_IDENT

The last one is a string that is used to identify URLs of that registry,
e.g. "registry.hub.docker.com".