### PR TITLE
Decorate cvmfs_config killall with extra options -r(reset fuse) / -s(stuck fuse reset)

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -99,6 +99,8 @@ var_list="$parm_list $switch_list"
 
 cvmfs_fs_bundle="/Library/Filesystems/cvmfs.fs/Contents/Resources" # Mac OS X
 
+PROCNAME=cvmfs2
+MOUNTPOINT=/cvmfs
 IS_KILLALL_STUCK=FALSE
 IS_KILLALL_FORCE=FALSE
 
@@ -106,7 +108,11 @@ IS_KILLALL_FORCE=FALSE
 # -f(orce): abort all cvmfs associated fuse devices
 # -s(tuck): abort all cvmfs associated fuse devices in waiting state
 parse_killall_opts(){
-  while [[ "${1:-}" == -* ]]; do
+  for arg in "$@"; do
+    [[ "$arg" == "killall"  ]] && shift && break
+    shift
+  done
+  while [[ $# -gt 0  ]]; do
     case "$1" in
       "-f")
         IS_KILLALL_FORCE=true
@@ -119,9 +125,9 @@ parse_killall_opts(){
         ;;
       *)
         echo "Ignoring unknown option $1"
+        break
         ;;
     esac
-    [ $# -gt 0 ] || break
     shift
   done
 }
@@ -157,7 +163,7 @@ get_cvmfs_devices()
       device_id=$(echo "$line" | cut -d' ' -f 3)
       current_mountpoint=$(echo "$line" | cut -d' ' -f 5)
 
-      if [[ "$current_mountpoint" == "$MOUNTPOINT"/*  ]]; then
+      if [[ "$current_mountpoint" == "$MOUNTPOINT/"*  ]]; then
         if ! grep -q "$device_id" <<< "$cvmfs_devices"; then
           cvmfs_devices=$cvmfs_devices" $device_id"
         fi
@@ -165,6 +171,27 @@ get_cvmfs_devices()
     done < /proc/$pid/mountinfo
   done
   echo $cvmfs_devices
+}
+
+get_devices_map()
+{
+  local devices_map=""
+  for pid in $(pidof "$PROCNAME")
+  do
+    while read -r line; do
+      # Get the interesting fields from every line of mountinfo;
+      # those are the mountpoint and the device id
+      device_id=$(echo "$line" | cut -d' ' -f 3)
+      current_mountpoint=$(echo "$line" | cut -d' ' -f 5)
+
+      if [[ "$current_mountpoint" == "$MOUNTPOINT/"*  ]]; then
+        if ! grep -q "$device_id" <<< "$devices_map"; then
+          devices_map="$current_mountpoint>$device_id "$devices_map
+        fi
+      fi
+    done < /proc/$pid/mountinfo
+  done
+  echo $devices_map
 }
 
 abort_all_devices()
@@ -180,14 +207,18 @@ abort_all_devices()
 abort_stuck_devices()
 {
   echo "Aborting stuck cvmfs fuse devices.."
-  local devices="$@"
-  for device in $devices
+  local device_map="$@"
+  for map_entry in $device_map
   do
+    local mountpoint=$(echo $map_entry | cut -d'>' -f 1)
+    local device=$(echo $map_entry | cut -d'>' -f 2)
+
     fuse_dev=$(get_minor_device_id $device)
     local fuse_dev_path="/sys/fs/fuse/connections/$fuse_dev"
     # Abort waiting devices only
     if [ "$(cat $fuse_dev_path/waiting)" != "0" ] ;
     then
+      echo "Aborting $mountpoint"
       abort_fuse_device $fuse_dev
     fi
   done
@@ -1482,11 +1513,14 @@ cvmfs_killall() {
   local pid=$$
 
   parse_killall_opts "$@"
-  local cvmfs_devices=$(get_cvmfs_devices)
+
+
   if [ ${IS_KILLALL_FORCE} = true ] ; then
+    local cvmfs_devices=$(get_cvmfs_devices)
     abort_all_devices $cvmfs_devices
   elif [ ${IS_KILLALL_STUCK} = true ] ; then
-    abort_stuck_devices $cvmfs_devices
+    local devices_map=$(get_devices_map)
+    abort_stuck_devices  $devices_map
   fi
 
   echo -n "Terminating cvmfs_config processes... "

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -99,11 +99,6 @@ var_list="$parm_list $switch_list"
 
 cvmfs_fs_bundle="/Library/Filesystems/cvmfs.fs/Contents/Resources" # Mac OS X
 
-PROCNAME=cvmfs2
-MOUNTPOINT=/cvmfs
-IS_KILLALL_STUCK=FALSE
-IS_KILLALL_FORCE=FALSE
-
 # Check if killall has extra arguments
 # -f(orce): abort all cvmfs associated fuse devices
 # -s(tuck): abort all cvmfs associated fuse devices in waiting state
@@ -114,11 +109,11 @@ parse_killall_opts(){
   done
   while [[ $# -gt 0  ]]; do
     case "$1" in
-      "-f")
-        IS_KILLALL_FORCE=true
+      "-r")
+        abort_all_devices $(get_cvmfs_devices)
         ;;
       "-s")
-        IS_KILLALL_STUCK=true
+        abort_stuck_devices $(get_devices_map)
         ;;
       "--help")
         cvmfs_config_usage
@@ -155,7 +150,7 @@ abort_fuse_device(){
 get_cvmfs_devices()
 {
   local cvmfs_devices=""
-  for pid in $(pidof "$PROCNAME")
+  for pid in $(pidof cvmfs2)
   do
     while read -r line; do
       # Get the interesting fields from every line of mountinfo;
@@ -163,7 +158,7 @@ get_cvmfs_devices()
       device_id=$(echo "$line" | cut -d' ' -f 3)
       current_mountpoint=$(echo "$line" | cut -d' ' -f 5)
 
-      if [[ "$current_mountpoint" == "$MOUNTPOINT/"*  ]]; then
+      if [[ "$current_mountpoint" == "/cvmfs/"*  ]]; then
         if ! grep -q "$device_id" <<< "$cvmfs_devices"; then
           cvmfs_devices=$cvmfs_devices" $device_id"
         fi
@@ -176,7 +171,7 @@ get_cvmfs_devices()
 get_devices_map()
 {
   local devices_map=""
-  for pid in $(pidof "$PROCNAME")
+  for pid in $(pidof cvmfs2)
   do
     while read -r line; do
       # Get the interesting fields from every line of mountinfo;
@@ -184,7 +179,7 @@ get_devices_map()
       device_id=$(echo "$line" | cut -d' ' -f 3)
       current_mountpoint=$(echo "$line" | cut -d' ' -f 5)
 
-      if [[ "$current_mountpoint" == "$MOUNTPOINT/"*  ]]; then
+      if [[ "$current_mountpoint" == "/cvmfs/"*  ]]; then
         if ! grep -q "$device_id" <<< "$devices_map"; then
           devices_map="$current_mountpoint>$device_id "$devices_map
         fi
@@ -275,7 +270,7 @@ cvmfs_config_usage() {
   echo "  reload [-c | <repository>]"
   echo "  umount"
   echo "  wipecache"
-  echo "  killall [-f(orce) ] [-s(tuck)]"
+  echo "  killall [-r(reset fuse) ] [-s(reset stuck fuse)]"
   echo "  bugreport <timeout_in_sec_per_command (default = 90)>"
 }
 
@@ -1513,15 +1508,6 @@ cvmfs_killall() {
   local pid=$$
 
   parse_killall_opts "$@"
-
-
-  if [ ${IS_KILLALL_FORCE} = true ] ; then
-    local cvmfs_devices=$(get_cvmfs_devices)
-    abort_all_devices $cvmfs_devices
-  elif [ ${IS_KILLALL_STUCK} = true ] ; then
-    local devices_map=$(get_devices_map)
-    abort_stuck_devices  $devices_map
-  fi
 
   echo -n "Terminating cvmfs_config processes... "
   # The exact match (pgrep -x) works only on Linux.  On macOS, one needs to

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -99,6 +99,100 @@ var_list="$parm_list $switch_list"
 
 cvmfs_fs_bundle="/Library/Filesystems/cvmfs.fs/Contents/Resources" # Mac OS X
 
+IS_KILLALL_STUCK=FALSE
+IS_KILLALL_FORCE=FALSE
+
+# Check if killall has extra arguments
+# -f(orce): abort all cvmfs associated fuse devices
+# -s(tuck): abort all cvmfs associated fuse devices in waiting state
+parse_killall_opts(){
+  while [[ "${1:-}" == -* ]]; do
+    case "$1" in
+      "-f")
+        IS_KILLALL_FORCE=true
+        ;;
+      "-s")
+        IS_KILLALL_STUCK=true
+        ;;
+      "--help")
+        cvmfs_config_usage
+        ;;
+      *)
+        echo "Ignoring unknown option $1"
+        ;;
+    esac
+    [ $# -gt 0 ] || break
+    shift
+  done
+}
+
+# Given a device id in the form <Major>:<minor>
+# we need only the <minor> part to identify the fuse device
+get_fuse_device()
+{
+  local device_id=$1
+  echo $device_id | cut -d':' -f2
+}
+
+abort_fuse_device(){
+  local fuse_device=$1
+  local device_path="/sys/fs/fuse/connections/$fuse_device"
+  if [ -d "$device_path" ]; then
+    echo -n "Aborting fuse device $fuse_device.. "
+    echo 1 > $device_path/abort
+    echo "OK"
+  fi
+}
+
+# Collect every device associated to a cvmfs mount point,
+# based on /proc/<cvmfs2_pid>/mountinfo
+get_cvmfs_devices()
+{
+  local cvmfs_devices=""
+  for pid in $(pidof "$PROCNAME")
+  do
+    while read -r line; do
+      # Get the interesting fields from every line of mountinfo;
+      # those are the mountpoint and the device id
+      device_id=$(echo "$line" | cut -d' ' -f 3)
+      current_mountpoint=$(echo "$line" | cut -d' ' -f 5)
+
+      if [[ "$current_mountpoint" == "$MOUNTPOINT"/*  ]]; then
+        if ! grep -q "$device_id" <<< "$cvmfs_devices"; then
+          cvmfs_devices=$cvmfs_devices" $device_id"
+        fi
+      fi
+    done < /proc/$pid/mountinfo
+  done
+  echo $cvmfs_devices
+}
+
+abort_all_devices()
+{
+  echo "Aborting all cvmfs fuse devices.."
+  local devices="$@"
+  for device in $devices
+  do
+    abort_fuse_device $(get_fuse_device $device)
+  done
+}
+
+abort_stuck_devices()
+{
+  echo "Aborting stuck cvmfs fuse devices.."
+  local devices="$@"
+  for device in $devices
+  do
+    fuse_dev=$(get_fuse_device $device)
+    local fuse_dev_path="/sys/fs/fuse/connections/$fuse_dev"
+    # Abort waiting devices only
+    if [ "$(cat $fuse_dev_path/waiting)" != "0" ] ;
+    then
+      abort_fuse_device $fuse_dev
+    fi
+  done
+}
+
 # makes sure that a version is always of the form x.y.z-b
 normalize_version() {
   local version_string="$1"
@@ -150,7 +244,7 @@ cvmfs_config_usage() {
   echo "  reload [-c | <repository>]"
   echo "  umount"
   echo "  wipecache"
-  echo "  killall"
+  echo "  killall [-f(orce) ] [-s(tuck)]"
   echo "  bugreport <timeout_in_sec_per_command (default = 90)>"
 }
 
@@ -1386,6 +1480,14 @@ cvmfs_umount() {
 
 cvmfs_killall() {
   local pid=$$
+
+  parse_killall_opts "$@"
+  local cvmfs_devices=$(get_cvmfs_devices)
+  if [ ${IS_KILLALL_FORCE} = true ] ; then
+    abort_all_devices $cvmfs_devices
+  elif [ ${IS_KILLALL_STUCK} = true ] ; then
+    abort_stuck_devices $cvmfs_devices
+  fi
 
   echo -n "Terminating cvmfs_config processes... "
   # The exact match (pgrep -x) works only on Linux.  On macOS, one needs to

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -128,7 +128,7 @@ parse_killall_opts(){
 
 # Given a device id in the form <Major>:<minor>
 # we need only the <minor> part to identify the fuse device
-get_fuse_device()
+get_minor_device_id()
 {
   local device_id=$1
   echo $device_id | cut -d':' -f2
@@ -173,7 +173,7 @@ abort_all_devices()
   local devices="$@"
   for device in $devices
   do
-    abort_fuse_device $(get_fuse_device $device)
+    abort_fuse_device $(get_minor_device_id $device)
   done
 }
 
@@ -183,7 +183,7 @@ abort_stuck_devices()
   local devices="$@"
   for device in $devices
   do
-    fuse_dev=$(get_fuse_device $device)
+    fuse_dev=$(get_minor_device_id $device)
     local fuse_dev_path="/sys/fs/fuse/connections/$fuse_dev"
     # Abort waiting devices only
     if [ "$(cat $fuse_dev_path/waiting)" != "0" ] ;

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -426,6 +426,9 @@ void *TalkManager::MainResponder(void *data) {
         mount_point->download_mgr()->SetDnsServer(host);
         talk_mgr->Answer(con_fd, "OK\n");
       }
+    } else if (line.substr(0,22) == "__testing_freeze_cvmfs") {
+      const std::string fs_dir=line.substr(23)+"/dir";
+      mkdir(fs_dir.c_str(),0700);
     } else if (line == "external metalink info") {
       const string external_metalink_info =
         talk_mgr->FormatMetalinkInfo(mount_point->external_download_mgr());

--- a/test/cloud_testing/platforms/centos7_x86_64-EXCLCACHE_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-EXCLCACHE_test.sh
@@ -9,6 +9,9 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 
 retval=0
 
+# Test exclusions
+# 066-killall: unresponsive CentOS7 machine (probably buggy fsfreeze support)
+
 # run tests
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
@@ -19,6 +22,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/007-testjobs                             \
                                  src/035-unpinumount                          \
                                  src/042-cleanuppipes                         \
+                                 src/066-killall                              \
                                  src/081-shrinkwrap                           \
                                  src/082-shrinkwrap-cms                       \
                                  src/084-premounted                           \

--- a/test/cloud_testing/platforms/centos7_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-FUSE3_test.sh
@@ -9,6 +9,9 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 
 retval=0
 
+# Test exclusions
+# 066-killall: unresponsive CentOS7 machine (probably buggy fsfreeze support)
+
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
 CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
@@ -16,6 +19,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                               -x src/005-asetup                               \
                                  src/004-davinci                              \
                                  src/007-testjobs                             \
+                                 src/066-killall                              \
                                  src/094-attachmount                          \
                                  --                                           \
                                  src/0*                                       \

--- a/test/cloud_testing/platforms/centos7_x86_64-NFS_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-NFS_test.sh
@@ -9,6 +9,9 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 
 retval=0
 
+# Test exclusions
+# 066-killall: unresponsive CentOS7 machine (probably buggy fsfreeze support)
+
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
 CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
@@ -22,6 +25,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/040-aliencache                           \
                                  src/041-rocache                              \
                                  src/043-highinodes                           \
+                                 src/066-killall                              \
                                  src/068-rocache                              \
                                  src/070-tieredcache                          \
                                  src/081-shrinkwrap                           \

--- a/test/cloud_testing/platforms/centos7_x86_64-RAMCACHE_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64-RAMCACHE_test.sh
@@ -9,6 +9,9 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 
 retval=0
 
+# Test exclusions
+# 066-killall: unresponsive CentOS7 machine (probably buggy fsfreeze support)
+
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
 CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
@@ -25,6 +28,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/044-unpinonmount                         \
                                  src/057-parallelmakecache                    \
                                  src/064-fsck                                 \
+                                 src/066-killall                              \
                                  src/068-rocache                              \
                                  src/070-tieredcache                          \
                                  src/081-shrinkwrap                           \

--- a/test/cloud_testing/platforms/centos7_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_test.sh
@@ -25,6 +25,8 @@ run_unittests --gtest_shuffle \
 
 # Exclusions
 # 682-enter: missing fuse-overlayfs
+# 066-killall: unresponsive CentOS7 machine (probably buggy fsfreeze support)
+
 
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
@@ -33,6 +35,7 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                               -x src/005-asetup                               \
                                  src/004-davinci                              \
                                  src/007-testjobs                             \
+                                 src/066-killall                              \
                                  src/084-premounted                           \
                                  src/094-attachmount                          \
                                  --                                           \

--- a/test/cloud_testing/platforms/centos9_x86_64-FUSE3_test.sh
+++ b/test/cloud_testing/platforms/centos9_x86_64-FUSE3_test.sh
@@ -11,7 +11,6 @@ retval=0
 
 # Test exclusions
 # 095: not needed on EL9 as attach mounts are supported
-# 066: temporarily until automounter reload bug is fixed
 
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
@@ -26,7 +25,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/030-missingrootcatalog                   \
                                  src/056-lowspeedlimit                        \
                                  src/065-http-400                             \
-                                 src/066-killall                              \
                                  src/084-premounted                           \
                                  src/095-fuser                                \
                                  src/096-cancelreq                            \

--- a/test/cloud_testing/platforms/centos9_x86_64_test.sh
+++ b/test/cloud_testing/platforms/centos9_x86_64_test.sh
@@ -25,7 +25,6 @@ run_unittests --gtest_shuffle \
 
 # Test exclusions
 # 095: not needed on EL9 as attach mounts are supported
-# 066: temporarily until automounter reload bug is fixed
 
 cd ${SOURCE_DIRECTORY}/test
 echo "running CernVM-FS client test cases..."
@@ -40,7 +39,6 @@ CVMFS_TEST_CLASS_NAME=ClientIntegrationTests                                  \
                                  src/030-missingrootcatalog                   \
                                  src/056-lowspeedlimit                        \
                                  src/065-http-400                             \
-                                 src/066-killall                              \
                                  src/084-premounted                           \
                                  src/095-fuser                                \
                                  src/096-cancelreq                            \

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -45,8 +45,13 @@ fs_cleanup(){
 
 freeze()
 {
+  # Inside docker fsfreeze is not supported.
+  # If fsfreeze fails, early return succesfully
   logdebug "Freezing ${DEST}.."
 	sudo fsfreeze -f -- "$DEST"
+  if [ "$?" != "0" ]; then
+    return 0
+  fi
 }
 
 unfreeze() {
@@ -191,10 +196,10 @@ cvmfs_run_test() {
   fs_setup
   trap fs_cleanup EXIT
 
-  logdebug "Testing killall -ff(fuse first)"
-  test_extra_args "-ff" || return $?
-  echo "Testing killall -sff(stuck ff)"
-  test_extra_args "-sff" || return $?
+  logdebug "Testing killall -r(reset fuse)"
+  test_extra_args "-r" || return $?
+  echo "Testing killall -s(stuck fuse reset)"
+  test_extra_args "-s" || return $?
 
   return 0
 }

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -191,10 +191,10 @@ cvmfs_run_test() {
   fs_setup
   trap fs_cleanup EXIT
 
-  logdebug "Testing killall -f(orce)"
-  test_extra_args "-f" || return $?
-  echo "Testing killall -s(tuck)"
-  test_extra_args "-s" || return $?
+  logdebug "Testing killall -ff(fuse first)"
+  test_extra_args "-ff" || return $?
+  echo "Testing killall -sff(stuck ff)"
+  test_extra_args "-sff" || return $?
 
   return 0
 }

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -3,6 +3,161 @@
 cvmfs_test_name="Killing all cvmfs2 instances"
 cvmfs_test_suites="quick"
 
+SRC=""
+DEST=""
+MOUNTPOINT=/cvmfs
+
+# Create a temporary filesystem and its mount point
+# The intension is to later freeze this fs using fsfreeze
+# and drive cvmfs2 in D-state to simulate a real world scenario.
+# More info on [this blog post](https://chrisdown.name/2024/02/05/reliably-creating-d-state-processes-on-demand.html)
+fs_setup(){
+  SRC="$(mktemp --suffix=FROZENFS)"
+  DEST="$(mktemp -d --suffix=FROZENFS)"
+
+  logdebug "Creating a filesystem on ${DEST}.."
+
+  if [ ! -d "$DEST" ] || [ ! -f "$SRC" ]; then
+    exit 51
+  fi
+
+	fallocate -l 8M -- "$SRC"
+	mkfs.ext4 -q -- "$SRC"
+	sudo mount -o loop -- "$SRC" "$DEST"
+}
+
+fs_cleanup(){
+  logdebug "Cleaning up ${DEST}.."
+
+  # If /tmp/freezeme is a mountpoint
+  # unfreeze it and unmount it
+  if mountpoint -q "${DEST}"; then
+    local loopdev=$(findmnt -n -o SOURCE --target "$DEST")
+    sudo fsfreeze -u ${DEST} 2> /dev/null
+    sudo umount ${DEST}
+    sudo losetup -d "$loopdev"
+    sudo rm -rf ${DEST}
+  fi
+  if [ -f ${SRC} ]; then
+    rm -- ${SRC}
+  fi
+}
+
+freeze()
+{
+  logdebug "Freezing ${DEST}.."
+	sudo fsfreeze -f -- "$DEST"
+}
+
+unfreeze() {
+  logdebug "Unfreezing ${DEST}.."
+  sudo fsfreeze -u -- "$DEST"
+}
+
+get_D_state_pid() {
+  local d_pid
+
+  for pid in $(ps -eT -o tid,comm | awk '$2=="cvmfs2" {print $1}' | xargs);
+  do
+    read -r _ _ state _ < /proc/$pid/stat
+    if [ "$state" = "D" ]; then
+      echo $pid
+      break
+    fi
+  done
+}
+
+get_fuse_devices_of_process(){
+  local pid
+  # Trim whitespaces in pid
+  pid="$(echo -e "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+  if [ -z "$pid" ]; then
+    return 50
+  fi
+  local cvmfs_devices=""
+  while read -r line; do
+    # Get the interesting fields from every line of mountinfo;
+    # those are the mountpoint and the device id
+    device_id=$(echo "$line" | cut -d' ' -f 3)
+    current_mountpoint=$(echo "$line" | cut -d' ' -f 5)
+
+    if [[ "$current_mountpoint" == "$MOUNTPOINT"/*  ]]; then
+      if ! grep -q "$device_id" <<< "$cvmfs_devices"; then
+        if [ -z "$cvmfs_devices" ]; then
+          cvmfs_devices="$(echo $device_id | cut -d ':' -f 2)"
+        else
+          cvmfs_devices=$cvmfs_devices" $(echo $device_id | cut -d ':' -f 2)"
+        fi
+      fi
+    fi
+  done < "/proc/$pid/mountinfo"
+
+  echo "$cvmfs_devices"
+}
+
+get_fuse_devices(){
+  local devices=""
+  for pid in $(pidof cvmfs2);
+  do
+    local associated_fuse_devices=$(get_fuse_devices_of_process ${pid})
+    for dev in $associated_fuse_devices;
+    do
+      if ! grep -q "$dev" <<< "$devices"; then
+        if [ -z "$devices" ]; then
+          devices="$dev"
+        else
+          devices="$devices $dev"
+        fi
+      fi
+    done
+  done
+  echo $devices
+}
+
+test_extra_args(){
+  logdebug "\tTesting cvmfs_config killall $1.."
+  arg="$1"
+  local repo="atlas.cern.ch"
+  freeze
+
+  logdebug "Mounting repositories and reloading.."
+  cvmfs_mount $repo || return 40
+  sudo cvmfs_config reload || return 41
+
+  logdebug "Freezing cvmfs.."
+  sudo cvmfs_talk -i $repo __testing_freeze_cvmfs &
+
+  # accessing a cvmfs repo with a cvmfs2 process
+  # in D-stat should hang.
+  ls ${MOUNTPOINT}/$repo
+  local d_pid=$!
+
+  local fuse_devices="$(get_fuse_devices)"
+
+  logdebug "\tbefore killall $arg FUSE devices: $fuse_devices"
+
+  logdebug "Killing cvmfs using cvmfs_config killall $arg"
+  sudo cvmfs_config killall "$arg" &
+
+  unfreeze
+
+  sleep 1
+
+  # At this point the ls process should have terminated
+  if [ -d /proc/$d_pid ]; then
+    return 42
+  fi
+}
+
+logdebug(){
+  if [[  "${DEBUG_LOGGING_MODE}" == "colored"  ]]; then
+    echo -e "\e[35m$1\e[0m"
+  else
+    echo -e "$1"
+  fi
+}
+
 cvmfs_run_test() {
   logfile=$1
 
@@ -25,6 +180,21 @@ cvmfs_run_test() {
 
   echo "Killall once again because we don't know where the reloaded was interrupted"
   sudo cvmfs_config killall || return 30
+  wait $!
+
+  if [ "$(uname)" != "Linux" ]; then
+    # specific killall options are not meant
+    # to be tested on non Linux machines
+    return 0
+  fi
+
+  fs_setup
+  trap fs_cleanup EXIT
+
+  logdebug "Testing killall -f(orce)"
+  test_extra_args "-f" || return $?
+  echo "Testing killall -s(tuck)"
+  test_extra_args "-s" || return $?
 
   return 0
 }


### PR DESCRIPTION
[Issue 3807](https://github.com/issues/assigned?issue=cvmfs%7Ccvmfs%7C3807)

A blocked fuse connection could bring a cvmfs2 process in D-state (unresponsive and not kill-able).
Invoking `cvmfs_config killall -r/-s` aborts the unresponsive fuse connection (`-s`) or every cvmfs fuse connection (`-r`), allowing the cvmfs2 process to become responsive again.

For testing, we can not replicate the exact scenario of freezing a fuse connection, hence we bring the cvmfs2 process in D state by  creating and freezing another fs in `/tmp/freezeme/` and instructing cvmfs2 to interact with this frozen fs.

**NOTE**: The solution is not tested with mount points outside `/cvmfs`.