### PR TITLE
Allocate cvmfs_server lock file descriptors dynamically

### DIFF
--- a/.github/workflows/test_cvmfs_server.yml
+++ b/.github/workflows/test_cvmfs_server.yml
@@ -11,7 +11,7 @@ on:
       branches: ['devel', 'cvmfs*']
 
 jobs:
-  docker:
+  test_cvmfs_server:
     name: "test_cvmfs_server"
     runs-on: ubuntu-latest
     steps:
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Test CVMFS server util
         run: | 
+           sudo mkdir -p /var/spool/cvmfs
            cd cvmfs/server
-           . test_cvmfs_server_util.sh
+           sh ./test_cvmfs_server_util.sh
 

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -828,7 +828,7 @@ acquire_update_lock()
     fi
 
     echo "waiting for another update to finish..."
-    if ! wait_and_acquire_lock $update_lock; then
+    if ! acquire_lock $update_lock 1; then
       echo "failed to acquire update lock"
       to_syslog_for_repo $name "did not $update_type (locking issues)"
       return 1
@@ -877,7 +877,7 @@ acquire_gc_lock()
     fi
 
     echo "Waiting for gc on $name to finish..."
-    if ! wait_and_acquire_lock $gc_lock; then
+    if ! acquire_lock $gc_lock 1; then
       echo "failed to acquire gc lock"
       to_syslog_for_repo $name "did not $check_type (locking issues)"
       return 1

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -362,23 +362,24 @@ __hc_transition() {
 
 ### Locking functions
 
-declare -A _lock_fds
+_lock_fds=""
+_lock_paths=""
 
 acquire_lock() {
   local path="$1"
   local wait_for_lock="${2:-0}"
   local lock_file="${path}.lock"
+  local lock_fd
   while true; do
-    exec {_lock_fds[$path]}<>${lock_file}
+    exec {lock_fd}<>${lock_file}
     if [ $wait_for_lock -eq 0 ]; then
-      if ! flock -n ${_lock_fds[$path]}; then
+      if ! flock -n ${lock_fd}; then
         # didn't get it, clean up and return failure
-        exec {_lock_fds[$path]}<&-
-        unset _lock_fds[$path]
+        exec {lock_fd}<&-
         return 1
       fi
     else
-      flock ${_lock_fds[$path]}
+      flock ${lock_fd}
     fi
     # now have the lock
     if [ -f $lock_file ]; then
@@ -386,17 +387,49 @@ acquire_lock() {
       break
     fi
     # was removed by former lock holder; close and try again
-    exec {_lock_fds[$path]}<&-
+    exec {lock_fd}<&-
   done
+  # add the fd number and path to the two lists
+  _lock_fds="$_lock_fds $lock_fd"
+  _lock_paths="$_lock_paths $path"
 }
 
 
 release_lock() {
   local path="$1"
   local lock_file="${path}.lock"
+  local lock_fd=-1
+  # Find the index of $path in $_lock_paths and from that find $lock_fd.
+  # Would be much easier with an associative array if we could rely on bash.
+  local index=0
+  local lock_index=0
+  local lock_path
+  local new_paths=""
+  for lock_path in $_lock_paths; do
+    let index+=1
+    if [ "$path" = "$lock_path" ]; then
+      lock_index=$index
+    else
+      new_paths="$new_paths $lock_path"
+    fi
+  done
+  [ "$lock_index" != 0 ] || die "attempt to release $path lock when it was not acquired"
+  index=0
+  local fd
+  local new_fds
+  for fd in $_lock_fds; do
+    let index+=1
+    if [ "$index" = "$lock_index" ]; then
+      lock_fd=$fd
+    else
+      new_fds="$new_fds $fd"
+    fi
+  done
+  [ "$lock_fd" != -1 ] || die "_lock_fds and _lock_paths out of sync while releasing $path lock"
+  _lock_fds="$new_fds"
+  _lock_paths="$new_paths"
   rm -f $lock_file
-  exec {_lock_fds[$path]}<&-
-  unset _lock_fds[$path]
+  exec {lock_fd}<&-
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -637,12 +637,14 @@ check_overlayfs_version() {
     if compare_versions "$krnl_version" -ge "$required_version" ; then
       # If the mounted filesystem name is long df will split output into two
       #  lines, so use tail -n +2 to skip first line and echo to combine them
-      local scratch_fstype=$(echo $(df -T /var/spool/cvmfs | tail -n +2) | awk {'print $2'})
+      local scratch_line="$(echo $(df -T /var/spool/cvmfs | tail -n +2))"
+      local scratch_fstype=$(echo $scratch_line | awk {'print $2'})
       if [ "x$scratch_fstype" = "xext3" ] || [ "x$scratch_fstype" = "xext4" ] ; then
         return 0
       fi
       if [ "x$scratch_fstype" = "xxfs" ] ; then
-        if [ "x$(xfs_info /var/spool/cvmfs 2>/dev/null | grep ftype=1)" != "x" ] ; then
+        local scratch_fsmnt=$(echo $scratch_line | awk {'print $7'})
+        if [ "x$(xfs_info $scratch_fsmnt 2>/dev/null | grep ftype=1)" != "x" ] ; then
           return 0
         else
           echo "XFS with ftype=0 is not supported for /var/spool/cvmfs. XFS with ftype=1 is required"

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -363,8 +363,10 @@ __hc_transition() {
 # Find an available file descriptor
 find_available_fd()
 {
-  local fd=11
-  local max=$(ulimit -n) 
+  # dash only supports single-digit file descriptors so the number
+  # of locks available is limited
+  local fd=3
+  local max=10
   while [ $fd -lt $max ]; do
     if [ ! -e /proc/$$/fd/$fd ]; then
       echo $fd
@@ -372,8 +374,7 @@ find_available_fd()
     fi
     fd=$((fd + 1))
   done
-  echo "No file descriptor available" >&2
-  return 1
+  die "No file descriptor available"
 }
 
 ### Locking functions

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -366,21 +366,28 @@ declare -A _lock_fds
 
 acquire_lock() {
   local path="$1"
+  local wait_for_lock="${2:-0}"
   local lock_file="${path}.lock"
-  exec {_lock_fds[$path]}<>${lock_file}
-  if ! flock -n ${_lock_fds[$path]}; then
+  while true; do
+    exec {_lock_fds[$path]}<>${lock_file}
+    if [ $wait_for_lock -eq 0 ]; then
+      if ! flock -n ${_lock_fds[$path]}; then
+        # didn't get it, clean up and return failure
+        exec {_lock_fds[$path]}<&-
+        unset _lock_fds[$path]
+        return 1
+      fi
+    else
+      flock ${_lock_fds[$path]}
+    fi
+    # now have the lock
+    if [ -f $lock_file ]; then
+      # was not removed by the former lock holder, good
+      break
+    fi
+    # was removed by former lock holder; close and try again
     exec {_lock_fds[$path]}<&-
-    unset _lock_fds[$path]
-    return 1
-  fi
-}
-
-
-wait_and_acquire_lock() {
-  local path="$1"
-  local lock_file="${path}.lock"
-  exec {_lock_fds[$path]}<>${lock_file}
-  flock ${_lock_fds[$path]}
+  done
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -362,20 +362,25 @@ __hc_transition() {
 
 ### Locking functions
 
+declare -A _lock_fds
 
 acquire_lock() {
   local path="$1"
   local lock_file="${path}.lock"
-  exec 9<>${lock_file}
-  flock -n 9
+  exec {_lock_fds[$path]}<>${lock_file}
+  if ! flock -n ${_lock_fds[$path]}; then
+    exec {_lock_fds[$path]}<&-
+    unset _lock_fds[$path]
+    return 1
+  fi
 }
 
 
 wait_and_acquire_lock() {
   local path="$1"
   local lock_file="${path}.lock"
-  exec 9<>${lock_file}
-  flock 9
+  exec {_lock_fds[$path]}<>${lock_file}
+  flock ${_lock_fds[$path]}
 }
 
 
@@ -383,7 +388,8 @@ release_lock() {
   local path="$1"
   local lock_file="${path}.lock"
   rm -f $lock_file
-  exec 9<&-
+  exec {_lock_fds[$path]}<&-
+  unset _lock_fds[$path]
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -360,6 +360,22 @@ __hc_transition() {
 }
 
 
+# Find an available file descriptor
+find_available_fd()
+{
+  local fd=11
+  local max=$(ulimit -n) 
+  while [ $fd -lt $max ]; do
+    if [ ! -e /proc/$$/fd/$fd ]; then
+      echo $fd
+      return
+    fi
+    fd=$((fd + 1))
+  done
+  echo "No file descriptor available" >&2
+  return 1
+}
+
 ### Locking functions
 
 _lock_fds=""
@@ -371,11 +387,12 @@ acquire_lock() {
   local lock_file="${path}.lock"
   local lock_fd
   while true; do
-    exec {lock_fd}<>${lock_file}
+    lock_fd=$(find_available_fd)
+    eval "exec ${lock_fd}<>${lock_file}"
     if [ $wait_for_lock -eq 0 ]; then
       if ! flock -n ${lock_fd}; then
         # didn't get it, clean up and return failure
-        exec {lock_fd}<&-
+        eval "exec ${lock_fd}<&-"
         return 1
       fi
     else
@@ -387,7 +404,7 @@ acquire_lock() {
       break
     fi
     # was removed by former lock holder; close and try again
-    exec {lock_fd}<&-
+    eval "exec ${lock_fd}<&-"
   done
   # add the fd number and path to the two lists
   _lock_fds="$_lock_fds $lock_fd"
@@ -406,7 +423,7 @@ release_lock() {
   local lock_path
   local new_paths=""
   for lock_path in $_lock_paths; do
-    let index+=1
+    index=$((index + 1))
     if [ "$path" = "$lock_path" ]; then
       lock_index=$index
     else
@@ -418,7 +435,7 @@ release_lock() {
   local fd
   local new_fds
   for fd in $_lock_fds; do
-    let index+=1
+    index=$((index + 1))
     if [ "$index" = "$lock_index" ]; then
       lock_fd=$fd
     else
@@ -429,7 +446,7 @@ release_lock() {
   _lock_fds="$new_fds"
   _lock_paths="$new_paths"
   rm -f $lock_file
-  exec {lock_fd}<&-
+  eval "exec ${lock_fd}<&-"
 }
 
 

--- a/cvmfs/server/test_cvmfs_server_util.sh
+++ b/cvmfs/server/test_cvmfs_server_util.sh
@@ -8,8 +8,13 @@
 
 . ./cvmfs_server_util.sh
 
+FAILS=0
+
 print_check() {
     echo "Got: $1 Expected: $2"
+    if [ "$1" != "$2" ]; then
+        FAILS=$(($FAILS + 1))
+    fi
 }
 
 ### Testing check_overlayfs_version
@@ -27,54 +32,53 @@ cvmfs_sys_is_redhat() {
     return $mock_is_redhat
 }
 
-
 mock_is_redhat=0 # true
 
 mock_kernel_version="4.2.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+print_check $(check_overlayfs_version >&2; echo $?) 0
 
 mock_kernel_version="4.2.0-100"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+print_check $(check_overlayfs_version >&2; echo $?) 0
 
 mock_kernel_version="3.10.0-493"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+print_check $(check_overlayfs_version >&2; echo $?) 0
 
 mock_kernel_version="3.10.0-999"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+print_check $(check_overlayfs_version >&2; echo $?) 0
 
 mock_kernel_version="3.10.0-492"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 1
+print_check $(check_overlayfs_version >&2; echo $?) 1
 
 mock_kernel_version="3.10.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 1
+print_check $(check_overlayfs_version >&2; echo $?) 1
 
 mock_is_redhat=1 # False
 
 mock_kernel_version="3.10.0-493"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 1
+print_check $(check_overlayfs_version >&2; echo $?) 1
 
 mock_kernel_version="3.10.0-492"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 1
+print_check $(check_overlayfs_version >&2; echo $?) 1
 
 mock_kernel_version="3.10.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 1
+print_check $(check_overlayfs_version >&2; echo $?) 1
 
 mock_kernel_version="4.2.0"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+print_check $(check_overlayfs_version >&2; echo $?) 0
 
 mock_kernel_version="4.2.0-100"
 printf "Kernel version: %s; RedHat: %s\n" $mock_kernel_version $mock_is_redhat
-print_check $(check_overlayfs_version >/dev/null; echo $?) 0
+print_check $(check_overlayfs_version >&2; echo $?) 0
 
 
 ################################################################################
@@ -107,3 +111,127 @@ print_check $(is_valid_repo_name $mock_repo_name; echo $?) 1
 mock_repo_name="_test.cern.ch"
 echo "Checking validity of repository name '$mock_repo_name'"
 print_check $(is_valid_repo_name $mock_repo_name; echo $?) 1
+
+#--------------------------------
+
+echo "Starting two background processes b & c to test locks"
+
+die() { echo "$@" >&2; exit 1; }
+
+LOCKDIR="$(mktemp -d)"
+
+RET=0
+
+# PS4 gives extra header in bash when set -x is enabled, showing active proc
+PS4='a+ '
+
+# Lock names starting with "lock" are the real tests; lock names starting
+# with "shake" are just for handshakes between processes although they also
+# help to test the functions.
+
+# Can't use simple "( ... ) &" form because that does not re-initialize $$,
+# which is needed by the lock functions.  Variables we don't want expanded
+# by the parent shell need to be escaped with a backslash.
+$SHELL <<!EOF! &
+. ./cvmfs_server_util.sh
+die() { echo "\$@" >&2; exit 1; }
+PS4='b+ '
+RET=0
+acquire_lock $LOCKDIR/lock1 1
+echo "b has lock1"
+if ! acquire_lock $LOCKDIR/lock2; then
+  echo "proc1 unexpectedly couldn't acquire lock2" >&2
+  RET=\$((\$RET + 1))
+fi
+echo "b has lock2"
+acquire_lock $LOCKDIR/shake1 1
+echo "b sent shake1"
+while ! check_lock $LOCKDIR/shake3; do
+  echo "b waiting for shake3"
+  sleep 1
+done
+release_lock $LOCKDIR/shake1
+release_lock $LOCKDIR/lock2
+echo "b released lock2"
+while ! check_lock $LOCKDIR/shake5; do
+  echo "b waiting for shake5"
+  sleep 1
+done
+release_lock $LOCKDIR/lock1
+echo "b released lock1"
+exit \$RET
+!EOF!
+PIDB=$!
+
+$SHELL <<!EOF! &
+. ./cvmfs_server_util.sh
+die() { echo "\$@" >&2; exit 1; }
+PS4='c+ '
+while ! check_lock $LOCKDIR/shake2; do
+  echo "c waiting for shake2"
+  sleep 1
+done
+echo "c waiting for lock2"
+acquire_lock $LOCKDIR/lock2 1
+echo "c has lock2"
+acquire_lock $LOCKDIR/shake4 1
+echo "c sent shake4"
+while ! check_lock $LOCKDIR/shake5; do
+  echo "c waiting for shake5"
+  sleep 1
+done
+release_lock $LOCKDIR/shake4
+release_lock $LOCKDIR/lock2
+echo "c released lock2"
+!EOF!
+PIDC=$!
+
+# set a timeout
+MYPID=$$
+(sleep 30; set -x; rm -f $LOCKDIR; kill $PIDB; kill $PIDC; kill $MYPID) 2>/dev/null &
+PIDTIMEOUT=$!
+
+while ! check_lock $LOCKDIR/shake1; do
+  echo "a waiting for shake1"
+  sleep 1
+done
+# b should have lock1 & lock2 now; tell c to wait for lock2
+acquire_lock $LOCKDIR/shake2 1
+echo "a sent shake2"
+# make sure it has enough time to start waiting
+echo "a sleeping 3 seconds"
+sleep 3
+# make sure c doesn't have lock2 yet
+if check_lock $LOCKDIR/shake4; then
+  echo "shake5 is unexpectedly held too early" >&2
+  RET=$(($RET + 1))
+fi
+# tell b to release lock2
+acquire_lock $LOCKDIR/shake3 1
+echo "a sent shake3"
+release_lock $LOCKDIR/shake2
+# wait for b's acknowledgement
+while ! check_lock $LOCKDIR/shake4; do
+  echo "a waiting for shake4"
+  sleep 1
+done
+release_lock $LOCKDIR/shake3
+acquire_lock $LOCKDIR/shake5 1
+echo "a sent shake5"
+
+wait $PIDB
+RET=$(($RET + $?))
+
+wait $PIDC
+RET=$(($RET + $?))
+
+release_lock $LOCKDIR/shake5
+
+kill $PIDTIMEOUT 2>/dev/null
+wait $PIDTIMEOUT 2>/dev/null
+
+rm -rf $LOCKDIR
+
+FAILS=$(($FAILS + $RET))
+
+exit $FAILS


### PR DESCRIPTION
Instead of always using fd 9 for locks, open the next available file descriptor and keep track of it.

- Fixes #3909

I thought about adding some unit tests of these functions to [test_cvmfs_server_util.sh](https://github.com/cvmfs/cvmfs/blob/devel/cvmfs/server/test_cvmfs_server_util.sh) but I haven't been able to figure out if it is being invoked anywhere.  Maybe it needs to be added to [run_unittests.sh](https://github.com/cvmfs/cvmfs/blob/devel/ci/run_unittests.sh)?