### PR TITLE
gitignore build folders like build.ubuntu25.04.aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ test/mylog
 ._*
 .fuse_hidden*
 build/
-build-*/
+/build*/
 benchmark/
 *.pyc
 test/cloud_testing/ec2_config.sh


### PR DESCRIPTION
Especially when building in docker images or lima on mac, there may be more than one build directory, so it helps to allow longer names than just build.