### PR TITLE
Add CVMFS_FUSE3_{IDLE,MAX}_THREADS

### DIFF
--- a/cvmfs/duplex_fuse.h
+++ b/cvmfs/duplex_fuse.h
@@ -68,7 +68,7 @@
     #endif  // FUSE_VERSION < 28
   #else
     // CVMFS_USE_LIBFUSE == 3
-    #define FUSE_USE_VERSION 31
+    #define FUSE_USE_VERSION 312
     #include <fuse3/fuse.h>
     #include <fuse3/fuse_lowlevel.h>
     #include <fuse3/fuse_opt.h>

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1039,7 +1039,7 @@ int FuseMain(int argc, char *argv[]) {
     retval = fuse_session_loop_mt(session);
 #else
   struct fuse_loop_config *fuse_loop_cfg =  fuse_loop_cfg_create();
-    fuse_loop_cfg_set_clone_fd( fuse_loop_cfg, 1 ); //the default as of 3.13.1 is 0
+  fuse_loop_cfg_set_clone_fd( fuse_loop_cfg, 1 ); //the default as of 3.13.1 is 0
   if (options_manager->GetValue("CVMFS_FUSE3_DISABLE_CLONE_FD", &parameter) &&
     options_manager->IsOn(parameter)) {
     fuse_loop_cfg_set_clone_fd( fuse_loop_cfg, 0 );


### PR DESCRIPTION
Adds configuration options for controlling the number of FUSE3 worker threads. 
```
CVMFS_FUSE3_IDLE_THREADS
CVMFS_FUSE3_MAX_THREADS
```

Unfortunately bumps minimum libfuse3 requirement to 3.12