### PR TITLE
ci: Fix permissions in 81 and timeouts on find

### DIFF
--- a/test/src/081-shrinkwrap/main
+++ b/test/src/081-shrinkwrap/main
@@ -7,8 +7,8 @@ CVMFS_TEST081_REPO=
 
 cleanup() {
     echo "*** [Cleanup]"
-    sudo rm -f /tmp/cvmfs-$CVMFS_TEST081_REPO.trace.log 2> /dev/null
-    sudo rm -f /tmp/cvmfs-$CVMFS_TEST081_REPO.spec.txt  2> /dev/null
+    sudo rm -f $workdir/cvmfs-$CVMFS_TEST081_REPO.trace.log 2> /dev/null
+    sudo rm -f $workdir/cvmfs-$CVMFS_TEST081_REPO.spec.txt  2> /dev/null
 
     sudo rm -rf $CVMFS_TEST081_SHRINKWRAP_DEST 2> /dev/null
     sudo rm -rf /var/lib/cvmfs/shrinkwrap 2> /dev/null
@@ -17,52 +17,61 @@ cleanup() {
 cvmfs_run_test() {
     logfile=$1
     local test_location=$2
+    workdir=/tmp/cvmfs-test-081-shrinkwrap-workdir
     CVMFS_TEST081_SHRINKWRAP_DEST="$PWD/shrinkwrap-base"
 
     local repo="sft.cern.ch"
     CVMFS_TEST081_REPO=$repo
+    tracelog=$workdir/cvmfs-$repo.trace.log
     echo "*** Setup..."
     cleanup
     trap cleanup HUP EXIT TERM INT || return 4
+    # make sure cvmfs user can write logs to workdir
+    mkdir -p $workdir
+    sudo chmod a+rw $workdir
 
     echo "*** Mounting test repository..."
     cvmfs_mount $repo "GLITE_VERSION=util" \
-      "CVMFS_TRACEFILE=/tmp/cvmfs-@fqrn@.trace.log" \
+      "CVMFS_CHECK_PERMISSIONS=no" \
+      "CVMFS_TRACEFILE=$workdir/cvmfs-@fqrn@.trace.log" \
       "CVMFS_TRACEBUFFER=4096" \
       "CVMFS_TRACEBUFFER_THRESHOLD=2048"
 
     echo "Checking trace log creation..."
     sudo cvmfs_talk -i $repo tracebuffer flush > /dev/null
 
-    if [ ! -f /tmp/cvmfs-$repo.trace.log ]; then
+    if [ ! -f $tracelog ]; then
         echo "*** ERROR: Trace file was not created"
         return 2
     fi
 
-    sudo truncate -s0 /tmp/cvmfs-$repo.trace.log
+    sudo truncate -s0 $tracelog
 
     echo "*** Executing a few operations to check tracing..."
-    for f in $(find /cvmfs/$repo -type f | head -n 3); do
-      cat $f > /dev/null
-    done
+
+    ls /cvmfs/sft.cern.ch/lcg/contrib/binutils/2.28/x86_64-centos7/
+    cat /cvmfs/sft.cern.ch/lcg/contrib/binutils/2.28/x86_64-centos7/version.txt > /dev/null
+    cat /cvmfs/sft.cern.ch/lcg/contrib/binutils/2.28/x86_64-centos7/lib/libopcodes.a > /dev/null
+    cat /cvmfs/sft.cern.ch/lcg/contrib/binutils/2.28/x86_64-centos7/lib/libopcodes.la > /dev/null
+
     sudo cvmfs_talk -i $repo tracebuffer flush
-    sudo cat /tmp/cvmfs-$repo.trace.log
+    sudo cat $tracelog
 
     echo "*** Creating specification file..."
     sudo $CVMFS_SYS_PYTHON /usr/libexec/cvmfs/shrinkwrap/spec_builder.py \
       --policy=exact \
       --filters opendir lookup -- \
-      /tmp/cvmfs-$repo.trace.log \
-      /tmp/cvmfs-$repo.spec.txt
+      $workdir/cvmfs-$repo.trace.log \
+      $workdir/cvmfs-$repo.spec.txt
     [ $? -eq 0 ] || return 3
-    cat /tmp/cvmfs-$repo.spec.txt
+    cat $workdir/cvmfs-$repo.spec.txt
     echo
 
     echo "*** Creating shrinkwrapped repository..."
-    echo "CVMFS_HTTP_PROXY=DIRECT" > local.config
+    echo "CVMFS_HTTP_PROXY=DIRECT" > $workdir/local.config
     sudo cvmfs_shrinkwrap --repo $repo \
-      --src-config "$test_location/$repo.config:local.config" \
-      --spec-file /tmp/cvmfs-$repo.spec.txt \
+      --src-config "$test_location/$repo.config:$workdir/local.config" \
+      --spec-file $workdir/cvmfs-$repo.spec.txt \
       --dest-base $CVMFS_TEST081_SHRINKWRAP_DEST
     [ $? -eq 0 ] || return 4
 
@@ -86,14 +95,14 @@ cvmfs_run_test() {
     [ $? -ne 0 ] || return 20
 
     echo "*** Update destination..."
-    echo | sudo tee -a /tmp/cvmfs-$repo.spec.txt
-    echo "^/lcg/lastUpdate" | sudo tee -a /tmp/cvmfs-$repo.spec.txt
+    echo | sudo tee -a $workdir/cvmfs-$repo.spec.txt
+    echo "^/lcg/lastUpdate" | sudo tee -a $workdir/cvmfs-$repo.spec.txt
     sudo cvmfs_shrinkwrap --repo $repo \
-      --src-config "$test_location/$repo.config:local.config" \
-      --spec-file /tmp/cvmfs-$repo.spec.txt \
+      --src-config "$test_location/$repo.config:$workdir/local.config" \
+      --spec-file $workdir/cvmfs-$repo.spec.txt \
       --dest-base $CVMFS_TEST081_SHRINKWRAP_DEST
     [ $? -eq 0 ] || return 30
     ls $CVMFS_TEST081_SHRINKWRAP_DEST/$repo/lcg/lastUpdate || return 31
-
+    rm $workdir
     return 0
 }

--- a/test/src/089-external_cache_plugin/main
+++ b/test/src/089-external_cache_plugin/main
@@ -38,8 +38,7 @@ cvmfs_run_test() {
 
   cvmfs_mount lhcb.cern.ch $mount_opts || return 3
   ls /cvmfs/lhcb.cern.ch > /dev/null || return 4
-  filename=$(find /cvmfs/lhcb.cern.ch -type f | head -n1)
-  cat $filename > /dev/null || return 5
+  cat /cvmfs/lhcb.cern.ch/README > /dev/null || return 5
   sudo cvmfs_config umount || return 6
 
   wait_for_umount || return 7
@@ -58,8 +57,7 @@ cvmfs_run_test() {
 
   cvmfs_mount lhcb.cern.ch $mount_opts || return $?
   ls /cvmfs/lhcb.cern.ch > /dev/null || return 10
-  filename=$(find /cvmfs/lhcb.cern.ch -type f | head -n1)
-  cat $filename > /dev/null || return 11
+  cat /cvmfs/lhcb.cern.ch/README > /dev/null || return 11
   sudo cvmfs_config umount || return 12
 
   wait_for_umount || return 13

--- a/test/src/092-stat/main
+++ b/test/src/092-stat/main
@@ -14,7 +14,7 @@ cvmfs_run_test() {
   echo "*** Initial hitrate: $hitrate_init"
 
   local files=
-  for f in $(find /cvmfs/cernvm-prod.cern.ch -type f | head -n 20); do
+  for f in $(find /cvmfs/cernvm-prod.cern.ch/update-packs/cvm3/ -type f | head -n 20); do
     files="$f $files"
     md5sum $f || return 10
   done

--- a/test/src/099-http_tracing/main
+++ b/test/src/099-http_tracing/main
@@ -25,7 +25,7 @@ mount_and_read() {
 
   echo "   Access data to send HTTP requests"
   local some_files
-  some_files=$(find $TEST099_MOUNTPOINT -type f | head -n3)
+  some_files=$(find /cvmfs/lhcb.cern.ch/lib/etc/ -type f | head -n3)
   for a_file in $some_files; do
     cat "$a_file" > /dev/null
   done

--- a/test/src/100-reload-switch-debug/main
+++ b/test/src/100-reload-switch-debug/main
@@ -24,7 +24,7 @@ reload_without_debuglog() {
   local specific_repo
   specific_repo=$1
   local some_file
-  some_file=$(find $TEST100_MOUNTPOINT -type f | head -n1)
+  some_file=$(find /cvmfs/lhcb.cern.ch/lib/etc/ -type f | head -n1)
   echo "   ** Access some data at $TEST100_REPO: $some_file"
   cat "$some_file" > /dev/null || return 10
 
@@ -68,7 +68,7 @@ reload_with_debuglog() {
   local specific_repo
   specific_repo=$1
   local some_file
-  some_file=$(find $TEST100_MOUNTPOINT -type f | head -n1)
+  some_file=$(find /cvmfs/lhcb.cern.ch/lib/etc/ -type f | head -n1)
   echo "   ** Access some data at $TEST100_REPO: $some_file"
   cat "$some_file" > /dev/null || return 20
 

--- a/test/src/102-reusefd/main
+++ b/test/src/102-reusefd/main
@@ -18,8 +18,7 @@ cvmfs_run_test() {
 
   ############
   # open some test file in several simultaneously in different processes
-
-  local testfile=$(find /cvmfs/atlas.cern.ch -type f | head -n1)
+  local testfile=$(find /cvmfs/atlas.cern.ch/repo/benchmarks/cern/current/run/ -type f | head -n1)
   # testfile has the following cvmfs hash:
   local testfile_hash=$(get_xattr hash $testfile)
 

--- a/test/src/103-reloadcachemgr/main
+++ b/test/src/103-reloadcachemgr/main
@@ -25,7 +25,7 @@ cvmfs_run_test() {
   ############
   # open some test file in several simultaneously in different processes
 
-  testfile=$(find /cvmfs/atlas.cern.ch -type f | head -n1)
+  testfile=$(find /cvmfs/atlas.cern.ch/repo/benchmarks/cern/current/run/ -type f | head -n1)
   # testfile has the following cvmfs hash:
   testfile_hash=$(get_xattr hash $testfile)
 

--- a/test/src/105-streaming-cache/main
+++ b/test/src/105-streaming-cache/main
@@ -13,7 +13,7 @@ cvmfs_run_test() {
   echo "*** root hash is $root_hash"
 
   local nfiles=100
-  find /cvmfs/alice.cern.ch -type f -size +100k -size -10M | head -n $nfiles \
+  find /cvmfs/alice.cern.ch/el9-x86_64/Packages/AEGIS -type f -size +100k -size -10M | head -n $nfiles \
     > filelist || return 10
 
   echo "*** Checksuming reference file set"


### PR DESCRIPTION
In a new cloudtesting setup that avoids the test/cloudtesting/platforms/*.sh scripts, there were several timeouts that seemed to come from `find` traversing more of the repository than intended.

The command find $repo | head -n 1 is indeed not guaranteed to stop the find after one file, and depends on line buffering of the shell.

This uses subdirectories of the repositories to find test files, to limit find and fix the tests. The downside is that those subdirectories could be deleted and the test logic needs to be updated, but that should be rare and not a problem.