### PR TITLE
[client] Skip open files on cache cleanup when possible

### DIFF
--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -269,9 +269,9 @@ PosixCacheManager *PosixCacheManager::Create(
     const string &cache_path,
     const bool alien_cache,
     const RenameWorkarounds rename_workaround,
-    const bool do_refcount) {
+    const bool do_refcount, const bool cleanup_unused_first) {
   UniquePtr<PosixCacheManager> cache_manager(
-      new PosixCacheManager(cache_path, alien_cache, do_refcount));
+      new PosixCacheManager(cache_path, alien_cache, do_refcount,cleanup_unused_first));
   assert(cache_manager.IsValid());
 
   cache_manager->rename_workaround_ = rename_workaround;

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -266,12 +266,11 @@ bool PosixCacheManager::InitCacheDirectory(const string &cache_path) {
 }
 
 PosixCacheManager *PosixCacheManager::Create(
-    const string &cache_path,
-    const bool alien_cache,
-    const RenameWorkarounds rename_workaround,
-    const bool do_refcount, const bool cleanup_unused_first) {
-  UniquePtr<PosixCacheManager> cache_manager(
-      new PosixCacheManager(cache_path, alien_cache, do_refcount,cleanup_unused_first));
+    const string &cache_path, const bool alien_cache,
+    const RenameWorkarounds rename_workaround, const bool do_refcount,
+    const bool cleanup_unused_first) {
+  UniquePtr<PosixCacheManager> cache_manager(new PosixCacheManager(
+      cache_path, alien_cache, do_refcount, cleanup_unused_first));
   assert(cache_manager.IsValid());
 
   cache_manager->rename_workaround_ = rename_workaround;
@@ -648,3 +647,4 @@ int64_t PosixCacheManager::Write(const void *buf, uint64_t size, void *txn) {
   transaction->size += written;
   return written;
 }
+

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -37,6 +37,7 @@ class DownloadManager;
  * Cache manager implementation using a file system (cache directory) as a
  * backing storage.
  */
+class ListOpenHashesMagicXattr;  // FD needed to access fd_mgr_
 class PosixCacheManager : public CacheManager {
   FRIEND_TEST(T_CacheManager, CommitTxnQuotaNotifications);
   FRIEND_TEST(T_CacheManager, CommitTxnRenameFail);
@@ -46,6 +47,7 @@ class PosixCacheManager : public CacheManager {
   FRIEND_TEST(T_CacheManager, Rename);
   FRIEND_TEST(T_CacheManager, StartTxn);
   FRIEND_TEST(T_CacheManager, TearDown2ReadOnly);
+  friend class ListOpenHashesMagicXattr;
 
  public:
   enum CacheModes {

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -16,9 +16,9 @@
 #include "cache.h"
 #include "catalog_mgr.h"
 #include "crypto/signature.h"
+#include "duplex_testing.h"
 #include "fd_refcount_mgr.h"
 #include "file_chunk.h"
-#include "duplex_testing.h"
 #include "manifest_fetch.h"
 #include "shortstring.h"
 #include "statistics.h"
@@ -70,10 +70,9 @@ class PosixCacheManager : public CacheManager {
   virtual std::string Describe();
 
   static PosixCacheManager *Create(
-      const std::string &cache_path,
-      const bool alien_cache,
+      const std::string &cache_path, const bool alien_cache,
       const RenameWorkarounds rename_workaround = kRenameNormal,
-      const bool do_refcount = true);
+      const bool do_refcount = true, const bool cleanup_unused_first = false);
   virtual ~PosixCacheManager() { }
   virtual bool AcquireQuotaManager(QuotaManager *quota_mgr);
 
@@ -105,6 +104,7 @@ class PosixCacheManager : public CacheManager {
   std::string cache_path() { return cache_path_; }
   bool is_tmpfs() { return is_tmpfs_; }
   bool do_refcount() const { return do_refcount_; }
+  bool cleanup_unused_first() const { return cleanup_unused_first_; }
 
  protected:
   virtual void *DoSaveState();
@@ -137,7 +137,8 @@ class PosixCacheManager : public CacheManager {
   };
 
   PosixCacheManager(const std::string &cache_path, const bool alien_cache,
-                    const bool do_refcount = true)
+                    const bool do_refcount = true,
+                    const bool cleanup_unused_first = false)
       : cache_path_(cache_path)
       , txn_template_path_(cache_path_ + "/txn/fetchXXXXXX")
       , alien_cache_(alien_cache)
@@ -146,7 +147,8 @@ class PosixCacheManager : public CacheManager {
       , reports_correct_filesize_(true)
       , is_tmpfs_(false)
       , do_refcount_(do_refcount)
-      , fd_mgr_(new FdRefcountMgr()) {
+      , fd_mgr_(new FdRefcountMgr())
+      , cleanup_unused_first_(cleanup_unused_first) {
     atomic_init32(&no_inflight_txns_);
   }
 
@@ -193,6 +195,9 @@ class PosixCacheManager : public CacheManager {
    */
   bool do_refcount_;
   UniquePtr<FdRefcountMgr> fd_mgr_;
+
+  bool cleanup_unused_first_;
 };  // class PosixCacheManager
 
 #endif  // CVMFS_CACHE_POSIX_H_
+

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2357,11 +2357,13 @@ static int Init(const loader::LoaderExports *loader_exports) {
              ->do_refcount()) {
     cvmfs::check_fd_overflow_ = false;
   }
-  if (cvmfs::file_system_->cache_mgr()->id() == kPosixCacheManager){
-    PosixCacheManager* pcm = dynamic_cast<PosixCacheManager*>(cvmfs::file_system_->cache_mgr());
-    if(pcm!=nullptr){
-      PosixQuotaManager* pqm = dynamic_cast<PosixQuotaManager*>(pcm->quota_mgr());
-      if(pqm!=nullptr){
+  if (cvmfs::file_system_->cache_mgr()->id() == kPosixCacheManager) {
+    PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(
+        cvmfs::file_system_->cache_mgr());
+    if (pcm != nullptr) {
+      PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
+          pcm->quota_mgr());
+      if (pqm != nullptr) {
         pqm->RegisterMountpoint(loader_exports->mount_point);
       }
     }
@@ -3045,3 +3047,4 @@ static void __attribute__((destructor)) LibraryExit() {
   delete g_cvmfs_exports;
   g_cvmfs_exports = NULL;
 }
+

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2357,6 +2357,15 @@ static int Init(const loader::LoaderExports *loader_exports) {
              ->do_refcount()) {
     cvmfs::check_fd_overflow_ = false;
   }
+  if (cvmfs::file_system_->cache_mgr()->id() == kPosixCacheManager){
+    PosixCacheManager* pcm = dynamic_cast<PosixCacheManager*>(cvmfs::file_system_->cache_mgr());
+    if(pcm!=nullptr){
+      PosixQuotaManager* pqm = dynamic_cast<PosixQuotaManager*>(pcm->quota_mgr());
+      if(pqm!=nullptr){
+        pqm->RegisterMountpoint(loader_exports->mount_point);
+      }
+    }
+  }
 
   cvmfs::mount_point_ = MountPoint::Create(loader_exports->repository_name,
                                            cvmfs::file_system_);

--- a/cvmfs/fd_refcount_mgr.h
+++ b/cvmfs/fd_refcount_mgr.h
@@ -22,7 +22,10 @@ static inline uint32_t hasher_int(const int &key) {
   return MurmurHash2(&key, sizeof(key), 0x07387a4f);
 }
 
+class ListOpenHashesMagicXattr;  // FD needed to access fd_mgr_
 class FdRefcountMgr {
+  friend class ListOpenHashesMagicXattr;
+
  public:
   /**
    * Helper class containing the values for the map: fd -> refcount+id
@@ -72,3 +75,4 @@ class FdRefcountMgr {
 };
 
 #endif  // CVMFS_FD_REFCOUNT_MGR_H_
+

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -835,7 +835,7 @@ void ListOpenHashesMagicXattr::FinalizeValue() {
         auto empty = hash_map.empty_key();
         auto *keys = hash_map.keys();
         for (size_t i = 0; i < hash_map.capacity(); ++i) {
-          shash::Any &hash = keys[i];
+          const shash::Any &hash = keys[i];
           if (hash != empty) {
             result += hash.ToString() + "\n";
           }

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "cache_posix.h"  // PosixCacheManager
+#include "cache_posix.h"
 #include "catalog_mgr_client.h"
 #include "crypto/signature.h"
 #include "fetch.h"

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -77,10 +77,6 @@ MagicXattrManager::MagicXattrManager(
 
   Register("user.cleanup_unused_first", new CleanupUnusedFirstMagicXattr());
   Register("user.list_open_hashes", new ListOpenHashesMagicXattr());
-  Register("user.list_groups_open_hashes",
-           new ListGroupsOpenHashesMagicXattr());
-  Register("user.list_managed_mountpoints",
-           new ListManagedMountpointsMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -841,36 +837,6 @@ void ListOpenHashesMagicXattr::FinalizeValue() {
           }
         }
       }
-    }
-  }
-  result_pages_.push_back(result);
-}
-
-void ListGroupsOpenHashesMagicXattr::FinalizeValue() {
-  auto cm = xattr_mgr_->mount_point()->file_system()->cache_mgr();
-  PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
-  std::string result;
-  if (pcm != nullptr) {
-    if (pcm->cleanup_unused_first()) {
-      PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
-          pcm->quota_mgr());
-      if (pqm != nullptr) {
-        result = pqm->GetGroupHashes();
-      }
-    }
-  }
-  result_pages_.push_back(result);
-}
-
-void ListManagedMountpointsMagicXattr::FinalizeValue() {
-  auto cm = xattr_mgr_->mount_point()->file_system()->cache_mgr();
-  PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
-  std::string result;
-  if (pcm != nullptr) {
-    PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
-        pcm->quota_mgr());
-    if (pqm != nullptr) {
-      result = pqm->GetMountpoints();
     }
   }
   result_pages_.push_back(result);

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -13,8 +13,8 @@
 #include "crypto/signature.h"
 #include "fetch.h"
 #include "mountpoint.h"
-#include "quota_posix.h"
 #include "quota.h"
+#include "quota_posix.h"
 #include "util/logging.h"
 #include "util/string.h"
 
@@ -77,7 +77,10 @@ MagicXattrManager::MagicXattrManager(
 
   Register("user.cleanup_unused_first", new CleanupUnusedFirstMagicXattr());
   Register("user.list_open_hashes", new ListOpenHashesMagicXattr());
-  Register("user.list_managed_mountpoints", new ListManagedMountpointsMagicXattr());
+  Register("user.list_groups_open_hashes",
+           new ListGroupsOpenHashesMagicXattr());
+  Register("user.list_managed_mountpoints",
+           new ListManagedMountpointsMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -830,14 +833,28 @@ void ListOpenHashesMagicXattr::FinalizeValue() {
       if (pcm->fd_mgr_.IsValid()) {
         const auto &hash_map = pcm->fd_mgr_->map_fd_;
         auto empty = hash_map.empty_key();
-        auto* keys = hash_map.keys();
+        auto *keys = hash_map.keys();
         for (size_t i = 0; i < hash_map.capacity(); ++i) {
-          shash::Any& hash = keys[i];
-          if (hash  != empty) {
-            result+=hash.ToString()+"\n";
+          shash::Any &hash = keys[i];
+          if (hash != empty) {
+            result += hash.ToString() + "\n";
           }
         }
       }
+    }
+  }
+  result_pages_.push_back(result);
+}
+
+void ListGroupsOpenHashesMagicXattr::FinalizeValue() {
+  auto cm = xattr_mgr_->mount_point()->file_system()->cache_mgr();
+  PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
+  std::string result;
+  if (pcm != nullptr) {
+    PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
+        pcm->quota_mgr());
+    if (pqm != nullptr) {
+      result = pqm->GetGroupHashes();
     }
   }
   result_pages_.push_back(result);
@@ -848,10 +865,12 @@ void ListManagedMountpointsMagicXattr::FinalizeValue() {
   PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
   std::string result;
   if (pcm != nullptr) {
-    PosixQuotaManager* pqm = dynamic_cast<PosixQuotaManager*>(pcm->quota_mgr());
-    if(pqm!=nullptr){
+    PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
+        pcm->quota_mgr());
+    if (pqm != nullptr) {
       result = pqm->GetMountpoints();
     }
   }
   result_pages_.push_back(result);
 }
+

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -13,6 +13,7 @@
 #include "crypto/signature.h"
 #include "fetch.h"
 #include "mountpoint.h"
+#include "quota_posix.h"
 #include "quota.h"
 #include "util/logging.h"
 #include "util/string.h"
@@ -76,6 +77,7 @@ MagicXattrManager::MagicXattrManager(
 
   Register("user.cleanup_unused_first", new CleanupUnusedFirstMagicXattr());
   Register("user.list_open_hashes", new ListOpenHashesMagicXattr());
+  Register("user.list_managed_mountpoints", new ListManagedMountpointsMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -841,3 +843,15 @@ void ListOpenHashesMagicXattr::FinalizeValue() {
   result_pages_.push_back(result);
 }
 
+void ListManagedMountpointsMagicXattr::FinalizeValue() {
+  auto cm = xattr_mgr_->mount_point()->file_system()->cache_mgr();
+  PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
+  std::string result;
+  if (pcm != nullptr) {
+    PosixQuotaManager* pqm = dynamic_cast<PosixQuotaManager*>(pcm->quota_mgr());
+    if(pqm!=nullptr){
+      result = pqm->GetMountpoints();
+    }
+  }
+  result_pages_.push_back(result);
+}

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "cache_posix.h"  // PosixCacheManager
 #include "catalog_mgr_client.h"
 #include "crypto/signature.h"
 #include "fetch.h"
@@ -72,6 +73,8 @@ MagicXattrManager::MagicXattrManager(
 
   Register("user.authz", new AuthzMagicXattr());
   Register("user.external_url", new ExternalURLMagicXattr());
+
+  Register("user.cleanup_unused_first", new CleanupUnusedFirstMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -800,3 +803,18 @@ void ExternalURLMagicXattr::FinalizeValue() {
 bool ExternalURLMagicXattr::PrepareValueFenced() {
   return dirent_->IsRegular() && dirent_->IsExternalFile();
 }
+
+void CleanupUnusedFirstMagicXattr::FinalizeValue() {
+  auto cm = xattr_mgr_->mount_point()->file_system()->cache_mgr();
+  PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
+  if (pcm != nullptr) {
+    if (pcm->cleanup_unused_first()) {
+      result_pages_.push_back("yes");
+    } else {
+      result_pages_.push_back("no");
+    }
+  } else {
+    result_pages_.push_back("no");
+  }
+}
+

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -851,10 +851,12 @@ void ListGroupsOpenHashesMagicXattr::FinalizeValue() {
   PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
   std::string result;
   if (pcm != nullptr) {
-    PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
-        pcm->quota_mgr());
-    if (pqm != nullptr) {
-      result = pqm->GetGroupHashes();
+    if (pcm->cleanup_unused_first()) {
+      PosixQuotaManager *pqm = dynamic_cast<PosixQuotaManager *>(
+          pcm->quota_mgr());
+      if (pqm != nullptr) {
+        result = pqm->GetGroupHashes();
+      }
     }
   }
   result_pages_.push_back(result);

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -75,6 +75,7 @@ MagicXattrManager::MagicXattrManager(
   Register("user.external_url", new ExternalURLMagicXattr());
 
   Register("user.cleanup_unused_first", new CleanupUnusedFirstMagicXattr());
+  Register("user.list_open_hashes", new ListOpenHashesMagicXattr());
 }
 
 std::string MagicXattrManager::GetListString(catalog::DirectoryEntry *dirent) {
@@ -816,5 +817,27 @@ void CleanupUnusedFirstMagicXattr::FinalizeValue() {
   } else {
     result_pages_.push_back("no");
   }
+}
+
+void ListOpenHashesMagicXattr::FinalizeValue() {
+  auto cm = xattr_mgr_->mount_point()->file_system()->cache_mgr();
+  PosixCacheManager *pcm = dynamic_cast<PosixCacheManager *>(cm);
+  std::string result;
+  if (pcm != nullptr) {
+    if (pcm->cleanup_unused_first()) {
+      if (pcm->fd_mgr_.IsValid()) {
+        const auto &hash_map = pcm->fd_mgr_->map_fd_;
+        auto empty = hash_map.empty_key();
+        auto* keys = hash_map.keys();
+        for (size_t i = 0; i < hash_map.capacity(); ++i) {
+          shash::Any& hash = keys[i];
+          if (hash  != empty) {
+            result+=hash.ToString()+"\n";
+          }
+        }
+      }
+    }
+  }
+  result_pages_.push_back(result);
 }
 

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -507,5 +507,9 @@ class ListOpenHashesMagicXattr : public ExternalMagicXattr {
 class ListManagedMountpointsMagicXattr : public ExternalMagicXattr {
   virtual void FinalizeValue();
 };
+
+class ListGroupsOpenHashesMagicXattr : public ExternalMagicXattr {
+  virtual void FinalizeValue();
+};
 #endif  // CVMFS_MAGIC_XATTR_H_
 

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -503,5 +503,9 @@ class CleanupUnusedFirstMagicXattr : public ExternalMagicXattr {
 class ListOpenHashesMagicXattr : public ExternalMagicXattr {
   virtual void FinalizeValue();
 };
+
+class ListManagedMountpointsMagicXattr : public ExternalMagicXattr {
+  virtual void FinalizeValue();
+};
 #endif  // CVMFS_MAGIC_XATTR_H_
 

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -496,4 +496,9 @@ class ExternalURLMagicXattr : public ExternalMagicXattr {
   virtual void FinalizeValue();
 };
 
+class CleanupUnusedFirstMagicXattr : public ExternalMagicXattr {
+  virtual void FinalizeValue();
+};
+
 #endif  // CVMFS_MAGIC_XATTR_H_
+

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -503,13 +503,5 @@ class CleanupUnusedFirstMagicXattr : public ExternalMagicXattr {
 class ListOpenHashesMagicXattr : public ExternalMagicXattr {
   virtual void FinalizeValue();
 };
-
-class ListManagedMountpointsMagicXattr : public ExternalMagicXattr {
-  virtual void FinalizeValue();
-};
-
-class ListGroupsOpenHashesMagicXattr : public ExternalMagicXattr {
-  virtual void FinalizeValue();
-};
 #endif  // CVMFS_MAGIC_XATTR_H_
 

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -500,5 +500,8 @@ class CleanupUnusedFirstMagicXattr : public ExternalMagicXattr {
   virtual void FinalizeValue();
 };
 
+class ListOpenHashesMagicXattr : public ExternalMagicXattr {
+  virtual void FinalizeValue();
+};
 #endif  // CVMFS_MAGIC_XATTR_H_
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1009,6 +1009,7 @@ bool FileSystem::SetupPosixQuotaMgr(
       return false;
     }
   }
+  quota_mgr->SetCleanupPolicy(settings.cleanup_unused_first);
 
   const int retval = cache_mgr->AcquireQuotaManager(quota_mgr);
   assert(retval);

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -306,6 +306,12 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
     settings.do_refcount = false;
   }
 
+  if (options_mgr_->GetValue(
+          MkCacheParm("CVMFS_CACHE_CLEANUP_NONOPENLRU", instance), &optarg)
+      && options_mgr_->IsOff(optarg)) {
+    settings.cleanup_unused_first = settings.do_refcount;
+  }
+
   if (options_mgr_->GetValue(MkCacheParm("CVMFS_CACHE_SHARED", instance),
                              &optarg)
       && options_mgr_->IsOn(optarg)) {
@@ -2258,3 +2264,4 @@ bool MountPoint::SetupOwnerMaps() {
 
   return true;
 }
+

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1011,6 +1011,10 @@ bool FileSystem::SetupPosixQuotaMgr(
   }
 
   const int retval = cache_mgr->AcquireQuotaManager(quota_mgr);
+  PosixQuotaManager* pqm = dynamic_cast<PosixQuotaManager*>(cache_mgr->quota_mgr());
+  if (pqm!=nullptr){
+    pqm->RegisterMountpoint(mountpoint_);
+  }
   assert(retval);
   LogCvmfs(kLogCvmfs, kLogDebug,
            "CernVM-FS: quota initialized, current size %luMB",

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1011,10 +1011,6 @@ bool FileSystem::SetupPosixQuotaMgr(
   }
 
   const int retval = cache_mgr->AcquireQuotaManager(quota_mgr);
-  PosixQuotaManager* pqm = dynamic_cast<PosixQuotaManager*>(cache_mgr->quota_mgr());
-  if (pqm!=nullptr){
-    pqm->RegisterMountpoint(mountpoint_);
-  }
   assert(retval);
   LogCvmfs(kLogCvmfs, kLogDebug,
            "CernVM-FS: quota initialized, current size %luMB",

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -309,6 +309,8 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
   if (options_mgr_->GetValue(
           MkCacheParm("CVMFS_CACHE_CLEANUP_NONOPENLRU", instance), &optarg)
       && options_mgr_->IsOn(optarg)) {
+    // Enable this policy only in a refcounted cache.
+    // Because it's the reference counter who will say if a file is open.
     settings.cleanup_unused_first = settings.do_refcount;
   }
 
@@ -684,11 +686,10 @@ CacheManager *FileSystem::SetupPosixCacheMgr(const string &instance) {
   if (!CheckPosixCacheSettings(settings))
     return NULL;
   UniquePtr<PosixCacheManager> cache_mgr(PosixCacheManager::Create(
-      settings.cache_path,
-      settings.is_alien,
+      settings.cache_path, settings.is_alien,
       settings.avoid_rename ? PosixCacheManager::kRenameLink
                             : PosixCacheManager::kRenameNormal,
-      settings.do_refcount,settings.cleanup_unused_first));
+      settings.do_refcount, settings.cleanup_unused_first));
   if (!cache_mgr.IsValid()) {
     boot_error_ = "Failed to setup posix cache '" + instance + "' in "
                   + settings.cache_path + ": " + strerror(errno);

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -308,7 +308,7 @@ FileSystem::PosixCacheSettings FileSystem::DeterminePosixCacheSettings(
 
   if (options_mgr_->GetValue(
           MkCacheParm("CVMFS_CACHE_CLEANUP_NONOPENLRU", instance), &optarg)
-      && options_mgr_->IsOff(optarg)) {
+      && options_mgr_->IsOn(optarg)) {
     settings.cleanup_unused_first = settings.do_refcount;
   }
 
@@ -688,7 +688,7 @@ CacheManager *FileSystem::SetupPosixCacheMgr(const string &instance) {
       settings.is_alien,
       settings.avoid_rename ? PosixCacheManager::kRenameLink
                             : PosixCacheManager::kRenameNormal,
-      settings.do_refcount));
+      settings.do_refcount,settings.cleanup_unused_first));
   if (!cache_mgr.IsValid()) {
     boot_error_ = "Failed to setup posix cache '" + instance + "' in "
                   + settings.cache_path + ": " + strerror(errno);

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -274,7 +274,8 @@ class FileSystem : SingleCopy, public BootFactory {
         , cache_base_defined(false)
         , cache_dir_defined(false)
         , quota_limit(0)
-        , do_refcount(true) { }
+        , do_refcount(true)
+        , cleanup_unused_first(false) { }
     bool is_shared;
     bool is_alien;
     bool is_managed;
@@ -287,6 +288,7 @@ class FileSystem : SingleCopy, public BootFactory {
      */
     int64_t quota_limit;
     bool do_refcount;
+    bool cleanup_unused_first;
     std::string cache_path;
     /**
      * Different from cache_path only if CVMFS_WORKSPACE or
@@ -686,3 +688,4 @@ class MountPoint : SingleCopy, public BootFactory {
 };  // class MointPoint
 
 #endif  // CVMFS_MOUNTPOINT_H_
+

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -35,6 +35,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -506,6 +507,8 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
   // the absolute sequence number with the first bit set in two's complement.
   // So -1 can be a marker that will never appear in the database.
   int64_t max_acseq = -1;
+  std::vector<EvictCandidate> lru_ordered_open;
+
   do {
     sqlite3_reset(stmt_lru_);
     sqlite3_bind_int64(stmt_lru_, 1,
@@ -533,24 +536,43 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
     }
 
     const unsigned N = candidates.size();
+
+    auto &&skip_eviction = [&hash_str, &stmt_block_ = this->stmt_block_](
+                               EvictCandidate &candidate) {
+      bool res = true;
+      hash_str = candidate.hash.ToString();
+      LogCvmfs(kLogQuota, kLogDebug, "skip %s for eviction", hash_str.c_str());
+      sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
+                        SQLITE_STATIC);
+      res = (sqlite3_step(stmt_block_) == SQLITE_DONE);
+      sqlite3_reset(stmt_block_);
+      assert(res);
+    };
+
+
     for (i = 0; i < N; ++i) {
       // That's a critical condition.  We must not delete a not yet inserted
       // pinned file as it is already reserved (but will be inserted later).
       // Instead, set the pin bit in the db to not run into an endless loop
-      if (pinned_chunks_.find(candidates[i].hash) != pinned_chunks_.end()) {
-        hash_str = candidates[i].hash.ToString();
-        LogCvmfs(kLogQuota, kLogDebug, "skip %s for eviction",
-                 hash_str.c_str());
-        sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
-                          SQLITE_STATIC);
-        result = (sqlite3_step(stmt_block_) == SQLITE_DONE);
-        sqlite3_reset(stmt_block_);
-        assert(result);
+      bool is_pinned = pinned_chunks_.find(candidates[i].hash)
+                       != pinned_chunks_.end();
+
+      // Avoid evicting open files hopping there are enough more recently used
+      // files to satisfy the cleanup request
+      bool is_open = std::find(open_files_.begin(), open_files_.end(),
+                               candidates[i].hash)
+                     != open_files_.end();
+      if (is_pinned or is_open) {
+        skip_eviction(candidates[i]);
         continue;
       }
 
-      trash.push_back(cache_dir_ + "/"
-                      + candidates[i].hash.MakePathWithoutSuffix());
+      if (is_open) {
+        lru_ordered_open.push_back(candidates[i]);
+      }
+
+      trash.push_back(cache_dir_ + "/" +
+                      candidates[i].hash.MakePathWithoutSuffix());
       gauge_ -= candidates[i].size;
       max_acseq = candidates[i].acseq;
       LogCvmfs(kLogQuota, kLogDebug, "lru cleanup %s, new gauge %" PRIu64,
@@ -570,6 +592,17 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
     result = (sqlite3_step(stmt_unblock_) == SQLITE_DONE);
     sqlite3_reset(stmt_unblock_);
     assert(result);
+  }
+
+  while (!lru_ordered_open.empty() and gauge_ > leave_size) {
+    // cleanup files in use
+    auto &candidate = lru_ordered_open[0];
+    trash.push_back(cache_dir_ + "/" + candidate.hash.MakePathWithoutSuffix());
+    gauge_ -= candidate.size;
+    max_acseq = candidate.acseq;
+    LogCvmfs(kLogQuota, kLogDebug, "lru cleanup %s, new gauge %" PRIu64,
+             candidate.hash.ToString().c_str(), gauge_);
+    lru_ordered_open.erase(lru_ordered_open.begin());
   }
 
   if (!EmptyTrash(trash))

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -18,7 +18,6 @@
 
 #include "quota_posix.h"
 
-#include <algorithm> //std::all_of
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -2260,27 +2259,40 @@ void PosixQuotaManager::ManagedReadHalfPipe(int fd, void *buf, size_t nbyte) {
 void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
   pthread_setname_np(pthread_self(), "hash_collector");
   auto *handler = static_cast<CollectorHandler *>(data);
-  shash::Any hash;
 
+  std::string mountpoint = handler->mp[handler->i];
+  ssize_t n = getxattr(mountpoint.c_str(), "user.list_open_hashes", nullptr, 0);
+  if (n < 0) {
+    pthread_exit(nullptr);
+  }
+  std::vector<char> buf((size_t)n);
+  n = getxattr(mountpoint.c_str(), "user.list_open_hashes", buf.data(),
+               buf.size());
+  if (n < 0) {
+    pthread_exit(nullptr);
+  }
+
+  std::vector<std::string> hash_strs;
+  std::string hash_str;
+  for (char c : buf) {
+    if (c == '\n') {
+      hash_strs.push_back(hash_str);
+      hash_str.clear();
+    } else {
+      hash_str += c;
+    }
+  }
   const MutexLockGuard lock_guard(handler->l);
-  handler->of.push_back(hash);
-  /*
-    ssize_t n = getxattr(handler->mountpoint.c_str(), "user.list_open_hashes",
-                         nullptr, 0);
-    if (n < 0) {
-      pthread_exit(nullptr);
-    }
-    std::vector<char> buf((size_t)n);
-    n = getxattr(handler->mountpoint.c_str(), "user.list_open_hashes",
-    buf.data(), buf.size()); if (n < 0) { pthread_exit(nullptr);
-    }
-  */
+  for (auto hash_str : hash_strs) {
+    handler->of.push_back(shash::MkFromHexPtr(shash::HexPtr(hash_str)));
+  }
   pthread_exit(nullptr);
 }
 
 std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
   std::vector<CollectorHandler *> handlers;
   std::vector<pthread_t *> threads;
+  open_files_.clear();
 
   auto &&a_after_b = [](const struct timespec a, const struct timespec b) {
     return (a.tv_sec > b.tv_sec) ? true : false;

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -540,7 +540,7 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
     const unsigned N = candidates.size();
 
     open_files_.clear();
-    open_files_ = (cleanup_unused_first_) ? CollectGroupsHashes()
+    open_files_ = (cleanup_unused_first_) ? CollectAllOpenHashes()
                                           : std::vector<shash::Any>();
 
     for (i = 0; i < N; ++i) {
@@ -1381,7 +1381,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       if (return_pipe < 0)
         continue;
 
-      std::vector<shash::Any> gh = quota_mgr->CollectGroupsHashes();
+      std::vector<shash::Any> gh = quota_mgr->CollectAllOpenHashes();
       std::string result;
       for (auto it = gh.begin(); it != gh.end(); ++it) {
         result += (*it).ToString() + "\n";
@@ -1871,10 +1871,11 @@ PosixQuotaManager::PosixQuotaManager(const uint64_t limit,
 
 
 PosixQuotaManager::~PosixQuotaManager() {
+  free(lock_open_files_);
+
   if (!initialized_)
     return;
 
-  free(lock_open_files_);
   if (shared_) {
     // Most of cleanup is done elsewhen by shared cache manager
     close(pipe_lru_[1]);
@@ -2291,7 +2292,7 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
   pthread_exit(nullptr);
 }
 
-std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
+std::vector<shash::Any> PosixQuotaManager::CollectAllOpenHashes() {
   std::vector<CollectorHandler *> handlers;
   std::vector<pthread_t *> threads;
   open_files_.clear();

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -2330,7 +2330,8 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
         joined[i] = true;
       }
     }
-    i = (++i) % handlers.size();
+    ++i;
+    i = i % handlers.size();
     clock_gettime(CLOCK_REALTIME, &current);
   }
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -549,13 +549,13 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       // pinned file as it is already reserved (but will be inserted later).
       // Instead, set the pin bit in the db to not run into an endless loop
       const bool is_pinned = pinned_chunks_.find(candidates[i].hash)
-                       != pinned_chunks_.end();
+                             != pinned_chunks_.end();
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
       const bool is_open = std::find(open_files_.begin(), open_files_.end(),
-                               candidates[i].hash)
-                     != open_files_.end();
+                                     candidates[i].hash)
+                           != open_files_.end();
 
       if (is_pinned) {
         SkipEviction(candidates[i]);
@@ -812,7 +812,7 @@ std::string PosixQuotaManager::GetMountpoints() {
   ManagedReadHalfPipe(pipe_mp[0], &mp_str_size, sizeof(size_t));
   char *buf = (char *)malloc(mp_str_size * sizeof(char));
   ManagedReadHalfPipe(pipe_mp[0], buf, mp_str_size);
-  return std::string( buf );
+  return std::string(buf);
 }
 
 std::string PosixQuotaManager::GetGroupHashes() {
@@ -827,7 +827,7 @@ std::string PosixQuotaManager::GetGroupHashes() {
   ManagedReadHalfPipe(pipe_gh[0], &mp_str_size, sizeof(size_t));
   char *buf = (char *)malloc(mp_str_size * sizeof(char));
   ManagedReadHalfPipe(pipe_gh[0], buf, mp_str_size);
-  return std::string( buf );
+  return std::string(buf);
 }
 
 /**
@@ -1340,8 +1340,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
     if (command_type == kRegisterMountpoint) {
       size_t mp_size = 0;
       ReadPipe(quota_mgr->pipe_lru_[0], &mp_size, sizeof(size_t));
-      std::string mountpoint(mp_size,'\0');
-      ReadPipe(quota_mgr->pipe_lru_[0], (void*)mountpoint.data(), mp_size);
+      std::string mountpoint(mp_size, '\0');
+      ReadPipe(quota_mgr->pipe_lru_[0], (void *)mountpoint.data(), mp_size);
       quota_mgr->mountpoints_.push_back(mountpoint);
       LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
                "Mountpoint %s registered in the group", mountpoint.c_str());
@@ -1741,15 +1741,15 @@ void PosixQuotaManager::ParseDirectories(const std::string cache_workspace,
   }
 }
 
-void PosixQuotaManager::SkipEviction(const EvictCandidate &candidate){
-      bool res = true;
-      std::string hash_str = candidate.hash.ToString();
-      LogCvmfs(kLogQuota, kLogDebug, "Exclude %s from eviction", hash_str.c_str());
-      sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
-                        SQLITE_STATIC);
-      res = (sqlite3_step(stmt_block_) == SQLITE_DONE);
-      sqlite3_reset(stmt_block_);
-      assert(res);
+void PosixQuotaManager::SkipEviction(const EvictCandidate &candidate) {
+  bool res = true;
+  std::string hash_str = candidate.hash.ToString();
+  LogCvmfs(kLogQuota, kLogDebug, "Exclude %s from eviction", hash_str.c_str());
+  sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
+                    SQLITE_STATIC);
+  res = (sqlite3_step(stmt_block_) == SQLITE_DONE);
+  sqlite3_reset(stmt_block_);
+  assert(res);
 }
 
 /**
@@ -2320,8 +2320,9 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
   clock_gettime(CLOCK_REALTIME, &current);
   reference.tv_sec += 10;  // Give 10sec for hash collection
   size_t i = 0;
-  while ((not std::all_of(joined.begin(), joined.end(),
-                          [](bool b) { return b; }))and a_after_b(reference,current)) {
+  while (
+      (not std::all_of(joined.begin(), joined.end(), [](bool b) { return b; }))
+      and a_after_b(reference, current)) {
     // as long as there are still threads that haven't joined yet
     // and for 10 seconds
     if (not joined[i]) {

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -569,13 +569,15 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
                                candidates[i].hash)
                      != open_files_.end();
 
-      if (is_pinned or (cleanup_unused_first_) ? is_open : false) {
+      if (is_pinned) {
         skip_eviction(candidates[i]);
         continue;
       }
 
-      if (is_open) {
+      if (cleanup_unused_first_ and is_open) {
+        skip_eviction(candidates[i]);
         lru_ordered_open.push_back(candidates[i]);
+        continue;
       }
 
       trash.push_back(cache_dir_ + "/"

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -29,7 +29,6 @@
 #include <sys/stat.h>
 #include <sys/xattr.h>
 
-#include <algorithm>  //std::all_of
 #ifndef __APPLE__
 #include <sys/statfs.h>
 #endif

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -785,6 +785,14 @@ uint32_t PosixQuotaManager::GetProtocolRevision() {
   return revision;
 }
 
+void PosixQuotaManager::SetCleanupPolicy(bool cleanup_unused_first) {
+  LruCommand cmd;
+  cmd.command_type = kSetCleanupPolicy;
+  WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
+
+  WritePipe(pipe_lru_[1], &cleanup_unused_first, sizeof(bool));
+}
+
 void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
   LruCommand cmd;
   cmd.command_type = kRegisterMountpoint;
@@ -1328,6 +1336,14 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       continue;
     }
 
+    // Set Cleanup Policy
+    if (command_type == kSetCleanupPolicy) {
+      bool policy = false;
+      ReadPipe(quota_mgr->pipe_lru_[0], &policy, sizeof(bool));
+      quota_mgr->cleanup_unused_first_=policy;
+      continue;
+    }
+
     // Mountpoints are returned immediately
     if (command_type == kGetMountpoints) {
       const int return_pipe = quota_mgr->BindReturnPipe(
@@ -1798,7 +1814,8 @@ PosixQuotaManager::PosixQuotaManager(const uint64_t limit,
     , stmt_list_pinned_(NULL)
     , stmt_list_catalogs_(NULL)
     , stmt_list_volatile_(NULL)
-    , initialized_(false) {
+    , initialized_(false)
+    , cleanup_unused_first_(false){
   ParseDirectories(cache_workspace, &cache_dir_, &workspace_dir_);
   pipe_lru_[0] = pipe_lru_[1] = -1;
   cleanup_recorder_.AddRecorder(1, 90);  // last 1.5 min with second resolution

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -786,16 +786,13 @@ uint32_t PosixQuotaManager::GetProtocolRevision() {
 }
 
 void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
-  int pipe_rm[2];
-  MakeReturnPipe(pipe_rm);
-
   LruCommand cmd;
   cmd.command_type = kRegisterMountpoint;
-  cmd.return_pipe = pipe_rm[0];
   WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
-  size_t mp_size = mountpoint.size() + 1;
-  WritePipe(pipe_rm[1], &mp_size, sizeof(size_t));
-  WritePipe(pipe_rm[1], mountpoint.c_str(), mp_size);
+
+  size_t mp_size = mountpoint.size();
+  WritePipe(pipe_lru_[1], &mp_size, sizeof(size_t));
+  WritePipe(pipe_lru_[1], mountpoint.c_str(), mp_size);
 }
 
 std::string PosixQuotaManager::GetMountpoints() {
@@ -1320,20 +1317,14 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
     }
 
     // Register a new mountpoint
-    if (command_type == kGetProtocolRevision) {
-      const int return_pipe = quota_mgr->BindReturnPipe(
-          command_buffer[num_commands].return_pipe);
-      if (return_pipe < 0)
-        continue;
-
+    if (command_type == kRegisterMountpoint) {
       size_t mp_size = 0;
-      ReadPipe(return_pipe, &mp_size, sizeof(size_t));
+      ReadPipe(quota_mgr->pipe_lru_[0], &mp_size, sizeof(size_t));
       char *buf = (char *)malloc(mp_size * sizeof(char));
       if (buf == nullptr)
         continue;
-      ReadPipe(return_pipe, buf, mp_size);
+      ReadPipe(quota_mgr->pipe_lru_[0], buf, mp_size);
       quota_mgr->mountpoints_.push_back(std::string{buf});
-      quota_mgr->UnbindReturnPipe(return_pipe);
       continue;
     }
 
@@ -1350,7 +1341,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
            ++it) {
         mps += *it + "\n";
       }
-      size_t mp_size = mps.size() + 1;
+      size_t mp_size = mps.size();
       WritePipe(return_pipe, &mp_size, sizeof(size_t));
       WritePipe(return_pipe, mps.c_str(), mp_size);
       quota_mgr->UnbindReturnPipe(return_pipe);

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -560,12 +560,12 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       // That's a critical condition.  We must not delete a not yet inserted
       // pinned file as it is already reserved (but will be inserted later).
       // Instead, set the pin bit in the db to not run into an endless loop
-      bool is_pinned = pinned_chunks_.find(candidates[i].hash)
+      const bool is_pinned = pinned_chunks_.find(candidates[i].hash)
                        != pinned_chunks_.end();
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
-      bool is_open = std::find(open_files_.begin(), open_files_.end(),
+      const bool is_open = std::find(open_files_.begin(), open_files_.end(),
                                candidates[i].hash)
                      != open_files_.end();
 
@@ -2261,7 +2261,7 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
   pthread_setname_np(pthread_self(), "hash_collector");
   auto *handler = static_cast<CollectorHandler *>(data);
 
-  std::string mountpoint = handler->mp[handler->i];
+  const std::string mountpoint = handler->mp[handler->i];
   ssize_t n = getxattr(mountpoint.c_str(), "user.list_open_hashes", nullptr, 0);
   if (n < 0) {
     pthread_exit(nullptr);
@@ -2275,7 +2275,7 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
 
   std::vector<std::string> hash_strs;
   std::string hash_str;
-  for (char c : buf) {
+  for (const char c : buf) {
     if (c == '\n') {
       hash_strs.push_back(hash_str);
       hash_str.clear();
@@ -2323,7 +2323,7 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
     // as long as there are still threads that haven't joined yet
     // and for 10 seconds
     if (not joined[i]) {
-      int s = pthread_tryjoin_np(*threads[i], NULL);
+      const int s = pthread_tryjoin_np(*threads[i], NULL);
       if (s == 0) {
         joined[i] = true;
       }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -29,6 +29,8 @@
 #include <sys/dir.h>
 #include <sys/stat.h>
 #include <sys/xattr.h>
+
+#include <algorithm>  //std::all_of
 #ifndef __APPLE__
 #include <sys/statfs.h>
 #endif
@@ -2277,8 +2279,12 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
 }
 
 std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
-  std::vector<CollectorHandler*> handlers;
-  std::vector<pthread_t*> threads;
+  std::vector<CollectorHandler *> handlers;
+  std::vector<pthread_t *> threads;
+
+  auto &&a_after_b = [](const struct timespec a, const struct timespec b) {
+    return (a.tv_sec > b.tv_sec) ? true : false;
+  };
 
   for (size_t i = 0; i < mountpoints_.size(); ++i) {
     handlers.push_back(
@@ -2290,15 +2296,19 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
   assert(retval == 0);
 
   for (size_t i = 0; i < mountpoints_.size(); ++i) {
-    pthread_create(threads[i], nullptr, CollectMountpointsHashes,
-                   handlers[i]);
+    pthread_create(threads[i], nullptr, CollectMountpointsHashes, handlers[i]);
   }
 
   std::vector<bool> joined(handlers.size(), false);
+  struct timespec reference, current;
+  clock_gettime(CLOCK_REALTIME, &reference);
+  clock_gettime(CLOCK_REALTIME, &current);
+  reference.tv_sec += 10;  // Give 10sec for hash collection
   size_t i = 0;
-  while (not std::all_of(joined.begin(),joined.end(),[](bool b){return b;})) {
+  while ((not std::all_of(joined.begin(), joined.end(),
+                          [](bool b) { return b; }))and a_after_b(reference,current)) {
     // as long as there are still threads that haven't joined yet
-    // TODO(christge): implement a timeout mechanism
+    // and for 10 seconds
     if (not joined[i]) {
       int s = pthread_tryjoin_np(*threads[i], NULL);
       if (s == 0) {
@@ -2306,9 +2316,10 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
       }
     }
     i = (++i) % handlers.size();
+    clock_gettime(CLOCK_REALTIME, &current);
   }
 
-  for(size_t i=0; i<handlers.size(); ++i){
+  for (size_t i = 0; i < handlers.size(); ++i) {
     delete handlers[i];
   }
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -569,7 +569,7 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
                                candidates[i].hash)
                      != open_files_.end();
 
-      if (is_pinned or (cleanup_unused_first_) ? is_open : true) {
+      if (is_pinned or (cleanup_unused_first_) ? is_open : false) {
         skip_eviction(candidates[i]);
         continue;
       }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -549,6 +549,16 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       assert(res);
     };
 
+    auto &&collect_hashes = []() -> std::vector<shash::Any> {
+      // TODO(christge): Implement the last missing component
+      // mountpoints_ contains all the mountopint associated to this QM.
+      // we can now retrieve the open hashes of a mountpoint just by getting the
+      // value of the dedicated magic xattr "list_open_hashes"
+    };
+
+    std::vector<shash::Any> open_files = (cleanup_unused_first_)
+                                             ? collect_hashes()
+                                             : std::vector<shash::Any>{};
 
     for (i = 0; i < N; ++i) {
       // That's a critical condition.  We must not delete a not yet inserted
@@ -559,10 +569,11 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
-      bool is_open = std::find(open_files_.begin(), open_files_.end(),
+      bool is_open = std::find(open_files.begin(), open_files.end(),
                                candidates[i].hash)
-                     != open_files_.end();
-      if (is_pinned or is_open) {
+                     != open_files.end();
+
+      if (is_pinned or (cleanup_unused_first_) ? is_open : true) {
         skip_eviction(candidates[i]);
         continue;
       }
@@ -1340,7 +1351,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
     if (command_type == kSetCleanupPolicy) {
       bool policy = false;
       ReadPipe(quota_mgr->pipe_lru_[0], &policy, sizeof(bool));
-      quota_mgr->cleanup_unused_first_=policy;
+      quota_mgr->cleanup_unused_first_ = policy;
       continue;
     }
 
@@ -1815,7 +1826,7 @@ PosixQuotaManager::PosixQuotaManager(const uint64_t limit,
     , stmt_list_catalogs_(NULL)
     , stmt_list_volatile_(NULL)
     , initialized_(false)
-    , cleanup_unused_first_(false){
+    , cleanup_unused_first_(false) {
   ParseDirectories(cache_workspace, &cache_dir_, &workspace_dir_);
   pipe_lru_[0] = pipe_lru_[1] = -1;
   cleanup_recorder_.AddRecorder(1, 90);  // last 1.5 min with second resolution

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -827,7 +827,7 @@ std::string PosixQuotaManager::GetGroupHashes() {
   ManagedReadHalfPipe(pipe_gh[0], &mp_str_size, sizeof(size_t));
   char *buf = (char *)malloc(mp_str_size * sizeof(char));
   ManagedReadHalfPipe(pipe_gh[0], buf, mp_str_size);
-  return std::string{buf};
+  return std::string( buf );
 }
 
 /**
@@ -1341,7 +1341,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       size_t mp_size = 0;
       ReadPipe(quota_mgr->pipe_lru_[0], &mp_size, sizeof(size_t));
       std::string mountpoint(mp_size,'\0');
-      ReadPipe(quota_mgr->pipe_lru_[0], mountpoint.data(), mp_size);
+      ReadPipe(quota_mgr->pipe_lru_[0], static_cast<void*>(mountpoint.data()), mp_size);
       quota_mgr->mountpoints_.push_back(mountpoint);
       LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
                "Mountpoint %s registered in the group", mountpoint.c_str());

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -571,8 +571,8 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
         lru_ordered_open.push_back(candidates[i]);
       }
 
-      trash.push_back(cache_dir_ + "/" +
-                      candidates[i].hash.MakePathWithoutSuffix());
+      trash.push_back(cache_dir_ + "/"
+                      + candidates[i].hash.MakePathWithoutSuffix());
       gauge_ -= candidates[i].size;
       max_acseq = candidates[i].acseq;
       LogCvmfs(kLogQuota, kLogDebug, "lru cleanup %s, new gauge %" PRIu64,
@@ -785,6 +785,18 @@ uint32_t PosixQuotaManager::GetProtocolRevision() {
   return revision;
 }
 
+void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
+  int pipe_rm[2];
+  MakeReturnPipe(pipe_rm);
+
+  LruCommand cmd;
+  cmd.command_type = kRegisterMountpoint;
+  cmd.return_pipe = pipe_rm[0];
+  WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
+  size_t mp_size = mountpoint.size() + 1;
+  WritePipe(pipe_rm[1], &mp_size, sizeof(size_t));
+  WritePipe(pipe_rm[1], mountpoint.c_str(), mp_size);
+}
 
 /**
  * Queries the shared local hard disk quota manager.
@@ -1288,6 +1300,24 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
         continue;
       WritePipe(return_pipe, &quota_mgr->kProtocolRevision,
                 sizeof(quota_mgr->kProtocolRevision));
+      quota_mgr->UnbindReturnPipe(return_pipe);
+      continue;
+    }
+
+    // Register a new mountpoint
+    if (command_type == kGetProtocolRevision) {
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
+      if (return_pipe < 0)
+        continue;
+
+      size_t mp_size = 0;
+      ReadPipe(return_pipe, &mp_size, sizeof(size_t));
+      char *buf = (char *)malloc(mp_size * sizeof(char));
+      if (buf == nullptr)
+        continue;
+      ReadPipe(return_pipe, buf, mp_size);
+      quota_mgr->mountpoints_.push_back(std::string{ buf });
       quota_mgr->UnbindReturnPipe(return_pipe);
       continue;
     }
@@ -2139,3 +2169,4 @@ void PosixQuotaManager::ManagedReadHalfPipe(int fd, void *buf, size_t nbyte) {
           "Error: quota manager could not read from cachemanager pipe");
   }
 }
+

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -540,21 +540,9 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
     const unsigned N = candidates.size();
 
-    auto &&skip_eviction = [&hash_str, &stmt_block_ = this->stmt_block_](
-                               EvictCandidate &candidate) {
-      bool res = true;
-      hash_str = candidate.hash.ToString();
-      LogCvmfs(kLogQuota, kLogDebug, "skip %s for eviction", hash_str.c_str());
-      sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
-                        SQLITE_STATIC);
-      res = (sqlite3_step(stmt_block_) == SQLITE_DONE);
-      sqlite3_reset(stmt_block_);
-      assert(res);
-    };
-
     open_files_.clear();
     open_files_ = (cleanup_unused_first_) ? CollectGroupsHashes()
-                                          : std::vector<shash::Any>{};
+                                          : std::vector<shash::Any>();
 
     for (i = 0; i < N; ++i) {
       // That's a critical condition.  We must not delete a not yet inserted
@@ -570,12 +558,12 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
                      != open_files_.end();
 
       if (is_pinned) {
-        skip_eviction(candidates[i]);
+        SkipEviction(candidates[i]);
         continue;
       }
 
       if (cleanup_unused_first_ and is_open) {
-        skip_eviction(candidates[i]);
+        SkipEviction(candidates[i]);
         lru_ordered_open.push_back(candidates[i]);
         continue;
       }
@@ -824,7 +812,7 @@ std::string PosixQuotaManager::GetMountpoints() {
   ManagedReadHalfPipe(pipe_mp[0], &mp_str_size, sizeof(size_t));
   char *buf = (char *)malloc(mp_str_size * sizeof(char));
   ManagedReadHalfPipe(pipe_mp[0], buf, mp_str_size);
-  return std::string{buf};
+  return std::string( buf );
 }
 
 std::string PosixQuotaManager::GetGroupHashes() {
@@ -1753,6 +1741,16 @@ void PosixQuotaManager::ParseDirectories(const std::string cache_workspace,
   }
 }
 
+void PosixQuotaManager::SkipEviction(const EvictCandidate &candidate){
+      bool res = true;
+      std::string hash_str = candidate.hash.ToString();
+      LogCvmfs(kLogQuota, kLogDebug, "Exclude %s from eviction", hash_str.c_str());
+      sqlite3_bind_text(stmt_block_, 1, &hash_str[0], hash_str.length(),
+                        SQLITE_STATIC);
+      res = (sqlite3_step(stmt_block_) == SQLITE_DONE);
+      sqlite3_reset(stmt_block_);
+      assert(res);
+}
 
 /**
  * Immediately inserts a new pinned catalog. Does cache cleanup if necessary.

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -806,7 +806,7 @@ void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
 
   size_t mp_size = mountpoint.size();
   WritePipe(pipe_lru_[1], &mp_size, sizeof(size_t));
-  WritePipe(pipe_lru_[1], mountpoint.c_str(), mp_size);
+  WritePipe(pipe_lru_[1], mountpoint.data(), mp_size);
 }
 
 std::string PosixQuotaManager::GetMountpoints() {
@@ -1349,11 +1349,11 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
     if (command_type == kRegisterMountpoint) {
       size_t mp_size = 0;
       ReadPipe(quota_mgr->pipe_lru_[0], &mp_size, sizeof(size_t));
-      char *buf = (char *)malloc(mp_size * sizeof(char));
-      if (buf == nullptr)
-        continue;
-      ReadPipe(quota_mgr->pipe_lru_[0], buf, mp_size);
-      quota_mgr->mountpoints_.push_back(std::string{buf});
+      std::string mountpoint(mp_size,'\0');
+      ReadPipe(quota_mgr->pipe_lru_[0], mountpoint.data(), mp_size);
+      quota_mgr->mountpoints_.push_back(mountpoint);
+      LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
+               "Mountpoint %s registered in the group", mountpoint.c_str());
       continue;
     }
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -552,6 +552,7 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       assert(res);
     };
 
+    open_files_.clear();
     open_files_ = (cleanup_unused_first_) ? CollectGroupsHashes()
                                           : std::vector<shash::Any>{};
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -18,6 +18,7 @@
 
 #include "quota_posix.h"
 
+#include <algorithm> //std::all_of
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -27,6 +28,7 @@
 #include <stdint.h>
 #include <sys/dir.h>
 #include <sys/stat.h>
+#include <sys/xattr.h>
 #ifndef __APPLE__
 #include <sys/statfs.h>
 #endif
@@ -549,16 +551,8 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
       assert(res);
     };
 
-    auto &&collect_hashes = []() -> std::vector<shash::Any> {
-      // TODO(christge): Implement the last missing component
-      // mountpoints_ contains all the mountopint associated to this QM.
-      // we can now retrieve the open hashes of a mountpoint just by getting the
-      // value of the dedicated magic xattr "list_open_hashes"
-    };
-
-    std::vector<shash::Any> open_files = (cleanup_unused_first_)
-                                             ? collect_hashes()
-                                             : std::vector<shash::Any>{};
+    open_files_ = (cleanup_unused_first_) ? CollectGroupsHashes()
+                                          : std::vector<shash::Any>{};
 
     for (i = 0; i < N; ++i) {
       // That's a critical condition.  We must not delete a not yet inserted
@@ -569,9 +563,9 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
-      bool is_open = std::find(open_files.begin(), open_files.end(),
+      bool is_open = std::find(open_files_.begin(), open_files_.end(),
                                candidates[i].hash)
-                     != open_files.end();
+                     != open_files_.end();
 
       if (is_pinned or (cleanup_unused_first_) ? is_open : true) {
         skip_eviction(candidates[i]);
@@ -1369,7 +1363,6 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       quota_mgr->cleanup_unused_first_ = policy;
       continue;
     }
-
     // Mountpoints are returned immediately
     if (command_type == kGetMountpoints) {
       const int return_pipe = quota_mgr->BindReturnPipe(
@@ -1397,10 +1390,14 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       if (return_pipe < 0)
         continue;
 
-      std::string gh = "Group Hashes";
-      size_t gh_size = gh.size();
-      WritePipe(return_pipe, &gh_size, sizeof(size_t));
-      WritePipe(return_pipe, gh.c_str(), gh_size);
+      std::vector<shash::Any> gh = quota_mgr->CollectGroupsHashes();
+      std::string result;
+      for (auto it = gh.begin(); it != gh.end(); ++it) {
+        result += (*it).ToString() + "\n";
+      }
+      size_t result_size = result.size();
+      WritePipe(return_pipe, &result_size, sizeof(size_t));
+      WritePipe(return_pipe, result.c_str(), result_size);
       quota_mgr->UnbindReturnPipe(return_pipe);
       continue;
     }
@@ -1866,6 +1863,9 @@ PosixQuotaManager::PosixQuotaManager(const uint64_t limit,
   cleanup_recorder_.AddRecorder(20 * 60, 60 * 60 * 18);
   // last 4 days with hour resolution
   cleanup_recorder_.AddRecorder(60 * 60, 60 * 60 * 24 * 4);
+
+  lock_open_files_ = reinterpret_cast<pthread_mutex_t *>(
+      smalloc(sizeof(pthread_mutex_t)));
 }
 
 
@@ -1873,6 +1873,7 @@ PosixQuotaManager::~PosixQuotaManager() {
   if (!initialized_)
     return;
 
+  free(lock_open_files_);
   if (shared_) {
     // Most of cleanup is done elsewhen by shared cache manager
     close(pipe_lru_[1]);
@@ -2252,5 +2253,66 @@ void PosixQuotaManager::ManagedReadHalfPipe(int fd, void *buf, size_t nbyte) {
     PANIC(kLogStderr,
           "Error: quota manager could not read from cachemanager pipe");
   }
+}
+
+void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
+  pthread_setname_np(pthread_self(), "hash_collector");
+  auto *handler = static_cast<CollectorHandler *>(data);
+  shash::Any hash;
+
+  const MutexLockGuard lock_guard(handler->l);
+  handler->of.push_back(hash);
+  /*
+    ssize_t n = getxattr(handler->mountpoint.c_str(), "user.list_open_hashes",
+                         nullptr, 0);
+    if (n < 0) {
+      pthread_exit(nullptr);
+    }
+    std::vector<char> buf((size_t)n);
+    n = getxattr(handler->mountpoint.c_str(), "user.list_open_hashes",
+    buf.data(), buf.size()); if (n < 0) { pthread_exit(nullptr);
+    }
+  */
+  pthread_exit(nullptr);
+}
+
+std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
+  std::vector<CollectorHandler*> handlers;
+  std::vector<pthread_t*> threads;
+
+  for (size_t i = 0; i < mountpoints_.size(); ++i) {
+    handlers.push_back(
+        new CollectorHandler{open_files_, mountpoints_, lock_open_files_, i});
+    threads.push_back(new pthread_t);
+  }
+
+  const int retval = pthread_mutex_init(lock_open_files_, NULL);
+  assert(retval == 0);
+
+  for (size_t i = 0; i < mountpoints_.size(); ++i) {
+    pthread_create(threads[i], nullptr, CollectMountpointsHashes,
+                   handlers[i]);
+  }
+
+  std::vector<bool> joined(handlers.size(), false);
+  size_t i = 0;
+  while (not std::all_of(joined.begin(),joined.end(),[](bool b){return b;})) {
+    // as long as there are still threads that haven't joined yet
+    // TODO(christge): implement a timeout mechanism
+    if (not joined[i]) {
+      int s = pthread_tryjoin_np(*threads[i], NULL);
+      if (s == 0) {
+        joined[i] = true;
+      }
+    }
+    i = (++i) % handlers.size();
+  }
+
+  for(size_t i=0; i<handlers.size(); ++i){
+    delete handlers[i];
+  }
+
+  pthread_mutex_destroy(lock_open_files_);
+  return open_files_;
 }
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -798,6 +798,21 @@ void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
   WritePipe(pipe_rm[1], mountpoint.c_str(), mp_size);
 }
 
+std::string PosixQuotaManager::GetMountpoints() {
+  int pipe_mp[2];
+  MakeReturnPipe(pipe_mp);
+
+  LruCommand cmd;
+  cmd.command_type = kGetMountpoints;
+  cmd.return_pipe = pipe_mp[1];
+  WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
+  size_t mp_str_size = 0;
+  ManagedReadHalfPipe(pipe_mp[0], &mp_str_size, sizeof(size_t));
+  char *buf = (char *)malloc(mp_str_size * sizeof(char));
+  ManagedReadHalfPipe(pipe_mp[0], buf, mp_str_size);
+  return std::string{buf};
+}
+
 /**
  * Queries the shared local hard disk quota manager.
  */
@@ -1317,7 +1332,27 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       if (buf == nullptr)
         continue;
       ReadPipe(return_pipe, buf, mp_size);
-      quota_mgr->mountpoints_.push_back(std::string{ buf });
+      quota_mgr->mountpoints_.push_back(std::string{buf});
+      quota_mgr->UnbindReturnPipe(return_pipe);
+      continue;
+    }
+
+    // Mountpoints are returned immediately
+    if (command_type == kGetMountpoints) {
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
+      if (return_pipe < 0)
+        continue;
+
+      std::string mps;
+      for (auto it = quota_mgr->mountpoints_.begin();
+           it != quota_mgr->mountpoints_.end();
+           ++it) {
+        mps += *it + "\n";
+      }
+      size_t mp_size = mps.size() + 1;
+      WritePipe(return_pipe, &mp_size, sizeof(size_t));
+      WritePipe(return_pipe, mps.c_str(), mp_size);
       quota_mgr->UnbindReturnPipe(return_pipe);
       continue;
     }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -829,6 +829,21 @@ std::string PosixQuotaManager::GetMountpoints() {
   return std::string{buf};
 }
 
+std::string PosixQuotaManager::GetGroupHashes() {
+  int pipe_gh[2];
+  MakeReturnPipe(pipe_gh);
+
+  LruCommand cmd;
+  cmd.command_type = kGetGroupHashes;
+  cmd.return_pipe = pipe_gh[1];
+  WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
+  size_t mp_str_size = 0;
+  ManagedReadHalfPipe(pipe_gh[0], &mp_str_size, sizeof(size_t));
+  char *buf = (char *)malloc(mp_str_size * sizeof(char));
+  ManagedReadHalfPipe(pipe_gh[0], buf, mp_str_size);
+  return std::string{buf};
+}
+
 /**
  * Queries the shared local hard disk quota manager.
  */
@@ -1371,6 +1386,21 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       size_t mp_size = mps.size();
       WritePipe(return_pipe, &mp_size, sizeof(size_t));
       WritePipe(return_pipe, mps.c_str(), mp_size);
+      quota_mgr->UnbindReturnPipe(return_pipe);
+      continue;
+    }
+
+    // Group hashes are returned immediately
+    if (command_type == kGetGroupHashes) {
+      const int return_pipe = quota_mgr->BindReturnPipe(
+          command_buffer[num_commands].return_pipe);
+      if (return_pipe < 0)
+        continue;
+
+      std::string gh = "Group Hashes";
+      size_t gh_size = gh.size();
+      WritePipe(return_pipe, &gh_size, sizeof(size_t));
+      WritePipe(return_pipe, gh.c_str(), gh_size);
       quota_mgr->UnbindReturnPipe(return_pipe);
       continue;
     }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1341,7 +1341,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       size_t mp_size = 0;
       ReadPipe(quota_mgr->pipe_lru_[0], &mp_size, sizeof(size_t));
       std::string mountpoint(mp_size,'\0');
-      ReadPipe(quota_mgr->pipe_lru_[0], static_cast<void*>(mountpoint.data()), mp_size);
+      ReadPipe(quota_mgr->pipe_lru_[0], (void*)mountpoint.data(), mp_size);
       quota_mgr->mountpoints_.push_back(mountpoint);
       LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
                "Mountpoint %s registered in the group", mountpoint.c_str());

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -2258,6 +2258,7 @@ void PosixQuotaManager::ManagedReadHalfPipe(int fd, void *buf, size_t nbyte) {
 }
 
 void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
+#ifndef __APPLE__
   pthread_setname_np(pthread_self(), "hash_collector");
   auto *handler = static_cast<CollectorHandler *>(data);
 
@@ -2287,6 +2288,7 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
   for (auto hash_str : hash_strs) {
     handler->of.push_back(shash::MkFromHexPtr(shash::HexPtr(hash_str)));
   }
+#endif
   pthread_exit(nullptr);
 }
 
@@ -2294,7 +2296,7 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
   std::vector<CollectorHandler *> handlers;
   std::vector<pthread_t *> threads;
   open_files_.clear();
-
+#ifndef __APPLE__
   auto &&a_after_b = [](const struct timespec a, const struct timespec b) {
     return (a.tv_sec > b.tv_sec) ? true : false;
   };
@@ -2337,6 +2339,7 @@ std::vector<shash::Any> PosixQuotaManager::CollectGroupsHashes() {
   }
 
   pthread_mutex_destroy(lock_open_files_);
+#endif
   return open_files_;
 }
 

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -275,6 +275,7 @@ class PosixQuotaManager : public QuotaManager {
                                std::string *workspace_dir);
   PosixQuotaManager(const uint64_t limit, const uint64_t cleanup_threshold,
                     const std::string &cache_workspace);
+  void SkipEviction(const EvictCandidate &candidate);
 
   /**
    * Indicates if the cache manager is a shared process or a thread within the

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -32,6 +32,7 @@ class Recorder;
  *
  * TODO(jblomer): split into client, server, and protocol classes.
  */
+class ListGroupsOpenHashesMagicXattr;
 class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, BindReturnPipe);
   FRIEND_TEST(T_QuotaManager, Cleanup);
@@ -39,6 +40,7 @@ class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, Contains);
   FRIEND_TEST(T_QuotaManager, InitDatabase);
   FRIEND_TEST(T_QuotaManager, MakeReturnPipe);
+  friend class ListGroupsOpenHashesMagicXattr;
 
  public:
   static PosixQuotaManager *Create(const std::string &cache_workspace,
@@ -88,6 +90,7 @@ class PosixQuotaManager : public QuotaManager {
   virtual void RegisterMountpoint(const std::string &mountpoint);
   virtual void SetCleanupPolicy(bool cleanup_unused_first);
   virtual std::string GetMountpoints();
+  virtual std::string GetGroupHashes();
 
   void ManagedReadHalfPipe(int fd, void *buf, size_t nbyte);
   void SetCacheMgrPid(pid_t pid_) { cachemgr_pid_ = pid_; };
@@ -131,6 +134,7 @@ class PosixQuotaManager : public QuotaManager {
     // After non open aware LRU cleanup
     kRegisterMountpoint,
     kGetMountpoints,
+    kGetGroupHashes,
     kSetCleanupPolicy,
   };
 

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -381,13 +381,6 @@ class PosixQuotaManager : public QuotaManager {
    */
   bool initialized_;
 
-  /**
-   * Used in DoCleanup to exclude currently used files from eviction
-   */
-  // TODO(gchr): it would be faster if it was a std::set. Needs a comparison
-  // operator for shash::Any
-  std::vector<shash::Any> open_files_;
-
   bool cleanup_unused_first_;
   std::vector<std::string> mountpoints_;
 };  // class PosixQuotaManager

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -86,6 +86,7 @@ class PosixQuotaManager : public QuotaManager {
   virtual pid_t GetPid();
   virtual uint32_t GetProtocolRevision();
   virtual void RegisterMountpoint(const std::string &mountpoint);
+  virtual std::string GetMountpoints();
 
   void ManagedReadHalfPipe(int fd, void *buf, size_t nbyte);
   void SetCacheMgrPid(pid_t pid_) { cachemgr_pid_ = pid_; };
@@ -128,6 +129,7 @@ class PosixQuotaManager : public QuotaManager {
     kSetLimit,
     // After non open aware LRU cleanup
     kRegisterMountpoint,
+    kGetMountpoints,
   };
 
   /**

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -35,6 +35,7 @@ class Recorder;
 class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, BindReturnPipe);
   FRIEND_TEST(T_QuotaManager, Cleanup);
+  FRIEND_TEST(T_QuotaManager, CleanupLru);
   FRIEND_TEST(T_QuotaManager, Contains);
   FRIEND_TEST(T_QuotaManager, InitDatabase);
   FRIEND_TEST(T_QuotaManager, MakeReturnPipe);
@@ -372,6 +373,14 @@ class PosixQuotaManager : public QuotaManager {
    * Used in the destructor to steer closing of the database and so on.
    */
   bool initialized_;
+
+  /**
+   * Used in DoCleanup to exclude currently used files from eviction
+   */
+  // TODO(gchr): it would be faster if it was a std::set. Needs a comparison
+  // operator for shash::Any
+  std::vector<shash::Any> open_files_;
+
 };  // class PosixQuotaManager
 
 #endif  // CVMFS_QUOTA_POSIX_H_

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -390,10 +390,22 @@ class PosixQuotaManager : public QuotaManager {
    */
   // TODO(gchr): it would be faster if it was a std::set. Needs a comparison
   // operator for shash::Any
+  pthread_mutex_t *lock_open_files_;
   std::vector<shash::Any> open_files_;
 
   bool cleanup_unused_first_;
   std::vector<std::string> mountpoints_;
+
+  std::vector<shash::Any> CollectGroupsHashes();
+
+  struct CollectorHandler {
+    std::vector<shash::Any> &of;
+    const std::vector<std::string> &mp;
+    pthread_mutex_t *l;
+    size_t i;
+  };
+
+  static void *CollectMountpointsHashes(void *data);
 };  // class PosixQuotaManager
 
 #endif  // CVMFS_QUOTA_POSIX_H_

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -86,6 +86,7 @@ class PosixQuotaManager : public QuotaManager {
   virtual pid_t GetPid();
   virtual uint32_t GetProtocolRevision();
   virtual void RegisterMountpoint(const std::string &mountpoint);
+  virtual void SetCleanupPolicy(bool cleanup_unused_first);
   virtual std::string GetMountpoints();
 
   void ManagedReadHalfPipe(int fd, void *buf, size_t nbyte);
@@ -130,6 +131,7 @@ class PosixQuotaManager : public QuotaManager {
     // After non open aware LRU cleanup
     kRegisterMountpoint,
     kGetMountpoints,
+    kSetCleanupPolicy,
   };
 
   /**
@@ -386,6 +388,7 @@ class PosixQuotaManager : public QuotaManager {
   // operator for shash::Any
   std::vector<shash::Any> open_files_;
 
+  bool cleanup_unused_first_;
   std::vector<std::string> mountpoints_;
 };  // class PosixQuotaManager
 

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -32,7 +32,6 @@ class Recorder;
  *
  * TODO(jblomer): split into client, server, and protocol classes.
  */
-class ListGroupsOpenHashesMagicXattr;
 class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, BindReturnPipe);
   FRIEND_TEST(T_QuotaManager, Cleanup);
@@ -40,7 +39,6 @@ class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, Contains);
   FRIEND_TEST(T_QuotaManager, InitDatabase);
   FRIEND_TEST(T_QuotaManager, MakeReturnPipe);
-  friend class ListGroupsOpenHashesMagicXattr;
 
  public:
   static PosixQuotaManager *Create(const std::string &cache_workspace,
@@ -397,7 +395,7 @@ class PosixQuotaManager : public QuotaManager {
   bool cleanup_unused_first_;
   std::vector<std::string> mountpoints_;
 
-  std::vector<shash::Any> CollectGroupsHashes();
+  std::vector<shash::Any> CollectAllOpenHashes();
 
   struct CollectorHandler {
     std::vector<shash::Any> &of;

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -381,6 +381,13 @@ class PosixQuotaManager : public QuotaManager {
    */
   bool initialized_;
 
+  /**
+   * Used in DoCleanup to exclude currently used files from eviction
+   */
+  // TODO(gchr): it would be faster if it was a std::set. Needs a comparison
+  // operator for shash::Any
+  std::vector<shash::Any> open_files_;
+
   bool cleanup_unused_first_;
   std::vector<std::string> mountpoints_;
 };  // class PosixQuotaManager

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -85,6 +85,7 @@ class PosixQuotaManager : public QuotaManager {
   virtual void Spawn();
   virtual pid_t GetPid();
   virtual uint32_t GetProtocolRevision();
+  virtual void RegisterMountpoint(const std::string &mountpoint);
 
   void ManagedReadHalfPipe(int fd, void *buf, size_t nbyte);
   void SetCacheMgrPid(pid_t pid_) { cachemgr_pid_ = pid_; };
@@ -125,6 +126,8 @@ class PosixQuotaManager : public QuotaManager {
     kListVolatile,
     kCleanupRate,
     kSetLimit,
+    // After non open aware LRU cleanup
+    kRegisterMountpoint,
   };
 
   /**
@@ -381,6 +384,8 @@ class PosixQuotaManager : public QuotaManager {
   // operator for shash::Any
   std::vector<shash::Any> open_files_;
 
+  std::vector<std::string> mountpoints_;
 };  // class PosixQuotaManager
 
 #endif  // CVMFS_QUOTA_POSIX_H_
+

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -2,21 +2,139 @@
 
 cvmfs_test_name="Cache cleanup"
 
+FILE_DB=/tmp/file.list
+OPEN_FILE_DB=/tmp/open_file.list
+
+CLEANUP_TARGET=772
+
+TARGET_REPO=atlas-condb.cern.ch
+
+cleanup(){
+  rm -rf $FILE_DB, $OPEN_FILE_DB
+  close_readers
+}
+
+is_greater(){
+  (( $1 > $2 ))
+}
+
+mount_repo_fresh(){
+  local is_enabled=$1
+  echo "Mounting $TARGET_REPO.."
+  cvmfs_umount "$TARGET_REPO"
+  cvmfs_mount "$TARGET_REPO" \
+    "CVMFS_QUOTA_LIMIT=1600" \
+    "CVMFS_CACHE_EXTERNAL_SIZE=750" \
+    "CVMFS_CACHE_CLEANUP_NONOPENLRU=$is_enabled" \
+    "CVMFS_CACHE_REFCOUNT=yes" \
+    "CVMFS_MIN_CHUNK_SIZE=200M" \
+    "CVMFS_SYSLOG_LEVEL=3" || return 1
+}
+
+pick_files_for_testing(){
+  find "/cvmfs/$TARGET_REPO" -type f -size +100M -size -200M -print0 | head -zn10 > $FILE_DB
+  head -zn5 $FILE_DB > $OPEN_FILE_DB
+}
+
+create_lru_access_pattern(){
+  echo "Creating an access pattern to establish an LRU chain.."
+  local file_list=$1
+  while IFS= read -r -d '' file; do
+    cat $file > /dev/null
+  done < $file_list
+}
+
+open_files(){
+  echo "Opening files until cleanup.."
+  local file_list=$1
+  while IFS= read -r -d '' file; do
+    tail -f "$file" &>/dev/null &
+  done < $file_list
+}
+
+close_readers(){
+  pkill tail
+}
+
+compute_actual_sizes(){
+  local total=0
+  while IFS= read -r -d '' file; do
+    size=$(stat --printf="%s" "$file")
+    size_mb=$(awk "BEGIN {printf \"%.2f\", $size/1024/1024}")
+    total=$(awk "BEGIN {printf \"%.2f\", $total + $size_mb}")
+  done < $FILE_DB
+
+  local subtotal=0
+  while IFS= read -r -d '' file; do
+    size=$(stat --printf="%s" "$file")
+    size_mb=$(awk "BEGIN {printf \"%.2f\", $size/1024/1024}")
+    subtotal=$(awk "BEGIN {printf \"%.2f\", $subtotal + $size_mb}")
+  done < $OPEN_FILE_DB
+
+  echo "$total $subtotal"
+}
+
+# returns the cache size in MB
+get_cache_size_linked(){
+  sudo du -c --block-size=1M /var/lib/cvmfs  | grep total | awk '/total/ {print$1}'
+}
+get_cache_size_unlinked(){
+  sudo lsof -nP +L1 2>/dev/null | ag cvmfs | ag REG | awk '{s+=$7} END {printf "%.2f\n", s/1024/1024}'
+}
+
+get_total_cache_size(){
+  local linked=$(get_cache_size_linked)
+  local unlinked=$(get_cache_size_unlinked)
+
+  awk -v a="$linked" -v b="$unlinked" 'BEGIN { print a + b }'
+}
+
+print_files(){
+  local file_list=$1
+  while IFS= read -r -d '' file; do
+    echo "$file"
+  done < $file_list
+}
+
+print_file_hashes(){
+  local file_list=$1
+  while IFS= read -r -d '' file; do
+    attr -g hash "$file"
+  done < $file_list
+}
+
+test_vanilla_lru(){
+  mount_repo_fresh "no"
+  local file_sizes="$(compute_actual_sizes)"
+  local total=$(echo "$file_sizes" | awk '{ print $1 }')
+  local subtotal=$(echo "$file_sizes" | awk '{ print $2 }')
+  echo -e "\tTotal file size is: $total MB"
+  echo -e "\tOpen files size is: $subtotal MB"
+}
+
+test_advanced_lru(){
+  mount_repo_fresh "yes"
+  local file_sizes="$(compute_actual_sizes)"
+  local total=$(echo "$file_sizes" | awk '{ print $1 }')
+  local subtotal=$(echo "$file_sizes" | awk '{ print $2 }')
+  echo -e "\tTotal file size is: $total MB"
+  echo -e "\tOpen files size is: $subtotal MB"
+
+  sudo cvmfs_config wipecache > /dev/null && echo "Whipping cache.. OK" || $(echo "Wipping cache.. FAILED!" && return 30)
+  
+  open_files "$OPEN_FILE_DB"
+  create_lru_access_pattern $FILE_DB
+}
+
 cvmfs_run_test() {
+  trap cleanup EXIT
   logfile=$1
 
-  cvmfs_mount "atlas.cern.ch,atlas-condb.cern.ch" \
-    "CVMFS_QUOTA_LIMIT=750" "CVMFS_CACHE_EXTERNAL_SIZE=750" || return 1
+  mount_repo_fresh "no"
+  pick_files_for_testing
 
-  find /cvmfs/atlas-condb.cern.ch -type f -size +100M -size -200M | head -n 64 | \
-    xargs file > /dev/null || return 1
-
-  turnover=$(sudo cvmfs_talk -i atlas-condb.cern.ch cleanup rate 120)
-  echo "number of cleanup in the last 2 hours: $turnover"
-  if [[ turnover -le 0 ]]; then
-    return 2
-  fi
-
+#  test_vanilla_lru && \
+    test_advanced_lru
   return 0
 }
 

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -9,6 +9,8 @@ CLEANUP_TARGET=772
 
 TARGET_REPO=atlas-condb.cern.ch
 
+vanilla_post=""
+
 cleanup(){
   rm -rf $FILE_DB, $OPEN_FILE_DB
   close_readers
@@ -121,6 +123,7 @@ test_vanilla_lru(){
   echo -n "Target: $CLEANUP_TARGET. Cleaning up.. "
   sudo cvmfs_talk -i "$TARGET_REPO" cleanup $CLEANUP_TARGET || $(echo "FAILED" && return 21)
   print_cache_statistics
+  vanilla_post=$(get_cache_size_linked)
   close_readers
 }
 
@@ -137,9 +140,22 @@ test_advanced_lru(){
     return 31
   fi
   print_cache_statistics
+  local pre=$(get_cache_size_linked)
   echo -n "Target: $CLEANUP_TARGET. Cleaning up.. "
   sudo cvmfs_talk -i "$TARGET_REPO" cleanup $CLEANUP_TARGET || $(echo "FAILED" && return 32)
   print_cache_statistics
+  local post=$(get_cache_size_linked)
+  if [ "$pre" -eq "$post" ]; then
+    return 33
+  elif [ "$post" -gt "$pre" ]; then
+    return 34
+  fi
+  if [ "$vanilla_post" -eq "$post" ]; then
+    return 35
+  elif [ "$post" -gt "$vanilla_post" ]; then
+    return 36
+  fi
+  return 0
 }
 
 cvmfs_run_test() {
@@ -150,7 +166,7 @@ cvmfs_run_test() {
   print_file_statistics
 
   test_vanilla_lru
-  test_advanced_lru 
+  test_advanced_lru || return $?
   cleanup
   return 0
 }

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -123,6 +123,7 @@ test_advanced_lru(){
   sudo cvmfs_config wipecache > /dev/null && echo "Whipping cache.. OK" || $(echo "Wipping cache.. FAILED!" && return 30)
   
   open_files "$OPEN_FILE_DB"
+  attr -qg list_open_hashes /cvmfs/$TARGET_REPO
   create_lru_access_pattern $FILE_DB
 }
 

--- a/test/src/034-cachecleanup/main
+++ b/test/src/034-cachecleanup/main
@@ -82,13 +82,6 @@ get_cache_size_unlinked(){
   sudo lsof -nP +L1 2>/dev/null | ag cvmfs | ag REG | awk '{s+=$7} END {printf "%.2f\n", s/1024/1024}'
 }
 
-get_total_cache_size(){
-  local linked=$(get_cache_size_linked)
-  local unlinked=$(get_cache_size_unlinked)
-
-  awk -v a="$linked" -v b="$unlinked" 'BEGIN { print a + b }'
-}
-
 print_files(){
   local file_list=$1
   while IFS= read -r -d '' file; do
@@ -103,39 +96,62 @@ print_file_hashes(){
   done < $file_list
 }
 
-test_vanilla_lru(){
-  mount_repo_fresh "no"
+print_file_statistics(){
   local file_sizes="$(compute_actual_sizes)"
   local total=$(echo "$file_sizes" | awk '{ print $1 }')
   local subtotal=$(echo "$file_sizes" | awk '{ print $2 }')
   echo -e "\tTotal file size is: $total MB"
   echo -e "\tOpen files size is: $subtotal MB"
+}
+
+print_cache_statistics(){
+  sleep 0.5
+  echo -e "\t$ statistics:"
+  echo -e "\t\tlinked: $(get_cache_size_linked) MB"
+  echo -e "\t\tunlinked: $(get_cache_size_unlinked) MB"
+}
+test_vanilla_lru(){
+  mount_repo_fresh "no"
+  sudo cvmfs_config wipecache > /dev/null && echo "Whipping cache.. OK" || $(echo "Wipping cache.. FAILED!" && return 20)
+  
+  open_files "$OPEN_FILE_DB" &> /dev/null
+  create_lru_access_pattern $FILE_DB
+
+  print_cache_statistics
+  echo -n "Target: $CLEANUP_TARGET. Cleaning up.. "
+  sudo cvmfs_talk -i "$TARGET_REPO" cleanup $CLEANUP_TARGET || $(echo "FAILED" && return 21)
+  print_cache_statistics
+  close_readers
 }
 
 test_advanced_lru(){
   mount_repo_fresh "yes"
-  local file_sizes="$(compute_actual_sizes)"
-  local total=$(echo "$file_sizes" | awk '{ print $1 }')
-  local subtotal=$(echo "$file_sizes" | awk '{ print $2 }')
-  echo -e "\tTotal file size is: $total MB"
-  echo -e "\tOpen files size is: $subtotal MB"
-
   sudo cvmfs_config wipecache > /dev/null && echo "Whipping cache.. OK" || $(echo "Wipping cache.. FAILED!" && return 30)
   
-  open_files "$OPEN_FILE_DB"
-  attr -qg list_open_hashes /cvmfs/$TARGET_REPO
+  open_files "$OPEN_FILE_DB" &> /dev/null
   create_lru_access_pattern $FILE_DB
+
+  echo "Retrieving the open hashes.."
+  local open_hashes="$(attr -qg list_open_hashes /cvmfs/$TARGET_REPO)"
+  if [ "x$open_hashes" = "x" ]; then
+    return 31
+  fi
+  print_cache_statistics
+  echo -n "Target: $CLEANUP_TARGET. Cleaning up.. "
+  sudo cvmfs_talk -i "$TARGET_REPO" cleanup $CLEANUP_TARGET || $(echo "FAILED" && return 32)
+  print_cache_statistics
 }
 
 cvmfs_run_test() {
-  trap cleanup EXIT
   logfile=$1
 
   mount_repo_fresh "no"
   pick_files_for_testing
+  print_file_statistics
 
-#  test_vanilla_lru && \
-    test_advanced_lru
+  test_vanilla_lru
+  test_advanced_lru 
+  cleanup
   return 0
 }
 

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -107,6 +107,14 @@ cvmfs_run_test() {
   [ "x$readme_chunk_offset" = "x0" ] || return 11
   [ "x$readme_chunk_size" = "x$readme_size" ] || return 12
 
+  echo "Test 'cleanup_unused_first' magic extended attribute"
+
+  local cleanup_unused_first_err=$(get_xattr cleanup_unused_first /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local cleanup_unused_first=$(get_xattr cleanup_unused_first /cvmfs/grid.cern.ch)
+  if [ "x$cleanup_unused_first" = "x" ] || [ "x$cleanup_unused_first_err" != "x" ]; then
+    return 13
+  fi
+
   echo "*** Test log buffer (quite basic)"
   local logbuffer
   logbuffer=$(get_xattr logbuffer /cvmfs/grid.cern.ch/)

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -119,24 +119,30 @@ cvmfs_run_test() {
 
   local list_open_hashes_err=$(get_xattr list_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
   local list_open_hashes=$(get_xattr list_open_hashes /cvmfs/grid.cern.ch)
-  if [ "x$list_open_hashes" = "x" ] || [ "x$list_open_hashes_err" != "x" ]; then
-    return 13
+  if [ "$cleanup_unused_first" = "yes" ]; then
+    if [ "x$list_open_hashes" = "x" ] || [ "x$list_open_hashes_err" != "x" ]; then
+      return 14
+    fi
   fi
 
   echo "Test 'list_groups_open_hashes' magic extended attribute"
 
   local list_groups_open_hashes_err=$(get_xattr list_groups_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
   local list_groups_open_hashes=$(get_xattr list_groups_open_hashes /cvmfs/grid.cern.ch)
-  if [ "x$list_groups_open_hashes" = "x" ] || [ "x$list_groups_open_hashes_err" != "x" ]; then
-    return 13
+  if [ "$cleanup_unused_first" = "yes" ]; then
+    if [ "x$list_groups_open_hashes" = "x" ] || [ "x$list_groups_open_hashes_err" != "x" ]; then
+      return 15
+    fi
   fi
 
   echo "Test 'list_managed_mountpoints' magic extended attribute"
 
   local list_managed_mountpoints_err=$(get_xattr list_managed_mountpoints /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
   local list_managed_mountpoints=$(get_xattr list_managed_mountpoints /cvmfs/grid.cern.ch)
-  if [ "x$list_managed_mountpoints" = "x" ] || [ "x$list_managed_mountpoints_err" != "x" ]; then
-    return 13
+  if [ "$cleanup_unused_first" = "yes" ]; then
+    if [ "x$list_managed_mountpoints" = "x" ] || [ "x$list_managed_mountpoints_err" != "x" ]; then
+      return 16
+    fi
   fi
 
   echo "*** Test log buffer (quite basic)"

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -115,6 +115,30 @@ cvmfs_run_test() {
     return 13
   fi
 
+  echo "Test 'list_open_hashes' magic extended attribute"
+
+  local list_open_hashes_err=$(get_xattr list_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local list_open_hashes=$(get_xattr list_open_hashes /cvmfs/grid.cern.ch)
+  if [ "x$list_open_hashes" = "x" ] || [ "x$list_open_hashes_err" != "x" ]; then
+    return 13
+  fi
+
+  echo "Test 'list_groups_open_hashes' magic extended attribute"
+
+  local list_groups_open_hashes_err=$(get_xattr list_groups_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local list_groups_open_hashes=$(get_xattr list_groups_open_hashes /cvmfs/grid.cern.ch)
+  if [ "x$list_groups_open_hashes" = "x" ] || [ "x$list_groups_open_hashes_err" != "x" ]; then
+    return 13
+  fi
+
+  echo "Test 'list_managed_mountpoints' magic extended attribute"
+
+  local list_managed_mountpoints_err=$(get_xattr list_managed_mountpoints /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local list_managed_mountpoints=$(get_xattr list_managed_mountpoints /cvmfs/grid.cern.ch)
+  if [ "x$list_managed_mountpoints" = "x" ] || [ "x$list_managed_mountpoints_err" != "x" ]; then
+    return 13
+  fi
+
   echo "*** Test log buffer (quite basic)"
   local logbuffer
   logbuffer=$(get_xattr logbuffer /cvmfs/grid.cern.ch/)

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -125,26 +125,6 @@ cvmfs_run_test() {
     fi
   fi
 
-  echo "Test 'list_groups_open_hashes' magic extended attribute"
-
-  local list_groups_open_hashes_err=$(get_xattr list_groups_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
-  local list_groups_open_hashes=$(get_xattr list_groups_open_hashes /cvmfs/grid.cern.ch)
-  if [ "$cleanup_unused_first" = "yes" ]; then
-    if [ "x$list_groups_open_hashes" = "x" ] || [ "x$list_groups_open_hashes_err" != "x" ]; then
-      return 15
-    fi
-  fi
-
-  echo "Test 'list_managed_mountpoints' magic extended attribute"
-
-  local list_managed_mountpoints_err=$(get_xattr list_managed_mountpoints /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
-  local list_managed_mountpoints=$(get_xattr list_managed_mountpoints /cvmfs/grid.cern.ch)
-  if [ "$cleanup_unused_first" = "yes" ]; then
-    if [ "x$list_managed_mountpoints" = "x" ] || [ "x$list_managed_mountpoints_err" != "x" ]; then
-      return 16
-    fi
-  fi
-
   echo "*** Test log buffer (quite basic)"
   local logbuffer
   logbuffer=$(get_xattr logbuffer /cvmfs/grid.cern.ch/)

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -229,21 +229,13 @@ TEST_F(T_QuotaManager, CleanupLru) {
     quota_mgr_->Touch(hashes_[i]);
   }
 
-  const unsigned open_files = N / 1000;
-  for (unsigned i = 0; i < open_files; ++i) {
-    quota_mgr_->open_files_.push_back(hashes_[i]);
-  }
-
-  EXPECT_TRUE(quota_mgr_->Cleanup(N/2));
+  quota_mgr_->cleanup_unused_first_ = false;
+  EXPECT_TRUE(quota_mgr_->Cleanup(N / 2));
   vector<string> remaining = quota_mgr_->List();
   EXPECT_EQ(N / 2, remaining.size());
   sort(remaining.begin(), remaining.end());
   for (unsigned i = 0; i < remaining.size(); ++i) {
-    if (i < open_files) {
-      EXPECT_EQ(StringifyIntLeadingZeros(i), remaining[i]);
-    } else {
-      EXPECT_EQ(StringifyIntLeadingZeros(N / 2 + i), remaining[i]);
-    }
+    EXPECT_EQ(StringifyIntLeadingZeros(N / 2 + i), remaining[i]);
   }
 }
 
@@ -583,3 +575,4 @@ TEST_F(T_QuotaManager, SetLimit) {
   const uint64_t limit = quota_mgr_->GetCapacity();
   EXPECT_EQ(100ul, limit);
 }
+

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -229,12 +229,21 @@ TEST_F(T_QuotaManager, CleanupLru) {
     quota_mgr_->Touch(hashes_[i]);
   }
 
-  EXPECT_TRUE(quota_mgr_->Cleanup(N / 2));
+  const unsigned open_files = N / 1000;
+  for (unsigned i = 0; i < open_files; ++i) {
+    quota_mgr_->open_files_.push_back(hashes_[i]);
+  }
+
+  EXPECT_TRUE(quota_mgr_->Cleanup(N/2));
   vector<string> remaining = quota_mgr_->List();
   EXPECT_EQ(N / 2, remaining.size());
   sort(remaining.begin(), remaining.end());
   for (unsigned i = 0; i < remaining.size(); ++i) {
-    EXPECT_EQ(StringifyIntLeadingZeros(N / 2 + i), remaining[i]);
+    if (i < open_files) {
+      EXPECT_EQ(StringifyIntLeadingZeros(i), remaining[i]);
+    } else {
+      EXPECT_EQ(StringifyIntLeadingZeros(N / 2 + i), remaining[i]);
+    }
   }
 }
 


### PR DESCRIPTION
On the Algorithmic side open files are handled as if they were pinned.

The tricky part is how the PosixQuotaManager (PQM) will get to know which files are open. In this approach, open hashes are communicated to the PQM using a dedicated magic xattr.

Firstly the PQM needs to know its managed mount points. This is happening early, when the PQM is acquired.
To get the open hashes of a mount point, this approach introduces the magic xattr `user.list_open_hashes`.
To get the mount points managed from the shared PQM,  this approach introduces the magic xattr `user.list_managed_mountopints`.
To get the open hashes of all the mount points associated to the shared PQM, this approach introduces the magic xattr `user.list_groups_open_hashes`. This last magic xattr uses exactly the same mechanism that is employed in `DoCleanup()`.


By default on this stage the feature is turned off. To enable it add `CVMFS_CACHE_CLEANUP_NONOPENLRU=yes` in the configuration.