### PR TITLE
Improve error reporting for watchdog failures

### DIFF
--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -543,17 +543,17 @@ void Watchdog::Supervise() {
   SigactionMap signal_handlers;
   signal_handlers[SIGHUP]  = sa;
   signal_handlers[SIGINT]  = sa;
-  signal_handlers[SIGTERM] = sa;
   signal_handlers[SIGQUIT] = sa;
   signal_handlers[SIGILL]  = sa;
   signal_handlers[SIGABRT] = sa;
-  signal_handlers[SIGFPE]  = sa;
-  signal_handlers[SIGSEGV] = sa;
   signal_handlers[SIGBUS]  = sa;
-  signal_handlers[SIGXFSZ] = sa;
+  signal_handlers[SIGFPE]  = sa;
   signal_handlers[SIGUSR1] = sa;
-  signal_handlers[SIGUSR2] = sa;
   signal_handlers[SIGSEGV] = sa;
+  signal_handlers[SIGUSR2] = sa;
+  signal_handlers[SIGTERM] = sa;
+  signal_handlers[SIGXCPU] = sa;
+  signal_handlers[SIGXFSZ] = sa;
   SetSignalHandlers(signal_handlers);
 
   ControlFlow::Flags control_flow;

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -498,7 +498,9 @@ void *Watchdog::MainWatchdogListener(void *data) {
           (watch_fds[0].revents & POLLNVAL))
       {
         LogCvmfs(kLogMonitor, kLogDebug | kLogSyslogErr,
-                 "watchdog disappeared, disabling stack trace reporting");
+                 "watchdog disappeared, disabling stack trace reporting "
+                 "(revents: %d / %d|%d|%d)",
+                 watch_fds[0].revents, POLLERR, POLLHUP, POLLNVAL);
         watchdog->SetSignalHandlers(watchdog->old_signal_handlers_);
         PANIC(kLogDebug | kLogSyslogErr, "watchdog disappeared, aborting");
       }

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -286,11 +286,13 @@ string Watchdog::ReportStacktrace() {
 }
 
 
-void Watchdog::ReportSignal(int sig, siginfo_t *siginfo, void * /* context */)
+void Watchdog::ReportSignalAndTerminate(
+  int sig, siginfo_t *siginfo, void * /* context */)
 {
   LogCvmfs(kLogMonitor, kLogSyslogErr,
            "watchdog: received unexpected signal %d from PID %d / UID %d",
            sig, siginfo->si_pid, siginfo->si_uid);
+  _exit(1);
 }
 
 
@@ -534,7 +536,7 @@ void Watchdog::Supervise() {
   // The watchdog is not supposed to receive signals. If it does, report it.
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
-  sa.sa_sigaction = ReportSignal;
+  sa.sa_sigaction = ReportSignalAndTerminate;
   sa.sa_flags = SA_SIGINFO;
   sigfillset(&sa.sa_mask);
 

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -63,7 +63,8 @@ class Watchdog {
   static Watchdog *instance_;
   static Watchdog *Me() { return instance_; }
 
-  static void ReportSignal(int sig, siginfo_t *siginfo, void *context);
+  static void ReportSignalAndTerminate(int sig, siginfo_t *siginfo,
+                                       void *context);
   static void SendTrace(int sig, siginfo_t *siginfo, void *context);
 
   explicit Watchdog(const std::string &crash_dump_path);

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -63,6 +63,7 @@ class Watchdog {
   static Watchdog *instance_;
   static Watchdog *Me() { return instance_; }
 
+  static void ReportSignal(int sig, siginfo_t *siginfo, void *context);
   static void SendTrace(int sig, siginfo_t *siginfo, void *context);
 
   explicit Watchdog(const std::string &crash_dump_path);


### PR DESCRIPTION
- Let the watchdog report unexpected signals
- Fix an issue that prevented the watchdog to log to syslog
- In the main process: report the reason of a broken pipe to the watchdog