### PR TITLE
Improve watchdog startup procedure

### DIFF
--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -361,7 +361,7 @@ void cvmcache_spawn_watchdog(const char *crash_dump_file) {
     return;
   g_watchdog = Watchdog::Create((crash_dump_file != NULL)
                                 ? string(crash_dump_file)
-                                : "");
+                                : "", NULL);
   assert(g_watchdog != NULL);
   g_watchdog->Spawn();
 }

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -359,11 +359,9 @@ void cvmcache_get_session(cvmcache_session *session) {
 void cvmcache_spawn_watchdog(const char *crash_dump_file) {
   if (g_watchdog != NULL)
     return;
-  g_watchdog = Watchdog::Create((crash_dump_file != NULL)
-                                ? string(crash_dump_file)
-                                : "", NULL);
+  g_watchdog = Watchdog::Create(NULL);
   assert(g_watchdog != NULL);
-  g_watchdog->Spawn();
+  g_watchdog->Spawn((crash_dump_file != NULL) ? string(crash_dump_file) : "");
 }
 
 void cvmcache_terminate_watchdog() {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2251,7 +2251,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   // Monitor, check for maximum number of open files
   if (cvmfs::UseWatchdog()) {
     cvmfs::watchdog_ = Watchdog::Create("./stacktrace." +
-                                        loader_exports->repository_name);
+                                        loader_exports->repository_name,
+                                        auto_umount::UmountOnCrash);
     if (cvmfs::watchdog_ == NULL) {
       *g_boot_error = "failed to initialize watchdog.";
       return loader::kFailMonitor;
@@ -2313,7 +2314,6 @@ static void Spawn() {
   // well-defined state
   cvmfs::pid_ = getpid();
   if (cvmfs::watchdog_) {
-    cvmfs::watchdog_->RegisterOnCrash(auto_umount::UmountOnCrash);
     cvmfs::watchdog_->Spawn();
   }
 

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -445,7 +445,7 @@ void Watchdog::Fork() {
 bool Watchdog::WaitForSupervisee() {
   // We want broken pipes not to raise a signal but handle the error in the
   // read/write code
-  sighandler_t rv_sig = signal(SIGPIPE, SIG_IGN);
+  platform_sighandler_t rv_sig = signal(SIGPIPE, SIG_IGN);
   assert(rv_sig != SIG_ERR);
 
   // The watchdog is not supposed to receive signals. If it does, report it.

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -58,9 +58,9 @@ using namespace std;  // NOLINT
 Watchdog *Watchdog::instance_ = NULL;
 
 
-Watchdog *Watchdog::Create(const string &crash_dump_path) {
+Watchdog *Watchdog::Create(const string &crash_dump_path, FnOnCrash on_crash) {
   assert(instance_ == NULL);
-  instance_ = new Watchdog(crash_dump_path);
+  instance_ = new Watchdog(crash_dump_path, on_crash);
   return instance_;
 }
 
@@ -235,11 +235,6 @@ string Watchdog::ReadUntilGdbPrompt(int fd_pipe) {
   }
 
   return result;
-}
-
-
-void Watchdog::RegisterOnCrash(void (*CleanupOnCrash)(void)) {
-  on_crash_ = CleanupOnCrash;
 }
 
 
@@ -589,7 +584,7 @@ void Watchdog::Supervise() {
 }
 
 
-Watchdog::Watchdog(const string &crash_dump_path)
+Watchdog::Watchdog(const string &crash_dump_path, FnOnCrash on_crash)
   : spawned_(false)
   , crash_dump_path_(crash_dump_path)
   , exe_path_(string(platform_getexepath()))
@@ -597,7 +592,7 @@ Watchdog::Watchdog(const string &crash_dump_path)
   , pipe_watchdog_(NULL)
   , pipe_listener_(NULL)
   , pipe_terminate_(NULL)
-  , on_crash_(NULL)
+  , on_crash_(on_crash)
 {
   int retval = platform_spinlock_init(&lock_handler_, 0);
   assert(retval == 0);

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -445,7 +445,8 @@ void Watchdog::Fork() {
 bool Watchdog::WaitForSupervisee() {
   // We want broken pipes not to raise a signal but handle the error in the
   // read/write code
-  signal(SIGPIPE, SIG_IGN);
+  sighandler_t rv_sig = signal(SIGPIPE, SIG_IGN);
+  assert(rv_sig != SIG_ERR);
 
   // The watchdog is not supposed to receive signals. If it does, report it.
   struct sigaction sa;

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -635,36 +635,3 @@ Watchdog::~Watchdog() {
   LogCvmfs(kLogMonitor, kLogDebug, "monitor stopped");
   instance_ = NULL;
 }
-
-
-
-namespace monitor {
-
-const unsigned kMinOpenFiles = 8192;
-
-unsigned GetMaxOpenFiles() {
-  static unsigned max_open_files;
-  static bool     already_done = false;
-
-  /* check number of open files (lazy evaluation) */
-  if (!already_done) {
-    unsigned soft_limit = 0;
-    unsigned hard_limit = 0;
-    GetLimitNoFile(&soft_limit, &hard_limit);
-
-    if (soft_limit < kMinOpenFiles) {
-      LogCvmfs(kLogMonitor, kLogSyslogWarn | kLogDebug,
-               "Warning: current limits for number of open files are "
-               "(%lu/%lu)\n"
-               "CernVM-FS is likely to run out of file descriptors, "
-               "set ulimit -n to at least %lu",
-               soft_limit, hard_limit, kMinOpenFiles);
-    }
-    max_open_files = soft_limit;
-    already_done   = true;
-  }
-
-  return max_open_files;
-}
-
-}  // namespace monitor

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -58,9 +58,10 @@ using namespace std;  // NOLINT
 Watchdog *Watchdog::instance_ = NULL;
 
 
-Watchdog *Watchdog::Create(const string &crash_dump_path, FnOnCrash on_crash) {
+Watchdog *Watchdog::Create(FnOnCrash on_crash) {
   assert(instance_ == NULL);
-  instance_ = new Watchdog(crash_dump_path, on_crash);
+  instance_ = new Watchdog(on_crash);
+  instance_->Fork();
   return instance_;
 }
 
@@ -161,10 +162,7 @@ string Watchdog::GenerateStackTrace(pid_t pid) {
 
 pid_t Watchdog::GetPid() {
   if (instance_ != NULL) {
-    if (!instance_->spawned_)
-      return getpid();
-    else
-      return instance_->watchdog_pid_;
+    return instance_->watchdog_pid_;
   }
   return getpid();
 }
@@ -242,9 +240,6 @@ string Watchdog::ReadUntilGdbPrompt(int fd_pipe) {
  * Generates useful information from the backtrace log in the pipe.
  */
 string Watchdog::ReportStacktrace() {
-  // Re-activate µSyslog, if necessary
-  SetLogMicroSyslog(GetLogMicroSyslog());
-
   CrashData crash_data;
   if (!pipe_watchdog_->TryRead(&crash_data)) {
     return "failed to read crash data (" + StringifyInt(errno) + ")";
@@ -422,8 +417,12 @@ void Watchdog::Fork() {
           CloseAllFildes(preserve_fds);
           SetLogMicroSyslog(usyslog_save);  // no-op if usyslog not used
           SetLogDebugFile(debuglog_save);  // no-op if debug log not used
-          WaitForSupervisee();
-          Supervise();
+
+          if (WaitForSupervisee())
+            Supervise();
+
+          close(pipe_watchdog_->read_end);
+          close(pipe_listener_->write_end);
           exit(0);
         }
         default:
@@ -442,72 +441,72 @@ void Watchdog::Fork() {
   close(pipe_pid.read_end);
 }
 
-void Watchdog::WaitForSupervisee() {
 
+bool Watchdog::WaitForSupervisee() {
+  // We want broken pipes not to raise a signal but handle the error in the
+  // read/write code
+  signal(SIGPIPE, SIG_IGN);
+
+  // The watchdog is not supposed to receive signals. If it does, report it.
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_sigaction = ReportSignalAndTerminate;
+  sa.sa_flags = SA_SIGINFO;
+  sigfillset(&sa.sa_mask);
+
+  SigactionMap signal_handlers;
+  signal_handlers[SIGHUP]  = sa;
+  signal_handlers[SIGINT]  = sa;
+  signal_handlers[SIGQUIT] = sa;
+  signal_handlers[SIGILL]  = sa;
+  signal_handlers[SIGABRT] = sa;
+  signal_handlers[SIGBUS]  = sa;
+  signal_handlers[SIGFPE]  = sa;
+  signal_handlers[SIGUSR1] = sa;
+  signal_handlers[SIGSEGV] = sa;
+  signal_handlers[SIGUSR2] = sa;
+  signal_handlers[SIGTERM] = sa;
+  signal_handlers[SIGXCPU] = sa;
+  signal_handlers[SIGXFSZ] = sa;
+  SetSignalHandlers(signal_handlers);
+
+  ControlFlow::Flags control_flow = ControlFlow::kUnknown;
+
+  if (!pipe_watchdog_->TryRead(&control_flow)) {
+    LogCvmfs(kLogMonitor, kLogDebug, "supervisee canceled watchdog");
+    return false;
+  }
+
+  switch (control_flow) {
+    case ControlFlow::kQuit:
+      return false;
+    case ControlFlow::kSupervise:
+      break;
+    default:
+      LogEmergency("Internal error: invalid control flow");
+      return false;
+  }
+
+  size_t size;
+  pipe_watchdog_->Read(&size);
+  crash_dump_path_.resize(size);
+  if (size > 0)
+    ReadPipe(pipe_watchdog_->read_end, &crash_dump_path_[0], size);
+
+  int retval = chdir(GetParentPath(crash_dump_path_).c_str());
+  if (retval != 0) {
+    LogEmergency(std::string("Cannot change to crash dump directory: ") +
+                 crash_dump_path_);
+    return false;
+  }
+  crash_dump_path_ = GetFileName(crash_dump_path_);
+  return true;
 }
 
 /**
- * Fork the watchdog process.
+ * Set up the signal handling and kick off the supervision.
  */
-void Watchdog::Spawn() {
-  Pipe pipe_pid;
-  pipe_watchdog_ = new Pipe();
-  pipe_listener_ = new Pipe();
-
-  pid_t pid;
-  int statloc;
-  switch (pid = fork()) {
-    case -1: PANIC(NULL);
-    case 0:
-      // Double fork to avoid zombie
-      switch (fork()) {
-        case -1: exit(1);
-        case 0: {
-          close(pipe_watchdog_->write_end);
-          Daemonize();
-          // send the watchdog PID to cvmfs
-          pid_t watchdog_pid = getpid();
-          pipe_pid.Write(watchdog_pid);
-          close(pipe_pid.write_end);
-          // Close all unused file descriptors
-          // close also usyslog, only get it back if necessary
-          // string usyslog_save = GetLogMicroSyslog();
-          string debuglog_save = GetLogDebugFile();
-          // SetLogMicroSyslog("");
-          SetLogDebugFile("");
-          // Gracefully close the syslog before closing all fds. The next call
-          // to syslog will reopen it.
-          closelog();
-          // Let's keep stdin, stdout, stderr open at /dev/null (daemonized)
-          // in order to prevent accidental outputs from messing with another
-          // file descriptor
-          std::set<int> preserve_fds;
-          preserve_fds.insert(0);
-          preserve_fds.insert(1);
-          preserve_fds.insert(2);
-          preserve_fds.insert(pipe_watchdog_->read_end);
-          preserve_fds.insert(pipe_listener_->write_end);
-          CloseAllFildes(preserve_fds);
-          // SetLogMicroSyslog(usyslog_save);  // no-op if usyslog not used
-          SetLogDebugFile(debuglog_save);  // no-op if debug log not used
-          Supervise();
-          exit(0);
-        }
-        default:
-          _exit(0);
-      }
-    default:
-      close(pipe_watchdog_->read_end);
-      close(pipe_listener_->write_end);
-      if (waitpid(pid, &statloc, 0) != pid) PANIC(NULL);
-      if (!WIFEXITED(statloc) || WEXITSTATUS(statloc)) PANIC(NULL);
-  }
-
-  // retrieve the watchdog PID from the pipe
-  close(pipe_pid.write_end);
-  pipe_pid.Read(&watchdog_pid_);
-  close(pipe_pid.read_end);
-
+void Watchdog::Spawn(const std::string &crash_dump_path) {
   // lower restrictions for ptrace
   if (!platform_allow_ptrace(watchdog_pid_)) {
     LogCvmfs(kLogMonitor, kLogSyslogWarn,
@@ -546,6 +545,12 @@ void Watchdog::Spawn() {
   int retval =
     pthread_create(&thread_listener_, NULL, MainWatchdogListener, this);
   assert(retval == 0);
+
+  pipe_watchdog_->Write(ControlFlow::kSupervise);
+  size_t path_size = crash_dump_path.size();
+  pipe_watchdog_->Write(path_size);
+  if (path_size > 0)
+    WritePipe(pipe_watchdog_->write_end, crash_dump_path.data(), path_size);
 
   spawned_ = true;
 }
@@ -587,7 +592,6 @@ void *Watchdog::MainWatchdogListener(void *data) {
       PANIC(NULL);
     }
   }
-  close(watchdog->pipe_listener_->read_end);
 
   LogCvmfs(kLogMonitor, kLogDebug, "stopping watchdog listener");
   return NULL;
@@ -595,38 +599,9 @@ void *Watchdog::MainWatchdogListener(void *data) {
 
 
 void Watchdog::Supervise() {
-  // We want that the reading from the pipe fd fails if the pipe breaks,
-  // instead of receiving a signal
-  signal(SIGPIPE, SIG_IGN);
-
-  // The watchdog is not supposed to receive signals. If it does, report it.
-  struct sigaction sa;
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_sigaction = ReportSignalAndTerminate;
-  sa.sa_flags = SA_SIGINFO;
-  sigfillset(&sa.sa_mask);
-
-  SigactionMap signal_handlers;
-  signal_handlers[SIGHUP]  = sa;
-  signal_handlers[SIGINT]  = sa;
-  signal_handlers[SIGQUIT] = sa;
-  signal_handlers[SIGILL]  = sa;
-  signal_handlers[SIGABRT] = sa;
-  signal_handlers[SIGBUS]  = sa;
-  signal_handlers[SIGFPE]  = sa;
-  signal_handlers[SIGUSR1] = sa;
-  signal_handlers[SIGSEGV] = sa;
-  signal_handlers[SIGUSR2] = sa;
-  signal_handlers[SIGTERM] = sa;
-  signal_handlers[SIGXCPU] = sa;
-  signal_handlers[SIGXFSZ] = sa;
-  SetSignalHandlers(signal_handlers);
-
   ControlFlow::Flags control_flow = ControlFlow::kUnknown;
 
   if (!pipe_watchdog_->TryRead(&control_flow)) {
-    // Re-activate µSyslog, if necessary
-    SetLogMicroSyslog(GetLogMicroSyslog());
     LogEmergency("watchdog: unexpected termination (" +
                  StringifyInt(control_flow) + ")");
     if (on_crash_) on_crash_();
@@ -641,21 +616,15 @@ void Watchdog::Supervise() {
         break;
 
       default:
-        // Re-activate µSyslog, if necessary
-        SetLogMicroSyslog(GetLogMicroSyslog());
         LogEmergency("watchdog: unexpected error");
         break;
     }
   }
-
-  close(pipe_watchdog_->read_end);
-  close(pipe_listener_->write_end);
 }
 
 
-Watchdog::Watchdog(const string &crash_dump_path, FnOnCrash on_crash)
+Watchdog::Watchdog(FnOnCrash on_crash)
   : spawned_(false)
-  , crash_dump_path_(crash_dump_path)
   , exe_path_(string(platform_getexepath()))
   , watchdog_pid_(0)
   , on_crash_(on_crash)
@@ -683,10 +652,11 @@ Watchdog::~Watchdog() {
     pipe_terminate_->Write(ControlFlow::kQuit);
     pthread_join(thread_listener_, NULL);
     pipe_terminate_->Close();
-
-    pipe_watchdog_->Write(ControlFlow::kQuit);
-    close(pipe_watchdog_->write_end);
   }
+
+  pipe_watchdog_->Write(ControlFlow::kQuit);
+  close(pipe_watchdog_->write_end);
+  close(pipe_listener_->read_end);
 
   platform_spinlock_destroy(&lock_handler_);
   LogCvmfs(kLogMonitor, kLogDebug, "monitor stopped");

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -658,9 +658,6 @@ Watchdog::Watchdog(const string &crash_dump_path, FnOnCrash on_crash)
   , crash_dump_path_(crash_dump_path)
   , exe_path_(string(platform_getexepath()))
   , watchdog_pid_(0)
-  , pipe_watchdog_(NULL)
-  , pipe_listener_(NULL)
-  , pipe_terminate_(NULL)
   , on_crash_(on_crash)
 {
   int retval = platform_spinlock_init(&lock_handler_, 0);
@@ -690,10 +687,6 @@ Watchdog::~Watchdog() {
     pipe_watchdog_->Write(ControlFlow::kQuit);
     close(pipe_watchdog_->write_end);
   }
-
-  delete pipe_watchdog_;
-  delete pipe_listener_;
-  delete pipe_terminate_;
 
   platform_spinlock_destroy(&lock_handler_);
   LogCvmfs(kLogMonitor, kLogDebug, "monitor stopped");

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -491,16 +491,17 @@ bool Watchdog::WaitForSupervisee() {
   size_t size;
   pipe_watchdog_->Read(&size);
   crash_dump_path_.resize(size);
-  if (size > 0)
+  if (size > 0) {
     ReadPipe(pipe_watchdog_->read_end, &crash_dump_path_[0], size);
 
-  int retval = chdir(GetParentPath(crash_dump_path_).c_str());
-  if (retval != 0) {
-    LogEmergency(std::string("Cannot change to crash dump directory: ") +
-                 crash_dump_path_);
-    return false;
+    int retval = chdir(GetParentPath(crash_dump_path_).c_str());
+    if (retval != 0) {
+      LogEmergency(std::string("Cannot change to crash dump directory: ") +
+                   crash_dump_path_);
+      return false;
+    }
+    crash_dump_path_ = GetFileName(crash_dump_path_);
   }
-  crash_dump_path_ = GetFileName(crash_dump_path_);
   return true;
 }
 

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "util/platform.h"
+#include "util/single_copy.h"
 
 struct Pipe;
 
@@ -29,7 +30,7 @@ struct Pipe;
  *
  * Note: logging should be set up before calling Create()
  */
-class Watchdog {
+class Watchdog : SingleCopy {
  public:
   /**
    * Crash cleanup handler signature.

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -29,11 +29,16 @@ struct Pipe;
  */
 class Watchdog {
  public:
-  static Watchdog *Create(const std::string &crash_dump_path);
+  /**
+   * Crash cleanup handler signature.
+   */
+  typedef void (*FnOnCrash)(void);
+
+  static Watchdog *Create(const std::string &crash_dump_path,
+                          FnOnCrash on_crash);
   static pid_t GetPid();
   ~Watchdog();
   void Spawn();
-  void RegisterOnCrash(void (*CleanupOnCrash)(void));
 
  private:
   typedef std::map<int, struct sigaction> SigactionMap;
@@ -72,7 +77,7 @@ class Watchdog {
                                        void *context);
   static void SendTrace(int sig, siginfo_t *siginfo, void *context);
 
-  explicit Watchdog(const std::string &crash_dump_path);
+  explicit Watchdog(const std::string &crash_dump_path, FnOnCrash on_crash);
   SigactionMap SetSignalHandlers(const SigactionMap &signal_handlers);
   void Supervise();
   void LogEmergency(std::string msg);
@@ -90,7 +95,7 @@ class Watchdog {
   /// Send the terminate signal to the listener
   Pipe *pipe_terminate_;
   pthread_t thread_listener_;
-  void (*on_crash_)(void);
+  FnOnCrash on_crash_;
   platform_spinlock lock_handler_;
   stack_t sighandler_stack_;
   SigactionMap old_signal_handlers_;

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "util/platform.h"
+#include "util/pointer.h"
 #include "util/single_copy.h"
 
 struct Pipe;
@@ -95,11 +96,11 @@ class Watchdog : SingleCopy {
   std::string exe_path_;
   pid_t watchdog_pid_;
   /// Communication channel from the supervisee to the watchdog
-  Pipe *pipe_watchdog_;
+  UniquePtr<Pipe> pipe_watchdog_;
   /// The supervisee makes sure its watchdog does not die
-  Pipe *pipe_listener_;
+  UniquePtr<Pipe> pipe_listener_;
   /// Send the terminate signal to the listener
-  Pipe *pipe_terminate_;
+  UniquePtr<Pipe> pipe_terminate_;
   pthread_t thread_listener_;
   FnOnCrash on_crash_;
   platform_spinlock lock_handler_;

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -91,9 +91,4 @@ class Watchdog {
   SigactionMap old_signal_handlers_;
 };
 
-namespace monitor {
-// TODO(jblomer): move me
-unsigned GetMaxOpenFiles();
-}  // namespace monitor
-
 #endif  // CVMFS_MONITOR_H_

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -26,6 +26,8 @@ struct Pipe;
  * the supervisee pid and the crash dump path to the watchdog and trigger
  * supervision.  Note that we cannot use the parent pid from Create() because
  * the supervisee may fork() / daemonize between Create() and Spawn().
+ *
+ * Note: logging should be set up before calling Create()
  */
 class Watchdog {
  public:
@@ -78,6 +80,8 @@ class Watchdog {
   static void SendTrace(int sig, siginfo_t *siginfo, void *context);
 
   explicit Watchdog(const std::string &crash_dump_path, FnOnCrash on_crash);
+  void Fork();
+  void WaitForSupervisee();
   SigactionMap SetSignalHandlers(const SigactionMap &signal_handlers);
   void Supervise();
   void LogEmergency(std::string msg);
@@ -89,6 +93,7 @@ class Watchdog {
   std::string crash_dump_path_;
   std::string exe_path_;
   pid_t watchdog_pid_;
+  /// Communication channel from the supervisee to the watchdog
   Pipe *pipe_watchdog_;
   /// The supervisee makes sure its watchdog does not die
   Pipe *pipe_listener_;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -858,21 +858,30 @@ void FileSystem::SetupGlobalEnvironmentParams() {
 }
 
 
-void FileSystem::SetupLogging() {
+void FileSystem::SetupLoggingStandalone(
+  const OptionsManager &options_mgr, const std::string &prefix)
+{
+  SetupGlobalEnvironmentParams();
+
   string optarg;
-  if (options_mgr_->GetValue("CVMFS_SYSLOG_LEVEL", &optarg))
+  if (options_mgr.GetValue("CVMFS_SYSLOG_LEVEL", &optarg))
     SetLogSyslogLevel(String2Uint64(optarg));
-  if (options_mgr_->GetValue("CVMFS_SYSLOG_FACILITY", &optarg))
+  if (options_mgr.GetValue("CVMFS_SYSLOG_FACILITY", &optarg))
     SetLogSyslogFacility(String2Int64(optarg));
-  if (options_mgr_->GetValue("CVMFS_USYSLOG", &optarg))
+  if (options_mgr.GetValue("CVMFS_USYSLOG", &optarg))
     SetLogMicroSyslog(optarg);
-  if (options_mgr_->GetValue("CVMFS_DEBUGLOG", &optarg))
+  if (options_mgr.GetValue("CVMFS_DEBUGLOG", &optarg))
     SetLogDebugFile(optarg);
-  if (options_mgr_->GetValue("CVMFS_SYSLOG_PREFIX", &optarg)) {
+  if (options_mgr.GetValue("CVMFS_SYSLOG_PREFIX", &optarg)) {
     SetLogSyslogPrefix(optarg);
   } else {
-    SetLogSyslogPrefix(name_);
+    SetLogSyslogPrefix(prefix);
   }
+}
+
+
+void FileSystem::SetupLogging() {
+  SetupLoggingStandalone(*options_mgr_, name_);
 }
 
 
@@ -1207,19 +1216,19 @@ bool MountPoint::ReloadBlacklists() {
 }
 
 /**
- * Disables kernel caching of symlinks. 
+ * Disables kernel caching of symlinks.
  * Symlink caching requires fuse >= 3.10 (FUSE_CAP_CACHE_SYMLINKS) and
  * linux kernel >= 4.2. Some OS might backport it.
- * 
+ *
  * NOTE: This function should only be called before or within cvmfs_init().
- * 
+ *
  */
 void MountPoint::DisableCacheSymlinks() {
   cache_symlinks_ = false;
 }
 
 /**
- * Instead of invalidate dentries, they should be expired. 
+ * Instead of invalidate dentries, they should be expired.
  * Fixes issues with mount-on-top mounts and symlink caching.
  */
 void MountPoint::EnableFuseExpireEntry() {

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -188,6 +188,10 @@ class FileSystem : SingleCopy, public BootFactory {
   static FileSystem *Create(const FileSystemInfo &fs_info);
   ~FileSystem();
 
+  // Used to setup logging before the file system object is created
+  static void SetupLoggingStandalone(
+    const OptionsManager &options_mgr, const std::string &prefix);
+
   bool IsNfsSource() { return nfs_mode_ & kNfsMaps; }
   bool IsHaNfsSource() { return nfs_mode_ & kNfsMapsHa; }
   void ResetErrorCounters();
@@ -283,7 +287,7 @@ class FileSystem : SingleCopy, public BootFactory {
 
   explicit FileSystem(const FileSystemInfo &fs_info);
 
-  void SetupGlobalEnvironmentParams();
+  static void SetupGlobalEnvironmentParams();
   void SetupLogging();
   void CreateStatistics();
   void SetupSqlite();

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -979,9 +979,9 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
   if (!foreground)
     Daemonize();
 
-  UniquePtr<Watchdog> watchdog(Watchdog::Create("./stacktrace.cachemgr", NULL));
+  UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL));
   assert(watchdog.IsValid());
-  watchdog->Spawn();
+  watchdog->Spawn("./stacktrace.cachemgr");
 
   // Initialize pipe, open non-blocking as cvmfs is not yet connected
   const int fd_lockfile_fifo =

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -979,7 +979,7 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
   if (!foreground)
     Daemonize();
 
-  UniquePtr<Watchdog> watchdog(Watchdog::Create("./stacktrace.cachemgr"));
+  UniquePtr<Watchdog> watchdog(Watchdog::Create("./stacktrace.cachemgr", NULL));
   assert(watchdog.IsValid());
   watchdog->Spawn();
 

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -112,7 +112,8 @@ int main(int argc, char** argv) {
       return 1;
     }
     std::string timestamp = GetGMTimestamp("%Y.%m.%d-%H.%M.%S");
-    watchdog = Watchdog::Create(watchdog_out_dir + "/stacktrace." + timestamp);
+    watchdog = Watchdog::Create(
+      watchdog_out_dir + "/stacktrace." + timestamp, NULL);
     if (watchdog.IsValid() == false) {
       LogCvmfs(kLogReceiver, kLogSyslogErr | kLogStderr,
                "Failed to initialize watchdog");

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -112,14 +112,13 @@ int main(int argc, char** argv) {
       return 1;
     }
     std::string timestamp = GetGMTimestamp("%Y.%m.%d-%H.%M.%S");
-    watchdog = Watchdog::Create(
-      watchdog_out_dir + "/stacktrace." + timestamp, NULL);
+    watchdog = Watchdog::Create(NULL);
     if (watchdog.IsValid() == false) {
       LogCvmfs(kLogReceiver, kLogSyslogErr | kLogStderr,
                "Failed to initialize watchdog");
       return 1;
     }
-    watchdog->Spawn();
+    watchdog->Spawn(watchdog_out_dir + "/stacktrace." + timestamp);
   }
 
   LogCvmfs(kLogReceiver, kLogSyslog, "CVMFS receiver started");

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -578,9 +578,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
                            watchdog_dir.c_str(), timestamp.c_str(), getpid());
   assert(path_size > 0);
   assert(path_size < PATH_MAX);
-  UniquePtr<Watchdog>
-    watchdog(Watchdog::Create(std::string(watchdog_path), NULL));
-  watchdog->Spawn();
+  UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL));
+  watchdog->Spawn(std::string(watchdog_path));
 
   SyncParameters params;
 

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -578,7 +578,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
                            watchdog_dir.c_str(), timestamp.c_str(), getpid());
   assert(path_size > 0);
   assert(path_size < PATH_MAX);
-  UniquePtr<Watchdog> watchdog(Watchdog::Create(std::string(watchdog_path)));
+  UniquePtr<Watchdog>
+    watchdog(Watchdog::Create(std::string(watchdog_path), NULL));
   watchdog->Spawn();
 
   SyncParameters params;

--- a/test/test_functions
+++ b/test/test_functions
@@ -320,7 +320,7 @@ autofs_check() {
   if running_on_osx; then
     return 0
   else
-    cat /proc/mounts | grep -q "^/etc/auto.cvmfs /cvmfs "
+    cat /proc/mounts | grep -q "^/etc/\(autofs/\)\?auto.cvmfs /cvmfs "
   fi
 }
 

--- a/test/unittests/main.cc
+++ b/test/unittests/main.cc
@@ -11,10 +11,9 @@
 #include "monitor.h"
 
 int main(int argc, char **argv) {
-  Watchdog *watchdog =
-    Watchdog::Create("/tmp/stacktrace.cvmfs_unittests", NULL);
+  Watchdog *watchdog = Watchdog::Create(NULL);
   assert(watchdog != NULL);
-  //  watchdog->Spawn();
+  //  watchdog->Spawn("/tmp/stacktrace.cvmfs_unittests");
   CvmfsEnvironment* env = new CvmfsEnvironment(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";

--- a/test/unittests/main.cc
+++ b/test/unittests/main.cc
@@ -11,7 +11,8 @@
 #include "monitor.h"
 
 int main(int argc, char **argv) {
-  Watchdog *watchdog = Watchdog::Create("/tmp/stacktrace.cvmfs_unittests");
+  Watchdog *watchdog =
+    Watchdog::Create("/tmp/stacktrace.cvmfs_unittests", NULL);
   assert(watchdog != NULL);
   //  watchdog->Spawn();
   CvmfsEnvironment* env = new CvmfsEnvironment(argc, argv);


### PR DESCRIPTION
Fork the watchdog before creation of the file system and the mount point objects. Besides less resource consumption, this change significantly reduces the state/complexity of the watchdog process and may solve the "sudden disappearance" issues.

Fixes: #3089
Maybe fixes: #2895
Replaces: #3092