### PR TITLE
Custom http tracing headers

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1460,10 +1460,10 @@ bool MountPoint::CreateDownloadManagers() {
       options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableHTTPTracing();
     if (options_mgr_->GetValue("CVMFS_HTTP_TRACING_HEADERS", &optarg)) {
-      if (optarg.size() > 200) {
+      if (optarg.size() > 1000) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-             "CVMFS_HTTP_TRACING_HEADERS too large ( max 200 chars, given %d )",
-             optarg.size());
+            "CVMFS_HTTP_TRACING_HEADERS too large ( max 1000 chars, given %d )",
+            optarg.size());
       } else {
         std::vector<std::string> tokens = SplitString(optarg, '|');
         sanitizer::AlphaNumSanitizer sanitizer;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1485,19 +1485,11 @@ bool MountPoint::CreateDownloadManagers() {
           std::string key = Trim(key_val[0]);
 
           if (!sanitizer.IsValid(key)) {
-            // check if the key starts already with the X-CVMFS- prefix and that
-            // no other "-" are part of it. If yes accept it as valid
-            // tracing header
-            if (key.compare(0, prefix.size(), prefix) == 0 &&
-                SplitString(key, '-').size() == 3) {
-              prefix = "";
-            } else {
-              LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-              "Http tracing header: Skipping current token part of "
-              "CVMFS_HTTP_TRACING_HEADERS! Invalid key. Only alphanumeric keys "
-              "are allowed (a-z, A-Z, 0-9). Token: %s", token.c_str());
-              continue;
-            }
+            LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+            "Http tracing header: Skipping current token part of "
+            "CVMFS_HTTP_TRACING_HEADERS! Invalid key. Only alphanumeric keys "
+            "are allowed (a-z, A-Z, 0-9). Token: %s", token.c_str());
+            continue;
           }
 
           std::string final_token = prefix + key + ": " + Trim(key_val[1]);

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1460,44 +1460,50 @@ bool MountPoint::CreateDownloadManagers() {
       options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableHTTPTracing();
     if (options_mgr_->GetValue("CVMFS_HTTP_TRACING_HEADERS", &optarg)) {
-      std::vector<std::string> tokens = SplitString(optarg, '|');
-      sanitizer::AlphaNumSanitizer sanitizer;
+      if (optarg.size() > 200) {
+        LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "CVMFS_HTTP_TRACING_HEADERS too large ( max 200 chars, given %d )",
+             optarg.size());
+      } else {
+        std::vector<std::string> tokens = SplitString(optarg, '|');
+        sanitizer::AlphaNumSanitizer sanitizer;
 
-      for (unsigned int i = 0; i < tokens.size(); i++) {
-        std::string token = Trim(tokens[i]);
+        for (unsigned int i = 0; i < tokens.size(); i++) {
+          std::string token = Trim(tokens[i]);
 
-        std::vector<std::string> key_val = SplitString(token, ':');
+          std::vector<std::string> key_val = SplitString(token, ':');
 
-        if (key_val.size() != 2) {
-          LogCvmfs(kLogCvmfs, kLogSyslog | kLogDebug,
-             "Http tracing header: Skipping current token part of "
-             "CVMFS_HTTP_TRACING_HEADERS! Invalid "
-             "<key:value> pair. Token: %s", token.c_str());
-          continue;
-        }
-
-        std::string prefix = "X-CVMFS-";
-        std::string key = Trim(key_val[0]);
-
-        if (!sanitizer.IsValid(key)) {
-          // check if the key starts already with the X-CVMFS- prefix and that
-          // no other "-" are part of it. If yes accept it as valid
-          // tracing header
-          if (key.compare(0, prefix.size(), prefix) == 0 &&
-              SplitString(key, '-').size() == 3) {
-            prefix = "";
-          } else {
-            LogCvmfs(kLogCvmfs, kLogSyslog | kLogDebug,
-            "Http tracing header: Skipping current token part of "
-            "CVMFS_HTTP_TRACING_HEADERS! Invalid key. Only alphanumeric keys "
-            "are allowed (a-z, A-Z, 0-9). Token: %s", token.c_str());
+          if (key_val.size() != 2) {
+            LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+              "Http tracing header: Skipping current token part of "
+              "CVMFS_HTTP_TRACING_HEADERS! Invalid "
+              "<key:value> pair. Token: %s", token.c_str());
             continue;
           }
+
+          std::string prefix = "X-CVMFS-";
+          std::string key = Trim(key_val[0]);
+
+          if (!sanitizer.IsValid(key)) {
+            // check if the key starts already with the X-CVMFS- prefix and that
+            // no other "-" are part of it. If yes accept it as valid
+            // tracing header
+            if (key.compare(0, prefix.size(), prefix) == 0 &&
+                SplitString(key, '-').size() == 3) {
+              prefix = "";
+            } else {
+              LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+              "Http tracing header: Skipping current token part of "
+              "CVMFS_HTTP_TRACING_HEADERS! Invalid key. Only alphanumeric keys "
+              "are allowed (a-z, A-Z, 0-9). Token: %s", token.c_str());
+              continue;
+            }
+          }
+
+          std::string final_token = prefix + key + ": " + Trim(key_val[1]);
+
+          download_mgr_->AddHTTPTracingHeader(final_token);
         }
-
-        std::string final_token = prefix + key + ": " + Trim(key_val[1]);
-
-        download_mgr_->AddHTTPTracingHeader(final_token);
       }
     }
   }

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1692,7 +1692,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
                  header_size - header_name_len);
     info->info_header()[header_size-1] = '\0';
   }
-  
+
   if (enable_http_tracing_) {
     const std::string str_pid = "X-CVMFS-PID: " + StringifyInt(info->pid);
     const std::string str_gid = "X-CVMFS-GID: " + StringifyUint(info->gid);

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -789,9 +789,9 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
     header_lists_->AppendHeader(info->headers(), info->info_header());
   }
   if (enable_http_tracing_) {
-    for (unsigned int i = 0; i < http_tracing_headers_->size(); i++) {
+    for (unsigned int i = 0; i < http_tracing_headers_.size(); i++) {
       header_lists_->AppendHeader(info->headers(),
-                                  (*http_tracing_headers_)[i].c_str());
+                                  (http_tracing_headers_)[i].c_str());
     }
 
     header_lists_->AppendHeader(info->headers(), info->tracing_header_pid());
@@ -1497,7 +1497,7 @@ DownloadManager::DownloadManager() {
   ignore_signature_failures_ = false;
 
   enable_http_tracing_ = false;
-  http_tracing_headers_ = new vector<string>();
+  http_tracing_headers_ = vector<string>();
 
   resolver_ = NULL;
 
@@ -2726,7 +2726,7 @@ void DownloadManager::EnableHTTPTracing() {
 }
 
 void DownloadManager::AddHTTPTracingHeader(const std::string &header) {
-  http_tracing_headers_->push_back(header);
+  http_tracing_headers_.push_back(header);
 }
 
 void DownloadManager::UseSystemCertificatePath() {
@@ -2757,9 +2757,7 @@ DownloadManager *DownloadManager::Clone(
   clone->opt_backoff_max_ms_ = opt_backoff_max_ms_;
   clone->enable_info_header_ = enable_info_header_;
   clone->enable_http_tracing_ = enable_http_tracing_;
-  if (enable_http_tracing_) {
-    clone->http_tracing_headers_ = new vector<string>(*http_tracing_headers_);
-  }
+  clone->http_tracing_headers_ = http_tracing_headers_;
   clone->follow_redirects_ = follow_redirects_;
   clone->ignore_signature_failures_ = ignore_signature_failures_;
   if (opt_host_chain_) {

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -799,7 +799,7 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
     header_lists_->AppendHeader(info->headers(), info->tracing_header_uid());
 
     LogCvmfs(kLogDownload, kLogDebug, "CURL Header for URL: %s is:\n %s",
-             info->url()->c_str(), header_lists_->Print(info->headers()).c_str());
+           info->url()->c_str(), header_lists_->Print(info->headers()).c_str());
   }
 
   if (info->force_nocache()) {

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -797,9 +797,9 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
     std::string str_gid = "X-CVMFS-GID: " + StringifyUint(info->gid);
     std::string str_uid = "X-CVMFS-UID: " + StringifyUint(info->uid);
 
-    header_lists_->AppendHeader(info->headers, str_pid.c_str());
-    header_lists_->AppendHeader(info->headers, str_gid.c_str());
-    header_lists_->AppendHeader(info->headers, str_uid.c_str());
+    header_lists_->AppendHeader(info->headers, strdup(str_pid.c_str()));
+    header_lists_->AppendHeader(info->headers, strdup(str_gid.c_str()));
+    header_lists_->AppendHeader(info->headers, strdup(str_uid.c_str()));
 
     LogCvmfs(kLogDownload, kLogDebug, "CURL Header for URL: %s is:\n %s",
              info->url->c_str(), header_lists_->Print(info->headers).c_str());

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -790,19 +790,19 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
   }
   if (enable_http_tracing_) {
     for (unsigned int i = 0; i < http_tracing_headers_->size(); i++) {
-      header_lists_->AppendHeader(info->headers,
+      header_lists_->AppendHeader(info->headers(),
                                   (*http_tracing_headers_)[i].c_str());
     }
 
-    header_lists_->AppendHeader(info->headers, info->tracing_header_pid);
-    header_lists_->AppendHeader(info->headers, info->tracing_header_gid);
-    header_lists_->AppendHeader(info->headers, info->tracing_header_uid);
+    header_lists_->AppendHeader(info->headers(), info->tracing_header_pid());
+    header_lists_->AppendHeader(info->headers(), info->tracing_header_gid());
+    header_lists_->AppendHeader(info->headers(), info->tracing_header_uid());
 
     LogCvmfs(kLogDownload, kLogDebug, "CURL Header for URL: %s is:\n %s",
-             info->url->c_str(), header_lists_->Print(info->headers).c_str());
+             info->url()->c_str(), header_lists_->Print(info->headers()).c_str());
   }
 
-  if (info->force_nocache) {
+  if (info->force_nocache()) {
     SetNocache(info);
   } else {
     info->SetNocache(false);
@@ -1694,18 +1694,18 @@ Failures DownloadManager::Fetch(JobInfo *info) {
   }
 
   if (enable_http_tracing_) {
-    const std::string str_pid = "X-CVMFS-PID: " + StringifyInt(info->pid);
-    const std::string str_gid = "X-CVMFS-GID: " + StringifyUint(info->gid);
-    const std::string str_uid = "X-CVMFS-UID: " + StringifyUint(info->uid);
+    const std::string str_pid = "X-CVMFS-PID: " + StringifyInt(info->pid());
+    const std::string str_gid = "X-CVMFS-GID: " + StringifyUint(info->gid());
+    const std::string str_uid = "X-CVMFS-UID: " + StringifyUint(info->uid());
 
     // will be auto freed at the end of this function Fetch(JobInfo *info)
-    info->tracing_header_pid = static_cast<char *>(alloca(str_pid.size() + 1));
-    info->tracing_header_gid = static_cast<char *>(alloca(str_gid.size() + 1));
-    info->tracing_header_uid = static_cast<char *>(alloca(str_uid.size() + 1));
+    info->SetTracingHeaderPid(static_cast<char *>(alloca(str_pid.size() + 1)));
+    info->SetTracingHeaderGid(static_cast<char *>(alloca(str_gid.size() + 1)));
+    info->SetTracingHeaderUid(static_cast<char *>(alloca(str_uid.size() + 1)));
 
-    memcpy(info->tracing_header_pid, str_pid.c_str(), str_pid.size() + 1);
-    memcpy(info->tracing_header_gid, str_gid.c_str(), str_gid.size() + 1);
-    memcpy(info->tracing_header_uid, str_uid.c_str(), str_uid.size() + 1);
+    memcpy(info->tracing_header_pid(), str_pid.c_str(), str_pid.size() + 1);
+    memcpy(info->tracing_header_gid(), str_gid.c_str(), str_gid.size() + 1);
+    memcpy(info->tracing_header_uid(), str_uid.c_str(), str_uid.size() + 1);
   }
 
   if (atomic_xadd32(&multi_threaded_, 0) == 1) {

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -206,6 +206,8 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void EnableInfoHeader();
   void EnableRedirects();
   void EnableIgnoreSignatureFailures();
+  void EnableHTTPTracing();
+  void AddHTTPTracingHeader(const std::string &header);
   void UseSystemCertificatePath();
 
   unsigned num_hosts() {
@@ -289,6 +291,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    * In general it is a bad idea to do this!
    */
   bool ignore_signature_failures_;
+  
+  bool enable_http_tracing_;
+  std::vector<std::string> *http_tracing_headers_;
 
   // Host list
   std::vector<std::string> *opt_host_chain_;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -293,7 +293,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool ignore_signature_failures_;
 
   bool enable_http_tracing_;
-  std::vector<std::string> *http_tracing_headers_;
+  std::vector<std::string> http_tracing_headers_;
 
   // Host list
   std::vector<std::string> *opt_host_chain_;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -291,7 +291,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    * In general it is a bad idea to do this!
    */
   bool ignore_signature_failures_;
-  
+
   bool enable_http_tracing_;
   std::vector<std::string> *http_tracing_headers_;
 

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -57,6 +57,9 @@ void JobInfo::Init() {
   curl_handle_ = NULL;
   headers_ = NULL;
   info_header_ = NULL;
+  tracing_header_pid_ = NULL;
+  tracing_header_gid_ = NULL;
+  tracing_header_uid_ = NULL;
   nocache_ = false;
   error_code_ = kFailOther;
   http_code_ = -1;

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -60,6 +60,9 @@ class JobInfo {
   CURL *curl_handle_;
   curl_slist *headers_;
   char *info_header_;
+  char *tracing_header_pid_;
+  char *tracing_header_gid_;
+  char *tracing_header_uid_;
   z_stream zstream_;
   shash::ContextPtr hash_context_;
   std::string proxy_;
@@ -142,6 +145,9 @@ class JobInfo {
   CURL *curl_handle() const { return curl_handle_; }
   curl_slist *headers() const { return headers_; }
   char *info_header() const { return info_header_; }
+  char *tracing_header_pid() const { return tracing_header_pid_; }
+  char *tracing_header_gid() const { return tracing_header_gid_; }
+  char *tracing_header_uid() const { return tracing_header_uid_; }
   z_stream zstream() const { return zstream_; }
   shash::ContextPtr hash_context() const { return hash_context_; }
   std::string proxy() const { return proxy_; }
@@ -154,26 +160,6 @@ class JobInfo {
   unsigned backoff_ms() const { return backoff_ms_; }
   unsigned int current_host_chain_index() const {
                                              return current_host_chain_index_; }
-  // Internal state, don't touch
-  CURL *curl_handle;
-  curl_slist *headers;
-  char *info_header;
-  char *tracing_header_pid;
-  char *tracing_header_gid;
-  char *tracing_header_uid;
-  z_stream zstream;
-  shash::ContextPtr hash_context;
-  /// Pipe used for the return value
-  UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;
-  std::string proxy;
-  bool nocache;
-  Failures error_code;
-  int http_code;
-  unsigned char num_used_proxies;
-  unsigned char num_used_hosts;
-  unsigned char num_retries;
-  unsigned backoff_ms;
-  unsigned int current_host_chain_index;
 
   void SetUrl(const std::string *url) { url_ = url; }
   void SetCompressed(bool compressed) { compressed_ = compressed; }
@@ -201,6 +187,12 @@ class JobInfo {
   void SetCurlHandle(CURL *curl_handle) { curl_handle_ = curl_handle; }
   void SetHeaders(curl_slist *headers) { headers_ = headers; }
   void SetInfoHeader(char *info_header) { info_header_ = info_header; }
+  void SetTracingHeaderPid (char *tracing_header_pid)
+                                  { tracing_header_pid_ = tracing_header_pid; };
+  void SetTracingHeaderGid (char *tracing_header_gid)
+                                  { tracing_header_gid_ = tracing_header_gid; };
+  void SetTracingHeaderUid (char *tracing_header_uid)
+                                  { tracing_header_uid_ = tracing_header_uid; };
   void SetZstream(z_stream zstream) { zstream_ = zstream; }
   void SetHashContext(shash::ContextPtr hash_context)
                                                { hash_context_ = hash_context; }

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -154,6 +154,26 @@ class JobInfo {
   unsigned backoff_ms() const { return backoff_ms_; }
   unsigned int current_host_chain_index() const {
                                              return current_host_chain_index_; }
+  // Internal state, don't touch
+  CURL *curl_handle;
+  curl_slist *headers;
+  char *info_header;
+  char *tracing_header_pid;
+  char *tracing_header_gid;
+  char *tracing_header_uid;
+  z_stream zstream;
+  shash::ContextPtr hash_context;
+  /// Pipe used for the return value
+  UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;
+  std::string proxy;
+  bool nocache;
+  Failures error_code;
+  int http_code;
+  unsigned char num_used_proxies;
+  unsigned char num_used_hosts;
+  unsigned char num_retries;
+  unsigned backoff_ms;
+  unsigned int current_host_chain_index;
 
   void SetUrl(const std::string *url) { url_ = url; }
   void SetCompressed(bool compressed) { compressed_ = compressed; }

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -187,11 +187,11 @@ class JobInfo {
   void SetCurlHandle(CURL *curl_handle) { curl_handle_ = curl_handle; }
   void SetHeaders(curl_slist *headers) { headers_ = headers; }
   void SetInfoHeader(char *info_header) { info_header_ = info_header; }
-  void SetTracingHeaderPid (char *tracing_header_pid)
+  void SetTracingHeaderPid(char *tracing_header_pid)
                                   { tracing_header_pid_ = tracing_header_pid; };
-  void SetTracingHeaderGid (char *tracing_header_gid)
+  void SetTracingHeaderGid(char *tracing_header_gid)
                                   { tracing_header_gid_ = tracing_header_gid; };
-  void SetTracingHeaderUid (char *tracing_header_uid)
+  void SetTracingHeaderUid(char *tracing_header_uid)
                                   { tracing_header_uid_ = tracing_header_uid; };
   void SetZstream(z_stream zstream) { zstream_ = zstream; }
   void SetHashContext(shash::ContextPtr hash_context)

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -10,19 +10,21 @@ TEST099_MOUNTPOINT=/cvmfs/lhcb.cern.ch
 CVMFS_TEST_099_TMPFILE=
 
 mount_and_read() {
-  echo "Check detection of counter change"
+  echo "Mount repo, read and check HTTP tracing headers"
 
   # used in file test_functions for cvmfs_moount()
   CVMFS_TEST_DEBUGLOG="/tmp/$CVMFS_TEST_099_TMPFILE"
-  CVMFS_TEST_QUOTED_PARAM_KEY="CVMFS_HTTP_TRACING_HEADERS"
-  CVMFS_TEST_QUOTED_PARAM_VAL="h1:test|CVMFS-X-h2:ff|X-CVMFS-h3:12_ad |  h4  : 12fs_?"
+  CVMFS_TEST_QUOTED_PARAM_KEY_VAL='CVMFS_HTTP_TRACING_HEADERS="h1:test|CVMFS-X-h2:ff|X-CVMFS-h3:12_ad |  h4  : 12fs_? "'
 
   echo "   Mount $TEST099_REPO"
   cvmfs_mount $TEST099_REPO "CVMFS_HTTP_TRACING=on"
 
+  echo "   Client config $TEST099_REPO"
+  cat /etc/cvmfs/default.local
 
 
-  echo "   Do something to change counters"
+
+  echo "   Access data to send HTTP requests"
   cat $TEST099_MOUNTPOINT/*.sh > /dev/null
   cat $TEST099_MOUNTPOINT/etc/grid-security/*.pem > /dev/null
 

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -17,7 +17,7 @@ mount_and_read() {
   CVMFS_TEST_QUOTED_PARAM_KEY_VAL='CVMFS_HTTP_TRACING_HEADERS="h1:test|CVMFS-X-h2:ff|X-CVMFS-h3:12_ad |  h4  : 12fs_? "'
 
   echo "   Mount $TEST099_REPO"
-  cvmfs_mount $TEST099_REPO "CVMFS_HTTP_TRACING=on"
+  cvmfs_mount $TEST099_REPO "CVMFS_HTTP_TRACING=on" || return 1
 
   echo "   Client config $TEST099_REPO"
   cat /etc/cvmfs/default.local

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -13,7 +13,7 @@ mount_and_read() {
   echo "Mount repo, read and check HTTP tracing headers"
 
   # used in file test_functions for cvmfs_moount()
-  CVMFS_TEST_DEBUGLOG="/tmp/$CVMFS_TEST_099_TMPFILE"
+  CVMFS_TEST_DEBUGLOG="$CVMFS_TEST_099_TMPFILE"
   CVMFS_TEST_QUOTED_PARAM_KEY_VAL='CVMFS_HTTP_TRACING_HEADERS="h1:test|CVMFS-X-h2:ff|X-CVMFS-h3:12_ad |  h4  : 12fs_? "'
 
   echo "   Mount $TEST099_REPO"
@@ -22,25 +22,30 @@ mount_and_read() {
   echo "   Client config $TEST099_REPO"
   cat /etc/cvmfs/default.local
 
-
-
   echo "   Access data to send HTTP requests"
-  cat $TEST099_MOUNTPOINT/*.sh > /dev/null
-  cat $TEST099_MOUNTPOINT/etc/grid-security/*.pem > /dev/null
+  local some_files
+  some_files=$(find $TEST099_MOUNTPOINT -type f | head -n3)
+  cat "$some_files" > /dev/null
 
   echo "   Umount $TEST099_REPO"
-  test099_unmount $TEST099_REPO
+  cvmfs_umount $TEST099_REPO
 
-  pwd
-  echo $CVMFS_TEST_099_TMPFILE
-  echo "   Check output in file /tmp/$CVMFS_TEST_099_TMPFILE"
-  local h1=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h1: test")
-  local h2=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h2: ff")
-  local h3=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h3: 12_ad")
-  local h4=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h4: 12fs_?")
-  local pid=$(sudo grep /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-PID:" | sort | uniq | wc -l)
-  local gid=$(sudo grep /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-GID:" | sort | uniq | wc -l)
-  local uid=$(sudo grep /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-UID:" | sort | uniq | wc -l)
+  echo "   Check output in file $CVMFS_TEST_099_TMPFILE"
+  local h1
+  local h2
+  local h3
+  local h4
+  local pid
+  local gid
+  local uid
+
+  h1=$(sudo grep -c "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-h1: test")
+  h2=$(sudo grep -c "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-h2: ff")
+  h3=$(sudo grep -c "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-h3: 12_ad")
+  h4=$(sudo grep -c "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-h4: 12fs_?")
+  pid=$(sudo grep "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-PID:" | sort | uniq | wc -l)
+  gid=$(sudo grep "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-GID:" | sort | uniq | wc -l)
+  uid=$(sudo grep "$CVMFS_TEST_099_TMPFILE" -e "X-CVMFS-UID:" | sort | uniq | wc -l)
 
   echo "      Occurence of h1 correct? $h1 > 0"
   [ "$h1" -gt "0" ] || return 10
@@ -57,11 +62,10 @@ mount_and_read() {
   [ "$pid" -gt "1" ] || return 20
 
   echo "      Unique occurence of gid correct? $gid > 1"
-  [ "$pid" -gt "1" ] || return 20
+  [ "$gid" -gt "1" ] || return 21
 
   echo "      Unique occurence of uid correct? $uid > 1"
-  [ "$pid" -gt "1" ] || return 20
-
+  [ "$uid" -gt "1" ] || return 22
 
   echo "   ... Success"
 }
@@ -71,7 +75,9 @@ cvmfs_run_test() {
   trap cleanup HUP INT TERM EXIT || return $?
 
   echo "create temporary directory"
-  CVMFS_TEST_099_TMPFILE=$(mktemp ./test099.log.XXXXXXXX)
+  CVMFS_TEST_099_TMPFILE=$(mktemp /tmp/cvmfs_test099.log.XXXXXXXX)
+  # needed because of wrong file ownership
+  sudo rm -f "$CVMFS_TEST_099_TMPFILE"
   echo "tmpfile is $CVMFS_TEST_099_TMPFILE"
 
   mount_and_read || return $?

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -1,0 +1,78 @@
+cvmfs_test_name="HTTP Tracing with Custom Headers"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+source ./src/099-http_tracing/setup_teardown
+
+TEST099_REPO=lhcb.cern.ch
+TEST099_MOUNTPOINT=/cvmfs/lhcb.cern.ch
+
+CVMFS_TEST_099_TMPFILE=
+
+mount_and_read() {
+  echo "Check detection of counter change"
+
+  # used in file test_functions for cvmfs_moount()
+  CVMFS_TEST_DEBUGLOG="/tmp/$CVMFS_TEST_099_TMPFILE"
+  CVMFS_TEST_QUOTED_PARAM_KEY="CVMFS_HTTP_TRACING_HEADERS"
+  CVMFS_TEST_QUOTED_PARAM_VAL="h1:test|CVMFS-X-h2:ff|X-CVMFS-h3:12_ad |  h4  : 12fs_?"
+
+  echo "   Mount $TEST099_REPO"
+  cvmfs_mount $TEST099_REPO "CVMFS_HTTP_TRACING=on"
+
+
+
+  echo "   Do something to change counters"
+  cat $TEST099_MOUNTPOINT/*.sh > /dev/null
+  cat $TEST099_MOUNTPOINT/etc/grid-security/*.pem > /dev/null
+
+  echo "   Umount $TEST099_REPO"
+  test099_unmount $TEST099_REPO
+
+  pwd
+  echo $CVMFS_TEST_099_TMPFILE
+  echo "   Check output in file /tmp/$CVMFS_TEST_099_TMPFILE"
+  local h1=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h1: test")
+  local h2=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h2: ff")
+  local h3=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h3: 12_ad")
+  local h4=$(sudo grep -c /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-h4: 12fs_?")
+  local pid=$(sudo grep /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-PID:" | sort | uniq | wc -l)
+  local gid=$(sudo grep /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-GID:" | sort | uniq | wc -l)
+  local uid=$(sudo grep /tmp/$CVMFS_TEST_099_TMPFILE -e "X-CVMFS-UID:" | sort | uniq | wc -l)
+
+  echo "      Occurence of h1 correct? $h1 > 0"
+  [ "$h1" -gt "0" ] || return 10
+  echo "      Occurence of h2 correct? $h2 == 0"
+  [ "$h2" -eq "0" ] || return 11
+  echo "      Occurence of h3 correct? $h3 > 0"
+  [ "$h3" -gt "0" ] || return 12
+  echo "      Occurence of h4 correct? $h4 > 0"
+  [ "$h4" -gt "0" ] || return 13
+
+  # if unique occurence would be 1 this means only the default values would be
+  # used and not the actual fuse pid/gid/uid
+  echo "      Unique occurence of pid correct? $pid > 1"
+  [ "$pid" -gt "1" ] || return 20
+
+  echo "      Unique occurence of gid correct? $gid > 1"
+  [ "$pid" -gt "1" ] || return 20
+
+  echo "      Unique occurence of uid correct? $uid > 1"
+  [ "$pid" -gt "1" ] || return 20
+
+
+  echo "   ... Success"
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  trap cleanup HUP INT TERM EXIT || return $?
+
+  echo "create temporary directory"
+  CVMFS_TEST_099_TMPFILE=$(mktemp ./test099.log.XXXXXXXX)
+  echo "tmpfile is $CVMFS_TEST_099_TMPFILE"
+
+  mount_and_read || return $?
+
+  return 0
+}

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -25,7 +25,9 @@ mount_and_read() {
   echo "   Access data to send HTTP requests"
   local some_files
   some_files=$(find $TEST099_MOUNTPOINT -type f | head -n3)
-  cat "$some_files" > /dev/null
+  for a_file in $some_files; do
+    cat "$a_file" > /dev/null
+  done
 
   echo "   Umount $TEST099_REPO"
   cvmfs_umount $TEST099_REPO
@@ -51,8 +53,8 @@ mount_and_read() {
   [ "$h1" -gt "0" ] || return 10
   echo "      Occurence of h2 correct? $h2 == 0"
   [ "$h2" -eq "0" ] || return 11
-  echo "      Occurence of h3 correct? $h3 > 0"
-  [ "$h3" -gt "0" ] || return 12
+  echo "      Occurence of h3 correct? $h3 == 0"
+  [ "$h3" -eq "0" ] || return 12
   echo "      Occurence of h4 correct? $h4 > 0"
   [ "$h4" -gt "0" ] || return 13
 

--- a/test/src/099-http_tracing/setup_teardown
+++ b/test/src/099-http_tracing/setup_teardown
@@ -1,21 +1,7 @@
-test099_mount() {
-  local repo=$1
-  local params=$2
-
-  cvmfs_mount $repo $params
-}
-
-test099_unmount() {
-  local repo=$1
-
-  cvmfs_umount $repo
-}
-
 cleanup() {
   echo "cleanup $cvmfs_test_name"
   if [ "x$CVMFS_TEST_099_TMPFILE" != "x" ]; then
-    rm $CVMFS_TEST_099_TMPFILE
-    sudo rm /tmp/$CVMFS_TEST_099_TMPFILE
+    sudo rm -f $CVMFS_TEST_099_TMPFILE
   fi
 }
 

--- a/test/src/099-http_tracing/setup_teardown
+++ b/test/src/099-http_tracing/setup_teardown
@@ -1,0 +1,21 @@
+test099_mount() {
+  local repo=$1
+  local params=$2
+
+  cvmfs_mount $repo $params
+}
+
+test099_unmount() {
+  local repo=$1
+
+  cvmfs_umount $repo
+}
+
+cleanup() {
+  echo "cleanup $cvmfs_test_name"
+  if [ "x$CVMFS_TEST_099_TMPFILE" != "x" ]; then
+    rm $CVMFS_TEST_099_TMPFILE
+    sudo rm /tmp/$CVMFS_TEST_099_TMPFILE
+  fi
+}
+

--- a/test/test_functions
+++ b/test/test_functions
@@ -509,6 +509,11 @@ cvmfs_mount() {
     sudo sh -c "echo \"CVMFS_DEBUGLOG=$CVMFS_TEST_DEBUGLOG\" >> /etc/cvmfs/default.local" || return 100
   fi
 
+  if [ "x$CVMFS_TEST_QUOTED_PARAM_KEY" != "x" ]; then
+    echo $CVMFS_TEST_QUOTED_PARAM_KEY
+    sudo sh -c "echo $CVMFS_TEST_QUOTED_PARAM_KEY=\"'$CVMFS_TEST_QUOTED_PARAM_VAL'\" >> /etc/cvmfs/default.local" || return 100
+  fi
+
   if running_on_osx; then
     cvmfs_mount_direct $repositories
   fi

--- a/test/test_functions
+++ b/test/test_functions
@@ -509,9 +509,8 @@ cvmfs_mount() {
     sudo sh -c "echo \"CVMFS_DEBUGLOG=$CVMFS_TEST_DEBUGLOG\" >> /etc/cvmfs/default.local" || return 100
   fi
 
-  if [ "x$CVMFS_TEST_QUOTED_PARAM_KEY" != "x" ]; then
-    echo $CVMFS_TEST_QUOTED_PARAM_KEY
-    sudo sh -c "echo $CVMFS_TEST_QUOTED_PARAM_KEY=\"'$CVMFS_TEST_QUOTED_PARAM_VAL'\" >> /etc/cvmfs/default.local" || return 100
+  if [ "x$CVMFS_TEST_QUOTED_PARAM_KEY_VAL" != "x" ]; then
+    sudo sh -c "echo '${CVMFS_TEST_QUOTED_PARAM_KEY_VAL}' >> /etc/cvmfs/default.local" || return 100
   fi
 
   if running_on_osx; then


### PR DESCRIPTION
Issue #3094 

Superseeds #3145 

client params:
```bash
CVMFS_HTTP_TRACING=on #(default off)

CVMFS_HTTP_TRACING_HEADERS='h1:test|CVMFS-X-h2:ff|X-CVMFS-h3:12_ad |  h4  : 12fs_?'
# only illegal header is: CVMFS-X-h2:ff
# all other will be expanded to valid ones 


# example debug output
(download) CURL Header for URL: /data/81/7c882d4a2e9dd7f9c5c2bfb4e04ff316e436dfC is:
 Connection: Keep-Alive
Pragma:
User-Agent: cvmfs Fuse 2.11.0
X-CVMFS-h1: test
X-CVMFS-h3: 12_ad
X-CVMFS-h4: 12fs_?
X-CVMFS-PID: 561710
X-CVMFS-GID: 0
X-CVMFS-UID: 0
```

requirements for the key: alphanumeric (a-z, A-Z, 0-9) and can start with `X-CVMFS-`, no other - or _ allowed
the value can be any sequences (obvisouly no quotes and the separators below)
separator between key and value: `:`
separator between different key value pairs: `|`


Included: new client integration test 099
**Question:** is there any better way how to set the `CVMFS_HTTP_TRACING_HEADERS` with white space etc. bash really does not like it and the workaround is horrible

Missing: Documentation


Edit:
final version only accepts alphanumerical keys and does not accept already added `X-CVMFS-<restofkey>`