### PR TITLE
Propose Github as the preferred issue tracker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome code contributions!
 
-If you are about to develop a bug fix or a new feature, it could be helpful to let us know about it beforehand, for instance on the cvmfs-devel@cern.ch mailing list or by private mail or through our [ticket tracker](https://sft.its.cern.ch/jira/browse/CVM).  This can avoid duplicated work and allows us to coordinate the developemnt.
+If you are about to develop a bug fix or a new feature, it could be helpful to let us know about it beforehand, for instance on the cvmfs-devel@cern.ch mailing list or by private mail or through our [ticket tracker](https://github.com/cvmfs/cvmfs).  This can avoid duplicated work and allows us to coordinate the developemnt.
 
 
 # Source Code Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome code contributions!
 
-If you are about to develop a bug fix or a new feature, it could be helpful to let us know about it beforehand, for instance on the cvmfs-devel@cern.ch mailing list or by private mail or through our [ticket tracker](https://github.com/cvmfs/cvmfs).  This can avoid duplicated work and allows us to coordinate the developemnt.
+If you are about to develop a bug fix or a new feature, it could be helpful to let us know about it beforehand, for instance on the cvmfs-devel@cern.ch mailing list or by private mail or through our [ticket tracker](https://github.com/cvmfs/cvmfs/issues).  This can avoid duplicated work and allows us to coordinate the developemnt.
 
 
 # Source Code Workflow

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1481,7 +1481,7 @@ cvmfs_bugreport() {
    echo
    echo "System information has been collected in ${tmpdir}/cvmfs-bugreport.tar.gz"
    echo "Please attach this file to your problem description and send it as a"
-   echo "bug report to https://github.com/cvmfs/cvmfs"
+   echo "bug report to https://github.com/cvmfs/cvmfs/issues"
 }
 
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1481,7 +1481,7 @@ cvmfs_bugreport() {
    echo
    echo "System information has been collected in ${tmpdir}/cvmfs-bugreport.tar.gz"
    echo "Please attach this file to your problem description and send it as a"
-   echo "JIRA bug report to https://sft.its.cern.ch/jira/browse/CVM"
+   echo "bug report to https://github.com/cvmfs/cvmfs"
 }
 
 

--- a/doc/parrot.md
+++ b/doc/parrot.md
@@ -72,7 +72,7 @@ In order to share this directory among multiple users, the users have to belong 
 
 ## Bugs and Problems
 
-For feedback and bug reports, please write to either the [cctools mailing list](http://ccl.cse.nd.edu/software/help/) or to the [CernVM-FS support](https://github.com/cvmfs/cvmfs).
+For feedback and bug reports, please write to either the [cctools mailing list](http://ccl.cse.nd.edu/software/help/) or to the [CernVM-FS support](https://github.com/cvmfs/cvmfs/issues).
 
 
 ## Compiling from Sources

--- a/doc/parrot.md
+++ b/doc/parrot.md
@@ -72,7 +72,7 @@ In order to share this directory among multiple users, the users have to belong 
 
 ## Bugs and Problems
 
-For feedback and bug reports, please write to either the [cctools mailing list](http://ccl.cse.nd.edu/software/help/) or to the [CernVM-FS support](https://sft.its.cern.ch/jira/browse/CVM).
+For feedback and bug reports, please write to either the [cctools mailing list](http://ccl.cse.nd.edu/software/help/) or to the [CernVM-FS support](https://github.com/cvmfs/cvmfs).
 
 
 ## Compiling from Sources


### PR DESCRIPTION
Replace links to CERN's Jira tracker by Github, following a private comment from @radupopescu 