### PR TITLE
[rpm] fix permissions for cvmfs_ducc

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -552,7 +552,8 @@ restorecon -R /var/log/cvmfs
 rm -f /var/lib/cvmfs-server/geo/*.dat
 /sbin/ldconfig
 
-
+%post ducc
+setcap "cap_dac_override=ep cap_dac_read_search=ep cap_fowner=ep cap_chown=ep cap_sys_admin=ep cap_mknod=ep" /usr/bin/cvmfs_ducc
 
 %preun
 if [ $1 = 0 ] ; then


### PR DESCRIPTION
Fixes errors of the type

```
ERRO[0021] Error in chown error="chown /var/spool/cvmfs/test.cern.ch/
        /scratch/current/.chains/XX...: operation not permitted"
```

when cvmfs_ducc is installed via rpm and not run as root. This just copies how the manual install sets permissions, the capabilities themselves should be reviewed in the future.

Fixes https://github.com/cvmfs/cvmfs/issues/3202 