### PR TITLE
New tools for overlays on catalog level

### DIFF
--- a/.github/workflows/ci_container_unpacker.yaml
+++ b/.github/workflows/ci_container_unpacker.yaml
@@ -63,9 +63,9 @@ jobs:
           ./ci/build_package.sh $PWD /tmp/build-ubuntu cvmfs
       - name: Install packages
         run: |
-          sudo apt-get -y remove "cvmfs*"
           sudo apt-get -y install /tmp/build-ubuntu*/*.deb
           sudo cvmfs_config setup
+          sudo systemctl stop autofs
           sudo systemctl start apache2
           sudo systemctl status apache2
       - name: Setup Go

--- a/.github/workflows/ci_container_unpacker.yaml
+++ b/.github/workflows/ci_container_unpacker.yaml
@@ -1,0 +1,98 @@
+name: container_unpacker
+on:
+  pull_request:
+    branches: [devel, cvmfs*]
+  push:
+  workflow_dispatch:
+
+jobs:
+  validate_unpacker:
+    runs-on: ubuntu-latest
+    steps:
+
+      - id: lsb-release
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            source /etc/lsb-release
+            echo "id=${DISTRIB_ID}" >> $GITHUB_OUTPUT
+            echo "release=${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
+            echo "codename=${DISTRIB_CODENAME}" >> $GITHUB_OUTPUT
+            echo "description=${DISTRIB_DESCRIPTION}" >> $GITHUB_OUTPUT
+            echo "id-release=${DISTRIB_ID}-${DISTRIB_RELEASE}" >> $GITHUB_OUTPUT
+            echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Create cache directories
+        run: |
+          mkdir -p /home/runner/.cache
+      - name: Restore CI cache
+        uses: actions/cache/restore@v4
+        id: cvmfs-ci-cache-restore
+        with:
+          path: /home/runner/.cache/
+          key: v3-cvmfs-ci-cache-${{ steps.lsb-release.outputs.id-release }}-${{ steps.lsb-release.outputs.arch }}
+      - name: Check for builddep package
+        id: cvmfs-builddep-check
+        run: |
+          if [ -f "/home/runner/.cache/cvmfs-build-deps_*_all.deb" ]; then
+            echo "package_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "package_exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Generate build-dep metapackage
+        if: steps.cvmfs-builddep-check.outputs.package_exists != 'true'
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y devscripts equivs
+          mk-build-deps ./packaging/debian/cvmfs/control
+          mv cvmfs-build-deps_*_all.deb /home/runner/.cache
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y /home/runner/.cache/cvmfs-build-deps_*_all.deb
+      - name: Build packages
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install devscripts ccache apache2 libapache2-mod-wsgi-py3
+          export CVMFS_EXTERNALS_PREFIX=/home/runner/.cache/cvmfs_externals_install
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          mkdir /tmp/build-ubuntu
+          mkdir /tmp/build-ubuntu-config
+          ./ci/build_package.sh $PWD /tmp/build-ubuntu-config cvmfs-config
+          ./ci/build_package.sh $PWD /tmp/build-ubuntu cvmfs
+      - name: Install packages
+        run: |
+          sudo apt-get -y remove "cvmfs*"
+          sudo apt-get -y install /tmp/build-ubuntu*/*.deb
+          sudo cvmfs_config setup
+          sudo systemctl start apache2
+          sudo systemctl status apache2
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+      - name: Build and install cvmfs_ducc
+        working-directory: ./ducc
+        run: |
+          sudo make install
+          cvmfs_ducc version || true
+      - name: Validate container unpacker
+        run: |
+          cd test/container
+          sudo ./validate_unpacker.sh -k -v -c https://registry.hub.docker.com/library/python:3.9
+      - name: Upload logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: validate-unpacker-logs
+          path: |
+            /tmp/validate_unpacker.*
+      - name: Save CI cache
+        if: github.ref == 'refs/heads/devel' && github.event_name != 'pull_request'
+        uses: actions/cache/save@v4
+        id: cvmfs-ci-cache-save
+        with:
+          path: /home/runner/.cache/
+          key: v3-cvmfs-ci-cache-${{ steps.lsb-release.outputs.id-release }}-${{ steps.lsb-release.outputs.arch }}
+

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -673,6 +673,7 @@ if (BUILD_SERVER)
        swissknife_main.cc
        swissknife_migrate.cc
        swissknife_notify.cc
+       swissknife_overlay.cc
        swissknife_pull.cc
        swissknife_reflog.cc
        swissknife_filestats.cc

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -30,6 +30,7 @@ class SyncItemDummyCatalog;
 }  // namespace publish
 namespace swissknife {
 class CommandMigrate;
+class CommandOverlay;
 class IngestSQL;
 }  // namespace swissknife
 
@@ -68,6 +69,7 @@ class DirectoryEntryBase {
   friend class publish::SyncItemTar;
   friend class publish::SyncItemDummyDir;
   friend class publish::SyncItemDummyCatalog;
+  friend class swissknife::CommandOverlay;
   friend class swissknife::IngestSQL;  // TODO(vvolkl): can probably avoided
                                        // with new setters
   // Simplify file system like _touch_ of DirectoryEntry objects

--- a/cvmfs/make_cvmfs_server.sh
+++ b/cvmfs/make_cvmfs_server.sh
@@ -67,6 +67,7 @@ COMPONENTS="\
     server/cvmfs_server_fix_permissions.sh
     server/cvmfs_server_fix_stats.sh
     server/cvmfs_server_ingest.sh
+    server/cvmfs_server_overlay.sh
     server/cvmfs_server_print_stats.sh
     server/cvmfs_server_merge_stats.sh
     server/cvmfs_server_coda.sh

--- a/cvmfs/server/cvmfs_server_overlay.sh
+++ b/cvmfs/server/cvmfs_server_overlay.sh
@@ -106,6 +106,12 @@ cvmfs_server_overlay() {
 
   # ---> do it!
   publish_before_hook $name
+
+  # check if we have open file descriptors on /cvmfs/<name>
+  [ $(count_wr_fds /cvmfs/$name) -eq 0 ] || { cvmfs_server_abort -f $name; die "Open writable file descriptors on $name"; }
+  local use_fd_fallback=0
+  handle_read_only_file_descriptors_on_mount_point $name $open_fd_dialog || use_fd_fallback=1
+
   publish_starting $name
 
   $user_shell "$overlay_command" || { publish_failed $name; cvmfs_server_abort -f $name; die "Overlay merge failed\n\nExecuted Command:\n$overlay_command"; }
@@ -114,7 +120,7 @@ cvmfs_server_overlay() {
   local trunk_hash=$(grep "^C" $manifest | tr -d C)
 
   if [ x"$upstream_type" = xgw ]; then
-    close_transaction $name 0
+    close_transaction $name $use_fd_fallback
     publish_after_hook $name
     publish_succeeded $name
     echo "Changes submitted to repository gateway"
@@ -145,8 +151,17 @@ cvmfs_server_overlay() {
   sign_manifest $name $manifest      || { publish_failed $name; cvmfs_server_abort -f $name; die "Signing failed"; }
   set_ro_root_hash $name $trunk_hash || { publish_failed $name; cvmfs_server_abort -f $name; die "Root hash update failed"; }
 
-  echo "Remounting newly created repository revision"
-  close_transaction $name 0
+  # check again for open file descriptors (potential race condition)
+  if has_file_descriptors_on_mount_point $name && \
+     [ $use_fd_fallback -ne 1 ]; then
+    file_descriptor_warning $name
+    echo "Forcing remount of already committed repository revision"
+    use_fd_fallback=1
+  else
+    echo "Remounting newly created repository revision"
+  fi
+
+  close_transaction $name $use_fd_fallback
   publish_after_hook $name
   publish_succeeded  $name
 }

--- a/cvmfs/server/cvmfs_server_overlay.sh
+++ b/cvmfs/server/cvmfs_server_overlay.sh
@@ -13,8 +13,6 @@
 cvmfs_server_overlay() {
   local layers=""
   local dest_path=""
-  local cache_dir=""
-  local force_refresh=0
   local name=""
 
   while [ "$2" != "" ]; do
@@ -26,12 +24,6 @@ cvmfs_server_overlay() {
         dest_path=$2
         # remove any duplicated slashes in pathname
         dest_path=$(echo $dest_path | tr -s / )
-        ;;
-      -c | --cache-dir )
-        cache_dir=$2
-        ;;
-      -f | --force )
-        force_refresh=1
         ;;
     esac
     shift
@@ -95,14 +87,6 @@ cvmfs_server_overlay() {
     -Z $compression_alg                          \
     $(get_swissknife_proxy)                      \
     $(get_follow_http_redirects_flag)"
-
-  if [ ! x"$cache_dir" = "x" ]; then
-    overlay_command="$overlay_command -c $cache_dir"
-  fi
-
-  if [ $force_refresh -eq 1 ]; then
-    overlay_command="$overlay_command -f"
-  fi
 
   # ---> do it!
   publish_before_hook $name

--- a/cvmfs/server/cvmfs_server_overlay.sh
+++ b/cvmfs/server/cvmfs_server_overlay.sh
@@ -1,0 +1,150 @@
+#
+# This file is part of the CernVM File System
+# This script takes care of creating, removing, and maintaining repositories
+# on a Stratum 0/1 server
+#
+# Implementation of the "cvmfs_server overlay" command
+
+# This file depends on functions implemented in the following files:
+# - cvmfs_server_util.sh
+# - cvmfs_server_common.sh
+
+
+cvmfs_server_overlay() {
+  local layers=""
+  local dest_path=""
+  local cache_dir=""
+  local force_refresh=0
+  local name=""
+
+  while [ "$2" != "" ]; do
+    case $1 in
+      -l | --layers )
+        layers=$2
+        ;;
+      -d | --dest )
+        dest_path=$2
+        # remove any duplicated slashes in pathname
+        dest_path=$(echo $dest_path | tr -s / )
+        ;;
+      -c | --cache-dir )
+        cache_dir=$2
+        ;;
+      -f | --force )
+        force_refresh=1
+        ;;
+    esac
+    shift
+  done
+
+  name=$1
+
+  if [ x"$name" = "x" ]; then
+    die "Please provide a repository name"
+  fi
+
+  if [ x"$layers" = "x" ]; then
+    die "Please provide layer paths with -l (comma-separated, bottom-to-top order)"
+  fi
+
+  if [ x"$dest_path" = "x" ]; then
+    die "Please provide a destination path with -d"
+  fi
+
+  load_repo_config $name
+
+  # sanity checks
+  is_stratum0 $name   || die "This is not a stratum 0 repository"
+  is_publishing $name && die "Another publish process is active for $name"
+  health_check -g -r $name
+  is_owner_or_root $name || die "Permission denied: Repository $name is owned by $CVMFS_USER"
+  check_repository_compatibility $name
+
+  local upstream=$CVMFS_UPSTREAM_STORAGE
+  local upstream_type=$(get_upstream_type $upstream)
+
+  # Open a transaction for the overlay operation
+  if [ x"$upstream_type" = xgw ]; then
+    cvmfs_server_transaction "$name/$dest_path" || die "Impossible to start a transaction"
+  else
+    cvmfs_server_transaction $name || die "Impossible to start a transaction"
+  fi
+
+  local spool_dir=$CVMFS_SPOOL_DIR
+  local stratum0=$CVMFS_STRATUM0
+  local hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
+  local compression_alg="${CVMFS_COMPRESSION_ALGORITHM-default}"
+
+  local user_shell="$(get_user_shell $name)"
+  local base_hash=$(get_mounted_root_hash $name)
+  local manifest="${spool_dir}/tmp/manifest"
+
+  # Build the swissknife overlay command
+  local overlay_command="$(__swissknife_cmd dbg) \
+    overlay                                      \
+    -r ${upstream}                               \
+    -w $stratum0                                 \
+    -t ${spool_dir}/tmp                          \
+    -o $manifest                                 \
+    -b $base_hash                                \
+    -K $CVMFS_PUBLIC_KEY                         \
+    -N $name                                     \
+    -l $layers                                   \
+    -d $dest_path                                \
+    -e $hash_algorithm                           \
+    -Z $compression_alg                          \
+    $(get_swissknife_proxy)                      \
+    $(get_follow_http_redirects_flag)"
+
+  if [ ! x"$cache_dir" = "x" ]; then
+    overlay_command="$overlay_command -c $cache_dir"
+  fi
+
+  if [ $force_refresh -eq 1 ]; then
+    overlay_command="$overlay_command -f"
+  fi
+
+  # ---> do it!
+  publish_before_hook $name
+  publish_starting $name
+
+  $user_shell "$overlay_command" || { publish_failed $name; cvmfs_server_abort -f $name; die "Overlay merge failed\n\nExecuted Command:\n$overlay_command"; }
+  cvmfs_sys_file_is_regular $manifest || { publish_failed $name; cvmfs_server_abort -f $name; die "Manifest creation failed"; }
+
+  local trunk_hash=$(grep "^C" $manifest | tr -d C)
+
+  if [ x"$upstream_type" = xgw ]; then
+    close_transaction $name 0
+    publish_after_hook $name
+    publish_succeeded $name
+    echo "Changes submitted to repository gateway"
+    return 0
+  fi
+
+  # Tag the new revision
+  local tag_command="$(__swissknife_cmd dbg) tag_edit \
+    -r $upstream                                      \
+    -w $stratum0                                      \
+    -t ${spool_dir}/tmp                               \
+    -m $manifest                                      \
+    -p /etc/cvmfs/keys/${name}.pub                    \
+    -f $name                                          \
+    -e $hash_algorithm                                \
+    $(get_swissknife_proxy)                           \
+    $(get_follow_http_redirects_flag)                 \
+    -x"
+
+  echo "Tagging $name"
+  $user_shell "$tag_command" || { publish_failed $name; cvmfs_server_abort -f $name; die "Tagging failed\n\nExecuted Command:\n$tag_command"; }
+
+  # Finalize
+  echo "Signing new manifest"
+  sign_manifest $name $manifest      || { publish_failed $name; cvmfs_server_abort -f $name; die "Signing failed"; }
+  set_ro_root_hash $name $trunk_hash || { publish_failed $name; cvmfs_server_abort -f $name; die "Root hash update failed"; }
+
+  echo "Remounting newly created repository revision"
+  close_transaction $name 0
+  publish_after_hook $name
+  publish_succeeded  $name
+}
+

--- a/cvmfs/server/cvmfs_server_overlay.sh
+++ b/cvmfs/server/cvmfs_server_overlay.sh
@@ -137,6 +137,9 @@ cvmfs_server_overlay() {
   echo "Tagging $name"
   $user_shell "$tag_command" || { publish_failed $name; cvmfs_server_abort -f $name; die "Tagging failed\n\nExecuted Command:\n$tag_command"; }
 
+
+  echo "Flushing file system buffers"
+  sync
   # Finalize
   echo "Signing new manifest"
   sign_manifest $name $manifest      || { publish_failed $name; cvmfs_server_abort -f $name; die "Signing failed"; }

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1241,7 +1241,7 @@ is_subcommand() {
     resign list info tag list-tags lstags check transaction enter abort snapshot    \
     skeleton migrate list-catalogs diff checkout update-geodb gc catalog-chown      \
     eliminate-hardlinks eliminate-bulk-hashes fix-stats update-info update-repoinfo \
-    mount fix-permissions masterkeycard ingest merge-stats print-stats"
+    mount fix-permissions masterkeycard ingest overlay merge-stats print-stats"
 
   for possible_command in $supported_commands; do
     if [ x"$possible_command" = x"$subcommand" ]; then
@@ -1415,6 +1415,12 @@ Supported Commands:
                   Extract the content of the tarfile inside the base directory,
                   in the same transaction it also delete the required folders.
                   Use '-' as -t argument to read the tarball from STDIN.
+  overlay         -l <layer1,layer2,...> (comma-separated, bottom-to-top order)
+                  -d <destination path>
+                  [-c <cache directory>] [-f force refresh]
+                  <fully qualified name>
+                  Merge multiple subdirectory catalogs using overlay semantics
+                  and publish the result under the destination path.
   print-stats     [-o output_file]
                   [-t table_name]
                   [-s separator] - char

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1417,7 +1417,6 @@ Supported Commands:
                   Use '-' as -t argument to read the tarball from STDIN.
   overlay         -l <layer1,layer2,...> (comma-separated, bottom-to-top order)
                   -d <destination path>
-                  [-c <cache directory>] [-f force refresh]
                   <fully qualified name>
                   Merge multiple subdirectory catalogs using overlay semantics
                   and publish the result under the destination path.

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -21,6 +21,7 @@
 #include "swissknife_lsrepo.h"
 #include "swissknife_migrate.h"
 #include "swissknife_notify.h"
+#include "swissknife_overlay.h"
 #include "swissknife_pull.h"
 #include "swissknife_reflog.h"
 #include "swissknife_scrub.h"
@@ -101,6 +102,7 @@ int main(int argc, char **argv) {
   command_list.push_back(new swissknife::Ingest());
   command_list.push_back(new swissknife::IngestSQL());
   command_list.push_back(new swissknife::CommandNotify());
+  command_list.push_back(new swissknife::CommandOverlay());
   command_list.push_back(new swissknife::CommandFileStats());
 
   if (argc < 2) {

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -91,7 +91,7 @@ bool CommandOverlay::CheckCachedMerge(
     map<string, OverlayEntry> *merged) {
   if (cache_dir.empty()) return false;
 
-  const string cache_path = cache_dir + "/" + cache_key + ".db";
+  const string cache_path = cache_dir + "/" + cache_key + ".cache.db";
   if (!FileExists(cache_path)) return false;
 
   // Open the cached catalog database
@@ -135,7 +135,7 @@ bool CommandOverlay::StoreMergeInCache(
 
   MkdirDeep(cache_dir, 0755);
 
-  const string cache_path = cache_dir + "/" + cache_key + ".db";
+  const string cache_path = cache_dir + "/" + cache_key + "cache.db";
 
   // The nested catalog at dest_path already contains the complete set of
   // merged entries (created by PublishMergedEntries).  Simply copy its

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -205,6 +205,15 @@ bool CommandOverlay::ReadCatalogEntries(
   for (size_t i = 0; i < listing.size(); ++i) {
     const catalog::DirectoryEntry &dirent = listing[i];
     const string name = dirent.name().ToString();
+
+    // Skip CVMFS bookkeeping files — they are internal metadata and must not
+    // be carried over into the merged overlay.  PublishMergedEntries() will
+    // create its own .cvmfscatalog marker for the destination catalog.
+    if (name == ".cvmfscatalog" || name == ".cvmfsdirtab"
+        || name == ".cvmfsautocatalog") {
+      continue;
+    }
+
     const string child_catalog_path =
         catalog_root_path.empty() ? "/" + name : catalog_root_path + "/" + name;
     const string child_relative =

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -88,7 +88,7 @@ string CommandOverlay::ComputeCacheKey(
 bool CommandOverlay::CheckCachedMerge(
     const string &cache_dir,
     const string &cache_key,
-    map<string, OverlayEntry> *merged) const {
+    map<string, OverlayEntry> *merged) {
   if (cache_dir.empty()) return false;
 
   const string cache_path = cache_dir + "/" + cache_key + ".db";
@@ -108,7 +108,7 @@ bool CommandOverlay::CheckCachedMerge(
   merged->clear();
 
   // Helper function to recursively read entries from a catalog path
-  bool success = ReadCatalogEntries(cached_catalog, "", "", merged);
+  bool success = ReadCatalogEntries(cached_catalog, "", "", "", "", merged);
 
   delete cached_catalog;
 
@@ -129,68 +129,37 @@ bool CommandOverlay::CheckCachedMerge(
 bool CommandOverlay::StoreMergeInCache(
     const string &cache_dir,
     const string &cache_key,
-    const map<string, OverlayEntry> &merged) const {
+    catalog::WritableCatalogManager *catalog_mgr,
+    const string &dest_path) const {
   if (cache_dir.empty()) return false;
 
   MkdirDeep(cache_dir, 0755);
 
   const string cache_path = cache_dir + "/" + cache_key + ".db";
 
-  // Create a new catalog database
-  catalog::CatalogDatabase *cache_db =
-      catalog::CatalogDatabase::Create(cache_path);
-  if (cache_db == NULL) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create cache database: %s",
-             cache_path.c_str());
-    return false;
-  }
-
-  // Create a root directory entry for the catalog
-  catalog::DirectoryEntry root_entry;
-  root_entry.mode_ = 0755 | S_IFDIR;
-  root_entry.uid_ = 0;
-  root_entry.gid_ = 0;
-  root_entry.mtime_ = time(NULL);
-
-  // Initialize the catalog with root entry
-  const bool volatile_content = false;
-  if (!cache_db->InsertInitialValues("", volatile_content, "", root_entry)) {
+  // The nested catalog at dest_path already contains the complete set of
+  // merged entries (created by PublishMergedEntries).  Simply copy its
+  // database file into the cache.
+  // GetHostingCatalog calls MakeRelativePath internally which prepends '/'.
+  // Strip any leading '/' to avoid a double leading slash.
+  const string dest_path_rel = (!dest_path.empty() && dest_path[0] == '/')
+      ? dest_path.substr(1) : dest_path;
+  catalog::WritableCatalog *nested_catalog =
+      catalog_mgr->GetHostingCatalog(dest_path_rel);
+  if (nested_catalog == NULL) {
     LogCvmfs(kLogCvmfs, kLogStderr,
-             "Failed to initialize cache catalog: %s", cache_path.c_str());
-    delete cache_db;
-    unlink(cache_path.c_str());
+             "Failed to find nested catalog for cache: %s",
+             dest_path.c_str());
     return false;
   }
 
-  delete cache_db;
-  cache_db = NULL;
-
-  // Open the catalog as writable to add entries
-  catalog::WritableCatalog *cache_catalog =
-      catalog::WritableCatalog::AttachFreely(
-          "", cache_path, shash::Any(shash::kSha1));
-  if (cache_catalog == NULL) {
+  const string db_path = nested_catalog->database_path();
+  if (!CopyPath2Path(db_path, cache_path)) {
     LogCvmfs(kLogCvmfs, kLogStderr,
-             "Failed to open cache catalog for writing: %s",
-             cache_path.c_str());
-    unlink(cache_path.c_str());
+             "Failed to copy nested catalog to cache: %s -> %s",
+             db_path.c_str(), cache_path.c_str());
     return false;
   }
-
-  cache_catalog->Transaction();
-
-  // Add all merged entries to the catalog
-  for (map<string, OverlayEntry>::const_iterator it = merged.begin();
-       it != merged.end(); ++it) {
-    const OverlayEntry &oe = it->second;
-    const string entry_path = "/" + oe.path;
-    const string parent_path = oe.parent.empty() ? "" : "/" + oe.parent;
-
-    cache_catalog->AddEntry(oe.entry, oe.xattrs, entry_path, parent_path);
-  }
-
-  cache_catalog->Commit();
-  delete cache_catalog;
 
   LogCvmfs(kLogCvmfs, kLogStdout, "Stored merge result in cache: %s",
            cache_key.c_str());
@@ -219,7 +188,9 @@ bool CommandOverlay::ReadCatalogEntries(
     catalog::Catalog *catalog,
     const string &catalog_root_path,
     const string &relative_prefix,
-    map<string, OverlayEntry> *entries) const {
+    const string &repo_base,
+    const string &temp_dir,
+    map<string, OverlayEntry> *entries) {
   // List entries at this path in the catalog
   catalog::DirectoryEntryList listing;
   const PathString ps_path(catalog_root_path.data(),
@@ -255,22 +226,60 @@ bool CommandOverlay::ReadCatalogEntries(
 
     (*entries)[child_relative] = oe;
 
-    // Recurse into directories (but not nested catalog mountpoints for now)
-    if (dirent.IsDirectory() && !dirent.IsNestedCatalogMountpoint()) {
-      // Check for opaque marker among children
-      catalog::DirectoryEntryList sub_listing;
-      catalog->ListingPath(ps_child, &sub_listing);
-      for (size_t j = 0; j < sub_listing.size(); ++j) {
-        if (IsOpaqueMarker(sub_listing[j].name().ToString())) {
-          (*entries)[child_relative].is_opaque_dir = true;
-          break;
+    if (dirent.IsDirectory()) {
+      if (dirent.IsNestedCatalogMountpoint() && !repo_base.empty()) {
+        // Load the nested catalog and recurse into it
+        shash::Any nested_hash;
+        uint64_t nested_size;
+        if (!catalog->FindNested(ps_child, &nested_hash, &nested_size)) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+                   "Failed to find nested catalog hash for %s",
+                   child_catalog_path.c_str());
+          return false;
+        }
+
+        catalog::Catalog *nested = LoadCatalogForPath(
+            repo_base, child_catalog_path, temp_dir, nested_hash);
+        if (nested == NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+                   "Failed to load nested catalog for %s",
+                   child_catalog_path.c_str());
+          return false;
+        }
+
+        // Check for opaque marker in the nested catalog root
+        catalog::DirectoryEntryList sub_listing;
+        nested->ListingPath(ps_child, &sub_listing);
+        for (size_t j = 0; j < sub_listing.size(); ++j) {
+          if (IsOpaqueMarker(sub_listing[j].name().ToString())) {
+            (*entries)[child_relative].is_opaque_dir = true;
+            break;
+          }
+        }
+
+        if (!ReadCatalogEntries(nested, child_catalog_path,
+                                child_relative, repo_base, temp_dir, entries)) {
+          delete nested;
+          return false;
+        }
+        delete nested;
+      } else if (!dirent.IsNestedCatalogMountpoint()) {
+        // Regular directory — check for opaque marker among children
+        catalog::DirectoryEntryList sub_listing;
+        catalog->ListingPath(ps_child, &sub_listing);
+        for (size_t j = 0; j < sub_listing.size(); ++j) {
+          if (IsOpaqueMarker(sub_listing[j].name().ToString())) {
+            (*entries)[child_relative].is_opaque_dir = true;
+            break;
+          }
+        }
+
+        if (!ReadCatalogEntries(catalog, child_catalog_path,
+                                child_relative, repo_base, temp_dir, entries)) {
+          return false;
         }
       }
-
-      if (!ReadCatalogEntries(catalog, child_catalog_path,
-                              child_relative, entries)) {
-        return false;
-      }
+      // else: nested catalog mountpoint but no repo_base — skip (e.g. cache)
     }
   }
 
@@ -444,8 +453,17 @@ bool CommandOverlay::PublishMergedEntries(
     }
   }
 
+  // Turn the destination directory into a nested catalog so that the overlay
+  // content lives in its own catalog database file.  This also allows
+  // StoreMergeInCache to simply copy the resulting DB instead of
+  // re-inserting every entry.
+  // CreateNestedCatalog calls MakeRelativePath internally which prepends '/'.
+  // Pass the stripped version to avoid a double leading slash.
+  catalog_mgr->CreateNestedCatalog(dest_path_rel);
+
   LogCvmfs(kLogCvmfs, kLogStdout,
-           "Published %zu entries under %s", merged.size(), dest_path.c_str());
+           "Published %zu entries under %s (nested catalog)",
+           merged.size(), dest_path.c_str());
   return true;
 }
 
@@ -762,10 +780,12 @@ int CommandOverlay::Main(const ArgumentList &args) {
           return 1;
         }
 
-        ReadCatalogEntries(nested_catalog, layer_path, "", &layer_entries);
+        ReadCatalogEntries(nested_catalog, layer_path, "",
+                           stratum0, temp_dir, &layer_entries);
         delete nested_catalog;
       } else {
-        ReadCatalogEntries(layer_catalog, layer_path, "", &layer_entries);
+        ReadCatalogEntries(layer_catalog, layer_path, "",
+                           stratum0, temp_dir, &layer_entries);
       }
 
       // Clean up any intermediate catalogs loaded during hierarchy walk
@@ -782,11 +802,6 @@ int CommandOverlay::Main(const ArgumentList &args) {
     }
 
     delete root_catalog;
-
-    // Cache the merge result
-    if (!cache_dir.empty()) {
-      StoreMergeInCache(cache_dir, cache_key, merged);
-    }
   }
 
   // Set up WritableCatalogManager and publish merged entries
@@ -809,6 +824,11 @@ int CommandOverlay::Main(const ArgumentList &args) {
   if (!PublishMergedEntries(&catalog_manager, merged, dest_path)) {
     PrintError("Failed to publish merged entries");
     return 5;
+  }
+
+  // Cache the nested catalog that PublishMergedEntries created at dest_path
+  if (!cache_hit && !cache_dir.empty()) {
+    StoreMergeInCache(cache_dir, cache_key, &catalog_manager, dest_path);
   }
 
   // Commit catalog changes and produce updated manifest

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -1,0 +1,734 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * Implementation of the overlay swissknife command that merges multiple
+ * CVMFS subdirectory catalogs using overlay semantics (similar to OverlayFS)
+ * and publishes the result as a repository subdirectory.
+ */
+
+#define __STDC_FORMAT_MACROS
+
+#include "swissknife_overlay.h"
+
+#include <inttypes.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cassert>
+#include <ctime>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "catalog.h"
+#include "catalog_mgr_rw.h"
+#include "compression/compression.h"
+#include "crypto/hash.h"
+#include "directory_entry.h"
+#include "manifest.h"
+#include "network/download.h"
+#include "network/sink_path.h"
+#include "repository_tag.h"
+#include "shortstring.h"
+#include "statistics.h"
+#include "upload.h"
+#include "upload_spooler_definition.h"
+#include "util/logging.h"
+#include "util/pointer.h"
+#include "util/posix.h"
+#include "util/string.h"
+#include "xattr.h"
+
+using namespace std;  // NOLINT
+
+namespace swissknife {
+
+ParameterList CommandOverlay::GetParams() const {
+  ParameterList r;
+  // Publish workflow parameters (same convention as ingest/sync)
+  r.push_back(Parameter::Mandatory('r', "upstream storage definition"));
+  r.push_back(Parameter::Mandatory('w', "stratum 0 URL"));
+  r.push_back(Parameter::Mandatory('t', "temporary directory"));
+  r.push_back(Parameter::Mandatory('o', "manifest output path"));
+  r.push_back(Parameter::Mandatory('b', "base hash of current root catalog"));
+  r.push_back(Parameter::Mandatory('K', "public key path"));
+  r.push_back(Parameter::Mandatory('N', "repository name"));
+
+  // Overlay-specific parameters
+  r.push_back(Parameter::Mandatory('l', "comma-separated layer paths "
+               "(bottom-to-top order)"));
+  r.push_back(Parameter::Mandatory('d', "destination subdirectory path in "
+               "repository for the merged overlay"));
+  r.push_back(Parameter::Optional('c', "cache directory for intermediate "
+               "merge results"));
+  r.push_back(Parameter::Optional('e', "hash algorithm (default: sha1)"));
+  r.push_back(Parameter::Optional('Z', "compression algorithm "
+               "(default: zlib)"));
+  r.push_back(Parameter::Optional('@', "proxy URL"));
+  r.push_back(Parameter::Switch('f', "force refresh (ignore cache)"));
+  r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
+  return r;
+}
+
+
+string CommandOverlay::ComputeCacheKey(
+    const vector<string> &layers) const {
+  string combined;
+  for (size_t i = 0; i < layers.size(); ++i) {
+    if (i > 0) combined += "\n";
+    combined += layers[i];
+  }
+  return shash::Sha256String(combined);
+}
+
+
+bool CommandOverlay::CheckCachedMerge(
+    const string &cache_dir,
+    const string &cache_key,
+    map<string, OverlayEntry> *merged) const {
+  if (cache_dir.empty()) return false;
+
+  const string cache_path = cache_dir + "/" + cache_key + ".cache";
+  if (!FileExists(cache_path)) return false;
+
+  FILE *f = fopen(cache_path.c_str(), "r");
+  if (f == NULL) return false;
+
+  // Read timestamp line
+  string line;
+  if (!GetLineFile(f, &line) || line.empty()) {
+    fclose(f);
+    return false;
+  }
+
+  // Read entries: each entry is 6 lines:
+  //   relative_path, parent_path, mode, size, checksum_hex, name
+  merged->clear();
+  while (GetLineFile(f, &line)) {
+    OverlayEntry oe;
+    oe.path = line;
+    if (!GetLineFile(f, &line)) break;
+    oe.parent = line;
+    if (!GetLineFile(f, &line)) break;
+    const unsigned int mode = String2Uint64(line);
+    if (!GetLineFile(f, &line)) break;
+    const uint64_t size = String2Uint64(line);
+    if (!GetLineFile(f, &line)) break;
+    const string checksum_hex = line;
+    if (!GetLineFile(f, &line)) break;
+    const string entry_name = line;
+
+    catalog::DirectoryEntryBase base;
+    base.name_.Assign(entry_name.data(), entry_name.length());
+    base.mode_ = mode;
+    base.size_ = size;
+    if (!checksum_hex.empty()) {
+      base.checksum_ = shash::MkFromHexPtr(
+          shash::HexPtr(checksum_hex), shash::kSuffixNone);
+    }
+    base.linkcount_ = 1;
+    oe.entry = catalog::DirectoryEntry(base);
+    oe.is_whiteout = false;
+    oe.is_opaque_dir = false;
+
+    (*merged)[oe.path] = oe;
+  }
+
+  fclose(f);
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Cache hit for key %s (%zu entries)",
+           cache_key.c_str(), merged->size());
+  return true;
+}
+
+
+bool CommandOverlay::StoreMergeInCache(
+    const string &cache_dir,
+    const string &cache_key,
+    const map<string, OverlayEntry> &merged) const {
+  if (cache_dir.empty()) return false;
+
+  MkdirDeep(cache_dir, 0755);
+
+  const string cache_path = cache_dir + "/" + cache_key + ".cache";
+  FILE *f = fopen(cache_path.c_str(), "w");
+  if (f == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create cache file: %s",
+             cache_path.c_str());
+    return false;
+  }
+
+  // Write timestamp
+  fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(time(NULL)));
+
+  // Write entries
+  for (map<string, OverlayEntry>::const_iterator it = merged.begin();
+       it != merged.end(); ++it) {
+    const OverlayEntry &oe = it->second;
+    fprintf(f, "%s\n", oe.path.c_str());
+    fprintf(f, "%s\n", oe.parent.c_str());
+    fprintf(f, "%u\n", oe.entry.mode());
+    fprintf(f, "%" PRIu64 "\n", oe.entry.size());
+    fprintf(f, "%s\n", oe.entry.checksum().ToString().c_str());
+    fprintf(f, "%s\n", oe.entry.name().ToString().c_str());
+  }
+
+  fclose(f);
+  LogCvmfs(kLogCvmfs, kLogStdout, "Stored merge result in cache: %s",
+           cache_key.c_str());
+  return true;
+}
+
+
+bool CommandOverlay::IsWhiteoutFile(const string &name) {
+  return HasPrefix(name, ".wh.", false) && !IsOpaqueMarker(name);
+}
+
+
+string CommandOverlay::GetWhiteoutTarget(const string &name) {
+  // ".wh." is 4 characters
+  if (name.length() <= 4) return "";
+  return name.substr(4);
+}
+
+
+bool CommandOverlay::IsOpaqueMarker(const string &name) {
+  return name == ".wh..wh..opq";
+}
+
+
+bool CommandOverlay::ReadCatalogEntries(
+    catalog::Catalog *catalog,
+    const string &catalog_root_path,
+    const string &relative_prefix,
+    map<string, OverlayEntry> *entries) const {
+  // List entries at this path in the catalog
+  catalog::DirectoryEntryList listing;
+  const PathString ps_path(catalog_root_path.data(),
+                           catalog_root_path.length());
+  const bool has_entries = catalog->ListingPath(ps_path, &listing);
+
+  if (!has_entries && catalog_root_path != catalog->mountpoint().ToString()) {
+    // No entries at this path - it might be a file, not a directory
+    return true;
+  }
+
+  for (size_t i = 0; i < listing.size(); ++i) {
+    const catalog::DirectoryEntry &dirent = listing[i];
+    const string name = dirent.name().ToString();
+    const string child_catalog_path =
+        catalog_root_path.empty() ? "/" + name : catalog_root_path + "/" + name;
+    const string child_relative =
+        relative_prefix.empty() ? name : relative_prefix + "/" + name;
+
+    OverlayEntry oe;
+    oe.entry = dirent;
+    oe.path = child_relative;
+    oe.parent = relative_prefix;
+    oe.is_whiteout = IsWhiteoutFile(name);
+    oe.is_opaque_dir = false;
+
+    // Look up xattrs for this entry
+    XattrList xattrs;
+    const PathString ps_child(child_catalog_path.data(),
+                              child_catalog_path.length());
+    catalog->LookupXattrsPath(ps_child, &xattrs);
+    oe.xattrs = xattrs;
+
+    (*entries)[child_relative] = oe;
+
+    // Recurse into directories (but not nested catalog mountpoints for now)
+    if (dirent.IsDirectory() && !dirent.IsNestedCatalogMountpoint()) {
+      // Check for opaque marker among children
+      catalog::DirectoryEntryList sub_listing;
+      catalog->ListingPath(ps_child, &sub_listing);
+      for (size_t j = 0; j < sub_listing.size(); ++j) {
+        if (IsOpaqueMarker(sub_listing[j].name().ToString())) {
+          (*entries)[child_relative].is_opaque_dir = true;
+          break;
+        }
+      }
+
+      if (!ReadCatalogEntries(catalog, child_catalog_path,
+                              child_relative, entries)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+
+void CommandOverlay::MergeLayer(
+    const map<string, OverlayEntry> &layer_entries,
+    map<string, OverlayEntry> *merged) const {
+  // First pass: collect whiteouts and opaque directories
+  vector<string> whiteout_targets;
+  vector<string> opaque_dirs;
+
+  for (map<string, OverlayEntry>::const_iterator it = layer_entries.begin();
+       it != layer_entries.end(); ++it) {
+    const OverlayEntry &oe = it->second;
+    const string &path = it->first;
+
+    if (oe.is_whiteout) {
+      // Whiteout: mark the target for deletion from lower layers
+      const string target_name = GetWhiteoutTarget(
+          GetFileName(path));
+      const string target_path =
+          oe.parent.empty() ? target_name : oe.parent + "/" + target_name;
+      whiteout_targets.push_back(target_path);
+      continue;
+    }
+
+    if (IsOpaqueMarker(GetFileName(path))) {
+      // Don't add the opaque marker itself to the merged output
+      continue;
+    }
+
+    if (oe.is_opaque_dir) {
+      opaque_dirs.push_back(path);
+    }
+  }
+
+  // Apply opaque directory semantics: remove all entries from lower layers
+  // that are under opaque directories
+  for (size_t i = 0; i < opaque_dirs.size(); ++i) {
+    const string &opaque_path = opaque_dirs[i];
+    const string prefix = opaque_path + "/";
+
+    // Remove children of this directory from merged (lower layer entries)
+    vector<string> to_remove;
+    for (map<string, OverlayEntry>::iterator it = merged->begin();
+         it != merged->end(); ++it) {
+      if (HasPrefix(it->first, prefix, false)) {
+        to_remove.push_back(it->first);
+      }
+    }
+    for (size_t j = 0; j < to_remove.size(); ++j) {
+      merged->erase(to_remove[j]);
+    }
+  }
+
+  // Apply whiteout semantics: remove targeted entries and their children
+  for (size_t i = 0; i < whiteout_targets.size(); ++i) {
+    const string &target = whiteout_targets[i];
+    const string prefix = target + "/";
+
+    // Remove the target entry itself
+    merged->erase(target);
+
+    // Remove all children of the target
+    vector<string> to_remove;
+    for (map<string, OverlayEntry>::iterator it = merged->begin();
+         it != merged->end(); ++it) {
+      if (HasPrefix(it->first, prefix, false)) {
+        to_remove.push_back(it->first);
+      }
+    }
+    for (size_t j = 0; j < to_remove.size(); ++j) {
+      merged->erase(to_remove[j]);
+    }
+  }
+
+  // Second pass: add/override entries from this layer
+  for (map<string, OverlayEntry>::const_iterator it = layer_entries.begin();
+       it != layer_entries.end(); ++it) {
+    const OverlayEntry &oe = it->second;
+    const string &path = it->first;
+
+    // Skip whiteout files and opaque markers - they are control files
+    if (oe.is_whiteout || IsOpaqueMarker(GetFileName(path))) {
+      continue;
+    }
+
+    // Upper layer overrides lower layer for the same path
+    (*merged)[path] = oe;
+  }
+}
+
+
+
+bool CommandOverlay::PublishMergedEntries(
+    catalog::WritableCatalogManager *catalog_mgr,
+    const map<string, OverlayEntry> &merged,
+    const string &dest_path) const {
+  // dest_path starts with '/' for LookupPath, but AddDirectory/AddFile
+  // expect parent_directory without leading '/' because MakeRelativePath
+  // (called internally) prepends it.  Create a stripped copy for add calls.
+  const string dest_path_rel = (!dest_path.empty() && dest_path[0] == '/')
+      ? dest_path.substr(1) : dest_path;
+
+  // Ensure the destination directory itself exists in the catalog.
+  // Check if dest_path already exists; if not, create it.
+  catalog::DirectoryEntry dest_dirent;
+  if (!catalog_mgr->LookupPath(dest_path, catalog::kLookupDefault,
+                                &dest_dirent)) {
+    // Create the destination directory (and any missing parents)
+    // Walk up to find the deepest existing ancestor
+    vector<string> dirs_to_create;
+    string check_path = dest_path;
+    while (!check_path.empty() && check_path != "/") {
+      catalog::DirectoryEntry check_dirent;
+      if (catalog_mgr->LookupPath(check_path, catalog::kLookupDefault,
+                                   &check_dirent)) {
+        break;
+      }
+      dirs_to_create.push_back(check_path);
+      check_path = GetParentPath(check_path);
+    }
+
+    // Create directories from outermost to innermost
+    for (int i = static_cast<int>(dirs_to_create.size()) - 1; i >= 0; --i) {
+      const string &dir = dirs_to_create[i];
+      string parent = GetParentPath(dir);
+      const string name = GetFileName(dir);
+
+      // Strip leading '/' — AddDirectory calls MakeRelativePath which adds it
+      if (!parent.empty() && parent[0] == '/') {
+        parent = parent.substr(1);
+      }
+
+      catalog::DirectoryEntryBase new_dir;
+      new_dir.name_.Assign(name.data(), name.length());
+      new_dir.mode_ = S_IFDIR | 0755;
+      new_dir.uid_ = 0;
+      new_dir.gid_ = 0;
+      new_dir.size_ = 4096;
+      new_dir.mtime_ = time(NULL);
+      new_dir.linkcount_ = 2;
+
+      catalog_mgr->AddDirectory(new_dir, XattrList(), parent);
+      LogCvmfs(kLogCvmfs, kLogDebug,
+               "Created destination directory: %s", dir.c_str());
+    }
+  }
+
+  // Add entries in sorted order. The map is sorted lexicographically,
+  // so parent directories appear before their children.
+  for (map<string, OverlayEntry>::const_iterator it = merged.begin();
+       it != merged.end(); ++it) {
+    const OverlayEntry &oe = it->second;
+
+    // Build parent path without leading '/' for AddDirectory/AddFile
+    // (MakeRelativePath inside those functions adds it back)
+    const string parent_path = oe.parent.empty()
+        ? dest_path_rel
+        : dest_path_rel + "/" + oe.parent;
+
+    if (oe.entry.IsDirectory()) {
+      catalog_mgr->AddDirectory(oe.entry, oe.xattrs, parent_path);
+    } else {
+      catalog_mgr->AddFile(
+          static_cast<const catalog::DirectoryEntryBase &>(oe.entry),
+          oe.xattrs, parent_path);
+    }
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Published %zu entries under %s", merged.size(), dest_path.c_str());
+  return true;
+}
+
+
+catalog::Catalog *CommandOverlay::LoadCatalogForPath(
+    const string &repo_base,
+    const string &subdirectory,
+    const string &temp_dir,
+    const shash::Any &root_hash) {
+  // Fetch the root catalog from the repository
+  const string hash_path = "data/" + root_hash.MakePath();
+  string catalog_path;
+
+  if (IsHttpUrl(repo_base)) {
+    // Download and decompress from remote
+    const string url = repo_base + "/" + hash_path;
+    catalog_path = temp_dir + "/" + root_hash.ToString();
+
+    cvmfs::PathSink pathsink(catalog_path);
+    download::JobInfo download_job(&url, true, false, &root_hash, &pathsink);
+    const download::Failures retval = download_manager()->Fetch(&download_job);
+    if (retval != download::kFailOk) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "Failed to download catalog %s (%d)",
+               root_hash.ToString().c_str(), retval);
+      return NULL;
+    }
+  } else {
+    // Local repository: decompress the catalog
+    const string source_path = repo_base + "/" + hash_path;
+    catalog_path = temp_dir + "/" + root_hash.ToString();
+
+    if (!zlib::DecompressPath2Path(source_path, catalog_path)) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Failed to decompress catalog %s from %s",
+               root_hash.ToString().c_str(), source_path.c_str());
+      return NULL;
+    }
+  }
+
+  catalog::Catalog *catalog = catalog::Catalog::AttachFreely(
+      subdirectory, catalog_path, root_hash);
+  if (catalog == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to attach catalog for path %s",
+             subdirectory.c_str());
+    unlink(catalog_path.c_str());
+    return NULL;
+  }
+
+  catalog->TakeDatabaseFileOwnership();
+  return catalog;
+}
+
+
+int CommandOverlay::Main(const ArgumentList &args) {
+  // Parse publish workflow parameters
+  const string spooler_definition_str = *args.find('r')->second;
+  const string stratum0 = *args.find('w')->second;
+  const string temp_dir = MakeCanonicalPath(*args.find('t')->second);
+  const string manifest_path = *args.find('o')->second;
+  const shash::Any base_hash =
+      shash::MkFromHexPtr(shash::HexPtr(*args.find('b')->second),
+                          shash::kSuffixCatalog);
+  const string public_keys = *args.find('K')->second;
+  const string repo_name = *args.find('N')->second;
+
+  // Parse overlay-specific parameters
+  const string layers_str = *args.find('l')->second;
+  string dest_path = MakeCanonicalPath(*args.find('d')->second);
+  // Ensure dest_path starts with exactly one '/'
+  while (dest_path.length() > 1 && dest_path[0] == '/' && dest_path[1] == '/') {
+    dest_path = dest_path.substr(1);
+  }
+  if (dest_path.empty() || dest_path[0] != '/') {
+    dest_path = "/" + dest_path;
+  }
+  const string cache_dir =
+      (args.count('c') > 0) ? *args.find('c')->second : "";
+  const bool force_refresh = (args.count('f') > 0);
+
+  shash::Algorithms hash_algorithm = shash::kSha1;
+  if (args.find('e') != args.end()) {
+    hash_algorithm = shash::ParseHashAlgorithm(*args.find('e')->second);
+    if (hash_algorithm == shash::kAny) {
+      PrintError("unknown hash algorithm");
+      return 1;
+    }
+  }
+  zlib::Algorithms compression_alg = zlib::kZlibDefault;
+  if (args.find('Z') != args.end()) {
+    compression_alg = zlib::ParseCompressionAlgorithm(
+        *args.find('Z')->second);
+  }
+
+  // Parse comma-separated layer paths
+  const vector<string> layers = SplitString(layers_str, ',');
+  if (layers.empty()) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "No layers specified");
+    return 1;
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStdout, "Overlay merge of %zu layers into %s",
+           layers.size(), dest_path.c_str());
+  for (size_t i = 0; i < layers.size(); ++i) {
+    LogCvmfs(kLogCvmfs, kLogStdout, "  Layer %zu: %s", i, layers[i].c_str());
+  }
+
+  // Set up spoolers (following the ingest pattern)
+  perf::StatisticsTemplate publish_statistics("publish", this->statistics());
+
+  const upload::SpoolerDefinition spooler_definition(
+      spooler_definition_str, hash_algorithm, compression_alg,
+      false /* generate_legacy_bulk_chunks */,
+      false /* use_file_chunking */,
+      0, 0, 0 /* chunk sizes: unused */,
+      "" /* session_token_file */, "" /* key_file */);
+
+  const upload::SpoolerDefinition spooler_definition_catalogs(
+      spooler_definition.Dup2DefaultCompression());
+
+  const UniquePtr<upload::Spooler> spooler_files(
+      upload::Spooler::Construct(spooler_definition, &publish_statistics));
+  if (!spooler_files.IsValid()) {
+    PrintError("Failed to create file spooler");
+    return 3;
+  }
+  const UniquePtr<upload::Spooler> spooler_catalogs(
+      upload::Spooler::Construct(spooler_definition_catalogs,
+                                 &publish_statistics));
+  if (!spooler_catalogs.IsValid()) {
+    PrintError("Failed to create catalog spooler");
+    return 3;
+  }
+
+  // Initialize download manager and signature manager
+  const bool follow_redirects = (args.count('L') > 0);
+  const string proxy = (args.count('@') > 0) ? *args.find('@')->second : "";
+  if (!InitDownloadManager(follow_redirects, proxy)) {
+    PrintError("Failed to initialize download manager");
+    return 3;
+  }
+  if (!InitSignatureManager(public_keys)) {
+    PrintError("Failed to initialize signature manager");
+    return 3;
+  }
+
+  // Fetch repository manifest
+  const UniquePtr<manifest::Manifest> manifest(
+      FetchRemoteManifest(stratum0, repo_name, base_hash));
+  if (!manifest.IsValid()) {
+    PrintError("Failed to load repository manifest");
+    return 3;
+  }
+
+  const string old_root_hash = manifest->catalog_hash().ToString(true);
+  LogCvmfs(kLogCvmfs, kLogStdout, "Root catalog hash: %s",
+           old_root_hash.c_str());
+
+  // Check merge cache first (unless force refresh)
+  const string cache_key = ComputeCacheKey(layers);
+  map<string, OverlayEntry> merged;
+  bool cache_hit = false;
+
+  if (!force_refresh && !cache_dir.empty()) {
+    cache_hit = CheckCachedMerge(cache_dir, cache_key, &merged);
+  }
+
+  if (!cache_hit) {
+    // Load root catalog for reading layer entries
+    catalog::Catalog *root_catalog = LoadCatalogForPath(
+        stratum0, "", temp_dir, manifest->catalog_hash());
+    if (root_catalog == NULL) {
+      PrintError("Failed to load root catalog");
+      return 1;
+    }
+
+    // Process layers bottom-to-top
+    for (size_t i = 0; i < layers.size(); ++i) {
+      string layer_path = MakeCanonicalPath(layers[i]);
+      // Ensure layer path starts with exactly one '/'
+      while (layer_path.length() > 1
+             && layer_path[0] == '/' && layer_path[1] == '/') {
+        layer_path = layer_path.substr(1);
+      }
+      if (layer_path.empty() || layer_path[0] != '/') {
+        layer_path = "/" + layer_path;
+      }
+      
+      LogCvmfs(kLogCvmfs, kLogStdout, "Processing layer %zu: %s",
+               i, layer_path.c_str());
+
+      map<string, OverlayEntry> layer_entries;
+
+      // Look up the subdirectory in the root catalog
+      catalog::DirectoryEntry subdir_entry;
+      const PathString ps_layer_path(layer_path.data(), layer_path.length());
+      if (!root_catalog->LookupPath(ps_layer_path, &subdir_entry)) {
+        LogCvmfs(kLogCvmfs, kLogStderr, "Layer path not found: %s",
+                 layer_path.c_str());
+        delete root_catalog;
+        return 1;
+      }
+
+      // Check if this is a nested catalog mountpoint
+      if (subdir_entry.IsNestedCatalogMountpoint()) {
+        shash::Any nested_hash;
+        uint64_t nested_size;
+        if (!root_catalog->FindNested(ps_layer_path, &nested_hash,
+                                      &nested_size)) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+                   "Failed to find nested catalog for %s",
+                   layer_path.c_str());
+          delete root_catalog;
+          return 1;
+        }
+
+        catalog::Catalog *nested_catalog = LoadCatalogForPath(
+            stratum0, layer_path, temp_dir, nested_hash);
+        if (nested_catalog == NULL) {
+          LogCvmfs(kLogCvmfs, kLogStderr,
+                   "Failed to load nested catalog for %s",
+                   layer_path.c_str());
+          delete root_catalog;
+          return 1;
+        }
+
+        ReadCatalogEntries(nested_catalog, layer_path, "", &layer_entries);
+        delete nested_catalog;
+      } else {
+        ReadCatalogEntries(root_catalog, layer_path, "", &layer_entries);
+      }
+
+      LogCvmfs(kLogCvmfs, kLogStdout, "  Read %zu entries from layer %s",
+               layer_entries.size(), layer_path.c_str());
+
+      MergeLayer(layer_entries, &merged);
+
+      LogCvmfs(kLogCvmfs, kLogStdout, "  Merged total: %zu entries",
+               merged.size());
+    }
+
+    delete root_catalog;
+
+    // Cache the merge result
+    if (!cache_dir.empty()) {
+      StoreMergeInCache(cache_dir, cache_key, merged);
+    }
+  }
+
+  // Set up WritableCatalogManager and publish merged entries
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Publishing %zu merged entries under %s",
+           merged.size(), dest_path.c_str());
+
+  catalog::WritableCatalogManager catalog_manager(
+      base_hash, stratum0, temp_dir,
+      spooler_catalogs.weak_ref(), download_manager(),
+      false /* enforce_limits */,
+      0 /* nested_kcatalog_limit */,
+      0 /* root_kcatalog_limit */,
+      0 /* file_mbyte_limit */,
+      statistics(),
+      false /* is_balanceable */,
+      0 /* max_weight */, 0 /* min_weight */);
+  catalog_manager.Init();
+
+  if (!PublishMergedEntries(&catalog_manager, merged, dest_path)) {
+    PrintError("Failed to publish merged entries");
+    return 5;
+  }
+
+  // Commit catalog changes and produce updated manifest
+  catalog_manager.PrecalculateListings();
+  if (!catalog_manager.Commit(false, 0, manifest.weak_ref())) {
+    PrintError("Failed to commit catalog changes");
+    return 5;
+  }
+
+  // Finalize spoolers
+  LogCvmfs(kLogCvmfs, kLogStdout, "Waiting for uploads to finish...");
+  spooler_files->WaitForUpload();
+  spooler_catalogs->WaitForUpload();
+  spooler_files->FinalizeSession(false);
+
+  const string new_root_hash = manifest->catalog_hash().ToString(true);
+  if (!spooler_catalogs->FinalizeSession(true, old_root_hash, new_root_hash,
+                                         RepositoryTag())) {
+    PrintError("Failed to finalize session");
+    return 5;
+  }
+
+  // Export manifest
+  if (!manifest->Export(manifest_path)) {
+    PrintError("Failed to export manifest");
+    return 6;
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Overlay published successfully to %s", dest_path.c_str());
+  return 0;
+}
+
+}  // namespace swissknife

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -457,6 +457,21 @@ bool CommandOverlay::PublishMergedEntries(
   // content lives in its own catalog database file.  This also allows
   // StoreMergeInCache to simply copy the resulting DB instead of
   // re-inserting every entry.
+
+  // Add a .cvmfscatalog marker file 
+  catalog::DirectoryEntryBase catalog_marker;
+  catalog_marker.name_ = NameString(".cvmfscatalog");
+  catalog_marker.mode_ = (S_IFREG | 0666);
+  catalog_marker.size_ = 0;
+  catalog_marker.mtime_ = time(NULL);
+  catalog_marker.uid_ = 0;
+  catalog_marker.gid_ = 0;
+  catalog_marker.linkcount_ = 1;
+  // Hash of the compressed empty file
+  catalog_marker.checksum_ = shash::MkFromHexPtr(
+            shash::HexPtr("e8ec3d88b62ebf526e4e5a4ff6162a3aa48a6b78"),
+            shash::kSuffixNone);  // hash of ""
+  catalog_mgr->AddFile(catalog_marker, XattrList(), dest_path_rel);
   // CreateNestedCatalog calls MakeRelativePath internally which prepends '/'.
   // Pass the stripped version to avoid a double leading slash.
   catalog_mgr->CreateNestedCatalog(dest_path_rel);

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -102,8 +102,18 @@ bool CommandOverlay::CheckCachedMerge(
     return false;
   }
 
-  // Read entries: each entry is 6 lines:
-  //   relative_path, parent_path, mode, size, checksum_hex, name
+  // Read format version marker
+  if (!GetLineFile(f, &line) || line != "v2") {
+    fclose(f);
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "Stale cache format for key %s, will recompute",
+             cache_key.c_str());
+    return false;
+  }
+
+  // Read entries: each entry is 10 lines (v2 format):
+  //   relative_path, parent_path, mode, size, checksum_hex, name,
+  //   symlink_target, mtime, uid, gid
   merged->clear();
   while (GetLineFile(f, &line)) {
     OverlayEntry oe;
@@ -118,11 +128,25 @@ bool CommandOverlay::CheckCachedMerge(
     const string checksum_hex = line;
     if (!GetLineFile(f, &line)) break;
     const string entry_name = line;
+    if (!GetLineFile(f, &line)) break;
+    const string symlink_target = line;
+    if (!GetLineFile(f, &line)) break;
+    const int64_t mtime = String2Int64(line);
+    if (!GetLineFile(f, &line)) break;
+    const uint64_t uid = String2Uint64(line);
+    if (!GetLineFile(f, &line)) break;
+    const uint64_t gid = String2Uint64(line);
 
     catalog::DirectoryEntryBase base;
     base.name_.Assign(entry_name.data(), entry_name.length());
     base.mode_ = mode;
     base.size_ = size;
+    base.mtime_ = static_cast<time_t>(mtime);
+    base.uid_ = static_cast<uid_t>(uid);
+    base.gid_ = static_cast<gid_t>(gid);
+    if (!symlink_target.empty()) {
+      base.symlink_.Assign(symlink_target.data(), symlink_target.length());
+    }
     if (!checksum_hex.empty()) {
       base.checksum_ = shash::MkFromHexPtr(
           shash::HexPtr(checksum_hex), shash::kSuffixNone);
@@ -162,7 +186,12 @@ bool CommandOverlay::StoreMergeInCache(
   // Write timestamp
   fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(time(NULL)));
 
-  // Write entries
+  // Write format version marker (v2 includes symlink, mtime, uid, gid)
+  fprintf(f, "v2\n");
+
+  // Write entries: each entry is 10 lines:
+  //   relative_path, parent_path, mode, size, checksum_hex, name,
+  //   symlink_target, mtime, uid, gid
   for (map<string, OverlayEntry>::const_iterator it = merged.begin();
        it != merged.end(); ++it) {
     const OverlayEntry &oe = it->second;
@@ -172,6 +201,10 @@ bool CommandOverlay::StoreMergeInCache(
     fprintf(f, "%" PRIu64 "\n", oe.entry.size());
     fprintf(f, "%s\n", oe.entry.checksum().ToString().c_str());
     fprintf(f, "%s\n", oe.entry.name().ToString().c_str());
+    fprintf(f, "%s\n", oe.entry.symlink().ToString().c_str());
+    fprintf(f, "%" PRId64 "\n", static_cast<int64_t>(oe.entry.mtime()));
+    fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(oe.entry.uid()));
+    fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(oe.entry.gid()));
   }
 
   fclose(f);
@@ -483,6 +516,78 @@ catalog::Catalog *CommandOverlay::LoadCatalogForPath(
 }
 
 
+catalog::Catalog *CommandOverlay::FindCatalogForLayer(
+    const string &repo_base,
+    const string &temp_dir,
+    catalog::Catalog *catalog,
+    const string &layer_path,
+    vector<catalog::Catalog *> *loaded_catalogs) {
+  // First try a direct lookup in the given catalog
+  catalog::DirectoryEntry test_entry;
+  const PathString ps_layer(layer_path.data(), layer_path.length());
+  if (catalog->LookupPath(ps_layer, &test_entry)) {
+    return catalog;
+  }
+
+  // The path was not found directly.  Walk the path components *below*
+  // this catalog's mountpoint to find a nested catalog mountpoint that
+  // is an ancestor of layer_path.
+  const string mountpoint = catalog->mountpoint().ToString();
+
+  // Verify layer_path starts with the mountpoint (or mountpoint is empty
+  // for the root catalog)
+  if (!mountpoint.empty() && layer_path.substr(0, mountpoint.length())
+                                                            != mountpoint) {
+    return NULL;
+  }
+
+  // Get the suffix of layer_path below the mountpoint
+  const string suffix = mountpoint.empty() ? layer_path
+                                           : layer_path.substr(
+                                                 mountpoint.length());
+  const vector<string> components = SplitString(suffix, '/');
+  string prefix = mountpoint;
+  for (size_t i = 0; i < components.size(); ++i) {
+    if (components[i].empty()) continue;
+    prefix += "/" + components[i];
+
+    catalog::DirectoryEntry dir_entry;
+    const PathString ps_prefix(prefix.data(), prefix.length());
+    if (!catalog->LookupPath(ps_prefix, &dir_entry)) {
+      break;
+    }
+
+    if (dir_entry.IsNestedCatalogMountpoint()) {
+      shash::Any nested_hash;
+      uint64_t nested_size;
+      if (!catalog->FindNested(ps_prefix, &nested_hash, &nested_size)) {
+        LogCvmfs(kLogCvmfs, kLogStderr,
+                 "Failed to find nested catalog hash for %s", prefix.c_str());
+        return NULL;
+      }
+
+      catalog::Catalog *nested = LoadCatalogForPath(
+          repo_base, prefix, temp_dir, nested_hash);
+      if (nested == NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr,
+                 "Failed to load nested catalog at %s", prefix.c_str());
+        return NULL;
+      }
+      loaded_catalogs->push_back(nested);
+
+      // Recurse: the layer path may be directly in this nested catalog
+      // or in an even deeper nested catalog
+      return FindCatalogForLayer(
+          repo_base, temp_dir, nested, layer_path, loaded_catalogs);
+    }
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStderr, "Layer path not found: %s",
+           layer_path.c_str());
+  return NULL;
+}
+
+
 int CommandOverlay::Main(const ArgumentList &args) {
   // Parse publish workflow parameters
   const string spooler_definition_str = *args.find('r')->second;
@@ -622,25 +727,41 @@ int CommandOverlay::Main(const ArgumentList &args) {
 
       map<string, OverlayEntry> layer_entries;
 
-      // Look up the subdirectory in the root catalog
-      catalog::DirectoryEntry subdir_entry;
-      const PathString ps_layer_path(layer_path.data(), layer_path.length());
-      if (!root_catalog->LookupPath(ps_layer_path, &subdir_entry)) {
-        LogCvmfs(kLogCvmfs, kLogStderr, "Layer path not found: %s",
-                 layer_path.c_str());
+      // Find the catalog that contains this layer path (may be nested)
+      vector<catalog::Catalog *> loaded_catalogs;
+      catalog::Catalog *layer_catalog = FindCatalogForLayer(
+          stratum0, temp_dir, root_catalog, layer_path, &loaded_catalogs);
+      if (layer_catalog == NULL) {
+        for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+          delete loaded_catalogs[j];
         delete root_catalog;
         return 1;
       }
 
-      // Check if this is a nested catalog mountpoint
+      catalog::DirectoryEntry subdir_entry;
+      const PathString ps_layer_path(layer_path.data(), layer_path.length());
+      if (!layer_catalog->LookupPath(ps_layer_path, &subdir_entry)) {
+        LogCvmfs(kLogCvmfs, kLogStderr,
+                 "Unexpected: layer path not found after catalog resolution: %s",
+                 layer_path.c_str());
+        for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+          delete loaded_catalogs[j];
+        delete root_catalog;
+        return 1;
+      }
+
+      // Check if the layer path itself is a nested catalog mountpoint;
+      // if so, load that catalog and read its entries.
       if (subdir_entry.IsNestedCatalogMountpoint()) {
         shash::Any nested_hash;
         uint64_t nested_size;
-        if (!root_catalog->FindNested(ps_layer_path, &nested_hash,
-                                      &nested_size)) {
+        if (!layer_catalog->FindNested(ps_layer_path, &nested_hash,
+                                       &nested_size)) {
           LogCvmfs(kLogCvmfs, kLogStderr,
                    "Failed to find nested catalog for %s",
                    layer_path.c_str());
+          for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+            delete loaded_catalogs[j];
           delete root_catalog;
           return 1;
         }
@@ -651,6 +772,8 @@ int CommandOverlay::Main(const ArgumentList &args) {
           LogCvmfs(kLogCvmfs, kLogStderr,
                    "Failed to load nested catalog for %s",
                    layer_path.c_str());
+          for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+            delete loaded_catalogs[j];
           delete root_catalog;
           return 1;
         }
@@ -658,8 +781,12 @@ int CommandOverlay::Main(const ArgumentList &args) {
         ReadCatalogEntries(nested_catalog, layer_path, "", &layer_entries);
         delete nested_catalog;
       } else {
-        ReadCatalogEntries(root_catalog, layer_path, "", &layer_entries);
+        ReadCatalogEntries(layer_catalog, layer_path, "", &layer_entries);
       }
+
+      // Clean up any intermediate catalogs loaded during hierarchy walk
+      for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+        delete loaded_catalogs[j];
 
       LogCvmfs(kLogCvmfs, kLogStdout, "  Read %zu entries from layer %s",
                layer_entries.size(), layer_path.c_str());

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -62,108 +62,12 @@ ParameterList CommandOverlay::GetParams() const {
                "(bottom-to-top order)"));
   r.push_back(Parameter::Mandatory('d', "destination subdirectory path in "
                "repository for the merged overlay"));
-  r.push_back(Parameter::Optional('c', "cache directory for intermediate "
-               "merge results"));
   r.push_back(Parameter::Optional('e', "hash algorithm (default: sha1)"));
   r.push_back(Parameter::Optional('Z', "compression algorithm "
                "(default: zlib)"));
   r.push_back(Parameter::Optional('@', "proxy URL"));
-  r.push_back(Parameter::Switch('f', "force refresh (ignore cache)"));
   r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
   return r;
-}
-
-
-string CommandOverlay::ComputeCacheKey(
-    const vector<string> &layers) const {
-  string combined;
-  for (size_t i = 0; i < layers.size(); ++i) {
-    if (i > 0) combined += "\n";
-    combined += layers[i];
-  }
-  return shash::Sha256String(combined);
-}
-
-
-bool CommandOverlay::CheckCachedMerge(
-    const string &cache_dir,
-    const string &cache_key,
-    map<string, OverlayEntry> *merged) {
-  if (cache_dir.empty()) return false;
-
-  const string cache_path = cache_dir + "/" + cache_key + ".cache.db";
-  if (!FileExists(cache_path)) return false;
-
-  // Open the cached catalog database
-  catalog::WritableCatalog *cached_catalog =
-      catalog::WritableCatalog::AttachFreely(
-          "", cache_path, shash::Any(shash::kSha1));
-  if (cached_catalog == NULL) {
-    LogCvmfs(kLogCvmfs, kLogStderr,
-             "Failed to open cached catalog: %s", cache_path.c_str());
-    return false;
-  }
-
-  // Read all entries from the cached catalog
-  merged->clear();
-
-  // Helper function to recursively read entries from a catalog path
-  const bool success = ReadCatalogEntries(cached_catalog, "", "", "", "", merged);
-
-  delete cached_catalog;
-
-  if (!success) {
-    LogCvmfs(kLogCvmfs, kLogStderr,
-             "Failed to read entries from cached catalog: %s",
-             cache_path.c_str());
-    return false;
-  }
-
-  LogCvmfs(kLogCvmfs, kLogStdout,
-           "Cache hit for key %s (%zu entries)",
-           cache_key.c_str(), merged->size());
-  return true;
-}
-
-
-bool CommandOverlay::StoreMergeInCache(
-    const string &cache_dir,
-    const string &cache_key,
-    catalog::WritableCatalogManager *catalog_mgr,
-    const string &dest_path) const {
-  if (cache_dir.empty()) return false;
-
-  MkdirDeep(cache_dir, 0755);
-
-  const string cache_path = cache_dir + "/" + cache_key + ".cache.db";
-
-  // The nested catalog at dest_path already contains the complete set of
-  // merged entries (created by PublishMergedEntries).  Simply copy its
-  // database file into the cache.
-  // GetHostingCatalog calls MakeRelativePath internally which prepends '/'.
-  // Strip any leading '/' to avoid a double leading slash.
-  const string dest_path_rel = (!dest_path.empty() && dest_path[0] == '/')
-      ? dest_path.substr(1) : dest_path;
-  catalog::WritableCatalog *nested_catalog =
-      catalog_mgr->GetHostingCatalog(dest_path_rel);
-  if (nested_catalog == NULL) {
-    LogCvmfs(kLogCvmfs, kLogStderr,
-             "Failed to find nested catalog for cache: %s",
-             dest_path.c_str());
-    return false;
-  }
-
-  const string db_path = nested_catalog->database_path();
-  if (!CopyPath2Path(db_path, cache_path)) {
-    LogCvmfs(kLogCvmfs, kLogStderr,
-             "Failed to copy nested catalog to cache: %s -> %s",
-             db_path.c_str(), cache_path.c_str());
-    return false;
-  }
-
-  LogCvmfs(kLogCvmfs, kLogStdout, "Stored merge result in cache: %s",
-           cache_key.c_str());
-  return true;
 }
 
 
@@ -463,9 +367,7 @@ bool CommandOverlay::PublishMergedEntries(
   }
 
   // Turn the destination directory into a nested catalog so that the overlay
-  // content lives in its own catalog database file.  This also allows
-  // StoreMergeInCache to simply copy the resulting DB instead of
-  // re-inserting every entry.
+  // content lives in its own catalog database file.
 
   // Add a .cvmfscatalog marker file 
   catalog::DirectoryEntryBase catalog_marker;
@@ -636,10 +538,6 @@ int CommandOverlay::Main(const ArgumentList &args) {
   if (dest_path.empty() || dest_path[0] != '/') {
     dest_path = "/" + dest_path;
   }
-  const string cache_dir =
-      (args.count('c') > 0) ? *args.find('c')->second : "";
-  const bool force_refresh = (args.count('f') > 0);
-
   shash::Algorithms hash_algorithm = shash::kSha1;
   if (args.find('e') != args.end()) {
     hash_algorithm = shash::ParseHashAlgorithm(*args.find('e')->second);
@@ -718,57 +616,64 @@ int CommandOverlay::Main(const ArgumentList &args) {
   LogCvmfs(kLogCvmfs, kLogStdout, "Root catalog hash: %s",
            old_root_hash.c_str());
 
-  // Check merge cache first (unless force refresh)
-  const string cache_key = ComputeCacheKey(layers);
+  // Load root catalog for reading layer entries
   map<string, OverlayEntry> merged;
-  bool cache_hit = false;
-
-  if (!force_refresh && !cache_dir.empty()) {
-    cache_hit = CheckCachedMerge(cache_dir, cache_key, &merged);
+  catalog::Catalog *root_catalog = LoadCatalogForPath(
+      stratum0, "", temp_dir, manifest->catalog_hash());
+  if (root_catalog == NULL) {
+    PrintError("Failed to load root catalog");
+    return 1;
   }
 
-  if (!cache_hit) {
-    // Load root catalog for reading layer entries
-    catalog::Catalog *root_catalog = LoadCatalogForPath(
-        stratum0, "", temp_dir, manifest->catalog_hash());
-    if (root_catalog == NULL) {
-      PrintError("Failed to load root catalog");
+  // Process layers bottom-to-top
+  for (size_t i = 0; i < layers.size(); ++i) {
+    string layer_path = MakeCanonicalPath(layers[i]);
+    // Ensure layer path starts with exactly one '/'
+    while (layer_path.length() > 1
+           && layer_path[0] == '/' && layer_path[1] == '/') {
+      layer_path = layer_path.substr(1);
+    }
+    if (layer_path.empty() || layer_path[0] != '/') {
+      layer_path = "/" + layer_path;
+    }
+
+    LogCvmfs(kLogCvmfs, kLogStdout, "Processing layer %zu: %s",
+             i, layer_path.c_str());
+
+    map<string, OverlayEntry> layer_entries;
+
+    // Find the catalog that contains this layer path (may be nested)
+    vector<catalog::Catalog *> loaded_catalogs;
+    catalog::Catalog *layer_catalog = FindCatalogForLayer(
+        stratum0, temp_dir, root_catalog, layer_path, &loaded_catalogs);
+    if (layer_catalog == NULL) {
+      for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+        delete loaded_catalogs[j];
+      delete root_catalog;
       return 1;
     }
 
-    // Process layers bottom-to-top
-    for (size_t i = 0; i < layers.size(); ++i) {
-      string layer_path = MakeCanonicalPath(layers[i]);
-      // Ensure layer path starts with exactly one '/'
-      while (layer_path.length() > 1
-             && layer_path[0] == '/' && layer_path[1] == '/') {
-        layer_path = layer_path.substr(1);
-      }
-      if (layer_path.empty() || layer_path[0] != '/') {
-        layer_path = "/" + layer_path;
-      }
-      
-      LogCvmfs(kLogCvmfs, kLogStdout, "Processing layer %zu: %s",
-               i, layer_path.c_str());
+    catalog::DirectoryEntry subdir_entry;
+    const PathString ps_layer_path(layer_path.data(), layer_path.length());
+    if (!layer_catalog->LookupPath(ps_layer_path, &subdir_entry)) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Unexpected: layer path not found after catalog resolution: %s",
+               layer_path.c_str());
+      for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+        delete loaded_catalogs[j];
+      delete root_catalog;
+      return 1;
+    }
 
-      map<string, OverlayEntry> layer_entries;
-
-      // Find the catalog that contains this layer path (may be nested)
-      vector<catalog::Catalog *> loaded_catalogs;
-      catalog::Catalog *layer_catalog = FindCatalogForLayer(
-          stratum0, temp_dir, root_catalog, layer_path, &loaded_catalogs);
-      if (layer_catalog == NULL) {
-        for (size_t j = 0; j < loaded_catalogs.size(); ++j)
-          delete loaded_catalogs[j];
-        delete root_catalog;
-        return 1;
-      }
-
-      catalog::DirectoryEntry subdir_entry;
-      const PathString ps_layer_path(layer_path.data(), layer_path.length());
-      if (!layer_catalog->LookupPath(ps_layer_path, &subdir_entry)) {
+    // Check if the layer path itself is a nested catalog mountpoint;
+    // if so, load that catalog and read its entries.
+    if (subdir_entry.IsNestedCatalogMountpoint()) {
+      shash::Any nested_hash;
+      uint64_t nested_size;
+      if (!layer_catalog->FindNested(ps_layer_path, &nested_hash,
+                                     &nested_size)) {
         LogCvmfs(kLogCvmfs, kLogStderr,
-                 "Unexpected: layer path not found after catalog resolution: %s",
+                 "Failed to find nested catalog for %s",
                  layer_path.c_str());
         for (size_t j = 0; j < loaded_catalogs.size(); ++j)
           delete loaded_catalogs[j];
@@ -776,57 +681,40 @@ int CommandOverlay::Main(const ArgumentList &args) {
         return 1;
       }
 
-      // Check if the layer path itself is a nested catalog mountpoint;
-      // if so, load that catalog and read its entries.
-      if (subdir_entry.IsNestedCatalogMountpoint()) {
-        shash::Any nested_hash;
-        uint64_t nested_size;
-        if (!layer_catalog->FindNested(ps_layer_path, &nested_hash,
-                                       &nested_size)) {
-          LogCvmfs(kLogCvmfs, kLogStderr,
-                   "Failed to find nested catalog for %s",
-                   layer_path.c_str());
-          for (size_t j = 0; j < loaded_catalogs.size(); ++j)
-            delete loaded_catalogs[j];
-          delete root_catalog;
-          return 1;
-        }
-
-        catalog::Catalog *nested_catalog = LoadCatalogForPath(
-            stratum0, layer_path, temp_dir, nested_hash);
-        if (nested_catalog == NULL) {
-          LogCvmfs(kLogCvmfs, kLogStderr,
-                   "Failed to load nested catalog for %s",
-                   layer_path.c_str());
-          for (size_t j = 0; j < loaded_catalogs.size(); ++j)
-            delete loaded_catalogs[j];
-          delete root_catalog;
-          return 1;
-        }
-
-        ReadCatalogEntries(nested_catalog, layer_path, "",
-                           stratum0, temp_dir, &layer_entries);
-        delete nested_catalog;
-      } else {
-        ReadCatalogEntries(layer_catalog, layer_path, "",
-                           stratum0, temp_dir, &layer_entries);
+      catalog::Catalog *nested_catalog = LoadCatalogForPath(
+          stratum0, layer_path, temp_dir, nested_hash);
+      if (nested_catalog == NULL) {
+        LogCvmfs(kLogCvmfs, kLogStderr,
+                 "Failed to load nested catalog for %s",
+                 layer_path.c_str());
+        for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+          delete loaded_catalogs[j];
+        delete root_catalog;
+        return 1;
       }
 
-      // Clean up any intermediate catalogs loaded during hierarchy walk
-      for (size_t j = 0; j < loaded_catalogs.size(); ++j)
-        delete loaded_catalogs[j];
-
-      LogCvmfs(kLogCvmfs, kLogStdout, "  Read %zu entries from layer %s",
-               layer_entries.size(), layer_path.c_str());
-
-      MergeLayer(layer_entries, &merged);
-
-      LogCvmfs(kLogCvmfs, kLogStdout, "  Merged total: %zu entries",
-               merged.size());
+      ReadCatalogEntries(nested_catalog, layer_path, "",
+                         stratum0, temp_dir, &layer_entries);
+      delete nested_catalog;
+    } else {
+      ReadCatalogEntries(layer_catalog, layer_path, "",
+                         stratum0, temp_dir, &layer_entries);
     }
 
-    delete root_catalog;
+    // Clean up any intermediate catalogs loaded during hierarchy walk
+    for (size_t j = 0; j < loaded_catalogs.size(); ++j)
+      delete loaded_catalogs[j];
+
+    LogCvmfs(kLogCvmfs, kLogStdout, "  Read %zu entries from layer %s",
+             layer_entries.size(), layer_path.c_str());
+
+    MergeLayer(layer_entries, &merged);
+
+    LogCvmfs(kLogCvmfs, kLogStdout, "  Merged total: %zu entries",
+             merged.size());
   }
+
+  delete root_catalog;
 
   // Set up WritableCatalogManager and publish merged entries
   LogCvmfs(kLogCvmfs, kLogStdout,
@@ -848,11 +736,6 @@ int CommandOverlay::Main(const ArgumentList &args) {
   if (!PublishMergedEntries(&catalog_manager, merged, dest_path)) {
     PrintError("Failed to publish merged entries");
     return 5;
-  }
-
-  // Cache the nested catalog that PublishMergedEntries created at dest_path
-  if (!cache_hit && !cache_dir.empty()) {
-    StoreMergeInCache(cache_dir, cache_key, &catalog_manager, dest_path);
   }
 
   // Commit catalog changes and produce updated manifest

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -135,7 +135,7 @@ bool CommandOverlay::StoreMergeInCache(
 
   MkdirDeep(cache_dir, 0755);
 
-  const string cache_path = cache_dir + "/" + cache_key + "cache.db";
+  const string cache_path = cache_dir + "/" + cache_key + ".cache.db";
 
   // The nested catalog at dest_path already contains the complete set of
   // merged entries (created by PublishMergedEntries).  Simply copy its

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -23,6 +23,8 @@
 
 #include "catalog.h"
 #include "catalog_mgr_rw.h"
+#include "catalog_rw.h"
+#include "catalog_sql.h"
 #include "compression/compression.h"
 #include "crypto/hash.h"
 #include "directory_entry.h"
@@ -89,77 +91,34 @@ bool CommandOverlay::CheckCachedMerge(
     map<string, OverlayEntry> *merged) const {
   if (cache_dir.empty()) return false;
 
-  const string cache_path = cache_dir + "/" + cache_key + ".cache";
+  const string cache_path = cache_dir + "/" + cache_key + ".db";
   if (!FileExists(cache_path)) return false;
 
-  FILE *f = fopen(cache_path.c_str(), "r");
-  if (f == NULL) return false;
-
-  // Read timestamp line
-  string line;
-  if (!GetLineFile(f, &line) || line.empty()) {
-    fclose(f);
+  // Open the cached catalog database
+  catalog::WritableCatalog *cached_catalog =
+      catalog::WritableCatalog::AttachFreely(
+          "", cache_path, shash::Any(shash::kSha1));
+  if (cached_catalog == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to open cached catalog: %s", cache_path.c_str());
     return false;
   }
 
-  // Read format version marker
-  if (!GetLineFile(f, &line) || line != "v2") {
-    fclose(f);
-    LogCvmfs(kLogCvmfs, kLogStdout,
-             "Stale cache format for key %s, will recompute",
-             cache_key.c_str());
-    return false;
-  }
-
-  // Read entries: each entry is 10 lines (v2 format):
-  //   relative_path, parent_path, mode, size, checksum_hex, name,
-  //   symlink_target, mtime, uid, gid
+  // Read all entries from the cached catalog
   merged->clear();
-  while (GetLineFile(f, &line)) {
-    OverlayEntry oe;
-    oe.path = line;
-    if (!GetLineFile(f, &line)) break;
-    oe.parent = line;
-    if (!GetLineFile(f, &line)) break;
-    const unsigned int mode = String2Uint64(line);
-    if (!GetLineFile(f, &line)) break;
-    const uint64_t size = String2Uint64(line);
-    if (!GetLineFile(f, &line)) break;
-    const string checksum_hex = line;
-    if (!GetLineFile(f, &line)) break;
-    const string entry_name = line;
-    if (!GetLineFile(f, &line)) break;
-    const string symlink_target = line;
-    if (!GetLineFile(f, &line)) break;
-    const int64_t mtime = String2Int64(line);
-    if (!GetLineFile(f, &line)) break;
-    const uint64_t uid = String2Uint64(line);
-    if (!GetLineFile(f, &line)) break;
-    const uint64_t gid = String2Uint64(line);
 
-    catalog::DirectoryEntryBase base;
-    base.name_.Assign(entry_name.data(), entry_name.length());
-    base.mode_ = mode;
-    base.size_ = size;
-    base.mtime_ = static_cast<time_t>(mtime);
-    base.uid_ = static_cast<uid_t>(uid);
-    base.gid_ = static_cast<gid_t>(gid);
-    if (!symlink_target.empty()) {
-      base.symlink_.Assign(symlink_target.data(), symlink_target.length());
-    }
-    if (!checksum_hex.empty()) {
-      base.checksum_ = shash::MkFromHexPtr(
-          shash::HexPtr(checksum_hex), shash::kSuffixNone);
-    }
-    base.linkcount_ = 1;
-    oe.entry = catalog::DirectoryEntry(base);
-    oe.is_whiteout = false;
-    oe.is_opaque_dir = false;
+  // Helper function to recursively read entries from a catalog path
+  bool success = ReadCatalogEntries(cached_catalog, "", "", merged);
 
-    (*merged)[oe.path] = oe;
+  delete cached_catalog;
+
+  if (!success) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to read entries from cached catalog: %s",
+             cache_path.c_str());
+    return false;
   }
 
-  fclose(f);
   LogCvmfs(kLogCvmfs, kLogStdout,
            "Cache hit for key %s (%zu entries)",
            cache_key.c_str(), merged->size());
@@ -175,39 +134,64 @@ bool CommandOverlay::StoreMergeInCache(
 
   MkdirDeep(cache_dir, 0755);
 
-  const string cache_path = cache_dir + "/" + cache_key + ".cache";
-  FILE *f = fopen(cache_path.c_str(), "w");
-  if (f == NULL) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create cache file: %s",
+  const string cache_path = cache_dir + "/" + cache_key + ".db";
+
+  // Create a new catalog database
+  catalog::CatalogDatabase *cache_db =
+      catalog::CatalogDatabase::Create(cache_path);
+  if (cache_db == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "Failed to create cache database: %s",
              cache_path.c_str());
     return false;
   }
 
-  // Write timestamp
-  fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(time(NULL)));
+  // Create a root directory entry for the catalog
+  catalog::DirectoryEntry root_entry;
+  root_entry.mode_ = 0755 | S_IFDIR;
+  root_entry.uid_ = 0;
+  root_entry.gid_ = 0;
+  root_entry.mtime_ = time(NULL);
 
-  // Write format version marker (v2 includes symlink, mtime, uid, gid)
-  fprintf(f, "v2\n");
+  // Initialize the catalog with root entry
+  const bool volatile_content = false;
+  if (!cache_db->InsertInitialValues("", volatile_content, "", root_entry)) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to initialize cache catalog: %s", cache_path.c_str());
+    delete cache_db;
+    unlink(cache_path.c_str());
+    return false;
+  }
 
-  // Write entries: each entry is 10 lines:
-  //   relative_path, parent_path, mode, size, checksum_hex, name,
-  //   symlink_target, mtime, uid, gid
+  delete cache_db;
+  cache_db = NULL;
+
+  // Open the catalog as writable to add entries
+  catalog::WritableCatalog *cache_catalog =
+      catalog::WritableCatalog::AttachFreely(
+          "", cache_path, shash::Any(shash::kSha1));
+  if (cache_catalog == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to open cache catalog for writing: %s",
+             cache_path.c_str());
+    unlink(cache_path.c_str());
+    return false;
+  }
+
+  cache_catalog->Transaction();
+
+  // Add all merged entries to the catalog
   for (map<string, OverlayEntry>::const_iterator it = merged.begin();
        it != merged.end(); ++it) {
     const OverlayEntry &oe = it->second;
-    fprintf(f, "%s\n", oe.path.c_str());
-    fprintf(f, "%s\n", oe.parent.c_str());
-    fprintf(f, "%u\n", oe.entry.mode());
-    fprintf(f, "%" PRIu64 "\n", oe.entry.size());
-    fprintf(f, "%s\n", oe.entry.checksum().ToString().c_str());
-    fprintf(f, "%s\n", oe.entry.name().ToString().c_str());
-    fprintf(f, "%s\n", oe.entry.symlink().ToString().c_str());
-    fprintf(f, "%" PRId64 "\n", static_cast<int64_t>(oe.entry.mtime()));
-    fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(oe.entry.uid()));
-    fprintf(f, "%" PRIu64 "\n", static_cast<uint64_t>(oe.entry.gid()));
+    const string entry_path = "/" + oe.path;
+    const string parent_path = oe.parent.empty() ? "" : "/" + oe.parent;
+
+    cache_catalog->AddEntry(oe.entry, oe.xattrs, entry_path, parent_path);
   }
 
-  fclose(f);
+  cache_catalog->Commit();
+  delete cache_catalog;
+
   LogCvmfs(kLogCvmfs, kLogStdout, "Stored merge result in cache: %s",
            cache_key.c_str());
   return true;

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -108,7 +108,7 @@ bool CommandOverlay::CheckCachedMerge(
   merged->clear();
 
   // Helper function to recursively read entries from a catalog path
-  bool success = ReadCatalogEntries(cached_catalog, "", "", "", "", merged);
+  const bool success = ReadCatalogEntries(cached_catalog, "", "", "", "", merged);
 
   delete cached_catalog;
 

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -130,6 +130,21 @@ class CommandOverlay : public Command {
       const std::string &subdirectory,
       const std::string &temp_dir,
       const shash::Any &root_hash);
+
+  /**
+   * Find the catalog that contains the given layer path by walking the
+   * nested catalog hierarchy.  The layer path may be deep inside a nested
+   * catalog (e.g. /.layers/ab/abcdef.../layerfs where /.layers is a nested
+   * catalog mountpoint).  Returns the catalog that can look up layer_path,
+   * or NULL on failure.  The caller takes ownership of any additionally
+   * loaded catalogs returned via loaded_catalogs.
+   */
+  catalog::Catalog *FindCatalogForLayer(
+      const std::string &repo_base,
+      const std::string &temp_dir,
+      catalog::Catalog *root_catalog,
+      const std::string &layer_path,
+      std::vector<catalog::Catalog *> *loaded_catalogs);
 };
 
 }  // namespace swissknife

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -68,26 +68,31 @@ class CommandOverlay : public Command {
    */
   bool CheckCachedMerge(const std::string &cache_dir,
                         const std::string &cache_key,
-                        std::map<std::string, OverlayEntry> *merged) const;
+                        std::map<std::string, OverlayEntry> *merged);
 
   /**
-   * Store the merged entry map in the cache with the given key.
-   * Creates a SQLite catalog database file containing all merged entries.
+   * Store the merge result in the cache by copying the nested catalog
+   * database that was created at dest_path during PublishMergedEntries.
    */
   bool StoreMergeInCache(
       const std::string &cache_dir,
       const std::string &cache_key,
-      const std::map<std::string, OverlayEntry> &merged) const;
+      catalog::WritableCatalogManager *catalog_mgr,
+      const std::string &dest_path) const;
 
   /**
    * Recursively read all entries from a catalog rooted at the given path.
    * The entries are stored with paths relative to the layer root.
+   * When a nested catalog mountpoint is encountered and repo_base/temp_dir
+   * are non-empty, the nested catalog is loaded and recursed into.
    */
   bool ReadCatalogEntries(
       catalog::Catalog *catalog,
       const std::string &catalog_root_path,
       const std::string &relative_prefix,
-      std::map<std::string, OverlayEntry> *entries) const;
+      const std::string &repo_base,
+      const std::string &temp_dir,
+      std::map<std::string, OverlayEntry> *entries);
 
   /**
    * Check if a filename represents a whiteout file (.wh.<name>).

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -1,0 +1,138 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * Swissknife command for performing catalog-level overlays of multiple
+ * subdirectories from a CVMFS repository, similar to how OverlayFS or
+ * container engines merge container image layers.
+ *
+ * The overlay tool merges the catalog entries of multiple layer subdirectories
+ * and publishes the result as a new subdirectory in the CVMFS repository,
+ * following the same publish workflow as swissknife sync/ingest.
+ */
+
+#ifndef CVMFS_SWISSKNIFE_OVERLAY_H_
+#define CVMFS_SWISSKNIFE_OVERLAY_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "catalog.h"
+#include "catalog_mgr_rw.h"
+#include "directory_entry.h"
+#include "shortstring.h"
+#include "swissknife.h"
+#include "xattr.h"
+
+namespace swissknife {
+
+/**
+ * Represents a single entry in the merged overlay catalog, tracking
+ * which layer it came from and its metadata.
+ */
+struct OverlayEntry {
+  catalog::DirectoryEntry entry;
+  XattrList xattrs;
+  std::string path;       // relative path in the merged view
+  std::string parent;     // parent directory relative path in the merged view
+  bool is_whiteout;       // true if this is a whiteout marker
+  bool is_opaque_dir;     // true if directory has opaque marker
+
+  OverlayEntry()
+      : is_whiteout(false), is_opaque_dir(false) {}
+};
+
+class CommandOverlay : public Command {
+ public:
+  virtual ~CommandOverlay() {}
+
+  virtual std::string GetName() const { return "overlay"; }
+  virtual std::string GetDescription() const {
+    return "Merge multiple CVMFS subdirectory catalogs using overlay "
+           "semantics and publish the result as a repository subdirectory";
+  }
+  virtual ParameterList GetParams() const;
+  virtual int Main(const ArgumentList &args);
+
+ private:
+  /**
+   * Compute SHA-256 cache key from the ordered list of layer paths.
+   */
+  std::string ComputeCacheKey(const std::vector<std::string> &layers) const;
+
+  /**
+   * Check if a valid cached catalog exists for the given cache key.
+   * The cached catalog stores the serialized merged OverlayEntry map so that
+   * re-running the same layer combination can skip the merge computation.
+   */
+  bool CheckCachedMerge(const std::string &cache_dir,
+                        const std::string &cache_key,
+                        std::map<std::string, OverlayEntry> *merged) const;
+
+  /**
+   * Store the merged entry map in the cache with the given key.
+   */
+  bool StoreMergeInCache(
+      const std::string &cache_dir,
+      const std::string &cache_key,
+      const std::map<std::string, OverlayEntry> &merged) const;
+
+  /**
+   * Recursively read all entries from a catalog rooted at the given path.
+   * The entries are stored with paths relative to the layer root.
+   */
+  bool ReadCatalogEntries(
+      catalog::Catalog *catalog,
+      const std::string &catalog_root_path,
+      const std::string &relative_prefix,
+      std::map<std::string, OverlayEntry> *entries) const;
+
+  /**
+   * Check if a filename represents a whiteout file (.wh.<name>).
+   */
+  static bool IsWhiteoutFile(const std::string &name);
+
+  /**
+   * Get the original filename from a whiteout filename.
+   * E.g., ".wh.foo" -> "foo"
+   */
+  static std::string GetWhiteoutTarget(const std::string &name);
+
+  /**
+   * Check if a filename represents an opaque directory marker (.wh..wh..opq).
+   */
+  static bool IsOpaqueMarker(const std::string &name);
+
+  /**
+   * Merge entries from a higher layer into the accumulated overlay map.
+   * Implements overlay semantics: whiteout handling, opaque dirs, overrides.
+   */
+  void MergeLayer(
+      const std::map<std::string, OverlayEntry> &layer_entries,
+      std::map<std::string, OverlayEntry> *merged) const;
+
+  /**
+   * Publish the merged overlay entries into the repository under dest_path
+   * using the WritableCatalogManager.  This adds directory and file entries
+   * to the live catalog, then commits the changes to produce a new manifest.
+   */
+  bool PublishMergedEntries(
+      catalog::WritableCatalogManager *catalog_mgr,
+      const std::map<std::string, OverlayEntry> &merged,
+      const std::string &dest_path) const;
+
+  /**
+   * Load a catalog from the repository for a given subdirectory path.
+   * Handles both local and remote repositories.
+   */
+  catalog::Catalog *LoadCatalogForPath(
+      const std::string &repo_base,
+      const std::string &subdirectory,
+      const std::string &temp_dir,
+      const shash::Any &root_hash);
+};
+
+}  // namespace swissknife
+
+#endif  // CVMFS_SWISSKNIFE_OVERLAY_H_
+

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -62,8 +62,9 @@ class CommandOverlay : public Command {
 
   /**
    * Check if a valid cached catalog exists for the given cache key.
-   * The cached catalog stores the serialized merged OverlayEntry map so that
-   * re-running the same layer combination can skip the merge computation.
+   * The cached catalog is stored as a SQLite database file containing
+   * the merged overlay entries, so that re-running the same layer
+   * combination can skip the merge computation.
    */
   bool CheckCachedMerge(const std::string &cache_dir,
                         const std::string &cache_key,
@@ -71,6 +72,7 @@ class CommandOverlay : public Command {
 
   /**
    * Store the merged entry map in the cache with the given key.
+   * Creates a SQLite catalog database file containing all merged entries.
    */
   bool StoreMergeInCache(
       const std::string &cache_dir,

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -2,12 +2,15 @@
  * This file is part of the CernVM File System.
  *
  * Swissknife command for performing catalog-level overlays of multiple
- * subdirectories from a CVMFS repository, similar to how OverlayFS or
+ * subdirectories from a CVMFS repository, similar to OverlayFS or how
  * container engines merge container image layers.
  *
- * The overlay tool merges the catalog entries of multiple layer subdirectories
- * and publishes the result as a new subdirectory in the CVMFS repository,
- * following the same publish workflow as swissknife sync/ingest.
+ * The overlay tool merges the catalog entries of multiple layer subdirectories,
+ * typically corresponding to container layers, and publishes the result as 
+ * a new subdirectory in the CVMFS repository, typically corresponding to the flat 
+ * root file system of the container image. 
+ * 
+ * The publish workflow is taken from swissknife ingest.
  */
 
 #ifndef CVMFS_SWISSKNIFE_OVERLAY_H_

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -59,31 +59,6 @@ class CommandOverlay : public Command {
 
  private:
   /**
-   * Compute SHA-256 cache key from the ordered list of layer paths.
-   */
-  std::string ComputeCacheKey(const std::vector<std::string> &layers) const;
-
-  /**
-   * Check if a valid cached catalog exists for the given cache key.
-   * The cached catalog is stored as a SQLite database file containing
-   * the merged overlay entries, so that re-running the same layer
-   * combination can skip the merge computation.
-   */
-  bool CheckCachedMerge(const std::string &cache_dir,
-                        const std::string &cache_key,
-                        std::map<std::string, OverlayEntry> *merged);
-
-  /**
-   * Store the merge result in the cache by copying the nested catalog
-   * database that was created at dest_path during PublishMergedEntries.
-   */
-  bool StoreMergeInCache(
-      const std::string &cache_dir,
-      const std::string &cache_key,
-      catalog::WritableCatalogManager *catalog_mgr,
-      const std::string &dest_path) const;
-
-  /**
    * Recursively read all entries from a catalog rooted at the given path.
    * The entries are stored with paths relative to the layer root.
    * When a nested catalog mountpoint is encountered and repo_base/temp_dir

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -17,13 +17,13 @@ else()
     # cvmfs2
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs2.1"
-        COMMAND ${HELP2MAN} 
+        COMMAND ${HELP2MAN}
             -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
             -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs2.h2m
-            --no-info 
-            --section=1 
+            --no-info
+            --section=1
             --output=${MAN_OUTPUT_DIR}/cvmfs2.1
-            --name "cvmfs2: fuse client for the CernVM-Filesystem" 
+            --name "cvmfs2: fuse client for the CernVM-Filesystem"
             "$<TARGET_FILE:cvmfs2>"
         DEPENDS cvmfs2 cvmfs_fuse3 cvmfs_fuse3_stub
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cvmfs/
@@ -39,6 +39,7 @@ else()
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
         COMPONENT documentation
     )
+    endif()
     # cvmfs_config
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_config.1"

--- a/doc/manpages/CMakeLists.txt
+++ b/doc/manpages/CMakeLists.txt
@@ -17,13 +17,13 @@ else()
     # cvmfs2
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs2.1"
-        COMMAND ${HELP2MAN}
+        COMMAND ${HELP2MAN} 
             -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs_common.h2m
             -i ${CMAKE_CURRENT_LIST_DIR}/cvmfs2.h2m
-            --no-info
-            --section=1
+            --no-info 
+            --section=1 
             --output=${MAN_OUTPUT_DIR}/cvmfs2.1
-            --name "cvmfs2: fuse client for the CernVM-Filesystem"
+            --name "cvmfs2: fuse client for the CernVM-Filesystem" 
             "$<TARGET_FILE:cvmfs2>"
         DEPENDS cvmfs2 cvmfs_fuse3 cvmfs_fuse3_stub
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cvmfs/
@@ -39,7 +39,6 @@ else()
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
         COMPONENT documentation
     )
-    endif()
     # cvmfs_config
     add_custom_command(
         OUTPUT "${MAN_OUTPUT_DIR}/cvmfs_config.1"

--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -91,18 +91,17 @@ var convertCmd = &cobra.Command{
 				"output image": wish.OutputName}
 			l.Log().WithFields(fields).Info("Start conversion of wish")
 
-
 			// Check if this wish is in the ignore errors list
 			isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
 
-      err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
-      if err != nil {
-        if isIgnored {
-          l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
-        } else {
-          l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-          conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
-        }
+			err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
+			if err != nil {
+				if isIgnored {
+					l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
+				} else {
+					l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
+					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+				}
 			}
 			if !skipThinImage {
 				err = lib.ConvertWishDocker(wish)

--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -29,7 +29,7 @@ func init() {
 	convertCmd.Flags().BoolVarP(&overwriteLayer, "overwrite-layers", "f", false, "overwrite the layer if they are already inside the CVMFS repository")
 	convertCmd.Flags().BoolVarP(&convertAgain, "convert-again", "g", false, "convert again images that are already successfully converted")
 	convertCmd.Flags().BoolVarP(&skipFlat, "skip-flat", "s", false, "do not create a flat image (compatible with singularity)")
-	convertCmd.Flags().BoolVarP(&skipLayers, "skip-layers", "d", false, "do not unpack the layers into the repository, implies --skip-thin-image and --skip-podman")
+	convertCmd.Flags().BoolVarP(&skipLayers, "skip-layers", "d", false, "[DEPRECATED] this option is no longer functional, layers will be unpacked regardless. Use `docker save` and `cvmfs_server ingest` if you only need the flat image.")
 	convertCmd.Flags().BoolVarP(&skipThinImage, "skip-thin-image", "i", false, "do not create and push the docker thin image")
 	convertCmd.Flags().BoolVarP(&skipPodman, "skip-podman", "p", false, "do not create podman image store")
 	rootCmd.AddCommand(convertCmd)
@@ -41,6 +41,10 @@ var convertCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		AliveMessage()
+
+		if skipLayers {
+			l.Log().Warn("--skip-layers is deprecated and no longer functional: layers will be unpacked regardless. If you only need the flat image, use `docker save` and `cvmfs_server ingest` instead.")
+		}
 
 		if (skipLayers == false) && (skipThinImage == false) {
 			_, err := lib.GetPassword()
@@ -70,12 +74,10 @@ var convertCmd = &cobra.Command{
 				"repository":   wish.CvmfsRepo,
 				"output image": wish.OutputName}
 			l.Log().WithFields(fields).Info("Start conversion of wish")
-			if !skipLayers {
-				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
-				if err != nil {
-					l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
-				}
+			err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
+			if err != nil {
+				l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
+				conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
 			}
 			if !skipThinImage {
 				err = lib.ConvertWishDocker(wish)

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -19,7 +19,7 @@ var (
 
 func init() {
 	convertSingleImageCmd.Flags().BoolVarP(&skipFlat, "skip-flat", "s", false, "do not create a flat images (compatible with singularity)")
-	convertSingleImageCmd.Flags().BoolVarP(&skipLayers, "skip-layers", "d", false, "do not unpack the layers into the repository, implies --skip-thin-image and --skip-podman")
+	convertSingleImageCmd.Flags().BoolVarP(&skipLayers, "skip-layers", "d", false, "[DEPRECATED] this option is no longer functional, layers will be unpacked regardless. Use `docker save` and `cvmfs_server ingest` if you only need the flat image.")
 	convertSingleImageCmd.Flags().BoolVarP(&skipThinImage, "skip-thin-image", "i", true, "do not create and push the docker thin image")
 	convertSingleImageCmd.Flags().BoolVarP(&skipPodman, "skip-podman", "p", true, "do not create podman image store")
 	convertSingleImageCmd.Flags().StringVarP(&username, "username", "u", "", "username to use when pushing thin image into the docker registry")
@@ -38,8 +38,8 @@ var convertSingleImageCmd = &cobra.Command{
 		inputImage := args[0]
 		cvmfsRepo := args[1]
 
-		if skipLayers == true {
-			l.Log().Info("Skipping the creation of the thin image and podman store since provided --skip-layers")
+		if skipLayers {
+			l.Log().Warn("--skip-layers is deprecated and no longer functional: layers will be unpacked regardless. If you only need the flat image, use `docker save` and `cvmfs_server ingest` instead.")
 			skipThinImage = true
 			skipPodman = true
 		}
@@ -77,22 +77,20 @@ var convertSingleImageCmd = &cobra.Command{
 
 		var conversionErrors []string
 
-		if !skipLayers {
-			for i := 0; i < attempts; i++ {
-				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
-				log := l.LogE(err).WithFields(fields).
-					WithFields(log.Fields{"attempts number": i})
-				if err != nil {
-					log.Warning("Could not convert wish (layers), trying again")
-				} else {
-					log.Info("Successfully converted the layers")
-					break
-				}
-			}
+		for i := 0; i < attempts; i++ {
+			err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
+			log := l.LogE(err).WithFields(fields).
+				WithFields(log.Fields{"attempts number": i})
 			if err != nil {
-				log.Error("Multiple Errors in converting layers, going on")
-				conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", err))
+				log.Warning("Could not convert wish (layers), trying again")
+			} else {
+				log.Info("Successfully converted the layers")
+				break
 			}
+		}
+		if err != nil {
+			log.Error("Multiple Errors in converting layers, going on")
+			conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", err))
 		}
 
 		if !skipFlat {

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -114,7 +114,6 @@ var convertSingleImageCmd = &cobra.Command{
 			}
 		}
 
-
 		if !skipThinImage {
 			for i := 0; i < attempts; i++ {
 				err = lib.ConvertWishDocker(wish)

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -77,6 +77,24 @@ var convertSingleImageCmd = &cobra.Command{
 
 		var conversionErrors []string
 
+		if !skipLayers {
+			for i := 0; i < attempts; i++ {
+				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
+				log := l.LogE(err).WithFields(fields).
+					WithFields(log.Fields{"attempts number": i})
+				if err != nil {
+					log.Warning("Could not convert wish (layers), trying again")
+				} else {
+					log.Info("Successfully converted the layers")
+					break
+				}
+			}
+			if err != nil {
+				log.Error("Multiple Errors in converting layers, going on")
+				conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", err))
+			}
+		}
+
 		if !skipFlat {
 			for i := 0; i < attempts; i++ {
 				err = lib.ConvertWishFlat(wish)
@@ -96,23 +114,6 @@ var convertSingleImageCmd = &cobra.Command{
 			}
 		}
 
-		if !skipLayers {
-			for i := 0; i < attempts; i++ {
-				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
-				log := l.LogE(err).WithFields(fields).
-					WithFields(log.Fields{"attempts number": i})
-				if err != nil {
-					log.Warning("Could not convert wish (layers), trying again")
-				} else {
-					log.Info("Successfully converted the layers")
-					break
-				}
-			}
-			if err != nil {
-				log.Error("Multiple Errors in converting layers, going on")
-				conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", err))
-			}
-		}
 
 		if !skipThinImage {
 			for i := 0; i < attempts; i++ {

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -20,7 +20,7 @@ func init() {
 	loopCmd.Flags().BoolVarP(&overwriteLayer, "overwrite-layers", "f", false, "overwrite the layer if they are already inside the CVMFS repository")
 	loopCmd.Flags().BoolVarP(&convertAgain, "convert-again", "g", false, "convert again images that are already successfully converted")
 	loopCmd.Flags().BoolVarP(&skipFlat, "skip-flat", "s", false, "do not create a flat images (compatible with singularity)")
-	loopCmd.Flags().BoolVarP(&skipLayers, "skip-layers", "d", false, "do not unpack the layers into the repository, implies --skip-thin-image and --skip-podman")
+	loopCmd.Flags().BoolVarP(&skipLayers, "skip-layers", "d", false, "[DEPRECATED] this option is no longer functional, layers will be unpacked regardless. Use `docker save` and `cvmfs_server ingest` if you only need the flat image.")
 	loopCmd.Flags().BoolVarP(&skipThinImage, "skip-thin-image", "i", false, "do not create and push the docker thin image")
 	loopCmd.Flags().BoolVarP(&skipPodman, "skip-podman", "p", false, "do not create podman image store")
 	rootCmd.AddCommand(loopCmd)
@@ -53,6 +53,10 @@ var loopCmd = &cobra.Command{
 			}
 		}
 
+		if skipLayers {
+			l.Log().Warn("--skip-layers is deprecated and no longer functional: layers will be unpacked regardless. If you only need the flat image, use `docker save` and `cvmfs_server ingest` instead.")
+		}
+
 		for {
 			data, err := ioutil.ReadFile(args[0])
 			if err != nil {
@@ -74,12 +78,10 @@ var loopCmd = &cobra.Command{
 					"repository":   wish.CvmfsRepo,
 					"output image": wish.OutputName}
 				l.Log().WithFields(fields).Info("Start conversion of wish")
-				if !skipLayers {
-					err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
-					if err != nil {
-						l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
-					}
+				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
+				if err != nil {
+					l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
+					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
 				}
 				if !skipThinImage {
 					err = lib.ConvertWishDocker(wish)

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -82,14 +82,14 @@ var loopCmd = &cobra.Command{
 				// Check if this wish is in the ignore errors list
 				isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
 
-        err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
-        if err != nil {
-          if isIgnored {
-            l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
-          } else {
-            l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-            conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
-          }
+				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
+				if err != nil {
+					if isIgnored {
+						l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
+					} else {
+						l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
+						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+					}
 				}
 				if !skipThinImage {
 					err = lib.ConvertWishDocker(wish)

--- a/ducc/constants/constants.go
+++ b/ducc/constants/constants.go
@@ -5,8 +5,6 @@ import (
 )
 
 var SubDirInsideRepo = ".layers"
-var ChainSubDir = ".chains"
-var DirtyChainSubDir = ".dirty-chains"
 
 var DirPermision = os.FileMode(0755)
 var FilePermision = os.FileMode(0644)

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -45,26 +45,23 @@ if [ "$1" == "ingest" ]; then
   fi
 fi
 
-# cvmfs_server overlay -l <layers> -d <dest> [-c <cache_dir>] <repo>
+# cvmfs_server overlay -l <layers> -d <dest> <repo>
 # Mock: just create the destination directory
 if [ "$1" == "overlay" ]; then
   shift
   layers=""
   dest=""
-  cache_dir=""
   while [ $# -gt 0 ]; do
     case "$1" in
       -l) layers="$2"; shift 2 ;;
       -d) dest="$2"; shift 2 ;;
-      -c) cache_dir="$2"; shift 2 ;;
       *)  repo="$1"; shift ;;
     esac
   done
-  echo "overlay: layers=$layers dest=$dest cache_dir=$cache_dir repo=$repo"
+  echo "overlay: layers=$layers dest=$dest repo=$repo"
   mkdir -p "$CVMFS_TEST_REPO/$dest"
   # Write a marker file so tests can verify the overlay was called
   echo "layers=$layers" > "$CVMFS_TEST_REPO/$dest/.overlay_marker"
-  echo "cache_dir=$cache_dir" >> "$CVMFS_TEST_REPO/$dest/.overlay_marker"
 fi
 
 # cvmfs_server ingest --catalog -t - -b <dir>

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -45,6 +45,28 @@ if [ "$1" == "ingest" ]; then
   fi
 fi
 
+# cvmfs_server overlay -l <layers> -d <dest> [-c <cache_dir>] <repo>
+# Mock: just create the destination directory
+if [ "$1" == "overlay" ]; then
+  shift
+  layers=""
+  dest=""
+  cache_dir=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -l) layers="$2"; shift 2 ;;
+      -d) dest="$2"; shift 2 ;;
+      -c) cache_dir="$2"; shift 2 ;;
+      *)  repo="$1"; shift ;;
+    esac
+  done
+  echo "overlay: layers=$layers dest=$dest cache_dir=$cache_dir repo=$repo"
+  mkdir -p "$CVMFS_TEST_REPO/$dest"
+  # Write a marker file so tests can verify the overlay was called
+  echo "layers=$layers" > "$CVMFS_TEST_REPO/$dest/.overlay_marker"
+  echo "cache_dir=$cache_dir" >> "$CVMFS_TEST_REPO/$dest/.overlay_marker"
+fi
+
 # cvmfs_server ingest --catalog -t - -b <dir>
 arg2=$(echo $@ | cut -d ' ' -f 2)
 arg3=$(echo $@ | cut -d ' ' -f 3)

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -487,9 +487,7 @@ func removeHashMarkerIfPresent(digest string) string {
 // a single flat image directory. The layers should be provided in bottom-to-top
 // order (base layer first). The destPath is the path inside the CVMFS repository
 // where the merged result will be placed (without the /cvmfs/$REPO prefix).
-// If cacheDir is non-empty, it is passed via the -c flag to cvmfs_server overlay
-// and the directory is created if it does not already exist.
-func Overlay(CVMFSRepo string, layerPaths []string, destPath string, cacheDir string) error {
+func Overlay(CVMFSRepo string, layerPaths []string, destPath string) error {
 	if len(layerPaths) == 0 {
 		return fmt.Errorf("no layer paths provided for overlay")
 	}
@@ -498,34 +496,22 @@ func Overlay(CVMFSRepo string, layerPaths []string, destPath string, cacheDir st
 
 	llog := func(ll *log.Entry) *log.Entry {
 		return ll.WithFields(log.Fields{
-			"action":   "overlay",
-			"repo":     CVMFSRepo,
-			"layers":   layers,
-			"dest":     destPath,
-			"cacheDir": cacheDir,
+			"action": "overlay",
+			"repo":   CVMFSRepo,
+			"layers": layers,
+			"dest":   destPath,
 		})
 	}
 
 	llog(l.Log()).Info("Starting overlay merge")
-
-	// Ensure the cache directory exists if specified
-	if cacheDir != "" {
-		if err := os.MkdirAll(cacheDir, 0755); err != nil {
-			llog(l.LogE(err)).Error("Error creating overlay cache directory")
-			return err
-		}
-	}
 
 	getLock(CVMFSRepo)
 	defer unlock(CVMFSRepo)
 
 	args := []string{"cvmfs_server", "overlay",
 		"-l", layers,
-		"-d", destPath}
-	if cacheDir != "" {
-		args = append(args, "-c", cacheDir)
-	}
-	args = append(args, CVMFSRepo)
+		"-d", destPath,
+		CVMFSRepo}
 
 	err := exec.ExecCommand(args...).Start()
 	if err != nil {

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -1,7 +1,6 @@
 package cvmfs
 
 import (
-	"archive/tar"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,14 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/sys/unix"
-
 	copy "github.com/otiai10/copy"
-	"github.com/pkg/xattr"
 	log "github.com/sirupsen/logrus"
 
 	constants "github.com/cvmfs/ducc/constants"
 	da "github.com/cvmfs/ducc/docker-api"
+	exec "github.com/cvmfs/ducc/exec"
 	l "github.com/cvmfs/ducc/log"
 	temp "github.com/cvmfs/ducc/temp"
 )
@@ -372,31 +369,6 @@ func LayerPath(CVMFSRepo, layerDigest string) string {
 	return filepath.Join("/", "cvmfs", CVMFSRepo, constants.SubDirInsideRepo, layerDigest[0:2], layerDigest)
 }
 
-func ChainPath(CVMFSRepo, layerDigest string) string {
-	layerDigest = removeHashMarkerIfPresent(layerDigest)
-	return filepath.Join("/", "cvmfs", CVMFSRepo, constants.ChainSubDir, layerDigest[0:2], layerDigest)
-}
-
-func DirtyChainPath(CVMFSRepo, layerDigest string) string {
-	layerDigest = removeHashMarkerIfPresent(layerDigest)
-	return filepath.Join("/", "cvmfs", CVMFSRepo, constants.DirtyChainSubDir, layerDigest)
-}
-
-func GetDirtyChains(CVMFSRepo string) []string {
-	path := filepath.Join("/", "cvmfs", CVMFSRepo, constants.DirtyChainSubDir)
-	result := make([]string, 0)
-	dirs, err := ioutil.ReadDir(path)
-	if err != nil {
-		return result
-	}
-	for _, dir := range dirs {
-		if dir.IsDir() {
-			result = append(result, dir.Name())
-		}
-	}
-	return result
-}
-
 func LayerRootfsPath(CVMFSRepo, layerDigest string) string {
 	return filepath.Join(LayerPath(CVMFSRepo, layerDigest), "layerfs")
 }
@@ -511,240 +483,56 @@ func removeHashMarkerIfPresent(digest string) string {
 	return digest
 }
 
-func CreateSneakyChain(CVMFSRepo, newChainId, previousChainId string, layer tar.Reader) error {
-	sneakyPath := filepath.Join("/", "var", "spool", "cvmfs", CVMFSRepo, "scratch", "current")
-	newChainPath := ChainPath(CVMFSRepo, newChainId)
-	dirtyChainPath := DirtyChainPath(CVMFSRepo, newChainId)
-	sneakyChainPath := filepath.Join(sneakyPath, TrimCVMFSRepoPrefix(newChainPath))
-	// we need to create the directory were to do the template transaction
-	dir := filepath.Dir(newChainPath)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		// if the directory does not exists, we create it
+// Overlay calls `cvmfs_server overlay` to merge multiple layer directories into
+// a single flat image directory. The layers should be provided in bottom-to-top
+// order (base layer first). The destPath is the path inside the CVMFS repository
+// where the merged result will be placed (without the /cvmfs/$REPO prefix).
+// If cacheDir is non-empty, it is passed via the -c flag to cvmfs_server overlay
+// and the directory is created if it does not already exist.
+func Overlay(CVMFSRepo string, layerPaths []string, destPath string, cacheDir string) error {
+	if len(layerPaths) == 0 {
+		return fmt.Errorf("no layer paths provided for overlay")
+	}
 
-		if err := WithinTransaction(CVMFSRepo, func() error {
-			os.MkdirAll(dir, constants.DirPermision)
-			filePath := filepath.Join(dir, ".cvmfscatalog")
-			f, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDONLY, constants.FilePermision)
-			if err != nil {
-				l.LogE(err).Info("Error in creating ", filePath)
-				return err
-			}
-			f.Close()
-			l.Log().Info("Closed file: ", filePath)
-			return nil
-		}); err != nil {
+	layers := strings.Join(layerPaths, ",")
+
+	llog := func(ll *log.Entry) *log.Entry {
+		return ll.WithFields(log.Fields{
+			"action":   "overlay",
+			"repo":     CVMFSRepo,
+			"layers":   layers,
+			"dest":     destPath,
+			"cacheDir": cacheDir,
+		})
+	}
+
+	llog(l.Log()).Info("Starting overlay merge")
+
+	// Ensure the cache directory exists if specified
+	if cacheDir != "" {
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			llog(l.LogE(err)).Error("Error creating overlay cache directory")
 			return err
 		}
 	}
-	// then we need the template transaction to populate it
-	if previousChainId != "" {
-		// if it is the very first chain, we don't need the template transaction
-		opt := TemplateTransaction{
-			source:      TrimCVMFSRepoPrefix(ChainPath(CVMFSRepo, previousChainId)),
-			destination: TrimCVMFSRepoPrefix(newChainPath),
-		}
-		if err := WithinTransaction(CVMFSRepo, func() error {
-			source := ChainPath(CVMFSRepo, previousChainId)
-			sourceDirs, err := ioutil.ReadDir(source)
-			if err != nil {
-				return err
-			}
-			destination := newChainPath
-			destinationDirs, err := ioutil.ReadDir(destination)
-			if err != nil {
-				return err
-			}
 
-			if len(sourceDirs) != len(destinationDirs) {
-				return fmt.Errorf("Different number of directories between the source and the target directories during a template transaction. source: %s , # of dir: %d, target: %s, # of dirs: %d", source, len(sourceDirs), destination, len(destinationDirs))
-			}
+	getLock(CVMFSRepo)
+	defer unlock(CVMFSRepo)
 
-			f, _ := os.OpenFile(filepath.Join(destination, ".cvmfscatalog"), os.O_CREATE|os.O_RDONLY, constants.FilePermision)
-			f.Close()
-			err = os.MkdirAll(dirtyChainPath, constants.DirPermision)
-			if err != nil {
-				return err
-			}
-			return nil
-		}, opt); err != nil {
-			return err
-		}
+	args := []string{"cvmfs_server", "overlay",
+		"-l", layers,
+		"-d", destPath}
+	if cacheDir != "" {
+		args = append(args, "-c", cacheDir)
 	}
-	// finally we need the sneaky transaction to create the chain
-	if err := ExecuteAndOpenTransaction(CVMFSRepo, func() error {
-	loop:
-		for {
-			header, err := layer.Next()
-			if err == io.EOF {
-				f, _ := os.OpenFile(filepath.Join(sneakyChainPath, ".cvmfscatalog"), os.O_CREATE|os.O_RDONLY, constants.FilePermision)
-				f.Close()
-				return nil
-			}
+	args = append(args, CVMFSRepo)
 
-			if err != nil {
-				l.LogE(err).Error("Error in getting next layer")
-				return err
-			}
-
-			if header == nil {
-				continue loop
-			}
-
-			path := filepath.Join(sneakyChainPath, header.Name)
-			dir := filepath.Dir(path)
-
-			os.MkdirAll(dir, constants.DirPermision)
-			if isWhiteout(path) {
-				// this will be an empty file
-				// check if it is an opaque directory or a standard whiteout file
-				base := filepath.Base(path)
-				if base == ".wh..wh..opq" {
-					// an opaque directory
-					if err := makeOpaqueDir(dir); err != nil {
-						l.LogE(err).Error("Error in making opaque directory")
-						return err
-					}
-				} else {
-					// a whiteout file
-					base = base[4:]
-					path := filepath.Join(dir, base)
-					if err := makeWhiteoutFile(path); err != nil {
-						l.LogE(err).Error("Error in creating whiteout file")
-						return err
-					}
-				}
-				continue
-			}
-
-			permissionMask := int64(0)
-			switch header.Typeflag {
-
-			case tar.TypeDir:
-				{
-					err := os.MkdirAll(path, constants.DirPermision)
-					if err != nil {
-						l.LogE(err).Error("Error in creating directory")
-						return err
-					}
-					permissionMask |= 0700
-				}
-			case tar.TypeReg, tar.TypeRegA:
-				{
-					f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, constants.FilePermision)
-					if err != nil {
-						l.LogE(err).Error("Error in creating file")
-						return err
-					}
-					if _, err = io.Copy(f, &layer); err != nil {
-						l.LogE(err).Error("Error in copying file from tar", path)
-						f.Close()
-						return err
-					}
-					f.Close()
-					permissionMask |= 0600
-				}
-			case tar.TypeLink:
-				{
-					// hardlink
-					// maybe we should just copy the file
-					oldLinkName := filepath.Join(sneakyChainPath, header.Linkname)
-					if err := os.Link(oldLinkName, path); err != nil {
-						l.LogE(err).Error("Error in creating hard link")
-						return err
-					}
-				}
-			case tar.TypeSymlink:
-				{
-					// symlink
-					if err := os.Symlink(header.Linkname, path); err != nil {
-						l.LogE(err).Error("Error in creating symbolic link")
-						return err
-					}
-					// TODO (smosciat)
-					// do we want to invoke also Lchmod ?
-					// the function does not really exist in std
-					os.Lchown(path, header.Uid, header.Gid)
-
-					continue loop
-				}
-			case tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
-				{
-					// char device
-					var mode uint32
-					switch header.Typeflag {
-					case tar.TypeChar:
-						mode = unix.S_IFCHR
-					case tar.TypeBlock:
-						mode = unix.S_IFBLK
-					case tar.TypeFifo:
-						mode = unix.S_IFIFO
-					}
-					dev := unix.Mkdev(uint32(header.Devmajor), uint32(header.Devminor))
-					if err := unix.Mknod(path, uint32(os.FileMode(int64(mode)|header.Mode)), int(dev)); err != nil {
-						l.LogE(err).Error("Error in creating special file")
-						return err
-					}
-				}
-			default:
-				{
-					// unclear what to do here, just skip it
-					continue loop
-				}
-			}
-
-			// these are common to everything
-			if err := os.Chmod(path, os.FileMode(header.Mode|permissionMask)); err != nil {
-				l.LogE(err).Error("Error in chmod")
-				return err
-			}
-			// TODO(vavolkl): do we need to chown?
-			if os.Getenv("CVMFS_DUCC_NO_CHOWN") == "" {
-				if err := os.Chown(path, header.Uid, header.Gid); err != nil {
-					l.LogE(err).Error("Error in chown")
-					return err
-				}
-			}
-			if err := os.Chtimes(path, header.AccessTime, header.ModTime); err != nil {
-				l.LogE(err).Error("Error in chtimes")
-				return err
-			}
-		}
-	}); err != nil {
-		os.RemoveAll(filepath.Join(sneakyPath, ".chains"))
-		// the creation of the chain is not complete, we delete the template created as well
-		IngestDelete(CVMFSRepo, TrimCVMFSRepoPrefix(newChainPath))
-		// we catch a problem in the creation of the chain, and the chain was destructed
-		// we don't need anymore the dirty flag
-		IngestDelete(CVMFSRepo, TrimCVMFSRepoPrefix(dirtyChainPath))
+	err := exec.ExecCommand(args...).Start()
+	if err != nil {
+		llog(l.LogE(err)).Error("Error in overlay merge")
 		return err
 	}
-	// everything went well, this flag is not necessary anymore
-	os.RemoveAll(dirtyChainPath)
 
-	// now the transaction is open and the sneaky overlay is populated
-	// we don't need to do anything else at this point and we can close the transaction
-	return Publish(CVMFSRepo)
-}
-
-func isWhiteout(path string) bool {
-	base := filepath.Base(path)
-	if len(base) <= 3 {
-		return false
-	}
-	return base[0:4] == ".wh."
-}
-
-func makeWhiteoutFile(path string) error {
-	dev := unix.Mkdev(0, 0)
-	mode := os.FileMode(int64(unix.S_IFCHR) | 0000)
-	return unix.Mknod(path, uint32(mode), int(dev))
-}
-
-func makeOpaqueDir(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, constants.DirPermision); err != nil {
-			return err
-		}
-	}
-	return xattr.Set(path, "trusted.overlay.opaque", []byte("y"))
+	llog(l.Log()).Info("Overlay merge complete")
+	return nil
 }

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -21,8 +21,6 @@ func TestMain(m *testing.M) {
 	os.MkdirAll(filepath.Join(mockrepo, "scratch", "current"), os.ModePerm)
 	os.Setenv("CVMFS_TEST_REPO", "/../../../../"+mockrepo)
 	os.Setenv("CVMFS_DUCC_NO_CHOWN", "nochown")
-	overlaycachedir, _ := os.MkdirTemp("", "ducc_overlaycache")
-	os.Setenv("DUCC_OVERLAY_CACHE_DIR", overlaycachedir)
 	// Test
 	code := m.Run()
 	// Teardown
@@ -73,7 +71,7 @@ func TestPublishToCVMFS(t *testing.T) {
 }
 
 func TestOverlayEmptyLayers(t *testing.T) {
-	err := Overlay("testrepo", []string{}, "/dest", "")
+	err := Overlay("testrepo", []string{}, "/dest")
 	if err == nil {
 		t.Fatal("Expected error for empty layer paths, got nil")
 	}
@@ -82,12 +80,12 @@ func TestOverlayEmptyLayers(t *testing.T) {
 	}
 }
 
-func TestOverlayWithoutCacheDir(t *testing.T) {
+func TestOverlay(t *testing.T) {
 	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
 	repoName := ".." + mockrepo
 
-	destPath := "overlay_test_no_cache"
-	err := Overlay(repoName, []string{"layer1", "layer2"}, destPath, "")
+	destPath := "overlay_test"
+	err := Overlay(repoName, []string{"layer1", "layer2"}, destPath)
 	if err != nil {
 		t.Fatalf("Overlay failed: %s", err)
 	}
@@ -101,74 +99,5 @@ func TestOverlayWithoutCacheDir(t *testing.T) {
 	content := string(markerContent)
 	if !strings.Contains(content, "layers=layer1,layer2") {
 		t.Fatalf("Marker file missing expected layers, got: %s", content)
-	}
-	if !strings.Contains(content, "cache_dir=\n") {
-		t.Fatalf("Marker file should have empty cache_dir, got: %s", content)
-	}
-}
-
-func TestOverlayWithCacheDir(t *testing.T) {
-	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
-	repoName := ".." + mockrepo
-
-	// Use a temp directory for the cache
-	cacheDir, err := os.MkdirTemp("", "overlay-cache-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(cacheDir)
-
-	destPath := "overlay_test_with_cache"
-	err = Overlay(repoName, []string{"layerA", "layerB", "layerC"}, destPath, cacheDir)
-	if err != nil {
-		t.Fatalf("Overlay failed: %s", err)
-	}
-
-	// Verify the mock created the destination directory with a marker file
-	markerPath := filepath.Join(mockrepo, destPath, ".overlay_marker")
-	markerContent, err := os.ReadFile(markerPath)
-	if err != nil {
-		t.Fatalf("Failed to read overlay marker: %s", err)
-	}
-	content := string(markerContent)
-	if !strings.Contains(content, "layers=layerA,layerB,layerC") {
-		t.Fatalf("Marker file missing expected layers, got: %s", content)
-	}
-	if !strings.Contains(content, "cache_dir="+cacheDir) {
-		t.Fatalf("Marker file missing expected cache_dir, got: %s", content)
-	}
-}
-
-func TestOverlayCacheDirCreated(t *testing.T) {
-	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
-	repoName := ".." + mockrepo
-
-	// Use a non-existent subdirectory as cache dir
-	tmpDir, err := os.MkdirTemp("", "overlay-cache-parent")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	cacheDir := filepath.Join(tmpDir, "nested", "cache", "dir")
-
-	// Verify it doesn't exist yet
-	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
-		t.Fatal("Cache dir should not exist before Overlay call")
-	}
-
-	destPath := "overlay_test_cache_created"
-	err = Overlay(repoName, []string{"layer1"}, destPath, cacheDir)
-	if err != nil {
-		t.Fatalf("Overlay failed: %s", err)
-	}
-
-	// Verify the cache directory was created
-	info, err := os.Stat(cacheDir)
-	if err != nil {
-		t.Fatalf("Cache dir was not created: %s", err)
-	}
-	if !info.IsDir() {
-		t.Fatal("Cache dir path is not a directory")
 	}
 }

--- a/ducc/cvmfs/cvmfs_test.go
+++ b/ducc/cvmfs/cvmfs_test.go
@@ -21,6 +21,8 @@ func TestMain(m *testing.M) {
 	os.MkdirAll(filepath.Join(mockrepo, "scratch", "current"), os.ModePerm)
 	os.Setenv("CVMFS_TEST_REPO", "/../../../../"+mockrepo)
 	os.Setenv("CVMFS_DUCC_NO_CHOWN", "nochown")
+	overlaycachedir, _ := os.MkdirTemp("", "ducc_overlaycache")
+	os.Setenv("DUCC_OVERLAY_CACHE_DIR", overlaycachedir)
 	// Test
 	code := m.Run()
 	// Teardown
@@ -67,5 +69,106 @@ func TestPublishToCVMFS(t *testing.T) {
 		t.Fatal(err)
 	} else if !bytes.Equal(testfile2Readback, testfile2Content) {
 		t.Fatal("Published file on CVMFS differs!")
+	}
+}
+
+func TestOverlayEmptyLayers(t *testing.T) {
+	err := Overlay("testrepo", []string{}, "/dest", "")
+	if err == nil {
+		t.Fatal("Expected error for empty layer paths, got nil")
+	}
+	if !strings.Contains(err.Error(), "no layer paths provided") {
+		t.Fatalf("Unexpected error message: %s", err.Error())
+	}
+}
+
+func TestOverlayWithoutCacheDir(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	repoName := ".." + mockrepo
+
+	destPath := "overlay_test_no_cache"
+	err := Overlay(repoName, []string{"layer1", "layer2"}, destPath, "")
+	if err != nil {
+		t.Fatalf("Overlay failed: %s", err)
+	}
+
+	// Verify the mock created the destination directory with a marker file
+	markerPath := filepath.Join(mockrepo, destPath, ".overlay_marker")
+	markerContent, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("Failed to read overlay marker: %s", err)
+	}
+	content := string(markerContent)
+	if !strings.Contains(content, "layers=layer1,layer2") {
+		t.Fatalf("Marker file missing expected layers, got: %s", content)
+	}
+	if !strings.Contains(content, "cache_dir=\n") {
+		t.Fatalf("Marker file should have empty cache_dir, got: %s", content)
+	}
+}
+
+func TestOverlayWithCacheDir(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	repoName := ".." + mockrepo
+
+	// Use a temp directory for the cache
+	cacheDir, err := os.MkdirTemp("", "overlay-cache-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %s", err)
+	}
+	defer os.RemoveAll(cacheDir)
+
+	destPath := "overlay_test_with_cache"
+	err = Overlay(repoName, []string{"layerA", "layerB", "layerC"}, destPath, cacheDir)
+	if err != nil {
+		t.Fatalf("Overlay failed: %s", err)
+	}
+
+	// Verify the mock created the destination directory with a marker file
+	markerPath := filepath.Join(mockrepo, destPath, ".overlay_marker")
+	markerContent, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("Failed to read overlay marker: %s", err)
+	}
+	content := string(markerContent)
+	if !strings.Contains(content, "layers=layerA,layerB,layerC") {
+		t.Fatalf("Marker file missing expected layers, got: %s", content)
+	}
+	if !strings.Contains(content, "cache_dir="+cacheDir) {
+		t.Fatalf("Marker file missing expected cache_dir, got: %s", content)
+	}
+}
+
+func TestOverlayCacheDirCreated(t *testing.T) {
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+	repoName := ".." + mockrepo
+
+	// Use a non-existent subdirectory as cache dir
+	tmpDir, err := os.MkdirTemp("", "overlay-cache-parent")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cacheDir := filepath.Join(tmpDir, "nested", "cache", "dir")
+
+	// Verify it doesn't exist yet
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Fatal("Cache dir should not exist before Overlay call")
+	}
+
+	destPath := "overlay_test_cache_created"
+	err = Overlay(repoName, []string{"layer1"}, destPath, cacheDir)
+	if err != nil {
+		t.Fatalf("Overlay failed: %s", err)
+	}
+
+	// Verify the cache directory was created
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		t.Fatalf("Cache dir was not created: %s", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("Cache dir path is not a directory")
 	}
 }

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -29,6 +29,16 @@ import (
 
 var NoPasswordError = 101
 
+// OverlayCacheDir is the path to the cache directory used by cvmfs_server overlay.
+// If empty, no -c flag is passed to cvmfs_server overlay.
+var OverlayCacheDir = "/var/tmp/cvmfs/overlay-cache"
+
+func init() {
+	if ocd := os.Getenv("DUCC_OVERLAY_CACHE_DIR"); ocd != "" {
+		OverlayCacheDir = ocd
+	}
+}
+
 type ConversionResult int
 
 const (
@@ -49,10 +59,7 @@ func ConvertWishFlat(wish WishFriendly) error {
 		nFlat.Elapsed(tFlat).AddField("action", "end_flat_conversion").Send()
 	}()
 
-	// it may happen at the very first round that this two calls return an error, let it be
-	if err := cvmfs.CreateCatalogIntoDir(wish.CvmfsRepo, ".chains"); err != nil {
-		l.LogE(err).Error("Error in creating catalog inside `.chains` directory")
-	}
+	// it may happen at the very first round that this call returns an error, let it be
 	if err := cvmfs.CreateCatalogIntoDir(wish.CvmfsRepo, ".flat"); err != nil {
 		l.LogE(err).Error("Error in creating catalog inside `.flat` directory")
 	}
@@ -128,24 +135,20 @@ func ConvertWishFlat(wish WishFriendly) error {
 
 		i := n.AddField("image", inputImage.GetSimpleName()).AddId()
 		t1 := time.Now()
-		i.Action("start_single_chain_conversion").Send()
-		i = i.Action("end_single_chain_convertion")
+		i.Action("start_flat_overlay_conversion").Send()
+		i = i.Action("end_flat_overlay_conversion")
 
-		err, lastChain := inputImage.CreateSneakyChainStructure(wish.CvmfsRepo)
+		// Use cvmfs_server overlay to merge layers into a flat image
+		_, err = inputImage.CreateFlatOverlay(wish.CvmfsRepo, OverlayCacheDir)
 		if err != nil {
 			if firstError == nil {
 				firstError = err
 			}
-			l.LogE(err).Error("Error in creating the chain structure")
+			l.LogE(err).Error("Error in creating the flat overlay")
 			i.Error(err).Elapsed(t1).Send()
 			continue
 		}
 
-		if _, err := os.Stat(filepath.Dir(completeSingularityPriPath)); err != nil {
-			cvmfs.WithinTransaction(wish.CvmfsRepo, func() error {
-				return os.MkdirAll(filepath.Dir(completeSingularityPriPath), constants.DirPermision)
-			})
-		}
 		ociImage, err := inputImage.GetOCIImage()
 		if err != nil {
 			if firstError == nil {
@@ -155,7 +158,7 @@ func ConvertWishFlat(wish WishFriendly) error {
 			i.Error(err).Elapsed(t1).Send()
 			continue
 		}
-		// we create the image with the correct singularity's dotfiles
+		// we create the singularity dotfiles inside the flat overlay result
 		err = cvmfs.WithinTransaction(wish.CvmfsRepo,
 			func() error {
 				if err := singularity.MakeBaseEnv(completeSingularityPriPath); err != nil {
@@ -171,10 +174,7 @@ func ConvertWishFlat(wish WishFriendly) error {
 					return err
 				}
 				return nil
-			},
-			cvmfs.NewTemplateTransaction(
-				cvmfs.TrimCVMFSRepoPrefix(cvmfs.ChainPath(wish.CvmfsRepo, lastChain)),
-				singularityPrivatePath))
+			})
 
 		if err != nil {
 			if firstError == nil {

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -29,16 +29,6 @@ import (
 
 var NoPasswordError = 101
 
-// OverlayCacheDir is the path to the cache directory used by cvmfs_server overlay.
-// If empty, no -c flag is passed to cvmfs_server overlay.
-var OverlayCacheDir = "/var/tmp/cvmfs/overlay-cache"
-
-func init() {
-	if ocd := os.Getenv("DUCC_OVERLAY_CACHE_DIR"); ocd != "" {
-		OverlayCacheDir = ocd
-	}
-}
-
 type ConversionResult int
 
 const (
@@ -139,7 +129,7 @@ func ConvertWishFlat(wish WishFriendly) error {
 		i = i.Action("end_flat_overlay_conversion")
 
 		// Use cvmfs_server overlay to merge layers into a flat image
-		_, err = inputImage.CreateFlatOverlay(wish.CvmfsRepo, OverlayCacheDir)
+		_, err = inputImage.CreateFlatOverlay(wish.CvmfsRepo)
 		if err != nil {
 			if firstError == nil {
 				firstError = err

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"archive/tar"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -24,7 +23,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 
-	constants "github.com/cvmfs/ducc/constants"
 	cvmfs "github.com/cvmfs/ducc/cvmfs"
 	da "github.com/cvmfs/ducc/docker-api"
 	l "github.com/cvmfs/ducc/log"
@@ -1181,144 +1179,49 @@ func (ld *LayerDownloader) DownloadAndIngest(CVMFSRepo string, layer da.Layer) e
 	return err
 }
 
-func (img *Image) CreateSneakyChainStructure(CVMFSRepo string) (err error, lastChainId string) {
-	// make sure we have the layers somewhere
+// CreateFlatOverlay uses cvmfs_server overlay to merge all image layers into a
+// flat filesystem. It returns the singularity path (relative to /cvmfs/$REPO)
+// where the merged image is placed. If cacheDir is non-empty, it is passed to
+// cvmfs_server overlay via the -c flag to use as a dedicated cache location.
+func (img *Image) CreateFlatOverlay(CVMFSRepo string, cacheDir string) (singularityPath string, err error) {
 	manifest, err := img.GetManifest()
 	if err != nil {
 		return
 	}
 
-	// then we start creating the chain structure
-	chainIDs := manifest.GetChainIDs()
-
-	paths := []string{}
-	for _, chain := range chainIDs {
-		if chain == "" {
+	// Collect layer rootfs paths in bottom-to-top order (as they appear in the manifest)
+	layerPaths := []string{}
+	for _, layer := range manifest.Layers {
+		if layer.MediaType == "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip" {
 			continue
 		}
-		path := cvmfs.ChainPath(CVMFSRepo, chain.String())
-		dir := filepath.Dir(path)
-		if _, err := os.Stat(dir); err != nil {
-			paths = append(paths, dir)
-		}
+		layerDigest := strings.Split(layer.Digest, ":")[1]
+		layerPaths = append(layerPaths, cvmfs.TrimCVMFSRepoPrefix(cvmfs.LayerRootfsPath(CVMFSRepo, layerDigest)))
 	}
 
-	if len(paths) > 0 {
-		err = cvmfs.WithinTransaction(CVMFSRepo, func() error {
-			for _, dir := range paths {
-				if err := os.MkdirAll(dir, constants.DirPermision); err != nil {
-					return err
-				}
-				// create the .cvmfscatalog, we don't really care if it fails
-				f, _ := os.OpenFile(filepath.Join(dir, ".cvmfscatalog"),
-					os.O_CREATE|os.O_RDONLY, constants.FilePermision)
-				f.Close()
-			}
-			return nil
-		})
-		if err != nil {
-			l.LogE(err).Error("Impossible to create directory to contains the chainID")
-			return
-		}
+	if len(layerPaths) == 0 {
+		err = fmt.Errorf("no layers found for image %s", img.GetSimpleName())
+		return
 	}
 
-	dirtyChains := cvmfs.GetDirtyChains(CVMFSRepo)
-	if len(dirtyChains) > 0 {
-		err = cvmfs.WithinTransaction(CVMFSRepo, func() error {
-			for _, chain := range dirtyChains {
-				chainPath := cvmfs.ChainPath(CVMFSRepo, chain)
-				dirtyChainPath := cvmfs.DirtyChainPath(CVMFSRepo, chain)
-				if err := os.RemoveAll(chainPath); err != nil {
-					return err
-				}
-				if err := os.RemoveAll(dirtyChainPath); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			l.LogE(err).Error("Error in deleting dirty chains, unsafe to continue")
-			return
-		}
-	}
+	singularityPath = manifest.GetSingularityPath()
 
 	n := notification.NewNotification(NotificationService)
 	n = n.AddField("image", img.GetSimpleName())
 
-	n.AddField("action", "start_chains_ingestion").Send()
+	t := time.Now()
+	n.AddField("action", "start_overlay_merge").Send()
 
-	ld := NewLayerDownloader(img)
-	previous := ""
-	for i, chain := range chainIDs {
-		if chain == "" {
-			continue
-		}
-		digest := chain.String()
-		lastChainId = digest
-		layer := manifest.Layers[i]
+	err = cvmfs.Overlay(CVMFSRepo, layerPaths, singularityPath, cacheDir)
 
-		l.Log().WithFields(
-			log.Fields{"chain id": digest, "next layer": layer.Digest}).
-			Info("adding new chain")
+	n.Elapsed(t).
+		AddField("action", "end_overlay_merge").
+		Error(err).
+		Send()
 
-		path := cvmfs.ChainPath(CVMFSRepo, digest)
-
-		if _, err := os.Stat(path); err == nil {
-			// the chain is present, we skip the loop
-			l.Log().WithFields(log.Fields{"chain id": digest}).Info("skipping (already present)")
-			previous = chainIDs[i].String()
-			continue
-		}
-
-		downloadLayer := func() error {
-			// we need to get the layer tar reader here
-			layerStream, err := ld.DownloadLayer(layer)
-
-			// we should call this even if there were issues in creating the file
-			defer layerStream.Close()
-
-			if err != nil {
-				l.LogE(err).Error("Error in downloading the layer from the docker registry")
-				return err
-			}
-
-			tarReader := *tar.NewReader(layerStream.Path)
-
-			chainN := n.AddField("chain", chain.String()).
-				AddField("layer", strings.Split(layer.Digest, ":")[1]).
-				AddId()
-
-			t := time.Now()
-			chainN.Action("start_single_chain_ingestion").Send()
-
-			err = cvmfs.CreateSneakyChain(CVMFSRepo,
-				chain.String(),
-				previous,
-				tarReader)
-
-			chainN.Elapsed(t).
-				Action("end_single_chain_ingestion").
-				SizeBytes(layerStream.GetSize()).
-				Error(err).
-				Send()
-
-			return err
-		}
-		for attempt := 0; attempt < 5; attempt++ {
-			l.Log().Info("Start attempt: ", attempt)
-			err = downloadLayer()
-			if err == nil {
-				l.Log().Info("Attempt ", attempt, " success")
-				break
-			}
-			l.Log().Warn("Attempt ", attempt, " fail")
-		}
-		if err != nil {
-			l.LogE(err).Error("Error in creating the chain")
-			return err, lastChainId
-		}
-		previous = chainIDs[i].String()
+	if err != nil {
+		l.LogE(err).Error("Error in creating flat overlay for image")
+		return
 	}
 	return
 }

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -1181,9 +1181,8 @@ func (ld *LayerDownloader) DownloadAndIngest(CVMFSRepo string, layer da.Layer) e
 
 // CreateFlatOverlay uses cvmfs_server overlay to merge all image layers into a
 // flat filesystem. It returns the singularity path (relative to /cvmfs/$REPO)
-// where the merged image is placed. If cacheDir is non-empty, it is passed to
-// cvmfs_server overlay via the -c flag to use as a dedicated cache location.
-func (img *Image) CreateFlatOverlay(CVMFSRepo string, cacheDir string) (singularityPath string, err error) {
+// where the merged image is placed.
+func (img *Image) CreateFlatOverlay(CVMFSRepo string) (singularityPath string, err error) {
 	manifest, err := img.GetManifest()
 	if err != nil {
 		return
@@ -1212,7 +1211,7 @@ func (img *Image) CreateFlatOverlay(CVMFSRepo string, cacheDir string) (singular
 	t := time.Now()
 	n.AddField("action", "start_overlay_merge").Send()
 
-	err = cvmfs.Overlay(CVMFSRepo, layerPaths, singularityPath, cacheDir)
+	err = cvmfs.Overlay(CVMFSRepo, layerPaths, singularityPath)
 
 	n.Elapsed(t).
 		AddField("action", "end_overlay_merge").

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -373,3 +373,25 @@ func TestCacheEmptyToken(t *testing.T) {
 		t.Errorf("Expected empty token, got %q", token)
 	}
 }
+
+func TestOverlayCacheDirDefault(t *testing.T) {
+	expected := "/var/lib/cvmfs/overlay-cache"
+	if OverlayCacheDir != expected {
+		t.Errorf("Expected default OverlayCacheDir to be %q, got %q", expected, OverlayCacheDir)
+	}
+}
+
+func TestOverlayCacheDirOverride(t *testing.T) {
+	original := OverlayCacheDir
+	defer func() { OverlayCacheDir = original }()
+
+	OverlayCacheDir = "/custom/cache/path"
+	if OverlayCacheDir != "/custom/cache/path" {
+		t.Errorf("Expected OverlayCacheDir to be /custom/cache/path, got %q", OverlayCacheDir)
+	}
+
+	OverlayCacheDir = ""
+	if OverlayCacheDir != "" {
+		t.Errorf("Expected OverlayCacheDir to be empty, got %q", OverlayCacheDir)
+	}
+}

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -374,7 +374,6 @@ func TestCacheEmptyToken(t *testing.T) {
 	}
 }
 
-
 func TestOverlayCacheDirOverride(t *testing.T) {
 	original := OverlayCacheDir
 	defer func() { OverlayCacheDir = original }()

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -374,17 +374,4 @@ func TestCacheEmptyToken(t *testing.T) {
 	}
 }
 
-func TestOverlayCacheDirOverride(t *testing.T) {
-	original := OverlayCacheDir
-	defer func() { OverlayCacheDir = original }()
 
-	OverlayCacheDir = "/custom/cache/path"
-	if OverlayCacheDir != "/custom/cache/path" {
-		t.Errorf("Expected OverlayCacheDir to be /custom/cache/path, got %q", OverlayCacheDir)
-	}
-
-	OverlayCacheDir = ""
-	if OverlayCacheDir != "" {
-		t.Errorf("Expected OverlayCacheDir to be empty, got %q", OverlayCacheDir)
-	}
-}

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -373,5 +373,3 @@ func TestCacheEmptyToken(t *testing.T) {
 		t.Errorf("Expected empty token, got %q", token)
 	}
 }
-
-

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -374,12 +374,6 @@ func TestCacheEmptyToken(t *testing.T) {
 	}
 }
 
-func TestOverlayCacheDirDefault(t *testing.T) {
-	expected := "/var/lib/cvmfs/overlay-cache"
-	if OverlayCacheDir != expected {
-		t.Errorf("Expected default OverlayCacheDir to be %q, got %q", expected, OverlayCacheDir)
-	}
-}
 
 func TestOverlayCacheDirOverride(t *testing.T) {
 	original := OverlayCacheDir

--- a/ducc/testutils/testutils.go
+++ b/ducc/testutils/testutils.go
@@ -36,6 +36,9 @@ func MockCvmfsSetup() {
 		TestRepo = "/../../../../" + mockrepo
 		os.Setenv("CVMFS_TEST_REPO", TestRepo)
 		os.Setenv("CVMFS_DUCC_NO_CHOWN", "nochown")
+		overlaycachedir, _ := os.MkdirTemp("", "ducc_overlaycache")
+		os.Setenv("DUCC_OVERLAY_CACHE_DIR", overlaycachedir)
+
 	}
 
 }

--- a/test/container/validate_unpacker.sh
+++ b/test/container/validate_unpacker.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+#
+# validate_unpacker.sh - Validate the CVMFS container unpacker (cvmfs_ducc)
+#
+# Compares the flat image produced by cvmfs_ducc convert-single-image with the
+# filesystem obtained via docker export of the same image.
+#
+# Usage: validate_unpacker.sh [options] <image_url> [cvmfs_repo]
+#
+#   image_url   URL of the container image
+#               e.g., https://registry.hub.docker.com/library/alpine:latest
+#   cvmfs_repo  CVMFS repository name (default: test-validate.cern.ch)
+#
+# Options:
+#   -c  Compare file contents (sha256 checksums), not just tree structure
+#   -k  Keep temporary files after completion
+#   -v  Verbose: print diffs to stdout
+#   -h  Show this help message
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+WORK_DIR=""
+DOCKER_CONTAINER_ID=""
+KEEP_TEMP=0
+VERBOSE=0
+COMPARE_CONTENT=0
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+die()      { echo "[ERROR] $*" >&2; exit 1; }
+log_info() { echo "[INFO]  $*"; }
+log_dbg()  { [ "$VERBOSE" -eq 1 ] && echo "[DEBUG] $*" || true; }
+
+usage() {
+    sed -n '2,/^$/{ s/^# \?//; p }' "$0"
+    exit 1
+}
+
+cleanup() {
+    local rc=$?
+    [ -n "$DOCKER_CONTAINER_ID" ] && docker rm "$DOCKER_CONTAINER_ID" >/dev/null 2>&1 || true
+    if [ "$KEEP_TEMP" -eq 0 ] && [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+        rm -rf "$WORK_DIR"
+    fi
+    exit $rc
+}
+
+# https://registry.hub.docker.com/library/alpine:latest  →  alpine:latest
+url_to_docker_ref() {
+    local ref="${1#*://}"
+    # Docker Hub library images can be pulled with the short name
+    ref="${ref#registry.hub.docker.com/library/}"
+    echo "$ref"
+}
+
+# https://registry.hub.docker.com/library/alpine:latest
+#   →  registry.hub.docker.com/library/alpine:latest
+url_to_cvmfs_image_path() { echo "${1#*://}"; }
+
+# Produce a deterministic, sorted listing of all entries in a directory.
+# Format: TYPE PERMS SIZE PATH [-> SYMLINK_TARGET]
+# Filters out CVMFS bookkeeping files and files that get special handling
+# by the unpacker's singularity support (see ducc/singularity/dotfiles.go
+# and ducc/singularity/startup_files.go):
+#   - .singularity.d/ tree (created/overwritten by makeBaseEnv)
+#   - /etc/hosts and /etc/resolv.conf (truncated by makeFiles)
+#   - symlinks: singularity .run .exec .test .shell environment
+generate_listing() {
+    local dir="$1" output="$2"
+    ( cd "$dir"
+      find . \( -name '.cvmfscatalog' -o -name '.cvmfsdirtab' \
+                -o -name '.cvmfsautocatalog' \
+                -o -path './.singularity.d' \) -prune -o -print \
+        | grep -v -x \
+            -e '\./\.singularity\.d' \
+            -e '\./etc/hosts' \
+            -e '\./etc/resolv\.conf' \
+            -e '\./singularity' \
+            -e '\./\.run' \
+            -e '\./\.exec' \
+            -e '\./\.test' \
+            -e '\./\.shell' \
+            -e '\./environment' \
+        | sort | while IFS= read -r entry; do
+            if   [ -L "$entry" ]; then
+                printf 'L %s -> %s\n' "$entry" "$(readlink "$entry")"
+            elif [ -d "$entry" ]; then
+                printf 'D %s\n' "$entry"
+            elif [ -f "$entry" ]; then
+                printf 'F %s %s\n' "$(stat -c '%s' "$entry")" "$entry"
+            else
+                printf '? %s\n' "$entry"
+            fi
+        done
+    ) > "$output"
+}
+
+# sha256 checksums of every regular file (excluding CVMFS metadata and
+# singularity special files — see generate_listing for details).
+generate_checksums() {
+    local dir="$1" output="$2"
+    ( cd "$dir"
+      find . -path './.singularity.d' -prune -o -type f \
+             ! -name '.cvmfscatalog' \
+             ! -name '.cvmfsdirtab' \
+             ! -name '.cvmfsautocatalog' \
+             ! -path './etc/hosts' \
+             ! -path './etc/resolv.conf' \
+             -print \
+        | sort | xargs -r sha256sum
+    ) > "$output"
+}
+
+# ── argument parsing ─────────────────────────────────────────────────────────
+
+while getopts "ckvh" opt; do
+    case $opt in
+        c) COMPARE_CONTENT=1 ;;
+        k) KEEP_TEMP=1 ;;
+        v) VERBOSE=1 ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+IMAGE_URL="${1:-}"
+CVMFS_REPO="${2:-test-validate.cern.ch}"
+[ -z "$IMAGE_URL" ] && { die "Missing required argument: image_url"; }
+
+command -v cvmfs_ducc >/dev/null 2>&1 || die "cvmfs_ducc not found in PATH"
+command -v docker     >/dev/null 2>&1 || die "docker not found in PATH"
+
+trap cleanup EXIT HUP INT TERM
+
+WORK_DIR=$(mktemp -d /tmp/validate_unpacker.XXXXXX)
+DOCKER_REF=$(url_to_docker_ref "$IMAGE_URL")
+CVMFS_IMAGE_PATH=$(url_to_cvmfs_image_path "$IMAGE_URL")
+
+log_info "Image URL       : $IMAGE_URL"
+log_info "Docker reference: $DOCKER_REF"
+log_info "CVMFS repo      : $CVMFS_REPO"
+log_info "Work dir        : $WORK_DIR"
+
+# ── Step 1: unpack with cvmfs_ducc ──────────────────────────────────────────
+
+log_info "=== Step 1: Unpacking with cvmfs_ducc ==="
+
+# Create the CVMFS repo if it does not already exist
+if ! cvmfs_server list 2>/dev/null | grep -q "^${CVMFS_REPO} "; then
+    log_info "Creating CVMFS repository $CVMFS_REPO"
+    sudo cvmfs_server mkfs -o "$USER" "$CVMFS_REPO" \
+        || die "Failed to create CVMFS repository"
+fi
+
+log_info "Running: cvmfs_ducc convert-single-image -i -pls $IMAGE_URL $CVMFS_REPO"
+cvmfs_ducc convert-single-image -i -p "$IMAGE_URL" "$CVMFS_REPO" \
+    2>&1 | tee "$WORK_DIR/ducc.log" \
+    || die "cvmfs_ducc conversion failed (see $WORK_DIR/ducc.log)"
+
+CVMFS_FLAT_DIR="/cvmfs/$CVMFS_REPO/$CVMFS_IMAGE_PATH"
+[ -d "$CVMFS_FLAT_DIR" ] || [ -L "$CVMFS_FLAT_DIR" ] \
+    || die "Expected flat image not found at $CVMFS_FLAT_DIR"
+
+# Resolve a potential symlink (.flat/xx/digest → public path)
+CVMFS_FLAT_DIR=$(readlink -f "$CVMFS_FLAT_DIR")
+log_info "Flat image resolved to: $CVMFS_FLAT_DIR"
+
+# ── Step 2: export the same image from Docker ───────────────────────────────
+
+log_info "=== Step 2: Exporting from Docker ==="
+
+docker pull "$DOCKER_REF" || die "docker pull failed for $DOCKER_REF"
+
+DOCKER_CONTAINER_ID=$(docker create "$DOCKER_REF" /bin/true)
+log_info "Created container $DOCKER_CONTAINER_ID"
+
+DOCKER_ROOTFS="$WORK_DIR/docker_rootfs"
+mkdir -p "$DOCKER_ROOTFS"
+docker export "$DOCKER_CONTAINER_ID" | tar -C "$DOCKER_ROOTFS" -xf -
+log_info "Docker rootfs exported to $DOCKER_ROOTFS"
+
+# ── Step 3: compare ─────────────────────────────────────────────────────────
+
+log_info "=== Step 3: Comparing filesystems ==="
+
+DUCC_LIST="$WORK_DIR/ducc_listing.txt"
+DOCKER_LIST="$WORK_DIR/docker_listing.txt"
+
+generate_listing "$CVMFS_FLAT_DIR" "$DUCC_LIST"
+generate_listing "$DOCKER_ROOTFS"  "$DOCKER_LIST"
+
+DUCC_N=$(wc -l < "$DUCC_LIST")
+DOCKER_N=$(wc -l < "$DOCKER_LIST")
+log_info "CVMFS flat image entries : $DUCC_N"
+log_info "Docker export entries    : $DOCKER_N"
+
+HAS_DIFF=0
+LISTING_DIFF="$WORK_DIR/listing_diff.txt"
+
+if diff -u "$DOCKER_LIST" "$DUCC_LIST" > "$LISTING_DIFF" 2>&1; then
+    log_info "Tree structure comparison : PASS"
+else
+    HAS_DIFF=1
+    ONLY_DOCKER=$(grep -c '^-[^-]' "$LISTING_DIFF" || true)
+    ONLY_DUCC=$(grep -c '^+[^+]' "$LISTING_DIFF" || true)
+    log_info "Tree structure comparison : FAIL"
+    log_info "  Only in Docker export   : $ONLY_DOCKER entries"
+    log_info "  Only in CVMFS flat image: $ONLY_DUCC entries"
+    [ "$VERBOSE" -eq 1 ] && head -80 "$LISTING_DIFF"
+fi
+
+if [ "$COMPARE_CONTENT" -eq 1 ]; then
+    log_info "Computing file checksums (this may take a while)..."
+    DUCC_SUMS="$WORK_DIR/ducc_checksums.txt"
+    DOCKER_SUMS="$WORK_DIR/docker_checksums.txt"
+    SUMS_DIFF="$WORK_DIR/checksum_diff.txt"
+
+    generate_checksums "$CVMFS_FLAT_DIR" "$DUCC_SUMS"
+    generate_checksums "$DOCKER_ROOTFS"  "$DOCKER_SUMS"
+
+    if diff -u "$DOCKER_SUMS" "$DUCC_SUMS" > "$SUMS_DIFF" 2>&1; then
+        log_info "Content comparison        : PASS"
+    else
+        HAS_DIFF=1
+        log_info "Content comparison        : FAIL"
+        [ "$VERBOSE" -eq 1 ] && head -80 "$SUMS_DIFF"
+    fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+if [ "$HAS_DIFF" -eq 0 ]; then
+    log_info "RESULT: PASS — flat image matches Docker export"
+    log_info "  Image:   $IMAGE_URL"
+    log_info "  Entries: $DOCKER_N"
+    exit 0
+else
+    log_info "RESULT: FAIL — differences detected"
+    log_info "  Image:   $IMAGE_URL"
+    log_info "  Details: $WORK_DIR/"
+    [ "$KEEP_TEMP" -eq 0 ] && log_info "  (re-run with -k to keep temp files)"
+    exit 1
+fi

--- a/test/container/validate_unpacker.sh
+++ b/test/container/validate_unpacker.sh
@@ -60,19 +60,23 @@ url_to_cvmfs_image_path() { echo "${1#*://}"; }
 
 # Produce a deterministic, sorted listing of all entries in a directory.
 # Format: TYPE PERMS SIZE PATH [-> SYMLINK_TARGET]
-# Filters out CVMFS bookkeeping files and files that get special handling
-# by the unpacker's singularity support (see ducc/singularity/dotfiles.go
-# and ducc/singularity/startup_files.go):
-#   - .singularity.d/ tree (created/overwritten by makeBaseEnv)
-#   - /etc/hosts and /etc/resolv.conf (truncated by makeFiles)
-#   - symlinks: singularity .run .exec .test .shell environment
+# Filters out:
+#   - CVMFS bookkeeping files (.cvmfscatalog, .cvmfsdirtab, .cvmfsautocatalog)
+#   - Singularity support files (see ducc/singularity/dotfiles.go and
+#     ducc/singularity/startup_files.go):
+#       .singularity.d/ tree, /etc/hosts, /etc/resolv.conf,
+#       symlinks: singularity .run .exec .test .shell environment
+#   - Docker runtime artifacts not present in image layers:
+#       .dockerenv, dev/console, dev/pts, dev/shm, etc/mtab, etc/hostname
 generate_listing() {
     local dir="$1" output="$2"
     ( cd "$dir"
       find . \( -name '.cvmfscatalog' -o -name '.cvmfsdirtab' \
                 -o -name '.cvmfsautocatalog' \
-                -o -path './.singularity.d' \) -prune -o -print \
-        | grep -v -x \
+                -o -path './.singularity.d' \
+                -o -path './dev/pts' -o -path './dev/shm' \
+                \) -prune -o -print0 \
+        | grep -z -v -x \
             -e '\./\.singularity\.d' \
             -e '\./etc/hosts' \
             -e '\./etc/resolv\.conf' \
@@ -82,7 +86,13 @@ generate_listing() {
             -e '\./\.test' \
             -e '\./\.shell' \
             -e '\./environment' \
-        | sort | while IFS= read -r entry; do
+            -e '\./\.dockerenv' \
+            -e '\./dev/console' \
+            -e '\./dev/pts' \
+            -e '\./dev/shm' \
+            -e '\./etc/mtab' \
+            -e '\./etc/hostname' \
+        | sort -z | while IFS= read -r -d '' entry; do
             if   [ -L "$entry" ]; then
                 printf 'L %s -> %s\n' "$entry" "$(readlink "$entry")"
             elif [ -d "$entry" ]; then
@@ -101,14 +111,21 @@ generate_listing() {
 generate_checksums() {
     local dir="$1" output="$2"
     ( cd "$dir"
-      find . -path './.singularity.d' -prune -o -type f \
+      find . -path './.singularity.d' -prune \
+             -o -path './dev/pts' -prune \
+             -o -path './dev/shm' -prune \
+             -o -type f \
              ! -name '.cvmfscatalog' \
              ! -name '.cvmfsdirtab' \
              ! -name '.cvmfsautocatalog' \
              ! -path './etc/hosts' \
              ! -path './etc/resolv.conf' \
-             -print \
-        | sort | xargs -r sha256sum
+             ! -path './.dockerenv' \
+             ! -path './dev/console' \
+             ! -path './etc/mtab' \
+             ! -path './etc/hostname' \
+             -print0 \
+        | sort -z | xargs -0 -r sha256sum
     ) > "$output"
 }
 

--- a/test/src/714-catalog-overlay/main
+++ b/test/src/714-catalog-overlay/main
@@ -99,7 +99,6 @@ produce_multi_layers() {
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
-  local scratch_dir=$(pwd)
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
@@ -200,63 +199,17 @@ cvmfs_run_test() {
   echo "*** TEST 5 passed: multi-layer overlay"
 
   # ============================================================================
-  # TEST 6: Cache hit/miss scenarios
+  # TEST 6: Combined whiteout + opaque + override multi-layer
   # ============================================================================
 
-  echo "*** TEST 6: Cache behavior"
-  local cache_dir="${scratch_dir}/overlay_cache"
-  mkdir -p "$cache_dir"
-
-  # First run: cache miss - should generate and store
-  cvmfs_server overlay \
-    -l "layer1,layer2" \
-    -d "/overlay_test6a" \
-    -c "$cache_dir" \
-    $CVMFS_TEST_REPO || return 60
-
-  # Verify cache files were created
-  local cache_files=$(ls "$cache_dir"/*.cache.db 2>/dev/null | wc -l)
-  [ "$cache_files" -ge 1 ] || return 62
-
-  # Second run: should be a cache hit
-  cvmfs_server overlay \
-    -l "layer1,layer2" \
-    -d "/overlay_test6b" \
-    -c "$cache_dir" \
-    $CVMFS_TEST_REPO  | tee test714_6b.log   || return 63
-
-  grep -q "Cache hit" test714_6b.log || return 64
-
-  check_repository $CVMFS_TEST_REPO -i || return 65
-  echo "*** TEST 6 passed: cache hit/miss"
-
-  # ============================================================================
-  # TEST 7: Cache invalidation (force refresh)
-  # ============================================================================
-
-  echo "*** TEST 7: Cache invalidation"
-  cvmfs_server overlay \
-    -l "layer1,layer2" \
-    -d "/overlay_test7" \
-    -c "$cache_dir" \
-    -f \
-    $CVMFS_TEST_REPO || return 70
-
-  check_repository $CVMFS_TEST_REPO -i || return 71
-  echo "*** TEST 7 passed: cache invalidation"
-
-  # ============================================================================
-  # TEST 8: Combined whiteout + opaque + override multi-layer
-  # ============================================================================
-
-  echo "*** TEST 8: Combined multi-layer with all features"
+  echo "*** TEST 6: Combined multi-layer with all features"
   cvmfs_server overlay \
     -l "layer1,layer2,layer3,layer4" \
-    -d "/overlay_test8" \
-    $CVMFS_TEST_REPO || return 80
+    -d "/overlay_test6" \
+    $CVMFS_TEST_REPO || return 60
 
-  check_repository $CVMFS_TEST_REPO -i || return 81
-  echo "*** TEST 8 passed: combined multi-layer"
+  check_repository $CVMFS_TEST_REPO -i || return 61
+  echo "*** TEST 6 passed: combined multi-layer"
 
   # ============================================================================
 

--- a/test/src/714-catalog-overlay/main
+++ b/test/src/714-catalog-overlay/main
@@ -1,0 +1,265 @@
+#!/bin/bash
+
+cvmfs_test_name="Catalog Overlay Tool"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+# Produce a base layer with some files and directories
+produce_base_layer() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir -p layer1/bin
+  mkdir -p layer1/lib
+  mkdir -p layer1/etc
+  echo "base binary" > layer1/bin/app
+  echo "base library" > layer1/lib/libfoo.so
+  echo "base config" > layer1/etc/app.conf
+  chmod 755 layer1/bin/app
+
+  popdir
+}
+
+# Produce a second layer that adds and overrides files
+produce_upper_layer() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir -p layer2/bin
+  mkdir -p layer2/lib
+  mkdir -p layer2/var/log
+  echo "updated binary" > layer2/bin/app
+  echo "new tool" > layer2/bin/tool
+  echo "additional lib" > layer2/lib/libbar.so
+  echo "log data" > layer2/var/log/app.log
+  chmod 755 layer2/bin/app
+  chmod 755 layer2/bin/tool
+
+  popdir
+}
+
+# Produce a third layer with whiteout files
+produce_whiteout_layer() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir -p layer3/lib
+  mkdir -p layer3/etc
+  # Whiteout: delete libfoo.so from lower layers
+  touch "layer3/lib/.wh.libfoo.so"
+  # Override config
+  echo "layer3 config" > layer3/etc/app.conf
+
+  popdir
+}
+
+# Produce a layer with opaque directory marker
+produce_opaque_layer() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  mkdir -p layer4/etc
+  # Opaque marker: hide all previous contents of etc/
+  touch "layer4/etc/.wh..wh..opq"
+  echo "completely new config" > layer4/etc/new.conf
+
+  popdir
+}
+
+# Produce a multi-layer scenario (5 layers)
+produce_multi_layers() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  # Layer A: base
+  mkdir -p layerA/data
+  echo "file1" > layerA/data/file1.txt
+  echo "file2" > layerA/data/file2.txt
+  echo "file3" > layerA/data/file3.txt
+
+  # Layer B: add and modify
+  mkdir -p layerB/data
+  echo "modified file1" > layerB/data/file1.txt
+  echo "file4" > layerB/data/file4.txt
+
+  # Layer C: whiteout file2
+  mkdir -p layerC/data
+  touch "layerC/data/.wh.file2.txt"
+  echo "file5" > layerC/data/file5.txt
+
+  popdir
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  # ============================================================================
+  # Populate all layers via normal transactions
+  # ============================================================================
+
+  echo "*** populating base layer (layer1)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_base_layer $repo_dir || return 3
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** populating upper layer (layer2)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_upper_layer $repo_dir || return 4
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** populating whiteout layer (layer3)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_whiteout_layer $repo_dir || return 5
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** populating opaque layer (layer4)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_opaque_layer $repo_dir || return 6
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** populating multi-layers (layerA, layerB, layerC)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_multi_layers $repo_dir || return 7
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  # ============================================================================
+  # TEST 1: Single layer overlay
+  # ============================================================================
+
+  echo "*** TEST 1: Single layer overlay"
+  cvmfs_server overlay \
+    -l "layer1" \
+    -d "overlay_test1" \
+    $CVMFS_TEST_REPO || return 10
+
+  echo "*** verify overlay result is accessible"
+  check_repository $CVMFS_TEST_REPO -i || return 11
+  echo "*** TEST 1 passed: single layer overlay"
+
+  # ============================================================================
+  # TEST 2: Two-layer overlay (upper overrides lower)
+  # ============================================================================
+
+  echo "*** TEST 2: Two-layer overlay"
+  cvmfs_server overlay \
+    -l "layer1,layer2" \
+    -d "overlay_test2" \
+    $CVMFS_TEST_REPO || return 20
+
+  check_repository $CVMFS_TEST_REPO -i || return 21
+  echo "*** TEST 2 passed: two-layer overlay"
+
+  # ============================================================================
+  # TEST 3: Whiteout handling
+  # ============================================================================
+
+  echo "*** TEST 3: Whiteout handling"
+  cvmfs_server overlay \
+    -l "layer1,layer3" \
+    -d "overlay_test3" \
+    $CVMFS_TEST_REPO || return 30
+
+  check_repository $CVMFS_TEST_REPO -i || return 31
+  echo "*** TEST 3 passed: whiteout handling"
+
+  # ============================================================================
+  # TEST 4: Opaque directory handling
+  # ============================================================================
+
+  echo "*** TEST 4: Opaque directory handling"
+  cvmfs_server overlay \
+    -l "layer1,layer4" \
+    -d "/overlay_test4" \
+    $CVMFS_TEST_REPO || return 40
+
+  check_repository $CVMFS_TEST_REPO -i || return 41
+  echo "*** TEST 4 passed: opaque directory handling"
+
+  # ============================================================================
+  # TEST 5: Multi-layer overlay (3+ layers)
+  # ============================================================================
+
+  echo "*** TEST 5: Multi-layer overlay"
+  cvmfs_server overlay \
+    -l "layerA,layerB,layerC" \
+    -d "/overlay_test5" \
+    $CVMFS_TEST_REPO || return 50
+
+  check_repository $CVMFS_TEST_REPO -i || return 51
+  echo "*** TEST 5 passed: multi-layer overlay"
+
+  # ============================================================================
+  # TEST 6: Cache hit/miss scenarios
+  # ============================================================================
+
+  echo "*** TEST 6: Cache behavior"
+  local cache_dir="${scratch_dir}/overlay_cache"
+  mkdir -p "$cache_dir"
+
+  # First run: cache miss - should generate and store
+  cvmfs_server overlay \
+    -l "layer1,layer2" \
+    -d "/overlay_test6a" \
+    -c "$cache_dir" \
+    $CVMFS_TEST_REPO || return 60
+
+  # Verify cache files were created
+  local cache_files=$(ls "$cache_dir"/*.cache 2>/dev/null | wc -l)
+  [ "$cache_files" -ge 1 ] || return 62
+
+  # Second run: should be a cache hit
+  cvmfs_server overlay \
+    -l "layer1,layer2" \
+    -d "/overlay_test6b" \
+    -c "$cache_dir" \
+    $CVMFS_TEST_REPO 2>&1 | grep -q "Cache hit" || return 63
+
+  check_repository $CVMFS_TEST_REPO -i || return 64
+  echo "*** TEST 6 passed: cache hit/miss"
+
+  # ============================================================================
+  # TEST 7: Cache invalidation (force refresh)
+  # ============================================================================
+
+  echo "*** TEST 7: Cache invalidation"
+  cvmfs_server overlay \
+    -l "layer1,layer2" \
+    -d "/overlay_test7" \
+    -c "$cache_dir" \
+    -f \
+    $CVMFS_TEST_REPO || return 70
+
+  check_repository $CVMFS_TEST_REPO -i || return 71
+  echo "*** TEST 7 passed: cache invalidation"
+
+  # ============================================================================
+  # TEST 8: Combined whiteout + opaque + override multi-layer
+  # ============================================================================
+
+  echo "*** TEST 8: Combined multi-layer with all features"
+  cvmfs_server overlay \
+    -l "layer1,layer2,layer3,layer4" \
+    -d "/overlay_test8" \
+    $CVMFS_TEST_REPO || return 80
+
+  check_repository $CVMFS_TEST_REPO -i || return 81
+  echo "*** TEST 8 passed: combined multi-layer"
+
+  # ============================================================================
+
+  echo "*** final catalog and data integrity check"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  return 0
+}
+

--- a/test/src/714-catalog-overlay/main
+++ b/test/src/714-catalog-overlay/main
@@ -215,7 +215,7 @@ cvmfs_run_test() {
     $CVMFS_TEST_REPO || return 60
 
   # Verify cache files were created
-  local cache_files=$(ls "$cache_dir"/*.cache 2>/dev/null | wc -l)
+  local cache_files=$(ls "$cache_dir"/*.cache.db 2>/dev/null | wc -l)
   [ "$cache_files" -ge 1 ] || return 62
 
   # Second run: should be a cache hit

--- a/test/src/714-catalog-overlay/main
+++ b/test/src/714-catalog-overlay/main
@@ -223,9 +223,11 @@ cvmfs_run_test() {
     -l "layer1,layer2" \
     -d "/overlay_test6b" \
     -c "$cache_dir" \
-    $CVMFS_TEST_REPO 2>&1 | grep -q "Cache hit" || return 63
+    $CVMFS_TEST_REPO  | tee test714_6b.log   || return 63
 
-  check_repository $CVMFS_TEST_REPO -i || return 64
+  grep -q "Cache hit" test714_6b.log || return 64
+
+  check_repository $CVMFS_TEST_REPO -i || return 65
   echo "*** TEST 6 passed: cache hit/miss"
 
   # ============================================================================

--- a/test/src/714-catalog-overlay/main
+++ b/test/src/714-catalog-overlay/main
@@ -16,6 +16,7 @@ produce_base_layer() {
   echo "base binary" > layer1/bin/app
   echo "base library" > layer1/lib/libfoo.so
   echo "base config" > layer1/etc/app.conf
+  touch emptyfile
   chmod 755 layer1/bin/app
 
   popdir


### PR DESCRIPTION
This should let us make the unpacker simpler and more efficient.  

First draft as of now, but basic functionality is working. Still to do:

- [x] complete test with some docker images, checking that we get the same overlay (can be done with integration tests when adapting ducc to use these tools.
-  nested subcatalogs in the layers are not handled as of yet (not needed for the immediate future).