### PR TITLE
ingest: Add fastdelete option to unlink nested catalogs

### DIFF
--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -24,6 +24,7 @@ cvmfs_server_ingest() {
   local gid=""
   local keep_ownership=false
   local create_catalog=false
+  local fast_delete=false
 
   local force_native=0
   local force_external=0
@@ -65,6 +66,9 @@ cvmfs_server_ingest() {
       ;;
       -k | --keep-ownership )
         keep_ownership=true
+      ;;
+      -f | --fast-delete )
+        fast_delete=true
       ;;
     esac
     shift
@@ -327,6 +331,10 @@ cvmfs_server_ingest() {
 
   if [ "x$CVMFS_ENABLE_MTIME_NS" = "xtrue" ]; then
     ingest_command="$ingest_command -j"
+  fi
+
+  if [ "$fast_delete" = true ]; then
+    ingest_command="$ingest_command -f"
   fi
 
   if [ "x$CVMFS_PRINT_STATISTICS" = "xtrue" ]; then

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -69,7 +69,14 @@ cvmfs_server_ingest() {
       ;;
       -f | --fast-delete )
         fast_delete=true
-      ;;
+        if [ "x$to_delete" = "x" ]
+        then
+          to_delete="$(echo $2 | tr -s /)"
+        else
+          to_delete="$to_delete///$(echo $2 | tr -s /)"
+          multiple_delete=1
+        fi
+        ;;
     esac
     shift
   done

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -177,7 +177,8 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
 
   publish::SyncUnion *sync = new publish::SyncUnionTarball(
       &mediator, params.dir_rdonly, params.tar_file, params.base_directory,
-      params.uid, params.gid, params.to_delete, create_catalog, "///");
+      params.uid, params.gid, params.to_delete, create_catalog,
+      params.fast_delete, "///");
 
   if (!sync->Initialize()) {
     LogCvmfs(kLogCvmfs, kLogStderr,

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -59,6 +59,9 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   if (args.find('j') != args.end()) {
     params.enable_mtime_ns = true;
   }
+  if (args.find('f') != args.end()) {
+    params.fast_delete = true;
+  }
   shash::Algorithms hash_algorithm = shash::kSha1;
   if (args.find('e') != args.end()) {
     hash_algorithm = shash::ParseHashAlgorithm(*args.find('e')->second);

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -49,6 +49,7 @@ class Ingest : public Command {
         'G',
         "gid of new owner of the ingested data (-1 for keep tarball owner)"));
     r.push_back(Parameter::Switch('j', "enable nanosecond timestamps"));
+    r.push_back(Parameter::Switch('f', "fast delete for nested catalogs"));
 
     return r;
   }

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -37,6 +37,7 @@ struct SyncParameters {
       , stop_for_catalog_tweaks(false)
       , include_xattrs(false)
       , enable_mtime_ns(false)
+      , fast_delete(false)
       , external_data(false)
       , direct_io(false)
       , voms_authz(false)
@@ -90,6 +91,7 @@ struct SyncParameters {
   bool stop_for_catalog_tweaks;
   bool include_xattrs;
   bool enable_mtime_ns;
+  bool fast_delete;
   bool external_data;
   bool direct_io;
   bool voms_authz;

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -229,11 +229,11 @@ void SyncMediator::Touch(SharedPtr<SyncItem> entry) {
 /**
  * Remove an entry from the repository. Directories will be recursively removed.
  */
-void SyncMediator::Remove(SharedPtr<SyncItem> entry) {
+void SyncMediator::Remove(SharedPtr<SyncItem> entry, bool fast_delete) {
   EnsureAllowed(entry);
 
   if (entry->WasDirectory()) {
-    RemoveDirectoryRecursively(entry);
+    RemoveDirectoryRecursively(entry, fast_delete);
     return;
   }
 
@@ -623,7 +623,8 @@ void SyncMediator::LeaveAddedDirectoryCallback(const std::string &parent_dir,
 }
 
 
-void SyncMediator::RemoveDirectoryRecursively(SharedPtr<SyncItem> entry) {
+void SyncMediator::RemoveDirectoryRecursively(SharedPtr<SyncItem> entry,
+                                              bool fast_delete) {
   // Delete a directory AFTER it was emptied here,
   // because it would start up another recursion
 
@@ -640,7 +641,7 @@ void SyncMediator::RemoveDirectoryRecursively(SharedPtr<SyncItem> entry) {
   traversal.Recurse(entry->GetRdOnlyPath());
 
   // The given directory was emptied recursively and can now itself be deleted
-  RemoveDirectory(entry);
+  RemoveDirectory(entry, fast_delete);
 }
 
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -625,7 +625,56 @@ void SyncMediator::LeaveAddedDirectoryCallback(const std::string &parent_dir,
 
 void SyncMediator::RemoveDirectoryRecursively(SharedPtr<SyncItem> entry,
                                               bool fast_delete) {
-  // Delete a directory AFTER it was emptied here,
+  const std::string directory_path = entry->GetRelativePath();
+
+  // Fast delete: skip filesystem traversal for nested catalog directories.
+  // Instead of recursively walking the filesystem and removing each entry,
+  // we just remove the nested catalog reference from the parent catalog
+  // (with merge=false so entries are not copied to the parent) and then
+  // remove the mountpoint directory entry.
+  if (fast_delete && catalog_manager_->IsTransitionPoint(directory_path)) {
+    // Get the nested catalog's counters before removal so we can update
+    // publish statistics with the total number of removed entries
+    std::string subcatalog_path;
+    shash::Any hash;
+    PathString ps_path;
+    ps_path.Assign(directory_path.data(), directory_path.length());
+    const catalog::Counters counters =
+        catalog_manager_->LookupCounters(ps_path, &subcatalog_path, &hash);
+    {
+      perf::Xadd(counters_->n_files_removed,
+          static_cast<int64_t>(counters.self.regular_files
+                               + counters.subtree.regular_files));
+      perf::Xadd(counters_->n_directories_removed,
+          static_cast<int64_t>(counters.self.directories
+                               + counters.subtree.directories));
+      perf::Xadd(counters_->n_symlinks_removed,
+          static_cast<int64_t>(counters.self.symlinks
+                               + counters.subtree.symlinks));
+      perf::Xadd(counters_->sz_removed_bytes,
+          static_cast<int64_t>(counters.self.file_size
+                               + counters.subtree.file_size));
+    }
+
+    // Remove nested catalog (merge=false: just remove the reference and
+    // adjust parent subtree counters, don't copy entries into parent)
+    const std::string notice = "Nested catalog at " + entry->GetUnionPath();
+    reporter_->OnRemove(notice, catalog::DirectoryEntry());
+    if (!params_->dry_run) {
+      catalog_manager_->RemoveNestedCatalog(directory_path, false);
+    }
+
+    // Remove the mountpoint directory entry from the parent catalog
+    reporter_->OnRemove(entry->GetUnionPath(), catalog::DirectoryEntry());
+    if (!params_->dry_run) {
+      catalog_manager_->RemoveDirectory(directory_path);
+    }
+    perf::Inc(counters_->n_directories_removed);
+
+    return;
+  }
+
+  // Normal path: delete a directory AFTER it was emptied here,
   // because it would start up another recursion
 
   const bool recurse = false;
@@ -641,7 +690,7 @@ void SyncMediator::RemoveDirectoryRecursively(SharedPtr<SyncItem> entry,
   traversal.Recurse(entry->GetRdOnlyPath());
 
   // The given directory was emptied recursively and can now itself be deleted
-  RemoveDirectory(entry, fast_delete);
+  RemoveDirectory(entry);
 }
 
 

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -115,7 +115,7 @@ class AbstractSyncMediator {
 
   virtual void Add(SharedPtr<SyncItem> entry) = 0;
   virtual void Touch(SharedPtr<SyncItem> entry) = 0;
-  virtual void Remove(SharedPtr<SyncItem> entry) = 0;
+  virtual void Remove(SharedPtr<SyncItem> entry, bool fast_delete = false) = 0;
   virtual void Replace(SharedPtr<SyncItem> entry) = 0;
   virtual void Clone(const std::string from, const std::string to) = 0;
 
@@ -158,7 +158,7 @@ class SyncMediator : public virtual AbstractSyncMediator {
 
   void Add(SharedPtr<SyncItem> entry);
   void Touch(SharedPtr<SyncItem> entry);
-  void Remove(SharedPtr<SyncItem> entry);
+  void Remove(SharedPtr<SyncItem> entry, bool fast_delete = false);
   void Replace(SharedPtr<SyncItem> entry);
   void Clone(const std::string from, const std::string to);
 
@@ -201,7 +201,8 @@ class SyncMediator : public virtual AbstractSyncMediator {
                                const std::string &link_name);
   void TouchDirectoryCallback(const std::string &parent_dir,
                               const std::string &dir_name);
-  void RemoveDirectoryRecursively(SharedPtr<SyncItem> entry);
+  void RemoveDirectoryRecursively(SharedPtr<SyncItem> entry,
+                                  bool fast_delete = false);
   void RemoveFileCallback(const std::string &parent_dir,
                           const std::string &file_name);
   void RemoveSymlinkCallback(const std::string &parent_dir,

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -107,7 +107,6 @@ bool SyncUnionTarball::Initialize() {
  * `first_iteration` boolean flag.
  */
 void SyncUnionTarball::Traverse() {
-  read_archive_signal_->Wakeup();
   assert(this->IsInitialized());
 
   /*
@@ -134,6 +133,9 @@ void SyncUnionTarball::Traverse() {
   // we are simply deleting entity from  the repo
   if (NULL == src)
     return;
+
+  // Prime the signal so the first Wait() in the loop below can proceed.
+  read_archive_signal_->Wakeup();
 
   struct archive_entry *entry = archive_entry_new();
   while (true) {

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -38,6 +38,7 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
                                    const gid_t gid,
                                    const std::string &to_delete,
                                    const bool create_catalog_on_root,
+                                   const bool fast_delete,
                                    const std::string &path_delimiter)
     : SyncUnion(mediator, rdonly_path, "", "")
     , src(NULL)
@@ -47,6 +48,7 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
     , gid_(gid)
     , to_delete_(to_delete)
     , create_catalog_on_root_(create_catalog_on_root)
+    , fast_delete_(fast_delete)
     , path_delimiter_(path_delimiter)
     , read_archive_signal_(new Signal) { }
 
@@ -125,7 +127,7 @@ void SyncUnionTarball::Traverse() {
         parent_path = "";
       const SharedPtr<SyncItem> sync_entry = CreateSyncItem(parent_path,
                                                             filename, kItemDir);
-      mediator_->Remove(sync_entry);
+      mediator_->Remove(sync_entry, fast_delete_);
     }
   }
 

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -34,6 +34,7 @@ class SyncUnionTarball : public SyncUnion {
                    const gid_t gid,
                    const std::string &to_delete,
                    const bool create_catalog_on_root,
+                   const bool fast_delete = false,
                    const std::string &path_delimiter = ":");
 
   ~SyncUnionTarball();
@@ -69,6 +70,7 @@ class SyncUnionTarball : public SyncUnion {
   const gid_t gid_;
   const std::string to_delete_;  ///< entity to delete before to extract the tar
   const bool create_catalog_on_root_;
+  const bool fast_delete_;
   const std::string path_delimiter_;  ///< delimiter used to split paths
   std::set<std::string>
       know_directories_;  ///< directory that we know already exist

--- a/ducc/lib/garbage_collection.go
+++ b/ducc/lib/garbage_collection.go
@@ -23,7 +23,7 @@ func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, C
 	repoName, _ := cvmfs.GetRepoAndSubdir(CVMFSRepo)
 
 	// we send pathsPerBatchCommand folders to deletion at a time
-	commandPrefix := []string{"cvmfs_server", "ingest", "--fast-delete"}
+	commandPrefix := []string{"cvmfs_server", "ingest"}
 	commands := make([][]string, 0)
 	command := commandPrefix
 	for i, path := range pathsToDelete {
@@ -33,7 +33,7 @@ func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, C
 			commands = append(commands, command)
 			command = commandPrefix
 		}
-		command = append(command, "--delete", path)
+		command = append(command, "--fast-delete", path)
 	}
 	command = append(command, repoName)
 	commands = append(commands, command)

--- a/ducc/lib/garbage_collection.go
+++ b/ducc/lib/garbage_collection.go
@@ -23,7 +23,7 @@ func ConstructDeleteCommands(pathsToDelete []string, pathsPerBatchCommand int, C
 	repoName, _ := cvmfs.GetRepoAndSubdir(CVMFSRepo)
 
 	// we send pathsPerBatchCommand folders to deletion at a time
-	commandPrefix := []string{"cvmfs_server", "ingest"}
+	commandPrefix := []string{"cvmfs_server", "ingest", "--fast-delete"}
 	commands := make([][]string, 0)
 	command := commandPrefix
 	for i, path := range pathsToDelete {

--- a/ducc/lib/garbage_collection_test.go
+++ b/ducc/lib/garbage_collection_test.go
@@ -11,22 +11,22 @@ func TestConstructDeleteCommands(t *testing.T) {
 	if len(commands) != 1 {
 		t.Errorf("Delete command missing")
 	}
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete --delete a/b test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
 
 	paths = []string{"a/b", "c/d"}
 	commands, _ = ConstructDeleteCommands(paths, 10, "test.cern.ch")
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b --delete c/d test.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete --delete a/b --delete c/d test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
 
 	paths = []string{"a/b", "c/d"}
 	commands, _ = ConstructDeleteCommands(paths, 1, "test.cern.ch")
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete a/b test.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete --delete a/b test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
-	if strings.Join(commands[1], " ") != "cvmfs_server ingest --delete c/d test.cern.ch" {
+	if strings.Join(commands[1], " ") != "cvmfs_server ingest --fast-delete --delete c/d test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
 }

--- a/ducc/lib/garbage_collection_test.go
+++ b/ducc/lib/garbage_collection_test.go
@@ -11,22 +11,22 @@ func TestConstructDeleteCommands(t *testing.T) {
 	if len(commands) != 1 {
 		t.Errorf("Delete command missing")
 	}
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete --delete a/b test.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete a/b test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
 
 	paths = []string{"a/b", "c/d"}
 	commands, _ = ConstructDeleteCommands(paths, 10, "test.cern.ch")
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete --delete a/b --delete c/d test.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete a/b --fast-delete c/d test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
 
 	paths = []string{"a/b", "c/d"}
 	commands, _ = ConstructDeleteCommands(paths, 1, "test.cern.ch")
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete --delete a/b test.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete a/b test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
-	if strings.Join(commands[1], " ") != "cvmfs_server ingest --fast-delete --delete c/d test.cern.ch" {
+	if strings.Join(commands[1], " ") != "cvmfs_server ingest --fast-delete c/d test.cern.ch" {
 		t.Errorf("Wrong delete command")
 	}
 }
@@ -37,7 +37,7 @@ func TestConstructDeleteCommandsSubdir(t *testing.T) {
 	if len(commands) != 1 {
 		t.Errorf("Delete command missing")
 	}
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete compat/.layers/aa --delete compat/.layers/bb repo.cern.ch" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete compat/.layers/aa --fast-delete compat/.layers/bb repo.cern.ch" {
 		t.Errorf("Wrong delete command for subdir repo")
 	}
 }
@@ -48,7 +48,7 @@ func TestConstructDeleteCommandsSubdirMockRepoFormat(t *testing.T) {
 	if len(commands) != 1 {
 		t.Errorf("Delete command missing")
 	}
-	if strings.Join(commands[0], " ") != "cvmfs_server ingest --delete target_subdir/.layers/aa --delete target_subdir/.layers/bb ../../tmp/mockrepo" {
+	if strings.Join(commands[0], " ") != "cvmfs_server ingest --fast-delete target_subdir/.layers/aa --fast-delete target_subdir/.layers/bb ../../tmp/mockrepo" {
 		t.Errorf("Wrong delete command for mock subdir repo")
 	}
 }

--- a/test/src/715-tarball_fast_delete/main
+++ b/test/src/715-tarball_fast_delete/main
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+cvmfs_test_name="Fast-delete a nested catalog directory via ingest"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+produce_tarball() {
+  local tarball_name=$1
+
+  mkdir tarball_foo
+  mkdir -p tarball_foo/a/b/c
+  mkdir -p tarball_foo/d/e/f
+
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/1.txt
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/2.txt
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/3.txt
+  touch tarball_foo/a/.cvmfscatalog
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/1.txt
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/2.txt
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/3.txt
+  touch tarball_foo/a/b/.cvmfscatalog
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/c/1.txt
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/c/2.txt
+  dd bs=1024 count=2 2>/dev/null </dev/urandom >tarball_foo/a/b/c/3.txt
+
+  dd bs=1024 count=5 2>/dev/null </dev/urandom >tarball_foo/d/e/f/foo.txt
+
+  echo "*** Generating a tarball in $tarball_name"
+  tar -cvf $tarball_name tarball_foo/
+
+  rm -rf tarball_foo
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local scratch_dir=$(pwd)
+  local tarfile=$scratch_dir/tarball.tar
+  local dir=tar_dir
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+
+  # ============================================================================
+
+  echo "*** generating a tarball $tarfile"
+  produce_tarball $tarfile
+
+  echo "*** ingesting the tarball in the directory $dir"
+  cvmfs_server ingest --base_dir $dir --tar_file $tarfile $CVMFS_TEST_REPO || return $?
+
+  echo "*** check catalog and data integrity"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  echo "*** check that the nested catalogs were created"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a$" || return 1
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a/b$" || return 2
+
+  echo "*** check that the files exist"
+  for d in a a/b a/b/c; do
+    for f in 1 2 3; do
+      file=$repo_dir/$dir/tarball_foo/$d/$f.txt
+      if [ ! -f $file ] || [ $(wc -c <$file) -ne 2048 ]; then
+        echo "*** Error not found file: $file"
+        return 3
+      fi
+    done
+  done
+
+  # ============================================================================
+
+  echo "*** fast-delete the nested catalog directory tarball_foo/a"
+  cvmfs_server ingest --fast-delete -d $dir/tarball_foo/a $CVMFS_TEST_REPO || return 10
+
+  echo "*** check catalog and data integrity after fast-delete"
+  check_repository $CVMFS_TEST_REPO -i || return 11
+
+  echo "*** check that the nested catalog at tarball_foo/a is gone"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a$" && return 12
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a/b$" && return 13
+
+  echo "*** check that the directory tarball_foo/a is gone from the filesystem"
+  if [ -d $repo_dir/$dir/tarball_foo/a ]; then
+    echo "*** Error: directory $repo_dir/$dir/tarball_foo/a still exists"
+    return 14
+  fi
+
+  echo "*** check that other content is still intact"
+  file=$repo_dir/$dir/tarball_foo/d/e/f/foo.txt
+  file_size=$(wc -c <$file)
+  if [ ! -f $file ] || [ $file_size -ne 5120 ]; then
+    echo "*** Error not found file of size 5120: $file"
+    return 15
+  fi
+
+  # ============================================================================
+
+  echo "*** re-ingest the tarball to restore content, then fast-delete again"
+  cvmfs_server ingest --base_dir $dir --tar_file $tarfile $CVMFS_TEST_REPO || return 20
+
+  echo "*** check catalog and data integrity after re-ingest"
+  check_repository $CVMFS_TEST_REPO -i || return 21
+
+  echo "*** verify nested catalogs are back"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a$" || return 22
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a/b$" || return 23
+
+  echo "*** fast-delete and ingest into a new dir in the same command"
+  local new_dir=tar_dir_new
+  cvmfs_server ingest --base_dir $new_dir --tar_file $tarfile --fast-delete -d $dir/tarball_foo/a $CVMFS_TEST_REPO || return 30
+
+  echo "*** check catalog and data integrity after combined ingest+fast-delete"
+  check_repository $CVMFS_TEST_REPO -i || return 31
+
+  echo "*** verify old nested catalog is gone"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$dir/tarball_foo/a$" && return 32
+
+  echo "*** verify new content was ingested"
+  if [ ! -d $repo_dir/$new_dir/tarball_foo ]; then
+    echo "*** Error: new tarball content not found"
+    return 33
+  fi
+
+  echo "*** verify new nested catalogs were created"
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$new_dir/tarball_foo/a$" || return 34
+  cvmfs_server list-catalogs -x $CVMFS_TEST_REPO | grep "/$new_dir/tarball_foo/a/b$" || return 35
+
+  return 0
+}
+

--- a/test/src/715-tarball_fast_delete/main
+++ b/test/src/715-tarball_fast_delete/main
@@ -71,7 +71,7 @@ cvmfs_run_test() {
   # ============================================================================
 
   echo "*** fast-delete the nested catalog directory tarball_foo/a"
-  cvmfs_server ingest --fast-delete -d $dir/tarball_foo/a $CVMFS_TEST_REPO || return 10
+  cvmfs_server ingest --fast-delete $dir/tarball_foo/a $CVMFS_TEST_REPO || return 10
 
   echo "*** check catalog and data integrity after fast-delete"
   check_repository $CVMFS_TEST_REPO -i || return 11
@@ -109,7 +109,7 @@ cvmfs_run_test() {
 
   echo "*** fast-delete and ingest into a new dir in the same command"
   local new_dir=tar_dir_new
-  cvmfs_server ingest --base_dir $new_dir --tar_file $tarfile --fast-delete -d $dir/tarball_foo/a $CVMFS_TEST_REPO || return 30
+  cvmfs_server ingest --base_dir $new_dir --tar_file $tarfile --fast-delete $dir/tarball_foo/a $CVMFS_TEST_REPO || return 30
 
   echo "*** check catalog and data integrity after combined ingest+fast-delete"
   check_repository $CVMFS_TEST_REPO -i || return 31

--- a/test/unittests/mock/m_sync_mediator.h
+++ b/test/unittests/mock/m_sync_mediator.h
@@ -19,7 +19,9 @@ namespace publish {
 
 class MockSyncMediator : public AbstractSyncMediator {
  public:
-  MockSyncMediator() : n_register(0), n_reg(0), n_lnk(0), n_dir(0) { }
+  MockSyncMediator()
+      : n_register(0), n_reg(0), n_lnk(0), n_dir(0),
+        n_remove(0), last_fast_delete(false) { }
   virtual ~MockSyncMediator() { }
 
   virtual void RegisterUnionEngine(SyncUnion * /* engine */) { n_register++; }
@@ -35,7 +37,11 @@ class MockSyncMediator : public AbstractSyncMediator {
     }
   }
   virtual void Touch(SharedPtr<SyncItem> /* entry */) { }
-  virtual void Remove(SharedPtr<SyncItem> /* entry */) { }
+  virtual void Remove(SharedPtr<SyncItem> /* entry */,
+                      bool fast_delete = false) {
+    n_remove++;
+    last_fast_delete = fast_delete;
+  }
   virtual void Replace(SharedPtr<SyncItem> /* entry */) { }
   virtual void Clone(const std::string /* from */, const std::string /* to */) {
   }
@@ -59,6 +65,8 @@ class MockSyncMediator : public AbstractSyncMediator {
   int n_reg;
   int n_lnk;
   int n_dir;
+  int n_remove;
+  bool last_fast_delete;
 };  // class MockSyncMediator
 
 }  // namespace publish

--- a/test/unittests/t_sync_union_tarball.cc
+++ b/test/unittests/t_sync_union_tarball.cc
@@ -85,4 +85,54 @@ TEST_F(T_SyncUnionTarball, Complex) {
   EXPECT_EQ(3, m_sync_mediator_->n_dir);
 }
 
+TEST_F(T_SyncUnionTarball, FastDeletePassedToRemove) {
+  // Create a SyncUnionTarball with fast_delete=true and a to_delete path
+  // but no actual tarball (empty string means delete-only mode)
+  publish::SyncUnionTarball sync_union(m_sync_mediator_.weak_ref(), "",
+                                       "", "", -1u, -1u,
+                                       "some/nested/dir",
+                                       false /* create_catalog_on_root */,
+                                       true  /* fast_delete */);
+
+  EXPECT_TRUE(sync_union.Initialize());
+
+  sync_union.Traverse();
+  // Verify Remove was called with fast_delete=true
+  EXPECT_EQ(1, m_sync_mediator_->n_remove);
+  EXPECT_TRUE(m_sync_mediator_->last_fast_delete);
+}
+
+TEST_F(T_SyncUnionTarball, NoFastDeleteByDefault) {
+  // Create a SyncUnionTarball with default fast_delete (false) and a
+  // to_delete path
+  publish::SyncUnionTarball sync_union(m_sync_mediator_.weak_ref(), "",
+                                       "", "", -1u, -1u,
+                                       "some/dir",
+                                       false /* create_catalog_on_root */);
+
+  EXPECT_TRUE(sync_union.Initialize());
+
+  sync_union.Traverse();
+  // Verify Remove was called with fast_delete=false (default)
+  EXPECT_EQ(1, m_sync_mediator_->n_remove);
+  EXPECT_FALSE(m_sync_mediator_->last_fast_delete);
+}
+
+TEST_F(T_SyncUnionTarball, FastDeleteMultiplePaths) {
+  // Test that fast_delete is passed for each path when deleting multiple
+  // paths (using the path delimiter ":")
+  publish::SyncUnionTarball sync_union(m_sync_mediator_.weak_ref(), "",
+                                       "", "", -1u, -1u,
+                                       "dir/a:dir/b",
+                                       false /* create_catalog_on_root */,
+                                       true  /* fast_delete */);
+
+  EXPECT_TRUE(sync_union.Initialize());
+
+  sync_union.Traverse();
+  // Verify Remove was called twice, both with fast_delete=true
+  EXPECT_EQ(2, m_sync_mediator_->n_remove);
+  EXPECT_TRUE(m_sync_mediator_->last_fast_delete);
+}
+
 }  // namespace


### PR DESCRIPTION
When removing a directory that is a nested catalog transition point,
`cvmfs_server ingest --fastdelete` drops the nested catalog reference directly
instead of walking the filesystem entry by entry, significantly speeding
up deletion of large nested catalogs.

Fixes #4051 