### PR TITLE
ducc: ignore errors on conversion for certain images

### DIFF
--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -33,6 +34,21 @@ func init() {
 	convertCmd.Flags().BoolVarP(&skipThinImage, "skip-thin-image", "i", false, "do not create and push the docker thin image")
 	convertCmd.Flags().BoolVarP(&skipPodman, "skip-podman", "p", false, "do not create podman image store")
 	rootCmd.AddCommand(convertCmd)
+}
+
+// isInIgnoreList checks if an image name matches any pattern in the ignore list
+func isInIgnoreList(imageName string, ignoreList []string) bool {
+	for _, pattern := range ignoreList {
+		matched, err := filepath.Match(pattern, imageName)
+		if err != nil {
+			l.LogE(err).WithFields(log.Fields{"pattern": pattern}).Warning("Invalid ignore pattern")
+			continue
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
 }
 
 var convertCmd = &cobra.Command{
@@ -70,32 +86,52 @@ var convertCmd = &cobra.Command{
 				"repository":   wish.CvmfsRepo,
 				"output image": wish.OutputName}
 			l.Log().WithFields(fields).Info("Start conversion of wish")
+
+			// Check if this wish is in the ignore errors list
+			isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
+
 			if !skipLayers {
 				err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
 				if err != nil {
-					l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+					if isIgnored {
+						l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
+					} else {
+						l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
+						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+					}
 				}
 			}
 			if !skipThinImage {
 				err = lib.ConvertWishDocker(wish)
 				if err != nil {
-					l.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
-					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] docker: %s", wish.InputName, err))
+					if isIgnored {
+						l.LogE(err).WithFields(fields).Warning("Error in converting wish (docker), but image is in ignoreErrors list")
+					} else {
+						l.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
+						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] docker: %s", wish.InputName, err))
+					}
 				}
 			}
 			if !skipPodman {
 				err = lib.ConvertWishPodman(wish, convertAgain)
 				if err != nil {
-					l.LogE(err).WithFields(fields).Error("Error in converting wish (podman), going on")
-					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] podman: %s", wish.InputName, err))
+					if isIgnored {
+						l.LogE(err).WithFields(fields).Warning("Error in converting wish (podman), but image is in ignoreErrors list")
+					} else {
+						l.LogE(err).WithFields(fields).Error("Error in converting wish (podman), going on")
+						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] podman: %s", wish.InputName, err))
+					}
 				}
 			}
 			if !skipFlat {
 				err = lib.ConvertWishFlat(wish)
 				if err != nil {
-					l.LogE(err).WithFields(fields).Error("Error in converting wish (singularity), going on")
-					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] singularity: %s", wish.InputName, err))
+					if isIgnored {
+						l.LogE(err).WithFields(fields).Warning("Error in converting wish (singularity), but image is in ignoreErrors list")
+					} else {
+						l.LogE(err).WithFields(fields).Error("Error in converting wish (singularity), going on")
+						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] singularity: %s", wish.InputName, err))
+					}
 				}
 			}
 		}

--- a/ducc/cmd/convert_test.go
+++ b/ducc/cmd/convert_test.go
@@ -64,4 +64,3 @@ func TestIsInIgnoreList(t *testing.T) {
 		})
 	}
 }
-

--- a/ducc/cmd/convert_test.go
+++ b/ducc/cmd/convert_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestIsInIgnoreList(t *testing.T) {
+	tests := []struct {
+		name       string
+		imageName  string
+		ignoreList []string
+		expected   bool
+	}{
+		{
+			name:       "exact match",
+			imageName:  "https://registry.hub.docker.com/library/ubuntu:20.04",
+			ignoreList: []string{"https://registry.hub.docker.com/library/ubuntu:20.04"},
+			expected:   true,
+		},
+		{
+			name:       "wildcard match - tag",
+			imageName:  "https://registry.hub.docker.com/library/nginx:latest",
+			ignoreList: []string{"https://registry.hub.docker.com/library/nginx:*"},
+			expected:   true,
+		},
+		{
+			name:       "wildcard match - repository",
+			imageName:  "https://registry.hub.docker.com/library/alpine:latest",
+			ignoreList: []string{"https://registry.hub.docker.com/library/*:latest"},
+			expected:   true,
+		},
+		{
+			name:       "no match",
+			imageName:  "https://registry.hub.docker.com/library/ubuntu:22.04",
+			ignoreList: []string{"https://registry.hub.docker.com/library/alpine:*"},
+			expected:   false,
+		},
+		{
+			name:       "empty ignore list",
+			imageName:  "https://registry.hub.docker.com/library/ubuntu:20.04",
+			ignoreList: []string{},
+			expected:   false,
+		},
+		{
+			name:       "multiple patterns - match second",
+			imageName:  "https://registry.hub.docker.com/library/nginx:1.21",
+			ignoreList: []string{"https://registry.hub.docker.com/library/alpine:*", "https://registry.hub.docker.com/library/nginx:*"},
+			expected:   true,
+		},
+		{
+			name:       "multiple patterns - no match",
+			imageName:  "https://registry.hub.docker.com/library/ubuntu:20.04",
+			ignoreList: []string{"https://registry.hub.docker.com/library/alpine:*", "https://registry.hub.docker.com/library/nginx:*"},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isInIgnoreList(tt.imageName, tt.ignoreList)
+			if result != tt.expected {
+				t.Errorf("isInIgnoreList(%q, %v) = %v, expected %v", tt.imageName, tt.ignoreList, result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -74,32 +74,52 @@ var loopCmd = &cobra.Command{
 					"repository":   wish.CvmfsRepo,
 					"output image": wish.OutputName}
 				l.Log().WithFields(fields).Info("Start conversion of wish")
+
+				// Check if this wish is in the ignore errors list
+				isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
+
 				if !skipLayers {
 					err = lib.ConvertWish(wish, convertAgain, overwriteLayer)
 					if err != nil {
-						l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+						if isIgnored {
+							l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
+						} else {
+							l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
+							conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+						}
 					}
 				}
 				if !skipThinImage {
 					err = lib.ConvertWishDocker(wish)
 					if err != nil {
-						l.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
-						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] docker: %s", wish.InputName, err))
+						if isIgnored {
+							l.LogE(err).WithFields(fields).Warning("Error in converting wish (docker), but image is in ignoreErrors list")
+						} else {
+							l.LogE(err).WithFields(fields).Error("Error in converting wish (docker), going on")
+							conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] docker: %s", wish.InputName, err))
+						}
 					}
 				}
 				if !skipPodman {
 					err = lib.ConvertWishPodman(wish, convertAgain)
 					if err != nil {
-						l.LogE(err).WithFields(fields).Error("Error in converting wish (podman), going on")
-						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] podman: %s", wish.InputName, err))
+						if isIgnored {
+							l.LogE(err).WithFields(fields).Warning("Error in converting wish (podman), but image is in ignoreErrors list")
+						} else {
+							l.LogE(err).WithFields(fields).Error("Error in converting wish (podman), going on")
+							conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] podman: %s", wish.InputName, err))
+						}
 					}
 				}
 				if !skipFlat {
 					err = lib.ConvertWishFlat(wish)
 					if err != nil {
-						l.LogE(err).WithFields(fields).Error("Error in converting wish (singularity), going on")
-						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] singularity: %s", wish.InputName, err))
+						if isIgnored {
+							l.LogE(err).WithFields(fields).Warning("Error in converting wish (singularity), but image is in ignoreErrors list")
+						} else {
+							l.LogE(err).WithFields(fields).Error("Error in converting wish (singularity), going on")
+							conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] singularity: %s", wish.InputName, err))
+						}
 					}
 				}
 				checkQuitSignal()

--- a/ducc/lib/recipe.go
+++ b/ducc/lib/recipe.go
@@ -1,7 +1,9 @@
 package lib
 
 import (
+	"io/ioutil"
 	"math/rand"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -18,11 +20,45 @@ type YamlRecipeV1 struct {
 	CVMFSRepo    string   `yaml:"cvmfs_repo"`
 	OutputFormat string   `yaml:"output_format"`
 	Input        []string `yaml:"input"`
+	IgnoreErrors []string `yaml:"ignoreErrors"`
+}
+
+type IgnoreErrorsConfig struct {
+	IgnoreErrors []string `yaml:"ignoreErrors"`
 }
 
 type Recipe struct {
-	Repo   string
-	Wishes chan WishFriendly
+	Repo             string
+	Wishes           chan WishFriendly
+	IgnoreErrorsList []string
+}
+
+// loadIgnoreErrorsList loads the ignore errors list from an external file if DUCC_IGNORE_ERRORS_FILE env var is set
+func loadIgnoreErrorsList() ([]string, error) {
+	ignoreFilePath := os.Getenv("DUCC_IGNORE_ERRORS_FILE")
+	if ignoreFilePath == "" {
+		return []string{}, nil
+	}
+
+	data, err := ioutil.ReadFile(ignoreFilePath)
+	if err != nil {
+		l.LogE(err).WithFields(log.Fields{"file": ignoreFilePath}).Warning("Failed to read ignore errors file from DUCC_IGNORE_ERRORS_FILE")
+		return []string{}, err
+	}
+
+	var ignoreConfig IgnoreErrorsConfig
+	err = yaml.Unmarshal(data, &ignoreConfig)
+	if err != nil {
+		l.LogE(err).WithFields(log.Fields{"file": ignoreFilePath}).Warning("Failed to parse ignore errors file")
+		return []string{}, err
+	}
+
+	l.Log().WithFields(log.Fields{
+		"file":  ignoreFilePath,
+		"count": len(ignoreConfig.IgnoreErrors),
+	}).Info("Loaded ignore errors list from external file")
+
+	return ignoreConfig.IgnoreErrors, nil
 }
 
 func ParseYamlRecipeV1(data []byte) (Recipe, error) {
@@ -31,6 +67,19 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 	recipe := Recipe{}
 	recipe.Repo = recipeYamlV1.CVMFSRepo
 	recipe.Wishes = make(chan WishFriendly, 500)
+
+	// Load ignore errors list from recipe file
+	recipe.IgnoreErrorsList = recipeYamlV1.IgnoreErrors
+
+	// Load and merge ignore errors list from external file if DUCC_IGNORE_ERRORS_FILE is set
+	externalIgnoreList, errIgnore := loadIgnoreErrorsList()
+	if errIgnore == nil && len(externalIgnoreList) > 0 {
+		recipe.IgnoreErrorsList = append(recipe.IgnoreErrorsList, externalIgnoreList...)
+		l.Log().WithFields(log.Fields{
+			"total_count": len(recipe.IgnoreErrorsList),
+		}).Info("Merged ignore errors lists from recipe and external file")
+	}
+
 	var wg sync.WaitGroup
 	defer func() {
 		go func() {


### PR DESCRIPTION
The pull-through registry cache at CERN has a known issue where tags deleted upstream still show up in the cache but cannot be pulled. In the recent changes the error reporting of the conversion is more correct, but this means that known failures are turning all conversion jobs red. As a workaround I add this feature to let us ignore failures for known bad images