### PR TITLE
Create scratch dir with consistent permissions

### DIFF
--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -562,7 +562,7 @@ void Publisher::OnUploadWhitelist(const upload::SpoolerResult &result) {
 
 void Publisher::CreateDirectoryAsOwner(const std::string &path, int mode)
 {
-  bool rvb = MkdirDeep(path, mode);
+  const bool rvb = MkdirDeep(path, mode);
   if (!rvb) throw EPublish("cannot create directory " + path);
   int rvi = chown(path.c_str(), settings_.owner_uid(), settings_.owner_gid());
   if (rvi != 0) throw EPublish("cannot set ownership on directory " + path);

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -578,7 +578,7 @@ void Publisher::InitSpoolArea() {
   CreateDirectoryAsOwner(settings_.transaction().spool_area().scratch_dir(),
                          kDefaultDirMode);
   CreateDirectoryAsOwner(settings_.transaction().spool_area().ovl_work_dir(),
-                         kDefaultDirMode);
+                         kPrivateDirMode);
 
   // On a managed node, the mount points are already mounted
   if (!DirectoryExists(settings_.transaction().spool_area().readonly_mnt())) {

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -562,7 +562,7 @@ void Publisher::OnUploadWhitelist(const upload::SpoolerResult &result) {
 
 void Publisher::CreateDirectoryAsOwner(const std::string &path, int mode)
 {
-  bool rvb = MkdirDeep(path, kPrivateDirMode);
+  bool rvb = MkdirDeep(path, mode);
   if (!rvb) throw EPublish("cannot create directory " + path);
   int rvi = chown(path.c_str(), settings_.owner_uid(), settings_.owner_gid());
   if (rvi != 0) throw EPublish("cannot set ownership on directory " + path);
@@ -576,18 +576,18 @@ void Publisher::InitSpoolArea() {
   CreateDirectoryAsOwner(settings_.transaction().spool_area().cache_dir(),
                          kPrivateDirMode);
   CreateDirectoryAsOwner(settings_.transaction().spool_area().scratch_dir(),
-                         kPrivateDirMode);
+                         kDefaultDirMode);
   CreateDirectoryAsOwner(settings_.transaction().spool_area().ovl_work_dir(),
-                         kPrivateDirMode);
+                         kDefaultDirMode);
 
   // On a managed node, the mount points are already mounted
   if (!DirectoryExists(settings_.transaction().spool_area().readonly_mnt())) {
     CreateDirectoryAsOwner(settings_.transaction().spool_area().readonly_mnt(),
-                           kPrivateDirMode);
+                           kDefaultDirMode);
   }
   if (!DirectoryExists(settings_.transaction().spool_area().union_mnt())) {
     CreateDirectoryAsOwner(
-      settings_.transaction().spool_area().union_mnt(), kPrivateDirMode);
+      settings_.transaction().spool_area().union_mnt(), kDefaultDirMode);
   }
 }
 

--- a/cvmfs/publish/repository_managed.cc
+++ b/cvmfs/publish/repository_managed.cc
@@ -66,7 +66,7 @@ void Publisher::ManagedNode::ClearScratch() {
   int rvi = rename(scratch_dir.c_str(), (waste_dir + "/delete-me").c_str());
   if (rvi != 0) throw EPublish("cannot move scratch directory to wastebin");
 
-  publisher_->CreateDirectoryAsOwner(scratch_dir, kPrivateDirMode);
+  publisher_->CreateDirectoryAsOwner(scratch_dir, kDefaultDirMode);
 
   AlterMountpoint(kAlterScratchWipe, kLogSyslog);
 

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -49,13 +49,13 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
-  check_mountpoint_permissions || return 121
+  check_mountpoint_permissions ${repo_dir} || return 121
 
   echo "start and abort transaction to check permissions"
   start_transaction $CVMFS_TEST_REPO || return 123
   abort_transaction $CVMFS_TEST_REPO || return 124
 
-  check_mountpoint_permissions || return 125
+  check_mountpoint_permissions ${repo_dir} || return 125
 
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -27,6 +27,11 @@ produce_files_in() {
 	popdir
 }
 
+check_mountpoint_permissions() {
+  local permission=$(stat --printf %a $1)
+  [ "x${permission}" = "x755" ] || return 121
+}
+
 cleanup() {
   if [ "x$CVMFS_TEST500_LONG_REPONAME" != "x" ]; then
     destroy_repo testrepo.osg-software-2580-el7-cvmfs-stratum-0.novalocal.crt
@@ -44,6 +49,14 @@ cvmfs_run_test() {
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
+  check_mountpoint_permissions || return 121
+
+  echo "start and abort transaction to check permissions"
+  start_transaction $CVMFS_TEST_REPO || return 123
+  abort_transaction $CVMFS_TEST_REPO || return 124
+
+  check_mountpoint_permissions || return 125
+
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
 
@@ -56,6 +69,7 @@ cvmfs_run_test() {
   sleep 2
   abort_transaction $CVMFS_TEST_REPO || return 31
   wait $pid_txn || return 32
+
 
   echo "putting some stuff in the new repository"
   produce_files_in $repo_dir || return 3


### PR DESCRIPTION
The scratch dir (typically under `/var/spool/cvmfs/@fqrn@/scratch/current`) gets initialised with mode 700, Publishing a transaction will recreate it with 755. Aborting a transaction will reinit the directory with mode 700.  Since this directory is used in the overlay for `/cvmfs/@fqrn@` the permissions for the top level dir also seem to change, with potential for confusion. For consistency, this patch already initialises the scratch dir with mode 755.

This patch also fixes `Publisher::CreateDirectoryAsOwner(const std::string &path, int mode)`, which ignored the mode parameter, hardcoding it to `kPrivateDirMode`.

Fixes #3658 