### PR TITLE
Fix number of seconds in kDefaultMaxTtl

### DIFF
--- a/cvmfs/network/dns.h
+++ b/cvmfs/network/dns.h
@@ -179,7 +179,7 @@ class Resolver : SingleCopy {
   /**
    * Cut off very large TTLs by default to 1 day.
    */
-  static const unsigned kDefaultMaxTtl = 84600;
+  static const unsigned kDefaultMaxTtl = 86400;
 
   Resolver(const bool ipv4_only,
            const unsigned retries,


### PR DESCRIPTION
Intended to be a day, likely a typo - this shouldn't have had any consequences except being slightly shorter than advertised in the comment.

Fixes #3600 