### PR TITLE
Add 507 s3 error

### DIFF
--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -94,6 +94,9 @@ static size_t CallbackCurlHeader(void *ptr, size_t size, size_t nmemb,
           info->throttle_ms = S3FanoutManager::kDefault429ThrottleMs;
           info->throttle_timestamp = platform_monotonic_time();
           return num_bytes;
+        case 507:  // Insufficient Storage
+          info->error_code = kFailInsufficientStorage;
+          break;
         case 503:
         case 502:  // Can happen if the S3 gateway-backend connection breaks
         case 500:  // sometimes see this as a transient error from S3

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -48,6 +48,7 @@ enum Failures {
   kFailNotFound,
   kFailServiceUnavailable,
   kFailRetry,
+  kFailInsufficientStorage,
   kFailOther,
 
   kFailNumEntries
@@ -66,7 +67,8 @@ inline const char *Code2Ascii(const Failures error) {
   texts[7] = "S3: service not available";
   texts[8] = "S3: unknown service error, perhaps wrong authentication protocol";
   texts[8] = "S3: too many requests, service asks for backoff and retry";
-  texts[9] = "no text";
+  texts[9] = "S3: Insufficient Storage";
+  texts[10] = "no text";
   return texts[error];
 }
 

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -68,7 +68,7 @@ inline const char *Code2Ascii(const Failures error) {
   texts[8] = "S3: unknown service error, perhaps wrong authentication protocol";
   texts[8] = "S3: too many requests, service asks for backoff and retry";
   texts[9] = "S3: Insufficient Storage";
-  texts[10] = "no text";
+  texts[10] = "unclassified failure";
   return texts[error];
 }
 


### PR DESCRIPTION
s3fanout: classify backend error "507 Insufficient Storage"

MinIO returns it when it runs out of disk space.
It returns "507 Insufficient Storage" which is a standard HTTP response
code and meaning.
This happened to me a number of times during stress-testing. The logs
said "error code 9 - no text" which is not obvious.

----

And another tiny change: "s3fanout: improve generic error description".