### PR TITLE
Update filter options in cvmfs_rsync to allow cvmfscatalog files to be created

### DIFF
--- a/cvmfs/cvmfs_rsync
+++ b/cvmfs/cvmfs_rsync
@@ -9,7 +9,7 @@ ME=cvmfs_rsync
 usage()
 {
     echo "Usage: $ME [rsync_parameters]" >&2
-    echo "  Rsync to cvmfs repositories.  Avoids .cvmfscatalog and .cvmfsautocatalog" >&2
+    echo "  Rsync to cvmfs repositories.  Avoids deleting .cvmfscatalog and .cvmfsautocatalog" >&2
     echo "  files while allowing directories containing them to be deleted when their" >&2
     echo "  source goes away." >&2
     exit 1
@@ -20,4 +20,4 @@ if [ $# -lt 2 ]; then
     usage
 fi
 
-exec rsync --filter='-p .cvmfscatalog' --filter='-p .cvmfsautocatalog' "$@"
+exec rsync --filter='Pp .cvmfscatalog' --filter='Pp .cvmfsautocatalog' "$@"


### PR DESCRIPTION
This PR modifies the `--filter` options automatically applied in `cvmfs_rsync` to allow `.cvmfs{auto}catalog` files to be _created_ during the rsync operation, but not (accidentally) deleted.

I'm not sure if the `Pp` filter should only apply to `.cvmfscatalog` and not `.cvmfsautocatalog` (i.e. don't allow rsync to create or delete `.cvmfsautocatalog`) - I don't really understand the standard use cases well enough.

cc @DrDaveD 