### PR TITLE
macos: CMake workarounds for some build issues

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -39,7 +39,6 @@ jobs:
           mkdir -p build
           export USE_MACFUSE_KEXT=OFF
           export CVMFS_TEST_USE_MACFUSE_KEXT=OFF
-          export CVMFS_EXTERNALS_EXCLUDE="sqlite3;zlib"
           export CPATH=$CPATH:/usr/local/include
           ./ci/build_package.sh ${GITHUB_WORKSPACE} ${GITHUB_WORKSPACE}/build cvmfs
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,16 @@ endif ()
 #
 # include file with user-defined options
 #
+
+# workaround for an issue with the libfuse3 target
+if (MACOS)
+  set(BUILD_MANPAGES_DEFAULT OFF)
+  set(BUILTIN_EXTERNALS_EXCLUDE_DEFAULT "sqlite3;zlib")
+else()
+  set(BUILD_MANPAGES_DEFAULT ON)
+  set(BUILTIN_EXTERNALS_EXCLUDE_DEFAULT "")
+endif()
+
 include (cvmfs_options)
 
 #
@@ -596,7 +606,9 @@ install (
 )
 
 # Man pages
-add_subdirectory(doc/manpages)
+if (BUILD_MANPAGES)
+  add_subdirectory(doc/manpages)
+endif()
 
 # Doxygen
 if (BUILD_DOCUMENTATION)

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -23,7 +23,8 @@ option (BUILD_UNITTESTS_DEBUG   "Build the CernVM-FS unit test set with verbose 
 option (BUILD_UBENCHMARKS       "Build the CernVM-FS micro benchmarks"                             OFF)
 option (BUILD_QC_TESTS          "Build the QuickCheck property random tests"                       OFF)
 option (BUILD_STRESS_TESTS      "Build the stress tests"                                           OFF)
-option (BUILD_DOCUMENTATION     "Build the CerVM-FS documentation using Doxygen"                   OFF)
+option (BUILD_DOCUMENTATION     "Build the CernVM-FS documentation using Doxygen"                   OFF)
+option (BUILD_MANPAGES          "Build the CernVM-FS manpages"                                      ${BUILD_MANPAGES_DEFAULT})
 option (BUILD_COVERAGE          "Compile to collect code coverage reports"                         OFF)
 option (BUILD_LIBFUSE2          "Build the libraries for libfuse2 support"                         OFF)
 option (BUILD_GATEWAY           "Build cvmfs_gateway, requires go compiler"                        OFF)
@@ -59,7 +60,7 @@ option (USE_EXTERNAL_GOOGLETEST "Use external (non-vendored) googletest installa
 # List of external libraries to build (overrides default list in bootstrap.sh)
 set (BUILTIN_EXTERNALS_LIST "" CACHE STRING "Semicolon-separated list of external libraries to build (overrides default list). Eg =libcurl;libcrypto;pacparser")
 # List of external libraries to exclude from building
-set (BUILTIN_EXTERNALS_EXCLUDE "" CACHE STRING "Semicolon-separated list of external libraries to exclude from building")
+set (BUILTIN_EXTERNALS_EXCLUDE ${BUILTIN_EXTERNALS_EXCLUDE_DEFAULT} CACHE STRING "Semicolon-separated list of external libraries to exclude from building")
 
 
 option (ENABLE_ASAN             "Enable the Address Sanitizer"                                     OFF)


### PR DESCRIPTION
* Use zlib and sqlite3 from the system by default instead of only in CI. This is mostly for convenience
* Set manpage generation off by default on MacOS. I was investigating FSKit which is still only fuse2 for now. The targets should be properly selected in that PR at one point, after which this can be removed again.