### PR TITLE
Add BuildRequires: git to the main rpm package

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -103,6 +103,7 @@ BuildRequires: fuse-devel
 %if 0%{?build_fuse3}
 BuildRequires: fuse3-devel
 %endif
+BuildRequires: git
 BuildRequires: libattr-devel
 BuildRequires: openssl-devel
 BuildRequires: patch


### PR DESCRIPTION
When building from the source rpm for osg I found this new BuildRequires was missing.