### PR TITLE
loader: do not attempt umount when fuse exits with ret 0

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1231,20 +1231,20 @@ int FuseMain(int argc, char *argv[]) {
   config_files_ = NULL;
   socket_path_ = NULL;
 
-  if (retval != 0)
+  // Decide whether to attempt a umount before exiting.
+  // The fuse main loop exists with 0 either when it is already umounted,
+  // or when the filesystem connection is aborted.
+  // In the first case we don't need to attempt to unmount,
+  // the second case we can ignore because it only ever happens on admin intervention.
+  if (retval != 0) {
     retval = kFailFuseLoop;
-  else
-    retval = kFailOk;
-
 #if CVMFS_USE_LIBFUSE != 2
-  if (premount_fd >= 0) {
-    if (retval == kFailOk) {
-      goto fuse_exit_success;
-    } else {
-      goto cleanup;
-    }
-  }
+    goto cleanup;
 #endif
+  } else {
+    retval = kFailOk;
+    if (premount_fd >= 0) close(premount_fd);
+  }
 
   LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
            mount_point_->c_str(), repository_name_->c_str());
@@ -1273,24 +1273,6 @@ cleanup:
     }
     close(premount_fd);
   }
-#endif
-
-  delete repository_name_;
-  delete mount_point_;
-  repository_name_ = NULL;
-  mount_point_ = NULL;
-
-  return retval;
-
-// The fuse main loop exists with 0 either on a umount,
-// or when the filesystem connection is aborted.
-// In the first case we don't need to attempt to unmount,
-// the second case we can ignore because it only ever happens on admin intervention.
-fuse_exit_success:
-#if CVMFS_USE_LIBFUSE != 2
-  LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
-           mount_point_->c_str(), repository_name_->c_str());
-  close(premount_fd);
 #endif
 
   delete repository_name_;

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1288,8 +1288,8 @@ cleanup:
 // the second case we can ignore because it only ever happens on admin intervention.
 fuse_exit_success:
 #if CVMFS_USE_LIBFUSE != 2
-    LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
-                mount_point_->c_str(), repository_name_->c_str());
+  LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
+           mount_point_->c_str(), repository_name_->c_str());
   close(premount_fd);
 #endif
 

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1238,7 +1238,11 @@ int FuseMain(int argc, char *argv[]) {
 
 #if CVMFS_USE_LIBFUSE != 2
   if (premount_fd >= 0) {
-    goto cleanup;
+    if (retval == kFailOk) {
+      goto fuse_exit_success;
+    } else {
+      goto cleanup;
+    }
   }
 #endif
 
@@ -1269,6 +1273,24 @@ cleanup:
     }
     close(premount_fd);
   }
+#endif
+
+  delete repository_name_;
+  delete mount_point_;
+  repository_name_ = NULL;
+  mount_point_ = NULL;
+
+  return retval;
+
+// The fuse main loop exists with 0 either on a umount,
+// or when the filesystem connection is aborted.
+// In the first case we don't need to attempt to unmount,
+// the second case we can ignore because it only ever happens on admin intervention.
+fuse_exit_success:
+#if CVMFS_USE_LIBFUSE != 2
+    LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
+                mount_point_->c_str(), repository_name_->c_str());
+  close(premount_fd);
 #endif
 
   delete repository_name_;

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1243,7 +1243,9 @@ int FuseMain(int argc, char *argv[]) {
 #endif
   } else {
     retval = kFailOk;
+#if CVMFS_USE_LIBFUSE != 2
     if (premount_fd >= 0) close(premount_fd);
+#endif
   }
 
   LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",


### PR DESCRIPTION
Another possible fix for #3993 . Here we do not even  attempt  the umount when the fuse loop exits with return value 0, very effectively avoiding the complications of a possible race with another following mount attempt.

However with  this patch,  a cvmfs repository needs to be manually unmounted when the filesystem connection in /sys/fs/fuse is aborted. Since this is rare enough and will only happen on admin intervention, it should be fine. 