### PR TITLE
Change geoip database to openhtc source by default

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -191,21 +191,6 @@ jobs:
           sudo cvmfs_config setup
           sudo systemctl start apache2
           sudo systemctl status apache2
-            
-          geoip_local_url="https://ecsft.cern.ch/dist/cvmfs/geodb/GeoLite2-City.mmdb"
-          dbfile="/var/lib/cvmfs-server/geo/GeoLite2-City-test.mmdb"
-          sudo mkdir -p /var/lib/cvmfs-server/geo/
-          if [ ! -f "/home/runner/.cache/testgeo.mmdb" ]; then
-            echo "Downloading $geoip_local_url ..."
-            curl  $geoip_local_url -o /home/runner/.cache/testgeo.mmdb
-          fi
-          sudo cp /home/runner/.cache/testgeo.mmdb $dbfile
-          if ! [ -f $dbfile ]; then
-            echo "failed to download geodb!"
-            exit 300 
-          fi  
-          sudo mkdir -p /etc/cvmfs
-          echo "CVMFS_GEO_DB_FILE=$dbfile" | sudo tee -a /etc/cvmfs/server.local > /dev/null
       - name: Check CCache Hits
         run: |
           ccache -s

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -48,19 +48,19 @@ publish_after_hook() { :; }
 
 cvmfs_sys_file_is_regular /etc/cvmfs/cvmfs_server_hooks.sh && . /etc/cvmfs/cvmfs_server_hooks.sh
 
-if [ "$CVMFS_UPDATEGEO_SOURCE" == openhtc ]; then
+if [ "$CVMFS_UPDATEGEO_SOURCE" = "openhtc" ]; then
   CVMFS_UPDATEGEO_MINDAYS=${CVMFS_UPDATEGEO_MINDAYS:-7}
   CVMFS_UPDATEGEO_MAXDAYS=${CVMFS_UPDATEGEO_MAXDAYS:-14}
   CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-iplocation.mmdb}"
   CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://geoipdb.openhtc.io}"
   CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-/${CVMFS_UPDATEGEO_DB}.gz}"
-elif [ "$CVMFS_UPDATEGEO_SOURCE" == maxmind ]; then
+elif [ "$CVMFS_UPDATEGEO_SOURCE" = "maxmind" ]; then
   CVMFS_UPDATEGEO_MINDAYS=${CVMFS_UPDATEGEO_MINDAYS:-14}
   CVMFS_UPDATEGEO_MAXDAYS=${CVMFS_UPDATEGEO_MAXDAYS:-28}
   CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-GeoLite2-City.mmdb}"
   CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://download.maxmind.com/geoip/databases/GeoLite2-City/download}"
   CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-?suffix=tar.gz}"
-elif [ -n "$CVMFS_UPDATEGEO_SOURCE" ] && [ "$CVMFS_UPDATEGEO_SOURCE" != none ]; then
+elif [ -n "$CVMFS_UPDATEGEO_SOURCE" ] && [ "$CVMFS_UPDATEGEO_SOURCE" != "none" ]; then
   die "CVMFS_UPDATEGEO_SOURCE not openhtc, maxmind, or none"
 fi
 

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -8,16 +8,19 @@
 #   /etc/cvmfs/cvmfs_server_hooks.sh, /etc/cvmfs/server.local, or
 #   per-repo in replica.conf.
 # Default settings will attempt to update from cvmfs_server snapshot
-#   once every 4 weeks in the 10 o'clock hour of Tuesday.
+#   in the 10 o'clock hour of Tuesday, every 2 weeks for openhtc or
+#   every 4 weeks for maxmind.
 CVMFS_GEO_AUTO_UPDATE=true # Automatically update from cvmfs_server snapshot
+CVMFS_UPDATEGEO_SOURCE=openhtc # Database source: openhtc, maxmind, or none
 CVMFS_UPDATEGEO_DAY=2   # Weekday of update, 0-6 where 0 is Sunday, default Tuesday
 CVMFS_UPDATEGEO_HOUR=10 # First hour of day for update, 0-23, default 10am
-CVMFS_UPDATEGEO_MINDAYS=14 # Minimum days between update attempts
-CVMFS_UPDATEGEO_MAXDAYS=28 # Maximum days before considering it urgent
+CVMFS_UPDATEGEO_MINDAYS= # Minimum days between update attempts (set below)
+CVMFS_UPDATEGEO_MAXDAYS= # Maximum days before considering it urgent (set below)
 
-CVMFS_UPDATEGEO_URLBASE="https://download.maxmind.com/geoip/databases/GeoLite2-City/download"
-CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo"
-CVMFS_UPDATEGEO_DB="GeoLite2-City.mmdb"
+CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo" # Directory to download into
+CVMFS_UPDATEGEO_DB=      # DB name (set below)
+CVMFS_UPDATEGEO_URLBASE= # Base of URL for download (set below)
+CVMFS_UPDATEGEO_URLSUFFIX= # Suffix to add to URLBASE for download
 
 DEFAULT_LOCAL_STORAGE="/srv/cvmfs"
 
@@ -44,6 +47,22 @@ publish_before_hook() { :; }
 publish_after_hook() { :; }
 
 cvmfs_sys_file_is_regular /etc/cvmfs/cvmfs_server_hooks.sh && . /etc/cvmfs/cvmfs_server_hooks.sh
+
+if [ "$CVMFS_UPDATEGEO_SOURCE" == openhtc ]; then
+  CVMFS_UPDATEGEO_MINDAYS=${CVMFS_UPDATEGEO_MINDAYS:-7}
+  CVMFS_UPDATEGEO_MAXDAYS=${CVMFS_UPDATEGEO_MAXDAYS:-14}
+  CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-iplocation.mmdb}"
+  CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://geoipdb.openhtc.io}"
+  CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-/${CVMFS_UPDATEGEO_DB}.gz}"
+elif [ "$CVMFS_UPDATEGEO_SOURCE" == maxmind ]; then
+  CVMFS_UPDATEGEO_MINDAYS=${CVMFS_UPDATEGEO_MINDAYS:-14}
+  CVMFS_UPDATEGEO_MAXDAYS=${CVMFS_UPDATEGEO_MAXDAYS:-28}
+  CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-GeoLite2-City.mmdb}"
+  CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://download.maxmind.com/geoip/databases/GeoLite2-City/download}"
+  CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-?suffix=tar.gz}"
+elif [ -n "$CVMFS_UPDATEGEO_SOURCE" ] && [ "$CVMFS_UPDATEGEO_SOURCE" != none ]; then
+  die "CVMFS_UPDATEGEO_SOURCE not openhtc, maxmind, or none"
+fi
 
 # Path to some useful sbin utilities
 LSOF_BIN="$(find_sbin       lsof)"       || true

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1066,8 +1066,9 @@ _update_geodb_install() {
   # downloading the GeoIP database file
   curl -L -sS --connect-timeout 10 \
               --max-time 60        \
+              --retry 2            \
               $authopts            \
-              "$dburl" > $download_target || true
+              "$dburl" -o $download_target || true
 
   if [ -n "$untar_dir" ]; then
     if ! tar tzf $download_target >/dev/null 2>&1; then

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1047,7 +1047,7 @@ _update_geodb_install() {
   esac
 
   local authopts=""
-  if [ "$CVMFS_UPDATEGEO_SOURCE" == maxmind ]; then
+  if [ "$CVMFS_UPDATEGEO_SOURCE" = "maxmind" ]; then
     if [ -z "$CVMFS_GEO_ACCOUNT_ID" ]; then
       echo "CVMFS_GEO_ACCOUNT_ID not set" >&2
       _to_syslog_for_geoip "CVMFS_GEO_ACCOUNT_ID not set"

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1027,70 +1027,116 @@ _to_syslog_for_geoip() {
 
 _update_geodb_install() {
   local retcode=0
-  local dburl="${CVMFS_UPDATEGEO_URLBASE}?suffix=tar.gz"
+  local dburl="${CVMFS_UPDATEGEO_URLBASE}${CVMFS_UPDATEGEO_URLSUFFIX}"
   local dbfile="${CVMFS_UPDATEGEO_DIR}/${CVMFS_UPDATEGEO_DB}"
-  local download_target=${dbfile}.tgz
-  local untar_dir=${dbfile}.untar
+  local download_target
+  local untar_dir=""
 
-  if [ -z "$CVMFS_GEO_ACCOUNT_ID" ]; then
+  case "$CVMFS_UPDATEGEO_URLSUFFIX" in
+    *tar.gz|*.tgz)
+      download_target="${dbfile}.tgz"
+      untar_dir="${dbfile}.untar"
+      ;;
+    *.gz)
+      download_target="${dbfile}.gz"
+      ;;
+    *) echo "CVMFS_UPDATEGEO_URLSUFFIX ($CVMFS_UPDATEGEO_URLSUFFIX) ends in unrecognized suffix" >&2
+      _to_syslog_for_geoip "CVMFS_UPDATEGEO_URLSUFFIX ends in unrecognized suffix"
+      return 1
+      ;;
+  esac
+
+  local authopts=""
+  if [ "$CVMFS_UPDATEGEO_SOURCE" == maxmind ]; then
+    if [ -z "$CVMFS_GEO_ACCOUNT_ID" ]; then
       echo "CVMFS_GEO_ACCOUNT_ID not set" >&2
       _to_syslog_for_geoip "CVMFS_GEO_ACCOUNT_ID not set"
-      return 1
-  fi
-  if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
+      return 2
+    fi
+    if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
       echo "CVMFS_GEO_LICENSE_KEY not set" >&2
       _to_syslog_for_geoip "CVMFS_GEO_LICENSE_KEY not set"
-      return 1
+      return 3
+    fi
+    authopts="-u ${CVMFS_GEO_ACCOUNT_ID}:${CVMFS_GEO_LICENSE_KEY}"
   fi
 
   _to_syslog_for_geoip "started update from $dburl"
 
   # downloading the GeoIP database file
-  curl -L -sS  --connect-timeout 10 \
-            --max-time 60        \
-            -u "${CVMFS_GEO_ACCOUNT_ID}:${CVMFS_GEO_LICENSE_KEY}" \
-            "$dburl" > $download_target || true
-  if ! tar tzf $download_target >/dev/null 2>&1; then
-    local msg
-    if file $download_target|grep -q "ASCII text$"; then
-      msg="`cat -v $download_target|head -1`"
-    else
-      msg="file not valid tarball"
+  curl -L -sS --connect-timeout 10 \
+              --max-time 60        \
+              $authopts            \
+              "$dburl" > $download_target || true
+
+  if [ -n "$untar_dir" ]; then
+    if ! tar tzf $download_target >/dev/null 2>&1; then
+      local msg
+      if file $download_target|grep -q "ASCII text$"; then
+        msg="`cat -v $download_target|head -1`"
+      else
+        msg="file not valid tarball"
+      fi
+      echo "failed to download geodb (see url in syslog): $msg" >&2
+      _to_syslog_for_geoip "failed to download from $dburl: $msg"
+      rm -f $download_target
+      return 4
     fi
-    echo "failed to download geodb (see url in syslog): $msg" >&2
-    _to_syslog_for_geoip "failed to download from $dburl: $msg"
-    rm -f $download_target
-    return 1
-  fi
 
-  # untar the GeoIP database file
-  rm -rf $untar_dir
-  mkdir -p $untar_dir
-  if ! tar xmf $download_target -C $untar_dir --no-same-owner 2>/dev/null; then
-    echo "failed to untar $download_target into $untar_dir" >&2
-    _to_syslog_for_geoip "failed to untar $download_target into $untar_dir"
-    rm -rf $download_target $untar_dir
-    return 2
-  fi
-
-  # get rid of the tarred GeoIP database
-  rm -f $download_target
-
-  # atomically install the GeoIP database
-  if ! mv -f $untar_dir/*/${CVMFS_UPDATEGEO_DB} $dbfile; then
-    echo "failed to install $dbfile" >&2
-    _to_syslog_for_geoip "failed to install $dbfile"
+    # untar the GeoIP database file
     rm -rf $untar_dir
-    return 3
+    mkdir -p $untar_dir
+    if ! tar xmf $download_target -C $untar_dir --no-same-owner 2>/dev/null; then
+      echo "failed to untar $download_target into $untar_dir" >&2
+      _to_syslog_for_geoip "failed to untar $download_target into $untar_dir"
+      rm -rf $download_target $untar_dir
+      return 5
+    fi
+
+    # get rid of the tarred GeoIP database
+    rm -f $download_target
+
+    # atomically install the GeoIP database
+    if ! mv -f $untar_dir/*/${CVMFS_UPDATEGEO_DB} $dbfile; then
+      echo "failed to install $dbfile" >&2
+      _to_syslog_for_geoip "failed to install $dbfile"
+      rm -rf $untar_dir
+      return 6
+    fi
+
+    # get rid of any other files in the untar
+    rm -rf $untar_dir
+  else # must be .gz
+    if ! zcat $download_target >$dbfile.new; then
+      local msg
+      if file $download_target|grep -q "ASCII text$"; then
+        msg="`cat -v $download_target|head -1`"
+      else
+        msg="file could not be uncompressed"
+      fi
+      echo "failed to download geodb (see url in syslog): $msg" >&2
+      _to_syslog_for_geoip "failed to download from $dburl: $msg"
+      rm -f $download_target $dbfile.new
+      return 7
+    fi
+
+    rm -f $download_target
+
+    if ! mv -f $dbfile.new $dbfile; then
+      echo "failed to install $dbfile" >&2
+      _to_syslog_for_geoip "failed to install $dbfile"
+      rm -f $dbfile.new
+      return 8
+    fi
   fi
+
+  # Remove any old name .mmdb
+  find $CVMFS_UPDATEGEO_DIR -name '*.mmdb' ! -name $CVMFS_UPDATEGEO_DB | xargs -r rm -f
 
   if [ -w "$(get_global_info_v1_path)" ]; then
     # update repositories.json for the new geodb timestamp, if possible
     update_global_repository_info || die "fail (update global repository info)"
   fi
-
-  # get rid of other files in the untar
-  rm -rf $untar_dir
 
   set_selinux_httpd_context_if_needed "$CVMFS_UPDATEGEO_DIR"
 

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -4,24 +4,27 @@ cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
 # NOTE:
-#  A full test requires a valid CVMFS_GEO_ACCOUNT_ID and CVMFS_GEO_LICENSE_KEY
-#  in a /etc/cvmfs/server.local that is readable by $CVMFS_TEST_USER.
-#  Test will be skipped with a warning if either CVMFS_GEO_DB_FILE is
-#    set or there's no CVMFS_GEO_LICENSE_KEY but there is a system
-#    geo DB in /usr/share/GeoIP.
+#  If CVMFS_GEO_ACCOUNT_ID and CVMFS_GEO_LICENSE_KEY exist in a
+#  /etc/cvmfs/server.local that is readable by $CVMFS_TEST_USER,
+#  this will test the maxmind source, otherwise it will test the
+#  openhtc source.
+#  Test will be skipped with a warning if CVMFS_GEO_DB_FILE is set.
 
 #
 # Location of the system-wide GeoIP databases
 # configurable: to be changed if $CVMFS_UPDATEGEO_DIR or CVMFS_UPDATEGEO_DB
 #    in cvmfs_server changes
 #
-CVMFS_TEST_595_GEODB="/var/lib/cvmfs-server/geo/GeoLite2-City.mmdb"
+CVMFS_TEST_595_GEODB=    # set at the beginning of the test below
+CVMFS_TEST_595_GEODBMAX="/var/lib/cvmfs-server/geo/GeoLite2-City.mmdb"
+CVMFS_TEST_595_GEODBHTC="/var/lib/cvmfs-server/geo/iplocation.mmdb"
 CVMFS_TEST_595_ATTEMPT_FILE="/var/lib/cvmfs-server/geo/.last_attempt_day"
 CVMFS_TEST_595_SERVER_HOOKS="/etc/cvmfs/cvmfs_server_hooks.sh"
 
 CVMFS_TEST_595_REPLICA_NAME=
 CVMFS_TEST_595_GEODB_TOUCHED=0
-CVMFS_TEST_595_GEODB_STASH=
+CVMFS_TEST_595_GEODBMAX_STASH=
+CVMFS_TEST_595_GEODBHTC_STASH=
 CVMFS_TEST_595_GEODB_OWNER=
 CVMFS_TEST_595_GEODB_GROUP=
 CVMFS_TEST_595_SERVER_HOOKS_TOUCHED=0
@@ -30,7 +33,8 @@ cleanup() {
   echo "running cleanup... "
   [ -z $CVMFS_TEST_595_REPLICA_NAME ]            || sudo cvmfs_server rmfs -f $CVMFS_TEST_595_REPLICA_NAME
   [ $CVMFS_TEST_595_GEODB_TOUCHED -eq 0 ]        || sudo rm -f $CVMFS_TEST_595_GEODB
-  [ -z $CVMFS_TEST_595_GEODB_STASH  ]            || cvmfs_unstash GEODB
+  [ -z $CVMFS_TEST_595_GEODBMAX_STASH  ]         || cvmfs_unstash GEODBMAX
+  [ -z $CVMFS_TEST_595_GEODBHTC_STASH  ]         || cvmfs_unstash GEODBHTC
   [ -z $CVMFS_TEST_595_GEODB_OWNER ]             || sudo chown ${CVMFS_TEST_595_GEODB_OWNER}:${CVMFS_TEST_595_GEODB_GROUP} $(dirname $CVMFS_TEST_595_GEODB)
   [ $CVMFS_TEST_595_SERVER_HOOKS_TOUCHED -eq 0 ] || sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS
   [ -z $CVMFS_TEST_595_SERVER_HOOKS_STASH ]      || sudo cp -f $CVMFS_TEST_595_SERVER_HOOKS_STASH $CVMFS_TEST_595_SERVER_HOOKS
@@ -58,28 +62,26 @@ cvmfs_unstash()
   eval source="\$$var"
   local stash
   eval stash="\$${var}_STASH"
-  sudo cp -f $stash $source
-  sudo chown ${CVMFS_TEST_595_GEODB_OWNER}:${CVMFS_TEST_595_GEODB_GROUP} $source
+  if [ -f "$stash" ]; then
+    sudo cp -f $stash $source
+    sudo chown ${CVMFS_TEST_595_GEODB_OWNER}:${CVMFS_TEST_595_GEODB_GROUP} $source
+  fi
 }
 
-recreate_server_hooks_from_stashed_if_needed() {
+recreate_server_hooks() {
   sudo rm -f $CVMFS_TEST_595_SERVER_HOOKS || true
   if [ ! -z $CVMFS_TEST_595_SERVER_HOOKS_STASH ] && \
      [   -f $CVMFS_TEST_595_SERVER_HOOKS_STASH ]; then
     # copying over CVMFS_UPDATEGEO_URLBASE configuration if necessary
-    grep -e 'CVMFS_UPDATEGEO_URLBASE='  $CVMFS_TEST_595_SERVER_HOOKS_STASH | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 50
-    grep -e 'CVMFS_UPDATEGEO_URLBASE6=' $CVMFS_TEST_595_SERVER_HOOKS_STASH | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 51
+    grep -e 'CVMFS_UPDATEGEO_URLBASE='  $CVMFS_TEST_595_SERVER_HOOKS_STASH | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 100
+    grep -e 'CVMFS_UPDATEGEO_URLBASE6=' $CVMFS_TEST_595_SERVER_HOOKS_STASH | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 101
   fi
+  # add type configuration
+  echo "CVMFS_UPDATEGEO_SOURCE=$updategeo_source" | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 102
 }
 
 cvmfs_run_test() {
   logfile=$1
-
-  if [ ! -d `dirname $CVMFS_TEST_595_GEODB` ]; then
-    echo "No geo database directory, disabled on this platform"
-    CVMFS_GENERAL_WARNING_FLAG=1
-    return 0
-  fi
 
   if [ -f /etc/cvmfs/server.local ]; then
     . /etc/cvmfs/server.local
@@ -90,22 +92,20 @@ cvmfs_run_test() {
     return 0
   fi
 
-  if [ -z "$CVMFS_GEO_ACCOUNT_ID" -o -z "$CVMFS_GEO_LICENSE_KEY" ]; then
-    if [ -z "$CVMFS_GEO_LICENSE_KEY" -a -f /usr/share/GeoIP/`basename $CVMFS_TEST_595_GEODB` ]; then
-      echo "System geo database installed, skipping tests"
-      CVMFS_GENERAL_WARNING_FLAG=1
-      return 0
-    fi
-    ACCT_MSG=
-    LICENSE_MSG=
-    if [ -z "$CVMFS_GEO_ACCOUNT_ID" ]; then
-      ACCT_MSG=", geo account ID"
-    fi
-    if [ -z "$CVMFS_GEO_LICENSE_KEY" ]; then
-      LICENSE_MSG=", geo license key"
-    fi
-    echo The following are not found: db file${ACCT_MSG}${LICENSE_MSG}
-    return 1
+  if [ -n "$CVMFS_GEO_ACCOUNT_ID" -a -n "$CVMFS_GEO_LICENSE_KEY" ]; then
+    echo "testing maxmind source"
+    updategeo_source=maxmind
+    CVMFS_TEST_595_GEODB="$CVMFS_TEST_595_GEODBMAX"
+  else
+    echo "testing openhtc source"
+    updategeo_source=openhtc
+    CVMFS_TEST_595_GEODB="$CVMFS_TEST_595_GEODBHTC"
+  fi
+
+  if [ ! -d `dirname $CVMFS_TEST_595_GEODB` ]; then
+    echo "No geo database directory, disabled on this platform"
+    CVMFS_GENERAL_WARNING_FLAG=1
+    return 0
   fi
 
   # can't start out as root, it causes some of the tests below to fail
@@ -129,11 +129,12 @@ cvmfs_run_test() {
   echo "install a disaster cleanup function"
   trap cleanup EXIT HUP INT TERM || return $?
 
-  cvmfs_stash GEODB
+  cvmfs_stash GEODBMAX
+  cvmfs_stash GEODBHTC
   cvmfs_stash SERVER_HOOKS
 
-  echo "create initial $CVMFS_TEST_595_SERVER_HOOKS if necessary"
-  recreate_server_hooks_from_stashed_if_needed || return 50
+  echo "create initial $CVMFS_TEST_595_SERVER_HOOKS"
+  recreate_server_hooks || return 50
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -311,8 +312,8 @@ cvmfs_run_test() {
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  echo "removing $CVMFS_TEST_595_SERVER_HOOKS"
-  recreate_server_hooks_from_stashed_if_needed || return 43
+  echo "recreating $CVMFS_TEST_595_SERVER_HOOKS"
+  recreate_server_hooks || return 43
 
   echo "create a stratum1 snapshot (should find database up to date)"
   local snapshot_1_log="snapshot_1.log"
@@ -344,9 +345,6 @@ cvmfs_run_test() {
   local snapshot_6_log="snapshot_6.log"
   echo CVMFS_GEO_AUTO_UPDATE=false | sudo tee --append $CVMFS_TEST_595_SERVER_HOOKS || return 51
   cvmfs_server snapshot $replica_name > $snapshot_6_log 2>&1 || return 52
-
-  echo "removing $CVMFS_TEST_595_SERVER_HOOKS"
-  recreate_server_hooks_from_stashed_if_needed || return 53
 
   echo "check output logs for the expected status messages"
   test -z "`cat $snapshot_1_log | grep GeoIP`"                                   || return 61


### PR DESCRIPTION
This maintains the maxmind geoip database as an option for the stratum 1 geo api but changes the default to reading via https://geoipdb.openhtc.io which currently redirects to the download area of the [cvmfs-contrib/config-repo geoipdb tag release assets](https://github.com/cvmfs-contrib/config-repo/releases/tag/geoipdb).