### PR TITLE
Drop chkconfig requirement for EL9

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -118,7 +118,9 @@ Requires: sysvinit
 Requires: sysvinit-tools
   %endif
 %else
+%if 0%{?el7}%{?el8}%{?suse_version}
 Requires: chkconfig
+%endif
 Requires: fuse-libs
 Requires: glibc-common
 Requires: which


### PR DESCRIPTION
Drop chkconfig requirement for EL9 and newer.

Fairly sure it could be dropped for everything but for the future is
the main thing.