### PR TITLE
mention `noautofs` option in usage of `cvmfs_config`

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -133,7 +133,7 @@ cvmfs_config_usage() {
   echo "Common configuration tasks for CernVM-FS"
   echo "Usage: $0 <command>"
   echo "Commands are"
-  echo "  setup [nouser] [nocfgmod] [nostart]"
+  echo "  setup [nouser] [nocfgmod] [nostart] [noautofs]"
   if is_wsl2; then
     echo "  wsl2_start"
   fi


### PR DESCRIPTION
The `noautofs` option of `cvmfs_config setup`, which is a combination of `nocfgmod` and `nostart`, was implemented in #2772, but the `cvmfs_config` help output doesn't mention it (and neither does the CernVM-FS documentation BTW).