### PR TITLE
cvmfs_config: get its own location correctly

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Common configuration tasks for CernVM-FS
 
-SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+SCRIPT_LOCATION=$(dirname "$(command -v "$0")")
 INSTALL_BASE=$(echo "$SCRIPT_LOCATION" | sed -e 's/^\(.*\)\/bin$/\1/')
 # workaround for fedora 42
 INSTALL_BASE=$(echo "$INSTALL_BASE" | sed -e 's/^\(.*\)\/sbin$/\1/')


### PR DESCRIPTION
"Try to cd into the path I'm invoked with (if any), and regardless of success, print current directory" is not an adequate way to deduce script location. It is guaranteed to work only if invoked with absolute path, or if CWD in an actual script location.

On Fedora 43, execution goes as follows, when invoked as
- `sudo cvmfs_config chksetup` (used in test/src/001-chksetup)
- `bash cvmfs_config chksetup`
- `sudo bash cvmfs_config chksetup`
- `sudo bash -x cvmfs_config chksetup`

But not if invoked as
- `cvmfs_config chksetup`
- `/usr/bin/cvmfs_config chksetup`
- `bash -c 'cvmfs_config chksetup'`

```
+++ dirname cvmfs_config
++ cd .
++ pwd
+ SCRIPT_LOCATION=/usr/local/src/cvmfs/test ++ echo /usr/local/src/cvmfs/test
++ sed -e 's/^\(.*\)\/bin$/\1/'
+ INSTALL_BASE=/usr/local/src/cvmfs/test ++ '[' x/usr/local/src/cvmfs/test = x/usr ']'
++ echo /usr/local/src/cvmfs/test/sbin
+ SBIN_BASE=/usr/local/src/cvmfs/test/sbin
```

---8<---

I tried to change `test/src/001-chksetup` in a way to provoke the same error in the actions runner, for demonstration and solution testing purposes, but so far I failed at provoking it. I can confirm that this patch solves the issue in my Fedora 43 container where I run tests.