### PR TITLE
support lazy unmounts

### DIFF
--- a/cvmfs/loader_talk.cc
+++ b/cvmfs/loader_talk.cc
@@ -96,7 +96,20 @@ void Spawn() {
 
 
 void Fini() {
-  unlink(socket_path_->c_str());
+  bool changed = false;
+  struct stat current_stat;
+  struct stat new_stat;
+  int ret1, ret2;
+  ret1 = fstat(socket_fd_, &current_stat);
+  ret2 = stat(socket_path_->c_str(), &new_stat);
+  if (!ret1 && !ret2
+     && (current_stat.st_dev != new_stat.st_dev
+     || current_stat.st_ino != new_stat.st_ino)) {
+     changed = true;
+  }
+  if (!changed) {
+    unlink(socket_path_->c_str());
+  }
   shutdown(socket_fd_, SHUT_RDWR);
   close(socket_fd_);
   if (spawned_) pthread_join(thread_talk_, NULL);

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -296,7 +296,7 @@ class LogBufferXattr : public BaseMagicXattr {
   LogBufferXattr();
 
  private:
-  const unsigned int kMaxLogLine = 4096;  // longer log lines are trimmed
+  static const unsigned int kMaxLogLine = 4096;  // longer log lines are trimmed
   // Generating the log buffer report involves 64 string copies. To mitigate
   // memory fragmentation and performance loss, throttle the use of this
   // attribute a little.

--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -40,12 +40,12 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 #define platform_sighandler_t sighandler_t
 
-inline std::vector<std::string> platform_mountlist() {
+inline std::vector<std::string> platform_mountlist(bool cvmfs_only = false) {
   std::vector<std::string> result;
   FILE *fmnt = setmntent("/proc/mounts", "r");
   struct mntent *mntbuf;  // Static buffer managed by libc!
   while ((mntbuf = getmntent(fmnt)) != NULL) {
-    if (!strcmp(mntbuf->mnt_type, "fuse")) {
+    if ( !cvmfs_only || !strcmp(mntbuf->mnt_type, "fuse") ) {
        result.push_back(mntbuf->mnt_dir);
     }
   }

--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -40,7 +40,8 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 #define platform_sighandler_t sighandler_t
 
-inline std::vector<std::string> platform_mountlist(bool cvmfs_only = false) {
+inline std::vector<std::string> platform_mountlist
+                                (const bool cvmfs_only = false) {
   std::vector<std::string> result;
   FILE *fmnt = setmntent("/proc/mounts", "r");
   struct mntent *mntbuf;  // Static buffer managed by libc!

--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -45,7 +45,9 @@ inline std::vector<std::string> platform_mountlist() {
   FILE *fmnt = setmntent("/proc/mounts", "r");
   struct mntent *mntbuf;  // Static buffer managed by libc!
   while ((mntbuf = getmntent(fmnt)) != NULL) {
-    result.push_back(mntbuf->mnt_dir);
+    if (!strcmp(mntbuf->mnt_type, "fuse")) {
+       result.push_back(mntbuf->mnt_dir);
+    }
   }
   endmntent(fmnt);
   return result;

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -60,7 +60,8 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 #define platform_sighandler_t sig_t
 
-inline std::vector<std::string> platform_mountlist(const bool cvmfs_only) {
+inline std::vector<std::string> platform_mountlist
+                                (const bool cvmfs_only = false) {
   std::vector<std::string> result;
   struct statfs *mntbufp;
   int num_elems = getmntinfo(&mntbufp, MNT_NOWAIT);  // modifies static memory

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -60,7 +60,7 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 #define platform_sighandler_t sig_t
 
-inline std::vector<std::string> platform_mountlist() {
+inline std::vector<std::string> platform_mountlist(const bool cvmfs_only) {
   std::vector<std::string> result;
   struct statfs *mntbufp;
   int num_elems = getmntinfo(&mntbufp, MNT_NOWAIT);  // modifies static memory

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -65,7 +65,9 @@ inline std::vector<std::string> platform_mountlist(const bool cvmfs_only) {
   struct statfs *mntbufp;
   int num_elems = getmntinfo(&mntbufp, MNT_NOWAIT);  // modifies static memory
   for (int i = 0; i < num_elems; ++i) {
-    result.push_back(mntbufp[i].f_mntonname);
+    if (!cvmfs_only || !strcmp(mntbufp[i].f_fstypename, "osxfuse")) {
+      result.push_back(mntbufp[i].f_mntonname);
+    }
   }
   return result;
 }

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -260,8 +260,8 @@ std::string ResolvePath(const std::string &path) {
 }
 
 
-bool IsMountPoint(const std::string &path) {
-  std::vector<std::string> mount_list = platform_mountlist();
+bool IsMountPoint(const std::string &path, const bool cvmfs_only) {
+  std::vector<std::string> mount_list = platform_mountlist(cvmfs_only);
   std::string resolved_path = ResolvePath(path);
   for (unsigned i = 0; i < mount_list.size(); ++i) {
     if (mount_list[i] == resolved_path)
@@ -269,7 +269,6 @@ bool IsMountPoint(const std::string &path) {
   }
   return false;
 }
-
 
 /**
  * By default PANIC(NULL) on failure

--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -75,7 +75,8 @@ CVMFS_EXPORT bool IsHttpUrl(const std::string &path);
 
 CVMFS_EXPORT std::string ReadSymlink(const std::string &path);
 CVMFS_EXPORT std::string ResolvePath(const std::string &path);
-CVMFS_EXPORT bool IsMountPoint(const std::string &path);
+CVMFS_EXPORT bool IsMountPoint(const std::string &path,
+                               const bool cvmfs_only = false);
 CVMFS_EXPORT FileSystemInfo GetFileSystemInfo(const std::string &path);
 
 CVMFS_EXPORT void CreateFile(const std::string &path, const int mode,

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -494,6 +494,7 @@ int main(int argc, char **argv) {
         LogCvmfs(kLogCvmfs, kLogStderr, "Already mounted");
         return 1;
     }
+  }
   if (remount) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Repository %s is not mounted on %s",
            fqrn.c_str(), mountpoint.c_str());

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -122,6 +122,13 @@ static bool CheckStrictMount(const string &fqrn) {
   return true;
 }
 
+static bool CheckAllowReattach() {
+  string param;
+  if (options_manager_.GetValue("CVMFS_ALLOW_REATTACH_MOUNT", &param)) {
+      return options_manager_.IsOn(param);
+  }
+  return true;
+}
 
 static bool CheckProxy() {
   string param;
@@ -453,13 +460,24 @@ int main(int argc, char **argv) {
   string prev_mountpoint;
   retval = CheckConcurrentMount(fqrn, workspace, &prev_mountpoint);
   if (retval) {
-    if (remount && (mountpoint == prev_mountpoint)) {
-      // Actually remounting is too hard, but pretend that it worked
-      return 0;
+    if (remount) {
+      if (mountpoint == prev_mountpoint) {
+        // Actually remounting is too hard, but pretend that it worked
+        return 0;
+      } else {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Repository %s is not mounted on %s",
+               fqrn.c_str(), mountpoint.c_str());
+        return 1;
+      }
+    }
+    if (mountpoint != prev_mountpoint && IsMountPoint(prev_mountpoint)) {
+       LogCvmfs(kLogCvmfs, kLogStderr,
+          "Already mounted at %s", prev_mountpoint.c_str());
+       return 1;
     }
     // Identify zombie fuse processes that are held open by other mount
     // namespaces
-    if ((mountpoint == prev_mountpoint) && !IsMountPoint(mountpoint)) {
+    if (!IsMountPoint(mountpoint)) {
       // Allow for group access to the socket receiving the fuse fd
       umask(007);
       int fuse_fd = GetExistingFuseFd(fqrn, workspace, uid_cvmfs);
@@ -468,17 +486,13 @@ int main(int argc, char **argv) {
                  "Cannot connect to existing fuse module");
         return 1;
       }
-      return AttachMount(mountpoint, fqrn, fuse_fd);
-    }
-    LogCvmfs(kLogCvmfs, kLogStderr, "Repository %s is already mounted on %s",
-             fqrn.c_str(), prev_mountpoint.c_str());
-    return 1;
-  } else {
-    // No double mount
-    if (remount) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Repository %s is not mounted on %s",
-               fqrn.c_str(), mountpoint.c_str());
-      return 1;
+      if (CheckAllowReattach()) {
+        return AttachMount(mountpoint, fqrn, fuse_fd);
+      }
+      // otherwise fall through and continue to try mounting
+    } else {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Already mounted");
+        return 1;
     }
   }
 

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -470,14 +470,14 @@ int main(int argc, char **argv) {
         return 1;
       }
     }
-    if (mountpoint != prev_mountpoint && IsMountPoint(prev_mountpoint)) {
+    if (mountpoint != prev_mountpoint && IsMountPoint(prev_mountpoint, true)) {
        LogCvmfs(kLogCvmfs, kLogStderr,
           "Already mounted at %s", prev_mountpoint.c_str());
        return 1;
     }
     // Identify zombie fuse processes that are held open by other mount
     // namespaces
-    if (!IsMountPoint(mountpoint)) {
+    if (!IsMountPoint(mountpoint, true)) {
       // Allow for group access to the socket receiving the fuse fd
       umask(007);
       int fuse_fd = GetExistingFuseFd(fqrn, workspace, uid_cvmfs);

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -494,6 +494,10 @@ int main(int argc, char **argv) {
         LogCvmfs(kLogCvmfs, kLogStderr, "Already mounted");
         return 1;
     }
+  if (remount) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Repository %s is not mounted on %s",
+           fqrn.c_str(), mountpoint.c_str());
+    return 1;
   }
 
   // Prepare workspace and cache directory


### PR DESCRIPTION
We'd like to be able to lazy unmount a repo, and then remount it before the first mount has terminated. This needs a change to `mount.cvmfs` to permit concurrent mounts, and to the cvmfs talk code to prevent the terminating mount from removing the new talk sockets created by the new mount.

This change: 
1) Upon termination check to see whether `/var/run/cvmfs/cvmfs.[repo]` and `/var/cache/cvmfs/cvmfs_io.[repo]` sockets have changed before deleting them.
A change indicates that a `umount -l` and remount has probably happened, and the sockets are now owned by a new mount. In this case, don't delete them.

2) 
* Modify (linux) platform_mountlist() to optionally list only fuse mountpoints
* control the ReattachMount() functionality with a configuration flag, so - even if the kernel has the capability - we can get a new mount rather than a reattach to a `zombie` one

An example of use: 
```
$ cd /cvmfs/repo
$ umount -l .  # unmounted, but mount process won't go until /cvmfs/repo is not in use
$ cvmfs_talk -i repo pid # returns the PID of the now unmounted mount process
$ ls /cvmfs/repo # trigger an automount, starting a new mount process
$ cvmfs_talk -i repo pid # returns the PID of the new mount process
$ cd /cvmfs/repo # this releases the first mount procss which will now exit
