### PR TITLE
Trim whitespace from list values in config file

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1439,7 +1439,10 @@ bool MountPoint::CreateDownloadManagers() {
                                    forced_proxy_template);
 
   string proxies;
-  if (options_mgr_->GetValue("CVMFS_HTTP_PROXY", &optarg))
+  vector<char> delims;
+  delims.push_back(';');
+  delims.push_back('|');
+  if (options_mgr_->GetValue("CVMFS_HTTP_PROXY", &optarg, delims))
     proxies = optarg;
   proxies = download::ResolveProxyDescription(
     proxies,

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -373,10 +373,19 @@ bool OptionsManager::IsDefined(const std::string &key) {
 }
 
 
-bool OptionsManager::GetValue(const string &key, string *value) const {
+bool OptionsManager::GetValue(const string &key, string *value,
+                              const vector<char> &delims) const {
   map<string, ConfigValue>::const_iterator iter = config_.find(key);
   if (iter != config_.end()) {
-    *value = iter->second.value;
+    if (delims.empty()) {
+      *value = iter->second.value;
+    } else {
+      *value = "";
+      vector<string> values = SplitString(iter->second.value, delims);
+      for (unsigned i = 0; i < values.size(); ++i) {
+        *value += Trim(values[i]) + delims[0];
+      }
+    }
     return true;
   }
   *value = "";

--- a/cvmfs/options.h
+++ b/cvmfs/options.h
@@ -108,9 +108,11 @@ class OptionsManager {
    *
    * @param  key variable to be accessed in the map
    * @param  value container of the received value, if it exists
+   * @param  delims container of the delimiters used in the value, if it exists
    * @return true if there was a value stored in the map for key
    */
-  bool GetValue(const std::string &key, std::string *value) const;
+  bool GetValue(const std::string &key, std::string *value,
+                const std::vector<char> &delims = std::vector<char>()) const;
 
   /**
    * Gets the stored value for a concrete variable. Panics if the value is

--- a/cvmfs/publish/cmd_commit.cc
+++ b/cvmfs/publish/cmd_commit.cc
@@ -28,8 +28,10 @@ int CmdCommit::Main(const Options &options) {
   std::string fqrn;
 
   if (!options.plain_args().empty()) {
+    std::vector<char> delims;
+    delims.push_back('/');
     std::vector<std::string> tokens =
-      SplitStringBounded(2, options.plain_args()[0].value_str, '/');
+        SplitStringBounded(2, options.plain_args()[0].value_str, delims);
     fqrn = tokens[0];
   }
 

--- a/cvmfs/publish/cmd_transaction.cc
+++ b/cvmfs/publish/cmd_transaction.cc
@@ -28,8 +28,10 @@ int CmdTransaction::Main(const Options &options) {
   std::string fqrn;
   std::string lease_path;
   if (!options.plain_args().empty()) {
-    std::vector<std::string> tokens =
-      SplitStringBounded(2, options.plain_args()[0].value_str, '/');
+    std::vector<char> delims;
+    delims.push_back('/');
+    std::vector<std::string> tokens = SplitStringBounded(
+        2, options.plain_args()[0].value_str, delims);
     fqrn = tokens[0];
     if (tokens.size() == 2)
       lease_path = MakeCanonicalPath(tokens[1]);

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -325,7 +325,10 @@ void SyncItem::CheckGraft() {
     if (!trimmed_line.size()) {continue;}
     if (trimmed_line[0] == '#') {continue;}
 
-    std::vector<std::string> info = SplitStringBounded(2, trimmed_line, '=');
+    std::vector<char> delims;
+    delims.push_back('=');
+    std::vector<std::string> info =
+        SplitStringBounded(2, trimmed_line, delims);
 
     if (info.size() != 2) {
       LogCvmfs(kLogFsTraversal, kLogWarning, "Invalid line in graft file: %s",

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <set>
 #include <string>
 
 using namespace std;  // NOLINT
@@ -288,13 +289,19 @@ bool HasSuffix(const std::string &str, const std::string &suffix,
 }
 
 vector<string> SplitString(const string &str, char delim) {
-  return SplitStringBounded(0, str, delim);
+  vector<char> delims;
+  delims.push_back(delim);
+  return SplitStringBounded(0, str, delims);
 }
 
-vector<string> SplitStringBounded(
-  unsigned max_chunks, const string &str, char delim)
-{
+vector<string> SplitString(const string &str, const vector<char> &delims) {
+  return SplitStringBounded(0, str, delims);
+}
+
+vector<string> SplitStringBounded(unsigned max_chunks, const string &str,
+                                  const vector<char> &delims) {
   vector<string> result;
+  const set<char> delims_set(delims.begin(), delims.end());
 
   // edge case... one chunk is always the whole string
   if (1 == max_chunks) {
@@ -308,7 +315,7 @@ vector<string> SplitStringBounded(
   unsigned chunks = 1;
   unsigned i;
   for (i = 0; i < size; ++i) {
-    if (str[i] == delim) {
+    if (delims_set.count(str[i])) {
       result.push_back(str.substr(marker, i - marker));
       marker = i + 1;
 

--- a/cvmfs/util/string.h
+++ b/cvmfs/util/string.h
@@ -48,9 +48,11 @@ CVMFS_EXPORT bool HasSuffix(const std::string &str, const std::string &suffix,
                             const bool ignore_case);
 
 CVMFS_EXPORT std::vector<std::string> SplitStringBounded(
-  unsigned max_chunks, const std::string &str, char delim);
+  unsigned max_chunks, const std::string &str, const std::vector<char> &delims);
 CVMFS_EXPORT std::vector<std::string> SplitString(const std::string &str,
                                                   char delim);
+CVMFS_EXPORT std::vector<std::string> SplitString(
+    const std::string &str, const std::vector<char> &delims);
 
 CVMFS_EXPORT std::string JoinStrings(const std::vector<std::string> &strings,
                                      const std::string &joint);

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -202,6 +202,19 @@ TYPED_TEST(T_Options, SetValue) {
   EXPECT_TRUE(options_manager.GetValue("UNKNOWN_BEFORE", &arg));
   EXPECT_EQ("information", arg);
 
+  options_manager.SetValue(
+      "CVMFS_HTTP_PROXY",
+      "http://p1.site.example.org:3128| http://p2.site.example.org:3128; "
+      "http://p3.region.example.org:3128| http://p4.region.example.org:3128");
+  vector<char> delims;
+  delims.push_back(';');
+  delims.push_back('|');
+  EXPECT_TRUE(options_manager.GetValue("CVMFS_HTTP_PROXY", &arg, delims));
+  EXPECT_EQ(
+      "http://p1.site.example.org:3128;http://p2.site.example.org:3128;http://"
+      "p3.region.example.org:3128;http://p4.region.example.org:3128;",
+      arg);
+
   EXPECT_TRUE(options_manager.IsDefined("CVMFS_SERVER_URL"));
   options_manager.UnsetValue("CVMFS_SERVER_URL");
   EXPECT_FALSE(options_manager.IsDefined("CVMFS_SERVER_URL"));

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1354,26 +1354,32 @@ TEST_F(T_Util, SplitString) {
   string str1 = "the string that will be cut in peaces";
   string str2 = "my::string:by:colons";
   vector<string> result;
+  vector<char> delims1, delims2, delims3, delims4;
 
-  result = SplitStringBounded(1, str1, ' ');
+  delims1.push_back(' ');
+  result = SplitStringBounded(1, str1, delims1);
   EXPECT_EQ(1u, result.size());
   EXPECT_EQ(str1, result[0]);
 
-  result = SplitStringBounded(2, str1, ' ');
+  delims2.push_back(' ');
+  result = SplitStringBounded(2, str1, delims2);
   EXPECT_EQ(2u, result.size());
   EXPECT_EQ("the", result[0]);
   EXPECT_EQ("string that will be cut in peaces", result[1]);
 
-  result = SplitStringBounded(200, str1, ';');
+  delims3.push_back(';');
+  result = SplitStringBounded(200, str1, delims3);
   EXPECT_EQ(1u, result.size());
   EXPECT_EQ(str1, result[0]);
 
-  result = SplitStringBounded(200, str2, ':');
+  delims4.push_back(':');
+  result = SplitStringBounded(200, str2, delims4);
   EXPECT_EQ(5u, result.size());
   EXPECT_EQ("", result[1]);
-  EXPECT_EQ(SplitStringBounded(5, str2, ':'),
-            SplitStringBounded(5000, str2, ':'));
+  EXPECT_EQ(SplitStringBounded(5, str2, delims4),
+            SplitStringBounded(5000, str2, delims4));
 }
+
 
 TEST_F(T_Util, JoinStrings) {
   vector<string> result;


### PR DESCRIPTION
What:
Trims whitespace from all list elements in a config file if the delimiter is specified.

Why:
https://github.com/cvmfs/cvmfs/issues/3572