### PR TITLE
Print correct timezone in logbuffer

### DIFF
--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -476,7 +476,7 @@ void LogBufferXattr::FinalizeValue() {
       itr->message.resize(kMaxLogLine);
       itr->message += " <snip>";
     }
-    result += "[" + StringifyTime(itr->timestamp, true /* UTC */) + " UTC] " +
+    result += "[" + StringifyLocalTime(itr->timestamp) + "] " +
               itr->message + "\n";
   }
   result_pages_.push_back(result);

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -130,7 +130,8 @@ string StringifyLocalTime(const time_t seconds) {
   const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
                           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
   char buffer[26];
-  snprintf(buffer, sizeof(buffer), "%d %s %d %02d:%02d:%02d %s", timestamp.tm_mday,
+  (void)/* cast to void ignores return and placates clang-tidy */
+   snprintf(buffer, sizeof(buffer), "%d %s %d %02d:%02d:%02d %s", timestamp.tm_mday,
            months[timestamp.tm_mon], timestamp.tm_year + 1900,
            timestamp.tm_hour, timestamp.tm_min, timestamp.tm_sec, timestamp.tm_zone);
 

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -120,6 +120,23 @@ string StringifyTime(const time_t seconds, const bool utc) {
   return string(buffer);
 }
 
+/**
+ * Converts seconds since UTC 0 into something like 12 Sep 14:59:37 CDT
+ */
+string StringifyLocalTime(const time_t seconds) {
+  struct tm timestamp;
+  localtime_r(&seconds, &timestamp);
+
+  const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+  char buffer[26];
+  snprintf(buffer, sizeof(buffer), "%d %s %d %02d:%02d:%02d %s", timestamp.tm_mday,
+           months[timestamp.tm_mon], timestamp.tm_year + 1900,
+           timestamp.tm_hour, timestamp.tm_min, timestamp.tm_sec, timestamp.tm_zone);
+
+  return string(buffer);
+}
+
 
 /**
  * Current time in format Wed, 01 Mar 2006 12:00:00 GMT

--- a/cvmfs/util/string.h
+++ b/cvmfs/util/string.h
@@ -30,6 +30,7 @@ CVMFS_EXPORT std::string StringifyUint(const uint64_t value);
 CVMFS_EXPORT std::string StringifyByteAsHex(const unsigned char value);
 CVMFS_EXPORT std::string StringifyDouble(const double value);
 CVMFS_EXPORT std::string StringifyTime(const time_t seconds, const bool utc);
+CVMFS_EXPORT std::string StringifyLocalTime(const time_t seconds);
 CVMFS_EXPORT std::string StringifyTimeval(const timeval value);
 CVMFS_EXPORT std::string RfcTimestamp();
 CVMFS_EXPORT std::string IsoTimestamp();

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1281,6 +1281,13 @@ TEST_F(T_Util, StringifyTime) {
   EXPECT_EQ(GetTimeString(other, false), StringifyTime(other, false));
 }
 
+TEST_F(T_Util, StringifyLocalTime) {
+  time_t other = 1263843;
+  setenv("TZ", "US/Pacific", true);
+  EXPECT_EQ(StringifyLocalTime(other), "15 Jan 1970 07:04:03 PST");
+  unsetenv("TZ");
+}
+
 TEST_F(T_Util, RfcTimestamp) {
   char *curr_locale = setlocale(LC_TIME, NULL);
   const char *format = "%a, %e %h %Y %H:%M:%S %Z";

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1287,8 +1287,9 @@ TEST_F(T_Util, StringifyLocalTime) {
     // TODO(vvolkl): use GTEST_SKIP once externals are updated
     printf("Skipping test, no tzdata available.\n");
   } else {
-  const time_t other = 1263843;
+    const time_t other = 1263843;
     setenv("TZ", "America/Los_Angeles", true);
+    tzset();
     EXPECT_EQ(StringifyLocalTime(other), "15 Jan 1970 07:04:03 PST");
     unsetenv("TZ");
   }

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1272,8 +1272,8 @@ TEST_F(T_Util, StringifyDouble) {
 }
 
 TEST_F(T_Util, StringifyTime) {
-  time_t now = time(NULL);
-  time_t other = 1263843;
+  const time_t now = time(NULL);
+  const time_t other = 1263843;
 
   EXPECT_EQ(GetTimeString(now, true), StringifyTime(now, true));
   EXPECT_EQ(GetTimeString(now, false), StringifyTime(now, false));
@@ -1282,7 +1282,7 @@ TEST_F(T_Util, StringifyTime) {
 }
 
 TEST_F(T_Util, StringifyLocalTime) {
-  time_t other = 1263843;
+  const time_t other = 1263843;
   setenv("TZ", "US/Pacific", true);
   EXPECT_EQ(StringifyLocalTime(other), "15 Jan 1970 07:04:03 PST");
   unsetenv("TZ");

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1282,10 +1282,16 @@ TEST_F(T_Util, StringifyTime) {
 }
 
 TEST_F(T_Util, StringifyLocalTime) {
+  struct stat tmpbuf;
+  if(stat("/usr/share/zoneinfo", &tmpbuf)) {
+    // TODO: use GTEST_SKIP once externals are updated
+    printf("Skipping test, no tzdata available.\n");
+  } else {
   const time_t other = 1263843;
-  setenv("TZ", "US/Pacific", true);
-  EXPECT_EQ(StringifyLocalTime(other), "15 Jan 1970 07:04:03 PST");
-  unsetenv("TZ");
+    setenv("TZ", "America/Los_Angeles", true);
+    EXPECT_EQ(StringifyLocalTime(other), "15 Jan 1970 07:04:03 PST");
+    unsetenv("TZ");
+  }
 }
 
 TEST_F(T_Util, RfcTimestamp) {

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1284,7 +1284,7 @@ TEST_F(T_Util, StringifyTime) {
 TEST_F(T_Util, StringifyLocalTime) {
   struct stat tmpbuf;
   if(stat("/usr/share/zoneinfo", &tmpbuf)) {
-    // TODO: use GTEST_SKIP once externals are updated
+    // TODO(vvolkl): use GTEST_SKIP once externals are updated
     printf("Skipping test, no tzdata available.\n");
   } else {
   const time_t other = 1263843;


### PR DESCRIPTION
The logbuffer extended attribute shows timestamp in local time, but labeled "UTC":
```
$ attr -g logbuffer /cvmfs/cvmfs-config.cern.ch/
Attribute "logbuffer" had a 877 byte value for /cvmfs/cvmfs-config.cern.ch/:
[12 Sep 2024 14:59:19 UTC] (manager 'default') switching proxy from (none) to http://131.225.152.34:3128. Reason: set random start proxy from the first proxy group

$ date
Thu Sep 12 14:59:37 CDT 2024
```
This commit uses a new `StringifyLocalTime` function to print the proper time zone abbreviation corresponding to local time.

Fixes #3663 