### PR TITLE
V2: Add paging to xattr 

### DIFF
--- a/cvmfs/crypto/signature.cc
+++ b/cvmfs/crypto/signature.cc
@@ -394,6 +394,17 @@ std::string SignatureManager::GetActivePubkeys() const {
   return pubkeys;
 }
 
+std::vector<std::string> SignatureManager::GetActivePubkeysAsVector() const {
+  std::vector<std::string> pubkeys;
+  for (std::vector<RSA *>::const_iterator it = public_keys_.begin();
+       it != public_keys_.end();
+       it++) {
+    pubkeys.push_back(GenerateKeyText(*it));
+  }
+  // NOTE: we do not add the pubkey of the certificate here, as it is
+  // not used for the whitelist verification.
+  return pubkeys;
+}
 
 std::string SignatureManager::GetCertificate() const {
   if (!certificate_) return "";

--- a/cvmfs/crypto/signature.h
+++ b/cvmfs/crypto/signature.h
@@ -84,6 +84,7 @@ class CVMFS_EXPORT SignatureManager {
 
   // Returns the PEM-encoded text of all loaded RSA pubkeys
   std::string GetActivePubkeys() const;
+  std::vector<std::string> GetActivePubkeysAsVector() const;
   // The PEM-encoded private key matching the public master key
   std::string GetPrivateMasterKey();
   // The PEM-encoded certificate without private key

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1800,6 +1800,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
       fuse_reply_err(req, ENOATTR);
       return;
     }
+    attribute_result.first = true;
   }
 
   if (!attribute_result.first) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1695,19 +1695,27 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   vector<string> tokens_mode_machine = SplitString(name, '~');
   vector<string> tokens_mode_human = SplitString(name, '@');
 
-  uint32_t attr_req_page;
+  int32_t attr_req_page;
   MagicXattrMode xattr_mode;
   string attr;
 
   if (tokens_mode_human.size() > 1) {
-    attr_req_page = static_cast<uint32_t>(String2Uint64(
+    if (tokens_mode_human[tokens_mode_human.size() - 1] == "?") {
+      attr_req_page = -1;
+    } else {
+      attr_req_page = static_cast<int32_t>(String2Uint64(
                               tokens_mode_human[tokens_mode_human.size() - 1]));
+    }
     xattr_mode = kXattrHumanMode;
     attr = tokens_mode_human[0];
   } else {
-    attr_req_page = tokens_mode_machine.size() > 1 ?
-            static_cast<uint32_t>(String2Uint64(
+    if (tokens_mode_machine[tokens_mode_machine.size() - 1] == "?") {
+      attr_req_page = -1;
+    } else {
+      attr_req_page = tokens_mode_machine.size() > 1 ?
+            static_cast<int32_t>(String2Uint64(
                       tokens_mode_machine[tokens_mode_machine.size() - 1])) : 0;
+    }
     xattr_mode = kXattrMachineMode;
     attr = tokens_mode_machine[0];
   }

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2134,7 +2134,7 @@ class UptimeMagicXattr : public BaseMagicXattr {
   virtual void FinalizeValue(){
     time_t now = time(NULL);
     uint64_t uptime = now - cvmfs::loader_exports_->boot_time;
-    result_pages_.push_back(StringifyInt(uptime / 60));
+    result_pages_.push_back(StringifyUint(uptime / 60));
   }
 };
 

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -203,22 +203,30 @@ std::string BaseMagicXattr::HeaderMultipageHuman(uint32_t max_pages,
          " with 0)\n";
 }
 
-std::string BaseMagicXattr::GetValue(uint32_t requested_page,
+std::string BaseMagicXattr::GetValue(int32_t requested_page,
                                      const MagicXattrMode mode) {
   result_pages_.clear();
   FinalizeValue();
 
   std::string res = "";
   if (mode == kXattrMachineMode) {
-    if (requested_page >= result_pages_.size()) {
+    if (requested_page >= static_cast<int32_t>(result_pages_.size())) {
       return "ENOENT";
     }
+    if (requested_page == -1) {
+      return "num_pages, " + StringifyUint(result_pages_.size());
+    }
   } else {
-    if (requested_page >= result_pages_.size()) {
+    if (requested_page >= static_cast<int32_t>(result_pages_.size())) {
       return "Page requested does not exists. There are "
-              + StringifyUint(result_pages_.size()) + " pages available.\n"
-              + "Access them with xattr~<page_num> (machine-readable mode) "
-              + "or xattr@<page_num> (human-readable mode)";
+             + StringifyUint(result_pages_.size()) + " pages available.\n"
+             + "Access them with xattr~<page_num> (machine-readable mode) "
+             + "or xattr@<page_num> (human-readable mode).\n"
+             + "Use xattr@? or xattr~? to get extra info about the attribute";
+    } else if (requested_page == -1) {
+      return "Access xattr with xattr~<page_num> (machine-readable mode) or "
+             + std::string(" xattr@<page_num> (human-readable mode).\n")
+             + "Pages available: " + StringifyUint(result_pages_.size());
     } else {
       res = HeaderMultipageHuman(result_pages_.size(), requested_page);
       result_pages_[requested_page];

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -202,7 +202,7 @@ std::string BaseMagicXattr::HeaderMultipageHuman(uint32_t requested_page) {
          " with 0; number of pages available: xattr~?)\n";
 }
 
-std::string BaseMagicXattr::GetValue(int32_t requested_page,
+std::pair<bool, std::string> BaseMagicXattr::GetValue(int32_t requested_page,
                                      const MagicXattrMode mode) {
   assert(requested_page >= -1);
   result_pages_.clear();
@@ -211,22 +211,25 @@ std::string BaseMagicXattr::GetValue(int32_t requested_page,
   std::string res = "";
   if (mode == kXattrMachineMode) {
     if (requested_page >= static_cast<int32_t>(result_pages_.size())) {
-      return "ENODATA";
+      return std::pair<bool, std::string> {false, ""};
     }
     if (requested_page == -1) {
-      return "num_pages, " + StringifyUint(result_pages_.size());
+      return std::pair<bool, std::string> {true,
+                           "num_pages, " + StringifyUint(result_pages_.size())};
     }
   } else if (mode == kXattrHumanMode) {
     if (requested_page >= static_cast<int32_t>(result_pages_.size())) {
-      return "Page requested does not exists. There are "
+      return std::pair<bool, std::string> {true,
+             "Page requested does not exists. There are "
              + StringifyUint(result_pages_.size()) + " pages available.\n"
              + "Access them with xattr~<page_num> (machine-readable mode) "
              + "or xattr@<page_num> (human-readable mode).\n"
-             + "Use xattr@? or xattr~? to get extra info about the attribute";
+             + "Use xattr@? or xattr~? to get extra info about the attribute"};
     } else if (requested_page == -1) {
-      return "Access xattr with xattr~<page_num> (machine-readable mode) or "
+      return std::pair<bool, std::string> {true,
+             "Access xattr with xattr~<page_num> (machine-readable mode) or "
              + std::string(" xattr@<page_num> (human-readable mode).\n")
-             + "Pages available: " + StringifyUint(result_pages_.size());
+             + "Pages available: " + StringifyUint(result_pages_.size())};
     } else {
       res = HeaderMultipageHuman(requested_page);
     }
@@ -237,7 +240,7 @@ std::string BaseMagicXattr::GetValue(int32_t requested_page,
 
   res += result_pages_[requested_page];
 
-  return res;
+  return std::pair<bool, std::string> {true, res};
 }
 
 bool AuthzMagicXattr::PrepareValueFenced() {

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -211,25 +211,25 @@ std::pair<bool, std::string> BaseMagicXattr::GetValue(int32_t requested_page,
   std::string res = "";
   if (mode == kXattrMachineMode) {
     if (requested_page >= static_cast<int32_t>(result_pages_.size())) {
-      return std::pair<bool, std::string> {false, ""};
+      return std::pair<bool, std::string> (false, "");
     }
     if (requested_page == -1) {
-      return std::pair<bool, std::string> {true,
-                           "num_pages, " + StringifyUint(result_pages_.size())};
+      return std::pair<bool, std::string> (true,
+                           "num_pages, " + StringifyUint(result_pages_.size()));
     }
   } else if (mode == kXattrHumanMode) {
     if (requested_page >= static_cast<int32_t>(result_pages_.size())) {
-      return std::pair<bool, std::string> {true,
+      return std::pair<bool, std::string> (true,
              "Page requested does not exists. There are "
              + StringifyUint(result_pages_.size()) + " pages available.\n"
              + "Access them with xattr~<page_num> (machine-readable mode) "
              + "or xattr@<page_num> (human-readable mode).\n"
-             + "Use xattr@? or xattr~? to get extra info about the attribute"};
+             + "Use xattr@? or xattr~? to get extra info about the attribute");
     } else if (requested_page == -1) {
-      return std::pair<bool, std::string> {true,
+      return std::pair<bool, std::string> (true,
              "Access xattr with xattr~<page_num> (machine-readable mode) or "
              + std::string(" xattr@<page_num> (human-readable mode).\n")
-             + "Pages available: " + StringifyUint(result_pages_.size())};
+             + "Pages available: " + StringifyUint(result_pages_.size()));
     } else {
       res = HeaderMultipageHuman(requested_page);
     }
@@ -240,7 +240,7 @@ std::pair<bool, std::string> BaseMagicXattr::GetValue(int32_t requested_page,
 
   res += result_pages_[requested_page];
 
-  return std::pair<bool, std::string> {true, res};
+  return std::pair<bool, std::string> (true, res);
 }
 
 bool AuthzMagicXattr::PrepareValueFenced() {

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -261,7 +261,7 @@ void CatalogCountersMagicXattr::FinalizeValue() {
 bool ChunkListMagicXattr::PrepareValueFenced() {
   chunk_list_.clear();
 
-  std::string header = "hash,offset,size\n";
+  const std::string header = "hash,offset,size\n";
   std::string chunk_list_page_(header);
   if (!dirent_->IsRegular()) {
     return false;
@@ -476,7 +476,7 @@ void NCleanup24MagicXattr::FinalizeValue() {
   } else {
     const uint64_t period_s = 24 * 60 * 60;
     const uint64_t rate = quota_mgr->GetCleanupRate(period_s);
-    result_pages_.push_back(StringifyInt(rate));
+    result_pages_.push_back(StringifyUint(rate));
   }
 }
 
@@ -543,7 +543,6 @@ static void ListProxy(download::DownloadManager *dm,
   unsigned current_group;
   dm->GetProxyInfo(&proxy_chain, &current_group, NULL);
   std::string buf = "";
-  std::string fulbuf = "";
   for (unsigned int i = 0; i < proxy_chain.size(); i++) {
     for (unsigned int j = 0; j < proxy_chain[i].size(); j++) {
       buf += proxy_chain[i][j].url;

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -195,24 +195,37 @@ void MagicXattrManager::SanityCheckProtectedXattrs() {
   }
 }
 
-std::string BaseMagicXattr::HeaderMultipage(uint32_t max_pages,
+std::string BaseMagicXattr::HeaderMultipageHuman(uint32_t max_pages,
                                             uint32_t requested_page) {
   return "# Access page at idx: " + StringifyUint(requested_page) + ". " +
          "Total num pages: " + StringifyUint(max_pages) +
          " (access other pages: xattr~<page_num>, starting " +
-         " with 0)\n\n";
+         " with 0)\n";
 }
 
-std::string BaseMagicXattr::GetValue(uint32_t requested_page) {
-  if (result_pages_.size() == 1) {
-    return result_pages_[0];
+std::string BaseMagicXattr::GetValue(uint32_t requested_page,
+                                     const MagicXattrMode mode) {
+  result_pages_.clear();
+  FinalizeValue();
+
+  std::string res = "";
+  if (mode == kXattrMachineMode) {
+    if (requested_page >= result_pages_.size()) {
+      return "ENOENT";
+    }
+  } else {
+    if (requested_page >= result_pages_.size()) {
+      return "Page requested does not exists. There are "
+              + StringifyUint(result_pages_.size()) + " pages available.\n"
+              + "Access them with xattr~<page_num> (machine-readable mode) "
+              + "or xattr@<page_num> (human-readable mode)";
+    } else {
+      res = HeaderMultipageHuman(result_pages_.size(), requested_page);
+      result_pages_[requested_page];
+    }
   }
 
-  std::string res = HeaderMultipage(result_pages_.size(), requested_page);
-
-  if (requested_page < result_pages_.size()) {
-    res += result_pages_[requested_page];
-  }
+  res += result_pages_[requested_page];
 
   return res;
 }
@@ -221,8 +234,8 @@ bool AuthzMagicXattr::PrepareValueFenced() {
   return xattr_mgr_->mount_point()->has_membership_req();
 }
 
-std::string AuthzMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->membership_req();
+void AuthzMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->membership_req());
 }
 
 MagicXattrFlavor AuthzMagicXattr::GetXattrFlavor() {
@@ -236,19 +249,20 @@ bool CatalogCountersMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string CatalogCountersMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void CatalogCountersMagicXattr::FinalizeValue() {
   std::string res;
   res = "catalog_hash: " + hash_.ToString() + "\n";
   res += "catalog_mountpoint: " + subcatalog_path_ + "\n";
   res += counters_.GetCsvMap();
-  return res;
+
+  result_pages_.push_back(res);
 }
 
 bool ChunkListMagicXattr::PrepareValueFenced() {
-  result_pages_.clear();
+  chunk_list_.clear();
 
   std::string header = "hash,offset,size\n";
-  std::string chunk_list_(header);
+  std::string chunk_list_page_(header);
   if (!dirent_->IsRegular()) {
     return false;
   }
@@ -263,28 +277,32 @@ bool ChunkListMagicXattr::PrepareValueFenced() {
       return false;
     } else {
       for (size_t i = 0; i < chunks.size(); ++i) {
-        chunk_list_ += chunks.At(i).content_hash().ToString() + ",";
-        chunk_list_ += StringifyInt(chunks.At(i).offset()) + ",";
-        chunk_list_ += StringifyUint(chunks.At(i).size()) + "\n";
+        chunk_list_page_ += chunks.At(i).content_hash().ToString() + ",";
+        chunk_list_page_ += StringifyInt(chunks.At(i).offset()) + ",";
+        chunk_list_page_ += StringifyUint(chunks.At(i).size()) + "\n";
 
-        if (chunk_list_.size() > kMaxCharsPerPage) {
-          result_pages_.push_back(chunk_list_);
-          chunk_list_ = header;
+        if (chunk_list_page_.size() > kMaxCharsPerPage) {
+          chunk_list_.push_back(chunk_list_page_);
+          chunk_list_page_ = header;
         }
       }
     }
   } else {
-    chunk_list_ += dirent_->checksum().ToString() + ",";
-    chunk_list_ += "0,";
-    chunk_list_ += StringifyUint(dirent_->size()) + "\n";
+    chunk_list_page_ += dirent_->checksum().ToString() + ",";
+    chunk_list_page_ += "0,";
+    chunk_list_page_ += StringifyUint(dirent_->size()) + "\n";
   }
 
   // add the last page
-  if (chunk_list_.size() > header.size()) {
-    result_pages_.push_back(chunk_list_);
+  if (chunk_list_page_.size() > header.size()) {
+    chunk_list_.push_back(chunk_list_page_);
   }
 
   return true;
+}
+
+void ChunkListMagicXattr::FinalizeValue() {
+  result_pages_ = chunk_list_;
 }
 
 bool ChunksMagicXattr::PrepareValueFenced() {
@@ -310,80 +328,81 @@ bool ChunksMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string ChunksMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return StringifyUint(n_chunks_);
+void ChunksMagicXattr::FinalizeValue() {
+  result_pages_.push_back(StringifyUint(n_chunks_));
 }
 
 bool CompressionMagicXattr::PrepareValueFenced() {
   return dirent_->IsRegular();
 }
 
-std::string CompressionMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return zlib::AlgorithmName(dirent_->compression_algorithm());
+void CompressionMagicXattr::FinalizeValue() {
+  result_pages_.push_back(zlib::AlgorithmName(
+                                             dirent_->compression_algorithm()));
 }
 
 bool DirectIoMagicXattr::PrepareValueFenced() {
   return dirent_->IsRegular();
 }
 
-std::string DirectIoMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return dirent_->IsDirectIo() ? "1" : "0";
+void DirectIoMagicXattr::FinalizeValue() {
+  result_pages_.push_back(dirent_->IsDirectIo() ? "1" : "0");
 }
 
 bool ExternalFileMagicXattr::PrepareValueFenced() {
   return dirent_->IsRegular();
 }
 
-std::string ExternalFileMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return dirent_->IsExternalFile() ? "1" : "0";
+void ExternalFileMagicXattr::FinalizeValue() {
+  result_pages_.push_back(dirent_->IsExternalFile() ? "1" : "0");
 }
 
-std::string ExternalHostMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void ExternalHostMagicXattr::FinalizeValue() {
   std::vector<string> host_chain;
   std::vector<int> rtt;
   unsigned current_host;
   xattr_mgr_->mount_point()->external_download_mgr()->GetHostInfo(
     &host_chain, &rtt, &current_host);
   if (host_chain.size()) {
-    return std::string(host_chain[current_host]);
+    result_pages_.push_back(std::string(host_chain[current_host]));
   } else {
-    return "internal error: no hosts defined";
+    result_pages_.push_back("internal error: no hosts defined");
   }
 }
 
-std::string ExternalTimeoutMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void ExternalTimeoutMagicXattr::FinalizeValue() {
   unsigned seconds, seconds_direct;
   xattr_mgr_->mount_point()->external_download_mgr()->
                                       GetTimeout(&seconds, &seconds_direct);
-  return StringifyUint(seconds_direct);
+  result_pages_.push_back(StringifyUint(seconds_direct));
 }
 
-std::string FqrnMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->fqrn();
+void FqrnMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->fqrn());
 }
 
 bool HashMagicXattr::PrepareValueFenced() {
   return !dirent_->checksum().IsNull();
 }
 
-std::string HashMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return dirent_->checksum().ToString();
+void HashMagicXattr::FinalizeValue() {
+  result_pages_.push_back(dirent_->checksum().ToString());
 }
 
-std::string HostMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void HostMagicXattr::FinalizeValue() {
   std::vector<std::string> host_chain;
   std::vector<int> rtt;
   unsigned current_host;
   xattr_mgr_->mount_point()->download_mgr()->
                                 GetHostInfo(&host_chain, &rtt, &current_host);
   if (host_chain.size()) {
-    return std::string(host_chain[current_host]);
+    result_pages_.push_back(std::string(host_chain[current_host]));
   } else {
-    return "internal error: no hosts defined";
+    result_pages_.push_back("internal error: no hosts defined");
   }
 }
 
-std::string HostListMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void HostListMagicXattr::FinalizeValue() {
   std::string result;
   std::vector<std::string> host_chain;
   std::vector<int> rtt;
@@ -399,14 +418,14 @@ std::string HostListMagicXattr::GetValue(uint32_t /*requested_page*/) {
   } else {
     result = "internal error: no hosts defined";
   }
-  return result;
+  result_pages_.push_back(result);
 }
 
 bool LHashMagicXattr::PrepareValueFenced() {
   return !dirent_->checksum().IsNull();
 }
 
-std::string LHashMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void LHashMagicXattr::FinalizeValue() {
   string result;
   CacheManager::Label label;
   label.path = path_.ToString();
@@ -427,12 +446,12 @@ std::string LHashMagicXattr::GetValue(uint32_t /*requested_page*/) {
       result = hash.ToString();
     xattr_mgr_->mount_point()->file_system()->cache_mgr()->Close(fd);
   }
-  return result;
+  result_pages_.push_back(result);
 }
 
 LogBufferXattr::LogBufferXattr() : BaseMagicXattr(), throttle_(1, 500, 2000) { }
 
-std::string LogBufferXattr::GetValue(uint32_t /*requested_page*/) {
+void LogBufferXattr::FinalizeValue() {
   throttle_.Throttle();
   std::vector<LogBufferEntry> buffer = GetLogBuffer();
   std::string result;
@@ -446,18 +465,18 @@ std::string LogBufferXattr::GetValue(uint32_t /*requested_page*/) {
     result += "[" + StringifyTime(itr->timestamp, true /* UTC */) + " UTC] " +
               itr->message + "\n";
   }
-  return result;
+  result_pages_.push_back(result);
 }
 
-std::string NCleanup24MagicXattr::GetValue(uint32_t /*requested_page*/) {
+void NCleanup24MagicXattr::FinalizeValue() {
   QuotaManager *quota_mgr =
     xattr_mgr_->mount_point()->file_system()->cache_mgr()->quota_mgr();
   if (!quota_mgr->HasCapability(QuotaManager::kCapIntrospectCleanupRate)) {
-    return StringifyInt(-1);
+    result_pages_.push_back(StringifyInt(-1));
   } else {
     const uint64_t period_s = 24 * 60 * 60;
     const uint64_t rate = quota_mgr->GetCleanupRate(period_s);
-    return StringifyInt(rate);
+    result_pages_.push_back(StringifyInt(rate));
   }
 }
 
@@ -466,51 +485,55 @@ bool NClgMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string NClgMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return StringifyInt(n_catalogs_);
+void NClgMagicXattr::FinalizeValue() {
+  result_pages_.push_back(StringifyInt(n_catalogs_));
 }
 
-std::string NDirOpenMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->file_system()->n_fs_dir_open()->ToString();
+void NDirOpenMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->
+                                    file_system()->n_fs_dir_open()->ToString());
 }
 
-std::string NDownloadMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->statistics()->Lookup("fetch.n_downloads")
-                                                                      ->Print();
+void NDownloadMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->statistics()
+                                        ->Lookup("fetch.n_downloads")->Print());
 }
 
-std::string NIOErrMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return StringifyInt(xattr_mgr_->mount_point()->file_system()->io_error_info()
-                                                                    ->count());
+void NIOErrMagicXattr::FinalizeValue() {
+  result_pages_.push_back(StringifyInt(xattr_mgr_->mount_point()->file_system()
+                                                   ->io_error_info()->count()));
 }
 
-std::string NOpenMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->file_system()->n_fs_open()->ToString();
+void NOpenMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->file_system()->n_fs_open()
+                                                                  ->ToString());
 }
 
-std::string HitrateMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void HitrateMagicXattr::FinalizeValue() {
   int64_t n_invocations =
     xattr_mgr_->mount_point()->statistics()->Lookup("fetch.n_invocations")
                                                                       ->Get();
-  if (n_invocations == 0)
-    return "n/a";
+  if (n_invocations == 0) {
+    result_pages_.push_back("n/a");
+    return;
+  }
 
   int64_t n_downloads =
     xattr_mgr_->mount_point()->statistics()->Lookup("fetch.n_downloads")->Get();
   float hitrate = 100. * (1. -
     (static_cast<float>(n_downloads) / static_cast<float>(n_invocations)));
-  return StringifyDouble(hitrate);
+  result_pages_.push_back(StringifyDouble(hitrate));
 }
 
-std::string ProxyMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void ProxyMagicXattr::FinalizeValue() {
   vector< vector<download::DownloadManager::ProxyInfo> > proxy_chain;
   unsigned current_group;
   xattr_mgr_->mount_point()->download_mgr()->GetProxyInfo(
     &proxy_chain, &current_group, NULL);
   if (proxy_chain.size()) {
-    return proxy_chain[current_group][0].url;
+    result_pages_.push_back(proxy_chain[current_group][0].url);
   } else {
-    return "DIRECT";
+    result_pages_.push_back("DIRECT");
   }
 }
 
@@ -538,70 +561,65 @@ static void ListProxy(download::DownloadManager *dm,
   }
 }
 
-std::string ProxyListMagicXattr::GetValue(uint32_t requested_page) {
-  result_pages_.clear();
+void ProxyListMagicXattr::FinalizeValue() {
   ListProxy(xattr_mgr_->mount_point()->download_mgr(), &result_pages_);
-
-  return BaseMagicXattr::GetValue(requested_page);
 }
 
-std::string ProxyListExternalMagicXattr::GetValue(uint32_t requested_page) {
-  result_pages_.clear();
+void ProxyListExternalMagicXattr::FinalizeValue() {
   ListProxy(xattr_mgr_->mount_point()->external_download_mgr(), &result_pages_);
-
-  return BaseMagicXattr::GetValue(requested_page);
 }
 
 bool PubkeysMagicXattr::PrepareValueFenced() {
-  pubkeys_ = xattr_mgr_->mount_point()->signature_mgr()->GetActivePubkeys();
+  pubkeys_ = xattr_mgr_->mount_point()->signature_mgr()
+                                                   ->GetActivePubkeysAsVector();
   return true;
 }
 
-std::string PubkeysMagicXattr::GetValue(uint32_t requested_page) {
-  result_pages_.clear();
+void PubkeysMagicXattr::FinalizeValue() {
+  size_t full_size = 0;
 
-  if (pubkeys_.size() <= kMaxCharsPerPage) {
-    result_pages_.push_back(pubkeys_);
-  } else {
-    // we need to creat our own pages, no need to do it in the fuse fence
-    result_pages_.push_back("pubkey size " + StringifyUint(pubkeys_.size()));
-    uint64_t start_idx = 0;
-    uint64_t end_idx = kMaxCharsPerPage - 400;  // find a hit for the end of a
-                                                // key up to 400 chars before
-                                                // the limit
-    uint64_t hit_idx = -1;
-    const std::string end_of_key = "-----END PUBLIC KEY-----";
-
-    while (end_idx < pubkeys_.size()) {
-      hit_idx = pubkeys_.find(end_of_key, end_idx);
-
-      // no more hits
-      if (hit_idx == -1ul) {
-        break;
-      }
-
-      hit_idx += end_of_key.size();
-
-      uint64_t length = (hit_idx + 1) - start_idx;
-
-      result_pages_.push_back(pubkeys_.substr(start_idx, length));
-
-      start_idx = hit_idx + 1;
-      end_idx = start_idx + kMaxCharsPerPage - 400;
-    }
-
-    result_pages_.push_back(pubkeys_.substr(start_idx, kMaxCharsPerPage));
+  for (size_t i = 0; i < pubkeys_.size(); i++) {
+    full_size += pubkeys_[i].size();
   }
 
-  return BaseMagicXattr::GetValue(requested_page);
+  if (full_size == 0) {
+    return;
+  }
+
+  if (full_size <= kMaxCharsPerPage) {
+    std::string res = "";
+
+    for (size_t i = 0; i < pubkeys_.size(); i++) {
+      res += pubkeys_[i] + "\n";
+    }
+
+    result_pages_.push_back(res);
+  } else {
+    size_t size_within_page = 0;
+    std::string res = "";
+
+    for (size_t i = 0; i < pubkeys_.size(); i++) {
+      if (size_within_page + pubkeys_[i].size() < kMaxCharsPerPage) {
+        res += pubkeys_[i] + "\n";
+        size_within_page += pubkeys_[i].size() + 1;  // +1 new line char
+      } else {
+        result_pages_.push_back(res);
+        res = pubkeys_[i] + "\n";;
+        size_within_page = pubkeys_[i].size() + 1;  // +1 new line char
+      }
+    }
+    if (res.size() > 0) {
+      result_pages_.push_back(res);
+    }
+  }
 }
 
 bool RawlinkMagicXattr::PrepareValueFenced() {
   return dirent_->IsLink();
 }
 
-std::string RawlinkMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return dirent_->symlink().ToString();
+void RawlinkMagicXattr::FinalizeValue() {
+  result_pages_.push_back(dirent_->symlink().ToString());
 }
 
 bool RepoCountersMagicXattr::PrepareValueFenced() {
@@ -610,8 +628,8 @@ bool RepoCountersMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string RepoCountersMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return counters_.GetCsvMap();
+void RepoCountersMagicXattr::FinalizeValue() {
+  result_pages_.push_back(counters_.GetCsvMap());
 }
 
 uint64_t RepoMetainfoMagicXattr::kMaxMetainfoLength = 65536;
@@ -631,9 +649,10 @@ bool RepoMetainfoMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string RepoMetainfoMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void RepoMetainfoMagicXattr::FinalizeValue() {
   if (metainfo_hash_.IsNull()) {
-    return error_reason_;
+    result_pages_.push_back(error_reason_);
+    return;
   }
 
   CacheManager::Label label;
@@ -643,13 +662,15 @@ std::string RepoMetainfoMagicXattr::GetValue(uint32_t /*requested_page*/) {
   int fd = xattr_mgr_->mount_point()->fetcher()->Fetch(
     CacheManager::LabeledObject(metainfo_hash_, label));
   if (fd < 0) {
-    return "Failed to open metadata file";
+    result_pages_.push_back("Failed to open metadata file");
+    return;
   }
   uint64_t actual_size = xattr_mgr_->mount_point()->file_system()->cache_mgr()
                                                                  ->GetSize(fd);
   if (actual_size > kMaxMetainfoLength) {
     xattr_mgr_->mount_point()->file_system()->cache_mgr()->Close(fd);
-    return "Failed to open: metadata file is too big";
+    result_pages_.push_back("Failed to open: metadata file is too big");
+    return;
   }
   char buffer[kMaxMetainfoLength];
   int64_t bytes_read =
@@ -657,9 +678,10 @@ std::string RepoMetainfoMagicXattr::GetValue(uint32_t /*requested_page*/) {
                                             ->Pread(fd, buffer, actual_size, 0);
   xattr_mgr_->mount_point()->file_system()->cache_mgr()->Close(fd);
   if (bytes_read < 0) {
-    return "Failed to read metadata file";
+    result_pages_.push_back("Failed to read metadata file");
+    return;
   }
-  return string(buffer, buffer + bytes_read);
+  result_pages_.push_back(string(buffer, buffer + bytes_read));
 }
 
 bool RevisionMagicXattr::PrepareValueFenced() {
@@ -667,8 +689,8 @@ bool RevisionMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string RevisionMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return StringifyUint(revision_);
+void RevisionMagicXattr::FinalizeValue() {
+  result_pages_.push_back(StringifyUint(revision_));
 }
 
 bool RootHashMagicXattr::PrepareValueFenced() {
@@ -676,24 +698,25 @@ bool RootHashMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string RootHashMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return root_hash_.ToString();
+void RootHashMagicXattr::FinalizeValue() {
+  result_pages_.push_back(root_hash_.ToString());
 }
 
-std::string RxMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void RxMagicXattr::FinalizeValue() {
   perf::Statistics *statistics = xattr_mgr_->mount_point()->statistics();
   int64_t rx = statistics->Lookup("download.sz_transferred_bytes")->Get();
-  return StringifyInt(rx/1024);
+  result_pages_.push_back(StringifyInt(rx/1024));
 }
 
-std::string SpeedMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void SpeedMagicXattr::FinalizeValue() {
   perf::Statistics *statistics = xattr_mgr_->mount_point()->statistics();
   int64_t rx = statistics->Lookup("download.sz_transferred_bytes")->Get();
   int64_t time = statistics->Lookup("download.sz_transfer_time")->Get();
-  if (time == 0)
-    return "n/a";
-  else
-    return StringifyInt((1000 * (rx/1024))/time);
+  if (time == 0) {
+    result_pages_.push_back("n/a");
+  } else {
+    result_pages_.push_back(StringifyInt((1000 * (rx/1024))/time));
+  }
 }
 
 bool TagMagicXattr::PrepareValueFenced() {
@@ -701,43 +724,45 @@ bool TagMagicXattr::PrepareValueFenced() {
   return true;
 }
 
-std::string TagMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return tag_;
+void TagMagicXattr::FinalizeValue() {
+  result_pages_.push_back(tag_);
 }
 
-std::string TimeoutMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void TimeoutMagicXattr::FinalizeValue() {
   unsigned seconds, seconds_direct;
   xattr_mgr_->mount_point()->download_mgr()
                            ->GetTimeout(&seconds, &seconds_direct);
-  return StringifyUint(seconds);
+  result_pages_.push_back(StringifyUint(seconds));
 }
 
-std::string TimeoutDirectMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void TimeoutDirectMagicXattr::FinalizeValue() {
   unsigned seconds, seconds_direct;
   xattr_mgr_->mount_point()->download_mgr()
                            ->GetTimeout(&seconds, &seconds_direct);
-  return StringifyUint(seconds_direct);
+  result_pages_.push_back(StringifyUint(seconds_direct));
 }
 
-std::string TimestampLastIOErrMagicXattr::GetValue(uint32_t /*req_page*/) {
-  return StringifyInt(
-    xattr_mgr_->mount_point()->file_system()->io_error_info()
-                                            ->timestamp_last());
+void TimestampLastIOErrMagicXattr::FinalizeValue() {
+  result_pages_.push_back(StringifyInt(xattr_mgr_->mount_point()->
+                             file_system()->io_error_info()->timestamp_last()));
 }
 
-std::string UsedFdMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->file_system()->no_open_files()->ToString();
+void UsedFdMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->file_system()->
+                                                   no_open_files()->ToString());
 }
 
-std::string UsedDirPMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return xattr_mgr_->mount_point()->file_system()->no_open_dirs()->ToString();
+void UsedDirPMagicXattr::FinalizeValue() {
+  result_pages_.push_back(xattr_mgr_->mount_point()->file_system()->
+                                                    no_open_dirs()->ToString());
 }
 
-std::string VersionMagicXattr::GetValue(uint32_t /*requested_page*/) {
-  return std::string(VERSION) + "." + std::string(CVMFS_PATCH_LEVEL);
+void VersionMagicXattr::FinalizeValue() {
+  result_pages_.push_back(std::string(VERSION) + "."
+                                              + std::string(CVMFS_PATCH_LEVEL));
 }
 
-std::string ExternalURLMagicXattr::GetValue(uint32_t /*requested_page*/) {
+void ExternalURLMagicXattr::FinalizeValue() {
   std::vector<std::string> host_chain;
   std::vector<int> rtt;
   unsigned current_host;
@@ -745,10 +770,12 @@ std::string ExternalURLMagicXattr::GetValue(uint32_t /*requested_page*/) {
     xattr_mgr_->mount_point()->external_download_mgr()->GetHostInfo(
       &host_chain, &rtt, &current_host);
     if (host_chain.size()) {
-      return std::string(host_chain[current_host]) + std::string(path_.c_str());
+      result_pages_.push_back(std::string(host_chain[current_host])
+                              + std::string(path_.c_str()));
+      return;
     }
   }
-  return std::string("");
+  result_pages_.push_back("");
 }
 
 bool ExternalURLMagicXattr::PrepareValueFenced() {

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -128,7 +128,7 @@ class BaseMagicXattr {
   virtual bool PrepareValueFenced() { return true; }
   virtual void FinalizeValue() {}
 
-  std::string HeaderMultipageHuman(uint32_t max_pages, uint32_t requested_page);
+  std::string HeaderMultipageHuman(uint32_t requested_page);
 
   MagicXattrManager *xattr_mgr_;
   PathString path_;

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -44,7 +44,7 @@ class MagicXattrManager;  // needed for BaseMagicXattr
  * To read out the attribute value, do:
  * 0. Get an instance through MagicXattrManager::Get()
  * 1. Call PrepareValueFenced() inside FuseRemounter::fence()
- * 2. Call GetValue(uint32_t requested_page, const MagicXattrMode mode);
+ * 2. Call GetValue(int32_t requested_page, const MagicXattrMode mode);
  *    to get the actual value (can be called outside the fence)
  *    This will internally call FinalizeValue() to finalize the value
  *    preparation outside the fuse fence.
@@ -93,12 +93,13 @@ class BaseMagicXattr {
    * It does the computationaly intensive part, which should not
    * be done inside the FuseRemounter::fence(), and returns the
    * value.
-   *
+   * 
    * Internally it calls FinalizeValue() which each MagicXAttr has to implement
    * to set the value of result_pages_
-   *
+   * 
+   * If request_page == -1 than the number of pages available are returned
    */
-  std::string GetValue(uint32_t requested_page,
+  std::string GetValue(int32_t requested_page,
                        const MagicXattrMode mode);
 
   virtual MagicXattrFlavor GetXattrFlavor() { return kXattrBase; }

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -44,13 +44,13 @@ class MagicXattrManager;  // needed for BaseMagicXattr
  * 
  * Implementation notes:
  * - best is to write the results to "std::vector<std::string> result_pages_"
- *   even if it is just a sinlge page xattr
+ *   even if it is just a single page xattr
  * - if no modification is needed outside of PrepareValueFenced(),
  *   no specific implementation for GetValue() is needed.
  *   BaseMagicXattr::GetValue() will be called that takes care both of single
  *   and multi-page xattrs
  *   (if you do not use it do not forget to call HeaderMultipage() first)
- * - for multi-page xattrs, a sinlge page should not be larger than
+ * - for multi-page xattrs, a single page should not be larger than
  *   BaseMagicXattr::kMaxCharsPerPage
  * - Do not forget to call result_pages_.clear() before each new request
  */

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -107,7 +107,8 @@ cvmfs_run_test() {
   [ "x$readme_chunk_size" = "x$readme_size" ] || return 12
 
   echo "*** Test log buffer (quite basic)"
-  local logbuffer=$(get_xattr logbuffer /cvmfs/grid.cern.ch/)
+  local logbuffer
+  logbuffer=$(get_xattr logbuffer /cvmfs/grid.cern.ch/)
   get_xattr logbuffer /cvmfs/grid.cern.ch/
   [ "x$logbuffer" != "x" ] || return 20
 
@@ -149,12 +150,12 @@ Pages available: 1"
   letters_num=$(get_xattr proxy_list~xxx /cvmfs/grid.cern.ch/README 2>&1) 
   nothing=$(get_xattr proxy_list@ /cvmfs/grid.cern.ch/README 2>&1) 
 
-  error="attr_get: No data available"
-
-  echo "raw output"
-  echo $(get_xattr proxy_list@-2 /cvmfs/grid.cern.ch/README)
-  echo "capture both"
-  echo $negative_num
+  local error
+  if running_on_osx; then
+    error="No message available on STREAM"
+  else
+    error="attr_get: No data available"
+  fi
 
   if echo $negative_num | grep -v "$error"; then
     return 50

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -3,7 +3,7 @@ cvmfs_test_suites="quick"
 
 # Test for protected extended attribute access
 check_protected_xattr() {
-  echo "Test protected extended attributes"
+  echo "*** Test protected extended attributes"
   echo "  Having no restrictions"
   cvmfs_mount grid.cern.ch "CVMFS_MAGIC_XATTRS_VISIBILITY=always" || return 3
   local no_restrictions=$(get_xattr fqrn /cvmfs/grid.cern.ch/README)
@@ -116,6 +116,22 @@ cvmfs_run_test() {
   proxy_list_external=$(get_xattr proxy_list_external /cvmfs/grid.cern.ch/README)
   [ "x$proxy_list" != "x" ] || return 21
   [ "x$proxy_list_external" != "x" ] || return 22
+
+  # check different access modes 
+  echo "*** Check different access modes: human vs machine"
+  runc_chunk_list_machine=$(attr -qg chunk_list~0 /cvmfs/grid.cern.ch/vc/containers/runc)
+  runc_chunk_list_human=$(attr -qg chunk_list@0 /cvmfs/grid.cern.ch/vc/containers/runc)
+
+  [ "x$runc_chunk_list" = "x$runc_chunk_list_machine" ] || return 30
+
+
+  if echo $runc_chunk_list_human | grep -v "# Access page at idx: 0. Total num pages: 1 "; then
+    return 31
+  fi
+
+  if echo $runc_chunk_list_human | grep -v "$runc_chunk_list_machine"; then
+    return 32
+  fi
 
   cvmfs_umount grid.cern.ch || return 2
 

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -151,6 +151,11 @@ Pages available: 1"
 
   error="attr_get: No data available"
 
+  echo "raw output"
+  echo $(get_xattr proxy_list@-2 /cvmfs/grid.cern.ch/README)
+  echo "capture both"
+  echo $negative_num
+
   if echo $negative_num | grep -v "$error"; then
     return 50
   fi

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -119,8 +119,8 @@ cvmfs_run_test() {
 
   # check different access modes 
   echo "*** Check different access modes: human vs machine"
-  runc_chunk_list_machine=$(attr -qg chunk_list~0 /cvmfs/grid.cern.ch/vc/containers/runc)
-  runc_chunk_list_human=$(attr -qg chunk_list@0 /cvmfs/grid.cern.ch/vc/containers/runc)
+  runc_chunk_list_machine=$(get_xattr chunk_list~0 /cvmfs/grid.cern.ch/vc/containers/runc)
+  runc_chunk_list_human=$(get_xattr chunk_list@0 /cvmfs/grid.cern.ch/vc/containers/runc)
 
   [ "x$runc_chunk_list" = "x$runc_chunk_list_machine" ] || return 30
 

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -8,7 +8,7 @@ check_protected_xattr() {
   cvmfs_mount grid.cern.ch "CVMFS_MAGIC_XATTRS_VISIBILITY=always" || return 3
   local no_restrictions=$(get_xattr fqrn /cvmfs/grid.cern.ch/README)
 
-  [ "$no_restrictions" = "grid.cern.ch" ] || return 30
+  [ "$no_restrictions" = "grid.cern.ch" ] || return 60
   cvmfs_umount grid.cern.ch || return 2
   echo "  ...Success"
 
@@ -19,7 +19,7 @@ CVMFS_XATTR_PRIVILEGED_GIDS=$user_gid
 CVMFS_XATTR_PROTECTED_XATTRS=user.fqrn" || return 3
   local ok_user=$(get_xattr fqrn /cvmfs/grid.cern.ch/README)
 
-  [ "$ok_user" = "grid.cern.ch" ] || return 31
+  [ "$ok_user" = "grid.cern.ch" ] || return 61
 
   cvmfs_umount grid.cern.ch || return 2
   echo "  ...Success"
@@ -38,8 +38,8 @@ CVMFS_XATTR_PROTECTED_XATTRS=user.fqrn" || return 3
   echo "    Test non-root"
   local non_root_denied=$(get_xattr fqrn /cvmfs/grid.cern.ch/README)
 
-  [ "$root_access" = "grid.cern.ch" ] || return 32
-  [ "$non_root_denied" = "grid.cern.ch" ] && return 33
+  [ "$root_access" = "grid.cern.ch" ] || return 62
+  [ "$non_root_denied" = "grid.cern.ch" ] && return 63
 
   cvmfs_umount grid.cern.ch || return 2
   echo "  ...Success"
@@ -131,6 +131,37 @@ cvmfs_run_test() {
 
   if echo $runc_chunk_list_human | grep -v "$runc_chunk_list_machine"; then
     return 32
+  fi
+
+  echo "*** Check info elements"
+  info_human_correct="Access xattr with xattr~<page_num> (machine-readable mode) or  xattr@<page_num> (human-readable mode).
+Pages available: 1"
+  info_machine_correct="num_pages, 1"
+  info_human=$(get_xattr proxy_list@? /cvmfs/grid.cern.ch/README)
+  info_machine=$(get_xattr proxy_list~? /cvmfs/grid.cern.ch/README)
+
+  [ "x$info_human" != "$info_human_correct" ] || return 40
+  [ "x$info_machine" != "$info_machine_correct" ] || return 41
+
+  echo "*** Check invalid input for num pages"
+  negative_num=$(get_xattr proxy_list@-2 /cvmfs/grid.cern.ch/README 2>&1)
+  large_num=$(get_xattr proxy_list~1000 /cvmfs/grid.cern.ch/README 2>&1)  
+  letters_num=$(get_xattr proxy_list~xxx /cvmfs/grid.cern.ch/README 2>&1) 
+  nothing=$(get_xattr proxy_list@ /cvmfs/grid.cern.ch/README 2>&1) 
+
+  error="attr_get: No data available"
+
+  if echo $negative_num | grep -v "$error"; then
+    return 50
+  fi
+  if echo $large_num | grep -v "$error"; then
+    return 51
+  fi
+  if echo $letters_num | grep -v "$error"; then
+    return 52
+  fi
+  if echo $nothing | grep -v "$error"; then
+    return 53
   fi
 
   cvmfs_umount grid.cern.ch || return 2

--- a/test/src/623-pubkeyattr/main
+++ b/test/src/623-pubkeyattr/main
@@ -13,7 +13,8 @@ cvmfs_run_test() {
   local known_pubkey=$(find /etc/cvmfs/keys/ -name "${CVMFS_TEST_REPO}.pub")
   attr -qg pubkeys /var/spool/cvmfs/$CVMFS_TEST_REPO/rdonly > pubkey_attr
 
-  if `diff -q pubkey_attr $known_pubkey`; then
+  # attr returns a new line at the end of the key. So ignore blank lines in diff
+  if eval "$(diff -B -q pubkey_attr $known_pubkey)"; then
     echo "Pubkeys match:"
     cat pubkey_attr
   else

--- a/test/unittests/t_magic_xattr.cc
+++ b/test/unittests/t_magic_xattr.cc
@@ -154,7 +154,8 @@ TEST_F(T_MagicXattr, ProtectedXattr) {
   ASSERT_FALSE(attr.IsNull());
   ASSERT_FALSE(attr->PrepareValueFencedProtected(2));
   ASSERT_TRUE(attr->PrepareValueFencedProtected(1));
-  EXPECT_STREQ("keys.cern.ch", attr->GetValue(0, kXattrMachineMode).second.c_str());
+  EXPECT_STREQ("keys.cern.ch",
+                           attr->GetValue(0, kXattrMachineMode).second.c_str());
 }
 
 TEST_F(T_MagicXattr, MultiPageMachineModeXattr) {
@@ -182,11 +183,13 @@ TEST_F(T_MagicXattr, MultiPageMachineModeXattr) {
   EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).second.find("ccccc"),
             std::string::npos);
   EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).second.find("dddddd"), 0);
-  EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).second.find("fffffff"), 0);
+  EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).second.find("fffffff"),
+            0);
 
   EXPECT_FALSE(attr.GetValue(3, kXattrMachineMode).first);
-  EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).second.find("# Access page at idx: "),
-            std::string::npos);
+  EXPECT_EQ(
+      attr.GetValue(1, kXattrMachineMode).second.find("# Access page at idx: "),
+      std::string::npos);
 }
 
 TEST_F(T_MagicXattr, MultiPageHumanModeXattr) {
@@ -204,7 +207,8 @@ TEST_F(T_MagicXattr, MultiPageHumanModeXattr) {
 
   EXPECT_EQ((int) attr.GetValue(1, kXattrHumanMode).second.find(
                                                   "# Access page at idx: "), 0);
-  EXPECT_EQ(attr.GetValue(1, kXattrHumanMode).second.find("ccccc"), std::string::npos);
+  EXPECT_EQ(attr.GetValue(1, kXattrHumanMode).second.find("ccccc"),
+                                                             std::string::npos);
   EXPECT_GE((int) attr.GetValue(1, kXattrHumanMode).second.find("ddddddd"), 0);
   EXPECT_GE((int) attr.GetValue(1, kXattrHumanMode).second.find("fffffff"), 0);
 

--- a/test/unittests/t_magic_xattr.cc
+++ b/test/unittests/t_magic_xattr.cc
@@ -159,7 +159,7 @@ TEST_F(T_MagicXattr, ProtectedXattr) {
 TEST_F(T_MagicXattr, MultiPageMachineModeXattr) {
   PubkeysMagicXattr attr;
 
-  EXPECT_STREQ(attr.GetValue(0, kXattrMachineMode).c_str(), "ENOENT");
+  EXPECT_STREQ(attr.GetValue(0, kXattrMachineMode).c_str(), "ENODATA");
 
   attr.pubkeys_.push_back("xx");
 
@@ -183,7 +183,7 @@ TEST_F(T_MagicXattr, MultiPageMachineModeXattr) {
   EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).find("dddddd"), 0);
   EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).find("fffffff"), 0);
 
-  EXPECT_STREQ(attr.GetValue(3, kXattrMachineMode).c_str(), "ENOENT");
+  EXPECT_STREQ(attr.GetValue(3, kXattrMachineMode).c_str(), "ENODATA");
   EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).find("# Access page at idx: "),
             std::string::npos);
 }

--- a/test/unittests/t_magic_xattr.cc
+++ b/test/unittests/t_magic_xattr.cc
@@ -75,7 +75,8 @@ TEST_F(T_MagicXattr, TestFqrn) {
   MagicXattrRAIIWrapper attr(mgr->GetLocked("user.fqrn", path, &dirent));
   ASSERT_FALSE(attr.IsNull());
   ASSERT_TRUE(attr->PrepareValueFenced());
-  EXPECT_STREQ("keys.cern.ch", attr->GetValue(0, kXattrMachineMode).c_str());
+  EXPECT_STREQ("keys.cern.ch", attr->
+                                 GetValue(0, kXattrMachineMode).second.c_str());
 }
 
 TEST_F(T_MagicXattr, TestLogBuffer) {
@@ -94,7 +95,7 @@ TEST_F(T_MagicXattr, TestLogBuffer) {
     MagicXattrRAIIWrapper attr(mgr->GetLocked("user.logbuffer", path, &dirent));
     ASSERT_FALSE(attr.IsNull());
     ASSERT_TRUE(attr->PrepareValueFenced());
-    EXPECT_TRUE(HasSuffix(attr->GetValue(0, kXattrMachineMode), "test\n",
+    EXPECT_TRUE(HasSuffix(attr->GetValue(0, kXattrMachineMode).second, "test\n",
                                                          false /* ign_case */));
   }
 
@@ -103,8 +104,8 @@ TEST_F(T_MagicXattr, TestLogBuffer) {
     MagicXattrRAIIWrapper attr(mgr->GetLocked("user.logbuffer", path, &dirent));
     ASSERT_FALSE(attr.IsNull());
     ASSERT_TRUE(attr->PrepareValueFenced());
-    EXPECT_TRUE(HasSuffix(attr->GetValue(0, kXattrMachineMode), "<snip>\n",
-                                                         false /* ign_case */));
+    EXPECT_TRUE(HasSuffix(attr->GetValue(0, kXattrMachineMode).second,
+                                             "<snip>\n", false /* ign_case */));
   }
 }
 
@@ -153,17 +154,17 @@ TEST_F(T_MagicXattr, ProtectedXattr) {
   ASSERT_FALSE(attr.IsNull());
   ASSERT_FALSE(attr->PrepareValueFencedProtected(2));
   ASSERT_TRUE(attr->PrepareValueFencedProtected(1));
-  EXPECT_STREQ("keys.cern.ch", attr->GetValue(0, kXattrMachineMode).c_str());
+  EXPECT_STREQ("keys.cern.ch", attr->GetValue(0, kXattrMachineMode).second.c_str());
 }
 
 TEST_F(T_MagicXattr, MultiPageMachineModeXattr) {
   PubkeysMagicXattr attr;
 
-  EXPECT_STREQ(attr.GetValue(0, kXattrMachineMode).c_str(), "ENODATA");
+  EXPECT_FALSE(attr.GetValue(0, kXattrMachineMode).first);
 
   attr.pubkeys_.push_back("xx");
 
-  EXPECT_STREQ(attr.GetValue(0, kXattrMachineMode).c_str(), "xx\n");
+  EXPECT_STREQ(attr.GetValue(0, kXattrMachineMode).second.c_str(), "xx");
 
   attr.pubkeys_.clear();
   attr.pubkeys_.push_back(std::string(10000, 'a'));
@@ -173,25 +174,25 @@ TEST_F(T_MagicXattr, MultiPageMachineModeXattr) {
   attr.pubkeys_.push_back(std::string(10000, 'e'));
   attr.pubkeys_.push_back(std::string(10000, 'f'));
 
-  EXPECT_EQ(attr.GetValue(0, kXattrMachineMode).find("ddddddd"),
+  EXPECT_EQ(attr.GetValue(0, kXattrMachineMode).second.find("ddddddd"),
             std::string::npos);
-  EXPECT_GE((int) attr.GetValue(0, kXattrMachineMode).find("aaaaaa"), 0);
-  EXPECT_GE((int) attr.GetValue(0, kXattrMachineMode).find("bbbbbb"), 0);
+  EXPECT_GE((int) attr.GetValue(0, kXattrMachineMode).second.find("aaaaaa"), 0);
+  EXPECT_GE((int) attr.GetValue(0, kXattrMachineMode).second.find("bbbbbb"), 0);
 
-  EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).find("ccccc"),
+  EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).second.find("ccccc"),
             std::string::npos);
-  EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).find("dddddd"), 0);
-  EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).find("fffffff"), 0);
+  EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).second.find("dddddd"), 0);
+  EXPECT_GE((int) attr.GetValue(1, kXattrMachineMode).second.find("fffffff"), 0);
 
-  EXPECT_STREQ(attr.GetValue(3, kXattrMachineMode).c_str(), "ENODATA");
-  EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).find("# Access page at idx: "),
+  EXPECT_FALSE(attr.GetValue(3, kXattrMachineMode).first);
+  EXPECT_EQ(attr.GetValue(1, kXattrMachineMode).second.find("# Access page at idx: "),
             std::string::npos);
 }
 
 TEST_F(T_MagicXattr, MultiPageHumanModeXattr) {
   PubkeysMagicXattr attr;
 
-  EXPECT_EQ((int) attr.GetValue(0, kXattrHumanMode).find(
+  EXPECT_EQ((int) attr.GetValue(0, kXattrHumanMode).second.find(
                                          "Page requested does not exists."), 0);
 
   attr.pubkeys_.push_back(std::string(10000, 'a'));
@@ -201,13 +202,13 @@ TEST_F(T_MagicXattr, MultiPageHumanModeXattr) {
   attr.pubkeys_.push_back(std::string(10000, 'e'));
   attr.pubkeys_.push_back(std::string(10000, 'f'));
 
-  EXPECT_EQ((int) attr.GetValue(1, kXattrHumanMode).find(
+  EXPECT_EQ((int) attr.GetValue(1, kXattrHumanMode).second.find(
                                                   "# Access page at idx: "), 0);
-  EXPECT_EQ(attr.GetValue(1, kXattrHumanMode).find("ccccc"), std::string::npos);
-  EXPECT_GE((int) attr.GetValue(1, kXattrHumanMode).find("ddddddd"), 0);
-  EXPECT_GE((int) attr.GetValue(1, kXattrHumanMode).find("fffffff"), 0);
+  EXPECT_EQ(attr.GetValue(1, kXattrHumanMode).second.find("ccccc"), std::string::npos);
+  EXPECT_GE((int) attr.GetValue(1, kXattrHumanMode).second.find("ddddddd"), 0);
+  EXPECT_GE((int) attr.GetValue(1, kXattrHumanMode).second.find("fffffff"), 0);
 
 
-  EXPECT_EQ((int) attr.GetValue(3, kXattrHumanMode).find(
+  EXPECT_EQ((int) attr.GetValue(3, kXattrHumanMode).second.find(
                                          "Page requested does not exists."), 0);
 }

--- a/test/unittests/t_magic_xattr.cc
+++ b/test/unittests/t_magic_xattr.cc
@@ -75,7 +75,7 @@ TEST_F(T_MagicXattr, TestFqrn) {
   MagicXattrRAIIWrapper attr(mgr->GetLocked("user.fqrn", path, &dirent));
   ASSERT_FALSE(attr.IsNull());
   ASSERT_TRUE(attr->PrepareValueFenced());
-  EXPECT_STREQ("keys.cern.ch", attr->GetValue().c_str());
+  EXPECT_STREQ("keys.cern.ch", attr->GetValue(0).c_str());
 }
 
 TEST_F(T_MagicXattr, TestLogBuffer) {
@@ -94,7 +94,7 @@ TEST_F(T_MagicXattr, TestLogBuffer) {
     MagicXattrRAIIWrapper attr(mgr->GetLocked("user.logbuffer", path, &dirent));
     ASSERT_FALSE(attr.IsNull());
     ASSERT_TRUE(attr->PrepareValueFenced());
-    EXPECT_TRUE(HasSuffix(attr->GetValue(), "test\n", false /* ign_case */));
+    EXPECT_TRUE(HasSuffix(attr->GetValue(0), "test\n", false /* ign_case */));
   }
 
   LogCvmfs(kLogCvmfs, 0, "%s", std::string(6000, 'x').c_str());
@@ -102,7 +102,7 @@ TEST_F(T_MagicXattr, TestLogBuffer) {
     MagicXattrRAIIWrapper attr(mgr->GetLocked("user.logbuffer", path, &dirent));
     ASSERT_FALSE(attr.IsNull());
     ASSERT_TRUE(attr->PrepareValueFenced());
-    EXPECT_TRUE(HasSuffix(attr->GetValue(), "<snip>\n", false /* ign_case */));
+    EXPECT_TRUE(HasSuffix(attr->GetValue(0), "<snip>\n", false /* ign_case */));
   }
 }
 
@@ -151,5 +151,5 @@ TEST_F(T_MagicXattr, ProtectedXattr) {
   ASSERT_FALSE(attr.IsNull());
   ASSERT_FALSE(attr->PrepareValueFencedProtected(2));
   ASSERT_TRUE(attr->PrepareValueFencedProtected(1));
-  EXPECT_STREQ("keys.cern.ch", attr->GetValue().c_str());
+  EXPECT_STREQ("keys.cern.ch", attr->GetValue(0).c_str());
 }


### PR DESCRIPTION
Issue #2922

Superseeds #3336 

-Page request now moved to `GetValue()`.
-New xattr wide variable `std::vector<std::string>> result_pages_` to save results. 
-Limit per page is `kMaxCharsPerPage`
-`GetValue()` is not pure virtual anymore, instead `GetValue()` of basexattr can automatically constructs output, single or multi-page xattr depending on `result_pages_` (so in theory, xattr that just get all their data in `preparedfencedvalue()` dont need their own `getvalue()` anymore

there might be more that can be extended. eg. i guess logbuffer? so far i only did the "simple" ones