### PR TITLE
Add switch `CVMFS_CACHE_SYMLINKS` 

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1556,6 +1556,22 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
           "libfuse, aborting");
 #endif
   }
+
+  if ( mount_point_->cache_symlinks() ) {
+#if FUSE_VERSION >= 310
+    if( (conn->capable & FUSE_CAP_CACHE_SYMLINK) == 0 ) {
+      PANIC(kLogDebug | kLogSyslogErr,
+           "Symlink caching requested but missing fuse kernel support, "
+           "aborting");
+    }
+    conn->want |= FUSE_CAP_CACHE_SYMLINK;
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog, "enabling symlink caching");
+#else
+    PANIC(kLogDebug | kLogSyslogErr,
+           "Symlink caching requested but libfuse too old (>=3.10.0 required)" );
+#endif
+  }
+
 }
 
 static void cvmfs_destroy(void *unused __attribute__((unused))) {

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1678,6 +1678,7 @@ MountPoint::MountPoint(
   , kcache_timeout_sec_(static_cast<double>(kDefaultKCacheTtlSec))
   , fixed_catalog_(false)
   , enforce_acls_(false)
+  , cache_symlinks_(false)
   , has_membership_req_(false)
   , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
   , talk_socket_uid_(0)
@@ -1775,6 +1776,14 @@ bool MountPoint::SetupBehavior() {
   {
     enforce_acls_ = true;
   }
+
+  if (options_mgr_->GetValue("CVMFS_CACHE_SYMLINKS", &optarg)
+      && options_mgr_->IsOn(optarg))
+  {
+    cache_symlinks_ = true;
+  }
+
+
 
   if (options_mgr_->GetValue("CVMFS_TALK_SOCKET", &optarg)) {
     talk_socket_path_ = optarg;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -443,6 +443,7 @@ class MountPoint : SingleCopy, public BootFactory {
   MagicXattrManager *magic_xattr_mgr() { return magic_xattr_mgr_; }
   bool has_membership_req() { return has_membership_req_; }
   bool enforce_acls() { return enforce_acls_; }
+  bool cache_symlinks() { return cache_symlinks_; }
   catalog::InodeAnnotation *inode_annotation() {
     return inode_annotation_;
   }
@@ -574,6 +575,7 @@ class MountPoint : SingleCopy, public BootFactory {
   double kcache_timeout_sec_;
   bool fixed_catalog_;
   bool enforce_acls_;
+  bool cache_symlinks_;
   std::string repository_tag_;
   std::vector<std::string> blacklist_paths_;
 


### PR DESCRIPTION
Lets the kernel cache symlink references, if there's kernel fuse support (rhel8+) and libfuse support (3.10.0+)

Ref issue #2949