### PR TITLE
ci-scripts: accept also test numbers 1* as  client tests

### DIFF
--- a/test/cloud_testing/platforms/centos7_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-EXCLCACHE_test.sh
@@ -26,6 +26,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 echo "running CernVM-FS client migration test cases..."

--- a/test/cloud_testing/platforms/centos7_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-FUSE3_test.sh
@@ -19,6 +19,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/centos7_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-NFS_test.sh
@@ -32,6 +32,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/097-statfs                               \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 echo "running CernVM-FS client migration test cases..."

--- a/test/cloud_testing/platforms/centos7_x86_64-RAMCACHE_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-RAMCACHE_test.sh
@@ -35,6 +35,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/097-statfs                               \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 echo "running CernVM-FS client migration test cases..."

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -37,6 +37,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/centos8_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64-FUSE3_test.sh
@@ -22,6 +22,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/centos8_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64_test.sh
@@ -35,6 +35,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/centos9_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos9_x86_64-FUSE3_test.sh
@@ -32,6 +32,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/096-cancelreq                            \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/centos9_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos9_x86_64_test.sh
@@ -46,6 +46,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/096-cancelreq                            \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/debian_test.sh
+++ b/test/cloud_testing/platforms/debian_test.sh
@@ -41,6 +41,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  $CVMFS_EXCLUDE                               \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/cloud_testing/platforms/fedora_test.sh
+++ b/test/cloud_testing/platforms/fedora_test.sh
@@ -26,6 +26,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 echo -n "make sure apache is running... "

--- a/test/cloud_testing/platforms/macos_test.sh
+++ b/test/cloud_testing/platforms/macos_test.sh
@@ -53,7 +53,8 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests
                                    src/094-attachmount                          \
                                    src/095-fuser                                \
                                    --                                           \
-                                   src/0*
+                                   src/0*                                       \
+                                   src/1*
 
 retval=$?
 exit $retval

--- a/test/cloud_testing/platforms/ubuntu_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_test.sh
@@ -56,6 +56,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  $CVMFS_EXCLUDE                               \
                                  --                                           \
                                  src/0*                                       \
+                                 src/1*                                       \
                               || retval=1
 
 

--- a/test/src/100-dummy/main
+++ b/test/src/100-dummy/main
@@ -1,0 +1,13 @@
+
+# can be replaced with a real client test
+cvmfs_test_name="Dummy test"
+cvmfs_test_suites="quick dummy"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  echo "Dummy test" || return 1
+
+  return 0
+}
+


### PR DESCRIPTION
Fixes #3328 until larger reorganization of the integration tests