### PR TITLE
[rpm] fix logrotate installation

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -718,9 +718,10 @@ systemctl daemon-reload
 /var/lib/cvmfs-server/
 /var/spool/cvmfs/README
 %doc COPYING AUTHORS README.md ChangeLog
+%config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs
+%config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 # sqlite version on rhel8 is too old for the statsdb logrotate script (needs >= 3.27)
 %define sqlite_version %(sqlite3 --version 2>/dev/null | cut -d' ' -f1 || echo "0")
-%config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 %if "%(echo '%{sqlite_version}' | awk 'BEGIN{print ("%{sqlite_version}" < "3.27")}')" == "1"
 %exclude %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 %endif

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -719,11 +719,11 @@ systemctl daemon-reload
 /var/spool/cvmfs/README
 %doc COPYING AUTHORS README.md ChangeLog
 # sqlite version on rhel8 is too old for the statsdb logrotate script (needs >= 3.27)
-%if 0%{?rhel} <= 8
-%else
+%define sqlite_version %(sqlite3 --version 2>/dev/null | cut -d' ' -f1 || echo "0")
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
+%if "%(echo '%{sqlite_version}' | awk 'BEGIN{print ("%{sqlite_version}" < "3.27")}')" == "1"
+%exclude %{_sysconfdir}/logrotate.d/cvmfs-statsdb
 %endif
-%config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs
 %doc %{_mandir}/man1/cvmfs_server.1.gz
 %doc %{_mandir}/man1/cvmfs_swissknife.1.gz
 


### PR DESCRIPTION
Better fix for https://github.com/cvmfs/cvmfs/issues/3896 : now checks the sqlite version directly instead of the platform, and avoids an installation error with rpmbuild.