### PR TITLE
Bump cvmfs version to 2.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@ message ("Running CMake version ${CMAKE_VERSION}")
 # The version numbers
 #
 # DON'T DELETE
-## CVMFS_VERSION 2.11.0
+## CVMFS_VERSION 2.12.0
 #---------------------
 set (CernVM-FS_VERSION_MAJOR 2)
-set (CernVM-FS_VERSION_MINOR 11)
+set (CernVM-FS_VERSION_MINOR 12)
 set (CernVM-FS_VERSION_PATCH 0)
 set (CernVM-FS_VERSION_STRING "${CernVM-FS_VERSION_MAJOR}.${CernVM-FS_VERSION_MINOR}.${CernVM-FS_VERSION_PATCH}")
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+2.12.0:
+
 2.11.0:
   * [client] Allow change to/from debug mode during cvmfs_config reload (#2897, #3359)
   * [client] Re-use the file descriptor for a file already open in the local cache (#3067)

--- a/cvmfs/libcvmfs.h
+++ b/cvmfs/libcvmfs.h
@@ -17,7 +17,7 @@
 
 #define LIBCVMFS_VERSION 2
 #define LIBCVMFS_VERSION_MAJOR LIBCVMFS_VERSION
-#define LIBCVMFS_VERSION_MINOR 11
+#define LIBCVMFS_VERSION_MINOR 12
 // Revision Changelog
 // 13: revision introduced
 // 14: fix expand_path for absolute paths, add mountpoint to cvmfs_context

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -69,7 +69,7 @@
 
 Summary: CernVM File System
 Name: cvmfs
-Version: 2.11.0
+Version: 2.12.0
 Release: 1%{?dist}
 URL: https://cernvm.cern.ch/fs/
 Source0: https://ecsft.cern.ch/dist/cvmfs/%{name}-%{version}/%{name}-%{version}.tar.gz


### PR DESCRIPTION
we forgot to call the bump_version.sh script after making the 2.11 release, doing it now.