### PR TITLE
Fix build in Docker on macOS w/ virtio-fs

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -100,6 +100,7 @@ create_cvmfs_source_tarball() {
         ${source_directory}/test               \
         ${source_directory}/ducc               \
         $tar_name
+  rm -r $tar_name/test/benchmarks
   tar czf $destination_path $tar_name || true
   local retval=$?
   cd ..


### PR DESCRIPTION
Removes invalid symlinks from the source tarball which cause the RPM build process to fail inside Docker on macOS, when virtio-fs shared volumes are enabled.