### PR TITLE
Add metalink support

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -2142,7 +2142,11 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
   }
   external_download_mgr_->SetTimeout(timeout, timeout_direct);
 
-  if (options_mgr_->GetValue("CVMFS_EXTERNAL_URL", &optarg)) {
+  if (options_mgr_->GetValue("CVMFS_EXTERNAL_METALINK", &optarg)) {
+    external_download_mgr_->SetMetalinkChain(optarg);  
+    // host chain will be set later when the metalink server is contacted
+    external_download_mgr_->SetHostChain("");
+  } else if (options_mgr_->GetValue("CVMFS_EXTERNAL_URL", &optarg)) {
     external_download_mgr_->SetHostChain(optarg);
     if (dogeosort) {
       std::vector<std::string> host_chain;
@@ -2212,8 +2216,13 @@ void MountPoint::SetupHttpTuning() {
 
   if (options_mgr_->GetValue("CVMFS_LOW_SPEED_LIMIT", &optarg))
     download_mgr_->SetLowSpeedLimit(String2Uint64(optarg));
-  if (options_mgr_->GetValue("CVMFS_PROXY_RESET_AFTER", &optarg))
+  if (options_mgr_->GetValue("CVMFS_PROXY_RESET_AFTER", &optarg)) {
     download_mgr_->SetProxyGroupResetDelay(String2Uint64(optarg));
+    // Use the proxy reset delay as the default for the metalink reset delay
+    download_mgr_->SetMetalinkResetDelay(String2Uint64(optarg));
+  }
+  if (options_mgr_->GetValue("CVMFS_METALINK_RESET_AFTER", &optarg))
+    download_mgr_->SetMetalinkResetDelay(String2Uint64(optarg));
   if (options_mgr_->GetValue("CVMFS_HOST_RESET_AFTER", &optarg))
     download_mgr_->SetHostResetDelay(String2Uint64(optarg));
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1421,7 +1421,13 @@ bool MountPoint::CreateDownloadManagers() {
       download_mgr_->SetFailoverIndefinitely();
   }
 
-  if (options_mgr_->GetValue("CVMFS_SERVER_URL", &optarg)) {
+  if (options_mgr_->GetValue("CVMFS_METALINK_URL", &optarg)) {
+    download_mgr_->SetMetalinkChain(optarg);  
+    // host chain will be set later when the metalink server is contacted
+    download_mgr_->SetHostChain("");
+    // metalink requires redirects
+    download_mgr_->EnableRedirects();
+  } else if (options_mgr_->GetValue("CVMFS_SERVER_URL", &optarg)) {
     download_mgr_->SetHostChain(optarg);
   }
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -2146,6 +2146,8 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
     external_download_mgr_->SetMetalinkChain(optarg);  
     // host chain will be set later when the metalink server is contacted
     external_download_mgr_->SetHostChain("");
+    // metalink requires redirects
+    external_download_mgr_->EnableRedirects();
   } else if (options_mgr_->GetValue("CVMFS_EXTERNAL_URL", &optarg)) {
     external_download_mgr_->SetHostChain(optarg);
     if (dogeosort) {

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -2415,7 +2415,7 @@ void DownloadManager::SwitchHostInfo(const std::string &typ,
   info_id += ")";
 
   const std::string old_host = (*info.chain)[info.current];
-  info.current = (info.current + 1) % info.chain->size();
+  info.current = (info.current + 1) % static_cast<int>(info.chain->size());
   if (typ == "host") {
     perf::Inc(counters_->n_host_failover);
   } else {

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1130,13 +1130,13 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   if (info->probe_hosts()) {
     if (CheckMetalinkChain(now)) {
       url_prefix = (*opt_metalink_.chain)[opt_metalink_.current];
-      info->SetCurrentMetalinkChainIndex(opt_metalink_.current);
+      info->SetCurrentMetalinkChainIndex(static_cast<int>(opt_metalink_.current));
       LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
                       "reading from metalink %d",
                       name_.c_str(), info->id(), opt_metalink_.current);
     } else if (opt_host_.chain) {
       url_prefix = (*opt_host_.chain)[opt_host_.current];
-      info->SetCurrentHostChainIndex(opt_host_.current);
+      info->SetCurrentHostChainIndex(static_cast<int>(opt_host_.current));
       LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
                       "reading from host %d",
                       name_.c_str(), info->id(), opt_host_.current);
@@ -1403,7 +1403,7 @@ void DownloadManager::ReleaseCredential(JobInfo *info) {
 
 
 /* Sort links based on the "pri=" parameter */
-static bool sortlinks(const std::string &s1, const std::string s2) {
+static bool sortlinks(const std::string &s1, const std::string &s2) {
   const size_t pos1 = s1.find("; pri=");
   const size_t pos2 = s2.find("; pri=");
   int pri1, pri2;
@@ -2227,7 +2227,7 @@ void DownloadManager::SetMetalinkChain(const string &metalink_list) {
 
 void DownloadManager::SetMetalinkChain(
     const std::vector<std::string> &metalink_list) {
-  MutexLockGuard m(lock_options_);
+  const MutexLockGuard m(lock_options_);
   opt_metalink_.timestamp_backup = 0;
   delete opt_metalink_.chain;
   opt_metalink_.current = 0;
@@ -2248,7 +2248,7 @@ void DownloadManager::SetMetalinkChain(
 void DownloadManager::GetMetalinkInfo(vector<string> *metalink_chain,
                                   unsigned *current_metalink)
 {
-  MutexLockGuard m(lock_options_);
+  const MutexLockGuard m(lock_options_);
   if (opt_metalink_.chain) {
     if (current_metalink) {*current_metalink = opt_metalink_.current;}
     if (metalink_chain) {*metalink_chain = *opt_metalink_.chain;}
@@ -3064,7 +3064,7 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
 
   // Report any change in proxy usage
   string new_proxy = JoinStrings(opt_proxies_, "|");
-  string curr_host = "Current host: " + (opt_host_.chain ?
+  const string curr_host = "Current host: " + (opt_host_.chain ?
                               (*opt_host_.chain)[opt_host_.current] : "");
   if (new_proxy != old_proxy) {
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
@@ -3135,7 +3135,7 @@ void DownloadManager::SetProxyGroupResetDelay(const unsigned seconds) {
 
 void DownloadManager::SetMetalinkResetDelay(const unsigned seconds)
 {
-  MutexLockGuard m(lock_options_);
+  const MutexLockGuard m(lock_options_);
   opt_metalink_.reset_after = seconds;
   if (opt_metalink_.reset_after == 0)
     opt_metalink_.timestamp_backup = 0;

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -226,7 +226,14 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
     // This is metalink info
     LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") %s",
                                       info->id(), header_line.c_str());
-    info->SetLink(header_line.substr(5));
+    std::string link = info->link();
+    if (link.size() != 0) {
+      // multiple LINK headers are allowed
+      link = link + ", " + header_line.substr(5);
+    } else {
+      link = header_line.substr(5);
+    }
+    info->SetLink(link);
   } else if (HasPrefix(header_line, "X-SQUID-ERROR:", true)) {
     // Reinterpret host error as proxy error
     if (info->error_code() == kFailHostHttp) {
@@ -1009,7 +1016,7 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
 }
 
 void DownloadManager::CheckHostInfoReset(
-    std::string typ,
+    const std::string &typ,
     HostInfo &info,
     JobInfo *jobinfo,
     time_t &now)
@@ -1399,6 +1406,81 @@ void DownloadManager::ReleaseCredential(JobInfo *info) {
 }
 
 
+/* Sort links based on the "pri=" parameter */
+static bool sortlinks(const std::string &s1, const std::string s2) {
+  const size_t pos1 = s1.find("; pri=");
+  const size_t pos2 = s2.find("; pri=");
+  int pri1, pri2;
+  if ((pos1 != std::string::npos) &&
+      (pos2 != std::string::npos) &&
+      (sscanf(s1.substr(pos1+6).c_str(), "%d", &pri1) == 1) &&
+      (sscanf(s2.substr(pos2+6).c_str(), "%d", &pri2) == 1)) {
+    return pri1 < pri2;
+  }
+  return false;
+}
+
+/**
+ * Parses Link header and uses it to set a new host chain.
+ * See rfc6249.
+ */
+void DownloadManager::ProcessLink(JobInfo *info) {
+
+  std::vector<std::string> links = SplitString(info->link(), ',');
+  if (info->link().find("; pri=") != std::string::npos)
+    std::sort(links.begin(), links.end(), sortlinks);
+
+  std::vector<std::string> host_list;
+
+  std::vector<std::string>::const_iterator il = links.begin();
+  for (; il != links.end(); ++il) {
+    const std::string &link = *il;
+    if ((link.find("; rel=duplicate") == std::string::npos) &&
+        (link.find("; rel=\"duplicate\"") == std::string::npos)) {
+      LogCvmfs(kLogDownload, kLogDebug,
+        "skipping link '%s' because it does not contain rel=duplicate",
+        link.c_str());
+      continue;
+    }
+    // ignore depth= field since there's nothing useful we can do with it
+
+    size_t start = link.find('<');
+    if (start == std::string::npos) {
+      LogCvmfs(kLogDownload, kLogDebug,
+        "skipping link '%s' because it does not have a left angle bracket",
+        link.c_str());
+      continue;
+    }
+
+    start++;
+    if ((link.substr(start, 7) != "http://") &&
+        (link.substr(start, 8) != "https://")) {
+      LogCvmfs(kLogDownload, kLogDebug,
+        "skipping link '%s' of unrecognized url protocol", link.c_str());
+      continue;
+    }
+
+    size_t end = link.find('/', start+8);
+    if (end == std::string::npos)
+      end = link.find('>');
+    if (end == std::string::npos) {
+      LogCvmfs(kLogDownload, kLogDebug,
+        "skipping link '%s' because no slash in url and no right angle bracket",
+        link.c_str());
+      continue;
+    }
+    const std::string host = link.substr(start, end-start);
+    LogCvmfs(kLogDownload, kLogDebug, "adding linked host '%s'", host.c_str());
+    host_list.push_back(host);
+  }
+
+  if (host_list.size() > 0) {
+    SetHostChain(host_list);
+    opt_metalink_timestamp_link_ = time(NULL);
+  }
+}
+
+
 /**
  * Checks the result of a curl download and implements the failure logic, such
  * as changing the proxy server.  Takes care of cleanup.
@@ -1411,6 +1493,21 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
                            name_.c_str(), info->id(), info->url()->c_str(),
                            info->proxy().c_str(), curl_error);
   UpdateStatistics(info->curl_handle());
+
+  bool was_metalink;
+  std::string typ;
+  if (info->current_metalink_chain_index() >= 0) {
+    was_metalink = true;
+    typ = "metalink";
+    if (info->link() != "") {
+      // process Link header whether or not the redirected URL got an error
+      ProcessLink(info);
+    }
+  } else {
+    was_metalink = false;
+    typ = "host";
+  }
+
 
   // Verification and error classification
   switch (curl_error) {
@@ -1512,18 +1609,12 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
       break;
   }
 
-  bool was_metalink;
-  std::string typ;
   std::vector<std::string> *host_chain;
   unsigned char num_used_hosts;
-  if (info->current_metalink_chain_index() >= 0) {
-    was_metalink = true;
-    typ = "metalink";
+  if (was_metalink) {
     host_chain = opt_metalink_.chain;
     num_used_hosts = info->num_used_metalinks();
   } else {
-    was_metalink = false;
-    typ = "host";
     host_chain = opt_host_.chain;
     num_used_hosts = info->num_used_hosts();
   }
@@ -1580,7 +1671,8 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
               {
                 opt_proxy_groups_current_ = 0;
                 opt_timestamp_backup_proxies_ = 0;
-                std::string msg = "reset proxies for " + typ + " failover";
+                const std::string msg =
+                  "reset proxies for " + typ + " failover";
                 RebalanceProxiesUnlocked(msg);
               }
             }
@@ -1924,6 +2016,9 @@ Failures DownloadManager::Fetch(JobInfo *info) {
     info->GetHashContextPtr()->size = shash::GetContextSize(algorithm);
     info->GetHashContextPtr()->buffer = alloca(info->hash_context().size);
   }
+
+  // In case JobInfo object is being reused
+  info->SetLink("");
 
   // Prepare cvmfs-info: header, allocate string on the stack
   info->SetInfoHeader(NULL);
@@ -2286,7 +2381,7 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
  * the current host is identical to the one used by jobinfo, otherwise another
  * transfer has already done the switch.
  */
-void DownloadManager::SwitchHostInfo(const std::string typ,
+void DownloadManager::SwitchHostInfo(const std::string &typ,
                                      HostInfo &info,
                                      JobInfo *jobinfo) {
   MutexLockGuard m(lock_options_);
@@ -2297,10 +2392,11 @@ void DownloadManager::SwitchHostInfo(const std::string typ,
 
   if (jobinfo) {
     unsigned lastused;
-    if (typ == "host")
+    if (typ == "host") {
       lastused = jobinfo->current_host_chain_index();
-    else
+    } else {
       lastused = jobinfo->current_metalink_chain_index();
+    }
     if (lastused != info.current) {
       LogCvmfs(kLogDownload, kLogDebug,
                "(manager '%s' - id %" PRId64 ")"
@@ -2321,7 +2417,7 @@ void DownloadManager::SwitchHostInfo(const std::string typ,
   }
   info_id += ")";
 
-  string old_host = (*info.chain)[info.current];
+  const std::string old_host = (*info.chain)[info.current];
   info.current = (info.current + 1) % info.chain->size();
   if (typ == "host") {
     perf::Inc(counters_->n_host_failover);
@@ -3153,6 +3249,7 @@ DownloadManager *DownloadManager::Clone(
   clone->proxy_template_direct_ = proxy_template_direct_;
   clone->proxy_template_forced_ = proxy_template_forced_;
   clone->opt_proxy_groups_reset_after_ = opt_proxy_groups_reset_after_;
+  clone->opt_metalink_.reset_after = opt_metalink_.reset_after;
   clone->opt_host_.reset_after = opt_host_.reset_after;
   clone->credentials_attachment_ = credentials_attachment_;
   clone->ssl_certificate_store_ = ssl_certificate_store_;

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1128,11 +1128,7 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
     curl_easy_setopt(curl_handle, CURLOPT_DNS_SERVERS, opt_dns_server_.c_str());
 
   if (info->probe_hosts()) {
-    if (opt_metalink_.chain &&
-        ((opt_metalink_timestamp_link_ == 0) ||
-         (static_cast<int64_t>((now == 0) ? time(NULL) : now) >
-          static_cast<int64_t>(opt_metalink_timestamp_link_ +
-                              opt_metalink_.reset_after)))) {
+    if (CheckMetalinkChain(now)) {
       url_prefix = (*opt_metalink_.chain)[opt_metalink_.current];
       info->SetCurrentMetalinkChainIndex(opt_metalink_.current);
       LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
@@ -1921,6 +1917,7 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
                   ignore_signature_failures_(false),
                   enable_http_tracing_(false),
                   opt_metalink_(NULL, 0, 0, 0),
+                  opt_metalink_timestamp_link_(0),
                   opt_host_(NULL, 0, 0, 0),
                   opt_host_chain_rtt_(NULL),
                   opt_proxy_groups_(NULL),
@@ -2453,8 +2450,17 @@ void DownloadManager::SwitchMetalink(JobInfo *info) {
   SwitchHostInfo("metalink", opt_metalink_, info);
 }
 
+
 void DownloadManager::SwitchMetalink() {
   SwitchMetalink(NULL);
+}
+
+bool DownloadManager::CheckMetalinkChain(time_t now) {
+  return (opt_metalink_.chain &&
+         ((opt_metalink_timestamp_link_ == 0) ||
+          (static_cast<int64_t>((now == 0) ? time(NULL) : now) >
+           static_cast<int64_t>(opt_metalink_timestamp_link_ +
+                               opt_metalink_.reset_after))));
 }
 
 

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1130,13 +1130,13 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   if (info->probe_hosts()) {
     if (CheckMetalinkChain(now)) {
       url_prefix = (*opt_metalink_.chain)[opt_metalink_.current];
-      info->SetCurrentMetalinkChainIndex(static_cast<int>(opt_metalink_.current));
+      info->SetCurrentMetalinkChainIndex(opt_metalink_.current);
       LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
                       "reading from metalink %d",
                       name_.c_str(), info->id(), opt_metalink_.current);
     } else if (opt_host_.chain) {
       url_prefix = (*opt_host_.chain)[opt_host_.current];
-      info->SetCurrentHostChainIndex(static_cast<int>(opt_host_.current));
+      info->SetCurrentHostChainIndex(opt_host_.current);
       LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
                       "reading from host %d",
                       name_.c_str(), info->id(), opt_host_.current);
@@ -2388,7 +2388,7 @@ void DownloadManager::SwitchHostInfo(const std::string &typ,
   }
 
   if (jobinfo) {
-    unsigned lastused;
+    int lastused;
     if (typ == "host") {
       lastused = jobinfo->current_host_chain_index();
     } else {

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -44,8 +44,9 @@ struct Counters {
   perf::Counter *sz_transfer_time;  // measured in milliseconds
   perf::Counter *n_requests;
   perf::Counter *n_retries;
-  perf::Counter *n_proxy_failover;
+  perf::Counter *n_metalink_failover;
   perf::Counter *n_host_failover;
+  perf::Counter *n_proxy_failover;
 
   explicit Counters(perf::StatisticsTemplate statistics) {
     sz_transferred_bytes = statistics.RegisterTemplated("sz_transferred_bytes",
@@ -55,10 +56,12 @@ struct Counters {
     n_requests = statistics.RegisterTemplated("n_requests",
         "Number of requests");
     n_retries = statistics.RegisterTemplated("n_retries", "Number of retries");
-    n_proxy_failover = statistics.RegisterTemplated("n_proxy_failover",
-        "Number of proxy failovers");
+    n_metalink_failover = statistics.RegisterTemplated("n_metalink_failover",
+        "Number of metalink failovers");
     n_host_failover = statistics.RegisterTemplated("n_host_failover",
         "Number of host failovers");
+    n_proxy_failover = statistics.RegisterTemplated("n_proxy_failover",
+        "Number of proxy failovers");
   }
 };  // Counters
 
@@ -119,6 +122,25 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   FRIEND_TEST(T_Download, EscapeUrl);
 
  public:
+  // HostInfo is used for both metalink and host
+  struct HostInfo {
+    HostInfo() { }
+    HostInfo(
+        std::vector<std::string> *chain,
+        const unsigned current,
+        const time_t timestamp_backup,
+        const unsigned reset_after)
+      : chain(chain)
+      , current(current)
+      , timestamp_backup(timestamp_backup)
+      , reset_after(reset_after)
+    { }
+    std::vector<std::string> *chain;
+    unsigned current;
+    time_t timestamp_backup;
+    unsigned reset_after;
+  };
+
   struct ProxyInfo {
     ProxyInfo() { }
     explicit ProxyInfo(const std::string &url) : url(url) { }
@@ -176,6 +198,11 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void SetTimeout(const unsigned seconds_proxy, const unsigned seconds_direct);
   void GetTimeout(unsigned *seconds_proxy, unsigned *seconds_direct);
   void SetLowSpeedLimit(const unsigned low_speed_limit);
+  void SetMetalinkChain(const std::string &metalink_list);
+  void SetMetalinkChain(const std::vector<std::string> &metalink_list);
+  void GetMetalinkInfo(std::vector<std::string> *metalink_chain,
+                       unsigned *current_metalink);
+  void SwitchMetalink();
   void SetHostChain(const std::string &host_list);
   void SetHostChain(const std::vector<std::string> &host_list);
   void GetHostInfo(std::vector<std::string> *host_chain,
@@ -201,6 +228,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void RebalanceProxies();
   void SwitchProxyGroup();
   void SetProxyGroupResetDelay(const unsigned seconds);
+  void SetMetalinkResetDelay(const unsigned seconds);
   void SetHostResetDelay(const unsigned seconds);
   void SetRetryParameters(const unsigned max_retries,
                           const unsigned backoff_init_ms,
@@ -219,7 +247,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void SetFqrn(const std::string &fqrn) { fqrn_ = fqrn; }
 
   unsigned num_hosts() {
-    if (opt_host_chain_) return opt_host_chain_->size();
+    if (opt_host_.chain) return opt_host_.chain->size();
     return 0;
   }
 
@@ -236,6 +264,8 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool ValidateGeoReply(const std::string &reply_order,
                         const unsigned expected_size,
                         std::vector<uint64_t> *reply_vals);
+  void SwitchHostInfo(std::string typ, HostInfo &info, JobInfo *jobinfo);
+  void SwitchMetalink(JobInfo *info);
   void SwitchHost(JobInfo *info);
   void SwitchProxy(JobInfo *info);
   ProxyInfo *ChooseProxyUnlocked(const shash::Any *hash);
@@ -255,6 +285,8 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool VerifyAndFinalize(const int curl_error, JobInfo *info);
   void InitHeaders();
   void CloneProxyConfig(DownloadManager *clone);
+  void CheckHostInfoReset(const std::string typ, HostInfo &info,
+                          JobInfo *jobinfo);
 
   bool EscapeUrlChar(unsigned char input, char output[3]);
   std::string EscapeUrl(const int64_t jobinfo_id, const std::string &url);
@@ -307,14 +339,17 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool enable_http_tracing_;
   std::vector<std::string> http_tracing_headers_;
 
+  // Metalink
+  HostInfo opt_metalink_;
+
   // Host list
-  std::vector<std::string> *opt_host_chain_;
+  HostInfo opt_host_;
+
   /**
    * Created by SetHostChain(), filled by probe_hosts.  Contains time to get
    * .cvmfschecksum in ms. -1 is unprobed, -2 is error.
    */
   std::vector<int> *opt_host_chain_rtt_;
-  unsigned opt_host_chain_current_;
 
   // Proxy list
   std::vector< std::vector<ProxyInfo> > *opt_proxy_groups_;
@@ -421,14 +456,6 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   time_t opt_timestamp_backup_proxies_;
   time_t opt_timestamp_failover_proxies_;  // failover within the same group
   unsigned opt_proxy_groups_reset_after_;
-
-  /**
-   * Similarly to proxy group reset, we'd also like to reset the host after a
-   * failover.  Host outages can last longer and might come with a separate
-   * reset delay.
-   */
-  time_t opt_timestamp_backup_host_;
-  unsigned opt_host_reset_after_;
 
   CredentialsAttachment *credentials_attachment_;
 

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -251,6 +251,11 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
     return 0;
   }
 
+  unsigned num_metalinks() {
+    if (opt_metalink_.chain) return opt_metalink_.chain->size();
+    return 0;
+  }
+
   dns::IpPreference opt_ip_preference() const {
     return opt_ip_preference_;
   }
@@ -286,7 +291,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void InitHeaders();
   void CloneProxyConfig(DownloadManager *clone);
   void CheckHostInfoReset(const std::string typ, HostInfo &info,
-                          JobInfo *jobinfo);
+                          JobInfo *jobinfo, time_t &now);
 
   bool EscapeUrlChar(unsigned char input, char output[3]);
   std::string EscapeUrl(const int64_t jobinfo_id, const std::string &url);
@@ -341,10 +346,10 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
 
   // Metalink
   HostInfo opt_metalink_;
+  time_t opt_metalink_timestamp_link_;
 
   // Host list
   HostInfo opt_host_;
-
   /**
    * Created by SetHostChain(), filled by probe_hosts.  Contains time to get
    * .cvmfschecksum in ms. -1 is unprobed, -2 is error.

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -127,7 +127,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
     HostInfo() { }
     HostInfo(
         std::vector<std::string> *chain,
-        const unsigned current,
+        const int current,
         const time_t timestamp_backup,
         const unsigned reset_after)
       : chain(chain)
@@ -269,7 +269,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool ValidateGeoReply(const std::string &reply_order,
                         const unsigned expected_size,
                         std::vector<uint64_t> *reply_vals);
-  void SwitchHostInfo(std::string typ, HostInfo &info, JobInfo *jobinfo);
+  void SwitchHostInfo(const std::string &typ, HostInfo &info, JobInfo *jobinfo);
   void SwitchMetalink(JobInfo *info);
   void SwitchHost(JobInfo *info);
   void SwitchProxy(JobInfo *info);
@@ -287,10 +287,11 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void Backoff(JobInfo *info);
   void SetNocache(JobInfo *info);
   void SetRegularCache(JobInfo *info);
+  void ProcessLink(JobInfo *info);
   bool VerifyAndFinalize(const int curl_error, JobInfo *info);
   void InitHeaders();
   void CloneProxyConfig(DownloadManager *clone);
-  void CheckHostInfoReset(const std::string typ, HostInfo &info,
+  void CheckHostInfoReset(const std::string &typ, HostInfo &info,
                           JobInfo *jobinfo, time_t &now);
 
   bool EscapeUrlChar(unsigned char input, char output[3]);
@@ -344,7 +345,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool enable_http_tracing_;
   std::vector<std::string> http_tracing_headers_;
 
-  // Metalink
+  // Metalink list
   HostInfo opt_metalink_;
   time_t opt_metalink_timestamp_link_;
 

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -136,7 +136,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
       , reset_after(reset_after)
     { }
     std::vector<std::string> *chain;
-    unsigned current;
+    int current;
     time_t timestamp_backup;
     unsigned reset_after;
   };

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -203,6 +203,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void GetMetalinkInfo(std::vector<std::string> *metalink_chain,
                        unsigned *current_metalink);
   void SwitchMetalink();
+  bool CheckMetalinkChain(const time_t now);
   void SetHostChain(const std::string &host_list);
   void SetHostChain(const std::vector<std::string> &host_list);
   void GetHostInfo(std::vector<std::string> *host_chain,

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -67,10 +67,12 @@ void JobInfo::Init() {
   error_code_ = kFailOther;
   http_code_ = -1;
   num_used_proxies_ = 0;
+  num_used_metalinks_ = 0;
   num_used_hosts_ = 0;
   num_retries_ = 0;
   backoff_ms_ = 0;
-  current_host_chain_index_ = 0;
+  current_metalink_chain_index_ = -1;
+  current_host_chain_index_ = -1;
 
   allow_failure_ = false;
 

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -66,6 +66,7 @@ void JobInfo::Init() {
   nocache_ = false;
   error_code_ = kFailOther;
   http_code_ = -1;
+  link_ = "";
   num_used_proxies_ = 0;
   num_used_metalinks_ = 0;
   num_used_hosts_ = 0;

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -99,6 +99,7 @@ class JobInfo {
   z_stream zstream_;
   shash::ContextPtr hash_context_;
   std::string proxy_;
+  std::string link_;
   bool nocache_;
   Failures error_code_;
   int http_code_;
@@ -196,6 +197,7 @@ class JobInfo {
   z_stream zstream() const { return zstream_; }
   shash::ContextPtr hash_context() const { return hash_context_; }
   std::string proxy() const { return proxy_; }
+  std::string link() const { return link_; }
   bool nocache() const { return nocache_; }
   Failures error_code() const { return error_code_; }
   int http_code() const { return http_code_; }
@@ -246,6 +248,7 @@ class JobInfo {
   void SetHashContext(shash::ContextPtr hash_context)
                                                { hash_context_ = hash_context; }
   void SetProxy(const std::string &proxy) { proxy_ = proxy; }
+  void SetLink(const std::string &link) { link_ = link; }
   void SetNocache(bool nocache) { nocache_ = nocache; }
   void SetErrorCode(Failures error_code) { error_code_ = error_code; }
   void SetHttpCode(int http_code) { http_code_ = http_code; }

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -104,10 +104,12 @@ class JobInfo {
   Failures error_code_;
   int http_code_;
   unsigned char num_used_proxies_;
+  unsigned char num_used_metalinks_;
   unsigned char num_used_hosts_;
   unsigned char num_retries_;
   unsigned backoff_ms_;
-  unsigned int current_host_chain_index_;
+  int current_metalink_chain_index_;
+  int current_host_chain_index_;
 
   // Don't fail-over proxies on download errors. default = false
   bool allow_failure_;
@@ -202,11 +204,13 @@ class JobInfo {
   Failures error_code() const { return error_code_; }
   int http_code() const { return http_code_; }
   unsigned char num_used_proxies() const { return num_used_proxies_; }
+  unsigned char num_used_metalinks() const { return num_used_metalinks_; }
   unsigned char num_used_hosts() const { return num_used_hosts_; }
   unsigned char num_retries() const { return num_retries_; }
   unsigned backoff_ms() const { return backoff_ms_; }
-  unsigned int current_host_chain_index() const {
-                                             return current_host_chain_index_; }
+  int current_metalink_chain_index() const {
+                                         return current_metalink_chain_index_; }
+  int current_host_chain_index() const { return current_host_chain_index_; }
 
   bool allow_failure() const { return allow_failure_; }
   int64_t id() const { return id_; }
@@ -254,11 +258,15 @@ class JobInfo {
   void SetHttpCode(int http_code) { http_code_ = http_code; }
   void SetNumUsedProxies(unsigned char num_used_proxies)
                                        { num_used_proxies_ = num_used_proxies; }
+  void SetNumUsedMetalinks(unsigned char num_used_metalinks)
+                                   { num_used_metalinks_ = num_used_metalinks; }
   void SetNumUsedHosts(unsigned char num_used_hosts)
                                            { num_used_hosts_ = num_used_hosts; }
   void SetNumRetries(unsigned char num_retries) { num_retries_ = num_retries; }
   void SetBackoffMs(unsigned backoff_ms) { backoff_ms_ = backoff_ms; }
-  void SetCurrentHostChainIndex(unsigned int current_host_chain_index)
+  void SetCurrentMetalinkChainIndex(int current_metalink_chain_index)
+               { current_metalink_chain_index_ = current_metalink_chain_index; }
+  void SetCurrentHostChainIndex(int current_host_chain_index)
                        { current_host_chain_index_ = current_host_chain_index; }
 
   void SetAllowFailure(bool allow_failure) { allow_failure_ = allow_failure; }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -107,7 +107,7 @@ string TalkManager::FormatMetalinkInfo(download::DownloadManager *download_mgr)
 
   string metalink_str;
   for (unsigned i = 0; i < metalink_chain.size(); ++i) {
-    metalink_str += "  [" + StringifyInt(i) + "] " + metalink_chain[i];
+    metalink_str += "  [" + StringifyInt(i) + "] " + metalink_chain[i] + "\n";
   }
   metalink_str += "Active metalink " + StringifyInt(active_metalink) + ": " +
               metalink_chain[active_metalink] + "\n";

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -96,6 +96,24 @@ TalkManager *TalkManager::Create(
 }
 
 
+string TalkManager::FormatMetalinkInfo(download::DownloadManager *download_mgr)
+{
+  vector<string> metalink_chain;
+  unsigned active_metalink;
+
+  download_mgr->GetMetalinkInfo(&metalink_chain, &active_metalink);
+  if (metalink_chain.size() == 0)
+    return "No metalinks defined\n";
+
+  string metalink_str;
+  for (unsigned i = 0; i < metalink_chain.size(); ++i) {
+    metalink_str += "  [" + StringifyInt(i) + "] " + metalink_chain[i];
+  }
+  metalink_str += "Active metalink " + StringifyInt(active_metalink) + ": " +
+              metalink_chain[active_metalink] + "\n";
+  return metalink_str;
+}
+
 string TalkManager::FormatHostInfo(download::DownloadManager *download_mgr) {
   vector<string> host_chain;
   vector<int> rtt;
@@ -407,6 +425,10 @@ void *TalkManager::MainResponder(void *data) {
         mount_point->download_mgr()->SetDnsServer(host);
         talk_mgr->Answer(con_fd, "OK\n");
       }
+    } else if (line == "external metalink info") {
+      string external_metalink_info =
+        talk_mgr->FormatMetalinkInfo(mount_point->external_download_mgr());
+      talk_mgr->Answer(con_fd, external_metalink_info);
     } else if (line == "external host info") {
       string external_host_info =
         talk_mgr->FormatHostInfo(mount_point->external_download_mgr());
@@ -423,12 +445,23 @@ void *TalkManager::MainResponder(void *data) {
         talk_mgr->Answer(con_fd, "OK\n");
       else
         talk_mgr->Answer(con_fd, "Failed\n");
+    } else if (line == "external metalink switch") {
+      mount_point->external_download_mgr()->SwitchMetalink();
+      talk_mgr->Answer(con_fd, "OK\n");
     } else if (line == "external host switch") {
       mount_point->external_download_mgr()->SwitchHost();
       talk_mgr->Answer(con_fd, "OK\n");
     } else if (line == "host switch") {
       mount_point->download_mgr()->SwitchHost();
       talk_mgr->Answer(con_fd, "OK\n");
+    } else if (line.substr(0, 21) == "external metalink set") {
+      if (line.length() < 23) {
+        talk_mgr->Answer(con_fd, "Usage: external metalink set <URL>\n");
+      } else {
+        const std::string host = line.substr(22);
+        mount_point->external_download_mgr()->SetMetalinkChain(host);
+        talk_mgr->Answer(con_fd, "OK\n");
+      }
     } else if (line.substr(0, 17) == "external host set") {
       if (line.length() < 19) {
         talk_mgr->Answer(con_fd, "Usage: external host set <URL>\n");

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -426,15 +426,20 @@ void *TalkManager::MainResponder(void *data) {
         talk_mgr->Answer(con_fd, "OK\n");
       }
     } else if (line == "external metalink info") {
-      string external_metalink_info =
+      const string external_metalink_info =
         talk_mgr->FormatMetalinkInfo(mount_point->external_download_mgr());
       talk_mgr->Answer(con_fd, external_metalink_info);
+    } else if (line == "metalink info") {
+      const string metalink_info =
+        talk_mgr->FormatMetalinkInfo(mount_point->download_mgr());
+      talk_mgr->Answer(con_fd, metalink_info);
     } else if (line == "external host info") {
-      string external_host_info =
+      const string external_host_info =
         talk_mgr->FormatHostInfo(mount_point->external_download_mgr());
       talk_mgr->Answer(con_fd, external_host_info);
     } else if (line == "host info") {
-      string host_info = talk_mgr->FormatHostInfo(mount_point->download_mgr());
+      const string host_info =
+        talk_mgr->FormatHostInfo(mount_point->download_mgr());
       talk_mgr->Answer(con_fd, host_info);
     } else if (line == "host probe") {
       mount_point->download_mgr()->ProbeHosts();
@@ -448,6 +453,9 @@ void *TalkManager::MainResponder(void *data) {
     } else if (line == "external metalink switch") {
       mount_point->external_download_mgr()->SwitchMetalink();
       talk_mgr->Answer(con_fd, "OK\n");
+    } else if (line == "metalink switch") {
+      mount_point->download_mgr()->SwitchMetalink();
+      talk_mgr->Answer(con_fd, "OK\n");
     } else if (line == "external host switch") {
       mount_point->external_download_mgr()->SwitchHost();
       talk_mgr->Answer(con_fd, "OK\n");
@@ -460,6 +468,14 @@ void *TalkManager::MainResponder(void *data) {
       } else {
         const std::string host = line.substr(22);
         mount_point->external_download_mgr()->SetMetalinkChain(host);
+        talk_mgr->Answer(con_fd, "OK\n");
+      }
+    } else if (line.substr(0, 12) == "metalink set") {
+      if (line.length() < 14) {
+        talk_mgr->Answer(con_fd, "Usage: metalink set <URL>\n");
+      } else {
+        const std::string host = line.substr(13);
+        mount_point->download_mgr()->SetMetalinkChain(host);
         talk_mgr->Answer(con_fd, "OK\n");
       }
     } else if (line.substr(0, 17) == "external host set") {

--- a/cvmfs/talk.h
+++ b/cvmfs/talk.h
@@ -47,6 +47,7 @@ class TalkManager : SingleCopy {
   static void *MainResponder(void *data);
   void Answer(int con_fd, const std::string &msg);
   void AnswerStringList(int con_fd, const std::vector<std::string> &list);
+  std::string FormatMetalinkInfo(download::DownloadManager *download_mgr);
   std::string FormatHostInfo(download::DownloadManager *download_mgr);
   std::string FormatProxyInfo(download::DownloadManager *download_mgr);
   std::string FormatLatencies(const MountPoint &mount_point,

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -708,7 +708,7 @@ systemctl daemon-reload
 %endif
 
 %changelog
-* Wed Nov 7 2023 Valentin Volkl <vavolkl@cern.ch> - 2.11.2
+* Tue Nov 7 2023 Valentin Volkl <vavolkl@cern.ch> - 2.11.2
 - Rename registry-webhook.py to registry_webhook.py to allow imports
 * Wed Nov 16 2022 Jakob Blomer <jblomer@cern.ch> - 2.11.0
 - Make cvmfs-libs a dependency of the cvmfs package

--- a/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_s3_test.sh
@@ -78,6 +78,7 @@ if [ $s3_retval -eq 0 ]; then
                                src/672-publish_stats_hardlinks              \
                                src/673-acl                                  \
                                src/682-enter                                \
+                               src/691-metalink                             \
                                src/702-symlink_caching                      \
                                src/811-commit-gateway                       \
                                --                                           \

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -54,6 +54,7 @@ CVMFS_TEST_UNIONFS=overlayfs                                                  \
                                  src/684-https_s3                             \
                                  src/686-azureblob_s3                         \
                                  src/687-import_s3                            \
+                                 src/691-metalink                             \
                                  src/702-symlink_caching                      \
                                  src/811-commit-gateway                       \
                                  --                                           \

--- a/test/cloud_testing/platforms/ubuntu_s3_test.sh
+++ b/test/cloud_testing/platforms/ubuntu_s3_test.sh
@@ -37,6 +37,9 @@ if [ "x$ubuntu_release" = "xbionic" ]; then
   CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/682-enter src/811-commit-gateway"
 fi
 
+# test assumes local srv storage
+CVMFS_EXCLUDE="$CVMFS_EXCLUDE src/691-metalink"
+
 export CVMFS_TEST_UNIONFS=overlayfs
 
 cd ${SOURCE_DIRECTORY}/test

--- a/test/common/mock_services/metalink_server.py
+++ b/test/common/mock_services/metalink_server.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+__version__ = "0.1"
+
+import http.server
+try:
+  import socketserver as SocketServer
+except ImportError:
+  import SocketServer
+import sys
+import os
+from optparse import OptionParser
+
+usagestr = "usage: %prog [-h|--version] -p port linkurl ..."
+parser = OptionParser(usage=usagestr, version=__version__, prog="metalink.py")
+parser.add_option("-p", "--port", dest="http_port", action="store", type="int",
+                  help="port number to be bound to (required)", metavar="PORT")
+parser.add_option("-r", "--reverse", dest="reverse", action="store_true",
+                  default=False, help="reverse the priorities of linkurls")
+
+(options, args) = parser.parse_args()
+
+if not options.http_port:
+  parser.print_help()
+  sys.exit(1)
+
+if len(args) < 1:
+  print("at least one link url required", file=sys.stderr);
+  sys.exit(1)
+
+class MetalinkRequestHandler(http.server.SimpleHTTPRequestHandler):
+  """
+  Extension of http.server.SimpleHTTPRequestHandler to support
+  sending a Link header according to the Metalink/HTTP rfc6249.
+  """
+
+  server_version = "metalink_server/" + __version__
+
+  def do_HEAD(self):
+    return self.do_common()
+
+  def do_GET(self):
+    return self.do_common()
+
+  def do_common(self):
+    self.send_response(307)
+    self.send_header("Location", args[0] + self.path)
+    pri = 0
+    if options.reverse:
+      pri = len(args) + 1
+    for a in args:
+      if options.reverse:
+        pri = pri - 1
+      else:
+        pri = pri + 1
+      link = '<' + a + self.path + '>; rel="duplicate"; pri=' + str(pri)
+      self.send_header("Link", link)
+    self.end_headers()
+    return None
+
+print("start serving...")
+handler = MetalinkRequestHandler
+httpd = SocketServer.TCPServer(("", options.http_port), handler)
+httpd.serve_forever()

--- a/test/src/691-metalink/main
+++ b/test/src/691-metalink/main
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+cvmfs_test_name="Metalink"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+has_correct_external_url() {
+  cvmfs_mntpnt=${1}
+  external_base=${2}
+  filename=${3}
+
+  local cvmfs_fullpath=$cvmfs_mntpnt/$filename
+  local external_fullpath=$external_base/$filename
+
+  [ x"$(attr -qg external_url "$cvmfs_fullpath")" = x"$external_fullpath" ]
+} 
+
+get_content_hash() {
+  local full_file_path="$1"
+  attr -qg hash "$full_file_path"
+}
+
+CVMFS_TEST_691_INTERNAL2_PID=
+cleanup() {
+  echo "running cleanup()"
+  [ -z $CVMFS_TEST_691_METALINK1_PID ] || sudo kill $CVMFS_TEST_691_METALINK1_PID
+  [ -z $CVMFS_TEST_691_METALINK2_PID ] || sudo kill $CVMFS_TEST_691_METALINK2_PID
+  [ -z $CVMFS_TEST_691_INTERNAL2_PID ] || sudo kill $CVMFS_TEST_691_INTERNAL2_PID
+  [ -z $CVMFS_TEST_691_EXTERNAL1_PID ] || sudo kill $CVMFS_TEST_691_EXTERNAL1_PID
+  [ -z $CVMFS_TEST_691_EXTERNAL2_PID ] || sudo kill $CVMFS_TEST_691_EXTERNAL2_PID
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  src_location=$2
+  local repo_dir="/cvmfs/${CVMFS_TEST_REPO}"
+  local scratch_dir="$(pwd)"
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  echo "*** Note: cvmfs_server mkfs -X --> enabled external files"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z -X -Z none || return $?
+
+  echo "*** Disable auto gc"
+  sudo sed -i -e /^CVMFS_AUTO_GC=/d /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+  echo "CVMFS_AUTO_GC=false" | sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
+
+  echo "*** get some global base paths and configs"
+  load_repo_config $CVMFS_TEST_REPO
+  local cvmfs_mnt="${CVMFS_SPOOL_DIR}/rdonly"
+  local cvmfs_cache="${CVMFS_CACHE_BASE}/$CVMFS_TEST_REPO"
+  local metalink_internal_port=8691
+  local metalink_external_port=9691
+  local refused_port=10691
+  local internal_port2=11691
+  local external_port1=12691
+  local external_port2=13691
+  local metalink_internal_http_base="http://localhost:$metalink_internal_port"
+  local metalink_external_http_base="http://localhost:$metalink_external_port"
+  local refused_base="http://localhost:$refused_port"
+  local internal_http_base1="http://localhost"
+  local internal_http_base2="http://localhost:$internal_port2"
+  local external_http_base1="http://localhost:$external_port1"
+  local external_http_base2="http://localhost:$external_port2"
+  local client_config="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/client.conf"
+  local original_root_hash=$(attr -qg root_hash ${cvmfs_mnt})
+
+  echo "*** install a disaster cleanup"
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "*** fill repository with external files"
+  start_transaction $CVMFS_TEST_REPO                             || return $?
+  mkdir -p ${repo_dir}/external                                  || return 1
+  echo "Hello ext1" >${repo_dir}/external/file1                  || return 2
+  echo "Hello ext2" >${repo_dir}/external/file2                  || return 3
+
+  echo "*** creating CVMFS revision with external files"
+  publish_repo $CVMFS_TEST_REPO -v || return $?
+
+  echo "*** fill repository with internal files"
+  start_transaction $CVMFS_TEST_REPO                             || return $?
+  mkdir -p ${repo_dir}/internal                                  || return 4
+  echo "Hello int1" >${repo_dir}/internal/file1                  || return 5
+  echo "Hello int2" >${repo_dir}/internal/file2                  || return 6
+
+  echo "*** creating CVMFS revision with native/internal files"
+  publish_repo $CVMFS_TEST_REPO -v -N || return $?
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  local internal_storage2="${scratch_dir}/internal_files2"
+  echo "*** Creating internal storage directory2 '$internal_storage2'"
+  mkdir -p $internal_storage2 || return 33
+
+  local external_storage1="${scratch_dir}/external_files1"
+  echo "*** Creating external storage directory1 '$external_storage1'"
+  mkdir -p $external_storage1 || return 34
+
+  local external_storage2="${scratch_dir}/external_files2"
+  echo "*** Creating external storage directory2 '$external_storage2'"
+  mkdir -p $external_storage2 || return 35
+
+  echo "*** Copying all repo files to second internal server area"
+  cp -r /srv/cvmfs/$CVMFS_TEST_REPO/* $internal_storage2            || return 36
+
+  echo "*** Move files to separate storage areas"
+  # after this section file1 will be in all 4 storage areas
+  # but file2 will be only in the storage2 areas, internal & external
+  local object_hash2=$(get_content_hash ${cvmfs_mnt}/internal/file2)
+  delete_from_backend $CVMFS_TEST_REPO $(make_path $object_hash2)   || return 37
+  mkdir -p ${external_storage1}/external
+  echo "Hello ext1" >${external_storage1}/external/file1            || return 38
+  mkdir -p ${external_storage2}/external
+  echo "Hello ext1" >${external_storage2}/external/file1            || return 39
+  echo "Hello ext2" >${external_storage2}/external/file2            || return 40
+
+  echo "*** Configure $CVMFS_TEST_REPO metalinks and remount"
+  (
+  cat <<!EOF!
+  CVMFS_METALINK_URL="$metalink_internal_http_base/cvmfs/@fqrn@"
+  CVMFS_EXTERNAL_METALINK="$refused_base;$metalink_external_http_base"
+  CVMFS_METALINK_RESET_AFTER=3
+  #CVMFS_DEBUGLOG="$scratch_dir/cvmfs-debug.log"
+!EOF!
+  ) | sudo tee --append $client_config
+  sudo umount ${repo_dir}                                || return 42
+  sudo umount ${cvmfs_mnt}                               || return 43
+  # the next two lines along with CVMFS_DEBUGLOG enable debugging
+  #sudo sed -i '/^cvmfs2/s/allow_other/debug,allow_other/' /etc/fstab
+  #sudo systemctl daemon-reload
+  sudo cvmfs_server mount $CVMFS_TEST_REPO               || return 44
+
+  local internal2_log="${scratch_dir}/internal2.log"
+  echo "*** Start second HTTP server to serve internal files (logging to $internal2_log)"
+  CVMFS_TEST_691_INTERNAL2_PID="$(open_http_server $internal_storage2 $internal_port2 $internal2_log)"
+  [ ! -z $CVMFS_TEST_691_INTERNAL2_PID ] && kill -0 $CVMFS_TEST_691_INTERNAL2_PID || { echo "fail"; return 45; }
+
+  echo "*** HTTP server running with PID $CVMFS_TEST_691_INTERNAL2_PID"
+
+  local external1_log="${scratch_dir}/external1.log"
+  echo "*** Start an HTTP server to serve external files (logging to $external1_log)"
+  CVMFS_TEST_691_EXTERNAL1_PID="$(open_http_server $external_storage1 $external_port1 $external1_log)"
+  [ ! -z $CVMFS_TEST_691_EXTERNAL1_PID ] && kill -0 $CVMFS_TEST_691_EXTERNAL1_PID || { echo "fail"; return 46; }
+  echo "*** HTTP server running with PID $CVMFS_TEST_691_EXTERNAL1_PID"
+
+  local external2_log="${scratch_dir}/external2.log"
+  echo "*** Start another HTTP server to serve external files (logging to $external2_log)"
+  CVMFS_TEST_691_EXTERNAL2_PID="$(open_http_server $external_storage2 $external_port2 $external2_log)"
+  [ ! -z $CVMFS_TEST_691_EXTERNAL2_PID ] && kill -0 $CVMFS_TEST_691_EXTERNAL2_PID || { echo "fail"; return 47; }
+  echo "*** HTTP server running with PID $CVMFS_TEST_691_EXTERNAL2_PID"
+
+  local metalink_internal_log="${scratch_dir}/metalink_internal.log"
+  echo "*** Start internal Metalink server (logging to $metalink_internal_log)"
+  CVMFS_TEST_691_METALINK1_PID="$(open_metalink_server "$internal_http_base1 $internal_http_base2" $metalink_internal_port $metalink_internal_log)"
+  [ ! -z $CVMFS_TEST_691_METALINK1_PID ] && kill -0 $CVMFS_TEST_691_METALINK1_PID || { echo "fail"; return 48; }
+  echo "*** Metalink server running with PID $CVMFS_TEST_691_METALINK1_PID"
+
+  local metalink_external_log="${scratch_dir}/metalink_external.log"
+  echo "*** Start external Metalink server (logging to $metalink_external_log)"
+  CVMFS_TEST_691_METALINK2_PID="$(open_metalink_server "-r $external_http_base2 $external_http_base1" $metalink_external_port $metalink_external_log)"
+  [ ! -z $CVMFS_TEST_691_METALINK2_PID ] && kill -0 $CVMFS_TEST_691_METALINK2_PID || { echo "fail"; return 49; }
+  echo "*** Metalink server running with PID $CVMFS_TEST_691_METALINK2_PID"
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  local test_pipe=$(cat /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/client.conf | \
+                      grep ^CVMFS_TALK_SOCKET= | cut -d= -f2)
+
+  echo "*** Read first file from first internal server"
+  cat ${repo_dir}/internal/file1                             || return 51
+  [ "$(attr -qg host $cvmfs_mnt)" = "$internal_http_base1" ] || return 52
+
+  # This causes an error on some machines but not others.
+  # It's not a vital check so comment it out.
+  #echo "*** Try reading second internal file, should fail"
+  #! cat ${repo_dir}/internal/file2                           || return 53
+
+  echo "*** Switch to next host and try again"
+  sudo cvmfs_talk -p $test_pipe host switch                  || return 54
+  cat ${repo_dir}/internal/file2                             || return 55
+  [ "$(attr -qg host $cvmfs_mnt)" = "$internal_http_base2" ] || return 56
+
+  echo "*** Read first file from first external server"
+  cat ${repo_dir}/external/file1                                      || return 61
+  [ "$(attr -qg external_host $cvmfs_mnt)" = "$external_http_base1" ] || return 62
+
+  echo "*** Try reading second external file, should fail"
+  ! cat ${repo_dir}/external/file2                                    || return 63
+
+  echo "*** Switch to next host and try again"
+  sudo cvmfs_talk -p $test_pipe external host switch                  || return 64
+  cat ${repo_dir}/external/file2                                      || return 65
+  [ "$(attr -qg external_host $cvmfs_mnt)" = "$external_http_base2" ] || return 66
+
+  echo "*** Remove the first internal file from the cache"
+  local object_hash1=$(get_content_hash ${cvmfs_mnt}/internal/file1)
+  local cache_object1="${cvmfs_cache}/$(get_hash_path $object_hash1)"
+  sudo rm $cache_object1                                     || return 70
+
+  echo "*** Wait four seconds for the metalink query to expire"
+  sleep 4
+
+  echo "*** Read first internal file again and verify it came from first server"
+  cat ${repo_dir}/internal/file1                             || return 71
+  [ "$(attr -qg host $cvmfs_mnt)" = "$internal_http_base1" ] || return 72
+
+
+  # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+  # This part has to be last
+
+  echo "*** test cvmfs_talk metalink commands"
+  local test_dom="example.com"
+  local test_dom2="cern.ch"
+  local test_hosts="http://$test_dom:80;http://$test_dom2:80"
+  local test_proxy="http://$test_dom:3128"
+
+  echo "*** test external host set"
+  sudo cvmfs_talk -p $test_pipe external metalink set "$test_hosts"        || return 80
+  echo "*** test external metalink info"
+  sudo cvmfs_talk -p $test_pipe external metalink info                     || return 81
+  sudo cvmfs_talk -p $test_pipe external metalink info | grep "$test_dom"  || return 82
+  echo "*** test external host switch"
+  sudo cvmfs_talk -p $test_pipe external metalink switch                   || return 83
+  sudo cvmfs_talk -p $test_pipe external metalink info | grep "Active.*$test_dom2"  || return 84
+  echo "*** test external proxy set"
+  sudo cvmfs_talk -p $test_pipe metalink set "$test_proxy"       || return 85
+  echo "*** test metalink info"
+  sudo cvmfs_talk -p $test_pipe metalink info                    || return 86
+  sudo cvmfs_talk -p $test_pipe metalink info | grep "$test_dom" || return 87
+
+  return 0
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -1113,18 +1113,18 @@ open_silent_port() {
 
 
 # spawns a mocked HTTP server on a given port and document root location
-# Note: The user is responsible to kill the server process once after usage
+# Note: The user is responsible to kill the server process after usage
 #
 # @param document_root  absolute path to be served via HTTP
 # @param port           http port to be used
 # @param logfile        (optional) where to log the HTTP server's status info
-# @return               PID of HTTP server or >0 on error
+# @return               0 and PID of HTTP server in stdout, or >0 on error
 open_http_server() {
   local document_root="$1"
   local port="$2"
-  local logfile="${3:=/dev/null}"
+  local logfile="${3:-/dev/null}"
 
-  local http_server="${TEST_ROOT}/common/mock_services/http_server.py"
+  local http_server="$CVMFS_SYS_PYTHON ${TEST_ROOT}/common/mock_services/http_server.py"
   local http_pid=
   local http_sentinel="http://localhost:${port}/http_sentinel"
 
@@ -1134,7 +1134,7 @@ open_http_server() {
 
   # waiting for the server to come up
   local timeout=15
-  while ! curl -Is $url ${http_sentinel} | head -n1 | grep "200 OK" >> $logfile 2>&1 && \
+  while ! curl -Is ${http_sentinel} | head -n1 | grep "200 OK" >> $logfile 2>&1 && \
         [ $timeout -gt 0 ]; do
     sleep 1
     if ! kill -0 $http_pid > /dev/null 2>&1;then
@@ -1147,6 +1147,40 @@ open_http_server() {
   echo "$http_pid"
 }
 
+# spawns a mocked HTTP server on given port which acts as a metalink
+# server that redirects to given linkurls referring to other HTTP servers.
+# Note: The user is responsible to kill the server process after usage
+#
+# @param args     quoted args: optional -r to reverse pri, followed by linkurls
+# @param port     http port to be used
+# @param logfile  (optional) where to log the HTTP server's status info
+# @return         0 and PID of HTTP server in stdout, or >0 on error
+open_metalink_server() {
+  local args="$1"
+  local port="$2"
+  local logfile="${3:-/dev/null}"
+
+  local http_server="python3 ${TEST_ROOT}/common/mock_services/metalink_server.py"
+  local http_pid=
+  local url="http://localhost:${port}"
+
+  # spawning the server
+  http_pid=$(run_background_service $logfile "$http_server -p $port $args")
+
+  # waiting for the server to come up
+  local timeout=15
+  while ! curl -Is $url | head -n1 | grep "307 Temporary Redirect" >> $logfile 2>&1 && \
+        [ $timeout -gt 0 ]; do
+    sleep 1
+    if ! kill -0 $http_pid > /dev/null 2>&1;then
+      return 1
+    fi
+    timeout=$(( $timeout - 1 ))
+  done
+
+  [ $timeout -gt 0 ] || return 2
+  echo "$http_pid"
+}
 
 # checks if a nested catalog is part of the current catalog configuration
 # of the repository


### PR DESCRIPTION
This adds support for `CVMFS_METALINK_URL`, `CVMFS_EXTERNAL_METALINK`, and `CVMFS_METALINK_RESET_AFTER`.   Much of the code supporting hosts is reused for metalinks.  The METALINK variables are much like their SERVER counterparts, except they do not geosort, they take precedent over the SERVER settings, and if there are rfc6249 `Link:` header(s) they are used to set the list of servers.  If a `Link` header is received, then the metalink server is not used until `CVMFS_METALINK_AFTER_DELAY` seconds later, which defaults to the value of `CVMFS_PROXY_RESET_AFTER`. 

I don't yet see a use case for `CVMFS_METALINK_URL` but it was trivial to add in addition to `CVMFS_EXTERNAL_METALINK` so I thought it might as well be included.

- Fixes #3668

I believe this is complete except for automated tests, which I will be adding.  In the meanwhile I wanted to make this available to begin to review.

Attn: @bbockelm @djw8605 @jthiltges @cvuosalo 