### PR TITLE
Add options to ignore the cache checks and make the memory threshold configurable

### DIFF
--- a/add-ons/check_cvmfs.sh
+++ b/add-ons/check_cvmfs.sh
@@ -322,7 +322,7 @@ do_check() {
     RETURN_STATUS=$STATUS_WARNING
   fi
 
-  if [ $OPT_IGNORE_CACHE = 0 ]; then
+  if [ $OPT_IGNORE_CACHE -eq 0 ]; then
     # Check for free space on cache partition
     DF_CACHE=`/bin/df -P "$CVMFS_CACHE_BASE"`
     if [ $? -ne 0 ]; then

--- a/add-ons/check_cvmfs.sh
+++ b/add-ons/check_cvmfs.sh
@@ -373,7 +373,7 @@ do_check() {
     fi
   fi
 
-  if [ $OPT_IGNORE_CACHE = 0 ]; then
+  if [ $OPT_IGNORE_CACHE -eq 0 ]; then
     # Check for number of cache cleanups within the last 24 hours
     if [ $NCLEANUP24 -gt 24 ]; then
       append_info "frequent cache cleanups, cache might be undersized"

--- a/add-ons/check_cvmfs.sh
+++ b/add-ons/check_cvmfs.sh
@@ -4,7 +4,7 @@
 # Bugs and comments to Jakob Blomer (jblomer@cern.ch)
 #
 # ChangeLog
-# 1.12a - 31.01.2023
+# 1.13 - 31.01.2023
 #    - Add -c option to skip cache checks (for osgstorage.org)
 #    - Add -M option to Customize the memory check threshold
 # 1.12 - 05.11.2021

--- a/add-ons/check_cvmfs.sh
+++ b/add-ons/check_cvmfs.sh
@@ -29,7 +29,7 @@
 #    - return immediately if transport endpoint is not connected
 #    - start of ChangeLog
 
-VERSION=1.12a
+VERSION=1.13
 
 STATUS_OK=0
 STATUS_WARNING=1     # Check timed out or CernVM-FS resource consumption high or

--- a/add-ons/check_cvmfs.sh
+++ b/add-ons/check_cvmfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # CernVM-FS check for Nagios
-# Version 1.12a, last modified: 31.01.2023
+# Version 1.13, last modified: 31.01.2023
 # Bugs and comments to Jakob Blomer (jblomer@cern.ch)
 #
 # ChangeLog


### PR DESCRIPTION
There are two additional configuration options to add to the check_cvmfs script:

1. An option to set the memory threshold instead of the hard-coded default
2. A flag to ignore the cache related checks, mostly for osgstorage.org which doesn't play well with the cache

According to DrDave, the osgstorage.org repos don't expect many cache hits. So the default (non-shared) cache size should be small. This is going to trip up the checks. For these repos we want to ignore the cache checks.
