### PR TITLE
Install apparmor profile for fusermount3/cvmfs

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -365,6 +365,13 @@ if (BUILD_CVMFS)
     DESTINATION /usr/lib/systemd/system
     PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   )
+  # Apparmor fusermount3 profile extension
+  install (
+    FILES pkg/apparmor.local.fusermount3
+    DESTINATION /etc/apparmor.d/local
+    RENAME fusermount3
+    PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+  )
 
 endif (BUILD_CVMFS)
 

--- a/cvmfs/pkg/apparmor.local.fusermount3
+++ b/cvmfs/pkg/apparmor.local.fusermount3
@@ -1,0 +1,2 @@
+# Added by cvmfs to allow mounts on /cvmfs
+mount fstype=@{fuse_types} options=(nosuid,nodev,ro) -> /cvmfs/**/, 

--- a/packaging/debian/cvmfs/conffiles
+++ b/packaging/debian/cvmfs/conffiles
@@ -1,0 +1,1 @@
+/etc/apparmor.d/local/fusermount3

--- a/packaging/debian/cvmfs/cvmfs.install.in
+++ b/packaging/debian/cvmfs/cvmfs.install.in
@@ -24,3 +24,4 @@ etc/cvmfs/default.conf
 etc/cvmfs/default.d/README
 etc/bash_completion.d/cvmfs
 usr/lib/systemd/system/cvmfs-reload.service
+etc/apparmor.d/local/fusermount3

--- a/packaging/debian/cvmfs/cvmfs.postinst
+++ b/packaging/debian/cvmfs/cvmfs.postinst
@@ -28,6 +28,9 @@ case "$1" in
         if [ -d /run/systemd/system ]; then
           systemctl daemon-reload
           systemctl start cvmfs-reload
+          # if apparmor is installed, reload to bring updated
+          # fusermount3 profile into effect
+          systemctl reload apparmor || true
         else
           if [ -d /var/run/cvmfs ]; then
             cvmfs_config reload

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -526,6 +526,9 @@ restorecon -R /var/lib/cvmfs
 if  [ -d /run/systemd/system ]; then
   systemctl daemon-reload
   systemctl start cvmfs-reload.service
+  # if there's apparmor, reload to bring
+  # fusermount3 config into effect
+  systemctl reload apparmor || true
 else
   if [ -d /var/run/cvmfs ]; then
     /usr/bin/cvmfs_config reload
@@ -656,6 +659,7 @@ systemctl daemon-reload
 %config(noreplace) %{_sysconfdir}/bash_completion.d/cvmfs
 %doc COPYING AUTHORS README.md ChangeLog
 %{_unitdir}/cvmfs-reload.service
+%config(noreplace) %{_sysconfdir}/apparmor.d/local/fusermount3
 
 %files libs
 %defattr(-,root,root)


### PR DESCRIPTION
Newer versions of apparmor come with a fusermount3 profile that prohibits mounts outside of certain directories like /mnt. This means that `/cvmfs/*` cannot be mounted on Ubuntu 24.10 and newer.

This patch installs an extension to the apparmor profile that fixes this issue. I've tried to upstream the change: https://gitlab.com/apparmor/apparmor/-/merge_requests/1587