### PR TITLE
Remove unnecessary remount fence in cvmfs_open error path

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1317,9 +1317,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
       LogCvmfs(kLogCvmfs, kLogSyslogErr, "open file descriptor limit exceeded");
       // not returning an fd, so close the page cache tracker entry if required
       if (!dirent.IsDirectIo()) {
-        fuse_remounter_->fence()->Enter();
         mount_point_->page_cache_tracker()->Close(ino);
-        fuse_remounter_->fence()->Leave();
       }
       fuse_reply_err(req, EMFILE);
       return;
@@ -1330,9 +1328,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   // fd < 0
   // the download has failed. Close the page cache tracker entry if required
   if (!dirent.IsDirectIo()) {
-    fuse_remounter_->fence()->Enter();
     mount_point_->page_cache_tracker()->Close(ino);
-    fuse_remounter_->fence()->Leave();
   }
 
   LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,


### PR DESCRIPTION
As discussed in https://github.com/cvmfs/cvmfs/pull/3588, the fence should be unnecessary.