### PR TITLE
add eio.emfile counter to record EMFILE returned on open() operations

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1195,6 +1195,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
       fuse_remounter_->fence()->Leave();
       LogCvmfs(kLogCvmfs, kLogSyslogErr, "open file descriptor limit exceeded");
       fuse_reply_err(req, EMFILE);
+      perf::Inc(file_system_->n_emfile());
       return;
     }
 
@@ -1322,6 +1323,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
         fuse_remounter_->fence()->Leave();
       }
       fuse_reply_err(req, EMFILE);
+      perf::Inc(file_system_->n_emfile());
       return;
     }
     assert(false);
@@ -1340,6 +1342,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
            uint64_t(ino), dirent.checksum().ToString().c_str(), errno);
   if (errno == EMFILE) {
     fuse_reply_err(req, EMFILE);
+    perf::Inc(file_system_->n_emfile());
     return;
   }
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -265,6 +265,8 @@ void FileSystem::CreateStatistics() {
      "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
   n_eio_08_ =  statistics_->Register("eio.08",
      "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
+  n_emfile_ =  statistics_->Register("eio.emfile",
+     "EMFILE returned to calling process. cvmfs.cc:cvmfs_read()");
 
   string optarg;
   if (options_mgr_->GetValue("CVMFS_INSTRUMENT_FUSE", &optarg) &&
@@ -427,6 +429,7 @@ FileSystem::FileSystem(const FileSystem::FileSystemInfo &fs_info)
   , n_eio_06_(NULL)
   , n_eio_07_(NULL)
   , n_eio_08_(NULL)
+  , n_emfile_(NULL)
   , statistics_(NULL)
   , fd_workspace_lock_(-1)
   , found_previous_crash_(false)
@@ -610,6 +613,7 @@ void FileSystem::ResetErrorCounters() {
   n_eio_06_->Set(0);
   n_eio_07_->Set(0);
   n_eio_08_->Set(0);
+  n_emfile_->Set(0);
 }
 
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -244,6 +244,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_eio_06() { return n_eio_06_; }
   perf::Counter *n_eio_07() { return n_eio_07_; }
   perf::Counter *n_eio_08() { return n_eio_08_; }
+  perf::Counter *n_emfile()  { return n_emfile_; }
   OptionsManager *options_mgr() { return options_mgr_; }
   perf::Statistics *statistics() { return statistics_; }
   Type type() { return type_; }
@@ -352,6 +353,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_eio_06_;
   perf::Counter *n_eio_07_;
   perf::Counter *n_eio_08_;
+  perf::Counter *n_emfile_;
   IoErrorInfo io_error_info_;
   perf::Statistics *statistics_;
 


### PR DESCRIPTION
Give visibility into when clients are receiving EMFILE as a result of fd exhaustion.