### PR TITLE
Update geo api for either mmdb name

### DIFF
--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -19,6 +19,7 @@ CVMFS_UPDATEGEO_MAXDAYS= # Maximum days before considering it urgent (set below)
 
 CVMFS_UPDATEGEO_DIR="/var/lib/cvmfs-server/geo" # Directory to download into
 CVMFS_UPDATEGEO_DB=      # DB name (set below)
+CVMFS_UPDATEGEO_OLDDB=   # DB name to remove if present (set below)
 CVMFS_UPDATEGEO_URLBASE= # Base of URL for download (set below)
 CVMFS_UPDATEGEO_URLSUFFIX= # Suffix to add to URLBASE for download
 
@@ -51,12 +52,14 @@ cvmfs_sys_file_is_regular /etc/cvmfs/cvmfs_server_hooks.sh && . /etc/cvmfs/cvmfs
 if [ "$CVMFS_UPDATEGEO_SOURCE" = "openhtc" ]; then
   CVMFS_UPDATEGEO_MINDAYS=${CVMFS_UPDATEGEO_MINDAYS:-7}
   CVMFS_UPDATEGEO_MAXDAYS=${CVMFS_UPDATEGEO_MAXDAYS:-14}
+  CVMFS_UPDATEGEO_OLDDB=GeoLite2-City.mmdb
   CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-iplocation.mmdb}"
   CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://geoipdb.openhtc.io}"
   CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-/${CVMFS_UPDATEGEO_DB}.gz}"
 elif [ "$CVMFS_UPDATEGEO_SOURCE" = "maxmind" ]; then
   CVMFS_UPDATEGEO_MINDAYS=${CVMFS_UPDATEGEO_MINDAYS:-14}
   CVMFS_UPDATEGEO_MAXDAYS=${CVMFS_UPDATEGEO_MAXDAYS:-28}
+  CVMFS_UPDATEGEO_OLDDB=iplocation.mmdb
   CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-GeoLite2-City.mmdb}"
   CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://download.maxmind.com/geoip/databases/GeoLite2-City/download}"
   CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-?suffix=tar.gz}"

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1105,6 +1105,9 @@ _update_geodb_install() {
       return 6
     fi
 
+    # get rid of old database if present
+    rm -f ${CVMFS_UPDATEGEO_DIR}/${CVMFS_UPDATEGEO_OLDDB}
+
     # get rid of any other files in the untar
     rm -rf $untar_dir
   else # must be .gz


### PR DESCRIPTION
Unfortunately I didn't fully test the new geo db download in #3967, and we apparently didn't notice that the cloudtest 614-geoservice would have failed.  This fixes that situation, including removing the alternate database name when switching between the two different types.

Test 614-geoservice takes about 3 minutes so it isn't exactly "quick" but I wonder if we should include it in the quick tests anyway so it will always run.  Alternatively, maybe the Jenkins cloudtests configuration can be changed to use the new geo database.