### PR TITLE
Fix compile error "'time' was not declared in this scope"

### DIFF
--- a/cvmfs/authz/helper_log.cc
+++ b/cvmfs/authz/helper_log.cc
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 
 using namespace std;  // NOLINT
 


### PR DESCRIPTION
In Archlinux with gcc 12.2.0 we see a compilation error that seems to come from a missing `<ctime>` include. More details can be found in https://aur.archlinux.org/packages/cvmfs#comment-879961.

This PR fixes the issue.