### PR TITLE
Gateway enhancements: kafka notifcations, telegraph telemetry, cache invalidation

### DIFF
--- a/gateway/config/repo.json
+++ b/gateway/config/repo.json
@@ -1,5 +1,12 @@
 {
     "version": 2,
+    "keys" : [
+        {
+            "type" : "plain_text",
+            "id" : "example_key",
+            "secret" : "SECRET"
+        }
+    ],
     "repos" : [
         {
             "domain" : "example_repo.domain.org",
@@ -8,14 +15,24 @@
                     "id": "example_key",
                     "path": "/"
                 }
-            ]
-        }
-    ],
-    "keys" : [
-        {
-            "type" : "plain_text",
-            "id" : "example_key",
-            "secret" : "SECRET"
+            ],
+            "events" : {
+                    "broker": [ "server1", "server2", "server3" ],
+                    "username": "kafka-username",
+                    "password": "kafka-password",
+                    "topic":    "kafka-topic"
+             },
+             "http-proxy" : {
+                    "url": "http://proxy-url/",
+                    "proxy_lookup": "http://proxy-lookup-url/",
+                    "username": "proxy-basic-auth-username",
+                    "password": "proxy-basic-auth-password"
+             },
+             "telegraf" : {
+                    "host": "telegraf-host",
+                    "line": "cvmfs_publication,repository=REPOSITORY,revision=REVISION published=1 TIME",
+                    "port": 8092
+             }
         }
     ]
 }

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,9 +1,8 @@
 module github.com/cvmfs/gateway
 
-go 1.12
+go 1.17
 
 require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/julienschmidt/httprouter v1.2.0
@@ -12,5 +11,26 @@ require (
 	github.com/rs/zerolog v1.14.3
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
+	github.com/twmb/franz-go v1.2.4
 	go.etcd.io/bbolt v1.3.2
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/klauspost/compress v1.13.5 // indirect
+	github.com/magiconair/properties v1.8.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.8 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7 // indirect
+	github.com/twmb/go-rbtree v1.0.0 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/gateway/internal/gateway/backend/access.go
+++ b/gateway/internal/gateway/backend/access.go
@@ -14,11 +14,37 @@ import (
 // KeyPaths maps from key ID to repository subpath
 type KeyPaths map[string]string
 
+// Kafka config for publishing repo update notifications
+type Events struct {
+	Broker   []string `json:"broker"`
+	Topic    string   `json:"topic"`
+	Username string   `json:"username"`
+	Password string   `json:"password"`
+}
+
+// HTTP Proxy info, for cache invalidation.
+type HTTPProxy struct {
+	URL         string `json:"url"`          // URL to invalidate
+	ProxyLookup string `json:"proxy_lookup"` // genders api lookup to list all DMs, which run varnish proxies
+	Username    string `json:"username"`     // Authn for the vanrish proxies
+	Password    string `json:"password"`     //
+}
+
+type Telegraf struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+	Line string `json:"line"`
+}
+
+
 // RepositoryConfig contains the access configuration (registered keys and
 // enabled status) for a repository
 type RepositoryConfig struct {
 	Keys    KeyPaths `json:"keys"`
 	Enabled bool     `json:"enabled"`
+	Events    Events    `json:"events"`
+	HTTPProxy HTTPProxy `json:"http-proxy"`
+	Telegraf  Telegraf  `json:"telegraf"`
 }
 
 // KeyConfig contains the secret part and the enabled status of a key
@@ -47,6 +73,9 @@ type RepositorySpecV2 struct {
 		Admin bool   `json:"admin"`
 		Path  string `json:"path"`
 	} `json:"keys"`
+	Events    Events    `json:"events"`
+	HTTPProxy HTTPProxy `json:"http-proxy"`
+	Telegraf  Telegraf  `json:"telegraf"`
 }
 
 // KeySpec is a gateway key specification from the configuration file
@@ -245,7 +274,10 @@ func (c *AccessConfig) loadV2(cfg rawConfig, importer KeyImportFun) error {
 					ks[k.ID] = k.Path
 				}
 				c.Repositories[spec.Name] = RepositoryConfig{
-					Keys: ks,
+					Keys:      ks,
+					Events:    spec.Events,
+					HTTPProxy: spec.HTTPProxy,
+					Telegraf:  spec.Telegraf,
 				}
 			}
 		}

--- a/gateway/internal/gateway/backend/lease_actions.go
+++ b/gateway/internal/gateway/backend/lease_actions.go
@@ -206,5 +206,10 @@ func (s *Services) CommitLease(ctx context.Context, tokenStr, oldRootHash, newRo
 		return finalRev, err
 	}
 
+	rr := s.GetRepo(ctx, repository)
+	InvalidateHTTPCaches(ctx, rr, finalRev, newRootHash)
+	SendNotification(ctx, repository, rr, leasePath, newRootHash, tag, finalRev)
+	SendToTelegraf(ctx, rr, repository, finalRev)
+
 	return finalRev, nil
 }

--- a/gateway/internal/gateway/backend/util.go
+++ b/gateway/internal/gateway/backend/util.go
@@ -1,11 +1,24 @@
 package backend
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	gw "github.com/cvmfs/gateway/internal/gateway"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
+
+var kafkaClient *kgo.Client
 
 func logAction(ctx context.Context, actionName string, outcome *string, t0 time.Time) {
 	gw.LogC(ctx, "actions", gw.LogInfo).
@@ -13,4 +26,198 @@ func logAction(ctx context.Context, actionName string, outcome *string, t0 time.
 		Str("outcome", *outcome).
 		Dur("action_dt", time.Since(t0)).
 		Msg("action complete")
+}
+
+type invalidateResult struct {
+	err  error
+	host string
+}
+
+// Does a proxied GET of the manifest URL with "Cache-Control: no-cache" to force proxy to invalide any cached copy
+// checks the returned manifest to verify that the revision is up to date
+// warms the cache with the new root hash object
+
+func InvalidateHTTPCaches(ctx context.Context, repo *RepositoryConfig, revision uint64, newRootHash string) {
+	if repo.HTTPProxy.ProxyLookup == "" {
+		return
+	} //nothing to do
+
+	// get a list of datamovers from the genders API
+	resp, err := http.Get(repo.HTTPProxy.ProxyLookup)
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Proxy lookup failed")
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Proxy lookup failed reading body of reply")
+		return
+	}
+
+	var buf []string
+	if err = json.Unmarshal(body, &buf); err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Proxy lookup failed parsing JSON in reply")
+		return
+	}
+
+	// for each datamover start a worker that warms and invalidates cache objects
+
+	results := make(chan invalidateResult, len(buf))
+	for _, p := range buf {
+		go invalidateWorker(ctx, p, repo.HTTPProxy, revision, results, newRootHash)
+	}
+	for range buf {
+		success := <-results
+		if success.err != nil {
+			gw.LogC(ctx, "actions", gw.LogInfo).Err(success.err).Str("proxy", success.host).Msg("Failed to invalidate manifest on proxy")
+		} else {
+			gw.LogC(ctx, "actions", gw.LogInfo).Str("proxy", success.host).Msg("Successfully invalidated manifest on proxy")
+		}
+	}
+}
+
+func invalidateWorker(ctx context.Context, dm string, proxyinfo HTTPProxy, revision uint64, success chan<- invalidateResult, newRootHash string) {
+	// compose the proxy URL, including basic auth credentials
+
+	proxy_url := fmt.Sprintf("http://%s:%s@%s:6081", proxyinfo.Username, proxyinfo.Password, dm)
+
+	parsed_url, err := url.Parse(proxy_url)
+
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msgf("url.Parse of %s failed", proxy_url)
+		success <- invalidateResult{err: err, host: dm}
+		return
+	}
+	c := &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(parsed_url)},
+		Timeout:   2 * time.Second,
+	}
+
+	//  Get the new root hash object to warm the cache
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/data/%s/%s", proxyinfo.URL, newRootHash[:2], newRootHash[2:]), nil)
+
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Failed to create HTTP request")
+		success <- invalidateResult{err: err, host: dm}
+		return
+	}
+
+	resp, err := c.Do(req)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	if err != nil || resp.StatusCode != 200 {
+		// not a fatal error - log continue on to invalidate manifest
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Failed to retrieve new root hash object from proxy")
+	}
+
+	// now invalidate the manifest object
+	req, err = http.NewRequest("GET", fmt.Sprintf("%s/.cvmfspublished", proxyinfo.URL), nil)
+
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Failed to create HTTP request")
+		success <- invalidateResult{err: err, host: dm}
+		return
+	}
+
+	req.Header = http.Header{"Cache-Control": []string{"no-cache"}}
+	resp, err = c.Do(req)
+	if err != nil {
+		success <- invalidateResult{err: err, host: dm}
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		success <- invalidateResult{err: fmt.Errorf("HTTP Status Code %d", resp.StatusCode), host: dm}
+		return
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		success <- invalidateResult{err: err, host: dm}
+		return
+	}
+
+	// look in the manifest for the revision number
+	// see https://cvmfs.readthedocs.io/en/stable/cpt-details.html#repository-manifest-cvmfspublished
+
+	needle := fmt.Sprintf("\nS%v\n", revision)
+	if !bytes.Contains(body, []byte(needle)) {
+		success <- invalidateResult{err: fmt.Errorf("Returned manifest does not contain expected revision %d", revision), host: dm}
+		return
+	}
+
+	success <- invalidateResult{err: nil, host: dm}
+}
+
+type kafkaMsg struct {
+	Repository string `json:"repository"`
+	Revision   uint64 `json:"revision"`
+	RootHash   string `json:"rootHash"`
+	LeasePath  string `json:"path"`
+}
+
+func SendNotification(ctx context.Context, repository string, repo *RepositoryConfig, leasePath string, newRootHash string, tag gw.RepositoryTag, revision uint64) {
+	var err error
+
+	// connect to message broker
+	if kafkaClient == nil {
+		opts := []kgo.Opt{
+			// longer timeout to maintain connection
+			kgo.ConnIdleTimeout(3*time.Minute),
+			kgo.SeedBrokers(repo.Events.Broker...),
+			kgo.ConsumeTopics(repo.Events.Topic),
+			kgo.DefaultProduceTopic(repo.Events.Topic),
+			kgo.SASL(scram.Auth{
+				User: repo.Events.Username,
+				Pass: repo.Events.Password,
+			}.AsSha512Mechanism()),
+		}
+		kafkaClient, err = kgo.NewClient(opts...)
+		if err != nil {
+			gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Unable to connect to message broker")
+			return
+		}
+	}
+
+	// compose and publih message
+	msg := kafkaMsg{
+		Repository: repository,
+		Revision:   revision,
+		RootHash:   newRootHash,
+		LeasePath:  leasePath,
+	}
+	msgstr, err := json.Marshal(msg)
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Failed to marshal json message")
+		return
+	}
+	record := &kgo.Record{Topic: repo.Events.Topic, Value: []byte(msgstr)}
+	if err := kafkaClient.ProduceSync(ctx, record).FirstErr(); err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Failed to publish to message broker")
+		return
+	}
+	gw.LogC(ctx, "actions", gw.LogInfo).Msg("Successfully published notification to message broker")
+}
+
+func SendToTelegraf(ctx context.Context, repo *RepositoryConfig, repository string, revision uint64) {
+	line := repo.Telegraf.Line
+	if line == "" { // nothing to log
+		return
+	}
+	line = strings.Replace(line, "REPOSITORY", repository, -1)
+	line = strings.Replace(line, "REVISION", fmt.Sprintf("%d", revision), -1)
+	line = strings.Replace(line, "TIME", fmt.Sprintf("%d", time.Now().UnixNano()), -1)
+
+	con, err := net.Dial("udp", fmt.Sprintf("%s:%d", repo.Telegraf.Host, repo.Telegraf.Port))
+	if err != nil {
+		gw.LogC(ctx, "actions", gw.LogError).Err(err).Msg("Failed to create UDP socket to telegraf")
+		return
+	}
+	con.Write([]byte(line))
+	con.Close()
+	gw.LogC(ctx, "actions", gw.LogInfo).Str("measurement", line).Msg("Sent to telegraf")
 }


### PR DESCRIPTION
Gateway enhancements:

1) Kafka notifications:

On publication event, publish a message to specified kafka topic. Used in conjunction with https://github.com/cvmfs/cvmfs/pull/2942

2) Telegraf telemetry
On publication event, emit event to configured telegraf collector. Metric sent is configured in `telegraf`->`line`, eg
```
cvmfs_publication,repository=REPOSITORY,revision=REVISION published=1 TIME
```
with substitutions made for the `REPOSITORY`, `REVISION`, `TIME` tokens

3) cache invalidation for `.cvmfspublished` objects. After publication, and before kafka notification, gateway will pull a list of HTTP cache hostnames from `http-proxy`->`proxy_lookup` (Json-encoded list of strings). It then makes a `Cache-Control: no-cache` request to a URL synthesised from `http-proxy`->`url` + `/.cvmfspublished`  + basic auth credentials taken from `http-proxy`->'username|password`
