### PR TITLE
XattrList::CreateFromFile(): add compile-time option to use fewer syscalls

### DIFF
--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -65,3 +65,4 @@ set (BUILTIN_EXTERNALS_EXCLUDE ${BUILTIN_EXTERNALS_EXCLUDE_DEFAULT} CACHE STRING
 
 option (ENABLE_ASAN             "Enable the Address Sanitizer"                                     OFF)
 option (CHECK_SYSTEM_HEADERS    "Check System for required headers"                                 OFF)
+option (GET_XATTR_FAST          "Use codepath for faster xattr retrieval using more memory"        OFF)

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -110,6 +110,10 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS)
       add_definitions (-DCVMFS_ENABLE_INOTIFY)
     endif ()
   endif ()
+
+  if (GET_XATTR_FAST)
+    add_definitions(-DCVMFS_GET_XATTR_FAST)
+  endif(GET_XATTR_FAST)
 endif (BUILD_CVMFS OR BUILD_LIBCVMFS)
 
 

--- a/cvmfs/xattr.cc
+++ b/cvmfs/xattr.cc
@@ -53,15 +53,21 @@ XattrList *XattrList::CreateFromFile(const std::string &path) {
 
   // Retrieve extended attribute values
   XattrList *result = new XattrList();
-  char value_smallbuf[255];
+#ifdef CVMFS_GET_XATTR_FAST
+#define XATTR_FIXED_BUF_SIZE (64*1024)
+#else
+#define XATTR_FIXED_BUF_SIZE 255
+#endif
+  char value_buf_fixed[XATTR_FIXED_BUF_SIZE];
   for (unsigned i = 0; i < keys.size(); ++i) {
     if (keys[i].empty())
       continue;
 
-    char *buffer = value_smallbuf;
-    size_t sz_buffer = 255;
+    char *buffer = value_buf_fixed;
+    size_t sz_buffer = XATTR_FIXED_BUF_SIZE;
     ssize_t sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer,
                                           sz_buffer);
+#ifndef CVMFS_GET_XATTR_FAST
     // check if we need to allocate bigger buffer
     if ((sz_value < 0) && (errno == ERANGE)) {
       // query lgetxattr with size 0 to get proper buffer size
@@ -71,12 +77,16 @@ XattrList *XattrList::CreateFromFile(const std::string &path) {
       sz_value = platform_lgetxattr(path.c_str(), keys[i].c_str(), buffer,
                                     sz_buffer);
     }
+#endif
     if (sz_value >= 0)
       result->Set(keys[i], string(buffer, sz_value));
-    if (buffer != value_smallbuf)
+#ifndef CVMFS_GET_XATTR_FAST
+    if (buffer != value_buf_fixed)
         free(buffer);
+#endif
   }
   return result;
+#undef XATTR_FIXED_BUF_SIZE
 }
 
 


### PR DESCRIPTION
If CVMFS_GET_XATTR_FAST is defined, the method uses automatic (on-stack) 64 KiB buffer with platform_lgetxattr(), using no more than one syscall to retrieve each key, and no dynamic memory allocation.

By default, it uses up to 3 syscalls per key retrieval and up to one dynamic memory allocation per key: it starts with 255 bytes buffer, and if it's not sufficient, it makes a syscall with buffer size argument 0, which returns the size of necessary buffer, which is then dynamically allocated, and used for the third platform_lgetxattr() call.

Link: https://github.com/cvmfs/cvmfs/pull/3622#discussion_r2294968712