### PR TITLE
Move the no collectable repos message to gc.log

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -69,6 +69,8 @@ cvmfs_server_gc() {
   names=$(get_or_guess_multiple_repository_names "$@")
   check_multiple_repository_existence "$names"
 
+  local gclog=/var/log/cvmfs/gc.log
+
   if [ $all_collect -ne 0 ]; then
     # reduce the names to those that are collectable
     local collectable_names
@@ -96,7 +98,7 @@ cvmfs_server_gc() {
       done
       names="`echo $collectable_names`"
       if [ -z "$names" ]; then
-        echo "There are no garbage-collectable repositories that were collected upstream"
+        echo "At `date` there are no garbage-collectable repositories that were collected upstream" >> $gclog
         exit
       fi
     fi
@@ -203,8 +205,6 @@ cvmfs_server_gc() {
                   "$preserve_timestamp"         \
                   "$deletion_log"
     else
-      local log=/var/log/cvmfs/gc.log
-
       (
       echo
       echo "Starting $name at `date`"
@@ -224,7 +224,7 @@ cvmfs_server_gc() {
         echo "ERROR from cvmfs_server gc!" >&2
       fi
       echo "Finished $name at `date`"
-      ) >> $log 2>&1
+      ) >> $gclog 2>&1
 
       # Always return success because this is used from cron and we
       #  don't want cron sending an email every time something fails.


### PR DESCRIPTION
All messages for `gc -a` should go to gc.log instead of stdout.  It is typically run from cron, which ends up sending an email if anything goes to stdout.  This is a follow-on to #3895.