### PR TITLE
Restrict access to xattrs containing secrets; configure acl with CVMFS_PRIVILEGED_XATTR_GID

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1365,7 +1365,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   MagicXattrRAIIWrapper magic_xattr(mount_point_->magic_xattr_mgr()->GetLocked(
     attr, path, &d));
   if (!magic_xattr.IsNull()) {
-    magic_xattr_success = magic_xattr->PrepareValueFenced();
+    magic_xattr_success = magic_xattr->PrepareValueFenced(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid);
   }
 
   fuse_remounter_->fence()->Leave();
@@ -1639,7 +1639,7 @@ loader::CvmfsExports *g_cvmfs_exports = NULL;
 class ExpiresMagicXattr : public BaseMagicXattr {
   time_t catalogs_valid_until_;
 
-  virtual bool PrepareValueFenced() {
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid ) {
     catalogs_valid_until_ = cvmfs::fuse_remounter_->catalogs_valid_until();
     return true;
   }

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -49,7 +49,7 @@ class BaseMagicXattr {
   * This function is used to obtain the necessary information while
   * inside FuseRemounter::fence(), which should prevent data races.
   */
-  virtual bool PrepareValueFenced() { return true; }
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid ) { return true; }
   /**
    * This function needs to be called after PrepareValueFenced(),
    * which prepares the necessary data.
@@ -158,7 +158,7 @@ class MagicXattrManager : public SingleCopy {
 };
 
 class AuthzMagicXattr : public BaseMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
   virtual MagicXattrFlavor GetXattrFlavor();
 };
@@ -167,40 +167,41 @@ class CatalogCountersMagicXattr : public BaseMagicXattr {
   std::string subcatalog_path_;
   catalog::Counters counters_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class ChunkListMagicXattr : public RegularMagicXattr {
   std::string chunk_list_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class ChunksMagicXattr : public RegularMagicXattr {
   uint64_t n_chunks_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class CompressionMagicXattr : public RegularMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class DirectIoMagicXattr : public RegularMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class ExternalFileMagicXattr : public RegularMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class ExternalHostMagicXattr : public BaseMagicXattr {
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
@@ -213,20 +214,22 @@ class FqrnMagicXattr : public BaseMagicXattr {
 };
 
 class HashMagicXattr : public WithHashMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class HostMagicXattr : public BaseMagicXattr {
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class HostListMagicXattr : public BaseMagicXattr {
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class LHashMagicXattr : public WithHashMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
@@ -250,7 +253,7 @@ class NCleanup24MagicXattr : public BaseMagicXattr {
 class NClgMagicXattr : public BaseMagicXattr {
   int n_catalogs_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
@@ -275,25 +278,26 @@ class HitrateMagicXattr : public BaseMagicXattr {
 };
 
 class ProxyMagicXattr : public BaseMagicXattr {
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class PubkeysMagicXattr : public BaseMagicXattr {
   std::string pubkeys_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class RawlinkMagicXattr : public SymlinkMagicXattr {
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class RepoCountersMagicXattr : public BaseMagicXattr {
   catalog::Counters counters_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
@@ -303,21 +307,21 @@ class RepoMetainfoMagicXattr : public BaseMagicXattr {
   shash::Any metainfo_hash_;
   std::string error_reason_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class RevisionMagicXattr : public BaseMagicXattr {
   uint64_t revision_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
 class RootHashMagicXattr : public BaseMagicXattr {
   shash::Any root_hash_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 
@@ -332,7 +336,7 @@ class SpeedMagicXattr : public BaseMagicXattr {
 class TagMagicXattr : public BaseMagicXattr {
   std::string tag_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced( uid_t uid, gid_t gid, pid_t pid );
   virtual std::string GetValue();
 };
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -443,6 +443,7 @@ class MountPoint : SingleCopy, public BootFactory {
   MagicXattrManager *magic_xattr_mgr() { return magic_xattr_mgr_; }
   bool has_membership_req() { return has_membership_req_; }
   bool enforce_acls() { return enforce_acls_; }
+  std::set<unsigned long>privileged_xattr_gid() { return privileged_xattr_gid_; }
   catalog::InodeAnnotation *inode_annotation() {
     return inode_annotation_;
   }
@@ -576,6 +577,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool enforce_acls_;
   std::string repository_tag_;
   std::vector<std::string> blacklist_paths_;
+  std::set<unsigned long>privileged_xattr_gid_;
 
   // TODO(jblomer): this should go in the catalog manager
   std::string membership_req_;


### PR DESCRIPTION
Some extended attributes may contain secrets (eg URLs containing basic auth credentials). 
This PR:
* restricts Proxy and Host extended attributes to root and other authorised groups
* Adds the configuration option CVMFS_PRIVILEGED_XATTR_GID for specifying a comma-separated list of groupnames to be allowed access to sensitive xattrs
* Extends  Xattr class's PrepareValueFenced() to allow gating of access based on uid, gid, and pid.
