### PR TITLE
Fix broken unit test T_CatalogMgrRw.SwapNestedCatalogFailSlow

### DIFF
--- a/test/unittests/t_catalog_mgr_rw.cc
+++ b/test/unittests/t_catalog_mgr_rw.cc
@@ -211,12 +211,13 @@ TEST_F(T_CatalogMgrRw, SwapNestedCatalogFailSlow) {
                                               sub1_hash, sub1_size),
                "not found in parent");
 
-  // Fail for nested catalog that is already attached
+  // Fail for nested catalog that is already attached and modified
   EXPECT_TRUE(catalog_mgr->LookupNested(PathString("/dir/dir/dir/sub1"),
                                         &path, &sub1_hash, &sub1_size));
+  catalog_mgr->RemoveFile("dir/dir/dir/sub1/file1");
   EXPECT_DEATH(catalog_mgr->SwapNestedCatalog("dir/dir/dir/sub1",
                                               sub1_hash, sub1_size),
-               "already attached");
+               "already modified");
 
   // Fail for non-existent catalog
   catalog_mgr->DetachNested();


### PR DESCRIPTION
Commit d5fbe10 ("Allow nested catalog to be swapped even if already
attached") neglected to update the unit tests to match the new
functionality, in which SwapNestedCatalog() should fail for an
already-attached nested catalog only if the catalog has been modified.

Fix the unit test to match the intended behaviour as described in the
commit.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>