### PR TITLE
Temporarily disable mockfuse tests in CI

### DIFF
--- a/.github/workflows/ci_ubuntu_unittest.yaml
+++ b/.github/workflows/ci_ubuntu_unittest.yaml
@@ -72,7 +72,8 @@ jobs:
           cd ..
       - name: Run Unittests - Mockfuse
         run: |
-          ./build/test/unittests/cvmfs_unittests_mockfuse
+          # ./build/test/unittests/cvmfs_unittests_mockfuse
+          echo "TODO: mockfuse unittests skipped"
       - name: Run Unittests - Regular
         run: |
           ./build/test/unittests/cvmfs_unittests --gtest_filter="-T_Namespace.*"


### PR DESCRIPTION
The FileSystem object cannot be constructed and destroyed for every test, needs to be fixed.