### PR TITLE
Clean up server lock file handling

### DIFF
--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -606,10 +606,8 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
   , settings_(settings)
   , statistics_publish_(new perf::StatisticsTemplate("publish", statistics_))
   , llvl_(settings.is_silent() ? kLogNone : kLogNormal)
-  , in_transaction_(settings.transaction().spool_area().transaction_lock(),
-                    true)
-  , is_publishing_(settings.transaction().spool_area().publishing_lock(),
-                   false)
+  , in_transaction_(settings.transaction().spool_area().transaction_lock())
+  , is_publishing_(settings.transaction().spool_area().publishing_lock())
   , spooler_files_(NULL)
   , spooler_catalogs_(NULL)
   , catalog_mgr_(NULL)
@@ -672,7 +670,7 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
   if (settings.is_managed())
     managed_node_ = new ManagedNode(this);
   session_ = new Session(settings_, llvl_);
-  if (in_transaction_.IsLocked())
+  if (in_transaction_.IsSet())
     ConstructSpoolers();
 }
 
@@ -841,12 +839,12 @@ void Publisher::SyncImpl() {
 }
 
 void Publisher::Publish() {
-  if (!in_transaction_.IsLocked())
+  if (!in_transaction_.IsSet())
     throw EPublish("cannot publish outside transaction");
 
   PushReflog();
   PushManifest();
-  in_transaction_.Release();
+  in_transaction_.Clear();
 }
 
 

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -772,14 +772,8 @@ void Publisher::Sync() {
     return;
   }
 
-  is_publishing_.Lock();
-  try {
-    SyncImpl();
-    is_publishing_.Unlock();
-  } catch (...) {
-    is_publishing_.Unlock();
-    throw;
-  }
+  ServerLockFileGuard g(is_publishing_);
+  SyncImpl();
 }
 
 void Publisher::ExitShell() {

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -766,16 +766,6 @@ void Publisher::ConstructSyncManagers() {
   }
 }
 
-void Publisher::Sync() {
-  if (settings_.transaction().dry_run()) {
-    SyncImpl();
-    return;
-  }
-
-  ServerLockFileGuard g(is_publishing_);
-  SyncImpl();
-}
-
 void Publisher::ExitShell() {
   std::string session_dir = Env::GetEnterSessionDir();
   std::string session_pid_tmp = session_dir + "/session_pid";
@@ -788,7 +778,9 @@ void Publisher::ExitShell() {
   kill(pid_child, SIGUSR1);
 }
 
-void Publisher::SyncImpl() {
+void Publisher::Sync() {
+  ServerLockFileGuard g(is_publishing_);
+
   ConstructSyncManagers();
 
   sync_union_->Traverse();

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -772,12 +772,12 @@ void Publisher::Sync() {
     return;
   }
 
-  is_publishing_.Acquire();
+  is_publishing_.Lock();
   try {
     SyncImpl();
-    is_publishing_.Release();
+    is_publishing_.Unlock();
   } catch (...) {
-    is_publishing_.Release();
+    is_publishing_.Unlock();
     throw;
   }
 }

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -46,21 +46,7 @@ const std::string CommandTag::kPreviousHeadTag = "trunk-previous";
 
 namespace publish {
 
-Repository::Repository()
-  : settings_("")
-  , statistics_(new perf::Statistics())
-  , signature_mgr_(new signature::SignatureManager())
-  , download_mgr_(NULL)
-  , simple_catalog_mgr_(NULL)
-  , whitelist_(NULL)
-  , reflog_(NULL)
-  , manifest_(NULL)
-  , history_(NULL)
-{
-  signature_mgr_->Init();
-}
-
-Repository::Repository(const SettingsRepository &settings)
+Repository::Repository(const SettingsRepository &settings, const bool exists)
   : settings_(settings)
   , statistics_(new perf::Statistics())
   , signature_mgr_(new signature::SignatureManager())
@@ -73,15 +59,17 @@ Repository::Repository(const SettingsRepository &settings)
 {
   signature_mgr_->Init();
 
-  int rvb;
-  std::string keys = JoinStrings(FindFilesBySuffix(
-    settings.keychain().keychain_dir(), ".pub"), ":");
-  rvb = signature_mgr_->LoadPublicRsaKeys(keys);
-  if (!rvb) {
-    signature_mgr_->Fini();
-    delete signature_mgr_;
-    delete statistics_;
-    throw EPublish("cannot load public rsa key");
+  if (exists) {
+    int rvb;
+    std::string keys = JoinStrings(FindFilesBySuffix(
+      settings.keychain().keychain_dir(), ".pub"), ":");
+    rvb = signature_mgr_->LoadPublicRsaKeys(keys);
+    if (!rvb) {
+      signature_mgr_->Fini();
+      delete signature_mgr_;
+      delete statistics_;
+      throw EPublish("cannot load public rsa key");
+    }
   }
 
   if (!settings.cert_bundle().empty()) {
@@ -100,15 +88,17 @@ Repository::Repository(const SettingsRepository &settings)
                                  download::DownloadManager::kSetProxyBoth);
   }
 
-  try {
-    DownloadRootObjects(settings.url(), settings.fqrn(), settings.tmp_dir());
-  } catch (const EPublish& e) {
-    signature_mgr_->Fini();
-    download_mgr_->Fini();
-    delete signature_mgr_;
-    delete download_mgr_;
-    delete statistics_;
-    throw;
+  if (exists) {
+    try {
+      DownloadRootObjects(settings.url(), settings.fqrn(), settings.tmp_dir());
+    } catch (const EPublish& e) {
+      signature_mgr_->Fini();
+      download_mgr_->Fini();
+      delete signature_mgr_;
+      delete download_mgr_;
+      delete statistics_;
+      throw;
+    }
   }
 }
 
@@ -471,13 +461,7 @@ void Publisher::PushWhitelist() {
 
 
 Publisher *Publisher::Create(const SettingsPublisher &settings) {
-  UniquePtr<Publisher> publisher(new Publisher());
-
-  publisher->settings_ = settings;
-  if (settings.is_silent())
-    publisher->llvl_ = kLogNone;
-  publisher->signature_mgr_ = new signature::SignatureManager();
-  publisher->signature_mgr_->Init();
+  UniquePtr<Publisher> publisher(new Publisher(settings, false));
 
   LogCvmfs(kLogCvmfs, publisher->llvl_ | kLogStdout | kLogNoLinebreak,
            "Creating Key Chain... ");
@@ -617,22 +601,8 @@ void Publisher::InitSpoolArea() {
   }
 }
 
-Publisher::Publisher()
-  : settings_("invalid.cvmfs.io")
-  , statistics_publish_(new perf::StatisticsTemplate("publish", statistics_))
-  , llvl_(kLogNormal)
-  , in_transaction_(false)
-  , spooler_files_(NULL)
-  , spooler_catalogs_(NULL)
-  , catalog_mgr_(NULL)
-  , sync_parameters_(NULL)
-  , sync_mediator_(NULL)
-  , sync_union_(NULL)
-{
-}
-
-Publisher::Publisher(const SettingsPublisher &settings)
-  : Repository(SettingsRepository(settings))
+Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
+  : Repository(SettingsRepository(settings), exists)
   , settings_(settings)
   , statistics_publish_(new perf::StatisticsTemplate("publish", statistics_))
   , llvl_(settings.is_silent() ? kLogNone : kLogNormal)
@@ -656,6 +626,9 @@ Publisher::Publisher(const SettingsPublisher &settings)
       "proceeding.",
       EPublish::kFailLayoutRevision);
   }
+
+  if (!exists)
+    return;
 
   CreateDirectoryAsOwner(settings_.transaction().spool_area().tmp_dir(),
                          kPrivateDirMode);
@@ -903,7 +876,9 @@ void Publisher::Transaction() {
 //------------------------------------------------------------------------------
 
 
-Replica::Replica(const SettingsReplica &settings) {
+Replica::Replica(const SettingsReplica &settings)
+  : Repository(SettingsRepository(settings))
+{
 }
 
 

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -668,6 +668,7 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
 
   if (settings.is_managed())
     managed_node_ = new ManagedNode(this);
+  session_ = new Session(settings_, llvl_);
   CheckTransactionStatus();
   if (in_transaction_)
     ConstructSpoolers();

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -360,8 +360,6 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
   void TransactionRetry();
   void TransactionImpl();
 
-  void SyncImpl();
-
   SettingsPublisher settings_;
   UniquePtr<perf::StatisticsTemplate> statistics_publish_;
   /**

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -11,6 +11,7 @@
 #include "gateway_util.h"
 #include "history.h"  // for History::Tag
 #include "publish/settings.h"
+#include "repository_util.h"
 #include "upload_spooler_result.h"
 #include "util/pointer.h"
 #include "util/single_copy.h"
@@ -313,8 +314,8 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
   void Migrate();
 
   const SettingsPublisher &settings() const { return settings_; }
-  bool in_transaction() const { return in_transaction_; }
-  bool is_publishing() const { return is_publishing_; }
+  const ServerLockFile &in_transaction() const { return in_transaction_; }
+  const ServerLockFile &is_publishing() const { return is_publishing_; }
   Session *session() const { return session_.weak_ref(); }
   const upload::Spooler *spooler_files() const { return spooler_files_; }
   const upload::Spooler *spooler_catalogs() const { return spooler_catalogs_; }
@@ -358,7 +359,6 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
 
   void TransactionRetry();
   void TransactionImpl();
-  void CheckTransactionStatus();
 
   void SyncImpl();
 
@@ -368,8 +368,8 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
    * The log level, set to kLogNone if settings_.is_silent() == true
    */
   int llvl_;
-  bool in_transaction_;
-  bool is_publishing_;
+  ServerLockFile in_transaction_;
+  ServerLockFile is_publishing_;
   gateway::GatewayKey gw_key_;
   /**
    * Only really used gateway mode when a transaction is opened. The session

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -97,7 +97,8 @@ class __attribute__((visibility("default"))) Repository : SingleCopy {
 
   static std::string GetFqrnFromUrl(const std::string &url);
 
-  explicit Repository(const SettingsRepository &settings);
+  explicit Repository(const SettingsRepository &settings,
+                      const bool exists = true);
   virtual ~Repository();
 
   void Check();
@@ -126,7 +127,6 @@ class __attribute__((visibility("default"))) Repository : SingleCopy {
   std::string meta_info() const { return meta_info_; }
 
  protected:
-  Repository();
   void DownloadRootObjects(
     const std::string &url,
     const std::string &fqrn,
@@ -277,7 +277,8 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
 
   static Publisher *Create(const SettingsPublisher &settings);
 
-  explicit Publisher(const SettingsPublisher &settings);
+  explicit Publisher(const SettingsPublisher &settings,
+                     const bool exists = true);
   virtual ~Publisher();
 
   void UpdateMetaInfo();
@@ -319,8 +320,6 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
   const upload::Spooler *spooler_catalogs() const { return spooler_catalogs_; }
 
  private:
-  Publisher();  ///< Used by Create
-
   /**
    * Used just before a spooler is required, e.g. in Create()
    */

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -314,7 +314,7 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
   void Migrate();
 
   const SettingsPublisher &settings() const { return settings_; }
-  const ServerLockFile &in_transaction() const { return in_transaction_; }
+  const ServerFlagFile &in_transaction() const { return in_transaction_; }
   const ServerLockFile &is_publishing() const { return is_publishing_; }
   Session *session() const { return session_.weak_ref(); }
   const upload::Spooler *spooler_files() const { return spooler_files_; }
@@ -368,7 +368,7 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
    * The log level, set to kLogNone if settings_.is_silent() == true
    */
   int llvl_;
-  ServerLockFile in_transaction_;
+  ServerFlagFile in_transaction_;
   ServerLockFile is_publishing_;
   gateway::GatewayKey gw_key_;
   /**

--- a/cvmfs/publish/repository_abort.cc
+++ b/cvmfs/publish/repository_abort.cc
@@ -26,11 +26,7 @@ void Publisher::WipeScratchArea() {
 }
 
 void Publisher::Abort() {
-  if (is_publishing_.IsLocked()) {
-    throw EPublish(
-      "Repository " + settings_.fqrn() + " is currently publishing "
-      "(aborting abort)", EPublish::kFailTransactionState);
-  }
+  ServerLockFileGuard g(is_publishing_);
 
   if (!in_transaction_.IsSet()) {
     if (session_->has_lease()) {

--- a/cvmfs/publish/repository_abort.cc
+++ b/cvmfs/publish/repository_abort.cc
@@ -32,7 +32,7 @@ void Publisher::Abort() {
       "(aborting abort)", EPublish::kFailTransactionState);
   }
 
-  if (!in_transaction_.IsLocked()) {
+  if (!in_transaction_.IsSet()) {
     if (session_->has_lease()) {
       LogCvmfs(kLogCvmfs, kLogSyslogWarn, "removing stale session token for %s",
                settings_.fqrn().c_str());
@@ -64,7 +64,7 @@ void Publisher::Abort() {
     managed_node_->Mount();
   }
 
-  in_transaction_.Release();
+  in_transaction_.Clear();
 }
 
 }  // namespace publish

--- a/cvmfs/publish/repository_abort.cc
+++ b/cvmfs/publish/repository_abort.cc
@@ -26,13 +26,13 @@ void Publisher::WipeScratchArea() {
 }
 
 void Publisher::Abort() {
-  if (is_publishing()) {
+  if (is_publishing_.IsLocked()) {
     throw EPublish(
       "Repository " + settings_.fqrn() + " is currently publishing "
       "(aborting abort)", EPublish::kFailTransactionState);
   }
 
-  if (!in_transaction()) {
+  if (!in_transaction_.IsLocked()) {
     if (session_->has_lease()) {
       LogCvmfs(kLogCvmfs, kLogSyslogWarn, "removing stale session token for %s",
                settings_.fqrn().c_str());
@@ -64,9 +64,7 @@ void Publisher::Abort() {
     managed_node_->Mount();
   }
 
-  ServerLockFile::Release(
-    settings_.transaction().spool_area().transaction_lock());
-  in_transaction_ = false;
+  in_transaction_.Release();
 }
 
 }  // namespace publish

--- a/cvmfs/publish/repository_managed.cc
+++ b/cvmfs/publish/repository_managed.cc
@@ -83,6 +83,7 @@ void Publisher::ManagedNode::ClearScratch() {
 
 
 int Publisher::ManagedNode::Check(bool is_quiet) {
+  ServerLockFileCheck publish_check(publisher_->is_publishing_);
   const std::string rdonly_mnt =
     publisher_->settings_.transaction().spool_area().readonly_mnt();
   const std::string union_mnt =
@@ -175,7 +176,7 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
     case kUnionMountRepairAlways:
       break;
     case kUnionMountRepairSafe:
-      if (publisher_->is_publishing_.IsLocked()) {
+      if (!publish_check.owns_lock()) {
         LogCvmfs(kLogCvmfs, logFlags,
           "WARNING: The repository %s is currently publishing and should not\n"
           "be touched. If you are absolutely sure, that this is _not_ the "

--- a/cvmfs/publish/repository_managed.cc
+++ b/cvmfs/publish/repository_managed.cc
@@ -126,9 +126,9 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
     result |= kFailUnionBroken;
   } else {
     FileSystemInfo fs_info = GetFileSystemInfo(union_mnt);
-    if (publisher_->in_transaction_.IsLocked() && fs_info.is_rdonly)
+    if (publisher_->in_transaction_.IsSet() && fs_info.is_rdonly)
       result |= kFailUnionLocked;
-    if (!publisher_->in_transaction_.IsLocked() && !fs_info.is_rdonly)
+    if (!publisher_->in_transaction_.IsSet() && !fs_info.is_rdonly)
       result |= kFailUnionWritable;
   }
 
@@ -185,7 +185,7 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
         return result;
       }
 
-      if (publisher_->in_transaction_.IsLocked()) {
+      if (publisher_->in_transaction_.IsSet()) {
         LogCvmfs(kLogCvmfs, logFlags,
           "Repository %s is in a transaction and cannot be repaired.\n"
           "--> Run `cvmfs_server abort $name` to revert and repair.",
@@ -244,7 +244,7 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
   if (result & kFailUnionBroken) {
     AlterMountpoint(kAlterUnionMount, log_flags);
     // read-only mount by default
-    if (publisher_->in_transaction_.IsLocked())
+    if (publisher_->in_transaction_.IsSet())
       result |= kFailUnionLocked;
 
     result &= ~kFailUnionBroken;

--- a/cvmfs/publish/repository_tags.cc
+++ b/cvmfs/publish/repository_tags.cc
@@ -27,7 +27,7 @@ void Publisher::CheckTagName(const std::string &name) {
 void Publisher::EditTags(const std::vector<history::History::Tag> &add_tags,
                          const std::vector<std::string> &rm_tags)
 {
-  if (!in_transaction_.IsLocked())
+  if (!in_transaction_.IsSet())
     throw EPublish("cannot edit tags outside transaction");
 
   for (unsigned i = 0; i < add_tags.size(); ++i) {

--- a/cvmfs/publish/repository_tags.cc
+++ b/cvmfs/publish/repository_tags.cc
@@ -27,7 +27,8 @@ void Publisher::CheckTagName(const std::string &name) {
 void Publisher::EditTags(const std::vector<history::History::Tag> &add_tags,
                          const std::vector<std::string> &rm_tags)
 {
-  if (!in_transaction_) throw EPublish("cannot edit tags outside transaction");
+  if (!in_transaction_.IsLocked())
+    throw EPublish("cannot edit tags outside transaction");
 
   for (unsigned i = 0; i < add_tags.size(); ++i) {
     std::string name = add_tags[i].name;

--- a/cvmfs/publish/repository_transaction.cc
+++ b/cvmfs/publish/repository_transaction.cc
@@ -34,8 +34,6 @@ void Publisher::CheckTransactionStatus() {
     settings_.transaction().spool_area().publishing_lock();
   is_publishing_ =
     ServerLockFile::IsLocked(publishing_lock, false /* ignore_stale */);
-
-  session_ = new Session(settings_, llvl_);
 }
 
 

--- a/cvmfs/publish/repository_util.cc
+++ b/cvmfs/publish/repository_util.cc
@@ -61,7 +61,15 @@ void CheckoutMarker::SaveAs(const std::string &path) const {
 //------------------------------------------------------------------------------
 
 
-bool ServerLockFile::Acquire() {
+void ServerLockFile::Lock() {
+  if (!TryLock()) {
+    throw EPublish("Could not acquire lock " + path_,
+                   EPublish::kFailTransactionState);
+  }
+}
+
+
+bool ServerLockFile::TryLock() {
   std::string tmp_path;
   FILE *ftmp = CreateTempFile(path_ + ".tmp", kDefaultFileMode, "w", &tmp_path);
   if (ftmp == NULL)
@@ -77,7 +85,7 @@ bool ServerLockFile::Acquire() {
     return false;
   }
 
-  Release();
+  Unlock();
   if (link(tmp_path.c_str(), path_.c_str()) == 0) {
     unlink(tmp_path.c_str());
     return true;
@@ -115,7 +123,7 @@ bool ServerLockFile::IsLocked() const {
 }
 
 
-void ServerLockFile::Release() {
+void ServerLockFile::Unlock() {
   unlink(path_.c_str());
 }
 

--- a/cvmfs/publish/repository_util.cc
+++ b/cvmfs/publish/repository_util.cc
@@ -97,11 +97,6 @@ bool ServerLockFile::IsLocked() const {
     throw EPublish("cannot open transaction marker " + path_);
   }
 
-  if (ignore_stale_) {
-    close(fd);
-    return true;
-  }
-
   std::string line;
   bool retval = GetLineFd(fd, &line);
   close(fd);
@@ -123,6 +118,30 @@ bool ServerLockFile::IsLocked() const {
 void ServerLockFile::Release() {
   unlink(path_.c_str());
 }
+
+
+//------------------------------------------------------------------------------
+
+
+void ServerFlagFile::Set() {
+  int fd = open(path_.c_str(), O_CREAT | O_RDWR, 0600);
+  if (fd < 0)
+    throw EPublish("cannot create flag file " + path_);
+  close(fd);
+}
+
+
+void ServerFlagFile::Clear() {
+  unlink(path_.c_str());
+}
+
+
+bool ServerFlagFile::IsSet() const {
+  return FileExists(path_);
+}
+
+
+//------------------------------------------------------------------------------
 
 
 void RunSuidHelper(const std::string &verb, const std::string &fqrn) {

--- a/cvmfs/publish/repository_util.h
+++ b/cvmfs/publish/repository_util.h
@@ -47,8 +47,7 @@ class CheckoutMarker {
  */
 class ServerLockFile {
  public:
-  ServerLockFile(const std::string &path, bool ignore_stale)
-    : path_(path), ignore_stale_(ignore_stale) {}
+  explicit ServerLockFile(const std::string &path) : path_(path) {}
 
   bool Acquire();
   void Release();
@@ -58,9 +57,26 @@ class ServerLockFile {
 
  private:
   std::string path_;
-  bool ignore_stale_;
 };
 
+/**
+ * A server flag file is a file used to indicate a single-bit state
+ * that extends beyond the lifetime of a process, such as the
+ * indication that a transaction is open.
+ */
+class ServerFlagFile {
+ public:
+  explicit ServerFlagFile(const std::string &path) : path_(path) {}
+
+  void Set();
+  void Clear();
+  bool IsSet() const;
+
+  const std::string &path() const { return path_; }
+
+ private:
+  std::string path_;
+};
 
 /**
  * Callout to cvmfs_suid_helper $verb $fqrn

--- a/cvmfs/publish/repository_util.h
+++ b/cvmfs/publish/repository_util.h
@@ -49,8 +49,9 @@ class ServerLockFile {
  public:
   explicit ServerLockFile(const std::string &path) : path_(path) {}
 
-  bool Acquire();
-  void Release();
+  void Lock();
+  bool TryLock();
+  void Unlock();
   bool IsLocked() const;
 
   const std::string &path() const { return path_; }

--- a/cvmfs/publish/repository_util.h
+++ b/cvmfs/publish/repository_util.h
@@ -47,9 +47,18 @@ class CheckoutMarker {
  */
 class ServerLockFile {
  public:
-  static bool Acquire(const std::string &path, bool ignore_stale);
-  static void Release(const std::string &path);
-  static bool IsLocked(const std::string &path, bool ignore_stale);
+  ServerLockFile(const std::string &path, bool ignore_stale)
+    : path_(path), ignore_stale_(ignore_stale) {}
+
+  bool Acquire();
+  void Release();
+  bool IsLocked() const;
+
+  const std::string &path() const { return path_; }
+
+ private:
+  std::string path_;
+  bool ignore_stale_;
 };
 
 

--- a/cvmfs/publish/repository_util.h
+++ b/cvmfs/publish/repository_util.h
@@ -41,24 +41,26 @@ class CheckoutMarker {
 
 
 /**
- * The server lock file is a file containing the pid of the creator, so that
- * with high probability one can determine stale locks.  This comes from the
- * cvmfs_server bash times and should at some point become a regular POSIX
- * lock file.
+ * A server lock file is a POSIX lock file used to obtain mutually
+ * exclusive access to the repository while conducting an operation
+ * that modifies the repository state.
+ *
+ * Since the lock is implemented using a POSIX lock file, the lock
+ * will automatically be released when the creating process exits.
  */
 class ServerLockFile {
  public:
-  explicit ServerLockFile(const std::string &path) : path_(path) {}
+  explicit ServerLockFile(const std::string &path) : path_(path), fd_(-1) {}
 
   void Lock();
   bool TryLock();
   void Unlock();
-  bool IsLocked() const;
 
   const std::string &path() const { return path_; }
 
  private:
   std::string path_;
+  int fd_;
 };
 
 /**

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -288,6 +288,15 @@ SettingsRepository::SettingsRepository(
 }
 
 
+SettingsRepository::SettingsRepository(
+  const SettingsReplica &settings_replica)
+  : fqrn_(settings_replica.fqrn())
+  , url_(settings_replica.url())
+  , keychain_(settings_replica.fqrn())
+{
+}
+
+
 void SettingsRepository::SetUrl(const std::string &url) {
   // TODO(jblomer): sanitiation, check availability
   url_ = url;

--- a/cvmfs/publish/settings.h
+++ b/cvmfs/publish/settings.h
@@ -345,6 +345,7 @@ class SettingsKeychain {
 
 
 class SettingsPublisher;
+class SettingsReplica;
 
 /**
  * Description of a read-only repository
@@ -359,6 +360,7 @@ class SettingsRepository {
     , keychain_(fqrn)
   {}
   explicit SettingsRepository(const SettingsPublisher &settings_publisher);
+  explicit SettingsRepository(const SettingsReplica &settings_replica);
 
   void SetUrl(const std::string &url);
   void SetProxy(const std::string &proxy);
@@ -462,6 +464,9 @@ class SettingsReplica {
     , alias_(fqrn)
     , url_(std::string("http://localhost/cvmfs/") + alias_())
   {}
+
+  std::string fqrn() const { return fqrn_(); }
+  std::string url() const { return url_(); }
 
  private:
   Setting<std::string> fqrn_;

--- a/test/unittests/publish/t_transaction.cc
+++ b/test/unittests/publish/t_transaction.cc
@@ -35,9 +35,9 @@ TEST_F(T_Transaction, TemplateSettings) {
 
 TEST_F(T_Transaction, BasicTransaction) {
   Publisher *publisher = GetTestPublisher();
-  EXPECT_FALSE(publisher->in_transaction());
+  EXPECT_FALSE(publisher->in_transaction().IsLocked());
   publisher->Transaction();
-  EXPECT_TRUE(publisher->in_transaction());
+  EXPECT_TRUE(publisher->in_transaction().IsLocked());
   delete publisher;
 
   // TODO(jblomer): add more tests when publish and abort are implemented

--- a/test/unittests/publish/t_transaction.cc
+++ b/test/unittests/publish/t_transaction.cc
@@ -35,9 +35,9 @@ TEST_F(T_Transaction, TemplateSettings) {
 
 TEST_F(T_Transaction, BasicTransaction) {
   Publisher *publisher = GetTestPublisher();
-  EXPECT_FALSE(publisher->in_transaction().IsLocked());
+  EXPECT_FALSE(publisher->in_transaction().IsSet());
   publisher->Transaction();
-  EXPECT_TRUE(publisher->in_transaction().IsLocked());
+  EXPECT_TRUE(publisher->in_transaction().IsSet());
   delete publisher;
 
   // TODO(jblomer): add more tests when publish and abort are implemented

--- a/test/unittests/publish/t_util.cc
+++ b/test/unittests/publish/t_util.cc
@@ -69,27 +69,29 @@ TEST_F(T_Util, CheckoutMarker4) {
 
 
 TEST_F(T_Util, ServerLockFile) {
-  EXPECT_FALSE(ServerLockFile::IsLocked("foo", true));
-  EXPECT_TRUE(ServerLockFile::Acquire("foo", true));
-  EXPECT_FALSE(ServerLockFile::Acquire("foo", true));
-  EXPECT_TRUE(ServerLockFile::IsLocked("foo", true));
-  ServerLockFile::Release("foo");
-  EXPECT_FALSE(ServerLockFile::IsLocked("foo", true));
+  ServerLockFile foo_flag("foo", true);
+  ServerLockFile foo_lock("foo", false);
+  EXPECT_FALSE(foo_flag.IsLocked());
+  EXPECT_TRUE(foo_flag.Acquire());
+  EXPECT_FALSE(foo_flag.Acquire());
+  EXPECT_TRUE(foo_flag.IsLocked());
+  foo_flag.Release();
+  EXPECT_FALSE(foo_flag.IsLocked());
 
   pid_t pid_child = fork();
   ASSERT_GE(pid_child, 0);
   if (pid_child == 0) {
-    EXPECT_TRUE(ServerLockFile::Acquire("foo", true));
+    EXPECT_TRUE(foo_flag.Acquire());
     exit(0);
   }
   EXPECT_EQ(0, WaitForChild(pid_child));
 
-  EXPECT_TRUE(ServerLockFile::IsLocked("foo", true));
-  EXPECT_FALSE(ServerLockFile::IsLocked("foo", false));
-  EXPECT_FALSE(ServerLockFile::Acquire("foo", true));
-  EXPECT_TRUE(ServerLockFile::Acquire("foo", false));
-  EXPECT_TRUE(ServerLockFile::IsLocked("foo", false));
-  ServerLockFile::Release("foo");
+  EXPECT_TRUE(foo_flag.IsLocked());
+  EXPECT_FALSE(foo_lock.IsLocked());
+  EXPECT_FALSE(foo_flag.Acquire());
+  EXPECT_TRUE(foo_lock.Acquire());
+  EXPECT_TRUE(foo_lock.IsLocked());
+  foo_lock.Release();
 }
 
 

--- a/test/unittests/publish/t_util.cc
+++ b/test/unittests/publish/t_util.cc
@@ -71,16 +71,16 @@ TEST_F(T_Util, CheckoutMarker4) {
 TEST_F(T_Util, ServerLockFile) {
   ServerLockFile lock("foo.lock");
   EXPECT_FALSE(lock.IsLocked());
-  EXPECT_TRUE(lock.Acquire());
-  EXPECT_FALSE(lock.Acquire());
+  EXPECT_TRUE(lock.TryLock());
+  EXPECT_FALSE(lock.TryLock());
   EXPECT_TRUE(lock.IsLocked());
-  lock.Release();
+  lock.Unlock();
   EXPECT_FALSE(lock.IsLocked());
 
   pid_t pid_child = fork();
   ASSERT_GE(pid_child, 0);
   if (pid_child == 0) {
-    EXPECT_TRUE(lock.Acquire());
+    EXPECT_TRUE(lock.TryLock());
     EXPECT_TRUE(lock.IsLocked());
     exit(0);
   }


### PR DESCRIPTION
The Publisher model is largely transliterated directly from the original shell scripts.  This leads to C++ code that is procedural in nature and difficult to follow, and prevents the use of object-oriented programming techniques such as RAII.

As a first step towards updating the Publisher to a full object-oriented model, clean up the handling of the server lock files:

- Use an object model to represent a server lock file
- Separate the logically distinct lock files and flag files
- Clean up method names to more closely approximate C++11 standard library equivalents
- Implement and use an RAII lock guard to hold a server lock file
- Reimplement server lock files as regular POSIX lock files (as per the existing TODO comment)
- Remove duplicated and redundant code

Commits have been structured for easy review.  Please retain the individual commits when merging this PR.