### PR TITLE
Fedora 41 support

### DIFF
--- a/cvmfs/crypto/signature.h
+++ b/cvmfs/crypto/signature.h
@@ -8,7 +8,6 @@
 #include <pthread.h>
 
 #include <openssl/bio.h>
-#include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -7,6 +7,7 @@
 
 #include "swissknife_lease_curl.h"
 
+#include <cstdint>
 #include <string>
 
 enum LeaseReply {

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -7,7 +7,6 @@
 
 #include "swissknife_lease_curl.h"
 
-#include <cstdint>
 #include <string>
 
 enum LeaseReply {


### PR DESCRIPTION
Trivial patches fixing issues encountered while doing `cmake -DBUILD_UNITTESTS=yes ../ && make` on Fedora 41.