### PR TITLE
Remove open-coded access to RepositoryTag private fields

### DIFF
--- a/cvmfs/repository_tag.cc
+++ b/cvmfs/repository_tag.cc
@@ -4,10 +4,43 @@
 
 #include "repository_tag.h"
 
+#include "platform.h"
+#include "util/string.h"
+
 RepositoryTag::RepositoryTag(const std::string& name,
                              const std::string& channel,
                              const std::string& description)
     : name_(name),
       channel_(channel),
       description_(description) {
+}
+
+/**
+ * Check if tag name is of the form "generic-*"
+ */
+bool RepositoryTag::HasGenericName() {
+  return HasPrefix(name_, "generic-", false);
+}
+
+/**
+ * Set a generic tag name of the form "generic-YYYY-MM-DDThh:mm:ss.sssZ"
+ */
+void RepositoryTag::SetGenericName() {
+  uint64_t nanoseconds = platform_realtime_ns();
+
+  // Use strftime() to format timestamp to one-second resolution
+  time_t seconds = static_cast<time_t>(nanoseconds / 1000000000);
+  struct tm timestamp;
+  gmtime_r(&seconds, &timestamp);
+  char seconds_buffer[32];
+  strftime(seconds_buffer, sizeof(seconds_buffer),
+           "generic-%Y-%m-%dT%H:%M:%S", &timestamp);
+
+  // Append milliseconds
+  unsigned offset_milliseconds = ((nanoseconds / 1000000) % 1000);
+  char name_buffer[48];
+  snprintf(name_buffer, sizeof(name_buffer), "%s.%03dZ", seconds_buffer,
+           offset_milliseconds);
+
+  name_ = std::string(name_buffer);
 }

--- a/cvmfs/repository_tag.h
+++ b/cvmfs/repository_tag.h
@@ -7,16 +7,35 @@
 
 #include <string>
 
-struct RepositoryTag {
-    RepositoryTag() : name_(""), channel_(""), description_("") {}
+class RepositoryTag {
 
-    RepositoryTag(const std::string& name,
-                  const std::string& channel,
-                  const std::string& description);
+ public:
+  RepositoryTag() : name_(""), channel_(""), description_("") {}
+  RepositoryTag(const std::string& name,
+                const std::string& channel,
+                const std::string& description);
 
-    std::string name_;
-    std::string channel_;
-    std::string description_;
+  void SetName(const std::string& name) {
+    name_ = name;
+  }
+  void SetChannel(const std::string& channel) {
+    channel_ = channel;
+  }
+  void SetDescription(const std::string& description) {
+    description_ = description;
+  }
+
+  bool HasGenericName();
+  void SetGenericName();
+
+  std::string name() const { return name_; }
+  std::string channel() const { return channel_; }
+  std::string description() const { return description_; }
+
+ private:
+  std::string name_;
+  std::string channel_;
+  std::string description_;
 };
 
 #endif  // CVMFS_REPOSITORY_TAG_H_

--- a/cvmfs/repository_tag.h
+++ b/cvmfs/repository_tag.h
@@ -8,7 +8,6 @@
 #include <string>
 
 class RepositoryTag {
-
  public:
   RepositoryTag() : name_(""), channel_(""), description_("") {}
   RepositoryTag(const std::string& name,

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -304,9 +304,9 @@ bool SessionContext::Commit(const std::string& old_root_hash,
   JsonStringGenerator request_input;
   request_input.Add("old_root_hash", old_root_hash);
   request_input.Add("new_root_hash", new_root_hash);
-  request_input.Add("tag_name", tag.name_);
-  request_input.Add("tag_channel", tag.channel_);
-  request_input.Add("tag_description", tag.description_);
+  request_input.Add("tag_name", tag.name());
+  request_input.Add("tag_channel", tag.channel());
+  request_input.Add("tag_description", tag.description());
   std::string request = request_input.GenerateString();
   CurlBuffer buffer;
   return MakeEndRequest("POST", key_id_, secret_, session_token_, api_url_,

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -715,15 +715,15 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   }
 
   if (args.find('D') != args.end()) {
-    params.repo_tag.name_ = *args.find('D')->second;
+    params.repo_tag.SetName(*args.find('D')->second);
   }
 
   if (args.find('G') != args.end()) {
-    params.repo_tag.channel_ = *args.find('G')->second;
+    params.repo_tag.SetChannel(*args.find('G')->second);
   }
 
   if (args.find('J') != args.end()) {
-    params.repo_tag.description_ = *args.find('J')->second;
+    params.repo_tag.SetDescription(*args.find('J')->second);
   }
 
   const bool upload_statsdb = (args.count('I') > 0);


### PR DESCRIPTION
Make the RepositoryTag "name_", "channel_", and "description_" fields
private, as implied by the trailing underscores.

Move the logic for constructing a generic timestamp-based tag name
from CommitProcessor::Commit() to RepositoryTag::SetGenericName(), to
allow for a single centralised implementation of this logic once
cvmfs_server_ingest.sh and cvmfs_server_publish.sh are ported to C++
code using the Publisher model.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>