### PR TITLE
Add support for high-precision timestamps

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -656,6 +656,7 @@ if (BUILD_SERVER)
        swissknife_sync.cc
        swissknife_zpipe.cc
        sync_item.cc
+       sync_item_dummy.cc
        sync_item_tar.cc
        sync_mediator.cc
        sync_union.cc
@@ -769,6 +770,7 @@ if (BUILD_SERVER)
        swissknife_assistant.cc
        swissknife_lease_curl.cc
        sync_item.cc
+       sync_item_dummy.cc
        sync_item_tar.cc
        sync_mediator.cc
        sync_union.cc

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -611,10 +611,11 @@ bool SqlDirentWrite::BindDirentFields(const int hash_idx,
     BindText(name_idx, entry.name_.GetChars(), entry.name_.GetLength()) &&
     BindText(symlink_idx, entry.symlink_.GetChars(),
                           entry.symlink_.GetLength());
-  if (entry.HasMtimeNs())
+  if (entry.HasMtimeNs()) {
     result &= BindInt(mtimens_idx, entry.mtime_ns_);
-  else
+  } else {
     result &= BindNull(mtimens_idx);
+  }
 
   return result;
 }
@@ -888,10 +889,11 @@ bool SqlDirentTouch::BindDirentBase(const DirectoryEntryBase &entry) {
     BindText(6, entry.symlink_.GetChars(), entry.symlink_.GetLength()) &&
     BindInt64(7, entry.uid_) &&
     BindInt64(8, entry.gid_);
-  if (entry.HasMtimeNs())
+  if (entry.HasMtimeNs()) {
     result &= BindInt(10, entry.mtime_ns_);
-  else
+  } else {
     result &= BindNull(10);
+  }
   return result;
 }
 

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -608,9 +608,10 @@ bool SqlDirentWrite::BindDirentFields(const int hash_idx,
     BindInt64(gid_idx, entry.gid_) &&
     BindInt64(mtime_idx, entry.mtime_) &&
     BindInt(flags_idx, CreateDatabaseFlags(entry)) &&
-    BindText(name_idx, entry.name_.GetChars(), entry.name_.GetLength()) &&
+    BindText(name_idx, entry.name_.GetChars(),
+                       static_cast<int>(entry.name_.GetLength())) &&
     BindText(symlink_idx, entry.symlink_.GetChars(),
-                          entry.symlink_.GetLength());
+                          static_cast<int>(entry.symlink_.GetLength()));
   if (entry.HasMtimeNs()) {
     result &= BindInt(mtimens_idx, entry.mtime_ns_);
   } else {

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -265,6 +265,7 @@ class SqlDirentWrite : public SqlDirent {
                         const int size_idx,
                         const int mode_idx,
                         const int mtime_idx,
+                        const int mtimens_idx,
                         const int flags_idx,
                         const int name_idx,
                         const int symlink_idx,

--- a/cvmfs/directory_entry.cc
+++ b/cvmfs/directory_entry.cc
@@ -23,7 +23,7 @@ DirectoryEntryBase::Differences DirectoryEntryBase::CompareTo(
   if (mode() != other.mode()) {
     result |= Difference::kMode;
   }
-  if (mtime() != other.mtime()) {
+  if ((mtime() != other.mtime()) || (mtime_ns() != other.mtime_ns())) {
     result |= Difference::kMtime;
   }
   if (symlink() != other.symlink()) {

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -109,6 +109,7 @@ class DirectoryEntryBase {
     , gid_(0)
     , size_(0)
     , mtime_(0)
+    , mtime_ns_(-1)
     , linkcount_(1)  // generally a normal file has linkcount 1 -> default
     , has_xattrs_(false)
     , is_external_file_(false)
@@ -129,12 +130,14 @@ class DirectoryEntryBase {
   inline bool IsExternalFile() const            { return is_external_file_; }
   inline bool IsDirectIo() const                { return is_direct_io_; }
   inline bool HasXattrs() const                 { return has_xattrs_;    }
+  inline bool HasMtimeNs() const                { return mtime_ns_ >= 0; }
 
   inline inode_t inode() const                  { return inode_; }
   inline uint32_t linkcount() const             { return linkcount_; }
   inline NameString name() const                { return name_; }
   inline LinkString symlink() const             { return symlink_; }
   inline time_t mtime() const                   { return mtime_; }
+  inline int32_t mtime_ns() const               { return mtime_ns_; }
   inline unsigned int mode() const              { return mode_; }
   inline uid_t uid() const                      { return uid_; }
   inline gid_t gid() const                      { return gid_; }
@@ -197,6 +200,11 @@ class DirectoryEntryBase {
     s.st_atime = mtime_;
     s.st_mtime = mtime_;
     s.st_ctime = mtime_;
+    if (HasMtimeNs()) {
+      s.st_atim.tv_nsec = mtime_ns_;
+      s.st_mtim.tv_nsec = mtime_ns_;
+      s.st_ctim.tv_nsec = mtime_ns_;
+    }
     return s;
   }
 
@@ -219,6 +227,8 @@ class DirectoryEntryBase {
   gid_t gid_;
   uint64_t size_;
   time_t mtime_;
+  // nanosecond part of the mtime. Only valid if non-negative
+  int32_t mtime_ns_;
   LinkString symlink_;
   uint32_t linkcount_;
   // In order to save memory, we only indicate if a directory entry has custom

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -201,9 +201,15 @@ class DirectoryEntryBase {
     s.st_mtime = mtime_;
     s.st_ctime = mtime_;
     if (HasMtimeNs()) {
+#ifdef __APPLE__
+      s.st_atimespec.tv_nsec = mtime_ns_;
+      s.st_mtimespec.tv_nsec = mtime_ns_;
+      s.st_ctimespec.tv_nsec = mtime_ns_;
+#else
       s.st_atim.tv_nsec = mtime_ns_;
       s.st_mtim.tv_nsec = mtime_ns_;
       s.st_ctim.tv_nsec = mtime_ns_;
+#endif
     }
     return s;
   }

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -87,6 +87,10 @@ void SettingsTransaction::SetEnforceLimits(bool value) {
   enforce_limits_ = value;
 }
 
+void SettingsTransaction::SetEnableMtimeNs(bool value) {
+  enable_mtime_ns_ = value;
+}
+
 void SettingsTransaction::SetLimitNestedCatalogKentries(unsigned value) {
   limit_nested_catalog_kentries_ = value;
 }
@@ -557,6 +561,10 @@ void SettingsBuilder::ApplyOptionsFromServerPath(
   }
   if (options_mgr_.GetValue("CVMFS_ENFORCE_LIMITS", &arg)) {
     settings_publisher->GetTransaction()->SetEnforceLimits(
+        options_mgr_.IsOn(arg));
+  }
+  if (options_mgr_.GetValue("CVMFS_ENABLE_MTIME_NS", &arg)) {
+    settings_publisher->GetTransaction()->SetEnableMtimeNs(
         options_mgr_.IsOn(arg));
   }
   if (options_mgr_.GetValue("CVMFS_NESTED_KCATALOG_LIMIT", &arg)) {

--- a/cvmfs/publish/settings.h
+++ b/cvmfs/publish/settings.h
@@ -166,6 +166,7 @@ class SettingsTransaction {
   void SetHashAlgorithm(const std::string &algorithm);
   void SetCompressionAlgorithm(const std::string &algorithm);
   void SetEnforceLimits(bool value);
+  void SetEnableMtimeNs(bool value);
   void SetLimitNestedCatalogKentries(unsigned value);
   void SetLimitRootCatalogKentries(unsigned value);
   void SetLimitFileSizeMb(unsigned value);
@@ -196,6 +197,7 @@ class SettingsTransaction {
   bool is_garbage_collectable() const { return is_garbage_collectable_(); }
   bool is_volatile() const { return is_volatile_(); }
   bool enforce_limits() const { return enforce_limits_(); }
+  bool enable_mtime_ns() const { return enable_mtime_ns_(); }
   unsigned limit_nested_catalog_kentries() const {
     return limit_nested_catalog_kentries_();
   }
@@ -245,6 +247,7 @@ class SettingsTransaction {
   Setting<bool> is_garbage_collectable_;
   Setting<bool> is_volatile_;
   Setting<bool> enforce_limits_;
+  Setting<bool> enable_mtime_ns_;
   Setting<unsigned> limit_nested_catalog_kentries_;
   Setting<unsigned> limit_root_catalog_kentries_;
   Setting<unsigned> limit_file_size_mb_;

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -287,6 +287,10 @@ cvmfs_server_ingest() {
     ingest_command="$ingest_command -C true"
   fi
 
+  if [ "x$CVMFS_ENABLE_MTIME_NS" = "xtrue" ]; then
+    ingest_command="$ingest_command -j"
+  fi
+
   if [ "x$CVMFS_PRINT_STATISTICS" = "xtrue" ]; then
     ingest_command="$ingest_command -+stats"
   fi

--- a/cvmfs/server/cvmfs_server_publish.sh
+++ b/cvmfs/server/cvmfs_server_publish.sh
@@ -251,6 +251,9 @@ cvmfs_server_publish() {
     if [ "x${CVMFS_ENFORCE_LIMITS:-$CVMFS_DEFAULT_ENFORCE_LIMITS}" = "xtrue" ]; then
       sync_command="$sync_command -E"
     fi
+    if [ "x$CVMFS_ENABLE_MTIME_NS" = "xtrue" ]; then
+      sync_command="$sync_command -j"
+    fi
     if [ "x$CVMFS_NESTED_KCATALOG_LIMIT" != "x" ]; then
       sync_command="$sync_command -Q $CVMFS_NESTED_KCATALOG_LIMIT"
     fi

--- a/cvmfs/sql.h
+++ b/cvmfs/sql.h
@@ -439,6 +439,11 @@ class Sql {
   double RetrieveDouble(const int idx_column) const {
     return sqlite3_column_double(statement_, idx_column);
   }
+  int RetrieveNullableInt(const int idx_column, const int val_null) const {
+    if (sqlite3_column_type(statement_, idx_column) == SQLITE_NULL)
+      return val_null;
+    return sqlite3_column_int(statement_, idx_column);
+  }
   int RetrieveInt(const int idx_column) const {
     return sqlite3_column_int(statement_, idx_column);
   }

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -56,6 +56,9 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   if (args.find('O') != args.end()) {
     params.generate_legacy_bulk_chunks = true;
   }
+  if (args.find('j') != args.end()) {
+    params.enable_mtime_ns = true;
+  }
   shash::Algorithms hash_algorithm = shash::kSha1;
   if (args.find('e') != args.end()) {
     hash_algorithm = shash::ParseHashAlgorithm(*args.find('e')->second);

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -46,7 +46,7 @@ class Ingest : public Command {
           "uid of new owner of the ingested data (-1 for keep tarball owner)"));
     r.push_back(Parameter::Optional('G',
           "gid of new owner of the ingested data (-1 for keep tarball owner)"));
-    r.push_back(Parameter::Optional('j', "enable nanosecond timestamps"));
+    r.push_back(Parameter::Switch('j', "enable nanosecond timestamps"));
 
     return r;
   }

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -46,6 +46,7 @@ class Ingest : public Command {
           "uid of new owner of the ingested data (-1 for keep tarball owner)"));
     r.push_back(Parameter::Optional('G',
           "gid of new owner of the ingested data (-1 for keep tarball owner)"));
+    r.push_back(Parameter::Optional('j', "enable nanosecond timestamps"));
 
     return r;
   }

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -859,7 +859,7 @@ bool CommandMigrate::AbstractMigrationWorker<DerivedT>::CleanupNestedCatalogs(
  * both the catalog management and migration classes get updated.
  */
 const float    CommandMigrate::MigrationWorker_20x::kSchema         = 2.5;
-const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 6;
+const unsigned CommandMigrate::MigrationWorker_20x::kSchemaRevision = 7;
 
 
 template<class DerivedT>
@@ -1106,7 +1106,7 @@ bool CommandMigrate::MigrationWorker_20x::MigrateFileMetadata(
     "         IFNULL(hardlink_group_id, 0) << 32 | "
     "         COALESCE(hardlinks.linkcount, dir_linkcounts.linkcount, 1) "
     "           AS hardlinks, "
-    "         hash, size, mode, mtime, "
+    "         hash, size, mode, mtime, NULL, " // set empty mtimens
     "         flags, name, symlink, "
     "         :uid, "
     "         :gid, "

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -622,6 +622,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   if (args.find('V') != args.end()) params.voms_authz = true;
   if (args.find('F') != args.end()) params.authz_file = *args.find('F')->second;
   if (args.find('k') != args.end()) params.include_xattrs = true;
+  if (args.find('j') != args.end()) params.enable_mtime_ns = true;
   if (args.find('Y') != args.end()) params.external_data = true;
   if (args.find('W') != args.end()) params.direct_io = true;
   if (args.find('S') != args.end()) {

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -255,7 +255,7 @@ class CommandSync : public Command {
     return "Pushes changes from scratch area back to the repository.";
   }
   virtual ParameterList GetParams() const {
-    // unused characters: j, J, 1-9, all special characters but @
+    // unused characters: J, 1-9, all special characters but @
     ParameterList r;
     r.push_back(Parameter::Mandatory('b', "base hash"));
     r.push_back(Parameter::Mandatory('c', "r/o volume"));
@@ -307,6 +307,7 @@ class CommandSync : public Command {
     r.push_back(Parameter::Switch('i', "ignore x-directory hardlinks"));
     r.push_back(Parameter::Switch('g', "ignore special files"));
     r.push_back(Parameter::Switch('k', "include extended attributes"));
+    r.push_back(Parameter::Switch('j', "enable nanosecond timestamps"));
     r.push_back(Parameter::Switch('m', "create micro catalogs"));
     r.push_back(Parameter::Switch('n', "create new repository"));
     r.push_back(Parameter::Switch('p', "enable file chunking"));

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -36,6 +36,7 @@ struct SyncParameters {
         ignore_xdir_hardlinks(false),
         stop_for_catalog_tweaks(false),
         include_xattrs(false),
+        enable_mtime_ns(false),
         external_data(false),
         direct_io(false),
         voms_authz(false),
@@ -88,6 +89,7 @@ struct SyncParameters {
   bool ignore_xdir_hardlinks;
   bool stop_for_catalog_tweaks;
   bool include_xattrs;
+  bool enable_mtime_ns;
   bool external_data;
   bool direct_io;
   bool voms_authz;

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -217,7 +217,8 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
   dirent.size_             = graft_size_ > -1 ? graft_size_ :
                              this->GetUnionStat().st_size;
   dirent.mtime_            = this->GetUnionStat().st_mtime;
-  dirent.mtime_ns_         = this->GetUnionStat().st_mtim.tv_nsec;
+  dirent.mtime_ns_         = static_cast<int32_t>(
+                               this->GetUnionStat().st_mtim.tv_nsec);
   dirent.checksum_         = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.is_direct_io_     = this->IsDirectIo();

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -22,6 +22,8 @@ using namespace std;  // NOLINT
 
 namespace publish {
 
+bool SyncItem::g_enable_mtime_ns = false;
+
 SyncItem::SyncItem() :
   rdonly_type_(static_cast<SyncItemType>(0)),
   graft_size_(-1),
@@ -217,8 +219,6 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
   dirent.size_             = graft_size_ > -1 ? graft_size_ :
                              this->GetUnionStat().st_size;
   dirent.mtime_            = this->GetUnionStat().st_mtime;
-  dirent.mtime_ns_         = static_cast<int32_t>(
-                               this->GetUnionStat().st_mtim.tv_nsec);
   dirent.checksum_         = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.is_direct_io_     = this->IsDirectIo();
@@ -236,6 +236,11 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
 
   if (this->IsCharacterDevice() || this->IsBlockDevice()) {
     dirent.size_ = makedev(GetRdevMajor(), GetRdevMinor());
+  }
+
+  if (g_enable_mtime_ns) {
+    dirent.mtime_ns_ = static_cast<int32_t>(
+      this->GetUnionStat().st_mtim.tv_nsec);
   }
 
   return dirent;

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -217,6 +217,7 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
   dirent.size_             = graft_size_ > -1 ? graft_size_ :
                              this->GetUnionStat().st_size;
   dirent.mtime_            = this->GetUnionStat().st_mtime;
+  dirent.mtime_ns_         = this->GetUnionStat().st_mtim.tv_nsec;
   dirent.checksum_         = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.is_direct_io_     = this->IsDirectIo();

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -239,8 +239,13 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent(
   }
 
   if (enable_mtime_ns) {
+#ifdef __APPLE__
+    dirent.mtime_ns_ = static_cast<int32_t>(
+      this->GetUnionStat().st_mtimespec.tv_nsec);
+#else
     dirent.mtime_ns_ = static_cast<int32_t>(
       this->GetUnionStat().st_mtim.tv_nsec);
+#endif
   }
 
   return dirent;

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -22,8 +22,6 @@ using namespace std;  // NOLINT
 
 namespace publish {
 
-bool SyncItem::g_enable_mtime_ns = false;
-
 SyncItem::SyncItem() :
   rdonly_type_(static_cast<SyncItemType>(0)),
   graft_size_(-1),
@@ -203,7 +201,9 @@ void SyncItem::StatGeneric(const string  &path,
 }
 
 
-catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
+catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent(
+  bool enable_mtime_ns) const
+{
   catalog::DirectoryEntryBase dirent;
 
   // inode and parent inode is determined at runtime of client
@@ -238,7 +238,7 @@ catalog::DirectoryEntryBase SyncItemNative::CreateBasicCatalogDirent() const {
     dirent.size_ = makedev(GetRdevMajor(), GetRdevMinor());
   }
 
-  if (g_enable_mtime_ns) {
+  if (enable_mtime_ns) {
     dirent.mtime_ns_ = static_cast<int32_t>(
       this->GetUnionStat().st_mtim.tv_nsec);
   }

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -58,19 +58,6 @@ class SyncItem {
   // SyncUnionTarball can create SyncItemTar and SyncItemDummyDir.
 
  public:
-  /**
-   * Publishing can globally turn on/off support for nanosecond timestamps.
-   * If turned off, directory entries from the changeset will have the
-   * ns timestamp unset (-1), and as a result the corresponding value in the
-   * catalog will be set to NULL. False by default.
-   *
-   * TODO(jblomer): once we have support for multiple paralle publish context
-   * within the same process, using libcvmfs_server, we need a more
-   * sophisticated mechanism than a global toggle for this setting.
-   * For the moment, it is simple and effective.
-   */
-  static bool g_enable_mtime_ns;
-
   SyncItem();
   virtual ~SyncItem();
 
@@ -149,9 +136,15 @@ class SyncItem {
    * Generates a DirectoryEntry that can be directly stored into a catalog db.
    * Note: this sets the inode fields to kInvalidInode as well as the link
    *       count to 1 if MaskHardlink() has been called before (cf. OverlayFS)
+   *
+   * If nanosecond timestamps are off, the directory entry will have a
+   * default initialized, negative nanosecond timestamp and as a result
+   * the corresponding field in the catalog table will be NULL.
+   *
    * @return  a DirectoryEntry structure to be written into a catalog
    */
-  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent() const = 0;
+  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent(
+    bool enable_mtime_ns) const = 0;
 
   inline std::string GetRelativePath() const {
     return (relative_parent_path_.empty()) ?
@@ -336,7 +329,8 @@ typedef std::map<std::string, SharedPtr<SyncItem> > SyncItemList;
 
 class SyncItemNative : public SyncItem {
   friend class SyncUnion;
-  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
+  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent(
+    bool enable_mtime_ns) const;
   virtual IngestionSource *CreateIngestionSource() const;
   virtual void MakePlaceholderDirectory() const { assert(false); }
   virtual SyncItemType GetScratchFiletype() const;

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -58,6 +58,19 @@ class SyncItem {
   // SyncUnionTarball can create SyncItemTar and SyncItemDummyDir.
 
  public:
+  /**
+   * Publishing can globally turn on/off support for nanosecond timestamps.
+   * If turned off, directory entries from the changeset will have the
+   * ns timestamp unset (-1), and as a result the corresponding value in the
+   * catalog will be set to NULL. False by default.
+   *
+   * TODO(jblomer): once we have support for multiple paralle publish context
+   * within the same process, using libcvmfs_server, we need a more
+   * sophisticated mechanism than a global toggle for this setting.
+   * For the moment, it is simple and effective.
+   */
+  static bool g_enable_mtime_ns;
+
   SyncItem();
   virtual ~SyncItem();
 

--- a/cvmfs/sync_item_dummy.cc
+++ b/cvmfs/sync_item_dummy.cc
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the CernVM File System
+ */
+
+#include "sync_item_dummy.h"
+
+#include <cassert>
+#include <ctime>
+
+namespace publish {
+
+catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent(
+  bool /* enable_mtime_ns */) const
+{
+  catalog::DirectoryEntryBase dirent;
+
+  dirent.inode_ = catalog::DirectoryEntry::kInvalidInode;
+
+  dirent.linkcount_ = 1;
+
+  dirent.mode_ = kPermision;
+
+  dirent.uid_ = scratch_stat_.stat.st_uid;
+  dirent.gid_ = scratch_stat_.stat.st_gid;
+  dirent.size_ = 4096;
+  dirent.mtime_ = time(NULL);
+  dirent.checksum_ = this->GetContentHash();
+  dirent.is_external_file_ = this->IsExternalData();
+  dirent.compression_algorithm_ = this->GetCompressionAlgorithm();
+
+  dirent.name_.Assign(this->filename().data(), this->filename().length());
+
+  assert(dirent.IsDirectory());
+
+  return dirent;
+}
+
+
+SyncItemType SyncItemDummyDir::GetScratchFiletype() const {
+  return kItemDir;
+}
+
+}  // namespace publish

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -29,7 +29,9 @@ class SyncItemDummyCatalog : public SyncItem {
     return expected_type == kItemFile;
   }
 
-  catalog::DirectoryEntryBase CreateBasicCatalogDirent() const {
+  catalog::DirectoryEntryBase CreateBasicCatalogDirent(
+    bool /* enable_mtime_ns */) const
+  {
     catalog::DirectoryEntryBase dirent;
     std::string name(".cvmfscatalog");
     dirent.inode_ = catalog::DirectoryEntry::kInvalidInode;

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -72,7 +72,8 @@ class SyncItemDummyDir : public SyncItemNative {
   friend class SyncUnionTarball;
 
  public:
-  catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
+  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent(
+    bool enable_mtime_ns) const;
   SyncItemType GetScratchFiletype() const;
   virtual void MakePlaceholderDirectory() const { rdonly_type_ = kItemDir; }
 
@@ -109,7 +110,9 @@ class SyncItemDummyDir : public SyncItemNative {
                                    S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 };
 
-catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent() const {
+catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent(
+  bool /* enable_mtime_ns */) const
+{
   catalog::DirectoryEntryBase dirent;
 
   dirent.inode_ = catalog::DirectoryEntry::kInvalidInode;

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -110,37 +110,6 @@ class SyncItemDummyDir : public SyncItemNative {
                                    S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 };
 
-catalog::DirectoryEntryBase SyncItemDummyDir::CreateBasicCatalogDirent(
-  bool /* enable_mtime_ns */) const
-{
-  catalog::DirectoryEntryBase dirent;
-
-  dirent.inode_ = catalog::DirectoryEntry::kInvalidInode;
-
-  dirent.linkcount_ = 1;
-
-  dirent.mode_ = kPermision;
-
-  dirent.uid_ = scratch_stat_.stat.st_uid;
-  dirent.gid_ = scratch_stat_.stat.st_gid;
-  dirent.size_ = 4096;
-  dirent.mtime_ = time(NULL);
-  dirent.checksum_ = this->GetContentHash();
-  dirent.is_external_file_ = this->IsExternalData();
-  dirent.compression_algorithm_ = this->GetCompressionAlgorithm();
-
-  dirent.name_.Assign(this->filename().data(), this->filename().length());
-
-  assert(dirent.IsDirectory());
-
-  return dirent;
-}
-
-
-SyncItemType SyncItemDummyDir::GetScratchFiletype() const {
-  return kItemDir;
-}
-
 }  // namespace publish
 
 #endif  // CVMFS_SYNC_ITEM_DUMMY_H_

--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -120,6 +120,7 @@ platform_stat64 SyncItemTar::GetStatFromTar() const {
   tar_stat_.st_rdev = entry_stat->st_rdev;
   tar_stat_.st_size = entry_stat->st_size;
   tar_stat_.st_mtime = entry_stat->st_mtime;
+  tar_stat_.st_mtim.tv_nsec = entry_stat->st_mtim.tv_nsec;
   tar_stat_.st_nlink = entry_stat->st_nlink;
 
   if (IsDirectory()) {
@@ -149,7 +150,7 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
   dirent.gid_ = this->tar_stat_.st_gid;
   dirent.size_ = this->tar_stat_.st_size;
   dirent.mtime_ = this->tar_stat_.st_mtime;
-  dirent.mtime_ = this->tar_stat_.st_mtim.tv_nsec;
+  dirent.mtime_ns_ = this->tar_stat_.st_mtim.tv_nsec;
   dirent.checksum_ = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.compression_algorithm_ = this->GetCompressionAlgorithm();

--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -149,6 +149,7 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
   dirent.gid_ = this->tar_stat_.st_gid;
   dirent.size_ = this->tar_stat_.st_size;
   dirent.mtime_ = this->tar_stat_.st_mtime;
+  dirent.mtime_ = this->tar_stat_.st_mtim.tv_nsec;
   dirent.checksum_ = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.compression_algorithm_ = this->GetCompressionAlgorithm();

--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -150,7 +150,6 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
   dirent.gid_ = this->tar_stat_.st_gid;
   dirent.size_ = this->tar_stat_.st_size;
   dirent.mtime_ = this->tar_stat_.st_mtime;
-  dirent.mtime_ns_ = static_cast<int32_t>(this->tar_stat_.st_mtim.tv_nsec);
   dirent.checksum_ = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.compression_algorithm_ = this->GetCompressionAlgorithm();
@@ -164,6 +163,10 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
 
   if (this->IsCharacterDevice() || this->IsBlockDevice()) {
     dirent.size_ = makedev(major(tar_stat_.st_rdev), minor(tar_stat_.st_rdev));
+  }
+
+  if (g_enable_mtime_ns) {
+    dirent.mtime_ns_ = static_cast<int32_t>(this->tar_stat_.st_mtim.tv_nsec);
   }
 
   assert(dirent.IsRegular() || dirent.IsDirectory() || dirent.IsLink() ||

--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -132,7 +132,9 @@ platform_stat64 SyncItemTar::GetStatFromTar() const {
   return tar_stat_;
 }
 
-catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
+catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent(
+  bool enable_mtime_ns) const
+{
   assert(obtained_tar_stat_);
 
   catalog::DirectoryEntryBase dirent;
@@ -165,7 +167,7 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
     dirent.size_ = makedev(major(tar_stat_.st_rdev), minor(tar_stat_.st_rdev));
   }
 
-  if (g_enable_mtime_ns) {
+  if (enable_mtime_ns) {
     dirent.mtime_ns_ = static_cast<int32_t>(this->tar_stat_.st_mtim.tv_nsec);
   }
 

--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -120,7 +120,11 @@ platform_stat64 SyncItemTar::GetStatFromTar() const {
   tar_stat_.st_rdev = entry_stat->st_rdev;
   tar_stat_.st_size = entry_stat->st_size;
   tar_stat_.st_mtime = entry_stat->st_mtime;
+#ifdef __APPLE__
+  tar_stat_.st_mtimespec.tv_nsec = entry_stat->st_mtimespec.tv_nsec;
+#else
   tar_stat_.st_mtim.tv_nsec = entry_stat->st_mtim.tv_nsec;
+#endif
   tar_stat_.st_nlink = entry_stat->st_nlink;
 
   if (IsDirectory()) {
@@ -168,7 +172,12 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent(
   }
 
   if (enable_mtime_ns) {
+#ifdef __APPLE__
+    dirent.mtime_ns_ =
+      static_cast<int32_t>(this->tar_stat_.st_mtimespec.tv_nsec);
+#else
     dirent.mtime_ns_ = static_cast<int32_t>(this->tar_stat_.st_mtim.tv_nsec);
+#endif
   }
 
   assert(dirent.IsRegular() || dirent.IsDirectory() || dirent.IsLink() ||

--- a/cvmfs/sync_item_tar.cc
+++ b/cvmfs/sync_item_tar.cc
@@ -150,7 +150,7 @@ catalog::DirectoryEntryBase SyncItemTar::CreateBasicCatalogDirent() const {
   dirent.gid_ = this->tar_stat_.st_gid;
   dirent.size_ = this->tar_stat_.st_size;
   dirent.mtime_ = this->tar_stat_.st_mtime;
-  dirent.mtime_ns_ = this->tar_stat_.st_mtim.tv_nsec;
+  dirent.mtime_ns_ = static_cast<int32_t>(this->tar_stat_.st_mtim.tv_nsec);
   dirent.checksum_ = this->GetContentHash();
   dirent.is_external_file_ = this->IsExternalData();
   dirent.compression_algorithm_ = this->GetCompressionAlgorithm();

--- a/cvmfs/sync_item_tar.h
+++ b/cvmfs/sync_item_tar.h
@@ -22,7 +22,8 @@ class SyncItemTar : public SyncItem {
   friend class SyncUnionTarball;
 
  public:
-  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent() const;
+  virtual catalog::DirectoryEntryBase CreateBasicCatalogDirent(
+    bool enable_mtime_ns) const;
   virtual IngestionSource *CreateIngestionSource() const;
   virtual void MakePlaceholderDirectory() const { rdonly_type_ = kItemDir; }
   virtual SyncItemType GetScratchFiletype() const;

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -72,6 +72,12 @@ cvmfs_run_test() {
   echo "check catalog and data integrity"
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
+  echo "checking nanosecond timestamps"
+  echo "entry information of $repo_dir/file:"
+  stat $repo_dir/file || return 40
+  local mtime_ns=$(stat -c%y $repo_dir/file | cut -d. -f2 | awk '{print $1}')
+  [ $mtime_ns -ne 0 ] || return 41
+
   echo "*** Maximum repository name with 60 characters (CVM-1173)"
   CVMFS_TEST500_LONG_REPONAME=testrepo.osg-software-2580-el7-cvmfs-stratum-0.novalocal.crt
   trap cleanup TERM HUP INT EXIT

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -73,10 +73,17 @@ cvmfs_run_test() {
   check_repository $CVMFS_TEST_REPO -i  || return $?
 
   echo "checking nanosecond timestamps"
-  echo "entry information of $repo_dir/file:"
+  echo "entry information of $repo_dir/file (expect unknown nanosecond timestamps by default):"
   stat $repo_dir/file || return 40
   local mtime_ns=$(stat -c%y $repo_dir/file | cut -d. -f2 | awk '{print $1}')
-  [ $mtime_ns -ne 0 ] || return 41
+  [ $mtime_ns -eq 0 ] || return 41
+  echo "CVMFS_ENABLE_MTIME_NS=true" | sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  start_transaction $CVMFS_TEST_REPO || return $?
+  touch $repo_dir/file || return 42
+  publish_repo $CVMFS_TEST_REPO || return $?
+  stat $repo_dir/file || return 43
+  mtime_ns=$(stat -c%y $repo_dir/file | cut -d. -f2 | awk '{print $1}')
+  [ $mtime_ns -ne 0 ] || return 44
 
   echo "*** Maximum repository name with 60 characters (CVM-1173)"
   CVMFS_TEST500_LONG_REPONAME=testrepo.osg-software-2580-el7-cvmfs-stratum-0.novalocal.crt

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -41,6 +41,7 @@ cvmfs_run_test() {
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  echo "CVMFS_ENABLE_MTIME_NS=true" | sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
 
   # ============================================================================
 

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -233,6 +233,12 @@ cvmfs_run_test() {
     echo "*** It compare well"
   fi
 
+  echo "checking nanosecond timestamps"
+  echo "entry information of $file:"
+  stat $file || return 50
+  local mtime_ns=$(stat -c%y $file | cut -d. -f2 | awk '{print $1}')
+  [ $mtime_ns -ne 0 ] || return 51
+
   echo "*** ingesting empty tarball with nested catalog"
   cat $script_location/layer.tar | cvmfs_server ingest --base_dir layer -c --tar_file - $CVMFS_TEST_REPO || return 42
   ls /cvmfs/$CVMFS_TEST_REPO/layer/.cvmfscatalog || return 42

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -26,7 +26,8 @@ produce_tarball() {
 
   echo "*** Generating a tarball in $tarball_name"
   # the -P option create a tarball with a leading slash
-  tar -Pcvf $tarball_name $(pwd)/tarball_foo
+  # the -H posix option creates nanosecond precision timestamps
+  tar -H posix -Pcvf $tarball_name $(pwd)/tarball_foo
 
   rm -rf tarball_foo
 }

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -198,6 +198,7 @@ if (BUILD_SERVER)
        ${CVMFS_SOURCE_DIR}/swissknife_assistant.cc
        ${CVMFS_SOURCE_DIR}/swissknife_lease_curl.cc
        ${CVMFS_SOURCE_DIR}/sync_item.cc
+       ${CVMFS_SOURCE_DIR}/sync_item_dummy.cc
        ${CVMFS_SOURCE_DIR}/sync_item_tar.cc
        ${CVMFS_SOURCE_DIR}/sync_mediator.cc
        ${CVMFS_SOURCE_DIR}/sync_union.cc
@@ -502,6 +503,7 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/swissknife_lease_json.cc
   ${CVMFS_SOURCE_DIR}/swissknife_lease_curl.cc
   ${CVMFS_SOURCE_DIR}/sync_item.cc
+  ${CVMFS_SOURCE_DIR}/sync_item_dummy.cc
   ${CVMFS_SOURCE_DIR}/sync_item_tar.cc
   ${CVMFS_SOURCE_DIR}/sync_mediator.cc
   ${CVMFS_SOURCE_DIR}/sync_union.cc


### PR DESCRIPTION
Extends the file catalog table by a `mtimens` column for the nanosecond part of the timestamp. The catalog revision increases to 7, the change is backwards and forwards compatible.

Introduces a new boolean server parameter `CVMFS_ENABLE_MTIME_NS`. Off by default, because nanosecond timstamps show a catalog size increase of a little under 10% compressed and a little under 5% uncompressed.

Fixes #3413 