### PR TITLE
shrinkwrap: ensure that directories are writeable to avoid copy errors

### DIFF
--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -391,6 +391,7 @@ bool handle_dir(
   struct cvmfs_attr *dest_st,
   const char *entry
 ) {
+  src_st->st_mode |= S_IWUSR;
   if (dest->do_mkdir(dest->context_, entry, src_st)) {
     if (errno == EEXIST) {
       errno = 0;


### PR DESCRIPTION
When using shrinkwrap without sudo, it will fail to shrinkwrap files in directories without write permissions:

```
cvmfs_shrinkwrap -r software.eessi.io   -f software.eessi.io.config   -t software.eessi.io.spec   --dest-base ~/cvmfs-shrinkwrap-output   -j 4
LibCvmfs version 2.12, revision 31
(libcvmfs) (manager 'standard') switching proxy from (none) to DIRECT. Reason: set random start proxy from the first proxy group [Current host: https://aws-eu-west-s1-sync.eessi.science/cvmfs/software.eessi.io]
(libcvmfs) (manager 'external') switching proxy from (none) to DIRECT. Reason: cloned [Current host: https://aws-eu-west-s1-sync.eessi.science/cvmfs/software.eessi.io]
(libcvmfs) (manager 'standard' - id 0) invalid SSL certificate of remote host. X509_CERT_DIR and/or X509_CERT_BUNDLE might point to the wrong location.
(libcvmfs) (manager 'standard' - id 0) invalid SSL certificate of remote host. X509_CERT_DIR and/or X509_CERT_BUNDLE might point to the wrong location.
(libcvmfs) failed to download repository manifest (7 - host connection problem)
(libcvmfs) Starting 4 workers
(libcvmfs) cntByte|0|Byte count of projected repository
cntDir|1|Number of directories from source repository
cntFile|0|Number of files from source repository
cntSymlink|0|Number of symlinks from source repository
dataBytes|0|Bytes transferred from source to destination
dataBytesDeduped|0|Number of bytes not copied due to deduplication
dataFiles|0|Number of data files transferred from source to destination
dataFilesDeduped|0|Number of files not copied due to deduplication
entriesDest|1|Number of file system entries processed in the destination
entriesSrc|1|Number of file system entries processed in the source

(libcvmfs) Failed to create link : /home/hvela/cvmfs-shrinkwrap-output/.data/e8/ec/3d88b62ebf526e4e5a4ff6162a3aa48a6b78.713e9bb163f52062c01fa6a5d36c8e06->/home/hvela/cvmfs-shrinkwrap-output/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/skylake_avx512/software/zstd/1.5.5-GCCcore-13.2.0/.cvmfscatalog : 13 : Permission denied

(libcvmfs) Failed to link /versions/2023.06/software/linux/x86_64/intel/skylake_avx512/software/zstd/1.5.5-GCCcore-13.2.0/.cvmfscatalog->/e8/ec/3d88b62ebf526e4e5a4ff6162a3aa48a6b78.713e9bb163f52062c01fa6a5d36c8e06 : 13 : Permission denied
(libcvmfs) File /versions/2023.06/software/linux/x86_64/intel/skylake_avx512/software/zstd/1.5.5-GCCcore-13.2.0 failed to copy
```

This is a hotfix that ensures that shrinkwrapped directories are writeable. This means that the shrinkwrapped content is different - if the directory permissions should be exactly preserved, shrinkwrap needs to do a second pass to set directory permissions.