### PR TITLE
Fix test using geodb api

### DIFF
--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -81,15 +81,15 @@ cvmfs_run_test() {
     return 0
   fi
 
+  if [ -f /etc/cvmfs/server.local ]; then
+    . /etc/cvmfs/server.local
+  fi
   if [ -n "$CVMFS_GEO_DB_FILE" ]; then
     echo "Geo database update disabled, skipping tests"
     CVMFS_GENERAL_WARNING_FLAG=1
     return 0
   fi
 
-  if [ -f /etc/cvmfs/server.local ]; then
-    . /etc/cvmfs/server.local
-  fi
   if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
     if [ -f /usr/share/GeoIP/`basename $CVMFS_TEST_595_GEODB` ]; then
       echo "System geo database installed, skipping tests"


### PR DESCRIPTION
This is a workaround for the recent introduction of rate limiting. Letting CVMFS_GEO_DB_FILE be  a url makes it easier to distribute it for cloudtests, and setting it via env var is convenient too.