### PR TITLE
Add github action workflow for codespelling cvmfs folder only

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [devel,master]
+  pull_request:
+    branches: [devel,master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1
+        with:
+          path: cvmfs


### PR DESCRIPTION
As instructed in the review of https://github.com/cvmfs/cvmfs/pull/3183 . Makes little sense to have until #3183 is updated/merged, but in general "is ready".