### PR TITLE
Remove unused cleanup traps that interfere with timeout

### DIFF
--- a/test/src/098-telemetry/main
+++ b/test/src/098-telemetry/main
@@ -135,7 +135,6 @@ CVMFS_INFLUX_SEND_DELTA=OFF"
 cvmfs_run_test() {
   logfile=$1
   local_script_dir=$2
-  trap cleanup HUP INT TERM EXIT || return $?
 
   echo "create temporary directory"
   CVMFS_TEST_098_TMPFILE=$(mktemp ./test098.log.XXXXXXXX)

--- a/test/src/100-reload-switch-debug/main
+++ b/test/src/100-reload-switch-debug/main
@@ -111,7 +111,6 @@ reload_with_debuglog() {
 cvmfs_run_test() {
   logfile=$1
   local_script_dir=$2
-  trap cleanup HUP INT TERM EXIT || return $?
 
   echo "create temporary directory"
   CVMFS_TEST_100_TMPFILE=$(mktemp /tmp/cvmfs_test100.log.XXXXXXXX)


### PR DESCRIPTION
I have sometimes seen some very long timeout run times in the dockerized cloud tests where they seemed to be stuck.  One time I investigated it and one of these unused cleanup traps were implicated in interfering with the 300-second per test timeout function in run.sh.  I searched through all the tests and found these two with trap statements but no cleanup function.