### PR TITLE
Fix streaming cache mgr with secure repos

### DIFF
--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <string>
 
+#include "clientctx.h"
 #include "network/download.h"
 #include "network/sink.h"
 #include "quota.h"
@@ -115,6 +116,14 @@ int64_t StreamingCacheManager::Stream(
   download_job.SetExtraInfo(&info.label.path);
   download_job.SetRangeOffset(info.label.range_offset);
   download_job.SetRangeSize(static_cast<int64_t>(info.label.size));
+  ClientCtx *ctx = ClientCtx::GetInstance();
+  if (ctx->IsSet()) {
+    ctx->Get(download_job.GetUidPtr(),
+             download_job.GetGidPtr(),
+             download_job.GetPidPtr(),
+             download_job.GetInterruptCuePtr());
+  }
+
   SelectDownloadManager(info)->Fetch(&download_job);
 
   if (download_job.error_code() != download::kFailOk) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1386,12 +1386,12 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   uint64_t abs_fd = (fd < 0) ? -fd : fd;
   ClearBit(glue::PageCacheTracker::kBitDirectIo, &abs_fd);
 
+  const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
+  FuseInterruptCue ic(&req);
+  const ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
+
   // Do we have a a chunked file?
   if (fd < 0) {
-    const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
-    FuseInterruptCue ic(&req);
-    ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
-
     const uint64_t chunk_handle = abs_fd;
     uint64_t unique_inode;
     ChunkFd chunk_fd;

--- a/test/src/647-bearercvmfs/main
+++ b/test/src/647-bearercvmfs/main
@@ -298,5 +298,18 @@ cvmfs_run_test() {
   authz_attr="$(attr -qg authz $mntpnt)" || return 41
   [ x"$authz_attr" = x"scitoken%cvmfs:/cvmfs" ]   || return 42
 
+  echo "*** Check streaming cache mgr with authentication"
+  sudo umount $mntpnt
+  sudo rm -rf ${mntpnt}c
+  do_local_mount_as_root "${mntpnt}" \
+                         "$CVMFS_TEST_REPO" \
+                         "https://${TEST647_HOSTNAME}:8443/cvmfs/$CVMFS_TEST_REPO" \
+                         "" "CVMFS_STREAMING_CACHE=yes" \
+                         || return 50
+  echo "*** This should work"
+  sudo -u nobody /bin/sh -c "export _CONDOR_CREDS=${TEST647_CRED_DIR}; cat ${mntpnt}/hello_world" > /dev/null || return 51
+  echo "*** This should not work"
+  sudo -u nobody setsid /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 52
+
   return 0
 }


### PR DESCRIPTION
Makes sure that the authentication token is used when the streaming cache manager downloads data.

Second part of the fix for #3629