### PR TITLE
cvmfs/publish: configure curl for https.

### DIFF
--- a/cvmfs/publish/repository_session.cc
+++ b/cvmfs/publish/repository_session.cc
@@ -82,6 +82,8 @@ static void MakeAcquireRequest(
   shash::Any hmac(shash::kSha1);
   shash::HmacString(key.secret(), payload, &hmac);
   SslCertificateStore cs;
+  cs.UseSystemCertificatePath();
+  cs.ApplySslCertificatePath(h_curl); 
 
   const std::string header_str =
     std::string("Authorization: ") + key.id() + " " +
@@ -92,9 +94,8 @@ static void MakeAcquireRequest(
 
   // Make request to acquire lease from repo services
   curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/leases").c_str());
-  curl_easy_setopt(h_curl, CURLOPT_CAPATH, cs.GetCaPath().c_str());
-  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
-  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
+  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
+  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(payload.length()));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
@@ -128,6 +129,8 @@ static void MakeDropRequest(
   shash::Any hmac(shash::kSha1);
   shash::HmacString(key.secret(), session_token, &hmac);
   SslCertificateStore cs;
+  cs.UseSystemCertificatePath();
+  cs.ApplySslCertificatePath(h_curl); 
 
   const std::string header_str =
     std::string("Authorization: ") + key.id() + " " +
@@ -138,9 +141,8 @@ static void MakeDropRequest(
 
   curl_easy_setopt(h_curl, CURLOPT_URL,
                    (repo_service_url + "/leases/" + session_token).c_str());
-  curl_easy_setopt(h_curl, CURLOPT_CAPATH, cs.GetCaPath().c_str());
-  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
-  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
+  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
+  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(0));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, NULL);

--- a/cvmfs/publish/repository_session.cc
+++ b/cvmfs/publish/repository_session.cc
@@ -83,7 +83,7 @@ static void MakeAcquireRequest(
   shash::HmacString(key.secret(), payload, &hmac);
   SslCertificateStore cs;
   cs.UseSystemCertificatePath();
-  cs.ApplySslCertificatePath(h_curl); 
+  cs.ApplySslCertificatePath(h_curl);
 
   const std::string header_str =
     std::string("Authorization: ") + key.id() + " " +
@@ -94,8 +94,6 @@ static void MakeAcquireRequest(
 
   // Make request to acquire lease from repo services
   curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/leases").c_str());
-  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
-  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(payload.length()));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
@@ -130,7 +128,7 @@ static void MakeDropRequest(
   shash::HmacString(key.secret(), session_token, &hmac);
   SslCertificateStore cs;
   cs.UseSystemCertificatePath();
-  cs.ApplySslCertificatePath(h_curl); 
+  cs.ApplySslCertificatePath(h_curl);
 
   const std::string header_str =
     std::string("Authorization: ") + key.id() + " " +
@@ -141,8 +139,6 @@ static void MakeDropRequest(
 
   curl_easy_setopt(h_curl, CURLOPT_URL,
                    (repo_service_url + "/leases/" + session_token).c_str());
-  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
-  //curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(0));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, NULL);

--- a/cvmfs/publish/repository_session.cc
+++ b/cvmfs/publish/repository_session.cc
@@ -19,6 +19,7 @@
 #include "gateway_util.h"
 #include "json_document.h"
 #include "publish/except.h"
+#include "ssl.h"
 #include "upload.h"
 #include "util/logging.h"
 #include "util/pointer.h"
@@ -80,6 +81,7 @@ static void MakeAcquireRequest(
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(key.secret(), payload, &hmac);
+  SslCertificateStore cs;
 
   const std::string header_str =
     std::string("Authorization: ") + key.id() + " " +
@@ -90,6 +92,9 @@ static void MakeAcquireRequest(
 
   // Make request to acquire lease from repo services
   curl_easy_setopt(h_curl, CURLOPT_URL, (repo_service_url + "/leases").c_str());
+  curl_easy_setopt(h_curl, CURLOPT_CAPATH, cs.GetCaPath().c_str());
+  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
+  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(payload.length()));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, payload.c_str());
@@ -122,6 +127,7 @@ static void MakeDropRequest(
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(key.secret(), session_token, &hmac);
+  SslCertificateStore cs;
 
   const std::string header_str =
     std::string("Authorization: ") + key.id() + " " +
@@ -132,6 +138,9 @@ static void MakeDropRequest(
 
   curl_easy_setopt(h_curl, CURLOPT_URL,
                    (repo_service_url + "/leases/" + session_token).c_str());
+  curl_easy_setopt(h_curl, CURLOPT_CAPATH, cs.GetCaPath().c_str());
+  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYPEER, 0);
+  curl_easy_setopt(h_curl, CURLOPT_SSL_VERIFYHOST, 0);
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDSIZE_LARGE,
                    static_cast<curl_off_t>(0));
   curl_easy_setopt(h_curl, CURLOPT_POSTFIELDS, NULL);

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -9,6 +9,7 @@
 #include "crypto/hash.h"
 #include "gateway_util.h"
 #include "json_document.h"
+#include "ssl.h"
 #include "util/logging.h"
 #include "util/pointer.h"
 #include "util/string.h"
@@ -62,6 +63,10 @@ bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
   shash::Any hmac(shash::kSha1);
   shash::HmacString(secret, payload, &hmac);
 
+  SslCertificateStore cs;
+  cs.UseSystemCertificatePath();
+  cs.ApplySslCertificatePath(h_curl);
+
   const std::string header_str = std::string("Authorization: ") + key_id + " " +
                                  Base64(hmac.ToString(false));
   struct curl_slist* auth_header = NULL;
@@ -102,6 +107,10 @@ bool MakeEndRequest(const std::string& method, const std::string& key_id,
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(secret, session_token, &hmac);
+
+  SslCertificateStore cs;
+  cs.UseSystemCertificatePath();
+  cs.ApplySslCertificatePath(h_curl);
 
   const std::string header_str = std::string("Authorization: ") + key_id + " " +
                                  Base64(hmac.ToString(false));


### PR DESCRIPTION
Add the curl_easy_setopt options for setting up a https publisher connection to gateway.

Implements the feature described in #3060. Tested with both http and https gateways under CentOS 7.