### PR TITLE
send counter deltas to telegraf

### DIFF
--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -72,6 +72,7 @@ struct Statistics {
   perf::Counter *n_listing;
   perf::Counter *n_nested_listing;
   perf::Counter *n_detach_siblings;
+  perf::Counter *catalog_revision;
 
   explicit Statistics(perf::Statistics *statistics) {
     n_lookup_inode = statistics->Register("catalog_mgr.n_lookup_inode",
@@ -89,6 +90,7 @@ struct Statistics {
         "Number of listings of nested catalogs");
     n_detach_siblings = statistics->Register("catalog_mgr.n_detach_siblings",
         "Number of times the CVMFS_CATALOG_WATERMARK was hit");
+    catalog_revision = statistics->Register("catalog_revision", "Catalog revision" );
   }
 };
 

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -665,6 +665,7 @@ uint64_t AbstractCatalogManager<CatalogT>::GetRevision() const {
   ReadLock();
   const uint64_t revision = revision_cache_;
   Unlock();
+  statistics_.catalog_revision->Set( revision );
   return revision;
 }
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1914,6 +1914,10 @@ static void Spawn() {
     cvmfs::file_system_->nfs_maps()->Spawn();
 
   cvmfs::file_system_->cache_mgr()->Spawn();
+
+  cvmfs::mount_point_->statistics()->Spawn( 
+       cvmfs::mount_point_->fqrn(), 
+       cvmfs::mount_point_->file_system()->options_mgr());
 }
 
 

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -110,8 +110,9 @@ FuseRemounter::Status FuseRemounter::Check() {
       return (retval == catalog::kLoadFail) ?
              kStatusFailGeneral : kStatusFailNoSpace;
     case catalog::kLoadUp2Date: {
+      uint64_t revision = mountpoint_->catalog_mgr()->GetRevision();
       LogCvmfs(kLogCvmfs, kLogDebug,
-               "catalog up to date (could be offline mode)");
+               "catalog up to date (could be offline mode) at revision %lu", revision);
       SetOfflineMode(mountpoint_->catalog_mgr()->offline_mode());
       unsigned ttl = offline_mode_ ?
         MountPoint::kShortTermTTL : mountpoint_->GetEffectiveTtlSec();

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "atomic.h"
+#include "options.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -72,6 +73,9 @@ class Statistics {
   std::string LookupDesc(const std::string &name);
   std::string PrintList(const PrintOptions print_options);
   std::string PrintJSON();
+  int SendToTelegraf(void);
+  void Spawn( std::string fqrn, OptionsManager *options_mgr );
+  static void* Run(void* instance);
 
  private:
   Statistics(const Statistics &other);
@@ -87,6 +91,15 @@ class Statistics {
   };
   std::map<std::string, CounterInfo *> counters_;
   mutable pthread_mutex_t *lock_;
+  std::string MakePayload(void);
+
+  std::string telegraf_host_;
+  int         telegraf_port_;
+  std::string telegraf_metric_name_;
+  std::string telegraf_extra_;
+  std::string repo_name_;
+  pthread_t *send_stats_thread_;
+  bool shutdown_;
 };
 
 


### PR DESCRIPTION
sends deltas of the internal counters + current catalog version to a telegraf endpoint. 

Configuration:
```
CVMFS_TELEGRAF_EXTRA=tag1=value1,tag2=value2,...
CVMFS_TELEGRAF_HOST=127.0.0.1
CVMFS_TELEGRAF_METRIC_NAME=cvmfs_client_counters
CVMFS_TELEGRAF_PORT=8092
```