### PR TITLE
Fix integration test after updating cvmfs-config-default

### DIFF
--- a/test/src/060-hidexattrs/main
+++ b/test/src/060-hidexattrs/main
@@ -5,7 +5,7 @@ cvmfs_test_suites="quick"
 cvmfs_run_test() {
   logfile=$1
 
-  cvmfs_mount grid.cern.ch "CVMFS_HIDE_MAGIC_XATTRS=no" || return 1
+  cvmfs_mount grid.cern.ch "CVMFS_MAGIC_XATTRS_VISIBILITY=always" || return 1
   local attributes=$(list_xattrs /cvmfs/grid.cern.ch)
   echo "Extended attributes: $attributes"
   if [ "x$attributes" = "x" ]; then
@@ -13,15 +13,15 @@ cvmfs_run_test() {
   fi
 
   cvmfs_umount grid.cern.ch || return 2
-  cvmfs_mount grid.cern.ch "CVMFS_HIDE_MAGIC_XATTRS=yes" || return 3
-  attributes=$(list_xattrs /cvmfs/grid.cern.ch/.cvmfsdirtab)
+  cvmfs_mount grid.cern.ch "CVMFS_MAGIC_XATTRS_VISIBILITY=never" || return 3
+  attributes=$(list_xattrs /cvmfs/grid.cern.ch)
   if [ "x$attributes" != "x" ]; then
     echo "Extended attributes (none expected): $attributes"
     return 20
   fi
 
   # Attributes are now hidden but they should still be retrievable
-  local fqrn=$(get_xattr fqrn /cvmfs/grid.cern.ch/.cvmfsdirtab)
+  local fqrn=$(get_xattr fqrn /cvmfs/grid.cern.ch)
   echo "Fqrn retrieved: $fqrn"
   if [ "x$fqrn" != "xgrid.cern.ch" ]; then
     return 30

--- a/test/src/060-hidexattrs/main
+++ b/test/src/060-hidexattrs/main
@@ -14,14 +14,14 @@ cvmfs_run_test() {
 
   cvmfs_umount grid.cern.ch || return 2
   cvmfs_mount grid.cern.ch "CVMFS_HIDE_MAGIC_XATTRS=yes" || return 3
-  attributes=$(list_xattrs /cvmfs/grid.cern.ch)
+  attributes=$(list_xattrs /cvmfs/grid.cern.ch/.cvmfsdirtab)
   if [ "x$attributes" != "x" ]; then
     echo "Extended attributes (none expected): $attributes"
     return 20
   fi
 
   # Attributes are now hidden but they should still be retrievable
-  local fqrn=$(get_xattr fqrn /cvmfs/grid.cern.ch)
+  local fqrn=$(get_xattr fqrn /cvmfs/grid.cern.ch/.cvmfsdirtab)
   echo "Fqrn retrieved: $fqrn"
   if [ "x$fqrn" != "xgrid.cern.ch" ]; then
     return 30


### PR DESCRIPTION
The new default config in cvmfs-config.cern.ch already sets `CVMFS_MAGIC_XATTRS_VISIBILITY=rootonly`.