### PR TITLE
Make telemetry aggregator delta calculation more reliable

### DIFF
--- a/cvmfs/telemetry_aggregator_influx.cc
+++ b/cvmfs/telemetry_aggregator_influx.cc
@@ -179,8 +179,13 @@ std::string TelemetryAggregatorInflux::MakeDeltaPayload() {
   for (std::map<std::string, int64_t>::iterator it
       = counters_.begin(), iEnd = counters_.end(); it != iEnd; it++) {
     int64_t value = it->second;
-    int64_t old_value = old_counters_.at(it->first);
     if (value != 0) {
+      int64_t old_value;
+      try {
+        old_value = old_counters_.at(it->first);
+      } catch(const std::out_of_range& ex) {
+        old_value = 0;
+      }
       if (add_token) {
         ret += ",";
       }


### PR DESCRIPTION
integration test `Telemetry Aggregator: Influx (test number 098)` is sometimes flaky due to wrong delta values.

delta values are calculated each time based on the raw values and as such it is only a single occurence that goes wrong.

it does not occur so often but it seems like those faulty tests have a longer than normal run time.
in the single output i got the 1st print of counters is missing some counters listed in the 2nd

so lets see if this `try/catch` resolves the issue...