### PR TITLE
Fix and simplify unit test runner

### DIFF
--- a/ci/build_incremental_multi.sh
+++ b/ci/build_incremental_multi.sh
@@ -59,12 +59,12 @@ fi
 # that go-junit-report is installed
 # and that we are on a 64bit architecture
 build_ducc="OFF"
-if [ $(can_build_ducc) -ge 1 ]; then
+if can_build_ducc; then
   build_ducc="ON"
 fi
 
 build_gateway="OFF"
-if [ $(can_build_gateway) -ge 1 ]; then
+if can_build_gateway; then
   build_gateway="ON"
 fi
 

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -234,8 +234,7 @@ expand_template() {
 can_build_ducc() {
   arch=$(go env GOARCH)
   if [ $arch != "amd64" ]; then
-    echo "0"
-    return
+    return 1
   fi
   if which go > /dev/null 2>&1 && which go-junit-report > /dev/null 2>&1 ; then
     go_version=$(go version)
@@ -244,24 +243,24 @@ can_build_ducc() {
     go_patch=$(echo $go_version | sed -n 's/go version go\([0-9]\)\.\([0-9]*\)\.\([0-9]*\).*/\3/p')
 
     if [ $go_major -gt 1 ]; then
-      echo "1"
+      return 0
     elif [ $go_major -lt 1 ]; then
-      echo "0"
+      return 1
     else
       if [ $go_minor -gt 12 ]; then
-        echo "1"
+        return 0
       elif [ $go_minor -lt 12 ]; then
-        echo "0"
+        return 1
       else
         if [ $go_patch -ge 0 ]; then
-          echo "1"
+          return 0
         else
-          echo "0"
+          return 1
         fi
       fi
     fi
   else
-    echo "0"
+    return 1
   fi
 }
 

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -136,7 +136,7 @@ if can_build_gateway; then
   popd > /dev/null
 fi
 
-if [ $CVMFS_TEST_DUCC = 1 ] && [ $(can_build_ducc) -ge 1 ]; then
+if [ $CVMFS_TEST_DUCC = 1 ] && can_build_ducc; then
   echo "running ducc unit tests into $CVMFS_UNITTESTS_RESULT_LOCATION"
   pushd ${SCRIPT_LOCATION}/../ducc > /dev/null
   go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -86,6 +86,7 @@ if [ "x$CVMFS_GEOAPI_SOURCES" != "x" ]; then
       PYTHON_COMMAND="python3"
     fi
   fi
+  echo "RUNNING Geo-API UNIT TESTS"
   $PYTHON_COMMAND test_cvmfs_geo.py
   popd
 fi
@@ -106,7 +107,8 @@ if [ "x$CVMFS_CACHE_PLUGIN" != "x" ]; then
       i=$((i + 1))
       CVMFS_CACHE_LOCATOR=tcp=127.0.0.1:$CVMFS_CACHE_LOCATOR_PORT
       echo "CVMFS_CACHE_PLUGIN_LOCATOR=$CVMFS_CACHE_LOCATOR" >> $CVMFS_CACHE_CONFIG
-      echo "running unit tests for cache plugin $plugin on $CVMFS_CACHE_LOCATOR"
+      echo -n "RUNNING CACHE PLUGIN UNIT TESTS for cache plugin $plugin on $CVMFS_CACHE_LOCATOR"
+      echo " (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.$(basename $plugin))"
       # All our plugins take a configuration file as a parameter
       plugin_pid="$($plugin $CVMFS_CACHE_CONFIG)"
       echo "cache plugin started as PID $plugin_pid"
@@ -123,28 +125,28 @@ fi
 
 # run the shrinkwrap tests
 if [ "x$CVMFS_SHRINKWRAP_TEST_BINARY" != "x" ]; then
-  echo "running shrinkwrap tests (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)..."
+  echo "RUNNING SHRINKWRAP UNIT TESTS (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.shrinkwrap)..."
   $CVMFS_SHRINKWRAP_TEST_BINARY --gtest_shuffle                                     \
     --gtest_output=xml:${CVMFS_UNITTESTS_RESULT_LOCATION}.shrinkwrap \
     --gtest_filter=$test_filter
 fi
 
 if can_build_gateway; then
-  echo "running gateway unit tests into $CVMFS_UNITTESTS_RESULT_LOCATION"
+  echo "RUNNING GATEWAY UNIT TESTS (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway)"
   pushd ${SCRIPT_LOCATION}/../gateway > /dev/null
   go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway
   popd > /dev/null
 fi
 
 if [ $CVMFS_TEST_DUCC = 1 ] && can_build_ducc; then
-  echo "running ducc unit tests into $CVMFS_UNITTESTS_RESULT_LOCATION"
+  echo "RUNNING CONTAINER TOOLS UNIT TEST (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc)"
   pushd ${SCRIPT_LOCATION}/../ducc > /dev/null
   go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc
   popd > /dev/null
 fi
 
 if [ $CVMFS_TEST_PUBLISH = 1 ]; then
-  echo "running publish unit tests into $CVMFS_UNITTESTS_RESULT_LOCATION"
+  echo "RUNNING PUBLISH UNIT TESTS (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)"
   CVMFS_PUBLISH_UNITTESTS="$(dirname $CVMFS_UNITTESTS_BINARY)/cvmfs_test_publish"
   $CVMFS_PUBLISH_UNITTESTS --gtest_shuffle                                     \
                            --gtest_output=xml:$CVMFS_UNITTESTS_RESULT_LOCATION \
@@ -152,7 +154,7 @@ if [ $CVMFS_TEST_PUBLISH = 1 ]; then
 fi
 
 # run the unit tests
-echo "running unit tests (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)..."
+echo "RUNNING CORE UNIT TESTS (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)..."
 $CVMFS_UNITTESTS_BINARY --gtest_shuffle                                     \
                         --gtest_output=xml:$CVMFS_UNITTESTS_RESULT_LOCATION \
                         --gtest_filter=$test_filter

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -71,7 +71,7 @@ CVMFS_UNITTESTS_RESULT_LOCATION=$2
 # check if only a quick subset of the unittests should be run
 test_filter='-'
 if [ $CVMFS_UNITTESTS_QUICK = 1 ]; then
-  echo "running only quick tests (without suffix 'Slow')"
+  echo "*** Running only quick tests (without suffix 'Slow')"
   test_filter='-*Slow'
 fi
 
@@ -86,9 +86,11 @@ if [ "x$CVMFS_GEOAPI_SOURCES" != "x" ]; then
       PYTHON_COMMAND="python3"
     fi
   fi
-  echo "RUNNING Geo-API UNIT TESTS"
+  echo "*** Running Geo-API unit tests"
   $PYTHON_COMMAND test_cvmfs_geo.py
   popd
+else
+  echo "*** Skipping Geo-API unit tests"
 fi
 
 # run the cache plugin unittests
@@ -107,7 +109,7 @@ if [ "x$CVMFS_CACHE_PLUGIN" != "x" ]; then
       i=$((i + 1))
       CVMFS_CACHE_LOCATOR=tcp=127.0.0.1:$CVMFS_CACHE_LOCATOR_PORT
       echo "CVMFS_CACHE_PLUGIN_LOCATOR=$CVMFS_CACHE_LOCATOR" >> $CVMFS_CACHE_CONFIG
-      echo -n "RUNNING CACHE PLUGIN UNIT TESTS for cache plugin $plugin on $CVMFS_CACHE_LOCATOR"
+      echo -n "*** Running cache plugin unit tests for cache plugin $plugin on $CVMFS_CACHE_LOCATOR"
       echo " (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.$(basename $plugin))"
       # All our plugins take a configuration file as a parameter
       plugin_pid="$($plugin $CVMFS_CACHE_CONFIG)"
@@ -123,38 +125,45 @@ if [ "x$CVMFS_CACHE_PLUGIN" != "x" ]; then
   rm -f $CVMFS_CACHE_CONFIG
 fi
 
-# run the shrinkwrap tests
 if [ "x$CVMFS_SHRINKWRAP_TEST_BINARY" != "x" ]; then
-  echo "RUNNING SHRINKWRAP UNIT TESTS (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.shrinkwrap)..."
+  echo "*** Running shrinkwrap unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.shrinkwrap)..."
   $CVMFS_SHRINKWRAP_TEST_BINARY --gtest_shuffle                                     \
     --gtest_output=xml:${CVMFS_UNITTESTS_RESULT_LOCATION}.shrinkwrap \
     --gtest_filter=$test_filter
+else
+  echo "*** Skipping shrinkwrap unit tests"
 fi
 
 if can_build_gateway; then
-  echo "RUNNING GATEWAY UNIT TESTS (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway)"
+  echo "*** Running gateway unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway)"
   pushd ${SCRIPT_LOCATION}/../gateway > /dev/null
   go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway
   popd > /dev/null
+else
+  echo "*** Skipping gateway unit tests"
 fi
 
 if [ $CVMFS_TEST_DUCC = 1 ] && can_build_ducc; then
-  echo "RUNNING CONTAINER TOOLS UNIT TEST (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc)"
+  echo "*** Running container tools unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc)"
   pushd ${SCRIPT_LOCATION}/../ducc > /dev/null
   go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc
   popd > /dev/null
+else
+  echo "*** Skipping container tools unit tests"
 fi
 
 if [ $CVMFS_TEST_PUBLISH = 1 ]; then
-  echo "RUNNING PUBLISH UNIT TESTS (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)"
+  echo "*** Running publish unit tests (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)"
   CVMFS_PUBLISH_UNITTESTS="$(dirname $CVMFS_UNITTESTS_BINARY)/cvmfs_test_publish"
   $CVMFS_PUBLISH_UNITTESTS --gtest_shuffle                                     \
                            --gtest_output=xml:$CVMFS_UNITTESTS_RESULT_LOCATION \
                            --gtest_filter=$test_filter
+else
+  echo "*** Skipping publish unit tests"
 fi
 
 # run the unit tests
-echo "RUNNING CORE UNIT TESTS (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)..."
+echo "*** Running core unit tests (with XML output $CVMFS_UNITTESTS_RESULT_LOCATION)..."
 $CVMFS_UNITTESTS_BINARY --gtest_shuffle                                     \
                         --gtest_output=xml:$CVMFS_UNITTESTS_RESULT_LOCATION \
                         --gtest_filter=$test_filter

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -24,7 +24,6 @@ CVMFS_UNITTESTS_QUICK=0
 CVMFS_SHRINKWRAP_TEST_BINARY="$CVMFS_SHRINKWRAP_TEST_BINARY"
 CVMFS_CACHE_PLUGIN=
 CVMFS_GEOAPI_SOURCES=
-CVMFS_TEST_DUCC=0
 CVMFS_TEST_PUBLISH=0
 
 while getopts "qc:g:s:l:Gdp" option; do
@@ -46,7 +45,7 @@ while getopts "qc:g:s:l:Gdp" option; do
       :
     ;;
     d)
-      CVMFS_TEST_DUCC=1
+      # Deprecated; container tools unit tests are always run when the code can build
     ;;
     p)
       CVMFS_TEST_PUBLISH=1
@@ -143,7 +142,7 @@ else
   echo "*** Skipping gateway unit tests"
 fi
 
-if [ $CVMFS_TEST_DUCC = 1 ] && can_build_ducc; then
+if can_build_ducc; then
   echo "*** Running container tools unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc)"
   pushd ${SCRIPT_LOCATION}/../ducc > /dev/null
   go test -v -mod=vendor ./... 2>&1 | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -4,8 +4,6 @@
 # This script wraps the unit test run of CernVM-FS.
 #
 
-set -e
-
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 . ${SCRIPT_LOCATION}/common.sh
 

--- a/cvmfs/smalloc.h
+++ b/cvmfs/smalloc.h
@@ -56,8 +56,6 @@ static inline void * __attribute__((used)) scalloc(size_t count, size_t size) {
   return mem;
 }
 
-#include <cstdio>
-#include <cerrno>
 static inline void * __attribute__((used)) smmap(size_t size) {
   // TODO(reneme): make page size platform independent
   assert(size > 0);

--- a/cvmfs/smalloc.h
+++ b/cvmfs/smalloc.h
@@ -56,6 +56,8 @@ static inline void * __attribute__((used)) scalloc(size_t count, size_t size) {
   return mem;
 }
 
+#include <cstdio>
+#include <cerrno>
 static inline void * __attribute__((used)) smmap(size_t size) {
   // TODO(reneme): make page size platform independent
   assert(size > 0);

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -843,7 +843,8 @@ TEST_F(T_Libcvmfs, Remount) {
   ReadPipe(pipe_send[0], &c, 1);
   if (c != '!') {
     DirSpec spec1 = MakeBaseSpec();
-    EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+    EXPECT_TRUE(
+      tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
     tester.UpdateManifest();
     tester.DestroyCatalogManager();
     WritePipe(pipe_recv[1], &c, 1);

--- a/test/unittests/t_libcvmfs.cc
+++ b/test/unittests/t_libcvmfs.cc
@@ -97,13 +97,19 @@ TEST_F(T_Libcvmfs, InitFailures) {
   stderr = fdevnull_;
   retval = cvmfs_init("bad option");
   stderr = save_stderr;
-  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   retval = cvmfs_init((opt_cache_ + ",max_open_files=100000000").c_str());
-  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   retval = cvmfs_init("");
-  ASSERT_EQ(LIBCVMFS_FAIL_MKCACHE, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_MKCACHE, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   sqlite3_shutdown();
 }
@@ -176,36 +182,50 @@ TEST_F(T_Libcvmfs, OptionAliases) {
 
   retval = cvmfs_init((opt_cache_ +
     ",nofiles=100000000,max_open_files=100000000").c_str());
-  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   retval = cvmfs_init((opt_cache_ + ",nofiles=100000000").c_str());
-  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   retval = cvmfs_init((opt_cache_ + ",max_open_files=100000000").c_str());
-  ASSERT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_NOFILES, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   stderr = fdevnull_;
   retval = cvmfs_init((opt_cache_ + ",nofiles=999,max_open_files=888").c_str());
   stderr = save_stderr;
-  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   stderr = fdevnull_;
   retval =
     cvmfs_init((opt_cache_ + ",syslog_level=0,log_syslog_level=1").c_str());
   stderr = save_stderr;
-  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   stderr = fdevnull_;
   retval =
     cvmfs_init((opt_cache_ + ",log_file=abc,logfile=efg").c_str());
   stderr = save_stderr;
-  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   stderr = fdevnull_;
   retval =
     cvmfs_init((opt_cache_ + ",cachedir=/abc").c_str());
   stderr = save_stderr;
-  ASSERT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  EXPECT_EQ(LIBCVMFS_FAIL_BADOPT, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   retval =
     cvmfs_init((opt_cache_ + ",cachedir=" + tmp_path_).c_str());
@@ -223,7 +243,10 @@ TEST_F(T_Libcvmfs, Initv2) {
   cvmfs_fini();
 
   cvmfs_options_set(opts, "CVMFS_NFILES", "100000000");
-  EXPECT_EQ(LIBCVMFS_ERR_PERMISSION, cvmfs_init_v2(opts));
+  int retval = cvmfs_init_v2(opts);
+  EXPECT_EQ(LIBCVMFS_ERR_PERMISSION, retval);
+  if (retval == LIBCVMFS_FAIL_OK)
+    cvmfs_fini();
 
   cvmfs_options_fini(opts);
 }
@@ -781,12 +804,23 @@ TEST_F(T_Libcvmfs, Remount) {
   pid_t pid;
   if ((pid = fork()) == 0) {
     // Initialize client repo based on options
-    ASSERT_EQ(LIBCVMFS_ERR_OK, cvmfs_init_v2(opts));
+    int retval = cvmfs_init_v2(opts);
+    EXPECT_EQ(LIBCVMFS_ERR_OK, retval);
+    if (retval != LIBCVMFS_ERR_OK) {
+      char c = '!';
+      WritePipe(pipe_send[1], &c, 1);
+      exit(1);
+    }
 
     // Attach to client repo
     cvmfs_context *ctx;
-    EXPECT_EQ(LIBCVMFS_ERR_OK,
-              cvmfs_attach_repo_v2("keys.cern.ch", opts, &ctx));
+    retval = cvmfs_attach_repo_v2("keys.cern.ch", opts, &ctx);
+    EXPECT_EQ(LIBCVMFS_ERR_OK, retval);
+    if (retval != LIBCVMFS_ERR_OK) {
+      char c = '!';
+      WritePipe(pipe_send[1], &c, 1);
+      exit(1);
+    }
 
     EXPECT_EQ(0u, cvmfs_get_revision(ctx));
     EXPECT_EQ(0, cvmfs_remount(ctx));
@@ -807,11 +841,13 @@ TEST_F(T_Libcvmfs, Remount) {
 
   char c;
   ReadPipe(pipe_send[0], &c, 1);
-  DirSpec spec1 = MakeBaseSpec();
-  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
-  tester.UpdateManifest();
-  tester.DestroyCatalogManager();
-  WritePipe(pipe_recv[1], &c, 1);
+  if (c != '!') {
+    DirSpec spec1 = MakeBaseSpec();
+    EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec1));
+    tester.UpdateManifest();
+    tester.DestroyCatalogManager();
+    WritePipe(pipe_recv[1], &c, 1);
+  }
 
   int retcode = WaitForChild(pid);
   EXPECT_EQ(0, retcode);


### PR DESCRIPTION
Fixes a faulty evaluation of `can_build_gateway`. Along the way, simplifies `can_build_ducc` to just use return codes instead of printed integers.