### PR TITLE
Use short hashes in cleanup

### DIFF
--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -497,7 +497,7 @@ struct CVMFS_EXPORT Short : public Digest<kShortDigestSize, kAny> {
   }
 
   std::string ToString(const bool with_suffix = false) {
-    Hex hex(this);
+    const Hex hex(this);
     const bool use_suffix = with_suffix && HasSuffix();
     const unsigned string_length = hex_size_ + use_suffix;
     std::string result(string_length, 0);

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -514,6 +514,8 @@ struct CVMFS_EXPORT Short : public Digest<kShortDigestSize, kAny> {
     return result;
   }
 
+  // TODO(christge):
+  // avoid memcpy for comparison. Compare here directly
   bool Collide(const Any &other) const { return *this == Short(other); }
 
  private:

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -514,9 +514,16 @@ struct CVMFS_EXPORT Short : public Digest<kShortDigestSize, kAny> {
     return result;
   }
 
-  // TODO(christge):
-  // avoid memcpy for comparison. Compare here directly
-  bool Collide(const Any &other) const { return *this == Short(other); }
+  bool Collide(const Any &other) const {
+    if (this->algorithm != other.algorithm) {
+      return false;
+    }
+    for (unsigned i = 0; i < digest_size_; ++i) {
+      if (this->digest[i] != other.digest[i])
+        return false;
+    }
+    return true;
+  }
 
  private:
   size_t digest_size_;

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -151,7 +151,7 @@ struct CVMFS_EXPORT Digest {
       return kAlgorithmIds[digest_.algorithm][position - hash_length_];
     }
 
-    char ToHex(const char c) const {
+    static char ToHex(const char c) {
       return static_cast<char>(c + ((c <= 9) ? '0' : 'a' - 10));
     }
 
@@ -472,17 +472,21 @@ struct CVMFS_EXPORT Any : public Digest<kMaxDigestSize, kAny> {
   Md5 CastToMd5();
 };
 
-struct CVMFS_EXPORT Short : public Digest<kMaxDigestSize / 4, kAny> {
-  explicit Short(const Any &full)
-      : Digest<kMaxDigestSize / 4, kAny>()
-      , digest_size_(kDigestSizes[full.algorithm] / 4) {
+constexpr size_t kShortDigestSize = kMaxDigestSize;
+struct CVMFS_EXPORT Short : public Digest<kShortDigestSize, kAny> {
+  explicit Short(const Any &full) : Digest<kShortDigestSize, kAny>() {
     algorithm = full.algorithm;
     suffix = full.suffix;
-    memcpy(digest, full.digest, digest_size_);
+    digest_size_ = kShortDigestSize / 4;
+    hex_size_ = 2 * digest_size_ + kAlgorithmIdSizes[algorithm];
+    memcpy(digest, full.digest, kShortDigestSize);
   }
 
   bool operator==(const Short &other) const {
     if (this->algorithm != other.algorithm) {
+      return false;
+    }
+    if (this->digest_size_ != other.digest_size_) {
       return false;
     }
     for (unsigned i = 0; i < digest_size_; ++i) {
@@ -492,10 +496,29 @@ struct CVMFS_EXPORT Short : public Digest<kMaxDigestSize / 4, kAny> {
     return true;
   }
 
+  std::string ToString(const bool with_suffix = false) {
+    Hex hex(this);
+    const bool use_suffix = with_suffix && HasSuffix();
+    const unsigned string_length = hex_size_ + use_suffix;
+    std::string result(string_length, 0);
+
+    for (unsigned int i = 0; i < hex_size_; ++i) {
+      result[i] = hex[i];
+    }
+
+    if (use_suffix) {
+      result[string_length - 1] = suffix;
+    }
+
+    assert(result.length() == string_length);
+    return result;
+  }
+
   bool collide(const Any &other) const { return *this == Short(other); }
 
  private:
-  const size_t digest_size_;
+  size_t digest_size_;
+  size_t hex_size_;
 };
 /**
  * Actual operations on digests, like "hash a file", "hash a buffer", or

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -514,7 +514,7 @@ struct CVMFS_EXPORT Short : public Digest<kShortDigestSize, kAny> {
     return result;
   }
 
-  bool collide(const Any &other) const { return *this == Short(other); }
+  bool Collide(const Any &other) const { return *this == Short(other); }
 
  private:
   size_t digest_size_;

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -66,14 +66,14 @@ const char kSuffixMetainfo = 'M';
  * When the maximum digest size changes, the memory layout of DirectoryEntry and
  * PosixQuotaManager::LruCommand changes, too!
  */
-const unsigned kDigestSizes[] = {16, 20, 20, 20, 20};
+constexpr unsigned kDigestSizes[] = {16, 20, 20, 20, 20};
 // Md5  Sha1  Rmd160  Shake128  Any
-const unsigned kMaxDigestSize = 20;
+constexpr unsigned kMaxDigestSize = 20;
 
 /**
  * The maximum of GetContextSize()
  */
-const unsigned kMaxContextSize = 256;
+constexpr unsigned kMaxContextSize = 256;
 
 /**
  * Hex representations of hashes with the same length need a suffix
@@ -472,7 +472,31 @@ struct CVMFS_EXPORT Any : public Digest<kMaxDigestSize, kAny> {
   Md5 CastToMd5();
 };
 
+struct CVMFS_EXPORT Short : public Digest<kMaxDigestSize / 4, kAny> {
+  explicit Short(const Any &full)
+      : Digest<kMaxDigestSize / 4, kAny>()
+      , digest_size_(kDigestSizes[full.algorithm] / 4) {
+    algorithm = full.algorithm;
+    suffix = full.suffix;
+    memcpy(digest, full.digest, digest_size_);
+  }
 
+  bool operator==(const Short &other) const {
+    if (this->algorithm != other.algorithm) {
+      return false;
+    }
+    for (unsigned i = 0; i < digest_size_; ++i) {
+      if (this->digest[i] != other.digest[i])
+        return false;
+    }
+    return true;
+  }
+
+  bool collide(const Any &other) const { return *this == Short(other); }
+
+ private:
+  const size_t digest_size_;
+};
 /**
  * Actual operations on digests, like "hash a file", "hash a buffer", or
  * iterative operations.
@@ -548,3 +572,4 @@ CVMFS_EXPORT Any MkFromSuffixedHexPtr(const HexPtr hex);
 #endif
 
 #endif  // CVMFS_CRYPTO_HASH_H_
+

--- a/cvmfs/crypto/hash.h
+++ b/cvmfs/crypto/hash.h
@@ -66,14 +66,14 @@ const char kSuffixMetainfo = 'M';
  * When the maximum digest size changes, the memory layout of DirectoryEntry and
  * PosixQuotaManager::LruCommand changes, too!
  */
-constexpr unsigned kDigestSizes[] = {16, 20, 20, 20, 20};
+const unsigned kDigestSizes[] = {16, 20, 20, 20, 20};
 // Md5  Sha1  Rmd160  Shake128  Any
-constexpr unsigned kMaxDigestSize = 20;
+const unsigned kMaxDigestSize = 20;
 
 /**
  * The maximum of GetContextSize()
  */
-constexpr unsigned kMaxContextSize = 256;
+const unsigned kMaxContextSize = 256;
 
 /**
  * Hex representations of hashes with the same length need a suffix
@@ -472,7 +472,7 @@ struct CVMFS_EXPORT Any : public Digest<kMaxDigestSize, kAny> {
   Md5 CastToMd5();
 };
 
-constexpr size_t kShortDigestSize = kMaxDigestSize;
+const size_t kShortDigestSize = kMaxDigestSize;
 struct CVMFS_EXPORT Short : public Digest<kShortDigestSize, kAny> {
   explicit Short(const Any &full) : Digest<kShortDigestSize, kAny>() {
     algorithm = full.algorithm;

--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -10,6 +10,7 @@
 
 #include "cache_posix.h"
 #include "catalog_mgr_client.h"
+#include "crypto/hash.h"
 #include "crypto/signature.h"
 #include "fetch.h"
 #include "mountpoint.h"
@@ -833,7 +834,8 @@ void ListOpenHashesMagicXattr::FinalizeValue() {
         for (size_t i = 0; i < hash_map.capacity(); ++i) {
           const shash::Any &hash = keys[i];
           if (hash != empty) {
-            result += hash.ToString() + "\n";
+            shash::Short short_hash(hash);
+            result += short_hash.ToString() + "\n";
           }
         }
       }

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -541,7 +541,7 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
     open_files_.clear();
     open_files_ = (cleanup_unused_first_) ? CollectAllOpenHashes()
-                                          : std::vector<shash::Any>();
+                                          : std::vector<shash::Short>();
 
     for (i = 0; i < N; ++i) {
       // That's a critical condition.  We must not delete a not yet inserted
@@ -552,8 +552,11 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
-      const bool is_open = std::find(open_files_.begin(), open_files_.end(),
-                                     candidates[i].hash)
+      const bool is_open = std::find_if(
+                               open_files_.begin(), open_files_.end(),
+                               [&candidates, &i](const auto &elem) -> bool {
+                                 return elem.Collide(candidates[i].hash);
+                               })
                            != open_files_.end();
 
       if (is_pinned) {
@@ -1381,7 +1384,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
       if (return_pipe < 0)
         continue;
 
-      std::vector<shash::Any> gh = quota_mgr->CollectAllOpenHashes();
+      std::vector<shash::Short> gh = quota_mgr->CollectAllOpenHashes();
       std::string result;
       for (auto it = gh.begin(); it != gh.end(); ++it) {
         result += (*it).ToString() + "\n";
@@ -2286,13 +2289,13 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
   }
   const MutexLockGuard lock_guard(handler->l);
   for (auto hash_str : hash_strs) {
-    handler->of.push_back(shash::MkFromHexPtr(shash::HexPtr(hash_str)));
+    handler->of.push_back(shash::Short( shash::MkFromHexPtr(shash::HexPtr(hash_str)) ));
   }
 #endif
   pthread_exit(nullptr);
 }
 
-std::vector<shash::Any> PosixQuotaManager::CollectAllOpenHashes() {
+std::vector<shash::Short> PosixQuotaManager::CollectAllOpenHashes() {
   std::vector<CollectorHandler *> handlers;
   std::vector<pthread_t *> threads;
   open_files_.clear();

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -552,12 +552,18 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
+/*
       const bool is_open = std::find_if(
                                open_files_.begin(), open_files_.end(),
                                [&candidates, &i](const auto &elem) -> bool {
                                  return elem.Collide(candidates[i].hash);
                                })
                            != open_files_.end();
+*/
+      bool is_open=false;
+      for(auto it=open_files_.begin();it!=open_files_.end();++it){
+        if (it->Collide(candidates[i].hash)){is_open=true; break;}
+      }
 
       if (is_pinned) {
         SkipEviction(candidates[i]);

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -390,15 +390,15 @@ class PosixQuotaManager : public QuotaManager {
   // TODO(gchr): it would be faster if it was a std::set. Needs a comparison
   // operator for shash::Any
   pthread_mutex_t *lock_open_files_;
-  std::vector<shash::Any> open_files_;
+  std::vector<shash::Short> open_files_;
 
   bool cleanup_unused_first_;
   std::vector<std::string> mountpoints_;
 
-  std::vector<shash::Any> CollectAllOpenHashes();
+  std::vector<shash::Short> CollectAllOpenHashes();
 
   struct CollectorHandler {
-    std::vector<shash::Any> &of;
+    std::vector<shash::Short> &of;
     const std::vector<std::string> &mp;
     pthread_mutex_t *l;
     size_t i;

--- a/test/unittests/t_shash.cc
+++ b/test/unittests/t_shash.cc
@@ -1273,4 +1273,5 @@ TEST(T_Shash, ShortHash) {
   auto hash = random_hash_generator();
   shash::Short short_hash(hash);
   EXPECT_TRUE(short_hash.collide(hash));
+  EXPECT_FALSE(short_hash.collide(random_hash_generator()));
 }

--- a/test/unittests/t_shash.cc
+++ b/test/unittests/t_shash.cc
@@ -1271,6 +1271,6 @@ TEST(T_Shash, ShortHash) {
   RandomHashGenerator random_hash_generator(rng);
   auto hash = random_hash_generator();
   shash::Short short_hash(hash);
-  EXPECT_TRUE(short_hash.collide(hash));
-  EXPECT_FALSE(short_hash.collide(random_hash_generator()));
+  EXPECT_TRUE(short_hash.Collide(hash));
+  EXPECT_FALSE(short_hash.Collide(random_hash_generator()));
 }

--- a/test/unittests/t_shash.cc
+++ b/test/unittests/t_shash.cc
@@ -26,8 +26,7 @@ class RandomHashGenerator {
   explicit RandomHashGenerator(Prng &rng) : rng_(rng) { }
 
   shash::Any operator()() {
-    const shash::Algorithms type = static_cast<shash::Algorithms>(rng_.Next(3));
-    shash::Any result_hash(type);
+    shash::Any result_hash(shash::Algorithms::kSha1);
     result_hash.Randomize(&rng_);
     return result_hash;
   }

--- a/test/unittests/t_shash.cc
+++ b/test/unittests/t_shash.cc
@@ -21,6 +21,21 @@
 
 using namespace std;  // NOLINT
 
+class RandomHashGenerator {
+ public:
+  explicit RandomHashGenerator(Prng &rng) : rng_(rng) { }
+
+  shash::Any operator()() {
+    const shash::Algorithms type = static_cast<shash::Algorithms>(rng_.Next(3));
+    shash::Any result_hash(type);
+    result_hash.Randomize(&rng_);
+    return result_hash;
+  }
+
+ private:
+  Prng &rng_;
+};
+
 TEST(T_Shash, ContextSize) {
   unsigned max_size = 0;
   for (int i = 0; i < shash::kAny; ++i) {
@@ -1249,4 +1264,13 @@ TEST(T_Shash, Sha256) {
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       hash.c_str());
 #endif
+}
+
+TEST(T_Shash, ShortHash) {
+  Prng rng;
+  rng.InitSeed(42);
+  RandomHashGenerator random_hash_generator(rng);
+  auto hash = random_hash_generator();
+  shash::Short short_hash(hash);
+  EXPECT_TRUE(short_hash.collide(hash));
 }


### PR DESCRIPTION
On cleanup, `PosixQuotaMgr` retrieves the managed open hashes via a dedicated magic xattr for every associated mountpoint.

In this feature, we use the notion of of a `Short()` hash as the return value, to balance the impact inherent restriction of 64kB per magic xattr page.