### PR TITLE
test_functions: clean: get rid of openwaitprint processes

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -475,6 +475,8 @@ wait_for_umount() {
 }
 
 cvmfs_clean() {
+  pkill   openwaitprint || true
+  pidwait openwaitprint || true
   sudo env CVMFS_USE_MACFUSE_KEXT="$CVMFS_TEST_USE_MACFUSE_KEXT" cvmfs_config umount > /dev/null  || return 100
   sudo sh -c "rm -rf /var/lib/cvmfs/*"                  || return 101
   sudo rm -f /etc/cvmfs/default.local                    || return 102


### PR DESCRIPTION
I am not experienced in running cvmfs test suite, but these processes seemed to block unmounting and thus fail tests which seem to pass in central CI, for no obvious reason.