### PR TITLE
[deb] explicitly build release package with xz

### DIFF
--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -1,3 +1,10 @@
+
+cvmfs-release (4.7) unstable; urgency=low
+
+  * Force build with xz for debian 11 compatibility
+
+ -- Valentin Volkl <vavolkl@cern.ch>  Sat, 25 Oct 2025 13:20:00 +0200
+
 cvmfs-release (4.6-1) lucid; urgency=low
 
   * Add Debian 13 "trixie"

--- a/packaging/debian/cvmfs-release/rules
+++ b/packaging/debian/cvmfs-release/rules
@@ -1,3 +1,6 @@
 #!/usr/bin/make -f
 %:
 	dh $@
+
+override_dh_builddeb:
+	dh_builddeb -- -Zxz

--- a/packaging/debian/cvmfs-release/rules
+++ b/packaging/debian/cvmfs-release/rules
@@ -2,5 +2,7 @@
 %:
 	dh $@
 
+# for compatibility with debian 11
+# can be removed when all distros support zstd
 override_dh_builddeb:
 	dh_builddeb -- -Zxz


### PR DESCRIPTION
zstd not supported yet on debian 11

Fixes #3984