### PR TITLE
Fix publication of uncompressed files through gateway

### DIFF
--- a/cvmfs/receiver/params.cc
+++ b/cvmfs/receiver/params.cc
@@ -70,22 +70,10 @@ bool GetParamsFromFile(const std::string& repo_name, Params* params) {
   params->hash_alg = shash::ParseHashAlgorithm(hash_algorithm_str);
   params->hash_alg_str = hash_algorithm_str;
 
-  std::string compression_algorithm_str;
-  if (!parser.GetValue("CVMFS_COMPRESSION_ALGORITHM",
-                       &compression_algorithm_str)) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "Missing parameter %s in repository configuration file.",
-             "CVMFS_COMPRESSION_ALGORITHM");
-    return false;
-  }
-  params->compression_alg =
-      zlib::ParseCompressionAlgorithm(compression_algorithm_str);
-
-  /**
-   * The receiver does not store files, only catalogs.  We can safely disable
-   * this option.
-   */
+  // The receiver does not store files, only catalogs.
+  // We can safely hard-code the following options
   params->generate_legacy_bulk_chunks = false;
+  params->compression_alg = zlib::kZlibDefault;
 
   std::string use_chunking_str;
   if (!parser.GetValue("CVMFS_USE_FILE_CHUNKING", &use_chunking_str)) {

--- a/test/src/816-gateway_uncompressed/main
+++ b/test/src/816-gateway_uncompressed/main
@@ -1,0 +1,30 @@
+#
+# Tests publication of uncompressed files through the gateway.
+# Catalogs should remain zlib compressed.
+#
+
+cvmfs_test_name="Uncompressed files through gateway"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+
+cvmfs_run_test() {
+    set_up_repository_gateway || return 1
+
+    echo "CVMFS_COMPRESSION_ALGORITHM=none" | sudo tee -a \
+        /etc/cvmfs/repositories.d/test.repo.org/server.conf || return 10
+
+    echo "*** Starting transaction with an uncompressed file"
+    cvmfs_server transaction test.repo.org               || return 20
+    mkdir /cvmfs/test.repo.org/foo                       || return 21
+    echo "Hello, World!" > /cvmfs/test.repo.org/foo/bar  || return 23
+    touch /cvmfs/test.repo.org/foo/.cvmfscatalog         || return 24
+    cvmfs_server publish test.repo.org                   || return 25
+
+    cat /var/spool/cvmfs/test.repo.org/rdonly/foo/bar || return 30
+    local compression=$(get_xattr compression /var/spool/cvmfs/test.repo.org/rdonly/foo/bar)
+    echo "*** compression: $compression"
+    [ "x$compression" = "xnone" ] || return 31
+
+    return 0
+}


### PR DESCRIPTION
Suggested replacement of #2919 

I think in the original issue, the workaround is to set `CVMFS_COMPRESSION_ALGORITHM=zlib` on the gateway.