### PR TITLE
Prefetch files from bundle when trigger is opened.

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -233,6 +233,7 @@ if (BUILD_CVMFS)
   set (CVMFS_FUSE_SOURCES
        ${CVMFS_COMMON_CLIENT_SOURCES}
        auto_umount.cc
+       bundle_mgr.cc
        compat.cc
        cvmfs.cc
        fuse_evict.cc

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -1,0 +1,166 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "bundle_mgr.h"
+
+#include <pthread.h>
+
+#include <cassert>
+
+#include "catalog_mgr_client.h"
+#include "fetch.h"
+#include "mountpoint.h"
+#include "options.h"
+#include "shortstring.h"
+#include "util/posix.h"
+
+BundleMgr::BundleMgr(MountPoint *mp, const PathString &path)
+    : mount_point_(mp), path_(path) {
+  fname_ = GetFileName(path_);
+  parent_path_ = GetParentPath(path_);
+  // There is a naming convention regarding the name of the file with the
+  // contents of the bundle
+  bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle."
+                                 + fname_.ToString());
+
+  bfm_ = new BundleFileMgr(bundle_file_path_);
+  pipe_bm_[0] = pipe_bm_[1] = -1;
+  SpawnFetcher();
+}
+
+void BundleMgr::Fetch() {
+  if (not is_valid_) {
+    LogCvmfs(kLogBundleMgr,
+             kLogDebug,
+             "BundleMgr is not in a valid state. Can't fetch!");
+    return;
+  }
+
+  while (auto file = bfm_->GetNext()) {
+    // TODO(christge): Make sure this TrySend is actually needed
+    while (not TrySendPath(back_channel_, file)) {
+    }
+  }
+}
+
+void BundleMgr::JoinFetcher() {
+  Command cmd = Command::kTerminate;
+  WritePipe(back_channel_, &cmd, sizeof(Command));
+  pthread_detach(*fetcher_thread_);
+  ClosePipe(pipe_bm_);
+  delete fetcher_thread_;
+}
+
+void BundleMgr::SpawnFetcher() {
+  MakePipe(pipe_bm_);
+
+  fetcher_thread_ = new pthread_t;
+  const int res = pthread_create(
+      fetcher_thread_, nullptr, MainBundleMgrFetcher, this);
+  if (res != 0) {
+    LogCvmfs(kLogBundleMgr, kLogDebug, "Thread creation failed!");
+    is_valid_ = false;
+    return;
+  }
+  ReadPipe(pipe_bm_[0], &back_channel_, sizeof(int));
+
+  // Make the write operation to the return pipe non blocking
+  // According to the man (7) page of write, when attempting to write
+  // n<=PIPE_BUF data on a non blocking pipe, it will either write all of them
+  // or errno will be set to EAGAIN. PIPE_BUF is at least 512bytes on and
+  // linux 4096bytes.
+  const int flags = fcntl(back_channel_, F_GETFL);
+  fcntl(back_channel_, F_SETFL, flags | O_NONBLOCK);
+}
+
+void BundleMgr::FetchPath(const PathString &path) {
+  catalog::DirectoryEntry dirent;
+  const bool found = mount_point_->catalog_mgr()->LookupPath(
+      path, catalog::kLookupDefault, &dirent);
+  cvmfs::Fetcher *this_fetcher = dirent.IsExternalFile()
+                                     ? mount_point_->external_fetcher()
+                                     : mount_point_->fetcher();
+  if (not(found and this_fetcher)) {
+    // The path should be resolved to a valid dirent and a fetcher should be
+    // available
+    return;
+  }
+
+  CacheManager::Label label;
+  label.path = path.ToString();
+  label.size = dirent.size();
+  label.zip_algorithm = dirent.compression_algorithm();
+  if (mount_point_->catalog_mgr()->volatile_flag())
+    label.flags |= CacheManager::kLabelVolatile;
+  if (dirent.IsExternalFile())
+    label.flags |= CacheManager::kLabelExternal;
+  this_fetcher->Fetch(CacheManager::LabeledObject(dirent.checksum(), label));
+}
+
+void *BundleMgr::MainBundleMgrFetcher(void *data) {
+  pthread_setname_np(pthread_self(), "bm_fetcher");
+  BundleMgr *mgr = static_cast<BundleMgr *>(data);
+  const int wfd = mgr->pipe_bm_[1];
+  int back_channel[2];
+  MakePipe(back_channel);
+
+  WritePipe(wfd, &back_channel[1], sizeof(int));
+
+  const int rfd = back_channel[0];
+
+  Command cmd;
+  while (read(rfd, &cmd, sizeof(Command)) == sizeof(Command)) {
+    bool terminate = false;
+    switch (cmd) {
+      case Command::kFetch:
+        {
+          auto path = mgr->ReceivePath(rfd);
+          std::string cvmfs_mount_dir;
+          if (not mgr->mount_point_->file_system()->options_mgr()->GetValue(
+                  "CVMFS_MOUNT_DIR", &cvmfs_mount_dir)) {
+            LogCvmfs(kLogBundleMgr,
+                     kLogDebug | kLogSyslogErr,
+                     "CVMFS_MOUNT_DIR missing");
+            terminate = true;
+          } else {
+            auto full_path = cvmfs_mount_dir + "/" + path.ToString();
+            mgr->FetchPath(PathString(full_path));
+          }
+        }
+        break;
+      case Command::kTerminate:
+      default:
+        terminate = true;
+        break;
+    }
+    if (terminate) {
+      break;
+    }
+  }
+
+  ClosePipe(back_channel);
+  pthread_exit(nullptr);
+}
+
+PathString BundleMgr::ReceivePath(int fd) const {
+  const std::string buffer = BlockingReceive(fd);
+  assert(buffer.size() > 0 && "A path can't be empty");
+  return PathString(buffer);
+}
+
+bool BundleMgr::TrySendPath(int fd, const PathString &path) const {
+  Command cmd = Command::kFetch;
+  if ((write(fd, &cmd, sizeof(Command))) != sizeof(Command)) {
+    if (not(errno == EAGAIN || errno == EWOULDBLOCK)) {
+      LogCvmfs(kLogBundleMgr,
+               kLogDebug,
+               "write() on back channel failed unexpectedly");
+    }
+    return false;
+  } else {
+    BlockingSend(fd, path);
+  }
+  return true;
+}
+

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -1,0 +1,123 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_BUNDLE_MGR_H_
+#define CVMFS_BUNDLE_MGR_H_
+
+#include <cassert>
+#include <type_traits>
+
+#include "duplex_testing.h"
+#include "file_bundle.h"
+#include "mountpoint.h"
+#include "shortstring.h"
+#include "util/single_copy.h"
+
+class MockFetcher;
+
+class BundleMgr : SingleCopy {
+  friend class T_BundleMgr;
+  FRIEND_TEST(T_BundleMgr, ExchangeCT);
+  FRIEND_TEST(T_BundleMgr, ExchangePathString);
+
+ public:
+  BundleMgr(MountPoint *mp, const PathString &path);
+  virtual ~BundleMgr() {
+    JoinFetcher();
+    delete bfm_;
+  }
+  void Fetch();
+  explicit operator bool() const { return is_valid_; }
+
+ private:
+  static void *MainBundleMgrFetcher(void *data);
+  void SpawnFetcher();
+  void JoinFetcher();
+  PathString ReceivePath(int fd) const;
+  bool TrySendPath(int fd, const PathString &path) const;
+
+  void FetchPath(const PathString &path);
+
+  // CT stands for contiguous type
+  template<typename CT,
+           typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
+  void BlockingSend(int fd, const CT &obj, size_t size = sizeof(CT)) const {
+    using T = std::remove_cv_t<CT>;
+    static_assert(
+        std::is_trivially_copyable_v<T>,
+        "Can't directly send non trivially copyable types over a pipe");
+    static_assert(sizeof(T) == sizeof(CT), "CT illformed");
+    static_assert(
+        sizeof(T) <= PIPE_BUF,
+        "Type too big to be guaranteed atomic transmission over a pipe");
+
+    const T *ptr = reinterpret_cast<const T *>(&obj);
+    while ((::write(fd, ptr, size)) != static_cast<ssize_t>(size)) {
+      // Percist until succesfful write
+    }
+  }
+
+  void BlockingSend(int fd, const PathString &path) const {
+    const size_t size = path.GetLength();
+    BlockingSend(fd, size);
+    while ((::write(fd, path.GetChars(), size * sizeof(char)))
+           != static_cast<ssize_t>(size * sizeof(char))) {
+      // Percist until succesfful write
+    }
+  }
+
+  void BlockingSend(int fd, const std::string &string) const {
+    const size_t size = string.size();
+    BlockingSend(fd, size);
+    while ((::write(fd, string.data(), size * sizeof(char)))
+           != static_cast<ssize_t>(size * sizeof(char))) {
+      // Percist until succesfful write
+    }
+  }
+
+  template<typename CT,
+           typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
+  CT BlockingReceive(int fd) const {
+    using T = std::remove_cv_t<CT>;
+    static_assert(
+        sizeof(T) <= PIPE_BUF,
+        "Type too big to be guaranteed atomic transmission over a pipe");
+    CT item;
+    ::read(fd, static_cast<void *>(&item), sizeof(CT));
+    return item;
+  }
+
+  std::string BlockingReceive(int fd) const {
+    const size_t size = BlockingReceive<size_t>(fd);
+    assert(size * sizeof(char) < PIPE_BUF);
+    std::string result(size, '\t');
+    ::read(fd, static_cast<void *>(result.data()), size * sizeof(char));
+    return result;
+  }
+
+  MountPoint *mount_point_;
+  PathString path_;
+  NameString fname_;
+  PathString parent_path_;
+
+  // The file that contains the dependences
+  PathString bundle_file_path_;
+  BundleFileMgr *bfm_;
+
+  pthread_t *fetcher_thread_;
+  int back_channel_;
+
+  enum class Command {
+    kTerminate,
+    kFetch
+  };
+
+  /**
+   * Used to send RPCs to the BundleMgr by the fetcher threads
+   */
+  int pipe_bm_[2];
+  bool is_valid_ = true;
+};
+#endif  // CVMFS_BUNDLE_MGR_H_
+

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -104,6 +104,11 @@ class CacheManager : SingleCopy {
     bool IsExternal() const { return flags & kLabelExternal; }
     bool IsCertificate() const { return flags & kLabelCertificate; }
 
+    bool operator==(const Label &other) const {
+      return flags == other.flags and size == other.size
+             and zip_algorithm == other.zip_algorithm
+             and range_offset == other.range_offset and path == other.path;
+    }
     /**
      * The description for the quota manager
      */
@@ -139,6 +144,10 @@ class CacheManager : SingleCopy {
   struct LabeledObject {
     explicit LabeledObject(const shash::Any &id) : id(id), label() { }
     LabeledObject(const shash::Any &id, const Label &l) : id(id), label(l) { }
+
+    bool operator==(const LabeledObject &other) const {
+      return id == other.id && label == other.label;
+    }
 
     shash::Any id;
     Label label;
@@ -252,3 +261,4 @@ class CacheManager : SingleCopy {
 };  // class CacheManager
 
 #endif  // CVMFS_CACHE_H_
+

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -253,8 +253,8 @@ class AbstractCatalogManager : public SingleCopy {
   LoadReturn ChangeRoot(const shash::Any &root_hash);
   void DetachNested();
 
-  bool LookupPath(const PathString &path, const LookupOptions options,
-                  DirectoryEntry *entry);
+  virtual bool LookupPath(const PathString &path, const LookupOptions options,
+                          DirectoryEntry *entry);
   bool LookupPath(const std::string &path, const LookupOptions options,
                   DirectoryEntry *entry) {
     PathString p;
@@ -539,3 +539,4 @@ class InodeNfsGenerationAnnotation : public InodeAnnotation {
 #include "catalog_mgr_impl.h"
 
 #endif  // CVMFS_CATALOG_MGR_H_
+

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -64,6 +64,7 @@
 #include "auto_umount.h"
 #include "backoff.h"
 #include "bigvector.h"
+#include "bundle_mgr.h"
 #include "cache.h"
 #include "cache_posix.h"
 #include "cache_stream.h"
@@ -1177,6 +1178,19 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
   }
 
   perf::Inc(file_system_->n_fs_open());  // Count actual open / fetch operations
+
+  if (dirent.IsBundleTrigger()) {
+    // fetch dependences if not there already
+    PathString trigger_path;
+    assert(GetPathForInode(ino,&trigger_path) && "Unable to retrieve the path of the trigger file");
+    BundleMgr bundle_mgr(mount_point_,  trigger_path);
+    if (bundle_mgr) {
+      bundle_mgr.Fetch();
+    } else {
+      LogCvmfs(kLogCvmfs, kLogDebug,
+               "Couldn't fetch bundle associated to file %s", path.c_str());
+    }
+  }
 
   glue::PageCacheTracker::OpenDirectives open_directives;
   if (!dirent.IsChunkedFile()) {

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1179,11 +1179,19 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
 
   perf::Inc(file_system_->n_fs_open());  // Count actual open / fetch operations
 
-  if (dirent.IsBundleTrigger()) {
+  std::string is_prefetching_enabled;
+  if (options_mgr_) {
+    options_mgr_->GetValue("CVMFS_FUSE_NOTIFY_INVALIDATION",
+                           &is_prefetching_enabled);
+  }
+  if (dirent.IsBundleTrigger() and (options_mgr_)
+          ? options_mgr_->IsOn(is_prefetching_enabled)
+          : false) {
     // fetch dependences if not there already
     PathString trigger_path;
-    assert(GetPathForInode(ino,&trigger_path) && "Unable to retrieve the path of the trigger file");
-    BundleMgr bundle_mgr(mount_point_,  trigger_path);
+    assert(GetPathForInode(ino, &trigger_path)
+           && "Unable to retrieve the path of the trigger file");
+    BundleMgr bundle_mgr(mount_point_, trigger_path);
     if (bundle_mgr) {
       bundle_mgr.Fetch();
     } else {
@@ -3050,3 +3058,4 @@ static void __attribute__((destructor)) LibraryExit() {
   delete g_cvmfs_exports;
   g_cvmfs_exports = NULL;
 }
+

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -108,10 +108,10 @@ class Fetcher : SingleCopy {
           download::DownloadManager *download_mgr,
           BackoffThrottle *backoff_throttle,
           perf::StatisticsTemplate statistics);
-  ~Fetcher();
+  virtual ~Fetcher();
 
-  int Fetch(const CacheManager::LabeledObject &object,
-            const std::string &alt_url = "");
+  virtual int Fetch(const CacheManager::LabeledObject &object,
+                    const std::string &alt_url = "");
 
   void ReplaceCacheManager(CacheManager *new_cache_mgr) {
     cache_mgr_ = new_cache_mgr;
@@ -192,3 +192,4 @@ class Fetcher : SingleCopy {
 }  // namespace cvmfs
 
 #endif  // CVMFS_FETCH_H_
+

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * This class implements the format for .cvmfsbundle files 
+ */
+
+#ifndef CVMFS_FILE_BUNDLE_H_
+#define CVMFS_FILE_BUNDLE_H_
+
+
+/*
+
+The .cvmfsbundle file servers both as a file list and as a trigger for loading a bundle. The convention is to call it .cvmfsbundle.<filename>, where <filename> should trigger the bundle.
+
+? The content could be structured in json.
+
+The file format should be versioned, with the header:
+
+#%CVMFS_BUNDLE version=1 encoding=UTF-8
+
+? end marker
+
+*/
+
+
+#endif

--- a/cvmfs/file_bundle.h
+++ b/cvmfs/file_bundle.h
@@ -1,16 +1,27 @@
 /**
  * This file is part of the CernVM File System.
  *
- * This class implements the format for .cvmfsbundle files 
+ * This class implements the format for .cvmfsbundle files
  */
 
 #ifndef CVMFS_FILE_BUNDLE_H_
 #define CVMFS_FILE_BUNDLE_H_
 
+#include <json.h>
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#include "json_document.h"
+#include "shortstring.h"
+#include "util/single_copy.h"
 
 /*
 
-The .cvmfsbundle file servers both as a file list and as a trigger for loading a bundle. The convention is to call it .cvmfsbundle.<filename>, where <filename> should trigger the bundle.
+The .cvmfsbundle file serves both as a file list and as a trigger for loading a
+bundle. The convention is to call it .cvmfsbundle.<filename>, where <filename>
+should trigger the bundle.
 
 ? The content could be structured in json.
 
@@ -20,7 +31,100 @@ The file format should be versioned, with the header:
 
 ? end marker
 
+The json file should contain an array of labeled objects as follows:
+{
+"name":"CVMFS_BUNDLE",
+"version":"1.0.0",
+"encoding":"UTF-8",
+"dependencies":["/absolute/path/to/file/from/repositories/root"]
+}
+
 */
 
+class BundleFileMgr : SingleCopy {
+ public:
+  BundleFileMgr(const PathString &bundle_file_path) {
+    std::ifstream file(bundle_file_path.ToString());
+    if (!file.is_open()) {
+      bundle_doc_ = nullptr;
+    } else {
+      std::stringstream rbuf;
+      rbuf << file.rdbuf();
+      JsonDocument *json = JsonDocument::Create(rbuf.str());
+      Manage(json);
+    }
+  }
+
+  BundleFileMgr(JsonDocument *fc) { Manage(fc); }
+
+  virtual ~BundleFileMgr() { ReleaseDocument(); }
+
+  std::string GetVersion() const {
+    auto *ptr = JsonDocument::SearchInObject(bundle_doc_->root(), "version",
+                                             JSON_STRING);
+    return (ptr) ? ptr->string_value : std::string();
+  }
+
+  std::string GetEncoding() const {
+    auto *ptr = JsonDocument::SearchInObject(bundle_doc_->root(), "encoding",
+                                             JSON_STRING);
+    return (ptr) ? ptr->string_value : std::string();
+  }
+
+  virtual PathString GetNext() {
+    if (current_entry_ == nullptr)
+      // This should be handled as an error code. Path string should never be
+      // empty;
+      return PathString();
+    assert(current_entry_->type == JSON_STRING);
+    const PathString result = static_cast<PathString>(
+        current_entry_->string_value);
+    current_entry_ = current_entry_->next_sibling;
+    return (result.IsEmpty()) ? GetNext() : result;
+  };
+
+  virtual size_t Size() const { return size_; }
+
+  operator bool() const {
+    return (bundle_doc_ != nullptr) ? bundle_doc_->IsValid() : false;
+  }
+
+ private:
+  void Manage(JsonDocument *fc) {
+    bundle_doc_ = fc;
+    ResetSize();
+    ResetCurrentEntry();
+  }
+
+  void ResetCurrentEntry() {
+    auto *ptr = JsonDocument::SearchInObject(bundle_doc_->root(),
+                                             "dependencies", JSON_ARRAY);
+    current_entry_ = (ptr) ? ptr->first_child : ptr;
+  }
+
+  void ResetSize() {
+    if (not bundle_doc_) {
+      size_ = 0;
+    } else {
+      auto *ptr = JsonDocument::SearchInObject(bundle_doc_->root(),
+                                               "dependencies", JSON_ARRAY);
+      size_ = 0;
+      for (ptr = ptr->first_child; ptr != nullptr; ptr = ptr->next_sibling) {
+        ++size_;
+      }
+    }
+  }
+
+  void ReleaseDocument() {
+    if (bundle_doc_ != nullptr) {
+      delete bundle_doc_;
+      bundle_doc_ = nullptr;
+    }
+  }
+  size_t size_ = 0;
+  JsonDocument *bundle_doc_ = nullptr;
+  JSON *current_entry_ = nullptr;
+};
 
 #endif
+

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -491,6 +491,8 @@ class StatfsCache : SingleCopy {
  * destruction explicit and also to keep the include list for this header small.
  */
 class MountPoint : SingleCopy, public BootFactory {
+  friend class T_BundleMgr;
+
  public:
   /**
    * If catalog reload fails, try again in 3 minutes

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -202,6 +202,8 @@ class ShortString {
   static uint64_t num_instances() { return atomic_read64(&num_instances_); }
   static uint64_t num_overflows() { return atomic_read64(&num_overflows_); }
 
+  operator bool() const { return not IsEmpty(); }
+
  private:
   std::string *long_string_;
   char stack_[StackSize + 1];  // +1 to add a final '\0' if necessary
@@ -231,3 +233,4 @@ bool IsSubPath(const PathString &parent, const PathString &path);
 #endif
 
 #endif  // CVMFS_SHORTSTRING_H_
+

--- a/cvmfs/util/logging_internal.h
+++ b/cvmfs/util/logging_internal.h
@@ -108,7 +108,8 @@ enum LogSource {
   kLogReflog,
   kLogKvStore,
   kLogTelemetry,
-  kLogCurl
+  kLogCurl,
+  kLogBundleMgr
 };
 
 const int kLogWarning = kLogStdout | kLogShowSource | kLogNormal;
@@ -161,3 +162,4 @@ CVMFS_EXPORT void PrintError(const std::string &message);
 #endif
 
 #endif  // CVMFS_UTIL_LOGGING_INTERNAL_H_
+

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -339,6 +339,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_bigqueue.cc
   t_bigvector.cc
   t_blocking_counter.cc
+  t_bundle_file_mgr.cc
   t_cache.cc
   t_cache_extern.cc
   t_cache_ram.cc

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -339,6 +339,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_bigqueue.cc
   t_bigvector.cc
   t_blocking_counter.cc
+  t_bundle_mgr.cc
   t_bundle_file_mgr.cc
   t_cache.cc
   t_cache_extern.cc
@@ -455,6 +456,7 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/authz/authz_fetch.cc
   ${CVMFS_SOURCE_DIR}/authz/authz_session.cc
   ${CVMFS_SOURCE_DIR}/backoff.cc
+  ${CVMFS_SOURCE_DIR}/bundle_mgr.cc
   ${CVMFS_SOURCE_DIR}/cache.cc
   ${CVMFS_SOURCE_DIR}/cache_extern.cc
   ${CVMFS_SOURCE_DIR}/cache_posix.cc
@@ -624,6 +626,7 @@ set(CVMFS_UNITTEST_MOCKFUSE_SOURCES
   ${CVMFS_SOURCE_DIR}/authz/authz_session.cc
   ${CVMFS_SOURCE_DIR}/auto_umount.cc
   ${CVMFS_SOURCE_DIR}/backoff.cc
+  ${CVMFS_SOURCE_DIR}/bundle_mgr.cc
   ${CVMFS_SOURCE_DIR}/cache.cc
   ${CVMFS_SOURCE_DIR}/cache_extern.cc
   ${CVMFS_SOURCE_DIR}/cache_posix.cc

--- a/test/unittests/t_bundle_file_mgr.cc
+++ b/test/unittests/t_bundle_file_mgr.cc
@@ -1,0 +1,62 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "file_bundle.h"
+#include "json_document.h"
+
+class T_BundleFileMgr : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    bfm_ = new BundleFileMgr(JsonDocument::Create(CreateJsonTxt()));
+    EXPECT_TRUE(bfm_);
+    EXPECT_TRUE(*bfm_);
+  }
+
+  virtual void TearDown() { delete bfm_; }
+  virtual ~T_BundleFileMgr() { }
+
+  BundleFileMgr* bfm_;
+  const std::vector<std::string> paths_{"a_file_without_extension",
+                                        "a_file_with.extension",
+                                        "a/file/within/a/directory.foo"};
+
+ private:
+  std::string CreateJsonTxt() {
+    std::ostringstream json;
+    json << "{";
+    json << "  \"name\": \"CVMFS_BUNDLE\",\n";
+    json << "  \"version\": \"1.0.0\",\n";
+    json << "  \"encoding\": \"UTF-8\",\n";
+    json << "  \"dependencies\": [\n";
+    for (size_t i = 0; i < paths_.size(); ++i) {
+      json << "    \"" << paths_[i] << "\"";
+      if (i < paths_.size() - 1) {
+        json << ",\n";
+      }
+    }
+    json << "]}";
+    return json.str();
+  }
+};
+
+TEST_F(T_BundleFileMgr, TestSize) { EXPECT_EQ(paths_.size(), bfm_->Size()); }
+
+
+TEST_F(T_BundleFileMgr, TestVersion) { EXPECT_EQ(bfm_->GetVersion(), "1.0.0"); }
+
+TEST_F(T_BundleFileMgr, TestEncoding) {
+  EXPECT_EQ(bfm_->GetEncoding(), "UTF-8");
+}
+
+TEST_F(T_BundleFileMgr, TestGetNext) {
+  for (size_t i = 0; i < paths_.size(); ++i) {
+    EXPECT_EQ(bfm_->GetNext().ToString(), paths_[i]);
+  }
+  EXPECT_TRUE(bfm_->GetNext().IsEmpty());
+}
+

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -1,0 +1,194 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "bundle_mgr.h"
+#include "catalog_mgr_client.h"
+#include "fetch.h"
+#include "file_bundle.h"
+#include "json_document.h"
+#include "mountpoint.h"
+#include "options.h"
+#include "shortstring.h"
+
+class MockCatalogManager : public catalog::ClientCatalogManager {
+ public:
+  MockCatalogManager(MountPoint *mountpoint)
+      : ClientCatalogManager(mountpoint) { };
+  virtual ~MockCatalogManager() = default;
+  MOCK_METHOD(fuse_ino_t, MangleInode, (fuse_ino_t ino), (const));
+  MOCK_METHOD(bool,
+              LookupPath,
+              (const PathString &path,
+               const catalog::LookupOptions options,
+               catalog::DirectoryEntry *dirent),
+              (override));
+};
+
+class MockFetcher : public cvmfs::Fetcher {
+ public:
+  MockFetcher(CacheManager *cache_mgr,
+              download::DownloadManager *download_mgr,
+              BackoffThrottle *backoff_throttle,
+              perf::StatisticsTemplate statistics)
+      : Fetcher(cache_mgr, download_mgr, backoff_throttle, statistics)
+      , statistics_(statistics.statistics()) { };
+  int Fetch(const CacheManager::LabeledObject &object,
+            const std::string &alt_url = "") override {
+    return ++counter_;
+  }
+  virtual ~MockFetcher() { delete statistics_; }
+  void Reset() { counter_ = 0; }
+
+  inline static size_t counter_ = 0;
+  perf::Statistics *statistics_;
+};
+
+class T_BundleMgr : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    tmp_path_ = CreateTempDir("./cvmfs_ut_cache");
+    options_mgr_.SetValue("CVMFS_CACHE_BASE", tmp_path_);
+    options_mgr_.SetValue("CVMFS_SHARED_CACHE", "no");
+    options_mgr_.SetValue("CVMFS_MAX_RETRIES", "0");
+    fs_info_.name = "unit-test";
+    fs_info_.options_mgr = &options_mgr_;
+    // Silence syslog error
+    options_mgr_.SetValue("CVMFS_MOUNT_DIR", "/no/such/dir");
+    file_system_ = FileSystem::Create(fs_info_);
+    ASSERT_TRUE(file_system_ != NULL);
+    EXPECT_TRUE(file_system_->IsValid());
+    mount_point_ = MountPoint::Create("keys.cern.ch", file_system_);
+
+    // MountPoint mocks allocation
+    mock_catalog_mgr_ = new testing::NiceMock<MockCatalogManager>(mount_point_);
+    mock_fetcher_ = new testing::NiceMock<MockFetcher>(
+        nullptr,
+        nullptr,
+        nullptr,
+        perf::StatisticsTemplate("fetch", new perf::Statistics()));
+    mock_external_fetcher_ = new testing::NiceMock<MockFetcher>(
+        nullptr,
+        nullptr,
+        nullptr,
+        perf::StatisticsTemplate("fetch", new perf::Statistics()));
+    // Determine mock behavior
+    ON_CALL(*mock_catalog_mgr_, LookupPath(testing::_, testing::_, testing::_))
+        .WillByDefault([this](const PathString &,
+                              const catalog::LookupOptions,
+                              catalog::DirectoryEntry *out) -> bool {
+          *out = this->trigger_dirent_;
+          return true;
+        });
+    // Plug mocks on mount_point_
+    mount_point_->catalog_mgr_ = mock_catalog_mgr_;
+    mount_point_->fetcher_ = mock_fetcher_;
+    mount_point_->external_fetcher_ = mock_external_fetcher_;
+
+    bundle_mgr_ = new BundleMgr(mount_point_, trigger_path_);
+
+    bfm_ = new BundleFileMgr(JsonDocument::Create(CreateJsonTxt()));
+
+    delete bundle_mgr_->bfm_;
+    bundle_mgr_->bfm_ = bfm_;
+    EXPECT_TRUE(bundle_mgr_);
+    EXPECT_EQ(bundle_mgr_->bfm_, bfm_);
+    MakePipe(common_pipe_);
+  }
+
+  virtual void TearDown() {
+    delete file_system_;
+    delete mount_point_;
+    delete bundle_mgr_;
+    ClosePipe(common_pipe_);
+    chdir("../..");
+    if (not tmp_path_.empty()) {
+      EXPECT_TRUE(RemoveTree(tmp_path_));
+    }
+  }
+
+  template<typename CT,
+           typename = std::enable_if_t<std::is_trivially_copyable_v<CT> > >
+  void test_blocking_exchange(const CT &obj) {
+    using T = std::remove_cv_t<CT>;
+    bundle_mgr_->BlockingSend(wfd_, obj);
+    T reply = bundle_mgr_->BlockingReceive<T>(rfd_);
+    EXPECT_EQ(obj, reply);
+  }
+  void test_blocking_exchange(const std::string &obj) {
+    bundle_mgr_->BlockingSend(wfd_, obj);
+    std::string reply = bundle_mgr_->BlockingReceive(rfd_);
+    EXPECT_EQ(obj, reply);
+  }
+
+ protected:
+  MountPoint *mount_point_;
+  FileSystem *file_system_;
+  FileSystem::FileSystemInfo fs_info_;
+  SimpleOptionsParser options_mgr_;
+  std::string tmp_path_;
+
+  PathString trigger_file_path_;
+  BundleMgr *bundle_mgr_;
+
+  catalog::DirectoryEntry trigger_dirent_{};
+  PathString trigger_path_{};
+
+  // Mocks
+  BundleFileMgr *bfm_;
+  testing::NiceMock<MockCatalogManager> *mock_catalog_mgr_;
+  testing::NiceMock<MockFetcher> *mock_fetcher_;
+  testing::NiceMock<MockFetcher> *mock_external_fetcher_;
+
+  int common_pipe_[2];
+  int &rfd_ = common_pipe_[0];
+  int &wfd_ = common_pipe_[1];
+
+  std::vector<std::string> dependencies_ = {"a_file_without_extension",
+                                            "a_file_with.extension",
+                                            "a/file/within/a/directory.foo"};
+
+  std::string CreateJsonTxt() {
+    std::ostringstream json;
+    json << "{";
+    json << "  \"name\": \"CVMFS_BUNDLE\",\n";
+    json << "  \"version\": \"1.0.0\",\n";
+    json << "  \"encoding\": \"UTF-8\",\n";
+    json << "  \"dependencies\": [\n";
+    for (size_t i = 0; i < dependencies_.size(); ++i) {
+      json << "    \"" << dependencies_[i] << "\"";
+      if (i < dependencies_.size() - 1) {
+        json << ",\n";
+      }
+    }
+    json << "]}";
+    return json.str();
+  }
+};
+
+TEST_F(T_BundleMgr, ExchangeCT) {
+  int integer = 42;
+  std::string string = "Test_String";
+
+  test_blocking_exchange(integer);
+  test_blocking_exchange(string);
+}
+
+TEST_F(T_BundleMgr, ExchangePathString) {
+  PathString path("path/to/file.txt");
+
+  bundle_mgr_->BlockingSend(wfd_, path);
+  EXPECT_EQ(path, bundle_mgr_->ReceivePath(rfd_));
+}
+
+TEST_F(T_BundleMgr, Fetch) {
+  bundle_mgr_->Fetch();
+  EXPECT_EQ(mock_fetcher_->counter_, MockFetcher::counter_);
+}
+


### PR DESCRIPTION
The approach here is to have an individual thread spawned on the spot that will do the prefetching.

There are two important entities here, the `BundleFileMgr` (that is iterating through the bundle file) and the `BundleMgr` (that is responsible to manage the fetcher thread).

With this PR https://github.com/cvmfs/cvmfs/pull/4049 and https://github.com/cvmfs/cvmfs/pull/4039 are now deprecated. I have tried to incorporate most of the remarks of @jblomer.

In case that performance is not enough, the `BundleMgr` is designed to easily go from a single thread to a pool of threads.