### PR TITLE
cvmfs-release.deb: fallback to focal 20.04 if >= 20

### DIFF
--- a/packaging/debian/cvmfs-release/postinst
+++ b/packaging/debian/cvmfs-release/postinst
@@ -28,7 +28,10 @@ case "$1" in
 	else
 		version_major=$(lsb_release -sr | cut -d. -f1)
 		fallback_release=
-		if [ $version_major -ge 18 ]; then
+		if [ $version_major -ge 20 ]; then
+			echo "Warning: this distribution is not supported. Using Ubuntu 20.04 packages as fallback."
+			fallback_release=focal
+		elif [ $version_major -ge 18 ]; then
 			echo "Warning: this distribution is not supported. Using Ubuntu 18.04 packages as fallback."
 			fallback_release=bionic
 		else


### PR DESCRIPTION
Instead of falling back to bionic 18.04, we can fall back to the supported focal 20.04 version when version_major >= 20. This avoids behavior on 21.04, 21.10 where fallback to 18.04 packages is done:
```
16:31:19 wdconinc@menelaos /tmp $ sudo dpkg -i cvmfs-release-latest_all.deb 
(Reading database ... 351038 files and directories currently installed.)
Preparing to unpack cvmfs-release-latest_all.deb ...
Unpacking cvmfs-release (3.3-1) over (3.2-1) ...
Setting up cvmfs-release (3.3-1) ...
Warning: this distribution is not supported. Using Ubuntu 18.04 packages as fallback.
```