### PR TITLE
Update method of downloading the MaxMind GeoIP database

### DIFF
--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -15,7 +15,7 @@ CVMFS_UPDATEGEO_HOUR=10 # First hour of day for update, 0-23, default 10am
 CVMFS_UPDATEGEO_MINDAYS=14 # Minimum days between update attempts
 CVMFS_UPDATEGEO_MAXDAYS=28 # Maximum days before considering it urgent
 
-CVMFS_UPDATEGEO_URLBASE="https://download.maxmind.com/app/geoip_download"
+CVMFS_UPDATEGEO_URLBASE="https://download.maxmind.com/geoip/databases/GeoLite2-City/download"
 CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo"
 CVMFS_UPDATEGEO_DB="GeoLite2-City.mmdb"
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -957,11 +957,16 @@ _to_syslog_for_geoip() {
 
 _update_geodb_install() {
   local retcode=0
-  local dburl="${CVMFS_UPDATEGEO_URLBASE}?edition_id=${CVMFS_UPDATEGEO_DB%.*}&suffix=tar.gz&license_key=$CVMFS_GEO_LICENSE_KEY"
+  local dburl="${CVMFS_UPDATEGEO_URLBASE}?suffix=tar.gz"
   local dbfile="${CVMFS_UPDATEGEO_DIR}/${CVMFS_UPDATEGEO_DB}"
   local download_target=${dbfile}.tgz
   local untar_dir=${dbfile}.untar
 
+  if [ -z "$CVMFS_GEO_ACCOUT_ID" ]; then
+      echo "CVMFS_GEO_ACCOUT_ID not set" >&2
+      _to_syslog_for_geoip "CVMFS_GEO_ACCOUT_ID not set"
+      return 1
+  fi
   if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
       echo "CVMFS_GEO_LICENSE_KEY not set" >&2
       _to_syslog_for_geoip "CVMFS_GEO_LICENSE_KEY not set"
@@ -971,8 +976,9 @@ _update_geodb_install() {
   _to_syslog_for_geoip "started update from $dburl"
 
   # downloading the GeoIP database file
-  curl -sS  --connect-timeout 10 \
+  curl -L -sS  --connect-timeout 10 \
             --max-time 60        \
+            -u "${CVMFS_GEO_ACCOUT_ID}:${CVMFS_GEO_LICENSE_KEY}" \
             "$dburl" > $download_target || true
   if ! tar tzf $download_target >/dev/null 2>&1; then
     local msg


### PR DESCRIPTION
This merge request addresses issue #3529 -- the need to update  `cvmfs_server` because MaxMind is changing the API for GeoIP database downloads. The new method requires the account ID.

`cvmfs` administrator documentation will have to be changed to say that the new variable `CVMFS_GEO_ACCOUT_ID` needs to be added to `/etc/cvmfs/server.local`. The administrator will need to check their MaxMind account to get their account ID.

These changes were tested to verify that the `cvmfs_server update-geodb` command successfully downloads the database file by the new method. Testing also confirms the command will now fail if `CVMFS_GEO_ACCOUT_ID` is not configured.