### PR TITLE
Adding support for image registry proxies

### DIFF
--- a/ducc/cmd/root.go
+++ b/ducc/cmd/root.go
@@ -24,6 +24,7 @@ var rootCmd = &cobra.Command{
 	Short: "Show the several commands available.",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		lib.SetupNotification()
+		lib.SetupRegistries()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/ducc/docker-api/util.go
+++ b/ducc/docker-api/util.go
@@ -27,6 +27,23 @@ type Manifest struct {
 	Layers        []Layer
 }
 
+type ManifestList struct {
+	SchemaVersion int
+	MediaType     string
+	Manifests     []ManifestListItem
+}
+
+type ManifestListItem struct {
+	MediaType string
+	Size      int
+	Digest    string
+	Platform  struct {
+		Architecture string
+		OS           string
+		Variant      *string
+	}
+}
+
 type ThinImageLayer struct {
 	Digest string `json:"digest"`
 	Url    string `json:"url,omitempty"`

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -318,11 +318,11 @@ func convertInputOutput(inputImage *Image, repo string, convertAgain, forceDownl
 	}
 	manifestPath := filepath.Join("/", "cvmfs", repo, ".metadata", inputImage.GetSimpleName(), "manifest.json")
 	alreadyConverted := AlreadyConverted(manifestPath, manifest.Config.Digest)
-	l.Log().WithFields(log.Fields{"alreadyConverted": alreadyConverted}).Info(
-		"Already converted the image, skipping.")
 
 	if alreadyConverted == ConversionMatch {
-		if convertAgain == false {
+		if !convertAgain {
+			l.Log().WithFields(log.Fields{"alreadyConverted": alreadyConverted}).Info(
+				"Already converted the image, skipping.")
 			return nil
 		}
 	}

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -59,7 +59,7 @@ type RegistryConfig struct {
 
 var inputRegistries []RegistryConfig
 
-func init() {
+func SetupRegistries() {
 	regs := os.Getenv("DUCC_AUTH_REGISTRIES")
 	for _, r := range strings.Split(regs, ",") {
 		if r == "" {

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -502,13 +502,9 @@ func firstRequestForAuth_internal(url, user, pass string) (token string, err err
 	}
 	if resp.StatusCode != 401 {
 		log.WithFields(log.Fields{
+			"url": url,
 			"status code": resp.StatusCode,
-		}).Info("Expected status code 401, print body anyway.")
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			l.LogE(err).Error("Error in reading the first http response")
-		}
-		fmt.Println(string(body))
+		}).Info("Expected status code 401.")
 		return "", err
 	}
 	WwwAuthenticate := resp.Header["Www-Authenticate"][0]
@@ -534,7 +530,7 @@ func firstRequestForAuth_internal(url, user, pass string) (token string, err err
 }
 
 func getLayerUrl(img *Image, layerDigest string) string {
-	return fmt.Sprintf("%s/blobs/%s", img.baseUrl(), layerDigest)
+	return fmt.Sprintf("%sblobs/%s", img.baseUrl(), layerDigest)
 }
 
 type downloadedLayer struct {

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -75,8 +75,9 @@ func SetupRegistries() {
 		pass := os.Getenv(uPass)
 		proxy := os.Getenv(proxyEnv)
 
-		if user == "" || pass == "" || ident == "" {
-			log.Fatalf("missing either $%s, $%s or $%s for %s", uEnv, uPass, iEnv, r)
+		if ident == "" || ((user == "" || pass == "") && proxy == "") {
+			log.Fatalf("missing either $%s, ($%s or $%s) or %s for %s",
+			           iEnv, uEnv, uPass, proxyEnv, r)
 		}
 
 		inputRegistries = append(inputRegistries, RegistryConfig{


### PR DESCRIPTION
Set `DUCC_<REGISTRY_NAME>_PROXY` for an input registry to direct all download requests to this proxy address.