### PR TITLE
cvmfs_server abort should ignore trailing path after repository name

### DIFF
--- a/cvmfs/publish/cmd_abort.cc
+++ b/cvmfs/publish/cmd_abort.cc
@@ -41,11 +41,13 @@ int CmdAbort::Main(const Options &options) {
 
   UniquePtr<SettingsPublisher> settings;
   try {
-    // Legacy behaviour is that trailing paths after the repository name should be ignored, e.g.
-    // cvmfs_server abort repo.cern.ch/some/path is equivalent to cvmfs_server abort repo.cern.ch
+    // Legacy behaviour is that trailing paths after the repository name should
+    // be ignored, e.g. cvmfs_server abort repo.cern.ch/some/path is equivalent
+    // to cvmfs_server abort repo.cern.ch
     std::string repository_ident = StripTrailingPath(
       options.plain_args().empty() ? "" : options.plain_args()[0].value_str);
-    settings = builder.CreateSettingsPublisher(repository_ident, true /* needs_managed */);
+    settings = builder.CreateSettingsPublisher(
+      repository_ident, true /* needs_managed */);
   } catch (const EPublish &e) {
     if ((e.failure() == EPublish::kFailRepositoryNotFound) ||
         (e.failure() == EPublish::kFailRepositoryType))

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -203,6 +203,15 @@ cvmfs_run_test() {
     cvmfs_server publish test.repo.org || return 101
     cvmfs_server check -i test.repo.org || return 102
 
+    ## Transactions 11 and 12 (Abort command should use repository name and ignore trailing path)
+    echo "***  Starting transaction 11"
+    cvmfs_server transaction test.repo.org/path || return 112
+    cvmfs_server abort -f test.repo.org || return 113
+
+    echo "***  Starting transaction 12"
+    cvmfs_server transaction test.repo.org/path || return 114
+    cvmfs_server abort -f test.repo.org/path || return 115
+
     echo "  Verify the contents of the repository"
     compare_file_checksum /cvmfs/test.repo.org/new/c/another_file_trailing.txt \
         f1885b1a57c71cacbd923fc5e9aefef3 || return 103


### PR DESCRIPTION
Addresses [CVM-2055](https://sft.its.cern.ch/jira/browse/CVM-2055).