### PR TITLE
commitprocessor performance: truncate instead of re-initializing PathString in DiffRec

### DIFF
--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -106,6 +106,15 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
   sort(old_listing.begin(), old_listing.end(), IsSmaller);
   AppendLastEntry(&old_listing);
 
+  // create these paths here so it can be "reused" in the loop without
+  // re-initializing every time, this should save time in doing memcpy
+  // especially when the path gets longer
+  PathString old_path(path);
+  old_path.Append("/", 1);
+  PathString new_path(path);
+  new_path.Append("/", 1);
+  unsigned char length_after_truncate = old_path.GetLength();
+
   catalog::DirectoryEntryList new_listing;
   AppendFirstEntry(&new_listing);
   new_catalog_mgr_->Listing(path, &new_listing);
@@ -135,11 +144,9 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString& path) {
     while (old_entry.IsHidden()) old_entry = old_listing[++i_from];
     while (new_entry.IsHidden()) new_entry = new_listing[++i_to];
 
-    PathString old_path(path);
-    old_path.Append("/", 1);
+    old_path.Truncate(length_after_truncate);
     old_path.Append(old_entry.name().GetChars(), old_entry.name().GetLength());
-    PathString new_path(path);
-    new_path.Append("/", 1);
+    new_path.Truncate(length_after_truncate);
     new_path.Append(new_entry.name().GetChars(), new_entry.name().GetLength());
 
     XattrList xattrs;

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -87,6 +87,15 @@ class ShortString {
     this->length_ = new_length;
   }
 
+  void Truncate(unsigned char new_length) {
+    assert(new_length <= this->GetLength());
+    if (long_string_) {
+      long_string_->erase(new_length);
+      return;
+    }
+    this->length_ = new_length;
+  }
+
   void Clear() {
     delete long_string_;
     long_string_ = NULL;


### PR DESCRIPTION
The DiffRec function is the main function to compare the new and old catalogs. Inside this function, it compares the old and new entry and create PathStrings in each iteration of the loop. This is quite inefficient because each time it does a memcpy (ShortString::Assign) to initialize old_path and new_path from path. This gets worse as you traverse down the directory tree because the path gets longer.

This PR adds a Truncate function to ShortString which allows us to simply reduce the length of old_path and new_path and append the entry name, instead of re-initializing it from path.























































