### PR TITLE
Allow cvmfs_server resign to be done without .crt if .cvmfswhitelist exists

### DIFF
--- a/cvmfs/server/cvmfs_server_resign.sh
+++ b/cvmfs/server/cvmfs_server_resign.sh
@@ -100,7 +100,7 @@ cvmfs_server_resign() {
 
         local wl="$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)/.cvmfswhitelist"
         local crt=/etc/cvmfs/keys/$name.crt
-        if [ ! -f "$wl" ] || [ -f $crt ]; then
+        if [ ! -f "$wl" ] || [ -f "$crt" ]; then
           # create from scratch
           wl=""
         fi

--- a/cvmfs/server/cvmfs_server_resign.sh
+++ b/cvmfs/server/cvmfs_server_resign.sh
@@ -98,8 +98,14 @@ cvmfs_server_resign() {
 
       else
 
+        local wl="$(get_upstream_config $CVMFS_UPSTREAM_STORAGE)/.cvmfswhitelist"
+        local crt=/etc/cvmfs/keys/$name.crt
+        if [ ! -f "$wl" ] || [ -f $crt ]; then
+          # create from scratch
+          wl=""
+        fi
         create_whitelist $name $CVMFS_USER \
-            ${CVMFS_UPSTREAM_STORAGE} ${CVMFS_SPOOL_DIR}/tmp "$expire_days"
+            ${CVMFS_UPSTREAM_STORAGE} ${CVMFS_SPOOL_DIR}/tmp "$expire_days" $wl
 
       fi
     else

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1335,7 +1335,7 @@ Supported Commands:
                   Re-publishes the given tag as the new latest revision.
                   All snapshots between trunk and the target tag become
                   inaccessible.  Without a tag name, trunk-previous is used.
-  resign          [ -w path to existing whitelist ]
+  resign          [ -w path to existing whitelist (avoids need for config) ]
                   [ -d days until expiration (default 30) ]
                   [ -f don't ask again ]
                   <fully qualified name>


### PR DESCRIPTION
It was reported on Mattermost that a `cvmfs_server resign` requires a repository's `.crt` file to be present, which was surprising.  This surprise can be avoided by actually resigning an existing `.cvmfswhitelist` file rather than recreating it.

However, this does not avoid the need for the configuration of the repo to be present; only the `-w` option does that.  There was no hint about that in the usage info though, so this PR also adds that.