### PR TITLE
Fix linker error on alma10

### DIFF
--- a/externals/pacparser/src/makeHook.sh
+++ b/externals/pacparser/src/makeHook.sh
@@ -32,11 +32,6 @@ rm -f *.o
 echo "finished creating static link library for libpacparser"
 
 
-if [ ! -e /etc/fedora-release ] # workaround for a rpmbuild error on fc38
-then 
-  echo "stripping debug symbols for libpacparser..."
-  strip -S libpacparser.a
-fi
 echo "finished building libpacparser.a"
 
 # Install


### PR DESCRIPTION
The compiler on alma10 has seemingly caught up with Fedora38, and the build fails with same linker error as in https://github.com/cvmfs/cvmfs/issues/3404 , although this time in the unittests:

```
/usr/bin/ld: /tmp/ccG2CfaC.ltrans3.ltrans.o:(.debug_info+0x1a3a): undefined reference to `pacparser.c.096c802e'
```

I remove the `strip` alltogether in order to fix this for 2.13.1, even though libpacparser.a goes from 1.5 to 5.8 MB.