### PR TITLE
Add performance counter `start_time` indicating the epoch time mount process was last started

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -235,6 +235,9 @@ void FileSystem::CreateStatistics() {
                   "Number of currently opened directories");
   io_error_info_.SetCounter(statistics_->Register("cvmfs.n_io_error",
                                                   "Number of I/O errors"));
+  start_time_ = statistics_->Register("cvmfs.start_time",
+                  "Epoch time that mount was started");
+  start_time_->Set( time(NULL) );
 
   string optarg;
   if (options_mgr_->GetValue("CVMFS_INSTRUMENT_FUSE", &optarg) &&

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -220,6 +220,7 @@ class FileSystem : SingleCopy, public BootFactory {
   NfsMaps *nfs_maps() { return nfs_maps_; }
   perf::Counter *no_open_dirs() { return no_open_dirs_; }
   perf::Counter *no_open_files() { return no_open_files_; }
+  perf::Counter *start_time() { return start_time_; }
   OptionsManager *options_mgr() { return options_mgr_; }
   perf::Statistics *statistics() { return statistics_; }
   Type type() { return type_; }
@@ -314,6 +315,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *no_open_files_;
   perf::Counter *no_open_dirs_;
   IoErrorInfo io_error_info_;
+  perf::Counter *start_time_;
   perf::Statistics *statistics_;
 
   Log2Histogram *hist_fs_lookup_;


### PR DESCRIPTION
This is useful to allow monitoring to determine whether the mount has restarted since last check of internal affairs counters.