### PR TITLE
Add user.external_url extended attribute

### DIFF
--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -64,6 +64,7 @@ MagicXattrManager::MagicXattrManager(MountPoint *mountpoint,
   Register("xfsroot.rawlink", new RawlinkMagicXattr());
 
   Register("user.authz", new AuthzMagicXattr());
+  Register("user.external_url", new ExternalURLMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -541,3 +542,22 @@ std::string UsedDirPMagicXattr::GetValue() {
 std::string VersionMagicXattr::GetValue() {
   return std::string(VERSION) + "." + std::string(CVMFS_PATCH_LEVEL);
 }
+
+std::string ExternalURLMagicXattr::GetValue() {
+  std::vector<std::string> host_chain;
+  std::vector<int> rtt;
+  unsigned current_host;
+  mount_point_->external_download_mgr()->GetHostInfo(
+    &host_chain, &rtt, &current_host);
+  if (host_chain.size()) {
+    return std::string(host_chain[current_host]) + std::string(path_.c_str());
+  } else {
+    return std::string("");
+  }
+}
+
+bool ExternalURLMagicXattr::PrepareValueFenced() {
+  return dirent_->IsRegular() && dirent_->IsExternalFile();
+}
+
+

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -360,4 +360,9 @@ class VersionMagicXattr : public BaseMagicXattr {
   virtual std::string GetValue();
 };
 
+class ExternalURLMagicXattr : public BaseMagicXattr {
+  virtual bool PrepareValueFenced();
+  virtual std::string GetValue();
+};
+
 #endif  // CVMFS_MAGIC_XATTR_H_


### PR DESCRIPTION
Add a new extended attribute that gives the URL of an external data object.
This is useful if there is also a direct object store access route available.