### PR TITLE
make zlib compression level a compile-time option

### DIFF
--- a/cmake/Modules/cvmfs_compiler.cmake
+++ b/cmake/Modules/cvmfs_compiler.cmake
@@ -85,6 +85,10 @@ if (ENABLE_ASAN)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 endif (ENABLE_ASAN)
 
+if (ENABLE_ZLIB_BEST_SPEED)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_ZLIB_BEST_SPEED=1")
+endif (ENABLE_ZLIB_BEST_SPEED)
+
 # Check for old Linux version that don't have a complete inotify implementation
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   try_compile(HAS_INOTIFY_INIT1 ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/check_inotify_init1.c)

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -45,6 +45,9 @@ option (BUILD_DUCC              "Build cvmfs_ducc, requires go compiler > 1.11.5
 
 option (BUILD_SNAPSHOTTER       "Build cvmfs_snapshotter, it requires a go compiler > 1.11.5"      OFF)
 
+
+option (ENABLE_ZLIB_BEST_SPEED   "Zlib compression level ON- Best speed: OFF: Default compression" OFF)
+
 if (BUILD_ALL)
   set (BUILD_CVMFS ON)
   set (BUILD_UNITTESTS ON)

--- a/cvmfs/compression.cc
+++ b/cvmfs/compression.cc
@@ -177,7 +177,11 @@ void CompressInit(z_stream *strm) {
   strm->opaque = Z_NULL;
   strm->next_in = Z_NULL;
   strm->avail_in = 0;
+#if ENABLE_ZLIB_BEST_SPEED==1
+  int retval = deflateInit(strm, Z_BEST_SPEED);
+#else
   int retval = deflateInit(strm, Z_DEFAULT_COMPRESSION);
+#endif
   assert(retval == 0);
 }
 
@@ -877,7 +881,11 @@ ZlibCompressor::ZlibCompressor(const Algorithms &alg)
   stream_.opaque   = Z_NULL;
   stream_.next_in  = Z_NULL;
   stream_.avail_in = 0;
+#if ENABLE_ZLIB_BEST_SPEED==1
+  const int zlib_retval = deflateInit(&stream_, Z_BEST_SPEED);
+#else
   const int zlib_retval = deflateInit(&stream_, Z_DEFAULT_COMPRESSION);
+#endif
   assert(zlib_retval == 0);
 }
 


### PR DESCRIPTION
set `-DENABLE_ZLIB_BEST_SPEED=ON` to set compression level to `Z_BEST_SPEED`, otherwise retain default of `Z_DEFAULT_COMPRESSION`