### PR TITLE
Containerize testing environment for "quick" suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: CI
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [devel,master]
 
 jobs:
-  test:
-    name: "Test"
+  docker:
+    name: "Docker"
     runs-on: ubuntu-20.04
 
     steps:
@@ -35,21 +35,23 @@ jobs:
           docker exec -u sftnight -t cvmfs-dev /bin/bash -c "sudo cvmfs_config setup"
           docker exec -u sftnight -t cvmfs-dev /bin/bash -c "sudo cvmfs_config chksetup" || exit 1
 
-      - name: Run quick test suite
+      - name: Run Tests
         run: |
           docker exec -u sftnight -t cvmfs-dev bash -c \
-            "cd /home/sftnight/cvmfs/test && \
-            CVMFS_TEST_USER=sftnight ./run.sh /tmp/cvmfs-test.log -s 'quick' ./src/0* ./src/1*"
+            "cd /home/sftnight/cvmfs/test/common/container && CVMFS_TEST_PROXY=DIRECT bash test.sh"
 
       - name: Archive logs
         if: ${{ always () }}
         run: |
-          docker cp cvmfs-dev:/tmp/cvmfs-test.log /tmp/cvmfs-test.log
+          docker cp cvmfs-dev:/tmp/cvmfs-client-test.log /tmp/cvmfs-client-test.log
+          docker cp cvmfs-dev:/tmp/cvmfs-server-test.log /tmp/cvmfs-server-test.log
 
       - name: Upload logs as artifact
         if: ${{ always () }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with: 
           name: CVMFS test logs
-          path: /tmp/cvmfs-test.log
+          path: |
+              /tmp/cvmfs-client-test.log
+              /tmp/cvmfs-server-test.log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [devel,master]
+      branches: [devel]
   pull_request:
-    branches: [devel,master]
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: Docker
+
+on:
+  push:
+    branches: [devel,master]
+  pull_request:
+    branches: [devel,master]
+
+jobs:
+  test:
+    name: "Test"
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: |
+          cd test/common/container
+          docker compose up --build -d cvmfs-dev
+
+      - name: Build CVMFS
+        run: |
+          docker exec -u sftnight -t cvmfs-dev bash -c \
+            "cmake -S /home/sftnight/cvmfs -B /tmp/cvmfs-build -D EXTERNALS_PREFIX=/tmp/cvmfs-ext -D BUILD_SHRINKWRAP=ON"
+
+      - name: Install CVMFS
+        run: |
+          docker exec -u sftnight -t cvmfs-dev bash -c \
+            "cd /tmp/cvmfs-build && make && sudo make install"
+
+      - name: Setup CVMFS
+        run: |
+          docker exec -u sftnight -t cvmfs-dev /bin/bash -c "sudo cvmfs_config setup"
+          docker exec -u sftnight -t cvmfs-dev /bin/bash -c "sudo cvmfs_config chksetup" || exit 1
+
+      - name: Run quick test suite
+        run: |
+          docker exec -u sftnight -t cvmfs-dev bash -c \
+            "cd /home/sftnight/cvmfs/test && \
+            CVMFS_TEST_USER=sftnight ./run.sh /tmp/cvmfs-test.log -s 'quick' ./src/0* ./src/1*"
+
+      - name: Archive logs
+        if: ${{ always () }}
+        run: |
+          docker cp cvmfs-dev:/tmp/cvmfs-test.log /tmp/cvmfs-test.log
+
+      - name: Upload logs as artifact
+        if: ${{ always () }}
+        uses: actions/upload-artifact@v2
+        with: 
+          name: CVMFS test logs
+          path: /tmp/cvmfs-test.log
+

--- a/test/common/container/Dockerfile-dev
+++ b/test/common/container/Dockerfile-dev
@@ -3,13 +3,13 @@ FROM gitlab-registry.cern.ch/cernvm/build-images/centos_x86_64:9
 USER root
 
 RUN dnf install -y sudo autofs fuse fuse3 httpd wget lsof \
-    python python3-pip attr nc sqlite python3-mod_wsgi jq
+    python python3-pip attr nc sqlite python3-mod_wsgi jq usbutils
 
 RUN pip3 install flask
 
 RUN echo '%sftnight ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-COPY test.sh test.sh
+ENV USER sftnight
 
 CMD ["/usr/sbin/init"]
 

--- a/test/common/container/Dockerfile-dev
+++ b/test/common/container/Dockerfile-dev
@@ -1,0 +1,61 @@
+FROM 	    gitlab-registry.cern.ch/linuxsupport/alma9-base
+
+# This two args should not be necessary, but the bug fixed by
+# https://github.com/opencontainers/runc/pull/2086
+# makes them necessary in our environment
+ARG SFTNIGHT_UID=5005
+ARG SFTNIGHT_GID=5005
+
+RUN         dnf -y update
+RUN         dnf -y install filesystem
+RUN         dnf -y install dnf-utils && dnf config-manager --set-enabled crb
+RUN         dnf -y install epel-release
+RUN         dnf -y install                     \
+                       clang-analyzer          \
+                       clang-tools-extra       \
+                       cmake                   \
+                       curl-devel              \
+                       fuse-devel              \
+                       fuse3-devel             \
+                       gcc-c++                 \
+                       gdb                     \
+                       git                     \
+                       golang                  \
+                       hardlink                \
+                       libattr-devel           \
+                       libcap-devel            \
+                       libffi-devel            \
+                       libuuid-devel           \
+                       make                    \
+                       openssl-devel           \
+                       python3-devel           \
+                       rpm-build               \
+                       ruby-devel              \
+                       selinux-policy-devel    \
+                       selinux-policy-targeted \
+                       systemd                 \
+                       which                   \
+                       valgrind-devel          \
+                       voms-devel              \
+                       zlib-devel              \
+                       attr                    \
+                       autofs                  \
+                       fuse                    \
+                       fuse3                   \
+                       sudo                    \
+                       httpd                   \
+                       wget                    \
+                       lsof                    \
+                       python
+
+
+# Similarly to the node above.
+# `adduser sftnight` should be sufficient, but the bug above requires
+# this workaround
+RUN  groupadd --gid $SFTNIGHT_GID sftnight && \
+        adduser --uid $SFTNIGHT_UID --gid $SFTNIGHT_GID sftnight
+
+RUN echo '%sftnight ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+CMD ["/usr/sbin/init"]
+

--- a/test/common/container/Dockerfile-dev
+++ b/test/common/container/Dockerfile-dev
@@ -2,7 +2,7 @@ FROM gitlab-registry.cern.ch/cernvm/build-images/centos_x86_64:9
 
 USER root
 
-RUN dnf install -y sudo autofs fuse fuse3 httpd wget lsof python attr
+RUN dnf install -y sudo autofs fuse fuse3 httpd wget lsof python attr nc
 
 RUN echo '%sftnight ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/test/common/container/Dockerfile-dev
+++ b/test/common/container/Dockerfile-dev
@@ -2,9 +2,14 @@ FROM gitlab-registry.cern.ch/cernvm/build-images/centos_x86_64:9
 
 USER root
 
-RUN dnf install -y sudo autofs fuse fuse3 httpd wget lsof python attr nc
+RUN dnf install -y sudo autofs fuse fuse3 httpd wget lsof \
+    python python3-pip attr nc sqlite python3-mod_wsgi jq
+
+RUN pip3 install flask
 
 RUN echo '%sftnight ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+COPY test.sh test.sh
 
 CMD ["/usr/sbin/init"]
 

--- a/test/common/container/Dockerfile-dev
+++ b/test/common/container/Dockerfile-dev
@@ -1,59 +1,8 @@
-FROM 	    gitlab-registry.cern.ch/linuxsupport/alma9-base
+FROM gitlab-registry.cern.ch/cernvm/build-images/centos_x86_64:9
 
-# This two args should not be necessary, but the bug fixed by
-# https://github.com/opencontainers/runc/pull/2086
-# makes them necessary in our environment
-ARG SFTNIGHT_UID=5005
-ARG SFTNIGHT_GID=5005
+USER root
 
-RUN         dnf -y update
-RUN         dnf -y install filesystem
-RUN         dnf -y install dnf-utils && dnf config-manager --set-enabled crb
-RUN         dnf -y install epel-release
-RUN         dnf -y install                     \
-                       clang-analyzer          \
-                       clang-tools-extra       \
-                       cmake                   \
-                       curl-devel              \
-                       fuse-devel              \
-                       fuse3-devel             \
-                       gcc-c++                 \
-                       gdb                     \
-                       git                     \
-                       golang                  \
-                       hardlink                \
-                       libattr-devel           \
-                       libcap-devel            \
-                       libffi-devel            \
-                       libuuid-devel           \
-                       make                    \
-                       openssl-devel           \
-                       python3-devel           \
-                       rpm-build               \
-                       ruby-devel              \
-                       selinux-policy-devel    \
-                       selinux-policy-targeted \
-                       systemd                 \
-                       which                   \
-                       valgrind-devel          \
-                       voms-devel              \
-                       zlib-devel              \
-                       attr                    \
-                       autofs                  \
-                       fuse                    \
-                       fuse3                   \
-                       sudo                    \
-                       httpd                   \
-                       wget                    \
-                       lsof                    \
-                       python
-
-
-# Similarly to the node above.
-# `adduser sftnight` should be sufficient, but the bug above requires
-# this workaround
-RUN  groupadd --gid $SFTNIGHT_GID sftnight && \
-        adduser --uid $SFTNIGHT_UID --gid $SFTNIGHT_GID sftnight
+RUN dnf install -y sudo autofs fuse fuse3 httpd wget lsof python attr
 
 RUN echo '%sftnight ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/test/common/container/README.md
+++ b/test/common/container/README.md
@@ -1,0 +1,29 @@
+# Running tests in Containers
+
+1. Setup
+```sh
+git clone https://github.com/cvmfs/cvmfs.git
+cd tests/common/container
+docker-compose up --build -d
+```
+
+2. Build:
+```sh
+docker exec -u sftnight -it cvmfs-dev bash
+cmake -S /home/sftnight/cvmfs -B /tmp/cvmfs-build -D EXTERNALS_PREFIX=/tmp/cvmfs-ext -D BUILD_SHRINKWRAP=ON
+cd /tmp/cvmfs-build
+make 
+sudo make install
+```
+
+3. Setup CVMFS
+```sh
+sudo cvmfs_config setup
+```
+
+4. Testing
+```sh
+cd /home/sftnight/cvmfs/test
+CVMFS_TEST_USER=sftnight ./run.sh /tmp/cvmfs-test.log -s "quick" 
+```
+

--- a/test/common/container/README.md
+++ b/test/common/container/README.md
@@ -23,7 +23,7 @@ sudo cvmfs_config setup
 
 4. Testing
 ```sh
-cd /home/sftnight/cvmfs/test
-CVMFS_TEST_USER=sftnight ./run.sh /tmp/cvmfs-test.log -s "quick" 
+cd /home/sftnight/cvmfs/test/common/container
+bash test.sh
 ```
 

--- a/test/common/container/docker-compose.yml
+++ b/test/common/container/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+    cvmfs-dev:
+        image: registry.cern.ch/cvmfs-dev:latest
+        container_name: cvmfs-dev
+        hostname: cvmfs-dev
+        privileged: true
+        build:
+            context: .
+            dockerfile: Dockerfile-dev
+        volumes:
+            - /sys/fs/cgroup:/sys/fs/cgroup
+            - var_spool_cvmfs:/var/spool/cvmfs
+            - ../../../:/home/sftnight/cvmfs
+
+volumes:
+    var_spool_cvmfs:
+

--- a/test/common/container/test.sh
+++ b/test/common/container/test.sh
@@ -5,53 +5,62 @@ cd "/home/sftnight/cvmfs/test"
 TEST_LOG_DIRECTORY=/tmp
 CLIENT_TEST_LOGFILE=/tmp/cvmfs-client-test.log
 SERVER_TEST_LOGFILE=/tmp/cvmfs-server-test.log
-                                     
-# echo "running CernVM-FS client test cases..."
-# ./run.sh $CLIENT_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE} -s "quick"            \
-#                               -x src/005-asetup                               \
-#                                  src/004-davinci                              \
-#                                  src/007-testjobs                             \
-#                                  src/017-dnstimeout                           \
-#                                  src/019-httptimeout                          \
-#                                  src/020-emptyrepofailover                    \
-#                                  src/030-missingrootcatalog                   \
-#                                  src/056-lowspeedlimit                        \
-#                                  src/065-http-400                             \
-#                                  src/066-killall                              \
-#                                  src/084-premounted                           \
-#                                  src/095-fuser                                \
-#                                  src/096-cancelreq                            \
-#                                  --                                           \
-#                                  src/0*                                       \
-#                                  src/1*                                       \
-#                               || exit 1
-# 
+
+echo "running CernVM-FS client test cases..."
+./run.sh $CLIENT_TEST_LOGFILE -s "quick"                                      \
+                              -x src/104-concurrent_mounts                    \
+                                 --                                           \
+                                 src/0*                                       \
+                                 src/1*                                       \
+                              || exit 1
+
 
 echo "running CernVM-FS server test cases..."
 CVMFS_TEST_UNIONFS=overlayfs                                                  \
-./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE} -s "quick"            \
-                              -x src/500-mkrepo                               \
+./run.sh $SERVER_TEST_LOGFILE -s "quick"                                      \
+                              -x src/514-changechunkedfile                    \
                                  src/518-hardlinkstresstest                   \
+                                 src/522-missingchunkfailover                 \
+                                 src/523-corruptchunkfailover                 \
+                                 src/524-corruptmanifestfailover              \
                                  src/525-bigrepo                              \
+                                 src/564-stratum1keysdir                      \
                                  src/572-proxyfailover                        \
                                  src/577-garbagecollecthiddenstratum1revision \
-                                 src/578-garbagecollecthiddenstratum1revision \
-                                 src/579-garbagecollecthiddenstratum1revision \
-                                 src/580-garbagecollecthiddenstratum1revision \
+                                 src/578-automaticgarbagecollection           \
+                                 src/579-garbagecollectstratum1legacytag      \
+                                 src/580-automaticgarbagecollectionstratum1   \
+                                 src/593-nestedwhiteout                       \
                                  src/595-geoipdbupdate                        \
                                  src/600-securecvmfs                          \
-                                 src/607-noapache                             \
+                                 src/608-infofile                             \
+                                 src/610-altpath                              \
                                  src/615-externaldata                         \
                                  src/616-blacklistconfigrepo                  \
+                                 src/618-repometainfo                         \
                                  src/620-pullmixedrepo                        \
+                                 src/621-snapshotallgcall                     \
                                  src/624-chunkedexternalgraft                 \
+                                 src/626-cacheexpiry                          \
                                  src/627-reflog                               \
                                  src/628-pythonwrappedcvmfsserver             \
+                                 src/634-reflogchecksum                       \
+                                 src/638-virtualdir                           \
+                                 src/647-bearercvmfs                          \
+                                 src/652-tarball_ingest_various_paths         \
+                                 src/655-tarball_multiple_ingest_same_location\
+                                 src/656-tarball_remove_directory             \
+                                 src/666-ingestownership                      \
+                                 src/667-ingestnested                         \
+                                 src/671-stats_db_upgrade                     \
                                  src/672-publish_stats_hardlinks              \
-                                 src/673-acl                                  \
+                                 src/682-enter                                \
                                  src/684-https_s3                             \
                                  src/686-azureblob_s3                         \
                                  src/687-import_s3                            \
+                                 src/688-checkall                             \
+                                 src/699-servermount                          \
+                                 src/700-overlayfs_validation                 \
                                  src/702-symlink_caching                      \
                                  --                                           \
                                  src/5*                                       \

--- a/test/common/container/test.sh
+++ b/test/common/container/test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+cd "/home/sftnight/cvmfs/test"
+
+TEST_LOG_DIRECTORY=/tmp
+CLIENT_TEST_LOGFILE=/tmp/cvmfs-client-test.log
+SERVER_TEST_LOGFILE=/tmp/cvmfs-server-test.log
+                                     
+# echo "running CernVM-FS client test cases..."
+# ./run.sh $CLIENT_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE} -s "quick"            \
+#                               -x src/005-asetup                               \
+#                                  src/004-davinci                              \
+#                                  src/007-testjobs                             \
+#                                  src/017-dnstimeout                           \
+#                                  src/019-httptimeout                          \
+#                                  src/020-emptyrepofailover                    \
+#                                  src/030-missingrootcatalog                   \
+#                                  src/056-lowspeedlimit                        \
+#                                  src/065-http-400                             \
+#                                  src/066-killall                              \
+#                                  src/084-premounted                           \
+#                                  src/095-fuser                                \
+#                                  src/096-cancelreq                            \
+#                                  --                                           \
+#                                  src/0*                                       \
+#                                  src/1*                                       \
+#                               || exit 1
+# 
+
+echo "running CernVM-FS server test cases..."
+CVMFS_TEST_UNIONFS=overlayfs                                                  \
+./run.sh $SERVER_TEST_LOGFILE -o ${SERVER_TEST_LOGFILE} -s "quick"            \
+                              -x src/500-mkrepo                               \
+                                 src/518-hardlinkstresstest                   \
+                                 src/525-bigrepo                              \
+                                 src/572-proxyfailover                        \
+                                 src/577-garbagecollecthiddenstratum1revision \
+                                 src/578-garbagecollecthiddenstratum1revision \
+                                 src/579-garbagecollecthiddenstratum1revision \
+                                 src/580-garbagecollecthiddenstratum1revision \
+                                 src/595-geoipdbupdate                        \
+                                 src/600-securecvmfs                          \
+                                 src/607-noapache                             \
+                                 src/615-externaldata                         \
+                                 src/616-blacklistconfigrepo                  \
+                                 src/620-pullmixedrepo                        \
+                                 src/624-chunkedexternalgraft                 \
+                                 src/627-reflog                               \
+                                 src/628-pythonwrappedcvmfsserver             \
+                                 src/672-publish_stats_hardlinks              \
+                                 src/673-acl                                  \
+                                 src/684-https_s3                             \
+                                 src/686-azureblob_s3                         \
+                                 src/687-import_s3                            \
+                                 src/702-symlink_caching                      \
+                                 --                                           \
+                                 src/5*                                       \
+                                 src/6*                                       \
+                                 src/7*                                       \
+                              || exit 1
+

--- a/test/test_functions
+++ b/test/test_functions
@@ -147,7 +147,7 @@ stat_wrapper() {
 
 # Find the service binary (or detect systemd)
 SERVICE_BIN="false"
-if ! pidof systemd > /dev/null 2>&1 || ! [ -d /run/systemd/system ]; then
+if ! ps -p 1 -o comm= > /dev/null 2>&1 || ! [ -d /run/systemd/system ]; then
   if [ -x /sbin/service ]; then
     SERVICE_BIN="/sbin/service"
   elif [ -x /usr/sbin/service ]; then


### PR DESCRIPTION
### What

Adds ability to execute the "quick" test suite in a container. Example workflow:

1. Cloning
```sh
git clone https://github.com/cvmfs/cvmfs.git
cd tests/common/container
docker-compose up --build -d
docker exec -u sftnight -it cvmfs-dev bash
```
2. Building (from inside the docker environment):
```
cmake -S /home/sftnight/cvmfs -B /tmp/cvmfs-build -D EXTERNALS_PREFIX=/tmp/cvmfs-ext -D BUILD_SHRINKWRAP=ON
```

3. Testing
```sh
cd /home/sftnight/cvmfs/test
CVMFS_TEST_USER=sftnight ./run.sh /tmp/cvmfs-test.log -s "quick" ./src/0* ./src/1*
```
### Why

- Enables faster developer testing iterations (versus provisioning/destroying VMs)
- Serves as a good first step towards containerizing other elements of CVMFS