### PR TITLE
Add CVMFS_WORLD_READABLE to make repo contents globally readable

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -749,6 +749,14 @@ DirectoryEntry SqlLookup::GetDirent(const Catalog *catalog,
   if (expand_symlink && !g_raw_symlinks)
     ExpandSymlink(&result.symlink_);
 
+  if (g_world_readable) {
+    if( S_ISDIR( result.mode_ ) ) {
+       result.mode_ |= 0555;
+    } else {
+       result.mode_ |= 0444;
+    }
+  }
+
   return result;
 }
 

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -750,7 +750,7 @@ DirectoryEntry SqlLookup::GetDirent(const Catalog *catalog,
     ExpandSymlink(&result.symlink_);
 
   if (g_world_readable) {
-    if( S_ISDIR( result.mode_ ) ) {
+    if (S_ISDIR(result.mode_)) {
        result.mode_ |= 0555;
     } else {
        result.mode_ |= 0444;

--- a/cvmfs/globals.cc
+++ b/cvmfs/globals.cc
@@ -12,6 +12,7 @@ bool g_claim_ownership = false;
 bool g_raw_symlinks = false;
 uid_t g_uid = 0;
 gid_t g_gid = 0;
+bool g_world_readable = false;
 
 #ifdef CVMFS_NAMESPACE_GUARD
 }

--- a/cvmfs/globals.cc
+++ b/cvmfs/globals.cc
@@ -15,5 +15,5 @@ gid_t g_gid = 0;
 bool g_world_readable = false;
 
 #ifdef CVMFS_NAMESPACE_GUARD
-}
+}  // namespace CVMFS_NAMESPACE_GUARD
 #endif

--- a/cvmfs/globals.h
+++ b/cvmfs/globals.h
@@ -18,7 +18,7 @@ extern gid_t g_gid;
 extern bool g_world_readable;
 
 #ifdef CVMFS_NAMESPACE_GUARD
-}
+}  // namespace CVMFS_NAMESPACE_GUARD
 #endif
 
 #endif  // CVMFS_GLOBALS_H_

--- a/cvmfs/globals.h
+++ b/cvmfs/globals.h
@@ -15,6 +15,7 @@ extern bool g_claim_ownership;
 extern bool g_raw_symlinks;
 extern uid_t g_uid;
 extern gid_t g_gid;
+extern bool g_world_readable;
 
 #ifdef CVMFS_NAMESPACE_GUARD
 }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -2017,6 +2017,13 @@ bool MountPoint::SetupOwnerMaps() {
   {
     g_claim_ownership = true;
   }
+  if (options_mgr_->GetValue("CVMFS_WORLD_READABLE", &optarg) &&
+      options_mgr_->IsOn(optarg))
+  {
+    g_world_readable = true;
+  }
+
+
 
   return true;
 }

--- a/test/src/704-world_readable/main
+++ b/test/src/704-world_readable/main
@@ -1,0 +1,84 @@
+cvmfs_test_name="World readable repository access"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+TEST704_PRIVATE_MOUNT=
+TEST704_PIDS=
+CVMFS_TEST_704_OSXMOUNTPOINT=
+
+source ./src/704-world_readable/setup_teardown
+
+# for fuse 2
+# checks that
+# 1) symlinks are not cached in kernel
+check_is_world_readable() {
+  local mntpnt="$1"
+
+
+  echo ""
+  echo "*** START Testing check_is_world_readable"
+
+  echo "Mounting repo..."
+  private_mount_world_readable $mntpnt || return $?
+
+  echo "Testing repo access... (should be possible)"
+  ls -ld $mntpnt/test1.txt  | grep -qe ^-r--r--r--
+  [ $? = "0" ] || return 11
+
+  ls -ld $mntpnt/testdir  | grep -qe ^dr-xr-xr-x
+  [ $? = "0" ] || return 12
+
+  ls -ld $mntpnt/testdir/test2.txt  | grep -qe ^-r--r--r--
+  [ $? = "0" ] || return 13
+
+  echo ""
+  echo "  *** Unmount repo"
+  private_unmount
+  echo "*** FINISHED Testing check_is_world_readable"
+  echo ""
+}
+
+check_is_not_world_readable() {
+  local mntpnt="$1"
+
+
+  echo ""
+  echo "*** START Testing check_is_not_world_readable"
+
+  echo "Mounting repo..."
+  private_mount_not_world_readable $mntpnt || return $?
+
+  echo "Testing repo access... (should not be possible)"
+  ls -ld $mntpnt/test1.txt  | grep -qe ^-r--------
+  [ $? = "0" ] || return 21
+
+  ls -ld $mntpnt/testdir  | grep -qe ^dr-x------
+  [ $? = "0" ] || return 22
+
+  ls -ld $mntpnt/testdir/test2.txt  | grep -qe ^-r--------
+  [ $? = "0" ] || return 23
+
+  echo ""
+  echo "  *** Unmount repo"
+  private_unmount
+  echo "*** FINISHED Testing check_is_not_world_readable"
+  echo ""
+}
+
+cvmfs_run_test() {
+  logfile=$1
+
+  local scratch_dir=$(pwd)
+  local mntpnt="${scratch_dir}/private_mnt"
+  local config_file_path="${scratch_dir}/${CVMFS_TEST_REPO}.config.txt"
+
+  echo "*** Set a trap for system directory cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  create_world_readable_repo || return $?
+
+  check_is_world_readable ${mntpnt} || return $?
+  check_is_not_world_readable ${mntpnt} || return $?
+
+  return 0
+}

--- a/test/src/704-world_readable/setup_teardown
+++ b/test/src/704-world_readable/setup_teardown
@@ -1,0 +1,80 @@
+create_world_readable_repo() {
+  echo ""
+  echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  local short_name="$1"
+  local long_name="$2"
+  local symlink_name="$3"  
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  touch /cvmfs/$CVMFS_TEST_REPO/test1.txt
+  mkdir /cvmfs/$CVMFS_TEST_REPO/testdir
+  touch /cvmfs/$CVMFS_TEST_REPO/testdir/test2.txt
+
+  chmod 0400 /cvmfs/$CVMFS_TEST_REPO/test1.txt
+  chmod 0400 /cvmfs/$CVMFS_TEST_REPO/testdir/test2.txt
+  chmod 0500 /cvmfs/$CVMFS_TEST_REPO/testdir
+
+  publish_repo $CVMFS_TEST_REPO || return 200
+  echo "*** FINISHED creating a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  echo ""
+}
+
+# add_some_tmp_file_to_repo() {
+#   echo "Adding some random file to the repo $CVMFS_TEST_REPO"
+#   start_transaction $CVMFS_TEST_REPO || return $?
+#   local tmpfile="$(mktemp /cvmfs/$CVMFS_TEST_REPO/tmpfile.XXXXX)"
+#   publish_repo $CVMFS_TEST_REPO || return 200
+# }
+
+private_mount_world_readable() {
+  local mntpnt="$1"
+  local fuse_version="$2"
+  local config_file_path="$3"
+  TEST704_PRIVATE_MOUNT="$mntpnt"
+
+  local mount_options="rw,system_mount,fsname=cvmfs2"
+
+  do_local_mount_as_root "$mntpnt"          \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_WORLD_READABLE=ON
+CVMFS_SYSLOG_LEVEL=2" \
+                 "$mount_options" || return 1
+}
+
+private_mount_not_world_readable() {
+  local mntpnt="$1"
+  local fuse_version="$2"
+  local config_file_path="$3"
+  TEST704_PRIVATE_MOUNT="$mntpnt"
+
+  local mount_options="rw,system_mount,fsname=cvmfs2"
+
+  do_local_mount_as_root "$mntpnt"          \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_WORLD_READABLE=OFF
+CVMFS_SYSLOG_LEVEL=2" \
+                 "$mount_options" || return 1
+}
+
+
+private_unmount() {
+  sudo umount $TEST704_PRIVATE_MOUNT
+  TEST704_PRIVATE_MOUNT=
+}
+
+cleanup() {
+  echo "running cleanup()..."
+  if [ "x$TEST704_PIDS" != "x" ]; then
+    sudo kill -9 $TEST704_PIDS
+  fi
+  if [ "x$TEST704_PRIVATE_MOUNT" != "x" ]; then
+    private_unmount
+  fi
+}


### PR DESCRIPTION
We have a use case for which it is desirable to override the posix permissions encoded in the repo, and make all files globally readable. This patch adds the binary configuration option `CVMFS_WORLD_READABLE` to enable this. It is patterned after `CVMFS_CLAIM_OWNERSHIP` which it is used in conjunction with.
