### PR TITLE
Also support Yubikey devices that are named `YubiKey` instead of `Yubikey`

### DIFF
--- a/cvmfs/server/cvmfs_server_masterkeycard.sh
+++ b/cvmfs/server/cvmfs_server_masterkeycard.sh
@@ -15,7 +15,7 @@
 # If not, the reason is sent to stdout and false is returned,
 # otherwise there's nothing to stdout and true is returned
 masterkeycard_available() {
-  local pattern="Yubikey.*CCID"
+  local pattern="Yubi[kK]ey.*CCID"
   local reason=""
   if ! lsusb | grep -q "$pattern"; then
     reason="USB device matching \"$pattern\" not present"


### PR DESCRIPTION
Fixes #3437.

Edit: I just found that there's a yubikey-related test as well in https://github.com/cvmfs/cvmfs/blob/devel/test/src/643-masterkeycard/main, but it looks like that doesn't need to be changed: for some reason, `lsusb` does name my Yubikey `Yubico.com Yubikey 4/5 OTP+U2F+CCID`, while `opensc-tool -l` shows `Yubico YubiKey OTP+FIDO+CCID 01 00`.