### PR TITLE
Remove cvmfs-server fuse3 requirement from rpm packaging

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -229,8 +229,6 @@ Requires: libcap-progs
 Requires: initscripts
   %endif
 %endif
-# TODO(vavolkl): remove fuse3 once server fstab is modernized
-Requires: fuse3
 Requires: bash
 Requires: coreutils
 Requires: grep


### PR DESCRIPTION
This was unnecessarily added in #3943.  It was trying to ensure that `mount.fuse` was installed for release manager machines, but the `fuse3` package on RHEL systems doesn't even have that, it has `mount.fuse3` instead, and the package that does have it (`fuse`) is still required by the cvmfs package.  The problem fixed by #3943 was a debian-only problem and solution.