### PR TITLE
Include date and hostname in bugreport tarball filename

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1573,8 +1573,8 @@ cvmfs_killall() {
 cvmfs_bugreport() {
   tmpdir=`mktemp -d -t cvmfs-bugreport.XXXXXX` || exit 1
   cd $tmpdir
-  mkdir bugreport
-  cd bugreport
+  mkdir bugreport_$(date -I)_$(hostname)
+  cd bugreport_$(date -I)_$(hostname)
 
   local timeout_sec
   if [ -z "$1" ]; then
@@ -1690,11 +1690,11 @@ cvmfs_bugreport() {
    done
 
    cd ..
-   tar cfz cvmfs-bugreport-$(date -I)-$(hostname).tar.gz *
-   rm -rf bugreport
+   tar cfz cvmfs-bugreport_$(date -I)_$(hostname).tar.gz *
+   rm -rf bugreport_$(date -I)_$(hostname)
 
    echo
-   echo "System information has been collected in ${tmpdir}/cvmfs-bugreport$(date -I)-$(hostname).tar.gz"
+   echo "System information has been collected in ${tmpdir}/cvmfs-bugreport_$(date -I)_$(hostname).tar.gz"
    echo "Please attach this file to your problem description and send it as a"
    echo "bug report to https://github.com/cvmfs/cvmfs/issues"
 }

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1690,11 +1690,11 @@ cvmfs_bugreport() {
    done
 
    cd ..
-   tar cfz cvmfs-bugreport.tar.gz *
+   tar cfz cvmfs-bugreport-$(date -I)-$(hostname).tar.gz *
    rm -rf bugreport
 
    echo
-   echo "System information has been collected in ${tmpdir}/cvmfs-bugreport.tar.gz"
+   echo "System information has been collected in ${tmpdir}/cvmfs-bugreport$(date -I)-$(hostname).tar.gz"
    echo "Please attach this file to your problem description and send it as a"
    echo "bug report to https://github.com/cvmfs/cvmfs/issues"
 }


### PR DESCRIPTION
A quality of life improvement for developers, who otherwise need to manually rename those files on download to keep track of them.