### PR TITLE
Small improvements for Fedora 43 build

### DIFF
--- a/ci/build_install_builddeps.sh
+++ b/ci/build_install_builddeps.sh
@@ -171,6 +171,13 @@ install_deps_deb() {
 
 install_deps_rhel() {
   [ -f "$RPM_SPEC" ] || die "RPM spec file not found at $RPM_SPEC"
+  if ! check_available rpmbuild; then
+    if [[ "$PKG_MGR" = "dnf" ]]; then
+      $SUDO dnf -y install rpm-build
+    else
+      $SUDO yum -y install rpm-build
+    fi
+  fi
   if [[ "$PKG_MGR" = "dnf" ]]; then
     $SUDO dnf -y install dnf-plugins-core || true
     if check_available dnf; then

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -36,16 +36,16 @@ get_package_type() {
   # Build the cvmfs service container if the build container says so
   [ -f /cvmfs-package-type ]  && cat /cvmfs-package-type && return 0
 
-  which dpkg > /dev/null 2>&1 && echo "deb" && return 0
-  which rpm  > /dev/null 2>&1 && echo "rpm" && return 0
+  command -v dpkg > /dev/null 2>&1 && echo "deb" && return 0
+  command -v rpm  > /dev/null 2>&1 && echo "rpm" && return 0
   [ x"$(uname)" = x"Darwin" ] && echo "pkg" && return 0
   return 1
 }
 
 get_default_compiler_arch() {
   local compiler=""
-  which gcc   > /dev/null 2>&1 && compiler="gcc"
-  which clang > /dev/null 2>&1 && compiler="clang"
+  command -v gcc   > /dev/null 2>&1 && compiler="gcc"
+  command -v clang > /dev/null 2>&1 && compiler="clang"
   [ ! -z $compiler ] && $compiler -dumpmachine | grep -ohe '^[^-]\+'
 }
 
@@ -247,10 +247,10 @@ can_build_ducc() {
   if [ $arch != "amd64" ]; then
     return 1
   fi
-  which go > /dev/null 2>&1 && which go-junit-report > /dev/null 2>&1
+  command -v go > /dev/null 2>&1 && command -v go-junit-report > /dev/null 2>&1
 }
 
 # The gateway services require a Go compiler
 can_build_gateway() {
-  which go > /dev/null 2>&1 && which go-junit-report > /dev/null 2>&1
+  command -v go > /dev/null 2>&1 && command -v go-junit-report > /dev/null 2>&1
 }

--- a/cvmfs/shrinkwrap/scripts/spec_builder.py
+++ b/cvmfs/shrinkwrap/scripts/spec_builder.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #
 # This file is part of the CernVM File System.
 #

--- a/ducc/webhook/registry_webhook.py
+++ b/ducc/webhook/registry_webhook.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from flask import Flask
 from flask import request
 


### PR DESCRIPTION
See #4136 . Some small improvements noticed during a build. There were more warnings in the reproducer of Andriy though, will have to revisit.

* make sure rpm-build is installed by ci script
* prefer command -v over which (not present in a fedora:43 container and not being installed)
* explicit python3