### PR TITLE
Add CVMFS_CURL_DEBUGLOG to enable Curl transaction tracing

### DIFF
--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -1663,8 +1663,8 @@ void DownloadManager::Init(const unsigned max_pool_handles,
   curl_debug_file_ = NULL;
 }
 
-void DownloadManager::SetCurlDebug(std::string f) {
-  curl_debug_file_ = fopen(f.c_str(), "w");
+void DownloadManager::SetCurlDebugFile(FILE *f) {
+  curl_debug_file_ = f;
 }
 
 void DownloadManager::Fini() {
@@ -1679,8 +1679,6 @@ void DownloadManager::Fini() {
     close(pipe_jobs_[1]);
     close(pipe_jobs_[0]);
   }
-
-  if (curl_debug_file_) { fclose(curl_debug_file_); }
 
   for (set<CURL *>::iterator i = pool_handles_idle_->begin(),
        iEnd = pool_handles_idle_->end(); i != iEnd; ++i)

--- a/cvmfs/download.cc
+++ b/cvmfs/download.cc
@@ -895,6 +895,10 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
     curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(handle, CURLOPT_MAXREDIRS, 4);
   }
+  if (curl_debug_file_) {
+    curl_easy_setopt(handle, CURLOPT_STDERR, curl_debug_file_);
+    curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
+  }
 }
 
 
@@ -1656,8 +1660,12 @@ void DownloadManager::Init(const unsigned max_pool_handles,
   resolver_ = dns::NormalResolver::Create(opt_ipv4_only_,
     kDnsDefaultRetries, kDnsDefaultTimeoutMs);
   assert(resolver_);
+  curl_debug_file_ = NULL;
 }
 
+void DownloadManager::SetCurlDebug(std::string f) {
+  curl_debug_file_ = fopen(f.c_str(), "w");
+}
 
 void DownloadManager::Fini() {
   if (atomic_xadd32(&multi_threaded_, 0) == 1) {
@@ -1671,6 +1679,8 @@ void DownloadManager::Fini() {
     close(pipe_jobs_[1]);
     close(pipe_jobs_[0]);
   }
+
+  if (curl_debug_file_) { fclose(curl_debug_file_); }
 
   for (set<CURL *>::iterator i = pool_handles_idle_->begin(),
        iEnd = pool_handles_idle_->end(); i != iEnd; ++i)

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -453,6 +453,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void EnableInfoHeader();
   void EnableRedirects();
   void UseSystemCertificatePath();
+  void SetCurlDebug(const std::string debugfile);
 
   unsigned num_hosts() {
     if (opt_host_chain_) return opt_host_chain_->size();
@@ -462,6 +463,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   dns::IpPreference opt_ip_preference() const {
     return opt_ip_preference_;
   }
+
 
  private:
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
@@ -633,6 +635,8 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    * Carries the path settings for SSL certificates
    */
   SslCertificateStore ssl_certificate_store_;
+
+  FILE *curl_debug_file_;
 };  // DownloadManager
 
 }  // namespace download

--- a/cvmfs/download.h
+++ b/cvmfs/download.h
@@ -453,7 +453,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void EnableInfoHeader();
   void EnableRedirects();
   void UseSystemCertificatePath();
-  void SetCurlDebug(const std::string debugfile);
+  void SetCurlDebugFile(FILE *f);
 
   unsigned num_hosts() {
     if (opt_host_chain_) return opt_host_chain_->size();

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1249,7 +1249,7 @@ MountPoint *MountPoint::Create(
 
   std::string optarg;
   if (options_mgr->GetValue("CVMFS_CURL_DEBUGLOG", &optarg)) {
-    mountpoint->curl_debug_logfile_ = fopen(optarg.c_str(), "w");
+    mountpoint->curl_debug_logfile_ = fopen(optarg.c_str(), "a");
     mountpoint->download_mgr_->SetCurlDebugFile(
        mountpoint->curl_debug_logfile_);
     mountpoint->external_download_mgr_->SetCurlDebugFile(

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1767,6 +1767,7 @@ MountPoint::MountPoint(
   , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
   , talk_socket_uid_(0)
   , talk_socket_gid_(0)
+  , curl_debug_logfile_(NULL)
 {
   int retval = pthread_mutex_init(&lock_max_ttl_, NULL);
   assert(retval == 0);

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1396,6 +1396,10 @@ bool MountPoint::CreateDownloadManagers() {
     download_mgr_->ShardProxies();
   }
 
+  if (options_mgr_->GetValue("CVMFS_CURL_DEBUGLOG", &optarg)) {
+    download_mgr_->SetCurlDebug(optarg);
+  }
+
   return SetupExternalDownloadMgr(do_geosort);
 }
 
@@ -1992,6 +1996,10 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
     fallback_proxies = optarg;
   external_download_mgr_->SetProxyChain(
     proxies, fallback_proxies, download::DownloadManager::kSetProxyBoth);
+
+  if (options_mgr_->GetValue("CVMFS_EXTERNAL_CURL_DEBUGLOG", &optarg)) {
+    download_mgr_->SetCurlDebug(optarg);
+  }
 
   return true;
 }

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -597,7 +597,6 @@ class MountPoint : SingleCopy, public BootFactory {
   bool FetchHistory(std::string *history_path);
   std::string ReplaceHosts(std::string hosts);
   std::string GetUniqFileSuffix();
-
   std::string fqrn_;
   cvmfs::Uuid *uuid_;
   /**
@@ -650,6 +649,7 @@ class MountPoint : SingleCopy, public BootFactory {
   std::string talk_socket_path_;
   uid_t talk_socket_uid_;
   gid_t talk_socket_gid_;
+  FILE *curl_debug_logfile_;
 };  // class MointPoint
 
 #endif  // CVMFS_MOUNTPOINT_H_


### PR DESCRIPTION
Useful for logging Curl's transactions, can be used to test features that set particular headers.