### PR TITLE
ingestsql: Detect accidental quit beacons

### DIFF
--- a/cvmfs/catalog.cc
+++ b/cvmfs/catalog.cc
@@ -628,6 +628,7 @@ const Catalog::NestedCatalogList &Catalog::ListNestedCatalogs() const {
       nested.mountpoint = PlantPath(sql_list_nested_->GetPath());
       nested.hash = sql_list_nested_->GetContentHash();
       nested.size = sql_list_nested_->GetSize();
+      assert(!nested.hash.IsNull());
       nested_catalog_cache_.push_back(nested);
     }
     sql_list_nested_->Reset();

--- a/cvmfs/catalog_downloader.cc
+++ b/cvmfs/catalog_downloader.cc
@@ -45,6 +45,7 @@ void CatalogDownloadPipeline::OnFileProcessed(
 
 void CatalogDownloadPipeline::Process(const shash::Any &catalog_hash) {
   CatalogItem *catalog_item = new CatalogItem(catalog_hash);
+  assert(!catalog_item->IsQuitBeacon());
   tube_counter_.EnqueueBack(catalog_item);
   tube_input_.EnqueueBack(catalog_item);
 }

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -1733,6 +1733,7 @@ void WritableCatalogManager::CatalogDownloadCallback(
   for (auto it = nested_catalogs.begin(); it != nested_catalogs.end(); ++it) {
     // schedule relevant child nested catalogs for download
     if (context.dirs->find(it->mountpoint.ToString()) != context.dirs->end()) {
+      assert(!it->hash.IsNull());
       Catalog *child_catalog = CreateCatalog(it->mountpoint, it->hash,
                                              NULL /* parent */);
       {


### PR DESCRIPTION
This adds assertions to what seems already going wrong in some cases of usage of ingestsql.
I consistently observe hangs of ingestsql when running `cvmfs-posix-tools` embedded tests (PR #3964); I am not currently aware of any other way to trigger the scenarios, but it should be straightforward to construct a test case not relying on `cvmfs-posix-tools`.

I am submitting this to get developers' comments and clarify this matter for myself. My understanding is that

* Quit Beacons are special CatalogItem objects which could be otherwise named "sentinel entries" in the processing pipelines, indicating the end of stream.
* Quit Beacons should be constructed by a call to a special method `CreateQuitBeacon()` of respective subclass.
* CatalogItem objects which were not created by `CreateQuitBeacon()` must never return `true` for `IsQuitBeacon()`.

In what I see, this unintended premature termination happens at

```
    TubeConsumer<CatalogItem>::MainConsumer() at cvmfs/ingestion/task.h:51
    
    static void *MainConsumer(void *data) {
      TubeConsumer<ItemT> *consumer = reinterpret_cast<TubeConsumer<ItemT> *>(
          data);
    
      while (true) {
        ItemT *item = consumer->tube_->PopFront();
        if (item->IsQuitBeacon()) { // <--- unintended early exit from loop
          delete item;
          break;
        }
        consumer->Process(item);    // <--- this would tube_counter_->PopFront()
      }
      consumer->OnTerminate();
      return NULL;
    }
```
    
This assertion actually does fire, crashing ingestsql process as launched by cvmfs_ln.test:

```
     Thread 2 received signal SIGABRT, Aborted.
     Completed event: 6991
     Current tick: 211308
     [Current thread is 2 (Thread 2546.2575)]
     (rr) bt
     #0  0x000072cde14d8e9c in __pthread_kill_implementation () from /lib64/libc.so.6
     #1  0x000072cde147ef3e in raise () from /lib64/libc.so.6
     #2  0x000072cde14666d0 in abort () from /lib64/libc.so.6
     #3  0x000072cde1466639 in __assert_fail_base.cold () from /lib64/libc.so.6
     #4  0x000000000042aeaf in catalog::WritableCatalogManager::CatalogDownloadCallback (this=0x7ffd514e2800, result=..., context=...) at /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1749
     #5  0x0000000000438149 in BoundClosure<CatalogDownloadResult, catalog::WritableCatalogManager, catalog::WritableCatalogManager::CatalogDownloadContext>::operator() (this=0x3239edf0, value=...) at /usr/local/src/cvmfs/cvmfs/util/async.h:138
     #6  0x000000000041bbf4 in Observable<CatalogDownloadResult>::NotifyListeners (this=0x32372a70, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
     #7  0x000000000041b379 in CatalogDownloadPipeline::OnFileProcessed (this=0x32372a70, catalog_download_result=...) at /usr/local/src/cvmfs/cvmfs/catalog_downloader.cc:43
     #8  0x000000000041ee0e in BoundCallback<CatalogDownloadResult, CatalogDownloadPipeline>::operator() (this=0x3239d190, value=...) at /usr/local/src/cvmfs/cvmfs/util/async.h:91
     #9  0x000000000041bbf4 in Observable<CatalogDownloadResult>::NotifyListeners (this=0x3239d330, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
     #10 0x000000000041b130 in TaskCatalogDownload::Process (this=0x3239d320, input=0x323a4220) at /usr/local/src/cvmfs/cvmfs/catalog_downloader.cc:15
     #11 0x000000000041ceb2 in TubeConsumer<CatalogItem>::MainConsumer (data=0x3239d320) at /usr/local/src/cvmfs/cvmfs/ingestion/task.h:56
     #12 0x000072cde14d6f54 in start_thread () from /lib64/libc.so.6
     #13 0x000072cde155a154 in clone () from /lib64/libc.so.6
     (rr) frame 4
     (rr) print nested_catalogs
     $18 = std::vector of length 1, capacity 1 = {{
         mountpoint = {
           long_string_ = 0x0,
           stack_ = "/dir/inner_dir\000\000\360U\001\204\315r\000\000\340T\001\204\315r\000\000\v\000\000\000\000\000\000\000self_chunks\000\000\000\000\000P\000\000\000\000\000\000\000T\000\000\000\000\000\000\000e\030ب\312r\000\000\360U\001\204\315r\000\000pV\001\204\315r\000\000\000\000\000\000\000\000\000\0000U\001\204\315r\000\000\016\000\000\000\000\000\000\000self_file_size\000\000X?:2\000\000\000\000Q\000\000\000\000\000\000\000@q\000\204\315r\000\000Ps\000\204\315r", '\000' <repeats 18 times>, "@J\001\204\315r\000\000\021\000\000\000\000\000\000\000\036",
           length_ = 14 '\016',
           static num_overflows_ = 0,
           static num_instances_ = 101
         },
         hash = {
           <shash::Digest<20, (shash::Algorithms)4>> = {
            digest = '\000' <repeats 19 times>,
            algorithm = shash::kAny,
            suffix = 0 '\000'
           }, <No data fields>},
         size = 0
       }}
```

Further debugging points to a row with path "/dir/inner_dir" read from bind_mountpoints SQL table:

```
     (rr) break FetchRow
     (rr) reverse-continue
     (rr) reverse-continue
     (rr) finish
     (rr) bt
     #0  0x000000000040aad7 in catalog::Catalog::ListNestedCatalogs (this=0x323a3c60) at /usr/local/src/cvmfs/cvmfs/catalog.cc:626
     #1  0x000000000042adc6 in catalog::WritableCatalogManager::CatalogDownloadCallback (this=0x7ffd514e2800, result=..., context=...) at /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1745
     #2  0x0000000000438149 in BoundClosure<CatalogDownloadResult, catalog::WritableCatalogManager, catalog::WritableCatalogManager::CatalogDownloadContext>::operator() (this=0x3239edf0, value=...)
         at /usr/local/src/cvmfs/cvmfs/util/async.h:138
     #3  0x000000000041bbf4 in Observable<CatalogDownloadResult>::NotifyListeners (this=0x32372a70, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
     #4  0x000000000041b379 in CatalogDownloadPipeline::OnFileProcessed (this=0x32372a70, catalog_download_result=...) at /usr/local/src/cvmfs/cvmfs/catalog_downloader.cc:43
     #5  0x000000000041ee0e in BoundCallback<CatalogDownloadResult, CatalogDownloadPipeline>::operator() (this=0x3239d190, value=...) at /usr/local/src/cvmfs/cvmfs/util/async.h:91
     #6  0x000000000041bbf4 in Observable<CatalogDownloadResult>::NotifyListeners (this=0x3239d330, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
     #7  0x000000000041b130 in TaskCatalogDownload::Process (this=0x3239d320, input=0x323a4220) at /usr/local/src/cvmfs/cvmfs/catalog_downloader.cc:15
     #8  0x000000000041ceb2 in TubeConsumer<CatalogItem>::MainConsumer (data=0x3239d320) at /usr/local/src/cvmfs/cvmfs/ingestion/task.h:56
     #9  0x000072cde14d6f54 in start_thread () from /lib64/libc.so.6
     #10 0x000072cde155a154 in clone () from /lib64/libc.so.6
     (rr) next
     (rr) next
     (rr) next
     (rr) next
     (rr) next
     (rr) print nested
     $29 = {
       mountpoint = {
         long_string_ = 0x0,
         stack_ = "/dir/inner_dir\000\000\3671]\000\000\000\000\000\030\032\000\204\315r\000\000\230\f\000\204\315r\000\000@\344\377\271\315r\000\000\270\354]\000\000\000\000\000\030\032\000\204\315r\000\000\230\f\000\204\315r\000\000`\344\377\271\315r\000\000,\203`\000\000\000\000\000\232\025\276h\000\000\000\000\003\000\000\000\001\000\000\000\300Z\001\204\315r\000\000 \000\000\000\000\000\000\000 \000\000\000\000\000\000\000\350.\000\204\315r\000\000@Z\001\204\315r\000\000 \000\000\000\000\000\000\000 \000\000\000\000\000\000\000|\230`\000\000\000\000\000\230\f\000\204\315r\000\000\247\344\377\271\315r\000\000\002", '\000' <repeats 15 times>,
         length_ = 14 '\016',
         static num_overflows_ = 0,
         static num_instances_ = 99
       },
       hash = {
         <shash::Digest<20, (shash::Algorithms)4>> = {
           digest = '\000' <repeats 19 times>,
           algorithm = shash::kAny,
           suffix = 0 '\000'
         }, <No data fields>},
       size = 0
     }
```