### PR TITLE
Update python shebangs to python3

### DIFF
--- a/add-ons/tools/download_catalog_graph.py
+++ b/add-ons/tools/download_catalog_graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cvmfs
 import os

--- a/add-ons/tools/get_info.py
+++ b/add-ons/tools/get_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import optparse

--- a/add-ons/tools/get_referenced_hashes.py
+++ b/add-ons/tools/get_referenced_hashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import cvmfs

--- a/add-ons/tools/get_root_hash.py
+++ b/add-ons/tools/get_root_hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import cvmfs

--- a/add-ons/tools/list_catalogs.py
+++ b/add-ons/tools/list_catalogs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import cvmfs

--- a/add-ons/tools/open_history.py
+++ b/add-ons/tools/open_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import cvmfs

--- a/add-ons/tools/open_root_catalog.py
+++ b/add-ons/tools/open_root_catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import cvmfs

--- a/cvmfs/webapi/test-api.py
+++ b/cvmfs/webapi/test-api.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # This tester listens on port 8051 for a single http request, with
 #  a URL that starts with /api/v....

--- a/test/common/mock_services/http_400.py
+++ b/test/common/mock_services/http_400.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 try:
   import http.server as BaseHTTPServer
   import socketserver as SocketServer

--- a/test/common/mock_services/http_server.py
+++ b/test/common/mock_services/http_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import HTTPRangeServer
 try:

--- a/test/common/mock_services/make_repo.py
+++ b/test/common/mock_services/make_repo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ CVMFS testing helper script to generate a populated nested directory.
 
 Example usage:

--- a/test/common/mock_services/metalink_server.py
+++ b/test/common/mock_services/metalink_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 __version__ = "0.1"
 

--- a/test/common/mock_services/silent_socket.py
+++ b/test/common/mock_services/silent_socket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import socket

--- a/test/src/628-pythonwrappedcvmfsserver/do_install.py
+++ b/test/src/628-pythonwrappedcvmfsserver/do_install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from LbCVMFS import Tools
 

--- a/test/src/647-bearercvmfs/cvmfs_scitoken_helper.py
+++ b/test/src/647-bearercvmfs/cvmfs_scitoken_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 # This is a simple echo script


### PR DESCRIPTION
This was seen in client tests:

	-- Testing Cancel file system request (Mon Jul  7 13:03:04 UTC 2025 / test number 096)
	restarting autofs...
	using systemd
	# Created by CVMFS integration tests
	CVMFS_SERVER_APACHE_RELOAD_IS_RESTART=true
	*** install a desaster cleanup
	*** mount repository
	*** run a silent HTTP server
	Calling /home/sftnight/cvmfs/test/common/mock_services/silent_socket.py TCP 8019
	silent server started with PID 69599
	env: 'python': No such file or directory