### PR TITLE
fix client reload if remote config repo is unavailable

### DIFF
--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.0-2_all.deb"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.1-0_all.deb"
 
 # retrieve the upstream version string from CVMFS
 cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.1-0_all.deb"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.1-1_all.deb"
 
 # retrieve the upstream version string from CVMFS
 cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.0-1_all.deb"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.0-2_all.deb"
 
 # retrieve the upstream version string from CVMFS
 cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"

--- a/ci/cvmfs/rpm.sh
+++ b/ci/cvmfs/rpm.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.0-1.noarch.rpm"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.0-3.noarch.rpm"
 
 rpm_infra_dirs="BUILD RPMS SOURCES SRPMS TMP"
 rpm_src_dir="${CVMFS_SOURCE_LOCATION}/packaging/rpm"

--- a/ci/cvmfs/rpm.sh
+++ b/ci/cvmfs/rpm.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.1-0.noarch.rpm"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.1-1.noarch.rpm"
 
 rpm_infra_dirs="BUILD RPMS SOURCES SRPMS TMP"
 rpm_src_dir="${CVMFS_SOURCE_LOCATION}/packaging/rpm"

--- a/ci/cvmfs/rpm.sh
+++ b/ci/cvmfs/rpm.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.0-3.noarch.rpm"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.1-0.noarch.rpm"
 
 rpm_infra_dirs="BUILD RPMS SOURCES SRPMS TMP"
 rpm_src_dir="${CVMFS_SOURCE_LOCATION}/packaging/rpm"

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1589,8 +1589,13 @@ bool MountPoint::CreateSignatureManager() {
     boot_status_ = loader::kFailSignature;
     return false;
   }
-  LogCvmfs(kLogCvmfs, kLogDebug, "CernVM-FS: using public key(s) %s",
-           public_keys.c_str());
+
+  if (public_keys.size() > 0) {
+    LogCvmfs(kLogCvmfs, kLogDebug, "CernVM-FS: using public key(s) %s",
+                                   public_keys.c_str());
+  } else {
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn, "no public key loaded");
+  }
 
   if (options_mgr_->GetValue("CVMFS_TRUSTED_CERTS", &optarg)) {
     if (!signature_mgr_->LoadTrustedCaCrl(optarg)) {

--- a/mount/default.conf
+++ b/mount/default.conf
@@ -87,6 +87,13 @@ CVMFS_SEND_INFO_HEADER=no
 # by the domain-specific configuration.
 CVMFS_USE_GEOAPI=no
 
+# Makes sure CVMFS_CONFIG_REPO_DEFAULT_ENV is unset. It should be set when 
+# using $CVMFS_CONFIG_REPOSITORY. Unsetting it here allows to fallback to
+# local configs, e.g. mount/domain.d/cern.ch.conf that provide local keys
+# in case the remote $CVMFS_CONFIG_REPOSITORY is unavailable
+# (they have an IF guard around it using CVMFS_CONFIG_REPO_DEFAULT_ENV)
+CVMFS_CONFIG_REPO_DEFAULT_ENV=
+
 # If the transfer rate falls below the given bytes/s for longer than
 # CVMFS_TIMEOUT[_DIRECT], treat the connection like a timeout.
 CVMFS_LOW_SPEED_LIMIT=1024

--- a/mount/default.conf
+++ b/mount/default.conf
@@ -87,13 +87,6 @@ CVMFS_SEND_INFO_HEADER=no
 # by the domain-specific configuration.
 CVMFS_USE_GEOAPI=no
 
-# Makes sure CVMFS_CONFIG_REPO_DEFAULT_ENV is unset. It should be set when 
-# using $CVMFS_CONFIG_REPOSITORY. Unsetting it here allows to fallback to
-# local configs, e.g. mount/domain.d/cern.ch.conf that provide local keys
-# in case the remote $CVMFS_CONFIG_REPOSITORY is unavailable
-# (they have an IF guard around it using CVMFS_CONFIG_REPO_DEFAULT_ENV)
-CVMFS_CONFIG_REPO_DEFAULT_ENV=
-
 # If the transfer rate falls below the given bytes/s for longer than
 # CVMFS_TIMEOUT[_DIRECT], treat the connection like a timeout.
 CVMFS_LOW_SPEED_LIMIT=1024

--- a/mount/default.d/50-cern-debian.conf
+++ b/mount/default.d/50-cern-debian.conf
@@ -1,3 +1,10 @@
+# Makes sure CVMFS_CONFIG_REPO_DEFAULT_ENV is unset. It should be set when 
+# using $CVMFS_CONFIG_REPOSITORY. Unsetting it here allows to fallback to
+# local configs, e.g. mount/domain.d/cern.ch.conf that provide local keys
+# in case the remote $CVMFS_CONFIG_REPOSITORY is unavailable
+# (they have an IF guard around it using CVMFS_CONFIG_REPO_DEFAULT_ENV)
+CVMFS_CONFIG_REPO_DEFAULT_ENV=
+
 # NOTE: on Debian/Ubuntu, autofs supports recursive mounting only as of version
 # >= 5.1.2.  For details see
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=721331

--- a/mount/default.d/50-cern.conf
+++ b/mount/default.d/50-cern.conf
@@ -1,2 +1,9 @@
+# Makes sure CVMFS_CONFIG_REPO_DEFAULT_ENV is unset. It should be set when 
+# using $CVMFS_CONFIG_REPOSITORY. Unsetting it here allows to fallback to
+# local configs, e.g. mount/domain.d/cern.ch.conf that provide local keys
+# in case the remote $CVMFS_CONFIG_REPOSITORY is unavailable
+# (they have an IF guard around it using CVMFS_CONFIG_REPO_DEFAULT_ENV)
+CVMFS_CONFIG_REPO_DEFAULT_ENV=
+
 CVMFS_CONFIG_REPOSITORY=cvmfs-config.cern.ch
 CVMFS_DEFAULT_DOMAIN=cern.ch

--- a/packaging/debian/config-default/changelog
+++ b/packaging/debian/config-default/changelog
@@ -1,4 +1,4 @@
-cvmfs-config-default (2.0-2) lucid; urgency=low
+cvmfs-config-default (2.1-0) lucid; urgency=low
 
   * During reload/mount: fallback to local config repo if remote repo is unavailable
 

--- a/packaging/debian/config-default/changelog
+++ b/packaging/debian/config-default/changelog
@@ -1,4 +1,4 @@
-cvmfs-config-default (2.1-0) lucid; urgency=low
+cvmfs-config-default (2.1-1) lucid; urgency=low
 
   * During reload/mount: fallback to local config repo if remote repo is unavailable
 

--- a/packaging/debian/config-default/changelog
+++ b/packaging/debian/config-default/changelog
@@ -1,3 +1,9 @@
+cvmfs-config-default (2.0-2) lucid; urgency=low
+
+  * During reload/mount: fallback to local config repo if remote repo is unavailable
+
+ -- HereThereBeDragons <HereThereBeDragons@users.noreply.github.com>  Wed, 13 Sep 2023 13:51:10 2023 +0200
+
 cvmfs-config-default (2.0-1) lucid; urgency=low
 
   * Various fixes, use config repository

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -1,7 +1,7 @@
 Summary: CernVM File System Default Configuration and Public Keys
 Name: cvmfs-config-default
-Version: 2.0
-Release: 3
+Version: 2.1
+Release: 0
 Source0: cern-it1.cern.ch.pub
 Source1: cern-it4.cern.ch.pub
 Source2: cern-it5.cern.ch.pub
@@ -75,7 +75,7 @@ install -D -m 444 "%{SOURCE9}" $RPM_BUILD_ROOT%{_sysconfdir}/cvmfs/config.d/READ
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
-* Wed Sep 13 2023 HereThereBeDragons <HereThereBeDragons@users.noreply.github.com> - 2.0-3
+* Wed Sep 13 2023 HereThereBeDragons <HereThereBeDragons@users.noreply.github.com> - 2.1-0
 - During reload/mount: fallback to local config repo if remote repo is unavailable
 
 * Sat Apr 10 2021 Jakob Blomer <jblomer@cern.ch> - 2.0-2

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -1,7 +1,7 @@
 Summary: CernVM File System Default Configuration and Public Keys
 Name: cvmfs-config-default
 Version: 2.1
-Release: 0
+Release: 1
 Source0: cern-it1.cern.ch.pub
 Source1: cern-it4.cern.ch.pub
 Source2: cern-it5.cern.ch.pub
@@ -75,7 +75,7 @@ install -D -m 444 "%{SOURCE9}" $RPM_BUILD_ROOT%{_sysconfdir}/cvmfs/config.d/READ
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
-* Wed Sep 13 2023 HereThereBeDragons <HereThereBeDragons@users.noreply.github.com> - 2.1-0
+* Wed Sep 13 2023 HereThereBeDragons <HereThereBeDragons@users.noreply.github.com> - 2.1-1
 - During reload/mount: fallback to local config repo if remote repo is unavailable
 
 * Sat Apr 10 2021 Jakob Blomer <jblomer@cern.ch> - 2.0-2

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -1,7 +1,7 @@
 Summary: CernVM File System Default Configuration and Public Keys
 Name: cvmfs-config-default
 Version: 2.0
-Release: 2
+Release: 3
 Source0: cern-it1.cern.ch.pub
 Source1: cern-it4.cern.ch.pub
 Source2: cern-it5.cern.ch.pub
@@ -75,6 +75,9 @@ install -D -m 444 "%{SOURCE9}" $RPM_BUILD_ROOT%{_sysconfdir}/cvmfs/config.d/READ
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
+* Wed Sep 13 2023 HereThereBeDragons <HereThereBeDragons@users.noreply.github.com> - 2.0-3
+- During reload/mount: fallback to local config repo if remote repo is unavailable
+
 * Sat Apr 10 2021 Jakob Blomer <jblomer@cern.ch> - 2.0-2
 - Fix RPM linter errors
 


### PR DESCRIPTION
Issue #3384 

Superseeds #3387 

parameter `CVMFS_CONFIG_REPO_DEFAULT_ENV` is set in the client config by the remote config repo. if the remote config repo is not available a local config should be loaded that is guarded behind `CVMFS_CONFIG_REPO_DEFAULT_ENV`. as such `/etc/cvmfs/default.conf` must reset `CVMFS_CONFIG_REPO_DEFAULT_ENV` to know if remote repo is available or not

+ add output if public keys are not set