### PR TITLE
cvmfs_server: fstab: change type from fuse to cvmfs, abandon cvmfs2# prefix in name

### DIFF
--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1194,7 +1194,7 @@ setup_and_mount_new_repository() {
   if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
     echo -n "(overlayfs) "
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+$name $rdonly_dir cvmfs allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 overlay_$name /cvmfs/$name overlay upperdir=${scratch_dir},lowerdir=${rdonly_dir},workdir=$ofs_workdir,noauto,nodev,ro 0 0 # added by CernVM-FS for $name
 EOF
   else
@@ -1203,7 +1203,7 @@ EOF
       selinux_context=",context=\"system_u:object_r:default_t:s0\""
     fi
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+$name $rdonly_dir cvmfs allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,noauto,nodev,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   fi

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1194,7 +1194,7 @@ setup_and_mount_new_repository() {
   if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
     echo -n "(overlayfs) "
     cat >> /etc/fstab << EOF
-$name $rdonly_dir cvmfs allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+$name $rdonly_dir fuse.cvmfs2 allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 overlay_$name /cvmfs/$name overlay upperdir=${scratch_dir},lowerdir=${rdonly_dir},workdir=$ofs_workdir,noauto,nodev,ro 0 0 # added by CernVM-FS for $name
 EOF
   else
@@ -1203,7 +1203,7 @@ EOF
       selinux_context=",context=\"system_u:object_r:default_t:s0\""
     fi
     cat >> /etc/fstab << EOF
-$name $rdonly_dir cvmfs allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+$name $rdonly_dir fuse.cvmfs2 allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,noauto,nodev,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   fi


### PR DESCRIPTION
See https://github.com/cvmfs/cvmfs/issues/3901

What seemed to work until recently now fails:

	incus launch --vm images:debian/12 cvmfs-server-fstab-issue
	incus exec cvmfs-server-fstab-issue -- bash -l <EOF
	apt install -y wget && wget http://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb && dpkg -i cvmfs-release-latest_all.deb && apt update && apt install -y cvmfs cvmfs-server && cvmfs_server mkfs -o root my.repo.name
	EOF

	...
	Warning: Failed to restart apache after enabling necessary modules
	Creating Configuration Files... done
	Creating CernVM-FS Master Key and Self-Signed Certificate... done
	Creating CernVM-FS Server Infrastructure... done
	Creating Backend Storage... done
	Signing 30 day whitelist with master key... done
	Creating Initial Repository... done
	Mounting CernVM-FS Storage... (overlayfs) mount: /var/spool/cvmfs/my.repo.name/rdonly: wrong fs type, bad option, bad superblock on cvmfs2#my.repo.name, missing codepage or helper program, or other error.
	       dmesg(1) may have more information after failed mount system call.
	fail
	root@cvmfs-server-fstab-issue:~# cat /etc/fstab
	LABEL=rootfs  /         ext4  defaults  0 0
	LABEL=UEFI    /boot/efi vfat  defaults  0 0
	cvmfs2#my.repo.name /var/spool/cvmfs/my.repo.name/rdonly fuse allow_other,fsname=my.repo.name,config=/etc/cvmfs/repositories.d/my.repo.name/client.conf:/var/spool/cvmfs/my.repo.name/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for my.repo.name
	overlay_my.repo.name /cvmfs/my.repo.name overlay upperdir=/var/spool/cvmfs/my.repo.name/scratch/current,lowerdir=/var/spool/cvmfs/my.repo.name/rdonly,workdir=/var/spool/cvmfs/my.repo.name/ofs_workdir,noauto,nodev,ro 0 0 # added by CernVM-FS for my.repo.name

dmesg says:

	fuse: Unknown parameter 'fsname'

`cvmfs2#` prefix in the first field, which is called deprecated by mount(8) and fstab(5).

Third field (with value fuse) gives mount an indication of which helper program to call. Says fuse, with no subtype (i'd expect fuse.cvmfs). cvmfs installs `mount.cvmfs`, so let's use `cvmfs` as type.