### PR TITLE
Correct PCT Close in cvmfs_open

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1313,7 +1313,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
         perf::Dec(file_system_->no_open_files());
       LogCvmfs(kLogCvmfs, kLogSyslogErr, "open file descriptor limit exceeded");
       // not returning an fd, so close the page cache tracker entry if required
-      if (!dirent.IsDirectIo()) {
+      if (!dirent.IsDirectIo() && !open_directives.direct_io) {
         fuse_remounter_->fence()->Enter();
         mount_point_->page_cache_tracker()->Close(ino);
         fuse_remounter_->fence()->Leave();
@@ -1327,7 +1327,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
 
   // fd < 0
   // the download has failed. Close the page cache tracker entry if required
-  if (!dirent.IsDirectIo()) {
+  if (!dirent.IsDirectIo() && !open_directives.direct_io) {
     fuse_remounter_->fence()->Enter();
     mount_point_->page_cache_tracker()->Close(ino);
     fuse_remounter_->fence()->Leave();


### PR DESCRIPTION
From issue #3520: 

`cvmfs_open()` calls `mount_point_->page_cache_tracker()->Close(ino);` in the case of an error. https://github.com/cvmfs/cvmfs/blob/42e04529dc8eccb52bf62b27b220aa54b660681a/cvmfs/cvmfs.cc#L1319-L1323 and
https://github.com/cvmfs/cvmfs/blob/42e04529dc8eccb52bf62b27b220aa54b660681a/cvmfs/cvmfs.cc#L1332-L1336

This call is gated on `dirent.IsDirectIo()`. However, it is possible that the original call to PageCacheTracker::Open() for a non direct-IO file actually treats the file as direct, and does not do a `map_.Insert()`. https://github.com/cvmfs/cvmfs/blob/42e04529dc8eccb52bf62b27b220aa54b660681a/cvmfs/glue_buffer.cc#L371-L379

The error-pathway close may therefore incorrectly call `PageCacheTracker::Close()` if the file is non-directIO but PageCacheTracker()::Open() treated it as one. This can cause an assert, as the inode isn't found in `map_`, as expected.

Sequence of events is:
* `cvmfs_open()` calls `PageCacheTracker::Open()` for a non-directIO file
* `PageCacheTracker::Open()` detects a page cache mismatch and treats the file as directIO, omitting an insert of `ino` into `map_`
* `cvmfs_open()` encounters a file-handle exhaustion error and enters the error pathway. It calls `PageCacheTracker::Close()`
* `PageCacheTracker::Close()` asserts because the inode is not found in `map_`

Fix is to change  the `cvmfs_open()` error pathways to:
```
      if (!dirent.IsDirectIo() && !open_directives.direct_io) {
        fuse_remounter_->fence()->Enter();
        mount_point_->page_cache_tracker()->Close(ino);
        fuse_remounter_->fence()->Leave();
      }
```
