### PR TITLE
add waitpid check in mount.cvmfs.cc

### DIFF
--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -684,7 +684,7 @@ int main(int argc, char **argv) {
   close(fd_stdout);
   close(fd_stderr);
 
-  if(!ended) {
+  if (!ended) {
     retval = waitpid(pid_cvmfs, &status, 0);
     if (retval == -1) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Failed reading return code");

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -680,18 +680,11 @@ int main(int argc, char **argv) {
           return 32;
       }
     }
-    ended = (waitpid(pid_cvmfs, &status, 0) == pid_cvmfs);
+    ended = (waitpid(pid_cvmfs, &status, WNOHANG) == pid_cvmfs);
   } while ((stdout_open || stderr_open) && !ended);
   close(fd_stdout);
   close(fd_stderr);
 
-  if (!ended) {
-    retval = waitpid(pid_cvmfs, &status, 0);
-    if (retval == -1) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Failed reading return code");
-      return 32;
-    }
-  }
   if (WIFEXITED(status) && (WEXITSTATUS(status) == 0))
     return 0;
 

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -680,6 +680,7 @@ int main(int argc, char **argv) {
           return 32;
       }
     }
+    ended = (waitpid(pid_cvmfs, &status, 0) == pid_cvmfs);
   } while ((stdout_open || stderr_open) && !ended);
   close(fd_stdout);
   close(fd_stderr);

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -633,19 +633,23 @@ int main(int argc, char **argv) {
   fd_set readfds;
   bool stdout_open = true;
   bool stderr_open = true;
+  int status = 0;
+  int ended = false;
+
   do {
     FD_ZERO(&readfds);
     if (stdout_open) FD_SET(fd_stdout, &readfds);
     if (stderr_open) FD_SET(fd_stderr, &readfds);
-    do {
-      retval = select(nfds, &readfds, NULL, NULL, NULL);
-      if ((retval == -1) && (errno != EINTR)) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Failed to pipe stdout/stderr");
-        return 32;
-      }
-      if (retval > 0)
-        break;
-    } while (true);
+
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 100;
+    retval = select(nfds, &readfds, NULL, NULL, &timeout);
+    if ((retval == -1) && (errno != EINTR)) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to pipe stdout/stderr");
+      return 32;
+    }
+
     char buf;
     ssize_t num_bytes;
     if (FD_ISSET(fd_stdout, &readfds)) {
@@ -676,15 +680,16 @@ int main(int argc, char **argv) {
           return 32;
       }
     }
-  } while (stdout_open || stderr_open);
+  } while ((stdout_open || stderr_open) && !ended);
   close(fd_stdout);
   close(fd_stderr);
 
-  int status;
-  retval = waitpid(pid_cvmfs, &status, 0);
-  if (retval == -1) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed reading return code");
-    return 32;
+  if(!ended) {
+    retval = waitpid(pid_cvmfs, &status, 0);
+    if (retval == -1) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed reading return code");
+      return 32;
+    }
   }
   if (WIFEXITED(status) && (WEXITSTATUS(status) == 0))
     return 0;


### PR DESCRIPTION
Ref https://github.com/cvmfs/cvmfs/issues/3143
Required when `auto_unmount` option is used. Without this PR, mount.cvmfs gets stuck on the select()