### PR TITLE
Fix race in cmake man page generation

### DIFF
--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
             --output=${MAN_OUTPUT_DIR}/cvmfs2.1
             --name "cvmfs2: fuse client for the CernVM-Filesystem" 
             "$<TARGET_FILE:cvmfs2>"
-        DEPENDS cvmfs2
+        DEPENDS cvmfs2 cvmfs_fuse3
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cvmfs/
         COMMENT "Generating man page for cvmfs2"
         VERBATIM

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
             --output=${MAN_OUTPUT_DIR}/cvmfs2.1
             --name "cvmfs2: fuse client for the CernVM-Filesystem" 
             "$<TARGET_FILE:cvmfs2>"
-        DEPENDS cvmfs2 cvmfs_fuse3
+        DEPENDS cvmfs2 cvmfs_fuse3 cvmfs_fuse3_stub
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cvmfs/
         COMMENT "Generating man page for cvmfs2"
         VERBATIM


### PR DESCRIPTION
When getting the output of cvmfs2, we need to ensure that the fuse library (that is dlopen'ed by cvmfs2) has been built already too.

Fixes #4070 

(This might make problems when building against libfuse2 - but that's already almost deprecated. The man page generation should just be disabled in that case. It's a good reminder to remove it completely from the build system)