### PR TITLE
ducc: start testing and mocking cvmfs bindings

### DIFF
--- a/ducc/cmd/root.go
+++ b/ducc/cmd/root.go
@@ -56,6 +56,9 @@ func AliveMessage() {
 func setUpLogs(out io.Writer, level string) error {
 	logrus.SetOutput(out)
 	lvl, err := logrus.ParseLevel(level)
+	if lvl == logrus.TraceLevel {
+		logrus.SetReportCaller(true)
+	}
 	if err != nil {
 		return err
 	}

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+echo "WARNING: This is a mock command for testing of ducc that does noops and simple copies on a normal folder"
+
+# Since /cvmfs + reponame  and /var/spool/cvmfs is hardcoded,
+# CVMFS_TEST_REPO is expected to look like ../../../tmp/testrepofolder
+
+
+if [ "$1" == "list" ]; then
+  echo "testunpacked.cern.ch"
+  echo "..$CVMFS_TEST_REPO"
+fi
+
+# Template transaction (cvmfs_server transaction -T /from:/to)
+# just do a copy
+if [ "$1" == "transaction" ]; then
+  arg2=$(echo $@ | cut -d ' ' -f 2)
+  if [ "$arg2" == "-T" ]; then
+    arg3=$(echo $@ | cut -d ' ' -f 3)
+    from=$(echo $arg3 | cut -d '=' -f 1)
+    to=$(echo $arg3 | cut -d '=' -f 2)
+    echo "template transaction from $CVMFS_TEST_REPO/$from to $CVMFS_TEST_REPO/$to" 
+    mkdir -p $CVMFS_TEST_REPO/$to
+    cp -r $CVMFS_TEST_REPO/$from/* $CVMFS_TEST_REPO/$to
+  fi
+fi
+
+# cvmfs_server publish
+# needs to support sneaky transactions
+# just apply changes
+# the upperdir would usually be in /var/spool/cvmfs
+# We leave it in CVMFS_TEST_REPO for convenience   
+if [ "$1" == "publish" ]; then
+  # needs sudo to work for opaque directories
+  mockcvmfs_overlay_helper.sh $CVMFS_TEST_REPO/scratch/current $CVMFS_TEST_REPO
+fi
+
+# cvmfs_server ingest --delete
+# just rm
+if [ "$1" == "ingest" ]; then
+  arg2=$(echo $@ | cut -d ' ' -f 2)
+  if [ "$arg2" == "--delete" ]; then
+    echo "deleting /$CVMFS_TEST_REPO/$3"
+    rm -rf /$CVMFS_TEST_REPO/$3
+  fi
+fi
+
+# cvmfs_server ingest --catalog -t - -b <dir>
+arg2=$(echo $@ | cut -d ' ' -f 2)
+arg3=$(echo $@ | cut -d ' ' -f 3)
+arg4=$(echo $@ | cut -d ' ' -f 4)
+arg5=$(echo $@ | cut -d ' ' -f 5)
+if [ "$1" == "ingest" ]; then
+  if [ "$arg2" == "--catalog" ]; then
+    if [ "$arg3" == "-t" ]; then
+      if [ "$arg4" == "-" ]; then
+        if [ "$arg5" == "-b" ]; then
+          mkdir -p /$CVMFS_TEST_REPO/$6
+          cat - > /tmp/tmptar.tar
+          tar xf /tmp/tmptar.tar -C /$CVMFS_TEST_REPO/$6
+        fi
+      fi
+    fi
+  fi
+fi

--- a/ducc/cvmfs/.mockcvmfs/mockcvmfs_overlay_helper.sh
+++ b/ducc/cvmfs/.mockcvmfs/mockcvmfs_overlay_helper.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Usage: ./apply_overlay.sh <upperdir> <destination>
+# This script applies changes from an overlayfs upperdir to a destination folder
+# Handles native overlayfs whiteouts (character devices) and opaque directories (xattr)
+
+set -e
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <upperdir> <destination>"
+    exit 1
+fi
+
+UPPERDIR="$1"
+DESTDIR="$2"
+
+if [ ! -d "$UPPERDIR" ]; then
+    echo "Error: Upperdir '$UPPERDIR' does not exist or is not a directory"
+    exit 1
+fi
+
+if [ ! -d "$DESTDIR" ]; then
+    echo "Error: Destination directory '$DESTDIR' does not exist or is not a directory"
+    exit 1
+fi
+
+# Function to check if a file is a whiteout
+is_whiteout() {
+    local file="$1"
+    # Check if it's a character device with 0:0 device numbers
+    if [ -c "$file" ]; then
+        local devnum=$(stat -c '%t:%T' "$file")
+        if [ "$devnum" = "0:0" ]; then
+            return 0  # True, it is a whiteout
+        fi
+    fi
+    return 1  # False, not a whiteout
+}
+
+# Function to check if a directory is opaque
+is_opaque_dir() {
+    local dir="$1"
+    if [ -d "$dir" ]; then
+        # Check for trusted.overlay.opaque xattr
+        if getfattr -n trusted.overlay.opaque --only-values "$dir" 2>/dev/null | grep -q "y"; then
+            return 0  # True, it is opaque
+        fi
+    fi
+    return 1  # False, not opaque
+}
+
+# Function to process a directory
+process_directory() {
+    local upper_path="$1"
+    local dest_path="$2"
+    local rel_path="$3"
+
+    # Create destination directory if it doesn't exist
+    mkdir -p "$dest_path"
+
+    # Check if directory is opaque
+    if is_opaque_dir "$upper_path"; then
+        echo "Found opaque directory: $rel_path"
+        # Remove all files in destination that aren't in upperdir
+        find "$dest_path" -mindepth 1 -maxdepth 1 | while read item; do
+            base_name=$(basename "$item")
+            if [ ! -e "$upper_path/$base_name" ]; then
+                echo "  Removing $rel_path/$base_name (due to opaque dir)"
+                rm -rf "$item"
+            fi
+        done
+    fi
+
+    # Process all entries in the upperdir
+    find "$upper_path" -mindepth 1 -maxdepth 1 | while read item; do
+        base_name=$(basename "$item")
+
+        # Handle whiteouts
+        if is_whiteout "$item"; then
+            echo "Found whiteout: $rel_path/$base_name"
+
+            # Remove the corresponding file or directory in destination
+            if [ -e "$dest_path/$base_name" ]; then
+                echo "  Removing $rel_path/$base_name"
+                rm -rf "$dest_path/$base_name"
+            fi
+            continue
+        fi
+
+        # Handle regular files and directories
+        if [ -d "$item" ] && [ ! -L "$item" ]; then
+            # Recursively process subdirectories
+            process_directory "$item" "$dest_path/$base_name" "$rel_path/$base_name"
+        else
+            # Copy file (or symlink)
+            echo "Copying $rel_path/$base_name"
+            cp -a "$item" "$dest_path/$base_name"
+        fi
+    done
+}
+
+# Start processing from the root
+process_directory "$UPPERDIR" "$DESTDIR" ""
+
+echo "Overlay changes have been applied successfully"
+

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -698,10 +698,12 @@ func CreateSneakyChain(CVMFSRepo, newChainId, previousChainId string, layer tar.
 				return err
 			}
       // TODO(vavolkl): do we need to chown?
-			//if err := os.Chown(path, header.Uid, header.Gid); err != nil {
-			//	l.LogE(err).Error("Error in chown")
-			//	return err
-			//}
+      if os.Getenv("CVMFS_DUCC_NO_CHOWN") == "" {
+			if err := os.Chown(path, header.Uid, header.Gid); err != nil {
+				l.LogE(err).Error("Error in chown")
+				return err
+			}
+      }
 			if err := os.Chtimes(path, header.AccessTime, header.ModTime); err != nil {
 				l.LogE(err).Error("Error in chtimes")
 				return err

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -697,10 +697,11 @@ func CreateSneakyChain(CVMFSRepo, newChainId, previousChainId string, layer tar.
 				l.LogE(err).Error("Error in chmod")
 				return err
 			}
-			if err := os.Chown(path, header.Uid, header.Gid); err != nil {
-				l.LogE(err).Error("Error in chown")
-				return err
-			}
+      // TODO(vavolkl): do we need to chown?
+			//if err := os.Chown(path, header.Uid, header.Gid); err != nil {
+			//	l.LogE(err).Error("Error in chown")
+			//	return err
+			//}
 			if err := os.Chtimes(path, header.AccessTime, header.ModTime); err != nil {
 				l.LogE(err).Error("Error in chtimes")
 				return err

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -697,13 +697,13 @@ func CreateSneakyChain(CVMFSRepo, newChainId, previousChainId string, layer tar.
 				l.LogE(err).Error("Error in chmod")
 				return err
 			}
-      // TODO(vavolkl): do we need to chown?
-      if os.Getenv("CVMFS_DUCC_NO_CHOWN") == "" {
-			if err := os.Chown(path, header.Uid, header.Gid); err != nil {
-				l.LogE(err).Error("Error in chown")
-				return err
+			// TODO(vavolkl): do we need to chown?
+			if os.Getenv("CVMFS_DUCC_NO_CHOWN") == "" {
+				if err := os.Chown(path, header.Uid, header.Gid); err != nil {
+					l.LogE(err).Error("Error in chown")
+					return err
+				}
 			}
-      }
 			if err := os.Chtimes(path, header.AccessTime, header.ModTime); err != nil {
 				l.LogE(err).Error("Error in chtimes")
 				return err

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -1,0 +1,70 @@
+package cvmfs
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// For these tests, use a mocked cvmfs_server command that does nothing, just lets
+// us copy or extract files to a normal directory
+// That makes unittests more lightweight and does not require a cvmfs installation
+// could go as well into init
+func TestMain(m *testing.M) {
+	// Setup
+	wd, _ := os.Getwd()
+	os.Setenv("PATH", wd+"/.mockcvmfs/:"+os.Getenv("PATH"))
+	mockrepo, _ := os.MkdirTemp("", "DuccMockRepo")
+	os.MkdirAll(filepath.Join(mockrepo, "scratch", "current"), os.ModePerm)
+	os.Setenv("CVMFS_TEST_REPO", "/../../../../"+mockrepo)
+	// Test
+	code := m.Run()
+	// Teardown
+	os.Exit(code)
+}
+
+// Check that we are indeed using the mocked cvmfs_server
+func TestMockCommand(t *testing.T) {
+	out, err := exec.Command("cvmfs_server").Output()
+	if err != nil {
+		t.Fatal(err)
+	} else if !strings.HasPrefix(string(out), "WARNING") {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishToCVMFS(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	t.Log("Mockrepo:", mockrepo)
+
+	// test publish file
+	f, _ := os.CreateTemp("", "PublishTestFile")
+	t.Log("Testfile:", f.Name())
+	testfile1Content := []byte("testfile1content")
+	f.Write(testfile1Content)
+	PublishToCVMFS(".."+mockrepo, "testfile1", f.Name())
+	testfile1Readback, err := os.ReadFile(mockrepo + "/testfile1")
+	if err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(testfile1Readback, testfile1Content) {
+		t.Fatal("Published file on CVMFS differs!")
+	}
+
+	// test publish dir
+	d, _ := os.MkdirTemp("", "PublishTestDir")
+	t.Log(d)
+	f2, _ := os.CreateTemp(d, "PublishTestFile2")
+	t.Log("Testfile2:", f2.Name())
+	testfile2Content := []byte("testfile2content")
+	f2.Write(testfile2Content)
+	PublishToCVMFS(".."+mockrepo, "subdir2", d)
+	testfile2Readback, err := os.ReadFile(filepath.Join(mockrepo, "subdir2", filepath.Base(f2.Name())))
+	if err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(testfile2Readback, testfile2Content) {
+		t.Fatal("Published file on CVMFS differs!")
+	}
+}

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -20,6 +20,7 @@ func TestMain(m *testing.M) {
 	mockrepo, _ := os.MkdirTemp("", "DuccMockRepo")
 	os.MkdirAll(filepath.Join(mockrepo, "scratch", "current"), os.ModePerm)
 	os.Setenv("CVMFS_TEST_REPO", "/../../../../"+mockrepo)
+	os.Setenv("CVMFS_DUCC_NO_CHOWN", "nochown")
 	// Test
 	code := m.Run()
 	// Teardown


### PR DESCRIPTION
This was a bit of a rabbithole, but ultimately very useful: In order to be able to unittest the unpacker, I wanted to be able to unpack to a normal directory (outside of cvmfs). Since the unpacker calls out to cvmfs_server, this can be achieved by mocking cvmfs_server to do nothing in a normal transaction, and a copy in a template transaction. The sneaky chains made this a bit more complicated, especially since I want to change that way of doing things.

There is a bit of specific setup for the tests to work, which can be found in cvmfs_test.go. As the unpacker gets cleaned up, this will no longer be needed, but adds some test coverage for the rewrite.