### PR TITLE
Fix Log2Histogram->Add() header

### DIFF
--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -143,7 +143,7 @@ friend class UTLog2Histogram;
  public:
   explicit Log2Histogram(unsigned int nbins);
 
-  void Add(unsigned int value) {
+  void Add(uint64_t value) {
     unsigned int i;
     const unsigned int n = this->bins_.size() - 1;
 


### PR DESCRIPTION
The parameter sent to the histogram `Add()` function is usualy the difference between two uint64_t values (returned by `platform_monotonic_ns()`). Currently, the header declares a 32 bits integer parameter. This may cause an overflow when callbacks take longer than 2^32-1 ns and can generate eronate results.
This PR fixes the function header.

This is a prerequisite for the future timer support https://github.com/cvmfs/cvmfs/pull/3018.