### PR TITLE
fast path merge for new and changing nested catalogs

### DIFF
--- a/cvmfs/catalog_diff_tool.h
+++ b/cvmfs/catalog_diff_tool.h
@@ -53,7 +53,9 @@ class CatalogDiffTool {
 
   bool Init();
 
-  bool Run(const PathString& path);
+  bool Run(const PathString& path, const PathString& lease_path);
+   
+  bool FastPathDiff(const PathString& lease_path_r);
 
  protected:
   /**

--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "catalog.h"
+#include "catalog_mgr.h"
 #include "crypto/hash.h"
 #include "network/download.h"
 #include "util/exception.h"
@@ -76,8 +77,68 @@ bool CatalogDiffTool<RoCatalogMgr>::Init() {
 }
 
 template <typename RoCatalogMgr>
-bool CatalogDiffTool<RoCatalogMgr>::Run(const PathString& path) {
-  DiffRec(path);
+bool CatalogDiffTool<RoCatalogMgr>::FastPathDiff(const PathString& lease_path_r) {
+  bool success = false;
+
+  catalog::DirectoryEntry old_dirent_parent;
+  catalog::DirectoryEntry old_dirent;
+  catalog::DirectoryEntry new_dirent;
+
+  bool has_old_dirent_parent;
+  bool has_old_dirent;
+  bool has_new_dirent;
+
+  PathString lease_path= PathString("/" + lease_path_r.ToString());
+  PathString lease_path_parent = GetParentPath(lease_path);
+
+  has_old_dirent_parent = old_catalog_mgr_->LookupPath( lease_path_parent, catalog::kLookupDefault, &old_dirent_parent);
+  has_old_dirent        = old_catalog_mgr_->LookupPath( lease_path, catalog::kLookupDefault, &old_dirent);
+  has_new_dirent        = new_catalog_mgr_->LookupPath( lease_path, catalog::kLookupDefault, &new_dirent);
+
+  if( !has_old_dirent_parent || !has_new_dirent) { return false; }
+
+  if(   has_old_dirent && old_dirent.IsDirectory() && old_dirent.IsNestedCatalogMountpoint()
+      && new_dirent.IsDirectory() && new_dirent.IsNestedCatalogMountpoint() ) {
+     // switching from nested catalog to nested catalog
+      FileChunkList chunks;
+      XattrList xattrs;
+      if (new_dirent.HasXattrs()) {
+        new_catalog_mgr_->LookupXattrs(lease_path, &xattrs);
+      }
+      LogCvmfs(kLogCvmfs, kLogSyslog, "Replacing existing nested catalog for directory %s", lease_path.c_str());
+
+      ReportModification(lease_path, old_dirent, new_dirent, xattrs, chunks);
+      success = true;
+  } else if (   !has_old_dirent && has_new_dirent
+              && new_dirent.IsDirectory() && new_dirent.IsNestedCatalogMountpoint() ) {
+      // new nested catalog in a parent nested catalog
+      FileChunkList chunks;
+      XattrList xattrs;
+      if (new_dirent.HasXattrs()) {
+        new_catalog_mgr_->LookupXattrs(lease_path, &xattrs);
+      }
+
+      LogCvmfs(kLogCvmfs, kLogSyslog, "Adding nested catalog for new directory %s", lease_path.c_str());
+      ReportAddition(lease_path, new_dirent, xattrs, chunks);
+      success = true;
+
+  }
+  return success;
+}
+
+
+template <typename RoCatalogMgr>
+bool CatalogDiffTool<RoCatalogMgr>::Run(const PathString& path, const PathString& lease_path) {
+  bool fast_path_success = false;
+  if( lease_path != PathString("") ) {
+    LogCvmfs(kLogCvmfs, kLogDebug, "Trying fast-path diff");
+    fast_path_success = FastPathDiff(lease_path);
+  }
+
+  if (!fast_path_success){
+    LogCvmfs(kLogCvmfs, kLogDebug, "Doing slow-path diff");
+    DiffRec(path);
+  }
 
   return true;
 }

--- a/cvmfs/publish/repository_diff.cc
+++ b/cvmfs/publish/repository_diff.cc
@@ -120,7 +120,7 @@ void Repository::Diff(const std::string &from, const std::string &to,
   DiffForwarder diff_forwarder(mgr_from, mgr_to, diff_listener);
   if (!diff_forwarder.Init())
     throw EPublish("cannot initialize difference engine");
-  diff_forwarder.Run(PathString());
+  diff_forwarder.Run(PathString(), PathString());
 }
 
 }  // namespace publish

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -75,7 +75,7 @@ bool CatalogMergeTool<RwCatalogMgr, RoCatalogMgr>::Run(
     output_catalog_mgr_->Init();
   }
 
-  bool ret = CatalogDiffTool<RoCatalogMgr>::Run(PathString(""));
+  bool ret = CatalogDiffTool<RoCatalogMgr>::Run(PathString(""), lease_path_);
 
   ret &= CreateNewManifest(new_manifest_path);
   *new_manifest_hash = manifest_->catalog_hash();


### PR DESCRIPTION
Performance optimisation for gateway merge.
When the lease is on a new or changing nested catalogue, we can simply add or swap them, without having to do the full  recursive listing iteration in DiffRec
Empirically observed to reduce receiver runtime by ~15% when merging on a catalog with 10k entries.