### PR TITLE
Improve performance of cache cleanup

### DIFF
--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -527,46 +527,53 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
   sqlite3_reset(stmt_unblock_);
   assert(result);
 
-  // Double fork avoids zombie, forked removal process must not flush file
-  // buffers
-  if (!trash.empty()) {
-    if (async_delete_) {
-      pid_t pid;
-      int statloc;
-      if ((pid = fork()) == 0) {
-        // TODO(jblomer): eviciting files in the cache should perhaps become a
-        // thread.  This would also allow to block the chunks and prevent the
-        // race with re-insertion.  Then again, a thread can block umount.
-#ifndef DEBUGMSG
-        CloseAllFildes(std::set<int>());
-#endif
-        if (fork() == 0) {
-          for (unsigned i = 0, iEnd = trash.size(); i < iEnd; ++i) {
-            LogCvmfs(kLogQuota, kLogDebug, "unlink %s", trash[i].c_str());
-            unlink(trash[i].c_str());
-          }
-          _exit(0);
-        }
-        _exit(0);
-      } else {
-        if (pid > 0)
-          waitpid(pid, &statloc, 0);
-        else
-          return false;
-      }
-    } else {  // !async_delete_
-      for (unsigned i = 0, iEnd = trash.size(); i < iEnd; ++i) {
-        LogCvmfs(kLogQuota, kLogDebug, "unlink %s", trash[i].c_str());
-        unlink(trash[i].c_str());
-      }
-    }
-  }
+  if (!EmptyTrash(trash))
+    return false;
 
   if (gauge_ > leave_size) {
     LogCvmfs(kLogQuota, kLogDebug | kLogSyslogWarn,
              "request to clean until %" PRIu64 ", "
              "but effective gauge is %" PRIu64, leave_size, gauge_);
     return false;
+  }
+  return true;
+}
+
+bool PosixQuotaManager::EmptyTrash(const std::vector<std::string> &trash) {
+  if (trash.empty())
+    return true;
+
+  if (async_delete_) {
+    // Double fork avoids zombie, forked removal process must not flush file
+    // buffers
+    pid_t pid;
+    int statloc;
+    if ((pid = fork()) == 0) {
+      // TODO(jblomer): eviciting files in the cache should perhaps become a
+      // thread. This would also allow to block the chunks and prevent the
+      // race with re-insertion. Then again, a thread can block umount.
+#ifndef DEBUGMSG
+      CloseAllFildes(std::set<int>());
+#endif
+      if (fork() == 0) {
+        for (unsigned i = 0, iEnd = trash.size(); i < iEnd; ++i) {
+          LogCvmfs(kLogQuota, kLogDebug, "unlink %s", trash[i].c_str());
+          unlink(trash[i].c_str());
+        }
+        _exit(0);
+      }
+      _exit(0);
+    } else {
+      if (pid > 0)
+        waitpid(pid, &statloc, 0);
+      else
+        return false;
+    }
+  } else {  // !async_delete_
+    for (unsigned i = 0, iEnd = trash.size(); i < iEnd; ++i) {
+      LogCvmfs(kLogQuota, kLogDebug, "unlink %s", trash[i].c_str());
+      unlink(trash[i].c_str());
+    }
   }
   return true;
 }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -472,36 +472,59 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
     return true;
 
   // TODO(jblomer) transaction
-  LogCvmfs(kLogQuota, kLogSyslog,
+  LogCvmfs(kLogQuota, kLogSyslog | kLogDebug,
            "clean up cache until at most %lu KB is used", leave_size/1024);
   LogCvmfs(kLogQuota, kLogDebug, "gauge %" PRIu64, gauge_);
   cleanup_recorder_.Tick();
 
   bool result;
-  string hash_str;
   vector<string> trash;
 
   do {
     sqlite3_reset(stmt_lru_);
-    if (sqlite3_step(stmt_lru_) != SQLITE_ROW) {
-      LogCvmfs(kLogQuota, kLogDebug, "could not get lru-entry");
+
+    std::vector<shash::Any> candidates;
+    std::vector<uint64_t> sizes;
+    candidates.reserve(kEvictBatchSize);
+    sizes.reserve(kEvictBatchSize);
+    string hash_str;
+    unsigned i = 0;
+    while (sqlite3_step(stmt_lru_) == SQLITE_ROW) {
+      hash_str = string(reinterpret_cast<const char *>(
+                        sqlite3_column_text(stmt_lru_, 0)));
+      candidates.push_back(shash::MkFromHexPtr(shash::HexPtr(hash_str)));
+      sizes.push_back(sqlite3_column_int64(stmt_lru_, 1));
+      i++;
+    }
+    if (candidates.empty()) {
+      LogCvmfs(kLogQuota, kLogDebug, "no more entries to evict");
       break;
     }
 
-    hash_str = string(reinterpret_cast<const char *>(
-                      sqlite3_column_text(stmt_lru_, 0)));
-    LogCvmfs(kLogQuota, kLogDebug, "removing %s", hash_str.c_str());
-    shash::Any hash = shash::MkFromHexPtr(shash::HexPtr(hash_str));
+    const unsigned N = candidates.size();
+    for (i = 0; i < N; ++i) {
+      // That's a critical condition.  We must not delete a not yet inserted
+      // pinned file as it is already reserved (but will be inserted later).
+      // Instead, set the pin bit in the db to not run into an endless loop
+      if (pinned_chunks_.find(candidates[i]) != pinned_chunks_.end()) {
+        hash_str = candidates[i].ToString();
+        sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
+                          SQLITE_STATIC);
+        result = (sqlite3_step(stmt_block_) == SQLITE_DONE);
+        sqlite3_reset(stmt_block_);
+        assert(result);
+        continue;
+      }
 
-    // That's a critical condition.  We must not delete a not yet inserted
-    // pinned file as it is already reserved (but will be inserted later).
-    // Instead, set the pin bit in the db to not run into an endless loop
-    if (pinned_chunks_.find(hash) == pinned_chunks_.end()) {
-      trash.push_back(cache_dir_ + "/" + hash.MakePathWithoutSuffix());
-      gauge_ -= sqlite3_column_int64(stmt_lru_, 1);
+      LogCvmfs(kLogQuota, kLogDebug, "removing %s",
+               candidates[i].ToString().c_str());
+
+      trash.push_back(cache_dir_ + "/" + candidates[i].MakePathWithoutSuffix());
+      gauge_ -= sizes[i];
       LogCvmfs(kLogQuota, kLogDebug, "lru cleanup %s, new gauge %" PRIu64,
                hash_str.c_str(), gauge_);
 
+      hash_str = candidates[i].ToString();
       sqlite3_bind_text(stmt_rm_, 1, &hash_str[0], hash_str.length(),
                         SQLITE_STATIC);
       result = (sqlite3_step(stmt_rm_) == SQLITE_DONE);
@@ -514,12 +537,9 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
                  "Restart cvmfs with clean cache.", hash_str.c_str(), result);
         return false;
       }
-    } else {
-      sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
-                        SQLITE_STATIC);
-      result = (sqlite3_step(stmt_block_) == SQLITE_DONE);
-      sqlite3_reset(stmt_block_);
-      assert(result);
+
+      if (gauge_ <= leave_size)
+        break;
     }
   } while (gauge_ > leave_size);
 
@@ -937,10 +957,11 @@ bool PosixQuotaManager::InitDatabase(const bool rebuild_database) {
                      -1, &stmt_size_, NULL);
   sqlite3_prepare_v2(database_, "DELETE FROM cache_catalog WHERE sha1=:sha1;",
                      -1, &stmt_rm_, NULL);
-  sqlite3_prepare_v2(database_,
-                     "SELECT sha1, size FROM cache_catalog WHERE "
-                     "acseq=(SELECT min(acseq) "
-                     "FROM cache_catalog WHERE pinned<>2);",
+  sqlite3_prepare_v2(database_, (std::string(
+                     "SELECT sha1, size FROM cache_catalog "
+                     "WHERE pinned<>2 "
+                     "ORDER BY acseq ASC "
+                     "LIMIT ") + StringifyInt(kEvictBatchSize) + ";").c_str(),
                      -1, &stmt_lru_, NULL);
   sqlite3_prepare_v2(database_,
                      ("SELECT path FROM cache_catalog WHERE type=" +

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -473,14 +473,6 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
   if (gauge_ <= leave_size)
     return true;
 
-  struct EvictCandidate {
-    uint64_t size;
-    uint64_t acseq;
-    shash::Any hash;
-    EvictCandidate(const shash::Any &h, uint64_t s, uint64_t a)
-      : size(s), acseq(a), hash(h) {}
-  };
-
   // TODO(jblomer) transaction
   LogCvmfs(kLogQuota, kLogSyslog | kLogDebug,
            "clean up cache until at most %lu KB is used", leave_size/1024);

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -39,7 +39,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-
+#include <limits>
 #include <map>
 #include <set>
 #include <string>
@@ -150,6 +150,7 @@ void PosixQuotaManager::CloseDatabase() {
   if (stmt_list_) sqlite3_finalize(stmt_list_);
   if (stmt_lru_) sqlite3_finalize(stmt_lru_);
   if (stmt_rm_) sqlite3_finalize(stmt_rm_);
+  if (stmt_rm_batch_) sqlite3_finalize(stmt_rm_batch_);
   if (stmt_size_) sqlite3_finalize(stmt_size_);
   if (stmt_touch_) sqlite3_finalize(stmt_touch_);
   if (stmt_unpin_) sqlite3_finalize(stmt_unpin_);
@@ -164,6 +165,7 @@ void PosixQuotaManager::CloseDatabase() {
   stmt_list_volatile_ = NULL;
   stmt_list_ = NULL;
   stmt_rm_ = NULL;
+  stmt_rm_batch_ = NULL;
   stmt_size_ = NULL;
   stmt_touch_ = NULL;
   stmt_unpin_ = NULL;
@@ -471,6 +473,14 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
   if (gauge_ <= leave_size)
     return true;
 
+  struct EvictCandidate {
+    uint64_t size;
+    uint64_t acseq;
+    shash::Any hash;
+    EvictCandidate(const shash::Any &h, uint64_t s, uint64_t a)
+      : size(s), acseq(a), hash(h) {}
+  };
+
   // TODO(jblomer) transaction
   LogCvmfs(kLogQuota, kLogSyslog | kLogDebug,
            "clean up cache until at most %lu KB is used", leave_size/1024);
@@ -480,20 +490,28 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
   bool result;
   vector<string> trash;
 
+  // Note that volatile files start counting from the smallest int64 number:
+  // the absolute sequence number with the first bit set in two's complement.
+  // So -1 can be a marker that will never appear in the database.
+  int64_t max_acseq = -1;
   do {
     sqlite3_reset(stmt_lru_);
+    sqlite3_bind_int64(stmt_lru_, 1, (max_acseq == -1) ?
+                       std::numeric_limits<int64_t>::min() : (max_acseq + 1));
 
-    std::vector<shash::Any> candidates;
-    std::vector<uint64_t> sizes;
+    std::vector<EvictCandidate> candidates;
     candidates.reserve(kEvictBatchSize);
-    sizes.reserve(kEvictBatchSize);
     string hash_str;
     unsigned i = 0;
     while (sqlite3_step(stmt_lru_) == SQLITE_ROW) {
-      hash_str = string(reinterpret_cast<const char *>(
-                        sqlite3_column_text(stmt_lru_, 0)));
-      candidates.push_back(shash::MkFromHexPtr(shash::HexPtr(hash_str)));
-      sizes.push_back(sqlite3_column_int64(stmt_lru_, 1));
+      hash_str = reinterpret_cast<const char *>(
+        sqlite3_column_text(stmt_lru_, 0));
+      LogCvmfs(kLogQuota, kLogDebug, "add %s to candidates for eviction",
+               hash_str.c_str());
+      candidates.push_back(EvictCandidate(
+        shash::MkFromHexPtr(shash::HexPtr(hash_str)),
+        sqlite3_column_int64(stmt_lru_, 1),
+        sqlite3_column_int64(stmt_lru_, 2)));
       i++;
     }
     if (candidates.empty()) {
@@ -506,8 +524,10 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       // That's a critical condition.  We must not delete a not yet inserted
       // pinned file as it is already reserved (but will be inserted later).
       // Instead, set the pin bit in the db to not run into an endless loop
-      if (pinned_chunks_.find(candidates[i]) != pinned_chunks_.end()) {
-        hash_str = candidates[i].ToString();
+      if (pinned_chunks_.find(candidates[i].hash) != pinned_chunks_.end()) {
+        hash_str = candidates[i].hash.ToString();
+        LogCvmfs(kLogQuota, kLogDebug, "skip %s for eviction",
+                 hash_str.c_str());
         sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
                           SQLITE_STATIC);
         result = (sqlite3_step(stmt_block_) == SQLITE_DONE);
@@ -516,36 +536,28 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
         continue;
       }
 
-      LogCvmfs(kLogQuota, kLogDebug, "removing %s",
-               candidates[i].ToString().c_str());
-
-      trash.push_back(cache_dir_ + "/" + candidates[i].MakePathWithoutSuffix());
-      gauge_ -= sizes[i];
+      trash.push_back(cache_dir_ + "/" +
+                      candidates[i].hash.MakePathWithoutSuffix());
+      gauge_ -= candidates[i].size;
+      max_acseq = candidates[i].acseq;
       LogCvmfs(kLogQuota, kLogDebug, "lru cleanup %s, new gauge %" PRIu64,
-               hash_str.c_str(), gauge_);
-
-      hash_str = candidates[i].ToString();
-      sqlite3_bind_text(stmt_rm_, 1, &hash_str[0], hash_str.length(),
-                        SQLITE_STATIC);
-      result = (sqlite3_step(stmt_rm_) == SQLITE_DONE);
-      sqlite3_reset(stmt_rm_);
-
-      if (!result) {
-        LogCvmfs(kLogQuota, kLogDebug | kLogSyslogErr,
-                 "failed to find %s in cache database (%d). "
-                 "Cache database is out of sync. "
-                 "Restart cvmfs with clean cache.", hash_str.c_str(), result);
-        return false;
-      }
+               candidates[i].hash.ToString().c_str(), gauge_);
 
       if (gauge_ <= leave_size)
         break;
     }
   } while (gauge_ > leave_size);
 
-  result = (sqlite3_step(stmt_unblock_) == SQLITE_DONE);
-  sqlite3_reset(stmt_unblock_);
-  assert(result);
+  if (max_acseq != -1) {
+    sqlite3_bind_int64(stmt_rm_batch_, 1, max_acseq);
+    result = (sqlite3_step(stmt_rm_batch_) == SQLITE_DONE);
+    assert(result);
+    sqlite3_reset(stmt_rm_batch_);
+
+    result = (sqlite3_step(stmt_unblock_) == SQLITE_DONE);
+    sqlite3_reset(stmt_unblock_);
+    assert(result);
+  }
 
   if (!EmptyTrash(trash))
     return false;
@@ -957,9 +969,12 @@ bool PosixQuotaManager::InitDatabase(const bool rebuild_database) {
                      -1, &stmt_size_, NULL);
   sqlite3_prepare_v2(database_, "DELETE FROM cache_catalog WHERE sha1=:sha1;",
                      -1, &stmt_rm_, NULL);
+  sqlite3_prepare_v2(database_,
+                     "DELETE FROM cache_catalog WHERE acseq<=:a AND pinned<>2;",
+                     -1, &stmt_rm_batch_, NULL);
   sqlite3_prepare_v2(database_, (std::string(
-                     "SELECT sha1, size FROM cache_catalog "
-                     "WHERE pinned<>2 "
+                     "SELECT sha1, size, acseq FROM cache_catalog "
+                     "WHERE pinned<>2 AND acseq>=:a "
                      "ORDER BY acseq ASC "
                      "LIMIT ") + StringifyInt(kEvictBatchSize) + ";").c_str(),
                      -1, &stmt_lru_, NULL);
@@ -1656,6 +1671,7 @@ PosixQuotaManager::PosixQuotaManager(
   , stmt_lru_(NULL)
   , stmt_size_(NULL)
   , stmt_rm_(NULL)
+  , stmt_rm_batch_(NULL)
   , stmt_list_(NULL)
   , stmt_list_pinned_(NULL)
   , stmt_list_catalogs_(NULL)

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -197,6 +197,11 @@ class PosixQuotaManager : public QuotaManager {
   static const unsigned kCommandBufferSize = 32;
 
   /**
+   * Batch size for database operations during DoCleanup()
+   */
+  static const unsigned kEvictBatchSize = 10000;
+
+  /**
    * Make sure that the amount of data transferred through the RPC pipe is
    * within the OS's guarantees for atomicity.
    */

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -180,9 +180,19 @@ class PosixQuotaManager : public QuotaManager {
   };
 
   /**
+   * Used for batch queries in DoCleanup()
+   */
+  struct EvictCandidate {
+    uint64_t size;
+    uint64_t acseq;
+    shash::Any hash;
+    EvictCandidate(const shash::Any &h, uint64_t s, uint64_t a)
+      : size(s), acseq(a), hash(h) {}
+  };
+
+  /**
    * Magic number to make reading PIDs from lockfiles more robust and versionable
    */
-
   static const unsigned kLockFileMagicNumber = 142857;
 
   /**

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -220,6 +220,7 @@ class PosixQuotaManager : public QuotaManager {
   void CloseDatabase();
   bool Contains(const std::string &hash_str);
   bool DoCleanup(const uint64_t leave_size);
+  bool EmptyTrash(const std::vector<std::string> &trash);
 
   void MakeReturnPipe(int pipe[2]);
   int BindReturnPipe(int pipe_wronly);

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -199,7 +199,7 @@ class PosixQuotaManager : public QuotaManager {
   /**
    * Batch size for database operations during DoCleanup()
    */
-  static const unsigned kEvictBatchSize = 10000;
+  static const unsigned kEvictBatchSize = 1000;
 
   /**
    * Make sure that the amount of data transferred through the RPC pipe is
@@ -352,6 +352,7 @@ class PosixQuotaManager : public QuotaManager {
   sqlite3_stmt *stmt_lru_;
   sqlite3_stmt *stmt_size_;
   sqlite3_stmt *stmt_rm_;
+  sqlite3_stmt *stmt_rm_batch_;
   sqlite3_stmt *stmt_list_;
   sqlite3_stmt *stmt_list_pinned_;  /**< Loaded catalogs are pinned. */
   sqlite3_stmt *stmt_list_catalogs_;

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -58,7 +58,7 @@ class T_QuotaManager : public ::testing::Test {
                                 false);
     ASSERT_TRUE(quota_mgr_not_spawned_ != NULL);
 
-    for (unsigned i = 0; i < 40000; ++i) {
+    for (unsigned i = 0; i < 50002; ++i) {
       hashes_.push_back(shash::Any(shash::kSha1));
       EncodeInHash(i, hashes_[i]);
     }
@@ -66,6 +66,7 @@ class T_QuotaManager : public ::testing::Test {
   }
 
   void EncodeInHash(int value, shash::Any &hash) {
+    assert(value < (1 << 16));
     hash.digest[0] = value / 256;
     hash.digest[1] = value % 256;
   }

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -58,11 +58,21 @@ class T_QuotaManager : public ::testing::Test {
                                 false);
     ASSERT_TRUE(quota_mgr_not_spawned_ != NULL);
 
-    for (unsigned i = 0; i < 8; ++i) {
+    for (unsigned i = 0; i < 40000; ++i) {
       hashes_.push_back(shash::Any(shash::kSha1));
-      hashes_[i].digest[0] = i;
+      EncodeInHash(i, hashes_[i]);
     }
     prng_.InitLocaltime();
+  }
+
+  void EncodeInHash(int value, shash::Any &hash) {
+    hash.digest[0] = value / 256;
+    hash.digest[1] = value % 256;
+  }
+
+  int DecodeFromHash(const shash::Any &hash) {
+    return static_cast<int>(hash.digest[1]) +
+           static_cast<int>(hash.digest[0]) * 256;
   }
 
   virtual void TearDown() {
@@ -79,6 +89,14 @@ class T_QuotaManager : public ::testing::Test {
     if (tmp_path_ != "")
       RemoveTree(tmp_path_);
     EXPECT_EQ(used_fds_, GetNoUsedFds());
+  }
+
+  string StringifyIntLeadingZeros(unsigned value) {
+    string result = StringifyInt(value);
+    int n_leading_zeros = (result.length() >= 10) ? 0 : (10u - result.length());
+    if (n_leading_zeros == 0)
+      return result;
+    return string(n_leading_zeros, '0') + result;
   }
 
   string PrintStringVector(const vector<string> &lines) {
@@ -202,18 +220,20 @@ TEST_F(T_QuotaManager, Cleanup) {
 TEST_F(T_QuotaManager, CleanupLru) {
   unsigned N = hashes_.size();
   vector<shash::Any> shuffled_hashes = Shuffle(hashes_, &prng_);
-  for (unsigned i = 0; i < N; ++i)
+  for (unsigned i = 0; i < N; ++i) {
     quota_mgr_->Insert(shuffled_hashes[i], 1,
-                       StringifyInt(shuffled_hashes[i].digest[0]));
-  for (unsigned i = 0; i < N; ++i)
+      StringifyIntLeadingZeros(DecodeFromHash(shuffled_hashes[i])));
+  }
+  for (unsigned i = 0; i < N; ++i) {
     quota_mgr_->Touch(hashes_[i]);
+  }
 
   EXPECT_TRUE(quota_mgr_->Cleanup(N/2));
   vector<string> remaining = quota_mgr_->List();
   EXPECT_EQ(N/2, remaining.size());
   sort(remaining.begin(), remaining.end());
   for (unsigned i = 0; i < remaining.size(); ++i) {
-    EXPECT_EQ(StringifyInt(N/2 + i), remaining[i]);
+    EXPECT_EQ(StringifyIntLeadingZeros(N/2 + i), remaining[i]);
   }
 }
 
@@ -234,10 +254,10 @@ TEST_F(T_QuotaManager, CleanupTouchPinnedOnExit) {
 TEST_F(T_QuotaManager, CleanupVolatile) {
   unsigned N = hashes_.size();
   for (unsigned i = 0; i < N-2; ++i)
-    quota_mgr_->Insert(hashes_[i], 1, StringifyInt(i));
+    quota_mgr_->Insert(hashes_[i], 1, StringifyIntLeadingZeros(i));
   // Two last ones are volatile
   for (unsigned i = N-2; i < N; ++i)
-    quota_mgr_->InsertVolatile(hashes_[i], 1, StringifyInt(i));
+    quota_mgr_->InsertVolatile(hashes_[i], 1, StringifyIntLeadingZeros(i));
 
   // Remove one out of two volatile entries
   EXPECT_TRUE(quota_mgr_->Cleanup(N-1));
@@ -245,9 +265,9 @@ TEST_F(T_QuotaManager, CleanupVolatile) {
   EXPECT_EQ(N-1, remaining.size());
   sort(remaining.begin(), remaining.end());
   for (unsigned i = 0; i < N-2; ++i) {
-    EXPECT_EQ(StringifyInt(i), remaining[i]);
+    EXPECT_EQ(StringifyIntLeadingZeros(i), remaining[i]);
   }
-  EXPECT_EQ(StringifyInt(N-1), remaining[N-2]);
+  EXPECT_EQ(StringifyIntLeadingZeros(N-1), remaining[N-2]);
 
   // Remove half of the entries, volatile entries first
   EXPECT_TRUE(quota_mgr_->Cleanup(N/2));
@@ -255,7 +275,7 @@ TEST_F(T_QuotaManager, CleanupVolatile) {
   EXPECT_EQ(N/2, remaining.size());
   sort(remaining.begin(), remaining.end());
   for (unsigned i = 0; i < remaining.size(); ++i) {
-    EXPECT_EQ(StringifyInt(N/2 + i - 2), remaining[i]);
+    EXPECT_EQ(StringifyIntLeadingZeros(N/2 + i - 2), remaining[i]);
   }
 }
 

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -60,15 +60,15 @@ class T_QuotaManager : public ::testing::Test {
 
     for (unsigned i = 0; i < 50002; ++i) {
       hashes_.push_back(shash::Any(shash::kSha1));
-      EncodeInHash(i, hashes_[i]);
+      EncodeInHash(i, &hashes_[i]);
     }
     prng_.InitLocaltime();
   }
 
-  void EncodeInHash(int value, shash::Any &hash) {
+  void EncodeInHash(int value, shash::Any *hash) {
     assert(value < (1 << 16));
-    hash.digest[0] = value / 256;
-    hash.digest[1] = value % 256;
+    hash->digest[0] = value / 256;
+    hash->digest[1] = value % 256;
   }
 
   int DecodeFromHash(const shash::Any &hash) {


### PR DESCRIPTION
Currently, during eviction, the cache database is processed entry-by-entry with (usually) two SQL queries per entry (select + remove). This PR changes the processing to batch selection (1000 entries per batch) and a single remove call per cache cleanup. The unit tests show a drastic improvement for 50000 entries from a few 100ms to <1ms.

Fixes #3491