### PR TITLE
unconditionally compress catalogs irrespective of `CVMFS_COMPRESSION_ALGORITHM` setting

### DIFF
--- a/cvmfs/ingestion/pipeline.cc
+++ b/cvmfs/ingestion/pipeline.cc
@@ -121,12 +121,19 @@ void IngestionPipeline::Process(
   bool allow_chunking,
   shash::Suffix hash_suffix)
 {
+  // always enable compression for anything that has a suffix
+  // (i.e. catalogs, certificates, histories)
+  zlib::Algorithms compression_algorithm = compression_algorithm_;
+  if (hash_suffix != shash::kSuffixNone) {
+      compression_algorithm = zlib::kZlibDefault;
+  }
+
   FileItem *file_item = new FileItem(
     source,
     minimal_chunk_size_,
     average_chunk_size_,
     maximal_chunk_size_,
-    compression_algorithm_,
+    compression_algorithm,
     hash_algorithm_,
     hash_suffix,
     allow_chunking && chunking_enabled_,


### PR DESCRIPTION
If the publisher has `CVMFS_COMPRESSION_ALGORITHM=none`  then it will upload catalog objects in uncompressed form. But the cvmfs client always expects these to be compressed, irrespective of any `CVMFS_COMPRESSION_ALGORITHM` setting it may have. 
The PR causes the publisher to unconditionally compress catalog objects irrespective of `CVMFS_COMPRESSION_ALGORITHM`



Context: We are grafting external data which is held in uncompressed form. We have to set `CVMFS_COMPRESSION_ALGORITHM=none` so that when grafting these objects they are correctly marked as uncompressed in the catalog. This has the side-effect of then also not compressing the catalog objects.