### PR TITLE
[cleanup] fix syntax highlighting in test scripts

### DIFF
--- a/test/benchmarks/000-dummy/main
+++ b/test/benchmarks/000-dummy/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Dummy benchmark"
 cvmfs_test_autofs_on_startup=false

--- a/test/benchmarks/001-atlas/main
+++ b/test/benchmarks/001-atlas/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="ATLAS benchmark"
 cvmfs_test_autofs_on_startup=false

--- a/test/benchmarks/002-lhcb/main
+++ b/test/benchmarks/002-lhcb/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="LHCB benchmark"
 cvmfs_test_autofs_on_startup=false

--- a/test/benchmarks/004-cms/main
+++ b/test/benchmarks/004-cms/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="CMS benchmark"
 cvmfs_test_autofs_on_startup=false

--- a/test/benchmarks/005-cmsmulti/main
+++ b/test/benchmarks/005-cmsmulti/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="CMS benchmark"
 cvmfs_test_autofs_on_startup=false

--- a/test/container/001-unpacked/main
+++ b/test/container/001-unpacked/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Check availability of /cvmfs/unpacked.cern.ch"
 cvmfs_test_suites="quick"
 

--- a/test/container/002-singularity/main
+++ b/test/container/002-singularity/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Start image from singularity"
 cvmfs_test_suites="quick"
 

--- a/test/container/004-runc/main
+++ b/test/container/004-runc/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Start image from runc"
 cvmfs_test_suites="quick"
 

--- a/test/container/006-k8s/main
+++ b/test/container/006-k8s/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="provide cvmfs to k8s pods"
 cvmfs_test_suites="quick"
 

--- a/test/src/000-dummy/main
+++ b/test/src/000-dummy/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Dummy test"
 cvmfs_test_suites="quick dummy"

--- a/test/src/001-chksetup/main
+++ b/test/src/001-chksetup/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Check installation"
 cvmfs_test_suites="quick"

--- a/test/src/002-probe/main
+++ b/test/src/002-probe/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Probing atlas, lhcb"
 cvmfs_test_suites="quick"

--- a/test/src/003-nested/main
+++ b/test/src/003-nested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Nested catalogs with same prefix"
 

--- a/test/src/004-davinci/main
+++ b/test/src/004-davinci/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Setup Davinci"
 

--- a/test/src/005-asetup/main
+++ b/test/src/005-asetup/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Setup ATLAS"
 

--- a/test/src/006-buildkernel/main
+++ b/test/src/006-buildkernel/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Linux Kernel Compile"
 

--- a/test/src/007-testjobs/main
+++ b/test/src/007-testjobs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Experiment framework test jobs"
 

--- a/test/src/008-default_domain/main
+++ b/test/src/008-default_domain/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Default domain"
 cvmfs_test_suites="quick"

--- a/test/src/009-tar/main
+++ b/test/src/009-tar/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Tar Linux Kernel"
 

--- a/test/src/010-du/main
+++ b/test/src/010-du/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Recursive listing"
 

--- a/test/src/011-rmemptyfilesrebuild/main
+++ b/test/src/011-rmemptyfilesrebuild/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Remove empty corrupted files on cache rebuild"
 cvmfs_test_suites="quick"

--- a/test/src/012-ls-l/main
+++ b/test/src/012-ls-l/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="ls -l"
 cvmfs_test_suites="quick"

--- a/test/src/013-certificate_cache/main
+++ b/test/src/013-certificate_cache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Caching of certificate"
 cvmfs_test_suites="quick"

--- a/test/src/014-corrupt_lru/main
+++ b/test/src/014-corrupt_lru/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Recover from corrupted LRU DB"
 cvmfs_test_suites="quick"

--- a/test/src/015-rebuild_on_crash/main
+++ b/test/src/015-rebuild_on_crash/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Rebuild cache db after crash"
 cvmfs_test_suites="quick"

--- a/test/src/016-dnsunreachable/main
+++ b/test/src/016-dnsunreachable/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="DNS Unreachable"
 cvmfs_test_suites="quick"

--- a/test/src/017-dnstimeout/main
+++ b/test/src/017-dnstimeout/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="DNS Timeout"
 

--- a/test/src/018-httpunreachable/main
+++ b/test/src/018-httpunreachable/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="HTTP Server Unreachable"
 cvmfs_test_suites="quick"

--- a/test/src/019-httptimeout/main
+++ b/test/src/019-httptimeout/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="HTTP Timeout"
 

--- a/test/src/020-emptyrepofailover/main
+++ b/test/src/020-emptyrepofailover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Failover on 404"
 cvmfs_test_suites="quick"

--- a/test/src/021-stacktrace/main
+++ b/test/src/021-stacktrace/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Post Mortem Stacktrace Retrieval"
 cvmfs_test_suites="quick"

--- a/test/src/022-stacktrace_private_mnt/main
+++ b/test/src/022-stacktrace_private_mnt/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Stacktrace from Private Mount Point"
 

--- a/test/src/023-reload_safe_path_traversal/main
+++ b/test/src/023-reload_safe_path_traversal/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Path Traversal while Catalog Reloading"
 

--- a/test/src/024-reload-during-asetup/main
+++ b/test/src/024-reload-during-asetup/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Reload during overcommitted asetup"
 

--- a/test/src/025-proxyfailover/main
+++ b/test/src/025-proxyfailover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="404 Proxy Failover"
 cvmfs_test_suites="quick"

--- a/test/src/026-tightcache/main
+++ b/test/src/026-tightcache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Recursive listing of ATLAS with small cache"
 

--- a/test/src/027-autoumount/main
+++ b/test/src/027-autoumount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Auto unmount of stalled mountpoint after crash"
 cvmfs_test_suites="quick"

--- a/test/src/028-negativecache/main
+++ b/test/src/028-negativecache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Negative cache and I/O errors"
 cvmfs_test_suites="quick"

--- a/test/src/029-requeststorm/main
+++ b/test/src/029-requeststorm/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="DoS protection"
 

--- a/test/src/030-missingrootcatalog/main
+++ b/test/src/030-missingrootcatalog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="404 on Root Catalog Download"
 cvmfs_test_suites="quick"

--- a/test/src/031-cacheautoproxy/main
+++ b/test/src/031-cacheautoproxy/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Cache result of proxy auto discovery"
 

--- a/test/src/032-workspace/main
+++ b/test/src/032-workspace/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="CVMFS_WORKSPACE"
 cvmfs_test_suites="quick"

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Cache cleanup"
 

--- a/test/src/035-unpinumount/main
+++ b/test/src/035-unpinumount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Unpin catalogs on umount"
 cvmfs_test_suites="quick"

--- a/test/src/036-cacheoverload/main
+++ b/test/src/036-cacheoverload/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Overload cache with pinned catalogs"
 

--- a/test/src/037-strictmount/main
+++ b/test/src/037-strictmount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Enforce CVMFS_STRICT_MOUNT"
 cvmfs_test_suites="quick"

--- a/test/src/038-maxttl/main
+++ b/test/src/038-maxttl/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Proper application of CVMFS_MAX_TTL"
 cvmfs_test_suites="quick"

--- a/test/src/039-reloadalarm/main
+++ b/test/src/039-reloadalarm/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Reload racing with ALARM signal"
 cvmfs_test_suites="quick"

--- a/test/src/040-aliencache/main
+++ b/test/src/040-aliencache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Alien cache"
 cvmfs_test_suites="quick"

--- a/test/src/041-rocache/main
+++ b/test/src/041-rocache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Read-only cache"
 cvmfs_test_suites="quick"

--- a/test/src/042-cleanuppipes/main
+++ b/test/src/042-cleanuppipes/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Cleanup left-over pipes"
 cvmfs_test_suites="quick"

--- a/test/src/043-highinodes/main
+++ b/test/src/043-highinodes/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Warn on high inode watermark"
 cvmfs_test_suites="quick"

--- a/test/src/044-unpinonmount/main
+++ b/test/src/044-unpinonmount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Trigger unpin listener on mount"
 cvmfs_test_suites="quick"

--- a/test/src/045-oasis/main
+++ b/test/src/045-oasis/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Probing oasis"
 cvmfs_test_suites="quick"

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Using config files from /etc/cvmfs/default.d/"
 cvmfs_test_suites="quick"

--- a/test/src/047-blacklist/main
+++ b/test/src/047-blacklist/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Blacklist"
 cvmfs_test_suites="quick"

--- a/test/src/048-exportfqrn/main
+++ b/test/src/048-exportfqrn/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Export CVMFS_FQRN"
 cvmfs_test_suites="quick"

--- a/test/src/049-cdconf/main
+++ b/test/src/049-cdconf/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Change directory to config file being parsed"
 cvmfs_test_suites="quick"

--- a/test/src/050-configrepo/main
+++ b/test/src/050-configrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Fetch configuration from config repository"
 

--- a/test/src/051-failonbrokenpubkey/main
+++ b/test/src/051-failonbrokenpubkey/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Mount with Broken Public Key Files"
 cvmfs_test_suites="quick"

--- a/test/src/052-roundrobindns/main
+++ b/test/src/052-roundrobindns/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Round-robin DNS handling"
 

--- a/test/src/053-uuid/main
+++ b/test/src/053-uuid/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Uuid generation and cache"
 cvmfs_test_suites="quick"

--- a/test/src/054-geoapi/main
+++ b/test/src/054-geoapi/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Query Geo-API for server and fallback proxy order"
 cvmfs_test_suites="quick"

--- a/test/src/055-ownership/main
+++ b/test/src/055-ownership/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ownership of files and directories"
 cvmfs_test_suites="quick"

--- a/test/src/056-lowspeedlimit/main
+++ b/test/src/056-lowspeedlimit/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Low speed limit"
 CVMFS_TEST056_MOUNTPOINT=

--- a/test/src/057-parallelmakecache/main
+++ b/test/src/057-parallelmakecache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Concurrent creation of the cache directory"
 cvmfs_test_suites="quick"

--- a/test/src/058-keysdir/main
+++ b/test/src/058-keysdir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="CVMFS_PUBLIC_KEY has precedence over CVMFS_KEYS_DIR"
 cvmfs_test_suites="quick"

--- a/test/src/059-fallbackproxy/main
+++ b/test/src/059-fallbackproxy/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Setting CVMFS_FALLBACK_PROXY"
 cvmfs_test_suites="quick"

--- a/test/src/060-hidexattrs/main
+++ b/test/src/060-hidexattrs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Hide extended attributes"
 cvmfs_test_suites="quick"

--- a/test/src/061-systemdnokill/main
+++ b/test/src/061-systemdnokill/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Mark cvmfs to survive systemd process termination on shutdown"
 cvmfs_test_suites="quick"

--- a/test/src/062-loadtag/main
+++ b/test/src/062-loadtag/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Mount a given repository tag"
 cvmfs_test_suites="quick"

--- a/test/src/063-uidmap/main
+++ b/test/src/063-uidmap/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Uid/Gid Mapping of files and directories"
 cvmfs_test_suites="quick"

--- a/test/src/064-fsck/main
+++ b/test/src/064-fsck/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="cvmfs_config fsck"
 cvmfs_test_suites="quick"

--- a/test/src/065-http-400/main
+++ b/test/src/065-http-400/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Probing host failover on HTTP 400"
 cvmfs_test_suites="quick"

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Killing all cvmfs2 instances"
 cvmfs_test_suites="quick"

--- a/test/src/067-wpad/main
+++ b/test/src/067-wpad/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Proxy auto-discovery"
 cvmfs_test_suites="quick"

--- a/test/src/068-rocache/main
+++ b/test/src/068-rocache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Read-only alien cache"
 cvmfs_test_suites="quick"

--- a/test/src/069-systemremount/main
+++ b/test/src/069-systemremount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="System mount -o remount"
 cvmfs_test_suites="quick"

--- a/test/src/070-tieredcache/main
+++ b/test/src/070-tieredcache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Probing tiered cache"
 

--- a/test/src/071-cvmfsconfiglist/main
+++ b/test/src/071-cvmfsconfiglist/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Check listing repositories in cvmfs_config"
 cvmfs_test_suites="quick"

--- a/test/src/072-mountdevicepath/main
+++ b/test/src/072-mountdevicepath/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Mount a repository that is also a path"
 cvmfs_test_suites="quick"

--- a/test/src/073-rawlink/main
+++ b/test/src/073-rawlink/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Getting rawlink extended attribute"
 cvmfs_test_suites="quick"

--- a/test/src/074-oom/main
+++ b/test/src/074-oom/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Adjust OOM score"
 cvmfs_test_suites="quick"

--- a/test/src/075-reloadenv/main
+++ b/test/src/075-reloadenv/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Reload with tainted environment"
 cvmfs_test_suites="quick"

--- a/test/src/076-mountover/main
+++ b/test/src/076-mountover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Mount over a directory in cvmfs and reload"
 cvmfs_test_suites="quick"

--- a/test/src/077-doublemount/main
+++ b/test/src/077-doublemount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Prevent double mount"
 cvmfs_test_suites="quick"

--- a/test/src/078-offlinemode/main
+++ b/test/src/078-offlinemode/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Offline mode - normal catalog and fixed catalog test"
 cvmfs_test_suites="quick"

--- a/test/src/079-dnsroaming/main
+++ b/test/src/079-dnsroaming/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="DNS roaming"
 cvmfs_test_suites="quick"

--- a/test/src/080-tracing/main
+++ b/test/src/080-tracing/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="tracing"
 cvmfs_test_suites="quick"
 

--- a/test/src/081-shrinkwrap/main
+++ b/test/src/081-shrinkwrap/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="shrinkwrap"
 cvmfs_test_suites="quick"
 

--- a/test/src/082-shrinkwrap-cms/main
+++ b/test/src/082-shrinkwrap-cms/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="shrinkwrap as a normal user"
 cvmfs_test_suites="quick"
 

--- a/test/src/083-suid/main
+++ b/test/src/083-suid/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Run suid binaries"
 cvmfs_test_suites="quick"

--- a/test/src/084-premounted/main
+++ b/test/src/084-premounted/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Pre-mounted startup"
 cvmfs_test_suites="quick"

--- a/test/src/084-traversesft/main
+++ b/test/src/084-traversesft/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Traverse sft.cern.ch with normal-size cache"
 

--- a/test/src/085-reloadmany/main
+++ b/test/src/085-reloadmany/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Repository reload stress test"
 

--- a/test/src/086-reloadmanualmount/main
+++ b/test/src/086-reloadmanualmount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Repository reload with config repository and manual mount"
 cvmfs_test_suites="quick"

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Test magic extended attributes"
 cvmfs_test_suites="quick"
 

--- a/test/src/088-watchdog/main
+++ b/test/src/088-watchdog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Die on watchdog abort"
 cvmfs_test_suites="quick"

--- a/test/src/089-external_cache_plugin/main
+++ b/test/src/089-external_cache_plugin/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Test CVMFS with external cache plugins"
 cvmfs_test_suites="quick"

--- a/test/src/090-talkchroot/main
+++ b/test/src/090-talkchroot/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="cvmfs_talk chroot"
 cvmfs_test_suites="quick"

--- a/test/src/091-defaultconfigrepo/main
+++ b/test/src/091-defaultconfigrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="default config repository"
 cvmfs_test_suites="quick"
 

--- a/test/src/091-talksocket/main
+++ b/test/src/091-talksocket/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Common cvmfs_talk socket"
 cvmfs_test_suites="quick"

--- a/test/src/092-stat/main
+++ b/test/src/092-stat/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Reporting in cvmfs_config stat"
 cvmfs_test_suites="quick"
 

--- a/test/src/093-deviceid/main
+++ b/test/src/093-deviceid/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Report device id"
 cvmfs_test_suites="quick"
 

--- a/test/src/094-attachmount/main
+++ b/test/src/094-attachmount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Attach mount to a 'zombie' fuse module"
 cvmfs_test_suites="quick"
 # We disable autofs for this test to get the output from the mount helper

--- a/test/src/095-fuser/main
+++ b/test/src/095-fuser/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Using cvmfs_config fuser to find processes accessing a repository"
 cvmfs_test_suites="quick"

--- a/test/src/096-cancelreq/main
+++ b/test/src/096-cancelreq/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Cancel file system request"
 cvmfs_test_suites="quick"

--- a/test/src/097-statfs/main
+++ b/test/src/097-statfs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Statfs"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/097-statfs/setup_teardown
+++ b/test/src/097-statfs/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 test097_mount() {
   local repo=$1
   local params=$2

--- a/test/src/098-telemetry/main
+++ b/test/src/098-telemetry/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Telemetry Aggregator: Influx"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/098-telemetry/setup_teardown
+++ b/test/src/098-telemetry/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 test098_mount() {
   local repo=$1
   local params=$2

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="HTTP Tracing with Custom Headers"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/099-http_tracing/setup_teardown
+++ b/test/src/099-http_tracing/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 cleanup() {
   echo "cleanup $cvmfs_test_name"
   if [ "x$CVMFS_TEST_099_TMPFILE" != "x" ]; then

--- a/test/src/100-reload-switch-debug/main
+++ b/test/src/100-reload-switch-debug/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Switch between debug and normal mode during cvmfs reload"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/100-reload-switch-debug/setup_teardown
+++ b/test/src/100-reload-switch-debug/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 cleanup() {
   echo "cleanup $cvmfs_test_name"
   if [ "x$CVMFS_TEST_100_TMPFILE" != "x" ]; then

--- a/test/src/101-cpuaffinity/main
+++ b/test/src/101-cpuaffinity/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 #
 # Test CVMFS_CPU_AFFINITY parameter to pin the cvmfs client to certain cores

--- a/test/src/400-ducc-ingest_images/main
+++ b/test/src/400-ducc-ingest_images/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="DUCC container ingestion"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="ducc"

--- a/test/src/401-ducc-convert_singularity/main
+++ b/test/src/401-ducc-convert_singularity/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="DUCC singularity image conversion"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="ducc"

--- a/test/src/402-ducc-ingest-temp-dir/main
+++ b/test/src/402-ducc-ingest-temp-dir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="DUCC container ingestion"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="ducc"

--- a/test/src/403-ducc-star/main
+++ b/test/src/403-ducc-star/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="DUCC container ingestion"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="ducc"

--- a/test/src/404-ducc-ingest_single_image_thin/main
+++ b/test/src/404-ducc-ingest_single_image_thin/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="DUCC singularity image conversion thin image"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="ducc"

--- a/test/src/405-ducc-convert-podman/main
+++ b/test/src/405-ducc-convert-podman/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="DUCC podman image conversion"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="ducc"

--- a/test/src/406-ducc-webhook-notifications/main
+++ b/test/src/406-ducc-webhook-notifications/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Webhook notifications test"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Populate Repository"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/501-changerepo/main
+++ b/test/src/501-changerepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Change Repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/502-deleteemptydir/main
+++ b/test/src/502-deleteemptydir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Delete Empty Directory"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/503-deletedirrecursive/main
+++ b/test/src/503-deletedirrecursive/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Delete Directory Recursive"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/504-opaquedir/main
+++ b/test/src/504-opaquedir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Delete and Recreate Directory"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/505-createnested/main
+++ b/test/src/505-createnested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Create Nested Catalog in Directory Tree"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/506-removenested/main
+++ b/test/src/506-removenested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Delete Nested Catalog (Merge into Parent)"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/507-removeintermediatenested/main
+++ b/test/src/507-removeintermediatenested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Remove Intermediate Nested Catalog"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/508-cvmfsdevelopment/main
+++ b/test/src/508-cvmfsdevelopment/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Simulate CVMFS Development"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/509-symlinkindirectory/main
+++ b/test/src/509-symlinkindirectory/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Creating Symlinks in Directory"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/510-filechunks/main
+++ b/test/src/510-filechunks/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Creating File Chunks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/511-removefilechunks/main
+++ b/test/src/511-removefilechunks/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Remove Chunked File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/512-movechunkstonested/main
+++ b/test/src/512-movechunkstonested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Move Chunked File To Nested Catalog"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/513-mergechunksfromnested/main
+++ b/test/src/513-mergechunksfromnested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Merge Nested Catalog Containing Chunked File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Change a Chunked File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/515-createsnapshot/main
+++ b/test/src/515-createsnapshot/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create Stratum1 snapshot"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create Stratum1 snapshot with nested Catalogs and Chunked Files"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/517-touchnested/main
+++ b/test/src/517-touchnested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Touch a Nested Catalog"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/518-hardlinkstresstest/main
+++ b/test/src/518-hardlinkstresstest/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Hardlinks"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/519-importlegacyrepo/main
+++ b/test/src/519-importlegacyrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Import Legacy Repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/520-history/main
+++ b/test/src/520-history/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="History"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create a Series of Stratum1 snapshots"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/522-missingchunkfailover/main
+++ b/test/src/522-missingchunkfailover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="404 on Data Chunk"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/523-corruptchunkfailover/main
+++ b/test/src/523-corruptchunkfailover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Data Corruption in Data Chunk"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/524-corruptmanifestfailover/main
+++ b/test/src/524-corruptmanifestfailover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Data Corruption in Whitelist or Manifest"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/525-bigrepo/main
+++ b/test/src/525-bigrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Split a Huge Repository into Nested Catalogs"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/526-recreatenested/main
+++ b/test/src/526-recreatenested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Recreate nested catalog tree"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/527-publishretval/main
+++ b/test/src/527-publishretval/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Non zero return value on failed publish"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/528-recreatespoolarea/main
+++ b/test/src/528-recreatespoolarea/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Recreate Repository Spool Area"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/529-ripemd160/main
+++ b/test/src/529-ripemd160/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create RIPEMD160 repository"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/530-recreatespoolarea_defaultkey/main
+++ b/test/src/530-recreatespoolarea_defaultkey/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Recreate Repository Spool Area (Default Key Location)"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/531-replacefilebydir/main
+++ b/test/src/531-replacefilebydir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Replace Symlink/Regular File by Directory"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/532-replacedirbyfile/main
+++ b/test/src/532-replacedirbyfile/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Replace Directory by Symlink/Regular File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/533-volatilecacheset/main
+++ b/test/src/533-volatilecacheset/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Volatile cache set"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/534-interleavingpublishes/main
+++ b/test/src/534-interleavingpublishes/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Prevent Interleaving Publish Operations"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/535-letter/main
+++ b/test/src/535-letter/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Send and Receive Letters"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/536-healthcheck/main
+++ b/test/src/536-healthcheck/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository Health Check (Disabled Auto-Repair)"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Backend In Symlinked Directory"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/538-symlinkedstratum1backend/main
+++ b/test/src/538-symlinkedstratum1backend/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create Stratum1 Snapshot In Symlinked Backend"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/539-symlinkedvarspoolcvmfs/main
+++ b/test/src/539-symlinkedvarspoolcvmfs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Use CernVM-FS Backend with Symlinked /var/spool/cvmfs"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/540-rootcvmfscatalog/main
+++ b/test/src/540-rootcvmfscatalog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Forbid .cvmfscatalog in root directory"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/541-preloadcache/main
+++ b/test/src/541-preloadcache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Preload cache"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/542-storagescrubbing/main
+++ b/test/src/542-storagescrubbing/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Local File Backend Health Check"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/543-storagescrubbing_scriptable/main
+++ b/test/src/543-storagescrubbing_scriptable/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Local File Backend Health Check (Machine Readable)"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/544-cvmfsdirtab/main
+++ b/test/src/544-cvmfsdirtab/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Manage Nested Catalogs Using .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/545-hugecatalogwarning/main
+++ b/test/src/545-hugecatalogwarning/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Warn on Huge Catalog Creation"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/546-extendeddirtab/main
+++ b/test/src/546-extendeddirtab/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Advanced Nested Catalogs Managagement Using .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/547-createintermediatenested/main
+++ b/test/src/547-createintermediatenested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Create Intermediate Nested Catalog"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/548-createintermediatenested2/main
+++ b/test/src/548-createintermediatenested2/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Create Intermediate Nested Catalog (2)"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/549-dirtabexclusions/main
+++ b/test/src/549-dirtabexclusions/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Exclusion Patterns in .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/550-livemigration/main
+++ b/test/src/550-livemigration/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Migrating CernVM-FS 2.0 Repository to 2.1.x"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/551-openfds/main
+++ b/test/src/551-openfds/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Publish with open file descriptors"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/552-repodate/main
+++ b/test/src/552-repodate/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Access repository tags by date"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/553-defragcatalog/main
+++ b/test/src/553-defragcatalog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Defragment due to Free Database Pages"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/554-defragcatalogrowid/main
+++ b/test/src/554-defragcatalogrowid/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Defragment due to Wasted Row IDs"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/555-manualrevision/main
+++ b/test/src/555-manualrevision/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Manually Setting the Repository Revision Number"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/556-customupstream/main
+++ b/test/src/556-customupstream/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create Stratum0/Stratum1 with custom Upstream String"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Basic Garbage Collection"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/558-garbagecollectnestedcatalogs/main
+++ b/test/src/558-garbagecollectnestedcatalogs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection With Nested Catalogs"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/559-garbagecollectnamedtags/main
+++ b/test/src/559-garbagecollectnamedtags/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection With Named Tag Awareness"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/560-garbagecollectpreservehistory/main
+++ b/test/src/560-garbagecollectpreservehistory/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection With Partial History Preservation"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/561-garbagecollectmultihash/main
+++ b/test/src/561-garbagecollectmultihash/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection With Multiple Hash Algorithms"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/562-aufsexdevrename/main
+++ b/test/src/562-aufsexdevrename/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Rename Cross-Branch Directory in AUFS (exdev)"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection After Legacy Repository Import"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/564-stratum1keysdir/main
+++ b/test/src/564-stratum1keysdir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Use keys directory on stratum 1"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/565-dirtabwildcardexclusions/main
+++ b/test/src/565-dirtabwildcardexclusions/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Exclusion Patterns With Wildcards in .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/566-dirtabrecreatenested/main
+++ b/test/src/566-dirtabrecreatenested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Recreate Manually Deleted Nested Catalog with .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/567-mkfswithlegacykeys/main
+++ b/test/src/567-mkfswithlegacykeys/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create Repository with Provided Keychain"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/568-migratecorruptrepo/main
+++ b/test/src/568-migratecorruptrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Import Corrupt Legacy Repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/569-nonzeroreturncode/main
+++ b/test/src/569-nonzeroreturncode/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Non-Zero Return Code on Failing Repo-Management Commands"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/570-remountrace/main
+++ b/test/src/570-remountrace/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Handle Races of Publish Remount and File Descriptors"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/571-localbackendumask/main
+++ b/test/src/571-localbackendumask/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Local Backend File Permissions with umask"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/572-proxyfailover/main
+++ b/test/src/572-proxyfailover/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Proxy Failover Scenarios"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/573-garbagecollecttimestamp/main
+++ b/test/src/573-garbagecollecttimestamp/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection Until Specified Timestamp"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/574-garbagecollecttimestampwithtags/main
+++ b/test/src/574-garbagecollecttimestampwithtags/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection Until Specified Timestamp With Named Snapshots"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/575-disablegarbagecollection/main
+++ b/test/src/575-disablegarbagecollection/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Disable Garbage Collection"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collection on Replication Server"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Find Intermediate Revisions after Garbage Collection on Stratum0"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/578-automaticgarbagecollection/main
+++ b/test/src/578-automaticgarbagecollection/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Automatic Garbage Collection"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/579-garbagecollectstratum1legacytag/main
+++ b/test/src/579-garbagecollectstratum1legacytag/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Garbage Collect Orphaned Named Snapshots on Stratum1"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/580-automaticgarbagecollectionstratum1/main
+++ b/test/src/580-automaticgarbagecollectionstratum1/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Automatic Garbage Collection on Stratum 1"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/581-snapshotgarbagecollectedrepo/main
+++ b/test/src/581-snapshotgarbagecollectedrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Replicate Garbage Collected Repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/582-autorepairmountpoints/main
+++ b/test/src/582-autorepairmountpoints/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Auto-Repair Bogus Mountpoints"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/583-httpredirects/main
+++ b/test/src/583-httpredirects/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Mounting repo with http redirects"
 
 cvmfs_run_test() {

--- a/test/src/584-interleavingsnapshot/main
+++ b/test/src/584-interleavingsnapshot/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Interleaving Stratum1 Snapshot Behaviour"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/585-xattrs/main
+++ b/test/src/585-xattrs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Extended attributes"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/586-dirtabslashasterisk/main
+++ b/test/src/586-dirtabslashasterisk/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Slash-Asterisk Rule in .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/587-serverhooks/main
+++ b/test/src/587-serverhooks/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Server Hooks"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/589-catalogchown/main
+++ b/test/src/589-catalogchown/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Map UID and GID in Repository on Catalog Level"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/590-manydirectories/main
+++ b/test/src/590-manydirectories/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Publish Many Directories"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/591-importrepo/main
+++ b/test/src/591-importrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Import Contemporary Repository"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/592-magicsymlinks/main
+++ b/test/src/592-magicsymlinks/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Magic Symlinks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/593-nestedwhiteout/main
+++ b/test/src/593-nestedwhiteout/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Rename of Directory containing Changes"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/594-backendoverwrite/main
+++ b/test/src/594-backendoverwrite/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Backend File Overwrite Behaviour"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Update GeoIP Database"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/596-catalogbalancer/main
+++ b/test/src/596-catalogbalancer/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Catalog balancer"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/597-graft/main
+++ b/test/src/597-graft/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Grafting"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/598-partialpreload/main
+++ b/test/src/598-partialpreload/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Partial preload"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/599-removehardlinks/main
+++ b/test/src/599-removehardlinks/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Remove Hardlinks From Legacy Repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Test CVMFS over HTTPS with VOMS authentication"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/601-shake128/main
+++ b/test/src/601-shake128/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create SHAKE128 repository"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/602-libcvmfs/main
+++ b/test/src/602-libcvmfs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Libcvmfs test"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/603-automaticgarbagecollectionrace/main
+++ b/test/src/603-automaticgarbagecollectionrace/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Automatic Garbage Collection Preserves Re-added Objects"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/604-cvmfsrsync/main
+++ b/test/src/604-cvmfsrsync/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Sync files into a repository using cvmfs_rsync"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/605-resurrectancientcatalog/main
+++ b/test/src/605-resurrectancientcatalog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Avoid Resurrection of Legacy Catalog via Rollback"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/606-graftutil/main
+++ b/test/src/606-graftutil/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Graft creation"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/607-noapache/main
+++ b/test/src/607-noapache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create Repository (S0 and S1) w/o Apache"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/608-infofile/main
+++ b/test/src/608-infofile/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository info JSON file"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/609-metainfofile/main
+++ b/test/src/609-metainfofile/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Stratum meta info JSON file"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Alternative catalog path"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/611-idleclient/main
+++ b/test/src/611-idleclient/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Idle client picking up new catalog version"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/612-setttl/main
+++ b/test/src/612-setttl/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Setting non-standard repository TTL"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/613-subtreecheck/main
+++ b/test/src/613-subtreecheck/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Health Check a Catalog Subtree"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/614-geoservice/main
+++ b/test/src/614-geoservice/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="GeoIP Service"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/615-externaldata/main
+++ b/test/src/615-externaldata/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="External data"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/616-blacklistconfigrepo/main
+++ b/test/src/616-blacklistconfigrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Blacklist in config repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/617-uncompressed/main
+++ b/test/src/617-uncompressed/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Populate repository of uncompressed files"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository meta info JSON file"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/619-dirtabtrim/main
+++ b/test/src/619-dirtabtrim/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Trim white spaces in .cvmfsdirtab"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/620-pullmixedrepo/main
+++ b/test/src/620-pullmixedrepo/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Stratum1 / preloaded snapshot with uncompressed and external files"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/621-snapshotallgcall/main
+++ b/test/src/621-snapshotallgcall/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="cvmfs_server snapshot -a and gc -a"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/622-gracefulrmfs/main
+++ b/test/src/622-gracefulrmfs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Data Preservation when Removing Repository"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/623-pubkeyattr/main
+++ b/test/src/623-pubkeyattr/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Pubkeys xattr"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/624-chunkedexternalgraft/main
+++ b/test/src/624-chunkedexternalgraft/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Chunked, grafted, uncompressed, external files"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/625-loadfailureduringgarbagecollect/main
+++ b/test/src/625-loadfailureduringgarbagecollect/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Detect Catalog Load Failures during Garbage Collection"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/626-cacheexpiry/main
+++ b/test/src/626-cacheexpiry/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="HTTP headers for cache expiry"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/627-reflog/main
+++ b/test/src/627-reflog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Reference Log Handling"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/628-pythonwrappedcvmfsserver/main
+++ b/test/src/628-pythonwrappedcvmfsserver/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Python-wrapped cvmfs_server Invoked Through Crontab"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/629-reflogrecreation/main
+++ b/test/src/629-reflogrecreation/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Missing Reference Log Ignore and On-Demand Recreation"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/631-nestedstresstest/main
+++ b/test/src/631-nestedstresstest/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Create a Plethora of Nested Catalogs"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Test authz helper interface"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/633-changedfiles/main
+++ b/test/src/633-changedfiles/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Test pickup of changed files"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/634-reflogchecksum/main
+++ b/test/src/634-reflogchecksum/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Creation and validation of reflog checksum"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/635-earlynestedcreation/main
+++ b/test/src/635-earlynestedcreation/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Early Creation of Nested Catalogs"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/636-autotagstimespan/main
+++ b/test/src/636-autotagstimespan/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Cleanup outdated repository tags"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/637-gcaux/main
+++ b/test/src/637-gcaux/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Garbage collection of auxiliary objects"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/638-virtualdir/main
+++ b/test/src/638-virtualdir/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Virtual .cvmfs Directory"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Publish special files"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/640-snapshottimespan/main
+++ b/test/src/640-snapshottimespan/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Apply timestamp threshold to replication of gc-enabled repos"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/641-diff/main
+++ b/test/src/641-diff/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Show snapshot change set"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/642-branching/main
+++ b/test/src/642-branching/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Branching off tags"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/643-masterkeycard/main
+++ b/test/src/643-masterkeycard/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="masterkeycard"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/644-nobulkchunk/main
+++ b/test/src/644-nobulkchunk/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Omit bulk chunks"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/645-zerofiles/main
+++ b/test/src/645-zerofiles/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Zero-filled files"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/646-publishlimits/main
+++ b/test/src/646-publishlimits/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Publish limits"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/647-bearercvmfs/main
+++ b/test/src/647-bearercvmfs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 #!/bin/sh -x
 
 cvmfs_test_name="Test CVMFS over HTTPS with HTTP Bearer Authorization"

--- a/test/src/648-variantsymlink/main
+++ b/test/src/648-variantsymlink/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Variant symlinks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/649-zeropermission/main
+++ b/test/src/649-zeropermission/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Publish files that forbid being read"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/650-heavyabort/main
+++ b/test/src/650-heavyabort/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Abort after filling temporary area"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/651-gctimespan/main
+++ b/test/src/651-gctimespan/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Garbage collect idle repositories"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest tarball to various subdirectories in the repository"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/653-tarball_ingest_from_stdin/main
+++ b/test/src/653-tarball_ingest_from_stdin/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest tarball in a repo from STDIN"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest weird and complex files"
 cvmfs_test_suites="quick"

--- a/test/src/655-tarball_multiple_ingest_same_location/main
+++ b/test/src/655-tarball_multiple_ingest_same_location/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest same tarball in same location multiple times"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/656-tarball_remove_directory/main
+++ b/test/src/656-tarball_remove_directory/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest tarball in a repo and while removing files"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/657-tarball_remove_base_directory/main
+++ b/test/src/657-tarball_remove_base_directory/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest tarball in a repo and while removing base-dir's"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/658-tarball_ingest_catalogs/main
+++ b/test/src/658-tarball_ingest_catalogs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest special files with nested catalog"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/659-tarball_ingest_in_root/main
+++ b/test/src/659-tarball_ingest_in_root/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Ingest tarball in a repository root"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/660-store_publish_statistics/main
+++ b/test/src/660-store_publish_statistics/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file contains $NR_OF_TESTS tests for checking the store publish statistics feature (checking the database integrity)
 cvmfs_test_name="Store publish statistics in a SQLite database"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file
 cvmfs_test_name="Gather garbage collector statistics"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/662-merge_stats_tool/main
+++ b/test/src/662-merge_stats_tool/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file contains $NR_OF_TESTS tests for checking the store publish statistics feature (checking the database integrity)
 cvmfs_test_name="Merge two database files"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/663-print_publish_statistics/main
+++ b/test/src/663-print_publish_statistics/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file contains $NR_OF_TESTS tests for checking the print publish statistics feature
 cvmfs_test_name="Print publish statistics"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/664-manysmallcatalogs/main
+++ b/test/src/664-manysmallcatalogs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Handling of many small catalogs"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/665-cleanupbigfile/main
+++ b/test/src/665-cleanupbigfile/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Cache cleanup for large chunks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/666-ingestownership/main
+++ b/test/src/666-ingestownership/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Tarball ingest: modify ownership"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/667-ingestnested/main
+++ b/test/src/667-ingestnested/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Ingest tarball on deeply nested catalog structure"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/668-nfschunkinodes/main
+++ b/test/src/668-nfschunkinodes/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="Test inodes of chunked files in NFS mode"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/669-filestats/main
+++ b/test/src/669-filestats/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Swissknife filestats feature"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/670-listreflog/main
+++ b/test/src/670-listreflog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Swissknife list_reflog feature"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/671-stats_db_upgrade/main
+++ b/test/src/671-stats_db_upgrade/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Upgrade statistics database schema"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/672-publish_stats_hardlinks/main
+++ b/test/src/672-publish_stats_hardlinks/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Store publish statistics in a SQLite database - hardlinks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/673-acl/main
+++ b/test/src/673-acl/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="POSIX ACLs"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/674-alienupdate/main
+++ b/test/src/674-alienupdate/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Apply updates on shared alien cache"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/675-statsupload/main
+++ b/test/src/675-statsupload/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Upload stats.db into upstream storage"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/676-deepnestedcatalogs/main
+++ b/test/src/676-deepnestedcatalogs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Optimized loading of deeply nested catalogs"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/677-removebulkhashes/main
+++ b/test/src/677-removebulkhashes/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Remove Redundant Bulk Hashes"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/678-preloadautoupdate/main
+++ b/test/src/678-preloadautoupdate/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Apply updated catalog from preloaded cache"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/678-templatetxn/main
+++ b/test/src/678-templatetxn/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Template transaction"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/679-migratemanifest/main
+++ b/test/src/679-migratemanifest/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Ensure healthy manifest after catalog migration"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/680-migratestats/main
+++ b/test/src/680-migratestats/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="fix-up catalog statistics"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/681-nonregularfile_cvmfscatalog/main
+++ b/test/src/681-nonregularfile_cvmfscatalog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="check that the .cvmfscatalog file is a regular file"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/682-enter/main
+++ b/test/src/682-enter/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Enter ephemeral writable subshell"
 cvmfs_test_autofs_on_startup=true
 cvmfs_test_suites="quick"

--- a/test/src/682-printchangeset/main
+++ b/test/src/682-printchangeset/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="PrintChangesetNotice prints"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/683-diffworktree/main
+++ b/test/src/683-diffworktree/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Set base hash in diff command"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/684-cvmfsbundles/main
+++ b/test/src/684-cvmfsbundles/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="cvmfsbundles"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/684-https_s3/main
+++ b/test/src/684-https_s3/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Test for running CVMFS agains a HTTPS S3 implementation
 #

--- a/test/src/685-mkfs_proxy/main
+++ b/test/src/685-mkfs_proxy/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Create repository with a server-side proxy"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/686-azureblob_s3/main
+++ b/test/src/686-azureblob_s3/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Test for running CVMFS against an Azure S3 implementation
 #

--- a/test/src/687-import_s3/main
+++ b/test/src/687-import_s3/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Test for running CVMFS against an Azure S3 implementation
 #

--- a/test/src/688-checkall/main
+++ b/test/src/688-checkall/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="cvmfs_server check -a"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/689-inodes/main
+++ b/test/src/689-inodes/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Corner cases for inode handling"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Streaming cache manager"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/699-servermount/main
+++ b/test/src/699-servermount/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Server Infrastructure Mounting"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 cvmfs_test_name="OverlayFS Validation"
 cvmfs_test_autofs_on_startup=false

--- a/test/src/701-xattr-catalog_counters/main
+++ b/test/src/701-xattr-catalog_counters/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Extended attribute: catalog_counters"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/701-xattr-catalog_counters/setup_teardown
+++ b/test/src/701-xattr-catalog_counters/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 create_nested_repo() {
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/src/702-symlink_caching/main
+++ b/test/src/702-symlink_caching/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Symlink caching and dentry eviction: Proper eviction policy for kernel cache"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/702-symlink_caching/setup_teardown
+++ b/test/src/702-symlink_caching/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 create_symlink_repo() {
   echo ""
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"

--- a/test/src/703-catalog_mgr_client/main
+++ b/test/src/703-catalog_mgr_client/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Catalog_mgr_client: LoadCatalog tests"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/703-catalog_mgr_client/setup_teardown
+++ b/test/src/703-catalog_mgr_client/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 create_nested_repo() {
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/src/704-world_readable/main
+++ b/test/src/704-world_readable/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="World readable repository access"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/704-world_readable/setup_teardown
+++ b/test/src/704-world_readable/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 create_world_readable_repo() {
   echo ""
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"

--- a/test/src/705-evict/main
+++ b/test/src/705-evict/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Evict chunks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/705-evict/setup_teardown
+++ b/test/src/705-evict/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 create_evict_repo() {
   echo ""
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"

--- a/test/src/707-breadcrumb_no_revision/main
+++ b/test/src/707-breadcrumb_no_revision/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Breadcrumb: Different scenarios with missing revision"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/707-breadcrumb_no_revision/setup_teardown
+++ b/test/src/707-breadcrumb_no_revision/setup_teardown
@@ -1,3 +1,4 @@
+#!/bin/bash
 create_nested_repo() {
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/801-repository_gateway_slow/main
+++ b/test/src/801-repository_gateway_slow/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway Slow"
 cvmfs_test_autofs_on_startup=false
 

--- a/test/src/802-repository_gateway_nested_catalogs/main
+++ b/test/src/802-repository_gateway_nested_catalogs/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway nested catalogs"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/803-repository_gateway_large_files/main
+++ b/test/src/803-repository_gateway_large_files/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway large files"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/804-repository_gateway_autotags/main
+++ b/test/src/804-repository_gateway_autotags/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway autotags"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/805-repository_gateway_reflog/main
+++ b/test/src/805-repository_gateway_reflog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway - missing reflog"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/806-repository_gateway_ingest/main
+++ b/test/src/806-repository_gateway_ingest/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Ingesting into repository gateway"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/807-nested_new_directories_gateway_ingest/main
+++ b/test/src/807-nested_new_directories_gateway_ingest/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway lease on non-existing directory"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/808-repository-gateway_watchdog/main
+++ b/test/src/808-repository-gateway_watchdog/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway - receiver watchdog"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/809-lease_failure/main
+++ b/test/src/809-lease_failure/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Test for the cvmfs_server transaction command returns codes
 #

--- a/test/src/810-reposity_gateway_dir_to_symlink/main
+++ b/test/src/810-reposity_gateway_dir_to_symlink/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway moving from directory to symlink with catalog"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/811-commit-gateway/main
+++ b/test/src/811-commit-gateway/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Commit command in a repository connected to the gateway"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/811-repository_gateway_graft/main
+++ b/test/src/811-repository_gateway_graft/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Grafted files via gateway"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/812-repository_gateway_uncompressed/main
+++ b/test/src/812-repository_gateway_uncompressed/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Uncompressed files via gateway"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/813-repository_gateway_convoluted/main
+++ b/test/src/813-repository_gateway_convoluted/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Repository gateway convoluted setups"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/814-expired_lease/main
+++ b/test/src/814-expired_lease/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Automatic cleanup when a lease has expired"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/815-gateway_restart/main
+++ b/test/src/815-gateway_restart/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Active leases survive gateway restart"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/816-gateway_uncompressed/main
+++ b/test/src/816-gateway_uncompressed/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Tests publication of uncompressed files through the gateway.
 # Catalogs should remain zlib compressed.

--- a/test/src/817-gateway_abort/main
+++ b/test/src/817-gateway_abort/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Lease cleanup when the publishing process aborts on the gateway"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/src/900-notification_system/main
+++ b/test/src/900-notification_system/main
@@ -1,3 +1,4 @@
+#!/bin/bash
 cvmfs_test_name="Notification system"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"

--- a/test/test_functions
+++ b/test/test_functions
@@ -1,3 +1,4 @@
+#!/bin/bash
 # By default, this script runs in testing mode
 # Although it allows for a server debugging mode, which attaches gdb to
 # the `cvmfs_server publish` process and allows for both online and


### PR DESCRIPTION
This is a purely decorative change, in the sense that it should have no effect on any functionality, but fixes syntax highlighting. Since the integration test scripts have no .sh suffix, most editors will display them as text files, in particular also the github web page renders them in this not-very-readable way (VSCode manages to infer that it's a script).

Adding a #!/bin/bash throughout seemed the easiest way of fixing this (adding a .sh suffix means changing a bunch more scripts) - it may be slightly confusing because none of these scripts are executed (all of them are sourced, which ignores the #!/bin/bash, and then cvmfs_run_test() is run by another script), but it provides enough of a hint to editors to make them more readable.

I also take the opportunity to harmonize file permissions on the main scripts - a few of them had +x set, I've removed this for all of them.