### PR TITLE
Fix updating of last_gc when no gc is run under gc -a without dry run

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -91,7 +91,7 @@ cvmfs_server_gc() {
       for name in $names; do
         if is_stratum0 $name || __was_garbage_collected_upstream $name; then
           collectable_names="$collectable_names $name"
-        elif [ $dry_run -ne 0 ]; then
+        elif [ $dry_run -eq 1 ]; then
           # pretend that gc was done to keep monitors happy
           update_repo_status $name last_gc "`date --utc`"
         fi


### PR DESCRIPTION
Fix mistake from #3895 which prevents the "last_gc" time from being updated in .cvmfs_status.json when gc is skipped.  The check for dry_run was reversed.  This bug causes cvmfs-servermon to complain if garbage collection is skipped for a time, default 30 days.