### PR TITLE
DownloadMgr: better logging for host/proxies

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -2845,8 +2845,8 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
 
   // Report any change in proxy usage
   string new_proxy = JoinStrings(opt_proxies_, "|");
-  string curr_host = "Current host: "
-                                  + (*opt_host_chain_)[opt_host_chain_current_];
+  string curr_host = "Current host: " + (opt_host_chain_ ?
+                              (*opt_host_chain_)[opt_host_chain_current_] : "");
   if (new_proxy != old_proxy) {
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
            "(manager '%s') switching proxy from %s to %s. Reason: %s [%s]",

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -2365,7 +2365,7 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
       }
     } else {
       LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-               "(manager '%s') GeoAPI request %s failed with error %d [%s]",
+               "(manager '%s') GeoAPI request for %s failed with error %d [%s]",
                name_.c_str(), url.c_str(), result, Code2Ascii(result));
     }
   }
@@ -2805,11 +2805,11 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
   // Identify number of non-burned proxies within the current group
   vector<ProxyInfo> *group = current_proxy_group();
   unsigned num_alive = (group->size() - opt_proxy_groups_current_burned_);
-  string old_proxy = JoinStrings(opt_proxy_urls_, "|");
+  string old_proxy = JoinStrings(opt_proxies_, "|");
 
   // Rebuild proxy map and URL list
   opt_proxy_map_.clear();
-  opt_proxy_urls_.clear();
+  opt_proxies_.clear();
   const uint32_t max_key = 0xffffffffUL;
   if (opt_proxy_shard_) {
     // Build a consistent map with multiple entries for each proxy
@@ -2823,7 +2823,9 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
         const std::pair<uint32_t, ProxyInfo *> entry(prng.Next(max_key), proxy);
         opt_proxy_map_.insert(entry);
       }
-      opt_proxy_urls_.push_back(proxy->url);
+      std::string proxy_name = proxy->host.name().empty() ?
+                                           "" : " (" + proxy->host.name() + ")";
+      opt_proxies_.push_back(proxy->url + proxy_name);
     }
     // Ensure lower_bound() finds a value for all keys
     ProxyInfo *first_proxy = opt_proxy_map_.begin()->second;
@@ -2835,18 +2837,22 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
     ProxyInfo *proxy = &(*group)[select];
     const std::pair<uint32_t, ProxyInfo *> entry(max_key, proxy);
     opt_proxy_map_.insert(entry);
-    opt_proxy_urls_.push_back(proxy->url);
+    std::string proxy_name = proxy->host.name().empty() ?
+                                           "" : " (" + proxy->host.name() + ")";
+    opt_proxies_.push_back(proxy->url + proxy_name);
   }
-  sort(opt_proxy_urls_.begin(), opt_proxy_urls_.end());
+  sort(opt_proxies_.begin(), opt_proxies_.end());
 
   // Report any change in proxy usage
-  string new_proxy = JoinStrings(opt_proxy_urls_, "|");
+  string new_proxy = JoinStrings(opt_proxies_, "|");
+  string curr_host = "Current host: "
+                                  + (*opt_host_chain_)[opt_host_chain_current_];
   if (new_proxy != old_proxy) {
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-           "(manager '%s') switching proxy from %s to %s. Reason: %s",
+           "(manager '%s') switching proxy from %s to %s. Reason: %s [%s]",
            name_.c_str(), (old_proxy.empty() ? "(none)" : old_proxy.c_str()),
            (new_proxy.empty() ? "(none)" : new_proxy.c_str()),
-           reason.c_str());
+           reason.c_str(), curr_host.c_str());
   }
 }
 

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -351,7 +351,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   /**
    * Sorted list of currently active proxy URLs (for log messages)
    */
-  std::vector<std::string> opt_proxy_urls_;
+  std::vector<std::string> opt_proxies_;
   /**
    * Shard requests across multiple proxies via consistent hashing
    */


### PR DESCRIPTION
issue #3616

add proxy host name and current host to the output when switching proxies.

please note that the current host might not have been the one that has been serving a previous download request!
( i first thought about adding a note... but then the log message in the syslog becomes even longer)

 we could think about some how reducing the length of the host e.g. from `http://cvmfs-stratum-one.cern.ch/cvmfs/cvmfs-config.cern.ch` to `http://cvmfs-stratum-one.cern.ch`?

new logs look like this:

```
 (cvmfs-config.cern.ch) (manager 'standard') switching proxy from (none) to DIRECT. Reason: set random start proxy from the first proxy group [Current host: http://cvmfs-stratum-one.cern.ch/cvmfs/cvmfs-config.cern.ch]

cvmfs2[1288189]: (sft.cern.ch) (manager 'standard') failed to resolve IP addresses for ca-proxy-sft.cern.ch (4 - unknown host name)
cvmfs2[1288189]: (sft.cern.ch) (manager 'standard') switching proxy from (none) to http://ca-proxy-sft.cern.ch:3128 (ca-proxy-sft.cern.ch). Reason: set random start proxy from the first proxy group [Current host: http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch]
cvmfs2[1288189]: (sft.cern.ch) (manager 'standard') switching proxy from http://ca-proxy-sft.cern.ch:3128 (ca-proxy-sft.cern.ch) to http://128.142.248.156:3126 (cmsextproxy.cern.ch). Reason: failed proxy [Current host: http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch]
cvmfs2[1288189]: (sft.cern.ch) (manager 'standard') geographic order of servers retrieved from cvmfs-s1bnl.opensciencegrid.org
cvmfs2[1288189]: (sft.cern.ch) (manager 'standard') switching proxy from http://128.142.248.156:3126 (cmsextproxy.cern.ch) to http://128.142.35.143:3126 (cmsextproxy.cern.ch). Reason: geosort [Current host: http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch]
cvmfs2[1288189]: (sft.cern.ch) (manager 'external') switching proxy from (none) to http://128.142.35.143:3126 (cmsextproxy.cern.ch). Reason: cloned [Current host: http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch]
cvmfs2[1288189]: (sft.cern.ch) (manager 'external') switching proxy from http://128.142.35.143:3126 (cmsextproxy.cern.ch) to DIRECT. Reason: set random start proxy from the first proxy group [Current host: ]
cvmfs2[1288189]: (sft.cern.ch) CernVM-FS: linking /cvmfs/sft.cern.ch to repository sft.cern.ch
cvmfs2[1288243]: (sft.cern.ch) (manager 'standard') switching proxy from http://128.142.35.143:3126 (cmsextproxy.cern.ch) to http://131.225.188.246:3126 (cmsextproxy.fnal.gov). Reason: switch to proxy group 2 [Current host: http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch]
cvmfs2[1288243]: (sft.cern.ch) (manager 'standard') switching proxy from http://131.225.188.246:3126 (cmsextproxy.fnal.gov) to DIRECT. Reason: switch to proxy group 3 [Current host: http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch]
cvmfs2[1288243]: (sft.cern.ch) (manager standard) switching host from http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sft.cern.ch to http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/sft.cern.ch (manually triggered)
cvmfs2[1288243]: (sft.cern.ch) (manager 'standard') switching proxy from DIRECT to http://ca-proxy-sft.cern.ch:3128 (ca-proxy-sft.cern.ch). Reason: switch to proxy group 0 [Current host: http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/sft.cern.ch]
cvmfs2[1288243]: (sft.cern.ch) (manager 'standard') switching proxy from http://ca-proxy-sft.cern.ch:3128 (ca-proxy-sft.cern.ch) to http://128.142.35.143:3126 (cmsextproxy.cern.ch). Reason: switch to proxy group 1 [Current host: http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/sft.cern.ch]
```