### PR TITLE
Avoid checking deduplicated files twice in cvmfs_server check

### DIFF
--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -603,7 +603,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
           bool chunk_needs_check = true;
           if (!no_duplicates_map_ && !duplicates_map_.Contains(chunk_hash)) {
             duplicates_map_.Insert(chunk_hash, 1);
-          } else if (!no_duplicates_map) {
+          } else if (!no_duplicates_map_) {
             chunk_needs_check = false;
           }
           if (chunk_needs_check) {

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -587,7 +587,8 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
           const shash::Any &chunk_hash = this_chunk.content_hash();
           // for performance reasons, only perform the check once
           // and skip if the hash has been checked before
-          if (duplicates_map_.Contains(chunk_hash)) {
+          if (!duplicates_map_.Contains(chunk_hash)) {
+            duplicates_map_.Insert(chunk_hash, 1);
             const string chunk_path = "data/" + chunk_hash.MakePath();
             if (!Exists(chunk_path)) {
               LogCvmfs(kLogCvmfs, kLogStderr, "partial data chunk %s (%s -> "
@@ -598,9 +599,6 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
                        this_chunk.size());
               retval = false;
             }
-          } else {
-            // now hash is checked - add it to map
-            duplicates_map_.Insert(chunk_hash, 1);
           }
         }
       }

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -49,7 +49,7 @@ namespace swissknife {
 CommandCheck::CommandCheck()
     : check_chunks_(false)
     , is_remote_(false) {
-    const shash::Any hash_null(shash::kMd5);
+    const shash::Any hash_null;
     duplicates_map_.Init(16, hash_null, hasher_any);
 }
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -1089,8 +1089,8 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
-  const shash::Any hash_zero(shash::kMd5);
-  duplicates_map_.Init(16, hash_zero, hasher_any);
+  const shash::Any hash_null(shash::kMd5);
+  duplicates_map_.Init(16, hash_null, hasher_any);
 
   catalog::DeltaCounters computed_counters;
   successful = InspectTree(subtree_path,

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -603,6 +603,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
           bool chunk_needs_check = true;
           if (!no_duplicates_map_ && !duplicates_map_.Contains(chunk_hash)) {
             duplicates_map_.Insert(chunk_hash, 1);
+          } else {
             chunk_needs_check = false;
           }
           if (chunk_needs_check) {

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -348,11 +348,14 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
   bool found_nested_marker = false;
 
   for (unsigned i = 0; i < entries.size(); ++i) {
+    // for performance reasons, keep track of files already checked
+    // and only run requests once per hash
     const bool entry_needs_check =
           !entries[i].checksum().IsNull() && !entries[i].IsExternalFile() &&
           !duplicates_map_.Contains(entries[i].checksum());
     if (entry_needs_check)
         duplicates_map_.Insert(entries[i].checksum(), 1);
+
     PathString full_path(path);
     full_path.Append("/", 1);
     full_path.Append(entries[i].name().GetChars(),

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -46,6 +46,13 @@ static inline uint32_t hasher_any(const shash::Any &key) {
 
 namespace swissknife {
 
+CommandCheck::CommandCheck()
+    : check_chunks_(false)
+    , is_remote_(false) {
+    const shash::Any hash_null(shash::kMd5);
+    duplicates_map_.Init(16, hash_null, hasher_any);
+}
+
 bool CommandCheck::CompareEntries(const catalog::DirectoryEntry &a,
                                   const catalog::DirectoryEntry &b,
                                   const bool compare_names,
@@ -1092,8 +1099,6 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
-  const shash::Any hash_null(shash::kMd5);
-  duplicates_map_.Init(16, hash_null, hasher_any);
 
   catalog::DeltaCounters computed_counters;
   successful = InspectTree(subtree_path,

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -344,10 +344,10 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
   bool found_nested_marker = false;
 
   for (unsigned i = 0; i < entries.size(); ++i) {
-    const bool entry_needs_check = 
+    const bool entry_needs_check =
           !entries[i].checksum().IsNull() && !entries[i].IsExternalFile() &&
           !duplicates_map_.Contains(entries[i].checksum());
-    if (entry_needs_check) 
+    if (entry_needs_check)
         duplicates_map_.Insert(entries[i].checksum(), 1);
     PathString full_path(path);
     full_path.Append("/", 1);
@@ -596,7 +596,8 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
                        this_chunk.size());
               retval = false;
             }
-          } else { // now hash is checked - add it to map
+          } else {
+            // now hash is checked - add it to map
             duplicates_map_.Insert(chunk_hash, 1);
           }
         }

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -39,7 +39,7 @@ using namespace std;  // NOLINT
 static inline uint32_t hasher_any(const shash::Any &key) {
   // We'll just do the same thing as hasher_md5, since every hash is at
   // least as large.
-  return (uint32_t) *(reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  return *const_cast<uint32_t *>((reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -600,14 +600,14 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
           const shash::Any &chunk_hash = this_chunk.content_hash();
           // for performance reasons, only perform the check once
           // and skip if the hash has been checked before
-         bool chunk_needs_check = true;
-          if (!no_duplicates_map_ && duplicates_map_.Contains(chunk_hash)) {
+          bool chunk_needs_check = true;
+          if (!no_duplicates_map_ && !duplicates_map_.Contains(chunk_hash)) {
             duplicates_map_.Insert(chunk_hash, 1);
-           chunk_needs_check = false;
-         }
+            chunk_needs_check = false;
+          }
           if (chunk_needs_check) {
-            const string chunk_path = "data/" + chunk_hash.MakePath();
-            if (!Exists(chunk_path)) {
+           const string chunk_path = "data/" + chunk_hash.MakePath();
+           if (!Exists(chunk_path)) {
               LogCvmfs(kLogCvmfs, kLogStderr, "partial data chunk %s (%s -> "
                                               "offset: %d | size: %d) missing",
                        this_chunk.content_hash().ToStringWithSuffix().c_str(),

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -317,6 +317,10 @@ bool CommandCheck::InspectHistory(history::History *history) {
 
 /**
  * Recursive catalog walk-through
+ *
+ * TODO(vavolkl): This method is large and does a lot of checks
+ * that could be split into smaller ones.
+ * 
  */
 bool CommandCheck::Find(const catalog::Catalog *catalog,
                         const PathString &path,
@@ -390,8 +394,6 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
       string chunk_path = "data/" + entries[i].checksum().MakePath();
       if (entries[i].IsDirectory())
         chunk_path += shash::kSuffixMicroCatalog;
-    LogCvmfs(kLogCvmfs, kLogVerboseMsg, "[chunkpath] %s",
-             chunk_path.c_str());
       if (!Exists(chunk_path)) {
         LogCvmfs(kLogCvmfs, kLogStderr, "data chunk %s (%s) missing",
                  entries[i].checksum().ToString().c_str(), full_path.c_str());

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -345,7 +345,8 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
 
   for (unsigned i = 0; i < entries.size(); ++i) {
     const bool entry_needs_check = 
-          !entries[i].checksum().IsNull() && !duplicates_map_.Contains(entries[i].checksum());
+          !entries[i].checksum().IsNull() && !entries[i].IsExternalFile() &&
+          !duplicates_map_.Contains(entries[i].checksum());
     if (entry_needs_check) 
         duplicates_map_.Insert(entries[i].checksum(), 1);
     PathString full_path(path);
@@ -384,8 +385,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
     }
 
     // Check if the chunk is there
-    if (check_chunks_ && entry_needs_check &&
-        !entries[i].checksum().IsNull() && !entries[i].IsExternalFile())
+    if (check_chunks_ && entry_needs_check)
     {
       string chunk_path = "data/" + entries[i].checksum().MakePath();
       if (entries[i].IsDirectory())

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -39,7 +39,8 @@ using namespace std;  // NOLINT
 static inline uint32_t hasher_any(const shash::Any &key) {
   // We'll just do the same thing as hasher_md5, since every hash is at
   // least as large.
-  return *const_cast<uint32_t *>((reinterpret_cast<const uint32_t *>(key.digest) + 1));
+  return *const_cast<uint32_t *>(
+             reinterpret_cast<const uint32_t *>(key.digest) + 1);
 }
 
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -603,7 +603,7 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
           bool chunk_needs_check = true;
           if (!no_duplicates_map_ && !duplicates_map_.Contains(chunk_hash)) {
             duplicates_map_.Insert(chunk_hash, 1);
-          } else {
+          } else if (!no_duplicates_map) {
             chunk_needs_check = false;
           }
           if (chunk_needs_check) {

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -35,7 +35,7 @@ class CommandCheck : public Command {
   virtual std::string GetName() const { return "check"; }
   virtual std::string GetDescription() const {
     return "CernVM File System repository sanity checker\n"
-      "This command checks the consisteny of the file catalogs of a "
+      "This command checks the consistency of the file catalogs of a "
         "cvmfs repository.";
   }
   virtual ParameterList GetParams() const {
@@ -51,6 +51,9 @@ class CommandCheck : public Command {
     r.push_back(Parameter::Optional('R', "path to reflog.chksum file"));
     r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Switch('c', "check availability of data chunks"));
+    r.push_back(Parameter::Switch('d', "don't use hashmap to avoid duplicated"
+                                      " lookups. Note that this is a fallback"
+                                      " option that may be removed."));
     r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
     return r;
   }
@@ -92,6 +95,7 @@ class CommandCheck : public Command {
   std::string temp_directory_;
   std::string repo_base_path_;
   bool        check_chunks_;
+  bool        no_duplicates_map_;
   bool        is_remote_;
   SmallHashDynamic<shash::Any, char> duplicates_map_;
 };

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -10,6 +10,7 @@
 
 #include "catalog.h"
 #include "crypto/hash.h"
+#include "smallhash.h"
 #include "swissknife.h"
 
 namespace download {
@@ -91,6 +92,8 @@ class CommandCheck : public Command {
   std::string repo_base_path_;
   bool        check_chunks_;
   bool        is_remote_;
+  bool        entry_needs_check_;
+  SmallHashDynamic<shash::Any, char> duplicates_map_;
 };
 
 }  // namespace swissknife

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -92,7 +92,6 @@ class CommandCheck : public Command {
   std::string repo_base_path_;
   bool        check_chunks_;
   bool        is_remote_;
-  bool        entry_needs_check_;
   SmallHashDynamic<shash::Any, char> duplicates_map_;
 };
 

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -23,13 +23,14 @@ namespace manifest {
 class Manifest;
 }
 
+
+
+
 namespace swissknife {
 
 class CommandCheck : public Command {
  public:
-  CommandCheck()
-    : check_chunks_(false)
-    , is_remote_(false) {}
+  CommandCheck();
   ~CommandCheck() { }
   virtual std::string GetName() const { return "check"; }
   virtual std::string GetDescription() const {

--- a/test/common/mock_services/make_repo.py
+++ b/test/common/mock_services/make_repo.py
@@ -26,6 +26,7 @@ import sys
 import os
 import math
 import random
+import shutil
 from optparse import OptionParser
 
 # for python 2/3 compatibility:
@@ -47,7 +48,7 @@ def PrintError(msg):
 class RepoFactory:
   def __init__(self, max_dir_depth, num_subdirs, num_files_per_dir,    \
                symlink_ratio, hardlink_ratio, repo_dir, min_file_size, \
-               max_file_size):
+               max_file_size, duplicate_ratio=0.0):
     self.max_dir_depth      = max_dir_depth
     self.num_subdirs        = num_subdirs
     self.num_files_per_dir  = num_files_per_dir
@@ -56,6 +57,7 @@ class RepoFactory:
     self.repo_dir           = repo_dir
     self.min_file_size      = min_file_size
     self.max_file_size      = max_file_size
+    self.duplicate_ratio    = duplicate_ratio
     self.dirs_produced      = 0
     self.files_produced     = 0
     self.symlinks_produced  = 0
@@ -106,6 +108,8 @@ class RepoFactory:
         self._ProduceSymlink(''.join([path, "/symlink", str(i)]), master_file)
       elif random_val < self.symlink_ratio + self.hardlink_ratio:
         self._ProduceHardlink(''.join([path, "/hardlink", str(i)]), master_file)
+      elif random.random() < self.duplicate_ratio:
+        shutil.copyfile(master_file, ''.join([path, "/file", str(i)]))
       else:
         self._ProduceFile(''.join([path, "/file", str(i)]))
 

--- a/test/common/mock_services/make_repo.py
+++ b/test/common/mock_services/make_repo.py
@@ -161,6 +161,7 @@ if __name__ == "__main__":
   parser.add_option("-f", "--num-files-per-dir", dest="num_files_per_dir", default=30,     help="number of files per directory")
   parser.add_option("-s", "--min-file-size",     dest="min_file_size",     default=0,      help="minimal file size for random file contents")
   parser.add_option("-b", "--max-file-size",     dest="max_file_size",     default=102400, help="maximal file size for random file contents")
+  parser.add_option("-c", "--duplicate-ratio",   dest="duplicate_ratio",   default=0.0,    help="maximal file size for random file contents")
 
   # read command line arguments
   (options, args) = parser.parse_args()
@@ -172,6 +173,7 @@ if __name__ == "__main__":
     num_files_per_dir = int(options.num_files_per_dir)
     min_file_size     = int(options.min_file_size)
     max_file_size     = int(options.max_file_size)
+    duplicate_ratio   = float(options.duplicate_ratio)
   except ValueError:
     PrintError("Cannot parse numerical options and/or parameters")
   repo_dir = args[0]
@@ -193,7 +195,8 @@ if __name__ == "__main__":
                              hardlink_ratio,    \
                              repo_dir,          \
                              min_file_size,     \
-                             max_file_size)
+                             max_file_size,     \
+                             duplicate_ratio)
   repo_factory.PredictResults()
   print()
   repo_factory.Produce()

--- a/test/src/525-bigrepo/main
+++ b/test/src/525-bigrepo/main
@@ -1,8 +1,6 @@
 cvmfs_test_name="Split a Huge Repository into Nested Catalogs"
 cvmfs_test_autofs_on_startup=false
 
-export CVMFS_TEST_USER=root
-
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO

--- a/test/src/525-bigrepo/main
+++ b/test/src/525-bigrepo/main
@@ -1,6 +1,7 @@
 cvmfs_test_name="Split a Huge Repository into Nested Catalogs"
 cvmfs_test_autofs_on_startup=false
 
+
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO

--- a/test/src/525-bigrepo/main
+++ b/test/src/525-bigrepo/main
@@ -1,6 +1,7 @@
 cvmfs_test_name="Split a Huge Repository into Nested Catalogs"
 cvmfs_test_autofs_on_startup=false
 
+export CVMFS_TEST_USER=root
 
 cvmfs_run_test() {
   logfile=$1

--- a/test/src/705-servercheck-hashmap/main
+++ b/test/src/705-servercheck-hashmap/main
@@ -1,0 +1,61 @@
+#!/bin/bash
+cvmfs_test_name="Hashmap to avoid duplicated lookups in cvmfs_server check"
+cvmfs_test_autofs_on_startup=false
+
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "generating an artificial but more or less representative repo"
+    ${TEST_ROOT}/common/mock_services/make_repo.py \
+    --max-dir-depth        3                                    \
+    --num-subdirs          2                                    \
+    --num-files-per-dir    5                                    \
+    --min-file-size        0                                    \
+    --max-file-size     5120                                    \
+    --duplicate-ratio    0.5                                    \
+    $repo_dir || return 1
+
+  mkdir /cvmfs/test.cern.ch/testdata
+  echo "abcdefg12345" > /cvmfs/test.cern.ch/testdata/a
+  cp /cvmfs/test.cern.ch/testdata/a /cvmfs/test.cern.ch/testdata/b
+
+
+  echo "creating CVMFS snapshot"
+  echo "--> redirecting publishing output to publish_output_1.log and publish_error_1.log"
+  publish_repo $CVMFS_TEST_REPO > publish_output_1.log 2>publish_error_1.log || return $?
+
+  echo "check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i | tee  server_check.log || return $?
+
+  grep  "/testdata/b \[needs check\] 0" server_check.log || return $?
+
+  cvmfs_swissknife check -c -d  -l 4 -r http://localhost/cvmfs/test.cern.ch  \
+                        -k /etc/cvmfs/keys/test.cern.ch.pub -N test.cern.ch \
+                         | tee server_check_no_hashmap.log || return $?
+
+  grep  "/testdata/b \[needs check\] 1" server_check_no_hashmap.log || return $?
+
+  #TODO (vvolkl): add test for chunked files
+
+  echo "find out how many file system items are in the repo"
+  local num_1
+  num_1=$(find $repo_dir | wc -l)
+  echo "found $num_1 file system entries"
+
+  if [ $num_1 -lt 1 ]; then
+    echo "found $num_1 file system entries, should be more than one"
+    return 3;
+  fi
+
+  return 0
+}


### PR DESCRIPTION
First implementation of the suggestion in  https://github.com/cvmfs/cvmfs/issues/3138. Adds a map that keeps track of checksums, and skips the `Exists()` check if the file has already been seen. In local tests this does speed up cvmfs_server check: Using `525-bigrepo` (modified to have half duplicated files) it reduces `cvmfs_server check` times from 2min to 1min20s.

Still to do:
- add formal testing
- restructure code (overload Exists())

Fixes #3138 