### PR TITLE
Add support for supervisord in place of systemd

### DIFF
--- a/cvmfs/server/cvmfs_server_apache.sh
+++ b/cvmfs/server/cvmfs_server_apache.sh
@@ -21,6 +21,11 @@ request_apache_service() {
   local request_verb="$1"
   if is_systemd; then
     /bin/systemctl $request_verb ${APACHE_CONF}
+  elif [ x"$SUPERVISOR_BIN" != x"false" ]; then
+    if [ x"$request_verb" = x"reload" ]; then
+      request_verb="restart"
+    fi
+    $SUPERVISOR_BIN $request_verb ${APACHE_CONF}
   else
     $SERVICE_BIN $APACHE_CONF $request_verb
   fi

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -79,6 +79,10 @@ else # RedHat based
   APACHE_WSGI_MODPKG="mod_wsgi"
 fi
 
+SUPERVISOR_BIN="false"
+if [ -f /bin/supervisorctl ]; then
+  SUPERVISOR_BIN=/bin/supervisorctl
+fi
 SERVICE_BIN="false"
 if [ ! -f /bin/systemctl ]; then
   if cvmfs_sys_file_is_executable /sbin/service ; then

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -913,8 +913,12 @@ minpidof() {
 }
 
 
+# Return true if systemd is to be used, that is, if neither the service
+# command nor the supervisorctl command has been located.  Note that
+# the service command is only looked for if systemctl is missing, but
+# the supervisorctl command will take precedence over systemctl.
 is_systemd() {
-  [ x"$SERVICE_BIN" = x"false" ]
+  [ x"$SERVICE_BIN" = x"false" ] && [ x"$SUPERVISOR_BIN" = x"false" ]
 }
 
 


### PR DESCRIPTION
If supervisorctl exists, use that instead of systemctl for managing apache in cvmfs_server.

- Fixes #3661