### PR TITLE
ingest: allow absolute paths for base_dir and to_delete

### DIFF
--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -165,6 +165,9 @@ get_repository_name() {
 # loads the configuration for a specific repository
 load_repo_config() {
   local name=$1
+  if [ ! -e /etc/cvmfs/repositories.d/${name}/server.conf ]; then
+    die "Error: The repository $name does not exist."
+  fi
   . /etc/cvmfs/repositories.d/${name}/server.conf
   if [ x"$CVMFS_REPOSITORY_TYPE" = x"stratum0" ]; then
     . /etc/cvmfs/repositories.d/${name}/client.conf

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -245,6 +245,21 @@ cvmfs_run_test() {
   cat $script_location/layer.tar | cvmfs_server ingest --base_dir layer -c --tar_file - $CVMFS_TEST_REPO || return 42
   ls /cvmfs/$CVMFS_TEST_REPO/layer/.cvmfscatalog || return 42
 
+  echo "*** ingesting absolute paths"
+
+  cvmfs_server ingest --base_dir /cvmfs/$CVMFS_TEST_REPO/absolute_path1  --tar_file $tarfile || return 43
+  ls /cvmfs/$CVMFS_TEST_REPO/absolute_path1/$(pwd)/tarball_foo || return 44
+
+  echo "*** delete with absolute paths"
+  cvmfs_server ingest -d /cvmfs/$CVMFS_TEST_REPO/absolute_path1/tarball_foo/a/1.txt || return 45
+  echo "*** delete with multiple absolute paths"
+  cvmfs_server ingest -d /cvmfs/$CVMFS_TEST_REPO/absolute_path1/tarball_foo/a/2.txt -d /cvmfs/$CVMFS_TEST_REPO/absolute_path1/tarball_foo/a/3.txt || return 46
+
+  echo "** check mismatches in repository name"
+  cvmfs_server ingest --base_dir /cvmfs/$CVMFS_TEST_REPO/absolute_path2  --tar_file $tarfile no.such.repository && return 47
+  cvmfs_server ingest --base_dir /cvmfs/no.such.repository/absolute_path2  --tar_file $tarfile  && return 48
+  cvmfs_server ingest -d /cvmfs/$CVMFS_TEST_REPO/absolute_path1/tarball_foo/a/b/2.txt -d /cvmfs/no.such.directory/absolute_path1/tarball_foo/a/b/3.txt && return 49
+
   return 0
 }
 


### PR DESCRIPTION
The interface of `cvmfs_server ingest` has caused some user confusion - in particular when an absolute path is given as a basedir, ingest ends up publishing to `/cvmfs/test.cern.ch/cvmfs/test.cern.ch/dir` instead of `/cvmfs/test.cern.ch/dir`. This patch adds support for absolute paths in the ingest interface, automatically deducing the repository name if possible.

The `--help` message of `cvmfs_server ingest` will be made consistent with the rest of cvmfs_server in a future patch.

Fixes #3466