### PR TITLE
ducc: add log level cli and trace http get requests

### DIFF
--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -140,7 +140,7 @@ if can_build_gateway; then
   echo "*** Running gateway unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway)"
   pushd ${SCRIPT_LOCATION}/../gateway > /dev/null
   CVMFS_TEST_GATEWAY_OUTPUT=$(mktemp /tmp/cvmfs-gateway-unittests-XXXXX)
-  ${SCRIPT_LOCATION}/../externals_install/bin/go test -v -mod=vendor ./... > $CVMFS_TEST_GATEWAY_OUTPUT 2>&1
+  go test -v -mod=vendor ./... > $CVMFS_TEST_GATEWAY_OUTPUT 2>&1
   RETVAL=$(( RETVAL | $? ))
   cat $CVMFS_TEST_GATEWAY_OUTPUT | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway
   rm -f $CVMFS_TEST_GATEWAY_OUTPUT
@@ -153,7 +153,7 @@ if can_build_ducc; then
   echo "*** Running container tools unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc)"
   pushd ${SCRIPT_LOCATION}/../ducc > /dev/null
   CVMFS_TEST_DUCC_OUTPUT=$(mktemp /tmp/cvmfs-ducc-unittests-XXXXX)
-  ${SCRIPT_LOCATION}/../externals_install/bin/go test -v -mod=vendor ./... > $CVMFS_TEST_DUCC_OUTPUT 2>&1
+  go test -v -mod=vendor ./... > $CVMFS_TEST_DUCC_OUTPUT 2>&1
   RETVAL=$(( RETVAL | $? ))
   cat $CVMFS_TEST_DUCC_OUTPUT | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc
   rm -f $CVMFS_TEST_DUCC_OUTPUT

--- a/ducc/go.mod
+++ b/ducc/go.mod
@@ -1,6 +1,7 @@
 module github.com/cvmfs/ducc
 
 require (
+	github.com/aoliveti/curling v1.1.0
 	github.com/docker/docker v0.0.0-20190123164140-de86ba27fbea
 	github.com/google/uuid v1.2.0
 	github.com/olekukonko/tablewriter v0.0.1
@@ -23,7 +24,6 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/ducc/go.sum
+++ b/ducc/go.sum
@@ -5,6 +5,8 @@ github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/aoliveti/curling v1.1.0 h1:/1k05HmPUEGYXNHo3aX5BWRJWvWQbiU0A7n9ugqhdLY=
+github.com/aoliveti/curling v1.1.0/go.mod h1:xoDmoUg9vX3pMTltyG/rp9tFtIlweL2QeCJVnvyAvzw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -24,8 +26,8 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
-github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aoliveti/curling"
 	"github.com/docker/docker/image"
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
@@ -1074,6 +1075,15 @@ func makeGetRequest(url string, headers map[string]string) ([]byte, error) {
 	req.Header.Set("Authorization", token)
 	for k, v := range headers {
 		req.Header.Set(k, v)
+	}
+
+	// for debugging: log curl command corresponding to request
+	if log.IsLevelEnabled(log.TraceLevel) {
+		curlcmd, err := curling.NewFromRequest(req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Trace(curlcmd)
 	}
 
 	resp, err := client.Do(req)

--- a/ducc/vendor/github.com/aoliveti/curling/.gitignore
+++ b/ducc/vendor/github.com/aoliveti/curling/.gitignore
@@ -1,0 +1,24 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+# Go workspace file
+go.work
+
+# GoLand settings
+.idea/

--- a/ducc/vendor/github.com/aoliveti/curling/LICENSE
+++ b/ducc/vendor/github.com/aoliveti/curling/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Andrea Oliveti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ducc/vendor/github.com/aoliveti/curling/README.md
+++ b/ducc/vendor/github.com/aoliveti/curling/README.md
@@ -1,0 +1,79 @@
+# curling
+
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/aoliveti/curling)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/aoliveti/curling/go.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aoliveti/curling)](https://pkg.go.dev/github.com/aoliveti/curling)
+[![codecov](https://codecov.io/gh/aoliveti/curling/graph/badge.svg?token=3L9FOZMEJH)](https://codecov.io/gh/aoliveti/curling)
+[![Go Report Card](https://goreportcard.com/badge/github.com/aoliveti/curling)](https://goreportcard.com/report/github.com/aoliveti/curling)
+![GitHub License](https://img.shields.io/github/license/aoliveti/curling)
+
+Curling is a Go library that converts [http.Request](https://pkg.go.dev/net/http#Request) objects
+into [cURL](https://curl.se/) commands
+
+## Install
+
+```sh
+go get -u github.com/aoliveti/curling
+```
+
+## Usage
+
+The following Go code demonstrates how to create a command from an HTTP request object:
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/aoliveti/curling"
+)
+
+func main() {
+	req, err := http.NewRequest(http.MethodGet, "https://www.google.com", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Add("If-None-Match", "foo")
+
+	cmd, err := curling.NewFromRequest(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(cmd)
+}
+```
+
+```sh
+curl -X 'GET' 'https://www.google.com' -H 'If-None-Match: foo'
+```
+
+### Options
+
+```go
+func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
+    ...
+}
+```
+
+When creating a new command, you can provide these options:
+
+| Option                          | Description                                       |
+|---------------------------------|---------------------------------------------------|
+| WithLongForm()                  | Enables the long form for cURL options            |
+| WithFollowRedirects()           | Sets the flag -L, --location                      |
+| WithInsecure()                  | Sets the flag -k, --insecure                      |
+| WithSilent()                    | Sets the flag -s, --silent                        |
+| WithCompressed()                | Sets the flag --compressed                        |
+| WithMultiLine()                 | Generates a multiline snippet for unix-like shell |
+| WithWindowsMultiLine()          | Generates a multiline snippet for Windows shell   |
+| WithPowerShellMultiLine()       | Generates a multiline snippet for PowerShell      |
+| WithDoubleQuotes()              | Uses double quotes to escape characters           |
+| WithRequestTimeout(seconds int) | Sets the flag -m, --max-time                      |
+
+## License
+
+The library is released under the MIT license. See [LICENSE](LICENSE) file.

--- a/ducc/vendor/github.com/aoliveti/curling/command.go
+++ b/ducc/vendor/github.com/aoliveti/curling/command.go
@@ -1,0 +1,207 @@
+package curling
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// A Command represents a cURL command based on an HTTP request.
+//
+// Returned by [NewFromRequest], a Command expects a pointer to [http.Request] as input.
+// It generates a cURL command string, which by default uses a single line command,
+// short form options, and single quote escaping.
+type Command struct {
+	// tokens is a set of lines that form the command.
+	tokens []string
+
+	// lineContinuation is the character used to break a single statement into multiple lines.
+	lineContinuation string
+
+	// location enables the option -L, --location.
+	location bool
+
+	// compressed enables the option --compressed.
+	compressed bool
+
+	// insecure enables the option -k, --insecure.
+	insecure bool
+
+	// useLongForm enables the long form for cURL options (example: --header instead of -H).
+	useLongForm bool
+
+	// useMultiLine splits the command across multiple lines.
+	useMultiLine bool
+
+	// silent enables the option -s, --silent.
+	silent bool
+
+	// useDoubleQuotes enables escaping using double quotes.
+	useDoubleQuotes bool
+
+	// requestTimeout enables the option -m, --max-time.
+	requestTimeout int
+}
+
+// NewFromRequest returns a new [Command] that reads from r.
+// If the request has an invalid URL, NewFromRequest returns an error.
+// If NewFromRequest can't read the request body, it returns an error.
+func NewFromRequest(r *http.Request, opts ...Option) (*Command, error) {
+	var c Command
+
+	if err := c.build(r, opts...); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+// String returns the cURL command.
+func (c *Command) String() string {
+	separator := " "
+	if c.useMultiLine {
+		separator = fmt.Sprintf(" %s\n", c.lineContinuation)
+	}
+
+	s := strings.Join(c.tokens, separator)
+	return strings.TrimSpace(s)
+}
+
+// appendToken appends a new token into tokens.
+func (c *Command) appendToken(s ...string) {
+	token := strings.Join(s, " ")
+	c.tokens = append(c.tokens, token)
+}
+
+// optionForm returns either the short or long form based on the useLongForm flag.
+func (c *Command) optionForm(short, long string) string {
+	if c.useLongForm {
+		return long
+	}
+
+	return short
+}
+
+// escape takes a string as input and escapes it with single or double quotes based
+// on the useDoubleQuotes option.
+func (c *Command) escape(s string) string {
+	if c.useDoubleQuotes {
+		v := strings.ReplaceAll(s, "\"", "\\\"")
+		return fmt.Sprintf("\"%s\"", v)
+	}
+
+	v := strings.ReplaceAll(s, "'", "'\\''")
+	return fmt.Sprintf("'%s'", v)
+}
+
+// build produces tokens based on the supplied options and http request.
+// If the request URL is nil, build returns an error.
+// If build can't read the request body, it returns an error.
+func (c *Command) build(r *http.Request, opts ...Option) error {
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	if r.URL == nil {
+		return fmt.Errorf("request url is nil")
+	}
+
+	c.buildCommand(r)
+	c.buildHeaders(r)
+
+	if err := c.buildData(r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// buildCommand produces the token representing the curl command and its related options.
+func (c *Command) buildCommand(r *http.Request) {
+	s := []string{"curl"}
+
+	if c.silent {
+		s = append(s, c.optionForm("-s", "--silent"))
+	}
+
+	if c.requestTimeout > 0 {
+		s = append(s, c.optionForm("-m", "--max-time"), strconv.Itoa(c.requestTimeout))
+	}
+
+	if c.insecure {
+		s = append(s, c.optionForm("-k", "--insecure"))
+	}
+
+	if c.compressed {
+		s = append(s, "--compressed")
+	}
+
+	if c.location {
+		s = append(s, c.optionForm("-L", "--location"))
+	}
+
+	var command string
+	if len(s) > 0 {
+		command = strings.Join(s, " ")
+	}
+
+	method := r.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	c.appendToken(
+		command,
+		c.optionForm("-X", "--request"),
+		c.escape(method),
+		c.escape(r.URL.String()),
+	)
+}
+
+// buildHeaders produces one token for each request header.
+func (c *Command) buildHeaders(r *http.Request) {
+	if len(r.Header) == 0 {
+		return
+	}
+
+	var headers []string
+	for key, values := range r.Header {
+		canonicalKey := http.CanonicalHeaderKey(key)
+		headers = append(headers, fmt.Sprintf("%s: %s", canonicalKey, strings.Join(values, ", ")))
+	}
+
+	slices.Sort(headers)
+
+	for _, header := range headers {
+		c.appendToken(
+			c.optionForm("-H", "--header"),
+			c.escape(header),
+		)
+	}
+}
+
+// buildData produces the token representing the request body and its related option (-d or --data).
+// If the request body is nil or [http.NoBody], no token is produced.
+// If buildData can't read the request body, it returns an error.
+func (c *Command) buildData(r *http.Request) error {
+	if r.Body == nil || r.Body == http.NoBody {
+		return nil
+	}
+
+	var b bytes.Buffer
+	if _, err := b.ReadFrom(r.Body); err != nil {
+		return fmt.Errorf("reading bytes from request body: %w", err)
+	}
+
+	// Reset request body for potential re-reads
+	r.Body = io.NopCloser(bytes.NewBuffer(b.Bytes()))
+
+	option := c.optionForm("-d", "--data")
+	c.appendToken(option, c.escape(b.String()))
+
+	return nil
+}

--- a/ducc/vendor/github.com/aoliveti/curling/option.go
+++ b/ducc/vendor/github.com/aoliveti/curling/option.go
@@ -1,0 +1,93 @@
+package curling
+
+const (
+	lineContinuationDefault    = "\\"
+	lineContinuationWindows    = "^"
+	lineContinuationPowerShell = "`"
+)
+
+type Option func(curling *Command)
+
+// WithFollowRedirects enables the option -L, --location.
+func WithFollowRedirects() Option {
+	return func(curling *Command) {
+		curling.location = true
+	}
+}
+
+// WithCompression enables the option --compressed.
+func WithCompression() Option {
+	return func(curling *Command) {
+		curling.compressed = true
+	}
+}
+
+// WithInsecure enables the option -k, --insecure.
+func WithInsecure() Option {
+	return func(curling *Command) {
+		curling.insecure = true
+	}
+}
+
+// WithLongForm enables the long form for cURL options.
+// Example: --header instead of -H.
+func WithLongForm() Option {
+	return func(curling *Command) {
+		curling.useLongForm = true
+	}
+}
+
+// WithSilent enables the option -s, --silent.
+func WithSilent() Option {
+	return func(curling *Command) {
+		curling.silent = true
+	}
+}
+
+// WithMultiLine splits the command across multiple lines.
+// The default line continuation character is backslash.
+func WithMultiLine() Option {
+	return func(curling *Command) {
+		curling.useMultiLine = true
+		curling.lineContinuation = lineContinuationDefault
+	}
+}
+
+// WithWindowsMultiLine splits the command across multiple lines.
+// The line continuation character is caret.
+func WithWindowsMultiLine() Option {
+	return func(curling *Command) {
+		curling.useMultiLine = true
+		curling.lineContinuation = lineContinuationWindows
+	}
+}
+
+// WithPowerShellMultiLine splits the command across multiple lines.
+// The line continuation character is backtick.
+func WithPowerShellMultiLine() Option {
+	return func(curling *Command) {
+		curling.useMultiLine = true
+		curling.lineContinuation = lineContinuationPowerShell
+	}
+}
+
+// WithDoubleQuotes enables escaping using double quotes.
+func WithDoubleQuotes() Option {
+	return func(curling *Command) {
+		curling.useDoubleQuotes = true
+	}
+}
+
+// WithRequestTimeout enables the option -m, --max-time.
+// It sets the number of seconds the request should wait
+// for a response before timing out.
+// Negative value seconds will be silently ignored.
+func WithRequestTimeout(seconds int) Option {
+	return func(curling *Command) {
+		if seconds < 0 {
+			seconds = 0
+		}
+
+		curling.requestTimeout = seconds
+	}
+}

--- a/ducc/vendor/modules.txt
+++ b/ducc/vendor/modules.txt
@@ -5,6 +5,9 @@
 github.com/Microsoft/go-winio
 # github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
 ## explicit
+# github.com/aoliveti/curling v1.1.0
+## explicit; go 1.21
+github.com/aoliveti/curling
 # github.com/containerd/continuity v0.0.0-20181203112020-004b46473808
 ## explicit
 github.com/containerd/continuity/devices
@@ -74,8 +77,8 @@ github.com/docker/go-units
 # github.com/gogo/protobuf v1.3.2
 ## explicit; go 1.15
 github.com/gogo/protobuf/proto
-# github.com/google/go-cmp v0.2.0
-## explicit
+# github.com/google/go-cmp v0.6.0
+## explicit; go 1.13
 # github.com/google/uuid v1.2.0
 ## explicit
 github.com/google/uuid


### PR DESCRIPTION
With `-v trace`, adds lines like 
```
TRAC[0001] curl -X 'GET' 'https://registry.hub.docker.com/v2/library/almalinux/manifests/sha256:324d32eb1e86cc42722f7b9a956c6c33478c32d0842cafa1acc1ff459f6891fc' -H 'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json ...
```
with curl commands corresponding to requests, which is very useful for debugging.