### PR TITLE
catalog_rw: hold lock for VacuumDatabaseIfNecessary()

### DIFF
--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -750,6 +750,7 @@ void WritableCatalog::VacuumDatabaseIfNecessary() {
   bool needs_defragmentation = false;
   double ratio = 0.0;
   std::string reason;
+  const MutexLockGuard m(lock_);
 
   if ((ratio = db.GetFreePageRatio()) > kMaximalFreePageRatio) {
     needs_defragmentation = true;


### PR DESCRIPTION
Observed SQLite errors
"cannot start a transaction within a transaction". The same catalog's database gets modified and vacuumed at the same time.

```
 Thread 2 (Thread 9156.9163 (cvmfs_swissknife_debug)):
 #0  0x000076a37a5ac728 in sqlite3_step () from /lib64/libsqlite3.so.0
 #1  0x00000000004e87cb in sqlite::Sql::Execute (this=0x5b09d10) at /usr/local/src/cvmfs/cvmfs/sql.cc:43
 #2  0x0000000000441410 in sqlite::Database<catalog::CatalogDatabase>::BeginTransaction (this=0x5b09680) at /usr/local/src/cvmfs/cvmfs/sql_impl.h:269
 #3  0x000000000044332e in catalog::WritableCatalog::Transaction (this=0x5b43f60) at /usr/local/src/cvmfs/cvmfs/catalog_rw.cc:75
 #4  0x000000000042bf54 in catalog::WritableCatalog::SetDirty (this=0x5b43f60) at /usr/local/src/cvmfs/cvmfs/catalog_rw.h:164
 #5  0x0000000000445867 in catalog::WritableCatalog::UpdateNestedCatalog (this=0x5b43f60, path="/dir/inner_dir5/inner_dir", hash=..., size=57344, child_counters=...) at /usr/local/src/cvmfs/cvmfs/catalog_rw.cc:596
 #6  0x000000000042aae9 in catalog::WritableCatalogManager::SingleCatalogUploadCallback (this=0x7fff5448d920, result=...) at /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1674
 #7  0x0000000000439812 in BoundCallback<upload::SpoolerResult, catalog::WritableCatalogManager>::operator() (this=0x5a4f1a0, value=...) at /usr/local/src/cvmfs/cvmfs/util/async.h:91
 #8  0x000000000046ee5e in Observable<upload::SpoolerResult>::NotifyListeners (this=0x59563f0, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
 #9  0x00000000005c35b5 in upload::Spooler::ProcessingCallback (this=0x59563f0, data=...) at /usr/local/src/cvmfs/cvmfs/upload.cc:133
 #10 0x00000000005c3d90 in BoundCallback<upload::SpoolerResult, upload::Spooler>::operator() (this=0x5969930, value=...) at /usr/local/src/cvmfs/cvmfs/util/async.h:91
 #11 0x000000000046ee5e in Observable<upload::SpoolerResult>::NotifyListeners (this=0x596b960, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
 #12 0x000000000046c1bf in IngestionPipeline::OnFileProcessed (this=0x596b960, spooler_result=...) at /usr/local/src/cvmfs/cvmfs/ingestion/pipeline.cc:115
 #13 0x0000000000474198 in BoundCallback<upload::SpoolerResult, IngestionPipeline>::operator() (this=0x596ad30, value=...) at /usr/local/src/cvmfs/cvmfs/util/async.h:91
 #14 0x000000000046ee5e in Observable<upload::SpoolerResult>::NotifyListeners (this=0x596d550, parameter=...) at /usr/local/src/cvmfs/cvmfs/util/concurrency_impl.h:174
 #15 0x0000000000478be7 in TaskRegister::Process (this=0x596d540, file_item=0x5b484e0) at /usr/local/src/cvmfs/cvmfs/ingestion/task_register.cc:30
 #16 0x0000000000470c31 in TubeConsumer<FileItem>::MainConsumer (data=0x596d540) at /usr/local/src/cvmfs/cvmfs/ingestion/task.h:56
 #17 0x000076a379ab1f54 in start_thread () from /lib64/libc.so.6
 #18 0x000076a379b35154 in clone () from /lib64/libc.so.6

 Thread 1 (Thread 9156.9156 (cvmfs_swissknife_debug)):
 #0  0x000076a379aba462 in __syscall_cancel_arch () from /lib64/libc.so.6
 #1  0x000076a379aae75c in __internal_syscall_cancel () from /lib64/libc.so.6
 #2  0x000076a379aae7a4 in __syscall_cancel () from /lib64/libc.so.6
 #3  0x000076a379b0b58c in pread64 () from /lib64/libc.so.6
 #4  0x000076a37a56925a in ?? () from /lib64/libsqlite3.so.0
 #5  0x000076a37a69aad3 in ?? () from /lib64/libsqlite3.so.0
 #6  0x000076a37a69afaa in ?? () from /lib64/libsqlite3.so.0
 #7  0x000076a37a59584e in sqlite3_backup_step () from /lib64/libsqlite3.so.0
 #8  0x000076a37a60a694 in ?? () from /lib64/libsqlite3.so.0
 #9  0x000076a37a5a3571 in ?? () from /lib64/libsqlite3.so.0
 #10 0x000076a37a5acae4 in sqlite3_step () from /lib64/libsqlite3.so.0
 #11 0x00000000004e87cb in sqlite::Sql::Execute (this=0x7fff5448c750) at /usr/local/src/cvmfs/cvmfs/sql.cc:43
 #12 0x0000000000446d13 in sqlite::Database<catalog::CatalogDatabase>::Vacuum (this=0x5b09680) at /usr/local/src/cvmfs/cvmfs/sql_impl.h:418
 #13 0x0000000000446652 in catalog::WritableCatalog::VacuumDatabaseIfNecessary (this=0x5b43f60) at /usr/local/src/cvmfs/cvmfs/catalog_rw.cc:767
 #14 0x000000000042913e in catalog::WritableCatalogManager::FinalizeCatalog (this=0x7fff5448d920, catalog=0x5b43f60, stop_for_tweaks=false) at /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1317
 #15 0x000000000042a6f4 in catalog::WritableCatalogManager::ScheduleReadyCatalogs (this=0x7fff5448d920) at /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1632
 #16 0x000000000052e80a in swissknife::IngestSQL::do_additions (this=0x59507a0, all_dirs=std::map with 18 elements = {...}, all_files=std::map with 10 elements = {...}, all_symlinks=std::map with 10 elements = {...}, lease_path="", catalog_manager=...) at /usr/local/src/cvmfs/cvmfs/swissknife_ingestsql.cc:1133
 #17 0x000000000052e007 in swissknife::IngestSQL::process_sqlite (this=0x59507a0, dbs=std::vector of length 1, capacity 1 = {...}, catalog_manager=..., allow_additions=true, allow_deletions=true, lease_path="", additional_prefix="") at /usr/local/src/cvmfs/cvmfs/swissknife_ingestsql.cc:1038
 #18 0x000000000052d4f4 in swissknife::IngestSQL::Main (this=0x59507a0, args=std::map with 12 elements = {...}) at /usr/local/src/cvmfs/cvmfs/swissknife_ingestsql.cc:889
 #19 0x0000000000553a40 in main (argc=24, argv=0x7fff5448f1a8) at /usr/local/src/cvmfs/cvmfs/swissknife_main.cc:189
 (rr) thread 1
 [Switching to thread 1 (Thread 9156.9156)]
 #0  0x000076a379aba462 in __syscall_cancel_arch () from /lib64/libc.so.6
 (rr) frame 11
 #11 0x00000000004e87cb in sqlite::Sql::Execute (this=0x7fff5448c750) at /usr/local/src/cvmfs/cvmfs/sql.cc:43
 43        last_error_code_ = sqlite3_step(statement_);
 (rr) print *this
 $53 = (sqlite::Sql) {
   _vptr.Sql = 0x66cfd0 <vtable for sqlite::Sql+16>,
   database_ = 0x5b0a050,
   statement_ = 0x5b34190,
   query_string_ = 0x0,
   last_error_code_ = 0
 }
 (rr) print database_
 $54 = (sqlite3 *) 0x5b0a050
 (rr) thread 2
 [Switching to thread 2 (Thread 9156.9163)]
 #0  0x000076a37a5ac728 in sqlite3_step () from /lib64/libsqlite3.so.0
 (rr) frame 2
 #2  0x0000000000441410 in sqlite::Database<catalog::CatalogDatabase>::BeginTransaction (this=0x5b09680) at /usr/local/src/cvmfs/cvmfs/sql_impl.h:269
 269       return begin_transaction_->Execute() && begin_transaction_->Reset();
 (rr) print database_
 $55 = {
   sqlite_db = 0x5b0a050,
   lookaside_buffer = 0x0,
   db_file_guard = {
     <SingleCopy> = {<No data fields>},
     members of UnlinkGuard:
     path_ = "/tmp/cvmfs_rsync_swissknife769119102/catalog.JTKTzC",
     enabled_ = true
   },
   delegate_ = 0x5b09680
 }
 (rr)
```