### PR TITLE
test/src/084-premounted: rely on run.sh for workdir cleaning

### DIFF
--- a/test/src/084-premounted/main
+++ b/test/src/084-premounted/main
@@ -8,24 +8,18 @@ CVMFS_TEST084_FUSEPREMOUNT=
 
 cleanup() {
   echo "*** cleanup "
-  if [ x"$CVMFS_TEST084_FUSEPREMOUNT" != "x" ]; then
-    sudo rm -f "$CVMFS_TEST084_FUSEPREMOUNT"
-  fi
   if [ x"$CVMFS_TEST084_MOUNTPOINT" != "x" ]; then
     sudo umount $CVMFS_TEST084_MOUNTPOINT
     rmdir $CVMFS_TEST084_MOUNTPOINT
     echo "  *** unmounted $CVMFS_TEST084_MOUNTPOINT"
   fi
-  if [ x"$workdir" != "x" ]; then
-    rm -rf $workdir
-  fi
+  trap '' HUP EXIT TERM INT
 }
 
 cvmfs_run_test() {
   local logfile=$1
   local sourcedir="$2"
-  workdir="/tmp/cvmfs-test/workdir-084-premount"
-  mkdir -p $workdir
+  workdir="$PWD"
 
   echo "*** creating fuse-premount"
   cc -o $workdir/fuse_premount "$sourcedir/fuse_premount.c" || return 1
@@ -57,7 +51,6 @@ EOF
   ls -lah "$CVMFS_TEST084_MOUNTPOINT" > $workdir/cvm-test-084-repo-listing.log  || return 12
   echo "*** checking dirtab in  $CVMFS_TEST084_MOUNTPOINT"
   cat "$CVMFS_TEST084_MOUNTPOINT/.cvmfsdirtab" > $workdir/cvm-test-084-repo-dirtab.log || return 13
-
 
   echo "*** finished successfully!"
   cleanup


### PR DESCRIPTION
This test's code has an immediate issue that upon test failure, workdir is still wiped, preventing immediate analysis.

test/run.sh already takes care of creation of workdir (the test function is launched with it as current working dir), and similarly of removing of it upon successful completion.

We still need a cleanup procedure to unmount our mount. This commit prevents multiple executions of the cleanup routine.