### PR TITLE
Remove Taiwan stratum 1 from config rpm for egi and osg

### DIFF
--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.1-1_all.deb"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default_2.2-1_all.deb"
 
 # retrieve the upstream version string from CVMFS
 cvmfs_version="$(get_cvmfs_version_from_cmake $CVMFS_SOURCE_LOCATION)"

--- a/ci/cvmfs/rpm.sh
+++ b/ci/cvmfs/rpm.sh
@@ -19,7 +19,7 @@ CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
 CVMFS_NIGHTLY_BUILD_NUMBER="${3-0}"
 
-CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.1-1.noarch.rpm"
+CVMFS_CONFIG_PACKAGE="cvmfs-config-default-2.2-1.noarch.rpm"
 
 rpm_infra_dirs="BUILD RPMS SOURCES SRPMS TMP"
 rpm_src_dir="${CVMFS_SOURCE_LOCATION}/packaging/rpm"

--- a/mount/domain.d/egi.eu.conf
+++ b/mount/domain.d/egi.eu.conf
@@ -10,9 +10,9 @@ if [ "$CVMFS_CONFIG_REPO_DEFAULT_ENV" = "" ]; then
 
   # Stratum 1 servers for the egi.eu domain.
   if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1triumf-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
   else
-    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfsrepo.lcg.triumf.ca:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
   fi
 
   # Key chain with public signing keys for repositories in the egi.eu domain

--- a/mount/domain.d/opensciencegrid.org.conf
+++ b/mount/domain.d/opensciencegrid.org.conf
@@ -10,9 +10,9 @@ if [ "$CVMFS_CONFIG_REPO_DEFAULT_ENV" = "" ]; then
 
   # Stratum 1 servers for the opensciencegrid.org domain
   if [ "$CVMFS_USE_CDN" = "yes" ]; then
-    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1nikhef-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io/cvmfs/@fqrn@"
   else
-    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
+    CVMFS_SERVER_URL="http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://klei.nikhef.nl:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@"
   fi
 
   # Key chain with public signing keys for repositories in the opensciencegrid.org domain

--- a/packaging/debian/config-default/changelog
+++ b/packaging/debian/config-default/changelog
@@ -1,3 +1,9 @@
+cvmfs-config-default (2.2-1) lucid; urgency=low
+
+  * Remove the ASGC Taiwan stratum 1 from the egi and opensciencegrid domains.  Note that the list of stratum 1s is normally overriden by the configuration repository so this only affects cases where the configuration repository is not available.
+
+ -- Dave Dykstra <dwd@fnal.gov>  Tue, 24 Sep 2024 14:30:22 +0200
+
 cvmfs-config-default (2.1-1) lucid; urgency=low
 
   * During reload/mount: fallback to local config repo if remote repo is unavailable

--- a/packaging/rpm/cvmfs-config-default.spec
+++ b/packaging/rpm/cvmfs-config-default.spec
@@ -1,6 +1,6 @@
 Summary: CernVM File System Default Configuration and Public Keys
 Name: cvmfs-config-default
-Version: 2.1
+Version: 2.2
 Release: 1
 Source0: cern-it1.cern.ch.pub
 Source1: cern-it4.cern.ch.pub
@@ -75,6 +75,12 @@ install -D -m 444 "%{SOURCE9}" $RPM_BUILD_ROOT%{_sysconfdir}/cvmfs/config.d/READ
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
+* Tue Sep 24 2024 Dave Dykstra <dwd@fnal.gov> - 2.2-1
+- Remove the ASGC Taiwan stratum 1 from the egi and opensciencegrid domains.
+  Note that the list of stratum 1s is normally overriden by the configuration
+  repository so this only affects cases where the configuration repository
+  is not available.
+
 * Wed Sep 13 2023 HereThereBeDragons <HereThereBeDragons@users.noreply.github.com> - 2.1-1
 - During reload/mount: fallback to local config repo if remote repo is unavailable
 


### PR DESCRIPTION
Remove the ASGC Taiwan stratum 1 from the egi and opensciencegrid domains in the cvmfs-config-default rpm.

The list of stratum 1s is normally overriden by the configuration repository so this only affects cases where the configuration repository is not available.