### PR TITLE
Allow authz helper to be ignored for HTTPS

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -934,7 +934,8 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
     if (info->pid != -1) {
       if (credentials_attachment_ == NULL) {
         LogCvmfs(kLogDownload, kLogDebug,
-                 "uses secure downloads but no credentials attachment set");
+                 "HTTPS download without credentials: file %s",
+                 info->url->c_str());
       } else {
         bool retval = credentials_attachment_->ConfigureCurlHandle(
           curl_handle, info->pid, &info->cred_data);


### PR DESCRIPTION
Issue #3213 

Authz is always created, but only used for HTTPS downloads. 
As such change `mountpoint.cc` that no Authz is created when no CVMFS param is given

Change of behavior:
`CVMFS_AUTHZ_HELPER` must always be given now. If the default authz helper should be used (found automatically by cvmfs) then `CVMFS_AUTHZ_HELPER=default` must be set (as such a custom authz helper cannot be called "default")

Still needs verification with a cloud test