### PR TITLE
ducc: fix garbage collection of only one path

### DIFF
--- a/ducc/cmd/garbage_collection.go
+++ b/ducc/cmd/garbage_collection.go
@@ -124,25 +124,7 @@ var garbageCollectionCmd = &cobra.Command{
 
 		llog(l.Log()).WithFields(log.Fields{"num. of path to delete": len(pathsToDelete)}).Info("Ready to delete paths")
 
-		// we send 50 folder to deletion at the time
-		commandPrefix := []string{"cvmfs_server", "ingest"}
-		commands := make([][]string, 0)
-		command := commandPrefix
-		j := 0
-		for i, path := range pathsToDelete {
-			j = i
-			if i%deleteBatch == 0 && i > 0 {
-				command = append(command, CVMFSRepo)
-				commands = append(commands, command)
-				command = commandPrefix
-				continue
-			}
-			command = append(command, "--delete", path)
-		}
-		if j%deleteBatch != 0 && j > 0 {
-			command = append(command, CVMFSRepo)
-			commands = append(commands, command)
-		}
+    commands, _ := lib.ConstructDeleteCommands(pathsToDelete, deleteBatch, CVMFSRepo)
 
 		if dryRun {
 			fmt.Printf("Dry run for garbage collection\n")

--- a/ducc/cmd/garbage_collection.go
+++ b/ducc/cmd/garbage_collection.go
@@ -124,7 +124,7 @@ var garbageCollectionCmd = &cobra.Command{
 
 		llog(l.Log()).WithFields(log.Fields{"num. of path to delete": len(pathsToDelete)}).Info("Ready to delete paths")
 
-    commands, _ := lib.ConstructDeleteCommands(pathsToDelete, deleteBatch, CVMFSRepo)
+		commands, _ := lib.ConstructDeleteCommands(pathsToDelete, deleteBatch, CVMFSRepo)
 
 		if dryRun {
 			fmt.Printf("Dry run for garbage collection\n")

--- a/ducc/lib/garbage_collection.go
+++ b/ducc/lib/garbage_collection.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"encoding/json"
+  "errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +14,31 @@ import (
 	da "github.com/cvmfs/ducc/docker-api"
 	l "github.com/cvmfs/ducc/log"
 )
+
+func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, CVMFSRepo string) ([][]string, error) {
+
+  if pathsPerBatchCommand < 1 {
+    return nil, errors.New("Num of paths per batch command must be greater than zero")
+  }
+
+	// we send pathsPerBatchCommand folders to deletion at a time
+	commandPrefix := []string{"cvmfs_server", "ingest"}
+	commands := make([][]string, 0)
+	command := commandPrefix
+	for i, path := range pathsToDelete {
+		if i%pathsPerBatchCommand == 0 && i > 0  {
+			command = append(command, CVMFSRepo)
+			commands = append(commands, command)
+			command = commandPrefix
+		}
+		command = append(command, "--delete", path)
+	}
+	command = append(command, CVMFSRepo)
+	commands = append(commands, command)
+
+  return commands, nil
+
+}
 
 func FindAllUsedFlatImages(CVMFSRepo string) ([]string, error) {
 	root := filepath.Join("/", "cvmfs", CVMFSRepo)

--- a/ducc/lib/garbage_collection.go
+++ b/ducc/lib/garbage_collection.go
@@ -2,7 +2,7 @@ package lib
 
 import (
 	"encoding/json"
-  "errors"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,16 +17,16 @@ import (
 
 func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, CVMFSRepo string) ([][]string, error) {
 
-  if pathsPerBatchCommand < 1 {
-    return nil, errors.New("Num of paths per batch command must be greater than zero")
-  }
+	if pathsPerBatchCommand < 1 {
+		return nil, errors.New("Num of paths per batch command must be greater than zero")
+	}
 
 	// we send pathsPerBatchCommand folders to deletion at a time
 	commandPrefix := []string{"cvmfs_server", "ingest"}
 	commands := make([][]string, 0)
 	command := commandPrefix
 	for i, path := range pathsToDelete {
-		if i%pathsPerBatchCommand == 0 && i > 0  {
+		if i%pathsPerBatchCommand == 0 && i > 0 {
 			command = append(command, CVMFSRepo)
 			commands = append(commands, command)
 			command = commandPrefix
@@ -36,7 +36,7 @@ func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, C
 	command = append(command, CVMFSRepo)
 	commands = append(commands, command)
 
-  return commands, nil
+	return commands, nil
 
 }
 
@@ -154,7 +154,7 @@ func FindAllUsedLayers(CVMFSRepo string) ([]string, error) {
 			}
 			for _, layerStruct := range manifest.Layers {
 				if layerStruct.MediaType == "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip" {
-					continue;
+					continue
 				}
 				layer := strings.Split(layerStruct.Digest, ":")[1]
 				layerPath := filepath.Join("/", "cvmfs", CVMFSRepo, ".layers", layer[0:2], layer)

--- a/ducc/lib/garbage_collection_test.go
+++ b/ducc/lib/garbage_collection_test.go
@@ -1,0 +1,32 @@
+package lib
+
+import (
+  "testing"
+  "strings"
+)
+
+func TestConstructDeleteCommands(t *testing.T) {
+  paths := []string{"a/b"}
+  commands, _ := ConstructDeleteCommands(paths, 10, "test.cern.ch")
+  if len(commands) != 1 {
+    t.Errorf("Delete command missing")
+  }
+  if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
+    t.Errorf("Wrong delete command")
+  }
+
+  paths = []string{"a/b", "c/d"}
+  commands, _ = ConstructDeleteCommands(paths, 10, "test.cern.ch")
+  if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b --delete c/d test.cern.ch" {
+    t.Errorf("Wrong delete command")
+  }
+
+  paths = []string{"a/b", "c/d"}
+  commands, _ = ConstructDeleteCommands(paths, 1, "test.cern.ch")
+  if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
+    t.Errorf("Wrong delete command")
+  }
+  if strings.Join(commands[1], " ") != "cvmfs_server ingest --delete c/d test.cern.ch" {
+    t.Errorf("Wrong delete command")
+  }
+}

--- a/ducc/lib/garbage_collection_test.go
+++ b/ducc/lib/garbage_collection_test.go
@@ -1,32 +1,32 @@
 package lib
 
 import (
-  "testing"
-  "strings"
+	"strings"
+	"testing"
 )
 
 func TestConstructDeleteCommands(t *testing.T) {
-  paths := []string{"a/b"}
-  commands, _ := ConstructDeleteCommands(paths, 10, "test.cern.ch")
-  if len(commands) != 1 {
-    t.Errorf("Delete command missing")
-  }
-  if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
-    t.Errorf("Wrong delete command")
-  }
+	paths := []string{"a/b"}
+	commands, _ := ConstructDeleteCommands(paths, 10, "test.cern.ch")
+	if len(commands) != 1 {
+		t.Errorf("Delete command missing")
+	}
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
+		t.Errorf("Wrong delete command")
+	}
 
-  paths = []string{"a/b", "c/d"}
-  commands, _ = ConstructDeleteCommands(paths, 10, "test.cern.ch")
-  if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b --delete c/d test.cern.ch" {
-    t.Errorf("Wrong delete command")
-  }
+	paths = []string{"a/b", "c/d"}
+	commands, _ = ConstructDeleteCommands(paths, 10, "test.cern.ch")
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b --delete c/d test.cern.ch" {
+		t.Errorf("Wrong delete command")
+	}
 
-  paths = []string{"a/b", "c/d"}
-  commands, _ = ConstructDeleteCommands(paths, 1, "test.cern.ch")
-  if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
-    t.Errorf("Wrong delete command")
-  }
-  if strings.Join(commands[1], " ") != "cvmfs_server ingest --delete c/d test.cern.ch" {
-    t.Errorf("Wrong delete command")
-  }
+	paths = []string{"a/b", "c/d"}
+	commands, _ = ConstructDeleteCommands(paths, 1, "test.cern.ch")
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
+		t.Errorf("Wrong delete command")
+	}
+	if strings.Join(commands[1], " ") != "cvmfs_server ingest --delete c/d test.cern.ch" {
+		t.Errorf("Wrong delete command")
+	}
 }


### PR DESCRIPTION
Correctly construct delete commands if `cvmfs_ducc gc`  discovers only one path to be deleted

Fixes #3639 - as reported by @marcoverl 