### PR TITLE
loader: delay mount until fuse session invocation

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1024,7 +1024,7 @@ int FuseMain(int argc, char *argv[]) {
 #if CVMFS_USE_LIBFUSE != 2
   if (!premounted_ && !suid_mode_ && getuid() == 0) {
     // If not already premounted or using suid mode, premount the fuse
-    // mountpoint before dropping privileges to avoid the need for fusermount.
+    // mountpoint  to avoid the need for fusermount.
     // Requires libfuse >= 3.3.0.
     //
     if ((uid_ != 0) || (gid_ != 0)) {

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -884,7 +884,9 @@ int FuseMain(int argc, char *argv[]) {
 
 
   int fd_mountinfo = -1;  // needs to be declared before start using goto
+#if CVMFS_USE_LIBFUSE != 2
   int premount_fd = -1;
+#endif
 
   // Drop credentials
   if ((uid_ != 0) || (gid_ != 0)) {
@@ -1025,11 +1027,13 @@ int FuseMain(int argc, char *argv[]) {
     // mountpoint before dropping privileges to avoid the need for fusermount.
     // Requires libfuse >= 3.3.0.
     //
-    if (!SwitchCredentials(0, getgid(), true)) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "failed to re-gain root permissions for mounting");
-      retval = kFailPermission;
-      goto cleanup;
+    if ((uid_ != 0) || (gid_ != 0)) {
+      if (!SwitchCredentials(0, getgid(), true)) {
+        LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+                 "failed to re-gain root permissions for mounting");
+        retval = kFailPermission;
+        goto cleanup;
+      }
     }
     platform_stat64 info;
     // Need to know if it is a directory or not
@@ -1070,8 +1074,6 @@ int FuseMain(int argc, char *argv[]) {
   }
   // Drop credentials
   if ((uid_ != 0) || (gid_ != 0)) {
-    LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: running with credentials %d:%d",
-             uid_, gid_);
     const bool retrievable = (suid_mode_ || !disable_watchdog_);
     if (!SwitchCredentials(uid_, gid_, retrievable)) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1222,7 +1222,7 @@ int FuseMain(int argc, char *argv[]) {
   SetLogMicroSyslog(*usyslog_path_);
   if (retval != 0) {
     LogCvmfs(kLogCvmfs, kLogSyslogErr, "CernVM-FS: fuse loop exited with error %i",
-             retval;
+             retval);
   }
 
   loader_talk::Fini();

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1071,15 +1071,15 @@ int FuseMain(int argc, char *argv[]) {
                mount_point_->c_str(), errno);
       return kFailPermission;
     }
-  }
-  // Drop credentials
-  if ((uid_ != 0) || (gid_ != 0)) {
-    const bool retrievable = (suid_mode_ || !disable_watchdog_);
-    if (!SwitchCredentials(uid_, gid_, retrievable)) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to drop credentials");
-      retval = kFailPermission;
-      goto cleanup;
+
+    // Drop credentials
+    if ((uid_ != 0) || (gid_ != 0)) {
+      if (!SwitchCredentials(uid_, gid_, true /*retrievable*/)) {
+        LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+                 "Failed to drop credentials");
+        retval = kFailPermission;
+        goto cleanup;
+      }
     }
   }
 #endif

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -882,52 +882,9 @@ int FuseMain(int argc, char *argv[]) {
     }
   }
 
-#if CVMFS_USE_LIBFUSE != 2
-  int premount_fd = -1;
-  if (!premounted_ && !suid_mode_ && getuid() == 0) {
-    // If not already premounted or using suid mode, premount the fuse
-    // mountpoint before dropping privileges to avoid the need for fusermount.
-    // Requires libfuse >= 3.3.0.
-    platform_stat64 info;
-    // Need to know if it is a directory or not
-    if (platform_stat(mount_point_->c_str(), &info) != 0) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to stat mountpoint %s (%d)", mount_point_->c_str(),
-               errno);
-      return kFailPermission;
-    }
-    premount_fd = open("/dev/fuse", O_RDWR);
-    if (premount_fd == -1) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to open /dev/fuse (%d)", errno);
-      return kFailPermission;
-    }
-    char opts[128];
-    snprintf(
-        opts, sizeof(opts), "fd=%i,rootmode=%o,user_id=0,group_id=0%s%s",
-        premount_fd, info.st_mode & S_IFMT,
-        MatchFuseOption(mount_options, "default_permissions")
-            ? ",default_permissions"
-            : "",
-        MatchFuseOption(mount_options, "allow_other") ? ",allow_other" : "");
-    unsigned long flags = MS_NOSUID | MS_NODEV | MS_RELATIME;
-    // Note that during the handling of the `CVMFS_MOUNT_RW` option, we ensure
-    // that at least one of `rw` or `ro` is part of the mount option string (we
-    // won't have both unset). If both `rw` and `ro` are set, the read-only
-    // option takes precedence.
-    if (MatchFuseOption(mount_options, "ro")) {
-      flags |= MS_RDONLY;
-    }
-    if (mount("cvmfs2", mount_point_->c_str(), "fuse", flags, opts) == -1) {
-      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to mount -t fuse -o %s cvmfs2 %s (%d)", opts,
-               mount_point_->c_str(), errno);
-      return kFailPermission;
-    }
-  }
-#endif
 
   int fd_mountinfo = -1;  // needs to be declared before start using goto
+  int premount_fd = -1;
 
   // Drop credentials
   if ((uid_ != 0) || (gid_ != 0)) {
@@ -1061,6 +1018,69 @@ int FuseMain(int argc, char *argv[]) {
       goto cleanup;
     }
   }
+
+#if CVMFS_USE_LIBFUSE != 2
+  if (!premounted_ && !suid_mode_ && getuid() == 0) {
+    // If not already premounted or using suid mode, premount the fuse
+    // mountpoint before dropping privileges to avoid the need for fusermount.
+    // Requires libfuse >= 3.3.0.
+    //
+    if (!SwitchCredentials(0, getgid(), true)) {
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+               "failed to re-gain root permissions for mounting");
+      retval = kFailPermission;
+      goto cleanup;
+    }
+    platform_stat64 info;
+    // Need to know if it is a directory or not
+    if (platform_stat(mount_point_->c_str(), &info) != 0) {
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+               "Failed to stat mountpoint %s (%d)", mount_point_->c_str(),
+               errno);
+      return kFailPermission;
+    }
+    premount_fd = open("/dev/fuse", O_RDWR);
+    if (premount_fd == -1) {
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+               "Failed to open /dev/fuse (%d)", errno);
+      return kFailPermission;
+    }
+    char opts[128];
+    snprintf(
+        opts, sizeof(opts), "fd=%i,rootmode=%o,user_id=0,group_id=0%s%s",
+        premount_fd, info.st_mode & S_IFMT,
+        MatchFuseOption(mount_options, "default_permissions")
+            ? ",default_permissions"
+            : "",
+        MatchFuseOption(mount_options, "allow_other") ? ",allow_other" : "");
+    unsigned long flags = MS_NOSUID | MS_NODEV | MS_RELATIME;
+    // Note that during the handling of the `CVMFS_MOUNT_RW` option, we ensure
+    // that at least one of `rw` or `ro` is part of the mount option string (we
+    // won't have both unset). If both `rw` and `ro` are set, the read-only
+    // option takes precedence.
+    if (MatchFuseOption(mount_options, "ro")) {
+      flags |= MS_RDONLY;
+    }
+    if (mount("cvmfs2", mount_point_->c_str(), "fuse", flags, opts) == -1) {
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+               "Failed to mount -t fuse -o %s cvmfs2 %s (%d)", opts,
+               mount_point_->c_str(), errno);
+      return kFailPermission;
+    }
+  }
+  // Drop credentials
+  if ((uid_ != 0) || (gid_ != 0)) {
+    LogCvmfs(kLogCvmfs, kLogStdout, "CernVM-FS: running with credentials %d:%d",
+             uid_, gid_);
+    const bool retrievable = (suid_mode_ || !disable_watchdog_);
+    if (!SwitchCredentials(uid_, gid_, retrievable)) {
+      LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
+               "Failed to drop credentials");
+      retval = kFailPermission;
+      goto cleanup;
+    }
+  }
+#endif
 
 
   struct fuse_lowlevel_ops loader_operations;

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1,7 +1,7 @@
 /**
  * This file is part of the CernVM File System.
  *
- * Implements stub callback functions for Fuse.  Their purpose is to
+ * Implements stub callback functions for Fuse. Their purpose is to
  * redirect calls to the cvmfs shared library and to block calls during the
  * update of the library.
  *
@@ -1024,7 +1024,7 @@ int FuseMain(int argc, char *argv[]) {
 #if CVMFS_USE_LIBFUSE != 2
   if (!premounted_ && !suid_mode_ && getuid() == 0) {
     // If not already premounted or using suid mode, premount the fuse
-    // mountpoint  to avoid the need for fusermount.
+    // mountpoint to avoid the need for fusermount.
     // Requires libfuse >= 3.3.0.
     //
     if ((uid_ != 0) || (gid_ != 0)) {
@@ -1220,6 +1220,10 @@ int FuseMain(int argc, char *argv[]) {
 #endif  // fuse2/3
   }
   SetLogMicroSyslog(*usyslog_path_);
+  if (retval != 0) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr, "CernVM-FS: fuse loop exited with error %i",
+             retval;
+  }
 
   loader_talk::Fini();
   cvmfs_exports_->fnFini();
@@ -1270,7 +1274,7 @@ int FuseMain(int argc, char *argv[]) {
 #endif
   }
 
-  LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
+  LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s) (exit success)",
            mount_point_->c_str(), repository_name_->c_str());
 
   delete repository_name_;
@@ -1292,7 +1296,7 @@ cleanup:
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
                     "failed to umount %s (%d)", mount_point_->c_str(), errno);
     } else {
-      LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s)",
+      LogCvmfs(kLogCvmfs, kLogSyslog, "CernVM-FS: unmounted %s (%s) (error cleanup) ",
                   mount_point_->c_str(), repository_name_->c_str());
     }
     close(premount_fd);

--- a/test/src/077-doublemount/main
+++ b/test/src/077-doublemount/main
@@ -28,6 +28,11 @@ cvmfs_run_test() {
   sudo mount -t cvmfs grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1 \
     | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
     || return 21
+  # check mounting without the mount helper (triggers a different check)
+  sudo cvmfs2 -d -f grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1 \
+    | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
+    || return 22
+
 
   return 0
 }

--- a/test/src/077-doublemount/main
+++ b/test/src/077-doublemount/main
@@ -28,10 +28,10 @@ cvmfs_run_test() {
   sudo mount -t cvmfs grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1 \
     | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
     || return 21
-  # check mounting on same directory without the mount helper
-  sudo cvmfs2 -o uid=996,gid=993 -d -f grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_ONE" 2>&1 \
-    | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
-    || return 22
+  # TODO(vvolkl) check mounting on same directory without the mount helper
+  # sudo cvmfs2 -o uid=996,gid=993 -d -f grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_ONE" 2>&1 \
+  #  | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
+  #  || return 22
 
 
   return 0

--- a/test/src/077-doublemount/main
+++ b/test/src/077-doublemount/main
@@ -28,8 +28,8 @@ cvmfs_run_test() {
   sudo mount -t cvmfs grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1 \
     | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
     || return 21
-  # check mounting without the mount helper (triggers a different check)
-  sudo cvmfs2 -d -f grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1 \
+  # check mounting on same directory without the mount helper
+  sudo cvmfs2 -o uid=996,gid=993 -d -f grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_ONE" 2>&1 \
     | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
     || return 22
 


### PR DESCRIPTION
Doing the mount just before where libfuse would do it; needs to elevate/drop permissions an additional time but avoids a potential deadlock in InitSystemFs when trying to mount over an existing cvmfs repository.