### PR TITLE
Ducc: increase reliability during downloading images from repositories

### DIFF
--- a/ducc/lib/recipe.go
+++ b/ducc/lib/recipe.go
@@ -62,7 +62,7 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 
 func formatOutputImage(OutputFormat string, inputImage Image) string {
 
-	if (OutputFormat == "") {
+	if OutputFormat == "" {
 		OutputFormat = "$(scheme)://$(registry)/$(repository)_thin:$(tag)"
 		l.Log().Info("Using default output image name ", OutputFormat)
 	}


### PR DESCRIPTION
increase reliability during downloading images from repositories. It has two primary changes:

It makes a probing request to determine if authentication is necessary (it is not for public images on quay) and continues without an auth token in that case. In the original branch, it necessarily needs an auth token.
The other change is implementing range requests for the layers along with a fail-retry logic. This is particularly helpful since we have firewalls which often block packets and can interrupt downloads (from external registries like docker hub)