### PR TITLE
handle CURLE_SEND_ERROR

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1324,6 +1324,9 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
       // Error set by callback
       break;
     case CURLE_SEND_ERROR:
+      // The curl error CURLE_SEND_ERROR can be seen when a cache is misbehaving
+      // and closing connections before the http request send is completed.
+      // Handle this error, treating it as a short transfer error.
       info->error_code = (info->proxy == "DIRECT") ?
         kFailHostShortTransfer : kFailProxyShortTransfer;
       break;

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1323,6 +1323,10 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     case CURLE_WRITE_ERROR:
       // Error set by callback
       break;
+    case CURLE_SEND_ERROR:
+      info->error_code = (info->proxy == "DIRECT") ?
+        kFailHostShortTransfer : kFailProxyShortTransfer;
+      break;
     default:
       LogCvmfs(kLogDownload, kLogSyslogErr, "unexpected curl error (%d) while "
                "trying to fetch %s", curl_error, info->url->c_str());


### PR DESCRIPTION
The curl error CURLE_SEND_ERROR can be seen when a cache is misbehaving, and closing connections before the http request send is completed.
Handle this error, treating it as a short transfer error.
