### PR TITLE
Fix  `ingest -d` with `:` in filename

### DIFF
--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -48,9 +48,9 @@ cvmfs_server_ingest() {
       -d | --delete )
         if [ "x$to_delete" = "x" ]
         then
-          to_delete=($2)
+          to_delete=($(echo $2 | tr -s /))
         else
-          to_delete+=($2)
+          to_delete+=($(echo $2 | tr -s /))
           multiple_delete=1
         fi
         ;;
@@ -318,7 +318,10 @@ cvmfs_server_ingest() {
   fi
 
   if [ ! x"$to_delete" = "x" ]; then
-    ingest_command="$ingest_command -D $to_delete"
+    # concatenate to_delete with three slashes
+    local to_delete2=${to_delete[@]:1}
+    local to_delete_delim=$(printf %s "${to_delete}" "${to_delete2[@]/#////}")
+    ingest_command="$ingest_command -D $to_delete_delim"
   fi
 
   if [ "$create_catalog" = true ]; then

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -318,10 +318,14 @@ cvmfs_server_ingest() {
   fi
 
   if [ ! x"$to_delete" = "x" ]; then
-    # concatenate to_delete with three slashes
-    local to_delete2=${to_delete[@]:1}
-    local to_delete_delim=$(printf %s "${to_delete}" "${to_delete2[@]/#////}")
-    ingest_command="$ingest_command -D $to_delete_delim"
+    if [ $multiple_delete -eq 1 ]; then
+      # concatenate to_delete with three slashes
+      local to_delete2=${to_delete[@]:1}
+      local to_delete_delim=$(printf %s "${to_delete}" "${to_delete2[@]/#////}")
+      ingest_command="$ingest_command -D $to_delete_delim"
+    else
+      ingest_command="$ingest_command -D ${to_delete}"
+    fi
   fi
 
   if [ "$create_catalog" = true ]; then

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -16,7 +16,7 @@
 cvmfs_server_ingest() {
   local base_dir="" # where to extract the tar file
   local tar_file=""
-  local to_delete="" # directories or file to delete before the extraction
+  local to_delete=() # directories or file to delete before the extraction
   local name="" #repository name
   local user=""
   local group=""
@@ -48,9 +48,9 @@ cvmfs_server_ingest() {
       -d | --delete )
         if [ "x$to_delete" = "x" ]
         then
-          to_delete=$2
+          to_delete=($2)
         else
-          to_delete=$to_delete:$2
+          to_delete+=($2)
           multiple_delete=1
         fi
         ;;
@@ -77,12 +77,12 @@ cvmfs_server_ingest() {
         name_from_absolute_arg=$(echo $base_dir | cut -d'/' -f3)
         base_dir=$(echo $base_dir | cut -d'/' -f 4-)
   esac
-  for to_delete_path in $(echo $to_delete | sed "s/:/ /g"); do
-    case x"$to_delete_path" in
+  for i in ${!to_delete[@]}; do
+    case x"${to_delete[$i]}" in
         x/cvmfs/*) 
           echo "Warning: interpreting the base_dir as absolute path. Remove leading slash to get a relative path to the mountpoint"
-          name_from_absolute_arg2=$(echo $to_delete_path | cut -d'/' -f3)
-          to_delete=$(echo $to_delete_path | cut -d'/' -f 4-)
+          name_from_absolute_arg2=$(echo ${to_delete[$i]} | cut -d'/' -f3)
+          to_delete[$i]=$(echo ${to_delete[$i]}  | cut -d'/' -f 4-)
           if [ ! x$name_from_absolute_arg = "x" ] ; then
             if [ ! x$name_from_absolute_arg = x$name_from_absolute_arg2 ] ; then
               die "Cannot use different repositories in same transaction: $name_from_absolute_arg2, $name_from_absolute_arg"

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -50,7 +50,7 @@ cvmfs_server_ingest() {
         then
           to_delete="$(echo $2 | tr -s /)"
         else
-          to_delete+="$to_delete///$(echo $2 | tr -s /)"
+          to_delete="$to_delete///$(echo $2 | tr -s /)"
           multiple_delete=1
         fi
         ;;

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -16,7 +16,7 @@
 cvmfs_server_ingest() {
   local base_dir="" # where to extract the tar file
   local tar_file=""
-  local to_delete=() # directories or file to delete before the extraction
+  local to_delete="" # directories or file to delete before the extraction
   local name="" #repository name
   local user=""
   local group=""
@@ -48,9 +48,9 @@ cvmfs_server_ingest() {
       -d | --delete )
         if [ "x$to_delete" = "x" ]
         then
-          to_delete=($(echo $2 | tr -s /))
+          to_delete="$(echo $2 | tr -s /)"
         else
-          to_delete+=($(echo $2 | tr -s /))
+          to_delete+="$to_delete///$(echo $2 | tr -s /)"
           multiple_delete=1
         fi
         ;;
@@ -77,12 +77,12 @@ cvmfs_server_ingest() {
         name_from_absolute_arg=$(echo $base_dir | cut -d'/' -f3)
         base_dir=$(echo $base_dir | cut -d'/' -f 4-)
   esac
-  for i in ${!to_delete[@]}; do
-    case x"${to_delete[$i]}" in
+  for to_delete_path in $(echo $to_delete | sed "s;///; ;g"); do
+    case x"$to_delete_path" in
         x/cvmfs/*) 
           echo "Warning: interpreting the base_dir as absolute path. Remove leading slash to get a relative path to the mountpoint"
-          name_from_absolute_arg2=$(echo ${to_delete[$i]} | cut -d'/' -f3)
-          to_delete[$i]=$(echo ${to_delete[$i]}  | cut -d'/' -f 4-)
+          name_from_absolute_arg2=$(echo $to_delete_path | cut -d'/' -f3)
+          to_delete=$(echo $to_delete_path  | cut -d'/' -f 4-)
           if [ ! x$name_from_absolute_arg = "x" ] ; then
             if [ ! x$name_from_absolute_arg = x$name_from_absolute_arg2 ] ; then
               die "Cannot use different repositories in same transaction: $name_from_absolute_arg2, $name_from_absolute_arg"
@@ -318,14 +318,7 @@ cvmfs_server_ingest() {
   fi
 
   if [ ! x"$to_delete" = "x" ]; then
-    if [ $multiple_delete -eq 1 ]; then
-      # concatenate to_delete with three slashes
-      local to_delete2=${to_delete[@]:1}
-      local to_delete_delim=$(printf %s "${to_delete}" "${to_delete2[@]/#////}")
-      ingest_command="$ingest_command -D $to_delete_delim"
-    else
       ingest_command="$ingest_command -D ${to_delete}"
-    fi
   fi
 
   if [ "$create_catalog" = true ]; then

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -173,7 +173,7 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
 
   publish::SyncUnion *sync = new publish::SyncUnionTarball(
     &mediator, params.dir_rdonly, params.tar_file, params.base_directory,
-    params.uid, params.gid, params.to_delete, create_catalog);
+    params.uid, params.gid, params.to_delete, create_catalog, "///");
 
   if (!sync->Initialize()) {
     LogCvmfs(kLogCvmfs, kLogStderr,

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -37,7 +37,8 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
                                    const uid_t uid,
                                    const gid_t gid,
                                    const std::string &to_delete,
-                                   const bool create_catalog_on_root)
+                                   const bool create_catalog_on_root,
+                                   const std::string &path_delimiter)
     : SyncUnion(mediator, rdonly_path, "", ""),
       src(NULL),
       tarball_path_(tarball_path),
@@ -46,6 +47,7 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
       gid_(gid),
       to_delete_(to_delete),
       create_catalog_on_root_(create_catalog_on_root),
+      path_delimiter_(path_delimiter),
       read_archive_signal_(new Signal) {}
 
 SyncUnionTarball::~SyncUnionTarball() { delete read_archive_signal_; }
@@ -110,7 +112,7 @@ void SyncUnionTarball::Traverse() {
    * As first step we eliminate the requested directories.
    */
   if (to_delete_ != "") {
-    vector<std::string> to_eliminate_vec = SplitString(to_delete_, ':');
+    vector<std::string> to_eliminate_vec = SplitStringMultiChar(to_delete_, path_delimiter_);
 
     for (vector<string>::iterator s = to_eliminate_vec.begin();
          s != to_eliminate_vec.end(); ++s) {

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -34,7 +34,8 @@ class SyncUnionTarball : public SyncUnion {
                    const uid_t uid,
                    const gid_t gid,
                    const std::string &to_delete,
-                   const bool create_catalog_on_root);
+                   const bool create_catalog_on_root,
+                   const std::string &path_delimiter=":");
 
   ~SyncUnionTarball();
 
@@ -69,6 +70,7 @@ class SyncUnionTarball : public SyncUnion {
   const gid_t gid_;
   const std::string to_delete_;  ///< entity to delete before to extract the tar
   const bool create_catalog_on_root_;
+  const std::string path_delimiter_; ///< delimiter used to split paths
   std::set<std::string>
       know_directories_;  ///< directory that we know already exist
 

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -340,6 +340,22 @@ vector<string> SplitStringBounded(
   return result;
 }
 
+vector<string> SplitStringMultiChar(const string &str, const string &delim) {
+    size_t pos_start = 0, pos_end = 0, delim_len = delim.length();
+    std::string substring;
+    std::vector<std::string> result;
+
+    while ((pos_end = str.find(delim, pos_start)) != string::npos) {
+        substring = str.substr (pos_start, pos_end - pos_start);
+        pos_start = pos_end + delim_len;
+        result.push_back(substring);
+    }
+
+    result.push_back(str.substr(pos_start));
+    return result;
+
+}
+
 string JoinStrings(const vector<string> &strings, const string &joint) {
   string result = "";
   const unsigned size = strings.size();

--- a/cvmfs/util/string.h
+++ b/cvmfs/util/string.h
@@ -52,6 +52,8 @@ CVMFS_EXPORT std::vector<std::string> SplitStringBounded(
   unsigned max_chunks, const std::string &str, char delim);
 CVMFS_EXPORT std::vector<std::string> SplitString(const std::string &str,
                                                   char delim);
+CVMFS_EXPORT std::vector<std::string> SplitStringMultiChar(const std::string &str,
+                                                  const std::string &delim);
 
 CVMFS_EXPORT std::string JoinStrings(const std::vector<std::string> &strings,
                                      const std::string &joint);

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -260,6 +260,13 @@ cvmfs_run_test() {
   cvmfs_server ingest --base_dir /cvmfs/no.such.repository/absolute_path2  --tar_file $tarfile  && return 48
   cvmfs_server ingest -d /cvmfs/$CVMFS_TEST_REPO/absolute_path1/tarball_foo/a/b/2.txt -d /cvmfs/no.such.directory/absolute_path1/tarball_foo/a/b/3.txt && return 49
 
+
+  echo "** check deletion of files with : in filename"
+  cvmfs_server transaction $CVMFS_TEST_REPO || return 50
+  echo "testwith:" > /cvmfs/$CVMFS_TEST_REPO/unlucky:filename || return 51
+  cvmfs_server publish $CVMFS_TEST_REPO || return 52
+  cvmfs_server ingest -d /cvmfs/$CVMFS_TEST_REPO/unlucky:filename || return 53
+
   return 0
 }
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -1435,6 +1435,26 @@ TEST_F(T_Util, SplitString) {
             SplitStringBounded(5000, str2, ':'));
 }
 
+TEST_F(T_Util, SplitStringMultiChar) {
+  string str1 = "the string that will be cut in pieces";
+  string str2 = "my///////string///by///colons";
+  vector<string> result;
+
+
+  result = SplitStringMultiChar(str1, " ");
+  EXPECT_EQ(8u, result.size());
+  EXPECT_EQ("the", result[0]);
+  EXPECT_EQ("string", result[1]);
+
+  result = SplitStringMultiChar(str1, ";");
+  EXPECT_EQ(1u, result.size());
+  EXPECT_EQ(str1, result[0]);
+
+  result = SplitStringMultiChar(str2, "///");
+  EXPECT_EQ(5u, result.size());
+  EXPECT_EQ("", result[1]);
+}
+
 TEST_F(T_Util, JoinStrings) {
   vector<string> result;
   result.push_back("my");


### PR DESCRIPTION
Not that it's a good idea to use `:` in filenames, but we unfortunately do this ourselves for symlinks to container images. This fixes ingest to be able to delete paths with colons in them. The new delimiter used is `///` because it's one of the few characters that's not allowed in filenames, and we can safely sanitize the pathname before joining it with the delimiter.