### PR TITLE
Update the cvmfs-release packages

### DIFF
--- a/packaging/debian/cernvm.list.bionic
+++ b/packaging/debian/cernvm.list.bionic
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt bionic-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt bionic-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt bionic-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt bionic-testing main

--- a/packaging/debian/cernvm.list.bullseye
+++ b/packaging/debian/cernvm.list.bullseye
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt bullseye-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt bullseye-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt bullseye-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt bullseye-testing main

--- a/packaging/debian/cernvm.list.buster
+++ b/packaging/debian/cernvm.list.buster
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt buster-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt buster-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt buster-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt buster-testing main

--- a/packaging/debian/cernvm.list.focal
+++ b/packaging/debian/cernvm.list.focal
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt focal-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt focal-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt focal-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt focal-testing main

--- a/packaging/debian/cernvm.list.jammy
+++ b/packaging/debian/cernvm.list.jammy
@@ -1,0 +1,2 @@
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt jammy-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt jammy-testing main

--- a/packaging/debian/cernvm.list.jessie
+++ b/packaging/debian/cernvm.list.jessie
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt jessie-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt jessie-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt jessie-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt jessie-testing main

--- a/packaging/debian/cernvm.list.precise
+++ b/packaging/debian/cernvm.list.precise
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt precise-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt precise-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt precise-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt precise-testing main

--- a/packaging/debian/cernvm.list.stretch
+++ b/packaging/debian/cernvm.list.stretch
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt stretch-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt stretch-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt stretch-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt stretch-testing main

--- a/packaging/debian/cernvm.list.trusty
+++ b/packaging/debian/cernvm.list.trusty
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt trusty-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt trusty-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt trusty-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt trusty-testing main

--- a/packaging/debian/cernvm.list.xenial
+++ b/packaging/debian/cernvm.list.xenial
@@ -1,2 +1,2 @@
-deb http://cvmrepo.web.cern.ch/cvmrepo/apt xenial-prod main
-# deb http://cvmrepo.web.cern.ch/cvmrepo/apt xenial-testing main
+deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt xenial-prod main
+# deb http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/apt xenial-testing main

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -3,7 +3,7 @@ cvmfs-release (4.0-1) lucid; urgency=low
   * Add Ubuntu 22.04 "jammy" platform
   * Change apt repository base URLs to S3 mirror
 
- -- Jakob Blomer <jblomer@cern.ch>  Wed, 04 July 2022 23:35:00 +0200
+ -- Jakob Blomer <jblomer@cern.ch>  Mon, 04 Jul 2022 23:35:00 +0200
 
 cvmfs-release (3.3-1) lucid; urgency=low
 

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -1,3 +1,10 @@
+cvmfs-release (4.0-1) lucid; urgency=low
+
+  * Add Ubuntu 22.04 "jammy" platform
+  * Change apt repository base URLs to S3 mirror
+
+ -- Jakob Blomer <jblomer@cern.ch>  Wed, 04 July 2022 23:35:00 +0200
+
 cvmfs-release (3.3-1) lucid; urgency=low
 
   * Add Debian 11 "bullseye" platform

--- a/packaging/debian/cvmfs-release/postinst
+++ b/packaging/debian/cvmfs-release/postinst
@@ -28,7 +28,10 @@ case "$1" in
 	else
 		version_major=$(lsb_release -sr | cut -d. -f1)
 		fallback_release=
-		if [ $version_major -ge 20 ]; then
+		if [ $version_major -ge 22 ]; then
+			echo "Warning: this distribution is not supported. Using Ubuntu 22.04 packages as fallback."
+			fallback_release=jammy
+		elif [ $version_major -ge 20 ]; then
 			echo "Warning: this distribution is not supported. Using Ubuntu 20.04 packages as fallback."
 			fallback_release=focal
 		elif [ $version_major -ge 18 ]; then

--- a/packaging/rpm/cernvm.repo
+++ b/packaging/rpm/cernvm.repo
@@ -1,6 +1,6 @@
 [cernvm]
 name=CernVM packages
-baseurl=http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
+baseurl=http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
 gpgcheck=1
 enabled=1
@@ -8,7 +8,7 @@ protect=1
 
 [cernvm-config]
 name=CernVM-FS extra config packages
-baseurl=http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+baseurl=http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
 gpgcheck=1
 enabled=0
@@ -16,17 +16,8 @@ protect=1
 
 [cernvm-testing]
 name=CernVM testing packages
-baseurl=http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-testing/EL/$releasever/$basearch/
+baseurl=http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/yum/cvmfs-testing/EL/$releasever/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
 gpgcheck=1
 enabled=0
 protect=1
-
-[cernvm-kernel]
-name=CernVM-FS AUFS enabled kernel
-baseurl=http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-kernel/EL/$releasever/$basearch/
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-gpgcheck=1
-enabled=0
-protect=1
-

--- a/packaging/rpm/cvmfs-release.spec
+++ b/packaging/rpm/cvmfs-release.spec
@@ -1,6 +1,6 @@
 Name:           cvmfs-release
-Version:        2
-Release:        7
+Version:        3
+Release:        1
 Summary:        Packages for the CernVM File System
 
 Group:          Applications/System
@@ -9,8 +9,8 @@ License:        BSD
 # This is a Red Hat maintained package which is specific to
 # our distribution.  Thus the source is only available from
 # within this srpm.
-URL:            http://cvmrepo.web.cern.ch/cvmrepo/yum
-Source0:        http://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
+URL:            http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/yum
+Source0:        http://cvmrepo.web.cern.ch.s3.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
 Source1:        BSD
 Source2:        cernvm.repo
 
@@ -54,6 +54,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue Jul 05 2022 Jakob Blomer <jblomer@cern.ch> - 3-1
+- Set repository URL to S3 mirror
+- Remove cernvm-kernel repository
 * Sat Apr 10 2021 Jakob Blomer <jblomer@cern.ch> - 2-7
 - Fix RPM linter errors
 * Tue Apr 05 2016 Jakob Blomer <jblomer@cern.ch> - 2-6


### PR DESCRIPTION
The new cvmfs-release packages 
  - use the S3 package mirror 
  - enable access to Ubuntu 22.04 repositories
  - remove the cernvm-kernel repository