### PR TITLE
allow switching of debug mode over hotpatch

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1054,7 +1054,14 @@ cvmfs_status() {
 _cvmfs_reload_pause() {
   # Helper function to put a particular repository in sleep mode
   local mountpoint="$1"
+ 
+  if [ "${CVMFS_DEBUGLOG:-unset}" != "unset" ]; then
+    DEBUG_FLAG="--debug"
+  else
+    DEBUG_FLAG=""
+  fi
 
+    return LoadCatalog(PathString("", 0), shash::Any(), NULL, NULL);
   cd "$mountpoint" 2>/dev/null || return
   get_attr fqrn ${mountpoint}; fqrn=$attr_value
   get_attr pid ${mountpoint}; pid=$attr_value
@@ -1066,7 +1073,7 @@ _cvmfs_reload_pause() {
   echo "Pausing ${fqrn} on ${mountpoint}"
   cd "$mountpoint" &&
     rm -f ${CVMFS_RELOAD_SOCKETS}/cvmfs.pause/$(echo -n "$mountpoint" | base64_nowrap) && \
-    cvmfs2 __RELOAD__ ${CVMFS_RELOAD_SOCKETS}/cvmfs.$fqrn stop_and_go | \
+    cvmfs2 __RELOAD__ ${CVMFS_RELOAD_SOCKETS}/cvmfs.$fqrn stop_and_go $DEBUG_FLAG | \
     awk -v PREFIX="$fqrn: " '{print PREFIX $0}' &
   cd /
   echo $pid > ${CVMFS_RELOAD_SOCKETS}/pid.cvmfs.${fqrn}.paused
@@ -1102,9 +1109,15 @@ cvmfs_reload() {
     shift
     cache_directories=$(list_cache_directories)
   elif [ "x$1" != "x" ]; then
+    if [ "${CVMFS_DEBUGLOG:-unset}" != "unset" ]; then
+      DEBUG_FLAG="--debug"
+    else
+      DEBUG_FLAG=""
+    fi
+
     org=$1
     fqrn=$(cvmfs_mkfqrn $org)
-    cvmfs2 __RELOAD__ ${CVMFS_RELOAD_SOCKETS}/cvmfs.$fqrn
+    cvmfs2 __RELOAD__ ${CVMFS_RELOAD_SOCKETS}/cvmfs.$fqrn $DEBUG_FLAG
     return $?
   fi
 

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -242,6 +242,7 @@ struct CvmfsExports {
 };
 
 Failures Reload(const int fd_progress, const bool stop_and_go);
+Failures Reload(const int fd_progress, const bool stop_and_go, const bool debug);
 
 }  // namespace loader
 

--- a/cvmfs/loader_talk.h
+++ b/cvmfs/loader_talk.h
@@ -15,6 +15,7 @@ void Spawn();
 void Fini();
 
 int MainReload(const std::string &socket_path, const bool stop_and_go);
+int MainReload(const std::string &socket_path, const bool stop_and_go, const bool debug);
 
 }  // namespace loader_talk
 }  // namespace loader


### PR DESCRIPTION
Ref #2897 
this patch has two short-comings:
1) it will break on hotpatch update of a client without this PR depending on the debug mode 
2) It only honours the CVMFS_DEBUGLOG from `default.local`, not the specfic repo's `.config`.
