### PR TITLE
Add conditional_assert()

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1887,6 +1887,13 @@ bool MountPoint::SetupBehavior() {
       return false;
     }
   }
+  if (options_mgr_->GetValue("CVMFS_SUPPRESS_ASSERTS", &optarg) &&
+      options_mgr_->IsOn(optarg))
+  {
+    g_conditional_assert = true;
+  } else {
+    g_conditional_assert = false;
+  }
 
   return true;
 }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1890,9 +1890,9 @@ bool MountPoint::SetupBehavior() {
   if (options_mgr_->GetValue("CVMFS_SUPPRESS_ASSERTS", &optarg) &&
       options_mgr_->IsOn(optarg))
   {
-    g_conditional_assert = true;
+    g_suppress_conditional_assert = true;
   } else {
-    g_conditional_assert = false;
+    g_suppress_conditional_assert = false;
   }
 
   return true;

--- a/cvmfs/util/exception.cc
+++ b/cvmfs/util/exception.cc
@@ -16,7 +16,7 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-bool g_conditional_assert = true;
+bool g_conditional_assert = false;
 
 void Panic(const char* coordinates, const LogSource source, const int mask,
            const char* format, ...) {

--- a/cvmfs/util/exception.cc
+++ b/cvmfs/util/exception.cc
@@ -16,6 +16,8 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
+bool g_conditional_assert = true;
+
 void Panic(const char* coordinates, const LogSource source, const int mask,
            const char* format, ...) {
   char* msg = NULL;

--- a/cvmfs/util/exception.cc
+++ b/cvmfs/util/exception.cc
@@ -16,7 +16,7 @@
 namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
-bool g_conditional_assert = false;
+bool g_suppress_conditional_assert = false;
 
 void Panic(const char* coordinates, const LogSource source, const int mask,
            const char* format, ...) {

--- a/cvmfs/util/exception.h
+++ b/cvmfs/util/exception.h
@@ -31,11 +31,10 @@ class CVMFS_EXPORT ECvmfsException : public std::runtime_error {
 
 
 // set to true to prevent conditional_assert() from asserting
-extern bool g_conditional_assert;
+extern bool g_suppress_conditional_assert;
 
-static inline bool conditional_assert(bool t) {
-  if ( !t && !g_conditional_assert ) { raise(SIGABRT); }
-  return t;
+static inline void conditional_assert(int t) {
+  if ( !(t == 0) && !g_suppress_conditional_assert ) { raise(SIGABRT); }
 }
 
 CVMFS_EXPORT

--- a/cvmfs/util/exception.h
+++ b/cvmfs/util/exception.h
@@ -5,10 +5,10 @@
 #ifndef CVMFS_UTIL_EXCEPTION_H_
 #define CVMFS_UTIL_EXCEPTION_H_
 
+#include <signal.h>
+
 #include <stdexcept>
 #include <string>
-
-#include <signal.h>
 
 #include "util/export.h"
 #include "util/logging.h"

--- a/cvmfs/util/exception.h
+++ b/cvmfs/util/exception.h
@@ -8,6 +8,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <signal.h>
+
 #include "util/export.h"
 #include "util/logging.h"
 
@@ -21,10 +23,20 @@ class CVMFS_EXPORT ECvmfsException : public std::runtime_error {
       : std::runtime_error(what_arg) {}
 };
 
+
 #define CVMFS_S1(x) #x
 #define CVMFS_S2(x) CVMFS_S1(x)
 #define CVMFS_SOURCE_LOCATION "PANIC: " __FILE__ " : " CVMFS_S2(__LINE__)
 #define PANIC(...) Panic(CVMFS_SOURCE_LOCATION, kLogCvmfs, __VA_ARGS__);
+
+
+// set to true to prevent conditional_assert() from asserting
+extern bool g_conditional_assert;
+
+static inline bool conditional_assert(bool t) {
+  if ( !t && !g_conditional_assert ) { raise(SIGABRT); }
+  return t;
+}
 
 CVMFS_EXPORT
 __attribute__((noreturn))

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -277,6 +277,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_clientctx.cc
   t_compression.cc
   t_compressor.cc
+  t_conditional_assert.cc
   t_dirtab.cc
   t_dns.cc
   t_download.cc

--- a/test/unittests/t_conditional_assert.cc
+++ b/test/unittests/t_conditional_assert.cc
@@ -1,0 +1,75 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <signal.h>
+
+#include "util/exception.h"
+
+#include "wpad.h"
+
+using namespace std;  // NOLINT
+
+bool g_conditional_assert;
+
+bool asserted = false;
+
+void handler(int sig) {
+  asserted = true;
+}
+
+#undef assert
+
+void assert(bool t) {
+  if (!t) { raise(SIGABRT); }
+}
+
+class T_Conditional_Assert : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    asserted = false;
+    signal(SIGABRT, handler);
+  }
+
+  virtual void TearDown() {
+    signal(SIGABRT, SIG_DFL);
+  }
+};
+
+
+TEST_F(T_Conditional_Assert, WithoutAssert) {
+  g_conditional_assert = false;
+  asserted = false;
+  bool ret = conditional_assert(0);
+
+  EXPECT_EQ(0, ret);
+  int has_asserted = asserted;
+  EXPECT_EQ(1, has_asserted);
+
+  asserted = false;
+  ret = conditional_assert(1);
+  EXPECT_EQ(1, ret);
+  has_asserted = asserted;
+  EXPECT_EQ(0, has_asserted);
+}
+
+TEST_F(T_Conditional_Assert, WithAssert) {
+  signal(SIGABRT, handler);
+
+  g_conditional_assert = true;
+  asserted = false;
+  bool ret = conditional_assert(0);
+  EXPECT_EQ(0, ret);
+  int has_asserted = asserted;
+  EXPECT_EQ(0, has_asserted);
+
+  asserted = false;
+  ret = conditional_assert(1);
+  EXPECT_EQ(1,  ret);
+  has_asserted = asserted;
+  EXPECT_EQ(0, has_asserted);
+
+  signal(SIGABRT, SIG_DFL);
+}

--- a/test/unittests/t_conditional_assert.cc
+++ b/test/unittests/t_conditional_assert.cc
@@ -17,7 +17,9 @@ bool g_conditional_assert;
 bool asserted = false;
 
 void handler(int sig) {
-  asserted = true;
+  if (sig == SIGABRT) {
+    asserted = true;
+  }
 }
 
 #undef assert

--- a/test/unittests/t_conditional_assert.cc
+++ b/test/unittests/t_conditional_assert.cc
@@ -53,6 +53,7 @@ TEST_F(T_Conditional_Assert, WithoutAssert) {
   EXPECT_EQ(0, has_asserted);
 
   asserted = false;
+  has_asserted = asserted;
   conditional_assert(1);
   EXPECT_EQ(0, has_asserted);
 
@@ -69,6 +70,7 @@ TEST_F(T_Conditional_Assert, WithAssert) {
   EXPECT_EQ(0, has_asserted);
 
   asserted = false;
+  has_asserted = asserted;
   conditional_assert(1);
   EXPECT_EQ(1, has_asserted);
 

--- a/test/unittests/t_conditional_assert.cc
+++ b/test/unittests/t_conditional_assert.cc
@@ -53,8 +53,8 @@ TEST_F(T_Conditional_Assert, WithoutAssert) {
   EXPECT_EQ(0, has_asserted);
 
   asserted = false;
-  has_asserted = asserted;
   conditional_assert(1);
+  has_asserted = asserted;
   EXPECT_EQ(0, has_asserted);
 
   signal(SIGABRT, SIG_DFL);
@@ -70,8 +70,8 @@ TEST_F(T_Conditional_Assert, WithAssert) {
   EXPECT_EQ(0, has_asserted);
 
   asserted = false;
-  has_asserted = asserted;
   conditional_assert(1);
+  has_asserted = asserted;
   EXPECT_EQ(1, has_asserted);
 
   signal(SIGABRT, SIG_DFL);


### PR DESCRIPTION
An alternative assert function. aborts if test if false unless CVMFS_SUPPRESS_ASSERTS=on, in which case the abort is suppressed.

Useful for situations where there is an assert()ing bug that doesn't yet have a fix but which has a tactical workaround in place.