### PR TITLE
Reduce write lock contention in catalog mgr

### DIFF
--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -334,6 +334,19 @@ class AbstractCatalogManager : public SingleCopy {
   const std::vector<CatalogT*>& GetCatalogs() const { return catalogs_; }
 
   /**
+   * Opportunistic optimization: the client catalog manager uses this method
+   * to preload into the cache a nested catalog that is likely to be required
+   * next. Likely, because there is a race with the root catalog reload which
+   * may result in the wrong catalog being staged. That's not a fault though,
+   * the correct catalog will still be loaded with the write lock held.
+   */
+  virtual void StageNestedCatalogByHash(const shash::Any & /*hash*/,
+                                        const PathString & /*mountpoint*/)
+  { }
+  void StageNestedCatalog(const PathString &path, const CatalogT *parent,
+                          bool is_listable);
+
+  /**
    * Create a new Catalog object.
    * Every derived class has to implement this and return a newly
    * created (derived) Catalog structure of it's desired type.

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -344,8 +344,13 @@ class AbstractCatalogManager : public SingleCopy {
   virtual void StageNestedCatalogByHash(const shash::Any & /*hash*/,
                                         const PathString & /*mountpoint*/)
   { }
-  void StageNestedCatalog(const PathString &path, const CatalogT *parent,
-                          bool is_listable);
+  /**
+   * Called within the ReadLock(), which will be released before downloading
+   * the catalog (and before leaving the method)
+   */
+  void StageNestedCatalogAndUnlock(const PathString &path,
+                                   const CatalogT *parent,
+                                   bool is_listable);
 
   /**
    * Create a new Catalog object.

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -339,6 +339,7 @@ class AbstractCatalogManager : public SingleCopy {
    * next. Likely, because there is a race with the root catalog reload which
    * may result in the wrong catalog being staged. That's not a fault though,
    * the correct catalog will still be loaded with the write lock held.
+   * Note that this method is never used for root catalogs.
    */
   virtual void StageNestedCatalogByHash(const shash::Any & /*hash*/,
                                         const PathString & /*mountpoint*/)

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -267,6 +267,16 @@ LoadReturn ClientCatalogManager::GetNewRootCatalogContext(
   return success_code;
 }
 
+std::string ClientCatalogManager::GetCatalogDescription(
+  const PathString &mountpoint, const shash::Any &hash)
+{
+  return "file catalog at " + repo_name_ + ":" +
+    (mountpoint.IsEmpty() ? "/"
+                          : string(mountpoint.GetChars(),
+                                   mountpoint.GetLength())) +
+    " (" + hash.ToString() + ")";
+}
+
 /**
  * Loads (and fetches) a catalog by hash for a given mountpoint.
  *
@@ -281,12 +291,8 @@ LoadReturn ClientCatalogManager::GetNewRootCatalogContext(
  */
 LoadReturn ClientCatalogManager::LoadCatalogByHash(
                                                  CatalogContext *ctlg_context) {
-  string catalog_descr = "file catalog at " + repo_name_ + ":" +
-    (ctlg_context->IsRootCatalog() ?
-      "/" : string(ctlg_context->mountpoint().GetChars(),
-                   ctlg_context->mountpoint().GetLength()));
-
-  catalog_descr += " (" + ctlg_context->hash().ToString() + ")";
+  string catalog_descr = GetCatalogDescription(ctlg_context->mountpoint(),
+                                               ctlg_context->hash());
   string alt_root_catalog_path = "";
 
   // root catalog needs special handling because of alt_root_catalog_path
@@ -371,11 +377,8 @@ void ClientCatalogManager::StageNestedCatalogByHash(
 {
   assert(hash.suffix == shash::kSuffixCatalog);
 
-  string catalog_descr = "file catalog at " + repo_name_ + ":" +
-    string(mountpoint.GetChars(), mountpoint.GetLength()) +
-    " (" + hash.ToString() + ")";
   CacheManager::Label label;
-  label.path = catalog_descr;
+  label.path = GetCatalogDescription(mountpoint, hash);
   label.flags = CacheManager::kLabelCatalog;
   int fd = fetcher_->Fetch(CacheManager::LabeledObject(hash, label));
   if (fd >= 0)

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -369,11 +369,11 @@ void ClientCatalogManager::StageNestedCatalogByHash(
   const shash::Any &hash,
   const PathString &mountpoint)
 {
+  assert(hash.suffix == shash::kSuffixCatalog);
+
   string catalog_descr = "file catalog at " + repo_name_ + ":" +
     string(mountpoint.GetChars(), mountpoint.GetLength()) +
     " (" + hash.ToString() + ")";
-
-  assert(hash.suffix == shash::kSuffixCatalog);
   CacheManager::Label label;
   label.path = catalog_descr;
   label.flags = CacheManager::kLabelCatalog;

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -365,6 +365,22 @@ LoadReturn ClientCatalogManager::FetchCatalogByHash(
   return kLoadFail;
 }
 
+void ClientCatalogManager::StageNestedCatalogByHash(
+  const shash::Any &hash,
+  const PathString &mountpoint)
+{
+  string catalog_descr = "file catalog at " + repo_name_ + ":" +
+    string(mountpoint.GetChars(), mountpoint.GetLength()) +
+    " (" + hash.ToString() + ")";
+
+  assert(hash.suffix == shash::kSuffixCatalog);
+  CacheManager::Label label;
+  label.path = catalog_descr;
+  label.flags = CacheManager::kLabelCatalog;
+  int fd = fetcher_->Fetch(CacheManager::LabeledObject(hash, label));
+  if (fd >= 0)
+    fetcher_->cache_mgr()->Close(fd);
+}
 
 void ClientCatalogManager::UnloadCatalog(const Catalog *catalog) {
   LogCvmfs(kLogCache, kLogDebug, "unloading catalog %s",

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -63,6 +63,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
   bool InitFixed(const shash::Any &root_hash, bool alternative_path);
 
   shash::Any GetRootHash();
+  std::string GetCatalogDescription(const PathString &mountpoint,
+                                    const shash::Any &hash);
 
   bool IsRevisionBlacklisted();
 

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -76,6 +76,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
  protected:
   virtual LoadReturn GetNewRootCatalogContext(CatalogContext *result);
   virtual LoadReturn LoadCatalogByHash(CatalogContext *ctlg_context);
+  virtual void StageNestedCatalogByHash(const shash::Any &hash,
+                                        const PathString &mountpoint);
   void UnloadCatalog(const catalog::Catalog *catalog);
   catalog::Catalog* CreateCatalog(const PathString &mountpoint,
                                   const shash::Any  &catalog_hash,

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -385,7 +385,7 @@ bool AbstractCatalogManager<CatalogT>::LookupNested(
   CatalogT *best_fit = FindCatalog(catalog_path);
   CatalogT *catalog = best_fit;
   if (MountSubtree(catalog_path, best_fit, false /* is_listable */, NULL)) {
-    Unlock();
+    StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(catalog_path);
@@ -448,7 +448,7 @@ bool AbstractCatalogManager<CatalogT>::ListCatalogSkein(
   CatalogT *catalog = best_fit;
   // True if there is an available nested catalog
   if (MountSubtree(test, best_fit, false /* is_listable */, NULL)) {
-    Unlock();
+    StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(test);
@@ -504,7 +504,7 @@ bool AbstractCatalogManager<CatalogT>::LookupXattrs(
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
   if (MountSubtree(path, best_fit, false /* is_listable */, NULL)) {
-    Unlock();
+    StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
@@ -619,7 +619,7 @@ bool AbstractCatalogManager<CatalogT>::ListFileChunks(
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
   if (MountSubtree(path, best_fit, false /* is_listable */, NULL)) {
-    Unlock();
+    StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
@@ -655,7 +655,7 @@ catalog::Counters AbstractCatalogManager<CatalogT>::LookupCounters(
   CatalogT *best_fit = FindCatalog(catalog_path);
   CatalogT *catalog = best_fit;
   if (MountSubtree(catalog_path, best_fit, false /* is_listable */, NULL)) {
-    Unlock();
+    StageNestedCatalogAndUnlock(path, best_fit, false /* is_listable */);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(catalog_path);


### PR DESCRIPTION
First draft at improved lock management in the catalog manager.

This patch stages a nested catalog in the cache while the cache manager holds the read lock. The following write-locked phase should then be quick since the catalog is attached from the local cache.

This patch should allow a first performance evaluation. There are the following caveats:
- Staging the catalog inspects the nested catalogs (again). This lookup should somehow be combined with the one from `MountSubtree`.
- There is a race between giving up on the read lock and taking the write lock, in which the file system revision (root catalog) may change. If this change also affects the nested catalog at hand, we staged an outdated nested catalog. That's not ideal but not fatal either and it should be rare.
- The cache may cleanup the staged nested catalog before it is attached. Again, not ideal but also not fatal and should be rare.
- The `MountSubtree()` method allows for "deep mounts" of catalog hierarchies. Only the first nested catalog is staged. In the context of the fuse module, however, that should not matter due to POSIX enforced incremental path loopups.

@mharvey-jt fyi.
