### PR TITLE
Hotfix for cache corruption alarms

### DIFF
--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -317,12 +317,14 @@ LoadReturn ClientCatalogManager::LoadCatalogByHash(
           CacheManager::Label label;
           label.path = repo_name_;
           label.flags |= CacheManager::kLabelCertificate;
+          if (ctlg_context->manifest_ensemble()->cert_size > 0) {
           fetcher_->cache_mgr()->CommitFromMem(
                 CacheManager::LabeledObject(ctlg_context->manifest_ensemble()->
                                                         manifest->certificate(),
                                             label),
                                   ctlg_context->manifest_ensemble()->cert_buf,
                                   ctlg_context->manifest_ensemble()->cert_size);
+          }
           fetcher_->cache_mgr()->StoreBreadcrumb(
                                   *ctlg_context->manifest_ensemble()->manifest);
       }

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -318,12 +318,12 @@ LoadReturn ClientCatalogManager::LoadCatalogByHash(
           label.path = repo_name_;
           label.flags |= CacheManager::kLabelCertificate;
           if (ctlg_context->manifest_ensemble()->cert_size > 0) {
-          fetcher_->cache_mgr()->CommitFromMem(
-                CacheManager::LabeledObject(ctlg_context->manifest_ensemble()->
-                                                        manifest->certificate(),
-                                            label),
-                                  ctlg_context->manifest_ensemble()->cert_buf,
-                                  ctlg_context->manifest_ensemble()->cert_size);
+            fetcher_->cache_mgr()->CommitFromMem(
+                  CacheManager::LabeledObject(ctlg_context->manifest_ensemble()->
+                                                          manifest->certificate(),
+                                              label),
+                                    ctlg_context->manifest_ensemble()->cert_buf,
+                                    ctlg_context->manifest_ensemble()->cert_size);
           }
           fetcher_->cache_mgr()->StoreBreadcrumb(
                                   *ctlg_context->manifest_ensemble()->manifest);

--- a/cvmfs/manifest_fetch.cc
+++ b/cvmfs/manifest_fetch.cc
@@ -74,6 +74,11 @@ static Failures DoVerify(unsigned char *manifest_data, size_t manifest_size,
     goto cleanup;
   }
 
+  // Quick way out: hash matches base catalog
+  if (base_catalog && (ensemble->manifest->catalog_hash() == *base_catalog)) {
+    return kFailOk;
+  }
+
   // Load certificate
   certificate_hash = ensemble->manifest->certificate();
   ensemble->FetchCertificate(certificate_hash);

--- a/cvmfs/manifest_fetch.cc
+++ b/cvmfs/manifest_fetch.cc
@@ -74,11 +74,6 @@ static Failures DoVerify(unsigned char *manifest_data, size_t manifest_size,
     goto cleanup;
   }
 
-  // Quick way out: hash matches base catalog
-  if (base_catalog && (ensemble->manifest->catalog_hash() == *base_catalog)) {
-    return kFailOk;
-  }
-
   // Load certificate
   certificate_hash = ensemble->manifest->certificate();
   ensemble->FetchCertificate(certificate_hash);


### PR DESCRIPTION
This fixes a bug introduced in #3156 that can lead to empty certificate files being left in the cache, triggering fsck alarms.

Has been deployed and confirmed to fix the issue on QA nodes. Followups should be a regression test and further investigation of all code paths.