### PR TITLE
Fix race condition on concurrent mounts

### DIFF
--- a/test/src/102-reusefd/main
+++ b/test/src/102-reusefd/main
@@ -11,12 +11,14 @@ cvmfs_run_test() {
 
   ############### 1) Check that the normal cache manager 
   ############### creates new fds for the same object 
-  cvmfs_mount alice.cern.ch CVMFS_CACHE_REFCOUNT=no  || return 10
+  # make sure the setting is not overridden by the config repo
+
+  cvmfs_mount atlas.cern.ch CVMFS_CACHE_REFCOUNT=no  || return 10
 
   ############
   # open some test file in several simultaneously in different processes
 
-  local testfile=$(find /cvmfs/alice.cern.ch -type f | head -n1)
+  local testfile=$(find /cvmfs/atlas.cern.ch -type f | head -n1)
   # testfile has the following cvmfs hash:
   local testfile_hash=$(get_xattr hash $testfile)
 
@@ -31,8 +33,8 @@ cvmfs_run_test() {
 
   ###########
   # check the open file descriptors of the cvmfs2 process 
-  local alice_pid=$(sudo cvmfs_talk -i alice.cern.ch pid)
-  local num_open_fds=$(sudo ls -l /proc/$alice_pid/fd/ | grep "$(get_cvmfs_cachedir alice.cern.ch)/${testfile_hash:0:2}/${testfile_hash:2}" | wc -l)
+  local atlas_pid=$(sudo cvmfs_talk -i atlas.cern.ch pid)
+  local num_open_fds=$(sudo ls -l /proc/$atlas_pid/fd/ | grep "$(get_cvmfs_cachedir atlas.cern.ch)/${testfile_hash:0:2}/${testfile_hash:2}" | wc -l)
 
   echo "The normal cache manager has $num_open_fds open file descriptors for the same open test file";
   if [ "$num_open_fds" -lt "2" ]; then
@@ -47,12 +49,12 @@ cvmfs_run_test() {
   wait $pid_helper3 || return 64
   sleep 1;
 
-  cvmfs_umount alice.cern.ch || return 22
+  cvmfs_umount atlas.cern.ch || return 22
 
   ############### 2) Check that the refcounted cache manager 
   ############### reuses fds for the same object 
 
-  cvmfs_mount alice.cern.ch CVMFS_CACHE_REFCOUNT=yes || return 30
+  cvmfs_mount atlas.cern.ch CVMFS_CACHE_REFCOUNT=yes || return 30
 
   ############
   # open some test file in several simultaneously in different processes
@@ -68,8 +70,8 @@ cvmfs_run_test() {
 
   ###########
   # check the open file descriptors of the cvmfs2 process 
-  alice_pid=$(cvmfs_talk -i alice.cern.ch pid)
-  local num_open_fds=$(sudo ls -l /proc/$alice_pid/fd/ | grep "$(get_cvmfs_cachedir alice.cern.ch)/${testfile_hash:0:2}/${testfile_hash:2}" | wc -l)
+  atlas_pid=$(sudo cvmfs_talk -i atlas.cern.ch pid)
+  local num_open_fds=$(sudo ls -l /proc/$atlas_pid/fd/ | grep "$(get_cvmfs_cachedir atlas.cern.ch)/${testfile_hash:0:2}/${testfile_hash:2}" | wc -l)
 
   kill -USR1 $pid_helper1
   wait $pid_helper1 || return 65
@@ -83,7 +85,7 @@ cvmfs_run_test() {
     return 40
   fi
 
-  cvmfs_umount alice.cern.ch || return 23
+  cvmfs_umount atlas.cern.ch || return 23
   return 0
 }
 

--- a/test/src/103-reloadcachemgr/main
+++ b/test/src/103-reloadcachemgr/main
@@ -10,9 +10,10 @@ cvmfs_run_test() {
 
   ############### 1) Check that the normal cache manager 
   ############### creates new fds for the same object 
-  cvmfs_mount alice.cern.ch CVMFS_CACHE_REFCOUNT=no  || return 10
-  local CVMFS_TEST_REPO=alice.cern.ch
-  local CVMFS_MOUNTPOINT=/cvmfs/alice.cern.ch
+
+  cvmfs_mount atlas.cern.ch CVMFS_CACHE_REFCOUNT=no  || return 10
+  local CVMFS_TEST_REPO=atlas.cern.ch
+  local CVMFS_MOUNTPOINT=/cvmfs/atlas.cern.ch
 
   local talk_socket="$(get_cvmfs_cachedir $CVMFS_TEST_REPO)/cvmfs_io.$CVMFS_TEST_REPO"
   echo $talk_socket
@@ -24,7 +25,7 @@ cvmfs_run_test() {
   ############
   # open some test file in several simultaneously in different processes
 
-  testfile=$(find /cvmfs/alice.cern.ch -type f | head -n1)
+  testfile=$(find /cvmfs/atlas.cern.ch -type f | head -n1)
   # testfile has the following cvmfs hash:
   testfile_hash=$(get_xattr hash $testfile)
 
@@ -87,7 +88,7 @@ cvmfs_run_test() {
   diff testfile6 $testfile || return 78
   diff testfile7 $testfile || return 79
 
-  cvmfs_umount alice.cern.ch || return 80
+  cvmfs_umount atlas.cern.ch || return 80
 
   return 0
 }

--- a/test/src/104-concurrent_mounts/main
+++ b/test/src/104-concurrent_mounts/main
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+cvmfs_test_name="Check that simultaneous mount attempts only mount the repository once"
+cvmfs_test_suites="quick"
+
+cleanup() {
+  echo "running cleanup() ..."
+  echo "  removing temporary changes from /etc/cvmfs/default.local ..."
+  sudo sed -i'' -e '/^CVMFS_HTTP_PROXY=DIRECT/d' /etc/cvmfs/default.local
+  echo "  unmounting all remaining mounts ..."
+  sudo sed -i'' -e '/^CVMFS_HTTP_PROXY=DIRECT/d' /etc/cvmfs/default.local
+  # clean up all mount attempts, a bunch of times for good measure
+  sudo umount /cvmfs/atlas-condb.cern.ch 2&>/dev/null || true
+  sudo umount /cvmfs/atlas-condb.cern.ch 2&>/dev/null|| true
+  sudo umount /cvmfs/atlas-condb.cern.ch 2&>/dev/null|| true
+  sudo umount /cvmfs/atlas-condb.cern.ch 2&>/dev/null|| true
+  sudo umount /cvmfs/atlas-condb.cern.ch 2&>/dev/null|| true
+  sudo umount /cvmfs/atlas-condb.cern.ch 2&>/dev/null|| true
+
+  sudo umount /cvmfs/cvmfs-config.cern.ch 2&>/dev/null|| true
+
+  echo "  restarting autofs ..."
+  autofs_switch on
+  echo "   ... done."
+
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  src_location=$2
+
+  # setup
+  autofs_switch off
+  echo "setting up configuration ..."
+  sudo sh -c 'echo "CVMFS_HTTP_PROXY=DIRECT" >> /etc/cvmfs/default.local'
+  sudo mkdir -p /cvmfs/atlas-condb.cern.ch
+  echo "mounting config repository ..."
+  sudo mkdir -p /cvmfs/cvmfs-config.cern.ch
+  sudo mount -t cvmfs cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch
+
+  trap cleanup EXIT HUP INT TERM || return 2
+
+  # try to mount the same repository several times simultaneously
+  # using the test function mount_cvmfs is not concurrent enough,
+  # so need to mount directly
+  echo "mounting test repository multiple times (all but one are expected to fail) ... "
+  sudo mount -t cvmfs atlas-condb.cern.ch  /cvmfs/atlas-condb.cern.ch &
+  sudo mount -t cvmfs atlas-condb.cern.ch  /cvmfs/atlas-condb.cern.ch &
+  sudo mount -t cvmfs atlas-condb.cern.ch  /cvmfs/atlas-condb.cern.ch &
+  sudo mount -t cvmfs atlas-condb.cern.ch  /cvmfs/atlas-condb.cern.ch &
+  sleep 6
+
+  echo "counting cvmfs_processes ..."
+  local num_cvmfs_processes=$(ps -efww | grep mount | grep atlas-condb | wc -l)
+
+  if [ "$num_cvmfs_processes" -gt "2" ]; then
+    echo "ERROR: more than one cvmfs process running after multiple simultaneous mounts"
+    return 21
+  fi
+  return 0
+}
+


### PR DESCRIPTION
Fixes #3392  as discussed there. Will uncomment the fix after checking that the cloudtest catches this issue.

With this solution, the lockfile will continue to hang around the cache directory, I'm not sure if it needs to be cleaned up.

