### PR TITLE
Run clang-format again on codebase

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -79,6 +79,7 @@ jobs:
                 -j 4 \
                 -extra-arg=-I${PWD}/build/cvmfs  \
                 -extra-arg=-I${PWD}/test/common  \
+                -extra-arg=-DCVMFS_USE_LIBFUSE=3  \
                 -allow-no-checks \
                 | tee clang-tidy.out
           echo "::remove-matcher owner=clang::"

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -79,7 +79,7 @@ jobs:
                 -j 4 \
                 -extra-arg=-I${PWD}/build/cvmfs  \
                 -extra-arg=-I${PWD}/test/common  \
-                -- --allow-no-checks \
+                -allow-no-checks \
                 | tee clang-tidy.out
           echo "::remove-matcher owner=clang::"
         shell: bash

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -77,9 +77,9 @@ jobs:
                -clang-tidy-binary clang-tidy-${{ env.CLANG_VERSION }}  \
                 -path ./build -p1 \
                 -j 4 \
-                --allow-no-checks \
                 -extra-arg=-I${PWD}/build/cvmfs  \
                 -extra-arg=-I${PWD}/test/common  \
+                -- --allow-no-checks \
                 | tee clang-tidy.out
           echo "::remove-matcher owner=clang::"
         shell: bash

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -77,6 +77,7 @@ jobs:
                -clang-tidy-binary clang-tidy-${{ env.CLANG_VERSION }}  \
                 -path ./build -p1 \
                 -j 4 \
+                --allow-no-checks \
                 -extra-arg=-I${PWD}/build/cvmfs  \
                 -extra-arg=-I${PWD}/test/common  \
                 | tee clang-tidy.out

--- a/cvmfs/acl.cc
+++ b/cvmfs/acl.cc
@@ -4,12 +4,12 @@
 
 #include "acl.h"
 
+#include <string.h>
+
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <vector>
-#include <algorithm>
-
-#include <string.h>
 
 #include "util/posix.h"
 
@@ -17,26 +17,26 @@ using namespace std;  // NOLINT
 
 #ifdef COMPARE_TO_LIBACL
 #include "acl/libacl.h"
-#else // COMPARE_TO_LIBACL
+#else  // COMPARE_TO_LIBACL
 
 // ACL permission bits
-#define ACL_READ (0x04)
-#define ACL_WRITE (0x02)
-#define ACL_EXECUTE (0x01)
+#define ACL_READ          (0x04)
+#define ACL_WRITE         (0x02)
+#define ACL_EXECUTE       (0x01)
 
 // ACL tag types
 #define ACL_UNDEFINED_TAG (0x00)
-#define ACL_USER_OBJ (0x01)
-#define ACL_USER (0x02)
-#define ACL_GROUP_OBJ (0x04)
-#define ACL_GROUP (0x08)
-#define ACL_MASK (0x10)
-#define ACL_OTHER (0x20)
+#define ACL_USER_OBJ      (0x01)
+#define ACL_USER          (0x02)
+#define ACL_GROUP_OBJ     (0x04)
+#define ACL_GROUP         (0x08)
+#define ACL_MASK          (0x10)
+#define ACL_OTHER         (0x20)
 
 // ACL qualifier constants
-#define ACL_UNDEFINED_ID ((id_t) - 1)
+#define ACL_UNDEFINED_ID  ((id_t) - 1)
 
-#endif // COMPARE_TO_LIBACL
+#endif  // COMPARE_TO_LIBACL
 
 #define ACL_EA_VERSION 0x0002
 
@@ -47,7 +47,7 @@ struct acl_ea_entry {
   u_int32_t e_id;
 
   // implements sorting compatible with libacl
-  bool operator<(const acl_ea_entry& other) const {
+  bool operator<(const acl_ea_entry &other) const {
     if (e_tag != other.e_tag) {
       return e_tag < other.e_tag;
     }
@@ -60,8 +60,8 @@ struct acl_ea_header {
   acl_ea_entry a_entries[0];
 };
 
-static int acl_from_text_to_string_entries(const string &acl_string, vector<string> &string_entries)
-{
+static int acl_from_text_to_string_entries(const string &acl_string,
+                                           vector<string> &string_entries) {
   std::size_t entry_pos = 0;
   while (entry_pos != string::npos) {
     size_t entry_length;
@@ -107,8 +107,7 @@ static int acl_from_text_to_string_entries(const string &acl_string, vector<stri
   return 0;
 }
 
-static int acl_parms_from_text(const string &str, u_int16_t *perms)
-{
+static int acl_parms_from_text(const string &str, u_int16_t *perms) {
   // Currently unsupported syntax features found in setfacl:
   // - X (capital x)
   // - numeric syntax
@@ -116,19 +115,26 @@ static int acl_parms_from_text(const string &str, u_int16_t *perms)
 
   *perms = 0;
   for (const char &c : str) {
-    switch(c) {
-      case 'r': *perms |= ACL_READ; break;
-      case 'w': *perms |= ACL_WRITE; break;
-      case 'x': *perms |= ACL_EXECUTE; break;
-      case '-': break;
-      default: return EINVAL;
+    switch (c) {
+      case 'r':
+        *perms |= ACL_READ;
+        break;
+      case 'w':
+        *perms |= ACL_WRITE;
+        break;
+      case 'x':
+        *perms |= ACL_EXECUTE;
+        break;
+      case '-':
+        break;
+      default:
+        return EINVAL;
     }
   }
   return 0;
 }
 
-static int acl_entry_from_text(const string &str, acl_ea_entry &entry)
-{
+static int acl_entry_from_text(const string &str, acl_ea_entry &entry) {
   // break down to 3 fields by ':'
   // type:qualifier:permissions according to terminology
   // e_tag:e_id:e_perm are acl_ea_entry field names
@@ -162,7 +168,7 @@ static int acl_entry_from_text(const string &str, acl_ea_entry &entry)
   if (qualifier.empty()) {
     entry.e_id = ACL_UNDEFINED_ID;
   } else {
-    char* at_null_terminator_if_number;
+    char *at_null_terminator_if_number;
     long number = strtol(qualifier.c_str(), &at_null_terminator_if_number, 10);
     if (*at_null_terminator_if_number != '\0') {
       bool ok;
@@ -197,8 +203,7 @@ static int acl_entry_from_text(const string &str, acl_ea_entry &entry)
   return 0;
 }
 
-static bool acl_valid_builtin(const vector<acl_ea_entry> &entries)
-{
+static bool acl_valid_builtin(const vector<acl_ea_entry> &entries) {
   // From man acl_valid:
   // The three required entries ACL_USER_OBJ, ACL_GROUP_OBJ, and ACL_OTHER must
   // exist exactly once in the ACL.
@@ -211,7 +216,9 @@ static bool acl_valid_builtin(const vector<acl_ea_entry> &entries)
   // The user identifiers must be unique among all entries of type ACL_USER.
   // The group identifiers must be unique among all entries of type ACL_GROUP.
 
-  bool types_met[ACL_OTHER + 1] = {false, };
+  bool types_met[ACL_OTHER + 1] = {
+      false,
+  };
 
   for (auto entry_it = entries.begin(); entry_it != entries.end(); ++entry_it) {
     const acl_ea_entry &e = *entry_it;
@@ -237,7 +244,8 @@ static bool acl_valid_builtin(const vector<acl_ea_entry> &entries)
         assert(false);
     }
   }
-  if (!(types_met[ACL_USER_OBJ] && types_met[ACL_GROUP_OBJ] && types_met[ACL_OTHER])) {
+  if (!(types_met[ACL_USER_OBJ] && types_met[ACL_GROUP_OBJ]
+        && types_met[ACL_OTHER])) {
     return false;
   }
   if ((types_met[ACL_USER] || types_met[ACL_GROUP]) && !types_met[ACL_MASK]) {
@@ -247,8 +255,8 @@ static bool acl_valid_builtin(const vector<acl_ea_entry> &entries)
   return true;
 }
 
-int acl_from_text_to_xattr_value(const string& textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode)
-{
+int acl_from_text_to_xattr_value(const string &textual_acl, char *&o_binary_acl,
+                                 size_t &o_size, bool &o_equiv_mode) {
   int ret;
 
   o_equiv_mode = true;
@@ -262,7 +270,8 @@ int acl_from_text_to_xattr_value(const string& textual_acl, char *&o_binary_acl,
 
   // get individual entries in structural form
   vector<acl_ea_entry> entries;
-  for (auto string_it = string_entries.begin(); string_it != string_entries.end(); ++string_it) {
+  for (auto string_it = string_entries.begin();
+       string_it != string_entries.end(); ++string_it) {
     acl_ea_entry entry;
     ret = acl_entry_from_text(*string_it, entry);
     if (ret) {
@@ -291,14 +300,15 @@ int acl_from_text_to_xattr_value(const string& textual_acl, char *&o_binary_acl,
 
   // get one big buffer with all the entries in the "on-disk" xattr format
   size_t const acl_entry_count = entries.size();
-  size_t const buf_size = sizeof(acl_ea_header) + (acl_entry_count * sizeof(acl_ea_entry));
-  char *buf = static_cast<char*>(malloc(buf_size));
+  size_t const buf_size = sizeof(acl_ea_header)
+                          + (acl_entry_count * sizeof(acl_ea_entry));
+  char *buf = static_cast<char *>(malloc(buf_size));
   if (!buf) {
     return ENOMEM;
   }
-  acl_ea_header* header = reinterpret_cast<acl_ea_header*>(buf);
+  acl_ea_header *header = reinterpret_cast<acl_ea_header *>(buf);
   header->a_version = htole32(ACL_EA_VERSION);
-  acl_ea_entry* ext_entry = reinterpret_cast<acl_ea_entry*>(header + 1);
+  acl_ea_entry *ext_entry = reinterpret_cast<acl_ea_entry *>(header + 1);
   for (auto entry_it = entries.begin(); entry_it != entries.end(); ++entry_it) {
     *ext_entry = *entry_it;
     ext_entry += 1;
@@ -310,9 +320,11 @@ int acl_from_text_to_xattr_value(const string& textual_acl, char *&o_binary_acl,
 }
 
 #ifdef COMPARE_TO_LIBACL
-int acl_from_text_to_xattr_value_libacl(const string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode)
-{
-  acl_t acl = acl_from_text(textual_acl.c_str());  // Convert ACL string to acl_t object
+int acl_from_text_to_xattr_value_libacl(const string textual_acl,
+                                        char *&o_binary_acl, size_t &o_size,
+                                        bool &o_equiv_mode) {
+  acl_t acl = acl_from_text(
+      textual_acl.c_str());  // Convert ACL string to acl_t object
   if (!acl) {
     return EINVAL;
   }
@@ -336,16 +348,19 @@ int acl_from_text_to_xattr_value_libacl(const string textual_acl, char *&o_binar
   return 0;
 }
 
-int acl_from_text_to_xattr_value_both_impl(const string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode)
-{
+int acl_from_text_to_xattr_value_both_impl(const string textual_acl,
+                                           char *&o_binary_acl, size_t &o_size,
+                                           bool &o_equiv_mode) {
   struct impl_result {
     int ret;
     size_t binary_size;
     char *binary_acl;
     bool equiv_mode;
   } b, l;
-  b.ret = acl_from_text_to_xattr_value(textual_acl, b.binary_acl, b.binary_size, b.equiv_mode);
-  l.ret = acl_from_text_to_xattr_value_libacl(textual_acl, l.binary_acl, l.binary_size, l.equiv_mode);
+  b.ret = acl_from_text_to_xattr_value(textual_acl, b.binary_acl, b.binary_size,
+                                       b.equiv_mode);
+  l.ret = acl_from_text_to_xattr_value_libacl(textual_acl, l.binary_acl,
+                                              l.binary_size, l.equiv_mode);
   assert(b.ret == l.ret);
   if (!l.ret) {
     assert(b.binary_size == l.binary_size);
@@ -358,4 +373,4 @@ int acl_from_text_to_xattr_value_both_impl(const string textual_acl, char *&o_bi
   o_equiv_mode = b.equiv_mode;
   return b.ret;
 }
-#endif // COMPARE_TO_LIBACL
+#endif  // COMPARE_TO_LIBACL

--- a/cvmfs/acl.cc
+++ b/cvmfs/acl.cc
@@ -271,7 +271,8 @@ int acl_from_text_to_xattr_value(const string &textual_acl, char *&o_binary_acl,
   // get individual entries in structural form
   vector<acl_ea_entry> entries;
   for (auto string_it = string_entries.begin();
-       string_it != string_entries.end(); ++string_it) {
+       string_it != string_entries.end();
+       ++string_it) {
     acl_ea_entry entry;
     ret = acl_entry_from_text(*string_it, entry);
     if (ret) {

--- a/cvmfs/acl.h
+++ b/cvmfs/acl.h
@@ -7,14 +7,20 @@
 
 #include <inttypes.h>
 #include <stddef.h>
+
 #include <string>
 
-/* Takes textual ACL, outputs binary array fit to be a value of system.posix_acl_access */
-int acl_from_text_to_xattr_value(const std::string& textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode);
+/* Takes textual ACL, outputs binary array fit to be a value of
+ * system.posix_acl_access */
+int acl_from_text_to_xattr_value(const std::string &textual_acl,
+                                 char *&o_binary_acl, size_t &o_size,
+                                 bool &o_equiv_mode);
 
-//#define COMPARE_TO_LIBACL
+// #define COMPARE_TO_LIBACL
 #ifdef COMPARE_TO_LIBACL
-int acl_from_text_to_xattr_value_both_impl(const std::string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode);
-#endif // COMPARE_TO_LIBACL
+int acl_from_text_to_xattr_value_both_impl(const std::string textual_acl,
+                                           char *&o_binary_acl, size_t &o_size,
+                                           bool &o_equiv_mode);
+#endif  // COMPARE_TO_LIBACL
 
 #endif  // CVMFS_ACL_H_

--- a/cvmfs/authz/authz_curl.cc
+++ b/cvmfs/authz/authz_curl.cc
@@ -131,11 +131,11 @@ bool AuthzAttachment::ConfigureSciTokenCurl(CURL *curl_handle,
   // The CURLOPT_XOAUTH2_BEARER option only works "IMAP, POP3 and SMTP"
   // protocols. Not HTTPS
   const std::string auth_preamble = "Authorization: Bearer ";
-  const std::string auth_header =
-      auth_preamble + static_cast<char *>(bearer->token);
+  const std::string auth_header = auth_preamble
+                                  + static_cast<char *>(bearer->token);
   bearer->list = curl_slist_append(bearer->list, auth_header.c_str());
-  const int retval =
-      curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, bearer->list);
+  const int retval = curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER,
+                                      bearer->list);
 
   if (retval != CURLE_OK) {
     LogCvmfs(kLogAuthz, kLogSyslogErr, "Failed to set Oauth2 Bearer Token");
@@ -194,8 +194,8 @@ bool AuthzAttachment::ConfigureCurlHandle(CURL *curl_handle,
   }
 
 
-  int retval = curl_easy_setopt(
-      curl_handle, CURLOPT_SSL_CTX_FUNCTION, CallbackSslCtx);
+  int retval = curl_easy_setopt(curl_handle, CURLOPT_SSL_CTX_FUNCTION,
+                                CallbackSslCtx);
   if (retval != CURLE_OK) {
     LogCvmfs(kLogAuthz, kLogDebug, "cannot configure curl ssl callback");
     return false;

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -602,8 +602,8 @@ int64_t ExternalCacheManager::Pread(int fd,
   transport_.FillMsgHash(id, &object_id);
   uint64_t nbytes = 0;
   while (nbytes < size) {
-    const uint64_t batch_size =
-        std::min(size - nbytes, static_cast<uint64_t>(max_object_size_));
+    const uint64_t batch_size = std::min(
+        size - nbytes, static_cast<uint64_t>(max_object_size_));
     cvmfs::MsgReadReq msg_read;
     msg_read.set_session_id(session_id_);
     msg_read.set_req_id(NextRequestId());

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -59,8 +59,8 @@ SessionCtx::~SessionCtx() {
 SessionCtx *SessionCtx::GetInstance() {
   if (instance_ == NULL) {
     instance_ = new SessionCtx();
-    const int retval =
-        pthread_key_create(&instance_->thread_local_storage_, TlsDestructor);
+    const int retval = pthread_key_create(&instance_->thread_local_storage_,
+                                          TlsDestructor);
     assert(retval == 0);
   }
 
@@ -121,7 +121,8 @@ void SessionCtx::TlsDestructor(void *data) {
   for (vector<ThreadLocalStorage *>::iterator
            i = instance_->tls_blocks_.begin(),
            iEnd = instance_->tls_blocks_.end();
-       i != iEnd; ++i) {
+       i != iEnd;
+       ++i) {
     if ((*i) == tls) {
       instance_->tls_blocks_.erase(i);
       break;
@@ -215,8 +216,8 @@ void CachePlugin::HandleBreadcrumbStore(cvmfs::MsgBreadcrumbStoreReq *msg_req,
     } else {
       breadcrumb.revision = 0;
     }
-    const cvmfs::EnumStatus status =
-        StoreBreadcrumb(msg_req->breadcrumb().fqrn(), breadcrumb);
+    const cvmfs::EnumStatus status = StoreBreadcrumb(
+        msg_req->breadcrumb().fqrn(), breadcrumb);
     msg_reply.set_status(status);
   }
   transport->SendFrame(&frame_send);
@@ -417,8 +418,8 @@ void CachePlugin::HandleRead(cvmfs::MsgReadReq *msg_req,
 #else
   unsigned char buffer[size];
 #endif
-  const cvmfs::EnumStatus status =
-      Pread(object_id, msg_req->offset(), &size, buffer);
+  const cvmfs::EnumStatus status = Pread(object_id, msg_req->offset(), &size,
+                                         buffer);
   msg_reply.set_status(status);
   if (status == cvmfs::STATUS_OK) {
     frame_send.set_attachment(buffer, size);
@@ -447,8 +448,8 @@ void CachePlugin::HandleRefcount(cvmfs::MsgRefcountReq *msg_req,
                     "malformed hash received from client");
     msg_reply.set_status(cvmfs::STATUS_MALFORMED);
   } else {
-    const cvmfs::EnumStatus status =
-        ChangeRefcount(object_id, msg_req->change_by());
+    const cvmfs::EnumStatus status = ChangeRefcount(object_id,
+                                                    msg_req->change_by());
     msg_reply.set_status(status);
     if ((status != cvmfs::STATUS_OK) && (status != cvmfs::STATUS_NOENTRY)) {
       LogSessionError(msg_req->session_id(), status,
@@ -479,8 +480,8 @@ bool CachePlugin::HandleRequest(int fd_con) {
     HandleHandshake(msg_req, &transport);
   } else if (msg_typed->GetTypeName() == "cvmfs.MsgQuit") {
     cvmfs::MsgQuit *msg_req = reinterpret_cast<cvmfs::MsgQuit *>(msg_typed);
-    const map<uint64_t, SessionInfo>::const_iterator iter =
-        sessions_.find(msg_req->session_id());
+    const map<uint64_t, SessionInfo>::const_iterator iter = sessions_.find(
+        msg_req->session_id());
     if (iter != sessions_.end()) {
       free(iter->second.reponame);
       free(iter->second.client_instance);
@@ -735,8 +736,8 @@ bool CachePlugin::Listen(const string &locator) {
 
 void CachePlugin::LogSessionInfo(uint64_t session_id, const string &msg) {
   string session_str("unidentified client (" + StringifyInt(session_id) + ")");
-  const map<uint64_t, SessionInfo>::const_iterator iter =
-      sessions_.find(session_id);
+  const map<uint64_t, SessionInfo>::const_iterator iter = sessions_.find(
+      session_id);
   if (iter != sessions_.end()) {
     session_str = iter->second.name;
   }
@@ -749,8 +750,8 @@ void CachePlugin::LogSessionError(uint64_t session_id,
                                   cvmfs::EnumStatus status,
                                   const std::string &msg) {
   string session_str("unidentified client (" + StringifyInt(session_id) + ")");
-  const map<uint64_t, SessionInfo>::const_iterator iter =
-      sessions_.find(session_id);
+  const map<uint64_t, SessionInfo>::const_iterator iter = sessions_.find(
+      session_id);
   if (iter != sessions_.end()) {
     session_str = iter->second.name;
   }
@@ -809,8 +810,8 @@ void *CachePlugin::MainProcessRequests(void *data) {
     if (watch_fds[1].revents) {
       struct sockaddr_un remote;
       socklen_t socket_size = sizeof(remote);
-      const int fd_con =
-          accept(watch_fds[1].fd, (struct sockaddr *)&remote, &socket_size);
+      const int fd_con = accept(watch_fds[1].fd, (struct sockaddr *)&remote,
+                                &socket_size);
       if (fd_con < 0) {
         LogCvmfs(kLogCache, kLogSyslogWarn | kLogDebug,
                  "failed to establish connection (%d)", errno);
@@ -872,8 +873,8 @@ void CachePlugin::NotifySupervisor(char signal) {
 
 void CachePlugin::ProcessRequests(unsigned num_workers) {
   num_workers_ = num_workers;
-  const int retval =
-      pthread_create(&thread_io_, NULL, MainProcessRequests, this);
+  const int retval = pthread_create(&thread_io_, NULL, MainProcessRequests,
+                                    this);
   assert(retval == 0);
   NotifySupervisor(CacheTransport::kReadyNotification);
   atomic_cas32(&running_, 0, 1);

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -179,8 +179,8 @@ class CachePlugin {
     SessionCtxGuard(uint64_t session_id, CachePlugin *plugin) {
       char *reponame = NULL;
       char *client_instance = NULL;
-      const std::map<uint64_t, SessionInfo>::const_iterator iter =
-          plugin->sessions_.find(session_id);
+      const std::map<uint64_t, SessionInfo>::const_iterator
+          iter = plugin->sessions_.find(session_id);
       if (iter != plugin->sessions_.end()) {
         reponame = iter->second.reponame;
         client_instance = iter->second.client_instance;

--- a/cvmfs/cache_plugin/cvmfs_cache_null.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_null.cc
@@ -102,8 +102,8 @@ static int null_pread(struct cvmcache_hash *id,
   string data = storage[h].data;
   if (offset > data.length())
     return CVMCACHE_STATUS_OUTOFBOUNDS;
-  const unsigned nbytes =
-      std::min(*size, static_cast<uint32_t>(data.length() - offset));
+  const unsigned nbytes = std::min(
+      *size, static_cast<uint32_t>(data.length() - offset));
   memcpy(buffer, data.data() + offset, nbytes);
   *size = nbytes;
   return CVMCACHE_STATUS_OK;
@@ -265,8 +265,8 @@ static int null_breadcrumb_store(const char *fqrn,
 
 static int null_breadcrumb_load(const char *fqrn,
                                 cvmcache_breadcrumb *breadcrumb) {
-  const map<std::string, cvmcache_breadcrumb>::const_iterator itr =
-      breadcrumbs.find(fqrn);
+  const map<std::string, cvmcache_breadcrumb>::const_iterator
+      itr = breadcrumbs.find(fqrn);
   if (itr == breadcrumbs.end())
     return CVMCACHE_STATUS_NOENTRY;
   *breadcrumb = itr->second;

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -131,7 +131,8 @@ Settings GetSettings(cvmcache_option_map *options) {
 }
 
 uint32_t cvmcache_hash_hasher(const struct cvmcache_hash &key) {
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 uint32_t uint64_hasher(const uint64_t &key) { return (uint32_t)key; }
@@ -215,8 +216,8 @@ int posix_pread(struct cvmcache_hash *id, uint64_t offset, uint32_t *size,
   if (offset > object.size) {
     return CVMCACHE_STATUS_OUTOFBOUNDS;
   }
-  const int64_t bytes_read =
-      g_cache_mgr->Pread(object.fd, buffer, *size, offset);
+  const int64_t bytes_read = g_cache_mgr->Pread(object.fd, buffer, *size,
+                                                offset);
   if (bytes_read < 0) {
     return CVMCACHE_STATUS_IOERR;
   }
@@ -259,8 +260,8 @@ int posix_write_txn(uint64_t txn_id, unsigned char *buffer, uint32_t size) {
   if (!g_transactions->Lookup(txn_id, &transaction)) {
     return CVMCACHE_STATUS_NOENTRY;
   }
-  const int64_t bytes_written =
-      g_cache_mgr->Write(buffer, size, transaction.txn);
+  const int64_t bytes_written = g_cache_mgr->Write(buffer, size,
+                                                   transaction.txn);
   if ((bytes_written >= 0) && (static_cast<uint32_t>(bytes_written) == size)) {
     return CVMCACHE_STATUS_OK;
   } else {

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -131,7 +131,7 @@ Settings GetSettings(cvmcache_option_map *options) {
 }
 
 uint32_t cvmcache_hash_hasher(const struct cvmcache_hash &key) {
-  return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 uint32_t uint64_hasher(const uint64_t &key) { return (uint32_t)key; }

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -144,7 +144,7 @@ static inline uint32_t hasher_uint64(const uint64_t &key) {
 }
 
 static inline uint32_t hasher_any(const ComparableHash &key) {
-  return (uint32_t) * (reinterpret_cast<const uint32_t *>(&key.hash));
+  return (uint32_t)*(reinterpret_cast<const uint32_t *>(&key.hash));
 }
 
 }  // anonymous namespace
@@ -242,8 +242,8 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
     assert(retval);
     if (offset > object->size_data)
       return CVMCACHE_STATUS_OUTOFBOUNDS;
-    const unsigned nbytes =
-        std::min(*size, static_cast<uint32_t>(object->size_data - offset));
+    const unsigned nbytes = std::min(
+        *size, static_cast<uint32_t>(object->size_data - offset));
     memcpy(buffer, object->GetData() + offset, nbytes);
     *size = nbytes;
     return CVMCACHE_STATUS_OK;
@@ -265,9 +265,8 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
     object_header.type = info->type;
     object_header.id = *id;
 
-    const uint32_t total_size = sizeof(object_header) +
-                                object_header.size_desc +
-                                object_header.size_data;
+    const uint32_t total_size = sizeof(object_header) + object_header.size_desc
+                                + object_header.size_data;
     Me()->TryFreeSpace(total_size);
     ObjectHeader *allocd_object = reinterpret_cast<ObjectHeader *>(
         Me()->storage_->Allocate(total_size, &object_header,
@@ -294,9 +293,9 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
     if ((size - txn_object->neg_nbytes_written) > txn_object->size_data) {
       const uint32_t current_size = Me()->storage_->GetSize(txn_object);
       const uint32_t header_size = current_size - txn_object->size_data;
-      const uint32_t new_size =
-          std::max(header_size + size - txn_object->neg_nbytes_written,
-                   uint32_t(current_size * kObjectExpandFactor));
+      const uint32_t new_size = std::max(
+          header_size + size - txn_object->neg_nbytes_written,
+          uint32_t(current_size * kObjectExpandFactor));
       const bool did_compact = Me()->TryFreeSpace(new_size);
       if (did_compact) {
         retval = Me()->transactions_.Lookup(txn_id, &txn_object);
@@ -445,8 +444,8 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
 
   static int ram_breadcrumb_load(const char *fqrn,
                                  cvmcache_breadcrumb *breadcrumb) {
-    const map<std::string, cvmcache_breadcrumb>::const_iterator itr =
-        Me()->breadcrumbs_.find(fqrn);
+    const map<std::string, cvmcache_breadcrumb>::const_iterator
+        itr = Me()->breadcrumbs_.find(fqrn);
     if (itr == Me()->breadcrumbs_.end())
       return CVMCACHE_STATUS_NOENTRY;
     *breadcrumb = itr->second;
@@ -478,10 +477,10 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
     transactions_.Init(64, uint64_t(-1), hasher_uint64);
     listings_.Init(8, uint64_t(-1), hasher_uint64);
 
-    const double slot_size =
-        lru::LruCache<ComparableHash, ObjectHeader *>::GetEntrySize();
-    const uint64_t num_slots =
-        uint64_t((heap_size * kSlotFraction) / (2.0 * slot_size));
+    const double slot_size = lru::LruCache<ComparableHash,
+                                           ObjectHeader *>::GetEntrySize();
+    const uint64_t num_slots = uint64_t((heap_size * kSlotFraction)
+                                        / (2.0 * slot_size));
     const unsigned mask_64 = ~((1 << 6) - 1);
 
     LogCvmfs(kLogCache, kLogDebug | kLogSyslog,
@@ -517,9 +516,9 @@ class PluginRamCache : public Callbackable<MallocHeap::BlockPtr> {
         return true;
     }
 
-    const uint64_t shrink_to =
-        std::min(storage_->capacity() - (bytes_required + 8),
-                 uint64_t(storage_->capacity() * kShrinkFactor));
+    const uint64_t shrink_to = std::min(
+        storage_->capacity() - (bytes_required + 8),
+        uint64_t(storage_->capacity() * kShrinkFactor));
     DoShrink(shrink_to);
     return true;
   }

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -144,7 +144,8 @@ static inline uint32_t hasher_uint64(const uint64_t &key) {
 }
 
 static inline uint32_t hasher_any(const ComparableHash &key) {
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(&key.hash)));
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(&key.hash)));
 }
 
 }  // anonymous namespace

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -144,7 +144,7 @@ static inline uint32_t hasher_uint64(const uint64_t &key) {
 }
 
 static inline uint32_t hasher_any(const ComparableHash &key) {
-  return (uint32_t)*(reinterpret_cast<const uint32_t *>(&key.hash));
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(&key.hash)));
 }
 
 }  // anonymous namespace

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -196,8 +196,8 @@ class ForwardCachePlugin : public CachePlugin {
     if (!(callbacks_.capabilities & CVMCACHE_CAP_LIST))
       return cvmfs::STATUS_NOSUPPORT;
 
-    const int result =
-        callbacks_.cvmcache_listing_begin(lst_id, ObjectType2CType(type));
+    const int result = callbacks_.cvmcache_listing_begin(
+        lst_id, ObjectType2CType(type));
     return static_cast<cvmfs::EnumStatus>(result);
   }
 
@@ -235,8 +235,8 @@ class ForwardCachePlugin : public CachePlugin {
       return cvmfs::STATUS_NOSUPPORT;
 
     cvmcache_breadcrumb c_breadcrumb;
-    const int result =
-        callbacks_.cvmcache_breadcrumb_load(fqrn.c_str(), &c_breadcrumb);
+    const int result = callbacks_.cvmcache_breadcrumb_load(fqrn.c_str(),
+                                                           &c_breadcrumb);
     if (result == CVMCACHE_STATUS_OK) {
       breadcrumb->catalog_hash = Chash2Cpphash(&c_breadcrumb.catalog_hash);
       breadcrumb->timestamp = c_breadcrumb.timestamp;
@@ -254,8 +254,8 @@ class ForwardCachePlugin : public CachePlugin {
     c_breadcrumb.catalog_hash = Cpphash2Chash(breadcrumb.catalog_hash);
     c_breadcrumb.timestamp = breadcrumb.timestamp;
     c_breadcrumb.revision = breadcrumb.revision;
-    const int result =
-        callbacks_.cvmcache_breadcrumb_store(fqrn.c_str(), &c_breadcrumb);
+    const int result = callbacks_.cvmcache_breadcrumb_store(fqrn.c_str(),
+                                                            &c_breadcrumb);
     return static_cast<cvmfs::EnumStatus>(result);
   }
 

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -380,8 +380,8 @@ int PosixCacheManager::Dup(int fd) {
 int PosixCacheManager::Flush(Transaction *transaction) {
   if (transaction->buf_pos == 0)
     return 0;
-  const int written =
-      write(transaction->fd, transaction->buffer, transaction->buf_pos);
+  const int written = write(transaction->fd, transaction->buffer,
+                            transaction->buf_pos);
   if (written < 0)
     return -errno;
   if (static_cast<unsigned>(written) != transaction->buf_pos) {
@@ -547,8 +547,8 @@ int PosixCacheManager::StartTxn(const shash::Any &id,
       const uint64_t cache_capacity = quota_mgr_->GetCapacity();
       assert(cache_capacity >= size);
       if ((cache_size + size) > cache_capacity) {
-        const uint64_t leave_size =
-            std::min(cache_capacity / 2, cache_capacity - size);
+        const uint64_t leave_size = std::min(cache_capacity / 2,
+                                             cache_capacity - size);
         quota_mgr_->Cleanup(leave_size);
       }
     }
@@ -637,8 +637,8 @@ int64_t PosixCacheManager::Write(const void *buf, uint64_t size, void *txn) {
       }
     }
     const uint64_t remaining = size - written;
-    const uint64_t space_in_buffer =
-        sizeof(transaction->buffer) - transaction->buf_pos;
+    const uint64_t space_in_buffer = sizeof(transaction->buffer)
+                                     - transaction->buf_pos;
     const uint64_t batch_size = std::min(remaining, space_in_buffer);
     memcpy(transaction->buffer + transaction->buf_pos, read_pos, batch_size);
     transaction->buf_pos += batch_size;

--- a/cvmfs/cache_stream.cc
+++ b/cvmfs/cache_stream.cc
@@ -55,8 +55,8 @@ class StreamingSink : public cvmfs::Sink {
     const uint64_t copy_offset = std::max(old_pos, window_offset_);
     const uint64_t inbuf_offset = copy_offset - old_pos;
     const uint64_t outbuf_offset = copy_offset - window_offset_;
-    const uint64_t copy_size =
-        std::min(sz - inbuf_offset, window_size_ - outbuf_offset);
+    const uint64_t copy_size = std::min(sz - inbuf_offset,
+                                        window_size_ - outbuf_offset);
 
     memcpy(reinterpret_cast<unsigned char *>(window_buf_) + outbuf_offset,
            reinterpret_cast<const unsigned char *>(buf) + inbuf_offset,
@@ -215,8 +215,8 @@ int64_t StreamingCacheManager::Stream(const FdInfo &info,
       perf::Inc(counters_->n_buffer_evicts);
       perf::Dec(counters_->n_buffer_objects);
     }
-    const RingBuffer::ObjectHandle_t handle =
-        buffer_->PushFront(object, nbytes_in_buffer);
+    const RingBuffer::ObjectHandle_t handle = buffer_->PushFront(
+        object, nbytes_in_buffer);
     buffered_objects_.Insert(info.object_id, handle);
     perf::Inc(counters_->n_buffer_objects);
   }
@@ -411,8 +411,8 @@ int StreamingCacheManager::DoRestoreState(void *data) {
 
   SavedState *state = reinterpret_cast<SavedState *>(data);
 
-  const int new_backing_root_fd =
-      cache_mgr_->RestoreState(-1, state->state_backing_cachemgr);
+  const int new_backing_root_fd = cache_mgr_->RestoreState(
+      -1, state->state_backing_cachemgr);
   fd_table_.AssignFrom(*state->fd_table);
 
   int new_root_fd = -1;

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -78,8 +78,8 @@ int TieredCacheManager::Open(const LabeledObject &object) {
   uint64_t remaining = size;
   uint64_t offset = 0;
   while (remaining > 0) {
-    const unsigned nbytes =
-        remaining > kCopyBufferSize ? kCopyBufferSize : remaining;
+    const unsigned nbytes = remaining > kCopyBufferSize ? kCopyBufferSize
+                                                        : remaining;
     int64_t result = lower_->Pread(fd2, &m_buffer[0], nbytes, offset);
     // The file we are reading is supposed to be exactly `size` bytes.
     if ((result < 0) || (result != nbytes)) {

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -451,8 +451,8 @@ void CacheTransport::SendData(void *message,
                               uint32_t msg_size,
                               void *attachment,
                               uint32_t att_size) {
-  const uint32_t total_size =
-      msg_size + att_size + ((att_size > 0) ? kInnerHeaderSize : 0);
+  const uint32_t total_size = msg_size + att_size
+                              + ((att_size > 0) ? kInnerHeaderSize : 0);
 
   assert(total_size > 0);
   assert(total_size <= kMaxMsgSize);

--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -593,8 +593,8 @@ inode_t Catalog::GetMangledInode(const uint64_t row_id,
   // Hardlinks are encoded in catalog-wide unique hard link group ids.
   // These ids must be resolved to actual inode relationships at runtime.
   if (hardlink_group > 0) {
-    const HardlinkGroupMap::const_iterator inode_iter =
-        hardlink_groups_.find(hardlink_group);
+    const HardlinkGroupMap::const_iterator inode_iter = hardlink_groups_.find(
+        hardlink_group);
 
     // Use cached entry if possible
     if (inode_iter == hardlink_groups_.end()) {

--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -31,11 +31,11 @@ inline void AppendLastEntry(catalog::DirectoryEntryList *entry_list) {
 
 inline bool IsSmaller(const catalog::DirectoryEntry &a,
                       const catalog::DirectoryEntry &b) {
-  const bool a_is_first =
-      (a.inode() == catalog::DirectoryEntryBase::kInvalidInode);
+  const bool a_is_first = (a.inode()
+                           == catalog::DirectoryEntryBase::kInvalidInode);
   const bool a_is_last = (a.inode() == kLastInode);
-  const bool b_is_first =
-      (b.inode() == catalog::DirectoryEntryBase::kInvalidInode);
+  const bool b_is_first = (b.inode()
+                           == catalog::DirectoryEntryBase::kInvalidInode);
   const bool b_is_last = (b.inode() == kLastInode);
 
   if (a_is_last || b_is_first)
@@ -194,8 +194,8 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString &path) {
     i_from++;
     i_to++;
 
-    const catalog::DirectoryEntryBase::Differences diff =
-        old_entry.CompareTo(new_entry);
+    const catalog::DirectoryEntryBase::Differences diff = old_entry.CompareTo(
+        new_entry);
     if ((diff == catalog::DirectoryEntryBase::Difference::kIdentical)
         && old_entry.IsNestedCatalogMountpoint()) {
       // Early recursion stop if nested catalogs are identical
@@ -216,8 +216,8 @@ void CatalogDiffTool<RoCatalogMgr>::DiffRec(const PathString &path) {
         new_catalog_mgr_->ListFileChunks(new_path, new_entry.hash_algorithm(),
                                          &chunks);
       }
-      const bool recurse =
-          ReportModification(old_path, old_entry, new_entry, xattrs, chunks);
+      const bool recurse = ReportModification(old_path, old_entry, new_entry,
+                                              xattrs, chunks);
       if (!recurse)
         continue;
     }

--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -8,6 +8,10 @@
 #include <algorithm>
 #include <string>
 
+// Only needed to let clang-tidy see the class definitions.
+// This would be an include loop if not for the header guard.
+#include "catalog_diff_tool.h"
+
 #include "catalog.h"
 #include "crypto/hash.h"
 #include "network/download.h"

--- a/cvmfs/catalog_diff_tool_impl.h
+++ b/cvmfs/catalog_diff_tool_impl.h
@@ -8,9 +8,11 @@
 #include <algorithm>
 #include <string>
 
+// clang-format off
 // Only needed to let clang-tidy see the class definitions.
 // This would be an include loop if not for the header guard.
 #include "catalog_diff_tool.h"
+// clang-format on
 
 #include "catalog.h"
 #include "crypto/hash.h"

--- a/cvmfs/catalog_downloader.cc
+++ b/cvmfs/catalog_downloader.cc
@@ -2,30 +2,31 @@
 
 int kCatalogDownloadMultiplier = 32;
 
-CatalogItem::CatalogItem(const shash::Any &hash) : hash_(hash) {}
+CatalogItem::CatalogItem(const shash::Any &hash) : hash_(hash) { }
 
 void TaskCatalogDownload::Process(CatalogItem *input) {
   std::string const catalog_path;
-  shash::Any  const catalog_hash;
+  shash::Any const catalog_hash;
   // will PANIC if download failed
-  //catalog_mgr_->LoadCatalog(PathString("") /* not used */, *input->GetHash(), &catalog_path, &catalog_hash, NULL);
+  // catalog_mgr_->LoadCatalog(PathString("") /* not used */, *input->GetHash(),
+  // &catalog_path, &catalog_hash, NULL);
   catalog::CatalogContext context(*input->GetHash(), PathString(catalog_path));
   catalog_mgr_->LoadCatalogByHash(&context);
-  NotifyListeners(CatalogDownloadResult(catalog_path, input->GetHash()->ToString()));
-  tube_counter_->PopFront(); // pop after calling callback as callback could enqueue additional items
+  NotifyListeners(
+      CatalogDownloadResult(catalog_path, input->GetHash()->ToString()));
+  tube_counter_->PopFront();  // pop after calling callback as callback could
+                              // enqueue additional items
 }
 
 CatalogDownloadPipeline::CatalogDownloadPipeline(
-  catalog::SimpleCatalogManager *catalog_mgr)
-  : spawned_(false)
-  , catalog_mgr_(catalog_mgr)
-{
+    catalog::SimpleCatalogManager *catalog_mgr)
+    : spawned_(false), catalog_mgr_(catalog_mgr) {
   const unsigned int nfork_base = 1;
 
   // spawn a bit more workers as this is just download task
   for (unsigned i = 0; i < nfork_base * kCatalogDownloadMultiplier; ++i) {
-    TaskCatalogDownload *task =
-      new TaskCatalogDownload(catalog_mgr_, &tube_input_, &tube_counter_);
+    TaskCatalogDownload *task = new TaskCatalogDownload(
+        catalog_mgr_, &tube_input_, &tube_counter_);
     task->RegisterListener(&CatalogDownloadPipeline::OnFileProcessed, this);
     tasks_download_.TakeConsumer(task);
   }
@@ -38,14 +39,11 @@ CatalogDownloadPipeline::~CatalogDownloadPipeline() {
 }
 
 void CatalogDownloadPipeline::OnFileProcessed(
-  const CatalogDownloadResult &catalog_download_result)
-{
+    const CatalogDownloadResult &catalog_download_result) {
   NotifyListeners(catalog_download_result);
 }
 
-void CatalogDownloadPipeline::Process(
-  const shash::Any &catalog_hash)
-{
+void CatalogDownloadPipeline::Process(const shash::Any &catalog_hash) {
   CatalogItem *catalog_item = new CatalogItem(catalog_hash);
   tube_counter_.EnqueueBack(catalog_item);
   tube_input_.EnqueueBack(catalog_item);
@@ -56,6 +54,4 @@ void CatalogDownloadPipeline::Spawn() {
   spawned_ = true;
 }
 
-void CatalogDownloadPipeline::WaitFor() {
-  tube_counter_.Wait();
-}
+void CatalogDownloadPipeline::WaitFor() { tube_counter_.Wait(); }

--- a/cvmfs/catalog_downloader.h
+++ b/cvmfs/catalog_downloader.h
@@ -2,8 +2,8 @@
 #define CVMFS_CATALOG_DOWNLOADER_H_
 
 #include "catalog_mgr_ro.h"
-#include "ingestion/task.h"
 #include "crypto/hash.h"
+#include "ingestion/task.h"
 #include "util/concurrency.h"
 
 extern int kCatalogDownloadMultiplier;
@@ -11,7 +11,7 @@ extern int kCatalogDownloadMultiplier;
 struct CatalogDownloadResult {
   CatalogDownloadResult() { }
   explicit CatalogDownloadResult(const std::string &p, const std::string &h)
-    : db_path(p), hash(h) { }
+      : db_path(p), hash(h) { }
   std::string db_path;
   std::string hash;
 };
@@ -23,23 +23,22 @@ class CatalogItem : SingleCopy {
     shash::Any const empty;
     return new CatalogItem(empty);
   }
-  bool IsQuitBeacon() {
-    return hash_.IsNull();
-  }
-  shash::Any *GetHash() {
-    return &hash_;
-  }
+  bool IsQuitBeacon() { return hash_.IsNull(); }
+  shash::Any *GetHash() { return &hash_; }
 
  private:
   shash::Any hash_;
 };
 
-class TaskCatalogDownload
-  : public TubeConsumer<CatalogItem>
-  , public Observable<CatalogDownloadResult> {
+class TaskCatalogDownload : public TubeConsumer<CatalogItem>,
+                            public Observable<CatalogDownloadResult> {
  public:
-  TaskCatalogDownload(catalog::SimpleCatalogManager *catalog_mgr, Tube<CatalogItem> *tube_in, Tube<CatalogItem> *tube_counter)
-    : TubeConsumer<CatalogItem>(tube_in), tube_counter_(tube_counter), catalog_mgr_(catalog_mgr) { }
+  TaskCatalogDownload(catalog::SimpleCatalogManager *catalog_mgr,
+                      Tube<CatalogItem> *tube_in,
+                      Tube<CatalogItem> *tube_counter)
+      : TubeConsumer<CatalogItem>(tube_in)
+      , tube_counter_(tube_counter)
+      , catalog_mgr_(catalog_mgr) { }
 
  protected:
   virtual void Process(CatalogItem *input_hash);
@@ -70,4 +69,4 @@ class CatalogDownloadPipeline : public Observable<CatalogDownloadResult> {
   catalog::SimpleCatalogManager *catalog_mgr_;
 };
 
-#endif // CVMFS_CATALOG_DOWNLOADER_H_
+#endif  // CVMFS_CATALOG_DOWNLOADER_H_

--- a/cvmfs/catalog_mgr_client.cc
+++ b/cvmfs/catalog_mgr_client.cc
@@ -153,8 +153,8 @@ LoadReturn ClientCatalogManager::GetNewRootCatalogContext(
   uint64_t local_newest_timestamp = 0;
   uint64_t local_newest_revision = manifest::Breadcrumb::kInvalidRevision;
 
-  const manifest::Breadcrumb breadcrumb =
-      fetcher_->cache_mgr()->LoadBreadcrumb(repo_name_);
+  const manifest::Breadcrumb breadcrumb = fetcher_->cache_mgr()->LoadBreadcrumb(
+      repo_name_);
   if (breadcrumb.IsValid()) {
     local_newest_hash = breadcrumb.catalog_hash;
     local_newest_timestamp = breadcrumb.timestamp;
@@ -288,8 +288,8 @@ std::string ClientCatalogManager::GetCatalogDescription(
  */
 LoadReturn ClientCatalogManager::LoadCatalogByHash(
     CatalogContext *ctlg_context) {
-  const string catalog_descr =
-      GetCatalogDescription(ctlg_context->mountpoint(), ctlg_context->hash());
+  const string catalog_descr = GetCatalogDescription(ctlg_context->mountpoint(),
+                                                     ctlg_context->hash());
   string alt_root_catalog_path = "";
 
   // root catalog needs special handling because of alt_root_catalog_path
@@ -385,8 +385,8 @@ void ClientCatalogManager::UnloadCatalog(const Catalog *catalog) {
   LogCvmfs(kLogCache, kLogDebug, "unloading catalog %s",
            catalog->mountpoint().c_str());
 
-  const map<PathString, shash::Any>::iterator iter =
-      mounted_catalogs_.find(catalog->mountpoint());
+  const map<PathString, shash::Any>::iterator iter = mounted_catalogs_.find(
+      catalog->mountpoint());
   assert(iter != mounted_catalogs_.end());
   fetcher_->cache_mgr()->quota_mgr()->Unpin(iter->second);
   mounted_catalogs_.erase(iter);

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -15,8 +15,8 @@
 #include <string>
 #include <vector>
 
-// only needed for clang-tidy to let it see the class definitions.
-// this would an include loop if not for the header guard
+// Only needed to let clang-tidy see the class definitions.
+// This would by an include loop if not for the header guard.
 #include "catalog_mgr.h"
 
 #include "shortstring.h"

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -964,8 +964,8 @@ CatalogT *AbstractCatalogManager<CatalogT>::MountCatalog(
     return NULL;
   }
 
-  attached_catalog = CreateCatalog(
-      ctlg_context.mountpoint(), ctlg_context.hash(), parent_catalog);
+  attached_catalog = CreateCatalog(ctlg_context.mountpoint(),
+                                   ctlg_context.hash(), parent_catalog);
 
   // Attach loaded catalog
   if (!AttachCatalog(ctlg_context.sqlite_path(), attached_catalog)) {

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -15,9 +15,11 @@
 #include <string>
 #include <vector>
 
+// clang-format off
 // Only needed to let clang-tidy see the class definitions.
 // This would by an include loop if not for the header guard.
 #include "catalog_mgr.h"
+// clang-format on
 
 #include "shortstring.h"
 #include "statistics.h"

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System
  */
 
-// avoid clang-tidy false positives (at least starting with clang14)
-// NOLINTBEGIN
 
 #ifndef CVMFS_CATALOG_MGR_IMPL_H_
 #define CVMFS_CATALOG_MGR_IMPL_H_
@@ -16,6 +14,10 @@
 #include <cassert>
 #include <string>
 #include <vector>
+
+// only needed for clang-tidy to let it see the class definitions.
+// this would an include loop if not for the header guard
+#include "catalog_mgr.h"
 
 #include "shortstring.h"
 #include "statistics.h"
@@ -884,7 +886,7 @@ bool AbstractCatalogManager<CatalogT>::MountSubtree(const PathString &path,
                          : const_cast<CatalogT *>(entry_point);
   assert(path.StartsWith(parent->mountpoint()));
 
-  unsigned path_len = path.GetLength();
+  const unsigned path_len = path.GetLength();
 
   // Try to find path as a super string of nested catalog mount points
   perf::Inc(statistics_.n_nested_listing);
@@ -1203,4 +1205,3 @@ void AbstractCatalogManager<CatalogT>::EnforceSqliteMemLimit() {
 
 
 #endif  // CVMFS_CATALOG_MGR_IMPL_H_
-// NOLINTEND

--- a/cvmfs/catalog_mgr_ro.cc
+++ b/cvmfs/catalog_mgr_ro.cc
@@ -99,8 +99,8 @@ LoadReturn SimpleCatalogManager::LoadCatalogByHash(
   FILE *fcatalog;
 
   if (UseLocalCache()) {
-    const std::string cache_path =
-        dir_cache_ + "/" + effective_hash.MakePathWithoutSuffix();
+    const std::string cache_path = dir_cache_ + "/"
+                                   + effective_hash.MakePathWithoutSuffix();
 
     ctlg_context->SetSqlitePath(cache_path);
 

--- a/cvmfs/catalog_mgr_ro.h
+++ b/cvmfs/catalog_mgr_ro.h
@@ -41,6 +41,7 @@ class SimpleCatalogManager : public AbstractCatalogManager<Catalog> {
                        const bool copy_to_tmp_dir = false);
 
   virtual LoadReturn LoadCatalogByHash(CatalogContext *ctlg_context);
+
  protected:
   virtual LoadReturn GetNewRootCatalogContext(CatalogContext *result);
   virtual Catalog *CreateCatalog(const PathString &mountpoint,

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -36,17 +36,17 @@
 #include <map>
 #include <set>
 #include <string>
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 
+#include "catalog_downloader.h"
 #include "catalog_mgr_ro.h"
 #include "catalog_rw.h"
 #include "file_chunk.h"
+#include "ingestion/pipeline.h"
 #include "upload_spooler_result.h"
 #include "util/future.h"
 #include "xattr.h"
-#include "catalog_downloader.h"
-#include "ingestion/pipeline.h"
 
 class XattrList;
 namespace upload {
@@ -162,7 +162,8 @@ class WritableCatalogManager : public SimpleCatalogManager {
     }
   }
 
-  void LoadCatalogs(const std::string &base_path, const std::unordered_set<std::string> &dirs);
+  void LoadCatalogs(const std::string &base_path,
+                    const std::unordered_set<std::string> &dirs);
   void SetupSingleCatalogUploadCallback();
   void RemoveSingleCatalogUploadCallback();
   void AddCatalogToQueue(const std::string &path);
@@ -170,7 +171,6 @@ class WritableCatalogManager : public SimpleCatalogManager {
   bool LookupDirEntry(const std::string &path,
                       const LookupOptions options,
                       DirectoryEntry *dirent);
-
 
 
  protected:
@@ -209,13 +209,12 @@ class WritableCatalogManager : public SimpleCatalogManager {
   };
 
   struct CatalogDownloadContext {
-    const std::unordered_set<std::string> * dirs;
+    const std::unordered_set<std::string> *dirs;
   };
 
   void CatalogDownloadCallback(const CatalogDownloadResult &result,
                                const CatalogDownloadContext context);
   void SingleCatalogUploadCallback(const upload::SpoolerResult &result);
-
 
 
   CatalogInfo SnapshotCatalogs(const bool stop_for_tweaks);
@@ -252,8 +251,7 @@ class WritableCatalogManager : public SimpleCatalogManager {
   void CatalogUploadSerializedCallback(const upload::SpoolerResult &result,
                                        const CatalogUploadContext unused);
   CatalogInfo SnapshotCatalogsSerialized(const bool stop_for_tweaks);
-    void CatalogHashSerializedCallback(
-    const CompressHashResult &result);
+  void CatalogHashSerializedCallback(const CompressHashResult &result);
   //****************************************************************************
 
   // defined in catalog_mgr_rw.cc
@@ -267,12 +265,12 @@ class WritableCatalogManager : public SimpleCatalogManager {
   std::map<std::string, WritableCatalog *> catalog_processing_map_;
 
   // ingestsql
-  std::list<WritableCatalog*>              pending_catalogs_;
-  CatalogDownloadPipeline                  *catalog_download_pipeline_;
-  pthread_mutex_t                          *catalog_download_lock_;
-  std::unordered_map<std::string, Catalog*> catalog_download_map_;
-  pthread_mutex_t                   *catalog_hash_lock_; 
-  std::map<std::string, shash::Any>  catalog_hash_map_;
+  std::list<WritableCatalog *> pending_catalogs_;
+  CatalogDownloadPipeline *catalog_download_pipeline_;
+  pthread_mutex_t *catalog_download_lock_;
+  std::unordered_map<std::string, Catalog *> catalog_download_map_;
+  pthread_mutex_t *catalog_hash_lock_;
+  std::map<std::string, shash::Any> catalog_hash_map_;
 
   // TODO(jblomer): catalog limits should become its own struct
   bool enforce_limits_;

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -89,8 +89,8 @@ void WritableCatalog::Commit() {
 void WritableCatalog::InitPreparedStatements() {
   Catalog::InitPreparedStatements();  // polymorphism: up call
 
-  const bool retval =
-      SqlCatalog(database(), "PRAGMA foreign_keys = ON;").Execute();
+  const bool retval = SqlCatalog(database(), "PRAGMA foreign_keys = ON;")
+                          .Execute();
   assert(retval);
   sql_insert_ = new SqlDirentInsert(database());
   sql_unlink_ = new SqlDirentUnlink(database());
@@ -206,9 +206,9 @@ void WritableCatalog::IncLinkcount(const string &path_within_group,
 
   const shash::Md5 path_hash = shash::Md5(shash::AsciiPtr(path_within_group));
 
-  const bool retval = sql_inc_linkcount_->BindPathHash(path_hash) &&
-                      sql_inc_linkcount_->BindDelta(delta) &&
-                      sql_inc_linkcount_->Execute();
+  const bool retval = sql_inc_linkcount_->BindPathHash(path_hash)
+                      && sql_inc_linkcount_->BindDelta(delta)
+                      && sql_inc_linkcount_->Execute();
   assert(retval);
   sql_inc_linkcount_->Reset();
 }
@@ -246,8 +246,9 @@ void WritableCatalog::UpdateEntry(const DirectoryEntry &entry,
                                   const shash::Md5 &path_hash) {
   SetDirty();
 
-  const bool retval = sql_update_->BindPathHash(path_hash) &&
-                      sql_update_->BindDirent(entry) && sql_update_->Execute();
+  const bool retval = sql_update_->BindPathHash(path_hash)
+                      && sql_update_->BindDirent(entry)
+                      && sql_update_->Execute();
   assert(retval);
   sql_update_->Reset();
 }
@@ -265,9 +266,9 @@ void WritableCatalog::AddFileChunk(const std::string &entry_path,
 
   delta_counters_.self.file_chunks++;
 
-  const bool retval = sql_chunk_insert_->BindPathHash(path_hash) &&
-                      sql_chunk_insert_->BindFileChunk(chunk) &&
-                      sql_chunk_insert_->Execute();
+  const bool retval = sql_chunk_insert_->BindPathHash(path_hash)
+                      && sql_chunk_insert_->BindFileChunk(chunk)
+                      && sql_chunk_insert_->Execute();
   assert(retval);
   sql_chunk_insert_->Reset();
 }
@@ -492,9 +493,9 @@ void WritableCatalog::InsertNestedCatalog(const string &mountpoint,
 
   SqlCatalog stmt(database(), "INSERT INTO nested_catalogs (path, sha1, size) "
                               "VALUES (:p, :sha1, :size);");
-  const bool retval = stmt.BindText(1, mountpoint) &&
-                      stmt.BindText(2, hash_string) &&
-                      stmt.BindInt64(3, size) && stmt.Execute();
+  const bool retval = stmt.BindText(1, mountpoint)
+                      && stmt.BindText(2, hash_string)
+                      && stmt.BindInt64(3, size) && stmt.Execute();
   assert(retval);
 
   // If a reference of the in-memory object of the newly referenced
@@ -519,9 +520,9 @@ void WritableCatalog::InsertBindMountpoint(const string &mountpoint,
   SqlCatalog stmt(database(),
                   "INSERT INTO bind_mountpoints (path, sha1, size) "
                   "VALUES (:p, :sha1, :size);");
-  const bool retval = stmt.BindText(1, mountpoint) &&
-                      stmt.BindText(2, content_hash.ToString()) &&
-                      stmt.BindInt64(3, size) && stmt.Execute();
+  const bool retval = stmt.BindText(1, mountpoint)
+                      && stmt.BindText(2, content_hash.ToString())
+                      && stmt.BindInt64(3, size) && stmt.Execute();
   assert(retval);
 }
 
@@ -601,8 +602,8 @@ void WritableCatalog::UpdateNestedCatalog(const std::string &path,
                      "WHERE path = :path;";
   SqlCatalog stmt(database(), sql);
 
-  const bool retval = stmt.BindText(1, hash_str) && stmt.BindInt64(2, size) &&
-                      stmt.BindText(3, path) && stmt.Execute();
+  const bool retval = stmt.BindText(1, hash_str) && stmt.BindInt64(2, size)
+                      && stmt.BindText(3, path) && stmt.Execute();
 
   ResetNestedCatalogCacheUnprotected();
 

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -305,9 +305,10 @@ bool CatalogDatabase::InsertInitialValues(const std::string &root_path,
 
   // Path hashes
   const shash::Md5 root_path_hash = shash::Md5(shash::AsciiPtr(root_path));
-  const shash::Md5 root_parent_hash =
-      (root_path == "") ? shash::Md5()
-                        : shash::Md5(shash::AsciiPtr(GetParentPath(root_path)));
+  const shash::Md5 root_parent_hash = (root_path == "")
+                                          ? shash::Md5()
+                                          : shash::Md5(shash::AsciiPtr(
+                                                GetParentPath(root_path)));
 
   // Start initial filling transaction
   retval = BeginTransaction();
@@ -506,8 +507,8 @@ shash::Algorithms SqlDirent::RetrieveHashAlgorithm(const unsigned flags) const {
 zlib::Algorithms SqlDirent::RetrieveCompressionAlgorithm(
     const unsigned flags) const {
   // 3 bits, so use 7 (111) to only pull out the flags we want
-  const unsigned in_flags =
-      ((7 << kFlagPosCompression) & flags) >> kFlagPosCompression;
+  const unsigned in_flags = ((7 << kFlagPosCompression) & flags)
+                            >> kFlagPosCompression;
   return static_cast<zlib::Algorithms>(in_flags);
 }
 
@@ -1345,15 +1346,16 @@ bool SqlCreateCounter::BindInitialValue(const int64_t value) {
 
 SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
   const int hash_mask = 7 << SqlDirent::kFlagPosHash;
-  const string flags2hash = " ((flags&" + StringifyInt(hash_mask) + ") >> " +
-                            StringifyInt(SqlDirent::kFlagPosHash) +
-                            ")+1 AS hash_algorithm ";
+  const string flags2hash = " ((flags&" + StringifyInt(hash_mask) + ") >> "
+                            + StringifyInt(SqlDirent::kFlagPosHash)
+                            + ")+1 AS hash_algorithm ";
 
   const int compression_mask = 7 << SqlDirent::kFlagPosCompression;
-  const string flags2compression =
-      " ((flags&" + StringifyInt(compression_mask) + ") >> " +
-      StringifyInt(SqlDirent::kFlagPosCompression) + ") " +
-      "AS compression_algorithm ";
+  const string flags2compression = " ((flags&" + StringifyInt(compression_mask)
+                                   + ") >> "
+                                   + StringifyInt(
+                                       SqlDirent::kFlagPosCompression)
+                                   + ") " + "AS compression_algorithm ";
 
   // TODO(reneme): this depends on shash::kSuffix* being a char!
   //               it should be more generic or replaced entirely

--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -552,8 +552,8 @@ class CatalogTraversal : public CatalogTraversalBase<ObjectFetcherT> {
                 const TraversalType type = Base::kBreadthFirst) {
     // add the root catalog of the repository as the first element on the job
     // stack
-    TraversalContext ctx(
-        this->default_history_depth_, this->default_timestamp_threshold_, type);
+    TraversalContext ctx(this->default_history_depth_,
+                         this->default_timestamp_threshold_, type);
     Push(root_catalog_hash, &ctx);
     return DoTraverse(&ctx);
   }
@@ -572,8 +572,8 @@ class CatalogTraversal : public CatalogTraversalBase<ObjectFetcherT> {
   bool TraverseRevision(const shash::Any &root_catalog_hash,
                         const TraversalType type = Base::kBreadthFirst) {
     // add the given root catalog as the first element on the job stack
-    TraversalContext ctx(
-        Parameters::kNoHistory, Parameters::kNoTimestampThreshold, type);
+    TraversalContext ctx(Parameters::kNoHistory,
+                         Parameters::kNoTimestampThreshold, type);
     Push(root_catalog_hash, &ctx);
     return DoTraverse(&ctx);
   }

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -167,7 +167,8 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
  protected:
   static uint32_t hasher(const shash::Any &key) {
     // Don't start with the first bytes, because == is using them as well
-    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+    return static_cast<uint32_t>(
+        *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 
   bool DoTraverse() {

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -167,7 +167,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
  protected:
   static uint32_t hasher(const shash::Any &key) {
     // Don't start with the first bytes, because == is using them as well
-    return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 
   bool DoTraverse() {

--- a/cvmfs/catalog_virtual.cc
+++ b/cvmfs/catalog_virtual.cc
@@ -70,13 +70,13 @@ void VirtualCatalog::CreateNestedCatalogMarker() {
   DirectoryEntryBase entry_marker;
   // Note that another entity needs to ensure that the object of an empty
   // file is in the repository!  It is currently done by the sync_mediator.
-  const shash::Algorithms algorithm =
-      catalog_mgr_->spooler_->GetHashAlgorithm();
+  const shash::Algorithms algorithm = catalog_mgr_->spooler_
+                                          ->GetHashAlgorithm();
   shash::Any file_hash(algorithm);
   void *empty_compressed;
   uint64_t sz_empty_compressed;
-  const bool retval =
-      zlib::CompressMem2Mem(NULL, 0, &empty_compressed, &sz_empty_compressed);
+  const bool retval = zlib::CompressMem2Mem(NULL, 0, &empty_compressed,
+                                            &sz_empty_compressed);
   assert(retval);
   shash::HashMem(static_cast<unsigned char *>(empty_compressed),
                  sz_empty_compressed, &file_hash);
@@ -111,8 +111,8 @@ void VirtualCatalog::CreateSnapshotDirectory() {
  */
 void VirtualCatalog::EnsurePresence() {
   DirectoryEntry e;
-  const bool retval =
-      catalog_mgr_->LookupPath("/" + string(kVirtualPath), kLookupDefault, &e);
+  const bool retval = catalog_mgr_->LookupPath("/" + string(kVirtualPath),
+                                               kLookupDefault, &e);
   if (!retval) {
     LogCvmfs(kLogCatalog, kLogDebug, "creating new virtual catalog");
     CreateBaseDirectory();
@@ -262,8 +262,8 @@ void VirtualCatalog::InsertSnapshot(TagId tag) {
   WritableCatalog *virtual_catalog = catalog_mgr_->GetHostingCatalog(
       kVirtualPath);
   assert(virtual_catalog != NULL);
-  const string mountpoint = "/" + string(kVirtualPath) + "/" +
-                            string(kSnapshotDirectory) + "/" + tag.name;
+  const string mountpoint = "/" + string(kVirtualPath) + "/"
+                            + string(kSnapshotDirectory) + "/" + tag.name;
   DirectoryEntry entry_bind_mountpoint(entry_dir);
   entry_bind_mountpoint.set_is_bind_mountpoint(true);
   virtual_catalog->UpdateEntry(entry_bind_mountpoint, mountpoint);
@@ -296,8 +296,8 @@ void VirtualCatalog::Remove() {
 
 void VirtualCatalog::RemoveRecursively(const string &directory) {
   DirectoryEntryList listing;
-  const bool retval =
-      catalog_mgr_->Listing(PathString("/" + directory), &listing);
+  const bool retval = catalog_mgr_->Listing(PathString("/" + directory),
+                                            &listing);
   assert(retval);
   for (unsigned i = 0; i < listing.size(); ++i) {
     const string this_path = directory + "/" + listing[i].name().ToString();
@@ -319,8 +319,8 @@ void VirtualCatalog::RemoveSnapshot(TagId tag) {
   LogCvmfs(kLogCatalog, kLogDebug,
            "remove snapshot %s (%s) from virtual catalog", tag.name.c_str(),
            tag.hash.ToString().c_str());
-  const string tag_dir =
-      string(kVirtualPath) + "/" + string(kSnapshotDirectory) + "/" + tag.name;
+  const string tag_dir = string(kVirtualPath) + "/" + string(kSnapshotDirectory)
+                         + "/" + tag.name;
   catalog_mgr_->RemoveDirectory(tag_dir);
 
   WritableCatalog *virtual_catalog = catalog_mgr_->GetHostingCatalog(

--- a/cvmfs/clientctx.cc
+++ b/cvmfs/clientctx.cc
@@ -45,8 +45,8 @@ ClientCtx::~ClientCtx() {
 ClientCtx *ClientCtx::GetInstance() {
   if (instance_ == NULL) {
     instance_ = new ClientCtx();
-    const int retval =
-        pthread_key_create(&instance_->thread_local_storage_, TlsDestructor);
+    const int retval = pthread_key_create(&instance_->thread_local_storage_,
+                                          TlsDestructor);
     assert(retval == 0);
   }
 
@@ -110,7 +110,8 @@ void ClientCtx::TlsDestructor(void *data) {
   for (vector<ThreadLocalStorage *>::iterator
            i = instance_->tls_blocks_.begin(),
            iEnd = instance_->tls_blocks_.end();
-       i != iEnd; ++i) {
+       i != iEnd;
+       ++i) {
     if ((*i) == tls) {
       instance_->tls_blocks_.erase(i);
       break;

--- a/cvmfs/compat.cc
+++ b/cvmfs/compat.cc
@@ -99,7 +99,7 @@ void Migrate(InodeTracker *old_tracker, glue::InodeTracker *new_tracker) {
 namespace inode_tracker_v2 {
 
 static uint32_t hasher_md5(const shash_v1::Md5 &key) {
-  return (uint32_t) * ((uint32_t *)key.digest + 1);  // NOLINT
+  return (uint32_t)*((uint32_t *)key.digest + 1);  // NOLINT
 }
 
 static uint32_t hasher_inode(const uint64_t &inode) {
@@ -135,7 +135,7 @@ void Migrate(InodeTracker *old_tracker, glue::InodeTracker *new_tracker) {
 namespace inode_tracker_v3 {
 
 static uint32_t hasher_md5(const shash_v1::Md5 &key) {
-  return (uint32_t) * ((uint32_t *)key.digest + 1);  // NOLINT
+  return (uint32_t)*((uint32_t *)key.digest + 1);  // NOLINT
 }
 
 static uint32_t hasher_inode(const uint64_t &inode) {

--- a/cvmfs/compat.cc
+++ b/cvmfs/compat.cc
@@ -99,7 +99,7 @@ void Migrate(InodeTracker *old_tracker, glue::InodeTracker *new_tracker) {
 namespace inode_tracker_v2 {
 
 static uint32_t hasher_md5(const shash_v1::Md5 &key) {
-  return (uint32_t)*((uint32_t *)key.digest + 1);  // NOLINT
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest + 1)));  // NOLINT
 }
 
 static uint32_t hasher_inode(const uint64_t &inode) {
@@ -135,7 +135,7 @@ void Migrate(InodeTracker *old_tracker, glue::InodeTracker *new_tracker) {
 namespace inode_tracker_v3 {
 
 static uint32_t hasher_md5(const shash_v1::Md5 &key) {
-  return (uint32_t)*((uint32_t *)key.digest + 1);  // NOLINT
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest + 1)));  // NOLINT
 }
 
 static uint32_t hasher_inode(const uint64_t &inode) {

--- a/cvmfs/compat.cc
+++ b/cvmfs/compat.cc
@@ -99,7 +99,8 @@ void Migrate(InodeTracker *old_tracker, glue::InodeTracker *new_tracker) {
 namespace inode_tracker_v2 {
 
 static uint32_t hasher_md5(const shash_v1::Md5 &key) {
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest + 1)));  // NOLINT
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(key.digest + 1)));
 }
 
 static uint32_t hasher_inode(const uint64_t &inode) {
@@ -135,7 +136,8 @@ void Migrate(InodeTracker *old_tracker, glue::InodeTracker *new_tracker) {
 namespace inode_tracker_v3 {
 
 static uint32_t hasher_md5(const shash_v1::Md5 &key) {
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest + 1)));  // NOLINT
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(key.digest + 1)));
 }
 
 static uint32_t hasher_inode(const uint64_t &inode) {

--- a/cvmfs/compat.h
+++ b/cvmfs/compat.h
@@ -448,8 +448,8 @@ class PathMap {
   }
   uint64_t LookupInode(const PathString &path) {
     PathInfo value;
-    const bool found =
-        map_.Lookup(shash_v1::Md5(path.GetChars(), path.GetLength()), &value);
+    const bool found = map_.Lookup(
+        shash_v1::Md5(path.GetChars(), path.GetLength()), &value);
     if (found)
       return value.inode;
     return 0;

--- a/cvmfs/crypto/hash.cc
+++ b/cvmfs/crypto/hash.cc
@@ -122,17 +122,19 @@ Any MkFromSuffixedHexPtr(const HexPtr hex) {
   if ((length == 2 * kDigestSizes[kRmd160] + kAlgorithmIdSizes[kRmd160])
       || (length
           == 2 * kDigestSizes[kRmd160] + kAlgorithmIdSizes[kRmd160] + 1)) {
-    const Suffix suffix =
-        (length == 2 * kDigestSizes[kRmd160] + kAlgorithmIdSizes[kRmd160] + 1)
-            ? *(hex.str->rbegin())
-            : kSuffixNone;
+    const Suffix suffix = (length
+                           == 2 * kDigestSizes[kRmd160]
+                                  + kAlgorithmIdSizes[kRmd160] + 1)
+                              ? *(hex.str->rbegin())
+                              : kSuffixNone;
     result = Any(kRmd160, hex, suffix);
   }
   if ((length == 2 * kDigestSizes[kShake128] + kAlgorithmIdSizes[kShake128])
       || (length
           == 2 * kDigestSizes[kShake128] + kAlgorithmIdSizes[kShake128] + 1)) {
-    const Suffix suffix = (length == 2 * kDigestSizes[kShake128] +
-                                         kAlgorithmIdSizes[kShake128] + 1)
+    const Suffix suffix = (length
+                           == 2 * kDigestSizes[kShake128]
+                                  + kAlgorithmIdSizes[kShake128] + 1)
                               ? *(hex.str->rbegin())
                               : kSuffixNone;
     result = Any(kShake128, hex, suffix);

--- a/cvmfs/crypto/signature.cc
+++ b/cvmfs/crypto/signature.cc
@@ -85,7 +85,7 @@ void SignatureManager::InitX509Store() {
   x509_store_ = X509_STORE_new();
   assert(x509_store_ != NULL);
 
-  const unsigned long verify_flags = // NOLINT(runtime/int)
+  const unsigned long verify_flags =  // NOLINT(runtime/int)
       X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL;
 #ifdef OPENSSL_API_INTERFACE_V09
   X509_STORE_set_flags(x509_store_, verify_flags);
@@ -437,8 +437,8 @@ std::string SignatureManager::GetPrivateKey() {
 
   BIO *bp = BIO_new(BIO_s_mem());
   assert(bp != NULL);
-  const bool rvb =
-      PEM_write_bio_PrivateKey(bp, private_key_, NULL, NULL, 0, 0, NULL);
+  const bool rvb = PEM_write_bio_PrivateKey(bp, private_key_, NULL, NULL, 0, 0,
+                                            NULL);
   assert(rvb);
   char *bio_privkey_text;
   long bytes = BIO_get_mem_data(bp, &bio_privkey_text);  // NOLINT
@@ -519,7 +519,8 @@ void SignatureManager::GenerateCertificate(const std::string &cn) {
 
   Prng prng;
   prng.InitLocaltime();
-  unsigned long rnd_serial_no = prng.Next(uint64_t(1) + uint32_t(-1));  // NOLINT
+  unsigned long rnd_serial_no = prng.Next(uint64_t(1)
+                                          + uint32_t(-1));  // NOLINT
   rnd_serial_no = rnd_serial_no
                   | uint64_t(prng.Next(uint64_t(1) + uint32_t(-1))) << 32;
   ASN1_INTEGER_set(X509_get_serialNumber(certificate_), rnd_serial_no);
@@ -609,8 +610,8 @@ bool SignatureManager::LoadTrustedCaCrl(const string &path_list) {
   }*/
   const vector<string> paths = SplitString(path_list, ':');
   for (unsigned i = 0; i < paths.size(); ++i) {
-    const int retval =
-        X509_LOOKUP_add_dir(x509_lookup_, paths[i].c_str(), X509_FILETYPE_PEM);
+    const int retval = X509_LOOKUP_add_dir(x509_lookup_, paths[i].c_str(),
+                                           X509_FILETYPE_PEM);
     if (!retval)
       return false;
   }
@@ -1087,8 +1088,8 @@ bool SignatureManager::VerifyPkcs7(const unsigned char *buffer,
 #else
             ASN1_STRING_data(this_name->d.uniformResourceIdentifier));
 #endif
-        const int name_len =
-            ASN1_STRING_length(this_name->d.uniformResourceIdentifier);
+        const int name_len = ASN1_STRING_length(
+            this_name->d.uniformResourceIdentifier);
         if (!name_ptr || (name_len <= 0))
           continue;
         alt_uris->push_back(string(name_ptr, name_len));

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -320,8 +320,8 @@ static bool GetDirentForInode(const fuse_ino_t ino,
     return true;
 
   // Look in the catalogs in 2 steps: lookup inode->path, lookup path
-  static const catalog::DirectoryEntry dirent_negative =
-      catalog::DirectoryEntry(catalog::kDirentNegative);
+  static const catalog::DirectoryEntry
+      dirent_negative = catalog::DirectoryEntry(catalog::kDirentNegative);
   // Reset directory entry.  If the function returns false and dirent is no
   // the kDirentNegative, it was an I/O error
   *dirent = catalog::DirectoryEntry();
@@ -348,8 +348,8 @@ static bool GetDirentForInode(const fuse_ino_t ino,
   // Non-NFS mode
   PathString path;
   if (ino == catalog_mgr->GetRootInode()) {
-    const bool retval =
-        catalog_mgr->LookupPath(PathString(), catalog::kLookupDefault, dirent);
+    const bool retval = catalog_mgr->LookupPath(
+        PathString(), catalog::kLookupDefault, dirent);
 
     if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
                      "GetDirentForInode: Race condition? Not found dirent %s",
@@ -676,8 +676,8 @@ static void cvmfs_forget(fuse_req_t req,
            uint64_t(ino), nlookup);
 
   if (!file_system_->IsNfsSource()) {
-    const bool removed =
-        mount_point_->inode_tracker()->GetVfsPutRaii().VfsPut(ino, nlookup);
+    const bool removed = mount_point_->inode_tracker()->GetVfsPutRaii().VfsPut(
+        ino, nlookup);
     if (removed)
       mount_point_->page_cache_tracker()->GetEvictRaii().Evict(ino);
   }
@@ -713,8 +713,8 @@ static void cvmfs_forget_multi(fuse_req_t req,
       LogCvmfs(kLogCvmfs, kLogDebug, "forget on inode %" PRIu64 " by %" PRIu64,
                forgets[i].ino, forgets[i].nlookup);
 
-      const bool removed =
-          vfs_put_raii.VfsPut(forgets[i].ino, forgets[i].nlookup);
+      const bool removed = vfs_put_raii.VfsPut(forgets[i].ino,
+                                               forgets[i].nlookup);
       if (removed)
         evict_raii.Evict(forgets[i].ino);
     }
@@ -788,8 +788,8 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
              ino);
     shash::Any hash;
     struct stat info;
-    const bool is_open =
-        mount_point_->page_cache_tracker()->GetInfoIfOpen(ino, &hash, &info);
+    const bool is_open = mount_point_->page_cache_tracker()->GetInfoIfOpen(
+        ino, &hash, &info);
     if (is_open) {
       fuse_remounter_->fence()->Leave();
       if (found && HasDifferentContent(dirent, hash, info)) {
@@ -1030,8 +1030,8 @@ static void cvmfs_releasedir(fuse_req_t req, fuse_ino_t ino,
 
   {
     const MutexLockGuard m(&lock_directory_handles_);
-    const DirectoryHandles::iterator iter_handle =
-        directory_handles_->find(fi->fh);
+    const DirectoryHandles::iterator iter_handle = directory_handles_->find(
+        fi->fh);
     if (iter_handle != directory_handles_->end()) {
       if (iter_handle->second.capacity == 0)
         smunmap(iter_handle->second.buffer);
@@ -1080,8 +1080,8 @@ static void cvmfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
   DirectoryListing listing;
 
   const MutexLockGuard m(&lock_directory_handles_);
-  const DirectoryHandles::const_iterator iter_handle =
-      directory_handles_->find(fi->fh);
+  const DirectoryHandles::const_iterator iter_handle = directory_handles_->find(
+      fi->fh);
   if (iter_handle != directory_handles_->end()) {
     listing = iter_handle->second;
 
@@ -1249,16 +1249,16 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
         chunk_tables->inode2references.Insert(unique_inode, 1);
       } else {
         uint32_t refctr;
-        const bool retval =
-            chunk_tables->inode2references.Lookup(unique_inode, &refctr);
+        const bool retval = chunk_tables->inode2references.Lookup(unique_inode,
+                                                                  &refctr);
         assert(retval);
         chunk_tables->inode2references.Insert(unique_inode, refctr + 1);
       }
     } else {
       fuse_remounter_->fence()->Leave();
       uint32_t refctr;
-      const bool retval =
-          chunk_tables->inode2references.Lookup(unique_inode, &refctr);
+      const bool retval = chunk_tables->inode2references.Lookup(unique_inode,
+                                                                &refctr);
       assert(retval);
       chunk_tables->inode2references.Insert(unique_inode, refctr + 1);
     }
@@ -1274,8 +1274,8 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     // Generate artificial content hash as hash over chunk hashes
     // TODO(jblomer): we may want to cache the result in the chunk tables
     FileChunkReflist chunk_reflist;
-    const bool retval =
-        chunk_tables->inode2chunks.Lookup(unique_inode, &chunk_reflist);
+    const bool retval = chunk_tables->inode2chunks.Lookup(unique_inode,
+                                                          &chunk_reflist);
     assert(retval);
 
     fi->fh = chunk_tables->next_handle;
@@ -1475,8 +1475,8 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
       const size_t remaining_bytes_in_chunk = chunks.list->AtPtr(chunk_idx)
                                                   ->size()
                                               - offset_in_chunk;
-      const size_t bytes_to_read_in_chunk =
-          std::min(bytes_to_read, remaining_bytes_in_chunk);
+      const size_t bytes_to_read_in_chunk = std::min(bytes_to_read,
+                                                     remaining_bytes_in_chunk);
       const int64_t bytes_fetched = file_system_->cache_mgr()->Pread(
           chunk_fd.fd,
           data + overall_bytes_fetched,
@@ -1514,8 +1514,8 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     LogCvmfs(kLogCvmfs, kLogDebug, "released chunk file descriptor %d",
              chunk_fd.fd);
   } else {
-    const int64_t nbytes =
-        file_system_->cache_mgr()->Pread(abs_fd, data, size, off);
+    const int64_t nbytes = file_system_->cache_mgr()->Pread(abs_fd, data, size,
+                                                            off);
     if (nbytes < 0) {
       if (EIO == errno || EIO == -nbytes) {
         PathString path;
@@ -1659,8 +1659,8 @@ static void cvmfs_statfs(fuse_req_t req, fuse_ino_t ino) {
 
   uint64_t available = 0;
   const uint64_t size = file_system_->cache_mgr()->quota_mgr()->GetSize();
-  const uint64_t capacity =
-      file_system_->cache_mgr()->quota_mgr()->GetCapacity();
+  const uint64_t
+      capacity = file_system_->cache_mgr()->quota_mgr()->GetCapacity();
   // Fuse/OS X doesn't like values < 512
   info->f_bsize = info->f_frsize = 512;
 
@@ -1790,9 +1790,9 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   }
 
   if (d.IsLink()) {
-    const catalog::LookupOptions lookup_options =
-        static_cast<catalog::LookupOptions>(catalog::kLookupDefault |
-                                            catalog::kLookupRawSymlink);
+    const catalog::LookupOptions
+        lookup_options = static_cast<catalog::LookupOptions>(
+            catalog::kLookupDefault | catalog::kLookupRawSymlink);
     catalog::DirectoryEntry raw_symlink;
     retval = catalog_mgr->LookupPath(path, lookup_options, &raw_symlink);
 
@@ -2245,8 +2245,8 @@ static FileSystem *InitSystemFs(const string &mount_path,
 
   if (file_system->boot_status() == loader::kFailLockWorkspace) {
     string fqrn_from_xattr;
-    const int retval =
-        platform_getxattr(mount_path, "user.fqrn", &fqrn_from_xattr);
+    const int retval = platform_getxattr(mount_path, "user.fqrn",
+                                         &fqrn_from_xattr);
     if (!retval) {
       // Cvmfs not mounted anymore, but another cvmfs process is still in
       // shutdown procedure.  Try again and wait for lock
@@ -2346,8 +2346,8 @@ static int Init(const loader::LoaderExports *loader_exports) {
   fs_info.exe_path = loader_exports->program_name;
   fs_info.options_mgr = cvmfs::options_mgr_;
   fs_info.foreground = loader_exports->foreground;
-  cvmfs::file_system_ = InitSystemFs(
-      loader_exports->mount_point, loader_exports->repository_name, fs_info);
+  cvmfs::file_system_ = InitSystemFs(loader_exports->mount_point,
+                                     loader_exports->repository_name, fs_info);
   if (!cvmfs::file_system_->IsValid()) {
     *g_boot_error = cvmfs::file_system_->boot_error();
     return cvmfs::file_system_->boot_status();
@@ -2860,8 +2860,9 @@ static bool RestoreState(const int fd_progress,
 
       // TODO(jblomer): make this less hacky
 
-      const CacheManagerIds saved_type =
-          cvmfs::file_system_->cache_mgr()->PeekState(saved_states[i]->state);
+      const CacheManagerIds saved_type = cvmfs::file_system_->cache_mgr()
+                                             ->PeekState(
+                                                 saved_states[i]->state);
       int fixup_root_fd = -1;
 
       if ((saved_type == kStreamingCacheManager)
@@ -2921,8 +2922,8 @@ static bool RestoreState(const int fd_progress,
     }
   }
   if (cvmfs::mount_point_->inode_annotation()) {
-    const uint64_t saved_generation =
-        cvmfs::inode_generation_info_.inode_generation;
+    const uint64_t saved_generation = cvmfs::inode_generation_info_
+                                          .inode_generation;
     cvmfs::mount_point_->inode_annotation()->IncGeneration(saved_generation);
   }
 

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -175,8 +175,8 @@ static void *MainCheck(void *data __attribute__((unused))) {
     platform_disable_kcache(fd_src);
 
     // Compress every file and calculate SHA-1 of stream
-    const shash::Any expected_hash =
-        shash::MkFromHexPtr(shash::HexPtr(hash_name));
+    const shash::Any expected_hash = shash::MkFromHexPtr(
+        shash::HexPtr(hash_name));
     shash::Any hash(expected_hash.algorithm);
     if (!zlib::CompressFd2Null(fd_src, &hash)) {
       LogCvmfs(kLogCvmfs, kLogStdout, "Error: could not compress %s",

--- a/cvmfs/cvmfs_talk.cc
+++ b/cvmfs/cvmfs_talk.cc
@@ -46,8 +46,8 @@ struct InstanceInfo {
     options_mgr.ParseDefault(fqrn);
     if (!options_mgr.GetValue("CVMFS_WORKSPACE", &workspace)) {
       if (!options_mgr.GetValue("CVMFS_CACHE_DIR", &workspace)) {
-        const bool retval =
-            options_mgr.GetValue("CVMFS_CACHE_BASE", &workspace);
+        const bool retval = options_mgr.GetValue("CVMFS_CACHE_BASE",
+                                                 &workspace);
         if (!retval) {
           LogCvmfs(kLogCvmfs, kLogStderr,
                    "CVMFS_WORKSPACE, CVMFS_CACHE_DIR, and CVMFS_CACHE_BASE "

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -31,7 +31,7 @@ class SyncItemDummyCatalog;
 namespace swissknife {
 class CommandMigrate;
 class IngestSQL;
-}
+}  // namespace swissknife
 
 namespace catalog {
 
@@ -68,7 +68,8 @@ class DirectoryEntryBase {
   friend class publish::SyncItemTar;
   friend class publish::SyncItemDummyDir;
   friend class publish::SyncItemDummyCatalog;
-  friend class swissknife::IngestSQL; //TODO(vvolkl): can probably avoided with new setters
+  friend class swissknife::IngestSQL;  // TODO(vvolkl): can probably avoided
+                                       // with new setters
   // Simplify file system like _touch_ of DirectoryEntry objects
   friend class SqlDirentTouch;
   // Allow creation of virtual directories and files

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -105,8 +105,8 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
   // Synchronization point: either act as a master thread for this object or
   // enqueue to the list of waiting threads.
   pthread_mutex_lock(lock_queues_download_);
-  const ThreadQueues::iterator iDownloadQueue =
-      queues_download_.find(object.id);
+  const ThreadQueues::iterator iDownloadQueue = queues_download_.find(
+      object.id);
   if (iDownloadQueue != queues_download_.end()) {
     LogCvmfs(kLogCache, kLogDebug, "waiting for download of %s",
              object.label.path.c_str());

--- a/cvmfs/file_watcher_inotify.cc
+++ b/cvmfs/file_watcher_inotify.cc
@@ -90,8 +90,8 @@ bool FileWatcherInotify::RunEventLoop(const FileWatcher::HandlerMap &handlers,
         struct inotify_event
             *inotify_event = reinterpret_cast<struct inotify_event *>(
                 &buffer[i]);
-        const std::map<int, WatchRecord>::const_iterator it =
-            watch_records_.find(inotify_event->wd);
+        const std::map<int, WatchRecord>::const_iterator
+            it = watch_records_.find(inotify_event->wd);
         if (it != watch_records_.end()) {
           WatchRecord current_record = it->second;
           file_watcher::Event event = file_watcher::kInvalid;

--- a/cvmfs/file_watcher_kqueue.h
+++ b/cvmfs/file_watcher_kqueue.h
@@ -33,4 +33,4 @@ class FileWatcherKqueue : public FileWatcher {
 }  // namespace file_watcher
 
 #endif  // CVMFS_FILE_WATCHER_KQUEUE_H_
-#endif // __APPLE__
+#endif  // __APPLE__

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -165,8 +165,8 @@ FuseRemounter::FuseRemounter(MountPoint *mountpoint,
                              bool fuse_notify_invalidation)
     : mountpoint_(mountpoint)
     , inode_generation_info_(inode_generation_info)
-    , invalidator_(new FuseInvalidator(
-          mountpoint, fuse_channel_or_session, fuse_notify_invalidation))
+    , invalidator_(new FuseInvalidator(mountpoint, fuse_channel_or_session,
+                                       fuse_notify_invalidation))
     , invalidator_handle_(static_cast<int>(mountpoint->kcache_timeout_sec()))
     , fence_(new Fence())
     , offline_mode_(false)

--- a/cvmfs/garbage_collection/hash_filter.h
+++ b/cvmfs/garbage_collection/hash_filter.h
@@ -96,7 +96,8 @@ class SmallhashFilter : public AbstractHashFilter {
  protected:
   static uint32_t hasher(const shash::Any &key) {
     // Don't start with the first bytes, because == is using them as well
-    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+    return static_cast<uint32_t>(
+        *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 
  public:

--- a/cvmfs/garbage_collection/hash_filter.h
+++ b/cvmfs/garbage_collection/hash_filter.h
@@ -96,7 +96,7 @@ class SmallhashFilter : public AbstractHashFilter {
  protected:
   static uint32_t hasher(const shash::Any &key) {
     // Don't start with the first bytes, because == is using them as well
-    return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 
  public:

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -93,7 +93,7 @@ class InodeEx {
 
 static inline uint32_t hasher_md5(const shash::Md5 &key) {
   // Don't start with the first bytes, because == is using them as well
-  return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 static inline uint32_t hasher_inode(const uint64_t &inode) {

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -93,7 +93,8 @@ class InodeEx {
 
 static inline uint32_t hasher_md5(const shash::Md5 &key) {
   // Don't start with the first bytes, because == is using them as well
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 static inline uint32_t hasher_inode(const uint64_t &inode) {
@@ -405,8 +406,8 @@ class PathMap {
 
   uint64_t LookupInodeByPath(const PathString &path) {
     uint64_t inode;
-    const bool found =
-        map_.Lookup(shash::Md5(path.GetChars(), path.GetLength()), &inode);
+    const bool found = map_.Lookup(
+        shash::Md5(path.GetChars(), path.GetLength()), &inode);
     if (found)
       return inode;
     return 0;
@@ -599,8 +600,8 @@ class InodeTracker {
         // TODO(jblomer): pop operation (Lookup+Erase)
         shash::Md5 md5path;
         InodeEx inode_ex(inode, InodeEx::kUnknownType);
-        const bool found =
-            tracker_->inode_ex_map_.LookupMd5Path(&inode_ex, &md5path);
+        const bool found = tracker_->inode_ex_map_.LookupMd5Path(&inode_ex,
+                                                                 &md5path);
         if (!found) {
           PANIC(kLogSyslogErr | kLogDebug,
                 "inode tracker ref map and path map out of sync: %" PRIu64,

--- a/cvmfs/history_sql.cc
+++ b/cvmfs/history_sql.cc
@@ -389,8 +389,9 @@ SqlListBranches::SqlListBranches(const HistoryDatabase *database) {
 
 History::Branch SqlListBranches::RetrieveBranch() const {
   const std::string branch = RetrieveString(0);
-  const std::string parent =
-      (RetrieveType(1) == SQLITE_NULL) ? "" : RetrieveString(1);
+  const std::string parent = (RetrieveType(1) == SQLITE_NULL)
+                                 ? ""
+                                 : RetrieveString(1);
   const unsigned initial_revision = RetrieveInt64(2);
   return History::Branch(branch, parent, initial_revision);
 }

--- a/cvmfs/ingestion/pipeline.h
+++ b/cvmfs/ingestion/pipeline.h
@@ -157,22 +157,18 @@ class ScrubbingPipeline : public Observable<ScrubbingResult> {
 struct CompressHashResult {
   CompressHashResult() { }
   CompressHashResult(const std::string &p, const shash::Any &h)
-    : path(p), hash(h) { }
+      : path(p), hash(h) { }
   std::string path;
   shash::Any hash;
 };
 
 
-class TaskCompressHashCallback
-  : public TubeConsumer<BlockItem>
-  , public Observable<CompressHashResult>
-{
+class TaskCompressHashCallback : public TubeConsumer<BlockItem>,
+                                 public Observable<CompressHashResult> {
  public:
   TaskCompressHashCallback(Tube<BlockItem> *tube_in,
                            Tube<FileItem> *tube_counter)
-    : TubeConsumer<BlockItem>(tube_in)
-    , tube_counter_(tube_counter)
-  { }
+      : TubeConsumer<BlockItem>(tube_in), tube_counter_(tube_counter) { }
 
  protected:
   virtual void Process(BlockItem *block_item);
@@ -188,7 +184,7 @@ class CompressHashPipeline : public Observable<CompressHashResult> {
   ~CompressHashPipeline();
 
   void Spawn();
-  void Process(IngestionSource* source,
+  void Process(IngestionSource *source,
                shash::Algorithms hash_algorithm,
                shash::Suffix hash_suffix);
   void WaitFor();

--- a/cvmfs/kvstore.cc
+++ b/cvmfs/kvstore.cc
@@ -23,7 +23,7 @@ namespace {
 static inline uint32_t hasher_any(const shash::Any &key) {
   // We'll just do the same thing as hasher_md5, since every hash is at
   // least as large.
-  return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 }  // anonymous namespace

--- a/cvmfs/kvstore.cc
+++ b/cvmfs/kvstore.cc
@@ -23,7 +23,8 @@ namespace {
 static inline uint32_t hasher_any(const shash::Any &key) {
   // We'll just do the same thing as hasher_md5, since every hash is at
   // least as large.
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 }  // anonymous namespace

--- a/cvmfs/letter.cc
+++ b/cvmfs/letter.cc
@@ -29,8 +29,8 @@ string Letter::Sign(const shash::Algorithms hash_algorithm) {
   bool retval = signature_manager_->WriteCertificateMem(&cert_buf,
                                                         &cert_buf_size);
   assert(retval);
-  const string cert_base64 =
-      Base64(string(reinterpret_cast<char *>(cert_buf), cert_buf_size));
+  const string cert_base64 = Base64(
+      string(reinterpret_cast<char *>(cert_buf), cert_buf_size));
   free(cert_buf);
 
   string output = text_;

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -235,8 +235,8 @@ int cvmfs_open(LibContext *ctx, const char *path) {
 }
 
 
-ssize_t cvmfs_pread(
-    LibContext *ctx, int fd, void *buf, size_t size, off_t off) {
+ssize_t cvmfs_pread(LibContext *ctx, int fd, void *buf, size_t size,
+                    off_t off) {
   const ssize_t nbytes = ctx->Pread(fd, buf, size, off);
   if (nbytes < 0) {
     errno = -nbytes;

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -519,8 +519,8 @@ int LibContext::ListNestedCatalogs(const char *c_path,
   path.Assign(c_path, strlen(c_path));
 
   std::vector<PathString> skein;
-  const bool retval =
-      mount_point_->catalog_mgr()->ListCatalogSkein(path, &skein);
+  const bool retval = mount_point_->catalog_mgr()->ListCatalogSkein(path,
+                                                                    &skein);
   if (!retval) {
     LogCvmfs(kLogCvmfs, kLogDebug,
              "cvmfs_list_nc failed to find skein of path: %s", c_path);
@@ -615,8 +615,8 @@ int64_t LibContext::Pread(int fd, void *buf, uint64_t size, uint64_t off) {
     SimpleChunkTables::OpenChunks
         open_chunks = mount_point_->simple_chunk_tables()->Get(chunk_handle);
     FileChunkList *chunk_list = open_chunks.chunk_reflist.list;
-    const zlib::Algorithms compression_alg =
-        open_chunks.chunk_reflist.compression_alg;
+    const zlib::Algorithms compression_alg = open_chunks.chunk_reflist
+                                                 .compression_alg;
     if (chunk_list == NULL)
       return -EBADF;
 
@@ -658,8 +658,8 @@ int64_t LibContext::Pread(int fd, void *buf, uint64_t size, uint64_t off) {
       const size_t remaining_bytes_in_chunk = chunk_list->AtPtr(chunk_idx)
                                                   ->size()
                                               - offset_in_chunk;
-      const size_t bytes_to_read_in_chunk =
-          std::min(bytes_to_read, remaining_bytes_in_chunk);
+      const size_t bytes_to_read_in_chunk = std::min(bytes_to_read,
+                                                     remaining_bytes_in_chunk);
       const int64_t bytes_fetched = file_system()->cache_mgr()->Pread(
           chunk_fd->fd,
           reinterpret_cast<char *>(buf) + overall_bytes_fetched,
@@ -690,8 +690,8 @@ int LibContext::Close(int fd) {
   LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_close on file number: %d", fd);
   if (fd & kFdChunked) {
     const int chunk_handle = fd & ~kFdChunked;
-    const SimpleChunkTables::OpenChunks open_chunks =
-        mount_point_->simple_chunk_tables()->Get(chunk_handle);
+    const SimpleChunkTables::OpenChunks
+        open_chunks = mount_point_->simple_chunk_tables()->Get(chunk_handle);
     if (open_chunks.chunk_reflist.list == NULL)
       return -EBADF;
     if (open_chunks.chunk_fd->fd != -1)

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -85,10 +85,8 @@ enum {
   KEY_CVMFS_DEBUG,
   KEY_OPTIONS_PARSE,
 };
-#define CVMFS_OPT(t, p, v) \
-  { t, offsetof(struct CvmfsOptions, p), v }
-#define CVMFS_SWITCH(t, p) \
-  { t, offsetof(struct CvmfsOptions, p), 1 }
+#define CVMFS_OPT(t, p, v) {t, offsetof(struct CvmfsOptions, p), v}
+#define CVMFS_SWITCH(t, p) {t, offsetof(struct CvmfsOptions, p), 1}
 static struct fuse_opt cvmfs_array_opts[] = {
     CVMFS_OPT("config=%s", config, 0),
     CVMFS_OPT("uid=%d", uid, 0),
@@ -191,9 +189,10 @@ static void Usage(const string &exename) {
 bool CheckPremounted(const std::string &mountpoint) {
   int len;
   unsigned fd;
-  const bool retval =
-      (sscanf(mountpoint.c_str(), "/dev/fd/%u%n", &fd, &len) == 1) &&
-      (len >= 0) && (static_cast<unsigned>(len) == mountpoint.length());
+  const bool retval = (sscanf(mountpoint.c_str(), "/dev/fd/%u%n", &fd, &len)
+                       == 1)
+                      && (len >= 0)
+                      && (static_cast<unsigned>(len) == mountpoint.length());
   if (retval) {
     LogCvmfs(kLogCvmfs, kLogStdout,
              "CernVM-FS: pre-mounted on file descriptor %d", fd);
@@ -592,8 +591,8 @@ Failures Reload(const int fd_progress, const bool stop_and_go,
     return kFailLoadLibrary;
   retval = cvmfs_exports_->fnInit(loader_exports_);
   if (retval != kFailOk) {
-    const string msg_progress =
-        cvmfs_exports_->fnGetErrorMsg() + " (" + StringifyInt(retval) + ")\n";
+    const string msg_progress = cvmfs_exports_->fnGetErrorMsg() + " ("
+                                + StringifyInt(retval) + ")\n";
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "%s", msg_progress.c_str());
     SendMsg2Socket(fd_progress, msg_progress);
     return (Failures)retval;
@@ -852,15 +851,15 @@ int FuseMain(int argc, char *argv[]) {
 
   // Apply OOM score adjustment
   if (options_manager->GetValue("CVMFS_OOM_SCORE_ADJ", &parameter)) {
-    const string proc_path =
-        "/proc/" + StringifyInt(getpid()) + "/oom_score_adj";
+    const string proc_path = "/proc/" + StringifyInt(getpid())
+                             + "/oom_score_adj";
     const int fd_oom = open(proc_path.c_str(), O_WRONLY);
     if (fd_oom < 0) {
       LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn, "failed to open %s",
                proc_path.c_str());
     } else {
-      const bool retval =
-          SafeWrite(fd_oom, parameter.data(), parameter.length());
+      const bool retval = SafeWrite(fd_oom, parameter.data(),
+                                    parameter.length());
       if (!retval) {
         LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogWarn,
                  "failed to set OOM score adjustment to %s", parameter.c_str());
@@ -915,9 +914,10 @@ int FuseMain(int argc, char *argv[]) {
             : "",
         MatchFuseOption(mount_options, "allow_other") ? ",allow_other" : "");
     unsigned long flags = MS_NOSUID | MS_NODEV | MS_RELATIME;
-    // Note that during the handling of the `CVMFS_MOUNT_RW` option, we ensure that
-    // at least one of `rw` or `ro` is part of the mount option string (we won't have both unset).
-    // If both `rw` and `ro` are set, the read-only option takes precedence.
+    // Note that during the handling of the `CVMFS_MOUNT_RW` option, we ensure
+    // that at least one of `rw` or `ro` is part of the mount option string (we
+    // won't have both unset). If both `rw` and `ro` are set, the read-only
+    // option takes precedence.
     if (MatchFuseOption(mount_options, "ro")) {
       flags |= MS_RDONLY;
     }

--- a/cvmfs/lru_md.h
+++ b/cvmfs/lru_md.h
@@ -28,7 +28,8 @@ namespace lru {
 // Hash functions
 static inline uint32_t hasher_md5(const shash::Md5 &key) {
   // Don't start with the first bytes, because == is using them as well
-  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+  return static_cast<uint32_t>(
+      *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 static inline uint32_t hasher_inode(const fuse_ino_t &inode) {

--- a/cvmfs/lru_md.h
+++ b/cvmfs/lru_md.h
@@ -28,7 +28,7 @@ namespace lru {
 // Hash functions
 static inline uint32_t hasher_md5(const shash::Md5 &key) {
   // Don't start with the first bytes, because == is using them as well
-  return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 static inline uint32_t hasher_inode(const fuse_ino_t &inode) {

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -452,9 +452,10 @@ void LHashMagicXattr::FinalizeValue() {
     result = "Not in cache";
   } else {
     shash::Any hash(dirent_->checksum().algorithm);
-    const int retval_i =
-        xattr_mgr_->mount_point()->file_system()->cache_mgr()->ChecksumFd(
-            fd, &hash);
+    const int retval_i = xattr_mgr_->mount_point()
+                             ->file_system()
+                             ->cache_mgr()
+                             ->ChecksumFd(fd, &hash);
     if (retval_i != 0)
       result = "I/O error (" + StringifyInt(retval_i) + ")";
     else
@@ -542,8 +543,10 @@ void HitrateMagicXattr::FinalizeValue() {
                                   ->statistics()
                                   ->Lookup("fetch.n_downloads")
                                   ->Get();
-  const float hitrate = 100. * (1. - (static_cast<float>(n_downloads) /
-                                      static_cast<float>(n_invocations)));
+  const float hitrate = 100.
+                        * (1.
+                           - (static_cast<float>(n_downloads)
+                              / static_cast<float>(n_invocations)));
   result_pages_.push_back(StringifyDouble(hitrate));
 }
 
@@ -679,16 +682,18 @@ void RepoMetainfoMagicXattr::FinalizeValue() {
     result_pages_.push_back("Failed to open metadata file");
     return;
   }
-  const uint64_t actual_size =
-      xattr_mgr_->mount_point()->file_system()->cache_mgr()->GetSize(fd);
+  const uint64_t actual_size = xattr_mgr_->mount_point()
+                                   ->file_system()
+                                   ->cache_mgr()
+                                   ->GetSize(fd);
   if (actual_size > kMaxMetainfoLength) {
     xattr_mgr_->mount_point()->file_system()->cache_mgr()->Close(fd);
     result_pages_.push_back("Failed to open: metadata file is too big");
     return;
   }
   char buffer[kMaxMetainfoLength];
-  const int64_t bytes_read =
-      xattr_mgr_->mount_point()->file_system()->cache_mgr()->Pread(
+  const int64_t
+      bytes_read = xattr_mgr_->mount_point()->file_system()->cache_mgr()->Pread(
           fd, buffer, actual_size, 0);
   xattr_mgr_->mount_point()->file_system()->cache_mgr()->Close(fd);
   if (bytes_read < 0) {

--- a/cvmfs/malloc_arena.cc
+++ b/cvmfs/malloc_arena.cc
@@ -67,10 +67,10 @@ void MallocArena::Free(void *ptr) {
 
   if (prior_tag == kTagAvail) {
     // Merge with block before and remove the block from the list
-    const int32_t prior_size =
-        reinterpret_cast<AvailBlockTag *>(reinterpret_cast<char *>(block_ctl) -
-                                          sizeof(AvailBlockTag))
-            ->size;
+    const int32_t prior_size = reinterpret_cast<AvailBlockTag *>(
+                                   reinterpret_cast<char *>(block_ctl)
+                                   - sizeof(AvailBlockTag))
+                                   ->size;
     assert(prior_size > 0);
     new_size += prior_size;
     new_avail = reinterpret_cast<AvailBlockCtl *>(
@@ -171,9 +171,9 @@ MallocArena::MallocArena(unsigned arena_size)
 
   const unsigned char padding = 7;
   // Size of the initial free block: everything minus arena boundaries
-  const int32_t usable_size =
-      arena_size_ - (sizeof(uint64_t) + sizeof(AvailBlockCtl) + padding + 1 +
-                     sizeof(int32_t));
+  const int32_t usable_size = arena_size_
+                              - (sizeof(uint64_t) + sizeof(AvailBlockCtl)
+                                 + padding + 1 + sizeof(int32_t));
   assert((usable_size % 8) == 0);
 
   // First 8 bytes of arena: this pointer (occupies only 4 bytes on 32bit
@@ -212,8 +212,8 @@ MallocArena *MallocArena::CreateInitialized(unsigned arena_size,
   assert(free_block != result->head_avail_);
   assert(free_block->size > 0);
   // Strip control information at both ends of the block
-  const int usable_size =
-      free_block->size - (sizeof(AvailBlockCtl) + sizeof(AvailBlockTag));
+  const int usable_size = free_block->size
+                          - (sizeof(AvailBlockCtl) + sizeof(AvailBlockTag));
   assert(usable_size > 0);
   memset(free_block + 1, pattern, usable_size);
   return result;

--- a/cvmfs/manifest.cc
+++ b/cvmfs/manifest.cc
@@ -47,15 +47,15 @@ Breadcrumb::Breadcrumb(const std::string &from_string) {
 
 bool Breadcrumb::Export(const string &fqrn, const string &directory,
                         const int mode) const {
-  const string breadcrumb_path =
-      MakeCanonicalPath(directory) + "/cvmfschecksum." + fqrn;
+  const string breadcrumb_path = MakeCanonicalPath(directory)
+                                 + "/cvmfschecksum." + fqrn;
   string tmp_path;
   FILE *fbreadcrumb = CreateTempFile(breadcrumb_path, mode, "w", &tmp_path);
   if (fbreadcrumb == NULL)
     return false;
   string str_breadcrumb = ToString();
-  const int written =
-      fwrite(&(str_breadcrumb[0]), 1, str_breadcrumb.length(), fbreadcrumb);
+  const int written = fwrite(&(str_breadcrumb[0]), 1, str_breadcrumb.length(),
+                             fbreadcrumb);
   fclose(fbreadcrumb);
   if (static_cast<unsigned>(written) != str_breadcrumb.length()) {
     unlink(tmp_path.c_str());

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -521,7 +521,7 @@ void Watchdog::Spawn(const std::string &crash_dump_path) {
   }
 
   // Extra stack for signal handlers
-  const int stack_size = kSignalHandlerStacksize; // 2 MB
+  const int stack_size = kSignalHandlerStacksize;  // 2 MB
   sighandler_stack_.ss_sp = smalloc(stack_size);
   sighandler_stack_.ss_size = stack_size;
   sighandler_stack_.ss_flags = 0;
@@ -542,8 +542,8 @@ void Watchdog::Spawn(const std::string &crash_dump_path) {
   old_signal_handlers_ = SetSignalHandlers(signal_handlers);
 
   pipe_terminate_ = new Pipe<kPipeThreadTerminator>();
-  const int retval =
-      pthread_create(&thread_listener_, NULL, MainWatchdogListener, this);
+  const int retval = pthread_create(&thread_listener_, NULL,
+                                    MainWatchdogListener, this);
   assert(retval == 0);
 
   pipe_watchdog_->Write(ControlFlow::kSupervise);

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1295,8 +1295,8 @@ void MountPoint::CreateAuthz() {
   if (options_mgr_->GetValue("CVMFS_AUTHZ_SEARCH_PATH", &optarg))
     authz_search_path = optarg;
 
-  authz_fetcher_ = new AuthzExternalFetcher(
-      fqrn_, authz_helper, authz_search_path, options_mgr_);
+  authz_fetcher_ = new AuthzExternalFetcher(fqrn_, authz_helper,
+                                            authz_search_path, options_mgr_);
   assert(authz_fetcher_ != NULL);
 
   authz_session_mgr_ = AuthzSessionManager::Create(authz_fetcher_, statistics_);
@@ -1324,9 +1324,9 @@ bool MountPoint::CreateCatalogManager() {
     retval = catalog_mgr_->Init();
   } else {
     fixed_catalog_ = true;
-    const bool alt_root_path =
-        options_mgr_->GetValue("CVMFS_ALT_ROOT_PATH", &optarg) &&
-        options_mgr_->IsOn(optarg);
+    const bool alt_root_path = options_mgr_->GetValue("CVMFS_ALT_ROOT_PATH",
+                                                      &optarg)
+                               && options_mgr_->IsOn(optarg);
     retval = catalog_mgr_->InitFixed(root_hash, alt_root_path);
   }
   if (!retval) {
@@ -1430,8 +1430,8 @@ bool MountPoint::CreateDownloadManagers() {
   download_mgr_->SetProxyChain(proxies, fallback_proxies,
                                download::DownloadManager::kSetProxyBoth);
 
-  const bool do_geosort = options_mgr_->GetValue("CVMFS_USE_GEOAPI", &optarg) &&
-                          options_mgr_->IsOn(optarg);
+  const bool do_geosort = options_mgr_->GetValue("CVMFS_USE_GEOAPI", &optarg)
+                          && options_mgr_->IsOn(optarg);
   if (do_geosort) {
     download_mgr_->ProbeGeo();
   }
@@ -1496,8 +1496,8 @@ bool MountPoint::CreateDownloadManagers() {
             continue;
           }
 
-          const std::string final_token =
-              prefix + key + ": " + Trim(key_val[1]);
+          const std::string final_token = prefix + key + ": "
+                                          + Trim(key_val[1]);
 
           download_mgr_->AddHTTPTracingHeader(final_token);
         }
@@ -1780,8 +1780,8 @@ bool MountPoint::FetchHistory(std::string *history_path) {
   CacheManager::Label label;
   label.flags = CacheManager::kLabelHistory;
   label.path = fqrn_;
-  const int fd =
-      fetcher_->Fetch(CacheManager::LabeledObject(history_hash, label));
+  const int fd = fetcher_->Fetch(
+      CacheManager::LabeledObject(history_hash, label));
   if (fd < 0) {
     boot_error_ = "failed to download history: " + StringifyInt(-fd);
     boot_status_ = loader::kFailHistory;

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -540,8 +540,8 @@ static Failures CaresExtractIpv6(const unsigned char *abuf, int alen,
  * Called when a DNS query returns or times out.  Sets the return status and the
  * IP addresses (if successful) in the QueryInfo object.
  */
-static void CallbackCares(
-    void *arg, int status, int timeouts_ms, unsigned char *abuf, int alen) {
+static void CallbackCares(void *arg, int status, int timeouts_ms,
+                          unsigned char *abuf, int alen) {
   QueryInfo *info = reinterpret_cast<QueryInfo *>(arg);
 
   info->complete = true;
@@ -596,8 +596,8 @@ static Failures CaresExtractIpv4(const unsigned char *abuf,
   struct hostent *host_entry = NULL;
   struct ares_addrttl records[CaresResolver::kMaxAddresses];
   int naddrttls = CaresResolver::kMaxAddresses;
-  const int retval =
-      ares_parse_a_reply(abuf, alen, &host_entry, records, &naddrttls);
+  const int retval = ares_parse_a_reply(abuf, alen, &host_entry, records,
+                                        &naddrttls);
 
   switch (retval) {
     case ARES_SUCCESS:
@@ -646,8 +646,8 @@ static Failures CaresExtractIpv6(const unsigned char *abuf,
   struct hostent *host_entry = NULL;
   struct ares_addr6ttl records[CaresResolver::kMaxAddresses];
   int naddrttls = CaresResolver::kMaxAddresses;
-  const int retval =
-      ares_parse_aaaa_reply(abuf, alen, &host_entry, records, &naddrttls);
+  const int retval = ares_parse_aaaa_reply(abuf, alen, &host_entry, records,
+                                           &naddrttls);
 
   switch (retval) {
     case ARES_SUCCESS:
@@ -1083,8 +1083,8 @@ void HostfileResolver::DoResolve(const vector<string> &names,
     (*failures)[i] = kFailUnknownHost;
     (*fqdns)[i] = names[i];
     for (unsigned j = 0; j < effective_names.size(); ++j) {
-      const map<string, HostEntry>::iterator iter =
-          host_map_.find(effective_names[j]);
+      const map<string, HostEntry>::iterator iter = host_map_.find(
+          effective_names[j]);
       if (iter != host_map_.end()) {
         (*ipv4_addresses)[i].insert((*ipv4_addresses)[i].end(),
                                     iter->second.ipv4_addresses.begin(),
@@ -1237,8 +1237,8 @@ NormalResolver *NormalResolver::Create(const bool ipv4_only,
     delete cares_resolver;
     return NULL;
   }
-  const bool retval =
-      hostfile_resolver->SetSearchDomains(cares_resolver->domains());
+  const bool retval = hostfile_resolver->SetSearchDomains(
+      cares_resolver->domains());
   assert(retval);
 
   NormalResolver *normal_resolver = new NormalResolver();
@@ -1285,8 +1285,8 @@ void NormalResolver::SetSystemResolvers() {
 
 void NormalResolver::SetSystemSearchDomains() {
   cares_resolver_->SetSystemSearchDomains();
-  const bool retval =
-      hostfile_resolver_->SetSearchDomains(cares_resolver_->domains());
+  const bool retval = hostfile_resolver_->SetSearchDomains(
+      cares_resolver_->domains());
   assert(retval);
 }
 

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -91,8 +91,8 @@ bool Interrupted(const std::string &fqrn, JobInfo *info) {
     // it is up to the user the create this sentinel file ("pause_file") if
     // CVMFS_FAILOVER_INDEFINITELY is used. It must be created during
     // "cvmfs_config reload" and "cvmfs_config reload $fqrn"
-    const std::string pause_file =
-        std::string("/var/run/cvmfs/interrupt.") + fqrn;
+    const std::string pause_file = std::string("/var/run/cvmfs/interrupt.")
+                                   + fqrn;
 
     LogCvmfs(kLogDownload, kLogDebug,
              "(id %" PRId64 ") Interrupted(): checking for existence of %s",
@@ -273,9 +273,9 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
   }
 
   if (info->compressed()) {
-    const zlib::StreamStates retval =
-        zlib::DecompressZStream2Sink(ptr, static_cast<int64_t>(num_bytes),
-                                     info->GetZstreamPtr(), info->sink());
+    const zlib::StreamStates retval = zlib::DecompressZStream2Sink(
+        ptr, static_cast<int64_t>(num_bytes), info->GetZstreamPtr(),
+        info->sink());
     if (retval == zlib::kStreamDataError) {
       LogCvmfs(kLogDownload, kLogSyslogErr,
                "(id %" PRId64 ") failed to decompress %s", info->id(),
@@ -610,16 +610,16 @@ void *DownloadManager::MainDownload(void *data) {
           1000 * DiffTimeSeconds(timeval_start, timeval_stop));
       perf::Xadd(download_mgr->counters_->sz_transfer_time, delta);
     }
-    const int retval =
-        poll(download_mgr->watch_fds_, download_mgr->watch_fds_inuse_, timeout);
+    const int retval = poll(download_mgr->watch_fds_,
+                            download_mgr->watch_fds_inuse_, timeout);
     if (retval < 0) {
       continue;
     }
 
     // Handle timeout
     if (retval == 0) {
-      curl_multi_socket_action(
-          download_mgr->curl_multi_, CURL_SOCKET_TIMEOUT, 0, &still_running);
+      curl_multi_socket_action(download_mgr->curl_multi_, CURL_SOCKET_TIMEOUT,
+                               0, &still_running);
     }
 
     // Terminate I/O thread
@@ -638,8 +638,8 @@ void *DownloadManager::MainDownload(void *data) {
       download_mgr->InitializeRequest(info, handle);
       download_mgr->SetUrlOptions(info);
       curl_multi_add_handle(download_mgr->curl_multi_, handle);
-      curl_multi_socket_action(
-          download_mgr->curl_multi_, CURL_SOCKET_TIMEOUT, 0, &still_running);
+      curl_multi_socket_action(download_mgr->curl_multi_, CURL_SOCKET_TIMEOUT,
+                               0, &still_running);
     }
 
     // Activity on curl sockets
@@ -851,8 +851,8 @@ string DownloadManager::ProxyInfo::Print() {
     return url;
 
   string result = url;
-  const int remaining =
-      static_cast<int>(host.deadline()) - static_cast<int>(time(NULL));
+  const int remaining = static_cast<int>(host.deadline())
+                        - static_cast<int>(time(NULL));
   string expinfo = (remaining >= 0) ? "+" : "";
   if (abs(remaining) >= 3600) {
     expinfo += StringifyInt(remaining / 3600) + "h";
@@ -1128,8 +1128,8 @@ void DownloadManager::SetUrlOptions(JobInfo *info) {
 
   curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 1L);
   if (url.substr(0, 5) == "https") {
-    const bool rvb =
-        ssl_certificate_store_.ApplySslCertificatePath(curl_handle);
+    const bool rvb = ssl_certificate_store_.ApplySslCertificatePath(
+        curl_handle);
     if (!rvb) {
       LogCvmfs(kLogDownload, kLogDebug | kLogSyslogWarn,
                "(manager %s - id %" PRId64 ") "
@@ -2539,8 +2539,8 @@ bool DownloadManager::GeoSortServers(std::vector<std::string> *servers,
   const unsigned max_attempts = std::min(host_chain_shuffled.size(), size_t(3));
   vector<uint64_t> geo_order(servers->size());
   for (unsigned i = 0; i < max_attempts; ++i) {
-    const string url =
-        host_chain_shuffled[i] + "/api/v1.0/geo/@proxy@/" + host_list;
+    const string url = host_chain_shuffled[i] + "/api/v1.0/geo/@proxy@/"
+                       + host_list;
     LogCvmfs(kLogDownload, kLogDebug,
              "(manager '%s') requesting ordered server list from %s",
              name_.c_str(), url.c_str());
@@ -2909,8 +2909,8 @@ void DownloadManager::SetProxyChain(const string &proxy_list,
                  name_.c_str(), hosts[num_proxy].name().c_str(),
                  hosts[num_proxy].status(),
                  dns::Code2Ascii(hosts[num_proxy].status()));
-        const dns::Host failed_host =
-            dns::Host::ExtendDeadline(hosts[num_proxy], resolver_->min_ttl());
+        const dns::Host failed_host = dns::Host::ExtendDeadline(
+            hosts[num_proxy], resolver_->min_ttl());
         infos.push_back(ProxyInfo(failed_host, this_group[j]));
         continue;
       }
@@ -2958,7 +2958,7 @@ void DownloadManager::GetProxyInfo(vector<vector<ProxyInfo> > *proxy_chain,
   const MutexLockGuard m(lock_options_);
 
   if (!opt_proxy_groups_) {
-    const vector< vector<ProxyInfo> > empty_chain;
+    const vector<vector<ProxyInfo> > empty_chain;
     *proxy_chain = empty_chain;
     if (current_group != NULL)
       *current_group = 0;
@@ -2989,8 +2989,8 @@ DownloadManager::ProxyInfo *DownloadManager::ChooseProxyUnlocked(
     return NULL;
 
   const uint32_t key = (hash ? hash->Partial32() : 0);
-  const map<uint32_t, ProxyInfo *>::iterator it =
-      opt_proxy_map_.lower_bound(key);
+  const map<uint32_t, ProxyInfo *>::iterator it = opt_proxy_map_.lower_bound(
+      key);
   ProxyInfo *proxy = it->second;
 
   return proxy;
@@ -3024,8 +3024,9 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
         const std::pair<uint32_t, ProxyInfo *> entry(prng.Next(max_key), proxy);
         opt_proxy_map_.insert(entry);
       }
-      const std::string proxy_name =
-          proxy->host.name().empty() ? "" : " (" + proxy->host.name() + ")";
+      const std::string proxy_name = proxy->host.name().empty()
+                                         ? ""
+                                         : " (" + proxy->host.name() + ")";
       opt_proxies_.push_back(proxy->url + proxy_name);
     }
     // Ensure lower_bound() finds a value for all keys
@@ -3038,8 +3039,9 @@ void DownloadManager::UpdateProxiesUnlocked(const string &reason) {
     ProxyInfo *proxy = &(*group)[select];
     const std::pair<uint32_t, ProxyInfo *> entry(max_key, proxy);
     opt_proxy_map_.insert(entry);
-    const std::string proxy_name =
-        proxy->host.name().empty() ? "" : " (" + proxy->host.name() + ")";
+    const std::string proxy_name = proxy->host.name().empty()
+                                       ? ""
+                                       : " (" + proxy->host.name() + ")";
     opt_proxies_.push_back(proxy->url + proxy_name);
   }
   sort(opt_proxies_.begin(), opt_proxies_.end());
@@ -3101,8 +3103,8 @@ void DownloadManager::SwitchProxyGroup() {
                               % opt_proxy_groups_->size();
   opt_timestamp_backup_proxies_ = time(NULL);
 
-  const std::string msg =
-      "switch to proxy group " + StringifyUint(opt_proxy_groups_current_);
+  const std::string msg = "switch to proxy group "
+                          + StringifyUint(opt_proxy_groups_current_);
   RebalanceProxiesUnlocked(msg);
 }
 

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -118,8 +118,8 @@ NfsMapsLeveldb *NfsMapsLeveldb::Create(const string &leveldb_dir,
   if (rebuild) {
     LogCvmfs(kLogNfsMaps, kLogSyslogWarn,
              "rebuilding NFS maps, might result in stale entries");
-    const bool retval = RemoveTree(leveldb_dir + "/inode2path") &&
-                        RemoveTree(leveldb_dir + "/path2inode");
+    const bool retval = RemoveTree(leveldb_dir + "/inode2path")
+                        && RemoveTree(leveldb_dir + "/path2inode");
     if (!retval) {
       LogCvmfs(kLogNfsMaps, kLogDebug, "failed to remove previous databases");
       return NULL;

--- a/cvmfs/notification_client.cc
+++ b/cvmfs/notification_client.cc
@@ -48,10 +48,10 @@ class ActivitySubscriber : public notify::SubscriberSSE {
     }
 
     manifest::ManifestEnsemble ensemble;
-    const manifest::Failures res =
-        manifest::Verify(reinterpret_cast<unsigned char *>(&(msg.manifest_[0])),
-                         msg.manifest_.size(), "", repo_name, 0, NULL, sig_mgr_,
-                         dl_mgr_, &ensemble);
+    const manifest::Failures res = manifest::Verify(
+        reinterpret_cast<unsigned char *>(&(msg.manifest_[0])),
+        msg.manifest_.size(), "", repo_name, 0, NULL, sig_mgr_, dl_mgr_,
+        &ensemble);
 
     if (res != manifest::kFailOk) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr,

--- a/cvmfs/notify/cmd_pub.cc
+++ b/cvmfs/notify/cmd_pub.cc
@@ -58,8 +58,8 @@ int DoPublish(const std::string &server_url, const std::string &repository_url,
     cvmfs::MemSink manifest_memsink;
     download::JobInfo download_manifest(&manifest_url, false, false, NULL,
                                         &manifest_memsink);
-    const download::Failures retval =
-        download_manager->Fetch(&download_manifest);
+    const download::Failures retval = download_manager->Fetch(
+        &download_manifest);
     if (retval != download::kFailOk) {
       LogCvmfs(kLogCvmfs, kLogError, "Failed to download manifest (%d - %s)",
                retval, download::Code2Ascii(retval));

--- a/cvmfs/notify/cmd_sub.cc
+++ b/cvmfs/notify/cmd_sub.cc
@@ -65,8 +65,8 @@ class SwissknifeSubscriber : public notify::SubscriberSSE {
 
     sig_mgr_->Init();
 
-    const std::string public_keys =
-        JoinStrings(FindFilesBySuffix("/etc/cvmfs/keys", ".pub"), ":");
+    const std::string public_keys = JoinStrings(
+        FindFilesBySuffix("/etc/cvmfs/keys", ".pub"), ":");
     if (!sig_mgr_->LoadPublicRsaKeys(public_keys)) {
       LogCvmfs(kLogCvmfs, kLogError,
                "SwissknifeSubscriber - could not load public keys");
@@ -87,10 +87,10 @@ class SwissknifeSubscriber : public notify::SubscriberSSE {
     }
 
     manifest::ManifestEnsemble ensemble;
-    const manifest::Failures res =
-        manifest::Verify(reinterpret_cast<unsigned char *>(&(msg.manifest_[0])),
-                         msg.manifest_.size(), "", repo, 0, NULL,
-                         sig_mgr_.weak_ref(), dl_mgr_.weak_ref(), &ensemble);
+    const manifest::Failures res = manifest::Verify(
+        reinterpret_cast<unsigned char *>(&(msg.manifest_[0])),
+        msg.manifest_.size(), "", repo, 0, NULL, sig_mgr_.weak_ref(),
+        dl_mgr_.weak_ref(), &ensemble);
 
     if (res != manifest::kFailOk) {
       LogCvmfs(kLogCvmfs, kLogError,

--- a/cvmfs/notify/subscriber_sse.cc
+++ b/cvmfs/notify/subscriber_sse.cc
@@ -41,8 +41,8 @@ bool SubscriberSSE::Subscribe(const std::string &topic) {
 
   this->topic_ = topic;
 
-  const std::string request =
-      "{\"version\":1,\"repository\":\"" + topic + "\"}";
+  const std::string request = "{\"version\":1,\"repository\":\"" + topic
+                              + "\"}";
 
   const char *user_agent_string = "cvmfs/" CVMFS_VERSION;
 
@@ -120,8 +120,8 @@ size_t SubscriberSSE::CurlRecvCB(void *buffer, size_t size, size_t nmemb,
     sub->AppendToBuffer(lines[0]);
   } else {
     sub->AppendToBuffer(lines[0]);
-    const notify::Subscriber::Status st =
-        sub->Consume(sub->topic_, sub->buffer_);
+    const notify::Subscriber::Status st = sub->Consume(sub->topic_,
+                                                       sub->buffer_);
     sub->ClearBuffer();
     for (size_t i = 1; i < lines.size(); ++i) {
       if (lines[i].substr(0, 5) == "data: ") {

--- a/cvmfs/object_fetcher.h
+++ b/cvmfs/object_fetcher.h
@@ -166,8 +166,8 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
       return retval;
     }
 
-    *catalog = CatalogTN::AttachFreely(
-        catalog_path, path, catalog_hash, parent, is_nested);
+    *catalog = CatalogTN::AttachFreely(catalog_path, path, catalog_hash, parent,
+                                       is_nested);
     if (NULL == *catalog) {
       return kFailLocalIO;
     }
@@ -228,8 +228,8 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
                         const bool is_nested = false,
                         CatalogTN *parent = NULL) {
     CatalogTN *raw_catalog_ptr = NULL;
-    Failures failure = FetchCatalog(
-        catalog_hash, catalog_path, &raw_catalog_ptr, is_nested, parent);
+    Failures failure = FetchCatalog(catalog_hash, catalog_path,
+                                    &raw_catalog_ptr, is_nested, parent);
     if (failure == kFailOk)
       *catalog = raw_catalog_ptr;
     return failure;
@@ -278,8 +278,8 @@ class AbstractObjectFetcher : public ObjectFetcherFailures {
                  const bool decompress,
                  const bool nocache,
                  std::string *file_path) {
-    return static_cast<DerivedT *>(this)->Fetch(
-        relative_path, decompress, nocache, file_path);
+    return static_cast<DerivedT *>(this)->Fetch(relative_path, decompress,
+                                                nocache, file_path);
   }
 
   /**

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -318,8 +318,8 @@ void OptionsManager::ParseDefault(const string &fqrn) {
 
 
 void OptionsManager::PopulateParameter(const string &param, ConfigValue val) {
-  const map<string, string>::const_iterator iter =
-      protected_parameters_.find(param);
+  const map<string, string>::const_iterator iter = protected_parameters_.find(
+      param);
   if ((iter != protected_parameters_.end()) && (iter->second != val.value)) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
              "error in cvmfs configuration: attempt to change protected %s "

--- a/cvmfs/pack.cc
+++ b/cvmfs/pack.cc
@@ -235,8 +235,8 @@ unsigned ObjectPackProducer::ProduceNext(const unsigned buf_size,
   unsigned nbytes_payload = 0;
 
   if (big_file_) {
-    const size_t nbytes =
-        fread(buf + nbytes_header, 1, remaining_in_buf, big_file_);
+    const size_t nbytes = fread(buf + nbytes_header, 1, remaining_in_buf,
+                                big_file_);
     nbytes_payload = nbytes;
     pos_ += nbytes_payload;
   } else if (idx_ < pack_->GetNoObjects()) {
@@ -423,8 +423,8 @@ bool ObjectPackConsumer::ParseHeader() {
   uint64_t sum_size = 0;
   do {
     const unsigned remaining_in_header = raw_header_.size() - index_idx;
-    const string line =
-        GetLineMem(raw_header_.data() + index_idx, remaining_in_header);
+    const string line = GetLineMem(raw_header_.data() + index_idx,
+                                   remaining_in_header);
     if (line == "")
       break;
 
@@ -485,8 +485,8 @@ bool ObjectPackConsumer::ParseItem(const std::string &line,
       return false;
     }
 
-    const uint64_t size =
-        String2Uint64(line.substr(separator1 + 1, separator2 - separator1 - 1));
+    const uint64_t size = String2Uint64(
+        line.substr(separator1 + 1, separator2 - separator1 - 1));
 
     std::string name;
     if (!Debase64(line.substr(separator2 + 1), &name)) {

--- a/cvmfs/path_filters/dirtab.cc
+++ b/cvmfs/path_filters/dirtab.cc
@@ -45,8 +45,8 @@ bool Dirtab::Parse(const std::string &dirtab) {
   valid_ = true;
   off_t line_offset = 0;
   while (line_offset < static_cast<off_t>(dirtab.size())) {
-    const std::string line =
-        GetLineMem(dirtab.c_str() + line_offset, dirtab.size() - line_offset);
+    const std::string line = GetLineMem(dirtab.c_str() + line_offset,
+                                        dirtab.size() - line_offset);
     line_offset += line.size() + 1;  // +1 == skipped \n
     if (!ParseLine(line)) {
       valid_ = false;

--- a/cvmfs/publish/cmd_commit.cc
+++ b/cvmfs/publish/cmd_commit.cc
@@ -73,8 +73,8 @@ int CmdCommit::Main(const Options &options) {
     }
   }
 
-  const double whitelist_valid_s =
-      difftime(publisher->whitelist()->expires(), time(NULL));
+  const double whitelist_valid_s = difftime(publisher->whitelist()->expires(),
+                                            time(NULL));
   if (whitelist_valid_s < (12 * 60 * 60)) {
     LogCvmfs(
         kLogCvmfs, kLogStdout,

--- a/cvmfs/publish/cmd_diff.cc
+++ b/cvmfs/publish/cmd_diff.cc
@@ -64,17 +64,17 @@ class DiffReporter : public publish::DiffListener {
     const std::string operation = machine_readable_ ? "S " : "d(";
     const std::string type_file = machine_readable_ ? "F" : "# regular files):";
     const std::string type_symlink = machine_readable_ ? "S" : "# symlinks):";
-    const std::string type_directory =
-        machine_readable_ ? "D" : "# directories):";
+    const std::string type_directory = machine_readable_ ? "D"
+                                                         : "# directories):";
     const std::string type_catalog = machine_readable_ ? "N" : "# catalogs):";
-    const int64_t diff_file =
-        delta.self.regular_files + delta.subtree.regular_files;
+    const int64_t diff_file = delta.self.regular_files
+                              + delta.subtree.regular_files;
     const int64_t diff_symlink = delta.self.symlinks + delta.subtree.symlinks;
-    const int64_t diff_catalog =
-        delta.self.nested_catalogs + delta.subtree.nested_catalogs;
+    const int64_t diff_catalog = delta.self.nested_catalogs
+                                 + delta.subtree.nested_catalogs;
     // Nested catalogs make internally two directory entries
-    const int64_t diff_directory =
-        delta.self.directories + delta.subtree.directories - diff_catalog;
+    const int64_t diff_directory = delta.self.directories
+                                   + delta.subtree.directories - diff_catalog;
     LogCvmfs(kLogCvmfs, kLogStdout, "%s%s %" PRId64, operation.c_str(),
              type_file.c_str(), diff_file);
     LogCvmfs(kLogCvmfs, kLogStdout, "%s%s %" PRId64, operation.c_str(),

--- a/cvmfs/publish/cmd_enter.cc
+++ b/cvmfs/publish/cmd_enter.cc
@@ -274,9 +274,9 @@ void CmdEnter::WriteCvmfsConfig(const std::string &extra_config) {
   options_manager.SetValue("CVMFS_CACHE_private_SHARED", "on");
   options_manager.SetValue("CVMFS_CACHE_private_QUOTA_LIMIT", "4000");
 
-  const bool rv =
-      SafeWriteToFile(options_manager.Dump(),
-                      settings_spool_area_.client_config(), kPrivateFileMode);
+  const bool rv = SafeWriteToFile(options_manager.Dump(),
+                                  settings_spool_area_.client_config(),
+                                  kPrivateFileMode);
   if (!rv) {
     throw EPublish("cannot write client config to "
                    + settings_spool_area_.client_config());
@@ -361,9 +361,9 @@ void CmdEnter::MountOverlayfs() {
   map_fds[fd_stdout] = 1;
   map_fds[fd_stderr] = 2;
   pid_t pid_child;
-  const bool rvb =
-      ManagedExec(cmdline, preserved_fds, map_fds, true /* drop_credentials */,
-                  false /* clear_env */, false /* double_fork */, &pid_child);
+  const bool rvb = ManagedExec(
+      cmdline, preserved_fds, map_fds, true /* drop_credentials */,
+      false /* clear_env */, false /* double_fork */, &pid_child);
   if (!rvb) {
     close(fd_stdout);
     close(fd_stderr);
@@ -590,8 +590,8 @@ int CmdEnter::Main(const Options &options) {
                  repo_config_.c_str());
 
         std::string config;
-        const std::string config_file =
-            repo_config_ + "/" + fqrn_ + "/server.conf";
+        const std::string config_file = repo_config_ + "/" + fqrn_
+                                        + "/server.conf";
         const std::string folderpath = session_dir_ + "/" + fqrn_;
         MkdirDeep(folderpath.c_str(), 0700, true /* veryfy_writable */);
 

--- a/cvmfs/publish/cmd_info.cc
+++ b/cvmfs/publish/cmd_info.cc
@@ -45,8 +45,8 @@ int CmdInfo::Main(const Options &options) {
   if (repository.whitelist()->IsExpired()) {
     LogCvmfs(kLogCvmfs, kLogStdout, "Whitelist is expired");
   } else {
-    const double delta_s =
-        difftime(repository.whitelist()->expires(), time(NULL));
+    const double delta_s = difftime(repository.whitelist()->expires(),
+                                    time(NULL));
     const int delta_d = static_cast<int>(delta_s / 86400);
     LogCvmfs(kLogCvmfs, kLogStdout, "Whitelist is valid for another %d days",
              delta_d);

--- a/cvmfs/publish/cmd_mkfs.cc
+++ b/cvmfs/publish/cmd_mkfs.cc
@@ -73,15 +73,15 @@ int CmdMkfs::Main(const Options &options) {
         options.GetString("s3config"),
         settings.transaction().spool_area().tmp_dir());
   }
-  const bool configure_apache =
-      (settings.storage().type() == upload::SpoolerDefinition::Local) &&
-      options.HasNot("no-apache");
+  const bool configure_apache = (settings.storage().type()
+                                 == upload::SpoolerDefinition::Local)
+                                && options.HasNot("no-apache");
 
   // Permission check
   if (geteuid() != 0) {
-    const bool can_unprivileged = options.Has("no-publisher") &&
-                                  !configure_apache &&
-                                  (user_name == GetUserName());
+    const bool can_unprivileged = options.Has("no-publisher")
+                                  && !configure_apache
+                                  && (user_name == GetUserName());
     if (!can_unprivileged)
       throw EPublish("root privileges required");
   }
@@ -90,9 +90,9 @@ int CmdMkfs::Main(const Options &options) {
   if (options.Has("stratum0")) {
     settings.SetUrl(options.GetString("stratum0"));
   } else {
-    const bool need_stratum0 =
-        (settings.storage().type() != upload::SpoolerDefinition::Local) &&
-        options.HasNot("no-publisher");
+    const bool need_stratum0 = (settings.storage().type()
+                                != upload::SpoolerDefinition::Local)
+                               && options.HasNot("no-publisher");
     if (need_stratum0) {
       throw EPublish("repository stratum 0 URL for non-local storage "
                      "(add option -w)");

--- a/cvmfs/publish/cmd_transaction.cc
+++ b/cvmfs/publish/cmd_transaction.cc
@@ -99,8 +99,8 @@ int CmdTransaction::Main(const Options &options) {
     return EIO;
   }
 
-  const double whitelist_valid_s =
-      difftime(publisher->whitelist()->expires(), time(NULL));
+  const double whitelist_valid_s = difftime(publisher->whitelist()->expires(),
+                                            time(NULL));
   if (whitelist_valid_s < (12 * 60 * 60)) {
     LogCvmfs(
         kLogCvmfs, kLogStdout,

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -145,9 +145,9 @@ void Repository::DownloadRootObjects(const std::string &url,
   manifest::ManifestEnsemble ensemble;
   const uint64_t minimum_timestamp = 0;
   const shash::Any *base_catalog = NULL;
-  const manifest::Failures rv_manifest =
-      manifest::Fetch(url, fqrn, minimum_timestamp, base_catalog,
-                      signature_mgr_, download_mgr_, &ensemble);
+  const manifest::Failures rv_manifest = manifest::Fetch(
+      url, fqrn, minimum_timestamp, base_catalog, signature_mgr_, download_mgr_,
+      &ensemble);
   if (rv_manifest != manifest::kFailOk)
     throw EPublish("cannot load manifest");
   delete manifest_;
@@ -182,8 +182,8 @@ void Repository::DownloadRootObjects(const std::string &url,
   FILE *tags_fd = CreateTempFile(tmp_dir + "/tags", kPrivateFileMode, "w",
                                  &tags_path);
   if (!manifest_->history().IsNull()) {
-    const std::string tags_url =
-        url + "/data/" + manifest_->history().MakePath();
+    const std::string tags_url = url + "/data/"
+                                 + manifest_->history().MakePath();
     const shash::Any tags_hash(manifest_->history());
     cvmfs::FileSink filesink(tags_fd);
     download::JobInfo download_tags(&tags_url, true /* compressed */,
@@ -587,8 +587,8 @@ void Publisher::CreateDirectoryAsOwner(const std::string &path, int mode) {
   const bool rvb = MkdirDeep(path, mode);
   if (!rvb)
     throw EPublish("cannot create directory " + path);
-  const int rvi =
-      chown(path.c_str(), settings_.owner_uid(), settings_.owner_gid());
+  const int rvi = chown(path.c_str(), settings_.owner_uid(),
+                        settings_.owner_gid());
   if (rvi != 0)
     throw EPublish("cannot set ownership on directory " + path);
 }

--- a/cvmfs/publish/repository_abort.cc
+++ b/cvmfs/publish/repository_abort.cc
@@ -67,8 +67,8 @@ void Publisher::Abort() {
     // We already checked for is_publishing and in_transaction.  Normally, at
     // this point we do want to repair the mount points of a repository
     // in transaction
-    const EUnionMountRepairMode repair_mode =
-        settings_.transaction().spool_area().repair_mode();
+    const EUnionMountRepairMode
+        repair_mode = settings_.transaction().spool_area().repair_mode();
     if (repair_mode == kUnionMountRepairSafe) {
       settings_.GetTransaction()->GetSpoolArea()->SetRepairMode(
           kUnionMountRepairAlways);

--- a/cvmfs/publish/repository_diff.cc
+++ b/cvmfs/publish/repository_diff.cc
@@ -105,8 +105,8 @@ void Repository::Diff(const std::string &from, const std::string &to,
       true /* manage_catalog_files */);
   mgr_to->Init();
 
-  const catalog::Counters counters_from =
-      mgr_from->GetRootCatalog()->GetCounters();
+  const catalog::Counters counters_from = mgr_from->GetRootCatalog()
+                                              ->GetCounters();
   const catalog::Counters counters_to = mgr_to->GetRootCatalog()->GetCounters();
   diff_listener->OnStats(catalog::Counters::Diff(counters_from, counters_to));
 

--- a/cvmfs/publish/repository_managed.cc
+++ b/cvmfs/publish/repository_managed.cc
@@ -65,8 +65,8 @@ void Publisher::ManagedNode::ClearScratch() {
   const std::string waste_dir = CreateTempDir(scratch_wastebin + "/waste");
   if (waste_dir.empty())
     throw EPublish("cannot create wastebin directory");
-  const int rvi =
-      rename(scratch_dir.c_str(), (waste_dir + "/delete-me").c_str());
+  const int rvi = rename(scratch_dir.c_str(),
+                         (waste_dir + "/delete-me").c_str());
   if (rvi != 0)
     throw EPublish("cannot move scratch directory to wastebin");
 
@@ -94,8 +94,9 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
   const std::string
       union_mnt = publisher_->settings_.transaction().spool_area().union_mnt();
   const std::string fqrn = publisher_->settings_.fqrn();
-  const EUnionMountRepairMode repair_mode =
-      publisher_->settings_.transaction().spool_area().repair_mode();
+  const EUnionMountRepairMode repair_mode = publisher_->settings_.transaction()
+                                                .spool_area()
+                                                .repair_mode();
 
   int result = kFailOk;
 
@@ -110,8 +111,8 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
   } else {
     const std::string root_hash_xattr = "user.root_hash";
     std::string root_hash_str;
-    const bool retval =
-        platform_getxattr(rdonly_mnt, root_hash_xattr, &root_hash_str);
+    const bool retval = platform_getxattr(rdonly_mnt, root_hash_xattr,
+                                          &root_hash_str);
     if (retval) {
       const shash::Any root_hash = shash::MkFromHexPtr(
           shash::HexPtr(root_hash_str), shash::kSuffixCatalog);

--- a/cvmfs/publish/repository_session.cc
+++ b/cvmfs/publish/repository_session.cc
@@ -274,8 +274,8 @@ void Publisher::Session::Acquire() {
   if (has_lease_)
     return;
 
-  const gateway::GatewayKey gw_key =
-      gateway::ReadGatewayKey(settings_.gw_key_path);
+  const gateway::GatewayKey gw_key = gateway::ReadGatewayKey(
+      settings_.gw_key_path);
   if (!gw_key.IsValid()) {
     throw EPublish("cannot read gateway key: " + settings_.gw_key_path,
                    EPublish::kFailGatewayKey);
@@ -285,13 +285,13 @@ void Publisher::Session::Acquire() {
                      settings_.llvl, &buffer);
 
   std::string session_token;
-  const LeaseReply rep =
-      ParseAcquireReply(buffer, &session_token, settings_.llvl);
+  const LeaseReply rep = ParseAcquireReply(buffer, &session_token,
+                                           settings_.llvl);
   switch (rep) {
     case kLeaseReplySuccess: {
       has_lease_ = true;
-      const bool rvb =
-          SafeWriteToFile(session_token, settings_.token_path, 0600);
+      const bool rvb = SafeWriteToFile(session_token, settings_.token_path,
+                                       0600);
       if (!rvb) {
         throw EPublish("cannot write session token: " + settings_.token_path);
       }
@@ -321,8 +321,8 @@ void Publisher::Session::Drop() {
     throw EPublish("cannot read session token: " + settings_.token_path,
                    EPublish::kFailGatewayKey);
   }
-  const gateway::GatewayKey gw_key =
-      gateway::ReadGatewayKey(settings_.gw_key_path);
+  const gateway::GatewayKey gw_key = gateway::ReadGatewayKey(
+      settings_.gw_key_path);
   if (!gw_key.IsValid()) {
     throw EPublish("cannot read gateway key: " + settings_.gw_key_path,
                    EPublish::kFailGatewayKey);

--- a/cvmfs/publish/repository_transaction.cc
+++ b/cvmfs/publish/repository_transaction.cc
@@ -84,12 +84,12 @@ void Publisher::TransactionImpl(bool waiting_on_lease) {
   // run into problems when merging catalogs later, so for the time being we
   // disallow transactions on non-existing paths.
   if (!settings_.transaction().lease_path().empty()) {
-    const std::string path =
-        GetParentPath("/" + settings_.transaction().lease_path());
+    const std::string path = GetParentPath(
+        "/" + settings_.transaction().lease_path());
     catalog::SimpleCatalogManager *catalog_mgr = GetSimpleCatalogManager();
     catalog::DirectoryEntry dirent;
-    const bool retval =
-        catalog_mgr->LookupPath(path, catalog::kLookupDefault, &dirent);
+    const bool retval = catalog_mgr->LookupPath(path, catalog::kLookupDefault,
+                                                &dirent);
     if (!retval) {
       throw EPublish("cannot open transaction on non-existing path " + path,
                      EPublish::kFailLeaseNoEntry);

--- a/cvmfs/publish/repository_util.cc
+++ b/cvmfs/publish/repository_util.cc
@@ -122,10 +122,10 @@ void RunSuidHelper(const std::string &verb, const std::string &fqrn) {
   preserved_fds.insert(1);
   preserved_fds.insert(2);
   pid_t child_pid;
-  const bool retval =
-      ManagedExec(cmd_line, preserved_fds, std::map<int, int>(),
-                  false /* drop_credentials */, true /* clear_env */,
-                  false /* double_fork */, &child_pid);
+  const bool retval = ManagedExec(cmd_line, preserved_fds, std::map<int, int>(),
+                                  false /* drop_credentials */,
+                                  true /* clear_env */, false /* double_fork */,
+                                  &child_pid);
   if (!retval)
     throw EPublish("cannot spawn suid helper");
   const int exit_code = WaitForChild(child_pid);

--- a/cvmfs/publish/settings.cc
+++ b/cvmfs/publish/settings.cc
@@ -337,8 +337,8 @@ void SettingsPublisher::SetProxy(const std::string &proxy) { proxy_ = proxy; }
 
 
 void SettingsPublisher::SetOwner(const std::string &user_name) {
-  const bool retval =
-      GetUidOf(user_name, owner_uid_.GetPtr(), owner_gid_.GetPtr());
+  const bool retval = GetUidOf(
+      user_name, owner_uid_.GetPtr(), owner_gid_.GetPtr());
   if (!retval) {
     throw EPublish("unknown user name for repository owner: " + user_name);
   }
@@ -485,8 +485,8 @@ SettingsPublisher *SettingsBuilder::CreateSettingsPublisherFromSession() {
   settings_publisher->GetTransaction()->GetSpoolArea()->SetSpoolArea(
       session_dir);
 
-  const std::string base_hash =
-      settings_publisher->GetReadOnlyXAttr("user.root_hash");
+  const std::string base_hash = settings_publisher->GetReadOnlyXAttr(
+      "user.root_hash");
 
   BashOptionsManager omgr;
   omgr.set_taint_environment(false);
@@ -604,8 +604,8 @@ SettingsPublisher *SettingsBuilder::CreateSettingsPublisher(
         EPublish::kFailRepositoryNotFound);
   }
 
-  const SettingsRepository settings_repository =
-      CreateSettingsRepository(alias);
+  const SettingsRepository settings_repository = CreateSettingsRepository(
+      alias);
   if (needs_managed && !IsManagedRepository())
     throw EPublish("remote repositories are not supported in this context");
 
@@ -618,8 +618,8 @@ SettingsPublisher *SettingsBuilder::CreateSettingsPublisher(
       new SettingsPublisher(settings_repository));
 
   try {
-    const std::string xattr =
-        settings_publisher->GetReadOnlyXAttr("user.root_hash");
+    const std::string xattr = settings_publisher->GetReadOnlyXAttr(
+        "user.root_hash");
     settings_publisher->GetTransaction()->SetBaseHash(
         shash::MkFromHexPtr(shash::HexPtr(xattr), shash::kSuffixCatalog));
   } catch (const EPublish &e) {

--- a/cvmfs/quota_listener.cc
+++ b/cvmfs/quota_listener.cc
@@ -128,9 +128,9 @@ ListenerHandle *RegisterUnpinListener(QuotaManager *quota_manager,
   handle->quota_manager = quota_manager;
   handle->catalog_manager = catalog_manager;
   handle->repository_name = repository_name;
-  const int retval =
-      pthread_create(&handle->thread_listener, NULL, MainUnpinListener,
-                     static_cast<void *>(handle));
+  const int retval = pthread_create(&handle->thread_listener, NULL,
+                                    MainUnpinListener,
+                                    static_cast<void *>(handle));
   assert(retval == 0);
   return handle;
 }
@@ -148,9 +148,9 @@ ListenerHandle *RegisterWatchdogListener(QuotaManager *quota_manager,
   handle->quota_manager = quota_manager;
   handle->catalog_manager = NULL;
   handle->repository_name = repository_name;
-  const int retval =
-      pthread_create(&handle->thread_listener, NULL, MainWatchdogListener,
-                     static_cast<void *>(handle));
+  const int retval = pthread_create(&handle->thread_listener, NULL,
+                                    MainWatchdogListener,
+                                    static_cast<void *>(handle));
   assert(retval == 0);
   return handle;
 }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -66,9 +66,9 @@ int PosixQuotaManager::BindReturnPipe(int pipe_wronly) {
     return pipe_wronly;
 
   // Connect writer's end
-  const int result =
-      open((workspace_dir_ + "/pipe" + StringifyInt(pipe_wronly)).c_str(),
-           O_WRONLY | O_NONBLOCK);
+  const int result = open(
+      (workspace_dir_ + "/pipe" + StringifyInt(pipe_wronly)).c_str(),
+      O_WRONLY | O_NONBLOCK);
   if (result >= 0) {
     Nonblock2Block(result);
   } else {
@@ -1249,8 +1249,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // The protocol revision is returned immediately
     if (command_type == kGetProtocolRevision) {
-      const int return_pipe =
-          quota_mgr->BindReturnPipe(command_buffer[num_commands].return_pipe);
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
       if (return_pipe < 0)
         continue;
       WritePipe(return_pipe, &quota_mgr->kProtocolRevision,
@@ -1261,12 +1261,12 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // The cleanup rate is returned immediately
     if (command_type == kCleanupRate) {
-      const int return_pipe =
-          quota_mgr->BindReturnPipe(command_buffer[num_commands].return_pipe);
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
       if (return_pipe < 0)
         continue;
-      const uint64_t period_s =
-          size; // use the size field to transmit the period
+      const uint64_t
+          period_s = size;  // use the size field to transmit the period
       uint64_t rate = quota_mgr->cleanup_recorder_.GetNoTicks(period_s);
       WritePipe(return_pipe, &rate, sizeof(rate));
       quota_mgr->UnbindReturnPipe(return_pipe);
@@ -1292,8 +1292,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
     // Reservations are handled immediately and "out of band"
     if (command_type == kReserve) {
       bool success = true;
-      const int return_pipe =
-          quota_mgr->BindReturnPipe(command_buffer[num_commands].return_pipe);
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
       if (return_pipe < 0)
         continue;
 
@@ -1322,8 +1322,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Back channels are also handled out of band
     if (command_type == kRegisterBackChannel) {
-      const int return_pipe =
-          quota_mgr->BindReturnPipe(command_buffer[num_commands].return_pipe);
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
       if (return_pipe < 0)
         continue;
 
@@ -1334,8 +1334,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
              shash::kDigestSizes[shash::kMd5]);
 
       quota_mgr->LockBackChannels();
-      const map<shash::Md5, int>::const_iterator iter =
-          quota_mgr->back_channels_.find(hash);
+      const map<shash::Md5, int>::const_iterator
+          iter = quota_mgr->back_channels_.find(hash);
       if (iter != quota_mgr->back_channels_.end()) {
         LogCvmfs(kLogQuota, kLogDebug | kLogSyslogWarn,
                  "closing left-over back channel %s", hash.ToString().c_str());
@@ -1358,8 +1358,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
              shash::kDigestSizes[shash::kMd5]);
 
       quota_mgr->LockBackChannels();
-      const map<shash::Md5, int>::iterator iter =
-          quota_mgr->back_channels_.find(hash);
+      const map<shash::Md5, int>::iterator iter = quota_mgr->back_channels_
+                                                      .find(hash);
       if (iter != quota_mgr->back_channels_.end()) {
         LogCvmfs(kLogQuota, kLogDebug, "closing back channel %s",
                  hash.ToString().c_str());
@@ -1379,8 +1379,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       const shash::Any hash = command_buffer[num_commands].RetrieveHash();
       const string hash_str(hash.ToString());
 
-      const map<shash::Any, uint64_t>::iterator iter =
-          quota_mgr->pinned_chunks_.find(hash);
+      const map<shash::Any, uint64_t>::iterator iter = quota_mgr->pinned_chunks_
+                                                           .find(hash);
       if (iter != quota_mgr->pinned_chunks_.end()) {
         quota_mgr->pinned_ -= iter->second;
         quota_mgr->pinned_chunks_.erase(iter);
@@ -1396,8 +1396,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
                             hash_str.length(), SQLITE_STATIC);
           int retval;
           if ((retval = sqlite3_step(quota_mgr->stmt_size_)) == SQLITE_ROW) {
-            const uint64_t size =
-                sqlite3_column_int64(quota_mgr->stmt_size_, 0);
+            const uint64_t size = sqlite3_column_int64(quota_mgr->stmt_size_,
+                                                       0);
             sqlite3_bind_text(quota_mgr->stmt_rm_, 1, &(hash_str[0]),
                               hash_str.length(), SQLITE_STATIC);
             retval = sqlite3_step(quota_mgr->stmt_rm_);
@@ -1417,12 +1417,15 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
     }
 
     // Immediate commands trigger flushing of the buffer
-    const bool immediate_command =
-        (command_type == kCleanup) || (command_type == kList) ||
-        (command_type == kListPinned) || (command_type == kListCatalogs) ||
-        (command_type == kListVolatile) || (command_type == kRemove) ||
-        (command_type == kStatus) || (command_type == kLimits) ||
-        (command_type == kPid);
+    const bool immediate_command = (command_type == kCleanup)
+                                   || (command_type == kList)
+                                   || (command_type == kListPinned)
+                                   || (command_type == kListCatalogs)
+                                   || (command_type == kListVolatile)
+                                   || (command_type == kRemove)
+                                   || (command_type == kStatus)
+                                   || (command_type == kLimits)
+                                   || (command_type == kPid);
     if (!immediate_command)
       num_commands++;
 
@@ -1435,8 +1438,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     if (immediate_command) {
       // Process cleanup, listings
-      const int return_pipe =
-          quota_mgr->BindReturnPipe(command_buffer[num_commands].return_pipe);
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
       if (return_pipe < 0) {
         num_commands = 0;
         continue;
@@ -1456,10 +1459,10 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
                             hash_str.length(), SQLITE_STATIC);
           int retval;
           if ((retval = sqlite3_step(quota_mgr->stmt_size_)) == SQLITE_ROW) {
-            const uint64_t size =
-                sqlite3_column_int64(quota_mgr->stmt_size_, 0);
-            const uint64_t is_pinned =
-                sqlite3_column_int64(quota_mgr->stmt_size_, 1);
+            const uint64_t size = sqlite3_column_int64(quota_mgr->stmt_size_,
+                                                       0);
+            const uint64_t is_pinned = sqlite3_column_int64(
+                quota_mgr->stmt_size_, 1);
 
             sqlite3_bind_text(quota_mgr->stmt_rm_, 1, &(hash_str[0]),
                               hash_str.length(), SQLITE_STATIC);

--- a/cvmfs/receiver/catalog_merge_tool_impl.h
+++ b/cvmfs/receiver/catalog_merge_tool_impl.h
@@ -8,16 +8,16 @@
 #include <string>
 
 #include "catalog.h"
+#include "catalog_merge_tool.h"
 #include "crypto/hash.h"
 #include "manifest.h"
 #include "options.h"
+#include "shortstring.h"
 #include "upload.h"
 #include "util/exception.h"
 #include "util/logging.h"
 #include "util/posix.h"
 #include "util/raii_temp_dir.h"
-#include "shortstring.h"
-#include "catalog_merge_tool.h"
 
 inline PathString MakeRelative(const PathString &path) {
   std::string rel_path;

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -33,8 +33,8 @@ namespace {
 
 PathString RemoveRepoName(const PathString &lease_path) {
   std::string abs_path = lease_path.ToString();
-  const std::string::const_iterator it =
-      std::find(abs_path.begin(), abs_path.end(), '/');
+  const std::string::const_iterator it = std::find(abs_path.begin(),
+                                                   abs_path.end(), '/');
   if (it != abs_path.end()) {
     const size_t idx = it - abs_path.begin() + 1;
     return lease_path.Suffix(idx);

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -284,8 +284,8 @@ bool Reactor::HandleCheckToken(const std::string &req, std::string *reply) {
 
   std::string path;
   JsonStringGenerator input;
-  const TokenCheckResult ret =
-      CheckToken(token->string_value, secret->string_value, &path);
+  const TokenCheckResult ret = CheckToken(token->string_value,
+                                          secret->string_value, &path);
   switch (ret) {
     case kExpired:
       // Expired token
@@ -349,9 +349,9 @@ bool Reactor::HandleSubmitPayload(int fdin, const std::string &req,
   const UniquePtr<PayloadProcessor> proc(MakePayloadProcessor());
   proc->SetStatistics(&statistics);
   JsonStringGenerator reply_input;
-  const PayloadProcessor::Result res =
-      proc->Process(fdin, digest_json->string_value, path_json->string_value,
-                    header_size_json->int_value);
+  const PayloadProcessor::Result res = proc->Process(
+      fdin, digest_json->string_value, path_json->string_value,
+      header_size_json->int_value);
 
   switch (res) {
     case PayloadProcessor::kPathViolation:
@@ -435,9 +435,9 @@ bool Reactor::HandleCommit(const std::string &req, std::string *reply) {
       shash::HexPtr(new_root_hash_json->string_value));
   const RepositoryTag repo_tag(tag_name_json->string_value,
                                tag_description_json->string_value);
-  const CommitProcessor::Result res =
-      proc->Process(lease_path_json->string_value, old_root_hash, new_root_hash,
-                    repo_tag, &final_revision);
+  const CommitProcessor::Result res = proc->Process(
+      lease_path_json->string_value, old_root_hash, new_root_hash, repo_tag,
+      &final_revision);
 
   JsonStringGenerator reply_input;
   switch (res) {

--- a/cvmfs/reflog.cc
+++ b/cvmfs/reflog.cc
@@ -63,8 +63,8 @@ bool Reflog::ReadChecksum(const std::string &path, shash::Any *checksum) {
 
 
 bool Reflog::WriteChecksum(const std::string &path, const shash::Any &value) {
-  const int fd =
-      open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, kDefaultFileMode);
+  const int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
+                      kDefaultFileMode);
   if (fd < 0) {
     return false;
   }
@@ -223,8 +223,8 @@ bool Reflog::ContainsCatalog(const shash::Any &catalog) const {
 bool Reflog::GetCatalogTimestamp(const shash::Any &catalog,
                                  uint64_t *timestamp) const {
   assert(catalog.HasSuffix() && catalog.suffix == shash::kSuffixCatalog);
-  const bool result =
-      GetReferenceTimestamp(catalog, SqlReflog::kRefCatalog, timestamp);
+  const bool result = GetReferenceTimestamp(catalog, SqlReflog::kRefCatalog,
+                                            timestamp);
   return result;
 }
 
@@ -265,8 +265,8 @@ bool Reflog::ContainsReference(const shash::Any &hash,
 bool Reflog::GetReferenceTimestamp(const shash::Any &hash,
                                    const SqlReflog::ReferenceType type,
                                    uint64_t *timestamp) const {
-  const bool retval =
-      get_timestamp_->BindReference(hash, type) && get_timestamp_->FetchRow();
+  const bool retval = get_timestamp_->BindReference(hash, type)
+                      && get_timestamp_->FetchRow();
 
   if (retval) {
     *timestamp = get_timestamp_->RetrieveTimestamp();

--- a/cvmfs/shortstring.cc
+++ b/cvmfs/shortstring.cc
@@ -44,7 +44,7 @@ NameString GetFileName(const PathString &path) {
 }
 
 
-bool IsSubPath(const PathString& parent, const PathString& path) {
+bool IsSubPath(const PathString &parent, const PathString &path) {
   // If parent is "", then any path is a subpath
   if (parent.GetLength() == 0) {
     return true;
@@ -53,10 +53,10 @@ bool IsSubPath(const PathString& parent, const PathString& path) {
   // If the parent string is the prefix of the path string and either
   // the strings are identical or the separator character is a "/",
   // then the path is a subpath
-  if (path.StartsWith(parent) &&
-      ((path.GetLength() == parent.GetLength()) ||
-       (path.GetChars()[parent.GetLength()] == '/') ||
-       (path.GetChars()[parent.GetLength() - 1] == '/'))) {
+  if (path.StartsWith(parent)
+      && ((path.GetLength() == parent.GetLength())
+          || (path.GetChars()[parent.GetLength()] == '/')
+          || (path.GetChars()[parent.GetLength() - 1] == '/'))) {
     return true;
   }
 

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -223,7 +223,7 @@ atomic_int64 ShortString<StackSize, Type>::num_instances_ = 0;
 PathString GetParentPath(const PathString &path);
 NameString GetFileName(const PathString &path);
 
-bool IsSubPath(const PathString& parent, const PathString& path);
+bool IsSubPath(const PathString &parent, const PathString &path);
 
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -691,9 +691,9 @@ int SyncInit(struct fs_traversal *src,
     for (unsigned i = 0; i < num_parallel_; ++i) {
       specificWorkerContexts[i].mwc = mwc;
       specificWorkerContexts[i].num_thread = i;
-      const int retval =
-          pthread_create(&workers[i], NULL, MainWorker,
-                         static_cast<void *>(&(specificWorkerContexts[i])));
+      const int retval = pthread_create(
+          &workers[i], NULL, MainWorker,
+          static_cast<void *>(&(specificWorkerContexts[i])));
       assert(retval == 0);
     }
   }

--- a/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
+++ b/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
@@ -113,8 +113,8 @@ int libcvmfs_do_fread(void *file_ctx,
                       size_t *read_len) {
   struct libcvmfs_file_handle
       *handle = reinterpret_cast<libcvmfs_file_handle *>(file_ctx);
-  const ssize_t read =
-      cvmfs_pread(handle->ctx, handle->fd, buff, len, handle->off);
+  const ssize_t read = cvmfs_pread(handle->ctx, handle->fd, buff, len,
+                                   handle->off);
   if (read == -1) {
     return -1;
   }

--- a/cvmfs/shrinkwrap/util.cc
+++ b/cvmfs/shrinkwrap/util.cc
@@ -16,9 +16,9 @@
 shash::Any HashMeta(const struct cvmfs_attr *stat_info) {
   // TODO(steuber): Can we do any better here?
   shash::Any meta_hash(shash::kMd5);
-  const unsigned min_buffer_size = sizeof(mode_t) / sizeof(unsigned char) + 1 +
-                                   sizeof(uid_t) / sizeof(unsigned char) + 1 +
-                                   sizeof(gid_t) / sizeof(unsigned char) + 1;
+  const unsigned min_buffer_size = sizeof(mode_t) / sizeof(unsigned char) + 1
+                                   + sizeof(uid_t) / sizeof(unsigned char) + 1
+                                   + sizeof(gid_t) / sizeof(unsigned char) + 1;
   XattrList *xlist = reinterpret_cast<XattrList *>(stat_info->cvm_xattrs);
   unsigned xlist_buffer_size = 0;
   unsigned char *xlist_buffer;

--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -153,9 +153,9 @@ class SmallHashBase {
 
  protected:
   uint32_t ScaleHash(const Key &key) const {
-    const double bucket =
-        (static_cast<double>(hasher_(key)) * static_cast<double>(capacity_) /
-         static_cast<double>(static_cast<uint32_t>(-1)));
+    const double bucket = (static_cast<double>(hasher_(key))
+                           * static_cast<double>(capacity_)
+                           / static_cast<double>(static_cast<uint32_t>(-1)));
     return static_cast<uint32_t>(bucket) % capacity_;
   }
 

--- a/cvmfs/sqlitemem.cc
+++ b/cvmfs/sqlitemem.cc
@@ -65,9 +65,9 @@ SqliteMemoryManager::LookasideBufferArena::~LookasideBufferArena() {
 
 void SqliteMemoryManager::LookasideBufferArena::PutBuffer(void *buffer) {
   assert(buffer >= arena_);
-  const ptrdiff_t nbuffer =
-      (reinterpret_cast<char *>(buffer) - reinterpret_cast<char *>(arena_)) /
-      kBufferSize;
+  const ptrdiff_t nbuffer = (reinterpret_cast<char *>(buffer)
+                             - reinterpret_cast<char *>(arena_))
+                            / kBufferSize;
   assert(static_cast<uint64_t>(nbuffer) < kBuffersPerArena);
   const int nfreemap = nbuffer / (sizeof(int) * 8);
   freemap_[nfreemap] |= 1 << (nbuffer % (sizeof(int) * 8));
@@ -155,9 +155,9 @@ void *SqliteMemoryManager::AssignLookasideBuffer(sqlite3 *db) {
 
   void *buffer = GetLookasideBuffer();
   assert(buffer != NULL);
-  const int retval =
-      sqlite3_db_config(db, SQLITE_DBCONFIG_LOOKASIDE, buffer,
-                        kLookasideSlotSize, kLookasideSlotsPerDb);
+  const int retval = sqlite3_db_config(db, SQLITE_DBCONFIG_LOOKASIDE, buffer,
+                                       kLookasideSlotSize,
+                                       kLookasideSlotsPerDb);
   assert(retval == SQLITE_OK);
   return buffer;
 }
@@ -176,8 +176,8 @@ void *SqliteMemoryManager::GetLookasideBuffer() {
   void *result;
   vector<LookasideBufferArena *>::reverse_iterator
       reverse_iter = lookaside_buffer_arenas_.rbegin();
-  const vector<LookasideBufferArena *>::reverse_iterator i_rend =
-      lookaside_buffer_arenas_.rend();
+  const vector<LookasideBufferArena *>::reverse_iterator
+      i_rend = lookaside_buffer_arenas_.rend();
   for (; reverse_iter != i_rend; ++reverse_iter) {
     result = (*reverse_iter)->GetBuffer();
     if (result != NULL)

--- a/cvmfs/ssl.cc
+++ b/cvmfs/ssl.cc
@@ -59,8 +59,8 @@ SslCertificateStore::SslCertificateStore() {
 
 
 bool SslCertificateStore::ApplySslCertificatePath(CURL *handle) const {
-  const CURLcode res1 =
-      curl_easy_setopt(handle, CURLOPT_CAPATH, ca_path_.c_str());
+  const CURLcode res1 = curl_easy_setopt(
+      handle, CURLOPT_CAPATH, ca_path_.c_str());
   CURLcode res2 = CURLE_OK;
   if (!ca_bundle_.empty())
     res2 = curl_easy_setopt(handle, CURLOPT_CAINFO, ca_bundle_.c_str());

--- a/cvmfs/statistics.cc
+++ b/cvmfs/statistics.cc
@@ -230,8 +230,8 @@ void Recorder::TickAt(uint64_t timestamp) {
   } else {
     // When clearing bins between last_timestamp_ and now, avoid cycling the
     // ring buffer multiple times.
-    const unsigned max_bins_clear =
-        std::min(bin_abs, last_bin_abs + no_bins_ + 1);
+    const unsigned max_bins_clear = std::min(bin_abs,
+                                             last_bin_abs + no_bins_ + 1);
     for (uint64_t i = last_bin_abs + 1; i < max_bins_clear; ++i)
       bins_[i % no_bins_] = 0;
     bins_[bin_abs % no_bins_] = 1;
@@ -248,9 +248,9 @@ uint64_t Recorder::GetNoTicks(uint32_t retrospect_s) const {
 
   const uint64_t last_bin_abs = last_timestamp_ / resolution_s_;
   const uint64_t past_bin_abs = (now - retrospect_s) / resolution_s_;
-  const int64_t min_bin_abs =
-      std::max(past_bin_abs,
-               (last_bin_abs < no_bins_) ? 0 : (last_bin_abs - (no_bins_ - 1)));
+  const int64_t min_bin_abs = std::max(
+      past_bin_abs,
+      (last_bin_abs < no_bins_) ? 0 : (last_bin_abs - (no_bins_ - 1)));
   uint64_t result = 0;
   for (int64_t i = last_bin_abs; i >= min_bin_abs; --i) {
     result += bins_[i % no_bins_];

--- a/cvmfs/statistics_database.cc
+++ b/cvmfs/statistics_database.cc
@@ -229,42 +229,42 @@ std::string PrepareStatementIntoGc(const perf::Statistics *statistics,
 
 bool StatisticsDatabase::CreateEmptyDatabase() {
   ++create_empty_db_calls;
-  const bool ret1 =
-      sqlite::Sql(sqlite_db(), "CREATE TABLE publish_statistics ("
-                               "publish_id INTEGER PRIMARY KEY,"
-                               "start_time TEXT,"
-                               "finish_time TEXT,"
-                               "revision INTEGER,"
-                               "files_added INTEGER,"
-                               "files_removed INTEGER,"
-                               "files_changed INTEGER,"
-                               "chunks_added INTEGER,"
-                               "chunks_duplicated INTEGER,"
-                               "catalogs_added INTEGER,"
-                               "directories_added INTEGER,"
-                               "directories_removed INTEGER,"
-                               "directories_changed INTEGER,"
-                               "symlinks_added INTEGER,"
-                               "symlinks_removed INTEGER,"
-                               "symlinks_changed INTEGER,"
-                               "sz_bytes_added INTEGER,"
-                               "sz_bytes_removed INTEGER,"
-                               "sz_bytes_uploaded INTEGER,"
-                               "sz_catalog_bytes_uploaded INTEGER,"
-                               "success INTEGER);")
-          .Execute();
-  const bool ret2 =
-      sqlite::Sql(sqlite_db(), "CREATE TABLE gc_statistics ("
-                               "gc_id INTEGER PRIMARY KEY,"
-                               "start_time TEXT,"
-                               "finish_time TEXT,"
-                               "n_preserved_catalogs INTEGER,"
-                               "n_condemned_catalogs INTEGER,"
-                               "n_condemned_objects INTEGER,"
-                               "sz_condemned_bytes INTEGER,"
-                               "n_duplicate_delete_requests INTEGER,"
-                               "success INTEGER);")
-          .Execute();
+  const bool ret1 = sqlite::Sql(sqlite_db(),
+                                "CREATE TABLE publish_statistics ("
+                                "publish_id INTEGER PRIMARY KEY,"
+                                "start_time TEXT,"
+                                "finish_time TEXT,"
+                                "revision INTEGER,"
+                                "files_added INTEGER,"
+                                "files_removed INTEGER,"
+                                "files_changed INTEGER,"
+                                "chunks_added INTEGER,"
+                                "chunks_duplicated INTEGER,"
+                                "catalogs_added INTEGER,"
+                                "directories_added INTEGER,"
+                                "directories_removed INTEGER,"
+                                "directories_changed INTEGER,"
+                                "symlinks_added INTEGER,"
+                                "symlinks_removed INTEGER,"
+                                "symlinks_changed INTEGER,"
+                                "sz_bytes_added INTEGER,"
+                                "sz_bytes_removed INTEGER,"
+                                "sz_bytes_uploaded INTEGER,"
+                                "sz_catalog_bytes_uploaded INTEGER,"
+                                "success INTEGER);")
+                        .Execute();
+  const bool ret2 = sqlite::Sql(sqlite_db(),
+                                "CREATE TABLE gc_statistics ("
+                                "gc_id INTEGER PRIMARY KEY,"
+                                "start_time TEXT,"
+                                "finish_time TEXT,"
+                                "n_preserved_catalogs INTEGER,"
+                                "n_condemned_catalogs INTEGER,"
+                                "n_condemned_objects INTEGER,"
+                                "sz_condemned_bytes INTEGER,"
+                                "n_duplicate_delete_requests INTEGER,"
+                                "success INTEGER);")
+                        .Execute();
   return ret1 & ret2;
 }
 
@@ -458,8 +458,8 @@ bool StatisticsDatabase::StorePublishStatistics(
     const std::string &start_time,
     const bool success) {
   const std::string finish_time = GetGMTimestamp();
-  const std::string statement =
-      PrepareStatementIntoPublish(statistics, start_time, finish_time, success);
+  const std::string statement = PrepareStatementIntoPublish(
+      statistics, start_time, finish_time, success);
   return StoreEntry(statement);
 }
 
@@ -494,15 +494,15 @@ bool StatisticsDatabase::Prune(uint32_t days) {
   if (days == 0)
     return true;
 
-  const std::string publish_stmt =
-      "DELETE FROM publish_statistics WHERE "
-      "julianday('now','start of day')-julianday(start_time) > " +
-      StringifyUint(days) + ";";
+  const std::string
+      publish_stmt = "DELETE FROM publish_statistics WHERE "
+                     "julianday('now','start of day')-julianday(start_time) > "
+                     + StringifyUint(days) + ";";
 
-  const std::string gc_stmt =
-      "DELETE FROM gc_statistics WHERE "
-      "julianday('now','start of day')-julianday(start_time) > " +
-      StringifyUint(days) + ";";
+  const std::string
+      gc_stmt = "DELETE FROM gc_statistics WHERE "
+                "julianday('now','start of day')-julianday(start_time) > "
+                + StringifyUint(days) + ";";
 
   sqlite::Sql publish_sql(this->sqlite_db(), publish_stmt);
   sqlite::Sql gc_sql(this->sqlite_db(), gc_stmt);
@@ -593,8 +593,8 @@ void StatisticsDatabase::GetDBParams(const std::string &repo_name,
     *path = db_default_path;
   } else {
     const std::string dirname = GetParentPath(statistics_db);
-    const int mode = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH |
-                     S_IXOTH; // 755
+    const int mode = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH
+                     | S_IXOTH;  // 755
     if (!MkdirDeep(dirname, mode, true)) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr,
                "Couldn't write statistics at the specified path %s.",

--- a/cvmfs/swissknife_assistant.cc
+++ b/cvmfs/swissknife_assistant.cc
@@ -40,8 +40,8 @@ catalog::Catalog *Assistant::GetCatalog(const shash::Any &catalog_hash,
           catalog_root_path, local_path, catalog_hash);
       break;
     case kOpenReadOnly:
-      catalog = catalog::Catalog::AttachFreely(
-          catalog_root_path, local_path, catalog_hash);
+      catalog = catalog::Catalog::AttachFreely(catalog_root_path, local_path,
+                                               catalog_hash);
       break;
     default:
       abort();

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -154,8 +154,8 @@ bool CommandCheck::CompareCounters(const catalog::Counters &a,
   catalog::Counters::FieldsMap::const_iterator i = map_a.begin();
   const catalog::Counters::FieldsMap::const_iterator iend = map_a.end();
   for (; i != iend; ++i) {
-    const catalog::Counters::FieldsMap::const_iterator comp =
-        map_b.find(i->first);
+    const catalog::Counters::FieldsMap::const_iterator comp = map_b.find(
+        i->first);
     assert(comp != map_b.end());
 
     if (*(i->second) != *(comp->second)) {
@@ -426,8 +426,8 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
                  full_path.c_str());
         retval = false;
       } else {
-        const HardlinkMap::iterator hardlink_group =
-            hardlinks.find(entries[i].hardlink_group());
+        const HardlinkMap::iterator hardlink_group = hardlinks.find(
+            entries[i].hardlink_group());
         if (hardlink_group == hardlinks.end()) {
           hardlinks[entries[i].hardlink_group()];
           hardlinks[entries[i].hardlink_group()].push_back(entries[i]);
@@ -684,8 +684,8 @@ string CommandCheck::DownloadPiece(const shash::Any catalog_hash) {
   cvmfs::PathSink pathsink(dest);
   download::JobInfo download_catalog(&url, true, false, &catalog_hash,
                                      &pathsink);
-  const download::Failures retval =
-      download_manager()->Fetch(&download_catalog);
+  const download::Failures retval = download_manager()->Fetch(
+      &download_catalog);
   if (retval != download::kFailOk) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to download object %s (%d)",
              catalog_hash.ToString().c_str(), retval);
@@ -765,8 +765,8 @@ bool CommandCheck::FindSubtreeRootCatalog(const string &subtree_path,
     }
 
     current_path += "/" + *i;
-    if (current_catalog->FindNested(
-            PathString(current_path), root_hash, root_size)) {
+    if (current_catalog->FindNested(PathString(current_path), root_hash,
+                                    root_size)) {
       delete current_catalog;
 
       if (current_path.length() < subtree_path.length()) {
@@ -795,8 +795,8 @@ bool CommandCheck::InspectTree(const string &path,
   LogCvmfs(kLogCvmfs, kLogStdout | kLogInform, "[inspecting catalog] %s at %s",
            catalog_hash.ToString().c_str(), path == "" ? "/" : path.c_str());
 
-  const catalog::Catalog *catalog = FetchCatalog(
-      path, catalog_hash, catalog_size);
+  const catalog::Catalog *catalog = FetchCatalog(path, catalog_hash,
+                                                 catalog_size);
   if (catalog == NULL) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to open catalog %s",
              catalog_hash.ToString().c_str());
@@ -885,7 +885,8 @@ bool CommandCheck::InspectTree(const string &path,
   for (catalog::Catalog::NestedCatalogList::const_iterator
            i = nested_catalogs.begin(),
            iEnd = nested_catalogs.end();
-       i != iEnd; ++i) {
+       i != iEnd;
+       ++i) {
     nested_catalog_paths.insert(i->mountpoint);
   }
   if (nested_catalog_paths.size() != nested_catalogs.size()) {
@@ -897,7 +898,8 @@ bool CommandCheck::InspectTree(const string &path,
   for (catalog::Catalog::NestedCatalogList::const_iterator
            i = nested_catalogs.begin(),
            iEnd = nested_catalogs.end();
-       i != iEnd; ++i) {
+       i != iEnd;
+       ++i) {
     if (bind_mountpoints.find(i->mountpoint) != bind_mountpoints.end()) {
       catalog::DirectoryEntry bind_mountpoint;
       const PathString mountpoint("/" + i->mountpoint.ToString().substr(1));

--- a/cvmfs/swissknife_filestats.cc
+++ b/cvmfs/swissknife_filestats.cc
@@ -114,8 +114,8 @@ void *CommandFileStats::MainProcessing(void *data) {
   while (fin == 0 || processed < downloaded) {
     if (processed < downloaded) {
       LogCvmfs(kLogCatalog, kLogStdout, "Processing catalog %d", processed);
-      const string db_path =
-          repo_stats->tmp_db_path_ + "/" + StringifyInt(processed + 1) + ".db";
+      const string db_path = repo_stats->tmp_db_path_ + "/"
+                             + StringifyInt(processed + 1) + ".db";
       repo_stats->ProcessCatalog(db_path);
       ++processed;
     }
@@ -138,8 +138,8 @@ void CommandFileStats::ProcessCatalog(string db_path) {
   sqlite::Sql *catalog_count = new sqlite::Sql(cat_db->sqlite_db(),
                                                "SELECT count(*) FROM catalog;");
   catalog_count->Execute();
-  const int cur_catalog_id =
-      db_->StoreCatalog(catalog_count->RetrieveInt64(0), file_size);
+  const int cur_catalog_id = db_->StoreCatalog(catalog_count->RetrieveInt64(0),
+                                               file_size);
   delete catalog_count;
 
   sqlite::Sql *catalog_list = new sqlite::Sql(

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -109,8 +109,8 @@ int CommandGc::Main(const ArgumentList &args) {
                                signature_manager());
 
   UniquePtr<manifest::Manifest> manifest;
-  const ObjectFetcher::Failures retval =
-      object_fetcher.FetchManifest(&manifest);
+  const ObjectFetcher::Failures retval = object_fetcher.FetchManifest(
+      &manifest);
   if (retval != ObjectFetcher::kFailOk) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "failed to load repository manifest "

--- a/cvmfs/swissknife_graft.cc
+++ b/cvmfs/swissknife_graft.cc
@@ -126,12 +126,14 @@ bool swissknife::CommandGraft::DirCallback(const std::string &relative_path,
   if (!output_file_.size()) {
     return true;
   }
-  const std::string full_output_path =
-      output_file_ + "/" + (relative_path.size() ? relative_path : ".") + "/" +
-      dir_name;
-  const std::string full_input_path =
-      input_file_ + "/" + (relative_path.size() ? relative_path : ".") + "/" +
-      dir_name;
+  const std::string full_output_path = output_file_ + "/"
+                                       + (relative_path.size() ? relative_path
+                                                               : ".")
+                                       + "/" + dir_name;
+  const std::string full_input_path = input_file_ + "/"
+                                      + (relative_path.size() ? relative_path
+                                                              : ".")
+                                      + "/" + dir_name;
   platform_stat64 sbuf;
   if (-1 == platform_stat(full_input_path.c_str(), &sbuf)) {
     return false;
@@ -141,9 +143,10 @@ bool swissknife::CommandGraft::DirCallback(const std::string &relative_path,
 
 void swissknife::CommandGraft::FileCallback(const std::string &relative_path,
                                             const std::string &file_name) {
-  const std::string full_input_path =
-      input_file_ + "/" + (relative_path.size() ? relative_path : ".") + "/" +
-      file_name;
+  const std::string full_input_path = input_file_ + "/"
+                                      + (relative_path.size() ? relative_path
+                                                              : ".")
+                                      + "/" + file_name;
   std::string full_output_path;
   if (output_file_.size()) {
     full_output_path = output_file_ + "/"
@@ -181,9 +184,11 @@ int swissknife::CommandGraft::Main(const swissknife::ArgumentList &args) {
   chunk_size_ *= 1024 * 1024;  // Convert to MB.
 
   platform_stat64 sbuf;
-  const bool output_file_is_dir =
-      output_file.size() && (0 == platform_stat(output_file.c_str(), &sbuf)) &&
-      S_ISDIR(sbuf.st_mode);
+  const bool output_file_is_dir = output_file.size()
+                                  && (0
+                                      == platform_stat(output_file.c_str(),
+                                                       &sbuf))
+                                  && S_ISDIR(sbuf.st_mode);
   if (output_file_is_dir && (input_file == "-")) {
     LogCvmfs(kLogCvmfs, kLogStderr, "Output file (%s): Is a directory\n",
              output_file.c_str());
@@ -191,9 +196,9 @@ int swissknife::CommandGraft::Main(const swissknife::ArgumentList &args) {
   }
 
   if (input_file != "-") {
-    const bool input_file_is_dir =
-        (0 == platform_stat(input_file.c_str(), &sbuf)) &&
-        S_ISDIR(sbuf.st_mode);
+    const bool input_file_is_dir = (0
+                                    == platform_stat(input_file.c_str(), &sbuf))
+                                   && S_ISDIR(sbuf.st_mode);
     if (input_file_is_dir) {
       if (!output_file_is_dir && output_file.size()) {
         LogCvmfs(kLogCvmfs, kLogStderr,
@@ -230,8 +235,8 @@ int swissknife::CommandGraft::Publish(const std::string &input_file,
   } else {
     fd = open(input_file.c_str(), O_RDONLY);
     if (fd < 0) {
-      const std::string errmsg =
-          "Unable to open input file (" + input_file + ")";
+      const std::string errmsg = "Unable to open input file (" + input_file
+                                 + ")";
       perror(errmsg.c_str());
       return 1;
     }
@@ -259,8 +264,8 @@ int swissknife::CommandGraft::Publish(const std::string &input_file,
     close(fd);
   }
   if (!retval) {
-    const std::string errmsg =
-        "Unable to checksum input file (" + input_file + ")";
+    const std::string errmsg = "Unable to checksum input file (" + input_file
+                               + ")";
     perror(errmsg.c_str());
     return 1;
   }
@@ -278,8 +283,8 @@ int swissknife::CommandGraft::Publish(const std::string &input_file,
     }
     fd = open(graft_fname.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0644);
     if (fd < 0) {
-      const std::string errmsg =
-          "Unable to open graft file (" + graft_fname + ")";
+      const std::string errmsg = "Unable to open graft file (" + graft_fname
+                                 + ")";
       perror(errmsg.c_str());
       return 1;
     }
@@ -328,8 +333,8 @@ int swissknife::CommandGraft::Publish(const std::string &input_file,
   fd = open(output_fname.c_str(), O_CREAT | O_TRUNC | O_WRONLY,
             input_file_mode);
   if (fd < 0) {
-    const std::string errmsg =
-        "Unable to open output file (" + output_file + ")";
+    const std::string errmsg = "Unable to open output file (" + output_file
+                               + ")";
     perror(errmsg.c_str());
     return 1;
   }

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -132,8 +132,8 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
     cvmfs::MemSink manifest_memsink;
     download::JobInfo download_manifest(&url, false, false, NULL,
                                         &manifest_memsink);
-    const download::Failures retval =
-        download_manager()->Fetch(&download_manifest);
+    const download::Failures retval = download_manager()->Fetch(
+        &download_manifest);
     if (retval != download::kFailOk) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to download manifest (%d - %s)",
                retval, download::Code2Ascii(retval));
@@ -256,8 +256,8 @@ int swissknife::CommandInfo::Main(const swissknife::ArgumentList &args) {
     cvmfs::MemSink metainfo_memsink;
     download::JobInfo download_metainfo(&url, true, false, &meta_info,
                                         &metainfo_memsink);
-    const download::Failures retval =
-        download_manager()->Fetch(&download_metainfo);
+    const download::Failures retval = download_manager()->Fetch(
+        &download_metainfo);
     if (retval != download::kFailOk) {
       if (human_readable)
         LogCvmfs(kLogCvmfs, kLogStderr,

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -136,8 +136,8 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
     return 3;
   }
 
-  const bool with_gateway =
-      spooler_definition.driver_type == upload::SpoolerDefinition::Gateway;
+  const bool with_gateway = spooler_definition.driver_type
+                            == upload::SpoolerDefinition::Gateway;
 
   // This may fail, in which case a warning is printed and the process continues
   ObtainDacReadSearchCapability();

--- a/cvmfs/swissknife_ingestsql.cc
+++ b/cvmfs/swissknife_ingestsql.cc
@@ -1,60 +1,63 @@
 #include "swissknife_ingestsql.h"
 
 #include <fcntl.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/types.h>
-#include <pwd.h>
 #include <grp.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <csignal>
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <stack>
 #include <unordered_map>
 #include <unordered_set>
-#include <stack>
 
 #include "acl.h"
+#include "catalog_downloader.h"
 #include "catalog_mgr_rw.h"
 #include "curl/curl.h"
 #include "gateway_util.h"
+#include "shortstring.h"
 #include "swissknife_lease_curl.h"
 #include "swissknife_lease_json.h"
 #include "swissknife_sync.h"
 #include "upload.h"
 #include "util/logging.h"
-#include "catalog_downloader.h"
-#include "shortstring.h"
 
-#define CHECK_SQLITE_ERROR(ret, expected) do {                                                            \
-                                            if ((ret)!=expected) {                                        \
-                                              LogCvmfs(kLogCvmfs, kLogStderr, "SQLite error: %d", (ret)); \
-                                              assert(0);                                                  \
-                                            }                                                             \
-                                          } while (0)
+#define CHECK_SQLITE_ERROR(ret, expected)                         \
+  do {                                                            \
+    if ((ret) != expected) {                                      \
+      LogCvmfs(kLogCvmfs, kLogStderr, "SQLite error: %d", (ret)); \
+      assert(0);                                                  \
+    }                                                             \
+  } while (0)
 
-#define CUSTOM_ASSERT(check, msg, ...) do {                                                     \
-                                         if (!(check)) {                                        \
-                                           LogCvmfs(kLogCvmfs, kLogStderr, msg, ##__VA_ARGS__); \
-                                           assert(0);                                           \
-                                         }                                                      \
-                                       } while (0)
+#define CUSTOM_ASSERT(check, msg, ...)                     \
+  do {                                                     \
+    if (!(check)) {                                        \
+      LogCvmfs(kLogCvmfs, kLogStderr, msg, ##__VA_ARGS__); \
+      assert(0);                                           \
+    }                                                      \
+  } while (0)
 
-#define SHOW_PROGRESS(item, freq, curr, total) do {                                                                            \
-                                                 if ((curr) % freq == 0 || (curr) == total) {                                  \
-                                                   LogCvmfs(kLogCvmfs, kLogStdout, "Processed %d/%d %s", (curr), total, item); \
-                                                 }                                                                             \
-                                               } while (0)
-
+#define SHOW_PROGRESS(item, freq, curr, total)                             \
+  do {                                                                     \
+    if ((curr) % freq == 0 || (curr) == total) {                           \
+      LogCvmfs(kLogCvmfs, kLogStdout, "Processed %d/%d %s", (curr), total, \
+               item);                                                      \
+    }                                                                      \
+  } while (0)
 
 
 static const unsigned kExternalChunkSize = 24 * 1024 * 1024;
-static const unsigned kInternalChunkSize = 6  * 1024 * 1024;
+static const unsigned kInternalChunkSize = 6 * 1024 * 1024;
 static const unsigned kDefaultLeaseBusyRetryInterval = 10;
-static const unsigned kLeaseRefreshInterval = 90; // seconds
+static const unsigned kLeaseRefreshInterval = 90;  // seconds
 
 
 static bool g_lease_acquired = false;
@@ -64,81 +67,87 @@ static string g_gateway_secret;
 static string g_session_token;
 static string g_session_token_file;
 static string g_s3_file;
-static time_t g_last_lease_refresh=0;
-static bool   g_stop_refresh = false;
-static int64_t g_priority=0;
-static bool   g_add_missing_catalogs = false;
+static time_t g_last_lease_refresh = 0;
+static bool g_stop_refresh = false;
+static int64_t g_priority = 0;
+static bool g_add_missing_catalogs = false;
 static string get_lease_from_paths(vector<string> paths);
-static vector<string> get_all_dirs_from_sqlite(vector<string>& sqlite_db_vec,
-                                                bool include_additions,
-                                                bool include_deletions);
-static string get_parent(const string& path);
-static string get_basename(const string& path);
+static vector<string> get_all_dirs_from_sqlite(vector<string> &sqlite_db_vec,
+                                               bool include_additions,
+                                               bool include_deletions);
+static string get_parent(const string &path);
+static string get_basename(const string &path);
 
 static XattrList marshal_xattrs(const char *acl);
 static string sanitise_name(const char *name_cstr, bool allow_leading_slash);
 static void on_signal(int sig);
-static string acquire_lease(const string& key_id, const string& secret, const string& lease_path,
-                            const string& repo_service_url, bool force_cancel_lease, uint64_t *current_revision, string &current_root_hash,
+static string acquire_lease(const string &key_id, const string &secret,
+                            const string &lease_path,
+                            const string &repo_service_url,
+                            bool force_cancel_lease, uint64_t *current_revision,
+                            string &current_root_hash,
                             unsigned int refresh_interval);
 static void cancel_lease();
 static void refresh_lease();
-static vector<string> get_file_list(string& path);
-static int check_hash(const char *hash) ;
-static void recursively_delete_directory(PathString& path, catalog::WritableCatalogManager &catalog_manager);
-static void create_empty_database( string& filename );
+static vector<string> get_file_list(string &path);
+static int check_hash(const char *hash);
+static void recursively_delete_directory(
+    PathString &path, catalog::WritableCatalogManager &catalog_manager);
+static void create_empty_database(string &filename);
 static void relax_db_locking(sqlite3 *db);
-static bool check_prefix(const std::string &path , const std::string &prefix); 
+static bool check_prefix(const std::string &path, const std::string &prefix);
 
 static bool isDatabaseMarkedComplete(const char *dbfile);
 static void setDatabaseMarkedComplete(const char *dbfile);
 
-extern "C" void* lease_refresh_thread(void *payload);
- 
+extern "C" void *lease_refresh_thread(void *payload);
+
 static string sanitise_name(const char *name_cstr,
                             bool allow_leading_slash = false) {
   int reason = 0;
   const char *c = name_cstr;
-  while(*c == '/') {c++;} // strip any leading slashes
+  while (*c == '/') {
+    c++;
+  }  // strip any leading slashes
   string const name = string(c);
   bool ok = true;
 
   if (!allow_leading_slash && HasPrefix(name, "/", true)) {
-    reason=1;
+    reason = 1;
     ok = false;
   }
   if (HasSuffix(name, "/", true)) {
-    if (!(allow_leading_slash &&
-          name.size() == 1)) {  // account for the case where name=="/"
-      reason=2;
+    if (!(allow_leading_slash
+          && name.size() == 1)) {  // account for the case where name=="/"
+      reason = 2;
       ok = false;
     }
   }
   if (name.find("//") != string::npos) {
-    reason=3;
+    reason = 3;
     ok = false;
   }
   if (HasPrefix(name, "./", true) || HasPrefix(name, "../", true)) {
-    reason=4;
+    reason = 4;
     ok = false;
   }
   if (HasSuffix(name, "/.", true) || HasSuffix(name, "/..", true)) {
-    reason=5;
+    reason = 5;
     ok = false;
   }
   if (name.find("/./") != string::npos || name.find("/../") != string::npos) {
-    reason=6;
+    reason = 6;
     ok = false;
   }
   if (name == "") {
-    reason=7;
+    reason = 7;
     ok = false;
   }
   CUSTOM_ASSERT(ok, "Name [%s] is invalid (reason %d)", name.c_str(), reason);
   return string(name);
 }
 
-static string get_parent(const string& path) {
+static string get_parent(const string &path) {
   size_t const found = path.find_last_of('/');
   if (found == string::npos) {
     return string("");
@@ -146,7 +155,7 @@ static string get_parent(const string& path) {
   return path.substr(0, found);
 }
 
-static string get_basename(const string& path) {
+static string get_basename(const string &path) {
   const size_t found = path.find_last_of('/');
   if (found == string::npos) {
     return path;
@@ -159,15 +168,19 @@ static string MakeCatalogPath(const std::string &relative_path) {
   return (relative_path == "") ? "" : "/" + relative_path;
 }
 
-static string acquire_lease(const string& key_id, const string& secret, const string& lease_path,
-                            const string& repo_service_url, bool force_cancel_lease, uint64_t *current_revision, string &current_root_hash,
+static string acquire_lease(const string &key_id, const string &secret,
+                            const string &lease_path,
+                            const string &repo_service_url,
+                            bool force_cancel_lease, uint64_t *current_revision,
+                            string &current_root_hash,
                             unsigned int refresh_interval) {
   const CURLcode ret = curl_global_init(CURL_GLOBAL_ALL);
   CUSTOM_ASSERT(ret == CURLE_OK, "failed to init curl");
 
   string gateway_metadata_str;
   char *gateway_metadata = getenv("CVMFS_GATEWAY_METADATA");
-  if (gateway_metadata != NULL) gateway_metadata_str = gateway_metadata;
+  if (gateway_metadata != NULL)
+    gateway_metadata_str = gateway_metadata;
 
   while (true) {
     CurlBuffer buffer;
@@ -175,7 +188,8 @@ static string acquire_lease(const string& key_id, const string& secret, const st
                            &buffer, gateway_metadata_str)) {
       string session_token;
 
-      const LeaseReply rep = ParseAcquireReplyWithRevision(buffer, &session_token, current_revision, current_root_hash);
+      const LeaseReply rep = ParseAcquireReplyWithRevision(
+          buffer, &session_token, current_revision, current_root_hash);
       switch (rep) {
         case kLeaseReplySuccess:
           g_lease_acquired = true;
@@ -183,20 +197,24 @@ static string acquire_lease(const string& key_id, const string& secret, const st
           return session_token;
           break;
         case kLeaseReplyBusy:
-          if( force_cancel_lease ) {
-            LogCvmfs(kLogCvmfs, kLogStderr, "Lease busy, forcing cancellation (TODO");
+          if (force_cancel_lease) {
+            LogCvmfs(kLogCvmfs, kLogStderr,
+                     "Lease busy, forcing cancellation (TODO");
           }
           LogCvmfs(kLogCvmfs, kLogStderr, "Lease busy, retrying in %d sec",
                    refresh_interval);
           sleep(refresh_interval);
           break;
         default:
-          LogCvmfs(kLogCvmfs, kLogStderr, "Error acquiring lease: %s. Retrying in %d sec",
+          LogCvmfs(kLogCvmfs, kLogStderr,
+                   "Error acquiring lease: %s. Retrying in %d sec",
                    buffer.data.c_str(), refresh_interval);
           sleep(refresh_interval);
       }
     } else {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Error making lease acquisition request. Retrying in %d sec", refresh_interval);
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Error making lease acquisition request. Retrying in %d sec",
+               refresh_interval);
       sleep(refresh_interval);
     }
   }
@@ -204,39 +222,47 @@ static string acquire_lease(const string& key_id, const string& secret, const st
   return "";
 }
 
-static uint64_t make_commit_on_gateway( const std::string &old_root_hash, const std::string &new_root_hash, int64_t priority) {
+static uint64_t make_commit_on_gateway(const std::string &old_root_hash,
+                                       const std::string &new_root_hash,
+                                       int64_t priority) {
   CurlBuffer buffer;
   char priorityStr[100];
-  (void)sprintf(priorityStr, "%" PRId64, priority); // skipping return value check; no way such large buffer will overflow
-  buffer.data="";
+  (void)sprintf(priorityStr, "%" PRId64,
+                priority);  // skipping return value check; no way such large
+                            // buffer will overflow
+  buffer.data = "";
 
-  const std::string payload = "{\n\"old_root_hash\": \"" + old_root_hash + "\",\n\"new_root_hash\": \""+new_root_hash+"\",\n\"priority\": "+priorityStr+"}";
+  const std::string payload = "{\n\"old_root_hash\": \"" + old_root_hash
+                              + "\",\n\"new_root_hash\": \"" + new_root_hash
+                              + "\",\n\"priority\": " + priorityStr + "}";
 
   return MakeEndRequest("POST", g_gateway_key_id, g_gateway_secret,
-                     g_session_token, g_gateway_url, payload,  &buffer, true);
+                        g_session_token, g_gateway_url, payload, &buffer, true);
 }
 
 static void refresh_lease() {
   CurlBuffer buffer;
-  buffer.data="";
-  if ( (time(NULL)- g_last_lease_refresh )< kLeaseRefreshInterval ){ return; }
+  buffer.data = "";
+  if ((time(NULL) - g_last_lease_refresh) < kLeaseRefreshInterval) {
+    return;
+  }
 
   if (MakeEndRequest("PATCH", g_gateway_key_id, g_gateway_secret,
-                     g_session_token, g_gateway_url, "", &buffer,false)) {
+                     g_session_token, g_gateway_url, "", &buffer, false)) {
     const int ret = ParseDropReply(buffer);
     if (kLeaseReplySuccess == ret) {
       LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Lease refreshed");
-      g_last_lease_refresh=time(NULL);
+      g_last_lease_refresh = time(NULL);
     } else {
       LogCvmfs(kLogCvmfs, kLogStderr, "Lease refresh failed: %d", ret);
     }
   } else {
     LogCvmfs(kLogCvmfs, kLogStderr, "Lease refresh request failed");
-    if(buffer.data == "Method Not Allowed\n") {
-      g_last_lease_refresh=time(NULL);
-      LogCvmfs(kLogCvmfs, kLogStderr, "This gateway does not support lease refresh");
-    } 
-    
+    if (buffer.data == "Method Not Allowed\n") {
+      g_last_lease_refresh = time(NULL);
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "This gateway does not support lease refresh");
+    }
   }
 }
 
@@ -254,7 +280,7 @@ static void cancel_lease() {
   } else {
     LogCvmfs(kLogCvmfs, kLogStderr, "Lease cancellation request failed");
   }
-  g_stop_refresh=true;
+  g_stop_refresh = true;
 }
 
 static void on_signal(int sig) {
@@ -264,17 +290,19 @@ static void on_signal(int sig) {
     cancel_lease();
     unlink(g_session_token_file.c_str());
   }
-  if (sig == SIGINT || sig == SIGTERM) exit(1);
+  if (sig == SIGINT || sig == SIGTERM)
+    exit(1);
 }
 
-static vector<string> get_all_dirs_from_sqlite(vector<string>& sqlite_db_vec,
-                                                bool include_additions,
-                                                bool include_deletions) {
+static vector<string> get_all_dirs_from_sqlite(vector<string> &sqlite_db_vec,
+                                               bool include_additions,
+                                               bool include_deletions) {
   int ret;
   vector<string> paths;
 
   for (vector<string>::iterator it = sqlite_db_vec.begin();
-       it != sqlite_db_vec.end(); it++) {
+       it != sqlite_db_vec.end();
+       it++) {
     sqlite3 *db;
     ret = sqlite3_open_v2((*it).c_str(), &db, SQLITE_OPEN_READONLY, NULL);
     CHECK_SQLITE_ERROR(ret, SQLITE_OK);
@@ -298,9 +326,10 @@ static vector<string> get_all_dirs_from_sqlite(vector<string>& sqlite_db_vec,
       ret = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, NULL);
       CHECK_SQLITE_ERROR(ret, SQLITE_OK);
       while (sqlite3_step(stmt) == SQLITE_ROW) {
-        const char *name = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0));
+        const char *name = reinterpret_cast<const char *>(
+            sqlite3_column_text(stmt, 0));
         const string names = sanitise_name(name);
-        if (*it=="dirs") { 
+        if (*it == "dirs") {
           paths.push_back(names);
         } else {
           paths.push_back(get_parent(names));
@@ -315,17 +344,20 @@ static vector<string> get_all_dirs_from_sqlite(vector<string>& sqlite_db_vec,
   return paths;
 }
 
-static int get_db_schema_revision(sqlite3 *db, const std::string &db_name = "") {
+static int get_db_schema_revision(sqlite3 *db,
+                                  const std::string &db_name = "") {
   sqlite3_stmt *stmt;
   std::ostringstream stmt_str;
-  stmt_str << "SELECT value FROM " << db_name << "properties WHERE key = 'schema_revision'";
+  stmt_str << "SELECT value FROM " << db_name
+           << "properties WHERE key = 'schema_revision'";
   int ret = sqlite3_prepare_v2(db, stmt_str.str().c_str(), -1, &stmt, NULL);
   CHECK_SQLITE_ERROR(ret, SQLITE_OK);
 
   ret = sqlite3_step(stmt);
   // if table exists, we require that it must have a schema_revision row
   CHECK_SQLITE_ERROR(ret, SQLITE_ROW);
-  const std::string schema_revision_str(reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0)));
+  const std::string schema_revision_str(
+      reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0)));
   CHECK_SQLITE_ERROR(sqlite3_finalize(stmt), SQLITE_OK);
   return std::stoi(schema_revision_str);
 }
@@ -339,14 +371,16 @@ static int get_row_count(sqlite3 *db, const std::string &table_name) {
 
   ret = sqlite3_step(stmt);
   CHECK_SQLITE_ERROR(ret, SQLITE_ROW);
-  const std::string count_str(reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0)));
+  const std::string count_str(
+      reinterpret_cast<const char *>(sqlite3_column_text(stmt, 0)));
   CHECK_SQLITE_ERROR(sqlite3_finalize(stmt), SQLITE_OK);
   return std::stoi(count_str);
 }
 
 static int calculate_print_frequency(int total) {
   int base = 1000;
-  while (base * 50 < total) base *= 10;
+  while (base * 50 < total)
+    base *= 10;
   return base;
 }
 
@@ -355,21 +389,23 @@ static string get_lease_from_paths(vector<string> paths) {
   CUSTOM_ASSERT(!paths.empty(), "no paths are provided");
 
   // we'd have to ensure path is relative
-  // (probably best to check this elsewhere as it is not just a requirement for this function)
+  // (probably best to check this elsewhere as it is not just a requirement for
+  // this function)
   auto lease = PathString(paths.at(0));
   for (auto it = paths.begin() + 1; it != paths.end(); ++it) {
     auto path = PathString(*it);
     // shrink the lease path until it is a parent of "path"
     while (!IsSubPath(lease, path)) {
-        auto i = lease.GetLength() - 1;
-        for (; i >= 0; --i) {
-            if (lease.GetChars()[i] == '/' || i == 0) {
-                lease.Truncate(i);
-                break;
-            }
+      auto i = lease.GetLength() - 1;
+      for (; i >= 0; --i) {
+        if (lease.GetChars()[i] == '/' || i == 0) {
+          lease.Truncate(i);
+          break;
         }
+      }
     }
-    if (lease.IsEmpty()) break; // early stop if lease is already at the root
+    if (lease.IsEmpty())
+      break;  // early stop if lease is already at the root
   }
 
   auto prefix = "/" + lease.ToString();
@@ -388,25 +424,31 @@ static XattrList marshal_xattrs(const char *acl_string) {
   bool equiv_mode;
   size_t binary_size;
   char *binary_acl;
-  const int ret = acl_from_text_to_xattr_value(string(acl_string), binary_acl, binary_size, equiv_mode);
+  const int ret = acl_from_text_to_xattr_value(string(acl_string), binary_acl,
+                                               binary_size, equiv_mode);
   if (ret) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failure of acl_from_text_to_xattr_value(%s)", acl_string);
-    assert(0); // TODO(vavolkl): incorporate error handling other than asserting
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "failure of acl_from_text_to_xattr_value(%s)", acl_string);
+    assert(
+        0);  // TODO(vavolkl): incorporate error handling other than asserting
     return aclobj;
   }
   if (!equiv_mode) {
-    CUSTOM_ASSERT(aclobj.Set("system.posix_acl_access", string(binary_acl, binary_size)), "failed to set system.posix_acl_access (ACL size %ld)", binary_size);
+    CUSTOM_ASSERT(
+        aclobj.Set("system.posix_acl_access", string(binary_acl, binary_size)),
+        "failed to set system.posix_acl_access (ACL size %ld)", binary_size);
     free(binary_acl);
   }
 
   return aclobj;
 }
 
-std::unordered_map<string, string> load_config(const string& config_file) {
+std::unordered_map<string, string> load_config(const string &config_file) {
   std::unordered_map<string, string> config_map;
   ifstream input(config_file);
   if (!input) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "could not open config file %s", config_file.c_str());
+    LogCvmfs(kLogCvmfs, kLogStderr, "could not open config file %s",
+             config_file.c_str());
     return config_map;
   }
   vector<string> lines;
@@ -431,13 +473,15 @@ std::unordered_map<string, string> load_config(const string& config_file) {
   return config_map;
 }
 
-string retrieve_config(std::unordered_map<string, string> &config_map, const string& key) {
+string retrieve_config(std::unordered_map<string, string> &config_map,
+                       const string &key) {
   auto kv = config_map.find(key);
-  CUSTOM_ASSERT(kv != config_map.end(), "Parameter %s not found in config", key.c_str());
+  CUSTOM_ASSERT(kv != config_map.end(), "Parameter %s not found in config",
+                key.c_str());
   return kv->second;
 }
 
-static vector<string> get_file_list(string& path) {
+static vector<string> get_file_list(string &path) {
   vector<string> paths;
   const char *cpath = path.c_str();
   struct stat st;
@@ -466,41 +510,39 @@ static vector<string> get_file_list(string& path) {
 extern bool g_log_with_time;
 
 int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
-
   // the catalog code uses assert() liberally.
   // install ABRT signal handler to catch an abort and cancel lease
-  if (
-    signal(SIGABRT, &on_signal) == SIG_ERR
-    || signal(SIGINT, &on_signal) == SIG_ERR
-    || signal(SIGTERM, &on_signal) == SIG_ERR
-  ) {
+  if (signal(SIGABRT, &on_signal) == SIG_ERR
+      || signal(SIGINT, &on_signal) == SIG_ERR
+      || signal(SIGTERM, &on_signal) == SIG_ERR) {
     LogCvmfs(kLogCvmfs, kLogStdout, "Setting signal handlers failed");
     exit(1);
   }
 
   const bool enable_corefiles = (args.find('c') != args.end());
-  if( !enable_corefiles ) {
+  if (!enable_corefiles) {
     struct rlimit rlim;
     rlim.rlim_cur = rlim.rlim_max = 0;
-    setrlimit( RLIMIT_CORE, &rlim );
+    setrlimit(RLIMIT_CORE, &rlim);
   }
 
 
   if (args.find('n') != args.end()) {
-    create_empty_database( *args.find('n')->second);
+    create_empty_database(*args.find('n')->second);
     exit(0);
   }
 
-  //TODO(@vvolkl): add 'B' option to wait_for_update
-  //TODO(@vvolkl): add 'T' option for ttl
+  // TODO(@vvolkl): add 'B' option to wait_for_update
+  // TODO(@vvolkl): add 'T' option for ttl
 
 
   if (args.find('P') != args.end()) {
     const char *arg = (*args.find('P')->second).c_str();
-    char* at_null_terminator_if_number;
+    char *at_null_terminator_if_number;
     g_priority = strtoll(arg, &at_null_terminator_if_number, 10);
     if (*at_null_terminator_if_number != '\0') {
-      LogCvmfs(kLogCvmfs, kLogStderr, "Priority parameter value '%s' parsing failed", arg);
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Priority parameter value '%s' parsing failed", arg);
       return 1;
     }
   } else {
@@ -527,9 +569,10 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
   string kConfigDir("/etc/cvmfs/gateway-client/");
   if (args.find('C') != args.end()) {
     kConfigDir = MakeCanonicalPath(*args.find('C')->second);
-     kConfigDir += "/";
-    LogCvmfs(kLogCvmfs, kLogStdout, "Overriding configuration dir prefix to %s", kConfigDir.c_str() );
-  } 
+    kConfigDir += "/";
+    LogCvmfs(kLogCvmfs, kLogStdout, "Overriding configuration dir prefix to %s",
+             kConfigDir.c_str());
+  }
 
   // mandatory arguments
   string const repo_name = *args.find('N')->second;
@@ -540,23 +583,26 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
   // optional arguments
   bool const allow_deletions = (args.find('d') != args.end());
   bool const force_cancel_lease = (args.find('x') != args.end());
-  bool const allow_additions = !allow_deletions || (args.find('a') != args.end());
-  g_add_missing_catalogs = ( args.find('z') != args.end());
-  bool const check_completed_graft_property = ( args.find('Z') != args.end());
+  bool const allow_additions = !allow_deletions
+                               || (args.find('a') != args.end());
+  g_add_missing_catalogs = (args.find('z') != args.end());
+  bool const check_completed_graft_property = (args.find('Z') != args.end());
   if (args.find('v') != args.end()) {
     SetLogVerbosity(kLogVerbose);
   }
 
-  if(check_completed_graft_property) {
-    if(sqlite_db_vec.size()!=1) {
+  if (check_completed_graft_property) {
+    if (sqlite_db_vec.size() != 1) {
       LogCvmfs(kLogCvmfs, kLogStderr, "-Z requires a single DB file");
       exit(1);
     }
-    if(isDatabaseMarkedComplete(sqlite_db_vec[0].c_str())) {
-      LogCvmfs(kLogCvmfs, kLogStderr, "DB file is already marked as completed_graft");
+    if (isDatabaseMarkedComplete(sqlite_db_vec[0].c_str())) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "DB file is already marked as completed_graft");
       exit(0);
     } else {
-      LogCvmfs(kLogCvmfs, kLogStderr, "DB file is not marked as completed_graft");
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "DB file is not marked as completed_graft");
     }
   }
 
@@ -564,17 +610,20 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
   string stratum0;
   string proxy;
 
-  string additional_prefix="";
-  bool   has_additional_prefix=false;
+  string additional_prefix = "";
+  bool has_additional_prefix = false;
   if (args.find('p') != args.end()) {
-      additional_prefix=*args.find('p')->second;
-      additional_prefix = sanitise_name(additional_prefix.c_str(), true);
-      if( additional_prefix.back() != '/' ) {
-        additional_prefix += "/";
-      }
-      has_additional_prefix= true;
-      LogCvmfs(kLogCvmfs, kLogStdout, "Adding additional prefix %s to lease and all paths", additional_prefix.c_str() );
-      // now we are confident that any additional prefix has no leading / and does have a tailing /
+    additional_prefix = *args.find('p')->second;
+    additional_prefix = sanitise_name(additional_prefix.c_str(), true);
+    if (additional_prefix.back() != '/') {
+      additional_prefix += "/";
+    }
+    has_additional_prefix = true;
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "Adding additional prefix %s to lease and all paths",
+             additional_prefix.c_str());
+    // now we are confident that any additional prefix has no leading / and does
+    // have a tailing /
   }
   auto config_map = load_config(config_file);
 
@@ -595,8 +644,8 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
     proxy = retrieve_config(config_map, "CVMFS_HTTP_PROXY");
   }
 
-  string lease_path="";
-  //bool lease_autodetected = false;
+  string lease_path = "";
+  // bool lease_autodetected = false;
   if (args.find('l') != args.end()) {
     lease_path = *args.find('l')->second;
   } else {
@@ -608,43 +657,51 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
       return 0;  // treat it as a success
     }
     lease_path = get_lease_from_paths(paths);
-    //lease_autodetected = true;
+    // lease_autodetected = true;
   }
 
   if (has_additional_prefix) {
-    if (lease_path == "/" ) { lease_path = "/" + additional_prefix; }
-    else { 
-      if ( lease_path.substr(0,1)=="/" ) {
-        lease_path = "/" + additional_prefix + lease_path.substr(1, lease_path.size()-1);
+    if (lease_path == "/") {
+      lease_path = "/" + additional_prefix;
+    } else {
+      if (lease_path.substr(0, 1) == "/") {
+        lease_path = "/" + additional_prefix
+                     + lease_path.substr(1, lease_path.size() - 1);
       } else {
-        lease_path = "/" + additional_prefix + lease_path;   // prefix is certain to have a trailing /
+        lease_path = "/" + additional_prefix
+                     + lease_path;  // prefix is certain to have a trailing /
       }
     }
   }
-  if (lease_path.substr(0,1)!="/") { lease_path = "/" + lease_path; }
+  if (lease_path.substr(0, 1) != "/") {
+    lease_path = "/" + lease_path;
+  }
   LogCvmfs(kLogCvmfs, kLogStdout, "Lease path is %s", lease_path.c_str());
 
 
   string public_keys = kConfigDir + repo_name + "/pubkey";
-  string key_file    = kConfigDir + repo_name + "/gatewaykey";
-  string s3_file     = kConfigDir + repo_name + "/s3.conf";
-  
-  if( args.find('k') != args.end()) {
-     public_keys = *args.find('k')->second;
+  string key_file = kConfigDir + repo_name + "/gatewaykey";
+  string s3_file = kConfigDir + repo_name + "/s3.conf";
+
+  if (args.find('k') != args.end()) {
+    public_keys = *args.find('k')->second;
   }
-  if( args.find('s') != args.end()) {
-     key_file = *args.find('s')->second;
+  if (args.find('s') != args.end()) {
+    key_file = *args.find('s')->second;
   }
-  if( args.find('3') != args.end()) {
-     s3_file = *args.find('3')->second;
+  if (args.find('3') != args.end()) {
+    s3_file = *args.find('3')->second;
   }
 
-  CUSTOM_ASSERT(access(public_keys.c_str(), R_OK) == 0, "%s is not readable", public_keys.c_str());
-  CUSTOM_ASSERT(access(key_file.c_str(), R_OK) == 0, "%s is not readable", key_file.c_str());
+  CUSTOM_ASSERT(access(public_keys.c_str(), R_OK) == 0, "%s is not readable",
+                public_keys.c_str());
+  CUSTOM_ASSERT(access(key_file.c_str(), R_OK) == 0, "%s is not readable",
+                key_file.c_str());
 
-//  string spooler_definition_string = string("gw,,") + g_gateway_url;
+  //  string spooler_definition_string = string("gw,,") + g_gateway_url;
   // create a spooler that will upload to S3
-  string const spooler_definition_string = string("S3,") + dir_temp + "," + repo_name + "@" + s3_file;
+  string const spooler_definition_string = string("S3,") + dir_temp + ","
+                                           + repo_name + "@" + s3_file;
 
   // load gateway lease
   if (!gateway::ReadKeys(key_file, &g_gateway_key_id, &g_gateway_secret)) {
@@ -652,45 +709,49 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
-  uint64_t current_revision=0;
-  std::string current_root_hash="";
+  uint64_t current_revision = 0;
+  std::string current_root_hash = "";
 
   // acquire lease and save token to a file in the tmpdir
   LogCvmfs(kLogCvmfs, kLogStdout, "Acquiring gateway lease on %s",
            lease_path.c_str());
   g_session_token = acquire_lease(g_gateway_key_id, g_gateway_secret,
-                                  repo_name + lease_path, g_gateway_url, force_cancel_lease,
-                                  &current_revision, current_root_hash, lease_busy_retry_interval);
+                                  repo_name + lease_path, g_gateway_url,
+                                  force_cancel_lease, &current_revision,
+                                  current_root_hash, lease_busy_retry_interval);
 
- 
-  char *_tmpfile = strdup( (dir_temp + "/gateway_session_token_XXXXXX").c_str() );
+
+  char *_tmpfile = strdup((dir_temp + "/gateway_session_token_XXXXXX").c_str());
   int const temp_fd = mkstemp(_tmpfile);
   g_session_token_file = string(_tmpfile);
   free(_tmpfile);
 
-  FILE *fout=fdopen(temp_fd, "wb"); 
-  CUSTOM_ASSERT(fout!=NULL, "failed to open session token file %s for writing", g_session_token_file.c_str());
+  FILE *fout = fdopen(temp_fd, "wb");
+  CUSTOM_ASSERT(fout != NULL,
+                "failed to open session token file %s for writing",
+                g_session_token_file.c_str());
   fputs(g_session_token.c_str(), fout);
   fclose(fout);
 
   // now start the lease refresh thread
   pthread_t lease_thread;
-  if ( 0 != pthread_create( &lease_thread, NULL, lease_refresh_thread, NULL ) ) {
-     LogCvmfs(kLogCvmfs, kLogStderr, "Unable to start lease refresh thread");
-     cancel_lease();
-     return 1;
+  if (0 != pthread_create(&lease_thread, NULL, lease_refresh_thread, NULL)) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Unable to start lease refresh thread");
+    cancel_lease();
+    return 1;
   }
 
   // now initialise the various bits we need
 
   upload::SpoolerDefinition spooler_definition(
       spooler_definition_string, shash::kSha1, zlib::kZlibDefault, false, true,
-      SyncParameters::kDefaultMinFileChunkSize, SyncParameters::kDefaultAvgFileChunkSize,
+      SyncParameters::kDefaultMinFileChunkSize,
+      SyncParameters::kDefaultAvgFileChunkSize,
       SyncParameters::kDefaultMaxFileChunkSize, g_session_token_file, key_file);
 
   if (args.find('q') != args.end()) {
-    spooler_definition.number_of_concurrent_uploads =
-        String2Uint64(*args.find('q')->second);
+    spooler_definition.number_of_concurrent_uploads = String2Uint64(
+        *args.find('q')->second);
   }
 
   upload::SpoolerDefinition const spooler_definition_catalogs(
@@ -725,33 +786,47 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
     return 1;
   }
 
-  if(current_revision > 0 ) {
-  if( current_revision == manifest->revision() ) {
-    if (current_root_hash != manifest->catalog_hash().ToString() ) {
-     LogCvmfs(kLogCvmfs, kLogStderr, "Mismatch between cvmfspublished and gateway hash for revision %lu (%s!=%s)", current_revision, current_root_hash.c_str(), manifest->catalog_hash().ToString().c_str() );
-     cancel_lease();
-     return 1;
-    } else {
-     LogCvmfs(kLogCvmfs, kLogStdout, "Gateway and .cvmfspublished agree on repo version %lu", current_revision );
+  if (current_revision > 0) {
+    if (current_revision == manifest->revision()) {
+      if (current_root_hash != manifest->catalog_hash().ToString()) {
+        LogCvmfs(kLogCvmfs, kLogStderr,
+                 "Mismatch between cvmfspublished and gateway hash for "
+                 "revision %lu (%s!=%s)",
+                 current_revision, current_root_hash.c_str(),
+                 manifest->catalog_hash().ToString().c_str());
+        cancel_lease();
+        return 1;
+      } else {
+        LogCvmfs(kLogCvmfs, kLogStdout,
+                 "Gateway and .cvmfspublished agree on repo version %lu",
+                 current_revision);
+      }
     }
-  }
-  if( current_revision > manifest->revision() ) {
-     LogCvmfs(kLogCvmfs, kLogStdout, "Gateway has supplied a newer revision than the current .cvmfspublished %lu > %lu", current_revision, manifest->revision() );
-     manifest->set_revision(current_revision);
-     manifest->set_catalog_hash( shash::MkFromHexPtr(shash::HexPtr(current_root_hash), shash::kSuffixCatalog));
-  } else if (current_revision < manifest->revision() ) {
-     LogCvmfs(kLogCvmfs, kLogStdout, "Gateway has supplied an older revision than the current .cvmfspublished %lu < %lu", current_revision, manifest->revision() );
-  } 
+    if (current_revision > manifest->revision()) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+               "Gateway has supplied a newer revision than the current "
+               ".cvmfspublished %lu > %lu",
+               current_revision, manifest->revision());
+      manifest->set_revision(current_revision);
+      manifest->set_catalog_hash(shash::MkFromHexPtr(
+          shash::HexPtr(current_root_hash), shash::kSuffixCatalog));
+    } else if (current_revision < manifest->revision()) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+               "Gateway has supplied an older revision than the current "
+               ".cvmfspublished %lu < %lu",
+               current_revision, manifest->revision());
+    }
   } else {
-     LogCvmfs(kLogCvmfs, kLogStdout, "Gateway has not supplied a revision. Using .cvmfspublished" );
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "Gateway has not supplied a revision. Using .cvmfspublished");
   }
 
 
   // get hash of current root catalog, remove terminal "C", encode it
   string const old_root_hash = manifest->catalog_hash().ToString(true);
   string const hash = old_root_hash.substr(0, old_root_hash.length() - 1);
-  shash::Any const base_hash =
-      shash::MkFromHexPtr(shash::HexPtr(hash), shash::kSuffixCatalog);
+  shash::Any const base_hash = shash::MkFromHexPtr(shash::HexPtr(hash),
+                                                   shash::kSuffixCatalog);
   LogCvmfs(kLogCvmfs, kLogStdout, "old_root_hash: %s", old_root_hash.c_str());
 
   bool const is_balanced = false;
@@ -759,23 +834,27 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
   catalog::WritableCatalogManager catalog_manager(
       base_hash, stratum0, dir_temp, spooler_catalogs.weak_ref(),
       download_manager(), false, SyncParameters::kDefaultNestedKcatalogLimit,
-      SyncParameters::kDefaultRootKcatalogLimit, SyncParameters::kDefaultFileMbyteLimit, statistics(),
-      is_balanced, SyncParameters::kDefaultMaxWeight, SyncParameters::kDefaultMinWeight, dir_temp /* dir_cache */);
+      SyncParameters::kDefaultRootKcatalogLimit,
+      SyncParameters::kDefaultFileMbyteLimit, statistics(), is_balanced,
+      SyncParameters::kDefaultMaxWeight, SyncParameters::kDefaultMinWeight,
+      dir_temp /* dir_cache */);
 
   catalog_manager.Init();
 
 
   // now graft the contents of the DB
-  vector<sqlite3*> open_dbs;
-  for (auto&& db_file : sqlite_db_vec) {
+  vector<sqlite3 *> open_dbs;
+  for (auto &&db_file : sqlite_db_vec) {
     sqlite3 *db;
-    CHECK_SQLITE_ERROR(sqlite3_open_v2(db_file.c_str(), &db, SQLITE_OPEN_READONLY, NULL), SQLITE_OK);
+    CHECK_SQLITE_ERROR(
+        sqlite3_open_v2(db_file.c_str(), &db, SQLITE_OPEN_READONLY, NULL),
+        SQLITE_OK);
     relax_db_locking(db);
     open_dbs.push_back(db);
   }
-  process_sqlite(open_dbs, catalog_manager, allow_additions,
-                 allow_deletions, lease_path.substr(1), additional_prefix);
-  for (auto&& db : open_dbs) {
+  process_sqlite(open_dbs, catalog_manager, allow_additions, allow_deletions,
+                 lease_path.substr(1), additional_prefix);
+  for (auto &&db : open_dbs) {
     CHECK_SQLITE_ERROR(sqlite3_close_v2(db), SQLITE_OK);
   }
 
@@ -799,79 +878,86 @@ int swissknife::IngestSQL::Main(const swissknife::ArgumentList &args) {
   // Get the path of the new root catalog
   const string new_root_hash = manifest->catalog_hash().ToString(true);
 
-//  if (!spooler_catalogs->FinalizeSession(true, old_root_hash, new_root_hash,
-//                                         RepositoryTag())) {
-//    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to commit the transaction");
-//    // lease is only released on success
-//    cancel_lease();
-//    return 1;
-//  }
+  //  if (!spooler_catalogs->FinalizeSession(true, old_root_hash, new_root_hash,
+  //                                         RepositoryTag())) {
+  //    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to commit the transaction");
+  //    // lease is only released on success
+  //    cancel_lease();
+  //    return 1;
+  //  }
 
-  LogCvmfs(kLogCvmfs, kLogStdout, "Committing with priority %" PRId64, g_priority);
+  LogCvmfs(kLogCvmfs, kLogStdout, "Committing with priority %" PRId64,
+           g_priority);
 
-  bool const ok = make_commit_on_gateway( old_root_hash, new_root_hash, g_priority );
-  if(!ok) {
-   LogCvmfs(kLogCvmfs, kLogStderr, "something went wrong during commit on gateway");
-   cancel_lease(); 
-   exit(1);
+  bool const ok = make_commit_on_gateway(old_root_hash, new_root_hash,
+                                         g_priority);
+  if (!ok) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "something went wrong during commit on gateway");
+    cancel_lease();
+    exit(1);
   }
 
 
-  unlink( g_session_token_file.c_str() );
+  unlink(g_session_token_file.c_str());
 
-  g_stop_refresh=true;
+  g_stop_refresh = true;
 
 
-  if(check_completed_graft_property) {
-    setDatabaseMarkedComplete(sqlite_db_vec[0].c_str()); 
+  if (check_completed_graft_property) {
+    setDatabaseMarkedComplete(sqlite_db_vec[0].c_str());
   }
-
 
 
   return 0;
 }
 
-size_t writeFunction(void *ptr, size_t size, size_t nmemb, std::string* data) {
-    return size * nmemb;
+size_t writeFunction(void *ptr, size_t size, size_t nmemb, std::string *data) {
+  return size * nmemb;
 }
 
-void replaceAllSubstrings(std::string& str, const std::string& from, const std::string& to) {
-    if (from.empty()) {
-        return; // Avoid infinite loop if 'from' is an empty string.
-    }
-    size_t startPos = 0;
-    while ((startPos = str.find(from, startPos)) != std::string::npos) {
-        str.replace(startPos, from.length(), to);
-        startPos += to.length(); // Advance startPos to avoid replacing the substring just inserted.
-    }
+void replaceAllSubstrings(std::string &str, const std::string &from,
+                          const std::string &to) {
+  if (from.empty()) {
+    return;  // Avoid infinite loop if 'from' is an empty string.
+  }
+  size_t startPos = 0;
+  while ((startPos = str.find(from, startPos)) != std::string::npos) {
+    str.replace(startPos, from.length(), to);
+    startPos += to.length();  // Advance startPos to avoid replacing the
+                              // substring just inserted.
+  }
 }
 
 
 void swissknife::IngestSQL::process_sqlite(
-    const std::vector<sqlite3*> &dbs,
-    catalog::WritableCatalogManager &catalog_manager,
-    bool allow_additions, bool allow_deletions, const std::string &lease_path, const std::string &additional_prefix)
-{
+    const std::vector<sqlite3 *> &dbs,
+    catalog::WritableCatalogManager &catalog_manager, bool allow_additions,
+    bool allow_deletions, const std::string &lease_path,
+    const std::string &additional_prefix) {
   std::map<std::string, Directory> all_dirs;
-  std::map<std::string, std::vector<File>> all_files;
-  std::map<std::string, std::vector<Symlink>> all_symlinks;
+  std::map<std::string, std::vector<File> > all_files;
+  std::map<std::string, std::vector<Symlink> > all_symlinks;
 
-  for (auto&& db : dbs) {
+  for (auto &&db : dbs) {
     load_dirs(db, lease_path, additional_prefix, all_dirs);
   }
 
   // put in a nested scope so we can free up memory of `dir_names`
   {
-    LogCvmfs(kLogCvmfs, kLogStdout, "Precaching existing directories (starting from %s)", lease_path.c_str());
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "Precaching existing directories (starting from %s)",
+             lease_path.c_str());
     std::unordered_set<std::string> dir_names;
-    std::transform(all_dirs.begin(), all_dirs.end(), std::inserter(dir_names, dir_names.end()),
-      [](const std::pair<std::string, Directory>& pair) {
-        return MakeCatalogPath(pair.first);
-      });
+    std::transform(all_dirs.begin(), all_dirs.end(),
+                   std::inserter(dir_names, dir_names.end()),
+                   [](const std::pair<std::string, Directory> &pair) {
+                     return MakeCatalogPath(pair.first);
+                   });
     catalog_manager.LoadCatalogs(MakeCatalogPath(lease_path), dir_names);
   }
 
-  for (auto&& db : dbs) {
+  for (auto &&db : dbs) {
     load_files(db, lease_path, additional_prefix, all_files);
     load_symlinks(db, lease_path, additional_prefix, all_symlinks);
   }
@@ -879,24 +965,31 @@ void swissknife::IngestSQL::process_sqlite(
   // perform all deletions first
   if (allow_deletions) {
     LogCvmfs(kLogCvmfs, kLogStdout, "Processing deletions...");
-    for (auto&& db : dbs) {
-      CHECK_SQLITE_ERROR(do_deletions(db, catalog_manager, lease_path, additional_prefix), SQLITE_OK);
+    for (auto &&db : dbs) {
+      CHECK_SQLITE_ERROR(
+          do_deletions(db, catalog_manager, lease_path, additional_prefix),
+          SQLITE_OK);
     }
   }
 
   if (allow_additions) {
     LogCvmfs(kLogCvmfs, kLogStdout, "Processing additions...");
     // first ensure all directories are present and create missing ones
-    do_additions(all_dirs, all_files, all_symlinks, lease_path, catalog_manager);
+    do_additions(all_dirs, all_files, all_symlinks, lease_path,
+                 catalog_manager);
   }
 }
 
-void add_dir_to_tree(std::string path, std::unordered_map<std::string, std::set<std::string>> &tree, const std::string &lease_path) {
+void add_dir_to_tree(
+    std::string path,
+    std::unordered_map<std::string, std::set<std::string> > &tree,
+    const std::string &lease_path) {
   tree[path];
   std::string parent_path = get_parent(path);
   // recursively create any missing parents in the tree
   // avoid creating a loop when we insert the root path
-  while (path != parent_path && path != lease_path && !tree[parent_path].count(path)) {
+  while (path != parent_path && path != lease_path
+         && !tree[parent_path].count(path)) {
     tree[parent_path].insert(path);
     path = parent_path;
     parent_path = get_parent(path);
@@ -904,26 +997,31 @@ void add_dir_to_tree(std::string path, std::unordered_map<std::string, std::set<
 }
 
 int swissknife::IngestSQL::do_additions(
-  const DirMap &all_dirs, const FileMap &all_files, const SymlinkMap &all_symlinks, const std::string &lease_path, catalog::WritableCatalogManager &catalog_manager) {
+    const DirMap &all_dirs, const FileMap &all_files,
+    const SymlinkMap &all_symlinks, const std::string &lease_path,
+    catalog::WritableCatalogManager &catalog_manager) {
   // STEP 1:
   // - collect all the dirs/symlinks/files we need to process from the DB
   // - build a tree of paths for DFS traversal
-  //   - note the tree will contain all parent dirs of symlinks/files even if those are not
+  //   - note the tree will contain all parent dirs of symlinks/files even if
+  //   those are not
   //     explicitly added to the dirs table
-  std::unordered_map<std::string, std::set<std::string>> tree;
-  for (auto&& p : all_dirs) {
+  std::unordered_map<std::string, std::set<std::string> > tree;
+  for (auto &&p : all_dirs) {
     add_dir_to_tree(p.first, tree, lease_path);
   }
-  for (auto&& p : all_files) {
+  for (auto &&p : all_files) {
     add_dir_to_tree(p.first, tree, lease_path);
   }
-  for (auto&& p : all_symlinks) {
+  for (auto &&p : all_symlinks) {
     add_dir_to_tree(p.first, tree, lease_path);
   }
   int const row_count = static_cast<int>(tree.size());
   int const print_every = calculate_print_frequency(row_count);
   int curr_row = 0;
-  LogCvmfs(kLogCvmfs, kLogStdout, "Changeset: %ld dirs, %ld files, %ld symlinks", tree.size(), all_files.size(), all_symlinks.size());
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Changeset: %ld dirs, %ld files, %ld symlinks", tree.size(),
+           all_files.size(), all_symlinks.size());
 
   // STEP 2:
   // - process all the changes with DFS traversal
@@ -931,10 +1029,12 @@ int swissknife::IngestSQL::do_additions(
   //   - add files/symlinks and schedule upload in post-order
   catalog_manager.SetupSingleCatalogUploadCallback();
   std::stack<string> dfs_stack;
-  for (auto&& p : tree) {
-    // figure out the starting point by checking whose parent is missing from the tree
+  for (auto &&p : tree) {
+    // figure out the starting point by checking whose parent is missing from
+    // the tree
     if (p.first == "" || !tree.count(get_parent(p.first))) {
-      CUSTOM_ASSERT(dfs_stack.empty(), "provided DB input forms more than one path trees");
+      CUSTOM_ASSERT(dfs_stack.empty(),
+                    "provided DB input forms more than one path trees");
       dfs_stack.push(p.first);
     }
   }
@@ -953,10 +1053,11 @@ int swissknife::IngestSQL::do_additions(
       // snapshot the dir (if it's a nested catalog mountpoint)
       catalog::DirectoryEntry dir_entry;
       bool exists = false;
-      exists = catalog_manager.LookupDirEntry(MakeCatalogPath(curr_dir),
-                                          catalog::kLookupDefault, &dir_entry);
-      assert(exists); // the dir must exist at this point
-      if (dir_entry.IsNestedCatalogMountpoint() || dir_entry.IsNestedCatalogRoot()) {
+      exists = catalog_manager.LookupDirEntry(
+          MakeCatalogPath(curr_dir), catalog::kLookupDefault, &dir_entry);
+      assert(exists);  // the dir must exist at this point
+      if (dir_entry.IsNestedCatalogMountpoint()
+          || dir_entry.IsNestedCatalogRoot()) {
         catalog_manager.AddCatalogToQueue(curr_dir);
         catalog_manager.ScheduleReadyCatalogs();
       }
@@ -967,21 +1068,25 @@ int swissknife::IngestSQL::do_additions(
       // push children to the stack
       auto it = tree.find(curr_dir);
       if (it != tree.end()) {
-        for (auto&& child : it->second) {
+        for (auto &&child : it->second) {
           dfs_stack.push(child);
         }
         tree.erase(it);
       }
-      if (!all_dirs.count(curr_dir)) continue;
+      if (!all_dirs.count(curr_dir))
+        continue;
 
       // create the dir first in pre-order traversal
-      const IngestSQL::Directory& dir = all_dirs.at(curr_dir);
+      const IngestSQL::Directory &dir = all_dirs.at(curr_dir);
       catalog::DirectoryEntry dir_entry;
 
       bool exists = false;
-      exists = catalog_manager.LookupDirEntry(MakeCatalogPath(curr_dir),
-                                          catalog::kLookupDefault, &dir_entry);
-      CUSTOM_ASSERT(!(exists && !S_ISDIR(dir_entry.mode_)), "Refusing to replace existing file/symlink at %s with a directory", dir.name.c_str());
+      exists = catalog_manager.LookupDirEntry(
+          MakeCatalogPath(curr_dir), catalog::kLookupDefault, &dir_entry);
+      CUSTOM_ASSERT(
+          !(exists && !S_ISDIR(dir_entry.mode_)),
+          "Refusing to replace existing file/symlink at %s with a directory",
+          dir.name.c_str());
 
       dir_entry.name_ = NameString(get_basename(dir.name));
       dir_entry.mtime_ = dir.mtime / 1000000000;
@@ -991,25 +1096,35 @@ int swissknife::IngestSQL::do_additions(
       dir_entry.gid_ = dir.grp;
       dir_entry.has_xattrs_ = !dir.xattr.IsEmpty();
 
-      bool add_nested_catalog=false;
+      bool add_nested_catalog = false;
 
       if (exists) {
         catalog_manager.TouchDirectory(dir_entry, dir.xattr, dir.name);
-        if((!dir_entry.IsNestedCatalogMountpoint() && !dir_entry.IsNestedCatalogRoot()) && ( g_add_missing_catalogs || dir.nested ) ) {
-          add_nested_catalog=true;
-          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Touching existing directory %s and adding nested catalog", dir.name.c_str());
+        if ((!dir_entry.IsNestedCatalogMountpoint()
+             && !dir_entry.IsNestedCatalogRoot())
+            && (g_add_missing_catalogs || dir.nested)) {
+          add_nested_catalog = true;
+          LogCvmfs(kLogCvmfs, kLogVerboseMsg,
+                   "Touching existing directory %s and adding nested catalog",
+                   dir.name.c_str());
         } else {
-          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Touching existing directory %s", dir.name.c_str());
+          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Touching existing directory %s",
+                   dir.name.c_str());
         }
       } else {
-        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Adding directory [%s]", dir.name.c_str());
-        catalog_manager.AddDirectory(dir_entry, dir.xattr, get_parent(dir.name));
-        if(dir.nested) {add_nested_catalog=true;}
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Adding directory [%s]",
+                 dir.name.c_str());
+        catalog_manager.AddDirectory(dir_entry, dir.xattr,
+                                     get_parent(dir.name));
+        if (dir.nested) {
+          add_nested_catalog = true;
+        }
       }
       if (add_nested_catalog) {
         // now add a .cvmfscatalog file
         // so that manual changes won't remove the nested catalog
-        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Placing .cvmfscatalog file in [%s]", dir.name.c_str());
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg,
+                 "Placing .cvmfscatalog file in [%s]", dir.name.c_str());
         catalog::DirectoryEntryBase dir2;
         dir2.name_ = NameString(".cvmfscatalog");
         dir2.mtime_ = dir.mtime / 1000000000;
@@ -1023,28 +1138,30 @@ int swissknife::IngestSQL::do_additions(
         XattrList const xattr2;
         catalog_manager.AddFile(dir2, xattr2, dir.name);
 
-        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Creating Nested Catalog [%s]", dir.name.c_str());
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Creating Nested Catalog [%s]",
+                 dir.name.c_str());
         catalog_manager.CreateNestedCatalog(dir.name);
       }
     }
   }
-  
+
   // sanity check that we have processed all the input
-  CUSTOM_ASSERT(tree.empty(), "not all directories are processed, malformed input DB?");
+  CUSTOM_ASSERT(tree.empty(),
+                "not all directories are processed, malformed input DB?");
   catalog_manager.RemoveSingleCatalogUploadCallback();
   return 0;
 }
 
 int swissknife::IngestSQL::add_symlinks(
-    catalog::WritableCatalogManager &catalog_manager, const std::vector<Symlink> &symlinks)
-{
-  for (auto&& symlink : symlinks) {
+    catalog::WritableCatalogManager &catalog_manager,
+    const std::vector<Symlink> &symlinks) {
+  for (auto &&symlink : symlinks) {
     catalog::DirectoryEntry dir;
     catalog::DirectoryEntryBase dir2;
     XattrList const xattr;
     bool exists = false;
     exists = catalog_manager.LookupDirEntry(MakeCatalogPath(symlink.name),
-                                        catalog::kLookupDefault, &dir);
+                                            catalog::kLookupDefault, &dir);
 
     dir2.name_ = NameString(get_basename(symlink.name));
     dir2.mtime_ = symlink.mtime / 1000000000;
@@ -1054,61 +1171,79 @@ int swissknife::IngestSQL::add_symlinks(
     dir2.symlink_ = LinkString(symlink.target);
     dir2.mode_ = S_IFLNK | 0777;
 
-    int noop=false;
+    int noop = false;
 
     if (exists) {
-      if(symlink.skip_if_file_or_dir) {
-        if(S_ISDIR(dir.mode_) || S_ISREG(dir.mode_)) {
-          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "File or directory for symlink [%s] exists, skipping symlink creation", symlink.name.c_str() );
+      if (symlink.skip_if_file_or_dir) {
+        if (S_ISDIR(dir.mode_) || S_ISREG(dir.mode_)) {
+          LogCvmfs(kLogCvmfs, kLogVerboseMsg,
+                   "File or directory for symlink [%s] exists, skipping "
+                   "symlink creation",
+                   symlink.name.c_str());
           noop = true;
         } else if (S_ISLNK(dir.mode_)) {
-           LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing existing symlink [%s]", 
-               symlink.name.c_str());
-           catalog_manager.RemoveFile(symlink.name);
+          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing existing symlink [%s]",
+                   symlink.name.c_str());
+          catalog_manager.RemoveFile(symlink.name);
         } else {
           CUSTOM_ASSERT(0, "unknown mode for dirent: %d", dir.mode_);
         }
       } else {
-        CUSTOM_ASSERT(!S_ISDIR(dir.mode_), "Not removing directory [%s] to create symlink", symlink.name.c_str());
-        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing existing file/symlink [%s]",
-               symlink.name.c_str());
+        CUSTOM_ASSERT(!S_ISDIR(dir.mode_),
+                      "Not removing directory [%s] to create symlink",
+                      symlink.name.c_str());
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg,
+                 "Removing existing file/symlink [%s]", symlink.name.c_str());
         catalog_manager.RemoveFile(symlink.name);
       }
     }
-    if(!noop) {
+    if (!noop) {
       string const parent = get_parent(symlink.name);
-      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Adding symlink [%s] -> [%s]", symlink.name.c_str(), symlink.target.c_str());
+      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Adding symlink [%s] -> [%s]",
+               symlink.name.c_str(), symlink.target.c_str());
       catalog_manager.AddFile(dir2, xattr, parent);
     }
   }
   return 0;
 }
 
-static int check_hash( const char*hash) {
-  if (strlen(hash)!=40) { return 1;}
-  for(int i=0; i<40; i++ ) {
-   // < '0' || > 'f' || ( > '9' && < 'a' )
-   if( hash[i]<0x30 || hash[i]>0x66 || ( hash[i]>0x39 && hash[i] <0x61 )) {
+static int check_hash(const char *hash) {
+  if (strlen(hash) != 40) {
     return 1;
-   }
+  }
+  for (int i = 0; i < 40; i++) {
+    // < '0' || > 'f' || ( > '9' && < 'a' )
+    if (hash[i] < 0x30 || hash[i] > 0x66
+        || (hash[i] > 0x39 && hash[i] < 0x61)) {
+      return 1;
+    }
   }
   return 0;
 }
 
-bool check_prefix(const std::string &path , const std::string &prefix) {
-    if (prefix=="" || prefix=="/") {return true;}
-    if ( "/"+path == prefix ) { return true; }
-    if(!HasPrefix( path, prefix, false)) {
-      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Entry %s is outside lease path: %s", path.c_str(), prefix.c_str());
-      return false;
-    }
+bool check_prefix(const std::string &path, const std::string &prefix) {
+  if (prefix == "" || prefix == "/") {
     return true;
+  }
+  if ("/" + path == prefix) {
+    return true;
+  }
+  if (!HasPrefix(path, prefix, false)) {
+    LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Entry %s is outside lease path: %s",
+             path.c_str(), prefix.c_str());
+    return false;
+  }
+  return true;
 }
 
-void swissknife::IngestSQL::load_dirs(sqlite3 *db, const std::string &lease_path, const std::string &additional_prefix, std::map<std::string, Directory> &all_dirs) {
+void swissknife::IngestSQL::load_dirs(
+    sqlite3 *db, const std::string &lease_path,
+    const std::string &additional_prefix,
+    std::map<std::string, Directory> &all_dirs) {
   sqlite3_stmt *stmt;
   int const schema_revision = get_db_schema_revision(db);
-  string select_stmt = "SELECT name, mode, mtime, owner, grp, acl, nested FROM dirs";
+  string select_stmt = "SELECT name, mode, mtime, owner, grp, acl, nested FROM "
+                       "dirs";
   if (schema_revision <= 3) {
     select_stmt = "SELECT name, mode, mtime, owner, grp, acl FROM dirs";
   }
@@ -1123,7 +1258,9 @@ void swissknife::IngestSQL::load_dirs(sqlite3 *db, const std::string &lease_path
     int const nested = schema_revision <= 3 ? 1 : sqlite3_column_int(stmt, 6);
 
     string const name = additional_prefix + sanitise_name(name_cstr);
-    CUSTOM_ASSERT(check_prefix(name, lease_path), "%s is not below lease path %s", name.c_str(), lease_path.c_str());
+    CUSTOM_ASSERT(check_prefix(name, lease_path),
+                  "%s is not below lease path %s", name.c_str(),
+                  lease_path.c_str());
 
     Directory dir(name, mtime, mode, owner, grp, nested);
     char *acl = (char *)sqlite3_column_text(stmt, 5);
@@ -1133,12 +1270,17 @@ void swissknife::IngestSQL::load_dirs(sqlite3 *db, const std::string &lease_path
   CHECK_SQLITE_ERROR(sqlite3_finalize(stmt), SQLITE_OK);
 }
 
-void swissknife::IngestSQL::load_files(sqlite3 *db, const std::string &lease_path, const std::string &additional_prefix, std::map<std::string, std::vector<File>> &all_files) {
+void swissknife::IngestSQL::load_files(
+    sqlite3 *db, const std::string &lease_path,
+    const std::string &additional_prefix,
+    std::map<std::string, std::vector<File> > &all_files) {
   sqlite3_stmt *stmt;
   int const schema_revision = get_db_schema_revision(db);
-  string select_stmt = "SELECT name, mode, mtime, owner, grp, size, hashes, internal, compressed FROM files";
+  string select_stmt = "SELECT name, mode, mtime, owner, grp, size, hashes, "
+                       "internal, compressed FROM files";
   if (schema_revision <= 2) {
-    select_stmt = "SELECT name, mode, mtime, owner, grp, size, hashes, internal FROM files";
+    select_stmt = "SELECT name, mode, mtime, owner, grp, size, hashes, "
+                  "internal FROM files";
   }
   int const ret = sqlite3_prepare_v2(db, select_stmt.c_str(), -1, &stmt, NULL);
   CHECK_SQLITE_ERROR(ret, SQLITE_OK);
@@ -1151,16 +1293,20 @@ void swissknife::IngestSQL::load_files(sqlite3 *db, const std::string &lease_pat
     size_t const size = sqlite3_column_int64(stmt, 5);
     char *hashes_cstr = (char *)sqlite3_column_text(stmt, 6);
     int const internal = sqlite3_column_int(stmt, 7);
-    int const compressed = schema_revision <= 2 ? 0 : sqlite3_column_int(stmt, 8);
+    int const compressed = schema_revision <= 2 ? 0
+                                                : sqlite3_column_int(stmt, 8);
 
     string names = additional_prefix + sanitise_name(name);
-    CUSTOM_ASSERT(check_prefix(names, lease_path), "%s is not below lease path %s", names.c_str(), lease_path.c_str());
+    CUSTOM_ASSERT(check_prefix(names, lease_path),
+                  "%s is not below lease path %s", names.c_str(),
+                  lease_path.c_str());
     string const parent_dir = get_parent(names);
 
     if (!all_files.count(parent_dir)) {
       all_files[parent_dir] = vector<swissknife::IngestSQL::File>();
     }
-    all_files[parent_dir].emplace_back(std::move(names), mtime, size, owner, grp, mode, internal, compressed);
+    all_files[parent_dir].emplace_back(std::move(names), mtime, size, owner,
+                                       grp, mode, internal, compressed);
 
     // tokenize hashes
     char *ref;
@@ -1171,23 +1317,32 @@ void swissknife::IngestSQL::load_files(sqlite3 *db, const std::string &lease_pat
     vector<shash::Any> hashes;
     off_t offset = 0;
 
-    CUSTOM_ASSERT(size>=0, "file size cannot be negative [%s]", names.c_str());
-    size_t const kChunkSize = internal ? kInternalChunkSize : kExternalChunkSize;
+    CUSTOM_ASSERT(size >= 0, "file size cannot be negative [%s]",
+                  names.c_str());
+    size_t const kChunkSize = internal ? kInternalChunkSize
+                                       : kExternalChunkSize;
 
     while (tok) {
       offsets.push_back(offset);
       // TODO: check the hash format
-      CUSTOM_ASSERT(check_hash(tok)==0, "provided hash for [%s] is invalid: %s", names.c_str(), tok);
+      CUSTOM_ASSERT(check_hash(tok) == 0,
+                    "provided hash for [%s] is invalid: %s", names.c_str(),
+                    tok);
       hashes.push_back(
           shash::MkFromHexPtr(shash::HexPtr(tok), shash::kSuffixNone));
       tok = strtok_r(NULL, ",", &ref);
       offset += kChunkSize;  // in the future we might want variable chunk
                              // sizes specified in the DB
     }
-    size_t expected_num_chunks = size/kChunkSize;
-    if (expected_num_chunks * (size_t)kChunkSize < (size_t) size || size==0 ) { expected_num_chunks++; }
-    CUSTOM_ASSERT(offsets.size() == expected_num_chunks, "offsets size %ld does not match expected number of chunks %ld", offsets.size(), expected_num_chunks);
-    for (size_t i = 0; i < offsets.size() - 1; i++) {  
+    size_t expected_num_chunks = size / kChunkSize;
+    if (expected_num_chunks * (size_t)kChunkSize < (size_t)size || size == 0) {
+      expected_num_chunks++;
+    }
+    CUSTOM_ASSERT(
+        offsets.size() == expected_num_chunks,
+        "offsets size %ld does not match expected number of chunks %ld",
+        offsets.size(), expected_num_chunks);
+    for (size_t i = 0; i < offsets.size() - 1; i++) {
       sizes.push_back(size_t(offsets[i + 1] - offsets[i]));
     }
 
@@ -1200,9 +1355,13 @@ void swissknife::IngestSQL::load_files(sqlite3 *db, const std::string &lease_pat
   CHECK_SQLITE_ERROR(sqlite3_finalize(stmt), SQLITE_OK);
 }
 
-void swissknife::IngestSQL::load_symlinks(sqlite3 *db, const std::string &lease_path, const std::string &additional_prefix, std::map<std::string, std::vector<Symlink>> &all_symlinks) {
+void swissknife::IngestSQL::load_symlinks(
+    sqlite3 *db, const std::string &lease_path,
+    const std::string &additional_prefix,
+    std::map<std::string, std::vector<Symlink> > &all_symlinks) {
   sqlite3_stmt *stmt;
-  string const select_stmt = "SELECT name, target, mtime, owner, grp, skip_if_file_or_dir FROM links";
+  string const select_stmt = "SELECT name, target, mtime, owner, grp, "
+                             "skip_if_file_or_dir FROM links";
   int const ret = sqlite3_prepare_v2(db, select_stmt.c_str(), -1, &stmt, NULL);
   CHECK_SQLITE_ERROR(ret, SQLITE_OK);
   while (sqlite3_step(stmt) == SQLITE_ROW) {
@@ -1214,27 +1373,31 @@ void swissknife::IngestSQL::load_symlinks(sqlite3 *db, const std::string &lease_
     int const skip_if_file_or_dir = sqlite3_column_int(stmt, 5);
 
     string names = additional_prefix + sanitise_name(name_cstr);
-    CUSTOM_ASSERT(check_prefix(names, lease_path), "%s is not below lease path %s", names.c_str(), lease_path.c_str());
-    string target= target_cstr;
+    CUSTOM_ASSERT(check_prefix(names, lease_path),
+                  "%s is not below lease path %s", names.c_str(),
+                  lease_path.c_str());
+    string target = target_cstr;
     string const parent_dir = get_parent(names);
-    
+
     if (!all_symlinks.count(parent_dir)) {
       all_symlinks[parent_dir] = vector<swissknife::IngestSQL::Symlink>();
     }
-    all_symlinks[parent_dir].emplace_back(std::move(names), std::move(target), mtime, owner, grp, skip_if_file_or_dir);
+    all_symlinks[parent_dir].emplace_back(std::move(names), std::move(target),
+                                          mtime, owner, grp,
+                                          skip_if_file_or_dir);
   }
   CHECK_SQLITE_ERROR(sqlite3_finalize(stmt), SQLITE_OK);
 }
 
 int swissknife::IngestSQL::add_files(
-    catalog::WritableCatalogManager &catalog_manager, const std::vector<File> &files)
-{
-  for (auto&& file : files) {
+    catalog::WritableCatalogManager &catalog_manager,
+    const std::vector<File> &files) {
+  for (auto &&file : files) {
     catalog::DirectoryEntry dir;
     XattrList const xattr;
     bool exists = false;
     exists = catalog_manager.LookupDirEntry(MakeCatalogPath(file.name),
-                                        catalog::kLookupDefault, &dir);
+                                            catalog::kLookupDefault, &dir);
 
     dir.name_ = NameString(get_basename(file.name));
     dir.mtime_ = file.mtime / 1000000000;
@@ -1251,27 +1414,36 @@ int swissknife::IngestSQL::add_files(
         shash::kSuffixNone);
 
     // compression is permitted only for internal data
-    CUSTOM_ASSERT(file.internal || (!file.internal && file.compressed<2), "compression is only allowed for internal data [%s]", file.name.c_str());
- 
+    CUSTOM_ASSERT(file.internal || (!file.internal && file.compressed < 2),
+                  "compression is only allowed for internal data [%s]",
+                  file.name.c_str());
+
     switch (file.compressed) {
-      case 1: // Uncompressed
+      case 1:  // Uncompressed
         dir.compression_algorithm_ = zlib::kNoCompression;
         break;
-      case 2: // Compressed with Zlib
+      case 2:  // Compressed with Zlib
         dir.compression_algorithm_ = zlib::kZlibDefault;
         break;
       // future cases: different compression schemes
-      default: // default behaviour: compressed if internal, content-addressed. Uncompressed if external
-        dir.compression_algorithm_ = file.internal ? zlib::kZlibDefault : zlib::kNoCompression;
+      default:  // default behaviour: compressed if internal, content-addressed.
+                // Uncompressed if external
+        dir.compression_algorithm_ = file.internal ? zlib::kZlibDefault
+                                                   : zlib::kNoCompression;
     }
 
     if (exists) {
-      CUSTOM_ASSERT(!S_ISDIR(dir.mode()) && !S_ISLNK(dir.mode()), "Refusing to replace existing dir/symlink at %s with a file", file.name.c_str());
-      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing existing file [%s]", file.name.c_str());
+      CUSTOM_ASSERT(
+          !S_ISDIR(dir.mode()) && !S_ISLNK(dir.mode()),
+          "Refusing to replace existing dir/symlink at %s with a file",
+          file.name.c_str());
+      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing existing file [%s]",
+               file.name.c_str());
       catalog_manager.RemoveFile(file.name);
     }
     string const parent = get_parent(file.name);
-    LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Adding chunked file [%s]", file.name.c_str());
+    LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Adding chunked file [%s]",
+             file.name.c_str());
     catalog_manager.AddChunkedFile(dir, xattr, parent, file.chunks);
   }
 
@@ -1279,41 +1451,52 @@ int swissknife::IngestSQL::add_files(
 }
 
 int swissknife::IngestSQL::do_deletions(
-    sqlite3 *db, catalog::WritableCatalogManager &catalog_manager, const std::string &lease_path, const std::string &additional_prefix) {
+    sqlite3 *db, catalog::WritableCatalogManager &catalog_manager,
+    const std::string &lease_path, const std::string &additional_prefix) {
   sqlite3_stmt *stmt;
   int const row_count = get_row_count(db, "deletions");
   int const print_every = calculate_print_frequency(row_count);
   int curr_row = 0;
-  int ret = sqlite3_prepare_v2(db, "SELECT name, directory, file, link FROM deletions ORDER BY length(name) DESC", -1, &stmt, NULL);
+  int ret = sqlite3_prepare_v2(db,
+                               "SELECT name, directory, file, link FROM "
+                               "deletions ORDER BY length(name) DESC",
+                               -1, &stmt, NULL);
   CHECK_SQLITE_ERROR(ret, SQLITE_OK);
   while (sqlite3_step(stmt) == SQLITE_ROW) {
     curr_row++;
 
     char *name = (char *)sqlite3_column_text(stmt, 0);
-    int64_t const isdir  = sqlite3_column_int64(stmt, 1);
+    int64_t const isdir = sqlite3_column_int64(stmt, 1);
     int64_t const isfile = sqlite3_column_int64(stmt, 2);
     int64_t const islink = sqlite3_column_int64(stmt, 3);
 
     string const names = additional_prefix + sanitise_name(name);
-    CUSTOM_ASSERT(check_prefix( names, lease_path), "%s is not below lease path %s", names.c_str(), lease_path.c_str());
+    CUSTOM_ASSERT(check_prefix(names, lease_path),
+                  "%s is not below lease path %s", names.c_str(),
+                  lease_path.c_str());
 
     catalog::DirectoryEntry dirent;
     bool exists = false;
     exists = catalog_manager.LookupDirEntry(MakeCatalogPath(names),
-                                        catalog::kLookupDefault, &dirent);
-    if(exists) {
-      if(    (isdir  && S_ISDIR(dirent.mode()) )
-          || (islink && S_ISLNK(dirent.mode()) )
-          || (isfile && S_ISREG(dirent.mode()) ) ) {
+                                            catalog::kLookupDefault, &dirent);
+    if (exists) {
+      if ((isdir && S_ISDIR(dirent.mode()))
+          || (islink && S_ISLNK(dirent.mode()))
+          || (isfile && S_ISREG(dirent.mode()))) {
         if (S_ISDIR(dirent.mode())) {
           PathString names_path(names);
           recursively_delete_directory(names_path, catalog_manager);
         } else {
-          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing link/file [%s]", names.c_str());
+          LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing link/file [%s]",
+                   names.c_str());
           catalog_manager.RemoveFile(names);
         }
       } else {
-        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Mismatch in deletion type, not deleting: [%s] (dir %ld/%d , link %ld/%d, file %ld/%d)", names.c_str(), isdir,  S_ISDIR(dirent.mode()), islink, S_ISLNK(dirent.mode()), isfile, S_ISREG(dirent.mode()) );
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg,
+                 "Mismatch in deletion type, not deleting: [%s] (dir %ld/%d , "
+                 "link %ld/%d, file %ld/%d)",
+                 names.c_str(), isdir, S_ISDIR(dirent.mode()), islink,
+                 S_ISLNK(dirent.mode()), isfile, S_ISREG(dirent.mode()));
       }
     } else {
       LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Not Removing non-existent [%s]",
@@ -1326,10 +1509,9 @@ int swissknife::IngestSQL::do_deletions(
   return ret;
 }
 
-const char*schema[] = {
- "PRAGMA journal_mode=WAL;",
+const char *schema[] = {"PRAGMA journal_mode=WAL;",
 
- "CREATE TABLE IF NOT EXISTS dirs ( \
+                        "CREATE TABLE IF NOT EXISTS dirs ( \
         name  TEXT    PRIMARY KEY, \
         mode  INTEGER NOT NULL DEFAULT 493,\
         mtime INTEGER NOT NULL DEFAULT (unixepoch()),\
@@ -1338,7 +1520,7 @@ const char*schema[] = {
         acl   TEXT    NOT NULL DEFAULT '', \
         nested INTEGER DEFAULT 1);",
 
- "CREATE TABLE IF NOT EXISTS files ( \
+                        "CREATE TABLE IF NOT EXISTS files ( \
         name   TEXT    PRIMARY KEY, \
         mode   INTEGER NOT NULL DEFAULT 420, \
         mtime  INTEGER NOT NULL DEFAULT (unixepoch()),\
@@ -1350,7 +1532,7 @@ const char*schema[] = {
         compressed INTEGER NOT NULL DEFAULT 0\
   );",
 
- "CREATE TABLE IF NOT EXISTS links (\
+                        "CREATE TABLE IF NOT EXISTS links (\
         name   TEXT    PRIMARY KEY,\
         target TEXT    NOT NULL DEFAULT '',\
         mtime  INTEGER NOT NULL DEFAULT (unixepoch()),\
@@ -1359,112 +1541,119 @@ const char*schema[] = {
         skip_if_file_or_dir INTEGER NOT NULL DEFAULT 0\
   );",
 
- "CREATE TABLE IF NOT EXISTS deletions (\
+                        "CREATE TABLE IF NOT EXISTS deletions (\
         name      TEXT PRIMARY KEY,\
         directory INTEGER NOT NULL DEFAULT 0,\
         file      INTEGER NOT NULL DEFAULT 0,\
         link      INTEGER NOT NULL DEFAULT 0\
   );",
 
- "CREATE TABLE IF NOT EXISTS properties (\
+                        "CREATE TABLE IF NOT EXISTS properties (\
         key   TEXT PRIMARY KEY,\
         value TEXT NOT NULL\
   );",
 
- "INSERT INTO properties VALUES ('schema_revision', '4') ON CONFLICT DO NOTHING;",
-  NULL
-};
+                        "INSERT INTO properties VALUES ('schema_revision', "
+                        "'4') ON CONFLICT DO NOTHING;",
+                        NULL};
 
-static void create_empty_database( string& filename ) {
+static void create_empty_database(string &filename) {
   sqlite3 *db_out;
-  LogCvmfs(kLogCvmfs, kLogStdout, "Creating empty database file %s", filename.c_str());
-  int ret = sqlite3_open_v2(filename.c_str(), &db_out, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+  LogCvmfs(kLogCvmfs, kLogStdout, "Creating empty database file %s",
+           filename.c_str());
+  int ret = sqlite3_open_v2(filename.c_str(), &db_out,
+                            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
   CHECK_SQLITE_ERROR(ret, SQLITE_OK);
   relax_db_locking(db_out);
-  
+
   const char **ptr = schema;
-  while (*ptr!=NULL) {
+  while (*ptr != NULL) {
     ret = sqlite3_exec(db_out, *ptr, NULL, NULL, NULL);
     CHECK_SQLITE_ERROR(ret, SQLITE_OK);
     ptr++;
-  } 
+  }
   sqlite3_close(db_out);
 }
 
-static void recursively_delete_directory(PathString& path, catalog::WritableCatalogManager &catalog_manager) {
-   catalog::DirectoryEntryList const listing;
+static void recursively_delete_directory(
+    PathString &path, catalog::WritableCatalogManager &catalog_manager) {
+  catalog::DirectoryEntryList const listing;
 
   // Add all names
-   catalog::StatEntryList listing_from_catalog;
-   bool const retval = catalog_manager.ListingStat(PathString( "/" +  path.ToString()), &listing_from_catalog);
+  catalog::StatEntryList listing_from_catalog;
+  bool const retval = catalog_manager.ListingStat(
+      PathString("/" + path.ToString()), &listing_from_catalog);
 
-   CUSTOM_ASSERT(retval, "failed to call ListingStat for %s", path.c_str());
+  CUSTOM_ASSERT(retval, "failed to call ListingStat for %s", path.c_str());
 
-  if(!catalog_manager.IsTransitionPoint(path.ToString())) {
+  if (!catalog_manager.IsTransitionPoint(path.ToString())) {
+    for (unsigned i = 0; i < listing_from_catalog.size(); ++i) {
+      PathString entry_path;
+      entry_path.Assign(path);
+      entry_path.Append("/", 1);
+      entry_path.Append(listing_from_catalog.AtPtr(i)->name.GetChars(),
+                        listing_from_catalog.AtPtr(i)->name.GetLength());
 
-   for (unsigned i = 0; i < listing_from_catalog.size(); ++i) {
-    PathString entry_path;
-    entry_path.Assign(path);
-    entry_path.Append("/", 1);
-    entry_path.Append(listing_from_catalog.AtPtr(i)->name.GetChars(),
-                      listing_from_catalog.AtPtr(i)->name.GetLength());
-
-    if( S_ISDIR( listing_from_catalog.AtPtr(i)->info.st_mode) ) {
-      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Recursing into %s/", entry_path.ToString().c_str());
-      recursively_delete_directory(entry_path, catalog_manager);
+      if (S_ISDIR(listing_from_catalog.AtPtr(i)->info.st_mode)) {
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Recursing into %s/",
+                 entry_path.ToString().c_str());
+        recursively_delete_directory(entry_path, catalog_manager);
 
 
-    } else {
-      LogCvmfs(kLogCvmfs, kLogVerboseMsg, " Recursively removing %s", entry_path.ToString().c_str());
-      catalog_manager.RemoveFile(entry_path.ToString());
+      } else {
+        LogCvmfs(kLogCvmfs, kLogVerboseMsg, " Recursively removing %s",
+                 entry_path.ToString().c_str());
+        catalog_manager.RemoveFile(entry_path.ToString());
+      }
     }
-
-   }
-  } else { 
-      LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing nested catalog %s", path.ToString().c_str());
-      catalog_manager.RemoveNestedCatalog(path.ToString(), false);
+  } else {
+    LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing nested catalog %s",
+             path.ToString().c_str());
+    catalog_manager.RemoveNestedCatalog(path.ToString(), false);
   }
-  LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing directory %s", path.ToString().c_str());
-     catalog_manager.RemoveDirectory(path.ToString());
-
+  LogCvmfs(kLogCvmfs, kLogVerboseMsg, "Removing directory %s",
+           path.ToString().c_str());
+  catalog_manager.RemoveDirectory(path.ToString());
 }
 
 
 static void relax_db_locking(sqlite3 *db) {
-    int ret=0;
-    ret = sqlite3_exec(db, "PRAGMA temp_store=2", NULL, NULL, NULL);
-    CHECK_SQLITE_ERROR(ret, SQLITE_OK);
-    ret = sqlite3_exec(db, "PRAGMA synchronous=OFF", NULL, NULL, NULL);
-    CHECK_SQLITE_ERROR(ret, SQLITE_OK);
+  int ret = 0;
+  ret = sqlite3_exec(db, "PRAGMA temp_store=2", NULL, NULL, NULL);
+  CHECK_SQLITE_ERROR(ret, SQLITE_OK);
+  ret = sqlite3_exec(db, "PRAGMA synchronous=OFF", NULL, NULL, NULL);
+  CHECK_SQLITE_ERROR(ret, SQLITE_OK);
 }
 
 
-extern "C" void* lease_refresh_thread(void *payload) {
- while( !g_stop_refresh ) {
-   sleep(2);
-   refresh_lease();
- }
- return NULL;
+extern "C" void *lease_refresh_thread(void *payload) {
+  while (!g_stop_refresh) {
+    sleep(2);
+    refresh_lease();
+  }
+  return NULL;
 }
 
 static bool isDatabaseMarkedComplete(const char *dbfile) {
   int ret;
   sqlite3 *db;
   sqlite3_stmt *stmt;
-  bool retval=false;
+  bool retval = false;
 
   ret = sqlite3_open(dbfile, &db);
-  if (ret!=SQLITE_OK) { return false; }
+  if (ret != SQLITE_OK) {
+    return false;
+  }
 
   const char *req = "SELECT value FROM properties WHERE key='completed_graft'";
   ret = sqlite3_prepare_v2(db, req, -1, &stmt, NULL);
-  if (ret!=SQLITE_OK) { 
-    return false; 
+  if (ret != SQLITE_OK) {
+    return false;
   }
-  if(sqlite3_step(stmt) == SQLITE_ROW) {
-    int const id = sqlite3_column_int(stmt,0);
-    if(id>0) { 
-      retval=true; 
+  if (sqlite3_step(stmt) == SQLITE_ROW) {
+    int const id = sqlite3_column_int(stmt, 0);
+    if (id > 0) {
+      retval = true;
     }
   }
   sqlite3_close(db);
@@ -1477,14 +1666,17 @@ static void setDatabaseMarkedComplete(const char *dbfile) {
   char *err;
 
   ret = sqlite3_open(dbfile, &db);
-  if (ret!=SQLITE_OK) { return; }
- 
-  const char *req = "INSERT INTO properties (key, value) VALUES ('completed_graft',1) ON CONFLICT(key) DO UPDATE SET value=1 WHERE key='completed_graft'";
+  if (ret != SQLITE_OK) {
+    return;
+  }
+
+  const char *req = "INSERT INTO properties (key, value) VALUES "
+                    "('completed_graft',1) ON CONFLICT(key) DO UPDATE SET "
+                    "value=1 WHERE key='completed_graft'";
 
   ret = sqlite3_exec(db, req, 0, 0, &err);
-  if (ret!=SQLITE_OK) { 
-    return; 
+  if (ret != SQLITE_OK) {
+    return;
   }
   sqlite3_close(db);
 }
-

--- a/cvmfs/swissknife_ingestsql.h
+++ b/cvmfs/swissknife_ingestsql.h
@@ -5,9 +5,9 @@
 #ifndef CVMFS_SWISSKNIFE_INGESTSQL_H_
 #define CVMFS_SWISSKNIFE_INGESTSQL_H_
 
+#include <map>
 #include <string>
 #include <utility>
-#include <map>
 #include <vector>
 
 #include "catalog_mgr_rw.h"
@@ -16,7 +16,7 @@
 namespace swissknife {
 class IngestSQL : public Command {
  public:
-  ~IngestSQL() {}
+  ~IngestSQL() { }
   virtual string GetName() const { return "ingestsql"; }
   virtual string GetDescription() const {
     return "Graft the contents of a SQLite DB to the repository";
@@ -33,7 +33,8 @@ class IngestSQL : public Command {
     r.push_back(Parameter::Optional('@', "proxy URL"));
     r.push_back(Parameter::Optional('k', "public key"));
     r.push_back(Parameter::Optional('l', "lease path"));
-    r.push_back(Parameter::Optional('p', "prefix to add to lease and all graft files"));
+    r.push_back(
+        Parameter::Optional('p', "prefix to add to lease and all graft files"));
     r.push_back(Parameter::Optional('q', "number of concurrent write jobs"));
     r.push_back(Parameter::Optional('s', "gateway secret"));
     r.push_back(Parameter::Optional('3', "s3 config"));
@@ -41,14 +42,18 @@ class IngestSQL : public Command {
         'a', "Allow additions (default true, false if -d specified)"));
     r.push_back(Parameter::Switch('d', "Allow deletions"));
     r.push_back(Parameter::Switch('x', "Force deletion of any lease"));
-    r.push_back(Parameter::Switch('c', "Enable corefile generation (requires ulimit -c >0)"));
+    r.push_back(Parameter::Switch(
+        'c', "Enable corefile generation (requires ulimit -c >0)"));
     r.push_back(Parameter::Optional('n', "create empty database file"));
-    r.push_back(Parameter::Optional('C', "config prefix, default /etc/cvmfs/gateway-client/"));
-    r.push_back(Parameter::Optional('B', "mount point to block on pending visibility of update"));
+    r.push_back(Parameter::Optional(
+        'C', "config prefix, default /etc/cvmfs/gateway-client/"));
+    r.push_back(Parameter::Optional(
+        'B', "mount point to block on pending visibility of update"));
     r.push_back(Parameter::Optional('T', "reset TTL in sec"));
     r.push_back(Parameter::Switch('z', "Create missing nested catalogs"));
     r.push_back(Parameter::Optional('r', "lease retry interval"));
-    r.push_back(Parameter::Switch('Z', "check and set completed_graft property"));
+    r.push_back(
+        Parameter::Switch('Z', "check and set completed_graft property"));
     r.push_back(Parameter::Optional('P', "priority for graft (integer)"));
     r.push_back(Parameter::Switch('v', "Enable verbose logging"));
 
@@ -64,12 +69,17 @@ class IngestSQL : public Command {
     gid_t grp;
     int nested;
     XattrList xattr;
-    Directory() {}
-    Directory(const std::string &name, time_t mtime, mode_t mode, uid_t owner, gid_t grp, int nested) :
-      name(name), mtime(mtime), mode(mode), owner(owner), grp(grp), nested(nested)
-    {}
+    Directory() { }
+    Directory(const std::string &name, time_t mtime, mode_t mode, uid_t owner,
+              gid_t grp, int nested)
+        : name(name)
+        , mtime(mtime)
+        , mode(mode)
+        , owner(owner)
+        , grp(grp)
+        , nested(nested) { }
   };
-  
+
   struct Symlink {
     std::string name;
     std::string target;
@@ -77,11 +87,16 @@ class IngestSQL : public Command {
     uid_t owner;
     gid_t grp;
     int skip_if_file_or_dir;
-    Symlink(std::string &&name, std::string &&target, time_t mtime, uid_t owner, gid_t grp, int skip_if_file_or_dir) :
-      name(std::move(name)), target(std::move(target)), mtime(mtime), owner(owner), grp(grp), skip_if_file_or_dir(skip_if_file_or_dir)
-    {}
+    Symlink(std::string &&name, std::string &&target, time_t mtime, uid_t owner,
+            gid_t grp, int skip_if_file_or_dir)
+        : name(std::move(name))
+        , target(std::move(target))
+        , mtime(mtime)
+        , owner(owner)
+        , grp(grp)
+        , skip_if_file_or_dir(skip_if_file_or_dir) { }
   };
-  
+
   struct File {
     std::string name;
     time_t mtime;
@@ -92,30 +107,51 @@ class IngestSQL : public Command {
     int internal;
     FileChunkList chunks;
     int compressed;
-  
-    File(std::string &&name, time_t mtime, size_t size, uid_t owner, gid_t grp, mode_t mode, int internal, int compressed) :
-      name(std::move(name)), mtime(mtime), size(size), owner(owner), grp(grp), mode(mode), internal(internal), compressed(compressed)
-    {}
+
+    File(std::string &&name, time_t mtime, size_t size, uid_t owner, gid_t grp,
+         mode_t mode, int internal, int compressed)
+        : name(std::move(name))
+        , mtime(mtime)
+        , size(size)
+        , owner(owner)
+        , grp(grp)
+        , mode(mode)
+        , internal(internal)
+        , compressed(compressed) { }
   };
 
- typedef std::map<std::string, Directory> DirMap;
- typedef std::map<std::string, std::vector<File>> FileMap;
- typedef std::map<std::string, std::vector<Symlink>> SymlinkMap;
+  typedef std::map<std::string, Directory> DirMap;
+  typedef std::map<std::string, std::vector<File> > FileMap;
+  typedef std::map<std::string, std::vector<Symlink> > SymlinkMap;
 
  private:
-  void process_sqlite(const std::vector<sqlite3*>& dbs,
+  void process_sqlite(const std::vector<sqlite3 *> &dbs,
                       catalog::WritableCatalogManager &catalog_manager,
-                      bool allow_additions, bool allow_deletions, const std::string &lease_path, const std::string &additional_prefix);
-  int add_files(catalog::WritableCatalogManager &catalog_manager, const std::vector<File> &files);
-  int add_symlinks(
-                   catalog::WritableCatalogManager &catalog_manager, const std::vector<Symlink> &symlinks);
-  int do_additions(const DirMap &all_dirs, const FileMap &all_files, const SymlinkMap &all_symlinks, const std::string &lease_path,
-                      catalog::WritableCatalogManager &catalog_manager);
+                      bool allow_additions, bool allow_deletions,
+                      const std::string &lease_path,
+                      const std::string &additional_prefix);
+  int add_files(catalog::WritableCatalogManager &catalog_manager,
+                const std::vector<File> &files);
+  int add_symlinks(catalog::WritableCatalogManager &catalog_manager,
+                   const std::vector<Symlink> &symlinks);
+  int do_additions(const DirMap &all_dirs, const FileMap &all_files,
+                   const SymlinkMap &all_symlinks,
+                   const std::string &lease_path,
+                   catalog::WritableCatalogManager &catalog_manager);
   int do_deletions(sqlite3 *db,
-                   catalog::WritableCatalogManager &catalog_manager, const std::string &lease_path, const std::string &additional_prefix);
-  void load_dirs(sqlite3 *db, const std::string &lease_path, const std::string &additional_prefix, std::map<std::string, Directory> &all_dirs);
-  void load_files(sqlite3 *db, const std::string &lease_path, const std::string &additional_prefix, std::map<std::string, std::vector<File>> &all_files);
-  void load_symlinks(sqlite3 *db, const std::string &lease_path, const std::string &additional_prefix, std::map<std::string, std::vector<Symlink>> &all_symlinks);
+                   catalog::WritableCatalogManager &catalog_manager,
+                   const std::string &lease_path,
+                   const std::string &additional_prefix);
+  void load_dirs(sqlite3 *db, const std::string &lease_path,
+                 const std::string &additional_prefix,
+                 std::map<std::string, Directory> &all_dirs);
+  void load_files(sqlite3 *db, const std::string &lease_path,
+                  const std::string &additional_prefix,
+                  std::map<std::string, std::vector<File> > &all_files);
+  void load_symlinks(
+      sqlite3 *db, const std::string &lease_path,
+      const std::string &additional_prefix,
+      std::map<std::string, std::vector<Symlink> > &all_symlinks);
 };
 }  // namespace swissknife
 

--- a/cvmfs/swissknife_lease.cc
+++ b/cvmfs/swissknife_lease.cc
@@ -109,8 +109,8 @@ int CommandLease::Main(const ArgumentList &args) {
   } else if (params.action == "drop") {
     // Try to read session token from repository scratch directory
     std::string session_token;
-    const std::string token_file_name =
-        "/var/spool/cvmfs/" + lease_fqdn + "/session_token";
+    const std::string token_file_name = "/var/spool/cvmfs/" + lease_fqdn
+                                        + "/session_token";
     FILE *token_file = std::fopen(token_file_name.c_str(), "r");
     if (token_file) {
       GetLineFile(token_file, &session_token);

--- a/cvmfs/swissknife_lease_curl.cc
+++ b/cvmfs/swissknife_lease_curl.cc
@@ -4,6 +4,8 @@
 
 #include "swissknife_lease_curl.h"
 
+#include <unistd.h>
+
 #include "crypto/hash.h"
 #include "gateway_util.h"
 #include "json_document.h"
@@ -13,8 +15,6 @@
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/string.h"
-
-#include <unistd.h>
 
 
 namespace {
@@ -49,11 +49,10 @@ size_t RecvCB(void *buffer, size_t size, size_t nmemb, void *userp) {
 
 }  // namespace
 
-bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
-                        const std::string& repo_path,
-                        const std::string& repo_service_url,
-                        CurlBuffer* buffer,
-                        const std::string& metadata) {
+bool MakeAcquireRequest(const std::string &key_id, const std::string &secret,
+                        const std::string &repo_path,
+                        const std::string &repo_service_url, CurlBuffer *buffer,
+                        const std::string &metadata) {
   CURLcode ret = static_cast<CURLcode>(0);
 
   CURL *h_curl = PrepareCurl("POST");
@@ -104,10 +103,11 @@ bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
   return !ret;
 }
 
-bool MakeEndRequest(const std::string& method, const std::string& key_id,
-                    const std::string& secret, const std::string& session_token,
-                    const std::string& repo_service_url,
-                    const std::string& request_payload, CurlBuffer* reply, bool expect_final_revision) {
+bool MakeEndRequest(const std::string &method, const std::string &key_id,
+                    const std::string &secret, const std::string &session_token,
+                    const std::string &repo_service_url,
+                    const std::string &request_payload, CurlBuffer *reply,
+                    bool expect_final_revision) {
   CURLcode ret = static_cast<CURLcode>(0);
 
   CURL *h_curl = PrepareCurl(method);
@@ -150,19 +150,17 @@ bool MakeEndRequest(const std::string& method, const std::string& key_id,
 
   JsonDocument *doc = JsonDocument::Create(reply->data);
   bool ok = true;
-  if (!doc ) {
-       ok=false;
-  }
-  else {
+  if (!doc) {
+    ok = false;
+  } else {
     UniquePtr<JsonDocument> const reply_json(doc);
-    const JSON *reply_status =
-      JsonDocument::SearchInObject(reply_json->root(), "status", JSON_STRING);
-    ok = (reply_status != NULL &&
-                   std::string(reply_status->string_value) == "ok");
+    const JSON *reply_status = JsonDocument::SearchInObject(
+        reply_json->root(), "status", JSON_STRING);
+    ok = (reply_status != NULL
+          && std::string(reply_status->string_value) == "ok");
     if (!ok) {
       LogCvmfs(kLogUploadGateway, kLogStderr,
-             "Lease end request - error reply: %s",
-             reply->data.c_str());
+               "Lease end request - error reply: %s", reply->data.c_str());
     }
   }
 
@@ -171,4 +169,3 @@ bool MakeEndRequest(const std::string& method, const std::string& key_id,
 
   return ok && !ret;
 }
-

--- a/cvmfs/swissknife_lease_curl.h
+++ b/cvmfs/swissknife_lease_curl.h
@@ -15,17 +15,15 @@ class CurlBuffer {
   CurlBuffer() : data("") { }
 };
 
-bool MakeAcquireRequest(const std::string& key_id, const std::string& secret,
-                        const std::string& repo_path,
-                        const std::string& repo_service_url,
-                        CurlBuffer* buffer,
-                        const std::string& metadata = std::string());
+bool MakeAcquireRequest(const std::string &key_id, const std::string &secret,
+                        const std::string &repo_path,
+                        const std::string &repo_service_url, CurlBuffer *buffer,
+                        const std::string &metadata = std::string());
 
-bool MakeEndRequest(const std::string& method, const std::string& key_id,
-                    const std::string& secret, const std::string& session_token,
-                    const std::string& repo_service_url,
-                    const std::string& request_payload,
-                    CurlBuffer* reply,
+bool MakeEndRequest(const std::string &method, const std::string &key_id,
+                    const std::string &secret, const std::string &session_token,
+                    const std::string &repo_service_url,
+                    const std::string &request_payload, CurlBuffer *reply,
                     bool expect_final_revision = true);
 
 #endif  // CVMFS_SWISSKNIFE_LEASE_CURL_H_

--- a/cvmfs/swissknife_lease_json.cc
+++ b/cvmfs/swissknife_lease_json.cc
@@ -9,9 +9,11 @@
 #include "util/logging.h"
 #include "util/pointer.h"
 
-//TODO(@vvolkl): refactor
+// TODO(@vvolkl): refactor
 LeaseReply ParseAcquireReplyWithRevision(const CurlBuffer &buffer,
-                             std::string *session_token, uint64_t *current_revision, std::string &current_root_hash) {
+                                         std::string *session_token,
+                                         uint64_t *current_revision,
+                                         std::string &current_root_hash) {
   if (buffer.data.size() == 0 || session_token == NULL) {
     return kLeaseReplyFailure;
   }
@@ -21,8 +23,8 @@ LeaseReply ParseAcquireReplyWithRevision(const CurlBuffer &buffer,
     return kLeaseReplyFailure;
   }
 
-  const JSON *result =
-      JsonDocument::SearchInObject(reply->root(), "status", JSON_STRING);
+  const JSON *result = JsonDocument::SearchInObject(reply->root(), "status",
+                                                    JSON_STRING);
   if (result != NULL) {
     const std::string status = result->string_value;
     if (status == "ok") {
@@ -30,10 +32,17 @@ LeaseReply ParseAcquireReplyWithRevision(const CurlBuffer &buffer,
       const JSON *token = JsonDocument::SearchInObject(
           reply->root(), "session_token", JSON_STRING);
       if (token != NULL) {
-        const JSON *rev  = JsonDocument::SearchInObject(reply->root(), "revision", JSON_INT); //TODO FIXME: make the json lib uint64 aware
-        if(rev!=NULL) { *current_revision = (uint64_t) rev->int_value; }
-        const JSON *hash = JsonDocument::SearchInObject(reply->root(), "root_hash", JSON_STRING);
-        if(hash!=NULL) { current_root_hash = hash->string_value; }
+        const JSON *rev = JsonDocument::SearchInObject(
+            reply->root(), "revision",
+            JSON_INT);  // TODO FIXME: make the json lib uint64 aware
+        if (rev != NULL) {
+          *current_revision = (uint64_t)rev->int_value;
+        }
+        const JSON *hash = JsonDocument::SearchInObject(
+            reply->root(), "root_hash", JSON_STRING);
+        if (hash != NULL) {
+          current_root_hash = hash->string_value;
+        }
         LogCvmfs(kLogCvmfs, kLogDebug, "Session token: %s",
                  token->string_value);
         *session_token = token->string_value;
@@ -48,8 +57,8 @@ LeaseReply ParseAcquireReplyWithRevision(const CurlBuffer &buffer,
         return kLeaseReplyBusy;
       }
     } else if (status == "error") {
-      const JSON *reason =
-          JsonDocument::SearchInObject(reply->root(), "reason", JSON_STRING);
+      const JSON *reason = JsonDocument::SearchInObject(reply->root(), "reason",
+                                                        JSON_STRING);
       if (reason != NULL) {
         LogCvmfs(kLogCvmfs, kLogStdout, "Error: %s", reason->string_value);
       }

--- a/cvmfs/swissknife_lease_json.h
+++ b/cvmfs/swissknife_lease_json.h
@@ -18,8 +18,8 @@ enum LeaseReply {
 
 LeaseReply ParseAcquireReply(const CurlBuffer &buffer,
                              std::string *session_token);
-LeaseReply ParseAcquireReplyWithRevision(const CurlBuffer& buffer,
-                                         std::string* session_token,
+LeaseReply ParseAcquireReplyWithRevision(const CurlBuffer &buffer,
+                                         std::string *session_token,
                                          uint64_t *current_revision,
                                          std::string &current_root_hash);
 LeaseReply ParseDropReply(const CurlBuffer &buffer);

--- a/cvmfs/swissknife_list_reflog.h
+++ b/cvmfs/swissknife_list_reflog.h
@@ -40,7 +40,7 @@ class CommandListReflog : public Command {
 
   static uint32_t hasher(const shash::Any &key) {
     // Don't start with the first bytes, because == is using them as well
-    return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 };
 

--- a/cvmfs/swissknife_list_reflog.h
+++ b/cvmfs/swissknife_list_reflog.h
@@ -40,7 +40,8 @@ class CommandListReflog : public Command {
 
   static uint32_t hasher(const shash::Any &key) {
     // Don't start with the first bytes, because == is using them as well
-    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+    return static_cast<uint32_t>(
+        *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 };
 

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -158,8 +158,8 @@ int CommandMigrate::Main(const ArgumentList &args) {
       return 1;
     }
 
-    ObjectFetcher fetcher(
-        repo_name, repo_url, tmp_dir, download_manager(), signature_manager());
+    ObjectFetcher fetcher(repo_name, repo_url, tmp_dir, download_manager(),
+                          signature_manager());
 
     loading_successful = LoadCatalogs(manual_root_hash, &fetcher);
   } else {
@@ -626,8 +626,8 @@ void CommandMigrate::AnalyzeCatalogStatistics() const {
   double aggregated_migration_time = 0.0;
 
   CatalogStatisticsList::const_iterator i = catalog_statistics_list_.begin();
-  const CatalogStatisticsList::const_iterator iend =
-      catalog_statistics_list_.end();
+  const CatalogStatisticsList::const_iterator iend = catalog_statistics_list_
+                                                         .end();
   for (; i != iend; ++i) {
     aggregated_entry_count += i->entry_count;
     aggregated_max_row_id += i->max_row_id;
@@ -1342,8 +1342,8 @@ bool CommandMigrate::MigrationWorker_20x::FixNestedCatalogTransitionPoints(
     lookup_mountpoint.Reset();
 
     // Compare nested catalog mountpoint and nested catalog root entries
-    const catalog::DirectoryEntry::Differences diffs =
-        mountpoint_entry.CompareTo(nested_root_entry);
+    const catalog::DirectoryEntry::Differences
+        diffs = mountpoint_entry.CompareTo(nested_root_entry);
 
     // We MUST deal with two directory entries that are a pair of nested cata-
     // log mountpoint and root entry! Thus we expect their transition flags to
@@ -1612,8 +1612,8 @@ bool CommandMigrate::MigrationWorker_20x::FindRootEntryInformation(
   bool retval;
 
   std::string root_path = data->root_path();
-  const shash::Md5 root_path_hash =
-      shash::Md5(root_path.data(), root_path.size());
+  const shash::Md5 root_path_hash = shash::Md5(root_path.data(),
+                                               root_path.size());
 
   catalog::SqlLookupPathHash lookup_root_entry(writable);
   retval = lookup_root_entry.BindPathHash(root_path_hash)
@@ -1624,8 +1624,8 @@ bool CommandMigrate::MigrationWorker_20x::FindRootEntryInformation(
     return false;
   }
 
-  const catalog::DirectoryEntry entry =
-      lookup_root_entry.GetDirent(data->new_catalog);
+  const catalog::DirectoryEntry entry = lookup_root_entry.GetDirent(
+      data->new_catalog);
   if (entry.linkcount() < 2 || entry.hardlink_group() > 0) {
     Error("Retrieved linkcount of catalog root entry is not sane.", data);
     return false;
@@ -1791,8 +1791,8 @@ bool CommandMigrate::MigrationWorker_217::UpdateCatalogSchema(
   const bool retval = update_schema_version.BindDouble(1, 2.5)
                       && update_schema_version.Execute();
   if (!retval) {
-    Error(
-        "Failed to update catalog schema version", update_schema_version, data);
+    Error("Failed to update catalog schema version", update_schema_version,
+          data);
     return false;
   }
 

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -319,7 +319,8 @@ bool CommandPull::PullRecursion(catalog::Catalog *catalog,
     for (catalog::Catalog::NestedCatalogList::const_iterator
              i = nested_catalogs.begin(),
              iEnd = nested_catalogs.end();
-         i != iEnd; ++i) {
+         i != iEnd;
+         ++i) {
       LogCvmfs(kLogCvmfs, kLogStdout, "Replicating from catalog at %s",
                i->mountpoint.c_str());
       const bool retval = Pull(i->hash, i->mountpoint.ToString());
@@ -637,8 +638,8 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     goto fini;
   }
 
-  m_retval = FetchRemoteManifestEnsemble(
-      *stratum0_url, repository_name, &ensemble);
+  m_retval = FetchRemoteManifestEnsemble(*stratum0_url, repository_name,
+                                         &ensemble);
   if (m_retval != manifest::kFailOk) {
     LogCvmfs(kLogCvmfs, kLogStderr, "failed to fetch manifest (%d - %s)",
              m_retval, manifest::Code2Ascii(m_retval));
@@ -874,8 +875,8 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
     }
 
     if (preload_cache) {
-      const bool retval =
-          ensemble.manifest->ExportBreadcrumb(*preload_cachedir, 0660);
+      const bool retval = ensemble.manifest->ExportBreadcrumb(*preload_cachedir,
+                                                              0660);
       assert(retval);
     } else {
       // pkcs#7 structure contains content + certificate + signature

--- a/cvmfs/swissknife_reflog.cc
+++ b/cvmfs/swissknife_reflog.cc
@@ -87,12 +87,12 @@ int CommandReconstructReflog::Main(const ArgumentList &args) {
     return 1;
   }
 
-  ObjectFetcher object_fetcher(
-      repo_name, repo_url, tmp_dir, download_manager(), signature_manager());
+  ObjectFetcher object_fetcher(repo_name, repo_url, tmp_dir, download_manager(),
+                               signature_manager());
 
   UniquePtr<manifest::Manifest> manifest;
-  const ObjectFetcher::Failures retval =
-      object_fetcher.FetchManifest(&manifest);
+  const ObjectFetcher::Failures retval = object_fetcher.FetchManifest(
+      &manifest);
   if (retval != ObjectFetcher::kFailOk) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "failed to load repository manifest "
@@ -116,8 +116,8 @@ int CommandReconstructReflog::Main(const ArgumentList &args) {
 
   reflog->BeginTransaction();
   AddStaticManifestObjects(reflog.weak_ref(), manifest.weak_ref());
-  RootChainWalker walker(
-      manifest.weak_ref(), &object_fetcher, reflog.weak_ref());
+  RootChainWalker walker(manifest.weak_ref(), &object_fetcher,
+                         reflog.weak_ref());
   walker.FindObjectsAndPopulateReflog();
   reflog->CommitTransaction();
 
@@ -255,8 +255,8 @@ RootChainWalker::CatalogTN *RootChainWalker::FetchCatalog(
     const shash::Any catalog_hash) {
   CatalogTN *catalog = NULL;
   const char *root_path = "";
-  const ObjectFetcherFailures::Failures failure =
-      object_fetcher_->FetchCatalog(catalog_hash, root_path, &catalog);
+  const ObjectFetcherFailures::Failures failure = object_fetcher_->FetchCatalog(
+      catalog_hash, root_path, &catalog);
 
   return ReturnOrAbort(failure, catalog_hash, catalog);
 }
@@ -265,8 +265,8 @@ RootChainWalker::CatalogTN *RootChainWalker::FetchCatalog(
 RootChainWalker::HistoryTN *RootChainWalker::FetchHistory(
     const shash::Any history_hash) {
   HistoryTN *history = NULL;
-  const ObjectFetcherFailures::Failures failure =
-      object_fetcher_->FetchHistory(&history, history_hash);
+  const ObjectFetcherFailures::Failures failure = object_fetcher_->FetchHistory(
+      &history, history_hash);
 
   return ReturnOrAbort(failure, history_hash, history);
 }

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -81,11 +81,11 @@ void CommandScrub::FileCallback(const std::string &relative_path,
     return;
   }
 
-  const shash::Any hash_from_name =
-      shash::MkFromSuffixedHexPtr(shash::HexPtr(hash_string));
+  const shash::Any hash_from_name = shash::MkFromSuffixedHexPtr(
+      shash::HexPtr(hash_string));
   IngestionSource *full_path_source = new FileIngestionSource(full_path);
-  pipeline_scrubbing_.Process(
-      full_path_source, hash_from_name.algorithm, hash_from_name.suffix);
+  pipeline_scrubbing_.Process(full_path_source, hash_from_name.algorithm,
+                              hash_from_name.suffix);
 }
 
 

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -588,10 +588,10 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
   const std::string watchdog_dir = "/tmp";
   char watchdog_path[PATH_MAX];
   const std::string timestamp = GetGMTimestamp("%Y.%m.%d-%H.%M.%S");
-  const int path_size =
-      snprintf(watchdog_path, sizeof(watchdog_path),
-               "%s/cvmfs-swissknife-sync-stacktrace.%s.%d",
-               watchdog_dir.c_str(), timestamp.c_str(), getpid());
+  const int path_size = snprintf(watchdog_path, sizeof(watchdog_path),
+                                 "%s/cvmfs-swissknife-sync-stacktrace.%s.%d",
+                                 watchdog_dir.c_str(), timestamp.c_str(),
+                                 getpid());
   assert(path_size > 0);
   assert(path_size < PATH_MAX);
   const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL));
@@ -652,8 +652,8 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     }
   }
   if (args.find('z') != args.end()) {
-    const unsigned log_level =
-        1 << (kLogLevel0 + String2Uint64(*args.find('z')->second));
+    const unsigned log_level = 1 << (kLogLevel0
+                                     + String2Uint64(*args.find('z')->second));
     if (log_level > kLogNone) {
       LogCvmfs(kLogCvmfs, kLogStderr, "Swissknife Sync: invalid log level");
       return 1;

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -452,8 +452,8 @@ void SyncItem::CheckGraft() {
              graftfile.c_str());
     valid_graft_ = false;
   }
-  graft_chunklist_->PushBack(FileChunk(
-      chunk_checksums.back(), last_offset, graft_size_ - last_offset));
+  graft_chunklist_->PushBack(FileChunk(chunk_checksums.back(), last_offset,
+                                       graft_size_ - last_offset));
 }
 
 }  // namespace publish

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -371,8 +371,8 @@ bool SyncMediator::Commit(manifest::Manifest *manifest) {
       catalog_manager_->Balance();
     // Commit empty string to ensure that the "content" of the auto catalog
     // markers is present in the repository.
-    const string empty_file =
-        CreateTempPath(params_->dir_temp + "/empty", 0600);
+    const string empty_file = CreateTempPath(params_->dir_temp + "/empty",
+                                             0600);
     IngestionSource *source = new FileIngestionSource(empty_file);
     params_->spooler->Process(source);
     params_->spooler->WaitForUpload();
@@ -383,8 +383,8 @@ bool SyncMediator::Commit(manifest::Manifest *manifest) {
     }
   }
   catalog_manager_->PrecalculateListings();
-  return catalog_manager_->Commit(
-      params_->stop_for_catalog_tweaks, params_->manual_revision, manifest);
+  return catalog_manager_->Commit(params_->stop_for_catalog_tweaks,
+                                  params_->manual_revision, manifest);
 }
 
 
@@ -396,8 +396,8 @@ void SyncMediator::InsertHardlink(SharedPtr<SyncItem> entry) {
            inode, entry->GetUnionPath().c_str());
 
   // Find the hard link group in the lists
-  const HardlinkGroupMap::iterator hardlink_group =
-      GetHardlinkMap().find(inode);
+  const HardlinkGroupMap::iterator hardlink_group = GetHardlinkMap().find(
+      inode);
 
   if (hardlink_group == GetHardlinkMap().end()) {
     // Create a new hardlink group
@@ -491,44 +491,44 @@ void SyncMediator::CompleteHardlinks(SharedPtr<SyncItem> entry) {
 
 void SyncMediator::LegacyRegularHardlinkCallback(const string &parent_dir,
                                                  const string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemFile);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemFile);
   InsertLegacyHardlink(entry);
 }
 
 
 void SyncMediator::LegacySymlinkHardlinkCallback(const string &parent_dir,
                                                  const string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemSymlink);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemSymlink);
   InsertLegacyHardlink(entry);
 }
 
 void SyncMediator::LegacyCharacterDeviceHardlinkCallback(
     const string &parent_dir, const string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemCharacterDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemCharacterDevice);
   InsertLegacyHardlink(entry);
 }
 
 void SyncMediator::LegacyBlockDeviceHardlinkCallback(const string &parent_dir,
                                                      const string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemBlockDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemBlockDevice);
   InsertLegacyHardlink(entry);
 }
 
 void SyncMediator::LegacyFifoHardlinkCallback(const string &parent_dir,
                                               const string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemFifo);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemFifo);
   InsertLegacyHardlink(entry);
 }
 
 void SyncMediator::LegacySocketHardlinkCallback(const string &parent_dir,
                                                 const string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemSocket);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemSocket);
   InsertLegacyHardlink(entry);
 }
 
@@ -556,8 +556,8 @@ void SyncMediator::AddDirectoryRecursively(SharedPtr<SyncItem> entry) {
 
 bool SyncMediator::AddDirectoryCallback(const std::string &parent_dir,
                                         const std::string &dir_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   AddDirectory(entry);
   return true;  // The recursion engine should recurse deeper here
 }
@@ -565,60 +565,60 @@ bool SyncMediator::AddDirectoryCallback(const std::string &parent_dir,
 
 void SyncMediator::AddFileCallback(const std::string &parent_dir,
                                    const std::string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemFile);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemFile);
   Add(entry);
 }
 
 
 void SyncMediator::AddCharacterDeviceCallback(const std::string &parent_dir,
                                               const std::string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemCharacterDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemCharacterDevice);
   Add(entry);
 }
 
 void SyncMediator::AddBlockDeviceCallback(const std::string &parent_dir,
                                           const std::string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemBlockDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemBlockDevice);
   Add(entry);
 }
 
 void SyncMediator::AddFifoCallback(const std::string &parent_dir,
                                    const std::string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemFifo);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemFifo);
   Add(entry);
 }
 
 void SyncMediator::AddSocketCallback(const std::string &parent_dir,
                                      const std::string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemSocket);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemSocket);
   Add(entry);
 }
 
 void SyncMediator::AddSymlinkCallback(const std::string &parent_dir,
                                       const std::string &link_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemSymlink);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemSymlink);
   Add(entry);
 }
 
 
 void SyncMediator::EnterAddedDirectoryCallback(const std::string &parent_dir,
                                                const std::string &dir_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   EnterDirectory(entry);
 }
 
 
 void SyncMediator::LeaveAddedDirectoryCallback(const std::string &parent_dir,
                                                const std::string &dir_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   LeaveDirectory(entry);
 }
 
@@ -646,51 +646,51 @@ void SyncMediator::RemoveDirectoryRecursively(SharedPtr<SyncItem> entry) {
 
 void SyncMediator::RemoveFileCallback(const std::string &parent_dir,
                                       const std::string &file_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemFile);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemFile);
   Remove(entry);
 }
 
 
 void SyncMediator::RemoveSymlinkCallback(const std::string &parent_dir,
                                          const std::string &link_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemSymlink);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemSymlink);
   Remove(entry);
 }
 
 void SyncMediator::RemoveCharacterDeviceCallback(const std::string &parent_dir,
                                                  const std::string &link_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemCharacterDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemCharacterDevice);
   Remove(entry);
 }
 
 void SyncMediator::RemoveBlockDeviceCallback(const std::string &parent_dir,
                                              const std::string &link_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemBlockDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemBlockDevice);
   Remove(entry);
 }
 
 void SyncMediator::RemoveFifoCallback(const std::string &parent_dir,
                                       const std::string &link_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemFifo);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemFifo);
   Remove(entry);
 }
 
 void SyncMediator::RemoveSocketCallback(const std::string &parent_dir,
                                         const std::string &link_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemSocket);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemSocket);
   Remove(entry);
 }
 
 void SyncMediator::RemoveDirectoryCallback(const std::string &parent_dir,
                                            const std::string &dir_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   RemoveDirectoryRecursively(entry);
 }
 
@@ -701,8 +701,8 @@ bool SyncMediator::IgnoreFileCallback(const std::string &parent_dir,
     return true;
   }
 
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, file_name, kItemUnknown);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, file_name,
+                                                   kItemUnknown);
   return entry->IsWhiteout();
 }
 
@@ -1103,9 +1103,9 @@ void SyncMediator::AddLocalHardlinkGroups(const HardlinkGroupMap &hardlinks) {
                                         jEnd = i->second.hardlinks.end();
            j != jEnd;
            ++j) {
-        const std::string changeset_notice =
-            GetParentPath(i->second.master->GetUnionPath()) + "/" +
-            j->second->filename();
+        const std::string changeset_notice = GetParentPath(i->second.master
+                                                               ->GetUnionPath())
+                                             + "/" + j->second->filename();
         reporter_->OnAdd(changeset_notice, catalog::DirectoryEntry());
       }
     }

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -63,8 +63,8 @@ bool SyncUnion::ProcessDirectory(const string &parent_dir,
                                  const string &dir_name) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessDirectory(%s, %s)",
            parent_dir.c_str(), dir_name.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   return ProcessDirectory(entry);
 }
 
@@ -101,8 +101,8 @@ void SyncUnion::ProcessRegularFile(const string &parent_dir,
                                    const string &filename) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessRegularFile(%s, %s)",
            parent_dir.c_str(), filename.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, filename, kItemFile);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, filename,
+                                                   kItemFile);
   ProcessFile(entry);
 }
 
@@ -110,8 +110,8 @@ void SyncUnion::ProcessSymlink(const string &parent_dir,
                                const string &link_name) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnion::ProcessSymlink(%s, %s)",
            parent_dir.c_str(), link_name.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, link_name, kItemSymlink);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, link_name,
+                                                   kItemSymlink);
   ProcessFile(entry);
 }
 
@@ -136,15 +136,15 @@ void SyncUnion::ProcessFile(SharedPtr<SyncItem> entry) {
 
 void SyncUnion::EnterDirectory(const string &parent_dir,
                                const string &dir_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   mediator_->EnterDirectory(entry);
 }
 
 void SyncUnion::LeaveDirectory(const string &parent_dir,
                                const string &dir_name) {
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, dir_name, kItemDir);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, dir_name,
+                                                   kItemDir);
   mediator_->LeaveDirectory(entry);
 }
 
@@ -153,8 +153,8 @@ void SyncUnion::ProcessCharacterDevice(const std::string &parent_dir,
   LogCvmfs(kLogUnionFs, kLogDebug,
            "SyncUnionOverlayfs::ProcessCharacterDevice(%s, %s)",
            parent_dir.c_str(), filename.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, filename, kItemCharacterDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, filename,
+                                                   kItemCharacterDevice);
   ProcessFile(entry);
 }
 
@@ -163,8 +163,8 @@ void SyncUnion::ProcessBlockDevice(const std::string &parent_dir,
   LogCvmfs(kLogUnionFs, kLogDebug,
            "SyncUnionOverlayfs::ProcessBlockDevice(%s, %s)", parent_dir.c_str(),
            filename.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, filename, kItemBlockDevice);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, filename,
+                                                   kItemBlockDevice);
   ProcessFile(entry);
 }
 
@@ -172,8 +172,8 @@ void SyncUnion::ProcessFifo(const std::string &parent_dir,
                             const std::string &filename) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnionOverlayfs::ProcessFifo(%s, %s)",
            parent_dir.c_str(), filename.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, filename, kItemFifo);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, filename,
+                                                   kItemFifo);
   ProcessFile(entry);
 }
 
@@ -181,8 +181,8 @@ void SyncUnion::ProcessSocket(const std::string &parent_dir,
                               const std::string &filename) {
   LogCvmfs(kLogUnionFs, kLogDebug, "SyncUnionOverlayfs::ProcessSocket(%s, %s)",
            parent_dir.c_str(), filename.c_str());
-  const SharedPtr<SyncItem> entry =
-      CreateSyncItem(parent_dir, filename, kItemSocket);
+  const SharedPtr<SyncItem> entry = CreateSyncItem(parent_dir, filename,
+                                                   kItemSocket);
   ProcessFile(entry);
 }
 

--- a/cvmfs/sync_union_overlayfs.cc
+++ b/cvmfs/sync_union_overlayfs.cc
@@ -33,10 +33,10 @@ bool SyncUnionOverlayfs::Initialize() {
 }
 
 bool ObtainSysAdminCapabilityInternal(cap_t caps) {
-  /*const*/ const cap_value_t cap =
-      CAP_SYS_ADMIN; // is non-const as cap_set_flag()
-                     // expects a non-const pointer
-                     // on RHEL 5 and older
+  /*const*/ const cap_value_t
+      cap = CAP_SYS_ADMIN;  // is non-const as cap_set_flag()
+                            // expects a non-const pointer
+                            // on RHEL 5 and older
 
 // do sanity-check if supported in <sys/capability.h> otherwise just pray...
 // Note: CAP_SYS_ADMIN is a rather common capability and is very likely to be
@@ -242,20 +242,21 @@ bool SyncUnionOverlayfs::IsWhiteoutEntry(SharedPtr<SyncItem> entry) const {
    * 3. whiteouts are marked as .wh. (as in aufs)
    */
 
-  const bool is_chardev_whiteout = entry->IsCharacterDevice() &&
-                                   entry->GetRdevMajor() == 0 &&
-                                   entry->GetRdevMinor() == 0;
+  const bool is_chardev_whiteout = entry->IsCharacterDevice()
+                                   && entry->GetRdevMajor() == 0
+                                   && entry->GetRdevMinor() == 0;
   if (is_chardev_whiteout)
     return true;
 
   const std::string whiteout_prefix_ = ".wh.";
-  const bool has_wh_prefix =
-      HasPrefix(entry->filename().c_str(), whiteout_prefix_, true);
+  const bool has_wh_prefix = HasPrefix(entry->filename().c_str(),
+                                       whiteout_prefix_, true);
   if (has_wh_prefix)
     return true;
 
-  const bool is_symlink_whiteout =
-      entry->IsSymlink() && IsWhiteoutSymlinkPath(entry->GetScratchPath());
+  const bool is_symlink_whiteout = entry->IsSymlink()
+                                   && IsWhiteoutSymlinkPath(
+                                       entry->GetScratchPath());
   if (is_symlink_whiteout)
     return true;
 

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -123,8 +123,8 @@ void SyncUnionTarball::Traverse() {
       SplitPath(*s, &parent_path, &filename);
       if (parent_path == ".")
         parent_path = "";
-      const SharedPtr<SyncItem> sync_entry =
-          CreateSyncItem(parent_path, filename, kItemDir);
+      const SharedPtr<SyncItem> sync_entry = CreateSyncItem(parent_path,
+                                                            filename, kItemDir);
       mediator_->Remove(sync_entry);
     }
   }
@@ -203,10 +203,11 @@ void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
   std::string archive_file_path(archive_entry_pathname(entry));
   archive_file_path = SanitizePath(archive_file_path);
 
-  const std::string complete_path =
-      base_directory_ != "/"
-          ? MakeCanonicalPath(base_directory_ + "/" + archive_file_path)
-          : MakeCanonicalPath(archive_file_path);
+  const std::string complete_path = base_directory_ != "/"
+                                        ? MakeCanonicalPath(base_directory_
+                                                            + "/"
+                                                            + archive_file_path)
+                                        : MakeCanonicalPath(archive_file_path);
 
   std::string parent_path;
   std::string filename;

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -190,8 +190,8 @@ void *TalkManager::MainResponder(void *data) {
     }
     LogCvmfs(kLogTalk, kLogDebug, "accepting connections on socketfd %d",
              talk_mgr->socket_fd_);
-    if ((con_fd = accept(
-             talk_mgr->socket_fd_, (struct sockaddr *)&remote, &socket_size))
+    if ((con_fd = accept(talk_mgr->socket_fd_, (struct sockaddr *)&remote,
+                         &socket_size))
         < 0) {
       LogCvmfs(kLogTalk, kLogDebug, "terminating talk thread (fd %d, errno %d)",
                con_fd, errno);
@@ -379,8 +379,8 @@ void *TalkManager::MainResponder(void *data) {
       if (line.length() < 8) {
         talk_mgr->Answer(con_fd, "Usage: chroot <hash>\n");
       } else {
-        const std::string root_hash =
-            Trim(line.substr(7), true /* trim_newline */);
+        const std::string root_hash = Trim(line.substr(7),
+                                           true /* trim_newline */);
         const FuseRemounter::Status status = remounter->ChangeRoot(
             MkFromHexPtr(shash::HexPtr(root_hash), shash::kSuffixCatalog));
         switch (status) {
@@ -396,8 +396,8 @@ void *TalkManager::MainResponder(void *data) {
       mount_point->catalog_mgr()->DetachNested();
       talk_mgr->Answer(con_fd, "OK\n");
     } else if (line == "revision") {
-      const string revision =
-          StringifyInt(mount_point->catalog_mgr()->GetRevision());
+      const string revision = StringifyInt(
+          mount_point->catalog_mgr()->GetRevision());
       talk_mgr->Answer(con_fd, revision + "\n");
     } else if (line == "max ttl info") {
       const unsigned max_ttl = mount_point->GetMaxTtlMn();
@@ -503,12 +503,12 @@ void *TalkManager::MainResponder(void *data) {
         talk_mgr->Answer(con_fd, "OK\n");
       }
     } else if (line == "external proxy info") {
-      const string external_proxy_info =
-          talk_mgr->FormatProxyInfo(mount_point->external_download_mgr());
+      const string external_proxy_info = talk_mgr->FormatProxyInfo(
+          mount_point->external_download_mgr());
       talk_mgr->Answer(con_fd, external_proxy_info);
     } else if (line == "proxy info") {
-      const string proxy_info =
-          talk_mgr->FormatProxyInfo(mount_point->download_mgr());
+      const string proxy_info = talk_mgr->FormatProxyInfo(
+          mount_point->download_mgr());
       talk_mgr->Answer(con_fd, proxy_info);
     } else if (line == "proxy rebalance") {
       mount_point->download_mgr()->RebalanceProxies();
@@ -618,10 +618,10 @@ void *TalkManager::MainResponder(void *data) {
       // Manually setting the inode tracker numbers
       glue::InodeTracker::Statistics inode_stats = mount_point->inode_tracker()
                                                        ->GetStatistics();
-      const glue::DentryTracker::Statistics dentry_stats =
-          mount_point->dentry_tracker()->GetStatistics();
-      const glue::PageCacheTracker::Statistics page_cache_stats =
-          mount_point->page_cache_tracker()->GetStatistics();
+      const glue::DentryTracker::Statistics
+          dentry_stats = mount_point->dentry_tracker()->GetStatistics();
+      const glue::PageCacheTracker::Statistics
+          page_cache_stats = mount_point->page_cache_tracker()->GetStatistics();
       mount_point->statistics()
           ->Lookup("inode_tracker.n_insert")
           ->Set(atomic_read64(&inode_stats.num_inserts));
@@ -822,8 +822,8 @@ void *TalkManager::MainResponder(void *data) {
         talk_mgr->Answer(con_fd, "In read-only mode\n");
       }
     } else if (line == "latency") {
-      const string result =
-          talk_mgr->FormatLatencies(*mount_point, file_system);
+      const string result = talk_mgr->FormatLatencies(*mount_point,
+                                                      file_system);
       talk_mgr->Answer(con_fd, result);
     } else {
       talk_mgr->Answer(con_fd, "unknown command\n");

--- a/cvmfs/telemetry_aggregator.cc
+++ b/cvmfs/telemetry_aggregator.cc
@@ -65,8 +65,8 @@ void TelemetryAggregator::Spawn() {
   assert(pipe_terminate_[0] == -1);
   assert(send_rate_sec_ > 0);
   MakePipe(pipe_terminate_);
-  const int retval =
-      pthread_create(&thread_telemetry_, NULL, MainTelemetry, this);
+  const int retval = pthread_create(&thread_telemetry_, NULL, MainTelemetry,
+                                    this);
   assert(retval == 0);
   LogCvmfs(kLogTelemetry, kLogDebug, "Spawning of telemetry thread.");
 }
@@ -79,10 +79,10 @@ void TelemetryAggregator::ManuallyUpdateSelectedCounters() {
   // Manually setting the inode tracker numbers
   glue::InodeTracker::Statistics inode_stats = mount_point_->inode_tracker()
                                                    ->GetStatistics();
-  const glue::DentryTracker::Statistics dentry_stats =
-      mount_point_->dentry_tracker()->GetStatistics();
-  const glue::PageCacheTracker::Statistics page_cache_stats =
-      mount_point_->page_cache_tracker()->GetStatistics();
+  const glue::DentryTracker::Statistics
+      dentry_stats = mount_point_->dentry_tracker()->GetStatistics();
+  const glue::PageCacheTracker::Statistics
+      page_cache_stats = mount_point_->page_cache_tracker()->GetStatistics();
   mount_point_->statistics()
       ->Lookup("inode_tracker.n_insert")
       ->Set(atomic_read64(&inode_stats.num_inserts));

--- a/cvmfs/telemetry_aggregator_influx.cc
+++ b/cvmfs/telemetry_aggregator_influx.cc
@@ -126,7 +126,8 @@ std::string TelemetryAggregatorInflux::MakePayload() {
   bool add_token = false;
   for (std::map<std::string, int64_t>::iterator it = counters_.begin(),
                                                 iEnd = counters_.end();
-       it != iEnd; it++) {
+       it != iEnd;
+       it++) {
     if (it->second != 0) {
       if (add_token) {
         ret += ",";
@@ -184,7 +185,8 @@ std::string TelemetryAggregatorInflux::MakeDeltaPayload() {
   bool add_token = false;
   for (std::map<std::string, int64_t>::iterator it = counters_.begin(),
                                                 iEnd = counters_.end();
-       it != iEnd; it++) {
+       it != iEnd;
+       it++) {
     const int64_t value = it->second;
     if (value != 0) {
       int64_t old_value;
@@ -242,10 +244,10 @@ TelemetryReturn TelemetryAggregatorInflux::SendToInflux(
   dest_addr = reinterpret_cast<sockaddr_in *>(res_->ai_addr);
   dest_addr->sin_port = htons(influx_port_);
 
-  const ssize_t num_bytes_sent =
-      sendto(socket_fd_, payload.data(), payload.size(), 0,
-             reinterpret_cast<struct sockaddr *>(dest_addr),
-             sizeof(struct sockaddr_in));
+  const ssize_t num_bytes_sent = sendto(
+      socket_fd_, payload.data(), payload.size(), 0,
+      reinterpret_cast<struct sockaddr *>(dest_addr),
+      sizeof(struct sockaddr_in));
 
   if (num_bytes_sent < 0) {
     LogCvmfs(kLogTelemetry, kLogDebug | kLogSyslogErr,

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -91,8 +91,8 @@ int32_t Tracer::DoTrace(const int event,
 
   if (my_seq_no - atomic_read32(&flushed_) == flush_threshold_) {
     const MutexLockGuard m(&sig_flush_mutex_);
-    const int err_code __attribute__((unused)) =
-        pthread_cond_signal(&sig_flush_);
+    const int err_code
+        __attribute__((unused)) = pthread_cond_signal(&sig_flush_);
     assert(err_code == 0 && "Could not signal flush thread");
   }
 
@@ -104,8 +104,8 @@ void Tracer::Flush() {
   if (!active_)
     return;
 
-  const int32_t save_seq_no =
-      DoTrace(kEventFlush, PathString("Tracer", 6), "flushed ring buffer");
+  const int32_t save_seq_no = DoTrace(kEventFlush, PathString("Tracer", 6),
+                                      "flushed ring buffer");
   while (atomic_read32(&flushed_) <= save_seq_no) {
     timespec timeout;
     int retval;
@@ -119,8 +119,8 @@ void Tracer::Flush() {
 
     GetTimespecRel(250, &timeout);
     retval = pthread_mutex_lock(&sig_continue_trace_mutex_);
-    retval |= pthread_cond_timedwait(
-        &sig_continue_trace_, &sig_continue_trace_mutex_, &timeout);
+    retval |= pthread_cond_timedwait(&sig_continue_trace_,
+                                     &sig_continue_trace_mutex_, &timeout);
     retval |= pthread_mutex_unlock(&sig_continue_trace_mutex_);
     assert(retval == ETIMEDOUT || retval == 0);
   }
@@ -156,8 +156,8 @@ void *Tracer::MainFlush(void *data) {
         && (atomic_read32(&tracer->seq_no_) - atomic_read32(&tracer->flushed_)
             <= tracer->flush_threshold_)) {
       tracer->GetTimespecRel(2000, &timeout);
-      retval = pthread_cond_timedwait(
-          &tracer->sig_flush_, &tracer->sig_flush_mutex_, &timeout);
+      retval = pthread_cond_timedwait(&tracer->sig_flush_,
+                                      &tracer->sig_flush_mutex_, &timeout);
       assert(retval != EINVAL);
     }
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -89,8 +89,8 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   s3fanout_mgr_ = new s3fanout::S3FanoutManager(s3config);
   s3fanout_mgr_->Spawn();
 
-  const int retval =
-      pthread_create(&thread_collect_results_, NULL, MainCollectResults, this);
+  const int retval = pthread_create(&thread_collect_results_, NULL,
+                                    MainCollectResults, this);
   assert(retval == 0);
 }
 

--- a/cvmfs/url.cc
+++ b/cvmfs/url.cc
@@ -45,8 +45,8 @@ Url *Url::Parse(const std::string &url, const std::string &default_protocol,
 
     // Check that part between ":" and "/" or the end of the string is an
     // unsigned number
-    const size_t port_end =
-        slash_pos == std::string::npos ? std::string::npos : slash_pos - cursor;
+    const size_t port_end = slash_pos == std::string::npos ? std::string::npos
+                                                           : slash_pos - cursor;
     if (!String2Uint64Parse(url.substr(cursor, port_end), &port)) {
       return NULL;
     }

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -43,8 +43,8 @@ double DiffTimeSeconds(struct timeval start, struct timeval end) {
 
   // Compute the time remaining to wait in microseconds.
   // tv_usec is certainly positive.
-  const uint64_t elapsed_usec =
-      ((end.tv_sec - start.tv_sec) * 1000000) + (end.tv_usec - start.tv_usec);
+  const uint64_t elapsed_usec = ((end.tv_sec - start.tv_sec) * 1000000)
+                                + (end.tv_usec - start.tv_usec);
   return static_cast<double>(elapsed_usec) / 1000000.0;
 }
 
@@ -115,8 +115,8 @@ unsigned int Log2Histogram::GetQuantile(float n) {
   // note that we _exclude_ the overflow bin
   unsigned int i = 0;
   for (i = 1; i <= this->bins_.size() - 1; i++) {
-    const unsigned int bin_value =
-        static_cast<unsigned int>(atomic_read32(&(this->bins_[i])));
+    const unsigned int bin_value = static_cast<unsigned int>(
+        atomic_read32(&(this->bins_[i])));
     if (pivot <= bin_value) {
       normalized_pivot = static_cast<float>(pivot)
                          / static_cast<float>(bin_value);
@@ -170,34 +170,53 @@ std::string Log2Histogram::ToString() {
     max_stars = max_bins * total_stars / total_sum_of_bins;
   }
 
-  const std::string format =
-      " %" +
-      StringifyUint(max_left_boundary_count < 2 ? 2 : max_left_boundary_count) +
-      "d -> %" + StringifyUint(max_right_boundary_count) + "d :     %" +
-      StringifyUint(max_value_count) + "d | %" +
-      StringifyUint(max_stars < 12 ? 12 : max_stars) + "s |\n";
+  const std::string format = " %"
+                             + StringifyUint(max_left_boundary_count < 2
+                                                 ? 2
+                                                 : max_left_boundary_count)
+                             + "d -> %"
+                             + StringifyUint(max_right_boundary_count)
+                             + "d :     %" + StringifyUint(max_value_count)
+                             + "d | %"
+                             + StringifyUint(max_stars < 12 ? 12 : max_stars)
+                             + "s |\n";
 
-  const std::string title_format =
-      " %" +
-      StringifyUint(
-          (max_left_boundary_count < 2 ? 2 : max_left_boundary_count) +
-          max_right_boundary_count + 4) +
-      "s | %" + StringifyUint(max_value_count + 4) + "s | %" +
-      StringifyUint(max_stars < 12 ? 12 : max_stars) + "s |\n";
+  const std::string title_format = " %"
+                                   + StringifyUint(
+                                       (max_left_boundary_count < 2
+                                            ? 2
+                                            : max_left_boundary_count)
+                                       + max_right_boundary_count + 4)
+                                   + "s | %"
+                                   + StringifyUint(max_value_count + 4)
+                                   + "s | %"
+                                   + StringifyUint(max_stars < 12 ? 12
+                                                                  : max_stars)
+                                   + "s |\n";
 
-  const std::string overflow_format =
-      "%" +
-      StringifyUint(max_left_boundary_count + max_right_boundary_count + 5) +
-      "s : %" + StringifyUint(max_value_count + 4) + "d | %" +
-      StringifyUint(max_stars < 12 ? 12 : max_stars) + "s |\n";
+  const std::string overflow_format = "%"
+                                      + StringifyUint(max_left_boundary_count
+                                                      + max_right_boundary_count
+                                                      + 5)
+                                      + "s : %"
+                                      + StringifyUint(max_value_count + 4)
+                                      + "d | %"
+                                      + StringifyUint(
+                                          max_stars < 12 ? 12 : max_stars)
+                                      + "s |\n";
 
-  const std::string total_format =
-      "%" +
-      StringifyUint(max_left_boundary_count + max_right_boundary_count + 5 < 8
-                        ? 8
-                        : max_left_boundary_count + max_right_boundary_count +
-                              5) +
-      "s : %" + StringifyUint(max_value_count + 4) + "lld\n";
+  const std::string total_format = "%"
+                                   + StringifyUint(
+                                       max_left_boundary_count
+                                                   + max_right_boundary_count
+                                                   + 5
+                                               < 8
+                                           ? 8
+                                           : max_left_boundary_count
+                                                 + max_right_boundary_count + 5)
+                                   + "s : %"
+                                   + StringifyUint(max_value_count + 4)
+                                   + "lld\n";
 
   std::string result_string = "";
 
@@ -205,8 +224,8 @@ std::string Log2Histogram::ToString() {
   char buffer[kBufSize];
   memset(buffer, 0, sizeof(buffer));
 
-  snprintf(
-      buffer, kBufSize, title_format.c_str(), "nsec", "count", "distribution");
+  snprintf(buffer, kBufSize, title_format.c_str(), "nsec", "count",
+           "distribution");
   result_string += buffer;
   memset(buffer, 0, sizeof(buffer));
 

--- a/cvmfs/util/file_backed_buffer.cc
+++ b/cvmfs/util/file_backed_buffer.cc
@@ -73,8 +73,8 @@ void FileBackedBuffer::Append(const void *source, uint64_t len) {
       buf_ = reinterpret_cast<unsigned char *>(smalloc(len));
       size_ = len;
     } else if (size_ < pos_ + len) {
-      const uint64_t newsize =
-          (size_ * 2 < pos_ + len) ? (pos_ + len) : (size_ * 2);
+      const uint64_t newsize = (size_ * 2 < pos_ + len) ? (pos_ + len)
+                                                        : (size_ * 2);
       buf_ = reinterpret_cast<unsigned char *>(srealloc(buf_, newsize));
       size_ = newsize;
     }
@@ -121,10 +121,10 @@ void FileBackedBuffer::Commit() {
 int64_t FileBackedBuffer::Data(void **ptr, int64_t len, uint64_t pos) {
   assert(state_ == kReadState);
 
-  const int64_t actual_len =
-      (pos + len <= size_)
-          ? len
-          : static_cast<int64_t>(size_) - static_cast<int64_t>(pos);
+  const int64_t actual_len = (pos + len <= size_)
+                                 ? len
+                                 : static_cast<int64_t>(size_)
+                                       - static_cast<int64_t>(pos);
   assert(actual_len >= 0);
 
   if (mode_ == kMemoryMode) {

--- a/cvmfs/util/fs_traversal.h
+++ b/cvmfs/util/fs_traversal.h
@@ -169,8 +169,8 @@ class FileSystemTraversal {
 
       // Notify user about found directory entry
       platform_stat64 info;
-      const int retval =
-          platform_lstat((path + "/" + dit->d_name).c_str(), &info);
+      const int retval = platform_lstat((path + "/" + dit->d_name).c_str(),
+                                        &info);
       if (retval != 0) {
         PANIC(kLogStderr, "failed to lstat '%s' errno: %d",
               (path + "/" + dit->d_name).c_str(), errno);

--- a/cvmfs/util/logging.cc
+++ b/cvmfs/util/logging.cc
@@ -603,8 +603,8 @@ static void LogCustom(unsigned id, const std::string &message) {
   pthread_mutex_lock(&customlog_locks[id]);
   assert(customlog_fds[id] >= 0);
 
-  const bool retval_b =
-      SafeWrite(customlog_fds[id], message.data(), message.size());
+  const bool retval_b = SafeWrite(customlog_fds[id], message.data(),
+                                  message.size());
   if (!retval_b) {
     LogCvmfs(kLogCvmfs, kLogDebug | kLogSyslogErr,
              "could not write into log file %s (%d), aborting - lost: %s",

--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -251,15 +251,15 @@ inline bool platform_getxattr(const std::string &path, const std::string &name,
 // TODO(jblomer): the translation from C to C++ should be done elsewhere
 inline bool platform_setxattr(const std::string &path, const std::string &name,
                               const std::string &value) {
-  const int retval =
-      setxattr(path.c_str(), name.c_str(), value.c_str(), value.size(), 0);
+  const int retval = setxattr(path.c_str(), name.c_str(), value.c_str(),
+                              value.size(), 0);
   return retval == 0;
 }
 
 inline bool platform_lsetxattr(const std::string &path, const std::string &name,
                                const std::string &value) {
-  const int retval =
-      lsetxattr(path.c_str(), name.c_str(), value.c_str(), value.size(), 0);
+  const int retval = lsetxattr(path.c_str(), name.c_str(), value.c_str(),
+                               value.size(), 0);
   return retval == 0;
 }
 

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -435,9 +435,9 @@ int ConnectSocket(const std::string &path) {
   const int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
   assert(socket_fd != -1);
 
-  const int retval =
-      connect(socket_fd, reinterpret_cast<struct sockaddr *>(&sock_addr),
-              sizeof(sock_addr.sun_family) + sizeof(sock_addr.sun_path));
+  const int retval = connect(
+      socket_fd, reinterpret_cast<struct sockaddr *>(&sock_addr),
+      sizeof(sock_addr.sun_family) + sizeof(sock_addr.sun_path));
   if (short_path != path)
     RemoveShortSocketLink(short_path);
 
@@ -632,8 +632,8 @@ bool DiffTree(const std::string &path_a, const std::string &path_b) {
   }
 
   for (unsigned i = 0; i < subdirs.size(); ++i) {
-    const bool retval_subtree =
-        DiffTree(path_a + "/" + subdirs[i], path_b + "/" + subdirs[i]);
+    const bool retval_subtree = DiffTree(path_a + "/" + subdirs[i],
+                                         path_b + "/" + subdirs[i]);
     if (!retval_subtree)
       return false;
   }
@@ -962,8 +962,8 @@ int WritePidFile(const std::string &path) {
   char buf[64];
 
   snprintf(buf, sizeof(buf), "%" PRId64 "\n", static_cast<uint64_t>(getpid()));
-  const bool retval =
-      (ftruncate(fd, 0) == 0) && SafeWrite(fd, buf, strlen(buf));
+  const bool retval = (ftruncate(fd, 0) == 0)
+                      && SafeWrite(fd, buf, strlen(buf));
   if (!retval) {
     UnlockFile(fd);
     return -1;
@@ -2058,8 +2058,8 @@ bool SafeWriteV(int fd, struct iovec *iov, unsigned iovcnt) {
   unsigned iov_idx = 0;
 
   while (nbytes) {
-    const ssize_t retval =
-        writev(fd, &iov[iov_idx], static_cast<int>(iovcnt - iov_idx));
+    const ssize_t retval = writev(fd, &iov[iov_idx],
+                                  static_cast<int>(iovcnt - iov_idx));
     if (retval < 0) {
       if (errno == EINTR)
         continue;

--- a/cvmfs/util/prng.h
+++ b/cvmfs/util/prng.h
@@ -43,9 +43,9 @@ class Prng {
    */
   uint32_t Next(const uint64_t boundary) {
     state_ = a * state_ + c;
-    const double scaled_val = static_cast<double>(state_) *
-                              static_cast<double>(boundary) /
-                              static_cast<double>(18446744073709551616.0);
+    const double scaled_val = static_cast<double>(state_)
+                              * static_cast<double>(boundary)
+                              / static_cast<double>(18446744073709551616.0);
     return static_cast<uint32_t>(static_cast<uint64_t>(scaled_val) % boundary);
   }
 
@@ -54,8 +54,8 @@ class Prng {
    */
   double NextDouble() {
     state_ = a * state_ + c;
-    const double unit_val = static_cast<double>(state_) /
-                            static_cast<double>(18446744073709551616.0);
+    const double unit_val = static_cast<double>(state_)
+                            / static_cast<double>(18446744073709551616.0);
     return unit_val;
   }
   /**

--- a/cvmfs/util/smalloc.h
+++ b/cvmfs/util/smalloc.h
@@ -86,8 +86,8 @@ static inline void * __attribute__((used)) smmap(size_t size) {
 
   const int anonymous_fd = -1;
   const off_t offset = 0;
-  const size_t pages =
-      ((size + 2 * sizeof(size_t)) + 4095) / 4096; // round to full page
+  const size_t pages = ((size + 2 * sizeof(size_t)) + 4095)
+                       / 4096;  // round to full page
   unsigned char *mem = NULL;
 
 #ifdef CVMFS_SUPPRESS_ASSERTS

--- a/cvmfs/whitelist.cc
+++ b/cvmfs/whitelist.cc
@@ -48,11 +48,13 @@ std::string Whitelist::CreateString(
     int validity_days,
     shash::Algorithms hash_algorithm,
     signature::SignatureManager *signature_manager) {
-  const std::string to_sign =
-      WhitelistTimestamp(time(NULL)) + "\n" + "E" +
-      WhitelistTimestamp(time(NULL) + validity_days * 24 * 3600) + "\n" + "N" +
-      fqrn + "\n" + signature_manager->FingerprintCertificate(hash_algorithm) +
-      "\n";
+  const std::string to_sign = WhitelistTimestamp(time(NULL)) + "\n" + "E"
+                              + WhitelistTimestamp(time(NULL)
+                                                   + validity_days * 24 * 3600)
+                              + "\n" + "N" + fqrn + "\n"
+                              + signature_manager->FingerprintCertificate(
+                                  hash_algorithm)
+                              + "\n";
   shash::Any hash(hash_algorithm);
   shash::HashString(to_sign, &hash);
   std::string hash_str = hash.ToString();
@@ -96,8 +98,8 @@ Failures Whitelist::VerifyLoadedCertificate() const {
 
   vector<string> blacklist = signature_manager_->GetBlacklist();
   for (unsigned i = 0; i < blacklist.size(); ++i) {
-    const shash::Any this_hash =
-        signature::SignatureManager::MkFromFingerprint(blacklist[i]);
+    const shash::Any this_hash = signature::SignatureManager::MkFromFingerprint(
+        blacklist[i]);
     if (this_hash.IsNull())
       continue;
 
@@ -375,8 +377,8 @@ Failures Whitelist::ParseWhitelist(const unsigned char *whitelist,
   do {
     if (line == "--")
       break;
-    const shash::Any this_hash =
-        signature::SignatureManager::MkFromFingerprint(line);
+    const shash::Any this_hash = signature::SignatureManager::MkFromFingerprint(
+        line);
     if (!this_hash.IsNull())
       fingerprints_.push_back(this_hash);
 

--- a/cvmfs/wpad.cc
+++ b/cvmfs/wpad.cc
@@ -104,9 +104,9 @@ static bool ParsePac(const char *pac_data, const size_t size,
   unsigned current_host;
   download_manager->GetHostInfo(&host_list, &rtt, &current_host);
   for (unsigned i = 0; i < host_list.size(); ++i) {
-    const size_t hostname_begin = 7; // Strip http:// or file://
-    const size_t hostname_end =
-        host_list[i].find_first_of(":/", hostname_begin);
+    const size_t hostname_begin = 7;  // Strip http:// or file://
+    const size_t hostname_end = host_list[i].find_first_of(":/",
+                                                           hostname_begin);
     const size_t hostname_len = (hostname_end == string::npos)
                                     ? string::npos
                                     : hostname_end - hostname_begin;
@@ -239,8 +239,8 @@ string ResolveProxyDescription(const string &cvmfs_proxies,
         }
       }
     } else {
-      const bool retval =
-          SafeWriteToFile(discovered_proxies, path_fallback_cache, 0660);
+      const bool retval = SafeWriteToFile(discovered_proxies,
+                                          path_fallback_cache, 0660);
       if (!retval) {
         LogCvmfs(kLogDownload, kLogSyslogWarn | kLogDebug,
                  "failed to write proxy settings into %s",
@@ -278,8 +278,8 @@ int MainResolveProxyDescription(int argc, char **argv) {
   DownloadManager download_manager(
       1, perf::StatisticsTemplate("pac", &statistics));
   download_manager.SetHostChain(host_list);
-  const string resolved_proxies =
-      ResolveProxyDescription(proxy_configuration, "", &download_manager);
+  const string resolved_proxies = ResolveProxyDescription(
+      proxy_configuration, "", &download_manager);
 
   LogCvmfs(kLogDownload, kLogStdout, "%s", resolved_proxies.c_str());
   return resolved_proxies == "";

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -56,8 +56,8 @@ XattrList *XattrList::CreateFromFile(const std::string &path) {
   for (unsigned i = 0; i < keys.size(); ++i) {
     if (keys[i].empty())
       continue;
-    const ssize_t sz_value =
-        platform_lgetxattr(path.c_str(), keys[i].c_str(), value, 256);
+    const ssize_t sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(),
+                                                value, 256);
     if (sz_value < 0)
       continue;
     result->Set(keys[i], string(value, sz_value));
@@ -81,8 +81,8 @@ XattrList *XattrList::Deserialize(const unsigned char *inbuf,
   unsigned pos = sizeof(header);
   for (unsigned i = 0; i < header.num_xattrs; ++i) {
     XattrEntry entry;
-    unsigned size_preamble = //NOLINT
-               sizeof(entry.len_key) + sizeof(entry.len_value);
+    unsigned size_preamble =  // NOLINT
+        sizeof(entry.len_key) + sizeof(entry.len_value);
     if (size - pos < size_preamble)
       return NULL;
     memcpy(&entry, inbuf + pos, size_preamble);

--- a/ducc/.clang-tidy
+++ b/ducc/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: '-*'

--- a/externals/.clang-tidy
+++ b/externals/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: '-*'

--- a/gateway/.clang-tidy
+++ b/gateway/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: '-*'

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -56,8 +56,8 @@ static string MkFqrn(const string &repository) {
   const string::size_type idx = repository.find_last_of('.');
   if (idx == string::npos) {
     string domain;
-    const bool retval =
-        options_manager_.GetValue("CVMFS_DEFAULT_DOMAIN", &domain);
+    const bool retval = options_manager_.GetValue("CVMFS_DEFAULT_DOMAIN",
+                                                  &domain);
     if (!retval) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
                "CVMFS_DEFAULT_DOMAIN missing");
@@ -219,8 +219,8 @@ static int GetExistingFuseFd(const string &fqrn, const string &workspace,
   if (result == "OK") {
     struct sockaddr_un addr;
     unsigned int len = sizeof(addr);
-    const int con_fd =
-        accept(recv_sock_fd, reinterpret_cast<struct sockaddr *>(&addr), &len);
+    const int con_fd = accept(recv_sock_fd,
+                              reinterpret_cast<struct sockaddr *>(&addr), &len);
     fuse_fd = RecvFdFromSocket(con_fd);
     close(con_fd);
   }

--- a/snapshotter/.clang-tidy
+++ b/snapshotter/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: '-*'

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,2 @@
+# Disable all checks in this folder.
+Checks: '-*'

--- a/test/micro-benchmarks/b_smallhash.cc
+++ b/test/micro-benchmarks/b_smallhash.cc
@@ -38,7 +38,7 @@ class BM_SmallHash : public benchmark::Fixture {
 
   static inline uint32_t hasher_md5(const shash::Md5 &key) {
     // Don't start with the first bytes, because == is using them as well
-    return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+    return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
   }
 
   void SetCollisionLabel(uint64_t num_collisions,

--- a/test/unittests/t_hash_filters.cc
+++ b/test/unittests/t_hash_filters.cc
@@ -2,6 +2,8 @@
  * This file is part of the CernVM File System.
  */
 
+//REMOVE ME
+
 #include <gtest/gtest.h>
 
 #include <algorithm>

--- a/test/unittests/t_hash_filters.cc
+++ b/test/unittests/t_hash_filters.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-//REMOVE ME
-
 #include <gtest/gtest.h>
 
 #include <algorithm>

--- a/test/unittests/t_smallhash.cc
+++ b/test/unittests/t_smallhash.cc
@@ -18,7 +18,7 @@ static uint32_t hasher_int(const int &key) {
 
 static uint32_t hasher_md5(const shash::Md5 &key) {
   // Don't start with the first bytes, because == is using them as well
-  return (uint32_t) * (reinterpret_cast<const uint32_t *>(key.digest) + 1);
+  return static_cast<uint32_t>(*(reinterpret_cast<const uint32_t *>(key.digest) + 1));
 }
 
 class T_Smallhash : public ::testing::Test {


### PR DESCRIPTION
Another run of clang-format that fixes ingestsql et al.

This PR does change a few C style casts to static_casts, mainly because different versions of clang-format cannot agree how to format the following:
```diff
diff --git a/cvmfs/cache_plugin/cvmfs_cache_ram.cc b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
index 03a45c907..30e5a4747 100644
--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -144,7 +144,7 @@ static inline uint32_t hasher_uint64(const uint64_t &key) {
 }
 
 static inline uint32_t hasher_any(const ComparableHash &key) {
-  return (uint32_t)*(reinterpret_cast<const uint32_t *>(&key.hash));
+  return (uint32_t) * (reinterpret_cast<const uint32_t *>(&key.hash));
 }
 
 }  // anonymous namespace
```
In order to avoid formatting noise when different contributors set up their formatting with different versions, I replace those by static_casts which are unproblematic. I've checked that both clang-format-18 and clang-format-20 now give the same output when run on the codebase.

Also adds a few fixes to make clang-tidy green:
* compiler definition -DCVMFS_USE_LIBFUSE=3 for fuse_duplex.h
* includes in _impl.h that are needed to let clang-tidy know about class definitions
* disable all tidy checks in non-relevant subdirectories ( clang-tidy tends to introduce compiler  errors when fixing unittests ) and add allow-no-checks option

As a note to myself, the command to run clang-tidy locally is
```
 clang-tidy-19 --fix-errors  -format-style='{QualifierAlignment: Left, InsertBraces: false}' --fix --extra-arg=-I/usr/lib/llvm-19/include/c++/v1/  --extra-arg=-I$PWD/cvmfs --allow-no-checks -p ./build $file
 ```