### PR TITLE
Bump quota manager protocol revision for recently added commands

### DIFF
--- a/cvmfs/quota.cc
+++ b/cvmfs/quota.cc
@@ -16,7 +16,7 @@
 
 using namespace std;  // NOLINT
 
-const uint32_t QuotaManager::kProtocolRevision = 2;
+const uint32_t QuotaManager::kProtocolRevision = 3;
 
 void QuotaManager::BroadcastBackchannels(const string &message) {
   assert(message.length() > 0);

--- a/cvmfs/quota.h
+++ b/cvmfs/quota.h
@@ -41,6 +41,9 @@ class QuotaManager : SingleCopy {
    *  - backchannel command 'R': release pinned files if possible
    * Revision 2:
    *  - add kCleanupRate command
+   * Revision 3:
+   *  - add kRegisterMountpoint, kGetMountpoints, kGetGroupHashes, and
+   *    kSetCleanupPolicy commands
    */
   static const uint32_t kProtocolRevision;
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -426,7 +426,9 @@ PosixQuotaManager *PosixQuotaManager::CreateShared(
     LogCvmfs(kLogQuota, kLogDebug, "failed to start cache manager");
     return NULL;
   }
-  LogCvmfs(kLogQuota, kLogDebug, "new cache manager pid: %d", new_cachemgr_pid);
+  LogCvmfs(kLogQuota, kLogDebug,
+           "new cache manager pid: %d protocol revision %d",
+           new_cachemgr_pid, QuotaManager::kProtocolRevision);
   quota_mgr->SetCacheMgrPid(new_cachemgr_pid);
   const int fd_lockfile_rw = open((workspace_dir + "/lock_cachemgr").c_str(),
                                   O_RDWR | O_TRUNC, 0600);
@@ -792,6 +794,8 @@ uint32_t PosixQuotaManager::GetProtocolRevision() {
 }
 
 void PosixQuotaManager::SetCleanupPolicy(bool cleanup_unused_first) {
+  if (protocol_revision_ < 3) return;
+
   LruCommand cmd;
   cmd.command_type = kSetCleanupPolicy;
   WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
@@ -800,6 +804,8 @@ void PosixQuotaManager::SetCleanupPolicy(bool cleanup_unused_first) {
 }
 
 void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
+  if (protocol_revision_ < 3) return;
+
   LruCommand cmd;
   cmd.command_type = kRegisterMountpoint;
   WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
@@ -810,6 +816,8 @@ void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
 }
 
 std::string PosixQuotaManager::GetMountpoints() {
+  if (protocol_revision_ < 3) return "";
+
   int pipe_mp[2];
   MakeReturnPipe(pipe_mp);
 
@@ -825,6 +833,8 @@ std::string PosixQuotaManager::GetMountpoints() {
 }
 
 std::string PosixQuotaManager::GetGroupHashes() {
+  if (protocol_revision_ < 3) return "";
+
   int pipe_gh[2];
   MakeReturnPipe(pipe_gh);
 

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -129,7 +129,7 @@ class PosixQuotaManager : public QuotaManager {
     kListVolatile,
     kCleanupRate,
     kSetLimit,
-    // After non open aware LRU cleanup
+    // as of protocol revision 3
     kRegisterMountpoint,
     kGetMountpoints,
     kGetGroupHashes,


### PR DESCRIPTION
After #4029, upgrading a running mount crashes.  I tracked it down to a Panic() on the running quota manager because it did not recognize the new `kSetCleanupPolicy` command.  This PR bumps the protocol revision number so a new cvmfs module won't send the new commands to an old quota manager, avoiding the crash.