### PR TITLE
shrinkwrap: skip named pipes without aborting sync of containing dirs

### DIFF
--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -505,6 +505,12 @@ bool Sync(
             result = false;
           }
           break;
+        case S_IFIFO:
+           // Ignore pipe, but continue
+            LogCvmfs(kLogCvmfs, kLogStderr,
+              "Skipping pipe: %s",
+              src_entry);
+          break;
         default:
           LogCvmfs(kLogCvmfs, kLogStderr,
             "Encountered unknown file type '%d' for source file %s",

--- a/cvmfs/shrinkwrap/fs_traversal_interface.h
+++ b/cvmfs/shrinkwrap/fs_traversal_interface.h
@@ -95,7 +95,7 @@ struct fs_traversal {
    * @note(steuber): The content checksum only needs to be calculated if this
    * is a source file system!
    * 
-   * For correnct behaviour the following fields must be set
+   * For correct behaviour the following fields must be set
    * (and may not be NULL):
    * - version
    * - size


### PR DESCRIPTION
When shrinkwrapping a spec like
 ```
/gentoo/* 
 ```
which includes the named pipe `/gentoo/2023/x86-64-v3/var/spool/nullmailer` (real world example from soft.computecanada.ca), shrinkwrap would log the following:
    
 ```
(libcvmfs) Encountered unknown file type '4096' for source file /gentoo/2023/x86-64-v3/var/spool/nullmailer/trigger
(libcvmfs) File /gentoo/2023/x86-64-v3/var/spool/nullmailer failed to copy
 ```
and stop processing the wildcard at this point, leaving the shrinkwrapped  `/gentoo` incomplete. This commit adds a case for this file type and just skips them, avoiding the incomplete copy.
    
The named pipe could actually be recreated in the shrinkrap destination, but I would assume most applications just recreate it themselves.

Fixes #3496 