### PR TITLE
Add support for xattrs with values up to 64k

### DIFF
--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -13,6 +13,7 @@
 // clang-format on
 
 #include <dirent.h>
+#include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -353,6 +354,14 @@ inline uint64_t platform_realtime_ns() {
 inline uint64_t platform_memsize() {
   return static_cast<uint64_t>(sysconf(_SC_PHYS_PAGES))
          * static_cast<uint64_t>(sysconf(_SC_PAGE_SIZE));
+}
+
+inline uint16_t platform_htole16(uint16_t host_16bits) {
+  return htole16(host_16bits);
+}
+
+inline uint16_t platform_le16toh(uint16_t little_endian_16bits) {
+  return le16toh(little_endian_16bits);
 }
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -17,6 +17,7 @@
 #include <libkern/OSAtomic.h>
 #endif  //  defined(__MAC_OS_X_VERSION_MIN_REQUIRED) &&
         //  __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+#include <libkern/OSByteOrder.h>
 #include <mach-o/dyld.h>
 #include <mach/mach.h>  // NOLINT
 #include <mach/mach_time.h>
@@ -307,6 +308,14 @@ inline uint64_t platform_memsize() {
   rc = sysctl(mib, 2, &ramsize, &len, NULL, 0);
   assert(rc == 0);
   return ramsize;
+}
+
+inline uint16_t platform_htole16(uint16_t host_16bits) {
+  return OSSwapHostToLittleInt16(host_16bits);
+}
+
+inline uint16_t platform_le16toh(uint16_t little_endian_16bits) {
+  return OSSwapLittleToHostInt16(little_endian_16bits);
 }
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -6,6 +6,7 @@
 
 #ifndef CVMFS_UTIL_PLATFORM_OSX_H_
 #define CVMFS_UTIL_PLATFORM_OSX_H_
+#ifdef __APPLE__
 
 #include <alloca.h>
 #include <dirent.h>
@@ -325,4 +326,5 @@ inline uint16_t platform_le16toh(uint16_t little_endian_16bits) {
 inline int prctl(int, uint64_t, uint64_t, uint64_t, uint64_t) { return 0; }
 #define PR_SET_DUMPABLE 0
 
+#endif // __APPLE__
 #endif  // CVMFS_UTIL_PLATFORM_OSX_H_

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -164,11 +164,11 @@ string XattrList::ListKeysPosix(const string &merge_with) const {
 bool XattrList::Set(const string &key, const string &value) {
   if (key.empty())
     return false;
-  if (key.length() > 256)
+  if (key.length() > 255)
     return false;
   if (key.find('\0') != string::npos)
     return false;
-  if (value.length() > 256)
+  if (value.length() >= 64 * 1024)
     return false;
 
   const map<string, string>::iterator iter = xattrs_.find(key);

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -20,7 +20,8 @@
 
 using namespace std;  // NOLINT
 
-const uint8_t XattrList::kVersion = 1;
+const uint8_t XattrList::kVersionSmall = 1;
+const uint8_t XattrList::kVersionBig = 2;  // As of cvmfs 2.12
 
 /**
  * Converts all the extended attributes of path into a XattrList.  Attributes
@@ -76,7 +77,7 @@ XattrList *XattrList::Deserialize(const unsigned char *inbuf,
     return NULL;
   XattrHeader header;
   memcpy(&header, inbuf, sizeof(header));
-  if (header.version != kVersion)
+  if (!IsSupportedVersion(header.version))
     return NULL;
   unsigned pos = sizeof(header);
   for (unsigned i = 0; i < header.num_xattrs; ++i) {

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -53,15 +53,27 @@ XattrList *XattrList::CreateFromFile(const std::string &path) {
 
   // Retrieve extended attribute values
   XattrList *result = new XattrList();
-  char value[256];
+  char value_smallbuf[255];
   for (unsigned i = 0; i < keys.size(); ++i) {
     if (keys[i].empty())
       continue;
-    const ssize_t sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(),
-                                                value, 256);
-    if (sz_value < 0)
-      continue;
-    result->Set(keys[i], string(value, sz_value));
+
+    char *buffer = value_smallbuf;
+    size_t sz_buffer = 255;
+    ssize_t sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer,
+                                          sz_buffer);
+    while ((sz_value < 0) && (errno == ERANGE)) {
+      if (buffer != value_smallbuf)
+        free(buffer);
+      sz_buffer *= 2;
+      buffer = reinterpret_cast<char *>(smalloc(sz_buffer));
+      sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer,
+                                    sz_buffer);
+    }
+    if (sz_value >= 0)
+      result->Set(keys[i], string(buffer, sz_value));
+    if (buffer != value_smallbuf)
+        free(buffer);
   }
   return result;
 }

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -91,24 +91,26 @@ XattrList *XattrList::Deserialize(const unsigned char *inbuf,
   memcpy(&header, inbuf, sizeof(header));
   if (!IsSupportedVersion(header.version))
     return NULL;
-  unsigned pos = sizeof(header);
+
+  XattrEntrySerializer entry_serializer(header.version);
+  unsigned char *bufpos = const_cast<unsigned char *>(inbuf);
+  unsigned remain = size;
+  bufpos += sizeof(XattrHeader);
+  remain -= sizeof(XattrHeader);
+
   for (unsigned i = 0; i < header.num_xattrs; ++i) {
-    XattrEntry entry;
-    unsigned size_preamble =  // NOLINT
-        sizeof(entry.len_key) + sizeof(entry.len_value);
-    if (size - pos < size_preamble)
+    std::string key;
+    std::string value;
+    uint32_t nbytes =
+      entry_serializer.Deserialize(bufpos, remain, &key, &value);
+    if (nbytes == 0)
       return NULL;
-    memcpy(&entry, inbuf + pos, size_preamble);
-    if (size - pos < entry.GetSize())
-      return NULL;
-    if (entry.GetSize() == size_preamble)
-      return NULL;
-    pos += size_preamble;
-    memcpy(entry.data, inbuf + pos, entry.GetSize() - size_preamble);
-    pos += entry.GetSize() - size_preamble;
-    const bool retval = result->Set(entry.GetKey(), entry.GetValue());
+    bool retval = result->Set(key, value);
     if (!retval)
       return NULL;
+
+    remain -= nbytes;
+    bufpos += nbytes;
   }
   return result.Release();
 }
@@ -218,13 +220,34 @@ void XattrList::Serialize(unsigned char **outbuf,
     return;
   }
 
-  XattrHeader header(xattrs_.size());
-  uint32_t packed_size = sizeof(header);
+  XattrHeader header;
+  *size = sizeof(header);
 
+<<<<<<< HEAD
   // Determine size of the buffer (allocate space for max num of attributes)
   XattrEntry *entries = reinterpret_cast<XattrEntry *>(
       smalloc(header.num_xattrs * sizeof(XattrEntry)));
   unsigned ientries = 0;
+=======
+  for (map<string, string>::const_iterator it_att = xattrs_.begin(),
+       it_att_end = xattrs_.end(); it_att != it_att_end; ++it_att)
+  {
+    *size += it_att->first.length();
+    *size += it_att->second.length();
+    if (it_att->second.length() > 255)
+      header.version = kVersionBig;
+  }
+
+  XattrEntrySerializer entry_serializer(header.version);
+  *size += xattrs_.size() * entry_serializer.GetHeaderSize();
+  *outbuf = reinterpret_cast<unsigned char *>(smalloc(*size));
+  unsigned char *bufpos = *outbuf;
+
+  // We copy the header at the end when we know the actual number of entries
+  bufpos += sizeof(header);
+
+  header.num_xattrs = 0;
+>>>>>>> 69f84da01 (add support for big xattrs (64k value))
   for (map<string, string>::const_iterator it_att = xattrs_.begin(),
                                            it_att_end = xattrs_.end();
        it_att != it_att_end;
@@ -242,37 +265,95 @@ void XattrList::Serialize(unsigned char **outbuf,
       if (skip)
         continue;
     }
-    /*entries[ientries] =*/
-    new (entries + ientries) XattrEntry(it_att->first, it_att->second);
-    packed_size += entries[ientries].GetSize();
-    ientries++;
+
+    bufpos += entry_serializer.Serialize(it_att->first, it_att->second, bufpos);
+    header.num_xattrs++;
   }
 
   // We might have skipped all attributes
-  if (ientries == 0) {
-    free(entries);
+  if (header.num_xattrs == 0) {
+    free(*outbuf);
     *size = 0;
     *outbuf = NULL;
-    return;
+  } else {
+    memcpy(*outbuf, &header, sizeof(header));
   }
-
-  // Copy data into buffer
-  header.num_xattrs = ientries;
-  *size = packed_size;
-  *outbuf = reinterpret_cast<unsigned char *>(smalloc(packed_size));
-  memcpy(*outbuf, &header, sizeof(header));
-  unsigned pos = sizeof(header);
-  for (unsigned i = 0; i < header.num_xattrs; ++i) {
-    memcpy(*outbuf + pos, &entries[i], entries[i].GetSize());
-    pos += entries[i].GetSize();
-  }
-
-  free(entries);
 }
 
 
 //------------------------------------------------------------------------------
 
+XattrList::XattrEntrySerializer::XattrEntrySerializer(uint8_t version)
+  : version_(version)
+{
+  assert(version_ == kVersionSmall || version_ == kVersionBig);
+}
+
+uint32_t XattrList::XattrEntrySerializer::Serialize(
+  const std::string &key, const std::string &value, unsigned char *to)
+{
+  assert(key.size() < 256);
+  assert(value.size() < ((version_ == kVersionSmall) ? 256 : 64 * 1024));
+
+  const uint8_t len_key = key.size();
+  memcpy(to, &len_key, 1);
+  to += 1;
+
+  if (version_ == kVersionSmall) {
+    const uint8_t len_value = value.size();
+    memcpy(to, &len_value, 1);
+    to += 1;
+  } else {
+    assert(version_ == kVersionBig);
+    const uint16_t len_value = platform_htole16(value.size());
+    memcpy(to, &len_value, 2);
+    to += 2;
+  }
+
+  memcpy(to, key.data(), key.size());
+  to += key.size();
+  memcpy(to, value.data(), value.size());
+  to += value.size();
+
+  return GetHeaderSize() + key.size() + value.size();
+}
+
+uint32_t XattrList::XattrEntrySerializer::Deserialize(
+  const unsigned char *from, uint32_t bufsize,
+  std::string *key, std::string *value)
+{
+  if (bufsize < GetHeaderSize())
+    return 0;
+  bufsize -= GetHeaderSize();
+
+  uint8_t len_key;
+  memcpy(&len_key, from, 1);
+  key->resize(len_key);
+  from += 1;
+
+  if (version_ == kVersionSmall) {
+    uint8_t len_value;
+    memcpy(&len_value, from, 1);
+    value->resize(len_value);
+    from += 1;
+  } else {
+    assert(version_ == kVersionBig);
+    uint16_t len_value;
+    memcpy(&len_value, from, 2);
+    value->resize(platform_le16toh(len_value));
+    from += 2;
+  }
+
+
+  if (bufsize < key->size() + value->size())
+    return 0;
+
+  memcpy(key->data(), from, key->size());
+  from += key->size();
+  memcpy(value->data(), from, value->size());
+
+  return GetHeaderSize() + key->size() + value->size();
+}
 
 string XattrList::XattrEntry::GetKey() const {
   if (len_key == 0)

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -62,10 +62,13 @@ XattrList *XattrList::CreateFromFile(const std::string &path) {
     size_t sz_buffer = 255;
     ssize_t sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer,
                                           sz_buffer);
-    while ((sz_value < 0) && (errno == ERANGE)) {
+    // check if we need to allocate bigger buffer
+    if ((sz_value < 0) && (errno == ERANGE)) {
+      // query lgetxattr with size 0 to get proper buffer size
+      sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer, 0);
       if (buffer != value_smallbuf)
         free(buffer);
-      sz_buffer *= 2;
+      sz_buffer = sz_value;
       buffer = reinterpret_cast<char *>(smalloc(sz_buffer));
       sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer,
                                     sz_buffer);

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -21,7 +21,7 @@
 using namespace std;  // NOLINT
 
 const uint8_t XattrList::kVersionSmall = 1;
-const uint8_t XattrList::kVersionBig = 2;  // As of cvmfs 2.12
+const uint8_t XattrList::kVersionBig = 2;  // As of cvmfs 2.14
 
 /**
  * Converts all the extended attributes of path into a XattrList.  Attributes

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -348,9 +348,9 @@ uint32_t XattrList::XattrEntrySerializer::Deserialize(
   if (bufsize < key->size() + value->size())
     return 0;
 
-  memcpy(key->data(), from, key->size());
+  memcpy(const_cast<char *>(key->data()), from, key->size());
   from += key->size();
-  memcpy(value->data(), from, value->size());
+  memcpy(const_cast<char *>(value->data()), from, value->size());
 
   return GetHeaderSize() + key->size() + value->size();
 }

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -223,12 +223,6 @@ void XattrList::Serialize(unsigned char **outbuf,
   XattrHeader header;
   *size = sizeof(header);
 
-<<<<<<< HEAD
-  // Determine size of the buffer (allocate space for max num of attributes)
-  XattrEntry *entries = reinterpret_cast<XattrEntry *>(
-      smalloc(header.num_xattrs * sizeof(XattrEntry)));
-  unsigned ientries = 0;
-=======
   for (map<string, string>::const_iterator it_att = xattrs_.begin(),
        it_att_end = xattrs_.end(); it_att != it_att_end; ++it_att)
   {
@@ -247,7 +241,6 @@ void XattrList::Serialize(unsigned char **outbuf,
   bufpos += sizeof(header);
 
   header.num_xattrs = 0;
->>>>>>> 69f84da01 (add support for big xattrs (64k value))
   for (map<string, string>::const_iterator it_att = xattrs_.begin(),
                                            it_att_end = xattrs_.end();
        it_att != it_att_end;

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -104,11 +104,11 @@ XattrList *XattrList::Deserialize(const unsigned char *inbuf,
   for (unsigned i = 0; i < header.num_xattrs; ++i) {
     std::string key;
     std::string value;
-    uint32_t nbytes =
+    const uint32_t nbytes =
       entry_serializer.Deserialize(bufpos, remain, &key, &value);
     if (nbytes == 0)
       return NULL;
-    bool retval = result->Set(key, value);
+    const bool retval = result->Set(key, value);
     if (!retval)
       return NULL;
 

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -58,6 +58,20 @@ class XattrList {
     uint8_t version;
     uint8_t num_xattrs;
   };
+
+  class XattrEntrySerializer {
+   public:
+    explicit XattrEntrySerializer(uint8_t version);
+    uint32_t GetHeaderSize() const { return version_ == kVersionBig ? 3 : 2; }
+    uint32_t Serialize(const std::string &key, const std::string &value,
+                       unsigned char *to);
+    uint32_t Deserialize(const unsigned char *from, uint32_t bufsize,
+                         std::string *key, std::string *value);
+
+   private:
+     uint8_t version_;
+  };
+
   struct XattrEntry {
     XattrEntry(const std::string &key, const std::string &value);
     XattrEntry() : len_key(0), len_value(0) { }

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -19,16 +19,22 @@
  *
  * First application of the extended attributes is security.capability in order
  * to support POSIX file capabilities.  Cvmfs' support for custom extended
- * attributes is limited to 256 attributes, with names <= 256 characters and
- * values <= 256 bytes.  Thus there is no need for big endian/little endian
- * conversion.  The name must not be the empty string and must not contain the
+ * attributes is limited to 256 attributes, with names <= 255 characters and
+ * values <= 64k bytes. Note that values > 255 characters require cvmfs
+ * version >= 2.12.  Earlier versions will ignore big attributes.
+ * Attribute names must not be the empty string and must not contain the
  * zero character.  There are no restrictions on the content.
  */
 class XattrList {
  public:
-  static const uint8_t kVersion;
+  static const uint8_t kVersionSmall;  ///< Version 1, key and value < 255 chars
+  static const uint8_t kVersionBig;    ///< Version 2, value up to 64k chars
 
-  XattrList() : version_(kVersion) { }
+  static bool IsSupportedVersion(uint8_t v) {
+    return v == kVersionSmall || v == kVersionBig;
+  }
+
+  XattrList() : version_(kVersionSmall) { }
   static XattrList *CreateFromFile(const std::string &path);
 
   std::vector<std::string> ListKeys() const;

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -34,7 +34,6 @@ class XattrList {
     return v == kVersionSmall || v == kVersionBig;
   }
 
-  XattrList() : version_(kVersionSmall) { }
   static XattrList *CreateFromFile(const std::string &path);
 
   std::vector<std::string> ListKeys() const;
@@ -50,8 +49,6 @@ class XattrList {
                  const std::vector<std::string> *blacklist = NULL) const;
   static XattrList *Deserialize(const unsigned char *inbuf,
                                 const unsigned size);
-
-  uint8_t version() { return version_; }
 
  private:
   struct XattrHeader {
@@ -74,7 +71,6 @@ class XattrList {
     char data[512];
   };
 
-  uint8_t version_;
   std::map<std::string, std::string> xattrs_;
 };
 

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -52,9 +52,9 @@ class XattrList {
 
  private:
   struct XattrHeader {
-    XattrHeader() : version(kVersion), num_xattrs(0) { }
+    XattrHeader() : version(kVersionSmall), num_xattrs(0) { }
     explicit XattrHeader(const uint8_t num_xattrs)
-        : version(kVersion), num_xattrs(num_xattrs) { }
+        : version(kVersionSmall), num_xattrs(num_xattrs) { }
     uint8_t version;
     uint8_t num_xattrs;
   };

--- a/cvmfs/xattr.h
+++ b/cvmfs/xattr.h
@@ -21,9 +21,9 @@
  * to support POSIX file capabilities.  Cvmfs' support for custom extended
  * attributes is limited to 256 attributes, with names <= 255 characters and
  * values <= 64k bytes. Note that values > 255 characters require cvmfs
- * version >= 2.12.  Earlier versions will ignore big attributes.
- * Attribute names must not be the empty string and must not contain the
- * zero character.  There are no restrictions on the content.
+ * version >= 2.14.  Earlier versions will ignore all xattrs for a file
+ * if a big one is set. Attribute names must not be the empty string and
+ * must not contain the zero character. There are no restrictions on the content.
  */
 class XattrList {
  public:

--- a/test/src/585-xattrs/main
+++ b/test/src/585-xattrs/main
@@ -8,6 +8,7 @@ cvmfs_test_suites="quick"
 
 verify_xattrs() {
   local attr1=$(attr -qg foo /cvmfs/$CVMFS_TEST_REPO/xattr)
+  local attr5=$(attr -qg large /cvmfs/$CVMFS_TEST_REPO/xattr)
   # local attr2=$(attr -qg x /cvmfs/$CVMFS_TEST_REPO/link)
   local attr3=$(attr -qg foo2 /cvmfs/$CVMFS_TEST_REPO/dir/xattr)
   local attr4=$(attr -qg baz /cvmfs/$CVMFS_TEST_REPO/dir)
@@ -24,6 +25,9 @@ verify_xattrs() {
     return 23
   fi
   setcap -q -v "cap_chown=ep" /cvmfs/$CVMFS_TEST_REPO/dir/capabilities || return 24
+  if [ "a$attr5" != "a$(printf 'x%.0s' {1..1000})" ]; then
+    return 25
+  fi
 
   return 0
 }
@@ -53,6 +57,7 @@ cvmfs_run_test() {
   touch /cvmfs/$CVMFS_TEST_REPO/dir/capabilities
 
   attr -s foo -V bar /cvmfs/$CVMFS_TEST_REPO/xattr || return 10
+  attr -s large -V $(printf 'x%.0s' {1..1000}) /cvmfs/$CVMFS_TEST_REPO/xattr || return 15
   # attr -s x -V Y /cvmfs/$CVMFS_TEST_REPO/link || return 11
   attr -s foo2 -V bar2 /cvmfs/$CVMFS_TEST_REPO/dir/xattr || return 12
   attr -s baz -V BAZ /cvmfs/$CVMFS_TEST_REPO/dir || return 13

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -143,7 +143,7 @@ TEST_F(T_Xattr, DeserializeInvalid) {
   buf[0] = 255;
   UniquePtr<XattrList> xl2(XattrList::Deserialize(buf, size));
   EXPECT_FALSE(xl2.IsValid());
-  buf[0] = XattrList::kVersion;
+  buf[0] = XattrList::kVersionSmall;
 
   UniquePtr<XattrList> xl3(XattrList::Deserialize(buf, 3));
   EXPECT_FALSE(xl3.IsValid());

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -82,12 +82,12 @@ TEST_F(T_Xattr, CreateFromFile) {
 #ifndef __APPLE__
   ASSERT_TRUE(platform_setxattr(tmp_path, "user.test2", "value2"));
   string long_string = "user." + string(250, 'x');
-  string very_long_string = "user." + string(1000, 'x');
+  string very_long_string = string(1000, 'y');
   ASSERT_TRUE(platform_setxattr(tmp_path, long_string, long_string));
   ASSERT_TRUE(platform_setxattr(tmp_path, "user.large", very_long_string));
   UniquePtr<XattrList> from_file3(XattrList::CreateFromFile(tmp_path));
   ASSERT_TRUE(from_file3.IsValid());
-  EXPECT_EQ(default_attrs + 3, from_file3->ListKeys().size());
+  EXPECT_EQ(default_attrs + 4, from_file3->ListKeys().size());
   EXPECT_TRUE(from_file3->Get("user.test", &value));
   EXPECT_TRUE(from_file3->Has("user.test"));
   EXPECT_EQ("value", value);
@@ -97,6 +97,9 @@ TEST_F(T_Xattr, CreateFromFile) {
   EXPECT_TRUE(from_file3->Get(long_string, &value));
   EXPECT_TRUE(from_file3->Has(long_string));
   EXPECT_EQ(long_string, value);
+  EXPECT_TRUE(from_file3->Has("user.large"));
+  EXPECT_TRUE(from_file3->Get("user.large", &value));
+  EXPECT_EQ(very_long_string, value);
 #endif
 }
 

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -82,9 +82,9 @@ TEST_F(T_Xattr, CreateFromFile) {
 #ifndef __APPLE__
   ASSERT_TRUE(platform_setxattr(tmp_path, "user.test2", "value2"));
   string long_string = "user." + string(250, 'x');
-  string too_long_string = "user." + string(300, 'x');
+  string very_long_string = "user." + string(1000, 'x');
   ASSERT_TRUE(platform_setxattr(tmp_path, long_string, long_string));
-  ASSERT_TRUE(platform_setxattr(tmp_path, "user.test3", too_long_string));
+  ASSERT_TRUE(platform_setxattr(tmp_path, "user.large", very_long_string));
   UniquePtr<XattrList> from_file3(XattrList::CreateFromFile(tmp_path));
   ASSERT_TRUE(from_file3.IsValid());
   EXPECT_EQ(default_attrs + 3, from_file3->ListKeys().size());
@@ -227,9 +227,10 @@ TEST_F(T_Xattr, Set) {
   EXPECT_EQ("", value);
 
   // Invalid operations
-  string longstring(257, 'a');
-  EXPECT_FALSE(default_list.Set(longstring, "value"));
-  EXPECT_FALSE(default_list.Set("key", longstring));
+  string longkey(256, 'a');
+  string longvalue(64 * 1024 + 1, 'a');
+  EXPECT_FALSE(default_list.Set(longkey, "value"));
+  EXPECT_FALSE(default_list.Set("key", longvalue));
   string nullstring(1, '\0');
   EXPECT_FALSE(default_list.Set(nullstring, "value"));
 
@@ -301,21 +302,21 @@ TEST_F(T_Xattr, SerializeBlacklist) {
 
 TEST_F(T_Xattr, Limits) {
   XattrList large_list;
-  string large_value(256, 'a');
-  for (unsigned i = 0; i < 256; ++i) {
+  string large_value(64 * 1024 - 1, 'a');
+  for (unsigned i = 0; i < 255; ++i) {
     char hex[4];
     snprintf(hex, sizeof(hex), "%02x", i);
     string large_key(128, hex[0]);
-    large_key += string(128, hex[1]);
+    large_key += string(127, hex[1]);
     EXPECT_TRUE(large_list.Set(large_key, large_value));
   }
-  EXPECT_EQ(256U, large_list.ListKeys().size());
-  for (unsigned i = 0; i < 256; ++i) {
+  EXPECT_EQ(255U, large_list.ListKeys().size());
+  for (unsigned i = 0; i < 255; ++i) {
     string value;
     char hex[4];
     snprintf(hex, sizeof(hex), "%02x", i);
     string large_key(128, hex[0]);
-    large_key += string(128, hex[1]);
+    large_key += string(127, hex[1]);
     EXPECT_TRUE(large_list.Get(large_key, &value));
     EXPECT_EQ(large_value, value);
   }

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -21,7 +21,7 @@ class T_Xattr : public ::testing::Test {
   virtual void SetUp() {
     default_list.Set("keya", "valuea");
     default_list.Set("keyb", "valueb");
-    default_list.Set("large", std::string(10, 'x'));
+    default_list.Set("large", std::string(1000, 'x'));
     default_list.Set("empty_key", "");
   }
 
@@ -144,10 +144,11 @@ TEST_F(T_Xattr, DeserializeInvalid) {
   UniquePtr<XattrList> xl1(XattrList::Deserialize(buf, 0));
   EXPECT_FALSE(xl1.IsValid());
 
+  uint8_t version = buf[0];
   buf[0] = 255;
   UniquePtr<XattrList> xl2(XattrList::Deserialize(buf, size));
   EXPECT_FALSE(xl2.IsValid());
-  buf[0] = XattrList::kVersionSmall;
+  buf[0] = version;
 
   UniquePtr<XattrList> xl3(XattrList::Deserialize(buf, 3));
   EXPECT_FALSE(xl3.IsValid());

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -280,6 +280,29 @@ TEST_F(T_Xattr, SerializeNull) {
   EXPECT_EQ(0U, size);
 }
 
+// Lists of small attributes should be serialized in the version 1 format,
+// digestable for old clients
+TEST_F(T_Xattr, SerializeCompat) {
+  XattrList list;
+  list.Set("key", "value");
+
+  unsigned char *buf;
+  unsigned size;
+
+  list.Serialize(&buf, &size);
+  EXPECT_TRUE(buf != NULL);
+  EXPECT_GT(size, 0u);
+
+  EXPECT_EQ(1, buf[0]);
+
+  XattrList *verify = XattrList::Deserialize(buf, size);
+  EXPECT_EQ(1u, verify->ListKeys().size());
+  string value;
+  EXPECT_TRUE(verify->Get("key", &value));
+  EXPECT_EQ("value", value);
+  delete verify;
+}
+
 
 TEST_F(T_Xattr, SerializeBlacklist) {
   std::vector<std::string> blacklist;

--- a/test/unittests/t_xattr.cc
+++ b/test/unittests/t_xattr.cc
@@ -21,6 +21,7 @@ class T_Xattr : public ::testing::Test {
   virtual void SetUp() {
     default_list.Set("keya", "valuea");
     default_list.Set("keyb", "valueb");
+    default_list.Set("large", std::string(10, 'x'));
     default_list.Set("empty_key", "");
   }
 
@@ -114,7 +115,7 @@ TEST_F(T_Xattr, Deserialize) {
   UniquePtr<XattrList> xattr_list(XattrList::Deserialize(buf, size));
   free(buf);
   ASSERT_TRUE(xattr_list.IsValid());
-  EXPECT_EQ(3U, xattr_list->ListKeys().size());
+  EXPECT_EQ(default_list.ListKeys().size(), xattr_list->ListKeys().size());
   string value;
   EXPECT_TRUE(xattr_list->Get("keya", &value));
   EXPECT_TRUE(xattr_list->Has("keya"));
@@ -194,10 +195,11 @@ TEST_F(T_Xattr, Get) {
 TEST_F(T_Xattr, ListKeys) {
   XattrList empty;
   EXPECT_TRUE(empty.ListKeys().empty());
-  ASSERT_EQ(3U, default_list.ListKeys().size());
+  ASSERT_EQ(4U, default_list.ListKeys().size());
   EXPECT_EQ("empty_key", default_list.ListKeys()[0]);
   EXPECT_EQ("keya", default_list.ListKeys()[1]);
   EXPECT_EQ("keyb", default_list.ListKeys()[2]);
+  EXPECT_EQ("large", default_list.ListKeys()[3]);
 }
 
 
@@ -209,11 +211,11 @@ TEST_F(T_Xattr, ListKeysPosix) {
   const char expect1[] = "user.a\0user.b\0keya\0";
   EXPECT_EQ(string(expect1, sizeof(expect1) - 1),
             empty.ListKeysPosix(existing_list));
-  const char expect2[] = "empty_key\0keya\0keyb\0";
-  EXPECT_EQ(string(expect2, sizeof(expect2) - 1),
+  const char expect2[] = "empty_key\0keya\0keyb\0large\0";
+  EXPECT_EQ(string(expect2, sizeof(expect2)-1),
             default_list.ListKeysPosix(""));
-  const char expect3[] = "user.a\0user.b\0empty_key\0keya\0keyb\0";
-  EXPECT_EQ(string(expect3, sizeof(expect3) - 1),
+  const char expect3[] = "user.a\0user.b\0empty_key\0keya\0keyb\0large\0";
+  EXPECT_EQ(string(expect3, sizeof(expect3)-1),
             default_list.ListKeysPosix(existing_list));
 }
 
@@ -291,12 +293,13 @@ TEST_F(T_Xattr, SerializeBlacklist) {
   UniquePtr<XattrList> xattr_list(XattrList::Deserialize(buf, size));
   free(buf);
   ASSERT_TRUE(xattr_list.IsValid());
-  EXPECT_EQ(1U, xattr_list->ListKeys().size());
+  EXPECT_EQ(default_list.ListKeys().size() - 2, xattr_list->ListKeys().size());
   string value;
   EXPECT_TRUE(xattr_list->Get("keyb", &value));
   EXPECT_EQ("valueb", value);
 
   blacklist.push_back("keyb");
+  blacklist.push_back("large");
   default_list.Serialize(&buf, &size, &blacklist);
   EXPECT_EQ(0U, size);
   EXPECT_EQ(NULL, buf);


### PR DESCRIPTION
Adds support in a backward and somewhat forward compatible way. If only small attributes are attached to a file, serialization will use the current format understood by old readers. If one of the attributes is a large one, the list of attributes is serialized in a new format that old clients don't understand. Old clients won't crash but they will show none of the attributes.

Fixes #3621 