### PR TITLE
External file direct download (WIP)

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -77,6 +77,7 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS)
        manifest_fetch.cc
        monitor.cc
        mountpoint.cc
+       network/direct_download.cc
        network/dns.cc
        network/download.cc
        network/jobinfo.cc

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -96,6 +96,7 @@
 #include "monitor.h"
 #include "mountpoint.h"
 #include "network/download.h"
+#include "network/direct_download.h"
 #include "nfs_maps.h"
 #include "notification_client.h"
 #include "options.h"
@@ -1176,7 +1177,16 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   perf::Inc(file_system_->n_fs_open());  // Count actual open / fetch operations
 
   glue::PageCacheTracker::OpenDirectives open_directives;
-  if (!dirent.IsChunkedFile()) {
+  if (mount_point_->external_direct() && dirent.IsExternalFile()) {
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "external file %s will be direct (open() skipped)",
+             path.c_str());
+    fuse_remounter_->fence()->Leave();
+    fi->fh = 0;
+    SetBit(download::DirectDownload::kBitDirectDownload, &fi->fh);
+    fuse_reply_open(req, fi);
+    return;
+  } else if (!dirent.IsChunkedFile()) {
     if (dirent.IsDirectIo()) {
       open_directives = mount_point_->page_cache_tracker()->OpenDirect();
     } else {
@@ -1357,6 +1367,16 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
 }
 
 
+static int cvmfs_read_reply(void *priv, const char *buf, size_t size)
+{
+  return fuse_reply_buf(static_cast<fuse_req_t>(priv), buf, size);
+}
+
+static int cvmfs_read_error(void *priv, int error)
+{
+  return fuse_reply_err(static_cast<fuse_req_t>(priv), error);
+}
+
 /**
  * Redirected to pread into cache.
  */
@@ -1378,6 +1398,25 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   }
 #endif
 
+  const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
+  FuseInterruptCue ic(&req);
+  ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
+
+  if (TestBit(download::DirectDownload::kBitDirectDownload, fi->fh)) {
+    PathString path;
+    bool found = GetPathForInode(ino, &path);
+    if (!found) {
+      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
+             "EIO (08) on <unknown inode> external direct");
+      perf::Inc(file_system_->n_eio_total());
+      perf::Inc(file_system_->n_eio_08());
+      return;
+    }
+    mount_point_->direct_download()->Read(cvmfs_read_reply, cvmfs_read_error, req,
+      mount_point_->external_download_mgr(), path.ToString(), off, size);
+    return;
+  }
+
   // Get data chunk (<=128k guaranteed by Fuse)
   char *data = static_cast<char *>(alloca(size));
   unsigned int overall_bytes_fetched = 0;
@@ -1388,10 +1427,6 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 
   // Do we have a a chunked file?
   if (fd < 0) {
-    const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
-    FuseInterruptCue ic(&req);
-    ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
-
     const uint64_t chunk_handle = abs_fd;
     uint64_t unique_inode;
     ChunkFd chunk_fd;
@@ -1548,6 +1583,12 @@ static void cvmfs_release(fuse_req_t req, fuse_ino_t ino,
     return;
   }
 #endif
+
+  if (TestBit(download::DirectDownload::kBitDirectDownload, fi->fh)) {
+    perf::Dec(file_system_->no_open_files());
+    fuse_reply_err(req, 0);
+    return;
+  }
 
   int64_t fd = static_cast<int64_t>(fi->fh);
   uint64_t abs_fd = (fd < 0) ? -fd : fd;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -52,6 +52,7 @@
 #include "manifest.h"
 #include "manifest_fetch.h"
 #include "network/download.h"
+#include "network/direct_download.h"
 #include "nfs_maps.h"
 #ifdef CVMFS_NFS_SUPPORT
 #include "nfs_maps_leveldb.h"
@@ -2177,6 +2178,21 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
     fallback_proxies = optarg;
   external_download_mgr_->SetProxyChain(
     proxies, fallback_proxies, download::DownloadManager::kSetProxyBoth);
+
+  if (options_mgr_->GetValue("CVMFS_EXTERNAL_DIRECT", &optarg) &&
+      options_mgr_->IsOn(optarg))
+  {
+    external_direct_ = true;
+    direct_download_ = new download::DirectDownload(
+      perf::StatisticsTemplate("direct-download", statistics_));
+
+    if (options_mgr_->GetValue("CVMFS_DIRECT_BOUNDRY", &optarg)) {
+      uint64_t boundry = String2Uint64(optarg);
+      if (boundry > 0) {
+        direct_download_->SetBoundry(boundry);
+      }
+    }
+  }
 
   return true;
 }

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -266,6 +266,8 @@ void FileSystem::CreateStatistics() {
      "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
   n_eio_08_ =  statistics_->Register("eio.08",
      "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
+  n_eio_09_ =  statistics_->Register("eio.09",
+     "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
 
   string optarg;
   if (options_mgr_->GetValue("CVMFS_INSTRUMENT_FUSE", &optarg) &&
@@ -428,6 +430,7 @@ FileSystem::FileSystem(const FileSystem::FileSystemInfo &fs_info)
   , n_eio_06_(NULL)
   , n_eio_07_(NULL)
   , n_eio_08_(NULL)
+  , n_eio_09_(NULL)
   , statistics_(NULL)
   , fd_workspace_lock_(-1)
   , found_previous_crash_(false)
@@ -611,6 +614,7 @@ void FileSystem::ResetErrorCounters() {
   n_eio_06_->Set(0);
   n_eio_07_->Set(0);
   n_eio_08_->Set(0);
+  n_eio_09_->Set(0);
 }
 
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -245,6 +245,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_eio_06() { return n_eio_06_; }
   perf::Counter *n_eio_07() { return n_eio_07_; }
   perf::Counter *n_eio_08() { return n_eio_08_; }
+  perf::Counter *n_eio_09() { return n_eio_09_; }
   OptionsManager *options_mgr() { return options_mgr_; }
   perf::Statistics *statistics() { return statistics_; }
   Type type() { return type_; }
@@ -353,6 +354,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_eio_06_;
   perf::Counter *n_eio_07_;
   perf::Counter *n_eio_08_;
+  perf::Counter *n_eio_09_;
   IoErrorInfo io_error_info_;
   perf::Statistics *statistics_;
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -41,6 +41,7 @@ class Uuid;
 }
 namespace download {
 class DownloadManager;
+class DirectDownload;
 }
 namespace glue {
 class InodeTracker;
@@ -504,6 +505,7 @@ class MountPoint : SingleCopy, public BootFactory {
   download::DownloadManager *external_download_mgr() {
     return external_download_mgr_;
   }
+  download::DirectDownload *direct_download() { return direct_download_; }
   file_watcher::FileWatcher* resolv_conf_watcher() {
     return resolv_conf_watcher_;
   }
@@ -518,6 +520,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool enforce_acls() { return enforce_acls_; }
   bool cache_symlinks() { return cache_symlinks_; }
   bool fuse_expire_entry() { return fuse_expire_entry_; }
+  bool external_direct() { return external_direct_; }
   catalog::InodeAnnotation *inode_annotation() {
     return inode_annotation_;
   }
@@ -639,6 +642,7 @@ class MountPoint : SingleCopy, public BootFactory {
   signature::SignatureManager *signature_mgr_;
   download::DownloadManager *download_mgr_;
   download::DownloadManager *external_download_mgr_;
+  download::DirectDownload *direct_download_;
   cvmfs::Fetcher *fetcher_;
   cvmfs::Fetcher *external_fetcher_;
   catalog::InodeAnnotation *inode_annotation_;
@@ -664,6 +668,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool enforce_acls_;
   bool cache_symlinks_;
   bool fuse_expire_entry_;
+  bool external_direct_;
   std::string repository_tag_;
   std::vector<std::string> blacklist_paths_;
 

--- a/cvmfs/network/direct_download.cc
+++ b/cvmfs/network/direct_download.cc
@@ -1,0 +1,325 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+
+#include "clientctx.h"
+#include "direct_download.h"
+#include "util/logging.h"
+
+using namespace std;  // NOLINT
+
+namespace download {
+
+static void curl_share_lock_cb(CURL *handle, curl_lock_data data,
+                    curl_lock_access access, void *userptr) {
+  pthread_mutex_t *locks = static_cast<pthread_mutex_t*>(userptr);
+  pthread_mutex_lock(&locks[data]);
+}
+
+static void curl_share_unlock_cb(CURL *handle, curl_lock_data data, void *userptr) {
+  pthread_mutex_t *locks = static_cast<pthread_mutex_t*>(userptr);
+  pthread_mutex_unlock(&locks[data]);
+}
+
+DirectDownload::DirectDownload(perf::StatisticsTemplate statistics) {
+  boundry_ = 0;
+
+  n_eio = statistics.RegisterTemplated("n_eio", "IO errors");
+
+  for (size_t i = 0; i < CURL_LOCK_DATA_LAST; i++) {
+    int retval = pthread_mutex_init(&curl_share_locks_[i], NULL);
+    assert(retval == 0);
+  }
+
+  curl_share_ = curl_share_init();
+  assert(curl_share_ != NULL);
+  assert(curl_share_setopt(curl_share_, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS) == CURLSHE_OK);
+  assert(curl_share_setopt(curl_share_, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT) == CURLSHE_OK);
+  assert(curl_share_setopt(curl_share_, CURLSHOPT_LOCKFUNC, curl_share_lock_cb) == CURLSHE_OK);
+  assert(curl_share_setopt(curl_share_, CURLSHOPT_UNLOCKFUNC, curl_share_unlock_cb) == CURLSHE_OK);
+  assert(curl_share_setopt(curl_share_, CURLSHOPT_USERDATA,
+                           static_cast<void *>(curl_share_locks_)) == CURLSHE_OK);
+}
+
+DirectDownload::~DirectDownload() {
+  curl_share_cleanup(curl_share_);
+  curl_share_ = NULL;
+
+  for (size_t i = 0; i < CURL_LOCK_DATA_LAST; i++) {
+    pthread_mutex_destroy(&curl_share_locks_[i]);
+  }
+}
+
+const char *DirectDownload::StripAuth(const char *url)
+{
+    const char *path = strrchr(url, '@');
+    return path ? path + 1 : url;
+}
+
+// Make sure the start(inclusize)-end(inclusive) stays within a boundry. Return the end.
+uint64_t DirectDownload::RangeBoundry(uint64_t start, uint64_t end) {
+  if (boundry_ == 0) {
+    return end;
+  }
+
+  uint64_t end_max = start + boundry_;
+  end_max = (end_max / boundry_) * boundry_;
+
+  if (end >= end_max) {
+    end = end_max - 1;
+  }
+
+  return end;
+}
+
+static size_t curl_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata) {
+  DirectResponse *response = static_cast<DirectResponse*>(userdata);
+
+  if (response->error) {
+    return 0;
+  }
+
+  // libcurl says size is always 1
+  if (size != 1) {
+    nmemb *= size;
+  }
+
+  if (nmemb > response->size - response->bytes) {
+    response->error = 1;
+    return 0;
+  }
+
+  memcpy(response->buffer + response->bytes, ptr, nmemb);
+  response->bytes += nmemb;
+  response->calls++;
+  assert(response->bytes <= response->size);
+
+  return nmemb;
+}
+
+void DirectDownload::Read(Read_f read_f, Error_f error_f, void *priv, download::DownloadManager *mgr,
+    const string &path, uint64_t offset, uint64_t size)
+{
+  if (size == 0) {
+    read_f(priv, NULL, 0);
+    return;
+  }
+
+  DirectResponse response;
+  memset(&response, 0, sizeof(response));
+  response.size = size;
+  response.buffer = (char*)smalloc(response.size);
+  if (!response.buffer) {
+    LogCvmfs(kLogDownload, kLogDebug, "direct read(%s) malloc failed", path.c_str());
+    error_f(priv, EIO);
+    perf::Inc(n_eio);
+    return;
+  }
+
+  //string host = (*opt_host_chain_)[opt_host_chain_current_];
+  vector<string> host_chain;
+  unsigned current_host = 0;
+  mgr->GetHostInfo(&host_chain, NULL, &current_host);
+  if (host_chain.size() <= current_host) {
+    LogCvmfs(kLogDownload, kLogDebug, "direct read(%s) bad host_chain", path.c_str());
+    error_f(priv, EIO);
+    perf::Inc(n_eio);
+    return;
+  }
+  string url = host_chain[current_host] + path;
+  string proxy;
+
+  CURL *curl = curl_easy_init();
+
+  if (!curl) {
+    LogCvmfs(kLogDownload, kLogDebug, "direct read(%s) curl_easy_init failed", path.c_str());
+    error_f(priv, EIO);
+    perf::Inc(n_eio);
+    return;
+  }
+
+  unsigned proxy_timeout, direct_timeout;
+  mgr->GetTimeout(&proxy_timeout, &direct_timeout);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, proxy_timeout);
+
+  if (curl_easy_setopt(curl, CURLOPT_SHARE, curl_share_) != CURLE_OK) {
+    LogCvmfs(kLogDownload, kLogSyslogWarn, "direct read(%s) CURLOPT_SHARE failed", path.c_str());
+  }
+
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "cvmfs direct " VERSION);
+  curl_easy_setopt(curl, CURLOPT_MAXCONNECTS, 100);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)&response);
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+  curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1);
+  curl_easy_setopt(curl, CURLOPT_URL, mgr->EscapeUrl(0, url).c_str());
+
+  if (proxy.length() > 0) {
+    curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());
+  }
+
+  // Tracing headers
+  char hbuf[256];
+  struct curl_slist *slist = NULL;
+
+  if (mgr->enable_info_header_) {
+    string path_escaped = mgr->EscapeUrl(0, path);
+    snprintf(hbuf, sizeof(hbuf), "cvmfs-info: %s", path_escaped.c_str());
+    slist = curl_slist_append(slist, hbuf);
+  }
+
+  if (mgr->enable_http_tracing_) {
+    uid_t uid;
+    gid_t gid;
+    pid_t pid;
+    InterruptCue *ic;
+    ClientCtx *ctx = ClientCtx::GetInstance();
+    ctx->Get(&uid, &gid, &pid, &ic);
+    snprintf(hbuf, sizeof(hbuf), "X-CVMFS-UID: %u", uid);
+    slist = curl_slist_append(slist, hbuf);
+    snprintf(hbuf, sizeof(hbuf), "X-CVMFS-GID: %u", gid);
+    slist = curl_slist_append(slist, hbuf);
+    snprintf(hbuf, sizeof(hbuf), "X-CVMFS-PID: %d", pid);
+    slist = curl_slist_append(slist, hbuf);
+
+    for (size_t i = 0; i < mgr->http_tracing_headers_.size(); i++) {
+      slist = curl_slist_append(slist, mgr->http_tracing_headers_[i].c_str());
+    }
+  }
+
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
+
+  // Ranges are inclusive
+  uint64_t offset_max = offset + size - 1;
+  unsigned int offset_tries = 0;
+  char range_buf[100];
+  bool done = false, retry, error = false;
+  unsigned int retries = 0;
+  unsigned int max_retries = mgr->opt_max_retries_;
+  long response_code = -1;
+  while (!done && !error) {
+    // Make sure we stay within a boundry
+    uint64_t offset_end = RangeBoundry(offset, offset_max);
+    snprintf(range_buf, sizeof(range_buf), "%lu-%lu", offset, offset_end);
+    curl_easy_setopt(curl, CURLOPT_RANGE, range_buf);
+
+    LogCvmfs(kLogDownload, kLogDebug, "direct read(%s, %lu, %lu/%lu) proxy: %s",
+      path.c_str(), offset, offset_end - offset + 1, size,
+      StripAuth(proxy.c_str()));
+
+    CURLcode res = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+    offset_tries++;
+    retry = false;
+
+    // These curl error codes are retried (see download.cc)
+    switch (res) {
+      case CURLE_COULDNT_RESOLVE_PROXY:
+      case CURLE_COULDNT_RESOLVE_HOST:
+      case CURLE_OPERATION_TIMEDOUT:
+      case CURLE_PARTIAL_FILE:
+      case CURLE_GOT_NOTHING:
+      case CURLE_RECV_ERROR:
+      case CURLE_COULDNT_CONNECT:
+        retry = true;
+        break;
+      case CURLE_WRITE_ERROR:
+        error = true;
+        break;
+      default:
+        break;
+    }
+
+    // All HTTP errors are marked for retry
+    if (response_code >= 400) {
+      retry = true;
+    }
+
+    // Do not retry these errors
+    if (response_code == 404 || response.error) {
+      error = true;
+    }
+
+    // We reached the end
+    if (response_code == 416) {
+      done = true;
+    }
+
+    // Too many retries
+    if (retries > max_retries) {
+      done = true;
+    }
+
+    if (done || error) {
+      break;
+    }
+
+    if (retry) {
+      //proxy = next proxy;
+      curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());
+
+      LogCvmfs(kLogDownload, kLogDebug, "direct read(%s) curl error (%d, %ld) new proxy: %s",
+        path.c_str(), res, response_code, StripAuth(proxy.c_str()));
+
+      perf::Inc(mgr->counters_->n_proxy_failover);
+
+      // TODO fix this
+      retries++;
+      if (retries > 10) {
+        SafeSleepMs(2000);
+      } else if (retries > 3) {
+        SafeSleepMs(250);
+      }
+    } else {
+      offset = offset_end + 1;
+      if (offset <= offset_max) {
+        // Still more left
+        offset_end = RangeBoundry(offset, offset_max);
+        snprintf(range_buf, sizeof(range_buf), "%lu-%lu", offset, offset_end);
+        curl_easy_setopt(curl, CURLOPT_RANGE, range_buf);
+
+        //proxy = next proxy;
+        curl_easy_setopt(curl, CURLOPT_PROXY, proxy.c_str());
+      } else {
+        done = true;
+      }
+    }
+  }
+
+  curl_slist_free_all(slist);
+  curl_easy_cleanup(curl);
+
+  // Not enough bytes
+  if (response.bytes < size) {
+    error = true;
+  }
+
+  int response_error = 1;
+  if (!error && !response.error) {
+    response_error = read_f(priv, response.buffer, response.bytes);
+  }
+  if (response_error) {
+    LogCvmfs(kLogDownload, kLogDebug, "direct read(%s) read_f error %d",
+      path.c_str(), response_error);
+    error_f(priv, EIO);
+    perf::Inc(n_eio);
+
+    free(response.buffer);
+    response.buffer = NULL;
+
+    return;
+  }
+
+  LogCvmfs(kLogDownload, kLogDebug, "direct read(%s) %ld response, %zu bytes in %zu calls %u boundries %u retries",
+    path.c_str(), response_code, response.bytes, response.calls, offset_tries, retries);
+
+  free(response.buffer);
+  response.buffer = NULL;
+
+  return;
+}
+
+}  // namespace download

--- a/cvmfs/network/direct_download.h
+++ b/cvmfs/network/direct_download.h
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_NETWORK_DIRECT_DOWNLOAD_H_
+#define CVMFS_NETWORK_DIRECT_DOWNLOAD_H_
+
+#include <pthread.h>
+#include <stddef.h>
+
+#include "directory_entry.h"
+#include "download.h"
+#include "duplex_curl.h"
+#include "statistics.h"
+
+namespace download {
+
+struct DirectResponse {
+  char *buffer;
+  size_t size;
+  size_t bytes;
+  size_t calls;
+  int error;
+};
+
+class DirectDownload {
+ public:
+  static const unsigned int kBitDirectDownload = 61;
+
+  typedef int (Read_f)(void *priv, const char *buf, size_t size);
+  typedef int (Error_f)(void *priv, int error);
+
+  DirectDownload(perf::StatisticsTemplate statistics);
+  ~DirectDownload();
+
+  void SetBoundry(uint64_t boundry) { boundry_ = boundry; }
+  void Read(Read_f read_f, Error_f error_f, void *priv, download::DownloadManager *mgr, const std::string &path,
+    uint64_t offset, uint64_t size);
+
+ private:
+
+  uint64_t RangeBoundry(uint64_t start, uint64_t end);
+  const char *StripAuth(const char *url);
+
+  CURLSH *curl_share_;
+  pthread_mutex_t curl_share_locks_[CURL_LOCK_DATA_LAST];
+  uint64_t boundry_;
+  perf::Counter *n_eio;
+
+};  // DirectDownload
+
+}  // namespace download
+
+#endif  // CVMFS_NETWORK_DOWNLOAD_H_

--- a/cvmfs/network/direct_download.h
+++ b/cvmfs/network/direct_download.h
@@ -40,6 +40,8 @@ class DirectDownload {
  private:
 
   uint64_t RangeBoundry(uint64_t start, uint64_t end);
+  std::string GetProxy(download::DownloadManager *mgr, const std::string &path,
+    const std::string &current_proxy, uint64_t offset);
   const char *StripAuth(const char *url);
 
   CURLSH *curl_share_;

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -117,6 +117,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   FRIEND_TEST(T_Download, ValidateGeoReply);
   FRIEND_TEST(T_Download, StripDirect);
   FRIEND_TEST(T_Download, EscapeUrl);
+  friend class DirectDownload;
 
  public:
   struct ProxyInfo {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -157,6 +157,7 @@ if (BUILD_SERVER)
        ${CVMFS_SOURCE_DIR}/catalog_mgr_ro.cc
        ${CVMFS_SOURCE_DIR}/catalog_mgr_rw.cc
        ${CVMFS_SOURCE_DIR}/catalog_virtual.cc
+       ${CVMFS_SOURCE_DIR}/clientctx.cc
        ${CVMFS_SOURCE_DIR}/compression/compression.cc
        ${CVMFS_SOURCE_DIR}/directory_entry.cc
        ${CVMFS_SOURCE_DIR}/gateway_util.cc
@@ -177,6 +178,7 @@ if (BUILD_SERVER)
        ${CVMFS_SOURCE_DIR}/malloc_arena.cc
        ${CVMFS_SOURCE_DIR}/manifest.cc
        ${CVMFS_SOURCE_DIR}/manifest_fetch.cc
+       ${CVMFS_SOURCE_DIR}/network/direct_download.cc
        ${CVMFS_SOURCE_DIR}/network/dns.cc
        ${CVMFS_SOURCE_DIR}/network/download.cc
        ${CVMFS_SOURCE_DIR}/network/jobinfo.cc
@@ -458,6 +460,7 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/manifest_fetch.cc
   ${CVMFS_SOURCE_DIR}/monitor.cc
   ${CVMFS_SOURCE_DIR}/mountpoint.cc
+  ${CVMFS_SOURCE_DIR}/network/direct_download.cc
   ${CVMFS_SOURCE_DIR}/network/dns.cc
   ${CVMFS_SOURCE_DIR}/network/download.cc
   ${CVMFS_SOURCE_DIR}/network/jobinfo.cc


### PR DESCRIPTION
This is the external file direct download patch. How it works is if `CVMFS_EXTERNAL_DIRECT` is enabled and an external file is opened and read, CVMFS will bypass the local cache and read directly from the external HTTP proxy.

This is still a work in progress, whats left todo:

- [x] Finish Fuse functionality
- [ ] Align proxy selection logic
- [ ] Add functionality to libcvmfs
- [ ] Test cases
- [ ] Review and feedback

Feel free to review and give feedback at any point during this process.