### PR TITLE
Gateway: remove "FQDN" check

### DIFF
--- a/gateway/internal/gateway/pathutil.go
+++ b/gateway/internal/gateway/pathutil.go
@@ -57,10 +57,6 @@ func SplitLeasePath(leasePath string) (string, string, error) {
 	}
 	repoName := tokens[0]
 
-	if strings.Count(repoName, ".") < 2 {
-		return "", "", fmt.Errorf("input does not start with a FQDN")
-	}
-
 	subPath := strings.TrimPrefix(leasePath, repoName)
 
 	return repoName, subPath, nil


### PR DESCRIPTION
This check imposes the constraint that repo names contain at least two periods. This is not imposed anywhere else in the publishing pathway, and prevents any existing repos being converted to using a gateway.