### PR TITLE
[rpm] Fix fuse3 libraries on suse

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -204,7 +204,12 @@ Common utility libraries for CernVM-FS packages
 Summary: additional libraries to enable libfuse3 support
 Group: Applications/System
 Requires: cvmfs-libs = %{version}-%{release}
+# fuse library package name differs on suse
+%if 0%{?suse_version}
+Requires: libfuse3-3
+%else
 Requires: fuse3-libs >= 3.3.0
+%endif
 %description fuse3
 Shared libraries implementing the CernVM-FS fuse module based on libfuse3
 


### PR DESCRIPTION
The fuse3 libraries on SLES have a different package name. It seems like cvmfs using fuse3 on SUSE has never been tried before, because it seems like this has always been broken, and just surfaced when we switched to fuse3 by default recently.

I'll make a 2.13.2-3 build  for SUSE. 