### PR TITLE
test: add 904-umount-should-stop-cvmfs2

### DIFF
--- a/test/src/904-umount-should-stop-cvmfs2/main
+++ b/test/src/904-umount-should-stop-cvmfs2/main
@@ -1,0 +1,19 @@
+#!/bin/bash
+cvmfs_test_name="umount-should-stop-cvmfs2"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+cleanup() {
+  true
+}
+
+cvmfs_run_test() {
+  [[ -v TEST_ROOT ]] # expected /home/sftnight/cvmfs/test
+  this_script_dir=$TEST_ROOT/src/904-umount-should-stop-cvmfs2
+  # We want strict mode here, to catch any failure.
+  # But turning on errexit (set -e) inside a function has no effect.
+  # So we exec our script to keep its error handling mode independent from test/run.sh.
+  exe="$this_script_dir"/run_test
+  echo Launching "$exe"
+  exec "$exe" "$@"
+}

--- a/test/src/904-umount-should-stop-cvmfs2/run_test
+++ b/test/src/904-umount-should-stop-cvmfs2/run_test
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+mkdir -p /var/{spool,run}/cvmfs/
+[[ -d /etc/cvmfs/default.d ]]
+cat > /etc/cvmfs/default.d/99-test.conf <<EOF
+CVMFS_USER=$(whoami)
+CVMFS_HTTP_PROXY=DIRECT
+CVMFS_AUTO_UPDATE=yes
+CVMFS_DEBUGLOG=/var/log/cvmfs-debug.log
+EOF
+export CVMFS_TEST_USER=$(whoami)
+export CVMFS_TEST_REPO=test.repo.$(date +%F_%H_%M_%S.%N)
+
+rsyslogd &
+systemctl enable --now httpd
+
+rm -rf /var/spool/cvmfs/$CVMFS_TEST_REPO # just in case
+cp -a /etc/fstab{,.orig}
+> /etc/fstab
+cvmfs_server mkfs -o "$CVMFS_TEST_USER" "$CVMFS_TEST_REPO"
+export CVMFS_TEST_MOUNTPOINT=/cvmfs/$CVMFS_TEST_REPO
+cat "$CVMFS_TEST_MOUNTPOINT"/new_repository
+
+# BUG FIXME umount does not reliably stops cvmfs2, its processes linger and block new mount.
+pgrep cvmfs2
+umount /var/spool/cvmfs/"$CVMFS_TEST_REPO"/rdonly
+sleep 10
+[[ "$(pgrep cvmfs2)" == "" ]]
+timeout 10 mount  /var/spool/cvmfs/"$CVMFS_TEST_REPO"/rdonly


### PR DESCRIPTION
An unexpectedly failing test which unmounts the actual cvmfs mount and expects cvmfs2 processes to be gone, and for success in mounting it again.

Still wondering: is it just me? Or is it "normal" that they linger? Or is there a setting?