### PR TITLE
Print error when trying to run cpplint.py with python 3

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -6327,4 +6327,8 @@ def main():
 
 
 if __name__ == '__main__':
+  if sys.version_info.major > 2:
+    print("Wrong python version!")
+    print("cpplint.py must be run with python 2")
+    print("Your version: Python", sys.version)
   main()


### PR DESCRIPTION
Issue #3050 

Before behavior:
```
python3 cpplint.py cvmfs/mountpoint.cc
>> no output <<

python2 cpplint.py cvmfs/mountpoint.cc
> Done processing cvmfs/mountpoint.cc
> Total errors found: 0
```

new behavior for python 3
```
python3 cpplint.py cvmfs/mountpoint.cc
> Wrong python version!
> cpplint.py must be run with python 2
> Your version: Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0]
```