### PR TITLE
Add  manpages for some cvmfs commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,9 +557,10 @@ install (
   PERMISSIONS             OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
 )
 
-#
-# Generate the documentation using doxygen
-#
+# Man pages
+add_subdirectory(doc/manpages)
+
+# Doxygen
 if (BUILD_DOCUMENTATION)
   message (STATUS "Generating Doxygen configuration ...")
   set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
@@ -576,4 +577,5 @@ if (BUILD_DOCUMENTATION)
     COMMAND sh -c "/bin/sed -i -e 's,@SRC_DIR@,${CMAKE_SOURCE_DIR},g' ${CMAKE_BINARY_DIR}/Doxyfile.in"
   )
   include (cmake/Modules/UseDoxygen)
+
 endif ()

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -286,7 +286,7 @@ cvmfs_config_usage() {
   echo ""
   echo "  killall [-r(reset fuse) ] [-s(reset stuck fuse)]"
   echo ""
-  echo "  bugreport <timeout_in_sec_per_command (default = 90)>"
+  echo "  bugreport [timeout_in_sec_per_command (default = 90)]"
 }
 
 has_selinux() {

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -257,22 +257,35 @@ compare_versions() {
 cvmfs_config_usage() {
   echo "Common configuration tasks for CernVM-FS"
   echo "Usage: $0 <command>"
-  echo "Commands are"
+  echo "Commands:"
   echo "  setup [nouser] [nocfgmod] [nostart] [noautofs]"
+  echo ""
   if is_wsl2; then
     echo "  wsl2_start"
+    echo ""
   fi
   echo "  chksetup"
+  echo ""
   echo "  showconfig [-s(hort output, only non-empty parameters)] [<repository>]"
+  echo ""
   echo "  stat [-v | <repository>]"
+  echo ""
   echo "  status"
+  echo ""
   echo "  probe [<repository list>]"
+  echo ""
   echo "  fsck [-q(uick check for zero byte files only) | <cvmfs_fsck options>]"
+  echo ""
   echo "  fuser <repository>"
+  echo ""
   echo "  reload [-c | <repository>]"
+  echo ""
   echo "  umount"
+  echo ""
   echo "  wipecache"
+  echo ""
   echo "  killall [-r(reset fuse) ] [-s(reset stuck fuse)]"
+  echo ""
   echo "  bugreport <timeout_in_sec_per_command (default = 90)>"
 }
 
@@ -2547,9 +2560,21 @@ case "$1" in
      RETVAL=$?
      ;;
 
-   *)
+   --version)
+     echo $(cvmfs2 --version)
+     RETVAL=0
+     ;;
+   --help)
      cvmfs_config_usage
      RETVAL=0
+     ;;
+   -h)
+     cvmfs_config_usage
+     RETVAL=0
+     ;;
+   *)
+     cvmfs_config_usage
+     RETVAL=1
      ;;
 esac
 

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -148,38 +148,35 @@ LoaderExports *loader_exports_;
 
 
 static void Usage(const string &exename) {
-  LogCvmfs(
-      kLogCvmfs, kLogStdout,
-      "The CernVM File System\n"
-      "Version %s\n"
-      "Copyright (c) 2009- CERN, all rights reserved\n\n"
-      "Please visit http://cernvm.cern.ch for details.\n\n"
-      "Usage: %s [-h] [-V] [-s] [-f] [-d] [-k] [-o mount options] "
-      "<repository name> <mount point>\n\n"
-      "CernVM-FS general options:\n"
-      "  --help|-h            Print Help output (this)\n"
-      "  --version|-V         Print CernVM-FS version\n"
-      "  -s                   Run singlethreaded\n"
-      "  -f                   Run in foreground\n"
-      "  -d                   Enable debugging\n"
-      "  -k                   Parse options\n"
-      "CernVM-FS mount options:\n"
-      "  -o config=FILES      colon-separated path list of config files\n"
-      "  -o uid=UID           Drop credentials to another user\n"
-      "  -o gid=GID           Drop credentials to another group\n"
-      "  -o system_mount      Indicate that mount is system-wide\n"
-      "  -o grab_mountpoint   give ownership of the mountpoint to the user "
-      "before mounting (required for autofs)\n"
-      "  -o parse             Parse and print cvmfs parameters\n"
-      "  -o cvmfs_suid        Enable suid mode\n\n"
-      "  -o disable_watchdog  Do not spawn a post mortem crash handler\n"
-      "  -o foreground        Run in foreground\n"
-      "  -o libfuse=[2,3]     Enforce a certain libfuse version\n"
-      "Fuse mount options:\n"
-      "  -o allow_other       allow access to other users\n"
-      "  -o allow_root        allow access to root\n"
-      "  -o nonempty          allow mounts over non-empty directory\n",
-      CVMFS_VERSION, exename.c_str());
+  LogCvmfs(kLogCvmfs, kLogStdout,
+    "Usage: %s [-h] [-V] [-s] [-f] [-d] [-k] [-o mount_options] "
+      "<repository_name> <mount_point>\n\n"
+    "Mounts a CernVM-FS with the given repository at the given mountpoint.\n"
+    "Usually invoked via autofs or 'mount -t cvmfs <repository_name> <mount_point>'\n\n"
+    "CernVM-FS general options:\n"
+    "  -h, --help           Print Help output (this)\n"
+    "  -V, --version        Print CernVM-FS version\n"
+    "  -s                   Run singlethreaded\n"
+    "  -f                   Run in foreground\n"
+    "  -d                   Enable debugging\n"
+    "  -k                   Parse options\n"
+    "CernVM-FS mount options:\n"
+    "  -o config=FILES      colon-separated path list of config files\n"
+    "  -o uid=UID           Drop credentials to another user\n"
+    "  -o gid=GID           Drop credentials to another group\n"
+    "  -o system_mount      Indicate that mount is system-wide\n"
+    "  -o grab_mountpoint   give ownership of the mountpoint to the user "
+                            "before mounting (required for autofs)\n"
+    "  -o parse             Parse and print cvmfs parameters\n"
+    "  -o cvmfs_suid        Enable suid mode\n"
+    "  -o disable_watchdog  Do not spawn a post mortem crash handler\n"
+    "  -o foreground        Run in foreground\n"
+    "  -o libfuse=[2,3]     Enforce a certain libfuse version\n"
+    "Fuse mount options:\n"
+    "  -o allow_other       allow access to other users\n"
+    "  -o allow_root        allow access to root\n"
+    "  -o nonempty          allow mounts over non-empty directory\n",
+     exename.c_str());
 }
 
 /**

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -185,6 +185,12 @@ if [ $# -lt 1 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
   usage
 fi
 
+## implement --version
+if [ "$1" == "--version" ]; then
+  echo "CernVM-FS version $(__swissknife --version)"
+  exit 0
+fi
+
 # check if the given sub-command is known and, if so, call it
 subcommand=$1
 shift

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -181,12 +181,12 @@ APACHE_CONF_MODE_CONFAVAIL=2 # *.conf goes to ${APACHE_CONF}/conf-available
 ################################################################################
 
 # check if there is at least a selected sub-command
-if [ $# -lt 1 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
+if [ $# -lt 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   usage
 fi
 
 ## implement --version
-if [ "$1" == "--version" ]; then
+if [ "$1" = "--version" ]; then
   echo "CernVM-FS version $(__swissknife --version)"
   exit 0
 fi

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -181,7 +181,7 @@ APACHE_CONF_MODE_CONFAVAIL=2 # *.conf goes to ${APACHE_CONF}/conf-available
 ################################################################################
 
 # check if there is at least a selected sub-command
-if [ $# -lt 1 ]; then
+if [ $# -lt 1 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
   usage
 fi
 

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -37,21 +37,15 @@ Commands command_list;
 
 void Usage() {
   LogCvmfs(kLogCvmfs, kLogStdout,
-           "CernVM-FS repository storage management commands\n"
-           "Version %s\n"
-           "Usage (normally called from cvmfs_server):\n"
-           "  cvmfs_swissknife <command> [options]\n",
-           CVMFS_VERSION);
+          "CernVM-FS repository storage management commands\n"
+          "Usage (normally called from cvmfs_server):\n"
+          "  cvmfs_swissknife <command> [options]\n");
 
   for (unsigned i = 0; i < command_list.size(); ++i) {
     LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
              "\n"
              "Command %s\n"
-             "--------",
-             command_list[i]->GetName().c_str());
-    for (unsigned j = 0; j < command_list[i]->GetName().length(); ++j) {
-      LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "-");
-    }
+             "--", command_list[i]->GetName().c_str());
     LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
     LogCvmfs(kLogCvmfs, kLogStdout, "%s",
              command_list[i]->GetDescription().c_str());

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -60,16 +60,14 @@ else()
         COMPONENT documentation
     )
     if (BUILD_SERVER) 
+
     # cvmfs_server
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_server.1"
-        COMMAND ${HELP2MAN} 
-            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
-            --no-info 
-            --section=1 
-            --output=${MAN_OUTPUT_DIR}/cvmfs_server.1
-            --name "cvmfs_server: tools for publishing and managing CernVM-FS repositories" 
-            "${CMAKE_BINARY_DIR}/cvmfs/cvmfs_server"
+        COMMAND ${CMAKE_CURRENT_LIST_DIR}/generate_manpage_cvmfs_server.sh
+                ${CMAKE_CURRENT_LIST_DIR} # location of include files
+                ${MAN_OUTPUT_DIR} # directory for generated manpage
+                ${CMAKE_BINARY_DIR}/cvmfs # location of swissknife binary
         DEPENDS cvmfs_server_script
         COMMENT "Generating man page for cvmfs_server"
         VERBATIM
@@ -85,13 +83,10 @@ else()
     # cvmfs_swissknife
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_swissknife.1"
-        COMMAND ${HELP2MAN} 
-            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
-            --no-info 
-            --section=1 
-            --output=${MAN_OUTPUT_DIR}/cvmfs_swissknife.1
-            --name "cvmfs_swissknife: Low-level tools for publishing and managing CernVM-FS repositories" 
-            "$<TARGET_FILE:cvmfs_swissknife>"
+        COMMAND ${CMAKE_CURRENT_LIST_DIR}/generate_manpage_cvmfs_swissknife.sh
+                ${CMAKE_CURRENT_LIST_DIR} # location of include files
+                ${MAN_OUTPUT_DIR} # directory for generated manpage
+                ${CMAKE_BINARY_DIR}/cvmfs # location of swissknife binary
         DEPENDS cvmfs_swissknife
         COMMENT "Generating man page for cvmfs_swissknife"
         VERBATIM

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -37,7 +37,29 @@ else()
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
         COMPONENT documentation
     )
+    # cvmfs_config
+    add_custom_command(
+        OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_config.1"
+        COMMAND ${HELP2MAN} 
+            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
+            --no-info 
+            --section=1 
+            --output=${MAN_OUTPUT_DIR}/cvmfs_config.1
+            --name "cvmfs_config: tools for common CernVM-FS config tasks" 
+            "${CMAKE_SOURCE_DIR}/cvmfs/cvmfs_config"
+        COMMENT "Generating man page for cvmfs_config"
+        VERBATIM
+    )
 
+    # Add to the list of generated man pages
+    list(APPEND MAN_PAGES "${MAN_OUTPUT_DIR}/cvmfs_config.1")
+    install(
+        FILES ${MAN_OUTPUT_DIR}/cvmfs_config.1
+        #TYPE MAN doesn't install into correct section dir
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+        COMPONENT documentation
+    )
+    if (BUILD_SERVER) 
     # cvmfs_server
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_server.1"
@@ -60,30 +82,30 @@ else()
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
         COMPONENT documentation
     )
-
-    # cvmfs_server
+    # cvmfs_swissknife
     add_custom_command(
-        OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_config.1"
+        OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_swissknife.1"
         COMMAND ${HELP2MAN} 
             -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
             --no-info 
             --section=1 
-            --output=${MAN_OUTPUT_DIR}/cvmfs_config.1
-            --name "cvmfs_config: tools for common CernVM-FS config tasks" 
-            "${CMAKE_SOURCE_DIR}/cvmfs/cvmfs_config"
-        COMMENT "Generating man page for cvmfs_config"
+            --output=${MAN_OUTPUT_DIR}/cvmfs_swissknife.1
+            --name "cvmfs_swissknife: Low-level tools for publishing and managing CernVM-FS repositories" 
+            "$<TARGET_FILE:cvmfs_swissknife>"
+        DEPENDS cvmfs_swissknife
+        COMMENT "Generating man page for cvmfs_swissknife"
         VERBATIM
     )
-
     # Add to the list of generated man pages
-    list(APPEND MAN_PAGES "${MAN_OUTPUT_DIR}/cvmfs_config.1")
+    list(APPEND MAN_PAGES "${MAN_OUTPUT_DIR}/cvmfs_swissknife.1")
     install(
-        FILES ${MAN_OUTPUT_DIR}/cvmfs_config.1
+        FILES ${MAN_OUTPUT_DIR}/cvmfs_swissknife.1
         #TYPE MAN doesn't install into correct section dir
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
         COMPONENT documentation
     )
 
+    endif()
     # Create a custom target for generating all man pages
     add_custom_target(manpages ALL DEPENDS ${MAN_PAGES})
 

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -14,7 +14,6 @@ else()
     file(MAKE_DIRECTORY ${MAN_OUTPUT_DIR})
 
     # cvmfs2
-    get_filename_component(CVMFS2_BINARY_DIR "$<TARGET_FILE:cvmfs2>" DIRECTORY)
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs2.1"
         COMMAND ${HELP2MAN} 
@@ -26,7 +25,7 @@ else()
             --name "cvmfs2: fuse client for the CernVM-Filesystem" 
             "$<TARGET_FILE:cvmfs2>"
         DEPENDS cvmfs2
-        WORKING_DIRECTORY ${CVMFS2_BINARY_DIR}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cvmfs/
         COMMENT "Generating man page for cvmfs2"
         VERBATIM
     )

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -1,0 +1,91 @@
+
+# Find help2man
+find_program(HELP2MAN help2man DOC "Path to help2man executable")
+
+include(GNUInstallDirs)
+
+if(NOT HELP2MAN)
+    message(WARNING "help2man not found - man pages will not be generated")
+else()
+    message(STATUS "Found help2man: ${HELP2MAN}")
+
+    # Set the output directory for man pages
+    set(MAN_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    file(MAKE_DIRECTORY ${MAN_OUTPUT_DIR})
+
+    # cvmfs2
+    add_custom_command(
+        OUTPUT "${MAN_OUTPUT_DIR}/cvmfs2.1"
+        COMMAND ${HELP2MAN} 
+            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
+            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs2.h2m
+            --no-info 
+            --section=1 
+            --output=${MAN_OUTPUT_DIR}/cvmfs2.1
+            --name "cvmfs2: fuse client for the CernVM-Filesystem" 
+            "$<TARGET_FILE:cvmfs2>"
+        DEPENDS cvmfs2
+        COMMENT "Generating man page for cvmfs2"
+        VERBATIM
+    )
+
+    # Add to the list of generated man pages
+    list(APPEND MAN_PAGES "${MAN_OUTPUT_DIR}/cvmfs2.1")
+    install(
+        FILES ${MAN_OUTPUT_DIR}/cvmfs2.1
+        #TYPE MAN
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+        COMPONENT documentation
+    )
+
+    # cvmfs_server
+    add_custom_command(
+        OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_server.1"
+        COMMAND ${HELP2MAN} 
+            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
+            --no-info 
+            --section=1 
+            --output=${MAN_OUTPUT_DIR}/cvmfs_server.1
+            --name "cvmfs_server: tools for publishing and managing CernVM-FS repositories" 
+            "${CMAKE_BINARY_DIR}/cvmfs/cvmfs_server"
+        DEPENDS cvmfs_server_script
+        COMMENT "Generating man page for cvmfs_server"
+        VERBATIM
+    )
+    # Add to the list of generated man pages
+    list(APPEND MAN_PAGES "${MAN_OUTPUT_DIR}/cvmfs_server.1")
+    install(
+        FILES ${MAN_OUTPUT_DIR}/cvmfs_server.1
+        #TYPE MAN doesn't install into correct section dir
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+        COMPONENT documentation
+    )
+
+    # cvmfs_server
+    add_custom_command(
+        OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_config.1"
+        COMMAND ${HELP2MAN} 
+            -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
+            --no-info 
+            --section=1 
+            --output=${MAN_OUTPUT_DIR}/cvmfs_config.1
+            --name "cvmfs_config: tools for common CernVM-FS config tasks" 
+            "${CMAKE_SOURCE_DIR}/cvmfs/cvmfs_config"
+        COMMENT "Generating man page for cvmfs_config"
+        VERBATIM
+    )
+
+    # Add to the list of generated man pages
+    list(APPEND MAN_PAGES "${MAN_OUTPUT_DIR}/cvmfs_config.1")
+    install(
+        FILES ${MAN_OUTPUT_DIR}/cvmfs_config.1
+        #TYPE MAN doesn't install into correct section dir
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+        COMPONENT documentation
+    )
+
+    # Create a custom target for generating all man pages
+    add_custom_target(manpages ALL DEPENDS ${MAN_PAGES})
+
+endif()
+

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
     file(MAKE_DIRECTORY ${MAN_OUTPUT_DIR})
 
     # cvmfs2
+    get_filename_component(CVMFS2_BINARY_DIR "$<TARGET_FILE:cvmfs2>" DIRECTORY)
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs2.1"
         COMMAND ${HELP2MAN} 
@@ -25,6 +26,7 @@ else()
             --name "cvmfs2: fuse client for the CernVM-Filesystem" 
             "$<TARGET_FILE:cvmfs2>"
         DEPENDS cvmfs2
+        WORKING_DIRECTORY ${CVMFS2_BINARY_DIR}
         COMMENT "Generating man page for cvmfs2"
         VERBATIM
     )
@@ -87,6 +89,7 @@ else()
                 ${CMAKE_CURRENT_LIST_DIR} # location of include files
                 ${MAN_OUTPUT_DIR} # directory for generated manpage
                 ${CMAKE_BINARY_DIR}/cvmfs # location of swissknife binary
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cvmfs
         DEPENDS cvmfs_swissknife
         COMMENT "Generating man page for cvmfs_swissknife"
         VERBATIM

--- a/doc/manpages/cvmfs.md
+++ b/doc/manpages/cvmfs.md
@@ -1,0 +1,9 @@
+# The CernVM Filesystem
+
+## Description
+
+The CernVM filesystem (CVMFS) is a global, readonly distributed file system optimized for software delivery - it lets you stream software from a remote server to your local machine on demand! 
+
+CVMFS is a filesystem in userspace that presents files on a remote server as if they were already on a local filesystem, and downloads them on demand. Unlike sshfs and similar tools, CernVM-FS needs the files on the server to be in a special format, the "CVMFS repository", which includes file metadata. The cvmfs_server command can be used to author and add files to CVMFS repositories.
+
+This lets 

--- a/doc/manpages/cvmfs.md
+++ b/doc/manpages/cvmfs.md
@@ -1,9 +1,0 @@
-# The CernVM Filesystem
-
-## Description
-
-The CernVM filesystem (CVMFS) is a global, readonly distributed file system optimized for software delivery - it lets you stream software from a remote server to your local machine on demand! 
-
-CVMFS is a filesystem in userspace that presents files on a remote server as if they were already on a local filesystem, and downloads them on demand. Unlike sshfs and similar tools, CernVM-FS needs the files on the server to be in a special format, the "CVMFS repository", which includes file metadata. The cvmfs_server command can be used to author and add files to CVMFS repositories.
-
-This lets 

--- a/doc/manpages/cvmfs2.h2m
+++ b/doc/manpages/cvmfs2.h2m
@@ -1,0 +1,6 @@
+[EXAMPLES]
+
+mount -t cvmfs cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch
+
+# same, but run in foreground for debugging
+cvmfs2 -d -f cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch

--- a/doc/manpages/cvmfs2.h2m
+++ b/doc/manpages/cvmfs2.h2m
@@ -3,4 +3,5 @@
 mount -t cvmfs cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch
 
 # same, but run in foreground for debugging
+
 cvmfs2 -d -f cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch

--- a/doc/manpages/cvmfs_common.h2m
+++ b/doc/manpages/cvmfs_common.h2m
@@ -1,0 +1,18 @@
+[GETTING HELP]
+
+For general questions regarding CernVM-FS, use the forum:
+
+https://cernvm-forum.cern.ch
+
+[REPORTING BUGS]
+
+The issue tracker is located on GitHub:
+
+https://github.com/cvmfs/cvmfs/issues
+
+Consider using cvmfs_config bugreport to create a tarball with debugging information, and attaching it to to your issue. 
+
+
+[COPYRIGHT]
+
+Copyright (c) 2009- CERN, all rights reserved

--- a/doc/manpages/generate_manpage_cvmfs_server.sh
+++ b/doc/manpages/generate_manpage_cvmfs_server.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docdir="$1"
+outdir=$2
+builddir=$3
+ help2man \
+ -i $docdir/cvmfs_common.h2m \
+ --no-info \
+ --section=1 \
+ --output=$outdir/cvmfs_server.1 \
+ --name "cvmfs_server: tools for publishing and managing CernVM-FS repositories" \
+ "bash -c '$builddir/cvmfs_server|sed "s/$/\\\\n/"'"
+

--- a/doc/manpages/generate_manpage_cvmfs_swissknife.sh
+++ b/doc/manpages/generate_manpage_cvmfs_swissknife.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docdir="$1"
+outdir=$2
+builddir=$3
+ help2man \
+ -i $docdir/cvmfs_common.h2m \
+ --no-info \
+ --section=1 \
+ --output=$outdir/cvmfs_swissknife.1 \
+ --name "cvmfs_swissknife: low-level tools for publishing and managing CernVM-FS repositories" \
+ "bash -c '$builddir/cvmfs_swissknife|sed "s/$/\\\\n/"'"
+

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -9,6 +9,7 @@ Build-Depends:
  autotools-dev,
  cmake,
  cpio,
+ help2man,
  libcap-dev,
  libssl-dev,
  libattr1-dev,

--- a/packaging/debian/cvmfs/cvmfs-server.install.in
+++ b/packaging/debian/cvmfs/cvmfs-server.install.in
@@ -30,3 +30,5 @@ var/lib/cvmfs-server/geo/
 var/spool/cvmfs/README
 etc/logrotate.d/cvmfs-statsdb
 etc/logrotate.d/cvmfs
+usr/share/man/man1/cvmfs_server.1
+usr/share/man/man1/cvmfs_swissknife.1

--- a/packaging/debian/cvmfs/cvmfs.install.in
+++ b/packaging/debian/cvmfs/cvmfs.install.in
@@ -24,3 +24,5 @@ etc/cvmfs/default.conf
 etc/cvmfs/default.d/README
 etc/bash_completion.d/cvmfs
 usr/lib/systemd/system/cvmfs-reload.service
+usr/share/man/man1/cvmfs2.1
+usr/share/man/man1/cvmfs_config.1

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -659,8 +659,8 @@ systemctl daemon-reload
 %config(noreplace) %{_sysconfdir}/bash_completion.d/cvmfs
 %doc COPYING AUTHORS README.md ChangeLog
 %{_unitdir}/cvmfs-reload.service
-%doc %{mandir}/man1/cvmfs2.1
-%doc %{mandir}/man1/cvmfs_config.1
+%doc %{_mandir}/man1/cvmfs2.1.gz
+%doc %{_mandir}/man1/cvmfs_config.1.gz
 
 %files libs
 %defattr(-,root,root)
@@ -717,10 +717,15 @@ systemctl daemon-reload
 /var/lib/cvmfs-server/
 /var/spool/cvmfs/README
 %doc COPYING AUTHORS README.md ChangeLog
+<<<<<<< HEAD
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs
 %doc %{mandir}/man1/cvmfs_server.1
 %doc %{mandir}/man1/cvmfs_swissknife.1
+=======
+%doc %{_mandir}/man1/cvmfs_server.1.gz
+%doc %{_mandir}/man1/cvmfs_swissknife.1.gz
+>>>>>>> 27c657bf4 (fix packaging for swissknife)
 
 %files shrinkwrap
 %defattr(-,root,root)

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -717,15 +717,10 @@ systemctl daemon-reload
 /var/lib/cvmfs-server/
 /var/spool/cvmfs/README
 %doc COPYING AUTHORS README.md ChangeLog
-<<<<<<< HEAD
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs
-%doc %{mandir}/man1/cvmfs_server.1
-%doc %{mandir}/man1/cvmfs_swissknife.1
-=======
 %doc %{_mandir}/man1/cvmfs_server.1.gz
 %doc %{_mandir}/man1/cvmfs_swissknife.1.gz
->>>>>>> 27c657bf4 (fix packaging for swissknife)
 
 %files shrinkwrap
 %defattr(-,root,root)

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -96,6 +96,7 @@ BuildRequires: gcc4-c++
 %else
 BuildRequires: gcc
 BuildRequires: gcc-c++
+BuildRequires: help2man
 BuildRequires: valgrind-devel
 %endif
 BuildRequires: cmake
@@ -213,6 +214,7 @@ Summary: CernVM-FS server tools
 Group: Application/System
 BuildRequires: %{cvmfs_python_devel}
 BuildRequires: libcap-devel
+BuildRequires: help2man
 BuildRequires: unzip
 BuildRequires: %{cvmfs_python_setuptools}
 %if 0%{?suse_version}
@@ -657,6 +659,8 @@ systemctl daemon-reload
 %config(noreplace) %{_sysconfdir}/bash_completion.d/cvmfs
 %doc COPYING AUTHORS README.md ChangeLog
 %{_unitdir}/cvmfs-reload.service
+%doc %{mandir}/man1/cvmfs2.1
+%doc %{mandir}/man1/cvmfs_config.1
 
 %files libs
 %defattr(-,root,root)
@@ -715,6 +719,8 @@ systemctl daemon-reload
 %doc COPYING AUTHORS README.md ChangeLog
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs
+%doc %{mandir}/man1/cvmfs_server.1
+%doc %{mandir}/man1/cvmfs_swissknife.1
 
 %files shrinkwrap
 %defattr(-,root,root)


### PR DESCRIPTION
Adds support for:
* `man cvmfs2`
* `man cvmfs_config`
* `man cvmfs_server`
* `man cvmfs_swissknife`

This is mainly for compliance with packaging guidelines of linux distro repositories. The man pages don't add much more information than what is currently available in the `--help` output, and use `help2man` in order to keep the information in sync with the codebase.

The `--help` output needs to be improved in a future patch - in particular cvmfs_server and swissknife should show the usage for individual subcommands and not just one long list with all of them.
