### PR TITLE
libcurl - (re)enable http basic auth

### DIFF
--- a/externals/libcurl/src/configureHook.sh
+++ b/externals/libcurl/src/configureHook.sh
@@ -21,7 +21,7 @@ sh configure $FIX_COMP CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \
   --disable-shared \
   --enable-static \
   --enable-http \
-  --enable-http-basic-auth \
+  --enable-http-auth \
   --enable-proxy \
   --enable-file \
   --enable-ipv6 \

--- a/externals/libcurl/src/configureHook.sh
+++ b/externals/libcurl/src/configureHook.sh
@@ -51,7 +51,6 @@ sh configure $FIX_COMP CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \
   --disable-tls-srp \
   --disable-unix-sockets \
   --disable-cookies \
-  --disable-http-auth \
   --disable-doh \
   --disable-mime \
   --disable-dateparse \

--- a/externals/libcurl/src/configureHook.sh
+++ b/externals/libcurl/src/configureHook.sh
@@ -21,6 +21,7 @@ sh configure $FIX_COMP CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \
   --disable-shared \
   --enable-static \
   --enable-http \
+  --enable-http-basic-auth \
   --enable-proxy \
   --enable-file \
   --enable-ipv6 \


### PR DESCRIPTION
Needed to allow basic authentication with HTTP servers