### PR TITLE
Make mount/reload fail if CVMFS_CONFIG_REPOSITORY unreachable

### DIFF
--- a/cvmfs/cvmfs_talk.cc
+++ b/cvmfs/cvmfs_talk.cc
@@ -28,6 +28,7 @@ struct InstanceInfo {
   static std::string GetDefaultDomain() {
     std::string result;
     BashOptionsManager options_mgr;
+    // TODO TODO return bool
     options_mgr.ParseDefault("");
     bool retval = options_mgr.GetValue("CVMFS_DEFAULT_DOMAIN", &result);
     if (!retval) {
@@ -45,6 +46,7 @@ struct InstanceInfo {
     }
 
     BashOptionsManager options_mgr;
+    // TODO TODO return bool
     options_mgr.ParseDefault(fqrn);
     if (!options_mgr.GetValue("CVMFS_WORKSPACE", &workspace)) {
       if (!options_mgr.GetValue("CVMFS_CACHE_DIR", &workspace)) {
@@ -251,6 +253,7 @@ int main(int argc, char *argv[]) {
   int retcode = 0;
   if (!instance_info.IsDefined()) {
     BashOptionsManager options_mgr;
+    // TODO TODO return bool
     options_mgr.ParseDefault("");
     std::string opt_repos;
     options_mgr.GetValue("CVMFS_REPOSITORIES", &opt_repos);

--- a/cvmfs/libcvmfs_options.cc
+++ b/cvmfs/libcvmfs_options.cc
@@ -82,6 +82,7 @@ int cvmfs_options_parse(SimpleOptionsParser *opts, const char *path) {
   return result ? 0 : -1;
 }
 
+// TODO TODO return bool?
 void cvmfs_options_parse_default(SimpleOptionsParser *opts, const char *fqrn) {
   opts->ParseDefault(fqrn);
 }

--- a/cvmfs/loader_talk.cc
+++ b/cvmfs/loader_talk.cc
@@ -194,7 +194,7 @@ int MainReload(const std::string &socket_path, const bool stop_and_go,
   }
   if (retval != 1) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Reload CRASHED! "
-             "CernVM-FS mountpoints unusable.");
+          "CernVM-FS mountpoints unusable. Check syslog for more information.");
     return 101;
   }
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1589,8 +1589,14 @@ bool MountPoint::CreateSignatureManager() {
     boot_status_ = loader::kFailSignature;
     return false;
   }
-  LogCvmfs(kLogCvmfs, kLogDebug, "CernVM-FS: using public key(s) %s",
+  if (public_keys.size() > 0) {
+    LogCvmfs(kLogCvmfs, kLogDebug, "CernVM-FS: using public key(s) %s",
            public_keys.c_str());
+  } else {
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
+                                              "CernVM-FS: NO PUBLIC KEY GIVEN");
+  }
+
 
   if (options_mgr_->GetValue("CVMFS_TRUSTED_CERTS", &optarg)) {
     if (!signature_mgr_->LoadTrustedCaCrl(optarg)) {

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -82,13 +82,13 @@ class OptionsManager {
    * @param external     if true it indicates the configuration file is in the
    *                     repository. If false the configuration file is in /etc
    */
-  virtual void ParsePath(const std::string &config_file,
+  virtual bool ParsePath(const std::string &config_file,
                          const bool external) = 0;
 
   /**
    * Parses the default config files for cvmfs
    */
-  void ParseDefault(const std::string &fqrn);
+  bool ParseDefault(const std::string &fqrn);
 
   /**
    * Cleans all information about the variables
@@ -248,10 +248,10 @@ class SimpleOptionsParser : public OptionsManager {
   explicit SimpleOptionsParser(
     OptionsTemplateManager *opt_templ_mgr_param = NULL)
     : OptionsManager(opt_templ_mgr_param) { }
-  virtual void ParsePath(
+  virtual bool ParsePath(
     const std::string &config_file,
     const bool external __attribute__((unused))) {
-    (void) TryParsePath(config_file);
+      return TryParsePath(config_file);
   }
   // Libcvmfs returns success or failure, the fuse module fails silently
   bool TryParsePath(const std::string &config_file);
@@ -269,7 +269,7 @@ class BashOptionsManager : public OptionsManager {
   explicit BashOptionsManager(
     OptionsTemplateManager *opt_templ_mgr_param = NULL)
     : OptionsManager(opt_templ_mgr_param) { }
-  void ParsePath(const std::string &config_file, const bool external);
+  bool ParsePath(const std::string &config_file, const bool external);
 };  // class BashOptionsManager
 
 

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -256,8 +256,14 @@ void CmdEnter::WriteCvmfsConfig(const std::string &extra_config) {
   BashOptionsManager options_manager(
     new DefaultOptionsTemplateManager(fqrn_));
   options_manager.ParseDefault(fqrn_);
-  if (!extra_config.empty())
-    options_manager.ParsePath(extra_config, false /* external */);
+  if (!extra_config.empty()) {
+    if (!options_manager.ParsePath(extra_config, false /* external */)) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+                          "Extra config path request but not found: %s. "
+                          "Config might be incomplete",
+                          extra_config.c_str());
+    }
+  }
 
   options_manager.SetValue("CVMFS_MOUNT_DIR",
                            settings_spool_area_.readonly_mnt());

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -395,7 +395,10 @@ std::map<std::string, std::string> SettingsBuilder::GetSessionEnvironment() {
   // Get the repository name from the ephemeral writable shell
   BashOptionsManager omgr;
   omgr.set_taint_environment(false);
-  omgr.ParsePath(session_dir + "/env.conf", false /* external */);
+  if (!omgr.ParsePath(session_dir + "/env.conf", false /* external */)) {
+    throw EPublish("no config file found in " + session_dir + "/env.conf",
+                   EPublish::kFailInvocation);
+  }
 
   // We require at least CVMFS_FQRN to be set
   std::string fqrn;

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -130,7 +130,12 @@ bool S3Uploader::ParseSpoolerDefinition(
   // Parse S3 configuration
   BashOptionsManager options_manager = BashOptionsManager(
     new DefaultOptionsTemplateManager(repository_alias_));
-  options_manager.ParsePath(config_path, false);
+  if (!options_manager.ParsePath(config_path, false)) {
+    LogCvmfs(kLogUploadS3, kLogStderr,
+             "Failed to parse S3 config in dir '%s'",
+             config_path.c_str());
+    return false;
+  }
   std::string parameter;
 
   if (!options_manager.GetValue("CVMFS_S3_HOST", &host_name_)) {

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -404,10 +404,12 @@ int main(int argc, char **argv) {
   }
   string mountpoint = argv[optind+1];
 
+  // TODO TODO return bool
   options_manager_.ParseDefault("");
   const string fqrn = MkFqrn(device);
   options_manager_.SwitchTemplateManager(
     new DefaultOptionsTemplateManager(fqrn));
+  // TODO TODO return bool
   options_manager_.ParseDefault(fqrn);
 
   string optarg;

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -93,7 +93,7 @@ TYPED_TEST(T_Options, ParsePath) {
   OptionsTemplateManager *opt_temp_mgr =
     new DefaultOptionsTemplateManager("atlas.cern.ch");
   opt_temp_mgr->SetTemplate("foo", "fourtytwo");
-  options_manager.ParsePath(config_file, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file, false));
   options_manager.SwitchTemplateManager(opt_temp_mgr);
 
   // printf("DUMP: ***\n%s\n***\n", options_manager.Dump().c_str());
@@ -144,7 +144,7 @@ TYPED_TEST(T_Options, ParsePath) {
 
 TYPED_TEST(T_Options, ParsePathNoFile) {
   string fileName = "somethingThatDoesntExists";
-  TestFixture::options_manager_.ParsePath(fileName, false);
+  EXPECT_FALSE(TestFixture::options_manager_.ParsePath(fileName, false));
   ASSERT_EQ(0u, TestFixture::options_manager_.GetAllKeys().size());
 }
 
@@ -154,15 +154,15 @@ TYPED_TEST(T_Options, ProtectedParameter) {
   const string &config_file = TestFixture::config_file_;
   const string &config_file_2 = TestFixture::config_file_2_;
 
-  options_manager.ParsePath(config_file, false);
-  options_manager.ParsePath(config_file_2, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file, false));
+  EXPECT_TRUE(options_manager.ParsePath(config_file_2, false));
   EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &container));
   EXPECT_EQ("/overwritten", container);
 
   options_manager.ClearConfig();
-  options_manager.ParsePath(config_file, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file, false));
   options_manager.ProtectParameter("CVMFS_CACHE_BASE");
-  options_manager.ParsePath(config_file_2, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file_2, false));
   EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &container));
   EXPECT_NE("/overwritten", container);
 }
@@ -170,7 +170,7 @@ TYPED_TEST(T_Options, ProtectedParameter) {
 TYPED_TEST(T_Options, GetEnvironmentSubset) {
   OptionsManager &options_manager = TestFixture::options_manager_;
   const string &config_file = TestFixture::config_file_;
-  options_manager.ParsePath(config_file, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file, false));
 
   EXPECT_EQ(0U,
     options_manager.GetEnvironmentSubset("NO_SUCH_PREFIX", false).size());
@@ -189,7 +189,7 @@ TYPED_TEST(T_Options, GetEnvironmentSubset) {
 TYPED_TEST(T_Options, SetValue) {
   OptionsManager &options_manager = TestFixture::options_manager_;
   const string &config_file = TestFixture::config_file_;
-  options_manager.ParsePath(config_file, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file, false));
 
   string arg;
   EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &arg));
@@ -211,7 +211,7 @@ TYPED_TEST(T_Options, SetValue) {
 TYPED_TEST(T_Options, TaintEnvironment) {
   OptionsManager &options_manager = TestFixture::options_manager_;
   const string &config_file = TestFixture::config_file_;
-  options_manager.ParsePath(config_file, false);
+  EXPECT_TRUE(options_manager.ParsePath(config_file, false));
 
   string arg;
   EXPECT_FALSE(options_manager.GetValue("NO_SUCH_OPTION", &arg));


### PR DESCRIPTION
Issue #3384 (explanation of failure will be there)

- if `CVMFS_CONFIG_REPOSITORY` is unreachable: fallback to `default`.
- if default `CVMFS_CONFIG_REPOSITORY` not reachable: PANIC/exit process

- added note to look in `syslog`
- added other output when pubkeys are empty

- 2nd commit just consists of maybe TODOs if we also want to add some checking around those `ParseDefault()`

tested on:
- mounting with invalid default CVMFS_CONFIG_REPOSITORY
- mounting with valid default CVMFS_CONFIG_REPOSITORY and then changing it to invalid one and reloading