### PR TITLE
Ignore signature failure during download

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1374,6 +1374,14 @@ bool MountPoint::CreateDownloadManagers() {
     download_mgr_->SetHostChain(optarg);
   }
 
+  if (options_mgr_->GetValue("_CVMFS_DEVEL_IGNORE_SIGNATURE_FAILURES", &optarg)
+      && options_mgr_->IsOn(optarg)) {
+    download_mgr_->EnableIgnoreSignatureFailures();
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
+      "Development option: Activate ignore signature failures during download. "
+      "DO NOT USE IN PRODUCTION");
+  }
+
   SetupDnsTuning(download_mgr_);
   SetupHttpTuning();
 

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -205,6 +205,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void SetProxyTemplates(const std::string &direct, const std::string &forced);
   void EnableInfoHeader();
   void EnableRedirects();
+  void EnableIgnoreSignatureFailures();
   void UseSystemCertificatePath();
 
   unsigned num_hosts() {
@@ -282,6 +283,12 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool enable_info_header_;
   bool opt_ipv4_only_;
   bool follow_redirects_;
+
+  /**
+   * Ignore signature failures during download.
+   * In general it is a bad idea to do this!
+   */
+  bool ignore_signature_failures_;
 
   // Host list
   std::vector<std::string> *opt_host_chain_;


### PR DESCRIPTION
Issue #3313 

current implementation still does a check of the hashes but ignore if it fails.

i guess we do not want to skip the check completely?

param `_CVMFS_DEVEL_IGNORE_SIGNATURE_FAILURES`, gives a warning in syslogwarn and debuglog if being used.