### PR TITLE
Fix link between watchdog and fuse module

### DIFF
--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -415,7 +415,10 @@ void Watchdog::Spawn() {
           // Gracefully close the syslog before closing all fds. The next call
           // to syslog will reopen it.
           closelog();
-          for (int fd = 0; fd < max_fd; fd++) {
+          // Let's keep stdin, stdout, stderr open at /dev/null (daemonized)
+          // in order to prevent accidental outputs from messing with another
+          // file descriptor
+          for (int fd = 3; fd < max_fd; fd++) {
             if (fd == pipe_watchdog_->read_end)
               continue;
             if (fd == pipe_listener_->write_end)

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1898,8 +1898,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
   // read the PID of the spawned process if requested
   // (the actual read needs to be done in any case!)
   pid_t buf_child_pid = 0;
-  retcode = pipe_fork.Read(&buf_child_pid);
-  assert(retcode);
+  pipe_fork.Read(&buf_child_pid);
   if (child_pid != NULL)
     *child_pid = buf_child_pid;
   close(pipe_fork.read_end);

--- a/test/unittests/t_pipe.cc
+++ b/test/unittests/t_pipe.cc
@@ -91,10 +91,10 @@ TEST_F(T_Pipe, ReadTemplate) {
   Foo              res_foobar;
   TestEnum::MyEnum res_optional;
 
-  retval = pipe.Read(&res_integer);   EXPECT_TRUE(retval);
-  retval = pipe.Read(&res_character); EXPECT_TRUE(retval);
-  retval = pipe.Read(&res_foobar);    EXPECT_TRUE(retval);
-  retval = pipe.Read(&res_optional);  EXPECT_TRUE(retval);
+  retval = pipe.TryRead(&res_integer);   EXPECT_TRUE(retval);
+  retval = pipe.TryRead(&res_character); EXPECT_TRUE(retval);
+  retval = pipe.TryRead(&res_foobar);    EXPECT_TRUE(retval);
+  retval = pipe.TryRead(&res_optional);  EXPECT_TRUE(retval);
 
   EXPECT_EQ(res_integer, integer)     << "Failed to retrieve integer";
   EXPECT_EQ(res_character, character) << "Failed to retrieve character";


### PR DESCRIPTION
Possibly fix the occasional unexplained termination of the watchdog (#2895). The watchdog blocks on `read()` on a control pipe. This `read()` call may be interrupted by a signal, which is currently not handled.

The patch is certainly an improvement. Unclear if it is the actual cause of the disappearing watchdog though. If it was, I would have expected to see a [syslog entry](https://github.com/cvmfs/cvmfs/blob/devel/cvmfs/monitor.cc#L564). Logging to syslog from the watchdog should have been fixed with [cvmfs-2.9.2](https://github.com/cvmfs/cvmfs/pull/2859) but I didn't see the entry in the CERN logs.

@traylenator Could I forcefully kill a cvmfs mount on an lxplus node, just to see if the reporting works as expected?