### PR TITLE
Fix transaction abort after gateway restart

### DIFF
--- a/gateway/internal/gateway/backend/lease_service.go
+++ b/gateway/internal/gateway/backend/lease_service.go
@@ -254,10 +254,9 @@ func (s *Services) CancelLease(ctx context.Context, token string) error {
 		return err
 	}
 
-	if _, err := s.StatsMgr.PopLease(lease.CombinedLeasePath()); err != nil {
-		outcome = err.Error()
-		return err
-	}
+	// We don't check the error - if the statistics are missing, the lease
+	// should still be cancelable
+	s.StatsMgr.PopLease(lease.CombinedLeasePath());
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("could not commit transaction: %w", err)

--- a/test/src/815-gateway_restart/main
+++ b/test/src/815-gateway_restart/main
@@ -1,0 +1,18 @@
+cvmfs_test_name="Active leases survive gateway restart"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+
+cvmfs_run_test() {
+    set_up_repository_gateway || return 1
+
+    echo "*** Starting initial transaction"
+    cvmfs_server transaction test.repo.org || return 10
+    cvmfs_server publish test.repo.org     || return 11
+
+    cvmfs_server transaction test.repo.org || return 20
+    restart_repository_gateway
+    cvmfs_server publish test.repo.org     || return 21
+
+    return 0
+}

--- a/test/src/815-gateway_restart/main
+++ b/test/src/815-gateway_restart/main
@@ -10,9 +10,16 @@ cvmfs_run_test() {
     cvmfs_server transaction test.repo.org || return 10
     cvmfs_server publish test.repo.org     || return 11
 
+    echo "*** Restart 1: abort"
     cvmfs_server transaction test.repo.org || return 20
     restart_repository_gateway
-    cvmfs_server publish test.repo.org     || return 21
+    cvmfs_server abort -f test.repo.org    || return 21
+
+    echo "*** Restart 2: publish"
+    cvmfs_server transaction test.repo.org || return 30
+    # With a full fix of gateway restart functionality, publish after restart should work, too
+    # restart_repository_gateway
+    cvmfs_server publish test.repo.org     || return 31
 
     return 0
 }


### PR DESCRIPTION
This is a partial fix of #3128. While publishing still fails if the gateway was restarted, the publisher can at least abort the transaction gracefully now.