### PR TITLE
Use the ISO ordering for the date in cvmfs_server_gc.sh

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -145,7 +145,7 @@ cvmfs_server_gc() {
       echo "Preserved Legacy Revisions:    $preserve_revisions"
     fi
     if [ $preserve_timestamp -gt 0 ]; then
-      echo "Preserve Revisions newer than: $(date -d@$preserve_timestamp +'%x %X')"
+      echo "Preserve Revisions newer than: $(date -d@$preserve_timestamp +'%Y/%m/%d %H:%M:%S')"
     fi
     if [ $preserve_revisions -le 0 ] && [ $preserve_timestamp -le 0 ]; then
       echo "Only the latest revision will be preserved."


### PR DESCRIPTION
It's less confusing. This only changes the ordering of the date, the rest should remain the same most of the time (I don't know if changing the locale the format would be different though). With `en_US.UTF-8` it only changes the ordering