### PR TITLE
Add user.external_url extended attribute (replaces #2924)

### DIFF
--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -553,10 +553,12 @@ std::string ExternalURLMagicXattr::GetValue() {
   std::vector<std::string> host_chain;
   std::vector<int> rtt;
   unsigned current_host;
-  mount_point_->external_download_mgr()->GetHostInfo(
-    &host_chain, &rtt, &current_host);
-  if (host_chain.size()) {
-    return std::string(host_chain[current_host]) + std::string(path_.c_str());
+  if (mount_point_->external_download_mgr() != NULL) {
+    mount_point_->external_download_mgr()->GetHostInfo(
+      &host_chain, &rtt, &current_host);
+    if (host_chain.size()) {
+      return std::string(host_chain[current_host]) + std::string(path_.c_str());
+    }
   } else {
     return std::string("");
   }

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -64,6 +64,7 @@ MagicXattrManager::MagicXattrManager(MountPoint *mountpoint,
   Register("xfsroot.rawlink", new RawlinkMagicXattr());
 
   Register("user.authz", new AuthzMagicXattr());
+  Register("user.external_url", new ExternalURLMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -547,3 +548,22 @@ std::string UsedDirPMagicXattr::GetValue() {
 std::string VersionMagicXattr::GetValue() {
   return std::string(VERSION) + "." + std::string(CVMFS_PATCH_LEVEL);
 }
+
+std::string ExternalURLMagicXattr::GetValue() {
+  std::vector<std::string> host_chain;
+  std::vector<int> rtt;
+  unsigned current_host;
+  mount_point_->external_download_mgr()->GetHostInfo(
+    &host_chain, &rtt, &current_host);
+  if (host_chain.size()) {
+    return std::string(host_chain[current_host]) + std::string(path_.c_str());
+  } else {
+    return std::string("");
+  }
+}
+
+bool ExternalURLMagicXattr::PrepareValueFenced() {
+  return dirent_->IsRegular() && dirent_->IsExternalFile();
+}
+
+

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -363,4 +363,9 @@ class VersionMagicXattr : public BaseMagicXattr {
   virtual std::string GetValue();
 };
 
+class ExternalURLMagicXattr : public BaseMagicXattr {
+  virtual bool PrepareValueFenced();
+  virtual std::string GetValue();
+};
+
 #endif  // CVMFS_MAGIC_XATTR_H_

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -7,6 +7,17 @@ is_external_file() {
   [ x"$(attr -qg external_file "$full_file_path")" = x"1" ]
 }
 
+has_correct_external_url() {
+  cvmfs_mntpnt=${1}
+  external_base=${2}
+  filename=${3}
+
+  local cvmfs_fullpath=$cvmfs_mntpnt/$filename
+  local external_fullpath=$external_base/$filename
+
+  [ x"$(attr -qg external_url "$cvmfs_fullpath")" = x"$external_fullpath" ]
+} 
+
 get_content_hash() {
   local full_file_path="$1"
   attr -qg hash "$full_file_path"
@@ -159,6 +170,10 @@ cvmfs_run_test() {
     echo "Chunk count is $chunk_count"
     return 28
   fi
+  if ! has_correct_external_url ${cvmfs_mnt} $external_http_base chunked_file ; then
+    echo "External URL of chunked file points to the wrong place."
+    return 29
+  fi
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -221,7 +236,8 @@ cvmfs_run_test() {
   ##############################################################################
 
   # This part has to be second last
-
+  
+  echo "*** Cleanup: Remove files"
   start_transaction $CVMFS_TEST_REPO || return $?
   is_external_file ${cvmfs_mnt}/external/file || return 90
   is_external_file ${cvmfs_mnt}/chunked_file || return 90

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -1,6 +1,7 @@
 
 cvmfs_test_name="External data"
 cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
 
 is_external_file() {
   local full_file_path="$1"


### PR DESCRIPTION
Extension of PR #2924 
- Added NULL check for `external_downloadmgr`
- Extended integration test 615
- Rebased it to match `devel`

Problems with test 615:
- Extra check for `has_correct_external_url` works
BUT following fails:

1 ) line 227  
```
  create_stratum1 $CVMFS_TEST_615_REPLICA_NAME          \
                  $CVMFS_TEST_USER                       \
                  $CVMFS_STRATUM0                        \
                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub || return 110
```
with `Installing GeoIP Database... CVMFS_GEO_LICENSE_KEY not set fail`
2 ) `rm ${repo_dir}/external/file || return 91` line 244 with
`rm: cannot remove '/cvmfs/just.test.repo/external/file': Function not implemented`

Commenting both sections out will make the test pass.

