### PR TITLE
Fix locale setting in cvmfs_server

### DIFF
--- a/cvmfs/server/cvmfs_server_prelude.sh
+++ b/cvmfs/server/cvmfs_server_prelude.sh
@@ -10,4 +10,4 @@ die() {
 }
 
 # set default locale
-export LANG=C
+export LC_ALL=C


### PR DESCRIPTION
An incident happened at NIKHEF where someone had LC_ALL=en_GB and it changed the date order in a date created by cvmfs_server (specifically, last_geodb_update in repositories.json).  That's because LC_ALL takes precedence over LANG.  This changes the setting in cvmfs_server to use LC_ALL instead of LANG.