### PR TITLE
Add unittest infrastructure for FUSE callbacks

### DIFF
--- a/.github/workflows/ci_ubuntu_unittest.yaml
+++ b/.github/workflows/ci_ubuntu_unittest.yaml
@@ -75,4 +75,4 @@ jobs:
           ./build/test/unittests/cvmfs_unittests_mockfuse
       - name: Run Unittests - Regular
         run: |
-          ./build/test/unittests/cvmfs_unittests
+          ./build/test/unittests/cvmfs_unittests --gtest_filter="-T_Namespace.*"

--- a/.github/workflows/ci_ubuntu_unittest.yaml
+++ b/.github/workflows/ci_ubuntu_unittest.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Build CVMFS
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install devscripts ccache apache2 libapache2-mod-wsgi-py3
+          sudo apt-get -y install devscripts ccache apache2 libapache2-mod-wsgi-py3 gdb
           export CVMFS_EXTERNALS_PREFIX=/home/runner/.cache/cvmfs_externals_install
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache
           mkdir build; cd build

--- a/.github/workflows/ci_ubuntu_unittest.yaml
+++ b/.github/workflows/ci_ubuntu_unittest.yaml
@@ -1,0 +1,78 @@
+name: unittest_ubuntu
+on:
+  pull_request:
+    branches: [devel, cvmfs*]
+  push:
+  workflow_dispatch:
+
+jobs:
+  unittest_ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+
+      - id: lsb-release
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            source /etc/lsb-release
+            echo "id=${DISTRIB_ID}" >> $GITHUB_OUTPUT
+            echo "release=${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
+            echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUT
+            echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+            echo "id-release=${DISTRIB_ID}-${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
+            echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            echo "id-release=macOS-$(sw_vers -productVersion)" >> $GITHUB_OUTPUT
+            echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Create cache directories
+        run: |
+          mkdir -p /home/runner/.cache
+      - name: Restore CI cache
+        uses: actions/cache/restore@v4
+        id: cvmfs-ci-cache-restore
+        with:
+          path: /home/runner/.cache/
+          key: v3-cvmfs-ci-cache-${{ steps.lsb-release.outputs.id-release }}-${{ steps.lsb-release.outputs.arch }}
+      - name: Check for builddep package
+        id: cvmfs-builddep-check
+        run: |
+          if [ -f "/home/runner/.cache/cvmfs-build-deps_*_all.deb" ]; then
+            # we could add the hash of the control file here
+            echo "package_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "package_exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Generate build-dep metapackage
+        if: steps.cvmfs-builddep-check.outputs.package_exists != 'true'
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y devscripts equivs
+          mk-build-deps ./packaging/debian/cvmfs/control
+          mv cvmfs-build-deps_*_all.deb /home/runner/.cache
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y /home/runner/.cache/cvmfs-build-deps_*_all.deb
+      - name: Hash Externals
+        id: get-externals-hash
+        run: |
+          echo "hash=$(ls -Rs externals | sha1sum)" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Build CVMFS
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install devscripts ccache apache2 libapache2-mod-wsgi-py3
+          export CVMFS_EXTERNALS_PREFIX=/home/runner/.cache/cvmfs_externals_install
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          mkdir build; cd build
+          cmake .. -DBUILD_UNITTESTS=ON
+          make -j 8
+          cd ..
+      - name: Run Unittests - Mockfuse
+        run: |
+          ./build/test/unittests/cvmfs_unittests_mockfuse
+      - name: Run Unittests - Regular
+        run: |
+          ./build/test/unittests/cvmfs_unittests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ project (${PROJECT_NAME})
 
 message ("Running CMake version ${CMAKE_VERSION}")
 
-
 #
 # The version numbers
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ project (${PROJECT_NAME})
 
 message ("Running CMake version ${CMAKE_VERSION}")
 
-set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
 
 #
 # The version numbers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project (${PROJECT_NAME})
 
 message ("Running CMake version ${CMAKE_VERSION}")
 
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+
 #
 # The version numbers
 #

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1540,8 +1540,6 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 }
 
 
-
-
 /**
  * File close operation, redirected into cache.
  */

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1548,7 +1548,8 @@ static void cvmfs_release(fuse_req_t req, fuse_ino_t ino,
   const HighPrecisionTimer guard_timer(file_system_->hist_fs_release());
 
   ino = mount_point_->catalog_mgr()->MangleInode(ino);
-
+  LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_release on inode: %" PRIu64,
+  uint64_t(ino));
 
 #ifdef __APPLE__
   if (fi->fh == kFileHandleIgnore) {
@@ -2312,7 +2313,6 @@ static unsigned CheckMaxOpenFiles() {
 
   return max_open_files;
 }
-
 
 
 static int Init(const loader::LoaderExports *loader_exports) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -75,6 +75,7 @@
 #include "crypto/crypto_util.h"
 #include "crypto/hash.h"
 #include "directory_entry.h"
+#include "duplex_fuse.h"
 #include "fence.h"
 #include "fetch.h"
 #include "file_chunk.h"
@@ -119,6 +120,7 @@ using namespace std;  // NOLINT
 
 namespace cvmfs {
 
+#ifndef __TEST_CVMFS_MOCKFUSE // will be mocked in tests
 FileSystem *file_system_ = NULL;
 MountPoint *mount_point_ = NULL;
 TalkManager *talk_mgr_ = NULL;
@@ -126,6 +128,7 @@ NotificationClient *notification_client_ = NULL;
 Watchdog *watchdog_ = NULL;
 FuseRemounter *fuse_remounter_ = NULL;
 InodeGenerationInfo inode_generation_info_;
+#endif // __TEST_CVMFS_MOCKFUSE
 
 
 /**
@@ -222,7 +225,7 @@ void GetReloadStatus(bool *drainout_mode, bool *maintenance_mode) {
   *maintenance_mode = fuse_remounter_->IsInMaintenanceMode();
 }
 
-
+#ifndef __TEST_CVMFS_MOCKFUSE // will be mocked in tests
 static bool UseWatchdog() {
   if (loader_exports_ == NULL || loader_exports_->version < 2) {
     return true;  // spawn watchdog by default
@@ -232,6 +235,7 @@ static bool UseWatchdog() {
 
   return !loader_exports_->disable_watchdog;
 }
+#endif
 
 std::string PrintInodeGeneration() {
   return "init-catalog-revision: "
@@ -1536,6 +1540,8 @@ static void cvmfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 }
 
 
+
+
 /**
  * File close operation, redirected into cache.
  */
@@ -1544,8 +1550,7 @@ static void cvmfs_release(fuse_req_t req, fuse_ino_t ino,
   const HighPrecisionTimer guard_timer(file_system_->hist_fs_release());
 
   ino = mount_point_->catalog_mgr()->MangleInode(ino);
-  LogCvmfs(kLogCvmfs, kLogDebug, "cvmfs_release on inode: %" PRIu64,
-           uint64_t(ino));
+
 
 #ifdef __APPLE__
   if (fi->fh == kFileHandleIgnore) {
@@ -2158,6 +2163,8 @@ string *g_boot_error = NULL;
 __attribute__((
     visibility("default"))) loader::CvmfsExports *g_cvmfs_exports = NULL;
 
+
+#ifndef __TEST_CVMFS_MOCKFUSE // will be mocked in tests
 /**
  * Begin section of cvmfs.cc-specific magic extended attributes
  */
@@ -2309,6 +2316,7 @@ static unsigned CheckMaxOpenFiles() {
 }
 
 
+
 static int Init(const loader::LoaderExports *loader_exports) {
   g_boot_error = new string("unknown error");
   cvmfs::loader_exports_ = loader_exports;
@@ -2432,6 +2440,7 @@ static int Init(const loader::LoaderExports *loader_exports) {
 
   return loader::kFailOk;
 }
+#endif // __TEST_CVMFS_MOCKFUSE
 
 
 /**
@@ -2571,7 +2580,7 @@ static bool MaintenanceMode(const int fd_progress) {
   return true;
 }
 
-
+#ifndef __TEST_CVMFS_MOCKFUSE
 static bool SaveState(const int fd_progress, loader::StateList *saved_states) {
   string msg_progress;
 
@@ -3002,6 +3011,7 @@ static void FreeSavedState(const int fd_progress,
     }
   }
 }
+#endif
 
 
 static void __attribute__((constructor)) LibraryMain() {
@@ -3013,9 +3023,11 @@ static void __attribute__((constructor)) LibraryMain() {
   g_cvmfs_exports->fnFini = Fini;
   g_cvmfs_exports->fnGetErrorMsg = GetErrorMsg;
   g_cvmfs_exports->fnMaintenanceMode = MaintenanceMode;
+  #ifndef __TEST_CVMFS_MOCKFUSE
   g_cvmfs_exports->fnSaveState = SaveState;
   g_cvmfs_exports->fnRestoreState = RestoreState;
   g_cvmfs_exports->fnFreeSavedState = FreeSavedState;
+  #endif
   cvmfs::SetCvmfsOperations(&g_cvmfs_exports->cvmfs_operations);
 }
 

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -100,6 +100,7 @@ class FileSystem : SingleCopy, public BootFactory {
   FRIEND_TEST(T_MountPoint, CacheSettings);
   FRIEND_TEST(T_MountPoint, CheckInstanceName);
   FRIEND_TEST(T_MountPoint, CheckPosixCacheSettings);
+  FRIEND_TEST(T_Cvmfs, Basics);
 
  public:
   enum Type {
@@ -250,6 +251,9 @@ class FileSystem : SingleCopy, public BootFactory {
   Type type() { return type_; }
   cvmfs::Uuid *uuid_cache() { return uuid_cache_; }
   std::string workspace() { return workspace_; }
+
+ protected:
+  void SetHasCustomVfs(bool setting) { has_custom_sqlitevfs_ = setting; }
 
  private:
   /**
@@ -549,6 +553,10 @@ class MountPoint : SingleCopy, public BootFactory {
   void DisableCacheSymlinks();
   void EnableFuseExpireEntry();
 
+  MountPoint(const std::string &fqrn,
+             FileSystem *file_system,
+             OptionsManager *options_mgr);
+
  private:
   /**
    * The maximum TTL can be used to cap a root catalogs registered ttl.  By
@@ -598,9 +606,6 @@ class MountPoint : SingleCopy, public BootFactory {
   static const int kDefaultTelemetrySendRateSec = 5 * 60;  // 5min
   static const int kMinimumTelemetrySendRateSec = 5;       // 5sec
 
-  MountPoint(const std::string &fqrn,
-             FileSystem *file_system,
-             OptionsManager *options_mgr);
 
   void CreateStatistics();
   void CreateAuthz();

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -544,6 +544,7 @@ endif ()
 set (CVMFS_UNITTESTS_LINK_LIBRARIES "")
 list (APPEND CVMFS_UNITTESTS_LINK_LIBRARIES
       GTest::gtest
+      GTest::gmock
       ${OPENSSL_LIBRARIES}
       ${CURL_LIBRARIES}
       ${CARES_LIBRARIES} ${CARES_LDFLAGS}
@@ -560,10 +561,175 @@ list (APPEND CVMFS_UNITTESTS_LINK_LIBRARIES
       dl
 )
 
+set(CVMFS_UNITTEST_MOCKFUSE_SOURCES
+  # test steering
+  main_mockfuse.cc
+
+  # test utility functions
+  #../common/env.cc
+  ../common/testutil.cc
+  ../common/catalog_test_tools.cc
+
+  t_cvmfs.cc
+  ${CVMFS_SOURCE_DIR}/acl.cc
+  ${CVMFS_SOURCE_DIR}/authz/authz.cc
+  ${CVMFS_SOURCE_DIR}/authz/authz_curl.cc
+  ${CVMFS_SOURCE_DIR}/authz/authz_fetch.cc
+  ${CVMFS_SOURCE_DIR}/authz/authz_session.cc
+  ${CVMFS_SOURCE_DIR}/auto_umount.cc
+  ${CVMFS_SOURCE_DIR}/backoff.cc
+  ${CVMFS_SOURCE_DIR}/cache.cc
+  ${CVMFS_SOURCE_DIR}/cache_extern.cc
+  ${CVMFS_SOURCE_DIR}/cache_posix.cc
+  ${CVMFS_SOURCE_DIR}/cache_plugin/channel.cc
+  ${CVMFS_SOURCE_DIR}/cache_ram.cc
+  ${CVMFS_SOURCE_DIR}/cache_stream.cc
+  ${CVMFS_SOURCE_DIR}/cache_tiered.cc
+  ${CVMFS_SOURCE_DIR}/cache_transport.cc
+  ${CVMFS_SOURCE_DIR}/catalog.cc
+  ${CVMFS_SOURCE_DIR}/catalog_counters.cc
+  ${CVMFS_SOURCE_DIR}/catalog_downloader.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr_client.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr_ro.cc
+  ${CVMFS_SOURCE_DIR}/catalog_mgr_rw.cc
+  ${CVMFS_SOURCE_DIR}/catalog_sql.cc
+  ${CVMFS_SOURCE_DIR}/catalog_rw.cc
+  ${CVMFS_SOURCE_DIR}/catalog_virtual.cc
+  ${CVMFS_SOURCE_DIR}/clientctx.cc
+  ${CVMFS_SOURCE_DIR}/compat.cc
+  ${CVMFS_SOURCE_DIR}/compression/compression.cc
+  ${CVMFS_SOURCE_DIR}/cvmfs_suid_util.cc
+  ${CVMFS_SOURCE_DIR}/directory_entry.cc
+  ${CVMFS_SOURCE_DIR}/duplex_fuse.cc
+  ${CVMFS_SOURCE_DIR}/fd_refcount_mgr.cc
+  ${CVMFS_SOURCE_DIR}/fetch.cc
+  ${CVMFS_SOURCE_DIR}/file_chunk.cc
+  ${CVMFS_SOURCE_DIR}/file_watcher.cc
+  ${CVMFS_SOURCE_DIR}/fuse_evict.cc
+  ${CVMFS_SOURCE_DIR}/fuse_remount.cc
+  ${CVMFS_SOURCE_DIR}/gateway_util.cc
+  ${CVMFS_SOURCE_DIR}/globals.cc
+  ${CVMFS_SOURCE_DIR}/glue_buffer.cc
+  ${CVMFS_SOURCE_DIR}/history_sql.cc
+  ${CVMFS_SOURCE_DIR}/history_sqlite.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/chunk_detector.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/item.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/item_mem.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/pipeline.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_chunk.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_compress.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_hash.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_read.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_register.cc
+  ${CVMFS_SOURCE_DIR}/ingestion/task_write.cc
+  ${CVMFS_SOURCE_DIR}/json_document.cc
+  ${CVMFS_SOURCE_DIR}/kvstore.cc
+  #  ${CVMFS_SOURCE_DIR}/libcvmfs.cc
+  #  ${CVMFS_SOURCE_DIR}/libcvmfs_int.cc
+  #  ${CVMFS_SOURCE_DIR}/libcvmfs_legacy.cc
+  #  ${CVMFS_SOURCE_DIR}/libcvmfs_options.cc
+  ${CVMFS_SOURCE_DIR}/magic_xattr.cc
+  ${CVMFS_SOURCE_DIR}/malloc_arena.cc
+  ${CVMFS_SOURCE_DIR}/malloc_heap.cc
+  ${CVMFS_SOURCE_DIR}/manifest.cc
+  ${CVMFS_SOURCE_DIR}/manifest_fetch.cc
+  ${CVMFS_SOURCE_DIR}/monitor.cc
+  ${CVMFS_SOURCE_DIR}/mountpoint.cc
+  ${CVMFS_SOURCE_DIR}/network/dns.cc
+  ${CVMFS_SOURCE_DIR}/network/download.cc
+  ${CVMFS_SOURCE_DIR}/network/jobinfo.cc
+  ${CVMFS_SOURCE_DIR}/network/s3fanout.cc
+  ${CVMFS_SOURCE_DIR}/network/sink_file.cc
+  ${CVMFS_SOURCE_DIR}/network/sink_mem.cc
+  ${CVMFS_SOURCE_DIR}/network/sink_path.cc
+  ${CVMFS_SOURCE_DIR}/notification_client.cc
+  ${CVMFS_SOURCE_DIR}/notify/messages.cc
+  ${CVMFS_SOURCE_DIR}/notify/subscriber_supervisor.cc
+  ${CVMFS_SOURCE_DIR}/notify/subscriber_sse.cc
+  ${CVMFS_SOURCE_DIR}/options.cc
+  ${CVMFS_SOURCE_DIR}/pack.cc
+  ${CVMFS_SOURCE_DIR}/path_filters/dirtab.cc
+  ${CVMFS_SOURCE_DIR}/path_filters/relaxed_path_filter.cc
+  ${CVMFS_SOURCE_DIR}/pathspec/pathspec.cc
+  ${CVMFS_SOURCE_DIR}/pathspec/pathspec_pattern.cc
+  ${CVMFS_SOURCE_DIR}/quota.cc
+  ${CVMFS_SOURCE_DIR}/quota_posix.cc
+  ${CVMFS_SOURCE_DIR}/quota_listener.cc
+  ${CVMFS_SOURCE_DIR}/receiver/commit_processor.cc
+  ${CVMFS_SOURCE_DIR}/receiver/params.cc
+  ${CVMFS_SOURCE_DIR}/receiver/payload_processor.cc
+  ${CVMFS_SOURCE_DIR}/receiver/reactor.cc
+  ${CVMFS_SOURCE_DIR}/receiver/session_token.cc
+  ${CVMFS_SOURCE_DIR}/reflog.cc
+  ${CVMFS_SOURCE_DIR}/reflog_sql.cc
+  ${CVMFS_SOURCE_DIR}/repository_tag.cc
+  ${CVMFS_SOURCE_DIR}/resolv_conf_event_handler.cc
+  ${CVMFS_SOURCE_DIR}/ring_buffer.cc
+  ${CVMFS_SOURCE_DIR}/sanitizer.cc
+  ${CVMFS_SOURCE_DIR}/server_tool.cc
+  ${CVMFS_SOURCE_DIR}/session_context.cc
+  ${CVMFS_SOURCE_DIR}/signing_tool.cc
+  ${CVMFS_SOURCE_DIR}/shortstring.cc
+  ${CVMFS_SOURCE_DIR}/sql.cc
+  ${CVMFS_SOURCE_DIR}/sqlitemem.cc
+  ${CVMFS_SOURCE_DIR}/sqlitevfs.cc
+  ${CVMFS_SOURCE_DIR}/ssl.cc
+  ${CVMFS_SOURCE_DIR}/statistics.cc
+  ${CVMFS_SOURCE_DIR}/statistics_database.cc
+  ${CVMFS_SOURCE_DIR}/supervisor.cc
+  ${CVMFS_SOURCE_DIR}/swissknife.cc
+  ${CVMFS_SOURCE_DIR}/swissknife_assistant.cc
+  ${CVMFS_SOURCE_DIR}/swissknife_history.cc
+  ${CVMFS_SOURCE_DIR}/swissknife_lease_json.cc
+  ${CVMFS_SOURCE_DIR}/swissknife_lease_curl.cc
+  ${CVMFS_SOURCE_DIR}/sync_item.cc
+  ${CVMFS_SOURCE_DIR}/sync_item_dummy.cc
+  ${CVMFS_SOURCE_DIR}/sync_item_tar.cc
+  ${CVMFS_SOURCE_DIR}/sync_mediator.cc
+  ${CVMFS_SOURCE_DIR}/sync_union.cc
+  ${CVMFS_SOURCE_DIR}/sync_union_tarball.cc
+  ${CVMFS_SOURCE_DIR}/talk.cc
+  ${CVMFS_SOURCE_DIR}/telemetry_aggregator.cc
+  ${CVMFS_SOURCE_DIR}/telemetry_aggregator_influx.cc
+  ${CVMFS_SOURCE_DIR}/tracer.cc
+  ${CVMFS_SOURCE_DIR}/upload.cc
+  ${CVMFS_SOURCE_DIR}/upload_facility.cc
+  ${CVMFS_SOURCE_DIR}/upload_local.cc
+  ${CVMFS_SOURCE_DIR}/upload_gateway.cc
+  ${CVMFS_SOURCE_DIR}/upload_s3.cc
+  ${CVMFS_SOURCE_DIR}/upload_spooler_definition.cc
+  ${CVMFS_SOURCE_DIR}/url.cc
+  ${CVMFS_SOURCE_DIR}/whitelist.cc
+  ${CVMFS_SOURCE_DIR}/wpad.cc
+  ${CVMFS_SOURCE_DIR}/xattr.cc
+
+  cache.pb.cc cache.pb.h
+)
+
+# Add file watcher implementation for mockfuse tests
+if (MACOSX)
+  list (APPEND CVMFS_UNITTEST_MOCKFUSE_SOURCES ${CVMFS_SOURCE_DIR}/file_watcher_kqueue.cc)
+else ()
+  if (CVMFS_ENABLE_INOTIFY)
+    list (APPEND CVMFS_UNITTEST_MOCKFUSE_SOURCES ${CVMFS_SOURCE_DIR}/file_watcher_inotify.cc)
+  endif ()
+endif ()
+
+add_executable (cvmfs_unittests_mockfuse ${CVMFS_UNITTEST_MOCKFUSE_SOURCES})
+add_dependencies (cvmfs_unittests_mockfuse cache.pb.generated-unittests)
+set_target_properties (cvmfs_unittests_mockfuse PROPERTIES
+	COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS}  -g"
+)
+target_link_libraries (cvmfs_unittests_mockfuse
+                       cvmfs_crypto
+                       cvmfs_util
+		       ${FUSE3_LIBRARIES}
+                       ${CVMFS_UNITTESTS_LINK_LIBRARIES})
+
 add_executable (cvmfs_unittests ${CVMFS_UNITTEST_SOURCES})
 add_dependencies (cvmfs_unittests cache.pb.generated-unittests)
 set_target_properties (cvmfs_unittests PROPERTIES
-                       COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS}"
+	COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS}"
 )
 target_link_libraries (cvmfs_unittests
                        cvmfs_crypto

--- a/test/unittests/main_mockfuse.cc
+++ b/test/unittests/main_mockfuse.cc
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cassert>
+
+#include "crypto/crypto_util.h"
+//#include "env.h"
+#include "monitor.h"
+
+int main(int argc, char **argv) {
+  Watchdog *watchdog = Watchdog::Create(NULL);
+  assert(watchdog != NULL);
+  //  watchdog->Spawn("/tmp/stacktrace.cvmfs_unittests");
+  //CvmfsEnvironment *env = new CvmfsEnvironment(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  //::testing::AddGlobalTestEnvironment(env);
+  // Open /dev/[u]random before starting the unit tests to make sure that the
+  // counting of open file descriptors is accurate
+  crypto::InitRng();
+  int result = RUN_ALL_TESTS();
+  delete watchdog;
+  return result;
+}

--- a/test/unittests/t_cvmfs.cc
+++ b/test/unittests/t_cvmfs.cc
@@ -1,0 +1,301 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+
+#define CVMFS_DUPLEX_FUSE_H_
+#define __TEST_CVMFS_MOCKFUSE
+#define CVMFS_USE_LIBFUSE 3
+#define FUSE_USE_VERSION  31
+#include <fuse3/fuse.h>
+#include <fuse3/fuse_lowlevel.h>
+#include <fuse3/fuse_opt.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "cache_posix.h"
+#include "catalog_mgr.h"
+#include "catalog_mgr_client.h"
+#include "cvmfs.h"
+#include "file_chunk.h"
+#include "fuse_inode_gen.h"
+#include "fuse_remount.h"
+#include "glue_buffer.h"
+#include "monitor.h"
+#include "mountpoint.h"
+#include "notification_client.h"
+#include "options.h"
+#include "quota_listener.h"
+#include "quota_posix.h"
+#include "talk.h"
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::StrictMock;
+
+class MockMountPoint;
+// Mock classes for testing cvmfs_release
+class MockCatalogManager : public catalog::ClientCatalogManager {
+ public:
+  MockCatalogManager(MountPoint *mountpoint)
+      : ClientCatalogManager(mountpoint) { };
+  MOCK_CONST_METHOD1(MangleInode, fuse_ino_t(fuse_ino_t ino));
+};
+
+class MockPageCacheTracker {
+ public:
+  MockPageCacheTracker() { }
+  virtual ~MockPageCacheTracker() { }
+
+  MOCK_METHOD1(Close, void(fuse_ino_t inode));
+  MOCK_CONST_METHOD1(IsStale, bool(const catalog::DirectoryEntry &dirent));
+  MOCK_METHOD0(GetEvictRaii, glue::PageCacheTracker::EvictRaii());
+  MOCK_METHOD3(GetInfoIfOpen,
+               bool(uint64_t inode, shash::Any *hash, struct stat *info));
+  MOCK_METHOD3(Open,
+               glue::PageCacheTracker::OpenDirectives(uint64_t inode,
+                                                      const shash::Any &hash,
+                                                      const struct stat &info));
+  MOCK_METHOD0(OpenDirect, glue::PageCacheTracker::OpenDirectives());
+  MOCK_METHOD0(Disable, void());
+  MOCK_METHOD1(Evict, void(uint64_t inode));
+};
+
+class MockCacheManager : public PosixCacheManager {
+ public:
+  virtual int Close(int fd) override final { return 0; }
+};
+
+class MockMountPoint : public MountPoint {
+ public:
+  MockMountPoint(const std::string &fqrn,
+                 FileSystem *file_system,
+                 OptionsManager *options_mgr)
+      : MountPoint(fqrn, file_system, options_mgr) { };
+  ~MockMountPoint() { };
+  NiceMock<MockPageCacheTracker> *page_cache_tracker() {
+    return mock_page_cache_tracker_;
+  }
+  NiceMock<MockCatalogManager> *catalog_mgr() { return mock_catalog_mgr_; }
+  NiceMock<ChunkTables> *chunk_tables() { return mock_chunk_tables_; }
+
+
+  NiceMock<MockPageCacheTracker> *mock_page_cache_tracker_;
+  NiceMock<MockCatalogManager> *mock_catalog_mgr_;
+  NiceMock<ChunkTables> *mock_chunk_tables_;
+};
+
+class MockFileSystem : public FileSystem {
+ public:
+  void FixCustomVfs() { this->SetHasCustomVfs(false); }
+  NiceMock<MockCacheManager> *cache_mgr() { return mock_cache_mgr_; }
+
+  NiceMock<MockCacheManager> *mock_cache_mgr_;
+};
+
+
+static int g_fuseReplyErr = -999;
+namespace cvmfs {
+NiceMock<MockFileSystem> *file_system_ = NULL;
+NiceMock<MockMountPoint> *mount_point_ = NULL;
+TalkManager *talk_mgr_ = NULL;
+NotificationClient *notification_client_ = NULL;
+Watchdog *watchdog_ = NULL;
+FuseRemounter *fuse_remounter_ = NULL;
+InodeGenerationInfo inode_generation_info_;
+NiceMock<MockCacheManager> *mock_cache_mgr_ = NULL;
+
+
+// Mock implementation of reply functions
+int fuse_reply_err(fuse_req_t req, int err) {
+  g_fuseReplyErr = err;  // TODO: set response in req instead of global for
+                         // multithreaded tests
+  printf("[FUSE REPLY] Error: %d (%s)\n", err, strerror(err));
+  return 0;
+}
+
+
+static void cvmfs_release_test(fuse_req_t req, fuse_ino_t ino,
+                               struct fuse_file_info *fi) {
+  const HighPrecisionTimer guard_timer(file_system_->hist_fs_release());
+  ino = mount_point_->catalog_mgr()->MangleInode(ino);
+  mount_point_->page_cache_tracker()->Close(ino);
+  cvmfs::fuse_reply_err(req, 0);
+}
+
+}  // namespace cvmfs
+
+static int Init(const loader::LoaderExports *loader_export) { return 0; }
+
+#define fuse_reply_err cvmfs::fuse_reply_err
+#include "cvmfs.cc"
+
+
+class T_Cvmfs : public ::testing::Test {
+ public:
+  void TestSetup() {
+    // Set up FileSystem for use in FUSE callbacks
+    // From t_mountpoint.cc, TODO(vvolkl): refactor
+    repo_path_ = "repo";
+    uuid_dummy_ = cvmfs::Uuid::Create("");
+    used_fds_ = 1;  // GetNoUsedFds();
+    fd_cwd_ = open(".", O_RDONLY);
+    ASSERT_GE(fd_cwd_, 0);
+    tmp_path_ = CreateTempDir("./cvmfs_ut_cache");
+    options_mgr_ = new SimpleOptionsParser();
+    options_mgr_->SetValue("CVMFS_CACHE_BASE", tmp_path_);
+    options_mgr_->SetValue("CVMFS_SHARED_CACHE", "no");
+    options_mgr_->SetValue("CVMFS_MAX_RETRIES", "0");
+    fs_info_.name = "unit-test";
+    fs_info_.options_mgr = options_mgr_;
+    // Silence syslog error
+    options_mgr_->SetValue("CVMFS_MOUNT_DIR", "/no/such/dir");
+    cvmfs::file_system_ = static_cast<NiceMock<MockFileSystem> *>(
+        FileSystem::Create(fs_info_));
+    cvmfs::file_system_->FixCustomVfs();
+    cvmfs::mount_point_ = static_cast<NiceMock<MockMountPoint> *>(
+        MountPoint::Create("TestMountPoint", cvmfs::file_system_,
+                           options_mgr_));
+    mock_page_cache_tracker_ = new NiceMock<MockPageCacheTracker>();
+    mock_chunk_tables_ = new NiceMock<ChunkTables>();
+    mock_catalog_mgr_ = new NiceMock<MockCatalogManager>(cvmfs::mount_point_);
+    mock_cache_tmp_path_ = CreateTempDir("/tmp/cvmfs_mf_cache");
+    mock_cache_mgr_ = static_cast<NiceMock<MockCacheManager> *>(
+        PosixCacheManager::Create(mock_cache_tmp_path_, false,
+                                  PosixCacheManager::kRenameNormal));
+    cvmfs::file_system_->mock_cache_mgr_ = mock_cache_mgr_;
+    cvmfs::mount_point_->mock_page_cache_tracker_ = mock_page_cache_tracker_;
+    cvmfs::mount_point_->mock_catalog_mgr_ = mock_catalog_mgr_;
+    cvmfs::mount_point_->mock_chunk_tables_ = mock_chunk_tables_;
+    ON_CALL(*mock_catalog_mgr_, MangleInode(_))
+        .WillByDefault([](fuse_ino_t ino) { return ino; });
+    ON_CALL(*mock_page_cache_tracker_, Close(_))
+        .WillByDefault([](fuse_ino_t ino) { return 0; });
+  }
+
+  void TestTearDown() {
+    delete mock_catalog_mgr_;
+    delete mock_page_cache_tracker_;
+    delete mock_cache_mgr_;
+
+    cvmfs::file_system_->mock_cache_mgr_ = nullptr;
+    cvmfs::mount_point_->mock_page_cache_tracker_ = nullptr;
+    cvmfs::mount_point_->mock_catalog_mgr_ = nullptr;
+    delete cvmfs::file_system_;
+  }
+
+ protected:
+  virtual void SetUp() { }
+
+  virtual void TearDown() {
+    delete uuid_dummy_;
+    int retval = fchdir(fd_cwd_);
+    ASSERT_EQ(0, retval);
+    close(fd_cwd_);
+  }
+
+ protected:
+  FileSystem::FileSystemInfo fs_info_;
+  SimpleOptionsParser *options_mgr_;
+  string tmp_path_;
+  string mock_cache_tmp_path_;
+  string repo_path_;
+  int fd_cwd_;
+  unsigned used_fds_;
+  cvmfs::Uuid *uuid_dummy_;
+
+
+  NiceMock<MockCatalogManager> *mock_catalog_mgr_;
+  NiceMock<MockPageCacheTracker> *mock_page_cache_tracker_;
+  NiceMock<MockCacheManager> *mock_cache_mgr_;
+  NiceMock<ChunkTables> *mock_chunk_tables_;
+};
+
+
+TEST_F(T_Cvmfs, Dummy) {
+  TestSetup();
+  // are we able to see symbols from cvmfs.cc?
+  ASSERT_NE(g_cvmfs_exports, nullptr);
+
+  // Are we mocking the cache manager correctly?
+  ASSERT_EQ(0, cvmfs::file_system_->cache_mgr()->Close(100));
+
+
+  fuse_ino_t ino = 100;
+  fuse_req_t mock_req = NULL;
+  fuse_file_info *fi;
+
+  EXPECT_CALL(*mock_page_cache_tracker_, Close(ino))
+      .Times(1);  // Should be called once
+  EXPECT_CALL(*mock_catalog_mgr_, MangleInode(ino))
+      .Times(1);  // Should be called once
+
+  cvmfs::cvmfs_release_test(mock_req, ino, fi);
+  ASSERT_EQ(g_fuseReplyErr, 0);
+
+  TestTearDown();
+}
+
+
+TEST_F(T_Cvmfs, cvmfs_release) {
+  TestSetup();
+
+  ASSERT_NE(g_cvmfs_exports, nullptr);
+
+
+  fuse_ino_t ino = 100;
+  fuse_req_t mock_req = NULL;
+  fuse_file_info fi;
+
+
+  // release non-chunked file
+  fi.fh = 1;
+  g_fuseReplyErr = -999;
+  cvmfs::file_system_->no_open_files()->Set(1);
+
+  EXPECT_CALL(*mock_page_cache_tracker_, Close(ino))
+      .Times(1);  // Should be called once
+
+
+  cvmfs::cvmfs_release(mock_req, ino, &fi);
+
+
+  ASSERT_EQ(cvmfs::file_system_->no_open_files()->Get(), 0);
+  ASSERT_EQ(g_fuseReplyErr, 0);
+
+
+  ///////////// release of chunked file ////
+
+  EXPECT_CALL(*mock_page_cache_tracker_, Close(ino))
+      .Times(1);  // Should be called once
+  g_fuseReplyErr = -999;
+
+
+  cvmfs::file_system_->no_open_files()->Set(1);
+  ChunkTables *chunk_tables = cvmfs::mount_point_->chunk_tables();
+
+  fi.fh = -1;
+  // chunk tables empty, expect failure
+  EXPECT_DEATH_IF_SUPPORTED(cvmfs::cvmfs_release(mock_req, ino, &fi),
+                            "Assertion");
+
+  fi.fh = -1;
+  const int64_t fd = static_cast<int64_t>(fi.fh);
+  const uint64_t chunk_handle = (fd < 0) ? -fd : fd;
+  ChunkFd chunk_fd;
+  chunk_fd.fd = 200;
+  chunk_fd.chunk_idx = 201;
+  chunk_tables->handle2uniqino.Insert(chunk_handle, ino);
+  chunk_tables->handle2fd.Insert(chunk_handle, chunk_fd);
+  chunk_tables->inode2references.Insert(ino, 2);
+
+  ChunkFd chunk_fd2;
+  ASSERT_EQ(true, chunk_tables->handle2fd.Lookup(chunk_handle, &chunk_fd2));
+
+  cvmfs::cvmfs_release(mock_req, ino, &fi);
+  ASSERT_EQ(g_fuseReplyErr, 0);
+
+  TestTearDown();
+}


### PR DESCRIPTION
Was fairly painful to mock everything, but at least gave some ideas for future renovations. This approach certainly tests some implementation details, but for the callbacks I think this is justified. The code changes little enough that updating the test logic  when it does is reasonable.

Currently only some basic tests for `cvmfs_release` -  regression tests for the page cache tracker issues are coming next.

Fixes #3911 