### PR TITLE
mkfs: do not overwrite existing manifest in s3 bucket

### DIFF
--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1245,6 +1245,16 @@ is_stratum0_garbage_collectable() {
 
 # checks if a manifest is present
 #
+# @param url  the url of the repository to be checked
+# @return      0 if it is empty
+is_empty_repository_from_url() {
+  local url=$1
+  [ x"$(get_repo_info_from_url "$url" -e)" = x"yes" ]
+}
+
+
+# checks if a manifest is present
+#
 # @param name  the name of the repository to be checked
 # @return      0 if it is empty
 is_empty_repository() {

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -205,7 +205,9 @@ cvmfs_server_mkfs() {
   # sanity checks
   check_repository_existence $name  && die "The repository $name already exists"
   is_empty_repository_from_url $stratum0 ||
-      die "A manifest already exists at this url. Did you mean to use cvmfs_server import?"
+      die "Error: A manifest already exists at this url: $stratum0/.cvmfspublished .\n 
+          Delete it manually and retry to force the creation of a new repository in this non-empty
+          storage. \n\n If you meant to setup a new stratum0 for this existing repository, use cvmfs_server import."
   check_upstream_validity $upstream
   if [ $unionfs = "aufs" ]; then
     check_aufs                      || die "aufs kernel module missing"

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -204,6 +204,8 @@ cvmfs_server_mkfs() {
 
   # sanity checks
   check_repository_existence $name  && die "The repository $name already exists"
+  is_empty_repository_from_url $stratum0 ||
+      die "A manifest already exists at this url. Did you mean to use cvmfs_server import?"
   check_upstream_validity $upstream
   if [ $unionfs = "aufs" ]; then
     check_aufs                      || die "aufs kernel module missing"


### PR DESCRIPTION
When using mkfs+s3 with a bucket already containing a repository, we will just overwrite the existing manifest, but it's very unlikely that's what the user actually wants to do. For local repositories on local storage this already fails due to the existence of the repository configuration on the local disk. This patch adds a check in mkfs. If one actually does want to overwrite the manifest, it's now necessary to delete the old one manually from the bucket.

Fixes #3691 