### PR TITLE
DownloadManager: Parallel decomp - global pool of unused elements

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1953,8 +1953,8 @@ Failures DownloadManager::Fetch(JobInfo *info) {
         break;
         default:
           LogCvmfs(kLogDownload, kLogSyslogErr | kLogDebug,
-                "(id %" PRId64 ") FAILURE - Unkown DataTube Element Action: %d",
-                info->id(), ele->action);
+               "(id %" PRId64 ") FAILURE - Unknown DataTube Element Action: %d",
+               info->id(), ele->action);
       }
       delete ele;
     } while (is_running);

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -255,8 +255,12 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
 
   // LogCvmfs(kLogDownload, kLogDebug, "Data callback,  %d bytes", num_bytes);
 
-  if (num_bytes == 0)
+  // the check for kFailOk is to check when using the DataTube that there was
+  // not early some cancellation of the download due to error
+  // TODO(heretherebedragons) we might want to have this as an atomic variable?
+  if (num_bytes == 0 || info->error_code() != kFailOk) {
     return 0;
+  }
 
   if (info->expected_hash()) {
     shash::Update(reinterpret_cast<unsigned char *>(ptr),
@@ -264,21 +268,30 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
   }
 
   if (info->compressed()) {
-    zlib::StreamStates retval =
-      zlib::DecompressZStream2Sink(ptr, static_cast<int64_t>(num_bytes),
-                                   info->GetZstreamPtr(), info->sink());
-    if (retval == zlib::kStreamDataError) {
-      LogCvmfs(kLogDownload, kLogSyslogErr,
+    if (info->IsValidDataTube()) {
+      char *data = static_cast<char*>(malloc(num_bytes));
+      memcpy(data, ptr, num_bytes);
+      DataTubeElement *ele = new DataTubeElement(data, num_bytes,
+                                                         kActionDecompressZlib);
+      info->GetDataTubeWeakRef()->EnqueueBack(ele);
+    } else { // TODO(heretherebedragons) i think we need this here to support
+             // the non-multihreaded version?
+      zlib::StreamStates retval =
+        zlib::DecompressZStream2Sink(ptr, static_cast<int64_t>(num_bytes),
+                                    info->GetZstreamPtr(), info->sink());
+      if (retval == zlib::kStreamDataError) {
+        LogCvmfs(kLogDownload, kLogSyslogErr,
                                      "(id %" PRId64 ") failed to decompress %s",
-                                     info->id(), info->url()->c_str());
-      info->SetErrorCode(kFailBadData);
-      return 0;
-    } else if (retval == zlib::kStreamIOError) {
-      LogCvmfs(kLogDownload, kLogSyslogErr,
+                                       info->id(), info->url()->c_str());
+        info->SetErrorCode(kFailBadData);
+        return 0;
+      } else if (retval == zlib::kStreamIOError) {
+        LogCvmfs(kLogDownload, kLogSyslogErr,
                             "(id %" PRId64 ") decompressing %s, local IO error",
                             info->id(), info->url()->c_str());
-      info->SetErrorCode(kFailLocalIO);
-      return 0;
+        info->SetErrorCode(kFailLocalIO);
+        return 0;
+      }
     }
   } else {
     int64_t written = info->sink()->Write(ptr, num_bytes);
@@ -689,6 +702,15 @@ void *DownloadManager::MainDownload(void *data) {
                  "Number of CURL redirects %" PRId64 , info->id(), redir_count);
 
         curl_multi_remove_handle(download_mgr->curl_multi_, easy_handle);
+
+        // let's notify CURL is done and wait for the finishing of
+        // decompressing the data so that VerifyAndFinalize executes correctly
+        if (info->IsValidDataTube()) {
+          DataTubeElement *ele = new DataTubeElement(kActionEndOfData);
+          info->GetDataTubeWeakRef()->EnqueueBack(ele);
+          info->GetDataTubeWeakRef()->Wait();
+        }
+
         if (download_mgr->VerifyAndFinalize(curl_error, info)) {
           curl_multi_add_handle(download_mgr->curl_multi_, easy_handle);
           curl_multi_socket_action(download_mgr->curl_multi_,
@@ -699,8 +721,10 @@ void *DownloadManager::MainDownload(void *data) {
           // Return easy handle into pool and write result back
           download_mgr->ReleaseCurlHandle(easy_handle);
 
-          DataTubeElement *ele = new DataTubeElement(kActionStop);
-          info->GetDataTubePtr()->EnqueueBack(ele);
+          if (info->IsValidDataTube()) {
+            DataTubeElement *ele = new DataTubeElement(kActionStop);
+            info->GetDataTubePtr()->EnqueueBack(ele);
+          }
           info->GetPipeJobResultPtr()->
                                   Write<download::Failures>(info->error_code());
         }
@@ -1895,7 +1919,26 @@ Failures DownloadManager::Fetch(JobInfo *info) {
         delete ele;
         break;
       }
-      // TODO(heretherebedragons) add compression
+      if (ele->action == kActionDecompressZlib) {
+        // TODO(heretherebedragons) after rebase add jobinfo id to logmsg
+        zlib::StreamStates retval =
+              zlib::DecompressZStream2Sink(ele->data,
+                                           static_cast<int64_t>(ele->size),
+                                           info->GetZstreamPtr(), info->sink());
+        if (retval == zlib::kStreamDataError) {
+          LogCvmfs(kLogDownload, kLogSyslogErr | kLogDebug, "failed to decompress %s",
+                                                          info->url()->c_str());
+          info->SetErrorCode(kFailBadData);
+        } else if (retval == zlib::kStreamIOError) {
+          LogCvmfs(kLogDownload, kLogSyslogErr | kLogDebug,
+                      "decompressing %s, local IO error", info->url()->c_str());
+          info->SetErrorCode(kFailLocalIO);
+        }
+        delete ele;
+      }
+      if (ele->action == kActionEndOfData) {
+        delete ele;
+      }
     } while (true);
 
     info->GetPipeJobResultPtr()->Read<download::Failures>(&result);

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -284,7 +284,6 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
 
   // the check for kFailOk is to check when using the DataTube that there was
   // not early some cancellation of the download due to error
-  // TODO(heretherebedragons) we might want to have this as an atomic variable?
   if (num_bytes == 0 || info->stop_data_download()) {
     return 0;
   }
@@ -1959,6 +1958,7 @@ void DownloadManager::Spawn() {
 Failures DownloadManager::Fetch(JobInfo *info) {
   assert(info != NULL);
   assert(info->url() != NULL);
+  info->SetStopDataDownload(false);
 
   Failures result;
   result = PrepareDownloadDestination(info);
@@ -2031,7 +2031,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
         case kActionData:
         {
           // quick escape
-          if (info->error_code() != kFailOk) {
+          if (info->stop_data_download()) {
             break;
           }
 

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -83,7 +83,11 @@ DataTubeElement* DownloadManager::GetUnusedDataTubeElement() {
 
 void DownloadManager::PutDataTubeElementToReuse(DataTubeElement* ele) {
   ele->action = kActionUnused;
-  data_tube_empty_elements_->EnqueueBack(ele);
+  Tube<DataTubeElement>::Link *link =
+                                 data_tube_empty_elements_->TryEnqueueBack(ele);
+  if (link == NULL) {  // queue is at max capacity
+    delete ele;
+  }
 }
 
 /**

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1772,7 +1772,7 @@ DownloadManager::~DownloadManager() {
   }
 
   // const int32_t old_count =
-  //                   atomic_xadd32(&DownloadManager::counter_use_data_tube_, -1);
+  //                atomic_xadd32(&DownloadManager::counter_use_data_tube_, -1);
   // if (old_count == 1) {
   //   delete data_tube_empty_elements_;
   // }

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -667,7 +667,7 @@ void *DownloadManager::MainDownload(void *data) {
                               Write<download::Failures>(info->error_code());
         }
 
-        vec_curl_done.erase(vec_curl_done.begin() + i);
+        vec_curl_done.erase(vec_curl_done.begin() + static_cast<int64_t>(i));
         --i;
       }
     }

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1917,8 +1917,8 @@ void DownloadManager::Spawn() {
   atomic_inc32(&multi_threaded_);
 
   for (size_t i = 0; i < 10000; i++) {
-    char *data = static_cast<char*>(malloc(CURL_MAX_HTTP_HEADER));
-    DataTubeElement *ele = new DataTubeElement(data, CURL_MAX_HTTP_HEADER,
+    char *data = static_cast<char*>(malloc(CURL_MAX_WRITE_SIZE));
+    DataTubeElement *ele = new DataTubeElement(data, CURL_MAX_WRITE_SIZE,
                                                kActionUnused);
     data_tube_empty_elements_->EnqueueBack(ele);
   }

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -34,6 +34,7 @@
 #include "util/pointer.h"
 #include "util/prng.h"
 #include "util/shared_ptr.h"
+#include "util/tube.h"
 
 class InterruptCue;
 
@@ -259,6 +260,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   unsigned EscapeHeader(const std::string &header, char *escaped_buf,
                         size_t buf_size);
 
+  DataTubeElement* GetUnusedDataTubeElement();
+  void PutDataTubeElementToReuse(DataTubeElement* ele);
+
   inline std::vector<ProxyInfo> *current_proxy_group() const {
     return (opt_proxy_groups_ ?
             &((*opt_proxy_groups_)[opt_proxy_groups_current_]) : NULL);
@@ -435,6 +439,11 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    * Carries the path settings for SSL certificates
    */
   SslCertificateStore ssl_certificate_store_;
+
+  /**
+   * Tube to hold empty elements use in JobInfo data_tube_
+   */
+  UniquePtr<Tube<DataTubeElement> > data_tube_empty_elements_;
 };  // DownloadManager
 
 }  // namespace download

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -145,7 +145,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    */
   static Tube<DataTubeElement>* data_tube_empty_elements_;
   // counter so that last DownloadManager can delete data_tube_empty_elements_
-  static atomic_int32 counter_use_data_tube_;
+  // static atomic_int32 counter_use_data_tube_;
 
   /**
    * No attempt was made to order stratum 1 servers

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -139,6 +139,15 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   };
 
   /**
+   * Tube to hold empty elements use in JobInfo data_tube_
+   * Shared with all DownloadManagers
+   * Must be static because of CallbackCurlData
+   */
+  static Tube<DataTubeElement>* data_tube_empty_elements_;
+  // counter so that last DownloadManager can delete data_tube_empty_elements_
+  static atomic_int32 counter_use_data_tube_;
+
+  /**
    * No attempt was made to order stratum 1 servers
    */
   static const int kProbeUnprobed;
@@ -259,9 +268,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   std::string EscapeUrl(const int64_t jobinfo_id, const std::string &url);
   unsigned EscapeHeader(const std::string &header, char *escaped_buf,
                         size_t buf_size);
-
-  DataTubeElement* GetUnusedDataTubeElement();
-  void PutDataTubeElementToReuse(DataTubeElement* ele);
 
   inline std::vector<ProxyInfo> *current_proxy_group() const {
     return (opt_proxy_groups_ ?
@@ -439,11 +445,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
    * Carries the path settings for SSL certificates
    */
   SslCertificateStore ssl_certificate_store_;
-
-  /**
-   * Tube to hold empty elements use in JobInfo data_tube_
-   */
-  UniquePtr<Tube<DataTubeElement> > data_tube_empty_elements_;
 };  // DownloadManager
 
 }  // namespace download

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -34,7 +34,8 @@ namespace download {
 enum DataTubeAction {
   kActionStop = 0,
   kActionContinue,
-  kActionDecompress
+  kActionEndOfData,
+  kActionDecompressZlib
 };
 
 /**

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -36,6 +36,7 @@ enum DataTubeAction {
   kActionContinue,
   kActionEndOfData,
   kActionDecompressZlib,
+  kActionUnused,
   kActionData
 };
 

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -35,7 +35,8 @@ enum DataTubeAction {
   kActionStop = 0,
   kActionContinue,
   kActionEndOfData,
-  kActionDecompressZlib
+  kActionDecompressZlib,
+  kActionData
 };
 
 /**

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -35,7 +35,6 @@ enum DataTubeAction {
   kActionStop = 0,
   kActionContinue,
   kActionEndOfData,
-  kActionDecompressZlib,
   kActionUnused,
   kActionData
 };
@@ -201,8 +200,7 @@ class JobInfo {
   shash::ContextPtr hash_context() const { return hash_context_; }
   std::string proxy() const { return proxy_; }
   bool nocache() const { return nocache_; }
-  bool stop_data_download()
-                           { return atomic_read32(&stop_data_download_) != 0; }
+  bool stop_data_download() { return atomic_read32(&stop_data_download_) != 0; }
   Failures error_code() const { return error_code_; }
   int http_code() const { return http_code_; }
   unsigned char num_used_proxies() const { return num_used_proxies_; }

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -56,7 +56,7 @@ struct DataTubeElement : SingleCopy {
                                    data(mov_data), size(xsize), action(xact) { }
 
   ~DataTubeElement() {
-    delete data;
+    free(data);
   }
 };
 
@@ -102,6 +102,7 @@ class JobInfo {
   shash::ContextPtr hash_context_;
   std::string proxy_;
   bool nocache_;
+  atomic_int32 stop_data_download_;
   Failures error_code_;
   int http_code_;
   unsigned char num_used_proxies_;
@@ -199,6 +200,8 @@ class JobInfo {
   shash::ContextPtr hash_context() const { return hash_context_; }
   std::string proxy() const { return proxy_; }
   bool nocache() const { return nocache_; }
+  bool stop_data_download()
+                           { return atomic_read32(&stop_data_download_) != 0; }
   Failures error_code() const { return error_code_; }
   int http_code() const { return http_code_; }
   unsigned char num_used_proxies() const { return num_used_proxies_; }
@@ -249,6 +252,9 @@ class JobInfo {
                                                { hash_context_ = hash_context; }
   void SetProxy(const std::string &proxy) { proxy_ = proxy; }
   void SetNocache(bool nocache) { nocache_ = nocache; }
+  void SetStopDataDownload(bool stop_data_download) {
+                                    int32_t tmp = stop_data_download ? 1 : 0;
+                                    atomic_write32(&stop_data_download_, tmp); }
   void SetErrorCode(Failures error_code) { error_code_ = error_code; }
   void SetHttpCode(int http_code) { http_code_ = http_code; }
   void SetNumUsedProxies(unsigned char num_used_proxies)

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -252,8 +252,8 @@ class JobInfo {
   void SetProxy(const std::string &proxy) { proxy_ = proxy; }
   void SetNocache(bool nocache) { nocache_ = nocache; }
   void SetStopDataDownload(bool stop_data_download) {
-                                    int32_t tmp = stop_data_download ? 1 : 0;
-                                    atomic_write32(&stop_data_download_, tmp); }
+                                 const int32_t tmp = stop_data_download ? 1 : 0;
+                                 atomic_write32(&stop_data_download_, tmp); }
   void SetErrorCode(Failures error_code) { error_code_ = error_code; }
   void SetHttpCode(int http_code) { http_code_ = http_code; }
   void SetNumUsedProxies(unsigned char num_used_proxies)

--- a/cvmfs/util/tube.h
+++ b/cvmfs/util/tube.h
@@ -88,6 +88,28 @@ class Tube : SingleCopy {
   }
 
   /**
+   * Push an item to the back of the queue.  If queue is full, do nothing with
+   * the item and return NULL.
+   */
+  Link *TryEnqueueBack(ItemT *item) {
+    assert(item != NULL);
+    MutexLockGuard lock_guard(&lock_);
+    if (size_ == limit_) {
+      return NULL;
+    }
+
+    Link *link = new Link(item);
+    link->next_ = head_->next_;
+    link->prev_ = head_;
+    head_->next_->prev_ = link;
+    head_->next_ = link;
+    size_++;
+    int retval = pthread_cond_signal(&cond_populated_);
+    assert(retval == 0);
+    return link;
+  }
+
+  /**
    * Push an item to the front of the queue. Block if queue currently full.
    */
   Link *EnqueueFront(ItemT *item) {


### PR DESCRIPTION
Based on PR #3504  -- possibly a performance improvement
 
PR #3504 has in each `CallbackCurlData` a malloc and in `Fetch()` a delete for each received element.

This PR here adds a "global pool" (another tube) of unused elements that `CallbackCurlData` can reuse. If none is available, a new element is created. 

During Spawn of DownloadManager 10k elements are created with CURL_MAX_WRITE_SIZE buffer size to give it a headstart.

All elements are destroyed during deconstruction of DownloadManager