### PR TITLE
Introduction of data tube to DownloadMgr

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1896,7 +1896,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
         break;
       }
       // TODO(heretherebedragons) add compression
-    } while(true);
+    } while (true);
 
     info->GetPipeJobResultWeakRef()->Read<download::Failures>(&result);
     // LogCvmfs(kLogDownload, kLogDebug, "got result %d", result);

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -700,8 +700,8 @@ void *DownloadManager::MainDownload(void *data) {
           download_mgr->ReleaseCurlHandle(easy_handle);
 
           DataTubeElement *ele = new DataTubeElement(kActionStop);
-          info->GetDataTubeWeakRef()->EnqueueBack(ele);
-          info->GetPipeJobResultWeakRef()->
+          info->GetDataTubePtr()->EnqueueBack(ele);
+          info->GetPipeJobResultPtr()->
                                   Write<download::Failures>(info->error_code());
         }
       }
@@ -1889,7 +1889,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
     pipe_jobs_->Write<JobInfo*>(info);
 
     do {
-      DataTubeElement* ele = info->GetDataTubeWeakRef()->PopFront();
+      DataTubeElement* ele = info->GetDataTubePtr()->PopFront();
 
       if (ele->action == kActionStop) {
         delete ele;
@@ -1898,7 +1898,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
       // TODO(heretherebedragons) add compression
     } while (true);
 
-    info->GetPipeJobResultWeakRef()->Read<download::Failures>(&result);
+    info->GetPipeJobResultPtr()->Read<download::Failures>(&result);
     // LogCvmfs(kLogDownload, kLogDebug, "got result %d", result);
   } else {
     MutexLockGuard l(lock_synchronous_mode_);

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -43,7 +43,7 @@ enum DataTubeAction {
  *
  * TODO(heretherebedragons): do we want to have a pool of those datatubeelements?
  */
-struct DataTubeElement {
+struct DataTubeElement : SingleCopy {
   char* data;
   size_t size;
   DataTubeAction action;
@@ -128,12 +128,8 @@ class JobInfo {
   JobInfo(const std::string *u, const bool ph);
 
   ~JobInfo() {
-    if (pipe_job_results.IsValid()) {
-      pipe_job_results.Destroy();
-    }
-    if (data_tube_.IsValid()) {
-      data_tube_.Destroy();
-    }
+    pipe_job_results.Destroy();
+    data_tube_.Destroy();
   }
 
   void CreatePipeJobResults() {
@@ -146,7 +142,7 @@ class JobInfo {
 
   void CreateDataTube() {
     // TODO(heretherebedragons) change to weighted queue
-    data_tube_ = new Tube<DataTubeElement>(10);
+    data_tube_ = new Tube<DataTubeElement>(500);
   }
 
   bool IsValidDataTube() {
@@ -169,10 +165,9 @@ class JobInfo {
   curl_slist **GetHeadersPtr() { return &headers_; }
   CURL **GetCurlHandle() { return &curl_handle_; }
   shash::ContextPtr *GetHashContextPtr() { return &hash_context_; }
-  Pipe<kPipeDownloadJobsResults> *GetPipeJobResultWeakRef() {
+  Pipe<kPipeDownloadJobsResults> *GetPipeJobResultPtr() {
                                            return pipe_job_results.weak_ref(); }
-  Tube<DataTubeElement> *GetDataTubeWeakRef() {
-                                                 return data_tube_.weak_ref(); }
+  Tube<DataTubeElement> *GetDataTubePtr() { return data_tube_.weak_ref(); }
 
   const std::string* url() const { return url_; }
   bool compressed() const { return compressed_; }

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -40,7 +40,7 @@ enum DataTubeAction {
 /**
  * Wrapper for the data tube to transfer data from CallbackCurlData() that is
  * executed in MainDownload() Thread to Fetch() called by a fuse thread
- * 
+ *
  * TODO(heretherebedragons): do we want to have a pool of those datatubeelements?
  */
 struct DataTubeElement {
@@ -49,10 +49,10 @@ struct DataTubeElement {
   DataTubeAction action;
 
   explicit DataTubeElement(DataTubeAction xact) :
-                                         data(NULL), size(0), action(xact) { };
+                                           data(NULL), size(0), action(xact) { }
   DataTubeElement(char* mov_data, size_t xsize, DataTubeAction xact) :
-                                  data(mov_data), size(xsize), action(xact) { };
-  
+                                   data(mov_data), size(xsize), action(xact) { }
+
   ~DataTubeElement() {
     delete data;
   }


### PR DESCRIPTION
Issue #3493 

At the moment only supports: creating the tube and when the download finished to sync with `Fetch()`

Next steps:
- finalize tube and surrounding logic to support decompression in `Fetch()` and remove it from `CallbackCurlData()`
- extended `tube.h` to allow for weighted elements to calculate size of tube