### PR TITLE
make shortstring counters only available for debug

### DIFF
--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -188,31 +188,25 @@ class ShortString {
     return ShortString(this->GetChars() + start_at, length-start_at);
   }
 
-#ifdef DEBUGMSG
   static uint64_t num_instances() { return atomic_read64(&num_instances_); }
   static uint64_t num_overflows() { return atomic_read64(&num_overflows_); }
-#endif
 
  private:
   std::string *long_string_;
   char stack_[StackSize+1];  // +1 to add a final '\0' if necessary
   unsigned char length_;
-#ifdef DEBUGMSG
   static atomic_int64 num_overflows_;
   static atomic_int64 num_instances_;
-#endif
 };  // class ShortString
 
 typedef ShortString<kDefaultMaxPath, 0> PathString;
 typedef ShortString<kDefaultMaxName, 1> NameString;
 typedef ShortString<kDefaultMaxLink, 2> LinkString;
 
-#ifdef DEBUGMSG
 template<unsigned char StackSize, char Type>
 atomic_int64 ShortString<StackSize, Type>::num_overflows_ = 0;
 template<unsigned char StackSize, char Type>
 atomic_int64 ShortString<StackSize, Type>::num_instances_ = 0;
-#endif
 
 // See posix.cc for the std::string counterparts
 PathString GetParentPath(const PathString &path);

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -506,6 +506,7 @@ void *TalkManager::MainResponder(void *data) {
 
       result += "Inode Generation:\n  " + cvmfs::PrintInodeGeneration();
 
+#ifdef DEBUGMSG
       // Manually setting the values of the ShortString counters
       mount_point->statistics()->Lookup("pathstring.n_instances")->
           Set(PathString::num_instances());
@@ -519,6 +520,7 @@ void *TalkManager::MainResponder(void *data) {
           Set(LinkString::num_instances());
       mount_point->statistics()->Lookup("linkstring.n_overflows")->
           Set(LinkString::num_overflows());
+#endif
 
       // Manually setting the inode tracker numbers
       glue::InodeTracker::Statistics inode_stats =

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -506,7 +506,6 @@ void *TalkManager::MainResponder(void *data) {
 
       result += "Inode Generation:\n  " + cvmfs::PrintInodeGeneration();
 
-#ifdef DEBUGMSG
       // Manually setting the values of the ShortString counters
       mount_point->statistics()->Lookup("pathstring.n_instances")->
           Set(PathString::num_instances());
@@ -520,7 +519,6 @@ void *TalkManager::MainResponder(void *data) {
           Set(LinkString::num_instances());
       mount_point->statistics()->Lookup("linkstring.n_overflows")->
           Set(LinkString::num_overflows());
-#endif
 
       // Manually setting the inode tracker numbers
       glue::InodeTracker::Statistics inode_stats =


### PR DESCRIPTION
Replacement for #2903; part of issue #2907 

I think `DEBUGMSG` should be the correct variable

Can be checked by removing or adding `CVMFS_DEBUGLOG` to the client config.

With the same actions performed on the repo...
If debuglog is given:
```
sudo cvmfs_talk -i lhcb.cern.ch internal affairs | grep pathstring
pathstring.n_instances|18028|Number of instances
pathstring.n_overflows|0|Number of overflows
```
Otherwise:
```
sudo cvmfs_talk -i lhcb.cern.ch internal affairs | grep pathstring
pathstring.n_instances|0|Number of instances
pathstring.n_overflows|0|Number of overflow
```

Not sure if it is worth to have an explicit test for it?