### PR TITLE
ducc: cache auth token for requests to registry

### DIFF
--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -64,6 +64,57 @@ type RegistryConfig struct {
 
 var inputRegistries []RegistryConfig
 
+// Token cache to avoid redundant auth requests for the same registry/repository.
+type cachedToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+var (
+	tokenCacheMu  sync.RWMutex
+	tokenCacheMap = make(map[string]*cachedToken)
+)
+
+// extractTokenCacheKey extracts a repository-scoped cache key from a registry URL.
+// URLs like https://registry/v2/repo/manifests/ref and https://registry/v2/repo/blobs/digest
+// all map to the same cache key based on the registry+repository prefix.
+func extractTokenCacheKey(url, user string) string {
+	for _, suffix := range []string{"/manifests/", "/blobs/", "/tags/"} {
+		if idx := strings.Index(url, suffix); idx != -1 {
+			return url[:idx] + "|" + user
+		}
+	}
+	return url + "|" + user
+}
+
+func getCachedToken(key string) (string, bool) {
+	tokenCacheMu.RLock()
+	defer tokenCacheMu.RUnlock()
+	cached, ok := tokenCacheMap[key]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(cached.expiresAt) {
+		return "", false
+	}
+	return cached.token, true
+}
+
+func setCachedToken(key, token string, expiresIn int) {
+	tokenCacheMu.Lock()
+	defer tokenCacheMu.Unlock()
+	ttl := time.Duration(expiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = 60 * time.Second // default 60s TTL
+	}
+	// Apply safety margin: use 80% of the TTL to refresh before actual expiry
+	ttl = time.Duration(float64(ttl) * 0.8)
+	tokenCacheMap[key] = &cachedToken{
+		token:     token,
+		expiresAt: time.Now().Add(ttl),
+	}
+}
+
 const rateLimitMaxRetries = 5
 
 // handleRateLimitBackoff checks if the response is a 429 (Too Many Requests) and implements
@@ -673,6 +724,12 @@ func firstRequestForAuth(url string) (token string, err error) {
 }
 
 func firstRequestForAuth_internal(url, user, pass string) (token string, err error) {
+	cacheKey := extractTokenCacheKey(url, user)
+	if cached, ok := getCachedToken(cacheKey); ok {
+		log.WithFields(log.Fields{"url": url}).Debug("Using cached auth token")
+		return cached, nil
+	}
+
 	client := &http.Client{}
 
 	for attempt := 0; attempt <= rateLimitMaxRetries; attempt++ {
@@ -699,6 +756,8 @@ func firstRequestForAuth_internal(url, user, pass string) (token string, err err
 				"status code": resp.StatusCode,
 			}).Info("Return valid response, token not necessary.")
 			resp.Body.Close()
+			// Cache "no auth needed" with a short TTL
+			setCachedToken(cacheKey, "", 60)
 			return "", nil
 		}
 		if resp.StatusCode != 401 {
@@ -714,17 +773,20 @@ func firstRequestForAuth_internal(url, user, pass string) (token string, err err
 		// we first try to get the token with the authentication
 		// if we fail, and we might since the docker hub might not have our user
 		// we try again without authentication
-		token, err = requestAuthToken(WwwAuthenticate, user, pass)
+		var expiresIn int
+		token, expiresIn, err = requestAuthToken(WwwAuthenticate, user, pass)
 		if err == nil {
 			// happy path
+			setCachedToken(cacheKey, token, expiresIn)
 			return token, nil
 		}
 		fmt.Printf("We failed with authentication and we now go without for %s\n", url)
 		// some error, we should retry without auth
 		if user != "" || pass != "" {
-			token, err = requestAuthToken(WwwAuthenticate, "", "")
+			token, expiresIn, err = requestAuthToken(WwwAuthenticate, "", "")
 			if err == nil {
 				// happy path without auth
+				setCachedToken(cacheKey, token, expiresIn)
 				return token, nil
 			}
 		}
@@ -969,7 +1031,7 @@ func parseBearerToken(token string) (realm string, options map[string]string, er
 	return
 }
 
-func requestAuthToken(token, user, pass string) (authToken string, err error) {
+func requestAuthToken(token, user, pass string) (authToken string, expiresIn int, err error) {
 	realm, options, err := parseBearerToken(token)
 	if err != nil {
 		return
@@ -980,7 +1042,7 @@ func requestAuthToken(token, user, pass string) (authToken string, err error) {
 	for attempt := 0; attempt <= rateLimitMaxRetries; attempt++ {
 		req, reqErr := http.NewRequest("GET", realm, nil)
 		if reqErr != nil {
-			return "", reqErr
+			return "", 0, reqErr
 		}
 
 		query := req.URL.Query()
@@ -1025,10 +1087,16 @@ func requestAuthToken(token, user, pass string) (authToken string, err error) {
 			resp.Body.Close()
 			return
 		}
+		// Extract expires_in if present (typically 300s for Docker Hub)
+		if expiresInInterface, ok := jsonResp["expires_in"]; ok {
+			if v, ok := expiresInInterface.(float64); ok {
+				expiresIn = int(v)
+			}
+		}
 		resp.Body.Close()
 		return
 	}
-	return "", fmt.Errorf("max retries exceeded for rate limiting")
+	return "", 0, fmt.Errorf("max retries exceeded for rate limiting")
 }
 
 type LayerDownloader struct {

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"testing"
+	"time"
 )
 
 func TestParseTags(t *testing.T) {
@@ -151,5 +152,224 @@ func TestFilterUsingGlobRealLifeImages02(t *testing.T) {
 		if result[i] != expected[i] {
 			t.Errorf("The match is missing something: %s != %s", result[i], input[i])
 		}
+	}
+}
+
+// --- Token cache tests ---
+
+func TestExtractTokenCacheKey_ManifestURL(t *testing.T) {
+	url := "https://registry.hub.docker.com/v2/library/redis/manifests/latest"
+	key := extractTokenCacheKey(url, "")
+	expected := "https://registry.hub.docker.com/v2/library/redis|"
+	if key != expected {
+		t.Errorf("Expected %q, got %q", expected, key)
+	}
+}
+
+func TestExtractTokenCacheKey_BlobURL(t *testing.T) {
+	url := "https://registry.hub.docker.com/v2/library/redis/blobs/sha256:abc123"
+	key := extractTokenCacheKey(url, "")
+	expected := "https://registry.hub.docker.com/v2/library/redis|"
+	if key != expected {
+		t.Errorf("Expected %q, got %q", expected, key)
+	}
+}
+
+func TestExtractTokenCacheKey_TagsURL(t *testing.T) {
+	url := "https://registry.hub.docker.com/v2/library/redis/tags/list"
+	key := extractTokenCacheKey(url, "")
+	expected := "https://registry.hub.docker.com/v2/library/redis|"
+	if key != expected {
+		t.Errorf("Expected %q, got %q", expected, key)
+	}
+}
+
+func TestExtractTokenCacheKey_SameRepoSameKey(t *testing.T) {
+	urls := []string{
+		"https://registry.hub.docker.com/v2/library/redis/manifests/latest",
+		"https://registry.hub.docker.com/v2/library/redis/blobs/sha256:abc123",
+		"https://registry.hub.docker.com/v2/library/redis/tags/list",
+	}
+	keys := make(map[string]bool)
+	for _, url := range urls {
+		keys[extractTokenCacheKey(url, "myuser")] = true
+	}
+	if len(keys) != 1 {
+		t.Errorf("Expected all URLs to produce the same cache key, got %d distinct keys: %v", len(keys), keys)
+	}
+}
+
+func TestExtractTokenCacheKey_DifferentRepoDifferentKey(t *testing.T) {
+	url1 := "https://registry.hub.docker.com/v2/library/redis/manifests/latest"
+	url2 := "https://registry.hub.docker.com/v2/library/nginx/manifests/latest"
+	key1 := extractTokenCacheKey(url1, "")
+	key2 := extractTokenCacheKey(url2, "")
+	if key1 == key2 {
+		t.Errorf("Expected different cache keys for different repos, both got %q", key1)
+	}
+}
+
+func TestExtractTokenCacheKey_DifferentUserDifferentKey(t *testing.T) {
+	url := "https://registry.hub.docker.com/v2/library/redis/manifests/latest"
+	key1 := extractTokenCacheKey(url, "alice")
+	key2 := extractTokenCacheKey(url, "bob")
+	if key1 == key2 {
+		t.Errorf("Expected different cache keys for different users, both got %q", key1)
+	}
+}
+
+func TestExtractTokenCacheKey_NoSuffix(t *testing.T) {
+	url := "https://registry.hub.docker.com/v2/library/redis"
+	key := extractTokenCacheKey(url, "user")
+	expected := url + "|user"
+	if key != expected {
+		t.Errorf("Expected %q, got %q", expected, key)
+	}
+}
+
+func clearTokenCache() {
+	tokenCacheMu.Lock()
+	defer tokenCacheMu.Unlock()
+	tokenCacheMap = make(map[string]*cachedToken)
+}
+
+func TestGetSetCachedToken(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	key := "test-key"
+
+	// Cache miss
+	_, ok := getCachedToken(key)
+	if ok {
+		t.Error("Expected cache miss for empty cache")
+	}
+
+	// Set and retrieve
+	setCachedToken(key, "Bearer abc123", 300)
+	token, ok := getCachedToken(key)
+	if !ok {
+		t.Error("Expected cache hit after set")
+	}
+	if token != "Bearer abc123" {
+		t.Errorf("Expected 'Bearer abc123', got %q", token)
+	}
+}
+
+func TestCachedTokenExpiry(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	key := "expiry-test"
+
+	// Set with a very short TTL by directly manipulating the cache
+	tokenCacheMu.Lock()
+	tokenCacheMap[key] = &cachedToken{
+		token:     "Bearer expired",
+		expiresAt: time.Now().Add(-1 * time.Second), // already expired
+	}
+	tokenCacheMu.Unlock()
+
+	_, ok := getCachedToken(key)
+	if ok {
+		t.Error("Expected cache miss for expired token")
+	}
+}
+
+func TestCachedTokenNotYetExpired(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	key := "fresh-test"
+
+	tokenCacheMu.Lock()
+	tokenCacheMap[key] = &cachedToken{
+		token:     "Bearer fresh",
+		expiresAt: time.Now().Add(5 * time.Minute),
+	}
+	tokenCacheMu.Unlock()
+
+	token, ok := getCachedToken(key)
+	if !ok {
+		t.Error("Expected cache hit for non-expired token")
+	}
+	if token != "Bearer fresh" {
+		t.Errorf("Expected 'Bearer fresh', got %q", token)
+	}
+}
+
+func TestSetCachedTokenDefaultTTL(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	key := "default-ttl"
+	setCachedToken(key, "Bearer tok", 0) // 0 should use default 60s
+
+	tokenCacheMu.RLock()
+	cached, ok := tokenCacheMap[key]
+	tokenCacheMu.RUnlock()
+
+	if !ok {
+		t.Fatal("Expected token to be cached")
+	}
+	// Default TTL is 60s * 0.8 = 48s. Check it's in a reasonable range.
+	remaining := time.Until(cached.expiresAt)
+	if remaining < 40*time.Second || remaining > 50*time.Second {
+		t.Errorf("Expected default TTL ~48s, got %v", remaining)
+	}
+}
+
+func TestSetCachedTokenSafetyMargin(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	key := "margin-test"
+	setCachedToken(key, "Bearer tok", 300) // 300s * 0.8 = 240s
+
+	tokenCacheMu.RLock()
+	cached, ok := tokenCacheMap[key]
+	tokenCacheMu.RUnlock()
+
+	if !ok {
+		t.Fatal("Expected token to be cached")
+	}
+	remaining := time.Until(cached.expiresAt)
+	// Should be ~240s, allow some slack
+	if remaining < 235*time.Second || remaining > 245*time.Second {
+		t.Errorf("Expected TTL ~240s (80%% of 300s), got %v", remaining)
+	}
+}
+
+func TestSetCachedTokenOverwrite(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	key := "overwrite-test"
+	setCachedToken(key, "Bearer old", 300)
+	setCachedToken(key, "Bearer new", 600)
+
+	token, ok := getCachedToken(key)
+	if !ok {
+		t.Error("Expected cache hit")
+	}
+	if token != "Bearer new" {
+		t.Errorf("Expected overwritten token 'Bearer new', got %q", token)
+	}
+}
+
+func TestCacheEmptyToken(t *testing.T) {
+	clearTokenCache()
+	defer clearTokenCache()
+
+	// Empty token is valid (means "no auth needed")
+	key := "no-auth"
+	setCachedToken(key, "", 60)
+
+	token, ok := getCachedToken(key)
+	if !ok {
+		t.Error("Expected cache hit for empty token")
+	}
+	if token != "" {
+		t.Errorf("Expected empty token, got %q", token)
 	}
 }


### PR DESCRIPTION
Should significantly decrease the number of requests the unpacker sends to registry APIs.