### PR TITLE
ci: correct the diff fed to clang-tidy-diff

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -68,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "::add-matcher::.github/scripts/clang_matcher.json" 
-          git diff -U0  HEAD HEAD~ | /usr/lib/llvm-${{ env.CLANG_VERSION }}/share/clang/clang-tidy-diff.py -clang-tidy-binary clang-tidy-${{ env.CLANG_VERSION }}  -path ./build -p1 | tee clang-tidy.out
+          git diff -U0  HEAD~ HEAD | /usr/lib/llvm-${{ env.CLANG_VERSION }}/share/clang/clang-tidy-diff.py -clang-tidy-binary clang-tidy-${{ env.CLANG_VERSION }}  -path ./build -p1 | tee clang-tidy.out
           echo "::remove-matcher owner=clang::"
         shell: bash
       - name: Generate Summary


### PR DESCRIPTION
It used `git diff -U0 HEAD HEAD~`, which is the inversion of the last commit, to run the lint on. This seems to be a mistake, because the changes of the pull request as a whole are to be linted, and not an inversion of it.

This commit changes the git diff command to output the difference from pull request's base branch to PR's HEAD.

---8<---

I haven't tested this change on real Github Actions - it's a speculative change, please check.