### PR TITLE
fix(ci): install equivs when missing in build_install_builddeps.sh

### DIFF
--- a/ci/build_install_builddeps.sh
+++ b/ci/build_install_builddeps.sh
@@ -162,7 +162,7 @@ list_deps_rpm() {
 install_deps_deb() {
   [ -f "$DEB_CONTROL" ] || die "Debian control file not found at $DEB_CONTROL"
   $SUDO apt-get -y update
-  if ! check_available mk-build-deps; then
+  if ! check_available mk-build-deps || ! dpkg -s equivs >/dev/null 2>&1; then
     $SUDO apt-get -y install devscripts equivs
   fi
   # Use mk-build-deps to create and install the meta-package, then remove it


### PR DESCRIPTION
Ensure the script installs 'equivs' if it's not present so mk-build-deps works on Debian/Ubuntu.

Otherwise, it fails:

```
> sudo ci/build_install_builddeps.sh --install
[builddeps] Detected platform: deb via apt-get
Get:1 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Hit:2 http://archive.ubuntu.com/ubuntu noble InRelease
Get:3 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:4 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [1822 kB]
Get:5 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:6 http://archive.ubuntu.com/ubuntu noble/main amd64 Components [665 kB]
Get:7 http://security.ubuntu.com/ubuntu noble-security/main amd64 Components [25.2 kB]
Get:8 http://security.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [9892 B]
Get:9 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1199 kB]
Get:10 http://archive.ubuntu.com/ubuntu noble/main amd64 c-n-f Metadata [30.5 kB]
Get:11 http://archive.ubuntu.com/ubuntu noble/universe amd64 Components [5943 kB]
Get:12 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Components [94.8 kB]
Get:13 http://security.ubuntu.com/ubuntu noble-security/universe amd64 c-n-f Metadata [19.9 kB]
Get:14 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [3106 kB]
Get:15 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Components [155 B]
Get:16 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 c-n-f Metadata [536 B]
Get:17 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [34.8 kB]
Get:18 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [157 B]
Get:19 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 c-n-f Metadata [396 B]
Get:20 http://archive.ubuntu.com/ubuntu noble/universe amd64 c-n-f Metadata [301 kB]
Get:21 http://archive.ubuntu.com/ubuntu noble/restricted amd64 c-n-f Metadata [416 B]
Get:22 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Components [41.9 kB]
Get:23 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 c-n-f Metadata [8328 B]
Get:24 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [2201 kB]
Get:25 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [234 kB]
Get:26 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [16.5 kB]
Get:27 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1978 kB]
Get:28 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [532 kB]
Get:29 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [31.9 kB]
Get:30 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [3287 kB]
Get:31 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [159 B]
Get:32 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 c-n-f Metadata [556 B]
Get:33 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [38.1 kB]
Get:34 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [887 B]
Get:35 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 c-n-f Metadata [496 B]
Get:36 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [8098 B]
Get:37 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 c-n-f Metadata [368 B]
Get:38 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [11.3 kB]
Get:39 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 c-n-f Metadata [1444 B]
Get:40 http://archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [160 B]
Get:41 http://archive.ubuntu.com/ubuntu noble-backports/restricted amd64 c-n-f Metadata [116 B]
Get:42 http://archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [161 B]
Get:43 http://archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 c-n-f Metadata [116 B]
Fetched 22.0 MB in 3s (7055 kB/s)
Reading package lists... Done
mk-build-deps: You must have equivs installed to use this program.
```