### PR TITLE
Example of using clang-format-19: With alignment of assignments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,297 @@
 ---
-Language: Cpp
-BasedOnStyle: Google
+Language:        Cpp
+# BasedOnStyle:  Google
+BasedOnStyle:    ''
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+# AlignConsecutiveMacros: None # clang-format < 15
+# AlignConsecutiveAssignments: None # clang-format-14
+# AlignConsecutiveBitFields: None # clang-format < 15
+# AlignConsecutiveDeclarations: None
+
+# clang-format-15
+AlignConsecutiveAssignments:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   true
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true # from false
+AllowAllParametersOfDeclarationOnNextLine: true # from false
+AllowShortEnumsOnASingleLine: false # from true
+AllowShortBlocksOnASingleLine: Never ## maybe have a look
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never # from WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false ## changed from true
+# AlwaysBreakTemplateDeclarations: Yes # v19: renamed to BreakTemplateDeclarations
+BreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false ## maybe
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment # old: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma # from BeforeColon
+BreakFunctionDefinitionParameters: false # v19
+BreakInheritanceList: BeforeColon # maybe something else?
+BreakBeforeInheritanceComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+# DeriveLineEnding: true  # deprecated, see below
+LineEnding: DeriveLF # DeriveLineEnding is deprecated, introduced in v16
+DerivePointerAlignment: false # from true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: true # from false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false # deprecated
+# AllowAllConstructorInitializersOnNextLine: true # deprecated
+IndentAccessModifiers: false
+AccessModifierOffset: -1
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause:  false # in clang-format 12, 13 and 14 it was named IndentRequires
+RequiresClausePosition: OwnLine
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false # should be yes in the future?
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+# KeepEmptyLinesAtTheStartOfBlocks: false # maybe
+KeepEmptyLines: # clang v19
+  AtEndOfFile:     false
+  AtStartOfBlock:  false
+  AtStartOfFile:   false # from true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2 # from 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false # from true
+PPIndentWidth:   -1
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 1000 # from 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: Lexicographic # from true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false # from true
+SpaceAroundPointerQualifiers: Before # from Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  AfterPlacementOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true # from false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        c++03 # from Auto --> increase later to c++11 or higher
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        2 # from 8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+###########################3
+# clang-format 16+
+###########################3
+InsertNewlineAtEOF: true # v16
+RequiresExpressionIndentation: Keyword # v16
+AllowShortCompoundRequirementOnASingleLine: true # v18
+# SkipMacroDefinitionBody: false # v17 - not sure which value
+SpaceBeforeJsonColon: false # v17
+SpacesInParens: Never # v17
+# SpacesInParensOptions:
+#   ExceptDoubleParentheses: false
+#   InConditionalStatements: false
+#   InCStyleCasts: false
+#   InEmptyParentheses: true
+#   Other: false
+RemoveSemicolon: false
+RemoveParentheses: Leave
+IntegerLiteralSeparator:
+  Binary:          4
+  BinaryMinDigits: 8
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             2
+  HexMinDigits:    6
+BreakBeforeInlineASMColon: OnlyMultiline # v16
+BreakArrays: false
+BreakAdjacentStringLiterals: true # v18
+AllowShortCaseExpressionOnASingleLine: false # v19
+AllowBreakBeforeNoexceptSpecifier: Never # v18
 ...
+

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -3,7 +3,7 @@
  */
 
 // avoid clang-tidy false positives (at least starting with clang14)
-//NOLINTBEGIN
+// NOLINTBEGIN
 
 #ifndef CVMFS_CATALOG_MGR_IMPL_H_
 #define CVMFS_CATALOG_MGR_IMPL_H_
@@ -11,7 +11,6 @@
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
-
 
 
 #include <cassert>
@@ -27,28 +26,28 @@ using namespace std;  // NOLINT
 
 namespace catalog {
 
-template <class CatalogT>
+template<class CatalogT>
 AbstractCatalogManager<CatalogT>::AbstractCatalogManager(
-    perf::Statistics *statistics) :
-  statistics_(statistics) {
+    perf::Statistics *statistics)
+    : statistics_(statistics) {
   inode_watermark_status_ = 0;
-  inode_gauge_ = AbstractCatalogManager<CatalogT>::kInodeOffset;
-  revision_cache_ = 0;
-  timestamp_cache_ = 0;
-  catalog_watermark_ = 0;
-  volatile_flag_ = false;
-  has_authz_cache_ = false;
-  inode_annotation_ = NULL;
-  incarnation_ = 0;
-  rwlock_ =
-    reinterpret_cast<pthread_rwlock_t *>(smalloc(sizeof(pthread_rwlock_t)));
+  inode_gauge_            = AbstractCatalogManager<CatalogT>::kInodeOffset;
+  revision_cache_         = 0;
+  timestamp_cache_        = 0;
+  catalog_watermark_      = 0;
+  volatile_flag_          = false;
+  has_authz_cache_        = false;
+  inode_annotation_       = NULL;
+  incarnation_            = 0;
+  rwlock_                 = reinterpret_cast<pthread_rwlock_t *>(
+      smalloc(sizeof(pthread_rwlock_t)));
   int retval = pthread_rwlock_init(rwlock_, NULL);
   assert(retval == 0);
   retval = pthread_key_create(&pkey_sqlitemem_, NULL);
   assert(retval == 0);
 }
 
-template <class CatalogT>
+template<class CatalogT>
 AbstractCatalogManager<CatalogT>::~AbstractCatalogManager() {
   DetachAll();
   pthread_key_delete(pkey_sqlitemem_);
@@ -56,28 +55,26 @@ AbstractCatalogManager<CatalogT>::~AbstractCatalogManager() {
   free(rwlock_);
 }
 
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::SetInodeAnnotation(
-    InodeAnnotation *new_annotation)
-{
+    InodeAnnotation *new_annotation) {
   assert(catalogs_.empty() || (new_annotation == inode_annotation_));
   inode_annotation_ = new_annotation;
 }
 
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::SetOwnerMaps(const OwnerMap &uid_map,
-                                          const OwnerMap &gid_map)
-{
+                                                    const OwnerMap &gid_map) {
   uid_map_ = uid_map;
   gid_map_ = gid_map;
 }
 
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::SetCatalogWatermark(unsigned limit) {
   catalog_watermark_ = limit;
 }
 
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::CheckInodeWatermark() {
   if (inode_watermark_status_ > 0)
     return;
@@ -86,7 +83,7 @@ void AbstractCatalogManager<CatalogT>::CheckInodeWatermark() {
   if (inode_annotation_)
     highest_inode += inode_annotation_->GetGeneration();
   uint64_t uint32_border = 1;
-  uint32_border = uint32_border << 32;
+  uint32_border          = uint32_border << 32;
   if (highest_inode >= uint32_border) {
     LogCvmfs(kLogCatalog, kLogDebug | kLogSyslogWarn, "inodes exceed 32bit");
     inode_watermark_status_++;
@@ -98,7 +95,7 @@ void AbstractCatalogManager<CatalogT>::CheckInodeWatermark() {
  * Initializes the CatalogManager and loads and attaches the root entry.
  * @return true on successful init, otherwise false
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::Init() {
   LogCvmfs(kLogCatalog, kLogDebug, "Initialize catalog");
   WriteLock();
@@ -118,23 +115,23 @@ bool AbstractCatalogManager<CatalogT>::Init() {
  * it is mounted and replaces the currently mounted tree (all existing catalogs
  * are detached)
  */
-template <class CatalogT>
+template<class CatalogT>
 LoadReturn AbstractCatalogManager<CatalogT>::RemountDryrun() {
-  LogCvmfs(kLogCatalog, kLogDebug,
-           "dryrun remounting repositories");
+  LogCvmfs(kLogCatalog, kLogDebug, "dryrun remounting repositories");
   CatalogContext ctlg_context;
   return GetNewRootCatalogContext(&ctlg_context);
 }
 
-template <class CatalogT>
+template<class CatalogT>
 LoadReturn AbstractCatalogManager<CatalogT>::Remount() {
   LogCvmfs(kLogCatalog, kLogDebug, "remounting repositories");
   CatalogContext ctlg_context;
 
   if (GetNewRootCatalogContext(&ctlg_context) != kLoadNew
       && GetNewRootCatalogContext(&ctlg_context) != kLoadUp2Date) {
-    LogCvmfs(kLogCatalog, kLogDebug, "remounting repositories: "
-                                "Did not find any valid root catalog to mount");
+    LogCvmfs(kLogCatalog, kLogDebug,
+             "remounting repositories: "
+             "Did not find any valid root catalog to mount");
     return kLoadFail;
   }
 
@@ -166,18 +163,17 @@ LoadReturn AbstractCatalogManager<CatalogT>::Remount() {
 /**
  * Remounts to the given hash
  */
-template <class CatalogT>
+template<class CatalogT>
 LoadReturn AbstractCatalogManager<CatalogT>::ChangeRoot(
-  const shash::Any &root_hash)
-{
+    const shash::Any &root_hash) {
   assert(!root_hash.IsNull());
-  LogCvmfs(kLogCatalog, kLogDebug,
-           "switching to root hash %s", root_hash.ToString().c_str());
+  LogCvmfs(kLogCatalog, kLogDebug, "switching to root hash %s",
+           root_hash.ToString().c_str());
 
   WriteLock();
 
   CatalogContext ctlg_context(root_hash, PathString("", 0),
-                                                         kCtlgNoLocationNeeded);
+                              kCtlgNoLocationNeeded);
   // we do not need to set revision as LoadCatalogByHash
   // needs only mountpoint, hash
 
@@ -188,8 +184,8 @@ LoadReturn AbstractCatalogManager<CatalogT>::ChangeRoot(
     DetachAll();
     inode_gauge_ = AbstractCatalogManager<CatalogT>::kInodeOffset;
 
-    CatalogT *new_root =
-                    CreateCatalog(PathString("", 0), ctlg_context.hash(), NULL);
+    CatalogT *new_root = CreateCatalog(PathString("", 0), ctlg_context.hash(),
+                                       NULL);
     assert(new_root);
     bool retval = AttachCatalog(ctlg_context.sqlite_path(), new_root);
     assert(retval);
@@ -208,7 +204,7 @@ LoadReturn AbstractCatalogManager<CatalogT>::ChangeRoot(
 /**
  * Detaches everything except the root catalog
  */
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::DetachNested() {
   WriteLock();
   if (catalogs_.empty()) {
@@ -220,8 +216,7 @@ void AbstractCatalogManager<CatalogT>::DetachNested() {
   typename CatalogList::const_iterator iend;
   CatalogList catalogs_to_detach = GetRootCatalog()->GetChildren();
   for (i = catalogs_to_detach.begin(), iend = catalogs_to_detach.end();
-       i != iend; ++i)
-  {
+       i != iend; ++i) {
     DetachSubtree(*i);
   }
 
@@ -232,10 +227,9 @@ void AbstractCatalogManager<CatalogT>::DetachNested() {
 /**
  * Returns the NULL hash if the nested catalog is not found.
  */
-template <class CatalogT>
+template<class CatalogT>
 shash::Any AbstractCatalogManager<CatalogT>::GetNestedCatalogHash(
-  const PathString &mountpoint)
-{
+    const PathString &mountpoint) {
   assert(!mountpoint.IsEmpty());
   CatalogT *catalog = FindCatalog(mountpoint);
   assert(catalog != NULL);
@@ -259,18 +253,17 @@ shash::Any AbstractCatalogManager<CatalogT>::GetNestedCatalogHash(
  *                  Note: can be set to zero if the result is not important
  * @return true if lookup succeeded otherwise false
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
-                                        const LookupOptions options,
-                                        DirectoryEntry *dirent)
-{
+                                                  const LookupOptions options,
+                                                  DirectoryEntry *dirent) {
   // initialize as non-negative
   assert(dirent);
   *dirent = DirectoryEntry();
 
   // create a dummy negative directory entry
-  const DirectoryEntry dirent_negative =
-    DirectoryEntry(catalog::kDirentNegative);
+  const DirectoryEntry dirent_negative = DirectoryEntry(
+      catalog::kDirentNegative);
 
   EnforceSqliteMemLimit();
   ReadLock();
@@ -300,8 +293,8 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
                "entry not found, we may have to load nested catalogs");
 
       CatalogT *nested_catalog;
-      found =
-        MountSubtree(path, best_fit, false /* is_listable */, &nested_catalog);
+      found = MountSubtree(path, best_fit, false /* is_listable */,
+                           &nested_catalog);
 
       if (!found) {
         LogCvmfs(kLogCatalog, kLogDebug,
@@ -316,14 +309,16 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
           LogCvmfs(kLogCatalog, kLogDebug,
                    "nested catalogs loaded but entry '%s' was still not found",
                    path.c_str());
-          if (dirent != NULL) *dirent = dirent_negative;
+          if (dirent != NULL)
+            *dirent = dirent_negative;
           goto lookup_path_notfound;
         } else {
           best_fit = nested_catalog;
         }
       } else {
         LogCvmfs(kLogCatalog, kLogDebug, "no nested catalog fits");
-        if (dirent != NULL) *dirent = dirent_negative;
+        if (dirent != NULL)
+          *dirent = dirent_negative;
         goto lookup_path_notfound;
       }
     }
@@ -332,7 +327,8 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
   // Not in a nested catalog (because no nested cataog fits), ENOENT
   if (!found) {
     LogCvmfs(kLogCatalog, kLogDebug, "ENOENT: '%s'", path.c_str());
-    if (dirent != NULL) *dirent = dirent_negative;
+    if (dirent != NULL)
+      *dirent = dirent_negative;
     goto lookup_path_notfound;
   }
 
@@ -349,7 +345,7 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
   Unlock();
   return true;
 
- lookup_path_notfound:
+lookup_path_notfound:
   Unlock();
   // Includes both: ENOENT and not found due to I/O error
   perf::Inc(statistics_.n_lookup_path_negative);
@@ -369,13 +365,11 @@ bool AbstractCatalogManager<CatalogT>::LookupPath(const PathString &path,
  * @return true if lookup succeeded otherwise false (available catalog failed
  *         to mount)
  */
-template <class CatalogT>
-bool AbstractCatalogManager<CatalogT>::LookupNested(
-  const PathString &path,
-  PathString *mountpoint,
-  shash::Any *hash,
-  uint64_t *size
-) {
+template<class CatalogT>
+bool AbstractCatalogManager<CatalogT>::LookupNested(const PathString &path,
+                                                    PathString *mountpoint,
+                                                    shash::Any *hash,
+                                                    uint64_t *size) {
   EnforceSqliteMemLimit();
   bool result = false;
   ReadLock();
@@ -386,14 +380,14 @@ bool AbstractCatalogManager<CatalogT>::LookupNested(
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(catalog_path);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   if (MountSubtree(catalog_path, best_fit, false /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(catalog_path);
-    result =
-      MountSubtree(catalog_path, best_fit, false /* is_listable */, &catalog);
+    result   = MountSubtree(catalog_path, best_fit, false /* is_listable */,
+                            &catalog);
     // Result is false if an available catalog failed to load (error happened)
     if (!result) {
       Unlock();
@@ -414,8 +408,8 @@ bool AbstractCatalogManager<CatalogT>::LookupNested(
   // itself, we manually set the values and leave the size as 0.
   // TODO(nhazekam) Allow for Root Catalog to be returned
   if (!result) {
-    *hash =  GetRootCatalog()->hash();
-    *size = 0;
+    *hash  = GetRootCatalog()->hash();
+    *size  = 0;
     result = true;
   }
 
@@ -433,11 +427,9 @@ bool AbstractCatalogManager<CatalogT>::LookupNested(
  * @param result_list the list where the results will be added.
  * @return true if the list could be created, false if catalog fails to mount.
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::ListCatalogSkein(
-  const PathString &path,
-  std::vector<PathString> *result_list
-) {
+    const PathString &path, std::vector<PathString> *result_list) {
   EnforceSqliteMemLimit();
   bool result;
   ReadLock();
@@ -448,14 +440,14 @@ bool AbstractCatalogManager<CatalogT>::ListCatalogSkein(
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(test);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   // True if there is an available nested catalog
   if (MountSubtree(test, best_fit, false /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(test);
-    result = MountSubtree(test, best_fit, false /* is_listable */, &catalog);
+    result   = MountSubtree(test, best_fit, false /* is_listable */, &catalog);
     // result is false if an available catalog failed to load
     if (!result) {
       Unlock();
@@ -467,7 +459,7 @@ bool AbstractCatalogManager<CatalogT>::ListCatalogSkein(
   CatalogT *cur_parent = catalog->parent();
   if (cur_parent) {
     // Walk up parent tree to find base
-    std::vector<catalog::Catalog*> parents;
+    std::vector<catalog::Catalog *> parents;
     while (cur_parent->HasParent()) {
       parents.push_back(cur_parent);
       cur_parent = cur_parent->parent();
@@ -494,24 +486,22 @@ bool AbstractCatalogManager<CatalogT>::ListCatalogSkein(
 }
 
 
-template <class CatalogT>
-bool AbstractCatalogManager<CatalogT>::LookupXattrs(
-  const PathString &path,
-  XattrList *xattrs)
-{
+template<class CatalogT>
+bool AbstractCatalogManager<CatalogT>::LookupXattrs(const PathString &path,
+                                                    XattrList *xattrs) {
   EnforceSqliteMemLimit();
   bool result;
   ReadLock();
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   if (MountSubtree(path, best_fit, false /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, false /* is_listable */, &catalog);
+    result   = MountSubtree(path, best_fit, false /* is_listable */, &catalog);
     if (!result) {
       Unlock();
       return false;
@@ -532,24 +522,23 @@ bool AbstractCatalogManager<CatalogT>::LookupXattrs(
  * @param listing the resulting DirectoryEntryList
  * @return true if listing succeeded otherwise false
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::Listing(const PathString &path,
-                                     DirectoryEntryList *listing,
-                                     const bool expand_symlink)
-{
+                                               DirectoryEntryList *listing,
+                                               const bool expand_symlink) {
   EnforceSqliteMemLimit();
   bool result;
   ReadLock();
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   if (MountSubtree(path, best_fit, true /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, true /* is_listable */);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, true /* is_listable */, &catalog);
+    result   = MountSubtree(path, best_fit, true /* is_listable */, &catalog);
     if (!result) {
       Unlock();
       return false;
@@ -570,23 +559,22 @@ bool AbstractCatalogManager<CatalogT>::Listing(const PathString &path,
  * @param listing the resulting StatEntryList
  * @return true if listing succeeded otherwise false
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::ListingStat(const PathString &path,
-                                        StatEntryList *listing)
-{
+                                                   StatEntryList *listing) {
   EnforceSqliteMemLimit();
   bool result;
   ReadLock();
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   if (MountSubtree(path, best_fit, true /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, true /* is_listable */);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, true /* is_listable */, &catalog);
+    result   = MountSubtree(path, best_fit, true /* is_listable */, &catalog);
     if (!result) {
       Unlock();
       return false;
@@ -608,25 +596,24 @@ bool AbstractCatalogManager<CatalogT>::ListingStat(const PathString &path,
  *        same than the chunk hashes)
  * @return true if listing succeeded otherwise false
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::ListFileChunks(
-  const PathString &path,
-  const shash::Algorithms interpret_hashes_as,
-  FileChunkList *chunks)
-{
+    const PathString &path,
+    const shash::Algorithms interpret_hashes_as,
+    FileChunkList *chunks) {
   EnforceSqliteMemLimit();
   bool result;
   ReadLock();
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(path);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   if (MountSubtree(path, best_fit, false /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, false);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(path);
-    result = MountSubtree(path, best_fit, false /* is_listable */, &catalog);
+    result   = MountSubtree(path, best_fit, false /* is_listable */, &catalog);
     if (!result) {
       Unlock();
       return false;
@@ -639,13 +626,9 @@ bool AbstractCatalogManager<CatalogT>::ListFileChunks(
   return result;
 }
 
-template <class CatalogT>
+template<class CatalogT>
 catalog::Counters AbstractCatalogManager<CatalogT>::LookupCounters(
-  const PathString &path,
-  std::string *subcatalog_path,
-  shash::Any *hash
-  )
-{
+    const PathString &path, std::string *subcatalog_path, shash::Any *hash) {
   EnforceSqliteMemLimit();
   bool result;
   ReadLock();
@@ -656,32 +639,32 @@ catalog::Counters AbstractCatalogManager<CatalogT>::LookupCounters(
 
   // Find catalog, possibly load nested
   CatalogT *best_fit = FindCatalog(catalog_path);
-  CatalogT *catalog = best_fit;
+  CatalogT *catalog  = best_fit;
   if (MountSubtree(catalog_path, best_fit, false /* is_listable */, NULL)) {
     StageNestedCatalogAndUnlock(path, best_fit, false /* is_listable */);
     WriteLock();
     // Check again to avoid race
     best_fit = FindCatalog(catalog_path);
-    result =
-      MountSubtree(catalog_path, best_fit, false /* is_listable */, &catalog);
+    result   = MountSubtree(catalog_path, best_fit, false /* is_listable */,
+                            &catalog);
     // Result is false if an available catalog failed to load (error happened)
     if (!result) {
       Unlock();
       *subcatalog_path = "error: failed to load catalog!";
-      *hash = shash::Any();
+      *hash            = shash::Any();
       return catalog::Counters();
     }
   }
 
-  *hash = catalog->hash();
-  *subcatalog_path = catalog->mountpoint().ToString();
+  *hash                      = catalog->hash();
+  *subcatalog_path           = catalog->mountpoint().ToString();
   catalog::Counters counters = catalog->GetCounters();
   Unlock();
   return counters;
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 uint64_t AbstractCatalogManager<CatalogT>::GetRevision() const {
   ReadLock();
   const uint64_t revision = GetRevisionNoLock();
@@ -695,12 +678,12 @@ uint64_t AbstractCatalogManager<CatalogT>::GetRevision() const {
  * As such should only be used in conditions where a lock was already taken
  * and calling GetRevision() would otherwise result in a deadlock.
  */
-template <class CatalogT>
+template<class CatalogT>
 uint64_t AbstractCatalogManager<CatalogT>::GetRevisionNoLock() const {
   return revision_cache_;
 }
 
-template <class CatalogT>
+template<class CatalogT>
 uint64_t AbstractCatalogManager<CatalogT>::GetTimestamp() const {
   ReadLock();
   const uint64_t timestamp = GetTimestampNoLock();
@@ -714,12 +697,12 @@ uint64_t AbstractCatalogManager<CatalogT>::GetTimestamp() const {
  * As such should only be used in conditions where a lock was already taken
  * and calling GetTimestamp() would otherwise result in a deadlock.
  */
-template <class CatalogT>
+template<class CatalogT>
 uint64_t AbstractCatalogManager<CatalogT>::GetTimestampNoLock() const {
   return timestamp_cache_;
 }
 
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::GetVOMSAuthz(std::string *authz) const {
   ReadLock();
   const bool has_authz = has_authz_cache_;
@@ -730,7 +713,7 @@ bool AbstractCatalogManager<CatalogT>::GetVOMSAuthz(std::string *authz) const {
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::HasExplicitTTL() const {
   ReadLock();
   const bool result = GetRootCatalog()->HasExplicitTTL();
@@ -739,7 +722,7 @@ bool AbstractCatalogManager<CatalogT>::HasExplicitTTL() const {
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 uint64_t AbstractCatalogManager<CatalogT>::GetTTL() const {
   ReadLock();
   const uint64_t ttl = GetRootCatalog()->GetTTL();
@@ -748,7 +731,7 @@ uint64_t AbstractCatalogManager<CatalogT>::GetTTL() const {
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 int AbstractCatalogManager<CatalogT>::GetNumCatalogs() const {
   ReadLock();
   int result = catalogs_.size();
@@ -760,7 +743,7 @@ int AbstractCatalogManager<CatalogT>::GetNumCatalogs() const {
 /**
  * Gets a formatted tree of the currently attached catalogs
  */
-template <class CatalogT>
+template<class CatalogT>
 string AbstractCatalogManager<CatalogT>::PrintHierarchy() const {
   ReadLock();
   string output = PrintHierarchyRecursively(GetRootCatalog(), 0);
@@ -772,11 +755,11 @@ string AbstractCatalogManager<CatalogT>::PrintHierarchy() const {
 /**
  * Assigns the next free numbers in the 64 bit space
  */
-template <class CatalogT>
+template<class CatalogT>
 InodeRange AbstractCatalogManager<CatalogT>::AcquireInodes(uint64_t size) {
   InodeRange result;
   result.offset = inode_gauge_;
-  result.size = size;
+  result.size   = size;
 
   inode_gauge_ += size;
   LogCvmfs(kLogCatalog, kLogDebug, "allocating inodes from %lu to %lu.",
@@ -791,7 +774,7 @@ InodeRange AbstractCatalogManager<CatalogT>::AcquireInodes(uint64_t size) {
  * invalid.
  * @param chunk the InodeChunk to be freed
  */
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::ReleaseInodes(const InodeRange chunk) {
   // TODO(jblomer) currently inodes are only released on remount
 }
@@ -803,8 +786,8 @@ void AbstractCatalogManager<CatalogT>::ReleaseInodes(const InodeRange chunk) {
  * @param path the path a catalog is searched for
  * @return the catalog which is best fitting at the given path
  */
-template <class CatalogT>
-CatalogT* AbstractCatalogManager<CatalogT>::FindCatalog(
+template<class CatalogT>
+CatalogT *AbstractCatalogManager<CatalogT>::FindCatalog(
     const PathString &path) const {
   assert(catalogs_.size() > 0);
 
@@ -828,10 +811,9 @@ CatalogT* AbstractCatalogManager<CatalogT>::FindCatalog(
  * @param attached_catalog is set to the searched catalog, if not NULL
  * @return true if catalog is already present, false otherwise
  */
-template <class CatalogT>
-bool AbstractCatalogManager<CatalogT>::IsAttached(const PathString &root_path,
-                                        CatalogT **attached_catalog) const
-{
+template<class CatalogT>
+bool AbstractCatalogManager<CatalogT>::IsAttached(
+    const PathString &root_path, CatalogT **attached_catalog) const {
   if (catalogs_.size() == 0)
     return false;
 
@@ -839,27 +821,26 @@ bool AbstractCatalogManager<CatalogT>::IsAttached(const PathString &root_path,
   if (best_fit->mountpoint() != root_path)
     return false;
 
-  if (attached_catalog != NULL) *attached_catalog = best_fit;
+  if (attached_catalog != NULL)
+    *attached_catalog = best_fit;
   return true;
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::StageNestedCatalogAndUnlock(
-  const PathString &path,
-  const CatalogT *parent,
-  bool is_listable)
-{
+    const PathString &path, const CatalogT *parent, bool is_listable) {
   assert(parent);
   const unsigned path_len = path.GetLength();
 
   perf::Inc(statistics_.n_nested_listing);
   typedef typename CatalogT::NestedCatalogList NestedCatalogList;
-  const NestedCatalogList& nested_catalogs = parent->ListNestedCatalogs();
+  const NestedCatalogList &nested_catalogs = parent->ListNestedCatalogs();
 
   for (typename NestedCatalogList::const_iterator i = nested_catalogs.begin(),
-       iEnd = nested_catalogs.end(); i != iEnd; ++i)
-  {
+                                                  iEnd = nested_catalogs.end();
+       i != iEnd;
+       ++i) {
     if (!path.StartsWith(i->mountpoint))
       continue;
 
@@ -892,16 +873,15 @@ void AbstractCatalogManager<CatalogT>::StageNestedCatalogAndUnlock(
  * if is_listable is true, the nested catalog will be used; otherwise the parent
  * with the transaction point is sufficient.
  */
-template <class CatalogT>
-bool AbstractCatalogManager<CatalogT>::MountSubtree(
-  const PathString &path,
-  const CatalogT *entry_point,
-  bool is_listable,
-  CatalogT **leaf_catalog)
-{
-  bool result = true;
-  CatalogT *parent = (entry_point == NULL) ?
-                     GetRootCatalog() : const_cast<CatalogT *>(entry_point);
+template<class CatalogT>
+bool AbstractCatalogManager<CatalogT>::MountSubtree(const PathString &path,
+                                                    const CatalogT *entry_point,
+                                                    bool is_listable,
+                                                    CatalogT **leaf_catalog) {
+  bool result      = true;
+  CatalogT *parent = (entry_point == NULL)
+                         ? GetRootCatalog()
+                         : const_cast<CatalogT *>(entry_point);
   assert(path.StartsWith(parent->mountpoint()));
 
   unsigned path_len = path.GetLength();
@@ -909,11 +889,11 @@ bool AbstractCatalogManager<CatalogT>::MountSubtree(
   // Try to find path as a super string of nested catalog mount points
   perf::Inc(statistics_.n_nested_listing);
   typedef typename CatalogT::NestedCatalogList NestedCatalogList;
-  const NestedCatalogList& nested_catalogs =
-    parent->ListNestedCatalogs();
+  const NestedCatalogList &nested_catalogs = parent->ListNestedCatalogs();
   for (typename NestedCatalogList::const_iterator i = nested_catalogs.begin(),
-       iEnd = nested_catalogs.end(); i != iEnd; ++i)
-  {
+                                                  iEnd = nested_catalogs.end();
+       i != iEnd;
+       ++i) {
     // Next nesting level
     if (path.StartsWith(i->mountpoint)) {
       // in this case the path doesn't start with
@@ -956,12 +936,11 @@ bool AbstractCatalogManager<CatalogT>::MountSubtree(
  * Load a catalog file and attach it to the tree of Catalog objects.
  * Loading of catalogs is implemented by derived classes.
  */
-template <class CatalogT>
+template<class CatalogT>
 CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
-                                              const PathString &mountpoint,
-                                              const shash::Any &hash,
-                                              CatalogT *parent_catalog)
-{
+    const PathString &mountpoint,
+    const shash::Any &hash,
+    CatalogT *parent_catalog) {
   CatalogT *attached_catalog = NULL;
   if (IsAttached(mountpoint, &attached_catalog)) {
     return attached_catalog;
@@ -972,8 +951,8 @@ CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
   if (ctlg_context.IsRootCatalog() && hash.IsNull()) {
     if (GetNewRootCatalogContext(&ctlg_context) == kLoadFail) {
       LogCvmfs(kLogCatalog, kLogDebug,
-                                   "failed to retrieve valid root catalog '%s'",
-                                   mountpoint.c_str());
+               "failed to retrieve valid root catalog '%s'",
+               mountpoint.c_str());
       return NULL;
     }
   }
@@ -985,9 +964,8 @@ CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
     return NULL;
   }
 
-  attached_catalog = CreateCatalog(ctlg_context.mountpoint(),
-                                   ctlg_context.hash(),
-                                   parent_catalog);
+  attached_catalog = CreateCatalog(
+      ctlg_context.mountpoint(), ctlg_context.hash(), parent_catalog);
 
   // Attach loaded catalog
   if (!AttachCatalog(ctlg_context.sqlite_path(), attached_catalog)) {
@@ -1009,11 +987,9 @@ CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
  * Load a catalog file as a freestanding Catalog object.
  * Loading of catalogs is implemented by derived classes.
  */
-template <class CatalogT>
+template<class CatalogT>
 CatalogT *AbstractCatalogManager<CatalogT>::LoadFreeCatalog(
-                                            const PathString     &mountpoint,
-                                            const shash::Any     &hash)
-{
+    const PathString &mountpoint, const shash::Any &hash) {
   assert(!hash.IsNull());
   CatalogContext ctlg_context(hash, mountpoint, kCtlgNoLocationNeeded);
 
@@ -1023,9 +999,8 @@ CatalogT *AbstractCatalogManager<CatalogT>::LoadFreeCatalog(
     return NULL;
   }
 
-  CatalogT *catalog = CatalogT::AttachFreely(mountpoint.ToString(),
-                                             ctlg_context.sqlite_path(),
-                                             ctlg_context.hash());
+  CatalogT *catalog = CatalogT::AttachFreely(
+      mountpoint.ToString(), ctlg_context.sqlite_path(), ctlg_context.hash());
   catalog->TakeDatabaseFileOwnership();
   return catalog;
 }
@@ -1037,10 +1012,9 @@ CatalogT *AbstractCatalogManager<CatalogT>::LoadFreeCatalog(
  * @param new_catalog the catalog to attach to this CatalogManager
  * @return true on success, false otherwise
  */
-template <class CatalogT>
+template<class CatalogT>
 bool AbstractCatalogManager<CatalogT>::AttachCatalog(const string &db_path,
-                                           CatalogT *new_catalog)
-{
+                                                     CatalogT *new_catalog) {
   LogCvmfs(kLogCatalog, kLogDebug, "attaching catalog file %s",
            db_path.c_str());
 
@@ -1053,7 +1027,7 @@ bool AbstractCatalogManager<CatalogT>::AttachCatalog(const string &db_path,
 
   // Determine the inode offset of this catalog
   uint64_t inode_chunk_size = new_catalog->max_row_id();
-  InodeRange range = AcquireInodes(inode_chunk_size);
+  InodeRange range          = AcquireInodes(inode_chunk_size);
   new_catalog->set_inode_range(range);
   new_catalog->SetInodeAnnotation(inode_annotation_);
   new_catalog->SetOwnerMaps(&uid_map_, &gid_map_);
@@ -1069,11 +1043,11 @@ bool AbstractCatalogManager<CatalogT>::AttachCatalog(const string &db_path,
 
   // The revision of the catalog tree is given by the root catalog revision
   if (catalogs_.empty()) {
-    revision_cache_ = new_catalog->GetRevision();
+    revision_cache_  = new_catalog->GetRevision();
     timestamp_cache_ = new_catalog->GetLastModified();
     statistics_.catalog_revision->Set(revision_cache_);
     has_authz_cache_ = new_catalog->GetVOMSAuthz(&authz_cache_);
-    volatile_flag_ = new_catalog->volatile_flag();
+    volatile_flag_   = new_catalog->volatile_flag();
   }
 
   catalogs_.push_back(new_catalog);
@@ -1090,7 +1064,7 @@ bool AbstractCatalogManager<CatalogT>::AttachCatalog(const string &db_path,
  * @param catalog the catalog to detach
  * @return true on success, false otherwise
  */
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::DetachCatalog(CatalogT *catalog) {
   if (catalog->HasParent())
     catalog->parent()->RemoveChild(catalog);
@@ -1119,15 +1093,14 @@ void AbstractCatalogManager<CatalogT>::DetachCatalog(CatalogT *catalog) {
  * @param catalog the catalog to detach
  * @return true on success, false otherwise
  */
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::DetachSubtree(CatalogT *catalog) {
   // Detach all child catalogs recursively
   typename CatalogList::const_iterator i;
   typename CatalogList::const_iterator iend;
   CatalogList catalogs_to_detach = catalog->GetChildren();
   for (i = catalogs_to_detach.begin(), iend = catalogs_to_detach.end();
-       i != iend; ++i)
-  {
+       i != iend; ++i) {
     DetachSubtree(*i);
   }
 
@@ -1139,19 +1112,17 @@ void AbstractCatalogManager<CatalogT>::DetachSubtree(CatalogT *catalog) {
  * Detaches all nested catalogs that are not on a prefix of the given tree.
  * Used when the catalog_watermark_ is surpassed.
  */
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::DetachSiblings(
-  const PathString &current_tree)
-{
+    const PathString &current_tree) {
   bool again;
   do {
-    again = false;
+    again      = false;
     unsigned N = catalogs_.size();
     for (unsigned i = 0; i < N; ++i) {
       if (!HasPrefix(current_tree.ToString(),
                      catalogs_[i]->mountpoint().ToString(),
-                     false /* ignore_case */))
-      {
+                     false /* ignore_case */)) {
         DetachSubtree(catalogs_[i]);
         again = true;
         break;
@@ -1165,23 +1136,21 @@ void AbstractCatalogManager<CatalogT>::DetachSiblings(
 /**
  * Formats the catalog hierarchy
  */
-template <class CatalogT>
+template<class CatalogT>
 string AbstractCatalogManager<CatalogT>::PrintHierarchyRecursively(
-                                                      const CatalogT *catalog,
-                                                      const int level) const
-{
+    const CatalogT *catalog, const int level) const {
   string output;
 
   // Indent according to level
-  for (int i = 0; i < level; ++i)
-    output += "    ";
+  for (int i = 0; i < level; ++i) output += "    ";
 
-  output += "-> " + string(catalog->mountpoint().GetChars(),
-                           catalog->mountpoint().GetLength())
+  output += "-> "
+            + string(catalog->mountpoint().GetChars(),
+                     catalog->mountpoint().GetLength())
             + "\n";
 
-  CatalogList children = catalog->GetChildren();
-  typename CatalogList::const_iterator i = children.begin();
+  CatalogList children                      = catalog->GetChildren();
+  typename CatalogList::const_iterator i    = children.begin();
   typename CatalogList::const_iterator iend = children.end();
   for (; i != iend; ++i) {
     output += PrintHierarchyRecursively(*i, level + 1);
@@ -1191,14 +1160,13 @@ string AbstractCatalogManager<CatalogT>::PrintHierarchyRecursively(
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 std::string AbstractCatalogManager<CatalogT>::PrintMemStatsRecursively(
-  const CatalogT *catalog) const
-{
+    const CatalogT *catalog) const {
   string result = catalog->PrintMemStatistics() + "\n";
 
-  CatalogList children = catalog->GetChildren();
-  typename CatalogList::const_iterator i = children.begin();
+  CatalogList children                      = catalog->GetChildren();
+  typename CatalogList::const_iterator i    = children.begin();
   typename CatalogList::const_iterator iend = children.end();
   for (; i != iend; ++i) {
     result += PrintMemStatsRecursively(*i);
@@ -1210,7 +1178,7 @@ std::string AbstractCatalogManager<CatalogT>::PrintMemStatsRecursively(
 /**
  * Statistics from all catalogs
  */
-template <class CatalogT>
+template<class CatalogT>
 std::string AbstractCatalogManager<CatalogT>::PrintAllMemStatistics() const {
   string result;
   ReadLock();
@@ -1220,10 +1188,10 @@ std::string AbstractCatalogManager<CatalogT>::PrintAllMemStatistics() const {
 }
 
 
-template <class CatalogT>
+template<class CatalogT>
 void AbstractCatalogManager<CatalogT>::EnforceSqliteMemLimit() {
-  char *mem_enforced =
-    static_cast<char *>(pthread_getspecific(pkey_sqlitemem_));
+  char *mem_enforced = static_cast<char *>(
+      pthread_getspecific(pkey_sqlitemem_));
   if (mem_enforced == NULL) {
     sqlite3_soft_heap_limit(kSqliteMemPerThread);
     pthread_setspecific(pkey_sqlitemem_, this);
@@ -1233,7 +1201,5 @@ void AbstractCatalogManager<CatalogT>::EnforceSqliteMemLimit() {
 }  // namespace catalog
 
 
-
-
 #endif  // CVMFS_CATALOG_MGR_IMPL_H_
-//NOLINTEND
+// NOLINTEND

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -22,22 +22,18 @@
 // TODO(jblomer): the file system root should probably always return 1 for an
 // inode.  See also integration test #23.
 
-#define ENOATTR ENODATA  /**< instead of including attr/xattr.h */
+#define ENOATTR ENODATA /**< instead of including attr/xattr.h */
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
 
 // sys/xattr.h conflicts with linux/xattr.h and needs to be loaded very early
-#include <sys/xattr.h>  // NOLINT
-
-
 #include "cvmfs.h"
 
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <google/dense_hash_map>
 #include <inttypes.h>
 #include <pthread.h>
 #include <stddef.h>
@@ -50,6 +46,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/xattr.h>  // NOLINT
 #include <unistd.h>
 
 #include <algorithm>
@@ -59,6 +56,7 @@
 #include <cstring>
 #include <ctime>
 #include <functional>
+#include <google/dense_hash_map>
 #include <map>
 #include <new>
 #include <string>
@@ -125,12 +123,12 @@ using namespace std;  // NOLINT
 
 namespace cvmfs {
 
-FileSystem *file_system_ = NULL;
-MountPoint *mount_point_ = NULL;
-TalkManager *talk_mgr_ = NULL;
+FileSystem *file_system_                 = NULL;
+MountPoint *mount_point_                 = NULL;
+TalkManager *talk_mgr_                   = NULL;
 NotificationClient *notification_client_ = NULL;
-Watchdog *watchdog_ = NULL;
-FuseRemounter *fuse_remounter_ = NULL;
+Watchdog *watchdog_                      = NULL;
+FuseRemounter *fuse_remounter_           = NULL;
 InodeGenerationInfo inode_generation_info_;
 
 
@@ -139,7 +137,7 @@ InodeGenerationInfo inode_generation_info_;
  * TODO: use mmap for very large listings
  */
 struct DirectoryListing {
-  char *buffer;  /**< Filled by fuse_add_direntry */
+  char *buffer; /**< Filled by fuse_add_direntry */
 
   // Not really used anymore.  But directory listing needs to be migrated during
   // hotpatch. If buffer is allocated by smmap, capacity is zero.
@@ -150,18 +148,18 @@ struct DirectoryListing {
 };
 
 const loader::LoaderExports *loader_exports_ = NULL;
-OptionsManager *options_mgr_ = NULL;
-pid_t pid_ = 0;  /**< will be set after daemon() */
+OptionsManager *options_mgr_                 = NULL;
+pid_t pid_ = 0; /**< will be set after daemon() */
 quota::ListenerHandle *watchdog_listener_ = NULL;
-quota::ListenerHandle *unpin_listener_ = NULL;
+quota::ListenerHandle *unpin_listener_    = NULL;
 
 
 typedef google::dense_hash_map<uint64_t, DirectoryListing,
                                hash_murmur<uint64_t> >
-        DirectoryHandles;
-DirectoryHandles *directory_handles_ = NULL;
+    DirectoryHandles;
+DirectoryHandles *directory_handles_    = NULL;
 pthread_mutex_t lock_directory_handles_ = PTHREAD_MUTEX_INITIALIZER;
-uint64_t next_directory_handle_ = 0;
+uint64_t next_directory_handle_         = 0;
 
 unsigned max_open_files_; /**< maximum allowed number of open files */
 /**
@@ -185,6 +183,7 @@ class FuseInterruptCue : public InterruptCue {
   explicit FuseInterruptCue(fuse_req_t *r) : req_ptr_(r) { }
   virtual ~FuseInterruptCue() { }
   virtual bool IsCanceled() { return fuse_req_interrupted(*req_ptr_); }
+
  private:
   fuse_req_t *req_ptr_;
 };
@@ -196,7 +195,7 @@ class FuseInterruptCue : public InterruptCue {
  * Used in SaveState and RestoreState to store the details of symlink caching.
  */
 struct FuseState {
-  FuseState() : version(0), cache_symlinks(false), has_dentry_expire(false) {}
+  FuseState() : version(0), cache_symlinks(false), has_dentry_expire(false) { }
   unsigned version;
   bool cache_symlinks;
   bool has_dentry_expire;
@@ -223,7 +222,7 @@ static inline double GetKcacheTimeout() {
 
 
 void GetReloadStatus(bool *drainout_mode, bool *maintenance_mode) {
-  *drainout_mode = fuse_remounter_->IsInDrainoutMode();
+  *drainout_mode    = fuse_remounter_->IsInDrainoutMode();
   *maintenance_mode = fuse_remounter_->IsInMaintenanceMode();
 }
 
@@ -239,13 +238,13 @@ static bool UseWatchdog() {
 }
 
 std::string PrintInodeGeneration() {
-  return "init-catalog-revision: " +
-    StringifyInt(inode_generation_info_.initial_revision) + "  " +
-    "current-catalog-revision: " +
-    StringifyInt(mount_point_->catalog_mgr()->GetRevision()) + "  " +
-    "incarnation: " + StringifyInt(inode_generation_info_.incarnation) + "  " +
-    "inode generation: " + StringifyInt(inode_generation_info_.inode_generation)
-    + "\n";
+  return "init-catalog-revision: "
+         + StringifyInt(inode_generation_info_.initial_revision) + "  "
+         + "current-catalog-revision: "
+         + StringifyInt(mount_point_->catalog_mgr()->GetRevision()) + "  "
+         + "incarnation: " + StringifyInt(inode_generation_info_.incarnation)
+         + "  " + "inode generation: "
+         + StringifyInt(inode_generation_info_.inode_generation) + "\n";
 }
 
 
@@ -253,8 +252,10 @@ static bool CheckVoms(const fuse_ctx &fctx) {
   if (!mount_point_->has_membership_req())
     return true;
   string mreq = mount_point_->membership_req();
-  LogCvmfs(kLogCvmfs, kLogDebug, "Got VOMS authz %s from filesystem "
-           "properties", mreq.c_str());
+  LogCvmfs(kLogCvmfs, kLogDebug,
+           "Got VOMS authz %s from filesystem "
+           "properties",
+           mreq.c_str());
 
   if (fctx.uid == 0)
     return true;
@@ -263,15 +264,13 @@ static bool CheckVoms(const fuse_ctx &fctx) {
 }
 
 static bool MayBeInPageCacheTracker(const catalog::DirectoryEntry &dirent) {
-  return dirent.IsRegular() &&
-         (dirent.inode() < mount_point_->catalog_mgr()->GetRootInode());
+  return dirent.IsRegular()
+         && (dirent.inode() < mount_point_->catalog_mgr()->GetRootInode());
 }
 
-static bool HasDifferentContent(
-  const catalog::DirectoryEntry &dirent,
-  const shash::Any &hash,
-  const struct stat &info)
-{
+static bool HasDifferentContent(const catalog::DirectoryEntry &dirent,
+                                const shash::Any &hash,
+                                const struct stat &info) {
   if (hash == dirent.checksum())
     return false;
   // For chunked files, we don't want to load the full list of chunk hashes
@@ -292,8 +291,7 @@ static bool HasDifferentContent(
  * structure connected to this inode is taken from the page cache tracker.
  */
 static bool FixupOpenInode(const PathString &path,
-                           catalog::DirectoryEntry *dirent)
-{
+                           catalog::DirectoryEntry *dirent) {
   if (!MayBeInPageCacheTracker(*dirent))
     return false;
 
@@ -312,15 +310,14 @@ static bool FixupOpenInode(const PathString &path,
 }
 
 static bool GetDirentForInode(const fuse_ino_t ino,
-                              catalog::DirectoryEntry *dirent)
-{
+                              catalog::DirectoryEntry *dirent) {
   // Lookup inode in cache
   if (mount_point_->inode_cache()->Lookup(ino, dirent))
     return true;
 
   // Look in the catalogs in 2 steps: lookup inode->path, lookup path
-  static catalog::DirectoryEntry dirent_negative =
-    catalog::DirectoryEntry(catalog::kDirentNegative);
+  static catalog::DirectoryEntry dirent_negative = catalog::DirectoryEntry(
+      catalog::kDirentNegative);
   // Reset directory entry.  If the function returns false and dirent is no
   // the kDirentNegative, it was an I/O error
   *dirent = catalog::DirectoryEntry();
@@ -347,8 +344,8 @@ static bool GetDirentForInode(const fuse_ino_t ino,
   // Non-NFS mode
   PathString path;
   if (ino == catalog_mgr->GetRootInode()) {
-    bool retval =
-      catalog_mgr->LookupPath(PathString(), catalog::kLookupDefault, dirent);
+    bool retval = catalog_mgr->LookupPath(PathString(), catalog::kLookupDefault,
+                                          dirent);
 
     if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
                      "GetDirentForInode: Race condition? Not found dirent %s",
@@ -377,8 +374,8 @@ static bool GetDirentForInode(const fuse_ino_t ino,
   if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
     if (!inode_ex.IsCompatibleFileType(dirent->mode())) {
       LogCvmfs(kLogCvmfs, kLogDebug,
-               "Warning: inode %" PRId64 " (%s) changed file type",
-               ino, path.c_str());
+               "Warning: inode %" PRId64 " (%s) changed file type", ino,
+               path.c_str());
       // TODO(jblomer): we detect this issue but let it continue unhandled.
       // Fix me.
     }
@@ -403,15 +400,14 @@ static bool GetDirentForInode(const fuse_ino_t ino,
  *           (see FixupOpenInode)
  */
 static uint64_t GetDirentForPath(const PathString &path,
-                                 catalog::DirectoryEntry *dirent)
-{
+                                 catalog::DirectoryEntry *dirent) {
   uint64_t live_inode = 0;
   if (!file_system_->IsNfsSource())
     live_inode = mount_point_->inode_tracker()->FindInode(path);
 
   LogCvmfs(kLogCvmfs, kLogDebug,
-           "GetDirentForPath: live inode for %s: %" PRIu64,
-           path.c_str(), live_inode);
+           "GetDirentForPath: live inode for %s: %" PRIu64, path.c_str(),
+           live_inode);
 
   shash::Md5 md5path(path.GetChars(), path.GetLength());
   if (mount_point_->md5path_cache()->Lookup(md5path, dirent)) {
@@ -436,8 +432,9 @@ static uint64_t GetDirentForPath(const PathString &path,
       dirent->set_inode(live_inode);
       if (FixupOpenInode(path, dirent)) {
         LogCvmfs(kLogCvmfs, kLogDebug,
-          "content of %s change, replacing inode %" PRIu64 " --> %" PRIu64,
-          path.c_str(), live_inode, dirent->inode());
+                 "content of %s change, replacing inode %" PRIu64
+                 " --> %" PRIu64,
+                 path.c_str(), live_inode, dirent->inode());
         return live_inode;
         // Do not populate the md5path cache until the inode tracker is fixed
       }
@@ -490,14 +487,13 @@ static bool GetPathForInode(const fuse_ino_t ino, PathString *path) {
 }
 
 static void DoTraceInode(const int event,
-                          fuse_ino_t ino,
-                          const std::string &msg)
-{
+                         fuse_ino_t ino,
+                         const std::string &msg) {
   PathString path;
   bool found = GetPathForInode(ino, &path);
   if (!found) {
     LogCvmfs(kLogCvmfs, kLogDebug,
-      "Tracing: Could not find path for inode %" PRIu64, uint64_t(ino));
+             "Tracing: Could not find path for inode %" PRIu64, uint64_t(ino));
     mount_point_->tracer()->Trace(event, PathString("@UNKNOWN"), msg);
   } else {
     mount_point_->tracer()->Trace(event, path, msg);
@@ -505,10 +501,10 @@ static void DoTraceInode(const int event,
 }
 
 static void inline TraceInode(const int event,
-                                fuse_ino_t ino,
-                                const std::string &msg)
-{
-  if (mount_point_->tracer()->IsActive()) DoTraceInode(event, ino, msg);
+                              fuse_ino_t ino,
+                              const std::string &msg) {
+  if (mount_point_->tracer()->IsActive())
+    DoTraceInode(event, ino, msg);
 }
 
 /**
@@ -529,7 +525,7 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   catalog::ClientCatalogManager *catalog_mgr = mount_point_->catalog_mgr();
 
   fuse_ino_t parent_fuse = parent;
-  parent = catalog_mgr->MangleInode(parent);
+  parent                 = catalog_mgr->MangleInode(parent);
   LogCvmfs(kLogCvmfs, kLogDebug,
            "cvmfs_lookup in parent inode: %" PRIu64 " for name: %s",
            uint64_t(parent), name);
@@ -541,8 +537,8 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   struct fuse_entry_param result;
 
   memset(&result, 0, sizeof(result));
-  double timeout = GetKcacheTimeout();
-  result.attr_timeout = timeout;
+  double timeout       = GetKcacheTimeout();
+  result.attr_timeout  = timeout;
   result.entry_timeout = timeout;
 
   // Special NFS lookups: . and ..
@@ -586,7 +582,7 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
       goto lookup_reply_error;
   }
 
- lookup_reply_positive:
+lookup_reply_positive:
   mount_point_->tracer()->Trace(Tracer::kEventLookup, path, "lookup()");
   if (!file_system_->IsNfsSource()) {
     if (live_inode > 1) {
@@ -596,12 +592,12 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 
       // The new inode is put in the tracker with refcounter == 0
       bool replaced = mount_point_->inode_tracker()->ReplaceInode(
-        live_inode, glue::InodeEx(dirent.inode(), dirent.mode()));
+          live_inode, glue::InodeEx(dirent.inode(), dirent.mode()));
       if (replaced)
         perf::Inc(file_system_->n_fs_inode_replace());
     }
     mount_point_->inode_tracker()->VfsGet(
-      glue::InodeEx(dirent.inode(), dirent.mode()), path);
+        glue::InodeEx(dirent.inode(), dirent.mode()), path);
   }
   // We do _not_ track (and evict) positive replies; among other things, test
   // 076 fails with the following line uncommented
@@ -617,13 +613,14 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   }
 
   fuse_remounter_->fence()->Leave();
-  result.ino = dirent.inode();
+  result.ino  = dirent.inode();
   result.attr = dirent.GetStatStructure();
   fuse_reply_entry(req, &result);
   return;
 
- lookup_reply_negative:
-  mount_point_->tracer()->Trace(Tracer::kEventLookup, path, "lookup()-NOTFOUND");
+lookup_reply_negative:
+  mount_point_->tracer()->Trace(Tracer::kEventLookup, path,
+                                "lookup()-NOTFOUND");
   // Will be a no-op if there is no fuse cache eviction
   mount_point_->dentry_tracker()->Add(parent_fuse, name, uint64_t(timeout));
   fuse_remounter_->fence()->Leave();
@@ -632,8 +629,9 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
   fuse_reply_entry(req, &result);
   return;
 
- lookup_reply_error:
-  mount_point_->tracer()->Trace(Tracer::kEventLookup, path, "lookup()-NOTFOUND");
+lookup_reply_error:
+  mount_point_->tracer()->Trace(Tracer::kEventLookup, path,
+                                "lookup()-NOTFOUND");
   fuse_remounter_->fence()->Leave();
 
   LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "EIO (01) on %s", name);
@@ -647,13 +645,12 @@ static void cvmfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 /**
  *
  */
-static void cvmfs_forget(
-  fuse_req_t req,
-  fuse_ino_t ino,
+static void cvmfs_forget(fuse_req_t req,
+                         fuse_ino_t ino,
 #if CVMFS_USE_LIBFUSE == 2
-  unsigned long nlookup  // NOLINT
+                         unsigned long nlookup  // NOLINT
 #else
-  uint64_t nlookup
+                         uint64_t nlookup
 #endif
 ) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_forget());
@@ -673,8 +670,8 @@ static void cvmfs_forget(
            uint64_t(ino), nlookup);
 
   if (!file_system_->IsNfsSource()) {
-    bool removed =
-      mount_point_->inode_tracker()->GetVfsPutRaii().VfsPut(ino, nlookup);
+    bool removed = mount_point_->inode_tracker()->GetVfsPutRaii().VfsPut(
+        ino, nlookup);
     if (removed)
       mount_point_->page_cache_tracker()->GetEvictRaii().Evict(ino);
   }
@@ -684,11 +681,9 @@ static void cvmfs_forget(
 
 
 #if (FUSE_VERSION >= 29)
-static void cvmfs_forget_multi(
-  fuse_req_t req,
-  size_t count,
-  struct fuse_forget_data *forgets
-) {
+static void cvmfs_forget_multi(fuse_req_t req,
+                               size_t count,
+                               struct fuse_forget_data *forgets) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_forget_multi());
 
   perf::Xadd(file_system_->n_fs_forget(), count);
@@ -698,10 +693,10 @@ static void cvmfs_forget_multi(
   }
 
   {
-    glue::InodeTracker::VfsPutRaii vfs_put_raii =
-      mount_point_->inode_tracker()->GetVfsPutRaii();
-    glue::PageCacheTracker::EvictRaii evict_raii =
-      mount_point_->page_cache_tracker()->GetEvictRaii();
+    glue::InodeTracker::VfsPutRaii vfs_put_raii = mount_point_->inode_tracker()
+                                                      ->GetVfsPutRaii();
+    glue::PageCacheTracker::EvictRaii
+        evict_raii = mount_point_->page_cache_tracker()->GetEvictRaii();
     for (size_t i = 0; i < count; ++i) {
       if (forgets[i].ino == FUSE_ROOT_ID) {
         continue;
@@ -730,18 +725,16 @@ static void cvmfs_forget_multi(
  * however, change anyway when a new catalog is applied.
  */
 static void ReplyNegative(const catalog::DirectoryEntry &dirent,
-                          fuse_req_t req)
-{
+                          fuse_req_t req) {
   if (dirent.GetSpecial() == catalog::kDirentNegative) {
     fuse_reply_err(req, ENOENT);
   } else {
-    const char * name = dirent.name().c_str();
-    const char * link = dirent.symlink().c_str();
+    const char *name = dirent.name().c_str();
+    const char *link = dirent.symlink().c_str();
 
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-       "EIO (02) name=%s symlink=%s",
-       name ? name: "<unset>",
-       link ? link: "<unset>");
+             "EIO (02) name=%s symlink=%s", name ? name : "<unset>",
+             link ? link : "<unset>");
 
     perf::Inc(file_system_->n_eio_total());
     perf::Inc(file_system_->n_eio_02());
@@ -754,8 +747,7 @@ static void ReplyNegative(const catalog::DirectoryEntry &dirent,
  * Transform a cvmfs dirent into a struct stat.
  */
 static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
-                          struct fuse_file_info *fi)
-{
+                          struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_getattr());
 
   perf::Inc(file_system_->n_fs_stat());
@@ -781,12 +773,14 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
     // Serve retired inode from page cache tracker; even if we find it in the
     // catalog, we replace the dirent by the page cache tracker version to
     // not confuse open file handles
-    LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_getattr %" PRIu64 " "
-             "served from page cache tracker", ino);
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "cvmfs_getattr %" PRIu64 " "
+             "served from page cache tracker",
+             ino);
     shash::Any hash;
     struct stat info;
-    bool is_open =
-      mount_point_->page_cache_tracker()->GetInfoIfOpen(ino, &hash, &info);
+    bool is_open = mount_point_->page_cache_tracker()->GetInfoIfOpen(ino, &hash,
+                                                                     &info);
     if (is_open) {
       fuse_remounter_->fence()->Leave();
       if (found && HasDifferentContent(dirent, hash, info)) {
@@ -795,9 +789,8 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
         // trigger a fresh LOOKUP call
         uint64_t parent_ino;
         NameString name;
-        if (mount_point_->inode_tracker()->FindDentry(
-              dirent.inode(), &parent_ino, &name))
-        {
+        if (mount_point_->inode_tracker()->FindDentry(dirent.inode(),
+                                                      &parent_ino, &name)) {
           fuse_remounter_->InvalidateDentry(parent_ino, name);
         }
         perf::Inc(file_system_->n_fs_stat_stale());
@@ -854,13 +847,12 @@ static void cvmfs_readlink(fuse_req_t req, fuse_ino_t ino) {
 }
 
 
-static void AddToDirListing(const fuse_req_t req,
-                            const char *name, const struct stat *stat_info,
-                            BigVector<char> *listing)
-{
-  LogCvmfs(kLogCvmfs, kLogDebug, "Add to listing: %s, inode %" PRIu64,
-           name, uint64_t(stat_info->st_ino));
-  size_t remaining_size = listing->capacity() - listing->size();
+static void AddToDirListing(const fuse_req_t req, const char *name,
+                            const struct stat *stat_info,
+                            BigVector<char> *listing) {
+  LogCvmfs(kLogCvmfs, kLogDebug, "Add to listing: %s, inode %" PRIu64, name,
+           uint64_t(stat_info->st_ino));
+  size_t remaining_size   = listing->capacity() - listing->size();
   const size_t entry_size = fuse_add_direntry(req, NULL, 0, name, stat_info, 0);
 
   while (entry_size > remaining_size) {
@@ -871,9 +863,8 @@ static void AddToDirListing(const fuse_req_t req,
   char *buffer;
   bool large_alloc;
   listing->ShareBuffer(&buffer, &large_alloc);
-  fuse_add_direntry(req, buffer + listing->size(),
-                    remaining_size, name, stat_info,
-                    listing->size() + entry_size);
+  fuse_add_direntry(req, buffer + listing->size(), remaining_size, name,
+                    stat_info, listing->size() + entry_size);
   listing->SetSize(listing->size() + entry_size);
 }
 
@@ -882,8 +873,7 @@ static void AddToDirListing(const fuse_req_t req,
  * Open a directory for listing.
  */
 static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
-                          struct fuse_file_info *fi)
-{
+                          struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_opendir());
 
   const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
@@ -893,7 +883,7 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
 
   fuse_remounter_->fence()->Enter();
   catalog::ClientCatalogManager *catalog_mgr = mount_point_->catalog_mgr();
-  ino = catalog_mgr->MangleInode(ino);
+  ino                                        = catalog_mgr->MangleInode(ino);
   LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_opendir on inode: %" PRIu64,
            uint64_t(ino));
   if (!CheckVoms(*fuse_ctx)) {
@@ -937,9 +927,8 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
 
   // Add parent directory link
   catalog::DirectoryEntry p;
-  if (d.inode() != catalog_mgr->GetRootInode() &&
-      (GetDirentForPath(GetParentPath(path), &p) > 0))
-  {
+  if (d.inode() != catalog_mgr->GetRootInode()
+      && (GetDirentForPath(GetParentPath(path), &p) > 0)) {
     info = p.GetStatStructure();
     AddToDirListing(req, "..", &info, &fuse_listing);
   }
@@ -952,8 +941,8 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
     fuse_remounter_->fence()->Leave();
     fuse_listing.Clear();  // Buffer is shared, empty manually
 
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-         "EIO (03) on %s", path.c_str());
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "EIO (03) on %s",
+             path.c_str());
     perf::Inc(file_system_->n_eio_total());
     perf::Inc(file_system_->n_eio_03());
     fuse_reply_err(req, EIO);
@@ -975,14 +964,14 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
     }
 
     struct stat fixed_info = listing_from_catalog.AtPtr(i)->info;
-    fixed_info.st_ino = entry_dirent.inode();
+    fixed_info.st_ino      = entry_dirent.inode();
     AddToDirListing(req, listing_from_catalog.AtPtr(i)->name.c_str(),
                     &fixed_info, &fuse_listing);
   }
   fuse_remounter_->fence()->Leave();
 
   DirectoryListing stream_listing;
-  stream_listing.size = fuse_listing.size();
+  stream_listing.size     = fuse_listing.size();
   stream_listing.capacity = fuse_listing.capacity();
   bool large_alloc;
   fuse_listing.ShareBuffer(&stream_listing.buffer, &large_alloc);
@@ -996,7 +985,7 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
              "linking directory handle %lu to dir inode: %" PRIu64,
              next_directory_handle_, uint64_t(ino));
     (*directory_handles_)[next_directory_handle_] = stream_listing;
-    fi->fh = next_directory_handle_;
+    fi->fh                                        = next_directory_handle_;
     ++next_directory_handle_;
   }
   perf::Inc(file_system_->n_fs_dir_open());
@@ -1018,13 +1007,13 @@ static void cvmfs_opendir(fuse_req_t req, fuse_ino_t ino,
  * Release a directory.
  */
 static void cvmfs_releasedir(fuse_req_t req, fuse_ino_t ino,
-                             struct fuse_file_info *fi)
-{
+                             struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_releasedir());
 
   ino = mount_point_->catalog_mgr()->MangleInode(ino);
-  LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_releasedir on inode %" PRIu64
-           ", handle %lu", uint64_t(ino), fi->fh);
+  LogCvmfs(kLogCvmfs, kLogDebug,
+           "cvmfs_releasedir on inode %" PRIu64 ", handle %lu", uint64_t(ino),
+           fi->fh);
 
   int reply = 0;
 
@@ -1052,11 +1041,11 @@ static void cvmfs_releasedir(fuse_req_t req, fuse_ino_t ino,
  */
 static void ReplyBufferSlice(const fuse_req_t req, const char *buffer,
                              const size_t buffer_size, const off_t offset,
-                             const size_t max_size)
-{
+                             const size_t max_size) {
   if (offset < static_cast<int>(buffer_size)) {
-    fuse_reply_buf(req, buffer + offset,
-      std::min(static_cast<size_t>(buffer_size - offset), max_size));
+    fuse_reply_buf(
+        req, buffer + offset,
+        std::min(static_cast<size_t>(buffer_size - offset), max_size));
   } else {
     fuse_reply_buf(req, NULL, 0);
   }
@@ -1067,20 +1056,20 @@ static void ReplyBufferSlice(const fuse_req_t req, const char *buffer,
  * Read the directory listing.
  */
 static void cvmfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
-                          off_t off, struct fuse_file_info *fi)
-{
+                          off_t off, struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_readdir());
 
   LogCvmfs(kLogCvmfs, kLogDebug,
-         "cvmfs_readdir on inode %" PRIu64 " reading %lu bytes from offset %ld",
-         static_cast<uint64_t>(mount_point_->catalog_mgr()->MangleInode(ino)),
-         size, off);
+           "cvmfs_readdir on inode %" PRIu64
+           " reading %lu bytes from offset %ld",
+           static_cast<uint64_t>(mount_point_->catalog_mgr()->MangleInode(ino)),
+           size, off);
 
   DirectoryListing listing;
 
   MutexLockGuard m(&lock_directory_handles_);
-  DirectoryHandles::const_iterator iter_handle =
-    directory_handles_->find(fi->fh);
+  DirectoryHandles::const_iterator iter_handle = directory_handles_->find(
+      fi->fh);
   if (iter_handle != directory_handles_->end()) {
     listing = iter_handle->second;
 
@@ -1092,11 +1081,10 @@ static void cvmfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 }
 
 static void FillOpenFlags(const glue::PageCacheTracker::OpenDirectives od,
-                          struct fuse_file_info *fi)
-{
+                          struct fuse_file_info *fi) {
   assert(!TestBit(glue::PageCacheTracker::kBitDirectIo, fi->fh));
   fi->keep_cache = od.keep_cache;
-  fi->direct_io = od.direct_io;
+  fi->direct_io  = od.direct_io;
   if (fi->direct_io)
     SetBit(glue::PageCacheTracker::kBitDirectIo, &fi->fh);
 }
@@ -1116,8 +1104,7 @@ static const uint64_t kFileHandleIgnore = static_cast<uint64_t>(2) << 60;
  * chunked files
  */
 static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
-                       struct fuse_file_info *fi)
-{
+                       struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_open());
 
   const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
@@ -1125,7 +1112,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
   fuse_remounter_->fence()->Enter();
   catalog::ClientCatalogManager *catalog_mgr = mount_point_->catalog_mgr();
-  ino = catalog_mgr->MangleInode(ino);
+  ino                                        = catalog_mgr->MangleInode(ino);
   LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_open on inode: %" PRIu64,
            uint64_t(ino));
 
@@ -1185,8 +1172,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     if (dirent.IsDirectIo()) {
       open_directives = mount_point_->page_cache_tracker()->OpenDirect();
     } else {
-      open_directives =
-        mount_point_->page_cache_tracker()->Open(
+      open_directives = mount_point_->page_cache_tracker()->Open(
           ino, dirent.checksum(), dirent.GetStatStructure());
     }
     fuse_remounter_->fence()->Leave();
@@ -1226,13 +1212,13 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
       // Retrieve File chunks from the catalog
       UniquePtr<FileChunkList> chunks(new FileChunkList());
       if (!catalog_mgr->ListFileChunks(path, dirent.hash_algorithm(),
-                                       chunks.weak_ref()) ||
-          chunks->IsEmpty())
-      {
+                                       chunks.weak_ref())
+          || chunks->IsEmpty()) {
         fuse_remounter_->fence()->Leave();
-        LogCvmfs(kLogCvmfs, kLogDebug| kLogSyslogErr,
-           "EIO (04) file %s is marked as 'chunked', but no chunks found.",
-           path.c_str());
+        LogCvmfs(
+            kLogCvmfs, kLogDebug | kLogSyslogErr,
+            "EIO (04) file %s is marked as 'chunked', but no chunks found.",
+            path.c_str());
         perf::Inc(file_system_->n_eio_total());
         perf::Inc(file_system_->n_eio_04());
         fuse_reply_err(req, EIO);
@@ -1244,24 +1230,24 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
       // Check again to avoid race
       if (!chunk_tables->inode2chunks.Contains(unique_inode)) {
         chunk_tables->inode2chunks.Insert(
-          unique_inode, FileChunkReflist(chunks.Release(), path,
-                                         dirent.compression_algorithm(),
-                                         dirent.IsExternalFile()));
+            unique_inode, FileChunkReflist(chunks.Release(), path,
+                                           dirent.compression_algorithm(),
+                                           dirent.IsExternalFile()));
         chunk_tables->inode2references.Insert(unique_inode, 1);
       } else {
         uint32_t refctr;
-        bool retval =
-          chunk_tables->inode2references.Lookup(unique_inode, &refctr);
+        bool retval = chunk_tables->inode2references.Lookup(unique_inode,
+                                                            &refctr);
         assert(retval);
-        chunk_tables->inode2references.Insert(unique_inode, refctr+1);
+        chunk_tables->inode2references.Insert(unique_inode, refctr + 1);
       }
     } else {
       fuse_remounter_->fence()->Leave();
       uint32_t refctr;
-      bool retval =
-        chunk_tables->inode2references.Lookup(unique_inode, &refctr);
+      bool retval = chunk_tables->inode2references.Lookup(unique_inode,
+                                                          &refctr);
       assert(retval);
-      chunk_tables->inode2references.Insert(unique_inode, refctr+1);
+      chunk_tables->inode2references.Insert(unique_inode, refctr + 1);
     }
 
     // Update the chunk handle list
@@ -1275,8 +1261,8 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     // Generate artificial content hash as hash over chunk hashes
     // TODO(jblomer): we may want to cache the result in the chunk tables
     FileChunkReflist chunk_reflist;
-    bool retval =
-        chunk_tables->inode2chunks.Lookup(unique_inode, &chunk_reflist);
+    bool retval = chunk_tables->inode2chunks.Lookup(unique_inode,
+                                                    &chunk_reflist);
     assert(retval);
 
     fi->fh = chunk_tables->next_handle;
@@ -1284,7 +1270,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
       open_directives = mount_point_->page_cache_tracker()->OpenDirect();
     } else {
       open_directives = mount_point_->page_cache_tracker()->Open(
-        ino, chunk_reflist.HashChunkList(), dirent.GetStatStructure());
+          ino, chunk_reflist.HashChunkList(), dirent.GetStatStructure());
     }
     FillOpenFlags(open_directives, fi);
     fi->fh = static_cast<uint64_t>(-static_cast<int64_t>(fi->fh));
@@ -1296,23 +1282,23 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   }
 
   Fetcher *this_fetcher = dirent.IsExternalFile()
-    ? mount_point_->external_fetcher()
-    : mount_point_->fetcher();
+                              ? mount_point_->external_fetcher()
+                              : mount_point_->fetcher();
   CacheManager::Label label;
-  label.path = path.ToString();
-  label.size = dirent.size();
+  label.path          = path.ToString();
+  label.size          = dirent.size();
   label.zip_algorithm = dirent.compression_algorithm();
   if (mount_point_->catalog_mgr()->volatile_flag())
     label.flags |= CacheManager::kLabelVolatile;
   if (dirent.IsExternalFile())
     label.flags |= CacheManager::kLabelExternal;
-  fd =
-    this_fetcher->Fetch(CacheManager::LabeledObject(dirent.checksum(), label));
+  fd = this_fetcher->Fetch(
+      CacheManager::LabeledObject(dirent.checksum(), label));
 
   if (fd >= 0) {
     if (IncAndCheckNoOpenFiles()) {
-      LogCvmfs(kLogCvmfs, kLogDebug, "file %s opened (fd %d)",
-               path.c_str(), fd);
+      LogCvmfs(kLogCvmfs, kLogDebug, "file %s opened (fd %d)", path.c_str(),
+               fd);
       fi->fh = fd;
       FillOpenFlags(open_directives, fi);
       fuse_reply_open(req, fi);
@@ -1354,9 +1340,9 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   mount_point_->backoff_throttle()->Throttle();
 
   mount_point_->file_system()->io_error_info()->AddIoError();
-  if (EIO == errno  || EIO == -fd) {
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-        "EIO (06) on %s", path.c_str() );
+  if (EIO == errno || EIO == -fd) {
+    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "EIO (06) on %s",
+             path.c_str());
     perf::Inc(file_system_->n_eio_total());
     perf::Inc(file_system_->n_eio_06());
   }
@@ -1369,14 +1355,14 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
  * Redirected to pread into cache.
  */
 static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
-                       struct fuse_file_info *fi)
-{
+                       struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_read());
 
   LogCvmfs(kLogCvmfs, kLogDebug,
            "cvmfs_read inode: %" PRIu64 " reading %lu bytes from offset %ld "
-           "fd %lu", uint64_t(mount_point_->catalog_mgr()->MangleInode(ino)),
-           size, off, fi->fh);
+           "fd %lu",
+           uint64_t(mount_point_->catalog_mgr()->MangleInode(ino)), size, off,
+           fi->fh);
   perf::Inc(file_system_->n_fs_read());
 
 #ifdef __APPLE__
@@ -1387,16 +1373,17 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 #endif
 
   // Get data chunk (<=128k guaranteed by Fuse)
-  char *data = static_cast<char *>(alloca(size));
+  char *data                         = static_cast<char *>(alloca(size));
   unsigned int overall_bytes_fetched = 0;
 
-  int64_t fd = static_cast<int64_t>(fi->fh);
+  int64_t fd      = static_cast<int64_t>(fi->fh);
   uint64_t abs_fd = (fd < 0) ? -fd : fd;
   ClearBit(glue::PageCacheTracker::kBitDirectIo, &abs_fd);
 
   const struct fuse_ctx *fuse_ctx = fuse_req_ctx(req);
   FuseInterruptCue ic(&req);
-  const ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid, &ic);
+  const ClientCtxGuard ctx_guard(fuse_ctx->uid, fuse_ctx->gid, fuse_ctx->pid,
+                                 &ic);
 
   // Do we have a a chunked file?
   if (fd < 0) {
@@ -1433,31 +1420,32 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     do {
       // Open file descriptor to chunk
       if ((chunk_fd.fd == -1) || (chunk_fd.chunk_idx != chunk_idx)) {
-        if (chunk_fd.fd != -1) file_system_->cache_mgr()->Close(chunk_fd.fd);
+        if (chunk_fd.fd != -1)
+          file_system_->cache_mgr()->Close(chunk_fd.fd);
         Fetcher *this_fetcher = chunks.external_data
-          ? mount_point_->external_fetcher()
-          : mount_point_->fetcher();
+                                    ? mount_point_->external_fetcher()
+                                    : mount_point_->fetcher();
         CacheManager::Label label;
-        label.path = chunks.path.ToString();
-        label.size = chunks.list->AtPtr(chunk_idx)->size();
-        label.zip_algorithm = chunks.compression_alg;
-        label.flags |= CacheManager::kLabelChunked;
+        label.path           = chunks.path.ToString();
+        label.size           = chunks.list->AtPtr(chunk_idx)->size();
+        label.zip_algorithm  = chunks.compression_alg;
+        label.flags         |= CacheManager::kLabelChunked;
         if (mount_point_->catalog_mgr()->volatile_flag())
           label.flags |= CacheManager::kLabelVolatile;
         if (chunks.external_data) {
-          label.flags |= CacheManager::kLabelExternal;
-          label.range_offset = chunks.list->AtPtr(chunk_idx)->offset();
+          label.flags        |= CacheManager::kLabelExternal;
+          label.range_offset  = chunks.list->AtPtr(chunk_idx)->offset();
         }
         chunk_fd.fd = this_fetcher->Fetch(CacheManager::LabeledObject(
-          chunks.list->AtPtr(chunk_idx)->content_hash(), label));
+            chunks.list->AtPtr(chunk_idx)->content_hash(), label));
         if (chunk_fd.fd < 0) {
           chunk_fd.fd = -1;
           chunk_tables->Lock();
           chunk_tables->handle2fd.Insert(chunk_handle, chunk_fd);
           chunk_tables->Unlock();
 
-          LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-              "EIO (05) on %s", chunks.path.ToString().c_str() );
+          LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "EIO (05) on %s",
+                   chunks.path.ToString().c_str());
           perf::Inc(file_system_->n_eio_total());
           perf::Inc(file_system_->n_eio_05());
           fuse_reply_err(req, EIO);
@@ -1466,19 +1454,19 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
         chunk_fd.chunk_idx = chunk_idx;
       }
 
-      LogCvmfs(kLogCvmfs, kLogDebug, "reading from chunk fd %d",
-               chunk_fd.fd);
+      LogCvmfs(kLogCvmfs, kLogDebug, "reading from chunk fd %d", chunk_fd.fd);
       // Read data from chunk
-      const size_t bytes_to_read = size - overall_bytes_fetched;
-      const size_t remaining_bytes_in_chunk =
-        chunks.list->AtPtr(chunk_idx)->size() - offset_in_chunk;
-      size_t bytes_to_read_in_chunk =
-        std::min(bytes_to_read, remaining_bytes_in_chunk);
-      const int64_t bytes_fetched = file_system_->cache_mgr()->Pread(
-        chunk_fd.fd,
-        data + overall_bytes_fetched,
-        bytes_to_read_in_chunk,
-        offset_in_chunk);
+      const size_t bytes_to_read            = size - overall_bytes_fetched;
+      const size_t remaining_bytes_in_chunk = chunks.list->AtPtr(chunk_idx)
+                                                  ->size()
+                                              - offset_in_chunk;
+      size_t bytes_to_read_in_chunk = std::min(bytes_to_read,
+                                               remaining_bytes_in_chunk);
+      const int64_t bytes_fetched   = file_system_->cache_mgr()->Pread(
+          chunk_fd.fd,
+          data + overall_bytes_fetched,
+          bytes_to_read_in_chunk,
+          offset_in_chunk);
 
       if (bytes_fetched < 0) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr, "read err no %" PRId64 " (%s)",
@@ -1486,9 +1474,9 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
         chunk_tables->Lock();
         chunk_tables->handle2fd.Insert(chunk_handle, chunk_fd);
         chunk_tables->Unlock();
-        if ( EIO == errno || EIO == -bytes_fetched ) {
-          LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-             "EIO (07) on %s", chunks.path.ToString().c_str() );
+        if (EIO == errno || EIO == -bytes_fetched) {
+          LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "EIO (07) on %s",
+                   chunks.path.ToString().c_str());
           perf::Inc(file_system_->n_eio_total());
           perf::Inc(file_system_->n_eio_07());
         }
@@ -1500,8 +1488,8 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
       // Proceed to the next chunk to keep on reading data
       ++chunk_idx;
       offset_in_chunk = 0;
-    } while ((overall_bytes_fetched < size) &&
-             (chunk_idx < chunks.list->size()));
+    } while ((overall_bytes_fetched < size)
+             && (chunk_idx < chunks.list->size()));
 
     // Update chunk file descriptor
     chunk_tables->Lock();
@@ -1512,15 +1500,15 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   } else {
     int64_t nbytes = file_system_->cache_mgr()->Pread(abs_fd, data, size, off);
     if (nbytes < 0) {
-      if ( EIO == errno || EIO == -nbytes ) {
+      if (EIO == errno || EIO == -nbytes) {
         PathString path;
         bool found = GetPathForInode(ino, &path);
-        if ( found ) {
-          LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-             "EIO (08) on %s", path.ToString().c_str() );
+        if (found) {
+          LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr, "EIO (08) on %s",
+                   path.ToString().c_str());
         } else {
           LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-             "EIO (08) on <unknown inode>");
+                   "EIO (08) on <unknown inode>");
         }
         perf::Inc(file_system_->n_eio_total());
         perf::Inc(file_system_->n_eio_08());
@@ -1542,8 +1530,7 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
  * File close operation, redirected into cache.
  */
 static void cvmfs_release(fuse_req_t req, fuse_ino_t ino,
-                          struct fuse_file_info *fi)
-{
+                          struct fuse_file_info *fi) {
   HighPrecisionTimer guard_timer(file_system_->hist_fs_release());
 
   ino = mount_point_->catalog_mgr()->MangleInode(ino);
@@ -1557,7 +1544,7 @@ static void cvmfs_release(fuse_req_t req, fuse_ino_t ino,
   }
 #endif
 
-  int64_t fd = static_cast<int64_t>(fi->fh);
+  int64_t fd      = static_cast<int64_t>(fi->fh);
   uint64_t abs_fd = (fd < 0) ? -fd : fd;
   if (!TestBit(glue::PageCacheTracker::kBitDirectIo, abs_fd)) {
     mount_point_->page_cache_tracker()->Close(ino);
@@ -1634,8 +1621,7 @@ static void cvmfs_statfs(fuse_req_t req, fuse_ino_t ino) {
 
   // Unmanaged cache (no lock needed - statfs is never modified)
   if (!file_system_->cache_mgr()->quota_mgr()->HasCapability(
-       QuotaManager::kCapIntrospectSize))
-  {
+          QuotaManager::kCapIntrospectSize)) {
     LogCvmfs(kLogCvmfs, kLogDebug, "QuotaManager does not support statfs");
     fuse_reply_statfs(req, (mount_point_->statfs_cache()->info()));
     return;
@@ -1644,18 +1630,18 @@ static void cvmfs_statfs(fuse_req_t req, fuse_ino_t ino) {
   MutexLockGuard m(mount_point_->statfs_cache()->lock());
 
   const uint64_t deadline = *mount_point_->statfs_cache()->expiry_deadline();
-  struct statvfs *info = mount_point_->statfs_cache()->info();
+  struct statvfs *info    = mount_point_->statfs_cache()->info();
 
   // cached version still valid
-  if ( platform_monotonic_time() < deadline ) {
+  if (platform_monotonic_time() < deadline) {
     perf::Inc(file_system_->n_fs_statfs_cached());
     fuse_reply_statfs(req, info);
     return;
   }
 
   uint64_t available = 0;
-  uint64_t size = file_system_->cache_mgr()->quota_mgr()->GetSize();
-  uint64_t capacity = file_system_->cache_mgr()->quota_mgr()->GetCapacity();
+  uint64_t size      = file_system_->cache_mgr()->quota_mgr()->GetSize();
+  uint64_t capacity  = file_system_->cache_mgr()->quota_mgr()->GetCapacity();
   // Fuse/OS X doesn't like values < 512
   info->f_bsize = info->f_frsize = 512;
 
@@ -1665,22 +1651,22 @@ static void cvmfs_statfs(fuse_req_t req, fuse_ino_t ino) {
   } else {
     // Take values from LRU module
     info->f_blocks = capacity / info->f_bsize;
-    available = capacity - size;
+    available      = capacity - size;
   }
 
   info->f_bfree = info->f_bavail = available / info->f_bsize;
 
   // Inodes / entries
   fuse_remounter_->fence()->Enter();
-  uint64_t all_inodes = mount_point_->catalog_mgr()->all_inodes();
+  uint64_t all_inodes   = mount_point_->catalog_mgr()->all_inodes();
   uint64_t loaded_inode = mount_point_->catalog_mgr()->loaded_inodes();
-  info->f_files = all_inodes;
+  info->f_files         = all_inodes;
   info->f_ffree = info->f_favail = all_inodes - loaded_inode;
   fuse_remounter_->fence()->Leave();
 
-  *mount_point_->statfs_cache()->expiry_deadline() =
-      platform_monotonic_time()
-    + mount_point_->statfs_cache()->cache_timeout();
+  *mount_point_->statfs_cache()
+       ->expiry_deadline() = platform_monotonic_time()
+                             + mount_point_->statfs_cache()->cache_timeout();
 
   fuse_reply_statfs(req, info);
 }
@@ -1699,10 +1685,10 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
 
   fuse_remounter_->fence()->Enter();
   catalog::ClientCatalogManager *catalog_mgr = mount_point_->catalog_mgr();
-  ino = catalog_mgr->MangleInode(ino);
+  ino                                        = catalog_mgr->MangleInode(ino);
   LogCvmfs(kLogCvmfs, kLogDebug,
-           "cvmfs_getxattr on inode: %" PRIu64 " for xattr: %s",
-           uint64_t(ino), name);
+           "cvmfs_getxattr on inode: %" PRIu64 " for xattr: %s", uint64_t(ino),
+           name);
   if (!CheckVoms(*fuse_ctx)) {
     fuse_remounter_->fence()->Leave();
     fuse_reply_err(req, EACCES);
@@ -1711,9 +1697,9 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   TraceInode(Tracer::kEventGetXAttr, ino, "getxattr()");
 
   vector<string> tokens_mode_machine = SplitString(name, '~');
-  vector<string> tokens_mode_human = SplitString(name, '@');
+  vector<string> tokens_mode_human   = SplitString(name, '@');
 
-  int32_t attr_req_page = 0;
+  int32_t attr_req_page     = 0;
   MagicXattrMode xattr_mode = kXattrMachineMode;
   string attr;
 
@@ -1724,33 +1710,33 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
     const std::string token = tokens_mode_human[tokens_mode_human.size() - 1];
     if (token == "?") {
       attr_req_is_valid = true;
-      attr_req_page = -1;
+      attr_req_page     = -1;
     } else {
       if (page_num_sanitizer.IsValid(token)) {
         attr_req_is_valid = true;
-        attr_req_page = static_cast<int32_t>(String2Uint64(token));
+        attr_req_page     = static_cast<int32_t>(String2Uint64(token));
       }
     }
     xattr_mode = kXattrHumanMode;
-    attr = tokens_mode_human[0];
+    attr       = tokens_mode_human[0];
   } else if (tokens_mode_machine.size() > 1) {
-    const std::string token =
-                            tokens_mode_machine[tokens_mode_machine.size() - 1];
+    const std::string
+        token = tokens_mode_machine[tokens_mode_machine.size() - 1];
     if (token == "?") {
       attr_req_is_valid = true;
-      attr_req_page = -1;
+      attr_req_page     = -1;
     } else {
       if (page_num_sanitizer.IsValid(token)) {
         attr_req_is_valid = true;
-        attr_req_page = static_cast<int32_t>(String2Uint64(token));
+        attr_req_page     = static_cast<int32_t>(String2Uint64(token));
       }
     }
     xattr_mode = kXattrMachineMode;
-    attr = tokens_mode_machine[0];
+    attr       = tokens_mode_machine[0];
 
   } else {
     attr_req_is_valid = true;
-    attr = tokens_mode_machine[0];
+    attr              = tokens_mode_machine[0];
   }
 
   if (!attr_req_is_valid) {
@@ -1774,10 +1760,10 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   retval = GetPathForInode(ino, &path);
 
   if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
-                    "cvmfs_statfs: Race condition? "
-                    "GetPathForInode did not succeed for path %s "
-                    "(path might have not been set)",
-                    path.c_str())) {
+                   "cvmfs_statfs: Race condition? "
+                   "GetPathForInode did not succeed for path %s "
+                   "(path might have not been set)",
+                   path.c_str())) {
     fuse_remounter_->fence()->Leave();
     fuse_reply_err(req, ESTALE);
     return;
@@ -1785,14 +1771,14 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
 
   if (d.IsLink()) {
     catalog::LookupOptions lookup_options = static_cast<catalog::LookupOptions>(
-      catalog::kLookupDefault | catalog::kLookupRawSymlink);
+        catalog::kLookupDefault | catalog::kLookupRawSymlink);
     catalog::DirectoryEntry raw_symlink;
     retval = catalog_mgr->LookupPath(path, lookup_options, &raw_symlink);
 
     if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
-                    "cvmfs_statfs: Race condition? "
-                    "LookupPath did not succeed for path %s",
-                    path.c_str())) {
+                     "cvmfs_statfs: Race condition? "
+                     "LookupPath did not succeed for path %s",
+                     path.c_str())) {
       fuse_remounter_->fence()->Leave();
       fuse_reply_err(req, ESTALE);
       return;
@@ -1814,11 +1800,11 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   }
 
   bool magic_xattr_success = true;
-  MagicXattrRAIIWrapper magic_xattr(mount_point_->magic_xattr_mgr()->GetLocked(
-    attr, path, &d));
+  MagicXattrRAIIWrapper magic_xattr(
+      mount_point_->magic_xattr_mgr()->GetLocked(attr, path, &d));
   if (!magic_xattr.IsNull()) {
-    magic_xattr_success = magic_xattr->
-                              PrepareValueFencedProtected(fuse_ctx->gid);
+    magic_xattr_success = magic_xattr->PrepareValueFencedProtected(
+        fuse_ctx->gid);
   }
 
   fuse_remounter_->fence()->Leave();
@@ -1846,7 +1832,7 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
     fuse_reply_xattr(req, attribute_result.second.length());
   } else if (size >= attribute_result.second.length()) {
     fuse_reply_buf(req, &attribute_result.second[0],
-                         attribute_result.second.length());
+                   attribute_result.second.length());
   } else {
     fuse_reply_err(req, ERANGE);
   }
@@ -1860,12 +1846,11 @@ static void cvmfs_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
 
   fuse_remounter_->fence()->Enter();
   catalog::ClientCatalogManager *catalog_mgr = mount_point_->catalog_mgr();
-  ino = catalog_mgr->MangleInode(ino);
+  ino                                        = catalog_mgr->MangleInode(ino);
   TraceInode(Tracer::kEventListAttr, ino, "listxattr()");
   LogCvmfs(kLogCvmfs, kLogDebug,
            "cvmfs_listxattr on inode: %" PRIu64 ", size %zu [visibility %d]",
-           uint64_t(ino), size,
-           mount_point_->magic_xattr_mgr()->visibility());
+           uint64_t(ino), size, mount_point_->magic_xattr_mgr()->visibility());
 
   catalog::DirectoryEntry d;
   const bool found = GetDirentForInode(ino, &d);
@@ -1901,7 +1886,7 @@ static void cvmfs_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
   }
 
   string attribute_list;
-  attribute_list = mount_point_->magic_xattr_mgr()->GetListString(&d);
+  attribute_list  = mount_point_->magic_xattr_mgr()->GetListString(&d);
   attribute_list += xattrs.ListKeysPosix(attribute_list);
 
   if (size == 0) {
@@ -1931,11 +1916,11 @@ bool Evict(const string &path) {
   } else {
     FileChunkList chunks;
     mount_point_->catalog_mgr()->ListFileChunks(
-      PathString(path), dirent.hash_algorithm(), &chunks);
+        PathString(path), dirent.hash_algorithm(), &chunks);
     fuse_remounter_->fence()->Leave();
     for (unsigned i = 0; i < chunks.size(); ++i) {
-        file_system_->cache_mgr()->quota_mgr()
-           ->Remove(chunks.AtPtr(i)->content_hash());
+      file_system_->cache_mgr()->quota_mgr()->Remove(
+          chunks.AtPtr(i)->content_hash());
     }
   }
   file_system_->cache_mgr()->quota_mgr()->Remove(dirent.checksum());
@@ -1953,19 +1938,18 @@ bool Pin(const string &path) {
   }
 
   Fetcher *this_fetcher = dirent.IsExternalFile()
-    ? mount_point_->external_fetcher()
-    : mount_point_->fetcher();
+                              ? mount_point_->external_fetcher()
+                              : mount_point_->fetcher();
 
   if (!dirent.IsChunkedFile()) {
     fuse_remounter_->fence()->Leave();
   } else {
     FileChunkList chunks;
     mount_point_->catalog_mgr()->ListFileChunks(
-      PathString(path), dirent.hash_algorithm(), &chunks);
+        PathString(path), dirent.hash_algorithm(), &chunks);
     fuse_remounter_->fence()->Leave();
     for (unsigned i = 0; i < chunks.size(); ++i) {
-      bool retval =
-        file_system_->cache_mgr()->quota_mgr()->Pin(
+      bool retval = file_system_->cache_mgr()->quota_mgr()->Pin(
           chunks.AtPtr(i)->content_hash(),
           chunks.AtPtr(i)->size(),
           "Part of " + path,
@@ -1974,17 +1958,17 @@ bool Pin(const string &path) {
         return false;
       int fd = -1;
       CacheManager::Label label;
-      label.path = path;
-      label.size = chunks.AtPtr(i)->size();
-      label.zip_algorithm = dirent.compression_algorithm();
-      label.flags |= CacheManager::kLabelPinned;
-      label.flags |= CacheManager::kLabelChunked;
+      label.path           = path;
+      label.size           = chunks.AtPtr(i)->size();
+      label.zip_algorithm  = dirent.compression_algorithm();
+      label.flags         |= CacheManager::kLabelPinned;
+      label.flags         |= CacheManager::kLabelChunked;
       if (dirent.IsExternalFile()) {
-        label.flags |= CacheManager::kLabelExternal;
-        label.range_offset = chunks.AtPtr(i)->offset();
+        label.flags        |= CacheManager::kLabelExternal;
+        label.range_offset  = chunks.AtPtr(i)->offset();
       }
-      fd = this_fetcher->Fetch(CacheManager::LabeledObject(
-        chunks.AtPtr(i)->content_hash(), label));
+      fd = this_fetcher->Fetch(
+          CacheManager::LabeledObject(chunks.AtPtr(i)->content_hash(), label));
       if (fd < 0) {
         return false;
       }
@@ -1994,16 +1978,16 @@ bool Pin(const string &path) {
   }
 
   bool retval = file_system_->cache_mgr()->quota_mgr()->Pin(
-    dirent.checksum(), dirent.size(), path, false);
+      dirent.checksum(), dirent.size(), path, false);
   if (!retval)
     return false;
   CacheManager::Label label;
-  label.flags = CacheManager::kLabelPinned;
-  label.size = dirent.size();
-  label.path = path;
+  label.flags         = CacheManager::kLabelPinned;
+  label.size          = dirent.size();
+  label.path          = path;
   label.zip_algorithm = dirent.compression_algorithm();
-  int fd = this_fetcher->Fetch(
-    CacheManager::LabeledObject(dirent.checksum(), label));
+  int fd              = this_fetcher->Fetch(
+      CacheManager::LabeledObject(dirent.checksum(), label));
   if (fd < 0) {
     return false;
   }
@@ -2035,50 +2019,55 @@ static void cvmfs_init(void *userdata, struct fuse_conn_info *conn) {
 #else
     PANIC(kLogDebug | kLogSyslogErr,
           "FUSE: ACL support requested but not available in this version of "
-          "libfuse %d, aborting", FUSE_VERSION);
+          "libfuse %d, aborting",
+          FUSE_VERSION);
 #endif
   }
 
-  if ( mount_point_->cache_symlinks() ) {
+  if (mount_point_->cache_symlinks()) {
 #ifdef FUSE_CAP_CACHE_SYMLINKS
     if ((conn->capable & FUSE_CAP_CACHE_SYMLINKS) == FUSE_CAP_CACHE_SYMLINKS) {
       conn->want |= FUSE_CAP_CACHE_SYMLINKS;
       LogCvmfs(kLogCvmfs, kLogDebug, "FUSE: Enable symlink caching");
-      #ifndef FUSE_CAP_EXPIRE_ONLY
-        LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
+#ifndef FUSE_CAP_EXPIRE_ONLY
+      LogCvmfs(
+          kLogCvmfs, kLogDebug | kLogSyslogWarn,
           "FUSE: Symlink caching enabled but no support for fuse_expire_entry. "
           "Symlinks will be cached but mountpoints on top of symlinks will "
           "break! "
           "Current libfuse %d is too old; required: libfuse >= 3.16, "
           "kernel >= 6.2-rc1",
           FUSE_VERSION);
-      #endif
+#endif
     } else {
       mount_point_->DisableCacheSymlinks();
-      LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-           "FUSE: Symlink caching requested but missing fuse kernel support, "
-           "falling back to no caching");
+      LogCvmfs(
+          kLogCvmfs, kLogDebug | kLogSyslogWarn,
+          "FUSE: Symlink caching requested but missing fuse kernel support, "
+          "falling back to no caching");
     }
 #else
     mount_point_->DisableCacheSymlinks();
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-          "FUSE: Symlink caching requested but missing libfuse support, "
-          "falling back to no caching. Current libfuse %d",
-          FUSE_VERSION);
+             "FUSE: Symlink caching requested but missing libfuse support, "
+             "falling back to no caching. Current libfuse %d",
+             FUSE_VERSION);
 #endif
   }
 
 #ifdef FUSE_CAP_EXPIRE_ONLY
-  if ((conn->capable & FUSE_CAP_EXPIRE_ONLY) == FUSE_CAP_EXPIRE_ONLY &&
-       FUSE_VERSION >= FUSE_MAKE_VERSION(3, 16)) {
+  if ((conn->capable & FUSE_CAP_EXPIRE_ONLY) == FUSE_CAP_EXPIRE_ONLY
+      && FUSE_VERSION >= FUSE_MAKE_VERSION(3, 16)) {
     mount_point_->EnableFuseExpireEntry();
     LogCvmfs(kLogCvmfs, kLogDebug, "FUSE: Enable fuse_expire_entry ");
   } else if (mount_point_->cache_symlinks()) {
-    LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-      "FUSE: Symlink caching enabled but no support for fuse_expire_entry. "
-      "Symlinks will be cached but mountpoints on top of symlinks will break! "
-      "Current libfuse %d; required: libfuse >= 3.16, kernel >= 6.2-rc1",
-      FUSE_VERSION);
+    LogCvmfs(
+        kLogCvmfs, kLogDebug | kLogSyslogWarn,
+        "FUSE: Symlink caching enabled but no support for fuse_expire_entry. "
+        "Symlinks will be cached but mountpoints on top of symlinks will "
+        "break! "
+        "Current libfuse %d; required: libfuse >= 3.16, kernel >= 6.2-rc1",
+        FUSE_VERSION);
   }
 #endif
 }
@@ -2095,22 +2084,22 @@ static void SetCvmfsOperations(struct fuse_lowlevel_ops *cvmfs_operations) {
   memset(cvmfs_operations, 0, sizeof(*cvmfs_operations));
 
   // Init/Fini
-  cvmfs_operations->init         = cvmfs_init;
-  cvmfs_operations->destroy      = cvmfs_destroy;
+  cvmfs_operations->init    = cvmfs_init;
+  cvmfs_operations->destroy = cvmfs_destroy;
 
-  cvmfs_operations->lookup       = cvmfs_lookup;
-  cvmfs_operations->getattr      = cvmfs_getattr;
-  cvmfs_operations->readlink     = cvmfs_readlink;
-  cvmfs_operations->open         = cvmfs_open;
-  cvmfs_operations->read         = cvmfs_read;
-  cvmfs_operations->release      = cvmfs_release;
-  cvmfs_operations->opendir      = cvmfs_opendir;
-  cvmfs_operations->readdir      = cvmfs_readdir;
-  cvmfs_operations->releasedir   = cvmfs_releasedir;
-  cvmfs_operations->statfs       = cvmfs_statfs;
-  cvmfs_operations->getxattr     = cvmfs_getxattr;
-  cvmfs_operations->listxattr    = cvmfs_listxattr;
-  cvmfs_operations->forget       = cvmfs_forget;
+  cvmfs_operations->lookup     = cvmfs_lookup;
+  cvmfs_operations->getattr    = cvmfs_getattr;
+  cvmfs_operations->readlink   = cvmfs_readlink;
+  cvmfs_operations->open       = cvmfs_open;
+  cvmfs_operations->read       = cvmfs_read;
+  cvmfs_operations->release    = cvmfs_release;
+  cvmfs_operations->opendir    = cvmfs_opendir;
+  cvmfs_operations->readdir    = cvmfs_readdir;
+  cvmfs_operations->releasedir = cvmfs_releasedir;
+  cvmfs_operations->statfs     = cvmfs_statfs;
+  cvmfs_operations->getxattr   = cvmfs_getxattr;
+  cvmfs_operations->listxattr  = cvmfs_listxattr;
+  cvmfs_operations->forget     = cvmfs_forget;
 #if (FUSE_VERSION >= 29)
   cvmfs_operations->forget_multi = cvmfs_forget_multi;
 #endif
@@ -2131,11 +2120,11 @@ void UnregisterQuotaListener() {
 bool SendFuseFd(const std::string &socket_path) {
   int fuse_fd;
 #if (FUSE_VERSION >= 30)
-  fuse_fd = fuse_session_fd(*reinterpret_cast<struct fuse_session**>(
-    loader_exports_->fuse_channel_or_session));
+  fuse_fd = fuse_session_fd(*reinterpret_cast<struct fuse_session **>(
+      loader_exports_->fuse_channel_or_session));
 #else
-  fuse_fd = fuse_chan_fd(*reinterpret_cast<struct fuse_chan**>(
-    loader_exports_->fuse_channel_or_session));
+  fuse_fd = fuse_chan_fd(*reinterpret_cast<struct fuse_chan **>(
+      loader_exports_->fuse_channel_or_session));
 #endif
   assert(fuse_fd >= 0);
   int sock_fd = ConnectSocket(socket_path);
@@ -2154,8 +2143,8 @@ bool SendFuseFd(const std::string &socket_path) {
 
 string *g_boot_error = NULL;
 
-__attribute__((visibility("default")))
-loader::CvmfsExports *g_cvmfs_exports = NULL;
+__attribute__((
+    visibility("default"))) loader::CvmfsExports *g_cvmfs_exports = NULL;
 
 /**
  * Begin section of cvmfs.cc-specific magic extended attributes
@@ -2183,26 +2172,27 @@ class ExpiresMagicXattr : public BaseMagicXattr {
 class InodeMaxMagicXattr : public BaseMagicXattr {
   virtual void FinalizeValue() {
     result_pages_.push_back(StringifyInt(
-      cvmfs::inode_generation_info_.inode_generation +
-      xattr_mgr_->mount_point()->catalog_mgr()->inode_gauge()));
+        cvmfs::inode_generation_info_.inode_generation
+        + xattr_mgr_->mount_point()->catalog_mgr()->inode_gauge()));
   }
 };
 
 class MaxFdMagicXattr : public BaseMagicXattr {
   virtual void FinalizeValue() {
-    result_pages_.push_back(StringifyInt(
-                               cvmfs::max_open_files_ - cvmfs::kNumReservedFd));
+    result_pages_.push_back(
+        StringifyInt(cvmfs::max_open_files_ - cvmfs::kNumReservedFd));
   }
 };
 
 class PidMagicXattr : public BaseMagicXattr {
   virtual void FinalizeValue() {
-    result_pages_.push_back(StringifyInt(cvmfs::pid_)); }
+    result_pages_.push_back(StringifyInt(cvmfs::pid_));
+  }
 };
 
 class UptimeMagicXattr : public BaseMagicXattr {
-  virtual void FinalizeValue(){
-    time_t now = time(NULL);
+  virtual void FinalizeValue() {
+    time_t now      = time(NULL);
     uint64_t uptime = now - cvmfs::loader_exports_->boot_time;
     result_pages_.push_back(StringifyUint(uptime / 60));
   }
@@ -2227,12 +2217,10 @@ static void RegisterMagicXattrs() {
  * Construct a file system but prevent hanging when already mounted.  That
  * means: at most one "system" mount of any given repository name.
  */
-static FileSystem *InitSystemFs(
-  const string &mount_path,
-  const string &fqrn,
-  FileSystem::FileSystemInfo fs_info)
-{
-  fs_info.wait_workspace = false;
+static FileSystem *InitSystemFs(const string &mount_path,
+                                const string &fqrn,
+                                FileSystem::FileSystemInfo fs_info) {
+  fs_info.wait_workspace  = false;
   FileSystem *file_system = FileSystem::Create(fs_info);
 
   if (file_system->boot_status() == loader::kFailLockWorkspace) {
@@ -2243,7 +2231,7 @@ static FileSystem *InitSystemFs(
       // shutdown procedure.  Try again and wait for lock
       delete file_system;
       fs_info.wait_workspace = true;
-      file_system = FileSystem::Create(fs_info);
+      file_system            = FileSystem::Create(fs_info);
     } else {
       if (fqrn_from_xattr == fqrn) {
         LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
@@ -2251,8 +2239,8 @@ static FileSystem *InitSystemFs(
         file_system->set_boot_status(loader::kFailDoubleMount);
       } else {
         LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
-                 "CernVM-FS repository %s already mounted on %s",
-                 fqrn.c_str(), mount_path.c_str());
+                 "CernVM-FS repository %s already mounted on %s", fqrn.c_str(),
+                 mount_path.c_str());
         file_system->set_boot_status(loader::kFailOtherMount);
       }
     }
@@ -2265,10 +2253,10 @@ static FileSystem *InitSystemFs(
 static void InitOptionsMgr(const loader::LoaderExports *loader_exports) {
   if (loader_exports->version >= 3 && loader_exports->simple_options_parsing) {
     cvmfs::options_mgr_ = new SimpleOptionsParser(
-      new DefaultOptionsTemplateManager(loader_exports->repository_name));
+        new DefaultOptionsTemplateManager(loader_exports->repository_name));
   } else {
     cvmfs::options_mgr_ = new BashOptionsManager(
-      new DefaultOptionsTemplateManager(loader_exports->repository_name));
+        new DefaultOptionsTemplateManager(loader_exports->repository_name));
   }
 
   if (loader_exports->config_files != "") {
@@ -2284,7 +2272,7 @@ static void InitOptionsMgr(const loader::LoaderExports *loader_exports) {
 
 static unsigned CheckMaxOpenFiles() {
   static unsigned max_open_files;
-  static bool     already_done = false;
+  static bool already_done = false;
 
   // check number of open files (lazy evaluation)
   if (!already_done) {
@@ -2309,7 +2297,7 @@ static unsigned CheckMaxOpenFiles() {
 
 
 static int Init(const loader::LoaderExports *loader_exports) {
-  g_boot_error = new string("unknown error");
+  g_boot_error           = new string("unknown error");
   cvmfs::loader_exports_ = loader_exports;
 
   crypto::SetupLibcryptoMt();
@@ -2317,8 +2305,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   InitOptionsMgr(loader_exports);
 
   // We need logging set up before forking the watchdog
-  FileSystem::SetupLoggingStandalone(
-    *cvmfs::options_mgr_, loader_exports->repository_name);
+  FileSystem::SetupLoggingStandalone(*cvmfs::options_mgr_,
+                                     loader_exports->repository_name);
 
   // Monitor, check for maximum number of open files
   if (cvmfs::UseWatchdog()) {
@@ -2332,23 +2320,20 @@ static int Init(const loader::LoaderExports *loader_exports) {
   cvmfs::max_open_files_ = CheckMaxOpenFiles();
 
   FileSystem::FileSystemInfo fs_info;
-  fs_info.type = FileSystem::kFsFuse;
-  fs_info.name = loader_exports->repository_name;
-  fs_info.exe_path = loader_exports->program_name;
+  fs_info.type        = FileSystem::kFsFuse;
+  fs_info.name        = loader_exports->repository_name;
+  fs_info.exe_path    = loader_exports->program_name;
   fs_info.options_mgr = cvmfs::options_mgr_;
-  fs_info.foreground = loader_exports->foreground;
+  fs_info.foreground  = loader_exports->foreground;
   cvmfs::file_system_ = InitSystemFs(
-    loader_exports->mount_point,
-    loader_exports->repository_name,
-    fs_info);
+      loader_exports->mount_point, loader_exports->repository_name, fs_info);
   if (!cvmfs::file_system_->IsValid()) {
     *g_boot_error = cvmfs::file_system_->boot_error();
     return cvmfs::file_system_->boot_status();
   }
-  if ((cvmfs::file_system_->cache_mgr()->id() == kPosixCacheManager) &&
-      dynamic_cast<PosixCacheManager *>(
-        cvmfs::file_system_->cache_mgr())->do_refcount())
-  {
+  if ((cvmfs::file_system_->cache_mgr()->id() == kPosixCacheManager)
+      && dynamic_cast<PosixCacheManager *>(cvmfs::file_system_->cache_mgr())
+             ->do_refcount()) {
     cvmfs::check_fd_overflow_ = false;
   }
 
@@ -2368,10 +2353,11 @@ static int Init(const loader::LoaderExports *loader_exports) {
   LogCvmfs(kLogCvmfs, kLogDebug, "fuse inode size is %lu bits",
            sizeof(fuse_ino_t) * 8);
 
-  cvmfs::inode_generation_info_.initial_revision =
-    cvmfs::mount_point_->catalog_mgr()->GetRevision();
-  cvmfs::inode_generation_info_.inode_generation =
-    cvmfs::mount_point_->inode_annotation()->GetGeneration();
+  cvmfs::inode_generation_info_
+      .initial_revision = cvmfs::mount_point_->catalog_mgr()->GetRevision();
+  cvmfs::inode_generation_info_.inode_generation = cvmfs::mount_point_
+                                                       ->inode_annotation()
+                                                       ->GetGeneration();
   LogCvmfs(kLogCvmfs, kLogDebug, "root inode is %" PRIu64,
            uint64_t(cvmfs::mount_point_->catalog_mgr()->GetRootInode()));
 
@@ -2382,53 +2368,52 @@ static int Init(const loader::LoaderExports *loader_exports) {
 
   bool fuse_notify_invalidation = true;
   std::string buf;
-  if (cvmfs::options_mgr_->GetValue("CVMFS_FUSE_NOTIFY_INVALIDATION",
-                                    &buf)) {
+  if (cvmfs::options_mgr_->GetValue("CVMFS_FUSE_NOTIFY_INVALIDATION", &buf)) {
     if (!cvmfs::options_mgr_->IsOn(buf)) {
       fuse_notify_invalidation = false;
       cvmfs::mount_point_->dentry_tracker()->Disable();
     }
   }
-  cvmfs::fuse_remounter_ =
-      new FuseRemounter(cvmfs::mount_point_, &cvmfs::inode_generation_info_,
-                        channel_or_session, fuse_notify_invalidation);
+  cvmfs::fuse_remounter_ = new FuseRemounter(
+      cvmfs::mount_point_, &cvmfs::inode_generation_info_, channel_or_session,
+      fuse_notify_invalidation);
 
   // Control & command interface
   cvmfs::talk_mgr_ = TalkManager::Create(
-    cvmfs::mount_point_->talk_socket_path(),
-    cvmfs::mount_point_,
-    cvmfs::fuse_remounter_);
-  if ((cvmfs::mount_point_->talk_socket_uid() != 0) ||
-      (cvmfs::mount_point_->talk_socket_gid() != 0))
-  {
+      cvmfs::mount_point_->talk_socket_path(),
+      cvmfs::mount_point_,
+      cvmfs::fuse_remounter_);
+  if ((cvmfs::mount_point_->talk_socket_uid() != 0)
+      || (cvmfs::mount_point_->talk_socket_gid() != 0)) {
     uid_t tgt_uid = cvmfs::mount_point_->talk_socket_uid();
     gid_t tgt_gid = cvmfs::mount_point_->talk_socket_gid();
-    int rvi = chown(cvmfs::mount_point_->talk_socket_path().c_str(),
-                    tgt_uid, tgt_gid);
+    int rvi = chown(cvmfs::mount_point_->talk_socket_path().c_str(), tgt_uid,
+                    tgt_gid);
     if (rvi != 0) {
       *g_boot_error = std::string("failed to set talk socket ownership - ")
-        + "target " + StringifyInt(tgt_uid) + ":" + StringifyInt(tgt_uid)
-        + ", user " + StringifyInt(geteuid()) + ":" + StringifyInt(getegid());
+                      + "target " + StringifyInt(tgt_uid) + ":"
+                      + StringifyInt(tgt_uid) + ", user "
+                      + StringifyInt(geteuid()) + ":" + StringifyInt(getegid());
       return loader::kFailTalk;
     }
   }
   if (cvmfs::talk_mgr_ == NULL) {
-    *g_boot_error = "failed to initialize talk socket (" +
-                    StringifyInt(errno) + ")";
+    *g_boot_error = "failed to initialize talk socket (" + StringifyInt(errno)
+                    + ")";
     return loader::kFailTalk;
   }
 
   // Notification system client
   {
-    OptionsManager* options = cvmfs::file_system_->options_mgr();
+    OptionsManager *options = cvmfs::file_system_->options_mgr();
     if (options->IsDefined("CVMFS_NOTIFICATION_SERVER")) {
       std::string config;
       options->GetValue("CVMFS_NOTIFICATION_SERVER", &config);
       const std::string repo_name = cvmfs::mount_point_->fqrn();
-      cvmfs::notification_client_ =
-          new NotificationClient(config, repo_name, cvmfs::fuse_remounter_,
-                                 cvmfs::mount_point_->download_mgr(),
-                                 cvmfs::mount_point_->signature_mgr());
+      cvmfs::notification_client_ = new NotificationClient(
+          config, repo_name, cvmfs::fuse_remounter_,
+          cvmfs::mount_point_->download_mgr(),
+          cvmfs::mount_point_->signature_mgr());
     }
   }
 
@@ -2444,8 +2429,8 @@ static void Spawn() {
   // well-defined state
   cvmfs::pid_ = getpid();
   if (cvmfs::watchdog_) {
-    cvmfs::watchdog_->Spawn(GetCurrentWorkingDirectory() + "/stacktrace." +
-                            cvmfs::mount_point_->fqrn());
+    cvmfs::watchdog_->Spawn(GetCurrentWorkingDirectory() + "/stacktrace."
+                            + cvmfs::mount_point_->fqrn());
   }
 
   cvmfs::fuse_remounter_->Spawn();
@@ -2464,12 +2449,11 @@ static void Spawn() {
   quota_mgr->Spawn();
   if (quota_mgr->HasCapability(QuotaManager::kCapListeners)) {
     cvmfs::watchdog_listener_ = quota::RegisterWatchdogListener(
-      quota_mgr,
-      cvmfs::mount_point_->uuid()->uuid() + "-watchdog");
+        quota_mgr, cvmfs::mount_point_->uuid()->uuid() + "-watchdog");
     cvmfs::unpin_listener_ = quota::RegisterUnpinListener(
-      quota_mgr,
-      cvmfs::mount_point_->catalog_mgr(),
-      cvmfs::mount_point_->uuid()->uuid() + "-unpin");
+        quota_mgr,
+        cvmfs::mount_point_->catalog_mgr(),
+        cvmfs::mount_point_->uuid()->uuid() + "-unpin");
   }
   cvmfs::mount_point_->tracer()->Spawn();
   cvmfs::talk_mgr_->Spawn();
@@ -2527,7 +2511,7 @@ static void ShutdownMountpoint() {
   delete cvmfs::directory_handles_;
   delete cvmfs::mount_point_;
   cvmfs::directory_handles_ = NULL;
-  cvmfs::mount_point_ = NULL;
+  cvmfs::mount_point_       = NULL;
 }
 
 
@@ -2567,8 +2551,8 @@ static bool MaintenanceMode(const int fd_progress) {
   if (FuseInvalidator::HasFuseNotifyInval())
     msg_progress += "up to ";
   msg_progress += StringifyInt(static_cast<int>(
-                               cvmfs::mount_point_->kcache_timeout_sec())) +
-                  "s)\n";
+                      cvmfs::mount_point_->kcache_timeout_sec()))
+                  + "s)\n";
   SendMsg2Socket(fd_progress, msg_progress);
   cvmfs::fuse_remounter_->EnterMaintenanceMode();
   return true;
@@ -2581,102 +2565,104 @@ static bool SaveState(const int fd_progress, loader::StateList *saved_states) {
   unsigned num_open_dirs = cvmfs::directory_handles_->size();
   if (num_open_dirs != 0) {
 #ifdef DEBUGMSG
-    for (cvmfs::DirectoryHandles::iterator i =
-         cvmfs::directory_handles_->begin(),
-         iEnd = cvmfs::directory_handles_->end(); i != iEnd; ++i)
-    {
+    for (cvmfs::DirectoryHandles::iterator
+             i    = cvmfs::directory_handles_->begin(),
+             iEnd = cvmfs::directory_handles_->end();
+         i != iEnd;
+         ++i) {
       LogCvmfs(kLogCvmfs, kLogDebug, "saving dirhandle %lu", i->first);
     }
 #endif
 
-    msg_progress = "Saving open directory handles (" +
-      StringifyInt(num_open_dirs) + " handles)\n";
+    msg_progress = "Saving open directory handles ("
+                   + StringifyInt(num_open_dirs) + " handles)\n";
     SendMsg2Socket(fd_progress, msg_progress);
 
     // TODO(jblomer): should rather be saved just in a malloc'd memory block
-    cvmfs::DirectoryHandles *saved_handles =
-      new cvmfs::DirectoryHandles(*cvmfs::directory_handles_);
+    cvmfs::DirectoryHandles *saved_handles = new cvmfs::DirectoryHandles(
+        *cvmfs::directory_handles_);
     loader::SavedState *save_open_dirs = new loader::SavedState();
-    save_open_dirs->state_id = loader::kStateOpenDirs;
-    save_open_dirs->state = saved_handles;
+    save_open_dirs->state_id           = loader::kStateOpenDirs;
+    save_open_dirs->state              = saved_handles;
     saved_states->push_back(save_open_dirs);
   }
 
   if (!cvmfs::file_system_->IsNfsSource()) {
     msg_progress = "Saving inode tracker\n";
     SendMsg2Socket(fd_progress, msg_progress);
-    glue::InodeTracker *saved_inode_tracker =
-      new glue::InodeTracker(*cvmfs::mount_point_->inode_tracker());
+    glue::InodeTracker *saved_inode_tracker = new glue::InodeTracker(
+        *cvmfs::mount_point_->inode_tracker());
     loader::SavedState *state_glue_buffer = new loader::SavedState();
-    state_glue_buffer->state_id = loader::kStateGlueBufferV4;
-    state_glue_buffer->state = saved_inode_tracker;
+    state_glue_buffer->state_id           = loader::kStateGlueBufferV4;
+    state_glue_buffer->state              = saved_inode_tracker;
     saved_states->push_back(state_glue_buffer);
   }
 
   msg_progress = "Saving negative entry cache\n";
   SendMsg2Socket(fd_progress, msg_progress);
-  glue::DentryTracker *saved_dentry_tracker =
-    new glue::DentryTracker(*cvmfs::mount_point_->dentry_tracker());
+  glue::DentryTracker *saved_dentry_tracker = new glue::DentryTracker(
+      *cvmfs::mount_point_->dentry_tracker());
   loader::SavedState *state_dentry_tracker = new loader::SavedState();
-  state_dentry_tracker->state_id = loader::kStateDentryTracker;
-  state_dentry_tracker->state = saved_dentry_tracker;
+  state_dentry_tracker->state_id           = loader::kStateDentryTracker;
+  state_dentry_tracker->state              = saved_dentry_tracker;
   saved_states->push_back(state_dentry_tracker);
 
   msg_progress = "Saving page cache entry tracker\n";
   SendMsg2Socket(fd_progress, msg_progress);
-  glue::PageCacheTracker *saved_page_cache_tracker =
-    new glue::PageCacheTracker(*cvmfs::mount_point_->page_cache_tracker());
+  glue::PageCacheTracker *saved_page_cache_tracker = new glue::PageCacheTracker(
+      *cvmfs::mount_point_->page_cache_tracker());
   loader::SavedState *state_page_cache_tracker = new loader::SavedState();
-  state_page_cache_tracker->state_id = loader::kStatePageCacheTracker;
-  state_page_cache_tracker->state = saved_page_cache_tracker;
+  state_page_cache_tracker->state_id           = loader::kStatePageCacheTracker;
+  state_page_cache_tracker->state              = saved_page_cache_tracker;
   saved_states->push_back(state_page_cache_tracker);
 
   msg_progress = "Saving chunk tables\n";
   SendMsg2Socket(fd_progress, msg_progress);
   ChunkTables *saved_chunk_tables = new ChunkTables(
-    *cvmfs::mount_point_->chunk_tables());
+      *cvmfs::mount_point_->chunk_tables());
   loader::SavedState *state_chunk_tables = new loader::SavedState();
-  state_chunk_tables->state_id = loader::kStateOpenChunksV4;
-  state_chunk_tables->state = saved_chunk_tables;
+  state_chunk_tables->state_id           = loader::kStateOpenChunksV4;
+  state_chunk_tables->state              = saved_chunk_tables;
   saved_states->push_back(state_chunk_tables);
 
   msg_progress = "Saving inode generation\n";
   SendMsg2Socket(fd_progress, msg_progress);
-  cvmfs::inode_generation_info_.inode_generation +=
-    cvmfs::mount_point_->catalog_mgr()->inode_gauge();
-  cvmfs::InodeGenerationInfo *saved_inode_generation =
-    new cvmfs::InodeGenerationInfo(cvmfs::inode_generation_info_);
+  cvmfs::inode_generation_info_
+      .inode_generation += cvmfs::mount_point_->catalog_mgr()->inode_gauge();
+  cvmfs::InodeGenerationInfo
+      *saved_inode_generation = new cvmfs::InodeGenerationInfo(
+          cvmfs::inode_generation_info_);
   loader::SavedState *state_inode_generation = new loader::SavedState();
-  state_inode_generation->state_id = loader::kStateInodeGeneration;
-  state_inode_generation->state = saved_inode_generation;
+  state_inode_generation->state_id           = loader::kStateInodeGeneration;
+  state_inode_generation->state              = saved_inode_generation;
   saved_states->push_back(state_inode_generation);
 
   msg_progress = "Saving fuse state\n";
   SendMsg2Socket(fd_progress, msg_progress);
-  cvmfs::FuseState *saved_fuse_state = new cvmfs::FuseState();
-  saved_fuse_state->cache_symlinks = cvmfs::mount_point_->cache_symlinks();
-  saved_fuse_state->has_dentry_expire =
-    cvmfs::mount_point_->fuse_expire_entry();
+  cvmfs::FuseState *saved_fuse_state  = new cvmfs::FuseState();
+  saved_fuse_state->cache_symlinks    = cvmfs::mount_point_->cache_symlinks();
+  saved_fuse_state->has_dentry_expire = cvmfs::mount_point_
+                                            ->fuse_expire_entry();
   loader::SavedState *state_fuse = new loader::SavedState();
-  state_fuse->state_id = loader::kStateFuse;
-  state_fuse->state = saved_fuse_state;
+  state_fuse->state_id           = loader::kStateFuse;
+  state_fuse->state              = saved_fuse_state;
   saved_states->push_back(state_fuse);
 
   // Close open file catalogs
   ShutdownMountpoint();
 
   loader::SavedState *state_cache_mgr = new loader::SavedState();
-  state_cache_mgr->state_id = loader::kStateOpenFiles;
-  state_cache_mgr->state =
-    cvmfs::file_system_->cache_mgr()->SaveState(fd_progress);
+  state_cache_mgr->state_id           = loader::kStateOpenFiles;
+  state_cache_mgr->state = cvmfs::file_system_->cache_mgr()->SaveState(
+      fd_progress);
   saved_states->push_back(state_cache_mgr);
 
-  msg_progress = "Saving open files counter\n";
-  uint32_t *saved_num_fd =
-    new uint32_t(cvmfs::file_system_->no_open_files()->Get());
+  msg_progress           = "Saving open files counter\n";
+  uint32_t *saved_num_fd = new uint32_t(
+      cvmfs::file_system_->no_open_files()->Get());
   loader::SavedState *state_num_fd = new loader::SavedState();
-  state_num_fd->state_id = loader::kStateOpenFilesCounter;
-  state_num_fd->state = saved_num_fd;
+  state_num_fd->state_id           = loader::kStateOpenFilesCounter;
+  state_num_fd->state              = saved_num_fd;
   saved_states->push_back(state_num_fd);
 
   return true;
@@ -2684,8 +2670,7 @@ static bool SaveState(const int fd_progress, loader::StateList *saved_states) {
 
 
 static bool RestoreState(const int fd_progress,
-                         const loader::StateList &saved_states)
-{
+                         const loader::StateList &saved_states) {
   // If we have no saved version of the page cache tracker, it is unsafe
   // to start using it.  The page cache tracker has to run for the entire
   // lifetime of the mountpoint or not at all.
@@ -2695,35 +2680,40 @@ static bool RestoreState(const int fd_progress,
     if (saved_states[i]->state_id == loader::kStateOpenDirs) {
       SendMsg2Socket(fd_progress, "Restoring open directory handles... ");
       delete cvmfs::directory_handles_;
-      cvmfs::DirectoryHandles *saved_handles =
-        (cvmfs::DirectoryHandles *)saved_states[i]->state;
+      cvmfs::DirectoryHandles
+          *saved_handles = (cvmfs::DirectoryHandles *)saved_states[i]->state;
       cvmfs::directory_handles_ = new cvmfs::DirectoryHandles(*saved_handles);
       cvmfs::file_system_->no_open_dirs()->Set(
-        cvmfs::directory_handles_->size());
-      cvmfs::DirectoryHandles::const_iterator i =
-        cvmfs::directory_handles_->begin();
+          cvmfs::directory_handles_->size());
+      cvmfs::DirectoryHandles::const_iterator i = cvmfs::directory_handles_
+                                                      ->begin();
       for (; i != cvmfs::directory_handles_->end(); ++i) {
         if (i->first >= cvmfs::next_directory_handle_)
           cvmfs::next_directory_handle_ = i->first + 1;
       }
 
-      SendMsg2Socket(fd_progress,
-        StringifyInt(cvmfs::directory_handles_->size()) + " handles\n");
+      SendMsg2Socket(
+          fd_progress,
+          StringifyInt(cvmfs::directory_handles_->size()) + " handles\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateGlueBuffer) {
       SendMsg2Socket(fd_progress, "Migrating inode tracker (v1 to v4)... ");
-      compat::inode_tracker::InodeTracker *saved_inode_tracker =
-        (compat::inode_tracker::InodeTracker *)saved_states[i]->state;
-      compat::inode_tracker::Migrate(
-        saved_inode_tracker, cvmfs::mount_point_->inode_tracker());
+      compat::inode_tracker::InodeTracker
+          *saved_inode_tracker = (compat::inode_tracker::InodeTracker *)
+                                     saved_states[i]
+                                         ->state;
+      compat::inode_tracker::Migrate(saved_inode_tracker,
+                                     cvmfs::mount_point_->inode_tracker());
       SendMsg2Socket(fd_progress, " done\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateGlueBufferV2) {
       SendMsg2Socket(fd_progress, "Migrating inode tracker (v2 to v4)... ");
-      compat::inode_tracker_v2::InodeTracker *saved_inode_tracker =
-        (compat::inode_tracker_v2::InodeTracker *)saved_states[i]->state;
+      compat::inode_tracker_v2::InodeTracker
+          *saved_inode_tracker = (compat::inode_tracker_v2::InodeTracker *)
+                                     saved_states[i]
+                                         ->state;
       compat::inode_tracker_v2::Migrate(saved_inode_tracker,
                                         cvmfs::mount_point_->inode_tracker());
       SendMsg2Socket(fd_progress, " done\n");
@@ -2731,8 +2721,10 @@ static bool RestoreState(const int fd_progress,
 
     if (saved_states[i]->state_id == loader::kStateGlueBufferV3) {
       SendMsg2Socket(fd_progress, "Migrating inode tracker (v3 to v4)... ");
-      compat::inode_tracker_v3::InodeTracker *saved_inode_tracker =
-        (compat::inode_tracker_v3::InodeTracker *)saved_states[i]->state;
+      compat::inode_tracker_v3::InodeTracker
+          *saved_inode_tracker = (compat::inode_tracker_v3::InodeTracker *)
+                                     saved_states[i]
+                                         ->state;
       compat::inode_tracker_v3::Migrate(saved_inode_tracker,
                                         cvmfs::mount_point_->inode_tracker());
       SendMsg2Socket(fd_progress, " done\n");
@@ -2741,30 +2733,32 @@ static bool RestoreState(const int fd_progress,
     if (saved_states[i]->state_id == loader::kStateGlueBufferV4) {
       SendMsg2Socket(fd_progress, "Restoring inode tracker... ");
       cvmfs::mount_point_->inode_tracker()->~InodeTracker();
-      glue::InodeTracker *saved_inode_tracker =
-        (glue::InodeTracker *)saved_states[i]->state;
+      glue::InodeTracker
+          *saved_inode_tracker = (glue::InodeTracker *)saved_states[i]->state;
       new (cvmfs::mount_point_->inode_tracker())
-        glue::InodeTracker(*saved_inode_tracker);
+          glue::InodeTracker(*saved_inode_tracker);
       SendMsg2Socket(fd_progress, " done\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateDentryTracker) {
       SendMsg2Socket(fd_progress, "Restoring dentry tracker... ");
       cvmfs::mount_point_->dentry_tracker()->~DentryTracker();
-      glue::DentryTracker *saved_dentry_tracker =
-        static_cast<glue::DentryTracker *>(saved_states[i]->state);
+      glue::DentryTracker
+          *saved_dentry_tracker = static_cast<glue::DentryTracker *>(
+              saved_states[i]->state);
       new (cvmfs::mount_point_->dentry_tracker())
-        glue::DentryTracker(*saved_dentry_tracker);
+          glue::DentryTracker(*saved_dentry_tracker);
       SendMsg2Socket(fd_progress, " done\n");
     }
 
     if (saved_states[i]->state_id == loader::kStatePageCacheTracker) {
       SendMsg2Socket(fd_progress, "Restoring page cache entry tracker... ");
       cvmfs::mount_point_->page_cache_tracker()->~PageCacheTracker();
-      glue::PageCacheTracker *saved_page_cache_tracker =
-        (glue::PageCacheTracker *)saved_states[i]->state;
+      glue::PageCacheTracker
+          *saved_page_cache_tracker = (glue::PageCacheTracker *)saved_states[i]
+                                          ->state;
       new (cvmfs::mount_point_->page_cache_tracker())
-        glue::PageCacheTracker(*saved_page_cache_tracker);
+          glue::PageCacheTracker(*saved_page_cache_tracker);
       SendMsg2Socket(fd_progress, " done\n");
     }
 
@@ -2772,48 +2766,57 @@ static bool RestoreState(const int fd_progress,
 
     if (saved_states[i]->state_id == loader::kStateOpenChunks) {
       SendMsg2Socket(fd_progress, "Migrating chunk tables (v1 to v4)... ");
-      compat::chunk_tables::ChunkTables *saved_chunk_tables =
-        (compat::chunk_tables::ChunkTables *)saved_states[i]->state;
+      compat::chunk_tables::ChunkTables
+          *saved_chunk_tables = (compat::chunk_tables::ChunkTables *)
+                                    saved_states[i]
+                                        ->state;
       compat::chunk_tables::Migrate(saved_chunk_tables, chunk_tables);
-      SendMsg2Socket(fd_progress,
-        StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
+      SendMsg2Socket(
+          fd_progress,
+          StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateOpenChunksV2) {
       SendMsg2Socket(fd_progress, "Migrating chunk tables (v2 to v4)... ");
-      compat::chunk_tables_v2::ChunkTables *saved_chunk_tables =
-        (compat::chunk_tables_v2::ChunkTables *)saved_states[i]->state;
+      compat::chunk_tables_v2::ChunkTables
+          *saved_chunk_tables = (compat::chunk_tables_v2::ChunkTables *)
+                                    saved_states[i]
+                                        ->state;
       compat::chunk_tables_v2::Migrate(saved_chunk_tables, chunk_tables);
-      SendMsg2Socket(fd_progress,
-        StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
+      SendMsg2Socket(
+          fd_progress,
+          StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateOpenChunksV3) {
       SendMsg2Socket(fd_progress, "Migrating chunk tables (v3 to v4)... ");
-      compat::chunk_tables_v3::ChunkTables *saved_chunk_tables =
-        (compat::chunk_tables_v3::ChunkTables *)saved_states[i]->state;
+      compat::chunk_tables_v3::ChunkTables
+          *saved_chunk_tables = (compat::chunk_tables_v3::ChunkTables *)
+                                    saved_states[i]
+                                        ->state;
       compat::chunk_tables_v3::Migrate(saved_chunk_tables, chunk_tables);
-      SendMsg2Socket(fd_progress,
-        StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
+      SendMsg2Socket(
+          fd_progress,
+          StringifyInt(chunk_tables->handle2fd.size()) + " handles\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateOpenChunksV4) {
       SendMsg2Socket(fd_progress, "Restoring chunk tables... ");
       chunk_tables->~ChunkTables();
       ChunkTables *saved_chunk_tables = reinterpret_cast<ChunkTables *>(
-        saved_states[i]->state);
+          saved_states[i]->state);
       new (chunk_tables) ChunkTables(*saved_chunk_tables);
       SendMsg2Socket(fd_progress, " done\n");
     }
 
     if (saved_states[i]->state_id == loader::kStateInodeGeneration) {
       SendMsg2Socket(fd_progress, "Restoring inode generation... ");
-      cvmfs::InodeGenerationInfo *old_info =
-        (cvmfs::InodeGenerationInfo *)saved_states[i]->state;
+      cvmfs::InodeGenerationInfo
+          *old_info = (cvmfs::InodeGenerationInfo *)saved_states[i]->state;
       if (old_info->version == 1) {
         // Migration
-        cvmfs::inode_generation_info_.initial_revision =
-          old_info->initial_revision;
+        cvmfs::inode_generation_info_.initial_revision = old_info
+                                                             ->initial_revision;
         cvmfs::inode_generation_info_.incarnation = old_info->incarnation;
         // Note: in the rare case of inode generation being 0 before, inode
         // can clash after reload before remount
@@ -2826,8 +2829,8 @@ static bool RestoreState(const int fd_progress,
 
     if (saved_states[i]->state_id == loader::kStateOpenFilesCounter) {
       SendMsg2Socket(fd_progress, "Restoring open files counter... ");
-      cvmfs::file_system_->no_open_files()->Set(*(reinterpret_cast<uint32_t *>(
-        saved_states[i]->state)));
+      cvmfs::file_system_->no_open_files()->Set(
+          *(reinterpret_cast<uint32_t *>(saved_states[i]->state)));
       SendMsg2Socket(fd_progress, " done\n");
     }
 
@@ -2836,44 +2839,44 @@ static bool RestoreState(const int fd_progress,
 
       // TODO(jblomer): make this less hacky
 
-      CacheManagerIds saved_type =
-        cvmfs::file_system_->cache_mgr()->PeekState(saved_states[i]->state);
+      CacheManagerIds saved_type = cvmfs::file_system_->cache_mgr()->PeekState(
+          saved_states[i]->state);
       int fixup_root_fd = -1;
 
-      if ((saved_type == kStreamingCacheManager) &&
-          (cvmfs::file_system_->cache_mgr()->id() != kStreamingCacheManager))
-      {
+      if ((saved_type == kStreamingCacheManager)
+          && (cvmfs::file_system_->cache_mgr()->id()
+              != kStreamingCacheManager)) {
         // stick to the streaming cache manager
-        StreamingCacheManager *new_cache_mgr = new
-          StreamingCacheManager(cvmfs::max_open_files_,
-                                cvmfs::file_system_->cache_mgr(),
-                                cvmfs::mount_point_->download_mgr(),
-                                cvmfs::mount_point_->external_download_mgr(),
-                                StreamingCacheManager::kDefaultBufferSize,
-                                cvmfs::file_system_->statistics());
+        StreamingCacheManager *new_cache_mgr = new StreamingCacheManager(
+            cvmfs::max_open_files_,
+            cvmfs::file_system_->cache_mgr(),
+            cvmfs::mount_point_->download_mgr(),
+            cvmfs::mount_point_->external_download_mgr(),
+            StreamingCacheManager::kDefaultBufferSize,
+            cvmfs::file_system_->statistics());
         fixup_root_fd = new_cache_mgr->PlantFd(old_root_fd);
         cvmfs::file_system_->ReplaceCacheManager(new_cache_mgr);
         cvmfs::mount_point_->fetcher()->ReplaceCacheManager(new_cache_mgr);
         cvmfs::mount_point_->external_fetcher()->ReplaceCacheManager(
-          new_cache_mgr);
+            new_cache_mgr);
       }
 
-      if ((cvmfs::file_system_->cache_mgr()->id() == kStreamingCacheManager) &&
-          (saved_type != kStreamingCacheManager))
-      {
+      if ((cvmfs::file_system_->cache_mgr()->id() == kStreamingCacheManager)
+          && (saved_type != kStreamingCacheManager)) {
         // stick to the cache manager wrapped into the streaming cache
         CacheManager *wrapped_cache_mgr = dynamic_cast<StreamingCacheManager *>(
-            cvmfs::file_system_->cache_mgr())->MoveOutBackingCacheMgr(
-              &fixup_root_fd);
+                                              cvmfs::file_system_->cache_mgr())
+                                              ->MoveOutBackingCacheMgr(
+                                                  &fixup_root_fd);
         delete cvmfs::file_system_->cache_mgr();
         cvmfs::file_system_->ReplaceCacheManager(wrapped_cache_mgr);
         cvmfs::mount_point_->fetcher()->ReplaceCacheManager(wrapped_cache_mgr);
         cvmfs::mount_point_->external_fetcher()->ReplaceCacheManager(
-          wrapped_cache_mgr);
+            wrapped_cache_mgr);
       }
 
       int new_root_fd = cvmfs::file_system_->cache_mgr()->RestoreState(
-        fd_progress, saved_states[i]->state);
+          fd_progress, saved_states[i]->state);
       LogCvmfs(kLogCvmfs, kLogDebug, "new root file catalog descriptor @%d",
                new_root_fd);
       if (new_root_fd >= 0) {
@@ -2887,8 +2890,8 @@ static bool RestoreState(const int fd_progress,
 
     if (saved_states[i]->state_id == loader::kStateFuse) {
       SendMsg2Socket(fd_progress, "Restoring fuse state... ");
-      cvmfs::FuseState *fuse_state =
-        static_cast<cvmfs::FuseState *>(saved_states[i]->state);
+      cvmfs::FuseState *fuse_state = static_cast<cvmfs::FuseState *>(
+          saved_states[i]->state);
       if (!fuse_state->cache_symlinks)
         cvmfs::mount_point_->DisableCacheSymlinks();
       if (fuse_state->has_dentry_expire)
@@ -2906,8 +2909,7 @@ static bool RestoreState(const int fd_progress,
 
 
 static void FreeSavedState(const int fd_progress,
-                           const loader::StateList &saved_states)
-{
+                           const loader::StateList &saved_states) {
   for (unsigned i = 0, l = saved_states.size(); i < l; ++i) {
     switch (saved_states[i]->state_id) {
       case loader::kStateOpenDirs:
@@ -2915,22 +2917,22 @@ static void FreeSavedState(const int fd_progress,
         delete static_cast<cvmfs::DirectoryHandles *>(saved_states[i]->state);
         break;
       case loader::kStateGlueBuffer:
-        SendMsg2Socket(
-          fd_progress, "Releasing saved glue buffer (version 1)\n");
+        SendMsg2Socket(fd_progress,
+                       "Releasing saved glue buffer (version 1)\n");
         delete static_cast<compat::inode_tracker::InodeTracker *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateGlueBufferV2:
-        SendMsg2Socket(
-          fd_progress, "Releasing saved glue buffer (version 2)\n");
+        SendMsg2Socket(fd_progress,
+                       "Releasing saved glue buffer (version 2)\n");
         delete static_cast<compat::inode_tracker_v2::InodeTracker *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateGlueBufferV3:
-        SendMsg2Socket(
-          fd_progress, "Releasing saved glue buffer (version 3)\n");
+        SendMsg2Socket(fd_progress,
+                       "Releasing saved glue buffer (version 3)\n");
         delete static_cast<compat::inode_tracker_v3::InodeTracker *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateGlueBufferV4:
         SendMsg2Socket(fd_progress, "Releasing saved glue buffer\n");
@@ -2947,17 +2949,17 @@ static void FreeSavedState(const int fd_progress,
       case loader::kStateOpenChunks:
         SendMsg2Socket(fd_progress, "Releasing chunk tables (version 1)\n");
         delete static_cast<compat::chunk_tables::ChunkTables *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateOpenChunksV2:
         SendMsg2Socket(fd_progress, "Releasing chunk tables (version 2)\n");
         delete static_cast<compat::chunk_tables_v2::ChunkTables *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateOpenChunksV3:
         SendMsg2Socket(fd_progress, "Releasing chunk tables (version 3)\n");
         delete static_cast<compat::chunk_tables_v3::ChunkTables *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateOpenChunksV4:
         SendMsg2Socket(fd_progress, "Releasing chunk tables\n");
@@ -2966,11 +2968,11 @@ static void FreeSavedState(const int fd_progress,
       case loader::kStateInodeGeneration:
         SendMsg2Socket(fd_progress, "Releasing saved inode generation info\n");
         delete static_cast<cvmfs::InodeGenerationInfo *>(
-          saved_states[i]->state);
+            saved_states[i]->state);
         break;
       case loader::kStateOpenFiles:
-        cvmfs::file_system_->cache_mgr()->FreeState(
-          fd_progress, saved_states[i]->state);
+        cvmfs::file_system_->cache_mgr()->FreeState(fd_progress,
+                                                    saved_states[i]->state);
         break;
       case loader::kStateOpenFilesCounter:
         SendMsg2Socket(fd_progress, "Releasing open files counter\n");
@@ -2988,17 +2990,17 @@ static void FreeSavedState(const int fd_progress,
 
 
 static void __attribute__((constructor)) LibraryMain() {
-  g_cvmfs_exports = new loader::CvmfsExports();
-  g_cvmfs_exports->so_version = CVMFS_VERSION;
+  g_cvmfs_exports                     = new loader::CvmfsExports();
+  g_cvmfs_exports->so_version         = CVMFS_VERSION;
   g_cvmfs_exports->fnAltProcessFlavor = AltProcessFlavor;
-  g_cvmfs_exports->fnInit = Init;
-  g_cvmfs_exports->fnSpawn = Spawn;
-  g_cvmfs_exports->fnFini = Fini;
-  g_cvmfs_exports->fnGetErrorMsg = GetErrorMsg;
-  g_cvmfs_exports->fnMaintenanceMode = MaintenanceMode;
-  g_cvmfs_exports->fnSaveState = SaveState;
-  g_cvmfs_exports->fnRestoreState = RestoreState;
-  g_cvmfs_exports->fnFreeSavedState = FreeSavedState;
+  g_cvmfs_exports->fnInit             = Init;
+  g_cvmfs_exports->fnSpawn            = Spawn;
+  g_cvmfs_exports->fnFini             = Fini;
+  g_cvmfs_exports->fnGetErrorMsg      = GetErrorMsg;
+  g_cvmfs_exports->fnMaintenanceMode  = MaintenanceMode;
+  g_cvmfs_exports->fnSaveState        = SaveState;
+  g_cvmfs_exports->fnRestoreState     = RestoreState;
+  g_cvmfs_exports->fnFreeSavedState   = FreeSavedState;
   cvmfs::SetCvmfsOperations(&g_cvmfs_exports->cvmfs_operations);
 }
 

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -57,16 +57,16 @@ enum Failures {
 
 inline const char *Code2Ascii(const Failures error) {
   const char *texts[kFailNumEntries + 1];
-  texts[0] = "OK";
-  texts[1] = "unknown error";
-  texts[2] = "illegal options";
-  texts[3] = "permission denied";
-  texts[4] = "failed to mount";
-  texts[5] = "unable to init loader talk socket";
-  texts[6] = "cannot run FUSE event loop";
-  texts[7] = "failed to load shared library";
-  texts[8] = "incompatible library version";
-  texts[9] = "cache directory/plugin problem";
+  texts[0]  = "OK";
+  texts[1]  = "unknown error";
+  texts[2]  = "illegal options";
+  texts[3]  = "permission denied";
+  texts[4]  = "failed to mount";
+  texts[5]  = "unable to init loader talk socket";
+  texts[6]  = "cannot run FUSE event loop";
+  texts[7]  = "failed to load shared library";
+  texts[8]  = "incompatible library version";
+  texts[9]  = "cache directory/plugin problem";
   texts[10] = "peering problem";
   texts[11] = "NFS maps init failure";
   texts[12] = "quota init failure";
@@ -90,21 +90,21 @@ inline const char *Code2Ascii(const Failures error) {
 
 enum StateId {
   kStateUnknown = 0,
-  kStateOpenDirs,           // >= 2.1.4
-  kStateOpenChunks,         // >= 2.1.4, used as of 2.1.15
-  kStateGlueBuffer,         // >= 2.1.9
-  kStateInodeGeneration,    // >= 2.1.9
-  kStateOpenFilesCounter,   // >= 2.1.9
-  kStateGlueBufferV2,       // >= 2.1.10
-  kStateGlueBufferV3,       // >= 2.1.15
-  kStateGlueBufferV4,       // >= 2.1.20
-  kStateOpenChunksV2,       // >= 2.1.20
-  kStateOpenChunksV3,       // >= 2.2.0
-  kStateOpenChunksV4,       // >= 2.2.3
-  kStateOpenFiles,          // >= 2.4
-  kStateDentryTracker,      // >= 2.7 (renamed from kStateNentryTracker in 2.10)
-  kStatePageCacheTracker,   // >= 2.10
-  kStateFuse                // >= 2.11
+  kStateOpenDirs,          // >= 2.1.4
+  kStateOpenChunks,        // >= 2.1.4, used as of 2.1.15
+  kStateGlueBuffer,        // >= 2.1.9
+  kStateInodeGeneration,   // >= 2.1.9
+  kStateOpenFilesCounter,  // >= 2.1.9
+  kStateGlueBufferV2,      // >= 2.1.10
+  kStateGlueBufferV3,      // >= 2.1.15
+  kStateGlueBufferV4,      // >= 2.1.20
+  kStateOpenChunksV2,      // >= 2.1.20
+  kStateOpenChunksV3,      // >= 2.2.0
+  kStateOpenChunksV4,      // >= 2.2.3
+  kStateOpenFiles,         // >= 2.4
+  kStateDentryTracker,     // >= 2.7 (renamed from kStateNentryTracker in 2.10)
+  kStatePageCacheTracker,  // >= 2.10
+  kStateFuse               // >= 2.11
 
   // Note: kStateOpenFilesXXX was renamed to kStateOpenChunksXXX as of 2.4
 };
@@ -112,10 +112,10 @@ enum StateId {
 
 struct SavedState {
   SavedState() {
-    version = 1;
-    size = sizeof(SavedState);
+    version  = 1;
+    size     = sizeof(SavedState);
     state_id = kStateUnknown;
-    state = NULL;
+    state    = NULL;
   }
 
   uint32_t version;
@@ -128,8 +128,8 @@ typedef std::vector<SavedState *> StateList;
 
 struct LoadEvent {
   LoadEvent() {
-    version = 1;
-    size = sizeof(LoadEvent);
+    version   = 1;
+    size      = sizeof(LoadEvent);
     timestamp = 0;
   }
 
@@ -155,19 +155,17 @@ typedef std::vector<LoadEvent *> EventList;
  * CernVM-FS 2.8.2 --> Version 5, add device_id
  */
 struct LoaderExports {
-  LoaderExports() :
-    version(5),
-    size(sizeof(LoaderExports)),
-    boot_time(0),
-    foreground(false),
-    disable_watchdog(false),
-    simple_options_parsing(false),
-    fuse_channel_or_session(NULL)
-  { }
+  LoaderExports()
+      : version(5)
+      , size(sizeof(LoaderExports))
+      , boot_time(0)
+      , foreground(false)
+      , disable_watchdog(false)
+      , simple_options_parsing(false)
+      , fuse_channel_or_session(NULL) { }
 
   ~LoaderExports() {
-    for (unsigned i = 0; i < history.size(); ++i)
-      delete history[i];
+    for (unsigned i = 0; i < history.size(); ++i) delete history[i];
   }
 
   uint32_t version;
@@ -212,17 +210,17 @@ struct LoaderExports {
  */
 struct CvmfsExports {
   CvmfsExports() {
-    version = 1;
-    size = sizeof(CvmfsExports);
+    version            = 1;
+    size               = sizeof(CvmfsExports);
     fnAltProcessFlavor = NULL;
-    fnInit = NULL;
-    fnSpawn = NULL;
-    fnFini = NULL;
-    fnGetErrorMsg = NULL;
-    fnMaintenanceMode = NULL;
-    fnSaveState = NULL;
-    fnRestoreState = NULL;
-    fnFreeSavedState = NULL;
+    fnInit             = NULL;
+    fnSpawn            = NULL;
+    fnFini             = NULL;
+    fnGetErrorMsg      = NULL;
+    fnMaintenanceMode  = NULL;
+    fnSaveState        = NULL;
+    fnRestoreState     = NULL;
+    fnFreeSavedState   = NULL;
     memset(&cvmfs_operations, 0, sizeof(cvmfs_operations));
   }
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -77,8 +77,8 @@
 using namespace std;  // NOLINT
 
 
-bool FileSystem::g_alive = false;
-const char *FileSystem::kDefaultCacheBase = "/var/lib/cvmfs";
+bool FileSystem::g_alive                         = false;
+const char *FileSystem::kDefaultCacheBase        = "/var/lib/cvmfs";
 const char *FileSystem::kDefaultCacheMgrInstance = "default";
 
 
@@ -101,7 +101,6 @@ int64_t FileSystem::IoErrorInfo::count() { return counter_->Get(); }
 time_t FileSystem::IoErrorInfo::timestamp_last() { return timestamp_last_; }
 
 
-
 /**
  * A cache instance name is part of a bash parameter and can only contain
  * certain characters.
@@ -111,8 +110,8 @@ bool FileSystem::CheckInstanceName(const std::string &instance) {
     return false;
   sanitizer::CacheInstanceSanitizer instance_sanitizer;
   if (!instance_sanitizer.IsValid(instance)) {
-    boot_error_ = "invalid instance name (" + instance + "), " +
-                  "only characters a-z, A-Z, 0-9, _ are allowed";
+    boot_error_ = "invalid instance name (" + instance + "), "
+                  + "only characters a-z, A-Z, 0-9, _ are allowed";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -124,17 +123,16 @@ bool FileSystem::CheckInstanceName(const std::string &instance) {
  * Not all possible combinations of cache flags / modes are valid.
  */
 bool FileSystem::CheckPosixCacheSettings(
-  const FileSystem::PosixCacheSettings &settings)
-{
+    const FileSystem::PosixCacheSettings &settings) {
   if (settings.is_alien && settings.is_shared) {
-    boot_error_ = "Failure: shared local disk cache and alien cache mutually "
-                  "exclusive. Please turn off shared local disk cache.";
+    boot_error_  = "Failure: shared local disk cache and alien cache mutually "
+                   "exclusive. Please turn off shared local disk cache.";
     boot_status_ = loader::kFailOptions;
     return false;
   }
   if (settings.is_alien && settings.is_managed) {
-    boot_error_ = "Failure: quota management and alien cache mutually "
-                  "exclusive. Please turn off quota limit.";
+    boot_error_  = "Failure: quota management and alien cache mutually "
+                   "exclusive. Please turn off quota limit.";
     boot_status_ = loader::kFailOptions;
     return false;
   }
@@ -149,8 +147,8 @@ bool FileSystem::CheckPosixCacheSettings(
   }
 
   if (settings.cache_base_defined && settings.cache_dir_defined) {
-    boot_error_ =
-      "'CVMFS_CACHE_BASE' and 'CVMFS_CACHE_DIR' are mutually exclusive";
+    boot_error_  = "'CVMFS_CACHE_BASE' and 'CVMFS_CACHE_DIR' are mutually "
+                   "exclusive";
     boot_status_ = loader::kFailOptions;
     return false;
   }
@@ -164,8 +162,7 @@ bool FileSystem::CheckPosixCacheSettings(
  * method.
  */
 FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
-  UniquePtr<FileSystem>
-    file_system(new FileSystem(fs_info));
+  UniquePtr<FileSystem> file_system(new FileSystem(fs_info));
 
   file_system->SetupGlobalEnvironmentParams();
 
@@ -182,7 +179,7 @@ FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
 
   // Redirect SQlite temp directory to workspace (global variable)
   unsigned length_tempdir = file_system->workspace_.length() + 1;
-  sqlite3_temp_directory = static_cast<char *>(sqlite3_malloc(length_tempdir));
+  sqlite3_temp_directory  = static_cast<char *>(sqlite3_malloc(length_tempdir));
   snprintf(sqlite3_temp_directory,
            length_tempdir,
            "%s",
@@ -193,10 +190,9 @@ FileSystem *FileSystem::Create(const FileSystem::FileSystemInfo &fs_info) {
   file_system->SetupUuid();
   if (!file_system->SetupNfsMaps())
     return file_system.Release();
-  bool retval = sqlite::RegisterVfsRdOnly(
-    file_system->cache_mgr_,
-    file_system->statistics_,
-    sqlite::kVfsOptDefault);
+  bool retval = sqlite::RegisterVfsRdOnly(file_system->cache_mgr_,
+                                          file_system->statistics_,
+                                          sqlite::kVfsOptDefault);
   assert(retval);
   file_system->has_custom_sqlitevfs_ = true;
 
@@ -219,73 +215,77 @@ void FileSystem::CreateStatistics() {
   statistics_->Register("linkstring.n_overflows", "Number of overflows");
 
   // Callback counters
-  n_fs_open_ = statistics_->Register("cvmfs.n_fs_open",
-                                     "Overall number of file open operations");
-  n_fs_dir_open_ = statistics_->Register("cvmfs.n_fs_dir_open",
-                   "Overall number of directory open operations");
-  n_fs_lookup_ = statistics_->Register("cvmfs.n_fs_lookup",
-                                       "Number of lookups");
+  n_fs_open_     = statistics_->Register("cvmfs.n_fs_open",
+                                         "Overall number of file open operations");
+  n_fs_dir_open_ = statistics_->Register(
+      "cvmfs.n_fs_dir_open", "Overall number of directory open operations");
+  n_fs_lookup_          = statistics_->Register("cvmfs.n_fs_lookup",
+                                                "Number of lookups");
   n_fs_lookup_negative_ = statistics_->Register("cvmfs.n_fs_lookup_negative",
                                                 "Number of negative lookups");
   n_fs_stat_ = statistics_->Register("cvmfs.n_fs_stat", "Number of stats");
-  n_fs_stat_stale_ = statistics_->Register("cvmfs.n_fs_stat_stale",
-    "Number of stats for stale (open, meanwhile changed) regular files");
-  n_fs_statfs_ = statistics_->Register("cvmfs.n_fs_statfs",
-                                       "Overall number of statsfs calls");
-  n_fs_statfs_cached_ = statistics_->Register("cvmfs.n_fs_statfs_cached",
-                "Number of statsfs calls that accessed the cached statfs info");
+  n_fs_stat_stale_ = statistics_->Register(
+      "cvmfs.n_fs_stat_stale",
+      "Number of stats for stale (open, meanwhile changed) regular files");
+  n_fs_statfs_        = statistics_->Register("cvmfs.n_fs_statfs",
+                                              "Overall number of statsfs calls");
+  n_fs_statfs_cached_ = statistics_->Register(
+      "cvmfs.n_fs_statfs_cached",
+      "Number of statsfs calls that accessed the cached statfs info");
   n_fs_read_ = statistics_->Register("cvmfs.n_fs_read", "Number of files read");
-  n_fs_readlink_ = statistics_->Register("cvmfs.n_fs_readlink",
-                                         "Number of links read");
-  n_fs_forget_ = statistics_->Register("cvmfs.n_fs_forget",
-                                       "Number of inode forgets");
-  n_fs_inode_replace_ = statistics_->Register("cvmfs.n_fs_inode_replace",
-    "Number of stale inodes that got replaced by an up-to-date version");
+  n_fs_readlink_      = statistics_->Register("cvmfs.n_fs_readlink",
+                                              "Number of links read");
+  n_fs_forget_        = statistics_->Register("cvmfs.n_fs_forget",
+                                              "Number of inode forgets");
+  n_fs_inode_replace_ = statistics_->Register(
+      "cvmfs.n_fs_inode_replace",
+      "Number of stale inodes that got replaced by an up-to-date version");
   no_open_files_ = statistics_->Register("cvmfs.no_open_files",
                                          "Number of currently opened files");
-  no_open_dirs_ = statistics_->Register("cvmfs.no_open_dirs",
-                  "Number of currently opened directories");
-  io_error_info_.SetCounter(statistics_->Register("cvmfs.n_io_error",
-                                                  "Number of I/O errors"));
-  n_eio_total_ =  statistics_->Register("eio.total",
-     "EIO returned to calling process. Sum of individual eio counters");
-  n_eio_01_ =  statistics_->Register("eio.01",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_lookup()");
-  n_eio_02_ =  statistics_->Register("eio.02",
-     "EIO returned to calling process. cvmfs.cc:ReplyNegative()");
-  n_eio_03_ =  statistics_->Register("eio.03",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_opendir()");
-  n_eio_04_ =  statistics_->Register("eio.04",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_open()");
-  n_eio_05_ =  statistics_->Register("eio.05",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
-  n_eio_06_ =  statistics_->Register("eio.06",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_open()");
-  n_eio_07_ =  statistics_->Register("eio.07",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
-  n_eio_08_ =  statistics_->Register("eio.08",
-     "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
-  n_emfile_ =  statistics_->Register("eio.emfile",
-     "EMFILE returned to calling process. cvmfs.cc:cvmfs_read()");
+  no_open_dirs_  = statistics_->Register(
+      "cvmfs.no_open_dirs", "Number of currently opened directories");
+  io_error_info_.SetCounter(
+      statistics_->Register("cvmfs.n_io_error", "Number of I/O errors"));
+  n_eio_total_ = statistics_->Register(
+      "eio.total",
+      "EIO returned to calling process. Sum of individual eio counters");
+  n_eio_01_ = statistics_->Register(
+      "eio.01", "EIO returned to calling process. cvmfs.cc:cvmfs_lookup()");
+  n_eio_02_ = statistics_->Register(
+      "eio.02", "EIO returned to calling process. cvmfs.cc:ReplyNegative()");
+  n_eio_03_ = statistics_->Register(
+      "eio.03", "EIO returned to calling process. cvmfs.cc:cvmfs_opendir()");
+  n_eio_04_ = statistics_->Register(
+      "eio.04", "EIO returned to calling process. cvmfs.cc:cvmfs_open()");
+  n_eio_05_ = statistics_->Register(
+      "eio.05", "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
+  n_eio_06_ = statistics_->Register(
+      "eio.06", "EIO returned to calling process. cvmfs.cc:cvmfs_open()");
+  n_eio_07_ = statistics_->Register(
+      "eio.07", "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
+  n_eio_08_ = statistics_->Register(
+      "eio.08", "EIO returned to calling process. cvmfs.cc:cvmfs_read()");
+  n_emfile_ = statistics_->Register(
+      "eio.emfile",
+      "EMFILE returned to calling process. cvmfs.cc:cvmfs_read()");
 
   string optarg;
-  if (options_mgr_->GetValue("CVMFS_INSTRUMENT_FUSE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_INSTRUMENT_FUSE", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     HighPrecisionTimer::g_is_enabled = true;
   }
 
-  hist_fs_lookup_ = new Log2Histogram(30);
-  hist_fs_forget_ = new Log2Histogram(30);
+  hist_fs_lookup_       = new Log2Histogram(30);
+  hist_fs_forget_       = new Log2Histogram(30);
   hist_fs_forget_multi_ = new Log2Histogram(30);
-  hist_fs_getattr_ = new Log2Histogram(30);
-  hist_fs_readlink_ = new Log2Histogram(30);
-  hist_fs_opendir_ = new Log2Histogram(30);
-  hist_fs_releasedir_ = new Log2Histogram(30);
-  hist_fs_readdir_ = new Log2Histogram(30);
-  hist_fs_open_ = new Log2Histogram(30);
-  hist_fs_read_ = new Log2Histogram(30);
-  hist_fs_release_ = new Log2Histogram(30);
+  hist_fs_getattr_      = new Log2Histogram(30);
+  hist_fs_readlink_     = new Log2Histogram(30);
+  hist_fs_opendir_      = new Log2Histogram(30);
+  hist_fs_releasedir_   = new Log2Histogram(30);
+  hist_fs_readdir_      = new Log2Histogram(30);
+  hist_fs_open_         = new Log2Histogram(30);
+  hist_fs_read_         = new Log2Histogram(30);
+  hist_fs_release_      = new Log2Histogram(30);
 }
 
 
@@ -294,36 +294,31 @@ void FileSystem::CreateStatistics() {
  * sanity is in a separate method.
  */
 FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
-  const string &instance
-) {
+    const string &instance) {
   string optarg;
   PosixCacheSettings settings;
 
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_REFCOUNT", instance),
                              &optarg)
-      && options_mgr_->IsOff(optarg))
-  {
+      && options_mgr_->IsOff(optarg)) {
     settings.do_refcount = false;
   }
 
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SHARED", instance),
                              &optarg)
-      && options_mgr_->IsOn(optarg))
-  {
+      && options_mgr_->IsOn(optarg)) {
     settings.is_shared = true;
   }
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SERVER_MODE", instance),
                              &optarg)
-      && options_mgr_->IsOn(optarg))
-  {
+      && options_mgr_->IsOn(optarg)) {
     settings.avoid_rename = true;
   }
 
   if (type_ == kFsFuse)
     settings.quota_limit = kDefaultQuotaLimit;
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_QUOTA_LIMIT", instance),
-                             &optarg))
-  {
+                             &optarg)) {
     settings.quota_limit = String2Int64(optarg) * 1024 * 1024;
   }
   if (settings.quota_limit > 0)
@@ -331,9 +326,8 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
 
   settings.cache_path = kDefaultCacheBase;
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_BASE", instance),
-                             &optarg))
-  {
-    settings.cache_path = MakeCanonicalPath(optarg);
+                             &optarg)) {
+    settings.cache_path         = MakeCanonicalPath(optarg);
     settings.cache_base_defined = true;
   }
   if (settings.is_shared) {
@@ -345,15 +339,13 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
   // CheckCacheMode makes sure that CVMFS_CACHE_DIR and CVMFS_CACHE_BASE are
   // not set at the same time.
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_DIR", instance),
-                             &optarg))
-  {
+                             &optarg)) {
     settings.cache_dir_defined = true;
-    settings.cache_path = optarg;
+    settings.cache_path        = optarg;
   }
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_ALIEN", instance),
-                             &optarg))
-  {
-    settings.is_alien = true;
+                             &optarg)) {
+    settings.is_alien   = true;
     settings.cache_path = optarg;
   }
   // We already changed the cwd to the workspace
@@ -366,9 +358,8 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
   // set otherwise
   settings.workspace = settings.cache_path;
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_WORKSPACE", instance),
-                             &optarg) ||
-      options_mgr_->GetValue("CVMFS_WORKSPACE", &optarg))
-  {
+                             &optarg)
+      || options_mgr_->GetValue("CVMFS_WORKSPACE", &optarg)) {
     // Used for the shared quota manager
     settings.workspace = optarg;
   }
@@ -380,18 +371,17 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
 bool FileSystem::DetermineNfsMode() {
   string optarg;
 
-  if (options_mgr_->GetValue("CVMFS_NFS_SOURCE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_NFS_SOURCE", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     nfs_mode_ |= kNfsMaps;
     if (options_mgr_->GetValue("CVMFS_NFS_SHARED", &optarg)) {
-      nfs_mode_ |= kNfsMapsHa;
-      nfs_maps_dir_ = optarg;
+      nfs_mode_     |= kNfsMapsHa;
+      nfs_maps_dir_  = optarg;
     }
   }
 
   if ((type_ == kFsLibrary) && (nfs_mode_ != kNfsNone)) {
-    boot_error_ = "Failure: libcvmfs does not support NFS export.";
+    boot_error_  = "Failure: libcvmfs does not support NFS export.";
     boot_status_ = loader::kFailOptions;
     return false;
   }
@@ -400,56 +390,54 @@ bool FileSystem::DetermineNfsMode() {
 
 
 FileSystem::FileSystem(const FileSystem::FileSystemInfo &fs_info)
-  : name_(fs_info.name)
-  , exe_path_(fs_info.exe_path)
-  , type_(fs_info.type)
-  , options_mgr_(fs_info.options_mgr)
-  , wait_workspace_(fs_info.wait_workspace)
-  , foreground_(fs_info.foreground)
-  , n_fs_open_(NULL)
-  , n_fs_dir_open_(NULL)
-  , n_fs_lookup_(NULL)
-  , n_fs_lookup_negative_(NULL)
-  , n_fs_stat_(NULL)
-  , n_fs_stat_stale_(NULL)
-  , n_fs_statfs_(NULL)
-  , n_fs_statfs_cached_(NULL)
-  , n_fs_read_(NULL)
-  , n_fs_readlink_(NULL)
-  , n_fs_forget_(NULL)
-  , n_fs_inode_replace_(NULL)
-  , no_open_files_(NULL)
-  , no_open_dirs_(NULL)
-  , n_eio_total_(NULL)
-  , n_eio_01_(NULL)
-  , n_eio_02_(NULL)
-  , n_eio_03_(NULL)
-  , n_eio_04_(NULL)
-  , n_eio_05_(NULL)
-  , n_eio_06_(NULL)
-  , n_eio_07_(NULL)
-  , n_eio_08_(NULL)
-  , n_emfile_(NULL)
-  , statistics_(NULL)
-  , fd_workspace_lock_(-1)
-  , found_previous_crash_(false)
-  , nfs_mode_(kNfsNone)
-  , cache_mgr_(NULL)
-  , uuid_cache_(NULL)
-  , nfs_maps_(NULL)
-  , has_custom_sqlitevfs_(false)
-{
+    : name_(fs_info.name)
+    , exe_path_(fs_info.exe_path)
+    , type_(fs_info.type)
+    , options_mgr_(fs_info.options_mgr)
+    , wait_workspace_(fs_info.wait_workspace)
+    , foreground_(fs_info.foreground)
+    , n_fs_open_(NULL)
+    , n_fs_dir_open_(NULL)
+    , n_fs_lookup_(NULL)
+    , n_fs_lookup_negative_(NULL)
+    , n_fs_stat_(NULL)
+    , n_fs_stat_stale_(NULL)
+    , n_fs_statfs_(NULL)
+    , n_fs_statfs_cached_(NULL)
+    , n_fs_read_(NULL)
+    , n_fs_readlink_(NULL)
+    , n_fs_forget_(NULL)
+    , n_fs_inode_replace_(NULL)
+    , no_open_files_(NULL)
+    , no_open_dirs_(NULL)
+    , n_eio_total_(NULL)
+    , n_eio_01_(NULL)
+    , n_eio_02_(NULL)
+    , n_eio_03_(NULL)
+    , n_eio_04_(NULL)
+    , n_eio_05_(NULL)
+    , n_eio_06_(NULL)
+    , n_eio_07_(NULL)
+    , n_eio_08_(NULL)
+    , n_emfile_(NULL)
+    , statistics_(NULL)
+    , fd_workspace_lock_(-1)
+    , found_previous_crash_(false)
+    , nfs_mode_(kNfsNone)
+    , cache_mgr_(NULL)
+    , uuid_cache_(NULL)
+    , nfs_maps_(NULL)
+    , has_custom_sqlitevfs_(false) {
   assert(!g_alive);
   g_alive = true;
-  g_uid = geteuid();
-  g_gid = getegid();
+  g_uid   = geteuid();
+  g_gid   = getegid();
 
   string optarg;
-  if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SERVER_MODE",
-                                         kDefaultCacheMgrInstance),
-                             &optarg)
-      && options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue(
+          MkCacheParm("CVMFS_CACHE_SERVER_MODE", kDefaultCacheMgrInstance),
+          &optarg)
+      && options_mgr_->IsOn(optarg)) {
     g_raw_symlinks = true;
   }
 }
@@ -503,13 +491,13 @@ FileSystem::~FileSystem() {
 
 bool FileSystem::LockWorkspace() {
   path_workspace_lock_ = workspace_ + "/lock." + name_;
-  fd_workspace_lock_ = TryLockFile(path_workspace_lock_);
+  fd_workspace_lock_   = TryLockFile(path_workspace_lock_);
   if (fd_workspace_lock_ >= 0)
     return true;
 
   if (fd_workspace_lock_ == -1) {
-    boot_error_ = "could not acquire workspace lock (" +
-                 StringifyInt(errno) + ")";
+    boot_error_ = "could not acquire workspace lock (" + StringifyInt(errno)
+                  + ")";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -523,8 +511,8 @@ bool FileSystem::LockWorkspace() {
 
   fd_workspace_lock_ = LockFile(path_workspace_lock_);
   if (fd_workspace_lock_ < 0) {
-    boot_error_ = "could not acquire workspace lock (" +
-                   StringifyInt(errno) + ")";
+    boot_error_ = "could not acquire workspace lock (" + StringifyInt(errno)
+                  + ")";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -532,12 +520,10 @@ bool FileSystem::LockWorkspace() {
 }
 
 
-void FileSystem::LogSqliteError(
-  void *user_data __attribute__((unused)),
-  int sqlite_extended_error,
-  const char *message)
-{
-  int log_dest = kLogDebug;
+void FileSystem::LogSqliteError(void *user_data __attribute__((unused)),
+                                int sqlite_extended_error,
+                                const char *message) {
+  int log_dest     = kLogDebug;
   int sqlite_error = sqlite_extended_error & 0xFF;
   switch (sqlite_error) {
     case SQLITE_INTERNAL:
@@ -557,8 +543,8 @@ void FileSystem::LogSqliteError(
     default:
       break;
   }
-  LogCvmfs(kLogCvmfs, log_dest, "SQlite3: %s (%d)",
-           message, sqlite_extended_error);
+  LogCvmfs(kLogCvmfs, log_dest, "SQlite3: %s (%d)", message,
+           sqlite_extended_error);
 }
 
 
@@ -567,32 +553,26 @@ void FileSystem::LogSqliteError(
  * the instance name such that CVMFS_CACHE_FOO_BAR becomes
  * CVMFS_CACHE_<INSTANCE>_FOO_BAR
  */
-string FileSystem::MkCacheParm(
-  const string &generic_parameter,
-  const string &instance)
-{
+string FileSystem::MkCacheParm(const string &generic_parameter,
+                               const string &instance) {
   assert(HasPrefix(generic_parameter, "CVMFS_CACHE_", false));
 
   if (instance == kDefaultCacheMgrInstance) {
     // Compatibility parameter names
-    if ((generic_parameter == "CVMFS_CACHE_SHARED") &&
-        !options_mgr_->IsDefined(generic_parameter))
-    {
+    if ((generic_parameter == "CVMFS_CACHE_SHARED")
+        && !options_mgr_->IsDefined(generic_parameter)) {
       return "CVMFS_SHARED_CACHE";
     }
-    if ((generic_parameter == "CVMFS_CACHE_ALIEN") &&
-        !options_mgr_->IsDefined(generic_parameter))
-    {
+    if ((generic_parameter == "CVMFS_CACHE_ALIEN")
+        && !options_mgr_->IsDefined(generic_parameter)) {
       return "CVMFS_ALIEN_CACHE";
     }
-    if ((generic_parameter == "CVMFS_CACHE_SERVER_MODE") &&
-        !options_mgr_->IsDefined(generic_parameter))
-    {
+    if ((generic_parameter == "CVMFS_CACHE_SERVER_MODE")
+        && !options_mgr_->IsDefined(generic_parameter)) {
       return "CVMFS_SERVER_CACHE_MODE";
     }
-    if ((generic_parameter == "CVMFS_CACHE_QUOTA_LIMIT") &&
-        !options_mgr_->IsDefined(generic_parameter))
-    {
+    if ((generic_parameter == "CVMFS_CACHE_QUOTA_LIMIT")
+        && !options_mgr_->IsDefined(generic_parameter)) {
       return "CVMFS_QUOTA_LIMIT";
     }
     return generic_parameter;
@@ -622,7 +602,7 @@ void FileSystem::ResetErrorCounters() {
  */
 CacheManager *FileSystem::SetupCacheMgr(const string &instance) {
   if (constructed_instances_.find(instance) != constructed_instances_.end()) {
-    boot_error_ = "circular cache definition: " + instance;
+    boot_error_  = "circular cache definition: " + instance;
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
@@ -646,8 +626,8 @@ CacheManager *FileSystem::SetupCacheMgr(const string &instance) {
   } else if (instance_type == "external") {
     return SetupExternalCacheMgr(instance);
   } else {
-    boot_error_ = "invalid cache manager type for '" + instance +  "':" +
-      instance_type;
+    boot_error_ = "invalid cache manager type for '" + instance
+                  + "':" + instance_type;
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
@@ -661,30 +641,28 @@ CacheManager *FileSystem::SetupExternalCacheMgr(const string &instance) {
     nfiles = String2Uint64(optarg);
   vector<string> cmd_line;
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_CMDLINE", instance),
-      &optarg))
-  {
+                             &optarg)) {
     cmd_line = SplitString(optarg, ',');
   }
 
   if (!options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_LOCATOR", instance),
-      &optarg))
-  {
-    boot_error_ = MkCacheParm("CVMFS_CACHE_LOCATOR", instance) + " missing";
+                              &optarg)) {
+    boot_error_  = MkCacheParm("CVMFS_CACHE_LOCATOR", instance) + " missing";
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
 
   UniquePtr<ExternalCacheManager::PluginHandle> plugin_handle(
-    ExternalCacheManager::CreatePlugin(optarg, cmd_line));
+      ExternalCacheManager::CreatePlugin(optarg, cmd_line));
   if (!plugin_handle->IsValid()) {
-    boot_error_ = plugin_handle->error_msg();
+    boot_error_  = plugin_handle->error_msg();
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
   ExternalCacheManager *cache_mgr = ExternalCacheManager::Create(
-    plugin_handle->fd_connection(), nfiles, name_ + ":" + instance);
+      plugin_handle->fd_connection(), nfiles, name_ + ":" + instance);
   if (cache_mgr == NULL) {
-    boot_error_ = "failed to create external cache manager for " + instance;
+    boot_error_  = "failed to create external cache manager for " + instance;
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
@@ -698,14 +676,14 @@ CacheManager *FileSystem::SetupPosixCacheMgr(const string &instance) {
   if (!CheckPosixCacheSettings(settings))
     return NULL;
   UniquePtr<PosixCacheManager> cache_mgr(PosixCacheManager::Create(
-    settings.cache_path,
-    settings.is_alien,
-    settings.avoid_rename ? PosixCacheManager::kRenameLink
-                          : PosixCacheManager::kRenameNormal,
-    settings.do_refcount));
+      settings.cache_path,
+      settings.is_alien,
+      settings.avoid_rename ? PosixCacheManager::kRenameLink
+                            : PosixCacheManager::kRenameNormal,
+      settings.do_refcount));
   if (!cache_mgr.IsValid()) {
-    boot_error_ = "Failed to setup posix cache '" + instance + "' in " +
-                  settings.cache_path + ": " + strerror(errno);
+    boot_error_ = "Failed to setup posix cache '" + instance + "' in "
+                  + settings.cache_path + ": " + strerror(errno);
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
@@ -731,10 +709,9 @@ CacheManager *FileSystem::SetupRamCacheMgr(const string &instance) {
   }
   uint64_t sz_cache_bytes;
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SIZE", instance),
-                             &optarg))
-  {
+                             &optarg)) {
     if (HasSuffix(optarg, "%", false)) {
-      sz_cache_bytes = platform_memsize() * String2Uint64(optarg)/100;
+      sz_cache_bytes = platform_memsize() * String2Uint64(optarg) / 100;
     } else {
       sz_cache_bytes = String2Uint64(optarg) * 1024 * 1024;
     }
@@ -743,28 +720,28 @@ CacheManager *FileSystem::SetupRamCacheMgr(const string &instance) {
   }
   MemoryKvStore::MemoryAllocator alloc = MemoryKvStore::kMallocHeap;
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_MALLOC", instance),
-                             &optarg))
-  {
+                             &optarg)) {
     if (optarg == "libc") {
       alloc = MemoryKvStore::kMallocLibc;
     } else if (optarg == "heap") {
       alloc = MemoryKvStore::kMallocHeap;
     } else {
-      boot_error_ = "Failure: unknown malloc " +
-                    MkCacheParm("CVMFS_CACHE_MALLOC", instance) + "=" + optarg;
+      boot_error_ = "Failure: unknown malloc "
+                    + MkCacheParm("CVMFS_CACHE_MALLOC", instance) + "="
+                    + optarg;
       boot_status_ = loader::kFailOptions;
       return NULL;
     }
   }
-  sz_cache_bytes = RoundUp8(std::max(static_cast<uint64_t>(40 * 1024 * 1024),
-                                     sz_cache_bytes));
+  sz_cache_bytes = RoundUp8(
+      std::max(static_cast<uint64_t>(40 * 1024 * 1024), sz_cache_bytes));
   RamCacheManager *cache_mgr = new RamCacheManager(
-        sz_cache_bytes,
-        nfiles,
-        alloc,
-        perf::StatisticsTemplate("cache." + instance, statistics_));
+      sz_cache_bytes,
+      nfiles,
+      alloc,
+      perf::StatisticsTemplate("cache." + instance, statistics_));
   if (cache_mgr == NULL) {
-    boot_error_ = "failed to create ram cache manager for " + instance;
+    boot_error_  = "failed to create ram cache manager for " + instance;
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
@@ -776,9 +753,8 @@ CacheManager *FileSystem::SetupRamCacheMgr(const string &instance) {
 CacheManager *FileSystem::SetupTieredCacheMgr(const string &instance) {
   string optarg;
   if (!options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_UPPER", instance),
-                              &optarg))
-  {
-    boot_error_ = MkCacheParm("CVMFS_CACHE_UPPER", instance) + " missing";
+                              &optarg)) {
+    boot_error_  = MkCacheParm("CVMFS_CACHE_UPPER", instance) + " missing";
     boot_status_ = loader::kFailOptions;
     return NULL;
   }
@@ -787,9 +763,8 @@ CacheManager *FileSystem::SetupTieredCacheMgr(const string &instance) {
     return NULL;
 
   if (!options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_LOWER", instance),
-                              &optarg))
-  {
-    boot_error_ = MkCacheParm("CVMFS_CACHE_LOWER", instance) + " missing";
+                              &optarg)) {
+    boot_error_  = MkCacheParm("CVMFS_CACHE_LOWER", instance) + " missing";
     boot_status_ = loader::kFailOptions;
     return NULL;
   }
@@ -797,18 +772,17 @@ CacheManager *FileSystem::SetupTieredCacheMgr(const string &instance) {
   if (!lower.IsValid())
     return NULL;
 
-  CacheManager *tiered =
-    TieredCacheManager::Create(upper.Release(), lower.Release());
+  CacheManager *tiered = TieredCacheManager::Create(upper.Release(),
+                                                    lower.Release());
   if (tiered == NULL) {
-    boot_error_ = "Failed to setup tiered cache manager " + instance;
+    boot_error_  = "Failed to setup tiered cache manager " + instance;
     boot_status_ = loader::kFailCacheDir;
     return NULL;
   }
   if (options_mgr_->GetValue(
-        MkCacheParm("CVMFS_CACHE_LOWER_READONLY", instance), &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
-    static_cast<TieredCacheManager*>(tiered)->SetLowerReadOnly();
+          MkCacheParm("CVMFS_CACHE_LOWER_READONLY", instance), &optarg)
+      && options_mgr_->IsOn(optarg)) {
+    static_cast<TieredCacheManager *>(tiered)->SetLowerReadOnly();
   }
   return tiered;
 }
@@ -825,8 +799,8 @@ bool FileSystem::SetupCrashGuard() {
   }
   retval = open(path_crash_guard_.c_str(), O_RDONLY | O_CREAT, 0600);
   if (retval < 0) {
-    boot_error_ = "could not open running sentinel (" +
-                  StringifyInt(errno) + ")";
+    boot_error_ = "could not open running sentinel (" + StringifyInt(errno)
+                  + ")";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -841,7 +815,7 @@ bool FileSystem::SetupCwd() {
     // accessible and it brings speed later on.
     int retval = chdir(workspace_.c_str());
     if (retval != 0) {
-      boot_error_ = "workspace " + workspace_ + " is unavailable";
+      boot_error_  = "workspace " + workspace_ + " is unavailable";
       boot_status_ = loader::kFailCacheDir;
       return false;
     }
@@ -870,9 +844,8 @@ void FileSystem::SetupGlobalEnvironmentParams() {
 }
 
 
-void FileSystem::SetupLoggingStandalone(
-  const OptionsManager &options_mgr, const std::string &prefix)
-{
+void FileSystem::SetupLoggingStandalone(const OptionsManager &options_mgr,
+                                        const std::string &prefix) {
   SetupGlobalEnvironmentParams();
 
   string optarg;
@@ -904,8 +877,8 @@ bool FileSystem::SetupNfsMaps() {
 
   string no_nfs_sentinel;
   if (cache_mgr_->id() == kPosixCacheManager) {
-    PosixCacheManager *posix_cache_mgr =
-        reinterpret_cast<PosixCacheManager *>(cache_mgr_);
+    PosixCacheManager *posix_cache_mgr = reinterpret_cast<PosixCacheManager *>(
+        cache_mgr_);
     no_nfs_sentinel = posix_cache_mgr->cache_path() + "/no_nfs_maps." + name_;
     if (!IsNfsSource()) {
       // Might be a read-only cache
@@ -915,7 +888,7 @@ bool FileSystem::SetupNfsMaps() {
     }
   } else {
     if (IsNfsSource()) {
-      boot_error_ = "NFS source only works with POSIX cache manager.";
+      boot_error_  = "NFS source only works with POSIX cache manager.";
       boot_status_ = loader::kFailNfsMaps;
       return false;
     }
@@ -925,25 +898,25 @@ bool FileSystem::SetupNfsMaps() {
   assert(cache_mgr_->id() == kPosixCacheManager);
   assert(IsNfsSource());
   if (!no_nfs_sentinel.empty() && FileExists(no_nfs_sentinel)) {
-    boot_error_ = "Cache was used without NFS maps before. "
-                  "It has to be wiped out.";
+    boot_error_  = "Cache was used without NFS maps before. "
+                   "It has to be wiped out.";
     boot_status_ = loader::kFailNfsMaps;
     return false;
   }
 
   // nfs maps need to be protected by workspace lock
-  PosixCacheManager *posix_cache_mgr =
-        reinterpret_cast<PosixCacheManager *>(cache_mgr_);
+  PosixCacheManager *posix_cache_mgr = reinterpret_cast<PosixCacheManager *>(
+      cache_mgr_);
   if (posix_cache_mgr->cache_path() != workspace_) {
-    boot_error_ = "Cache directory and workspace must be identical for "
-                  "NFS export";
+    boot_error_  = "Cache directory and workspace must be identical for "
+                   "NFS export";
     boot_status_ = loader::kFailNfsMaps;
     return false;
   }
 
   string inode_cache_dir = nfs_maps_dir_ + "/nfs_maps." + name_;
   if (!MkdirDeep(inode_cache_dir, 0700)) {
-    boot_error_ = "Failed to initialize NFS maps";
+    boot_error_  = "Failed to initialize NFS maps";
     boot_status_ = loader::kFailNfsMaps;
     return false;
   }
@@ -951,20 +924,20 @@ bool FileSystem::SetupNfsMaps() {
   // TODO(jblomer): make this a manager class
   if (IsHaNfsSource()) {
     nfs_maps_ = NfsMapsSqlite::Create(
-      inode_cache_dir,
-      catalog::ClientCatalogManager::kInodeOffset + 1,
-      found_previous_crash_,
-      statistics_);
+        inode_cache_dir,
+        catalog::ClientCatalogManager::kInodeOffset + 1,
+        found_previous_crash_,
+        statistics_);
   } else {
     nfs_maps_ = NfsMapsLeveldb::Create(
-      inode_cache_dir,
-      catalog::ClientCatalogManager::kInodeOffset + 1,
-      found_previous_crash_,
-      statistics_);
+        inode_cache_dir,
+        catalog::ClientCatalogManager::kInodeOffset + 1,
+        found_previous_crash_,
+        statistics_);
   }
 
   if (nfs_maps_ == NULL) {
-    boot_error_ = "Failed to initialize NFS maps";
+    boot_error_  = "Failed to initialize NFS maps";
     boot_status_ = loader::kFailNfsMaps;
     return false;
   }
@@ -973,8 +946,8 @@ bool FileSystem::SetupNfsMaps() {
   if (options_mgr_->GetValue("CVMFS_NFS_INTERLEAVED_INODES", &optarg)) {
     vector<string> tokens = SplitString(optarg, '%');
     if (tokens.size() != 2) {
-      boot_error_ =
-        "invalid format for CVMFS_NFS_INTERLEAVED_INODES: " + optarg;
+      boot_error_ = "invalid format for CVMFS_NFS_INTERLEAVED_INODES: "
+                    + optarg;
       boot_status_ = loader::kFailNfsMaps;
       return false;
     }
@@ -991,12 +964,10 @@ bool FileSystem::SetupNfsMaps() {
 
 
 bool FileSystem::SetupPosixQuotaMgr(
-  const FileSystem::PosixCacheSettings &settings,
-  CacheManager *cache_mgr
-) {
+    const FileSystem::PosixCacheSettings &settings, CacheManager *cache_mgr) {
   assert(settings.quota_limit >= 0);
   int64_t quota_threshold = settings.quota_limit / 2;
-  string cache_workspace = settings.cache_path;
+  string cache_workspace  = settings.cache_path;
   if (settings.cache_path != settings.workspace) {
     LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
              "using workspace %s to protect cache database in %s",
@@ -1006,25 +977,23 @@ bool FileSystem::SetupPosixQuotaMgr(
   PosixQuotaManager *quota_mgr;
 
   if (settings.is_shared) {
-    quota_mgr = PosixQuotaManager::CreateShared(
-                  exe_path_,
-                  cache_workspace,
-                  settings.quota_limit,
-                  quota_threshold,
-                  foreground_);
+    quota_mgr = PosixQuotaManager::CreateShared(exe_path_,
+                                                cache_workspace,
+                                                settings.quota_limit,
+                                                quota_threshold,
+                                                foreground_);
     if (quota_mgr == NULL) {
-      boot_error_ = "Failed to initialize shared lru cache";
+      boot_error_  = "Failed to initialize shared lru cache";
       boot_status_ = loader::kFailQuota;
       return false;
     }
   } else {
-    quota_mgr = PosixQuotaManager::Create(
-                  cache_workspace,
-                  settings.quota_limit,
-                  quota_threshold,
-                  found_previous_crash_);
+    quota_mgr = PosixQuotaManager::Create(cache_workspace,
+                                          settings.quota_limit,
+                                          quota_threshold,
+                                          found_previous_crash_);
     if (quota_mgr == NULL) {
-      boot_error_ = "Failed to initialize lru cache";
+      boot_error_  = "Failed to initialize lru cache";
       boot_status_ = loader::kFailQuota;
       return false;
     }
@@ -1037,7 +1006,7 @@ bool FileSystem::SetupPosixQuotaMgr(
              quota_mgr->GetSize(), quota_mgr->GetCapacity());
     if (!quota_mgr->Cleanup(quota_threshold)) {
       delete quota_mgr;
-      boot_error_ = "Failed to clean up cache";
+      boot_error_  = "Failed to clean up cache";
       boot_status_ = loader::kFailQuota;
       return false;
     }
@@ -1078,17 +1047,16 @@ bool FileSystem::SetupWorkspace() {
   workspace_ = kDefaultCacheBase;
   if (options_mgr_->GetValue("CVMFS_CACHE_BASE", &optarg))
     workspace_ = MakeCanonicalPath(optarg);
-  if (options_mgr_->GetValue("CVMFS_SHARED_CACHE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_SHARED_CACHE", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     workspace_ += "/shared";
   } else {
     workspace_ += "/" + name_;
   }
   if (options_mgr_->GetValue("CVMFS_CACHE_DIR", &optarg)) {
     if (options_mgr_->IsDefined("CVMFS_CACHE_BASE")) {
-      boot_error_ =
-        "'CVMFS_CACHE_BASE' and 'CVMFS_CACHE_DIR' are mutually exclusive";
+      boot_error_  = "'CVMFS_CACHE_BASE' and 'CVMFS_CACHE_DIR' are mutually "
+                     "exclusive";
       boot_status_ = loader::kFailOptions;
       return false;
     }
@@ -1102,7 +1070,7 @@ bool FileSystem::SetupWorkspace() {
   // permission now to 0770 to avoid a race when fixing it later
   const int mode = 0770;
   if (!MkdirDeep(workspace_, mode, false)) {
-    boot_error_ = "cannot create workspace directory " + workspace_;
+    boot_error_  = "cannot create workspace directory " + workspace_;
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -1134,10 +1102,9 @@ void FileSystem::SetupUuid() {
  * cache in order to properly unravel the file system stack on shutdown.
  */
 void FileSystem::TearDown2ReadOnly() {
-  if ((cache_mgr_ != NULL) &&
-      (cache_mgr_->id() == kPosixCacheManager)) {
-    PosixCacheManager *posix_cache_mgr =
-      reinterpret_cast<PosixCacheManager *>(cache_mgr_);
+  if ((cache_mgr_ != NULL) && (cache_mgr_->id() == kPosixCacheManager)) {
+    PosixCacheManager *posix_cache_mgr = reinterpret_cast<PosixCacheManager *>(
+        cache_mgr_);
     posix_cache_mgr->TearDown2ReadOnly();
   }
 
@@ -1160,9 +1127,8 @@ void FileSystem::ReplaceCacheManager(CacheManager *new_cache_mgr) {
 bool FileSystem::TriageCacheMgr() {
   cache_mgr_instance_ = kDefaultCacheMgrInstance;
   string instance;
-  if (options_mgr_->GetValue("CVMFS_CACHE_PRIMARY", &instance) &&
-      !instance.empty())
-  {
+  if (options_mgr_->GetValue("CVMFS_CACHE_PRIMARY", &instance)
+      && !instance.empty()) {
     if (!CheckInstanceName(instance))
       return false;
     cache_mgr_instance_ = instance;
@@ -1173,9 +1139,8 @@ bool FileSystem::TriageCacheMgr() {
     return false;
 
   std::string optarg;
-  if (options_mgr_->GetValue("CVMFS_STREAMING_CACHE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_STREAMING_CACHE", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     unsigned nfiles = kDefaultNfiles;
     if (options_mgr_->GetValue("CVMFS_NFILES", &optarg))
       nfiles = String2Uint64(optarg);
@@ -1194,7 +1159,7 @@ bool FileSystem::TriageCacheMgr() {
 
 
 const char *MountPoint::kDefaultAuthzSearchPath = "/usr/libexec/cvmfs/authz";
-const char *MountPoint::kDefaultBlacklist = "/etc/cvmfs/blacklist";
+const char *MountPoint::kDefaultBlacklist       = "/etc/cvmfs/blacklist";
 
 bool MountPoint::CheckBlacklists() {
   blacklist_paths_.clear();
@@ -1206,7 +1171,7 @@ bool MountPoint::CheckBlacklists() {
   bool append = false;
   if (FileExists(blacklist)) {
     if (!signature_mgr_->LoadBlacklist(blacklist, append)) {
-      boot_error_ = "failed to load blacklist " + blacklist;
+      boot_error_  = "failed to load blacklist " + blacklist;
       boot_status_ = loader::kFailSignature;
       return false;
     }
@@ -1219,7 +1184,7 @@ bool MountPoint::CheckBlacklists() {
     blacklist_paths_.push_back(blacklist);
     if (FileExists(blacklist)) {
       if (!signature_mgr_->LoadBlacklist(blacklist, append)) {
-        boot_error_ = "failed to load blacklist from config repository";
+        boot_error_  = "failed to load blacklist from config repository";
         boot_status_ = loader::kFailSignature;
         return false;
       }
@@ -1258,32 +1223,26 @@ bool MountPoint::ReloadBlacklists() {
  * NOTE: This function should only be called before or within cvmfs_init().
  *
  */
-void MountPoint::DisableCacheSymlinks() {
-  cache_symlinks_ = false;
-}
+void MountPoint::DisableCacheSymlinks() { cache_symlinks_ = false; }
 
 /**
  * Instead of invalidate dentries, they should be expired.
  * Fixes issues with mount-on-top mounts and symlink caching.
  */
-void MountPoint::EnableFuseExpireEntry() {
-  fuse_expire_entry_ = true;
-}
+void MountPoint::EnableFuseExpireEntry() { fuse_expire_entry_ = true; }
 
 
 /**
  * The option_mgr parameter can be NULL, in which case the global option manager
  * from the file system is used.
  */
-MountPoint *MountPoint::Create(
-  const string &fqrn,
-  FileSystem *file_system,
-  OptionsManager *options_mgr)
-{
+MountPoint *MountPoint::Create(const string &fqrn,
+                               FileSystem *file_system,
+                               OptionsManager *options_mgr) {
   if (options_mgr == NULL)
     options_mgr = file_system->options_mgr();
-  UniquePtr<MountPoint> mountpoint(new MountPoint(
-    fqrn, file_system, options_mgr));
+  UniquePtr<MountPoint> mountpoint(
+      new MountPoint(fqrn, file_system, options_mgr));
 
   // At this point, we have a repository name, the type (fuse or library) and
   // an options manager (which can be the same than the FileSystem's one).
@@ -1297,11 +1256,12 @@ MountPoint *MountPoint::Create(
   if (!mountpoint->CreateDownloadManagers())
     return mountpoint.Release();
   if (file_system->cache_mgr()->id() == kStreamingCacheManager) {
-    StreamingCacheManager *streaming_cachemgr =
-      dynamic_cast<StreamingCacheManager *>(file_system->cache_mgr());
+    StreamingCacheManager
+        *streaming_cachemgr = dynamic_cast<StreamingCacheManager *>(
+            file_system->cache_mgr());
     streaming_cachemgr->SetRegularDownloadManager(mountpoint->download_mgr());
     streaming_cachemgr->SetExternalDownloadManager(
-      mountpoint->external_download_mgr());
+        mountpoint->external_download_mgr());
   }
   if (!mountpoint->CreateResolvConfWatcher()) {
     return mountpoint.Release();
@@ -1332,15 +1292,10 @@ void MountPoint::CreateAuthz() {
     authz_search_path = optarg;
 
   authz_fetcher_ = new AuthzExternalFetcher(
-    fqrn_,
-    authz_helper,
-    authz_search_path,
-    options_mgr_);
+      fqrn_, authz_helper, authz_search_path, options_mgr_);
   assert(authz_fetcher_ != NULL);
 
-  authz_session_mgr_ = AuthzSessionManager::Create(
-    authz_fetcher_,
-    statistics_);
+  authz_session_mgr_ = AuthzSessionManager::Create(authz_fetcher_, statistics_);
   assert(authz_session_mgr_ != NULL);
 
   authz_attachment_ = new AuthzAttachment(authz_session_mgr_);
@@ -1364,27 +1319,25 @@ bool MountPoint::CreateCatalogManager() {
   if (root_hash.IsNull()) {
     retval = catalog_mgr_->Init();
   } else {
-    fixed_catalog_ = true;
-    bool alt_root_path =
-      options_mgr_->GetValue("CVMFS_ALT_ROOT_PATH", &optarg) &&
-      options_mgr_->IsOn(optarg);
+    fixed_catalog_     = true;
+    bool alt_root_path = options_mgr_->GetValue("CVMFS_ALT_ROOT_PATH", &optarg)
+                         && options_mgr_->IsOn(optarg);
     retval = catalog_mgr_->InitFixed(root_hash, alt_root_path);
   }
   if (!retval) {
-    boot_error_ = "Failed to initialize root file catalog";
+    boot_error_  = "Failed to initialize root file catalog";
     boot_status_ = loader::kFailCatalog;
     return false;
   }
 
   if (catalog_mgr_->IsRevisionBlacklisted()) {
-    boot_error_ = "repository revision blacklisted";
+    boot_error_  = "repository revision blacklisted";
     boot_status_ = loader::kFailRevisionBlacklisted;
     return false;
   }
 
-  if (options_mgr_->GetValue("CVMFS_AUTO_UPDATE", &optarg) &&
-      !options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_AUTO_UPDATE", &optarg)
+      && !options_mgr_->IsOn(optarg)) {
     fixed_catalog_ = true;
   }
 
@@ -1407,8 +1360,9 @@ bool MountPoint::CreateCatalogManager() {
 
 bool MountPoint::CreateDownloadManagers() {
   string optarg;
-  download_mgr_ = new download::DownloadManager(kDefaultNumConnections,
-                             perf::StatisticsTemplate("download", statistics_));
+  download_mgr_ = new download::DownloadManager(
+      kDefaultNumConnections,
+      perf::StatisticsTemplate("download", statistics_));
   download_mgr_->SetCredentialsAttachment(authz_attachment_);
 
   // must be set before proxy and host chains are being initialized
@@ -1420,13 +1374,13 @@ bool MountPoint::CreateDownloadManagers() {
     }
   }
 
-  if (options_mgr_->GetValue("CVMFS_FAILOVER_INDEFINITELY", &optarg) &&
-      options_mgr_->IsOn(optarg)) {
-      download_mgr_->SetFailoverIndefinitely();
+  if (options_mgr_->GetValue("CVMFS_FAILOVER_INDEFINITELY", &optarg)
+      && options_mgr_->IsOn(optarg)) {
+    download_mgr_->SetFailoverIndefinitely();
   }
 
   if (options_mgr_->GetValue("CVMFS_METALINK_URL", &optarg)) {
-    download_mgr_->SetMetalinkChain(optarg);  
+    download_mgr_->SetMetalinkChain(optarg);
     // host chain will be set later when the metalink server is contacted
     download_mgr_->SetHostChain("");
     // metalink requires redirects
@@ -1439,8 +1393,9 @@ bool MountPoint::CreateDownloadManagers() {
       && options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableIgnoreSignatureFailures();
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
-      "Development option: Activate ignore signature failures during download. "
-      "DO NOT USE IN PRODUCTION");
+             "Development option: Activate ignore signature failures during "
+             "download. "
+             "DO NOT USE IN PRODUCTION");
   }
 
   SetupDnsTuning(download_mgr_);
@@ -1456,11 +1411,11 @@ bool MountPoint::CreateDownloadManagers() {
   if (options_mgr_->GetValue("CVMFS_HTTP_PROXY", &optarg))
     proxies = optarg;
   proxies = download::ResolveProxyDescription(
-    proxies,
-    file_system_->workspace() + "/proxies" + GetUniqFileSuffix(),
-    download_mgr_);
+      proxies,
+      file_system_->workspace() + "/proxies" + GetUniqFileSuffix(),
+      download_mgr_);
   if (proxies == "") {
-    boot_error_ = "failed to discover HTTP proxy servers";
+    boot_error_  = "failed to discover HTTP proxy servers";
     boot_status_ = loader::kFailWpad;
     return false;
   }
@@ -1470,8 +1425,8 @@ bool MountPoint::CreateDownloadManagers() {
   download_mgr_->SetProxyChain(proxies, fallback_proxies,
                                download::DownloadManager::kSetProxyBoth);
 
-  bool do_geosort = options_mgr_->GetValue("CVMFS_USE_GEOAPI", &optarg) &&
-                    options_mgr_->IsOn(optarg);
+  bool do_geosort = options_mgr_->GetValue("CVMFS_USE_GEOAPI", &optarg)
+                    && options_mgr_->IsOn(optarg);
   if (do_geosort) {
     download_mgr_->ProbeGeo();
   }
@@ -1485,25 +1440,26 @@ bool MountPoint::CreateDownloadManagers() {
     }
   }
 
-  if (options_mgr_->GetValue("CVMFS_USE_SSL_SYSTEM_CA", &optarg) &&
-      options_mgr_->IsOn(optarg)) {
+  if (options_mgr_->GetValue("CVMFS_USE_SSL_SYSTEM_CA", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     download_mgr_->UseSystemCertificatePath();
   }
 
-  if (options_mgr_->GetValue("CVMFS_PROXY_SHARD", &optarg) &&
-      options_mgr_->IsOn(optarg)) {
+  if (options_mgr_->GetValue("CVMFS_PROXY_SHARD", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     download_mgr_->ShardProxies();
   }
 
   // configure http tracing header
-  if (options_mgr_->GetValue("CVMFS_HTTP_TRACING", &optarg) &&
-      options_mgr_->IsOn(optarg)) {
+  if (options_mgr_->GetValue("CVMFS_HTTP_TRACING", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableHTTPTracing();
     if (options_mgr_->GetValue("CVMFS_HTTP_TRACING_HEADERS", &optarg)) {
       if (optarg.size() > 1000) {
         LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-           "CVMFS_HTTP_TRACING_HEADERS too large ( max 1000 chars, given %ld )",
-           optarg.size());
+                 "CVMFS_HTTP_TRACING_HEADERS too large ( max 1000 chars, given "
+                 "%ld )",
+                 optarg.size());
       } else {
         std::vector<std::string> tokens = SplitString(optarg, '|');
         sanitizer::AlphaNumSanitizer sanitizer;
@@ -1515,20 +1471,23 @@ bool MountPoint::CreateDownloadManagers() {
 
           if (key_val.size() != 2) {
             LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-              "Http tracing header: Skipping current token part of "
-              "CVMFS_HTTP_TRACING_HEADERS! Invalid "
-              "<key:value> pair. Token: %s", token.c_str());
+                     "Http tracing header: Skipping current token part of "
+                     "CVMFS_HTTP_TRACING_HEADERS! Invalid "
+                     "<key:value> pair. Token: %s",
+                     token.c_str());
             continue;
           }
 
           std::string prefix = "X-CVMFS-";
-          std::string key = Trim(key_val[0]);
+          std::string key    = Trim(key_val[0]);
 
           if (!sanitizer.IsValid(key)) {
             LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-            "Http tracing header: Skipping current token part of "
-            "CVMFS_HTTP_TRACING_HEADERS! Invalid key. Only alphanumeric keys "
-            "are allowed (a-z, A-Z, 0-9). Token: %s", token.c_str());
+                     "Http tracing header: Skipping current token part of "
+                     "CVMFS_HTTP_TRACING_HEADERS! Invalid key. Only "
+                     "alphanumeric keys "
+                     "are allowed (a-z, A-Z, 0-9). Token: %s",
+                     token.c_str());
             continue;
           }
 
@@ -1546,8 +1505,8 @@ bool MountPoint::CreateDownloadManagers() {
 bool MountPoint::CreateResolvConfWatcher() {
   std::string roaming_value;
   options_mgr_->GetValue("CVMFS_DNS_ROAMING", &roaming_value);
-  if (options_mgr_->IsDefined("CVMFS_DNS_ROAMING") &&
-      options_mgr_->IsOn(roaming_value)) {
+  if (options_mgr_->IsDefined("CVMFS_DNS_ROAMING")
+      && options_mgr_->IsOn(roaming_value)) {
     LogCvmfs(kLogCvmfs, kLogDebug,
              "DNS roaming is enabled for this repository.");
     // Create a file watcher to update the DNS settings of the download
@@ -1555,8 +1514,8 @@ bool MountPoint::CreateResolvConfWatcher() {
     resolv_conf_watcher_ = file_watcher::FileWatcher::Create();
 
     if (resolv_conf_watcher_) {
-      ResolvConfEventHandler *handler =
-          new ResolvConfEventHandler(download_mgr_, external_download_mgr_);
+      ResolvConfEventHandler *handler = new ResolvConfEventHandler(
+          download_mgr_, external_download_mgr_);
       resolv_conf_watcher_->RegisterHandler("/etc/resolv.conf", handler);
     }
   } else {
@@ -1567,17 +1526,16 @@ bool MountPoint::CreateResolvConfWatcher() {
 }
 
 void MountPoint::CreateFetchers() {
-  fetcher_ = new cvmfs::Fetcher(
-    file_system_->cache_mgr(),
-    download_mgr_,
-    backoff_throttle_,
-    perf::StatisticsTemplate("fetch", statistics_));
+  fetcher_ = new cvmfs::Fetcher(file_system_->cache_mgr(),
+                                download_mgr_,
+                                backoff_throttle_,
+                                perf::StatisticsTemplate("fetch", statistics_));
 
   external_fetcher_ = new cvmfs::Fetcher(
-    file_system_->cache_mgr(),
-    external_download_mgr_,
-    backoff_throttle_,
-    perf::StatisticsTemplate("fetch-external", statistics_));
+      file_system_->cache_mgr(),
+      external_download_mgr_,
+      backoff_throttle_,
+      perf::StatisticsTemplate("fetch-external", statistics_));
 }
 
 
@@ -1593,19 +1551,19 @@ bool MountPoint::CreateSignatureManager() {
     // Collect .pub files from CVMFS_KEYS_DIR
     public_keys = JoinStrings(FindFilesBySuffix(optarg, ".pub"), ":");
   } else {
-    public_keys =
-      JoinStrings(FindFilesBySuffix("/etc/cvmfs/keys", ".pub"), ":");
+    public_keys = JoinStrings(FindFilesBySuffix("/etc/cvmfs/keys", ".pub"),
+                              ":");
   }
 
   if (!signature_mgr_->LoadPublicRsaKeys(public_keys)) {
-    boot_error_ = "failed to load public key(s)";
+    boot_error_  = "failed to load public key(s)";
     boot_status_ = loader::kFailSignature;
     return false;
   }
 
   if (public_keys.size() > 0) {
     LogCvmfs(kLogCvmfs, kLogDebug, "CernVM-FS: using public key(s) %s",
-                                   public_keys.c_str());
+             public_keys.c_str());
   } else {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn, "no public key loaded");
   }
@@ -1646,10 +1604,12 @@ void MountPoint::CreateStatistics() {
                         "overall number of evicted page cache entries");
   statistics_->Register("page_cache_tracker.n_open_direct",
                         "overall number of direct I/O open calls");
-  statistics_->Register("page_cache_tracker.n_open_flush",
-    "overall number of open calls where the file's page cache gets flushed");
-  statistics_->Register("page_cache_tracker.n_open_cached",
-    "overall number of open calls where the file's page cache is reused");
+  statistics_->Register(
+      "page_cache_tracker.n_open_flush",
+      "overall number of open calls where the file's page cache gets flushed");
+  statistics_->Register(
+      "page_cache_tracker.n_open_cached",
+      "overall number of open calls where the file's page cache is reused");
 }
 
 
@@ -1668,20 +1628,22 @@ void MountPoint::CreateTables() {
   if (options_mgr_->GetValue("CVMFS_MEMCACHE_SIZE", &optarg))
     mem_cache_size = String2Uint64(optarg) * 1024 * 1024;
 
-  const double memcache_unit_size =
-    (static_cast<double>(kInodeCacheFactor) * lru::Md5PathCache::GetEntrySize())
-    + lru::InodeCache::GetEntrySize() + lru::PathCache::GetEntrySize();
-  const unsigned memcache_num_units =
-    mem_cache_size / static_cast<unsigned>(memcache_unit_size);
+  const double memcache_unit_size = (static_cast<double>(kInodeCacheFactor)
+                                     * lru::Md5PathCache::GetEntrySize())
+                                    + lru::InodeCache::GetEntrySize()
+                                    + lru::PathCache::GetEntrySize();
+  const unsigned memcache_num_units = mem_cache_size
+                                      / static_cast<unsigned>(
+                                          memcache_unit_size);
   // Number of cache entries must be a multiple of 64
   const unsigned mask_64 = ~((1 << 6) - 1);
   inode_cache_ = new lru::InodeCache(memcache_num_units & mask_64, statistics_);
-  path_cache_ = new lru::PathCache(memcache_num_units & mask_64, statistics_);
+  path_cache_  = new lru::PathCache(memcache_num_units & mask_64, statistics_);
   md5path_cache_ = new lru::Md5PathCache((memcache_num_units * 7) & mask_64,
                                          statistics_);
 
-  inode_tracker_ = new glue::InodeTracker();
-  dentry_tracker_ = new glue::DentryTracker();
+  inode_tracker_      = new glue::InodeTracker();
+  dentry_tracker_     = new glue::DentryTracker();
   page_cache_tracker_ = new glue::PageCacheTracker();
   if (file_system_->IsNfsSource())
     page_cache_tracker_->Disable();
@@ -1700,28 +1662,27 @@ bool MountPoint::CreateTracer() {
   tracer_ = new Tracer();
   if (options_mgr_->GetValue("CVMFS_TRACEFILE", &optarg)) {
     if (file_system_->type() != FileSystem::kFsFuse) {
-      boot_error_ = "tracer is only supported in the fuse module";
+      boot_error_  = "tracer is only supported in the fuse module";
       boot_status_ = loader::kFailOptions;
       return false;
     }
-    string tracebuffer_file = optarg;
-    uint64_t tracebuffer_size = kTracerBufferSize;
+    string tracebuffer_file        = optarg;
+    uint64_t tracebuffer_size      = kTracerBufferSize;
     uint64_t tracebuffer_threshold = kTracerFlushThreshold;
 
     if (options_mgr_->GetValue("CVMFS_TRACEBUFFER", &optarg)) {
       tracebuffer_size = String2Uint64(optarg);
     }
-    if (options_mgr_->GetValue("CVMFS_TRACEBUFFER_THRESHOLD",
-      &optarg)) {
+    if (options_mgr_->GetValue("CVMFS_TRACEBUFFER_THRESHOLD", &optarg)) {
       tracebuffer_threshold = String2Uint64(optarg);
     }
-    assert(tracebuffer_size <= INT_MAX
-      && tracebuffer_threshold <= INT_MAX);
+    assert(tracebuffer_size <= INT_MAX && tracebuffer_threshold <= INT_MAX);
     LogCvmfs(kLogCvmfs, kLogDebug,
-      "Initialising tracer with buffer size %" PRIu64 " and threshold %" PRIu64,
-      tracebuffer_size, tracebuffer_threshold);
+             "Initialising tracer with buffer size %" PRIu64
+             " and threshold %" PRIu64,
+             tracebuffer_size, tracebuffer_threshold);
     tracer_->Activate(tracebuffer_size, tracebuffer_threshold,
-      tracebuffer_file);
+                      tracebuffer_file);
   }
   return true;
 }
@@ -1734,9 +1695,8 @@ bool MountPoint::DetermineRootHash(shash::Any *root_hash) {
     return true;
   }
 
-  if (!options_mgr_->IsDefined("CVMFS_REPOSITORY_TAG") &&
-      !options_mgr_->IsDefined("CVMFS_REPOSITORY_DATE"))
-  {
+  if (!options_mgr_->IsDefined("CVMFS_REPOSITORY_TAG")
+      && !options_mgr_->IsDefined("CVMFS_REPOSITORY_DATE")) {
     root_hash->SetNull();
     return true;
   }
@@ -1746,11 +1706,11 @@ bool MountPoint::DetermineRootHash(shash::Any *root_hash) {
     return false;
   UnlinkGuard history_file(history_path);
   UniquePtr<history::History> tag_db(
-    history::SqliteHistory::Open(history_path));
+      history::SqliteHistory::Open(history_path));
   if (!tag_db.IsValid()) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
              "failed to open history database (%s)", history_path.c_str());
-    boot_error_ = "failed to open history database";
+    boot_error_  = "failed to open history database";
     boot_status_ = loader::kFailHistory;
     return false;
   }
@@ -1763,27 +1723,26 @@ bool MountPoint::DetermineRootHash(shash::Any *root_hash) {
     options_mgr_->GetValue("CVMFS_REPOSITORY_DATE", &repository_date);
     time_t repository_utctime = IsoTimestamp2UtcTime(repository_date);
     if (repository_utctime == 0) {
-      boot_error_ = "invalid timestamp in CVMFS_REPOSITORY_DATE: " +
-                    repository_date + ". Use YYYY-MM-DDTHH:MM:SSZ";
+      boot_error_ = "invalid timestamp in CVMFS_REPOSITORY_DATE: "
+                    + repository_date + ". Use YYYY-MM-DDTHH:MM:SSZ";
       boot_status_ = loader::kFailHistory;
       return false;
     }
     retval = tag_db->GetByDate(repository_utctime, &tag);
     if (!retval) {
-      boot_error_ = "no repository state as early as utc timestamp " +
-                     StringifyTime(repository_utctime, true);
+      boot_error_ = "no repository state as early as utc timestamp "
+                    + StringifyTime(repository_utctime, true);
       boot_status_ = loader::kFailHistory;
       return false;
     }
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslog,
              "time stamp %s UTC resolved to tag '%s'",
-             StringifyTime(repository_utctime, true).c_str(),
-             tag.name.c_str());
+             StringifyTime(repository_utctime, true).c_str(), tag.name.c_str());
     repository_tag_ = tag.name;
   } else {
     retval = tag_db->GetByName(repository_tag_, &tag);
     if (!retval) {
-      boot_error_ = "no such tag: " + repository_tag_;
+      boot_error_  = "no such tag: " + repository_tag_;
       boot_status_ = loader::kFailHistory;
       return false;
     }
@@ -1801,23 +1760,23 @@ bool MountPoint::FetchHistory(std::string *history_path) {
   retval_mf = manifest::Fetch("", fqrn_, 0, NULL, signature_mgr_, download_mgr_,
                               &ensemble);
   if (retval_mf != manifest::kFailOk) {
-    boot_error_ = "Failed to fetch manifest";
+    boot_error_  = "Failed to fetch manifest";
     boot_status_ = loader::kFailHistory;
     return false;
   }
   shash::Any history_hash = ensemble.manifest->history();
   if (history_hash.IsNull()) {
-    boot_error_ = "No history";
+    boot_error_  = "No history";
     boot_status_ = loader::kFailHistory;
     return false;
   }
 
   CacheManager::Label label;
   label.flags = CacheManager::kLabelHistory;
-  label.path = fqrn_;
+  label.path  = fqrn_;
   int fd = fetcher_->Fetch(CacheManager::LabeledObject(history_hash, label));
   if (fd < 0) {
-    boot_error_ = "failed to download history: " + StringifyInt(-fd);
+    boot_error_  = "failed to download history: " + StringifyInt(-fd);
     boot_status_ = loader::kFailHistory;
     return false;
   }
@@ -1854,49 +1813,47 @@ string MountPoint::GetUniqFileSuffix() {
 }
 
 
-MountPoint::MountPoint(
-  const string &fqrn,
-  FileSystem *file_system,
-  OptionsManager *options_mgr)
-  : fqrn_(fqrn)
-  , uuid_(cvmfs::Uuid::Create(""))
-  , file_system_(file_system)
-  , options_mgr_(options_mgr)
-  , statistics_(NULL)
-  , telemetry_aggr_(NULL)
-  , authz_fetcher_(NULL)
-  , authz_session_mgr_(NULL)
-  , authz_attachment_(NULL)
-  , backoff_throttle_(NULL)
-  , signature_mgr_(NULL)
-  , download_mgr_(NULL)
-  , external_download_mgr_(NULL)
-  , fetcher_(NULL)
-  , external_fetcher_(NULL)
-  , inode_annotation_(NULL)
-  , catalog_mgr_(NULL)
-  , chunk_tables_(NULL)
-  , simple_chunk_tables_(NULL)
-  , inode_cache_(NULL)
-  , path_cache_(NULL)
-  , md5path_cache_(NULL)
-  , tracer_(NULL)
-  , inode_tracker_(NULL)
-  , dentry_tracker_(NULL)
-  , page_cache_tracker_(NULL)
-  , statfs_cache_(NULL)
-  , resolv_conf_watcher_(NULL)
-  , max_ttl_sec_(kDefaultMaxTtlSec)
-  , kcache_timeout_sec_(static_cast<double>(kDefaultKCacheTtlSec))
-  , fixed_catalog_(false)
-  , enforce_acls_(false)
-  , cache_symlinks_(false)
-  , fuse_expire_entry_(false)
-  , has_membership_req_(false)
-  , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
-  , talk_socket_uid_(0)
-  , talk_socket_gid_(0)
-{
+MountPoint::MountPoint(const string &fqrn,
+                       FileSystem *file_system,
+                       OptionsManager *options_mgr)
+    : fqrn_(fqrn)
+    , uuid_(cvmfs::Uuid::Create(""))
+    , file_system_(file_system)
+    , options_mgr_(options_mgr)
+    , statistics_(NULL)
+    , telemetry_aggr_(NULL)
+    , authz_fetcher_(NULL)
+    , authz_session_mgr_(NULL)
+    , authz_attachment_(NULL)
+    , backoff_throttle_(NULL)
+    , signature_mgr_(NULL)
+    , download_mgr_(NULL)
+    , external_download_mgr_(NULL)
+    , fetcher_(NULL)
+    , external_fetcher_(NULL)
+    , inode_annotation_(NULL)
+    , catalog_mgr_(NULL)
+    , chunk_tables_(NULL)
+    , simple_chunk_tables_(NULL)
+    , inode_cache_(NULL)
+    , path_cache_(NULL)
+    , md5path_cache_(NULL)
+    , tracer_(NULL)
+    , inode_tracker_(NULL)
+    , dentry_tracker_(NULL)
+    , page_cache_tracker_(NULL)
+    , statfs_cache_(NULL)
+    , resolv_conf_watcher_(NULL)
+    , max_ttl_sec_(kDefaultMaxTtlSec)
+    , kcache_timeout_sec_(static_cast<double>(kDefaultKCacheTtlSec))
+    , fixed_catalog_(false)
+    , enforce_acls_(false)
+    , cache_symlinks_(false)
+    , fuse_expire_entry_(false)
+    , has_membership_req_(false)
+    , talk_socket_path_(std::string("./cvmfs_io.") + fqrn)
+    , talk_socket_uid_(0)
+    , talk_socket_gid_(0) {
   int retval = pthread_mutex_init(&lock_max_ttl_, NULL);
   assert(retval == 0);
 }
@@ -1947,7 +1904,7 @@ MountPoint::~MountPoint() {
 
 void MountPoint::ReEvaluateAuthz() {
   string old_membership_req = membership_req_;
-  has_membership_req_ = catalog_mgr_->GetVOMSAuthz(&membership_req_);
+  has_membership_req_       = catalog_mgr_->GetVOMSAuthz(&membership_req_);
   if (old_membership_req != membership_req_) {
     authz_session_mgr_->ClearSessionCache();
     authz_attachment_->set_membership(membership_req_);
@@ -1968,8 +1925,8 @@ bool MountPoint::SetupBehavior() {
 
   if (options_mgr_->GetValue("CVMFS_KCACHE_TIMEOUT", &optarg)) {
     // Can be negative and should then be interpreted as 0.0
-    kcache_timeout_sec_ =
-      std::max(0.0, static_cast<double>(String2Int64(optarg)));
+    kcache_timeout_sec_ = std::max(0.0,
+                                   static_cast<double>(String2Int64(optarg)));
   }
   LogCvmfs(kLogCvmfs, kLogDebug, "kernel caches expire after %d seconds",
            static_cast<int>(kcache_timeout_sec_));
@@ -1982,8 +1939,8 @@ bool MountPoint::SetupBehavior() {
            static_cast<int>(statfs_time_cache_valid));
   statfs_cache_ = new StatfsCache(statfs_time_cache_valid);
 
-  MagicXattrManager::EVisibility xattr_visibility =
-    MagicXattrManager::kVisibilityRootOnly;
+  MagicXattrManager::EVisibility
+      xattr_visibility = MagicXattrManager::kVisibilityRootOnly;
   if (options_mgr_->GetValue("CVMFS_HIDE_MAGIC_XATTRS", &optarg)) {
     if (options_mgr_->IsOn(optarg))
       xattr_visibility = MagicXattrManager::kVisibilityNever;
@@ -2010,8 +1967,8 @@ bool MountPoint::SetupBehavior() {
 
     for (size_t i = 0; i < tmp.size(); i++) {
       std::string trimmed = Trim(tmp[i]);
-      LogCvmfs(kLogCvmfs, kLogDebug,
-               "Privileged gid for xattr added: %s", trimmed.c_str());
+      LogCvmfs(kLogCvmfs, kLogDebug, "Privileged gid for xattr added: %s",
+               trimmed.c_str());
       protected_xattr_gids.insert(static_cast<gid_t>(String2Uint64(trimmed)));
     }
   }
@@ -2021,8 +1978,8 @@ bool MountPoint::SetupBehavior() {
 
     for (size_t i = 0; i < tmp.size(); i++) {
       std::string trimmed = Trim(tmp[i]);
-      LogCvmfs(kLogCvmfs, kLogDebug,
-               "Protected xattr added: %s", trimmed.c_str());
+      LogCvmfs(kLogCvmfs, kLogDebug, "Protected xattr added: %s",
+               trimmed.c_str());
       protected_xattrs.insert(trimmed);
     }
 
@@ -2030,25 +1987,22 @@ bool MountPoint::SetupBehavior() {
     if (protected_xattr_gids.count(0) < 1) {
       protected_xattr_gids.insert(0);
       LogCvmfs(kLogCvmfs, kLogDebug,
-              "Automatically added root to have access to protected xattrs.");
+               "Automatically added root to have access to protected xattrs.");
     }
   }
-  magic_xattr_mgr_ = new MagicXattrManager(this, xattr_visibility,
-                                    protected_xattrs, protected_xattr_gids);
+  magic_xattr_mgr_ = new MagicXattrManager(
+      this, xattr_visibility, protected_xattrs, protected_xattr_gids);
 
 
   if (options_mgr_->GetValue("CVMFS_ENFORCE_ACLS", &optarg)
-      && options_mgr_->IsOn(optarg))
-  {
+      && options_mgr_->IsOn(optarg)) {
     enforce_acls_ = true;
   }
 
   if (options_mgr_->GetValue("CVMFS_CACHE_SYMLINKS", &optarg)
-      && options_mgr_->IsOn(optarg))
-  {
+      && options_mgr_->IsOn(optarg)) {
     cache_symlinks_ = true;
   }
-
 
 
   if (options_mgr_->GetValue("CVMFS_TALK_SOCKET", &optarg)) {
@@ -2057,7 +2011,7 @@ bool MountPoint::SetupBehavior() {
   if (options_mgr_->GetValue("CVMFS_TALK_OWNER", &optarg)) {
     bool retval = GetUidOf(optarg, &talk_socket_uid_, &talk_socket_gid_);
     if (!retval) {
-      boot_error_ = "unknown owner of cvmfs_talk socket: " + optarg;
+      boot_error_  = "unknown owner of cvmfs_talk socket: " + optarg;
       boot_status_ = loader::kFailOptions;
       return false;
     }
@@ -2076,12 +2030,13 @@ bool MountPoint::SetupBehavior() {
         telemetry_send_rate_sec = kMinimumTelemetrySendRateSec;
       }
 
-      telemetry_aggr_ = perf::TelemetryAggregator::Create(statistics_,
-                                                        telemetry_send_rate_sec,
-                                                        options_mgr_,
-                                                        this,
-                                                        fqrn_,
-                                                        perf::kTelemetryInflux);
+      telemetry_aggr_ = perf::TelemetryAggregator::Create(
+          statistics_,
+          telemetry_send_rate_sec,
+          options_mgr_,
+          this,
+          fqrn_,
+          perf::kTelemetryInflux);
       LogCvmfs(kLogTelemetry, kLogSyslog | kLogDebug,
                "Enable telemetry to report every %d seconds",
                telemetry_send_rate_sec);
@@ -2099,7 +2054,7 @@ bool MountPoint::SetupBehavior() {
 void MountPoint::SetupDnsTuning(download::DownloadManager *manager) {
   string optarg;
   unsigned dns_timeout_ms = download::DownloadManager::kDnsDefaultTimeoutMs;
-  unsigned dns_retries = download::DownloadManager::kDnsDefaultRetries;
+  unsigned dns_retries    = download::DownloadManager::kDnsDefaultRetries;
   if (options_mgr_->GetValue("CVMFS_DNS_TIMEOUT", &optarg))
     dns_timeout_ms = String2Uint64(optarg) * 1000;
   if (options_mgr_->GetValue("CVMFS_DNS_RETRIES", &optarg))
@@ -2138,9 +2093,8 @@ void MountPoint::SetupDnsTuning(download::DownloadManager *manager) {
 
 bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
   string optarg;
-  external_download_mgr_ =
-    download_mgr_->Clone(perf::StatisticsTemplate("download-external",
-      statistics_), "external");
+  external_download_mgr_ = download_mgr_->Clone(
+      perf::StatisticsTemplate("download-external", statistics_), "external");
 
   unsigned timeout;
   unsigned timeout_direct;
@@ -2154,7 +2108,7 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
   external_download_mgr_->SetTimeout(timeout, timeout_direct);
 
   if (options_mgr_->GetValue("CVMFS_EXTERNAL_METALINK", &optarg)) {
-    external_download_mgr_->SetMetalinkChain(optarg);  
+    external_download_mgr_->SetMetalinkChain(optarg);
     // host chain will be set later when the metalink server is contacted
     external_download_mgr_->SetHostChain("");
     // metalink requires redirects
@@ -2184,11 +2138,11 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
   string proxies = "DIRECT";
   if (options_mgr_->GetValue("CVMFS_EXTERNAL_HTTP_PROXY", &optarg)) {
     proxies = download::ResolveProxyDescription(
-      optarg,
-      file_system_->workspace() + "/proxies-external" + GetUniqFileSuffix(),
-      external_download_mgr_);
+        optarg,
+        file_system_->workspace() + "/proxies-external" + GetUniqFileSuffix(),
+        external_download_mgr_);
     if (proxies == "") {
-      boot_error_ = "failed to discover external HTTP proxy servers";
+      boot_error_  = "failed to discover external HTTP proxy servers";
       boot_status_ = loader::kFailWpad;
       return false;
     }
@@ -2197,7 +2151,7 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
   if (options_mgr_->GetValue("CVMFS_EXTERNAL_FALLBACK_PROXY", &optarg))
     fallback_proxies = optarg;
   external_download_mgr_->SetProxyChain(
-    proxies, fallback_proxies, download::DownloadManager::kSetProxyBoth);
+      proxies, fallback_proxies, download::DownloadManager::kSetProxyBoth);
 
   return true;
 }
@@ -2208,7 +2162,7 @@ void MountPoint::SetupHttpTuning() {
 
   // TODO(jblomer): avoid double default settings
 
-  unsigned timeout = kDefaultTimeoutSec;
+  unsigned timeout        = kDefaultTimeoutSec;
   unsigned timeout_direct = kDefaultTimeoutSec;
   if (options_mgr_->GetValue("CVMFS_TIMEOUT", &optarg))
     timeout = String2Uint64(optarg);
@@ -2216,9 +2170,9 @@ void MountPoint::SetupHttpTuning() {
     timeout_direct = String2Uint64(optarg);
   download_mgr_->SetTimeout(timeout, timeout_direct);
 
-  unsigned max_retries = kDefaultRetries;
+  unsigned max_retries  = kDefaultRetries;
   unsigned backoff_init = kDefaultBackoffInitMs;
-  unsigned backoff_max = kDefaultBackoffMaxMs;
+  unsigned backoff_max  = kDefaultBackoffMaxMs;
   if (options_mgr_->GetValue("CVMFS_MAX_RETRIES", &optarg))
     max_retries = String2Uint64(optarg);
   if (options_mgr_->GetValue("CVMFS_BACKOFF_INIT", &optarg))
@@ -2239,14 +2193,12 @@ void MountPoint::SetupHttpTuning() {
   if (options_mgr_->GetValue("CVMFS_HOST_RESET_AFTER", &optarg))
     download_mgr_->SetHostResetDelay(String2Uint64(optarg));
 
-  if (options_mgr_->GetValue("CVMFS_FOLLOW_REDIRECTS", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_FOLLOW_REDIRECTS", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableRedirects();
   }
-  if (options_mgr_->GetValue("CVMFS_SEND_INFO_HEADER", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_SEND_INFO_HEADER", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     download_mgr_->EnableInfoHeader();
   }
 }
@@ -2277,14 +2229,14 @@ bool MountPoint::SetupOwnerMaps() {
 
   if (options_mgr_->GetValue("CVMFS_UID_MAP", &optarg)) {
     if (!uid_map.Read(optarg)) {
-      boot_error_ = "failed to parse uid map " + optarg;
+      boot_error_  = "failed to parse uid map " + optarg;
       boot_status_ = loader::kFailOptions;
       return false;
     }
   }
   if (options_mgr_->GetValue("CVMFS_GID_MAP", &optarg)) {
     if (!gid_map.Read(optarg)) {
-      boot_error_ = "failed to parse gid map " + optarg;
+      boot_error_  = "failed to parse gid map " + optarg;
       boot_status_ = loader::kFailOptions;
       return false;
     }
@@ -2292,17 +2244,14 @@ bool MountPoint::SetupOwnerMaps() {
   catalog_mgr_->SetOwnerMaps(uid_map, gid_map);
 
   // TODO(jblomer): make local to catalog manager
-  if (options_mgr_->GetValue("CVMFS_CLAIM_OWNERSHIP", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_CLAIM_OWNERSHIP", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     g_claim_ownership = true;
   }
-  if (options_mgr_->GetValue("CVMFS_WORLD_READABLE", &optarg) &&
-      options_mgr_->IsOn(optarg))
-  {
+  if (options_mgr_->GetValue("CVMFS_WORLD_READABLE", &optarg)
+      && options_mgr_->IsOn(optarg)) {
     g_world_readable = true;
   }
-
 
 
   return true;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -33,12 +33,12 @@ class CacheManager;
 namespace catalog {
 class ClientCatalogManager;
 class InodeAnnotation;
-}
+}  // namespace catalog
 struct ChunkTables;
 namespace cvmfs {
 class Fetcher;
 class Uuid;
-}
+}  // namespace cvmfs
 namespace download {
 class DownloadManager;
 }
@@ -46,19 +46,19 @@ namespace glue {
 class InodeTracker;
 class DentryTracker;
 class PageCacheTracker;
-}
+}  // namespace glue
 namespace lru {
 class InodeCache;
 class Md5PathCache;
 class PathCache;
-}
+}  // namespace lru
 class NfsMaps;
 class OptionsManager;
 namespace perf {
 class Counter;
 class Statistics;
 class TelemetryAggregator;
-}
+}  // namespace perf
 namespace signature {
 class SignatureManager;
 }
@@ -109,10 +109,10 @@ class FileSystem : SingleCopy, public BootFactory {
 
   struct FileSystemInfo {
     FileSystemInfo()
-      : type(kFsFuse)
-      , options_mgr(NULL)
-      , wait_workspace(false)
-      , foreground(false) { }
+        : type(kFsFuse)
+        , options_mgr(NULL)
+        , wait_workspace(false)
+        , foreground(false) { }
     /**
      * Name can is used to identify this particular instance of cvmfs in the
      * cache (directory).  Normally it is the fully qualified repository name.
@@ -189,8 +189,8 @@ class FileSystem : SingleCopy, public BootFactory {
   ~FileSystem();
 
   // Used to setup logging before the file system object is created
-  static void SetupLoggingStandalone(
-    const OptionsManager &options_mgr, const std::string &prefix);
+  static void SetupLoggingStandalone(const OptionsManager &options_mgr,
+                                     const std::string &prefix);
 
   bool IsNfsSource() { return nfs_mode_ & kNfsMaps; }
   bool IsHaNfsSource() { return nfs_mode_ & kNfsMapsHa; }
@@ -244,7 +244,7 @@ class FileSystem : SingleCopy, public BootFactory {
   perf::Counter *n_eio_06() { return n_eio_06_; }
   perf::Counter *n_eio_07() { return n_eio_07_; }
   perf::Counter *n_eio_08() { return n_eio_08_; }
-  perf::Counter *n_emfile()  { return n_emfile_; }
+  perf::Counter *n_emfile() { return n_emfile_; }
   OptionsManager *options_mgr() { return options_mgr_; }
   perf::Statistics *statistics() { return statistics_; }
   Type type() { return type_; }
@@ -258,15 +258,19 @@ class FileSystem : SingleCopy, public BootFactory {
   static bool g_alive;
   static const char *kDefaultCacheBase;  // /var/lib/cvmfs
   static const unsigned kDefaultQuotaLimit = 1024 * 1024 * 1024;  // 1GB
-  static const unsigned kDefaultNfiles = 8192;  // if CVMFS_NFILES is unset
-  static const char *kDefaultCacheMgrInstance;  // "default"
+  static const unsigned kDefaultNfiles     = 8192;  // if CVMFS_NFILES is unset
+  static const char *kDefaultCacheMgrInstance;      // "default"
 
   struct PosixCacheSettings {
-    PosixCacheSettings() :
-      is_shared(false), is_alien(false), is_managed(false),
-      avoid_rename(false), cache_base_defined(false), cache_dir_defined(false),
-      quota_limit(0), do_refcount(true)
-      { }
+    PosixCacheSettings()
+        : is_shared(false)
+        , is_alien(false)
+        , is_managed(false)
+        , avoid_rename(false)
+        , cache_base_defined(false)
+        , cache_dir_defined(false)
+        , quota_limit(0)
+        , do_refcount(true) { }
     bool is_shared;
     bool is_alien;
     bool is_managed;
@@ -443,11 +447,11 @@ class FileSystem : SingleCopy, public BootFactory {
  */
 class StatfsCache : SingleCopy {
  public:
-  explicit StatfsCache(uint64_t cacheValid) : expiry_deadline_(0),
-                                     cache_timeout_(cacheValid) {
+  explicit StatfsCache(uint64_t cacheValid)
+      : expiry_deadline_(0), cache_timeout_(cacheValid) {
     memset(&info_, 0, sizeof(info_));
-    lock_ =
-      reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+    lock_ = reinterpret_cast<pthread_mutex_t *>(
+        smalloc(sizeof(pthread_mutex_t)));
     int retval = pthread_mutex_init(lock_, NULL);
     assert(retval == 0);
   }
@@ -485,7 +489,7 @@ class MountPoint : SingleCopy, public BootFactory {
   /**
    * If catalog reload fails, try again in 3 minutes
    */
-  static const unsigned kShortTermTTL = 180;
+  static const unsigned kShortTermTTL     = 180;
   static const time_t kIndefiniteDeadline = time_t(-1);
 
   static MountPoint *Create(const std::string &fqrn,
@@ -506,7 +510,7 @@ class MountPoint : SingleCopy, public BootFactory {
   download::DownloadManager *external_download_mgr() {
     return external_download_mgr_;
   }
-  file_watcher::FileWatcher* resolv_conf_watcher() {
+  file_watcher::FileWatcher *resolv_conf_watcher() {
     return resolv_conf_watcher_;
   }
   cvmfs::Fetcher *fetcher() { return fetcher_; }
@@ -520,9 +524,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool enforce_acls() { return enforce_acls_; }
   bool cache_symlinks() { return cache_symlinks_; }
   bool fuse_expire_entry() { return fuse_expire_entry_; }
-  catalog::InodeAnnotation *inode_annotation() {
-    return inode_annotation_;
-  }
+  catalog::InodeAnnotation *inode_annotation() { return inode_annotation_; }
   glue::InodeTracker *inode_tracker() { return inode_tracker_; }
   lru::InodeCache *inode_cache() { return inode_cache_; }
   double kcache_timeout_sec() { return kcache_timeout_sec_; }
@@ -580,21 +582,21 @@ class MountPoint : SingleCopy, public BootFactory {
   /**
    * Default network timeout
    */
-  static const unsigned kDefaultTimeoutSec = 5;
-  static const unsigned kDefaultRetries = 1;
+  static const unsigned kDefaultTimeoutSec    = 5;
+  static const unsigned kDefaultRetries       = 1;
   static const unsigned kDefaultBackoffInitMs = 2000;
-  static const unsigned kDefaultBackoffMaxMs = 10000;
+  static const unsigned kDefaultBackoffMaxMs  = 10000;
   /**
    * Memory buffer sizes for an activated tracer
    */
-  static const unsigned kTracerBufferSize = 8192;
+  static const unsigned kTracerBufferSize     = 8192;
   static const unsigned kTracerFlushThreshold = 7000;
   static const char *kDefaultBlacklist;  // "/etc/cvmfs/blacklist"
   /**
    * Default values for telemetry aggregator
-  */
+   */
   static const int kDefaultTelemetrySendRateSec = 5 * 60;  // 5min
-  static const int kMinimumTelemetrySendRateSec = 5;  // 5sec
+  static const int kMinimumTelemetrySendRateSec = 5;       // 5sec
 
   MountPoint(const std::string &fqrn,
              FileSystem *file_system,
@@ -657,7 +659,7 @@ class MountPoint : SingleCopy, public BootFactory {
   MagicXattrManager *magic_xattr_mgr_;
   StatfsCache *statfs_cache_;
 
-  file_watcher::FileWatcher* resolv_conf_watcher_;
+  file_watcher::FileWatcher *resolv_conf_watcher_;
 
   unsigned max_ttl_sec_;
   pthread_mutex_t lock_max_ttl_;

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -94,17 +94,17 @@ bool Interrupted(const std::string &fqrn, JobInfo *info) {
     std::string pause_file = std::string("/var/run/cvmfs/interrupt.") + fqrn;
 
     LogCvmfs(kLogDownload, kLogDebug,
-            "(id %" PRId64 ") Interrupted(): checking for existence of %s",
-            info->id(), pause_file.c_str());
+             "(id %" PRId64 ") Interrupted(): checking for existence of %s",
+             info->id(), pause_file.c_str());
     if (FileExists(pause_file)) {
       LogCvmfs(kLogDownload, kLogDebug,
-                 "(id %" PRId64 ") Interrupt marker found - "
-                 "Interrupting current download, this will EIO outstanding IO.",
-                 info->id());
+               "(id %" PRId64 ") Interrupt marker found - "
+               "Interrupting current download, this will EIO outstanding IO.",
+               info->id());
       if (0 != unlink(pause_file.c_str())) {
         LogCvmfs(kLogDownload, kLogDebug,
-                  "(id %" PRId64 ") Couldn't delete interrupt marker: errno=%d",
-                  info->id(), errno);
+                 "(id %" PRId64 ") Couldn't delete interrupt marker: errno=%d",
+                 info->id(), errno);
       }
       return true;
     }
@@ -114,16 +114,17 @@ bool Interrupted(const std::string &fqrn, JobInfo *info) {
 
 static Failures PrepareDownloadDestination(JobInfo *info) {
   if (info->sink() != NULL && !info->sink()->IsValid()) {
-    cvmfs::PathSink* psink = dynamic_cast<cvmfs::PathSink*>(info->sink());
+    cvmfs::PathSink *psink = dynamic_cast<cvmfs::PathSink *>(info->sink());
     if (psink != NULL) {
       LogCvmfs(kLogDownload, kLogDebug,
-                     "(id %" PRId64 ") Failed to open path %s: %s  (errno=%d).",
-                     info->id(), psink->path().c_str(), strerror(errno), errno);
+               "(id %" PRId64 ") Failed to open path %s: %s  (errno=%d).",
+               info->id(), psink->path().c_str(), strerror(errno), errno);
       return kFailLocalIO;
     } else {
-      LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") "
-                                  "Failed to create a valid sink: \n %s",
-                                  info->id(), info->sink()->Describe().c_str());
+      LogCvmfs(kLogDownload, kLogDebug,
+               "(id %" PRId64 ") "
+               "Failed to create a valid sink: \n %s",
+               info->id(), info->sink()->Describe().c_str());
       return kFailOther;
     }
   }
@@ -136,9 +137,8 @@ static Failures PrepareDownloadDestination(JobInfo *info) {
  * Called by curl for every HTTP header. Not called for file:// transfers.
  */
 static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
-                                 void *info_link)
-{
-  const size_t num_bytes = size*nmemb;
+                                 void *info_link) {
+  const size_t num_bytes = size * nmemb;
   const string header_line(static_cast<const char *>(ptr), num_bytes);
   JobInfo *info = static_cast<JobInfo *>(info_link);
 
@@ -152,38 +152,35 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
     }
 
     unsigned i;
-    for (i = 8; (i < header_line.length()) && (header_line[i] == ' '); ++i) {}
+    for (i = 8; (i < header_line.length()) && (header_line[i] == ' '); ++i) {
+    }
 
     // Code is initialized to -1
-    if (header_line.length() > i+2) {
+    if (header_line.length() > i + 2) {
       info->SetHttpCode(DownloadManager::ParseHttpCode(&header_line[i]));
     }
 
     if ((info->http_code() / 100) == 2) {
       return num_bytes;
-    } else if ((info->http_code() == 301) ||
-               (info->http_code() == 302) ||
-               (info->http_code() == 303) ||
-               (info->http_code() == 307))
-    {
+    } else if ((info->http_code() == 301) || (info->http_code() == 302)
+               || (info->http_code() == 303) || (info->http_code() == 307)) {
       if (!info->follow_redirects()) {
         LogCvmfs(kLogDownload, kLogDebug,
-                            "(id %" PRId64 ") redirect support not enabled: %s",
-                            info->id(), header_line.c_str());
+                 "(id %" PRId64 ") redirect support not enabled: %s",
+                 info->id(), header_line.c_str());
         info->SetErrorCode(kFailHostHttp);
         return 0;
       }
       LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") http redirect: %s",
-                                        info->id(), header_line.c_str());
+               info->id(), header_line.c_str());
       // libcurl will handle this because of CURLOPT_FOLLOWLOCATION
       return num_bytes;
     } else {
       LogCvmfs(kLogDownload, kLogDebug,
-                            "(id %" PRId64 ") http status error code: %s [%d]",
-                            info->id(), header_line.c_str(), info->http_code());
-      if (((info->http_code() / 100) == 5) ||
-          (info->http_code() == 400) || (info->http_code() == 404))
-      {
+               "(id %" PRId64 ") http status error code: %s [%d]", info->id(),
+               header_line.c_str(), info->http_code());
+      if (((info->http_code() / 100) == 5) || (info->http_code() == 400)
+          || (info->http_code() == 404)) {
         // 5XX returned by host
         // 400: error from the GeoAPI module
         // 404: the stratum 1 does not have the newest files
@@ -192,25 +189,25 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
         // 429: rate throttling (we ignore the backoff hint for the time being)
         info->SetErrorCode(kFailHostConnection);
       } else {
-        info->SetErrorCode((info->proxy() == "DIRECT") ? kFailHostHttp :
-                                                       kFailProxyHttp);
+        info->SetErrorCode((info->proxy() == "DIRECT") ? kFailHostHttp
+                                                       : kFailProxyHttp);
       }
       return 0;
     }
   }
 
   // If needed: allocate space in sink
-  if (info->sink() != NULL && info->sink()->RequiresReserve() &&
-      HasPrefix(header_line, "CONTENT-LENGTH:", true))
-  {
-    char *tmp = reinterpret_cast<char *>(alloca(num_bytes+1));
+  if (info->sink() != NULL && info->sink()->RequiresReserve()
+      && HasPrefix(header_line, "CONTENT-LENGTH:", true)) {
+    char *tmp       = reinterpret_cast<char *>(alloca(num_bytes + 1));
     uint64_t length = 0;
     sscanf(header_line.c_str(), "%s %" PRIu64, tmp, &length);
     if (length > 0) {
       if (!info->sink()->Reserve(length)) {
-        LogCvmfs(kLogDownload, kLogDebug | kLogSyslogErr, "(id %" PRId64 ") "
-                       "resource %s too large to store in memory (%" PRIu64 ")",
-                       info->id(), info->url()->c_str(), length);
+        LogCvmfs(kLogDownload, kLogDebug | kLogSyslogErr,
+                 "(id %" PRId64 ") "
+                 "resource %s too large to store in memory (%" PRIu64 ")",
+                 info->id(), info->url()->c_str(), length);
         info->SetErrorCode(kFailTooBig);
         return 0;
       }
@@ -220,12 +217,12 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
     }
   } else if (HasPrefix(header_line, "LOCATION:", true)) {
     // This comes along with redirects
-    LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") %s",
-                                      info->id(), header_line.c_str());
+    LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") %s", info->id(),
+             header_line.c_str());
   } else if (HasPrefix(header_line, "LINK:", true)) {
     // This is metalink info
-    LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") %s",
-                                      info->id(), header_line.c_str());
+    LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") %s", info->id(),
+             header_line.c_str());
     std::string link = info->link();
     if (link.size() != 0) {
       // multiple LINK headers are allowed
@@ -241,8 +238,8 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
     }
   } else if (HasPrefix(header_line, "PROXY-STATUS:", true)) {
     // Reinterpret host error as proxy error if applicable
-    if ((info->error_code() == kFailHostHttp) &&
-        (header_line.find("error=") != string::npos)) {
+    if ((info->error_code() == kFailHostHttp)
+        && (header_line.find("error=") != string::npos)) {
       info->SetErrorCode(kFailProxyHttp);
     }
   }
@@ -255,10 +252,9 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
  * Called by curl for every received data chunk.
  */
 static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
-                               void *info_link)
-{
-  const size_t num_bytes = size*nmemb;
-  JobInfo *info = static_cast<JobInfo *>(info_link);
+                               void *info_link) {
+  const size_t num_bytes = size * nmemb;
+  JobInfo *info          = static_cast<JobInfo *>(info_link);
 
   // TODO(heretherebedragons) remove if no error comes up
   // as this means only jobinfo data request (and not header only)
@@ -271,33 +267,35 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
     return 0;
 
   if (info->expected_hash()) {
-    shash::Update(reinterpret_cast<unsigned char *>(ptr),
-                  num_bytes, info->hash_context());
+    shash::Update(reinterpret_cast<unsigned char *>(ptr), num_bytes,
+                  info->hash_context());
   }
 
   if (info->compressed()) {
-    zlib::StreamStates retval =
-      zlib::DecompressZStream2Sink(ptr, static_cast<int64_t>(num_bytes),
-                                   info->GetZstreamPtr(), info->sink());
+    zlib::StreamStates retval = zlib::DecompressZStream2Sink(
+        ptr, static_cast<int64_t>(num_bytes), info->GetZstreamPtr(),
+        info->sink());
     if (retval == zlib::kStreamDataError) {
       LogCvmfs(kLogDownload, kLogSyslogErr,
-                                     "(id %" PRId64 ") failed to decompress %s",
-                                     info->id(), info->url()->c_str());
+               "(id %" PRId64 ") failed to decompress %s", info->id(),
+               info->url()->c_str());
       info->SetErrorCode(kFailBadData);
       return 0;
     } else if (retval == zlib::kStreamIOError) {
       LogCvmfs(kLogDownload, kLogSyslogErr,
-                            "(id %" PRId64 ") decompressing %s, local IO error",
-                            info->id(), info->url()->c_str());
+               "(id %" PRId64 ") decompressing %s, local IO error", info->id(),
+               info->url()->c_str());
       info->SetErrorCode(kFailLocalIO);
       return 0;
     }
   } else {
     int64_t written = info->sink()->Write(ptr, num_bytes);
     if (written < 0 || static_cast<uint64_t>(written) != num_bytes) {
-      LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") "
-              "Failed to perform write of %zu bytes to sink %s with errno %ld",
-              info->id(), num_bytes, info->sink()->Describe().c_str(), written);
+      LogCvmfs(kLogDownload, kLogDebug,
+               "(id %" PRId64 ") "
+               "Failed to perform write of %zu bytes to sink %s with errno %ld",
+               info->id(), num_bytes, info->sink()->Describe().c_str(),
+               written);
     }
   }
 
@@ -305,13 +303,11 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
 }
 
 #ifdef DEBUGMSG
-static int CallbackCurlDebug(
-  CURL * handle,
-  curl_infotype type,
-  char *data,
-  size_t size,
-  void * /* clientp */)
-{
+static int CallbackCurlDebug(CURL *handle,
+                             curl_infotype type,
+                             char *data,
+                             size_t size,
+                             void * /* clientp */) {
   JobInfo *info;
   curl_easy_getinfo(handle, CURLINFO_PRIVATE, &info);
 
@@ -348,7 +344,7 @@ static int CallbackCurlDebug(
         break;
       } else {
         LogCvmfs(kLogCurl, kLogDebug, "%s{ssldata/recv} <snip>",
-                                      prefix.c_str());
+                 prefix.c_str());
         return 0;
       }
     case CURLINFO_SSL_DATA_OUT:
@@ -357,7 +353,7 @@ static int CallbackCurlDebug(
         break;
       } else {
         LogCvmfs(kLogCurl, kLogDebug, "%s{ssldata/sent} <snip>",
-                                      prefix.c_str());
+                 prefix.c_str());
         return 0;
       }
     default:
@@ -384,8 +380,8 @@ static int CallbackCurlDebug(
     msg = "<Non-plaintext sequence>";
   }
 
-  LogCvmfs(kLogCurl, kLogDebug, "%s%s",
-           prefix.c_str(), Trim(msg, true /* trim_newline */).c_str());
+  LogCvmfs(kLogCurl, kLogDebug, "%s%s", prefix.c_str(),
+           Trim(msg, true /* trim_newline */).c_str());
   return 0;
 }
 #endif
@@ -398,24 +394,20 @@ const int DownloadManager::kProbeDown     = -2;
 const int DownloadManager::kProbeGeo      = -3;
 
 bool DownloadManager::EscapeUrlChar(unsigned char input, char output[3]) {
-  if (((input >= '0') && (input <= '9')) ||
-      ((input >= 'A') && (input <= 'Z')) ||
-      ((input >= 'a') && (input <= 'z')) ||
-      (input == '/') || (input == ':') || (input == '.') ||
-      (input == '@') ||
-      (input == '+') || (input == '-') ||
-      (input == '_') || (input == '~') ||
-      (input == '[') || (input == ']') || (input == ','))
-  {
+  if (((input >= '0') && (input <= '9')) || ((input >= 'A') && (input <= 'Z'))
+      || ((input >= 'a') && (input <= 'z')) || (input == '/') || (input == ':')
+      || (input == '.') || (input == '@') || (input == '+') || (input == '-')
+      || (input == '_') || (input == '~') || (input == '[') || (input == ']')
+      || (input == ',')) {
     output[0] = static_cast<char>(input);
     return false;
   }
 
   output[0] = '%';
-  output[1] = static_cast<char>(
-                             (input / 16) + ((input / 16 <= 9) ? '0' : 'A'-10));
-  output[2] = static_cast<char>(
-                             (input % 16) + ((input % 16 <= 9) ? '0' : 'A'-10));
+  output[1] = static_cast<char>((input / 16)
+                                + ((input / 16 <= 9) ? '0' : 'A' - 10));
+  output[2] = static_cast<char>((input % 16)
+                                + ((input % 16 <= 9) ? '0' : 'A' - 10));
   return true;
 }
 
@@ -437,7 +429,7 @@ string DownloadManager::EscapeUrl(const int64_t jobinfo_id, const string &url) {
     }
   }
   LogCvmfs(kLogDownload, kLogDebug, "(id %" PRId64 ") escaped %s to %s",
-                                      jobinfo_id, url.c_str(), escaped.c_str());
+           jobinfo_id, url.c_str(), escaped.c_str());
 
   return escaped;
 }
@@ -447,9 +439,8 @@ string DownloadManager::EscapeUrl(const int64_t jobinfo_id, const string &url) {
  * passing NULL to EscapeHeader.
  */
 unsigned DownloadManager::EscapeHeader(const string &header,
-                             char *escaped_buf,
-                             size_t buf_size)
-{
+                                       char *escaped_buf,
+                                       size_t buf_size) {
   unsigned esc_pos = 0;
   char escaped_char[3];
   for (unsigned i = 0, s = header.size(); i < s; ++i) {
@@ -498,8 +489,7 @@ int DownloadManager::CallbackCurlSocket(CURL * /* easy */,
                                         curl_socket_t s,
                                         int action,
                                         void *userp,
-                                        void * /* socketp */)
-{
+                                        void * /* socketp */) {
   // LogCvmfs(kLogDownload, kLogDebug, "CallbackCurlSocket called with easy "
   //          "handle %p, socket %d, action %d", easy, s, action);
   DownloadManager *download_mgr = static_cast<DownloadManager *>(userp);
@@ -518,16 +508,15 @@ int DownloadManager::CallbackCurlSocket(CURL * /* easy */,
   // Or create newly
   if (index == download_mgr->watch_fds_inuse_) {
     // Extend array if necessary
-    if (download_mgr->watch_fds_inuse_ == download_mgr->watch_fds_size_)
-    {
+    if (download_mgr->watch_fds_inuse_ == download_mgr->watch_fds_size_) {
       assert(download_mgr->watch_fds_size_ > 0);
       download_mgr->watch_fds_size_ *= 2;
-      download_mgr->watch_fds_ = static_cast<struct pollfd *>(
-        srealloc(download_mgr->watch_fds_,
-                 download_mgr->watch_fds_size_ * sizeof(struct pollfd)));
+      download_mgr->watch_fds_       = static_cast<struct pollfd *>(
+          srealloc(download_mgr->watch_fds_,
+                         download_mgr->watch_fds_size_ * sizeof(struct pollfd)));
     }
-    download_mgr->watch_fds_[download_mgr->watch_fds_inuse_].fd = s;
-    download_mgr->watch_fds_[download_mgr->watch_fds_inuse_].events = 0;
+    download_mgr->watch_fds_[download_mgr->watch_fds_inuse_].fd      = s;
+    download_mgr->watch_fds_[download_mgr->watch_fds_inuse_].events  = 0;
     download_mgr->watch_fds_[download_mgr->watch_fds_inuse_].revents = 0;
     download_mgr->watch_fds_inuse_++;
   }
@@ -540,25 +529,26 @@ int DownloadManager::CallbackCurlSocket(CURL * /* easy */,
       download_mgr->watch_fds_[index].events = POLLOUT | POLLWRBAND;
       break;
     case CURL_POLL_INOUT:
-      download_mgr->watch_fds_[index].events =
-        POLLIN | POLLPRI | POLLOUT | POLLWRBAND;
+      download_mgr->watch_fds_[index].events = POLLIN | POLLPRI | POLLOUT
+                                               | POLLWRBAND;
       break;
     case CURL_POLL_REMOVE:
-      if (index < download_mgr->watch_fds_inuse_-1) {
-        download_mgr->watch_fds_[index] =
-          download_mgr->watch_fds_[download_mgr->watch_fds_inuse_-1];
+      if (index < download_mgr->watch_fds_inuse_ - 1) {
+        download_mgr
+            ->watch_fds_[index] = download_mgr->watch_fds_
+                                      [download_mgr->watch_fds_inuse_ - 1];
       }
       download_mgr->watch_fds_inuse_--;
       // Shrink array if necessary
-      if ((download_mgr->watch_fds_inuse_ > download_mgr->watch_fds_max_) &&
-          (download_mgr->watch_fds_inuse_ < download_mgr->watch_fds_size_/2))
-      {
+      if ((download_mgr->watch_fds_inuse_ > download_mgr->watch_fds_max_)
+          && (download_mgr->watch_fds_inuse_
+              < download_mgr->watch_fds_size_ / 2)) {
         download_mgr->watch_fds_size_ /= 2;
         // LogCvmfs(kLogDownload, kLogDebug, "shrinking watch_fds_ (%d)",
         //          watch_fds_size_);
         download_mgr->watch_fds_ = static_cast<struct pollfd *>(
-          srealloc(download_mgr->watch_fds_,
-                   download_mgr->watch_fds_size_*sizeof(struct pollfd)));
+            srealloc(download_mgr->watch_fds_,
+                     download_mgr->watch_fds_size_ * sizeof(struct pollfd)));
         // LogCvmfs(kLogDownload, kLogDebug, "shrinking watch_fds_ done",
         //          watch_fds_size_);
       }
@@ -577,24 +567,24 @@ int DownloadManager::CallbackCurlSocket(CURL * /* easy */,
 void *DownloadManager::MainDownload(void *data) {
   DownloadManager *download_mgr = static_cast<DownloadManager *>(data);
   LogCvmfs(kLogDownload, kLogDebug,
-                         "download I/O thread of DownloadManager '%s' started",
-                         download_mgr->name_.c_str());
+           "download I/O thread of DownloadManager '%s' started",
+           download_mgr->name_.c_str());
 
   const int kIdxPipeTerminate = 0;
-  const int kIdxPipeJobs = 1;
+  const int kIdxPipeJobs      = 1;
 
-  download_mgr->watch_fds_ =
-    static_cast<struct pollfd *>(smalloc(2 * sizeof(struct pollfd)));
-  download_mgr->watch_fds_size_ = 2;
-  download_mgr->watch_fds_[kIdxPipeTerminate].fd =
-                                     download_mgr->pipe_terminate_->GetReadFd();
-  download_mgr->watch_fds_[kIdxPipeTerminate].events = POLLIN | POLLPRI;
+  download_mgr->watch_fds_ = static_cast<struct pollfd *>(
+      smalloc(2 * sizeof(struct pollfd)));
+  download_mgr->watch_fds_size_                  = 2;
+  download_mgr->watch_fds_[kIdxPipeTerminate].fd = download_mgr->pipe_terminate_
+                                                       ->GetReadFd();
+  download_mgr->watch_fds_[kIdxPipeTerminate].events  = POLLIN | POLLPRI;
   download_mgr->watch_fds_[kIdxPipeTerminate].revents = 0;
-  download_mgr->watch_fds_[kIdxPipeJobs].fd =
-                                          download_mgr->pipe_jobs_->GetReadFd();
-  download_mgr->watch_fds_[kIdxPipeJobs].events = POLLIN | POLLPRI;
+  download_mgr->watch_fds_[kIdxPipeJobs].fd           = download_mgr->pipe_jobs_
+                                                  ->GetReadFd();
+  download_mgr->watch_fds_[kIdxPipeJobs].events  = POLLIN | POLLPRI;
   download_mgr->watch_fds_[kIdxPipeJobs].revents = 0;
-  download_mgr->watch_fds_inuse_ = 2;
+  download_mgr->watch_fds_inuse_                 = 2;
 
   int still_running = 0;
   struct timeval timeval_start, timeval_stop;
@@ -616,7 +606,7 @@ void *DownloadManager::MainDownload(void *data) {
       timeout = -1;
       gettimeofday(&timeval_stop, NULL);
       int64_t delta = static_cast<int64_t>(
-        1000 * DiffTimeSeconds(timeval_start, timeval_stop));
+          1000 * DiffTimeSeconds(timeval_start, timeval_stop));
       perf::Xadd(download_mgr->counters_->sz_transfer_time, delta);
     }
     int retval = poll(download_mgr->watch_fds_, download_mgr->watch_fds_inuse_,
@@ -627,10 +617,8 @@ void *DownloadManager::MainDownload(void *data) {
 
     // Handle timeout
     if (retval == 0) {
-      curl_multi_socket_action(download_mgr->curl_multi_,
-                               CURL_SOCKET_TIMEOUT,
-                               0,
-                               &still_running);
+      curl_multi_socket_action(
+          download_mgr->curl_multi_, CURL_SOCKET_TIMEOUT, 0, &still_running);
     }
 
     // Terminate I/O thread
@@ -641,7 +629,7 @@ void *DownloadManager::MainDownload(void *data) {
     if (download_mgr->watch_fds_[kIdxPipeJobs].revents) {
       download_mgr->watch_fds_[kIdxPipeJobs].revents = 0;
       JobInfo *info;
-      download_mgr->pipe_jobs_->Read<JobInfo*>(&info);
+      download_mgr->pipe_jobs_->Read<JobInfo *>(&info);
       if (!still_running) {
         gettimeofday(&timeval_start, NULL);
       }
@@ -649,10 +637,8 @@ void *DownloadManager::MainDownload(void *data) {
       download_mgr->InitializeRequest(info, handle);
       download_mgr->SetUrlOptions(info);
       curl_multi_add_handle(download_mgr->curl_multi_, handle);
-      curl_multi_socket_action(download_mgr->curl_multi_,
-                               CURL_SOCKET_TIMEOUT,
-                               0,
-                               &still_running);
+      curl_multi_socket_action(
+          download_mgr->curl_multi_, CURL_SOCKET_TIMEOUT, 0, &still_running);
     }
 
     // Activity on curl sockets
@@ -660,7 +646,7 @@ void *DownloadManager::MainDownload(void *data) {
     // to be removed from watch_fds_. If a socket is removed it is replaced
     // by the socket at the end of the array and the inuse count is decreased.
     // Therefore loop over the array in reverse order.
-    for (int64_t i = download_mgr->watch_fds_inuse_-1; i >= 2; --i) {
+    for (int64_t i = download_mgr->watch_fds_inuse_ - 1; i >= 2; --i) {
       if (i >= download_mgr->watch_fds_inuse_) {
         continue;
       }
@@ -670,9 +656,8 @@ void *DownloadManager::MainDownload(void *data) {
           ev_bitmask |= CURL_CSELECT_IN;
         if (download_mgr->watch_fds_[i].revents & (POLLOUT | POLLWRBAND))
           ev_bitmask |= CURL_CSELECT_OUT;
-        if (download_mgr->watch_fds_[i].revents &
-            (POLLERR | POLLHUP | POLLNVAL))
-        {
+        if (download_mgr->watch_fds_[i].revents
+            & (POLLERR | POLLHUP | POLLNVAL)) {
           ev_bitmask |= CURL_CSELECT_ERR;
         }
         download_mgr->watch_fds_[i].revents = 0;
@@ -688,21 +673,20 @@ void *DownloadManager::MainDownload(void *data) {
     CURLMsg *curl_msg;
     int msgs_in_queue;
     while ((curl_msg = curl_multi_info_read(download_mgr->curl_multi_,
-                                            &msgs_in_queue)))
-    {
+                                            &msgs_in_queue))) {
       if (curl_msg->msg == CURLMSG_DONE) {
         perf::Inc(download_mgr->counters_->n_requests);
         JobInfo *info;
         CURL *easy_handle = curl_msg->easy_handle;
-        int curl_error = curl_msg->data.result;
+        int curl_error    = curl_msg->data.result;
         curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &info);
 
         int64_t redir_count;
         curl_easy_getinfo(easy_handle, CURLINFO_REDIRECT_COUNT, &redir_count);
-        LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                                  "Number of CURL redirects %" PRId64 ,
-                                  download_mgr->name_.c_str(), info->id(),
-                                  redir_count);
+        LogCvmfs(kLogDownload, kLogDebug,
+                 "(manager '%s' - id %" PRId64 ") "
+                 "Number of CURL redirects %" PRId64,
+                 download_mgr->name_.c_str(), info->id(), redir_count);
 
         curl_multi_remove_handle(download_mgr->curl_multi_, easy_handle);
         if (download_mgr->VerifyAndFinalize(curl_error, info)) {
@@ -717,16 +701,17 @@ void *DownloadManager::MainDownload(void *data) {
 
           DataTubeElement *ele = new DataTubeElement(kActionStop);
           info->GetDataTubePtr()->EnqueueBack(ele);
-          info->GetPipeJobResultPtr()->
-                                  Write<download::Failures>(info->error_code());
+          info->GetPipeJobResultPtr()->Write<download::Failures>(
+              info->error_code());
         }
       }
     }
   }
 
-  for (set<CURL *>::iterator i = download_mgr->pool_handles_inuse_->begin(),
-       iEnd = download_mgr->pool_handles_inuse_->end(); i != iEnd; ++i)
-  {
+  for (set<CURL *>::iterator i    = download_mgr->pool_handles_inuse_->begin(),
+                             iEnd = download_mgr->pool_handles_inuse_->end();
+       i != iEnd;
+       ++i) {
     curl_multi_remove_handle(download_mgr->curl_multi_, *i);
     curl_easy_cleanup(*i);
   }
@@ -734,8 +719,8 @@ void *DownloadManager::MainDownload(void *data) {
   free(download_mgr->watch_fds_);
 
   LogCvmfs(kLogDownload, kLogDebug,
-                       "download I/O thread of DownloadManager '%s' terminated",
-                       download_mgr->name_.c_str());
+           "download I/O thread of DownloadManager '%s' terminated",
+           download_mgr->name_.c_str());
   return NULL;
 }
 
@@ -751,23 +736,21 @@ HeaderLists::~HeaderLists() {
 }
 
 
-curl_slist *HeaderLists::GetList(const char *header) {
-  return Get(header);
-}
+curl_slist *HeaderLists::GetList(const char *header) { return Get(header); }
 
 
 curl_slist *HeaderLists::DuplicateList(curl_slist *slist) {
   assert(slist);
   curl_slist *copy = GetList(slist->data);
-  copy->next = slist->next;
+  copy->next       = slist->next;
   curl_slist *prev = copy;
-  slist = slist->next;
+  slist            = slist->next;
   while (slist) {
     curl_slist *new_link = Get(slist->data);
-    new_link->next = slist->next;
-    prev->next = new_link;
-    prev = new_link;
-    slist = slist->next;
+    new_link->next       = slist->next;
+    prev->next           = new_link;
+    prev                 = new_link;
+    slist                = slist->next;
   }
   return copy;
 }
@@ -776,10 +759,9 @@ curl_slist *HeaderLists::DuplicateList(curl_slist *slist) {
 void HeaderLists::AppendHeader(curl_slist *slist, const char *header) {
   assert(slist);
   curl_slist *new_link = Get(header);
-  new_link->next = NULL;
+  new_link->next       = NULL;
 
-  while (slist->next)
-    slist = slist->next;
+  while (slist->next) slist = slist->next;
   slist->next = new_link;
 }
 
@@ -792,8 +774,8 @@ void HeaderLists::AppendHeader(curl_slist *slist, const char *header) {
 void HeaderLists::CutHeader(const char *header, curl_slist **slist) {
   assert(slist);
   curl_slist head;
-  head.next = *slist;
-  curl_slist *prev = &head;
+  head.next         = *slist;
+  curl_slist *prev  = &head;
   curl_slist *rover = *slist;
   while (rover) {
     if (strcmp(rover->data, header) == 0) {
@@ -801,7 +783,7 @@ void HeaderLists::CutHeader(const char *header, curl_slist **slist) {
       Put(rover);
       rover = prev;
     }
-    prev = rover;
+    prev  = rover;
     rover = rover->next;
   }
   *slist = head.next;
@@ -821,7 +803,7 @@ string HeaderLists::Print(curl_slist *slist) {
   string verbose;
   while (slist) {
     verbose += string(slist->data) + "\n";
-    slist = slist->next;
+    slist    = slist->next;
   }
   return verbose;
 }
@@ -839,8 +821,8 @@ curl_slist *HeaderLists::Get(const char *header) {
 
   // All used, new block
   AddBlock();
-  blocks_[blocks_.size()-1][0].data = const_cast<char *>(header);
-  return &(blocks_[blocks_.size()-1][0]);
+  blocks_[blocks_.size() - 1][0].data = const_cast<char *>(header);
+  return &(blocks_[blocks_.size() - 1][0]);
 }
 
 
@@ -867,13 +849,13 @@ string DownloadManager::ProxyInfo::Print() {
     return url;
 
   string result = url;
-  int remaining =
-    static_cast<int>(host.deadline()) - static_cast<int>(time(NULL));
+  int remaining = static_cast<int>(host.deadline())
+                  - static_cast<int>(time(NULL));
   string expinfo = (remaining >= 0) ? "+" : "";
   if (abs(remaining) >= 3600) {
-    expinfo += StringifyInt(remaining/3600) + "h";
+    expinfo += StringifyInt(remaining / 3600) + "h";
   } else if (abs(remaining) >= 60) {
-    expinfo += StringifyInt(remaining/60) + "m";
+    expinfo += StringifyInt(remaining / 60) + "m";
   } else {
     expinfo += StringifyInt(remaining) + "s";
   }
@@ -956,10 +938,11 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
     header_lists_->AppendHeader(info->headers(), info->tracing_header_gid());
     header_lists_->AppendHeader(info->headers(), info->tracing_header_uid());
 
-    LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                                "CURL Header for URL: %s is:\n %s",
-                                name_.c_str(), info->id(), info->url()->c_str(),
-                                header_lists_->Print(info->headers()).c_str());
+    LogCvmfs(kLogDownload, kLogDebug,
+             "(manager '%s' - id %" PRId64 ") "
+             "CURL Header for URL: %s is:\n %s",
+             name_.c_str(), info->id(), info->url()->c_str(),
+             header_lists_->Print(info->headers()).c_str());
   }
 
   if (info->force_nocache()) {
@@ -978,12 +961,11 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
   if ((info->range_offset() != -1) && (info->range_size())) {
     char byte_range_array[100];
     const int64_t range_lower = static_cast<int64_t>(info->range_offset());
-    const int64_t range_upper = static_cast<int64_t>(
-                                 info->range_offset() + info->range_size() - 1);
+    const int64_t range_upper = static_cast<int64_t>(info->range_offset()
+                                                     + info->range_size() - 1);
     if (snprintf(byte_range_array, sizeof(byte_range_array),
-                 "%" PRId64 "-%" PRId64,
-                 range_lower, range_upper) == 100)
-    {
+                 "%" PRId64 "-%" PRId64, range_lower, range_upper)
+        == 100) {
       PANIC(NULL);  // Should be impossible given limits on offset size.
     }
     curl_easy_setopt(handle, CURLOPT_RANGE, byte_range_array);
@@ -993,8 +975,7 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
 
   // Set curl parameters
   curl_easy_setopt(handle, CURLOPT_PRIVATE, static_cast<void *>(info));
-  curl_easy_setopt(handle, CURLOPT_WRITEHEADER,
-                   static_cast<void *>(info));
+  curl_easy_setopt(handle, CURLOPT_WRITEHEADER, static_cast<void *>(info));
   curl_easy_setopt(handle, CURLOPT_WRITEDATA, static_cast<void *>(info));
   curl_easy_setopt(handle, CURLOPT_HTTPHEADER, info->headers());
   if (info->head_request()) {
@@ -1015,24 +996,22 @@ void DownloadManager::InitializeRequest(JobInfo *info, CURL *handle) {
 #endif
 }
 
-void DownloadManager::CheckHostInfoReset(
-    const std::string &typ,
-    HostInfo &info,
-    JobInfo *jobinfo,
-    time_t &now)
-{
+void DownloadManager::CheckHostInfoReset(const std::string &typ,
+                                         HostInfo &info,
+                                         JobInfo *jobinfo,
+                                         time_t &now) {
   if (info.timestamp_backup > 0) {
     if (now == 0)
       now = time(NULL);
-    if (static_cast<int64_t>(now) >
-        static_cast<int64_t>(info.timestamp_backup + info.reset_after))
-    {
+    if (static_cast<int64_t>(now)
+        > static_cast<int64_t>(info.timestamp_backup + info.reset_after)) {
       LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-              "(manager %s - id %" PRId64 ") "
-              "switching %s from %s to %s (reset %s)", name_.c_str(),
-              jobinfo->id(), typ.c_str(), (*info.chain)[info.current].c_str(),
-              (*info.chain)[0].c_str(), typ.c_str());
-      info.current = 0;
+               "(manager %s - id %" PRId64 ") "
+               "switching %s from %s to %s (reset %s)",
+               name_.c_str(), jobinfo->id(), typ.c_str(),
+               (*info.chain)[info.current].c_str(), (*info.chain)[0].c_str(),
+               typ.c_str());
+      info.current          = 0;
       info.timestamp_backup = 0;
     }
   }
@@ -1056,19 +1035,18 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
       // proxy already set, so this is a failover event
       perf::Inc(counters_->n_proxy_failover);
     }
-    info->SetProxy(sharding_policy_->GetNextProxy(info->url(), info->proxy(),
-                   info->range_offset() == -1 ? 0 : info->range_offset()));
+    info->SetProxy(sharding_policy_->GetNextProxy(
+        info->url(), info->proxy(),
+        info->range_offset() == -1 ? 0 : info->range_offset()));
 
     curl_easy_setopt(info->curl_handle(), CURLOPT_PROXY, info->proxy().c_str());
   } else {  // no sharding policy
     // Check if proxy group needs to be reset from backup to primary
     if (opt_timestamp_backup_proxies_ > 0) {
       now = time(NULL);
-      if (static_cast<int64_t>(now) >
-          static_cast<int64_t>(opt_timestamp_backup_proxies_ +
-                              opt_proxy_groups_reset_after_))
-      {
-        opt_proxy_groups_current_ = 0;
+      if (static_cast<int64_t>(now) > static_cast<int64_t>(
+              opt_timestamp_backup_proxies_ + opt_proxy_groups_reset_after_)) {
+        opt_proxy_groups_current_     = 0;
         opt_timestamp_backup_proxies_ = 0;
         RebalanceProxiesUnlocked("Reset proxy group from backup to primary");
       }
@@ -1077,12 +1055,11 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
     if (opt_timestamp_failover_proxies_ > 0) {
       if (now == 0)
         now = time(NULL);
-      if (static_cast<int64_t>(now) >
-          static_cast<int64_t>(opt_timestamp_failover_proxies_ +
-                              opt_proxy_groups_reset_after_))
-      {
+      if (static_cast<int64_t>(now)
+          > static_cast<int64_t>(opt_timestamp_failover_proxies_
+                                 + opt_proxy_groups_reset_after_)) {
         RebalanceProxiesUnlocked(
-                         "Reset load-balanced proxies within the active group");
+            "Reset load-balanced proxies within the active group");
       }
     }
 
@@ -1094,8 +1071,8 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
       // Note: inside ValidateProxyIpsUnlocked() we may change the proxy data
       // structure, so we must not pass proxy->... (== current_proxy())
       // parameters directly
-      std::string purl = proxy->url;
-      dns::Host phost = proxy->host;
+      std::string purl   = proxy->url;
+      dns::Host phost    = proxy->host;
       const bool changed = ValidateProxyIpsUnlocked(purl, phost);
       // Current proxy may have changed
       if (changed) {
@@ -1104,7 +1081,7 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
       info->SetProxy(proxy->url);
       if (proxy->host.status() == dns::kFailOk) {
         curl_easy_setopt(info->curl_handle(), CURLOPT_PROXY,
-                        info->proxy().c_str());
+                         info->proxy().c_str());
       } else {
         // We know it can't work, don't even try to download
         curl_easy_setopt(info->curl_handle(), CURLOPT_PROXY, "0.0.0.0");
@@ -1131,15 +1108,17 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
     if (CheckMetalinkChain(now)) {
       url_prefix = (*opt_metalink_.chain)[opt_metalink_.current];
       info->SetCurrentMetalinkChainIndex(opt_metalink_.current);
-      LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
-                      "reading from metalink %d",
-                      name_.c_str(), info->id(), opt_metalink_.current);
+      LogCvmfs(kLogDownload, kLogDebug,
+               "(manager %s - id %" PRId64 ") "
+               "reading from metalink %d",
+               name_.c_str(), info->id(), opt_metalink_.current);
     } else if (opt_host_.chain) {
       url_prefix = (*opt_host_.chain)[opt_host_.current];
       info->SetCurrentHostChainIndex(opt_host_.current);
-      LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
-                      "reading from host %d",
-                      name_.c_str(), info->id(), opt_host_.current);
+      LogCvmfs(kLogDownload, kLogDebug,
+               "(manager %s - id %" PRId64 ") "
+               "reading from host %d",
+               name_.c_str(), info->id(), opt_host_.current);
     }
   }
 
@@ -1150,22 +1129,25 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
     bool rvb = ssl_certificate_store_.ApplySslCertificatePath(curl_handle);
     if (!rvb) {
       LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-                       "(manager %s - id %" PRId64 ") "
-                       "Failed to set SSL certificate path %s", name_.c_str(),
-                       info->id(), ssl_certificate_store_.GetCaPath().c_str());
+               "(manager %s - id %" PRId64 ") "
+               "Failed to set SSL certificate path %s",
+               name_.c_str(), info->id(),
+               ssl_certificate_store_.GetCaPath().c_str());
     }
     if (info->pid() != -1) {
       if (credentials_attachment_ == NULL) {
-        LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
-                      "uses secure downloads but no credentials attachment set",
-                      name_.c_str(), info->id());
+        LogCvmfs(kLogDownload, kLogDebug,
+                 "(manager %s - id %" PRId64 ") "
+                 "uses secure downloads but no credentials attachment set",
+                 name_.c_str(), info->id());
       } else {
         bool retval = credentials_attachment_->ConfigureCurlHandle(
-          curl_handle, info->pid(), info->GetCredDataPtr());
+            curl_handle, info->pid(), info->GetCredDataPtr());
         if (!retval) {
-          LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
-                                    "failed attaching credentials",
-                                    name_.c_str(), info->id());
+          LogCvmfs(kLogDownload, kLogDebug,
+                   "(manager %s - id %" PRId64 ") "
+                   "failed attaching credentials",
+                   name_.c_str(), info->id());
         }
       }
     }
@@ -1200,9 +1182,10 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
       }
     }
     replacement = (replacement == "") ? proxy_template_direct_ : replacement;
-    LogCvmfs(kLogDownload, kLogDebug, "(manager %s - id %" PRId64 ") "
-                                "replacing @proxy@ by %s",
-                                name_.c_str(), info->id(), replacement.c_str());
+    LogCvmfs(kLogDownload, kLogDebug,
+             "(manager %s - id %" PRId64 ") "
+             "replacing @proxy@ by %s",
+             name_.c_str(), info->id(), replacement.c_str());
     url = ReplaceAll(url, "@proxy@", replacement);
   }
 
@@ -1210,9 +1193,9 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   // static_cast<cvmfs::MemSink*>(info->sink)->size() == 0
   // and just always call info->sink->Reserve()
   // we should do a speed check
-  if ((info->sink() != NULL) && info->sink()->RequiresReserve() &&
-      (static_cast<cvmfs::MemSink*>(info->sink())->size() == 0) &&
-      HasPrefix(url, "file://", false)) {
+  if ((info->sink() != NULL) && info->sink()->RequiresReserve()
+      && (static_cast<cvmfs::MemSink *>(info->sink())->size() == 0)
+      && HasPrefix(url, "file://", false)) {
     platform_stat64 stat_buf;
     int retval = platform_stat(url.c_str(), &stat_buf);
     if (retval != 0) {
@@ -1225,7 +1208,7 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
   }
 
   curl_easy_setopt(curl_handle, CURLOPT_URL,
-                                            EscapeUrl(info->id(), url).c_str());
+                   EscapeUrl(info->id(), url).c_str());
 }
 
 
@@ -1238,14 +1221,12 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
  *
  * Returns true if proxies may have changed.
  */
-bool DownloadManager::ValidateProxyIpsUnlocked(
-  const string &url,
-  const dns::Host &host)
-{
+bool DownloadManager::ValidateProxyIpsUnlocked(const string &url,
+                                               const dns::Host &host) {
   if (!host.IsExpired())
     return false;
   LogCvmfs(kLogDownload, kLogDebug, "(manager '%s') validate DNS entry for %s",
-                                    name_.c_str(), host.name().c_str());
+           name_.c_str(), host.name().c_str());
 
   unsigned group_idx = opt_proxy_groups_current_;
   dns::Host new_host = resolver_->Resolve(host.name());
@@ -1276,9 +1257,9 @@ bool DownloadManager::ValidateProxyIpsUnlocked(
   LogCvmfs(kLogDownload, kLogDebug | kLogSyslog,
            "(manager '%s') DNS entries for proxy %s changed, adjusting",
            name_.c_str(), host.name().c_str());
-  vector<ProxyInfo> *group = current_proxy_group();
-  opt_num_proxies_ -= group->size();
-  for (unsigned i = 0; i < group->size(); ) {
+  vector<ProxyInfo> *group  = current_proxy_group();
+  opt_num_proxies_         -= group->size();
+  for (unsigned i = 0; i < group->size();) {
     if ((*group)[i].host.id() == host.id()) {
       group->erase(group->begin() + i);
     } else {
@@ -1327,9 +1308,9 @@ bool DownloadManager::CanRetry(const JobInfo *info) {
   MutexLockGuard m(lock_options_);
   unsigned max_retries = opt_max_retries_;
 
-  return !(info->nocache()) && (info->num_retries() < max_retries) &&
-          (IsProxyTransferError(info->error_code()) ||
-           IsHostTransferError(info->error_code()));
+  return !(info->nocache()) && (info->num_retries() < max_retries)
+         && (IsProxyTransferError(info->error_code())
+             || IsHostTransferError(info->error_code()));
 }
 
 /**
@@ -1341,11 +1322,11 @@ bool DownloadManager::CanRetry(const JobInfo *info) {
  */
 void DownloadManager::Backoff(JobInfo *info) {
   unsigned backoff_init_ms = 0;
-  unsigned backoff_max_ms = 0;
+  unsigned backoff_max_ms  = 0;
   {
     MutexLockGuard m(lock_options_);
     backoff_init_ms = opt_backoff_init_ms_;
-    backoff_max_ms = opt_backoff_max_ms_;
+    backoff_max_ms  = opt_backoff_max_ms_;
   }
 
   info->SetNumRetries(info->num_retries() + 1);
@@ -1360,8 +1341,8 @@ void DownloadManager::Backoff(JobInfo *info) {
   }
 
   LogCvmfs(kLogDownload, kLogDebug,
-                        "(manager '%s' - id %" PRId64 ") backing off for %d ms",
-                        name_.c_str(), info->id(), info->backoff_ms());
+           "(manager '%s' - id %" PRId64 ") backing off for %d ms",
+           name_.c_str(), info->id(), info->backoff_ms());
   SafeSleepMs(info->backoff_ms());
 }
 
@@ -1407,10 +1388,9 @@ static bool sortlinks(const std::string &s1, const std::string &s2) {
   const size_t pos1 = s1.find("; pri=");
   const size_t pos2 = s2.find("; pri=");
   int pri1, pri2;
-  if ((pos1 != std::string::npos) &&
-      (pos2 != std::string::npos) &&
-      (sscanf(s1.substr(pos1+6).c_str(), "%d", &pri1) == 1) &&
-      (sscanf(s2.substr(pos2+6).c_str(), "%d", &pri2) == 1)) {
+  if ((pos1 != std::string::npos) && (pos2 != std::string::npos)
+      && (sscanf(s1.substr(pos1 + 6).c_str(), "%d", &pri1) == 1)
+      && (sscanf(s2.substr(pos2 + 6).c_str(), "%d", &pri2) == 1)) {
     return pri1 < pri2;
   }
   return false;
@@ -1421,7 +1401,6 @@ static bool sortlinks(const std::string &s1, const std::string &s2) {
  * See rfc6249.
  */
 void DownloadManager::ProcessLink(JobInfo *info) {
-
   std::vector<std::string> links = SplitString(info->link(), ',');
   if (info->link().find("; pri=") != std::string::npos)
     std::sort(links.begin(), links.end(), sortlinks);
@@ -1431,41 +1410,43 @@ void DownloadManager::ProcessLink(JobInfo *info) {
   std::vector<std::string>::const_iterator il = links.begin();
   for (; il != links.end(); ++il) {
     const std::string &link = *il;
-    if ((link.find("; rel=duplicate") == std::string::npos) &&
-        (link.find("; rel=\"duplicate\"") == std::string::npos)) {
+    if ((link.find("; rel=duplicate") == std::string::npos)
+        && (link.find("; rel=\"duplicate\"") == std::string::npos)) {
       LogCvmfs(kLogDownload, kLogDebug,
-        "skipping link '%s' because it does not contain rel=duplicate",
-        link.c_str());
+               "skipping link '%s' because it does not contain rel=duplicate",
+               link.c_str());
       continue;
     }
     // ignore depth= field since there's nothing useful we can do with it
 
     size_t start = link.find('<');
     if (start == std::string::npos) {
-      LogCvmfs(kLogDownload, kLogDebug,
-        "skipping link '%s' because it does not have a left angle bracket",
-        link.c_str());
+      LogCvmfs(
+          kLogDownload, kLogDebug,
+          "skipping link '%s' because it does not have a left angle bracket",
+          link.c_str());
       continue;
     }
 
     start++;
-    if ((link.substr(start, 7) != "http://") &&
-        (link.substr(start, 8) != "https://")) {
+    if ((link.substr(start, 7) != "http://")
+        && (link.substr(start, 8) != "https://")) {
       LogCvmfs(kLogDownload, kLogDebug,
-        "skipping link '%s' of unrecognized url protocol", link.c_str());
+               "skipping link '%s' of unrecognized url protocol", link.c_str());
       continue;
     }
 
-    size_t end = link.find('/', start+8);
+    size_t end = link.find('/', start + 8);
     if (end == std::string::npos)
       end = link.find('>');
     if (end == std::string::npos) {
       LogCvmfs(kLogDownload, kLogDebug,
-        "skipping link '%s' because no slash in url and no right angle bracket",
-        link.c_str());
+               "skipping link '%s' because no slash in url and no right angle "
+               "bracket",
+               link.c_str());
       continue;
     }
-    const std::string host = link.substr(start, end-start);
+    const std::string host = link.substr(start, end - start);
     LogCvmfs(kLogDownload, kLogDebug, "adding linked host '%s'", host.c_str());
     host_list.push_back(host);
   }
@@ -1484,24 +1465,25 @@ void DownloadManager::ProcessLink(JobInfo *info) {
  * \return true if another download should be performed, false otherwise
  */
 bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
-  LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                           "Verify downloaded url %s, proxy %s (curl error %d)",
-                           name_.c_str(), info->id(), info->url()->c_str(),
-                           info->proxy().c_str(), curl_error);
+  LogCvmfs(kLogDownload, kLogDebug,
+           "(manager '%s' - id %" PRId64 ") "
+           "Verify downloaded url %s, proxy %s (curl error %d)",
+           name_.c_str(), info->id(), info->url()->c_str(),
+           info->proxy().c_str(), curl_error);
   UpdateStatistics(info->curl_handle());
 
   bool was_metalink;
   std::string typ;
   if (info->current_metalink_chain_index() >= 0) {
     was_metalink = true;
-    typ = "metalink";
+    typ          = "metalink";
     if (info->link() != "") {
       // process Link header whether or not the redirected URL got an error
       ProcessLink(info);
     }
   } else {
     was_metalink = false;
-    typ = "host";
+    typ          = "host";
   }
 
 
@@ -1514,18 +1496,20 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
         shash::Final(info->hash_context(), &match_hash);
         if (match_hash != *(info->expected_hash())) {
           if (ignore_signature_failures_) {
-            LogCvmfs(kLogDownload, kLogDebug | kLogSyslogErr,
+            LogCvmfs(
+                kLogDownload, kLogDebug | kLogSyslogErr,
                 "(manager '%s' - id %" PRId64 ") "
                 "ignoring failed hash verification of %s (expected %s, got %s)",
                 name_.c_str(), info->id(), info->url()->c_str(),
                 info->expected_hash()->ToString().c_str(),
                 match_hash.ToString().c_str());
           } else {
-            LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                         "hash verification of %s failed (expected %s, got %s)",
-                         name_.c_str(), info->id(), info->url()->c_str(),
-                         info->expected_hash()->ToString().c_str(),
-                         match_hash.ToString().c_str());
+            LogCvmfs(kLogDownload, kLogDebug,
+                     "(manager '%s' - id %" PRId64 ") "
+                     "hash verification of %s failed (expected %s, got %s)",
+                     name_.c_str(), info->id(), info->url()->c_str(),
+                     info->expected_hash()->ToString().c_str(),
+                     match_hash.ToString().c_str());
             info->SetErrorCode(kFailBadData);
             break;
           }
@@ -1547,14 +1531,14 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
       info->SetErrorCode(kFailHostResolve);
       break;
     case CURLE_OPERATION_TIMEDOUT:
-    info->SetErrorCode((info->proxy() == "DIRECT") ?
-                         kFailHostTooSlow : kFailProxyTooSlow);
+      info->SetErrorCode((info->proxy() == "DIRECT") ? kFailHostTooSlow
+                                                     : kFailProxyTooSlow);
       break;
     case CURLE_PARTIAL_FILE:
     case CURLE_GOT_NOTHING:
     case CURLE_RECV_ERROR:
-      info->SetErrorCode((info->proxy() == "DIRECT") ?
-                         kFailHostShortTransfer : kFailProxyShortTransfer);
+      info->SetErrorCode((info->proxy() == "DIRECT") ? kFailHostShortTransfer
+                                                     : kFailProxyShortTransfer);
       break;
     case CURLE_FILE_COULDNT_READ_FILE:
     case CURLE_COULDNT_CONNECT:
@@ -1583,7 +1567,8 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
                "(manager '%s' - id %" PRId64 ") "
                "invalid SSL certificate of remote host. "
                "X509_CERT_DIR and/or X509_CERT_BUNDLE might point to the wrong "
-               "location.", name_.c_str(), info->id());
+               "location.",
+               name_.c_str(), info->id());
       info->SetErrorCode(kFailHostConnection);
       break;
     case CURLE_ABORTED_BY_CALLBACK:
@@ -1594,13 +1579,14 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
       // The curl error CURLE_SEND_ERROR can be seen when a cache is misbehaving
       // and closing connections before the http request send is completed.
       // Handle this error, treating it as a short transfer error.
-      info->SetErrorCode((info->proxy() == "DIRECT") ?
-        kFailHostShortTransfer : kFailProxyShortTransfer);
+      info->SetErrorCode((info->proxy() == "DIRECT") ? kFailHostShortTransfer
+                                                     : kFailProxyShortTransfer);
       break;
     default:
-      LogCvmfs(kLogDownload, kLogSyslogErr, "(manager '%s' - id %" PRId64 ") "
-                   "unexpected curl error (%d) while trying to fetch %s",
-                   name_.c_str(), info->id(), curl_error, info->url()->c_str());
+      LogCvmfs(kLogDownload, kLogSyslogErr,
+               "(manager '%s' - id %" PRId64 ") "
+               "unexpected curl error (%d) while trying to fetch %s",
+               name_.c_str(), info->id(), curl_error, info->url()->c_str());
       info->SetErrorCode(kFailOther);
       break;
   }
@@ -1608,15 +1594,15 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
   std::vector<std::string> *host_chain;
   unsigned char num_used_hosts;
   if (was_metalink) {
-    host_chain = opt_metalink_.chain;
+    host_chain     = opt_metalink_.chain;
     num_used_hosts = info->num_used_metalinks();
   } else {
-    host_chain = opt_host_.chain;
+    host_chain     = opt_host_.chain;
     num_used_hosts = info->num_used_hosts();
   }
 
   // Determination if download should be repeated
-  bool try_again = false;
+  bool try_again      = false;
   bool same_url_retry = CanRetry(info);
   if (info->error_code() != kFailOk) {
     MutexLockGuard m(lock_options_);
@@ -1626,57 +1612,51 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
       } else {
         // Make it a host failure
         LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-                       "(manager '%s' - id %" PRId64 ") "
-                       "data corruption with no-cache header, try another %s",
-                       name_.c_str(), info->id(), typ.c_str());
+                 "(manager '%s' - id %" PRId64 ") "
+                 "data corruption with no-cache header, try another %s",
+                 name_.c_str(), info->id(), typ.c_str());
 
         info->SetErrorCode(kFailHostHttp);
       }
     }
-    if ( same_url_retry || (
-         ( (info->error_code() == kFailHostResolve) ||
-           IsHostTransferError(info->error_code()) ||
-           (info->error_code() == kFailHostHttp)) &&
-         info->probe_hosts() &&
-         host_chain && (num_used_hosts < host_chain->size()))
-       )
-    {
+    if (same_url_retry
+        || (((info->error_code() == kFailHostResolve)
+             || IsHostTransferError(info->error_code())
+             || (info->error_code() == kFailHostHttp))
+            && info->probe_hosts() && host_chain
+            && (num_used_hosts < host_chain->size()))) {
       try_again = true;
     }
-    if ( same_url_retry || (
-         ( (info->error_code() == kFailProxyResolve) ||
-           IsProxyTransferError(info->error_code()) ||
-           (info->error_code() == kFailProxyHttp)) )
-       )
-    {
+    if (same_url_retry
+        || (((info->error_code() == kFailProxyResolve)
+             || IsProxyTransferError(info->error_code())
+             || (info->error_code() == kFailProxyHttp)))) {
       if (sharding_policy_.UseCount() > 0) {  // sharding policy
-       try_again = true;
-       same_url_retry = false;
+        try_again      = true;
+        same_url_retry = false;
       } else {  // no sharding
         try_again = true;
         // If all proxies failed, do a next round with the next host
         if (!same_url_retry && (info->num_used_proxies() >= opt_num_proxies_)) {
           // Check if this can be made a host fail-over
-          if (info->probe_hosts() &&
-              host_chain && (num_used_hosts < host_chain->size()))
-          {
+          if (info->probe_hosts() && host_chain
+              && (num_used_hosts < host_chain->size())) {
             // reset proxy group if not already performed by other handle
             if (opt_proxy_groups_) {
-              if ((opt_proxy_groups_current_ > 0) ||
-                  (opt_proxy_groups_current_burned_ > 0))
-              {
-                opt_proxy_groups_current_ = 0;
+              if ((opt_proxy_groups_current_ > 0)
+                  || (opt_proxy_groups_current_burned_ > 0)) {
+                opt_proxy_groups_current_     = 0;
                 opt_timestamp_backup_proxies_ = 0;
-                const std::string msg =
-                  "reset proxies for " + typ + " failover";
+                const std::string msg         = "reset proxies for " + typ
+                                        + " failover";
                 RebalanceProxiesUnlocked(msg);
               }
             }
 
             // Make it a host failure
             LogCvmfs(kLogDownload, kLogDebug,
-                       "(manager '%s' - id %" PRId64 ") make it a %s failure",
-                       name_.c_str(), info->id(), typ.c_str());
+                     "(manager '%s' - id %" PRId64 ") make it a %s failure",
+                     name_.c_str(), info->id(), typ.c_str());
             info->SetNumUsedProxies(1);
             info->SetErrorCode(kFailHostAfterProxy);
           } else {
@@ -1684,22 +1664,21 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
               // Instead of giving up, reset the num_used_proxies counter,
               // switch proxy and try again
               LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-                   "(manager '%s' - id %" PRId64 ") "
-                   "VerifyAndFinalize() would fail the download here. "
-                   "Instead switch proxy and retry download. "
-                   "typ=%s "
-                   "info->probe_hosts=%d host_chain=%p num_used_hosts=%d "
-                   "host_chain->size()=%lu same_url_retry=%d "
-                   "info->num_used_proxies=%d opt_num_proxies_=%d",
-                   name_.c_str(), info->id(), typ.c_str(),
-                   static_cast<int>(info->probe_hosts()),
-                   host_chain, num_used_hosts,
-                   host_chain ?
-                      host_chain->size() : -1, static_cast<int>(same_url_retry),
-                   info->num_used_proxies(), opt_num_proxies_);
+                       "(manager '%s' - id %" PRId64 ") "
+                       "VerifyAndFinalize() would fail the download here. "
+                       "Instead switch proxy and retry download. "
+                       "typ=%s "
+                       "info->probe_hosts=%d host_chain=%p num_used_hosts=%d "
+                       "host_chain->size()=%lu same_url_retry=%d "
+                       "info->num_used_proxies=%d opt_num_proxies_=%d",
+                       name_.c_str(), info->id(), typ.c_str(),
+                       static_cast<int>(info->probe_hosts()), host_chain,
+                       num_used_hosts, host_chain ? host_chain->size() : -1,
+                       static_cast<int>(same_url_retry),
+                       info->num_used_proxies(), opt_num_proxies_);
               info->SetNumUsedProxies(1);
               RebalanceProxiesUnlocked(
-                                     "download failed - failover indefinitely");
+                  "download failed - failover indefinitely");
               try_again = !Interrupted(fqrn_, info);
             } else {
               try_again = false;
@@ -1711,11 +1690,12 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
   }
 
   if (try_again) {
-    LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                              "Trying again on same curl handle, same url: %d, "
-                              "error code %d no-cache %d",
-                              name_.c_str(), info->id(), same_url_retry,
-                              info->error_code(), info->nocache());
+    LogCvmfs(kLogDownload, kLogDebug,
+             "(manager '%s' - id %" PRId64 ") "
+             "Trying again on same curl handle, same url: %d, "
+             "error code %d no-cache %d",
+             name_.c_str(), info->id(), same_url_retry, info->error_code(),
+             info->nocache());
     // Reset internal state and destination
     if (info->sink() != NULL && info->sink()->Reset() != 0) {
       info->SetErrorCode(kFailLocalIO);
@@ -1741,7 +1721,7 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
 
       // Failure handling
       bool switch_proxy = false;
-      bool switch_host = false;
+      bool switch_host  = false;
       switch (info->error_code()) {
         case kFailBadData:
           SetNocache(info);
@@ -1800,7 +1780,7 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     return true;  // try again
   }
 
- verify_and_finalize_stop:
+verify_and_finalize_stop:
   // Finalize, flush destination file
   ReleaseCredential(info);
   if (info->sink() != NULL && info->sink()->Flush() != 0) {
@@ -1826,7 +1806,7 @@ DownloadManager::~DownloadManager() {
   if (health_check_.UseCount() > 0) {
     if (health_check_.Unique()) {
       LogCvmfs(kLogDownload, kLogDebug,
-                   "(manager '%s') Stopping healthcheck thread", name_.c_str());
+               "(manager '%s') Stopping healthcheck thread", name_.c_str());
       health_check_->StopHealthcheck();
     }
     health_check_.Reset();
@@ -1841,9 +1821,10 @@ DownloadManager::~DownloadManager() {
     pipe_jobs_.Destroy();
   }
 
-  for (set<CURL *>::iterator i = pool_handles_idle_->begin(),
-       iEnd = pool_handles_idle_->end(); i != iEnd; ++i)
-  {
+  for (set<CURL *>::iterator i    = pool_handles_idle_->begin(),
+                             iEnd = pool_handles_idle_->end();
+       i != iEnd;
+       ++i) {
     curl_easy_cleanup(*i);
   }
 
@@ -1880,8 +1861,9 @@ void DownloadManager::InitHeaders() {
 #endif
   cernvm_id += string(CVMFS_VERSION);
   if (getenv("CERNVM_UUID") != NULL) {
-    cernvm_id += " " +
-    sanitizer::InputSanitizer("az AZ 09 -").Filter(getenv("CERNVM_UUID"));
+    cernvm_id += " "
+                 + sanitizer::InputSanitizer("az AZ 09 -")
+                       .Filter(getenv("CERNVM_UUID"));
   }
   user_agent_ = strdup(cernvm_id.c_str());
 
@@ -1893,56 +1875,55 @@ void DownloadManager::InitHeaders() {
 }
 
 DownloadManager::DownloadManager(const unsigned max_pool_handles,
-                           const perf::StatisticsTemplate &statistics,
-                           const std::string &name) :
-                  prng_(Prng()),
-                  pool_handles_idle_(new set<CURL *>),
-                  pool_handles_inuse_(new set<CURL *>),
-                  pool_max_handles_(max_pool_handles),
-                  pipe_terminate_(NULL),
-                  pipe_jobs_(NULL),
-                  watch_fds_(NULL),
-                  watch_fds_size_(0),
-                  watch_fds_inuse_(0),
-                  watch_fds_max_(4 * max_pool_handles),
-                  opt_timeout_proxy_(5),
-                  opt_timeout_direct_(10),
-                  opt_low_speed_limit_(1024),
-                  opt_max_retries_(0),
-                  opt_backoff_init_ms_(0),
-                  opt_backoff_max_ms_(0),
-                  enable_info_header_(false),
-                  opt_ipv4_only_(false),
-                  follow_redirects_(false),
-                  ignore_signature_failures_(false),
-                  enable_http_tracing_(false),
-                  opt_metalink_(NULL, 0, 0, 0),
-                  opt_metalink_timestamp_link_(0),
-                  opt_host_(NULL, 0, 0, 0),
-                  opt_host_chain_rtt_(NULL),
-                  opt_proxy_groups_(NULL),
-                  opt_proxy_groups_current_(0),
-                  opt_proxy_groups_current_burned_(0),
-                  opt_proxy_groups_fallback_(0),
-                  opt_num_proxies_(0),
-                  opt_proxy_shard_(false),
-                  failover_indefinitely_(false),
-                  name_(name),
-                  opt_ip_preference_(dns::kIpPreferSystem),
-                  opt_timestamp_backup_proxies_(0),
-                  opt_timestamp_failover_proxies_(0),
-                  opt_proxy_groups_reset_after_(0),
-                  credentials_attachment_(NULL),
-                  counters_(new Counters(statistics))
-{
+                                 const perf::StatisticsTemplate &statistics,
+                                 const std::string &name)
+    : prng_(Prng())
+    , pool_handles_idle_(new set<CURL *>)
+    , pool_handles_inuse_(new set<CURL *>)
+    , pool_max_handles_(max_pool_handles)
+    , pipe_terminate_(NULL)
+    , pipe_jobs_(NULL)
+    , watch_fds_(NULL)
+    , watch_fds_size_(0)
+    , watch_fds_inuse_(0)
+    , watch_fds_max_(4 * max_pool_handles)
+    , opt_timeout_proxy_(5)
+    , opt_timeout_direct_(10)
+    , opt_low_speed_limit_(1024)
+    , opt_max_retries_(0)
+    , opt_backoff_init_ms_(0)
+    , opt_backoff_max_ms_(0)
+    , enable_info_header_(false)
+    , opt_ipv4_only_(false)
+    , follow_redirects_(false)
+    , ignore_signature_failures_(false)
+    , enable_http_tracing_(false)
+    , opt_metalink_(NULL, 0, 0, 0)
+    , opt_metalink_timestamp_link_(0)
+    , opt_host_(NULL, 0, 0, 0)
+    , opt_host_chain_rtt_(NULL)
+    , opt_proxy_groups_(NULL)
+    , opt_proxy_groups_current_(0)
+    , opt_proxy_groups_current_burned_(0)
+    , opt_proxy_groups_fallback_(0)
+    , opt_num_proxies_(0)
+    , opt_proxy_shard_(false)
+    , failover_indefinitely_(false)
+    , name_(name)
+    , opt_ip_preference_(dns::kIpPreferSystem)
+    , opt_timestamp_backup_proxies_(0)
+    , opt_timestamp_failover_proxies_(0)
+    , opt_proxy_groups_reset_after_(0)
+    , credentials_attachment_(NULL)
+    , counters_(new Counters(statistics)) {
   atomic_init32(&multi_threaded_);
 
-  lock_options_ =
-          reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+  lock_options_ = reinterpret_cast<pthread_mutex_t *>(
+      smalloc(sizeof(pthread_mutex_t)));
   int retval = pthread_mutex_init(lock_options_, NULL);
   assert(retval == 0);
-  lock_synchronous_mode_ =
-          reinterpret_cast<pthread_mutex_t *>(smalloc(sizeof(pthread_mutex_t)));
+  lock_synchronous_mode_ = reinterpret_cast<pthread_mutex_t *>(
+      smalloc(sizeof(pthread_mutex_t)));
   retval = pthread_mutex_init(lock_synchronous_mode_, NULL);
   assert(retval == 0);
 
@@ -1963,13 +1944,12 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
   prng_.InitLocaltime();
 
   // Name resolving
-  if ((getenv("CVMFS_IPV4_ONLY") != NULL) &&
-      (strlen(getenv("CVMFS_IPV4_ONLY")) > 0))
-  {
+  if ((getenv("CVMFS_IPV4_ONLY") != NULL)
+      && (strlen(getenv("CVMFS_IPV4_ONLY")) > 0)) {
     opt_ipv4_only_ = true;
   }
-  resolver_ = dns::NormalResolver::Create(opt_ipv4_only_,
-    kDnsDefaultRetries, kDnsDefaultTimeoutMs);
+  resolver_ = dns::NormalResolver::Create(opt_ipv4_only_, kDnsDefaultRetries,
+                                          kDnsDefaultTimeoutMs);
   assert(resolver_);
 }
 
@@ -1979,7 +1959,7 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
  */
 void DownloadManager::Spawn() {
   pipe_terminate_ = new Pipe<kPipeThreadTerminator>();
-  pipe_jobs_ = new Pipe<kPipeDownloadJobs>();
+  pipe_jobs_      = new Pipe<kPipeDownloadJobs>();
 
   int retval = pthread_create(&thread_download_, NULL, MainDownload,
                               static_cast<void *>(this));
@@ -1989,7 +1969,7 @@ void DownloadManager::Spawn() {
 
   if (health_check_.UseCount() > 0) {
     LogCvmfs(kLogDownload, kLogDebug,
-                   "(manager '%s') Starting healthcheck thread", name_.c_str());
+             "(manager '%s') Starting healthcheck thread", name_.c_str());
     health_check_->StartHealthcheck();
   }
 }
@@ -2008,10 +1988,10 @@ Failures DownloadManager::Fetch(JobInfo *info) {
     return result;
 
   if (info->expected_hash()) {
-    const shash::Algorithms algorithm = info->expected_hash()->algorithm;
+    const shash::Algorithms algorithm    = info->expected_hash()->algorithm;
     info->GetHashContextPtr()->algorithm = algorithm;
-    info->GetHashContextPtr()->size = shash::GetContextSize(algorithm);
-    info->GetHashContextPtr()->buffer = alloca(info->hash_context().size);
+    info->GetHashContextPtr()->size      = shash::GetContextSize(algorithm);
+    info->GetHashContextPtr()->buffer    = alloca(info->hash_context().size);
   }
 
   // In case JobInfo object is being reused
@@ -2020,15 +2000,15 @@ Failures DownloadManager::Fetch(JobInfo *info) {
   // Prepare cvmfs-info: header, allocate string on the stack
   info->SetInfoHeader(NULL);
   if (enable_info_header_ && info->extra_info()) {
-    const char *header_name = "cvmfs-info: ";
+    const char *header_name      = "cvmfs-info: ";
     const size_t header_name_len = strlen(header_name);
-    const unsigned header_size = 1 + header_name_len +
-      EscapeHeader(*(info->extra_info()), NULL, 0);
+    const unsigned header_size   = 1 + header_name_len
+                                 + EscapeHeader(*(info->extra_info()), NULL, 0);
     info->SetInfoHeader(static_cast<char *>(alloca(header_size)));
     memcpy(info->info_header(), header_name, header_name_len);
     EscapeHeader(*(info->extra_info()), info->info_header() + header_name_len,
                  header_size - header_name_len);
-    info->info_header()[header_size-1] = '\0';
+    info->info_header()[header_size - 1] = '\0';
   }
 
   if (enable_http_tracing_) {
@@ -2056,10 +2036,10 @@ Failures DownloadManager::Fetch(JobInfo *info) {
 
     // LogCvmfs(kLogDownload, kLogDebug, "send job to thread, pipe %d %d",
     //          info->wait_at[0], info->wait_at[1]);
-    pipe_jobs_->Write<JobInfo*>(info);
+    pipe_jobs_->Write<JobInfo *>(info);
 
     do {
-      DataTubeElement* ele = info->GetDataTubePtr()->PopFront();
+      DataTubeElement *ele = info->GetDataTubePtr()->PopFront();
 
       if (ele->action == kActionStop) {
         delete ele;
@@ -2081,8 +2061,8 @@ Failures DownloadManager::Fetch(JobInfo *info) {
       retval = curl_easy_perform(handle);
       perf::Inc(counters_->n_requests);
       double elapsed;
-      if (curl_easy_getinfo(handle, CURLINFO_TOTAL_TIME, &elapsed) == CURLE_OK)
-      {
+      if (curl_easy_getinfo(handle, CURLINFO_TOTAL_TIME, &elapsed)
+          == CURLE_OK) {
         perf::Xadd(counters_->sz_transfer_time,
                    static_cast<int64_t>(elapsed * 1000));
       }
@@ -2092,10 +2072,10 @@ Failures DownloadManager::Fetch(JobInfo *info) {
   }
 
   if (result != kFailOk) {
-    LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                                      "download failed (error %d - %s)",
-                                      name_.c_str(),
-                                      info->id(), result, Code2Ascii(result));
+    LogCvmfs(kLogDownload, kLogDebug,
+             "(manager '%s' - id %" PRId64 ") "
+             "download failed (error %d - %s)",
+             name_.c_str(), info->id(), result, Code2Ascii(result));
 
     if (info->sink() != NULL) {
       info->sink()->Purge();
@@ -2118,9 +2098,7 @@ void DownloadManager::SetCredentialsAttachment(CredentialsAttachment *ca) {
 /**
  * Gets the DNS sever.
  */
-std::string DownloadManager::GetDnsServer() const {
-  return opt_dns_server_;
-}
+std::string DownloadManager::GetDnsServer() const { return opt_dns_server_; }
 
 /**
  * Sets a DNS server.  Only for testing as it cannot be reverted to the system
@@ -2138,35 +2116,29 @@ void DownloadManager::SetDnsServer(const string &address) {
     assert(retval);
   }
   LogCvmfs(kLogDownload, kLogSyslog, "(manager '%s') set nameserver to %s",
-                                     name_.c_str(), address.c_str());
+           name_.c_str(), address.c_str());
 }
 
 
 /**
  * Sets the DNS query timeout parameters.
  */
-void DownloadManager::SetDnsParameters(
-  const unsigned retries,
-  const unsigned timeout_ms)
-{
+void DownloadManager::SetDnsParameters(const unsigned retries,
+                                       const unsigned timeout_ms) {
   MutexLockGuard m(lock_options_);
-  if ((resolver_->retries() == retries) &&
-      (resolver_->timeout_ms() == timeout_ms))
-  {
+  if ((resolver_->retries() == retries)
+      && (resolver_->timeout_ms() == timeout_ms)) {
     return;
   }
   delete resolver_;
   resolver_ = NULL;
-  resolver_ =
-    dns::NormalResolver::Create(opt_ipv4_only_, retries, timeout_ms);
+  resolver_ = dns::NormalResolver::Create(opt_ipv4_only_, retries, timeout_ms);
   assert(resolver_);
 }
 
 
-void DownloadManager::SetDnsTtlLimits(
-  const unsigned min_seconds,
-  const unsigned max_seconds)
-{
+void DownloadManager::SetDnsTtlLimits(const unsigned min_seconds,
+                                      const unsigned max_seconds) {
   MutexLockGuard m(lock_options_);
   resolver_->set_min_ttl(min_seconds);
   resolver_->set_max_ttl(max_seconds);
@@ -2185,10 +2157,9 @@ void DownloadManager::SetIpPreference(dns::IpPreference preference) {
  * DNS, HTTP connect, etc.
  */
 void DownloadManager::SetTimeout(const unsigned seconds_proxy,
-                                 const unsigned seconds_direct)
-{
+                                 const unsigned seconds_direct) {
   MutexLockGuard m(lock_options_);
-  opt_timeout_proxy_ = seconds_proxy;
+  opt_timeout_proxy_  = seconds_proxy;
   opt_timeout_direct_ = seconds_direct;
 }
 
@@ -2208,10 +2179,9 @@ void DownloadManager::SetLowSpeedLimit(const unsigned low_speed_limit) {
  * Receives the currently active timeout values.
  */
 void DownloadManager::GetTimeout(unsigned *seconds_proxy,
-                                 unsigned *seconds_direct)
-{
+                                 unsigned *seconds_direct) {
   MutexLockGuard m(lock_options_);
-  *seconds_proxy = opt_timeout_proxy_;
+  *seconds_proxy  = opt_timeout_proxy_;
   *seconds_direct = opt_timeout_direct_;
 }
 
@@ -2246,12 +2216,15 @@ void DownloadManager::SetMetalinkChain(
  * used metalink host.
  */
 void DownloadManager::GetMetalinkInfo(vector<string> *metalink_chain,
-                                  unsigned *current_metalink)
-{
+                                      unsigned *current_metalink) {
   const MutexLockGuard m(lock_options_);
   if (opt_metalink_.chain) {
-    if (current_metalink) {*current_metalink = opt_metalink_.current;}
-    if (metalink_chain) {*metalink_chain = *opt_metalink_.chain;}
+    if (current_metalink) {
+      *current_metalink = opt_metalink_.current;
+    }
+    if (metalink_chain) {
+      *metalink_chain = *opt_metalink_.chain;
+    }
   }
 }
 
@@ -2273,14 +2246,14 @@ void DownloadManager::SetHostChain(const std::vector<std::string> &host_list) {
   opt_host_.current = 0;
 
   if (host_list.empty()) {
-    opt_host_.chain = NULL;
+    opt_host_.chain     = NULL;
     opt_host_chain_rtt_ = NULL;
     return;
   }
 
-  opt_host_.chain = new vector<string>(host_list);
-  opt_host_chain_rtt_ =
-    new vector<int>(opt_host_.chain->size(), kProbeUnprobed);
+  opt_host_.chain     = new vector<string>(host_list);
+  opt_host_chain_rtt_ = new vector<int>(opt_host_.chain->size(),
+                                        kProbeUnprobed);
   // LogCvmfs(kLogDownload, kLogSyslog, "using host %s",
   //          (*opt_host_.chain)[0].c_str());
 }
@@ -2291,13 +2264,18 @@ void DownloadManager::SetHostChain(const std::vector<std::string> &host_list) {
  * currently used host.
  */
 void DownloadManager::GetHostInfo(vector<string> *host_chain, vector<int> *rtt,
-                                  unsigned *current_host)
-{
+                                  unsigned *current_host) {
   MutexLockGuard m(lock_options_);
   if (opt_host_.chain) {
-    if (current_host) {*current_host = opt_host_.current;}
-    if (host_chain) {*host_chain = *opt_host_.chain;}
-    if (rtt) {*rtt = *opt_host_chain_rtt_;}
+    if (current_host) {
+      *current_host = opt_host_.current;
+    }
+    if (host_chain) {
+      *host_chain = *opt_host_.chain;
+    }
+    if (rtt) {
+      *rtt = *opt_host_chain_rtt_;
+    }
   }
 }
 
@@ -2318,9 +2296,9 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
   }
 
   // Fail any matching proxies within the current load-balancing group
-  vector<ProxyInfo> *group = current_proxy_group();
+  vector<ProxyInfo> *group  = current_proxy_group();
   const unsigned group_size = group->size();
-  unsigned failed = 0;
+  unsigned failed           = 0;
   for (unsigned i = 0; i < group_size - opt_proxy_groups_current_burned_; ++i) {
     if (info && (info->proxy() == (*group)[i].url)) {
       // Move to list of failed proxies
@@ -2341,8 +2319,8 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
   if (opt_proxy_groups_current_burned_ == group->size()) {
     opt_proxy_groups_current_burned_ = 0;
     if (opt_proxy_groups_->size() > 1) {
-      opt_proxy_groups_current_ = (opt_proxy_groups_current_ + 1) %
-      opt_proxy_groups_->size();
+      opt_proxy_groups_current_ = (opt_proxy_groups_current_ + 1)
+                                  % opt_proxy_groups_->size();
       // Remember the timestamp of switching to backup proxies
       if (opt_proxy_groups_reset_after_ > 0) {
         if (opt_proxy_groups_current_ > 0) {
@@ -2367,9 +2345,11 @@ void DownloadManager::SwitchProxy(JobInfo *info) {
   }
 
   UpdateProxiesUnlocked("failed proxy");
-  LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-              "%lu proxies remain in group", name_.c_str(), info->id(),
-              current_proxy_group()->size() - opt_proxy_groups_current_burned_);
+  LogCvmfs(kLogDownload, kLogDebug,
+           "(manager '%s' - id %" PRId64 ") "
+           "%lu proxies remain in group",
+           name_.c_str(), info->id(),
+           current_proxy_group()->size() - opt_proxy_groups_current_burned_);
 }
 
 
@@ -2399,17 +2379,17 @@ void DownloadManager::SwitchHostInfo(const std::string &typ,
                "(manager '%s' - id %" PRId64 ")"
                "don't switch %s, "
                "last used %s: %s, current %s: %s",
-               name_.c_str(), jobinfo->id(), typ.c_str(),
-               typ.c_str(), (*info.chain)[lastused].c_str(),
-               typ.c_str(), (*info.chain)[info.current].c_str());
+               name_.c_str(), jobinfo->id(), typ.c_str(), typ.c_str(),
+               (*info.chain)[lastused].c_str(), typ.c_str(),
+               (*info.chain)[info.current].c_str());
       return;
     }
   }
 
-  string reason = "manually triggered";
+  string reason  = "manually triggered";
   string info_id = "(manager " + name_;
   if (jobinfo) {
-    reason = download::Code2Ascii(jobinfo->error_code());
+    reason  = download::Code2Ascii(jobinfo->error_code());
     info_id = " - id " + StringifyInt(jobinfo->id());
   }
   info_id += ")";
@@ -2422,9 +2402,9 @@ void DownloadManager::SwitchHostInfo(const std::string &typ,
     perf::Inc(counters_->n_metalink_failover);
   }
   LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-          "%s switching %s from %s to %s (%s)", info_id.c_str(), typ.c_str(),
-          old_host.c_str(), (*info.chain)[info.current].c_str(),
-          reason.c_str());
+           "%s switching %s from %s to %s (%s)", info_id.c_str(), typ.c_str(),
+           old_host.c_str(), (*info.chain)[info.current].c_str(),
+           reason.c_str());
 
   // Remember the timestamp of switching to backup host
   if (info.reset_after > 0) {
@@ -2441,9 +2421,7 @@ void DownloadManager::SwitchHost(JobInfo *info) {
   SwitchHostInfo("host", opt_host_, info);
 }
 
-void DownloadManager::SwitchHost() {
-  SwitchHost(NULL);
-}
+void DownloadManager::SwitchHost() { SwitchHost(NULL); }
 
 
 void DownloadManager::SwitchMetalink(JobInfo *info) {
@@ -2451,16 +2429,14 @@ void DownloadManager::SwitchMetalink(JobInfo *info) {
 }
 
 
-void DownloadManager::SwitchMetalink() {
-  SwitchMetalink(NULL);
-}
+void DownloadManager::SwitchMetalink() { SwitchMetalink(NULL); }
 
 bool DownloadManager::CheckMetalinkChain(time_t now) {
-  return (opt_metalink_.chain &&
-         ((opt_metalink_timestamp_link_ == 0) ||
-          (static_cast<int64_t>((now == 0) ? time(NULL) : now) >
-           static_cast<int64_t>(opt_metalink_timestamp_link_ +
-                               opt_metalink_.reset_after))));
+  return (opt_metalink_.chain
+          && ((opt_metalink_timestamp_link_ == 0)
+              || (static_cast<int64_t>((now == 0) ? time(NULL) : now)
+                  > static_cast<int64_t>(opt_metalink_timestamp_link_
+                                         + opt_metalink_.reset_after))));
 }
 
 
@@ -2493,17 +2469,18 @@ void DownloadManager::ProbeHosts() {
       gettimeofday(&tv_end, NULL);
       memsink.Reset();
       if (result == kFailOk) {
-        host_rtt[i] = static_cast<int>(
-          DiffTimeSeconds(tv_start, tv_end) * 1000);
-        LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                                          "probing host %s had %dms rtt",
-                                          name_.c_str(), info.id(),
-                                          url.c_str(), host_rtt[i]);
+        host_rtt[i] = static_cast<int>(DiffTimeSeconds(tv_start, tv_end)
+                                       * 1000);
+        LogCvmfs(kLogDownload, kLogDebug,
+                 "(manager '%s' - id %" PRId64 ") "
+                 "probing host %s had %dms rtt",
+                 name_.c_str(), info.id(), url.c_str(), host_rtt[i]);
       } else {
-        LogCvmfs(kLogDownload, kLogDebug, "(manager '%s' - id %" PRId64 ") "
-                                       "error while probing host %s: %d %s",
-                                       name_.c_str(), info.id(),
-                                       url.c_str(), result, Code2Ascii(result));
+        LogCvmfs(kLogDownload, kLogDebug,
+                 "(manager '%s' - id %" PRId64 ") "
+                 "error while probing host %s: %d %s",
+                 name_.c_str(), info.id(), url.c_str(), result,
+                 Code2Ascii(result));
         host_rtt[i] = INT_MAX;
       }
     }
@@ -2511,20 +2488,23 @@ void DownloadManager::ProbeHosts() {
 
   SortTeam(&host_rtt, &host_chain);
   for (i = 0; i < host_chain.size(); ++i) {
-    if (host_rtt[i] == INT_MAX) host_rtt[i] = kProbeDown;
+    if (host_rtt[i] == INT_MAX)
+      host_rtt[i] = kProbeDown;
   }
 
   MutexLockGuard m(lock_options_);
   delete opt_host_.chain;
   delete opt_host_chain_rtt_;
-  opt_host_.chain = new vector<string>(host_chain);
+  opt_host_.chain     = new vector<string>(host_chain);
   opt_host_chain_rtt_ = new vector<int>(host_rtt);
-  opt_host_.current = 0;
+  opt_host_.current   = 0;
 }
 
 bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
-                    std::vector<uint64_t> *output_order) {
-  if (!servers) {return false;}
+                                     std::vector<uint64_t> *output_order) {
+  if (!servers) {
+    return false;
+  }
   if (servers->size() == 1) {
     if (output_order) {
       output_order->clear();
@@ -2552,7 +2532,7 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
     host_chain_shuffled = Shuffle(host_chain, &prng_);
   }
   // Request ordered list via Geo-API
-  bool success = false;
+  bool success          = false;
   unsigned max_attempts = std::min(host_chain_shuffled.size(), size_t(3));
   vector<uint64_t> geo_order(servers->size());
   for (unsigned i = 0; i < max_attempts; ++i) {
@@ -2564,7 +2544,7 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
     JobInfo info(&url, false, false, NULL, &memsink);
     Failures result = Fetch(&info);
     if (result == kFailOk) {
-      string order(reinterpret_cast<char*>(memsink.data()), memsink.pos());
+      string order(reinterpret_cast<char *>(memsink.data()), memsink.pos());
       memsink.Reset();
       bool retval = ValidateGeoReply(order, servers->size(), &geo_order);
       if (!retval) {
@@ -2572,13 +2552,14 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
                  "(manager '%s') retrieved invalid GeoAPI reply from %s [%s]",
                  name_.c_str(), url.c_str(), order.c_str());
       } else {
-        LogCvmfs(kLogDownload, kLogDebug | kLogSyslog, "(manager '%s') "
-                              "geographic order of servers retrieved from %s",
-                              name_.c_str(),
-                              dns::ExtractHost(host_chain_shuffled[i]).c_str());
+        LogCvmfs(kLogDownload, kLogDebug | kLogSyslog,
+                 "(manager '%s') "
+                 "geographic order of servers retrieved from %s",
+                 name_.c_str(),
+                 dns::ExtractHost(host_chain_shuffled[i]).c_str());
         // remove new line at end of "order"
         LogCvmfs(kLogDownload, kLogDebug, "order is %s",
-                                  Trim(order, true /* trim_newline */).c_str());
+                 Trim(order, true /* trim_newline */).c_str());
         success = true;
         break;
       }
@@ -2589,7 +2570,8 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
     }
   }
   if (!success) {
-    LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn, "(manager '%s') "
+    LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
+             "(manager '%s') "
              "failed to retrieve geographic order from stratum 1 servers",
              name_.c_str());
     return false;
@@ -2621,7 +2603,7 @@ bool DownloadManager::ProbeGeo() {
   vector<string> host_chain;
   vector<int> host_rtt;
   unsigned current_host;
-  vector< vector<ProxyInfo> > proxy_chain;
+  vector<vector<ProxyInfo> > proxy_chain;
   unsigned fallback_group;
 
   GetHostInfo(&host_chain, &host_rtt, &current_host);
@@ -2663,7 +2645,7 @@ bool DownloadManager::ProbeGeo() {
   MutexLockGuard m(lock_options_);
   delete opt_host_.chain;
   opt_num_proxies_ = 0;
-  opt_host_.chain = new vector<string>(host_chain.size());
+  opt_host_.chain  = new vector<string>(host_chain.size());
 
   // It's possible that opt_proxy_groups_fallback_ might have changed while
   // the lock wasn't held
@@ -2671,15 +2653,15 @@ bool DownloadManager::ProbeGeo() {
       opt_proxy_groups_fallback_ + proxy_chain.size() - fallback_group);
   // First copy the non-fallback part of the current proxy chain
   for (unsigned i = 0; i < opt_proxy_groups_fallback_; ++i) {
-    (*proxy_groups)[i] = (*opt_proxy_groups_)[i];
-    opt_num_proxies_ += (*opt_proxy_groups_)[i].size();
+    (*proxy_groups)[i]  = (*opt_proxy_groups_)[i];
+    opt_num_proxies_   += (*opt_proxy_groups_)[i].size();
   }
 
   // Copy the host chain and fallback proxies by geo order.  Array indices
   // in geo_order that are smaller than last_geo_host refer to a stratum 1,
   // and those indices greater than or equal to first_geo_fallback refer to
   // a fallback proxy.
-  unsigned hosti = 0;
+  unsigned hosti  = 0;
   unsigned proxyi = opt_proxy_groups_fallback_;
   for (unsigned i = 0; i < geo_order.size(); ++i) {
     uint64_t orderval = geo_order[i];
@@ -2691,9 +2673,9 @@ bool DownloadManager::ProbeGeo() {
       // LogCvmfs(kLogCvmfs, kLogSyslog,
       // "this is orderval %u at proxy index %u, using proxy_chain index %u",
       // orderval, proxyi, fallback_group + orderval - first_geo_fallback);
-      (*proxy_groups)[proxyi] =
-          proxy_chain[fallback_group + orderval - first_geo_fallback];
-      opt_num_proxies_ += (*proxy_groups)[proxyi].size();
+      (*proxy_groups)[proxyi]  = proxy_chain[fallback_group + orderval
+                                            - first_geo_fallback];
+      opt_num_proxies_        += (*proxy_groups)[proxyi].size();
       proxyi++;
     }
   }
@@ -2716,7 +2698,7 @@ bool DownloadManager::ProbeGeo() {
 
   delete opt_host_chain_rtt_;
   opt_host_chain_rtt_ = new vector<int>(host_chain.size(), kProbeGeo);
-  opt_host_.current = 0;
+  opt_host_.current   = 0;
 
   return true;
 }
@@ -2729,19 +2711,17 @@ bool DownloadManager::ProbeGeo() {
  * fills in the reply_vals array with zero-based order indexes (e.g.
  * [0,3,1,2]) and returns true.
  */
-bool DownloadManager::ValidateGeoReply(
-  const string &reply_order,
-  const unsigned expected_size,
-  vector<uint64_t> *reply_vals)
-{
+bool DownloadManager::ValidateGeoReply(const string &reply_order,
+                                       const unsigned expected_size,
+                                       vector<uint64_t> *reply_vals) {
   if (reply_order.empty())
     return false;
   sanitizer::InputSanitizer sanitizer("09 , \n");
   if (!sanitizer.IsValid(reply_order))
     return false;
   sanitizer::InputSanitizer strip_newline("09 ,");
-  vector<string> reply_strings =
-    SplitString(strip_newline.Filter(reply_order), ',');
+  vector<string> reply_strings = SplitString(strip_newline.Filter(reply_order),
+                                             ',');
   vector<uint64_t> tmp_vals;
   for (unsigned i = 0; i < reply_strings.size(); ++i) {
     if (reply_strings[i].empty())
@@ -2769,10 +2749,8 @@ bool DownloadManager::ValidateGeoReply(
  * Removes DIRECT from a list of ';' and '|' separated proxies.
  * \return true if DIRECT was present, false otherwise
  */
-bool DownloadManager::StripDirect(
-  const string &proxy_list,
-  string *cleaned_list)
-{
+bool DownloadManager::StripDirect(const string &proxy_list,
+                                  string *cleaned_list) {
   assert(cleaned_list);
   if (proxy_list == "") {
     *cleaned_list = "";
@@ -2809,17 +2787,15 @@ bool DownloadManager::StripDirect(
  *   proxies unchanged) or fallback proxies (leaving regular proxies unchanged)
  *   or both.
  */
-void DownloadManager::SetProxyChain(
-  const string &proxy_list,
-  const string &fallback_proxy_list,
-  const ProxySetModes set_mode)
-{
+void DownloadManager::SetProxyChain(const string &proxy_list,
+                                    const string &fallback_proxy_list,
+                                    const ProxySetModes set_mode) {
   MutexLockGuard m(lock_options_);
 
-  opt_timestamp_backup_proxies_ = 0;
+  opt_timestamp_backup_proxies_   = 0;
   opt_timestamp_failover_proxies_ = 0;
-  string set_proxy_list = opt_proxy_list_;
-  string set_proxy_fallback_list = opt_proxy_fallback_list_;
+  string set_proxy_list           = opt_proxy_list_;
+  string set_proxy_fallback_list  = opt_proxy_fallback_list_;
   bool contains_direct;
   if ((set_mode == kSetProxyFallback) || (set_mode == kSetProxyBoth)) {
     opt_proxy_fallback_list_ = fallback_proxy_list;
@@ -2827,8 +2803,8 @@ void DownloadManager::SetProxyChain(
   if ((set_mode == kSetProxyRegular) || (set_mode == kSetProxyBoth)) {
     opt_proxy_list_ = proxy_list;
   }
-  contains_direct =
-    StripDirect(opt_proxy_fallback_list_, &set_proxy_fallback_list);
+  contains_direct = StripDirect(opt_proxy_fallback_list_,
+                                &set_proxy_fallback_list);
   if (contains_direct) {
     LogCvmfs(kLogDownload, kLogSyslogWarn | kLogDebug,
              "(manager '%s') fallback proxies do not support DIRECT, removing",
@@ -2851,11 +2827,11 @@ void DownloadManager::SetProxyChain(
   opt_proxy_map_.clear();
   delete opt_proxy_groups_;
   if ((set_proxy_list == "") && (set_proxy_fallback_list == "")) {
-    opt_proxy_groups_ = NULL;
-    opt_proxy_groups_current_ = 0;
+    opt_proxy_groups_                = NULL;
+    opt_proxy_groups_current_        = 0;
     opt_proxy_groups_current_burned_ = 0;
-    opt_proxy_groups_fallback_ = 0;
-    opt_num_proxies_ = 0;
+    opt_proxy_groups_fallback_       = 0;
+    opt_num_proxies_                 = 0;
     return;
   }
 
@@ -2864,9 +2840,10 @@ void DownloadManager::SetProxyChain(
   if (set_proxy_list != "") {
     opt_proxy_groups_fallback_ = SplitString(set_proxy_list, ';').size();
   }
-  LogCvmfs(kLogDownload, kLogDebug, "(manager '%s') "
-                                    "first fallback proxy group %u",
-                                    name_.c_str(), opt_proxy_groups_fallback_);
+  LogCvmfs(kLogDownload, kLogDebug,
+           "(manager '%s') "
+           "first fallback proxy group %u",
+           name_.c_str(), opt_proxy_groups_fallback_);
 
   // Concatenate regular proxies and fallback proxies, both of which can be
   // empty.
@@ -2877,7 +2854,7 @@ void DownloadManager::SetProxyChain(
     all_proxy_list += set_proxy_fallback_list;
   }
   LogCvmfs(kLogDownload, kLogDebug, "(manager '%s') full proxy list %s",
-                                    name_.c_str(), all_proxy_list.c_str());
+           name_.c_str(), all_proxy_list.c_str());
 
   // Resolve server names in provided urls
   vector<string> hostnames;  // All encountered hostnames
@@ -2896,15 +2873,16 @@ void DownloadManager::SetProxyChain(
     }
   }
   vector<dns::Host> hosts;
-  LogCvmfs(kLogDownload, kLogDebug, "(manager '%s') "
-                                    "resolving %lu proxy addresses",
-                                    name_.c_str(), hostnames.size());
+  LogCvmfs(kLogDownload, kLogDebug,
+           "(manager '%s') "
+           "resolving %lu proxy addresses",
+           name_.c_str(), hostnames.size());
   resolver_->ResolveMany(hostnames, &hosts);
 
   // Construct opt_proxy_groups_: traverse proxy list in same order and expand
   // names to resolved IP addresses.
-  opt_proxy_groups_ = new vector< vector<ProxyInfo> >();
-  opt_num_proxies_ = 0;
+  opt_proxy_groups_  = new vector<vector<ProxyInfo> >();
+  opt_num_proxies_   = 0;
   unsigned num_proxy = 0;  // Combined i, j counter
   for (unsigned i = 0; i < proxy_groups.size(); ++i) {
     vector<string> this_group = SplitString(proxy_groups[i], '|');
@@ -2920,19 +2898,21 @@ void DownloadManager::SetProxyChain(
       }
 
       if (hosts[num_proxy].status() != dns::kFailOk) {
-        LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn, "(manager '%s') "
-               "failed to resolve IP addresses for %s (%d - %s)", name_.c_str(),
-               hosts[num_proxy].name().c_str(), hosts[num_proxy].status(),
-               dns::Code2Ascii(hosts[num_proxy].status()));
-        dns::Host failed_host =
-          dns::Host::ExtendDeadline(hosts[num_proxy], resolver_->min_ttl());
+        LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
+                 "(manager '%s') "
+                 "failed to resolve IP addresses for %s (%d - %s)",
+                 name_.c_str(), hosts[num_proxy].name().c_str(),
+                 hosts[num_proxy].status(),
+                 dns::Code2Ascii(hosts[num_proxy].status()));
+        dns::Host failed_host = dns::Host::ExtendDeadline(hosts[num_proxy],
+                                                          resolver_->min_ttl());
         infos.push_back(ProxyInfo(failed_host, this_group[j]));
         continue;
       }
 
       // IPv4 addresses have precedence
-      set<string> best_addresses =
-        hosts[num_proxy].ViewBestAddresses(opt_ip_preference_);
+      set<string> best_addresses = hosts[num_proxy].ViewBestAddresses(
+          opt_ip_preference_);
       set<string>::const_iterator iter_ips = best_addresses.begin();
       for (; iter_ips != best_addresses.end(); ++iter_ips) {
         string url_ip = dns::RewriteUrl(this_group[j], *iter_ips);
@@ -2949,7 +2929,7 @@ void DownloadManager::SetProxyChain(
   LogCvmfs(kLogDownload, kLogDebug,
            "(manager '%s') installed %u proxies in %lu load-balance groups",
            name_.c_str(), opt_num_proxies_, opt_proxy_groups_->size());
-  opt_proxy_groups_current_ = 0;
+  opt_proxy_groups_current_        = 0;
   opt_proxy_groups_current_burned_ = 0;
 
   // Select random start proxy from the first group.
@@ -2966,16 +2946,15 @@ void DownloadManager::SetProxyChain(
  *   If there are no fallback proxies, the index will equal the size of
  *   the proxy chain.
  */
-void DownloadManager::GetProxyInfo(vector< vector<ProxyInfo> > *proxy_chain,
+void DownloadManager::GetProxyInfo(vector<vector<ProxyInfo> > *proxy_chain,
                                    unsigned *current_group,
-                                   unsigned *fallback_group)
-{
+                                   unsigned *fallback_group) {
   assert(proxy_chain != NULL);
   MutexLockGuard m(lock_options_);
 
 
   if (!opt_proxy_groups_) {
-    vector< vector<ProxyInfo> > empty_chain;
+    vector<vector<ProxyInfo> > empty_chain;
     *proxy_chain = empty_chain;
     if (current_group != NULL)
       *current_group = 0;
@@ -2991,9 +2970,7 @@ void DownloadManager::GetProxyInfo(vector< vector<ProxyInfo> > *proxy_chain,
     *fallback_group = opt_proxy_groups_fallback_;
 }
 
-string DownloadManager::GetProxyList() {
-  return opt_proxy_list_;
-}
+string DownloadManager::GetProxyList() { return opt_proxy_list_; }
 
 string DownloadManager::GetFallbackProxyList() {
   return opt_proxy_fallback_list_;
@@ -3002,14 +2979,14 @@ string DownloadManager::GetFallbackProxyList() {
 /**
  * Choose proxy
  */
-DownloadManager::ProxyInfo *
-DownloadManager::ChooseProxyUnlocked(const shash::Any *hash) {
+DownloadManager::ProxyInfo *DownloadManager::ChooseProxyUnlocked(
+    const shash::Any *hash) {
   if (!opt_proxy_groups_)
     return NULL;
 
-  uint32_t key = (hash ? hash->Partial32() : 0);
+  uint32_t key                            = (hash ? hash->Partial32() : 0);
   map<uint32_t, ProxyInfo *>::iterator it = opt_proxy_map_.lower_bound(key);
-  ProxyInfo *proxy = it->second;
+  ProxyInfo *proxy                        = it->second;
 
   return proxy;
 }
@@ -3023,14 +3000,13 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
 
   // Identify number of non-burned proxies within the current group
   vector<ProxyInfo> *group = current_proxy_group();
-  unsigned num_alive = (group->size() - opt_proxy_groups_current_burned_);
-  string old_proxy = JoinStrings(opt_proxies_, "|");
+  unsigned num_alive       = (group->size() - opt_proxy_groups_current_burned_);
+  string old_proxy         = JoinStrings(opt_proxies_, "|");
 
   // Rebuild proxy map and URL list
   opt_proxy_map_.clear();
   opt_proxies_.clear();
-  const uint32_t max_key = 0xffffffffUL;
-  if (opt_proxy_shard_) {
+  const uint32_t max_key = 0xff 'ff' ff'ffUL; if (opt_proxy_shard_) {
     // Build a consistent map with multiple entries for each proxy
     for (unsigned i = 0; i < num_alive; ++i) {
       ProxyInfo *proxy = &(*group)[i];
@@ -3042,36 +3018,41 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
         const std::pair<uint32_t, ProxyInfo *> entry(prng.Next(max_key), proxy);
         opt_proxy_map_.insert(entry);
       }
-      std::string proxy_name = proxy->host.name().empty() ?
-                                           "" : " (" + proxy->host.name() + ")";
+      std::string proxy_name = proxy->host.name().empty()
+                                   ? ""
+                                   : " (" + proxy->host.name() + ")";
       opt_proxies_.push_back(proxy->url + proxy_name);
     }
     // Ensure lower_bound() finds a value for all keys
     ProxyInfo *first_proxy = opt_proxy_map_.begin()->second;
     const std::pair<uint32_t, ProxyInfo *> last_entry(max_key, first_proxy);
     opt_proxy_map_.insert(last_entry);
-  } else {
+  }
+  else {
     // Build a map with a single entry for one randomly selected proxy
-    unsigned select = prng_.Next(num_alive);
+    unsigned select  = prng_.Next(num_alive);
     ProxyInfo *proxy = &(*group)[select];
     const std::pair<uint32_t, ProxyInfo *> entry(max_key, proxy);
     opt_proxy_map_.insert(entry);
-    std::string proxy_name = proxy->host.name().empty() ?
-                                           "" : " (" + proxy->host.name() + ")";
+    std::string proxy_name = proxy->host.name().empty()
+                                 ? ""
+                                 : " (" + proxy->host.name() + ")";
     opt_proxies_.push_back(proxy->url + proxy_name);
   }
   sort(opt_proxies_.begin(), opt_proxies_.end());
 
   // Report any change in proxy usage
-  string new_proxy = JoinStrings(opt_proxies_, "|");
-  const string curr_host = "Current host: " + (opt_host_.chain ?
-                              (*opt_host_.chain)[opt_host_.current] : "");
+  string new_proxy       = JoinStrings(opt_proxies_, "|");
+  const string curr_host = "Current host: "
+                           + (opt_host_.chain
+                                  ? (*opt_host_.chain)[opt_host_.current]
+                                  : "");
   if (new_proxy != old_proxy) {
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
-           "(manager '%s') switching proxy from %s to %s. Reason: %s [%s]",
-           name_.c_str(), (old_proxy.empty() ? "(none)" : old_proxy.c_str()),
-           (new_proxy.empty() ? "(none)" : new_proxy.c_str()),
-           reason.c_str(), curr_host.c_str());
+             "(manager '%s') switching proxy from %s to %s. Reason: %s [%s]",
+             name_.c_str(), (old_proxy.empty() ? "(none)" : old_proxy.c_str()),
+             (new_proxy.empty() ? "(none)" : new_proxy.c_str()), reason.c_str(),
+             curr_host.c_str());
   }
 }
 
@@ -3091,7 +3072,7 @@ void DownloadManager::RebalanceProxiesUnlocked(const string &reason) {
   if (!opt_proxy_groups_)
     return;
 
-  opt_timestamp_failover_proxies_ = 0;
+  opt_timestamp_failover_proxies_  = 0;
   opt_proxy_groups_current_burned_ = 0;
   UpdateProxiesUnlocked(reason);
 }
@@ -3113,12 +3094,12 @@ void DownloadManager::SwitchProxyGroup() {
     return;
   }
 
-  opt_proxy_groups_current_ = (opt_proxy_groups_current_ + 1) %
-                                                      opt_proxy_groups_->size();
+  opt_proxy_groups_current_ = (opt_proxy_groups_current_ + 1)
+                              % opt_proxy_groups_->size();
   opt_timestamp_backup_proxies_ = time(NULL);
 
-  std::string msg = "switch to proxy group " +
-                                       StringifyUint(opt_proxy_groups_current_);
+  std::string msg = "switch to proxy group "
+                    + StringifyUint(opt_proxy_groups_current_);
   RebalanceProxiesUnlocked(msg);
 }
 
@@ -3127,14 +3108,13 @@ void DownloadManager::SetProxyGroupResetDelay(const unsigned seconds) {
   MutexLockGuard m(lock_options_);
   opt_proxy_groups_reset_after_ = seconds;
   if (opt_proxy_groups_reset_after_ == 0) {
-    opt_timestamp_backup_proxies_ = 0;
+    opt_timestamp_backup_proxies_   = 0;
     opt_timestamp_failover_proxies_ = 0;
   }
 }
 
 
-void DownloadManager::SetMetalinkResetDelay(const unsigned seconds)
-{
+void DownloadManager::SetMetalinkResetDelay(const unsigned seconds) {
   const MutexLockGuard m(lock_options_);
   opt_metalink_.reset_after = seconds;
   if (opt_metalink_.reset_after == 0)
@@ -3142,8 +3122,7 @@ void DownloadManager::SetMetalinkResetDelay(const unsigned seconds)
 }
 
 
-void DownloadManager::SetHostResetDelay(const unsigned seconds)
-{
+void DownloadManager::SetHostResetDelay(const unsigned seconds) {
   MutexLockGuard m(lock_options_);
   opt_host_.reset_after = seconds;
   if (opt_host_.reset_after == 0)
@@ -3153,12 +3132,11 @@ void DownloadManager::SetHostResetDelay(const unsigned seconds)
 
 void DownloadManager::SetRetryParameters(const unsigned max_retries,
                                          const unsigned backoff_init_ms,
-                                         const unsigned backoff_max_ms)
-{
+                                         const unsigned backoff_max_ms) {
   MutexLockGuard m(lock_options_);
-  opt_max_retries_ = max_retries;
+  opt_max_retries_     = max_retries;
   opt_backoff_init_ms_ = backoff_init_ms;
-  opt_backoff_max_ms_ = backoff_max_ms;
+  opt_backoff_max_ms_  = backoff_max_ms;
 }
 
 
@@ -3168,32 +3146,24 @@ void DownloadManager::SetMaxIpaddrPerProxy(unsigned limit) {
 }
 
 
-void DownloadManager::SetProxyTemplates(
-  const std::string &direct,
-  const std::string &forced)
-{
+void DownloadManager::SetProxyTemplates(const std::string &direct,
+                                        const std::string &forced) {
   MutexLockGuard m(lock_options_);
   proxy_template_direct_ = direct;
   proxy_template_forced_ = forced;
 }
 
 
-void DownloadManager::EnableInfoHeader() {
-  enable_info_header_ = true;
-}
+void DownloadManager::EnableInfoHeader() { enable_info_header_ = true; }
 
 
-void DownloadManager::EnableRedirects() {
-  follow_redirects_ = true;
-}
+void DownloadManager::EnableRedirects() { follow_redirects_ = true; }
 
 void DownloadManager::EnableIgnoreSignatureFailures() {
   ignore_signature_failures_ = true;
 }
 
-void DownloadManager::EnableHTTPTracing() {
-  enable_http_tracing_ = true;
-}
+void DownloadManager::EnableHTTPTracing() { enable_http_tracing_ = true; }
 
 void DownloadManager::AddHTTPTracingHeader(const std::string &header) {
   http_tracing_headers_.push_back(header);
@@ -3207,9 +3177,11 @@ bool DownloadManager::SetShardingPolicy(const ShardingPolicySelector type) {
   bool success = false;
   switch (type) {
     default:
-      LogCvmfs(kLogDownload, kLogDebug | kLogSyslogErr, "(manager '%s') "
-            "Proposed sharding policy does not exist. Falling back to default",
-            name_.c_str());
+      LogCvmfs(
+          kLogDownload, kLogDebug | kLogSyslogErr,
+          "(manager '%s') "
+          "Proposed sharding policy does not exist. Falling back to default",
+          name_.c_str());
   }
   return success;
 }
@@ -3223,8 +3195,8 @@ void DownloadManager::SetFailoverIndefinitely() {
  * single-threaded stage because it calls curl_global_init().
  */
 DownloadManager *DownloadManager::Clone(
-  const perf::StatisticsTemplate &statistics, const std::string &cloned_name)
-{
+    const perf::StatisticsTemplate &statistics,
+    const std::string &cloned_name) {
   DownloadManager *clone = new DownloadManager(pool_max_handles_, statistics,
                                                cloned_name);
 
@@ -3234,54 +3206,53 @@ DownloadManager *DownloadManager::Clone(
 
   if (!opt_dns_server_.empty())
     clone->SetDnsServer(opt_dns_server_);
-  clone->opt_timeout_proxy_ = opt_timeout_proxy_;
-  clone->opt_timeout_direct_ = opt_timeout_direct_;
-  clone->opt_low_speed_limit_ = opt_low_speed_limit_;
-  clone->opt_max_retries_ = opt_max_retries_;
-  clone->opt_backoff_init_ms_ = opt_backoff_init_ms_;
-  clone->opt_backoff_max_ms_ = opt_backoff_max_ms_;
-  clone->enable_info_header_ = enable_info_header_;
-  clone->enable_http_tracing_ = enable_http_tracing_;
-  clone->http_tracing_headers_ = http_tracing_headers_;
-  clone->follow_redirects_ = follow_redirects_;
+  clone->opt_timeout_proxy_         = opt_timeout_proxy_;
+  clone->opt_timeout_direct_        = opt_timeout_direct_;
+  clone->opt_low_speed_limit_       = opt_low_speed_limit_;
+  clone->opt_max_retries_           = opt_max_retries_;
+  clone->opt_backoff_init_ms_       = opt_backoff_init_ms_;
+  clone->opt_backoff_max_ms_        = opt_backoff_max_ms_;
+  clone->enable_info_header_        = enable_info_header_;
+  clone->enable_http_tracing_       = enable_http_tracing_;
+  clone->http_tracing_headers_      = http_tracing_headers_;
+  clone->follow_redirects_          = follow_redirects_;
   clone->ignore_signature_failures_ = ignore_signature_failures_;
   if (opt_host_.chain) {
-    clone->opt_host_.chain = new vector<string>(*opt_host_.chain);
+    clone->opt_host_.chain     = new vector<string>(*opt_host_.chain);
     clone->opt_host_chain_rtt_ = new vector<int>(*opt_host_chain_rtt_);
   }
 
   CloneProxyConfig(clone);
-  clone->opt_ip_preference_ = opt_ip_preference_;
-  clone->proxy_template_direct_ = proxy_template_direct_;
-  clone->proxy_template_forced_ = proxy_template_forced_;
+  clone->opt_ip_preference_            = opt_ip_preference_;
+  clone->proxy_template_direct_        = proxy_template_direct_;
+  clone->proxy_template_forced_        = proxy_template_forced_;
   clone->opt_proxy_groups_reset_after_ = opt_proxy_groups_reset_after_;
-  clone->opt_metalink_.reset_after = opt_metalink_.reset_after;
-  clone->opt_host_.reset_after = opt_host_.reset_after;
-  clone->credentials_attachment_ = credentials_attachment_;
-  clone->ssl_certificate_store_ = ssl_certificate_store_;
+  clone->opt_metalink_.reset_after     = opt_metalink_.reset_after;
+  clone->opt_host_.reset_after         = opt_host_.reset_after;
+  clone->credentials_attachment_       = credentials_attachment_;
+  clone->ssl_certificate_store_        = ssl_certificate_store_;
 
-  clone->health_check_ = health_check_;
-  clone->sharding_policy_ = sharding_policy_;
+  clone->health_check_          = health_check_;
+  clone->sharding_policy_       = sharding_policy_;
   clone->failover_indefinitely_ = failover_indefinitely_;
-  clone->fqrn_ = fqrn_;
+  clone->fqrn_                  = fqrn_;
 
   return clone;
 }
 
 
 void DownloadManager::CloneProxyConfig(DownloadManager *clone) {
-  clone->opt_proxy_groups_current_ = opt_proxy_groups_current_;
+  clone->opt_proxy_groups_current_        = opt_proxy_groups_current_;
   clone->opt_proxy_groups_current_burned_ = opt_proxy_groups_current_burned_;
-  clone->opt_proxy_groups_fallback_ = opt_proxy_groups_fallback_;
-  clone->opt_num_proxies_ = opt_num_proxies_;
-  clone->opt_proxy_shard_ = opt_proxy_shard_;
-  clone->opt_proxy_list_ = opt_proxy_list_;
-  clone->opt_proxy_fallback_list_ = opt_proxy_fallback_list_;
+  clone->opt_proxy_groups_fallback_       = opt_proxy_groups_fallback_;
+  clone->opt_num_proxies_                 = opt_num_proxies_;
+  clone->opt_proxy_shard_                 = opt_proxy_shard_;
+  clone->opt_proxy_list_                  = opt_proxy_list_;
+  clone->opt_proxy_fallback_list_         = opt_proxy_fallback_list_;
   if (opt_proxy_groups_ == NULL)
     return;
 
-  clone->opt_proxy_groups_ = new vector< vector<ProxyInfo> >(
-    *opt_proxy_groups_);
+  clone->opt_proxy_groups_ = new vector<vector<ProxyInfo> >(*opt_proxy_groups_);
   clone->UpdateProxiesUnlocked("cloned");
 }
 

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -41,21 +41,20 @@ enum DataTubeAction {
  * Wrapper for the data tube to transfer data from CallbackCurlData() that is
  * executed in MainDownload() Thread to Fetch() called by a fuse thread
  *
- * TODO(heretherebedragons): do we want to have a pool of those datatubeelements?
+ * TODO(heretherebedragons): do we want to have a pool of those
+ * datatubeelements?
  */
 struct DataTubeElement : SingleCopy {
-  char* data;
+  char *data;
   size_t size;
   DataTubeAction action;
 
-  explicit DataTubeElement(DataTubeAction xact) :
-                                           data(NULL), size(0), action(xact) { }
-  DataTubeElement(char* mov_data, size_t xsize, DataTubeAction xact) :
-                                   data(mov_data), size(xsize), action(xact) { }
+  explicit DataTubeElement(DataTubeAction xact)
+      : data(NULL), size(0), action(xact) { }
+  DataTubeElement(char *mov_data, size_t xsize, DataTubeAction xact)
+      : data(mov_data), size(xsize), action(xact) { }
 
-  ~DataTubeElement() {
-    delete data;
-  }
+  ~DataTubeElement() { delete data; }
 };
 
 /**
@@ -139,18 +138,14 @@ class JobInfo {
     pipe_job_results = new Pipe<kPipeDownloadJobsResults>();
   }
 
-  bool IsValidPipeJobResults() {
-    return pipe_job_results.IsValid();
-  }
+  bool IsValidPipeJobResults() { return pipe_job_results.IsValid(); }
 
   void CreateDataTube() {
     // TODO(heretherebedragons) change to weighted queue
     data_tube_ = new Tube<DataTubeElement>(500);
   }
 
-  bool IsValidDataTube() {
-    return data_tube_.IsValid();
-  }
+  bool IsValidDataTube() { return data_tube_.IsValid(); }
 
   /**
    * Tells whether the error is because of a non-existing file. Should only
@@ -169,10 +164,11 @@ class JobInfo {
   CURL **GetCurlHandle() { return &curl_handle_; }
   shash::ContextPtr *GetHashContextPtr() { return &hash_context_; }
   Pipe<kPipeDownloadJobsResults> *GetPipeJobResultPtr() {
-                                           return pipe_job_results.weak_ref(); }
+    return pipe_job_results.weak_ref();
+  }
   Tube<DataTubeElement> *GetDataTubePtr() { return data_tube_.weak_ref(); }
 
-  const std::string* url() const { return url_; }
+  const std::string *url() const { return url_; }
   bool compressed() const { return compressed_; }
   bool probe_hosts() const { return probe_hosts_; }
   bool head_request() const { return head_request_; }
@@ -209,7 +205,8 @@ class JobInfo {
   unsigned char num_retries() const { return num_retries_; }
   unsigned backoff_ms() const { return backoff_ms_; }
   int current_metalink_chain_index() const {
-                                         return current_metalink_chain_index_; }
+    return current_metalink_chain_index_;
+  }
   int current_host_chain_index() const { return current_host_chain_index_; }
 
   bool allow_failure() const { return allow_failure_; }
@@ -220,21 +217,22 @@ class JobInfo {
   void SetCompressed(bool compressed) { compressed_ = compressed; }
   void SetProbeHosts(bool probe_hosts) { probe_hosts_ = probe_hosts; }
   void SetHeadRequest(bool head_request) { head_request_ = head_request; }
-  void SetFollowRedirects(bool follow_redirects)
-                                      { follow_redirects_ = follow_redirects; }
+  void SetFollowRedirects(bool follow_redirects) {
+    follow_redirects_ = follow_redirects;
+  }
   void SetForceNocache(bool force_nocache) { force_nocache_ = force_nocache; }
   void SetPid(pid_t pid) { pid_ = pid; }
   void SetUid(uid_t uid) { uid_ = uid; }
   void SetGid(gid_t gid) { gid_ = gid; }
   void SetCredData(void *cred_data) { cred_data_ = cred_data; }
-  void SetInterruptCue(InterruptCue *interrupt_cue)
-                                             { interrupt_cue_ = interrupt_cue; }
-  void SetSink(cvmfs::Sink *sink)
-                                       { sink_ = sink; }
-  void SetExpectedHash(const shash::Any *expected_hash)
-                                             { expected_hash_ = expected_hash; }
-  void SetExtraInfo(const std::string *extra_info)
-                                                   { extra_info_ = extra_info; }
+  void SetInterruptCue(InterruptCue *interrupt_cue) {
+    interrupt_cue_ = interrupt_cue;
+  }
+  void SetSink(cvmfs::Sink *sink) { sink_ = sink; }
+  void SetExpectedHash(const shash::Any *expected_hash) {
+    expected_hash_ = expected_hash;
+  }
+  void SetExtraInfo(const std::string *extra_info) { extra_info_ = extra_info; }
 
   void SetRangeOffset(off_t range_offset) { range_offset_ = range_offset; }
   void SetRangeSize(off_t range_size) { range_size_ = range_size; }
@@ -242,32 +240,41 @@ class JobInfo {
   void SetCurlHandle(CURL *curl_handle) { curl_handle_ = curl_handle; }
   void SetHeaders(curl_slist *headers) { headers_ = headers; }
   void SetInfoHeader(char *info_header) { info_header_ = info_header; }
-  void SetTracingHeaderPid(char *tracing_header_pid)
-                                  { tracing_header_pid_ = tracing_header_pid; };
-  void SetTracingHeaderGid(char *tracing_header_gid)
-                                  { tracing_header_gid_ = tracing_header_gid; };
-  void SetTracingHeaderUid(char *tracing_header_uid)
-                                  { tracing_header_uid_ = tracing_header_uid; };
+  void SetTracingHeaderPid(char *tracing_header_pid) {
+    tracing_header_pid_ = tracing_header_pid;
+  };
+  void SetTracingHeaderGid(char *tracing_header_gid) {
+    tracing_header_gid_ = tracing_header_gid;
+  };
+  void SetTracingHeaderUid(char *tracing_header_uid) {
+    tracing_header_uid_ = tracing_header_uid;
+  };
   void SetZstream(z_stream zstream) { zstream_ = zstream; }
-  void SetHashContext(shash::ContextPtr hash_context)
-                                               { hash_context_ = hash_context; }
+  void SetHashContext(shash::ContextPtr hash_context) {
+    hash_context_ = hash_context;
+  }
   void SetProxy(const std::string &proxy) { proxy_ = proxy; }
   void SetLink(const std::string &link) { link_ = link; }
   void SetNocache(bool nocache) { nocache_ = nocache; }
   void SetErrorCode(Failures error_code) { error_code_ = error_code; }
   void SetHttpCode(int http_code) { http_code_ = http_code; }
-  void SetNumUsedProxies(unsigned char num_used_proxies)
-                                       { num_used_proxies_ = num_used_proxies; }
-  void SetNumUsedMetalinks(unsigned char num_used_metalinks)
-                                   { num_used_metalinks_ = num_used_metalinks; }
-  void SetNumUsedHosts(unsigned char num_used_hosts)
-                                           { num_used_hosts_ = num_used_hosts; }
+  void SetNumUsedProxies(unsigned char num_used_proxies) {
+    num_used_proxies_ = num_used_proxies;
+  }
+  void SetNumUsedMetalinks(unsigned char num_used_metalinks) {
+    num_used_metalinks_ = num_used_metalinks;
+  }
+  void SetNumUsedHosts(unsigned char num_used_hosts) {
+    num_used_hosts_ = num_used_hosts;
+  }
   void SetNumRetries(unsigned char num_retries) { num_retries_ = num_retries; }
   void SetBackoffMs(unsigned backoff_ms) { backoff_ms_ = backoff_ms; }
-  void SetCurrentMetalinkChainIndex(int current_metalink_chain_index)
-               { current_metalink_chain_index_ = current_metalink_chain_index; }
-  void SetCurrentHostChainIndex(int current_host_chain_index)
-                       { current_host_chain_index_ = current_host_chain_index; }
+  void SetCurrentMetalinkChainIndex(int current_metalink_chain_index) {
+    current_metalink_chain_index_ = current_metalink_chain_index;
+  }
+  void SetCurrentHostChainIndex(int current_host_chain_index) {
+    current_host_chain_index_ = current_host_chain_index;
+  }
 
   void SetAllowFailure(bool allow_failure) { allow_failure_ = allow_failure; }
 

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -23,7 +23,6 @@
 
 #include "swissknife_sync.h"
 
-
 #include <errno.h>
 #include <fcntl.h>
 #include <glob.h>
@@ -85,17 +84,16 @@ bool swissknife::CommandSync::CheckParams(const SyncParameters &p) {
     return false;
   }
 
-  if (p.min_file_chunk_size >= p.avg_file_chunk_size ||
-      p.avg_file_chunk_size >= p.max_file_chunk_size) {
+  if (p.min_file_chunk_size >= p.avg_file_chunk_size
+      || p.avg_file_chunk_size >= p.max_file_chunk_size) {
     PrintError("file chunk size values are not sane");
     return false;
   }
 
   if (HasPrefix(p.spooler_definition, "gw", false)) {
     if (p.session_token_file.empty()) {
-      PrintError(
-          "Session token file has to be provided "
-          "when upstream type is gw.");
+      PrintError("Session token file has to be provided "
+                 "when upstream type is gw.");
       return false;
     }
   }
@@ -104,14 +102,13 @@ bool swissknife::CommandSync::CheckParams(const SyncParameters &p) {
 }
 
 int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
-  const string manifest_path = *args.find('o')->second;
-  const string dir_temp = *args.find('t')->second;
+  const string manifest_path      = *args.find('o')->second;
+  const string dir_temp           = *args.find('t')->second;
   const string spooler_definition = *args.find('r')->second;
-  const string repo_name = *args.find('n')->second;
+  const string repo_name          = *args.find('n')->second;
   const string reflog_chksum_path = *args.find('R')->second;
   if (args.find('l') != args.end()) {
-    unsigned log_level =
-      kLogLevel0 << String2Uint64(*args.find('l')->second);
+    unsigned log_level = kLogLevel0 << String2Uint64(*args.find('l')->second);
     if (log_level > kLogNone) {
       LogCvmfs(kLogCvmfs, kLogStderr, "invalid log level");
       return 1;
@@ -127,7 +124,7 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
     }
   }
 
-  const bool volatile_content = (args.count('v') > 0);
+  const bool volatile_content    = (args.count('v') > 0);
   const bool garbage_collectable = (args.count('z') > 0);
   std::string voms_authz;
   if (args.find('V') != args.end()) {
@@ -182,9 +179,9 @@ int swissknife::CommandCreate::Main(const swissknife::ArgumentList &args) {
 }
 
 int swissknife::CommandUpload::Main(const swissknife::ArgumentList &args) {
-  const string source = *args.find('i')->second;
-  const string dest = *args.find('o')->second;
-  const string spooler_definition = *args.find('r')->second;
+  const string source              = *args.find('i')->second;
+  const string dest                = *args.find('o')->second;
+  const string spooler_definition  = *args.find('r')->second;
   shash::Algorithms hash_algorithm = shash::kSha1;
   if (args.find('a') != args.end()) {
     hash_algorithm = shash::ParseHashAlgorithm(*args.find('a')->second);
@@ -202,7 +199,7 @@ int swissknife::CommandUpload::Main(const swissknife::ArgumentList &args) {
 
   if (spooler->GetNumberOfErrors() > 0) {
     LogCvmfs(kLogCatalog, kLogStderr, "Swissknife Sync: failed to upload %s",
-                                      source.c_str());
+             source.c_str());
     return 1;
   }
 
@@ -212,7 +209,7 @@ int swissknife::CommandUpload::Main(const swissknife::ArgumentList &args) {
 }
 
 int swissknife::CommandPeek::Main(const swissknife::ArgumentList &args) {
-  const string file_to_peek = *args.find('d')->second;
+  const string file_to_peek       = *args.find('d')->second;
   const string spooler_definition = *args.find('r')->second;
 
   // Hash doesn't matter
@@ -228,11 +225,11 @@ int swissknife::CommandPeek::Main(const swissknife::ArgumentList &args) {
   }
   if (!success) {
     LogCvmfs(kLogCatalog, kLogStdout, "Swissknife Sync: %s not found",
-                                      file_to_peek.c_str());
+             file_to_peek.c_str());
     return 1;
   }
   LogCvmfs(kLogCatalog, kLogStdout, "Swissknife Sync: %s available",
-                                    file_to_peek.c_str());
+           file_to_peek.c_str());
 
   delete spooler;
 
@@ -240,7 +237,7 @@ int swissknife::CommandPeek::Main(const swissknife::ArgumentList &args) {
 }
 
 int swissknife::CommandRemove::Main(const ArgumentList &args) {
-  const string file_to_delete = *args.find('o')->second;
+  const string file_to_delete     = *args.find('o')->second;
   const string spooler_definition = *args.find('r')->second;
 
   // Hash doesn't matter
@@ -262,20 +259,20 @@ int swissknife::CommandRemove::Main(const ArgumentList &args) {
 }
 
 int swissknife::CommandApplyDirtab::Main(const ArgumentList &args) {
-  const string dirtab_file = *args.find('d')->second;
-  union_dir_ = MakeCanonicalPath(*args.find('u')->second);
-  scratch_dir_ = MakeCanonicalPath(*args.find('s')->second);
+  const string dirtab_file   = *args.find('d')->second;
+  union_dir_                 = MakeCanonicalPath(*args.find('u')->second);
+  scratch_dir_               = MakeCanonicalPath(*args.find('s')->second);
   const shash::Any base_hash = shash::MkFromHexPtr(
       shash::HexPtr(*args.find('b')->second), shash::kSuffixCatalog);
   const string stratum0 = *args.find('w')->second;
   const string dir_temp = *args.find('t')->second;
-  verbose_ = (args.find('x') != args.end());
+  verbose_              = (args.find('x') != args.end());
 
   // check if there is a dirtab file
   if (!FileExists(dirtab_file)) {
     LogCvmfs(kLogCatalog, kLogVerboseMsg,
-                   "Swissknife Sync: Didn't find a dirtab at '%s'. Skipping...",
-                   dirtab_file.c_str());
+             "Swissknife Sync: Didn't find a dirtab at '%s'. Skipping...",
+             dirtab_file.c_str());
     return 0;
   }
 
@@ -283,17 +280,17 @@ int swissknife::CommandApplyDirtab::Main(const ArgumentList &args) {
   catalog::Dirtab *dirtab = catalog::Dirtab::Create(dirtab_file);
   if (!dirtab->IsValid()) {
     LogCvmfs(kLogCatalog, kLogStderr,
-                         "Swissknife Sync: Invalid or not readable dirtab '%s'",
-                         dirtab_file.c_str());
+             "Swissknife Sync: Invalid or not readable dirtab '%s'",
+             dirtab_file.c_str());
     return 1;
   }
   LogCvmfs(kLogCatalog, kLogVerboseMsg,
-                              "Swissknife Sync: Found %lu rules in dirtab '%s'",
-                              dirtab->RuleCount(), dirtab_file.c_str());
+           "Swissknife Sync: Found %lu rules in dirtab '%s'",
+           dirtab->RuleCount(), dirtab_file.c_str());
 
   // initialize catalog infrastructure
   const bool auto_manage_catalog_files = true;
-  const bool follow_redirects = (args.count('L') > 0);
+  const bool follow_redirects          = (args.count('L') > 0);
   const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
   if (!InitDownloadManager(follow_redirects, proxy)) {
     return 1;
@@ -323,10 +320,12 @@ std::string *g_glob_uniondir = NULL;
 bool GlobCheckPath(const char *name) {
   char resolved_cstr[PATH_MAX];
   char *retval = realpath(name, resolved_cstr);
-  if (retval == NULL) return false;
+  if (retval == NULL)
+    return false;
 
   std::string resolved(resolved_cstr);
-  if (resolved == *g_glob_uniondir) return true;
+  if (resolved == *g_glob_uniondir)
+    return true;
   if (!HasPrefix(resolved, (*g_glob_uniondir) + "/", false /*ignore_case*/)) {
     errno = EACCES;
     return false;
@@ -335,25 +334,26 @@ bool GlobCheckPath(const char *name) {
 }
 
 void *GlobOpendir(const char *name) {
-  if (!GlobCheckPath(name)) return NULL;
+  if (!GlobCheckPath(name))
+    return NULL;
   return opendir(name);
 }
 
-void GlobClosedir(void *dirp) {
-  closedir(static_cast<DIR *>(dirp));
-}
+void GlobClosedir(void *dirp) { closedir(static_cast<DIR *>(dirp)); }
 
 struct dirent *GlobReaddir(void *dirp) {
   return readdir(static_cast<DIR *>(dirp));
 }
 
 int GlobLstat(const char *name, struct stat *st) {
-  if (!GlobCheckPath(name)) return -1;
+  if (!GlobCheckPath(name))
+    return -1;
   return lstat(name, st);
 }
 
 int GlobStat(const char *name, struct stat *st) {
-  if (!GlobCheckPath(name)) return -1;
+  if (!GlobCheckPath(name))
+    return -1;
   return stat(name, st);
 }
 
@@ -365,46 +365,46 @@ void swissknife::CommandApplyDirtab::DetermineNestedCatalogCandidates(
     catalog::SimpleCatalogManager *catalog_manager,
     vector<string> *nested_catalog_candidates) {
   // find possible new nested catalog locations
-  const catalog::Dirtab::Rules &lookup_rules = dirtab.positive_rules();
-  catalog::Dirtab::Rules::const_iterator i = lookup_rules.begin();
+  const catalog::Dirtab::Rules &lookup_rules        = dirtab.positive_rules();
+  catalog::Dirtab::Rules::const_iterator i          = lookup_rules.begin();
   const catalog::Dirtab::Rules::const_iterator iend = lookup_rules.end();
   for (; i != iend; ++i) {
     assert(!i->is_negation);
 
     // run a glob using the current dirtab rule on the current repository
     // state
-    const std::string &glob_string = i->pathspec.GetGlobString();
+    const std::string &glob_string     = i->pathspec.GetGlobString();
     const std::string &glob_string_abs = union_dir_ + glob_string;
-    const int glob_flags = GLOB_ONLYDIR | GLOB_NOSORT | GLOB_PERIOD |
-                           GLOB_ALTDIRFUNC;
+    const int glob_flags = GLOB_ONLYDIR | GLOB_NOSORT | GLOB_PERIOD
+                           | GLOB_ALTDIRFUNC;
     glob_t glob_res;
-    g_glob_uniondir = new std::string(union_dir_);
-    glob_res.gl_opendir = GlobOpendir;
-    glob_res.gl_readdir = GlobReaddir;
-    glob_res.gl_closedir = GlobClosedir;
-    glob_res.gl_lstat = GlobLstat;
-    glob_res.gl_stat = GlobStat;
-    const int glob_retval =
-        glob(glob_string_abs.c_str(), glob_flags, NULL, &glob_res);
+    g_glob_uniondir       = new std::string(union_dir_);
+    glob_res.gl_opendir   = GlobOpendir;
+    glob_res.gl_readdir   = GlobReaddir;
+    glob_res.gl_closedir  = GlobClosedir;
+    glob_res.gl_lstat     = GlobLstat;
+    glob_res.gl_stat      = GlobStat;
+    const int glob_retval = glob(glob_string_abs.c_str(), glob_flags, NULL,
+                                 &glob_res);
     delete g_glob_uniondir;
     g_glob_uniondir = NULL;
 
     if (glob_retval == 0) {
       // found some candidates... filtering by cvmfs catalog structure
       LogCvmfs(kLogCatalog, kLogDebug,
-                         "Swissknife Sync: Found %lu entries for pathspec (%s)",
-                         glob_res.gl_pathc, glob_string.c_str());
+               "Swissknife Sync: Found %lu entries for pathspec (%s)",
+               glob_res.gl_pathc, glob_string.c_str());
       FilterCandidatesFromGlobResult(dirtab, glob_res.gl_pathv,
                                      glob_res.gl_pathc, catalog_manager,
                                      nested_catalog_candidates);
     } else if (glob_retval == GLOB_NOMATCH) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                           "Swissknife Sync: WARNING: cannot apply pathspec %s",
-                           glob_string.c_str());
+               "Swissknife Sync: WARNING: cannot apply pathspec %s",
+               glob_string.c_str());
     } else {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                            "Swissknife Sync: Failed to run glob matching (%s)",
-                            glob_string.c_str());
+               "Swissknife Sync: Failed to run glob matching (%s)",
+               glob_string.c_str());
     }
 
     globfree(&glob_res);
@@ -435,7 +435,8 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
     if (!S_ISDIR(candidate_info.st_mode)) {
       // The GLOB_ONLYDIR flag is only a hint, non-directories can still be
       // returned
-      LogCvmfs(kLogCatalog, kLogDebug, "Swissknife Sync: "
+      LogCvmfs(kLogCatalog, kLogDebug,
+               "Swissknife Sync: "
                "The '%s' dirtab entry does not point to a directory "
                "but to a file or a symbolic link",
                candidate_rel.c_str());
@@ -444,16 +445,16 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
 
     // check if the path is a meta-directory (. or ..)
     assert(candidate_rel.size() >= 2);
-    if (candidate_rel.substr(candidate_rel.size() - 2) == "/." ||
-        candidate_rel.substr(candidate_rel.size() - 3) == "/..") {
+    if (candidate_rel.substr(candidate_rel.size() - 2) == "/."
+        || candidate_rel.substr(candidate_rel.size() - 3) == "/..") {
       continue;
     }
 
     // check that the path isn't excluded in the dirtab
     if (dirtab.IsOpposing(candidate_rel)) {
       LogCvmfs(kLogCatalog, kLogDebug,
-                        "Swissknife Sync: Candidate '%s' is excluded by dirtab",
-                        candidate_rel.c_str());
+               "Swissknife Sync: Candidate '%s' is excluded by dirtab",
+               candidate_rel.c_str());
       continue;
     }
 
@@ -469,8 +470,8 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
                "be a new directory and nested catalog.",
                candidate_rel.c_str());
       nested_catalog_candidates->push_back(candidate);
-    } else if (!dirent.IsNestedCatalogMountpoint() &&
-               !dirent.IsNestedCatalogRoot()) {
+    } else if (!dirent.IsNestedCatalogMountpoint()
+               && !dirent.IsNestedCatalogRoot()) {
       LogCvmfs(kLogCatalog, kLogDebug,
                "Swissknife Sync: Found '%s' in catalogs but is not a "
                "nested catalog yet.",
@@ -484,8 +485,8 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
       //       Otherwise we would force the cvmfs client behind the union
       //       file-
       //       system to (potentially) unnecessarily fetch catalogs
-      if (DirectoryExists(scratch_dir_ + candidate_rel) &&
-          !FileExists(union_dir_ + candidate_rel + "/.cvmfscatalog")) {
+      if (DirectoryExists(scratch_dir_ + candidate_rel)
+          && !FileExists(union_dir_ + candidate_rel + "/.cvmfscatalog")) {
         LogCvmfs(kLogCatalog, kLogStdout,
                  "Swissknife Sync: WARNING: '%s' should be a nested "
                  "catalog according to the dirtab. "
@@ -493,7 +494,8 @@ void swissknife::CommandApplyDirtab::FilterCandidatesFromGlobResult(
                  candidate_rel.c_str());
         nested_catalog_candidates->push_back(candidate);
       } else {
-        LogCvmfs(kLogCatalog, kLogDebug, "Swissknife Sync: "
+        LogCvmfs(kLogCatalog, kLogDebug,
+                 "Swissknife Sync: "
                  "Found '%s' in catalogs and it already is a nested catalog.",
                  candidate_rel.c_str());
       }
@@ -505,10 +507,10 @@ bool swissknife::CommandApplyDirtab::CreateCatalogMarkers(
     const std::vector<std::string> &new_nested_catalogs) {
   // go through the new nested catalog paths and create .cvmfscatalog markers
   // where necessary
-  bool success = true;
+  bool success                               = true;
   std::vector<std::string>::const_iterator k = new_nested_catalogs.begin();
-  const std::vector<std::string>::const_iterator kend =
-      new_nested_catalogs.end();
+  const std::vector<std::string>::const_iterator kend = new_nested_catalogs
+                                                            .end();
   for (; k != kend; ++k) {
     assert(!k->empty() && k->size() > union_dir_.size());
 
@@ -520,7 +522,7 @@ bool swissknife::CommandApplyDirtab::CreateCatalogMarkers(
 
     // create a nested catalog marker
     const mode_t mode = kDefaultFileMode;
-    const int fd = open(marker_path.c_str(), O_CREAT, mode);
+    const int fd      = open(marker_path.c_str(), O_CREAT, mode);
     if (fd < 0) {
       LogCvmfs(kLogCvmfs, kLogStderr,
                "Swissknife Sync: Failed to create nested catalog marker "
@@ -534,8 +536,8 @@ bool swissknife::CommandApplyDirtab::CreateCatalogMarkers(
     // inform the user if requested
     if (verbose_) {
       LogCvmfs(kLogCvmfs, kLogStdout,
-                          "Swissknife Sync: Auto-creating nested catalog in %s",
-                          k->c_str());
+               "Swissknife Sync: Auto-creating nested catalog in %s",
+               k->c_str());
     }
   }
 
@@ -543,7 +545,7 @@ bool swissknife::CommandApplyDirtab::CreateCatalogMarkers(
 }
 
 struct chunk_arg {
-  chunk_arg(char param, size_t *save_to) : param(param), save_to(save_to) {}
+  chunk_arg(char param, size_t *save_to) : param(param), save_to(save_to) { }
   char param;
   size_t *save_to;
 };
@@ -559,7 +561,7 @@ bool swissknife::CommandSync::ReadFileChunkingArgs(
   chunk_args.push_back(chunk_arg('h', &params->max_file_chunk_size));
 
   // read the arguments
-  ChunkArgs::const_iterator i = chunk_args.begin();
+  ChunkArgs::const_iterator i    = chunk_args.begin();
   ChunkArgs::const_iterator iend = chunk_args.end();
   for (; i != iend; ++i) {
     swissknife::ArgumentList::const_iterator arg = args.find(i->param);
@@ -585,9 +587,9 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   std::string watchdog_dir = "/tmp";
   char watchdog_path[PATH_MAX];
   std::string timestamp = GetGMTimestamp("%Y.%m.%d-%H.%M.%S");
-  int path_size = snprintf(watchdog_path, sizeof(watchdog_path),
-                           "%s/cvmfs-swissknife-sync-stacktrace.%s.%d",
-                           watchdog_dir.c_str(), timestamp.c_str(), getpid());
+  int path_size         = snprintf(watchdog_path, sizeof(watchdog_path),
+                                   "%s/cvmfs-swissknife-sync-stacktrace.%s.%d",
+                                   watchdog_dir.c_str(), timestamp.c_str(), getpid());
   assert(path_size > 0);
   assert(path_size < PATH_MAX);
   UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL));
@@ -596,48 +598,60 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   SyncParameters params;
 
   // Initialization
-  params.dir_union = MakeCanonicalPath(*args.find('u')->second);
+  params.dir_union   = MakeCanonicalPath(*args.find('u')->second);
   params.dir_scratch = MakeCanonicalPath(*args.find('s')->second);
-  params.dir_rdonly = MakeCanonicalPath(*args.find('c')->second);
-  params.dir_temp = MakeCanonicalPath(*args.find('t')->second);
+  params.dir_rdonly  = MakeCanonicalPath(*args.find('c')->second);
+  params.dir_temp    = MakeCanonicalPath(*args.find('t')->second);
   params.base_hash = shash::MkFromHexPtr(shash::HexPtr(*args.find('b')->second),
                                          shash::kSuffixCatalog);
-  params.stratum0 = *args.find('w')->second;
-  params.manifest_path = *args.find('o')->second;
+  params.stratum0  = *args.find('w')->second;
+  params.manifest_path      = *args.find('o')->second;
   params.spooler_definition = *args.find('r')->second;
 
   params.public_keys = *args.find('K')->second;
-  params.repo_name = *args.find('N')->second;
+  params.repo_name   = *args.find('N')->second;
 
   params.ttl_seconds = catalog::Catalog::kDefaultTTL;
 
   if (args.find('f') != args.end())
     params.union_fs_type = *args.find('f')->second;
-  if (args.find('A') != args.end()) params.is_balanced = true;
-  if (args.find('x') != args.end()) params.print_changeset = true;
-  if (args.find('y') != args.end()) params.dry_run = true;
-  if (args.find('m') != args.end()) params.mucatalogs = true;
-  if (args.find('i') != args.end()) params.ignore_xdir_hardlinks = true;
-  if (args.find('d') != args.end()) params.stop_for_catalog_tweaks = true;
-  if (args.find('V') != args.end()) params.voms_authz = true;
-  if (args.find('F') != args.end()) params.authz_file = *args.find('F')->second;
-  if (args.find('k') != args.end()) params.include_xattrs = true;
-  if (args.find('j') != args.end()) params.enable_mtime_ns = true;
-  if (args.find('Y') != args.end()) params.external_data = true;
-  if (args.find('W') != args.end()) params.direct_io = true;
+  if (args.find('A') != args.end())
+    params.is_balanced = true;
+  if (args.find('x') != args.end())
+    params.print_changeset = true;
+  if (args.find('y') != args.end())
+    params.dry_run = true;
+  if (args.find('m') != args.end())
+    params.mucatalogs = true;
+  if (args.find('i') != args.end())
+    params.ignore_xdir_hardlinks = true;
+  if (args.find('d') != args.end())
+    params.stop_for_catalog_tweaks = true;
+  if (args.find('V') != args.end())
+    params.voms_authz = true;
+  if (args.find('F') != args.end())
+    params.authz_file = *args.find('F')->second;
+  if (args.find('k') != args.end())
+    params.include_xattrs = true;
+  if (args.find('j') != args.end())
+    params.enable_mtime_ns = true;
+  if (args.find('Y') != args.end())
+    params.external_data = true;
+  if (args.find('W') != args.end())
+    params.direct_io = true;
   if (args.find('S') != args.end()) {
     bool retval = catalog::VirtualCatalog::ParseActions(
         *args.find('S')->second, &params.virtual_dir_actions);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                         "Swissknife Sync: Invalid virtual catalog options: %s",
-                          args.find('S')->second->c_str());
+               "Swissknife Sync: Invalid virtual catalog options: %s",
+               args.find('S')->second->c_str());
       return 1;
     }
   }
   if (args.find('z') != args.end()) {
-    unsigned log_level =
-        1 << (kLogLevel0 + String2Uint64(*args.find('z')->second));
+    unsigned log_level = 1 << (kLogLevel0
+                               + String2Uint64(*args.find('z')->second));
     if (log_level > kLogNone) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Swissknife Sync: invalid log level");
       return 1;
@@ -669,11 +683,12 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     }
   }
   if (args.find('Z') != args.end()) {
-    params.compression_alg =
-        zlib::ParseCompressionAlgorithm(*args.find('Z')->second);
+    params.compression_alg = zlib::ParseCompressionAlgorithm(
+        *args.find('Z')->second);
   }
 
-  if (args.find('E') != args.end()) params.enforce_limits = true;
+  if (args.find('E') != args.end())
+    params.enforce_limits = true;
   if (args.find('Q') != args.end()) {
     params.nested_kcatalog_limit = String2Uint64(*args.find('Q')->second);
   } else {
@@ -739,7 +754,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
 
   const bool upload_statsdb = (args.count('I') > 0);
 
-  if (!CheckParams(params)) return 2;
+  if (!CheckParams(params))
+    return 2;
   // This may fail, in which case a warning is printed and the process continues
   ObtainDacReadSearchCapability();
 
@@ -752,8 +768,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
       params.min_file_chunk_size, params.avg_file_chunk_size,
       params.max_file_chunk_size, params.session_token_file, params.key_file);
   if (params.max_concurrent_write_jobs > 0) {
-    spooler_definition.number_of_concurrent_uploads =
-        params.max_concurrent_write_jobs;
+    spooler_definition
+        .number_of_concurrent_uploads = params.max_concurrent_write_jobs;
   }
   spooler_definition.num_upload_tasks = params.num_upload_tasks;
 
@@ -762,11 +778,12 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
 
   params.spooler = upload::Spooler::Construct(spooler_definition,
                                               &publish_statistics);
-  if (NULL == params.spooler) return 3;
-  UniquePtr<upload::Spooler> spooler_catalogs(
-      upload::Spooler::Construct(spooler_definition_catalogs,
-                                 &publish_statistics));
-  if (!spooler_catalogs.IsValid()) return 3;
+  if (NULL == params.spooler)
+    return 3;
+  UniquePtr<upload::Spooler> spooler_catalogs(upload::Spooler::Construct(
+      spooler_definition_catalogs, &publish_statistics));
+  if (!spooler_catalogs.IsValid())
+    return 3;
 
   const bool follow_redirects = (args.count('L') > 0);
   const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
@@ -788,31 +805,31 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   if (params.branched_catalog) {
     // Throw-away manifest
     manifest = new manifest::Manifest(shash::Any(), 0, "");
-  } else if (params.virtual_dir_actions !=
-             catalog::VirtualCatalog::kActionNone) {
-    manifest = this->OpenLocalManifest(params.manifest_path);
+  } else if (params.virtual_dir_actions
+             != catalog::VirtualCatalog::kActionNone) {
+    manifest         = this->OpenLocalManifest(params.manifest_path);
     params.base_hash = manifest->catalog_hash();
   } else {
     // TODO(jblomer): revert to params.base_hash if spooler driver type is not
     // upload::SpoolerDefinition::Gateway
-    manifest =
-      FetchRemoteManifest(params.stratum0, params.repo_name, shash::Any());
+    manifest = FetchRemoteManifest(params.stratum0, params.repo_name,
+                                   shash::Any());
   }
   if (!manifest.IsValid()) {
     return 3;
   }
 
-  StatisticsDatabase *stats_db =
-    StatisticsDatabase::OpenStandardDB(params.repo_name);
+  StatisticsDatabase *stats_db = StatisticsDatabase::OpenStandardDB(
+      params.repo_name);
 
   const std::string old_root_hash = manifest->catalog_hash().ToString(true);
 
   catalog::WritableCatalogManager catalog_manager(
-         params.base_hash, params.stratum0, params.dir_temp,
-         spooler_catalogs.weak_ref(), download_manager(), params.enforce_limits,
-         params.nested_kcatalog_limit, params.root_kcatalog_limit,
-         params.file_mbyte_limit, statistics(), params.is_balanced,
-         params.max_weight, params.min_weight, params.cache_dir);
+      params.base_hash, params.stratum0, params.dir_temp,
+      spooler_catalogs.weak_ref(), download_manager(), params.enforce_limits,
+      params.nested_kcatalog_limit, params.root_kcatalog_limit,
+      params.file_mbyte_limit, statistics(), params.is_balanced,
+      params.max_weight, params.min_weight, params.cache_dir);
   catalog_manager.Init();
 
   publish::SyncMediator mediator(&catalog_manager, &params, publish_statistics);
@@ -820,12 +837,12 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
 
   // Should be before the synchronization starts to avoid race of GetTTL with
   // other sqlite operations
-  if ((params.ttl_seconds > 0) &&
-      ((params.ttl_seconds != catalog_manager.GetTTL()) ||
-       !catalog_manager.HasExplicitTTL())) {
+  if ((params.ttl_seconds > 0)
+      && ((params.ttl_seconds != catalog_manager.GetTTL())
+          || !catalog_manager.HasExplicitTTL())) {
     LogCvmfs(kLogCvmfs, kLogStdout,
-                      "Swissknife Sync: Setting repository TTL to %" PRIu64 "s",
-                      params.ttl_seconds);
+             "Swissknife Sync: Setting repository TTL to %" PRIu64 "s",
+             params.ttl_seconds);
     catalog_manager.SetTTL(params.ttl_seconds);
   }
 
@@ -840,8 +857,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
                                         params.dir_union, params.dir_scratch);
     } else {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                               "Swissknife Sync: unknown union file system: %s",
-                               params.union_fs_type.c_str());
+               "Swissknife Sync: unknown union file system: %s",
+               params.union_fs_type.c_str());
       return 3;
     }
 
@@ -880,8 +897,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
 
     if (!read_successful) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-                          "Swissknife Sync: Failed to read authz file (%s): %s",
-                          params.authz_file.c_str(), strerror(errno));
+               "Swissknife Sync: Failed to read authz file (%s): %s",
+               params.authz_file.c_str(), strerror(errno));
       return 8;
     }
 
@@ -899,20 +916,20 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     return 5;
   }
 
-  perf::Counter *revision_counter = statistics()->Register("publish.revision",
-                                                  "Published revision number");
-  revision_counter->Set(static_cast<int64_t>(
-    catalog_manager.GetRootCatalog()->revision()));
+  perf::Counter *revision_counter = statistics()->Register(
+      "publish.revision", "Published revision number");
+  revision_counter->Set(
+      static_cast<int64_t>(catalog_manager.GetRootCatalog()->revision()));
 
   // finalize the spooler
   LogCvmfs(kLogCvmfs, kLogStdout,
-                             "Swissknife Sync: Wait for all uploads to finish");
+           "Swissknife Sync: Wait for all uploads to finish");
   params.spooler->WaitForUpload();
   spooler_catalogs->WaitForUpload();
   params.spooler->FinalizeSession(false);
 
   LogCvmfs(kLogCvmfs, kLogStdout,
-                              "Swissknife Sync: Exporting repository manifest");
+           "Swissknife Sync: Exporting repository manifest");
 
   // We call FinalizeSession(true) this time, to also trigger the commit
   // operation on the gateway machine (if the upstream is of type "gw").

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -14,55 +14,55 @@
 #include "upload.h"
 
 struct SyncParameters {
-  static const unsigned kDefaultMaxWeight = 100000;
-  static const unsigned kDefaultMinWeight = 1000;
-  static const size_t kDefaultMinFileChunkSize = 4 * 1024 * 1024;
-  static const size_t kDefaultAvgFileChunkSize = 8 * 1024 * 1024;
-  static const size_t kDefaultMaxFileChunkSize = 16 * 1024 * 1024;
+  static const unsigned kDefaultMaxWeight           = 100000;
+  static const unsigned kDefaultMinWeight           = 1000;
+  static const size_t kDefaultMinFileChunkSize      = 4 * 1024 * 1024;
+  static const size_t kDefaultAvgFileChunkSize      = 8 * 1024 * 1024;
+  static const size_t kDefaultMaxFileChunkSize      = 16 * 1024 * 1024;
   static const unsigned kDefaultNestedKcatalogLimit = 500;
-  static const unsigned kDefaultRootKcatalogLimit = 200;
-  static const unsigned kDefaultFileMbyteLimit = 1024;
+  static const unsigned kDefaultRootKcatalogLimit   = 200;
+  static const unsigned kDefaultFileMbyteLimit      = 1024;
 
   SyncParameters()
-      : spooler(NULL),
-        union_fs_type("aufs"),
-        to_delete(""),
-        cache_dir(""),
-        print_changeset(false),
-        dry_run(false),
-        mucatalogs(false),
-        use_file_chunking(false),
-        generate_legacy_bulk_chunks(false),
-        ignore_xdir_hardlinks(false),
-        stop_for_catalog_tweaks(false),
-        include_xattrs(false),
-        enable_mtime_ns(false),
-        external_data(false),
-        direct_io(false),
-        voms_authz(false),
-        virtual_dir_actions(0),
-        ignore_special_files(false),
-        branched_catalog(false),
-        compression_alg(zlib::kZlibDefault),
-        enforce_limits(false),
-        nested_kcatalog_limit(0),
-        root_kcatalog_limit(0),
-        file_mbyte_limit(0),
-        min_file_chunk_size(kDefaultMinFileChunkSize),
-        avg_file_chunk_size(kDefaultAvgFileChunkSize),
-        max_file_chunk_size(kDefaultMaxFileChunkSize),
-        manual_revision(0),
-        ttl_seconds(0),
-        max_concurrent_write_jobs(0),
-        num_upload_tasks(1),
-        is_balanced(false),
-        max_weight(kDefaultMaxWeight),
-        min_weight(kDefaultMinWeight),
-        gid(-1u),
-        uid(-1u),
-        session_token_file(),
-        key_file(),
-        repo_tag() {}
+      : spooler(NULL)
+      , union_fs_type("aufs")
+      , to_delete("")
+      , cache_dir("")
+      , print_changeset(false)
+      , dry_run(false)
+      , mucatalogs(false)
+      , use_file_chunking(false)
+      , generate_legacy_bulk_chunks(false)
+      , ignore_xdir_hardlinks(false)
+      , stop_for_catalog_tweaks(false)
+      , include_xattrs(false)
+      , enable_mtime_ns(false)
+      , external_data(false)
+      , direct_io(false)
+      , voms_authz(false)
+      , virtual_dir_actions(0)
+      , ignore_special_files(false)
+      , branched_catalog(false)
+      , compression_alg(zlib::kZlibDefault)
+      , enforce_limits(false)
+      , nested_kcatalog_limit(0)
+      , root_kcatalog_limit(0)
+      , file_mbyte_limit(0)
+      , min_file_chunk_size(kDefaultMinFileChunkSize)
+      , avg_file_chunk_size(kDefaultAvgFileChunkSize)
+      , max_file_chunk_size(kDefaultMaxFileChunkSize)
+      , manual_revision(0)
+      , ttl_seconds(0)
+      , max_concurrent_write_jobs(0)
+      , num_upload_tasks(1)
+      , is_balanced(false)
+      , max_weight(kDefaultMaxWeight)
+      , min_weight(kDefaultMinWeight)
+      , gid(-1u)
+      , uid(-1u)
+      , session_token_file()
+      , key_file()
+      , repo_tag() { }
 
   upload::Spooler *spooler;
   std::string repo_name;
@@ -129,7 +129,7 @@ namespace swissknife {
 
 class CommandCreate : public Command {
  public:
-  ~CommandCreate() {}
+  ~CommandCreate() { }
   virtual std::string GetName() const { return "create"; }
   virtual std::string GetDescription() const {
     return "Bootstraps a fresh repository.";
@@ -159,7 +159,7 @@ class CommandCreate : public Command {
 
 class CommandUpload : public Command {
  public:
-  ~CommandUpload() {}
+  ~CommandUpload() { }
   virtual std::string GetName() const { return "upload"; }
   virtual std::string GetDescription() const {
     return "Uploads a local file to the repository.";
@@ -177,7 +177,7 @@ class CommandUpload : public Command {
 
 class CommandPeek : public Command {
  public:
-  ~CommandPeek() {}
+  ~CommandPeek() { }
   virtual std::string GetName() const { return "peek"; }
   virtual std::string GetDescription() const {
     return "Checks whether a file exists in the repository.";
@@ -193,7 +193,7 @@ class CommandPeek : public Command {
 
 class CommandRemove : public Command {
  public:
-  ~CommandRemove() {}
+  ~CommandRemove() { }
   virtual std::string GetName() const { return "remove"; }
   virtual std::string GetDescription() const {
     return "Removes a file in the repository storage.";
@@ -209,8 +209,8 @@ class CommandRemove : public Command {
 
 class CommandApplyDirtab : public Command {
  public:
-  CommandApplyDirtab() : verbose_(false) {}
-  ~CommandApplyDirtab() {}
+  CommandApplyDirtab() : verbose_(false) { }
+  ~CommandApplyDirtab() { }
   virtual std::string GetName() const { return "dirtab"; }
   virtual std::string GetDescription() const {
     return "Parses the dirtab file and produces nested catalog markers.";
@@ -249,7 +249,7 @@ class CommandApplyDirtab : public Command {
 
 class CommandSync : public Command {
  public:
-  ~CommandSync() {}
+  ~CommandSync() { }
   virtual std::string GetName() const { return "sync"; }
   virtual std::string GetDescription() const {
     return "Pushes changes from scratch area back to the repository.";
@@ -299,8 +299,8 @@ class CommandSync : public Command {
 
     r.push_back(
         Parameter::Switch('G', "Use persistent caching for all catalogs "
-                                 "used during the publishing process"
-                                 " Warning: No automatic garbage collection!"));
+                               "used during the publishing process"
+                               " Warning: No automatic garbage collection!"));
     r.push_back(Parameter::Switch('d',
                                   "pause publishing to allow for catalog "
                                   "tweaks"));


### PR DESCRIPTION
This is an example how the created `.clang-format` using clang-format v19 would look like.
The this version also aligns assignment operators.

For more read issue #3744

- this would be my preferred version - 
