### PR TITLE
Improve error messages for fuse and fix some typos

### DIFF
--- a/cvmfs/crypto/signature.cc
+++ b/cvmfs/crypto/signature.cc
@@ -833,7 +833,7 @@ bool SignatureManager::SignRsa(const unsigned char *buffer,
 
 
 /**
- * Veryfies a signature against loaded certificate.
+ * Verifies a signature against loaded certificate.
  *
  * \return True if signature is valid, false on error or otherwise
  */
@@ -880,7 +880,7 @@ bool SignatureManager::Verify(const unsigned char *buffer,
 
 
 /**
- * Veryfies a signature against all loaded public keys.
+ * Verifies a signature against all loaded public keys.
  *
  * \return True if signature is valid with any public key, false on error or otherwise
  */

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1920,15 +1920,15 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
 #ifdef FUSE_CAP_POSIX_ACL
     if ((conn->capable & FUSE_CAP_POSIX_ACL) == 0) {
       PANIC(kLogDebug | kLogSyslogErr,
-            "ACL support requested but missing fuse kernel support, "
+            "FUSE: ACL support requested but missing fuse kernel support, "
             "aborting");
     }
     conn->want |= FUSE_CAP_POSIX_ACL;
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog, "enforcing ACLs");
 #else
     PANIC(kLogDebug | kLogSyslogErr,
-          "ACL support requested but not available in this version of "
-          "libfuse, aborting");
+          "FUSE: ACL support requested but not available in this version of "
+          "libfuse %d, aborting", FUSE_VERSION);
 #endif
   }
 
@@ -1939,9 +1939,12 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
       LogCvmfs(kLogCvmfs, kLogDebug, "FUSE: Enable symlink caching");
       #ifndef FUSE_CAP_EXPIRE_ONLY
         LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-          "FUSE: Symlink caching enabled but no support for fuse_expire_entry, "
-          "libfuse must be >= 3.16 and kernel >= 6.2-rc1, "
-          "mountpoints on top of symlinks will break!");
+          "FUSE: Symlink caching enabled but no support for fuse_expire_entry. "
+          "Symlinks will be cached but mountpoints on top of symlinks will "
+          "break! "
+          "Current libfuse %d is too old; required: libfuse >= 3.16, "
+          "kernel >= 6.2-rc1",
+          FUSE_VERSION);
       #endif
     } else {
       mount_point_->DisableCacheSymlinks();
@@ -1953,7 +1956,8 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
     mount_point_->DisableCacheSymlinks();
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
           "FUSE: Symlink caching requested but missing libfuse support, "
-          "falling back to no caching");
+          "falling back to no caching. Current libfuse %d",
+          FUSE_VERSION);
 #endif
   }
 
@@ -1964,9 +1968,10 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
     LogCvmfs(kLogCvmfs, kLogDebug, "FUSE: Enable fuse_expire_entry ");
   } else if (mount_point_->cache_symlinks()) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-      "FUSE: Symlink caching enabled but no support for fuse_expire_entry, "
-      "libfuse must be >= 3.16 and kernel >= 6.2-rc1, "
-      "mountpoints on top of symlinks will break!");
+      "FUSE: Symlink caching enabled but no support for fuse_expire_entry. "
+      "Symlinks will be cached but mountpoints on top of symlinks will break! "
+      "Current libfuse %d; required: libfuse >= 3.16, kernel >= 6.2-rc1",
+      FUSE_VERSION);
   }
 #endif
 }

--- a/cvmfs/malloc_heap.cc
+++ b/cvmfs/malloc_heap.cc
@@ -98,7 +98,7 @@ void MallocHeap::MarkFree(void *block) {
   stored_ -= tag->GetSize();
   num_blocks_--;
   // TODO(jblomer): if MarkFree() takes place at the top of the heap, one could
-  // move back the gauge_ pointer.  If this is an optimiziation or unnecessary
+  // move back the gauge_ pointer.  If this is an optimization or unnecessary
   // extra work depends on how the MallocHeap is used.
 }
 

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -3,7 +3,7 @@
  *
  * An optimized virtual file system layer for the client only.  It expects to
  * operate on immutable, valid SQlite files.  Hence it can do a few
- * optimiziations.  Most notably it doesn't need to know about the path of
+ * optimizations.  Most notably it doesn't need to know about the path of
  * the SQlite file once opened.  It works purely on the file descriptor.
  */
 

--- a/cvmfs/sqlitevfs.h
+++ b/cvmfs/sqlitevfs.h
@@ -25,7 +25,7 @@ bool RegisterVfsRdOnly(CacheManager *cache_mgr,
 bool UnregisterVfsRdOnly();
 
 /**
- * After a reload, existing file catalog file dscriptors might need a remap
+ * After a reload, existing file catalog file descriptors might need a remap
  * to the fd in the context of the restored cache manager.
  */
 void RegisterFdMapping(int from, int to);

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -472,7 +472,7 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
       //       space to verify that it was touched (copy-on-write)
       //       Otherwise we would force the cvmfs client behind the union
       //       file-
-      //       system to (potentially) unncessarily fetch catalogs
+      //       system to (potentially) unnecessarily fetch catalogs
       if (DirectoryExists(scratch_dir_ + candidate_rel) &&
           !FileExists(union_dir_ + candidate_rel + "/.cvmfscatalog")) {
         LogCvmfs(kLogCatalog, kLogStdout,

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -192,7 +192,7 @@ string StringifyTimeval(const timeval value) {
 }
 
 /**
- * Parses a timstamp of the form YYYY-MM-DDTHH:MM:SSZ
+ * Parses a timestamp of the form YYYY-MM-DDTHH:MM:SSZ
  * Return 0 on error
  */
 time_t IsoTimestamp2UtcTime(const std::string &iso8601) {


### PR DESCRIPTION
Issue #3405 

better error messages for fuse related errors in `cvmfs.cc` + fixing some typos in other files 

