### PR TITLE
getxattr: move check of valid return value closer to its request

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1747,7 +1747,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   catalog::DirectoryEntry d;
   const bool found = GetDirentForInode(ino, &d);
 
-  if (false && !found) {
+  if (!found) {
     fuse_remounter_->fence()->Leave();
     ReplyNegative(d, req);
     return;
@@ -1807,12 +1807,6 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   }
 
   fuse_remounter_->fence()->Leave();
-
-  // TODO TODO readded to see if where failure of test 089 is
-  if (!found) {
-    ReplyNegative(d, req);
-    return;
-  }
 
   if (!magic_xattr_success) {
     fuse_reply_err(req, ENOATTR);

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1747,7 +1747,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   catalog::DirectoryEntry d;
   const bool found = GetDirentForInode(ino, &d);
 
-  if (!found) {
+  if (false && !found) {
     fuse_remounter_->fence()->Leave();
     ReplyNegative(d, req);
     return;
@@ -1807,6 +1807,12 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   }
 
   fuse_remounter_->fence()->Leave();
+
+  // TODO TODO readded to see if where failure of test 089 is
+  if (!found) {
+    ReplyNegative(d, req);
+    return;
+  }
 
   if (!magic_xattr_success) {
     fuse_reply_err(req, ENOATTR);

--- a/test/src/089-external_cache_plugin/main
+++ b/test/src/089-external_cache_plugin/main
@@ -56,8 +56,6 @@ cvmfs_run_test() {
   CVMFS_CACHE_PLUGIN_RAM_PID=$($CVMFS_CACHE_PLUGIN_RAM_PATH cache.config)
   echo "*** PID of RAM cache plugin is $CVMFS_CACHE_PLUGIN_RAM_PID"
 
-  echo $mount_opts
-
   cvmfs_mount lhcb.cern.ch $mount_opts || return $?
   ls /cvmfs/lhcb.cern.ch > /dev/null || return 10
   filename=$(find /cvmfs/lhcb.cern.ch -type f | head -n1)

--- a/test/src/089-external_cache_plugin/main
+++ b/test/src/089-external_cache_plugin/main
@@ -56,6 +56,8 @@ cvmfs_run_test() {
   CVMFS_CACHE_PLUGIN_RAM_PID=$($CVMFS_CACHE_PLUGIN_RAM_PATH cache.config)
   echo "*** PID of RAM cache plugin is $CVMFS_CACHE_PLUGIN_RAM_PID"
 
+  echo $mount_opts
+
   cvmfs_mount lhcb.cern.ch $mount_opts || return $?
   ls /cvmfs/lhcb.cern.ch > /dev/null || return 10
   filename=$(find /cvmfs/lhcb.cern.ch -type f | head -n1)


### PR DESCRIPTION
Issue #3515 

check for the `found` was definitely done too late

 https://github.com/cvmfs/cvmfs/blob/9fc9c4015f6f3fcc98c9cec1f48fdb77003a034f/cvmfs/cvmfs.cc#L1747-L1755

hopefully also solves the assert issue 
