### PR TITLE
extend grep filter to accept microsecond precision in tags

### DIFF
--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -494,7 +494,7 @@ filter_auto_tags() {
     $(get_swissknife_proxy)                    \
     -x $(get_follow_http_redirects_flag)       | \
     grep -E \
-    '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.?[[:digit:]]{0,3}Z' | \
+    '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}(\.[[:digit:]]{1,3})?Z' | \
     awk '{print $1 " " $5}')"
   [ "x$auto_tags" = "x" ] && return 0 || true
 

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -494,7 +494,7 @@ filter_auto_tags() {
     $(get_swissknife_proxy)                    \
     -x $(get_follow_http_redirects_flag)       | \
     grep -E \
-    '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}Z' | \
+    '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.?[[:digit:]]{0,3}Z' | \
     awk '{print $1 " " $5}')"
   [ "x$auto_tags" = "x" ] && return 0 || true
 


### PR DESCRIPTION
In some cases the tag names can have extra precision in their timestamps. This extends the filter to accept a potential dot and up to 3 digits for microseconds.

Fix https://github.com/cvmfs/cvmfs/issues/3271

It works based on this simple test:
```
$ cat tags
generic-2023-05-04T22:00:25Z     │    13476 │ 4 May 2023 15:00:49  │        │ 
generic-2023-05-04T22:51:06Z     │    13478 │ 4 May 2023 15:51:27  │        │ 
generic-2023-05-05T21:20:12.918Z │    13480 │ 5 May 2023 14:20:13  │        │ 
generic-2023-05-07T15:05:56.115Z │    13481 │ 7 May 2023 08:05:57  │        │ 
# previous filter
$ grep -E  '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}Z' tags
generic-2023-05-04T22:00:25Z     │    13476 │ 4 May 2023 15:00:49  │        │ 
generic-2023-05-04T22:51:06Z     │    13478 │ 4 May 2023 15:51:27  │        │ 
# updated filter
$ grep -E '^generic(_[[:digit:]]+)?-[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.?[[:digit:]]{0,3}Z' tags
generic-2023-05-04T22:00:25Z     │    13476 │ 4 May 2023 15:00:49  │        │ 
generic-2023-05-04T22:51:06Z     │    13478 │ 4 May 2023 15:51:27  │        │ 
generic-2023-05-05T21:20:12.918Z │    13480 │ 5 May 2023 14:20:13  │        │ 
generic-2023-05-07T15:05:56.115Z │    13481 │ 7 May 2023 08:05:57  │        │ 
```