### PR TITLE
[ducc] make requests to registries more robust

### DIFF
--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -62,7 +62,7 @@ var convertSingleImageCmd = &cobra.Command{
 			os.Exit(RepoNotExistsError)
 		}
 
-    input, err := lib.ParseImage(inputImage)
+		input, err := lib.ParseImage(inputImage)
 		wish, err := lib.CreateWish(input, thinImageName, cvmfsRepo, username, username)
 		if err != nil {
 			l.LogE(err).Error("Error in creating the wish to convert")

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -62,7 +62,8 @@ var convertSingleImageCmd = &cobra.Command{
 			os.Exit(RepoNotExistsError)
 		}
 
-		wish, err := lib.CreateWish(inputImage, thinImageName, cvmfsRepo, username, username)
+    input, err := lib.ParseImage(inputImage)
+		wish, err := lib.CreateWish(input, thinImageName, cvmfsRepo, username, username)
 		if err != nil {
 			l.LogE(err).Error("Error in creating the wish to convert")
 			os.Exit(1)

--- a/ducc/lib/recipe.go
+++ b/ducc/lib/recipe.go
@@ -1,10 +1,10 @@
 package lib
 
 import (
+	"math/rand"
 	"strings"
 	"sync"
-  "time"
-  "math/rand"
+	"time"
 
 	l "github.com/cvmfs/ducc/log"
 	log "github.com/sirupsen/logrus"
@@ -42,35 +42,35 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 		return recipe, err
 	}
 
-  registryMap := make(map[string][]Image)
+	registryMap := make(map[string][]Image)
 	for _, inputImage := range recipeYamlV1.Input {
-			input, err := ParseImage(inputImage)
-			if err != nil {
-				l.LogE(err).WithFields(log.Fields{"image": inputImage}).Warning("Impossible to parse the image")
-			}
-      registryMap[input.Registry] = append(registryMap[input.Registry], input)
-  }
-  for reg, inputImages := range registryMap {
+		input, err := ParseImage(inputImage)
+		if err != nil {
+			l.LogE(err).WithFields(log.Fields{"image": inputImage}).Warning("Impossible to parse the image")
+		}
+		registryMap[input.Registry] = append(registryMap[input.Registry], input)
+	}
+	for reg, inputImages := range registryMap {
 		wg.Add(1)
 		go func(inputImages []Image, reg string) {
-		  l.Log().Info("Starting with", inputImages[0])
+			l.Log().Info("Starting with", inputImages[0])
 			defer wg.Done()
-      for _, input := range inputImages {
-        if reg == "gitlab-registry.cern.ch" {
-            time.Sleep(500 * time.Millisecond + time.Duration(rand.Intn(500)) * time.Millisecond)
-        }
+			for _, input := range inputImages {
+				if reg == "gitlab-registry.cern.ch" {
+					time.Sleep(500*time.Millisecond + time.Duration(rand.Intn(500))*time.Millisecond)
+				}
 
-        l.Log().Info(reg)
-        l.Log().Info(input)
+				l.Log().Info(reg)
+				l.Log().Info(input)
 
-        output := formatOutputImage(recipeYamlV1.OutputFormat, input)
-        wish, err := CreateWish(input, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
-        if err != nil {
-          l.LogE(err).Warning("Error in creating the wish")
-        } else {
-          recipe.Wishes <- wish
-        }
-    }
+				output := formatOutputImage(recipeYamlV1.OutputFormat, input)
+				wish, err := CreateWish(input, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
+				if err != nil {
+					l.LogE(err).Warning("Error in creating the wish")
+				} else {
+					recipe.Wishes <- wish
+				}
+			}
 		}(inputImages, reg)
 	}
 	return recipe, nil
@@ -78,7 +78,7 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 
 func formatOutputImage(OutputFormat string, inputImage Image) string {
 
-	if (OutputFormat == "") {
+	if OutputFormat == "" {
 		OutputFormat = "$(scheme)://$(registry)/$(repository)_thin:$(tag)"
 		l.Log().Info("Using default output image name ", OutputFormat)
 	}

--- a/ducc/lib/recipe.go
+++ b/ducc/lib/recipe.go
@@ -3,6 +3,8 @@ package lib
 import (
 	"strings"
 	"sync"
+  "time"
+  "math/rand"
 
 	l "github.com/cvmfs/ducc/log"
 	log "github.com/sirupsen/logrus"
@@ -39,23 +41,37 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 	if err != nil {
 		return recipe, err
 	}
+
+  registryMap := make(map[string][]Image)
 	for _, inputImage := range recipeYamlV1.Input {
-		wg.Add(1)
-		go func(inputImage string) {
-			defer wg.Done()
 			input, err := ParseImage(inputImage)
 			if err != nil {
 				l.LogE(err).WithFields(log.Fields{"image": inputImage}).Warning("Impossible to parse the image")
-				return
 			}
-			output := formatOutputImage(recipeYamlV1.OutputFormat, input)
-			wish, err := CreateWish(inputImage, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
-			if err != nil {
-				l.LogE(err).Warning("Error in creating the wish")
-			} else {
-				recipe.Wishes <- wish
-			}
-		}(inputImage)
+      registryMap[input.Registry] = append(registryMap[input.Registry], input)
+  }
+  for reg, inputImages := range registryMap {
+		wg.Add(1)
+		go func(inputImages []Image, reg string) {
+		  l.Log().Info("Starting with", inputImages[0])
+			defer wg.Done()
+      for _, input := range inputImages {
+        if reg == "gitlab-registry.cern.ch" {
+            time.Sleep(500 * time.Millisecond + time.Duration(rand.Intn(500)) * time.Millisecond)
+        }
+
+        l.Log().Info(reg)
+        l.Log().Info(input)
+
+        output := formatOutputImage(recipeYamlV1.OutputFormat, input)
+        wish, err := CreateWish(input, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
+        if err != nil {
+          l.LogE(err).Warning("Error in creating the wish")
+        } else {
+          recipe.Wishes <- wish
+        }
+    }
+		}(inputImages, reg)
 	}
 	return recipe, nil
 }

--- a/ducc/lib/wish.go
+++ b/ducc/lib/wish.go
@@ -29,13 +29,8 @@ type WishFriendly struct {
 	ExpandedTagImagesFlat  []*Image
 }
 
-func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string) (wish WishFriendly, err error) {
+func CreateWish(inputImg Image, outputImage, cvmfsRepo, userInput, userOutput string) (wish WishFriendly, err error) {
 
-	inputImg, err := ParseImage(inputImage)
-	if err != nil {
-		err = fmt.Errorf("%s | %s", err.Error(), "Error in parsing the input image")
-		return
-	}
 	inputImg.User = userInput
 
 	wish.InputName = inputImg.WholeName()
@@ -66,7 +61,7 @@ func CreateWish(inputImage, outputImage, cvmfsRepo, userInput, userOutput string
 	if errEx != nil {
 		err = errEx
 		l.LogE(err).WithFields(log.Fields{
-			"input image": inputImage}).
+			"input image": inputImg.WholeName()}).
 			Error("Error in retrieving all the tags from the image")
 		return
 	}


### PR DESCRIPTION
Launches one thread per registry instead of one per request as before, avoiding load spikes and rate limits. This also has the advantage of allowing some registry-specific treatments. In order to do that, the loop over `recipeYamlV1.Input ` is split up, in a first step the input lines are parsed and filled into a map, so all images in one repository can be easily adressed. The second step is as before, but moves the loop over the input image into the goroutine, and launches one goroutine per registry instead.

- [ ] the input list could be shuffled to get a bit more resilience in situations where the registry stops responding halfway through the wishlist