### PR TITLE
Track page cache state

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1025,7 +1025,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     assert(retval);
 
     fi->fh = static_cast<uint64_t>(-chunk_tables->next_handle);
-    // TODO: hash over chunk hashes
+    // TODO(jblomer): hash over chunk hashes
     open_directives = mount_point_->page_cache_tracker()->Open(
       ino, chunk_reflist.HashChunkList());
     FillOpenFlags(open_directives, fi);

--- a/cvmfs/glue_buffer.cc
+++ b/cvmfs/glue_buffer.cc
@@ -313,7 +313,7 @@ void PageCacheTracker::InitLock() {
 }
 
 PageCacheTracker::OpenDirectives PageCacheTracker::Open(
-  std::uint64_t inode, const shash::Any &hash)
+  uint64_t inode, const shash::Any &hash)
 {
   OpenDirectives open_directives;
   // Old behavior: always flush page cache on open
@@ -373,7 +373,7 @@ PageCacheTracker::OpenDirectives PageCacheTracker::Open(
   return open_directives;
 }
 
-void PageCacheTracker::Close(std::uint64_t inode) {
+void PageCacheTracker::Close(uint64_t inode) {
   if (!is_active_)
     return;
 
@@ -390,6 +390,14 @@ void PageCacheTracker::Close(std::uint64_t inode) {
   }
   entry.nopen--;
   map_.Insert(inode, entry);
+}
+
+void PageCacheTracker::Evict(uint64_t inode) {
+  if (!is_active_)
+    return;
+
+  MutexLockGuard guard(lock_);
+  map_.Erase(inode);
 }
 
 }  // namespace glue

--- a/cvmfs/glue_buffer.cc
+++ b/cvmfs/glue_buffer.cc
@@ -325,7 +325,7 @@ PageCacheTracker::OpenDirectives PageCacheTracker::Open(
   if (!retval) {
     open_directives.keep_cache = true;
     open_directives.direct_io = false;
-    statistics_.ninsert++;
+    statistics_.n_insert++;
 
     entry.hash = hash;
     entry.nopen = 1;
@@ -394,6 +394,7 @@ void PageCacheTracker::Evict(uint64_t inode) {
   if (!is_active_)
     return;
 
+  statistics_.n_remove++;
   MutexLockGuard guard(lock_);
   map_.Erase(inode);
 }

--- a/cvmfs/glue_buffer.cc
+++ b/cvmfs/glue_buffer.cc
@@ -263,10 +263,7 @@ void NentryTracker::EndEnumerate(Cursor *cursor) {
 //------------------------------------------------------------------------------
 
 
-PageCacheTracker::PageCacheTracker(bool is_active)
-  : version_(kVersion)
-  , is_active_(is_active)
-{
+PageCacheTracker::PageCacheTracker() : version_(kVersion), is_active_(true) {
   map_.Init(16, 0, hasher_inode);
   InitLock();
 }
@@ -288,9 +285,8 @@ PageCacheTracker &PageCacheTracker::operator= (const PageCacheTracker &other) {
   if (&other == this)
     return *this;
 
-  Lock();
+  MutexLockGuard guard(lock_);
   CopyFrom(other);
-  Unlock();
   return *this;
 }
 
@@ -301,6 +297,8 @@ void PageCacheTracker::CopyFrom(const PageCacheTracker &other) {
   version_ = kVersion;
   is_active_ = other.is_active_;
   statistics_ = other.statistics_;
+
+  map_.Init(16, 0, hasher_inode);
   map_ = other.map_;
 }
 

--- a/cvmfs/glue_buffer.cc
+++ b/cvmfs/glue_buffer.cc
@@ -376,6 +376,17 @@ PageCacheTracker::OpenDirectives PageCacheTracker::Open(
   return open_directives;
 }
 
+PageCacheTracker::OpenDirectives PageCacheTracker::OpenDirect() {
+  OpenDirectives open_directives(true, true);
+  // Old behavior: always flush page cache on open
+  if (!is_active_)
+    return open_directives;
+
+  MutexLockGuard guard(lock_);
+  statistics_.n_open_direct++;
+  return open_directives;
+}
+
 void PageCacheTracker::Close(uint64_t inode) {
   if (!is_active_)
     return;

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -742,6 +742,96 @@ class NentryTracker {
   pthread_t thread_cleaner_;
 };  // class NentryTracker
 
+/**
+ * Tracks the content hash associated to inodes of regular files whose content
+ * may be in the page cache. It is used in cvmfs_open() and cvmfs_close().
+ */
+class PageCacheTracker {
+ private:
+  struct Entry {
+    Entry() : nopen(0) {}
+    Entry(int32_t n, const shash::Any &h) : nopen(n), hash(h) {}
+    /**
+     * Reference counter for currently open files with a given inode. If the
+     * sign bit is set, the entry is in the transition phase from one hash to
+     * another. The sign will be cleared on Close() in this case.
+     */
+    int32_t nopen;
+    /**
+     * The content hash of the data stored in the page cache. For chunked files,
+     * hash contains an artificial hash over all the chunk hash values.
+     */
+    shash::Any hash;
+  };
+
+ public:
+  /**
+   * Instruct cvmfs_open() on how to handle the page cache.
+   */
+  struct OpenDirectives {
+    /**
+     * Flush the page cache; logically, the flush takes place some time between
+     * cvmfs_open() and cvmfs_close().  That's important in case we have two
+     * open() calls on stale page cache data.
+     */
+    bool keep_cache;
+    /**
+     * Don't use the page cache at all (neither write nor read). If this is set
+     * on cvmfs_open(), don't call Close() on cvmfs_close().
+     * Direct I/O prevents shared mmap on the file. Private mmap, however,
+     * which includes loading binaries, still works.
+     */
+    bool direct_io;
+
+    // Defaults to the old (pre v2.10) behavior: always flush the cache, never
+    // use direct I/O.
+    OpenDirectives() : keep_cache(false), direct_io(false) {}
+  };
+
+  // Cannot be moved to the statistics manager because it has to survive
+  // reloads.  Added manually in the fuse module initialization and in talk.cc.
+  struct Statistics {
+    Statistics() : ninsert(0), nremove(0) {}
+    uint64_t ninsert;
+    uint64_t nremove;
+  };
+  Statistics GetStatistics() { return statistics_; }
+
+  explicit PageCacheTracker(bool is_active);
+  explicit PageCacheTracker(const PageCacheTracker &other);
+  PageCacheTracker &operator= (const PageCacheTracker &other);
+  ~PageCacheTracker();
+
+  OpenDirectives Open(std::uint64_t inode, const shash::Any &hash);
+  void Close(std::uint64_t inode);
+
+ private:
+  static const unsigned kVersion = 0;
+
+  void CopyFrom(const PageCacheTracker &other);
+
+  void InitLock();
+  inline void Lock() const {
+    int retval = pthread_mutex_lock(lock_);
+    assert(retval == 0);
+  }
+  inline void Unlock() const {
+    int retval = pthread_mutex_unlock(lock_);
+    assert(retval == 0);
+  }
+
+  pthread_mutex_t *lock_;
+  unsigned version_;
+  /**
+   * The page cache tracker only works correctly if it is used from the start
+   * of the mount. If the instance is hot-patched from a previous version, the
+   * page cache tracker remains turned off.
+   */
+  bool is_active_;
+  Statistics statistics_;
+  SmallHashDynamic<uint64_t, Entry> map_;
+};
+
 
 }  // namespace glue
 

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -802,8 +802,9 @@ class PageCacheTracker {
   PageCacheTracker &operator= (const PageCacheTracker &other);
   ~PageCacheTracker();
 
-  OpenDirectives Open(std::uint64_t inode, const shash::Any &hash);
-  void Close(std::uint64_t inode);
+  OpenDirectives Open(uint64_t inode, const shash::Any &hash);
+  void Close(uint64_t inode);
+  void Evict(uint64_t inode);
 
  private:
   static const unsigned kVersion = 0;

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -811,6 +811,8 @@ class PageCacheTracker {
     // Defaults to the old (pre v2.10) behavior: always flush the cache, never
     // use direct I/O.
     OpenDirectives() : keep_cache(false), direct_io(false) {}
+
+    OpenDirectives(bool k, bool d) : keep_cache(k), direct_io(d) {}
   };
 
   /**
@@ -853,6 +855,11 @@ class PageCacheTracker {
   ~PageCacheTracker();
 
   OpenDirectives Open(uint64_t inode, const shash::Any &hash);
+  /**
+   * Forced direct I/O open. Used when the corresponding flag is set in the
+   * file catalogs. In this case, we don't need to track the inode.
+   */
+  OpenDirectives OpenDirect() { return OpenDirectives(true, true); }
   void Close(uint64_t inode);
 
   EvictRaii GetEvictRaii() { return EvictRaii(this); }

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -799,9 +799,18 @@ class PageCacheTracker {
   // Cannot be moved to the statistics manager because it has to survive
   // reloads.  Added manually in the fuse module initialization and in talk.cc.
   struct Statistics {
-    Statistics() : n_insert(0), n_remove(0) {}
+    Statistics()
+      : n_insert(0)
+      , n_remove(0)
+      , n_open_direct(0)
+      , n_open_flush(0)
+      , n_open_cached(0)
+    {}
     uint64_t n_insert;
     uint64_t n_remove;
+    uint64_t n_open_direct;
+    uint64_t n_open_flush;
+    uint64_t n_open_cached;
   };
   Statistics GetStatistics() { return statistics_; }
 

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -859,7 +859,7 @@ class PageCacheTracker {
    * Forced direct I/O open. Used when the corresponding flag is set in the
    * file catalogs. In this case, we don't need to track the inode.
    */
-  OpenDirectives OpenDirect() { return OpenDirectives(true, true); }
+  OpenDirectives OpenDirect();
   void Close(uint64_t inode);
 
   EvictRaii GetEvictRaii() { return EvictRaii(this); }

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -797,7 +797,7 @@ class PageCacheTracker {
   };
   Statistics GetStatistics() { return statistics_; }
 
-  explicit PageCacheTracker(bool is_active);
+  PageCacheTracker();
   explicit PageCacheTracker(const PageCacheTracker &other);
   PageCacheTracker &operator= (const PageCacheTracker &other);
   ~PageCacheTracker();
@@ -806,20 +806,15 @@ class PageCacheTracker {
   void Close(uint64_t inode);
   void Evict(uint64_t inode);
 
+  // Used in RestoreState to prevent using the page cache tracker from a
+  // previous version after hotpatch
+  void Disable() { is_active_ = false; }
+
  private:
   static const unsigned kVersion = 0;
 
-  void CopyFrom(const PageCacheTracker &other);
-
   void InitLock();
-  inline void Lock() const {
-    int retval = pthread_mutex_lock(lock_);
-    assert(retval == 0);
-  }
-  inline void Unlock() const {
-    int retval = pthread_mutex_unlock(lock_);
-    assert(retval == 0);
-  }
+  void CopyFrom(const PageCacheTracker &other);
 
   pthread_mutex_t *lock_;
   unsigned version_;

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -102,7 +102,8 @@ enum StateId {
   kStateOpenChunksV3,       // >= 2.2.0
   kStateOpenChunksV4,       // >= 2.2.3
   kStateOpenFiles,          // >= 2.4
-  kStateNentryTracker       // >= 2.7
+  kStateNentryTracker,      // >= 2.7
+  kStatePageCacheTracker    // >= 2.10
 
   // Note: kStateOpenFilesXXX was renamed to kStateOpenChunksXXX as of 2.4
 };

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1442,6 +1442,11 @@ void MountPoint::CreateStatistics() {
                         "overall number of evicted negative cache entries");
   statistics_->Register("nentry_tracker.n_prune",
                         "overall number of prune calls");
+
+  statistics_->Register("page_cache_tracker.n_insert",
+                        "overall number of added page cache entries");
+  statistics_->Register("page_cache_tracker.n_remove",
+                        "overall number of evicted page cache entries");
 }
 
 
@@ -1474,6 +1479,7 @@ void MountPoint::CreateTables() {
 
   inode_tracker_ = new glue::InodeTracker();
   nentry_tracker_ = new glue::NentryTracker();
+  page_cache_tracker_ = new glue::PageCacheTracker();
 }
 
 /**
@@ -1673,6 +1679,7 @@ MountPoint::MountPoint(
   , tracer_(NULL)
   , inode_tracker_(NULL)
   , nentry_tracker_(NULL)
+  , page_cache_tracker_(NULL)
   , resolv_conf_watcher_(NULL)
   , max_ttl_sec_(kDefaultMaxTtlSec)
   , kcache_timeout_sec_(static_cast<double>(kDefaultKCacheTtlSec))
@@ -1691,6 +1698,7 @@ MountPoint::MountPoint(
 MountPoint::~MountPoint() {
   pthread_mutex_destroy(&lock_max_ttl_);
 
+  delete page_cache_tracker_;
   delete nentry_tracker_;
   delete inode_tracker_;
   delete tracer_;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1447,6 +1447,12 @@ void MountPoint::CreateStatistics() {
                         "overall number of added page cache entries");
   statistics_->Register("page_cache_tracker.n_remove",
                         "overall number of evicted page cache entries");
+  statistics_->Register("page_cache_tracker.n_open_direct",
+                        "overall number of direct I/O open calls");
+  statistics_->Register("page_cache_tracker.n_open_flush",
+    "overall number of open calls where the file's page cache gets flushed");
+  statistics_->Register("page_cache_tracker.n_open_cached",
+    "overall number of open calls where the file's page cache is reused");
 }
 
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1480,6 +1480,8 @@ void MountPoint::CreateTables() {
   inode_tracker_ = new glue::InodeTracker();
   nentry_tracker_ = new glue::NentryTracker();
   page_cache_tracker_ = new glue::PageCacheTracker();
+  if (file_system_->IsNfsSource())
+    page_cache_tracker_->Disable();
 }
 
 /**

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -44,6 +44,7 @@ class DownloadManager;
 namespace glue {
 class InodeTracker;
 class NentryTracker;
+class PageCacheTracker;
 }
 namespace lru {
 class InodeCache;
@@ -452,6 +453,7 @@ class MountPoint : SingleCopy, public BootFactory {
   lru::Md5PathCache *md5path_cache() { return md5path_cache_; }
   std::string membership_req() { return membership_req_; }
   glue::NentryTracker *nentry_tracker() { return nentry_tracker_; }
+  glue::PageCacheTracker *page_cache_tracker() { return page_cache_tracker_; }
   lru::PathCache *path_cache() { return path_cache_; }
   std::string repository_tag() { return repository_tag_; }
   SimpleChunkTables *simple_chunk_tables() { return simple_chunk_tables_; }
@@ -565,6 +567,7 @@ class MountPoint : SingleCopy, public BootFactory {
   Tracer *tracer_;
   glue::InodeTracker *inode_tracker_;
   glue::NentryTracker *nentry_tracker_;
+  glue::PageCacheTracker *page_cache_tracker_;
   MagicXattrManager *magic_xattr_mgr_;
 
   file_watcher::FileWatcher* resolv_conf_watcher_;

--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -92,7 +92,7 @@ class SmallHashBase {
     size_ += !overwritten;  // size + 1 if the key was not yet in the map
   }
 
-  void Erase(const Key &key) {
+  bool Erase(const Key &key) {
     uint32_t bucket;
     uint32_t collisions;
     const bool found = DoLookup(key, &bucket, &collisions);
@@ -108,6 +108,7 @@ class SmallHashBase {
       }
       static_cast<Derived *>(this)->Shrink();  // No-op if fixed-size
     }
+    return found;
   }
 
   void Clear() {

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -525,6 +525,8 @@ void *TalkManager::MainResponder(void *data) {
         mount_point->inode_tracker()->GetStatistics();
       glue::NentryTracker::Statistics nentry_stats =
         mount_point->nentry_tracker()->GetStatistics();
+      glue::PageCacheTracker::Statistics page_cache_stats =
+        mount_point->page_cache_tracker()->GetStatistics();
       mount_point->statistics()->Lookup("inode_tracker.n_insert")->Set(
         atomic_read64(&inode_stats.num_inserts));
       mount_point->statistics()->Lookup("inode_tracker.n_remove")->Set(
@@ -543,6 +545,10 @@ void *TalkManager::MainResponder(void *data) {
         nentry_stats.num_remove);
       mount_point->statistics()->Lookup("nentry_tracker.n_prune")->Set(
         nentry_stats.num_prune);
+      mount_point->statistics()->Lookup("page_cache_tracker.n_insert")->Set(
+        page_cache_stats.n_insert);
+      mount_point->statistics()->Lookup("page_cache_tracker.n_remove")->Set(
+        page_cache_stats.n_remove);
 
       if (file_system->cache_mgr()->id() == kPosixCacheManager) {
         PosixCacheManager *cache_mgr =

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -549,6 +549,12 @@ void *TalkManager::MainResponder(void *data) {
         page_cache_stats.n_insert);
       mount_point->statistics()->Lookup("page_cache_tracker.n_remove")->Set(
         page_cache_stats.n_remove);
+      mount_point->statistics()->Lookup("page_cache_tracker.n_open_direct")->
+        Set(page_cache_stats.n_open_direct);
+      mount_point->statistics()->Lookup("page_cache_tracker.n_open_flush")->
+        Set(page_cache_stats.n_open_flush);
+      mount_point->statistics()->Lookup("page_cache_tracker.n_open_cached")->
+        Set(page_cache_stats.n_open_cached);
 
       if (file_system->cache_mgr()->id() == kPosixCacheManager) {
         PosixCacheManager *cache_mgr =

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -25,6 +25,22 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 double DiffTimeSeconds(struct timeval start, struct timeval end);
 
+// Bitfield manipulation for different integer types T
+template <typename T>
+inline void SetBit(unsigned int bit, T *field) {
+  *field |= static_cast<T>(1) << bit;
+}
+
+template <typename T>
+inline void ClearBit(unsigned int bit, T *field) {
+  *field &= ~(static_cast<T>(1) << bit);
+}
+
+template <typename T>
+inline bool TestBit(unsigned int bit, const T field) {
+  return field & (static_cast<T>(1) << bit);
+}
+
 
 /**
  * Knuth's random shuffle algorithm.

--- a/test/src/633-changedfiles/main
+++ b/test/src/633-changedfiles/main
@@ -22,6 +22,16 @@ private_unmount() {
   TEST633_PRIVATE_MOUNT=
 }
 
+get_internal_counter() {
+  local name="$1"
+
+  sudo cvmfs_talk -p \
+    ${TEST633_PRIVATE_MOUNT}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO \
+    internal affairs | \
+    grep ^$name | \
+    cut -d \| -f2
+}
+
 cleanup() {
   echo "running cleanup()..."
   if [ "x$TEST633_TAIL_SMALL" != "x" ]; then
@@ -63,17 +73,6 @@ cvmfs_run_test() {
      | awk '{print $1}')                                          || return 3
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
-  local directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
-  echo "*** directio: $directio"
-  [ "x$directio" = "x0" ]                 || return 70
-  start_transaction $CVMFS_TEST_REPO      || return $?
-  touch /cvmfs/$CVMFS_TEST_REPO/dir/small || return 71
-  touch /cvmfs/$CVMFS_TEST_REPO/dir/large || return 71
-  publish_repo $CVMFS_TEST_REPO -d        || return 72
-  directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
-  echo "*** directio: $directio"
-  [ "x$directio" = "x1" ]                 || return 73
-
   local mntpnt="${scratch_dir}/private_mnt"
   echo "*** mount private mount point"
   private_mount $mntpnt || return 20
@@ -85,36 +84,103 @@ cvmfs_run_test() {
   local no_chunks=$(get_xattr chunks ${mntpnt}/dir/large) || return 21
   [ $no_chunks -gt 1 ] || return 22
 
+  echo "*** regular file opens (cached)"
+  cat ${mntpnt}/dir/small > /dev/null
+  cat ${mntpnt}/dir/large > /dev/null
+  cat ${mntpnt}/dir/small > /dev/null
+  cat ${mntpnt}/dir/large > /dev/null
+
+  echo "*** check that those first opens were cached"
+  local ncached=$(get_internal_counter page_cache_tracker.n_open_cached)
+  echo "*** number of cached opens: $ncached"
+  [ $ncached -eq 4 ] || return 81
+
+  echo "*** add contents to files in repository (1st change)"
+  ls -lisa ${mntpnt}/dir/*
+  start_transaction $CVMFS_TEST_REPO                      || return $?
+  echo "1st change" >> /cvmfs/$CVMFS_TEST_REPO/dir/small  || return 85
+  echo "1st change" >> /cvmfs/$CVMFS_TEST_REPO/dir/large  || return 86
+  publish_repo $CVMFS_TEST_REPO -v                        || return $?
+  ls -lisa /cvmfs/$CVMFS_TEST_REPO/dir/*
+
+  echo "*** remount private mount point"
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 87
+  local revision_2nd=$(get_xattr revision ${mntpnt}) || return 88
+  echo "revision is now $revision_2nd"
+  [ $revision_2nd -gt $revision_old ] || return 89
+
+  echo "*** new open()s should flush the cache, the reuse it"
+  cat ${mntpnt}/dir/small > /dev/null
+  cat ${mntpnt}/dir/large > /dev/null
+  cat ${mntpnt}/dir/small > /dev/null
+  cat ${mntpnt}/dir/large > /dev/null
+  nflush=$(get_internal_counter page_cache_tracker.n_open_flush)
+  ncached=$(get_internal_counter page_cache_tracker.n_open_cached)
+  echo "*** number of flushed opens: $nflush"
+  echo "*** number of cached opens: $ncached"
+  [ $nflush -eq 2 ]  || return 91
+  [ $ncached -eq 6 ] || return 90
+
   echo "*** open file descriptors"
   tail -f ${mntpnt}/dir/small > tail_small.log &
   TEST633_TAIL_SMALL=$!
   tail -f ${mntpnt}/dir/large > tail_large.log &
   TEST633_TAIL_LARGE=$!
 
-  echo "*** add contents to files in repository"
+  echo "*** add contents to files in repository (2nd change)"
   ls -lisa ${mntpnt}/dir/*
-  start_transaction $CVMFS_TEST_REPO                    || return $?
-  echo "modified" >> /cvmfs/$CVMFS_TEST_REPO/dir/small  || return 30
-  echo "modified" >> /cvmfs/$CVMFS_TEST_REPO/dir/large  || return 30
-  publish_repo $CVMFS_TEST_REPO -v                      || return $?
+  start_transaction $CVMFS_TEST_REPO                      || return $?
+  echo "2nd change" >> /cvmfs/$CVMFS_TEST_REPO/dir/small  || return 30
+  echo "2nd change" >> /cvmfs/$CVMFS_TEST_REPO/dir/large  || return 30
+  publish_repo $CVMFS_TEST_REPO -v                        || return $?
   ls -lisa /cvmfs/$CVMFS_TEST_REPO/dir/*
 
   echo "*** remount private mount point"
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 40
-  local revision_new=$(get_xattr revision ${mntpnt}) || return 41
-  echo "revision is now $revision_new"
-  [ $revision_new -gt $revision_old ] || return 42
+  local revision_3rd=$(get_xattr revision ${mntpnt}) || return 41
+  echo "revision is now $revision_3rd"
+  [ $revision_3rd -gt $revision_2nd ] || return 42
 
   echo "*** verify new content"
   ls -lisa ${mntpnt}/dir/*
-  [ "x$(tail -n 1 ${mntpnt}/dir/small)" = "xmodified" ] || return 50
-  [ "x$(tail -n 1 ${mntpnt}/dir/large)" = "xmodified" ] || return 51
+  [ "x$(tail -n 1 ${mntpnt}/dir/small)" = "x2nd change" ] || return 50
+  [ "x$(tail -n 1 ${mntpnt}/dir/large)" = "x2nd change" ] || return 51
+
+  echo "*** check that these files where opened in direct I/O mode"
+  local ndirect=$(get_internal_counter page_cache_tracker.n_open_direct)
+  echo "*** number of direct i/o opens: $ndirect"
+  [ $ndirect -eq 2 ]  || return 52
 
   echo "*** verify that our open tail processes did acutally run"
   /bin/kill -TERM $TEST633_TAIL_SMALL || return 60
   TEST633_TAIL_SMALL=
   /bin/kill -TERM $TEST633_TAIL_LARGE || return 61
   TEST633_TAIL_LARGE=
+
+  echo "*** Forced direct I/O"
+
+  local directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
+  echo "*** directio: $directio"
+  [ "x$directio" = "x0" ]                 || return 70
+  start_transaction $CVMFS_TEST_REPO      || return $?
+  touch /cvmfs/$CVMFS_TEST_REPO/dir/small || return 71
+  touch /cvmfs/$CVMFS_TEST_REPO/dir/large || return 71
+  publish_repo $CVMFS_TEST_REPO -d        || return 72
+  directio=$(get_xattr direct_io /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly/dir/small)
+  echo "*** directio: $directio"
+  [ "x$directio" = "x1" ]                 || return 73
+
+  echo "*** remount private mount point"
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 74
+  local revision_4th=$(get_xattr revision ${mntpnt}) || return 75
+  echo "revision is now $revision_4th"
+  [ $revision_4th -gt $revision_3rd ] || return 76
+
+  cat ${mntpnt}/dir/small > /dev/null
+  cat ${mntpnt}/dir/large > /dev/null
+  ndirect=$(get_internal_counter page_cache_tracker.n_open_direct)
+  echo "*** number of direct i/o opens: $ndirect"
+  [ $ndirect -eq 4 ]  || return 77
 
   return 0
 }

--- a/test/unittests/t_glue_buffer.cc
+++ b/test/unittests/t_glue_buffer.cc
@@ -206,7 +206,7 @@ TEST_F(T_GlueBuffer, PageCacheTrackerOff) {
   EXPECT_EQ(false, directives.direct_io);
   // Don't crash on unknown inode
   tracker.Close(2);
-  tracker.Evict(3);
+  tracker.GetEvictRaii().Evict(3);
 }
 
 TEST_F(T_GlueBuffer, PageCacheTrackerBasics) {
@@ -252,7 +252,7 @@ TEST_F(T_GlueBuffer, PageCacheTrackerBasics) {
   tracker.Close(1);
   tracker.Close(1);
 
-  tracker.Evict(1);
+  tracker.GetEvictRaii().Evict(1);
   directives = tracker.Open(1, hashA);
   EXPECT_EQ(true, directives.keep_cache);
   EXPECT_EQ(false, directives.direct_io);

--- a/test/unittests/t_glue_buffer.cc
+++ b/test/unittests/t_glue_buffer.cc
@@ -198,17 +198,19 @@ TEST_F(T_GlueBuffer, StringHeap) {
 }
 
 TEST_F(T_GlueBuffer, PageCacheTrackerOff) {
-  PageCacheTracker tracker(false);
+  PageCacheTracker tracker;
+  tracker.Disable();
   PageCacheTracker::OpenDirectives directives;
   directives = tracker.Open(1, shash::Any());
   EXPECT_EQ(false, directives.keep_cache);
   EXPECT_EQ(false, directives.direct_io);
   // Don't crash on unknown inode
   tracker.Close(2);
+  tracker.Evict(3);
 }
 
 TEST_F(T_GlueBuffer, PageCacheTrackerBasics) {
-  PageCacheTracker tracker(true);
+  PageCacheTracker tracker;
   PageCacheTracker::OpenDirectives directives;
 
   shash::Any hashA(shash::kShake128);

--- a/test/unittests/t_glue_buffer.cc
+++ b/test/unittests/t_glue_buffer.cc
@@ -227,7 +227,7 @@ TEST_F(T_GlueBuffer, PageCacheTrackerBasics) {
   EXPECT_EQ(false, directives.direct_io);
 
   directives = tracker.Open(1, hashB);
-  EXPECT_EQ(false, directives.keep_cache);
+  EXPECT_EQ(true, directives.keep_cache);
   EXPECT_EQ(true, directives.direct_io);
 
   EXPECT_DEATH(tracker.Close(2), ".*");

--- a/test/unittests/t_glue_buffer.cc
+++ b/test/unittests/t_glue_buffer.cc
@@ -249,6 +249,11 @@ TEST_F(T_GlueBuffer, PageCacheTrackerBasics) {
 
   tracker.Close(1);
   tracker.Close(1);
+
+  tracker.Evict(1);
+  directives = tracker.Open(1, hashA);
+  EXPECT_EQ(true, directives.keep_cache);
+  EXPECT_EQ(false, directives.direct_io);
 }
 
 

--- a/test/unittests/t_smallhash.cc
+++ b/test/unittests/t_smallhash.cc
@@ -147,9 +147,12 @@ TEST_F(T_Smallhash, EraseUnknown) {
   for (unsigned i = 0; i < N; ++i) {
     smallhash_.Insert(i, i);
   }
-  smallhash_.Erase(N+1);
+  EXPECT_FALSE(smallhash_.Erase(N+1));
 
   EXPECT_EQ(N, smallhash_.size());
+
+  EXPECT_TRUE(smallhash_.Erase(0));
+  EXPECT_EQ(N - 1, smallhash_.size());
 }
 
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -2017,6 +2017,35 @@ TEST_F(T_Util, DiffTree) {
   EXPECT_FALSE(DiffTree(".", "/"));
 }
 
+TEST_F(T_Util, Bitfields) {
+  int field = 0;
+
+  SetBit(0, &field);
+  EXPECT_EQ(1, field);
+  EXPECT_TRUE(TestBit(0, field));
+  ClearBit(0, &field);
+  EXPECT_EQ(0, field);
+  EXPECT_FALSE(TestBit(0, field));
+
+  SetBit(1, &field);
+  SetBit(2, &field);
+  EXPECT_EQ(6, field);
+  EXPECT_TRUE(TestBit(2, field));
+  EXPECT_FALSE(TestBit(3, field));
+  ClearBit(3, &field);
+  EXPECT_EQ(6, field);
+  ClearBit(1, &field);
+  EXPECT_EQ(4, field);
+
+  int64_t long_field = 0;
+  SetBit(63, &long_field);
+  EXPECT_LT(long_field, static_cast<int64_t>(0));
+  EXPECT_TRUE(TestBit(63, long_field));
+  EXPECT_FALSE(TestBit(62, long_field));
+  ClearBit(63, &long_field);
+  EXPECT_EQ(0, long_field);
+}
+
 TEST(Log2Histogram, 2BinEmpty) {
   Log2Histogram log2hist(2);
   log2hist.Add(10);


### PR DESCRIPTION
Adds a new page cache tracker to the data structures that track the state of the kernel caches. The page cache tracker is only used if the mount point is not in NFS mode and if it is not hotpatched from a previous version without one.

The page cache tracker remembers the content hash of the data that are in the page cache for a given inode. This allows us to make an informed decision on whether or not to flush the page cache and when to use direct I/O (if the inode has open files with a different content hash). The page cache tracker evicts entries if the corresponding inode receives a fuse FORGET message.  Still to be verified if the FORGET message is coupled to the page cache (and not just to the dentry cache).

- [x] Add counters for total number of files opened with cache (1), without cache (2), with direct i/o (3)
- [x] Add integration test
- [x] Confirm that removing from the tracker on FORGET is [correct](https://sourceforge.net/p/fuse/mailman/message/37642687/)
- [x] Respect "direct i/o" flag in the file catalogs
- [x] Possibly: take only single lock on inode tracker and page cache tracker in FORGET_MULTI

Fixes #2879 