### PR TITLE
Improve nested catalog staging

### DIFF
--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -334,6 +334,19 @@ class AbstractCatalogManager : public SingleCopy {
   const std::vector<CatalogT*>& GetCatalogs() const { return catalogs_; }
 
   /**
+   * Opportunistic optimization: the client catalog manager uses this method
+   * to preload into the cache a nested catalog that is likely to be required
+   * next. Likely, because there is a race with the root catalog reload which
+   * may result in the wrong catalog being staged. That's not a fault though,
+   * the correct catalog will still be loaded with the write lock held.
+   */
+  virtual void StageNestedCatalogByHash(const shash::Any & /*hash*/,
+                                        const PathString & /*mountpoint*/)
+  { }
+  void StageNestedCatalog(const PathString &path, const CatalogT *parent,
+                          bool is_listable);
+
+  /**
    * Create a new Catalog object.
    * Every derived class has to implement this and return a newly
    * created (derived) Catalog structure of it's desired type.

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -38,7 +38,8 @@ static time_t tick(void) {
 static void tock(time_t tick) {
   time_t delta = platform_monotonic_time_ns() - tick;
   float delta_ms =  delta /1000000.;
-  LogCvmfs(kLogCatalog, kLogDebug, "Catalog Writelock delay %.3f ms", delta_ms );
+  LogCvmfs(kLogCatalog, kLogDebug,
+		  "Catalog Writelock delay %.3f ms", delta_ms);
 }
 
 
@@ -397,7 +398,7 @@ class AbstractCatalogManager : public SingleCopy {
     assert(retval == 0);
   }
   inline void WriteLock() const {
-    time_t t =tick();
+    time_t t = tick();
     int retval = pthread_rwlock_wrlock(rwlock_);
     assert(retval == 0);
     tock(t);

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -339,6 +339,7 @@ class AbstractCatalogManager : public SingleCopy {
    * next. Likely, because there is a race with the root catalog reload which
    * may result in the wrong catalog being staged. That's not a fault though,
    * the correct catalog will still be loaded with the write lock held.
+   * Note that this method is never used for root catalogs.
    */
   virtual void StageNestedCatalogByHash(const shash::Any & /*hash*/,
                                         const PathString & /*mountpoint*/)

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -39,7 +39,7 @@ static void tock(time_t tick) {
   time_t delta = platform_monotonic_time_ns() - tick;
   float delta_ms =  delta /1000000.;
   LogCvmfs(kLogCatalog, kLogDebug,
-		  "Catalog Writelock delay %.3f ms", delta_ms);
+       "Catalog Writelock delay %.3f ms", delta_ms);
 }
 
 

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -267,6 +267,16 @@ LoadReturn ClientCatalogManager::GetNewRootCatalogContext(
   return success_code;
 }
 
+std::string ClientCatalogManager::GetCatalogDescription(
+  const PathString &mountpoint, const shash::Any &hash)
+{
+  return "file catalog at " + repo_name_ + ":" +
+    (mountpoint.IsEmpty() ? "/"
+                          : string(mountpoint.GetChars(),
+                                   mountpoint.GetLength())) +
+    " (" + hash.ToString() + ")";
+}
+
 /**
  * Loads (and fetches) a catalog by hash for a given mountpoint.
  *
@@ -281,12 +291,8 @@ LoadReturn ClientCatalogManager::GetNewRootCatalogContext(
  */
 LoadReturn ClientCatalogManager::LoadCatalogByHash(
                                                  CatalogContext *ctlg_context) {
-  string catalog_descr = "file catalog at " + repo_name_ + ":" +
-    (ctlg_context->IsRootCatalog() ?
-      "/" : string(ctlg_context->mountpoint().GetChars(),
-                   ctlg_context->mountpoint().GetLength()));
-
-  catalog_descr += " (" + ctlg_context->hash().ToString() + ")";
+  string catalog_descr = GetCatalogDescription(ctlg_context->mountpoint(),
+                                               ctlg_context->hash());
   string alt_root_catalog_path = "";
 
   // root catalog needs special handling because of alt_root_catalog_path
@@ -371,11 +377,8 @@ void ClientCatalogManager::StageNestedCatalogByHash(
 {
   assert(hash.suffix == shash::kSuffixCatalog);
 
-  string catalog_descr = "file catalog at " + repo_name_ + ":" +
-    string(mountpoint.GetChars(), mountpoint.GetLength()) +
-    " (" + hash.ToString() + ")";
   CacheManager::Label label;
-  label.path = catalog_descr;
+  label.path = GetCatalogDescription(mountpoint, hash);
   label.flags = CacheManager::kLabelCatalog;
   int fd = fetcher_->Fetch(CacheManager::LabeledObject(hash, label));
   if (fd >= 0)

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -369,11 +369,11 @@ void ClientCatalogManager::StageNestedCatalogByHash(
   const shash::Any &hash,
   const PathString &mountpoint)
 {
+  assert(hash.suffix == shash::kSuffixCatalog);
+
   string catalog_descr = "file catalog at " + repo_name_ + ":" +
     string(mountpoint.GetChars(), mountpoint.GetLength()) +
     " (" + hash.ToString() + ")";
-
-  assert(hash.suffix == shash::kSuffixCatalog);
   CacheManager::Label label;
   label.path = catalog_descr;
   label.flags = CacheManager::kLabelCatalog;

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -365,6 +365,22 @@ LoadReturn ClientCatalogManager::FetchCatalogByHash(
   return kLoadFail;
 }
 
+void ClientCatalogManager::StageNestedCatalogByHash(
+  const shash::Any &hash,
+  const PathString &mountpoint)
+{
+  string catalog_descr = "file catalog at " + repo_name_ + ":" +
+    string(mountpoint.GetChars(), mountpoint.GetLength()) +
+    " (" + hash.ToString() + ")";
+
+  assert(hash.suffix == shash::kSuffixCatalog);
+  CacheManager::Label label;
+  label.path = catalog_descr;
+  label.flags = CacheManager::kLabelCatalog;
+  int fd = fetcher_->Fetch(CacheManager::LabeledObject(hash, label));
+  if (fd >= 0)
+    fetcher_->cache_mgr()->Close(fd);
+}
 
 void ClientCatalogManager::UnloadCatalog(const Catalog *catalog) {
   LogCvmfs(kLogCache, kLogDebug, "unloading catalog %s",

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -63,6 +63,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
   bool InitFixed(const shash::Any &root_hash, bool alternative_path);
 
   shash::Any GetRootHash();
+  std::string GetCatalogDescription(const PathString &mountpoint,
+                                    const shash::Any &hash);
 
   bool IsRevisionBlacklisted();
 

--- a/cvmfs/catalog_mgr_client.h
+++ b/cvmfs/catalog_mgr_client.h
@@ -76,6 +76,8 @@ class ClientCatalogManager : public AbstractCatalogManager<Catalog> {
  protected:
   virtual LoadReturn GetNewRootCatalogContext(CatalogContext *result);
   virtual LoadReturn LoadCatalogByHash(CatalogContext *ctlg_context);
+  virtual void StageNestedCatalogByHash(const shash::Any &hash,
+                                        const PathString &mountpoint);
   void UnloadCatalog(const catalog::Catalog *catalog);
   catalog::Catalog* CreateCatalog(const PathString &mountpoint,
                                   const shash::Any  &catalog_hash,

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -850,7 +850,10 @@ void AbstractCatalogManager<CatalogT>::StageNestedCatalog(
   assert(parent);
   const unsigned path_len = path.GetLength();
 
-  if(getenv("_CVMFS_NO_CATALOG_STAGING")) {return;}
+  if(getenv("_CVMFS_NO_CATALOG_STAGING")) {
+    Unlock();
+    return;
+  }
 
   perf::Inc(statistics_.n_nested_listing);
   typedef typename CatalogT::NestedCatalogList NestedCatalogList;

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -619,7 +619,7 @@ bool AbstractCatalogManager<CatalogT>::ListFileChunks(
   CatalogT *best_fit = FindCatalog(path);
   CatalogT *catalog = best_fit;
   if (MountSubtree(path, best_fit, false /* is_listable */, NULL)) {
-    StageNestedCatalog(path, best_fit, false /* is_listable */);	  
+    StageNestedCatalog(path, best_fit, false /* is_listable */);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
@@ -850,7 +850,7 @@ void AbstractCatalogManager<CatalogT>::StageNestedCatalog(
   assert(parent);
   const unsigned path_len = path.GetLength();
 
-  if(getenv("_CVMFS_NO_CATALOG_STAGING")) {
+  if (getenv("_CVMFS_NO_CATALOG_STAGING")) {
     Unlock();
     return;
   }


### PR DESCRIPTION
* Add StageNestedCatalog to other if(MountSubtree()) clauses
* Carry the read lock down into StageNestedCatalog and release immediately before download
* Add write lock acquisition latency logging
* Add envvar control for runtime disablement of staging