### PR TITLE
Batched S3 deletes

### DIFF
--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -24,6 +24,101 @@ using namespace std;  // NOLINT
 
 namespace s3fanout {
 
+/**
+ * Escapes characters that are not allowed in XML text content.
+ * Only & and < need escaping; >, ', " are safe in text nodes.
+ */
+static string XmlEscape(const string &input) {
+  string result;
+  result.reserve(input.size());
+  for (unsigned i = 0; i < input.size(); ++i) {
+    switch (input[i]) {
+      case '&': result += "&amp;"; break;
+      case '<': result += "&lt;"; break;
+      default:  result += input[i]; break;
+    }
+  }
+  return result;
+}
+
+
+/**
+ * Builds an S3 DeleteObjects XML request body for multi-object delete.
+ * Uses Quiet mode so the response only contains errors, not successes.
+ */
+string ComposeDeleteMultiXml(const vector<string> &keys) {
+  string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+               "<Delete><Quiet>true</Quiet>\n";
+  // ~70 bytes per <Object><Key>...</Key></Object> entry
+  xml.reserve(xml.size() + keys.size() * 70 + 10);
+  for (unsigned i = 0; i < keys.size(); ++i) {
+    xml += "<Object><Key>" + XmlEscape(keys[i]) + "</Key></Object>\n";
+  }
+  xml += "</Delete>";
+  return xml;
+}
+
+
+/**
+ * Parses the S3 DeleteObjects error response XML.
+ * In Quiet mode, the response only contains <Error> elements for failed keys.
+ * Returns the number of errors found.
+ */
+unsigned ParseDeleteMultiResponse(const string &response,
+                                  vector<string> *error_keys,
+                                  vector<string> *error_codes,
+                                  vector<string> *error_messages) {
+  unsigned num_errors = 0;
+  string::size_type pos = 0;
+
+  while (true) {
+    const string::size_type err_start = response.find("<Error>", pos);
+    if (err_start == string::npos)
+      break;
+    const string::size_type err_end = response.find("</Error>", err_start);
+    if (err_end == string::npos)
+      break;
+
+    const string error_block = response.substr(err_start,
+                                                err_end - err_start);
+    num_errors++;
+
+    // Extract <Key>...</Key>
+    const string::size_type key_start = error_block.find("<Key>");
+    const string::size_type key_end = error_block.find("</Key>");
+    if (key_start != string::npos && key_end != string::npos) {
+      error_keys->push_back(
+          error_block.substr(key_start + 5, key_end - key_start - 5));
+    } else {
+      error_keys->push_back("");
+    }
+
+    // Extract <Code>...</Code>
+    const string::size_type code_start = error_block.find("<Code>");
+    const string::size_type code_end = error_block.find("</Code>");
+    if (code_start != string::npos && code_end != string::npos) {
+      error_codes->push_back(
+          error_block.substr(code_start + 6, code_end - code_start - 6));
+    } else {
+      error_codes->push_back("");
+    }
+
+    // Extract <Message>...</Message>
+    const string::size_type msg_start = error_block.find("<Message>");
+    const string::size_type msg_end = error_block.find("</Message>");
+    if (msg_start != string::npos && msg_end != string::npos) {
+      error_messages->push_back(
+          error_block.substr(msg_start + 9, msg_end - msg_start - 9));
+    } else {
+      error_messages->push_back("");
+    }
+
+    pos = err_end + 8;  // length of "</Error>"
+  }
+
+  return num_errors;
+}
+
 const char *S3FanoutManager::kCacheControlCas = "Cache-Control: max-age=259200";
 const unsigned S3FanoutManager::kDefault429ThrottleMs = 250;
 const unsigned S3FanoutManager::kMax429ThrottleMs = 10000;
@@ -189,11 +284,17 @@ static size_t CallbackCurlData(void *ptr, size_t size, size_t nmemb,
 
 
 /**
- * For the time being, ignore all received information in the HTTP body
+ * Captures the HTTP response body. For kReqDeleteMulti, the response contains
+ * XML error information. For other requests, the body is ignored.
  */
-static size_t CallbackCurlBody(char * /*ptr*/, size_t size, size_t nmemb,
-                               void * /*userdata*/) {
-  return size * nmemb;
+static size_t CallbackCurlBody(char *ptr, size_t size, size_t nmemb,
+                               void *userdata) {
+  const size_t num_bytes = size * nmemb;
+  JobInfo *info = static_cast<JobInfo *>(userdata);
+  if (info != NULL && info->request == JobInfo::kReqDeleteMulti) {
+    info->response_body.append(ptr, num_bytes);
+  }
+  return num_bytes;
 }
 
 
@@ -438,6 +539,7 @@ CURL *S3FanoutManager::AcquireCurlHandle() const {
     assert(retval == CURLE_OK);
     retval = curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, CallbackCurlBody);
     assert(retval == CURLE_OK);
+    // WRITEDATA is set per-request in InitializeRequest
   } else {
     handle = *(pool_handles_idle_->begin());
     pool_handles_idle_->erase(pool_handles_idle_->begin());
@@ -506,6 +608,14 @@ bool S3FanoutManager::MkV2Authz(const JobInfo &info,
   if (config_.x_amz_acl != "") {
     to_sign += "x-amz-acl:" + config_.x_amz_acl + "\n" +  // default ACL
                "/" + config_.bucket + "/" + info.object_key;
+  }
+  // S3 V2 requires subresources to be included in the string to sign.
+  // For kReqDeleteMulti, object_key is intentionally empty: the canonical
+  // resource becomes "/<bucket>/?delete", matching the POST URL.
+  if (info.request == JobInfo::kReqDeleteMulti) {
+    if (config_.x_amz_acl == "")
+      to_sign += "/" + config_.bucket + "/" + info.object_key;
+    to_sign += "?delete";
   }
   LogCvmfs(kLogS3Fanout, kLogDebug, "%s string to sign for: %s",
            request.c_str(), info.object_key.c_str());
@@ -621,8 +731,15 @@ bool S3FanoutManager::MkV4Authz(const JobInfo &info,
                                          : (string("/") + config_.bucket + "/"
                                             + info.object_key);
 
+  // V4 canonical query string: empty for most requests, "delete=" for
+  // multi-object delete (the S3 ?delete parameter has no value)
+  const string canonical_query = (info.request == JobInfo::kReqDeleteMulti)
+                                     ? "delete="
+                                     : "";
+
   const string canonical_request = GetRequestString(info) + "\n"
-                                   + GetUriEncode(uri, false) + "\n" + "\n"
+                                   + GetUriEncode(uri, false) + "\n"
+                                   + canonical_query + "\n"
                                    + canonical_headers + "\n" + signed_headers
                                    + "\n" + payload_hash;
 
@@ -646,6 +763,20 @@ bool S3FanoutManager::MkV4Authz(const JobInfo &info,
                      + ","
                        "Signature="
                      + signature);
+
+  // S3 requires Content-MD5 for multi-object delete
+  if (info.request == JobInfo::kReqDeleteMulti) {
+    shash::Any md5_hash(shash::kMd5);
+    unsigned char *data;
+    const unsigned int nbytes = info.origin->Data(
+        reinterpret_cast<void **>(&data), info.origin->GetSize(), 0);
+    assert(nbytes == info.origin->GetSize());
+    shash::HashMem(data, nbytes, &md5_hash);
+    headers->push_back(
+        "Content-MD5: "
+        + Base64(string(reinterpret_cast<char *>(md5_hash.digest),
+                        md5_hash.GetDigestSize())));
+  }
   return true;
 }
 
@@ -778,9 +909,9 @@ int S3FanoutManager::InitializeDnsSettings(CURL *handle,
 
 bool S3FanoutManager::MkPayloadHash(const JobInfo &info,
                                     string *hex_hash) const {
-  if ((info.request == JobInfo::kReqHeadOnly)
-      || (info.request == JobInfo::kReqHeadPut)
-      || (info.request == JobInfo::kReqDelete)) {
+  if (info.request == JobInfo::kReqHeadOnly
+      || info.request == JobInfo::kReqHeadPut
+      || info.request == JobInfo::kReqDelete) {
     switch (config_.authz_method) {
       case kAuthzAwsV2:
         hex_hash->clear();
@@ -800,7 +931,10 @@ bool S3FanoutManager::MkPayloadHash(const JobInfo &info,
     return true;
   }
 
-  // PUT, there is actually payload
+  // kReqDeleteMulti is a POST with a body (XML payload), same hashing as PUT
+  // falls through intentionally.
+
+  // PUT or POST with payload
   shash::Any payload_hash(shash::kMd5);
 
   unsigned char *data;
@@ -838,6 +972,8 @@ string S3FanoutManager::GetRequestString(const JobInfo &info) const {
       return "PUT";
     case JobInfo::kReqDelete:
       return "DELETE";
+    case JobInfo::kReqDeleteMulti:
+      return "POST";
     default:
       PANIC(NULL);
   }
@@ -857,6 +993,7 @@ string S3FanoutManager::GetContentType(const JobInfo &info) const {
     case JobInfo::kReqPutHtml:
       return "text/html";
     case JobInfo::kReqPutBucket:
+    case JobInfo::kReqDeleteMulti:
       return "text/xml";
     default:
       PANIC(NULL);
@@ -885,9 +1022,9 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
   InitializeDnsSettings(handle, complete_hostname_);
 
   CURLcode retval;
-  if ((info->request == JobInfo::kReqHeadOnly)
-      || (info->request == JobInfo::kReqHeadPut)
-      || (info->request == JobInfo::kReqDelete)) {
+  if (info->request == JobInfo::kReqHeadOnly
+      || info->request == JobInfo::kReqHeadPut
+      || info->request == JobInfo::kReqDelete) {
     retval = curl_easy_setopt(handle, CURLOPT_UPLOAD, 0);
     assert(retval == CURLE_OK);
     retval = curl_easy_setopt(handle, CURLOPT_NOBODY, 1);
@@ -901,6 +1038,18 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
       retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, NULL);
       assert(retval == CURLE_OK);
     }
+  } else if (info->request == JobInfo::kReqDeleteMulti) {
+    // POST request with XML body read from origin buffer
+    retval = curl_easy_setopt(handle, CURLOPT_UPLOAD, 1);
+    assert(retval == CURLE_OK);
+    retval = curl_easy_setopt(handle, CURLOPT_NOBODY, 0);
+    assert(retval == CURLE_OK);
+    retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, "POST");
+    assert(retval == CURLE_OK);
+    retval = curl_easy_setopt(handle, CURLOPT_INFILESIZE_LARGE,
+                              static_cast<curl_off_t>(info->origin->GetSize()));
+    assert(retval == CURLE_OK);
+    info->response_body.clear();
   } else {
     retval = curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, NULL);
     assert(retval == CURLE_OK);
@@ -965,6 +1114,9 @@ Failures S3FanoutManager::InitializeRequest(JobInfo *info, CURL *handle) const {
   retval = curl_easy_setopt(handle, CURLOPT_READDATA,
                             static_cast<void *>(info));
   assert(retval == CURLE_OK);
+  retval = curl_easy_setopt(handle, CURLOPT_WRITEDATA,
+                            static_cast<void *>(info));
+  assert(retval == CURLE_OK);
   retval = curl_easy_setopt(handle, CURLOPT_HTTPHEADER, info->http_headers);
   assert(retval == CURLE_OK);
   if (opt_ipv4_only_) {
@@ -1014,7 +1166,9 @@ void S3FanoutManager::SetUrlOptions(JobInfo *info) const {
     assert(retval == CURLE_OK);
   }
 
-  const string url = MkUrl(info->object_key);
+  string url = MkUrl(info->object_key);
+  if (info->request == JobInfo::kReqDeleteMulti)
+    url += "?delete";
   retval = curl_easy_setopt(curl_handle, CURLOPT_URL, url.c_str());
   assert(retval == CURLE_OK);
 
@@ -1167,11 +1321,14 @@ bool S3FanoutManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
   if (try_again) {
     if (info->request == JobInfo::kReqPutCas
         || info->request == JobInfo::kReqPutDotCvmfs
-        || info->request == JobInfo::kReqPutHtml) {
+        || info->request == JobInfo::kReqPutHtml
+        || info->request == JobInfo::kReqDeleteMulti) {
       LogCvmfs(kLogS3Fanout, kLogDebug, "Trying again to upload %s",
                info->object_key.c_str());
       // Reset origin
       info->origin->Rewind();
+      if (info->request == JobInfo::kReqDeleteMulti)
+        info->response_body.clear();
     }
     Backoff(info);
     info->error_code = kFailOk;

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -104,6 +104,7 @@ struct JobInfo : SingleCopy {
     kReqPutHtml,       // HTML file - display instead of downloading
     kReqPutBucket,     // bucket creation
     kReqDelete,
+    kReqDeleteMulti,   // S3 multi-object delete (POST /?delete)
   };
 
   const std::string object_key;
@@ -133,6 +134,10 @@ struct JobInfo : SingleCopy {
         smalloc(sizeof(char) * CURL_ERROR_SIZE));
   }
   ~JobInfo() { free(errorbuffer); }
+
+  // For kReqDeleteMulti: keys included in the batch, and response body
+  std::vector<std::string> multi_delete_keys;
+  std::string response_body;
 
   // Internal state, don't touch
   CURL *curl_handle;
@@ -341,6 +346,12 @@ class S3FanoutManager : SingleCopy {
 
   std::string dot_cvmfs_cache_control_header;           // Cache-Control: max-age=...
 };  // S3FanoutManager
+
+std::string ComposeDeleteMultiXml(const std::vector<std::string> &keys);
+unsigned ParseDeleteMultiResponse(const std::string &response,
+                                  std::vector<std::string> *error_keys,
+                                  std::vector<std::string> *error_codes,
+                                  std::vector<std::string> *error_messages);
 
 }  // namespace s3fanout
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -9,6 +9,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -17,6 +18,7 @@
 #include "options.h"
 #include "util/exception.h"
 #include "util/logging.h"
+#include "util/mutex.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -51,6 +53,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
     , authz_method_(s3fanout::kAuthzAwsV2)
     , peek_before_put_(true)
     , use_https_(false)
+    , batch_delete_enabled_(true)
     , proxy_("")
     , temporary_path_(spooler_definition.temporary_path)
     , x_amz_acl_("public-read") {
@@ -58,10 +61,16 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
          && spooler_definition.driver_type == SpoolerDefinition::S3);
 
   atomic_init32(&io_errors_);
+  const int mutex_ret = pthread_mutex_init(&delete_batch_mutex_, NULL);
+  assert(mutex_ret == 0);
 
   if (!ParseSpoolerDefinition(spooler_definition)) {
     PANIC(kLogStderr, "Error in parsing the spooler definition");
   }
+
+  // Disable batch delete for Azure (not supported)
+  if (authz_method_ == s3fanout::kAuthzAzure)
+    batch_delete_enabled_ = false;
 
   s3fanout::S3FanoutManager::S3Config s3config;
   s3config.access_key = access_key_;
@@ -99,6 +108,7 @@ S3Uploader::~S3Uploader() {
   // Signal termination to our own worker thread
   s3fanout_mgr_->PushCompletedJob(NULL);
   pthread_join(thread_collect_results_, NULL);
+  pthread_mutex_destroy(&delete_batch_mutex_);
 }
 
 
@@ -205,6 +215,10 @@ bool S3Uploader::ParseSpoolerDefinition(
     x_amz_acl_ = parameter;
   }
 
+  if (options_manager.GetValue("CVMFS_S3_BATCH_DELETE", &parameter)) {
+    batch_delete_enabled_ = options_manager.IsOn(parameter);
+  }
+
   if (options_manager.GetValue("CVMFS_S3_USE_HTTPS", &parameter)) {
     use_https_ = options_manager.IsOn(parameter);
   }
@@ -280,15 +294,50 @@ void *S3Uploader::MainCollectResults(void *data) {
     if (info->error_code != s3fanout::kFailOk) {
       if ((info->request != s3fanout::JobInfo::kReqHeadOnly)
           || (info->error_code != s3fanout::kFailNotFound)) {
-        LogCvmfs(kLogUploadS3, kLogStderr,
-                 "Upload job for '%s' failed. (error code: %d - %s)",
-                 info->object_key.c_str(), info->error_code,
-                 s3fanout::Code2Ascii(info->error_code));
+        if (info->request == s3fanout::JobInfo::kReqDeleteMulti) {
+          LogCvmfs(kLogUploadS3, kLogStderr,
+                   "Batch delete of %lu objects failed. (error code: %d - %s)",
+                   info->multi_delete_keys.size(), info->error_code,
+                   s3fanout::Code2Ascii(info->error_code));
+        } else {
+          LogCvmfs(kLogUploadS3, kLogStderr,
+                   "Upload job for '%s' failed. (error code: %d - %s)",
+                   info->object_key.c_str(), info->error_code,
+                   s3fanout::Code2Ascii(info->error_code));
+        }
         reply_code = 99;
         atomic_inc32(&uploader->io_errors_);
       }
     }
-    if (info->request == s3fanout::JobInfo::kReqDelete) {
+    if (info->request == s3fanout::JobInfo::kReqDeleteMulti) {
+      // Parse response for per-key errors
+      std::set<std::string> failed_keys;
+      if (info->error_code == s3fanout::kFailOk
+          && !info->response_body.empty()) {
+        std::vector<std::string> error_keys, error_codes, error_messages;
+        const unsigned num_errors = s3fanout::ParseDeleteMultiResponse(
+            info->response_body, &error_keys, &error_codes, &error_messages);
+        for (unsigned i = 0; i < num_errors; ++i) {
+          LogCvmfs(kLogUploadS3, kLogStderr,
+                   "S3 multi-delete error for key '%s': %s - %s",
+                   error_keys[i].c_str(), error_codes[i].c_str(),
+                   error_messages[i].c_str());
+          atomic_inc32(&uploader->io_errors_);
+          failed_keys.insert(error_keys[i]);
+        }
+      }
+      // Decrement jobs_in_flight_ once per key in the batch.
+      // Report per-key error code so callers can distinguish failures.
+      const unsigned batch_size = info->multi_delete_keys.size();
+      const int batch_error = (info->error_code != s3fanout::kFailOk) ? 99 : 0;
+      for (unsigned i = 0; i < batch_size; ++i) {
+        const int key_error = batch_error
+            ? batch_error
+            : (failed_keys.count(info->multi_delete_keys[i]) ? 99 : 0);
+        uploader->Respond(NULL, UploaderResults(UploaderResults::kRemove,
+                                                key_error));
+      }
+    } else if (info->request == s3fanout::JobInfo::kReqDelete) {
       uploader->Respond(NULL, UploaderResults());
     } else if (info->request == s3fanout::JobInfo::kReqHeadOnly) {
       if (info->error_code == s3fanout::kFailNotFound)
@@ -454,13 +503,57 @@ s3fanout::JobInfo *S3Uploader::CreateJobInfo(const std::string &path) const {
 
 void S3Uploader::DoRemoveAsync(const std::string &file_to_delete) {
   const std::string mangled_path = repository_alias_ + "/" + file_to_delete;
-  s3fanout::JobInfo *info = CreateJobInfo(mangled_path);
 
-  info->request = s3fanout::JobInfo::kReqDelete;
+  if (!batch_delete_enabled_) {
+    s3fanout::JobInfo *info = CreateJobInfo(mangled_path);
+    info->request = s3fanout::JobInfo::kReqDelete;
+    LogCvmfs(kLogUploadS3, kLogDebug, "Asynchronously removing %s/%s",
+             bucket_.c_str(), info->object_key.c_str());
+    s3fanout_mgr_->PushNewJob(info);
+    return;
+  }
 
-  LogCvmfs(kLogUploadS3, kLogDebug, "Asynchronously removing %s/%s",
-           bucket_.c_str(), info->object_key.c_str());
+  // Batch delete: collect keys and flush when batch is full
+  const MutexLockGuard guard(delete_batch_mutex_);
+  pending_deletes_.push_back(mangled_path);
+  if (pending_deletes_.size() >= kMaxBatchDeleteSize) {
+    FlushDeleteBatch();
+  }
+}
+
+
+void S3Uploader::FlushDeleteBatch() const {
+  // Caller must hold delete_batch_mutex_
+  if (pending_deletes_.empty())
+    return;
+
+  LogCvmfs(kLogUploadS3, kLogDebug,
+           "Flushing batch delete of %lu objects",
+           pending_deletes_.size());
+
+  // Build XML request body
+  const std::string xml = s3fanout::ComposeDeleteMultiXml(pending_deletes_);
+  FileBackedBuffer *buf = FileBackedBuffer::Create(kInMemoryObjectThreshold);
+  buf->Append(xml.data(), xml.length());
+  buf->Commit();
+
+  // The object_key for multi-delete is empty (URL is bucket root + ?delete)
+  s3fanout::JobInfo *info = new s3fanout::JobInfo("", NULL, buf);
+  info->request = s3fanout::JobInfo::kReqDeleteMulti;
+  info->multi_delete_keys.swap(pending_deletes_);
+
+  // Each key was already counted in jobs_in_flight_ by DoRemoveAsync().
+  // MainCollectResults will call Respond() once per key to balance them.
   s3fanout_mgr_->PushNewJob(info);
+}
+
+
+void S3Uploader::WaitForUpload() const {
+  {
+    const MutexLockGuard guard(delete_batch_mutex_);
+    FlushDeleteBatch();
+  }
+  AbstractUploader::WaitForUpload();
 }
 
 

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -67,6 +67,7 @@ class S3Uploader : public AbstractUploader {
                                       const shash::Any &content_hash);
 
   virtual void DoRemoveAsync(const std::string &file_to_delete);
+  virtual void WaitForUpload() const;
   virtual bool Peek(const std::string &path);
   virtual bool Mkdir(const std::string &path);
   virtual bool PlaceBootstrappingShortcut(const shash::Any &object);
@@ -111,9 +112,12 @@ class S3Uploader : public AbstractUploader {
   bool ParseSpoolerDefinition(const SpoolerDefinition &spooler_definition);
   void UploadJobInfo(s3fanout::JobInfo *info);
 
-  s3fanout::JobInfo *CreateJobInfo(const std::string &path) const;
+  static const unsigned kMaxBatchDeleteSize = 1000;
 
-  UniquePtr<s3fanout::S3FanoutManager> s3fanout_mgr_;
+  s3fanout::JobInfo *CreateJobInfo(const std::string &path) const;
+  void FlushDeleteBatch() const;
+
+  mutable UniquePtr<s3fanout::S3FanoutManager> s3fanout_mgr_;
   std::string repository_alias_;
   std::string host_name_port_;
   std::string host_name_;
@@ -129,6 +133,7 @@ class S3Uploader : public AbstractUploader {
   s3fanout::AuthzMethods authz_method_;
   bool peek_before_put_;
   bool use_https_;
+  bool batch_delete_enabled_;
   std::string proxy_;
 
   const std::string temporary_path_;
@@ -136,6 +141,9 @@ class S3Uploader : public AbstractUploader {
   pthread_t thread_collect_results_;
 
   std::string x_amz_acl_;
+
+  mutable pthread_mutex_t delete_batch_mutex_;
+  mutable std::vector<std::string> pending_deletes_;
 };  // S3Uploader
 
 }  // namespace upload

--- a/test/unittests/t_s3fanout.cc
+++ b/test/unittests/t_s3fanout.cc
@@ -51,3 +51,125 @@ TEST(T_S3Fanout, DetectThrottleIndicator) {
                                                      &info);
   EXPECT_EQ(12U, info.throttle_ms);
 }
+
+
+TEST(T_S3Fanout, ComposeDeleteMultiXmlSingleKey) {
+  vector<string> keys;
+  keys.push_back("data/ab/file1");
+  const string xml = s3fanout::ComposeDeleteMultiXml(keys);
+
+  EXPECT_NE(string::npos, xml.find("<?xml version=\"1.0\""));
+  EXPECT_NE(string::npos, xml.find("<Delete>"));
+  EXPECT_NE(string::npos, xml.find("<Quiet>true</Quiet>"));
+  EXPECT_NE(string::npos, xml.find("<Object><Key>data/ab/file1</Key></Object>"));
+  EXPECT_NE(string::npos, xml.find("</Delete>"));
+}
+
+
+TEST(T_S3Fanout, ComposeDeleteMultiXmlMultipleKeys) {
+  vector<string> keys;
+  keys.push_back("data/ab/file1");
+  keys.push_back("data/cd/file2");
+  keys.push_back("data/ef/file3");
+  const string xml = s3fanout::ComposeDeleteMultiXml(keys);
+
+  EXPECT_NE(string::npos, xml.find("<Object><Key>data/ab/file1</Key></Object>"));
+  EXPECT_NE(string::npos, xml.find("<Object><Key>data/cd/file2</Key></Object>"));
+  EXPECT_NE(string::npos, xml.find("<Object><Key>data/ef/file3</Key></Object>"));
+}
+
+
+TEST(T_S3Fanout, ComposeDeleteMultiXmlEmptyKeys) {
+  vector<string> keys;
+  const string xml = s3fanout::ComposeDeleteMultiXml(keys);
+
+  EXPECT_NE(string::npos, xml.find("<Delete>"));
+  EXPECT_NE(string::npos, xml.find("<Quiet>true</Quiet>"));
+  EXPECT_NE(string::npos, xml.find("</Delete>"));
+  EXPECT_EQ(string::npos, xml.find("<Object>"));
+}
+
+
+TEST(T_S3Fanout, ComposeDeleteMultiXmlEscaping) {
+  vector<string> keys;
+  keys.push_back("repo&name/data/ab/file1");
+  keys.push_back("repo<name/data/cd/file2");
+  keys.push_back("normal/data/ef/file3");
+  const string xml = s3fanout::ComposeDeleteMultiXml(keys);
+
+  EXPECT_NE(string::npos,
+            xml.find("<Key>repo&amp;name/data/ab/file1</Key>"));
+  EXPECT_NE(string::npos,
+            xml.find("<Key>repo&lt;name/data/cd/file2</Key>"));
+  EXPECT_NE(string::npos,
+            xml.find("<Key>normal/data/ef/file3</Key>"));
+  // Raw & and < must not appear unescaped in key values
+  EXPECT_EQ(string::npos, xml.find("repo&name"));
+  EXPECT_EQ(string::npos, xml.find("repo<name"));
+}
+
+
+TEST(T_S3Fanout, ParseDeleteMultiResponseEmpty) {
+  vector<string> error_keys, error_codes, error_messages;
+  const unsigned n = s3fanout::ParseDeleteMultiResponse(
+      "", &error_keys, &error_codes, &error_messages);
+
+  EXPECT_EQ(0U, n);
+  EXPECT_TRUE(error_keys.empty());
+}
+
+
+TEST(T_S3Fanout, ParseDeleteMultiResponseSingleError) {
+  const string response =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<DeleteResult>"
+      "<Error>"
+      "<Key>data/ab/file1</Key>"
+      "<Code>AccessDenied</Code>"
+      "<Message>Access Denied</Message>"
+      "</Error>"
+      "</DeleteResult>";
+
+  vector<string> error_keys, error_codes, error_messages;
+  const unsigned n = s3fanout::ParseDeleteMultiResponse(
+      response, &error_keys, &error_codes, &error_messages);
+
+  EXPECT_EQ(1U, n);
+  ASSERT_EQ(1U, error_keys.size());
+  EXPECT_EQ("data/ab/file1", error_keys[0]);
+  EXPECT_EQ("AccessDenied", error_codes[0]);
+  EXPECT_EQ("Access Denied", error_messages[0]);
+}
+
+
+TEST(T_S3Fanout, ParseDeleteMultiResponseMultipleErrors) {
+  const string response =
+      "<DeleteResult>"
+      "<Error><Key>key1</Key><Code>NoSuchKey</Code>"
+      "<Message>Not found</Message></Error>"
+      "<Error><Key>key2</Key><Code>InternalError</Code>"
+      "<Message>Internal</Message></Error>"
+      "</DeleteResult>";
+
+  vector<string> error_keys, error_codes, error_messages;
+  const unsigned n = s3fanout::ParseDeleteMultiResponse(
+      response, &error_keys, &error_codes, &error_messages);
+
+  EXPECT_EQ(2U, n);
+  ASSERT_EQ(2U, error_keys.size());
+  EXPECT_EQ("key1", error_keys[0]);
+  EXPECT_EQ("NoSuchKey", error_codes[0]);
+  EXPECT_EQ("key2", error_keys[1]);
+  EXPECT_EQ("InternalError", error_codes[1]);
+}
+
+
+TEST(T_S3Fanout, ParseDeleteMultiResponseMalformed) {
+  const string response = "<DeleteResult><Error><Key>k1</Key>";
+
+  vector<string> error_keys, error_codes, error_messages;
+  const unsigned n = s3fanout::ParseDeleteMultiResponse(
+      response, &error_keys, &error_codes, &error_messages);
+
+  EXPECT_EQ(0U, n);
+}

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -354,6 +354,26 @@ class T_Uploaders : public FileSandbox {
         response.reason = "Not Found";
       }
 
+    } else if (req.method == "POST"
+               && req.path.find("?delete") != std::string::npos) {
+      // Multi-object delete: parse <Key>...</Key> elements from XML body
+      std::string::size_type pos = 0;
+      while (true) {
+        std::string::size_type ks = req.body.find("<Key>", pos);
+        if (ks == std::string::npos)
+          break;
+        ks += 5;  // length of "<Key>"
+        std::string::size_type ke = req.body.find("</Key>", ks);
+        if (ke == std::string::npos)
+          break;
+        std::string key = req.body.substr(ks, ke - ks);
+        std::string path = T_Uploaders::dest_dir + "/" + key;
+        if (FileExists(path)) {
+          int retval = remove(path.c_str());
+          assert(retval == 0);
+        }
+        pos = ke + 6;  // length of "</Key>"
+      }
     } else if (req.method == "DELETE") {
       std::string path = T_Uploaders::dest_dir + "/" + req_file;
       if (FileExists(path)) {


### PR DESCRIPTION
This is the first step of https://github.com/cvmfs/cvmfs/issues/4118.

The basic idea is that it's more efficient to do a bulk delete operation via POST with up to 1000 objects instead of doing one DELETE request per object. See [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) for more details.