### PR TITLE
Reapply the fix of linkage of s3benchmark.cc

### DIFF
--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries (s3benchmark
                        ${ZLIB_LIBRARIES}
                        ${OPENSSL_LIBRARIES}
                        ${VJSON_LIBRARIES}
+                       LibArchive::LibArchive
                        pthread
                        dl
 )


### PR DESCRIPTION
Commit 9b0f21ab4f88 reverted the fix.

(cherry picked from commit 79e375ae4e3e8e400d49d307693a01de4b8787b9)

Fixes: 9b0f21ab4f88 ("golang: Prepare for removal of vendor dir, remove --mod=vendor (#4137)")