### PR TITLE
codespell fix typos in the main cvmfs/ codebase, add codespell workflow to catch any new typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -7,4 +7,5 @@ skip = .git
 # quarantaine -- type cripped into a folder name, change is undesired so far into
 #                the project, makes it tricky/impossible to distinguish
 #                folder name for a generally mistyped word, so ignored altogether
-ignore-words-list = gir,ative,parm,numer,quarantaine
+# MSDOS -- used in C-preprocessor directives
+ignore-words-list = gir,ative,parm,numer,quarantaine,msdos

--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,7 @@ skip = .git
 # ative -- used in 3 lines, not really sure if there is no ad-hoc semantic
 # parm -- used in cvmfs/authz/authz_curl.cc
 # numer -- numerator abbreviated in cvmfs/util/platform_osx.h
-ignore-words-list = gir,ative,parm,numer
+# quarantaine -- type cripped into a folder name, change is undesired so far into
+#                the project, makes it tricky/impossible to distinguish
+#                folder name for a generally mistyped word, so ignored altogether
+ignore-words-list = gir,ative,parm,numer,quarantaine

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,6 @@
 [codespell]
 skip = .git
 # gir -- codespell wants it to be git
-ignore-words-list = gir
+# ative -- used in 3 lines, not really sure if there is no ad-hoc semantic
+# parm -- used in cvmfs/authz/authz_curl.cc
+ignore-words-list = gir,ative,parm

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.rtf
+skip = .git,*.rtf,cvmfs-universal.spec
 # gir -- codespell wants it to be git
 # ative -- used in 3 lines, not really sure if there is no ad-hoc semantic
 # parm -- used in cvmfs/authz/authz_curl.cc

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git
+# gir -- codespell wants it to be git
+ignore-words-list = gir

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,5 @@ skip = .git
 # gir -- codespell wants it to be git
 # ative -- used in 3 lines, not really sure if there is no ad-hoc semantic
 # parm -- used in cvmfs/authz/authz_curl.cc
-ignore-words-list = gir,ative,parm
+# numer -- numerator abbreviated in cvmfs/util/platform_osx.h
+ignore-words-list = gir,ative,parm,numer

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git
+skip = .git,*.rtf
 # gir -- codespell wants it to be git
 # ative -- used in 3 lines, not really sure if there is no ad-hoc semantic
 # parm -- used in cvmfs/authz/authz_curl.cc

--- a/cvmfs/authz/authz.h
+++ b/cvmfs/authz/authz.h
@@ -47,7 +47,7 @@ enum AuthzStatus {
 
 /**
  * The credentials together with the membership string it was verified for.
- * Entries expire.  Negative credential verification can be representated, too,
+ * Entries expire.  Negative credential verification can be represented, too,
  * with status != kAuthzOk.
  */
 struct AuthzData {

--- a/cvmfs/authz/authz_curl.cc
+++ b/cvmfs/authz/authz_curl.cc
@@ -253,7 +253,7 @@ bool AuthzAttachment::ConfigureCurlHandle(
 
   if (parm->pkey == NULL) {
     // Sigh - PEM_X509_INFO_read doesn't understand old key encodings.
-    // Try a more general-purpose funciton.
+    // Try a more general-purpose function.
     BIO *bio_token = BIO_new_mem_buf(token->data, token->size);
     assert(bio_token != NULL);
     EVP_PKEY *old_pkey = PEM_read_bio_PrivateKey(bio_token, NULL, NULL, NULL);

--- a/cvmfs/authz/authz_fetch.h
+++ b/cvmfs/authz/authz_fetch.h
@@ -124,7 +124,7 @@ class AuthzExternalFetcher : public AuthzFetcher, SingleCopy {
 
  private:
   /**
-   * After 5 seconds of unresponsiveness, helper prcesses may be killed.
+   * After 5 seconds of unresponsiveness, helper processes may be killed.
    */
   static const unsigned kChildTimeout = 5;
 

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -205,7 +205,7 @@ class CacheManager : SingleCopy {
    * When RestoreState is called, the cache has already exactly one file
    * descriptor open: the root file catalog. This file descriptor might be
    * remapped to another number. A return value of -1 means no action needs
-   * to take place. A smaller value inidicates an error.
+   * to take place. A smaller value indicates an error.
    */
   int RestoreState(const int fd_progress, void *state);
   void FreeState(const int fd_progress, void *state);

--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -1,6 +1,6 @@
 // This file is part of the CernVM File System.
 //
-// Protocol defintion for RPCs between cvmfs client and cache manager plugin.
+// Protocol definition for RPCs between cvmfs client and cache manager plugin.
 // The protocol is used to access a store of content-addressable objects that
 // are maintained by a cache manager plugin.  Objects are reference counted,
 // mirroring currently open files.  Only objects with reference count zero may
@@ -154,7 +154,7 @@ message MsgIoctl {
   required uint64 session_id = 1;
   // When there are no more open connections, the cache plugin can shutdown
   // itself.  During client reloads, this is unwanted.  Before the reload, the
-  // client tells the plugin to artifically increase the connection counter.
+  // client tells the plugin to artificially increase the connection counter.
   // Once reloading has finished, the connection counter is decreased again.
   optional sint32 conncnt_change_by  = 2;
 }
@@ -238,7 +238,7 @@ message MsgShrinkReply {
   required uint64 used_bytes  = 3;
 }
 
-// Read a portion from a stored object.  Garuanteed to work for objects with a
+// Read a portion from a stored object.  Guaranteed to work for objects with a
 // reference counter larger than zero.
 message MsgReadReq {
   required uint64 session_id = 1;
@@ -297,7 +297,7 @@ message MsgListReq {
 }
 
 // The cache manager decides how many objects are in each part.  The cache
-// manager assignes a unique listing id so that clients can continue to query
+// manager assigns a unique listing id so that clients can continue to query
 // for more listings.
 message MsgListReply {
   required uint64 req_id             = 1;

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -153,7 +153,7 @@ struct cvmcache_context *ctx;
 
 
 /**
- * Implements all the cache plugin callbacks.  Singelton.
+ * Implements all the cache plugin callbacks.  Singleton.
  */
 class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
  public:

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -163,7 +163,7 @@ struct cvmcache_callbacks {
   int (*cvmcache_info)(struct cvmcache_info *info);
   int (*cvmcache_shrink)(uint64_t shrink_to, uint64_t *used);
   /**
-   * Listing can be "approximate", e.g. if files are removed and/or addded in
+   * Listing can be "approximate", e.g. if files are removed and/or added in
    * the meantime, this may or may not be reflected.
    */
   int (*cvmcache_listing_begin)(uint64_t lst_id,

--- a/cvmfs/cache_plugin/libcvmfs_cache.h
+++ b/cvmfs/cache_plugin/libcvmfs_cache.h
@@ -19,7 +19,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-// Map C++ clases to their C interface names
+// Map C++ classes to their C interface names
 typedef class SimpleOptionsParser cvmcache_option_map;
 #else
 typedef struct OptionsManager cvmcache_option_map;

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -33,7 +33,7 @@ class DownloadManager;
 }
 
 /**
- * Cache manger implementation using a file system (cache directory) as a
+ * Cache manager implementation using a file system (cache directory) as a
  * backing storage.
  */
 class PosixCacheManager : public CacheManager {

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -293,7 +293,7 @@ int RamCacheManager::OpenFromTxn(void *txn) {
   int64_t retval = CommitToKvStore(transaction);
   if (retval < 0) {
     LogCvmfs(kLogCache, kLogDebug,
-             "error while commiting transaction on %s: %s",
+             "error while committing transaction on %s: %s",
              transaction->buffer.id.ToString().c_str(), strerror(-retval));
     return retval;
   }

--- a/cvmfs/cache_transport.h
+++ b/cvmfs/cache_transport.h
@@ -67,7 +67,7 @@ class CacheTransport {
    */
   static const uint32_t kMaxMsgSize = (2 << 24) - 1;  // 24MB (3 bytes)
   /**
-   * The first byte has the wire protocol version, optinally or-ed with the
+   * The first byte has the wire protocol version, optionally or-ed with the
    * "has attachment" flag.  The other three bytes encode the overall message
    * size in little-endian.
    */

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -790,7 +790,7 @@ Catalog* Catalog::FindSubtree(const PathString &path) const {
       result = FindChild(path_prefix);
 
       // If we found a child serving a part of the path we can stop searching.
-      // Remaining sub path elements are possbily served by a grand child.
+      // Remaining sub path elements are possibly served by a grand child.
       if (result != NULL)
         break;
     }
@@ -818,7 +818,7 @@ Catalog* Catalog::FindChild(const PathString &mountpoint) const {
 
 
 /**
- * For the transtion points for nested catalogs and bind mountpoints, the inode
+ * For the transition points for nested catalogs and bind mountpoints, the inode
  * is ambiguous. It has to be set to the parent inode because nested catalogs
  * are lazily loaded.
  * @param md5path the MD5 hash of the entry to check

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -806,7 +806,7 @@ bool AbstractCatalogManager<CatalogT>::IsAttached(const PathString &root_path,
  * The final leaf nested catalog is returned.
  * The is_listable parameter is relevant if path is a nested catalog.  Only
  * if is_listable is true, the nested catalog will be used; otherwise the parent
- * with the transation point is sufficient.
+ * with the transaction point is sufficient.
  */
 template <class CatalogT>
 bool AbstractCatalogManager<CatalogT>::MountSubtree(

--- a/cvmfs/catalog_mgr_ro.h
+++ b/cvmfs/catalog_mgr_ro.h
@@ -60,7 +60,7 @@ class SimpleCatalogManager : public AbstractCatalogManager<Catalog> {
 
   /**
    * Makes the given path relative to the catalog structure
-   * Pathes coming out here can be used for lookups in catalogs
+   * Paths coming out here can be used for lookups in catalogs
    * @param relativePath the path to be mangled
    * @return the mangled path
    */

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -128,7 +128,7 @@ manifest::Manifest *WritableCatalogManager::CreateRepository(
   root_entry.linkcount_         = 2;
   string root_path = "";
 
-  // Create the database schema and the inital root entry
+  // Create the database schema and the initial root entry
   {
     UniquePtr<CatalogDatabase> new_clg_db(CatalogDatabase::Create(file_path));
     if (!new_clg_db.IsValid() ||
@@ -331,7 +331,7 @@ void WritableCatalogManager::Clone(const std::string destination,
 
 
 /**
- * Copies an entire directory tree from the exisitng from_dir to the
+ * Copies an entire directory tree from the existing from_dir to the
  * non-existing to_dir. The destination's parent directory must exist. On the
  * catalog level, the new entries will be identical to the old ones except
  * for their path hash fields.
@@ -634,7 +634,7 @@ void WritableCatalogManager::AddHardlinkGroup(
   }
 
   // Get a valid hardlink group id for the catalog the group will end up in
-  // TODO(unkown): Compaction
+  // TODO(unknown): Compaction
   uint32_t new_group_id = catalog->GetMaxLinkId() + 1;
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "hardlink group id %u issued",
            new_group_id);
@@ -724,7 +724,7 @@ void WritableCatalogManager::TouchDirectory(const DirectoryEntryBase &entry,
     LogCvmfs(kLogCatalog, kLogVerboseMsg,
              "updating transition point at %s", entry_path.c_str());
 
-    // find and mount nested catalog assciated to this transition point
+    // find and mount nested catalog associated to this transition point
     shash::Any nested_hash;
     uint64_t nested_size;
     retval = catalog->FindNested(transition_path, &nested_hash, &nested_size);
@@ -766,7 +766,7 @@ void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
           nested_root_path.c_str());
   }
 
-  // Create the database schema and the inital root entry
+  // Create the database schema and the initial root entry
   // for the new nested catalog
   const string database_file_path = CreateTempPath(dir_temp() + "/catalog",
                                                    0666);
@@ -781,7 +781,7 @@ void WritableCatalogManager::CreateNestedCatalog(const std::string &mountpoint)
                                                     // catalog gets VOMS authz
                                                new_root_entry);
   assert(retval);
-  // TODO(rmeusel): we need a way to attach a catalog directy from an open
+  // TODO(rmeusel): we need a way to attach a catalog directly from an open
   // database to remove this indirection
   delete new_catalog_db;
   new_catalog_db = NULL;
@@ -1093,12 +1093,12 @@ bool WritableCatalogManager::Commit(const bool           stop_for_tweaks,
 
 /**
  * Handles the snapshotting of dirty (i.e. modified) catalogs while trying to
- * parallize the compression and upload as much as possible. We use a parallel
+ * parallelize the compression and upload as much as possible. We use a parallel
  * depth first post order tree traversal based on 'continuations'.
  *
  * The idea is as follows:
  *  1. find all leaf-catalogs (i.e. dirty catalogs with no dirty children)
- *     --> these can be processed and uploaded immedately and independently
+ *     --> these can be processed and uploaded immediately and independently
  *         see WritableCatalogManager::GetModifiedCatalogLeafs()
  *  2. annotate non-leaf catalogs with their number of dirty children
  *     --> a finished child will notify it's parent and decrement this number
@@ -1115,7 +1115,7 @@ bool WritableCatalogManager::Commit(const bool           stop_for_tweaks,
  *       catalogs.
  *
  * TODO(rmeusel): since all leaf catalogs are finalized in the main thread, we
- *                sacrafice some potential concurrency for simplicity.
+ *                sacrifice some potential concurrency for simplicity.
  */
 WritableCatalogManager::CatalogInfo WritableCatalogManager::SnapshotCatalogs(
                                                    const bool stop_for_tweaks) {
@@ -1295,7 +1295,7 @@ void WritableCatalogManager::CatalogUploadCallback(
 
 /**
  * Finds dirty catalogs that can be snapshot right away and annotates all the
- * other catalogs with their number of dirty decendants.
+ * other catalogs with their number of dirty descendants.
  * Note that there is a convenience wrapper to start the recursion:
  *   WritableCatalogManager::GetModifiedCatalogLeafs()
  *

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -18,7 +18,7 @@
  * catalog do not change (expect on reload). As we do exactly that with the
  * WritableCatalogManager here, inode numbers derived from WritableCatalogs
  * and the WritableCatalogManager may (and will) be screwed.  This is not an
- * issue in the current implementation, as they are not used in the synching
+ * issue in the current implementation, as they are not used in the syncing
  * process.  Just keep in mind.
  *
  * The WritableCatalogManager starts with a base repository (given by the

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -590,7 +590,7 @@ void WritableCatalog::RemoveNestedCatalog(const string &mountpoint,
 
 
 /**
- * Unregisteres a snapshot from /.cvmfs/snapshots. Note that bind mountpoints
+ * Unregisters a snapshot from /.cvmfs/snapshots. Note that bind mountpoints
  * are not universally handled: in Partition and MergeIntoParent, bind
  * mountpoint handling is missing!
  */

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -528,7 +528,7 @@ void WritableCatalog::InsertNestedCatalog(const string &mountpoint,
 
 
 /**
- * Registeres a snapshot in /.cvmfs/snapshots. Note that bind mountpoints are
+ * Registers a snapshot in /.cvmfs/snapshots. Note that bind mountpoints are
  * not universally handled: in Partition and MergeIntoParent, bind mountpoint
  * handling is missing!
  */
@@ -698,7 +698,7 @@ void WritableCatalog::CopyCatalogsToParent() {
 void WritableCatalog::CopyToParent() {
   // We could simply copy all entries from this database to the 'other' database
   // BUT: 1. this would create collisions in hardlink group IDs.
-  //         therefor we first update all hardlink group IDs to fit behind the
+  //         therefore we first update all hardlink group IDs to fit behind the
   //         ones in the 'other' database
   //      2. the root entry of the nested catalog is present twice:
   //         1. in the parent directory (as mount point) and

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -52,7 +52,7 @@ namespace catalog {
 //
 // 1.x (earlier - code base still in SVN)
 //     * pre-historic times
-// 0.9 (some time 2011, artifical version)
+// 0.9 (some time 2011, artificial version)
 //     * 1.0 catalogs that lack the SHA-1 value for nested catalogs
 const float CatalogDatabase::kLatestSchema = 2.5;
 const float CatalogDatabase::kLatestSupportedSchema = 2.5;  // + 1.X (r/o)

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -73,7 +73,7 @@ class CatalogDatabase : public sqlite::Database<CatalogDatabase> {
 
 /**
  * Base class for all SQL statement classes.  It wraps a single SQL statement
- * and all neccessary calls of the sqlite3 API to deal with this statement.
+ * and all necessary calls of the sqlite3 API to deal with this statement.
  */
 class SqlCatalog : public sqlite::Sql {
  public:
@@ -169,7 +169,7 @@ class SqlCatalog : public sqlite::Sql {
 
 
 /**
- * Common ancestor of SQL statemnts that deal with directory entries.
+ * Common ancestor of SQL statements that deal with directory entries.
  */
 class SqlDirent : public SqlCatalog {
  public:

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -458,7 +458,7 @@ class CatalogTraversalBase
  *
  * Breadth First Traversal Strategy
  *   Catalogs are handed out to the user identical as they are traversed.
- *   Say: From top to buttom. When you would simply print each received catalog
+ *   Say: From top to bottom. When you would simply print each received catalog
  *        the result would be a nice representation of the catalog tree.
  *   This method is more efficient, because catalogs are opened, processed and
  *   thrown away directly afterwards.

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -404,7 +404,7 @@ class CatalogTraversalBase
 
   /**
    * Checks if a root catalog is below one of the pruning thresholds.
-   * Pruning thesholds can be either the catalog's history depth or a timestamp
+   * Pruning thresholds can be either the catalog's history depth or a timestamp
    * threshold applied to the last modified timestamp of the catalog.
    *
    * @param ctx  traversal context for traversal-specific state
@@ -655,7 +655,7 @@ class CatalogTraversal
       }
     }
 
-    // invariant: after the traversal finshed, there should be no more catalogs
+    // invariant: after the traversal finished, there should be no more catalogs
     //            to traverse or to yield!
     assert(ctx->catalog_stack.empty());
     assert(ctx->callback_stack.empty());

--- a/cvmfs/catalog_virtual.cc
+++ b/cvmfs/catalog_virtual.cc
@@ -140,7 +140,7 @@ void VirtualCatalog::GenerateSnapshots() {
   vector<TagId> tags_catalog;
   GetSortedTagsFromHistory(&tags_history);
   GetSortedTagsFromCatalog(&tags_catalog);
-  // Add artifical end markers to both lists
+  // Add artificial end markers to both lists
   string tag_name_end = "";
   if (!tags_history.empty())
     tag_name_end = std::max(tag_name_end, tags_history.rbegin()->name);

--- a/cvmfs/compression.cc
+++ b/cvmfs/compression.cc
@@ -3,7 +3,7 @@
  *
  * This is a wrapper around zlib.  It provides
  * a set of functions to conveniently compress and decompress stuff.
- * Allmost all of the functions return true on success, otherwise false.
+ * Almost all of the functions return true on success, otherwise false.
  *
  * TODO: think about code deduplication
  */

--- a/cvmfs/compression.h
+++ b/cvmfs/compression.h
@@ -54,7 +54,7 @@ enum Algorithms {
  * which is a sub-class of the Compressor.  The subclass needs to implement the
  * Deflate, DeflateBound, Clone, and WillHandle functions.  For information on
  * the WillHandle function, read up on the PolymorphicConstruction class.
- * The new sub-class must be listed in the implemention of the
+ * The new sub-class must be listed in the implementation of the
  * Compressor::RegisterPlugins function.
  *
  */
@@ -66,7 +66,7 @@ class Compressor: public PolymorphicConstruction<Compressor, Algorithms> {
    * Deflate function.  The arguments and returns closely match the input and
    * output of the zlib deflate function.
    * Input:
-   *   - outbuf - Ouput buffer to write the compressed data.
+   *   - outbuf - Output buffer to write the compressed data.
    *   - outbufsize - Size of the output buffer
    *   - inbuf - Input data to be compressed
    *   - inbufsize - Size of the input buffer

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -215,7 +215,7 @@ struct CVMFS_EXPORT Digest {
    * Generates a purely random hash
    * Only used for testing purposes
    *
-   * @param seed  random number generator seed (for reproducability)
+   * @param seed  random number generator seed (for reproducibility)
    */
   void Randomize(const uint64_t seed) {
     Prng prng;
@@ -227,7 +227,7 @@ struct CVMFS_EXPORT Digest {
    * Generates a purely random hash
    * Only used for testing purposes
    *
-   * @param prng  random number generator object (for external reproducability)
+   * @param prng  random number generator object (for external reproducibility)
    */
   void Randomize(Prng *prng) {
     const unsigned bytes = GetDigestSize();
@@ -240,7 +240,7 @@ struct CVMFS_EXPORT Digest {
   void set_suffix(const Suffix s) { suffix = s; }
 
   /**
-   * Generates a hexified repesentation of the digest including the identifier
+   * Generates a hexified representation of the digest including the identifier
    * string for newly added hashes.
    *
    * @param with_suffix  append the hash suffix (C,H,X, ...) to the result
@@ -265,7 +265,7 @@ struct CVMFS_EXPORT Digest {
   }
 
   /**
-   * Generates a hexified repesentation of the digest including the identifier
+   * Generates a hexified representation of the digest including the identifier
    * string for newly added hashes.  Output is in the form of
    * 'openssl x509 fingerprint', e.g. 00:AA:BB:...-SHAKE128
    *

--- a/cvmfs/crypto/signature.cc
+++ b/cvmfs/crypto/signature.cc
@@ -2,7 +2,7 @@
  * This file is part of the CernVM File System.
  *
  * This is a wrapper around OpenSSL's libcrypto.  It supports
- * signing of data with an X.509 certificate and verifiying
+ * signing of data with an X.509 certificate and verifying
  * a signature against a certificate.  The certificates can act only as key
  * store, in which case there is no verification against the CA chain.
  *
@@ -753,7 +753,7 @@ bool SignatureManager::VerifyCaChain() {
 /**
  * Signs a data block using the loaded private key.
  *
- * \return True on sucess, false otherwise
+ * \return True on success, false otherwise
  */
 bool SignatureManager::Sign(const unsigned char *buffer,
                             const unsigned buffer_size,
@@ -801,7 +801,7 @@ bool SignatureManager::Sign(const unsigned char *buffer,
 /**
  * Signs a data block using the loaded private master key.
  *
- * \return True on sucess, false otherwise
+ * \return True on success, false otherwise
  */
 bool SignatureManager::SignRsa(const unsigned char *buffer,
                                const unsigned buffer_size,

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -146,7 +146,7 @@ struct DirectoryListing {
 
 const loader::LoaderExports *loader_exports_ = NULL;
 OptionsManager *options_mgr_ = NULL;
-pid_t pid_ = 0;  /**< will be set after deamon() */
+pid_t pid_ = 0;  /**< will be set after daemon() */
 quota::ListenerHandle *watchdog_listener_ = NULL;
 quota::ListenerHandle *unpin_listener_ = NULL;
 
@@ -474,7 +474,7 @@ static void inline TraceInode(const int event,
 
 /**
  * Find the inode number of a file name in a directory given by inode.
- * This or getattr is called as kind of prerequisit to every operation.
+ * This or getattr is called as kind of prerequisite to every operation.
  * We do check catalog TTL here (and reload, if necessary).
  */
 static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -531,7 +531,7 @@ cvmfs_chksetup() {
     fi
   done
 
-  # Check repository specfic settings
+  # Check repository specific settings
   local repo_list="$(list_repos)"
   local repo
   for repo in $repo_list
@@ -642,7 +642,7 @@ cvmfs_chksetup() {
       fi
       if [ ! -z $CVMFS_SYSLOG_FACILITY ]; then
         if ! expr "$CVMFS_SYSLOG_FACILITY" : '[0,1,2,3,4,5,6,7]' > /dev/null; then
-          echo -n "Error: invalud value for CVMFS_SYSLOG_FACILITY ($CVMFS_SYSLOG_FACILITY) for $fqrn. "
+          echo -n "Error: invalid value for CVMFS_SYSLOG_FACILITY ($CVMFS_SYSLOG_FACILITY) for $fqrn. "
           echo "Valid entries: 0..7"
           num_errors=$(($num_errors+1))
         fi

--- a/cvmfs/cvmfs_talk.cc
+++ b/cvmfs/cvmfs_talk.cc
@@ -32,7 +32,7 @@ struct InstanceInfo {
     bool retval = options_mgr.GetValue("CVMFS_DEFAULT_DOMAIN", &result);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-               "Error: could not determin CVMFS_DEFAULT_DOMAIN");
+               "Error: could not determine CVMFS_DEFAULT_DOMAIN");
     }
     return result;
   }
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
 
   int c;
   // 's' for socket would have been a better option letter but we keep 'p'
-  // for backwards compatibility.  The '+' at the beginning of the option stirng
+  // for backwards compatibility.  The '+' at the beginning of the option string
   // prevents permutation of the option and non-option arguments.
   while ((c = getopt(argc, argv, "+hi:p:")) != -1) {
     switch (c) {

--- a/cvmfs/fd_table.h
+++ b/cvmfs/fd_table.h
@@ -72,7 +72,7 @@ class FdTable : SingleCopy {
 
 
   /**
-   * Registeres fd with a currently unused number.  If the table is full,
+   * Registers fd with a currently unused number.  If the table is full,
    * returns -ENFILE;
    */
   int OpenFd(const HandleT &handle) {

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -27,7 +27,7 @@ class DentryTracker;
  * fuse_lowlevel_notify_inval_entry, it falls back to waiting for drainout.
  *
  * Evicting entries from the cache must be done from a separate thread to
- * avoid a deadlock in the fuse callbacks (see Fuse documenatation).
+ * avoid a deadlock in the fuse callbacks (see Fuse documentation).
  */
 class FuseInvalidator : SingleCopy {
   FRIEND_TEST(T_FuseInvalidator, StartStop);
@@ -98,7 +98,7 @@ class FuseInvalidator : SingleCopy {
   int pipe_ctrl_[2];
   pthread_t thread_invalidator_;
   /**
-   * An invalidation run can take some time.  Allow for early cancelation if
+   * An invalidation run can take some time.  Allow for early cancellation if
    * thread should be shut down.
    */
   atomic_int32 terminated_;

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -126,7 +126,7 @@ FuseRemounter::Status FuseRemounter::Check() {
 
 
 /**
- * Used from the TalkManager.  Continously calls 'check' until it returns with
+ * Used from the TalkManager.  Continuously calls 'check' until it returns with
  * "up to date" or a failure.
  */
 FuseRemounter::Status FuseRemounter::CheckSynchronously() {

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -120,7 +120,7 @@ class FuseRemounter : SingleCopy {
    */
   time_t catalogs_valid_until_;
   /**
-   * In drainout mode, the fuse module sets the timeout of meta data replys to
+   * In drainout mode, the fuse module sets the timeout of meta data replies to
    * zero.  If supported by Fuse, the FuseInvalidator will evict all active
    * entries from the kernel cache.  Drainout mode is left only once the new
    * root catalog is active (after TryFinish()).

--- a/cvmfs/history.h
+++ b/cvmfs/history.h
@@ -138,7 +138,7 @@ class History {
   virtual bool ExistsBranch(const std::string &branch_name) const = 0;
   virtual bool InsertBranch(const Branch &branch) = 0;
   /**
-   * When removing tags, branches can become abandonded. Remove abandoned
+   * When removing tags, branches can become abandoned. Remove abandoned
    * branches and redirect the parent pointer of their child branches.
    */
   virtual bool PruneBranches() = 0;
@@ -178,7 +178,7 @@ class History {
 
   /**
    * Provides a list of all referenced catalog hashes in this History.
-   * The hashes will be ordered by their timestamp in acending order.
+   * The hashes will be ordered by their timestamp in ascending order.
    *
    * @param hashes  pointer to the result vector to be filled
    */

--- a/cvmfs/history_sql.h
+++ b/cvmfs/history_sql.h
@@ -197,7 +197,7 @@ class SqlInsertBranch : public SqlHistory {
  *
  * @param MixinT  the class that should gain BindTargetTags()'s functionality
  * @param offset  offset for SQLite placeholders, if used inside other complex
- *                SQL queries with preceeding placeholders
+ *                SQL queries with preceding placeholders
  */
 template <class MixinT, int offset = 0>
 class SqlRollback : public MixinT {

--- a/cvmfs/history_sqlite.h
+++ b/cvmfs/history_sqlite.h
@@ -133,7 +133,7 @@ class SqliteHistory : public History {
   /**
    * Provides a list of all referenced catalog hashes in this History.
    * The hashes will be ordered by their associated revision number in
-   * acending order.
+   * ascending order.
    *
    * @param hashes  pointer to the result vector to be filled
    */

--- a/cvmfs/ingestion/ingestion_source.h
+++ b/cvmfs/ingestion/ingestion_source.h
@@ -26,7 +26,7 @@
  * The purpose of this class is to add a common interface for object that are
  * ingested by the pipeline. Hence the pipeline is able to ingest everything
  * that implements this interface.
- * The ownership of new IngestionSource objects is transfered from their creator
+ * The ownership of new IngestionSource objects is transferred from their creator
  * directly to the pipeline itself that will take care of deallocating
  * everything.
  * The pipeline is multithreaded so it is very likely that the code implement in

--- a/cvmfs/interrupt.h
+++ b/cvmfs/interrupt.h
@@ -7,7 +7,7 @@
 
 /**
  * Allows to query for interrupts of active file system requests.  Used
- * to hande canceled fuse requests with the inherited class FuseInterruptCue.
+ * to handle canceled fuse requests with the inherited class FuseInterruptCue.
  */
 class InterruptCue {
  public:

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -63,7 +63,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-// Map C++ clases to their C interface names
+// Map C++ classes to their C interface names
 typedef class LibContext cvmfs_context;
 typedef class SimpleOptionsParser cvmfs_option_map;
 #else

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -773,7 +773,7 @@ int FuseMain(int argc, char *argv[]) {
 
   if (!premounted_ && !DirectoryExists(*mount_point_)) {
     LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-             "Moint point %s does not exist", mount_point_->c_str());
+             "Mount point %s does not exist", mount_point_->c_str());
     return kFailPermission;
   }
 

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -121,7 +121,7 @@ class MagicXattrRAIIWrapper: public SingleCopy {
   {
     if (ptr_ != NULL) ptr_->Lock(path, d);
   }
-  /// Wraps around a BaseMagicXattr* tha is already locked (or NULL)
+  /// Wraps around a BaseMagicXattr* that is already locked (or NULL)
   inline explicit MagicXattrRAIIWrapper(BaseMagicXattr *ptr) : ptr_(ptr) { }
 
   inline ~MagicXattrRAIIWrapper() { if (ptr_ != NULL) ptr_->Release(); }

--- a/cvmfs/malloc_arena.cc
+++ b/cvmfs/malloc_arena.cc
@@ -101,7 +101,7 @@ void MallocArena::Free(void *ptr) {
 
 
 /**
- * Inserts an avilable block at the end of the free list.
+ * Inserts an available block at the end of the free list.
  */
 void MallocArena::EnqueueAvailBlock(AvailBlockCtl *block) {
   AvailBlockCtl *next = head_avail_;

--- a/cvmfs/manifest.h
+++ b/cvmfs/manifest.h
@@ -156,7 +156,7 @@ class Manifest {
   bool garbage_collectable_;
 
   /**
-   * The root catalog and the certifacte might be available as .cvmfscatalog and
+   * The root catalog and the certificate might be available as .cvmfscatalog and
    * .cvmfscertificate.  That is helpful if the data subdirectory is protected
    * on the web server.
    */

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -213,7 +213,7 @@ string Watchdog::ReadUntilGdbPrompt(int fd_pipe) {
   int           chars_io;
   unsigned int  ring_buffer_pos = 0;
 
-  // read from stdout of gdb until gdb prompt occures --> (gdb)
+  // read from stdout of gdb until gdb prompt occurs --> (gdb)
   while (1) {
     chars_io = read(fd_pipe, &mini_buffer, 1);
 

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -2,7 +2,7 @@
  * This file is part of the CernVM File System.
  *
  * The CernVM-FS name resolving uses objects that inherit from the Resolver
- * interface.  Resolvers implement a vector interface that resolves mutliple
+ * interface.  Resolvers implement a vector interface that resolves multiple
  * names in parallel.  Common cases such as IP addresses as names are handled
  * by the base class -- Resolver implementations only have to resolve real host
  * names to IPv4/6 addresses, using given search domains if necessary.

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1725,7 +1725,7 @@ void DownloadManager::Spawn() {
 
 
 /**
- * Downloads data from an unsecure outside channel (currently HTTP or file).
+ * Downloads data from an insecure outside channel (currently HTTP or file).
  */
 Failures DownloadManager::Fetch(JobInfo *info) {
   assert(info != NULL);
@@ -1880,7 +1880,7 @@ void DownloadManager::SetIpPreference(dns::IpPreference preference) {
 
 
 /**
- * Sets two timeout values for proxied and for direct conections, respectively.
+ * Sets two timeout values for proxied and for direct connections, respectively.
  * The timeout counts for all sorts of connection phases,
  * DNS, HTTP connect, etc.
  */
@@ -2004,7 +2004,7 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
     if (opt_proxy_groups_->size() > 1) {
       opt_proxy_groups_current_ = (opt_proxy_groups_current_ + 1) %
       opt_proxy_groups_->size();
-      // Remeber the timestamp of switching to backup proxies
+      // Remember the timestamp of switching to backup proxies
       if (opt_proxy_groups_reset_after_ > 0) {
         if (opt_proxy_groups_current_ > 0) {
           if (opt_timestamp_backup_proxies_ == 0)

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -126,7 +126,7 @@ enum Destination {
 
 struct Counters {
   perf::Counter *sz_transferred_bytes;
-  perf::Counter *sz_transfer_time;  // measured in miliseconds
+  perf::Counter *sz_transfer_time;  // measured in milliseconds
   perf::Counter *n_requests;
   perf::Counter *n_retries;
   perf::Counter *n_proxy_failover;
@@ -136,7 +136,7 @@ struct Counters {
     sz_transferred_bytes = statistics.RegisterTemplated("sz_transferred_bytes",
         "Number of transferred bytes");
     sz_transfer_time = statistics.RegisterTemplated("sz_transfer_time",
-        "Transfer time (miliseconds)");
+        "Transfer time (milliseconds)");
     n_requests = statistics.RegisterTemplated("n_requests",
         "Number of requests");
     n_retries = statistics.RegisterTemplated("n_retries", "Number of retries");

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -330,7 +330,7 @@ class S3FanoutManager : SingleCopy {
   // thread than writing.
   Statistics *statistics_;
 
-  // Report not every occurance of throtteling but only every so often
+  // Report not every occurrence of throtteling but only every so often
   uint64_t timestamp_last_throttle_report_;
 
   bool is_curl_debug_;

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -5,7 +5,7 @@
  * issued once by an NFS exported file system might be asked for
  * any time later by clients.
  *
- * In "NFS mode", cvmfs will issue inodes consequtively and reuse inodes
+ * In "NFS mode", cvmfs will issue inodes consecutively and reuse inodes
  * based on path name.  The inode --> path and path --> inode maps are
  * handled by leveldb.  This workaround is comparable to the Fuse "noforget"
  * option, except that the mappings are persistent and thus consistent during

--- a/cvmfs/nfs_maps_sqlite.cc
+++ b/cvmfs/nfs_maps_sqlite.cc
@@ -5,7 +5,7 @@
  * issued once by an NFS exported file system might be asked for
  * any time later by clients.
  *
- * In "NFS mode", cvmfs will issue inodes consequtively and reuse inodes
+ * In "NFS mode", cvmfs will issue inodes consecutively and reuse inodes
  * based on path name.  The inode --> path and path --> inode maps are
  * handled by sqlite.  This workaround is comparable to the Fuse "noforget"
  * option, except that the mappings are persistent and thus consistent during

--- a/cvmfs/notify/publisher_http.h
+++ b/cvmfs/notify/publisher_http.h
@@ -14,7 +14,7 @@ namespace notify {
 /**
  * Implementation of Publisher based on HTTP
  *
- * Messsages are published to the notification system backend using cURL
+ * Messages are published to the notification system backend using cURL
  */
 class PublisherHTTP : public Publisher {
  public:

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -262,7 +262,7 @@ class SimpleOptionsParser : public OptionsManager {
  * Derived class from OptionsManager. This class provides the
  * complete parsing of the configuration files. In order to parse the
  * configuration files it retrieves the "KEY=VALUE" pairs and uses bash for
- * the rest, so that you can execute sightly complex scripts
+ * the rest, so that you can execute slightly complex scripts
  */
 class BashOptionsManager : public OptionsManager {
  public:

--- a/cvmfs/pack.h
+++ b/cvmfs/pack.h
@@ -169,7 +169,7 @@ enum State {
  * "object pack", which otherwise would need special treatment.
  *
  * The serialized format has a global, human readable header which has lines of
- * character keys and string values (like the cvmfs manifest) follwed by a "--"
+ * character keys and string values (like the cvmfs manifest) followed by a "--"
  * separator line followed by the index of objects. The index contains one line
  * for each item in the pack. Each line contains the following space-separated
  * tokens:

--- a/cvmfs/path_filters/dirtab.h
+++ b/cvmfs/path_filters/dirtab.h
@@ -12,7 +12,7 @@
 
 namespace catalog {
 
-// TODO(jblomer): Dirtab and RelaxedPathFilter can use static inhertiance.  It
+// TODO(jblomer): Dirtab and RelaxedPathFilter can use static inheritance.  It
 // is clear at compile time which one should be used.  They are not on a
 // critical path though.
 

--- a/cvmfs/publish/cmd_diff.h
+++ b/cvmfs/publish/cmd_diff.h
@@ -45,7 +45,7 @@ class CmdDiff : public Command {
     p.push_back(Parameter::Optional("keychain", 'k', "directory",
       "Path to the directory containing the repository public key"));
     p.push_back(Parameter::Switch("machine-readable", 'm',
-      "Produce machine readble output"));
+      "Produce machine readable output"));
     p.push_back(Parameter::Optional("from", 's', "repository tag",
       "The source tag name [default='trunk-previous']"));
     p.push_back(Parameter::Optional("to", 'd', "repository tag",

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -27,7 +27,8 @@ class CmdEnter : public Command {
     return "Open an ephemeral namespace to publish content";
   }
   virtual std::string GetUsage() const {
-    return "[options] <fully qualified repository name> [-- <command> <params>]";
+    return \
+        "[options] <fully qualified repository name> [-- <command> <params>]";
   }
   virtual ParameterList GetParams() const {
     ParameterList p;

--- a/cvmfs/publish/cmd_enter.h
+++ b/cvmfs/publish/cmd_enter.h
@@ -27,7 +27,7 @@ class CmdEnter : public Command {
     return "Open an ephemeral namespace to publish content";
   }
   virtual std::string GetUsage() const {
-    return "[options] <fully qualified repository name> [-- <command> <parms>]";
+    return "[options] <fully qualified repository name> [-- <command> <params>]";
   }
   virtual ParameterList GetParams() const {
     ParameterList p;

--- a/cvmfs/publish/cmd_mkfs.h
+++ b/cvmfs/publish/cmd_mkfs.h
@@ -41,7 +41,7 @@ class CmdMkfs : public Command {
       "Disable automatic creation of timestamp tags, useful with --gc"));
 
     p.push_back(Parameter::Optional("autotag-span", 'G', "timespan",
-      "Speficy a `date` compatible time windows for keeping auto tags"));
+      "Specify a `date` compatible time windows for keeping auto tags"));
 
     p.push_back(Parameter::Optional("hash", 'a', "algorithm",
       "Select a secure hash algorithm: sha1 (default) or rmd160 or shake128"));

--- a/cvmfs/publish/cmd_transaction.h
+++ b/cvmfs/publish/cmd_transaction.h
@@ -49,9 +49,9 @@ class CmdTransaction : public Command {
       "Clone directory 'from-dir' to 'to-dir' as part of opening the "
       "transaction"));
     p.push_back(Parameter::Optional("template-from", 'U', "from-dir",
-      "Use -U and -V as an alternative to the -T parmeter"));
+      "Use -U and -V as an alternative to the -T parameter"));
     p.push_back(Parameter::Optional("template-to", 'V', "to-dir",
-      "Use -U and -V as an alternative to the -T parmeter"));
+      "Use -U and -V as an alternative to the -T parameter"));
     return p;
   }
 

--- a/cvmfs/publish/main.cc
+++ b/cvmfs/publish/main.cc
@@ -41,7 +41,7 @@ static void Usage(const std::string &progname,
     "Usage:\n"
     "------\n"
     "  %s COMMAND [options] <parameters>\n\n"
-    "Supported Commmands\n"
+    "Supported Commands\n"
     "-------------------\n",
     VERSION, progname.c_str());
     const vector<publish::Command *> commands = clist.commands();

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -74,7 +74,7 @@ class __attribute__((visibility("default"))) DiffListener {
 class __attribute__((visibility("default"))) Env {
  public:
   /**
-   * Depending on the desired course of action, the permitted capabilites of the
+   * Depending on the desired course of action, the permitted capabilities of the
    * binary (cap_dac_read_search, cap_sys_admin) needs to be dropped or gained.
    * Dropped for creating user namespaces in `enter`, gained for walking through
    * overlayfs.
@@ -195,7 +195,7 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
      */
     void Mount();
     /**
-     * Move scratch space to waste bin and clear it out asynchonously
+     * Move scratch space to waste bin and clear it out asynchronously
      */
     void ClearScratch();
 

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -107,7 +107,7 @@ class __attribute__((visibility("default"))) Repository : SingleCopy {
   void List();
 
   /**
-   * From and to are either tag names or catalog root hashes preceeded by
+   * From and to are either tag names or catalog root hashes preceded by
    * a '@'.
    */
   void Diff(const std::string &from, const std::string &to,

--- a/cvmfs/publish/settings.h
+++ b/cvmfs/publish/settings.h
@@ -21,7 +21,7 @@ class OptionsManager;
 namespace publish {
 
 /**
- * Allows for settings that remember whether they have been explictily
+ * Allows for settings that remember whether they have been explicitly
  * overwritten.  Otherwise, default values can be changed to upstream repository
  * settings.
  */
@@ -124,7 +124,7 @@ class SettingsSpoolArea {
   Setting<std::string> tmp_dir_;
   Setting<std::string> union_mnt_;
   /**
-   * How aggresively should the mount point stack be repaired
+   * How aggressively should the mount point stack be repaired
    */
   Setting<EUnionMountRepairMode> repair_mode_;
 };  // SettingsSpoolArea
@@ -451,7 +451,7 @@ class SettingsPublisher {
   Setting<bool> is_silent_;
   Setting<bool> is_managed_;
   // When trying to drop the session, ignore an invalid lease failure. Useful
-  // to recover a pulisher with abort -f.
+  // to recover a publisher with abort -f.
   Setting<bool> ignore_invalid_lease_;
 
   SettingsStorage storage_;
@@ -501,7 +501,7 @@ class SettingsBuilder : SingleCopy {
    * If ident is a url, creates a generic settings object inferring the fqrn
    * from the url.
    * Otherwise, looks in the config files in /etc/cvmfs/repositories.d/<alias>/
-   * If alias is an empty string, the command still succeds iff there is a
+   * If alias is an empty string, the command still succeeds iff there is a
    * single repository under /etc/cvmfs/repositories.d
    */
   SettingsRepository CreateSettingsRepository(const std::string &ident);
@@ -510,7 +510,7 @@ class SettingsBuilder : SingleCopy {
    * If ident is a url, creates a generic settings object inferring the fqrn
    * from the url.
    * Otherwise, looks in the config files in /etc/cvmfs/repositories.d/<alias>/
-   * If alias is an empty string, the command still succeds iff there is a
+   * If alias is an empty string, the command still succeeds iff there is a
    * single repository under /etc/cvmfs/repositories.d
    * If needs_managed is true, remote repositories are rejected
    * In an "enter environment" (see cmd_enter), the spool area of the enter

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1791,7 +1791,7 @@ bool PosixQuotaManager::RebuildDatabase() {
   seq_ = seq;
   result = true;
   LogCvmfs(kLogQuota, kLogDebug,
-           "rebuilding finished, seqence %" PRIu64 ", gauge %" PRIu64,
+           "rebuilding finished, sequence %" PRIu64 ", gauge %" PRIu64,
            seq_, gauge_);
 
  build_return:

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -186,7 +186,7 @@ class PosixQuotaManager : public QuotaManager {
 
   /**
    * Make sure that the amount of data transferred through the RPC pipe is
-   * within the OS's guarantees for atomiticity.
+   * within the OS's guarantees for atomicity.
    */
   static const unsigned kMaxDescription = 512-sizeof(LruCommand);
 

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -95,7 +95,7 @@ CommitProcessor::~CommitProcessor() {}
  *
  * This method applies all the changes from C_N, with respect to C_O, onto C_G.
  * The resulting catalog on the gateway machine (C_GN) is then set as root
- * catalog in the repository manifest. The method also signes the updated
+ * catalog in the repository manifest. The method also signs the updated
  * repository manifest.
  */
 CommitProcessor::Result CommitProcessor::Process(

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -139,7 +139,7 @@ int main(int argc, char** argv) {
     return 2;
   } catch (...) {
     LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "Unknow error during CVMFS Receiver event loop.\n");
+             "Unknown error during CVMFS Receiver event loop.\n");
       return 3;
   }
 

--- a/cvmfs/reflog.h
+++ b/cvmfs/reflog.h
@@ -25,11 +25,11 @@ namespace manifest {
  *
  * Every time such an object is newly added to a backend storage of CernVM-FS
  * its content hash (and object type) will be added to the Reflog. This ensures
- * an authorative list of "root objects" in a given backend storage.
+ * an authoritative list of "root objects" in a given backend storage.
  *
  * Reflogs are associated to a specific backend storage of Stratum0 or Stratum1
  * and _not_ to a CernVM-FS repository. Thus, the Reflogs of Stratum0 and its
- * replicas can and probably will be different and are _not_ interchangable.
+ * replicas can and probably will be different and are _not_ interchangeable.
  *
  * TODO(rmeusel): this shares a lot of database management code with
  *                SqliteHistory and (potentially) ...Catalog. This might be an

--- a/cvmfs/server/cvmfs_server_add_replica.sh
+++ b/cvmfs/server/cvmfs_server_add_replica.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server add-replica" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -5,7 +5,7 @@
 #
 # Functionality related to the Apache web server
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 
 
@@ -42,7 +42,7 @@ reload_apache() {
 }
 
 
-# An Apache reload is asynchronous, the new configration is not immediately
+# An Apache reload is asynchronous, the new configuration is not immediately
 # accessible.  Wait up to 1 minute until a test url can be fetched
 wait_for_apache() {
   local url="$1"
@@ -204,7 +204,7 @@ get_compatible_apache_allow_from_all_config() {
 # Note: Configuration file content is expected to come through stdin
 #
 # @param   file_name  the name of the apache config file (no path!)
-# @return             0 on succes
+# @return             0 on success
 create_apache_config_file() {
   local file_name=$1
   local conf_path

--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server check" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 
@@ -249,7 +249,7 @@ __do_all_checks() {
       echo "ERROR from cvmfs_server check!" >&2
     else
       check_status=succeeded
-      to_syslog_for_repo $repo "sucessfully completed check"
+      to_syslog_for_repo $repo "successfully completed check"
     fi
     update_repo_status $repo check_status $check_status
     echo "Finished $repo at `date`"

--- a/cvmfs/server/cvmfs_server_checkout.sh
+++ b/cvmfs/server/cvmfs_server_checkout.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server checkout" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_chown.sh
+++ b/cvmfs/server/cvmfs_server_chown.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server chown" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -35,7 +35,7 @@ if [ -f /etc/cvmfs/server.local ]; then
   fi
 fi
 
-# setup server hooks: no-ops (overrideable by /etc/cvmfs/cvmfs_server_hooks.sh)
+# setup server hooks: no-ops (overridable by /etc/cvmfs/cvmfs_server_hooks.sh)
 transaction_before_hook() { :; }
 transaction_after_hook() { :; }
 abort_before_hook() { :; }

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1244,7 +1244,7 @@ is_stratum0_garbage_collectable() {
 }
 
 
-# checks if a manifest ist present
+# checks if a manifest is present
 #
 # @param name  the name of the repository to be checked
 # @return      0 if it is empty

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -592,7 +592,7 @@ get_expiry_from_string() {
 # figures out the time to expiry of the repository's whitelist
 #
 # @param stratum0  path/URL to stratum0 storage
-# @return          number of seconds until expiry (negativ if already expired)
+# @return          number of seconds until expiry (negative if already expired)
 get_expiry() {
   local name=$1
   local stratum0=$2

--- a/cvmfs/server/cvmfs_server_compat.sh
+++ b/cvmfs/server/cvmfs_server_compat.sh
@@ -4,7 +4,7 @@
 # on a Stratum 0/1 server
 
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_deprecated.sh
+++ b/cvmfs/server/cvmfs_server_deprecated.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of deprecated cvmfs_server commands
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_eliminate_bulk_hashes.sh
+++ b/cvmfs/server/cvmfs_server_eliminate_bulk_hashes.sh
@@ -4,7 +4,7 @@
 #
 # Implementation of the "cvmfs_server eliminate-bulk-hashes" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_eliminate_hardlinks.sh
+++ b/cvmfs/server/cvmfs_server_eliminate_hardlinks.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server eliminate-hardlinks" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_fix_permissions.sh
+++ b/cvmfs/server/cvmfs_server_fix_permissions.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server fix-permissions" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_fix_stats.sh
+++ b/cvmfs/server/cvmfs_server_fix_stats.sh
@@ -3,7 +3,7 @@
 #
 # Implementation of the "cvmfs_server fix-stats" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server gc" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_health_check.sh
+++ b/cvmfs/server/cvmfs_server_health_check.sh
@@ -4,7 +4,7 @@
 # on a Stratum 0/1 server
 #
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_import.sh
+++ b/cvmfs/server/cvmfs_server_import.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server import" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh
@@ -209,7 +209,7 @@ cvmfs_server_import() {
     masterkeycard_cert_available >/dev/null || die "Neither masterkey nor masterkeycard found for recreating whitelist"
   fi
 
-  # set up desaster cleanup
+  # set up disaster cleanup
   IMPORT_DESASTER_REPO_NAME="$name"
   trap _import_desaster_cleanup EXIT HUP INT QUIT TERM
 

--- a/cvmfs/server/cvmfs_server_info.sh
+++ b/cvmfs/server/cvmfs_server_info.sh
@@ -6,7 +6,7 @@
 # Implementation of the "cvmfs_server info" command
 # Migrated to the new cvmfs_publish command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -5,12 +5,12 @@
 #
 # Implementation of the "cvmfs_server ingest-tarball" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 
 
-# TODO Most of this code is replicated and shared between different scrips,
+# TODO Most of this code is replicated and shared between different scripts,
 # it would be a good idea to refactor common patterns into coherent functions.
 
 cvmfs_server_ingest() {
@@ -79,7 +79,7 @@ cvmfs_server_ingest() {
     if [ ! x"$tar_file" = "x" ] && [ ! x"$to_delete" = "x" ]; then
       die "Could not delete and add a file in the same transaction while using gateway."
     fi
-    # by the chek above we are sure that there is only a tar_file to ingest or a directory to_delete
+    # by the check above we are sure that there is only a tar_file to ingest or a directory to_delete
     # hence we just concatenate them with the name for the transaction
     cvmfs_server_transaction "$name/$base_dir$to_delete" || die "Impossible to start a transaction"
   else

--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -5,7 +5,7 @@
 #
 # JSON "API" related functions
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_list.sh
+++ b/cvmfs/server/cvmfs_server_list.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server list" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_list_catalogs.sh
+++ b/cvmfs/server/cvmfs_server_list_catalogs.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server list-catalogs" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_masterkeycard.sh
+++ b/cvmfs/server/cvmfs_server_masterkeycard.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server masterkeycard" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_sys.sh
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server migrate" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server mkfs" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_mount.sh
+++ b/cvmfs/server/cvmfs_server_mount.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server mount" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_resign.sh
+++ b/cvmfs/server/cvmfs_server_resign.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server resign" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_rmfs.sh
+++ b/cvmfs/server/cvmfs_server_rmfs.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server rmfs" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_rollback.sh
+++ b/cvmfs/server/cvmfs_server_rollback.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server rollback" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 # - cvmfs_server_ssl.sh

--- a/cvmfs/server/cvmfs_server_skeleton.sh
+++ b/cvmfs/server/cvmfs_server_skeleton.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server skeleton" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server snapshot" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_ssl.sh
+++ b/cvmfs/server/cvmfs_server_ssl.sh
@@ -5,7 +5,7 @@
 #
 # Functionality related to SSL
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_sys.sh
 # - cvmfs_server_util.sh
 # - cvmfs_server_masterkeycard.sh

--- a/cvmfs/server/cvmfs_server_tag.sh
+++ b/cvmfs/server/cvmfs_server_tag.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server tag" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_update_info.sh
+++ b/cvmfs/server/cvmfs_server_update_info.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server update-info" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_update_repoinfo.sh
+++ b/cvmfs/server/cvmfs_server_update_repoinfo.sh
@@ -5,7 +5,7 @@
 #
 # Implementation of the "cvmfs_server update-repoinfo" command
 
-# This file depends on fuctions implemented in the following files:
+# This file depends on functions implemented in the following files:
 # - cvmfs_server_util.sh
 # - cvmfs_server_common.sh
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -553,7 +553,7 @@ check_upstream_validity() {
 # @return  0 if overlayfs is installed and viable
 #          1 if it is not viable, and stdout contains a reason
 # This should probably now be called check_overlayfs_viability except
-#   that for backward compatiblity we need to keep the variable that
+#   that for backward compatibility we need to keep the variable that
 #   overrides it, CVMFS_DONT_CHECK_OVERLAYFS_VERSION, and changing the
 #   function name would make the variable name not make sense.
 check_overlayfs_version() {

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -371,7 +371,7 @@ bool handle_file(
     pstats->Lookup(SHRINKWRAP_STAT_DATA_BYTES_DEDUPED)->Xadd(src_st->st_size);
   }
 
-  // The target alway exists (either previously existed or just created).
+  // The target always exists (either previously existed or just created).
   // This is not done in parallel like copyFile
   if (result && dest->do_link(dest->context_, entry, dest_data)) {
     LogCvmfs(kLogCvmfs, kLogStderr,
@@ -654,9 +654,9 @@ perf::Statistics *GetSyncStatTemplate() {
   result->Register(SHRINKWRAP_STAT_ENTRIES_DEST,
     "Number of file system entries processed in the destination");
   result->Register(SHRINKWRAP_STAT_DATA_FILES,
-    "Number of data files transfered from source to destination");
+    "Number of data files transferred from source to destination");
   result->Register(SHRINKWRAP_STAT_DATA_BYTES,
-    "Bytes transfered from source to destination");
+    "Bytes transferred from source to destination");
   result->Register(SHRINKWRAP_STAT_DATA_FILES_DEDUPED,
     "Number of files not copied due to deduplication");
   result->Register(SHRINKWRAP_STAT_DATA_BYTES_DEDUPED,

--- a/cvmfs/shrinkwrap/fs_traversal_interface.h
+++ b/cvmfs/shrinkwrap/fs_traversal_interface.h
@@ -135,11 +135,11 @@ struct fs_traversal {
                 const struct cvmfs_attr *stat);
 
   /**
-   * Sets the meta informations for the directory entry.
+   * Sets the meta information for the directory entry.
    * This assumes that other information is the same, and
    * only updates the metadata. Used only on directories.
    *
-   * @param[in] ctx The file systme traverssal context
+   * @param[in] ctx The file system traversal context
    * @param[in] path The path of the object to be updated
    * @param[in] stat The stat structure that determines the new values
    * @returns 0 on success, -1 otherwise

--- a/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
+++ b/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
@@ -224,7 +224,7 @@ struct fs_traversal_context *libcvmfs_initialize(
   retval = cvmfs_init_v2(options_mgr);
   if (retval) {
     LogCvmfs(kLogCvmfs, kLogStderr,
-    "CVMFS Initilization failed : %s", repo);
+    "CVMFS Initialization failed : %s", repo);
     return NULL;
   }
 

--- a/cvmfs/shrinkwrap/posix/data_dir_mgmt.h
+++ b/cvmfs/shrinkwrap/posix/data_dir_mgmt.h
@@ -9,7 +9,7 @@
 #include <string>
 
 /**
- * The functions in this file handle the managment of the .data directory
+ * The functions in this file handle the management of the .data directory
  * structure in the POSIX File System Traversal interface.
  * 
  * The .data directory structure contains (meta)content-adressable links to all

--- a/cvmfs/shrinkwrap/posix/helpers.h
+++ b/cvmfs/shrinkwrap/posix/helpers.h
@@ -27,7 +27,7 @@ struct fs_traversal_posix_context {
 };
 
 /**
- * INTIALIZATION FUNCTIONS
+ * INITIALIZATION FUNCTIONS
  */
 void InitialFsOperations(struct fs_traversal_context *ctx);
 void FinalizeFsOperations(struct fs_traversal_context *ctx);

--- a/cvmfs/shrinkwrap/posix/interface.cc
+++ b/cvmfs/shrinkwrap/posix/interface.cc
@@ -459,7 +459,7 @@ bool posix_is_hash_consistent(struct fs_traversal_context *ctx,
   struct stat hidden_path_stat;
   int res2 = stat(hidden_datapath.c_str(), &hidden_path_stat);
   if (res2 == -1) {
-    // If hidden path doesn't exist although apprently existing => error
+    // If hidden path doesn't exist although apparently existing => error
     return false;
   }
   return display_path_stat.st_ino == hidden_path_stat.st_ino;

--- a/cvmfs/shrinkwrap/scripts/spec_builder.py
+++ b/cvmfs/shrinkwrap/scripts/spec_builder.py
@@ -102,7 +102,7 @@ class TraceParser:
                       if r[3] not in self.filters and int(r[1])>=0
                         and r[2] not in TraceParser.blacklist]:
         if row[2] == "@UNKNOWN":
-          print("ERROR: An error occured during tracing (event code 8)")
+          print("ERROR: An error occurred during tracing (event code 8)")
           quit(-1)
         pathsToInclude.append(TracePoint(row[2], row[3]))
     specsToInclude = self.policy(pathsToInclude)

--- a/cvmfs/shrinkwrap/scripts/spec_diff.py
+++ b/cvmfs/shrinkwrap/scripts/spec_diff.py
@@ -53,17 +53,17 @@ class DiffBuilder:
             curNode = self.root
             passthrough = '-' if mode=='!' else '_'
             curDepth = 0
-            mergable = True
+            mergeable = True
             for part in path_parts:
               curDepth+=1
               if not part in curNode.children\
                 and curDepth > self.depth\
-                and mergable:
-                print("Found mergable")
+                and mergeable:
+                print("Found mergeable")
                 curNode.mode = self.calc_new_mode(curNode.mode, '*')
                 break
               elif not part in curNode.children:
-                mergable = False
+                mergeable = False
                 curNode.children[part] = TreeNode(passthrough)
               curNode = curNode.children[part]
               curNode.mode = self.calc_new_mode(curNode.mode, passthrough)

--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -82,7 +82,7 @@ class SmallHashBase {
   /**
    * Returns both the key and the value. That is useful if Key's equality
    * operator implements an equivalence relation on Key. In this case, LookupEx
-   * returns the key representing the equivalance class that has been used
+   * returns the key representing the equivalence class that has been used
    * during Insert().
    * Used to return a glue::InodeEx element when looking for an inode.
    */

--- a/cvmfs/sql.cc
+++ b/cvmfs/sql.cc
@@ -55,7 +55,7 @@ bool Sql::Execute() {
 /**
  * Execute the prepared statement or fetch its next row.
  * This method is intended to step through the result set.
- * If it returns false this does not neccessarily mean, that the actual
+ * If it returns false this does not necessarily mean, that the actual
  * statement execution failed, but that no row was fetched.
  * @return true if a new row was fetched otherwise false
  */

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -307,7 +307,7 @@ class Database : SingleCopy {
 
 /**
  * Base class for all SQL statement classes.  It wraps a single SQL statement
- * and all neccessary calls of the sqlite3 API to deal with this statement.
+ * and all necessary calls of the sqlite3 API to deal with this statement.
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE  *

--- a/cvmfs/ssl.h
+++ b/cvmfs/ssl.h
@@ -12,7 +12,7 @@
 /**
  * Manages the location of certificates, either system certificates or
  * the ones in $X509_CERT_DIR or /etc/grid-security/certificates
- * On construction, $X509_CERT_DIR has precendence over
+ * On construction, $X509_CERT_DIR has precedence over
  * /etc/grid-security/certificates.
  * $X509_CERT_BUNDLE is checked for a bundle.
  * The path settings can later be overwritten by UseSystemCertificatePath();

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -94,7 +94,7 @@ class Statistics {
 
 /**
  * Allows multiple instance of the same class to use the same Statistics
- * instance.  The "name_major" part is used to contruct counter names in the
+ * instance.  The "name_major" part is used to construct counter names in the
  * form name_major.<provided name>
  */
 class StatisticsTemplate {
@@ -198,7 +198,7 @@ class Recorder {
   std::vector<uint32_t> bins_;
 
   /**
-   * When the most recent tick occured.
+   * When the most recent tick occurred.
    */
   uint64_t last_timestamp_;
 

--- a/cvmfs/statistics_database.h
+++ b/cvmfs/statistics_database.h
@@ -28,7 +28,7 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   bool StoreEntry(const std::string &insert_statement);
 
 /**
- * Prune the statistics DB (delete records older than certain threshhold)
+ * Prune the statistics DB (delete records older than certain threshold)
  * @param days number of days of records to keep, 0 means no pruning
  * @return true on success, false otherwise
  */
@@ -108,7 +108,7 @@ class StatisticsDatabase : public sqlite::Database<StatisticsDatabase> {
   * maximum age (in days) of records to keep when pruning
   * (zero means keep forever)
   *   key: CVMFS_STATS_DB_DAYS_TO_KEEP
-  *   deafult: 365
+  *   default: 365
   *
   * @param repo_name Fully qualified name of the repository
   * @param path pointer to save the db path in

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -160,7 +160,7 @@ bool CommandCheck::CompareCounters(const catalog::Counters &a,
 
 
 /**
- * Checks for existance of a file either locally or via HTTP head
+ * Checks for existence of a file either locally or via HTTP head
  */
 bool CommandCheck::Exists(const string &file)
 {

--- a/cvmfs/swissknife_history.cc
+++ b/cvmfs/swissknife_history.cc
@@ -514,7 +514,7 @@ int CommandEditTag::AddNewTag(const ArgumentList &args, Environment *env) {
     return 1;
   }
 
-  // open the catalog to be tagged (to check for existance and for meta info)
+  // open the catalog to be tagged (to check for existence and for meta info)
   const UnlinkGuard catalog_path(
       CreateTempPath(env->tmp_path + "/catalog", 0600));
   const bool catalog_read_write = false;

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -32,7 +32,7 @@ static bool IsRemote(const string &repository) {
 }
 
 /**
- * Checks for existance of a file either locally or via HTTP head
+ * Checks for existence of a file either locally or via HTTP head
  */
 bool CommandInfo::Exists(const string &repository, const string &file) const {
   if (IsRemote(repository)) {

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -23,7 +23,7 @@
  * Many of the options possible to set in the ArgumentList are not actually used
  * by the ingest command since they are not part of its interface, hence those
  * unused options cannot be set by the shell script. Of course if there is the
- * necessitty those paramenters can be added and managed.
+ * necessitty those parameters can be added and managed.
  * At the moment this approach worked fine and didn't add much complexity,
  * however if yet another command will need to use a similar approach it would
  * be good to consider creating different options handler for each command.

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -748,8 +748,8 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::
     "INSERT OR REPLACE INTO nested_catalogs (path,   sha1,  size) "
     "                VALUES                 (:path, :sha1, :size);");
 
-  // go through all nested catalogs and update their references (we are currently
-  // in their parent catalog)
+  // go through all nested catalogs and update their references (we are
+  // currently in their parent catalog)
   // Note: we might need to wait for the nested catalog to be fully processed.
   PendingCatalogList::const_iterator i    = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -1561,7 +1561,8 @@ bool CommandMigrate::MigrationWorker_20x::GenerateCatalogStatistics(
   const catalog::CatalogDatabase &writable = data->new_catalog->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are successfully processed
+  // Note: we might need to wait until nested catalogs are successfully
+  // processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i    = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -1745,7 +1746,8 @@ bool CommandMigrate::MigrationWorker_217::GenerateNewStatisticsCounters
     GetWritable(data->old_catalog)->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are successfully processed
+  // Note: we might need to wait until nested catalogs are successfully
+  // processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -2100,7 +2102,8 @@ bool CommandMigrate::StatsMigrationWorker::RepairStatisticsCounters(
     GetWritable(data->old_catalog)->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are successfully processed
+  // Note: we might need to wait until nested catalogs are successfully
+  // processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -443,7 +443,7 @@ bool CommandMigrate::DoMigrationAndCommit(
                           new_catalog->GetLastModified(),
                           &history_hash))
       {
-        Error("Updateing tag database failed.\nAborting...");
+        Error("Updating tag database failed.\nAborting...");
         return false;
       }
       manifest.set_history(history_hash);
@@ -748,7 +748,7 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::
     "INSERT OR REPLACE INTO nested_catalogs (path,   sha1,  size) "
     "                VALUES                 (:path, :sha1, :size);");
 
-  // go through all nested catalogs and update their references (we are curently
+  // go through all nested catalogs and update their references (we are currently
   // in their parent catalog)
   // Note: we might need to wait for the nested catalog to be fully processed.
   PendingCatalogList::const_iterator i    = data->nested_catalogs.begin();
@@ -1410,7 +1410,7 @@ bool CommandMigrate::MigrationWorker_20x::FixNestedCatalogTransitionPoints(
       update_directory_entry.Reset();
 
       // Fixing of this mountpoint went well... inform the user that this minor
-      // issue occured
+      // issue occurred
       LogCvmfs(kLogCatalog, kLogStdout,
                "NOTE: fixed incompatible nested catalog transition point at: "
                "'%s' ", nested_root_path.c_str());
@@ -1561,7 +1561,7 @@ bool CommandMigrate::MigrationWorker_20x::GenerateCatalogStatistics(
   const catalog::CatalogDatabase &writable = data->new_catalog->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are sucessfully processed
+  // Note: we might need to wait until nested catalogs are successfully processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i    = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -1745,7 +1745,7 @@ bool CommandMigrate::MigrationWorker_217::GenerateNewStatisticsCounters
     GetWritable(data->old_catalog)->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are sucessfully processed
+  // Note: we might need to wait until nested catalogs are successfully processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();
@@ -2100,7 +2100,7 @@ bool CommandMigrate::StatsMigrationWorker::RepairStatisticsCounters(
     GetWritable(data->old_catalog)->database();
 
   // Aggregated the statistics counters of all nested catalogs
-  // Note: we might need to wait until nested catalogs are sucessfully processed
+  // Note: we might need to wait until nested catalogs are successfully processed
   catalog::DeltaCounters stats_counters;
   PendingCatalogList::const_iterator i = data->nested_catalogs.begin();
   PendingCatalogList::const_iterator iend = data->nested_catalogs.end();

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -227,7 +227,7 @@ static void StoreBuffer(const unsigned char *buffer, const unsigned size,
   assert(ftmp);
   int retval;
   if (compress) {
-    shash::Any dummy(shash::kSha1);  // hardcoded hash no problem, unsused
+    shash::Any dummy(shash::kSha1);  // hardcoded hash no problem, unused
     retval = zlib::CompressMem2File(buffer, size, ftmp, &dummy);
   } else {
     retval = CopyMem2File(buffer, size, ftmp);
@@ -589,7 +589,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   }
 
   if (!this->InitVerifyingSignatureManager(master_keys, trusted_certs)) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to initalize CVMFS signatures");
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to initialize CVMFS signatures");
     return 1;
   } else {
     LogCvmfs(kLogCvmfs, kLogStdout,

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -6,7 +6,7 @@
  * We take all three volumes (namely union, overlay and repository) into
  * account to sync the changes back into the repository.
  *
- * On the repository side we have a catalogs directory that mimicks the
+ * On the repository side we have a catalogs directory that mimics the
  * shadow directory structure and stores compressed and uncompressed
  * versions of all catalogs.  The raw data are stored in the data
  * subdirectory in zlib-compressed form.  They are named with their SHA-1
@@ -805,7 +805,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   publish::SyncMediator mediator(&catalog_manager, &params, publish_statistics);
   LogCvmfs(kLogPublish, kLogStdout, "Processing changes...");
 
-  // Should be before the syncronization starts to avoid race of GetTTL with
+  // Should be before the synchronization starts to avoid race of GetTTL with
   // other sqlite operations
   if ((params.ttl_seconds > 0) &&
       ((params.ttl_seconds != catalog_manager.GetTTL()) ||

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -181,7 +181,7 @@ void SyncMediator::Touch(SharedPtr<SyncItem> entry) {
     // Replace calls Remove; cancel Remove's actions:
     perf::Xadd(counters_->sz_removed_bytes, -entry->GetRdOnlySize());
 
-    // Count only the diference between the old and new file
+    // Count only the difference between the old and new file
     // Symlinks do not count into added or removed bytes
     int64_t dif = 0;
 

--- a/cvmfs/sync_union.h
+++ b/cvmfs/sync_union.h
@@ -131,7 +131,7 @@ class SyncUnion {
    * Note: This needs to be up-called!
    * @param parent directory in which file resides
    * @param filename to decide whether to ignore or not
-   * @return true if file should be ignored, othewise false
+   * @return true if file should be ignored, otherwise false
    */
   virtual bool IgnoreFilePredicate(const std::string &parent_dir,
                                    const std::string &filename);
@@ -147,7 +147,7 @@ class SyncUnion {
   AbstractSyncMediator *mediator_;
 
   /**
-   * Allow for preprocessing steps before emiting any SyncItems from SyncUnion.
+   * Allow for preprocessing steps before emitting any SyncItems from SyncUnion.
    * This can be overridden by sub-classes but should always be up-called. Typi-
    * cally this sets whiteout and opaque-directory flags or handles hardlinks.
    * @param entry  the SyncItem to be pre-processed

--- a/cvmfs/sync_union_aufs.cc
+++ b/cvmfs/sync_union_aufs.cc
@@ -26,7 +26,7 @@ SyncUnionAufs::SyncUnionAufs(SyncMediator *mediator,
   ignore_filenames_.insert(".wh..wh.orph");
   ignore_filenames_.insert(".wh..wh..opq");
 
-  // set the whiteout prefix AUFS preceeds for every whiteout file
+  // set the whiteout prefix AUFS precedes for every whiteout file
   whiteout_prefix_ = ".wh.";
 }
 

--- a/cvmfs/sync_union_aufs.h
+++ b/cvmfs/sync_union_aufs.h
@@ -16,7 +16,7 @@
 
 namespace publish {
 /**
- * Syncing a cvmfs repository by the help of an overlayed AUFS
+ * Syncing a cvmfs repository by the help of an overlaid AUFS
  * read-write volume.
  */
 class SyncUnionAufs : public SyncUnion {

--- a/cvmfs/sync_union_overlayfs.h
+++ b/cvmfs/sync_union_overlayfs.h
@@ -19,7 +19,7 @@
 namespace publish {
 
 /**
- * Syncing a cvmfs repository by the help of an overlayed overlayfs
+ * Syncing a cvmfs repository by the help of an overlaid overlayfs
  * read-write volume.
  */
 class SyncUnionOverlayfs : public SyncUnion {

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -180,7 +180,7 @@ void SyncUnionTarball::Traverse() {
       default: {
         // We should never enter in this branch, but just for safeness we prefer
         // to abort in case we hit a case we don't how to manage.
-        PANIC(kLogStderr, "Enter in unknow state. Aborting.\nError: %s\n",
+        PANIC(kLogStderr, "Enter in unknown state. Aborting.\nError: %s\n",
               result, archive_error_string(src));
       }
     }
@@ -313,7 +313,7 @@ bool SyncUnionTarball::IsWhiteoutEntry(SharedPtr<SyncItem> entry) const {
   return false;
 }
 
-/* Tar files are not necessarly traversed in order from root to leave.
+/* Tar files are not necessarily traversed in order from root to leave.
  * So it may happens that we are expanding the file `/a/b/c.txt` without
  * having created yet the directory `/a/b/`.
  * In order to overcome this limitation the following function create dummy

--- a/cvmfs/telemetry_aggregator.cc
+++ b/cvmfs/telemetry_aggregator.cc
@@ -83,7 +83,7 @@ void *TelemetryAggregator::MainTelemetry(void *data) {
     watch_term.revents = 0;
     int retval = poll(&watch_term, 1, timeout_ms);
     if (retval < 0) {
-      if (errno == EINTR) {  // external interrupt occured - no error for us
+      if (errno == EINTR) {  // external interrupt occurred - no error for us
         if (timeout_ms >= 0) {
           uint64_t now = platform_monotonic_time();
           timeout_ms = (now > deadline_sec) ? 0 :

--- a/cvmfs/telemetry_aggregator_influx.cc
+++ b/cvmfs/telemetry_aggregator_influx.cc
@@ -98,8 +98,8 @@ TelemetryAggregatorInflux::~TelemetryAggregatorInflux() {
 }
 
 /**
- * Creates a string in the influx data format containing the absolut values
- * of the counters. Counters are only included if their absolut value is > 0.
+ * Creates a string in the influx data format containing the absolute values
+ * of the counters. Counters are only included if their absolute value is > 0.
  * 
  * Influx dataformat
  * ( https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/ )
@@ -150,7 +150,7 @@ std::string TelemetryAggregatorInflux::MakePayload() {
 /**
  * Creates a string in the influx data format containing the delta between
  * 2 measurements of the same counter. Counters are only included if their 
- * absolut value is > 0 (delta can be 0).
+ * absolute value is > 0 (delta can be 0).
  * 
  * NOTE: As influx_extra_fields_ are static, they are excluded of this 
  *       delta format

--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -15,7 +15,7 @@
  *      -> generate a content hash of the compression result
  *
  *   2. Upload files
- *      -> pluggable to support different upload pathes (local, S3, ...)
+ *      -> pluggable to support different upload paths (local, S3, ...)
  *
  * There are a number of different entities involved in this process. Namely:
  *   -> Spooler            - general steering tasks ( + common interface )
@@ -81,7 +81,7 @@
  *                 *********************
  *
  *
- * TODO(rmeusel): special purpose ::Process...() methods should (opionally?)
+ * TODO(rmeusel): special purpose ::Process...() methods should (optionally?)
  *                return Future<> instead of relying on the callbacks. Those are
  *                somewhat one-shot calls and require a rather fishy idiom when
  *                using callbacks, like:
@@ -152,7 +152,7 @@ class Spooler : public Observable<SpoolerResult> {
   std::string backend_name() const;
 
   /**
-   * Calls the concrete uploder to create a new repository area
+   * Calls the concrete uploader to create a new repository area
    */
   bool Create();
 

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -320,7 +320,7 @@ class AbstractUploader
   /**
    * Waits until the current upload queue is empty.
    *
-   * Note: This does NOT necessarily mean, that all files are actuall uploaded.
+   * Note: This does NOT necessarily mean, that all files are actually uploaded.
    *       If new jobs are concurrently scheduled the behavior of this method is
    *       not defined (it returns also on intermediately empty queues)
    */

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -71,7 +71,7 @@ struct UploadStreamHandle;
 /**
  * Abstract base class for all backend upload facilities
  * This class defines an interface and constructs the concrete Uploaders,
- * futhermore it handles callbacks to the outside world to notify users of done
+ * furthermore it handles callbacks to the outside world to notify users of done
  * upload jobs.
  *
  * Note: Users could be both the Spooler (when calling Spooler::Upload()) and
@@ -151,7 +151,7 @@ class AbstractUploader
   /**
    * Concrete uploaders might want to use a customized setting for multi-stream
    * writing, for instance one per disk.  Note that the S3 backend uses one task
-   * but this one task uses internally mutliple HTTP streams through curl async
+   * but this one task uses internally multiple HTTP streams through curl async
    * I/O.
    */
   virtual unsigned GetNumTasks() const { return num_upload_tasks_; }
@@ -351,7 +351,7 @@ class AbstractUploader
    * Implementation of a streamed upload step. See public interface for details.
    * Public interface: AbstractUploader::ScheduleUpload()
    *
-   * @param handle     decendant of UploadStreamHandle specifying the stream
+   * @param handle     descendant of UploadStreamHandle specifying the stream
    * @param buffer     the CharBuffer to be uploaded to the stream
    * @param callback   callback to be called on completion
    */
@@ -360,10 +360,10 @@ class AbstractUploader
                               const CallbackTN *callback) = 0;
 
   /**
-   * Implemetation of streamed upload commit
+   * Implementation of streamed upload commit
    * Public interface: AbstractUploader::ScheduleUpload()
    *
-   * @param handle        decendant of UploadStreamHandle specifying the stream
+   * @param handle        descendant of UploadStreamHandle specifying the stream
    * @param content_hash  the computed content hash of the streamed object
    */
   virtual void FinalizeStreamedUpload(UploadStreamHandle *handle,
@@ -428,7 +428,7 @@ class AbstractUploader
   const SpoolerDefinition spooler_definition_;
 
   /**
-   * Number of threads used for I/O write calls. Effectively this paramater
+   * Number of threads used for I/O write calls. Effectively this parameter
    * sets the I/O depth. Defaults to 1.
    */
   unsigned num_upload_tasks_;

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -88,7 +88,7 @@ class LocalUploader : public AbstractUploader {
   // state information
   const std::string upstream_path_;
   const std::string temporary_path_;
-  mutable atomic_int32 copy_errors_;  //!< counts the number of occured
+  mutable atomic_int32 copy_errors_;  //!< counts the number of occurred
                                       //!< errors in Upload()
 };
 

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -83,7 +83,7 @@ struct SpoolerDefinition {
   unsigned int number_of_concurrent_uploads;
 
   /**
-   * Number of threads used for I/O write calls. Effectively this paramater
+   * Number of threads used for I/O write calls. Effectively this parameter
    * sets the I/O depth.
    */
   unsigned int num_upload_tasks;

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -29,7 +29,7 @@ bool HighPrecisionTimer::g_is_enabled = false;
 
 
 double DiffTimeSeconds(struct timeval start, struct timeval end) {
-  // Time substraction, from GCC documentation
+  // Time subtraction, from GCC documentation
   if (end.tv_usec < start.tv_usec) {
     int64_t nsec = (end.tv_usec - start.tv_usec) / 1000000 + 1;
     start.tv_usec -= 1000000 * nsec;

--- a/cvmfs/util/concurrency.h
+++ b/cvmfs/util/concurrency.h
@@ -686,7 +686,7 @@ class ConcurrentWorkers : public Observable<typename WorkerT::returned_data> {
  *     as its only parameter:
  *        AwesomeWorker(const AwesomeWorker::worker_context*)
  *     Note: do not rely on the context object to be available after the
- *           consturctor has returned!
+ *           constructor has returned!
  *
  *  -> needs to define the calling-operator expecting one parameter of type:
  *     const expected_data& and returning void

--- a/cvmfs/util/logging.cc
+++ b/cvmfs/util/logging.cc
@@ -445,7 +445,7 @@ void vLogCvmfs(const LogSource source, const int mask,
   if (mask & kLogDebug) {
     pthread_mutex_lock(&lock_debug);
 
-    // Set the file pointer for debuging to stderr, if necessary
+    // Set the file pointer for debugging to stderr, if necessary
     if (file_debug == NULL) file_debug = stderr;
 
     // Get timestamp

--- a/cvmfs/util/mutex.h
+++ b/cvmfs/util/mutex.h
@@ -15,7 +15,7 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 /**
  * Used to allow for static polymorphism in the RAII template to statically
- * decide which 'lock' functions to use, if we have more than one possiblity.
+ * decide which 'lock' functions to use, if we have more than one possibility.
  * (I.e. Read/Write locks)
  * Note: Static Polymorphism - Strategy Pattern
  *

--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -173,7 +173,7 @@ inline int platform_sigwait(const int signum) {
 }
 
 /**
- * Grants a PID capabilites for ptrace() usage
+ * Grants a PID capabilities for ptrace() usage
  *
  * @param PID  the PID of the process to be granted ptrace()-access
  *             (may be ignored)

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -25,7 +25,7 @@ namespace CVMFS_NAMESPACE_GUARD {
  * @param AbstractProductT  the abstract base class of all classes that could be
  *                          polymorphically constructed by this factory
  * @param ParameterT        the type of the parameter that is used to figure out
- *                          which class should be instanciated at runtime
+ *                          which class should be instantiated at runtime
  * @param InfoT             wrapper type for introspection data of registered
  *                          plugins
  */
@@ -46,7 +46,7 @@ class AbstractFactory {
  * specific class instance. Namely ConcreteProductT. (Note: still abstract)
  * See the description of PolymorphicCreation for more details
  *
- * @param ConcreteProductT  the class that will be instanciated by this factory
+ * @param ConcreteProductT  the class that will be instantiated by this factory
  *                          class (must be derived from AbstractProductT)
  * @param AbstractProductT  the base class of all used ConcreteProductT classes
  * @param ParameterT        the type of the parameter that is used to poly-

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -1060,7 +1060,7 @@ std::string GetCurrentWorkingDirectory() {
 
 
 /**
- * Helper class that provides callback funtions for the file system traversal.
+ * Helper class that provides callback functions for the file system traversal.
  */
 class RemoveTreeHelper {
  public:
@@ -1593,7 +1593,7 @@ void WaitForSignal(int signum) {
 /**
  * Returns -1 if the child crashed or the exit code otherwise.
  * @param pid Process identifier.
- * @param sig_ok List of signals that are still considered a sucessful termination.
+ * @param sig_ok List of signals that are still considered a successful termination.
  */
 int WaitForChild(pid_t pid, const std::vector<int> &sig_ok) {
   assert(pid > 0);

--- a/packaging/container/mount_cvmfs.sh
+++ b/packaging/container/mount_cvmfs.sh
@@ -60,7 +60,7 @@ fi
 
 # TODO(jblomer): add all CVMFS_* environment variables to $CONFIG
 
-# Gracefully unmount on container exit to avoid the error messge
+# Gracefully unmount on container exit to avoid the error message
 # "transport endpoint not connected" on /cvmfs/* directories
 trap cleanup SIGTERM SIGINT SIGQUIT SIGHUP
 

--- a/packaging/debian/config-default/control
+++ b/packaging/debian/config-default/control
@@ -13,5 +13,5 @@ Conflicts: cvmfs-keys, cvmfs-config
 Breaks: cvmfs-keys, cvmfs (<< 2.1.20), cvmfs-server (<< 2.1.20)
 Provides: cvmfs-config
 Description: CernVM File System Default Configuration
- Defaulf configuration and public keys for mounting common CernVM-FS
+ Default configuration and public keys for mounting common CernVM-FS
  repositories.

--- a/packaging/debian/config-default/copyright
+++ b/packaging/debian/config-default/copyright
@@ -5,7 +5,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/debian/config-graphdriver/copyright
+++ b/packaging/debian/config-graphdriver/copyright
@@ -5,7 +5,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/debian/config-none/copyright
+++ b/packaging/debian/config-none/copyright
@@ -5,7 +5,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/debian/config-shrinkwrap/copyright
+++ b/packaging/debian/config-shrinkwrap/copyright
@@ -5,7 +5,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/debian/cvmfs-release/copyright
+++ b/packaging/debian/cvmfs-release/copyright
@@ -5,7 +5,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/debian/cvmfs/copyright
+++ b/packaging/debian/cvmfs/copyright
@@ -14,7 +14,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/debian/keys/copyright
+++ b/packaging/debian/keys/copyright
@@ -5,7 +5,7 @@ Copyright:
 
 License:
 
-    Distributed unter the BSD License.
+    Distributed under the BSD License.
 
 The Debian packaging is:
 

--- a/packaging/rpm/cvmfs-auto-setup.spec
+++ b/packaging/rpm/cvmfs-auto-setup.spec
@@ -5,7 +5,7 @@ Release: 3
 BuildArch: noarch
 Requires: cvmfs >= 2.1
 Group: System/Filesystems
-License: Copyright (c) 2009, CERN.  Distributed unter the BSD License.
+License: Copyright (c) 2009, CERN.  Distributed under the BSD License.
 %description
 HTTP File System for Distributing Software to CernVM.
 See http://cernvm.cern.ch

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -1,7 +1,7 @@
 
 CVMFS_EC_BASE_URL="https://ecsft.cern.ch/dist/cvmfs"
 
-# tries to guess the pacakge download URLs for a provided package name and cvmfs
+# tries to guess the package download URLs for a provided package name and cvmfs
 # version. This relies on the Electric Commander installation of SFT.
 #
 # Note: CVMFS_EC_BASE_URL needs to point to the cvmfs download location

--- a/test/micro-benchmarks/bm_util.h
+++ b/test/micro-benchmarks/bm_util.h
@@ -12,7 +12,7 @@ inline static void Escape(void *p) {
 }
 
 /**
- * Tell the optimizier that after this command, everything in the memory could
+ * Tell the optimizer that after this command, everything in the memory could
  * have changed.
  */
 inline static void ClobberMemory() {

--- a/test/run.sh
+++ b/test/run.sh
@@ -77,7 +77,7 @@ fi
 echo "Start test suite for cvmfs $(cvmfs2 --version)" > $logfile
 date >> $logfile
 
-# read command line paramters
+# read command line parameters
 shift
 test_exclusions=0
 xml_output=""

--- a/test/src/017-dnstimeout/main
+++ b/test/src/017-dnstimeout/main
@@ -39,7 +39,7 @@ cvmfs_run_test() {
   echo "unmounting and cleaning"
   cvmfs_clean || return 2
 
-  echo "install a desaster cleanup"
+  echo "install a disaster cleanup"
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "run a silent DNS server"

--- a/test/src/019-httptimeout/main
+++ b/test/src/019-httptimeout/main
@@ -34,7 +34,7 @@ cvmfs_run_test() {
 
   cvmfs_disable_config_repository
 
-  echo "install a desaster cleanup"
+  echo "install a disaster cleanup"
   trap cleanup EXIT HUP INT TERM || return $?
 
   echo "run a silent HTTP server"

--- a/test/src/705-evict/main
+++ b/test/src/705-evict/main
@@ -30,7 +30,7 @@ evict_file() {
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO evict "/$filename"
 
   local lc_newCache=$(sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO cache list | grep -e $filename | wc -l)
-  # make sure file is completly evicted from cache
+  # make sure file is completely evicted from cache
   [ $lc_newCache -eq 0 ] || return 11 
 
 
@@ -80,7 +80,7 @@ evict_and_readd() {
   cat $mntpnt/small > /dev/null
 
   local lc_newCache=$(sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO cache list | grep -e $filename | wc -l)
-  # make sure file is completly evicted from cache
+  # make sure file is completely evicted from cache
   [ $lc_newCache -eq $lc_oldCache ] || return 21 
 
   echo "   ...Success"

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -386,7 +386,7 @@ void *TestFetchCollapse2(void *data) {
 }
 
 TEST_F(T_Fetcher, FetchCollapse) {
-  // Test race condition: first open fails, second one succeds
+  // Test race condition: first open fails, second one succeeds
   perf::Statistics statistics;
   BuggyCacheManager bcm;
   bcm.open_2nd_try = true;

--- a/test/unittests/t_reflog.cc
+++ b/test/unittests/t_reflog.cc
@@ -130,7 +130,7 @@ TEST(T_Reflog, Checksum) {
 }
 
 
-TYPED_TEST(T_Reflog, Initalize) {}
+TYPED_TEST(T_Reflog, Initialize) {}
 
 
 TYPED_TEST(T_Reflog, CreateReflog) {


### PR DESCRIPTION
- [x] workflow was moved to a separate PR
- [x] ~~one typo fix is "functional": `quarantaine/` folder is being renamed to `quarantine/`.  May be should be reverted?~~ reverted, thus no more pertinent.
- there are some typos still left in test cases happen someone wants to practice codespell'-ing ;) 