### PR TITLE
Fix some printf related warnings (for fedora38 build)

### DIFF
--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
   }
   free(workers);
   if (!g_verbose)
-    LogCvmfs(kLogCvmfs, kLogStdout, "");
+    LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
   LogCvmfs(kLogCvmfs, kLogStdout, "Verified %d files",
            atomic_read32(&g_num_files));
 

--- a/cvmfs/publish/cmd_diff.cc
+++ b/cvmfs/publish/cmd_diff.cc
@@ -95,7 +95,7 @@ class DiffReporter : public publish::DiffListener {
       if (!entry.IsDirectory()) {
         LogCvmfs(kLogCvmfs, kLogStdout, " +%" PRIu64, entry.size());
       } else {
-        LogCvmfs(kLogCvmfs, kLogStdout, "");
+        LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
       }
     } else {
       LogCvmfs(kLogCvmfs, kLogStdout, "%s %s %s +%" PRIu64 " bytes",

--- a/cvmfs/publish/cmd_help.cc
+++ b/cvmfs/publish/cmd_help.cc
@@ -29,7 +29,7 @@ int CmdHelp::Main(const Options &options) {
   LogCvmfs(kLogCvmfs, kLogStdout, "\nHelp for '%s'", cmd->GetName().c_str());
   for (unsigned i = 0; i < cmd->GetName().length() + 11; ++i)
     LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "=");
-  LogCvmfs(kLogCvmfs, kLogStdout, "");
+  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
   LogCvmfs(kLogCvmfs, kLogStdout, "%s\n", cmd->GetDescription().c_str());
 
   LogCvmfs(kLogCvmfs, kLogStdout, "Usage:");
@@ -45,7 +45,7 @@ int CmdHelp::Main(const Options &options) {
     for (unsigned i = 0; i < ex_lines.size() - 1; ++i) {
       LogCvmfs(kLogCvmfs, kLogStdout, "  [%d] %s", i + 1, ex_lines[i].c_str());
     }
-    LogCvmfs(kLogCvmfs, kLogStdout, "");
+    LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
   }
 
   ParameterList params = cmd->GetParams();
@@ -74,7 +74,7 @@ int CmdHelp::Main(const Options &options) {
              params[i].description.c_str(),
              params[i].is_optional ? "" : " [mandatory]");
   }
-  LogCvmfs(kLogCvmfs, kLogStdout, "");
+  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
 
   return 0;
 }

--- a/cvmfs/publish/main.cc
+++ b/cvmfs/publish/main.cc
@@ -61,7 +61,7 @@ static void Usage(const std::string &progname,
     LogCvmfs(kLogCvmfs, kLogStdout, "   %s", commands[i]->GetBrief().c_str());
   }
 
-  LogCvmfs(kLogCvmfs, kLogStdout, "");
+  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
 }
 
 

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -54,7 +54,7 @@ void Usage() {
     for (unsigned j = 0; j < command_list[i]->GetName().length(); ++j) {
       LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "-");
     }
-    LogCvmfs(kLogCvmfs, kLogStdout, "");
+    LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
     LogCvmfs(kLogCvmfs, kLogStdout, "%s",
              command_list[i]->GetDescription().c_str());
     swissknife::ParameterList params = command_list[i]->GetParams();
@@ -65,12 +65,12 @@ void Usage() {
                  params[j].key(), params[j].description().c_str());
         if (params[j].optional())
           LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, " (optional)");
-        LogCvmfs(kLogCvmfs, kLogStdout, "");
+        LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
       }
     }  // Parameter list
   }  // Command list
 
-  LogCvmfs(kLogCvmfs, kLogStdout, "");
+  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
 }
 
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -854,7 +854,7 @@ void SyncDiffReporter::OnModify(const std::string &path,
 void SyncDiffReporter::CommitReport() {
   if (print_action_ == kPrintDots) {
     if (changed_items_ >= processing_dot_interval_) {
-      LogCvmfs(kLogPublish, kLogStdout, "");
+      LogCvmfs(kLogPublish, kLogStdout | kLogNoLinebreak, "\n");
     }
   }
 }

--- a/cvmfs/util/exception.cc
+++ b/cvmfs/util/exception.cc
@@ -44,7 +44,7 @@ void Panic(const char* coordinates, const LogSource source, const int mask,
   (void) mask;
   throw ECvmfsException(msg);
 #else
-  LogCvmfs(source, mask, msg);
+  LogCvmfs(source, mask, "%s", msg);
   abort();
 #endif
 }


### PR DESCRIPTION
This commit silences two types of  warnings, that need to be fixed since rpmbuild treats them as errors, starting with Fedora 38.

The first is:
```
cvmfs/cvmfs/util/exception.cc: In function ‘void Panic(const char*, LogSource, int, const char*, ...)’: cvmfs/cvmfs/util/logging.h:28:51: warning: format not a string literal and no format arguments [-Wformat-security]
   28 |     ((void)0) : LogCvmfs(source, mask, __VA_ARGS__));  // NOLINT
      |                                                   ^
cvmfs/cvmfs/util/exception.cc:47:3: note: in expansion of macro ‘LogCvmfs’
   47 |   LogCvmfs(source, mask, msg);
      |   ^~~~~~~~
```
where I add a "%s" format to fix it.

The second is -Wformat-zero-length, with more occurrences due to the use of
```
LogCvmfs(kLogCvmfs, kLogStdout, "");
```
to print a newline. The fix is to replace these with
```
LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
```