### PR TITLE
Cleanup gateway tests

### DIFF
--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -127,7 +127,7 @@ fi
 if [ $CVMFS_TEST_GATEWAY = 1 ] && can_build_gateway; then
   echo "running gateway unit tests into $CVMFS_UNITTESTS_RESULT_LOCATION"
   pushd ${SCRIPT_LOCATION}/../gateway > /dev/null
-  go test -v -mod=vendor internal/... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway
+  go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway
   popd > /dev/null
 fi
 

--- a/gateway/internal/gateway/receiver/mock_receiver.go
+++ b/gateway/internal/gateway/receiver/mock_receiver.go
@@ -2,44 +2,61 @@ package receiver
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	gw "github.com/cvmfs/gateway/internal/gateway"
-	stats "github.com/cvmfs/gateway/internal/gateway/statistics"
 )
 
 // MockReceiver is a mocked implementation of the Receiver interface, for testing
 // Can implement fault injection
 type MockReceiver struct {
-	CvmfsReceiver
+	ctx context.Context
 }
 
 // NewMockReceiver constructs a new MockReceiver object which implements the
 // Receiver interface
-func NewMockReceiver(ctx context.Context, execPath string, args ...string) (Receiver, error) {
-	CvmfsReceiver, err := NewCvmfsReceiver(ctx, execPath, stats.NewStatisticsMgr(), args...)
-	// if some error happens, like the receiver code cannot be started,
-	// we want to handle it separately, otherwise it crash with Segmentation Fault.
-	if err != nil {
-		return &MockReceiver{}, err
-	}
-	return &MockReceiver{*CvmfsReceiver}, nil
+func NewMockReceiver(ctx context.Context) (Receiver, error) {
+	return &MockReceiver{ctx}, nil
+}
+
+func (r *MockReceiver) Quit() error {
+	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
+		Str("command", "quit").
+		Msg("worker process has stopped")
+	return nil
+}
+
+func (r *MockReceiver) Echo() error {
+	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
+		Str("command", "echo").
+		Msgf("reply: PID: 12345")
+	return nil
 }
 
 func (r *MockReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
-	gw.LogC(r.CvmfsReceiver.ctx, "mock receiver", gw.LogWarn).
-		Str("leaserPath", leasePath).
-		Msg("Requested commit agains a testing mock, shortcircuit success")
+	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
+		Str("command", "commit").
+		Str("lease_path", leasePath).
+		Msgf("new revision committed")
 	return 1, nil
 }
 
 func (r *MockReceiver) SubmitPayload(leasePath string, payload io.Reader, digest string, headerSize int) error {
-	gw.LogC(r.CvmfsReceiver.ctx, "mock receiver", gw.LogWarn).
-		Str("leaserPath", leasePath).
-		Msg("Requested submit agains a testing mock, shortcircuit success")
+	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
+		Str("command", "submit payload").
+		Str("lease_path", leasePath).
+		Msgf("payload submitted")
 	return nil
 }
 
 func (r *MockReceiver) Interrupt() error {
 	return nil
+}
+
+func (r *MockReceiver) TestCrash() error {
+	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
+		Str("command", "test crash").
+		Msgf("worker process is crashing")
+	return fmt.Errorf("mock receiver has crashed")
 }

--- a/gateway/internal/gateway/receiver/pool.go
+++ b/gateway/internal/gateway/receiver/pool.go
@@ -130,14 +130,6 @@ func (p *Pool) CommitLease(ctx context.Context, leasePath, oldRootHash, newRootH
 	return 0, result
 }
 
-// this is private, it is not enough to just make it private but it is a good start
-func (p *Pool) testCrash(ctx context.Context) error {
-	reply := make(chan error)
-	p.tasks <- testCrashTask{ctx, reply}
-	result := <-reply
-	return result
-}
-
 func worker(tasks <-chan task, pool *Pool, workerIdx int) {
 	gw.Log("worker_pool", gw.LogDebug).
 		Int("worker_id", workerIdx).

--- a/gateway/internal/gateway/receiver/receiver_test.go
+++ b/gateway/internal/gateway/receiver/receiver_test.go
@@ -1,15 +1,26 @@
+//go:build integration
+
 package receiver
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	stats "github.com/cvmfs/gateway/internal/gateway/statistics"
 )
 
+func getReceiverPath() string {
+	receiverPath := os.Getenv("CVMFS_RECEIVER_PATH")
+	if receiverPath == "" {
+		receiverPath = "/usr/bin/cvmfs_receiver"
+	}
+	return receiverPath
+}
+
 func TestReceiverCycle(t *testing.T) {
 	st := stats.NewStatisticsMgr()
-	receiver, err := NewReceiver(context.TODO(), "/usr/bin/cvmfs_receiver", true, st)
+	receiver, err := NewReceiver(context.TODO(), getReceiverPath(), false, st)
 	if err != nil {
 		t.Fatalf("could not start receiver: %v", err)
 	}
@@ -23,7 +34,7 @@ func TestReceiverCycle(t *testing.T) {
 }
 
 func TestReceiverOnCrashWeReturnError(t *testing.T) {
-	receiver, err := NewReceiver(context.TODO(), "/usr/bin/cvmfs_receiver", true, stats.NewStatisticsMgr())
+	receiver, err := NewReceiver(context.TODO(), getReceiverPath(), false, stats.NewStatisticsMgr())
 	if err != nil {
 		t.Fatalf("could not start receiver: %v", err)
 	}
@@ -38,7 +49,7 @@ func TestReceiverOnCrashWeReturnError(t *testing.T) {
 }
 
 func TestReceiverAfterCrashWeCanStillCallCommandAndTheyWillReturnAnError(t *testing.T) {
-	receiver, err := NewReceiver(context.TODO(), "/usr/bin/cvmfs_receiver", true, stats.NewStatisticsMgr())
+	receiver, err := NewReceiver(context.TODO(), getReceiverPath(), false, stats.NewStatisticsMgr())
 	if err != nil {
 		t.Fatalf("could not start receiver: %v", err)
 	}
@@ -59,8 +70,8 @@ func TestReceiverAfterCrashWeCanStillCallCommandAndTheyWillReturnAnError(t *test
 
 // reduntat test, but it mimic a problem we found in production.
 // after a crash the .Quit() was hanging
-func TestReceiverAfterCrashQuiteDoesNotHang(t *testing.T) {
-	receiver, err := NewReceiver(context.TODO(), "/usr/bin/cvmfs_receiver", true, stats.NewStatisticsMgr())
+func TestReceiverAfterCrashQuitDoesNotHang(t *testing.T) {
+	receiver, err := NewReceiver(context.TODO(), getReceiverPath(), false, stats.NewStatisticsMgr())
 	if err != nil {
 		t.Fatalf("could not start receiver: %v", err)
 	}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -14,7 +14,7 @@ import (
 var Version = "development"
 
 func main() {
-	fmt.Println("CernVM-FS Gateway Service Version:\t", Version, "\n")
+	fmt.Println("CernVM-FS Gateway Service Version:\t", Version)
 	gw.InitLogging(os.Stderr)
 	cfg, err := gw.ReadConfig()
 	if err != nil {


### PR DESCRIPTION
* Mock receiver implementation should not use the real `cvmfs_receiver` worker process
* Run tests using the real `cvmfs_receiver` worker process as integration tests (`INTEGRATION_TESTS=ON`)
* Point integration tests to a specific `cvmfs_receiver` process (`CVMFS_RECEIVER_PATH`). By default, `/usr/bin/cvmfs_receiver` is used.