### PR TITLE
Proxy sharding

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -2657,6 +2657,14 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
 }
 
 /**
+ * Enable proxy sharding
+ */
+void DownloadManager::ShardProxies() {
+  opt_proxy_shard_ = true;
+  RebalanceProxiesUnlocked("enable sharding");
+}
+
+/**
  * Selects a new random proxy in the current load-balancing group.  Resets the
  * "burned" counter.
  */

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -435,6 +435,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
                     unsigned *fallback_group);
   std::string GetProxyList();
   std::string GetFallbackProxyList();
+  void ShardProxies();
   void RebalanceProxies();
   void SwitchProxyGroup();
   void SetProxyGroupResetDelay(const unsigned seconds);

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -466,8 +466,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
                         std::vector<uint64_t> *reply_vals);
   void SwitchHost(JobInfo *info);
   void SwitchProxy(JobInfo *info);
-  void SetRandomProxyUnlocked();
-  void RebalanceProxiesUnlocked();
+  ProxyInfo *ChooseProxyUnlocked(const shash::Any *hash);
+  void UpdateProxiesUnlocked(const std::string &reason);
+  void RebalanceProxiesUnlocked(const std::string &reason);
   CURL *AcquireCurlHandle();
   void ReleaseCurlHandle(CURL *handle);
   void ReleaseCredential(JobInfo *info);
@@ -487,11 +488,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   inline std::vector<ProxyInfo> *current_proxy_group() const {
     return (opt_proxy_groups_ ?
             &((*opt_proxy_groups_)[opt_proxy_groups_current_]) : NULL);
-  }
-
-  inline ProxyInfo *current_proxy() const {
-    return (opt_proxy_groups_ ?
-            &((*opt_proxy_groups_)[opt_proxy_groups_current_][0]) : NULL);
   }
 
   Prng prng_;

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -473,7 +473,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void ReleaseCredential(JobInfo *info);
   void InitializeRequest(JobInfo *info, CURL *handle);
   void SetUrlOptions(JobInfo *info);
-  void ValidateProxyIpsUnlocked(const std::string &url, const dns::Host &host);
+  bool ValidateProxyIpsUnlocked(const std::string &url, const dns::Host &host);
   void UpdateStatistics(CURL *handle);
   bool CanRetry(const JobInfo *info);
   void Backoff(JobInfo *info);

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include <cstdio>
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -390,6 +391,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
 
   static const unsigned kDnsDefaultRetries = 1;
   static const unsigned kDnsDefaultTimeoutMs = 3000;
+  static const unsigned kProxyMapScale = 16;
 
   DownloadManager();
   ~DownloadManager();
@@ -559,6 +561,18 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    * The original proxy fallback list provided to SetProxyChain.
    */
   std::string opt_proxy_fallback_list_;
+  /**
+   * Load-balancing map of currently active proxies
+   */
+  std::map<uint32_t, ProxyInfo *> opt_proxy_map_;
+  /**
+   * Sorted list of currently active proxy URLs (for log messages)
+   */
+  std::vector<std::string> opt_proxy_urls_;
+  /**
+   * Shard requests across multiple proxies via consistent hashing
+   */
+  bool opt_proxy_shard_;
 
   /**
    * Used to resolve proxy addresses (host addresses are resolved by the proxy).

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -12,6 +12,7 @@
 #ifndef CVMFS_HASH_H_
 #define CVMFS_HASH_H_
 
+#include <arpa/inet.h>
 #include <stdint.h>
 
 #include <cassert>
@@ -384,6 +385,14 @@ struct Digest {
         return false;
     }
     return true;
+  }
+
+  /**
+   * Get a partial digest for use when only 32 bits are required
+   */
+  uint32_t Partial32() const {
+    const uint32_t *partial = (const uint32_t *)digest;
+    return ntohl(*partial);
   }
 
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1333,6 +1333,11 @@ bool MountPoint::CreateDownloadManagers() {
     download_mgr_->UseSystemCertificatePath();
   }
 
+  if (options_mgr_->GetValue("CVMFS_PROXY_SHARD", &optarg) &&
+      options_mgr_->IsOn(optarg)) {
+    download_mgr_->ShardProxies();
+  }
+
   return SetupExternalDownloadMgr(do_geosort);
 }
 

--- a/test/src/572-proxyfailover/main
+++ b/test/src/572-proxyfailover/main
@@ -164,6 +164,18 @@ cvmfs_run_test() {
   [ $i -eq $num_proxies ] || return 8
   sleep 1
 
+  echo "run tests in single-proxy configuration"
+  run_proxy_test no || return $?
+
+  echo "run tests in sharded configuration"
+  run_proxy_test yes || return $?
+
+  return 0
+}
+
+run_proxy_test() {
+  local shard=$1
+
   echo "define proxy group:"
   proxies="$(get_proxy 0)|$(get_proxy 1);$(get_proxy 2)|$(get_proxy 3)"
   echo $proxies
@@ -182,6 +194,7 @@ CVMFS_SERVER_URL=$http_url/cvmfs/${CVMFS_TEST_REPO}
 CVMFS_HTTP_PROXY='$proxies'
 CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
 CVMFS_TIMEOUT=5
+CVMFS_PROXY_SHARD=$shard
 EOF
 
   echo "mount CVMFS with the full setup working"
@@ -288,6 +301,13 @@ EOF
   mount_time="$(stop_watch mount_private $mntpnt $mnt_conf 2>/dev/null)" || return 40
   echo "took $(msec_to_sec $mount_time) seconds"
   check_active_proxy_group $mnt_pipe 1 || return 41
+
+  echo "reset the proxies"
+  reset_proxies
+
+  echo "switch proxy group back to original proxies"
+  switch_proxy_group $mnt_pipe         || return 42
+  check_active_proxy_group $mnt_pipe 0 || return 43
 
   return 0
 }


### PR DESCRIPTION
Add support for sharding requests across multiple proxies using consistent hashing, controlled via the `CVMFS_PROXY_SHARD` option in the client configuration.  This allows load to be distributed approximately equally across multiple proxies, with clients independently choosing the same proxy for a given piece of content.

This pull request does not implement bounded loads (as used in e.g. haproxy's `hash-type consistent`) since there is no obvious way for clients to share knowledge about pending requests, and there is probably limited utility in bounding the per-proxy load generated by a single client acting in isolation.