### PR TITLE
Use unbounded queue for items to invalidate

### DIFF
--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -77,7 +77,6 @@ FuseInvalidator::FuseInvalidator(
   , spawned_(false)
 {
   g_fuse_notify_invalidation_ = fuse_notify_invalidation;
-  MakePipe(pipe_ctrl_);
   memset(&thread_invalidator_, 0, sizeof(thread_invalidator_));
   atomic_init32(&terminated_);
 }
@@ -94,7 +93,6 @@ FuseInvalidator::FuseInvalidator(
   , spawned_(false)
 {
   g_fuse_notify_invalidation_ = fuse_notify_invalidation;
-  MakePipe(pipe_ctrl_);
   memset(&thread_invalidator_, 0, sizeof(thread_invalidator_));
   atomic_init32(&terminated_);
 }
@@ -103,30 +101,39 @@ FuseInvalidator::FuseInvalidator(
 FuseInvalidator::~FuseInvalidator() {
   atomic_cas32(&terminated_, 0, 1);
   if (spawned_) {
-    char c = 'Q';
-    WritePipe(pipe_ctrl_[1], &c, 1);
+    channel_.PushBack(new QuitCommand());
     pthread_join(thread_invalidator_, NULL);
   }
-  ClosePipe(pipe_ctrl_);
 }
 
 
 void FuseInvalidator::InvalidateInodes(Handle *handle) {
   assert(handle != NULL);
-  char c = 'I';
-  WritePipe(pipe_ctrl_[1], &c, 1);
-  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+  InvalInodesCommand *inval_inodes_command = new InvalInodesCommand();
+  inval_inodes_command->handle = handle;
+  channel_.PushBack(inval_inodes_command);
 }
 
 void FuseInvalidator::InvalidateDentry(
   uint64_t parent_ino, const NameString &name)
 {
-  char c = 'D';
-  WritePipe(pipe_ctrl_[1], &c, 1);
-  WritePipe(pipe_ctrl_[1], &parent_ino, sizeof(parent_ino));
-  unsigned len = name.GetLength();
-  WritePipe(pipe_ctrl_[1], &len, sizeof(len));
-  WritePipe(pipe_ctrl_[1], name.GetChars(), len);
+  InvalDentryCommand *inval_dentry_command;
+  vector<Command *> *items = channel_.StartEnqueueing();
+  for (size_t i = 0; i < items->size(); ++i) {
+    inval_dentry_command = dynamic_cast<InvalDentryCommand *>(items->at(i));
+    if (!inval_dentry_command)
+      continue;
+    if (inval_dentry_command->parent_ino != parent_ino)
+      continue;
+    channel_.AbortEnqueueing();
+    return;
+  }
+
+  inval_dentry_command = new InvalDentryCommand();
+  inval_dentry_command->parent_ino = parent_ino;
+  inval_dentry_command->name = name;
+  items->push_back(inval_dentry_command);
+  channel_.CommitEnqueueing();
 }
 
 void *FuseInvalidator::MainInvalidator(void *data) {
@@ -134,48 +141,57 @@ void *FuseInvalidator::MainInvalidator(void *data) {
   LogCvmfs(kLogCvmfs, kLogDebug, "starting dentry invalidator thread");
 
   bool reported_missing_inval_support = false;
-  char c;
-  Handle *handle;
   while (true) {
-    ReadPipe(invalidator->pipe_ctrl_[0], &c, 1);
-    if (c == 'Q')
-      break;
+    Command *command = invalidator->channel_.PopFront();
 
-    if (c == 'D') {
-      uint64_t parent_ino;
-      unsigned len;
-      ReadPipe(invalidator->pipe_ctrl_[0], &parent_ino, sizeof(parent_ino));
-      ReadPipe(invalidator->pipe_ctrl_[0], &len, sizeof(len));
-      char *name = static_cast<char *>(smalloc(len + 1));
-      ReadPipe(invalidator->pipe_ctrl_[0], name, len);
-      name[len] = '\0';
+    if (dynamic_cast<QuitCommand *>(command)) {
+      delete command;
+      break;
+    }
+
+    InvalDentryCommand *inval_dentry_command =
+      dynamic_cast<InvalDentryCommand *>(command);
+    if (inval_dentry_command) {
       if (invalidator->fuse_channel_or_session_ == NULL) {
+        delete inval_dentry_command;
         if (!reported_missing_inval_support) {
           LogCvmfs(kLogCvmfs, kLogSyslogWarn,
-                   "missing fuse support for dentry invalidation (%lu/%s)",
-                   parent_ino, name);
+                   "missing fuse support for dentry invalidation "
+                   "(%" PRIu64 "/%s)",
+                   inval_dentry_command->parent_ino,
+                   inval_dentry_command->name.ToString().c_str());
           reported_missing_inval_support = true;
         }
-        free(name);
         continue;
       }
       LogCvmfs(kLogCvmfs, kLogDebug, "evicting single dentry %" PRIu64 "/%s",
-               parent_ino, name);
+               inval_dentry_command->parent_ino,
+               inval_dentry_command->name.ToString().c_str());
 #if CVMFS_USE_LIBFUSE == 2
       fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_chan**>(
-        invalidator->fuse_channel_or_session_), parent_ino, name, len);
+        invalidator->fuse_channel_or_session_),
+        inval_dentry_command->parent_ino,
+        inval_dentry_command->name.GetChars(),
+        inval_dentry_command->name.GetLength());
 #else
       fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_session**>(
-        invalidator->fuse_channel_or_session_), parent_ino, name, len);
+        invalidator->fuse_channel_or_session_),
+        inval_dentry_command->parent_ino,
+        inval_dentry_command->name.GetChars(),
+        inval_dentry_command->name.GetLength());
 #endif
-      free(name);
+      delete inval_dentry_command;
       continue;
     }
 
-    assert(c == 'I');
-    ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
+    InvalInodesCommand *inval_inodes_command =
+      dynamic_cast<InvalInodesCommand *>(command);
+    assert(inval_inodes_command);
+
+    Handle *handle = inval_inodes_command->handle;
     LogCvmfs(kLogCvmfs, kLogDebug, "invalidating kernel caches, timeout %u",
              handle->timeout_s_);
+    delete inval_inodes_command;
 
     uint64_t deadline = platform_monotonic_time() + handle->timeout_s_;
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -126,6 +126,8 @@ void FuseInvalidator::InvalidateDentry(
       continue;
     if (inval_dentry_command->parent_ino != parent_ino)
       continue;
+    if (inval_dentry_command->name != name)
+      continue;
     channel_.AbortEnqueueing();
     return;
   }

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #include "glue_buffer.h"
 #include "mountpoint.h"

--- a/cvmfs/util/concurrency.h
+++ b/cvmfs/util/concurrency.h
@@ -23,6 +23,81 @@ namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
 /**
+ * A thread-safe, unbounded vector of items that implement a FIFO channel.
+ * Uses conditional variables to block when threads try to pop from the empty
+ * channel.
+ */
+template <class ItemT>
+class Channel : SingleCopy {
+ public:
+  Channel() {
+    int retval = pthread_mutex_init(&lock_, NULL);
+    assert(retval == 0);
+    retval = pthread_cond_init(&cond_populated_, NULL);
+    assert(retval == 0);
+  }
+
+  ~Channel() {
+    pthread_cond_destroy(&cond_populated_);
+    pthread_mutex_destroy(&lock_);
+  }
+
+  /**
+   * Returns the queue locked and ready for appending 1 item.
+   */
+  std::vector<ItemT *> *StartEnqueueing() {
+    int retval = pthread_mutex_lock(&lock_);
+    assert(retval == 0);
+    return &items_;
+  }
+
+  /**
+   * Unlocks the queue. The queue must remain unchanged when this is called.
+   */
+  void AbortEnqueueing() {
+    int retval = pthread_mutex_unlock(&lock_);
+    assert(retval == 0);
+  }
+
+  /**
+   * 1 new item was added to the queue. Unlock and signal to reader thread.
+   */
+  void CommitEnqueueing() {
+    int retval = pthread_cond_signal(&cond_populated_);
+    assert(retval == 0);
+    retval = pthread_mutex_unlock(&lock_);
+    assert(retval == 0);
+  }
+
+  /**
+   * Remove and return the first element from the queue.  Block if tube is
+   * empty.
+   */
+  ItemT *PopFront() {
+    MutexLockGuard lock_guard(&lock_);
+    while (items_.size() == 0)
+      pthread_cond_wait(&cond_populated_, &lock_);
+    ItemT *item = items_[0];
+    items_.erase(items_.begin());
+    return item;
+  }
+
+ private:
+  /**
+   * The locked queue/channel
+   */
+  std::vector<ItemT *> items_;
+  /**
+   * Protects all internal state
+   */
+  pthread_mutex_t lock_;
+  /**
+   * Signals if there are items enqueued
+   */
+  pthread_cond_t cond_populated_;
+};
+
+/**
  * Implements a simple interface to lock objects of derived classes. Classes that
  * inherit from Lockable are also usable with the LockGuard template for scoped
  * locking semantics.

--- a/cvmfs/util/concurrency.h
+++ b/cvmfs/util/concurrency.h
@@ -69,6 +69,13 @@ class Channel : SingleCopy {
     assert(retval == 0);
   }
 
+  void PushBack(ItemT *item) {
+    MutexLockGuard lock_guard(&lock_);
+    items_.push_back(item);
+    int retval = pthread_cond_signal(&cond_populated_);
+    assert(retval == 0);
+  }
+
   /**
    * Remove and return the first element from the queue.  Block if tube is
    * empty.

--- a/test/unittests/t_fuse_evict.cc
+++ b/test/unittests/t_fuse_evict.cc
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "fuse_evict.h"
 #include "glue_buffer.h"
 #include "util/string.h"

--- a/test/unittests/t_fuse_evict.cc
+++ b/test/unittests/t_fuse_evict.cc
@@ -37,8 +37,6 @@ TEST_F(T_FuseInvalidator, StartStop) {
     new FuseInvalidator(&inode_tracker_, &dentry_tracker_, NULL, true);
   noop_invalidator->Spawn();
   EXPECT_TRUE(noop_invalidator->spawned_);
-  EXPECT_GE(noop_invalidator->pipe_ctrl_[0], 0);
-  EXPECT_GE(noop_invalidator->pipe_ctrl_[1], 0);
   delete noop_invalidator;
 }
 


### PR DESCRIPTION
Replaces the potentially blocking UNIX pipe by a Channel. The Channel class implements a thread-safe, unbounded queue with conditional variables. Should fix #3480.