### PR TITLE
fix: add macOS compatibility for byte-order macros and unit tests

### DIFF
--- a/cvmfs/acl.cc
+++ b/cvmfs/acl.cc
@@ -13,6 +13,12 @@
 
 #include "util/posix.h"
 
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#endif
+
 using namespace std;  // NOLINT
 
 #ifdef COMPARE_TO_LIBACL

--- a/test/unittests/t_acl.cc
+++ b/test/unittests/t_acl.cc
@@ -76,7 +76,7 @@ TEST_F(T_Acl, t1) {
   const char *textual =
     "user::rwx\n"
     "group::r-x\n"
-    "group:root:rwx\n"
+    "group:0:rwx\n"
     "group:1000:rwx\n"
     "mask::rwx\n"
     "other::---\n";
@@ -182,7 +182,7 @@ TEST_F(T_Acl, t8) {
 }
 
 TEST_F(T_Acl, t9) {
-  const char *textual = "u:2:rx,g:root:rx,g:2:rwx,u::-,g::-,o::-,m::-";
+  const char *textual = "u:2:rx,g:0:rx,g:2:rwx,u::-,g::-,o::-,m::-";
   unsigned char acl_binary_expected[] = {
     0x02, 0x00, 0x00, 0x00,
     0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,

--- a/test/unittests/t_catalog.cc
+++ b/test/unittests/t_catalog.cc
@@ -509,7 +509,6 @@ TEST_F(T_Catalog, AttachSchema09) {
 
   WritableCatalog *catalog = WritableCatalog::AttachFreely("", temp_path,
                                                            shash::Any());
-  unlink(temp_path.c_str());
   EXPECT_TRUE(catalog != NULL);
 
   int nchunk = 0;
@@ -533,6 +532,8 @@ TEST_F(T_Catalog, AttachSchema09) {
   shash::Any previous_revision = shash::MkFromHexPtr(
       shash::HexPtr("5fd3e9d6dd96ffb23228fa0be88356b7347e815e"));
   EXPECT_EQ(catalog->GetPreviousRevision(), previous_revision);
+  delete catalog;
+  unlink(temp_path.c_str());
 }
 
 TEST_F(T_Catalog, AttachSchema10) {


### PR DESCRIPTION
- Add `htole16`/`htole32` compatibility shims for macOS in `acl.cc`
- Use numeric GID instead of group name "root" in ACL tests (macOS has no "root" group)
- Defer `unlink` in `AttachSchema09` test to avoid SQLite journaling failures on macOS