### PR TITLE
Re-enable core-file generation after credentials drop

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -847,6 +847,10 @@ int FuseMain(int argc, char *argv[]) {
       return kFailPermission;
     }
   }
+  if (disable_watchdog_) {
+    LogCvmfs(kLogCvmfs, kLogDebug, "No watchdog, enabling core files");
+    prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+  }
 
   // Only set usyslog now, otherwise file permissions are wrong
   usyslog_path_ = new string();

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -312,4 +312,8 @@ inline uint64_t platform_memsize() {
 }  // namespace CVMFS_NAMESPACE_GUARD
 #endif
 
+static int prctl(int option, uint64_t arg2, uint64_t arg3,
+                uint64_t arg4, uint64_t arg5) { return 0; }
+#define PR_SET_DUMPABLE 0
+
 #endif  // CVMFS_UTIL_PLATFORM_OSX_H_


### PR DESCRIPTION
We'd like the cvmfs2 process to dump core on assert() if the watchdog process is disabled. Since RHEL systems default to having the sysctl `fs.suid_dumpable==0`, we need to explicitly re-enable dumpability with an appropriate `prctl()` after dropping credentials.
(This is linux-only. I've not idea what the situation on macOS is)
