### PR TITLE
[GC] delete objects only once

### DIFF
--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -96,6 +96,8 @@ class GarbageCollector {
   unsigned int preserved_catalog_count() const { return preserved_catalogs_; }
   unsigned int condemned_catalog_count() const { return condemned_catalogs_; }
   unsigned int condemned_objects_count() const { return condemned_objects_;  }
+  unsigned int duplicate_delete_requests() const { 
+                                           return duplicate_delete_requests_;  }
   uint64_t condemned_bytes_count() const { return condemned_bytes_;  }
   uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }
 
@@ -144,6 +146,8 @@ class GarbageCollector {
   ReflogBasedInfoShim  catalog_info_shim_;
   CatalogTraversalT    traversal_;
   HashFilterT          hash_filter_;
+  HashFilterT          hash_map_delete_requests_;
+
 
   bool use_reflog_timestamps_;
   /**
@@ -175,6 +179,7 @@ class GarbageCollector {
 
   unsigned int          condemned_objects_;
   uint64_t              condemned_bytes_;
+  unsigned int          duplicate_delete_requests_;
 };
 
 #include "garbage_collector_impl.h"

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -96,7 +96,7 @@ class GarbageCollector {
   unsigned int preserved_catalog_count() const { return preserved_catalogs_; }
   unsigned int condemned_catalog_count() const { return condemned_catalogs_; }
   unsigned int condemned_objects_count() const { return condemned_objects_;  }
-  unsigned int duplicate_delete_requests() const { 
+  unsigned int duplicate_delete_requests() const {
                                            return duplicate_delete_requests_;  }
   uint64_t condemned_bytes_count() const { return condemned_bytes_;  }
   uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -312,7 +312,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
         "gc.sz_condemned_bytes", "number of deleted bytes");
     perf::Counter *ctr_duplicate_delete_requests =
       configuration_.statistics->Register(
-        "gc.n_duplicate_delete_requests", "number of duplicated delete requests");
+      "gc.n_duplicate_delete_requests", "number of duplicated delete requests");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -312,7 +312,7 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
         "gc.sz_condemned_bytes", "number of deleted bytes");
     perf::Counter *ctr_duplicate_delete_requests =
       configuration_.statistics->Register(
-        "gc.duplicate_delete_requests", "number of duplicated delete requests");
+        "gc.n_duplicate_delete_requests", "number of duplicated delete requests");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -175,7 +175,7 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::CheckAndSweep(
     } else {
       ++duplicate_delete_requests_;
       LogCvmfs(kLogGc, kLogDebug, "Hash %s already marked as to delete",
-               hash.ToString());
+               hash.ToString().c_str());
     }
   }
 }

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -36,6 +36,7 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(
       GarbageCollector<CatalogTraversalT, HashFilterT>::GetTraversalParams(
                                                                 configuration))
   , hash_filter_()
+  , hash_map_delete_requests_()
   , use_reflog_timestamps_(false)
   , oldest_trunk_catalog_(static_cast<uint64_t>(-1))
   , oldest_trunk_catalog_found_(false)
@@ -46,6 +47,7 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(
   , last_reported_status_(0.0)
   , condemned_objects_(0)
   , condemned_bytes_(0)
+  , duplicate_delete_requests_(0)
 {
   assert(configuration_.uploader != NULL);
 }
@@ -166,8 +168,16 @@ template <class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::CheckAndSweep(
   const shash::Any &hash)
 {
-  if (!hash_filter_.Contains(hash))
-    Sweep(hash);
+  if (!hash_filter_.Contains(hash)) {
+    if (!hash_map_delete_requests_.Contains(hash)) {
+      hash_map_delete_requests_.Fill(hash);
+      Sweep(hash);
+    } else {
+      ++duplicate_delete_requests_;
+      LogCvmfs(kLogGc, kLogDebug, "Hash %s already marked as to delete",
+               hash.ToString());
+    }
+  }
 }
 
 
@@ -300,10 +310,14 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
     perf::Counter *ctr_condemned_bytes =
       configuration_.statistics->Register(
         "gc.sz_condemned_bytes", "number of deleted bytes");
+    perf::Counter *ctr_duplicate_delete_requests =
+      configuration_.statistics->Register(
+        "gc.duplicate_delete_requests", "number of duplicated delete requests");
     ctr_preserved_catalogs->Set(preserved_catalog_count());
     ctr_condemned_catalogs->Set(condemned_catalog_count());
     ctr_condemned_objects->Set(condemned_objects_count());
     ctr_condemned_bytes->Set(condemned_bytes_count());
+    ctr_duplicate_delete_requests->Set(duplicate_delete_requests());
   }
 
   configuration_.uploader->WaitForUpload();

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -374,7 +374,7 @@ bool StatisticsDatabase::LiveSchemaUpgradeIfNecessary() {
     }
   }
 
-  if (IsEqualSchema(schema_version(), kLatestSchema) && 
+  if (IsEqualSchema(schema_version(), kLatestSchema) &&
       (schema_revision() == 3)) {
     LogCvmfs(kLogCvmfs, kLogDebug, "upgrading schema revision (3 --> 4) of "
                                    "statistics database");

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -99,7 +99,7 @@ struct GcStats {
   std::string n_condemned_catalogs;
   std::string n_condemned_objects;
   std::string sz_condemned_bytes;
-  std::string duplicate_delete_requests;
+  std::string n_duplicate_delete_requests;
 
   explicit GcStats(const perf::Statistics *statistics) {
     perf::Counter *c = NULL;
@@ -111,8 +111,8 @@ struct GcStats {
     n_condemned_objects = c ? c->ToString() : "0";
     c = statistics->Lookup("gc.sz_condemned_bytes");
     sz_condemned_bytes = c ? c->ToString() : "0";
-    c = statistics->Lookup("gc.duplicate_delete_requests");
-    duplicate_delete_requests = c ? c->ToString() : "0";
+    c = statistics->Lookup("gc.n_duplicate_delete_requests");
+    n_duplicate_delete_requests = c ? c->ToString() : "0";
   }
 };
 
@@ -200,7 +200,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       "n_condemned_catalogs,"
       "n_condemned_objects,"
       "sz_condemned_bytes,"
-      "duplicate_delete_requests,"
+      "n_duplicate_delete_requests,"
       "success)"
       " VALUES("
       "'" + start_time + "'," +
@@ -209,7 +209,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       stats.n_condemned_catalogs + ","+
       stats.n_condemned_objects + "," +
       stats.sz_condemned_bytes + "," +
-      stats.duplicate_delete_requests + "," +
+      stats.n_duplicate_delete_requests + "," +
       (success ? "1" : "0") + ");";
   } else {
     // insert values except sz_condemned_bytes
@@ -220,7 +220,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       "n_preserved_catalogs,"
       "n_condemned_catalogs,"
       "n_condemned_objects,"
-      "duplicate_delete_requests,"
+      "n_duplicate_delete_requests,"
       "success)"
       " VALUES("
       "'" + start_time + "'," +
@@ -228,7 +228,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       stats.n_preserved_catalogs + "," +
       stats.n_condemned_catalogs + "," +
       stats.n_condemned_objects + "," +
-      stats.duplicate_delete_requests + "," +
+      stats.n_duplicate_delete_requests + "," +
       (success ? "1" : "0") + ");";
   }
   return insert_statement;
@@ -271,7 +271,7 @@ bool StatisticsDatabase::CreateEmptyDatabase() {
     "n_condemned_catalogs INTEGER,"
     "n_condemned_objects INTEGER,"
     "sz_condemned_bytes INTEGER,"
-    "duplicate_delete_requests INTEGER,"
+    "n_duplicate_delete_requests INTEGER,"
     "success INTEGER);").Execute();
   return ret1 & ret2;
 }

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -99,6 +99,7 @@ struct GcStats {
   std::string n_condemned_catalogs;
   std::string n_condemned_objects;
   std::string sz_condemned_bytes;
+  std::string duplicate_delete_requests;
 
   explicit GcStats(const perf::Statistics *statistics) {
     perf::Counter *c = NULL;
@@ -110,6 +111,8 @@ struct GcStats {
     n_condemned_objects = c ? c->ToString() : "0";
     c = statistics->Lookup("gc.sz_condemned_bytes");
     sz_condemned_bytes = c ? c->ToString() : "0";
+    c = statistics->Lookup("gc.duplicate_delete_requests");
+    duplicate_delete_requests = c ? c->ToString() : "0";
   }
 };
 
@@ -197,6 +200,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       "n_condemned_catalogs,"
       "n_condemned_objects,"
       "sz_condemned_bytes,"
+      "duplicate_delete_requests,"
       "success)"
       " VALUES("
       "'" + start_time + "'," +
@@ -205,6 +209,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       stats.n_condemned_catalogs + ","+
       stats.n_condemned_objects + "," +
       stats.sz_condemned_bytes + "," +
+      stats.duplicate_delete_requests + "," +
       (success ? "1" : "0") + ");";
   } else {
     // insert values except sz_condemned_bytes
@@ -215,6 +220,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       "n_preserved_catalogs,"
       "n_condemned_catalogs,"
       "n_condemned_objects,"
+      "duplicate_delete_requests,"
       "success)"
       " VALUES("
       "'" + start_time + "'," +
@@ -222,6 +228,7 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
       stats.n_preserved_catalogs + "," +
       stats.n_condemned_catalogs + "," +
       stats.n_condemned_objects + "," +
+      stats.duplicate_delete_requests + "," +
       (success ? "1" : "0") + ");";
   }
   return insert_statement;
@@ -264,6 +271,7 @@ bool StatisticsDatabase::CreateEmptyDatabase() {
     "n_condemned_catalogs INTEGER,"
     "n_condemned_objects INTEGER,"
     "sz_condemned_bytes INTEGER,"
+    "duplicate_delete_requests INTEGER,"
     "success INTEGER);").Execute();
   return ret1 & ret2;
 }

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -80,6 +80,12 @@ cvmfs_run_test() {
   cvmfs_server gc -r1 -f $CVMFS_TEST_REPO || return 4
 
   # ====================== Test gc stats ======================
+  
+  # just check that we have 2 different values (start value = 0 and 7?) 
+  # for n_duplicate_delete_requests
+  local diff_values_duplicates=$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT n_duplicate_delete_requests FROM gc_statistics" | sort | uniq | wc -l)
+  [ $diff_values_duplicates -eq "2" ] || return 5
+ 
   local sz_condemned_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_condemned_bytes) FROM gc_statistics")"
   local uploaded_bytes="$(sqlite3 $CVMFS_TEST_661_DB_PATH "SELECT SUM(sz_bytes_uploaded) FROM publish_statistics")"
 


### PR DESCRIPTION
Issue #3117 
new hashmap that remembers which hashes are already requested to be deleted and skips them if called again
new counter `duplicate_delete_requests_` to count how many of the requests were skipped

2 questions:
- `// TODO(jblomer): turn current counters into perf::Counters` - ??
- `generate_stats_plots.c` - extend it?

extended test by some super simple lines. not sure if needed?