### PR TITLE
Fix releasing of gc lock

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -252,20 +252,23 @@ __do_gc_cmd()
     [ $preserve_revisions   -ge 0 ] && additional_switches="$additional_switches -h $preserve_revisions"
     [ $preserve_timestamp   -gt 0 ] && additional_switches="$additional_switches -z $preserve_timestamp"
 
+    local trapcmd
     if [ $dry_run -eq 0 ]; then
       # if a check or other gc is in progress on this repo, abort
       acquire_gc_lock $name gc 1 || die "Failed to acquire gc lock for $name"
-      local trapcmd="release_gc_lock $name"
+      trapcmd="release_gc_lock $name"
       trap "$trapcmd" EXIT HUP INT TERM
       if is_stratum0 $name; then
         is_in_transaction $name  && die "Cannot run garbage collection while in a transaction"
-        trap "close_transaction $name 0; $trapcmd" EXIT HUP INT TERM
+        trapcmd="close_transaction $name 0; $trapcmd"
+        trap "$trapcmd" EXIT HUP INT TERM
         open_transaction $name   || die "Failed to open transaction for garbage collection"
       else
         # on stratum1
         # if an update is in progress, wait for it
         acquire_update_lock $name gc || die "Failed to acquire update lock for $name"
-        trap "release_update_lock $name; $trapcmd" EXIT HUP INT TERM
+        trapcmd="release_update_lock $name; $trapcmd"
+        trap "$trapcmd" EXIT HUP INT TERM
       fi
     fi
 
@@ -286,19 +289,14 @@ __do_gc_cmd()
              $additional_switches || die "Fail ($?)!"
 
     if [ $dry_run -eq 0 ]; then
-      # sign the result
       if is_stratum0 $name; then
-        # close the transaction
-        trap - EXIT HUP INT TERM
         if [ "x$CVMFS_UPLOAD_STATS_PLOTS" = "xtrue" ]; then
           /usr/share/cvmfs-server/upload_stats_plots.sh $name
         fi
-        close_transaction $name 0
-      else
-        # release the update lock
-        trap - EXIT HUP INT TERM
-        release_update_lock $name
       fi
+      # release lock(s) and close transaction
+      eval $trapcmd
+      trap - EXIT HUP INT TERM
     fi
 
     syncfs cautious

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -300,11 +300,15 @@ cvmfs_run_test() {
 
   # ============================================================================
 
+  echo "check if the repository's garbage collection lock is gone"
+  load_repo_config $CVMFS_TEST_REPO
+  test -f ${CVMFS_SPOOL_DIR}/is_collecting.lock && return 16
+
   echo "check if the repository is still sane"
-  check_repository $CVMFS_TEST_REPO -i || return 16
+  check_repository $CVMFS_TEST_REPO -i || return 17
 
   echo "check if the repository's previous revision is still sane"
-  check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 17
+  check_repository $CVMFS_TEST_REPO -i -t trunk-previous || return 18
 
   echo "check that the temporary scratch directory is empty"
   [ $(ls ${CVMFS_SPOOL_DIR}/tmp | wc -l) -eq 0 ] || return 50

--- a/test/src/621-snapshotallgcall/main
+++ b/test/src/621-snapshotallgcall/main
@@ -150,5 +150,10 @@ cvmfs_run_test() {
     echo "skipping pass-through test"
   fi
 
+  echo "*** checking if updating and gc locks have been removed on test repo"
+  load_repo_config $CVMFS_TEST_REPO
+  test -f ${CVMFS_SPOOL_DIR}/is_updating.lock && return 60
+  test -f ${CVMFS_SPOOL_DIR}/is_collecting.lock && return 61
+
   return 0
 }


### PR DESCRIPTION
The new gc lock added in #2850 introduced in 2.9.1 is never getting released.  This PR fixes that.

I'm afraid this bug is bad enough to require a 2.9.3 release.  The tests added fail without the fix.