### PR TITLE
gateway: add PATCH operation to lease endpoint to refresh lease expiry

### DIFF
--- a/gateway/internal/gateway/backend/backend.go
+++ b/gateway/internal/gateway/backend/backend.go
@@ -32,6 +32,7 @@ type ActionController interface {
 	GetLease(ctx context.Context, tokenStr string) (*LeaseDTO, error)
 	CancelLeases(ctx context.Context, repoPath string) error
 	CancelLease(ctx context.Context, tokenStr string) error
+	RefreshLease(ctx context.Context, tokenStr string) (int64, error)
 	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error)
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
 	RunGC(ctx context.Context, options GCOptions) (string, error)

--- a/gateway/internal/gateway/backend/lease_entity.go
+++ b/gateway/internal/gateway/backend/lease_entity.go
@@ -186,7 +186,7 @@ func RefreshLeaseByToken(ctx context.Context, tx *sql.Tx, token string, expirati
 
 	res, err := tx.ExecContext(
 		ctx,
-		"update lease set Expiration =? Lease where Token = ?;", expiration, token)
+		"update lease set Expiration = ? where Token = ?;", expiration, token)
 	if err != nil {
 		return 0, fmt.Errorf("query failed: %w", err)
 	}

--- a/gateway/internal/gateway/backend/lease_entity.go
+++ b/gateway/internal/gateway/backend/lease_entity.go
@@ -181,6 +181,24 @@ func FindLeaseByToken(ctx context.Context, tx *sql.Tx, token string) (*Lease, er
 	return &lease, nil
 }
 
+func RefreshLeaseByToken(ctx context.Context, tx *sql.Tx, token string, expiration int64) (int64, error) {
+	t0 := time.Now()
+
+	res, err := tx.ExecContext(
+		ctx,
+		"update lease set Expiration =? Lease where Token = ?;", expiration, token)
+	if err != nil {
+		return 0, fmt.Errorf("query failed: %w", err)
+	}
+
+	gw.LogC(ctx, "lease_entity", gw.LogDebug).
+		Str("operation", "refresh_by_token").
+		Dur("task_dt", time.Since(t0)).
+		Msgf("success")
+
+	return res.RowsAffected()
+}
+
 func DeleteAllExpiredLeases(ctx context.Context, tx *sql.Tx) error {
 	t0 := time.Now()
 

--- a/gateway/internal/gateway/frontend/testutil.go
+++ b/gateway/internal/gateway/frontend/testutil.go
@@ -104,3 +104,7 @@ func (b *mockBackend) UnsubscribeFromNotifications(
 	ctx context.Context, repository string, handle be.SubscriberHandle) error {
 	return nil
 }
+
+func (b *mockBackend) RefreshLease(ctx context.Context, tokenStr string) (int64, error) {
+	return 1, nil
+}


### PR DESCRIPTION
Enable refreshing a gateway lease by making a PATCH request to the lease endpoint. Extends expiration of the lease to `now() + MaxLeaseTime`
This means that MaxLeaseTime can be kept short to allow prompt recovery in the case of an orphaned lease.
