### PR TITLE
Optionally adding extra information to meta.json.

### DIFF
--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -25,7 +25,7 @@ LATEST_JSON_INFO_SCHEMA=1
 
 # Should we publish CVMFS and OS versions in meta.json?
 # Set to any non-true string to turn off this feature.
-PUBLISH_VERSIONS_IN_META_FILE=true
+CVMFS_PUBLISH_VERSIONS_IN_META_FILE=true
 
 if [ -f /etc/cvmfs/server.local ]; then
   if [ -r /etc/cvmfs/server.local ]; then

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -23,6 +23,10 @@ DEFAULT_LOCAL_STORAGE="/srv/cvmfs"
 
 LATEST_JSON_INFO_SCHEMA=1
 
+# Should we publish CVMFS and OS versions in meta.json?
+# Set to any non-true string to turn off this feature.
+PUBLISH_VERSIONS_IN_META_FILE=true
+
 if [ -f /etc/cvmfs/server.local ]; then
   if [ -r /etc/cvmfs/server.local ]; then
     . /etc/cvmfs/server.local

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -91,7 +91,7 @@ _render_info_file() {
     echo '  "last_geodb_update" : "'$modtime'",'
   fi
 
-  if [ "x${PUBLISH_VERSIONS_IN_META_FILE}" == "xtrue" ]; then
+  if [ "x${CVMFS_PUBLISH_VERSIONS_IN_META_FILE}" == "xtrue" ]; then
     echo '  "cvmfs_version" : "$(cvmfs_version_string)",'
     echo '  "os_version" : "' $(lsb_release -d | cut -f2) '", '
   fi

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -91,6 +91,11 @@ _render_info_file() {
     echo '  "last_geodb_update" : "'$modtime'",'
   fi
 
+  if [ "x${PUBLISH_VERSIONS_IN_META_FILE}" == "xtrue" ]; then
+    echo '  "cvmfs_version" : "$(cvmfs_version_string)",'
+    echo '  "os_version" : "' $(lsb_release -d | cut -f2) '", '
+  fi
+
   echo '  "repositories" : ['
 
   _render_repos $(_available_repos "stratum0")
@@ -101,6 +106,7 @@ _render_info_file() {
   _render_repos $(_available_repos "stratum1")
 
   echo '  ]'
+
   echo '}'
 }
 

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -92,7 +92,7 @@ _render_info_file() {
   fi
 
   if [ "x${CVMFS_PUBLISH_VERSIONS_IN_META_FILE}" == "xtrue" ]; then
-    echo '  "cvmfs_version" : "$(cvmfs_version_string)",'
+    echo '  "cvmfs_version" : "'$(cvmfs_version_string)'",'
     echo '  "os_id" : "'$(_os_id)'", '
     echo '  "os_version_id" : "'$(_os_version_id)'", '
     echo '  "os_pretty_name" : "'$(_os_pretty_name)'", '

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -106,7 +106,6 @@ _render_info_file() {
   _render_repos $(_available_repos "stratum1")
 
   echo '  ]'
-
   echo '}'
 }
 

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -93,7 +93,9 @@ _render_info_file() {
 
   if [ "x${CVMFS_PUBLISH_VERSIONS_IN_META_FILE}" == "xtrue" ]; then
     echo '  "cvmfs_version" : "$(cvmfs_version_string)",'
-    echo '  "os_version" : "' $(lsb_release -d | cut -f2) '", '
+    echo '  "os_id" : "'$(_os_id)'", '
+    echo '  "os_version_id" : "'$(_os_version_id)'", '
+    echo '  "os_pretty_name" : "'$(_os_pretty_name)'", '
   fi
 
   echo '  "repositories" : ['

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -756,7 +756,7 @@ _os_set_etc_release_filename() {
 _os_etc_release_get_field() {
 	_os_set_etc_release_filename
 
-	fieldname=$1
+	local fieldname=$1
 	if [ "x${fieldname}" == "x" ]; then
 		die "Internal error: _os_etc_release_get_field expects a field name to search for!"
 	fi

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -733,6 +733,54 @@ has_selinux() {
   $GETENFORCE_BIN | grep -qi "enforc" || return 1
 }
 
+# Functions to retrieve information about the operating system.
+# Used in cvmfs_server_json.sh to populate meta.json.
+# Fails gracefully if no os-release file is found (values become empty strings)
+_os_set_etc_release_filename() {
+	_CVMFS_OS_RELEASE_FILENAME=''
+	if test -e "/etc/os-release"; then
+		_CVMFS_OS_RELEASE_FILENAME="/etc/os-release";
+	elif test -e "/usr/lib/os-release"; then
+		_CVMFS_OS_RELEASE_FILENAME="/usr/lib/os-release";
+	fi
+}
+
+# Pick a specific field from the os-release file and return it. 
+# 1. _os_set_etc_release_filename is called on every check, this is probably overkill,
+#    but the question would be where to call this once and for all. In theory one could
+#    call it right after the declaration above?
+# 2. If a fieldname isn't provided, die due to wrongful usage of the (internal) function.
+# 3. If we couldn't find an os-release file, return nothing.
+# 4. If we grep fails to find anything, return nothing. We may want to check against known
+#    keys from https://www.freedesktop.org/software/systemd/man/os-release.html?
+_os_etc_release_get_field() {
+	_os_set_etc_release_filename
+
+	fieldname=$1
+	if [ "x${fieldname}" == "x" ]; then
+		die "Internal error: _os_etc_release_get_field expects a field name to search for!"
+	fi
+
+	if [ "x${_CVMFS_OS_RELEASE_FILENAME}" == "x" ]; then
+		# If we are unable to find a proper /etc/os-release file return nothing.
+		:
+	else
+		grep "^${fieldname}=" ${_CVMFS_OS_RELEASE_FILENAME} | cut -f2 -d'"'
+	fi
+}
+
+_os_id() {
+	_os_etc_release_get_field 'ID'
+}
+
+_os_version_id() {
+	_os_etc_release_get_field 'VERSION_ID'
+}
+
+_os_pretty_name() {
+	_os_etc_release_get_field 'PRETTY_NAME'
+}
+
 
 set_selinux_httpd_context_if_needed() {
   local directory="$1"

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -765,7 +765,7 @@ _os_etc_release_get_field() {
 		# If we are unable to find a proper /etc/os-release file return nothing.
 		:
 	else
-		grep "^${fieldname}=" ${_CVMFS_OS_RELEASE_FILENAME} | cut -f2 -d'"'
+    sed -n "s/\"//g;s/^${fieldname}=//p" ${_CVMFS_OS_RELEASE_FILENAME}
 	fi
 }
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -737,12 +737,12 @@ has_selinux() {
 # Used in cvmfs_server_json.sh to populate meta.json.
 # Fails gracefully if no os-release file is found (values become empty strings)
 _os_set_etc_release_filename() {
-	_CVMFS_OS_RELEASE_FILENAME=''
-	if test -e "/etc/os-release"; then
-		_CVMFS_OS_RELEASE_FILENAME="/etc/os-release";
-	elif test -e "/usr/lib/os-release"; then
-		_CVMFS_OS_RELEASE_FILENAME="/usr/lib/os-release";
-	fi
+  _CVMFS_OS_RELEASE_FILENAME=''
+  if test -e "/etc/os-release"; then
+    _CVMFS_OS_RELEASE_FILENAME="/etc/os-release";
+  elif test -e "/usr/lib/os-release"; then
+    _CVMFS_OS_RELEASE_FILENAME="/usr/lib/os-release";
+  fi
 }
 
 # Pick a specific field from the os-release file and return it. 
@@ -754,31 +754,31 @@ _os_set_etc_release_filename() {
 # 4. If we grep fails to find anything, return nothing. We may want to check against known
 #    keys from https://www.freedesktop.org/software/systemd/man/os-release.html?
 _os_etc_release_get_field() {
-	_os_set_etc_release_filename
+  _os_set_etc_release_filename
 
-	local fieldname=$1
-	if [ "x${fieldname}" == "x" ]; then
-		die "Internal error: _os_etc_release_get_field expects a field name to search for!"
-	fi
+  local fieldname=$1
+  if [ "x${fieldname}" == "x" ]; then
+    die "Internal error: _os_etc_release_get_field expects a field name to search for!"
+  fi
 
-	if [ "x${_CVMFS_OS_RELEASE_FILENAME}" == "x" ]; then
-		# If we are unable to find a proper /etc/os-release file return nothing.
-		:
-	else
+  if [ "x${_CVMFS_OS_RELEASE_FILENAME}" == "x" ]; then
+    # If we are unable to find a proper /etc/os-release file return nothing.
+    :
+  else
     sed -n "s/\"//g;s/^${fieldname}=//p" ${_CVMFS_OS_RELEASE_FILENAME}
-	fi
+  fi
 }
 
 _os_id() {
-	_os_etc_release_get_field 'ID'
+  _os_etc_release_get_field 'ID'
 }
 
 _os_version_id() {
-	_os_etc_release_get_field 'VERSION_ID'
+  _os_etc_release_get_field 'VERSION_ID'
 }
 
 _os_pretty_name() {
-	_os_etc_release_get_field 'PRETTY_NAME'
+  _os_etc_release_get_field 'PRETTY_NAME'
 }
 
 


### PR DESCRIPTION
This patch seeks to add some useful system information to the meta.json file for logging and monitoring. This feature is optional.

  - Adds the following fields to meta.json:
    - cvmfs_version : version_string
    - os_version : $(lsb_release -d | cut -f2)
  - Can be disabled by setting PUBLISH_VERSIONS_IN_META_FILE to anything but "true".