### PR TITLE
Fix replacement of stale inodes

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -299,11 +299,11 @@ static bool FixupOpenInode(const PathString &path,
 
   CVMFS_TEST_INJECT_BARRIER("_CVMFS_TEST_BARRIER_INODE_REPLACE");
 
-  bool is_stale = mount_point_->page_cache_tracker()->IsStale(*dirent);
+  const bool is_stale = mount_point_->page_cache_tracker()->IsStale(*dirent);
 
   if (is_stale) {
     // Overwrite dirent with inode from current generation
-    bool found = mount_point_->catalog_mgr()->LookupPath(
+    const bool found = mount_point_->catalog_mgr()->LookupPath(
         path, catalog::kLookupDefault, dirent);
     assert(found);
   }

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -1056,9 +1056,9 @@ class PageCacheTracker {
    */
   bool IsStale(const catalog::DirectoryEntry &dirent) {
     Entry entry;
-    MutexLockGuard guard(lock_);
+    const MutexLockGuard guard(lock_);
 
-    bool retval = map_.Lookup(dirent.inode(), &entry);
+    const bool retval = map_.Lookup(dirent.inode(), &entry);
     if (!retval)
       return false;
     if (entry.hash.IsNull()) {

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -22,6 +22,7 @@
 #include "bigqueue.h"
 #include "bigvector.h"
 #include "crypto/hash.h"
+#include "directory_entry.h"
 #include "shortstring.h"
 #include "smallhash.h"
 #include "util/atomic.h"
@@ -1045,6 +1046,47 @@ class PageCacheTracker {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Checks if the dirent's inode is registered in the page cache tracker and
+   * if
+   *  - it is currently open and has a different content than dirent
+   *  - it has been previously found stale (no matter if now open or not)
+   */
+  bool IsStale(catalog::DirectoryEntry &dirent) {
+    Entry entry;
+    MutexLockGuard guard(lock_);
+
+    bool retval = map_.Lookup(dirent.inode(), &entry);
+    if (!retval)
+      return false;
+    if (entry.hash.IsNull()) {
+      // A previous call to IsStale() returned true (see below)
+      return true;
+    }
+    if (entry.nopen == 0)
+      return false;
+    if (entry.hash == dirent.checksum())
+      return false;
+
+    bool is_stale = true;
+    if (dirent.IsChunkedFile()) {
+      // Shortcut for chunked files: go by last modified timestamp
+      is_stale =
+        stat_store_.Get(entry.idx_stat).st_mtime != dirent.mtime();
+    }
+    if (is_stale) {
+      // We mark that inode as "stale" by setting its hash to NULL.
+      // When we check next time IsStale(), it is returned stale even
+      // if it is not open.
+      // The call to GetInfoIfOpen() will from now on return the null hash.
+      // That works, the caller will still assume that the version in the
+      // page cache tracker is different from any inode in the catalogs.
+      entry.hash = shash::Any();
+      map_.Insert(dirent.inode(), entry);
+    }
+    return is_stale;
   }
 
   EvictRaii GetEvictRaii() { return EvictRaii(this); }

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -1054,7 +1054,7 @@ class PageCacheTracker {
    *  - it is currently open and has a different content than dirent
    *  - it has been previously found stale (no matter if now open or not)
    */
-  bool IsStale(catalog::DirectoryEntry &dirent) {
+  bool IsStale(const catalog::DirectoryEntry &dirent) {
     Entry entry;
     MutexLockGuard guard(lock_);
 

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -44,6 +44,7 @@
 #include "fuse_remount.h"
 #include "glue_buffer.h"
 #include "loader.h"
+#include "lru_md.h"
 #include "monitor.h"
 #include "mountpoint.h"
 #include "network/download.h"
@@ -520,6 +521,18 @@ void *TalkManager::MainResponder(void *data) {
       }
     } else if (line == "open catalogs") {
       talk_mgr->Answer(con_fd, mount_point->catalog_mgr()->PrintHierarchy());
+    } else if (line == "drop metadata caches") {
+      // For testing
+      mount_point->inode_cache()->Pause();
+      mount_point->path_cache()->Pause();
+      mount_point->md5path_cache()->Pause();
+      mount_point->inode_cache()->Drop();
+      mount_point->path_cache()->Drop();
+      mount_point->md5path_cache()->Drop();
+      mount_point->inode_cache()->Resume();
+      mount_point->path_cache()->Resume();
+      mount_point->md5path_cache()->Resume();
+      talk_mgr->Answer(con_fd, "OK\n");
     } else if (line == "internal affairs") {
       int current;
       int highwater;

--- a/cvmfs/util/testing.h
+++ b/cvmfs/util/testing.h
@@ -22,7 +22,7 @@ namespace CVMFS_NAMESPACE_GUARD {
 #ifdef DEBUGMSG
 // Let an external program pause cvmfs if
 //  - program runs in debug mode
-//  - the given environemnt variable is defined _and_
+//  - the given environment variable is defined _and_
 //  - points to an existing file
 //  - whose content is stop/start
 void CVMFS_TEST_INJECT_BARRIER(const char *env) {

--- a/cvmfs/util/testing.h
+++ b/cvmfs/util/testing.h
@@ -12,8 +12,8 @@
 #include <string>
 
 #include "util/posix.h"
-#include "util/string.h"
 #include "util/prng.h"
+#include "util/string.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {

--- a/cvmfs/util/testing.h
+++ b/cvmfs/util/testing.h
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_UTIL_TESTING_H_
+#define CVMFS_UTIL_TESTING_H_
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "util/posix.h"
+#include "util/string.h"
+#include "util/prng.h"
+
+#ifdef CVMFS_NAMESPACE_GUARD
+namespace CVMFS_NAMESPACE_GUARD {
+#endif
+
+#ifdef DEBUGMSG
+// Let an external program pause cvmfs if
+//  - program runs in debug mode
+//  - the given environemnt variable is defined _and_
+//  - points to an existing file
+//  - whose content is stop/start
+void CVMFS_TEST_INJECT_BARRIER(const char *env) {
+  char *value = getenv(env);
+  if (value == NULL)
+    return;
+  int fd = open(value, O_RDONLY);
+  if (fd < 0)
+    return;
+  std::string action;
+  bool retval = SafeReadToString(fd, &action);
+  close(fd);
+  if (!retval)
+    return;
+  action = Trim(action, true /* trim_newline */);
+  if (action != "pause")
+    return;
+  Prng prng;
+  prng.InitLocaltime();
+  while (true) {
+    int fd = open(value, O_RDONLY);
+    if (fd < 0)
+      return;
+    retval = SafeReadToString(fd, &action);
+    close(fd);
+    action = Trim(action, true /* trim_newline */);
+    if (action == "resume")
+      break;
+    if (action == "resume one") {
+      SafeWriteToFile("pause", value, 0644);
+      break;
+    }
+    SafeSleepMs(prng.Next(1000));
+  }
+}
+#else
+#define CVMFS_TEST_INJECT_BARRIER(...) ((void)0)
+#endif
+
+#ifdef CVMFS_NAMESPACE_GUARD
+}  // namespace CVMFS_NAMESPACE_GUARD
+#endif
+
+#endif  // CVMFS_UTIL_TESTING_H_

--- a/test/src/633-changedfiles-corners/main
+++ b/test/src/633-changedfiles-corners/main
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Repreoducer for https://github.com/cvmfs/cvmfs/issues/3481
+
+cvmfs_test_name="Test inode management when files change"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+TEST633_CORNERS_PRIVATE_MOUNT=
+TEST633_CORNERS_PIDS=
+
+private_mount() {
+  local mntpnt="$1"
+  TEST633_CORNERS_PRIVATE_MOUNT="$mntpnt"
+  do_local_mount "$mntpnt"          \
+                 "$CVMFS_TEST_REPO" \
+                 "$(get_repo_url $CVMFS_TEST_REPO)" \
+                 "" \
+                 "CVMFS_KCACHE_TIMEOUT=0\n_CVMFS_TEST_BARRIER_INODE_REPLACE=${mntpnt}c/barrier01" \
+                 "" || return 1
+}
+
+private_unmount() {
+  sudo umount $TEST633_CORNERS_PRIVATE_MOUNT
+  TEST633_CORNERS_PRIVATE_MOUNT=
+}
+
+cleanup() {
+  echo "running cleanup()..."
+  if [ "x$TEST633_CORNERS_PIDS" != "x" ]; then
+    kill -9 $TEST633_CORNERS_PIDS
+  fi
+  if [ "x$TEST633_CORNERS_PRIVATE_MOUNT" != "x" ]; then
+    private_unmount
+  fi
+}
+
+get_inode() {
+  stat --format=%i $1
+}
+
+get_internal_counter() {
+  local name="$1"
+
+  sudo cvmfs_talk -p \
+    ${TEST633_CORNERS_PRIVATE_MOUNT}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO \
+    internal affairs | \
+    grep ^$name | head -n1 | \
+    cut -d \| -f2
+}
+
+
+cvmfs_run_test() {
+  local logfile=$1
+  local script_location=$2
+  local scratch_dir=$(pwd)
+
+  echo "*** compile helper utility"
+  gcc -std=c99 -Wall -o topen ${script_location}/topen.c || return 2
+
+  echo "*** set a trap for system directory cleanup"
+  trap cleanup EXIT HUP INT TERM
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  local hello=/cvmfs/$CVMFS_TEST_REPO/hello
+  start_transaction $CVMFS_TEST_REPO || return 10
+  echo "Hello World" > $hello || return 12
+  publish_repo $CVMFS_TEST_REPO -v || return 13
+
+  local mntpnt="${scratch_dir}/private_mnt"
+  echo "*** mount private mount point"
+  private_mount $mntpnt || return 20
+
+  rm -f stop_topen
+
+  ./topen ${mntpnt}/hello > topen01.stdout 2> topen02.stderr &
+  local pid_topen01=$!
+  TEST633_CORNERS_PIDS="$TEST633_CORNERS_PIDS $pid_topen01"
+
+  local inode00=$(get_inode ${mntpnt}/hello)
+  echo "*** inode of original hello: $inode00"
+
+  start_transaction $CVMFS_TEST_REPO || return 30
+  echo "Hello World, modified" > $hello || return 31
+  publish_repo $CVMFS_TEST_REPO -v || return 32
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 33
+
+  echo "*** get two concurrent processes into the "replace inode" path"
+
+  echo "pause" > ${mntpnt}c/barrier01
+
+  get_inode ${mntpnt}/hello > inode01 &
+  local pid_lookup01=$!
+  TEST633_CORNERS_PIDS="$TEST633_CORNERS_PIDS $pid_lookup01"
+
+  get_inode ${mntpnt}/hello > inode02 &
+  local pid_lookup02=$!
+  TEST633_CORNERS_PIDS="$TEST633_CORNERS_PIDS $pid_lookup02"
+
+  sleep 3
+
+  echo "*** let one of them finish"
+  echo "resume one" > ${mntpnt}c/barrier01
+  sleep 3
+
+  echo "*** stop the reader, release the old inode"
+
+  touch stop_topen
+  wait $pid_topen01
+
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO drop metadata caches || return 50
+
+  echo "*** finish the second reader"
+
+  echo "resume" > ${mntpnt}c/barrier01
+  wait $pid_lookup01 $pid_lookup02
+  TEST633_CORNERS_PIDS=
+
+  echo "*** The two inodes:"
+  cat inode01
+  cat inode02
+
+  diff inode01 inode02 || return 60
+
+  return 0
+}

--- a/test/src/633-changedfiles-corners/main
+++ b/test/src/633-changedfiles-corners/main
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Repreoducer for https://github.com/cvmfs/cvmfs/issues/3481
+# Reproducer for https://github.com/cvmfs/cvmfs/issues/3481
 
 cvmfs_test_name="Test inode management when files change"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/633-changedfiles-corners/topen.c
+++ b/test/src/633-changedfiles-corners/topen.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
   }
 
   char *path = argv[1];
-  int fd = open(path, O_RDONLY);
+  const int fd = open(path, O_RDONLY);
   if (fd < 0) {
     (void)fprintf(stderr, "cannot open %s\n", path);
     return 1;

--- a/test/src/633-changedfiles-corners/topen.c
+++ b/test/src/633-changedfiles-corners/topen.c
@@ -1,0 +1,40 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <sys/xattr.h>  // NOLINT
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int Exists(char *path) {
+  struct stat info;
+  return stat(path, &info) == 0;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    (void)fprintf(stderr, "Usage: %s /cvmfs/<path>\n", argv[0]);
+    return 1;
+  }
+
+  char *path = argv[1];
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    (void)fprintf(stderr, "cannot open %s\n", path);
+    return 1;
+  }
+
+  while (!Exists("stop_topen")) {
+    sleep(1);
+  }
+
+  printf("*** END %s %s\n", argv[0], path);
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #3481 (see issue for details).

Adds testing infrastructure:
  - CVMFS_TEST_INJECT_BARRIER macro
  - "drop metadata caches" talk command