### PR TITLE
Add CVMFS_INFO_HEADER

### DIFF
--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -341,7 +341,7 @@ void cvmcache_get_session(cvmcache_session *session) {
 void cvmcache_spawn_watchdog(const char *crash_dump_file) {
   if (g_watchdog != NULL)
     return;
-  g_watchdog = Watchdog::Create(NULL, false);
+  g_watchdog = Watchdog::Create(NULL, false /* needs_read_environ */);
   assert(g_watchdog != NULL);
   g_watchdog->Spawn((crash_dump_file != NULL) ? string(crash_dump_file) : "");
 }

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -341,7 +341,7 @@ void cvmcache_get_session(cvmcache_session *session) {
 void cvmcache_spawn_watchdog(const char *crash_dump_file) {
   if (g_watchdog != NULL)
     return;
-  g_watchdog = Watchdog::Create(NULL);
+  g_watchdog = Watchdog::Create(NULL, false);
   assert(g_watchdog != NULL);
   g_watchdog->Spawn((crash_dump_file != NULL) ? string(crash_dump_file) : "");
 }

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -176,7 +176,7 @@ int64_t StreamingCacheManager::Stream(const FdInfo &info,
 
   download::JobInfo download_job(&url, is_zipped, true /* probe_hosts */,
                                  &info.object_id, &sink);
-  download_job.SetExtraInfo(&info.label.path);
+  download_job.SetPathInfo(&info.label.path);
   download_job.SetRangeOffset(info.label.range_offset);
   download_job.SetRangeSize(static_cast<int64_t>(info.label.size));
   ClientCtx *ctx = ClientCtx::GetInstance();

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2442,6 +2442,11 @@ static unsigned CheckMaxOpenFiles() {
 }
 
 
+static bool NeedsReadEnviron() {
+  return MountPoint::NeedsReadEnviron(cvmfs::options_mgr_);
+}
+
+
 static int Init(const loader::LoaderExports *loader_exports) {
   g_boot_error = new string("unknown error");
   cvmfs::loader_exports_ = loader_exports;
@@ -2458,7 +2463,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   // an old loader that expected the FUSE module to start a watchdog
   if (cvmfs::ShouldStartWatchdog()) {
     auto_umount::SetMountpoint(loader_exports->mount_point);
-    cvmfs::watchdog_ = Watchdog::Create(auto_umount::UmountOnExit);
+    cvmfs::watchdog_ = Watchdog::Create(auto_umount::UmountOnExit,
+                                        NeedsReadEnviron());
     if (cvmfs::watchdog_ == NULL) {
       *g_boot_error = "failed to initialize watchdog.";
       return loader::kFailMonitor;
@@ -2608,10 +2614,13 @@ static void Spawn() {
     // Earlier switched to using elevated capabilities without real uid root,
     // now reduce to minimum capabilities.
     const std::vector<cap_value_t> nocaps;
-    // CAP_DAC_READ_SEARCH will be sometimes needed for a future feature;
-    // for now reserve it all the time for testing.
-    const std::vector<cap_value_t> reservecaps = {CAP_DAC_READ_SEARCH};
-    assert(ClearPermittedCapabilities(reservecaps, nocaps));
+    if (NeedsReadEnviron()) {
+      // Reserve the capabilities to read process environments
+      const std::vector<cap_value_t> reservecaps = {CAP_DAC_READ_SEARCH, CAP_SYS_PTRACE};
+      assert(ClearPermittedCapabilities(reservecaps, nocaps));
+    } else {
+      assert(ClearPermittedCapabilities(nocaps, nocaps));
+    }
   } else {
     LogCvmfs(kLogCvmfs, kLogDebug, "Not clearing capabilities, uid %d euid%d",
                                    getuid(), geteuid());
@@ -3113,6 +3122,7 @@ static bool RestoreState(const int fd_progress,
       WatchdogState *watchdog_state = static_cast<WatchdogState *>(
           saved_states[i]->state);
       cvmfs::watchdog_ = Watchdog::Create(auto_umount::UmountOnExit,
+                                          NeedsReadEnviron(),
                                           watchdog_state);
       assert(cvmfs::watchdog_ != NULL);
       SendMsg2Socket(fd_progress, " done\n");

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -157,7 +157,7 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
   tls->download_job.SetUrl(&url);
   tls->download_job.SetSink(&sink);
   tls->download_job.SetExpectedHash(&object.id);
-  tls->download_job.SetExtraInfo(&object.label.path);
+  tls->download_job.SetPathInfo(&object.label.path);
   ClientCtx *ctx = ClientCtx::GetInstance();
   if (ctx->IsSet()) {
     ctx->Get(tls->download_job.GetUidPtr(),

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -210,7 +210,8 @@ struct LoaderExports {
 
 /**
  * This contains the public interface of the cvmfs fuse module.
- * Whenever something changes, change the version number.
+ * Whenever something changes, change the version number and add only
+ * to the end of the struct.
  * A global CvmfsExports struct is looked up by the loader via dlsym.
  * Since the cvmfs fuse module gets replaced each time there's an
  * upgrade or downgrade, the only way to get a cvmfs module older than

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -65,13 +65,15 @@ int Watchdog::g_suppressed_signals[] = {
 int Watchdog::g_crash_signals[] = {SIGQUIT, SIGILL, SIGABRT, SIGFPE,
                                    SIGSEGV, SIGBUS, SIGPIPE, SIGXFSZ};
 
-Watchdog *Watchdog::Create(FnOnExit on_exit, WatchdogState *saved_state) {
+Watchdog *Watchdog::Create(FnOnExit on_exit,
+                           bool needs_read_environ,
+                           WatchdogState *saved_state) {
   assert(instance_ == NULL);
   instance_ = new Watchdog(on_exit);
   if (saved_state != NULL)
     instance_->RestoreState(saved_state);
   else
-    instance_->Fork();
+    instance_->Fork(needs_read_environ);
   return instance_;
 }
 
@@ -389,7 +391,7 @@ Watchdog::SigactionMap Watchdog::SetSignalHandlers(
 /**
  * Fork the watchdog process and put it on hold until Spawn() is called.
  */
-void Watchdog::Fork() {
+void Watchdog::Fork(bool needs_read_environ) {
   Pipe<kPipeWatchdogPid> pipe_pid;
   pipe_watchdog_ = new Pipe<kPipeWatchdog>();
   pipe_listener_ = new Pipe<kPipeWatchdogSupervisor>();
@@ -413,11 +415,18 @@ void Watchdog::Fork() {
               // Reduce to minimum capabilities, which unfortunately is
               // still quite powerful.
               // CAP_SYS_ADMIN is needed to unmount, and CAP_SYS_PTRACE
-              // is needed in order to get a stack trace since one of
-              // the main process threads is privileged.
-              const std::vector<cap_value_t> reservecaps = {CAP_SYS_ADMIN, CAP_SYS_PTRACE};
-              const std::vector<cap_value_t> inheritcaps = {CAP_SYS_PTRACE};
-              assert(ClearPermittedCapabilities(reservecaps, inheritcaps));
+              // is needed when needs_read_environ is true because then
+              // the main Fuse process has elevated capabilities and
+              // ptrace (needed for collecting a stack trace) is not
+              // allowed on a process with more capabilities.
+              if (needs_read_environ) {
+                const std::vector<cap_value_t> reservecaps = {CAP_SYS_ADMIN, CAP_SYS_PTRACE};
+                const std::vector<cap_value_t> inheritcaps = {CAP_SYS_PTRACE};
+                assert(ClearPermittedCapabilities(reservecaps, inheritcaps));
+              } else {
+                const std::vector<cap_value_t> reservecaps = {CAP_SYS_ADMIN};
+                assert(ClearPermittedCapabilities(reservecaps, nocaps));
+              }
             } else {
               // Only need to be able to do the stack trace, and the
               // main process needs no extra capabilities, so we can
@@ -506,6 +515,9 @@ bool Watchdog::WaitForSupervisee() {
 
   switch (control_flow) {
     case ControlFlow::kQuit:
+      return false;
+    case ControlFlow::kQuitWithExit:
+      if (on_exit_) on_exit_(false);
       return false;
     case ControlFlow::kSupervise:
       break;

--- a/cvmfs/monitor.h
+++ b/cvmfs/monitor.h
@@ -61,7 +61,9 @@ class Watchdog : SingleCopy {
    */
   typedef void (*FnOnExit)(const bool crashed);
 
-  static Watchdog *Create(FnOnExit on_exit, WatchdogState *saved_state = 0);
+  static Watchdog *Create(FnOnExit on_exit,
+                          bool needs_read_environ,
+                          WatchdogState *saved_state = 0);
   static pid_t GetPid();
   ~Watchdog();
   void Spawn(const std::string &crash_dump_path);
@@ -118,7 +120,7 @@ class Watchdog : SingleCopy {
   static void SendTrace(int sig, siginfo_t *siginfo, void *context);
 
   explicit Watchdog(FnOnExit on_exit);
-  void Fork();
+  void Fork(bool needs_read_environ);
   void RestoreState(WatchdogState *saved_state);
   bool WaitForSupervisee();
   SigactionMap SetSignalHandlers(const SigactionMap &signal_handlers);

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -2207,12 +2207,29 @@ void MountPoint::SetupHttpTuning() {
       && options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableRedirects();
   }
-  if (options_mgr_->GetValue("CVMFS_SEND_INFO_HEADER", &optarg)
-      && options_mgr_->IsOn(optarg)) {
+  if (options_mgr_->GetValue("CVMFS_INFO_HEADER", &optarg) && (optarg != ""))
+  {
     download_mgr_->EnableInfoHeader();
+    download_mgr_->SetInfoHeaderTemplate(optarg);
+  } else if (options_mgr_->GetValue("CVMFS_SEND_INFO_HEADER", &optarg)
+      && options_mgr_->IsOn(optarg))
+  {
+    download_mgr_->EnableInfoHeader();
+    download_mgr_->SetInfoHeaderTemplate("%{path}");
   }
 }
 
+/*
+ * Check whether permission is needed to read from user process environment.
+ */
+bool MountPoint::NeedsReadEnviron(OptionsManager *omgr) {
+  // This is a class (static) method because it is used early, before 
+  // all the above initialization is done, so can't rely on mountpoint
+  // object data.
+  string info_header;
+  omgr->GetValue("CVMFS_INFO_HEADER", &info_header);
+  return (info_header.find("%{env:") != std::string::npos);
+}
 
 void MountPoint::SetupInodeAnnotation() {
   string optarg;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -502,6 +502,9 @@ class MountPoint : SingleCopy, public BootFactory {
                             OptionsManager *options_mgr = NULL);
   ~MountPoint();
 
+  // Check whether permission is needed to read from user process environment
+  static bool NeedsReadEnviron(OptionsManager *omgr);
+
   unsigned GetMaxTtlMn();
   unsigned GetEffectiveTtlSec();
   void SetMaxTtlMn(unsigned value_minutes);

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -394,25 +394,6 @@ const int DownloadManager::kProbeUnprobed = -1;
 const int DownloadManager::kProbeDown = -2;
 const int DownloadManager::kProbeGeo = -3;
 
-bool DownloadManager::EscapeUrlChar(unsigned char input, char output[3]) {
-  if (((input >= '0') && (input <= '9')) || ((input >= 'A') && (input <= 'Z'))
-      || ((input >= 'a') && (input <= 'z')) || (input == '/') || (input == ':')
-      || (input == '.') || (input == '@') || (input == '+') || (input == '-')
-      || (input == '_') || (input == '~') || (input == '[') || (input == ']')
-      || (input == ',')) {
-    output[0] = static_cast<char>(input);
-    return false;
-  }
-
-  output[0] = '%';
-  output[1] = static_cast<char>((input / 16)
-                                + ((input / 16 <= 9) ? '0' : 'A' - 10));
-  output[2] = static_cast<char>((input % 16)
-                                + ((input % 16 <= 9) ? '0' : 'A' - 10));
-  return true;
-}
-
-
 /**
  * Escape special chars from the URL, except for ':' and '/',
  * which should keep their meaning.
@@ -423,7 +404,7 @@ string DownloadManager::EscapeUrl(const int64_t jobinfo_id, const string &url) {
 
   char escaped_char[3];
   for (unsigned i = 0, s = url.length(); i < s; ++i) {
-    if (EscapeUrlChar(url[i], escaped_char)) {
+    if (JobInfo::EscapeUrlChar(url[i], escaped_char)) {
       escaped.append(escaped_char, 3);
     } else {
       escaped.push_back(escaped_char[0]);
@@ -433,38 +414,6 @@ string DownloadManager::EscapeUrl(const int64_t jobinfo_id, const string &url) {
            jobinfo_id, url.c_str(), escaped.c_str());
 
   return escaped;
-}
-
-/**
- * escaped array needs to be sufficiently large.  Its size is calculated by
- * passing NULL to EscapeHeader.
- */
-unsigned DownloadManager::EscapeHeader(const string &header,
-                                       char *escaped_buf,
-                                       size_t buf_size) {
-  unsigned esc_pos = 0;
-  char escaped_char[3];
-  for (unsigned i = 0, s = header.size(); i < s; ++i) {
-    if (EscapeUrlChar(header[i], escaped_char)) {
-      for (unsigned j = 0; j < 3; ++j) {
-        if (escaped_buf) {
-          if (esc_pos >= buf_size)
-            return esc_pos;
-          escaped_buf[esc_pos] = escaped_char[j];
-        }
-        esc_pos++;
-      }
-    } else {
-      if (escaped_buf) {
-        if (esc_pos >= buf_size)
-          return esc_pos;
-        escaped_buf[esc_pos] = escaped_char[0];
-      }
-      esc_pos++;
-    }
-  }
-
-  return esc_pos;
 }
 
 /**
@@ -2002,16 +1951,18 @@ Failures DownloadManager::Fetch(JobInfo *info) {
 
   // Prepare cvmfs-info: header, allocate string on the stack
   info->SetInfoHeader(NULL);
-  if (enable_info_header_ && info->extra_info()) {
-    const char *header_name = "cvmfs-info: ";
-    const size_t header_name_len = strlen(header_name);
-    const unsigned header_size = 1 + header_name_len
-                                 + EscapeHeader(*(info->extra_info()), NULL, 0);
-    info->SetInfoHeader(static_cast<char *>(alloca(header_size)));
-    memcpy(info->info_header(), header_name, header_name_len);
-    EscapeHeader(*(info->extra_info()), info->info_header() + header_name_len,
-                 header_size - header_name_len);
-    info->info_header()[header_size - 1] = '\0';
+  if (enable_info_header_) {
+    const string header_info = info->GetInfoHeaderContents(info_header_template_);
+    if (header_info != "") {
+      const char * const header_name = "cvmfs-info: ";
+      const size_t header_name_len = strlen(header_name);
+      const size_t info_len = header_info.length();
+      char *buf = static_cast<char *>(alloca(header_name_len + info_len + 1));
+      memcpy(buf, header_name, header_name_len);
+      memcpy(buf + header_name_len, header_info.c_str(), info_len);
+      buf[header_name_len + info_len] = '\0';
+      info->SetInfoHeader(buf);
+    }
   }
 
   if (enable_http_tracing_) {

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -242,6 +242,9 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   bool SetShardingPolicy(const ShardingPolicySelector type);
   void SetFailoverIndefinitely();
   void SetFqrn(const std::string &fqrn) { fqrn_ = fqrn; }
+  void SetInfoHeaderTemplate(const std::string &templ) {
+    info_header_template_ = templ;
+  }
 
   unsigned num_hosts() {
     if (opt_host_.chain)
@@ -291,10 +294,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   void CheckHostInfoReset(const std::string &typ, HostInfo &info,
                           JobInfo *jobinfo, time_t &now);
 
-  bool EscapeUrlChar(unsigned char input, char output[3]);
   std::string EscapeUrl(const int64_t jobinfo_id, const std::string &url);
-  unsigned EscapeHeader(const std::string &header, char *escaped_buf,
-                        size_t buf_size);
 
   inline std::vector<ProxyInfo> *current_proxy_group() const {
     return (opt_proxy_groups_
@@ -324,6 +324,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   pthread_mutex_t *lock_options_;
   pthread_mutex_t *lock_synchronous_mode_;
   std::string opt_dns_server_;
+  std::string info_header_template_;
   unsigned opt_timeout_proxy_;
   unsigned opt_timeout_direct_;
   unsigned opt_low_speed_limit_;

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -137,37 +137,49 @@ std::string EscapeHeader(const std::string &header) {
  * Return the filled-in template of CVMFS_INFO_HEADER
  */
 std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
+  enum ParseMode {
+    kParseModeDefault,       // reading literal characters
+    kParseModeAfterPercent,  // just saw '%'
+    kParseModeInKey,         // inside '%{...}'
+  };
+
+  enum MatchMode {
+    kMatchModeSkipping,    // skipping to next '\0' separator
+    kMatchModeMatching,    // comparing chars against variable name
+    kMatchModeCollecting,  // name matched, collecting value
+  };
+
   std::string answer = "";
   std::string key;
-  int parsemode = 0;  // 0 default, 1 after '%', 2 after '%{'
-  int envsize = -1;
-  char *envbuf = NULL;
+  ParseMode parsemode = kParseModeDefault;
+  std::vector<char> envbuf;
+  bool env_attempted = false;
 
   for (std::string::const_iterator i = templ.begin(); i != templ.end(); i++) {
     const char c = *i;
     switch (parsemode) {
-    case 0:
+    case kParseModeDefault:
       if (c == '%') {
-        parsemode = 1;
+        parsemode = kParseModeAfterPercent;
         key = "";
       } else {
         answer += c;
       }
       break;
-    case 1:
+    case kParseModeAfterPercent:
       if (c == '{') {
-        parsemode = 2;
+        parsemode = kParseModeInKey;
       } else {
-        parsemode = 0;
+        parsemode = kParseModeDefault;
         answer += '%';
         answer += c;
       }
       break;
-    case 2:
+    case kParseModeInKey:
       if (c != '}') {
         key += c;
       } else {
-        parsemode = 0;
+        parsemode = kParseModeDefault;
         if (key == "path") {
           if (path_info_ != NULL) {
             answer += EscapeHeader(*path_info_);
@@ -193,9 +205,9 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
             answer += "-";
           }
         } else if (key.substr(0, 4) == "env:") {
+          if (!env_attempted) {
+            env_attempted = true;
 #ifndef __APPLE__
-          if (envsize == -1) {
-            envsize = 0;
             if (pid_ != static_cast<pid_t>(-1)) {
               ObtainDacReadSearchCapability();
               ObtainSysPtraceCapability();
@@ -214,17 +226,13 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
                 }
                 if ((n >= 0) && (size > 0)) {
                   if (lseek(fd, 0, SEEK_SET) >= 0) {
-                    envbuf = static_cast<char *>(malloc(size));
-                    if (envbuf != NULL) {
-                      if (read(fd, envbuf, size) > 0) {
-                        envsize = size;
-                        LogCvmfs(kLogDownload, kLogDebug,
-                          "(job id %" PRId64 ") read %d bytes from %s",
-                          id_, size, fname.c_str());
-                      } else {
-                        free(envbuf);
-                        envbuf = NULL;
-                      }
+                    envbuf.resize(size);
+                    if (read(fd, envbuf.data(), size) > 0) {
+                      LogCvmfs(kLogDownload, kLogDebug,
+                        "(job id %" PRId64 ") read %d bytes from %s",
+                        id_, size, fname.c_str());
+                    } else {
+                      envbuf.clear();
                     }
                   }
                 }
@@ -237,24 +245,24 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
               DropSysPtraceCapability();
               DropDacReadSearchCapability();
             }
-          }
 #endif
-          if (envbuf != NULL) {
+          }
+          if (!envbuf.empty()) {
             const char * const var = key.c_str() + 4; // everything after "env:"
             const char *varp = var;
             std::string val = "";
-            int matchmode = 1;
-            const char * const endp = envbuf + envsize;
-            for (const char *p = envbuf; p < endp; p++) {
-              switch(matchmode) {
-              case 0:
+            MatchMode matchmode = kMatchModeMatching;
+            const char * const endp = envbuf.data() + envbuf.size();
+            for (const char *p = envbuf.data(); p < endp; p++) {
+              switch (matchmode) {
+              case kMatchModeSkipping:
                 // skipping to next null character
                 if (*p == '\0') {
                   varp = var;
-                  matchmode = 1;
+                  matchmode = kMatchModeMatching;
                 }
                 break;
-              case 1:
+              case kMatchModeMatching:
                 // matching variable name
                 if (*p == '\0') {
                   // premature end without an '='
@@ -264,13 +272,13 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
                   ++varp;
                 } else if ((*varp == '\0') && (*p == '=')) {
                   // matched
-                  matchmode = 2;
+                  matchmode = kMatchModeCollecting;
                 } else {
                   // didn't match
-                  matchmode = 0;
+                  matchmode = kMatchModeSkipping;
                 }
                 break;
-              case 2:
+              case kMatchModeCollecting:
                 // matched, collecting value
                 if (*p == '\0') {
                   // all done
@@ -278,8 +286,6 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
                   break;
                 }
                 val += *p;
-                break;
-              default:
                 break;
               }
             }
@@ -291,13 +297,8 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
         }
       }
       break;
-    default:
-      break;
     }
   }
-
-  if (envbuf != NULL)
-    free(envbuf);
 
   return answer;
 }

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -2,8 +2,15 @@
  * This file is part of the CernVM File System.
  */
 
-#include "jobinfo.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <sys/stat.h>
 
+#include "jobinfo.h"
+#include "util/capabilities.h"
+#include "util/logging.h"
 #include "util/string.h"
 
 namespace download {
@@ -53,7 +60,7 @@ void JobInfo::Init() {
   interrupt_cue_ = NULL;
   sink_ = NULL;
   expected_hash_ = NULL;
-  extra_info_ = NULL;
+  path_info_ = NULL;
   //
   range_offset_ = -1;
   range_size_ = -1;
@@ -79,6 +86,220 @@ void JobInfo::Init() {
   allow_failure_ = false;
 
   memset(&zstream_, 0, sizeof(zstream_));
+}
+
+
+/*
+ * Return true if input character is escaped to 3 output characters,
+ * otherwise return false and leave the input character in the first
+ * output character.
+ */
+bool JobInfo::EscapeUrlChar(unsigned char input, char output[3]) {
+  if (((input >= '0') && (input <= '9')) || ((input >= 'A') && (input <= 'Z'))
+      || ((input >= 'a') && (input <= 'z')) || (input == '/') || (input == ':')
+      || (input == '.') || (input == '@') || (input == '+') || (input == '-')
+      || (input == '_') || (input == '~') || (input == '[') || (input == ']')
+      || (input == ',')) {
+    output[0] = static_cast<char>(input);
+    return false;
+  }
+
+  output[0] = '%';
+  output[1] = static_cast<char>((input / 16)
+                                + ((input / 16 <= 9) ? '0' : 'A' - 10));
+  output[2] = static_cast<char>((input % 16)
+                                + ((input % 16 <= 9) ? '0' : 'A' - 10));
+  return true;
+}
+
+
+namespace {
+
+std::string EscapeHeader(const std::string &header) {
+  std::string escaped = "";
+  char escaped_char[3];
+  for (std::string::const_iterator i = header.begin(); i != header.end(); i++) {
+    if (JobInfo::EscapeUrlChar(*i, escaped_char)) {
+      for (unsigned j = 0; j < 3; ++j) {
+        escaped += escaped_char[j];
+      }
+    } else {
+      escaped += escaped_char[0];
+    }
+  }
+
+  return escaped;
+}
+
+} // namespace
+
+/*
+ * Return the filled-in template of CVMFS_INFO_HEADER
+ */
+std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
+  std::string answer = "";
+  std::string key;
+  int parsemode = 0;  // 0 default, 1 after '%', 2 after '%{'
+  int envsize = -1;
+  char *envbuf = NULL;
+
+  for (std::string::const_iterator i = templ.begin(); i != templ.end(); i++) {
+    const char c = *i;
+    switch (parsemode) {
+    case 0:
+      if (c == '%') {
+        parsemode = 1;
+        key = "";
+      } else {
+        answer += c;
+      }
+      break;
+    case 1:
+      if (c == '{') {
+        parsemode = 2;
+      } else {
+        parsemode = 0;
+        answer += '%';
+        answer += c;
+      }
+      break;
+    case 2:
+      if (c != '}') {
+        key += c;
+      } else {
+        parsemode = 0;
+        if (key == "path") {
+          if (path_info_ != NULL) {
+            answer += EscapeHeader(*path_info_);
+          } else {
+            answer += "-";
+          }
+        } else if (key == "pid") {
+          if (pid_ != static_cast<pid_t>(-1)) {
+            answer += StringifyInt(pid_);
+          } else {
+            answer += "-";
+          }
+        } else if (key == "uid") {
+          if (uid_ != static_cast<uid_t>(-1)) {
+            answer += StringifyInt(uid_);
+          } else {
+            answer += "-";
+          }
+        } else if (key == "gid") {
+          if (gid_ != static_cast<gid_t>(-1)) {
+            answer += StringifyInt(gid_);
+          } else {
+            answer += "-";
+          }
+        } else if (key.substr(0, 4) == "env:") {
+#ifndef __APPLE__
+          if (envsize == -1) {
+            envsize = 0;
+            if (pid_ != static_cast<pid_t>(-1)) {
+              ObtainDacReadSearchCapability();
+              ObtainSysPtraceCapability();
+              const std::string fname = "/proc/" +
+                                        StringifyInt(pid_) +
+                                        "/environ";
+              const int fd = open(fname.c_str(), O_RDONLY);
+              if (fd != -1) {
+                // Unfortunately fstat does not show the size so need to
+                // read it to find out the size
+                ssize_t n;
+                int size = 0;
+                char buf[BUFSIZ];
+                while ((n = read(fd, buf, BUFSIZ)) > 0) {
+                  size += static_cast<int>(n);
+                }
+                if ((n >= 0) && (size > 0)) {
+                  if (lseek(fd, 0, SEEK_SET) >= 0) {
+                    envbuf = static_cast<char *>(malloc(size));
+                    if (envbuf != NULL) {
+                      if (read(fd, envbuf, size) > 0) {
+                        envsize = size;
+                        LogCvmfs(kLogDownload, kLogDebug,
+                          "(job id %" PRId64 ") read %d bytes from %s",
+                          id_, size, fname.c_str());
+                      } else {
+                        free(envbuf);
+                        envbuf = NULL;
+                      }
+                    }
+                  }
+                }
+                close(fd);
+              } else {
+                LogCvmfs(kLogDownload, kLogDebug,
+                  "(job id %" PRId64 ") unable to open %s: %s",
+                  id_, fname.c_str(), strerror(errno));
+              }
+              DropSysPtraceCapability();
+              DropDacReadSearchCapability();
+            }
+          }
+#endif
+          if (envbuf != NULL) {
+            const char * const var = key.c_str() + 4; // everything after "env:"
+            const char *varp = var;
+            std::string val = "";
+            int matchmode = 1;
+            const char * const endp = envbuf + envsize;
+            for (const char *p = envbuf; p < endp; p++) {
+              switch(matchmode) {
+              case 0:
+                // skipping to next null character
+                if (*p == '\0') {
+                  varp = var;
+                  matchmode = 1;
+                }
+                break;
+              case 1:
+                // matching variable name
+                if (*p == '\0') {
+                  // premature end without an '='
+                  varp = var;
+                } else if (*varp == *p) {
+                  // so far so good
+                  ++varp;
+                } else if ((*varp == '\0') && (*p == '=')) {
+                  // matched
+                  matchmode = 2;
+                } else {
+                  // didn't match
+                  matchmode = 0;
+                }
+                break;
+              case 2:
+                // matched, collecting value
+                if (*p == '\0') {
+                  // all done
+                  p = endp;
+                  break;
+                }
+                val += *p;
+                break;
+              default:
+                break;
+              }
+            }
+            if (val != "") {
+              answer += ' ';
+              answer += EscapeHeader(val);
+            }
+          }
+        }
+      }
+      break;
+    default:
+      break;
+    }
+  }
+
+  if (envbuf != NULL)
+    free(envbuf);
+
+  return answer;
 }
 
 }  // namespace download

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -82,7 +82,7 @@ class JobInfo {
   InterruptCue *interrupt_cue_;
   cvmfs::Sink *sink_;
   const shash::Any *expected_hash_;
-  const std::string *extra_info_;
+  const std::string *path_info_;
 
   // Allow byte ranges to be specified.
   off_t range_offset_;
@@ -134,6 +134,8 @@ class JobInfo {
     data_tube_.Destroy();
   }
 
+  static bool EscapeUrlChar(unsigned char input, char output[3]);
+
   void CreatePipeJobResults() {
     pipe_job_results = new Pipe<kPipeDownloadJobsResults>();
   }
@@ -181,7 +183,7 @@ class JobInfo {
   InterruptCue *interrupt_cue() const { return interrupt_cue_; }
   cvmfs::Sink *sink() const { return sink_; }
   const shash::Any *expected_hash() const { return expected_hash_; }
-  const std::string *extra_info() const { return extra_info_; }
+  const std::string *path_info() const { return path_info_; }
 
   off_t range_offset() const { return range_offset_; }
   off_t range_size() const { return range_size_; }
@@ -212,7 +214,7 @@ class JobInfo {
   bool allow_failure() const { return allow_failure_; }
   int64_t id() const { return id_; }
 
-
+  std::string GetInfoHeaderContents(const std::string &templ);
   void SetUrl(const std::string *url) { url_ = url; }
   void SetCompressed(bool compressed) { compressed_ = compressed; }
   void SetProbeHosts(bool probe_hosts) { probe_hosts_ = probe_hosts; }
@@ -221,9 +223,6 @@ class JobInfo {
     follow_redirects_ = follow_redirects;
   }
   void SetForceNocache(bool force_nocache) { force_nocache_ = force_nocache; }
-  void SetPid(pid_t pid) { pid_ = pid; }
-  void SetUid(uid_t uid) { uid_ = uid; }
-  void SetGid(gid_t gid) { gid_ = gid; }
   void SetCredData(void *cred_data) { cred_data_ = cred_data; }
   void SetInterruptCue(InterruptCue *interrupt_cue) {
     interrupt_cue_ = interrupt_cue;
@@ -232,7 +231,7 @@ class JobInfo {
   void SetExpectedHash(const shash::Any *expected_hash) {
     expected_hash_ = expected_hash;
   }
-  void SetExtraInfo(const std::string *extra_info) { extra_info_ = extra_info; }
+  void SetPathInfo(const std::string *path_info) { path_info_ = path_info; }
 
   void SetRangeOffset(off_t range_offset) { range_offset_ = range_offset; }
   void SetRangeSize(off_t range_size) { range_size_ = range_size; }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1224,7 +1224,7 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
     assert(SetLimitCore(0));
   }
 
-  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL));
+  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false));
   assert(watchdog.IsValid());
   watchdog->Spawn("./stacktrace.cachemgr");
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1224,7 +1224,7 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
     assert(SetLimitCore(0));
   }
 
-  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false));
+  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false /* needs_read_environ */));
   assert(watchdog.IsValid());
   watchdog->Spawn("./stacktrace.cachemgr");
 

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
       return 1;
     }
     const std::string timestamp = GetGMTimestamp("%Y.%m.%d-%H.%M.%S");
-    watchdog = Watchdog::Create(NULL);
+    watchdog = Watchdog::Create(NULL, false);
     if (watchdog.IsValid() == false) {
       LogCvmfs(kLogReceiver, kLogSyslogErr | kLogStderr,
                "Failed to initialize watchdog");

--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
       return 1;
     }
     const std::string timestamp = GetGMTimestamp("%Y.%m.%d-%H.%M.%S");
-    watchdog = Watchdog::Create(NULL, false);
+    watchdog = Watchdog::Create(NULL, false /* needs_read_environ */);
     if (watchdog.IsValid() == false) {
       LogCvmfs(kLogReceiver, kLogSyslogErr | kLogStderr,
                "Failed to initialize watchdog");

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -593,7 +593,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
                                  getpid());
   assert(path_size > 0);
   assert(path_size < PATH_MAX);
-  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL));
+  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false));
   watchdog->Spawn(std::string(watchdog_path));
 
   SyncParameters params;

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -593,7 +593,7 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
                                  getpid());
   assert(path_size > 0);
   assert(path_size < PATH_MAX);
-  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false));
+  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false /* needs_read_environ */));
   watchdog->Spawn(std::string(watchdog_path));
 
   SyncParameters params;

--- a/cvmfs/util/capabilities.cc
+++ b/cvmfs/util/capabilities.cc
@@ -30,15 +30,27 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &,
 
 namespace {
 
+uid_t old_uid;
+gid_t old_gid;
+
 bool ObtainCapability(const cap_value_t,
                       const char *,
                       const bool avoid_mutexes = false) {
   // there are no individual capabilities on OSX so switch back to root
+  old_uid = geteuid();
+  old_gid = getegid();
   return (SwitchCredentials(0, getgid(), true, avoid_mutexes));
 }
 
 bool CheckCapabilityPermitted(const cap_value_t) {
   return (getuid() == 0);
+}
+
+bool DropCapability(const cap_value_t,
+                    const char *,
+                    const bool avoid_mutexes = false) {
+  // there are no individual capabilities on OSX so temporarily back to user
+  return (SwitchCredentials(old_uid, old_gid, true, avoid_mutexes));
 }
 
 } // namespace
@@ -175,8 +187,8 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
 namespace {
 
 bool ObtainCapability(const cap_value_t cap,
-                            const char *capname,
-                            const bool avoid_mutexes = false) {
+                      const char *capname,
+                      const bool avoid_mutexes = false) {
 #ifdef CAP_IS_SUPPORTED
   assert(CAP_IS_SUPPORTED(cap));
 #endif
@@ -224,6 +236,43 @@ bool ObtainCapability(const cap_value_t cap,
   return true;
 }
 
+bool DropCapability(const cap_value_t cap,
+                    const char *capname,
+                    const bool avoid_mutexes = false) {
+#ifdef CAP_IS_SUPPORTED
+  assert(CAP_IS_SUPPORTED(cap));
+#endif
+
+  cap_t caps_proc = cap_get_proc();
+  assert(caps_proc != NULL);
+
+  cap_flag_value_t cap_state;
+  int retval = cap_get_flag(caps_proc, cap, CAP_EFFECTIVE, &cap_state);
+  assert(retval == 0);
+
+  if (cap_state == CAP_CLEAR) {
+    cap_free(caps_proc);
+    return true;
+  }
+
+  retval = cap_set_flag(caps_proc, CAP_EFFECTIVE, 1, &cap, CAP_CLEAR);
+  assert(retval == 0);
+
+  retval = cap_set_proc(caps_proc);
+  cap_free(caps_proc);
+
+  if (retval != 0) {
+    if (!avoid_mutexes) {
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogDebug,
+               "Cannot reset %s capability for current process (errno: %d)",
+               capname, errno);
+    }
+    return false;
+  }
+
+  return true;
+}
+
 bool CheckCapabilityPermitted(const cap_value_t cap) {
   cap_t caps_proc = cap_get_proc();
   assert(caps_proc != NULL);
@@ -245,12 +294,20 @@ bool ObtainDacReadSearchCapability() {
   return ObtainCapability(CAP_DAC_READ_SEARCH, "CAP_DAC_READ_SEARCH");
 }
 
+bool DropDacReadSearchCapability() {
+  return DropCapability(CAP_DAC_READ_SEARCH, "CAP_DAC_READ_SEARCH");
+}
+
 bool ObtainSysAdminCapability() {
   return ObtainCapability(CAP_SYS_ADMIN, "CAP_SYS_ADMIN");
 }
 
 bool ObtainSysPtraceCapability() {
   return ObtainCapability(CAP_SYS_PTRACE, "CAP_SYS_PTRACE");
+}
+
+bool DropSysPtraceCapability() {
+  return DropCapability(CAP_SYS_PTRACE, "CAP_SYS_PTRACE");
 }
 
 bool ObtainSetuidgidCapabilities(const bool avoid_mutexes) {

--- a/cvmfs/util/capabilities.h
+++ b/cvmfs/util/capabilities.h
@@ -26,8 +26,10 @@ namespace CVMFS_NAMESPACE_GUARD {
 #endif
 
 CVMFS_EXPORT bool ObtainDacReadSearchCapability();
+CVMFS_EXPORT bool DropDacReadSearchCapability();
 CVMFS_EXPORT bool ObtainSysAdminCapability();
 CVMFS_EXPORT bool ObtainSysPtraceCapability();
+CVMFS_EXPORT bool DropSysPtraceCapability();
 CVMFS_EXPORT bool ObtainSetuidgidCapabilities(const bool avoid_mutexes = false);
 CVMFS_EXPORT bool ObtainSetpcapCapability();
 CVMFS_EXPORT bool SetuidCapabilityPermitted();

--- a/test/src/109-capabilities/main
+++ b/test/src/109-capabilities/main
@@ -26,71 +26,96 @@ cvmfs_run_test() {
 
   echo "check default capabilities on the main fuse cvmfs process"
   pid=$(sudo cvmfs_talk -i $repo pid)
-  [ -n "$pid" ] || return 10
+  [ -n "$pid" ] || return 8
 
   cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapPrm: $dec"
-  [ "$dec" == "cap_dac_read_search" ] || return 11
+  [ "$dec" == "" ] || return 9
   cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapEff: $dec"
-  [ "$dec" == "" ] || return 17
+  [ "$dec" == "" ] || return 10
 
   echo "check default capabilities on the watchdog cvmfs process"
   pid=$(sudo cvmfs_talk -i $repo pid watchdog)
-  [ -n "$pid" ] || return 12
+  [ -n "$pid" ] || return 11
 
   cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapPrm: $dec"
-  [ "$dec" == "cap_sys_ptrace,cap_sys_admin" ] || return 13
+  [ "$dec" == "cap_sys_admin" ] || return 12
   cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapEff: $dec"
-  [ "$dec" == "" ] || return 18
+  [ "$dec" == "" ] || return 13
   cap="$(sudo sed -n 's/^CapInh:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapInh: $dec"
-  [ "$dec" == "cap_sys_ptrace" ] || return 14
+  [ "$dec" == "" ] || return 14
+
+  echo "and again after reload"
+  sudo cvmfs_config reload || return 15
+  cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
+  dec="$(capsh --decode=$cap|cut -d= -f2)"
+  echo "CapPrm: $dec"
+  [ "$dec" == "cap_sys_admin" ] || return 16
 
   echo "check default capabilities on the main cache manager process"
   pid=$(sudo cvmfs_talk -i $repo pid cachemgr)
-  [ -n "$pid" ] || return 15
+  [ -n "$pid" ] || return 17
 
   cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapPrm: $dec"
-  [ "$dec" == "" ] || return 16
+  [ "$dec" == "" ] || return 18
   cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapEff: $dec"
   [ "$dec" == "" ] || return 19
 
-  echo "reloading $repo"
-  sudo cvmfs_config reload $repo || return 20
+  echo "setting up CVMFS_INFO_HEADER to read from user process environment"
+  echo 'CVMFS_INFO_HEADER="%{env:HOME}"' | sudo tee /etc/cvmfs/config.d/$repo.local || return 20
+  trap "sudo umount -l /cvmfs/${repo}; sudo rm -f /etc/cvmfs/config.d/$repo.local" EXIT
 
-  echo "check env-reading capabilities on the main fuse cvmfs process after reload"
+  echo "umount /cvmfs/${repo}"
+  sudo umount /cvmfs/${repo} || return 21
+
+  echo "remount /cvmfs/${repo}"
+  cvmfs_mount $repo || return 22
+
+  echo "check env-reading capabilities on the main fuse cvmfs process"
   pid=$(sudo cvmfs_talk -i $repo pid)
   [ -n "$pid" ] || return 30
 
   cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapPrm: $dec"
-  [ "$dec" == "cap_dac_read_search" ] || return 31
+  [ "$dec" == "cap_dac_read_search,cap_sys_ptrace" ] || return 31
   cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapEff: $dec"
-  [ "$dec" == "" ] || return 37
+  [ "$dec" == "" ] || return 32
+
+  echo "and again after reload"
+  sudo cvmfs_config reload || return 33
+  cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
+  dec="$(capsh --decode=$cap|cut -d= -f2)"
+  echo "CapPrm: $dec"
+  [ "$dec" == "cap_dac_read_search,cap_sys_ptrace" ] || return 34
+  cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
+  dec="$(capsh --decode=$cap|cut -d= -f2)"
+  echo "CapEff: $dec"
+  [ "$dec" == "" ] || return 35
 
   echo "check env-reading capabilities on the watchdog cvmfs process"
   pid=$(sudo cvmfs_talk -i $repo pid watchdog)
-  [ -n "$pid" ] || return 32
+  [ -n "$pid" ] || return 36
 
   cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapPrm: $dec"
-  [ "$dec" == "cap_sys_ptrace,cap_sys_admin" ] || return 33
+  [ "$dec" == "cap_sys_ptrace,cap_sys_admin" ] || return 37
   cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapEff: $dec"
@@ -98,20 +123,20 @@ cvmfs_run_test() {
   cap="$(sudo sed -n 's/^CapInh:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapInh: $dec"
-  [ "$dec" == "cap_sys_ptrace" ] || return 34
+  [ "$dec" == "cap_sys_ptrace" ] || return 39
 
   echo "check default capabilities on the main cache manager process"
   pid=$(sudo cvmfs_talk -i $repo pid cachemgr)
-  [ -n "$pid" ] || return 35
+  [ -n "$pid" ] || return 40
 
   cap="$(sudo sed -n 's/^CapPrm:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapPrm: $dec"
-  [ "$dec" == "" ] || return 36
+  [ "$dec" == "" ] || return 41
   cap="$(sudo sed -n 's/^CapEff:[^0]*//p' /proc/$pid/status)"
   dec="$(capsh --decode=$cap|cut -d= -f2)"
   echo "CapEff: $dec"
-  [ "$dec" == "" ] || return 39
+  [ "$dec" == "" ] || return 42
 
   return 0
 }

--- a/test/src/110-cvmfs-info-header/main
+++ b/test/src/110-cvmfs-info-header/main
@@ -1,0 +1,81 @@
+#!/bin/bash
+cvmfs_test_name="cvmfs-info header"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+cvmfs_run_test() {
+  logfile=$1
+
+  if running_on_osx; then
+    echo "Skipping test on macOS"
+    return 0
+  fi
+
+  local repo=sft.cern.ch
+
+  # Use mktemp instead of a file in $pwd or the debug log fails to open.
+  # Use mktemp -u to only provide a file name without creating it,
+  # because otherwise the debug log also fails to open.  The -u option
+  # is in general considered unsafe but if cvmfs tests are run on
+  # machines with untrustworthy users there are a lot of easier targets
+  # than this.
+  CVMFS_TEST_DEBUGLOG="$(mktemp -u /tmp/cvmfs_test110.log.XXXXXXXX)"
+  CVMFS_TEST_QUOTED_PARAM_KEY_VAL='CVMFS_INFO_HEADER="%{path} %{pid} %{uid} %{gid}%{env:TEST110_INFO1}%{env:TEST110_INFO2}"'
+
+  echo "mount $repo"
+  cvmfs_mount $repo || return 1
+  trap "sudo umount /cvmfs/$repo && sudo rm -f $CVMFS_TEST_DEBUGLOG" EXIT
+
+  file1=README.md
+  file2=lcg/lastUpdate
+
+  local pid1 pid2
+  local info1 info2
+
+  echo "read first test file with test environment"
+  TEST110_INFO1="myinfo1" cat "/cvmfs/$repo/$file1" >/dev/null &
+  pid1=$!
+  wait $pid1 || return 2
+  info1="$(sudo grep "^cvmfs-info:" "$CVMFS_TEST_DEBUGLOG"|tail -n1)"
+
+  echo "do reload"
+  sudo cvmfs_config reload || return 3
+
+  echo "read second test file with test environment"
+  TEST110_INFO2="my info2" cat "/cvmfs/$repo/$file2" >/dev/null &
+  pid2=$!
+  wait $pid2 || return 4
+  info2="$(sudo grep "^cvmfs-info:" "$CVMFS_TEST_DEBUGLOG"|tail -n1)"
+
+  echo "check output read from $CVMFS_TEST_DEBUGLOG"
+  local path pid uid gid env x
+  local mygid="$(id -g)"
+  echo "$info1" | while read x path pid uid gid env x; do
+    echo "check if $path matches /$file1"
+    [ "$path" = "/$file1" ] || return 10
+    echo "check if $pid matches $pid1"
+    [ "$pid" = "$pid1" ] || return 11
+    echo "check if $uid matches $UID"
+    [ "$uid" = "$UID" ] || return 12
+    echo "check if $gid matches $mygid"
+    [ "$gid" = "$mygid" ] || return 13
+    echo "check if $env matches myinfo1"
+    [ "$env" = "myinfo1" ] || return 14
+  done || return $?
+
+  echo "$info2" | while read x path pid uid gid env x; do
+    echo "check if $path matches /$file2"
+    [ "$path" = "/$file2" ] || return 20
+    echo "check if $pid matches $pid2"
+    [ "$pid" = "$pid2" ] || return 21
+    echo "check if $uid matches $UID"
+    [ "$uid" = "$UID" ] || return 22
+    echo "check if $gid matches $mygid"
+    [ "$gid" = "$mygid" ] || return 13
+    echo "check if $env matches my%20info2"
+    [ "$env" = "my%20info2" ] || return 24
+  done || return $?
+
+  return 0
+}
+

--- a/test/unittests/main.cc
+++ b/test/unittests/main.cc
@@ -11,7 +11,7 @@
 #include "monitor.h"
 
 int main(int argc, char **argv) {
-  Watchdog *watchdog = Watchdog::Create(NULL);
+  Watchdog *watchdog = Watchdog::Create(NULL, 0);
   assert(watchdog != NULL);
   //  watchdog->Spawn("/tmp/stacktrace.cvmfs_unittests");
   CvmfsEnvironment *env = new CvmfsEnvironment(argc, argv);

--- a/test/unittests/main_mockfuse.cc
+++ b/test/unittests/main_mockfuse.cc
@@ -11,7 +11,7 @@
 #include "monitor.h"
 
 int main(int argc, char **argv) {
-  Watchdog *watchdog = Watchdog::Create(NULL);
+  Watchdog *watchdog = Watchdog::Create(NULL, false);
   assert(watchdog != NULL);
   //  watchdog->Spawn("/tmp/stacktrace.cvmfs_unittests");
   //CvmfsEnvironment *env = new CvmfsEnvironment(argc, argv);

--- a/test/unittests/main_mockfuse.cc
+++ b/test/unittests/main_mockfuse.cc
@@ -11,7 +11,7 @@
 #include "monitor.h"
 
 int main(int argc, char **argv) {
-  Watchdog *watchdog = Watchdog::Create(NULL, false);
+  Watchdog *watchdog = Watchdog::Create(NULL, false /* needs_read_environ */);
   assert(watchdog != NULL);
   //  watchdog->Spawn("/tmp/stacktrace.cvmfs_unittests");
   //CvmfsEnvironment *env = new CvmfsEnvironment(argc, argv);

--- a/test/unittests/t_cvmfs.cc
+++ b/test/unittests/t_cvmfs.cc
@@ -203,6 +203,7 @@ static bool GetDirentForInode(const fuse_ino_t,
 }  // namespace cvmfs
 
 static int Init(const loader::LoaderExports *loader_export) { return 0; }
+static bool NeedsReadEnviron() { return false; }
 
 #define fuse_reply_err cvmfs::fuse_reply_err
 #define fuse_reply_open cvmfs::fuse_reply_open


### PR DESCRIPTION
This extends the `cvmfs-info` header when a template passed in `CVMFS_INFO_HEADER` is set, as defined in #3666.

This PR depends on #3730 which must be merged first.

- Fixes #3666