### PR TITLE
cache-bypass direct-read pathway

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1877,6 +1877,8 @@ MountPoint::MountPoint(
   , fixed_catalog_(false)
   , enforce_acls_(false)
   , cache_symlinks_(false)
+  , cache_bypass_(false)
+  , max_retry_time_(0)
   , fuse_expire_entry_(false)
   , has_membership_req_(false)
   , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
@@ -2034,8 +2036,20 @@ bool MountPoint::SetupBehavior() {
   {
     cache_symlinks_ = true;
   }
+  if (options_mgr_->GetValue("CVMFS_CACHE_BYPASS", &optarg)
+      && options_mgr_->IsOn(optarg))
+  {
+    cache_bypass_ = true;
+  }
 
-
+  unsigned max_retry_time = kDefaultMaxTime;
+  if (options_mgr_->GetValue("CVMFS_MAX_RETRY_TIME", &optarg))
+  {
+    max_retry_time = String2Uint64(optarg);
+  }
+  max_retry_time_ = max_retry_time;
+  download_mgr_->SetMaxRetryTime(max_retry_time);
+  external_download_mgr_->SetMaxRetryTime(max_retry_time);
 
   if (options_mgr_->GetValue("CVMFS_TALK_SOCKET", &optarg)) {
     talk_socket_path_ = optarg;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -517,6 +517,8 @@ class MountPoint : SingleCopy, public BootFactory {
   bool has_membership_req() { return has_membership_req_; }
   bool enforce_acls() { return enforce_acls_; }
   bool cache_symlinks() { return cache_symlinks_; }
+  bool cache_bypass() { return cache_bypass_; }
+  uint64_t max_retry_time() { return max_retry_time_; }
   bool fuse_expire_entry() { return fuse_expire_entry_; }
   catalog::InodeAnnotation *inode_annotation() {
     return inode_annotation_;
@@ -582,6 +584,8 @@ class MountPoint : SingleCopy, public BootFactory {
   static const unsigned kDefaultRetries = 1;
   static const unsigned kDefaultBackoffInitMs = 2000;
   static const unsigned kDefaultBackoffMaxMs = 10000;
+  static const unsigned kDefaultMaxTime = 10800;
+  
   /**
    * Memory buffer sizes for an activated tracer
    */
@@ -663,6 +667,8 @@ class MountPoint : SingleCopy, public BootFactory {
   bool fixed_catalog_;
   bool enforce_acls_;
   bool cache_symlinks_;
+  bool cache_bypass_;
+  uint64_t max_retry_time_;
   bool fuse_expire_entry_;
   std::string repository_tag_;
   std::vector<std::string> blacklist_paths_;


### PR DESCRIPTION
Enable by setting `CVMFS_CACHE_BYPASS`. `cvmfs_read()` will then use a direct read pathway, where each fuse read request is directly translated to at least one back-end HTTP GET. Does not affect speculatively eager prefetch of non-chunked files.

(caveat emptor: feature backport without any testing)