### PR TITLE
Gracefully ignore toggling streaming cache on reload

### DIFF
--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -204,6 +204,9 @@ class CacheManager : SingleCopy {
    */
   int RestoreState(const int fd_progress, void *state);
   void FreeState(const int fd_progress, void *state);
+  CacheManagerIds PeekState(void *state) {
+    return static_cast<State *>(state)->manager_type;
+  }
 
   /**
    * While not strictly necessary, cache managers often have a directory

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -181,6 +181,11 @@ int StreamingCacheManager::Open(const LabeledObject &object) {
   return fd_table_.OpenFd(FdInfo(object));
 }
 
+int StreamingCacheManager::PlantFd(int fd_in_cache_mgr) {
+  MutexLockGuard lock_guard(lock_fd_table_);
+  return fd_table_.OpenFd(FdInfo(fd_in_cache_mgr));
+}
+
 int64_t StreamingCacheManager::GetSize(int fd) {
   FdInfo info;
   {
@@ -316,4 +321,9 @@ bool StreamingCacheManager::DoFreeState(void *data) {
   delete state->fd_table;
   delete state;
   return true;
+}
+
+CacheManager *StreamingCacheManager::MoveOutBackingCacheMgr(int *root_fd) {
+  *root_fd = fd_table_.GetHandle(0).fd_in_cache_mgr;
+  return cache_mgr_.Release();
 }

--- a/cvmfs/cache_stream.h
+++ b/cvmfs/cache_stream.h
@@ -79,6 +79,15 @@ class StreamingCacheManager : public CacheManager {
     return cache_mgr_->StoreBreadcrumb(manifest);
   }
 
+  // Used in cvmfs' RestoreState to switch back from the streaming to the
+  // regular cache manager. At this point, the streaming cache manager has
+  // opened the root file catalog. We need to return the file descriptor in
+  // the wrapped cache manager, too.
+  CacheManager *MoveOutBackingCacheMgr(int *root_fd);
+  // Used in cvmfs' RestoreState to create a virtual file descriptor for the
+  // root catalog fd, that has been already opened in the backing cache manager
+  int PlantFd(int fd_in_cache_mgr);
+
  protected:
   virtual void *DoSaveState();
   virtual int DoRestoreState(void *data);

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -45,6 +45,7 @@ ClientCatalogManager::ClientCatalogManager(MountPoint *mountpoint)
   , all_inodes_(0)
   , loaded_inodes_(0)
   , fixed_alt_root_catalog_(false)
+  , root_fd_(-1)
 {
   LogCvmfs(kLogCatalog, kLogDebug, "constructing client catalog manager");
   n_certificate_hits_ = mountpoint->statistics()->Register(
@@ -264,6 +265,9 @@ LoadError ClientCatalogManager::LoadCatalogCas(
   int fd = fetcher_->Fetch(CacheManager::LabeledObject(hash, label),
                            alt_catalog_path);
   if (fd >= 0) {
+    if (root_fd_ < 0) {
+      root_fd_ = fd;
+    }
     *catalog_path = "@" + StringifyInt(fd);
     return kLoadNew;
   }

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -65,6 +65,7 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
   uint64_t loaded_inodes() const { return loaded_inodes_; }
   std::string repo_name() const { return repo_name_; }
   manifest::Manifest *manifest() const { return manifest_.weak_ref(); }
+  int root_fd() const { return root_fd_; }
 
  protected:
   LoadError LoadCatalog(const PathString  &mountpoint,
@@ -102,6 +103,12 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
   BackoffThrottle backoff_throttle_;
   perf::Counter *n_certificate_hits_;
   perf::Counter *n_certificate_misses_;
+
+  /**
+   * File descriptor of first loaded catalog; used for mapping the root catalog
+   * file descriptor when restoring the cache manager after a fuse module reload
+   */
+  int root_fd_;
 };
 
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -68,6 +68,7 @@
 #include "auto_umount.h"
 #include "backoff.h"
 #include "cache.h"
+#include "cache_stream.h"
 #include "catalog_mgr_client.h"
 #include "clientctx.h"
 #include "compat.h"
@@ -2685,12 +2686,54 @@ static bool RestoreState(const int fd_progress,
     }
 
     if (saved_states[i]->state_id == loader::kStateOpenFiles) {
+      int old_root_fd = cvmfs::mount_point_->catalog_mgr()->root_fd();
+
+      // TODO(jblomer): make this less hacky
+
+      CacheManagerIds saved_type =
+        cvmfs::file_system_->cache_mgr()->PeekState(saved_states[i]->state);
+      int fixup_root_fd = -1;
+
+      if ((saved_type == kStreamingCacheManager) &&
+          (cvmfs::file_system_->cache_mgr()->id() != kStreamingCacheManager))
+      {
+        // stick to the streaming cache manager
+        StreamingCacheManager *new_cache_mgr = new
+          StreamingCacheManager(cvmfs::max_open_files_,
+                                cvmfs::file_system_->cache_mgr(),
+                                cvmfs::mount_point_->download_mgr(),
+                                cvmfs::mount_point_->external_download_mgr());
+        fixup_root_fd = new_cache_mgr->PlantFd(old_root_fd);
+        cvmfs::file_system_->ReplaceCacheManager(new_cache_mgr);
+        cvmfs::mount_point_->fetcher()->ReplaceCacheManager(new_cache_mgr);
+        cvmfs::mount_point_->external_fetcher()->ReplaceCacheManager(
+          new_cache_mgr);
+      }
+
+      if ((cvmfs::file_system_->cache_mgr()->id() == kStreamingCacheManager) &&
+          (saved_type != kStreamingCacheManager))
+      {
+        // stick to the cache manager wrapped into the streaming cache
+        CacheManager *wrapped_cache_mgr = dynamic_cast<StreamingCacheManager *>(
+            cvmfs::file_system_->cache_mgr())->MoveOutBackingCacheMgr(
+              &fixup_root_fd);
+        delete cvmfs::file_system_->cache_mgr();
+        cvmfs::file_system_->ReplaceCacheManager(wrapped_cache_mgr);
+        cvmfs::mount_point_->fetcher()->ReplaceCacheManager(wrapped_cache_mgr);
+        cvmfs::mount_point_->external_fetcher()->ReplaceCacheManager(
+          wrapped_cache_mgr);
+      }
+
       int new_root_fd = cvmfs::file_system_->cache_mgr()->RestoreState(
         fd_progress, saved_states[i]->state);
       LogCvmfs(kLogCvmfs, kLogDebug, "new root file catalog descriptor @%d",
                new_root_fd);
       if (new_root_fd >= 0) {
-        cvmfs::file_system_->RemapCatalogFd(0, new_root_fd);
+        cvmfs::file_system_->RemapCatalogFd(old_root_fd, new_root_fd);
+      } else if (fixup_root_fd >= 0) {
+        LogCvmfs(kLogCvmfs, kLogDebug,
+                 "new root file catalog descriptor (fixup) @%d", fixup_root_fd);
+        cvmfs::file_system_->RemapCatalogFd(old_root_fd, fixup_root_fd);
       }
     }
   }

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -121,6 +121,9 @@ class Fetcher : SingleCopy {
   int Fetch(const CacheManager::LabeledObject &object,
             const std::string &alt_url = "");
 
+  void ReplaceCacheManager(CacheManager *new_cache_mgr) {
+    cache_mgr_ = new_cache_mgr;
+  }
   CacheManager *cache_mgr() { return cache_mgr_; }
   download::DownloadManager *download_mgr() { return download_mgr_; }
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1139,6 +1139,11 @@ void FileSystem::RemapCatalogFd(int from, int to) {
   sqlite::RegisterFdMapping(from, to);
 }
 
+void FileSystem::ReplaceCacheManager(CacheManager *new_cache_mgr) {
+  cache_mgr_ = new_cache_mgr;
+  sqlite::ReplaceCacheManager(new_cache_mgr);
+}
+
 
 bool FileSystem::TriageCacheMgr() {
   cache_mgr_instance_ = kDefaultCacheMgrInstance;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -198,6 +198,10 @@ class FileSystem : SingleCopy, public BootFactory {
   void TearDown2ReadOnly();
   void RemapCatalogFd(int from, int to);
 
+  // Used in cvmfs' RestoreState to prevent change of cache manager type
+  // during reload
+  void ReplaceCacheManager(CacheManager *new_cache_mgr);
+
   CacheManager *cache_mgr() { return cache_mgr_; }
   std::string cache_mgr_instance() { return cache_mgr_instance_; }
   std::string exe_path() { return exe_path_; }

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -543,4 +543,11 @@ void RegisterFdMapping(int from, int to) {
   fd_to_->push_back(to);
 }
 
+void ReplaceCacheManager(CacheManager *new_cache_mgr) {
+  sqlite3_vfs *vfs = sqlite3_vfs_find(kVfsName);
+  if (vfs == NULL)
+    return;
+  static_cast<VfsRdOnly *>(vfs->pAppData)->cache_mgr = new_cache_mgr;
+}
+
 }  // namespace sqlite

--- a/cvmfs/sqlitevfs.h
+++ b/cvmfs/sqlitevfs.h
@@ -29,6 +29,7 @@ bool UnregisterVfsRdOnly();
  * to the fd in the context of the restored cache manager.
  */
 void RegisterFdMapping(int from, int to);
+void ReplaceCacheManager(CacheManager *new_cache_mgr);
 
 }  // namespace sqlite
 

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -24,6 +24,8 @@ cvmfs_run_test() {
 
   start_transaction $CVMFS_TEST_REPO                             || return $?
   mkdir -p ${repo_dir}/internal                                  || return 2
+  mkdir -p ${repo_dir}/nested                                    || return 2
+  touch ${repo_dir}/nested/.cvmfscatalog                         || return 2
   echo "Hello World" > ${repo_dir}/internal/small                || return 3
   cat /dev/urandom | head -c 2500 > ${repo_dir}/internal/bar     || return 4
   publish_repo $CVMFS_TEST_REPO -v                               || return 5
@@ -60,8 +62,6 @@ cvmfs_run_test() {
   trap cleanup EXIT HUP INT TERM || return $?
 
   CVMFS_TEST_690_PRIVATE_MOUNTPOINT="$(pwd)/mountpoint"
-  echo "CVMFS_STREAMING_CACHE=yes" > test690.conf
-  echo "CVMFS_EXTERNAL_URL=http://localhost/cvmfs/${CVMFS_TEST_REPO}" >> test690.conf
   do_local_mount "$CVMFS_TEST_690_PRIVATE_MOUNTPOINT" \
                  "$CVMFS_TEST_REPO" \
                  "$(get_repo_url $CVMFS_TEST_REPO)" \
@@ -112,6 +112,44 @@ cvmfs_run_test() {
   kill -USR1 $pid_helper
   wait $pid_helper || return 62
   diff small $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 63
+
+  echo "*** ignore changing from streaming to non-streaming"
+  local config=$(sudo cvmfs_talk -p $talk_socket parameters | \
+    grep ^CVMFS_STREAMING_CACHE | awk '{print $NF}')
+  echo "*** config is $config"
+  echo "CVMFS_STREAMING_CACHE=no" >> $config
+  ./openwaitprint $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small > small &
+  pid_helper=$!
+  cvmfs2 __RELOAD__ $(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/cvmfs.$CVMFS_TEST_REPO || return 70
+  sudo cvmfs_talk -p $talk_socket parameters
+  sudo cvmfs_talk -p $talk_socket cache instance
+  kill -USR1 $pid_helper
+  wait $pid_helper || return 71
+  diff small $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 72
+  cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/bar > /dev/null || return 73
+  ls -lR $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/ || return 74
+
+  echo "*** ignore changing from non-streaming to streaming"
+  remove_local_mount $CVMFS_TEST_690_PRIVATE_MOUNTPOINT || return 80
+  do_local_mount "$CVMFS_TEST_690_PRIVATE_MOUNTPOINT" \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_DEBUGLOG=/tmp/debug.log\nCVMFS_STREAMING_CACHE=no\nCVMFS_EXTERNAL_URL=http://localhost/cvmfs/${CVMFS_TEST_REPO}\nCVMFS_EXTERNAL_HTTP_PROXY=DIRECT" || return 81
+  config=$(sudo cvmfs_talk -p $talk_socket parameters | \
+    grep ^CVMFS_STREAMING_CACHE | awk '{print $NF}')
+  echo "*** config is $config"
+  echo "CVMFS_STREAMING_CACHE=yes" >> $config
+  ./openwaitprint $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small > small &
+  pid_helper=$!
+  cvmfs2 __RELOAD__ $(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/cvmfs.$CVMFS_TEST_REPO --debug || return 82
+  sudo cvmfs_talk -p $talk_socket parameters
+  sudo cvmfs_talk -p $talk_socket cache instance
+  kill -USR1 $pid_helper
+  wait $pid_helper || return 83
+  diff small $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small || return 84
+  cat $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/bar > /dev/null || return 85
+  ls -lR $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/ || return 86
 
   return 0
 }

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -135,14 +135,14 @@ cvmfs_run_test() {
                  "$CVMFS_TEST_REPO" \
                  "$(get_repo_url $CVMFS_TEST_REPO)" \
                  "" \
-                 "CVMFS_DEBUGLOG=/tmp/debug.log\nCVMFS_STREAMING_CACHE=no\nCVMFS_EXTERNAL_URL=http://localhost/cvmfs/${CVMFS_TEST_REPO}\nCVMFS_EXTERNAL_HTTP_PROXY=DIRECT" || return 81
+                 "CVMFS_STREAMING_CACHE=no\nCVMFS_EXTERNAL_URL=http://localhost/cvmfs/${CVMFS_TEST_REPO}\nCVMFS_EXTERNAL_HTTP_PROXY=DIRECT" || return 81
   config=$(sudo cvmfs_talk -p $talk_socket parameters | \
     grep ^CVMFS_STREAMING_CACHE | awk '{print $NF}')
   echo "*** config is $config"
   echo "CVMFS_STREAMING_CACHE=yes" >> $config
   ./openwaitprint $CVMFS_TEST_690_PRIVATE_MOUNTPOINT/internal/small > small &
   pid_helper=$!
-  cvmfs2 __RELOAD__ $(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/cvmfs.$CVMFS_TEST_REPO --debug || return 82
+  cvmfs2 __RELOAD__ $(get_cache_directory $CVMFS_TEST_690_PRIVATE_MOUNTPOINT)/cvmfs.$CVMFS_TEST_REPO || return 82
   sudo cvmfs_talk -p $talk_socket parameters
   sudo cvmfs_talk -p $talk_socket cache instance
   kill -USR1 $pid_helper


### PR DESCRIPTION
Similar to what was discussed for the refcounted cache manager, this patch lets cvmfs ignore toggling of the streaming cache manager during reload. The patch is, unfortunately, relatively ugly but I think it's still better than crashing fuse modules when the streaming cache option is used.