### PR TITLE
Fix ReadHalfPipe for reads larger than the timeout (cherry-pick from 2.11)

### DIFF
--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -528,7 +528,7 @@ bool ReadHalfPipe(int fd, void *buf, size_t nbyte, unsigned timeout_ms) {
   unsigned backoff_ms = 1;
   uint64_t duration_ms = 0;
   uint64_t timestamp = 0;
-  if (timeout_ms != 0) 
+  if (timeout_ms != 0)
     timestamp = platform_monotonic_time_ns();
 
   const unsigned max_backoff_ms = 256;
@@ -545,7 +545,7 @@ bool ReadHalfPipe(int fd, void *buf, size_t nbyte, unsigned timeout_ms) {
       SafeSleepMs(backoff_ms);
       if (backoff_ms < max_backoff_ms) backoff_ms *= 2;
     }
-    if (timeout_ms != 0) {
+    if ((timeout_ms != 0) && (num_bytes == 0)) {
       duration_ms = (platform_monotonic_time_ns() - timestamp) / (1000UL * 1000UL);
       if (duration_ms  > timeout_ms)
         return false;

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -569,6 +569,52 @@ TEST_F(T_Util, ReadHalfPipe) {
   ClosePipe(fd);
 }
 
+namespace {
+
+struct ReadHalfPipeInfo {
+  int fd;
+  int length;
+  void *dst;
+};
+
+static void *MainReadHalfPipe(void *data) {
+  ReadHalfPipeInfo *info = reinterpret_cast<ReadHalfPipeInfo *>(data);
+  bool retval;
+  do {
+    retval = ReadHalfPipe(info->fd, info->dst, info->length, 10);
+  } while (retval == false);
+  return NULL;
+}
+
+}  // anonymous namespace
+
+TEST_F(T_Util, ReadHalfPipeTimeout) {
+  int fd[2];
+  void *buffer_output = scalloc(20, sizeof(char));
+  MakePipe(fd);
+
+  const int size = static_cast<int>(to_write.length());
+
+  ReadHalfPipeInfo info;
+  info.fd = fd[0];
+  info.length = size;
+  info.dst = buffer_output;
+  pthread_t thread_read;
+  const int retval =
+    pthread_create(&thread_read, NULL, MainReadHalfPipe, &info);
+  assert(retval == 0);
+
+  SafeSleepMs(250);
+  EXPECT_EQ(size, write(fd[1], to_write.data(), size));
+
+  pthread_join(thread_read, NULL);
+
+  EXPECT_EQ(0,
+    memcmp(const_cast<char *>(to_write.data()), buffer_output, size));
+  free(buffer_output);
+  ClosePipe(fd);
+}
+
 TEST_F(T_Util, ClosePipe) {
   int fd[2];
   UniquePtr<void> buffer_output(scalloc(20, sizeof(char)));


### PR DESCRIPTION
* fix ReadHalfPipe for reads larger than the timeout

* fix clang-tidy detected defect



* fix formatting error

* Update test/unittests/t_util.cc

---------