### PR TITLE
fix multibyte utf-8 conversion of escapeurl 

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -382,7 +382,7 @@ string DownloadManager::EscapeUrl(const string &url) {
 }
 
 /**
- * escaped array needs to be sufficiently large.  It's size is calculated by
+ * escaped array needs to be sufficiently large.  Its size is calculated by
  * passing NULL to EscapeHeader.
  */
 unsigned DownloadManager::EscapeHeader(const string &header,

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -121,7 +121,7 @@ static inline bool EscapeUrlChar(unsigned char input, char output[3]) {
       (input == '_') || (input == '~') ||
       (input == '[') || (input == ']') || (input == ','))
   {
-    output[0] = input;
+    output[0] = static_cast<char>(input);
     return false;
   }
 

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -108,91 +108,6 @@ bool Interrupted(const std::string &fqrn, JobInfo *info) {
   return false;
 }
 
-/**
- * @note changes here must be MANUALLY updated in the unittest t_download.cc
-*/
-static inline bool EscapeUrlChar(unsigned char input, char output[3]) {
-  if (((input >= '0') && (input <= '9')) ||
-      ((input >= 'A') && (input <= 'Z')) ||
-      ((input >= 'a') && (input <= 'z')) ||
-      (input == '/') || (input == ':') || (input == '.') ||
-      (input == '@') ||
-      (input == '+') || (input == '-') ||
-      (input == '_') || (input == '~') ||
-      (input == '[') || (input == ']') || (input == ','))
-  {
-    output[0] = static_cast<char>(input);
-    return false;
-  }
-
-  output[0] = '%';
-  output[1] = static_cast<char>(
-                             (input / 16) + ((input / 16 <= 9) ? '0' : 'A'-10));
-  output[2] = static_cast<char>(
-                             (input % 16) + ((input % 16 <= 9) ? '0' : 'A'-10));
-  return true;
-}
-
-
-/**
- * Escape special chars from the URL, except for ':' and '/',
- * which should keep their meaning.
- * 
- * @note changes here must be MANUALLY updated in the unittest t_download.cc
- */
-static string EscapeUrl(const string &url) {
-  string escaped;
-  escaped.reserve(url.length());
-
-  char escaped_char[3];
-  for (unsigned i = 0, s = url.length(); i < s; ++i) {
-    if (EscapeUrlChar(url[i], escaped_char)) {
-      escaped.append(escaped_char, 3);
-    } else {
-      escaped.push_back(escaped_char[0]);
-    }
-  }
-  LogCvmfs(kLogDownload, kLogDebug, "escaped %s to %s",
-           url.c_str(), escaped.c_str());
-
-  return escaped;
-}
-
-
-/**
- * escaped array needs to be sufficiently large.  It's size is calculated by
- * passing NULL to EscapeHeader.
- */
-static unsigned EscapeHeader(const string &header,
-                             char *escaped_buf,
-                             size_t buf_size)
-{
-  unsigned esc_pos = 0;
-  char escaped_char[3];
-  for (unsigned i = 0, s = header.size(); i < s; ++i) {
-    if (EscapeUrlChar(header[i], escaped_char)) {
-      for (unsigned j = 0; j < 3; ++j) {
-        if (escaped_buf) {
-          if (esc_pos >= buf_size)
-            return esc_pos;
-          escaped_buf[esc_pos] = escaped_char[j];
-        }
-        esc_pos++;
-      }
-    } else {
-      if (escaped_buf) {
-        if (esc_pos >= buf_size)
-          return esc_pos;
-        escaped_buf[esc_pos] = escaped_char[0];
-      }
-      esc_pos++;
-    }
-  }
-
-  return esc_pos;
-}
-
-
 static Failures PrepareDownloadDestination(JobInfo *info) {
   if (info->sink() != NULL && !info->sink()->IsValid()) {
     cvmfs::PathSink* psink = dynamic_cast<cvmfs::PathSink*>(info->sink());
@@ -420,6 +335,84 @@ static int CallbackCurlDebug(
 const int DownloadManager::kProbeUnprobed = -1;
 const int DownloadManager::kProbeDown     = -2;
 const int DownloadManager::kProbeGeo      = -3;
+
+bool DownloadManager::EscapeUrlChar(unsigned char input, char output[3]) {
+  if (((input >= '0') && (input <= '9')) ||
+      ((input >= 'A') && (input <= 'Z')) ||
+      ((input >= 'a') && (input <= 'z')) ||
+      (input == '/') || (input == ':') || (input == '.') ||
+      (input == '@') ||
+      (input == '+') || (input == '-') ||
+      (input == '_') || (input == '~') ||
+      (input == '[') || (input == ']') || (input == ','))
+  {
+    output[0] = static_cast<char>(input);
+    return false;
+  }
+
+  output[0] = '%';
+  output[1] = static_cast<char>(
+                             (input / 16) + ((input / 16 <= 9) ? '0' : 'A'-10));
+  output[2] = static_cast<char>(
+                             (input % 16) + ((input % 16 <= 9) ? '0' : 'A'-10));
+  return true;
+}
+
+
+/**
+ * Escape special chars from the URL, except for ':' and '/',
+ * which should keep their meaning.
+ */
+string DownloadManager::EscapeUrl(const string &url) {
+  string escaped;
+  escaped.reserve(url.length());
+
+  char escaped_char[3];
+  for (unsigned i = 0, s = url.length(); i < s; ++i) {
+    if (EscapeUrlChar(url[i], escaped_char)) {
+      escaped.append(escaped_char, 3);
+    } else {
+      escaped.push_back(escaped_char[0]);
+    }
+  }
+  LogCvmfs(kLogDownload, kLogDebug, "escaped %s to %s",
+           url.c_str(), escaped.c_str());
+
+  return escaped;
+}
+
+/**
+ * escaped array needs to be sufficiently large.  It's size is calculated by
+ * passing NULL to EscapeHeader.
+ */
+unsigned DownloadManager::EscapeHeader(const string &header,
+                             char *escaped_buf,
+                             size_t buf_size)
+{
+  unsigned esc_pos = 0;
+  char escaped_char[3];
+  for (unsigned i = 0, s = header.size(); i < s; ++i) {
+    if (EscapeUrlChar(header[i], escaped_char)) {
+      for (unsigned j = 0; j < 3; ++j) {
+        if (escaped_buf) {
+          if (esc_pos >= buf_size)
+            return esc_pos;
+          escaped_buf[esc_pos] = escaped_char[j];
+        }
+        esc_pos++;
+      }
+    } else {
+      if (escaped_buf) {
+        if (esc_pos >= buf_size)
+          return esc_pos;
+        escaped_buf[esc_pos] = escaped_char[0];
+      }
+      esc_pos++;
+    }
+  }
+
+  return esc_pos;
+}
 
 /**
  * -1 of digits is not a valid Http return code

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -108,7 +108,10 @@ bool Interrupted(const std::string &fqrn, JobInfo *info) {
   return false;
 }
 
-static inline bool EscapeUrlChar(char input, char output[3]) {
+/**
+ * @note changes here must be MANUALLY updated in the unittest t_download.cc
+*/
+static inline bool EscapeUrlChar(unsigned char input, char output[3]) {
   if (((input >= '0') && (input <= '9')) ||
       ((input >= 'A') && (input <= 'Z')) ||
       ((input >= 'a') && (input <= 'z')) ||
@@ -134,6 +137,8 @@ static inline bool EscapeUrlChar(char input, char output[3]) {
 /**
  * Escape special chars from the URL, except for ':' and '/',
  * which should keep their meaning.
+ * 
+ * @note changes here must be MANUALLY updated in the unittest t_download.cc
  */
 static string EscapeUrl(const string &url) {
   string escaped;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -116,6 +116,7 @@ class CredentialsAttachment {
 class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   FRIEND_TEST(T_Download, ValidateGeoReply);
   FRIEND_TEST(T_Download, StripDirect);
+  FRIEND_TEST(T_Download, EscapeUrl);
 
  public:
   struct ProxyInfo {
@@ -255,6 +256,11 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void InitHeaders();
   void FiniHeaders();
   void CloneProxyConfig(DownloadManager *clone);
+
+  bool EscapeUrlChar(unsigned char input, char output[3]);
+  std::string EscapeUrl(const std::string &url);
+  unsigned EscapeHeader(const std::string &header, char *escaped_buf,
+                        size_t buf_size);
 
   inline std::vector<ProxyInfo> *current_proxy_group() const {
     return (opt_proxy_groups_ ?

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -561,7 +561,7 @@ static inline bool EscapeUrlChar(unsigned char input, char output[3]) {
       (input == '_') || (input == '~') ||
       (input == '[') || (input == ']') || (input == ','))
   {
-    output[0] = input;
+    output[0] = static_cast<char>(input);
     return false;
   }
 

--- a/test/unittests/t_download.cc
+++ b/test/unittests/t_download.cc
@@ -548,61 +548,10 @@ TEST_F(T_Download, ParseHttpCode) {
   EXPECT_EQ(999, DownloadManager::ParseHttpCode(digits));
 }
 
-/**
- * @note changes here must be MANUALLY updated in the unittest t_download.cc
-*/
-static inline bool EscapeUrlChar(unsigned char input, char output[3]) {
-  if (((input >= '0') && (input <= '9')) ||
-      ((input >= 'A') && (input <= 'Z')) ||
-      ((input >= 'a') && (input <= 'z')) ||
-      (input == '/') || (input == ':') || (input == '.') ||
-      (input == '@') ||
-      (input == '+') || (input == '-') ||
-      (input == '_') || (input == '~') ||
-      (input == '[') || (input == ']') || (input == ','))
-  {
-    output[0] = static_cast<char>(input);
-    return false;
-  }
-
-  output[0] = '%';
-  output[1] = static_cast<char>(
-                             (input / 16) + ((input / 16 <= 9) ? '0' : 'A'-10));
-  output[2] = static_cast<char>(
-                             (input % 16) + ((input % 16 <= 9) ? '0' : 'A'-10));
-  return true;
-}
-
-
-/**
- * Escape special chars from the URL, except for ':' and '/',
- * which should keep their meaning.
- * 
- * @note changes here must be MANUALLY updated in the unittest t_download.cc
- */
-static string EscapeUrl(const string &url) {
-  string escaped;
-  escaped.reserve(url.length());
-
-  char escaped_char[3];
-  for (unsigned i = 0, s = url.length(); i < s; ++i) {
-    if (EscapeUrlChar(url[i], escaped_char)) {
-      escaped.append(escaped_char, 3);
-    } else {
-      escaped.push_back(escaped_char[0]);
-    }
-  }
-  LogCvmfs(kLogDownload, kLogDebug, "escaped %s to %s",
-           url.c_str(), escaped.c_str());
-
-  return escaped;
-}
-
-
 TEST_F(T_Download, EscapeUrl) {
   std::string url = "http://ab0341.¡ÿϦ랝"; // c2a1 c3bf cfa6 eb9e9d
   std::string correct = "http://ab0341.%C2%A1%C3%BF%CF%A6%EB%9E%9D";
-  std::string res = EscapeUrl(url);
+  std::string res = download_mgr.EscapeUrl(url);
 
   EXPECT_TRUE(res == correct);
 }


### PR DESCRIPTION
Issue #3368

as in `download.cc` the functions are `static` i know copied them to `t_download.cc` and added a comment to them.

if another solution is preferred, pls let me know
