### PR TITLE
S3FanoutManager: unhardcode "Cache-Control: max-age" value for PUT .cvmfs*

### DIFF
--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -227,8 +227,9 @@ class S3FanoutManager : SingleCopy {
  private:
   // Reflects the default Apache configuration of the local backend
   static const char *kCacheControlCas;          // Cache-Control: max-age=259200
-  static const char *kCacheControlDotCvmfs;     // Cache-Control: max-age=61
   static const unsigned kLowSpeedLimit = 1024;  // Require at least 1kB/s
+
+  std::string MkDotCvmfsCacheControlHeader(unsigned defaultMaxAge=61, int overrideMaxAge=-1);
 
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);
@@ -335,6 +336,8 @@ class S3FanoutManager : SingleCopy {
    * Carries the path settings for SSL certificates
    */
   SslCertificateStore ssl_certificate_store_;
+
+  std::string dot_cvmfs_cache_control_header;           // Cache-Control: max-age=...
 };  // S3FanoutManager
 
 }  // namespace s3fanout


### PR DESCRIPTION
It had hardcoded value of 61 second, which is remembered by e.g. Minio S3 server, which is inconvenient for testing.

S3FanoutManager can set max-age to any non-negative integer value. If no such override value is given, it looks for environment variables CVMFS_MAX_TTL_SEC or CVMFS_MAX_TTL; if not found, it uses the fallback value (same as was, 61).

To make `cvmfs_config mkfs` conform to desired setting, it can be put into /etc/cvmfs/default.d/99-something.conf .