### PR TITLE
Fix use-after-free error in swissknife_check

### DIFF
--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -696,8 +696,7 @@ bool CommandCheck::FindSubtreeRootCatalog(const string &subtree_path,
   typedef vector<string> Tokens;
   const Tokens path_tokens = SplitString(subtree_path, '/');
 
-  string      current_path = "";
-  bool        found        = false;
+  string current_path = "";
 
   Tokens::const_iterator i    = path_tokens.begin();
   Tokens::const_iterator iend = path_tokens.end();
@@ -718,12 +717,11 @@ bool CommandCheck::FindSubtreeRootCatalog(const string &subtree_path,
           break;
         }
       } else {
-        found = true;
+        return true;
       }
     }
   }
-
-  return found;
+  return false;
 }
 
 


### PR DESCRIPTION
Fixes a defect found by clang-tidy in #2859. @radupopescu This may explain the occasional failures reported in CVMFSOPS-272