### PR TITLE
Streaming cache manager

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -49,6 +49,7 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS)
        cache_extern.cc
        cache_posix.cc
        cache_ram.cc
+       cache_stream.cc
        cache_tiered.cc
        cache_transport.cc
        catalog.cc

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -127,17 +127,14 @@ void CacheManager::FreeState(const int fd_progress, void *data) {
  * \return True if successful, false otherwise.
  */
 bool CacheManager::Open2Mem(
-  const shash::Any &id,
-  const std::string &description,
+  const LabeledObject &object,
   unsigned char **buffer,
   uint64_t *size)
 {
   *size = 0;
   *buffer = NULL;
 
-  Label label;
-  label.description = description;
-  int fd = this->Open(LabeledObject(id, label));
+  int fd = this->Open(object);
   if (fd < 0)
     return false;
 

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -86,7 +86,9 @@ bool CacheManager::CommitFromMem(
   int fd = this->StartTxn(id, size, txn);
   if (fd < 0)
     return false;
-  this->CtrlTxn(ObjectInfo(kTypeRegular, description), 0, txn);
+  ObjectInfo object_info;
+  object_info.description = description;
+  this->CtrlTxn(object_info, 0, txn);
   int64_t retval = this->Write(buffer, size, txn);
   if ((retval < 0) || (static_cast<uint64_t>(retval) != size)) {
     this->AbortTxn(txn);
@@ -133,7 +135,9 @@ bool CacheManager::Open2Mem(
   *size = 0;
   *buffer = NULL;
 
-  int fd = this->Open(Label(id, kTypeRegular, description));
+  ObjectInfo object_info;
+  object_info.description = description;
+  int fd = this->Open(Label(id, object_info));
   if (fd < 0)
     return false;
 
@@ -172,7 +176,10 @@ int CacheManager::OpenPinned(
   const string &description,
   bool is_catalog)
 {
-  ObjectInfo object_info(is_catalog ? kTypeCatalog : kTypeRegular, description);
+  ObjectInfo object_info;
+  object_info.description = description;
+  if (is_catalog)
+    object_info.flags |= ObjectInfo::kLabelCatalog;
   int fd = this->Open(Label(id, object_info));
   if (fd >= 0) {
     int64_t size = this->GetSize(fd);

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -166,7 +166,6 @@ bool CacheManager::Open2Mem(
  * pins into a no-op, so that the accounting does not get out of sync.)
  */
 int CacheManager::OpenPinned(const LabeledObject &object) {
-  assert(object.label.IsPinned());
   int fd = this->Open(object);
   if (fd >= 0) {
     int64_t size = this->GetSize(fd);

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -77,18 +77,15 @@ int CacheManager::ChecksumFd(int fd, shash::Any *id) {
  * The hash and the memory blob need to match.
  */
 bool CacheManager::CommitFromMem(
-  const shash::Any &id,
+  const LabeledObject &object,
   const unsigned char *buffer,
-  const uint64_t size,
-  const string &description)
+  const uint64_t size)
 {
   void *txn = alloca(this->SizeOfTxn());
-  int fd = this->StartTxn(id, size, txn);
+  int fd = this->StartTxn(object.id, size, txn);
   if (fd < 0)
     return false;
-  Label label;
-  label.description = description;
-  this->CtrlTxn(label, 0, txn);
+  this->CtrlTxn(object.label, 0, txn);
   int64_t retval = this->Write(buffer, size, txn);
   if ((retval < 0) || (static_cast<uint64_t>(retval) != size)) {
     this->AbortTxn(txn);

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -176,7 +176,7 @@ int CacheManager::OpenPinned(const LabeledObject &object) {
     }
     bool retval = quota_mgr_->Pin(
       object.id, static_cast<uint64_t>(size),
-      object.label.description, object.label.IsCatalog());
+      object.label.GetDescription(), object.label.IsCatalog());
     if (!retval) {
       this->Close(fd);
       return -ENOSPC;

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -137,7 +137,7 @@ bool CacheManager::Open2Mem(
 
   ObjectInfo object_info;
   object_info.description = description;
-  int fd = this->Open(Label(id, object_info));
+  int fd = this->Open(LabeledObject(id, object_info));
   if (fd < 0)
     return false;
 
@@ -180,7 +180,7 @@ int CacheManager::OpenPinned(
   object_info.description = description;
   if (is_catalog)
     object_info.flags |= ObjectInfo::kLabelCatalog;
-  int fd = this->Open(Label(id, object_info));
+  int fd = this->Open(LabeledObject(id, object_info));
   if (fd >= 0) {
     int64_t size = this->GetSize(fd);
     if (size < 0) {

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -86,9 +86,9 @@ bool CacheManager::CommitFromMem(
   int fd = this->StartTxn(id, size, txn);
   if (fd < 0)
     return false;
-  ObjectInfo object_info;
-  object_info.description = description;
-  this->CtrlTxn(object_info, 0, txn);
+  Label label;
+  label.description = description;
+  this->CtrlTxn(label, 0, txn);
   int64_t retval = this->Write(buffer, size, txn);
   if ((retval < 0) || (static_cast<uint64_t>(retval) != size)) {
     this->AbortTxn(txn);
@@ -135,9 +135,9 @@ bool CacheManager::Open2Mem(
   *size = 0;
   *buffer = NULL;
 
-  ObjectInfo object_info;
-  object_info.description = description;
-  int fd = this->Open(LabeledObject(id, object_info));
+  Label label;
+  label.description = description;
+  int fd = this->Open(LabeledObject(id, label));
   if (fd < 0)
     return false;
 
@@ -176,11 +176,11 @@ int CacheManager::OpenPinned(
   const string &description,
   bool is_catalog)
 {
-  ObjectInfo object_info;
-  object_info.description = description;
+  Label label;
+  label.description = description;
   if (is_catalog)
-    object_info.flags |= ObjectInfo::kLabelCatalog;
-  int fd = this->Open(LabeledObject(id, object_info));
+    label.flags |= kLabelCatalog;
+  int fd = this->Open(LabeledObject(id, label));
   if (fd >= 0) {
     int64_t size = this->GetSize(fd);
     if (size < 0) {

--- a/cvmfs/cache.cc
+++ b/cvmfs/cache.cc
@@ -133,7 +133,7 @@ bool CacheManager::Open2Mem(
   *size = 0;
   *buffer = NULL;
 
-  int fd = this->Open(Bless(id, kTypeRegular, description));
+  int fd = this->Open(Label(id, kTypeRegular, description));
   if (fd < 0)
     return false;
 
@@ -173,7 +173,7 @@ int CacheManager::OpenPinned(
   bool is_catalog)
 {
   ObjectInfo object_info(is_catalog ? kTypeCatalog : kTypeRegular, description);
-  int fd = this->Open(Bless(id, object_info));
+  int fd = this->Open(Label(id, object_info));
   if (fd >= 0) {
     int64_t size = this->GetSize(fd);
     if (size < 0) {

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -26,6 +26,7 @@ enum CacheManagerIds {
   kRamCacheManager,
   kTieredCacheManager,
   kExternalCacheManager,
+  kStreamingCacheManager,
 };
 
 enum CacheModes {

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -101,18 +101,18 @@ class CacheManager : SingleCopy {
   /**
    * A content hash together with a (partial) ObjectInfo meta-data.
    */
-  struct BlessedObject {
-    explicit BlessedObject(const shash::Any &id) : id(id), info() { }
-    BlessedObject(const shash::Any &id, const ObjectInfo info)
+  struct LabeledObject {
+    explicit LabeledObject(const shash::Any &id) : id(id), info() { }
+    LabeledObject(const shash::Any &id, const ObjectInfo info)
       : id(id)
       , info(info) { }
-    BlessedObject(const shash::Any &id, ObjectType type)
+    LabeledObject(const shash::Any &id, ObjectType type)
       : id(id)
       , info(type, "") { }
-    BlessedObject(const shash::Any &id, const std::string &description)
+    LabeledObject(const shash::Any &id, const std::string &description)
       : id(id)
       , info(kTypeRegular, description) { }
-    BlessedObject(
+    LabeledObject(
       const shash::Any &id,
       ObjectType type,
       const std::string &description)
@@ -122,31 +122,31 @@ class CacheManager : SingleCopy {
     shash::Any id;
     ObjectInfo info;
   };
-  // Convenience constructors, users can call Open(CacheManager::Bless(my_hash))
-  static inline BlessedObject Bless(const shash::Any &id) {
-    return BlessedObject(id);
+  // Convenience constructors, users can call Open(CacheManager::Label(my_hash))
+  static inline LabeledObject Label(const shash::Any &id) {
+    return LabeledObject(id);
   }
-  static inline BlessedObject Bless(
+  static inline LabeledObject Label(
     const shash::Any &id,
     const ObjectInfo &info)
   {
-    return BlessedObject(id, info);
+    return LabeledObject(id, info);
   }
-  static inline BlessedObject Bless(const shash::Any &id, ObjectType type) {
-    return BlessedObject(id, type);
+  static inline LabeledObject Label(const shash::Any &id, ObjectType type) {
+    return LabeledObject(id, type);
   }
-  static inline BlessedObject Bless(
+  static inline LabeledObject Label(
     const shash::Any &id,
     const std::string &description)
   {
-    return BlessedObject(id, description);
+    return LabeledObject(id, description);
   }
-  static inline BlessedObject Bless(
+  static inline LabeledObject Label(
     const shash::Any &id,
     ObjectType type,
     const std::string &description)
   {
-    return BlessedObject(id, type, description);
+    return LabeledObject(id, type, description);
   }
 
   virtual CacheManagerIds id() = 0;
@@ -165,7 +165,7 @@ class CacheManager : SingleCopy {
    * beneficial to register the object with the accurate meta-data, in the same
    * way it is done during transactions.
    */
-  virtual int Open(const BlessedObject &object) = 0;
+  virtual int Open(const LabeledObject &object) = 0;
   virtual int64_t GetSize(int fd) = 0;
   virtual int Close(int fd) = 0;
   virtual int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset) = 0;

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -73,13 +73,14 @@ class CacheManager : SingleCopy {
   static const uint64_t kSizeUnknown;
 
   /**
-   * Relevant for the quota management
+   * Relevant for the quota management and for downloading
    */
   enum ObjectType {
     kTypeRegular = 0,
     kTypeCatalog,  // implies pinned
     kTypePinned,
     kTypeVolatile,
+    kTypeExternal,
   };
 
   /**
@@ -88,10 +89,17 @@ class CacheManager : SingleCopy {
    * objects.
    */
   struct ObjectInfo {
+    struct Range {
+      Range() : offset(0), size(0) {}
+      uint64_t offset;
+      uint64_t size;
+    };
+
     ObjectInfo() : type(kTypeRegular), description() { }
-    ObjectInfo(ObjectType t, const std::string &d) : type(t), description(d) { }
+    ObjectInfo(ObjectType t, const std::string &d) : type(t), description(d) {}
 
     ObjectType type;
+    Range range;
     /**
      * Typically the path that triggered storing the object in the cache
      */
@@ -134,12 +142,6 @@ class CacheManager : SingleCopy {
   }
   static inline LabeledObject Label(const shash::Any &id, ObjectType type) {
     return LabeledObject(id, type);
-  }
-  static inline LabeledObject Label(
-    const shash::Any &id,
-    const std::string &description)
-  {
-    return LabeledObject(id, description);
   }
   static inline LabeledObject Label(
     const shash::Any &id,

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -102,6 +102,7 @@ class CacheManager : SingleCopy {
     bool IsCatalog() const { return flags & kLabelCatalog; }
     bool IsPinned() const { return flags & kLabelPinned; }
     bool IsExternal() const { return flags & kLabelExternal; }
+    bool IsCertificate() const { return flags & kLabelCertificate; }
 
     /**
      * The description for the quota manager

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -161,9 +161,7 @@ class CacheManager : SingleCopy {
 
   virtual void Spawn() = 0;
 
-  int OpenPinned(const shash::Any &id,
-                 const std::string &description,
-                 bool is_catalog);
+  int OpenPinned(const LabeledObject &object);
   int ChecksumFd(int fd, shash::Any *id);
   bool Open2Mem(const shash::Any &id, const std::string &description,
                 unsigned char **buffer, uint64_t *size);

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -161,9 +161,9 @@ class CacheManager : SingleCopy {
 
   virtual void Spawn() = 0;
 
-  int OpenPinned(const LabeledObject &object);
   int ChecksumFd(int fd, shash::Any *id);
-  bool Open2Mem(const shash::Any &id, const std::string &description,
+  int OpenPinned(const LabeledObject &object);
+  bool Open2Mem(const LabeledObject &object,
                 unsigned char **buffer, uint64_t *size);
   bool CommitFromMem(const shash::Any &id,
                      const unsigned char *buffer,

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -13,6 +13,7 @@
 
 #include <string>
 
+#include "compression.h"
 #include "crypto/hash.h"
 #include "manifest.h"
 #include "util/pointer.h"
@@ -96,7 +97,7 @@ class CacheManager : SingleCopy {
       uint64_t size;
     };
 
-    Label() : flags(0) { }
+    Label() : flags(0), size(kSizeUnknown), zip_algorithm(zlib::kZlibDefault) {}
 
     bool IsCatalog() const { return flags & kLabelCatalog; }
     bool IsPinned() const { return flags & kLabelPinned; }
@@ -112,6 +113,8 @@ class CacheManager : SingleCopy {
     }
 
     int flags;
+    uint64_t size;
+    zlib::Algorithms zip_algorithm;
     Range range;
     /**
      * The logical path on the mountpoint connected to the object. For meta-

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -94,7 +94,6 @@ class CacheManager : SingleCopy {
     };
 
     ObjectInfo() : flags(0), description() { }
-    ObjectInfo(int f, const std::string &d) : flags(f), description(d) {}
 
     bool IsCatalog() const { return flags & kLabelCatalog; }
     bool IsPinned() const { return flags & kLabelPinned; }
@@ -115,39 +114,14 @@ class CacheManager : SingleCopy {
     LabeledObject(const shash::Any &id, const ObjectInfo info)
       : id(id)
       , info(info) { }
-    LabeledObject(const shash::Any &id, int flags)
-      : id(id)
-      , info(flags, "") { }
-    LabeledObject(
-      const shash::Any &id,
-      int flags,
-      const std::string &description)
-      : id(id)
-      , info(flags, description) { }
 
     shash::Any id;
     ObjectInfo info;
   };
-  // Convenience constructors, users can call Open(CacheManager::Label(my_hash))
-  static inline LabeledObject Label(const shash::Any &id) {
-    return LabeledObject(id);
-  }
-  static inline LabeledObject Label(
-    const shash::Any &id,
-    const ObjectInfo &info)
-  {
-    return LabeledObject(id, info);
-  }
-  static inline LabeledObject Label(const shash::Any &id, int flags) {
-    return LabeledObject(id, flags);
-  }
-  static inline LabeledObject Label(
-    const shash::Any &id,
-    int flags,
-    const std::string &description)
-  {
-    return LabeledObject(id, flags, description);
-  }
+  //// Convenience constructors, users can call Open(CacheManager::Label(my_hash))
+  //static inline LabeledObject Label(const shash::Any &id) {
+  //  return LabeledObject(id);
+  //}
 
   virtual CacheManagerIds id() = 0;
   /**

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -144,10 +144,6 @@ class CacheManager : SingleCopy {
     shash::Any id;
     Label label;
   };
-  //// Convenience constructors, users can call Open(CacheManager::Label(my_hash))
-  //static inline LabeledObject Label(const shash::Any &id) {
-  //  return LabeledObject(id);
-  //}
 
   virtual CacheManagerIds id() = 0;
   /**

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -76,11 +76,12 @@ class CacheManager : SingleCopy {
    * Relevant for the quota management and for downloading (URL construction).
    * Used in Label::flags.
    */
-  static const int kLabelCatalog  = 0x01;
-  static const int kLabelPinned   = 0x02;
-  static const int kLabelVolatile = 0x04;
-  static const int kLabelExternal = 0x08;
-  static const int kLabelChunked  = 0x10;
+  static const int kLabelCatalog     = 0x01;
+  static const int kLabelPinned      = 0x02;
+  static const int kLabelVolatile    = 0x04;
+  static const int kLabelExternal    = 0x08;
+  static const int kLabelChunked     = 0x10;
+  static const int kLabelCertificate = 0x20;
 
   /**
    * Meta-data of an object that the cache may or may not maintain/use.
@@ -99,13 +100,25 @@ class CacheManager : SingleCopy {
 
     bool IsCatalog() const { return flags & kLabelCatalog; }
     bool IsPinned() const { return flags & kLabelPinned; }
+    /**
+     * The description for the quota manager
+     */
+    std::string GetDescription() const {
+      if (flags & kLabelCatalog)
+        return "file catalog at " + path;
+      if (flags & kLabelCertificate)
+        return "certificate for " + path;
+      return path;
+    }
 
     int flags;
     Range range;
     /**
-     * Typically the path that triggered storing the object in the cache
+     * The logical path on the mountpoint connected to the object. For meta-
+     * data objects, e.g. certificate, catalog, it's the repository name (which
+     * does not start with a slash).
      */
-    std::string description;
+    std::string path;
   };
 
   /**

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -165,10 +165,9 @@ class CacheManager : SingleCopy {
   int OpenPinned(const LabeledObject &object);
   bool Open2Mem(const LabeledObject &object,
                 unsigned char **buffer, uint64_t *size);
-  bool CommitFromMem(const shash::Any &id,
+  bool CommitFromMem(const LabeledObject &object,
                      const unsigned char *buffer,
-                     const uint64_t size,
-                     const std::string &description);
+                     const uint64_t size);
 
   QuotaManager *quota_mgr() { return quota_mgr_; }
 

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -447,7 +447,7 @@ int ExternalCacheManager::Flush(bool do_commit, Transaction *transaction) {
 
   if (transaction->object_info_modified) {
     cvmfs::EnumObjectType object_type;
-    transport_.FillObjectType(transaction->object_info.type, &object_type);
+    transport_.FillObjectType(transaction->object_info.flags, &object_type);
     msg_store.set_object_type(object_type);
     msg_store.set_description(transaction->object_info.description);
   }

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -296,13 +296,13 @@ ExternalCacheManager::PluginHandle *ExternalCacheManager::CreatePlugin(
 
 
 void ExternalCacheManager::CtrlTxn(
-  const ObjectInfo &object_info,
+  const Label &label,
   const int flags,
   void *txn)
 {
   Transaction *transaction = reinterpret_cast<Transaction *>(txn);
-  transaction->object_info = object_info;
-  transaction->object_info_modified = true;
+  transaction->label = label;
+  transaction->label_modified = true;
 }
 
 
@@ -445,11 +445,11 @@ int ExternalCacheManager::Flush(bool do_commit, Transaction *transaction) {
   msg_store.set_expected_size(transaction->expected_size);
   msg_store.set_last_part(do_commit);
 
-  if (transaction->object_info_modified) {
+  if (transaction->label_modified) {
     cvmfs::EnumObjectType object_type;
-    transport_.FillObjectType(transaction->object_info.flags, &object_type);
+    transport_.FillObjectType(transaction->label.flags, &object_type);
     msg_store.set_object_type(object_type);
-    msg_store.set_description(transaction->object_info.description);
+    msg_store.set_description(transaction->label.description);
   }
 
   RpcJob rpc_job(&msg_store);
@@ -657,7 +657,7 @@ int ExternalCacheManager::Reset(void *txn) {
   transaction->size = 0;
   transaction->open_fds = 0;
   transaction->committed = false;
-  transaction->object_info_modified = true;
+  transaction->label_modified = true;
 
   if (!transaction->flushed)
     return 0;

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -572,7 +572,7 @@ void *ExternalCacheManager::MainRead(void *data) {
 }
 
 
-int ExternalCacheManager::Open(const BlessedObject &object) {
+int ExternalCacheManager::Open(const LabeledObject &object) {
   return DoOpen(object.id);
 }
 

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -449,7 +449,7 @@ int ExternalCacheManager::Flush(bool do_commit, Transaction *transaction) {
     cvmfs::EnumObjectType object_type;
     transport_.FillObjectType(transaction->label.flags, &object_type);
     msg_store.set_object_type(object_type);
-    msg_store.set_description(transaction->label.description);
+    msg_store.set_description(transaction->label.GetDescription());
   }
 
   RpcJob rpc_job(&msg_store);

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -81,7 +81,7 @@ class ExternalCacheManager : public CacheManager {
   }
 #endif
   virtual int StartTxn(const shash::Any &id, uint64_t size, void *txn);
-  virtual void CtrlTxn(const ObjectInfo &object_info,
+  virtual void CtrlTxn(const Label &label,
                        const int flags,
                        void *txn);
   virtual int64_t Write(const void *buf, uint64_t size, void *txn);
@@ -127,11 +127,11 @@ class ExternalCacheManager : public CacheManager {
       , buf_pos(0)
       , size(0)
       , expected_size(kSizeUnknown)
-      , object_info()
+      , label()
       , open_fds(0)
       , flushed(false)
       , committed(false)
-      , object_info_modified(false)
+      , label_modified(false)
       , transaction_id(0)
       , id(id)
     { }
@@ -144,11 +144,11 @@ class ExternalCacheManager : public CacheManager {
     unsigned buf_pos;
     uint64_t size;
     uint64_t expected_size;
-    ObjectInfo object_info;
+    Label label;
     int open_fds;
     bool flushed;
     bool committed;
-    bool object_info_modified;
+    bool label_modified;
     uint64_t transaction_id;
     shash::Any id;
   };  // class Transaction

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -127,7 +127,7 @@ class ExternalCacheManager : public CacheManager {
       , buf_pos(0)
       , size(0)
       , expected_size(kSizeUnknown)
-      , object_info(kTypeRegular, "")
+      , object_info()
       , open_fds(0)
       , flushed(false)
       , committed(false)

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -66,7 +66,7 @@ class ExternalCacheManager : public CacheManager {
   virtual std::string Describe();
   virtual bool AcquireQuotaManager(QuotaManager *quota_mgr);
 
-  virtual int Open(const BlessedObject &object);
+  virtual int Open(const LabeledObject &object);
   virtual int64_t GetSize(int fd);
   virtual int Close(int fd);
   virtual int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset);

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -248,7 +248,7 @@ int posix_start_txn(struct cvmcache_hash *id,
     label.flags = CacheManager::kLabelVolatile;
   }
   if (info->description) {
-    label.description = info->description;
+    label.path = info->description;
   }
   g_cache_mgr->CtrlTxn(label, 0, txn);
   return CVMCACHE_STATUS_OK;

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -241,16 +241,16 @@ int posix_start_txn(struct cvmcache_hash *id,
   transaction.type = info->type;
   g_transactions->Insert(txn_id, transaction);
 
-  CacheManager::ObjectInfo object_info;
+  CacheManager::Label label;
   if (info->type == CVMCACHE_OBJECT_CATALOG) {
-    object_info.flags |= CacheManager::ObjectInfo::kLabelCatalog;
+    label.flags |= CacheManager::kLabelCatalog;
   } else if (info->type == CVMCACHE_OBJECT_VOLATILE) {
-    object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
+    label.flags = CacheManager::kLabelVolatile;
   }
   if (info->description) {
-    object_info.description = info->description;
+    label.description = info->description;
   }
-  g_cache_mgr->CtrlTxn(object_info, 0, txn);
+  g_cache_mgr->CtrlTxn(label, 0, txn);
   return CVMCACHE_STATUS_OK;
 }
 

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -243,11 +243,9 @@ int posix_start_txn(struct cvmcache_hash *id,
 
   CacheManager::ObjectInfo object_info;
   if (info->type == CVMCACHE_OBJECT_CATALOG) {
-    object_info.type = CacheManager::kTypeCatalog;
+    object_info.flags |= CacheManager::ObjectInfo::kLabelCatalog;
   } else if (info->type == CVMCACHE_OBJECT_VOLATILE) {
-    object_info.type = CacheManager::kTypeVolatile;
-  } else {
-    object_info.type = CacheManager::kTypeRegular;
+    object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
   }
   if (info->description) {
     object_info.description = info->description;

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -168,8 +168,8 @@ int posix_chrefcnt(struct cvmcache_hash *id, int32_t change_by) {
     if (change_by < 0) {
       return CVMCACHE_STATUS_BADCOUNT;
     }
-    CacheManager::BlessedObject blessed_object(Chash2Cpphash(id));
-    int fd = g_cache_mgr->Open(blessed_object);
+    CacheManager::LabeledObject labeled_object(Chash2Cpphash(id));
+    int fd = g_cache_mgr->Open(labeled_object);
     if (fd < 0) {
       return CVMCACHE_STATUS_NOENTRY;
     }

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -356,7 +356,7 @@ int64_t PosixCacheManager::GetSize(int fd) {
 }
 
 
-int PosixCacheManager::Open(const BlessedObject &object) {
+int PosixCacheManager::Open(const LabeledObject &object) {
   const string path = GetPathInCache(object.id);
   int result = open(path.c_str(), O_RDONLY);
 

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -184,7 +184,7 @@ int PosixCacheManager::CommitTxn(void *txn) {
       (transaction->label.flags & kLabelCatalog))
   {
     bool retval = quota_mgr_->Pin(
-      transaction->id, transaction->size, transaction->label.description,
+      transaction->id, transaction->size, transaction->label.GetDescription(),
       (transaction->label.flags & kLabelCatalog));
     if (!retval) {
       LogCvmfs(kLogCache, kLogDebug, "commit failed: cannot pin %s",
@@ -215,12 +215,12 @@ int PosixCacheManager::CommitTxn(void *txn) {
     // Success, inform quota manager
     if (transaction->label.flags & kLabelVolatile) {
       quota_mgr_->InsertVolatile(transaction->id, transaction->size,
-                                 transaction->label.description);
+                                 transaction->label.GetDescription());
     } else if (!transaction->label.IsCatalog() &&
                !transaction->label.IsPinned())
     {
       quota_mgr_->Insert(transaction->id, transaction->size,
-                         transaction->label.description);
+                         transaction->label.GetDescription());
     }
   }
   transaction->~Transaction();

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -84,7 +84,7 @@ class PosixCacheManager : public CacheManager {
 
   virtual uint32_t SizeOfTxn() { return sizeof(Transaction); }
   virtual int StartTxn(const shash::Any &id, uint64_t size, void *txn);
-  virtual void CtrlTxn(const ObjectInfo &object_info,
+  virtual void CtrlTxn(const Label &label,
                        const int flags,
                        void *txn);
   virtual int64_t Write(const void *buf, uint64_t size, void *txn);
@@ -117,7 +117,7 @@ class PosixCacheManager : public CacheManager {
       , size(0)
       , expected_size(kSizeUnknown)
       , fd(-1)
-      , object_info()
+      , label()
       , tmp_path()
       , final_path(final_path)
       , id(id)
@@ -128,7 +128,7 @@ class PosixCacheManager : public CacheManager {
     uint64_t size;
     uint64_t expected_size;
     int fd;
-    ObjectInfo object_info;
+    Label label;
     std::string tmp_path;
     std::string final_path;
     shash::Any id;

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -75,7 +75,7 @@ class PosixCacheManager : public CacheManager {
   virtual ~PosixCacheManager() { }
   virtual bool AcquireQuotaManager(QuotaManager *quota_mgr);
 
-  virtual int Open(const BlessedObject &object);
+  virtual int Open(const LabeledObject &object);
   virtual int64_t GetSize(int fd);
   virtual int Close(int fd);
   virtual int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset);

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -117,7 +117,7 @@ class PosixCacheManager : public CacheManager {
       , size(0)
       , expected_size(kSizeUnknown)
       , fd(-1)
-      , object_info(kTypeRegular, "")
+      , object_info()
       , tmp_path()
       , final_path(final_path)
       , id(id)

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -75,7 +75,7 @@ bool RamCacheManager::AcquireQuotaManager(QuotaManager *quota_mgr) {
 }
 
 
-int RamCacheManager::Open(const BlessedObject &object) {
+int RamCacheManager::Open(const LabeledObject &object) {
   WriteLockGuard guard(rwlock_);
   return DoOpen(object.id);
 }

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -223,14 +223,10 @@ int RamCacheManager::StartTxn(const shash::Any &id, uint64_t size, void *txn) {
 }
 
 
-void RamCacheManager::CtrlTxn(
-  const ObjectInfo &object_info,
-  const int flags,
-  void *txn)
-{
+void RamCacheManager::CtrlTxn(const Label &label, const int flags, void *txn) {
   Transaction *transaction = reinterpret_cast<Transaction *>(txn);
-  transaction->description = object_info.description;
-  transaction->buffer.object_flags = object_info.flags;
+  transaction->description = label.description;
+  transaction->buffer.object_flags = label.flags;
   LogCvmfs(kLogCache, kLogDebug, "modified transaction %s",
            transaction->buffer.id.ToString().c_str());
 }
@@ -328,17 +324,14 @@ int RamCacheManager::CommitTxn(void *txn) {
 int64_t RamCacheManager::CommitToKvStore(Transaction *transaction) {
   MemoryKvStore *store;
 
-  if (transaction->buffer.object_flags &
-      CacheManager::ObjectInfo::kLabelVolatile)
+  if (transaction->buffer.object_flags & CacheManager::kLabelVolatile)
   {
     store = &volatile_entries_;
   } else {
     store = &regular_entries_;
   }
-  if ((transaction->buffer.object_flags &
-       CacheManager::ObjectInfo::kLabelPinned) ||
-      (transaction->buffer.object_flags &
-       CacheManager::ObjectInfo::kLabelCatalog))
+  if ((transaction->buffer.object_flags & CacheManager::kLabelPinned) ||
+      (transaction->buffer.object_flags & CacheManager::kLabelCatalog))
   {
     transaction->buffer.refcount = 1;
   } else {

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -225,7 +225,7 @@ int RamCacheManager::StartTxn(const shash::Any &id, uint64_t size, void *txn) {
 
 void RamCacheManager::CtrlTxn(const Label &label, const int flags, void *txn) {
   Transaction *transaction = reinterpret_cast<Transaction *>(txn);
-  transaction->description = label.description;
+  transaction->description = label.GetDescription();
   transaction->buffer.object_flags = label.flags;
   LogCvmfs(kLogCache, kLogDebug, "modified transaction %s",
            transaction->buffer.id.ToString().c_str());

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -49,6 +49,9 @@ RamCacheManager::RamCacheManager(
   assert(retval == 0);
   LogCvmfs(kLogCache, kLogDebug, "max %u B, %u entries",
            max_size, max_entries);
+  LogCvmfs(kLogCache, kLogDebug | kLogSyslogWarn,
+           "DEPRECATION WARNING: The RAM cache manager is depcreated and "
+           "will be removed from future releases.");
 }
 
 

--- a/cvmfs/cache_ram.cc
+++ b/cvmfs/cache_ram.cc
@@ -226,7 +226,9 @@ int RamCacheManager::StartTxn(const shash::Any &id, uint64_t size, void *txn) {
 }
 
 
-void RamCacheManager::CtrlTxn(const Label &label, const int flags, void *txn) {
+void RamCacheManager::CtrlTxn(const Label &label, const int /* flags */,
+                              void *txn)
+{
   Transaction *transaction = reinterpret_cast<Transaction *>(txn);
   transaction->description = label.GetDescription();
   transaction->buffer.object_flags = label.flags;

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -284,7 +284,7 @@ class RamCacheManager : public CacheManager {
   }
 
   inline MemoryKvStore *GetTransactionStore(Transaction *txn) {
-    if (txn->buffer.object_type == kTypeVolatile) {
+    if (txn->buffer.object_flags & CacheManager::ObjectInfo::kLabelVolatile) {
       return &volatile_entries_;
     } else {
       return &regular_entries_;

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -190,9 +190,7 @@ class RamCacheManager : public CacheManager {
    * @param flags Unused
    * @param txn A pointer to space allocated for storing the transaction details
    */
-  virtual void CtrlTxn(const ObjectInfo &object_info,
-                       const int flags,
-                       void *txn);
+  virtual void CtrlTxn(const Label &label, const int flags, void *txn);
 
   /**
    * Copy the given memory region into the transaction buffer. Copying starts at
@@ -284,7 +282,7 @@ class RamCacheManager : public CacheManager {
   }
 
   inline MemoryKvStore *GetTransactionStore(Transaction *txn) {
-    if (txn->buffer.object_flags & CacheManager::ObjectInfo::kLabelVolatile) {
+    if (txn->buffer.object_flags & CacheManager::kLabelVolatile) {
       return &volatile_entries_;
     } else {
       return &regular_entries_;

--- a/cvmfs/cache_ram.h
+++ b/cvmfs/cache_ram.h
@@ -117,12 +117,12 @@ class RamCacheManager : public CacheManager {
    * Open a new file descriptor into the cache. Note that opening entries
    * effectively pins them in the cache, so it may be necessary to close
    * unneeded file descriptors to allow eviction to make room in the cache
-   * @param object The blessed hash key
+   * @param object The tagged hash key
    * @returns A nonnegative integer file descriptor
    * @retval -ENOENT The entry is not in the cache
    * @retval -ENFILE No handles are available
    */
-  virtual int Open(const BlessedObject &object);
+  virtual int Open(const LabeledObject &object);
 
   /**
    * Look up the size in bytes of the open cache entry

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -1,0 +1,89 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+#include "cache_stream.h"
+
+#include <cstdlib>
+#include <string>
+
+#include "util/murmur.hxx"
+#include "util/mutex.h"
+#include "util/smalloc.h"
+
+
+namespace {
+
+static uint32_t hasher_int(const int &key) {
+  return MurmurHash2(&key, sizeof(key), 0x07387a4f);
+}
+
+}  // anonymous namespace
+
+
+StreamingCacheManager::StreamingCacheManager(
+  CacheManager *cache_mgr, download::DownloadManager *download_mgr)
+  : cache_mgr_(cache_mgr)
+  , download_mgr_(download_mgr)
+  , min_stream_size_(kMinStreamSize)
+{
+  lock_fd_table_ =
+    reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+  int retval = pthread_mutex_init(lock_fd_table_, NULL);
+  assert(retval == 0);
+  fd_table_.Init(16, -1, hasher_int);
+}
+
+StreamingCacheManager::~StreamingCacheManager() {
+  pthread_mutex_destroy(lock_fd_table_);
+  free(lock_fd_table_);
+  quota_mgr_ = NULL;  // gets deleted by cache_mgr_
+}
+
+std::string StreamingCacheManager::Describe() {
+  return "Streaming shim, underlying cache manager:\n" + cache_mgr_->Describe();
+}
+
+bool StreamingCacheManager::AcquireQuotaManager(QuotaManager *quota_mgr) {
+  bool result = cache_mgr_->AcquireQuotaManager(quota_mgr);
+  if (result)
+    quota_mgr_ = cache_mgr_->quota_mgr();
+  return result;
+}
+
+int StreamingCacheManager::Open(const BlessedObject &object) {
+  int fd_in_cache_mgr = cache_mgr_->Open(object);
+  if (fd_in_cache_mgr >= 0) {
+    MutexLockGuard lock_guard(lock_fd_table_);
+    int fd = fd_table_.size();
+    fd_table_.Insert(fd, FdInfo(fd_in_cache_mgr));
+    return fd;
+  }
+
+  if (fd_in_cache_mgr != -ENOENT)
+    return fd_in_cache_mgr;
+
+  if ((object.info.type == kTypeCatalog) || (object.info.type == kTypePinned))
+    return -ENOENT;
+
+  MutexLockGuard lock_guard(lock_fd_table_);
+  int fd = fd_table_.size();
+  fd_table_.Insert(fd, FdInfo(object.id));
+  return fd;
+}
+
+int StreamingCacheManager::Close(int fd) {
+  FdInfo info;
+  {
+    MutexLockGuard lock_guard(lock_fd_table_);
+    bool found = fd_table_.Lookup(fd, &info);
+    if (!found)
+      return -EBADF;
+    fd_table_.Erase(fd);
+  }
+
+  if (info.fd_in_cache_mgr >= 0)
+    return cache_mgr_->Close(info.fd_in_cache_mgr);
+  return 0;
+}

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -163,7 +163,7 @@ int StreamingCacheManager::Open(const LabeledObject &object) {
   if (fd_in_cache_mgr != -ENOENT)
     return fd_in_cache_mgr;
 
-  if (object.info.IsCatalog() || object.info.IsPinned())
+  if (object.label.IsCatalog() || object.label.IsPinned())
     return -ENOENT;
 
   MutexLockGuard lock_guard(lock_fd_table_);

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -12,6 +12,7 @@
 
 #include "network/download.h"
 #include "network/sink.h"
+#include "quota.h"
 #include "util/mutex.h"
 #include "util/smalloc.h"
 
@@ -79,7 +80,7 @@ int64_t StreamingCacheManager::Stream(
   uint64_t offset)
 {
   StreamingSink sink(buf, size, offset);
-  std::string url = "data/" + object_id.MakePath();
+  std::string url = "/data/" + object_id.MakePath();
   download::JobInfo download_job(&url,
                                  true, /* compressed */
                                  true, /* probe_hosts */
@@ -106,6 +107,9 @@ StreamingCacheManager::StreamingCacheManager(
     reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
   int retval = pthread_mutex_init(lock_fd_table_, NULL);
   assert(retval == 0);
+
+  delete quota_mgr_;
+  quota_mgr_ = cache_mgr_->quota_mgr();
 }
 
 StreamingCacheManager::~StreamingCacheManager() {

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -78,10 +78,10 @@ class StreamingSink : public cvmfs::Sink {
   int64_t GetNBytesStreamed() const { return pos_; }
 
  private:
-   uint64_t pos_;
-   void *window_buf_;
-   uint64_t window_size_;
-   uint64_t window_offset_;
+  uint64_t pos_;
+  void *window_buf_;
+  uint64_t window_size_;
+  uint64_t window_offset_;
 };  // class StreamingSink
 
 }  // anonymous namespace
@@ -96,7 +96,7 @@ download::DownloadManager *StreamingCacheManager::SelectDownloadManager(
 }
 
 int64_t StreamingCacheManager::Stream(
-  FdInfo &info,
+  const FdInfo &info,
   void *buf,
   uint64_t size,
   uint64_t offset)

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -5,34 +5,107 @@
 #include "cvmfs_config.h"
 #include "cache_stream.h"
 
+#include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 
-#include "util/murmur.hxx"
+#include "network/download.h"
+#include "network/sink.h"
 #include "util/mutex.h"
 #include "util/smalloc.h"
 
 
 namespace {
 
-static uint32_t hasher_int(const int &key) {
-  return MurmurHash2(&key, sizeof(key), 0x07387a4f);
-}
+class StreamingSink : public cvmfs::Sink {
+ public:
+  StreamingSink(void *buf, uint64_t size, uint64_t offset)
+    : pos_(0)
+    , window_buf_(buf)
+    , window_size_(size)
+    , window_offset_(offset)
+  { }
+
+  virtual ~StreamingSink() {}
+
+  virtual int64_t Write(const void *buf, uint64_t sz) {
+    uint64_t old_pos = pos_;
+    pos_ += sz;
+
+    if (!window_buf_)
+      return sz;
+
+    if (pos_ < window_offset_)
+      return sz;
+
+    if (old_pos >= (window_offset_ + window_size_))
+      return sz;
+
+    uint64_t copy_offset = std::max(old_pos, window_offset_);
+    uint64_t inbuf_offset = copy_offset - old_pos;
+    uint64_t outbuf_offset = copy_offset - window_offset_;
+    uint64_t copy_size =
+      std::min(sz - inbuf_offset, window_size_ - outbuf_offset);
+
+    memcpy(reinterpret_cast<unsigned char *>(window_buf_) + outbuf_offset,
+           reinterpret_cast<const unsigned char *>(buf) + inbuf_offset,
+           copy_size);
+
+    return sz;
+  }
+
+  virtual int Reset() {
+    pos_ = 0;
+    return 0;
+  }
+
+  int64_t GetNBytesWritten() const { return pos_; }
+
+ private:
+   uint64_t pos_;
+   void *window_buf_;
+   uint64_t window_size_;
+   uint64_t window_offset_;
+};  // class StreamingSink
 
 }  // anonymous namespace
 
 
+int64_t StreamingCacheManager::Stream(
+  const shash::Any &object_id,
+  void *buf,
+  uint64_t size,
+  uint64_t offset)
+{
+  StreamingSink sink(buf, size, offset);
+  std::string url = "data/" + object_id.MakePath();
+  download::JobInfo download_job(&url,
+                                 true, /* compressed */
+                                 true, /* probe_hosts */
+                                 &sink,
+                                 &object_id);
+  download_mgr_->Fetch(&download_job);
+
+  if (download_job.error_code != download::kFailOk)
+    return -EIO;
+
+  return sink.GetNBytesWritten();
+}
+
+
 StreamingCacheManager::StreamingCacheManager(
-  CacheManager *cache_mgr, download::DownloadManager *download_mgr)
+  unsigned max_open_fds,
+  CacheManager *cache_mgr,
+  download::DownloadManager *download_mgr)
   : cache_mgr_(cache_mgr)
   , download_mgr_(download_mgr)
-  , min_stream_size_(kMinStreamSize)
+  , fd_table_(max_open_fds, FdInfo())
 {
   lock_fd_table_ =
     reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
   int retval = pthread_mutex_init(lock_fd_table_, NULL);
   assert(retval == 0);
-  fd_table_.Init(16, -1, hasher_int);
 }
 
 StreamingCacheManager::~StreamingCacheManager() {
@@ -56,9 +129,7 @@ int StreamingCacheManager::Open(const BlessedObject &object) {
   int fd_in_cache_mgr = cache_mgr_->Open(object);
   if (fd_in_cache_mgr >= 0) {
     MutexLockGuard lock_guard(lock_fd_table_);
-    int fd = fd_table_.size();
-    fd_table_.Insert(fd, FdInfo(fd_in_cache_mgr));
-    return fd;
+    return fd_table_.OpenFd(FdInfo(fd_in_cache_mgr));
   }
 
   if (fd_in_cache_mgr != -ENOENT)
@@ -68,22 +139,99 @@ int StreamingCacheManager::Open(const BlessedObject &object) {
     return -ENOENT;
 
   MutexLockGuard lock_guard(lock_fd_table_);
-  int fd = fd_table_.size();
-  fd_table_.Insert(fd, FdInfo(object.id));
-  return fd;
+  return fd_table_.OpenFd(FdInfo(object.id));
+}
+
+int64_t StreamingCacheManager::GetSize(int fd) {
+  FdInfo info;
+  {
+    MutexLockGuard lock_guard(lock_fd_table_);
+    info = fd_table_.GetHandle(fd);
+  }
+
+  if (!info.IsValid())
+    return -EBADF;
+
+  if (info.fd_in_cache_mgr >= 0)
+    return cache_mgr_->GetSize(info.fd_in_cache_mgr);
+
+  return Stream(info.object_id, NULL, 0, 0);
+}
+
+int StreamingCacheManager::Dup(int fd) {
+  FdInfo info;
+
+  MutexLockGuard lock_guard(lock_fd_table_);
+  info = fd_table_.GetHandle(fd);
+
+  if (!info.IsValid())
+    return -EBADF;
+
+  if (info.fd_in_cache_mgr >= 0) {
+    int dup_fd = cache_mgr_->Dup(info.fd_in_cache_mgr);
+    if (dup_fd < 0)
+      return dup_fd;
+    return fd_table_.OpenFd(FdInfo(dup_fd));
+  }
+
+  return fd_table_.OpenFd(FdInfo(info.object_id));
 }
 
 int StreamingCacheManager::Close(int fd) {
   FdInfo info;
   {
     MutexLockGuard lock_guard(lock_fd_table_);
-    bool found = fd_table_.Lookup(fd, &info);
-    if (!found)
+    info = fd_table_.GetHandle(fd);
+    if (!info.IsValid())
       return -EBADF;
-    fd_table_.Erase(fd);
+    fd_table_.CloseFd(fd);
   }
 
   if (info.fd_in_cache_mgr >= 0)
     return cache_mgr_->Close(info.fd_in_cache_mgr);
+
   return 0;
+}
+
+int64_t StreamingCacheManager::Pread(
+  int fd, void *buf, uint64_t size, uint64_t offset)
+{
+  FdInfo info;
+  {
+    MutexLockGuard lock_guard(lock_fd_table_);
+    info = fd_table_.GetHandle(fd);
+  }
+
+  if (!info.IsValid())
+    return -EBADF;
+
+  if (info.fd_in_cache_mgr >= 0)
+    return cache_mgr_->Pread(info.fd_in_cache_mgr, buf, size, offset);
+
+  return Stream(info.object_id, buf, size, offset);
+}
+
+int StreamingCacheManager::Readahead(int fd) {
+  FdInfo info;
+  {
+    MutexLockGuard lock_guard(lock_fd_table_);
+    info = fd_table_.GetHandle(fd);
+  }
+
+  if (!info.IsValid())
+    return -EBADF;
+
+  if (info.fd_in_cache_mgr >= 0)
+    return cache_mgr_->Readahead(info.fd_in_cache_mgr);
+
+  return 0;
+}
+
+int StreamingCacheManager::OpenFromTxn(void *txn) {
+  int fd = cache_mgr_->OpenFromTxn(txn);
+  if (fd < 0)
+    return fd;
+
+  MutexLockGuard lock_guard(lock_fd_table_);
+  return fd_table_.OpenFd(FdInfo(fd));
 }

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -82,13 +82,13 @@ download::DownloadManager *StreamingCacheManager::SelectDownloadManager(
 }
 
 int64_t StreamingCacheManager::Stream(
-  (FdInfo &info,
+  FdInfo &info,
   void *buf,
   uint64_t size,
   uint64_t offset)
 {
   StreamingSink sink(buf, size, offset);
-  std::string url = "/data/" + object_id.MakePath();
+  std::string url = "/data/" + info.object_id.MakePath();
   download::JobInfo download_job(&url,
                                  true, /* compressed */
                                  true, /* probe_hosts */
@@ -139,7 +139,7 @@ bool StreamingCacheManager::AcquireQuotaManager(QuotaManager *quota_mgr) {
   return result;
 }
 
-int StreamingCacheManager::Open(const BlessedObject &object) {
+int StreamingCacheManager::Open(const LabeledObject &object) {
   int fd_in_cache_mgr = cache_mgr_->Open(object);
   if (fd_in_cache_mgr >= 0) {
     MutexLockGuard lock_guard(lock_fd_table_);
@@ -169,7 +169,7 @@ int64_t StreamingCacheManager::GetSize(int fd) {
   if (info.fd_in_cache_mgr >= 0)
     return cache_mgr_->GetSize(info.fd_in_cache_mgr);
 
-  return Stream(info, download_mgr, NULL, 0, 0);
+  return Stream(info, NULL, 0, 0);
 }
 
 int StreamingCacheManager::Dup(int fd) {

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -36,13 +36,13 @@ class StreamingSink : public cvmfs::Sink {
     pos_ += sz;
 
     if (!window_buf_)
-      return sz;
+      return static_cast<int64_t>(sz);
 
     if (pos_ < window_offset_)
-      return sz;
+      return static_cast<int64_t>(sz);
 
     if (old_pos >= (window_offset_ + window_size_))
-      return sz;
+      return static_cast<int64_t>(sz);
 
     uint64_t copy_offset = std::max(old_pos, window_offset_);
     uint64_t inbuf_offset = copy_offset - old_pos;
@@ -54,7 +54,7 @@ class StreamingSink : public cvmfs::Sink {
            reinterpret_cast<const unsigned char *>(buf) + inbuf_offset,
            copy_size);
 
-    return sz;
+    return static_cast<int64_t>(sz);
   }
 
   virtual int Reset() {
@@ -67,7 +67,7 @@ class StreamingSink : public cvmfs::Sink {
     return (window_buf_ != NULL) || (window_size_ == 0);
   }
   virtual int Flush() { return 0; }
-  virtual bool Reserve(size_t size) { return true; }
+  virtual bool Reserve(size_t /* size */) { return true; }
   virtual bool RequiresReserve() { return false; }
   virtual std::string Describe() {
     std::string result =  "Streaming sink that is ";
@@ -75,7 +75,7 @@ class StreamingSink : public cvmfs::Sink {
     return result;
   }
 
-  int64_t GetNBytesStreamed() const { return pos_; }
+  int64_t GetNBytesStreamed() const { return static_cast<int64_t>(pos_); }
 
  private:
   uint64_t pos_;
@@ -116,7 +116,7 @@ int64_t StreamingCacheManager::Stream(
                                  &sink);
   download_job.extra_info = &info.label.path;
   download_job.range_offset = info.label.range_offset;
-  download_job.range_size = info.label.size;
+  download_job.range_size = static_cast<int64_t>(info.label.size);
   SelectDownloadManager(info)->Fetch(&download_job);
 
   if (download_job.error_code != download::kFailOk)
@@ -249,8 +249,8 @@ int64_t StreamingCacheManager::Pread(
   if (nbytes_streamed < offset)
     return 0;
   if (nbytes_streamed > (offset + size))
-    return size;
-  return offset + size - nbytes_streamed;
+    return static_cast<int64_t>(size);
+  return static_cast<int64_t>(offset + size - nbytes_streamed);
 }
 
 int StreamingCacheManager::Readahead(int fd) {

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -163,7 +163,7 @@ int StreamingCacheManager::Open(const LabeledObject &object) {
   if (fd_in_cache_mgr != -ENOENT)
     return fd_in_cache_mgr;
 
-  if ((object.info.type == kTypeCatalog) || (object.info.type == kTypePinned))
+  if (object.info.IsCatalog() || object.info.IsPinned())
     return -ENOENT;
 
   MutexLockGuard lock_guard(lock_fd_table_);

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -253,7 +253,7 @@ int64_t StreamingCacheManager::Pread(
     return 0;
   if (nbytes_streamed > (offset + size))
     return static_cast<int64_t>(size);
-  return static_cast<int64_t>(offset + size - nbytes_streamed);
+  return static_cast<int64_t>(nbytes_streamed - offset);
 }
 
 int StreamingCacheManager::Readahead(int fd) {

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -1,0 +1,75 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_CACHE_STREAM_H_
+#define CVMFS_CACHE_STREAM_H_
+
+#include "cache.h"
+
+#include <pthread.h>
+
+#include <string>
+
+#include <crypto/hash.h>
+#include <smallhash.h>
+#include <util/pointer.h>
+
+namespace download {
+class DownloadManager;
+}
+
+/**
+ * Cache manager that streams regular files using a download manager and stores
+ * file catalogs in an underlying cache manager.
+ */
+class StreamingCacheManager : public CacheManager {
+ public:
+  StreamingCacheManager(CacheManager *cache_mgr,
+                        download::DownloadManager *download_mgr);
+  virtual ~StreamingCacheManager();
+
+  virtual CacheManagerIds id() { return kStreamingCacheManager; }
+  virtual std::string Describe();
+
+  virtual bool AcquireQuotaManager(QuotaManager *quota_mgr);
+
+  virtual int Open(const BlessedObject &object);
+  virtual int64_t GetSize(int fd);
+  virtual int Close(int fd);
+  virtual int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset);
+  virtual int Dup(int fd);
+  virtual int Readahead(int fd);
+
+  virtual void Spawn() { cache_mgr_->Spawn(); }
+
+  virtual manifest::Breadcrumb LoadBreadcrumb(const std::string &fqrn) {
+    return cache_mgr_->LoadBreadcrumb(fqrn);
+  }
+  virtual bool StoreBreadcrumb(const manifest::Manifest &manifest) {
+    return cache_mgr_->StoreBreadcrumb(manifest);
+  }
+
+ protected:
+
+ private:
+  static const uint64_t kMinStreamSize = 64 * 1024;
+  struct FdInfo {
+    int fd_in_cache_mgr;
+    shash::Any object_id;
+
+    FdInfo() : fd_in_cache_mgr(-1) {}
+    explicit FdInfo(int fd) : fd_in_cache_mgr(fd) {}
+    explicit FdInfo(const shash::Any &id)
+      : fd_in_cache_mgr(-1), object_id(id) {}
+  };
+
+  UniquePtr<CacheManager> cache_mgr_;
+  download::DownloadManager *download_mgr_;
+  uint64_t min_stream_size_;
+
+  pthread_mutex_t *lock_fd_table_;
+  SmallHashDynamic<int, FdInfo> fd_table_;
+};  // class StreamingCacheManager
+
+#endif  // CVMFS_CACHE_STREAM_H_

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -79,6 +79,11 @@ class StreamingCacheManager : public CacheManager {
     return cache_mgr_->StoreBreadcrumb(manifest);
   }
 
+ protected:
+  virtual void *DoSaveState();
+  virtual int DoRestoreState(void *data);
+  virtual bool DoFreeState(void *data);
+
  private:
   struct FdInfo {
     int fd_in_cache_mgr;
@@ -99,6 +104,14 @@ class StreamingCacheManager : public CacheManager {
     }
 
     bool IsValid() const { return fd_in_cache_mgr >= 0 || !object_id.IsNull(); }
+  };
+
+  struct SavedState {
+    explicit SavedState()
+      : version(0), fd_table(NULL), state_backing_cachemgr(NULL) { }
+    unsigned int version;
+    FdTable<FdInfo> *fd_table;
+    void *state_backing_cachemgr;
   };
 
   /// Depending on info.flags, selects either the regular or the external

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -59,11 +59,8 @@ class StreamingCacheManager : public CacheManager {
   virtual int StartTxn(const shash::Any &id, uint64_t size, void *txn) {
     return cache_mgr_->StartTxn(id, size, txn);
   }
-  virtual void CtrlTxn(const ObjectInfo &object_info,
-                       const int flags,
-                       void *txn)
-  {
-    cache_mgr_->CtrlTxn(object_info, flags, txn);
+  virtual void CtrlTxn(const Label &label, const int flags, void *txn) {
+    cache_mgr_->CtrlTxn(label, flags, txn);
   }
   virtual int64_t Write(const void *buf, uint64_t size, void *txn)
   {

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -81,16 +81,14 @@ class StreamingCacheManager : public CacheManager {
 
  private:
   struct FdInfo {
-    static const int kFlagExternal = 0x01;  ///< use external download manager
-
     int fd_in_cache_mgr;
-    int flags;
     shash::Any object_id;
+    CacheManager::Label label;
 
-    FdInfo() : fd_in_cache_mgr(-1), flags(0) {}
-    explicit FdInfo(int fd) : fd_in_cache_mgr(fd), flags(0) {}
-    FdInfo(const shash::Any &id, int f)
-      : fd_in_cache_mgr(-1), flags(f), object_id(id) {}
+    FdInfo() : fd_in_cache_mgr(-1) {}
+    explicit FdInfo(int fd) : fd_in_cache_mgr(fd) {}
+    explicit FdInfo(const CacheManager::LabeledObject &object)
+      : fd_in_cache_mgr(-1), object_id(object.id), label(object.label) {}
 
     bool operator ==(const FdInfo &other) const {
       return this->fd_in_cache_mgr == other.fd_in_cache_mgr &&

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -107,8 +107,7 @@ class StreamingCacheManager : public CacheManager {
   };
 
   struct SavedState {
-    explicit SavedState()
-      : version(0), fd_table(NULL), state_backing_cachemgr(NULL) { }
+    SavedState() : version(0), fd_table(NULL), state_backing_cachemgr(NULL) { }
     unsigned int version;
     FdTable<FdInfo> *fd_table;
     void *state_backing_cachemgr;

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -30,6 +30,13 @@ class StreamingCacheManager : public CacheManager {
                         download::DownloadManager *download_mgr);
   virtual ~StreamingCacheManager();
 
+  // In the files system / mountpoint initialization, we create the cache
+  // manager before we know about the download manager.  Hence we allow to
+  // patch in the download manager at a later point.
+  void SetDownloadManager(download::DownloadManager *download_mgr) {
+    download_mgr_ = download_mgr;
+  }
+
   virtual CacheManagerIds id() { return kStreamingCacheManager; }
   virtual std::string Describe();
 

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -46,7 +46,7 @@ class StreamingCacheManager : public CacheManager {
 
   virtual bool AcquireQuotaManager(QuotaManager *quota_mgr);
 
-  virtual int Open(const BlessedObject &object);
+  virtual int Open(const LabeledObject &object);
   virtual int64_t GetSize(int fd);
   virtual int Close(int fd);
   virtual int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset);

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -5,15 +5,14 @@
 #ifndef CVMFS_CACHE_STREAM_H_
 #define CVMFS_CACHE_STREAM_H_
 
-#include "cache.h"
-
 #include <pthread.h>
 
 #include <string>
 
-#include <crypto/hash.h>
-#include <fd_table.h>
-#include <util/pointer.h>
+#include "cache.h"
+#include "crypto/hash.h"
+#include "fd_table.h"
+#include "util/pointer.h"
 
 namespace download {
 class DownloadManager;
@@ -80,11 +79,9 @@ class StreamingCacheManager : public CacheManager {
     return cache_mgr_->StoreBreadcrumb(manifest);
   }
 
- protected:
-
  private:
   struct FdInfo {
-    const static int kFlagExternal = 0x01;  ///< use external download manager
+    static const int kFlagExternal = 0x01;  ///< use external download manager
 
     int fd_in_cache_mgr;
     int flags;
@@ -114,7 +111,7 @@ class StreamingCacheManager : public CacheManager {
   /// and its size is returned (-errno on error).
   /// The given section of the object is copied into the provided buffer,
   /// which may be NULL if only the size of the object is relevant.
-  int64_t Stream(FdInfo &info, void *buf, uint64_t size, uint64_t offset);
+  int64_t Stream(const FdInfo &info, void *buf, uint64_t size, uint64_t offset);
 
   UniquePtr<CacheManager> cache_mgr_;
   download::DownloadManager *regular_download_mgr_;

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -67,7 +67,7 @@ int TieredCacheManager::Open(const LabeledObject &object) {
     lower_->Close(fd2);
     return fd;
   }
-  upper_->CtrlTxn(object.info, 0, txn);
+  upper_->CtrlTxn(object.label, 0, txn);
 
   std::vector<char> m_buffer;
   m_buffer.resize(kCopyBufferSize);
@@ -134,15 +134,12 @@ CacheManager *TieredCacheManager::Create(
 }
 
 
-void TieredCacheManager::CtrlTxn(
-  const ObjectInfo &object_info,
-  const int flags,
-  void *txn)
+void TieredCacheManager::CtrlTxn(const Label &label, const int flags, void *txn)
 {
-  upper_->CtrlTxn(object_info, flags, txn);
+  upper_->CtrlTxn(label, flags, txn);
   if (!lower_readonly_) {
     void *txn2 = static_cast<char*>(txn) + upper_->SizeOfTxn();
-    lower_->CtrlTxn(object_info, flags, txn2);
+    lower_->CtrlTxn(label, flags, txn2);
   }
 }
 

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -48,7 +48,7 @@ void *TieredCacheManager::DoSaveState() {
 }
 
 
-int TieredCacheManager::Open(const BlessedObject &object) {
+int TieredCacheManager::Open(const LabeledObject &object) {
   int fd = upper_->Open(object);
   if ((fd >= 0) || (fd != -ENOENT)) {return fd;}
 

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -53,9 +53,7 @@ class TieredCacheManager : public CacheManager {
   virtual uint32_t SizeOfTxn()
   { return upper_->SizeOfTxn() + lower_->SizeOfTxn(); }
   virtual int StartTxn(const shash::Any &id, uint64_t size, void *txn);
-  virtual void CtrlTxn(const ObjectInfo &object_info,
-                       const int flags,
-                       void *txn);
+  virtual void CtrlTxn(const Label &label, const int flags, void *txn);
   virtual int64_t Write(const void *buf, uint64_t size, void *txn);
   virtual int Reset(void *txn);
   virtual int OpenFromTxn(void *txn) { return upper_->OpenFromTxn(txn); }

--- a/cvmfs/cache_tiered.h
+++ b/cvmfs/cache_tiered.h
@@ -42,7 +42,7 @@ class TieredCacheManager : public CacheManager {
     return result;
   }
 
-  virtual int Open(const BlessedObject &object);
+  virtual int Open(const LabeledObject &object);
   virtual int64_t GetSize(int fd) {return upper_->GetSize(fd);}
   virtual int Close(int fd) {return upper_->Close(fd);}
   virtual int64_t Pread(int fd, void *buf, uint64_t size, uint64_t offset)

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -321,24 +321,13 @@ void CacheTransport::FillMsgHash(
 
 
 void CacheTransport::FillObjectType(
-  CacheManager::ObjectType object_type,
-  cvmfs::EnumObjectType *wire_type)
+  int object_flags, cvmfs::EnumObjectType *wire_type)
 {
-  switch (object_type) {
-    case CacheManager::kTypeRegular:
-    // TODO(jblomer): "pinned" should mean a permanently open fd
-    case CacheManager::kTypePinned:
-      *wire_type = cvmfs::OBJECT_REGULAR;
-      break;
-    case CacheManager::kTypeCatalog:
-      *wire_type = cvmfs::OBJECT_CATALOG;
-      break;
-    case CacheManager::kTypeVolatile:
-      *wire_type = cvmfs::OBJECT_VOLATILE;
-      break;
-    default:
-      PANIC(NULL);
-  }
+  *wire_type = cvmfs::OBJECT_REGULAR;
+  if (object_flags & CacheManager::ObjectInfo::kLabelCatalog)
+    *wire_type = cvmfs::OBJECT_CATALOG;
+  if (object_flags & CacheManager::ObjectInfo::kLabelVolatile)
+    *wire_type = cvmfs::OBJECT_VOLATILE;
 }
 
 
@@ -368,18 +357,17 @@ bool CacheTransport::ParseMsgHash(
 
 
 bool CacheTransport::ParseObjectType(
-  cvmfs::EnumObjectType wire_type,
-  CacheManager::ObjectType *object_type)
+  cvmfs::EnumObjectType wire_type, int *object_flags)
 {
+  *object_flags = 0;
   switch (wire_type) {
     case cvmfs::OBJECT_REGULAR:
-      *object_type = CacheManager::kTypeRegular;
       return true;
     case cvmfs::OBJECT_CATALOG:
-      *object_type = CacheManager::kTypeCatalog;
+      *object_flags |= CacheManager::ObjectInfo::kLabelCatalog;
       return true;
     case cvmfs::OBJECT_VOLATILE:
-      *object_type = CacheManager::kTypeVolatile;
+      *object_flags |= CacheManager::ObjectInfo::kLabelVolatile;
       return true;
     default:
       return false;

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -324,9 +324,9 @@ void CacheTransport::FillObjectType(
   int object_flags, cvmfs::EnumObjectType *wire_type)
 {
   *wire_type = cvmfs::OBJECT_REGULAR;
-  if (object_flags & CacheManager::ObjectInfo::kLabelCatalog)
+  if (object_flags & CacheManager::kLabelCatalog)
     *wire_type = cvmfs::OBJECT_CATALOG;
-  if (object_flags & CacheManager::ObjectInfo::kLabelVolatile)
+  if (object_flags & CacheManager::kLabelVolatile)
     *wire_type = cvmfs::OBJECT_VOLATILE;
 }
 
@@ -364,10 +364,10 @@ bool CacheTransport::ParseObjectType(
     case cvmfs::OBJECT_REGULAR:
       return true;
     case cvmfs::OBJECT_CATALOG:
-      *object_flags |= CacheManager::ObjectInfo::kLabelCatalog;
+      *object_flags |= CacheManager::kLabelCatalog;
       return true;
     case cvmfs::OBJECT_VOLATILE:
-      *object_flags |= CacheManager::ObjectInfo::kLabelVolatile;
+      *object_flags |= CacheManager::kLabelVolatile;
       return true;
     default:
       return false;

--- a/cvmfs/cache_transport.h
+++ b/cvmfs/cache_transport.h
@@ -141,10 +141,8 @@ class CacheTransport {
 
   void FillMsgHash(const shash::Any &hash, cvmfs::MsgHash *msg_hash);
   bool ParseMsgHash(const cvmfs::MsgHash &msg_hash, shash::Any *hash);
-  void FillObjectType(CacheManager::ObjectType object_type,
-                      cvmfs::EnumObjectType *wire_type);
-  bool ParseObjectType(cvmfs::EnumObjectType wire_type,
-                       CacheManager::ObjectType *object_type);
+  void FillObjectType(int object_flags, cvmfs::EnumObjectType *wire_type);
+  bool ParseObjectType(cvmfs::EnumObjectType wire_type, int *object_flags);
 
   int fd_connection() const { return fd_connection_; }
 

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -240,9 +240,11 @@ LoadError ClientCatalogManager::LoadCatalog(
   *catalog_hash = ensemble.manifest->catalog_hash();
 
   // Store new manifest and certificate
-  fetcher_->cache_mgr()->CommitFromMem(ensemble.manifest->certificate(),
-                                       ensemble.cert_buf, ensemble.cert_size,
-                                       "certificate for " + repo_name_);
+  CacheManager::Label label;
+  label.description = "certificate for " + repo_name_;
+  fetcher_->cache_mgr()->CommitFromMem(
+    CacheManager::LabeledObject(ensemble.manifest->certificate(), label),
+    ensemble.cert_buf, ensemble.cert_size);
   fetcher_->cache_mgr()->StoreBreadcrumb(*ensemble.manifest);
   return catalog::kLoadNew;
 }

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -258,9 +258,11 @@ LoadError ClientCatalogManager::LoadCatalogCas(
   string *catalog_path)
 {
   assert(hash.suffix == shash::kSuffixCatalog);
-  int fd = fetcher_->Fetch(hash, CacheManager::kSizeUnknown, name,
-    zlib::kZlibDefault, CacheManager::kLabelCatalog,
-    alt_catalog_path);
+  CacheManager::Label label;
+  label.path = name;
+  label.flags = CacheManager::kLabelCatalog;
+  int fd = fetcher_->Fetch(CacheManager::LabeledObject(hash, label),
+                           alt_catalog_path);
   if (fd >= 0) {
     *catalog_path = "@" + StringifyInt(fd);
     return kLoadNew;

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -256,7 +256,8 @@ LoadError ClientCatalogManager::LoadCatalogCas(
 {
   assert(hash.suffix == shash::kSuffixCatalog);
   int fd = fetcher_->Fetch(hash, CacheManager::kSizeUnknown, name,
-    zlib::kZlibDefault, CacheManager::kTypeCatalog, alt_catalog_path);
+    zlib::kZlibDefault, CacheManager::ObjectInfo::kLabelCatalog,
+    alt_catalog_path);
   if (fd >= 0) {
     *catalog_path = "@" + StringifyInt(fd);
     return kLoadNew;

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -241,7 +241,8 @@ LoadError ClientCatalogManager::LoadCatalog(
 
   // Store new manifest and certificate
   CacheManager::Label label;
-  label.description = "certificate for " + repo_name_;
+  label.path = repo_name_;
+  label.flags |= CacheManager::kLabelCertificate;
   fetcher_->cache_mgr()->CommitFromMem(
     CacheManager::LabeledObject(ensemble.manifest->certificate(), label),
     ensemble.cert_buf, ensemble.cert_size);
@@ -333,7 +334,8 @@ bool ClientCatalogManager::IsRevisionBlacklisted() {
 
 void CachedManifestEnsemble::FetchCertificate(const shash::Any &hash) {
   CacheManager::Label label;
-  label.description = "certificate for " + catalog_mgr_->repo_name();
+  label.flags |= CacheManager::kLabelCertificate;
+  label.path = catalog_mgr_->repo_name();
   uint64_t size;
   bool retval = cache_mgr_->Open2Mem(CacheManager::LabeledObject(hash, label),
                                      &cert_buf, &size);

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -256,7 +256,7 @@ LoadError ClientCatalogManager::LoadCatalogCas(
 {
   assert(hash.suffix == shash::kSuffixCatalog);
   int fd = fetcher_->Fetch(hash, CacheManager::kSizeUnknown, name,
-    zlib::kZlibDefault, CacheManager::ObjectInfo::kLabelCatalog,
+    zlib::kZlibDefault, CacheManager::kLabelCatalog,
     alt_catalog_path);
   if (fd >= 0) {
     *catalog_path = "@" + StringifyInt(fd);

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -112,7 +112,7 @@ LoadError ClientCatalogManager::LoadCatalog(
   std::string *catalog_path,
   shash::Any *catalog_hash)
 {
-  string cvmfs_path = "file catalog at " + repo_name_ + ":" +
+  string cvmfs_path = repo_name_ + ":" +
     (mountpoint.IsEmpty() ?
       "/" : string(mountpoint.GetChars(), mountpoint.GetLength()));
 

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -330,9 +330,11 @@ bool ClientCatalogManager::IsRevisionBlacklisted() {
 
 
 void CachedManifestEnsemble::FetchCertificate(const shash::Any &hash) {
+  CacheManager::Label label;
+  label.description = "certificate for " + catalog_mgr_->repo_name();
   uint64_t size;
-  bool retval = cache_mgr_->Open2Mem(
-    hash, "certificate for " + catalog_mgr_->repo_name(), &cert_buf, &size);
+  bool retval = cache_mgr_->Open2Mem(CacheManager::LabeledObject(hash, label),
+                                     &cert_buf, &size);
   cert_size = size;
   if (retval)
     perf::Inc(catalog_mgr_->n_certificate_hits_);

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1266,13 +1266,16 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   Fetcher *this_fetcher = dirent.IsExternalFile()
     ? mount_point_->external_fetcher()
     : mount_point_->fetcher();
-  fd = this_fetcher->Fetch(
-    dirent.checksum(),
-    dirent.size(),
-    string(path.GetChars(), path.GetLength()),
-    dirent.compression_algorithm(),
-    mount_point_->catalog_mgr()->volatile_flag()
-      ? CacheManager::kLabelVolatile : 0);
+  CacheManager::Label label;
+  label.path = path.GetChars(), path.GetLength();
+  label.size = dirent.size();
+  label.zip_algorithm = dirent.compression_algorithm();
+  if (mount_point_->catalog_mgr()->volatile_flag())
+    label.flags |= CacheManager::kLabelVolatile;
+  if (dirent.IsExternalFile())
+    label.flags |= CacheManager::kLabelExternal;
+  fd =
+    this_fetcher->Fetch(CacheManager::LabeledObject(dirent.checksum(), label));
 
   if (fd >= 0) {
     if (perf::Xadd(file_system_->no_open_files(), 1) <
@@ -1385,28 +1388,22 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
       // Open file descriptor to chunk
       if ((chunk_fd.fd == -1) || (chunk_fd.chunk_idx != chunk_idx)) {
         if (chunk_fd.fd != -1) file_system_->cache_mgr()->Close(chunk_fd.fd);
-        string verbose_path = "Part of " + chunks.path.ToString();
+        Fetcher *this_fetcher = chunks.external_data
+          ? mount_point_->external_fetcher()
+          : mount_point_->fetcher();
+        CacheManager::Label label;
+        label.path = chunks.path.ToString();
+        label.size = chunks.list->AtPtr(chunk_idx)->size();
+        label.zip_algorithm = chunks.compression_alg;
+        label.flags |= CacheManager::kLabelChunked;
+        if (mount_point_->catalog_mgr()->volatile_flag())
+          label.flags |= CacheManager::kLabelVolatile;
         if (chunks.external_data) {
-          chunk_fd.fd = mount_point_->external_fetcher()->Fetch(
-            chunks.list->AtPtr(chunk_idx)->content_hash(),
-            chunks.list->AtPtr(chunk_idx)->size(),
-            verbose_path,
-            chunks.compression_alg,
-            mount_point_->catalog_mgr()->volatile_flag()
-              ? CacheManager::kLabelVolatile
-              : 0,
-            chunks.path.ToString(),
-            chunks.list->AtPtr(chunk_idx)->offset());
-        } else {
-          chunk_fd.fd = mount_point_->fetcher()->Fetch(
-            chunks.list->AtPtr(chunk_idx)->content_hash(),
-            chunks.list->AtPtr(chunk_idx)->size(),
-            verbose_path,
-            chunks.compression_alg,
-            mount_point_->catalog_mgr()->volatile_flag()
-              ? CacheManager::kLabelVolatile
-              : 0);
+          label.flags |= CacheManager::kLabelExternal;
+          label.range_offset = chunks.list->AtPtr(chunk_idx)->offset();
         }
+        chunk_fd.fd = this_fetcher->Fetch(CacheManager::LabeledObject(
+          chunks.list->AtPtr(chunk_idx)->content_hash(), label));
         if (chunk_fd.fd < 0) {
           chunk_fd.fd = -1;
           chunk_tables->Lock();
@@ -1836,6 +1833,10 @@ bool Pin(const string &path) {
     return false;
   }
 
+  Fetcher *this_fetcher = dirent.IsExternalFile()
+    ? mount_point_->external_fetcher()
+    : mount_point_->fetcher();
+
   if (!dirent.IsChunkedFile()) {
     fuse_remounter_->fence()->Leave();
   } else {
@@ -1853,23 +1854,18 @@ bool Pin(const string &path) {
       if (!retval)
         return false;
       int fd = -1;
+      CacheManager::Label label;
+      label.path = path;
+      label.size = chunks.AtPtr(i)->size();
+      label.zip_algorithm = dirent.compression_algorithm();
+      label.flags |= CacheManager::kLabelPinned;
+      label.flags |= CacheManager::kLabelChunked;
       if (dirent.IsExternalFile()) {
-        fd = mount_point_->external_fetcher()->Fetch(
-          chunks.AtPtr(i)->content_hash(),
-          chunks.AtPtr(i)->size(),
-          "Part of " + path,
-          dirent.compression_algorithm(),
-          CacheManager::kLabelPinned,
-          path,
-          chunks.AtPtr(i)->offset());
-      } else {
-        fd = mount_point_->fetcher()->Fetch(
-          chunks.AtPtr(i)->content_hash(),
-          chunks.AtPtr(i)->size(),
-          "Part of " + path,
-          dirent.compression_algorithm(),
-          CacheManager::kLabelPinned);
+        label.flags |= CacheManager::kLabelExternal;
+        label.range_offset = chunks.AtPtr(i)->offset();
       }
+      fd = this_fetcher->Fetch(CacheManager::LabeledObject(
+        chunks.AtPtr(i)->content_hash(), label));
       if (fd < 0) {
         return false;
       }
@@ -1882,12 +1878,13 @@ bool Pin(const string &path) {
     dirent.checksum(), dirent.size(), path, false);
   if (!retval)
     return false;
-  Fetcher *this_fetcher = dirent.IsExternalFile()
-    ? mount_point_->external_fetcher()
-    : mount_point_->fetcher();
+  CacheManager::Label label;
+  label.flags = CacheManager::kLabelPinned;
+  label.size = dirent.size();
+  label.path = path;
+  label.zip_algorithm = dirent.compression_algorithm();
   int fd = this_fetcher->Fetch(
-    dirent.checksum(), dirent.size(), path, dirent.compression_algorithm(),
-    CacheManager::kLabelPinned);
+    CacheManager::LabeledObject(dirent.checksum(), label));
   if (fd < 0) {
     return false;
   }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1272,7 +1272,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     string(path.GetChars(), path.GetLength()),
     dirent.compression_algorithm(),
     mount_point_->catalog_mgr()->volatile_flag()
-      ? CacheManager::ObjectInfo::kLabelVolatile : 0);
+      ? CacheManager::kLabelVolatile : 0);
 
   if (fd >= 0) {
     if (perf::Xadd(file_system_->no_open_files(), 1) <
@@ -1393,7 +1393,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
             verbose_path,
             chunks.compression_alg,
             mount_point_->catalog_mgr()->volatile_flag()
-              ? CacheManager::ObjectInfo::kLabelVolatile
+              ? CacheManager::kLabelVolatile
               : 0,
             chunks.path.ToString(),
             chunks.list->AtPtr(chunk_idx)->offset());
@@ -1404,7 +1404,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
             verbose_path,
             chunks.compression_alg,
             mount_point_->catalog_mgr()->volatile_flag()
-              ? CacheManager::ObjectInfo::kLabelVolatile
+              ? CacheManager::kLabelVolatile
               : 0);
         }
         if (chunk_fd.fd < 0) {
@@ -1859,7 +1859,7 @@ bool Pin(const string &path) {
           chunks.AtPtr(i)->size(),
           "Part of " + path,
           dirent.compression_algorithm(),
-          CacheManager::ObjectInfo::kLabelPinned,
+          CacheManager::kLabelPinned,
           path,
           chunks.AtPtr(i)->offset());
       } else {
@@ -1868,7 +1868,7 @@ bool Pin(const string &path) {
           chunks.AtPtr(i)->size(),
           "Part of " + path,
           dirent.compression_algorithm(),
-          CacheManager::ObjectInfo::kLabelPinned);
+          CacheManager::kLabelPinned);
       }
       if (fd < 0) {
         return false;
@@ -1887,7 +1887,7 @@ bool Pin(const string &path) {
     : mount_point_->fetcher();
   int fd = this_fetcher->Fetch(
     dirent.checksum(), dirent.size(), path, dirent.compression_algorithm(),
-    CacheManager::ObjectInfo::kLabelPinned);
+    CacheManager::kLabelPinned);
   if (fd < 0) {
     return false;
   }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1272,8 +1272,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     string(path.GetChars(), path.GetLength()),
     dirent.compression_algorithm(),
     mount_point_->catalog_mgr()->volatile_flag()
-      ? CacheManager::kTypeVolatile
-      : CacheManager::kTypeRegular);
+      ? CacheManager::ObjectInfo::kLabelVolatile : 0);
 
   if (fd >= 0) {
     if (perf::Xadd(file_system_->no_open_files(), 1) <
@@ -1394,8 +1393,8 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
             verbose_path,
             chunks.compression_alg,
             mount_point_->catalog_mgr()->volatile_flag()
-              ? CacheManager::kTypeVolatile
-              : CacheManager::kTypeRegular,
+              ? CacheManager::ObjectInfo::kLabelVolatile
+              : 0,
             chunks.path.ToString(),
             chunks.list->AtPtr(chunk_idx)->offset());
         } else {
@@ -1405,8 +1404,8 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
             verbose_path,
             chunks.compression_alg,
             mount_point_->catalog_mgr()->volatile_flag()
-              ? CacheManager::kTypeVolatile
-              : CacheManager::kTypeRegular);
+              ? CacheManager::ObjectInfo::kLabelVolatile
+              : 0);
         }
         if (chunk_fd.fd < 0) {
           chunk_fd.fd = -1;
@@ -1860,7 +1859,7 @@ bool Pin(const string &path) {
           chunks.AtPtr(i)->size(),
           "Part of " + path,
           dirent.compression_algorithm(),
-          CacheManager::kTypePinned,
+          CacheManager::ObjectInfo::kLabelPinned,
           path,
           chunks.AtPtr(i)->offset());
       } else {
@@ -1869,7 +1868,7 @@ bool Pin(const string &path) {
           chunks.AtPtr(i)->size(),
           "Part of " + path,
           dirent.compression_algorithm(),
-          CacheManager::kTypePinned);
+          CacheManager::ObjectInfo::kLabelPinned);
       }
       if (fd < 0) {
         return false;
@@ -1888,7 +1887,7 @@ bool Pin(const string &path) {
     : mount_point_->fetcher();
   int fd = this_fetcher->Fetch(
     dirent.checksum(), dirent.size(), path, dirent.compression_algorithm(),
-    CacheManager::kTypePinned);
+    CacheManager::ObjectInfo::kLabelPinned);
   if (fd < 0) {
     return false;
   }

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -271,7 +271,7 @@ int Fetcher::OpenSelect(
   if (is_catalog || (object_type == CacheManager::kTypePinned)) {
     return cache_mgr_->OpenPinned(id, name, is_catalog);
   } else {
-    return cache_mgr_->Open(CacheManager::Bless(id, object_type, name));
+    return cache_mgr_->Open(CacheManager::Label(id, object_type, name));
   }
 }
 

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -270,13 +270,14 @@ int Fetcher::OpenSelect(
   const std::string &name,
   int object_flags)
 {
+  CacheManager::Label label;
+  label.flags = object_flags;
+  label.description = name;
   bool is_catalog = object_flags & CacheManager::kLabelCatalog;
   if (is_catalog || (object_flags & CacheManager::kLabelPinned)) {
-    return cache_mgr_->OpenPinned(id, name, is_catalog);
+    label.flags |= CacheManager::kLabelPinned;
+    return cache_mgr_->OpenPinned(CacheManager::LabeledObject(id, label));
   } else {
-    CacheManager::Label label;
-    label.flags = object_flags;
-    label.description = name;
     return cache_mgr_->Open(CacheManager::LabeledObject(id, label));
   }
 }

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -274,7 +274,10 @@ int Fetcher::OpenSelect(
   if (is_catalog || (object_flags & CacheManager::ObjectInfo::kLabelPinned)) {
     return cache_mgr_->OpenPinned(id, name, is_catalog);
   } else {
-    return cache_mgr_->Open(CacheManager::Label(id, object_flags, name));
+    CacheManager::ObjectInfo object_info;
+    object_info.flags = object_flags;
+    object_info.description = name;
+    return cache_mgr_->Open(CacheManager::LabeledObject(id, object_info));
   }
 }
 

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -155,7 +155,7 @@ int Fetcher::Fetch(
   }
   CacheManager::Label label;
   label.flags = object_flags;
-  label.description = name;
+  label.path = name;
   cache_mgr_->CtrlTxn(label, 0, txn);
 
   LogCvmfs(kLogCache, kLogDebug, "miss: %s %s", name.c_str(), url.c_str());
@@ -272,7 +272,7 @@ int Fetcher::OpenSelect(
 {
   CacheManager::Label label;
   label.flags = object_flags;
-  label.description = name;
+  label.path = name;
   bool is_catalog = object_flags & CacheManager::kLabelCatalog;
   if (is_catalog || (object_flags & CacheManager::kLabelPinned)) {
     label.flags |= CacheManager::kLabelPinned;

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -153,10 +153,10 @@ int Fetcher::Fetch(
     SignalWaitingThreads(retval, id, tls);
     return retval;
   }
-  CacheManager::ObjectInfo object_info;
-  object_info.flags = object_flags;
-  object_info.description = name;
-  cache_mgr_->CtrlTxn(object_info, 0, txn);
+  CacheManager::Label label;
+  label.flags = object_flags;
+  label.description = name;
+  cache_mgr_->CtrlTxn(label, 0, txn);
 
   LogCvmfs(kLogCache, kLogDebug, "miss: %s %s", name.c_str(), url.c_str());
   TransactionSink sink(cache_mgr_, txn);
@@ -270,14 +270,14 @@ int Fetcher::OpenSelect(
   const std::string &name,
   int object_flags)
 {
-  bool is_catalog = object_flags & CacheManager::ObjectInfo::kLabelCatalog;
-  if (is_catalog || (object_flags & CacheManager::ObjectInfo::kLabelPinned)) {
+  bool is_catalog = object_flags & CacheManager::kLabelCatalog;
+  if (is_catalog || (object_flags & CacheManager::kLabelPinned)) {
     return cache_mgr_->OpenPinned(id, name, is_catalog);
   } else {
-    CacheManager::ObjectInfo object_info;
-    object_info.flags = object_flags;
-    object_info.description = name;
-    return cache_mgr_->Open(CacheManager::LabeledObject(id, object_info));
+    CacheManager::Label label;
+    label.flags = object_flags;
+    label.description = name;
+    return cache_mgr_->Open(CacheManager::LabeledObject(id, label));
   }
 }
 

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -79,13 +79,8 @@ Fetcher::ThreadLocalStorage *Fetcher::GetTls() {
 
 
 int Fetcher::Fetch(
-  const shash::Any &id,
-  const uint64_t size,
-  const std::string &name,
-  const zlib::Algorithms compression_algorithm,
-  const int object_flags,
-  const std::string &alt_url,
-  off_t range_offset)
+  const CacheManager::LabeledObject &object,
+  const std::string &alt_url)
 {
   int fd_return;  // Read-only file descriptor that is returned
   int retval;
@@ -93,12 +88,12 @@ int Fetcher::Fetch(
   perf::Inc(n_invocations);
 
   // Try to open from local cache
-  if ((fd_return = OpenSelect(id, name, object_flags)) >= 0) {
-    LogCvmfs(kLogCache, kLogDebug, "hit: %s", name.c_str());
+  if ((fd_return = OpenSelect(object)) >= 0) {
+    LogCvmfs(kLogCache, kLogDebug, "hit: %s", object.label.path.c_str());
     return fd_return;
   }
 
-  if (id.IsNull()) {
+  if (object.id.IsNull()) {
     // This has been seen when trying to load the root catalog signed by an
     // invalid certificate on an empty cache
     // TODO(jblomer): check if still necessary after the catalog reload refactor
@@ -111,59 +106,58 @@ int Fetcher::Fetch(
   // Synchronization point: either act as a master thread for this object or
   // enqueue to the list of waiting threads.
   pthread_mutex_lock(lock_queues_download_);
-  ThreadQueues::iterator iDownloadQueue = queues_download_.find(id);
+  ThreadQueues::iterator iDownloadQueue = queues_download_.find(object.id);
   if (iDownloadQueue != queues_download_.end()) {
-    LogCvmfs(kLogCache, kLogDebug, "waiting for download of %s", name.c_str());
+    LogCvmfs(kLogCache, kLogDebug, "waiting for download of %s",
+             object.label.path.c_str());
 
     iDownloadQueue->second->push_back(tls->pipe_wait[1]);
     pthread_mutex_unlock(lock_queues_download_);
     ReadPipe(tls->pipe_wait[0], &fd_return, sizeof(int));
 
     LogCvmfs(kLogCache, kLogDebug, "received from another thread fd %d for %s",
-             fd_return, name.c_str());
+             fd_return, object.label.path.c_str());
     return fd_return;
   } else {
     // Seems we are the first one, check again in the cache (race condition)
-    fd_return = OpenSelect(id, name, object_flags);
+    fd_return = OpenSelect(object);
     if (fd_return >= 0) {
       pthread_mutex_unlock(lock_queues_download_);
       return fd_return;
     }
 
     // Create a new queue for this chunk
-    queues_download_[id] = &tls->other_pipes_waiting;
+    queues_download_[object.id] = &tls->other_pipes_waiting;
     pthread_mutex_unlock(lock_queues_download_);
   }
 
   perf::Inc(n_downloads);
 
   // Involve the download manager
-  LogCvmfs(kLogCache, kLogDebug, "downloading %s", name.c_str());
+  LogCvmfs(kLogCache, kLogDebug, "downloading %s", object.label.path.c_str());
   std::string url;
-  if (external_) {
-    url = !alt_url.empty() ? alt_url : name;
+  if (object.label.IsExternal()) {
+    url = !alt_url.empty() ? alt_url : object.label.path;
   } else {
-    url = "/" + (alt_url.size() ? alt_url : "data/" + id.MakePath());
+    url = "/" + (alt_url.size() ? alt_url : "data/" + object.id.MakePath());
   }
   void *txn = alloca(cache_mgr_->SizeOfTxn());
-  retval = cache_mgr_->StartTxn(id, size, txn);
+  retval = cache_mgr_->StartTxn(object.id, object.label.size, txn);
   if (retval < 0) {
     LogCvmfs(kLogCache, kLogDebug, "could not start transaction on %s",
-             name.c_str());
-    SignalWaitingThreads(retval, id, tls);
+             object.label.path.c_str());
+    SignalWaitingThreads(retval, object.id, tls);
     return retval;
   }
-  CacheManager::Label label;
-  label.flags = object_flags;
-  label.path = name;
-  cache_mgr_->CtrlTxn(label, 0, txn);
+  cache_mgr_->CtrlTxn(object.label, 0, txn);
 
-  LogCvmfs(kLogCache, kLogDebug, "miss: %s %s", name.c_str(), url.c_str());
+  LogCvmfs(kLogCache, kLogDebug, "miss: %s %s",
+           object.label.path.c_str(), url.c_str());
   TransactionSink sink(cache_mgr_, txn);
   tls->download_job.url = &url;
   tls->download_job.sink = &sink;
-  tls->download_job.expected_hash = &id;
-  tls->download_job.extra_info = &name;
+  tls->download_job.expected_hash = &object.id;
+  tls->download_job.extra_info = &object.label.path;
   ClientCtx *ctx = ClientCtx::GetInstance();
   if (ctx->IsSet()) {
     ctx->Get(&tls->download_job.uid,
@@ -171,9 +165,10 @@ int Fetcher::Fetch(
              &tls->download_job.pid,
              &tls->download_job.interrupt_cue);
   }
-  tls->download_job.compressed = (compression_algorithm == zlib::kZlibDefault);
-  tls->download_job.range_offset = range_offset;
-  tls->download_job.range_size = size;
+  tls->download_job.compressed =
+    (object.label.zip_algorithm == zlib::kZlibDefault);
+  tls->download_job.range_offset = object.label.range_offset;
+  tls->download_job.range_size = object.label.size;
   download_mgr_->Fetch(&tls->download_job);
 
   if (tls->download_job.error_code == download::kFailOk) {
@@ -182,28 +177,30 @@ int Fetcher::Fetch(
     fd_return = cache_mgr_->OpenFromTxn(txn);
     if (fd_return < 0) {
       cache_mgr_->AbortTxn(txn);
-      SignalWaitingThreads(fd_return, id, tls);
+      SignalWaitingThreads(fd_return, object.id, tls);
       return fd_return;
     }
 
     retval = cache_mgr_->CommitTxn(txn);
     if (retval < 0) {
       cache_mgr_->Close(fd_return);
-      SignalWaitingThreads(retval, id, tls);
+      SignalWaitingThreads(retval, object.id, tls);
       return retval;
     }
-    SignalWaitingThreads(fd_return, id, tls);
+    SignalWaitingThreads(fd_return, object.id, tls);
     return fd_return;
   }
 
   // Download failed
   LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
-           "failed to fetch %s (hash: %s, error %d [%s])", name.c_str(),
-           id.ToString().c_str(), tls->download_job.error_code,
+           "failed to fetch %s (hash: %s, error %d [%s])",
+           object.label.path.c_str(),
+           object.id.ToString().c_str(),
+           tls->download_job.error_code,
            download::Code2Ascii(tls->download_job.error_code));
   cache_mgr_->AbortTxn(txn);
   backoff_throttle_->Throttle();
-  SignalWaitingThreads(-EIO, id, tls);
+  SignalWaitingThreads(-EIO, object.id, tls);
   return -EIO;
 }
 
@@ -212,10 +209,8 @@ Fetcher::Fetcher(
   CacheManager *cache_mgr,
   download::DownloadManager *download_mgr,
   BackoffThrottle *backoff_throttle,
-  perf::StatisticsTemplate statistics,
-  bool external)
-  : external_(external)
-  , lock_queues_download_(NULL)
+  perf::StatisticsTemplate statistics)
+  : lock_queues_download_(NULL)
   , lock_tls_blocks_(NULL)
   , cache_mgr_(cache_mgr)
   , download_mgr_(download_mgr)
@@ -265,20 +260,11 @@ Fetcher::~Fetcher() {
  * Depending on the object type, uses either Open() or OpenPinned() from the
  * cache manager
  */
-int Fetcher::OpenSelect(
-  const shash::Any &id,
-  const std::string &name,
-  int object_flags)
-{
-  CacheManager::Label label;
-  label.flags = object_flags;
-  label.path = name;
-  bool is_catalog = object_flags & CacheManager::kLabelCatalog;
-  if (is_catalog || (object_flags & CacheManager::kLabelPinned)) {
-    label.flags |= CacheManager::kLabelPinned;
-    return cache_mgr_->OpenPinned(CacheManager::LabeledObject(id, label));
+int Fetcher::OpenSelect(const CacheManager::LabeledObject &object) {
+  if (object.label.IsCatalog() || object.label.IsPinned()) {
+    return cache_mgr_->OpenPinned(object);
   } else {
-    return cache_mgr_->Open(CacheManager::LabeledObject(id, label));
+    return cache_mgr_->Open(object);
   }
 }
 

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -168,7 +168,7 @@ int Fetcher::Fetch(
   tls->download_job.compressed =
     (object.label.zip_algorithm == zlib::kZlibDefault);
   tls->download_job.range_offset = object.label.range_offset;
-  tls->download_job.range_size = object.label.size;
+  tls->download_job.range_size = static_cast<int64_t>(object.label.size);
   download_mgr_->Fetch(&tls->download_job);
 
   if (tls->download_job.error_code == download::kFailOk) {

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -115,17 +115,11 @@ class Fetcher : SingleCopy {
   Fetcher(CacheManager *cache_mgr,
           download::DownloadManager *download_mgr,
           BackoffThrottle *backoff_throttle,
-          perf::StatisticsTemplate statistics,
-          bool external_data = false);
+          perf::StatisticsTemplate statistics);
   ~Fetcher();
-  // TODO(jblomer): reduce number of arguments
-  int Fetch(const shash::Any &id,
-            const uint64_t size,
-            const std::string &name,
-            const zlib::Algorithms compression_algorithm,
-            const int object_flags,
-            const std::string &alt_url = "",
-            off_t range_offset = -1);
+
+  int Fetch(const CacheManager::LabeledObject &object,
+            const std::string &alt_url = "");
 
   CacheManager *cache_mgr() { return cache_mgr_; }
   download::DownloadManager *download_mgr() { return download_mgr_; }
@@ -176,16 +170,7 @@ class Fetcher : SingleCopy {
   void CleanupTls(ThreadLocalStorage *tls);
   void SignalWaitingThreads(const int fd, const shash::Any &id,
                             ThreadLocalStorage *tls);
-  int OpenSelect(const shash::Any &id,
-                 const std::string &name,
-                 int object_flags);
-
-  /**
-   * If set to true, this fetcher is in 'external data' mode:
-   * instead of constructing the to-be-downloaded URL from the entry hash,
-   * it will use the filename.
-   */
-  bool external_;
+  int OpenSelect(const CacheManager::LabeledObject &object);
 
   /**
    * Key to the thread's ThreadLocalStorage memory

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -40,7 +40,7 @@ class TransactionSink : public Sink {
 
   /**
    * Appends data to the sink
-   * 
+   *
    * @returns on success: number of bytes written (can be less than requested)
    *          on failure: -errno.
    */
@@ -50,7 +50,7 @@ class TransactionSink : public Sink {
 
   /**
    * Truncate all written data and start over at position zero.
-   * 
+   *
    * @returns Success = 0
    *          Failure = -errno
    */
@@ -62,7 +62,7 @@ class TransactionSink : public Sink {
    * Purges all resources leaving the sink in an invalid state.
    * More aggressive version of Reset().
    * For some sinks it might do the same as Reset().
-   * 
+   *
    * @returns Success = 0
    *          Failure = -errno
    */
@@ -123,7 +123,7 @@ class Fetcher : SingleCopy {
             const uint64_t size,
             const std::string &name,
             const zlib::Algorithms compression_algorithm,
-            const CacheManager::ObjectType object_type,
+            const int object_flags,
             const std::string &alt_url = "",
             off_t range_offset = -1);
 
@@ -178,7 +178,7 @@ class Fetcher : SingleCopy {
                             ThreadLocalStorage *tls);
   int OpenSelect(const shash::Any &id,
                  const std::string &name,
-                 const CacheManager::ObjectType object_type);
+                 int object_flags);
 
   /**
    * If set to true, this fetcher is in 'external data' mode:

--- a/cvmfs/kvstore.cc
+++ b/cvmfs/kvstore.cc
@@ -295,7 +295,7 @@ int MemoryKvStore::DoCommit(const MemoryBuffer &buf) {
     // refcount (starting at 1 for pinning, for example)
     mem.refcount = buf.refcount;
   }
-  mem.object_type = buf.object_type;
+  mem.object_flags = buf.object_flags;
   mem.id = buf.id;
   mem.size = buf.size;
   if (entry_count_ == max_entries_) {

--- a/cvmfs/kvstore.h
+++ b/cvmfs/kvstore.h
@@ -42,12 +42,12 @@ struct MemoryBuffer {
     : address(NULL)
     , size(0)
     , refcount(0)
-    , object_type(CacheManager::kTypeRegular)
+    , object_flags(0)
     , id() {}
   void *address;
   size_t size;
   unsigned int refcount;
-  CacheManager::ObjectType object_type;
+  int object_flags;
   shash::Any id;
 };
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -655,7 +655,7 @@ int64_t LibContext::Pread(
         label.size = chunk_list->AtPtr(chunk_idx)->size();
         label.zip_algorithm = compression_alg;
         label.flags |= CacheManager::kLabelChunked;
-        if ( open_chunks.chunk_reflist.external_data) {
+        if (open_chunks.chunk_reflist.external_data) {
           label.flags |= CacheManager::kLabelExternal;
           label.range_offset = chunk_list->AtPtr(chunk_idx)->offset();
         }

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -591,12 +591,14 @@ int LibContext::Open(const char *c_path) {
   cvmfs::Fetcher *this_fetcher = dirent.IsExternalFile()
     ? mount_point_->external_fetcher()
     : mount_point_->fetcher();
-  fd = this_fetcher->Fetch(
-    dirent.checksum(),
-    dirent.size(),
-    string(path.GetChars(), path.GetLength()),
-    dirent.compression_algorithm(),
-    0);
+  CacheManager::Label label;
+  label.path = std::string(path.GetChars(), path.GetLength());
+  label.size = dirent.size();
+  label.zip_algorithm = dirent.compression_algorithm();
+  if (dirent.IsExternalFile())
+    label.flags |= CacheManager::kLabelExternal;
+  fd =
+    this_fetcher->Fetch(CacheManager::LabeledObject(dirent.checksum(), label));
   perf::Inc(file_system()->n_fs_open());
 
   if (fd >= 0) {
@@ -644,23 +646,21 @@ int64_t LibContext::Pread(
       ChunkFd *chunk_fd = open_chunks.chunk_fd;
       if ((chunk_fd->fd == -1) || (chunk_fd->chunk_idx != chunk_idx)) {
         if (chunk_fd->fd != -1) file_system()->cache_mgr()->Close(chunk_fd->fd);
-        if (open_chunks.chunk_reflist.external_data) {
-          chunk_fd->fd = mount_point_->external_fetcher()->Fetch(
-            chunk_list->AtPtr(chunk_idx)->content_hash(),
-            chunk_list->AtPtr(chunk_idx)->size(),
-            "no path info",
-            compression_alg,
-            0,
-            open_chunks.chunk_reflist.path.ToString(),
-            chunk_list->AtPtr(chunk_idx)->offset());
-        } else {
-          chunk_fd->fd = mount_point_->fetcher()->Fetch(
-            chunk_list->AtPtr(chunk_idx)->content_hash(),
-            chunk_list->AtPtr(chunk_idx)->size(),
-            "no path info",
-            compression_alg,
-            0);
+        cvmfs::Fetcher *this_fetcher = open_chunks.chunk_reflist.external_data
+          ? mount_point_->external_fetcher()
+          : mount_point_->fetcher();
+        CacheManager::Label label;
+        label.path = std::string(open_chunks.chunk_reflist.path.GetChars(),
+                                 open_chunks.chunk_reflist.path.GetLength());
+        label.size = chunk_list->AtPtr(chunk_idx)->size();
+        label.zip_algorithm = compression_alg;
+        label.flags |= CacheManager::kLabelChunked;
+        if ( open_chunks.chunk_reflist.external_data) {
+          label.flags |= CacheManager::kLabelExternal;
+          label.range_offset = chunk_list->AtPtr(chunk_idx)->offset();
         }
+        chunk_fd->fd = this_fetcher->Fetch(CacheManager::LabeledObject(
+          chunk_list->AtPtr(chunk_idx)->content_hash(), label));
         if (chunk_fd->fd < 0) {
           chunk_fd->fd = -1;
           return -EIO;

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -596,7 +596,7 @@ int LibContext::Open(const char *c_path) {
     dirent.size(),
     string(path.GetChars(), path.GetLength()),
     dirent.compression_algorithm(),
-    CacheManager::kTypeRegular);
+    0);
   perf::Inc(file_system()->n_fs_open());
 
   if (fd >= 0) {
@@ -650,7 +650,7 @@ int64_t LibContext::Pread(
             chunk_list->AtPtr(chunk_idx)->size(),
             "no path info",
             compression_alg,
-            CacheManager::kTypeRegular,
+            0,
             open_chunks.chunk_reflist.path.ToString(),
             chunk_list->AtPtr(chunk_idx)->offset());
         } else {
@@ -659,7 +659,7 @@ int64_t LibContext::Pread(
             chunk_list->AtPtr(chunk_idx)->size(),
             "no path info",
             compression_alg,
-            CacheManager::kTypeRegular);
+            0);
         }
         if (chunk_fd->fd < 0) {
           chunk_fd->fd = -1;

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -381,7 +381,7 @@ std::string LHashMagicXattr::GetValue() {
   if (xattr_mgr_->mount_point()->catalog_mgr()->volatile_flag())
     object_info.type = CacheManager::kTypeVolatile;
   int fd = xattr_mgr_->mount_point()->file_system()->cache_mgr()->Open(
-    CacheManager::Bless(dirent_->checksum(), object_info));
+    CacheManager::Label(dirent_->checksum(), object_info));
   if (fd < 0) {
     result = "Not in cache";
   } else {

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -377,7 +377,7 @@ bool LHashMagicXattr::PrepareValueFenced() {
 std::string LHashMagicXattr::GetValue() {
   string result;
   CacheManager::Label label;
-  label.description = path_.ToString();
+  label.path = path_.ToString();
   if (xattr_mgr_->mount_point()->catalog_mgr()->volatile_flag())
     label.flags = CacheManager::kLabelVolatile;
   int fd = xattr_mgr_->mount_point()->file_system()->cache_mgr()->Open(

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -553,10 +553,12 @@ std::string RepoMetainfoMagicXattr::GetValue() {
     return error_reason_;
   }
 
-  int fd = xattr_mgr_->mount_point()->fetcher()->
-            Fetch(metainfo_hash_, CacheManager::kSizeUnknown,
-                  "metainfo (" + metainfo_hash_.ToString() + ")",
-                  zlib::kZlibDefault, 0, "");
+  CacheManager::Label label;
+  label.path = xattr_mgr_->mount_point()->fqrn() +
+               "(" + metainfo_hash_.ToString() + ")";
+  label.flags = CacheManager::kLabelMetainfo;
+  int fd = xattr_mgr_->mount_point()->fetcher()->Fetch(
+    CacheManager::LabeledObject(metainfo_hash_, label));
   if (fd < 0) {
     return "Failed to open metadata file";
   }

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -379,7 +379,7 @@ std::string LHashMagicXattr::GetValue() {
   CacheManager::ObjectInfo object_info;
   object_info.description = path_.ToString();
   if (xattr_mgr_->mount_point()->catalog_mgr()->volatile_flag())
-    object_info.type = CacheManager::kTypeVolatile;
+    object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
   int fd = xattr_mgr_->mount_point()->file_system()->cache_mgr()->Open(
     CacheManager::Label(dirent_->checksum(), object_info));
   if (fd < 0) {
@@ -556,7 +556,7 @@ std::string RepoMetainfoMagicXattr::GetValue() {
   int fd = xattr_mgr_->mount_point()->fetcher()->
             Fetch(metainfo_hash_, CacheManager::kSizeUnknown,
                   "metainfo (" + metainfo_hash_.ToString() + ")",
-                  zlib::kZlibDefault, CacheManager::kTypeRegular, "");
+                  zlib::kZlibDefault, 0, "");
   if (fd < 0) {
     return "Failed to open metadata file";
   }

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -376,12 +376,12 @@ bool LHashMagicXattr::PrepareValueFenced() {
 
 std::string LHashMagicXattr::GetValue() {
   string result;
-  CacheManager::ObjectInfo object_info;
-  object_info.description = path_.ToString();
+  CacheManager::Label label;
+  label.description = path_.ToString();
   if (xattr_mgr_->mount_point()->catalog_mgr()->volatile_flag())
-    object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
+    label.flags = CacheManager::kLabelVolatile;
   int fd = xattr_mgr_->mount_point()->file_system()->cache_mgr()->Open(
-    CacheManager::LabeledObject(dirent_->checksum(), object_info));
+    CacheManager::LabeledObject(dirent_->checksum(), label));
   if (fd < 0) {
     result = "Not in cache";
   } else {

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -381,7 +381,7 @@ std::string LHashMagicXattr::GetValue() {
   if (xattr_mgr_->mount_point()->catalog_mgr()->volatile_flag())
     object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
   int fd = xattr_mgr_->mount_point()->file_system()->cache_mgr()->Open(
-    CacheManager::Label(dirent_->checksum(), object_info));
+    CacheManager::LabeledObject(dirent_->checksum(), object_info));
   if (fd < 0) {
     result = "Not in cache";
   } else {

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1162,7 +1162,7 @@ bool FileSystem::TriageCacheMgr() {
     unsigned nfiles = kDefaultNfiles;
     if (options_mgr_->GetValue("CVMFS_NFILES", &optarg))
       nfiles = String2Uint64(optarg);
-    cache_mgr_ = new StreamingCacheManager(nfiles, cache_mgr_, NULL);
+    cache_mgr_ = new StreamingCacheManager(nfiles, cache_mgr_, NULL, NULL);
   }
 
   return true;
@@ -1276,8 +1276,11 @@ MountPoint *MountPoint::Create(
   if (!mountpoint->CreateDownloadManagers())
     return mountpoint.Release();
   if (file_system->cache_mgr()->id() == kStreamingCacheManager) {
-    dynamic_cast<StreamingCacheManager *>(file_system->cache_mgr())->
-      SetDownloadManager(mountpoint->download_mgr());
+    StreamingCacheManager *streaming_cachemgr =
+      dynamic_cast<StreamingCacheManager *>(file_system->cache_mgr());
+    streaming_cachemgr->SetRegularDownloadManager(mountpoint->download_mgr());
+    streaming_cachemgr->SetExternalDownloadManager(
+      mountpoint->external_download_mgr());
   }
   if (!mountpoint->CreateResolvConfWatcher()) {
     return mountpoint.Release();

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1729,7 +1729,7 @@ bool MountPoint::FetchHistory(std::string *history_path) {
     CacheManager::kSizeUnknown,
     "tag database for " + fqrn_,
     zlib::kZlibDefault,
-    CacheManager::kTypeRegular);
+    0);
   if (fd < 0) {
     boot_error_ = "failed to download history: " + StringifyInt(-fd);
     boot_status_ = loader::kFailHistory;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1480,13 +1480,11 @@ void MountPoint::CreateFetchers() {
     backoff_throttle_,
     perf::StatisticsTemplate("fetch", statistics_));
 
-  const bool is_external_data = true;
   external_fetcher_ = new cvmfs::Fetcher(
     file_system_->cache_mgr(),
     external_download_mgr_,
     backoff_throttle_,
-    perf::StatisticsTemplate("fetch-external", statistics_),
-    is_external_data);
+    perf::StatisticsTemplate("fetch-external", statistics_));
 }
 
 
@@ -1724,12 +1722,10 @@ bool MountPoint::FetchHistory(std::string *history_path) {
     return false;
   }
 
-  int fd = fetcher_->Fetch(
-    history_hash,
-    CacheManager::kSizeUnknown,
-    "tag database for " + fqrn_,
-    zlib::kZlibDefault,
-    0);
+  CacheManager::Label label;
+  label.flags = CacheManager::kLabelHistory;
+  label.path = fqrn_;
+  int fd = fetcher_->Fetch(CacheManager::LabeledObject(history_hash, label));
   if (fd < 0) {
     boot_error_ = "failed to download history: " + StringifyInt(-fd);
     boot_status_ = loader::kFailHistory;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -505,6 +505,7 @@ class MountPoint : SingleCopy, public BootFactory {
   cvmfs::Fetcher *fetcher() { return fetcher_; }
   bool fixed_catalog() { return fixed_catalog_; }
   std::string fqrn() const { return fqrn_; }
+  // TODO(jblomer): use only a singler fetcher object
   cvmfs::Fetcher *external_fetcher() { return external_fetcher_; }
   FileSystem *file_system() { return file_system_; }
   MagicXattrManager *magic_xattr_mgr() { return magic_xattr_mgr_; }

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -1,0 +1,33 @@
+cvmfs_test_name="Streaming cache manager"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+CVMFS_TEST_690_HTTP_PID=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_690_HTTP_PID ] || sudo kill $CVMFS_TEST_690_HTTP_PID
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  src_location=$2
+  local repo_dir="/cvmfs/${CVMFS_TEST_REPO}"
+  local scratch_dir="$(pwd)"
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  start_transaction $CVMFS_TEST_REPO                             || return $?
+  mkdir -p ${repo_dir}/external                                  || return 1
+  mkdir -p ${repo_dir}/internal                                  || return 2
+  echo "Hello World" > ${repo_dir}/external/file                 || return 3
+  cp ${repo_dir}/external/file ${repo_dir}/internal/file         || return 4
+
+  echo "*** Check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "*** install a desaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  return 0
+}

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -30,9 +30,11 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO                                      || return $?
   echo "CVMFS_COMPRESSION_ALGORITHM=none" | \
     sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
-  echo "CVMFS_EXTERNAL_DATA=true" | \
-    sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
-  mkdir -p ${repo_dir}/external                                           || return 6
+  if ! running_on_s3; then
+    echo "CVMFS_EXTERNAL_DATA=true" | \
+      sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+    mkdir -p ${repo_dir}/external                                         || return 6
+  fi
   cat /dev/urandom | head -c $((1000*1000*25)) > ${repo_dir}/external/foo || return 7
   publish_repo $CVMFS_TEST_REPO -v                                        || return 9
 
@@ -40,16 +42,18 @@ cvmfs_run_test() {
   check_repository $CVMFS_TEST_REPO -i || return $?
 
   echo "*** Plant external file"
-  local chunk_list=$(get_xattr chunk_list /var/spool/cvmfs/${CVMFS_TEST_REPO}/rdonly/external/foo | tail -n +2)
-  printf "$chunk_list\n"
-  local nchunks=$(printf "$chunk_list\n" | wc -l)
-  [ $nchunks -gt 1 ] || return 30
-  mkdir /srv/cvmfs/${CVMFS_TEST_REPO}/data/external || return 31
-  for c in $chunk_list; do
-    local hash=$(echo $c | cut -d, -f1)
-    cat /srv/cvmfs/${CVMFS_TEST_REPO}/data/${hash:0:2}/${hash:2}P >> \
-      /srv/cvmfs/${CVMFS_TEST_REPO}/data/external/foo || return 32
-  done
+  if ! running_on_s3; then
+    local chunk_list=$(get_xattr chunk_list /var/spool/cvmfs/${CVMFS_TEST_REPO}/rdonly/external/foo | tail -n +2)
+    printf "$chunk_list\n"
+    local nchunks=$(printf "$chunk_list\n" | wc -l)
+    [ $nchunks -gt 1 ] || return 30
+    mkdir /srv/cvmfs/${CVMFS_TEST_REPO}/data/external || return 31
+    for c in $chunk_list; do
+      local hash=$(echo $c | cut -d, -f1)
+      cat /srv/cvmfs/${CVMFS_TEST_REPO}/data/${hash:0:2}/${hash:2}P >> \
+        /srv/cvmfs/${CVMFS_TEST_REPO}/data/external/foo || return 32
+    done
+  fi
 
   echo "*** install a desaster cleanup"
   trap cleanup EXIT HUP INT TERM || return $?
@@ -73,7 +77,7 @@ cvmfs_run_test() {
   cat cache_list | grep small && return 22
 
   local is_external=$(get_xattr external_file $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo)
-  [ x"$is_external" = "x1" ] || return 42
+  running_on_s3 || [ x"$is_external" = "x1" ] || return 42
   md5sum $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo || return 43
   sudo cvmfs_talk -p $talk_socket cache list | tee cache_list
   cat cache_list | grep foo && return 44

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -27,18 +27,41 @@ cvmfs_run_test() {
   echo "Hello World" > ${repo_dir}/internal/small                || return 3
   publish_repo $CVMFS_TEST_REPO -v                               || return 5
 
+  start_transaction $CVMFS_TEST_REPO                                      || return $?
+  echo "CVMFS_COMPRESSION_ALGORITHM=none" | \
+    sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  echo "CVMFS_EXTERNAL_DATA=true" | \
+    sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  mkdir -p ${repo_dir}/external                                           || return 6
+  cat /dev/urandom | head -c $((1000*1000*25)) > ${repo_dir}/external/foo || return 7
+  publish_repo $CVMFS_TEST_REPO -v                                        || return 9
+
   echo "*** Check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "*** Plant external file"
+  local chunk_list=$(get_xattr chunk_list /var/spool/cvmfs/${CVMFS_TEST_REPO}/rdonly/external/foo | tail -n +2)
+  printf "$chunk_list\n"
+  local nchunks=$(printf "$chunk_list\n" | wc -l)
+  [ $nchunks -gt 1 ] || return 30
+  mkdir /srv/cvmfs/${CVMFS_TEST_REPO}/data/external || return 31
+  for c in $chunk_list; do
+    local hash=$(echo $c | cut -d, -f1)
+    cat /srv/cvmfs/${CVMFS_TEST_REPO}/data/${hash:0:2}/${hash:2}P >> \
+      /srv/cvmfs/${CVMFS_TEST_REPO}/data/external/foo || return 32
+  done
 
   echo "*** install a desaster cleanup"
   trap cleanup EXIT HUP INT TERM || return $?
 
   CVMFS_TEST_690_PRIVATE_MOUNTPOINT="$(pwd)/mountpoint"
+  echo "CVMFS_STREAMING_CACHE=yes" > test690.conf
+  echo "CVMFS_EXTERNAL_URL=http://localhost/cvmfs/${CVMFS_TEST_REPO}" >> test690.conf
   do_local_mount "$CVMFS_TEST_690_PRIVATE_MOUNTPOINT" \
                  "$CVMFS_TEST_REPO" \
                  "$(get_repo_url $CVMFS_TEST_REPO)" \
                  "" \
-                 "CVMFS_STREAMING_CACHE=yes" || return 10
+                 "CVMFS_STREAMING_CACHE=yes\nCVMFS_EXTERNAL_URL=http://localhost/cvmfs/${CVMFS_TEST_REPO}\nCVMFS_EXTERNAL_HTTP_PROXY=DIRECT" || return 10
   local talk_socket="$(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO"
   local cache_instance=$(sudo cvmfs_talk -p $talk_socket cache instance)
   echo "$cache_instance"
@@ -48,6 +71,12 @@ cvmfs_run_test() {
   cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 21
   sudo cvmfs_talk -p $talk_socket cache list | tee cache_list
   cat cache_list | grep small && return 22
+
+  local is_external=$(get_xattr external_file $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo)
+  [ x"$is_external" = "x1" ] || return 42
+  md5sum $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo || return 43
+  sudo cvmfs_talk -p $talk_socket cache list | tee cache_list
+  cat cache_list | grep foo && return 44
 
   return 0
 }

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -30,12 +30,12 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO                                      || return $?
   echo "CVMFS_COMPRESSION_ALGORITHM=none" | \
     sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  mkdir -p ${repo_dir}/external                                           || return 6
+  cat /dev/urandom | head -c $((1000*1000*25)) > ${repo_dir}/external/foo || return 7
   if ! running_on_s3; then
     echo "CVMFS_EXTERNAL_DATA=true" | \
       sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
-    mkdir -p ${repo_dir}/external                                         || return 6
   fi
-  cat /dev/urandom | head -c $((1000*1000*25)) > ${repo_dir}/external/foo || return 7
   publish_repo $CVMFS_TEST_REPO -v                                        || return 9
 
   echo "*** Check catalog and data integrity"
@@ -90,7 +90,7 @@ cvmfs_run_test() {
   cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 51
   md5sum $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo || return 52
 
-  gcc -Wall -o openwaitprint ${src_location}/openwaitprint.c || return 60
+  gcc -Wall -pthread -o openwaitprint ${src_location}/openwaitprint.c || return 60
   ./openwaitprint $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small > small &
   local pid_helper=$!
 

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -90,5 +90,14 @@ cvmfs_run_test() {
   cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 51
   md5sum $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo || return 52
 
+  gcc -Wall -o openwaitprint ${src_location}/openwaitprint.c || return 60
+  ./openwaitprint $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small > small &
+  local pid_helper=$!
+
+  cvmfs2 __RELOAD__ $(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/cvmfs.$CVMFS_TEST_REPO || return 61
+  kill -USR1 $pid_helper
+  wait $pid_helper || return 62
+  diff small $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 63
+
   return 0
 }

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -3,8 +3,13 @@ cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
 CVMFS_TEST_690_HTTP_PID=
+CVMFS_TEST_690_PRIVATE_MOUNTPOINT=
 cleanup() {
   echo "running cleanup()"
+  if [ ! -z $CVMFS_TEST_690_PRIVATE_MOUNTPOINT ]; then
+    echo -n "umounting ${CVMFS_TEST_690_PRIVATE_MOUNTPOINT}... "
+    remove_local_mount $CVMFS_TEST_690_PRIVATE_MOUNTPOINT && echo "done" || echo "fail"
+  fi
   [ -z $CVMFS_TEST_690_HTTP_PID ] || sudo kill $CVMFS_TEST_690_HTTP_PID
 }
 
@@ -18,16 +23,31 @@ cvmfs_run_test() {
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   start_transaction $CVMFS_TEST_REPO                             || return $?
-  mkdir -p ${repo_dir}/external                                  || return 1
   mkdir -p ${repo_dir}/internal                                  || return 2
-  echo "Hello World" > ${repo_dir}/external/file                 || return 3
-  cp ${repo_dir}/external/file ${repo_dir}/internal/file         || return 4
+  echo "Hello World" > ${repo_dir}/internal/small                || return 3
+  publish_repo $CVMFS_TEST_REPO -v                               || return 5
 
   echo "*** Check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i || return $?
 
   echo "*** install a desaster cleanup"
   trap cleanup EXIT HUP INT TERM || return $?
+
+  CVMFS_TEST_690_PRIVATE_MOUNTPOINT="$(pwd)/mountpoint"
+  do_local_mount "$CVMFS_TEST_690_PRIVATE_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_STREAMING_CACHE=yes" || return 10
+  local talk_socket="$(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO"
+  local cache_instance=$(sudo cvmfs_talk -p $talk_socket cache instance)
+  echo "$cache_instance"
+  echo "$cache_instance" | grep Streaming || return 11
+
+  ls -lah $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/ || return 20
+  cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 21
+  sudo cvmfs_talk -p $talk_socket cache list | tee cache_list
+  cat cache_list | grep small && return 22
 
   return 0
 }

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -82,5 +82,13 @@ cvmfs_run_test() {
   sudo cvmfs_talk -p $talk_socket cache list | tee cache_list
   cat cache_list | grep foo && return 44
 
+  sudo cvmfs_talk -p $talk_socket cache list
+  sudo cvmfs_talk -p $talk_socket cache list catalogs
+
+  cvmfs2 __RELOAD__ $(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/cvmfs.$CVMFS_TEST_REPO || return 50
+  ls -lR $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/
+  cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 51
+  md5sum $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo || return 52
+
   return 0
 }

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -25,6 +25,7 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO                             || return $?
   mkdir -p ${repo_dir}/internal                                  || return 2
   echo "Hello World" > ${repo_dir}/internal/small                || return 3
+  cat /dev/urandom | head -c 2500 > ${repo_dir}/internal/bar     || return 4
   publish_repo $CVMFS_TEST_REPO -v                               || return 5
 
   start_transaction $CVMFS_TEST_REPO                                      || return $?
@@ -81,6 +82,19 @@ cvmfs_run_test() {
   md5sum $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo || return 43
   sudo cvmfs_talk -p $talk_socket cache list | tee cache_list
   cat cache_list | grep foo && return 44
+
+  local size_md=$(stat --format=%s $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo)
+  local size_cat=$(cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/external/foo | wc -c)
+  echo "*** size of 'foo': $size_md / $size_cat"
+  [ $size_md -eq $size_cat ] || return 45
+  size_md=$(stat --format=%s $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small)
+  size_cat=$(cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small | wc -c)
+  echo "*** size of 'small': $size_md / $size_cat"
+  [ $size_md -eq $size_cat ] || return 46
+  size_md=$(stat --format=%s $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/bar)
+  size_cat=$(cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/bar | wc -c)
+  echo "*** size of 'bar': $size_md / $size_cat"
+  [ $size_md -eq $size_cat ] || return 47
 
   sudo cvmfs_talk -p $talk_socket cache list
   sudo cvmfs_talk -p $talk_socket cache list catalogs

--- a/test/src/690-streamingcache/openwaitprint.c
+++ b/test/src/690-streamingcache/openwaitprint.c
@@ -47,13 +47,14 @@ int main(int argc, char **argv) {
     return ReturnError();
 
   int c;
+  ssize_t nbytes;
   do {
-    retval = read(fd, &c, 1);
-    if (retval == 0)
+    nbytes = read(fd, &c, 1);
+    if (nbytes == 0)
       break;
     printf("%c", c);
-  } while (retval == 1);
-  if (retval < 0)
+  } while (nbytes == 1);
+  if (nbytes < 0)
     return ReturnError();
 
   close(fd);

--- a/test/src/690-streamingcache/openwaitprint.c
+++ b/test/src/690-streamingcache/openwaitprint.c
@@ -1,0 +1,61 @@
+/**
+ * This file is part of the CernVM File System.
+ * Helper for integration test 690 (streaming cache manager)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int fd = -1;
+
+static int ReturnError() {
+  if (fd >= 0)
+    close(fd);
+  return 1;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2)
+    return 1;
+
+  char *path = argv[1];
+  fd = open(path, O_RDONLY);
+  if (fd < 0)
+    return 1;
+
+  int sigwait = SIGUSR1;
+
+  sigset_t sigset;
+  int retval = sigemptyset(&sigset);
+  if (retval != 0)
+    return ReturnError();
+  retval = sigaddset(&sigset, sigwait);
+  if (retval != 0)
+    return ReturnError();
+  retval = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
+  if (retval != 0)
+    return ReturnError();
+
+  do {
+    retval = sigwaitinfo(&sigset, NULL);
+  } while ((retval != sigwait) && (errno == EINTR));
+  if (retval != sigwait)
+    return ReturnError();
+
+  int c;
+  do {
+    retval = read(fd, &c, 1);
+    if (retval == 0)
+      break;
+    printf("%c", c);
+  } while (retval == 1);
+  if (retval < 0)
+    return ReturnError();
+
+  close(fd);
+  return 0;
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -2375,7 +2375,7 @@ EOF
   else
     cat $config_file > $config
   fi
-  echo "$extra_option" >> $config
+  printf "$extra_option\n" >> $config
   echo "  *** local mount config:"
   cat "$config"
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -379,6 +379,7 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/cache_posix.cc
   ${CVMFS_SOURCE_DIR}/cache_plugin/channel.cc
   ${CVMFS_SOURCE_DIR}/cache_ram.cc
+  ${CVMFS_SOURCE_DIR}/cache_stream.cc
   ${CVMFS_SOURCE_DIR}/cache_tiered.cc
   ${CVMFS_SOURCE_DIR}/cache_transport.cc
   ${CVMFS_SOURCE_DIR}/catalog.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -268,6 +268,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_cache.cc
   t_cache_extern.cc
   t_cache_ram.cc
+  t_cache_stream.cc
   t_cache_tiered.cc
   t_callbacks.cc
   t_catalog.cc

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -58,11 +58,11 @@ class T_CachePlugin : public ::testing::Test {
     }
   }
 
-  CacheManager::LabeledObject LabelWithDesc(const shash::Any &id,
-                                            const std::string &desc)
+  CacheManager::LabeledObject LabelWithPath(const shash::Any &id,
+                                            const std::string &path)
   {
     CacheManager::Label label;
-    label.description = desc;
+    label.path = path;
     return CacheManager::LabeledObject(id, label);
   }
 
@@ -98,11 +98,11 @@ TEST_F(T_CachePlugin, OpenClose) {
   HashString(content, &id);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id, "test"),
                                         data, content.length()));
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id, "test"), &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
 }
@@ -112,12 +112,12 @@ TEST_F(T_CachePlugin, StoreEmpty) {
   shash::Any empty_id(shash::kSha1);
   string empty;
   shash::HashString(empty, &empty_id);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(empty_id, "enpty"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(empty_id, "enpty"),
                                         NULL, 0));
 
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(empty_id, "test"),
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(empty_id, "test"),
                                    &buffer, &size));
   EXPECT_EQ(0U, size);
   EXPECT_EQ(NULL, buffer);
@@ -142,23 +142,23 @@ TEST_F(T_CachePlugin, HashAlgorithms) {
   HashString(content, &id_shake128);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_sha1, "sha1"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_sha1, "sha1"),
                                         data, content.length()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_rmd160, "rmd160"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_rmd160, "rmd160"),
                                         data, content.length()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_shake128, "shake128"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_shake128, "shake128"),
                                         data, content.length()));
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_sha1, "sha1"),
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id_sha1, "sha1"),
                                    &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_rmd160, "rmd160"),
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id_rmd160, "rmd160"),
                                    &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_shake128, "id_shake128"),
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id_shake128, "id_shake128"),
                                    &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
@@ -175,19 +175,19 @@ TEST_F(T_CachePlugin, Read) {
   shash::Any id_odd(shash::kSha1);
   shash::HashMem(buffer, size_even, &id_even);
   shash::HashMem(buffer, size_odd, &id_odd);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_even, "even"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_even, "even"),
                                         buffer, size_even));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_odd, "odd"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_odd, "odd"),
                                         buffer, size_odd));
 
   unsigned char *read_buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_even, "even"),
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id_even, "even"),
                                    &read_buffer, &size));
   EXPECT_EQ(size, size_even);
   EXPECT_EQ(0, memcmp(read_buffer, buffer, size_even));
   free(read_buffer);
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_odd, "odd"),
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id_odd, "odd"),
                                    &read_buffer, &size));
   EXPECT_EQ(size, size_odd);
   EXPECT_EQ(0, memcmp(read_buffer, buffer, size_odd));
@@ -237,7 +237,7 @@ TEST_F(T_CachePlugin, TransactionAbort) {
 
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id, "test"), &buf, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -263,7 +263,7 @@ TEST_F(T_CachePlugin, CommitHandover) {
 
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id, "test"), &buf, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -287,7 +287,7 @@ TEST_F(T_CachePlugin, CommitConcurrent) {
 
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id, "test"), &buf, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -309,7 +309,7 @@ TEST_F(T_CachePlugin, Info) {
   HashString(content, &id);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id, "test"),
                                         data, content.length()));
   int fd = cache_mgr_->Open(CacheManager::LabeledObject(id));
   EXPECT_GE(fd, 0);
@@ -345,15 +345,15 @@ TEST_F(T_CachePlugin, Shrink) {
     reinterpret_cast<const unsigned char *>(str_reg.data()));
   unsigned char *dat_clg = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(str_clg.data()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_vol, ""),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_vol, ""),
                                         dat_vol, str_vol.length()));
   uint64_t size_with1 = quota_mgr_->GetSize();
   EXPECT_GT(size_with1, size_vanilla);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_reg, ""),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_reg, ""),
                                         dat_reg, str_reg.length()));
   uint64_t size_with2 = quota_mgr_->GetSize();
   EXPECT_GT(size_with2, size_with1);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_clg, ""),
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id_clg, ""),
                                         dat_clg, str_clg.length()));
   uint64_t size_with3 = quota_mgr_->GetSize();
   EXPECT_GT(size_with3, size_with2);
@@ -379,7 +379,7 @@ TEST_F(T_CachePlugin, Shrink) {
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_txn, "test"), &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithPath(id_txn, "test"), &buf, &size));
   EXPECT_EQ(str_txn, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -399,7 +399,7 @@ TEST_F(T_CachePlugin, List) {
     unsigned char *data = reinterpret_cast<unsigned char *>(&i);
     HashMem(data, sizeof(i), &id);
     descriptions.insert(id.ToString());
-    EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, id.ToString()),
+    EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithPath(id, id.ToString()),
                                           data, sizeof(i)));
     if ((i % 10) == 0) {
       int fd = cache_mgr_->Open(CacheManager::LabeledObject(id));

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -98,8 +98,8 @@ TEST_F(T_CachePlugin, OpenClose) {
   HashString(content, &id);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                        data, content.length()));
   unsigned char *buffer;
   uint64_t size;
   EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
@@ -112,7 +112,8 @@ TEST_F(T_CachePlugin, StoreEmpty) {
   shash::Any empty_id(shash::kSha1);
   string empty;
   shash::HashString(empty, &empty_id);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(empty_id, NULL, 0, "empty"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(empty_id, "enpty"),
+                                        NULL, 0));
 
   unsigned char *buffer;
   uint64_t size;
@@ -141,12 +142,12 @@ TEST_F(T_CachePlugin, HashAlgorithms) {
   HashString(content, &id_shake128);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id_sha1, data, content.length(), "sha1"));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id_rmd160, data, content.length(), "rmd160"));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id_shake128, data, content.length(), "shake128"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_sha1, "sha1"),
+                                        data, content.length()));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_rmd160, "rmd160"),
+                                        data, content.length()));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_shake128, "shake128"),
+                                        data, content.length()));
   unsigned char *buffer;
   uint64_t size;
   EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_sha1, "sha1"),
@@ -174,8 +175,10 @@ TEST_F(T_CachePlugin, Read) {
   shash::Any id_odd(shash::kSha1);
   shash::HashMem(buffer, size_even, &id_even);
   shash::HashMem(buffer, size_odd, &id_odd);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(id_even, buffer, size_even, "even"));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(id_odd, buffer, size_odd, "odd"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_even, "even"),
+                                        buffer, size_even));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_odd, "odd"),
+                                        buffer, size_odd));
 
   unsigned char *read_buffer;
   uint64_t size;
@@ -306,7 +309,8 @@ TEST_F(T_CachePlugin, Info) {
   HashString(content, &id);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                        data, content.length()));
   int fd = cache_mgr_->Open(CacheManager::LabeledObject(id));
   EXPECT_GE(fd, 0);
   EXPECT_GT(quota_mgr_->GetSizePinned(), size_pinned);
@@ -341,13 +345,16 @@ TEST_F(T_CachePlugin, Shrink) {
     reinterpret_cast<const unsigned char *>(str_reg.data()));
   unsigned char *dat_clg = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(str_clg.data()));
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(id_vol, dat_vol, str_vol.length(), ""));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_vol, ""),
+                                        dat_vol, str_vol.length()));
   uint64_t size_with1 = quota_mgr_->GetSize();
   EXPECT_GT(size_with1, size_vanilla);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(id_reg, dat_reg, str_reg.length(), ""));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_reg, ""),
+                                        dat_reg, str_reg.length()));
   uint64_t size_with2 = quota_mgr_->GetSize();
   EXPECT_GT(size_with2, size_with1);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(id_clg, dat_clg, str_clg.length(), ""));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id_clg, ""),
+                                        dat_clg, str_clg.length()));
   uint64_t size_with3 = quota_mgr_->GetSize();
   EXPECT_GT(size_with3, size_with2);
   void *txn = alloca(cache_mgr_->SizeOfTxn());
@@ -392,7 +399,8 @@ TEST_F(T_CachePlugin, List) {
     unsigned char *data = reinterpret_cast<unsigned char *>(&i);
     HashMem(data, sizeof(i), &id);
     descriptions.insert(id.ToString());
-    EXPECT_TRUE(cache_mgr_->CommitFromMem(id, data, sizeof(i), id.ToString()));
+    EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, id.ToString()),
+                                          data, sizeof(i)));
     if ((i % 10) == 0) {
       int fd = cache_mgr_->Open(CacheManager::LabeledObject(id));
       EXPECT_GE(fd, 0);

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -83,7 +83,7 @@ TEST_F(T_CachePlugin, Connection) {
 TEST_F(T_CachePlugin, OpenClose) {
   shash::Any rnd_id(shash::kSha1);
   rnd_id.Randomize();
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_id)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_id)));
 
   shash::Any id(shash::kSha1);
   string content = "foo";
@@ -113,7 +113,7 @@ TEST_F(T_CachePlugin, StoreEmpty) {
   EXPECT_EQ(NULL, buffer);
   free(buffer);
 
-  int fd = cache_mgr_->Open(CacheManager::Label(empty_id));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(empty_id));
   EXPECT_GE(fd, 0);
   unsigned char small_buf[1];
   EXPECT_EQ(0, cache_mgr_->Pread(fd, small_buf, 1, 0));
@@ -176,7 +176,7 @@ TEST_F(T_CachePlugin, Read) {
   EXPECT_EQ(0, memcmp(read_buffer, buffer, size_odd));
   free(read_buffer);
 
-  int fd = cache_mgr_->Open(CacheManager::Label(id_odd));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(id_odd));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Pread(fd, NULL, 0, 0));
 
@@ -293,7 +293,7 @@ TEST_F(T_CachePlugin, Info) {
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
   EXPECT_TRUE(cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
-  int fd = cache_mgr_->Open(CacheManager::Label(id));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(id));
   EXPECT_GE(fd, 0);
   EXPECT_GT(quota_mgr_->GetSizePinned(), size_pinned);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -343,17 +343,17 @@ TEST_F(T_CachePlugin, Shrink) {
   uint64_t size_with4 = quota_mgr_->GetSize();
   EXPECT_GE(size_with4, size_with3);
 
-  int fd_clg = cache_mgr_->Open(CacheManager::Label(id_clg));
-  int fd_vol = cache_mgr_->Open(CacheManager::Label(id_vol));
+  int fd_clg = cache_mgr_->Open(CacheManager::LabeledObject(id_clg));
+  int fd_vol = cache_mgr_->Open(CacheManager::LabeledObject(id_vol));
   EXPECT_GE(fd_clg, 0);
   EXPECT_GE(fd_vol, 0);
   EXPECT_FALSE(quota_mgr_->Cleanup(0));
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(id_reg)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(id_reg)));
   EXPECT_EQ(0, cache_mgr_->Close(fd_clg));
   EXPECT_EQ(0, cache_mgr_->Close(fd_vol));
   EXPECT_TRUE(quota_mgr_->Cleanup(0));
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(id_vol)));
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(id_clg)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(id_vol)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(id_clg)));
 
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   unsigned char *buf;
@@ -380,7 +380,7 @@ TEST_F(T_CachePlugin, List) {
     descriptions.insert(id.ToString());
     EXPECT_TRUE(cache_mgr_->CommitFromMem(id, data, sizeof(i), id.ToString()));
     if ((i % 10) == 0) {
-      int fd = cache_mgr_->Open(CacheManager::Label(id));
+      int fd = cache_mgr_->Open(CacheManager::LabeledObject(id));
       EXPECT_GE(fd, 0);
       open_fds.insert(fd);
     }

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -58,6 +58,14 @@ class T_CachePlugin : public ::testing::Test {
     }
   }
 
+  CacheManager::LabeledObject LabelWithDesc(const shash::Any &id,
+                                            const std::string &desc)
+  {
+    CacheManager::Label label;
+    label.description = desc;
+    return CacheManager::LabeledObject(id, label);
+  }
+
   static const int nfiles;
   ExternalCacheManager *cache_mgr_;
   ExternalQuotaManager *quota_mgr_;
@@ -94,7 +102,7 @@ TEST_F(T_CachePlugin, OpenClose) {
     cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
 }
@@ -108,7 +116,8 @@ TEST_F(T_CachePlugin, StoreEmpty) {
 
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(empty_id, "test", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(empty_id, "test"),
+                                   &buffer, &size));
   EXPECT_EQ(0U, size);
   EXPECT_EQ(NULL, buffer);
   free(buffer);
@@ -140,13 +149,16 @@ TEST_F(T_CachePlugin, HashAlgorithms) {
     cache_mgr_->CommitFromMem(id_shake128, data, content.length(), "shake128"));
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id_sha1, "sha1", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_sha1, "sha1"),
+                                   &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id_rmd160, "rmd160", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_rmd160, "rmd160"),
+                                   &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id_shake128, "id_shake128", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_shake128, "id_shake128"),
+                                   &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
 }
@@ -167,11 +179,13 @@ TEST_F(T_CachePlugin, Read) {
 
   unsigned char *read_buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id_even, "even", &read_buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_even, "even"),
+                                   &read_buffer, &size));
   EXPECT_EQ(size, size_even);
   EXPECT_EQ(0, memcmp(read_buffer, buffer, size_even));
   free(read_buffer);
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id_odd, "odd", &read_buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_odd, "odd"),
+                                   &read_buffer, &size));
   EXPECT_EQ(size, size_odd);
   EXPECT_EQ(0, memcmp(read_buffer, buffer, size_odd));
   free(read_buffer);
@@ -220,7 +234,7 @@ TEST_F(T_CachePlugin, TransactionAbort) {
 
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buf, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -246,7 +260,7 @@ TEST_F(T_CachePlugin, CommitHandover) {
 
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buf, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -270,7 +284,7 @@ TEST_F(T_CachePlugin, CommitConcurrent) {
 
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buf, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }
@@ -358,7 +372,7 @@ TEST_F(T_CachePlugin, Shrink) {
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   unsigned char *buf;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id_txn, "test", &buf, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id_txn, "test"), &buf, &size));
   EXPECT_EQ(str_txn, string(reinterpret_cast<char *>(buf), size));
   free(buf);
 }

--- a/test/unittests/cache_plugin/t_cache_plugin.cc
+++ b/test/unittests/cache_plugin/t_cache_plugin.cc
@@ -83,7 +83,7 @@ TEST_F(T_CachePlugin, Connection) {
 TEST_F(T_CachePlugin, OpenClose) {
   shash::Any rnd_id(shash::kSha1);
   rnd_id.Randomize();
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_id)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_id)));
 
   shash::Any id(shash::kSha1);
   string content = "foo";
@@ -113,7 +113,7 @@ TEST_F(T_CachePlugin, StoreEmpty) {
   EXPECT_EQ(NULL, buffer);
   free(buffer);
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(empty_id));
+  int fd = cache_mgr_->Open(CacheManager::Label(empty_id));
   EXPECT_GE(fd, 0);
   unsigned char small_buf[1];
   EXPECT_EQ(0, cache_mgr_->Pread(fd, small_buf, 1, 0));
@@ -176,7 +176,7 @@ TEST_F(T_CachePlugin, Read) {
   EXPECT_EQ(0, memcmp(read_buffer, buffer, size_odd));
   free(read_buffer);
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(id_odd));
+  int fd = cache_mgr_->Open(CacheManager::Label(id_odd));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Pread(fd, NULL, 0, 0));
 
@@ -293,7 +293,7 @@ TEST_F(T_CachePlugin, Info) {
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
   EXPECT_TRUE(cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
-  int fd = cache_mgr_->Open(CacheManager::Bless(id));
+  int fd = cache_mgr_->Open(CacheManager::Label(id));
   EXPECT_GE(fd, 0);
   EXPECT_GT(quota_mgr_->GetSizePinned(), size_pinned);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -343,17 +343,17 @@ TEST_F(T_CachePlugin, Shrink) {
   uint64_t size_with4 = quota_mgr_->GetSize();
   EXPECT_GE(size_with4, size_with3);
 
-  int fd_clg = cache_mgr_->Open(CacheManager::Bless(id_clg));
-  int fd_vol = cache_mgr_->Open(CacheManager::Bless(id_vol));
+  int fd_clg = cache_mgr_->Open(CacheManager::Label(id_clg));
+  int fd_vol = cache_mgr_->Open(CacheManager::Label(id_vol));
   EXPECT_GE(fd_clg, 0);
   EXPECT_GE(fd_vol, 0);
   EXPECT_FALSE(quota_mgr_->Cleanup(0));
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(id_reg)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(id_reg)));
   EXPECT_EQ(0, cache_mgr_->Close(fd_clg));
   EXPECT_EQ(0, cache_mgr_->Close(fd_vol));
   EXPECT_TRUE(quota_mgr_->Cleanup(0));
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(id_vol)));
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(id_clg)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(id_vol)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(id_clg)));
 
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   unsigned char *buf;
@@ -380,7 +380,7 @@ TEST_F(T_CachePlugin, List) {
     descriptions.insert(id.ToString());
     EXPECT_TRUE(cache_mgr_->CommitFromMem(id, data, sizeof(i), id.ToString()));
     if ((i % 10) == 0) {
-      int fd = cache_mgr_->Open(CacheManager::Bless(id));
+      int fd = cache_mgr_->Open(CacheManager::Label(id));
       EXPECT_GE(fd, 0);
       open_fds.insert(fd);
     }

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -255,7 +255,7 @@ class TestCacheManager : public CacheManager {
     *static_cast<int *>(txn) = fd;
     return 0;
   }
-  virtual void CtrlTxn(const ObjectInfo &info, const int flags, void *txn) { }
+  virtual void CtrlTxn(const Label &label, const int flags, void *txn) { }
   virtual int64_t Write(const void *buf, uint64_t sz, void *txn) {
     return -EIO;
   }
@@ -482,10 +482,10 @@ TEST_F(T_CacheManager, CommitTxnQuotaNotifications) {
   EXPECT_EQ(1U, quota_mgr->last_cmd.size);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 1, txn), 0);
-  CacheManager::ObjectInfo object_info;
-  object_info.description = "desc0";
-  object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
-  cache_mgr_->CtrlTxn(object_info, 0, txn);
+  CacheManager::Label label;
+  label.description = "desc0";
+  label.flags = CacheManager::kLabelVolatile;
+  cache_mgr_->CtrlTxn(label, 0, txn);
   EXPECT_EQ(1U, cache_mgr_->Write(buf, 1, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   EXPECT_EQ(TestQuotaManager::kCmdInsertVolatile, quota_mgr->last_cmd.cmd);
@@ -494,9 +494,9 @@ TEST_F(T_CacheManager, CommitTxnQuotaNotifications) {
   EXPECT_EQ("desc0", quota_mgr->last_cmd.description);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 2, txn), 0);
-  object_info.description = "desc1";
-  object_info.flags = CacheManager::ObjectInfo::kLabelPinned;
-  cache_mgr_->CtrlTxn(object_info, 0, txn);
+  label.description = "desc1";
+  label.flags = CacheManager::kLabelPinned;
+  cache_mgr_->CtrlTxn(label, 0, txn);
   EXPECT_EQ(2U, cache_mgr_->Write(buf, 2, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   EXPECT_EQ(TestQuotaManager::kCmdPin, quota_mgr->last_cmd.cmd);
@@ -506,17 +506,17 @@ TEST_F(T_CacheManager, CommitTxnQuotaNotifications) {
   EXPECT_FALSE(quota_mgr->last_cmd.is_catalog);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 3, txn), 0);
-  object_info.description = "desc2";
-  object_info.flags = CacheManager::ObjectInfo::kLabelCatalog;
-  cache_mgr_->CtrlTxn(object_info, 0, txn);
+  label.description = "desc2";
+  label.flags = CacheManager::kLabelCatalog;
+  cache_mgr_->CtrlTxn(label, 0, txn);
   EXPECT_EQ(3U, cache_mgr_->Write(buf, 3, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   EXPECT_EQ(TestQuotaManager::kCmdPin, quota_mgr->last_cmd.cmd);
   EXPECT_TRUE(quota_mgr->last_cmd.is_catalog);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
-  object_info.description = "fail";
-  cache_mgr_->CtrlTxn(object_info, 0, txn);
+  label.description = "fail";
+  cache_mgr_->CtrlTxn(label, 0, txn);
   EXPECT_EQ(-ENOSPC, cache_mgr_->CommitTxn(txn));
 }
 
@@ -535,10 +535,10 @@ TEST_F(T_CacheManager, CommitTxnRenameFail) {
     cache_mgr_->quota_mgr());
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
-  CacheManager::ObjectInfo object_info;
-  object_info.description = "desc";
-  object_info.flags = CacheManager::ObjectInfo::kLabelCatalog;
-  cache_mgr_->CtrlTxn(object_info, 0, txn);
+  CacheManager::Label label;
+  label.description = "desc";
+  label.flags = CacheManager::kLabelCatalog;
+  cache_mgr_->CtrlTxn(label, 0, txn);
   string final_dir = GetParentPath(tmp_path_ + "/" + rnd_hash.MakePath());
   EXPECT_EQ(0, unlink((tmp_path_ + "/" + hash_null_.MakePath()).c_str()));
   EXPECT_EQ(0, unlink((tmp_path_ + "/" + hash_one_.MakePath()).c_str()));

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -35,15 +35,18 @@ class T_CacheManager : public ::testing::Test {
     alien_cache_mgr_ = PosixCacheManager::Create(tmp_path_, true);
     ASSERT_TRUE(alien_cache_mgr_ != NULL);
 
-    ASSERT_TRUE(cache_mgr_->CommitFromMem(hash_null_, NULL, 0, "null"));
+    ASSERT_TRUE(cache_mgr_->CommitFromMem(
+      CacheManager::LabeledObject(hash_null_), NULL, 0));
     unsigned char buf = 'A';
     hash_one_.digest[0] = 1;
-    ASSERT_TRUE(cache_mgr_->CommitFromMem(hash_one_, &buf, 1, "one"));
+    ASSERT_TRUE(cache_mgr_->CommitFromMem(
+      CacheManager::LabeledObject(hash_one_), &buf, 1));
 
     unsigned char *zero_page;
     hash_page_.digest[0] = 2;
     zero_page = reinterpret_cast<unsigned char *>(scalloc(4096, 1));
-    ASSERT_TRUE(cache_mgr_->CommitFromMem(hash_page_, zero_page, 4096, "buf"));
+    ASSERT_TRUE(cache_mgr_->CommitFromMem(
+      CacheManager::LabeledObject(hash_page_), zero_page, 4096));
     free(zero_page);
   }
 
@@ -308,7 +311,8 @@ TEST_F(T_CacheManager, CommitFromMem) {
   shash::Any rnd_hash;
   rnd_hash.Randomize();
   unsigned char buf = '1';
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(rnd_hash, &buf, 1, "1"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(CacheManager::LabeledObject(rnd_hash),
+                                        &buf, 1));
   unsigned char *retrieve_buf;
   uint64_t retrieve_size;
   EXPECT_TRUE(cache_mgr_->Open2Mem(CacheManager::LabeledObject(rnd_hash),
@@ -318,7 +322,8 @@ TEST_F(T_CacheManager, CommitFromMem) {
   free(retrieve_buf);
 
   TestCacheManager faulty_cache;
-  EXPECT_FALSE(faulty_cache.CommitFromMem(rnd_hash, &buf, 1, "1"));
+  EXPECT_FALSE(faulty_cache.CommitFromMem(CacheManager::LabeledObject(rnd_hash),
+                                          &buf, 1));
 
   string final_dir = tmp_path_ + "/" + rnd_hash.MakePath();
   EXPECT_EQ(0, unlink((tmp_path_ + "/" + hash_null_.MakePath()).c_str()));
@@ -326,7 +331,8 @@ TEST_F(T_CacheManager, CommitFromMem) {
   EXPECT_EQ(0, unlink((tmp_path_ + "/" + hash_page_.MakePath()).c_str()));
   EXPECT_EQ(0, unlink(final_dir.c_str()));
   EXPECT_EQ(0, rmdir(GetParentPath(final_dir).c_str()));
-  EXPECT_FALSE(cache_mgr_->CommitFromMem(rnd_hash, &buf, 1, "1"));
+  EXPECT_FALSE(cache_mgr_->CommitFromMem(CacheManager::LabeledObject(rnd_hash),
+                                         &buf, 1));
 }
 
 

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -284,19 +284,19 @@ class TestCacheManager : public CacheManager {
 TEST_F(T_CacheManager, ChecksumFd) {
   shash::Any hash(shash::kSha1);
   EXPECT_EQ(-EBADF, cache_mgr_->ChecksumFd(1000000, &hash));
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->ChecksumFd(fd, &hash));
   EXPECT_EQ("e8ec3d88b62ebf526e4e5a4ff6162a3aa48a6b78", hash.ToString());
   cache_mgr_->Close(fd);
 
-  fd = cache_mgr_->Open(CacheManager::Label(hash_one_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->ChecksumFd(fd, &hash));
   EXPECT_EQ("0bbd725a1003cd41b89b209f70e514f12f2a1062", hash.ToString());
   cache_mgr_->Close(fd);
 
-  fd = cache_mgr_->Open(CacheManager::Label(hash_page_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_page_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->ChecksumFd(fd, &hash));
   EXPECT_EQ("54b34b84872a06a373967f68726e29353d3fe7b2", hash.ToString());
@@ -394,7 +394,7 @@ TEST_F(T_CacheManager, AbortTxn) {
 
 
 TEST_F(T_CacheManager, Close) {
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
   EXPECT_EQ(-EBADF, cache_mgr_->Close(fd));
@@ -408,11 +408,11 @@ TEST_F(T_CacheManager, CommitTxn) {
   ASSERT_TRUE(txn != NULL);
   int fd;
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash)));
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
-  fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->GetSize(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -422,7 +422,7 @@ TEST_F(T_CacheManager, CommitTxn) {
   unsigned char buf = 'A';
   EXPECT_EQ(1U, cache_mgr_->Write(&buf, 1, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
-  fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, cache_mgr_->GetSize(fd));
   EXPECT_EQ(1, cache_mgr_->Pread(fd, &buf, 1, 0));
@@ -448,7 +448,7 @@ TEST_F(T_CacheManager, CommitTxnSizeMismatch) {
   ASSERT_TRUE(txn != NULL);
   unsigned char content = 'x';
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash)));
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 2, txn), 0);
   EXPECT_EQ(1U, cache_mgr_->Write(&content, 1, txn));
@@ -527,7 +527,7 @@ TEST_F(T_CacheManager, CommitTxnRenameFail) {
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   ASSERT_TRUE(txn != NULL);
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash)));
 
   delete cache_mgr_->quota_mgr_;
   cache_mgr_->quota_mgr_ = new TestQuotaManager();
@@ -556,7 +556,7 @@ TEST_F(T_CacheManager, CommitTxnFlushFail) {
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   ASSERT_TRUE(txn != NULL);
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash)));
 
   int fd = cache_mgr_->StartTxn(rnd_hash, 1, txn);
   EXPECT_GE(fd, 0);
@@ -600,7 +600,7 @@ TEST_F(T_CacheManager, Create) {
 
 TEST_F(T_CacheManager, Dup) {
   EXPECT_EQ(-EBADF, cache_mgr_->Dup(-1));
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
   EXPECT_GE(fd, 0);
   int fd_dup = cache_mgr_->Dup(fd);
   EXPECT_NE(fd, fd_dup);
@@ -610,12 +610,12 @@ TEST_F(T_CacheManager, Dup) {
 
 
 TEST_F(T_CacheManager, GetSize) {
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->GetSize(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
-  fd = cache_mgr_->Open(CacheManager::Label(hash_one_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, cache_mgr_->GetSize(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -632,10 +632,10 @@ TEST_F(T_CacheManager, Open) {
 
   shash::Any rnd_hash;
   rnd_hash.Randomize();
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash)));
   EXPECT_EQ(TestQuotaManager::kCmdUnknown, quota_mgr->last_cmd.cmd);
 
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
   EXPECT_EQ(TestQuotaManager::kCmdTouch, quota_mgr->last_cmd.cmd);
@@ -649,7 +649,7 @@ TEST_F(T_CacheManager, OpenFromTxn) {
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   ASSERT_TRUE(txn != NULL);
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash)));
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 2, txn), 0);
   unsigned char buf = 'A';
@@ -686,7 +686,7 @@ TEST_F(T_CacheManager, OpenFromTxn) {
 
 TEST_F(T_CacheManager, Pread) {
   char buf[1024];
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_one_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1U, cache_mgr_->Pread(fd, &buf, 1024, 0));
   EXPECT_EQ('A', buf[0]);
@@ -738,7 +738,7 @@ TEST_F(T_CacheManager, Reset) {
   EXPECT_EQ(5000, cache_mgr_->Write(large_buf, 5000, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 
-  int fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(5000, cache_mgr_->GetSize(fd));
   EXPECT_EQ(1, cache_mgr_->Pread(fd, large_buf, 1, 0));
@@ -748,7 +748,7 @@ TEST_F(T_CacheManager, Reset) {
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
   EXPECT_EQ(0, cache_mgr_->Reset(txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
-  fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->GetSize(fd));
   cache_mgr_->Close(fd);
@@ -863,7 +863,7 @@ TEST_F(T_CacheManager, Write) {
   EXPECT_EQ(0, cache_mgr_->Write(NULL, 0, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 
-  int fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(14096, cache_mgr_->GetSize(fd));
   cache_mgr_->Close(fd);
@@ -897,7 +897,7 @@ TEST_F(T_CacheManager, WriteCompare) {
   EXPECT_EQ(N, cache_mgr_->Write(large_buf, N, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 
-  int fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(N, cache_mgr_->GetSize(fd));
   char receive_buf[N];

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -482,9 +482,10 @@ TEST_F(T_CacheManager, CommitTxnQuotaNotifications) {
   EXPECT_EQ(1U, quota_mgr->last_cmd.size);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 1, txn), 0);
-  cache_mgr_->CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypeVolatile, "desc0"),
-    0, txn);
+  CacheManager::ObjectInfo object_info;
+  object_info.description = "desc0";
+  object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
+  cache_mgr_->CtrlTxn(object_info, 0, txn);
   EXPECT_EQ(1U, cache_mgr_->Write(buf, 1, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   EXPECT_EQ(TestQuotaManager::kCmdInsertVolatile, quota_mgr->last_cmd.cmd);
@@ -493,9 +494,9 @@ TEST_F(T_CacheManager, CommitTxnQuotaNotifications) {
   EXPECT_EQ("desc0", quota_mgr->last_cmd.description);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 2, txn), 0);
-  cache_mgr_->CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypePinned, "desc1"),
-    0, txn);
+  object_info.description = "desc1";
+  object_info.flags = CacheManager::ObjectInfo::kLabelPinned;
+  cache_mgr_->CtrlTxn(object_info, 0, txn);
   EXPECT_EQ(2U, cache_mgr_->Write(buf, 2, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   EXPECT_EQ(TestQuotaManager::kCmdPin, quota_mgr->last_cmd.cmd);
@@ -505,18 +506,17 @@ TEST_F(T_CacheManager, CommitTxnQuotaNotifications) {
   EXPECT_FALSE(quota_mgr->last_cmd.is_catalog);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 3, txn), 0);
-  cache_mgr_->CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypeCatalog, "desc2"),
-    0, txn);
+  object_info.description = "desc2";
+  object_info.flags = CacheManager::ObjectInfo::kLabelCatalog;
+  cache_mgr_->CtrlTxn(object_info, 0, txn);
   EXPECT_EQ(3U, cache_mgr_->Write(buf, 3, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
   EXPECT_EQ(TestQuotaManager::kCmdPin, quota_mgr->last_cmd.cmd);
   EXPECT_TRUE(quota_mgr->last_cmd.is_catalog);
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
-  cache_mgr_->CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypeCatalog, "fail"),
-    0, txn);
+  object_info.description = "fail";
+  cache_mgr_->CtrlTxn(object_info, 0, txn);
   EXPECT_EQ(-ENOSPC, cache_mgr_->CommitTxn(txn));
 }
 
@@ -535,9 +535,10 @@ TEST_F(T_CacheManager, CommitTxnRenameFail) {
     cache_mgr_->quota_mgr());
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
-  cache_mgr_->CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypeCatalog, "desc"),
-    0, txn);
+  CacheManager::ObjectInfo object_info;
+  object_info.description = "desc";
+  object_info.flags = CacheManager::ObjectInfo::kLabelCatalog;
+  cache_mgr_->CtrlTxn(object_info, 0, txn);
   string final_dir = GetParentPath(tmp_path_ + "/" + rnd_hash.MakePath());
   EXPECT_EQ(0, unlink((tmp_path_ + "/" + hash_null_.MakePath()).c_str()));
   EXPECT_EQ(0, unlink((tmp_path_ + "/" + hash_one_.MakePath()).c_str()));

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -238,7 +238,7 @@ class TestCacheManager : public CacheManager {
   virtual CacheManagerIds id() { return type; }
   virtual std::string Describe() { return "test\n"; }
   virtual bool AcquireQuotaManager(QuotaManager *qm) { return false; }
-  virtual int Open(const BlessedObject &object) {
+  virtual int Open(const LabeledObject &object) {
     return open("/dev/null", O_RDONLY);
   }
   virtual int64_t GetSize(int fd) { return 1; }
@@ -284,19 +284,19 @@ class TestCacheManager : public CacheManager {
 TEST_F(T_CacheManager, ChecksumFd) {
   shash::Any hash(shash::kSha1);
   EXPECT_EQ(-EBADF, cache_mgr_->ChecksumFd(1000000, &hash));
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->ChecksumFd(fd, &hash));
   EXPECT_EQ("e8ec3d88b62ebf526e4e5a4ff6162a3aa48a6b78", hash.ToString());
   cache_mgr_->Close(fd);
 
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_one_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->ChecksumFd(fd, &hash));
   EXPECT_EQ("0bbd725a1003cd41b89b209f70e514f12f2a1062", hash.ToString());
   cache_mgr_->Close(fd);
 
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_page_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_page_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->ChecksumFd(fd, &hash));
   EXPECT_EQ("54b34b84872a06a373967f68726e29353d3fe7b2", hash.ToString());
@@ -394,7 +394,7 @@ TEST_F(T_CacheManager, AbortTxn) {
 
 
 TEST_F(T_CacheManager, Close) {
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
   EXPECT_EQ(-EBADF, cache_mgr_->Close(fd));
@@ -408,11 +408,11 @@ TEST_F(T_CacheManager, CommitTxn) {
   ASSERT_TRUE(txn != NULL);
   int fd;
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
-  fd = cache_mgr_->Open(CacheManager::Bless(rnd_hash));
+  fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->GetSize(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -422,7 +422,7 @@ TEST_F(T_CacheManager, CommitTxn) {
   unsigned char buf = 'A';
   EXPECT_EQ(1U, cache_mgr_->Write(&buf, 1, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
-  fd = cache_mgr_->Open(CacheManager::Bless(rnd_hash));
+  fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, cache_mgr_->GetSize(fd));
   EXPECT_EQ(1, cache_mgr_->Pread(fd, &buf, 1, 0));
@@ -448,7 +448,7 @@ TEST_F(T_CacheManager, CommitTxnSizeMismatch) {
   ASSERT_TRUE(txn != NULL);
   unsigned char content = 'x';
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 2, txn), 0);
   EXPECT_EQ(1U, cache_mgr_->Write(&content, 1, txn));
@@ -527,7 +527,7 @@ TEST_F(T_CacheManager, CommitTxnRenameFail) {
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   ASSERT_TRUE(txn != NULL);
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
 
   delete cache_mgr_->quota_mgr_;
   cache_mgr_->quota_mgr_ = new TestQuotaManager();
@@ -555,7 +555,7 @@ TEST_F(T_CacheManager, CommitTxnFlushFail) {
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   ASSERT_TRUE(txn != NULL);
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
 
   int fd = cache_mgr_->StartTxn(rnd_hash, 1, txn);
   EXPECT_GE(fd, 0);
@@ -599,7 +599,7 @@ TEST_F(T_CacheManager, Create) {
 
 TEST_F(T_CacheManager, Dup) {
   EXPECT_EQ(-EBADF, cache_mgr_->Dup(-1));
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
   EXPECT_GE(fd, 0);
   int fd_dup = cache_mgr_->Dup(fd);
   EXPECT_NE(fd, fd_dup);
@@ -609,12 +609,12 @@ TEST_F(T_CacheManager, Dup) {
 
 
 TEST_F(T_CacheManager, GetSize) {
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->GetSize(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_one_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, cache_mgr_->GetSize(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -631,10 +631,10 @@ TEST_F(T_CacheManager, Open) {
 
   shash::Any rnd_hash;
   rnd_hash.Randomize();
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_hash)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
   EXPECT_EQ(TestQuotaManager::kCmdUnknown, quota_mgr->last_cmd.cmd);
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_null_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_null_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
   EXPECT_EQ(TestQuotaManager::kCmdTouch, quota_mgr->last_cmd.cmd);
@@ -648,7 +648,7 @@ TEST_F(T_CacheManager, OpenFromTxn) {
   void *txn = alloca(cache_mgr_->SizeOfTxn());
   ASSERT_TRUE(txn != NULL);
 
-  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_hash)));
+  ASSERT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_hash)));
 
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 2, txn), 0);
   unsigned char buf = 'A';
@@ -685,7 +685,7 @@ TEST_F(T_CacheManager, OpenFromTxn) {
 
 TEST_F(T_CacheManager, Pread) {
   char buf[1024];
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_one_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1U, cache_mgr_->Pread(fd, &buf, 1024, 0));
   EXPECT_EQ('A', buf[0]);
@@ -737,7 +737,7 @@ TEST_F(T_CacheManager, Reset) {
   EXPECT_EQ(5000, cache_mgr_->Write(large_buf, 5000, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(rnd_hash));
+  int fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(5000, cache_mgr_->GetSize(fd));
   EXPECT_EQ(1, cache_mgr_->Pread(fd, large_buf, 1, 0));
@@ -747,7 +747,7 @@ TEST_F(T_CacheManager, Reset) {
   EXPECT_GE(cache_mgr_->StartTxn(rnd_hash, 0, txn), 0);
   EXPECT_EQ(0, cache_mgr_->Reset(txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
-  fd = cache_mgr_->Open(CacheManager::Bless(rnd_hash));
+  fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->GetSize(fd));
   cache_mgr_->Close(fd);
@@ -862,7 +862,7 @@ TEST_F(T_CacheManager, Write) {
   EXPECT_EQ(0, cache_mgr_->Write(NULL, 0, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(rnd_hash));
+  int fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(14096, cache_mgr_->GetSize(fd));
   cache_mgr_->Close(fd);
@@ -896,7 +896,7 @@ TEST_F(T_CacheManager, WriteCompare) {
   EXPECT_EQ(N, cache_mgr_->Write(large_buf, N, txn));
   EXPECT_EQ(0, cache_mgr_->CommitTxn(txn));
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(rnd_hash));
+  int fd = cache_mgr_->Open(CacheManager::Label(rnd_hash));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(N, cache_mgr_->GetSize(fd));
   char receive_buf[N];

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -358,20 +358,25 @@ TEST_F(T_CacheManager, Open2Mem) {
 TEST_F(T_CacheManager, OpenPinned) {
   shash::Any rnd_hash(shash::kSha1);
   rnd_hash.Randomize();
-  EXPECT_EQ(-ENOENT, cache_mgr_->OpenPinned(rnd_hash, "", false));
+  CacheManager::Label label;
+  label.flags |= CacheManager::kLabelPinned;
+  EXPECT_EQ(-ENOENT,
+    cache_mgr_->OpenPinned(CacheManager::LabeledObject(rnd_hash, label)));
 
   delete cache_mgr_->quota_mgr_;
   TestQuotaManager *quota_mgr = new TestQuotaManager();
   cache_mgr_->quota_mgr_ = quota_mgr;
 
-  int fd = cache_mgr_->OpenPinned(hash_null_, "", false);
+  int fd =
+    cache_mgr_->OpenPinned(CacheManager::LabeledObject(hash_null_, label));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(TestQuotaManager::kCmdPin, quota_mgr->last_cmd.cmd);
   EXPECT_EQ(hash_null_, quota_mgr->last_cmd.hash);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
   quota_mgr->Unpin(hash_null_);
 
-  fd = cache_mgr_->OpenPinned(hash_null_, "fail", false);
+  label.description = "fail";
+  fd = cache_mgr_->OpenPinned(CacheManager::LabeledObject(hash_null_, label));
   EXPECT_EQ(-ENOSPC, fd);
 }
 

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -311,8 +311,8 @@ TEST_F(T_CacheManager, CommitFromMem) {
   EXPECT_TRUE(cache_mgr_->CommitFromMem(rnd_hash, &buf, 1, "1"));
   unsigned char *retrieve_buf;
   uint64_t retrieve_size;
-  EXPECT_TRUE(
-    cache_mgr_->Open2Mem(rnd_hash, "", &retrieve_buf, &retrieve_size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(CacheManager::LabeledObject(rnd_hash),
+                                   &retrieve_buf, &retrieve_size));
   EXPECT_EQ(1U, retrieve_size);
   EXPECT_EQ('1', retrieve_buf[0]);
   free(retrieve_buf);
@@ -334,22 +334,23 @@ TEST_F(T_CacheManager, Open2Mem) {
   unsigned char *retrieve_buf;
   uint64_t retrieve_size;
 
-  EXPECT_FALSE(cache_mgr_->Open2Mem(shash::Any(shash::kMd5), "",
-    &retrieve_buf, &retrieve_size));
+  EXPECT_FALSE(
+    cache_mgr_->Open2Mem(CacheManager::LabeledObject(shash::Any(shash::kMd5)),
+                         &retrieve_buf, &retrieve_size));
 
-  EXPECT_TRUE(
-    cache_mgr_->Open2Mem(hash_null_, "", &retrieve_buf, &retrieve_size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(CacheManager::LabeledObject(hash_null_),
+                                   &retrieve_buf, &retrieve_size));
   EXPECT_EQ(0U, retrieve_size);
   EXPECT_EQ(NULL, retrieve_buf);
 
-  EXPECT_TRUE(cache_mgr_->Open2Mem(
-    hash_one_, "", &retrieve_buf, &retrieve_size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(CacheManager::LabeledObject(hash_one_),
+                                   &retrieve_buf, &retrieve_size));
   EXPECT_EQ(1U, retrieve_size);
   EXPECT_EQ('A', retrieve_buf[0]);
 
   TestCacheManager faulty_cache;
-  EXPECT_FALSE(
-    faulty_cache.Open2Mem(hash_one_, "", &retrieve_buf, &retrieve_size));
+  EXPECT_FALSE(faulty_cache.Open2Mem(CacheManager::LabeledObject(hash_one_),
+                                     &retrieve_buf, &retrieve_size));
   EXPECT_EQ(0U, retrieve_size);
   EXPECT_EQ(NULL, retrieve_buf);
 }

--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -46,9 +46,10 @@ class T_CacheManager : public ::testing::Test {
     unsigned char *zero_page;
     hash_page_.digest[0] = 2;
     zero_page = reinterpret_cast<unsigned char *>(scalloc(4096, 1));
-    ASSERT_TRUE(cache_mgr_->CommitFromMem(
-      CacheManager::LabeledObject(hash_page_), zero_page, 4096));
+    bool retval = cache_mgr_->CommitFromMem(
+      CacheManager::LabeledObject(hash_page_), zero_page, 4096);
     free(zero_page);
+    ASSERT_TRUE(retval);
   }
 
   virtual void TearDown() {
@@ -242,7 +243,7 @@ class TestCacheManager : public CacheManager {
   virtual CacheManagerIds id() { return type; }
   virtual std::string Describe() { return "test\n"; }
   virtual bool AcquireQuotaManager(QuotaManager *qm) { return false; }
-  virtual int Open(const LabeledObject &object) {
+  virtual int Open(const LabeledObject & /* object */) {
     return open("/dev/null", O_RDONLY);
   }
   virtual int64_t GetSize(int fd) { return 1; }

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -256,6 +256,14 @@ class T_ExternalCacheManager : public ::testing::Test {
     delete mock_plugin_;
   }
 
+  CacheManager::LabeledObject LabelWithDesc(const shash::Any &id,
+                                            const std::string &desc)
+  {
+    CacheManager::Label label;
+    label.description = desc;
+    return CacheManager::LabeledObject(id, label);
+  }
+
   static const unsigned nfiles;
   int fd_client;
   string socket_path_;
@@ -418,7 +426,7 @@ TEST_F(T_ExternalCacheManager, Transaction) {
     cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
   unsigned char *buffer;
   uint64_t size;
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
   EXPECT_EQ(content, string(reinterpret_cast<char *>(buffer), size));
   free(buffer);
 
@@ -427,7 +435,7 @@ TEST_F(T_ExternalCacheManager, Transaction) {
   data = NULL;
   EXPECT_TRUE(
     cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &buffer, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
   EXPECT_EQ(0U, size);
   EXPECT_EQ(NULL, buffer);
 
@@ -438,7 +446,8 @@ TEST_F(T_ExternalCacheManager, Transaction) {
     cache_mgr_->CommitFromMem(id, large_buffer, large_size, "test"));
   unsigned char *large_buffer_verify = reinterpret_cast<unsigned char *>(
     smalloc(large_size));
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &large_buffer_verify, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"),
+                                   &large_buffer_verify, &size));
   EXPECT_EQ(large_size, size);
   EXPECT_EQ(0, memcmp(large_buffer, large_buffer_verify, large_size));
   free(large_buffer_verify);
@@ -449,7 +458,8 @@ TEST_F(T_ExternalCacheManager, Transaction) {
   EXPECT_TRUE(
     cache_mgr_->CommitFromMem(id, large_buffer, large_size, "test"));
   large_buffer_verify = reinterpret_cast<unsigned char *>(smalloc(large_size));
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &large_buffer_verify, &size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"),
+                                   &large_buffer_verify, &size));
   EXPECT_EQ(large_size, size);
   EXPECT_EQ(0, memcmp(large_buffer, large_buffer_verify, large_size));
   free(large_buffer_verify);
@@ -481,7 +491,8 @@ TEST_F(T_ExternalCacheManager, TransactionAbort) {
 
   uint64_t read_size = write_size;
   unsigned char *read_buffer = static_cast<unsigned char *>(smalloc(read_size));
-  EXPECT_TRUE(cache_mgr_->Open2Mem(id, "test", &read_buffer, &read_size));
+  EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"),
+                                   &read_buffer, &read_size));
   EXPECT_EQ(read_size, write_size);
   EXPECT_EQ(0, memcmp(read_buffer, write_buffer, read_size));
   free(read_buffer);
@@ -617,7 +628,11 @@ static void *MainMultiThread(void *data) {
 
   uint64_t size;
   unsigned char *buffer;
-  EXPECT_TRUE(td->cache_mgr->Open2Mem(td->id, "test", &buffer, &size));
+  CacheManager::Label label;
+  label.description = "test";
+  EXPECT_TRUE(
+    td->cache_mgr->Open2Mem(CacheManager::LabeledObject(td->id, label),
+                            &buffer, &size));
   EXPECT_EQ(td->large_size, size);
   EXPECT_EQ(0, memcmp(buffer, td->large_buffer, size));
   free(buffer);

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -349,7 +349,8 @@ TEST_F(T_ExternalCacheManager, ReadOnly) {
   EXPECT_EQ(-EROFS, cache_mgr_->StartTxn(id, content.length(), txn));
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_FALSE(cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
+  EXPECT_FALSE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                         data, content.length()));
 }
 
 
@@ -422,8 +423,8 @@ TEST_F(T_ExternalCacheManager, Transaction) {
   HashString(content, &id);
   unsigned char *data = const_cast<unsigned char *>(
     reinterpret_cast<const unsigned char *>(content.data()));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                        data, content.length()));
   unsigned char *buffer;
   uint64_t size;
   EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
@@ -433,8 +434,8 @@ TEST_F(T_ExternalCacheManager, Transaction) {
   content = "";
   HashString(content, &id);
   data = NULL;
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id, data, content.length(), "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+              data, content.length()));
   EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"), &buffer, &size));
   EXPECT_EQ(0U, size);
   EXPECT_EQ(NULL, buffer);
@@ -442,8 +443,8 @@ TEST_F(T_ExternalCacheManager, Transaction) {
   unsigned large_size = 50 * 1024 * 1024;
   unsigned char *large_buffer = reinterpret_cast<unsigned char *>(
     scalloc(large_size, 1));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id, large_buffer, large_size, "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                        large_buffer, large_size));
   unsigned char *large_buffer_verify = reinterpret_cast<unsigned char *>(
     smalloc(large_size));
   EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"),
@@ -455,8 +456,8 @@ TEST_F(T_ExternalCacheManager, Transaction) {
 
   large_size = 50 * 1024 * 1024 + 1;
   large_buffer = reinterpret_cast<unsigned char *>(scalloc(large_size, 1));
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id, large_buffer, large_size, "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                        large_buffer, large_size));
   large_buffer_verify = reinterpret_cast<unsigned char *>(smalloc(large_size));
   EXPECT_TRUE(cache_mgr_->Open2Mem(LabelWithDesc(id, "test"),
                                    &large_buffer_verify, &size));
@@ -659,8 +660,8 @@ TEST_F(T_ExternalCacheManager, MultiThreaded) {
   memset(large_buffer, 1, large_size);
   shash::Any id(shash::kSha1);
   shash::HashMem(large_buffer, large_size, &id);
-  EXPECT_TRUE(
-    cache_mgr_->CommitFromMem(id, large_buffer, large_size, "test"));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(LabelWithDesc(id, "test"),
+                                        large_buffer, large_size));
 
   const unsigned num_threads = 10;
   pthread_t threads[num_threads];

--- a/test/unittests/t_cache_extern.cc
+++ b/test/unittests/t_cache_extern.cc
@@ -287,20 +287,20 @@ TEST_F(T_ExternalCacheManager, OpenClose) {
   EXPECT_EQ(-EBADF, cache_mgr_->Close(0));
   shash::Any rnd_id(shash::kSha1);
   rnd_id.Randomize();
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(rnd_id)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(rnd_id)));
   uint64_t session_id = mock_plugin_->last_id;
   EXPECT_EQ(0, strcmp(mock_plugin_->last_reponame, "test"));
   EXPECT_EQ(0, strcmp(mock_plugin_->last_client_instance, "instance"));
 
   int fds[nfiles];
   for (unsigned i = 0; i < nfiles; ++i) {
-    fds[i] = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+    fds[i] = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
     EXPECT_GE(fds[i], 0);
   }
   EXPECT_EQ(session_id, mock_plugin_->last_id);
   EXPECT_EQ(static_cast<int>(nfiles), mock_plugin_->known_object_refcnt);
   EXPECT_EQ(-ENFILE,
-            cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object)));
+            cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object)));
   for (unsigned i = 0; i < nfiles; ++i) {
     EXPECT_EQ(0, cache_mgr_->Close(fds[i]));
   }
@@ -308,7 +308,7 @@ TEST_F(T_ExternalCacheManager, OpenClose) {
 
   mock_plugin_->next_status = cvmfs::STATUS_MALFORMED;
   EXPECT_EQ(-EINVAL,
-            cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object)));
+            cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object)));
   mock_plugin_->next_status = -1;
 }
 
@@ -328,7 +328,7 @@ TEST_F(T_ExternalCacheManager, ReadOnly) {
   cache_mgr_->AcquireQuotaManager(quota_mgr_);
   EXPECT_GE(cache_mgr_->session_id(), 0);
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
@@ -345,7 +345,7 @@ TEST_F(T_ExternalCacheManager, ReadOnly) {
 
 TEST_F(T_ExternalCacheManager, GetSize) {
   EXPECT_EQ(-EBADF, cache_mgr_->GetSize(0));
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(static_cast<int64_t>(mock_plugin_->known_object_content.length()),
             cache_mgr_->GetSize(fd));
@@ -361,7 +361,7 @@ TEST_F(T_ExternalCacheManager, GetSize) {
 TEST_F(T_ExternalCacheManager, Dup) {
   EXPECT_EQ(-EBADF, cache_mgr_->Dup(0));
   int fds[nfiles];
-  fds[0] = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  fds[0] = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fds[0], 0);
   for (unsigned i = 1; i < nfiles; ++i) {
     fds[i] = cache_mgr_->Dup(fds[0]);
@@ -381,7 +381,7 @@ TEST_F(T_ExternalCacheManager, Pread) {
   char buffer[64];
   EXPECT_EQ(-EBADF, cache_mgr_->Pread(0, buffer, buf_size, 0));
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(-EINVAL, cache_mgr_->Pread(fd, buffer, 1, 64));
   int64_t len = cache_mgr_->Pread(fd, buffer, 64, 0);
@@ -395,7 +395,7 @@ TEST_F(T_ExternalCacheManager, Pread) {
 
 TEST_F(T_ExternalCacheManager, Readahead) {
   EXPECT_EQ(-EBADF, cache_mgr_->Readahead(0));
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Readahead(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -509,7 +509,7 @@ void *MainBackchannel(void *data) {
 }  // anonymous namespace
 
 TEST_F(T_ExternalCacheManager, Detach) {
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   BackchannelData bd;
   quota_mgr_->RegisterBackChannel(bd.channel, "xyz");
@@ -543,7 +543,7 @@ TEST_F(T_ExternalCacheManager, Info) {
   EXPECT_EQ(mock_plugin_->known_object_content.length(), quota_mgr_->GetSize());
   EXPECT_EQ(0U, quota_mgr_->GetSizePinned());
 
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(mock_plugin_->known_object_content.length(),
             quota_mgr_->GetSizePinned());
@@ -553,7 +553,7 @@ TEST_F(T_ExternalCacheManager, Info) {
 
 TEST_F(T_ExternalCacheManager, Shrink) {
   EXPECT_TRUE(quota_mgr_->Cleanup(0));
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   EXPECT_GE(fd, 0);
   EXPECT_FALSE(quota_mgr_->Cleanup(0));
   EXPECT_EQ(0, cache_mgr_->Close(fd));
@@ -672,7 +672,7 @@ TEST_F(T_ExternalCacheManager, SaveState) {
   cache_mgr_->FreeState(-1, data);
 
   // Now with a new cache manager
-  int fd = cache_mgr_->Open(CacheManager::Bless(mock_plugin_->known_object));
+  int fd = cache_mgr_->Open(CacheManager::Label(mock_plugin_->known_object));
   uint64_t old_session_id = mock_plugin_->last_id;
   EXPECT_GE(fd, 0);
   data = cache_mgr_->SaveState(-1);

--- a/test/unittests/t_cache_ram.cc
+++ b/test/unittests/t_cache_ram.cc
@@ -84,7 +84,7 @@ TEST_F(T_RamCacheManager, Read) {
 
   char out[alloc_size];
   memset(out, 0, alloc_size);
-  EXPECT_GE((fd = ramcache_.Open(CacheManager::Bless(a_))), 0);
+  EXPECT_GE((fd = ramcache_.Open(CacheManager::Label(a_))), 0);
   EXPECT_EQ(alloc_size, ramcache_.Pread(fd, out, alloc_size, 0));
   EXPECT_EQ(0, memcmp(buf, out, alloc_size));
 
@@ -158,7 +158,7 @@ TEST_F(T_RamCacheManager, Eviction) {
   EXPECT_EQ(0, ramcache_.CommitTxn(txn5));
 
   a_.digest[1] = 1;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Bless(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
 }
 
 TEST_F(T_RamCacheManager, OpenEntries) {
@@ -235,9 +235,9 @@ TEST_F(T_RamCacheManager, PinnedEntry) {
   EXPECT_EQ(0, ramcache_.CommitTxn(txn5));
 
   a_.digest[1] = 1;
-  EXPECT_GE(ramcache_.Open(CacheManager::Bless(a_)), 0);
+  EXPECT_GE(ramcache_.Open(CacheManager::Label(a_)), 0);
   a_.digest[1] = 2;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Bless(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
 }
 
 TEST_F(T_RamCacheManager, VolatileEntry) {
@@ -278,9 +278,9 @@ TEST_F(T_RamCacheManager, VolatileEntry) {
   EXPECT_EQ(0, ramcache_.CommitTxn(txn5));
 
   a_.digest[1] = 1;
-  EXPECT_GE(ramcache_.Open(CacheManager::Bless(a_)), 0);
+  EXPECT_GE(ramcache_.Open(CacheManager::Label(a_)), 0);
   a_.digest[1] = 4;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Bless(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
 }
 
 TEST_F(T_RamCacheManager, LargeCommit) {
@@ -307,7 +307,7 @@ TEST_F(T_RamCacheManager, LargeCommit) {
   EXPECT_GE(fd, 0);
   EXPECT_EQ(-ENOSPC, ramcache_.CommitTxn(txn3));
   a_.digest[1] = 1;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Bless(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
   a_.digest[1] = 2;
   EXPECT_EQ(0, ramcache_.Close(fd));
   EXPECT_EQ(0, ramcache_.CommitTxn(txn3));

--- a/test/unittests/t_cache_ram.cc
+++ b/test/unittests/t_cache_ram.cc
@@ -84,7 +84,7 @@ TEST_F(T_RamCacheManager, Read) {
 
   char out[alloc_size];
   memset(out, 0, alloc_size);
-  EXPECT_GE((fd = ramcache_.Open(CacheManager::Label(a_))), 0);
+  EXPECT_GE((fd = ramcache_.Open(CacheManager::LabeledObject(a_))), 0);
   EXPECT_EQ(alloc_size, ramcache_.Pread(fd, out, alloc_size, 0));
   EXPECT_EQ(0, memcmp(buf, out, alloc_size));
 
@@ -158,7 +158,7 @@ TEST_F(T_RamCacheManager, Eviction) {
   EXPECT_EQ(0, ramcache_.CommitTxn(txn5));
 
   a_.digest[1] = 1;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::LabeledObject(a_)));
 }
 
 TEST_F(T_RamCacheManager, OpenEntries) {
@@ -235,9 +235,9 @@ TEST_F(T_RamCacheManager, PinnedEntry) {
   EXPECT_EQ(0, ramcache_.CommitTxn(txn5));
 
   a_.digest[1] = 1;
-  EXPECT_GE(ramcache_.Open(CacheManager::Label(a_)), 0);
+  EXPECT_GE(ramcache_.Open(CacheManager::LabeledObject(a_)), 0);
   a_.digest[1] = 2;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::LabeledObject(a_)));
 }
 
 TEST_F(T_RamCacheManager, VolatileEntry) {
@@ -278,9 +278,9 @@ TEST_F(T_RamCacheManager, VolatileEntry) {
   EXPECT_EQ(0, ramcache_.CommitTxn(txn5));
 
   a_.digest[1] = 1;
-  EXPECT_GE(ramcache_.Open(CacheManager::Label(a_)), 0);
+  EXPECT_GE(ramcache_.Open(CacheManager::LabeledObject(a_)), 0);
   a_.digest[1] = 4;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::LabeledObject(a_)));
 }
 
 TEST_F(T_RamCacheManager, LargeCommit) {
@@ -307,7 +307,7 @@ TEST_F(T_RamCacheManager, LargeCommit) {
   EXPECT_GE(fd, 0);
   EXPECT_EQ(-ENOSPC, ramcache_.CommitTxn(txn3));
   a_.digest[1] = 1;
-  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::Label(a_)));
+  EXPECT_EQ(-ENOENT, ramcache_.Open(CacheManager::LabeledObject(a_)));
   a_.digest[1] = 2;
   EXPECT_EQ(0, ramcache_.Close(fd));
   EXPECT_EQ(0, ramcache_.CommitTxn(txn3));

--- a/test/unittests/t_cache_ram.cc
+++ b/test/unittests/t_cache_ram.cc
@@ -218,9 +218,9 @@ TEST_F(T_RamCacheManager, PinnedEntry) {
   a_.digest[1] = 5;
   EXPECT_EQ(0, ramcache_.StartTxn(a_, alloc_size, txn5));
 
-  ramcache_.CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypePinned, ""),
-    0, txn1);
+  CacheManager::ObjectInfo object_info;
+  object_info.flags = CacheManager::ObjectInfo::kLabelPinned;
+  ramcache_.CtrlTxn(object_info, 0, txn1);
 
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn1));
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn2));
@@ -261,9 +261,9 @@ TEST_F(T_RamCacheManager, VolatileEntry) {
   a_.digest[1] = 5;
   EXPECT_EQ(0, ramcache_.StartTxn(a_, alloc_size, txn5));
 
-  ramcache_.CtrlTxn(
-    CacheManager::ObjectInfo(CacheManager::kTypeVolatile, ""),
-    0, txn4);
+  CacheManager::ObjectInfo object_info;
+  object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
+  ramcache_.CtrlTxn(object_info, 0, txn4);
 
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn1));
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn2));

--- a/test/unittests/t_cache_ram.cc
+++ b/test/unittests/t_cache_ram.cc
@@ -218,9 +218,9 @@ TEST_F(T_RamCacheManager, PinnedEntry) {
   a_.digest[1] = 5;
   EXPECT_EQ(0, ramcache_.StartTxn(a_, alloc_size, txn5));
 
-  CacheManager::ObjectInfo object_info;
-  object_info.flags = CacheManager::ObjectInfo::kLabelPinned;
-  ramcache_.CtrlTxn(object_info, 0, txn1);
+  CacheManager::Label label;
+  label.flags = CacheManager::kLabelPinned;
+  ramcache_.CtrlTxn(label, 0, txn1);
 
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn1));
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn2));
@@ -261,9 +261,9 @@ TEST_F(T_RamCacheManager, VolatileEntry) {
   a_.digest[1] = 5;
   EXPECT_EQ(0, ramcache_.StartTxn(a_, alloc_size, txn5));
 
-  CacheManager::ObjectInfo object_info;
-  object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
-  ramcache_.CtrlTxn(object_info, 0, txn4);
+  CacheManager::Label label;
+  label.flags = CacheManager::kLabelVolatile;
+  ramcache_.CtrlTxn(label, 0, txn4);
 
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn1));
   EXPECT_EQ(alloc_size, ramcache_.Write(buf, alloc_size, txn2));

--- a/test/unittests/t_cache_stream.cc
+++ b/test/unittests/t_cache_stream.cc
@@ -62,7 +62,7 @@ class T_StreamingCacheManager : public ::testing::Test {
 };
 
 TEST_F(T_StreamingCacheManager, Basics) {
-  CacheManager::LabeledObject labeled_obj = CacheManager::Label(hash_demo_);
+  CacheManager::LabeledObject labeled_obj(hash_demo_);
   int fd = streaming_cache_->Open(labeled_obj);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(static_cast<int64_t>(demo_.length()),

--- a/test/unittests/t_cache_stream.cc
+++ b/test/unittests/t_cache_stream.cc
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cache_stream.h>
+#include <util/pointer.h>
+
+class T_StreamingCacheManager : public ::testing::Test {
+ protected:
+  virtual void SetUp() {}
+  virtual void TearDown() {}
+
+  UniquePtr<StreamingCacheManager> cache_mgr_;
+};
+
+TEST_F(T_StreamingCacheManager, Basics) {
+
+}

--- a/test/unittests/t_cache_stream.cc
+++ b/test/unittests/t_cache_stream.cc
@@ -18,7 +18,8 @@ class T_StreamingCacheManager : public ::testing::Test {
   void StageFile(const std::string &content, shash::Any *hash) {
     void *zipped_buf;
     uint64_t zipped_size;
-    zlib::CompressMem2Mem(content.data(), content.length(),
+    zlib::CompressMem2Mem(content.data(),
+                          static_cast<int64_t>(content.length()),
                           &zipped_buf, &zipped_size);
     std::string zipped_data(reinterpret_cast<char *>(zipped_buf), zipped_size);
     HashString(zipped_data, hash);

--- a/test/unittests/t_cache_stream.cc
+++ b/test/unittests/t_cache_stream.cc
@@ -4,17 +4,72 @@
 
 #include <gtest/gtest.h>
 
+#include <cache_posix.h>
 #include <cache_stream.h>
+#include <compression.h>
+#include <crypto/hash.h>
+#include <network/download.h>
+#include <statistics.h>
 #include <util/pointer.h>
+#include <util/posix.h>
 
 class T_StreamingCacheManager : public ::testing::Test {
  protected:
-  virtual void SetUp() {}
-  virtual void TearDown() {}
+  void StageFile(const std::string &content, shash::Any *hash) {
+    void *zipped_buf;
+    uint64_t zipped_size;
+    zlib::CompressMem2Mem(content.data(), content.length(),
+                          &zipped_buf, &zipped_size);
+    std::string zipped_data(reinterpret_cast<char *>(zipped_buf), zipped_size);
+    HashString(zipped_data, hash);
+    EXPECT_TRUE(SafeWriteToFile(zipped_data, "data/" + hash->MakePath(), 0600));
+  }
 
-  UniquePtr<StreamingCacheManager> cache_mgr_;
+  virtual void SetUp() {
+    statistics_ = new perf::Statistics();
+    download_mgr_ = new download::DownloadManager();
+    download_mgr_->Init(16,
+      perf::StatisticsTemplate("download", statistics_.weak_ref()));
+    download_mgr_->SetHostChain("file://" + GetCurrentWorkingDirectory());
+    backing_cache_ =
+      PosixCacheManager::Create("cache", true /* alien_cache */);
+    backing_cache_ref_ = backing_cache_.weak_ref();
+    streaming_cache_ = new StreamingCacheManager(
+      32, backing_cache_.Release(), download_mgr_.weak_ref(), NULL);
+
+    EXPECT_TRUE(MkdirDeep("data", 0700));
+    EXPECT_TRUE(MakeCacheDirectories("data", 0700));
+    hash_demo_.algorithm = shash::kShake128;
+    demo_ = "Hello, World!";
+    StageFile(demo_, &hash_demo_);
+  }
+
+  virtual void TearDown() {
+    streaming_cache_.Destroy();
+    download_mgr_->Fini();
+    download_mgr_.Destroy();
+    statistics_.Destroy();
+  }
+
+  UniquePtr<perf::Statistics> statistics_;
+  UniquePtr<download::DownloadManager> download_mgr_;
+  UniquePtr<PosixCacheManager> backing_cache_;
+  UniquePtr<StreamingCacheManager> streaming_cache_;
+
+  CacheManager *backing_cache_ref_;
+  std::string demo_;
+  shash::Any hash_demo_;
 };
 
 TEST_F(T_StreamingCacheManager, Basics) {
-
+  CacheManager::LabeledObject labeled_obj = CacheManager::Label(hash_demo_);
+  int fd = streaming_cache_->Open(labeled_obj);
+  EXPECT_GE(fd, 0);
+  EXPECT_EQ(static_cast<int64_t>(demo_.length()),
+            streaming_cache_->GetSize(fd));
+  char W = 0;
+  EXPECT_EQ(1, streaming_cache_->Pread(fd, &W, 1, 7));
+  EXPECT_EQ('W', W);
+  EXPECT_EQ(0, streaming_cache_->Close(fd));
+  EXPECT_EQ(-ENOENT, backing_cache_ref_->Open(labeled_obj));
 }

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -45,7 +45,8 @@ TEST_F(T_TieredCacheManager, OpenUpper) {
   EXPECT_EQ(-ENOENT,
             tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
 
-  EXPECT_TRUE(upper_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
+  EXPECT_TRUE(upper_cache_->CommitFromMem(
+    CacheManager::LabeledObject(hash_one_), &buf_, 1));
   int fd = tiered_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd, 0);
 
@@ -62,7 +63,8 @@ TEST_F(T_TieredCacheManager, CopyUp) {
   EXPECT_EQ(-ENOENT,
             tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
 
-  EXPECT_TRUE(lower_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
+  EXPECT_TRUE(lower_cache_->CommitFromMem(
+    CacheManager::LabeledObject(hash_one_), &buf_, 1));
   CacheManager::Label label;
   label.flags = CacheManager::kLabelVolatile;
   int fd = tiered_cache_->Open(CacheManager::LabeledObject(hash_one_, label));
@@ -85,7 +87,8 @@ TEST_F(T_TieredCacheManager, CopyUp) {
 TEST_F(T_TieredCacheManager, Transaction) {
   EXPECT_EQ(-ENOENT,
             tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
-  EXPECT_TRUE(tiered_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
+  EXPECT_TRUE(tiered_cache_->CommitFromMem(
+    CacheManager::LabeledObject(hash_one_), &buf_, 1));
 
   int fd_upper = upper_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd_upper, 0);
@@ -100,7 +103,8 @@ TEST_F(T_TieredCacheManager, ReadOnly) {
   reinterpret_cast<TieredCacheManager *>(tiered_cache_)->SetLowerReadOnly();
   EXPECT_EQ(-ENOENT,
             tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
-  EXPECT_TRUE(tiered_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
+  EXPECT_TRUE(tiered_cache_->CommitFromMem(
+    CacheManager::LabeledObject(hash_one_), &buf_, 1));
 
   int fd_upper = upper_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd_upper, 0);

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -42,10 +42,10 @@ class T_TieredCacheManager : public ::testing::Test {
 
 
 TEST_F(T_TieredCacheManager, OpenUpper) {
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Bless(hash_one_)));
+  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
 
   EXPECT_TRUE(upper_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
-  int fd = tiered_cache_->Open(CacheManager::Bless(hash_one_));
+  int fd = tiered_cache_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd, 0);
 
   EXPECT_EQ(1, tiered_cache_->GetSize(fd));
@@ -58,15 +58,15 @@ TEST_F(T_TieredCacheManager, OpenUpper) {
 
 
 TEST_F(T_TieredCacheManager, CopyUp) {
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Bless(hash_one_)));
+  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
 
   EXPECT_TRUE(lower_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
-  int fd = tiered_cache_->Open(CacheManager::Bless(
+  int fd = tiered_cache_->Open(CacheManager::Label(
     hash_one_, CacheManager::kTypeVolatile));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, stats_upper_.Lookup("test.n_openvolatile")->Get());
 
-  int fd_upper = upper_cache_->Open(CacheManager::Bless(hash_one_));
+  int fd_upper = upper_cache_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd_upper, 0);
   EXPECT_EQ(0, upper_cache_->Close(fd_upper));
 
@@ -80,13 +80,13 @@ TEST_F(T_TieredCacheManager, CopyUp) {
 
 
 TEST_F(T_TieredCacheManager, Transaction) {
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Bless(hash_one_)));
+  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
   EXPECT_TRUE(tiered_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
 
-  int fd_upper = upper_cache_->Open(CacheManager::Bless(hash_one_));
+  int fd_upper = upper_cache_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd_upper, 0);
   EXPECT_EQ(0, upper_cache_->Close(fd_upper));
-  int fd_lower = lower_cache_->Open(CacheManager::Bless(hash_one_));
+  int fd_lower = lower_cache_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd_lower, 0);
   EXPECT_EQ(0, lower_cache_->Close(fd_lower));
 }
@@ -94,13 +94,13 @@ TEST_F(T_TieredCacheManager, Transaction) {
 
 TEST_F(T_TieredCacheManager, ReadOnly) {
   reinterpret_cast<TieredCacheManager *>(tiered_cache_)->SetLowerReadOnly();
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Bless(hash_one_)));
+  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
   EXPECT_TRUE(tiered_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
 
-  int fd_upper = upper_cache_->Open(CacheManager::Bless(hash_one_));
+  int fd_upper = upper_cache_->Open(CacheManager::Label(hash_one_));
   EXPECT_GE(fd_upper, 0);
   EXPECT_EQ(0, upper_cache_->Close(fd_upper));
-  EXPECT_EQ(-ENOENT, lower_cache_->Open(CacheManager::Bless(hash_one_)));
+  EXPECT_EQ(-ENOENT, lower_cache_->Open(CacheManager::Label(hash_one_)));
 
   void *txn = alloca(tiered_cache_->SizeOfTxn());
   EXPECT_EQ(0, tiered_cache_->StartTxn(hash_one_, 1, txn));

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -63,10 +63,9 @@ TEST_F(T_TieredCacheManager, CopyUp) {
             tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
 
   EXPECT_TRUE(lower_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
-  CacheManager::ObjectInfo object_info;
-  object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
-  int fd =
-    tiered_cache_->Open(CacheManager::LabeledObject(hash_one_, object_info));
+  CacheManager::Label label;
+  label.flags = CacheManager::kLabelVolatile;
+  int fd = tiered_cache_->Open(CacheManager::LabeledObject(hash_one_, label));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, stats_upper_.Lookup("test.n_openvolatile")->Get());
 

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -42,10 +42,11 @@ class T_TieredCacheManager : public ::testing::Test {
 
 
 TEST_F(T_TieredCacheManager, OpenUpper) {
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
+  EXPECT_EQ(-ENOENT,
+            tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
 
   EXPECT_TRUE(upper_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
-  int fd = tiered_cache_->Open(CacheManager::Label(hash_one_));
+  int fd = tiered_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd, 0);
 
   EXPECT_EQ(1, tiered_cache_->GetSize(fd));
@@ -58,16 +59,18 @@ TEST_F(T_TieredCacheManager, OpenUpper) {
 
 
 TEST_F(T_TieredCacheManager, CopyUp) {
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
+  EXPECT_EQ(-ENOENT,
+            tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
 
   EXPECT_TRUE(lower_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
   CacheManager::ObjectInfo object_info;
   object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
-  int fd = tiered_cache_->Open(CacheManager::Label(hash_one_, object_info));
+  int fd =
+    tiered_cache_->Open(CacheManager::LabeledObject(hash_one_, object_info));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, stats_upper_.Lookup("test.n_openvolatile")->Get());
 
-  int fd_upper = upper_cache_->Open(CacheManager::Label(hash_one_));
+  int fd_upper = upper_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd_upper, 0);
   EXPECT_EQ(0, upper_cache_->Close(fd_upper));
 
@@ -81,13 +84,14 @@ TEST_F(T_TieredCacheManager, CopyUp) {
 
 
 TEST_F(T_TieredCacheManager, Transaction) {
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
+  EXPECT_EQ(-ENOENT,
+            tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
   EXPECT_TRUE(tiered_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
 
-  int fd_upper = upper_cache_->Open(CacheManager::Label(hash_one_));
+  int fd_upper = upper_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd_upper, 0);
   EXPECT_EQ(0, upper_cache_->Close(fd_upper));
-  int fd_lower = lower_cache_->Open(CacheManager::Label(hash_one_));
+  int fd_lower = lower_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd_lower, 0);
   EXPECT_EQ(0, lower_cache_->Close(fd_lower));
 }
@@ -95,13 +99,15 @@ TEST_F(T_TieredCacheManager, Transaction) {
 
 TEST_F(T_TieredCacheManager, ReadOnly) {
   reinterpret_cast<TieredCacheManager *>(tiered_cache_)->SetLowerReadOnly();
-  EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
+  EXPECT_EQ(-ENOENT,
+            tiered_cache_->Open(CacheManager::LabeledObject(hash_one_)));
   EXPECT_TRUE(tiered_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
 
-  int fd_upper = upper_cache_->Open(CacheManager::Label(hash_one_));
+  int fd_upper = upper_cache_->Open(CacheManager::LabeledObject(hash_one_));
   EXPECT_GE(fd_upper, 0);
   EXPECT_EQ(0, upper_cache_->Close(fd_upper));
-  EXPECT_EQ(-ENOENT, lower_cache_->Open(CacheManager::Label(hash_one_)));
+  EXPECT_EQ(-ENOENT,
+            lower_cache_->Open(CacheManager::LabeledObject(hash_one_)));
 
   void *txn = alloca(tiered_cache_->SizeOfTxn());
   EXPECT_EQ(0, tiered_cache_->StartTxn(hash_one_, 1, txn));

--- a/test/unittests/t_cache_tiered.cc
+++ b/test/unittests/t_cache_tiered.cc
@@ -61,8 +61,9 @@ TEST_F(T_TieredCacheManager, CopyUp) {
   EXPECT_EQ(-ENOENT, tiered_cache_->Open(CacheManager::Label(hash_one_)));
 
   EXPECT_TRUE(lower_cache_->CommitFromMem(hash_one_, &buf_, 1, "one"));
-  int fd = tiered_cache_->Open(CacheManager::Label(
-    hash_one_, CacheManager::kTypeVolatile));
+  CacheManager::ObjectInfo object_info;
+  object_info.flags = CacheManager::ObjectInfo::kLabelVolatile;
+  int fd = tiered_cache_->Open(CacheManager::Label(hash_one_, object_info));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(1, stats_upper_.Lookup("test.n_openvolatile")->Get());
 

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -230,7 +230,7 @@ TEST_F(T_Fetcher, ExternalFetch) {
                                     0);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Label(hash_regular_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_regular_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
@@ -262,7 +262,7 @@ TEST_F(T_Fetcher, Fetch) {
                        zlib::kZlibDefault, 0);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Label(hash_regular_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_regular_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
@@ -279,14 +279,15 @@ TEST_F(T_Fetcher, Fetch) {
                        CacheManager::ObjectInfo::kLabelCatalog);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Label(hash_catalog_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_catalog_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 }
 
 
 TEST_F(T_Fetcher, FetchUncompressed) {
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(hash_uncompressed_)));
+  EXPECT_EQ(-ENOENT,
+            cache_mgr_->Open(CacheManager::LabeledObject(hash_uncompressed_)));
 
   // Download and store in cache
   // TODO(jblomer): use CacheManager::kSizeUnknown
@@ -298,7 +299,7 @@ TEST_F(T_Fetcher, FetchUncompressed) {
     fetcher_->Fetch(hash_uncompressed_, 1, "x", zlib::kNoCompression, 0);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Label(hash_uncompressed_));
+  fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_uncompressed_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 }
@@ -427,7 +428,7 @@ TEST_F(T_Fetcher, FetchCollapse) {
 TEST_F(T_Fetcher, SignalWaitingThreads) {
   unsigned char x = 'x';
   EXPECT_TRUE(cache_mgr_->CommitFromMem(hash_regular_, &x, 1, ""));
-  int fd = cache_mgr_->Open(CacheManager::Label(hash_regular_));
+  int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_regular_));
   EXPECT_GE(fd, 0);
   int tls_pipe[2];
   MakePipe(tls_pipe);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -126,7 +126,7 @@ class BuggyCacheManager : public CacheManager {
   virtual CacheManagerIds id() { return kUnknownCacheManager; }
   virtual std::string Describe() { return "test\n"; }
   virtual bool AcquireQuotaManager(QuotaManager *qm) { return false; }
-  virtual int Open(const BlessedObject &object) {
+  virtual int Open(const LabeledObject &object) {
     if (!allow_open) {
       if (open_2nd_try)
         allow_open = true;
@@ -230,7 +230,7 @@ TEST_F(T_Fetcher, ExternalFetch) {
                                     CacheManager::kTypeRegular);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_regular_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_regular_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
@@ -263,7 +263,7 @@ TEST_F(T_Fetcher, Fetch) {
                        zlib::kZlibDefault, CacheManager::kTypeRegular);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_regular_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_regular_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 
@@ -279,14 +279,14 @@ TEST_F(T_Fetcher, Fetch) {
                        zlib::kZlibDefault, CacheManager::kTypeCatalog);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_catalog_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_catalog_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 }
 
 
 TEST_F(T_Fetcher, FetchUncompressed) {
-  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Bless(hash_uncompressed_)));
+  EXPECT_EQ(-ENOENT, cache_mgr_->Open(CacheManager::Label(hash_uncompressed_)));
 
   // Download and store in cache
   // TODO(jblomer): use CacheManager::kSizeUnknown
@@ -300,7 +300,7 @@ TEST_F(T_Fetcher, FetchUncompressed) {
                     zlib::kNoCompression, CacheManager::kTypeRegular);
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
-  fd = cache_mgr_->Open(CacheManager::Bless(hash_uncompressed_));
+  fd = cache_mgr_->Open(CacheManager::Label(hash_uncompressed_));
   EXPECT_GE(fd, 0);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
 }
@@ -429,7 +429,7 @@ TEST_F(T_Fetcher, FetchCollapse) {
 TEST_F(T_Fetcher, SignalWaitingThreads) {
   unsigned char x = 'x';
   EXPECT_TRUE(cache_mgr_->CommitFromMem(hash_regular_, &x, 1, ""));
-  int fd = cache_mgr_->Open(CacheManager::Bless(hash_regular_));
+  int fd = cache_mgr_->Open(CacheManager::Label(hash_regular_));
   EXPECT_GE(fd, 0);
   int tls_pipe[2];
   MakePipe(tls_pipe);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -243,7 +243,8 @@ TEST_F(T_Fetcher, Fetch) {
   // Cache hit
   unsigned char x = 'x';
   shash::Any hash_avail(shash::kSha1);
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(hash_avail, &x, 1, ""));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(CacheManager::LabeledObject(hash_avail),
+                                        &x, 1));
   int fd =
     fetcher_->Fetch(hash_avail, 1, "", zlib::kZlibDefault, 0);
   EXPECT_GE(fd, 0);
@@ -421,7 +422,8 @@ TEST_F(T_Fetcher, FetchCollapse) {
 
 TEST_F(T_Fetcher, SignalWaitingThreads) {
   unsigned char x = 'x';
-  EXPECT_TRUE(cache_mgr_->CommitFromMem(hash_regular_, &x, 1, ""));
+  EXPECT_TRUE(cache_mgr_->CommitFromMem(
+    CacheManager::LabeledObject(hash_regular_), &x, 1));
   int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_regular_));
   EXPECT_GE(fd, 0);
   int tls_pipe[2];

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -126,7 +126,7 @@ class BuggyCacheManager : public CacheManager {
   virtual CacheManagerIds id() { return kUnknownCacheManager; }
   virtual std::string Describe() { return "test\n"; }
   virtual bool AcquireQuotaManager(QuotaManager *qm) { return false; }
-  virtual int Open(const LabeledObject &object) {
+  virtual int Open(const LabeledObject & /* object */) {
     if (!allow_open) {
       if (open_2nd_try)
         allow_open = true;
@@ -149,7 +149,9 @@ class BuggyCacheManager : public CacheManager {
     *static_cast<int *>(txn) = fd;
     return 0;
   }
-  virtual void CtrlTxn(const Label &label, const int flags, void *txn) {
+  virtual void CtrlTxn(const Label & /* label */, const int /* flags */,
+                       void * /* txn */)
+  {
     if (stall_in_ctrltxn) {
       atomic_inc32(&waiting_in_ctrltxn);
       while (atomic_read32(&continue_ctrltxn) == 0) { }

--- a/test/unittests/t_kvstore.cc
+++ b/test/unittests/t_kvstore.cc
@@ -36,7 +36,7 @@ class T_MemoryKvStore : public ::testing::Test {
     buf_.address = malloc(malloc_size);
     buf_.size = malloc_size;
     buf_.refcount = 0;
-    buf_.object_type = CacheManager::kTypeRegular;
+    buf_.object_flags = 0;
   }
 
   virtual void TearDown() {}


### PR DESCRIPTION
This is a first draft of a streaming cache manager. The streaming cache manager implements the `CacheManager` interface. It uses a download manager and a backing cache manager to deliver data. Pinned files and catalogs use the backing cache manager. Regular data blocks are downloaded on read, the required data window copied to the user.  

To turn it on, just set `CVMFS_STREAMING_CACHE=yes`.

For small files, we probably don't need a memory cache for downloaded objects. The kernel page cache does all the work.  It gets problematic for large chunks that are read in several small pieces, because each of them trigger a re-download of the entire chunk.

TODOs:

- [x] Fix use of external files
- [x] Save and restore the file table to support client reload
- [x] Testing