### PR TITLE
Use dedicated log files for mount helper

### DIFF
--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -416,9 +416,9 @@ int main(int argc, char **argv) {
   if (options_manager_.GetValue("CVMFS_SYSLOG_FACILITY", &optarg))
     SetLogSyslogFacility(String2Int64(optarg));
   if (options_manager_.GetValue("CVMFS_USYSLOG", &optarg))
-    SetLogMicroSyslog(optarg);
+    SetLogMicroSyslog(optarg + ".mount");
   if (options_manager_.GetValue("CVMFS_DEBUGLOG", &optarg))
-    SetLogDebugFile(optarg);
+    SetLogDebugFile(optarg + ".mount");
   SetLogSyslogPrefix(fqrn);
 
   int retval;


### PR DESCRIPTION
PR #3302 introduced a problem when the log file is created by the mount helper: it is then owned by root and the fuse module (running as cvmfs user) cannot use it.  This patch adds the `.mount` suffix for log files, to separate them from the fuse module's logs. This should fix the recent failures seen in test 043.