### PR TITLE
cvmfs_server check: add -x option for custom scratch dir

### DIFF
--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -79,11 +79,11 @@ __do_check() {
   local with_reflog=
   has_reflog_checksum $name && with_reflog="-R $(get_reflog_checksum $name)"
 
-  default_scratch_dir="$CVMFS_SPOOL_DIR/tmp"
-
+  default_scratch_dir="${CVMFS_SPOOL_DIR}/tmp"
   if [ -z "$scratch_dir" ]; then
     scratch_dir=$default_scratch_dir
   fi
+
   local user_shell="$(get_user_shell $name)"
   local check_cmd
   check_cmd="$(__swissknife_cmd dbg) check $tag        \
@@ -157,12 +157,17 @@ __check_repair_reflog() {
     to_syslog_for_repo $name "reference log reconstruction started"
     local repository_url
 
+    default_scratch_dir="${CVMFS_SPOOL_DIR}/tmp"
+    if [ -z "$scratch_dir" ]; then
+      scratch_dir=$default_scratch_dir
+    fi
+
     local reflog_reconstruct_command="$(__swissknife_cmd dbg) reconstruct_reflog \
                                                   -r $repository_url             \
                                                   $(get_swissknife_proxy)        \
                                                   -u $CVMFS_UPSTREAM_STORAGE     \
                                                   -n $CVMFS_REPOSITORY_NAME      \
-                                                  -t ${CVMFS_SPOOL_DIR}/tmp/     \
+                                                  -t ${scratch_dir}              \
                                                   -k $CVMFS_PUBLIC_KEY           \
                                                   -R $(get_reflog_checksum $name)"
     if ! $user_shell "$reflog_reconstruct_command"; then

--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -79,6 +79,12 @@ __do_check() {
   local with_reflog=
   has_reflog_checksum $name && with_reflog="-R $(get_reflog_checksum $name)"
 
+  default_scratch_dir="$CVMFS_SPOOL_DIR/tmp"
+
+  if [ -z "$scratch_dir" ]; then
+    scratch_dir=$default_scratch_dir
+  fi
+  echo "scratch_dir: $scratch_dir"
   local user_shell="$(get_user_shell $name)"
   local check_cmd
   check_cmd="$(__swissknife_cmd dbg) check $tag        \
@@ -86,7 +92,7 @@ __do_check() {
                      $log_level_param                  \
                      $subtree_param                    \
                      -r $url                           \
-                     -t ${CVMFS_SPOOL_DIR}/tmp         \
+                    -t ${scratch_dir}                 \
                      -k ${CVMFS_PUBLIC_KEY}            \
                      -N ${CVMFS_REPOSITORY_NAME}       \
                      $(get_swissknife_proxy)           \
@@ -276,10 +282,11 @@ cvmfs_server_check() {
   local subtree_path=""
   local tag=
   local repair_reflog=0
+  local scratch_dir=""
 
   # optional parameter handling
   OPTIND=1
-  while getopts "acit:s:r" option
+  while getopts "acit:s:rx:" option
   do
     case $option in
       a)
@@ -299,6 +306,9 @@ cvmfs_server_check() {
       ;;
       r)
         repair_reflog=1
+      ;;
+      x)
+        scratch_dir="$OPTARG"
       ;;
       ?)
         shift $(($OPTIND-2))

--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -84,7 +84,6 @@ __do_check() {
   if [ -z "$scratch_dir" ]; then
     scratch_dir=$default_scratch_dir
   fi
-  echo "scratch_dir: $scratch_dir"
   local user_shell="$(get_user_shell $name)"
   local check_cmd
   check_cmd="$(__swissknife_cmd dbg) check $tag        \
@@ -92,7 +91,7 @@ __do_check() {
                      $log_level_param                  \
                      $subtree_param                    \
                      -r $url                           \
-                    -t ${scratch_dir}                 \
+                     -t ${scratch_dir}                 \
                      -k ${CVMFS_PUBLIC_KEY}            \
                      -N ${CVMFS_REPOSITORY_NAME}       \
                      $(get_swissknife_proxy)           \

--- a/test/src/536-healthcheck/main
+++ b/test/src/536-healthcheck/main
@@ -102,6 +102,9 @@ cvmfs_run_test() {
   echo "*** check repository integrity"
   check_repository $CVMFS_TEST_REPO -i || return 18
 
+  echo "*** check repository integrity with custom scratch dir"
+  check_repository $CVMFS_TEST_REPO -i -x $(mktemp -d) || return 19
+
   return 0
 }
 


### PR DESCRIPTION
This allows to run 

```
cvmfs_server check -x $(mktemp -d)
```
as a workaround for https://github.com/cvmfs/cvmfs/issues/3703