### PR TITLE
fix bug: prevent symlink corruption during updating catalog revisions

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -823,6 +823,11 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
  * Reads a symlink from the catalog.  Environment variables are expanded.
  */
 static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
+  while (mount_point_->cache_symlinks()
+         && fuse_remounter_->IsPausedReadlink()) {
+    SafeSleepMs(100);
+  }
+
   HighPrecisionTimer guard_timer(file_system_->hist_fs_readlink());
 
   perf::Inc(file_system_->n_fs_readlink());
@@ -839,6 +844,11 @@ static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
   const bool found = GetDirentForInode(ino, &dirent);
   TraceInode(Tracer::kEventReadlink, ino, "readlink()");
   fuse_remounter_->fence()->Leave();
+
+  if (mount_point_->cache_symlinks()
+      && fuse_remounter_->RequestPauseReadlink()) {
+    fuse_remounter_->PauseReadlink();
+  }
 
   if (!found) {
     ReplyNegative(dirent, req);

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -823,16 +823,16 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
  * Reads a symlink from the catalog.  Environment variables are expanded.
  */
 static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
-  if (mount_point_->cache_symlinks()) {
-    fuse_remounter_->WaitAndIncreaseReadlinkCnt();
-  }
-
   HighPrecisionTimer guard_timer(file_system_->hist_fs_readlink());
 
   perf::Inc(file_system_->n_fs_readlink());
   const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
   FuseInterruptCue ic(&req);
   ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
+
+  if (mount_point_->cache_symlinks()) {
+    fuse_remounter_->WaitAndIncreaseReadlinkCnt();
+  }
 
   fuse_remounter_->fence()->Enter();
   ino = mount_point_->catalog_mgr()->MangleInode(ino);
@@ -2568,8 +2568,9 @@ static int AltProcessFlavor(int argc, char **argv) {
 static bool MaintenanceMode(const int fd_progress) {
   SendMsg2Socket(fd_progress, "Entering maintenance mode\n");
   string msg_progress = "Draining out kernel caches (";
-  if (FuseInvalidator::HasFuseNotifyInval())
-    msg_progress += "up to ";
+#ifndef __APPLE__
+    msg_progress += "up to ";  // linux can evict, macos has to wait for timeout
+#endif
   msg_progress += StringifyInt(static_cast<int>(
                                cvmfs::mount_point_->kcache_timeout_sec())) +
                   "s)\n";

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -823,9 +823,8 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
  * Reads a symlink from the catalog.  Environment variables are expanded.
  */
 static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
-  while (mount_point_->cache_symlinks()
-         && fuse_remounter_->IsPausedReadlink()) {
-    SafeSleepMs(100);
+  if (mount_point_->cache_symlinks()) {
+    fuse_remounter_->WaitAndIncreaseReadlinkCnt();
   }
 
   HighPrecisionTimer guard_timer(file_system_->hist_fs_readlink());
@@ -845,22 +844,17 @@ static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
   TraceInode(Tracer::kEventReadlink, ino, "readlink()");
   fuse_remounter_->fence()->Leave();
 
-  if (mount_point_->cache_symlinks()
-      && fuse_remounter_->RequestPauseReadlink()) {
-    fuse_remounter_->PauseReadlink();
-  }
-
   if (!found) {
     ReplyNegative(dirent, req);
-    return;
-  }
-
-  if (!dirent.IsLink()) {
+  } else if (!dirent.IsLink()) {
     fuse_reply_err(req, EINVAL);
-    return;
+  } else {
+    fuse_reply_readlink(req, dirent.symlink().c_str());
   }
 
-  fuse_reply_readlink(req, dirent.symlink().c_str());
+  if (mount_point_->cache_symlinks()) {
+    fuse_remounter_->DecreaseReadlinkCnt();
+  }
 }
 
 

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -831,10 +831,12 @@ static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
   ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
 
   if (mount_point_->cache_symlinks()) {
-    fuse_remounter_->WaitAndIncreaseReadlinkCnt();
+    fuse_remounter_->WaitReadlinkCnt();
   }
-
   fuse_remounter_->fence()->Enter();
+  if (mount_point_->cache_symlinks()) {
+    fuse_remounter_->IncreaseReadlinkCnt();
+  }
   ino = mount_point_->catalog_mgr()->MangleInode(ino);
   LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_readlink on inode: %" PRIu64,
            uint64_t(ino));
@@ -842,6 +844,9 @@ static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
   catalog::DirectoryEntry dirent;
   const bool found = GetDirentForInode(ino, &dirent);
   TraceInode(Tracer::kEventReadlink, ino, "readlink()");
+  if (mount_point_->cache_symlinks()) {
+    fuse_remounter_->DecreaseReadlinkCnt();
+  }
   fuse_remounter_->fence()->Leave();
 
   if (!found) {
@@ -852,9 +857,6 @@ static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
     fuse_reply_readlink(req, dirent.symlink().c_str());
   }
 
-  if (mount_point_->cache_symlinks()) {
-    fuse_remounter_->DecreaseReadlinkCnt();
-  }
 }
 
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -101,23 +101,28 @@ FuseInvalidator::~FuseInvalidator() {
 
 void FuseInvalidator::InvalidateInodesAndDentries(Handle *handle) {
   assert(handle != NULL);
-  char c = 'B';
-  WritePipe(pipe_ctrl_[1], &c, 1);
-  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+  InvalDentriesAndInodesCommand *command =
+    new (smalloc(sizeof(InvalDentriesAndInodesCommand)))
+         InvalDentriesAndInodesCommand();
+  command->handle = handle;
+  channel_.PushBack(command);
 }
 
 void FuseInvalidator::InvalidateInodesNoEvictAndDentries(Handle *handle) {
   assert(handle != NULL);
-  char c = 'X';
-  WritePipe(pipe_ctrl_[1], &c, 1);
-  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+  InvalDentriesAndInodesNoEvictCommand *command =
+    new (smalloc(sizeof(InvalDentriesAndInodesNoEvictCommand)))
+         InvalDentriesAndInodesNoEvictCommand();
+  command->handle = handle;
+  channel_.PushBack(command);
 }
 
 void FuseInvalidator::InvalidateDentries(Handle *handle) {
   assert(handle != NULL);
-  char c = 'D';
-  WritePipe(pipe_ctrl_[1], &c, 1);
-  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+  InvalDentriesCommand *command =
+    new (smalloc(sizeof(InvalDentriesCommand))) InvalDentriesCommand();
+  command->handle = handle;
+  channel_.PushBack(command);
 }
 
 
@@ -161,86 +166,115 @@ void *FuseInvalidator::MainInvalidator(void *data) {
 #ifdef __APPLE__
   bool reported_missing_inval_support = false;
 #endif
-  char c;
-  Handle *handle;
+
   while (true) {
     Command *command = invalidator->channel_.PopFront();
 
     if (dynamic_cast<QuitCommand *>(command)) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "stopping dentry invalidator thread");
       command->~Command();
       free(command);
-      break;
+      return NULL;
     }
 
+    // invalidate single dentry
     InvalDentryCommand *inval_dentry_command =
       dynamic_cast<InvalDentryCommand *>(command);
     if (inval_dentry_command) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "InvalDentryCommand");
+      uint64_t parent_ino = inval_dentry_command->parent_ino;
+      const NameString name = inval_dentry_command->name;
 #ifdef __APPLE__
-      if (invalidator->fuse_channel_or_session_ == NULL) {
-        if (!reported_missing_inval_support) {
-          LogCvmfs(kLogCvmfs, kLogSyslogWarn,
-                   "missing fuse support for dentry invalidation "
-                   "(%" PRIu64 "/%s)",
-                   inval_dentry_command->parent_ino,
-                   inval_dentry_command->name.ToString().c_str());
-          reported_missing_inval_support = true;
-        }
+      if (!reported_missing_inval_support) {
+        LogCvmfs(kLogCvmfs, kLogSyslogWarn,
+                  "missing fuse support for dentry invalidation "
+                  "(%" PRIu64 "/%s)", parent_ino, name.ToString().c_str());
+        reported_missing_inval_support = true;
+      }
 #else
-        invalidator->DoInvalidateDentry();
+      invalidator->DoInvalidateDentry(parent_ino, name);
 #endif
-break;
-case 'I':  // invalidate all "I"nodes
-  ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
-#ifdef __APPLE__
-  ClearCacheByTimeout(handle);
-#else
-        invalidator->DoInvalidateInodes(handle);
-        invalidator->evict_list_.Clear(); 
-#endif
-  handle->SetDone();
-break;
-case 'D':  // invalidate all "D"entries
-  ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
-#ifdef __APPLE__
-  ClearCacheByTimeout(handle);
-#else
-        invalidator->DoInvalidateDentries();
-#endif
-  handle->SetDone();
-break;
-case 'B':  // invalidate all "B"oth: inodes and dentries
-  ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
-#ifdef __APPLE__
-  ClearCacheByTimeout(handle);
-#else
-        invalidator->DoInvalidateDentries();
-        invalidator->DoInvalidateInodes(handle);
-        invalidator->evict_list_.Clear();
-#endif
-        handle->SetDone();
-      break;
-      case 'X':  // invalidate all both: inodes (do not delete evict list)
-                 // and dentries
-        ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
-#ifdef __APPLE__
-        ClearCacheByTimeout(handle);
-#else
-        invalidator->DoInvalidateDentries();
-        invalidator->DoInvalidateInodes(handle);
-#endif
-  handle->SetDone();
-break;
-default:
-// TODO(heretherebedragons) PANIC?
-break;
-}
-}
+      inval_dentry_command->~InvalDentryCommand();
+      free(inval_dentry_command);
+      LogCvmfs(kLogCvmfs, kLogDebug, "END InvalDentryCommand");
+      continue;
+    }  // end invalidate single dentry
 
-quit_thread:
-LogCvmfs(kLogCvmfs, kLogDebug, "stopping dentry invalidator thread");
-return NULL;
-}
+    // invalidate all "I"nodes
+    InvalInodesCommand *inval_inodes_command =
+          dynamic_cast<InvalInodesCommand *>(command);
+    if (inval_inodes_command) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "InvalInodesCommand");
+      Handle *handle = inval_inodes_command->handle;
+#ifdef __APPLE__
+      ClearCacheByTimeout(handle);
+#else
+      invalidator->DoInvalidateInodes(handle);
+      invalidator->evict_list_.Clear(); 
+#endif
+      handle->SetDone();
+      inval_inodes_command->~InvalInodesCommand();
+      free(inval_inodes_command);
+      LogCvmfs(kLogCvmfs, kLogDebug, "END InvalInodesCommand");
+      continue;  // end invalidate all "I"nodes
+    }
 
+    // invalidate all "D"entries
+    InvalDentriesCommand *inval_dentries_command =
+      dynamic_cast<InvalDentriesCommand *>(command);
+    if (inval_dentries_command) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "InvalDentriesCommand");
+      Handle *handle = inval_dentries_command->handle;
+#ifdef __APPLE__
+      ClearCacheByTimeout(handle);
+#else
+      invalidator->DoInvalidateDentries();
+#endif
+      handle->SetDone();
+      inval_dentries_command->~InvalDentriesCommand();
+      free(inval_dentries_command);
+      LogCvmfs(kLogCvmfs, kLogDebug, "END InvalDentriesCommand");
+      continue;
+    }  //  end invalidate all "D"entries
+
+    // invalidate all "B"oth: inodes and dentries
+    InvalDentriesAndInodesCommand *inval_both_command =
+      dynamic_cast<InvalDentriesAndInodesCommand *>(command);
+    if (inval_both_command) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "InvalDentriesAndInodesCommand");
+      Handle *handle = inval_both_command->handle;
+#ifdef __APPLE__
+      ClearCacheByTimeout(handle);
+#else
+      invalidator->DoInvalidateDentries();
+      invalidator->DoInvalidateInodes(handle);
+      invalidator->evict_list_.Clear();
+#endif
+      handle->SetDone();
+      inval_both_command->~InvalDentriesAndInodesCommand();
+      free(inval_both_command);
+      LogCvmfs(kLogCvmfs, kLogDebug, "END InvalDentriesAndInodesCommand");
+      continue;
+    }
+
+    // invalidate all both: inodes (do not delete evict list)  and dentries
+    InvalDentriesAndInodesNoEvictCommand *inval_both_no_evict_command =
+      dynamic_cast<InvalDentriesAndInodesNoEvictCommand *>(command);
+    if (inval_both_no_evict_command) {
+      Handle *handle = inval_both_no_evict_command->handle;
+#ifdef __APPLE__
+      ClearCacheByTimeout(handle);
+#else
+      invalidator->DoInvalidateDentries();
+      invalidator->DoInvalidateInodes(handle);
+#endif
+      handle->SetDone();
+      inval_both_no_evict_command->~InvalDentriesAndInodesNoEvictCommand();
+      free(inval_both_no_evict_command);
+      continue;
+    }
+  }
+}
 
 void FuseInvalidator::ClearCacheByTimeout(Handle *handle) {
   LogCvmfs(kLogCvmfs, kLogDebug,
@@ -259,40 +293,24 @@ void FuseInvalidator::ClearCacheByTimeout(Handle *handle) {
   }
 }
 
-void FuseInvalidator::DoInvalidateDentry() {
-  uint64_t parent_ino;
-  unsigned len;
-  ReadPipe(pipe_ctrl_[0], &parent_ino, sizeof(parent_ino));
-  ReadPipe(pipe_ctrl_[0], &len, sizeof(len));
-  char *name = static_cast<char *>(smalloc(len + 1));
-  ReadPipe(pipe_ctrl_[0], name, len);
-  name[len] = '\0';
-
-      LogCvmfs(kLogCvmfs, kLogDebug, "evicting single dentry %" PRIu64 "/%s",
-               parent_ino, name);
+void FuseInvalidator::DoInvalidateDentry(uint64_t parent_ino,
+                                         const NameString &name) {
+  LogCvmfs(kLogCvmfs, kLogDebug, "evicting single dentry %" PRIu64 "/%s",
+            parent_ino, name.ToString().c_str());
 #if CVMFS_USE_LIBFUSE == 2
-      fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_chan**>(
-        invalidator->fuse_channel_or_session_),
-        inval_dentry_command->parent_ino,
-        inval_dentry_command->name.GetChars(),
-        inval_dentry_command->name.GetLength());
+  fuse_lowlevel_notify_inval_entry(
+    *reinterpret_cast<struct fuse_chan**>(fuse_channel_or_session_),
+    parent_ino, name.GetChars(), name.GetLength());
 #else
-      fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_session**>(
-        invalidator->fuse_channel_or_session_),
-        inval_dentry_command->parent_ino,
-        inval_dentry_command->name.GetChars(),
-        inval_dentry_command->name.GetLength());
+  fuse_lowlevel_notify_inval_entry(
+    *reinterpret_cast<struct fuse_session**>(fuse_channel_or_session_),
+    parent_ino, name.GetChars(), name.GetLength());
 #endif
-      inval_dentry_command->~InvalDentryCommand();
-      free(inval_dentry_command);
-      continue;
-    }
+}
 
-  void FuseInvalidator::DoInvalidateInodes(Handle *handle) {
-    LogCvmfs(kLogCvmfs, kLogDebug, "invalidating kernel caches, timeout %u",
-             handle->timeout_s_);
-    inval_inodes_command->~InvalInodesCommand();
-    free(inval_inodes_command);
+void FuseInvalidator::DoInvalidateInodes(Handle *handle) {
+  LogCvmfs(kLogCvmfs, kLogDebug, "invalidating kernel caches, timeout %u",
+            handle->timeout_s_);
 
   uint64_t deadline = platform_monotonic_time() + handle->timeout_s_;
 
@@ -346,8 +364,10 @@ void FuseInvalidator::DoInvalidateDentry() {
 }
 
 void FuseInvalidator::DoInvalidateDentries() {
+  LogCvmfs(kLogCvmfs, kLogDebug, "eviciting dentries");
   // Do not do any prune. Can create deadlocks and give back broken symlinks
   // during catalog reload
+  // dentry_tracker_->Prune();
 
   // Copy and empty the dentry tracker in a single atomic operation
   glue::DentryTracker *dentries_copy = dentry_tracker_->Move();

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -51,22 +51,11 @@ const unsigned FuseInvalidator::kTimeoutSafetyMarginSec = 1;
 const unsigned FuseInvalidator::kCheckTimeoutFreqMs = 100;
 const unsigned FuseInvalidator::kCheckTimeoutFreqOps = 256;
 
+// TODO(heretherebedragons) - we should remove this. This is set based on
+// CVMFS_FUSE_NOTIFY_INVALIDATION (which we then should also remove)
+// - introduced for macos. but now we have it
+// hardcoded to use timeout to drain the kernel cache on timeout.
 bool FuseInvalidator::g_fuse_notify_invalidation_ = true;
-
-bool FuseInvalidator::HasFuseNotifyInval() {
-  /**
-   * Technically, also libfuse 2.8 has support.  Libfuse 2.8 comes with EL6,
-   * which had bugs reported related to the fuse_notify_inval_...() functions.
-   * Since just waiting for the timeout works perfectly fine, there is no reason
-   * to optimize for forced cache eviction too aggressively.
-   *
-   * TODO(jblomer): could we have libfuse 2.9 or higher with a very old kernel
-   * that doesn't support active invalidation?  How old does the kernel need
-   * to be?  Probably that situation is never triggered in practice.
-   */
-  return FuseInvalidator::g_fuse_notify_invalidation_ && (FUSE_VERSION >= 29);
-}
-
 
 FuseInvalidator::FuseInvalidator(
   MountPoint *mount_point,
@@ -110,6 +99,13 @@ FuseInvalidator::~FuseInvalidator() {
 }
 
 
+void FuseInvalidator::InvalidateInodesAndDentries(Handle *handle) {
+  assert(handle != NULL);
+  char c = 'B';
+  WritePipe(pipe_ctrl_[1], &c, 1);
+  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+}
+
 void FuseInvalidator::InvalidateInodes(Handle *handle) {
   assert(handle != NULL);
   InvalInodesCommand *inval_inodes_command =
@@ -147,7 +143,11 @@ void *FuseInvalidator::MainInvalidator(void *data) {
   FuseInvalidator *invalidator = reinterpret_cast<FuseInvalidator *>(data);
   LogCvmfs(kLogCvmfs, kLogDebug, "starting dentry invalidator thread");
 
+#ifdef __APPLE__
   bool reported_missing_inval_support = false;
+#endif
+  char c;
+  Handle *handle;
   while (true) {
     Command *command = invalidator->channel_.PopFront();
 
@@ -160,6 +160,7 @@ void *FuseInvalidator::MainInvalidator(void *data) {
     InvalDentryCommand *inval_dentry_command =
       dynamic_cast<InvalDentryCommand *>(command);
     if (inval_dentry_command) {
+#ifdef __APPLE__
       if (invalidator->fuse_channel_or_session_ == NULL) {
         if (!reported_missing_inval_support) {
           LogCvmfs(kLogCvmfs, kLogSyslogWarn,
@@ -169,13 +170,80 @@ void *FuseInvalidator::MainInvalidator(void *data) {
                    inval_dentry_command->name.ToString().c_str());
           reported_missing_inval_support = true;
         }
-        inval_dentry_command->~InvalDentryCommand();
-        free(inval_dentry_command);
-        continue;
-      }
+#else
+        invalidator->DoInvalidateDentry();
+#endif
+break;
+case 'I':  // invalidate all "I"nodes
+  ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
+#ifdef __APPLE__
+  ClearCacheByTimeout(handle);
+#else
+  invalidator->DoInvalidateInodes(handle);
+#endif
+  handle->SetDone();
+break;
+case 'D':  // invalidate all "D"entries
+  ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
+#ifdef __APPLE__
+  ClearCacheByTimeout(handle);
+#else
+  invalidator->DoInvalidateDentries();
+  invalidator->evict_list_.Clear();
+#endif
+  handle->SetDone();
+break;
+case 'B':  // invalidate all "B"oth: inodes and dentries
+  ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
+#ifdef __APPLE__
+  ClearCacheByTimeout(handle);
+#else
+  invalidator->DoInvalidateInodes(handle);
+  invalidator->DoInvalidateDentries();
+  invalidator->evict_list_.Clear();
+#endif
+  handle->SetDone();
+break;
+default:
+// TODO(heretherebedragons) PANIC?
+break;
+}
+}
+
+quit_thread:
+LogCvmfs(kLogCvmfs, kLogDebug, "stopping dentry invalidator thread");
+return NULL;
+}
+
+
+void FuseInvalidator::ClearCacheByTimeout(Handle *handle) {
+  LogCvmfs(kLogCvmfs, kLogDebug,
+          "invalidating kernel caches, timeout %u", handle->timeout_s_);
+  uint64_t deadline = platform_monotonic_time() + handle->timeout_s_;
+  LogCvmfs(kLogCvmfs, kLogDebug,
+                "fallback: (inode) cache eviction by request not supported, "
+                "using drainout by timeout");
+  while (platform_monotonic_time() < deadline) {
+    SafeSleepMs(kCheckTimeoutFreqMs);
+    if (atomic_read32(&terminated_) == 1) {
+      LogCvmfs(kLogCvmfs, kLogDebug,
+                          "cancel (inode) cache eviction due to termination");
+      break;
+    }
+  }
+}
+
+void FuseInvalidator::DoInvalidateDentry() {
+  uint64_t parent_ino;
+  unsigned len;
+  ReadPipe(pipe_ctrl_[0], &parent_ino, sizeof(parent_ino));
+  ReadPipe(pipe_ctrl_[0], &len, sizeof(len));
+  char *name = static_cast<char *>(smalloc(len + 1));
+  ReadPipe(pipe_ctrl_[0], name, len);
+  name[len] = '\0';
+
       LogCvmfs(kLogCvmfs, kLogDebug, "evicting single dentry %" PRIu64 "/%s",
-               inval_dentry_command->parent_ino,
-               inval_dentry_command->name.ToString().c_str());
+               parent_ino, name);
 #if CVMFS_USE_LIBFUSE == 2
       fuse_lowlevel_notify_inval_entry(*reinterpret_cast<struct fuse_chan**>(
         invalidator->fuse_channel_or_session_),
@@ -194,145 +262,116 @@ void *FuseInvalidator::MainInvalidator(void *data) {
       continue;
     }
 
-    InvalInodesCommand *inval_inodes_command =
-      dynamic_cast<InvalInodesCommand *>(command);
-    assert(inval_inodes_command);
-
-    Handle *handle = inval_inodes_command->handle;
+  void FuseInvalidator::DoInvalidateInodes(Handle *handle) {
     LogCvmfs(kLogCvmfs, kLogDebug, "invalidating kernel caches, timeout %u",
              handle->timeout_s_);
     inval_inodes_command->~InvalInodesCommand();
     free(inval_inodes_command);
 
-    uint64_t deadline = platform_monotonic_time() + handle->timeout_s_;
+  uint64_t deadline = platform_monotonic_time() + handle->timeout_s_;
 
-    // Fallback: drainout by timeout
-    if ((invalidator->fuse_channel_or_session_ == NULL) ||
-        !HasFuseNotifyInval())
-    {
-      while (platform_monotonic_time() < deadline) {
-        SafeSleepMs(kCheckTimeoutFreqMs);
-        if (atomic_read32(&invalidator->terminated_) == 1) {
-          LogCvmfs(kLogCvmfs, kLogDebug,
-                   "cancel cache eviction due to termination");
-          break;
-        }
-      }
-      handle->SetDone();
-      continue;
-    }
-
-    // We must not hold a lock when calling fuse_lowlevel_notify_inval_entry.
-    // Therefore, we first copy all the inodes into a temporary data structure.
-    glue::InodeTracker::Cursor inode_cursor(
-      invalidator->inode_tracker_->BeginEnumerate());
-    uint64_t inode;
-    while (invalidator->inode_tracker_->NextInode(&inode_cursor, &inode))
-    {
-      invalidator->evict_list_.PushBack(inode);
-    }
-    invalidator->inode_tracker_->EndEnumerate(&inode_cursor);
-
-    unsigned i = 0;
-    unsigned N = invalidator->evict_list_.size();
-    while (i < N) {
-      uint64_t inode = invalidator->evict_list_.At(i);
-      if (inode == 0)
-        inode = FUSE_ROOT_ID;
-      // Can fail, e.g. the inode might be already evicted
-
-      int dbg_retval;
-
-#if CVMFS_USE_LIBFUSE == 2
-      dbg_retval = fuse_lowlevel_notify_inval_inode(
-                    *reinterpret_cast<struct fuse_chan**>(
-                    invalidator->fuse_channel_or_session_), inode, 0, 0);
-#else
-      dbg_retval = fuse_lowlevel_notify_inval_inode(
-                    *reinterpret_cast<struct fuse_session**>(
-                    invalidator->fuse_channel_or_session_), inode, 0, 0);
-#endif
-      LogCvmfs(kLogCvmfs, kLogDebug,
-                "evicting inode %" PRIu64 " with retval: %d",
-                inode, dbg_retval);
-
-      (void) dbg_retval;  // prevent compiler complaining
-
-      if ((++i % kCheckTimeoutFreqOps) == 0) {
-        if (platform_monotonic_time() >= deadline) {
-          LogCvmfs(kLogCvmfs, kLogDebug,
-                   "cancel cache eviction after %u entries due to timeout", i);
-          break;
-        }
-        if (atomic_read32(&invalidator->terminated_) == 1) {
-          LogCvmfs(kLogCvmfs, kLogDebug,
-                   "cancel cache eviction due to termination");
-          break;
-        }
-      }
-    }
-
-    // Do the dentry tracker last to increase the effectiveness of pruning
-    invalidator->dentry_tracker_->Prune();
-    // Copy and empty the dentry tracker in a single atomic operation
-    glue::DentryTracker *dentries_copy = invalidator->dentry_tracker_->Move();
-    glue::DentryTracker::Cursor dentry_cursor = dentries_copy->BeginEnumerate();
-    uint64_t entry_parent;
-    NameString entry_name;
-    i = 0;
-
-#if CVMFS_USE_LIBFUSE == 2
-    int (*notify_func)(struct fuse_chan*, fuse_ino_t, const char*, size_t);
-    notify_func = &fuse_lowlevel_notify_inval_entry;
-#else
-    int (*notify_func)(struct fuse_session*, fuse_ino_t, const char*, size_t);
-    notify_func = &fuse_lowlevel_notify_inval_entry;
-#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 16)
-    // must be libfuse >= 3.16, otherwise the signature is wrong and it
-    // will fail building
-    // mount_point can only be NULL for unittests
-    if (invalidator->mount_point_ != NULL &&
-        invalidator->mount_point_->fuse_expire_entry()) {
-      notify_func = &fuse_lowlevel_notify_expire_entry;
-    }
-#endif
-#endif
-
-    while (dentries_copy->NextEntry(&dentry_cursor, &entry_parent, &entry_name))
-    {
-      LogCvmfs(kLogCvmfs, kLogDebug, "evicting dentry %lu --> %s",
-               entry_parent, entry_name.c_str());
-      // Can fail, e.g. the entry might be already evicted
-#if CVMFS_USE_LIBFUSE == 2
-      struct fuse_chan* channel_or_session =
-                                    *reinterpret_cast<struct fuse_chan**>(
-                                     invalidator->fuse_channel_or_session_);
-#else
-      struct fuse_session* channel_or_session =
-                                  *reinterpret_cast<struct fuse_session**>(
-                                  invalidator->fuse_channel_or_session_);
-#endif
-
-      notify_func(channel_or_session, entry_parent, entry_name.GetChars(),
-                                                    entry_name.GetLength());
-
-      if ((++i % kCheckTimeoutFreqOps) == 0) {
-        if (atomic_read32(&invalidator->terminated_) == 1) {
-          LogCvmfs(kLogCvmfs, kLogDebug,
-                   "cancel cache eviction due to termination");
-          break;
-        }
-      }
-    }
-    dentries_copy->EndEnumerate(&dentry_cursor);
-    delete dentries_copy;
-
-    handle->SetDone();
-    invalidator->evict_list_.Clear();
+  // We must not hold a lock when calling fuse_lowlevel_notify_inval_entry.
+  // Therefore, we first copy all the inodes into a temporary data structure.
+  glue::InodeTracker::Cursor inode_cursor(inode_tracker_->BeginEnumerate());
+  uint64_t inode;
+  while (inode_tracker_->NextInode(&inode_cursor, &inode)) {
+    evict_list_.PushBack(inode);
   }
+  inode_tracker_->EndEnumerate(&inode_cursor);
 
-  LogCvmfs(kLogCvmfs, kLogDebug, "stopping dentry invalidator thread");
-  return NULL;
+  unsigned i = 0;
+  unsigned N = evict_list_.size();
+  while (i < N) {
+    uint64_t inode = evict_list_.At(i);
+    if (inode == 0) {
+      inode = FUSE_ROOT_ID;
+    }
+    // Can fail, e.g. the inode might be already evicted
+
+    int dbg_retval;
+
+#if CVMFS_USE_LIBFUSE == 2
+    dbg_retval = fuse_lowlevel_notify_inval_inode(
+                                        *reinterpret_cast<struct fuse_chan**>(
+                                        fuse_channel_or_session_), inode, 0, 0);
+#else
+    dbg_retval = fuse_lowlevel_notify_inval_inode(
+                                       *reinterpret_cast<struct fuse_session**>(
+                                       fuse_channel_or_session_), inode, 0, 0);
+#endif
+    LogCvmfs(kLogCvmfs, kLogDebug, "evicting inode %" PRIu64 " with retval: %d",
+                                   inode, dbg_retval);
+
+    (void) dbg_retval;  // prevent compiler complaining
+
+    if ((++i % kCheckTimeoutFreqOps) == 0) {
+      if (platform_monotonic_time() >= deadline) {
+        LogCvmfs(kLogCvmfs, kLogDebug,
+                    "cancel cache eviction after %u entries due to timeout", i);
+        break;
+      }
+      if (atomic_read32(&terminated_) == 1) {
+        LogCvmfs(kLogCvmfs, kLogDebug,
+                                    "cancel cache eviction due to termination");
+        break;
+      }
+    }
+  }
+}
+
+void FuseInvalidator::DoInvalidateDentries() {
+  // Do the dentry tracker last to increase the effectiveness of pruning
+  dentry_tracker_->Prune();
+  // Copy and empty the dentry tracker in a single atomic operation
+  glue::DentryTracker *dentries_copy = dentry_tracker_->Move();
+  glue::DentryTracker::Cursor dentry_cursor = dentries_copy->BeginEnumerate();
+  uint64_t entry_parent;
+  NameString entry_name;
+  unsigned i = 0;
+
+#if CVMFS_USE_LIBFUSE == 2
+  int (*notify_func)(struct fuse_chan*, fuse_ino_t, const char*, size_t);
+  notify_func = &fuse_lowlevel_notify_inval_entry;
+#else
+  int (*notify_func)(struct fuse_session*, fuse_ino_t, const char*, size_t);
+  notify_func = &fuse_lowlevel_notify_inval_entry;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 16)
+  // must be libfuse >= 3.16, otherwise the signature is wrong and it
+  // will fail building
+  // mount_point can only be NULL for unittests
+  if (mount_point_->fuse_expire_entry() &&
+      mount_point_ != NULL) {
+    notify_func = &fuse_lowlevel_notify_expire_entry;
+  }
+#endif
+#endif
+
+  while (dentries_copy->NextEntry(&dentry_cursor, &entry_parent, &entry_name)) {
+    LogCvmfs(kLogCvmfs, kLogDebug, "evicting dentry %lu --> %s",
+                                   entry_parent, entry_name.c_str());
+    // Can fail, e.g. the entry might be already evicted
+#if CVMFS_USE_LIBFUSE == 2
+    struct fuse_chan* channel_or_session =*reinterpret_cast<struct fuse_chan**>(
+                                                      fuse_channel_or_session_);
+#else
+    struct fuse_session* channel_or_session =
+                                       *reinterpret_cast<struct fuse_session**>(
+                                                      fuse_channel_or_session_);
+#endif
+
+    notify_func(channel_or_session, entry_parent, entry_name.GetChars(),
+                                                  entry_name.GetLength());
+
+    if ((++i % kCheckTimeoutFreqOps) == 0) {
+      if (atomic_read32(&terminated_) == 1) {
+        LogCvmfs(kLogCvmfs, kLogDebug,
+                                    "cancel cache eviction due to termination");
+        break;
+      }
+    }
+  }
+  dentries_copy->EndEnumerate(&dentry_cursor);
+  delete dentries_copy;
 }
 
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -106,6 +106,21 @@ void FuseInvalidator::InvalidateInodesAndDentries(Handle *handle) {
   WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
 }
 
+void FuseInvalidator::InvalidateInodesNoEvictAndDentries(Handle *handle) {
+  assert(handle != NULL);
+  char c = 'X';
+  WritePipe(pipe_ctrl_[1], &c, 1);
+  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+}
+
+void FuseInvalidator::InvalidateDentries(Handle *handle) {
+  assert(handle != NULL);
+  char c = 'D';
+  WritePipe(pipe_ctrl_[1], &c, 1);
+  WritePipe(pipe_ctrl_[1], &handle, sizeof(handle));
+}
+
+
 void FuseInvalidator::InvalidateInodes(Handle *handle) {
   assert(handle != NULL);
   InvalInodesCommand *inval_inodes_command =
@@ -179,7 +194,8 @@ case 'I':  // invalidate all "I"nodes
 #ifdef __APPLE__
   ClearCacheByTimeout(handle);
 #else
-  invalidator->DoInvalidateInodes(handle);
+        invalidator->DoInvalidateInodes(handle);
+        invalidator->evict_list_.Clear(); 
 #endif
   handle->SetDone();
 break;
@@ -188,8 +204,7 @@ case 'D':  // invalidate all "D"entries
 #ifdef __APPLE__
   ClearCacheByTimeout(handle);
 #else
-  invalidator->DoInvalidateDentries();
-  invalidator->evict_list_.Clear();
+        invalidator->DoInvalidateDentries();
 #endif
   handle->SetDone();
 break;
@@ -198,9 +213,20 @@ case 'B':  // invalidate all "B"oth: inodes and dentries
 #ifdef __APPLE__
   ClearCacheByTimeout(handle);
 #else
-  invalidator->DoInvalidateInodes(handle);
-  invalidator->DoInvalidateDentries();
-  invalidator->evict_list_.Clear();
+        invalidator->DoInvalidateDentries();
+        invalidator->DoInvalidateInodes(handle);
+        invalidator->evict_list_.Clear();
+#endif
+        handle->SetDone();
+      break;
+      case 'X':  // invalidate all both: inodes (do not delete evict list)
+                 // and dentries
+        ReadPipe(invalidator->pipe_ctrl_[0], &handle, sizeof(handle));
+#ifdef __APPLE__
+        ClearCacheByTimeout(handle);
+#else
+        invalidator->DoInvalidateDentries();
+        invalidator->DoInvalidateInodes(handle);
 #endif
   handle->SetDone();
 break;
@@ -320,8 +346,9 @@ void FuseInvalidator::DoInvalidateDentry() {
 }
 
 void FuseInvalidator::DoInvalidateDentries() {
-  // Do the dentry tracker last to increase the effectiveness of pruning
-  dentry_tracker_->Prune();
+  // Do not do any prune. Can create deadlocks and give back broken symlinks
+  // during catalog reload
+
   // Copy and empty the dentry tracker in a single atomic operation
   glue::DentryTracker *dentries_copy = dentry_tracker_->Move();
   glue::DentryTracker::Cursor dentry_cursor = dentries_copy->BeginEnumerate();
@@ -339,8 +366,7 @@ void FuseInvalidator::DoInvalidateDentries() {
   // must be libfuse >= 3.16, otherwise the signature is wrong and it
   // will fail building
   // mount_point can only be NULL for unittests
-  if (mount_point_->fuse_expire_entry() &&
-      mount_point_ != NULL) {
+  if (mount_point_->fuse_expire_entry() && mount_point_ != NULL) {
     notify_func = &fuse_lowlevel_notify_expire_entry;
   }
 #endif

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -83,6 +83,7 @@ class FuseInvalidator : SingleCopy {
   ~FuseInvalidator();
   void Spawn();
   void InvalidateInodes(Handle *handle);
+  void InvalidateInodesAndDentries(Handle *handle);
 
   void InvalidateDentry(uint64_t parent_ino, const NameString &name);
 
@@ -95,6 +96,40 @@ class FuseInvalidator : SingleCopy {
                 glue::DentryTracker *dentry_tracker,
                 void **fuse_channel_or_session,
                 bool fuse_notify_invalidation);
+
+  /**
+   * For MacOS. MacOS has no fuse invalidate, as such just wait for timeout of the
+   * kernel cache to 
+   */
+  void ClearCacheByTimeout(Handle *handle);
+  /**
+   * Invalidates a single dentry. 
+   * Information which dentry should be invalidated is communicated via the
+   * pipe pipe_ctrl_.
+   * 
+   * This function should not be called for MacOS.
+   */
+  void DoInvalidateDentry();
+      /**
+   * Invalidates all inodes tracked by inode_tracker_.
+   * Information which dentry should be invalidated is communicated via the
+   * pipe pipe_ctrl_.
+   * 
+   * This function should not be called for MacOS, use ClearCacheByTimeout()
+   * instead
+   */
+  void DoInvalidateInodes(Handle *handle);
+    /**
+   * Invalidates all inodes tracked by dentry_tracker_.
+   * Information which dentry should be invalidated is communicated via the
+   * pipe pipe_ctrl_.
+   * 
+   * This function should not be called for MacOS, use ClearCacheByTimeout()
+   * instead
+   */
+  void DoInvalidateDentries();
+
+
   /**
    * Add one second to the caller-provided timeout to be on the safe side.
    */

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -76,6 +76,16 @@ class FuseInvalidator : SingleCopy {
     uint64_t parent_ino;
     NameString name;
   };
+  struct InvalDentriesCommand : public Command {
+    Handle *handle;
+  };
+  struct InvalDentriesAndInodesCommand : public Command {
+    Handle *handle;
+  };
+  struct InvalDentriesAndInodesNoEvictCommand : public Command {
+    Handle *handle;
+  };
+  
 
   FuseInvalidator(MountPoint *mountpoint,
                   void **fuse_channel_or_session,
@@ -139,7 +149,7 @@ class FuseInvalidator : SingleCopy {
    * 
    * This function should not be called for MacOS.
    */
-  void DoInvalidateDentry();
+  void DoInvalidateDentry(uint64_t parent_ino, const NameString &name);
       /**
    * Invalidates all inodes tracked by inode_tracker_.
    * Information which dentry should be invalidated is communicated via the

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -82,9 +82,39 @@ class FuseInvalidator : SingleCopy {
                   bool fuse_notify_invalidation);
   ~FuseInvalidator();
   void Spawn();
+  /**
+   * Requests to asynchronously invalidate all inodes saved in inode_tracker
+   * and clears the inode_tracker.
+   */
   void InvalidateInodes(Handle *handle);
+  /**
+   * Requests to asynchronously invalidate or expire all dentries saved in
+   * dentry_tracker and clears the dentry_tracker. 
+   */
+  void InvalidateDentries(Handle *handle);
+  /**
+   * Requests to asynchronously first invalidate inodes and then invalidate
+   * dentries. IsDone() will only return true if both actions were performed.
+   */
   void InvalidateInodesAndDentries(Handle *handle);
+  /**
+   * Like InvalidateInodesAndDentries() but does not delete the temporary list
+   * of "to-be-deleted inodes" (evict_list_). Next call to any form of
+   * InvalidateInodes() will appened their new inodes to the old list and then
+   * deletes old + new inodes.
+   * 
+   * This is useful for the fuse_remount where you first want to delete all
+   * inodes and dentries, perform the reload, and then because of possible
+   * race conditions want to make sure that all inodes (before and after the
+   * reload) are invalidated again.
+   */
+  void InvalidateInodesNoEvictAndDentries(Handle *handle);
 
+  /**
+   * Invalidates a single dentry.
+   * 
+   * @note Expire is not supported, and the dentry_tracker is not updated.
+   */
   void InvalidateDentry(uint64_t parent_ino, const NameString &name);
 
  private:

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -100,7 +100,7 @@ class FuseInvalidator : SingleCopy {
   /**
    * Like InvalidateInodesAndDentries() but does not delete the temporary list
    * of "to-be-deleted inodes" (evict_list_). Next call to any form of
-   * InvalidateInodes() will appened their new inodes to the old list and then
+   * InvalidateInodes() will append their new inodes to the old list and then
    * deletes old + new inodes.
    * 
    * This is useful for the fuse_remount where you first want to delete all

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -81,7 +81,7 @@ FuseRemounter::Status FuseRemounter::ChangeRoot(const shash::Any &root_hash) {
     // As of this point, fuse callbacks return zero as cache timeout
     LogCvmfs(kLogCvmfs, kLogDebug, "chroot, draining out meta-data caches");
     invalidator_handle_.Reset();
-    invalidator_->InvalidateInodes(&invalidator_handle_);
+    invalidator_->InvalidateInodesAndDentries(&invalidator_handle_);
     atomic_inc32(&drainout_mode_);
     // drainout_mode_ == 2, IsInDrainoutMode is now 'true'
   } else {
@@ -135,7 +135,7 @@ FuseRemounter::Status FuseRemounter::Check() {
                  "new catalog revision available, "
                  "draining out meta-data caches");
         invalidator_handle_.Reset();
-        invalidator_->InvalidateInodes(&invalidator_handle_);
+        invalidator_->InvalidateInodesAndDentries(&invalidator_handle_);
         atomic_inc32(&drainout_mode_);
         // drainout_mode_ == 2, IsInDrainoutMode is now 'true'
       } else {
@@ -198,7 +198,7 @@ void FuseRemounter::EnterMaintenanceMode() {
 
   // Flush caches before reload of fuse module
   invalidator_handle_.Reset();
-  invalidator_->InvalidateInodes(&invalidator_handle_);
+  invalidator_->InvalidateInodesAndDentries(&invalidator_handle_);
   invalidator_handle_.WaitFor();
 }
 
@@ -358,6 +358,12 @@ void FuseRemounter::TryFinish(const shash::Any &root_hash) {
 
   RequestStopReadlink();
   WaitForStopReadlink();
+
+  // Reset inodes again, just to make sure
+  // (Contrary to dentry, inodes dont have a modifiable timeout)
+  invalidator_handle_.Reset();
+  invalidator_->InvalidateInodes(&invalidator_handle_);
+  invalidator_handle_.WaitFor();
 
   // No new inserts into caches
   mountpoint_->inode_cache()->Pause();

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -16,6 +16,7 @@
 #include "backoff.h"
 #include "catalog_mgr_client.h"
 #include "fuse_inode_gen.h"
+#include "glue_buffer.h"
 #include "lru_md.h"
 #include "mountpoint.h"
 #include "statistics.h"
@@ -26,11 +27,13 @@
 
 using namespace std;  // NOLINT
 
-void FuseRemounter::WaitAndIncreaseReadlinkCnt() {
+void FuseRemounter::WaitReadlinkCnt() {
   while (atomic_read32(&cnt_readlink_) < 0) {
-    SafeSleepMs(100);
+    SafeSleepMs(500);
   }
+}
 
+void FuseRemounter::IncreaseReadlinkCnt() {
   int32_t old_val;
   int32_t new_val;
   do {
@@ -81,7 +84,7 @@ FuseRemounter::Status FuseRemounter::ChangeRoot(const shash::Any &root_hash) {
     // As of this point, fuse callbacks return zero as cache timeout
     LogCvmfs(kLogCvmfs, kLogDebug, "chroot, draining out meta-data caches");
     invalidator_handle_.Reset();
-    invalidator_->InvalidateInodesAndDentries(&invalidator_handle_);
+    invalidator_->InvalidateInodesNoEvictAndDentries(&invalidator_handle_);
     atomic_inc32(&drainout_mode_);
     // drainout_mode_ == 2, IsInDrainoutMode is now 'true'
   } else {
@@ -135,7 +138,7 @@ FuseRemounter::Status FuseRemounter::Check() {
                  "new catalog revision available, "
                  "draining out meta-data caches");
         invalidator_handle_.Reset();
-        invalidator_->InvalidateInodesAndDentries(&invalidator_handle_);
+        invalidator_->InvalidateInodesNoEvictAndDentries(&invalidator_handle_);
         atomic_inc32(&drainout_mode_);
         // drainout_mode_ == 2, IsInDrainoutMode is now 'true'
       } else {
@@ -357,24 +360,17 @@ void FuseRemounter::TryFinish(const shash::Any &root_hash) {
   LogCvmfs(kLogCvmfs, kLogDebug, "caches drained out, applying new catalog");
 
   RequestStopReadlink();
-  WaitForStopReadlink();
 
-  // Reset inodes again, just to make sure
-  // (Contrary to dentry, inodes dont have a modifiable timeout)
-  invalidator_handle_.Reset();
-  invalidator_->InvalidateInodes(&invalidator_handle_);
-  invalidator_handle_.WaitFor();
-
-  // No new inserts into caches
+  // Ensure that all Fuse callbacks left the catalog query code
+  fence_->Drain();
   mountpoint_->inode_cache()->Pause();
   mountpoint_->path_cache()->Pause();
   mountpoint_->md5path_cache()->Pause();
+
   mountpoint_->inode_cache()->Drop();
   mountpoint_->path_cache()->Drop();
   mountpoint_->md5path_cache()->Drop();
 
-  // Ensure that all Fuse callbacks left the catalog query code
-  fence_->Drain();
   catalog::LoadReturn retval;
   if (root_hash.IsNull()) {
     retval = mountpoint_->catalog_mgr()->Remount();
@@ -386,11 +382,11 @@ void FuseRemounter::TryFinish(const shash::Any &root_hash) {
       mountpoint_->inode_annotation()->GetGeneration();
   }
   mountpoint_->ReEvaluateAuthz();
-  fence_->Open();
-
   mountpoint_->inode_cache()->Resume();
   mountpoint_->path_cache()->Resume();
   mountpoint_->md5path_cache()->Resume();
+
+  fence_->Open();
 
   atomic_xadd32(&drainout_mode_, -2);  // 2 --> 0, end of drainout mode
 
@@ -408,6 +404,16 @@ void FuseRemounter::TryFinish(const shash::Any &root_hash) {
     SetAlarm(mountpoint_->GetEffectiveTtlSec());
   }
 
+  // do not remove sleep or change order. this reduces corruption of reading 
+  // symlinks. Inodes cannot be evicted while POSIX lock is active as such it
+  // must be after RestartReadlink()
+  SafeSleepMs(300);
+  invalidator_handle_.Reset();
+  invalidator_->InvalidateDentries(&invalidator_handle_);
+  invalidator_handle_.WaitFor();
   RestartReadlink();
+  invalidator_handle_.Reset();
+  invalidator_->InvalidateInodes(&invalidator_handle_);
+  invalidator_handle_.WaitFor();
   LeaveCriticalSection();
 }

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -79,7 +79,8 @@ class FuseRemounter : SingleCopy {
    * Increase is adjusted depending if pause readlink is active or not.
    * Used in cvmfs_readlink (cvmfs.cc); see cnt_readlink_ for more
    */
-  void WaitAndIncreaseReadlinkCnt();
+  void WaitReadlinkCnt();
+  void IncreaseReadlinkCnt();
   /**
    * Readlink request has finished. Decreases the counter cnt_readlink_.
    * Value is adjusted based on if readlinks are paused or not.

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -64,29 +64,29 @@ class FuseRemounter : SingleCopy {
   bool IsInDrainoutMode() { return atomic_read32(&drainout_mode_) == 2; }
   bool IsInMaintenanceMode() { return atomic_read32(&maintenance_mode_) == 1; }
 
-  /**
-   * True if readlink requests are paused (for more see WaitForPauseReadlink())
-   */
-  bool IsPausedReadlink() { return atomic_read32(&pause_readlink_) == 2; }
-  /**
-   * Requests to pause readlinks
-   * Requested by FuseRemounter, checked by cvmfs_readlink in cvmfs.cc
-   */
-  bool RequestPauseReadlink() { return atomic_read32(&pause_readlink_) == 1; }
-  /**
-   * Pauses any further the readlink requests.
-   * 
-   * Called by cvmfs_readlink at the end of the execution to block any new 
-   * requests
-   */
-  bool PauseReadlink() { return atomic_cas32(&pause_readlink_, 1, 2); }
-
   Fence *fence() { return fence_; }
   time_t catalogs_valid_until() { return catalogs_valid_until_; }
 
   void InvalidateDentry(uint64_t parent_ino, const NameString &name) {
     invalidator_->InvalidateDentry(parent_ino, name);
   }
+
+  /**
+   * Registers that a new readlink request has been made and increases the
+   * counter cnt_readlink_.
+   * If it is requested to pause readlink requests, wait until it is unpaused.
+   * 
+   * Increase is adjusted depending if pause readlink is active or not.
+   * Used in cvmfs_readlink (cvmfs.cc); see cnt_readlink_ for more
+   */
+  void WaitAndIncreaseReadlinkCnt();
+  /**
+   * Readlink request has finished. Decreases the counter cnt_readlink_.
+   * Value is adjusted based on if readlinks are paused or not.
+   * 
+   * see cnt_readlink_ for more
+   */
+  void DecreaseReadlinkCnt();
 
  private:
   static void *MainRemountTrigger(void *data);
@@ -102,16 +102,25 @@ class FuseRemounter : SingleCopy {
   void SetOfflineMode(bool value);
 
   /**
-   * Waits for readlink requests to be paused.
-   * 
-   * Before eviction of kernel caches is possible, the readlink requests must be
-   * finished and paused to prevent mismatch of dentry and inode when a new
-   * catalog revision is loaded. This is only a problem when symlink caching is
-   * being used and a high frequency of readlink requests is executed during the
-   * revision update. However, in that case, corrupted symlinks can be returned
-   * if readlink requests are not paused before.
+   * Requests to pause/stop readlink requests
+   * see cnt_readlink_ for more
    */
-  void WaitForPauseReadlink();
+  void RequestStopReadlink();
+  /**
+   * After RequestStopReadlink() has been invoked, wait for all ongoing readlink
+   * requests to stop.
+   * see cnt_readlink_ for more
+   */
+  void WaitForStopReadlink();
+  /**
+   * Restarts the processing of readlink requests. 
+   * see cnt_readlink_ for more
+   * 
+   * @note This call will block infinitely unless cnt_readlink_ is in the mode
+   *       "stop readlink requests" and all ongoing readlink requests were
+  *        processed (cnt_readlink_ == -1)
+   */
+  void RestartReadlink();
 
   MountPoint *mountpoint_;  ///< Not owned
   cvmfs::InodeGenerationInfo *inode_generation_info_;  ///< Not owned
@@ -148,6 +157,39 @@ class FuseRemounter : SingleCopy {
    * TODO(jblomer): access to this field should be locked
    */
   time_t catalogs_valid_until_;
+
+  /**
+   * Counter for how many cvmfs_readlink requests are currently being performed.
+   * (see cvmfs.cc)
+   * 
+   * Before eviction of kernel caches is possible, the readlink requests must be
+   * finished and paused to prevent mismatch of dentry and inode when a new
+   * catalog revision is loaded. This is only a problem when symlink caching is
+   * being used and a high frequency of readlink requests is executed during the
+   * revision update. However, in that case, corrupted symlinks can be returned
+   * if readlink requests are not paused before.
+   * 
+   * The counter works the following:
+   * - counter == 1 or -1: no readlink request ongoing
+   * - counter > 1: readlink requests ongoing, no stop requested
+   * - counter < -1: readlink requests ongoing, stop requested
+   * 
+   * Usage:
+   * cvmfs_readlink() (cvmfs.cc):
+   *   WaitAndIncreaseReadlinkCnt()
+   *   DoStuff()
+   *   DecreaseReadlinkCnt()
+   * 
+   * TryFinish() (fuse_remount.cc):
+   *   Fence()
+   *   RequestStopReadlink()
+   *   WaitForStopReadlink()
+   *   DoAllOtherStuff()
+   *   RestartReadlink()
+   *   LeaveCriticalSection()
+   */
+  atomic_int32 cnt_readlink_;
+
   /**
    * In drainout mode, the fuse module sets the timeout of meta data replies to
    * zero.  If supported by Fuse, the FuseInvalidator will evict all active
@@ -159,7 +201,6 @@ class FuseRemounter : SingleCopy {
    * actual move into drainout mode.
    */
   atomic_int32 drainout_mode_;
-  atomic_int32 pause_readlink_;
   /**
    * in maintenance mode, cache timeout is 0 and catalogs are not reloaded.
    * Maintenance mode is entered when the fuse module gets reloaded.

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -870,11 +870,13 @@ class DentryTracker {
     Lock();
     entries_.PushBack(Entry(now + timeout_s, inode_parent, name));
     statistics_.num_insert++;
-    DoPrune(now);
+    // do not delete "now". 1 sec granularity is too inaccurate
+    DoPrune(now - 1);  
     Unlock();
   }
 
   void Prune();
+  size_t Size() { return entries_.size(); }
   /**
    * The nentry tracker is only needed for active cache eviction and can
    * otherwise ignore new entries.

--- a/test/unittests/t_fuse_evict.cc
+++ b/test/unittests/t_fuse_evict.cc
@@ -46,14 +46,14 @@ TEST_F(T_FuseInvalidator, StartStop) {
 TEST_F(T_FuseInvalidator, InvalidateTimeout) {
   FuseInvalidator::Handle handle(0);
   EXPECT_FALSE(handle.IsDone());
-  invalidator_->InvalidateInodes(&handle);
+  invalidator_->InvalidateInodesAndDentries(&handle);
   handle.WaitFor();
   EXPECT_TRUE(handle.IsDone());
 
   invalidator_->terminated_ = 1;
   FuseInvalidator::Handle handle2(1000000);
   EXPECT_FALSE(handle2.IsDone());
-  invalidator_->InvalidateInodes(&handle2);
+  invalidator_->InvalidateInodesAndDentries(&handle2);
   handle2.WaitFor();
   EXPECT_TRUE(handle2.IsDone());
 }
@@ -73,7 +73,7 @@ TEST_F(T_FuseInvalidator, InvalidateOps) {
 
   FuseInvalidator::Handle handle(0);
   EXPECT_FALSE(handle.IsDone());
-  invalidator_->InvalidateInodes(&handle);
+  invalidator_->InvalidateInodesAndDentries(&handle);
   handle.WaitFor();
   EXPECT_TRUE(handle.IsDone());
   EXPECT_EQ(FuseInvalidator::kCheckTimeoutFreqOps,
@@ -82,7 +82,7 @@ TEST_F(T_FuseInvalidator, InvalidateOps) {
 
   FuseInvalidator::Handle handle2(1000000);
   EXPECT_FALSE(handle2.IsDone());
-  invalidator_->InvalidateInodes(&handle2);
+  invalidator_->InvalidateInodesAndDentries(&handle2);
   handle2.WaitFor();
   EXPECT_TRUE(handle2.IsDone());
   EXPECT_EQ(FuseInvalidator::kCheckTimeoutFreqOps + 1024,
@@ -95,7 +95,7 @@ TEST_F(T_FuseInvalidator, InvalidateOps) {
   invalidator_->terminated_ = 1;
   handle2.Reset();
   EXPECT_FALSE(handle2.IsDone());
-  invalidator_->InvalidateInodes(&handle2);
+  invalidator_->InvalidateInodesAndDentries(&handle2);
   handle2.WaitFor();
   EXPECT_TRUE(handle2.IsDone());
   EXPECT_EQ((2 * FuseInvalidator::kCheckTimeoutFreqOps) + 1024,


### PR DESCRIPTION
Issue #3626 

i tried the following:
- 1 step-lock that immediately locks at the top of `cvmfs_readlink` --> does not work, you stay forever in the sleep loop
- return `EAGAIN` --> does not work (forgot what exactly)

working solution: have a 2-step lock
- fuse_remounter requests lock, readlink can finish 1 more call and then locks/sleeps before any further call to readlink
- if no readlink is called, have a timeout of waiting for it for 100ms (see `WaitForPauseReadlink`)
- when fuse_remounter is finished, the lock is released and readlink can function correctly on the new data

note:
there might be a super tiny chance that a readlink appears between waiting for readlink to stop, but non readlink to be read and the reload. see `WaitForPauseReadlink` for more information. it seems like it gets stuck if you try to add `PauseReadlink` in case it was not triggered during waiting for it

