### PR TITLE
Set CVMFS_ARCH env variable in cvmfs client

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -165,6 +165,8 @@ FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
   UniquePtr<FileSystem>
     file_system(new FileSystem(fs_info));
 
+  file_system->SetupGlobalEnvironmentParams();
+
   file_system->SetupLogging();
   LogCvmfs(kLogCvmfs, kLogDebug, "Options:\n%s",
            file_system->options_mgr()->Dump().c_str());
@@ -808,6 +810,14 @@ bool FileSystem::SetupCwd() {
   //  ...
   // }
   return true;
+}
+
+
+/**
+ * Environment variables useful, e.g., for variant symlinks
+ */
+void FileSystem::SetupGlobalEnvironmentParams() {
+  setenv("CVMFS_ARCH", GetArch().c_str(), 1 /* overwrite */);
 }
 
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -273,6 +273,7 @@ class FileSystem : SingleCopy, public BootFactory {
 
   explicit FileSystem(const FileSystemInfo &fs_info);
 
+  void SetupGlobalEnvironmentParams();
   void SetupLogging();
   void CreateStatistics();
   void SetupSqlite();
@@ -406,8 +407,8 @@ class FileSystem : SingleCopy, public BootFactory {
 
 /**
  * The StatfsCache class is a class purely designed as "struct" (= holding
- * object for all its parameters). 
- * All its logic, including the locking mechanism, is implemented in the 
+ * object for all its parameters).
+ * All its logic, including the locking mechanism, is implemented in the
  * function cvmfs_statfs in cvmfs.cc
  */
 class StatfsCache : SingleCopy {

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -33,6 +33,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <sys/utsname.h>
 #include <sys/wait.h>
 #include <unistd.h>
 // If valgrind headers are present on the build system, then we can detect
@@ -1425,6 +1426,16 @@ std::string GetHomeDirectory() {
   std::string home_dir = result->pw_dir;
   free(buf);
   return home_dir;
+}
+
+/**
+ * Returns the output of `uname -m`
+ */
+std::string GetArch() {
+  struct utsname info;
+  int retval = uname(&info);
+  assert(retval == 0);
+  return info.machine;
 }
 
 

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -149,6 +149,8 @@ CVMFS_EXPORT mode_t GetUmask();
 CVMFS_EXPORT bool AddGroup2Persona(const gid_t gid);
 CVMFS_EXPORT std::string GetHomeDirectory();
 
+CVMFS_EXPORT std::string GetArch();
+
 CVMFS_EXPORT int SetLimitNoFile(unsigned limit_nofile);
 CVMFS_EXPORT void GetLimitNoFile(unsigned *soft_limit, unsigned *hard_limit);
 

--- a/test/src/648-variantsymlink/main
+++ b/test/src/648-variantsymlink/main
@@ -2,6 +2,16 @@ cvmfs_test_name="Variant symlinks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
+TEST648_PRIVATE_MOUNT=
+
+cleanup() {
+  echo "running cleanup()..."
+  if [ "x$TEST648_PRIVATE_MOUNT" != "x" ]; then
+    sudo umount $TEST648_PRIVATE_MOUNT
+    TEST648_PRIVATE_MOUNT=
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -12,6 +22,8 @@ cvmfs_run_test() {
   echo "*** create variant symlink"
   start_transaction $CVMFS_TEST_REPO || return $?
   ln -s '$(CVMFS_VAR_LINK)' /cvmfs/$CVMFS_TEST_REPO/varlink || return 10
+  ln -s '$(CVMFS_ARCH)' /cvmfs/$CVMFS_TEST_REPO/arch || return 10
+  mkdir /cvmfs/$CVMFS_TEST_REPO/$(uname -m) || return 10
   publish_repo $CVMFS_TEST_REPO || return 11
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
@@ -19,6 +31,14 @@ cvmfs_run_test() {
   echo '$(CVMFS_VAR_LINK)' > varlink.reference
   readlink /cvmfs/$CVMFS_TEST_REPO/varlink > varlink.published
   diff varlink.reference varlink.published || return 20
+
+  TEST648_PRIVATE_MOUNT="$(pwd)/mntpnt"
+  do_local_mount "$TEST648_PRIVATE_MOUNT"          \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" || return 30
+  trap cleanup EXIT HUP INT TERM
+
+  ls $TEST648_PRIVATE_MOUNT/arch/ || return 31
 
   return 0
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -145,11 +145,8 @@ stat_wrapper() {
 }
 
 # Find the service binary (or detect systemd)
-minpidof() {
-  pidof $1 | tr " " "\n" | sort --numeric-sort | head -n1
-}
 SERVICE_BIN="false"
-if ! pidof systemd > /dev/null 2>&1 || [ $(minpidof systemd) -ne 1 ]; then
+if ! pidof systemd > /dev/null 2>&1 || ! [ -d /run/systemd/system ]; then
   if [ -x /sbin/service ]; then
     SERVICE_BIN="/sbin/service"
   elif [ -x /usr/sbin/service ]; then

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -166,6 +166,24 @@ TEST_F(T_Util, GetHomeDirectory) {
 }
 
 
+TEST_F(T_Util, GetArch) {
+  int fd_stdin;
+  int fd_stdout;
+  int fd_stderr;
+  ASSERT_TRUE(Shell(&fd_stdin, &fd_stdout, &fd_stderr));
+  ASSERT_TRUE(SafeWrite(fd_stdin, "/usr/bin/uname -m\n", 18));
+  close(fd_stdin);
+  char arch[257];
+  ssize_t nbytes = SafeRead(fd_stdout, arch, 256);
+  close(fd_stdout);
+  close(fd_stderr);
+  ASSERT_GT(nbytes, 0);
+  ASSERT_LT(nbytes, 257);
+  arch[nbytes] = '\0';
+  EXPECT_EQ(Trim(arch, true /* trim_newline */), GetArch());
+}
+
+
 TEST_F(T_Util, GetGidOf) {
 #ifdef __APPLE__
   const std::string group_name = "wheel";

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -171,7 +171,7 @@ TEST_F(T_Util, GetArch) {
   int fd_stdout;
   int fd_stderr;
   ASSERT_TRUE(Shell(&fd_stdin, &fd_stdout, &fd_stderr));
-  ASSERT_TRUE(SafeWrite(fd_stdin, "/usr/bin/uname -m\n", 18));
+  ASSERT_TRUE(SafeWrite(fd_stdin, "uname -m\n", 18));
   close(fd_stdin);
   char arch[257];
   ssize_t nbytes = SafeRead(fd_stdout, arch, 256);


### PR DESCRIPTION
Makes it possible to use CVMFS_ARCH (== uname -m) in variant symlinks