### PR TITLE
feat(ducc): support publishing to CVMFS repository subdirectories

### DIFF
--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -58,8 +58,8 @@ var convertSingleImageCmd = &cobra.Command{
 		}
 
 		if !cvmfs.RepositoryExists(cvmfsRepo) {
-			l.Log().Error("The repository does not seem to exists.")
-			return fmt.Errorf("The repository does not seem to exists.")
+			l.Log().Errorf("The repository %s does not seem to exist.", cvmfsRepo)
+			return fmt.Errorf("The repository %s does not seem to exist.", cvmfsRepo)
 		}
 
 		input, err := lib.ParseImage(inputImage)

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -5,6 +5,35 @@ echo "WARNING: This is a mock command for testing of ducc that does noops and si
 # Since /cvmfs + reponame  and /var/spool/cvmfs is hardcoded,
 # CVMFS_TEST_REPO is expected to look like ../../../tmp/testrepofolder
 
+# Helper function to extract repo name from repo or repo:subdir or repo/subdir
+get_repo_name() {
+    local repo="$1"
+    # Handle colon separator (for testing): "../../tmp/mockrepo:subdir"
+    if [[ "$repo" == *":"* ]]; then
+        echo "${repo%%:*}"
+    else
+        # Handle slash separator: "repo.cern.ch/subdir" or "../tmp/mockrepo"
+        echo "${repo%%/*}"
+    fi
+}
+
+# Helper function to extract subdir from repo specification
+get_subdir() {
+    local repo="$1"
+    # Handle colon separator: "../../tmp/mockrepo:subdir"
+    if [[ "$repo" == *":"* ]]; then
+        local rest="${repo#*:}"
+        echo "${rest%/}"
+    elif [[ "$repo" == *"/"* ]] && [[ "$repo" != ".."* ]]; then
+        # Handle slash separator only for absolute paths: "repo.cern.ch/subdir"
+        local rest="${repo#*/}"
+        echo "${rest%/}"
+    else
+        # Relative paths like "../../tmp/mockrepo" have no subdir
+        echo ""
+    fi
+}
+
 
 if [ "$1" == "list" ]; then
   echo "testunpacked.cern.ch"
@@ -14,8 +43,12 @@ fi
 # Template transaction (cvmfs_server transaction -T /from:/to)
 # just do a copy
 if [ "$1" == "transaction" ]; then
-  arg2=$(echo $@ | cut -d ' ' -f 2)
-  if [ "$arg2" == "-T" ]; then
+  repo_arg=$(echo $@ | cut -d ' ' -f 2)
+  if [[ "$repo_arg" == *"/"* ]]; then
+      echo "Transaction opened for subdirectory: $repo_arg"
+  fi
+  
+  if [ "$repo_arg" == "-T" ]; then
     arg3=$(echo $@ | cut -d ' ' -f 3)
     from=$(echo $arg3 | cut -d '=' -f 1)
     to=$(echo $arg3 | cut -d '=' -f 2)
@@ -40,12 +73,26 @@ fi
 if [ "$1" == "ingest" ]; then
   arg2=$(echo $@ | cut -d ' ' -f 2)
   if [ "$arg2" == "--delete" ]; then
-    echo "deleting /$CVMFS_TEST_REPO/$3"
-    rm -rf /$CVMFS_TEST_REPO/$3
+    # Get the repo argument (last one)
+    repo_arg=$(echo $@ | awk '{print $NF}')
+    # Extract repo name and subdir
+    repo_name=$(get_repo_name "$repo_arg")
+    subdir=$(get_subdir "$repo_arg")
+    
+    # Get the path to delete (3rd argument after --delete)
+    delete_path=$(echo $@ | cut -d ' ' -f 3)
+    
+    # If there's a subdir, prepend it to the delete path
+    if [ -n "$subdir" ]; then
+        delete_path="$subdir/$delete_path"
+    fi
+    
+    echo "deleting /$CVMFS_TEST_REPO/$delete_path (repo: $repo_name, subdir: $subdir)"
+    rm -rf /$CVMFS_TEST_REPO/$delete_path
   fi
 fi
 
-# cvmfs_server ingest --catalog -t - -b <dir>
+# cvmfs_server ingest --catalog -t - -b <dir> <repo>
 arg2=$(echo $@ | cut -d ' ' -f 2)
 arg3=$(echo $@ | cut -d ' ' -f 3)
 arg4=$(echo $@ | cut -d ' ' -f 4)
@@ -55,9 +102,24 @@ if [ "$1" == "ingest" ]; then
     if [ "$arg3" == "-t" ]; then
       if [ "$arg4" == "-" ]; then
         if [ "$arg5" == "-b" ]; then
-          mkdir -p /$CVMFS_TEST_REPO/$6
+          # Get the base directory (6th argument)
+          base_dir="$6"
+          # Get the repo argument (7th argument)
+          repo_arg="$7"
+          
+          # Extract repo name and subdir
+          repo_name=$(get_repo_name "$repo_arg")
+          subdir=$(get_subdir "$repo_arg")
+          
+          # If there's a subdir, prepend it to the base directory
+          if [ -n "$subdir" ]; then
+              base_dir="$subdir/$base_dir"
+          fi
+          
+          echo "ingesting to $CVMFS_TEST_REPO/$base_dir (repo: $repo_name, subdir: $subdir)"
+          mkdir -p /$CVMFS_TEST_REPO/$base_dir
           cat - > /tmp/tmptar.tar
-          tar xf /tmp/tmptar.tar -C /$CVMFS_TEST_REPO/$6
+          tar xf /tmp/tmptar.tar -C /$CVMFS_TEST_REPO/$base_dir
         fi
       fi
     fi

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -5,12 +5,12 @@ echo "WARNING: This is a mock command for testing of ducc that does noops and si
 # Since /cvmfs + reponame  and /var/spool/cvmfs is hardcoded,
 # CVMFS_TEST_REPO is expected to look like ../../../tmp/testrepofolder
 
-# Helper function to extract repo name from repo or repo:subdir or repo/subdir
+# Helper function to extract repo name from repo or repo///subdir or repo/subdir
 get_repo_name() {
     local repo="$1"
-    # Handle colon separator (for testing): "../../tmp/mockrepo:subdir"
-    if [[ "$repo" == *":"* ]]; then
-        echo "${repo%%:*}"
+    # Handle triple-slash separator (for testing): "../../tmp/mockrepo///subdir"
+    if [[ "$repo" == *"///"* ]]; then
+        echo "${repo%%///*}"
     else
         # Handle slash separator: "repo.cern.ch/subdir" or "../tmp/mockrepo"
         echo "${repo%%/*}"
@@ -20,9 +20,9 @@ get_repo_name() {
 # Helper function to extract subdir from repo specification
 get_subdir() {
     local repo="$1"
-    # Handle colon separator: "../../tmp/mockrepo:subdir"
-    if [[ "$repo" == *":"* ]]; then
-        local rest="${repo#*:}"
+    # Handle triple-slash separator: "../../tmp/mockrepo///subdir"
+    if [[ "$repo" == *"///"* ]]; then
+        local rest="${repo#*///}"
         echo "${rest%/}"
     elif [[ "$repo" == *"/"* ]] && [[ "$repo" != ".."* ]]; then
         # Handle slash separator only for absolute paths: "repo.cern.ch/subdir"

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -36,8 +36,9 @@ func PublishToCVMFS(CVMFSRepo string, path string, target string) (err error) {
 	}()
 	l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Start ingesting")
 
-	repoName, subDir := GetRepoAndSubdir(CVMFSRepo)
-	path = filepath.Join("/", "cvmfs", repoName, subDir, path)
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	path = PrefixRepoSubdirOnce(CVMFSRepo, path)
+	path = filepath.Join("/", "cvmfs", repoName, path)
 
 	l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Start transaction")
 

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -36,7 +36,8 @@ func PublishToCVMFS(CVMFSRepo string, path string, target string) (err error) {
 	}()
 	l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Start ingesting")
 
-	path = filepath.Join("/", "cvmfs", CVMFSRepo, path)
+	repoName, subDir := GetRepoAndSubdir(CVMFSRepo)
+	path = filepath.Join("/", "cvmfs", repoName, subDir, path)
 
 	l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Start transaction")
 
@@ -466,14 +467,19 @@ func RemoveDirectory(CVMFSRepo string, dirPath ...string) error {
 }
 
 func CreateCatalogIntoDir(CVMFSRepo, dir string) (err error) {
-	catalogPath := filepath.Join("/", "cvmfs", CVMFSRepo, dir, ".cvmfscatalog")
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	normalizedDir := PrefixRepoSubdirOnce(CVMFSRepo, dir)
+	catalogRelativePath := filepath.Join(normalizedDir, ".cvmfscatalog")
+	catalogPath := filepath.Join("/", "cvmfs", repoName, catalogRelativePath)
 	if _, err := os.Stat(catalogPath); os.IsNotExist(err) {
 		tmpFile, err := ioutil.TempFile("", "tempCatalog")
-		tmpFile.Close()
 		if err != nil {
 			return err
 		}
-		err = PublishToCVMFS(CVMFSRepo, TrimCVMFSRepoPrefix(catalogPath), tmpFile.Name())
+		if err := tmpFile.Close(); err != nil {
+			return err
+		}
+		err = PublishToCVMFS(repoName, catalogRelativePath, tmpFile.Name())
 		if err != nil {
 			return err
 		}
@@ -512,7 +518,8 @@ func removeHashMarkerIfPresent(digest string) string {
 }
 
 func CreateSneakyChain(CVMFSRepo, newChainId, previousChainId string, layer tar.Reader) error {
-	sneakyPath := filepath.Join("/", "var", "spool", "cvmfs", CVMFSRepo, "scratch", "current")
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	sneakyPath := filepath.Join("/", "var", "spool", "cvmfs", repoName, "scratch", "current")
 	newChainPath := ChainPath(CVMFSRepo, newChainId)
 	dirtyChainPath := DirtyChainPath(CVMFSRepo, newChainId)
 	sneakyChainPath := filepath.Join(sneakyPath, TrimCVMFSRepoPrefix(newChainPath))

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -101,3 +101,83 @@ func TestPublishToSubdir(t *testing.T) {
 		t.Fatal("Published file content differs!")
 	}
 }
+
+func TestCreateCatalogIntoDirSubdir(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	subdirName := "catalog_target_subdir"
+	fullRepoPath := ".." + mockrepo + ":" + subdirName
+	dir := filepath.Join("catalog_test", "nested")
+
+	if err := CreateCatalogIntoDir(fullRepoPath, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPath := filepath.Join(mockrepo, subdirName, dir, ".cvmfscatalog")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("Expected catalog file missing at %s: %v", expectedPath, err)
+	}
+
+	wrongRootPath := filepath.Join(mockrepo, dir, ".cvmfscatalog")
+	if _, err := os.Stat(wrongRootPath); err == nil {
+		t.Fatalf("Catalog file was unexpectedly created in repository root: %s", wrongRootPath)
+	}
+}
+
+func TestIngestDeleteSubdirPathHandling(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	subdirName := "delete_target_subdir"
+	fullRepoPath := ".." + mockrepo + ":" + subdirName
+
+	tests := []struct {
+		name         string
+		deletePathFn func(repoRelativePath string) string
+	}{
+		{
+			name: "unprefixed_path",
+			deletePathFn: func(repoRelativePath string) string {
+				return repoRelativePath
+			},
+		},
+		{
+			name: "already_prefixed_path",
+			deletePathFn: func(repoRelativePath string) string {
+				return filepath.Join(subdirName, repoRelativePath)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoRelativePath := filepath.Join("delete_test", tt.name, "file")
+			target, err := os.CreateTemp("", "DeleteSubdirTestFile")
+			if err != nil {
+				t.Fatal(err)
+			}
+			content := []byte("delete_subdir_test_content")
+			if _, err := target.Write(content); err != nil {
+				t.Fatal(err)
+			}
+			if err := target.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := PublishToCVMFS(fullRepoPath, repoRelativePath, target.Name()); err != nil {
+				t.Fatal(err)
+			}
+
+			expectedPath := filepath.Join(mockrepo, subdirName, repoRelativePath)
+			if _, err := os.Stat(expectedPath); err != nil {
+				t.Fatalf("Expected test file missing at %s: %v", expectedPath, err)
+			}
+
+			deletePath := tt.deletePathFn(repoRelativePath)
+			if err := IngestDelete(fullRepoPath, deletePath); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
+				t.Fatalf("Expected file to be deleted at %s, stat error: %v", expectedPath, err)
+			}
+		})
+	}
+}

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -76,7 +76,7 @@ func TestPublishToSubdir(t *testing.T) {
 
 	// Create a subdirectory in the mock repo to simulate a pre-existing state or just target it
 	subdirName := "target_subdir"
-	fullRepoPath := ".." + mockrepo + ":" + subdirName
+	fullRepoPath := ".." + mockrepo + "///" + subdirName
 
 	f, _ := os.CreateTemp("", "PublishSubdirTestFile")
 	t.Log("SubdirTestFile:", f.Name())
@@ -105,7 +105,7 @@ func TestPublishToSubdir(t *testing.T) {
 func TestPublishToSubdirAlreadyPrefixedPath(t *testing.T) {
 	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
 	subdirName := "prefixed_target_subdir"
-	fullRepoPath := ".." + mockrepo + ":" + subdirName
+	fullRepoPath := ".." + mockrepo + "///" + subdirName
 
 	f, err := os.CreateTemp("", "PublishSubdirPrefixedPathTestFile")
 	if err != nil {
@@ -142,7 +142,7 @@ func TestPublishToSubdirAlreadyPrefixedPath(t *testing.T) {
 func TestCreateCatalogIntoDirSubdir(t *testing.T) {
 	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
 	subdirName := "catalog_target_subdir"
-	fullRepoPath := ".." + mockrepo + ":" + subdirName
+	fullRepoPath := ".." + mockrepo + "///" + subdirName
 	dir := filepath.Join("catalog_test", "nested")
 
 	if err := CreateCatalogIntoDir(fullRepoPath, dir); err != nil {
@@ -163,7 +163,7 @@ func TestCreateCatalogIntoDirSubdir(t *testing.T) {
 func TestIngestDeleteSubdirPathHandling(t *testing.T) {
 	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
 	subdirName := "delete_target_subdir"
-	fullRepoPath := ".." + mockrepo + ":" + subdirName
+	fullRepoPath := ".." + mockrepo + "///" + subdirName
 
 	tests := []struct {
 		name         string

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -102,6 +102,43 @@ func TestPublishToSubdir(t *testing.T) {
 	}
 }
 
+func TestPublishToSubdirAlreadyPrefixedPath(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	subdirName := "prefixed_target_subdir"
+	fullRepoPath := ".." + mockrepo + ":" + subdirName
+
+	f, err := os.CreateTemp("", "PublishSubdirPrefixedPathTestFile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("prefixed_subdir_test_content")
+	if _, err := f.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	alreadyPrefixedPath := filepath.Join(subdirName, "deep", "path", "file")
+	if err := PublishToCVMFS(fullRepoPath, alreadyPrefixedPath, f.Name()); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPath := filepath.Join(mockrepo, subdirName, "deep", "path", "file")
+	readback, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("Failed to read expected file %s: %v", expectedPath, err)
+	}
+	if !bytes.Equal(readback, content) {
+		t.Fatal("Published file content differs!")
+	}
+
+	duplicatedPath := filepath.Join(mockrepo, subdirName, subdirName, "deep", "path", "file")
+	if _, err := os.Stat(duplicatedPath); err == nil {
+		t.Fatalf("Unexpected duplicated subdir path created: %s", duplicatedPath)
+	}
+}
+
 func TestCreateCatalogIntoDirSubdir(t *testing.T) {
 	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
 	subdirName := "catalog_target_subdir"

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -69,3 +69,35 @@ func TestPublishToCVMFS(t *testing.T) {
 		t.Fatal("Published file on CVMFS differs!")
 	}
 }
+
+func TestPublishToSubdir(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	t.Log("Mockrepo:", mockrepo)
+
+	// Create a subdirectory in the mock repo to simulate a pre-existing state or just target it
+	subdirName := "target_subdir"
+	fullRepoPath := ".." + mockrepo + ":" + subdirName
+
+	f, _ := os.CreateTemp("", "PublishSubdirTestFile")
+	t.Log("SubdirTestFile:", f.Name())
+	content := []byte("subdir_test_content")
+	f.Write(content)
+
+	// Publish to a sub-path within the subdirectory
+	// Logic: ducc should extract 'mockrepo' as the scratch base, but put files into 'subdirName/deep/path'
+	err := PublishToCVMFS(fullRepoPath, "deep/path/file", f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verification
+	// The file should exist at mockrepo/subdirName/deep/path/file
+	expectedPath := filepath.Join(mockrepo, subdirName, "deep", "path", "file")
+	readback, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("Failed to read back file from expected path %s: %v", expectedPath, err)
+	}
+	if !bytes.Equal(readback, content) {
+		t.Fatal("Published file content differs!")
+	}
+}

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -158,8 +158,19 @@ func RepositoryExists(CVMFSRepo string) bool {
 }
 
 func repositoryExistsInList(stdoutString, repo string) bool {
+	candidates := map[string]struct{}{
+		repo: {},
+	}
+	if strings.HasPrefix(repo, "/") {
+		candidates[strings.TrimPrefix(repo, "/")] = struct{}{}
+		candidates[".."+repo] = struct{}{}
+	}
+	if strings.HasPrefix(repo, "..") {
+		candidates[strings.TrimPrefix(repo, "..")] = struct{}{}
+	}
+
 	for _, line := range strings.Split(stdoutString, "\n") {
-		if strings.TrimSpace(line) == repo {
+		if _, ok := candidates[strings.TrimSpace(line)]; ok {
 			return true
 		}
 	}

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -97,8 +97,9 @@ func OpenTransaction(CVMFSRepo string, options ...TransactionOption) error {
 }
 
 func Publish(CVMFSRepo string) error {
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	defer unlock(CVMFSRepo)
-	err := exec.ExecCommand("cvmfs_server", "publish", CVMFSRepo).Start()
+	err := exec.ExecCommand("cvmfs_server", "publish", repoName).Start()
 	if err != nil {
 		l.LogE(err).WithFields(
 			log.Fields{"repo": CVMFSRepo}).
@@ -125,7 +126,8 @@ func Abort(CVMFSRepo string) error {
 }
 
 func abort(CVMFSRepo string) error {
-	return exec.ExecCommand("cvmfs_server", "abort", "-f", CVMFSRepo).Start()
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	return exec.ExecCommand("cvmfs_server", "abort", "-f", repoName).Start()
 }
 
 func RepositoryExists(CVMFSRepo string) bool {
@@ -139,7 +141,7 @@ func RepositoryExists(CVMFSRepo string) bool {
 	stdoutString := string(stdout.Bytes())
 
 	// remove sub directory in case it was passed
-	repo, _, _ := strings.Cut(CVMFSRepo, "/")
+	repo, _ := GetRepoAndSubdir(CVMFSRepo)
 	if strings.Contains(stdoutString, repo) {
 		return true
 	} else {
@@ -160,18 +162,21 @@ func WithinTransaction(CVMFSRepo string, f func() error, opts ...TransactionOpti
 }
 
 func Ingest(CVMFSRepo string, input io.ReadCloser, options ...string) error {
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	cmd := []string{"cvmfs_server", "ingest"}
 	for _, opt := range options {
 		cmd = append(cmd, opt)
 	}
-	cmd = append(cmd, CVMFSRepo)
+	cmd = append(cmd, repoName)
 	getLock(CVMFSRepo)
 	defer unlock(CVMFSRepo)
 	return exec.ExecCommand(cmd...).StdIn(input).Start()
 }
 
 func IngestDelete(CVMFSRepo string, path string) error {
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	path = PrefixRepoSubdirOnce(CVMFSRepo, path)
 	getLock(CVMFSRepo)
 	defer unlock(CVMFSRepo)
-	return exec.ExecCommand("cvmfs_server", "ingest", "--delete", path, CVMFSRepo).Start()
+	return exec.ExecCommand("cvmfs_server", "ingest", "--delete", path, repoName).Start()
 }

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -138,7 +138,9 @@ func RepositoryExists(CVMFSRepo string) bool {
 	}
 	stdoutString := string(stdout.Bytes())
 
-	if strings.Contains(stdoutString, CVMFSRepo) {
+	// remove sub directory in case it was passed
+	repo, _, _ := strings.Cut(CVMFSRepo, "/")
+	if strings.Contains(stdoutString, repo) {
 		return true
 	} else {
 		return false

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -38,6 +38,11 @@ func lockRepoKey(CVMFSRepo string) string {
 	return repoName
 }
 
+func transactionRepoName(CVMFSRepo string) string {
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	return repoName
+}
+
 func getLock(CVMFSRepo string) {
 	key := lockRepoKey(CVMFSRepo)
 	lockMap.Lock()
@@ -82,7 +87,7 @@ func ExecuteAndOpenTransaction(CVMFSRepo string, f func() error, options ...Tran
 	for _, opt := range options {
 		cmd = append(cmd, opt.ToString())
 	}
-	cmd = append(cmd, CVMFSRepo)
+	cmd = append(cmd, transactionRepoName(CVMFSRepo))
 	getLock(CVMFSRepo)
 	if err := f(); err != nil {
 		unlock(CVMFSRepo)

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -33,18 +33,24 @@ var locksMap = make(map[string]*sync.Mutex)
 var locksFile = make(map[string]fSLock)
 var lockMap = &sync.Mutex{}
 
+func lockRepoKey(CVMFSRepo string) string {
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	return repoName
+}
+
 func getLock(CVMFSRepo string) {
+	key := lockRepoKey(CVMFSRepo)
 	lockMap.Lock()
-	lc := locksMap[CVMFSRepo]
+	lc := locksMap[key]
 	if lc == nil {
-		locksMap[CVMFSRepo] = &sync.Mutex{}
-		lc = locksMap[CVMFSRepo]
+		locksMap[key] = &sync.Mutex{}
+		lc = locksMap[key]
 	}
-	f := locksFile[CVMFSRepo]
+	f := locksFile[key]
 	if f == nil {
 		f = newFSLock("/tmp/DUCC.lock")
-		locksFile[CVMFSRepo] = f
-		f = locksFile[CVMFSRepo]
+		locksFile[key] = f
+		f = locksFile[key]
 	}
 	lockMap.Unlock()
 
@@ -61,9 +67,10 @@ func getLock(CVMFSRepo string) {
 }
 
 func unlock(CVMFSRepo string) {
+	key := lockRepoKey(CVMFSRepo)
 	lockMap.Lock()
-	l := locksMap[CVMFSRepo]
-	f := locksFile[CVMFSRepo]
+	l := locksMap[key]
+	f := locksFile[key]
 	lockMap.Unlock()
 
 	l.Unlock()

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -170,8 +170,15 @@ func repositoryExistsInList(stdoutString, repo string) bool {
 	}
 
 	for _, line := range strings.Split(stdoutString, "\n") {
-		if _, ok := candidates[strings.TrimSpace(line)]; ok {
+		line = strings.TrimSpace(line)
+		if _, ok := candidates[line]; ok {
 			return true
+		}
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			if _, ok := candidates[fields[0]]; ok {
+				return true
+			}
 		}
 	}
 	return false

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -154,11 +154,16 @@ func RepositoryExists(CVMFSRepo string) bool {
 
 	// remove sub directory in case it was passed
 	repo, _ := GetRepoAndSubdir(CVMFSRepo)
-	if strings.Contains(stdoutString, repo) {
-		return true
-	} else {
-		return false
+	return repositoryExistsInList(stdoutString, repo)
+}
+
+func repositoryExistsInList(stdoutString, repo string) bool {
+	for _, line := range strings.Split(stdoutString, "\n") {
+		if strings.TrimSpace(line) == repo {
+			return true
+		}
 	}
+	return false
 }
 
 func WithinTransaction(CVMFSRepo string, f func() error, opts ...TransactionOption) error {

--- a/ducc/cvmfs/raw_test.go
+++ b/ducc/cvmfs/raw_test.go
@@ -1,0 +1,27 @@
+package cvmfs
+
+import "testing"
+
+func TestLockRepoKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain_repo", "repo.cern.ch", "repo.cern.ch"},
+		{"repo_with_subdir_slash", "repo.cern.ch/ducc/subdir", "repo.cern.ch"},
+		{"repo_with_subdir_colon", "repo.cern.ch:ducc/subdir", "repo.cern.ch"},
+		{"mock_repo_with_subdir", "../../tmp/mockrepo:target_subdir", "../../tmp/mockrepo"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := lockRepoKey(tc.input)
+			if got != tc.expected {
+				t.Fatalf("lockRepoKey(%q)=%q, expected %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+

--- a/ducc/cvmfs/raw_test.go
+++ b/ducc/cvmfs/raw_test.go
@@ -49,7 +49,7 @@ func TestTransactionRepoName(t *testing.T) {
 }
 
 func TestRepositoryExistsInList(t *testing.T) {
-	list := "test.cern.ch\nrepo.cern.ch\nrepo.cern.chx\n../../tmp/mockrepo\n"
+	list := "test.cern.ch\nrepo.cern.ch\nrepo.cern.chx\n../../tmp/mockrepo\nrepo-decorated.cern.ch [stratum0]\n"
 	cases := []struct {
 		name     string
 		repo     string
@@ -59,6 +59,7 @@ func TestRepositoryExistsInList(t *testing.T) {
 		{name: "no_false_positive_on_prefix", repo: "repo.cern", expected: false},
 		{name: "no_false_positive_on_suffix", repo: "repo.cern.ch-extra", expected: false},
 		{name: "legacy_mock_list_prefix", repo: "/../../tmp/mockrepo", expected: true},
+		{name: "decorated_repo_line", repo: "repo-decorated.cern.ch", expected: true},
 		{name: "missing_repo", repo: "absent.cern.ch", expected: false},
 	}
 

--- a/ducc/cvmfs/raw_test.go
+++ b/ducc/cvmfs/raw_test.go
@@ -47,3 +47,27 @@ func TestTransactionRepoName(t *testing.T) {
 		})
 	}
 }
+
+func TestRepositoryExistsInList(t *testing.T) {
+	list := "test.cern.ch\nrepo.cern.ch\nrepo.cern.chx\n"
+	cases := []struct {
+		name     string
+		repo     string
+		expected bool
+	}{
+		{name: "exact_match", repo: "repo.cern.ch", expected: true},
+		{name: "no_false_positive_on_prefix", repo: "repo.cern", expected: false},
+		{name: "no_false_positive_on_suffix", repo: "repo.cern.ch-extra", expected: false},
+		{name: "missing_repo", repo: "absent.cern.ch", expected: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := repositoryExistsInList(list, tc.repo)
+			if got != tc.expected {
+				t.Fatalf("repositoryExistsInList(%q)=%v, expected %v", tc.repo, got, tc.expected)
+			}
+		})
+	}
+}

--- a/ducc/cvmfs/raw_test.go
+++ b/ducc/cvmfs/raw_test.go
@@ -10,8 +10,8 @@ func TestLockRepoKey(t *testing.T) {
 	}{
 		{"plain_repo", "repo.cern.ch", "repo.cern.ch"},
 		{"repo_with_subdir_slash", "repo.cern.ch/ducc/subdir", "repo.cern.ch"},
-		{"repo_with_subdir_colon", "repo.cern.ch:ducc/subdir", "repo.cern.ch"},
-		{"mock_repo_with_subdir", "../../tmp/mockrepo:target_subdir", "../../tmp/mockrepo"},
+		{"repo_with_subdir_triple_slash", "repo.cern.ch///ducc/subdir", "repo.cern.ch"},
+		{"mock_repo_with_subdir", "../../tmp/mockrepo///target_subdir", "../../tmp/mockrepo"},
 	}
 
 	for _, tc := range cases {
@@ -33,8 +33,8 @@ func TestTransactionRepoName(t *testing.T) {
 	}{
 		{"plain_repo", "repo.cern.ch", "repo.cern.ch"},
 		{"repo_with_subdir_slash", "repo.cern.ch/ducc/subdir", "repo.cern.ch"},
-		{"repo_with_subdir_colon", "repo.cern.ch:ducc/subdir", "repo.cern.ch"},
-		{"mock_repo_with_subdir", "../../tmp/mockrepo:target_subdir", "../../tmp/mockrepo"},
+		{"repo_with_subdir_triple_slash", "repo.cern.ch///ducc/subdir", "repo.cern.ch"},
+		{"mock_repo_with_subdir", "../../tmp/mockrepo///target_subdir", "../../tmp/mockrepo"},
 	}
 
 	for _, tc := range cases {

--- a/ducc/cvmfs/raw_test.go
+++ b/ducc/cvmfs/raw_test.go
@@ -49,7 +49,7 @@ func TestTransactionRepoName(t *testing.T) {
 }
 
 func TestRepositoryExistsInList(t *testing.T) {
-	list := "test.cern.ch\nrepo.cern.ch\nrepo.cern.chx\n"
+	list := "test.cern.ch\nrepo.cern.ch\nrepo.cern.chx\n../../tmp/mockrepo\n"
 	cases := []struct {
 		name     string
 		repo     string
@@ -58,6 +58,7 @@ func TestRepositoryExistsInList(t *testing.T) {
 		{name: "exact_match", repo: "repo.cern.ch", expected: true},
 		{name: "no_false_positive_on_prefix", repo: "repo.cern", expected: false},
 		{name: "no_false_positive_on_suffix", repo: "repo.cern.ch-extra", expected: false},
+		{name: "legacy_mock_list_prefix", repo: "/../../tmp/mockrepo", expected: true},
 		{name: "missing_repo", repo: "absent.cern.ch", expected: false},
 	}
 

--- a/ducc/cvmfs/raw_test.go
+++ b/ducc/cvmfs/raw_test.go
@@ -25,3 +25,25 @@ func TestLockRepoKey(t *testing.T) {
 	}
 }
 
+func TestTransactionRepoName(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain_repo", "repo.cern.ch", "repo.cern.ch"},
+		{"repo_with_subdir_slash", "repo.cern.ch/ducc/subdir", "repo.cern.ch"},
+		{"repo_with_subdir_colon", "repo.cern.ch:ducc/subdir", "repo.cern.ch"},
+		{"mock_repo_with_subdir", "../../tmp/mockrepo:target_subdir", "../../tmp/mockrepo"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := transactionRepoName(tc.input)
+			if got != tc.expected {
+				t.Fatalf("transactionRepoName(%q)=%q, expected %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/ducc/cvmfs/utils.go
+++ b/ducc/cvmfs/utils.go
@@ -11,17 +11,19 @@ import (
 // component is the repository name and the rest is the subdirectory path.
 //
 // For testing with mock repositories (relative paths like "../../tmp/mockrepo"),
-// use a colon separator: "../../tmp/mockrepo:subdir" to avoid ambiguity with
-// the slashes in the relative path itself.
+// use a triple-slash separator: "../../tmp/mockrepo///subdir" to avoid ambiguity
+// with the slashes in the relative path itself. The string stays a valid path
+// (multiple / are treated as one by the OS) and avoids headaches with filepaths
+// that could contain literal colons.
 //
 // Examples:
-//   - "unpacked.cern.ch"           → ("unpacked.cern.ch", "")
-//   - "unpacked.cern.ch/images"    → ("unpacked.cern.ch", "images")
-//   - "../../tmp/mock:subdir"      → ("../../tmp/mock", "subdir")
+//   - "unpacked.cern.ch"              → ("unpacked.cern.ch", "")
+//   - "unpacked.cern.ch/images"       → ("unpacked.cern.ch", "images")
+//   - "../../tmp/mock///subdir"       → ("../../tmp/mock", "subdir")
 func GetRepoAndSubdir(cvmfsRepo string) (repoName, subDir string) {
-	if strings.Contains(cvmfsRepo, ":") {
-		repoName, subDir, _ = strings.Cut(cvmfsRepo, ":")
-		subDir = strings.TrimSuffix(subDir, "/")
+	if idx := strings.Index(cvmfsRepo, "///"); idx >= 0 {
+		repoName = cvmfsRepo[:idx]
+		subDir = strings.TrimSuffix(cvmfsRepo[idx+3:], "/")
 		return
 	}
 	if strings.HasPrefix(cvmfsRepo, "..") || strings.HasPrefix(cvmfsRepo, "/..") {

--- a/ducc/cvmfs/utils.go
+++ b/ducc/cvmfs/utils.go
@@ -27,6 +27,13 @@ func GetRepoAndSubdir(cvmfsRepo string) (repoName, subDir string) {
 	if strings.HasPrefix(cvmfsRepo, "..") || strings.HasPrefix(cvmfsRepo, "/..") {
 		return cvmfsRepo, ""
 	}
+	if strings.HasPrefix(cvmfsRepo, "/") {
+		if strings.HasPrefix(cvmfsRepo, "/cvmfs/") {
+			cvmfsRepo = strings.TrimPrefix(cvmfsRepo, "/cvmfs/")
+		} else {
+			return strings.TrimSuffix(cvmfsRepo, "/"), ""
+		}
+	}
 	repoName, subDir, _ = strings.Cut(cvmfsRepo, "/")
 	subDir = strings.TrimSuffix(subDir, "/")
 	return

--- a/ducc/cvmfs/utils.go
+++ b/ducc/cvmfs/utils.go
@@ -1,0 +1,58 @@
+package cvmfs
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// GetRepoAndSubdir splits a CVMFSRepo specification into repository name and subdirectory.
+//
+// In production, repository paths look like "repo.cern.ch/subdir" where the first
+// component is the repository name and the rest is the subdirectory path.
+//
+// For testing with mock repositories (relative paths like "../../tmp/mockrepo"),
+// use a colon separator: "../../tmp/mockrepo:subdir" to avoid ambiguity with
+// the slashes in the relative path itself.
+//
+// Examples:
+//   - "unpacked.cern.ch"           → ("unpacked.cern.ch", "")
+//   - "unpacked.cern.ch/images"    → ("unpacked.cern.ch", "images")
+//   - "../../tmp/mock:subdir"      → ("../../tmp/mock", "subdir")
+func GetRepoAndSubdir(cvmfsRepo string) (repoName, subDir string) {
+	if strings.Contains(cvmfsRepo, ":") {
+		repoName, subDir, _ = strings.Cut(cvmfsRepo, ":")
+		subDir = strings.TrimSuffix(subDir, "/")
+		return
+	}
+	if strings.HasPrefix(cvmfsRepo, "..") || strings.HasPrefix(cvmfsRepo, "/..") {
+		return cvmfsRepo, ""
+	}
+	repoName, subDir, _ = strings.Cut(cvmfsRepo, "/")
+	subDir = strings.TrimSuffix(subDir, "/")
+	return
+}
+
+// PrefixRepoSubdirOnce ensures repoPath is relative and prefixed with the repo
+// subdirectory exactly once.
+func PrefixRepoSubdirOnce(cvmfsRepo, repoPath string) string {
+	_, subDir := GetRepoAndSubdir(cvmfsRepo)
+
+	relativePath := strings.TrimLeft(repoPath, "/")
+	relativePath = filepath.Clean(relativePath)
+	if relativePath == "." {
+		relativePath = ""
+	}
+
+	if subDir == "" {
+		return relativePath
+	}
+
+	separator := string(filepath.Separator)
+	if relativePath == subDir || strings.HasPrefix(relativePath, subDir+separator) {
+		return relativePath
+	}
+	if relativePath == "" {
+		return subDir
+	}
+	return filepath.Join(subDir, relativePath)
+}

--- a/ducc/cvmfs/utils_test.go
+++ b/ducc/cvmfs/utils_test.go
@@ -18,6 +18,9 @@ func TestGetRepoAndSubdir(t *testing.T) {
 		{"../../tmp/mockrepo", "../../tmp/mockrepo", ""},
 		{"../../tmp/mockrepo:subdir", "../../tmp/mockrepo", "subdir"},
 		{"/../../tmp/mockrepo", "/../../tmp/mockrepo", ""},
+		{"/tmp/mockrepo", "/tmp/mockrepo", ""},
+		{"/tmp/mockrepo/subdir", "/tmp/mockrepo/subdir", ""},
+		{"/cvmfs/repo.cern.ch/subdir", "repo.cern.ch", "subdir"},
 		// Edge cases
 		{"", "", ""},                                       // empty input
 		{"repo.cern.ch/", "repo.cern.ch", ""},              // trailing slash on repo
@@ -34,6 +37,16 @@ func TestGetRepoAndSubdir(t *testing.T) {
 				t.Errorf("GetRepoAndSubdir() gotSubDir = %v, want %v", gotSubDir, tt.wantSubDir)
 			}
 		})
+	}
+}
+
+func TestGetRepoAndSubdirAbsolutePathKeepsRepoName(t *testing.T) {
+	repo, subdir := GetRepoAndSubdir("/tmp/mockrepo")
+	if repo == "" {
+		t.Fatal("GetRepoAndSubdir returned an empty repository name for an absolute path")
+	}
+	if subdir != "" {
+		t.Fatalf("GetRepoAndSubdir returned unexpected subdir %q for an absolute path", subdir)
 	}
 }
 

--- a/ducc/cvmfs/utils_test.go
+++ b/ducc/cvmfs/utils_test.go
@@ -11,12 +11,12 @@ func TestGetRepoAndSubdir(t *testing.T) {
 		// Basic cases
 		{"repo.cern.ch", "repo.cern.ch", ""},
 		{"repo.cern.ch/subdir", "repo.cern.ch", "subdir"},
-		{"repo.cern.ch:subdir", "repo.cern.ch", "subdir"},
+		{"repo.cern.ch///subdir", "repo.cern.ch", "subdir"},
 		{"repo.cern.ch/nested/subdir", "repo.cern.ch", "nested/subdir"},
-		{"repo.cern.ch:nested/subdir", "repo.cern.ch", "nested/subdir"},
+		{"repo.cern.ch///nested/subdir", "repo.cern.ch", "nested/subdir"},
 		// Relative paths (for testing)
 		{"../../tmp/mockrepo", "../../tmp/mockrepo", ""},
-		{"../../tmp/mockrepo:subdir", "../../tmp/mockrepo", "subdir"},
+		{"../../tmp/mockrepo///subdir", "../../tmp/mockrepo", "subdir"},
 		{"/../../tmp/mockrepo", "/../../tmp/mockrepo", ""},
 		{"/tmp/mockrepo", "/tmp/mockrepo", ""},
 		{"/tmp/mockrepo/subdir", "/tmp/mockrepo/subdir", ""},
@@ -94,8 +94,8 @@ func TestPrefixRepoSubdirOnce(t *testing.T) {
 			expected: "compat",
 		},
 		{
-			name:     "mock_repo_colon_separator",
-			repo:     "../../tmp/mockrepo:target_subdir",
+			name:     "mock_repo_triple_slash_separator",
+			repo:     "../../tmp/mockrepo///target_subdir",
 			path:     ".layers/aa",
 			expected: "target_subdir/.layers/aa",
 		},

--- a/ducc/cvmfs/utils_test.go
+++ b/ducc/cvmfs/utils_test.go
@@ -1,0 +1,38 @@
+package cvmfs
+
+import "testing"
+
+func TestGetRepoAndSubdir(t *testing.T) {
+	tests := []struct {
+		input        string
+		wantRepoName string
+		wantSubDir   string
+	}{
+		// Basic cases
+		{"repo.cern.ch", "repo.cern.ch", ""},
+		{"repo.cern.ch/subdir", "repo.cern.ch", "subdir"},
+		{"repo.cern.ch:subdir", "repo.cern.ch", "subdir"},
+		{"repo.cern.ch/nested/subdir", "repo.cern.ch", "nested/subdir"},
+		{"repo.cern.ch:nested/subdir", "repo.cern.ch", "nested/subdir"},
+		// Relative paths (for testing)
+		{"../../tmp/mockrepo", "../../tmp/mockrepo", ""},
+		{"../../tmp/mockrepo:subdir", "../../tmp/mockrepo", "subdir"},
+		{"/../../tmp/mockrepo", "/../../tmp/mockrepo", ""},
+		// Edge cases
+		{"", "", ""},                                       // empty input
+		{"repo.cern.ch/", "repo.cern.ch", ""},              // trailing slash on repo
+		{"repo.cern.ch/subdir/", "repo.cern.ch", "subdir"}, // trailing slash in subdir
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotRepoName, gotSubDir := GetRepoAndSubdir(tt.input)
+			if gotRepoName != tt.wantRepoName {
+				t.Errorf("GetRepoAndSubdir() gotRepoName = %v, want %v", gotRepoName, tt.wantRepoName)
+			}
+			if gotSubDir != tt.wantSubDir {
+				t.Errorf("GetRepoAndSubdir() gotSubDir = %v, want %v", gotSubDir, tt.wantSubDir)
+			}
+		})
+	}
+}

--- a/ducc/cvmfs/utils_test.go
+++ b/ducc/cvmfs/utils_test.go
@@ -36,3 +36,64 @@ func TestGetRepoAndSubdir(t *testing.T) {
 		})
 	}
 }
+
+func TestPrefixRepoSubdirOnce(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "root_repo_path_unchanged",
+			repo:     "repo.cern.ch",
+			path:     ".chains/ab/test",
+			expected: ".chains/ab/test",
+		},
+		{
+			name:     "subdir_repo_prefix_added",
+			repo:     "repo.cern.ch/compat",
+			path:     ".chains/ab/test",
+			expected: "compat/.chains/ab/test",
+		},
+		{
+			name:     "subdir_repo_prefix_not_duplicated",
+			repo:     "repo.cern.ch/compat",
+			path:     "compat/.chains/ab/test",
+			expected: "compat/.chains/ab/test",
+		},
+		{
+			name:     "absolute_path_is_normalized",
+			repo:     "repo.cern.ch/compat",
+			path:     "/compat/.chains/ab/test",
+			expected: "compat/.chains/ab/test",
+		},
+		{
+			name:     "similar_prefix_is_not_treated_as_equal",
+			repo:     "repo.cern.ch/compat",
+			path:     "compat2/.chains/ab/test",
+			expected: "compat/compat2/.chains/ab/test",
+		},
+		{
+			name:     "empty_path_points_to_subdir_root",
+			repo:     "repo.cern.ch/compat",
+			path:     "",
+			expected: "compat",
+		},
+		{
+			name:     "mock_repo_colon_separator",
+			repo:     "../../tmp/mockrepo:target_subdir",
+			path:     ".layers/aa",
+			expected: "target_subdir/.layers/aa",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PrefixRepoSubdirOnce(tt.repo, tt.path)
+			if got != tt.expected {
+				t.Errorf("PrefixRepoSubdirOnce() got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -488,7 +488,7 @@ func CreateThinImage(manifest da.Manifest, layerLocations map[string]string, inp
 		return
 	}
 
-	dockerClient, err := client.NewClientWithOpts(client.WithVersion("1.19"))
+	dockerClient, err := NewDockerClient()
 	if err != nil {
 		return
 	}
@@ -537,7 +537,7 @@ func PushImageToRegistry(outputImage Image) (err error) {
 	pushOptions := dockerImage.PushOptions{
 		RegistryAuth: authCredential,
 	}
-	dockerClient, err := client.NewClientWithOpts(client.WithVersion("1.19"))
+	dockerClient, err := NewDockerClient()
 	if err != nil {
 		return err
 	}
@@ -560,6 +560,15 @@ func PushImageToRegistry(outputImage Image) (err error) {
 	}
 	l.Log().Info("Finish pushing the image to the registry")
 	return
+}
+
+// NewDockerClient creates a Docker client that negotiates the API version with
+// the daemon to stay compatible across Docker releases.
+func NewDockerClient() (*client.Client, error) {
+	return client.NewClientWithOpts(
+		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
+	)
 }
 
 func StoreLayerInfo(CVMFSRepo string, layerDigest string, r ReadHashCloseSizer) (err error) {

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -263,6 +263,12 @@ func outputImageForExpandedTag(inputImage, outputImage *Image, expandedTag strin
 	return outputWithTag
 }
 
+func outputRepositoryForImport(outputImage Image) string {
+	outputRepository := outputImage
+	outputRepository.Tag = ""
+	return outputRepository.GetSimpleName()
+}
+
 func ConvertWishPodman(wish WishFriendly, convertAgain bool) (err error) {
 	var firstError error
 	for _, expandedImgTag := range wish.ExpandedTagImagesLayer {
@@ -509,7 +515,7 @@ func CreateThinImage(manifest da.Manifest, layerLocations map[string]string, inp
 	importResult, err := dockerClient.ImageImport(
 		context.Background(),
 		image,
-		outputImage.GetSimpleName(),
+		outputRepositoryForImport(outputImage),
 		importOptions)
 	if err != nil {
 		l.LogE(err).Error("Error in image import")

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -226,12 +226,7 @@ func ConvertWishDocker(wish WishFriendly) (err error) {
 	var firstError error
 	for _, expandedImgTag := range wish.ExpandedTagImagesLayer {
 		tag := expandedImgTag.Tag
-		outputWithTag := *outputImage
-		if inputImage.TagWildcard {
-			outputWithTag.Tag = tag
-		} else {
-			outputWithTag.Tag = outputImage.Tag
-		}
+		outputWithTag := outputImageForExpandedTag(inputImage, outputImage, tag)
 
 		manifestPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, ".metadata", expandedImgTag.GetSimpleName(), "manifest.json")
 		if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
@@ -248,16 +243,24 @@ func ConvertWishDocker(wish WishFriendly) (err error) {
 			layerPath := cvmfs.LayerRootfsPath(wish.CvmfsRepo, layerDigest)
 			layerLocations[layer.Digest] = layerPath
 		}
-		err = CreateThinImage(manifest, layerLocations, *expandedImgTag, *outputImage)
+		err = CreateThinImage(manifest, layerLocations, *expandedImgTag, outputWithTag)
 		if err != nil && firstError == nil {
 			firstError = err
 		}
-		err = PushImageToRegistry(*outputImage)
+		err = PushImageToRegistry(outputWithTag)
 		if err != nil && firstError == nil {
 			firstError = err
 		}
 	}
 	return firstError
+}
+
+func outputImageForExpandedTag(inputImage, outputImage *Image, expandedTag string) Image {
+	outputWithTag := *outputImage
+	if inputImage.TagWildcard {
+		outputWithTag.Tag = expandedTag
+	}
+	return outputWithTag
 }
 
 func ConvertWishPodman(wish WishFriendly, convertAgain bool) (err error) {

--- a/ducc/lib/conversion_test.go
+++ b/ducc/lib/conversion_test.go
@@ -1,0 +1,29 @@
+package lib
+
+import "testing"
+
+func TestOutputImageForExpandedTagWildcard(t *testing.T) {
+	input := &Image{TagWildcard: true}
+	output := &Image{Registry: "localhost:5000", Repository: "mock/repo", Tag: "*"}
+
+	got := outputImageForExpandedTag(input, output, "v1")
+
+	if got.Tag != "v1" {
+		t.Fatalf("expected resolved tag v1, got %q", got.Tag)
+	}
+	if got.Registry != output.Registry || got.Repository != output.Repository {
+		t.Fatalf("output image fields changed unexpectedly: got %s/%s", got.Registry, got.Repository)
+	}
+}
+
+func TestOutputImageForExpandedTagFixedTag(t *testing.T) {
+	input := &Image{TagWildcard: false}
+	output := &Image{Registry: "localhost:5000", Repository: "mock/repo", Tag: "stable"}
+
+	got := outputImageForExpandedTag(input, output, "ignored")
+
+	if got.Tag != "stable" {
+		t.Fatalf("expected fixed tag stable, got %q", got.Tag)
+	}
+}
+

--- a/ducc/lib/conversion_test.go
+++ b/ducc/lib/conversion_test.go
@@ -27,3 +27,12 @@ func TestOutputImageForExpandedTagFixedTag(t *testing.T) {
 	}
 }
 
+func TestOutputRepositoryForImport(t *testing.T) {
+	output := Image{Registry: "localhost:5000", Repository: "mock/repo", Tag: "stable"}
+
+	got := outputRepositoryForImport(output)
+
+	if got != "localhost:5000/mock/repo" {
+		t.Fatalf("expected repository-only reference, got %q", got)
+	}
+}

--- a/ducc/lib/garbage_collection.go
+++ b/ducc/lib/garbage_collection.go
@@ -20,20 +20,22 @@ func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, C
 	if pathsPerBatchCommand < 1 {
 		return nil, errors.New("Num of paths per batch command must be greater than zero")
 	}
+	repoName, _ := cvmfs.GetRepoAndSubdir(CVMFSRepo)
 
 	// we send pathsPerBatchCommand folders to deletion at a time
 	commandPrefix := []string{"cvmfs_server", "ingest"}
 	commands := make([][]string, 0)
 	command := commandPrefix
 	for i, path := range pathsToDelete {
+		path = cvmfs.PrefixRepoSubdirOnce(CVMFSRepo, path)
 		if i%pathsPerBatchCommand == 0 && i > 0 {
-			command = append(command, CVMFSRepo)
+			command = append(command, repoName)
 			commands = append(commands, command)
 			command = commandPrefix
 		}
 		command = append(command, "--delete", path)
 	}
-	command = append(command, CVMFSRepo)
+	command = append(command, repoName)
 	commands = append(commands, command)
 
 	return commands, nil

--- a/ducc/lib/garbage_collection_test.go
+++ b/ducc/lib/garbage_collection_test.go
@@ -44,7 +44,7 @@ func TestConstructDeleteCommandsSubdir(t *testing.T) {
 
 func TestConstructDeleteCommandsSubdirMockRepoFormat(t *testing.T) {
 	paths := []string{".layers/aa", "target_subdir/.layers/bb"}
-	commands, _ := ConstructDeleteCommands(paths, 10, "../../tmp/mockrepo:target_subdir")
+	commands, _ := ConstructDeleteCommands(paths, 10, "../../tmp/mockrepo///target_subdir")
 	if len(commands) != 1 {
 		t.Errorf("Delete command missing")
 	}

--- a/ducc/lib/garbage_collection_test.go
+++ b/ducc/lib/garbage_collection_test.go
@@ -30,3 +30,25 @@ func TestConstructDeleteCommands(t *testing.T) {
 		t.Errorf("Wrong delete command")
 	}
 }
+
+func TestConstructDeleteCommandsSubdir(t *testing.T) {
+	paths := []string{".layers/aa", "compat/.layers/bb"}
+	commands, _ := ConstructDeleteCommands(paths, 10, "repo.cern.ch/compat")
+	if len(commands) != 1 {
+		t.Errorf("Delete command missing")
+	}
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete compat/.layers/aa --delete compat/.layers/bb repo.cern.ch" {
+		t.Errorf("Wrong delete command for subdir repo")
+	}
+}
+
+func TestConstructDeleteCommandsSubdirMockRepoFormat(t *testing.T) {
+	paths := []string{".layers/aa", "target_subdir/.layers/bb"}
+	commands, _ := ConstructDeleteCommands(paths, 10, "../../tmp/mockrepo:target_subdir")
+	if len(commands) != 1 {
+		t.Errorf("Delete command missing")
+	}
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete target_subdir/.layers/aa --delete target_subdir/.layers/bb ../../tmp/mockrepo" {
+		t.Errorf("Wrong delete command for mock subdir repo")
+	}
+}

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -664,7 +664,12 @@ func (d *downloadedLayer) IngestIntoCVMFS(CVMFSRepo string) error {
 		return nil
 	}
 	superDir := filepath.Dir(filepath.Dir(cvmfs.TrimCVMFSRepoPrefix(layerPath)))
-	go cvmfs.CreateCatalogIntoDir(CVMFSRepo, superDir)
+	if err := cvmfs.CreateCatalogIntoDir(CVMFSRepo, superDir); err != nil {
+		l.LogE(err).WithFields(
+			log.Fields{"layer": d.Name, "dir": superDir}).
+			Error("Error creating catalog for layer directory")
+		return err
+	}
 	ingestPath := cvmfs.TrimCVMFSRepoPrefix(layerPath)
 	err := cvmfs.Ingest(CVMFSRepo, d.Path,
 		"--catalog", "-t", "-",
@@ -673,7 +678,11 @@ func (d *downloadedLayer) IngestIntoCVMFS(CVMFSRepo string) error {
 		l.LogE(err).WithFields(
 			log.Fields{"layer": d.Name}).
 			Error("Some error in ingest the layer")
-		go cvmfs.IngestDelete(CVMFSRepo, ingestPath)
+		if errDelete := cvmfs.IngestDelete(CVMFSRepo, ingestPath); errDelete != nil {
+			l.LogE(errDelete).WithFields(
+				log.Fields{"layer": d.Name, "path": ingestPath}).
+				Warning("Error cleaning up failed ingest path")
+		}
 		return err
 	}
 	err = StoreLayerInfo(CVMFSRepo, layerDigest, d.Path)

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -10,6 +10,7 @@ Build-Depends:
  cmake,
  cpio,
  help2man,
+ libarchive-dev,
  libcap-dev,
  libssl-dev,
  libattr1-dev,

--- a/test/src/400-ducc-ingest_images/main
+++ b/test/src/400-ducc-ingest_images/main
@@ -17,6 +17,7 @@ ducc_test_400_clean_up() {
     echo -n "Cleaning up..."
 
     export DUCC_DOCKER_REGISTRY_PASS=""
+    export DUCC_OUTPUT_REGISTRY_PASS=""
 
     # delete the recipe file
     rm $CVMFS_TEST400_RECIPE
@@ -127,6 +128,7 @@ EOL
 
     # set the password to access the docker hub
     export DUCC_DOCKER_REGISTRY_PASS=mock_pass
+    export DUCC_OUTPUT_REGISTRY_PASS=mock_pass
 
     # crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."
@@ -190,4 +192,3 @@ EOL'
 
     return 0
 }
-

--- a/test/src/402-ducc-ingest-temp-dir/main
+++ b/test/src/402-ducc-ingest-temp-dir/main
@@ -15,6 +15,7 @@ ducc_test_400_clean_up() {
     echo -n "Cleaning up..."
 
     export DUCC_DOCKER_REGISTRY_PASS=""
+    export DUCC_OUTPUT_REGISTRY_PASS=""
 
     # delete the recipe file
     rm $CVMFS_TEST402_RECIPE
@@ -51,6 +52,7 @@ EOL
 
     # set the password to access the docker hub
     export DUCC_DOCKER_REGISTRY_PASS=mock_pass
+    export DUCC_OUTPUT_REGISTRY_PASS=mock_pass
 
     # crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."
@@ -96,4 +98,3 @@ EOL
 
     return 0
 }
-

--- a/test/src/403-ducc-star/main
+++ b/test/src/403-ducc-star/main
@@ -13,6 +13,7 @@ ducc_test_403_clean_up() {
     echo -n "Cleaning up..."
 
     export DUCC_DOCKER_REGISTRY_PASS=""
+    export DUCC_OUTPUT_REGISTRY_PASS=""
 
     # delete the recipe file
     rm $CVMFS_TEST403_RECIPE
@@ -56,6 +57,7 @@ EOL
 
     # set the password to access the docker hub
     export DUCC_DOCKER_REGISTRY_PASS=mock_pass
+    export DUCC_OUTPUT_REGISTRY_PASS=mock_pass
 
     # crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."

--- a/test/src/404-ducc-ingest_single_image_thin/main
+++ b/test/src/404-ducc-ingest_single_image_thin/main
@@ -11,6 +11,7 @@ ducc_test_401_clean_up() {
   sudo cvmfs_server rmfs -f $CVMFS_TEST_REPO
     
   export DUCC_DOCKER_REGISTRY_PASS=""
+  export DUCC_OUTPUT_REGISTRY_PASS=""
 
   echo -n "Stopping and deleting docker registry..."
   docker stop $CVMFS_TEST404_REGISTRY >> /dev/null
@@ -30,6 +31,7 @@ cvmfs_run_test() {
 
   echo "*** converting image to flat ***"
   export DUCC_DOCKER_REGISTRY_PASS=mock_pass
+  export DUCC_OUTPUT_REGISTRY_PASS=mock_pass
   cvmfs_ducc convert-single-image \
         --skip-flat \
         --thin-image-name http://localhost:5000/mock/thin_404/centos:7 \

--- a/test/src/405-ducc-convert-podman/main
+++ b/test/src/405-ducc-convert-podman/main
@@ -6,6 +6,7 @@ cvmfs_test_suites="ducc"
 CVMFS_TEST405_RECIPE="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).yaml"
 CVMFS_TEST405_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).cern.ch"
 CVMFS_TEST405_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
+PODMAN_STORAGE_CONF=/etc/containers/storage.conf
 
 ducc_test_405_clean_up() {
 	# delete the recipe file
@@ -50,18 +51,36 @@ EOL
         cvmfs_ducc convert --skip-flat --skip-thin-image $CVMFS_TEST405_RECIPE 2> $CVMFS_TEST405_DUCC_ERR || return 101
         grep "level=error" $CVMFS_TEST405_DUCC_ERR
     done
-    echo "*** Converted recipe successfully"
+	echo "*** Converted recipe successfully"
+
+	if [ ! -f "$PODMAN_STORAGE_CONF" ]; then
+		sudo mkdir -p /etc/containers || return 10
+		if [ -f /usr/share/containers/storage.conf ]; then
+			sudo cp /usr/share/containers/storage.conf "$PODMAN_STORAGE_CONF" || return 10
+		else
+			echo "missing podman storage config template at /usr/share/containers/storage.conf"
+			return 10
+		fi
+	fi
 
 	# add the repository to configuration file
 	additionalstore="/cvmfs/"$CVMFS_TEST405_REPOSITORY"/podmanStore"
-	sudo sed -i -e "/additionalimage.*/a\"$additionalstore\"," /etc/containers/storage.conf || return 10
+	sudo grep -q "additionalimage" "$PODMAN_STORAGE_CONF" || {
+		echo "missing additionalimagestores entry in $PODMAN_STORAGE_CONF"
+		return 10
+	}
+	sudo sed -i -e "/additionalimage.*/a\"$additionalstore\"," "$PODMAN_STORAGE_CONF" || return 10
+	sudo grep -q "$CVMFS_TEST405_REPOSITORY/podmanStore" "$PODMAN_STORAGE_CONF" || {
+		echo "failed to inject additional image store in $PODMAN_STORAGE_CONF"
+		return 10
+	}
 
 	# run the image using podman
 	sudo podman run --rm ubuntu echo "hello from ubuntu container" || return $?
 
 	echo "*** Test successfull ***"
 
-	sudo sed -i "/$CVMFS_TEST405_REPOSITORY/d" /etc/containers/storage.conf
+	sudo sed -i "/$CVMFS_TEST405_REPOSITORY/d" "$PODMAN_STORAGE_CONF"
 
 	return 0
 }

--- a/test/src/405-ducc-convert-podman/main
+++ b/test/src/405-ducc-convert-podman/main
@@ -58,18 +58,30 @@ EOL
 		if [ -f /usr/share/containers/storage.conf ]; then
 			sudo cp /usr/share/containers/storage.conf "$PODMAN_STORAGE_CONF" || return 10
 		else
-			echo "missing podman storage config template at /usr/share/containers/storage.conf"
-			return 10
+			echo "podman storage config template missing, creating minimal $PODMAN_STORAGE_CONF"
+			sudo tee "$PODMAN_STORAGE_CONF" > /dev/null << EOL
+[storage]
+driver = "overlay"
+runroot = "/run/containers/storage"
+graphroot = "/var/lib/containers/storage"
+
+[storage.options]
+additionalimagestores = []
+EOL
 		fi
 	fi
 
 	# add the repository to configuration file
 	additionalstore="/cvmfs/"$CVMFS_TEST405_REPOSITORY"/podmanStore"
-	sudo grep -q "additionalimage" "$PODMAN_STORAGE_CONF" || {
-		echo "missing additionalimagestores entry in $PODMAN_STORAGE_CONF"
-		return 10
-	}
-	sudo sed -i -e "/additionalimage.*/a\"$additionalstore\"," "$PODMAN_STORAGE_CONF" || return 10
+	if sudo grep -q "additionalimagestores = \\[\\]" "$PODMAN_STORAGE_CONF"; then
+		sudo sed -i -e "s|additionalimagestores = \\[\\]|additionalimagestores = [\"$additionalstore\"]|" "$PODMAN_STORAGE_CONF" || return 10
+	else
+		sudo grep -q "additionalimage" "$PODMAN_STORAGE_CONF" || {
+			echo "missing additionalimagestores entry in $PODMAN_STORAGE_CONF"
+			return 10
+		}
+		sudo sed -i -e "/additionalimage.*/a\"$additionalstore\"," "$PODMAN_STORAGE_CONF" || return 10
+	fi
 	sudo grep -q "$CVMFS_TEST405_REPOSITORY/podmanStore" "$PODMAN_STORAGE_CONF" || {
 		echo "failed to inject additional image store in $PODMAN_STORAGE_CONF"
 		return 10

--- a/test/src/405-ducc-convert-podman/main
+++ b/test/src/405-ducc-convert-podman/main
@@ -7,12 +7,22 @@ CVMFS_TEST405_RECIPE="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8
 CVMFS_TEST405_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).cern.ch"
 CVMFS_TEST405_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
 PODMAN_STORAGE_CONF=/etc/containers/storage.conf
+PODMAN_STORAGE_CONF_CREATED=0
 
 ducc_test_405_clean_up() {
+	local additionalstore="/cvmfs/$CVMFS_TEST405_REPOSITORY/podmanStore"
+
 	# delete the recipe file
     rm $CVMFS_TEST405_RECIPE
     # delete the logs and error from ducc
     rm $CVMFS_TEST405_DUCC_ERR
+
+	if [ "$PODMAN_STORAGE_CONF_CREATED" -eq 1 ]; then
+		sudo rm -f "$PODMAN_STORAGE_CONF"
+	elif [ -f "$PODMAN_STORAGE_CONF" ]; then
+		sudo sed -i -e "s|additionalimagestores = \\[\"$additionalstore\"\\]|additionalimagestores = []|" "$PODMAN_STORAGE_CONF"
+		sudo sed -i -e "/$CVMFS_TEST405_REPOSITORY\\/podmanStore/d" "$PODMAN_STORAGE_CONF"
+	fi
 
 	sudo cvmfs_server rmfs -f $CVMFS_TEST405_REPOSITORY
 }
@@ -59,12 +69,23 @@ EOL
 			sudo cp /usr/share/containers/storage.conf "$PODMAN_STORAGE_CONF" || return 10
 		else
 			echo "podman storage config template missing, creating minimal $PODMAN_STORAGE_CONF"
+			PODMAN_STORAGE_CONF_CREATED=1
 			sudo tee "$PODMAN_STORAGE_CONF" > /dev/null << EOL
 [storage]
 driver = "overlay"
 runroot = "/run/containers/storage"
 graphroot = "/var/lib/containers/storage"
 
+[storage.options]
+additionalimagestores = []
+EOL
+		fi
+	fi
+	if ! sudo grep -q "additionalimage" "$PODMAN_STORAGE_CONF"; then
+		if sudo grep -q "^\[storage.options\]" "$PODMAN_STORAGE_CONF"; then
+			sudo sed -i -e "/^\[storage.options\]/a additionalimagestores = []" "$PODMAN_STORAGE_CONF" || return 10
+		else
+			sudo tee -a "$PODMAN_STORAGE_CONF" > /dev/null << EOL
 [storage.options]
 additionalimagestores = []
 EOL
@@ -91,8 +112,6 @@ EOL
 	sudo podman run --rm ubuntu echo "hello from ubuntu container" || return $?
 
 	echo "*** Test successfull ***"
-
-	sudo sed -i "/$CVMFS_TEST405_REPOSITORY/d" "$PODMAN_STORAGE_CONF"
 
 	return 0
 }

--- a/test/src/407-ducc-subdir/main
+++ b/test/src/407-ducc-subdir/main
@@ -1,0 +1,68 @@
+#!/bin/bash
+cvmfs_test_name="DUCC repository subdirectory ingestion"
+cvmfs_test_autofs_on_startup=true
+cvmfs_test_suites="ducc"
+
+CVMFS_TEST407_RECIPE="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).yaml"
+CVMFS_TEST407_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).cern.ch"
+CVMFS_TEST407_SUBDIR="ducc/subdir"
+CVMFS_TEST407_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
+
+ducc_test_407_clean_up() {
+    echo -n "Cleaning up..."
+
+    rm $CVMFS_TEST407_RECIPE
+    rm $CVMFS_TEST407_DUCC_ERR
+
+    sudo cvmfs_server rmfs -f $CVMFS_TEST407_REPOSITORY
+
+    echo "done"
+}
+
+cvmfs_run_test() {
+    trap ducc_test_407_clean_up EXIT HUP INT TERM
+
+    echo -n "*** Creating recipe file..."
+    cat > $CVMFS_TEST407_RECIPE << EOL
+version: 1
+user: mock_user
+cvmfs_repo: '$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR'
+output_format: '\$(scheme)://localhost:5000/mock/\$(image)'
+input:
+    - 'https://registry.hub.docker.com/library/ubuntu:latest'
+EOL
+    echo "done"
+
+    echo -n "*** Creating CVMFS repo..."
+    create_empty_repo $CVMFS_TEST407_REPOSITORY $USER || return $?
+    echo "done"
+
+    echo "*** Starting test."
+    echo "*** Converting recipe..."
+    cvmfs_ducc convert --skip-flat --skip-thin-image --skip-podman $CVMFS_TEST407_RECIPE 2> $CVMFS_TEST407_DUCC_ERR || return 101
+    grep -q "level=error" $CVMFS_TEST407_DUCC_ERR
+    while [ $? -ne 1 ]
+    do
+        echo -n "*** Some error during conversion, let's do it again. Converting recipe..."
+        rm $CVMFS_TEST407_DUCC_ERR
+        cvmfs_ducc convert --skip-flat --skip-thin-image --skip-podman $CVMFS_TEST407_RECIPE 2> $CVMFS_TEST407_DUCC_ERR || return 101
+        grep -q "level=error" $CVMFS_TEST407_DUCC_ERR
+    done
+    echo "*** Convert recipe successfully"
+
+    echo "*** Check integrity of the repository..."
+    check_repository $CVMFS_TEST407_REPOSITORY -i || return 102
+    echo "*** Repository checked successfully"
+
+    subdir_root="/cvmfs/$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR"
+    ls "$subdir_root/.layers" || return 111
+    ls "$subdir_root/.metadata" || return 112
+    ls "$subdir_root/.metadata/registry.hub.docker.com/library/ubuntu:latest" || return 113
+
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.layers" ] || return 114
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.metadata" ] || return 115
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/registry.hub.docker.com" ] || return 116
+
+    echo "*** Test successful"
+    return 0
+}

--- a/test/src/407-ducc-subdir/main
+++ b/test/src/407-ducc-subdir/main
@@ -8,21 +8,12 @@ CVMFS_TEST407_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | 
 CVMFS_TEST407_SUBDIR="ducc/subdir"
 CVMFS_TEST407_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
 ducc_test_407_max_attempts=3
-CVMFS_TEST407_INPUT_REGISTRY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-CVMFS_TEST407_INPUT_PORT="$((5100 + RANDOM % 900))"
-CVMFS_TEST407_INPUT_IMAGE_REF="localhost:${CVMFS_TEST407_INPUT_PORT}/ducc-subdir/input:latest"
-CVMFS_TEST407_INPUT_IMAGE_URL="http://${CVMFS_TEST407_INPUT_IMAGE_REF}"
-CVMFS_TEST407_BUILD_DIR="$(mktemp -d $(pwd)/build407.XXXXX)"
 
 ducc_test_407_clean_up() {
     echo -n "Cleaning up..."
 
     rm $CVMFS_TEST407_RECIPE
     rm $CVMFS_TEST407_DUCC_ERR
-    rm -rf $CVMFS_TEST407_BUILD_DIR
-
-    docker stop $CVMFS_TEST407_INPUT_REGISTRY >> /dev/null
-    docker rm $CVMFS_TEST407_INPUT_REGISTRY >> /dev/null
 
     sudo cvmfs_server rmfs -f $CVMFS_TEST407_REPOSITORY
 
@@ -39,22 +30,8 @@ user: mock_user
 cvmfs_repo: '$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR'
 output_format: '\$(scheme)://localhost:5000/mock/\$(image)'
 input:
-    - '$CVMFS_TEST407_INPUT_IMAGE_URL'
+    - 'https://registry.hub.docker.com/library/ubuntu:latest'
 EOL
-    echo "done"
-
-    echo -n "*** Starting local registry for test input image..."
-    docker run -d -p ${CVMFS_TEST407_INPUT_PORT}:5000 --name $CVMFS_TEST407_INPUT_REGISTRY registry:2 >> /dev/null || return 3
-    echo "done"
-
-    echo -n "*** Building and publishing local input image..."
-    cat > $CVMFS_TEST407_BUILD_DIR/Dockerfile << EOL
-FROM scratch
-ADD hello.txt /hello.txt
-EOL
-    echo "hello from DUCC subdir test" > $CVMFS_TEST407_BUILD_DIR/hello.txt
-    docker build -t $CVMFS_TEST407_INPUT_IMAGE_REF $CVMFS_TEST407_BUILD_DIR >> /dev/null || return 4
-    docker push $CVMFS_TEST407_INPUT_IMAGE_REF >> /dev/null || return 5
     echo "done"
 
     echo -n "*** Creating CVMFS repo..."
@@ -96,11 +73,11 @@ EOL
     subdir_root="/cvmfs/$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR"
     ls "$subdir_root/.layers" || return 111
     ls "$subdir_root/.metadata" || return 112
-    ls "$subdir_root/.metadata/localhost:${CVMFS_TEST407_INPUT_PORT}/ducc-subdir/input:latest" || return 113
+    ls "$subdir_root/.metadata/registry.hub.docker.com/library/ubuntu:latest" || return 113
 
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.layers" ] || return 114
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.metadata" ] || return 115
-    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/localhost:${CVMFS_TEST407_INPUT_PORT}" ] || return 116
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/registry.hub.docker.com" ] || return 116
 
     echo "*** Test successful"
     return 0

--- a/test/src/407-ducc-subdir/main
+++ b/test/src/407-ducc-subdir/main
@@ -7,6 +7,7 @@ CVMFS_TEST407_RECIPE="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8
 CVMFS_TEST407_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).cern.ch"
 CVMFS_TEST407_SUBDIR="ducc/subdir"
 CVMFS_TEST407_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
+ducc_test_407_max_attempts=3
 
 ducc_test_407_clean_up() {
     echo -n "Cleaning up..."
@@ -39,15 +40,30 @@ EOL
 
     echo "*** Starting test."
     echo "*** Converting recipe..."
-    cvmfs_ducc convert --skip-flat --skip-thin-image --skip-podman $CVMFS_TEST407_RECIPE 2> $CVMFS_TEST407_DUCC_ERR || return 101
-    grep -q "level=error" $CVMFS_TEST407_DUCC_ERR
-    while [ $? -ne 1 ]
+    local attempt=1
+    local conversion_ok=0
+    while [ $attempt -le $ducc_test_407_max_attempts ]
     do
-        echo -n "*** Some error during conversion, let's do it again. Converting recipe..."
-        rm $CVMFS_TEST407_DUCC_ERR
-        cvmfs_ducc convert --skip-flat --skip-thin-image --skip-podman $CVMFS_TEST407_RECIPE 2> $CVMFS_TEST407_DUCC_ERR || return 101
+        rm -f $CVMFS_TEST407_DUCC_ERR
+        cvmfs_ducc convert --skip-flat --skip-thin-image --skip-podman $CVMFS_TEST407_RECIPE 2> $CVMFS_TEST407_DUCC_ERR
+        local retval=$?
         grep -q "level=error" $CVMFS_TEST407_DUCC_ERR
+        local has_level_error=$?
+
+        if [ $retval -eq 0 ] && [ $has_level_error -eq 1 ]; then
+            conversion_ok=1
+            break
+        fi
+
+        echo "*** Conversion attempt ${attempt}/${ducc_test_407_max_attempts} failed (retval=$retval)."
+        attempt=$((attempt+1))
+        sleep 1
     done
+    if [ $conversion_ok -ne 1 ]; then
+        echo "*** Conversion failed after ${ducc_test_407_max_attempts} attempts. Last DUCC stderr follows:"
+        cat $CVMFS_TEST407_DUCC_ERR
+        return 101
+    fi
     echo "*** Convert recipe successfully"
 
     echo "*** Check integrity of the repository..."

--- a/test/src/407-ducc-subdir/main
+++ b/test/src/407-ducc-subdir/main
@@ -8,12 +8,21 @@ CVMFS_TEST407_REPOSITORY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | 
 CVMFS_TEST407_SUBDIR="ducc/subdir"
 CVMFS_TEST407_DUCC_ERR="$(pwd)/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1).err"
 ducc_test_407_max_attempts=3
+CVMFS_TEST407_INPUT_REGISTRY="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
+CVMFS_TEST407_INPUT_PORT="$((5100 + RANDOM % 900))"
+CVMFS_TEST407_INPUT_IMAGE_REF="localhost:${CVMFS_TEST407_INPUT_PORT}/ducc-subdir/input:latest"
+CVMFS_TEST407_INPUT_IMAGE_URL="http://${CVMFS_TEST407_INPUT_IMAGE_REF}"
+CVMFS_TEST407_BUILD_DIR="$(mktemp -d $(pwd)/build407.XXXXX)"
 
 ducc_test_407_clean_up() {
     echo -n "Cleaning up..."
 
     rm $CVMFS_TEST407_RECIPE
     rm $CVMFS_TEST407_DUCC_ERR
+    rm -rf $CVMFS_TEST407_BUILD_DIR
+
+    docker stop $CVMFS_TEST407_INPUT_REGISTRY >> /dev/null
+    docker rm $CVMFS_TEST407_INPUT_REGISTRY >> /dev/null
 
     sudo cvmfs_server rmfs -f $CVMFS_TEST407_REPOSITORY
 
@@ -30,8 +39,22 @@ user: mock_user
 cvmfs_repo: '$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR'
 output_format: '\$(scheme)://localhost:5000/mock/\$(image)'
 input:
-    - 'https://registry.hub.docker.com/library/ubuntu:latest'
+    - '$CVMFS_TEST407_INPUT_IMAGE_URL'
 EOL
+    echo "done"
+
+    echo -n "*** Starting local registry for test input image..."
+    docker run -d -p ${CVMFS_TEST407_INPUT_PORT}:5000 --name $CVMFS_TEST407_INPUT_REGISTRY registry:2 >> /dev/null || return 3
+    echo "done"
+
+    echo -n "*** Building and publishing local input image..."
+    cat > $CVMFS_TEST407_BUILD_DIR/Dockerfile << EOL
+FROM scratch
+ADD hello.txt /hello.txt
+EOL
+    echo "hello from DUCC subdir test" > $CVMFS_TEST407_BUILD_DIR/hello.txt
+    docker build -t $CVMFS_TEST407_INPUT_IMAGE_REF $CVMFS_TEST407_BUILD_DIR >> /dev/null || return 4
+    docker push $CVMFS_TEST407_INPUT_IMAGE_REF >> /dev/null || return 5
     echo "done"
 
     echo -n "*** Creating CVMFS repo..."
@@ -73,11 +96,11 @@ EOL
     subdir_root="/cvmfs/$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR"
     ls "$subdir_root/.layers" || return 111
     ls "$subdir_root/.metadata" || return 112
-    ls "$subdir_root/.metadata/registry.hub.docker.com/library/ubuntu:latest" || return 113
+    ls "$subdir_root/.metadata/localhost:${CVMFS_TEST407_INPUT_PORT}/ducc-subdir/input:latest" || return 113
 
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.layers" ] || return 114
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.metadata" ] || return 115
-    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/registry.hub.docker.com" ] || return 116
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/localhost:${CVMFS_TEST407_INPUT_PORT}" ] || return 116
 
     echo "*** Test successful"
     return 0

--- a/test/src/407-ducc-subdir/main
+++ b/test/src/407-ducc-subdir/main
@@ -78,6 +78,8 @@ EOL
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.layers" ] || return 114
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/.metadata" ] || return 115
     [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/registry.hub.docker.com" ] || return 116
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR/$CVMFS_TEST407_SUBDIR/.layers" ] || return 117
+    [ ! -e "/cvmfs/$CVMFS_TEST407_REPOSITORY/$CVMFS_TEST407_SUBDIR/$CVMFS_TEST407_SUBDIR/.metadata" ] || return 118
 
     echo "*** Test successful"
     return 0


### PR DESCRIPTION
feat(ducc): support publishing to CVMFS repository subdirectories

## Description
This PR implements support for specifying a target subdirectory within a CVMFS repository for `ducc` unpacking (e.g., `unpacked.cern.ch/compat`). This addresses the feedback from PR #3806 and ensures robust handling of repository paths.

## Changes
- **Utilities**: Added `GetRepoAndSubdir` in [ducc/cvmfs/utils.go](https://github.com/clelange/cvmfs/blob/3f5dc356924f589477a404a22c879392a2011a0e/ducc/cvmfs/utils.go) to correctly split repository names and subdirectories, supporting both production strings and test harness paths.
- **Core Logic**: Updated `CreateSneakyChain` in [ducc/cvmfs/cvmfs.go](https://github.com/clelange/cvmfs/blob/3f5dc356924f589477a404a22c879392a2011a0e/ducc/cvmfs/cvmfs.go) to use the base repository name for scratch directory resolution (`/var/spool/cvmfs/REPO/scratch/current`) while preserving the subdirectory structure for the internal layout.
- **Command Handling**: Updated [ducc/cvmfs/raw.go](https://github.com/clelange/cvmfs/blob/3f5dc356924f589477a404a22c879392a2011a0e/ducc/cvmfs/raw.go) to pass the full path to `cvmfs_server transaction` (supporting subdir locking) while stripping the subdirectory for `publish` and `abort` commands.
- **Tests**:
  - Added unit tests for path splitting in [ducc/cvmfs/utils_test.go](https://github.com/clelange/cvmfs/blob/3f5dc356924f589477a404a22c879392a2011a0e/ducc/cvmfs/utils_test.go).
  - Extended the mock `cvmfs_server` to verify subdirectory transaction arguments.
  - Added a new integration test `TestPublishToSubdir` to verify the end-to-end flow.

## Verification
- **Unit/Integration Tests**: Verified using the local Docker-based test harness (`golang:1.24.0-bookworm`) with `TEST_DUCC_ONLINE=yes`. All tests passed, including the new integration test.
- **Build**: Verified standard CMake build succeeds.

Fixes #3780