### PR TITLE
Workaround for OpenSSL issues on EL9

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -481,6 +481,17 @@ set (CVMFS_SWISSKNIFE_SOURCES
   xattr.cc
 )
 
+# TODO(jblomer): remove me
+set (CVMFS_SIGN_SOURCES
+  signature_offload.cc
+  hash.cc
+  logging.cc
+  signature.cc
+  util/exception.cc
+  util/posix.cc
+  util/string.cc
+)
+
 set (CVMFS_SUID_HELPER_SOURCES
   cvmfs_suid_helper.cc
   cvmfs_suid_util.cc
@@ -964,12 +975,18 @@ if (BUILD_SERVER)
   add_executable (cvmfs_suid_helper ${CVMFS_SUID_HELPER_SOURCES})
   add_library (cvmfs_server SHARED ${LIBCVMFS_SERVER_SOURCES})
   add_executable (cvmfs_publish ${CVMFS_PUBLISH_SOURCES})
+  add_executable (cvmfs_signing_helper ${CVMFS_SIGN_SOURCES})
 
   set_target_properties (cvmfs_swissknife PROPERTIES COMPILE_FLAGS "${CVMFS_SWISSKNIFE_CFLAGS}" LINK_FLAGS "${CVMFS_SWISSKNIFE_LD_FLAGS}")
   set_target_properties (cvmfs_server PROPERTIES
     VERSION ${CernVM-FS_VERSION_STRING}
     COMPILE_FLAGS "${LIBCVMFS_SERVER_CFLAGS}")
   set_target_properties (cvmfs_publish PROPERTIES COMPILE_FLAGS "${CVMFS_PUBLISH_CFLAGS}" LINK_FLAGS "${CVMFS_PUBLISH_LD_FLAGS}")
+  set_target_properties (cvmfs_signing_helper PROPERTIES
+                           COMPILE_FLAGS "${CVMFS_PUBLISH_CFLAGS}")
+  target_link_libraries (cvmfs_signing_helper
+                         ${SHA3_LIBRARIES}
+                         ${OPENSSL_LIBRARIES})
 
   # link the stuff (*_LIBRARIES are dynamic link libraries)
   set (LIBCVMFS_SERVER_LINK_LIBRARIES "")
@@ -1162,7 +1179,7 @@ endif(BUILD_RECEIVER)
 
 if (BUILD_SERVER)
   install (
-    TARGETS     cvmfs_swissknife cvmfs_publish
+    TARGETS     cvmfs_swissknife cvmfs_publish cvmfs_signing_helper
     RUNTIME
     DESTINATION    bin
   )

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -986,7 +986,8 @@ if (BUILD_SERVER)
                            COMPILE_FLAGS "${CVMFS_PUBLISH_CFLAGS}")
   target_link_libraries (cvmfs_signing_helper
                          ${SHA3_LIBRARIES}
-                         ${OPENSSL_LIBRARIES})
+                         ${OPENSSL_LIBRARIES}
+                         pthread dl)
 
   # link the stuff (*_LIBRARIES are dynamic link libraries)
   set (LIBCVMFS_SERVER_LINK_LIBRARIES "")

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -648,6 +648,7 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
   if ((settings.storage().type() != upload::SpoolerDefinition::Gateway) &&
       !settings.transaction().in_enter_session())
   {
+    signature_mgr_->SetSignOffload();
     int rvb = signature_mgr_->LoadCertificatePath(
       settings.keychain().certificate_path());
     if (!rvb)

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -648,7 +648,8 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
   if ((settings.storage().type() != upload::SpoolerDefinition::Gateway) &&
       !settings.transaction().in_enter_session())
   {
-    signature_mgr_->SetSignOffload();
+    if (settings.offload_signing())
+      signature_mgr_->SetSignOffload();
     int rvb = signature_mgr_->LoadCertificatePath(
       settings.keychain().certificate_path());
     if (!rvb)

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -373,6 +373,10 @@ void SettingsPublisher::SetIsManaged(bool value) {
   is_managed_ = value;
 }
 
+void SettingsPublisher::SetOffloadSigning(bool value) {
+  offload_signing_ = value;
+}
+
 
 //------------------------------------------------------------------------------
 

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -334,6 +334,7 @@ SettingsPublisher::SettingsPublisher(
   , whitelist_validity_days_(kDefaultWhitelistValidity)
   , is_silent_(false)
   , is_managed_(false)
+  , offload_signing_(true)
   , storage_(fqrn_())
   , transaction_(fqrn_())
   , keychain_(fqrn_())

--- a/cvmfs/publish/settings.h
+++ b/cvmfs/publish/settings.h
@@ -405,6 +405,7 @@ class SettingsPublisher {
     , whitelist_validity_days_(kDefaultWhitelistValidity)
     , is_silent_(false)
     , is_managed_(false)
+    , offload_signing_(true)
     , storage_(fqrn_())
     , transaction_(fqrn_())
     , keychain_(fqrn_())
@@ -417,6 +418,7 @@ class SettingsPublisher {
   void SetOwner(uid_t uid, gid_t gid);
   void SetIsSilent(bool value);
   void SetIsManaged(bool value);
+  void SetOffloadSigning(bool value);
 
   std::string GetReadOnlyXAttr(const std::string &attr);
 
@@ -430,6 +432,7 @@ class SettingsPublisher {
   uid_t owner_gid() const { return owner_gid_(); }
   bool is_silent() const { return is_silent_(); }
   bool is_managed() const { return is_managed_(); }
+  bool offload_signing() const { return offload_signing_(); }
 
   const SettingsStorage &storage() const { return storage_; }
   const SettingsTransaction &transaction() const { return transaction_; }
@@ -447,6 +450,7 @@ class SettingsPublisher {
   Setting<unsigned> whitelist_validity_days_;
   Setting<bool> is_silent_;
   Setting<bool> is_managed_;
+  Setting<bool> offload_signing_;
 
   SettingsStorage storage_;
   SettingsTransaction transaction_;

--- a/cvmfs/server_tool.cc
+++ b/cvmfs/server_tool.cc
@@ -81,6 +81,7 @@ bool ServerTool::InitSigningSignatureManager(
   signature_manager_ = new signature::SignatureManager();
   assert(signature_manager_.IsValid());
   signature_manager_->Init();
+  signature_manager_->SetSignOffload();
 
   // Load certificate
   if (!signature_manager_->LoadCertificatePath(certificate_path)) {

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -910,7 +910,7 @@ std::string SignatureManager::SignOffload(
     unsigned size;
     ReadPipe(pipe_output[0], &size, sizeof(size));
     result.resize(size);
-    ReadPipe(pipe_output[0], result.data(), size);
+    ReadPipe(pipe_output[0], reinterpret_cast<void *>(result.data()), size);
   }
 
   ClosePipe(pipe_input);

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -74,6 +74,7 @@ SignatureManager::SignatureManager() {
   x509_lookup_ = NULL;
   int retval = pthread_mutex_init(&lock_blacklist_, NULL);
   assert(retval == 0);
+  offload_signing_ = false;
 
   /*
     Note: OpenSSL 3.0 deprecated SHA1 signatures. This env override is needed
@@ -168,6 +169,12 @@ bool SignatureManager::LoadPrivateMasterKeyPath(const string &file_pem)
   return (private_master_key_ != NULL);
 }
 
+bool SignatureManager::LoadPrivateMasterKeyMem(const string &key)
+{
+  UnloadPrivateMasterKey();
+  return false;
+}
+
 
 /**
  * @param[in] file_pem File name of the PEM key file
@@ -188,6 +195,12 @@ bool SignatureManager::LoadPrivateKeyPath(const string &file_pem,
   result = (private_key_ = PEM_read_PrivateKey(fp, NULL, NULL, tmp)) != NULL;
   fclose(fp);
   return result;
+}
+
+bool SignatureManager::LoadPrivateKeyMem(const std::string &key)
+{
+  UnloadPrivateKey();
+  return false;
 }
 
 
@@ -745,6 +758,18 @@ bool SignatureManager::Sign(const unsigned char *buffer,
     return false;
   }
 
+  if (offload_signing_) {
+    std::string s = SignOffload(kSignManifest, buffer_size, buffer);
+    *signature_size = s.size();
+    if (!s.empty()) {
+      *signature = reinterpret_cast<unsigned char *>(smalloc(s.size()));
+      memcpy(*signature, s.data(), s.size());
+    } else {
+      *signature = NULL;
+    }
+    return !s.empty();
+  }
+
   bool result = false;
 #ifdef OPENSSL_API_INTERFACE_V11
   EVP_MD_CTX *ctx_ptr = EVP_MD_CTX_new();
@@ -793,6 +818,18 @@ bool SignatureManager::SignRsa(const unsigned char *buffer,
     return false;
   }
 
+  if (offload_signing_) {
+    std::string s = SignOffload(kSignWhitelist, buffer_size, buffer);
+    *signature_size = s.size();
+    if (!s.empty()) {
+      *signature = reinterpret_cast<unsigned char *>(smalloc(s.size()));
+      memcpy(*signature, s.data(), s.size());
+    } else {
+      *signature = NULL;
+    }
+    return !s.empty();
+  }
+
   unsigned char *to = (unsigned char *)smalloc(RSA_size(private_master_key_));
   unsigned char *from = (unsigned char *)smalloc(buffer_size);
   memcpy(from, buffer, buffer_size);
@@ -808,6 +845,54 @@ bool SignatureManager::SignRsa(const unsigned char *buffer,
   *signature = to;
   *signature_size = size;
   return true;
+}
+
+std::string SignatureManager::SignOffload(
+  ESignMethod method, size_t buf_size, const unsigned char *buf)
+{
+  std::vector<std::string> cmd;
+  cmd.push_back("/usr/bin/cvmfs_signing_helper");
+  std::set<int> preserve_filedes;
+  preserve_filedes.insert(0);
+  preserve_filedes.insert(1);
+
+  int pipe_input[2];
+  int pipe_output[2];
+  MakePipe(pipe_input);
+  MakePipe(pipe_output);
+  std::map<int, int> map_filedes;
+  map_filedes[pipe_input[0]] = 0;
+  map_filedes[pipe_output[1]] = 1;
+
+  std::string result;
+  bool retval = ManagedExec(cmd, preserve_filedes, map_filedes,
+                            true /* drop_credentials */,
+                            true /* clear_env */);
+  if (retval) {
+    WritePipe(pipe_input[1], &method, sizeof(method));
+    std::string key;
+    if (method == kSignManifest) {
+      key = GetPrivateKey();
+    } else if (method == kSignWhitelist) {
+      key = GetPrivateMasterKey();
+    } else {
+      assert(false);
+    }
+    size_t key_size = key.size();
+    WritePipe(pipe_input[1], &key_size, sizeof(key_size));
+    WritePipe(pipe_input[1], key.data(), key.size());
+    WritePipe(pipe_input[1], &buf_size, sizeof(buf_size));
+    WritePipe(pipe_input[1], buf, buf_size);
+
+    size_t size;
+    ReadPipe(pipe_output[0], &size, sizeof(size));
+    result.resize(size);
+    ReadPipe(pipe_output[0], result.data(), size);
+  }
+
+  ClosePipe(pipe_input);
+  ClosePipe(pipe_output);
+  return result;
 }
 
 

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -868,6 +868,12 @@ bool SignatureManager::SignRsa(const unsigned char *buffer,
 std::string SignatureManager::SignOffload(
   ESignMethod method, unsigned buf_size, const unsigned char *buf)
 {
+  if (!FileExists("/usr/bin/cvmfs_signing_helper")) {
+    LogCvmfs(kLogSignature, kLogDebug | kLogSyslogErr,
+             "missing signing helper");
+    return "";
+  }
+
   std::vector<std::string> cmd;
   cmd.push_back("/usr/bin/cvmfs_signing_helper");
   std::set<int> preserve_filedes;

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -172,7 +172,15 @@ bool SignatureManager::LoadPrivateMasterKeyPath(const string &file_pem)
 bool SignatureManager::LoadPrivateMasterKeyMem(const string &key)
 {
   UnloadPrivateMasterKey();
-  return false;
+  BIO *bp = BIO_new(BIO_s_mem());
+  assert(bp != NULL);
+  if (BIO_write(bp, key.data(), key.size()) <= 0) {
+    BIO_free(bp);
+    return false;
+  }
+  private_master_key_ = PEM_read_bio_RSAPrivateKey(bp, NULL, NULL, NULL);
+  BIO_free(bp);
+  return (private_master_key_ != NULL);
 }
 
 
@@ -200,7 +208,15 @@ bool SignatureManager::LoadPrivateKeyPath(const string &file_pem,
 bool SignatureManager::LoadPrivateKeyMem(const std::string &key)
 {
   UnloadPrivateKey();
-  return false;
+  BIO *bp = BIO_new(BIO_s_mem());
+  assert(bp != NULL);
+  if (BIO_write(bp, key.data(), key.size()) <= 0) {
+    BIO_free(bp);
+    return false;
+  }
+  private_key_ = PEM_read_bio_PrivateKey(bp, NULL, NULL, NULL);
+  BIO_free(bp);
+  return (private_key_ != NULL);
 }
 
 

--- a/cvmfs/signature.cc
+++ b/cvmfs/signature.cc
@@ -910,7 +910,7 @@ std::string SignatureManager::SignOffload(
     unsigned size;
     ReadPipe(pipe_output[0], &size, sizeof(size));
     result.resize(size);
-    ReadPipe(pipe_output[0], reinterpret_cast<void *>(result.data()), size);
+    ReadPipe(pipe_output[0], const_cast<char *>(result.data()), size);
   }
 
   ClosePipe(pipe_input);

--- a/cvmfs/signature.h
+++ b/cvmfs/signature.h
@@ -16,6 +16,8 @@
 #include <openssl/x509.h>
 
 #include <cstdio>
+#include <map>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/cvmfs/signature.h
+++ b/cvmfs/signature.h
@@ -25,6 +25,8 @@ namespace signature {
 
 class SignatureManager {
  public:
+  enum ESignMethod { kSignManifest, kSignWhitelist };
+
   SignatureManager();
 
   void Init();
@@ -39,6 +41,8 @@ class SignatureManager {
   bool LoadPrivateMasterKeyPath(const std::string &file_pem);
   bool LoadPrivateKeyPath(const std::string &file_pem,
                           const std::string &password);
+  bool LoadPrivateMasterKeyMem(const std::string &key);
+  bool LoadPrivateKeyMem(const std::string &key);
   bool LoadCertificatePath(const std::string &file_pem);
   bool LoadCertificateMem(const unsigned char *buffer,
                           const unsigned buffer_size);
@@ -56,6 +60,7 @@ class SignatureManager {
 
   bool LoadTrustedCaCrl(const std::string &path_list);
 
+  void SetSignOffload() { offload_signing_ = true; }
   bool Sign(const unsigned char *buffer, const unsigned buffer_size,
             unsigned char **signature, unsigned *signature_size);
   bool SignRsa(const unsigned char *buffer, const unsigned buffer_size,
@@ -93,6 +98,9 @@ class SignatureManager {
 
   void InitX509Store();
 
+  std::string SignOffload(ESignMethod method,
+                          size_t buf_size, const unsigned char *buf);
+
   EVP_PKEY *private_key_;
   RSA *private_master_key_;
   X509 *certificate_;
@@ -101,6 +109,7 @@ class SignatureManager {
   std::vector<std::string> blacklist_;
   X509_STORE *x509_store_;
   X509_LOOKUP *x509_lookup_;
+  bool offload_signing_;
 };  // class SignatureManager
 
 }  // namespace signature

--- a/cvmfs/signature.h
+++ b/cvmfs/signature.h
@@ -99,7 +99,7 @@ class SignatureManager {
   void InitX509Store();
 
   std::string SignOffload(ESignMethod method,
-                          size_t buf_size, const unsigned char *buf);
+                          unsigned buf_size, const unsigned char *buf);
 
   EVP_PKEY *private_key_;
   RSA *private_master_key_;

--- a/cvmfs/signature_offload.cc
+++ b/cvmfs/signature_offload.cc
@@ -7,18 +7,67 @@
  * cannot use SignatureManager::Sign themselves even with the environemnt
  * variable OPENSSL_ENABLE_SHA1_SIGNATURES defined.
  * It buys us time until a proper fix is found.
+ *
+ * This utility reads the private key and the buffer to sign from stdin and
+ * writes the signature to stdout. In case of errors, it writes an empty
+ * signature.
  */
+
+#include <string>
 
 #include "signature.h"
 #include "util/posix.h"
 
+static std::string ReadString() {
+  unsigned size;
+  ReadPipe(0, &size, sizeof(size));
+  std::string result;
+  result.resize(size);
+  ReadPipe(0, result.data(), size);
+  return result;
+}
+
 int main() {
+  signature::SignatureManager::ESignMethod method;
+  ReadPipe(0, &method, sizeof(method));
+  std::string key = ReadString();
+  std::string buffer = ReadString();
+
   signature::SignatureManager smgr;
   smgr.Init();
 
-  signature::SignatureManager::ESignMethod method;
-  ReadPipe(0, &method, sizeof(method));
+  unsigned char *signature = NULL;
+  unsigned signature_size = 0;
 
+  bool rv_key = false;
+  if (method == signature::SignatureManager::kSignWhitelist) {
+    rv_key = smgr.LoadPrivateMasterKeyMem(key);
+  } else if (method == signature::SignatureManager::kSignManifest) {
+    rv_key = smgr.LoadPrivateKeyMem(key);
+  }
+  if (!rv_key) {
+    WritePipe(1, &signature_size, sizeof(signature_size));
+    smgr.Fini();
+    return 1;
+  }
+
+  bool rv_sign = false;
+  if (method == signature::SignatureManager::kSignWhitelist) {
+    rv_sign = smgr.SignRsa(reinterpret_cast<unsigned char *>(buffer.data()),
+                           buffer.size(), &signature, &signature_size);
+  } else if (method == signature::SignatureManager::kSignManifest) {
+    rv_sign = smgr.Sign(reinterpret_cast<unsigned char *>(buffer.data()),
+                        buffer.size(), &signature, &signature_size);
+  }
+  if (!rv_sign) {
+    WritePipe(1, &signature_size, sizeof(signature_size));
+    smgr.Fini();
+    return 1;
+  }
+
+  WritePipe(1, &signature_size, sizeof(signature_size));
+  WritePipe(1, signature, signature_size);
+  free(signature);
 
   smgr.Fini();
   return 0;

--- a/cvmfs/signature_offload.cc
+++ b/cvmfs/signature_offload.cc
@@ -53,11 +53,13 @@ int main() {
 
   bool rv_sign = false;
   if (method == signature::SignatureManager::kSignWhitelist) {
-    rv_sign = smgr.SignRsa(reinterpret_cast<unsigned char *>(buffer.data()),
-                           buffer.size(), &signature, &signature_size);
+    rv_sign = smgr.SignRsa(
+      reinterpret_cast<unsigned char *>(const_cast<char *>(buffer.data())),
+      buffer.size(), &signature, &signature_size);
   } else if (method == signature::SignatureManager::kSignManifest) {
-    rv_sign = smgr.Sign(reinterpret_cast<unsigned char *>(buffer.data()),
-                        buffer.size(), &signature, &signature_size);
+    rv_sign = smgr.Sign(
+      reinterpret_cast<unsigned char *>(const_cast<char *>(buffer.data())),
+      buffer.size(), &signature, &signature_size);
   }
   if (!rv_sign) {
     WritePipe(1, &signature_size, sizeof(signature_size));

--- a/cvmfs/signature_offload.cc
+++ b/cvmfs/signature_offload.cc
@@ -1,0 +1,16 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * A standalone utility that executes SignatureManager::Sign().
+ * This is a transitional workaround for EL9 / OpenSSL 3; it is necessary
+ * because setuid binaries (and binaries with elevated file capailities)
+ * cannot use SignatureManager::Sign themselves even with the environemnt
+ * variable OPENSSL_ENABLE_SHA1_SIGNATURES defined.
+ * It buys us time until a proper fix is found.
+ */
+
+#include "signature.h"
+
+int main() {
+  return 0;
+}

--- a/cvmfs/signature_offload.cc
+++ b/cvmfs/signature_offload.cc
@@ -10,7 +10,16 @@
  */
 
 #include "signature.h"
+#include "util/posix.h"
 
 int main() {
+  signature::SignatureManager smgr;
+  smgr.Init();
+
+  signature::SignatureManager::ESignMethod method;
+  ReadPipe(0, &method, sizeof(method));
+
+
+  smgr.Fini();
   return 0;
 }

--- a/cvmfs/signature_offload.cc
+++ b/cvmfs/signature_offload.cc
@@ -23,7 +23,7 @@ static std::string ReadString() {
   ReadPipe(0, &size, sizeof(size));
   std::string result;
   result.resize(size);
-  ReadPipe(0, reinterpret_cast<void *>(result.data()), size);
+  ReadPipe(0, const_cast<char *>(result.data()), size);
   return result;
 }
 

--- a/cvmfs/signature_offload.cc
+++ b/cvmfs/signature_offload.cc
@@ -23,7 +23,7 @@ static std::string ReadString() {
   ReadPipe(0, &size, sizeof(size));
   std::string result;
   result.resize(size);
-  ReadPipe(0, result.data(), size);
+  ReadPipe(0, reinterpret_cast<void *>(result.data()), size);
   return result;
 }
 

--- a/packaging/debian/cvmfs/cvmfs-server.install.in
+++ b/packaging/debian/cvmfs/cvmfs-server.install.in
@@ -2,6 +2,7 @@ usr/bin/cvmfs_publish
 usr/bin/cvmfs_publish_debug
 usr/bin/cvmfs_receiver
 usr/bin/cvmfs_receiver_debug
+usr/bin/cvmfs_signing_helper
 usr/bin/cvmfs_swissknife
 usr/bin/cvmfs_swissknife_debug
 usr/bin/cvmfs_suid_helper

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -633,6 +633,7 @@ systemctl daemon-reload
 %{_bindir}/cvmfs_publish_debug
 %{_bindir}/cvmfs_receiver
 %{_bindir}/cvmfs_receiver_debug
+%{_bindir}/cvmfs_signing_helper
 %{_bindir}/cvmfs_swissknife
 %{_bindir}/cvmfs_swissknife_debug
 %{_bindir}/cvmfs_suid_helper

--- a/test/unittests/publish/c_repository.cc
+++ b/test/unittests/publish/c_repository.cc
@@ -16,6 +16,7 @@ publish::Publisher *GetTestPublisher() {
   std::string keys_dir = base_dir + "/keys";
 
   publish::SettingsPublisher settings("test.cvmfs.io");
+  settings.SetOffloadSigning(false);
   settings.SetIsSilent(true);
   settings.SetOwner(GetUserName());
   settings.GetStorage()->MakeLocal(srv_dir);

--- a/test/unittests/t_signature.cc
+++ b/test/unittests/t_signature.cc
@@ -84,4 +84,30 @@ TEST_F(T_Signature, Export) {
   free(signature);
 }
 
+TEST_F(T_Signature, GetSetKeys) {
+  sign_mgr_.GenerateMasterKeyPair();
+  sign_mgr_.GenerateCertificate("test.cvmfs.io");
+  EXPECT_TRUE(sign_mgr_.KeysMatch());
+
+  const unsigned char *buffer = reinterpret_cast<const unsigned char *>("abc");
+  unsigned char *signature;
+  unsigned signature_size;
+  EXPECT_TRUE(sign_mgr_.SignRsa(buffer, 3, &signature, &signature_size));
+  EXPECT_TRUE(sign_mgr_.VerifyRsa(buffer, 3, signature, signature_size));
+  free(signature);
+  EXPECT_TRUE(sign_mgr_.Sign(buffer, 3, &signature, &signature_size));
+  EXPECT_TRUE(sign_mgr_.Verify(buffer, 3, signature, signature_size));
+  free(signature);
+
+  EXPECT_TRUE(
+    sign_mgr_.LoadPrivateMasterKeyMem(sign_mgr_.GetPrivateMasterKey()));
+  EXPECT_TRUE(sign_mgr_.LoadPrivateKeyMem(sign_mgr_.GetPrivateKey()));
+  EXPECT_TRUE(sign_mgr_.SignRsa(buffer, 3, &signature, &signature_size));
+  EXPECT_TRUE(sign_mgr_.VerifyRsa(buffer, 3, signature, signature_size));
+  free(signature);
+  EXPECT_TRUE(sign_mgr_.Sign(buffer, 3, &signature, &signature_size));
+  EXPECT_TRUE(sign_mgr_.Verify(buffer, 3, signature, signature_size));
+  free(signature);
+}
+
 }  // namespace signature

--- a/test/unittests/t_signature.cc
+++ b/test/unittests/t_signature.cc
@@ -110,4 +110,28 @@ TEST_F(T_Signature, GetSetKeys) {
   free(signature);
 }
 
+TEST_F(T_Signature, Offload) {
+  if (!FileExists("/usr/bin/cvmfs_signing_helper")) {
+    printf("Signing helper not installed, skipping\n");
+    return;
+  }
+  sign_mgr_.SetSignOffload();
+
+  sign_mgr_.GenerateMasterKeyPair();
+  sign_mgr_.GenerateCertificate("test.cvmfs.io");
+  EXPECT_TRUE(sign_mgr_.KeysMatch());
+  const unsigned char *buffer = reinterpret_cast<const unsigned char *>("abc");
+  unsigned char *signature;
+  unsigned signature_size;
+  EXPECT_TRUE(sign_mgr_.SignRsa(buffer, 3, &signature, &signature_size));
+  EXPECT_TRUE(sign_mgr_.VerifyRsa(buffer, 3, signature, signature_size));
+  free(signature);
+
+  std::string key = sign_mgr_.GetPrivateKey();
+  sign_mgr_.GenerateCertificate("new.cvmfs.io");
+  EXPECT_TRUE(sign_mgr_.KeysMatch());
+  sign_mgr_.LoadPrivateKeyMem(key);
+  EXPECT_FALSE(sign_mgr_.KeysMatch());
+}
+
 }  // namespace signature


### PR DESCRIPTION
Adds a new binary `cvmfs_signing_helper`. This helper does not have any elevated privileges so that the `OPENSSL_ENABLE_SHA1_SIGNATURES` environment variable is effective. It is called from `cvmfs_swissknife` and `cvmfs_publish` so that the manifest and the whitelist can be signed on EL9 publishers.

That's not a great workaround.  It should buy us some time for a better fix.