### PR TITLE
ManagedExec: close only FDs that have been opened

### DIFF
--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1719,7 +1719,7 @@ struct ForkFailures {  // TODO(rmeusel): C++11 (type safe enum)
     kSendPid,
     kUnknown,
     kFailDupFd,
-    kFailGetMaxFd,
+    kFailCloseFds,
     kFailGetFdFlags,
     kFailSetFdFlags,
     kFailDropCredentials,
@@ -1736,8 +1736,8 @@ struct ForkFailures {  // TODO(rmeusel): C++11 (type safe enum)
         return "Unknown Status";
       case kFailDupFd:
         return "Duplicate File Descriptor";
-      case kFailGetMaxFd:
-        return "Read maximal File Descriptor";
+      case kFailCloseFds:
+        return "Close File Descriptors";
       case kFailGetFdFlags:
         return "Read File Descriptor Flags";
       case kFailSetFdFlags:
@@ -1884,7 +1884,8 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
 
     // Child, close file descriptors
     if (!CloseAllFildes(skip_fds)) {
-      failed = ForkFailures::kUnknown;
+      failed = ForkFailures::kFailCloseFds;
+      goto fork_failure;
     }
 
     // Double fork to disconnect from parent


### PR DESCRIPTION
This PR replaces the current way of closing FDs before `exec()`. Instead iterating over 0..max_fd and doing as many `close()` syscalls, look into what FDs are actually open and `close` only those.

I have a version with [`close_range()`](https://man7.org/linux/man-pages/man2/close_range.2.html) too, but this might be sufficient for now?

With this patch:
```
[root@a9f6578addd9 cvmfs]# ulimit -n
1073741816
[root@a9f6578addd9 cvmfs]# time ./cvmfs2 -o parse,debug '' /mnt -d --foreground
Debug: using library ./libcvmfs_fuse3_stub.so
# CernVM-FS parameters:


real	0m0.005s
user	0m0.002s
sys	0m0.002s
```

Without this patch, with this `ulimit -n`, it takes around 45min.

Fixes: https://github.com/cvmfs/cvmfs/issues/3158