### PR TITLE
Skip unreliable metalink test

### DIFF
--- a/test/src/691-metalink/main
+++ b/test/src/691-metalink/main
@@ -173,8 +173,9 @@ cvmfs_run_test() {
   # It's not a vital check so comment it out.
   #echo "*** Try reading second internal file, should fail"
   #! cat ${repo_dir}/internal/file2                           || return 53
-
-  echo "*** Switch to next host and try again"
+  #
+  #echo "*** Switch to next host and try again"
+  echo "*** Switch to next host to read next file"
   sudo cvmfs_talk -p $test_pipe host switch                  || return 54
   cat ${repo_dir}/internal/file2                             || return 55
   [ "$(attr -qg host $cvmfs_mnt)" = "$internal_http_base2" ] || return 56
@@ -183,10 +184,13 @@ cvmfs_run_test() {
   cat ${repo_dir}/external/file1                                      || return 61
   [ "$(attr -qg external_host $cvmfs_mnt)" = "$external_http_base1" ] || return 62
 
-  echo "*** Try reading second external file, should fail"
-  ! cat ${repo_dir}/external/file2                                    || return 63
-
-  echo "*** Switch to next host and try again"
+  # This one usually works but sometimes failed on Fedora 40
+  # so comment it out too.
+  #echo "*** Try reading second external file, should fail"
+  #! cat ${repo_dir}/external/file2                                    || return 63
+  #
+  #echo "*** Switch to next host and try again"
+  echo "*** Switch to next external host to read next file"
   sudo cvmfs_talk -p $test_pipe external host switch                  || return 64
   cat ${repo_dir}/external/file2                                      || return 65
   [ "$(attr -qg external_host $cvmfs_mnt)" = "$external_http_base2" ] || return 66


### PR DESCRIPTION
This test that was added in #3683 has been seen to [fail once](https://lcgapp-services.cern.ch/cvmfs-jenkins/job/CvmfsCloudTesting/2357/CVMFS_PLATFORM=fedora40,CVMFS_PLATFORM_CONFIG=x86_64,label=trampoline/testReport/junit/(root)/ServerIntegrationTests/Metalink/) on Fedora 40 cloud test.  It's very similar to another test that was already commented out for being unreliable, so comment out this one too.