### PR TITLE
Templated pipe class for downloadmanager

### DIFF
--- a/cvmfs/authz/authz_fetch.cc
+++ b/cvmfs/authz/authz_fetch.cc
@@ -192,10 +192,12 @@ void AuthzExternalFetcher::ExecHelper() {
       close(open_fds[i]);
 #endif
 
+    // TODO(heretherebdragons) RESET SIGNAL HANDLERS
+
     execve(argv0, argv, &envp[0]);
     syslog(LOG_USER | LOG_ERR, "failed to start authz helper %s (%d)",
            argv0, errno);
-    abort();
+    _exit(1);
   }
   assert(pid > 0);
   close(pipe_send[0]);

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -241,7 +241,7 @@ string Watchdog::ReadUntilGdbPrompt(int fd_pipe) {
  */
 string Watchdog::ReportStacktrace() {
   CrashData crash_data;
-  if (!pipe_watchdog_->TryRead(&crash_data)) {
+  if (!pipe_watchdog_->TryRead<CrashData>(&crash_data)) {
     return "failed to read crash data (" + StringifyInt(errno) + ")";
   }
 
@@ -308,7 +308,7 @@ void Watchdog::SendTrace(int sig, siginfo_t *siginfo, void *context) {
   crash_data.signal     = sig;
   crash_data.sys_errno  = send_errno;
   crash_data.pid        = getpid();
-  if (!Me()->pipe_watchdog_->Write(crash_data)) {
+  if (!Me()->pipe_watchdog_->Write<CrashData>(crash_data)) {
     _exit(1);
   }
 
@@ -375,10 +375,10 @@ Watchdog::SigactionMap Watchdog::SetSignalHandlers(
 /**
  * Fork the watchdog process and put it on hold until Spawn() is called.
  */
-void Watchdog::Fork() {
-  Pipe pipe_pid;
-  pipe_watchdog_ = new Pipe();
-  pipe_listener_ = new Pipe();
+void Watchdog::Spawn() {
+  Pipe<kPipeWatchdogPid> pipe_pid;
+  pipe_watchdog_ = new Pipe<kPipeWatchdog>();
+  pipe_listener_ = new Pipe<kPipeWatchdogSupervisor>();
 
   pid_t pid;
   int statloc;
@@ -389,12 +389,12 @@ void Watchdog::Fork() {
       switch (fork()) {
         case -1: _exit(1);
         case 0: {
-          close(pipe_watchdog_->write_end);
+          pipe_watchdog_->CloseWriteFd();
           Daemonize();
           // send the watchdog PID to the supervisee
           pid_t watchdog_pid = getpid();
-          pipe_pid.Write(watchdog_pid);
-          close(pipe_pid.write_end);
+          pipe_pid.Write<pid_t>(watchdog_pid);
+          pipe_pid.CloseWriteFd();
           // Close all unused file descriptors
           // close also usyslog, only get it back if necessary
           // string usyslog_save = GetLogMicroSyslog();
@@ -412,33 +412,34 @@ void Watchdog::Fork() {
           preserve_fds.insert(0);
           preserve_fds.insert(1);
           preserve_fds.insert(2);
-          preserve_fds.insert(pipe_watchdog_->read_end);
-          preserve_fds.insert(pipe_listener_->write_end);
+          preserve_fds.insert(pipe_watchdog_->GetReadFd());
+          preserve_fds.insert(pipe_listener_->GetWriteFd());
           CloseAllFildes(preserve_fds);
           SetLogMicroSyslog(usyslog_save);  // no-op if usyslog not used
           SetLogDebugFile(debuglog_save);  // no-op if debug log not used
 
-          if (WaitForSupervisee())
+          if (WaitForSupervisee()) {
             Supervise();
+          }
 
-          close(pipe_watchdog_->read_end);
-          close(pipe_listener_->write_end);
+          pipe_watchdog_->CloseReadFd();
+          pipe_listener_->CloseWriteFd();
           exit(0);
         }
         default:
           _exit(0);
       }
     default:
-      close(pipe_watchdog_->read_end);
-      close(pipe_listener_->write_end);
-      close(pipe_pid.write_end);
+      pipe_watchdog_->CloseReadFd();
+      pipe_listener_->CloseWriteFd();
+      pipe_pid.CloseWriteFd();
       if (waitpid(pid, &statloc, 0) != pid) PANIC(NULL);
       if (!WIFEXITED(statloc) || WEXITSTATUS(statloc)) PANIC(NULL);
   }
 
   // retrieve the watchdog PID from the pipe
   pipe_pid.Read(&watchdog_pid_);
-  close(pipe_pid.read_end);
+  pipe_pid.CloseReadFd();
 }
 
 
@@ -492,7 +493,7 @@ bool Watchdog::WaitForSupervisee() {
   pipe_watchdog_->Read(&size);
   crash_dump_path_.resize(size);
   if (size > 0) {
-    ReadPipe(pipe_watchdog_->read_end, &crash_dump_path_[0], size);
+    pipe_watchdog_->Read(&crash_dump_path_[0], size);
 
     int retval = chdir(GetParentPath(crash_dump_path_).c_str());
     if (retval != 0) {
@@ -543,7 +544,7 @@ void Watchdog::Spawn(const std::string &crash_dump_path) {
   signal_handlers[SIGXFSZ] = sa;
   old_signal_handlers_ = SetSignalHandlers(signal_handlers);
 
-  pipe_terminate_ = new Pipe();
+  pipe_terminate_ = new Pipe<kPipeThreadTerminator>();
   int retval =
     pthread_create(&thread_listener_, NULL, MainWatchdogListener, this);
   assert(retval == 0);
@@ -563,10 +564,10 @@ void *Watchdog::MainWatchdogListener(void *data) {
   LogCvmfs(kLogMonitor, kLogDebug, "starting watchdog listener");
 
   struct pollfd watch_fds[2];
-  watch_fds[0].fd = watchdog->pipe_listener_->read_end;
+  watch_fds[0].fd = watchdog->pipe_listener_->GetReadFd();
   watch_fds[0].events = 0;  // Only check for POLL[ERR,HUP,NVAL] in revents
   watch_fds[0].revents = 0;
-  watch_fds[1].fd = watchdog->pipe_terminate_->read_end;
+  watch_fds[1].fd = watchdog->pipe_terminate_->GetReadFd();
   watch_fds[1].events = POLLIN | POLLPRI;
   watch_fds[1].revents = 0;
   while (true) {
@@ -603,7 +604,7 @@ void *Watchdog::MainWatchdogListener(void *data) {
 void Watchdog::Supervise() {
   ControlFlow::Flags control_flow = ControlFlow::kUnknown;
 
-  if (!pipe_watchdog_->TryRead(&control_flow)) {
+  if (!pipe_watchdog_->TryRead<ControlFlow::Flags>(&control_flow)) {
     LogEmergency("watchdog: unexpected termination (" +
                  StringifyInt(control_flow) + ")");
     if (on_crash_) on_crash_();
@@ -657,8 +658,8 @@ Watchdog::~Watchdog() {
   }
 
   pipe_watchdog_->Write(ControlFlow::kQuit);
-  close(pipe_watchdog_->write_end);
-  close(pipe_listener_->read_end);
+  pipe_watchdog_->CloseWriteFd();
+  pipe_listener_->CloseReadFd();
 
   platform_spinlock_destroy(&lock_handler_);
   LogCvmfs(kLogMonitor, kLogDebug, "monitor stopped");

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -18,7 +18,6 @@
 #include "util/pipe.h"
 #include "util/single_copy.h"
 
-
 /**
  * This class can fork a watchdog process that listens on a pipe and prints a
  * stackstrace into syslog, when cvmfs fails.  The crash dump is also appended

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -13,8 +13,8 @@
 #include <map>
 #include <string>
 
-#include "util/platform.h"
 #include "util/pipe.h"
+#include "util/platform.h"
 #include "util/pointer.h"
 #include "util/single_copy.h"
 

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -15,9 +15,9 @@
 
 #include "util/platform.h"
 #include "util/pointer.h"
+#include "util/pipe.h"
 #include "util/single_copy.h"
 
-struct Pipe;
 
 /**
  * This class can fork a watchdog process that listens on a pipe and prints a
@@ -95,12 +95,11 @@ class Watchdog : SingleCopy {
   std::string crash_dump_path_;
   std::string exe_path_;
   pid_t watchdog_pid_;
-  /// Communication channel from the supervisee to the watchdog
-  UniquePtr<Pipe> pipe_watchdog_;
+  UniquePtr<Pipe<kPipeWatchdog>> pipe_watchdog_;
   /// The supervisee makes sure its watchdog does not die
-  UniquePtr<Pipe> pipe_listener_;
+  UniquePtr<Pipe<kPipeWatchdogSupervisor>> pipe_listener_;
   /// Send the terminate signal to the listener
-  UniquePtr<Pipe> pipe_terminate_;
+  UniquePtr<Pipe<kPipeThreadTerminator>> pipe_terminate_;
   pthread_t thread_listener_;
   FnOnCrash on_crash_;
   platform_spinlock lock_handler_;

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -95,11 +95,11 @@ class Watchdog : SingleCopy {
   std::string crash_dump_path_;
   std::string exe_path_;
   pid_t watchdog_pid_;
-  UniquePtr<Pipe<kPipeWatchdog>> pipe_watchdog_;
+  UniquePtr<Pipe<kPipeWatchdog> > pipe_watchdog_;
   /// The supervisee makes sure its watchdog does not die
-  UniquePtr<Pipe<kPipeWatchdogSupervisor>> pipe_listener_;
+  UniquePtr<Pipe<kPipeWatchdogSupervisor> > pipe_listener_;
   /// Send the terminate signal to the listener
-  UniquePtr<Pipe<kPipeThreadTerminator>> pipe_terminate_;
+  UniquePtr<Pipe<kPipeThreadTerminator> > pipe_terminate_;
   pthread_t thread_listener_;
   FnOnCrash on_crash_;
   platform_spinlock lock_handler_;

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -14,8 +14,8 @@
 #include <string>
 
 #include "util/platform.h"
-#include "util/pointer.h"
 #include "util/pipe.h"
+#include "util/pointer.h"
 #include "util/single_copy.h"
 
 /**

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -510,7 +510,7 @@ void *DownloadManager::MainDownload(void *data) {
   download_mgr->watch_fds_size_ = 2;
   download_mgr->watch_fds_[kIdxPipeTerminate].fd =
                                      download_mgr->pipe_terminate_->GetReadFd();
- download_mgr->watch_fds_[kIdxPipeTerminate].events = POLLIN | POLLPRI;
+  download_mgr->watch_fds_[kIdxPipeTerminate].events = POLLIN | POLLPRI;
   download_mgr->watch_fds_[kIdxPipeTerminate].revents = 0;
   download_mgr->watch_fds_[kIdxPipeJobs].fd =
                                           download_mgr->pipe_jobs_->GetReadFd();

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -27,6 +27,7 @@
 #include "statistics.h"
 #include "util/atomic.h"
 #include "util/pipe.h"
+#include "util/pointer.h"
 #include "util/prng.h"
 
 class InterruptCue;
@@ -289,7 +290,7 @@ struct JobInfo {
   z_stream zstream;
   shash::ContextPtr hash_context;
 
-  /**< Pipe used for the return value */
+  /// Pipe used for the return value
   UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;
 
   std::string proxy;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -288,7 +288,10 @@ struct JobInfo {
   char *info_header;
   z_stream zstream;
   shash::ContextPtr hash_context;
-  UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;  /**< Pipe used for the return value */
+
+  /**< Pipe used for the return value */
+  UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;
+
   std::string proxy;
   bool nocache;
   Failures error_code;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -288,7 +288,7 @@ struct JobInfo {
   char *info_header;
   z_stream zstream;
   shash::ContextPtr hash_context;
-  UniquePtr<Pipe<kPipeDownloadJobsResults>> pipe_job_results;  /**< Pipe used for the return value */
+  UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;  /**< Pipe used for the return value */
   std::string proxy;
   bool nocache;
   Failures error_code;
@@ -509,9 +509,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
 
   pthread_t thread_download_;
   atomic_int32 multi_threaded_;
-  UniquePtr<Pipe<kPipeThreadTerminator>> pipe_terminate_;
+  UniquePtr<Pipe<kPipeThreadTerminator> > pipe_terminate_;
 
-  UniquePtr<Pipe<kPipeDownloadJobs>> pipe_jobs_;
+  UniquePtr<Pipe<kPipeDownloadJobs> > pipe_jobs_;
   struct pollfd *watch_fds_;
   uint32_t watch_fds_size_;
   uint32_t watch_fds_inuse_;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -26,6 +26,7 @@
 #include "ssl.h"
 #include "statistics.h"
 #include "util/atomic.h"
+#include "util/pipe.h"
 #include "util/prng.h"
 
 class InterruptCue;
@@ -205,7 +206,7 @@ struct JobInfo {
     headers = NULL;
     memset(&zstream, 0, sizeof(zstream));
     info_header = NULL;
-    wait_at[0] = wait_at[1] = -1;
+    pipe_job_results = NULL;
     nocache = false;
     error_code = kFailOther;
     num_used_proxies = num_used_hosts = num_retries = 0;
@@ -270,9 +271,8 @@ struct JobInfo {
   }
 
   ~JobInfo() {
-    if (wait_at[0] >= 0) {
-      close(wait_at[0]);
-      close(wait_at[1]);
+    if (pipe_job_results.IsValid()) {
+      pipe_job_results.Destroy();
     }
   }
 
@@ -288,7 +288,7 @@ struct JobInfo {
   char *info_header;
   z_stream zstream;
   shash::ContextPtr hash_context;
-  int wait_at[2];  /**< Pipe used for the return value */
+  UniquePtr<Pipe<kPipeDownloadJobsResults>> pipe_job_results;  /**< Pipe used for the return value */
   std::string proxy;
   bool nocache;
   Failures error_code;
@@ -509,9 +509,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
 
   pthread_t thread_download_;
   atomic_int32 multi_threaded_;
-  int pipe_terminate_[2];
+  UniquePtr<Pipe<kPipeThreadTerminator>> pipe_terminate_;
 
-  int pipe_jobs_[2];
+  UniquePtr<Pipe<kPipeDownloadJobs>> pipe_jobs_;
   struct pollfd *watch_fds_;
   uint32_t watch_fds_size_;
   uint32_t watch_fds_inuse_;

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -5,13 +5,14 @@
 #ifndef CVMFS_UTIL_PIPE_H_
 #define CVMFS_UTIL_PIPE_H_
 
-#include <cassert>
-#include <cerrno>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
+
+#include <cassert>
+#include <cerrno>
 
 #include "gtest/gtest_prod.h"
 #include "util/export.h"

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -24,7 +24,7 @@ namespace CVMFS_NAMESPACE_GUARD {
  * Describes the functionality of a pipe
  */
 enum PipeType {
-  kPipeThreadTerminator = 0, // pipe only used to signal a thread to stop
+  kPipeThreadTerminator = 0,  // pipe only used to signal a thread to stop
   kPipeWatchdog,
   kPipeWatchdogSupervisor,
   kPipeWatchdogPid,
@@ -35,10 +35,10 @@ enum PipeType {
 };
 
 /**
- * Common signals used by pipes 
+ * Common signals used by pipes
  */
 enum PipeSignals {
-  kPipeTerminateSignal = 1 
+  kPipeTerminateSignal = 1
 };
 
 template <PipeType pipeType>
@@ -52,10 +52,10 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
    * A pipe is a simple asynchronous communication mechanism. It establishes
    * a unidirectional communication link between two file descriptors. One of
    * them is used to only write to the pipe, the other one only to read from it.
-   * 
+   *
    * This class is a simple wrapper around the handling of a "standard" pipe
    * that uses system calls.
-   * 
+   *
    * @note PipeType as class template parameter should symbolize the
    *       functionality of the specific type, independent of what variable
    *       name it has
@@ -113,9 +113,9 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
 
   /**
    * Tries to write an object to the pipe
-   * 
+   *
    * @returns true if the entire object was written
-   *          false otherwise 
+   *          false otherwise
    */
   template<typename T>
   bool TryWrite(const T &data) {
@@ -125,10 +125,10 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
 
   /**
    * Writes an object to the pipe
-   * 
+   *
    * @returns true on success
    *          otherwise kills the program with an assert
-   * 
+   *
    */
   template<typename T>
   bool Write(const T &data) {
@@ -139,10 +139,10 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
   /**
    * Writes an object to the pipe
    * If possible, it is recommended to use "bool Write(const T &data)"
-   * 
+   *
    * @returns true on success
    *          otherwise kills the program with an assert
-   * 
+   *
    */
   bool Write(const void *buf, size_t nbyte) {
     WritePipe(fd_write_, buf, nbyte);
@@ -152,7 +152,7 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
   /**
    * Tries to read from the pipe until it receives data or it is interrupted
    * by a system call
-   * 
+   *
    * @returns true if sizeof(data) bytes were received
    *          false otherwise
    */

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -5,6 +5,8 @@
 #ifndef CVMFS_UTIL_PIPE_H_
 #define CVMFS_UTIL_PIPE_H_
 
+#include <cassert>
+#include <cerrno>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -1,0 +1,254 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_UTIL_PIPE_H_
+#define CVMFS_UTIL_PIPE_H_
+
+#include <pthread.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include "gtest/gtest_prod.h"
+#include "util/export.h"
+#include "util/pointer.h"
+#include "util/single_copy.h"
+
+#ifdef CVMFS_NAMESPACE_GUARD
+namespace CVMFS_NAMESPACE_GUARD {
+#endif
+
+/**
+ * Describes the functionality of a pipe
+ */
+enum PipeType {
+  kPipeThreadTerminator = 0, // pipe only used to signal a thread to stop
+  kPipeWatchdog,
+  kPipeWatchdogSupervisor,
+  kPipeWatchdogPid,
+  kPipeDetachedChild,
+  kPipeTest,
+  kPipeDownloadJobs,
+  kPipeDownloadJobsResults
+};
+
+/**
+ * Common signals used by pipes 
+ */
+enum PipeSignals {
+  kPipeTerminateSignal = 1 
+};
+
+template <PipeType pipeType>
+class CVMFS_EXPORT Pipe : public SingleCopy {
+  FRIEND_TEST(T_Util, ManagedExecRunShell);
+  FRIEND_TEST(T_Util, ManagedExecExecuteBinaryDoubleFork);
+  FRIEND_TEST(T_Util, ManagedExecExecuteBinaryAsChild);
+
+ public:
+  /**
+   * A pipe is a simple asynchronous communication mechanism. It establishes
+   * a unidirectional communication link between two file descriptors. One of
+   * them is used to only write to the pipe, the other one only to read from it.
+   * 
+   * This class is a simple wrapper around the handling of a "standard" pipe
+   * that uses system calls.
+   * 
+   * @note PipeType as class template parameter should symbolize the
+   *       functionality of the specific type, independent of what variable
+   *       name it has
+   */
+  Pipe() {
+    int pipe_fd[2];
+    MakePipe(pipe_fd);
+    fd_read_ = pipe_fd[0];
+    fd_write_ = pipe_fd[1];
+  }
+
+  /**
+   * Destructor closes all valid file descriptors of the pipe
+   */
+  ~Pipe() {
+    if (fd_read_ != -1) {
+      close(fd_read_);
+    }
+
+    if (fd_write_ != -1) {
+      close(fd_write_);
+    }
+  }
+
+  /**
+   * Closes all open file descriptors of the pipe and marks them as invalid
+   */
+  void Close() {
+    if (fd_read_ != -1) {
+      close(fd_read_);
+      fd_read_ = -1;
+    }
+
+    if (fd_write_ != -1) {
+      close(fd_write_);
+      fd_write_ = -1;
+    }
+  }
+
+  /**
+   * Closes file descriptor that reads from the pipe and marks it as invalid.
+   */
+  void CloseReadFd() {
+    close(fd_read_);
+    fd_read_ = -1;
+  }
+
+  /**
+   * Closes file descriptor that writes to the pipe and marks it as invalid.
+   */
+  void CloseWriteFd() {
+    close(fd_write_);
+    fd_write_ = -1;
+  }
+
+  /**
+   * Tries to write an object to the pipe
+   * 
+   * @returns true if the entire object was written
+   *          false otherwise 
+   */
+  template<typename T>
+  bool TryWrite(const T &data) {
+    const int num_bytes = write(fd_write_, &data, sizeof(T));
+    return (num_bytes >= 0) && (static_cast<size_t>(num_bytes) == sizeof(T));
+  }
+
+  /**
+   * Writes an object to the pipe
+   * 
+   * @returns true on success
+   *          otherwise kills the program with an assert
+   * 
+   */
+  template<typename T>
+  bool Write(const T &data) {
+    WritePipe(fd_write_, &data, sizeof(T));
+    return true;
+  }
+
+  /**
+   * Writes an object to the pipe
+   * If possible, it is recommended to use "bool Write(const T &data)"
+   * 
+   * @returns true on success
+   *          otherwise kills the program with an assert
+   * 
+   */
+  bool Write(const void *buf, size_t nbyte) {
+    WritePipe(fd_write_, buf, nbyte);
+    return true;
+  }
+
+  /**
+   * Tries to read from the pipe until it receives data or it is interrupted
+   * by a system call
+   * 
+   * @returns true if sizeof(data) bytes were received
+   *          false otherwise
+   */
+  template<typename T>
+  bool TryRead(T *data) {
+    ssize_t num_bytes;
+    do {
+      num_bytes = read(fd_read_, data, sizeof(T));
+    } while ((num_bytes < 0) && (errno == EINTR));
+    return (num_bytes >= 0) && (static_cast<size_t>(num_bytes) == sizeof(T));
+  }
+
+  /**
+   * Reads an object from the pipe
+   *
+   * @returns true on success
+   *          otherwise kills the program with an assert
+   */
+  template<typename T>
+  bool Read(T *data) {
+    ReadPipe(fd_read_, data, sizeof(T));
+    return true;
+  }
+
+  /**
+   * Reads an object from the pipe
+   * If possible, it is recommend to use "bool Read(T *data)""
+   *
+   * @returns true on success
+   *          otherwise kills the program with an assert
+   */
+  bool Read(void *buf, size_t nbyte) {
+    ReadPipe(fd_read_, buf, nbyte);
+    return true;
+  }
+
+  /**
+   * Returns the file descriptor that reads from the pipe
+   */
+  int GetReadFd() {
+    return fd_read_;
+  }
+
+  /**
+   * Returns the file descriptor that writes to the pipe
+   */
+  int GetWriteFd() {
+    return fd_write_;
+  }
+
+
+ private:
+  int fd_read_;
+  int fd_write_;
+
+  /**
+   * Only used in the unit tests to test pipes using stdin/stdout as read/write.
+  */
+  Pipe(const int fd_read, const int fd_write) : fd_read_(fd_read),
+                                                fd_write_(fd_write) {}
+
+  /**
+   * Creating a pipe should always succeed.
+   */
+  void MakePipe(int pipe_fd[2]) {
+    int retval = pipe(pipe_fd);
+    assert(retval == 0);
+  }
+
+
+  /**
+   * Writes to a pipe should always succeed.
+   */
+  void WritePipe(int fd, const void *buf, size_t nbyte) {
+    ssize_t num_bytes;
+    do {
+      num_bytes = write(fd, buf, nbyte);
+    } while ((num_bytes < 0) && (errno == EINTR));
+    assert((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte));
+  }
+
+
+  /**
+   * Reads from a pipe should always succeed.
+   */
+  void ReadPipe(int fd, void *buf, size_t nbyte) {
+    ssize_t num_bytes;
+    do {
+      num_bytes = read(fd, buf, nbyte);
+    } while ((num_bytes < 0) && (errno == EINTR));
+    assert((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte));
+  }
+};
+
+#ifdef CVMFS_NAMESPACE_GUARD
+}  // namespace CVMFS_NAMESPACE_GUARD
+#endif
+
+#endif  // CVMFS_UTIL_PIPE_H_

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -210,9 +210,8 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
    */
   void MakePipe(int pipe_fd[2]) {
     int retval = pipe(pipe_fd);
-    if (!(retval == 0)) {
-      PANIC(kLogSyslogErr | kLogDebug,
-                      "MakePipe failed with retval %d errno %d", retval, errno);
+    if (retval != 0) {
+      PANIC(kLogSyslogErr | kLogDebug, "MakePipe failed with errno %d", errno);
     }
   }
 

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -223,7 +223,7 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
    */
   void MakePipe(int pipe_fd[2]) {
     int retval = pipe(pipe_fd);
-    if (retval == 0) {
+    if (!(retval == 0)) {
       PANIC(kLogSyslogErr | kLogDebug,
                       "MakePipe failed with retval %d errno %d", retval, errno);
     }
@@ -238,7 +238,7 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
     do {
       num_bytes = write(fd, buf, nbyte);
     } while ((num_bytes < 0) && (errno == EINTR));
-    if ((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte)) {
+    if (!((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte))) {
       PANIC(kLogSyslogErr | kLogDebug,
                                    "WritePipe failed: expected write size %lu, "
                                    "actually written %lu, errno %d, fd %d",
@@ -255,7 +255,7 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
     do {
       num_bytes = read(fd, buf, nbyte);
     } while ((num_bytes < 0) && (errno == EINTR));
-    if ((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte)) {
+    if (!((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte))) {
       PANIC(kLogSyslogErr | kLogDebug,
                                      "ReadPipe failed: expected read size %lu, "
                                      "actually read %lu, errno %d, fd %d",

--- a/cvmfs/util/pipe.h
+++ b/cvmfs/util/pipe.h
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <cerrno>
 
+#include "exception.h"
 #include "gtest/gtest_prod.h"
 #include "util/export.h"
 #include "util/pointer.h"
@@ -222,7 +223,10 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
    */
   void MakePipe(int pipe_fd[2]) {
     int retval = pipe(pipe_fd);
-    assert(retval == 0);
+    if (retval == 0) {
+      PANIC(kLogSyslogErr | kLogDebug,
+                      "MakePipe failed with retval %d errno %d", retval, errno);
+    }
   }
 
 
@@ -234,7 +238,12 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
     do {
       num_bytes = write(fd, buf, nbyte);
     } while ((num_bytes < 0) && (errno == EINTR));
-    assert((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte));
+    if ((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte)) {
+      PANIC(kLogSyslogErr | kLogDebug,
+                                   "WritePipe failed: expected write size %lu, "
+                                   "actually written %lu, errno %d, fd %d",
+                                   nbyte, num_bytes, errno, fd);
+    }
   }
 
 
@@ -246,7 +255,12 @@ class CVMFS_EXPORT Pipe : public SingleCopy {
     do {
       num_bytes = read(fd, buf, nbyte);
     } while ((num_bytes < 0) && (errno == EINTR));
-    assert((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte));
+    if ((num_bytes >= 0) && (static_cast<size_t>(num_bytes) == nbyte)) {
+      PANIC(kLogSyslogErr | kLogDebug,
+                                     "ReadPipe failed: expected read size %lu, "
+                                     "actually read %lu, errno %d, fd %d",
+                                     nbyte, num_bytes, errno, fd);
+    }
   }
 };
 

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -56,9 +56,9 @@
 #include "util/exception.h"
 #include "util/fs_traversal.h"
 #include "util/logging.h"
+#include "util/pipe.h"
 #include "util/platform.h"
 #include "util/string.h"
-#include "util/pipe.h"
 
 //using namespace std;  // NOLINT
 

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -58,6 +58,7 @@
 #include "util/logging.h"
 #include "util/platform.h"
 #include "util/string.h"
+#include "util/pipe.h"
 
 //using namespace std;  // NOLINT
 
@@ -1846,7 +1847,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
 {
   assert(command_line.size() >= 1);
 
-  Pipe pipe_fork;
+  Pipe<kPipeDetachedChild> pipe_fork;
   pid_t pid = fork();
   assert(pid >= 0);
   if (pid == 0) {
@@ -1855,7 +1856,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
     ForkFailures::Names failed = ForkFailures::kUnknown;
 
     std::set<int> skip_fds = preserve_fildes;
-    skip_fds.insert(pipe_fork.write_end);
+    skip_fds.insert(pipe_fork.GetWriteFd());
 
     if (clear_env) {
 #ifdef __APPLE__
@@ -1895,13 +1896,13 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
       if (pid_grand_child != 0) _exit(0);
     }
 
-    fd_flags = fcntl(pipe_fork.write_end, F_GETFD);
+    fd_flags = fcntl(pipe_fork.GetWriteFd(), F_GETFD);
     if (fd_flags < 0) {
       failed = ForkFailures::kFailGetFdFlags;
       goto fork_failure;
     }
     fd_flags |= FD_CLOEXEC;
-    if (fcntl(pipe_fork.write_end, F_SETFD, fd_flags) < 0) {
+    if (fcntl(pipe_fork.GetWriteFd(), F_SETFD, fd_flags) < 0) {
       failed = ForkFailures::kFailSetFdFlags;
       goto fork_failure;
     }
@@ -1918,15 +1919,15 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
     // grand father
     pid_grand_child = getpid();
     failed = ForkFailures::kSendPid;
-    pipe_fork.Write(&failed, sizeof(failed));
-    pipe_fork.Write(pid_grand_child);
+    pipe_fork.Write<ForkFailures::Names>(failed);
+    pipe_fork.Write<pid_t>(pid_grand_child);
 
     execvp(command_line[0].c_str(), const_cast<char **>(argv));
 
     failed = ForkFailures::kFailExec;
 
    fork_failure:
-    pipe_fork.Write(&failed, sizeof(failed));
+    pipe_fork.Write<ForkFailures::Names>(failed);
     _exit(1);
   }
   if (double_fork) {
@@ -1934,14 +1935,14 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
     waitpid(pid, &statloc, 0);
   }
 
-  close(pipe_fork.write_end);
+  pipe_fork.CloseWriteFd();
 
   // Either the PID or a return value is sent
   ForkFailures::Names status_code;
-  bool retcode = pipe_fork.Read(&status_code, sizeof(status_code));
-  assert(retcode);
+  pipe_fork.Read<ForkFailures::Names>(&status_code);
+
   if (status_code != ForkFailures::kSendPid) {
-    close(pipe_fork.read_end);
+    pipe_fork.CloseReadFd();
     LogCvmfs(kLogCvmfs, kLogDebug, "managed execve failed (%s)",
              ForkFailures::ToString(status_code).c_str());
     return false;
@@ -1953,7 +1954,7 @@ bool ManagedExec(const std::vector<std::string>  &command_line,
   pipe_fork.Read(&buf_child_pid);
   if (child_pid != NULL)
     *child_pid = buf_child_pid;
-  close(pipe_fork.read_end);
+  pipe_fork.CloseReadFd();
   LogCvmfs(kLogCvmfs, kLogDebug, "execve'd %s (PID: %d)",
            command_line[0].c_str(),
            static_cast<int>(buf_child_pid));

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -197,60 +197,6 @@ CVMFS_EXPORT bool SafeReadToString(int fd, std::string *final_result);
 CVMFS_EXPORT bool SafeWriteToFile(const std::string &content,
                                   const std::string &path, int mode);
 
-struct CVMFS_EXPORT Pipe : public SingleCopy {
-  Pipe() {
-    int pipe_fd[2];
-    MakePipe(pipe_fd);
-    read_end = pipe_fd[0];
-    write_end = pipe_fd[1];
-  }
-
-  Pipe(const int fd_read, const int fd_write) :
-    read_end(fd_read), write_end(fd_write) {}
-
-  void Close() {
-    close(read_end);
-    close(write_end);
-  }
-
-  template<typename T>
-  bool Write(const T &data) {
-    assert(!IsPointer<T>::value);  // TODO(rmeusel): C++11 static_assert
-    const int num_bytes = write(write_end, &data, sizeof(T));
-    return (num_bytes >= 0) && (static_cast<size_t>(num_bytes) == sizeof(T));
-  }
-
-  template<typename T>
-  bool TryRead(T *data) {
-    assert(!IsPointer<T>::value);  // TODO(rmeusel): C++11 static_assert
-    ssize_t num_bytes;
-    do {
-      num_bytes = read(read_end, data, sizeof(T));
-    } while ((num_bytes < 0) && (errno == EINTR));
-    return (num_bytes >= 0) && (static_cast<size_t>(num_bytes) == sizeof(T));
-  }
-
-  template<typename T>
-  void Read(T *data) {
-    assert(!IsPointer<T>::value);  // TODO(rmeusel): C++11 static_assert
-    ReadPipe(read_end, data, sizeof(T));
-  }
-
-  bool Write(const void *buf, size_t nbyte) {
-    WritePipe(write_end, buf, nbyte);
-    return true;
-  }
-
-  bool Read(void *buf, size_t nbyte) {
-    ReadPipe(read_end, buf, nbyte);
-    return true;
-  }
-
-  int read_end;
-  int write_end;
-};
-
-
 #ifdef CVMFS_NAMESPACE_GUARD
 }  // namespace CVMFS_NAMESPACE_GUARD
 #endif

--- a/test/unittests/t_pipe.cc
+++ b/test/unittests/t_pipe.cc
@@ -7,12 +7,13 @@
 #include <fcntl.h>
 
 #include "util/posix.h"
+#include "util/pipe.h"
 
 class T_Pipe : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    const int fd_read_flags  = fcntl(pipe.read_end,  F_GETFD);
-    const int fd_write_flags = fcntl(pipe.write_end, F_GETFD);
+    const int fd_read_flags  = fcntl(pipe.GetReadFd(),  F_GETFD);
+    const int fd_write_flags = fcntl(pipe.GetWriteFd(), F_GETFD);
 
     ASSERT_GE(fd_read_flags,  0) << "Failed to create pipe (read end)";
     ASSERT_GE(fd_write_flags, 0) << "Failed to create pipe (write end)";
@@ -53,7 +54,7 @@ class T_Pipe : public ::testing::Test {
   };
 
  protected:
-  Pipe pipe;
+  Pipe<kPipeTest> pipe;
 };
 
 
@@ -70,7 +71,7 @@ TEST_F(T_Pipe, WriteTemplate) {
   retval = pipe.Write(integer);   EXPECT_TRUE(retval);
   retval = pipe.Write(character); EXPECT_TRUE(retval);
   retval = pipe.Write(foobar);    EXPECT_TRUE(retval);
-  EXPECT_DEATH(pipe.Write(&foobar), "");
+  retval = pipe.Write(&foobar);    EXPECT_TRUE(retval);
 }
 
 

--- a/test/unittests/t_pipe.cc
+++ b/test/unittests/t_pipe.cc
@@ -6,8 +6,8 @@
 
 #include <fcntl.h>
 
-#include "util/posix.h"
 #include "util/pipe.h"
+#include "util/posix.h"
 
 class T_Pipe : public ::testing::Test {
  protected:

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -25,6 +25,7 @@
 #include "util/atomic.h"
 #include "util/file_guard.h"
 #include "util/mmap_file.h"
+#include "util/pipe.h"
 #include "util/posix.h"
 #include "util/smalloc.h"
 #include "util/string.h"
@@ -1781,7 +1782,7 @@ TEST_F(T_Util, ManagedExecRunShell) {
   bool retval = Shell(&fd_stdin, &fd_stdout, &fd_stderr);
   EXPECT_TRUE(retval);
 
-  Pipe shell_pipe(fd_stdout, fd_stdin);
+  Pipe<kPipeTest> shell_pipe(fd_stdout, fd_stdin);
   const char *command = "echo \"Hello World\"\n";
   retval = shell_pipe.Write(command, strlen(command));
   EXPECT_TRUE(retval);
@@ -1833,7 +1834,7 @@ TEST_F(T_Util, ManagedExecExecuteBinaryDoubleFork) {
   }
 
   // tell the process to terminate
-  Pipe shell_pipe(fd_stdout, fd_stdin);
+  Pipe<kPipeTest> shell_pipe(fd_stdout, fd_stdin);
   const char *quit = "quit\n";
   retval = shell_pipe.Write(quit, strlen(quit));
   EXPECT_TRUE(retval);
@@ -1879,7 +1880,7 @@ TEST_F(T_Util, ManagedExecExecuteBinaryAsChild) {
   EXPECT_EQ(my_pid, child_parent_pid);
 
   // tell the process to terminate
-  Pipe shell_pipe(fd_stdout, fd_stdin);
+  Pipe<kPipeTest> shell_pipe(fd_stdout, fd_stdin);
   const char *quit = "quit\n";
   retval = shell_pipe.Write(quit, strlen(quit));
   EXPECT_TRUE(retval);


### PR DESCRIPTION
Issue #3095 

- Moved `Pipe` class from `posix.h` to `pipe.h`
- Introduced templated version of `Pipe` class
- Refactored code that used old `Pipe` class
- `download.h/cc` replace pipes to use new `Pipe` class