### PR TITLE
Ignore bulk hashes

### DIFF
--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -1369,8 +1369,9 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
                + StringifyInt(shash::kSuffixMicroCatalog) + " END "
                + "AS chunk_type, " + flags2hash + "," + flags2compression
                + "FROM catalog WHERE (hash IS NOT NULL) AND "
-                 "(flags & "
-               + StringifyInt(SqlDirent::kFlagFileExternal) + " = 0)";
+                 " (flags & "
+               + StringifyInt(SqlDirent::kFlagFileExternal |
+                              SqlDirent::kFlagFileChunk) + " = 0)";
   if (database.schema_version() >= 2.4 - CatalogDatabase::kSchemaEpsilon) {
     sql += " UNION "
            "SELECT DISTINCT chunks.hash, "

--- a/cvmfs/catalog_sql.cc
+++ b/cvmfs/catalog_sql.cc
@@ -18,6 +18,11 @@ using namespace std;  // NOLINT
 
 namespace catalog {
 
+// Emergency fallback: if CVMFS_NO_IGNORE_LEGACY_BULKHASHES is set, revert to the
+// old behavior of including bulk hashes for chunked files.
+bool g_ignore_legacy_bulk_hashes =
+    (getenv("CVMFS_NO_IGNORE_LEGACY_BULKHASHES") == NULL);
+
 /**
  * NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
  * Always remember to update the legacy catalog migration classes to produce a
@@ -1357,6 +1362,10 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
                                        SqlDirent::kFlagPosCompression)
                                    + ") " + "AS compression_algorithm ";
 
+  if (!g_ignore_legacy_bulk_hashes)
+    LogCvmfs(kLogCatalog, kLogDebug, "CVMFS_NO_IGNORE_LEGACY_BULKHASHES is set, "
+		     "legacy bulk hashes won't be ignored in catalog operations");
+
   // TODO(reneme): this depends on shash::kSuffix* being a char!
   //               it should be more generic or replaced entirely
   // TODO(reneme): this is practically the same as SqlListContentHashes and
@@ -1371,7 +1380,9 @@ SqlAllChunks::SqlAllChunks(const CatalogDatabase &database) {
                + "FROM catalog WHERE (hash IS NOT NULL) AND "
                  " (flags & "
                + StringifyInt(SqlDirent::kFlagFileExternal |
-                              SqlDirent::kFlagFileChunk) + " = 0)";
+                              (g_ignore_legacy_bulk_hashes
+                                   ? SqlDirent::kFlagFileChunk
+                                   : 0)) + " = 0)";
   if (database.schema_version() >= 2.4 - CatalogDatabase::kSchemaEpsilon) {
     sql += " UNION "
            "SELECT DISTINCT chunks.hash, "

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -35,6 +35,10 @@ class XattrList;
 
 namespace catalog {
 
+// Set to false via CVMFS_NO_IGNORE_LEGACY_BULKHASHES env var to restore the
+// pre-2.14 behavior of including bulk hashes for chunked files.
+extern bool g_ignore_legacy_bulk_hashes;
+
 class Catalog;
 
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -366,7 +366,8 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
     // and only run requests once per hash
     const bool entry_needs_check = !entries[i].checksum().IsNull() &&
                                    !entries[i].IsExternalFile() &&
-                                   !entries[i].IsChunkedFile() &&
+                                   !(catalog::g_ignore_legacy_bulk_hashes &&
+                                     entries[i].IsChunkedFile()) &&
                                    // fallback cli option can force the entry to
                                    // be checked
                                    (no_duplicates_map_

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -364,8 +364,9 @@ bool CommandCheck::Find(const catalog::Catalog *catalog,
   for (unsigned i = 0; i < entries.size(); ++i) {
     // for performance reasons, keep track of files already checked
     // and only run requests once per hash
-    const bool entry_needs_check = !entries[i].checksum().IsNull()
-                                   && !entries[i].IsExternalFile() &&
+    const bool entry_needs_check = !entries[i].checksum().IsNull() &&
+                                   !entries[i].IsExternalFile() &&
+                                   !entries[i].IsChunkedFile() &&
                                    // fallback cli option can force the entry to
                                    // be checked
                                    (no_duplicates_map_

--- a/test/unittests/t_catalog.cc
+++ b/test/unittests/t_catalog.cc
@@ -359,7 +359,11 @@ TEST_F(T_Catalog, Chunks) {
     EXPECT_EQ(zlib::kZlibDefault, compression_alg);
   }
   EXPECT_TRUE(catalog->AllChunksEnd());
-  EXPECT_EQ(4u, counter);  // number of files with content + empty hash
+  // Expect the number of chunks in files plus the number of hashes in
+  // files with no chunks.
+  // In particular the file '/foo' has both a hash and a chunk but the
+  // hash is ignored because bulk hashes are no longer used.
+  EXPECT_EQ(3u, counter);
 }
 
 TEST_F(T_Catalog, Statistics) {


### PR DESCRIPTION
This makes catalog access for snapshot (pull), gc, and check ignore any bulk hashes when there are chunks available.  This cleans out all the old legacy bulk hashes from the early days of CVMFS without needing to run `cvmfs_server eliminate-bulk-hashes`.

The repository most affected is cms.cern.ch which has about 2T of these old bulk hashes.  I first tried using `cvmfs_server eliminate-bulk-hashes` on a copy of the repository and for some reason it was not successful in removing the old hashes.

The caveat with the approach in this PR is that if someone tries to replicate from a repository that has been cleaned out with this while using an older version of cvmfs-server, they will run into missing files.  There are no longer any existing clients that still use the old bulk hashes.  That was already the case when the `eliminate-bulk-hashes` command was added almost 6 years ago in #2545.