### PR TITLE
Cleanly handle when there is no geo db desired

### DIFF
--- a/cvmfs/server/cvmfs_server_add_replica.sh
+++ b/cvmfs/server/cvmfs_server_add_replica.sh
@@ -149,7 +149,7 @@ cvmfs_server_add_replica() {
         echo "       user ID and run update-geodb monthly as that user"
         echo "    4. Use another update tool such as Maxmind's geoipupdate and"
         echo "       set CVMFS_GEO_DB_FILE to point to the downloaded file"
-        echo "    5. Disable the geo api with CVMFS_GEO_DB_FILE=none"
+        echo "    5. Disable the geo api with CVMFS_GEO_DB_FILE=NONE"
         echo "  See 'Geo API Setup' in the cvmfs documentation for more info."
       fi
     else

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -63,7 +63,11 @@ elif [ "$CVMFS_UPDATEGEO_SOURCE" = "maxmind" ]; then
   CVMFS_UPDATEGEO_DB="${CVMFS_UPDATEGEO_DB:-GeoLite2-City.mmdb}"
   CVMFS_UPDATEGEO_URLBASE="${CVMFS_UPDATEGEO_URLBASE:-https://download.maxmind.com/geoip/databases/GeoLite2-City/download}"
   CVMFS_UPDATEGEO_URLSUFFIX="${CVMFS_UPDATEGEO_URLSUFFIX:-?suffix=tar.gz}"
-elif [ -n "$CVMFS_UPDATEGEO_SOURCE" ] && [ "$CVMFS_UPDATEGEO_SOURCE" != "none" ]; then
+elif [ "$CVMFS_UPDATEGEO_SOURCE" = "none" ] || [ "$CVMFS_UPDATEGEO_SOURCE" = "NONE" ]; then
+  if [ -z "$CVMFS_GEO_DB_FILE" ]; then
+    CVMFS_GEO_DB_FILE=NONE
+  fi
+else
   die "CVMFS_UPDATEGEO_SOURCE not openhtc, maxmind, or none"
 fi
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1179,9 +1179,12 @@ _update_geodb() {
     CVMFS_GEO_DB_FILE=/usr/share/GeoIP/$CVMFS_UPDATEGEO_DB
   fi
   if [ -n "$CVMFS_GEO_DB_FILE" ]; then
+    if [ "$CVMFS_GEO_DB_FILE" = "NONE" ] || [ "$CVMFS_GEO_DB_FILE" = "none" ]; then
+      return 0
+    fi
     # This overrides the update/install; link to the given file instead.
     if [ ! -L "$dbfile" ] || [ "`readlink $dbfile`" != "$CVMFS_GEO_DB_FILE" ]; then
-      if [ "$CVMFS_GEO_DB_FILE" != "NONE" ] && [ ! -r "$CVMFS_GEO_DB_FILE" ]; then
+      if [ ! -r "$CVMFS_GEO_DB_FILE" ]; then
         echo "$CVMFS_GEO_DB_FILE doesn't exist or is not readable" >&2
         return 1
       fi

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -323,10 +323,6 @@ cvmfs_run_test() {
   mv -f $CVMFS_TEST_595_GEODB . || return 45
 
   echo "try snapshot with a dbfile of NONE"
-  local snapshot_2_log="snapshot_2.log"
-  CVMFS_GEO_DB_FILE=NONE cvmfs_server snapshot $replica_name > $snapshot_2_log 2>&1 || return 46
-
-  echo "try again with a dbfile of NONE (database should be up to date)"
   local snapshot_3_log="snapshot_3.log"
   CVMFS_GEO_DB_FILE=NONE cvmfs_server snapshot $replica_name > $snapshot_3_log 2>&1 || return 47
 
@@ -348,7 +344,6 @@ cvmfs_run_test() {
 
   echo "check output logs for the expected status messages"
   test -z "`cat $snapshot_1_log | grep GeoIP`"                                   || return 61
-  cat $snapshot_2_log | grep "Linking GeoIP Database"                            || return 62
   test -z "`cat $snapshot_3_log | grep GeoIP`"                                   || return 63
   cat $snapshot_4_log | grep "Linking GeoIP Database"                            || return 64
   cat $snapshot_5_log | grep -e "Directory.*not writable.*$CVMFS_TEST_USER"      || return 65


### PR DESCRIPTION
While writing up the documenation for the new geoip db source I noticed that the documented `CVMFS_GEO_DB_FILE=NONE` and the allowed `CVMFS_UPDATEGEO_SOURCE=none` both worked but printed disconcerting errors each time snapshot ran.  This removes those error messages.