### PR TITLE
Fix wrong variable names in cvmfs_server_gc, faulty cherry-pick of (#3575)

### DIFF
--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -188,7 +188,7 @@ cvmfs_server_gc() {
   # Use /dev/shm for the lock file because it is world-writable and goes
   # away during reboot
   local gc_all_lock=/dev/shm/cvmfs_is_gcing_all
-  if [ $all_collectable -ne 0 ]; then
+  if [ $all_collected -ne 0 ]; then
     if ! acquire_lock $gc_all_lock; then
       to_syslog "skipping starting cvmfs_server gc -a because $gc_all_lock held by active process"
       return 1
@@ -232,7 +232,7 @@ cvmfs_server_gc() {
     fi
   done
 
-  if [ $all_collectable -ne 0 ]; then
+  if [ $all_collected -ne 0 ]; then
     release_lock $gc_all_lock
   fi
 }


### PR DESCRIPTION
https://github.com/cvmfs/cvmfs/pull/3895 renamed `all_collectable` to `all_collected`, but then, when  https://github.com/cvmfs/cvmfs/pull/3575 was cherry-picked back on devel, it added a block using the old variable names.

Should have been caught by tests, so that's a todo. Maybe we also do need the strict mode for bash.