### PR TITLE
visiblity changes to expose additional functionality in libcvmfs_server

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -757,6 +757,7 @@ if (BUILD_SERVER)
        reflog_sql.cc
        sanitizer.cc
        session_context.cc
+       server_tool.cc
        shortstring.cc
        sql.cc
        sqlitemem.cc
@@ -780,7 +781,7 @@ if (BUILD_SERVER)
        whitelist.cc
        xattr.cc
   )
-  set (LIBCVMFS_SERVER_CFLAGS "-D_FILE_OFFSET_BITS=64 -DCVMFS_RAISE_EXCEPTIONS -fexceptions")
+  set (LIBCVMFS_SERVER_CFLAGS "-D_FILE_OFFSET_BITS=64 -DCVMFS_LIBRARY -DCVMFS_RAISE_EXCEPTIONS -fexceptions")
   set (LIBCVMFS_SERVER_LINK_LIBRARIES "")
   list (APPEND LIBCVMFS_SERVER_LINK_LIBRARIES
         ${CURL_LIBRARIES}

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -237,7 +237,7 @@ bool Catalog::OpenDatabase(const string &db_path) {
 /**
  * Removes the mountpoint and prepends the root prefix to path
  */
-shash::Md5 Catalog::NormalizePath(const PathString &path) const {
+CVMFS_EXPORT shash::Md5 Catalog::NormalizePath(const PathString &path) const {
   if (is_regular_mountpoint_)
     return shash::Md5(path.GetChars(), path.GetLength());
 

--- a/cvmfs/catalog.h
+++ b/cvmfs/catalog.h
@@ -23,6 +23,7 @@
 #include "sql.h"
 #include "uid_map.h"
 #include "xattr.h"
+#include "util/export.h"
 
 namespace swissknife {
 class CommandMigrate;
@@ -88,7 +89,7 @@ class InodeAnnotation {
  *
  * Read-only catalog. A sub-class provides read-write access.
  */
-class Catalog : SingleCopy {
+class CVMFS_EXPORT Catalog : SingleCopy {
   FRIEND_TEST(T_Catalog, NormalizePath);
   FRIEND_TEST(T_Catalog, PlantPath);
   friend class swissknife::CommandMigrate;  // for catalog version migration

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -28,7 +28,7 @@ using namespace std;  // NOLINT
 
 namespace catalog {
 
-WritableCatalogManager::WritableCatalogManager(
+CVMFS_EXPORT WritableCatalogManager::WritableCatalogManager(
   const shash::Any          &base_hash,
   const std::string         &stratum0,
   const string              &dir_temp,
@@ -65,7 +65,7 @@ WritableCatalogManager::WritableCatalogManager(
 }
 
 
-WritableCatalogManager::~WritableCatalogManager() {
+CVMFS_EXPORT WritableCatalogManager::~WritableCatalogManager() {
   pthread_mutex_destroy(sync_lock_);
   free(sync_lock_);
   pthread_mutex_destroy(catalog_processing_lock_);

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -41,6 +41,7 @@
 #include "file_chunk.h"
 #include "upload_spooler_result.h"
 #include "util/concurrency.h"
+#include "util/export.h"
 #include "xattr.h"
 
 class XattrList;
@@ -67,14 +68,14 @@ class CatalogBalancer;
 
 namespace catalog {
 
-class WritableCatalogManager : public SimpleCatalogManager {
+class CVMFS_EXPORT WritableCatalogManager : public SimpleCatalogManager {
   friend class CatalogBalancer<WritableCatalogManager>;
   // TODO(jblomer): only needed to get Spooler's hash algorithm.  Remove me
   // after refactoring of the swissknife utility.
   friend class VirtualCatalog;
 
  public:
-  WritableCatalogManager(const shash::Any  &base_hash,
+  CVMFS_EXPORT WritableCatalogManager(const shash::Any  &base_hash,
                          const std::string &stratum0,
                          const std::string &dir_temp,
                          upload::Spooler   *spooler,
@@ -87,7 +88,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
                          bool is_balanceable,
                          unsigned max_weight,
                          unsigned min_weight);
-  ~WritableCatalogManager();
+  CVMFS_EXPORT ~WritableCatalogManager();
   static manifest::Manifest *CreateRepository(const std::string &dir_temp,
                                               const bool volatile_content,
                                               const std::string &voms_authz,

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -211,7 +211,7 @@ class DirectoryEntryBase {
  protected:
   // Inodes are generated based on the rowid of the entry in the file catalog.
   inode_t inode_;
-
+ public:
   // Data from struct stat
   NameString name_;
   unsigned int mode_;

--- a/cvmfs/gateway_util.cc
+++ b/cvmfs/gateway_util.cc
@@ -34,7 +34,7 @@ GatewayKey ReadGatewayKey(const std::string& key_file_name) {
   return GatewayKey(id, secret);
 }
 
-bool ReadKeys(const std::string& key_file_name, std::string* key_id,
+CVMFS_EXPORT bool ReadKeys(const std::string& key_file_name, std::string* key_id,
               std::string* secret) {
   if (!(key_id && secret)) {
     return false;

--- a/cvmfs/gateway_util.h
+++ b/cvmfs/gateway_util.h
@@ -6,10 +6,12 @@
 #define CVMFS_GATEWAY_UTIL_H_
 
 #include <string>
+#include "util/export.h"
+
 
 namespace gateway {
 
-struct GatewayKey {
+struct CVMFS_EXPORT GatewayKey {
  public:
   GatewayKey() {}
   GatewayKey(const std::string &i, const std::string &s) : id_(i), secret_(s) {}
@@ -27,7 +29,7 @@ int APIVersion();
 
 GatewayKey ReadGatewayKey(const std::string& key_file_name);
 
-bool ReadKeys(const std::string& key_file_name, std::string* key_id,
+CVMFS_EXPORT bool ReadKeys(const std::string& key_file_name, std::string* key_id,
               std::string* secret);
 
 bool ParseKey(const std::string& body, std::string* key_id,

--- a/cvmfs/server_tool.cc
+++ b/cvmfs/server_tool.cc
@@ -6,9 +6,10 @@
 
 #include "util/posix.h"
 
-ServerTool::ServerTool() {}
 
-ServerTool::~ServerTool() {
+CVMFS_EXPORT ServerTool::ServerTool() {}
+
+CVMFS_EXPORT ServerTool::~ServerTool() {
   if (download_manager_.IsValid()) {
     download_manager_->Fini();
   }
@@ -18,7 +19,7 @@ ServerTool::~ServerTool() {
   }
 }
 
-bool ServerTool::InitDownloadManager(const bool follow_redirects,
+CVMFS_EXPORT bool ServerTool::InitDownloadManager(const bool follow_redirects,
                                      const std::string &proxy,
                                      const unsigned max_pool_handles) {
   if (download_manager_.IsValid()) {
@@ -46,7 +47,7 @@ bool ServerTool::InitDownloadManager(const bool follow_redirects,
   return true;
 }
 
-bool ServerTool::InitVerifyingSignatureManager(
+CVMFS_EXPORT bool ServerTool::InitVerifyingSignatureManager(
     const std::string &pubkey_path, const std::string &trusted_certs) {
   if (signature_manager_.IsValid()) {
     return true;
@@ -71,7 +72,7 @@ bool ServerTool::InitVerifyingSignatureManager(
   return true;
 }
 
-bool ServerTool::InitSigningSignatureManager(
+CVMFS_EXPORT bool ServerTool::InitSigningSignatureManager(
     const std::string &certificate_path, const std::string &private_key_path,
     const std::string &private_key_password) {
   if (signature_manager_.IsValid()) {

--- a/cvmfs/server_tool.h
+++ b/cvmfs/server_tool.h
@@ -12,19 +12,22 @@
 #include "network/download.h"
 #include "reflog.h"
 #include "statistics.h"
+#include "util/export.h"
 #include "util/pointer.h"
 
-class ServerTool {
- public:
-  ServerTool();
-  virtual ~ServerTool();
 
-  bool InitDownloadManager(const bool follow_redirects,
+
+class CVMFS_EXPORT ServerTool {
+ public:
+  CVMFS_EXPORT ServerTool();
+  CVMFS_EXPORT virtual ~ServerTool();
+
+  CVMFS_EXPORT bool InitDownloadManager(const bool follow_redirects,
                            const std::string &proxy,
                            const unsigned max_pool_handles = 1);
-  bool InitVerifyingSignatureManager(const std::string &pubkey_path,
+  CVMFS_EXPORT bool InitVerifyingSignatureManager(const std::string &pubkey_path,
                                      const std::string &trusted_certs = "");
-  bool InitSigningSignatureManager(const std::string &certificate_path,
+  CVMFS_EXPORT bool InitSigningSignatureManager(const std::string &certificate_path,
                                    const std::string &private_key_path,
                                    const std::string &private_key_password);
 

--- a/cvmfs/upload.cc
+++ b/cvmfs/upload.cc
@@ -12,7 +12,7 @@
 
 namespace upload {
 
-Spooler *Spooler::Construct(const SpoolerDefinition &spooler_definition,
+CVMFS_EXPORT Spooler *Spooler::Construct(const SpoolerDefinition &spooler_definition,
                                   perf::StatisticsTemplate *statistics) {
   Spooler *result = new Spooler(spooler_definition);
   if (!result->Initialize(statistics)) {
@@ -22,10 +22,10 @@ Spooler *Spooler::Construct(const SpoolerDefinition &spooler_definition,
   return result;
 }
 
-Spooler::Spooler(const SpoolerDefinition &spooler_definition)
+CVMFS_EXPORT Spooler::Spooler(const SpoolerDefinition &spooler_definition)
     : spooler_definition_(spooler_definition) {}
 
-Spooler::~Spooler() {
+CVMFS_EXPORT Spooler::~Spooler() {
   FinalizeSession(false);
   if (uploader_.IsValid()) {
     uploader_->TearDown();

--- a/cvmfs/upload.h
+++ b/cvmfs/upload.h
@@ -124,6 +124,7 @@
 #include "util/concurrency.h"
 #include "util/pointer.h"
 #include "util/shared_ptr.h"
+#include "util/export.h"
 
 namespace upload {
 
@@ -139,11 +140,11 @@ namespace upload {
  * Note: A spooler is derived from the Observable template, meaning that it
  *       allows for Listeners to be registered onto it.
  */
-class Spooler : public Observable<SpoolerResult> {
+class CVMFS_EXPORT Spooler : public Observable<SpoolerResult> {
  public:
-  static Spooler *Construct(const SpoolerDefinition &spooler_definition,
+  CVMFS_EXPORT static Spooler *Construct(const SpoolerDefinition &spooler_definition,
                               perf::StatisticsTemplate *statistics = NULL);
-  virtual ~Spooler();
+  CVMFS_EXPORT virtual ~Spooler();
 
   /**
    * Prints the name of the targeted backend storage.

--- a/cvmfs/upload_spooler_definition.cc
+++ b/cvmfs/upload_spooler_definition.cc
@@ -14,7 +14,7 @@ namespace upload {
 const char* SpoolerDefinition::kDriverNames[] =
   {"S3", "local", "gw", "mock", "unknown"};
 
-SpoolerDefinition::SpoolerDefinition(
+CVMFS_EXPORT SpoolerDefinition::SpoolerDefinition(
     const std::string& definition_string,
     const shash::Algorithms hash_algorithm,
     const zlib::Algorithms compression_algorithm,
@@ -74,7 +74,7 @@ SpoolerDefinition::SpoolerDefinition(
   valid_ = true;
 }
 
-SpoolerDefinition SpoolerDefinition::Dup2DefaultCompression() const {
+CVMFS_EXPORT SpoolerDefinition SpoolerDefinition::Dup2DefaultCompression() const {
   SpoolerDefinition result(*this);
   result.compression_alg = zlib::kZlibDefault;
   return result;

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -9,6 +9,7 @@
 
 #include "compression.h"
 #include "crypto/hash.h"
+#include "util/export.h"
 
 namespace upload {
 
@@ -19,7 +20,7 @@ namespace upload {
  * F.e: local:/srv/cvmfs/dev.cern.ch
  *      to define a local spooler with upstream path /srv/cvmfs/dev.cern.ch
  */
-struct SpoolerDefinition {
+struct CVMFS_EXPORT SpoolerDefinition {
   static const unsigned kDefaultMaxConcurrentUploads = 512;
   static const unsigned kDefaultNumUploadTasks = 1;
   static const char* kDriverNames[];  ///< corresponds to DriverType
@@ -34,7 +35,7 @@ struct SpoolerDefinition {
    * @param definition_string   the spooler definition string to be inter-
    *                            preted by the constructor
    */
-  SpoolerDefinition(
+  CVMFS_EXPORT SpoolerDefinition(
       const std::string& definition_string,
       const shash::Algorithms hash_algorithm,
       const zlib::Algorithms compression_algorithm = zlib::kZlibDefault,
@@ -46,14 +47,14 @@ struct SpoolerDefinition {
       const std::string& session_token_file = "",
       const std::string& key_file = "");
 
-  bool IsValid() const { return valid_; }
+  CVMFS_EXPORT bool IsValid() const { return valid_; }
 
   /**
    * Creates a new SpoolerDefinition based on an existing one.  The new spooler
    * has compression set to zlib, which is required for catalogs and other meta-
    * objects.
    */
-  SpoolerDefinition Dup2DefaultCompression() const;
+  CVMFS_EXPORT SpoolerDefinition Dup2DefaultCompression() const;
 
   DriverType driver_type;      //!< the type of the spooler driver
   std::string temporary_path;  //!< scratch space for the IngestionPipeline

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <string>
+#include "util/export.h"
 #include <vector>
 
 /**
@@ -26,7 +27,7 @@
  */
 class XattrList {
  public:
-  static const uint8_t kVersion;
+  static const CVMFS_EXPORT uint8_t kVersion;
 
   XattrList() : version_(kVersion) { }
   static XattrList *CreateFromFile(const std::string &path);


### PR DESCRIPTION
Rebasing our cvmfs_swissknife SQL ingest tool to libcvmfs_server requires exporting these additional symbols, and changing the protection of fields within DirectoryEntryBase (or else adding additional friends or writing accessor methods)