### PR TITLE
Use proxy for all applicable cvmfs_swissknife commands

### DIFF
--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -88,6 +88,7 @@ __do_check() {
                      -t ${CVMFS_SPOOL_DIR}/tmp         \
                      -k ${CVMFS_PUBLIC_KEY}            \
                      -N ${CVMFS_REPOSITORY_NAME}       \
+                     $(get_swissknife_proxy)           \
                      $(get_follow_http_redirects_flag) \
                      $with_reflog                      \
                      -z /etc/cvmfs/repositories.d/${name}/trusted_certs"
@@ -153,6 +154,7 @@ __check_repair_reflog() {
 
     local reflog_reconstruct_command="$(__swissknife_cmd dbg) reconstruct_reflog \
                                                   -r $repository_url             \
+                                                  $(get_swissknife_proxy)        \
                                                   -u $CVMFS_UPSTREAM_STORAGE     \
                                                   -n $CVMFS_REPOSITORY_NAME      \
                                                   -t ${CVMFS_SPOOL_DIR}/tmp/     \

--- a/cvmfs/server/cvmfs_server_chown.sh
+++ b/cvmfs/server/cvmfs_server_chown.sh
@@ -46,6 +46,7 @@ cvmfs_server_catalog_chown() {
   local migrate_command="$(__swissknife_cmd dbg) migrate     \
                               -v 'chown'                     \
                               -r $CVMFS_STRATUM0             \
+                              $(get_swissknife_proxy)        \
                               -n $name                       \
                               -u $CVMFS_UPSTREAM_STORAGE     \
                               -k $CVMFS_PUBLIC_KEY           \

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -210,6 +210,7 @@ get_tag_hash() {
     -t ${CVMFS_SPOOL_DIR}/tmp                 \
     -p /etc/cvmfs/keys/${repository_name}.pub \
     -f $repository_name                       \
+    $(get_swissknife_proxy)                   \
     $(get_follow_http_redirects_flag) -x      \
     -n "$tag" 2>/dev/null | cut -d" " -f2
 }
@@ -230,6 +231,7 @@ get_tag_branch() {
     -t ${CVMFS_SPOOL_DIR}/tmp                 \
     -p /etc/cvmfs/keys/${repository_name}.pub \
     -f $repository_name                       \
+    $(get_swissknife_proxy)                   \
     $(get_follow_http_redirects_flag) -x      \
     -n "$tag" 2>/dev/null | cut -d" " -f7)
   if [ "x$branch" = "x(default)" ]; then
@@ -268,6 +270,7 @@ get_head_of() {
     -t ${CVMFS_SPOOL_DIR}/tmp                 \
     -p /etc/cvmfs/keys/${repository_name}.pub \
     -f $repository_name                       \
+    $(get_swissknife_proxy)                   \
     $(get_follow_http_redirects_flag) -x      \
     | cut -d" " -f1,2,7 | grep " $branch\$" | head -n 1
 }

--- a/cvmfs/server/cvmfs_server_eliminate_bulk_hashes.sh
+++ b/cvmfs/server/cvmfs_server_eliminate_bulk_hashes.sh
@@ -55,6 +55,7 @@ cvmfs_server_eliminate_bulk_hashes() {
   local migrate_command="$(__swissknife_cmd dbg) migrate     \
                               -v 'bulkhash'                  \
                               -r $CVMFS_STRATUM0             \
+                              $(get_swissknife_proxy)        \
                               -n $name                       \
                               -u $CVMFS_UPSTREAM_STORAGE     \
                               -k $CVMFS_PUBLIC_KEY           \

--- a/cvmfs/server/cvmfs_server_eliminate_hardlinks.sh
+++ b/cvmfs/server/cvmfs_server_eliminate_hardlinks.sh
@@ -56,6 +56,7 @@ cvmfs_server_eliminate_hardlinks() {
   local migrate_command="$(__swissknife_cmd dbg) migrate     \
                               -v 'hardlink'                  \
                               -r $CVMFS_STRATUM0             \
+                              $(get_swissknife_proxy)        \
                               -n $name                       \
                               -u $CVMFS_UPSTREAM_STORAGE     \
                               -k $CVMFS_PUBLIC_KEY           \

--- a/cvmfs/server/cvmfs_server_fix_stats.sh
+++ b/cvmfs/server/cvmfs_server_fix_stats.sh
@@ -54,6 +54,7 @@ cvmfs_server_fix_stats() {
   local migrate_command="$(__swissknife_cmd dbg) migrate     \
                               -v 'stats'                     \
                               -r $CVMFS_STRATUM0             \
+                              $(get_swissknife_proxy)        \
                               -n $name                       \
                               -u $CVMFS_UPSTREAM_STORAGE     \
                               -k $CVMFS_PUBLIC_KEY           \

--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -342,6 +342,7 @@ __run_gc() {
     to_syslog_for_repo $name "reference log reconstruction started"
     local reflog_reconstruct_command="$(__swissknife_cmd dbg) reconstruct_reflog \
                                                   -r $repository_url             \
+                                                  $(get_swissknife_proxy)        \
                                                   -u $CVMFS_UPSTREAM_STORAGE     \
                                                   -n $CVMFS_REPOSITORY_NAME      \
                                                   -t ${CVMFS_SPOOL_DIR}/tmp/     \
@@ -357,6 +358,7 @@ __run_gc() {
   [ $dry_run -ne 0 ] || to_syslog_for_repo $name "started garbage collection"
   local gc_command="$(__swissknife_cmd dbg) gc                              \
                                             -r $repository_url              \
+                                            $(get_swissknife_proxy)         \
                                             -u $CVMFS_UPSTREAM_STORAGE      \
                                             -n $CVMFS_REPOSITORY_NAME       \
                                             -k $CVMFS_PUBLIC_KEY            \

--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -312,6 +312,7 @@ cvmfs_server_import() {
     __swissknife migrate               \
       -v "2.0.x"                       \
       -r $storage_location             \
+      $(get_swissknife_proxy)          \
       -n $name                         \
       -u $upstream                     \
       -t $temp_dir                     \

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -145,6 +145,7 @@ cvmfs_server_ingest() {
     -d /cvmfs/${name}/.cvmfsdirtab                     \
     -b $base_hash                                      \
     -w $stratum0                                       \
+    $(get_swissknife_proxy)                            \
     -t ${spool_dir}/tmp                                \
     -u /cvmfs/${name}                                  \
     -s ${scratch_dir}                                  \
@@ -164,6 +165,7 @@ cvmfs_server_ingest() {
     -p /etc/cvmfs/keys/${name}.pub                    \
     -f $name                                          \
     -e $hash_algorithm                                \
+    $(get_swissknife_proxy)                           \
     $(get_follow_http_redirects_flag)"
   if ! is_checked_out $name; then
     # enables magic undo tag handling
@@ -192,6 +194,7 @@ cvmfs_server_ingest() {
     -p /etc/cvmfs/keys/${name}.pub                              \
     -f $name                                                    \
     -e $hash_algorithm                                          \
+    $(get_swissknife_proxy)                                     \
     $(get_follow_http_redirects_flag)                           \
     -x"
 
@@ -204,6 +207,7 @@ cvmfs_server_ingest() {
     -b $base_hash                               \
     -r ${upstream}                              \
     -w $stratum0                                \
+    $(get_swissknife_proxy)                     \
     -o $manifest                                \
     -K $CVMFS_PUBLIC_KEY                        \
     -N $name                                    \
@@ -294,6 +298,7 @@ cvmfs_server_ingest() {
         -f $name                                            \
         -b $base_hash                                       \
         -e $hash_algorithm                                  \
+        $(get_swissknife_proxy)                             \
         $(get_follow_http_redirects_flag)                   \
         -d \\\"$REPLY\\\""
       echo $user_shell \"${tag_cleanup_command}\" >> $tag_remove_cmd_file

--- a/cvmfs/server/cvmfs_server_list_catalogs.sh
+++ b/cvmfs/server/cvmfs_server_list_catalogs.sh
@@ -64,6 +64,7 @@ cvmfs_server_list_catalogs() {
   local lsrepo_cmd
   lsrepo_cmd="$(__swissknife_cmd dbg) lsrepo     \
                        -r $CVMFS_STRATUM0        \
+                       $(get_swissknife_proxy)   \
                        -n $CVMFS_REPOSITORY_NAME \
                        -k $CVMFS_PUBLIC_KEY      \
                        -l ${CVMFS_SPOOL_DIR}/tmp \

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -121,6 +121,7 @@ _migrate_2_1_7() {
   __swissknife migrate                                 \
     -v "2.1.7"                                         \
     -r ${CVMFS_STRATUM0}                               \
+    $(get_swissknife_proxy)                            \
     -n $name                                           \
     -u ${CVMFS_UPSTREAM_STORAGE}                       \
     -t $temp_dir                                       \

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -181,6 +181,7 @@ cvmfs_server_publish() {
       -d /cvmfs/${name}/.cvmfsdirtab                     \
       -b $base_hash                                      \
       -w $stratum0                                       \
+      $(get_swissknife_proxy)                            \
       -t ${spool_dir}/tmp                                \
       -u /cvmfs/${name}                                  \
       -s ${scratch_dir}                                  \
@@ -339,6 +340,7 @@ cvmfs_server_publish() {
       -p /etc/cvmfs/keys/${name}.pub                              \
       -f $name                                                    \
       -e $hash_algorithm                                          \
+      $(get_swissknife_proxy)                                     \
       $(get_follow_http_redirects_flag)                           \
       -x"
 
@@ -392,6 +394,7 @@ cvmfs_server_publish() {
           -f $name                                            \
           -b $base_hash                                       \
           -e $hash_algorithm                                  \
+          $(get_swissknife_proxy)                             \
           $(get_follow_http_redirects_flag)                   \
           -d \\\"$REPLY\\\""
         echo $user_shell \"${tag_cleanup_command}\" >> $tag_remove_cmd_file
@@ -498,6 +501,7 @@ filter_auto_tags() {
     -t ${CVMFS_SPOOL_DIR}/tmp                  \
     -p /etc/cvmfs/keys/${repository_name}.pub  \
     -f $repository_name                        \
+    $(get_swissknife_proxy)                    \
     -x $(get_follow_http_redirects_flag)       | \
     grep -E \
     '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}Z' | \

--- a/cvmfs/server/cvmfs_server_rollback.sh
+++ b/cvmfs/server/cvmfs_server_rollback.sh
@@ -94,6 +94,7 @@ cvmfs_server_rollback() {
 
   local rollback_command="$(__swissknife_cmd dbg) tag_rollback \
     -w $stratum0                                               \
+    $(get_swissknife_proxy)                                    \
     -t ${spool_dir}/tmp                                        \
     -p /etc/cvmfs/keys/${name}.pub                             \
     -z /etc/cvmfs/repositories.d/${name}/trusted_certs         \

--- a/cvmfs/server/cvmfs_server_tag.sh
+++ b/cvmfs/server/cvmfs_server_tag.sh
@@ -99,6 +99,7 @@ cvmfs_server_tag() {
   if [ $action_list_tags -eq 1 ] || [ $action_list_branches -eq 1 ] || [ $actions -eq 0 ]; then
     local tag_list_command="$(__swissknife_cmd dbg) tag_list \
       -w $CVMFS_STRATUM0                                     \
+      $(get_swissknife_proxy)                                \
       -t ${CVMFS_SPOOL_DIR}/tmp                              \
       -p /etc/cvmfs/keys/${name}.pub                         \
       -z /etc/cvmfs/repositories.d/${name}/trusted_certs     \
@@ -117,6 +118,7 @@ cvmfs_server_tag() {
   if [ $action_inspect -eq 1 ]; then
     local tag_inspect_command="$(__swissknife_cmd dbg) tag_info \
       -w $CVMFS_STRATUM0                                        \
+      $(get_swissknife_proxy)                                   \
       -t ${CVMFS_SPOOL_DIR}/tmp                                 \
       -p /etc/cvmfs/keys/${name}.pub                            \
       -z /etc/cvmfs/repositories.d/${name}/trusted_certs        \
@@ -157,6 +159,7 @@ cvmfs_server_tag() {
       -C /etc/cvmfs/repositories.d/${name}/trusted_certs \
       -N $name                                           \
       -K $CVMFS_PUBLIC_KEY                               \
+      $(get_swissknife_proxy)                            \
       $(get_follow_http_redirects_flag) $log_level -S snapshots"
   local tag_command_undo_tags="$(__swissknife_cmd dbg) tag_edit \
       -r $CVMFS_UPSTREAM_STORAGE                        \
@@ -166,6 +169,7 @@ cvmfs_server_tag() {
       -p /etc/cvmfs/keys/${name}.pub                    \
       -f $name                                          \
       -e $hash_algorithm                                \
+      $(get_swissknife_proxy)                           \
       $(get_follow_http_redirects_flag)                 \
       -x"
 
@@ -181,6 +185,7 @@ cvmfs_server_tag() {
       -m $new_manifest                                           \
       -b $base_hash                                              \
       -e $hash_algorithm                                         \
+      $(get_swissknife_proxy)                                    \
       $(get_follow_http_redirects_flag)                          \
       -a $tag_name"
     if [ ! -z "$add_tag_channel" ]; then
@@ -212,6 +217,7 @@ cvmfs_server_tag() {
 
     $user_shell "$(__swissknife_cmd dbg) tag_edit        \
       -w $CVMFS_STRATUM0                                 \
+      $(get_swissknife_proxy)                            \
       -t ${CVMFS_SPOOL_DIR}/tmp                          \
       -p /etc/cvmfs/keys/${name}.pub                     \
       -z /etc/cvmfs/repositories.d/${name}/trusted_certs \

--- a/cvmfs/server_tool.h
+++ b/cvmfs/server_tool.h
@@ -20,7 +20,7 @@ class ServerTool {
   virtual ~ServerTool();
 
   bool InitDownloadManager(const bool follow_redirects,
-                           const std::string &proxy = "",
+                           const std::string &proxy,
                            const unsigned max_pool_handles = 1);
   bool InitVerifyingSignatureManager(const std::string &pubkey_path,
                                      const std::string &trusted_certs = "");

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -930,7 +930,8 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
   // initialize the (swissknife global) download and signature managers
   if (is_remote_) {
     const bool follow_redirects = (args.count('L') > 0);
-    if (!this->InitDownloadManager(follow_redirects)) {
+    const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+    if (!this->InitDownloadManager(follow_redirects, proxy)) {
       return 1;
     }
 

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -47,6 +47,7 @@ class CommandCheck : public Command {
     r.push_back(Parameter::Optional('z', "trusted certificates"));
     r.push_back(Parameter::Optional('N', "name of the repository"));
     r.push_back(Parameter::Optional('R', "path to reflog.chksum file"));
+    r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Switch('c', "check availability of data chunks"));
     r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
     return r;

--- a/cvmfs/swissknife_filestats.cc
+++ b/cvmfs/swissknife_filestats.cc
@@ -24,6 +24,7 @@ ParameterList CommandFileStats::GetParams() const {
   r.push_back(Parameter::Optional('k', "repository master key(s) / dir"));
   r.push_back(Parameter::Optional('l', "temporary directory"));
   r.push_back(Parameter::Optional('h', "root hash (other than trunk)"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   return r;
 }
 
@@ -50,7 +51,8 @@ int CommandFileStats::Main(const ArgumentList &args) {
   bool success = false;
   if (IsHttpUrl(repo_url)) {
     const bool follow_redirects = false;
-    if (!this->InitDownloadManager(follow_redirects) ||
+    const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+    if (!this->InitDownloadManager(follow_redirects, proxy) ||
         !this->InitVerifyingSignatureManager(repo_keys)) {
       LogCvmfs(kLogCatalog, kLogStderr, "Failed to init remote connection");
       return 1;

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -42,6 +42,7 @@ ParameterList CommandGc::GetParams() const {
   r.push_back(Parameter::Optional('t', "temporary directory"));
   r.push_back(Parameter::Optional('L', "path to deletion log file"));
   r.push_back(Parameter::Optional('N', "number of threads to use"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   r.push_back(Parameter::Switch('d', "dry run"));
   r.push_back(Parameter::Switch('l', "list objects to be removed"));
   r.push_back(Parameter::Switch('I', "upload updated statistics DB file"));
@@ -95,7 +96,9 @@ int CommandGc::Main(const ArgumentList &args) {
   }
 
   const bool follow_redirects = false;
-  if (!this->InitDownloadManager(follow_redirects) ||
+  const std::string proxy = ((args.count('@') > 0) ?
+                             *args.find('@')->second : "");
+  if (!this->InitDownloadManager(follow_redirects, proxy) ||
       !this->InitVerifyingSignatureManager(repo_keys)) {
     LogCvmfs(kLogCatalog, kLogStderr, "failed to init repo connection");
     return 1;

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -117,7 +117,8 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   if (!spooler_catalogs.IsValid()) return 3;
 
   const bool follow_redirects = (args.count('L') > 0);
-  if (!InitDownloadManager(follow_redirects)) {
+  const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+  if (!InitDownloadManager(follow_redirects, proxy)) {
     return 3;
   }
 

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -40,6 +40,7 @@ class Ingest : public Command {
 
     r.push_back(Parameter::Optional('P', "session_token_file"));
     r.push_back(Parameter::Optional('H', "key file for HTTP API"));
+    r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Switch('I', "upload updated statistics DB file"));
 
     return r;

--- a/cvmfs/swissknife_list_reflog.cc
+++ b/cvmfs/swissknife_list_reflog.cc
@@ -26,6 +26,7 @@ ParameterList CommandListReflog::GetParams() const {
   r.push_back(Parameter::Optional('k', "repository master key(s) / dir"));
   r.push_back(Parameter::Optional('t', "temporary directory"));
   r.push_back(Parameter::Optional('o', "output file"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   return r;
 }
 
@@ -52,7 +53,8 @@ int CommandListReflog::Main(const ArgumentList &args) {
   }
 
   const bool follow_redirects = false;
-  if (!this->InitDownloadManager(follow_redirects) ||
+  const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+  if (!this->InitDownloadManager(follow_redirects, proxy) ||
       !this->InitVerifyingSignatureManager(repo_keys)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to init repo connection");
     return 1;

--- a/cvmfs/swissknife_lsrepo.cc
+++ b/cvmfs/swissknife_lsrepo.cc
@@ -26,6 +26,7 @@ ParameterList CommandListCatalogs::GetParams() const {
   r.push_back(Parameter::Optional('k', "repository master key(s) / dir"));
   r.push_back(Parameter::Optional('l', "temporary directory"));
   r.push_back(Parameter::Optional('h', "root hash (other than trunk)"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   r.push_back(Parameter::Switch('t', "print tree structure of catalogs"));
   r.push_back(Parameter::Switch('d', "print digest for each catalog"));
   r.push_back(Parameter::Switch('s', "print catalog file sizes"));
@@ -58,7 +59,9 @@ int CommandListCatalogs::Main(const ArgumentList &args) {
   bool success = false;
   if (IsHttpUrl(repo_url)) {
     const bool follow_redirects = false;
-    if (!this->InitDownloadManager(follow_redirects) ||
+    const std::string proxy = ((args.count('@') > 0) ?
+                               *args.find('@')->second : "");
+    if (!this->InitDownloadManager(follow_redirects, proxy) ||
         !this->InitVerifyingSignatureManager(repo_keys)) {
       LogCvmfs(kLogCatalog, kLogStderr, "Failed to init remote connection");
       return 1;

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -57,6 +57,7 @@ ParameterList CommandMigrate::GetParams() const {
   r.push_back(Parameter::Optional('k', "repository master key(s)"));
   r.push_back(Parameter::Optional('i', "UID map for chown"));
   r.push_back(Parameter::Optional('j', "GID map for chown"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   r.push_back(Parameter::Switch('f', "fix nested catalog transition points"));
   r.push_back(Parameter::Switch('l', "disable linkcount analysis of files"));
   r.push_back(Parameter::Switch('s',
@@ -153,7 +154,8 @@ int CommandMigrate::Main(const ArgumentList &args) {
     typedef HttpObjectFetcher<catalog::WritableCatalog> ObjectFetcher;
 
     const bool follow_redirects = false;
-    if (!this->InitDownloadManager(follow_redirects) ||
+    const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+    if (!this->InitDownloadManager(follow_redirects, proxy) ||
         !this->InitVerifyingSignatureManager(repo_keys)) {
       LogCvmfs(kLogCatalog, kLogStderr, "Failed to init repo connection");
       return 1;

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -66,6 +66,7 @@ ParameterList CommandReconstructReflog::GetParams() const {
   r.push_back(Parameter::Mandatory('t', "temporary directory"));
   r.push_back(Parameter::Mandatory('k', "repository keychain"));
   r.push_back(Parameter::Mandatory('R', "path to reflog.chksum file"));
+  r.push_back(Parameter::Optional('@', "proxy url"));
   return r;
 }
 
@@ -79,7 +80,9 @@ int CommandReconstructReflog::Main(const ArgumentList &args) {
   const std::string &reflog_chksum_path = *args.find('R')->second;
 
   const bool follow_redirects = false;
-  if (!this->InitDownloadManager(follow_redirects) ||
+  const std::string proxy = ((args.count('@') > 0) ?
+                             *args.find('@')->second : "");
+  if (!this->InitDownloadManager(follow_redirects, proxy) ||
       !this->InitVerifyingSignatureManager(repo_keys)) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to init repo connection");
     return 1;

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -288,7 +288,8 @@ int swissknife::CommandApplyDirtab::Main(const ArgumentList &args) {
   // initialize catalog infrastructure
   const bool auto_manage_catalog_files = true;
   const bool follow_redirects = (args.count('L') > 0);
-  if (!InitDownloadManager(follow_redirects)) {
+  const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+  if (!InitDownloadManager(follow_redirects, proxy)) {
     return 1;
   }
   catalog::SimpleCatalogManager catalog_manager(

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -216,6 +216,7 @@ class CommandApplyDirtab : public Command {
     r.push_back(Parameter::Mandatory('b', "base hash"));
     r.push_back(Parameter::Mandatory('w', "stratum 0 base url"));
     r.push_back(Parameter::Mandatory('t', "directory for temporary storage"));
+    r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Switch('x', "verbose mode"));
     return r;
   }

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -262,7 +262,7 @@ CatalogTestTool::CatalogTestTool(const std::string& name)
     : name_(name), manifest_(), spooler_(), history_() {}
 
 bool CatalogTestTool::Init() {
-  if (!InitDownloadManager(true)) {
+  if (!InitDownloadManager(true, "")) {
     return false;
   }
 

--- a/test/unittests/t_catalog_merge_tool.cc
+++ b/test/unittests/t_catalog_merge_tool.cc
@@ -105,7 +105,7 @@ TEST_F(T_CatalogMergeTool, CRUD) {
   EXPECT_TRUE(tester.Apply("second", spec2));
 
   UniquePtr<ServerTool> server_tool(new ServerTool());
-  EXPECT_TRUE(server_tool->InitDownloadManager(true));
+  EXPECT_TRUE(server_tool->InitDownloadManager(true, ""));
 
   receiver::Params params = MakeMergeToolParams("test");
 
@@ -191,7 +191,7 @@ TEST_F(T_CatalogMergeTool, Symlink) {
   EXPECT_TRUE(tester.Apply("second", update));
 
   UniquePtr<ServerTool> server_tool(new ServerTool());
-  EXPECT_TRUE(server_tool->InitDownloadManager(true));
+  EXPECT_TRUE(server_tool->InitDownloadManager(true, ""));
 
   receiver::Params params = MakeMergeToolParams("test_symlink");
 


### PR DESCRIPTION
Respect the `CVMFS_SERVER_PROXY` setting for all invocations of `cvmfs_swissknife` within the server-side scripts.