### PR TITLE
commitprocessor performance: Increase kDefaultMaxName,kDefaultMaxLink

### DIFF
--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -19,8 +19,8 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-const unsigned char kDefaultMaxName = 25;
-const unsigned char kDefaultMaxLink = 25;
+const unsigned char kDefaultMaxName = 80;
+const unsigned char kDefaultMaxLink = 80;
 const unsigned char kDefaultMaxPath = 200;
 
 template<unsigned char StackSize, char Type>


### PR DESCRIPTION
In our environment, filesnames are consistently longer than 25 characters. Perf shows a fair bit of time spent in malloc because the ShortString on the stack is not big enough.  This PR increases the default lengths.