### PR TITLE
Make recognition of CVMFS_DEBUGLOG at reload be per-repo

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1257,10 +1257,6 @@ _cvmfs_reload_pause() {
   local mountpoint="$1"
   local debug_flag=""
  
-  if [ "x${CVMFS_DEBUGLOG}" != "x" ]; then
-    debug_flag="--debug"
-  fi
-
   cd "$mountpoint" 2>/dev/null || return
   get_attr fqrn ${mountpoint}; fqrn=$attr_value
   get_attr pid ${mountpoint}; pid=$attr_value
@@ -1269,6 +1265,12 @@ _cvmfs_reload_pause() {
     cd /
     return 1
   fi
+
+  cvmfs_readconfig $fqrn || die "Failed to read CernVM-FS configuration of $fqrn"
+  if [ "x${CVMFS_DEBUGLOG}" != "x" ]; then
+    debug_flag="--debug"
+  fi
+
   echo "Pausing ${fqrn} on ${mountpoint}"
   cd "$mountpoint" &&
     rm -f ${CVMFS_RELOAD_SOCKETS}/cvmfs.pause/$(echo -n "$mountpoint" | base64_nowrap) && \
@@ -1309,12 +1311,14 @@ cvmfs_reload() {
     shift
     cache_directories=$(list_cache_directories)
   elif [ "x$1" != "x" ]; then
+    org=$1
+    fqrn=$(cvmfs_mkfqrn $org)
+    cvmfs_readconfig $fqrn || die "Failed to read CernVM-FS configuration of $fqrn"
+
     if [ "x${CVMFS_DEBUGLOG}" != "x" ]; then
       debug_flag="--debug"
     fi
 
-    org=$1
-    fqrn=$(cvmfs_mkfqrn $org)
     cvmfs2 __RELOAD__ ${CVMFS_RELOAD_SOCKETS}/cvmfs.$fqrn ${debug_flag}
     return $?
   fi

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -654,7 +654,7 @@ int FuseMain(int argc, char *argv[]) {
       // reload ignores the current state
       //
       // if you mount with debug but do not set CVMFS_DEBUGLOG and reload,
-      // you will reload with
+      // debug will be turned off
       if (std::string(argv[argc - 1]) == std::string("--debug")) {
         debug_mode_ = true;
       } else {


### PR DESCRIPTION
I noticed in https://github.com/cvmfs/cvmfs/pull/4062#issuecomment-3844380032 that debug mode gets lost at reload time if it isn't set for all repositories.  This has been a problem since #3327 where debug mode was implemented to be enabled or disabled at reload time.  This PR makes it separately enable or disable debug mode per repo.