### PR TITLE
Fix a few Log2Histogram bugs

### DIFF
--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -2102,6 +2102,9 @@ TEST(Log2Histogram, 2BinEmpty) {
   for (int i = 0; i < 3; i++) {
     EXPECT_EQ(res[i], atomic_read32(&bins[i]));
   }
+
+  unsigned int q = log2hist.GetQuantile(0.5);
+  EXPECT_EQ(q, 4U);
 }
 
 TEST(Log2Histogram, 2Bins) {


### PR DESCRIPTION
This fixes an infinite loop overrun in `Log2Histogram::GetQuantile()`. This also adds a case when the quantile cannot be satisfied and returns the last boundary. Finally, 0 was being in a log function which in certain circumstances resulted in an incorrect result.

I believe we may have hit this bug a few times in the past. It will surface when using `cvmfs_talk` and can result in either wrong data or worse a segfault and crash. We experienced the latter. I added a simple test case to `Log2Histogram.2BinEmpty` exposing this.

These bugs came to surface because I spent a bit of time enhancing the logic for Histograms. In particular, the "Log2" method currently used favors buckets on the lower end of the histogram. For example, the latency histograms have approx 16 buckets for timings between 0s and 100us but only 5 for times greater than 100ms. So what I did was make the histogram range configurable and then dynamically generate higher order logarithmic based buckets for that range. For the latencies histograms, I then configured the range to be 100us to 20s with 64 buckets and that gave us a good granularity for the latency metrics. I also had to bump up the field widths to 64bit since 32bit maxes out around 2s for these timings.

Anyway, if you are interested in this enhancement, I can PR it as well. It doesnt break anything and keeps the boundary arrays intact, just with different values.