### PR TITLE
Fix linkage of s3benchmark.cc

### DIFF
--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries (s3benchmark
                        ${ZLIB_LIBRARIES}
                        ${OPENSSL_LIBRARIES}
                        ${VJSON_LIBRARIES}
+                       LibArchive::LibArchive
                        pthread
                        dl
 )


### PR DESCRIPTION
Fixes #4125 