### PR TITLE
Fix "failed to umount (errno 22)" errors

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1238,7 +1238,7 @@ int FuseMain(int argc, char *argv[]) {
 
 #if CVMFS_USE_LIBFUSE != 2
   if (premount_fd >= 0) {
-    close(premount_fd);
+    goto cleanup;
   }
 #endif
 
@@ -1259,13 +1259,13 @@ cleanup:
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
                "failed to re-gain root permissions for umounting");
       retval = kFailPermission;
-    } else if (umount(mount_point_->c_str()) < 0) {
+    // do lazy unmount and ignore if it is already unmounted
+    } else if (umount2(mount_point_->c_str(), MNT_DETACH) < 0 && errno != EINVAL) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "failed to umount %s (%d)", mount_point_->c_str(), errno);
-      retval = kFailPermission;
+                    "failed to umount %s (%d)", mount_point_->c_str(), errno);
     } else {
       LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
-               mount_point_->c_str(), repository_name_->c_str());
+                  mount_point_->c_str(), repository_name_->c_str());
     }
     close(premount_fd);
   }

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1238,7 +1238,7 @@ int FuseMain(int argc, char *argv[]) {
 
 #if CVMFS_USE_LIBFUSE != 2
   if (premount_fd >= 0) {
-    goto cleanup;
+    close(premount_fd);
   }
 #endif
 


### PR DESCRIPTION
Following the upgrade to cvmfs 2.13, many nodes started to report something like:
```
Jul 22 12:09:22 lxplusxxx.cern.ch cvmfs2[3158959]: (atlas-nightlies.cern.ch) failed to umount /cvmfs/atlas-nightlies.cern.ch (22)
```
This seems to be a regression introduced by https://github.com/cvmfs/cvmfs/pull/3796 :
https://github.com/cvmfs/cvmfs/blob/a982d22292738500100c51218fefb0221c22fc17/cvmfs/loader.cc#L1241

 When exiting the main loop normally, we should not do another umount - at least in case the automounter already unmounted.

Can be easily reproduced by mounting a repo with autofs and letting it auto-unmount after the timeout.

It's not clear to me yet if this bug just resulted in a spurious error message or may be connected to some of the hangs reported. One of the nodes I'm looking at has the config repostory stuck in d state with this kernel stack:
```
[<0>] autofs_wait+0x1cd/0x6d0
[<0>] autofs_mount_wait+0x4c/0x100
[<0>] autofs_d_manage+0x79/0x190
[<0>] __traverse_mounts+0xd9/0x230
[<0>] step_into+0x296/0x380
[<0>] walk_component+0x70/0x1d0
[<0>] path_lookupat+0x6e/0x1c0
[<0>] filename_lookup+0xcf/0x1d0
[<0>] user_path_at_empty+0x3a/0x60
[<0>] __x64_sys_umount+0x43/0x80
[<0>] do_syscall_64+0x5f/0xe0
[<0>] entry_SYSCALL_64_after_hwframe+0x78/0x80
```
The wrong return value this bug is producing could in principle trigger strange autofs conditions.