### PR TITLE
Removed performance-enum-size from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks: -*
   ,-performance-enum-size
   ,-performance-inefficient-string-concatenation
   ,portability-*
+  # performance-enum-size is only supported since c++11. When using c++11 or later, this option can be re-enabled
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'cvmfs\/[a-zA-Z0-9_]*\.h$'
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: -*
   ,-misc-no-recursion
   ,-misc-non-private-member-variables-in-classes
   ,performance-*
+  ,-performance-enum-size
   ,-performance-inefficient-string-concatenation
   ,portability-*
 WarningsAsErrors: '*'


### PR DESCRIPTION
Adding typed enums, which is suggested by the performance-enum-size check, is only supported since C++11, which is not yet supported by all the platforms that use CVMFS.