### PR TITLE
cvmfs_server: tolerate a 500 from S3

### DIFF
--- a/cvmfs/s3fanout.cc
+++ b/cvmfs/s3fanout.cc
@@ -97,6 +97,7 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
           return num_bytes;
         case 503:
         case 502:  // Can happen if the S3 gateway-backend connection breaks
+        case 500:  // sometimes see this as a transient error from S3
           info->error_code = kFailServiceUnavailable;
           break;
         case 501:


### PR DESCRIPTION
Very rarely, S3 returns a 500 error. Tolerate this and treat it as a 503, 502.

