### PR TITLE
Spelling: docs and comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ if (NOT MACOSX)
   set (REQUIRED_HEADERS ${REQUIRED_HEADERS}
                         sys/statfs.h)
 
-  # As of attr-2.4.48, the attr/xattr.h header disappeard in favor of sys/xattr.h
+  # As of attr-2.4.48, the attr/xattr.h header disappeared in favor of sys/xattr.h
   #
   # Unfortunately, attr/xattr.h fails to compile without including sys/types.h
   # before including attr/xattr.h (it uses size_t and ssize_t).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome code contributions!
 
-If you are about to develop a bug fix or a new feature, it could be helpful to let us know about it beforehand, for instance on the cvmfs-devel@cern.ch mailing list or by private mail or through our [ticket tracker](https://sft.its.cern.ch/jira/browse/CVM).  This can avoid duplicated work and allows us to coordinate the developemnt.
+If you are about to develop a bug fix or a new feature, it could be helpful to let us know about it beforehand, for instance on the cvmfs-devel@cern.ch mailing list or by private mail or through our [ticket tracker](https://sft.its.cern.ch/jira/browse/CVM).  This can avoid duplicated work and allows us to coordinate the development.
 
 
 # Source Code Workflow

--- a/ChangeLog
+++ b/ChangeLog
@@ -144,7 +144,7 @@
   * Add the cvmfs_publish transitional utility
   * Add convert-singularity-image command to DUCC
   * Enable readdir caching on fuse3 and kernel >= 4.20
-  * Add fuse forget_multi calback for fuse >= 2.9
+  * Add fuse forget_multi callback for fuse >= 2.9
   * Add POSIX external cache plugin (CVM-1823)
   * Manage DUCC daemon with systemd units
 
@@ -179,7 +179,7 @@
   * Fix packaging for Fedora 31
   * [gw] use watchdog in cvmfs_receiver (CVM-1864)
   * [gw] build debug version of cvmfs_receiver (CVM-1863)
-  * [gw] fix lease acquisiton on non-existing paths (CVM-1696)
+  * [gw] fix lease acquisition on non-existing paths (CVM-1696)
   * Optimize loading of nested catalogs (CVM-1848)
   * Fix creation of nested catalogs by ingestion command (CVM-1862)
   * [gw] fix/relax JSON parsing of success status message
@@ -412,7 +412,7 @@
   * Add RapidCheck for property based testing
   * Fix compilation on macOS 10.11+
   * Add stratum 1 agent for triggered replication
-  * Autmatically restart failed authz helper after a cool-off period
+  * Automatically restart failed authz helper after a cool-off period
   * Make `true` to be a valid boolean option
 
 2.4.5:
@@ -484,7 +484,7 @@
   * Use a repository layout revision as CVMFS_CREATOR_VERSION (CVM-1065)
   * Improve error reporting when cache hosting file system is full (CVM-1253)
   * Perform fail-over when whitelist or manifest is corrupted (CVM-837)
-  * Increase maximum repostory name from ~30 chars to 60 chars (CVM-1173)
+  * Increase maximum repository name from ~30 chars to 60 chars (CVM-1173)
   * Add cvmfs_server gc -a option (CVM-1095)
   * Fixes for OpenSSL 1.1 interface changes
   * Use rsync "perishable" feature instead of list-catalogs (CVM-1199)
@@ -562,7 +562,7 @@
   * Fixes for macOS 10.12 Sierra (CVM-1084)
 
 2.3.2:
-  * Fix error reporting when downloading replication sentinal file (CVM-1078)
+  * Fix error reporting when downloading replication sentinel file (CVM-1078)
   * Fix publishing of auto catalog markers (CVM-1079)
   * Fix segfault in debug logging of certain download failures (CVM-1076)
 
@@ -616,7 +616,7 @@
   * Call cvmfs_suid_helper with a clean environment from cvmfs_server
   * Add .cvmfsreflog for garbage collection
   * Omit S3 bucket number if only a single bucket is used
-  * Warn when forcfully remounting the file system stack on the server, new
+  * Warn when forcefully remounting the file system stack on the server, new
     parameter CVMFS_FORCE_REMOUNT_WARNING
   * Add support for default.conf in config repository (CVM-993)
 
@@ -709,7 +709,7 @@
   * Add make check target
   * Fix leak of temporary files in .cvmfsdirtab handling (CVM-818)
   * Allow geodb update for non-root users (CVM-895)
-  * Don't commit exisiting files to local storage backend in server (CVM-894)
+  * Don't commit existing files to local storage backend in server (CVM-894)
   * Fix stale lock file on server machine crash (CVM-810)
   * Fix crash for invalid spooler definition (CVM-891)
   * Fix leak of temporary files in the S3 backend (CVM-881)
@@ -785,7 +785,7 @@
     CVMFS_CLAIM_OWNERSHIP (CVM-678)
   * Add support for garbage-collected repositories (CVM-583, CVM-760)
   * Add support for automatically ordering Stratum 1 servers according to
-    geographic loations (CVM-629, CVM-630)
+    geographic locations (CVM-629, CVM-630)
   * Add 'host probe geo' command to cvmfs_talk
   * Add CVMFS_USE_GEOAPI parameter
   * Add host_list extended attribute
@@ -872,7 +872,7 @@
   * Fix automounter map on EL6.2 (CVM-601)
   * Log to syslog in addition to stderr when debug log cannot
     be opened (CVM-273)
-  * Fix false parsing of /etc/cvmfs/domaind.d/cern.ch.* on mount
+  * Fix false parsing of /etc/cvmfs/domain.d/cern.ch.* on mount
     (CVM-600)
   * Improve error logging when loading the cvmfs library (cf. CVM-595)
   * Fix crash in exclusive cache mode if unpin listener is called
@@ -960,7 +960,7 @@
   * Automatically unmount a crashed mountpoint from the watchdog
   * Connect SQlite logger to cvmfs logger
   * Switch to sqlite 3.7.17
-  * Add check for accessibiliy of /etc/nsswitch.conf to
+  * Add check for accessibility of /etc/nsswitch.conf to
     cvmfs_config chksetup
   * Add experimental support for overlayfs as an alternative to
     aufs
@@ -983,7 +983,7 @@
   * Fix various issues with reading of chunked files
   * Decrease memory consumption of the inode tracker
   * Remove trailing empty attribute in listattr callback
-  * Make repositories replicatable by default
+  * Make repositories replicable by default
   * Experimental support for repository tags (named snapshots).
     Allows to mount a specific repository version and to rollback
     and re-publish previous repository states.
@@ -999,7 +999,7 @@
 2.1.12:
   * Perform host failover after unsuccessful proxy
     failover (test all paths)
-  * Improve recovery reliabiliy after node crash
+  * Improve recovery reliability after node crash
     (force removal of cache database)
   * Fix help text of cvmfs_talk
   * Fix timeout for NFS shared maps
@@ -1193,7 +1193,7 @@
   * Create cvmfs user in cvmfs_server if necessary
   * Fixed cvmfs_fsck on xfs
   * Fixed get_origin in config.sh
-  * Speed up searach for existing mount point in mount helper
+  * Speed up search for existing mount point in mount helper
   * Log to syslog when new repository snapshot is applied
   * Fixed presentation error in cvmfs_stat
   * Added repository prefix to syslog messages
@@ -1221,7 +1221,7 @@
   * Verify decompressed size on download
   * Unlink left-over temporary file catalogs in cvmfs_fsck
   * Fixed a file descriptor leak on loading certificates
-  * Move dodgy files into a quarantaine folder in the cache
+  * Move dodgy files into a quarantine folder in the cache
   * Log proxy switches to syslog
   * Use stack buffer for streamed file I/O
   * Fixed a file descriptor leak in the catalog load code
@@ -1451,7 +1451,7 @@
   * Fixed some multi-threading bugs
   * Switched to libcurl 7.21.3
   * Include timestamp in debug log
-  * Changed failover + load-balaning proxy syntax: introduced 3rd
+  * Changed failover + load-balancing proxy syntax: introduced 3rd
     level to specify load-balance blocks first, failover later
   * Proper mapping of file catalogs and whitelists to repository
     names
@@ -1504,7 +1504,7 @@
   * add last modified timestamp when making catalog snapshot
   * fixed time comparison to work on UTC instead of
     local time
-  * use the SQlite auto_vaccum=full feature for new catalogs
+  * use the SQlite auto_vacuum=full feature for new catalogs
   * added cvmfs_unsign tool to strip a signature from a
     file catalog
   * store .cvmfscatalog as symlink into data dir

--- a/INSTALL
+++ b/INSTALL
@@ -3,12 +3,12 @@ Installation Instructions
 
 The CernVM-FS build system uses cmake.  
 
-In order to corerctly build the system several dependencies are necessary.
+In order to correctly build the system several dependencies are necessary.
 The dependencies are listed inside the `packaging` directory.
 
 For debian based system you can find the dependencies inside the `control` file under `packaging/debian/cvmfs`.
 
-Similarly for CentOS you can find them inside `packagin/rpm/cvmfs-universal.spec`.
+Similarly for CentOS you can find them inside `packaging/rpm/cvmfs-universal.spec`.
 
 In order to compile and install, run from the source directory
 

--- a/add-ons/tools/legacy/downloadCatalogs.py
+++ b/add-ons/tools/legacy/downloadCatalogs.py
@@ -58,7 +58,7 @@ def getCatalogFilePath(catalogName, catalogDirectory):
 
 
 def downloadCatalog(repositoryUrl, catalogName, catalogDirectory, beVerbose):
-	# find out some pathes and init the zlib decompressor
+	# find out some paths and init the zlib decompressor
 	subdir = catalogName[0:2]
 	filename = catalogName[2:] + "C"
 	url = repositoryUrl + "/data/" + subdir + "/" + filename

--- a/cmake/Modules/UseDoxygen.cmake
+++ b/cmake/Modules/UseDoxygen.cmake
@@ -30,7 +30,7 @@
 # Variables you may define are:
 #  DOXYFILE_SOURCE_DIR - Path where the Doxygen input files are.
 #  	Defaults to the current source directory.
-#  DOXYFILE_EXTRA_SOURCES - Additional source diretories/files for Doxygen to scan.
+#  DOXYFILE_EXTRA_SOURCES - Additional source directories/files for Doxygen to scan.
 #  	The Paths should be in double quotes and separated by space. e.g.:
 #  	 "${CMAKE_CURRENT_BINARY_DIR}/foo.c" "${CMAKE_CURRENT_BINARY_DIR}/bar/"
 #

--- a/cpplint.py
+++ b/cpplint.py
@@ -3907,7 +3907,7 @@ def CheckBraces(filename, clean_lines, linenum, error):
     # perfectly: we just don't complain if the last non-whitespace character on
     # the previous non-blank line is ',', ';', ':', '(', '{', or '}', or if the
     # previous line starts a preprocessor block.
-    # Additionall allow an open brace when the previous line is a multi line
+    # Additionally allow an open brace when the previous line is a multi line
     # method signature or if/for/while statement.  That is: previous line ends
     # on ) or const (t).
     prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]
@@ -4685,7 +4685,7 @@ def _GetTextInside(text, start_pattern):
   Given a string of lines and a regular expression string, retrieve all the text
   following the expression and between opening punctuation symbols like
   (, [, or {, and the matching close-punctuation symbol. This properly nested
-  occurrences of the punctuations, so for the text like
+  occurrences of the punctuation, so for the text like
     printf(a(), b(c()));
   a call to _GetTextInside(text, r'printf\(') will return 'a(), b(c())'.
   start_pattern must match string having an open punctuation symbol at the end.
@@ -4702,7 +4702,7 @@ def _GetTextInside(text, start_pattern):
   # TODO(unknown): Audit cpplint.py to see what places could be profitably
   # rewritten to use _GetTextInside (and use inferior regexp matching today).
 
-  # Give opening punctuations to get the matching close-punctuations.
+  # Give opening punctuation to get the matching close-punctuation.
   matching_punctuation = {'(': ')', '{': '}', '[': ']'}
   closing_punctuation = set(matching_punctuation.itervalues())
 
@@ -4716,22 +4716,22 @@ def _GetTextInside(text, start_pattern):
       'start_pattern must ends with an opening punctuation.')
   assert text[start_position - 1] in matching_punctuation, (
       'start_pattern must ends with an opening punctuation.')
-  # Stack of closing punctuations we expect to have in text after position.
+  # Stack of closing punctuation we expect to have in text after position.
   punctuation_stack = [matching_punctuation[text[start_position - 1]]]
   position = start_position
   while punctuation_stack and position < len(text):
     if text[position] == punctuation_stack[-1]:
       punctuation_stack.pop()
     elif text[position] in closing_punctuation:
-      # A closing punctuation without matching opening punctuations.
+      # A closing punctuation without matching opening punctuation.
       return None
     elif text[position] in matching_punctuation:
       punctuation_stack.append(matching_punctuation[text[position]])
     position += 1
   if punctuation_stack:
-    # Opening punctuations left without matching close-punctuations.
+    # Opening punctuation left without matching close-punctuation.
     return None
-  # punctuations match.
+  # punctuation matches.
   return text[start_position:position - 1]
 
 

--- a/cpplint.py.rev141
+++ b/cpplint.py.rev141
@@ -4699,7 +4699,7 @@ def _GetTextInside(text, start_pattern):
   # TODO(unknown): Audit cpplint.py to see what places could be profitably
   # rewritten to use _GetTextInside (and use inferior regexp matching today).
 
-  # Give opening punctuations to get the matching close-punctuations.
+  # Give opening punctuation to get the matching close-punctuation.
   matching_punctuation = {'(': ')', '{': '}', '[': ']'}
   closing_punctuation = set(matching_punctuation.itervalues())
 
@@ -4713,14 +4713,14 @@ def _GetTextInside(text, start_pattern):
       'start_pattern must ends with an opening punctuation.')
   assert text[start_position - 1] in matching_punctuation, (
       'start_pattern must ends with an opening punctuation.')
-  # Stack of closing punctuations we expect to have in text after position.
+  # Stack of closing punctuation we expect to have in text after position.
   punctuation_stack = [matching_punctuation[text[start_position - 1]]]
   position = start_position
   while punctuation_stack and position < len(text):
     if text[position] == punctuation_stack[-1]:
       punctuation_stack.pop()
     elif text[position] in closing_punctuation:
-      # A closing punctuation without matching opening punctuations.
+      # A closing punctuation without matching opening punctuation.
       return None
     elif text[position] in matching_punctuation:
       punctuation_stack.append(matching_punctuation[text[position]])

--- a/cvmfs/authz/authz_curl.cc
+++ b/cvmfs/authz/authz_curl.cc
@@ -253,7 +253,7 @@ bool AuthzAttachment::ConfigureCurlHandle(
 
   if (parm->pkey == NULL) {
     // Sigh - PEM_X509_INFO_read doesn't understand old key encodings.
-    // Try a more general-purpose funciton.
+    // Try a more general-purpose function.
     BIO *bio_token = BIO_new_mem_buf(token->data, token->size);
     assert(bio_token != NULL);
     EVP_PKEY *old_pkey = PEM_read_bio_PrivateKey(bio_token, NULL, NULL, NULL);

--- a/cvmfs/authz/authz_fetch.h
+++ b/cvmfs/authz/authz_fetch.h
@@ -124,7 +124,7 @@ class AuthzExternalFetcher : public AuthzFetcher, SingleCopy {
 
  private:
   /**
-   * After 5 seconds of unresponsiveness, helper prcesses may be killed.
+   * After 5 seconds of unresponsiveness, helper processes may be killed.
    */
   static const unsigned kChildTimeout = 5;
 
@@ -190,7 +190,7 @@ class AuthzExternalFetcher : public AuthzFetcher, SingleCopy {
   pid_t pid_;
 
   /**
-   * If the external helper behaves unexectely, enter fail state and stop
+   * If the external helper behaves unexpectedly, enter fail state and stop
    * authenticating
    */
   bool fail_state_;

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -43,7 +43,7 @@ enum CacheModes {
  *
  * Writing into the cache is streamed and transactional: a file descriptor must
  * be acquired from StartTxn and the object is only visible in the cache after
- * CommitTxn.  The state of the transaction is carried in an opque transaction
+ * CommitTxn.  The state of the transaction is carried in an opaque transaction
  * object, which needs to be provided by the caller.  The size of the object is
  * returned by SizeOfTxn.  This way, users of derived classes can take care of
  * the storage allocation (e.g. on the stack), while the derived class
@@ -205,7 +205,7 @@ class CacheManager : SingleCopy {
    * When RestoreState is called, the cache has already exactly one file
    * descriptor open: the root file catalog. This file descriptor might be
    * remapped to another number. A return value of -1 means no action needs
-   * to take place. A smaller value inidicates an error.
+   * to take place. A smaller value indicates an error.
    */
   int RestoreState(const int fd_progress, void *state);
   void FreeState(const int fd_progress, void *state);
@@ -226,7 +226,7 @@ class CacheManager : SingleCopy {
  protected:
   CacheManager();
 
-  // Unless overwritten, Saving/Restoring states will crash the Fuse module
+  // Unless overridden, Saving/Restoring states will crash the Fuse module
   virtual void *DoSaveState() { return NULL; }
   virtual int DoRestoreState(void *data) { return false; }
   virtual bool DoFreeState(void *data) { return false; }

--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -1,6 +1,6 @@
 // This file is part of the CernVM File System.
 //
-// Protocol defintion for RPCs between cvmfs client and cache manager plugin.
+// Protocol definition for RPCs between cvmfs client and cache manager plugin.
 // The protocol is used to access a store of content-addressable objects that
 // are maintained by a cache manager plugin.  Objects are reference counted,
 // mirroring currently open files.  Only objects with reference count zero may
@@ -73,14 +73,14 @@ enum EnumCapabilities {
   // A read-only cache needs to be pre-populated by other means
   CAP_WRITE       = 1;
   // Proper refcounting is implemented; for lower tier caches, this capability
-  // can be unset and reference counting can simply beomce file existence check
+  // can be unset and reference counting can simply become file existence check
   CAP_REFCOUNT    = 2;
   CAP_SHRINK      = 4;   // clients can ask the cache to shrink
   CAP_INFO        = 8;   // cache plugin knows about its size and fill level
   CAP_SHRINK_RATE = 16;  // cache knows number of cleanup operations
   CAP_LIST        = 32;  // cache can return a list of objects
   CAP_ALL_V1      = 63;
-  CAP_BREADCRUMB  = 64;  // cache can load and store breadcrumps
+  CAP_BREADCRUMB  = 64;  // cache can load and store breadcrumbs
   CAP_ALL_V2      = 127;
 }
 
@@ -154,7 +154,7 @@ message MsgIoctl {
   required uint64 session_id = 1;
   // When there are no more open connections, the cache plugin can shutdown
   // itself.  During client reloads, this is unwanted.  Before the reload, the
-  // client tells the plugin to artifically increase the connection counter.
+  // client tells the plugin to artificially increase the connection counter.
   // Once reloading has finished, the connection counter is decreased again.
   optional sint32 conncnt_change_by  = 2;
 }
@@ -238,7 +238,7 @@ message MsgShrinkReply {
   required uint64 used_bytes  = 3;
 }
 
-// Read a portion from a stored object.  Garuanteed to work for objects with a
+// Read a portion from a stored object.  Guaranteed to work for objects with a
 // reference counter larger than zero.
 message MsgReadReq {
   required uint64 session_id = 1;
@@ -297,7 +297,7 @@ message MsgListReq {
 }
 
 // The cache manager decides how many objects are in each part.  The cache
-// manager assignes a unique listing id so that clients can continue to query
+// manager assigns a unique listing id so that clients can continue to query
 // for more listings.
 message MsgListReply {
   required uint64 req_id             = 1;

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -153,7 +153,7 @@ struct cvmcache_context *ctx;
 
 
 /**
- * Implements all the cache plugin callbacks.  Singelton.
+ * Implements all the cache plugin callbacks.  Singleton.
  */
 class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
  public:

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -19,7 +19,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-// Map C++ clases to their C interface names
+// Map C++ classes to their C interface names
 typedef class SimpleOptionsParser cvmcache_option_map;
 #else
 typedef struct OptionsManager cvmcache_option_map;
@@ -65,7 +65,7 @@ enum cvmcache_capabilities {
   // A read-only cache needs to be pre-populated by other means
   CVMCACHE_CAP_WRITE       = 1,
   // Proper refcounting is implemented; for lower tier caches, this capability
-  // can be unset and reference counting can simply beomce file existence check
+  // can be unset and reference counting can simply become file existence check
   CVMCACHE_CAP_REFCOUNT    = 2,
   CVMCACHE_CAP_SHRINK      = 4,   // clients can ask the cache to shrink
   CVMCACHE_CAP_INFO        = 8,   // cache plugin knows about its fill level
@@ -163,7 +163,7 @@ struct cvmcache_callbacks {
   int (*cvmcache_info)(struct cvmcache_info *info);
   int (*cvmcache_shrink)(uint64_t shrink_to, uint64_t *used);
   /**
-   * Listing can be "approximate", e.g. if files are removed and/or addded in
+   * Listing can be "approximate", e.g. if files are removed and/or added in
    * the meantime, this may or may not be reflected.
    */
   int (*cvmcache_listing_begin)(uint64_t lst_id,
@@ -224,7 +224,7 @@ void cvmcache_wait_for(struct cvmcache_context *ctx);
 uint32_t cvmcache_max_object_size(struct cvmcache_context *ctx);
 
 /**
- * Can be used to spawn a second process that superwises the cache plugin.
+ * Can be used to spawn a second process that supervises the cache plugin.
  * The watchdog can use gdb/lldb to generate stack traces.  Must be closed by
  * a call to cvmcache_close_watchdog(), otherwise the main process will be
  * reported has having died unexpectedly.

--- a/cvmfs/cache_transport.h
+++ b/cvmfs/cache_transport.h
@@ -67,7 +67,7 @@ class CacheTransport {
    */
   static const uint32_t kMaxMsgSize = (2 << 24) - 1;  // 24MB (3 bytes)
   /**
-   * The first byte has the wire protocol version, optinally or-ed with the
+   * The first byte has the wire protocol version, optionally or-ed with the
    * "has attachment" flag.  The other three bytes encode the overall message
    * size in little-endian.
    */

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -584,7 +584,7 @@ string Catalog::PrintMemStatistics() const {
 
 /**
  * Determine the actual inode of a DirectoryEntry.
- * The first used entry from a hardlink group deterimines the inode of the
+ * The first used entry from a hardlink group determines the inode of the
  * others.
  * @param row_id the row id of a read row in the sqlite database
  * @param hardlink_group the id of a possibly present hardlink group
@@ -790,7 +790,7 @@ Catalog* Catalog::FindSubtree(const PathString &path) const {
       result = FindChild(path_prefix);
 
       // If we found a child serving a part of the path we can stop searching.
-      // Remaining sub path elements are possbily served by a grand child.
+      // Remaining sub path elements are possibly served by a grand child.
       if (result != NULL)
         break;
     }
@@ -818,7 +818,7 @@ Catalog* Catalog::FindChild(const PathString &mountpoint) const {
 
 
 /**
- * For the transtion points for nested catalogs and bind mountpoints, the inode
+ * For the transition points for nested catalogs and bind mountpoints, the inode
  * is ambiguous. It has to be set to the parent inode because nested catalogs
  * are lazily loaded.
  * @param md5path the MD5 hash of the entry to check

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -312,7 +312,7 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
     }
     assert(found);
   }
-  // Not in a nested catalog (because no nested cataog fits), ENOENT
+  // Not in a nested catalog (because no nested catalog fits), ENOENT
   if (!found) {
     LogCvmfs(kLogCatalog, kLogDebug, "ENOENT: '%s'", path.c_str());
     if (dirent != NULL) *dirent = dirent_negative;
@@ -801,7 +801,7 @@ bool AbstractCatalogManager<CatalogT>::IsAttached(const PathString &root_path,
  * The final leaf nested catalog is returned.
  * The is_listable parameter is relevant if path is a nested catalog.  Only
  * if is_listable is true, the nested catalog will be used; otherwise the parent
- * with the transation point is sufficient.
+ * with the transaction point is sufficient.
  */
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::MountSubtree(

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -331,7 +331,7 @@ void WritableCatalogManager::Clone(const std::string destination,
 
 
 /**
- * Copies an entire directory tree from the exisitng from_dir to the
+ * Copies an entire directory tree from the existing from_dir to the
  * non-existing to_dir. The destination's parent directory must exist. On the
  * catalog level, the new entries will be identical to the old ones except
  * for their path hash fields.
@@ -634,7 +634,7 @@ void WritableCatalogManager::AddHardlinkGroup(
   }
 
   // Get a valid hardlink group id for the catalog the group will end up in
-  // TODO(unkown): Compaction
+  // TODO(unknown): Compaction
   uint32_t new_group_id = catalog->GetMaxLinkId() + 1;
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "hardlink group id %u issued",
            new_group_id);
@@ -724,7 +724,7 @@ void WritableCatalogManager::TouchDirectory(const DirectoryEntryBase &entry,
     LogCvmfs(kLogCatalog, kLogVerboseMsg,
              "updating transition point at %s", entry_path.c_str());
 
-    // find and mount nested catalog assciated to this transition point
+    // find and mount nested catalog associated to this transition point
     shash::Any nested_hash;
     uint64_t nested_size;
     retval = catalog->FindNested(transition_path, &nested_hash, &nested_size);
@@ -781,7 +781,7 @@ void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
                                                     // catalog gets VOMS authz
                                                new_root_entry);
   assert(retval);
-  // TODO(rmeusel): we need a way to attach a catalog directy from an open
+  // TODO(rmeusel): we need a way to attach a catalog directly from an open
   // database to remove this indirection
   delete new_catalog_db;
   new_catalog_db = NULL;
@@ -1086,12 +1086,12 @@ bool WritableCatalogManager::Commit(const bool           stop_for_tweaks,
 
 /**
  * Handles the snapshotting of dirty (i.e. modified) catalogs while trying to
- * parallize the compression and upload as much as possible. We use a parallel
+ * parallelize the compression and upload as much as possible. We use a parallel
  * depth first post order tree traversal based on 'continuations'.
  *
  * The idea is as follows:
  *  1. find all leaf-catalogs (i.e. dirty catalogs with no dirty children)
- *     --> these can be processed and uploaded immedately and independently
+ *     --> these can be processed and uploaded immediately and independently
  *         see WritableCatalogManager::GetModifiedCatalogLeafs()
  *  2. annotate non-leaf catalogs with their number of dirty children
  *     --> a finished child will notify it's parent and decrement this number
@@ -1108,7 +1108,7 @@ bool WritableCatalogManager::Commit(const bool           stop_for_tweaks,
  *       catalogs.
  *
  * TODO(rmeusel): since all leaf catalogs are finalized in the main thread, we
- *                sacrafice some potential concurrency for simplicity.
+ *                sacrifice some potential concurrency for simplicity.
  */
 WritableCatalogManager::CatalogInfo WritableCatalogManager::SnapshotCatalogs(
                                                    const bool stop_for_tweaks) {
@@ -1288,7 +1288,7 @@ void WritableCatalogManager::CatalogUploadCallback(
 
 /**
  * Finds dirty catalogs that can be snapshot right away and annotates all the
- * other catalogs with their number of dirty decendants.
+ * other catalogs with their number of dirty descendants.
  * Note that there is a convenience wrapper to start the recursion:
  *   WritableCatalogManager::GetModifiedCatalogLeafs()
  *

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -528,7 +528,7 @@ void WritableCatalog::InsertNestedCatalog(const string &mountpoint,
 
 
 /**
- * Registeres a snapshot in /.cvmfs/snapshots. Note that bind mountpoints are
+ * Registers a snapshot in /.cvmfs/snapshots. Note that bind mountpoints are
  * not universally handled: in Partition and MergeIntoParent, bind mountpoint
  * handling is missing!
  */
@@ -590,7 +590,7 @@ void WritableCatalog::RemoveNestedCatalog(const string &mountpoint,
 
 
 /**
- * Unregisteres a snapshot from /.cvmfs/snapshots. Note that bind mountpoints
+ * Unregisters a snapshot from /.cvmfs/snapshots. Note that bind mountpoints
  * are not universally handled: in Partition and MergeIntoParent, bind
  * mountpoint handling is missing!
  */

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -52,7 +52,7 @@ namespace catalog {
 //
 // 1.x (earlier - code base still in SVN)
 //     * pre-historic times
-// 0.9 (some time 2011, artifical version)
+// 0.9 (some time 2011, artificial version)
 //     * 1.0 catalogs that lack the SHA-1 value for nested catalogs
 const float CatalogDatabase::kLatestSchema = 2.5;
 const float CatalogDatabase::kLatestSupportedSchema = 2.5;  // + 1.X (r/o)

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -73,7 +73,7 @@ class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
 
 /**
  * Base class for all SQL statement classes.  It wraps a single SQL statement
- * and all neccessary calls of the sqlite3 API to deal with this statement.
+ * and all necessary calls of the sqlite3 API to deal with this statement.
  */
 class SqlCatalog : public sqlite::Sql {
  public:
@@ -169,7 +169,7 @@ class SqlCatalog : public sqlite::Sql {
 
 
 /**
- * Common ancestor of SQL statemnts that deal with directory entries.
+ * Common ancestor of SQL statements that deal with directory entries.
  */
 class SqlDirent : public SqlCatalog {
  public:
@@ -298,7 +298,7 @@ class SqlLookup : public SqlDirent {
                            const bool expand_symlink = true) const;
 
   /**
-   * DirectoryEntrys do not contain their path hash.
+   * DirectoryEntries do not contain their path hash.
    * This method retrieves the saved path hash from the database
    * @return the MD5 path hash of a freshly performed lookup
    */
@@ -350,7 +350,7 @@ class SqlLookupInode : public SqlLookup {
  * This SQL statement is only used for legacy catalog migrations and has been
  * moved here as it needs to use a locally defined macro inside catalog_sql.cc
  *
- * Queries a single catalog and looks for DirectoryEntrys that have direct
+ * Queries a single catalog and looks for DirectoryEntries that have direct
  * children in the same catalog but are marked as 'nested catalog mountpoints'.
  * This is an inconsistent situation, since a mountpoint is supposed to be empty
  * and it's children are stored in the corresponding referenced nested catalog.
@@ -358,7 +358,7 @@ class SqlLookupInode : public SqlLookup {
  * Note: the user code needs to check if there is a corresponding nested catalog
  *       reference for the found dangling mountpoints. If so, we also have a
  *       bogus state, but it is not reliably fixable automatically. The child-
- *       DirectoryEntrys would be masked by the mounting nested catalog but it
+ *       DirectoryEntries would be masked by the mounting nested catalog but it
  *       is not clear if we can simply delete them or if this would destroy data.
  */
 class SqlLookupDanglingMountpoints : public catalog::SqlLookup {

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -111,7 +111,7 @@ class CatalogTraversalBase
    * @param no_close             do not close catalogs after they were attached
    *                             (catalogs retain their parent/child pointers)
    * @param ignore_load_failure  suppressed an error message if a catalog file
-   *                             could not be loaded (i.e. was sweeped before by
+   *                             could not be loaded (i.e. was swept before by
    *                             a garbage collection run)
    * @param quiet                silence messages that would go to stderr
    * @param tmp_dir              path to the temporary directory to be used
@@ -404,7 +404,7 @@ class CatalogTraversalBase
 
   /**
    * Checks if a root catalog is below one of the pruning thresholds.
-   * Pruning thesholds can be either the catalog's history depth or a timestamp
+   * Pruning thresholds can be either the catalog's history depth or a timestamp
    * threshold applied to the last modified timestamp of the catalog.
    *
    * @param ctx  traversal context for traversal-specific state
@@ -458,7 +458,7 @@ class CatalogTraversalBase
  *
  * Breadth First Traversal Strategy
  *   Catalogs are handed out to the user identical as they are traversed.
- *   Say: From top to buttom. When you would simply print each received catalog
+ *   Say: From top to bottom. When you would simply print each received catalog
  *        the result would be a nice representation of the catalog tree.
  *   This method is more efficient, because catalogs are opened, processed and
  *   thrown away directly afterwards.
@@ -605,7 +605,7 @@ class CatalogTraversal
    *        After these steps the catalog is opened either opened and ready for
    *        the traversal to continue, or it was marked for ignore (job.ignore)
    *  3.) Check if the catalog is marked to be ignored
-   *        Catalog might not be loadable (sweeped root catalog) or is too old
+   *        Catalog might not be loadable (swept root catalog) or is too old
    *        Note: ignored catalogs can still trigger postponed yields
    *  4.) Mark the catalog as visited to be able to skip it later on
    *  5.) Find and push referencing catalogs
@@ -655,7 +655,7 @@ class CatalogTraversal
       }
     }
 
-    // invariant: after the traversal finshed, there should be no more catalogs
+    // invariant: after the traversal finished, there should be no more catalogs
     //            to traverse or to yield!
     assert(ctx->catalog_stack.empty());
     assert(ctx->callback_stack.empty());

--- a/cvmfs/catalog_virtual.cc
+++ b/cvmfs/catalog_virtual.cc
@@ -140,7 +140,7 @@ void VirtualCatalog::GenerateSnapshots() {
   vector<TagId> tags_catalog;
   GetSortedTagsFromHistory(&tags_history);
   GetSortedTagsFromCatalog(&tags_catalog);
-  // Add artifical end markers to both lists
+  // Add artificial end markers to both lists
   string tag_name_end = "";
   if (!tags_history.empty())
     tag_name_end = std::max(tag_name_end, tags_history.rbegin()->name);

--- a/cvmfs/clientctx.h
+++ b/cvmfs/clientctx.h
@@ -18,7 +18,7 @@
  * can be figured out from the system. A client context is used to download
  * files with the credentials of the caller.
  *
- * A ClientCtx encapulates thread-local storage.  It can be set somewhere at the
+ * A ClientCtx encapsulates thread-local storage.  It can be set somewhere at the
  * beginning of a file system call and used anywhere during the processing of
  * the call.  It is a singleton.
  */

--- a/cvmfs/compression.cc
+++ b/cvmfs/compression.cc
@@ -3,7 +3,7 @@
  *
  * This is a wrapper around zlib.  It provides
  * a set of functions to conveniently compress and decompress stuff.
- * Allmost all of the functions return true on success, otherwise false.
+ * Almost all of the functions return true on success, otherwise false.
  *
  * TODO: think about code deduplication
  */

--- a/cvmfs/compression.h
+++ b/cvmfs/compression.h
@@ -54,7 +54,7 @@ enum Algorithms {
  * which is a sub-class of the Compressor.  The subclass needs to implement the
  * Deflate, DeflateBound, Clone, and WillHandle functions.  For information on
  * the WillHandle function, read up on the PolymorphicConstruction class.
- * The new sub-class must be listed in the implemention of the
+ * The new sub-class must be listed in the implementation of the
  * Compressor::RegisterPlugins function.
  *
  */
@@ -66,7 +66,7 @@ class Compressor: public PolymorphicConstruction<Compressor, Algorithms> {
    * Deflate function.  The arguments and returns closely match the input and
    * output of the zlib deflate function.
    * Input:
-   *   - outbuf - Ouput buffer to write the compressed data.
+   *   - outbuf - Output buffer to write the compressed data.
    *   - outbufsize - Size of the output buffer
    *   - inbuf - Input data to be compressed
    *   - inbufsize - Size of the input buffer

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -143,7 +143,7 @@ struct DirectoryListing {
 
 const loader::LoaderExports *loader_exports_ = NULL;
 OptionsManager *options_mgr_ = NULL;
-pid_t pid_ = 0;  /**< will be set after deamon() */
+pid_t pid_ = 0;  /**< will be set after daemon() */
 quota::ListenerHandle *watchdog_listener_ = NULL;
 quota::ListenerHandle *unpin_listener_ = NULL;
 
@@ -366,7 +366,7 @@ static void inline TraceInode(const int event,
 
 /**
  * Find the inode number of a file name in a directory given by inode.
- * This or getattr is called as kind of prerequisit to every operation.
+ * This or getattr is called as kind of prerequisite to every operation.
  * We do check catalog TTL here (and reload, if necessary).
  */
 static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
@@ -1936,7 +1936,7 @@ static void ShutdownMountpoint() {
   delete cvmfs::notification_client_;
   cvmfs::notification_client_ = NULL;
 
-  // The remonter has a reference to the mount point and the inode generation
+  // The remounter has a reference to the mount point and the inode generation
   delete cvmfs::fuse_remounter_;
   cvmfs::fuse_remounter_ = NULL;
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -531,7 +531,7 @@ cvmfs_chksetup() {
     fi
   done
 
-  # Check repository specfic settings
+  # Check repository specific settings
   local repo_list="$(list_repos)"
   local repo
   for repo in $repo_list

--- a/cvmfs/cvmfs_talk.cc
+++ b/cvmfs/cvmfs_talk.cc
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
 
   int c;
   // 's' for socket would have been a better option letter but we keep 'p'
-  // for backwards compatibility.  The '+' at the beginning of the option stirng
+  // for backwards compatibility.  The '+' at the beginning of the option string
   // prevents permutation of the option and non-option arguments.
   while ((c = getopt(argc, argv, "+hi:p:")) != -1) {
     switch (c) {

--- a/cvmfs/dns.cc
+++ b/cvmfs/dns.cc
@@ -2,7 +2,7 @@
  * This file is part of the CernVM File System.
  *
  * The CernVM-FS name resolving uses objects that inherit from the Resolver
- * interface.  Resolvers implement a vector interface that resolves mutliple
+ * interface.  Resolvers implement a vector interface that resolves multiple
  * names in parallel.  Common cases such as IP addresses as names are handled
  * by the base class -- Resolver implementations only have to resolve real host
  * names to IPv4/6 addresses, using given search domains if necessary.
@@ -225,7 +225,7 @@ void Host::CopyFrom(const Host &other) {
 
 
 /**
- * Creates a copy of the original host with a new ID and sets a new dealine
+ * Creates a copy of the original host with a new ID and sets a new deadline
  * given in seconds from the current time.
  */
 Host Host::ExtendDeadline(const Host &original, unsigned seconds_from_now) {
@@ -275,7 +275,7 @@ bool Host::IsEquivalent(const Host &other) const {
 
 
 /**
- * Compares the TTL from a provious call to time() with the current time.
+ * Compares the TTL from a previous call to time() with the current time.
  */
 bool Host::IsExpired() const {
   time_t now = time(NULL);
@@ -364,7 +364,7 @@ Host Resolver::Resolve(const string &name) {
 
 
 /**
- * Calls the overwritten concrete resolver, verifies the sanity of the returned
+ * Calls the overridden concrete resolver, verifies the sanity of the returned
  * addresses and constructs the Host objects in the same order as the names.
  */
 void Resolver::ResolveMany(const vector<string> &names, vector<Host> *hosts) {
@@ -976,7 +976,7 @@ void CaresResolver::SetSystemSearchDomains() {
 
 /**
  * Polls on c-ares sockets and triggers call-backs execution.  Might be
- * necessary to call this repeatadly.
+ * necessary to call this repeatedly.
  */
 void CaresResolver::WaitOnCares() {
   // Adapted from libcurl
@@ -1014,7 +1014,7 @@ void CaresResolver::WaitOnCares() {
   }
 
   if (nfds == 0) {
-    // Call ares_process() unconditonally here, even if we simply timed out
+    // Call ares_process() unconditionally here, even if we simply timed out
     // above, as otherwise the ares name resolve won't timeout.
     ares_process_fd(*channel_, ARES_SOCKET_BAD, ARES_SOCKET_BAD);
   } else {

--- a/cvmfs/dns.h
+++ b/cvmfs/dns.h
@@ -256,7 +256,7 @@ class Resolver : SingleCopy {
 
   /**
    * Limit number of resolved IP addresses.  If throttle_ is 0 it has no effect.
-   * Otherwise, if more than thottle_ IPs are registered for a host, only
+   * Otherwise, if more than throttle_ IPs are registered for a host, only
    * throttle_ randomly picked IPs are returned.
    */
   unsigned throttle_;
@@ -287,7 +287,7 @@ class CaresResolver : public Resolver {
   /**
    * More IP addresses for a single name will be ignored.  Due to c-ares
    * exponential backoff, the number of retries should be limited to 2.
-   * That results in 2 apptempts with the given timeout and a third one with
+   * That results in 2 attempts with the given timeout and a third one with
    * the timeout doubled.
    */
   static const unsigned kMaxAddresses = 16;

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1867,7 +1867,7 @@ void DownloadManager::SetIpPreference(dns::IpPreference preference) {
 
 
 /**
- * Sets two timeout values for proxied and for direct conections, respectively.
+ * Sets two timeout values for proxied and for direct connections, respectively.
  * The timeout counts for all sorts of connection phases,
  * DNS, HTTP connect, etc.
  */
@@ -1991,7 +1991,7 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
     if (opt_proxy_groups_->size() > 1) {
       opt_proxy_groups_current_ = (opt_proxy_groups_current_ + 1) %
       opt_proxy_groups_->size();
-      // Remeber the timestamp of switching to backup proxies
+      // Remember the timestamp of switching to backup proxies
       if (opt_proxy_groups_reset_after_ > 0) {
         if (opt_proxy_groups_current_ > 0) {
           if (opt_timestamp_backup_proxies_ == 0)
@@ -2075,7 +2075,7 @@ void DownloadManager::SwitchHost() {
  * Orders the hostlist according to RTT of downloading .cvmfschecksum.
  * Sets the current host to the best-responsive host.
  * If you change the host list in between by SetHostChain(), it will be
- * overwritten by this function.
+ * overridden by this function.
  */
 void DownloadManager::ProbeHosts() {
   vector<string> host_chain;
@@ -2211,7 +2211,7 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
  *   and fallback proxies (if any).
  * Tries at most three random Stratum 1s before giving up.
  * If you change the host list in between by SetHostChain() or the fallback
- *   proxy list by SetProxyChain(), they will be overwritten by this function.
+ *   proxy list by SetProxyChain(), they will be overridden by this function.
  */
 bool DownloadManager::ProbeGeo() {
   vector<string> host_chain;

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -26,7 +26,7 @@ class Statistics;
 namespace cvmfs {
 
 /**
- * TransacionSink uses an open transaction in a cache manager as a sink.  It
+ * TransactionSink uses an open transaction in a cache manager as a sink.  It
  * allows the download manager to write data without knowing about the cache
  * manager.
  */

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -27,7 +27,7 @@ class NentryTracker;
  * fuse_lowlevel_notify_inval_entry, it falls back to waiting for drainout.
  *
  * Evicting entries from the cache must be done from a separate thread to
- * avoid a deadlock in the fuse callbacks (see Fuse documenatation).
+ * avoid a deadlock in the fuse callbacks (see Fuse documentation).
  */
 class FuseInvalidator : SingleCopy {
   FRIEND_TEST(T_FuseInvalidator, StartStop);

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -126,7 +126,7 @@ FuseRemounter::Status FuseRemounter::Check() {
 
 
 /**
- * Used from the TalkManager.  Continously calls 'check' until it returns with
+ * Used from the TalkManager.  Continuously calls 'check' until it returns with
  * "up to date" or a failure.
  */
 FuseRemounter::Status FuseRemounter::CheckSynchronously() {

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -116,7 +116,7 @@ class FuseRemounter : SingleCopy {
    */
   time_t catalogs_valid_until_;
   /**
-   * In drainout mode, the fuse module sets the timeout of meta data replys to
+   * In drainout mode, the fuse module sets the timeout of meta data replies to
    * zero.  If supported by Fuse, the FuseInvalidator will evict all active
    * entries from the kernel cache.  Drainout mode is left only once the new
    * root catalog is active (after TryFinish()).

--- a/cvmfs/hash.h
+++ b/cvmfs/hash.h
@@ -116,7 +116,7 @@ typedef char Suffix;
  * Holds a hash digest and provides from string / to string conversion and
  * comparison.  The kAny algorithm may not be used in functions!  The algorithm
  * has to be changed beforehand.
- * This class is not used directly, but used as base clase of Md5, Sha1, ...
+ * This class is not used directly, but used as base class of Md5, Sha1, ...
  */
 template<unsigned digest_size_, Algorithms algorithm_>
 struct Digest {
@@ -214,7 +214,7 @@ struct Digest {
    * Generates a purely random hash
    * Only used for testing purposes
    *
-   * @param seed  random number generator seed (for reproducability)
+   * @param seed  random number generator seed (for reproducibility)
    */
   void Randomize(const uint64_t seed) {
     Prng prng;
@@ -226,7 +226,7 @@ struct Digest {
    * Generates a purely random hash
    * Only used for testing purposes
    *
-   * @param prng  random number generator object (for external reproducability)
+   * @param prng  random number generator object (for external reproducibility)
    */
   void Randomize(Prng *prng) {
     const unsigned bytes = GetDigestSize();
@@ -239,7 +239,7 @@ struct Digest {
   void set_suffix(const Suffix s) { suffix = s; }
 
   /**
-   * Generates a hexified repesentation of the digest including the identifier
+   * Generates a hexified representation of the digest including the identifier
    * string for newly added hashes.
    *
    * @param with_suffix  append the hash suffix (C,H,X, ...) to the result
@@ -264,7 +264,7 @@ struct Digest {
   }
 
   /**
-   * Generates a hexified repesentation of the digest including the identifier
+   * Generates a hexified representation of the digest including the identifier
    * string for newly added hashes.  Output is in the form of
    * 'openssl x509 fingerprint', e.g. 00:AA:BB:...-SHAKE128
    *
@@ -492,7 +492,7 @@ unsigned GetContextSize(const Algorithms algorithm);
 
 /**
  * Holds an OpenSSL context, only required for hash operations.  Allows to
- * deferr the storage allocation for the context to alloca.
+ * defer the storage allocation for the context to alloca.
  */
 class ContextPtr {
  public:
@@ -533,7 +533,7 @@ inline void HmacString(const std::string &key, const std::string &content,
  * Only used for AWS4 signature.
  *
  * Adding SHA-256 to the standard hash infrastructure would generally bloat the
- * digets size to 32 bytes and require client data structure transformation
+ * digits size to 32 bytes and require client data structure transformation
  * during hotpatch.
  */
 std::string Hmac256(const std::string &key, const std::string &content,

--- a/cvmfs/history.h
+++ b/cvmfs/history.h
@@ -164,7 +164,7 @@ class History {
   virtual bool ExistsBranch(const std::string &branch_name) const = 0;
   virtual bool InsertBranch(const Branch &branch) = 0;
   /**
-   * When removing tags, branches can become abandonded. Remove abandoned
+   * When removing tags, branches can become abandoned. Remove abandoned
    * branches and redirect the parent pointer of their child branches.
    */
   virtual bool PruneBranches() = 0;
@@ -204,7 +204,7 @@ class History {
 
   /**
    * Provides a list of all referenced catalog hashes in this History.
-   * The hashes will be ordered by their timestamp in acending order.
+   * The hashes will be ordered by their timestamp in ascending order.
    *
    * @param hashes  pointer to the result vector to be filled
    */

--- a/cvmfs/history_sqlite.h
+++ b/cvmfs/history_sqlite.h
@@ -134,7 +134,7 @@ class SqliteHistory : public History {
   /**
    * Provides a list of all referenced catalog hashes in this History.
    * The hashes will be ordered by their associated revision number in
-   * acending order.
+   * ascending order.
    *
    * @param hashes  pointer to the result vector to be filled
    */

--- a/cvmfs/ingestion/ingestion_source.h
+++ b/cvmfs/ingestion/ingestion_source.h
@@ -26,7 +26,7 @@
  * The purpose of this class is to add a common interface for object that are
  * ingested by the pipeline. Hence the pipeline is able to ingest everything
  * that implements this interface.
- * The ownership of new IngestionSource objects is transfered from their creator
+ * The ownership of new IngestionSource objects is transferred from their creator
  * directly to the pipeline itself that will take care of deallocating
  * everything.
  * The pipeline is multithreaded so it is very likely that the code implement in
@@ -80,7 +80,7 @@ class FileIngestionSource : public IngestionSource {
     if (fd_ == -1) return true;
 
     // tell to the OS that we are not going to access the file again in the
-    // foreaseable future.
+    // foreseeable future.
     (void)platform_invalidate_kcache(fd_, 0, 0);
 
     int ret = close(fd_);

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -34,7 +34,7 @@ struct AllocHeader {
 
 
 /**
- * A MmeoryBuffer is used in the staging phase of new objects until they are
+ * A MemoryBuffer is used in the staging phase of new objects until they are
  * committed.
  */
 struct MemoryBuffer {

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -61,7 +61,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-// Map C++ clases to their C interface names
+// Map C++ classes to their C interface names
 typedef class LibContext cvmfs_context;
 typedef class SimpleOptionsParser cvmfs_option_map;
 #else

--- a/cvmfs/libcvmfs_int.h
+++ b/cvmfs/libcvmfs_int.h
@@ -150,7 +150,7 @@ class LibContext : SingleCopy {
                            struct cvmfs_attr *attr);
 
   /**
-   * Only non-NULL if cvmfs_attache_repo is used for initialization.  In this
+   * Only non-NULL if cvmfs_attach_repo is used for initialization.  In this
    * case, the options manager needs to be cleaned up by cvmfs_fini.
    */
   OptionsManager *options_mgr_;

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -817,7 +817,7 @@ int FuseMain(int argc, char *argv[]) {
   if (options_manager->GetValue("CVMFS_SYSLOG_FACILITY", &parameter))
     SetLogSyslogFacility(String2Int64(parameter));
   SetLogSyslogPrefix(*repository_name_);
-  // Deferr setting usyslog until credentials are dropped
+  // Defer setting usyslog until credentials are dropped
 
   // Permissions check
   if (options_manager->GetValue("CVMFS_CHECK_PERMISSIONS", &parameter)) {

--- a/cvmfs/logging.cc
+++ b/cvmfs/logging.cc
@@ -441,7 +441,7 @@ void LogCvmfs(const LogSource source, const int mask, const char *format, ...) {
   if (mask & kLogDebug) {
     pthread_mutex_lock(&lock_debug);
 
-    // Set the file pointer for debuging to stderr, if necessary
+    // Set the file pointer for debugging to stderr, if necessary
     if (file_debug == NULL) file_debug = stderr;
 
     // Get timestamp

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -53,7 +53,7 @@ class BaseMagicXattr {
   /**
    * This function needs to be called after PrepareValueFenced(),
    * which prepares the necessary data.
-   * It does the computationaly intensive part, which should not
+   * It does the computationally intensive part, which should not
    * be done inside the FuseRemounter::fence(), and returns the
    * value.
    */

--- a/cvmfs/malloc_arena.cc
+++ b/cvmfs/malloc_arena.cc
@@ -101,7 +101,7 @@ void MallocArena::Free(void *ptr) {
 
 
 /**
- * Inserts an avilable block at the end of the free list.
+ * Inserts an available block at the end of the free list.
  */
 void MallocArena::EnqueueAvailBlock(AvailBlockCtl *block) {
   AvailBlockCtl *next = head_avail_;

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -98,7 +98,7 @@ void MallocHeap::MarkFree(void *block) {
   stored_ -= tag->GetSize();
   num_blocks_--;
   // TODO(jblomer): if MarkFree() takes place at the top of the heap, one could
-  // move back the gauge_ pointer.  If this is an optimiziation or unnecessary
+  // move back the gauge_ pointer.  If this is an optimization or unnecessary
   // extra work depends on how the MallocHeap is used.
 }
 

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -156,7 +156,7 @@ class Manifest {
   bool garbage_collectable_;
 
   /**
-   * The root catalog and the certifacte might be available as .cvmfscatalog and
+   * The root catalog and the certificate might be available as .cvmfscatalog and
    * .cvmfscertificate.  That is helpful if the data subdirectory is protected
    * on the web server.
    */

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -2,7 +2,7 @@
  * This file is part of the CernVM File System.
  *
  * This module forks a watchdog process that listens on
- * a pipe and prints a stackstrace into syslog, when cvmfs
+ * a pipe and prints a stacktrace into syslog, when cvmfs
  * fails.
  *
  * Also, it handles getting and setting the maximum number of file descriptors.
@@ -212,7 +212,7 @@ string Watchdog::ReadUntilGdbPrompt(int fd_pipe) {
   int           chars_io;
   unsigned int  ring_buffer_pos = 0;
 
-  // read from stdout of gdb until gdb prompt occures --> (gdb)
+  // read from stdout of gdb until gdb prompt occurs --> (gdb)
   while (1) {
     chars_io = read(fd_pipe, &mini_buffer, 1);
 
@@ -221,7 +221,7 @@ string Watchdog::ReadUntilGdbPrompt(int fd_pipe) {
 
     result += mini_buffer;
 
-    // find the gdb_promt in the stdout data
+    // find the gdb_prompt in the stdout data
     if (mini_buffer == gdb_prompt[ring_buffer_pos]) {
       ++ring_buffer_pos;
       if (ring_buffer_pos == gdb_prompt.size()) {

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -5,7 +5,7 @@
  * issued once by an NFS exported file system might be asked for
  * any time later by clients.
  *
- * In "NFS mode", cvmfs will issue inodes consequtively and reuse inodes
+ * In "NFS mode", cvmfs will issue inodes consecutively and reuse inodes
  * based on path name.  The inode --> path and path --> inode maps are
  * handled by leveldb.  This workaround is comparable to the Fuse "noforget"
  * option, except that the mappings are persistent and thus consistent during

--- a/cvmfs/nfs_maps_sqlite.cc
+++ b/cvmfs/nfs_maps_sqlite.cc
@@ -5,7 +5,7 @@
  * issued once by an NFS exported file system might be asked for
  * any time later by clients.
  *
- * In "NFS mode", cvmfs will issue inodes consequtively and reuse inodes
+ * In "NFS mode", cvmfs will issue inodes consecutively and reuse inodes
  * based on path name.  The inode --> path and path --> inode maps are
  * handled by sqlite.  This workaround is comparable to the Fuse "noforget"
  * option, except that the mappings are persistent and thus consistent during

--- a/cvmfs/notify/publisher_http.h
+++ b/cvmfs/notify/publisher_http.h
@@ -14,7 +14,7 @@ namespace notify {
 /**
  * Implementation of Publisher based on HTTP
  *
- * Messsages are published to the notification system backend using cURL
+ * Messages are published to the notification system backend using cURL
  */
 class PublisherHTTP : public Publisher {
  public:

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -2,7 +2,7 @@
  * This file is part of the CernVM File System.
  *
  * Fills an internal map of key-value pairs from ASCII files in key=value
- * style.  Parameters can be overwritten.  Used to read configuration from
+ * style.  Parameters can be overridden.  Used to read configuration from
  * /etc/cvmfs/...
  */
 

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -169,7 +169,7 @@ enum State {
  * "object pack", which otherwise would need special treatment.
  *
  * The serialized format has a global, human readable header which has lines of
- * character keys and string values (like the cvmfs manifest) follwed by a "--"
+ * character keys and string values (like the cvmfs manifest) followed by a "--"
  * separator line followed by the index of objects. The index contains one line
  * for each item in the pack. Each line contains the following space-separated
  * tokens:

--- a/cvmfs/path_filters/dirtab.h
+++ b/cvmfs/path_filters/dirtab.h
@@ -12,7 +12,7 @@
 
 namespace catalog {
 
-// TODO(jblomer): Dirtab and RelaxedPathFilter can use static inhertiance.  It
+// TODO(jblomer): Dirtab and RelaxedPathFilter can use static inheritance.  It
 // is clear at compile time which one should be used.  They are not on a
 // critical path though.
 
@@ -20,7 +20,7 @@ namespace catalog {
  * A Dirtab is handling the parsing and processing of the .cvmfsdirtab file.
  * The .cvmfsdirtab contains a list of Pathspecs that define where CernVM-FS
  * should automatically create nested catalogs. Furthermore it can contain neg-
- * ative rules to omit the automatic creation of nested catalogs in certain
+ * native rules to omit the automatic creation of nested catalogs in certain
  * directories.
  *
  * Example (adding a space in front of * - silence compiler warning):

--- a/cvmfs/platform_linux.h
+++ b/cvmfs/platform_linux.h
@@ -178,7 +178,7 @@ inline int platform_sigwait(const int signum) {
 }
 
 /**
- * Grants a PID capabilites for ptrace() usage
+ * Grants a PID capabilities for ptrace() usage
  *
  * @param PID  the PID of the process to be granted ptrace()-access
  *             (may be ignored)

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -73,7 +73,7 @@ class __attribute__((visibility("default"))) DiffListener {
 class __attribute__((visibility("default"))) Env {
  public:
   /**
-   * Depending on the desired course of action, the permitted capabilites of the
+   * Depending on the desired course of action, the permitted capabilities of the
    * binary (cap_dac_read_search, cap_sys_admin) needs to be dropped or gained.
    * Dropped for creating user namespaces in `enter`, gained for walking through
    * overlayfs.
@@ -105,7 +105,7 @@ class __attribute__((visibility("default"))) Repository : SingleCopy {
   void List();
 
   /**
-   * From and to are either tag names or catalog root hashes preceeded by
+   * From and to are either tag names or catalog root hashes preceded by
    * a '@'.
    */
   void Diff(const std::string &from, const std::string &to,
@@ -194,7 +194,7 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
      */
     void Mount();
     /**
-     * Move scratch space to waste bin and clear it out asynchonously
+     * Move scratch space to waste bin and clear it out asynchronously
      */
     void ClearScratch();
 

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -289,7 +289,7 @@ SettingsRepository::SettingsRepository(
 
 
 void SettingsRepository::SetUrl(const std::string &url) {
-  // TODO(jblomer): sanitiation, check availability
+  // TODO(jblomer): sanitization, check availability
   url_ = url;
 }
 
@@ -334,7 +334,7 @@ SettingsPublisher::SettingsPublisher(
 
 
 void SettingsPublisher::SetUrl(const std::string &url) {
-  // TODO(jblomer): sanitiation, check availability
+  // TODO(jblomer): sanitization, check availability
   url_ = url;
 }
 

--- a/cvmfs/publish/settings.h
+++ b/cvmfs/publish/settings.h
@@ -21,8 +21,8 @@ class OptionsManager;
 namespace publish {
 
 /**
- * Allows for settings that remember whether they have been explictily
- * overwritten.  Otherwise, default values can be changed to upstream repository
+ * Allows for settings that remember whether they have been explicitly
+ * overridden.  Otherwise, default values can be changed to upstream repository
  * settings.
  */
 template <class T>
@@ -69,7 +69,7 @@ enum EUnionMountRepairMode {
 
 
 // Settings from the point of construction always represent a valid
-// configuration. The constructor sets default values, which can be overwritten
+// configuration. The constructor sets default values, which can be overridden
 // by setters. The setters throw errors when invalid options are detected.
 
 class SettingsSpoolArea {
@@ -124,7 +124,7 @@ class SettingsSpoolArea {
   Setting<std::string> tmp_dir_;
   Setting<std::string> union_mnt_;
   /**
-   * How aggresively should the mount point stack be repaired
+   * How aggressively should the mount point stack be repaired
    */
   Setting<EUnionMountRepairMode> repair_mode_;
 };  // SettingsSpoolArea
@@ -490,7 +490,7 @@ class SettingsBuilder : SingleCopy {
    * If ident is a url, creates a generic settings object inferring the fqrn
    * from the url.
    * Otherwise, looks in the config files in /etc/cvmfs/repositories.d/<alias>/
-   * If alias is an empty string, the command still succeds iff there is a
+   * If alias is an empty string, the command still succeeds iff there is a
    * single repository under /etc/cvmfs/repositories.d
    */
   SettingsRepository CreateSettingsRepository(const std::string &ident);
@@ -499,7 +499,7 @@ class SettingsBuilder : SingleCopy {
    * If ident is a url, creates a generic settings object inferring the fqrn
    * from the url.
    * Otherwise, looks in the config files in /etc/cvmfs/repositories.d/<alias>/
-   * If alias is an empty string, the command still succeds iff there is a
+   * If alias is an empty string, the command still succeeds iff there is a
    * single repository under /etc/cvmfs/repositories.d
    * If needs_managed is true, remote repositories are rejected
    * In an "enter environment" (see cmd_enter), the spool area of the enter
@@ -552,7 +552,7 @@ class SettingsBuilder : SingleCopy {
   std::map<std::string, std::string> GetSessionEnvironment();
 
   /**
-   * Create settings from an ephermal writable shell
+   * Create settings from an ephemeral writable shell
    */
   SettingsPublisher* CreateSettingsPublisherFromSession();
 };  // class SettingsBuilder

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -488,7 +488,7 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       pid_t pid;
       int statloc;
       if ((pid = fork()) == 0) {
-        // TODO(jblomer): eviciting files in the cache should perhaps become a
+        // TODO(jblomer): evicting files in the cache should perhaps become a
         // thread.  This would also allow to block the chunks and prevent the
         // race with re-insertion.  Then again, a thread can block umount.
 #ifndef DEBUGMSG

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -186,7 +186,7 @@ class PosixQuotaManager : public QuotaManager {
 
   /**
    * Make sure that the amount of data transferred through the RPC pipe is
-   * within the OS's guarantees for atomiticity.
+   * within the OS's guarantees for atomicity.
    */
   static const unsigned kMaxDescription = 512-sizeof(LruCommand);
 

--- a/cvmfs/s3fanout.h
+++ b/cvmfs/s3fanout.h
@@ -328,7 +328,7 @@ class S3FanoutManager : SingleCopy {
   // thread than writing.
   Statistics *statistics_;
 
-  // Report not every occurance of throtteling but only every so often
+  // Report not every occurrence of throttling but only every so often
   uint64_t timestamp_last_throttle_report_;
 
   bool is_curl_debug_;

--- a/cvmfs/server/cvmfs_server_add_replica.sh
+++ b/cvmfs/server/cvmfs_server_add_replica.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server add-replica" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -5,7 +5,7 @@
 #
 # Functionality related to the Apache web server
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 
 
@@ -42,7 +42,7 @@ reload_apache() {
 }
 
 
-# An Apache reload is asynchronous, the new configration is not immediately
+# An Apache reload is asynchronous, the new configuration is not immediately
 # accessible.  Wait up to 1 minute until a test url can be fetched
 wait_for_apache() {
   local url="$1"

--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server check" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 
@@ -246,7 +246,7 @@ __do_all_checks() {
       echo "ERROR from cvmfs_server check!" >&2
     else
       check_status=succeeded
-      to_syslog_for_repo $repo "sucessfully completed check"
+      to_syslog_for_repo $repo "successfully completed check"
     fi
     update_repo_status $repo check_status $check_status
     echo "Finished $repo at `date`"

--- a/cvmfs/server/cvmfs_server_checkout.sh
+++ b/cvmfs/server/cvmfs_server_checkout.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server checkout" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_chown.sh
+++ b/cvmfs/server/cvmfs_server_chown.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server chown" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -30,7 +30,7 @@ if [ -f /etc/cvmfs/server.local ]; then
   fi
 fi
 
-# setup server hooks: no-ops (overrideable by /etc/cvmfs/cvmfs_server_hooks.sh)
+# setup server hooks: no-ops (overridable by /etc/cvmfs/cvmfs_server_hooks.sh)
 transaction_before_hook() { :; }
 transaction_after_hook() { :; }
 abort_before_hook() { :; }
@@ -110,7 +110,7 @@ CVMFS_SERVER_SWISSKNIFE_DEBUG=$CVMFS_SERVER_SWISSKNIFE
 CVMFS_SERVER_PUBLISH="/usr/bin/cvmfs_publish"
 CVMFS_SERVER_PUBLISH_DEBUG=$CVMFS_SERVER_PUBLISH
 
-# On newer Apache version, reloading is asynchonrous and not guaranteed to succeed.
+# On newer Apache version, reloading is asynchronous and not guaranteed to succeed.
 # The integration test cases set this parameter to true.
 CVMFS_SERVER_APACHE_RELOAD_IS_RESTART=${CVMFS_SERVER_APACHE_RELOAD_IS_RESTART:=false}
 

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -7,7 +7,7 @@
 #
 
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_json.sh
 
@@ -299,7 +299,7 @@ get_published_root_hash() {
 # retrieves the current manifest without signature
 #
 # @param repository_name   the name of the repository to be checked
-# @return                  echoes the published manufest
+# @return                  echoes the published manifest
 get_raw_manifest() {
   local repository_name=$1
 
@@ -590,7 +590,7 @@ get_expiry_from_string() {
 # figures out the time to expiry of the repository's whitelist
 #
 # @param stratum0  path/URL to stratum0 storage
-# @return          number of seconds until expiry (negativ if already expired)
+# @return          number of seconds until expiry (negative if already expired)
 get_expiry() {
   local name=$1
   local stratum0=$2

--- a/cvmfs/server/cvmfs_server_compat.sh
+++ b/cvmfs/server/cvmfs_server_compat.sh
@@ -4,7 +4,7 @@
 # on a Stratum 0/1 server
 
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_deprecated.sh
+++ b/cvmfs/server/cvmfs_server_deprecated.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of deprecated cvmfs_server commands
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_eliminate_bulk_hashes.sh
+++ b/cvmfs/server/cvmfs_server_eliminate_bulk_hashes.sh
@@ -4,7 +4,7 @@
 #
 # Implementation of the "cvmfs_server eliminate-bulk-hashes" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_eliminate_hardlinks.sh
+++ b/cvmfs/server/cvmfs_server_eliminate_hardlinks.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server eliminate-hardlinks" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_fix_permissions.sh
+++ b/cvmfs/server/cvmfs_server_fix_permissions.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server fix-permissions" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_fix_stats.sh
+++ b/cvmfs/server/cvmfs_server_fix_stats.sh
@@ -3,7 +3,7 @@
 #
 # Implementation of the "cvmfs_server fix-stats" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server gc" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 
@@ -96,7 +96,7 @@ cvmfs_server_gc() {
     fi
   done
 
-  # TODO: Once the gateway administration endpoint is in place (CVM-1685), it should be forbidded
+  # TODO: Once the gateway administration endpoint is in place (CVM-1685), it should be forbidden
   #       to run GC directly on the gateway
   # Check if the command is called on a repository gateway, and if so,
   # abort if there are any active leases

--- a/cvmfs/server/cvmfs_server_health_check.sh
+++ b/cvmfs/server/cvmfs_server_health_check.sh
@@ -4,7 +4,7 @@
 # on a Stratum 0/1 server
 #
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server import" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_info.sh
+++ b/cvmfs/server/cvmfs_server_info.sh
@@ -6,7 +6,7 @@
 # Implementation of the "cvmfs_server info" command
 # Migrated to the new cvmfs_publish command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server ingest-tarball" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 
@@ -79,7 +79,7 @@ cvmfs_server_ingest() {
     if [ ! x"$tar_file" = "x" ] && [ ! x"$to_delete" = "x" ]; then
       die "Could not delete and add a file in the same transaction while using gateway."
     fi
-    # by the chek above we are sure that there is only a tar_file to ingest or a directory to_delete
+    # by the check above we are sure that there is only a tar_file to ingest or a directory to_delete
     # hence we just concatenate them with the name for the transaction
     cvmfs_server_transaction "$name/$base_dir$to_delete" || die "Impossible to start a transaction"
   else

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -5,7 +5,7 @@
 #
 # JSON "API" related functions
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_list.sh
+++ b/cvmfs/server/cvmfs_server_list.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server list" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_list_catalogs.sh
+++ b/cvmfs/server/cvmfs_server_list_catalogs.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server list-catalogs" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_masterkeycard.sh
+++ b/cvmfs/server/cvmfs_server_masterkeycard.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server masterkeycard" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_sys.sh
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server migrate" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server mkfs" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_mount.sh
+++ b/cvmfs/server/cvmfs_server_mount.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server mount" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_resign.sh
+++ b/cvmfs/server/cvmfs_server_resign.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server resign" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_rmfs.sh
+++ b/cvmfs/server/cvmfs_server_rmfs.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server rmfs" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_rollback.sh
+++ b/cvmfs/server/cvmfs_server_rollback.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server rollback" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_skeleton.sh
+++ b/cvmfs/server/cvmfs_server_skeleton.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server skeleton" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server snapshot" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 
@@ -186,7 +186,7 @@ __do_all_snapshots() {
   local skip_noninitial=0
   local snapshot_group
   local log
-  local fullog
+  local fulllog
   local repo
   local repos
 

--- a/cvmfs/server/cvmfs_server_ssl.sh
+++ b/cvmfs/server/cvmfs_server_ssl.sh
@@ -5,7 +5,7 @@
 #
 # Functionality related to SSL
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_sys.sh
 # - cvmfs_server_util.sh
 # - cvmfs_server_masterkeycard.sh

--- a/cvmfs/server/cvmfs_server_tag.sh
+++ b/cvmfs/server/cvmfs_server_tag.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server tag" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_update_info.sh
+++ b/cvmfs/server/cvmfs_server_update_info.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server update-info" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_update_repoinfo.sh
+++ b/cvmfs/server/cvmfs_server_update_repoinfo.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server update-repoinfo" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -568,7 +568,7 @@ check_upstream_validity() {
 # @return  0 if overlayfs is installed and viable
 #          1 if it is not viable, and stdout contains a reason
 # This should probably now be called check_overlayfs_viability except
-#   that for backward compatiblity we need to keep the variable that
+#   that for backward compatibility we need to keep the variable that
 #   overrides it, CVMFS_DONT_CHECK_OVERLAYFS_VERSION, and changing the
 #   function name would make the variable name not make sense.
 check_overlayfs_version() {

--- a/cvmfs/shrinkwrap/fs_traversal_interface.h
+++ b/cvmfs/shrinkwrap/fs_traversal_interface.h
@@ -95,7 +95,7 @@ struct fs_traversal {
    * @note(steuber): The content checksum only needs to be calculated if this
    * is a source file system!
    * 
-   * For correnct behaviour the following fields must be set
+   * For correct behaviour the following fields must be set
    * (and may not be NULL):
    * - version
    * - size
@@ -139,7 +139,7 @@ struct fs_traversal {
    * This assumes that other information is the same, and
    * only updates the metadata. Used only on directories.
    *
-   * @param[in] ctx The file systme traverssal context
+   * @param[in] ctx The file system traversal context
    * @param[in] path The path of the object to be updated
    * @param[in] stat The stat structure that determines the new values
    * @returns 0 on success, -1 otherwise

--- a/cvmfs/shrinkwrap/posix/data_dir_mgmt.h
+++ b/cvmfs/shrinkwrap/posix/data_dir_mgmt.h
@@ -9,10 +9,10 @@
 #include <string>
 
 /**
- * The functions in this file handle the managment of the .data directory
+ * The functions in this file handle the management of the .data directory
  * structure in the POSIX File System Traversal interface.
  * 
- * The .data directory structure contains (meta)content-adressable links to all
+ * The .data directory structure contains (meta)content-addressable links to all
  * inodes of the exported file system. This is used for deduplication.
  */
 

--- a/cvmfs/shrinkwrap/posix/helpers.h
+++ b/cvmfs/shrinkwrap/posix/helpers.h
@@ -27,7 +27,7 @@ struct fs_traversal_posix_context {
 };
 
 /**
- * INTIALIZATION FUNCTIONS
+ * INITIALIZATION FUNCTIONS
  */
 void InitialFsOperations(struct fs_traversal_context *ctx);
 void FinalizeFsOperations(struct fs_traversal_context *ctx);

--- a/cvmfs/shrinkwrap/posix/interface.cc
+++ b/cvmfs/shrinkwrap/posix/interface.cc
@@ -459,7 +459,7 @@ bool posix_is_hash_consistent(struct fs_traversal_context *ctx,
   struct stat hidden_path_stat;
   int res2 = stat(hidden_datapath.c_str(), &hidden_path_stat);
   if (res2 == -1) {
-    // If hidden path doesn't exist although apprently existing => error
+    // If hidden path doesn't exist although apparently existing => error
     return false;
   }
   return display_path_stat.st_ino == hidden_path_stat.st_ino;

--- a/cvmfs/shrinkwrap/spec_tree.h
+++ b/cvmfs/shrinkwrap/spec_tree.h
@@ -34,7 +34,7 @@ class SpecTreeNode {
    * ^: include flat copy from here on
    * 
    * _: passby directory
-   * -: NOT passby directory (for internal purposes, can be overwritten by _)
+   * -: NOT passby directory (for internal purposes, can be overridden by _)
    * 
    * !: Do not include this file
    */

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -2,7 +2,7 @@
  * This file is part of the CernVM File System.
  *
  * This is a wrapper around OpenSSL's libcrypto.  It supports
- * signing of data with an X.509 certificate and verifiying
+ * signing of data with an X.509 certificate and verifying
  * a signature against a certificate.  The certificates can act only as key
  * store, in which case there is no verification against the CA chain.
  *
@@ -725,7 +725,7 @@ bool SignatureManager::VerifyCaChain() {
 /**
  * Signs a data block using the loaded private key.
  *
- * \return True on sucess, false otherwise
+ * \return True on success, false otherwise
  */
 bool SignatureManager::Sign(const unsigned char *buffer,
                             const unsigned buffer_size,
@@ -773,7 +773,7 @@ bool SignatureManager::Sign(const unsigned char *buffer,
 /**
  * Signs a data block using the loaded private master key.
  *
- * \return True on sucess, false otherwise
+ * \return True on success, false otherwise
  */
 bool SignatureManager::SignRsa(const unsigned char *buffer,
                                const unsigned buffer_size,
@@ -805,7 +805,7 @@ bool SignatureManager::SignRsa(const unsigned char *buffer,
 
 
 /**
- * Veryfies a signature against loaded certificate.
+ * Verifies a signature against loaded certificate.
  *
  * \return True if signature is valid, false on error or otherwise
  */
@@ -852,7 +852,7 @@ bool SignatureManager::Verify(const unsigned char *buffer,
 
 
 /**
- * Veryfies a signature against all loaded public keys.
+ * Verifies a signature against all loaded public keys.
  *
  * \return True if signature is valid with any public key, false on error or otherwise
  */

--- a/cvmfs/sql.cc
+++ b/cvmfs/sql.cc
@@ -55,7 +55,7 @@ bool Sql::Execute() {
 /**
  * Execute the prepared statement or fetch its next row.
  * This method is intended to step through the result set.
- * If it returns false this does not neccessarily mean, that the actual
+ * If it returns false this does not necessarily mean, that the actual
  * statement execution failed, but that no row was fetched.
  * @return true if a new row was fetched otherwise false
  */

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -36,7 +36,7 @@ struct MemStatistics {
   int page_cache_hit;
   int page_cache_miss;
   int schema_used;  ///< Bytes used to store db schema
-  int stmt_used;  ///< Bytes used for prepared statmements (lookaside + heap)
+  int stmt_used;  ///< Bytes used for prepared statements (lookaside + heap)
 };
 
 class Sql;
@@ -307,7 +307,7 @@ class Database : SingleCopy {
 
 /**
  * Base class for all SQL statement classes.  It wraps a single SQL statement
- * and all neccessary calls of the sqlite3 API to deal with this statement.
+ * and all necessary calls of the sqlite3 API to deal with this statement.
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE  *

--- a/cvmfs/sqlitemem.h
+++ b/cvmfs/sqlitemem.h
@@ -60,7 +60,7 @@ class SqliteMemoryManager {
   static const unsigned kScratchSize = kScratchSlotSize * kScratchNoSlots;
 
   /**
-   * Empricially, the largest page cache allocation is 1296B.
+   * Empirically, the largest page cache allocation is 1296B.
    */
   static const unsigned kPageCacheSlotSize = 1300;
   /**

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -3,7 +3,7 @@
  *
  * An optimized virtual file system layer for the client only.  It expects to
  * operate on immutable, valid SQlite files.  Hence it can do a few
- * optimiziations.  Most notably it doesn't need to know about the path of
+ * optimizations.  Most notably it doesn't need to know about the path of
  * the SQlite file once opened.  It works purely on the file descriptor.
  */
 

--- a/cvmfs/ssl.h
+++ b/cvmfs/ssl.h
@@ -12,10 +12,10 @@
 /**
  * Manages the location of certificates, either system certificates or
  * the ones in $X509_CERT_DIR or /etc/grid-security/certificates
- * On construction, $X509_CERT_DIR has precendence over
+ * On construction, $X509_CERT_DIR has precedence over
  * /etc/grid-security/certificates.
  * $X509_CERT_BUNDLE is checked for a bundle.
- * The path settings can later be overwritten by UseSystemCertificatePath();
+ * The path settings can later be overridden by UseSystemCertificatePath();
  * the $X509_CERT_BUNDLE settings are unaffected by UseSystemCertificatePath().
  */
 class SslCertificateStore {

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -92,7 +92,7 @@ class Statistics {
 
 /**
  * Allows multiple instance of the same class to use the same Statistics
- * instance.  The "name_major" part is used to contruct counter names in the
+ * instance.  The "name_major" part is used to construct counter names in the
  * form name_major.<provided name>
  */
 class StatisticsTemplate {
@@ -191,12 +191,12 @@ class Recorder {
  private:
   /**
    * Records number of ticks (events) per unit of resolution.  A ring buffer.
-   * Entries older than capacity_s get overwritten by new events.
+   * Entries older than capacity_s get overridden by new events.
    */
   std::vector<uint32_t> bins_;
 
   /**
-   * When the most recent tick occured.
+   * When the most recent tick occurred.
    */
   uint64_t last_timestamp_;
 
@@ -218,7 +218,7 @@ class Recorder {
 
 
 /**
- * Writes to multiple recorders.  Recorders with coarsed-grained resolution and
+ * Writes to multiple recorders.  Recorders with coarse resolution and
  * a large capacity are combined with precise recorders with shorter capacity.
  * Preferred recorders should be added first because GetNoTicks will use the
  * first recorder with a capacity >= retrospect_s (or the last recorder).

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -28,7 +28,7 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   bool StoreEntry(const std::string &insert_statement);
 
 /**
- * Prune the statistics DB (delete records older than certain threshhold)
+ * Prune the statistics DB (delete records older than certain threshold)
  * @param days number of days of records to keep, 0 means no pruning
  * @return true on success, false otherwise
  */
@@ -108,7 +108,7 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   * maximum age (in days) of records to keep when pruning
   * (zero means keep forever)
   *   key: CVMFS_STATS_DB_DAYS_TO_KEEP
-  *   deafult: 365
+  *   default: 365
   *
   * @param repo_name Fully qualified name of the repository
   * @param path pointer to save the db path in

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -143,7 +143,7 @@ bool CommandCheck::CompareCounters(const catalog::Counters &a,
 
 
 /**
- * Checks for existance of a file either locally or via HTTP head
+ * Checks for existence of a file either locally or via HTTP head
  */
 bool CommandCheck::Exists(const string &file)
 {

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -522,7 +522,7 @@ int CommandEditTag::AddNewTag(const ArgumentList &args, Environment *env) {
     return 1;
   }
 
-  // open the catalog to be tagged (to check for existance and for meta info)
+  // open the catalog to be tagged (to check for existence and for meta info)
   const UnlinkGuard catalog_path(
       CreateTempPath(env->tmp_path + "/catalog", 0600));
   const bool catalog_read_write = false;

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -23,7 +23,7 @@
  * Many of the options possible to set in the ArgumentList are not actually used
  * by the ingest command since they are not part of its interface, hence those
  * unused options cannot be set by the shell script. Of course if there is the
- * necessitty those paramenters can be added and managed.
+ * necessity those parameters can be added and managed.
  * At the moment this approach worked fine and didn't add much complexity,
  * however if yet another command will need to use a similar approach it would
  * be good to consider creating different options handler for each command.

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -746,7 +746,7 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::
     "INSERT OR REPLACE INTO nested_catalogs (path,   sha1,  size) "
     "                VALUES                 (:path, :sha1, :size);");
 
-  // go through all nested catalogs and update their references (we are curently
+  // go through all nested catalogs and update their references (we are currently
   // in their parent catalog)
   // Note: we might need to wait for the nested catalog to be fully processed.
   PendingCatalogList::const_iterator i    = data->nested_catalogs.begin();
@@ -1178,7 +1178,7 @@ bool CommandMigrate::MigrationWorker_20x::AnalyzeFileLinkcounts(
   bool retval;
 
   // Analyze the hardlink relationships in the old catalog
-  //   inodes used to be assigned at publishing time, implicitly constituating
+  //   inodes used to be assigned at publishing time, implicitly constituting
   //   those relationships. We now need them explicitly in the file catalogs
   // This looks for directory entries with matching inodes but differing path-
   // hashes and saves the results in a temporary table called 'hl_scratch'
@@ -1408,7 +1408,7 @@ bool CommandMigrate::MigrationWorker_20x::FixNestedCatalogTransitionPoints(
       update_directory_entry.Reset();
 
       // Fixing of this mountpoint went well... inform the user that this minor
-      // issue occured
+      // issue occurred
       LogCvmfs(kLogCatalog, kLogStdout,
                "NOTE: fixed incompatible nested catalog transition point at: "
                "'%s' ", nested_root_path.c_str());
@@ -1559,7 +1559,7 @@ bool CommandMigrate::MigrationWorker_20x::GenerateCatalogStatistics(
   const catalog::CatalogDatabase &writable = data->new_catalog->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are sucessfully processed
+  // Note: we might need to wait until nested catalogs are successfully processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i    = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -1743,7 +1743,7 @@ bool CommandMigrate::MigrationWorker_217::GenerateNewStatisticsCounters
     GetWritable(data->old_catalog)->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are sucessfully processed
+  // Note: we might need to wait until nested catalogs are successfully processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -2098,7 +2098,7 @@ bool CommandMigrate::StatsMigrationWorker::RepairStatisticsCounters(
     GetWritable(data->old_catalog)->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are sucessfully processed
+  // Note: we might need to wait until nested catalogs are successfully processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -227,7 +227,7 @@ static void StoreBuffer(const unsigned char *buffer, const unsigned size,
   assert(ftmp);
   int retval;
   if (compress) {
-    shash::Any dummy(shash::kSha1);  // hardcoded hash no problem, unsused
+    shash::Any dummy(shash::kSha1);  // hardcoded hash no problem, unused
     retval = zlib::CompressMem2File(buffer, size, ftmp, &dummy);
   } else {
     retval = CopyMem2File(buffer, size, ftmp);
@@ -764,7 +764,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
 
     LogCvmfs(kLogCvmfs, kLogStdout, "Found %u named snapshots",
              historic_tags.size());
-    // TODO(jblomer): We should repliacte the previous history dbs, too,
+    // TODO(jblomer): We should replicate the previous history dbs, too,
     // in order to avoid races on fail-over between non-synchronized stratum 1s
     LogCvmfs(kLogCvmfs, kLogStdout, "Uploading history database");
     Store(history_path, history_hash);

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -6,7 +6,7 @@
  * We take all three volumes (namely union, overlay and repository) into
  * account to sync the changes back into the repository.
  *
- * On the repository side we have a catalogs directory that mimicks the
+ * On the repository side we have a catalogs directory that mimics the
  * shadow directory structure and stores compressed and uncompressed
  * versions of all catalogs.  The raw data are stored in the data
  * subdirectory in zlib-compressed form.  They are named with their SHA-1
@@ -808,7 +808,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   publish::SyncMediator mediator(&catalog_manager, &params, publish_statistics);
   LogCvmfs(kLogPublish, kLogStdout, "Processing changes...");
 
-  // Should be before the syncronization starts to avoid race of GetTTL with
+  // Should be before the synchronization starts to avoid race of GetTTL with
   // other sqlite operations
   if ((params.ttl_seconds > 0) &&
       ((params.ttl_seconds != catalog_manager.GetTTL()) ||

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -181,7 +181,7 @@ void SyncMediator::Touch(SharedPtr<SyncItem> entry) {
     // Replace calls Remove; cancel Remove's actions:
     perf::Xadd(counters_->sz_removed_bytes, -entry->GetRdOnlySize());
 
-    // Count only the diference between the old and new file
+    // Count only the difference between the old and new file
     // Symlinks do not count into added or removed bytes
     int64_t dif = 0;
 

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -74,7 +74,7 @@ bool SyncUnion::ProcessDirectory(SharedPtr<SyncItem> entry) {
     // is added later by the SyncMediator
     return false;
   } else {                             // directory already existed...
-    if (entry->IsOpaqueDirectory()) {  // was directory completely overwritten?
+    if (entry->IsOpaqueDirectory()) {  // was directory completely overridden?
       mediator_->Replace(entry);
       return false;  // <-- replace does not need any further recursion
     } else {  // directory was just changed internally... only touch needed

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -131,7 +131,7 @@ class SyncUnion {
    * Note: This needs to be up-called!
    * @param parent directory in which file resides
    * @param filename to decide whether to ignore or not
-   * @return true if file should be ignored, othewise false
+   * @return true if file should be ignored, otherwise false
    */
   virtual bool IgnoreFilePredicate(const std::string &parent_dir,
                                    const std::string &filename);
@@ -147,7 +147,7 @@ class SyncUnion {
   AbstractSyncMediator *mediator_;
 
   /**
-   * Allow for preprocessing steps before emiting any SyncItems from SyncUnion.
+   * Allow for preprocessing steps before emitting any SyncItems from SyncUnion.
    * This can be overridden by sub-classes but should always be up-called. Typi-
    * cally this sets whiteout and opaque-directory flags or handles hardlinks.
    * @param entry  the SyncItem to be pre-processed

--- a/cvmfs/sync_union_aufs.cc
+++ b/cvmfs/sync_union_aufs.cc
@@ -26,7 +26,7 @@ SyncUnionAufs::SyncUnionAufs(SyncMediator *mediator,
   ignore_filenames_.insert(".wh..wh.orph");
   ignore_filenames_.insert(".wh..wh..opq");
 
-  // set the whiteout prefix AUFS preceeds for every whiteout file
+  // set the whiteout prefix AUFS precedes for every whiteout file
   whiteout_prefix_ = ".wh.";
 }
 

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -119,7 +119,7 @@ void SyncUnionTarball::Traverse() {
     }
   }
 
-  // we are simplying deleting entity from  the repo
+  // we are simplifying deleting entity from  the repo
   if (NULL == src) return;
 
   struct archive_entry *entry = archive_entry_new();
@@ -312,11 +312,11 @@ bool SyncUnionTarball::IsWhiteoutEntry(SharedPtr<SyncItem> entry) const {
   return false;
 }
 
-/* Tar files are not necessarly traversed in order from root to leave.
+/* Tar files are not necessarily traversed in order from root to leave.
  * So it may happens that we are expanding the file `/a/b/c.txt` without
  * having created yet the directory `/a/b/`.
  * In order to overcome this limitation the following function create dummy
- * directories that can be used as placeholder and that they will be overwritten
+ * directories that can be used as placeholder and that they will be overridden
  * as soon as the real directory is found in the tarball
  */
 void SyncUnionTarball::CreateDirectories(const std::string &target) {

--- a/cvmfs/uid_map.h
+++ b/cvmfs/uid_map.h
@@ -64,7 +64,7 @@ class IntegerMap {
 
   /**
    * Sets a default (or fallback) value to be used if no other mapping rule fits
-   * Note: A previously defined default value is overwritten.
+   * Note: A previously defined default value is overridden.
    * @param v  the value to be used as a fallback in Map()
    */
   void SetDefault(const T v) {

--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -15,7 +15,7 @@
  *      -> generate a content hash of the compression result
  *
  *   2. Upload files
- *      -> pluggable to support different upload pathes (local, S3, ...)
+ *      -> pluggable to support different upload paths (local, S3, ...)
  *
  * There are a number of different entities involved in this process. Namely:
  *   -> Spooler            - general steering tasks ( + common interface )
@@ -81,7 +81,7 @@
  *                 *********************
  *
  *
- * TODO(rmeusel): special purpose ::Process...() methods should (opionally?)
+ * TODO(rmeusel): special purpose ::Process...() methods should (optionally?)
  *                return Future<> instead of relying on the callbacks. Those are
  *                somewhat one-shot calls and require a rather fishy idiom when
  *                using callbacks, like:
@@ -152,7 +152,7 @@ class Spooler : public Observable<SpoolerResult> {
   std::string backend_name() const;
 
   /**
-   * Calls the concrete uploder to create a new repository area
+   * Calls the concrete uploader to create a new repository area
    */
   bool Create();
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -151,7 +151,7 @@ class AbstractUploader
   /**
    * Concrete uploaders might want to use a customized setting for multi-stream
    * writing, for instance one per disk.  Note that the S3 backend uses one task
-   * but this one task uses internally mutliple HTTP streams through curl async
+   * but this one task uses internally multiple HTTP streams through curl async
    * I/O.
    */
   virtual unsigned GetNumTasks() const { return num_upload_tasks_; }
@@ -320,7 +320,7 @@ class AbstractUploader
   /**
    * Waits until the current upload queue is empty.
    *
-   * Note: This does NOT necessarily mean, that all files are actuall uploaded.
+   * Note: This does NOT necessarily mean, that all files are actually uploaded.
    *       If new jobs are concurrently scheduled the behavior of this method is
    *       not defined (it returns also on intermediately empty queues)
    */
@@ -351,7 +351,7 @@ class AbstractUploader
    * Implementation of a streamed upload step. See public interface for details.
    * Public interface: AbstractUploader::ScheduleUpload()
    *
-   * @param handle     decendant of UploadStreamHandle specifying the stream
+   * @param handle     descendant of UploadStreamHandle specifying the stream
    * @param buffer     the CharBuffer to be uploaded to the stream
    * @param callback   callback to be called on completion
    */
@@ -360,10 +360,10 @@ class AbstractUploader
                               const CallbackTN *callback) = 0;
 
   /**
-   * Implemetation of streamed upload commit
+   * Implementation of streamed upload commit
    * Public interface: AbstractUploader::ScheduleUpload()
    *
-   * @param handle        decendant of UploadStreamHandle specifying the stream
+   * @param handle        descendant of UploadStreamHandle specifying the stream
    * @param content_hash  the computed content hash of the streamed object
    */
   virtual void FinalizeStreamedUpload(UploadStreamHandle *handle,
@@ -428,7 +428,7 @@ class AbstractUploader
   const SpoolerDefinition spooler_definition_;
 
   /**
-   * Number of threads used for I/O write calls. Effectively this paramater
+   * Number of threads used for I/O write calls. Effectively this parameter
    * sets the I/O depth. Defaults to 1.
    */
   unsigned num_upload_tasks_;

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -88,7 +88,7 @@ class LocalUploader : public AbstractUploader {
   // state information
   const std::string upstream_path_;
   const std::string temporary_path_;
-  mutable atomic_int32 copy_errors_;  //!< counts the number of occured
+  mutable atomic_int32 copy_errors_;  //!< counts the number of occurred
                                       //!< errors in Upload()
 };
 

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -83,7 +83,7 @@ struct SpoolerDefinition {
   unsigned int number_of_concurrent_uploads;
 
   /**
-   * Number of threads used for I/O write calls. Effectively this paramater
+   * Number of threads used for I/O write calls. Effectively this parameter
    * sets the I/O depth.
    */
   unsigned int num_upload_tasks;

--- a/cvmfs/util/async.h
+++ b/cvmfs/util/async.h
@@ -36,7 +36,7 @@ class CallbackBase<void> {
  * functions with the following signature:
  * void <name>(ParamT <parameter>);
  *
- * TODO: One might use varidic templates once C++11 will be supported, in order
+ * TODO: One might use variadic templates once C++11 will be supported, in order
  *       to allow for more than one parameter to be passed to the callback.
  *
  * @param ParamT    the type of the parameter to be passed to the callback

--- a/cvmfs/util/mutex.h
+++ b/cvmfs/util/mutex.h
@@ -15,7 +15,7 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 /**
  * Used to allow for static polymorphism in the RAII template to statically
- * decide which 'lock' functions to use, if we have more than one possiblity.
+ * decide which 'lock' functions to use, if we have more than one possibility.
  * (I.e. Read/Write locks)
  * Note: Static Polymorphism - Strategy Pattern
  *

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1088,7 +1088,7 @@ std::string GetCurrentWorkingDirectory() {
 
 
 /**
- * Helper class that provides callback funtions for the file system traversal.
+ * Helper class that provides callback functions for the file system traversal.
  */
 class RemoveTreeHelper {
  public:
@@ -1198,7 +1198,7 @@ std::vector<std::string> FindFilesByPrefix(
 
 /**
  * Finds all direct subdirectories under parent_dir (except ., ..).  Used,
- * for instance, to parse /etc/cvmfs/repositories.d/<reponoame>
+ * for instance, to parse /etc/cvmfs/repositories.d/<reponame>
  */
 std::vector<std::string> FindDirectories(const std::string &parent_dir) {
   std::vector<std::string> result;
@@ -1611,7 +1611,7 @@ void WaitForSignal(int signum) {
 /**
  * Returns -1 if the child crashed or the exit code otherwise.
  * @param pid Process identifier.
- * @param sig_ok List of signals that are still considered a sucessful termination.
+ * @param sig_ok List of signals that are still considered a successful termination.
  */
 int WaitForChild(pid_t pid, const std::vector<int> &sig_ok) {
   assert(pid > 0);

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -192,7 +192,7 @@ string StringifyTimeval(const timeval value) {
 }
 
 /**
- * Parses a timstamp of the form YYYY-MM-DDTHH:MM:SSZ
+ * Parses a timestamp of the form YYYY-MM-DDTHH:MM:SSZ
  * Return 0 on error
  */
 time_t IsoTimestamp2UtcTime(const std::string &iso8601) {
@@ -310,7 +310,7 @@ vector<string> SplitString(const string &str, const char delim,
     }
   }
 
-  // push the remainings of the string and return
+  // push the remains of the string and return
   result.push_back(str.substr(marker));
   return result;
 }

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1475,7 +1475,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/doc/hpc.md
+++ b/doc/hpc.md
@@ -9,7 +9,7 @@ These problems can be overcome by preloading a CernVM-FS cache on the shared clu
 
   * Millions of synchronized meta-data operations per node (path lookups, in particular) will not drown the shared cluster file system but resolve locally in the parrot-cvmfs clients.
   * The file system is always consistent; applications never see half-synchronized directories.
-  * After initial preloading, only change sets need to be transfered to the shared file system.  This is much faster than `rsync`, which always has to browse the entire name space.
+  * After initial preloading, only change sets need to be transferred to the shared file system.  This is much faster than `rsync`, which always has to browse the entire name space.
   * Identical files are internally de-duplicated.  While space of the order of terabytes is usually not an issue for HPC shared file systems, file system caches benefit from deduplication. It is also possible to preload only specific parts of a repository namespace.
   * Support for extra functionality implemented by CernVM-FS such as versioning and variant symlinks (symlinks resolved according to environment variables).
 
@@ -32,12 +32,12 @@ This will preload the entire repository.  In order to preload only specific part
     /example/x86_64-2.6-gnu-4.8.3/Packages/gcc
     /example/x86_64-2.6-gnu-4.8.3/Packages/AliRoot/v5*
 
-The corresponding invokation of `cvmfs_preload` is
+The corresponding invocation of `cvmfs_preload` is
 
     cvmfs_preload -u http://hcc-cvmfs.unl.edu:8000/cvmfs/alice.cern.ch -r /shared/cache \
       -d </path/to/dirtab>
 
-The initial preloading can take several hours to a few days.  Subsequent invokations of the same command only transfer a change set and typically finish within seconds or minutes. These subsequent invokations need to be either done manually when necessary or scheduled for instance with a cron job.
+The initial preloading can take several hours to a few days.  Subsequent invocations of the same command only transfer a change set and typically finish within seconds or minutes. These subsequent invocations need to be either done manually when necessary or scheduled for instance with a cron job.
 
 The `cvmfs_preload` command can preload files from multiple repositories
 into the same cache directory.

--- a/doc/igprof_linux.md
+++ b/doc/igprof_linux.md
@@ -16,7 +16,7 @@ Some more notes:
   - Make sure libunwind and libigprof are also in /usr/lib64
   - Memory profiling needs to use the debug library for proper stack traces
 
-The following code runned as superuser would sum up what was explained before:
+The following code ran as superuser would sum up what was explained before:
 
 ``` bash
 mv /etc/mtab /etc/mtab.disabled

--- a/doc/valgrind.md
+++ b/doc/valgrind.md
@@ -3,7 +3,7 @@
   - build with valgrind-devel
   - no autofs
   - use `-o simple_options_parsing`
-    (no qotes for CVMFS_HTTP_PROXY and CVMFS_SERVER_URL in the options)
+    (no quotes for CVMFS_HTTP_PROXY and CVMFS_SERVER_URL in the options)
   - use `-o disable_watchdog`
   - user root (`-o gid=0,uid=0`)
   - no shared cache to avoid forking the quota manager, CVMFS_QUOTA_LIMIT=-1 to disable quota sqlite handling

--- a/ducc/README.md
+++ b/ducc/README.md
@@ -182,7 +182,7 @@ The conversion is quite straightforward, we first download the input image, we
 store each layer on the cvmfs repository, we create the output image and unpack
 the singularity one, finally we upload the output image to the registry.
 
-It does not support dowloading images that are not public.
+It does not support downloading images that are not public.
 
 In order to publish images to a registry is necessary to sign up in the
 docker hub. It will use the user from the recipe, while it will read the

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -117,7 +117,7 @@ func CreateSymlinkIntoCVMFS(CVMFSRepo, newLinkName, toLinkPath string) (err erro
 		return err
 	}
 	// from the relativePath we remove the first part of the path.
-	// The part we remove reprensent the same directory where is the target.
+	// The part we remove represent the same directory where is the target.
 	linkChunks := strings.Split(relativePath, string(os.PathSeparator))
 	link := filepath.Join(linkChunks[1:]...)
 

--- a/ducc/docker-api/util.go
+++ b/ducc/docker-api/util.go
@@ -44,7 +44,7 @@ var thinImageVersion = "1.0"
 
 // m is the manifest of the original image
 // repoLocation is where inside the repo we saved the several layers
-// origin is an ecoding fo the original referencese and original registry
+// origin is an encoding of the original references and original registry
 // I believe origin is quite useless but maybe is better to preserv it for
 // ergonomic reasons.
 func MakeThinImage(m Manifest, layersMapping map[string]string, origin string) (ThinImage, error) {
@@ -76,7 +76,7 @@ func (m Manifest) GetSingularityPath() string {
 }
 
 // please note how we use the simple digest from the layers, it is not
-// striclty correct, since we would need the digest of the uncompressed
+// strictly correct, since we would need the digest of the uncompressed
 // layer, that can be found in the Config file of the image.
 // For our purposes, however, this is good enough.
 func (m Manifest) GetChainIDs() []digest.Digest {

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -49,7 +49,7 @@ func ConvertWishFlat(wish WishFriendly) error {
 		nFlat.Elapsed(tFlat).AddField("action", "end_flat_conversion").Send()
 	}()
 
-	// it may happend at the very first round that this two calls return an error, let it be
+	// it may happen at the very first round that this two calls return an error, let it be
 	if err := cvmfs.CreateCatalogIntoDir(wish.CvmfsRepo, ".chains"); err != nil {
 		l.LogE(err).Error("Error in creating catalog inside `.chains` directory")
 	}
@@ -87,7 +87,7 @@ func ConvertWishFlat(wish WishFriendly) error {
 				continue
 			}
 			// delete the old pubLink
-			// make a new Link to the privatePaht
+			// make a new Link to the privatePath
 			// after that skip and continue
 			l.Log().WithFields(log.Fields{"image": inputImage.GetSimpleName()}).Info("Updating Singularity Image")
 			err = cvmfs.CreateSymlinkIntoCVMFS(wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
@@ -553,7 +553,7 @@ func PushImageToRegistry(outputImage Image) (err error) {
 	l.Log().WithFields(log.Fields{"action": "prepared thin-image manifest"}).Info(string(b))
 	defer res.Close()
 	// here is possible to use the result of the above ReadAll to have
-	// informantion about the status of the upload.
+	// information about the status of the upload.
 	_, errReadDocker := ioutil.ReadAll(res)
 	if err != nil {
 		l.LogE(errReadDocker).Warning("Error in reading the status from docker")

--- a/ducc/lib/parse.go
+++ b/ducc/lib/parse.go
@@ -52,7 +52,7 @@ func ParseImage(image string) (img Image, err error) {
 		return Image{}, fmt.Errorf("Impossible to parse the string into an image, too many `:` in : %s", image)
 	}
 	// the colon `:` is used also as separator in the digest between sha256
-	// and the actuall digest, a len(pathSplitted) == 2 could either means
+	// and the actual digest, a len(pathSplitted) == 2 could either means
 	// a repository and a tag or a repository and an hash, in the case of
 	// the hash however the split will be more complex.  Now we split for
 	// the at `@` which separate the digest from everything else. If this

--- a/ducc/lib/podman_store.go
+++ b/ducc/lib/podman_store.go
@@ -200,7 +200,7 @@ func (img *Image) LinkRootfsIntoPodmanStore(CVMFSRepo, subDirInsideRepo string, 
 		l.LogE(err).Warn("Error in getting the image manifest")
 		return err
 	}
-	// this is extremelly bad, we are making one transaction for each layer
+	// this is extremely bad, we are making one transaction for each layer
 	// all of them could be done in a single transaction
 	for _, layer := range manifest.Layers {
 		layerid := strings.Split(layer.Digest, ":")[1]
@@ -468,7 +468,7 @@ func (img *Image) CheckImageChanged(CVMFSRepo string) error {
 
 // Ingest all the necessary files and dir in podmanStore dir.
 func (img *Image) CreatePodmanImageStore(CVMFSRepo, subDirInsideRepo string) (err error) {
-	// this code is extremelly slow
+	// this code is extremely slow
 	// if opens and publish several transaction and I believe it is possible to do pretty much anything in a single transaction
 	// it should be rewritten.
 	n := notification.NewNotification(NotificationService).AddField("image", img.GetSimpleName())

--- a/ducc/lib/utils.go
+++ b/ducc/lib/utils.go
@@ -28,7 +28,7 @@ type OnDiskReadAndHash struct {
 	path string
 }
 
-// this structure is useful, but each time we use this, we are hogging up the netowrk
+// this structure is useful, but each time we use this, we are hogging up the network
 // we force to download all the layer, and **then** we check if the layer is already in CVMFS
 // this can be optimize
 // the constructor, this function, should be smarter.

--- a/gateway/internal/gateway/backend/gc_actions.go
+++ b/gateway/internal/gateway/backend/gc_actions.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// GCOptions represents the different options supplied for a garbace collection run
+// GCOptions represents the different options supplied for a garbage collection run
 type GCOptions struct {
 	Repository   string    `json:"repo"`
 	NumRevisions int       `json:"num_revisions"`

--- a/gateway/internal/gateway/backend/leasedb.go
+++ b/gateway/internal/gateway/backend/leasedb.go
@@ -83,7 +83,7 @@ type LeaseDB interface {
 	GetRepositoryEnabled(ctx context.Context, repository string) bool
 }
 
-// OpenLeaseDB opens or creats a new LeaseDB object of the specified type
+// OpenLeaseDB opens or creates a new LeaseDB object of the specified type
 // (either "embedded" or "etcd").
 func OpenLeaseDB(dbType string, config *gw.Config) (LeaseDB, error) {
 	switch dbType {

--- a/gateway/internal/gateway/backend/leasedb_bolt.go
+++ b/gateway/internal/gateway/backend/leasedb_bolt.go
@@ -57,7 +57,7 @@ func (db *BoltLeaseDB) Close() error {
 	return db.store.Close()
 }
 
-// NewLease attemps to acquire a new lease for the given path
+// NewLease attempts to acquire a new lease for the given path
 func (db *BoltLeaseDB) NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int, token LeaseToken) error {
 	return db.store.Update(func(txn *bolt.Tx) error {
 		t0 := time.Now()

--- a/gateway/internal/gateway/backend/leasedb_etcd.go
+++ b/gateway/internal/gateway/backend/leasedb_etcd.go
@@ -22,7 +22,7 @@ func (db *EtcdLeaseDB) Close() error {
 	return nil
 }
 
-// NewLease attemps to acquire a new lease for the given path
+// NewLease attempts to acquire a new lease for the given path
 func (db *EtcdLeaseDB) NewLease(
 	ctx context.Context, keyID, leasePath string, protocolVersion int, token LeaseToken) error {
 	return nil

--- a/gateway/internal/gateway/backend/leasedb_sqlite.go
+++ b/gateway/internal/gateway/backend/leasedb_sqlite.go
@@ -122,7 +122,7 @@ func (db *SqliteLeaseDB) Close() error {
 	return nil
 }
 
-// NewLease attemps to acquire a new lease for the given path
+// NewLease attempts to acquire a new lease for the given path
 func (db *SqliteLeaseDB) NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int, token LeaseToken) error {
 	t0 := time.Now()
 

--- a/gateway/internal/gateway/config.go
+++ b/gateway/internal/gateway/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	MockReceiver bool `mapstructure:"mock_receiver"`
 }
 
-// ReadConfig reads configuration files and commandline flags, and populates a Config object
+// ReadConfig reads configuration files and command-line flags, and populates a Config object
 func ReadConfig() (*Config, error) {
 	var configFile string
 	pflag.StringVar(&configFile, "user_config_file", "/etc/cvmfs/gateway/user.json", "config file with user modifiable settings")

--- a/gateway/internal/gateway/receiver/receiver_test.go
+++ b/gateway/internal/gateway/receiver/receiver_test.go
@@ -69,7 +69,7 @@ func TestReceiverAfterCrashWeCanStillCallCommandAndTheyWillReturnAnError(t *test
 	}
 }
 
-// reduntat test, but it mimic a problem we found in production.
+// redundant test, but it mimic a problem we found in production.
 // after a crash the .Quit() was hanging
 func TestReceiverAfterCrashQuitDoesNotHang(t *testing.T) {
 	receiver := createReceiver(t)

--- a/mount/config.d/README
+++ b/mount/config.d/README
@@ -1,4 +1,4 @@
 The repository-specific configuration is set in the cvmfs config repository,
 e.g. /cvmfs/cvmfs-config.cern.ch/etc/cvmfs/config.d/grid.cern.ch.conf
 
-Parameters can be overwritten in corresponding .local files.
+Parameters can be overridden in corresponding .local files.

--- a/mount/default.conf
+++ b/mount/default.conf
@@ -58,7 +58,7 @@ CVMFS_CHECK_PERMISSIONS=yes
 CVMFS_CLAIM_OWNERSHIP=yes
 
 # Default directory containing .pub public master keys.  This is usually
-# overwritten per domain (e.g. /etc/cvmfs/keys/cern.ch)
+# overridden per domain (e.g. /etc/cvmfs/keys/cern.ch)
 CVMFS_KEYS_DIR=/etc/cvmfs/keys
 
 # Leave undefined for LOG_USER.  Set to 0..7 for local0..local7

--- a/packaging/container/mount_cvmfs.sh
+++ b/packaging/container/mount_cvmfs.sh
@@ -60,7 +60,7 @@ fi
 
 # TODO(jblomer): add all CVMFS_* environment variables to $CONFIG
 
-# Gracefully unmount on container exit to avoid the error messge
+# Gracefully unmount on container exit to avoid the error message
 # "transport endpoint not connected" on /cvmfs/* directories
 trap cleanup SIGTERM SIGINT SIGQUIT SIGHUP
 

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -416,7 +416,7 @@ rm -f $RPM_BUILD_ROOT/etc/cvmfs/domain.d/*.conf
 rm -f $RPM_BUILD_ROOT/etc/cvmfs/default.d/*.conf
 rm -f $RPM_BUILD_ROOT/etc/cvmfs/serverorder.sh
 
-# Don't install coincidentially built libfuse3 libraries
+# Don't install coincidentally built libfuse3 libraries
 %if ! 0%{?build_fuse3}
 rm -f $RPM_BUILD_ROOT%{_libdir}/libcvmfs_fuse3*
 %endif
@@ -734,7 +734,7 @@ systemctl daemon-reload
 * Thu Jun 30 2016 Jakob Blomer <jblomer@cern.ch> - 2.3.1
 - Fix SLES12 dist tag
 * Tue May 03 2016 Jakob Blomer <jblomer@cern.ch> - 2.3.0
-- No optimiziation on EL5/i686 to prevent faulty atomics
+- No optimization on EL5/i686 to prevent faulty atomics
 * Fri Apr 29 2016 Jakob Blomer <jblomer@cern.ch> - 2.3.0
 - voms-devel not necessary anymore
 * Mon Apr 11 2016 Rene Meusel <rene.meusel@cern.ch> - 2.3.0
@@ -809,7 +809,7 @@ systemctl daemon-reload
 * Thu Feb 16 2012 Jakob Blomer <jblomer@cern.ch>
 - SuSE compatibility, disabled SELinux for SuSE
 * Wed Feb 15 2012 Jakob Blomer <jblomer@cern.ch>
-- Small adjustments to run with continueous integration
+- Small adjustments to run with continuous integration
 * Thu Jan 12 2012 Brian Bockelman <bbockelm@cse.unl.edu> - 2.0.13
 - Addition of SELinux support.
 

--- a/test/benchmarks/003-alice/ppbench/Config.C
+++ b/test/benchmarks/003-alice/ppbench/Config.C
@@ -1444,7 +1444,7 @@ AliGenGeVSim* GeVSimStandard(Float_t mult, Float_t vn)
   // Mult is the number of charged particles in |eta| < 0.5
   // Vn is in (%)
   //
-  // Sigma of the Gaussian dN/deta
+  // Sigma of the Gaussian dN/delta
   Float_t sigma_eta  = 2.75;
   //
   // Maximum eta

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -1,7 +1,7 @@
 
 CVMFS_EC_BASE_URL="https://ecsft.cern.ch/dist/cvmfs"
 
-# tries to guess the pacakge download URLs for a provided package name and cvmfs
+# tries to guess the package download URLs for a provided package name and cvmfs
 # version. This relies on the Electric Commander installation of SFT.
 #
 # Note: CVMFS_EC_BASE_URL needs to point to the cvmfs download location

--- a/test/container/006-k8s/deploy/pv-cvmfs-noderoot.yaml
+++ b/test/container/006-k8s/deploy/pv-cvmfs-noderoot.yaml
@@ -22,7 +22,7 @@ spec:
     storage: 5Gi
   volumeMode: Filesystem
   accessModes:
-  # Exclusice access to a single pod (the cvmfs daemonset)
+  # Exclusive access to a single pod (the cvmfs daemonset)
   - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: cvmfs-noderoot

--- a/test/micro-benchmarks/bm_util.h
+++ b/test/micro-benchmarks/bm_util.h
@@ -12,7 +12,7 @@ inline static void Escape(void *p) {
 }
 
 /**
- * Tell the optimizier that after this command, everything in the memory could
+ * Tell the optimizer that after this command, everything in the memory could
  * have changed.
  */
 inline static void ClobberMemory() {

--- a/test/run.sh
+++ b/test/run.sh
@@ -77,7 +77,7 @@ fi
 echo "Start test suite for cvmfs $(cvmfs2 --version)" > $logfile
 date >> $logfile
 
-# read command line paramters
+# read command line parameters
 shift
 test_exclusions=0
 xml_output=""

--- a/test/src/510-filechunks/main
+++ b/test/src/510-filechunks/main
@@ -29,7 +29,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/511-removefilechunks/main
+++ b/test/src/511-removefilechunks/main
@@ -29,7 +29,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/512-movechunkstonested/main
+++ b/test/src/512-movechunkstonested/main
@@ -29,7 +29,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/513-mergechunksfromnested/main
+++ b/test/src/513-mergechunksfromnested/main
@@ -29,7 +29,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -29,7 +29,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile
@@ -113,7 +113,7 @@ check_chunk_alignment() {
 
   # compare the chunk sizes of associated chunks in the old and the new version
   # of the updated file.
-  # the final output is the chunk difference which occured most frequently
+  # the final output is the chunk difference which occurred most frequently
   # --> in the best case this is 0 :-)
   most_common_size_difference=$(echo " \
   ATTACH '${old_catalog}' AS old; \

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -82,7 +82,7 @@ cvmfs_run_test() {
     sudo cvmfs_server eliminate-hardlinks -f $legacy_repo_name || return 101
   fi
 
-  # cheate a new repository revision of the migrated catalogs
+  # create a new repository revision of the migrated catalogs
   echo "create a new repository revision"
   local big_file="${repo_dir}/dir6/bigfile"
   start_transaction $legacy_repo_name || return $?

--- a/test/src/522-missingchunkfailover/main
+++ b/test/src/522-missingchunkfailover/main
@@ -30,7 +30,7 @@ cvmfs_run_test() {
   cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 3; }
 
   echo "delete all file data chunks in the Stratum0 repository"
-  # go through the repo backend storage and search for data chunk pathes
+  # go through the repo backend storage and search for data chunk paths
   # that do not end with a capital letter (catalog, history, certificate) except
   # a capital P (big file data chunks) and delete them
   for f in $(find /srv/cvmfs/$CVMFS_TEST_REPO/data/ | \

--- a/test/src/523-corruptchunkfailover/main
+++ b/test/src/523-corruptchunkfailover/main
@@ -34,7 +34,7 @@ cvmfs_run_test() {
   cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 3; }
 
   echo "corrupt all file data chunks in the Stratum0 repository"
-  # go through the repo backend storage and search for data chunk pathes
+  # go through the repo backend storage and search for data chunk paths
   # that do not end with a capital letter (catalog, history, certificate) except
   # a capital P (big file data chunks) and append crap to them
   for f in $(find /srv/cvmfs/$CVMFS_TEST_REPO/data/ | \

--- a/test/src/528-recreatespoolarea/main
+++ b/test/src/528-recreatespoolarea/main
@@ -28,7 +28,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/530-recreatespoolarea_defaultkey/main
+++ b/test/src/530-recreatespoolarea_defaultkey/main
@@ -28,7 +28,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/542-storagescrubbing/main
+++ b/test/src/542-storagescrubbing/main
@@ -28,7 +28,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/543-storagescrubbing_scriptable/main
+++ b/test/src/543-storagescrubbing_scriptable/main
@@ -28,7 +28,7 @@ produce_files_in() {
   echo "Die unbegreiflich hohen Werke"       > small_files/verse7
   echo "Sind herrlich wie am ersten Tag."    > small_files/verse8
 
-  # create a full poem in one file that will get concatinated later
+  # create a full poem in one file that will get concatenated later
   local bigtxtfile=small_files/heidenroeslein
   touch $bigtxtfile
   echo "Heidenröslein"                     >> $bigtxtfile

--- a/test/src/562-aufsexdevrename/main
+++ b/test/src/562-aufsexdevrename/main
@@ -33,7 +33,7 @@ produce_files_2_in() {
   # internal copy-up of 'mallory'.
   # Assuming that 'mallory' is not yet in the cvmfs cache, it is downloaded and
   # committed into the cvmfs cache using a rename(tmp file, cache-entry) which
-  # deadlocks with the still blocking intial rename('foo/mallory', ...). Phew!
+  # deadlocks with the still blocking initial rename('foo/mallory', ...). Phew!
   mv foo bar/
 
   popdir

--- a/test/src/568-migratecorruptrepo/main
+++ b/test/src/568-migratecorruptrepo/main
@@ -88,7 +88,7 @@ cvmfs_run_test() {
   echo "check that it produces the expected catalog statistics errors"
   [ $(cat $check_log_1 | grep '^catalog statistics mismatch' | wc -l) -eq 3 ] || return 15
 
-  # cheate a new repository revision of the migrated catalogs
+  # create a new repository revision of the migrated catalogs
   echo "create a new repository revision"
   start_transaction $legacy_repo_name || return $?
   cd $repo_dir

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -100,7 +100,7 @@ generate_certs() {
   elif is_el6; then
     voms_path="${TEST600_GRID_MOUNTPOINT}/emi-ui-2.10.4-1_sl5v1"
     # TODO(rmeusel): use that once the world stopped burning...
-    #                removes a couple of compat* depedencies
+    #                removes a couple of compat* dependencies
     # voms_path="${TEST600_GRID_MOUNTPOINT}/emi-ui-3.17.1-1_sl6v1"
   else
     echo "didn't find voms path for this platform"

--- a/test/src/600-securecvmfs/openssl.config
+++ b/test/src/600-securecvmfs/openssl.config
@@ -44,7 +44,7 @@ certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
+					# several certificates with same subject.
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 
 certificate	= $dir/cacert.pem 	# The CA certificate

--- a/test/src/634-reflogchecksum/main
+++ b/test/src/634-reflogchecksum/main
@@ -37,7 +37,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO || return $?
 
   # The stratum 0 reflog checksum is now stored in the manifest but it can
-  # be overwritten by the local reflog checksum, e.g. on stratum 1.
+  # be overridden by the local reflog checksum, e.g. on stratum 1.
   # Deleting the checksum therefore means setting it to the null hash
   echo "*** check missing checksum"
   echo -n "0000000000000000000000000000000000000000" > $checksum

--- a/test/src/647-bearercvmfs/openssl.config
+++ b/test/src/647-bearercvmfs/openssl.config
@@ -44,7 +44,7 @@ certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
+					# several certificates with same subject.
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 
 certificate	= $dir/cacert.pem 	# The CA certificate

--- a/test/src/660-store_publish_statistics/main
+++ b/test/src/660-store_publish_statistics/main
@@ -104,7 +104,7 @@ cvmfs_run_test() {
   # echo "*** Activate the statistics by writing in server.conf file CVMFS_PRINT_STATISTICS=true"
   # cat /etc/cvmfs/repositories.d/$repo_name/server.conf | grep CVMFS_PRINT_STATISTICS
   # if [ $? -eq 0 ]; then   # just change the value
-  #   echo "*** Found CVMFS_PRINT_STATISTICS variable, value overwritten with true."
+  #   echo "*** Found CVMFS_PRINT_STATISTICS variable, value overridden with true."
   #   sed -i 's/CVMFS_PRINT_STATISTICS=.*/CVMFS_PRINT_STATISTICS=true/' /etc/cvmfs/repositories.d/$repo_name/server.conf
   # else
   #   echo "*** CVMFS_PRINT_STATISTICS not found, append CVMFS_PRINT_STATISTICS=true in server.conf"

--- a/test/src/684-https_s3/main
+++ b/test/src/684-https_s3/main
@@ -1,5 +1,5 @@
 #
-# Test for running CVMFS agains a HTTPS S3 implementation
+# Test for running CVMFS against a HTTPS S3 implementation
 #
 # In this test we create our own CA (certificate authority).
 # the CA will create and sign the certificates for the minio/S3 backend

--- a/test/src/807-nested_new_directories_gateway_ingest/main
+++ b/test/src/807-nested_new_directories_gateway_ingest/main
@@ -2,7 +2,7 @@ cvmfs_test_name="Repository gateway lease on non-existing directory"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-# This test covers the creation of subdirectories that don't yet exists when the reporitory upstream is of type GW.
+# This test covers the creation of subdirectories that don't yet exists when the repository upstream is of type GW.
 # Refers to [CVM-1696](https://sft.its.cern.ch/jira/projects/CVM/issues/CVM-1696)
 #
 # Basically it makes sure that

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -2110,7 +2110,7 @@ TYPED_TEST(T_CatalogTraversal, DepthFirstSearchFullHistoryTraversalNoRepeat) {
 
   this->CheckVisitedCatalogs(catalogs,
     DepthFirstSearchFullHistoryTraversalNoRepeat_visited_catalogs);
-  // disable for CatatalogTraversalParallel since the ordering is different
+  // disable for CatalogTraversalParallel since the ordering is different
   if (!TraversalIsParallel<TypeParam>()) {
     this->CheckCatalogSequence(catalogs,
       DepthFirstSearchFullHistoryTraversalNoRepeat_visited_catalogs);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -386,7 +386,7 @@ void *TestFetchCollapse2(void *data) {
 }
 
 TEST_F(T_Fetcher, FetchCollapse) {
-  // Test race condition: first open fails, second one succeds
+  // Test race condition: first open fails, second one succeeds
   perf::Statistics statistics;
   BuggyCacheManager bcm;
   bcm.open_2nd_try = true;

--- a/test/unittests/t_malloc_arena.cc
+++ b/test/unittests/t_malloc_arena.cc
@@ -112,7 +112,7 @@ TEST_F(T_MallocArena, Basic) {
   do {
     ptrs.push_back(M.Malloc(8192));
   } while (ptrs.back() != NULL);
-  // More than 90% utiliziation
+  // More than 90% utilization
   unsigned num = ptrs.size();
   EXPECT_GE(num, (kSmallArena / 8192) * 90 / 100);
   EXPECT_FALSE(M.IsEmpty());

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -54,7 +54,7 @@ class T_Options : public ::testing::Test {
   }
 
  protected:
-  // type-based overlaoded instantiation of History object wrapper
+  // type-based overloaded instantiation of History object wrapper
   // Inspired from here:
   //   http://stackoverflow.com/questions/5512910/
   //          explicit-specialization-of-template-class-member-function


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/cvmfs/commit/b81da4ee22ded01ed33ed3b67b734db571249b84#commitcomment-61970638

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/cvmfs/commit/6911cc0f6680169c96d11526d223774225437b82

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

---

If you need things split, dropped, or squashed, just let me know, it isn't a big deal.

Note that one typo was identified by this tool and I sent a PR to remove it entirely.

I've tried to preserve whitespace indentation (including some trailing whitespace, which my editors hate).

I will try to call out a bunch of things (it'll take time).