### PR TITLE
Do only one gc -a at a time, and remove need for check -a to be run by root

### DIFF
--- a/test/src/688-checkall/main
+++ b/test/src/688-checkall/main
@@ -84,7 +84,7 @@ cvmfs_run_test() {
                     $CVMFS_STRATUM0                        \
                     /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
                     || return $num
-    sudo cvmfs_server snapshot ${replica_name}-$num
+    cvmfs_server snapshot ${replica_name}-$num
   done
 
   echo "*** disabling snapshots to second replica"
@@ -100,9 +100,10 @@ cvmfs_run_test() {
   delete_from_backend ${replica_name}-4 ".cvmfswhitelist"
 
   create_fake_gc_lock_until_contention ${replica_name}-1 &
+  sleep 1 # give time to create lock
 
   echo "*** running cvmfs_server check -a"
-  sudo cvmfs_server check -a || return 10
+  cvmfs_server check -a || return 10
 
   echo "*** contents of checks.log"
   cat /var/log/cvmfs/checks.log
@@ -119,17 +120,17 @@ cvmfs_run_test() {
   curl -f -s "$(get_repo_url ${replica_name}-4)/.cvmfs_status.json" | grep check_status.*failed || return 54
 
   echo "*** fix replica 4"
-  sudo cvmfs_server snapshot ${replica_name}-4 || return 55
+  cvmfs_server snapshot ${replica_name}-4 || return 55
 
   echo "*** do individual check on replica 4"
-  sudo cvmfs_server check ${replica_name}-4 || return 56
+  cvmfs_server check ${replica_name}-4 || return 56
 
   echo "*** verifying check now succeeded on replica 4"
   curl -f -s "$(get_repo_url ${replica_name}-4)/.cvmfs_status.json" | grep check_status.*succeeded || return 57
 
   create_fake_gc_lock ${replica_name}-1
   echo "*** verify that fake gc lock prevents gc"
-  sudo cvmfs_server gc -f ${replica_name}-1 2>&1 | grep aborting || return 60
+  cvmfs_server gc -f ${replica_name}-1 2>&1 | grep aborting || return 60
   remove_fake_gc_lock ${replica_name}-1
 
   return 0


### PR DESCRIPTION
Make sure only one `cvmfs_server gc -a` command is running at a time.
- Fixes #3574

Also, when comparing this behavior to `cvmfs_server check -a` I noticed that had inadvertently added a requirement that the command be run by root even if the repositories were owned by another user.  This removes that requirement as well.  For backward compatibility it checks for the old lock file as well, but without attempting to acquire it since it may not have the permission.  So there's a slight chance that the old lock file will exist without the corresponding active process still existing, but it should only happen at most once on a given machine and be found & remedied pretty easily on investigation.