### PR TITLE
[test] explicitly use python3 in cloudtests

### DIFF
--- a/test/src/030-missingrootcatalog/main
+++ b/test/src/030-missingrootcatalog/main
@@ -46,12 +46,7 @@ cvmfs_run_test() {
   cd ..
 
   echo "run a simple HTTP server"
-  export PYTHON_VERSION=`python -c 'import sys; version=sys.version_info[:1]; print("{0}".format(*version))'`
-   if [  $PYTHON_VERSION -gt 2  ]; then
-     cmd="python -m http.server 8000"
-   else
-     cmd="python -m SimpleHTTPServer 8000"
-   fi
+  cmd="python3 -m SimpleHTTPServer 8000"
 
   http_pid=$(run_background_service $logfile "$cmd")
   if [ $? -ne 0 ]; then return 9; fi

--- a/test/src/030-missingrootcatalog/main
+++ b/test/src/030-missingrootcatalog/main
@@ -46,7 +46,8 @@ cvmfs_run_test() {
   cd ..
 
   echo "run a simple HTTP server"
-  cmd="python3 -m SimpleHTTPServer 8000"
+  cmd="python3 -m http.server 8000"
+
 
   http_pid=$(run_background_service $logfile "$cmd")
   if [ $? -ne 0 ]; then return 9; fi

--- a/test/src/639-specialfiles/main
+++ b/test/src/639-specialfiles/main
@@ -6,7 +6,7 @@ cvmfs_test_autofs_on_startup=false
 create_socket() {
   socket="$1"
 
-  python -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('$socket')" || return 1
+  python3 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('$socket')" || return 1
 }
 
 create_special_files() {


### PR DESCRIPTION
I think it's safe to start dropping python2 compatibility.