### PR TITLE
autoreconf needed for RISC-V build

### DIFF
--- a/externals/libcrypto/src/configureHook.sh
+++ b/externals/libcrypto/src/configureHook.sh
@@ -9,6 +9,7 @@ if [ "$IS_64_BIT" = "FALSE" ]; then
   DISABLE_ASM="--disable-asm"
 fi
 
+autoreconf -vfi
 mkdir build && cd build
 CFLAGS="${CVMFS_BASE_C_FLAGS} -fPIC" ../configure \
   --enable-static \

--- a/externals/libcrypto/src/configureHook.sh
+++ b/externals/libcrypto/src/configureHook.sh
@@ -9,13 +9,14 @@ if [ "$IS_64_BIT" = "FALSE" ]; then
   DISABLE_ASM="--disable-asm"
 fi
 
+### On RISC-V systems, we need to run autoreconf
+### to detect the correct architecture
 ISA=`grep isa /proc/cpuinfo | head -1 | cut -d: -f2`
-
 echo "System ISA is: $ISA"
-
 case "$ISA" in
 *rv64*) autoreconf -vfi
 esac
+############################
 
 mkdir build && cd build
 CFLAGS="${CVMFS_BASE_C_FLAGS} -fPIC" ../configure \

--- a/externals/libcrypto/src/configureHook.sh
+++ b/externals/libcrypto/src/configureHook.sh
@@ -9,7 +9,14 @@ if [ "$IS_64_BIT" = "FALSE" ]; then
   DISABLE_ASM="--disable-asm"
 fi
 
-autoreconf -vfi
+ISA=`grep isa /proc/cpuinfo | head -1 | cut -d: -f2`
+
+echo "System ISA is: $ISA"
+
+case "$ISA" in
+*rv64*) autoreconf -vfi
+esac
+
 mkdir build && cd build
 CFLAGS="${CVMFS_BASE_C_FLAGS} -fPIC" ../configure \
   --enable-static \

--- a/externals/protobuf/src/configureHook.sh
+++ b/externals/protobuf/src/configureHook.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
+### On RISC-V systems, we need to run autoreconf
+### to detect the correct architecture
 ISA=`grep isa /proc/cpuinfo | head -1 | cut -d: -f2`
-
 echo "System ISA is: $ISA"
-
 case "$ISA" in
 *rv64*) autoreconf -vfi
 esac
+################################
 
 CFLAGS="$CVMFS_BASE_C_FLAGS -fPIC" CXXFLAGS="$CVMFS_BASE_CXX_FLAGS -fPIC" ./configure --without-zlib --disable-shared \
     --prefix=$EXTERNALS_INSTALL_LOCATION

--- a/externals/protobuf/src/configureHook.sh
+++ b/externals/protobuf/src/configureHook.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
-autoreconf -vfi
+ISA=`grep isa /proc/cpuinfo | head -1 | cut -d: -f2`
+
+echo "System ISA is: $ISA"
+
+case "$ISA" in
+*rv64*) autoreconf -vfi
+esac
+
 CFLAGS="$CVMFS_BASE_C_FLAGS -fPIC" CXXFLAGS="$CVMFS_BASE_CXX_FLAGS -fPIC" ./configure --without-zlib --disable-shared \
     --prefix=$EXTERNALS_INSTALL_LOCATION

--- a/externals/protobuf/src/configureHook.sh
+++ b/externals/protobuf/src/configureHook.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+autoreconf -vfi
 CFLAGS="$CVMFS_BASE_C_FLAGS -fPIC" CXXFLAGS="$CVMFS_BASE_CXX_FLAGS -fPIC" ./configure --without-zlib --disable-shared \
     --prefix=$EXTERNALS_INSTALL_LOCATION


### PR DESCRIPTION
Updating the config.guess files as distributed within libcrypto and protobuf dependencies is needed in order to recognize the system build type when building in a RISCV Fedora 37 system (see Issue #3441 ).