### PR TITLE
commitprocessor performance: remove ShortString counters

### DIFF
--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -506,20 +506,6 @@ void *TalkManager::MainResponder(void *data) {
 
       result += "Inode Generation:\n  " + cvmfs::PrintInodeGeneration();
 
-      // Manually setting the values of the ShortString counters
-      mount_point->statistics()->Lookup("pathstring.n_instances")->
-          Set(PathString::num_instances());
-      mount_point->statistics()->Lookup("pathstring.n_overflows")->
-          Set(PathString::num_overflows());
-      mount_point->statistics()->Lookup("namestring.n_instances")->
-          Set(NameString::num_instances());
-      mount_point->statistics()->Lookup("namestring.n_overflows")->
-          Set(NameString::num_overflows());
-      mount_point->statistics()->Lookup("linkstring.n_instances")->
-          Set(LinkString::num_instances());
-      mount_point->statistics()->Lookup("linkstring.n_overflows")->
-          Set(LinkString::num_overflows());
-
       // Manually setting the inode tracker numbers
       glue::InodeTracker::Statistics inode_stats =
         mount_point->inode_tracker()->GetStatistics();


### PR DESCRIPTION
In profiling the commit processor critical path, we observed that a substantial amount of time in `AbstractCatalogManager::MountSubtree`->`ShortString::ShortString`.  Approx half of the time spent in this constructor is in the atomic_inc64() of `num_instances_`.

In our environment, we don't use the `num_instances` or `num_overflows` statistics for `ShortString` derived objects, so this PR removes them.

It might, perhaps, be more elegant to make these counters configurable, so they can be disabled only where required.

```
12.68% 0.76% cvmfs_receiver cvmfs_receiver
11.93% catalog::AbstractCatalogManager<catalog: : Catalog>: :MountSubtree
- 6.31% ShortString<(unsigned char)200, (char)0>::ShortString 2.53% ShortString<(unsigned char) 200, (char)0>:: Assign 2.44% atomic_inc64
0.59% ShortString<(unsigned char)200, (char)0>::GetLength
2.64% ShortString<(unsigned char) 200, (char)0>:: Append
1.11% ShortString<(unsigned char)200, (char)0>::GetLength
1.01% ShortString<(unsigned char)200, (char)0>:: StartsWith
+0.76% libc_start_main
[.] catalog::AbstractCatalogManager<catalog::Catalog>:: MountSubtree
```