### PR TITLE
gw: annotate cvmfs_receiver process with lease path

### DIFF
--- a/cvmfs/receiver/receiver.cc
+++ b/cvmfs/receiver/receiver.cc
@@ -30,6 +30,8 @@ swissknife::ParameterList MakeParameterList() {
       'd', "Path to debug log. Ignored if the non-debug version runs, "
            "Default: "
                + std::string(kDefaultDebugLog)));
+  params.push_back(swissknife::Parameter::Optional(
+      'l', "Lease path (unused, for process identification)"));
   return params;
 }
 

--- a/gateway/internal/gateway/receiver/pool.go
+++ b/gateway/internal/gateway/receiver/pool.go
@@ -146,7 +146,19 @@ M:
 
 		func() {
 			t0 := time.Now()
-			receiver, err := NewReceiver(task.Context(), pool.workerExec, pool.mock, pool.smgr)
+			var extraArgs []string
+			var leasePath string
+			switch t := task.(type) {
+			case payloadTask:
+				leasePath = t.leasePath
+			case commitTask:
+				leasePath = t.leasePath
+			}
+			if leasePath != "" {
+				extraArgs = append(extraArgs, "-l", leasePath)
+			}
+
+			receiver, err := NewReceiver(task.Context(), pool.workerExec, pool.mock, pool.smgr, extraArgs...)
 			if err != nil {
 				task.Reply() <- err
 				return


### PR DESCRIPTION
This PR addresses issue #3399 by adding an optional `-l` argument to the `cvmfs_receiver` process.

### Description
The `cvmfs_receiver` process is spawned by the gateway. This change passes the lease path as an unused `-l` command-line argument to the receiver process. This allows administrators to easily identify which receiver process corresponds to which lease path using standard process listing tools, aiding in debugging and monitoring.

### Changes
*   **`cvmfs/receiver/receiver.cc`**: Updated argument parsing to accept an optional `-l` flag.
*   **`gateway/internal/gateway/receiver/pool.go`**: Updated the worker pool to extract the lease path from the task and pass it to the receiver process.

### Testing
*   Verified that the gateway compiles and tests pass.
*   The extra argument is ignored by the receiver logic, ensuring no side effects on functionality.

Fixes #3399