### PR TITLE
Add paging to xattr chunk_list that can overflow the 64kiB limit

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1668,7 +1668,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
 
   // split xattr if of format <name>_<num>
   // for different "pages" of xattr to be returned
-  // if no <num> is valid, the first page is printed 
+  // if no <num> is valid, the first page is printed
   // as String2Uint64 failure defaults to 0
   string paged_attr = "user.chunk_list";
   if (attr.rfind(paged_attr, 0) == 0) {
@@ -1676,7 +1676,8 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
 
     vector<string> tokens = SplitString(name, '_');
 
-    attr_page_num = String2Uint64(tokens[tokens.size() - 1]);
+    attr_page_num =
+                 static_cast<int32_t>(String2Uint64(tokens[tokens.size() - 1]));
   }
 
 

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -245,9 +245,9 @@ bool ChunkListMagicXattr::PrepareValueFenced(int32_t attr_page_num) {
                 "'chunked', but no chunks found.", path_.c_str());
       return false;
     } else {
-      const int32_t kB_limit = 64 * 1024;
-      const int32_t header_size = 120;
-      const int32_t max_digits_offset =
+      const size_t kB_limit = 64 * 1024;
+      const size_t header_size = 120;
+      const size_t max_digits_offset =
                       StringifyInt(chunks.At(chunks.size()-1).offset()).size();
 
       // entry_size is calculated to find out how many entries we can show per
@@ -264,12 +264,13 @@ bool ChunkListMagicXattr::PrepareValueFenced(int32_t attr_page_num) {
       // +      max offset within file (this should be the max size of any
       //                             chunk, but for simplicity we use this here.
       //                             this should be for sure larger.)
-      const int32_t entry_size = 3 + 3 + StringifyUint(chunks.size()).size() +
-                                 chunks.At(0).content_hash().ToString().size() +
-                                 max_digits_offset + max_digits_offset;
-      const int32_t entries_per_page = (kB_limit - header_size) / entry_size;
+      const size_t entry_size = (3ul * 2) +
+                                StringifyUint(chunks.size()).size() +
+                                chunks.At(0).content_hash().ToString().size() +
+                                max_digits_offset + max_digits_offset;
+      const size_t entries_per_page = (kB_limit - header_size) / entry_size;
 
-      const int32_t num_pages = chunks.size() / entries_per_page +
+      const size_t num_pages = chunks.size() / entries_per_page +
                               ((chunks.size() % entries_per_page != 0) ? 1 : 0);
 
       chunk_list_  = "Access different pages with 'chunk_list_<page>' ";
@@ -279,12 +280,12 @@ bool ChunkListMagicXattr::PrepareValueFenced(int32_t attr_page_num) {
       chunk_list_ += "max_pages,curr_page,idx,hash,offset,size\n";
 
       attr_page_num = attr_page_num == 0 ? 1 : attr_page_num;
-      int32_t attr_page_num_fixed = attr_page_num - 1;
+      size_t attr_page_num_fixed = static_cast<size_t>(attr_page_num) - 1;
       size_t start_entry = entries_per_page * attr_page_num_fixed;
       for (size_t i = start_entry;
                   i < chunks.size() && i < start_entry + entries_per_page;
                   ++i) {
-        chunk_list_ += StringifyInt(num_pages) + ",";
+        chunk_list_ += StringifyUint(num_pages) + ",";
         chunk_list_ += StringifyInt(attr_page_num) + ",";
         chunk_list_ += StringifyUint(i) + ",";
         chunk_list_ += chunks.At(i).content_hash().ToString() + ",";

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -96,7 +96,7 @@ class BaseMagicXattr {
   * inside FuseRemounter::fence(), which should prevent data races.
   */
   virtual bool PrepareValueFenced() { return true; }
-  virtual bool PrepareValueFenced(int32_t attr_page_num) { return true; }
+  virtual bool PrepareValueFenced(int32_t /*attr_page_num*/) { return true; }
 
   MagicXattrManager *xattr_mgr_;
   PathString path_;

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -65,7 +65,7 @@ class BaseMagicXattr {
   /**
    * Access right check before normal fence
    */
-  bool PrepareValueFencedProtected(gid_t gid);
+  bool PrepareValueFencedProtected(gid_t gid, int32_t attr_page_num);
 
   /**
    * This function needs to be called after PrepareValueFenced(),
@@ -96,6 +96,7 @@ class BaseMagicXattr {
   * inside FuseRemounter::fence(), which should prevent data races.
   */
   virtual bool PrepareValueFenced() { return true; }
+  virtual bool PrepareValueFenced(int32_t attr_page_num) { return true; }
 
   MagicXattrManager *xattr_mgr_;
   PathString path_;
@@ -235,7 +236,7 @@ class CatalogCountersMagicXattr : public BaseMagicXattr {
 class ChunkListMagicXattr : public RegularMagicXattr {
   std::string chunk_list_;
 
-  virtual bool PrepareValueFenced();
+  virtual bool PrepareValueFenced(int32_t attr_page_num);
   virtual std::string GetValue();
 };
 

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -85,17 +85,17 @@ cvmfs_run_test() {
   runc_chunk_list=$(get_xattr chunk_list /cvmfs/grid.cern.ch/vc/containers/runc)
   [ "x$runc_chunks" = "x2" ] || return 6
   runc_chunk_list_n=$(echo $runc_chunk_list | wc -w | awk '{print $1}')
-  [ "x$runc_chunk_list_n" = "x3" ] || return 7
-  runc_chunk_list_header=$(echo $runc_chunk_list | cut -d" " -f1)
-  [ "x$runc_chunk_list_header" = "xhash,offset,size" ] || return 8
+  [ "x$runc_chunk_list_n" = "x12" ] || return 7
+  runc_chunk_list_header=$(echo $runc_chunk_list | cut -d" " -f10)
+  [ "x$runc_chunk_list_header" = "xmax_pages,curr_page,idx,hash,offset,size" ] || return 8
   # test a short non-chunked file
   readme_chunks=$(get_xattr chunks /cvmfs/grid.cern.ch/README)
   readme_chunk_list=$(get_xattr chunk_list /cvmfs/grid.cern.ch/README)
   [ "x$readme_chunks" = "x1" ] || return 9
   readme_chunk_list_1=$(echo $readme_chunk_list | cut -d" " -f2)
-  readme_chunk_hash=$(echo $readme_chunk_list_1 | cut -d"," -f1)
-  readme_chunk_offset=$(echo $readme_chunk_list_1 | cut -d"," -f2)
-  readme_chunk_size=$(echo $readme_chunk_list_1 | cut -d"," -f3)
+  readme_chunk_hash=$(echo $readme_chunk_list_1 | cut -d"," -f4)
+  readme_chunk_offset=$(echo $readme_chunk_list_1 | cut -d"," -f5)
+  readme_chunk_size=$(echo $readme_chunk_list_1 | cut -d"," -f6)
   readme_hash=$(get_xattr hash /cvmfs/grid.cern.ch/README)
   if running_on_osx; then
     readme_size=$(gstat -c%s /cvmfs/grid.cern.ch/README)

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -50,9 +50,12 @@ cvmfs_run_test() {
     [ $nchunks -gt 1 ] || return 30
     mkdir /srv/cvmfs/${CVMFS_TEST_REPO}/data/external || return 31
     for c in $chunk_list; do
-      local hash=$(echo $c | cut -d, -f1)
-      cat /srv/cvmfs/${CVMFS_TEST_REPO}/data/${hash:0:2}/${hash:2}P >> \
-        /srv/cvmfs/${CVMFS_TEST_REPO}/data/external/foo || return 32
+      # ignore header
+      if [ "x$c" != "xmax_pages,curr_page,idx,hash,offset,size" ]; then
+        local hash=$(echo $c | cut -d, -f4)
+        cat /srv/cvmfs/${CVMFS_TEST_REPO}/data/${hash:0:2}/${hash:2}P >> \
+          /srv/cvmfs/${CVMFS_TEST_REPO}/data/external/foo || return 32
+      fi
     done
   fi
 

--- a/test/unittests/t_magic_xattr.cc
+++ b/test/unittests/t_magic_xattr.cc
@@ -102,6 +102,8 @@ TEST_F(T_MagicXattr, TestLogBuffer) {
     MagicXattrRAIIWrapper attr(mgr->GetLocked("user.logbuffer", path, &dirent));
     ASSERT_FALSE(attr.IsNull());
     ASSERT_TRUE(attr->PrepareValueFenced());
+    // in debug mode this fails because a time stamp is added at the end of
+    // the message
     EXPECT_TRUE(HasSuffix(attr->GetValue(), "<snip>\n", false /* ign_case */));
   }
 }
@@ -149,7 +151,7 @@ TEST_F(T_MagicXattr, ProtectedXattr) {
   MagicXattrRAIIWrapper attr(mgr->GetLocked("user.fqrn", path, &dirent));
 
   ASSERT_FALSE(attr.IsNull());
-  ASSERT_FALSE(attr->PrepareValueFencedProtected(2));
-  ASSERT_TRUE(attr->PrepareValueFencedProtected(1));
+  ASSERT_FALSE(attr->PrepareValueFencedProtected(2, -1));
+  ASSERT_TRUE(attr->PrepareValueFencedProtected(1, -1));
   EXPECT_STREQ("keys.cern.ch", attr->GetValue().c_str());
 }


### PR DESCRIPTION
Issue #2922 

add functionality that xattr `chunk_list` will return in pages if otherwise an overflow would occur.
pages can be accessed by `chunk_list_<num>`

based on the file size, dynamically calculates how many entries per page to be shown

`chunk_list`, `chunk_list_0` and `chunk_list_1` default to the same page: page 1

output:
on error: starts with `ERROR`
on success:
```
Access different pages with 'chunk_list_<page>' ( 2 pages )
max_pages,curr_page,idx,hash,offset,size
2,1,0,39008434907e0d569a0131f024f1a39822cdd0be,0,7393679
2,1,1,ae4c82590fd6a5cfea1a325a0dc1394f0af13dab,7393679,69786
...
```

10 GB file created with 1MB blocks of `/dev/urandom` creates 2 pages with the first page having 907 chunks.
`Attribute "chunk_list" had a 61820 byte value for /cvmfs/my.test.repo/bigfile.blob:`


file that has no chunks but is valid:
```
Attribute "chunk_list" had a 92 byte value for /cvmfs/my.test.repo/text1.txt:
max_pages,curr_page,idx,hash,offset,size
1,1,0,e8ec3d88b62ebf526e4e5a4ff6162a3aa48a6b78,0,0
```


Possible future  improvements:
- right now it only works for `chunk_list` -- could be made as a vector of paged attributes if needed and selected from the vector which xattr should be paged
- we now have 2 functions. in theory with little refactoring it could be just one and xattr that dont need the `attr_page_num` ignore it
```c++
  virtual bool PrepareValueFenced() { return true; }
  virtual bool PrepareValueFenced(int32_t attr_page_num) { return true; }
````

