### PR TITLE
Added a cmake option to allow for building libcurl without SSL support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,9 @@ if (BUILTIN_EXTERNALS)
     if (BUILD_SNAPSHOTTER)
       set(ENV{BUILD_SNAPSHOTTER} "true")
     endif()
+    if (BUILD_CURL_WITHOUT_SSL)
+      set(ENV{BUILD_CURL_NO_SSL} "true")
+    endif()
 
     message (STATUS "running bootstrap.sh ...")
     execute_process (
@@ -230,6 +233,7 @@ if (BUILTIN_EXTERNALS)
     set(ENV{BUILD_GATEWAY} "")
     set(ENV{BUILD_DUCC} "")
     set(ENV{BUILD_SNAPSHOTTER} "")
+    set(ENV{BUILD_CURL_WITHOUT_SSL} "")
   endif (EXISTS "${CMAKE_SOURCE_DIR}/bootstrap.sh")
 
   # In the case of built-in external libraries, we need to set CMAKE_PREFIX_PATH to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,9 +206,11 @@ if (BUILTIN_EXTERNALS)
     if (BUILD_SNAPSHOTTER)
       set(ENV{BUILD_SNAPSHOTTER} "true")
     endif()
-    if (BUILD_CURL_WITHOUT_SSL)
-      set(ENV{BUILD_CURL_NO_SSL} "true")
+    if (NO_SSL_SUPPORT_EXPERIMENTAL)
+      message(WARNING "SSL support for CURL has been disabled. This is an experimental feature, it might break CVMFS. Only use if you are absolutely certain this is correct.")
+      set(ENV{NO_SSL_SUPPORT_EXPERIMENTAL} "true")
     endif()
+    execute_process(COMMAND sed -i /ssl_support_disabled=/c\\\ \ ssl_support_disabled=${NO_SSL_SUPPORT_EXPERIMENTAL} ${CMAKE_SOURCE_DIR}/cvmfs/cvmfs_config)
 
     message (STATUS "running bootstrap.sh ...")
     execute_process (
@@ -233,7 +235,7 @@ if (BUILTIN_EXTERNALS)
     set(ENV{BUILD_GATEWAY} "")
     set(ENV{BUILD_DUCC} "")
     set(ENV{BUILD_SNAPSHOTTER} "")
-    set(ENV{BUILD_CURL_WITHOUT_SSL} "")
+    set(ENV{NO_SSL_SUPPORT_EXPERIMENTAL} "")
   endif (EXISTS "${CMAKE_SOURCE_DIR}/bootstrap.sh")
 
   # In the case of built-in external libraries, we need to set CMAKE_PREFIX_PATH to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ if (BUILTIN_EXTERNALS)
       message(WARNING "SSL support for CURL has been disabled. This is an experimental feature, it might break CVMFS. Only use if you are absolutely certain this is correct.")
       set(ENV{NO_SSL_SUPPORT_EXPERIMENTAL} "true")
     endif()
-    execute_process(COMMAND sed -i /ssl_support_disabled=/c\\\ \ ssl_support_disabled=${NO_SSL_SUPPORT_EXPERIMENTAL} ${CMAKE_SOURCE_DIR}/cvmfs/cvmfs_config)
+    execute_process(COMMAND sed -i /ssl_support_disabled=/c\\\ \ ssl_support_disabled=$ENV{NO_SSL_SUPPORT_EXPERIMENTAL} ${CMAKE_SOURCE_DIR}/cvmfs/cvmfs_config)
 
     message (STATUS "running bootstrap.sh ...")
     execute_process (

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -708,7 +708,7 @@ if (BUILD_SERVER)
     )
   else() # SSL disabled, so use vendored library for functionality which would otherwise be taken form OpenSSL
     list(APPEND CVMFS_SWISSKNIFE_LINK_LIBRARIES
-      -l:libcrypto.a
+      cvmfs_crypto
     )
   endif()
   add_executable (cvmfs_swissknife ${CVMFS_SWISSKNIFE_SOURCES})
@@ -830,7 +830,7 @@ if (BUILD_SERVER)
     )
   else() # SSL disabled, so use vendored library for functionality which would otherwise be taken form OpenSSL
     list(APPEND LIBCVMFS_SERVER_LINK_LIBRARIES
-      -l:libcrypto.a
+      cvmfs_crypto
     )
   endif()
   add_library (cvmfs_server SHARED ${LIBCVMFS_SERVER_SOURCES})

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -256,7 +256,6 @@ if (BUILD_CVMFS)
   list(APPEND CVMFS_FUSE_LINK_LIBRARIES
        ${CURL_LIBRARIES}
        ${CARES_LIBRARIES} ${CARES_LDFLAGS}
-       ${OPENSSL_LIBRARIES}
        ${PACPARSER_LIBRARIES}
        ${SQLITE3_LIBRARY}
        ${ZLIB_LIBRARIES}
@@ -269,6 +268,11 @@ if (BUILD_CVMFS)
        pthread
        dl
   )
+  if (NOT NO_SSL_SUPPORT_EXPERIMENTAL) # SSL not disabled, so link OpenSSL
+    list(APPEND CVMFS_FUSE_LINK_LIBRARIES
+      ${OPENSSL_LIBRARIES}
+    )
+  endif()
   add_library (cvmfs_fuse SHARED ${CVMFS_FUSE_SOURCES})
   add_library (cvmfs_fuse_debug SHARED ${CVMFS_FUSE_SOURCES})
   add_dependencies (cvmfs_fuse cache.pb.generated)
@@ -411,7 +415,6 @@ if (BUILD_LIBCVMFS)
                          PUBLIC cvmfs_crypto
                                 cvmfs_util
                                 ${CARES_LDFLAGS}
-                                ${OPENSSL_LIBRARIES}
                          PRIVATE ${SQLITE3_LIBRARY}
                                  ${CURL_LIBRARIES}
                                  ${CARES_LIBRARIES}
@@ -421,6 +424,11 @@ if (BUILD_LIBCVMFS)
                                  ${VJSON_LIBRARIES}
                                  ${PROTOBUF_LITE_LIBRARY}
   )
+  if (NOT NO_SSL_SUPPORT_EXPERIMENTAL) # SSL not disabled, so link OpenSSL
+    target_link_libraries(cvmfs_client 
+                          PUBLIC ${OPENSSL_LIBRARIES}
+    )
+  endif()
 
   install (
     TARGETS      cvmfs_client
@@ -687,7 +695,6 @@ if (BUILD_SERVER)
         ${CURL_LIBRARIES}
         ${CARES_LIBRARIES} ${CARES_LDFLAGS}
         ${ZLIB_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
         ${RT_LIBRARY}
         ${VJSON_LIBRARIES}
         ${CAP_LIBRARIES}
@@ -695,6 +702,15 @@ if (BUILD_SERVER)
         pthread
         dl
   )
+  if (NOT NO_SSL_SUPPORT_EXPERIMENTAL) # SSL not disabled, so link OpenSSL
+    list(APPEND CVMFS_SWISSKNIFE_LINK_LIBRARIES
+      ${OPENSSL_LIBRARIES}
+    )
+  else() # SSL disabled, so use vendored library for functionality which would otherwise be taken form OpenSSL
+    list(APPEND CVMFS_SWISSKNIFE_LINK_LIBRARIES
+      -l:libcrypto.a
+    )
+  endif()
   add_executable (cvmfs_swissknife ${CVMFS_SWISSKNIFE_SOURCES})
   target_link_libraries (cvmfs_swissknife
                          cvmfs_crypto
@@ -799,7 +815,6 @@ if (BUILD_SERVER)
   list (APPEND LIBCVMFS_SERVER_LINK_LIBRARIES
         ${CURL_LIBRARIES}
         ${CARES_LIBRARIES} ${CARES_LDFLAGS}
-        ${OPENSSL_LIBRARIES}
         ${SQLITE3_LIBRARY}
         ${ZLIB_LIBRARIES}
         ${VJSON_LIBRARIES}
@@ -809,6 +824,15 @@ if (BUILD_SERVER)
         pthread
         dl
   )
+  if (NOT NO_SSL_SUPPORT_EXPERIMENTAL) # SSL not disabled, so link OpenSSL
+    list(APPEND LIBCVMFS_SERVER_LINK_LIBRARIES
+      ${OPENSSL_LIBRARIES}
+    )
+  else() # SSL disabled, so use vendored library for functionality which would otherwise be taken form OpenSSL
+    list(APPEND LIBCVMFS_SERVER_LINK_LIBRARIES
+      -l:libcrypto.a
+    )
+  endif()
   add_library (cvmfs_server SHARED ${LIBCVMFS_SERVER_SOURCES})
   set_target_properties (cvmfs_server PROPERTIES
     VERSION ${CernVM-FS_VERSION_STRING}
@@ -1247,13 +1271,17 @@ if (BUILD_PRELOADER)
                         ${CURL_LIBRARIES}
                         ${CARES_LIBRARIES} ${CARES_LDFLAGS}
                         ${ZLIB_LIBRARIES}
-                        ${OPENSSL_LIBRARIES}
                         ${RT_LIBRARY}
                         ${UUID_LIBRARIES}
                         ${VJSON_LIBRARIES}
                         pthread
                         dl
   )
+  if (NOT NO_SSL_SUPPORT_EXPERIMENTAL) # SSL not disabled, so link OpenSSL
+    target_link_libraries(cvmfs_preload_bin
+                          ${OPENSSL_LIBRARIES}
+    )
+  endif()
 
   #
   # Generate a bash self-extracting script for the cvmfs_preload target

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -1082,13 +1082,17 @@ if(BUILD_RECEIVER)
         ${CARES_LIBRARIES} ${CARES_LDFLAGS}
         ${SQLITE3_LIBRARY}
         ${VJSON_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
         ${ZLIB_LIBRARIES}
         ${RT_LIBRARY}
         ${LibArchive_LIBRARY}
         pthread
         dl
   )
+  if (NOT NO_SSL_SUPPORT_EXPERIMENTAL)
+    list(APPEND CVMFS_RECEIVER_LINK_LIBRARIES
+      ${OPENSSL_LIBRARIES}
+    )
+  endif()
   add_executable(cvmfs_receiver ${CVMFS_RECEIVER_SOURCES})
   set_target_properties (cvmfs_receiver PROPERTIES
     COMPILE_FLAGS "${CVMFS_RECEIVER_CFLAGS}"

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -839,6 +839,12 @@ cvmfs_chksetup() {
     fi
   done
 
+  # Check if CVMFS was built without SSL support
+  ssl_support_disabled=
+  if [[ "x$ssl_support_disabled" = "xYES" ]]; then
+    echo "Warning: SSL support is disabled. This is experimental and might cause problems"
+  fi
+
   if [ $(($num_warnings+$num_errors)) -eq 0 ]; then
     echo "OK"
   fi
@@ -912,10 +918,6 @@ cvmfs_showconfig() {
       [ $short_output -eq 0 ] && echo "${var}="
     fi
   done <<< "$all_vars"
-
-  # Check if CVMFS was built without SSL support
-  ssl_support_disabled=YES
-  echo "SSL support disabled=${ssl_support_disabled}"
 }
 
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -912,6 +912,10 @@ cvmfs_showconfig() {
       [ $short_output -eq 0 ] && echo "${var}="
     fi
   done <<< "$all_vars"
+
+  # Check if CVMFS was built without SSL support
+  ssl_support_disabled=YES
+  echo "SSL support disabled=${ssl_support_disabled}"
 }
 
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -839,10 +839,11 @@ cvmfs_chksetup() {
     fi
   done
 
-  # Check if CVMFS was built without SSL support
+  # Check if CVMFS was built without SSL support (the following line is automatically substituded by CMake)
   ssl_support_disabled=
-  if [[ "x$ssl_support_disabled" = "xYES" ]]; then
+  if [[ "x$ssl_support_disabled" = "xtrue" ]]; then
     echo "Warning: SSL support is disabled. This is experimental and might cause problems"
+    num_warnings=$(($num_warnings+1))
   fi
 
   if [ $(($num_warnings+$num_errors)) -eq 0 ]; then

--- a/externals/libcurl/src/configureHook.sh
+++ b/externals/libcurl/src/configureHook.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
 curl_ssl_config="--with-openssl"
+if [ x$BUILD_CURL_WITHOUT_SSL = x"true" ]; then
+  curl_ssl_config="--without-ssl"
+fi
+
 FIX_COMP=""
 LIBS=""
 if [ x"$(uname)" = x"Darwin" ]; then

--- a/externals/libcurl/src/configureHook.sh
+++ b/externals/libcurl/src/configureHook.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
 curl_ssl_config="--with-openssl"
-if [ x$BUILD_CURL_WITHOUT_SSL = x"true" ]; then
-  curl_ssl_config="--without-ssl"
-fi
 
 FIX_COMP=""
 LIBS=""
@@ -12,6 +9,10 @@ if [ x"$(uname)" = x"Darwin" ]; then
   FIX_COMP="CC=/usr/bin/clang CXX=/usr/bin/clang++"
   # On macOS, c-ares >= 1.16.1 uses libresolv for finding name servers
   LIBS="-lresolv"
+fi
+
+if [ x$NO_SSL_SUPPORT_EXPERIMENTAL = x"true" ]; then
+  curl_ssl_config="--without-ssl"
 fi
 
 sh configure $FIX_COMP CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64" \


### PR DESCRIPTION
This option was requested in issue #3531. Building curl without SSL support improves the speed of the curl initialization in https://github.com/cvmfs/cvmfs/blob/8444c2ccf2c2eb91ac572b62a5cadd3ae05e26b5/cvmfs/network/download.cc#L1949
However, it cannot be set as a standard option, because some features (such as S3) require SSL support.