### PR TITLE
Fixes and improvements to concurrency in SessionContext

### DIFF
--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -40,7 +40,7 @@
 #include "catalog_rw.h"
 #include "file_chunk.h"
 #include "upload_spooler_result.h"
-#include "util/concurrency.h"
+#include "util/future.h"
 #include "xattr.h"
 
 class XattrList;

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -19,7 +19,7 @@
 
 namespace {
 // Maximum number of jobs during a session. No limit, for practical
-// purposes. Note that we use uint32_t so that the FifoChannel code works
+// purposes. Note that we use uint32_t so that the Tube code works
 // correctly with this limit on 32bit systems.
 const uint32_t kMaxNumJobs = std::numeric_limits<uint32_t>::max();
 }
@@ -74,7 +74,7 @@ size_t RecvCB(void* buffer, size_t size, size_t nmemb, void* userp) {
 }
 
 SessionContextBase::SessionContextBase()
-    : upload_results_(kMaxNumJobs, kMaxNumJobs),
+    : upload_results_(kMaxNumJobs),
       api_url_(),
       session_token_(),
       key_id_(),
@@ -118,8 +118,7 @@ bool SessionContextBase::Initialize(const std::string& api_url,
   bytes_committed_ = 0u;
   bytes_dispatched_ = 0u;
 
-  // Ensure that the upload job and result queues are empty
-  upload_results_.Drop();
+  assert(upload_results_.IsEmpty());
 
   // Ensure that there are not open object packs
   if (current_pack_) {
@@ -156,7 +155,7 @@ bool SessionContextBase::Finalize(bool commit, const std::string& old_root_hash,
 
   bool results = true;
   while (!upload_results_.IsEmpty()) {
-    Future<bool>* future = upload_results_.Dequeue();
+    Future<bool>* future = upload_results_.PopBack();
     results = future->Get() && results;
     delete future;
   }
@@ -253,7 +252,7 @@ void SessionContextBase::Dispatch() {
   }
 
   bytes_dispatched_ += current_pack_->size();
-  upload_results_.Enqueue(DispatchObjectPack(current_pack_));
+  upload_results_.EnqueueFront(DispatchObjectPack(current_pack_));
 }
 
 SessionContext::SessionContext()
@@ -265,8 +264,7 @@ SessionContext::SessionContext()
 
 bool SessionContext::InitializeDerived(uint64_t max_queue_size) {
   // Start worker thread
-  upload_jobs_ = new FifoChannel<UploadJob*>(max_queue_size, max_queue_size);
-  upload_jobs_->Drop();
+  upload_jobs_ = new Tube<UploadJob>(max_queue_size);
 
   int retval =
       pthread_create(&worker_, NULL, UploadLoop, reinterpret_cast<void*>(this));
@@ -283,7 +281,7 @@ bool SessionContext::FinalizeDerived() {
   // TODO(jblomer): Refactor SessionContext (and Uploader*) classes to
   // use a factory method for construction.
   //
-  upload_jobs_->Enqueue(&terminator_);
+  upload_jobs_->EnqueueFront(&terminator_);
   pthread_join(worker_, NULL);
 
   return true;
@@ -311,7 +309,7 @@ Future<bool>* SessionContext::DispatchObjectPack(ObjectPack* pack) {
   UploadJob* job = new UploadJob;
   job->pack = pack;
   job->result = new Future<bool>();
-  upload_jobs_->Enqueue(job);
+  upload_jobs_->EnqueueFront(job);
   return job->result;
 }
 
@@ -399,7 +397,7 @@ void* SessionContext::UploadLoop(void* data) {
   UploadJob *job;
 
   while (true) {
-    job = ctx->upload_jobs_->Dequeue();
+    job = ctx->upload_jobs_->PopBack();
     if (job == &terminator_)
       return NULL;
     if (!ctx->DoUpload(job)) {

--- a/cvmfs/session_context.cc
+++ b/cvmfs/session_context.cc
@@ -305,12 +305,13 @@ bool SessionContext::Commit(const std::string& old_root_hash,
                         request, &buffer);
 }
 
-Future<bool>* SessionContext::DispatchObjectPack(ObjectPack* pack) {
-  UploadJob* job = new UploadJob;
+Future<bool> *SessionContext::DispatchObjectPack(ObjectPack* pack) {
+  UploadJob *job = new UploadJob;
+  Future<bool> *result = new Future<bool>();
   job->pack = pack;
-  job->result = new Future<bool>();
+  job->result = result;
   upload_jobs_->EnqueueFront(job);
-  return job->result;
+  return result;
 }
 
 bool SessionContext::DoUpload(const SessionContext::UploadJob* job) {

--- a/cvmfs/session_context.h
+++ b/cvmfs/session_context.h
@@ -5,12 +5,15 @@
 #ifndef CVMFS_SESSION_CONTEXT_H_
 #define CVMFS_SESSION_CONTEXT_H_
 
+#include <pthread.h>
+
 #include <string>
 #include <vector>
 
 #include "pack.h"
 #include "repository_tag.h"
 #include "util/concurrency.h"
+#include "util/future.h"
 #include "util/pointer.h"
 #include "util/tube.h"
 

--- a/cvmfs/session_context.h
+++ b/cvmfs/session_context.h
@@ -12,6 +12,7 @@
 #include "repository_tag.h"
 #include "util/concurrency.h"
 #include "util/pointer.h"
+#include "util/tube.h"
 
 namespace upload {
 
@@ -72,7 +73,7 @@ bool Initialize(const std::string& api_url, const std::string& session_token,
 
   virtual Future<bool>* DispatchObjectPack(ObjectPack* pack) = 0;
 
-  FifoChannel<Future<bool>*> upload_results_;
+  Tube<Future<bool> > upload_results_;
 
   std::string api_url_;
   std::string session_token_;
@@ -120,7 +121,7 @@ class SessionContext : public SessionContextBase {
  private:
   static void* UploadLoop(void* data);
 
-  UniquePtr<FifoChannel<UploadJob*> > upload_jobs_;
+  UniquePtr<Tube<UploadJob> > upload_jobs_;
 
   pthread_t worker_;
 

--- a/cvmfs/session_context.h
+++ b/cvmfs/session_context.h
@@ -72,8 +72,6 @@ bool Initialize(const std::string& api_url, const std::string& session_token,
 
   virtual Future<bool>* DispatchObjectPack(ObjectPack* pack) = 0;
 
-  int64_t NumJobsSubmitted() const;
-
   FifoChannel<Future<bool>*> upload_results_;
 
   std::string api_url_;
@@ -91,7 +89,6 @@ bool Initialize(const std::string& api_url, const std::string& session_token,
   ObjectPack* current_pack_;
   pthread_mutex_t current_pack_mtx_;
 
-  mutable atomic_int64 objects_dispatched_;
   uint64_t bytes_committed_;
   uint64_t bytes_dispatched_;
 

--- a/cvmfs/signing_tool.h
+++ b/cvmfs/signing_tool.h
@@ -10,7 +10,7 @@
 
 #include "crypto/hash.h"
 #include "server_tool.h"
-#include "util/concurrency.h"
+#include "util/future.h"
 
 class ServerTool;
 

--- a/cvmfs/swissknife_history.h
+++ b/cvmfs/swissknife_history.h
@@ -11,7 +11,7 @@
 #include "crypto/hash.h"
 #include "history_sqlite.h"
 #include "swissknife.h"
-#include "util/concurrency.h"
+#include "util/future.h"
 
 namespace manifest {
 class Manifest;

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -21,6 +21,7 @@
 #include "util/algorithm.h"
 #include "util/atomic.h"
 #include "util/concurrency.h"
+#include "util/future.h"
 #include "util/logging.h"
 #include "util/pointer.h"
 

--- a/cvmfs/util/concurrency.h
+++ b/cvmfs/util/concurrency.h
@@ -52,55 +52,6 @@ class CVMFS_EXPORT Lockable : SingleCopy {
 
 
 /**
- * This is a simple implementation of a Future wrapper template.
- * It is used as a proxy for results that are computed asynchronously and might
- * not be available on the first access.
- * Since this is a very simple implementation one needs to use the Future's
- * Get() and Set() methods to obtain the containing data resp. to write it.
- * Note: More than a single call to Set() is prohibited!
- *       If Get() is called before Set() the calling thread will block until
- *       the value has been set by a different thread.
- *
- * @param T  the value type wrapped by this Future template
- */
-template <typename T>
-class Future : SingleCopy {
- public:
-  Future();
-  virtual ~Future();
-
-  /**
-   * Save an asynchronously computed value into the Future. This potentially
-   * unblocks threads that already wait for the value.
-   * @param object  the value object to be set
-   */
-  void     Set(const T &object);
-
-  /**
-   * Retrieves the wrapped value object. If the value is not yet available it
-   * will automatically block until a different thread calls Set().
-   * @return  the containing value object
-   */
-  T&       Get();
-  const T& Get() const;
-
- protected:
-  void Wait() const;
-
- private:
-  T                       object_;
-  mutable pthread_mutex_t mutex_;
-  mutable pthread_cond_t  object_set_;
-  bool                    object_was_set_;
-};
-
-
-//
-// -----------------------------------------------------------------------------
-//
-
-
-/**
  * This counter can be counted up and down using the usual increment/decrement
  * operators. It allows threads to wait for it to become zero as well as to
  * block when a specified maximal value would be exceeded by an increment.

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -13,61 +13,6 @@ namespace CVMFS_NAMESPACE_GUARD {
 
 //
 // +----------------------------------------------------------------------------
-// |  Future
-//
-
-
-template <typename T>
-Future<T>::Future() : object_(), object_was_set_(false) {
-  const bool init_successful = (pthread_mutex_init(&mutex_, NULL)     == 0   &&
-                                pthread_cond_init(&object_set_, NULL) == 0);
-  assert(init_successful);
-}
-
-
-template <typename T>
-Future<T>::~Future() {
-  pthread_cond_destroy(&object_set_);
-  pthread_mutex_destroy(&mutex_);
-}
-
-
-template <typename T>
-void Future<T>::Set(const T &object) {
-  MutexLockGuard guard(mutex_);
-  assert(!object_was_set_);
-  object_         = object;
-  object_was_set_ = true;
-  pthread_cond_broadcast(&object_set_);
-}
-
-
-template <typename T>
-void Future<T>::Wait() const {
-  MutexLockGuard guard(mutex_);
-  while (!object_was_set_) {
-    pthread_cond_wait(&object_set_, &mutex_);
-  }
-  assert(object_was_set_);
-}
-
-
-template <typename T>
-T& Future<T>::Get() {
-  Wait();
-  return object_;
-}
-
-
-template <typename T>
-const T& Future<T>::Get() const {
-  Wait();
-  return object_;
-}
-
-
-//
-// +----------------------------------------------------------------------------
 // |  SynchronizingCounter
 //
 

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -45,7 +45,7 @@ void Future<T>::Set(const T &object) {
 template <typename T>
 void Future<T>::Wait() const {
   MutexLockGuard guard(mutex_);
-  if (!object_was_set_) {
+  while (!object_was_set_) {
     pthread_cond_wait(&object_set_, &mutex_);
   }
   assert(object_was_set_);

--- a/cvmfs/util/future.h
+++ b/cvmfs/util/future.h
@@ -1,0 +1,94 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_UTIL_FUTURE_H_
+#define CVMFS_UTIL_FUTURE_H_
+
+#include <pthread.h>
+
+#include <cassert>
+
+#include "util/mutex.h"
+#include "util/single_copy.h"
+
+#ifdef CVMFS_NAMESPACE_GUARD
+namespace CVMFS_NAMESPACE_GUARD {
+#endif
+
+/**
+ * This is a simple implementation of a Future wrapper template.
+ * It is used as a proxy for results that are computed asynchronously and might
+ * not be available on the first access.
+ * Since this is a very simple implementation one needs to use the Future's
+ * Get() and Set() methods to obtain the containing data resp. to write it.
+ * Note: More than a single call to Set() is prohibited!
+ *       If Get() is called before Set() the calling thread will block until
+ *       the value has been set by a different thread.
+ *
+ * @param T  the value type wrapped by this Future template
+ */
+template <typename T>
+class Future : SingleCopy {
+ public:
+  Future() : object_was_set_(false) {
+    int retval = pthread_mutex_init(&mutex_, NULL);
+    assert(retval == 0);
+    retval = pthread_cond_init(&object_set_, NULL);
+    assert(retval == 0);
+  }
+
+  ~Future() {
+    int retval = pthread_cond_destroy(&object_set_);
+    assert(retval == 0);
+    retval = pthread_mutex_destroy(&mutex_);
+    assert(retval == 0);
+  }
+
+  /**
+   * Save an asynchronously computed value into the Future. This potentially
+   * unblocks threads that already wait for the value.
+   * @param object  the value object to be set
+   */
+  void Set(const T &object) {
+    MutexLockGuard guard(mutex_);
+    assert(!object_was_set_);
+    object_ = object;
+    object_was_set_ = true;
+    pthread_cond_broadcast(&object_set_);
+  }
+
+  /**
+   * Retrieves the wrapped value object. If the value is not yet available it
+   * will automatically block until a different thread calls Set().
+   * @return  the containing value object
+   */
+  T& Get() {
+    Wait();
+    return object_;
+  }
+
+  const T& Get() const {
+    Wait();
+    return object_;
+  }
+
+ private:
+  void Wait() const {
+    MutexLockGuard guard(mutex_);
+    while (!object_was_set_) {
+      pthread_cond_wait(&object_set_, &mutex_);
+    }
+  }
+
+  T object_;
+  mutable pthread_mutex_t mutex_;
+  mutable pthread_cond_t object_set_;
+  bool object_was_set_;
+};
+
+#ifdef CVMFS_NAMESPACE_GUARD
+}  // namespace CVMFS_NAMESPACE_GUARD
+#endif
+
+#endif  // CVMFS_UTIL_FUTURE_H_


### PR DESCRIPTION
The macOS unit test revealed a race in the `SessionContext` class. This PR
  - fixes the race
  - slightly simplifies the `SessionContext` class
  - fixes a pthread API misuse in the `Future` class
  - moves the `Future` class in its own header
  - replaces the `FifoChannel` class by the (newer) `Tube` in SessionContext