### PR TITLE
[gw] Store publisher hostname as part of lease

### DIFF
--- a/cvmfs/publish/repository_session.cc
+++ b/cvmfs/publish/repository_session.cc
@@ -77,7 +77,8 @@ static void MakeAcquireRequest(
 
   const std::string payload = "{\"path\" : \"" + repo_path +
                               "\", \"api_version\" : \"" +
-                              StringifyInt(gateway::APIVersion()) + "\"}";
+                              StringifyInt(gateway::APIVersion()) + "\", " +
+                              "\"hostname\" : \"" + GetHostname() + "\"}";
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(key.secret(), payload, &hmac);

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -58,7 +58,8 @@ bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
 
   const std::string payload = "{\"path\" : \"" + repo_path +
                               "\", \"api_version\" : \"" +
-                              StringifyInt(gateway::APIVersion()) + "\"}";
+                              StringifyInt(gateway::APIVersion()) + "\"" +
+                              ", \"hostname\" : \"clientident\"}";
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(secret, payload, &hmac);

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -12,6 +12,7 @@
 #include "ssl.h"
 #include "util/logging.h"
 #include "util/pointer.h"
+#include "util/posix.h"
 #include "util/string.h"
 
 namespace {
@@ -59,7 +60,7 @@ bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
   const std::string payload = "{\"path\" : \"" + repo_path +
                               "\", \"api_version\" : \"" +
                               StringifyInt(gateway::APIVersion()) + "\"" +
-                              ", \"hostname\" : \"clientident\"}";
+                              ", \"hostname\" : \"" + GetHostname() + "\"}";
 
   shash::Any hmac(shash::kSha1);
   shash::HmacString(secret, payload, &hmac);

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -743,6 +743,14 @@ int RecvFdFromSocket(int msg_fd) {
 }
 
 
+std::string GetHostname() {
+  char name[HOST_NAME_MAX + 1];
+  int retval = gethostname(name, HOST_NAME_MAX);
+  assert(retval == 0);
+  return name;
+}
+
+
 /**
  * set(e){g/u}id wrapper.
  */

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -98,6 +98,7 @@ CVMFS_EXPORT void Block2Nonblock(int filedes);
 CVMFS_EXPORT void SendMsg2Socket(const int fd, const std::string &msg);
 CVMFS_EXPORT bool SendFd2Socket(int socket_fd, int passing_fd);
 CVMFS_EXPORT int RecvFdFromSocket(int msg_fd);
+CVMFS_EXPORT std::string GetHostname();
 
 CVMFS_EXPORT bool SwitchCredentials(const uid_t uid, const gid_t gid,
                                     const bool temporarily);

--- a/gateway/internal/gateway/backend/backend.go
+++ b/gateway/internal/gateway/backend/backend.go
@@ -27,7 +27,7 @@ type ActionController interface {
 	GetRepo(ctx context.Context, repoName string) (*RepositoryConfig, error)
 	GetRepos(ctx context.Context) (map[string]RepositoryConfig, error)
 	SetRepoEnabled(ctx context.Context, repository string, enabled bool) error
-	NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error)
+	NewLease(ctx context.Context, keyID, leasePath, hostname string, protocolVersion int) (string, error)
 	GetLeases(ctx context.Context) (map[string]LeaseDTO, error)
 	GetLease(ctx context.Context, tokenStr string) (*LeaseDTO, error)
 	CancelLeases(ctx context.Context, repoPath string) error

--- a/gateway/internal/gateway/backend/db.go
+++ b/gateway/internal/gateway/backend/db.go
@@ -90,9 +90,9 @@ create table if not exists Lease (
 	Repository string not null,
 	Path string not null,
 	KeyID string not null,
-	Hostname string,
 	Expiration integer not null,
-	ProtocolVersion integer not null
+	ProtocolVersion integer not null,
+	Hostname string
 );
 create index lease_repository_path_idx ON Lease(Repository,Path);
 create table if not exists Repository (

--- a/gateway/internal/gateway/backend/db.go
+++ b/gateway/internal/gateway/backend/db.go
@@ -13,7 +13,7 @@ import (
 const (
 	// latestSchemaVersion represents the most recent lease DB schema version
 	// known to the application
-	latestSchemaVersion = 2
+	latestSchemaVersion = 3
 )
 
 // DB stores active leases
@@ -90,6 +90,7 @@ create table if not exists Lease (
 	Repository string not null,
 	Path string not null,
 	KeyID string not null,
+	Hostname string,
 	Expiration integer not null,
 	ProtocolVersion integer not null
 );
@@ -118,6 +119,18 @@ func checkSchemaVersion(db *sql.DB) (int, error) {
 		return 0, fmt.Errorf(
 			"unknown schema version: %v, latest known %v",
 			version, latestSchemaVersion)
+	}
+
+	if version == 2 {
+		statement := `
+alter table lease add column hostname string;
+update SchemaVersion set VersionNumber=3, ValidFrom=datetime('now');
+`
+		if _, err := db.Exec(statement); err != nil {
+			return 2, fmt.Errorf("could not migrate table schema (2->3): %w", err)
+		}
+
+		version = 3
 	}
 
 	return version, nil

--- a/gateway/internal/gateway/backend/lease_service.go
+++ b/gateway/internal/gateway/backend/lease_service.go
@@ -17,7 +17,7 @@ type LeaseDTO struct {
 }
 
 // NewLease for the specified path, using keyID
-func (s *Services) NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error) {
+func (s *Services) NewLease(ctx context.Context, keyID, leasePath, hostname string, protocolVersion int) (string, error) {
 	t0 := time.Now()
 
 	outcome := "success"
@@ -81,6 +81,7 @@ func (s *Services) NewLease(ctx context.Context, keyID, leasePath string, protoc
 		KeyID:           keyID,
 		Expiration:      time.Now().Add(s.Config.MaxLeaseTime),
 		ProtocolVersion: protocolVersion,
+		Hostname:        hostname,
 	}
 
 	if err := CreateLease(ctx, tx, lease); err != nil {
@@ -130,7 +131,7 @@ func (s *Services) GetLeases(ctx context.Context) (map[string]LeaseDTO, error) {
 	ret := make(map[string]LeaseDTO)
 	for _, l := range leases {
 		leasePath := l.Repository + l.Path
-		ret[leasePath] = LeaseDTO{KeyID: l.KeyID, LeasePath: leasePath, Expires: l.Expiration.String()}
+		ret[leasePath] = LeaseDTO{KeyID: l.KeyID, LeasePath: leasePath, Expires: l.Expiration.String(), Hostname: l.Hostname}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -173,6 +174,7 @@ func (s *Services) GetLease(ctx context.Context, token string) (*LeaseDTO, error
 		KeyID:     lease.KeyID,
 		LeasePath: lease.CombinedLeasePath(),
 		Expires:   lease.Expiration.String(),
+		Hostname:  lease.Hostname,
 	}
 	return ret, nil
 }

--- a/gateway/internal/gateway/backend/lease_service.go
+++ b/gateway/internal/gateway/backend/lease_service.go
@@ -13,6 +13,7 @@ type LeaseDTO struct {
 	KeyID     string `json:"key_id,omitempty"`
 	LeasePath string `json:"path,omitempty"`
 	Expires   string `json:"expires,omitempty"`
+	Hostname  string `json:"hostname,omitempty"`
 }
 
 // NewLease for the specified path, using keyID

--- a/gateway/internal/gateway/backend/lease_service_test.go
+++ b/gateway/internal/gateway/backend/lease_service_test.go
@@ -23,12 +23,12 @@ func TestLeaseServiceNewLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
 		defer backend.CancelLease(context.TODO(), token1)
-		token2, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token2, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err == nil {
 			backend.CancelLease(context.TODO(), token2)
 			t.Fatalf("new lease should not have been granted for busy path")
@@ -38,13 +38,13 @@ func TestLeaseServiceNewLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Microsecond
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
 		defer backend.CancelLease(context.TODO(), token1)
 		time.Sleep(backend.Config.MaxLeaseTime)
-		if _, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion); err != nil {
+		if _, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion); err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
 	})
@@ -52,12 +52,12 @@ func TestLeaseServiceNewLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
 		defer backend.CancelLease(context.TODO(), token1)
-		token2, err := backend.NewLease(context.TODO(), keyID, leasePath+"/below", lastProtocolVersion)
+		token2, err := backend.NewLease(context.TODO(), keyID, leasePath+"/below", "host", lastProtocolVersion)
 		if err == nil {
 			backend.CancelLease(context.TODO(), token2)
 			t.Fatalf("new lease should not have been granted for conflicting path")
@@ -67,7 +67,7 @@ func TestLeaseServiceNewLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyidNO"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err == nil {
 			backend.CancelLease(context.TODO(), token1)
 			t.Fatalf("invalid key was accepted")
@@ -77,7 +77,7 @@ func TestLeaseServiceNewLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "testNO.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err == nil {
 			backend.CancelLease(context.TODO(), token1)
 			t.Fatalf("invalid repo for key was accepted")
@@ -87,7 +87,7 @@ func TestLeaseServiceNewLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid2"
 		leasePath := "test2.repo.org/NO"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err == nil {
 			backend.CancelLease(context.TODO(), token1)
 			t.Fatalf("invalid path for key was accepted")
@@ -107,7 +107,7 @@ func TestLeaseServiceCancelLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
@@ -119,7 +119,7 @@ func TestLeaseServiceCancelLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
@@ -145,10 +145,10 @@ func TestLeaseServiceCancelLeaseByPath(t *testing.T) {
 	prefix := "test2.repo.org/some"
 	leasePath1 := path.Join(prefix, "path")
 	leasePath2 := "test2.repo.org/another"
-	if _, err := backend.NewLease(context.TODO(), keyID, leasePath1, lastProtocolVersion); err != nil {
+	if _, err := backend.NewLease(context.TODO(), keyID, leasePath1, "host", lastProtocolVersion); err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
-	if _, err := backend.NewLease(context.TODO(), keyID, leasePath2, lastProtocolVersion); err != nil {
+	if _, err := backend.NewLease(context.TODO(), keyID, leasePath2, "host", lastProtocolVersion); err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
 	if err := backend.CancelLeases(context.TODO(), prefix); err != nil {
@@ -172,7 +172,7 @@ func TestLeaseServiceGetLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
@@ -189,7 +189,7 @@ func TestLeaseServiceGetLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Microsecond
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token1, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
@@ -206,7 +206,7 @@ func TestLeaseServiceGetLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		_, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		_, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
@@ -236,7 +236,7 @@ func TestLeaseServiceCommitLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Second
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}
@@ -266,7 +266,7 @@ func TestLeaseServiceCommitLease(t *testing.T) {
 		backend.Config.MaxLeaseTime = 1 * time.Millisecond
 		keyID := "keyid1"
 		leasePath := "test2.repo.org/some/path"
-		token, err := backend.NewLease(context.TODO(), keyID, leasePath, lastProtocolVersion)
+		token, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", lastProtocolVersion)
 		if err != nil {
 			t.Fatalf("could not obtain new lease: %v", err)
 		}

--- a/gateway/internal/gateway/backend/session_test.go
+++ b/gateway/internal/gateway/backend/session_test.go
@@ -21,7 +21,7 @@ func TestSessionValid(t *testing.T) {
 	ctx := context.TODO()
 	keyID := "keyid1"
 	leasePath := "test2.repo.org/some/path"
-	token, err := backend.NewLease(ctx, keyID, leasePath, lastProtocolVersion)
+	token, err := backend.NewLease(ctx, keyID, leasePath, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestSessionSubmitWithInvalidToken(t *testing.T) {
 	ctx := context.TODO()
 	keyID := "keyid1"
 	leasePath := "test2.repo.org/some/path"
-	token, err := backend.NewLease(ctx, keyID, leasePath, lastProtocolVersion)
+	token, err := backend.NewLease(ctx, keyID, leasePath, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestSessionSubmitWithExpiredToken(t *testing.T) {
 	ctx := context.TODO()
 	keyID := "keyid1"
 	leasePath := "test2.repo.org/some/path"
-	token, err := backend.NewLease(ctx, keyID, leasePath, lastProtocolVersion)
+	token, err := backend.NewLease(ctx, keyID, leasePath, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestSessionCommitWithInvalidToken(t *testing.T) {
 	ctx := context.TODO()
 	keyID := "keyid1"
 	leasePath := "test2.repo.org/some/path"
-	token, err := backend.NewLease(ctx, keyID, leasePath, lastProtocolVersion)
+	token, err := backend.NewLease(ctx, keyID, leasePath, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestSessionCommitWithExpiredToken(t *testing.T) {
 	ctx := context.TODO()
 	keyID := "keyid1"
 	leasePath := "test2.repo.org/some/path"
-	token, err := backend.NewLease(ctx, keyID, leasePath, lastProtocolVersion)
+	token, err := backend.NewLease(ctx, keyID, leasePath, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
@@ -194,14 +194,14 @@ func TestSessionTwoConcurrentValid(t *testing.T) {
 	keyID := "keyid1"
 
 	leasePath1 := "test2.repo.org/some/path/one"
-	token1, err := backend.NewLease(ctx, keyID, leasePath1, lastProtocolVersion)
+	token1, err := backend.NewLease(ctx, keyID, leasePath1, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}
 	defer backend.CancelLease(ctx, token1)
 
 	leasePath2 := "test2.repo.org/some/path/two"
-	token2, err := backend.NewLease(ctx, keyID, leasePath2, lastProtocolVersion)
+	token2, err := backend.NewLease(ctx, keyID, leasePath2, "host", lastProtocolVersion)
 	if err != nil {
 		t.Fatalf("could not obtain new lease: %v", err)
 	}

--- a/gateway/internal/gateway/frontend/leases.go
+++ b/gateway/internal/gateway/frontend/leases.go
@@ -91,7 +91,7 @@ func handleNewLease(services be.ActionController, w http.ResponseWriter, h *http
 		// The authorization is expected to have the correct format, since it has already been checked.
 		keyID := strings.Split(h.Header.Get("Authorization"), " ")[0]
 		protocolVersion := MaxAPIVersion(clientVersion)
-		token, err := services.NewLease(ctx, keyID, reqMsg.Path, protocolVersion)
+		token, err := services.NewLease(ctx, keyID, reqMsg.Path, h.RemoteAddr, protocolVersion)
 		if err != nil {
 			if busyError, ok := err.(be.PathBusyError); ok {
 				msg["status"] = "path_busy"

--- a/gateway/internal/gateway/frontend/testutil.go
+++ b/gateway/internal/gateway/frontend/testutil.go
@@ -48,7 +48,7 @@ func (b *mockBackend) SetRepoEnabled(ctx context.Context, repository string, ena
 	return nil
 }
 
-func (b *mockBackend) NewLease(ctx context.Context, keyID, leasePath string, protocolVersion int) (string, error) {
+func (b *mockBackend) NewLease(ctx context.Context, keyID, leasePath, hostname string, protocolVersion int) (string, error) {
 	return "lease_token_string", nil
 }
 

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -38,6 +38,12 @@ cvmfs_run_test() {
     echo "***  Starting transaction 1"
     cvmfs_server transaction test.repo.org || return 20
 
+    echo "*** Checking lease database"
+    local hostname_lease=$(curl http://localhost:4929/api/v1/leases | jq -r '.data | .["test.repo.org/"].hostname')
+    echo "  Hostname from lease DB: $hostname_lease"
+    echo "  Hostname from env: $HOSTNAME"
+    [ x"$hostname_lease" = x"$HOSTNAME" ] || return 21
+
     echo "  Writing to a new file"
     echo "test" >> /cvmfs/test.repo.org/new_file.txt || return 21
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2526,8 +2526,13 @@ find_or_build_cvmfs_preload() {
 set_up_repository_gateway() {
     echo "Setting up repository gateway"
 
+    gateway_script=/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh
+    if [ -f /usr/lib/cvmfs-gateway/scripts/run_cvmfs_gateway.sh ]; then
+      gateway_script=/usr/lib/cvmfs-gateway/scripts/run_cvmfs_gateway.sh
+    fi
+
     echo "  Stopping repository gateway"
-    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh stop
+    sudo $gateway_script stop
 
     echo "  Cleaning up the repository gateway db"
     sudo rm -rf /var/lib/cvmfs-gateway/*
@@ -2567,12 +2572,12 @@ EOF'
     sudo sed -i -e "s/CVMFS_ROOT_HASH=.*//" /var/spool/cvmfs/test.repo.org/client.local
 
     echo "  Starting repository gateway"
-    sudo /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh start
+    sudo $gateway_script start
     # Let the service boot up
     sleep 1
-    /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh status
-    /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh status
-    /usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh status
+    $gateway_script status
+    $gateway_script status
+    $gateway_script status
 }
 
 lockfile() {

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -817,6 +817,11 @@ TEST_F(T_Util, SendRecvFd) {
 }
 
 
+TEST_F(T_Util, GetHostname) {
+  EXPECT_FALSE(GetHostname().empty());
+}
+
+
 TEST_F(T_Util, TcpEndpoints) {
   EXPECT_EQ(-1, MakeTcpEndpoint("foobar", 0));
   int fd_server = MakeTcpEndpoint("", 12345);


### PR DESCRIPTION
The publisher transmits its own hostname when asking for a new lease, which gets stored in the lease db. When the lease db is queried, available hostnames are returned.

This requires a schema upgrade of the lease db from v2 to v3.  The gateway will do this automatically when opening a v2 db.  Old publishers won't transmit a hostname, in which case the remote IP address from the HTTP request is used as a fallback.  Old leases will not have a hostname set, in which case none is returned in the lease listing.  Old gateways speaking to new publishers will ignore the transmitted hostname.