### PR TITLE
Fix for broken `openssl pkeyutl` command when using `cvmfs_server masterkeycard`

### DIFF
--- a/cvmfs/server/cvmfs_server_ssl.sh
+++ b/cvmfs/server/cvmfs_server_ssl.sh
@@ -113,9 +113,9 @@ create_whitelist() {
     else
       masterkeycard_read_pubkey >${whitelist}.pub
     fi
-    ${openssl_keyutil_cmd} -verify -inkey ${whitelist}.pub -pubin -sigfile ${whitelist}.signature -in ${whitelist}.hash > /dev/null 2>&1 \
-      || die "invalid masterkeycard signature"
+    local checkhash="`${openssl_keyutil_cmd} -verify -inkey ${whitelist}.pub -pubin -sigfile ${whitelist}.signature -in ${whitelist}.hash 2>/dev/null`"
     rm -f ${whitelist}.pub
+    [ "$checkhash" = "Signature Verified Successfully" ] || die "invalid masterkeycard signature"
   else
     ${openssl_keyutil_cmd} -inkey $masterkey -sign -in ${whitelist}.hash -out ${whitelist}.signature
   fi

--- a/cvmfs/server/cvmfs_server_ssl.sh
+++ b/cvmfs/server/cvmfs_server_ssl.sh
@@ -64,11 +64,7 @@ create_whitelist() {
   local usemasterkeycard=0
   local hash_algorithm
 
-  local openssl_keyutil_cmd="openssl rsautl"
-  local openssl_version=`openssl version | cut -d' ' -f2`
-  if compare_versions "${openssl_version}" -ge "3.0.0" ; then
-    openssl_keyutil_cmd="openssl pkeyutl"
-  fi
+  local openssl_keyutil_cmd="openssl pkeyutl"
 
   local whitelist
   whitelist=${temp_dir}/whitelist.$name
@@ -117,9 +113,9 @@ create_whitelist() {
     else
       masterkeycard_read_pubkey >${whitelist}.pub
     fi
-    local checkhash="`${openssl_keyutil_cmd} -verify -inkey ${whitelist}.pub -pubin -in ${whitelist}.signature 2>/dev/null`"
+    ${openssl_keyutil_cmd} -verify -inkey ${whitelist}.pub -pubin -sigfile ${whitelist}.signature -in ${whitelist}.hash > /dev/null 2>&1 \
+      || die "invalid masterkeycard signature"
     rm -f ${whitelist}.pub
-    [ "$hash" = "$checkhash" ] || die "invalid masterkeycard signature"
   else
     ${openssl_keyutil_cmd} -inkey $masterkey -sign -in ${whitelist}.hash -out ${whitelist}.signature
   fi


### PR DESCRIPTION
This fixes #3439 by adding the required `-sigfile` option to the `openssl pkeyutl` command that is being used for systems with OpenSSL 3 and Yubikeys/Smartcards. In oder to simplify things and not having to use separate verify command for OpenSSL 1 and 3, it now uses this same command for both versions, as `pkeyutl` is already available in OpenSSL 1 as well (and `rsautl` is deprecated in OpenSSL 3).

Note that `openssl pkeyutl` doesn't actually output a hash as `rsautl` did, but instead it takes the hash as input and just prints `Signature Verified Successfully` or an error.