### PR TITLE
server: remove code working around absense of jq

### DIFF
--- a/cvmfs/server/cvmfs_server_json.sh
+++ b/cvmfs/server/cvmfs_server_json.sh
@@ -146,30 +146,8 @@ get_editor() {
 }
 
 
-has_jq() {
-  which jq > /dev/null 2>&1
-}
-
-check_jq() {
-  local hasjq=1
-  if ! has_jq; then
-    hasjq=0
-    echo 1>&2
-    echo "Warning: Didn't find 'jq' on your system. It is your responsibility" 1>&2
-    echo "         to produce a valid JSON file." 1>&2
-    echo 1>&2
-    read -p "  Press any key to continue..." nirvana
-  fi
-  echo $hasjq
-}
-
-
 validate_json() {
   local json_file="$1"
-
-  if ! which jq > /dev/null 2>&1; then
-    return 0 # no jq -> assume JSON is valid
-  fi
 
   jq '.' $json_file 2>&1
 }
@@ -178,12 +156,10 @@ validate_json() {
 edit_json_until_valid() {
   local json_file="$1"
   local editor=$(get_editor)
-  local has_jq=$(check_jq)
 
   local retval=0
   while true; do
     $editor $json_file < $(tty) > $(tty) 2>&1
-    [ $has_jq -eq 1 ] || break
 
     local jq_output=""
     local retry=""
@@ -212,11 +188,6 @@ edit_json_until_valid() {
 # @param variable  the status variable to update
 # @param value     the value to set the variable to
 update_repo_status() {
-  if ! has_jq; then
-    # silently do nothing if there is no jq
-    return
-  fi
-
   local name="$1"
   local variable="$2"
   local value="$3"
@@ -239,8 +210,6 @@ update_repo_status() {
 
 
 get_json_field() {
-  has_jq || return ""
-
   local snippet="$1"
   local field="$2"
   echo "$snippet" | jq -r ".$field // empty"


### PR DESCRIPTION
cvmfs_server's JSON utility code makes effort to detect absense of jq. This on its own produces a side-effect of jq absense not showing up in error logs.

If jq is absent, there were different code paths to handle the task at hand, sometimes giving a warning ("it's your responsibility to ensure JSON is valid").

Some of such fallback code paths simply cannot count as accomplishing the task:

* update_repo_status() does nothing
* get_json_field() always provides empty result

This seems risky - it is surprising upon discovery, so it may produce surprising results in operation. Hopefully jq is ubiquitous enough to not need any workarounds.

There seems to be no testing for jq-less configuration, because there is a shell syntax error, as can be seen in test 689. I only stumbled upon this because of running tests in a different setting.

	Verifying integrity of test.cern.ch...
	Inspecting log of references
	Inspecting tag database
	[inspecting catalog] 0b9e8b479c3d6a36e0c1f5a7cfac3492a8feeb04 at /
	no problems found
	/usr/bin/cvmfs_server: line 2206: return: : numeric argument required
	*** setup cleanup handler

This change doesn't make it safe to operate cvmfs_server in jq-less configuration, because [cvmfs_server doesn't use strict mode](https://github.com/cvmfs/cvmfs/issues/3902) (at least `set -eo pipefail`), and running it without jq will not abort the execution immediately upon failure to launch jq, which may cause damage. Consumers of packaged cvmfs which properly declare runtime dependency on jq are safe, though. If this change is not acceptable on its own, it can wait until possibly cvmfs_server adopts necessary elements of strict mode.