### PR TITLE
[CLIENT] Parse Bundle File

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -244,6 +244,7 @@ if (BUILD_CVMFS)
        notify/subscriber_supervisor.cc
        notify/subscriber_sse.cc
        quota_listener.cc
+       util/inode.cc
        shortstring.cc
        supervisor.cc
        talk.cc

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -248,6 +248,7 @@ if (BUILD_CVMFS)
        supervisor.cc
        talk.cc
        url.cc
+       bundle_mgr.cc
   )
   set (CVMFS_FUSE_CFLAGS "-DCVMFS_FUSE_MODULE -D_FILE_OFFSET_BITS=64 -fexceptions")
   if (CVMFS_ENABLE_FUSE3_CACHE_READDIR)

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -116,7 +116,7 @@ void BundleMgr::SpawnFetchers() {
     // Make the write operation to the return pipe non blocking
     // According to the man (7) page of write, when attempting to write
     // n<=PIPE_BUF data on a non blocking pipe, it will either write all of them
-    // or errno will set to EAGAIN. PIPE_BUF is at least 512bytes on and linux
+    // or errno will be set to EAGAIN. PIPE_BUF is at least 512bytes on and linux
     // 4096bytes.
     int flags = fcntl(fd, F_GETFL);
     fcntl(fd, F_SETFL, flags | O_NONBLOCK);

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -1,0 +1,7 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "bundle_mgr.h"
+
+void BundleMgr::Fetch(){}

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -10,8 +10,8 @@
 
 #include "fetch.h"
 #include "util/inode.h"
-#include "util/posix.h"
 #include "util/pointer.h"
+#include "util/posix.h"
 
 BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : mount_point_(mp) {
   is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
@@ -103,7 +103,7 @@ void BundleMgr::JoinFetchers() {
 void BundleMgr::SpawnFetchers() {
   MakePipe(pipe_bm_);
 
-  size_t size = 1+( bfm_->Size() / 30 ); // Spawn at least one fetcher
+  size_t size = 1 + (bfm_->Size() / 30);  // Spawn at least one fetcher
   for (size_t i = 0; i < size; ++i) {
     pthread_t thread;
     int res = pthread_create(&thread, nullptr, EstablishConnection, this);
@@ -116,8 +116,8 @@ void BundleMgr::SpawnFetchers() {
     // Make the write operation to the return pipe non blocking
     // According to the man (7) page of write, when attempting to write
     // n<=PIPE_BUF data on a non blocking pipe, it will either write all of them
-    // or errno will be set to EAGAIN. PIPE_BUF is at least 512bytes on and linux
-    // 4096bytes.
+    // or errno will be set to EAGAIN. PIPE_BUF is at least 512bytes on and
+    // linux 4096bytes.
     int flags = fcntl(fd, F_GETFL);
     fcntl(fd, F_SETFL, flags | O_NONBLOCK);
     fetcher_pool_.push_back({thread, fd});
@@ -162,13 +162,28 @@ CacheManager::LabeledObject BundleMgr::ReceiveLabeledObject(int fd) const {
   return CacheManager::LabeledObject(shash::Any{}, CacheManager::Label());
 }
 
-void BundleMgr::SendLabeledObject(
-    int fd, UniquePtr<CacheManager::LabeledObject>& obj) const {
-  (void)obj;
+bool BundleMgr::SendLabeledObject(
+    int fd, UniquePtr<CacheManager::LabeledObject> &obj) const {
+  return true;
 }
 
-bool BundleMgr::TrySendData(
-    int fd, UniquePtr<CacheManager::LabeledObject>& obj) const {
+bool BundleMgr::TrySendData(int fd,
+                            UniquePtr<CacheManager::LabeledObject> &obj) const {
+  Command cmd = Command::kFetch;
+  size_t n = write(fd, &cmd, sizeof(Command));
+  if (n != sizeof(Command)) {
+    if (not(errno == EAGAIN || errno == EWOULDBLOCK)) {
+      LogCvmfs(kLogBungleMgr,
+               kLogDebug,
+               "write() on back channel failed unexpectedly");
+    }
+    return false;
+  } else {
+    while (SendLabeledObject(fd, obj) != true) {
+      // If a Fetcher receives a kFetch command should receive the Labeled Object also.
+    }
+  }
+
   return true;
 }
 

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -139,8 +139,12 @@ void *BundleMgr::EstablishConnection(void *data) {
     bool terminate = false;
     switch (cmd) {
       case Command::kFetch: {
-        auto object = mgr->ReceiveLabeledObject(rfd);
-        mgr->fetcher_->Fetch(object);
+        auto obj = mgr->ReceiveLabeledObject(rfd);
+        if (not obj.IsValid()) {
+          LogCvmfs(kLogBungleMgr, kLogDebug, "Received a null object");
+          break;
+        }
+        mgr->fetcher_->Fetch(*obj);
       } break;
       case Command::kTerminate:
       default:
@@ -156,13 +160,29 @@ void *BundleMgr::EstablishConnection(void *data) {
   pthread_exit(nullptr);
 }
 
-CacheManager::LabeledObject BundleMgr::ReceiveLabeledObject(int fd) const {
-  (void)fd;
-  return CacheManager::LabeledObject(shash::Any{}, CacheManager::Label());
+UniquePtr<CacheManager::LabeledObject> BundleMgr::ReceiveLabeledObject(
+    int fd) const {
+  shash::Any id = BlockingReceive<shash::Any>(fd);
+  CacheManager::Label label;
+  label.flags=BlockingReceive<int>(fd);
+  label.size=BlockingReceive<uint64_t>(fd);
+  label.zip_algorithm=BlockingReceive<zlib::Algorithms>(fd);
+  label.range_offset=BlockingReceive<off_t>(fd);
+  label.path=BlockingReceive(fd);
+  CacheManager::LabeledObject* obj = new CacheManager::LabeledObject(id,label);
+  assert(obj!=nullptr);
+  return UniquePtr<CacheManager::LabeledObject>(obj);
 }
 
 bool BundleMgr::SendLabeledObject(
-    int fd, UniquePtr<CacheManager::LabeledObject> &obj) const {
+    int fd, const UniquePtr<CacheManager::LabeledObject> &obj) const {
+  BlockingSend(fd, obj->id);
+  BlockingSend(fd, obj->label.flags);
+  BlockingSend(fd, obj->label.size);
+  BlockingSend(fd, obj->label.zip_algorithm);
+  BlockingSend(fd, obj->label.range_offset);
+  const std::string &path=obj->label.path;
+  BlockingSend(fd, path);
   return true;
 }
 
@@ -179,7 +199,8 @@ bool BundleMgr::TrySendData(int fd,
     return false;
   } else {
     while (SendLabeledObject(fd, obj) != true) {
-      // If a Fetcher receives a kFetch command should receive the Labeled Object also.
+      // If a Fetcher receives a kFetch command should receive the Labeled
+      // Object also.
     }
   }
 

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -99,11 +99,13 @@ void BundleMgr::SpawnFetchers() {
 void *BundleMgr::EstablishConnection(void *data) {
   pthread_setname_np(pthread_self(), "bm_fetcher");
   BundleMgr *mgr = static_cast<BundleMgr *>(data);
-  int rfd = mgr->pipe_bm_[1];
+  int wfd = mgr->pipe_bm_[1];
   int back_channel[2];
   MakePipe(back_channel);
 
-  WritePipe(rfd, &back_channel[1], sizeof(int));
+  WritePipe(wfd, &back_channel[1], sizeof(int));
+
+  int& rfd=back_channel[0];
 
   Command cmd;
   while (read(rfd, &cmd, sizeof(Command)) == sizeof(Command)) {
@@ -128,6 +130,7 @@ void *BundleMgr::EstablishConnection(void *data) {
 }
 
 CacheManager::LabeledObject BundleMgr::ReceiveLabeledObject(int fd) const {
+  (void)fd;
   return CacheManager::LabeledObject(shash::Any{}, CacheManager::Label());
 }
 

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -99,11 +99,11 @@ void BundleMgr::SpawnFetchers() {
 void *BundleMgr::EstablishConnection(void *data) {
   pthread_setname_np(pthread_self(), "bm_fetcher");
   BundleMgr *mgr = static_cast<BundleMgr *>(data);
-  int rfd = mgr->pipe_bm_[0];
+  int rfd = mgr->pipe_bm_[1];
   int back_channel[2];
   MakePipe(back_channel);
 
-  WritePipe(rfd, back_channel + 1, sizeof(int));
+  WritePipe(rfd, &back_channel[1], sizeof(int));
 
   Command cmd;
   while (read(rfd, &cmd, sizeof(Command)) == sizeof(Command)) {

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -22,7 +22,6 @@ BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : mount_point_(mp) {
   fname_ = GetFileName(path_);
   parent_path_ = GetParentPath(path_);
   fetcher_ = dirent_.IsExternalFile() ? mp->external_fetcher() : mp->fetcher();
-
   // There is a naming convention regarding the name of the file with the
   // contents of the bundle
   bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -8,6 +8,20 @@
 
 #include <vector>
 
+BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : is_valid_(true) {
+    is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
+    is_valid_ &= cvmfs::GetDirentForInode(mp, mp->file_system(), ino, &dirent_);
+    fname_ = GetFileName(path_);
+    parent_path_ = GetParentPath(path_);
+
+    // There is a naming convention regarding the name of the file with the
+    // contents of the bundle
+    bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
+                                   + fname_.ToString());
+
+    bfm_ = new BundleFileMgr(bundle_file_path_);
+  }
+
 void BundleMgr::Fetch() {
   std::vector<pthread_t> fetcher_pool;
 

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -4,4 +4,36 @@
 
 #include "bundle_mgr.h"
 
-void BundleMgr::Fetch(){}
+#include <pthread.h>
+
+#include <vector>
+
+void BundleMgr::Fetch() {
+  std::vector<pthread_t> fetcher_pool;
+
+  for (PathString next_f = bfm_->GetNext(); not next_f.IsEmpty();
+       next_f = bfm_->GetNext()) {
+    pthread_t fetcher_t;
+
+    // TODO(christge): DoFetch requires real arguments
+    pthread_create(&fetcher_t, nullptr, DoFetch, nullptr);
+    fetcher_pool.emplace_back(fetcher_t);
+  }
+
+  // Join fetcher threads
+  while (not fetcher_pool.empty()) {
+    for (auto it = fetcher_pool.begin(); it != fetcher_pool.end();) {
+      auto &thread = *it;
+      void *retval;
+      int is_joinable = pthread_tryjoin_np(thread, &retval);
+      if (is_joinable == 0) {
+        // fetch has finished
+        fetcher_pool.erase(it);
+      } else {
+        // still busy
+        ++it;
+      }
+    }
+  }
+}
+

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -161,7 +161,7 @@ void *BundleMgr::EstablishConnection(void *data) {
 
 UniquePtr<CacheManager::LabeledObject> BundleMgr::ReceiveLabeledObject(
     int fd) const {
-  shash::Any id = BlockingReceive<shash::Any>(fd);
+  const shash::Any id = BlockingReceive<shash::Any>(fd);
   CacheManager::Label label;
   label.flags = BlockingReceive<int>(fd);
   label.size = BlockingReceive<uint64_t>(fd);

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -11,6 +11,7 @@
 #include "fetch.h"
 #include "util/inode.h"
 #include "util/posix.h"
+#include "util/pointer.h"
 
 BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : mount_point_(mp) {
   is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
@@ -34,7 +35,6 @@ BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : mount_point_(mp) {
 void BundleMgr::Fetch() {
   SpawnFetchers();
 
-  CacheManager::LabeledObject *obj;
   auto it = fetcher_pool_.begin();
   if (it == fetcher_pool_.end()) {
     LogCvmfs(kLogBungleMgr,
@@ -43,18 +43,21 @@ void BundleMgr::Fetch() {
              "Aborting Op.");
     return;
   }
-  while ((obj = bfm_->GetNext()) != nullptr) {
-    auto pair = *it;
-    auto wfd = std::get<1>(pair);
+
+  while (true) {
+    UniquePtr<CacheManager::LabeledObject> obj = bfm_->GetNext();
+    if (not obj.IsValid()) {
+      break;
+    }
+    auto wfd = std::get<1>(*it);
     // Find the first available Fetcher to send the data
-    while (not TrySendData(wfd, *obj)) {
-      if (( ++it ) == fetcher_pool_.end()) {
+    while (not TrySendData(wfd, obj)) {
+      if ((++it) == fetcher_pool_.end()) {
         it = fetcher_pool_.begin();
       }
-      pair = *it;
-      wfd = std::get<1>(pair);
+      wfd = std::get<1>(*it);
     }
-    if (( ++it ) == fetcher_pool_.end()) {
+    if ((++it) == fetcher_pool_.end()) {
       it = fetcher_pool_.begin();
     }
   }
@@ -100,7 +103,7 @@ void BundleMgr::JoinFetchers() {
 void BundleMgr::SpawnFetchers() {
   MakePipe(pipe_bm_);
 
-  size_t size = bfm_->Size() / 30;
+  size_t size = 1+( bfm_->Size() / 30 ); // Spawn at least one fetcher
   for (size_t i = 0; i < size; ++i) {
     pthread_t thread;
     int res = pthread_create(&thread, nullptr, EstablishConnection, this);
@@ -160,11 +163,12 @@ CacheManager::LabeledObject BundleMgr::ReceiveLabeledObject(int fd) const {
 }
 
 void BundleMgr::SendLabeledObject(
-    int fd, const CacheManager::LabeledObject &obj) const {
+    int fd, UniquePtr<CacheManager::LabeledObject>& obj) const {
   (void)obj;
 }
 
 bool BundleMgr::TrySendData(
-    int fd, const CacheManager::LabeledObject &obj) const {
-  (void)obj;
+    int fd, UniquePtr<CacheManager::LabeledObject>& obj) const {
+  return true;
 }
+

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -87,8 +87,7 @@ void BundleMgr::JoinFetchers() {
       ts.tv_sec += 10;
       Command cmd = Command::kTerminate;
       WritePipe(fd, &cmd, sizeof(Command));
-      int res = pthread_timedjoin_np(thread, nullptr, &ts);
-      if (res != 0) {
+      if (pthread_timedjoin_np(thread, nullptr, &ts) != 0) {
         LogCvmfs(kLogBungleMgr,
                  kLogDebug,
                  "Fetcher is busy for too long. Detaching.");
@@ -126,7 +125,7 @@ void BundleMgr::SpawnFetchers() {
 void *BundleMgr::EstablishConnection(void *data) {
   pthread_setname_np(pthread_self(), "bm_fetcher");
   BundleMgr *mgr = static_cast<BundleMgr *>(data);
-  int wfd = mgr->pipe_bm_[1];
+  const int& wfd = mgr->pipe_bm_[1];
   int back_channel[2];
   MakePipe(back_channel);
 
@@ -164,13 +163,13 @@ UniquePtr<CacheManager::LabeledObject> BundleMgr::ReceiveLabeledObject(
     int fd) const {
   shash::Any id = BlockingReceive<shash::Any>(fd);
   CacheManager::Label label;
-  label.flags=BlockingReceive<int>(fd);
-  label.size=BlockingReceive<uint64_t>(fd);
-  label.zip_algorithm=BlockingReceive<zlib::Algorithms>(fd);
-  label.range_offset=BlockingReceive<off_t>(fd);
-  label.path=BlockingReceive(fd);
-  CacheManager::LabeledObject* obj = new CacheManager::LabeledObject(id,label);
-  assert(obj!=nullptr);
+  label.flags = BlockingReceive<int>(fd);
+  label.size = BlockingReceive<uint64_t>(fd);
+  label.zip_algorithm = BlockingReceive<zlib::Algorithms>(fd);
+  label.range_offset = BlockingReceive<off_t>(fd);
+  label.path = BlockingReceive(fd);
+  CacheManager::LabeledObject *obj = new CacheManager::LabeledObject(id, label);
+  assert(obj != nullptr);
   return UniquePtr<CacheManager::LabeledObject>(obj);
 }
 
@@ -181,7 +180,7 @@ bool BundleMgr::SendLabeledObject(
   BlockingSend(fd, obj->label.size);
   BlockingSend(fd, obj->label.zip_algorithm);
   BlockingSend(fd, obj->label.range_offset);
-  const std::string &path=obj->label.path;
+  const std::string &path = obj->label.path;
   BlockingSend(fd, path);
   return true;
 }

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -51,3 +51,4 @@ void BundleMgr::Fetch() {
   }
 }
 
+void* BundleMgr::DoFetch(void* data){}

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -102,10 +102,10 @@ void BundleMgr::JoinFetchers() {
 void BundleMgr::SpawnFetchers() {
   MakePipe(pipe_bm_);
 
-  size_t size = 1 + (bfm_->Size() / 30);  // Spawn at least one fetcher
+  const size_t size = 1 + (bfm_->Size() / 30);  // Spawn at least one fetcher
   for (size_t i = 0; i < size; ++i) {
     pthread_t thread;
-    int res = pthread_create(&thread, nullptr, EstablishConnection, this);
+    const int res = pthread_create(&thread, nullptr, EstablishConnection, this);
     if (res != 0) {
       continue;
     }
@@ -117,7 +117,7 @@ void BundleMgr::SpawnFetchers() {
     // n<=PIPE_BUF data on a non blocking pipe, it will either write all of them
     // or errno will be set to EAGAIN. PIPE_BUF is at least 512bytes on and
     // linux 4096bytes.
-    int flags = fcntl(fd, F_GETFL);
+    const int flags = fcntl(fd, F_GETFL);
     fcntl(fd, F_SETFL, flags | O_NONBLOCK);
     fetcher_pool_.push_back({thread, fd});
   }
@@ -132,7 +132,7 @@ void *BundleMgr::EstablishConnection(void *data) {
 
   WritePipe(wfd, &back_channel[1], sizeof(int));
 
-  int &rfd = back_channel[0];
+  const int &rfd = back_channel[0];
 
   Command cmd;
   while (read(rfd, &cmd, sizeof(Command)) == sizeof(Command)) {
@@ -189,8 +189,7 @@ bool BundleMgr::SendLabeledObject(
 bool BundleMgr::TrySendData(int fd,
                             UniquePtr<CacheManager::LabeledObject> &obj) const {
   Command cmd = Command::kFetch;
-  size_t n = write(fd, &cmd, sizeof(Command));
-  if (n != sizeof(Command)) {
+  if ((write(fd, &cmd, sizeof(Command))) != sizeof(Command)) {
     if (not(errno == EAGAIN || errno == EWOULDBLOCK)) {
       LogCvmfs(kLogBungleMgr,
                kLogDebug,

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -8,47 +8,131 @@
 
 #include <vector>
 
-BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : is_valid_(true) {
-    is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
-    is_valid_ &= cvmfs::GetDirentForInode(mp, mp->file_system(), ino, &dirent_);
-    fname_ = GetFileName(path_);
-    parent_path_ = GetParentPath(path_);
+#include "fetch.h"
+#include "util/inode.h"
+#include "util/posix.h"
 
-    // There is a naming convention regarding the name of the file with the
-    // contents of the bundle
-    bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
-                                   + fname_.ToString());
-
-    bfm_ = new BundleFileMgr(bundle_file_path_);
+BundleMgr::BundleMgr(MountPoint *mp, fuse_ino_t ino) : mount_point_(mp) {
+  is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
+  is_valid_ &= cvmfs::GetDirentForInode(mp, mp->file_system(), ino, &dirent_);
+  if (not is_valid_) {
+    return;
   }
+  fname_ = GetFileName(path_);
+  parent_path_ = GetParentPath(path_);
+  fetcher_ = dirent_.IsExternalFile() ? mp->external_fetcher() : mp->fetcher();
+
+  // There is a naming convention regarding the name of the file with the
+  // contents of the bundle
+  bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
+                                 + fname_.ToString());
+
+  bfm_ = new BundleFileMgr(bundle_file_path_);
+  pipe_bm_[0] = pipe_bm_[1] = -1;
+}
 
 void BundleMgr::Fetch() {
-  std::vector<pthread_t> fetcher_pool;
+  SpawnFetchers();
 
-  for (PathString next_f = bfm_->GetNext(); not next_f.IsEmpty();
-       next_f = bfm_->GetNext()) {
-    pthread_t fetcher_t;
-
-    // TODO(christge): DoFetch requires real arguments
-    pthread_create(&fetcher_t, nullptr, DoFetch, nullptr);
-    fetcher_pool.emplace_back(fetcher_t);
+  CacheManager::LabeledObject *obj;
+  while ((obj = bfm_->GetNext()) != nullptr) {
+    // TODO(christge): In this form the assignment of a fetcher is left to
+    // SendLabeledObject. This is incorrect. SendLabeledObject should only
+    // unpack the LabeledObject and send it over the pipe
+    SendLabeledObject(*obj);
   }
 
-  // Join fetcher threads
-  while (not fetcher_pool.empty()) {
-    for (auto it = fetcher_pool.begin(); it != fetcher_pool.end();) {
-      auto &thread = *it;
-      void *retval;
-      int is_joinable = pthread_tryjoin_np(thread, &retval);
-      if (is_joinable == 0) {
-        // fetch has finished
-        fetcher_pool.erase(it);
-      } else {
-        // still busy
-        ++it;
+  JoinFetchers();
+}
+
+void BundleMgr::JoinFetchers() {
+  bool detach_mode = false;
+  // Join fetcher threads.
+  // Give a fetcher thread 10 seconds to join.
+  for (auto it = fetcher_pool_.begin(); it != fetcher_pool_.end(); ++it) {
+    auto &tuple = *it;
+    auto thread = std::get<0>(tuple);
+    auto fd = std::get<1>(tuple);
+
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
+      LogCvmfs(kLogBungleMgr,
+               kLogDebug,
+               "Failed to read CLOCK_REALTIME. Detaching fetchers.");
+      detach_mode = true;
+    }
+
+    if (detach_mode) {
+      pthread_detach(thread);
+    } else {
+      ts.tv_sec += 10;
+      Command cmd = Command::kTerminate;
+      WritePipe(fd, &cmd, sizeof(Command));
+      int res = pthread_timedjoin_np(thread, nullptr, &ts);
+      if (res != 0) {
+        LogCvmfs(kLogBungleMgr,
+                 kLogDebug,
+                 "Fetcher is busy for too long. Detaching.");
+        pthread_detach(thread);
       }
     }
   }
+  ClosePipe(pipe_bm_);
 }
 
-void* BundleMgr::DoFetch(void* data){}
+void BundleMgr::SpawnFetchers() {
+  MakePipe(pipe_bm_);
+
+  size_t size = bfm_->Size() / 30;
+  for (size_t i = 0; i < size; ++i) {
+    pthread_t thread;
+    int res = pthread_create(&thread, nullptr, EstablishConnection, this);
+    if (res != 0) {
+      continue;
+    }
+    int fd;
+    ReadPipe(pipe_bm_[0], &fd, sizeof(int));
+    fetcher_pool_.push_back({thread, fd});
+  }
+}
+
+void *BundleMgr::EstablishConnection(void *data) {
+  pthread_setname_np(pthread_self(), "bm_fetcher");
+  BundleMgr *mgr = static_cast<BundleMgr *>(data);
+  int rfd = mgr->pipe_bm_[0];
+  int back_channel[2];
+  MakePipe(back_channel);
+
+  WritePipe(rfd, back_channel + 1, sizeof(int));
+
+  Command cmd;
+  while (read(rfd, &cmd, sizeof(Command)) == sizeof(Command)) {
+    bool terminate = false;
+    switch (cmd) {
+      case Command::kFetch: {
+        auto object = mgr->ReceiveLabeledObject(rfd);
+        mgr->fetcher_->Fetch(object);
+      } break;
+      case Command::kTerminate:
+      default:
+        terminate = true;
+        break;
+    }
+    if (terminate) {
+      break;
+    }
+  }
+
+  ClosePipe(back_channel);
+  pthread_exit(nullptr);
+}
+
+CacheManager::LabeledObject BundleMgr::ReceiveLabeledObject(int fd) const {
+  return CacheManager::LabeledObject(shash::Any{}, CacheManager::Label());
+}
+
+void BundleMgr::SendLabeledObject(
+    const CacheManager::LabeledObject &obj) const {
+  (void)obj;
+}
+

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -35,11 +35,28 @@ void BundleMgr::Fetch() {
   SpawnFetchers();
 
   CacheManager::LabeledObject *obj;
+  auto it = fetcher_pool_.begin();
+  if (it == fetcher_pool_.end()) {
+    LogCvmfs(kLogBungleMgr,
+             kLogDebug,
+             "The pool of fetchers is empty. Can't fetch dependencies. "
+             "Aborting Op.");
+    return;
+  }
   while ((obj = bfm_->GetNext()) != nullptr) {
-    // TODO(christge): In this form the assignment of a fetcher is left to
-    // SendLabeledObject. This is incorrect. SendLabeledObject should only
-    // unpack the LabeledObject and send it over the pipe
-    SendLabeledObject(*obj);
+    auto pair = *it;
+    auto wfd = std::get<1>(pair);
+    // Find the first available Fetcher to send the data
+    while (not TrySendData(wfd, *obj)) {
+      if (( ++it ) == fetcher_pool_.end()) {
+        it = fetcher_pool_.begin();
+      }
+      pair = *it;
+      wfd = std::get<1>(pair);
+    }
+    if (( ++it ) == fetcher_pool_.end()) {
+      it = fetcher_pool_.begin();
+    }
   }
 
   JoinFetchers();
@@ -92,6 +109,14 @@ void BundleMgr::SpawnFetchers() {
     }
     int fd;
     ReadPipe(pipe_bm_[0], &fd, sizeof(int));
+
+    // Make the write operation to the return pipe non blocking
+    // According to the man (7) page of write, when attempting to write
+    // n<=PIPE_BUF data on a non blocking pipe, it will either write all of them
+    // or errno will set to EAGAIN. PIPE_BUF is at least 512bytes on and linux
+    // 4096bytes.
+    int flags = fcntl(fd, F_GETFL);
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
     fetcher_pool_.push_back({thread, fd});
   }
 }
@@ -105,7 +130,7 @@ void *BundleMgr::EstablishConnection(void *data) {
 
   WritePipe(wfd, &back_channel[1], sizeof(int));
 
-  int& rfd=back_channel[0];
+  int &rfd = back_channel[0];
 
   Command cmd;
   while (read(rfd, &cmd, sizeof(Command)) == sizeof(Command)) {
@@ -135,7 +160,11 @@ CacheManager::LabeledObject BundleMgr::ReceiveLabeledObject(int fd) const {
 }
 
 void BundleMgr::SendLabeledObject(
-    const CacheManager::LabeledObject &obj) const {
+    int fd, const CacheManager::LabeledObject &obj) const {
   (void)obj;
 }
 
+bool BundleMgr::TrySendData(
+    int fd, const CacheManager::LabeledObject &obj) const {
+  (void)obj;
+}

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -7,6 +7,7 @@
 #include <gtest/gtest_prod.h>
 
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include "file_bundle.h"
@@ -19,6 +20,8 @@ class MockFetcher;
 
 class BundleMgr : SingleCopy {
   friend class T_BundleMgr;
+  FRIEND_TEST(T_BundleMgr, ExchangeLabeledObjects);
+  FRIEND_TEST(T_BundleMgr, ExchangeCT);
 
  public:
   BundleMgr(MountPoint *mp, fuse_ino_t ino);
@@ -34,6 +37,53 @@ class BundleMgr : SingleCopy {
   bool SendLabeledObject(int fd,
                          UniquePtr<CacheManager::LabeledObject> &obj) const;
   bool TrySendData(int fd, UniquePtr<CacheManager::LabeledObject> &obj) const;
+
+  // CT stands for contiguous type
+  template<typename CT>
+  void BlockingSend(int fd, const CT &obj, size_t size = sizeof(CT)) const {
+    using T = std::remove_cv_t<CT>;
+    static_assert(
+        std::is_trivially_copyable_v<T>,
+        "Can't directly send non trivially copyable types over a pipe");
+    static_assert(sizeof(T) == sizeof(CT), "CT illformed");
+    static_assert(
+        sizeof(T) <= PIPE_BUF,
+        "Type too big to be guaranteed atomic transmission over a pipe");
+
+    const T *ptr = reinterpret_cast<const T *>(&obj);
+    while ((::write(fd, ptr, size)) != static_cast<ssize_t>(size)) {
+      // Percist until succesfful write
+    }
+  }
+
+  void BlockingSend(int fd, const std::string &string) {
+    size_t size = string.size();
+    BlockingSend(fd, size);
+    while ((::write(fd, string.data(), size * sizeof(char)))
+           != static_cast<ssize_t>(size * sizeof(char))) {
+      // Percist until succesfful write
+    }
+  }
+
+  template<typename CT,
+           typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
+  CT BlockingReceive(int fd) {
+    using T = std::remove_cv_t<CT>;
+    static_assert(
+        sizeof(T) <= PIPE_BUF,
+        "Type too big to be guaranteed atomic transmission over a pipe");
+    CT item;
+    ::read(fd, static_cast<void *>(&item), sizeof(CT));
+    return item;
+  }
+
+  std::string BlockingReceive(int fd) {
+    size_t size = BlockingReceive<size_t>(fd);
+    assert(size * sizeof(char) < PIPE_BUF);
+    std::string result(size, '\t');
+    ::read(fd, static_cast<void *>(result.data()), size * sizeof(char));
+    return result;
+  }
 
   MountPoint *mount_point_;
 #ifndef __TEST_CVMFS_MOCKFUSE

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -10,21 +10,14 @@
 #include "file_bundle.h"   // BundleFileMgr
 #include "mountpoint.h"    //MountPoint*, FileSystem*
 #include "shortstring.h"   // GetParentPath, GetFileName
+#include "util/inode.h"    // GetPathForInode, GetDirentForInode
 #include "util/pointer.h"  // UniquePtr
-
-namespace cvmfs {
-/*
- * functions defined inside /cvmfs/cvmfs.cc
- */
-bool GetPathForInode(const fuse_ino_t ino, PathString *path);
-bool GetDirentForInode(const fuse_ino_t ino, catalog::DirectoryEntry *dirent);
-}  // namespace cvmfs
 
 class BundleMgr {
  public:
   BundleMgr(MountPoint *mp, fuse_ino_t ino) : is_valid_(true) {
-    is_valid_ = cvmfs::GetPathForInode(ino, &path_);
-    is_valid_ &= cvmfs::GetDirentForInode(ino, &dirent_);
+    is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
+    is_valid_ &= cvmfs::GetDirentForInode(mp, mp->file_system(), ino, &dirent_);
     fname_ = GetFileName(path_);
     parent_path_ = GetParentPath(path_);
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -4,6 +4,8 @@
 
 #ifndef CVMFS_BUNDLE_MGR_H_
 #define CVMFS_BUNDLE_MGR_H_
+#include <gtest/gtest_prod.h>
+
 #include <tuple>
 #include <vector>
 
@@ -11,10 +13,15 @@
 #include "mountpoint.h"
 #include "shortstring.h"
 #include "util/pointer.h"
+#include "util/single_copy.h"
 
-class BundleMgr {
+class BundleMgr : SingleCopy {
+  friend class T_BundleMgr;
+  FRIEND_TEST(T_BundleMgr, Simple);
+
  public:
   BundleMgr(MountPoint *mp, fuse_ino_t ino);
+  virtual ~BundleMgr() { delete bfm_; }
   void Fetch();
   explicit operator bool() const { return is_valid_; }
 
@@ -36,7 +43,7 @@ class BundleMgr {
 
   // The file that contains the dependences
   PathString bundle_file_path_;
-  UniquePtr<BundleFileMgr> bfm_;
+  BundleFileMgr *bfm_;
 
   std::vector<std::tuple<pthread_t, int> > fetcher_pool_;
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -4,8 +4,11 @@
 
 #ifndef CVMFS_BUNDLE_MGR_H_
 #define CVMFS_BUNDLE_MGR_H_
+#include <string>
+
 #include "duplex_fuse.h"  // fuse_ino_t
 #include "mountpoint.h"   //MountPoint*, FileSystem*
+#include "shortstring.h"  // GetParentPath, GetFileName
 
 namespace cvmfs {
 /*
@@ -20,6 +23,13 @@ class BundleMgr {
   BundleMgr(MountPoint *mp, FileSystem *fs, fuse_ino_t ino) : is_valid_(true) {
     is_valid_ = cvmfs::GetPathForInode(ino, &path_);
     is_valid_ &= cvmfs::GetDirentForInode(ino, &dirent_);
+    fname_ = GetFileName(path_);
+    parent_path_ = GetParentPath(path_);
+
+    // There is a naming convention regarding the name of the file with the
+    // contents of the bundle
+    bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
+                                   + fname_.ToString());
   }
 
   void Fetch();
@@ -28,6 +38,9 @@ class BundleMgr {
  private:
   catalog::DirectoryEntry dirent_;
   PathString path_;
+  NameString fname_;
+  PathString parent_path_;
+  PathString bundle_file_path_;
   bool is_valid_;
 };
 #endif  // CVMFS_BUNDLE_MGR_H_

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -22,7 +22,7 @@ bool GetDirentForInode(const fuse_ino_t ino, catalog::DirectoryEntry *dirent);
 
 class BundleMgr {
  public:
-  BundleMgr(MountPoint *mp, FileSystem *fs, fuse_ino_t ino) : is_valid_(true) {
+  BundleMgr(MountPoint *mp, fuse_ino_t ino) : is_valid_(true) {
     is_valid_ = cvmfs::GetPathForInode(ino, &path_);
     is_valid_ &= cvmfs::GetDirentForInode(ino, &dirent_);
     fname_ = GetFileName(path_);

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -29,7 +29,7 @@ class BundleMgr : SingleCopy {
   void SpawnFetchers();
   void JoinFetchers();
   CacheManager::LabeledObject ReceiveLabeledObject(int fd) const;
-  void SendLabeledObject(int fd,
+  bool SendLabeledObject(int fd,
                          UniquePtr<CacheManager::LabeledObject> &obj) const;
   bool TrySendData(int fd, UniquePtr<CacheManager::LabeledObject> &obj) const;
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -15,6 +15,8 @@
 #include "util/pointer.h"
 #include "util/single_copy.h"
 
+class MockFetcher;
+
 class BundleMgr : SingleCopy {
   friend class T_BundleMgr;
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -17,7 +17,6 @@
 
 class BundleMgr : SingleCopy {
   friend class T_BundleMgr;
-  FRIEND_TEST(T_BundleMgr, Simple);
 
  public:
   BundleMgr(MountPoint *mp, fuse_ino_t ino);

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -4,12 +4,12 @@
 
 #ifndef CVMFS_BUNDLE_MGR_H_
 #define CVMFS_BUNDLE_MGR_H_
-#include <gtest/gtest_prod.h>
 
 #include <tuple>
 #include <type_traits>
 #include <vector>
 
+#include "duplex_testing.h"
 #include "file_bundle.h"
 #include "mountpoint.h"
 #include "shortstring.h"

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -15,20 +15,7 @@
 
 class BundleMgr {
  public:
-  BundleMgr(MountPoint *mp, fuse_ino_t ino) : is_valid_(true) {
-    is_valid_ = cvmfs::GetPathForInode(mp, mp->file_system(), ino, &path_);
-    is_valid_ &= cvmfs::GetDirentForInode(mp, mp->file_system(), ino, &dirent_);
-    fname_ = GetFileName(path_);
-    parent_path_ = GetParentPath(path_);
-
-    // There is a naming convention regarding the name of the file with the
-    // contents of the bundle
-    bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
-                                   + fname_.ToString());
-
-    bfm_ = new BundleFileMgr(bundle_file_path_);
-  }
-
+  BundleMgr(MountPoint *mp, fuse_ino_t ino);
   void Fetch();
   explicit operator bool() const { return is_valid_; }
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -6,9 +6,11 @@
 #define CVMFS_BUNDLE_MGR_H_
 #include <string>
 
-#include "duplex_fuse.h"  // fuse_ino_t
-#include "mountpoint.h"   //MountPoint*, FileSystem*
-#include "shortstring.h"  // GetParentPath, GetFileName
+#include "duplex_fuse.h"   // fuse_ino_t
+#include "file_bundle.h"   // BundleFileMgr
+#include "mountpoint.h"    //MountPoint*, FileSystem*
+#include "shortstring.h"   // GetParentPath, GetFileName
+#include "util/pointer.h"  // UniquePtr
 
 namespace cvmfs {
 /*
@@ -30,6 +32,8 @@ class BundleMgr {
     // contents of the bundle
     bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
                                    + fname_.ToString());
+
+    bfm_ = new BundleFileMgr(bundle_file_path_);
   }
 
   void Fetch();
@@ -41,6 +45,7 @@ class BundleMgr {
   NameString fname_;
   PathString parent_path_;
   PathString bundle_file_path_;
+  UniquePtr<BundleFileMgr> bfm_;
   bool is_valid_;
 };
 #endif  // CVMFS_BUNDLE_MGR_H_

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -4,14 +4,13 @@
 
 #ifndef CVMFS_BUNDLE_MGR_H_
 #define CVMFS_BUNDLE_MGR_H_
-#include <string>
+#include <tuple>
+#include <vector>
 
-#include "duplex_fuse.h"   // fuse_ino_t
-#include "file_bundle.h"   // BundleFileMgr
-#include "mountpoint.h"    //MountPoint*, FileSystem*
-#include "shortstring.h"   // GetParentPath, GetFileName
-#include "util/inode.h"    // GetPathForInode, GetDirentForInode
-#include "util/pointer.h"  // UniquePtr
+#include "file_bundle.h"
+#include "mountpoint.h"
+#include "shortstring.h"
+#include "util/pointer.h"
 
 class BundleMgr {
  public:
@@ -20,15 +19,37 @@ class BundleMgr {
   explicit operator bool() const { return is_valid_; }
 
  private:
-  static void *DoFetch(void *data);
+  static void *EstablishConnection(void *data);
+  void SpawnFetchers();
+  void JoinFetchers();
+  CacheManager::LabeledObject ReceiveLabeledObject(int fd) const;
+  void SendLabeledObject(const CacheManager::LabeledObject &obj) const;
 
+  MountPoint *mount_point_;
+#ifndef __TEST_CVMFS_MOCKFUSE
+  cvmfs::Fetcher *fetcher_;
+#endif
   catalog::DirectoryEntry dirent_;
   PathString path_;
   NameString fname_;
   PathString parent_path_;
+
+  // The file that contains the dependences
   PathString bundle_file_path_;
   UniquePtr<BundleFileMgr> bfm_;
-  bool is_valid_;
+
+  std::vector<std::tuple<pthread_t, int> > fetcher_pool_;
+
+  enum class Command {
+    kTerminate,
+    kFetch
+  };
+
+  /**
+   * Used to send RPCs to the BundleMgr by the fetcher threads
+   */
+  int pipe_bm_[2];
+  bool is_valid_ = true;
 };
 #endif  // CVMFS_BUNDLE_MGR_H_
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -58,7 +58,7 @@ class BundleMgr : SingleCopy {
   }
 
   void BlockingSend(int fd, const std::string &string) const {
-    size_t size = string.size();
+    const size_t size = string.size();
     BlockingSend(fd, size);
     while ((::write(fd, string.data(), size * sizeof(char)))
            != static_cast<ssize_t>(size * sizeof(char))) {
@@ -79,7 +79,7 @@ class BundleMgr : SingleCopy {
   }
 
   std::string BlockingReceive(int fd) const {
-    size_t size = BlockingReceive<size_t>(fd);
+    const size_t size = BlockingReceive<size_t>(fd);
     assert(size * sizeof(char) < PIPE_BUF);
     std::string result(size, '\t');
     ::read(fd, static_cast<void *>(result.data()), size * sizeof(char));

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -33,13 +33,14 @@ class BundleMgr : SingleCopy {
   static void *EstablishConnection(void *data);
   void SpawnFetchers();
   void JoinFetchers();
-  CacheManager::LabeledObject ReceiveLabeledObject(int fd) const;
-  bool SendLabeledObject(int fd,
-                         UniquePtr<CacheManager::LabeledObject> &obj) const;
+  UniquePtr<CacheManager::LabeledObject> ReceiveLabeledObject(int fd) const;
+  bool SendLabeledObject(
+      int fd, const UniquePtr<CacheManager::LabeledObject> &obj) const;
   bool TrySendData(int fd, UniquePtr<CacheManager::LabeledObject> &obj) const;
 
   // CT stands for contiguous type
-  template<typename CT>
+  template<typename CT,
+           typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
   void BlockingSend(int fd, const CT &obj, size_t size = sizeof(CT)) const {
     using T = std::remove_cv_t<CT>;
     static_assert(
@@ -56,7 +57,7 @@ class BundleMgr : SingleCopy {
     }
   }
 
-  void BlockingSend(int fd, const std::string &string) {
+  void BlockingSend(int fd, const std::string &string) const {
     size_t size = string.size();
     BlockingSend(fd, size);
     while ((::write(fd, string.data(), size * sizeof(char)))
@@ -67,7 +68,7 @@ class BundleMgr : SingleCopy {
 
   template<typename CT,
            typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
-  CT BlockingReceive(int fd) {
+  CT BlockingReceive(int fd) const {
     using T = std::remove_cv_t<CT>;
     static_assert(
         sizeof(T) <= PIPE_BUF,
@@ -77,7 +78,7 @@ class BundleMgr : SingleCopy {
     return item;
   }
 
-  std::string BlockingReceive(int fd) {
+  std::string BlockingReceive(int fd) const {
     size_t size = BlockingReceive<size_t>(fd);
     assert(size * sizeof(char) < PIPE_BUF);
     std::string result(size, '\t');

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -29,8 +29,9 @@ class BundleMgr : SingleCopy {
   void SpawnFetchers();
   void JoinFetchers();
   CacheManager::LabeledObject ReceiveLabeledObject(int fd) const;
-  void SendLabeledObject(int fd, const CacheManager::LabeledObject &obj) const;
-  bool TrySendData(int fd, const CacheManager::LabeledObject &obj) const;
+  void SendLabeledObject(int fd,
+                         UniquePtr<CacheManager::LabeledObject> &obj) const;
+  bool TrySendData(int fd, UniquePtr<CacheManager::LabeledObject> &obj) const;
 
   MountPoint *mount_point_;
 #ifndef __TEST_CVMFS_MOCKFUSE

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -29,7 +29,8 @@ class BundleMgr : SingleCopy {
   void SpawnFetchers();
   void JoinFetchers();
   CacheManager::LabeledObject ReceiveLabeledObject(int fd) const;
-  void SendLabeledObject(const CacheManager::LabeledObject &obj) const;
+  void SendLabeledObject(int fd, const CacheManager::LabeledObject &obj) const;
+  bool TrySendData(int fd, const CacheManager::LabeledObject &obj) const;
 
   MountPoint *mount_point_;
 #ifndef __TEST_CVMFS_MOCKFUSE

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_BUNDLE_MGR_H_
+#define CVMFS_BUNDLE_MGR_H_
+#include "duplex_fuse.h"  // fuse_ino_t
+#include "mountpoint.h"   //MountPoint*, FileSystem*
+
+namespace cvmfs {
+/*
+ * functions defined inside /cvmfs/cvmfs.cc
+ */
+bool GetPathForInode(const fuse_ino_t ino, PathString *path);
+bool GetDirentForInode(const fuse_ino_t ino, catalog::DirectoryEntry *dirent);
+}  // namespace cvmfs
+
+class BundleMgr {
+ public:
+  BundleMgr(MountPoint *mp, FileSystem *fs, fuse_ino_t ino) : is_valid_(true) {
+    is_valid_ = cvmfs::GetPathForInode(ino, &path_);
+    is_valid_ &= cvmfs::GetDirentForInode(ino, &dirent_);
+  }
+
+  void Fetch();
+  explicit operator bool() const { return is_valid_; }
+
+ private:
+  catalog::DirectoryEntry dirent_;
+  PathString path_;
+  bool is_valid_;
+};
+#endif  // CVMFS_BUNDLE_MGR_H_
+

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -40,6 +40,8 @@ class BundleMgr {
   explicit operator bool() const { return is_valid_; }
 
  private:
+  static void *DoFetch(void *data);
+
   catalog::DirectoryEntry dirent_;
   PathString path_;
   NameString fname_;

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -104,6 +104,11 @@ class CacheManager : SingleCopy {
     bool IsExternal() const { return flags & kLabelExternal; }
     bool IsCertificate() const { return flags & kLabelCertificate; }
 
+    bool operator==(const Label &other) const {
+      return flags == other.flags and size == other.size
+             and zip_algorithm == other.zip_algorithm
+             and range_offset == other.range_offset and path == other.path;
+    }
     /**
      * The description for the quota manager
      */
@@ -139,6 +144,10 @@ class CacheManager : SingleCopy {
   struct LabeledObject {
     explicit LabeledObject(const shash::Any &id) : id(id), label() { }
     LabeledObject(const shash::Any &id, const Label &l) : id(id), label(l) { }
+
+    bool operator==(const LabeledObject &other) const {
+      return id == other.id && label == other.label;
+    }
 
     shash::Any id;
     Label label;
@@ -252,3 +261,4 @@ class CacheManager : SingleCopy {
 };  // class CacheManager
 
 #endif  // CVMFS_CACHE_H_
+

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -253,8 +253,8 @@ class AbstractCatalogManager : public SingleCopy {
   LoadReturn ChangeRoot(const shash::Any &root_hash);
   void DetachNested();
 
-  bool LookupPath(const PathString &path, const LookupOptions options,
-                  DirectoryEntry *entry);
+  virtual bool LookupPath(const PathString &path, const LookupOptions options,
+                          DirectoryEntry *entry);
   bool LookupPath(const std::string &path, const LookupOptions options,
                   DirectoryEntry *entry) {
     PathString p;
@@ -539,3 +539,4 @@ class InodeNfsGenerationAnnotation : public InodeAnnotation {
 #include "catalog_mgr_impl.h"
 
 #endif  // CVMFS_CATALOG_MGR_H_
+

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -64,6 +64,7 @@
 #include "auto_umount.h"
 #include "backoff.h"
 #include "bigvector.h"
+#include "bundle_mgr.h"
 #include "cache.h"
 #include "cache_posix.h"
 #include "cache_stream.h"
@@ -310,7 +311,7 @@ static bool FixupOpenInode(const PathString &path,
   return is_stale;
 }
 
-static bool GetDirentForInode(const fuse_ino_t ino,
+bool GetDirentForInode(const fuse_ino_t ino,
                               catalog::DirectoryEntry *dirent) {
   // Lookup inode in cache
   if (mount_point_->inode_cache()->Lookup(ino, dirent))
@@ -454,7 +455,7 @@ static uint64_t GetDirentForPath(const PathString &path,
 #endif
 
 
-static bool GetPathForInode(const fuse_ino_t ino, PathString *path) {
+bool GetPathForInode(const fuse_ino_t ino, PathString *path) {
   // Check the path cache first
   if (mount_point_->path_cache()->Lookup(ino, path))
     return true;
@@ -1174,6 +1175,17 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
     fuse_remounter_->fence()->Leave();
     fuse_reply_err(req, EEXIST);
     return;
+  }
+
+  if (dirent.IsBundleTrigger()) {
+    // fetch dependences if not there already
+    BundleMgr bundle_mgr(mount_point_, file_system_, ino);
+    if (bundle_mgr) {
+      bundle_mgr.Fetch();
+    } else {
+      LogCvmfs(kLogCvmfs, kLogDebug,
+               "Couldn't fetch bundle associated to file %s", path.c_str());
+    }
   }
 
   perf::Inc(file_system_->n_fs_open());  // Count actual open / fetch operations
@@ -3036,3 +3048,4 @@ static void __attribute__((destructor)) LibraryExit() {
   delete g_cvmfs_exports;
   g_cvmfs_exports = NULL;
 }
+

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -116,6 +116,7 @@
 #include "util/uuid.h"
 #include "wpad.h"
 #include "xattr.h"
+#include "util/inode.h"
 
 using namespace std;  // NOLINT
 
@@ -313,84 +314,7 @@ static bool FixupOpenInode(const PathString &path,
 
 bool GetDirentForInode(const fuse_ino_t ino,
                               catalog::DirectoryEntry *dirent) {
-  // Lookup inode in cache
-  if (mount_point_->inode_cache()->Lookup(ino, dirent))
-    return true;
-
-  // Look in the catalogs in 2 steps: lookup inode->path, lookup path
-  static const catalog::DirectoryEntry
-      dirent_negative = catalog::DirectoryEntry(catalog::kDirentNegative);
-  // Reset directory entry.  If the function returns false and dirent is no
-  // the kDirentNegative, it was an I/O error
-  *dirent = catalog::DirectoryEntry();
-
-  catalog::ClientCatalogManager *catalog_mgr = mount_point_->catalog_mgr();
-
-  if (file_system_->IsNfsSource()) {
-    // NFS mode
-    PathString path;
-    const bool retval = file_system_->nfs_maps()->GetPath(ino, &path);
-    if (!retval) {
-      *dirent = dirent_negative;
-      return false;
-    }
-    if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
-      // Fix inodes
-      dirent->set_inode(ino);
-      mount_point_->inode_cache()->Insert(ino, *dirent);
-      return true;
-    }
-    return false;  // Not found in catalog or catalog load error
-  }
-
-  // Non-NFS mode
-  PathString path;
-  if (ino == catalog_mgr->GetRootInode()) {
-    const bool retval = catalog_mgr->LookupPath(
-        PathString(), catalog::kLookupDefault, dirent);
-
-    if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
-                     "GetDirentForInode: Race condition? Not found dirent %s",
-                     dirent->name().c_str())) {
-      return false;
-    }
-
-    dirent->set_inode(ino);
-    mount_point_->inode_cache()->Insert(ino, *dirent);
-    return true;
-  }
-
-  glue::InodeEx inode_ex(ino, glue::InodeEx::kUnknownType);
-  const bool retval = mount_point_->inode_tracker()->FindPath(&inode_ex, &path);
-  if (!retval) {
-    // This may be a retired inode whose stat information is only available
-    // in the page cache tracker because there is still an open file
-    LogCvmfs(kLogCvmfs, kLogDebug,
-             "GetDirentForInode inode lookup failure %" PRId64, ino);
-    *dirent = dirent_negative;
-    // Indicate that the inode was not found in the tracker rather than not
-    // found in the catalog
-    dirent->set_inode(ino);
-    return false;
-  }
-  if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
-    if (!inode_ex.IsCompatibleFileType(dirent->mode())) {
-      LogCvmfs(kLogCvmfs, kLogDebug,
-               "Warning: inode %" PRId64 " (%s) changed file type", ino,
-               path.c_str());
-      // TODO(jblomer): we detect this issue but let it continue unhandled.
-      // Fix me.
-    }
-
-    // Fix inodes
-    dirent->set_inode(ino);
-    mount_point_->inode_cache()->Insert(ino, *dirent);
-    return true;
-  }
-
-  // Can happen after reload of catalogs or on catalog load failure
-  LogCvmfs(kLogCvmfs, kLogDebug, "GetDirentForInode path lookup failure");
-  return false;
+  return GetDirentForInode(mount_point_,file_system_,ino, dirent);
 }
 
 
@@ -456,37 +380,7 @@ static uint64_t GetDirentForPath(const PathString &path,
 
 
 bool GetPathForInode(const fuse_ino_t ino, PathString *path) {
-  // Check the path cache first
-  if (mount_point_->path_cache()->Lookup(ino, path))
-    return true;
-
-  if (file_system_->IsNfsSource()) {
-    // NFS mode, just a lookup
-    LogCvmfs(kLogCvmfs, kLogDebug, "MISS %lu - lookup in NFS maps", ino);
-    if (file_system_->nfs_maps()->GetPath(ino, path)) {
-      mount_point_->path_cache()->Insert(ino, *path);
-      return true;
-    }
-    return false;
-  }
-
-  if (ino == mount_point_->catalog_mgr()->GetRootInode())
-    return true;
-
-  LogCvmfs(kLogCvmfs, kLogDebug, "MISS %lu - looking in inode tracker", ino);
-  glue::InodeEx inode_ex(ino, glue::InodeEx::kUnknownType);
-  const bool retval = mount_point_->inode_tracker()->FindPath(&inode_ex, path);
-
-  if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
-                   "GetPathForInode: Race condition? "
-                   "Inode not found in inode tracker at path %s",
-                   path->c_str())) {
-    return false;
-  }
-
-
-  mount_point_->path_cache()->Insert(ino, *path);
-  return true;
+  return GetPathForInode(mount_point_,file_system_,ino,path);
 }
 
 static void DoTraceInode(const int event,

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1179,7 +1179,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
 
   if (dirent.IsBundleTrigger()) {
     // fetch dependences if not there already
-    BundleMgr bundle_mgr(mount_point_, file_system_, ino);
+    BundleMgr bundle_mgr(mount_point_,  ino);
     if (bundle_mgr) {
       bundle_mgr.Fetch();
     } else {

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -397,3 +397,4 @@ typedef BigVector<StatEntry> StatEntryList;
 }  // namespace catalog
 
 #endif  // CVMFS_DIRECTORY_ENTRY_H_
+

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -108,10 +108,10 @@ class Fetcher : SingleCopy {
           download::DownloadManager *download_mgr,
           BackoffThrottle *backoff_throttle,
           perf::StatisticsTemplate statistics);
-  ~Fetcher();
+  virtual ~Fetcher();
 
-  int Fetch(const CacheManager::LabeledObject &object,
-            const std::string &alt_url = "");
+  virtual int Fetch(const CacheManager::LabeledObject &object,
+                    const std::string &alt_url = "");
 
   void ReplaceCacheManager(CacheManager *new_cache_mgr) {
     cache_mgr_ = new_cache_mgr;
@@ -192,3 +192,4 @@ class Fetcher : SingleCopy {
 }  // namespace cvmfs
 
 #endif  // CVMFS_FETCH_H_
+

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * This class implements the format for .cvmfsbundle files 
+ */
+
+#ifndef CVMFS_FILE_BUNDLE_H_
+#define CVMFS_FILE_BUNDLE_H_
+
+
+/*
+
+The .cvmfsbundle file servers both as a file list and as a trigger for loading a bundle. The convention is to call it .cvmfsbundle.<filename>, where <filename> should trigger the bundle.
+
+? The content could be structured in json.
+
+The file format should be versioned, with the header:
+
+#%CVMFS_BUNDLE version=1 encoding=UTF-8
+
+? end marker
+
+*/
+
+
+#endif

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -7,8 +7,9 @@
 #ifndef CVMFS_FILE_BUNDLE_H_
 #define CVMFS_FILE_BUNDLE_H_
 
-#include "shortstring.h"  // PathString
-
+#include "cache.h"         // LabeledObject
+#include "shortstring.h"   // PathString
+#include "util/pointer.h"  // UniquePtr
 
 /*
 
@@ -31,7 +32,21 @@ class BundleFileMgr {
   // TODO(christge): this is to be reverted. It's the basic interface needed to
   // interact with the file bundle. Now there are some mocks for prototyping
   BundleFileMgr(const PathString &bf) { }
-  PathString GetNext() { return PathString{}; };
+  CacheManager::LabeledObject *GetNext() {
+    // TODO(christge): return actual labled objects
+    CacheManager::Label label;
+    label.path = std::string{};
+    label.size = sizeof(shash::Any);
+    label.zip_algorithm = zlib::kZlibDefault;
+    return new CacheManager::LabeledObject(shash::Any{}, label);
+  };
+
+  size_t Size() const { return size_; }
+
+ private:
+  // TODO(christge): properly setup in construction to return the number of
+  // files in the bundle
+  size_t size_ = 42;
 };
 
 #endif

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -46,19 +46,52 @@ class BundleFileMgr : SingleCopy {
   void Manage(JsonDocument *fc) {
     ReleaseDocument();
     file_content_ = fc;
-    UpdateSize();
+    ResetSize();
+    ResetCurrentLabeledObject();
   }
 
   virtual ~BundleFileMgr() { ReleaseDocument(); }
 
-  virtual UniquePtr<CacheManager::LabeledObject> GetNext() const {
-    // TODO(christge): return actual labled objects
-    CacheManager::Label label;
-    label.path = std::string{};
-    label.size = sizeof(shash::Any);
-    label.zip_algorithm = zlib::kZlibDefault;
+  virtual UniquePtr<CacheManager::LabeledObject> GetNext() {
+    if (not current_labeled_object_)
+      return UniquePtr<CacheManager::LabeledObject>(nullptr);
+
+    auto *id_ptr = JsonDocument::SearchInObject(current_labeled_object_, "id",
+                                                JSON_OBJECT);
+    assert(id_ptr != nullptr);
+    int algorithm;
+    GetFromJSON<int>(id_ptr, "algorithm", &algorithm);
+    std::string suffix;
+    GetFromJSON<std::string>(id_ptr, "suffix", &suffix);
+    std::string digest;
+    GetFromJSON<std::string>(id_ptr, "digest", &digest);
+    shash::Any id = shash::MkFromHexPtr(shash::HexPtr(digest), suffix[0]);
+    id.algorithm = static_cast<shash::Algorithms>(algorithm);
+    auto label_ptr = JsonDocument::SearchInObject(current_labeled_object_,
+                                                  "label", JSON_OBJECT);
+    assert(label_ptr != nullptr);
+
+    int flags;
+    GetFromJSON<int>(label_ptr, "flags", &flags);
+    int size;  ///< unzipped size, if known
+    GetFromJSON<int>(label_ptr, "size", &size);
+    int zip_algorithm;
+    GetFromJSON<int>(label_ptr, "zip_algorithm", &zip_algorithm);
+    int range_offset;
+    GetFromJSON<int>(label_ptr, "range_offset", &range_offset);
+    std::string path;
+    GetFromJSON<std::string>(label_ptr, "path", &path);
+
+    CacheManager::Label label{};
+    label.flags = flags;
+    label.size = size;
+    label.zip_algorithm = static_cast<zlib::Algorithms>(zip_algorithm);
+    label.range_offset = range_offset;
+    label.path = path;
+
+    current_labeled_object_ = current_labeled_object_->next_sibling;
     return UniquePtr<CacheManager::LabeledObject>(
-        new CacheManager::LabeledObject(shash::Any{}, label));
+        new CacheManager::LabeledObject(id, label));
   };
 
   virtual size_t Size() const { return size_; }
@@ -68,7 +101,16 @@ class BundleFileMgr : SingleCopy {
   }
 
  private:
-  void UpdateSize() {
+  void ResetCurrentLabeledObject() {
+    auto *ptr = JsonDocument::SearchInObject(file_content_->root(),
+                                             "labeled_objects", JSON_ARRAY);
+    if (not ptr) {
+      current_labeled_object_ = nullptr;
+    } else {
+      current_labeled_object_ = ptr->first_child;
+    }
+  }
+  void ResetSize() {
     if (not file_content_) {
       size_ = 0;
     } else {
@@ -88,6 +130,7 @@ class BundleFileMgr : SingleCopy {
   }
   size_t size_ = 0;
   JsonDocument *file_content_ = nullptr;
+  JSON *current_labeled_object_ = nullptr;
 };
 
 #endif

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -7,9 +7,11 @@
 #ifndef CVMFS_FILE_BUNDLE_H_
 #define CVMFS_FILE_BUNDLE_H_
 
-#include "cache.h"         // LabeledObject
-#include "shortstring.h"   // PathString
-#include "util/pointer.h"  // UniquePtr
+#include "cache.h"
+#include "json_document.h"
+#include "shortstring.h"
+#include "util/pointer.h"
+#include "util/single_copy.h"
 
 /*
 
@@ -27,12 +29,24 @@ The file format should be versioned, with the header:
 
 */
 
-class BundleFileMgr {
+class BundleFileMgr : SingleCopy {
  public:
-  // TODO(christge): this is to be reverted. It's the basic interface needed to
-  // interact with the file bundle. Now there are some mocks for prototyping
-  BundleFileMgr(const PathString &bf) { }
-  virtual ~BundleFileMgr() = default;
+  BundleFileMgr() = default;
+  BundleFileMgr(const PathString &bf) : file_content_(nullptr) { }
+  BundleFileMgr(UniquePtr<JsonDocument> &fc) : file_content_(fc.Release()) { }
+  BundleFileMgr(JsonDocument *fc) : file_content_(fc) { fc = nullptr; }
+
+  void Manage(UniquePtr<JsonDocument> &fc) {
+    ReleaseDocument();
+    file_content_ = fc.Release();
+  }
+  void Manage(JsonDocument *fc) {
+    ReleaseDocument();
+    file_content_ = fc;
+  }
+
+  virtual ~BundleFileMgr() { ReleaseDocument(); }
+
   virtual UniquePtr<CacheManager::LabeledObject> GetNext() const {
     // TODO(christge): return actual labled objects
     CacheManager::Label label;
@@ -45,8 +59,19 @@ class BundleFileMgr {
 
   virtual size_t Size() const { return size_; }
 
+  operator bool() const {
+    return (file_content_ != nullptr) ? file_content_->IsValid() : false;
+  }
+
  private:
+  void ReleaseDocument() {
+    if (file_content_ != nullptr) {
+      delete file_content_;
+      file_content_ = nullptr;
+    }
+  }
   size_t size_ = 42;
+  JsonDocument *file_content_ = nullptr;
 };
 
 #endif

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -33,13 +33,14 @@ class BundleFileMgr {
   // interact with the file bundle. Now there are some mocks for prototyping
   BundleFileMgr(const PathString &bf) { }
   virtual ~BundleFileMgr() = default;
-  virtual CacheManager::LabeledObject *GetNext() const {
+  virtual UniquePtr<CacheManager::LabeledObject> GetNext() const {
     // TODO(christge): return actual labled objects
     CacheManager::Label label;
     label.path = std::string{};
     label.size = sizeof(shash::Any);
     label.zip_algorithm = zlib::kZlibDefault;
-    return new CacheManager::LabeledObject(shash::Any{}, label);
+    return UniquePtr<CacheManager::LabeledObject>(
+        new CacheManager::LabeledObject(shash::Any{}, label));
   };
 
   virtual size_t Size() const { return size_; }

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -1,16 +1,20 @@
 /**
  * This file is part of the CernVM File System.
  *
- * This class implements the format for .cvmfsbundle files 
+ * This class implements the format for .cvmfsbundle files
  */
 
 #ifndef CVMFS_FILE_BUNDLE_H_
 #define CVMFS_FILE_BUNDLE_H_
 
+#include "shortstring.h"  // PathString
+
 
 /*
 
-The .cvmfsbundle file servers both as a file list and as a trigger for loading a bundle. The convention is to call it .cvmfsbundle.<filename>, where <filename> should trigger the bundle.
+The .cvmfsbundle file servers both as a file list and as a trigger for loading a
+bundle. The convention is to call it .cvmfsbundle.<filename>, where <filename>
+should trigger the bundle.
 
 ? The content could be structured in json.
 
@@ -22,5 +26,13 @@ The file format should be versioned, with the header:
 
 */
 
+class BundleFileMgr {
+ public:
+  // TODO(christge): this is to be reverted. It's the basic interface needed to
+  // interact with the file bundle. Now there are some mocks for prototyping
+  BundleFileMgr(const PathString &bf) { }
+  PathString GetNext() { return PathString{}; };
+};
 
 #endif
+

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -33,7 +33,7 @@ class BundleFileMgr {
   // interact with the file bundle. Now there are some mocks for prototyping
   BundleFileMgr(const PathString &bf) { }
   virtual ~BundleFileMgr() = default;
-  CacheManager::LabeledObject *GetNext() const {
+  virtual CacheManager::LabeledObject *GetNext() const {
     // TODO(christge): return actual labled objects
     CacheManager::Label label;
     label.path = std::string{};
@@ -42,11 +42,9 @@ class BundleFileMgr {
     return new CacheManager::LabeledObject(shash::Any{}, label);
   };
 
-  size_t Size() const { return size_; }
+  virtual size_t Size() const { return size_; }
 
  private:
-  // TODO(christge): properly setup in construction to return the number of
-  // files in the bundle
   size_t size_ = 42;
 };
 

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -7,6 +7,8 @@
 #ifndef CVMFS_FILE_BUNDLE_H_
 #define CVMFS_FILE_BUNDLE_H_
 
+#include <json.h>
+
 #include "cache.h"
 #include "json_document.h"
 #include "shortstring.h"
@@ -27,6 +29,10 @@ The file format should be versioned, with the header:
 
 ? end marker
 
+The json file should contain an array of labeled objects as follows:
+{
+"labeled_objects":[{"id":{"algorithm":%d,"suffix":"%c","digest":"%s"},"label":{"flags":%d,"size":%PRIu64,"zip_algorithm":%d,"range_offset":%d,"path":"%s"}}]
+}
 */
 
 class BundleFileMgr : SingleCopy {
@@ -36,13 +42,11 @@ class BundleFileMgr : SingleCopy {
   BundleFileMgr(UniquePtr<JsonDocument> &fc) : file_content_(fc.Release()) { }
   BundleFileMgr(JsonDocument *fc) : file_content_(fc) { fc = nullptr; }
 
-  void Manage(UniquePtr<JsonDocument> &fc) {
-    ReleaseDocument();
-    file_content_ = fc.Release();
-  }
+  void Manage(UniquePtr<JsonDocument> &fc) { Manage(fc.Release()); }
   void Manage(JsonDocument *fc) {
     ReleaseDocument();
     file_content_ = fc;
+    UpdateSize();
   }
 
   virtual ~BundleFileMgr() { ReleaseDocument(); }
@@ -64,13 +68,25 @@ class BundleFileMgr : SingleCopy {
   }
 
  private:
+  void UpdateSize() {
+    if (not file_content_) {
+      size_ = 0;
+    } else {
+      auto *ptr = JsonDocument::SearchInObject(file_content_->root(),
+                                               "labeled_objects", JSON_ARRAY);
+      size_ = 0;
+      for (ptr = ptr->first_child; ptr != nullptr; ptr = ptr->next_sibling) {
+        ++size_;
+      }
+    }
+  }
   void ReleaseDocument() {
     if (file_content_ != nullptr) {
       delete file_content_;
       file_content_ = nullptr;
     }
   }
-  size_t size_ = 42;
+  size_t size_ = 0;
   JsonDocument *file_content_ = nullptr;
 };
 

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -32,7 +32,8 @@ class BundleFileMgr {
   // TODO(christge): this is to be reverted. It's the basic interface needed to
   // interact with the file bundle. Now there are some mocks for prototyping
   BundleFileMgr(const PathString &bf) { }
-  CacheManager::LabeledObject *GetNext() {
+  virtual ~BundleFileMgr() = default;
+  CacheManager::LabeledObject *GetNext() const {
     // TODO(christge): return actual labled objects
     CacheManager::Label label;
     label.path = std::string{};

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -8,7 +8,6 @@
  * functions.
  */
 
-#include "duplex_testing.h"
 #include <pthread.h>
 #include <sched.h>
 #include <stdint.h>
@@ -23,6 +22,7 @@
 #include "bigvector.h"
 #include "crypto/hash.h"
 #include "directory_entry.h"
+#include "duplex_testing.h"
 #include "shortstring.h"
 #include "smallhash.h"
 #include "util/atomic.h"
@@ -651,7 +651,7 @@ class InodeTracker {
   InodeTracker();
   explicit InodeTracker(const InodeTracker &other);
   InodeTracker &operator=(const InodeTracker &other);
-  ~InodeTracker();
+  virtual ~InodeTracker();
 
   void VfsGetBy(const InodeEx inode_ex, const uint32_t by,
                 const PathString &path) {
@@ -673,7 +673,7 @@ class InodeTracker {
 
   VfsPutRaii GetVfsPutRaii() { return VfsPutRaii(this); }
 
-  bool FindPath(InodeEx *inode_ex, PathString *path) {
+  virtual bool FindPath(InodeEx *inode_ex, PathString *path) {
     Lock();
     shash::Md5 md5path;
     bool found = inode_ex_map_.LookupMd5Path(inode_ex, &md5path);
@@ -1087,3 +1087,4 @@ class PageCacheTracker {
 }  // namespace glue
 
 #endif  // CVMFS_GLUE_BUFFER_H_
+

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -491,6 +491,8 @@ class StatfsCache : SingleCopy {
  * destruction explicit and also to keep the include list for this header small.
  */
 class MountPoint : SingleCopy, public BootFactory {
+  friend class T_BundleMgr;
+
  public:
   /**
    * If catalog reload fails, try again in 3 minutes
@@ -689,3 +691,4 @@ class MountPoint : SingleCopy, public BootFactory {
 };  // class MointPoint
 
 #endif  // CVMFS_MOUNTPOINT_H_
+

--- a/cvmfs/util/inode.cc
+++ b/cvmfs/util/inode.cc
@@ -1,0 +1,125 @@
+#include "inode.h"
+
+#include "catalog_mgr.h"         // kLookupDefault
+#include "catalog_mgr_client.h"  // GetRootInode(), LookupPath
+#include "glue_buffer.h"         // glue::InodeEx
+#include "lru_md.h"              // Lookup(ino,dirent)
+#include "nfs_maps.h"            // nfs_maps()->GetPath()
+
+bool cvmfs::GetDirentForInode(MountPoint *mountpoint, FileSystem *filesystem,
+                       const fuse_ino_t ino, catalog::DirectoryEntry *dirent) {
+  // Lookup inode in cache
+  if (mountpoint->inode_cache()->Lookup(ino, dirent))
+    return true;
+
+  // Look in the catalogs in 2 steps: lookup inode->path, lookup path
+  static const catalog::DirectoryEntry
+      dirent_negative = catalog::DirectoryEntry(catalog::kDirentNegative);
+  // Reset directory entry.  If the function returns false and dirent is no
+  // the kDirentNegative, it was an I/O error
+  *dirent = catalog::DirectoryEntry();
+
+  catalog::ClientCatalogManager *catalog_mgr = mountpoint->catalog_mgr();
+
+  if (filesystem->IsNfsSource()) {
+    // NFS mode
+    PathString path;
+    const bool retval = filesystem->nfs_maps()->GetPath(ino, &path);
+    if (!retval) {
+      *dirent = dirent_negative;
+      return false;
+    }
+    if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
+      // Fix inodes
+      dirent->set_inode(ino);
+      mountpoint->inode_cache()->Insert(ino, *dirent);
+      return true;
+    }
+    return false;  // Not found in catalog or catalog load error
+  }
+
+  // Non-NFS mode
+  PathString path;
+  if (ino == catalog_mgr->GetRootInode()) {
+    const bool retval = catalog_mgr->LookupPath(
+        PathString(), catalog::kLookupDefault, dirent);
+
+    if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
+                     "GetDirentForInode: Race condition? Not found dirent %s",
+                     dirent->name().c_str())) {
+      return false;
+    }
+
+    dirent->set_inode(ino);
+    mountpoint->inode_cache()->Insert(ino, *dirent);
+    return true;
+  }
+
+  glue::InodeEx inode_ex(ino, glue::InodeEx::kUnknownType);
+  const bool retval = mountpoint->inode_tracker()->FindPath(&inode_ex, &path);
+  if (!retval) {
+    // This may be a retired inode whose stat information is only available
+    // in the page cache tracker because there is still an open file
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "GetDirentForInode inode lookup failure %" PRId64, ino);
+    *dirent = dirent_negative;
+    // Indicate that the inode was not found in the tracker rather than not
+    // found in the catalog
+    dirent->set_inode(ino);
+    return false;
+  }
+  if (catalog_mgr->LookupPath(path, catalog::kLookupDefault, dirent)) {
+    if (!inode_ex.IsCompatibleFileType(dirent->mode())) {
+      LogCvmfs(kLogCvmfs, kLogDebug,
+               "Warning: inode %" PRId64 " (%s) changed file type", ino,
+               path.c_str());
+      // TODO(jblomer): we detect this issue but let it continue unhandled.
+      // Fix me.
+    }
+
+    // Fix inodes
+    dirent->set_inode(ino);
+    mountpoint->inode_cache()->Insert(ino, *dirent);
+    return true;
+  }
+
+  // Can happen after reload of catalogs or on catalog load failure
+  LogCvmfs(kLogCvmfs, kLogDebug, "GetDirentForInode path lookup failure");
+  return false;
+}
+
+bool cvmfs::GetPathForInode(MountPoint *mountpoint, FileSystem *filesystem,
+                     const fuse_ino_t ino, PathString *path) {
+  // Check the path cache first
+  if (mountpoint->path_cache()->Lookup(ino, path))
+    return true;
+
+  if (filesystem->IsNfsSource()) {
+    // NFS mode, just a lookup
+    LogCvmfs(kLogCvmfs, kLogDebug, "MISS %lu - lookup in NFS maps", ino);
+    if (filesystem->nfs_maps()->GetPath(ino, path)) {
+      mountpoint->path_cache()->Insert(ino, *path);
+      return true;
+    }
+    return false;
+  }
+
+  if (ino == mountpoint->catalog_mgr()->GetRootInode())
+    return true;
+
+  LogCvmfs(kLogCvmfs, kLogDebug, "MISS %lu - looking in inode tracker", ino);
+  glue::InodeEx inode_ex(ino, glue::InodeEx::kUnknownType);
+  const bool retval = mountpoint->inode_tracker()->FindPath(&inode_ex, path);
+
+  if (!AssertOrLog(retval, kLogCvmfs, kLogSyslogWarn | kLogDebug,
+                   "GetPathForInode: Race condition? "
+                   "Inode not found in inode tracker at path %s",
+                   path->c_str())) {
+    return false;
+  }
+
+
+  mountpoint->path_cache()->Insert(ino, *path);
+  return true;
+}
+

--- a/cvmfs/util/inode.h
+++ b/cvmfs/util/inode.h
@@ -1,0 +1,16 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+#ifndef CVMFS_UTIL_INODE_H_
+#define CVMFS_UTIL_INODE_H_
+#include "directory_entry.h"  // catalog::DirectoryEntry
+#include "duplex_fuse.h"
+#include "mountpoint.h"
+namespace cvmfs {
+bool GetDirentForInode(MountPoint *mountpoint, FileSystem *filesystem,
+                       const fuse_ino_t ino, catalog::DirectoryEntry *dirent);
+bool GetPathForInode(MountPoint *mountpoint, FileSystem *filesystem,
+                     const fuse_ino_t ino, PathString *path);
+}  // namespace cvmfs
+#endif  // CVMFS_UTIL_INODE_H_
+

--- a/cvmfs/util/logging_internal.h
+++ b/cvmfs/util/logging_internal.h
@@ -108,7 +108,8 @@ enum LogSource {
   kLogReflog,
   kLogKvStore,
   kLogTelemetry,
-  kLogCurl
+  kLogCurl,
+  kLogBungleMgr
 };
 
 const int kLogWarning = kLogStdout | kLogShowSource | kLogNormal;
@@ -161,3 +162,4 @@ CVMFS_EXPORT void PrintError(const std::string &message);
 #endif
 
 #endif  // CVMFS_UTIL_LOGGING_INTERNAL_H_
+

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -748,6 +748,7 @@ set(CVMFS_UNITTEST_MOCKFUSE_SOURCES
   ${CVMFS_SOURCE_DIR}/wpad.cc
   ${CVMFS_SOURCE_DIR}/xattr.cc
   ${CVMFS_SOURCE_DIR}/bundle_mgr.cc
+  ${CVMFS_SOURCE_DIR}/util/inode.cc
 
   cache.pb.cc cache.pb.h
 )

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -747,6 +747,7 @@ set(CVMFS_UNITTEST_MOCKFUSE_SOURCES
   ${CVMFS_SOURCE_DIR}/whitelist.cc
   ${CVMFS_SOURCE_DIR}/wpad.cc
   ${CVMFS_SOURCE_DIR}/xattr.cc
+  ${CVMFS_SOURCE_DIR}/bundle_mgr.cc
 
   cache.pb.cc cache.pb.h
 )

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -505,6 +505,7 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/libcvmfs_options.cc
   ${CVMFS_SOURCE_DIR}/magic_xattr.cc
   ${CVMFS_SOURCE_DIR}/bundle_mgr.cc
+  ${CVMFS_SOURCE_DIR}/fetch.cc
   ${CVMFS_SOURCE_DIR}/util/inode.cc
   ${CVMFS_SOURCE_DIR}/malloc_arena.cc
   ${CVMFS_SOURCE_DIR}/malloc_heap.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -448,6 +448,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_wpad.cc
   t_xattr.cc
   t_bundle_mgr.cc
+  t_bundle_file_mgr.cc
 
   ${CVMFS_SOURCE_DIR}/acl.cc
   ${CVMFS_SOURCE_DIR}/authz/authz.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -447,6 +447,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_whitelist.cc
   t_wpad.cc
   t_xattr.cc
+  t_bundle_mgr.cc
 
   ${CVMFS_SOURCE_DIR}/acl.cc
   ${CVMFS_SOURCE_DIR}/authz/authz.cc
@@ -503,6 +504,8 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/libcvmfs_legacy.cc
   ${CVMFS_SOURCE_DIR}/libcvmfs_options.cc
   ${CVMFS_SOURCE_DIR}/magic_xattr.cc
+  ${CVMFS_SOURCE_DIR}/bundle_mgr.cc
+  ${CVMFS_SOURCE_DIR}/util/inode.cc
   ${CVMFS_SOURCE_DIR}/malloc_arena.cc
   ${CVMFS_SOURCE_DIR}/malloc_heap.cc
   ${CVMFS_SOURCE_DIR}/manifest.cc

--- a/test/unittests/t_bundle_file_mgr.cc
+++ b/test/unittests/t_bundle_file_mgr.cc
@@ -1,0 +1,30 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include "file_bundle.h"
+#include "json_document.h"
+#include "shortstring.h"
+#include "util/pointer.h"
+
+class T_BundleFileMgr : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    UniquePtr<JsonDocument> json_doc(JsonDocument::Create("{}"));
+    EXPECT_TRUE(json_doc->IsValid());
+    bfm_.Manage(json_doc);
+    EXPECT_TRUE(bfm_);
+  }
+  virtual void TearDown() { }
+  virtual ~T_BundleFileMgr() { }
+
+  BundleFileMgr bfm_;
+};
+
+TEST_F(T_BundleFileMgr, Construction) {
+  PathString path("test_string");
+  BundleFileMgr mgr(path);
+}
+

--- a/test/unittests/t_bundle_file_mgr.cc
+++ b/test/unittests/t_bundle_file_mgr.cc
@@ -11,15 +11,15 @@
 #include "crypto/hash.h"
 #include "file_bundle.h"
 #include "json_document.h"
-#include "shortstring.h"
 #include "util/pointer.h"
 
 class T_BundleFileMgr : public ::testing::Test {
  protected:
   virtual void SetUp() {
     InitObjects(42);
-    UniquePtr<JsonDocument> json_doc(JsonDocument::Create("{}"));
+    UniquePtr<JsonDocument> json_doc(JsonDocument::Create(CreateJsonTxt()));
     EXPECT_TRUE(json_doc->IsValid());
+    EXPECT_TRUE(json_doc.weak_ref()!=nullptr);
     bfm_.Manage(json_doc);
     EXPECT_TRUE(bfm_);
   }
@@ -92,6 +92,14 @@ class T_BundleFileMgr : public ::testing::Test {
       objects_.push_back(CacheManager::LabeledObject(hash, label));
     }
   }
+  std::string CreateJsonTxt(){
+    std::string result{"{\"labeled_objects\":["};
+    for(size_t i=0; i<objects_.size();++i){
+      result+=ToJsonStr(objects_[i]);
+    }
+    result+="]}";
+    return result;
+  }
 };
 
 TEST_F(T_BundleFileMgr, Conversions) {
@@ -103,8 +111,7 @@ TEST_F(T_BundleFileMgr, Conversions) {
   }
 }
 
-TEST_F(T_BundleFileMgr, Construction) {
-  PathString path("test_string");
-  BundleFileMgr mgr(path);
+TEST_F(T_BundleFileMgr, Size) {
+  EXPECT_EQ(objects_.size(),bfm_.Size());
 }
 

--- a/test/unittests/t_bundle_file_mgr.cc
+++ b/test/unittests/t_bundle_file_mgr.cc
@@ -3,7 +3,12 @@
  */
 
 #include <gtest/gtest.h>
+#include <inttypes.h>
 
+#include <vector>
+
+#include "cache.h"
+#include "crypto/hash.h"
 #include "file_bundle.h"
 #include "json_document.h"
 #include "shortstring.h"
@@ -12,16 +17,91 @@
 class T_BundleFileMgr : public ::testing::Test {
  protected:
   virtual void SetUp() {
+    InitObjects(42);
     UniquePtr<JsonDocument> json_doc(JsonDocument::Create("{}"));
     EXPECT_TRUE(json_doc->IsValid());
     bfm_.Manage(json_doc);
     EXPECT_TRUE(bfm_);
   }
+  std::string ToJsonStr(const CacheManager::LabeledObject &obj) {
+    constexpr size_t obj_size = 200;
+    char buf[obj_size];
+    std::string suf{obj.id.suffix};
+    snprintf(
+        buf, obj_size,
+        "{\"id\":{\"algorithm\":%d,\"suffix\":\"%s\",\"digest\":\"%s\"},\"label\":{"
+        "\"flags\":%d,\"size\":%" PRIu64
+        ",\"zip_algorithm\":%d,\"range_offset\":%d,\"path\":\"%s\"}}",
+        obj.id.algorithm, suf.c_str(), obj.id.ToString().c_str(), obj.label.flags,
+        obj.label.size, obj.label.zip_algorithm,
+        static_cast<int>(obj.label.range_offset), obj.label.path.c_str());
+    return std::string(buf);
+  }
+
+  CacheManager::LabeledObject *ToLabeledObject(const std::string &txt_obj) {
+    EXPECT_GT(txt_obj.size(), 0);
+    UniquePtr<JsonDocument> jdoc(JsonDocument::Create(txt_obj));
+    EXPECT_TRUE(jdoc.weak_ref() != nullptr);
+    auto id_ptr = JsonDocument::SearchInObject(jdoc->root(), "id", JSON_OBJECT);
+    EXPECT_TRUE(id_ptr != nullptr);
+    int algorithm;
+    EXPECT_TRUE(GetFromJSON<int>(id_ptr, "algorithm", &algorithm));
+    std::string suffix;
+    EXPECT_TRUE(GetFromJSON<std::string>(id_ptr, "suffix", &suffix));
+    std::string digest;
+    EXPECT_TRUE(GetFromJSON<std::string>(id_ptr, "digest", &digest));
+    shash::Any id = shash::MkFromHexPtr(shash::HexPtr( digest ),suffix[0]);
+    id.algorithm=static_cast<shash::Algorithms>(algorithm);
+    auto label_ptr = JsonDocument::SearchInObject(jdoc->root(), "label",
+                                                  JSON_OBJECT);
+    EXPECT_TRUE(label_ptr != nullptr);
+
+    int flags;
+    EXPECT_TRUE(GetFromJSON<int>(label_ptr, "flags", &flags));
+    int size;  ///< unzipped size, if known
+    EXPECT_TRUE(GetFromJSON<int>(label_ptr, "size", &size));
+    int zip_algorithm;
+    EXPECT_TRUE(GetFromJSON<int>(label_ptr, "zip_algorithm", &zip_algorithm));
+    int range_offset;
+    EXPECT_TRUE(GetFromJSON<int>(label_ptr, "range_offset", &range_offset));
+    std::string path;
+    EXPECT_TRUE(GetFromJSON<std::string>(label_ptr, "path", &path));
+
+    CacheManager::Label label{};
+    label.flags = flags;
+    label.size = size;
+    label.zip_algorithm = static_cast<zlib::Algorithms>(zip_algorithm);
+    label.range_offset = range_offset;
+    label.path = path;
+    return new CacheManager::LabeledObject(id, label);
+  }
+
   virtual void TearDown() { }
   virtual ~T_BundleFileMgr() { }
 
   BundleFileMgr bfm_;
+  std::vector<CacheManager::LabeledObject> objects_;
+
+ private:
+  void InitObjects(size_t number_of_objects) {
+    for (size_t i = 0; i < number_of_objects; ++i) {
+      shash::Any hash;
+      hash.Randomize(i);
+      CacheManager::Label label;
+      label.path = "/path/to/file/" + std::to_string(i);
+      objects_.push_back(CacheManager::LabeledObject(hash, label));
+    }
+  }
 };
+
+TEST_F(T_BundleFileMgr, Conversions) {
+  for (size_t i = 0; i < objects_.size(); ++i) {
+    auto *obj = ToLabeledObject(ToJsonStr(objects_[i]));
+    EXPECT_EQ(objects_[i].id, (obj)->id);
+    EXPECT_EQ(objects_[i].label, (obj)->label);
+    delete obj;
+  }
+}
 
 TEST_F(T_BundleFileMgr, Construction) {
   PathString path("test_string");

--- a/test/unittests/t_bundle_file_mgr.cc
+++ b/test/unittests/t_bundle_file_mgr.cc
@@ -102,7 +102,7 @@ class T_BundleFileMgr : public ::testing::Test {
   }
 };
 
-TEST_F(T_BundleFileMgr, Conversions) {
+TEST_F(T_BundleFileMgr, CheckConversions) {
   for (size_t i = 0; i < objects_.size(); ++i) {
     auto *obj = ToLabeledObject(ToJsonStr(objects_[i]));
     EXPECT_EQ(objects_[i].id, (obj)->id);
@@ -111,7 +111,7 @@ TEST_F(T_BundleFileMgr, Conversions) {
   }
 }
 
-TEST_F(T_BundleFileMgr, Size) {
+TEST_F(T_BundleFileMgr, TestSize) {
   EXPECT_EQ(objects_.size(),bfm_.Size());
 }
 

--- a/test/unittests/t_bundle_file_mgr.cc
+++ b/test/unittests/t_bundle_file_mgr.cc
@@ -115,3 +115,11 @@ TEST_F(T_BundleFileMgr, TestSize) {
   EXPECT_EQ(objects_.size(),bfm_.Size());
 }
 
+TEST_F(T_BundleFileMgr, TestGetNext) {
+  for(size_t i=0; i<objects_.size(); ++i){
+    auto obj = bfm_.GetNext();
+    EXPECT_TRUE(obj.IsValid());
+    EXPECT_EQ(*(obj),objects_[i]);
+  }
+  EXPECT_TRUE(bfm_.GetNext().weak_ref() == nullptr);
+}

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -16,6 +16,7 @@
 #include "options.h"
 #include "shortstring.h"
 #include "testutil.h"
+#include "util/pointer.h"
 #include "util/uuid.h"
 
 using namespace std;  // NOLINT
@@ -68,11 +69,9 @@ class MockBundleFileMgr : public BundleFileMgr {
       : BundleFileMgr(trigger_file_path) { };
   virtual ~MockBundleFileMgr() = default;
   MOCK_METHOD(size_t, Size, (), (const));
-  MOCK_METHOD(CacheManager::LabeledObject *, GetNext, (), (const));
-  void Reset(std::vector<CacheManager::LabeledObject *> &vec) {
-    it = vec.begin();
-  }
-  std::vector<CacheManager::LabeledObject *>::iterator it;
+  MOCK_METHOD(UniquePtr<CacheManager::LabeledObject>, GetNext, (), (const));
+  void Reset() { counter_ = 0; }
+  size_t counter_=0;
 };
 
 
@@ -134,28 +133,21 @@ class T_BundleMgr : public ::testing::Test {
     ON_CALL(*bfm_, Size).WillByDefault(testing::Return(10));
     EXPECT_EQ(bfm_->Size(), 10);
     srand(time(NULL));
-    shash::Any hash;
-    for (size_t i = 0; i < bfm_->Size(); ++i) {
-      CacheManager::Label label;
-      label.path = std::string{};
-      label.size = sizeof(hash);
-      label.zip_algorithm = zlib::kZlibDefault;
-      auto *obj = new CacheManager::LabeledObject(hash, label);
-      entries_.push_back(obj);
-    }
-    EXPECT_EQ(entries_.size(), bfm_->Size());
-    ON_CALL(*bfm_, GetNext)
-        .WillByDefault([this]() -> CacheManager::LabeledObject * {
-          auto &it = this->bfm_->it;
-          auto end = this->entries_.end();
-          auto res = it;
-          if (it != end) {
-            ++it;
-            return *res;
-          } else {
-            return nullptr;
-          }
-        });
+    ON_CALL(*bfm_, GetNext).WillByDefault([this]() {
+      if (bfm_->counter_ < bfm_->Size()) {
+        bfm_->counter_+=1;
+        shash::Any hash;
+        CacheManager::Label label;
+        label.path = std::string{};
+        label.size = sizeof(shash::Any);
+        label.zip_algorithm = zlib::kZlibDefault;
+        return UniquePtr<CacheManager::LabeledObject>(
+            new CacheManager::LabeledObject(hash, label));
+
+      } else {
+        return UniquePtr<CacheManager::LabeledObject>{nullptr};
+      }
+    });
     // replace the real bfm_ with the mock
     delete bundle_mgr_->bfm_;
     bundle_mgr_->bfm_ = bfm_;
@@ -176,9 +168,6 @@ class T_BundleMgr : public ::testing::Test {
     delete file_system_;
     delete mount_point_;
     delete bundle_mgr_;
-    for (auto entry : entries_) {
-      delete entry;
-    }
   }
 
  protected:
@@ -203,8 +192,6 @@ class T_BundleMgr : public ::testing::Test {
   catalog::DirectoryEntry trigger_dirent_{};
   PathString trigger_path_{};
 
-  std::vector<CacheManager::LabeledObject *> entries_;
-
   // Mocks
   testing::NiceMock<MockBundleFileMgr> *bfm_;
   testing::NiceMock<MockPathCache> *mock_path_cache_;
@@ -214,8 +201,8 @@ class T_BundleMgr : public ::testing::Test {
 };
 
 TEST_F(T_BundleMgr, Fetch) {
-  bfm_->Reset(entries_);
+  bfm_->Reset();
   bundle_mgr_->Fetch();
-  EXPECT_EQ(bfm_->it,entries_.end());
+  EXPECT_EQ(bfm_->counter_, bfm_->Size());
 }
 

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 
 #include <type_traits>
-#include <vector>
 
 #include "bundle_mgr.h"
 #include "catalog_mgr_client.h"

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -42,13 +42,13 @@ class MockFetcher : public cvmfs::Fetcher {
               download::DownloadManager *download_mgr,
               BackoffThrottle *backoff_throttle,
               perf::StatisticsTemplate statistics)
-    : Fetcher(cache_mgr, download_mgr, backoff_throttle, statistics),statistics_(statistics.statistics()) { 
-    };
+      : Fetcher(cache_mgr, download_mgr, backoff_throttle, statistics)
+      , statistics_(statistics.statistics()) { };
   int Fetch(const CacheManager::LabeledObject &object,
             const std::string &alt_url = "") override {
     return ++counter_;
   }
-  virtual ~MockFetcher(){delete statistics_;}
+  virtual ~MockFetcher() { delete statistics_; }
   void Reset() { counter_ = 0; }
 
   size_t counter_ = 0;
@@ -124,7 +124,11 @@ class T_BundleMgr : public ::testing::Test {
         64 * 1024, new perf::Statistics());
     mock_catalog_mgr_ = new testing::NiceMock<MockCatalogManager>(mount_point_);
     mock_inode_tracker_ = new testing::NiceMock<MockInodeTracker>();
-    mock_fetcher_ = new testing::NiceMock<MockFetcher>(nullptr, nullptr, nullptr, perf::StatisticsTemplate("fetch", new perf::Statistics()));
+    mock_fetcher_ = new testing::NiceMock<MockFetcher>(
+        nullptr,
+        nullptr,
+        nullptr,
+        perf::StatisticsTemplate("fetch", new perf::Statistics()));
     // Determine mock behavior
     ON_CALL(*mock_catalog_mgr_, LookupPath(testing::_, testing::_, testing::_))
         .WillByDefault([this](const PathString &,
@@ -169,7 +173,7 @@ class T_BundleMgr : public ::testing::Test {
         return UniquePtr<CacheManager::LabeledObject>{nullptr};
       }
     });
-    if (bundle_mgr_->fetcher_!=nullptr){
+    if (bundle_mgr_->fetcher_ != nullptr) {
       delete bundle_mgr_->fetcher_;
     }
 
@@ -262,6 +266,24 @@ TEST_F(T_BundleMgr, ExchangeCT) {
   test_blocking_exchange(algo);
   test_blocking_exchange(offset);
   test_blocking_exchange(string);
+}
+
+TEST_F(T_BundleMgr, ExchangeLabeledObjects) { 
+  shash::Any hash;
+  hash.Randomize(42);
+  CacheManager::Label label{};
+  UniquePtr<CacheManager::LabeledObject> object {new CacheManager::LabeledObject{hash,label}};
+
+  bundle_mgr_->SendLabeledObject(wfd_, object);
+  UniquePtr<CacheManager::LabeledObject> replied_obj = bundle_mgr_->ReceiveLabeledObject(rfd_);
+  EXPECT_TRUE(replied_obj.IsValid());
+
+  EXPECT_EQ(object->id,replied_obj->id);
+  EXPECT_EQ(object->label.flags,replied_obj->label.flags);
+  EXPECT_EQ(object->label.size,replied_obj->label.size);
+  EXPECT_EQ(object->label.zip_algorithm,replied_obj->label.zip_algorithm);
+  EXPECT_EQ(object->label.range_offset,replied_obj->label.range_offset);
+  EXPECT_EQ(object->label.path,replied_obj->label.path);
 }
 
 TEST_F(T_BundleMgr, Fetch) {

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <type_traits>
 #include <vector>
 
 #include "bundle_mgr.h"
@@ -178,6 +179,7 @@ class T_BundleMgr : public ::testing::Test {
     bundle_mgr_->bfm_ = bfm_;
     EXPECT_TRUE(bundle_mgr_);
     EXPECT_EQ(bundle_mgr_->bfm_, bfm_);
+    MakePipe(common_pipe_);
   }
 
   virtual void TearDown() {
@@ -194,6 +196,21 @@ class T_BundleMgr : public ::testing::Test {
     delete mount_point_;
     delete mock_fetcher_;
     delete bundle_mgr_;
+    ClosePipe(common_pipe_);
+  }
+
+  template<typename CT,
+           typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
+  void test_blocking_exchange(const CT &obj) {
+    using T = std::remove_cv_t<CT>;
+    bundle_mgr_->BlockingSend(wfd_, obj);
+    T reply = bundle_mgr_->BlockingReceive<T>(rfd_);
+    EXPECT_EQ(obj, reply);
+  }
+  void test_blocking_exchange(const std::string&obj) {
+    bundle_mgr_->BlockingSend(wfd_, obj);
+    std::string reply = bundle_mgr_->BlockingReceive(rfd_);
+    EXPECT_EQ(obj, reply);
   }
 
  protected:
@@ -210,7 +227,6 @@ class T_BundleMgr : public ::testing::Test {
    */
   cvmfs::Uuid *uuid_dummy_;
 
-
   PathString trigger_file_path_;
   BundleMgr *bundle_mgr_;
 
@@ -225,7 +241,28 @@ class T_BundleMgr : public ::testing::Test {
   testing::NiceMock<MockCatalogManager> *mock_catalog_mgr_;
   testing::NiceMock<MockInodeTracker> *mock_inode_tracker_;
   testing::NiceMock<MockFetcher> *mock_fetcher_;
+
+  int common_pipe_[2];
+  int &rfd_ = common_pipe_[0];
+  int &wfd_ = common_pipe_[1];
 };
+
+TEST_F(T_BundleMgr, ExchangeCT) {
+  int integer = 42;
+  shash::Any hash;
+  uint64_t size = 42;
+  zlib::Algorithms algo{zlib::Algorithms::kNoCompression};
+  off_t offset = 42;
+  hash.Randomize(integer);
+  std::string string="Test_String";
+
+  test_blocking_exchange(integer);
+  test_blocking_exchange(hash);
+  test_blocking_exchange(size);
+  test_blocking_exchange(algo);
+  test_blocking_exchange(offset);
+  test_blocking_exchange(string);
+}
 
 TEST_F(T_BundleMgr, Fetch) {
   bfm_->Reset();

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -89,7 +89,7 @@ class MockBundleFileMgr : public BundleFileMgr {
       : BundleFileMgr(trigger_file_path) { };
   virtual ~MockBundleFileMgr() = default;
   MOCK_METHOD(size_t, Size, (), (const));
-  MOCK_METHOD(UniquePtr<CacheManager::LabeledObject>, GetNext, (), (const));
+  MOCK_METHOD(UniquePtr<CacheManager::LabeledObject>, GetNext, (), (override));
   void Reset() { counter_ = 0; }
   size_t counter_ = 0;
 };

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -216,5 +216,6 @@ class T_BundleMgr : public ::testing::Test {
 TEST_F(T_BundleMgr, Fetch) {
   bfm_->Reset(entries_);
   bundle_mgr_->Fetch();
+  EXPECT_EQ(bfm_->it,entries_.end());
 }
 

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -9,6 +9,7 @@
 
 #include "bundle_mgr.h"
 #include "catalog_mgr_client.h"
+#include "fetch.h"
 #include "file_bundle.h"
 #include "glue_buffer.h"
 #include "lru_md.h"
@@ -32,6 +33,25 @@ class MockCatalogManager : public catalog::ClientCatalogManager {
                const catalog::LookupOptions options,
                catalog::DirectoryEntry *dirent),
               (override));
+};
+
+class MockFetcher : public cvmfs::Fetcher {
+ public:
+  MockFetcher(CacheManager *cache_mgr,
+              download::DownloadManager *download_mgr,
+              BackoffThrottle *backoff_throttle,
+              perf::StatisticsTemplate statistics)
+    : Fetcher(cache_mgr, download_mgr, backoff_throttle, statistics),statistics_(statistics.statistics()) { 
+    };
+  int Fetch(const CacheManager::LabeledObject &object,
+            const std::string &alt_url = "") override {
+    return ++counter_;
+  }
+  virtual ~MockFetcher(){delete statistics_;}
+  void Reset() { counter_ = 0; }
+
+  size_t counter_ = 0;
+  perf::Statistics *statistics_;
 };
 
 class MockInodeTracker : public glue::InodeTracker {
@@ -71,7 +91,7 @@ class MockBundleFileMgr : public BundleFileMgr {
   MOCK_METHOD(size_t, Size, (), (const));
   MOCK_METHOD(UniquePtr<CacheManager::LabeledObject>, GetNext, (), (const));
   void Reset() { counter_ = 0; }
-  size_t counter_=0;
+  size_t counter_ = 0;
 };
 
 
@@ -103,7 +123,7 @@ class T_BundleMgr : public ::testing::Test {
         64 * 1024, new perf::Statistics());
     mock_catalog_mgr_ = new testing::NiceMock<MockCatalogManager>(mount_point_);
     mock_inode_tracker_ = new testing::NiceMock<MockInodeTracker>();
-
+    mock_fetcher_ = new testing::NiceMock<MockFetcher>(nullptr, nullptr, nullptr, perf::StatisticsTemplate("fetch", new perf::Statistics()));
     // Determine mock behavior
     ON_CALL(*mock_catalog_mgr_, LookupPath(testing::_, testing::_, testing::_))
         .WillByDefault([this](const PathString &,
@@ -135,7 +155,7 @@ class T_BundleMgr : public ::testing::Test {
     srand(time(NULL));
     ON_CALL(*bfm_, GetNext).WillByDefault([this]() {
       if (bfm_->counter_ < bfm_->Size()) {
-        bfm_->counter_+=1;
+        bfm_->counter_ += 1;
         shash::Any hash;
         CacheManager::Label label;
         label.path = std::string{};
@@ -148,6 +168,11 @@ class T_BundleMgr : public ::testing::Test {
         return UniquePtr<CacheManager::LabeledObject>{nullptr};
       }
     });
+    if (bundle_mgr_->fetcher_!=nullptr){
+      delete bundle_mgr_->fetcher_;
+    }
+
+    bundle_mgr_->fetcher_ = mock_fetcher_;
     // replace the real bfm_ with the mock
     delete bundle_mgr_->bfm_;
     bundle_mgr_->bfm_ = bfm_;
@@ -167,6 +192,7 @@ class T_BundleMgr : public ::testing::Test {
     //    EXPECT_EQ(used_fds_, GetNoUsedFds()) << ShowOpenFiles();
     delete file_system_;
     delete mount_point_;
+    delete mock_fetcher_;
     delete bundle_mgr_;
   }
 
@@ -198,11 +224,13 @@ class T_BundleMgr : public ::testing::Test {
   testing::NiceMock<MockInodeCache> *mock_inode_cache_;
   testing::NiceMock<MockCatalogManager> *mock_catalog_mgr_;
   testing::NiceMock<MockInodeTracker> *mock_inode_tracker_;
+  testing::NiceMock<MockFetcher> *mock_fetcher_;
 };
 
 TEST_F(T_BundleMgr, Fetch) {
   bfm_->Reset();
   bundle_mgr_->Fetch();
   EXPECT_EQ(bfm_->counter_, bfm_->Size());
+  EXPECT_EQ(mock_fetcher_->counter_, bfm_->Size());
 }
 

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -5,6 +5,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "bundle_mgr.h"
 #include "catalog_mgr_client.h"
 #include "file_bundle.h"
@@ -67,6 +69,10 @@ class MockBundleFileMgr : public BundleFileMgr {
   virtual ~MockBundleFileMgr() = default;
   MOCK_METHOD(size_t, Size, (), (const));
   MOCK_METHOD(CacheManager::LabeledObject *, GetNext, (), (const));
+  void Reset(std::vector<CacheManager::LabeledObject *> &vec) {
+    it = vec.begin();
+  }
+  std::vector<CacheManager::LabeledObject *>::iterator it;
 };
 
 
@@ -122,10 +128,39 @@ class T_BundleMgr : public ::testing::Test {
     mount_point_->inode_tracker_ = mock_inode_tracker_;
 
     bundle_mgr_ = new BundleMgr(mount_point_, trigger_ino_);
+
+    // Create a BundleFileMgr mock
     bfm_ = new testing::NiceMock<MockBundleFileMgr>(trigger_file_path_);
     ON_CALL(*bfm_, Size).WillByDefault(testing::Return(10));
+    EXPECT_EQ(bfm_->Size(), 10);
+    srand(time(NULL));
+    shash::Any hash;
+    for (size_t i = 0; i < bfm_->Size(); ++i) {
+      CacheManager::Label label;
+      label.path = std::string{};
+      label.size = sizeof(hash);
+      label.zip_algorithm = zlib::kZlibDefault;
+      auto *obj = new CacheManager::LabeledObject(hash, label);
+      entries_.push_back(obj);
+    }
+    EXPECT_EQ(entries_.size(), bfm_->Size());
+    ON_CALL(*bfm_, GetNext)
+        .WillByDefault([this]() -> CacheManager::LabeledObject * {
+          auto &it = this->bfm_->it;
+          auto end = this->entries_.end();
+          auto res = it;
+          if (it != end) {
+            ++it;
+            return *res;
+          } else {
+            return nullptr;
+          }
+        });
+    // replace the real bfm_ with the mock
     delete bundle_mgr_->bfm_;
     bundle_mgr_->bfm_ = bfm_;
+    EXPECT_TRUE(bundle_mgr_);
+    EXPECT_EQ(bundle_mgr_->bfm_, bfm_);
   }
 
   virtual void TearDown() {
@@ -141,6 +176,9 @@ class T_BundleMgr : public ::testing::Test {
     delete file_system_;
     delete mount_point_;
     delete bundle_mgr_;
+    for (auto entry : entries_) {
+      delete entry;
+    }
   }
 
  protected:
@@ -165,6 +203,8 @@ class T_BundleMgr : public ::testing::Test {
   catalog::DirectoryEntry trigger_dirent_{};
   PathString trigger_path_{};
 
+  std::vector<CacheManager::LabeledObject *> entries_;
+
   // Mocks
   testing::NiceMock<MockBundleFileMgr> *bfm_;
   testing::NiceMock<MockPathCache> *mock_path_cache_;
@@ -173,5 +213,8 @@ class T_BundleMgr : public ::testing::Test {
   testing::NiceMock<MockInodeTracker> *mock_inode_tracker_;
 };
 
-TEST_F(T_BundleMgr, Simple) { EXPECT_TRUE(bundle_mgr_); }
+TEST_F(T_BundleMgr, Fetch) {
+  bfm_->Reset(entries_);
+  bundle_mgr_->Fetch();
+}
 

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -2,16 +2,75 @@
  * This file is part of the CernVM File System.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "mountpoint.h"
-#include "util/uuid.h"
-#include "testutil.h"
-#include "options.h"
+
 #include "bundle_mgr.h"
+#include "catalog_mgr_client.h"
+#include "file_bundle.h"
+#include "glue_buffer.h"
+#include "lru_md.h"
+#include "mountpoint.h"
+#include "options.h"
+#include "shortstring.h"
+#include "testutil.h"
+#include "util/uuid.h"
 
 using namespace std;  // NOLINT
+class MockCatalogManager : public catalog::ClientCatalogManager {
+ public:
+  MockCatalogManager(MountPoint *mountpoint)
+      : ClientCatalogManager(mountpoint) { };
+  virtual ~MockCatalogManager() = default;
+  MOCK_METHOD(fuse_ino_t, MangleInode, (fuse_ino_t ino), (const));
+  MOCK_METHOD(bool,
+              LookupPath,
+              (const PathString &path,
+               const catalog::LookupOptions options,
+               catalog::DirectoryEntry *dirent),
+              (override));
+};
 
-class T_BundleMgr: public ::testing::Test {
+class MockInodeTracker : public glue::InodeTracker {
+ public:
+  virtual ~MockInodeTracker() = default;
+  MOCK_METHOD(bool,
+              FindPath,
+              (glue::InodeEx * inode_ex, PathString *path),
+              (override));
+};
+
+class MockInodeCache : public lru::InodeCache {
+ public:
+  MockInodeCache(unsigned int cache_size, perf::Statistics *statistics)
+      : lru::InodeCache(cache_size, statistics), statistics_(statistics) { }
+  virtual ~MockInodeCache() { delete statistics_; }
+
+ private:
+  perf::Statistics *statistics_;
+};
+
+class MockPathCache : public lru::PathCache {
+ public:
+  MockPathCache(unsigned int cache_size, perf::Statistics *statistics)
+      : lru::PathCache(cache_size, statistics), statistics_(statistics) { }
+  virtual ~MockPathCache() { delete statistics_; }
+
+ private:
+  perf::Statistics *statistics_;
+};
+
+class MockBundleFileMgr : public BundleFileMgr {
+ public:
+  MockBundleFileMgr(const PathString &trigger_file_path)
+      : BundleFileMgr(trigger_file_path) { };
+  virtual ~MockBundleFileMgr() = default;
+  MOCK_METHOD(size_t, Size, (), (const));
+  MOCK_METHOD(CacheManager::LabeledObject *, GetNext, (), (const));
+};
+
+
+class T_BundleMgr : public ::testing::Test {
  protected:
   virtual void SetUp() {
     repo_path_ = "repo";
@@ -28,7 +87,45 @@ class T_BundleMgr: public ::testing::Test {
     // Silence syslog error
     options_mgr_.SetValue("CVMFS_MOUNT_DIR", "/no/such/dir");
     file_system_ = FileSystem::Create(fs_info_);
+    ASSERT_TRUE(file_system_ != NULL);
+    EXPECT_TRUE(file_system_->IsValid());
     mount_point_ = MountPoint::Create("keys.cern.ch", file_system_);
+
+    // MountPoint mocks allocation
+    mock_path_cache_ = new testing::NiceMock<MockPathCache>(
+        64 * 1024, new perf::Statistics());
+    mock_inode_cache_ = new testing::NiceMock<MockInodeCache>(
+        64 * 1024, new perf::Statistics());
+    mock_catalog_mgr_ = new testing::NiceMock<MockCatalogManager>(mount_point_);
+    mock_inode_tracker_ = new testing::NiceMock<MockInodeTracker>();
+
+    // Determine mock behavior
+    ON_CALL(*mock_catalog_mgr_, LookupPath(testing::_, testing::_, testing::_))
+        .WillByDefault([this](const PathString &,
+                              const catalog::LookupOptions,
+                              catalog::DirectoryEntry *out) -> bool {
+          *out = this->trigger_dirent_;
+          return true;
+        });
+    ON_CALL(*mock_inode_tracker_, FindPath(testing::_, testing::_))
+        .WillByDefault([this](glue::InodeEx *inode_ex,
+                              PathString *path) -> bool {
+          glue::InodeEx result(this->trigger_ino_, glue::InodeEx::kUnknownType);
+          *inode_ex = result;
+          *path = this->trigger_path_;
+          return true;
+        });
+    // Plug mocks on mount_point_
+    mount_point_->path_cache_ = mock_path_cache_;
+    mount_point_->inode_cache_ = mock_inode_cache_;
+    mount_point_->catalog_mgr_ = mock_catalog_mgr_;
+    mount_point_->inode_tracker_ = mock_inode_tracker_;
+
+    bundle_mgr_ = new BundleMgr(mount_point_, trigger_ino_);
+    bfm_ = new testing::NiceMock<MockBundleFileMgr>(trigger_file_path_);
+    ON_CALL(*bfm_, Size).WillByDefault(testing::Return(10));
+    delete bundle_mgr_->bfm_;
+    bundle_mgr_->bfm_ = bfm_;
   }
 
   virtual void TearDown() {
@@ -40,7 +137,10 @@ class T_BundleMgr: public ::testing::Test {
       RemoveTree(tmp_path_);
     if (repo_path_ != "")
       RemoveTree(repo_path_);
-    EXPECT_EQ(used_fds_, GetNoUsedFds()) << ShowOpenFiles();
+    //    EXPECT_EQ(used_fds_, GetNoUsedFds()) << ShowOpenFiles();
+    delete file_system_;
+    delete mount_point_;
+    delete bundle_mgr_;
   }
 
  protected:
@@ -57,11 +157,21 @@ class T_BundleMgr: public ::testing::Test {
    */
   cvmfs::Uuid *uuid_dummy_;
 
-  fuse_ino_t ino_;
+
+  PathString trigger_file_path_;
+  BundleMgr *bundle_mgr_;
+
+  fuse_ino_t trigger_ino_{};
+  catalog::DirectoryEntry trigger_dirent_{};
+  PathString trigger_path_{};
+
+  // Mocks
+  testing::NiceMock<MockBundleFileMgr> *bfm_;
+  testing::NiceMock<MockPathCache> *mock_path_cache_;
+  testing::NiceMock<MockInodeCache> *mock_inode_cache_;
+  testing::NiceMock<MockCatalogManager> *mock_catalog_mgr_;
+  testing::NiceMock<MockInodeTracker> *mock_inode_tracker_;
 };
 
-
-TEST_F(T_BundleMgr, Construct) {
-  BundleMgr b_mgr (mount_point_,ino_);
-}
+TEST_F(T_BundleMgr, Simple) { EXPECT_TRUE(bundle_mgr_); }
 

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -1,0 +1,67 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+#include "mountpoint.h"
+#include "util/uuid.h"
+#include "testutil.h"
+#include "options.h"
+#include "bundle_mgr.h"
+
+using namespace std;  // NOLINT
+
+class T_BundleMgr: public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    repo_path_ = "repo";
+    uuid_dummy_ = cvmfs::Uuid::Create("");
+    used_fds_ = GetNoUsedFds();
+    fd_cwd_ = open(".", O_RDONLY);
+    ASSERT_GE(fd_cwd_, 0);
+    tmp_path_ = CreateTempDir("./cvmfs_ut_cache");
+    options_mgr_.SetValue("CVMFS_CACHE_BASE", tmp_path_);
+    options_mgr_.SetValue("CVMFS_SHARED_CACHE", "no");
+    options_mgr_.SetValue("CVMFS_MAX_RETRIES", "0");
+    fs_info_.name = "unit-test";
+    fs_info_.options_mgr = &options_mgr_;
+    // Silence syslog error
+    options_mgr_.SetValue("CVMFS_MOUNT_DIR", "/no/such/dir");
+    file_system_ = FileSystem::Create(fs_info_);
+    mount_point_ = MountPoint::Create("keys.cern.ch", file_system_);
+  }
+
+  virtual void TearDown() {
+    delete uuid_dummy_;
+    int retval = fchdir(fd_cwd_);
+    ASSERT_EQ(0, retval);
+    close(fd_cwd_);
+    if (tmp_path_ != "")
+      RemoveTree(tmp_path_);
+    if (repo_path_ != "")
+      RemoveTree(repo_path_);
+    EXPECT_EQ(used_fds_, GetNoUsedFds()) << ShowOpenFiles();
+  }
+
+ protected:
+  MountPoint *mount_point_;
+  FileSystem *file_system_;
+  FileSystem::FileSystemInfo fs_info_;
+  SimpleOptionsParser options_mgr_;
+  string tmp_path_;
+  string repo_path_;
+  int fd_cwd_;
+  unsigned used_fds_;
+  /**
+   * Initialize libuuid / open file descriptor on /dev/urandom
+   */
+  cvmfs::Uuid *uuid_dummy_;
+
+  fuse_ino_t ino_;
+};
+
+
+TEST_F(T_BundleMgr, Construct) {
+  BundleMgr b_mgr (mount_point_,ino_);
+}
+


### PR DESCRIPTION
This is a complement of https://github.com/cvmfs/cvmfs/pull/4039.

It is the mechanism that parses the trigger file and returns `CacheManager::LabeledObject - s` to the `BundleMgr()` in order to trigger fetching.

The trigger file is assumed to have the following format:
```json
{                                                                                      
"labeled_objects":[{"id":{"algorithm":%d,"suffix":"%c","digest":"%s"},"label":{"flags":%d,"size":%PRIu64,"zip_algorithm":%d,"range_offset":%d,"path":"%s"}}]                  
}                                                                                      
```

At the moment I have provided multiple different constructors for the `BundleFileMgr` because we haven't yet converged on how will the trigger file be propagated to the `BundleMgr` and the `BundleFileMgr`.