### PR TITLE
Add catalog_hash xattr

### DIFF
--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -75,6 +75,9 @@ Catalog *ClientCatalogManager::CreateCatalog(
   return new Catalog(mountpoint, catalog_hash, parent_catalog);
 }
 
+shash::Any ClientCatalogManager::GetCatalogHashForPath( const PathString &path ) {
+  return mounted_catalogs_[path];
+}
 
 shash::Any ClientCatalogManager::GetRootHash() {
   ReadLock();

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -56,6 +56,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
 
   bool InitFixed(const shash::Any &root_hash, bool alternative_path);
 
+  shash::Any GetCatalogHashForPath( const PathString &path );
+
   shash::Any GetRootHash();
 
   bool IsRevisionBlacklisted();

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -22,6 +22,7 @@ MagicXattrManager::MagicXattrManager(MountPoint *mountpoint,
     visibility_(visibility)
 {
   Register("user.catalog_counters", new CatalogCountersMagicXattr());
+  Register("user.catalog_hash", new CatalogHashMagicXattr());
   Register("user.external_host", new ExternalHostMagicXattr());
   Register("user.external_timeout", new ExternalTimeoutMagicXattr());
   Register("user.fqrn", new FqrnMagicXattr());
@@ -156,6 +157,10 @@ std::string CatalogCountersMagicXattr::GetValue() {
   res = "catalog_mountpoint: " + subcatalog_path_ + "\n";
   res += counters_.GetCsvMap();
   return res;
+}
+
+std::string CatalogHashMagicXattr::GetValue() {
+  return mount_point_->catalog_mgr()->GetCatalogHashForPath( path_ ).ToString();
 }
 
 bool ChunkListMagicXattr::PrepareValueFenced() {

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -173,6 +173,10 @@ class CatalogCountersMagicXattr : public BaseMagicXattr {
   virtual std::string GetValue();
 };
 
+class CatalogHashMagicXattr : public BaseMagicXattr {
+  virtual std::string GetValue();
+};
+
 class ChunkListMagicXattr : public RegularMagicXattr {
   std::string chunk_list_;
 


### PR DESCRIPTION
Adds the magic extended attribute "catalog_hash" for mapping a directory back to a catalog object (if not the root of a nested catalog returns 000000000000000000000000000000000000000 )

Ref Issue https://github.com/cvmfs/cvmfs/issues/2900