### PR TITLE
golang: Prepare for removal of vendor dir, remove --mod=vendor

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -104,6 +104,12 @@ create_cvmfs_source_tarball() {
                       ${source_directory}/ducc               \
                       $tar_name
   rm -r $tar_name/test/benchmarks
+
+  # Vendor Go dependencies so offline builds (e.g. koji) work without network access
+  for godir in ducc gateway snapshotter; do
+    (cd ${tmpd}/${tar_name}/${godir} && go mod vendor)
+  done
+
   tar czf $destination_path $tar_name || true
   local retval=$?
   cd ..

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -140,7 +140,7 @@ if can_build_gateway; then
   echo "*** Running gateway unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway)"
   pushd ${SCRIPT_LOCATION}/../gateway > /dev/null
   CVMFS_TEST_GATEWAY_OUTPUT=$(mktemp /tmp/cvmfs-gateway-unittests-XXXXX)
-  go test -v -mod=vendor ./... > $CVMFS_TEST_GATEWAY_OUTPUT 2>&1
+  go test -v  ./... > $CVMFS_TEST_GATEWAY_OUTPUT 2>&1
   RETVAL=$(( RETVAL | $? ))
   cat $CVMFS_TEST_GATEWAY_OUTPUT | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.gateway
   rm -f $CVMFS_TEST_GATEWAY_OUTPUT
@@ -153,7 +153,7 @@ if can_build_ducc; then
   echo "*** Running container tools unit tests (with XML output ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc)"
   pushd ${SCRIPT_LOCATION}/../ducc > /dev/null
   CVMFS_TEST_DUCC_OUTPUT=$(mktemp /tmp/cvmfs-ducc-unittests-XXXXX)
-  go test -v -mod=vendor ./... > $CVMFS_TEST_DUCC_OUTPUT 2>&1
+  go test -v ./... > $CVMFS_TEST_DUCC_OUTPUT 2>&1
   RETVAL=$(( RETVAL | $? ))
   cat $CVMFS_TEST_DUCC_OUTPUT | go-junit-report > ${CVMFS_UNITTESTS_RESULT_LOCATION}.ducc
   rm -f $CVMFS_TEST_DUCC_OUTPUT

--- a/ducc/CMakeLists.txt
+++ b/ducc/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB_RECURSE CVMFS_CONTAINER_TOOLS_GO_SOURCES LIST_DIRECTORIES false ./*.go
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc
-  COMMAND ${GO_COMPILER} build -mod=vendor -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc -ldflags='-X github.com/cvmfs/ducc/cmd.Version=${CernVM-FS_VERSION_STRING}'
+  COMMAND ${GO_COMPILER} build -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_ducc -ldflags='-X github.com/cvmfs/ducc/cmd.Version=${CernVM-FS_VERSION_STRING}'
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CVMFS_CONTAINER_TOOLS_GO_SOURCES}
   COMMENT "Build ducc using the Go Compiler"

--- a/ducc/Makefile
+++ b/ducc/Makefile
@@ -1,4 +1,4 @@
-cvmfs_ducc: cmd/*.go constants/*.go cvmfs/*.go docker-api/*.go exec/*.go lib/*.go log/*.go singularity/*.go temp/*.go notification/*.go vendor/
+cvmfs_ducc: cmd/*.go constants/*.go cvmfs/*.go docker-api/*.go exec/*.go lib/*.go log/*.go singularity/*.go temp/*.go notification/*.go
 	go build -o cvmfs_ducc
 	sudo setcap "cap_dac_override=ep cap_dac_read_search=ep cap_fowner=ep cap_chown=ep cap_sys_admin=ep cap_mknod=ep" cvmfs_ducc
 

--- a/gateway/CMakeLists.txt
+++ b/gateway/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB_RECURSE CVMFS_GATEWAY_GO_SOURCES LIST_DIRECTORIES false ./*.go)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_gateway
-  COMMAND ${GO_COMPILER} build -mod=vendor -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_gateway -ldflags='-X main.Version=${CernVM-FS_VERSION_STRING}'
+  COMMAND ${GO_COMPILER} build -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_gateway -ldflags='-X main.Version=${CernVM-FS_VERSION_STRING}'
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CVMFS_GATEWAY_GO_SOURCES}
   COMMENT "Build gateway using the Go Compiler"

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -6,16 +6,11 @@ The CernVM-FS repository gateway exposes a service API which is consumed by the 
 Building
 --------
 
-Go version 1.11.5 or newer is required to build `cvmfs-gateway`. The packages
-uses standard Go modules for dependency management. To build the package, run:
+The Gateway uses standard Go modules for dependency management. To build the package, run:
 ```bash
 $ go build
 ```
 
-Vendored copies of all dependencies are provided in this repository, for use in CI environments where it is not desirable to depend on external package sources. To build using the vendored dependencies, run:
-```bash
-$ go build -mod=vendor
-```
 
 Running the testsuite
 ---------------------

--- a/snapshotter/CMakeLists.txt
+++ b/snapshotter/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB_RECURSE CVMFS_SNAPSHOTTER_GO_SOURCES LIST_DIRECTORIES false ./*.go)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_snapshotter
-  COMMAND ${GO_COMPILER} build -mod=vendor -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_snapshotter -ldflags='-X main.Version=${CernVM-FS_VERSION_STRING}'
+  COMMAND ${GO_COMPILER} build -o ${CMAKE_CURRENT_BINARY_DIR}/cvmfs_snapshotter -ldflags='-X main.Version=${CernVM-FS_VERSION_STRING}'
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CVMFS_SNAPSHOTTER_GO_SOURCES}
   COMMENT "Build containerd cvmfs_snapshotter using the Go Compiler"

--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries (s3benchmark
                        ${ZLIB_LIBRARIES}
                        ${OPENSSL_LIBRARIES}
                        ${VJSON_LIBRARIES}
-                       LibArchive::LibArchive
                        pthread
                        dl
 )


### PR DESCRIPTION
Newer ( > 1.14) golang versions have a [good default](https://go.dev/ref/mod#build-commands) that makes explicit `--mod=vendor` unnecessary.