### PR TITLE
Really fix updating of last_gc when no gc is run under gc -a without dry run

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -91,7 +91,7 @@ cvmfs_server_gc() {
       for name in $names; do
         if is_stratum0 $name || __was_garbage_collected_upstream $name; then
           collectable_names="$collectable_names $name"
-        elif [ $dry_run -eq 1 ]; then
+        elif [ $dry_run -eq 0 ]; then
           # pretend that gc was done to keep monitors happy
           update_repo_status $name last_gc "`date --utc`"
         fi


### PR DESCRIPTION
It turns out that the "fix" in #3947 didn't actually change any behavior.  That's what I get for changing it after testing.  This is what I meant to submit, after having tested it with `$dry_run -ne 1` but thinking it would be slightly better to go with comparing `$dry_run` with `0` instead.