### PR TITLE
Avoid segfault when calling dtor on uninitialized smallhash

### DIFF
--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -186,8 +186,10 @@ class SmallHashBase {
     for (uint32_t i = 0; i < c; ++i) {
       v[i].~Value();
     }
-    smunmap(k);
-    smunmap(v);
+    if (k)
+      smunmap(k);
+    if (v)
+      smunmap(v);
     k = NULL;
     v = NULL;
   }

--- a/test/unittests/t_smallhash.cc
+++ b/test/unittests/t_smallhash.cc
@@ -231,3 +231,8 @@ TEST_F(T_Smallhash, MultihashMultithread) {
   EXPECT_EQ(unsigned(0), GetMultiSize());
 }
 
+TEST_F(T_Smallhash, CanDestructUninitialized) {
+  SmallHashDynamic<int, int>*  smallhash_uninit = new SmallHashDynamic<int, int>();
+  // No Init()
+  delete smallhash_uninit;
+}

--- a/test/unittests/t_smallhash.cc
+++ b/test/unittests/t_smallhash.cc
@@ -232,7 +232,8 @@ TEST_F(T_Smallhash, MultihashMultithread) {
 }
 
 TEST_F(T_Smallhash, CanDestructUninitialized) {
-  SmallHashDynamic<int, int>*  smallhash_uninit = new SmallHashDynamic<int, int>();
+  SmallHashDynamic<int, int>*  smallhash_uninit =
+      new SmallHashDynamic<int, int>();
   // No Init()
   delete smallhash_uninit;
 }


### PR DESCRIPTION
Fixes #3177 