### PR TITLE
Fix ATLAS tightcache find test

### DIFF
--- a/test/src/026-tightcache/main
+++ b/test/src/026-tightcache/main
@@ -5,15 +5,18 @@ cvmfs_test_name="Recursive listing of ATLAS with small cache"
 cvmfs_run_test() {
   logfile=$1
 
-  cvmfs_mount "atlas.cern.ch,atlas-nightlies.cern.ch,atlas-condb.cern.ch" \
+  cvmfs_mount "atlas.cern.ch" \
     "CVMFS_QUOTA_LIMIT=2500" \
     "CVMFS_CACHE_EXTERNAL_SIZE=2500" \
     "CVMFS_CHECK_PERMISSIONS=no" \
+    "CVMFS_REPOSITORY_DATE=2022-03-01T13:00:00Z" \
     "CVMFS_AUTO_UPDATE=no" || return 1
 
   echo "Walking through /cvmfs/atlas.cern.ch"
   sudo find /cvmfs/atlas.cern.ch -ignore_readdir_race > /dev/null
   local retval=$?
+  echo "cache size after find:"
+  sudo cvmfs_talk -i atlas.cern.ch cache size
   if [ $retval -ne 0 ]; then
     echo "retval $retval"
     return 2


### PR DESCRIPTION
This test keeps failing with Input/Output errors as the repository grows. It is likely that this is just the increased size of pinned catalogs that do not fit anymore in the purposefully small cache, but it should be debugged with a recent root hash. For now, use an older root hash that is known to work in this test to fix the test suite.