### PR TITLE
Dynamic vendoring of libfuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ RemoteSystemsTempFiles/
 # Externals
 externals/build_*/
 externals/.decompressionDone
+externals/libfuse*
 externals_build*
 externals_install*
 externals/*.tar*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,6 +479,56 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS OR BUILD_LIBCVMFS_CACHE OR
   set (INCLUDE_DIRECTORIES ${INCLUDE_DIRECTORIES} ${PROTOBUF_INCLUDE_DIRS})
 endif ()
 
+# Fetch and build libfuse if a specific version is requested
+if (LIBFUSE_VERSION)
+  include(ExternalProject)
+  set(LIBFUSE_URL "https://github.com/libfuse/libfuse/releases/download/fuse-${LIBFUSE_VERSION}/fuse-${LIBFUSE_VERSION}.tar.gz")
+  set(LIBFUSE_INSTALL_DIR "${EXTERNALS_INSTALL_LOCATION}/libfuse-${LIBFUSE_VERSION}")
+  set(LIBFUSE_BUILD_DIR "${EXTERNALS_BUILD_LOCATION}/build_libfuse-${LIBFUSE_VERSION}")
+  set(LIBFUSE_SOURCE_DIR "${EXTERNALS_LIB_LOCATION}/libfuse-${LIBFUSE_VERSION}")
+
+  ExternalProject_Add(libfuse_external
+    URL ${LIBFUSE_URL}
+    SOURCE_DIR ${LIBFUSE_SOURCE_DIR}
+    BINARY_DIR ${LIBFUSE_BUILD_DIR}
+    INSTALL_DIR ${LIBFUSE_INSTALL_DIR}
+    PREFIX "${EXTERNALS_BUILD_LOCATION}/build_libfuse-${LIBFUSE_VERSION}"
+    CONFIGURE_COMMAND
+      meson setup
+      --prefix=${LIBFUSE_INSTALL_DIR}
+      -Dudevrulesdir=lib/udev/rules.d
+      -Dinitscriptdir=etc/init.d
+      -Duseroot=false
+      -Dexamples=false
+      -Dtests=false
+      ${LIBFUSE_BUILD_DIR}
+      ${LIBFUSE_SOURCE_DIR}
+    BUILD_COMMAND ninja -C ${LIBFUSE_BUILD_DIR}
+    INSTALL_COMMAND ninja -C ${LIBFUSE_BUILD_DIR} install
+  )
+
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+  
+  # Set FUSE3_INCLUDE_DIR and FUSE3_LIBRARY to use the locally built libfuse
+  set(FUSE3_INCLUDE_DIR "${LIBFUSE_INSTALL_DIR}/include" CACHE PATH "libfuse3 include dir")
+  set(FUSE3_LIBRARY "${LIBFUSE_INSTALL_DIR}/lib/x86_64-linux-gnu/libfuse3.so" CACHE FILEPATH "libfuse3 library path")
+
+  # Add dependencies for all FUSE-related targets
+  if(TARGET cvmfs_fuse3_stub)
+    add_dependencies(cvmfs_fuse3_stub libfuse_external)
+  endif()
+  if(TARGET cvmfs_fuse3)
+    add_dependencies(cvmfs_fuse3 libfuse_external)
+  endif()
+  if(TARGET cvmfs_fuse3_debug)
+    add_dependencies(cvmfs_fuse3_debug libfuse_external)
+  endif()
+
+  message(STATUS "Using libfuse: ${LIBFUSE_VERSION} from ${LIBFUSE_INSTALL_DIR}")
+else()
+  message(STATUS "No LIBFUSE_VERSION specified, using system libfuse")
+endif()
+
 # Fuse client only
 if (BUILD_CVMFS)
   if (MACOSX)

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -26,6 +26,7 @@ option (BUILD_STRESS_TESTS      "Build the stress tests"                        
 option (BUILD_DOCUMENTATION     "Build the CerVM-FS documentation using Doxygen"                   OFF)
 option (BUILD_COVERAGE          "Compile to collect code coverage reports"                         OFF)
 option (BUILD_LIBFUSE2          "Build the libraries for libfuse2 support"                         OFF)
+option (LIBFUSE_VERSION         "Build the libraries for a specific libfuse version (e.g. 3.10.5)" "")
 option (BUILD_GATEWAY           "Build cvmfs_gateway, requires go compiler"                        OFF)
 option (BUILD_DUCC              "Build cvmfs_ducc, requires go compiler"                           OFF)
 option (BUILD_SNAPSHOTTER       "Build cvmfs_snapshotter, it requires a go compiler"               OFF)

--- a/doc/developer/30-building-from-source.md
+++ b/doc/developer/30-building-from-source.md
@@ -61,6 +61,16 @@ or
 - Copy respective `libcvmfs*` from `cvmfs/build/cvmfs/` to `/usr/lib/`
 
 
+### Example: Use specific libfuse version (e.g. 3.17.4)
+```
+mkdir build && cd build
+cmake -DLIBFUSE_VERSION=3.17.4 ../
+ninja
+sudo ninja install
+```
+- This will fetch given valid libfuse version from [libfuse repository](https://github.com/libfuse/libfuse/releases), build it and link it to cvmfs for use.
+- The source and build artifacts for libfuse will be present in externals and externals_build respectively.
+
 ### Example: Locally build Fuse3 to have version 3.10
 
 1) Build [libfuse](https://github.com/libfuse/libfuse/) from source 


### PR DESCRIPTION
This PR contains a feature addition to dynamically vendor libfuse using cmake.

Key features includes:
- New cmake flag `LIBFUSE_VERSION`
- Fetching, building, installing and linking given libfuse version to cvmfs libraries
- Documentation update for example usage