### PR TITLE
Add support for symlink kernel caching

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1649,15 +1649,20 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
       conn->want |= FUSE_CAP_CACHE_SYMLINKS;
       LogCvmfs(kLogCvmfs, kLogDebug, "FUSE: "
                                     "Enable symlink caching");
+      #ifndef FUSE_CAP_EXPIRE_ONLY
+        LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
+          "FUSE: Symlink caching enabled but no support for fuse_expire_entry, "
+          "mountpoints on top of symlinks will break!");
+      #endif
     } else {
       mount_point_->DisableCacheSymlinks();
-      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
+      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
            "FUSE: Symlink caching requested but missing fuse kernel support, "
            "falling back to no caching");
     }
 #else
     mount_point_->DisableCacheSymlinks();
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
           "FUSE: Symlink caching requested but missing libfuse support, "
           "falling back to no caching");
 #endif
@@ -1668,6 +1673,10 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
     mount_point_->EnableFuseExpireEntry();
     LogCvmfs(kLogCvmfs, kLogDebug, "FUSE: "
                                    "Enable fuse_expire_entry");
+  } else if (mount_point_->cache_symlinks()) {
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
+      "FUSE: Symlink caching enabled but no support for fuse_expire_entry, "
+      "mountpoints on top of symlinks will break!");
   }
 #endif
 }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -466,7 +466,7 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   // 076 fails with the following line uncommented
   //
   // WARNING! ENABLING THIS BREAKS ANY TYPE OF MOUNTPOINT POINTING TO THIS INODE
-  if (mount_point_->cache_symlinks() && dirent.IsLink()) { 
+  if (mount_point_->cache_symlinks() && dirent.IsLink()) {
     mount_point_->dentry_tracker()->Add(parent_fuse, name, uint64_t(timeout));
   }
 
@@ -1641,7 +1641,7 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
 
   if ( mount_point_->cache_symlinks() ) {
 #if FUSE_VERSION >= 310
-    if( (conn->capable & FUSE_CAP_CACHE_SYMLINKS) == 0 ) {
+    if ((conn->capable & FUSE_CAP_CACHE_SYMLINKS) == 0) {
       mount_point_->DisableCacheSymlinks();
       LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
            "Symlink caching requested but missing fuse kernel support, "
@@ -1656,7 +1656,6 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
            "falling back to no caching");
 #endif
   }
-
 }
 
 static void cvmfs_destroy(void *unused __attribute__((unused))) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -471,7 +471,8 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   if (mount_point_->fuse_expire_entry()
       || (mount_point_->cache_symlinks() && dirent.IsLink())) {
     LogCvmfs(kLogCache, kLogDebug, "Dentry to evict: %s", name);
-    mount_point_->dentry_tracker()->Add(parent_fuse, name, uint64_t(timeout));
+    mount_point_->dentry_tracker()->Add(parent_fuse, name,
+                                        static_cast<uint64_t>(timeout));
   }
 
   fuse_remounter_->fence()->Leave();

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -466,7 +466,7 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   // 076 fails with the following line uncommented
   //
   // WARNING! ENABLING THIS BREAKS ANY TYPE OF MOUNTPOINT POINTING TO THIS INODE
-  if (mount_point_->cache_symlinks()) { // && dirent.IsLink()) {
+  if (mount_point_->cache_symlinks()) {  //  && dirent.IsLink()) {
     LogCvmfs(kLogCache, kLogDebug, "Dentry to evict: %s", name);
     mount_point_->dentry_tracker()->Add(parent_fuse, name, uint64_t(timeout));
   }
@@ -1644,7 +1644,7 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
 #if FUSE_VERSION >= 310
     if ((conn->capable & FUSE_CAP_CACHE_SYMLINKS) == 0) {
       mount_point_->DisableCacheSymlinks();
-      LogCvmfs(kLogCvmfs, kLogDebug, //kLogDebug | kLogSyslogErr,
+      LogCvmfs(kLogCvmfs, kLogDebug,  // kLogDebug | kLogSyslogErr,
            "Symlink caching requested but missing fuse kernel support, "
            "falling back to no caching");
     }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -466,7 +466,8 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   // 076 fails with the following line uncommented
   //
   // WARNING! ENABLING THIS BREAKS ANY TYPE OF MOUNTPOINT POINTING TO THIS INODE
-  if (mount_point_->cache_symlinks() && dirent.IsLink()) {
+  if (mount_point_->cache_symlinks()) { // && dirent.IsLink()) {
+    LogCvmfs(kLogCache, kLogDebug, "Dentry to evict: %s", name);
     mount_point_->dentry_tracker()->Add(parent_fuse, name, uint64_t(timeout));
   }
 
@@ -1643,15 +1644,15 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
 #if FUSE_VERSION >= 310
     if ((conn->capable & FUSE_CAP_CACHE_SYMLINKS) == 0) {
       mount_point_->DisableCacheSymlinks();
-      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
+      LogCvmfs(kLogCvmfs, kLogDebug, //kLogDebug | kLogSyslogErr,
            "Symlink caching requested but missing fuse kernel support, "
            "falling back to no caching");
     }
     conn->want |= FUSE_CAP_CACHE_SYMLINKS;
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog, "enabling symlink caching");
+    LogCvmfs(kLogCvmfs, kLogDebug, "enabling symlink caching");
 #else
     mount_point_->DisableCacheSymlinks();
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
+    LogCvmfs(kLogCvmfs, kLogDebug,
            "Symlink caching requested but fuse version not >=3.10, "
            "falling back to no caching");
 #endif

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -466,7 +466,7 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   // 076 fails with the following line uncommented
   //
   // WARNING! ENABLING THIS BREAKS ANY TYPE OF MOUNTPOINT POINTING TO THIS INODE
-  // 
+  //
   // only safe if fuse_expire_entry is available
   if (mount_point_->fuse_expire_entry()
       || (mount_point_->cache_symlinks() && dirent.IsLink())) {
@@ -1660,7 +1660,7 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
           "FUSE: Symlink caching requested but missing libfuse support, "
           "falling back to no caching");
-#endif 
+#endif
   }
 
 #ifdef FUSE_CAP_EXPIRE_ONLY

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1633,6 +1633,22 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
           "libfuse, aborting");
 #endif
   }
+
+  if ( mount_point_->cache_symlinks() ) {
+#if FUSE_VERSION >= 310
+    if( (conn->capable & FUSE_CAP_CACHE_SYMLINK) == 0 ) {
+      PANIC(kLogDebug | kLogSyslogErr,
+           "Symlink caching requested but missing fuse kernel support, "
+           "aborting");
+    }
+    conn->want |= FUSE_CAP_CACHE_SYMLINK;
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog, "enabling symlink caching");
+#else
+    PANIC(kLogDebug | kLogSyslogErr,
+           "Symlink caching requested but libfuse too old (>=3.10.0 required)" );
+#endif
+  }
+
 }
 
 static void cvmfs_destroy(void *unused __attribute__((unused))) {

--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -15,6 +15,11 @@
     // Empty structs have different sizes in C and C++, hence the dummy int
     struct fuse_chan { int dummy; };
     struct fuse_lowlevel_ops { int dummy; };  // for loader.h
+    enum fuse_expire_flags {
+        FUSE_LL_EXPIRE_ONLY     = (1 << 0),
+    };
+
+
     // Defined in t_fuse_evict.cc
     extern unsigned fuse_lowlevel_notify_inval_inode_cnt;
     extern unsigned fuse_lowlevel_notify_inval_entry_cnt;
@@ -26,6 +31,12 @@
     }
     static int __attribute__((used)) fuse_lowlevel_notify_inval_entry(
       void *, unsigned /*fuse_ino_t*/, const char *, size_t)  // NOLINT
+    {
+      fuse_lowlevel_notify_inval_entry_cnt++;
+      return -1;
+    }
+    static int __attribute__((used)) fuse_lowlevel_notify_expire_entry(
+      void *, unsigned /*fuse_ino_t*/, const char *, size_t, enum fuse_expire_flags)  // NOLINT
     {
       fuse_lowlevel_notify_inval_entry_cnt++;
       return -1;

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -204,9 +204,11 @@ void *FuseInvalidator::MainInvalidator(void *data) {
         entry_parent, entry_name.GetChars(), entry_name.GetLength());
 #else
 #ifdef FUSE_CAP_DENTRY_EXPIRE_ONLY
-      fuse_lowlevel_notify_expire_entry(*reinterpret_cast<struct fuse_session**>(
+      fuse_lowlevel_notify_expire_entry(
+        *reinterpret_cast<struct fuse_session**>(
         invalidator->fuse_channel_or_session_),
-        entry_parent, entry_name.GetChars(), entry_name.GetLength(), fuse_expire_flags::FUSE_LL_EXPIRE_ONLY);
+        entry_parent, entry_name.GetChars(), entry_name.GetLength(),
+        fuse_expire_flags::FUSE_LL_EXPIRE_ONLY);
 #else
       fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_session**>(
         invalidator->fuse_channel_or_session_),

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -203,9 +203,15 @@ void *FuseInvalidator::MainInvalidator(void *data) {
         invalidator->fuse_channel_or_session_),
         entry_parent, entry_name.GetChars(), entry_name.GetLength());
 #else
+#ifdef FUSE_CAP_DENTRY_EXPIRE_ONLY
+      fuse_lowlevel_notify_expire_entry(*reinterpret_cast<struct fuse_session**>(
+        invalidator->fuse_channel_or_session_),
+        entry_parent, entry_name.GetChars(), entry_name.GetLength(), fuse_expire_flags::FUSE_LL_EXPIRE_ONLY);
+#else
       fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_session**>(
         invalidator->fuse_channel_or_session_),
         entry_parent, entry_name.GetChars(), entry_name.GetLength());
+#endif
 #endif
       if ((++i % kCheckTimeoutFreqOps) == 0) {
         if (atomic_read32(&invalidator->terminated_) == 1) {

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -153,14 +153,19 @@ void *FuseInvalidator::MainInvalidator(void *data) {
       if (inode == 0)
         inode = FUSE_ROOT_ID;
       // Can fail, e.g. the inode might be already evicted
+
+      int dbg_retval;
+
 #if CVMFS_USE_LIBFUSE == 2
-      fuse_lowlevel_notify_inval_inode(*reinterpret_cast<struct fuse_chan**>(
+      dbg_retval = fuse_lowlevel_notify_inval_inode(*reinterpret_cast<struct fuse_chan**>(
         invalidator->fuse_channel_or_session_), inode, 0, 0);
 #else
-      fuse_lowlevel_notify_inval_inode(*reinterpret_cast<struct fuse_session**>(
+      dbg_retval = fuse_lowlevel_notify_inval_inode(*reinterpret_cast<struct fuse_session**>(
         invalidator->fuse_channel_or_session_), inode, 0, 0);
 #endif
-      LogCvmfs(kLogCvmfs, kLogDebug, "evicting inode %" PRIu64, inode);
+      LogCvmfs(kLogCvmfs, kLogDebug, "evicting inode %" PRIu64 " with retval: %d", inode, dbg_retval);
+
+      (void) dbg_retval; //prevent compiler complaining
 
       if ((++i % kCheckTimeoutFreqOps) == 0) {
         if (platform_monotonic_time() >= deadline) {

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -199,16 +199,16 @@ void *FuseInvalidator::MainInvalidator(void *data) {
                entry_parent, entry_name.c_str());
       // Can fail, e.g. the entry might be already evicted
 #if CVMFS_USE_LIBFUSE == 2
-      struct fuse_chan* channel_or_session = 
+      struct fuse_chan* channel_or_session =
                                     *reinterpret_cast<struct fuse_chan**>(
                                      invalidator->fuse_channel_or_session_);
-#else 
-      struct fuse_session* channel_or_session = 
+#else
+      struct fuse_session* channel_or_session =
                                   *reinterpret_cast<struct fuse_session**>(
                                   invalidator->fuse_channel_or_session_);
 #endif
 
-// we do not care if fuse kernel supports expire_entry as if it is 
+// we do not care if fuse kernel supports expire_entry as if it is
 // not support it will just be handled like a fuse_inval
 #ifdef FUSE_CAP_EXPIRE_ONLY
       fuse_lowlevel_notify_expire_entry(channel_or_session,

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -213,7 +213,7 @@ void *FuseInvalidator::MainInvalidator(void *data) {
 #ifdef FUSE_CAP_EXPIRE_ONLY
       fuse_lowlevel_notify_expire_entry(channel_or_session,
         entry_parent, entry_name.GetChars(), entry_name.GetLength(),
-        fuse_expire_flags::FUSE_LL_EXPIRE_ONLY);
+        FUSE_LL_EXPIRE_ONLY);
 #else
       fuse_lowlevel_notify_inval_entry(channel_or_session,
         entry_parent, entry_name.GetChars(), entry_name.GetLength());

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -157,15 +157,19 @@ void *FuseInvalidator::MainInvalidator(void *data) {
       int dbg_retval;
 
 #if CVMFS_USE_LIBFUSE == 2
-      dbg_retval = fuse_lowlevel_notify_inval_inode(*reinterpret_cast<struct fuse_chan**>(
-        invalidator->fuse_channel_or_session_), inode, 0, 0);
+      dbg_retval = fuse_lowlevel_notify_inval_inode(
+                    *reinterpret_cast<struct fuse_chan**>(
+                    invalidator->fuse_channel_or_session_), inode, 0, 0);
 #else
-      dbg_retval = fuse_lowlevel_notify_inval_inode(*reinterpret_cast<struct fuse_session**>(
-        invalidator->fuse_channel_or_session_), inode, 0, 0);
+      dbg_retval = fuse_lowlevel_notify_inval_inode(
+                    *reinterpret_cast<struct fuse_session**>(
+                    invalidator->fuse_channel_or_session_), inode, 0, 0);
 #endif
-      LogCvmfs(kLogCvmfs, kLogDebug, "evicting inode %" PRIu64 " with retval: %d", inode, dbg_retval);
+      LogCvmfs(kLogCvmfs, kLogDebug,
+                "evicting inode %" PRIu64 " with retval: %d",
+                inode, dbg_retval);
 
-      (void) dbg_retval; //prevent compiler complaining
+      (void) dbg_retval;  // prevent compiler complaining
 
       if ((++i % kCheckTimeoutFreqOps) == 0) {
         if (platform_monotonic_time() >= deadline) {

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1147,6 +1147,18 @@ bool MountPoint::ReloadBlacklists() {
   return result;
 }
 
+/**
+ * Disables kernel caching of symlinks. 
+ * Symlink caching requires fuse >= 3.10 (FUSE_CAP_CACHE_SYMLINKS) and
+ * linux kernel >= 4.2 
+ * 
+ * NOTE: This function should only be called before or within cvmfs_init().
+ * 
+ */
+void MountPoint::DisableCacheSymlinks() {
+  cache_symlinks_ = false;
+}
+
 
 /**
  * The option_mgr parameter can be NULL, in which case the global option manager
@@ -1762,7 +1774,6 @@ void MountPoint::SetMaxTtlMn(unsigned value_minutes) {
   MutexLockGuard lock_guard(lock_max_ttl_);
   max_ttl_sec_ = value_minutes * 60;
 }
-
 
 bool MountPoint::SetupBehavior() {
   string optarg;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1693,6 +1693,7 @@ MountPoint::MountPoint(
   , kcache_timeout_sec_(static_cast<double>(kDefaultKCacheTtlSec))
   , fixed_catalog_(false)
   , enforce_acls_(false)
+  , cache_symlinks_(false)
   , has_membership_req_(false)
   , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
   , talk_socket_uid_(0)
@@ -1806,6 +1807,14 @@ bool MountPoint::SetupBehavior() {
   {
     enforce_acls_ = true;
   }
+
+  if (options_mgr_->GetValue("CVMFS_CACHE_SYMLINKS", &optarg)
+      && options_mgr_->IsOn(optarg))
+  {
+    cache_symlinks_ = true;
+  }
+
+
 
   if (options_mgr_->GetValue("CVMFS_TALK_SOCKET", &optarg)) {
     talk_socket_path_ = optarg;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1150,13 +1150,21 @@ bool MountPoint::ReloadBlacklists() {
 /**
  * Disables kernel caching of symlinks. 
  * Symlink caching requires fuse >= 3.10 (FUSE_CAP_CACHE_SYMLINKS) and
- * linux kernel >= 4.2 
+ * linux kernel >= 4.2. Some OS might backport it.
  * 
  * NOTE: This function should only be called before or within cvmfs_init().
  * 
  */
 void MountPoint::DisableCacheSymlinks() {
   cache_symlinks_ = false;
+}
+
+/**
+ * Instead of invalidate dentries, they should be expired. 
+ * Fixes issues with mount-on-top mounts and symlink caching.
+ */
+void MountPoint::EnableFuseExpireEntry() {
+  fuse_expire_entry_ = true;
 }
 
 
@@ -1706,6 +1714,7 @@ MountPoint::MountPoint(
   , fixed_catalog_(false)
   , enforce_acls_(false)
   , cache_symlinks_(false)
+  , fuse_expire_entry_(false)
   , has_membership_req_(false)
   , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
   , talk_socket_uid_(0)

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -444,6 +444,7 @@ class MountPoint : SingleCopy, public BootFactory {
   MagicXattrManager *magic_xattr_mgr() { return magic_xattr_mgr_; }
   bool has_membership_req() { return has_membership_req_; }
   bool enforce_acls() { return enforce_acls_; }
+  bool cache_symlinks() { return cache_symlinks_; }
   catalog::InodeAnnotation *inode_annotation() {
     return inode_annotation_;
   }
@@ -577,6 +578,7 @@ class MountPoint : SingleCopy, public BootFactory {
   double kcache_timeout_sec_;
   bool fixed_catalog_;
   bool enforce_acls_;
+  bool cache_symlinks_;
   std::string repository_tag_;
   std::vector<std::string> blacklist_paths_;
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -445,6 +445,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool has_membership_req() { return has_membership_req_; }
   bool enforce_acls() { return enforce_acls_; }
   bool cache_symlinks() { return cache_symlinks_; }
+  bool fuse_expire_entry() { return fuse_expire_entry_; }
   catalog::InodeAnnotation *inode_annotation() {
     return inode_annotation_;
   }
@@ -468,6 +469,7 @@ class MountPoint : SingleCopy, public BootFactory {
 
   bool ReloadBlacklists();
   void DisableCacheSymlinks();
+  void EnableFuseExpireEntry();
 
  private:
   /**
@@ -580,6 +582,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool fixed_catalog_;
   bool enforce_acls_;
   bool cache_symlinks_;
+  bool fuse_expire_entry_;
   std::string repository_tag_;
   std::vector<std::string> blacklist_paths_;
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -467,6 +467,7 @@ class MountPoint : SingleCopy, public BootFactory {
   cvmfs::Uuid *uuid() { return uuid_; }
 
   bool ReloadBlacklists();
+  void DisableCacheSymlinks();
 
  private:
   /**

--- a/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
@@ -78,6 +78,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/672-publish_stats_hardlinks              \
                                src/673-acl                                  \
                                src/682-enter                                \
+                               src/702-symlink_caching                      \
                                src/811-commit-gateway                       \
                                --                                           \
                                src/5*                                       \

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -53,6 +53,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/684-https_s3                             \
                                  src/686-azureblob_s3                         \
                                  src/687-import_s3                            \
+                                 src/702-symlink_caching                      \
                                  src/811-commit-gateway                       \
                                  --                                           \
                                  src/5*                                       \

--- a/test/cloud_testing/platforms/centos8_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64_test.sh
@@ -50,6 +50,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/684-https_s3                             \
                                  src/686-azureblob_s3                         \
                                  src/687-import_s3                            \
+                                 src/702-symlink_caching                      \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/cloud_testing/platforms/centos9_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos9_x86_64_test.sh
@@ -50,6 +50,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/684-https_s3                             \
                                  src/686-azureblob_s3                         \
                                  src/687-import_s3                            \
+                                 src/702-symlink_caching                      \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/cloud_testing/platforms/debian_test.sh
+++ b/test/cloud_testing/platforms/debian_test.sh
@@ -55,6 +55,7 @@ if [ x"$(uname -m)" = x"x86_64" ]; then
                                    src/684-https_s3                             \
                                    src/686-azureblob_s3                         \
                                    src/687-import_s3                            \
+                                   src/702-symlink_caching                      \
                                    $CVMFS_EXCLUDE                               \
                                    --                                           \
                                    src/5*                                       \

--- a/test/cloud_testing/platforms/fedora_test.sh
+++ b/test/cloud_testing/platforms/fedora_test.sh
@@ -43,6 +43,7 @@ CVMFS_TEST_CLASS_NAME=ServerIntegrationTests                                  \
                                  src/684-https_s3                             \
                                  src/686-azureblob_s3                         \
                                  src/687-import_s3                            \
+                                 src/702-symlink_caching                      \
                                  --                                           \
                                  src/5*                                       \
                                  src/6*                                       \

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -90,6 +90,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/670-listreflog                           \
                                src/672-publish_stats_hardlinks              \
                                src/673-acl                                  \
+                               src/702-symlink_caching                      \
                                $CVMFS_EXCLUDE                               \
                                --                                           \
                                src/5*                                       \

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -70,6 +70,7 @@ if [ x"$(uname -m)" = x"x86_64" ]; then
                                    src/684-https_s3                             \
                                    src/686-azureblob_s3                         \
                                    src/687-import_s3                            \
+                                   src/702-symlink_caching                      \
                                    $CVMFS_EXCLUDE                               \
                                    --                                           \
                                    src/5*                                       \

--- a/test/src/702-symlink_caching/main
+++ b/test/src/702-symlink_caching/main
@@ -151,7 +151,7 @@ check_libfuse3() {
   replace_short_symlink_with_long $short_name $long_name $symlink_name
   local new_symlink_pointer=$(readlink ${mntpnt}/${symlink_name})
   # res_switch must be 0
-  if [ "$new_symlink_pointer" = "$long_name" ] && [ "$new_symlink_pointer" != "$short_name" ]; then
+  if [ "$new_symlink_pointer" = "$long_name" ] && [ "$old_symlink_pointer" = "$short_name" ]; then
     local res_switch="0"
   else
     local res_switch="1"

--- a/test/src/702-symlink_caching/main
+++ b/test/src/702-symlink_caching/main
@@ -4,6 +4,7 @@ cvmfs_test_suites="quick"
 
 TEST702_PRIVATE_MOUNT=
 TEST702_PIDS=
+CVMFS_TEST_702_OSXMOUNTPOINT=
 
 source ./src/702-symlink_caching/setup_teardown
 
@@ -17,12 +18,12 @@ check_readlink_is_cached() {
 
   readlink ${mntpnt}/${symlink_name} > /dev/null
   readlink ${mntpnt}/${symlink_name} > /dev/null
-  local old_counter=$(cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs | grep readlink)
+  local old_counter=$(sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs | grep readlink)
 
   readlink ${mntpnt}/${symlink_name} > /dev/null
   readlink ${mntpnt}/${symlink_name} > /dev/null
   readlink ${mntpnt}/${symlink_name} > /dev/null
-  local new_counter=$(cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs | grep readlink)
+  local new_counter=$(sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs | grep readlink)
 
   if [ "$old_counter" = "$new_counter" ] && [ "$old_counter" != "" ] ; then
     echo "0"
@@ -51,6 +52,45 @@ replace_short_symlink_with_long() {
   echo "  *** FINISHED Replace symlink from $short_name to $long_name"
 }
 
+cleanup_mount_on_top() {
+  echo "Cleaning up: umount mount-on-top"
+  sudo umount $TEST702_PRIVATE_MOUNT/testdir_mountpoint
+  if [ "x$CVMFS_TEST_702_OSXMOUNTPOINT" != "x" ]; then
+    sudo hdiutil detach $CVMFS_TEST_702_OSXMOUNTPOINT
+  fi
+}
+
+# should work both for libfuse2 and libfuse3 as
+# - libfuse2 does not evict dentries
+# - libfuse3 expires dentries instead of evicting
+mount_on_top() {
+  local mntpnt="$1"
+  echo $mntpnt
+
+
+  if running_on_osx; then
+    CVMFS_TEST_702_OSXMOUNTPOINT=$(sudo hdid -nomount ram://256000)
+    sudo newfs_hfs $CVMFS_TEST_702_OSXMOUNTPOINT || return 30
+    sudo mount -t hfs $CVMFS_TEST_702_OSXMOUNTPOINT $mntpnt/testdir_mountpoint || return 31
+    sudo mkdir $mntpnt/testdir_mountpoint/self || return 32
+  else
+    sudo mount -t proc none $mntpnt/testdir_mountpoint || return 33
+  fi
+  trap cleanup_mount_on_top EXIT HUP INT TERM
+
+  ls $mntpnt/testdir_mountpoint/self > /dev/null || return 34
+  diff $mntpnt/testdir_mountpoint/self/maps /proc/self/maps || return 35
+
+  # sudo cvmfs_config reload -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO || return 36
+  add_some_tmp_file_to_repo
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 36
+
+  ls $mntpnt/testdir_mountpoint/self > /dev/null || return 37
+  diff $mntpnt/testdir_mountpoint/self/maps /proc/self/maps  || return 38
+
+  cleanup_mount_on_top
+}
+
 # for fuse 2
 # checks that
 # 1) symlinks are not cached in kernel
@@ -62,11 +102,20 @@ check_libfuse2() {
   
   echo ""
   echo "*** START Testing libfuse2"
-  echo "Testing caching..."
   
+  echo "Mounting repo..."
   private_mount $mntpnt "2"|| return $?
   
+  echo ""
+  echo "Testing caching..."
   local res=$(check_readlink_is_cached $mntpnt $symlink_name)
+
+  echo ""
+  echo "Testing mount on top..."
+  mount_on_top $mntpnt || return $?
+
+  echo ""
+  echo "Unmount repo"
   private_unmount
   echo "*** FINISHED Testing libfuse2"
   echo ""
@@ -88,11 +137,16 @@ check_libfuse3() {
 
   echo ""
   echo "*** START Testing libfuse3"
+
+  echo "Mounting repo..."
   private_mount $mntpnt "3"
+
+  echo ""
   echo "Testing caching..."
   # res_cached must be 0
   local res_cached=$(check_readlink_is_cached $mntpnt $symlink_name)
 
+  echo ""
   echo "Test symlink short -> long replacement"
   local old_symlink_pointer=$(readlink ${mntpnt}/${symlink_name})
   replace_short_symlink_with_long $short_name $long_name $symlink_name
@@ -103,11 +157,19 @@ check_libfuse3() {
   else
     local res_switch="1"
   fi
+
+  echo ""
+  echo "Testing mount on top..."
+  mount_on_top $mntpnt || return $?
+
+  echo ""
+  echo "Unmount repo"
   private_unmount
 
   [ $res_cached = "0" ] || return 20
   [ $res_switch = "0" ] || return 21
 
+  echo ""
   echo "*** FINISHED Testing libfuse3"
   echo ""
 }
@@ -130,7 +192,7 @@ cvmfs_run_test() {
 
   check_libfuse2 ${mntpnt} ${config_file_path} ${symlink_name} || return $?
   check_libfuse3 ${mntpnt} ${config_file_path} ${short_name} ${long_name} ${symlink_name} || return $?
-
+  return -1
 
   return 0
 }

--- a/test/src/702-symlink_caching/main
+++ b/test/src/702-symlink_caching/main
@@ -1,0 +1,165 @@
+cvmfs_test_name="Symlink caching: Proper eviction policy for kernel cache"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+TEST702_PRIVATE_MOUNT=
+TEST702_PIDS=
+
+
+
+source ./src/702-symlink_caching/setup_teardown
+
+private_mount() {
+  local mntpnt="$1"
+  local fuse_version="$2"
+  local config_file_path="$3"
+  TEST702_PRIVATE_MOUNT="$mntpnt"
+  do_local_mount "$mntpnt"          \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_KCACHE_TIMEOUT=20
+CVMFS_CACHE_SYMLINKS=1" "libfuse=$fuse_version" || return 1
+  # sudo /usr/bin/cvmfs2 -o rw,system_mount,fsname=cvmfs2,allow_other,grab_mountpoint,uid=998,gid=997,libfuse=$fuse_version ${CVMFS_TEST_REPO} $mntpnt
+}
+
+private_unmount() {
+  sudo umount $TEST702_PRIVATE_MOUNT
+  TEST702_PRIVATE_MOUNT=
+}
+
+cleanup() {
+  echo "running cleanup()..."
+  if [ "x$TEST702_PIDS" != "x" ]; then
+    kill -9 $TEST702_PIDS
+  fi
+  if [ "x$TEST702_PRIVATE_MOUNT" != "x" ]; then
+    private_unmount
+  fi
+}
+
+# Returns 0 if readlink is cached in kernel cache
+# Otherwise 1
+check_readlink_is_cached() {
+  local mntpnt="$1"
+  local symlink_name="$2"
+
+  readlink ${mntpnt}/${symlink_name} > /dev/null
+  readlink ${mntpnt}/${symlink_name} > /dev/null
+  local old_counter=$(cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs | grep readlink)
+
+  readlink ${mntpnt}/${symlink_name} > /dev/null
+  readlink ${mntpnt}/${symlink_name} > /dev/null
+  readlink ${mntpnt}/${symlink_name} > /dev/null
+  local new_counter=$(cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs | grep readlink)
+
+  if [ "$old_counter" = "$new_counter" ] && [ "$old_counter" != "" ] ; then
+    echo "0"
+  elif [ "$old_counter" != "$new_counter" ] && [ "$old_counter" != "" ] && [ "$new_counter" != "" ] ; then
+    echo "1"
+  else
+    echo "2"
+  fi
+}
+
+replace_short_symlink_with_long() {
+  local short_name="$1"
+  local long_name="$2"
+  local symlink_name="$3"
+
+  echo "*** START Replace symlink from $short_name to $long_name"
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+  ln -sf ${long_name} /cvmfs/${CVMFS_TEST_REPO}/${symlink_name}
+  publish_repo ${CVMFS_TEST_REPO} || return $?
+
+  #remount
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync
+
+  echo "*** FINISHED Replace symlink from $short_name to $long_name"
+}
+
+check_libfuse2() {
+  local mntpnt="$1"
+  local config_file_path="$2"
+  local symlink_name="$3"
+
+  
+  echo ""
+  echo "*** START Testing libfuse2"
+  echo "check_libfuse2: " ${mntpnt} ${symlink_name}
+
+  echo "libfuse=2" > ${config_file_path}
+
+  private_mount $mntpnt "2"|| return $?
+  
+  local res=$(check_readlink_is_cached $mntpnt $symlink_name)
+  private_unmount
+  echo "*** FINISHED Testing libfuse2"
+  echo "Return value $res"
+
+  [ $res = "1" ] || return 11
+}
+
+check_libfuse3() {
+  local mntpnt="$1"
+  local config_file_path="$2"
+  local short_name="$3"
+  local long_name="$4"
+  local symlink_name="$5"  
+
+  echo "libfuse=3" > ${config_file_path}
+
+  echo "*** START Testing libfuse3"
+  private_mount $mntpnt "3"
+  echo "Testing caching..."
+  # res_cached must be 0
+  local res_cached=$(check_readlink_is_cached $mntpnt $symlink_name)
+
+  echo "Test symlink short -> long replacement"
+  local old_symlink_pointer=$(readlink ${mntpnt}/${symlink_name})
+  replace_short_symlink_with_long $short_name $long_name $symlink_name
+  local new_symlink_pointer=$(readlink ${mntpnt}/${symlink_name})
+  # res_switch must be 0
+  if [ "$new_symlink_pointer" = "$long_name" ] && [ "$new_symlink_pointer" != "$short_name" ]; then
+    local res_switch="0"
+  else
+    local res_switch="1"
+  fi
+  private_unmount
+
+  echo ""
+  echo "res_cached" $res_cached
+  echo "res_switch" $res_switch
+  echo ""
+  
+
+  [ $res_cached = "0" ] || return 20
+  [ $res_switch = "0" ] || return 21
+
+  echo "*** FINISHED Testing libfuse3"
+}
+
+cvmfs_run_test() {
+  logfile=$1
+
+  local scratch_dir=$(pwd)
+  local mntpnt="${scratch_dir}/private_mnt"
+  local config_file_path="${scratch_dir}/${CVMFS_TEST_REPO}.config.txt"
+  local short_name="test1.txt"
+  local long_name="thisismyverylongsecondfile_solongthatnoonebelieveshowlongitis_butneverthelessitislongerthananythingyouhaveeverseen_especiallybecausewehavetogetthe200charactersfull_andwearestillafewaway_butnotanymore.txt"
+  local symlink_name="symlink.txt"  
+
+  echo "*** set a trap for system directory cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+
+  create_symlink_repo ${short_name} ${long_name} ${symlink_name} || return $?
+
+  check_libfuse2 ${mntpnt} ${config_file_path} ${symlink_name} || return $?
+  echo "finished libfuse2"
+  check_libfuse3 ${mntpnt} ${config_file_path} ${short_name} ${long_name} ${symlink_name} || return $?
+
+
+  return 0
+}

--- a/test/src/702-symlink_caching/main
+++ b/test/src/702-symlink_caching/main
@@ -5,41 +5,12 @@ cvmfs_test_suites="quick"
 TEST702_PRIVATE_MOUNT=
 TEST702_PIDS=
 
-
-
 source ./src/702-symlink_caching/setup_teardown
 
-private_mount() {
-  local mntpnt="$1"
-  local fuse_version="$2"
-  local config_file_path="$3"
-  TEST702_PRIVATE_MOUNT="$mntpnt"
-  do_local_mount "$mntpnt"          \
-                 "$CVMFS_TEST_REPO" \
-                 "$(get_repo_url $CVMFS_TEST_REPO)" \
-                 "" \
-                 "CVMFS_KCACHE_TIMEOUT=20
-CVMFS_CACHE_SYMLINKS=1" "libfuse=$fuse_version" || return 1
-  # sudo /usr/bin/cvmfs2 -o rw,system_mount,fsname=cvmfs2,allow_other,grab_mountpoint,uid=998,gid=997,libfuse=$fuse_version ${CVMFS_TEST_REPO} $mntpnt
-}
-
-private_unmount() {
-  sudo umount $TEST702_PRIVATE_MOUNT
-  TEST702_PRIVATE_MOUNT=
-}
-
-cleanup() {
-  echo "running cleanup()..."
-  if [ "x$TEST702_PIDS" != "x" ]; then
-    kill -9 $TEST702_PIDS
-  fi
-  if [ "x$TEST702_PRIVATE_MOUNT" != "x" ]; then
-    private_unmount
-  fi
-}
 
 # Returns 0 if readlink is cached in kernel cache
 # Otherwise 1
+# If empty string (=error) return 2
 check_readlink_is_cached() {
   local mntpnt="$1"
   local symlink_name="$2"
@@ -62,12 +33,13 @@ check_readlink_is_cached() {
   fi
 }
 
+# for fuse3 check
 replace_short_symlink_with_long() {
   local short_name="$1"
   local long_name="$2"
   local symlink_name="$3"
 
-  echo "*** START Replace symlink from $short_name to $long_name"
+  echo "  *** START Replace symlink from $short_name to $long_name"
 
   start_transaction $CVMFS_TEST_REPO || return $?
   ln -sf ${long_name} /cvmfs/${CVMFS_TEST_REPO}/${symlink_name}
@@ -76,9 +48,12 @@ replace_short_symlink_with_long() {
   #remount
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync
 
-  echo "*** FINISHED Replace symlink from $short_name to $long_name"
+  echo "  *** FINISHED Replace symlink from $short_name to $long_name"
 }
 
+# for fuse 2
+# checks that
+# 1) symlinks are not cached in kernel
 check_libfuse2() {
   local mntpnt="$1"
   local config_file_path="$2"
@@ -87,20 +62,23 @@ check_libfuse2() {
   
   echo ""
   echo "*** START Testing libfuse2"
-  echo "check_libfuse2: " ${mntpnt} ${symlink_name}
-
-  echo "libfuse=2" > ${config_file_path}
-
+  echo "Testing caching..."
+  
   private_mount $mntpnt "2"|| return $?
   
   local res=$(check_readlink_is_cached $mntpnt $symlink_name)
   private_unmount
   echo "*** FINISHED Testing libfuse2"
-  echo "Return value $res"
+  echo ""
 
   [ $res = "1" ] || return 11
 }
 
+# for fuse3 (prerequirement: fuse >= 3.10)
+# checks that
+# 1) symlinks are cached in kernel
+# 2) symlinks switching from location with a short path --> long path should 
+#    not trunacte
 check_libfuse3() {
   local mntpnt="$1"
   local config_file_path="$2"
@@ -108,8 +86,7 @@ check_libfuse3() {
   local long_name="$4"
   local symlink_name="$5"  
 
-  echo "libfuse=3" > ${config_file_path}
-
+  echo ""
   echo "*** START Testing libfuse3"
   private_mount $mntpnt "3"
   echo "Testing caching..."
@@ -128,16 +105,11 @@ check_libfuse3() {
   fi
   private_unmount
 
-  echo ""
-  echo "res_cached" $res_cached
-  echo "res_switch" $res_switch
-  echo ""
-  
-
   [ $res_cached = "0" ] || return 20
   [ $res_switch = "0" ] || return 21
 
   echo "*** FINISHED Testing libfuse3"
+  echo ""
 }
 
 cvmfs_run_test() {
@@ -157,7 +129,6 @@ cvmfs_run_test() {
   create_symlink_repo ${short_name} ${long_name} ${symlink_name} || return $?
 
   check_libfuse2 ${mntpnt} ${config_file_path} ${symlink_name} || return $?
-  echo "finished libfuse2"
   check_libfuse3 ${mntpnt} ${config_file_path} ${short_name} ${long_name} ${symlink_name} || return $?
 
 

--- a/test/src/702-symlink_caching/main
+++ b/test/src/702-symlink_caching/main
@@ -1,4 +1,4 @@
-cvmfs_test_name="Symlink caching: Proper eviction policy for kernel cache"
+cvmfs_test_name="Symlink caching and dentry eviction: Proper eviction policy for kernel cache"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
@@ -40,16 +40,12 @@ replace_short_symlink_with_long() {
   local long_name="$2"
   local symlink_name="$3"
 
-  echo "  *** START Replace symlink from $short_name to $long_name"
-
   start_transaction $CVMFS_TEST_REPO || return $?
   ln -sf ${long_name} /cvmfs/${CVMFS_TEST_REPO}/${symlink_name}
   publish_repo ${CVMFS_TEST_REPO} || return $?
 
   #remount
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync
-
-  echo "  *** FINISHED Replace symlink from $short_name to $long_name"
 }
 
 cleanup_mount_on_top() {
@@ -81,7 +77,10 @@ mount_on_top() {
   ls $mntpnt/testdir_mountpoint/self > /dev/null || return 34
   diff $mntpnt/testdir_mountpoint/self/maps /proc/self/maps || return 35
 
-  # sudo cvmfs_config reload -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO || return 36
+  # better to use: sudo cvmfs_config reload $CVMFS_TEST_REPO || return 36
+  # however this is not possible with a socket
+  # as such workaround: use remount sync
+  # this requires change to repo to foce catalog update
   add_some_tmp_file_to_repo
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 36
 
@@ -107,15 +106,15 @@ check_libfuse2() {
   private_mount $mntpnt "2"|| return $?
   
   echo ""
-  echo "Testing caching..."
+  echo "  *** Testing caching..."
   local res=$(check_readlink_is_cached $mntpnt $symlink_name)
 
   echo ""
-  echo "Testing mount on top..."
+  echo "  *** Testing mount on top..."
   mount_on_top $mntpnt || return $?
 
   echo ""
-  echo "Unmount repo"
+  echo "  *** Unmount repo"
   private_unmount
   echo "*** FINISHED Testing libfuse2"
   echo ""
@@ -138,16 +137,16 @@ check_libfuse3() {
   echo ""
   echo "*** START Testing libfuse3"
 
-  echo "Mounting repo..."
+  echo "  *** Mounting repo..."
   private_mount $mntpnt "3"
 
   echo ""
-  echo "Testing caching..."
+  echo "  *** Testing caching..."
   # res_cached must be 0
   local res_cached=$(check_readlink_is_cached $mntpnt $symlink_name)
 
   echo ""
-  echo "Test symlink short -> long replacement"
+  echo "  *** Test symlink short -> long replacement"
   local old_symlink_pointer=$(readlink ${mntpnt}/${symlink_name})
   replace_short_symlink_with_long $short_name $long_name $symlink_name
   local new_symlink_pointer=$(readlink ${mntpnt}/${symlink_name})
@@ -159,11 +158,11 @@ check_libfuse3() {
   fi
 
   echo ""
-  echo "Testing mount on top..."
+  echo "  *** Testing mount on top..."
   mount_on_top $mntpnt || return $?
 
   echo ""
-  echo "Unmount repo"
+  echo "  *** Unmount repo"
   private_unmount
 
   [ $res_cached = "0" ] || return 20
@@ -184,7 +183,7 @@ cvmfs_run_test() {
   local long_name="thisismyverylongsecondfile_solongthatnoonebelieveshowlongitis_butneverthelessitislongerthananythingyouhaveeverseen_especiallybecausewehavetogetthe200charactersfull_andwearestillafewaway_butnotanymore.txt"
   local symlink_name="symlink.txt"  
 
-  echo "*** set a trap for system directory cleanup"
+  echo "*** Set a trap for system directory cleanup"
   trap cleanup EXIT HUP INT TERM
 
 
@@ -192,7 +191,6 @@ cvmfs_run_test() {
 
   check_libfuse2 ${mntpnt} ${config_file_path} ${symlink_name} || return $?
   check_libfuse3 ${mntpnt} ${config_file_path} ${short_name} ${long_name} ${symlink_name} || return $?
-  return -1
 
   return 0
 }

--- a/test/src/702-symlink_caching/setup_teardown
+++ b/test/src/702-symlink_caching/setup_teardown
@@ -11,26 +11,44 @@ create_symlink_repo() {
 
   touch /cvmfs/$CVMFS_TEST_REPO/${short_name}
   touch /cvmfs/$CVMFS_TEST_REPO/${long_name}
+  mkdir /cvmfs/$CVMFS_TEST_REPO/testdir_mountpoint
 
   ln -s ${short_name} /cvmfs/$CVMFS_TEST_REPO/${symlink_name}
+
+  ls /cvmfs/$CVMFS_TEST_REPO/
 
   publish_repo $CVMFS_TEST_REPO || return 200
   echo "*** FINISHED creating a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   echo ""
 }
 
+add_some_tmp_file_to_repo() {
+  start_transaction $CVMFS_TEST_REPO || return $?
+  local tmpfile="$(mktemp /cvmfs/$CVMFS_TEST_REPO/tmpfile.XXXXX)"
+  publish_repo $CVMFS_TEST_REPO || return 200
+}
 
 private_mount() {
   local mntpnt="$1"
   local fuse_version="$2"
   local config_file_path="$3"
   TEST702_PRIVATE_MOUNT="$mntpnt"
-  do_local_mount "$mntpnt"          \
+
+  # mkdir -p $mntpnt
+  # local output="$(mktemp ${mntpnt}.log.XXXXX)"
+  
+  
+  # sudo cvmfs2 -d -o rw,system_mount,fsname=cvmfs2,allow_other,grab_mountpoint,uid=998,gid=997,libfuse=$fuse_version $CVMFS_TEST_REPO $mntpnt >> $output 2>&1
+
+  local mount_options="rw,system_mount,fsname=cvmfs2,libfuse=$fuse_version"
+
+  do_local_mount_as_root "$mntpnt"          \
                  "$CVMFS_TEST_REPO" \
                  "$(get_repo_url $CVMFS_TEST_REPO)" \
                  "" \
-                 "CVMFS_CACHE_SYMLINKS=1" \
-                 "libfuse=$fuse_version" || return 1
+                 "CVMFS_CACHE_SYMLINKS=1
+CVMFS_SYSLOG_LEVEL=2" \
+                 "$mount_options" || return 1
 }
 
 private_unmount() {
@@ -41,7 +59,7 @@ private_unmount() {
 cleanup() {
   echo "running cleanup()..."
   if [ "x$TEST702_PIDS" != "x" ]; then
-    kill -9 $TEST702_PIDS
+    sudo kill -9 $TEST702_PIDS
   fi
   if [ "x$TEST702_PRIVATE_MOUNT" != "x" ]; then
     private_unmount

--- a/test/src/702-symlink_caching/setup_teardown
+++ b/test/src/702-symlink_caching/setup_teardown
@@ -15,14 +15,13 @@ create_symlink_repo() {
 
   ln -s ${short_name} /cvmfs/$CVMFS_TEST_REPO/${symlink_name}
 
-  ls /cvmfs/$CVMFS_TEST_REPO/
-
   publish_repo $CVMFS_TEST_REPO || return 200
   echo "*** FINISHED creating a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   echo ""
 }
 
 add_some_tmp_file_to_repo() {
+  echo "Adding some random file to the repo $CVMFS_TEST_REPO"
   start_transaction $CVMFS_TEST_REPO || return $?
   local tmpfile="$(mktemp /cvmfs/$CVMFS_TEST_REPO/tmpfile.XXXXX)"
   publish_repo $CVMFS_TEST_REPO || return 200
@@ -33,12 +32,6 @@ private_mount() {
   local fuse_version="$2"
   local config_file_path="$3"
   TEST702_PRIVATE_MOUNT="$mntpnt"
-
-  # mkdir -p $mntpnt
-  # local output="$(mktemp ${mntpnt}.log.XXXXX)"
-  
-  
-  # sudo cvmfs2 -d -o rw,system_mount,fsname=cvmfs2,allow_other,grab_mountpoint,uid=998,gid=997,libfuse=$fuse_version $CVMFS_TEST_REPO $mntpnt >> $output 2>&1
 
   local mount_options="rw,system_mount,fsname=cvmfs2,libfuse=$fuse_version"
 

--- a/test/src/702-symlink_caching/setup_teardown
+++ b/test/src/702-symlink_caching/setup_teardown
@@ -1,0 +1,19 @@
+create_symlink_repo() {
+  echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  local short_name="$1"
+  local long_name="$2"
+  local symlink_name="$3"  
+
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  touch /cvmfs/$CVMFS_TEST_REPO/${short_name}
+  touch /cvmfs/$CVMFS_TEST_REPO/${long_name}
+
+  ln -s ${short_name} /cvmfs/$CVMFS_TEST_REPO/${symlink_name}
+
+  publish_repo $CVMFS_TEST_REPO || return 200
+  echo "*** FINISHED creating a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+}
+

--- a/test/src/702-symlink_caching/setup_teardown
+++ b/test/src/702-symlink_caching/setup_teardown
@@ -1,4 +1,5 @@
 create_symlink_repo() {
+  echo ""
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
@@ -15,5 +16,34 @@ create_symlink_repo() {
 
   publish_repo $CVMFS_TEST_REPO || return 200
   echo "*** FINISHED creating a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  echo ""
 }
 
+
+private_mount() {
+  local mntpnt="$1"
+  local fuse_version="$2"
+  local config_file_path="$3"
+  TEST702_PRIVATE_MOUNT="$mntpnt"
+  do_local_mount "$mntpnt"          \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_CACHE_SYMLINKS=1" \
+                 "libfuse=$fuse_version" || return 1
+}
+
+private_unmount() {
+  sudo umount $TEST702_PRIVATE_MOUNT
+  TEST702_PRIVATE_MOUNT=
+}
+
+cleanup() {
+  echo "running cleanup()..."
+  if [ "x$TEST702_PIDS" != "x" ]; then
+    kill -9 $TEST702_PIDS
+  fi
+  if [ "x$TEST702_PRIVATE_MOUNT" != "x" ]; then
+    private_unmount
+  fi
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -2375,13 +2375,13 @@ EOF
   cat "$config"
 
   if [[ ! -z $mount_options ]]; then
-    mount_options=$(echo ","$mount_options" ")
+    mount_options=$(echo $mount_options",")
   fi
 
   if [ x"$as_root" != x"" ]; then
-    sudo cvmfs2 -d -o allow_other,config=$config$mount_options $repo_name $mountpoint >> $output 2>&1
+    sudo cvmfs2 -d -o allow_other,${mount_options}config=$config $repo_name $mountpoint >> $output 2>&1
   else
-    cvmfs2 -d -o config=$config$mount_options $repo_name $mountpoint >> $output 2>&1
+    cvmfs2 -d -o ${mount_options}config=$config $repo_name $mountpoint >> $output 2>&1
   fi
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2347,6 +2347,7 @@ __do_local_mount() {
   local repo_url="$4"
   local config_file="$5"
   local extra_option="$6"
+  local mount_options="$7"
 
   local cache="$(get_cache_directory $mountpoint)"
   local config="$(mktemp ${mountpoint}.conf.XXXXX)"
@@ -2372,10 +2373,14 @@ EOF
   echo "  *** local mount config:"
   cat "$config"
 
+  if [[ ! -z $mount_options ]]; then
+    mount_options=$(echo ","$mount_options" ")
+  fi
+
   if [ x"$as_root" != x"" ]; then
-    sudo cvmfs2 -d -o allow_other,config=$config $repo_name $mountpoint >> $output 2>&1
+    sudo cvmfs2 -d -o allow_other,config=$config$mount_options $repo_name $mountpoint >> $output 2>&1
   else
-    cvmfs2 -d -o config=$config $repo_name $mountpoint >> $output 2>&1
+    cvmfs2 -d -o config=$config$mount_options $repo_name $mountpoint >> $output 2>&1
   fi
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2374,8 +2374,8 @@ EOF
   echo "  *** local mount config:"
   cat "$config"
 
-  if [[ ! -z $mount_options ]]; then
-    mount_options=$(echo $mount_options",")
+  if [ ! -z $mount_options ]; then
+    mount_options="${$mount_options},"
   fi
 
   if [ x"$as_root" != x"" ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -2345,9 +2345,10 @@ __do_local_mount() {
   local mountpoint="$2"
   local repo_name="$3"
   local repo_url="$4"
-  local config_file="$5"
-  local extra_option="$6"
-  local mount_options="$7"
+  local config_file="$5"   # config file containing CVMFS client options,
+                           # if used the options listed below are not added
+  local extra_option="$6"  # CVMFS client options as str
+  local mount_options="$7" # comma separated mount options
 
   local cache="$(get_cache_directory $mountpoint)"
   local config="$(mktemp ${mountpoint}.conf.XXXXX)"


### PR DESCRIPTION
Extended @mharvey-jt PR #2959 :
- fixes the wrongly truncated new symlinks when short -> long
- added fallback in case symlink caching is not possible 
- and fixed some small things.

Note: If you use this PR, enabling symlink kernel caching, you SHOULD NOT use symlinks as mountpoint. 
Currently it is not possible to just invalidate dentries in away that they are just considered stale in cache and need revalidation. Instead, the dentry of the symlink is evicted and the mountpoint on the symlink will be just gone.

The current libfuse implementation does not offer any solution to this problem.

Missing: Tests..

Fixes #2949 
