### PR TITLE
curl now initializes to default, but excluding ssl 

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1946,7 +1946,8 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
   retval = pthread_mutex_init(lock_synchronous_mode_, NULL);
   assert(retval == 0);
 
-  retval = curl_global_init(CURL_GLOBAL_ALL);
+  // Use the default initialization, except for ssl as it is not required
+  retval = curl_global_init(CURL_GLOBAL_DEFAULT & ~CURL_GLOBAL_SSL);
   assert(retval == CURLE_OK);
 
   InitHeaders();


### PR DESCRIPTION
This is done instead of initializing everything (which is default), because ssl is not required