### PR TITLE
Avoid accessing held mutexes after forking

### DIFF
--- a/cvmfs/util/posix.h
+++ b/cvmfs/util/posix.h
@@ -105,7 +105,8 @@ CVMFS_EXPORT int RecvFdFromSocket(int msg_fd);
 CVMFS_EXPORT std::string GetHostname();
 
 CVMFS_EXPORT bool SwitchCredentials(const uid_t uid, const gid_t gid,
-                                    const bool temporarily);
+                                    const bool temporarily,
+                                    const bool avoid_mutexes = false);
 
 CVMFS_EXPORT bool FileExists(const std::string &path);
 CVMFS_EXPORT int64_t GetFileSize(const std::string &path);


### PR DESCRIPTION
CVMFS uses fork() to launch a subprocess to interpret shell-syntax config files. But between fork() and exec(), the forked child writes log messages. The logging messages themselves seem to not go anywhere, but the attempt to operate on the LogBuffer object involves obtaining its mutex. And if this mutex was held at the moment of forking, the forked, single-threaded process issues a system call to wait on this mutex, which is wrong. It has been observed multiple times that the forked child aburptly terminates (either rr or kernel does it), and the parent process waits forever.

This patch addresses this issue by sending an extra parameter to the only procedure, SwitchCredentials(), which is called between fork() and exec() and issues log messages.

Possible alternative approaches:
* unrolling the SwitchCredentials() into caller, ManagedExec();
* purging the invalid mutex object state, and possibly reestablishing the flushing of the LogBuffer;
* lockless LogBuffer.

Below is a long-winded show of evidence and the explanation.

The following traces show a specific case, but the issue seems to have some generality, as `ManagedExec()`, `ExecuteBinary()` and `BashOptionsManager` are in widespread use.

This has been seen, by now, two times, on different hardware, in Docker containers inside KVM virtual machines, on `cvmfs_swissknife_debug` binary running under `rr` debugger, executing its `sync` command, launched by `cvmfs_server mkfs` command. This happens only sometimes, not every time. I do not know yet whether this occurs without `rr`.

The immediately observable issue is that `cvmfs_swissknife sync` hangs indefinitely.

It hangs because the main process waits to read back from a forked subprocess launched from `BashOptionsManager::ParsePath()` to interpret a shell-syntax config file.

In the forked process, right after the `fork()`, the process executes `SwitchCredentials()` procedure, which executes a logging operation. The process terminates at the moment it enters a `futex_wait` system call as a part of `pthread_mutex_lock()` glibc libpthread routine. `rr` says the forked child terminated with SIGKILL, as it often wrongly says, but here it might actually be correct, if there happens to be a sanity check in the kernel, that a single-threaded process should not wait for a locked private mutex. However, this does not generate any interesting log lines in syslog, journald, dmesg or docker logs - neither in container nor in the VM.

So the system is not explicitly telling any exact reason why it has terminated this process. But the last operation which the forked process did is inadequate: the mutex is regular and not process-shared, and the mutex is in private memory, so a single-thread process making a system call to wait on a regular mutex is not doing the right thing.

From here it's easy to unwind why it happened. The LogBuffer uses its own mutex, and its memory state is inherited from the parent process, and the mutex happened to be held at the moment of the forking.

The fix is to either avoid use of that mutex, or to recreate it.

	(rr) info threads
	  Id   Target Id                                   Frame
	* 1    Thread 45382.45382 (cvmfs_swissknife_debug) __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
	  2    Thread 45382.45387 (cvmfs_swissknife_debug) __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
	(rr) thread apply all bt

	Thread 2 (Thread 45382.45387 (cvmfs_swissknife_debug)):
	#0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
	#1  0x00007c2a31b8675c in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=a4@entry=0, a5=a5@entry=0, a6=a6@entry=0, nr=7) at cancellation.c:49
	#2  0x00007c2a31b867a4 in __syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=a4@entry=0, a5=a5@entry=0, a6=a6@entry=0, nr=7) at cancellation.c:75
	#3  0x00007c2a31c0029e in __GI___poll (fds=<optimized out>, nfds=<optimized out>, timeout=<optimized out>) at ../sysdeps/unix/sysv/linux/poll.c:29
	#4  0x0000000000483f89 in Watchdog::MainWatchdogListener (data=0x36e7ea50) at /usr/local/src/cvmfs/cvmfs/monitor.cc:572
	#5  0x00007c2a31b89f54 in start_thread (arg=<optimized out>) at pthread_create.c:448
	#6  0x00007c2a31c0d154 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:100

	Thread 1 (Thread 45382.45382 (cvmfs_swissknife_debug)):
	#0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
	#1  0x00007c2a31b8675c in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=a4@entry=0, a5=a5@entry=0, a6=a6@entry=0, nr=0) at cancellation.c:49
	#2  0x00007c2a31b867a4 in __syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=a4@entry=0, a5=a5@entry=0, a6=a6@entry=0, nr=0) at cancellation.c:75
	#3  0x00007c2a31c007fe in __GI___libc_read (fd=<optimized out>, buf=<optimized out>, nbytes=<optimized out>) at ../sysdeps/unix/sysv/linux/read.c:26
	#4  0x00007c2a327d5c0e in Pipe<(PipeType)4>::ReadPipe (this=0x7ffca3762644, fd=15, buf=0x7ffca3762640, nbyte=4) at /usr/local/src/cvmfs/cvmfs/util/pipe.h:238
	#5  0x00007c2a327d38b1 in Pipe<(PipeType)4>::Read<ForkFailures::Names> (this=0x7ffca3762644, data=0x7ffca3762640) at /usr/local/src/cvmfs/cvmfs/util/pipe.h:167
	#6  0x00007c2a327d0e9d in ManagedExec (command_line=std::vector of length 1, capacity 1 = {...}, preserve_fildes=std::set with 3 elements = {...}, map_fildes=std::map with 3 elements = {...}, drop_credentials=true, clear_env=false, double_fork=true, child_pid=0x0) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:2013
	#7  0x00007c2a327d05ef in ExecuteBinary (fd_stdin=0x7ffca37629bc, fd_stdout=0x7ffca37629b8, fd_stderr=0x7ffca37629b4, binary_path="/bin/sh", argv=std::vector of length 0, capacity 0, double_fork=true, child_pid=0x0) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1756
	#8  0x00007c2a327d076f in Shell (fd_stdin=0x7ffca37629bc, fd_stdout=0x7ffca37629b8, fd_stderr=0x7ffca37629b4) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1785
	#9  0x00000000004c5ae3 in BashOptionsManager::ParsePath (this=0x7ffca3762b80, config_file="/etc/cvmfs/s3.conf", external=false) at /usr/local/src/cvmfs/cvmfs/options.cc:218
	#10 0x00000000005cced2 in upload::S3Uploader::ParseSpoolerDefinition (this=0x36e82cd0, spooler_definition=...) at /usr/local/src/cvmfs/cvmfs/upload_s3.cc:128
	#11 0x00000000005cc915 in upload::S3Uploader::S3Uploader (this=0x36e82cd0, spooler_definition=...) at /usr/local/src/cvmfs/cvmfs/upload_s3.cc:62
	#12 0x00000000005c7f4b in AbstractFactoryImpl2<upload::S3Uploader, upload::AbstractUploader, upload::SpoolerDefinition, void>::Construct (this=0x36e82c90, param=...) at /usr/local/src/cvmfs/cvmfs/util/plugin.h:67
	#13 0x000000000050a663 in PolymorphicConstructionImpl<upload::AbstractUploader, upload::SpoolerDefinition, void>::Construct (param=...) at /usr/local/src/cvmfs/cvmfs/util/plugin.h:181
	#14 0x00000000005c365b in upload::Spooler::Initialize (this=0x36e82a60, statistics=0x7ffca3763a30) at /usr/local/src/cvmfs/cvmfs/upload.cc:38
	#15 0x00000000005c33d8 in upload::Spooler::Construct (spooler_definition=..., statistics=0x7ffca3763a30) at /usr/local/src/cvmfs/cvmfs/upload.cc:17
	#16 0x000000000059de55 in swissknife::CommandSync::Main (this=0x36e7c9c0, args=std::map with 21 elements = {...}) at /usr/local/src/cvmfs/cvmfs/swissknife_sync.cc:781
	#17 0x0000000000554186 in main (argc=40, argv=0x7ffca3766028) at /usr/local/src/cvmfs/cvmfs/swissknife_main.cc:190
	(rr) frame 6
	#6  0x00007c2a327d0e9d in ManagedExec (command_line=std::vector of length 1, capacity 1 = {...}, preserve_fildes=std::set with 3 elements = {...},
	    map_fildes=std::map with 3 elements = {...}, drop_credentials=true, clear_env=false, double_fork=true, child_pid=0x0)
	    at /usr/local/src/cvmfs/cvmfs/util/posix.cc:2013
	2013      pipe_fork.Read<ForkFailures::Names>(&status_code);
	(rr) print pid
	$1 = 45388
	(rr) print double_fork
	$2 = true
	(rr) quit

	[root@d14cf42cac61 rr]# rr ps cvmfs_swissknife_debug-412
	PID     PPID    EXIT    CMD
	45382   --      -9      /usr/bin/cvmfs_swissknife_debug sync -u /cvmfs/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482 -s /var/spool/cvmfs/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482/scratch/current -c /var/spool/cvmfs/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482/rdonly -t /var/spool/cvmfs/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482/tmp -b 8ef063afa6f8dd7fc2ff7db7bfb89bdbbf4dd22b -r S3,/var/spool/cvmfs/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482/tmp,test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482@/etc/cvmfs/s3.conf -w http://127.0.0.1:9000/mybucket/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482 -o /var/spool/cvmfs/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482/tmp/manifest -e sha1 -Z default -N test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482 -K /etc/cvmfs/keys/test.repo.cvmfs_setfacl.2025-09-22_13_31_02.028607482.pub -L -Y -D generic-2025-09-22T13:31:04Z -f overlayfs -p -l 4194304 -a 8388608 -h 16777216 -i
	45383   45382   0       (forked without exec)
	45384   45383   0       (forked without exec)
	45385   45384   0       (forked without exec)
	45386   45385   -9      (forked without exec)
	45388   45382   0       (forked without exec)
	45389   45388   -9      (forked without exec)
	45514   45386   0       gdb -p 45382
	45515   45514   0       iconv -l
	45517   45514   -9      (forked without exec)
	45518   45514   -9      (forked without exec)

	[root@d14cf42cac61 log]# rr replay -f 45388 ~/.local/share/rr//cvmfs_swissknife_debug-412/
	...
	--------------------------------------------------
	 ---> Reached target process 45388 at event 773.
	--------------------------------------------------
	...
	(rr) info threads
	  Id   Target Id                                   Frame
	* 1    Thread 45388.45388 (cvmfs_swissknife_debug) 0x0000000070000002 in syscall_traced ()
	(rr) c
	Continuing.

	Program received signal SIGKILL, Killed.
	[Current thread is 1 (Thread 45388.45388)]
	#0  0x0000000070000002 in syscall_traced ()
	(rr) bt
	#0  0x0000000070000002 in syscall_traced ()
	Backtrace stopped: Cannot access memory at address 0x7c2a30fffde0
	(rr) rsi
	(rr) bt
	#0  _raw_syscall () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/raw_syscall.S:120
	#1  0x00007c2a329b12fd in traced_raw_syscall (call=<optimized out>) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:379
	#2  0x00007c2a329b4748 in sys_set_robust_list (call=<optimized out>) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:3906
	#3  syscall_hook_internal (call=0x7c2a30ffffa0) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:4280
	#4  syscall_hook (call=0x7c2a30ffffa0) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:4387
	#5  syscall_hook (call=0x7c2a30ffffa0) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:4371
	#6  0x00007c2a329b05c3 in _syscall_hook_trampoline () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscall_hook.S:308
	#7  0x00007c2a329b062d in __morestack () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscall_hook.S:443
	#8  0x00007c2a329b0649 in _syscall_hook_trampoline_48_3d_00_f0_ff_ff () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscall_hook.S:462
	#9  0x00007c2a31bd80ce in __GI__exit (status=0) at ../sysdeps/unix/sysv/linux/_exit.c:30
	#10 0x00007c2a327d0cde in ManagedExec (command_line=std::vector of length 1, capacity 1 = {...}, preserve_fildes=std::set with 3 elements = {...},
	    map_fildes=std::map with 3 elements = {...}, drop_credentials=true, clear_env=false, double_fork=true, child_pid=0x0)
	    at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1967
	#11 0x00007c2a327d05ef in ExecuteBinary (fd_stdin=0x7ffca37629bc, fd_stdout=0x7ffca37629b8, fd_stderr=0x7ffca37629b4, binary_path="/bin/sh",
	    argv=std::vector of length 0, capacity 0, double_fork=true, child_pid=0x0) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1756
	#12 0x00007c2a327d076f in Shell (fd_stdin=0x7ffca37629bc, fd_stdout=0x7ffca37629b8, fd_stderr=0x7ffca37629b4) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1785
	#13 0x00000000004c5ae3 in BashOptionsManager::ParsePath (this=0x7ffca3762b80, config_file="/etc/cvmfs/s3.conf", external=false)
	    at /usr/local/src/cvmfs/cvmfs/options.cc:218
	#14 0x00000000005cced2 in upload::S3Uploader::ParseSpoolerDefinition (this=0x36e82cd0, spooler_definition=...) at /usr/local/src/cvmfs/cvmfs/upload_s3.cc:128
	#15 0x00000000005cc915 in upload::S3Uploader::S3Uploader (this=0x36e82cd0, spooler_definition=...) at /usr/local/src/cvmfs/cvmfs/upload_s3.cc:62
	#16 0x00000000005c7f4b in AbstractFactoryImpl2<upload::S3Uploader, upload::AbstractUploader, upload::SpoolerDefinition, void>::Construct (this=0x36e82c90,
	    param=...) at /usr/local/src/cvmfs/cvmfs/util/plugin.h:67
	#17 0x000000000050a663 in PolymorphicConstructionImpl<upload::AbstractUploader, upload::SpoolerDefinition, void>::Construct (param=...)
	    at /usr/local/src/cvmfs/cvmfs/util/plugin.h:181
	#18 0x00000000005c365b in upload::Spooler::Initialize (this=0x36e82a60, statistics=0x7ffca3763a30) at /usr/local/src/cvmfs/cvmfs/upload.cc:38
	#19 0x00000000005c33d8 in upload::Spooler::Construct (spooler_definition=..., statistics=0x7ffca3763a30) at /usr/local/src/cvmfs/cvmfs/upload.cc:17
	#20 0x000000000059de55 in swissknife::CommandSync::Main (this=0x36e7c9c0, args=std::map with 21 elements = {...})
	    at /usr/local/src/cvmfs/cvmfs/swissknife_sync.cc:781
	#21 0x0000000000554186 in main (argc=40, argv=0x7ffca3766028) at /usr/local/src/cvmfs/cvmfs/swissknife_main.cc:190
	(rr) frame 10
	#10 0x00007c2a327d0cde in ManagedExec (command_line=std::vector of length 1, capacity 1 = {...}, preserve_fildes=std::set with 3 elements = {...},
	    map_fildes=std::map with 3 elements = {...}, drop_credentials=true, clear_env=false, double_fork=true, child_pid=0x0)
	    at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1967
	1967            _exit(0);
	(rr) print pid_grand_child
	$1 = 45389
	(rr) quit

	[root@d14cf42cac61 rr]# rr replay -f 45389 cvmfs_swissknife_debug-412
	...
	--------------------------------------------------
	 ---> Reached target process 45389 at event 863.
	--------------------------------------------------
	...
	(rr) c
	Continuing.

	Program received signal SIGKILL, Killed.
	(rr) info threads
	  Id   Target Id                                   Frame
	* 1    Thread 45389.45389 (cvmfs_swissknife_debug) 0x0000000070000002 in syscall_traced ()
	(rr) bt
	#0  0x0000000070000002 in syscall_traced ()
	#1  0x00007c2a329b6fd8 in _raw_syscall () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/raw_syscall.S:120
	#2  0x00007c2a329b12fd in traced_raw_syscall (call=<optimized out>) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:379
	#3  0x00007c2a329b620b in syscall_hook_internal (call=0x7c2a30dfffa0) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:4203
	#4  syscall_hook (call=0x7c2a30dfffa0) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:4387
	#5  syscall_hook (call=0x7c2a30dfffa0) at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscallbuf.c:4371
	#6  0x00007c2a329b05c3 in _syscall_hook_trampoline () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscall_hook.S:308
	#7  0x00007c2a329b062d in __morestack () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscall_hook.S:443
	#8  0x00007c2a329b0649 in _syscall_hook_trampoline_48_3d_00_f0_ff_ff () at /builddir/build/BUILD/rr-5.9.0-build/rr-5.9.0/src/preload/syscall_hook.S:462
	#9  0x00007c2a31b87006 in futex_wait (futex_word=0x7c2a32812e40 <(anonymous namespace)::g_log_buffer>, expected=2, private=0)
	    at ../sysdeps/nptl/futex-internal.h:146
	#10 __GI___lll_lock_wait (futex=futex@entry=0x7c2a32812e40 <(anonymous namespace)::g_log_buffer>, private=0) at lowlevellock.c:49
	#11 0x00007c2a31b8d501 in lll_mutex_lock_optimized (mutex=0x7c2a32812e40 <(anonymous namespace)::g_log_buffer>) at pthread_mutex_lock.c:48
	#12 ___pthread_mutex_lock (mutex=0x7c2a32812e40 <(anonymous namespace)::g_log_buffer>) at pthread_mutex_lock.c:93
	#13 0x00007c2a327c31f1 in RAII<pthread_mutex_t, (RAII_Polymorphism::T)0>::Enter (this=0x7ffca3762130) at /usr/local/src/cvmfs/cvmfs/util/mutex.h:77
	#14 0x00007c2a327c3245 in RAII<pthread_mutex_t, (RAII_Polymorphism::T)0>::RAII (this=0x7ffca3762130, object=...) at /usr/local/src/cvmfs/cvmfs/util/mutex.h:44
	#15 0x00007c2a327c4cbc in (anonymous namespace)::LogBuffer::Append (this=0x7c2a32812e40 <(anonymous namespace)::g_log_buffer>, entry=...)
	    at /usr/local/src/cvmfs/cvmfs/util/logging.cc:112
	#16 0x00007c2a327c6493 in vLogCvmfs (source=kLogCvmfs, mask=1,
	    format=0x7c2a328023a8 "current credentials uid %d gid %d euid %d egid %d, switching to %d %d (temp: %d)", variadic_list=0x7ffca3762458)
	    at /usr/local/src/cvmfs/cvmfs/util/logging.cc:545
	#17 0x00007c2a327c6712 in LogCvmfs (source=kLogCvmfs, mask=1,
	    format=0x7c2a328023a8 "current credentials uid %d gid %d euid %d egid %d, switching to %d %d (temp: %d)")
	    at /usr/local/src/cvmfs/cvmfs/util/logging.cc:553
	#18 0x00007c2a327cc70f in SwitchCredentials (uid=0, gid=0, temporarily=false) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:789
	#19 0x00007c2a327d0db5 in ManagedExec (command_line=std::vector of length 1, capacity 1 = {...}, preserve_fildes=std::set with 3 elements = {...},
	    map_fildes=std::map with 3 elements = {...}, drop_credentials=true, clear_env=false, double_fork=true, child_pid=0x0)
	    at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1984
	#20 0x00007c2a327d05ef in ExecuteBinary (fd_stdin=0x7ffca37629bc, fd_stdout=0x7ffca37629b8, fd_stderr=0x7ffca37629b4, binary_path="/bin/sh",
	    argv=std::vector of length 0, capacity 0, double_fork=true, child_pid=0x0) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1756
	#21 0x00007c2a327d076f in Shell (fd_stdin=0x7ffca37629bc, fd_stdout=0x7ffca37629b8, fd_stderr=0x7ffca37629b4) at /usr/local/src/cvmfs/cvmfs/util/posix.cc:1785
	#22 0x00000000004c5ae3 in BashOptionsManager::ParsePath (this=0x7ffca3762b80, config_file="/etc/cvmfs/s3.conf", external=false)
	    at /usr/local/src/cvmfs/cvmfs/options.cc:218
	#23 0x00000000005cced2 in upload::S3Uploader::ParseSpoolerDefinition (this=0x36e82cd0, spooler_definition=...) at /usr/local/src/cvmfs/cvmfs/upload_s3.cc:128
	#24 0x00000000005cc915 in upload::S3Uploader::S3Uploader (this=0x36e82cd0, spooler_definition=...) at /usr/local/src/cvmfs/cvmfs/upload_s3.cc:62
	#25 0x00000000005c7f4b in AbstractFactoryImpl2<upload::S3Uploader, upload::AbstractUploader, upload::SpoolerDefinition, void>::Construct (this=0x36e82c90,
	    param=...) at /usr/local/src/cvmfs/cvmfs/util/plugin.h:67
	#26 0x000000000050a663 in PolymorphicConstructionImpl<upload::AbstractUploader, upload::SpoolerDefinition, void>::Construct (param=...)
	    at /usr/local/src/cvmfs/cvmfs/util/plugin.h:181
	#27 0x00000000005c365b in upload::Spooler::Initialize (this=0x36e82a60, statistics=0x7ffca3763a30) at /usr/local/src/cvmfs/cvmfs/upload.cc:38
	#28 0x00000000005c33d8 in upload::Spooler::Construct (spooler_definition=..., statistics=0x7ffca3763a30) at /usr/local/src/cvmfs/cvmfs/upload.cc:17
	#29 0x000000000059de55 in swissknife::CommandSync::Main (this=0x36e7c9c0, args=std::map with 21 elements = {...})
	    at /usr/local/src/cvmfs/cvmfs/swissknife_sync.cc:781
	#30 0x0000000000554186 in main (argc=40, argv=0x7ffca3766028) at /usr/local/src/cvmfs/cvmfs/swissknife_main.cc:190
	(rr) frame 11
	#11 0x00007c2a31b8d501 in lll_mutex_lock_optimized (mutex=0x7c2a32812e40 <(anonymous namespace)::g_log_buffer>) at pthread_mutex_lock.c:48
	48          lll_lock (mutex->__data.__lock, private);
	(rr) print mutex->__data.__lock
	$6 = 2
	(rr) print mutex->__data.__owner
	$7 = 45387
	(rr)