### PR TITLE
Update method of downloading the MaxMind GeoIP

### DIFF
--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -15,7 +15,7 @@ CVMFS_UPDATEGEO_HOUR=10 # First hour of day for update, 0-23, default 10am
 CVMFS_UPDATEGEO_MINDAYS=14 # Minimum days between update attempts
 CVMFS_UPDATEGEO_MAXDAYS=28 # Maximum days before considering it urgent
 
-CVMFS_UPDATEGEO_URLBASE="https://download.maxmind.com/app/geoip_download"
+CVMFS_UPDATEGEO_URLBASE="https://download.maxmind.com/geoip/databases/GeoLite2-City/download"
 CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo"
 CVMFS_UPDATEGEO_DB="GeoLite2-City.mmdb"
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -957,11 +957,16 @@ _to_syslog_for_geoip() {
 
 _update_geodb_install() {
   local retcode=0
-  local dburl="${CVMFS_UPDATEGEO_URLBASE}?edition_id=${CVMFS_UPDATEGEO_DB%.*}&suffix=tar.gz&license_key=$CVMFS_GEO_LICENSE_KEY"
+  local dburl="${CVMFS_UPDATEGEO_URLBASE}?suffix=tar.gz"
   local dbfile="${CVMFS_UPDATEGEO_DIR}/${CVMFS_UPDATEGEO_DB}"
   local download_target=${dbfile}.tgz
   local untar_dir=${dbfile}.untar
 
+  if [ -z "$CVMFS_GEO_ACCOUNT_ID" ]; then
+      echo "CVMFS_GEO_ACCOUNT_ID not set" >&2
+      _to_syslog_for_geoip "CVMFS_GEO_ACCOUNT_ID not set"
+      return 1
+  fi
   if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
       echo "CVMFS_GEO_LICENSE_KEY not set" >&2
       _to_syslog_for_geoip "CVMFS_GEO_LICENSE_KEY not set"
@@ -971,8 +976,9 @@ _update_geodb_install() {
   _to_syslog_for_geoip "started update from $dburl"
 
   # downloading the GeoIP database file
-  curl -sS  --connect-timeout 10 \
+  curl -L -sS  --connect-timeout 10 \
             --max-time 60        \
+            -u "${CVMFS_GEO_ACCOUNT_ID}:${CVMFS_GEO_LICENSE_KEY}" \
             "$dburl" > $download_target || true
   if ! tar tzf $download_target >/dev/null 2>&1; then
     local msg

--- a/test/cloud_testing/platforms/common_test.sh
+++ b/test/cloud_testing/platforms/common_test.sh
@@ -59,7 +59,7 @@ usage() {
 
 
 # parse script parameters (same for all platforms)
-while getopts "t:s:c:d:l:S:G:" option; do
+while getopts "t:s:c:d:l:S:G:K:" option; do
   case $option in
     t)
       SOURCE_DIRECTORY=$OPTARG
@@ -81,6 +81,9 @@ while getopts "t:s:c:d:l:S:G:" option; do
       ;;
     G)
       export CVMFS_TEST_GEO_LICENSE_KEY="$OPTARG"
+      ;;
+    K)
+      export CVMFS_TEST_GEO_ACCOUNT_ID="$OPTARG"
       ;;
     ?)
       shift $(($OPTIND-2))

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -3,8 +3,8 @@ cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
 # NOTE:
-#  A full test requires a valid CVMFS_GEO_LICENSE_KEY in a
-#    /etc/cvmfs/server.local that is readable by $CVMFS_TEST_USER.
+#  A full test requires a valid CVMFS_GEO_ACCOUNT_ID and CVMFS_GEO_LICENSE_KEY
+#  in a /etc/cvmfs/server.local that is readable by $CVMFS_TEST_USER.
 #  Test will be skipped with a warning if either CVMFS_GEO_DB_FILE is
 #    set or there's no CVMFS_GEO_LICENSE_KEY but there is a system
 #    geo DB in /usr/share/GeoIP.
@@ -89,13 +89,21 @@ cvmfs_run_test() {
   if [ -f /etc/cvmfs/server.local ]; then
     . /etc/cvmfs/server.local
   fi
-  if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
-    if [ -f /usr/share/GeoIP/`basename $CVMFS_TEST_595_GEODB` ]; then
+  if [ -z "$CVMFS_GEO_ACCOUNT_ID" -o -z "$CVMFS_GEO_LICENSE_KEY" ]; then
+    if [ -z "$CVMFS_GEO_LICENSE_KEY" -a -f /usr/share/GeoIP/`basename $CVMFS_TEST_595_GEODB` ]; then
       echo "System geo database installed, skipping tests"
       CVMFS_GENERAL_WARNING_FLAG=1
       return 0
     fi
-    echo "No geo license key or db file found"
+    ACCT_MSG=
+    LICENSE_MSG=
+    if [ -z "$CVMFS_GEO_ACCOUNT_ID" ]; then
+      ACCT_MSG=", geo account ID"
+    fi
+    if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
+      LICENSE_MSG=", geo license key"
+    fi
+    echo The following are not found: db file${ACCT_MSG}${LICENSE_MSG}
     return 1
   fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -24,6 +24,7 @@ CVMFS_TEST_REPO_MORE=${CVMFS_TEST_REPO_MORE:=test-more.cern.ch}
 CVMFS_TEST_USER=${CVMFS_TEST_USER:=sftnight}   # user and group are used to over-
 CVMFS_TEST_GROUP=${CVMFS_TEST_GROUP:=sftnight} # write the owner of files for testing
 CVMFS_TEST_GEO_LICENSE_KEY=${CVMFS_TEST_GEO_LICENSE_KEY:=}
+CVMFS_TEST_GEO_ACCOUNT_ID=${CVMFS_TEST_GEO_ACCOUNT_ID:=}
 
 CVMFS_TEST_UNIONFS=${CVMFS_TEST_UNIONFS:=} # union filesystem type to test
 CVMFS_TEST_SRVDEBUG=${CVMFS_TEST_SRVDEBUG:=}
@@ -57,6 +58,9 @@ fi
 
 if [ ! -z "$CVMFS_TEST_GEO_LICENSE_KEY" ]; then
   echo "CVMFS_GEO_LICENSE_KEY=$CVMFS_TEST_GEO_LICENSE_KEY" | sudo tee /etc/cvmfs/server.local > /dev/null
+fi
+if [ ! -z "$CVMFS_TEST_GEO_ACCOUNT_ID" ]; then
+  echo "CVMFS_GEO_ACCOUNT_ID=$CVMFS_TEST_GEO_ACCOUNT_ID" | sudo tee /etc/cvmfs/server.local > /dev/null
 fi
 
 if [ -f /.dockerinit ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -60,7 +60,7 @@ if [ ! -z "$CVMFS_TEST_GEO_LICENSE_KEY" ]; then
   echo "CVMFS_GEO_LICENSE_KEY=$CVMFS_TEST_GEO_LICENSE_KEY" | sudo tee /etc/cvmfs/server.local > /dev/null
 fi
 if [ ! -z "$CVMFS_TEST_GEO_ACCOUNT_ID" ]; then
-  echo "CVMFS_GEO_ACCOUNT_ID=$CVMFS_TEST_GEO_ACCOUNT_ID" | sudo tee /etc/cvmfs/server.local > /dev/null
+  echo "CVMFS_GEO_ACCOUNT_ID=$CVMFS_TEST_GEO_ACCOUNT_ID" | sudo tee -a /etc/cvmfs/server.local > /dev/null
 fi
 
 if [ -f /.dockerinit ]; then


### PR DESCRIPTION
This merge request addresses issue https://github.com/cvmfs/cvmfs/issues/3529 -- the need to update `cvmfs_server` because MaxMind is changing the API for GeoIP database downloads. The new method requires the account ID.

`cvmfs` administrator documentation will have to be changed to say that the new variable `CVMFS_GEO_ACCOUNT_ID` needs to be added to `/etc/cvmfs/server.local`. The administrator will need to check their MaxMind account to get their account ID.

These changes were tested to verify that the `cvmfs_server update-geodb` command successfully downloads the database file by the new method. Testing also confirms the command will now fail if `CVMFS_GEO_ACCOUNT_ID` is not configured.

The test script  `test/src/595-geoipdbupdate/main` was updated and tested successfully.