### PR TITLE
test/src/055-ownership: fix CVMFS_USER inference

### DIFF
--- a/test/src/055-ownership/main
+++ b/test/src/055-ownership/main
@@ -6,7 +6,10 @@ cvmfs_test_suites="quick"
 cvmfs_run_test() {
   logfile=$1
 
-  local cvmfs_user=$(sh -c '. /etc/cvmfs/default.conf && echo $CVMFS_USER')
+  local cvmfs_user=$(
+    eval "$(cvmfs_config showconfig grid.cern.ch | grep CVMFS_USER=)"
+    echo $CVMFS_USER
+  )
   local cvmfs_uid=$(get_user_data "$cvmfs_user" | cut -d: -f3)
   local cvmfs_gid=$(get_user_data "$cvmfs_user" | cut -d: -f4)
 


### PR DESCRIPTION
The test sources only /etc/cvmfs/default.conf, while it should consult all the parameter files as described in mount/default.conf comment, or use `cvmfs_config showconfig`.