### PR TITLE
Use cvmfs-libs in cvmfs_talk, cvmfs_fsck

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -139,15 +139,12 @@ if (BUILD_CVMFS)
   #
   add_executable (cvmfs_fsck
                   compression.cc
-                  crypto/hash.cc
                   cvmfs_fsck.cc
                   statistics.cc
-                  util/exception.cc
-                  util/logging.cc
-                  util/posix.cc
-                  util/string.cc
   )
   target_link_libraries (cvmfs_fsck
+                         cvmfs_crypto
+                         cvmfs_util
                          ${ZLIB_LIBRARIES}
                          ${OPENSSL_LIBRARIES}
                          ${SHA3_LIBRARIES}
@@ -162,12 +159,8 @@ if (BUILD_CVMFS)
                   cvmfs_talk.cc
                   options.cc
                   sanitizer.cc
-                  util/exception.cc
-                  util/logging.cc
-                  util/posix.cc
-                  util/string.cc
   )
-  target_link_libraries (cvmfs_talk ${RT_LIBRARY} pthread)
+  target_link_libraries (cvmfs_talk cvmfs_util ${RT_LIBRARY} pthread)
 
   #
   # /usr/bin/cvmfs2

--- a/packaging/debian/cvmfs/control.in
+++ b/packaging/debian/cvmfs/control.in
@@ -11,7 +11,7 @@ Homepage: http://cernvm.cern.ch/portal/filesystem
 Package: cvmfs
 Architecture: i386 amd64 armhf arm64
 #Pre-Depends: ${misc:Pre-Depends}   (preparation for multiarch support)
-Depends: cvmfs-config-default | cvmfs-config, gawk, psmisc, lsof, autofs, fuse, curl, attr, libfuse2, zlib1g, gdb, uuid-dev, uuid, adduser, ${misc:Depends}
+Depends: cvmfs-config-default | cvmfs-config, gawk, psmisc, lsof, autofs, fuse, curl, attr, libfuse2, zlib1g, gdb, uuid-dev, uuid, adduser, cvmfs-libs (= ${binary:Version}), ${misc:Depends}
 Recommends: autofs (>= 5.1.2)
 #Multi-Arch: same   (preparation for multiarch support)
 Homepage: http://cernvm.cern.ch

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -165,6 +165,7 @@ Requires: util-linux
   %endif
 %endif
 Requires: cvmfs-config
+Requires: cvmfs-libs = %{version}
 
 # SELinux integration
 # These are needed to build the selinux policy module.
@@ -701,6 +702,8 @@ systemctl daemon-reload
 %endif
 
 %changelog
+* Wed Nov 16 2022 Jakob Blomer <jblomer@cern.ch> - 2.11.0
+- Make cvmfs-libs a dependency of the cvmfs package
 * Mon May 16 2022 Jakob Blomer <jblomer@cern.ch> - 2.10.0
 - Add /var/log/cvmfs to cvmfs-server package, set its SElinux label
 * Thu Sep 30 2021 Jakob Blomer <jblomer@cern.ch> - 2.9.0


### PR DESCRIPTION
Adds cvmfs-libs as a dependency for the cvmfs client package. This is a careful first PR to increase the use of cvmfs-libs, replacing multiple static compilations of the same utility classes.