### PR TITLE
Microbenchmark catalog grafting performance.

### DIFF
--- a/test/micro-benchmarks/CMakeLists.txt
+++ b/test/micro-benchmarks/CMakeLists.txt
@@ -1,8 +1,16 @@
 set (PROJECT_UBENCHMARKS_NAME "cvmfs_ubenchmarks")
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
+
 set(CVMFS_UBENCHMARKS_FILES
   main.cc
 
+  # test utility functions
+  ../common/env.cc
+  ../common/testutil.cc
+  ../common/catalog_test_tools.cc
+
+  b_catalog_grafting.cc
   b_compression.cc
   b_gluebuffer.cc
   b_hash.cc
@@ -17,17 +25,77 @@ set (CVMFS_UBENCHMARKS_SOURCES
   ${CVMFS_UBENCHMARKS_FILES}
 
   # dependencies
+  ${CVMFS_SOURCE_DIR}/backoff.cc
   ${CVMFS_SOURCE_DIR}/cache_transport.cc
+  ${CVMFS_SOURCE_DIR}/catalog.cc
+  ${CVMFS_SOURCE_DIR}/catalog_counters.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr_ro.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr_rw.cc
+  ${CVMFS_SOURCE_DIR}/catalog_rw.cc
+  ${CVMFS_SOURCE_DIR}/catalog_sql.cc
   ${CVMFS_SOURCE_DIR}/compression/compression.cc
   ${CVMFS_SOURCE_DIR}/crypto/hash.cc
+  ${CVMFS_SOURCE_DIR}/crypto/signature.cc
   ${CVMFS_SOURCE_DIR}/directory_entry.cc
   ${CVMFS_SOURCE_DIR}/glue_buffer.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/chunk_detector.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/item.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/item_mem.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/pipeline.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_chunk.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_compress.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_hash.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_read.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_register.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_write.cc
+  ${CVMFS_SOURCE_DIR}/gateway_util.cc
+  ${CVMFS_SOURCE_DIR}/globals.cc
+  ${CVMFS_SOURCE_DIR}/history_sql.cc
+  ${CVMFS_SOURCE_DIR}/history_sqlite.cc
+  ${CVMFS_SOURCE_DIR}/json_document.cc
+  ${CVMFS_SOURCE_DIR}/malloc_arena.cc
+  ${CVMFS_SOURCE_DIR}/manifest.cc
+  ${CVMFS_SOURCE_DIR}/manifest_fetch.cc
+  ${CVMFS_SOURCE_DIR}/monitor.cc
+  ${CVMFS_SOURCE_DIR}/network/dns.cc
+  ${CVMFS_SOURCE_DIR}/network/download.cc
+  ${CVMFS_SOURCE_DIR}/network/jobinfo.cc
+  ${CVMFS_SOURCE_DIR}/network/s3fanout.cc
+  ${CVMFS_SOURCE_DIR}/network/sink_file.cc
+  ${CVMFS_SOURCE_DIR}/network/sink_mem.cc
+  ${CVMFS_SOURCE_DIR}/network/sink_path.cc
+  ${CVMFS_SOURCE_DIR}/options.cc
+  ${CVMFS_SOURCE_DIR}/pack.cc
+  ${CVMFS_SOURCE_DIR}/receiver/lease_path_util.cc
+  ${CVMFS_SOURCE_DIR}/reflog.cc
+  ${CVMFS_SOURCE_DIR}/reflog_sql.cc
+  ${CVMFS_SOURCE_DIR}/upload_facility.cc
+  ${CVMFS_SOURCE_DIR}/upload_local.cc
+  ${CVMFS_SOURCE_DIR}/upload_gateway.cc
+  ${CVMFS_SOURCE_DIR}/upload_s3.cc
+  ${CVMFS_SOURCE_DIR}/upload_spooler_definition.cc
+  ${CVMFS_SOURCE_DIR}/sanitizer.cc
+  ${CVMFS_SOURCE_DIR}/server_tool.cc
+  ${CVMFS_SOURCE_DIR}/session_context.cc
   ${CVMFS_SOURCE_DIR}/shortstring.cc
+  ${CVMFS_SOURCE_DIR}/ssl.cc
+  ${CVMFS_SOURCE_DIR}/sql.cc
+  ${CVMFS_SOURCE_DIR}/sqlitemem.cc
+  ${CVMFS_SOURCE_DIR}/statistics.cc
+  ${CVMFS_SOURCE_DIR}/swissknife_lease_json.cc
+  ${CVMFS_SOURCE_DIR}/swissknife_lease_curl.cc
+  ${CVMFS_SOURCE_DIR}/upload.cc
   ${CVMFS_SOURCE_DIR}/util/algorithm.cc
+  ${CVMFS_SOURCE_DIR}/util/concurrency.cc
   ${CVMFS_SOURCE_DIR}/util/exception.cc
+  ${CVMFS_SOURCE_DIR}/util/file_backed_buffer.cc
   ${CVMFS_SOURCE_DIR}/util/logging.cc
+  ${CVMFS_SOURCE_DIR}/util/mmap_file.cc
   ${CVMFS_SOURCE_DIR}/util/posix.cc
+  ${CVMFS_SOURCE_DIR}/util/raii_temp_dir.cc
   ${CVMFS_SOURCE_DIR}/util/string.cc
+  ${CVMFS_SOURCE_DIR}/whitelist.cc
+  ${CVMFS_SOURCE_DIR}/xattr.cc
   cache.pb.cc cache.pb.h
 )
 
@@ -60,11 +128,17 @@ set_target_properties (${PROJECT_UBENCHMARKS_NAME} PROPERTIES
                        LINK_FLAGS "${CVMFS_UBENCHMARKS_LD_FLAGS}")
 
 set (UBENCHMARKS_LINK_LIBRARIES ${GOOGLEBENCH_LIBRARIES}
+                                ${GTEST_LIBRARIES}
+                                ${CURL_LIBRARIES}
+                                ${CARES_LIBRARIES} ${CARES_LDFLAGS}
+                                ${OPENSSL_LIBRARIES}
                                 ${Libcrypto_LIBRARIES}
                                 ${SHA3_LIBRARIES}
                                 ${PROTOBUF_LITE_LIBRARY}
                                 ${ZLIB_LIBRARIES}
                                 ${RT_LIBRARY}
+                                ${SQLITE3_LIBRARY}
+                                ${VJSON_LIBRARIES}
                                 pthread dl)
 
 target_link_libraries (${PROJECT_UBENCHMARKS_NAME} ${UBENCHMARKS_LINK_LIBRARIES})

--- a/test/micro-benchmarks/b_catalog_grafting.cc
+++ b/test/micro-benchmarks/b_catalog_grafting.cc
@@ -1,0 +1,129 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+#define __STDC_FORMAT_MACROS
+#include <benchmark/benchmark.h>
+
+#include <inttypes.h>
+#include <stdint.h>
+
+#include <cstdio>
+#include <iostream>
+
+#include "bm_util.h"
+#include "catalog_test_tools.h"
+#include "crypto/hash.h"
+#include "directory_entry.h"
+#include "shortstring.h"
+#include "util/murmur.hxx"
+#include "util/prng.h"
+#include "receiver/catalog_merge_tool.h"
+#include "receiver/params.h"
+#include "testutil.h"
+#include "xattr.h"
+
+namespace {  
+  receiver::Params MakeMergeToolParams(const std::string& name) {
+    receiver::Params params;
+  
+    const std::string sandbox_root = GetCurrentWorkingDirectory();
+    const std::string stratum0 = sandbox_root + "/" + name;
+    const std::string temp_dir = stratum0 + "/data/txn";
+  
+    params.stratum0 = "file://" + stratum0;
+    params.spooler_configuration = "local," + temp_dir + "," + stratum0;
+    params.hash_alg = shash::kSha1;
+    params.compression_alg = zlib::kZlibDefault;
+    params.generate_legacy_bulk_chunks = false;
+    params.use_file_chunking = true;
+    params.min_chunk_size = 4194304;
+    params.avg_chunk_size = 8388608;
+    params.max_chunk_size = 16777216;
+    params.enforce_limits = false;
+    params.nested_kcatalog_limit = 0;
+    params.root_kcatalog_limit = 0;
+    params.file_mbyte_limit = 0;
+    params.use_autocatalogs = false;
+    params.max_weight = 0;
+    params.min_weight = 0;
+  
+    return params;
+  }
+  
+}  // namespace
+
+class BM_CatalogGrafting : public benchmark::Fixture {
+ protected:
+  virtual void SetUp(const benchmark::State &st) {
+  }
+
+  virtual void TearDown(const benchmark::State &st) {
+  }
+  const char* file_hash{"b026324c6904b2a9cb4b88d6d61c81d100000000"};
+  const size_t size{4096};
+};
+
+BENCHMARK_DEFINE_F(BM_CatalogGrafting, Baseline)(benchmark::State &st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+
+    // Create initial spec with only 1 dir
+    DirSpec spec1;
+    spec1.AddDirectory("dir", "", size);
+
+    CatalogTestTool tester("test");
+    tester.Init();  
+    tester.Apply("first", spec1);
+    
+    manifest::Manifest first_manifest = *(tester.manifest());
+  
+    DirSpec spec2{spec1};
+    // add nested directories
+    spec2.AddDirectory("1", "dir", size);
+    spec2.AddDirectory("2", "dir/1", size);
+    spec2.AddDirectory("3", "dir/1/2", size);
+    spec2.AddDirectory("4", "dir/1/2/3", size);
+    spec2.AddDirectory("5", "dir/1/2/3/4", size);
+    // Add files to each of the added directories
+    spec2.AddFile("file1", "dir/1", file_hash, size);
+    spec2.AddFile("file2", "dir/1/2", file_hash, size);
+    spec2.AddFile("file3", "dir/1/2/3", file_hash, size);
+    spec2.AddFile("file4", "dir/1/2/3/4", file_hash, size);
+    spec2.AddFile("file5", "dir/1/2/3/4/5", file_hash, size);
+    // Add catalogs to each of the added directories
+    spec2.AddNestedCatalog("dir");
+    spec2.AddNestedCatalog("dir/1");
+    spec2.AddNestedCatalog("dir/1/2");
+    spec2.AddNestedCatalog("dir/1/2/3");
+    spec2.AddNestedCatalog("dir/1/2/3/4");
+    spec2.AddNestedCatalog("dir/1/2/3/4/5");
+  
+    tester.Apply("second", spec2);
+  
+    UniquePtr<ServerTool> server_tool(new ServerTool());
+    server_tool->InitDownloadManager(true, "");
+  
+    receiver::Params params = MakeMergeToolParams("test");
+  
+    CatalogTestTool::History history = tester.history();
+  
+    perf::Statistics statistics;
+  
+    receiver::CatalogMergeTool<catalog::WritableCatalogManager,
+                              catalog::SimpleCatalogManager>
+       merge_tool(params.stratum0, history[1].second, history[2].second,
+                  PathString(""), GetCurrentWorkingDirectory() + "/merge_tool",
+                  server_tool->download_manager(), &first_manifest, &statistics, "");
+    merge_tool.Init();
+
+    std::string output_manifest_path;
+    shash::Any output_manifest_hash;
+    uint64_t final_rev;
+
+    // Measure only the merge tool's time
+    st.ResumeTiming();
+    merge_tool.Run(params, &output_manifest_path, &output_manifest_hash, &final_rev);
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+BENCHMARK_REGISTER_F(BM_CatalogGrafting, Baseline)->Repetitions(3);


### PR DESCRIPTION
This microbenchmark measures the `CatalogMergeTool::Run()`. It can be used to verify a speed increase caused by #3565. It makes use of the common test tools (which were not used in the benchmarks yet), which is why there are many dependencies added to the cmake file.