### PR TITLE
Test: Fix flaky test 102

### DIFF
--- a/test/src/102-reusefd/main
+++ b/test/src/102-reusefd/main
@@ -13,6 +13,7 @@ cvmfs_run_test() {
   ############### creates new fds for the same object
   # make sure the setting is not overridden by the config repo
 
+
   cvmfs_mount atlas.cern.ch CVMFS_CACHE_REFCOUNT=no  || return 10
 
   ############
@@ -98,10 +99,12 @@ cvmfs_run_test() {
   sudo cat /proc/$atlas_pid/limits
 
   echo "Non-refcounted manager: should fail"
+  local job_pids=""
   for i in $(seq 1 64); do
     ./openwaitprint $testfile >/dev/null &
+    job_pids="$job_pids $!"
   done
-  local job_pids=$(jobs -p)
+  sleep 1
   local got_emfile=0
   for p in $job_pids; do
     kill -USR1 $p
@@ -115,10 +118,12 @@ cvmfs_run_test() {
   cvmfs_umount atlas.cern.ch || return 55
   cvmfs_mount atlas.cern.ch CVMFS_NFILES=550 CVMFS_CACHE_REFCOUNT=yes || return 56
   echo "Refcounted manager: should succeed"
+  job_pids=""
   for i in $(seq 1 64); do
     ./openwaitprint $testfile >/dev/null &
+    job_pids="$job_pids $!"
   done
-  job_pids=$(jobs -p)
+  sleep 1
   got_emfile=0
   for p in $job_pids; do
     kill -USR1 $p


### PR DESCRIPTION
Fixes a subtle bug in the test logic of 102. When the job pids are gathered, the attempts to open the test file may have already failed and exited, so the call to  `wait`  never checks the return code of those jobs. 

This does not explain why in some circumstances also the last part of the test (checking the refcounted manager) was failing with the output:

```
Non-refcounted manager: should fail
src/102-reusefd/main: line 110: 31133 User defined signal 1   ./openwaitprint $testfile > /dev/null
src/102-reusefd/main: line 110: 31134 User defined signal 1   ./openwaitprint $testfile > /dev/null
src/102-reusefd/main: line 110: 31135 User defined signal 1   ./openwaitprint $testfile > /dev/null
src/102-reusefd/main: line 109: kill: (31146) - No such process
src/102-reusefd/main: line 109: kill: (31147) - No such process
src/102-reusefd/main: line 109: kill: (31149) - No such process
src/102-reusefd/main: line 109: kill: (31151) - No such process
src/102-reusefd/main: line 109: kill: (31152) - No such process
src/102-reusefd/main: line 109: kill: (31153) - No such process
src/102-reusefd/main: line 109: kill: (31154) - No such process
src/102-reusefd/main: line 109: kill: (31155) - No such process
src/102-reusefd/main: line 109: kill: (31156) - No such process
src/102-reusefd/main: line 109: kill: (31157) - No such process
src/102-reusefd/main: line 109: kill: (31159) - No such process
src/102-reusefd/main: line 109: kill: (31160) - No such process
src/102-reusefd/main: line 109: kill: (31167) - No such process
src/102-reusefd/main: line 109: kill: (31172) - No such process
src/102-reusefd/main: line 109: kill: (31177) - No such process
src/102-reusefd/main: line 109: kill: (31179) - No such process
src/102-reusefd/main: line 109: kill: (31184) - No such process
src/102-reusefd/main: line 109: kill: (31187) - No such process
src/102-reusefd/main: line 109: kill: (31189) - No such process
src/102-reusefd/main: line 109: kill: (31190) - No such process
src/102-reusefd/main: line 109: kill: (31191) - No such process
src/102-reusefd/main: line 109: kill: (31193) - No such process
src/102-reusefd/main: line 109: kill: (31196) - No such process
Refcounted manager: should succeed
src/102-reusefd/main: line 128: 31382 User defined signal 1   ./openwaitprint $testfile > /dev/null
src/102-reusefd/main: line 128: 31383 User defined signal 1   ./openwaitprint $testfile > /dev/null
execution took 10.353 seconds
Testcase failed with RETVAL 57
```
( from [here](https://lcgapp-services.cern.ch/cvmfs-jenkins/job/CvmfsCloudTesting/1965/CVMFS_PLATFORM=el7,CVMFS_PLATFORM_CONFIG=x86_64_fuse3,label=trampoline/testReport/(root)/ClientIntegrationTests/Check_that_open_cache_file_descriptors_from_different_processes_are_not_duplicated_in_cvmfs/) ),
but the `sleep` seems to fix this - I don't understand why yet ...