### PR TITLE
`cvmfs_config stat <org>`: ignore issues with unrelated repos

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -952,7 +952,7 @@ cvmfs_stat() {
   local active=0
   for mountpoint in $mounted_repos
   do
-    cd $mountpoint || exit 32
+    cd $mountpoint 2>/dev/null || continue
     local this_fqrn
     get_attr fqrn; this_fqrn=$attr_value
     if [ "$this_fqrn" = "$fqrn" ]; then


### PR DESCRIPTION
Fixes #3331 :

The cvmfs_config stat command seems to loop over all mounted filesystems to find the requested one. In case the cd onto any of the other filesystem fails (for instance due to permissions, transport endpoint no being connected, etc.) the command fails.