### PR TITLE
DownloadManager: Replace `Init()` with constructor

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1399,9 +1399,8 @@ bool MountPoint::CreateCatalogManager() {
 
 bool MountPoint::CreateDownloadManagers() {
   string optarg;
-  download_mgr_ = new download::DownloadManager();
-  download_mgr_->Init(kDefaultNumConnections,
-                      perf::StatisticsTemplate("download", statistics_));
+  download_mgr_ = new download::DownloadManager(kDefaultNumConnections,
+                             perf::StatisticsTemplate("download", statistics_));
   download_mgr_->SetCredentialsAttachment(authz_attachment_);
 
   // must be set before proxy and host chains are being initialized

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1586,70 +1586,6 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
   return false;  // stop transfer and return to Fetch()
 }
 
-
-DownloadManager::DownloadManager() {
-  pool_handles_idle_ = NULL;
-  pool_handles_inuse_ = NULL;
-  pool_max_handles_ = 0;
-  curl_multi_ = NULL;
-  default_headers_ = NULL;
-
-  atomic_init32(&multi_threaded_);
-  pipe_terminate_ = NULL;
-
-  pipe_jobs_ = NULL;
-  watch_fds_ = NULL;
-  watch_fds_size_ = 0;
-  watch_fds_inuse_ = 0;
-  watch_fds_max_ = 0;
-
-  lock_options_ =
-  reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
-  int retval = pthread_mutex_init(lock_options_, NULL);
-  assert(retval == 0);
-  lock_synchronous_mode_ =
-  reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
-  retval = pthread_mutex_init(lock_synchronous_mode_, NULL);
-  assert(retval == 0);
-
-  opt_dns_server_ = "";
-  opt_ip_preference_ = dns::kIpPreferSystem;
-  opt_timeout_proxy_ = 0;
-  opt_timeout_direct_ = 0;
-  opt_low_speed_limit_ = 0;
-  opt_host_chain_ = NULL;
-  opt_host_chain_rtt_ = NULL;
-  opt_host_chain_current_ = 0;
-  opt_proxy_groups_ = NULL;
-  opt_proxy_groups_current_ = 0;
-  opt_proxy_groups_current_burned_ = 0;
-  opt_num_proxies_ = 0;
-  opt_proxy_shard_ = false;
-  opt_max_retries_ = 0;
-  opt_backoff_init_ms_ = 0;
-  opt_backoff_max_ms_ = 0;
-  enable_info_header_ = false;
-  opt_ipv4_only_ = false;
-  follow_redirects_ = false;
-  ignore_signature_failures_ = false;
-
-  enable_http_tracing_ = false;
-  http_tracing_headers_ = vector<string>();
-
-  resolver_ = NULL;
-
-  opt_timestamp_backup_proxies_ = 0;
-  opt_timestamp_failover_proxies_ = 0;
-  opt_proxy_groups_reset_after_ = 0;
-  opt_timestamp_backup_host_ = 0;
-  opt_host_reset_after_ = 0;
-
-  credentials_attachment_ = NULL;
-
-  counters_ = NULL;
-}
-
-
 DownloadManager::~DownloadManager() {
   pthread_mutex_destroy(lock_options_);
   pthread_mutex_destroy(lock_synchronous_mode_);
@@ -1756,58 +1692,6 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
   retval = curl_global_init(CURL_GLOBAL_ALL);
   assert(retval == CURLE_OK);
 
-  InitHeaders();
-
-  curl_multi_ = curl_multi_init();
-  assert(curl_multi_ != NULL);
-  curl_multi_setopt(curl_multi_, CURLMOPT_SOCKETFUNCTION, CallbackCurlSocket);
-  curl_multi_setopt(curl_multi_, CURLMOPT_SOCKETDATA,
-                    static_cast<void *>(this));
-  curl_multi_setopt(curl_multi_, CURLMOPT_MAXCONNECTS, watch_fds_max_);
-  curl_multi_setopt(curl_multi_, CURLMOPT_MAX_TOTAL_CONNECTIONS,
-                    pool_max_handles_);
-
-  prng_.InitLocaltime();
-
-  // Name resolving
-  if ((getenv("CVMFS_IPV4_ONLY") != NULL) &&
-      (strlen(getenv("CVMFS_IPV4_ONLY")) > 0))
-  {
-    opt_ipv4_only_ = true;
-  }
-  resolver_ = dns::NormalResolver::Create(opt_ipv4_only_,
-    kDnsDefaultRetries, kDnsDefaultTimeoutMs);
-  assert(resolver_);
-}
-
-void DownloadManager::Init(const unsigned max_pool_handles,
-                           const perf::StatisticsTemplate &statistics)
-{
-  atomic_init32(&multi_threaded_);
-  int retval = curl_global_init(CURL_GLOBAL_ALL);
-  assert(retval == CURLE_OK);
-  pool_handles_idle_ = new set<CURL *>;
-  pool_handles_inuse_ = new set<CURL *>;
-  pool_max_handles_ = max_pool_handles;
-  watch_fds_max_ = 4*pool_max_handles_;
-
-  opt_timeout_proxy_ = 5;
-  opt_timeout_direct_ = 10;
-  opt_low_speed_limit_ = 1024;
-  opt_proxy_groups_current_ = 0;
-  opt_proxy_groups_current_burned_ = 0;
-  opt_num_proxies_ = 0;
-  opt_proxy_shard_ = false;
-  opt_host_chain_current_ = 0;
-  opt_ip_preference_ = dns::kIpPreferSystem;
-
-  sharding_policy_ = SharedPtr<ShardingPolicy>();
-  health_check_ = SharedPtr<HealthCheck>();
-  failover_indefinitely_ = false;
-
-  counters_ = new Counters(statistics);
-
-  user_agent_ = NULL;
   InitHeaders();
 
   curl_multi_ = curl_multi_init();
@@ -3007,13 +2891,12 @@ void DownloadManager::SetFailoverIndefinitely() {
 DownloadManager *DownloadManager::Clone(
   const perf::StatisticsTemplate &statistics)
 {
-  DownloadManager *clone = new DownloadManager();
-  clone->Init(pool_max_handles_, statistics);
-  if (resolver_) {
-    clone->SetDnsParameters(resolver_->retries(), resolver_->timeout_ms());
-    clone->SetDnsTtlLimits(resolver_->min_ttl(), resolver_->max_ttl());
-    clone->SetMaxIpaddrPerProxy(resolver_->throttle());
-  }
+  DownloadManager *clone = new DownloadManager(pool_max_handles_, statistics);
+
+  clone->SetDnsParameters(resolver_->retries(), resolver_->timeout_ms());
+  clone->SetDnsTtlLimits(resolver_->min_ttl(), resolver_->max_ttl());
+  clone->SetMaxIpaddrPerProxy(resolver_->throttle());
+
   if (!opt_dns_server_.empty())
     clone->SetDnsServer(opt_dns_server_);
   clone->opt_timeout_proxy_ = opt_timeout_proxy_;
@@ -3031,6 +2914,13 @@ DownloadManager *DownloadManager::Clone(
     clone->opt_host_chain_ = new vector<string>(*opt_host_chain_);
     clone->opt_host_chain_rtt_ = new vector<int>(*opt_host_chain_rtt_);
   }
+  // opt_ipv4_only_
+  // opt_host_chain_current_(0)
+  // opt_proxy_map_(std::map<uint32_t, ProxyInfo *>()),  // added
+  // opt_proxy_urls_(vector<string>()),  // added
+  // opt_timestamp_backup_proxies_(0),
+  // opt_timestamp_failover_proxies_(0),
+  // opt_timestamp_backup_host_(0),
   CloneProxyConfig(clone);
   clone->opt_ip_preference_ = opt_ip_preference_;
   clone->proxy_template_direct_ = proxy_template_direct_;

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1624,19 +1624,16 @@ void DownloadManager::FiniHeaders() {
 
 DownloadManager::DownloadManager(const unsigned max_pool_handles,
                            const perf::StatisticsTemplate &statistics) :
-                  prng_(Prng()),  // added
+                  prng_(Prng()),
                   pool_handles_idle_(new set<CURL *>),
                   pool_handles_inuse_(new set<CURL *>),
                   pool_max_handles_(max_pool_handles),
-                  user_agent_(NULL),
-                  // pthread_t thread_download_;
                   pipe_terminate_(NULL),
                   pipe_jobs_(NULL),
                   watch_fds_(NULL),
                   watch_fds_size_(0),
                   watch_fds_inuse_(0),
                   watch_fds_max_(4 * max_pool_handles),
-                  opt_dns_server_(""),
                   opt_timeout_proxy_(5),
                   opt_timeout_direct_(10),
                   opt_low_speed_limit_(1024),
@@ -1648,44 +1645,33 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
                   follow_redirects_(false),
                   ignore_signature_failures_(false),
                   enable_http_tracing_(false),
-                  http_tracing_headers_(vector<string>()),
                   opt_host_chain_(NULL),
                   opt_host_chain_rtt_(NULL),
                   opt_host_chain_current_(0),
                   opt_proxy_groups_(NULL),
                   opt_proxy_groups_current_(0),
                   opt_proxy_groups_current_burned_(0),
-                  opt_proxy_groups_fallback_(0),  // added
+                  opt_proxy_groups_fallback_(0),
                   opt_num_proxies_(0),
-                  opt_proxy_list_(""),  // added
-                  opt_proxy_fallback_list_(""),  // added
-                  opt_proxy_map_(std::map<uint32_t, ProxyInfo *>()),  // added
-                  opt_proxy_urls_(vector<string>()),  // added
                   opt_proxy_shard_(false),
-                  sharding_policy_(SharedPtr<ShardingPolicy>()),
-                  health_check_(SharedPtr<HealthCheck>()),
                   failover_indefinitely_(false),
-                  fqrn_(""),  // added, used in sharding policy && Interrupted()
                   opt_ip_preference_(dns::kIpPreferSystem),
-                  proxy_template_direct_(""),  // added - should be mandatory?
-                  proxy_template_forced_(""),  // added
                   opt_timestamp_backup_proxies_(0),
                   opt_timestamp_failover_proxies_(0),
                   opt_proxy_groups_reset_after_(0),
                   opt_timestamp_backup_host_(0),
                   opt_host_reset_after_(0),
                   credentials_attachment_(NULL),
-                  counters_(new Counters(statistics)),
-                  ssl_certificate_store_(SslCertificateStore())  // added
+                  counters_(new Counters(statistics))
 {
   atomic_init32(&multi_threaded_);
 
   lock_options_ =
-  reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+          reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
   int retval = pthread_mutex_init(lock_options_, NULL);
   assert(retval == 0);
   lock_synchronous_mode_ =
-  reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+          reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
   retval = pthread_mutex_init(lock_synchronous_mode_, NULL);
   assert(retval == 0);
 
@@ -2914,13 +2900,7 @@ DownloadManager *DownloadManager::Clone(
     clone->opt_host_chain_ = new vector<string>(*opt_host_chain_);
     clone->opt_host_chain_rtt_ = new vector<int>(*opt_host_chain_rtt_);
   }
-  // opt_ipv4_only_
-  // opt_host_chain_current_(0)
-  // opt_proxy_map_(std::map<uint32_t, ProxyInfo *>()),  // added
-  // opt_proxy_urls_(vector<string>()),  // added
-  // opt_timestamp_backup_proxies_(0),
-  // opt_timestamp_failover_proxies_(0),
-  // opt_timestamp_backup_host_(0),
+
   CloneProxyConfig(clone);
   clone->opt_ip_preference_ = opt_ip_preference_;
   clone->proxy_template_direct_ = proxy_template_direct_;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -155,13 +155,12 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   static const unsigned kDnsDefaultTimeoutMs = 3000;
   static const unsigned kProxyMapScale = 16;
 
-  DownloadManager();
+  DownloadManager(const unsigned max_pool_handles,
+                  const perf::StatisticsTemplate &statistics);
   ~DownloadManager();
 
   static int ParseHttpCode(const char digits[3]);
 
-  void Init(const unsigned max_pool_handles,
-            const perf::StatisticsTemplate &statistics);
   void Fini();
   void Spawn();
   DownloadManager *Clone(const perf::StatisticsTemplate &statistics);
@@ -228,6 +227,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   }
 
  private:
+  DownloadManager();
+  void Init(const unsigned max_pool_handles,
+            const perf::StatisticsTemplate &statistics);
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);
   static void *MainDownload(void *data);
@@ -361,7 +363,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   /**
    * Sharding policy deciding which proxy should be chosen for each download
    * request
-   * 
+   *
    * Sharding policy is shared between all download managers. As such shared
    * pointers are used to allow for proper clean-up afterwards in Fini()
    * (We cannot assume the order in which the download managers are stopped)
@@ -369,7 +371,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   SharedPtr<ShardingPolicy> sharding_policy_;
   /**
    * Health check for the proxies
-   * 
+   *
    * Health check is shared between all download managers. As such shared
    * pointers are used to allow for proper clean-up afterwards in Fini()
    * (We cannot assume the order in which the download managers are stopped)

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -380,7 +380,8 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool failover_indefinitely_;
   /**
    * Repo name. Needed for the re-try logic if a download was unsuccessful
-  */
+   * Used in sharding policy && Interrupted()
+   */
   std::string fqrn_;
 
   /**

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -227,9 +227,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   }
 
  private:
-  DownloadManager();
-  void Init(const unsigned max_pool_handles,
-            const perf::StatisticsTemplate &statistics);
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);
   static void *MainDownload(void *data);

--- a/cvmfs/notify/cmd_pub.cc
+++ b/cvmfs/notify/cmd_pub.cc
@@ -48,10 +48,9 @@ int DoPublish(const std::string& server_url, const std::string& repository_url,
   if (IsHttpUrl(repo_url)) {
     perf::Statistics stats;
     UniquePtr<download::DownloadManager> download_manager(
-        new download::DownloadManager());
+        new download::DownloadManager(kMaxPoolHandles,
+                                 perf::StatisticsTemplate("download", &stats)));
     assert(download_manager.IsValid());
-    download_manager->Init(kMaxPoolHandles,
-                           perf::StatisticsTemplate("download", &stats));
 
     download_manager->SetTimeout(kDownloadTimeout, kDownloadTimeout);
     download_manager->SetRetryParameters(kDownloadRetries, 500, 2000);

--- a/cvmfs/notify/cmd_sub.cc
+++ b/cvmfs/notify/cmd_sub.cc
@@ -33,7 +33,8 @@ class SwissknifeSubscriber : public notify::SubscriberSSE {
       : notify::SubscriberSSE(server_url),
         repository_(repository),
         stats_(),
-        dl_mgr_(new download::DownloadManager()),
+        dl_mgr_(new download::DownloadManager(kMaxPoolHandles,
+                                perf::StatisticsTemplate("download", &stats_))),
         sig_mgr_(new signature::SignatureManager()),
         revision_(min_revision),
         continuous_(continuous),
@@ -52,9 +53,6 @@ class SwissknifeSubscriber : public notify::SubscriberSSE {
                "SwissknifeSubscriber - could not parse configuration file");
       return false;
     }
-
-    dl_mgr_->Init(kMaxPoolHandles,
-                  perf::StatisticsTemplate("download", &stats_));
 
     std::string arg;
     if (options.GetValue("CVMFS_SERVER_URL", &arg)) {

--- a/cvmfs/preload.cc
+++ b/cvmfs/preload.cc
@@ -29,9 +29,7 @@ const int kDefaultPreloaderTimeout = 10;
 const int kDefaultPreloaderRetries = 2;
 
 namespace swissknife {
-download::DownloadManager *g_download_manager;
-signature::SignatureManager *g_signature_manager;
-perf::Statistics *g_statistics;
+
 void Usage() {
     LogCvmfs(kLogCvmfs, kLogStderr, "Version: %s\n\n"
     "Usage:\n"
@@ -195,10 +193,6 @@ int main(int argc, char *argv[]) {
   }
 
   // now launch swissknife_pull
-  swissknife::g_download_manager = new download::DownloadManager();
-  swissknife::g_signature_manager = new signature::SignatureManager();
-  swissknife::g_statistics = new perf::Statistics();
-
   // load the command
   if (HasDirtabChanged(dirtab, dirtab_in_cache)) {
     LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: new dirtab, forced run");

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -78,9 +78,8 @@ Repository::Repository(const SettingsRepository &settings, const bool exists)
     if (rvi != 0)
       throw EPublish("cannot set X509_CERT_BUNDLE environment variable");
   }
-  download_mgr_ = new download::DownloadManager();
-  download_mgr_->Init(16,
-                      perf::StatisticsTemplate("download", statistics_));
+  download_mgr_ = new download::DownloadManager(16,
+                             perf::StatisticsTemplate("download", statistics_));
   download_mgr_->UseSystemCertificatePath();
 
   if (settings.proxy() != "") {

--- a/cvmfs/server_tool.cc
+++ b/cvmfs/server_tool.cc
@@ -25,10 +25,9 @@ bool ServerTool::InitDownloadManager(const bool follow_redirects,
     return true;
   }
 
-  download_manager_ = new download::DownloadManager();
+  download_manager_ = new download::DownloadManager(max_pool_handles,
+                            perf::StatisticsTemplate("download", statistics()));
   assert(download_manager_.IsValid());
-  download_manager_->Init(max_pool_handles,
-                          perf::StatisticsTemplate("download", statistics()));
 
   download_manager_->SetTimeout(kDownloadTimeout, kDownloadTimeout);
   download_manager_->SetRetryParameters(kDownloadRetries, 2000, 5000);

--- a/cvmfs/wpad.cc
+++ b/cvmfs/wpad.cc
@@ -279,8 +279,8 @@ int MainResolveProxyDescription(int argc, char **argv) {
   string proxy_configuration = argv[2];
   string host_list = argv[3];
 
-  DownloadManager download_manager;
-  download_manager.Init(1, perf::StatisticsTemplate("pac", &statistics));
+  DownloadManager download_manager(1,
+                                  perf::StatisticsTemplate("pac", &statistics));
   download_manager.SetHostChain(host_list);
   string resolved_proxies = ResolveProxyDescription(proxy_configuration, "",
                                                     &download_manager);

--- a/test/unittests/t_cache_stream.cc
+++ b/test/unittests/t_cache_stream.cc
@@ -28,9 +28,8 @@ class T_StreamingCacheManager : public ::testing::Test {
 
   virtual void SetUp() {
     statistics_ = new perf::Statistics();
-    download_mgr_ = new download::DownloadManager();
-    download_mgr_->Init(16,
-      perf::StatisticsTemplate("download", statistics_.weak_ref()));
+    download_mgr_ = new download::DownloadManager(16,
+                  perf::StatisticsTemplate("download", statistics_.weak_ref()));
     download_mgr_->SetHostChain("file://" + GetCurrentWorkingDirectory());
     backing_cache_ =
       PosixCacheManager::Create("cache", true /* alien_cache */);

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -36,13 +36,12 @@ namespace download {
 
 class T_Download : public FileSandbox {
  public:
-  T_Download() : FileSandbox(string(tmp_path) + "/server_dir") {}
+  T_Download() : FileSandbox(string(tmp_path) + "/server_dir"),
+                 download_mgr(DownloadManager(8,
+                              perf::StatisticsTemplate("test", &statistics))) {}
 
  protected:
   virtual void SetUp() {
-    download_mgr.Init(8,
-      perf::StatisticsTemplate("test", &statistics));
-
     CreateSandbox();
   }
 
@@ -181,7 +180,8 @@ TEST_F(T_Download, Clone) {
   delete download_mgr_cloned;
 
   // Don't crash
-  DownloadManager *dm = new DownloadManager();
+  DownloadManager *dm = new DownloadManager(1,
+                                    perf::StatisticsTemplate("h", &statistics));
   download_mgr_cloned = dm->Clone(perf::StatisticsTemplate("y", &statistics));
   delete dm;
   delete download_mgr_cloned;
@@ -197,8 +197,7 @@ TEST_F(T_Download, Multiple) {
   string src_path = GetAbsolutePath(GetSmallFile());
   string src_url = "file://" + src_path;
 
-  DownloadManager second_mgr;
-  second_mgr.Init(8,
+  DownloadManager second_mgr(8,
     perf::StatisticsTemplate("second", &statistics));
 
   cvmfs::FileSink filesink(fdest);

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -552,7 +552,7 @@ TEST_F(T_Download, ParseHttpCode) {
 TEST_F(T_Download, EscapeUrl) {
   std::string url = "http://ab0341.¡ÿϦ랝"; // c2a1 c3bf cfa6 eb9e9d
   std::string correct = "http://ab0341.%C2%A1%C3%BF%CF%A6%EB%9E%9D";
-  std::string res = download_mgr.EscapeUrl(url);
+  std::string res = download_mgr->EscapeUrl(url);
 
   EXPECT_TRUE(res == correct);
 }

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -550,9 +550,9 @@ TEST_F(T_Download, ParseHttpCode) {
 }
 
 TEST_F(T_Download, EscapeUrl) {
-  std::string url = "http://ab0341.¡ÿϦ랝"; // c2a1 c3bf cfa6 eb9e9d
-  std::string correct = "http://ab0341.%C2%A1%C3%BF%CF%A6%EB%9E%9D";
-  std::string res = download_mgr->EscapeUrl(url);
+  const std::string url = "http://ab0341.¡ÿϦ랝"; // c2a1 c3bf cfa6 eb9e9d
+  const std::string correct = "http://ab0341.%C2%A1%C3%BF%CF%A6%EB%9E%9D";
+  const std::string res = download_mgr->EscapeUrl(url);
 
   EXPECT_TRUE(res == correct);
 }

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -37,7 +37,7 @@ namespace download {
 class T_Download : public FileSandbox {
  public:
   T_Download() : FileSandbox(string(tmp_path) + "/server_dir"),
-                 download_mgr(DownloadManager(8,
+                 download_mgr(new DownloadManager(8,
                              perf::StatisticsTemplate("test", &statistics))) {}
 
  protected:
@@ -50,7 +50,8 @@ class T_Download : public FileSandbox {
   }
 
   virtual ~T_Download() {
-    download_mgr.Fini();
+    download_mgr->Fini();
+    delete download_mgr;
   }
 
   FILE *CreateTemporaryFile(std::string *path) const {
@@ -61,7 +62,7 @@ class T_Download : public FileSandbox {
   static const char tmp_path[];
 
   perf::Statistics statistics;
-  DownloadManager download_mgr;
+  DownloadManager *download_mgr;
 };
 
 const char T_Download::tmp_path[] = "./cvmfs_ut_download";
@@ -131,7 +132,7 @@ TEST_F(T_Download, LocalFile) {
   cvmfs::FileSink filesink(fdest);
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                NULL, &filesink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   EXPECT_EQ(info.error_code(), kFailOk);
   fclose(fdest);
 }
@@ -150,14 +151,14 @@ TEST_F(T_Download, RemoteFile) {
   cvmfs::FileSink filesink(fdest);
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                NULL, &filesink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   EXPECT_EQ(file_server.num_processed_requests(), 1);
   EXPECT_EQ(info.error_code(), kFailOk);
   fclose(fdest);
 }
 
 TEST_F(T_Download, Clone) {
-  DownloadManager *download_mgr_cloned = download_mgr.Clone(
+  DownloadManager *download_mgr_cloned = download_mgr->Clone(
     perf::StatisticsTemplate("x", &statistics));
 
   string dest_path;
@@ -205,7 +206,7 @@ TEST_F(T_Download, Multiple) {
                NULL, &filesink);
   JobInfo info2(&src_url, false /* compressed */, false /* probe hosts */,
                 NULL, &filesink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   second_mgr.Fetch(&info2);
   EXPECT_EQ(info.error_code(), kFailOk);
   EXPECT_EQ(info2.error_code(), kFailOk);
@@ -224,7 +225,7 @@ TEST_F(T_Download, RemoteFile2Mem) {
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
@@ -241,11 +242,11 @@ TEST_F(T_Download, RemoteFileRedirect) {
 
   string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
 
-  download_mgr.EnableRedirects();
+  download_mgr->EnableRedirects();
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(redirect_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -260,13 +261,13 @@ TEST_F(T_Download, RemoteFileSimpleProxy) {
   MockProxyServer proxy_server(8083);
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr.SetProxyChain("http://127.0.0.1:8083", "",
+  download_mgr->SetProxyChain("http://127.0.0.1:8083", "",
                              DownloadManager::kSetProxyRegular);
   string url = "http://127.0.0.1:8082/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(proxy_server.num_processed_requests(), 1);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -282,14 +283,14 @@ TEST_F(T_Download, RemoteFileProxyRedirect) {
   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8082");
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr.SetProxyChain("http://127.0.0.1:8084", "",
+  download_mgr->SetProxyChain("http://127.0.0.1:8084", "",
                              DownloadManager::kSetProxyRegular);
-  download_mgr.EnableRedirects();
+  download_mgr->EnableRedirects();
   string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(proxy_server.num_processed_requests(), 2);
   ASSERT_EQ(redirect_server.num_processed_requests(), 1);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
@@ -307,7 +308,7 @@ TEST_F(T_Download, LocalFile2Mem) {
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
   EXPECT_STREQ(reinterpret_cast<char*>(memsink.data()), src_content.c_str());
@@ -318,12 +319,12 @@ TEST_F(T_Download, RemoteFileSwitchHosts) {
   string src_content = GetFileContents(src_path);
 
   MockFileServer file_server(8082, sandbox_path_);
-  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.num_used_hosts(), 2);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -336,14 +337,14 @@ TEST_F(T_Download, CancelRequest) {
   string src_content = GetFileContents(src_path);
 
   MockFileServer file_server(8082, sandbox_path_);
-  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
   TestInterruptCue tci;
   info.SetInterruptCue(&tci);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(info.num_used_hosts(), 1);
   ASSERT_EQ(info.error_code(), kFailCanceled);
   EXPECT_EQ(NULL, memsink.data());
@@ -356,13 +357,13 @@ TEST_F(T_Download, RemoteFileSwitchHostsAfterRedirect) {
   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8084");
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr.EnableRedirects();
-  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr->EnableRedirects();
+  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(info.num_used_hosts(), 2);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
@@ -378,14 +379,14 @@ TEST_F(T_Download, RemoteFileSwitchProxies) {
 
   MockFileServer file_server(8082, sandbox_path_);
   MockProxyServer proxy_server(8083);
-  download_mgr.SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
+  download_mgr->SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
                              "", DownloadManager::kSetProxyRegular);
 
   string src_url = "http://127.0.0.1:8082/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL,
            &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(proxy_server.num_processed_requests(), 1);
   ASSERT_EQ(info.num_used_proxies(), 2);
@@ -403,7 +404,7 @@ TEST_F(T_Download, RemoteFileEmpty) {
   cvmfs::MemSink memsink;
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL,
            &memsink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), 0U);
@@ -422,7 +423,7 @@ TEST_F(T_Download, LocalFile2Sink) {
   string url = "file://" + dest_path;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */,
                NULL /* expected hash */, &test_sink);
-  download_mgr.Fetch(&info);
+  download_mgr->Fetch(&info);
   EXPECT_EQ(info.error_code(), kFailOk);
   EXPECT_EQ(1, pread(test_sink.fd, &buf, 1, 0));
   EXPECT_EQ('1', buf);
@@ -444,7 +445,7 @@ TEST_F(T_Download, LocalFile2Sink) {
   TestSink test_sink2;
   JobInfo info2(&url, true /* compressed */, false /* probe hosts */,
                 &checksum /* expected hash */, &test_sink2);
-  download_mgr.Fetch(&info2);
+  download_mgr->Fetch(&info2);
   EXPECT_EQ(info2.error_code(), kFailOk);
   EXPECT_EQ(size, GetFileSize(test_sink2.path));
 
@@ -457,67 +458,67 @@ TEST_F(T_Download, LocalFile2Sink) {
 
 TEST_F(T_Download, StripDirect) {
   string cleaned = "FALSE";
-  EXPECT_FALSE(download_mgr.StripDirect("", &cleaned));
+  EXPECT_FALSE(download_mgr->StripDirect("", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect("DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect("DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT|DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT|DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT|", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT|", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect(";", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect(";", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect(";||;;;|||", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect(";||;;;|||", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_FALSE(download_mgr.StripDirect("A|B", &cleaned));
+  EXPECT_FALSE(download_mgr->StripDirect("A|B", &cleaned));
   EXPECT_EQ("A|B", cleaned);
-  EXPECT_FALSE(download_mgr.StripDirect("A|B;C|D;E|F|G", &cleaned));
+  EXPECT_FALSE(download_mgr->StripDirect("A|B;C|D;E|F|G", &cleaned));
   EXPECT_EQ("A|B;C|D;E|F|G", cleaned);
-  EXPECT_TRUE(download_mgr.StripDirect("A|DIRECT;C|D;E|F;DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr->StripDirect("A|DIRECT;C|D;E|F;DIRECT", &cleaned));
   EXPECT_EQ("A;C|D;E|F", cleaned);
 }
 
 
 TEST_F(T_Download, ValidateGeoReply) {
   vector<uint64_t> geo_order;
-  EXPECT_FALSE(download_mgr.ValidateGeoReply("", geo_order.size(),
+  EXPECT_FALSE(download_mgr->ValidateGeoReply("", geo_order.size(),
                &geo_order));
 
   geo_order.push_back(0);
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("a", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("a", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("1,1", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("1,1", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("1,3", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("1,3", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("2,3", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("2,3", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("2", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("2", geo_order.size(), &geo_order));
   EXPECT_TRUE(
-    download_mgr.ValidateGeoReply("1", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("1", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 1U);
   EXPECT_EQ(geo_order[0], 0U);
 
   geo_order.push_back(0);
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply(",", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply(",", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("2,", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("2,", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("1", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("1", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr.ValidateGeoReply("3,2,1", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("3,2,1", geo_order.size(), &geo_order));
   EXPECT_TRUE(
-    download_mgr.ValidateGeoReply("2,1", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("2,1", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 2U);
   EXPECT_EQ(geo_order[0], 1U);
   EXPECT_EQ(geo_order[1], 0U);
 
   EXPECT_TRUE(
-    download_mgr.ValidateGeoReply("2,1\n", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("2,1\n", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 2U);
   EXPECT_EQ(geo_order[0], 1U);
   EXPECT_EQ(geo_order[1], 0U);
@@ -525,7 +526,7 @@ TEST_F(T_Download, ValidateGeoReply) {
   geo_order.push_back(0);
   geo_order.push_back(0);
   EXPECT_TRUE(
-    download_mgr.ValidateGeoReply("4,3,1,2\n", geo_order.size(), &geo_order));
+    download_mgr->ValidateGeoReply("4,3,1,2\n", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 4U);
   EXPECT_EQ(geo_order[0], 3U);
   EXPECT_EQ(geo_order[1], 2U);

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -37,7 +37,7 @@ namespace download {
 class T_Download : public FileSandbox {
  public:
   T_Download() : FileSandbox(string(tmp_path) + "/server_dir"),
-                 download_mgr(new DownloadManager(8,
+                 download_mgr(DownloadManager(8,
                              perf::StatisticsTemplate("test", &statistics))) {}
 
  protected:
@@ -50,8 +50,7 @@ class T_Download : public FileSandbox {
   }
 
   virtual ~T_Download() {
-    download_mgr->Fini();
-    delete download_mgr;
+    download_mgr.Fini();
   }
 
   FILE *CreateTemporaryFile(std::string *path) const {
@@ -62,7 +61,7 @@ class T_Download : public FileSandbox {
   static const char tmp_path[];
 
   perf::Statistics statistics;
-  DownloadManager *download_mgr;
+  DownloadManager download_mgr;
 };
 
 const char T_Download::tmp_path[] = "./cvmfs_ut_download";
@@ -132,7 +131,7 @@ TEST_F(T_Download, LocalFile) {
   cvmfs::FileSink filesink(fdest);
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                NULL, &filesink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   EXPECT_EQ(info.error_code(), kFailOk);
   fclose(fdest);
 }
@@ -151,14 +150,14 @@ TEST_F(T_Download, RemoteFile) {
   cvmfs::FileSink filesink(fdest);
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                NULL, &filesink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   EXPECT_EQ(file_server.num_processed_requests(), 1);
   EXPECT_EQ(info.error_code(), kFailOk);
   fclose(fdest);
 }
 
 TEST_F(T_Download, Clone) {
-  DownloadManager *download_mgr_cloned = download_mgr->Clone(
+  DownloadManager *download_mgr_cloned = download_mgr.Clone(
     perf::StatisticsTemplate("x", &statistics));
 
   string dest_path;
@@ -206,7 +205,7 @@ TEST_F(T_Download, Multiple) {
                NULL, &filesink);
   JobInfo info2(&src_url, false /* compressed */, false /* probe hosts */,
                 NULL, &filesink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   second_mgr.Fetch(&info2);
   EXPECT_EQ(info.error_code(), kFailOk);
   EXPECT_EQ(info2.error_code(), kFailOk);
@@ -225,7 +224,7 @@ TEST_F(T_Download, RemoteFile2Mem) {
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
@@ -242,11 +241,11 @@ TEST_F(T_Download, RemoteFileRedirect) {
 
   string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
 
-  download_mgr->EnableRedirects();
+  download_mgr.EnableRedirects();
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(redirect_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -261,13 +260,13 @@ TEST_F(T_Download, RemoteFileSimpleProxy) {
   MockProxyServer proxy_server(8083);
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr->SetProxyChain("http://127.0.0.1:8083", "",
+  download_mgr.SetProxyChain("http://127.0.0.1:8083", "",
                              DownloadManager::kSetProxyRegular);
   string url = "http://127.0.0.1:8082/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(proxy_server.num_processed_requests(), 1);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -283,14 +282,14 @@ TEST_F(T_Download, RemoteFileProxyRedirect) {
   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8082");
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr->SetProxyChain("http://127.0.0.1:8084", "",
+  download_mgr.SetProxyChain("http://127.0.0.1:8084", "",
                              DownloadManager::kSetProxyRegular);
-  download_mgr->EnableRedirects();
+  download_mgr.EnableRedirects();
   string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(proxy_server.num_processed_requests(), 2);
   ASSERT_EQ(redirect_server.num_processed_requests(), 1);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
@@ -308,7 +307,7 @@ TEST_F(T_Download, LocalFile2Mem) {
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
   EXPECT_STREQ(reinterpret_cast<char*>(memsink.data()), src_content.c_str());
@@ -319,12 +318,12 @@ TEST_F(T_Download, RemoteFileSwitchHosts) {
   string src_content = GetFileContents(src_path);
 
   MockFileServer file_server(8082, sandbox_path_);
-  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.num_used_hosts(), 2);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -337,14 +336,14 @@ TEST_F(T_Download, CancelRequest) {
   string src_content = GetFileContents(src_path);
 
   MockFileServer file_server(8082, sandbox_path_);
-  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
   TestInterruptCue tci;
   info.SetInterruptCue(&tci);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(info.num_used_hosts(), 1);
   ASSERT_EQ(info.error_code(), kFailCanceled);
   EXPECT_EQ(NULL, memsink.data());
@@ -357,13 +356,13 @@ TEST_F(T_Download, RemoteFileSwitchHostsAfterRedirect) {
   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8084");
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr->EnableRedirects();
-  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr.EnableRedirects();
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(info.num_used_hosts(), 2);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
@@ -379,14 +378,14 @@ TEST_F(T_Download, RemoteFileSwitchProxies) {
 
   MockFileServer file_server(8082, sandbox_path_);
   MockProxyServer proxy_server(8083);
-  download_mgr->SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
+  download_mgr.SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
                              "", DownloadManager::kSetProxyRegular);
 
   string src_url = "http://127.0.0.1:8082/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL,
            &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(proxy_server.num_processed_requests(), 1);
   ASSERT_EQ(info.num_used_proxies(), 2);
@@ -404,7 +403,7 @@ TEST_F(T_Download, RemoteFileEmpty) {
   cvmfs::MemSink memsink;
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL,
            &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), 0U);
@@ -423,7 +422,7 @@ TEST_F(T_Download, LocalFile2Sink) {
   string url = "file://" + dest_path;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */,
                NULL /* expected hash */, &test_sink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   EXPECT_EQ(info.error_code(), kFailOk);
   EXPECT_EQ(1, pread(test_sink.fd, &buf, 1, 0));
   EXPECT_EQ('1', buf);
@@ -445,7 +444,7 @@ TEST_F(T_Download, LocalFile2Sink) {
   TestSink test_sink2;
   JobInfo info2(&url, true /* compressed */, false /* probe hosts */,
                 &checksum /* expected hash */, &test_sink2);
-  download_mgr->Fetch(&info2);
+  download_mgr.Fetch(&info2);
   EXPECT_EQ(info2.error_code(), kFailOk);
   EXPECT_EQ(size, GetFileSize(test_sink2.path));
 
@@ -458,67 +457,67 @@ TEST_F(T_Download, LocalFile2Sink) {
 
 TEST_F(T_Download, StripDirect) {
   string cleaned = "FALSE";
-  EXPECT_FALSE(download_mgr->StripDirect("", &cleaned));
+  EXPECT_FALSE(download_mgr.StripDirect("", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT|DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT|DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT|", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT|", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect(";", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect(";", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect(";||;;;|||", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect(";||;;;|||", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_FALSE(download_mgr->StripDirect("A|B", &cleaned));
+  EXPECT_FALSE(download_mgr.StripDirect("A|B", &cleaned));
   EXPECT_EQ("A|B", cleaned);
-  EXPECT_FALSE(download_mgr->StripDirect("A|B;C|D;E|F|G", &cleaned));
+  EXPECT_FALSE(download_mgr.StripDirect("A|B;C|D;E|F|G", &cleaned));
   EXPECT_EQ("A|B;C|D;E|F|G", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("A|DIRECT;C|D;E|F;DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("A|DIRECT;C|D;E|F;DIRECT", &cleaned));
   EXPECT_EQ("A;C|D;E|F", cleaned);
 }
 
 
 TEST_F(T_Download, ValidateGeoReply) {
   vector<uint64_t> geo_order;
-  EXPECT_FALSE(download_mgr->ValidateGeoReply("", geo_order.size(),
+  EXPECT_FALSE(download_mgr.ValidateGeoReply("", geo_order.size(),
                &geo_order));
 
   geo_order.push_back(0);
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("a", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("a", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("1,1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1,1", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("1,3", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1,3", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("2,3", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,3", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("2", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2", geo_order.size(), &geo_order));
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 1U);
   EXPECT_EQ(geo_order[0], 0U);
 
   geo_order.push_back(0);
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply(",", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply(",", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("2,", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("3,2,1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("3,2,1", geo_order.size(), &geo_order));
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("2,1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,1", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 2U);
   EXPECT_EQ(geo_order[0], 1U);
   EXPECT_EQ(geo_order[1], 0U);
 
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("2,1\n", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,1\n", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 2U);
   EXPECT_EQ(geo_order[0], 1U);
   EXPECT_EQ(geo_order[1], 0U);
@@ -526,7 +525,7 @@ TEST_F(T_Download, ValidateGeoReply) {
   geo_order.push_back(0);
   geo_order.push_back(0);
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("4,3,1,2\n", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("4,3,1,2\n", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 4U);
   EXPECT_EQ(geo_order[0], 3U);
   EXPECT_EQ(geo_order[1], 2U);

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -37,22 +37,21 @@ namespace download {
 class T_Download : public FileSandbox {
  public:
   T_Download() : FileSandbox(string(tmp_path) + "/server_dir"),
-                 download_mgr(NULL) {}
+                 download_mgr(new DownloadManager(8,
+                             perf::StatisticsTemplate("test", &statistics))) {}
 
  protected:
   virtual void SetUp() {
     CreateSandbox();
-    download_mgr = new DownloadManager(8,
-                             perf::StatisticsTemplate("test", &statistics));
   }
 
   virtual void TearDown() {
     RemoveSandbox();
-    delete download_mgr;
   }
 
   virtual ~T_Download() {
     download_mgr->Fini();
+    delete download_mgr;
   }
 
   FILE *CreateTemporaryFile(std::string *path) const {

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -37,8 +37,8 @@ namespace download {
 class T_Download : public FileSandbox {
  public:
   T_Download() : FileSandbox(string(tmp_path) + "/server_dir"),
-                 download_mgr(new DownloadManager(8,
-                             perf::StatisticsTemplate("test", &statistics))) {}
+                 download_mgr(8, perf::StatisticsTemplate("test", &statistics))
+                 {}
 
  protected:
   virtual void SetUp() {
@@ -50,8 +50,7 @@ class T_Download : public FileSandbox {
   }
 
   virtual ~T_Download() {
-    download_mgr->Fini();
-    delete download_mgr;
+    download_mgr.Fini();
   }
 
   FILE *CreateTemporaryFile(std::string *path) const {
@@ -62,7 +61,7 @@ class T_Download : public FileSandbox {
   static const char tmp_path[];
 
   perf::Statistics statistics;
-  DownloadManager *download_mgr;
+  DownloadManager download_mgr;
 };
 
 const char T_Download::tmp_path[] = "./cvmfs_ut_download";
@@ -132,7 +131,7 @@ TEST_F(T_Download, LocalFile) {
   cvmfs::FileSink filesink(fdest);
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                NULL, &filesink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   EXPECT_EQ(info.error_code(), kFailOk);
   fclose(fdest);
 }
@@ -151,14 +150,14 @@ TEST_F(T_Download, RemoteFile) {
   cvmfs::FileSink filesink(fdest);
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */,
                NULL, &filesink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   EXPECT_EQ(file_server.num_processed_requests(), 1);
   EXPECT_EQ(info.error_code(), kFailOk);
   fclose(fdest);
 }
 
 TEST_F(T_Download, Clone) {
-  DownloadManager *download_mgr_cloned = download_mgr->Clone(
+  DownloadManager *download_mgr_cloned = download_mgr.Clone(
     perf::StatisticsTemplate("x", &statistics));
 
   string dest_path;
@@ -206,7 +205,7 @@ TEST_F(T_Download, Multiple) {
                NULL, &filesink);
   JobInfo info2(&src_url, false /* compressed */, false /* probe hosts */,
                 NULL, &filesink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   second_mgr.Fetch(&info2);
   EXPECT_EQ(info.error_code(), kFailOk);
   EXPECT_EQ(info2.error_code(), kFailOk);
@@ -225,7 +224,7 @@ TEST_F(T_Download, RemoteFile2Mem) {
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
@@ -242,11 +241,11 @@ TEST_F(T_Download, RemoteFileRedirect) {
 
   string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
 
-  download_mgr->EnableRedirects();
+  download_mgr.EnableRedirects();
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(redirect_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -261,13 +260,13 @@ TEST_F(T_Download, RemoteFileSimpleProxy) {
   MockProxyServer proxy_server(8083);
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr->SetProxyChain("http://127.0.0.1:8083", "",
+  download_mgr.SetProxyChain("http://127.0.0.1:8083", "",
                              DownloadManager::kSetProxyRegular);
   string url = "http://127.0.0.1:8082/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(proxy_server.num_processed_requests(), 1);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -283,14 +282,14 @@ TEST_F(T_Download, RemoteFileProxyRedirect) {
   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8082");
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr->SetProxyChain("http://127.0.0.1:8084", "",
+  download_mgr.SetProxyChain("http://127.0.0.1:8084", "",
                              DownloadManager::kSetProxyRegular);
-  download_mgr->EnableRedirects();
+  download_mgr.EnableRedirects();
   string url = "http://127.0.0.1:8083/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(proxy_server.num_processed_requests(), 2);
   ASSERT_EQ(redirect_server.num_processed_requests(), 1);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
@@ -308,7 +307,7 @@ TEST_F(T_Download, LocalFile2Mem) {
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
   EXPECT_STREQ(reinterpret_cast<char*>(memsink.data()), src_content.c_str());
@@ -319,12 +318,12 @@ TEST_F(T_Download, RemoteFileSwitchHosts) {
   string src_content = GetFileContents(src_path);
 
   MockFileServer file_server(8082, sandbox_path_);
-  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.num_used_hosts(), 2);
   ASSERT_EQ(info.error_code(), kFailOk);
@@ -337,14 +336,14 @@ TEST_F(T_Download, CancelRequest) {
   string src_content = GetFileContents(src_path);
 
   MockFileServer file_server(8082, sandbox_path_);
-  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
   TestInterruptCue tci;
   info.SetInterruptCue(&tci);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(info.num_used_hosts(), 1);
   ASSERT_EQ(info.error_code(), kFailCanceled);
   EXPECT_EQ(NULL, memsink.data());
@@ -357,13 +356,13 @@ TEST_F(T_Download, RemoteFileSwitchHostsAfterRedirect) {
   MockRedirectServer redirect_server(8083, "http://127.0.0.1:8084");
   MockFileServer file_server(8082, sandbox_path_);
 
-  download_mgr->EnableRedirects();
-  download_mgr->SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
+  download_mgr.EnableRedirects();
+  download_mgr.SetHostChain("http://127.0.0.1:8083;http://127.0.0.1:8082");
   string url = "/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&url, false /* compressed */, true /* probe hosts */, NULL,
                &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(info.num_used_hosts(), 2);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), src_content.length());
@@ -379,14 +378,14 @@ TEST_F(T_Download, RemoteFileSwitchProxies) {
 
   MockFileServer file_server(8082, sandbox_path_);
   MockProxyServer proxy_server(8083);
-  download_mgr->SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
+  download_mgr.SetProxyChain("http://127.0.0.1:8084;http://127.0.0.1:8083",
                              "", DownloadManager::kSetProxyRegular);
 
   string src_url = "http://127.0.0.1:8082/" + GetFileName(src_path);
   cvmfs::MemSink memsink;
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL,
            &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(proxy_server.num_processed_requests(), 1);
   ASSERT_EQ(info.num_used_proxies(), 2);
@@ -404,7 +403,7 @@ TEST_F(T_Download, RemoteFileEmpty) {
   cvmfs::MemSink memsink;
   JobInfo info(&src_url, false /* compressed */, false /* probe hosts */, NULL,
            &memsink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   ASSERT_EQ(file_server.num_processed_requests(), 1);
   ASSERT_EQ(info.error_code(), kFailOk);
   ASSERT_EQ(memsink.pos(), 0U);
@@ -423,7 +422,7 @@ TEST_F(T_Download, LocalFile2Sink) {
   string url = "file://" + dest_path;
   JobInfo info(&url, false /* compressed */, false /* probe hosts */,
                NULL /* expected hash */, &test_sink);
-  download_mgr->Fetch(&info);
+  download_mgr.Fetch(&info);
   EXPECT_EQ(info.error_code(), kFailOk);
   EXPECT_EQ(1, pread(test_sink.fd, &buf, 1, 0));
   EXPECT_EQ('1', buf);
@@ -445,7 +444,7 @@ TEST_F(T_Download, LocalFile2Sink) {
   TestSink test_sink2;
   JobInfo info2(&url, true /* compressed */, false /* probe hosts */,
                 &checksum /* expected hash */, &test_sink2);
-  download_mgr->Fetch(&info2);
+  download_mgr.Fetch(&info2);
   EXPECT_EQ(info2.error_code(), kFailOk);
   EXPECT_EQ(size, GetFileSize(test_sink2.path));
 
@@ -458,67 +457,67 @@ TEST_F(T_Download, LocalFile2Sink) {
 
 TEST_F(T_Download, StripDirect) {
   string cleaned = "FALSE";
-  EXPECT_FALSE(download_mgr->StripDirect("", &cleaned));
+  EXPECT_FALSE(download_mgr.StripDirect("", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT|DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT|DIRECT", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("DIRECT;DIRECT|", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("DIRECT;DIRECT|", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect(";", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect(";", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect(";||;;;|||", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect(";||;;;|||", &cleaned));
   EXPECT_EQ("", cleaned);
-  EXPECT_FALSE(download_mgr->StripDirect("A|B", &cleaned));
+  EXPECT_FALSE(download_mgr.StripDirect("A|B", &cleaned));
   EXPECT_EQ("A|B", cleaned);
-  EXPECT_FALSE(download_mgr->StripDirect("A|B;C|D;E|F|G", &cleaned));
+  EXPECT_FALSE(download_mgr.StripDirect("A|B;C|D;E|F|G", &cleaned));
   EXPECT_EQ("A|B;C|D;E|F|G", cleaned);
-  EXPECT_TRUE(download_mgr->StripDirect("A|DIRECT;C|D;E|F;DIRECT", &cleaned));
+  EXPECT_TRUE(download_mgr.StripDirect("A|DIRECT;C|D;E|F;DIRECT", &cleaned));
   EXPECT_EQ("A;C|D;E|F", cleaned);
 }
 
 
 TEST_F(T_Download, ValidateGeoReply) {
   vector<uint64_t> geo_order;
-  EXPECT_FALSE(download_mgr->ValidateGeoReply("", geo_order.size(),
+  EXPECT_FALSE(download_mgr.ValidateGeoReply("", geo_order.size(),
                &geo_order));
 
   geo_order.push_back(0);
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("a", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("a", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("1,1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1,1", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("1,3", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1,3", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("2,3", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,3", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("2", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2", geo_order.size(), &geo_order));
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 1U);
   EXPECT_EQ(geo_order[0], 0U);
 
   geo_order.push_back(0);
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply(",", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply(",", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("2,", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("1", geo_order.size(), &geo_order));
   EXPECT_FALSE(
-    download_mgr->ValidateGeoReply("3,2,1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("3,2,1", geo_order.size(), &geo_order));
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("2,1", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,1", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 2U);
   EXPECT_EQ(geo_order[0], 1U);
   EXPECT_EQ(geo_order[1], 0U);
 
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("2,1\n", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("2,1\n", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 2U);
   EXPECT_EQ(geo_order[0], 1U);
   EXPECT_EQ(geo_order[1], 0U);
@@ -526,7 +525,7 @@ TEST_F(T_Download, ValidateGeoReply) {
   geo_order.push_back(0);
   geo_order.push_back(0);
   EXPECT_TRUE(
-    download_mgr->ValidateGeoReply("4,3,1,2\n", geo_order.size(), &geo_order));
+    download_mgr.ValidateGeoReply("4,3,1,2\n", geo_order.size(), &geo_order));
   EXPECT_EQ(geo_order.size(), 4U);
   EXPECT_EQ(geo_order[0], 3U);
   EXPECT_EQ(geo_order[1], 2U);
@@ -552,7 +551,7 @@ TEST_F(T_Download, ParseHttpCode) {
 TEST_F(T_Download, EscapeUrl) {
   const std::string url = "http://ab0341.¡ÿϦ랝"; // c2a1 c3bf cfa6 eb9e9d
   const std::string correct = "http://ab0341.%C2%A1%C3%BF%CF%A6%EB%9E%9D";
-  const std::string res = download_mgr->EscapeUrl(url);
+  const std::string res = download_mgr.EscapeUrl(url);
 
   EXPECT_TRUE(res == correct);
 }

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -69,9 +69,8 @@ class T_Fetcher : public ::testing::Test {
     cache_mgr_ = PosixCacheManager::Create(tmp_path_, false);
     ASSERT_TRUE(cache_mgr_ != NULL);
 
-    download_mgr_ = new download::DownloadManager();
-    download_mgr_->Init(8,
-      perf::StatisticsTemplate("test", &statistics_));
+    download_mgr_ = new download::DownloadManager(8,
+                                perf::StatisticsTemplate("test", &statistics_));
     download_mgr_->SetHostChain("file://" + tmp_path_);
 
     fetcher_ = new Fetcher(

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -34,7 +34,9 @@ class T_ObjectFetcher : public ::testing::Test {
     public_key_path(sandbox + "/" + fqrn + ".pub"),
     private_key_path(sandbox + "/" + fqrn + ".key"),
     certificate_path(sandbox + "/" + fqrn + ".crt"),
-    master_key_path(sandbox + "/" + fqrn + ".masterkey") { }
+    master_key_path(sandbox + "/" + fqrn + ".masterkey"),
+    download_manager_(download::DownloadManager(1,
+      perf::StatisticsTemplate("test", &statistics_))) { }
 
  protected:
   const std::string  sandbox;
@@ -340,8 +342,6 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void InitializeExternalManagers() {
-    download_manager_.Init(1,
-      perf::StatisticsTemplate("test", &statistics_));
     signature_manager_.Init();
     ASSERT_TRUE(signature_manager_.LoadPublicRsaKeys(public_key_path));
   }

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -35,8 +35,12 @@ class T_ObjectFetcher : public ::testing::Test {
     private_key_path(sandbox + "/" + fqrn + ".key"),
     certificate_path(sandbox + "/" + fqrn + ".crt"),
     master_key_path(sandbox + "/" + fqrn + ".masterkey"),
-    download_manager_(download::DownloadManager(1,
+    download_manager_(new download::DownloadManager(1,
                       perf::StatisticsTemplate("test", &statistics_))) { }
+
+  virtual ~T_ObjectFetcher() {
+    delete download_manager_;
+  }
 
  protected:
   const std::string  sandbox;
@@ -347,7 +351,7 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void FinalizeExternalManagers() {
-    download_manager_.Fini();
+    download_manager_->Fini();
     signature_manager_.Fini();
   }
 
@@ -439,7 +443,7 @@ class T_ObjectFetcher : public ::testing::Test {
     return new HttpObjectFetcher<>(fqrn,
                                    "file://" + backend_storage,
                                    temp_directory,
-                                   &download_manager_,
+                                   download_manager_,
                                    &signature_manager_);
   }
 
@@ -635,7 +639,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
  private:
   perf::Statistics             statistics_;
-  download::DownloadManager    download_manager_;
+  download::DownloadManager    *download_manager_;
   signature::SignatureManager  signature_manager_;
 };
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -35,12 +35,8 @@ class T_ObjectFetcher : public ::testing::Test {
     private_key_path(sandbox + "/" + fqrn + ".key"),
     certificate_path(sandbox + "/" + fqrn + ".crt"),
     master_key_path(sandbox + "/" + fqrn + ".masterkey"),
-    download_manager_(new download::DownloadManager(1,
+    download_manager_(download::DownloadManager(1,
                       perf::StatisticsTemplate("test", &statistics_))) { }
-
-  virtual ~T_ObjectFetcher() {
-    delete download_manager_;
-  }
 
  protected:
   const std::string  sandbox;
@@ -351,7 +347,7 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void FinalizeExternalManagers() {
-    download_manager_->Fini();
+    download_manager_.Fini();
     signature_manager_.Fini();
   }
 
@@ -443,7 +439,7 @@ class T_ObjectFetcher : public ::testing::Test {
     return new HttpObjectFetcher<>(fqrn,
                                    "file://" + backend_storage,
                                    temp_directory,
-                                   download_manager_,
+                                   &download_manager_,
                                    &signature_manager_);
   }
 
@@ -639,7 +635,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
  private:
   perf::Statistics             statistics_;
-  download::DownloadManager    *download_manager_;
+  download::DownloadManager    download_manager_;
   signature::SignatureManager  signature_manager_;
 };
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -35,7 +35,12 @@ class T_ObjectFetcher : public ::testing::Test {
     private_key_path(sandbox + "/" + fqrn + ".key"),
     certificate_path(sandbox + "/" + fqrn + ".crt"),
     master_key_path(sandbox + "/" + fqrn + ".masterkey"),
-    download_manager_(NULL) { }
+    download_manager_(new download::DownloadManager(1,
+                      perf::StatisticsTemplate("test", &statistics_))) { }
+
+  virtual ~T_ObjectFetcher() {
+    delete download_manager_;
+  }
 
  protected:
   const std::string  sandbox;
@@ -341,8 +346,6 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void InitializeExternalManagers() {
-    download_manager_ = new download::DownloadManager(1,
-                       perf::StatisticsTemplate("test", &statistics_));
     signature_manager_.Init();
     ASSERT_TRUE(signature_manager_.LoadPublicRsaKeys(public_key_path));
   }

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -35,12 +35,7 @@ class T_ObjectFetcher : public ::testing::Test {
     private_key_path(sandbox + "/" + fqrn + ".key"),
     certificate_path(sandbox + "/" + fqrn + ".crt"),
     master_key_path(sandbox + "/" + fqrn + ".masterkey"),
-    download_manager_(new download::DownloadManager(1,
-                      perf::StatisticsTemplate("test", &statistics_))) { }
-
-  virtual ~T_ObjectFetcher() {
-    delete download_manager_;
-  }
+    download_manager_(1, perf::StatisticsTemplate("test", &statistics_)) {}
 
  protected:
   const std::string  sandbox;
@@ -351,7 +346,7 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void FinalizeExternalManagers() {
-    download_manager_->Fini();
+    download_manager_.Fini();
     signature_manager_.Fini();
   }
 
@@ -443,7 +438,7 @@ class T_ObjectFetcher : public ::testing::Test {
     return new HttpObjectFetcher<>(fqrn,
                                    "file://" + backend_storage,
                                    temp_directory,
-                                   download_manager_,
+                                   &download_manager_,
                                    &signature_manager_);
   }
 
@@ -639,7 +634,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
  private:
   perf::Statistics             statistics_;
-  download::DownloadManager    *download_manager_;
+  download::DownloadManager    download_manager_;
   signature::SignatureManager  signature_manager_;
 };
 

--- a/test/unittests/t_object_fetcher.cc
+++ b/test/unittests/t_object_fetcher.cc
@@ -35,8 +35,7 @@ class T_ObjectFetcher : public ::testing::Test {
     private_key_path(sandbox + "/" + fqrn + ".key"),
     certificate_path(sandbox + "/" + fqrn + ".crt"),
     master_key_path(sandbox + "/" + fqrn + ".masterkey"),
-    download_manager_(download::DownloadManager(1,
-      perf::StatisticsTemplate("test", &statistics_))) { }
+    download_manager_(NULL) { }
 
  protected:
   const std::string  sandbox;
@@ -342,12 +341,14 @@ class T_ObjectFetcher : public ::testing::Test {
   }
 
   void InitializeExternalManagers() {
+    download_manager_ = new download::DownloadManager(1,
+                       perf::StatisticsTemplate("test", &statistics_));
     signature_manager_.Init();
     ASSERT_TRUE(signature_manager_.LoadPublicRsaKeys(public_key_path));
   }
 
   void FinalizeExternalManagers() {
-    download_manager_.Fini();
+    download_manager_->Fini();
     signature_manager_.Fini();
   }
 
@@ -439,7 +440,7 @@ class T_ObjectFetcher : public ::testing::Test {
     return new HttpObjectFetcher<>(fqrn,
                                    "file://" + backend_storage,
                                    temp_directory,
-                                   &download_manager_,
+                                   download_manager_,
                                    &signature_manager_);
   }
 
@@ -635,7 +636,7 @@ class T_ObjectFetcher : public ::testing::Test {
 
  private:
   perf::Statistics             statistics_;
-  download::DownloadManager    download_manager_;
+  download::DownloadManager    *download_manager_;
   signature::SignatureManager  signature_manager_;
 };
 


### PR DESCRIPTION
issue #3095 

old empty constructor would create incomplete objects and `Init()` needed to be called.

now the constructor combines the old constructor + `Init()`

For reviewers:
- `new constructor`: variables commented with `// added` were not part of either `Init()` or the constructor. They might therefore need a change to a better initialization value
- `clone()`: commented variables are part of the constructor but not set in clone. maybe they need other values than the default?