### PR TITLE
Have premount check for -oro instead of !-orw to determine readonly

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -926,7 +926,7 @@ int FuseMain(int argc, char *argv[]) {
                                      ",default_permissions" : "",
       MatchFuseOption(mount_options, "allow_other") ? ",allow_other" : "");
     unsigned long flags = MS_NOSUID | MS_NODEV | MS_RELATIME;
-    if (!MatchFuseOption(mount_options, "rw")) {
+    if (MatchFuseOption(mount_options, "ro")) {
       flags |= MS_RDONLY;
     }
     if (mount("cvmfs2", mount_point_->c_str(), "fuse", flags, opts) == -1) {

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -926,6 +926,9 @@ int FuseMain(int argc, char *argv[]) {
                                      ",default_permissions" : "",
       MatchFuseOption(mount_options, "allow_other") ? ",allow_other" : "");
     unsigned long flags = MS_NOSUID | MS_NODEV | MS_RELATIME;
+    // Note that during the handling of the `CVMFS_MOUNT_RW` option, we ensure that
+    // at least one of `rw` or `ro` is part of the mount option string (we won't have both unset).
+    // If both `rw` and `ro` are set, the read-only option takes precedence.
     if (MatchFuseOption(mount_options, "ro")) {
       flags |= MS_RDONLY;
     }


### PR DESCRIPTION
When doing premount look for the "-oro" fuse option instead of a lack of "-orw".  Apparently both are being included.  This was causing the mount to be done as read-write instead of read-only, and on Ubuntu 24 inside a docker container it ended up with a different error from the `futimes()` system call that julia was apparently not checking for.

- Fixes #3868