### PR TITLE
Improve/fix fuse client context handling

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1371,6 +1371,10 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
                        struct fuse_file_info *fi) {
   const HighPrecisionTimer guard_timer(file_system_->hist_fs_read());
 
+  const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
+  FuseInterruptCue ic(&req);
+  ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
+
   LogCvmfs(kLogCvmfs, kLogDebug,
            "cvmfs_read inode: %" PRIu64 " reading %lu bytes from offset %ld "
            "fd %lu",

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1397,11 +1397,6 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   uint64_t abs_fd = (fd < 0) ? -fd : fd;
   ClearBit(glue::PageCacheTracker::kBitDirectIo, &abs_fd);
 
-  const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
-  FuseInterruptCue ic(&req);
-  const ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid,
-                                 &ic);
-
   // Do we have a a chunked file?
   if (fd < 0) {
     const uint64_t chunk_handle = abs_fd;

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1373,7 +1373,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 
   const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
   FuseInterruptCue ic(&req);
-  ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
+  const ClientCtxGuard ctxgd(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
 
   LogCvmfs(kLogCvmfs, kLogDebug,
            "cvmfs_read inode: %" PRIu64 " reading %lu bytes from offset %ld "

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -164,6 +164,11 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
              tls->download_job.GetGidPtr(),
              tls->download_job.GetPidPtr(),
              tls->download_job.GetInterruptCuePtr());
+  } else {
+    *(tls->download_job.GetUidPtr()) = -1;
+    *(tls->download_job.GetGidPtr()) = -1;
+    *(tls->download_job.GetPidPtr()) = -1;
+    *(tls->download_job.GetInterruptCuePtr()) = nullptr;
   }
   tls->download_job.SetCompressed(object.label.zip_algorithm
                                   == zlib::kZlibDefault);

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -168,7 +168,7 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
     *(tls->download_job.GetUidPtr()) = -1;
     *(tls->download_job.GetGidPtr()) = -1;
     *(tls->download_job.GetPidPtr()) = -1;
-    *(tls->download_job.GetInterruptCuePtr()) = nullptr;
+    *(tls->download_job.GetInterruptCuePtr()) = NULL;
   }
   tls->download_job.SetCompressed(object.label.zip_algorithm
                                   == zlib::kZlibDefault);


### PR DESCRIPTION
While we unfortunately don't have a reproducer for the crashes seen in #3518, both code changes in this PR were identified as potential culprits. They should make the code safer in any case, if only in the light of future changes. 

May fix #3518