### PR TITLE
[deb] Add trixie to release package

### DIFF
--- a/ci/cvmfs-release/deb.sh
+++ b/ci/cvmfs-release/deb.sh
@@ -17,27 +17,35 @@ fi
 
 CVMFS_SOURCE_LOCATION="$1"
 CVMFS_RESULT_LOCATION="$2"
+CVMFS_BUILD_LOCATION="$2/build/cvmfs-release"
+mkdir -p $CVMFS_BUILD_LOCATION
+
 
 # sanity checks
-[ ! -d ${CVMFS_SOURCE_LOCATION}/debian ]   || die "source directory seemed to be built before (${CVMFS_SOURCE_LOCATION}/debian exists)"
-[ ! -f ${CVMFS_SOURCE_LOCATION}/Makefile ] || die "source directory seemed to be built before (${CVMFS_SOURCE_LOCATION}/Makefile exists)"
+[ ! -d ${CVMFS_BUILD_LOCATION}/debian ]   || die "source directory seemed to be built before (${CVMFS_BUILD_LOCATION}/debian exists)"
+[ ! -f ${CVMFS_BUILD_LOCATION}/Makefile ] || die "source directory seemed to be built before (${CVMFS_BUILD_LOCATION}/Makefile exists)"
 
 echo "preparing source directory for the build ($config_package)..."
+
+#TODO: adapt Makefile, copy only .list files
+cp -r $CVMFS_SOURCE_LOCATION/packaging $CVMFS_BUILD_LOCATION 
+
 cp -rv ${CVMFS_SOURCE_LOCATION}/packaging/debian/cvmfs-release \
-       ${CVMFS_SOURCE_LOCATION}/debian
+       ${CVMFS_BUILD_LOCATION}/debian
 cp -v ${CVMFS_SOURCE_LOCATION}/packaging/debian/cvmfs-release/Makefile \
-      ${CVMFS_SOURCE_LOCATION}/Makefile
+      ${CVMFS_BUILD_LOCATION}/Makefile
 
 echo "switching to the debian source directory..."
-cd ${CVMFS_SOURCE_LOCATION}/debian
+cd ${CVMFS_BUILD_LOCATION}/debian
 
 echo "running the debian package build..."
 debuild --no-tgz-check -us -uc # -us -uc == skip signing
-mv ${CVMFS_SOURCE_LOCATION}/../cvmfs-release_* ${CVMFS_RESULT_LOCATION}/
+mv ${CVMFS_BUILD_LOCATION}/../cvmfs-release_* ${CVMFS_RESULT_LOCATION}/
+
+
+echo "cleaning up..."
+rm -fR ${CVMFS_BUILD_LOCATION}/debian
+rm -f  ${CVMFS_BUILD_LOCATION}/Makefile
 
 echo "switching back to the source directory..."
 cd ${CVMFS_SOURCE_LOCATION}
-
-echo "cleaning up..."
-rm -fR ${CVMFS_SOURCE_LOCATION}/debian
-rm -f  ${CVMFS_SOURCE_LOCATION}/Makefile

--- a/packaging/debian/cernvm.list.trixie
+++ b/packaging/debian/cernvm.list.trixie
@@ -1,0 +1,2 @@
+deb http://cvmrepo.s3.cern.ch/cvmrepo/apt trixie-prod main
+# deb http://cvmrepo.s3.cern.ch/cvmrepo/apt trixie-testing main

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -1,4 +1,3 @@
-
 cvmfs-release (4.6-1) lucid; urgency=low
 
   * Add Debian 13 "trixie"

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -1,3 +1,8 @@
+
+cvmfs-release (4.6-1) lucid; urgency=low
+
+  * Add Debian 13 "trixie"
+
 cvmfs-release (4.5-1) lucid; urgency=low
 
   * Avoid dependency on lsb-release

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -2,6 +2,8 @@ cvmfs-release (4.6-1) lucid; urgency=low
 
   * Add Debian 13 "trixie"
 
+ -- Valentin Volkl <vavolkl@cern.ch>  Wed, 11 Jun 2025 13:20:00 +0200
+
 cvmfs-release (4.5-1) lucid; urgency=low
 
   * Avoid dependency on lsb-release

--- a/packaging/debian/cvmfs-release/postinst
+++ b/packaging/debian/cvmfs-release/postinst
@@ -21,6 +21,7 @@ set -e
 case "$1" in
     configure)
 	codename=$(env -i sh -c '. /etc/os-release; echo $VERSION_CODENAME')
+	ID=$(env -i sh -c '. /etc/os-release; echo $ID')
 	repolist=/usr/share/cvmfs-release/cernvm.list.${codename}
 	mkdir -p /etc/apt/sources.list.d
 	if [ -f $repolist ]; then
@@ -28,19 +29,26 @@ case "$1" in
 	else
 		version_major=$(env -i sh -c '. /etc/os-release; echo $VERSION_ID' | cut -d. -f1)
 		fallback_release=
-		if [ $version_major -ge 22 ]; then
-			echo "Warning: this distribution is not supported. Using Ubuntu 22.04 packages as fallback."
-			fallback_release=jammy
-		elif [ $version_major -ge 20 ]; then
-			echo "Warning: this distribution is not supported. Using Ubuntu 20.04 packages as fallback."
-			fallback_release=focal
-		elif [ $version_major -ge 18 ]; then
-			echo "Warning: this distribution is not supported. Using Ubuntu 18.04 packages as fallback."
-			fallback_release=bionic
-		else
-			echo "Warning: this distribution is not supported. Using Ubuntu 16.04 packages as fallback."
-			fallback_release=xenial
-		fi
+    if [ "$ID" = "Ubuntu" ]; then
+      if [ $version_major -ge 22 ]; then
+        echo "Warning: this distribution is not supported. Using Ubuntu 22.04 packages as fallback."
+        fallback_release=jammy
+      elif [ $version_major -ge 20 ]; then
+        echo "Warning: this distribution is not supported. Using Ubuntu 20.04 packages as fallback."
+        fallback_release=focal
+      elif [ $version_major -ge 18 ]; then
+        echo "Warning: this distribution is not supported. Using Ubuntu 18.04 packages as fallback."
+        fallback_release=bionic
+      else
+        echo "Warning: this distribution is not supported. Using Ubuntu 16.04 packages as fallback."
+        fallback_release=xenial
+      fi
+    else
+      # debian
+      echo "Warning: this distribution is not supported. Using Debian bookworm packages as fallback."
+      fallback_release=bookworm
+    fi
+    
 		ln -f -s /usr/share/cvmfs-release/cernvm.list.$fallback_release \
 	        /etc/apt/sources.list.d/cernvm.list
 	fi


### PR DESCRIPTION
* Adds a list file for Debian 13 "Trixie"
* Fixes the postinstall logic that would mix up debian and ubuntu versions, using the oldest ubuntu repo as fallback for debian
* updates the build_package script to not use the source directory for build products