### PR TITLE
Fix for `cvmfs_server transaction -t`: update repository state  after waiting for lease

### DIFF
--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -359,7 +359,7 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
   void CheckTagName(const std::string &name);
 
   void TransactionRetry();
-  void TransactionImpl();
+  void TransactionImpl(bool waiting_on_lease=false);
 
   SettingsPublisher settings_;
   UniquePtr<perf::StatisticsTemplate> statistics_publish_;

--- a/test/container/500-concurrent-publishing/Dockerfile-dev-pub
+++ b/test/container/500-concurrent-publishing/Dockerfile-dev-pub
@@ -1,0 +1,18 @@
+FROM gitlab-registry.cern.ch/cernvm/build-images/centos_x86_64:9
+
+USER root
+
+
+#RUN yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm
+#RUN yum install -y cvmfs-2.10.1 cvmfs-server-2.10.1 cvmfs-gateway-2.10.1 
+
+
+RUN echo '%sftnight ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+ENV USER sftnight
+
+RUN yum -y install rpm-build
+RUN cd /home/sftnight/cvmfs; ./ci/build_package.sh $PWD $PWD/../buildpackage/ cvmfs
+
+CMD ["/usr/sbin/init"]
+

--- a/test/container/500-concurrent-publishing/README.md
+++ b/test/container/500-concurrent-publishing/README.md
@@ -1,0 +1,11 @@
+# Test of concurrent publishing
+
+```sh
+docker-compose up --build -d
+./setup.sh
+./test.sh
+./teardown.sh
+```
+
+
+

--- a/test/container/500-concurrent-publishing/config/repo.json
+++ b/test/container/500-concurrent-publishing/config/repo.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+
+  "repos": [
+    "test.repo.org"
+  ]
+}
+

--- a/test/container/500-concurrent-publishing/config/repo.json.rpmnew
+++ b/test/container/500-concurrent-publishing/config/repo.json.rpmnew
@@ -1,0 +1,21 @@
+{
+    "version": 2,
+    "repos" : [
+        {
+            "domain" : "example_repo.domain.org",
+            "keys" : [
+                {
+                    "id": "example_key",
+                    "path": "/"
+                }
+            ]
+        }
+    ],
+    "keys" : [
+        {
+            "type" : "plain_text",
+            "id" : "example_key",
+            "secret" : "SECRET"
+        }
+    ]
+}

--- a/test/container/500-concurrent-publishing/config/user.json
+++ b/test/container/500-concurrent-publishing/config/user.json
@@ -1,0 +1,9 @@
+{
+    "max_lease_time" : 7200,
+    "port" : 4929,
+    "num_receivers": 1,
+    "receiver_path": "/usr/bin/cvmfs_receiver",
+    "log_level" : "info",
+    "log_timestamps" : false,
+    "work_dir": "/var/lib/cvmfs-gateway"
+}

--- a/test/container/500-concurrent-publishing/docker-compose.yml
+++ b/test/container/500-concurrent-publishing/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3'
+
+services:
+    cvmfs-test-gw1:
+        image: registry.cern.ch/cvmfs-dev:latest
+        container_name: cvmfs-gw1
+        hostname: cvmfs-gw1
+        privileged: true
+        build:
+            context: .
+            dockerfile: Dockerfile-dev-pub
+        volumes:
+            - /sys/fs/cgroup:/sys/fs/cgroup
+            - ./keys/:/etc/cvmfs/keys
+            - var_spool_cvmfs1:/var/spool/cvmfs
+            - ../../../:/home/sftnight/cvmfs
+            - ./config/:/etc/cvmfs/gateway
+            - ./scripts:/scripts
+        ports:
+            - "4929"
+            - "80"
+
+    cvmfs-test-pub1:
+        image: registry.cern.ch/cvmfs-dev:latest
+        container_name: cvmfs-pub1
+        hostname: cvmfs-pub1
+        privileged: true
+        build:
+            context: .
+            dockerfile: Dockerfile-dev-pub
+        volumes:
+            - /sys/fs/cgroup:/sys/fs/cgroup
+            - ./keys/:/etc/cvmfs/keys
+            - ./scripts:/scripts
+            - var_spool_cvmfs2:/var/spool/cvmfs
+            - ../../../:/home/sftnight/cvmfs
+
+    cvmfs-test-pub2:
+        image: registry.cern.ch/cvmfs-dev-pub:latest
+        container_name: cvmfs-pub2
+        hostname: cvmfs-pub2
+        privileged: true
+        build:
+            context: .
+            dockerfile: Dockerfile-dev-pub
+        volumes:
+            - /sys/fs/cgroup:/sys/fs/cgroup
+            - ./keys/:/etc/cvmfs/keys
+            - ./scripts:/scripts
+            - var_spool_cvmfs3:/var/spool/cvmfs
+            - ../../../:/home/sftnight/cvmfs
+
+volumes:
+    var_spool_cvmfs1:
+    var_spool_cvmfs2:
+    var_spool_cvmfs3:
+

--- a/test/container/500-concurrent-publishing/scripts/setup_connected_publisher.sh
+++ b/test/container/500-concurrent-publishing/scripts/setup_connected_publisher.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#jsudo yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm
+#sudo yum install -y cvmfs cvmfs-server
+FQRN=test.repo.org
+CVMFS_GATEWAY_URL=http://cvmfs-gw1
+CVMFS_SERVER_DEBUG=3 cvmfs_server mkfs -w $CVMFS_GATEWAY_URL/cvmfs/$FQRN \
+                         -u gw,/srv/cvmfs/$FQRN/data/txn,$CVMFS_GATEWAY_URL:4929/api/v1 \
+                         -k /etc/cvmfs/keys -o `whoami` $FQRN
+cvmfs_server transaction
+cvmfs_server publish
+

--- a/test/container/500-concurrent-publishing/scripts/setup_gateway.sh
+++ b/test/container/500-concurrent-publishing/scripts/setup_gateway.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "plain_text mykey mysecret" > /etc/cvmfs/keys/test.repo.org.gw
+systemctl start httpd
+cvmfs_server mkfs -o root  test.repo.org
+systemctl start cvmfs-gateway

--- a/test/container/500-concurrent-publishing/setup.sh
+++ b/test/container/500-concurrent-publishing/setup.sh
@@ -1,0 +1,4 @@
+docker exec -it cvmfs-gw1 /scripts/setup_gateway.sh
+docker exec -it cvmfs-pub1 /scripts/setup_connected_publisher.sh
+docker exec -it cvmfs-pub2 /scripts/setup_connected_publisher.sh
+

--- a/test/container/500-concurrent-publishing/teardown.sh
+++ b/test/container/500-concurrent-publishing/teardown.sh
@@ -1,0 +1,3 @@
+docker stop cvmfs-pub2 && docker rm cvmfs-pub2
+docker stop cvmfs-pub1 && docker rm cvmfs-pub1
+docker stop cvmfs-gw1 &&  docker rm cvmfs-gw1

--- a/test/container/500-concurrent-publishing/test.sh
+++ b/test/container/500-concurrent-publishing/test.sh
@@ -1,0 +1,17 @@
+docker exec  cvmfs-pub1 cvmfs_server transaction
+docker exec  cvmfs-pub1 bash -c 'echo abc > /cvmfs/test.repo.org/testfile'
+docker exec  cvmfs-pub1 cvmfs_server publish
+docker exec  cvmfs-pub1 cvmfs_server transaction
+docker exec  cvmfs-pub1 bash -c 'echo important_change > /cvmfs/test.repo.org/testfile'
+docker exec  cvmfs-pub2 cvmfs_server transaction -t 5000 &
+sleep 1
+docker exec  cvmfs-pub1 cvmfs_server publish
+wait $(jobs -p) 
+sleep 1
+docker exec  cvmfs-pub2 bash -c 'echo unrelated_change > /cvmfs/test.repo.org/another_file'
+docker exec  cvmfs-pub2 cvmfs_server publish
+docker exec  cvmfs-gw1 cvmfs_server tag -l
+docker exec  cvmfs-gw1 cat /cvmfs/test.repo.org/another_file
+docker exec  cvmfs-gw1 cat /cvmfs/test.repo.org/testfile
+docker exec  cvmfs-gw1 cat /cvmfs/test.repo.org/testfile | tee | grep important_change ||  echo -e ERROR >&2; exit 1
+


### PR DESCRIPTION
This is an important fix relevant when using the `cvmfs_server transaction -t`  option to wait for a lease on a publisher connected to a gateway. Without this patch, the transaction that is waited on can be lost (to be precise, it is reverted by the following transaction due to the wrong choice of the base of the catalog diff)

This is a rather narrow fix that updates the current readonly mount with the latest revision. We do this only when we are waiting for a lease to avoid the overhead of the manifest download and remount - to do that is really not required when we change a subrepository that isn't currently in a transaction by another publisher.

However, there might still be an unlikely race condition when the start of the transaction happens before an ongoing publication is concluded, but the check for the lease happens after. To be investigated.

A test reproducing this issue is included, but has yet to be added to the CI - needs a good way to build an image with the current cvmfs installed.

This issue was first reported in https://its.cern.ch/jira/projects/SPI/issues/SPI-2652