### PR TITLE
Change LookupOption

### DIFF
--- a/cvmfs/catalog_balancer.h
+++ b/cvmfs/catalog_balancer.h
@@ -112,7 +112,7 @@ class CatalogBalancer {
     VirtualNode(const std::string &path, CatalogMgrT *catalog_mgr)
       : children(), weight(1), dirent(), path(path),
         is_new_nested_catalog(false) {
-      catalog_mgr->LookupPath(path, kLookupSole, &dirent);
+      catalog_mgr->LookupPath(path, kLookupDefault, &dirent);
     }
     VirtualNode(const std::string &path, const DirectoryEntry &dirent,
                 CatalogMgrT *catalog_mgr)

--- a/cvmfs/catalog_balancer_impl.h
+++ b/cvmfs/catalog_balancer_impl.h
@@ -59,7 +59,7 @@ void CatalogBalancer<CatalogMgrT>::AddCatalogMarker(string path) {
   XattrList xattr;
   DirectoryEntry parent;
   bool retval;
-  retval = catalog_mgr_->LookupPath(PathString(path), kLookupSole, &parent);
+  retval = catalog_mgr_->LookupPath(PathString(path), kLookupDefault, &parent);
   assert(retval);
   DirectoryEntryBase cvmfscatalog =
       MakeEmptyDirectoryEntryBase(".cvmfscatalog", parent.uid(),

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -35,7 +35,7 @@ const unsigned kSqliteMemPerThread = 1*1024*1024;
 /**
  * LookupOption for a directory entry (bitmask).
  * kLookupDefault = Look solely at the given directory entry (parent is ignored)
- * kLookupRawSymlink = Mangle symlink to which the directory entry points to 
+ * kLookupRawSymlink = Don't resolve environment variables in symlink targets
  */
 typedef unsigned LookupOptions;
 const unsigned kLookupDefault = 0b1;

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -33,18 +33,13 @@ const unsigned kSqliteMemPerThread = 1*1024*1024;
 
 
 /**
- * Lookup a directory entry including its parent entry or not.
+ * LookupOption for a directory entry (bitmask).
+ * kLookupDefault = Look solely at the given directory entry (parent is ignored)
+ * kLookupRawSymlink = Mangle symlink to which the directory entry points to 
  */
 typedef unsigned LookupOptions;
-const unsigned kLookupSole = 0b1;
+const unsigned kLookupDefault = 0b1;
 const unsigned kLookupRawSymlink = 0b10;
-
-// enum LookupOptions {
-//   kLookupSole        = 0x01,
-//   // kLookupFull        = 0x02  not used anymore
-//   kLookupRawSymlink  = 0x10,
-// };
-
 
 /**
  * Results upon loading a catalog file.

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -31,14 +31,19 @@ namespace catalog {
 
 const unsigned kSqliteMemPerThread = 1*1024*1024;
 
+
 /**
  * Lookup a directory entry including its parent entry or not.
  */
-enum LookupOptions {
-  kLookupSole        = 0x01,
-  // kLookupFull        = 0x02  not used anymore
-  kLookupRawSymlink  = 0x10,
-};
+typedef unsigned LookupOptions;
+const unsigned kLookupSole = 0b1;
+const unsigned kLookupRawSymlink = 0b10;
+
+// enum LookupOptions {
+//   kLookupSole        = 0x01,
+//   // kLookupFull        = 0x02  not used anymore
+//   kLookupRawSymlink  = 0x10,
+// };
 
 
 /**

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -299,7 +299,7 @@ void WritableCatalogManager::Clone(const std::string destination,
   const std::string relative_source = MakeRelativePath(source);
 
   DirectoryEntry source_dirent;
-  if (!LookupPath(relative_source, kLookupSole, &source_dirent)) {
+  if (!LookupPath(relative_source, kLookupDefault, &source_dirent)) {
     PANIC(kLogStderr, "catalog for file '%s' cannot be found, aborting",
           source.c_str());
   }
@@ -311,7 +311,7 @@ void WritableCatalogManager::Clone(const std::string destination,
   // if the file is already there we remove it and we add it back
   DirectoryEntry check_dirent;
   bool destination_already_present =
-      LookupPath(MakeRelativePath(destination), kLookupSole, &check_dirent);
+      LookupPath(MakeRelativePath(destination), kLookupDefault, &check_dirent);
   if (destination_already_present) {
     this->RemoveFile(destination);
   }
@@ -356,7 +356,7 @@ void WritableCatalogManager::CloneTree(const std::string &from_dir,
   }
 
   DirectoryEntry source_dirent;
-  if (!LookupPath(relative_source, kLookupSole, &source_dirent)) {
+  if (!LookupPath(relative_source, kLookupDefault, &source_dirent)) {
     PANIC(kLogStderr, "path '%s' cannot be found, aborting", from_dir.c_str());
   }
   if (!source_dirent.IsDirectory()) {
@@ -365,13 +365,13 @@ void WritableCatalogManager::CloneTree(const std::string &from_dir,
   }
 
   DirectoryEntry dest_dirent;
-  if (LookupPath(relative_dest, kLookupSole, &dest_dirent)) {
+  if (LookupPath(relative_dest, kLookupDefault, &dest_dirent)) {
     PANIC(kLogStderr, "destination '%s' exists, aborting", to_dir.c_str());
   }
 
   const std::string dest_parent = GetParentPath(relative_dest);
   DirectoryEntry dest_parent_dirent;
-  if (!LookupPath(dest_parent, kLookupSole, &dest_parent_dirent)) {
+  if (!LookupPath(dest_parent, kLookupDefault, &dest_parent_dirent)) {
     PANIC(kLogStderr, "destination '%s' not on a known path, aborting",
           to_dir.c_str());
   }
@@ -396,7 +396,7 @@ void WritableCatalogManager::CloneTreeImpl(
   PathString relative_source(MakeRelativePath(source_dir.ToString()));
 
   DirectoryEntry source_dirent;
-  bool retval = LookupPath(relative_source, kLookupSole, &source_dirent);
+  bool retval = LookupPath(relative_source, kLookupDefault, &source_dirent);
   assert(retval);
   assert(!source_dirent.IsBindMountpoint());
 

--- a/cvmfs/catalog_virtual.cc
+++ b/cvmfs/catalog_virtual.cc
@@ -111,7 +111,7 @@ void VirtualCatalog::CreateSnapshotDirectory() {
 void VirtualCatalog::EnsurePresence() {
   DirectoryEntry e;
   bool retval = catalog_mgr_->LookupPath("/" + string(kVirtualPath),
-                                        kLookupSole, &e);
+                                        kLookupDefault, &e);
   if (!retval) {
     LogCvmfs(kLogCatalog, kLogDebug, "creating new virtual catalog");
     CreateBaseDirectory();
@@ -287,7 +287,7 @@ void VirtualCatalog::Remove() {
   assert(!virtual_catalog->IsRoot());
   DirectoryEntry entry_virtual;
   bool retval = catalog_mgr_->LookupPath(
-    PathString("/" + string(kVirtualPath)), kLookupSole, &entry_virtual);
+    PathString("/" + string(kVirtualPath)), kLookupDefault, &entry_virtual);
   assert(retval);
   assert(entry_virtual.IsHidden());
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -266,7 +266,7 @@ static bool FixupOpenInode(const PathString &path,
 
   // Overwrite dirent with inode from current generation
   bool found = mount_point_->catalog_mgr()->LookupPath(
-      path, catalog::kLookupSole, dirent);
+      path, catalog::kLookupDefault, dirent);
   assert(found);
 
   return true;
@@ -296,7 +296,7 @@ static bool GetDirentForInode(const fuse_ino_t ino,
       *dirent = dirent_negative;
       return false;
     }
-    if (catalog_mgr->LookupPath(path, catalog::kLookupSole, dirent)) {
+    if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
       // Fix inodes
       dirent->set_inode(ino);
       mount_point_->inode_cache()->Insert(ino, *dirent);
@@ -309,7 +309,7 @@ static bool GetDirentForInode(const fuse_ino_t ino,
   PathString path;
   if (ino == catalog_mgr->GetRootInode()) {
     bool retval =
-      catalog_mgr->LookupPath(PathString(), catalog::kLookupSole, dirent);
+      catalog_mgr->LookupPath(PathString(), catalog::kLookupDefault, dirent);
     assert(retval);
     dirent->set_inode(ino);
     mount_point_->inode_cache()->Insert(ino, *dirent);
@@ -329,7 +329,7 @@ static bool GetDirentForInode(const fuse_ino_t ino,
     dirent->set_inode(ino);
     return false;
   }
-  if (catalog_mgr->LookupPath(path, catalog::kLookupSole, dirent)) {
+  if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
     if (!inode_ex.IsCompatibleFileType(dirent->mode())) {
       LogCvmfs(kLogCvmfs, kLogDebug,
                "Warning: inode %" PRId64 " (%s) changed file type",
@@ -379,7 +379,7 @@ static uint64_t GetDirentForPath(const PathString &path,
 
   // Lookup inode in catalog TODO: not twice md5 calculation
   bool retval;
-  retval = catalog_mgr->LookupPath(path, catalog::kLookupSole, dirent);
+  retval = catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent);
   if (retval) {
     if (file_system_->IsNfsSource()) {
       dirent->set_inode(file_system_->nfs_maps()->GetInode(path));
@@ -1112,7 +1112,8 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     // TODO(jblomer): we only need to lookup if the inode is not from the
     // current generation
     catalog::DirectoryEntry dirent_origin;
-    if (!catalog_mgr->LookupPath(path, catalog::kLookupSole, &dirent_origin)) {
+    if (!catalog_mgr->LookupPath(path, catalog::kLookupDefault,
+                                 &dirent_origin)) {
       fuse_remounter_->fence()->Leave();
       LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
                "chunked file %s vanished unexpectedly", path.c_str());
@@ -1544,7 +1545,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   assert(retval);
   if (d.IsLink()) {
     catalog::LookupOptions lookup_options = static_cast<catalog::LookupOptions>(
-      catalog::kLookupSole | catalog::kLookupRawSymlink);
+      catalog::kLookupDefault | catalog::kLookupRawSymlink);
     catalog::DirectoryEntry raw_symlink;
     retval = catalog_mgr->LookupPath(path, lookup_options, &raw_symlink);
     assert(retval);

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -195,7 +195,7 @@ bool LibContext::GetDirentForPath(const PathString         &path,
     return dirent->GetSpecial() != catalog::kDirentNegative;
 
   // TODO(jblomer): not twice md5 calculation
-  if (mount_point_->catalog_mgr()->LookupPath(path, catalog::kLookupSole,
+  if (mount_point_->catalog_mgr()->LookupPath(path, catalog::kLookupDefault,
                                               dirent))
   {
     mount_point_->md5path_cache()->Insert(md5path, *dirent);

--- a/cvmfs/publish/repository_transaction.cc
+++ b/cvmfs/publish/repository_transaction.cc
@@ -88,7 +88,8 @@ void Publisher::TransactionImpl() {
       "/" + settings_.transaction().lease_path());
     catalog::SimpleCatalogManager *catalog_mgr = GetSimpleCatalogManager();
     catalog::DirectoryEntry dirent;
-    bool retval = catalog_mgr->LookupPath(path, catalog::kLookupSole, &dirent);
+    bool retval = catalog_mgr->LookupPath(path, catalog::kLookupDefault,
+                                          &dirent);
     if (!retval) {
       throw EPublish("cannot open transaction on non-existing path " + path,
                      EPublish::kFailLeaseNoEntry);

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -451,7 +451,7 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
     // a new directory and thus not in any catalog yet.
     catalog::DirectoryEntry dirent;
     const bool lookup_success = catalog_manager->LookupPath(
-        candidate_rel, catalog::kLookupSole, &dirent);
+        candidate_rel, catalog::kLookupDefault, &dirent);
     if (!lookup_success) {
       LogCvmfs(kLogCatalog, kLogDebug,
                "Didn't find '%s' in catalogs, could "

--- a/test/common/catalog_test_tools.cc
+++ b/test/common/catalog_test_tools.cc
@@ -404,7 +404,7 @@ bool CatalogTestTool::LookupNestedCatalogHash(
 
   catalog::DirectoryEntry entry;
   // This lookup is used to ensure the needed catalogs are mounted
-  catalog_mgr->LookupPath(path, catalog::kLookupSole, &entry);
+  catalog_mgr->LookupPath(path, catalog::kLookupDefault, &entry);
 
   p.Assign(&path[0], path.length());
   shash::Any hash = catalog_mgr->GetNestedCatalogHash(p);
@@ -436,7 +436,7 @@ bool CatalogTestTool::FindEntry(
     return false;
   }
 
-  if (!catalog_mgr->LookupPath(path, catalog::kLookupSole, entry)) {
+  if (!catalog_mgr->LookupPath(path, catalog::kLookupDefault, entry)) {
     LogCvmfs(kLogCatalog, kLogStderr,
              "catalog for directory '%s' cannot be found",
              path.c_str());

--- a/test/unittests/t_catalog_mgr.cc
+++ b/test/unittests/t_catalog_mgr.cc
@@ -186,14 +186,14 @@ TEST_F(T_CatalogManager, Lookup) {
   catalog::DirectoryEntry dirent;
   ASSERT_TRUE(catalog_mgr_.Init());
   AddTree();
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir", kLookupDefault, &dirent));
   EXPECT_TRUE(dirent.IsDirectory());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir", kLookupDefault, &dirent));
   EXPECT_TRUE(dirent.IsDirectory());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/file1", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/file1", kLookupDefault, &dirent));
   EXPECT_TRUE(dirent.IsRegular());
   // /dir/dir/dir/file4 belongs to a catalog that is not mounted yet
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/file4", kLookupSole,
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/file4", kLookupDefault,
                                       &dirent));
   // the new catalog should be mounted now
   EXPECT_EQ(2, catalog_mgr_.GetNumCatalogs());
@@ -204,17 +204,18 @@ TEST_F(T_CatalogManager, Lookup) {
 
   // load the next catalog
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/dir/dir/file5",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   // the new catalog should be mounted now
   EXPECT_EQ(3, catalog_mgr_.GetNumCatalogs());
 
   // load the next catalog
   EXPECT_FALSE(catalog_mgr_.LookupPath("/nested_not_available",
-                                       kLookupSole, &dirent));
+                                       kLookupDefault, &dirent));
   EXPECT_EQ(3, catalog_mgr_.GetNumCatalogs());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/nested", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/nested", kLookupDefault, &dirent));
   EXPECT_EQ(3, catalog_mgr_.GetNumCatalogs());
-  EXPECT_TRUE(catalog_mgr_.LookupPath("/nested/file6", kLookupSole, &dirent));
+  EXPECT_TRUE(catalog_mgr_.LookupPath("/nested/file6", kLookupDefault,
+                                      &dirent));
   EXPECT_EQ(4, catalog_mgr_.GetNumCatalogs());
 }
 
@@ -223,7 +224,7 @@ TEST_F(T_CatalogManager, LongLookup) {
   ASSERT_TRUE(catalog_mgr_.Init());
   AddTree();
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/dir/dir/file5",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   EXPECT_TRUE(dirent.IsRegular());
   // we should have mounted two catalogs
   EXPECT_EQ(3, catalog_mgr_.GetNumCatalogs());
@@ -318,7 +319,7 @@ TEST_F(T_CatalogManager, Balance) {
 
   // load the other catalogs so that they can be removed
   EXPECT_TRUE(catalog_mgr_.LookupPath("/dir/dir/dir/dir/dir/file5",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
 }
 
 TEST_F(T_CatalogManager, Remount) {

--- a/test/unittests/t_catalog_mgr_rw.cc
+++ b/test/unittests/t_catalog_mgr_rw.cc
@@ -122,12 +122,12 @@ TEST_F(T_CatalogMgrRw, CloneTree) {
 
   DirectoryEntry dirent;
   EXPECT_TRUE(catalog_mgr->LookupPath("/clone/dir/dir/dir/file1",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   EXPECT_STREQ(g_hashes[0], dirent.checksum().ToString().c_str());
   EXPECT_EQ(g_file_size, dirent.size());
 
   EXPECT_TRUE(catalog_mgr->LookupPath("/clone/dir/dir",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   EXPECT_TRUE(dirent.IsNestedCatalogRoot());
 }
 
@@ -157,7 +157,7 @@ TEST_F(T_CatalogMgrRw, SwapNestedCatalog) {
   catalog_mgr->DetachNested();
   catalog_mgr->SwapNestedCatalog("dir/dir/dir/sub1", sub1_hash, sub1_size);
   EXPECT_TRUE(catalog_mgr->LookupPath("/dir/dir/dir/sub1/file1",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   EXPECT_STREQ(g_hashes[6], dirent.checksum().ToString().c_str());
 
   // Swap sub1 and sub2
@@ -165,10 +165,10 @@ TEST_F(T_CatalogMgrRw, SwapNestedCatalog) {
   catalog_mgr->SwapNestedCatalog("dir/dir/dir/sub1", sub2_hash, sub2_size);
   catalog_mgr->SwapNestedCatalog("dir/dir/dir/sub2", sub1_hash, sub1_size);
   EXPECT_TRUE(catalog_mgr->LookupPath("/dir/dir/dir/sub1/file2",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   EXPECT_STREQ(g_hashes[7], dirent.checksum().ToString().c_str());
   EXPECT_TRUE(catalog_mgr->LookupPath("/dir/dir/dir/sub2/file1",
-                                      kLookupSole, &dirent));
+                                      kLookupDefault, &dirent));
   EXPECT_STREQ(g_hashes[6], dirent.checksum().ToString().c_str());
 }
 


### PR DESCRIPTION
Related to #3028 
- LookupOption type changes from enum to unsigned to be able to be a bit mask
- `kLookupSole` is renamed to `kLookupDefault` as this is the default treatment of a directory entry
- added some comments about the functionality