### PR TITLE
Apply %pretrans transaction check in most subpackages

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -70,7 +70,7 @@
 Summary: CernVM File System
 Name: cvmfs
 Version: 2.12.7
-Release: 1%{?dist}
+Release: 2%{?dist}
 URL: https://cernvm.cern.ch/fs/
 Source0: https://ecsft.cern.ch/dist/cvmfs/%{name}-%{version}/%{name}-%{version}.tar.gz
 %if 0%{?selinux_cvmfs}
@@ -358,23 +358,45 @@ popd
 
 %if 0%{?el4}
 %else
+# apply this to all subpackages that need to stay in version sync
+%define check_transaction \
+  [ -d "/var/spool/cvmfs"  ]          || exit 0; \
+  [ -d "/etc/cvmfs/repositories.d/" ] || exit 0; \
+  for repo in /var/spool/cvmfs/*; do \
+    [ -d $repo ] && [ ! -f /etc/cvmfs/repositories.d/$(basename $repo)/replica.conf ] || continue; \
+    if [ -f ${repo}/in_transaction.lock ] || \
+       [ -d ${repo}/in_transaction      ] || \
+       [ -f ${repo}/in_transaction      ]; then \
+      echo "     Found open CernVM-FS repository transactions."           >&2; \
+      echo "     Please abort or publish them before updating CernVM-FS." >&2; \
+      exit 1; \
+    fi; \
+  done
+
+%pretrans
+%check_transaction
+
+%pretrans libs
+%check_transaction
+
+%pretrans fuse3
+%check_transaction
+
+%pretrans devel
+%check_transaction
+
 %pretrans server
-[ -d "/var/spool/cvmfs"  ]          || exit 0
-[ -d "/etc/cvmfs/repositories.d/" ] || exit 0
+%check_transaction
 
-for repo in /var/spool/cvmfs/*; do
-  [ -d $repo ] && [ ! -f /etc/cvmfs/repositories.d/$(basename $repo)/replica.conf ] || continue
+%pretrans shrinkwrap
+%check_transaction
 
-  if [ -f ${repo}/in_transaction.lock ] || \
-     [ -d ${repo}/in_transaction      ] || \
-     [ -f ${repo}/in_transaction      ]; then
-    echo "     Found open CernVM-FS repository transactions."           >&2
-    echo "     Please abort or publish them before updating CernVM-FS." >&2
-    exit 1
-  fi
-done
+%pretrans unittests
+%check_transaction
 
-exit 0
+%pretrans gateway
+%check_transaction
+
 %endif
 
 %pre
@@ -708,6 +730,10 @@ systemctl daemon-reload
 %endif
 
 %changelog
+* Mon Mar 3 2025 Dave Dykstra <dwd@cern.ch>> - 2.12.7-2
+- Apply %pretrans transaction check to all subpackages that need to
+  have their version stay in sync
+- Rename registry-webhook.py to registry_webhook.py to allow imports
 * Tue Nov 7 2023 Valentin Volkl <vavolkl@cern.ch> - 2.11.2
 - Rename registry-webhook.py to registry_webhook.py to allow imports
 * Wed Nov 16 2022 Jakob Blomer <jblomer@cern.ch> - 2.11.0


### PR DESCRIPTION
This turns the transaction check that was only in `%pretrans server` into a macro and applied in `%pretrans` scriptlets for all the subpackages that need to have their version stay in sync.

- Fixes #3778