### PR TITLE
Make busy snapshot during -a not be an ERROR

### DIFF
--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -793,7 +793,8 @@ release_update_lock() {
 #
 # @param name               the repository to lock
 # @param update_type        update type such as snapshot or gc
-# @param abort_on_conflict  0 to wait for lock, 1 to abort if already acquired.
+# @param abort_on_conflict  0 to wait for lock, 1 to abort if already acquired,
+#                           2 to skip if already acquired.
 #                           Default 0.  Always aborts if initial snapshot is
 #                           in progress.
 # @return                   0 if lock successfully acquired
@@ -809,9 +810,13 @@ acquire_update_lock()
 
   # check for other updates in progress
   if ! acquire_lock $update_lock; then
-    if [ $abort_on_conflict -eq 1 ]; then
-      echo "another update is in progress... aborting"
-      to_syslog_for_repo $name "did not $update_type (another update in progress)"
+    if [ $abort_on_conflict -ge 1 ]; then
+      if [ $abort_on_conflict -ge 2 ]; then
+        echo "another update is in progress... skipping"
+      else
+        echo "another update is in progress... aborting"
+        to_syslog_for_repo $name "did not $update_type (another update in progress)"
+      fi
       return 1
     fi
 
@@ -822,8 +827,12 @@ acquire_update_lock()
     fi
 
     if [ $initial_snapshot -eq 1 ]; then
-      echo "an initial snapshot is in progress... aborting"
-      to_syslog_for_repo $name "did not $update_type (initial snapshot in progress)"
+      if [ $abort_on_conflict -ge 2 ]; then
+        echo "another update is in progress... skipping"
+      else
+        echo "an initial snapshot is in progress... aborting"
+        to_syslog_for_repo $name "did not $update_type (initial snapshot in progress)"
+      fi
       return 1
     fi
 

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -95,7 +95,9 @@ __do_snapshot() {
     fi
 
     if ! acquire_update_lock $alias_name snapshot $abort_on_conflict; then
-      retcode=1
+      if [ $abort_on_conflict -lt 2 ]; then
+        retcode=1
+      fi
       continue
     fi
 
@@ -317,7 +319,7 @@ __do_all_snapshots() {
     # See https://lists.gnu.org/archive/html/bug-bash/2012-12/msg00093.html
     set +e
     (set -e
-    __do_snapshot $repo 1
+    __do_snapshot $repo 2
     )
     if [ $? != 0 ]; then
       echo "ERROR from cvmfs_server snapshot!" >&2


### PR DESCRIPTION
Stratum 1s that use snapshot -a end up getting many occurrences in the snapshot log of messages like this even though it is a very normal situation:
```
another update is in progress... aborting
ERROR from cvmfs_server snapshot!
```
Especially that ERROR message makes it more difficult to search for real errors in the log.  This PR turns "aborting" into "skipping" and removes the ERROR message.  It also removes the extraneous message in /var/log/messages.

(I thought there was probably an open issue about fixing this but I wasn't able to locate one).