### PR TITLE
cmake: add BUILTIN_EXTERNALS_LIST option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,9 @@ if (BUILTIN_EXTERNALS)
     if (BUILD_SNAPSHOTTER)
       set(ENV{BUILD_SNAPSHOTTER} "true")
     endif()
+    if (BUILTIN_EXTERNALS_LIST)
+      set(ENV{BUILTIN_EXTERNALS_LIST} "${BUILTIN_EXTERNALS_LIST}")
+    endif()
 
     message (STATUS "running bootstrap.sh ...")
     execute_process (
@@ -245,6 +248,7 @@ if (BUILTIN_EXTERNALS)
     set(ENV{BUILD_GATEWAY} "")
     set(ENV{BUILD_DUCC} "")
     set(ENV{BUILD_SNAPSHOTTER} "")
+    set(ENV{BUILTIN_EXTERNALS_LIST} "")
   endif (EXISTS "${CMAKE_SOURCE_DIR}/externals/bootstrap.sh")
 
   # In the case of built-in external libraries, we need to set CMAKE_PREFIX_PATH to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,9 @@ if (BUILTIN_EXTERNALS)
     if (BUILTIN_EXTERNALS_LIST)
       set(ENV{BUILTIN_EXTERNALS_LIST} "${BUILTIN_EXTERNALS_LIST}")
     endif()
+    if (BUILTIN_EXTERNALS_EXCLUDE)
+      set(ENV{BUILTIN_EXTERNALS_EXCLUDE} "${BUILTIN_EXTERNALS_EXCLUDE}")
+    endif()
 
     message (STATUS "running bootstrap.sh ...")
     execute_process (
@@ -249,6 +252,7 @@ if (BUILTIN_EXTERNALS)
     set(ENV{BUILD_DUCC} "")
     set(ENV{BUILD_SNAPSHOTTER} "")
     set(ENV{BUILTIN_EXTERNALS_LIST} "")
+    set(ENV{BUILTIN_EXTERNALS_EXCLUDE} "")
   endif (EXISTS "${CMAKE_SOURCE_DIR}/externals/bootstrap.sh")
 
   # In the case of built-in external libraries, we need to set CMAKE_PREFIX_PATH to

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -42,6 +42,9 @@ option (BUILD_LIBFUSE2          "Build the libraries for libfuse2 support"      
 option (BUILTIN_EXTERNALS       "Use built-in versions of all third-party libraries"               ON)
 option (USE_EXTERNAL_GOOGLETEST "Use external (non-vendored) googletest installation if available. Set to ON or OFF to force cmake to either download it from the fly, or take it from the system." AUTO)
 
+# List of external libraries to build (overrides default list in bootstrap.sh)
+set (BUILTIN_EXTERNALS_LIST "" CACHE STRING "Semicolon-separated list of external libraries to build (overrides default list)")
+
 
 option (BUILD_GATEWAY           "Build cvmfs_gateway, requires go compiler"                        OFF)
 option (BUILD_DUCC              "Build cvmfs_ducc, requires go compiler"                           OFF)

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -45,6 +45,9 @@ option (USE_EXTERNAL_GOOGLETEST "Use external (non-vendored) googletest installa
 # List of external libraries to build (overrides default list in bootstrap.sh)
 set (BUILTIN_EXTERNALS_LIST "" CACHE STRING "Semicolon-separated list of external libraries to build (overrides default list). Eg =libcurl;libcrypto;pacparser")
 
+# List of external libraries to exclude from building
+set (BUILTIN_EXTERNALS_EXCLUDE "" CACHE STRING "Semicolon-separated list of external libraries to exclude from building")
+
 
 option (BUILD_GATEWAY           "Build cvmfs_gateway, requires go compiler"                        OFF)
 option (BUILD_DUCC              "Build cvmfs_ducc, requires go compiler"                           OFF)

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -43,7 +43,7 @@ option (BUILTIN_EXTERNALS       "Use built-in versions of all third-party librar
 option (USE_EXTERNAL_GOOGLETEST "Use external (non-vendored) googletest installation if available. Set to ON or OFF to force cmake to either download it from the fly, or take it from the system." AUTO)
 
 # List of external libraries to build (overrides default list in bootstrap.sh)
-set (BUILTIN_EXTERNALS_LIST "" CACHE STRING "Semicolon-separated list of external libraries to build (overrides default list)")
+set (BUILTIN_EXTERNALS_LIST "" CACHE STRING "Semicolon-separated list of external libraries to build (overrides default list). Eg =libcurl;libcrypto;pacparser")
 
 
 option (BUILD_GATEWAY           "Build cvmfs_gateway, requires go compiler"                        OFF)

--- a/externals/bootstrap.sh
+++ b/externals/bootstrap.sh
@@ -298,6 +298,23 @@ else
     echo "Bootstrap - Using default externals list: $missing_libs"
 fi
 
+# Apply exclusions if BUILTIN_EXTERNALS_EXCLUDE is set
+if [ x"$BUILTIN_EXTERNALS_EXCLUDE" != x"" ]; then
+    # Convert semicolon-separated list to space-separated
+    exclude_libs=$(echo "$BUILTIN_EXTERNALS_EXCLUDE" | tr ';' ' ')
+    echo "Bootstrap - Excluding libraries: $exclude_libs"
+
+    # Remove each excluded library from missing_libs
+    for exclude_lib in $exclude_libs; do
+        missing_libs=$(echo $missing_libs | sed -e "s/\b$exclude_lib\b//g" | tr -s ' ')
+    done
+
+    # Clean up any leading/trailing spaces
+    missing_libs=$(echo $missing_libs | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+    echo "Bootstrap - Final externals list after exclusions: $missing_libs"
+fi
+
 if [ -f $externals_install_dir/.bootstrapDone ]; then
   existing_libs=$(cat $externals_install_dir/.bootstrapDone)
   for l in $existing_libs; do

--- a/externals/bootstrap.sh
+++ b/externals/bootstrap.sh
@@ -267,29 +267,35 @@ build_lib() {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # Build a list of libs that need to be built
-missing_libs="libcurl libcrypto pacparser zlib sparsehash leveldb maxminddb protobuf sqlite3 vjson sha3 libarchive"
+# Check if BUILTIN_EXTERNALS_LIST is set and override missing_libs
+if [ x"$BUILTIN_EXTERNALS_LIST" != x"" ]; then
+    # Convert semicolon-separated list to space-separated
+    missing_libs=$(echo "$BUILTIN_EXTERNALS_LIST" | tr ';' ' ')
+    echo "Bootstrap - Using custom externals list: $missing_libs"
+else
+    missing_libs="libcurl libcrypto pacparser zlib sparsehash leveldb maxminddb protobuf sqlite3 vjson sha3 libarchive"
 
-if [ x"$BUILD_UBENCHMARKS" != x"" ]; then
-    missing_libs="$missing_libs googlebench"
-fi
-
-if [ x"$BUILD_GATEWAY" != x ] || [ x"$BUILD_DUCC" != x ] || [ x"$BUILD_SNAPSHOTTER" != x ]; then
-    required_go_minor_version="23"
-    if [ -n "$(command -v go)" ]; then
-      go_minor_version=`go version | { read _ _ v _; echo ${v#go}; } | cut -d '.' -f2`
-       if expr "'$go_minor_version" \< "'$required_go_minor_version"   > /dev/null ; then 
-         missing_libs="$missing_libs golang_rev2"
-       fi  
-    else
-      missing_libs="$missing_libs golang_rev2"
+    if [ x"$BUILD_UBENCHMARKS" != x"" ]; then
+        missing_libs="$missing_libs googlebench"
     fi
-fi
 
-echo $missing_libs
+    if [ x"$BUILD_GATEWAY" != x ] || [ x"$BUILD_DUCC" != x ] || [ x"$BUILD_SNAPSHOTTER" != x ]; then
+        required_go_minor_version="23"
+        if [ -n "$(command -v go)" ]; then
+          go_minor_version=`go version | { read _ _ v _; echo ${v#go}; } | cut -d '.' -f2`
+           if expr "'$go_minor_version" \< "'$required_go_minor_version"   > /dev/null ; then
+             missing_libs="$missing_libs golang_rev2"
+           fi
+        else
+          missing_libs="$missing_libs golang_rev2"
+        fi
+    fi
 
+    if [ x"$BUILD_QC_TESTS" != x"" ]; then
+        missing_libs="$missing_libs rapidcheck"
+    fi
 
-if [ x"$BUILD_QC_TESTS" != x"" ]; then
-    missing_libs="$missing_libs rapidcheck"
+    echo "Bootstrap - Using default externals list: $missing_libs"
 fi
 
 if [ -f $externals_install_dir/.bootstrapDone ]; then


### PR DESCRIPTION
Allows some granularity for which vendored libs are being built. The main purpose is to allow  Arch Linux packagers to remove a patch (which I broke because I moved the bootstrap script).