### PR TITLE
Limit initscripts dependency to rhel <=7

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -222,7 +222,9 @@ Requires: insserv
 Requires: libcap-progs
   %endif
 %else
+  %if 0%{?rhel} < 8
 Requires: initscripts
+  %endif
 %endif
 Requires: bash
 Requires: coreutils


### PR DESCRIPTION
The `initscripts` dependency has already been removed on debian, and should not be needed after el 6. Removing this fixes an issue for IT, where yum check reports a spurious error, related to: https://access.redhat.com/solutions/6969215