### PR TITLE
Improve run.sh test output formatting

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -670,7 +670,7 @@ if [ "$preview_run_count" -gt 0 ] || [ "$preview_suite_skip_count" -gt 0 ] || [ 
   printf '%s\n' "$(format_section_heading "Selection preview:")"
   echo "Will run $preview_run_count tests."
   if [ "$preview_suite_skip_count" -gt 0 ]; then
-    printf '%s\n' "$(format_section_heading "Ignored by suite (-s) ($preview_suite_skip_count):")"
+    printf '%s\n' "$(format_section_heading "Excluded by suite (-s) ($preview_suite_skip_count):")"
     printf "%s" "$preview_suite_skip_entries"
   fi
   if [ "$preview_excluded_count" -gt 0 ]; then

--- a/test/run.sh
+++ b/test/run.sh
@@ -134,6 +134,19 @@ num_passed=0
 num_failures=0
 num_warnings=0
 
+TEST_ID_WIDTH=24
+TEST_STATUS_WIDTH=6
+STATUS_LAYOUT_MIN_COLUMNS=100
+STATUS_LAYOUT="aligned"
+STATUS_COLOR_ENABLED=0
+
+COLOR_RESET=""
+COLOR_PASS=""
+COLOR_WARN=""
+COLOR_FAIL=""
+COLOR_SKIP=""
+COLOR_HEADING=""
+
 # test failure handling
 # this functions should EXCLUSIVELY be called in the run loop (global state)
 report_failure() {
@@ -163,6 +176,249 @@ report_skipped() {
   local message="$1"
   echo $message
   num_skipped=$(($num_skipped+1))
+}
+
+test_display_id() {
+  local test_path="$1"
+  local display_id="${test_path#./}"
+
+  display_id="${display_id#test/}"
+  display_id="${display_id#src/}"
+
+  echo "$display_id"
+}
+
+test_elapsed_display() {
+  local elapsed_ms="$1"
+  echo "$(milliseconds_to_seconds "$elapsed_ms")s"
+}
+
+is_positive_integer() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    0) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+terminal_columns() {
+  local columns
+
+  if is_positive_integer "$COLUMNS"; then
+    echo "$COLUMNS"
+    return
+  fi
+
+  if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+    columns="$(tput cols 2>/dev/null)"
+    if is_positive_integer "$columns"; then
+      echo "$columns"
+      return
+    fi
+  fi
+
+  echo 120
+}
+
+configure_status_layout() {
+  local columns
+
+  columns="$(terminal_columns)"
+  if [ "$columns" -lt "$STATUS_LAYOUT_MIN_COLUMNS" ]; then
+    STATUS_LAYOUT="compact"
+  else
+    STATUS_LAYOUT="aligned"
+  fi
+}
+
+configure_status_colors() {
+  if [ ! -t 1 ]; then
+    return
+  fi
+
+  if [ -n "$NO_COLOR" ]; then
+    return
+  fi
+
+  case "${TERM:-}" in
+    ''|dumb)
+      return
+      ;;
+  esac
+
+  STATUS_COLOR_ENABLED=1
+  COLOR_RESET=$'\033[0m'
+  COLOR_PASS=$'\033[32m'
+  COLOR_WARN=$'\033[33m'
+  COLOR_FAIL=$'\033[31m'
+  COLOR_SKIP=$'\033[36m'
+  COLOR_HEADING=$'\033[1m'
+}
+
+status_color() {
+  case "$1" in
+    PASS)
+      printf '%s' "$COLOR_PASS"
+      ;;
+    WARN)
+      printf '%s' "$COLOR_WARN"
+      ;;
+    FAIL)
+      printf '%s' "$COLOR_FAIL"
+      ;;
+    SKIP)
+      printf '%s' "$COLOR_SKIP"
+      ;;
+  esac
+}
+
+format_status_label() {
+  local status="$1"
+  local color
+
+  if [ "$STATUS_COLOR_ENABLED" -eq 0 ]; then
+    printf '%s' "$status"
+    return
+  fi
+
+  color="$(status_color "$status")"
+  if [ -z "$color" ]; then
+    printf '%s' "$status"
+  else
+    printf '%s%s%s' "$color" "$status" "$COLOR_RESET"
+  fi
+}
+
+format_section_heading() {
+  local title="$1"
+
+  if [ "$STATUS_COLOR_ENABLED" -eq 0 ] || [ -z "$COLOR_HEADING" ]; then
+    printf '%s' "$title"
+  else
+    printf '%s%s%s' "$COLOR_HEADING" "$title" "$COLOR_RESET"
+  fi
+}
+
+format_status_entry() {
+  local test_id="$1"
+  local test_name="$2"
+  local status="$3"
+  local detail="$4"
+  local status_label
+  local status_padding=""
+  local status_padding_width=0
+
+  : "$test_name"
+  status_label="$(format_status_label "$status")"
+
+  if [ "$STATUS_LAYOUT" = "compact" ]; then
+    printf "%s | %s" "$test_id" "$status_label"
+  else
+    status_padding_width=$((TEST_STATUS_WIDTH - ${#status}))
+    if [ "$status_padding_width" -gt 0 ]; then
+      printf -v status_padding '%*s' "$status_padding_width" ''
+      status_padding="${status_padding// /.}"
+    fi
+
+    printf "%-${TEST_ID_WIDTH}s | %s%s" "$test_id" "$status_padding" "$status_label"
+  fi
+
+  if [ -n "$detail" ]; then
+    printf " | %s" "$detail"
+  fi
+}
+
+print_test_status() {
+  local test_id="$1"
+  local test_name="$2"
+  local status="$3"
+  local detail="$4"
+
+  format_status_entry "$test_id" "$test_name" "$status" "$detail"
+  printf "\n"
+}
+
+append_status_digest() {
+  local digest_var="$1"
+  local test_id="$2"
+  local test_name="$3"
+  local status="$4"
+  local detail="$5"
+  local digest_entry
+
+  digest_entry="$(format_status_entry "$test_id" "$test_name" "$status" "$detail")"
+
+  printf -v "$digest_var" '%s%s\n' "${!digest_var}" "$digest_entry"
+}
+
+print_digest_section() {
+  local title="$1"
+  local digest_content="$2"
+  local empty_message="$3"
+
+  echo ""
+  printf '%s\n' "$(format_section_heading "$title")"
+  if [ -n "$digest_content" ]; then
+    printf "%s" "$digest_content"
+  elif [ -n "$empty_message" ]; then
+    echo "$empty_message"
+  fi
+}
+
+print_preview_group() {
+  local title="$1"
+  local preview_content="$2"
+
+  if [ -z "$preview_content" ]; then
+    return
+  fi
+
+  printf '%s\n' "$(format_section_heading "$title")"
+  printf "%s" "$preview_content"
+}
+
+run_test_with_timeout() {
+  local test_path="$1"
+  local test_workdir="$2"
+  local test_logfile="$3"
+  local test_timeout="$4"
+  local test_root="$5"
+
+  timeout --foreground -s HUP "$test_timeout" \
+    bash $debug -c '
+      set -m
+      test_tree_pid=""
+
+      stop_test_tree() {
+        local signal="$1"
+
+        if [ -z "$test_tree_pid" ]; then
+          return 0
+        fi
+
+        kill -s "$signal" -- "-$test_tree_pid" 2>/dev/null || true
+        sleep 1
+        kill -KILL -- "-$test_tree_pid" 2>/dev/null || true
+      }
+
+      trap '\''stop_test_tree HUP; wait "$test_tree_pid" 2>/dev/null || true; exit 124'\'' HUP
+      trap '\''stop_test_tree INT; wait "$test_tree_pid" 2>/dev/null || true; exit 130'\'' INT
+      trap '\''stop_test_tree TERM; wait "$test_tree_pid" 2>/dev/null || true; exit 143'\'' TERM
+
+      bash -c '\''
+        cd "$4" &&
+        . ./test_functions &&
+        . "$1/main" &&
+        cd "$2" &&
+        cvmfs_run_test "$3" "$4/$1"
+        retval=$?
+        mangle_test_retval "$retval"
+        exit $?
+      '\'' run_test_child "$1" "$2" "$3" "$4" &
+      test_tree_pid=$!
+      wait "$test_tree_pid"
+      exit $?
+    ' run_test_wrapper "$test_path" "$test_workdir" "$test_logfile" "$test_root" >> "$test_logfile" 2>&1
 }
 
 clean_workdir() {
@@ -235,6 +491,9 @@ setup_environment() {
 # source common functions used in the test cases
 . ./test_functions
 
+configure_status_layout
+configure_status_colors
+
 testsuite_start="$(get_millisecond_epoch)"
 
 workdir_basedir="${CVMFS_TEST_SCRATCH}/workdir"
@@ -242,9 +501,44 @@ scratch_basedir="${CVMFS_TEST_SCRATCH}/scratch"
 [ ! -d $scratch_basedir ] || rm -fR $scratch_basedir
 mkdir -p $scratch_basedir
 
+preview_run_entries=""
+preview_suite_skip_entries=""
+preview_excluded_entries=""
+preview_run_count=0
+preview_suite_skip_count=0
+preview_excluded_count=0
+issue_digest_entries=""
+
 get_iso8601_timestamp > ${scratch_basedir}/starttime
 
 to_syslog "Test Suite started"
+
+for t in $testsuite
+do
+  TEST_DISPLAY_ID="$(test_display_id "$t")"
+  if contains "$exclusions" $t; then
+    append_status_digest preview_excluded_entries "$TEST_DISPLAY_ID" "" "SKIP" "excluded via -x"
+    preview_excluded_count=$((preview_excluded_count+1))
+    continue
+  fi
+
+  if ! is_in_suite $t $labels; then
+    append_status_digest preview_suite_skip_entries "$TEST_DISPLAY_ID" "" "SKIP" "suite restriction"
+    preview_suite_skip_count=$((preview_suite_skip_count+1))
+    continue
+  fi
+
+  append_status_digest preview_run_entries "$TEST_DISPLAY_ID" "" "RUN" ""
+  preview_run_count=$((preview_run_count+1))
+done
+
+if [ -n "$preview_run_entries$preview_suite_skip_entries$preview_excluded_entries" ]; then
+  echo ""
+  printf '%s\n' "$(format_section_heading "Selection preview:")"
+  print_preview_group "Will run ($preview_run_count):" "$preview_run_entries"
+  print_preview_group "Ignored by suite (-s) ($preview_suite_skip_count):" "$preview_suite_skip_entries"
+  print_preview_group "Excluded by -x ($preview_excluded_count):" "$preview_excluded_entries"
+fi
 
 # run the tests
 for t in $testsuite
@@ -260,11 +554,14 @@ do
   done
 
   # source the test code
+  TEST_DISPLAY_ID="$(test_display_id "$t")"
   workdir="${workdir_basedir}/$(basename $t)"
   scratchdir="${scratch_basedir}/$(basename $t)"
 
   if ! mkdir -p $scratchdir; then
     report_failure "failed to create $scratchdir" >> $logfile
+    print_test_status "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "failed to create scratchdir"
+    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "failed to create scratchdir"
     continue
   fi
 
@@ -277,7 +574,9 @@ do
   cvmfs_test_autofs_on_startup=true # might be overwritten by some tests
   if ! . $t/main; then
     report_failure "failed to source $t/main" >> $logfile
+    print_test_status "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "failed to source main"
     echo "101" > ${scratchdir}/retval
+    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "retval 101, failed to source main"
     continue
   fi
 
@@ -285,21 +584,18 @@ do
   TEST_NR="$(basename $t | head -c3)"
   to_syslog "Test $TEST_NR (${cvmfs_test_name}) started"
   echo "-- Testing ${cvmfs_test_name} ($(date) / test number $TEST_NR)" >> $logfile
-  echo -n "Testing ${cvmfs_test_name}... "
   echo "$cvmfs_test_name"          > ${scratchdir}/name
   echo "$(basename $t | head -c3)" > ${scratchdir}/number
 
   # check if test should be skipped
   if contains "$exclusions" $t; then
     report_skipped "test case was marked to be skipped" >> $logfile
-    echo "Skipped by exclusion"
     touch ${scratchdir}/skipped
     continue
   fi
 
   if ! is_in_suite $t $labels; then
     report_skipped "test case not part of selected suites" >> $logfile
-    echo "Skipped by suite restriction"
     touch ${scratchdir}/skipped
     continue
   fi
@@ -321,7 +617,7 @@ do
   if [ $setup_retval -ne 0 ]; then
     to_syslog "Test $TEST_NR (${cvmfs_test_name}) failed (setup)"
     report_failure "failed to setup environment (retval: $setup_retval)" >> $logfile
-    echo "Failed! (setup)"
+    print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "setup retval $setup_retval"
     echo "0"         > ${scratchdir}/elapsed
     echo "102"       > ${scratchdir}/retval
     # Allow non-regular files e.g. /dev/stdout to be used as logfile.
@@ -330,27 +626,24 @@ do
       wc -l < "$logfile" > ${scratchdir}/log_end
     fi
     touch              ${scratchdir}/failure
+    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval 102, setup retval $setup_retval"
     continue
   fi
 
   # run the test
   test_start=$(get_millisecond_epoch)
-  timeout -s HUP $cvmfs_test_timeout \
-    bash $debug -c "PID=\$\$                                                 && \
-                    trap 'echo KILLING:\$PID; pkill -P \$PID; exit 124' HUP  && \
-                    . ./test_functions                                       && \
-                    . $t/main                                                && \
-                    cd $workdir                                              && \
-                    cvmfs_run_test $logfile $(pwd)/${t}                      && \
-                    retval=\$?                                               && \
-                    retval=\$(mangle_test_retval \$retval)                   && \
-                    exit \$retval" >> $logfile 2>&1
+  run_test_with_timeout "$t" "$workdir" "$logfile" "$cvmfs_test_timeout" "$TEST_ROOT"
   RETVAL=$?
+  if [ $RETVAL -eq 130 ] || [ $RETVAL -eq 143 ]; then
+    to_syslog "Test Suite interrupted"
+    exit $RETVAL
+  fi
   if [ $RETVAL -eq 124 ]; then
     RETVAL=$CVMFS_TEST_RETVAL_TIMEOUT
   fi
   test_end=$(get_millisecond_epoch)
   test_time_elapsed=$(( ( $test_end - $test_start ) ))
+  TEST_ELAPSED_DISPLAY="$(test_elapsed_display "$test_time_elapsed")"
   echo "execution took $(milliseconds_to_seconds $test_time_elapsed) seconds" >> $logfile
   echo "$test_time_elapsed" > ${scratchdir}/elapsed
   echo "$RETVAL"            > ${scratchdir}/retval
@@ -368,14 +661,15 @@ do
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) finished successfully"
       report_passed "Test passed" >> $logfile
       touch ${scratchdir}/success
-      echo "OK"
+      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "PASS" "$TEST_ELAPSED_DISPLAY"
       ;;
     $CVMFS_MEMORY_WARNING)
       clean_workdir
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) finished with memory warning"
       report_warning "Memory limit exceeded!" >> $logfile
       touch ${scratchdir}/memorywarning
-      echo "Memory Warning!"
+      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "memory limit exceeded, $TEST_ELAPSED_DISPLAY"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "memory limit exceeded, $TEST_ELAPSED_DISPLAY"
       ;;
     $CVMFS_TIME_WARNING)
       clean_workdir
@@ -383,27 +677,31 @@ do
       report_warning "Time limit exceeded!" >> $logfile
       tail -n 50 /var/log/messages /var/log.syslog >> $logfile 2>/dev/null
       touch ${scratchdir}/timewarning
-      echo "Time Warning!"
+      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "time limit exceeded, $TEST_ELAPSED_DISPLAY"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "time limit exceeded, $TEST_ELAPSED_DISPLAY"
       ;;
     $CVMFS_GENERAL_WARNING)
       clean_workdir
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) finished with warning"
       report_warning "Test case finished with warnings!" >> $logfile
       touch ${scratchdir}/generalwarning
-      echo "Warning!"
+      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "warning, $TEST_ELAPSED_DISPLAY"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "warning, $TEST_ELAPSED_DISPLAY"
       ;;
     $CVMFS_TEST_RETVAL_TIMEOUT)
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) timed out"
       report_failure "Testcase timed out" $workdir >> $logfile
       touch ${scratchdir}/failure
-      echo "Timeout!"
+      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "timeout, $TEST_ELAPSED_DISPLAY"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval $CVMFS_TEST_RETVAL_TIMEOUT (timeout), $TEST_ELAPSED_DISPLAY"
       ;;
     *)
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) failed"
       report_failure "Testcase failed with RETVAL $RETVAL" $workdir >> $logfile
       tail -n 50 /var/log/messages /var/log.syslog >> $logfile 2>/dev/null
       touch ${scratchdir}/failure
-      echo "Failed!"
+      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval $RETVAL, $TEST_ELAPSED_DISPLAY"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval $RETVAL, $TEST_ELAPSED_DISPLAY"
       ;;
   esac
 
@@ -444,6 +742,8 @@ echo "Warnings: $num_warnings"
 echo "Failures: $num_failures"
 echo ""
 echo "took $(milliseconds_to_human_readable $testsuite_time_elapsed)"
+
+print_digest_section "Warnings / failures digest:" "$issue_digest_entries" "  none"
 
 to_syslog "Test Suite finished"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -136,6 +136,7 @@ num_warnings=0
 
 TEST_ID_WIDTH=24
 TEST_STATUS_WIDTH=6
+TEST_TIMESTAMP_WIDTH=6
 STATUS_LAYOUT_MIN_COLUMNS=100
 STATUS_LAYOUT="aligned"
 STATUS_COLOR_ENABLED=0
@@ -190,7 +191,11 @@ test_display_id() {
 
 test_elapsed_display() {
   local elapsed_ms="$1"
-  echo "$(milliseconds_to_seconds "$elapsed_ms")s"
+  local elapsed_tenths=$(( (elapsed_ms + 50) / 100 ))
+  local elapsed_seconds=$(( elapsed_tenths / 10 ))
+  local elapsed_fraction=$(( elapsed_tenths % 10 ))
+
+  printf '%3d.%1ds' "$elapsed_seconds" "$elapsed_fraction"
 }
 
 is_positive_integer() {
@@ -299,28 +304,43 @@ format_section_heading() {
   fi
 }
 
-format_status_entry() {
+format_status_entry_prefix() {
   local test_id="$1"
   local test_name="$2"
-  local status="$3"
-  local detail="$4"
-  local status_label
-  local status_padding=""
-  local status_padding_width=0
+  local test_padding=""
+  local test_padding_width=0
 
   : "$test_name"
+
+  if [ "$STATUS_LAYOUT" = "compact" ]; then
+    printf "%s" "$test_id"
+  else
+    test_padding_width=$((TEST_ID_WIDTH - ${#test_id} - 1))
+    if [ "$test_padding_width" -gt 0 ]; then
+      printf -v test_padding '%*s' "$test_padding_width" ''
+      test_padding="${test_padding// /.}"
+    fi
+
+    printf "%s %s " "$test_id" "$test_padding"
+  fi
+}
+
+format_status_entry_suffix() {
+  local status="$1"
+  local timestamp="$2"
+  local detail="$3"
+  local status_label
+
   status_label="$(format_status_label "$status")"
 
   if [ "$STATUS_LAYOUT" = "compact" ]; then
-    printf "%s | %s" "$test_id" "$status_label"
+    printf " | %s" "$status_label"
   else
-    status_padding_width=$((TEST_STATUS_WIDTH - ${#status}))
-    if [ "$status_padding_width" -gt 0 ]; then
-      printf -v status_padding '%*s' "$status_padding_width" ''
-      status_padding="${status_padding// /.}"
-    fi
+    printf "%s" "$status_label"
+  fi
 
-    printf "%-${TEST_ID_WIDTH}s | %s%s" "$test_id" "$status_padding" "$status_label"
+  if [ -n "$timestamp" ] || [ -n "$detail" ]; then
+    printf " | %${TEST_TIMESTAMP_WIDTH}s" "$timestamp"
   fi
 
   if [ -n "$detail" ]; then
@@ -328,13 +348,41 @@ format_status_entry() {
   fi
 }
 
+format_status_entry() {
+  local test_id="$1"
+  local test_name="$2"
+  local status="$3"
+  local timestamp="$4"
+  local detail="$5"
+
+  format_status_entry_prefix "$test_id" "$test_name"
+  format_status_entry_suffix "$status" "$timestamp" "$detail"
+}
+
 print_test_status() {
   local test_id="$1"
   local test_name="$2"
   local status="$3"
-  local detail="$4"
+  local timestamp="$4"
+  local detail="$5"
 
-  format_status_entry "$test_id" "$test_name" "$status" "$detail"
+  format_status_entry "$test_id" "$test_name" "$status" "$timestamp" "$detail"
+  printf "\n"
+}
+
+print_test_status_prefix() {
+  local test_id="$1"
+  local test_name="$2"
+
+  format_status_entry_prefix "$test_id" "$test_name"
+}
+
+print_test_status_suffix() {
+  local status="$1"
+  local timestamp="$2"
+  local detail="$3"
+
+  format_status_entry_suffix "$status" "$timestamp" "$detail"
   printf "\n"
 }
 
@@ -343,10 +391,11 @@ append_status_digest() {
   local test_id="$2"
   local test_name="$3"
   local status="$4"
-  local detail="$5"
+  local timestamp="$5"
+  local detail="$6"
   local digest_entry
 
-  digest_entry="$(format_status_entry "$test_id" "$test_name" "$status" "$detail")"
+  digest_entry="$(format_status_entry "$test_id" "$test_name" "$status" "$timestamp" "$detail")"
 
   printf -v "$digest_var" '%s%s\n' "${!digest_var}" "$digest_entry"
 }
@@ -363,18 +412,6 @@ print_digest_section() {
   elif [ -n "$empty_message" ]; then
     echo "$empty_message"
   fi
-}
-
-print_preview_group() {
-  local title="$1"
-  local preview_content="$2"
-
-  if [ -z "$preview_content" ]; then
-    return
-  fi
-
-  printf '%s\n' "$(format_section_heading "$title")"
-  printf "%s" "$preview_content"
 }
 
 run_test_with_timeout() {
@@ -501,12 +538,11 @@ scratch_basedir="${CVMFS_TEST_SCRATCH}/scratch"
 [ ! -d $scratch_basedir ] || rm -fR $scratch_basedir
 mkdir -p $scratch_basedir
 
-preview_run_entries=""
-preview_suite_skip_entries=""
-preview_excluded_entries=""
 preview_run_count=0
 preview_suite_skip_count=0
 preview_excluded_count=0
+preview_suite_skip_entries=""
+preview_excluded_entries=""
 issue_digest_entries=""
 
 get_iso8601_timestamp > ${scratch_basedir}/starttime
@@ -517,27 +553,32 @@ for t in $testsuite
 do
   TEST_DISPLAY_ID="$(test_display_id "$t")"
   if contains "$exclusions" $t; then
-    append_status_digest preview_excluded_entries "$TEST_DISPLAY_ID" "" "SKIP" "excluded via -x"
     preview_excluded_count=$((preview_excluded_count+1))
+    printf -v preview_excluded_entries '%s%s\n' "$preview_excluded_entries" "$TEST_DISPLAY_ID"
     continue
   fi
 
   if ! is_in_suite $t $labels; then
-    append_status_digest preview_suite_skip_entries "$TEST_DISPLAY_ID" "" "SKIP" "suite restriction"
     preview_suite_skip_count=$((preview_suite_skip_count+1))
+    printf -v preview_suite_skip_entries '%s%s\n' "$preview_suite_skip_entries" "$TEST_DISPLAY_ID"
     continue
   fi
 
-  append_status_digest preview_run_entries "$TEST_DISPLAY_ID" "" "RUN" ""
   preview_run_count=$((preview_run_count+1))
 done
 
-if [ -n "$preview_run_entries$preview_suite_skip_entries$preview_excluded_entries" ]; then
+if [ "$preview_run_count" -gt 0 ] || [ "$preview_suite_skip_count" -gt 0 ] || [ "$preview_excluded_count" -gt 0 ]; then
   echo ""
   printf '%s\n' "$(format_section_heading "Selection preview:")"
-  print_preview_group "Will run ($preview_run_count):" "$preview_run_entries"
-  print_preview_group "Ignored by suite (-s) ($preview_suite_skip_count):" "$preview_suite_skip_entries"
-  print_preview_group "Excluded by -x ($preview_excluded_count):" "$preview_excluded_entries"
+  echo "Will run $preview_run_count tests."
+  if [ "$preview_suite_skip_count" -gt 0 ]; then
+    printf '%s\n' "$(format_section_heading "Ignored by suite (-s) ($preview_suite_skip_count):")"
+    printf "%s" "$preview_suite_skip_entries"
+  fi
+  if [ "$preview_excluded_count" -gt 0 ]; then
+    printf '%s\n' "$(format_section_heading "Excluded by -x ($preview_excluded_count):")"
+    printf "%s" "$preview_excluded_entries"
+  fi
 fi
 
 # run the tests
@@ -560,8 +601,8 @@ do
 
   if ! mkdir -p $scratchdir; then
     report_failure "failed to create $scratchdir" >> $logfile
-    print_test_status "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "failed to create scratchdir"
-    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "failed to create scratchdir"
+    print_test_status "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "" "failed to create scratchdir"
+    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "" "failed to create scratchdir"
     continue
   fi
 
@@ -574,9 +615,9 @@ do
   cvmfs_test_autofs_on_startup=true # might be overwritten by some tests
   if ! . $t/main; then
     report_failure "failed to source $t/main" >> $logfile
-    print_test_status "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "failed to source main"
+    print_test_status "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "" "failed to source main"
     echo "101" > ${scratchdir}/retval
-    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "retval 101, failed to source main"
+    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$(basename "$t")" "FAIL" "" "retval 101, failed to source main"
     continue
   fi
 
@@ -617,7 +658,7 @@ do
   if [ $setup_retval -ne 0 ]; then
     to_syslog "Test $TEST_NR (${cvmfs_test_name}) failed (setup)"
     report_failure "failed to setup environment (retval: $setup_retval)" >> $logfile
-    print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "setup retval $setup_retval"
+    print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "" "setup retval $setup_retval"
     echo "0"         > ${scratchdir}/elapsed
     echo "102"       > ${scratchdir}/retval
     # Allow non-regular files e.g. /dev/stdout to be used as logfile.
@@ -626,15 +667,17 @@ do
       wc -l < "$logfile" > ${scratchdir}/log_end
     fi
     touch              ${scratchdir}/failure
-    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval 102, setup retval $setup_retval"
+    append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "" "retval 102, setup retval $setup_retval"
     continue
   fi
 
   # run the test
+  print_test_status_prefix "$TEST_DISPLAY_ID" "$cvmfs_test_name"
   test_start=$(get_millisecond_epoch)
   run_test_with_timeout "$t" "$workdir" "$logfile" "$cvmfs_test_timeout" "$TEST_ROOT"
   RETVAL=$?
   if [ $RETVAL -eq 130 ] || [ $RETVAL -eq 143 ]; then
+    printf "\n"
     to_syslog "Test Suite interrupted"
     exit $RETVAL
   fi
@@ -661,15 +704,15 @@ do
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) finished successfully"
       report_passed "Test passed" >> $logfile
       touch ${scratchdir}/success
-      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "PASS" "$TEST_ELAPSED_DISPLAY"
+      print_test_status_suffix "PASS" "$TEST_ELAPSED_DISPLAY" ""
       ;;
     $CVMFS_MEMORY_WARNING)
       clean_workdir
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) finished with memory warning"
       report_warning "Memory limit exceeded!" >> $logfile
       touch ${scratchdir}/memorywarning
-      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "memory limit exceeded, $TEST_ELAPSED_DISPLAY"
-      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "memory limit exceeded, $TEST_ELAPSED_DISPLAY"
+      print_test_status_suffix "WARN" "$TEST_ELAPSED_DISPLAY" "memory limit exceeded"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "$TEST_ELAPSED_DISPLAY" "memory limit exceeded"
       ;;
     $CVMFS_TIME_WARNING)
       clean_workdir
@@ -677,31 +720,31 @@ do
       report_warning "Time limit exceeded!" >> $logfile
       tail -n 50 /var/log/messages /var/log.syslog >> $logfile 2>/dev/null
       touch ${scratchdir}/timewarning
-      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "time limit exceeded, $TEST_ELAPSED_DISPLAY"
-      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "time limit exceeded, $TEST_ELAPSED_DISPLAY"
+      print_test_status_suffix "WARN" "$TEST_ELAPSED_DISPLAY" "time limit exceeded"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "$TEST_ELAPSED_DISPLAY" "time limit exceeded"
       ;;
     $CVMFS_GENERAL_WARNING)
       clean_workdir
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) finished with warning"
       report_warning "Test case finished with warnings!" >> $logfile
       touch ${scratchdir}/generalwarning
-      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "warning, $TEST_ELAPSED_DISPLAY"
-      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "warning, $TEST_ELAPSED_DISPLAY"
+      print_test_status_suffix "WARN" "$TEST_ELAPSED_DISPLAY" "warning"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "WARN" "$TEST_ELAPSED_DISPLAY" "warning"
       ;;
     $CVMFS_TEST_RETVAL_TIMEOUT)
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) timed out"
       report_failure "Testcase timed out" $workdir >> $logfile
       touch ${scratchdir}/failure
-      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "timeout, $TEST_ELAPSED_DISPLAY"
-      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval $CVMFS_TEST_RETVAL_TIMEOUT (timeout), $TEST_ELAPSED_DISPLAY"
+      print_test_status_suffix "FAIL" "$TEST_ELAPSED_DISPLAY" "timeout"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "$TEST_ELAPSED_DISPLAY" "retval $CVMFS_TEST_RETVAL_TIMEOUT (timeout)"
       ;;
     *)
       to_syslog "Test $TEST_NR (${cvmfs_test_name}) failed"
       report_failure "Testcase failed with RETVAL $RETVAL" $workdir >> $logfile
       tail -n 50 /var/log/messages /var/log.syslog >> $logfile 2>/dev/null
       touch ${scratchdir}/failure
-      print_test_status "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval $RETVAL, $TEST_ELAPSED_DISPLAY"
-      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "retval $RETVAL, $TEST_ELAPSED_DISPLAY"
+      print_test_status_suffix "FAIL" "$TEST_ELAPSED_DISPLAY" "retval $RETVAL"
+      append_status_digest issue_digest_entries "$TEST_DISPLAY_ID" "$cvmfs_test_name" "FAIL" "$TEST_ELAPSED_DISPLAY" "retval $RETVAL"
       ;;
   esac
 
@@ -743,7 +786,12 @@ echo "Failures: $num_failures"
 echo ""
 echo "took $(milliseconds_to_human_readable $testsuite_time_elapsed)"
 
-print_digest_section "Warnings / failures digest:" "$issue_digest_entries" "  none"
+if [ -n "$issue_digest_entries" ]; then
+  print_digest_section "Warnings / failures digest:" "$issue_digest_entries" ""
+elif [ "$num_warnings" -eq 0 ] && [ "$num_failures" -eq 0 ]; then
+  echo ""
+  printf '%s\n' "$(format_section_heading "All executed tests ran successfully.")"
+fi
 
 to_syslog "Test Suite finished"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,25 +1,70 @@
 #!/bin/bash
 
 usage() {
-  echo "$0 <logfile> [-o xUnit XML output] [-s suite labels] [-x <exclusion list> --] [test list]"
+  echo "$0 [logfile] [-o xUnit XML output] [-s suite labels] [-x <exclusion list> --] [test list]"
   echo "  -- or --"
-  echo "$0 <logfile> -s3 <S3 storage path>"
+  echo "$0 [logfile] -s3 <S3 storage path>"
+}
+
+git_source_revision() {
+  local source_tree="$1"
+  local git_root
+  local git_revision
+
+  if ! command -v git >/dev/null 2>&1; then
+    return 0
+  fi
+
+  git_root="$(git -C "$source_tree" rev-parse --show-toplevel 2>/dev/null)" || return 0
+  git_revision="$(git -C "$git_root" rev-parse --short=12 HEAD 2>/dev/null)" || return 0
+
+  if [ -n "$(git -C "$git_root" status --porcelain 2>/dev/null)" ]; then
+    git_revision="${git_revision}-dirty"
+  fi
+
+  printf '%s' "$git_revision"
 }
 
 export LC_ALL=C
 
-# set up a log file
-logfile=$1
-if [ -z $logfile ]; then
-  usage
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+CURRENT_DIR=$(pwd)
+SOURCE_GIT_REVISION="$(git_source_revision "$SCRIPT_DIR")"
+
+if [ "$CURRENT_DIR" != "$SCRIPT_DIR" ]; then
+  echo "Warning: run.sh must be started from its parent directory: $SCRIPT_DIR"
+  echo "Fatal: please cd $SCRIPT_DIR and run ./run.sh from there"
   exit 1
 fi
+
+# set up a log file
+logfile_arg_consumed=0
+default_logfile_used=0
+case "${1:-}" in
+  ''|-*)
+    logfile="/tmp/cvmfs-test-logs/cvmfs-test-log-$(date +'%Y%m%d-%H%M%S').log"
+    default_logfile_used=1
+    if ! mkdir -p "$(dirname "$logfile")"; then
+      echo "failed to create log directory $(dirname "$logfile")"
+      exit 1
+    fi
+    ;;
+  *)
+    logfile=$1
+    logfile_arg_consumed=1
+    ;;
+esac
+
 if ! echo "$logfile" | grep -q ^/; then
   logfile=$(pwd)/$(basename $logfile)
 fi
 
-if [ "x$2" = "x-s3" ]; then
-  s3_storage=$3
+if [ "$logfile_arg_consumed" -eq 1 ]; then
+  shift
+fi
+
+if [ "x$1" = "x-s3" ]; then
+  s3_storage=$2
   if [ "x$s3_storage" = "x" ]; then
     usage
     exit 1
@@ -29,6 +74,9 @@ if [ "x$2" = "x-s3" ]; then
     exit 1
   fi
   echo "Starting S3 test server" > $logfile
+  if [ -n "$SOURCE_GIT_REVISION" ]; then
+    echo "Source tree git revision: $SOURCE_GIT_REVISION" >> $logfile
+  fi
   mkdir -p $s3_storage/{config,mc_config,data}
 
   s3_config=$s3_storage/test_s3.conf
@@ -76,13 +124,18 @@ fi
 
 echo "Start test suite for cvmfs $(cvmfs2 --version)" > $logfile
 date >> $logfile
+if [ -n "$SOURCE_GIT_REVISION" ]; then
+  echo "Source tree git revision: $SOURCE_GIT_REVISION" >> $logfile
+fi
 
 # read command line parameters
-shift
 test_exclusions=0
 xml_output=""
 debug=""
 labels="$CVMFS_TEST_SUITES"
+suite_option_provided=0
+default_suite_used=0
+default_testsuite_used=0
 while getopts "xo:ds:" option; do
   case $option in
     x)
@@ -96,6 +149,7 @@ while getopts "xo:ds:" option; do
     ;;
     s)
       labels="$OPTARG"
+      suite_option_provided=1
     ;;
     ?)
       usage
@@ -117,15 +171,50 @@ fi
 
 testsuite="$@"
 if [ -z "$testsuite" ]; then
-  testsuite=$(find src -mindepth 1 -maxdepth 1 -type d | sort)
+  if [ "$suite_option_provided" -eq 0 ]; then
+    if [ -z "$labels" ]; then
+      labels="quick"
+      default_suite_used=1
+    fi
+    testsuite="src/0* src/1* src/5* src/6*"
+    default_testsuite_used=1
+  else
+    testsuite=$(find src -mindepth 1 -maxdepth 1 -type d | sort)
+  fi
+fi
+
+default_cli_parameters=""
+if [ "$default_logfile_used" -eq 1 ]; then
+  default_cli_parameters="logfile=$logfile"
+fi
+if [ "$default_suite_used" -eq 1 ]; then
+  if [ -n "$default_cli_parameters" ]; then
+    default_cli_parameters="$default_cli_parameters; "
+  fi
+  default_cli_parameters="${default_cli_parameters}-s quick"
+fi
+if [ "$default_testsuite_used" -eq 1 ]; then
+  if [ -n "$default_cli_parameters" ]; then
+    default_cli_parameters="$default_cli_parameters; "
+  fi
+  default_cli_parameters="${default_cli_parameters}-- src/0* src/1* src/5* src/6*"
 fi
 
 if [ "x$labels" != "x" ]; then
   echo "Limiting test cases to suite(s): $labels"
 fi
 
+echo "Starting CernVM-FS integration test run at $(date)"
+echo "Logging test output to $logfile"
+if [ -n "$SOURCE_GIT_REVISION" ]; then
+  echo "Running from git revision $SOURCE_GIT_REVISION"
+fi
+if [ -n "$default_cli_parameters" ]; then
+  echo "Defaulted CLI parameters for this run: $default_cli_parameters"
+fi
+
 # start running the tests
-TEST_ROOT=$(cd "$(dirname "$0")"; pwd)
+TEST_ROOT="$SCRIPT_DIR"
 export TEST_ROOT
 
 num_tests=0
@@ -359,6 +448,15 @@ format_status_entry() {
   format_status_entry_suffix "$status" "$timestamp" "$detail"
 }
 
+append_preview_skip_entry() {
+  local preview_var="$1"
+  local test_id="$2"
+  local preview_entry
+
+  preview_entry="$(format_status_entry "$test_id" "" "SKIP" "" "")"
+  printf -v "$preview_var" '%s%s\n' "${!preview_var}" "$preview_entry"
+}
+
 print_test_status() {
   local test_id="$1"
   local test_name="$2"
@@ -554,13 +652,13 @@ do
   TEST_DISPLAY_ID="$(test_display_id "$t")"
   if contains "$exclusions" $t; then
     preview_excluded_count=$((preview_excluded_count+1))
-    printf -v preview_excluded_entries '%s%s\n' "$preview_excluded_entries" "$TEST_DISPLAY_ID"
+    append_preview_skip_entry preview_excluded_entries "$TEST_DISPLAY_ID"
     continue
   fi
 
   if ! is_in_suite $t $labels; then
     preview_suite_skip_count=$((preview_suite_skip_count+1))
-    printf -v preview_suite_skip_entries '%s%s\n' "$preview_suite_skip_entries" "$TEST_DISPLAY_ID"
+    append_preview_skip_entry preview_suite_skip_entries "$TEST_DISPLAY_ID"
     continue
   fi
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -578,6 +578,7 @@ if [ "$preview_run_count" -gt 0 ] || [ "$preview_suite_skip_count" -gt 0 ] || [ 
   if [ "$preview_excluded_count" -gt 0 ]; then
     printf '%s\n' "$(format_section_heading "Excluded by -x ($preview_excluded_count):")"
     printf "%s" "$preview_excluded_entries"
+    printf "\n"
   fi
 fi
 


### PR DESCRIPTION
As discussed in https://github.com/cvmfs/cvmfs/pull/3923:

> This is opening a can of worms for sure :-) I agree that this printout should show the most relevant information in a way that catches the eye. For me that's actually the failing tests, and the return code they failed with, which can be added in a digest at the end. Then I think all of the skipped test could be similarly grouped in the beginning - we can do a first loop to find those.
> 
> It should be noted that these scripts originally intended for the test report to be generated from the JUnit xml, relying on Jenkins to do this. We could still use JUnit, but it should still work without additional dependencies when just invoking run.sh from bash.
> 
> One thing that would make sense to me is to generate CTest testcases for all the integration tests. That way running the tests becomes much more standard. However I also appreciate the flexibility that comes from having our own test runner script, so I would still keep run.sh.
> 
> So, back to the run.sh output. With this PR this goes from:
> 
> ```
> docker exec -u sftnight -t cvmfs-dev bash -c \
>     "cd /home/sftnight/cvmfs/test/common/container && CVMFS_TEST_PROXY=DIRECT bash test.sh"
>   shell: /usr/bin/bash -e {0}
> running CernVM-FS client test cases...
> Limiting test cases to suite(s): quick
> Testing Dummy test... OK
> Testing Check installation... OK
> Testing Probing atlas, lhcb... OK
> Testing Nested catalogs with same prefix... Skipped by suite restriction
> ...
> Testing Check changing CVMFS_CACHE_REFCOUNT between reloads... OK
> Testing Check that simultaneous mount attempts only mount the repository once... Skipped by exclusion
> Testing Browsing with the streaming cache manager... Skipped by exclusion
> 
> Tests:    107
> Skipped:  26
> Passed:   77
> Warnings: 4
> Failures: 0
> ```
> 
> To:
> 
> ```
>  docker exec -u sftnight -t cvmfs-dev bash -c \
>     "cd /home/sftnight/cvmfs/test/common/container && CVMFS_TEST_PROXY=DIRECT bash test.sh"
>   shell: /usr/bin/bash -e {0}
> running CernVM-FS client test cases...
> Limiting test cases to suite(s): quick
> Testing src/000-dummy Dummy test... OK
> Testing src/001-chksetup Check installation... OK
> Testing src/002-probe Probing atlas, lhcb... OK
> Testing src/003-nested Nested catalogs with same prefix... Skipped by suite restriction
> Testing src/004-davinci Setup Davinci... Skipped by suite restriction
> Testing src/005-asetup Setup ATLAS... Skipped by suite restriction
> ...
> Testing src/103-reloadcachemgr Check changing CVMFS_CACHE_REFCOUNT between reloads... OK
> Testing src/104-concurrent_mounts Check that simultaneous mount attempts only mount the repository once... Skipped by exclusion
> Testing src/105-streaming-cache Browsing with the streaming cache manager... Skipped by exclusion
> 
> Tests:    107
> Skipped:  26
> Passed:   78
> Warnings: 3
> Failures: 0
> ```
> 
> A very nice improvement for sure! I think the "src/" can be dropped, as github and any ide allows you to easily find the location of `105-streaming-cache`. I would also add some padding to make the OKs more visible, and print the time taken to complete the test. So it could look something like (imagine proper alignment):
> 
> ```
> Testing 001-chksetup   Check installation ............................. OK     in    125.3s
> Testing 002-probe         Probing atlas, lhcb ........................... OK      in     34.3s
> Testing 003-nested        Nested catalogs with same...  ........ Skipped by suite restriction
> ```



Now looks a bit like (but with richer formatting/colors):
```
./run.sh test.log -x src/007-testjobs --  src/00*

Limiting test cases to suite(s): quick
Starting CernVM-FS integration test run at Wed Mar 11 17:18:45 CET 2026
Logging test output to /tmp/cvmfs-test-logs/cvmfs-test-log-20260311-172130.log
Running from git revision 8571ddd7cfad

Selection preview:
Will run 9 tests.
Excluded by -x (1):
007-testjobs ........... SKIP

000-dummy .............. PASS |   0.1s
001-chksetup ........... PASS |   0.4s
002-probe .............. PASS |   1.2s
003-nested ............. PASS |   0.8s
004-davinci ............ WARN |  16.7s | memory limit exceeded
005-asetup ............. PASS |   8.1s
006-buildkernel ........ FAIL |   1.1s | retval 2
008-default_domain ..... PASS |   3.5s
009-tar ................ PASS | 349.8s

Tests:    10
Skipped:  1
Passed:   7
Warnings: 1
Failures: 1

took 6 minutes 30.392 seconds

Warnings / failures digest:
004-davinci ............ WARN |  16.7s | memory limit exceeded
006-buildkernel ........ FAIL |   1.1s | retval 2
```

Output with -s argument:

```
 ./run.sh test.log -s quick -x src/007-testjobs -- src/00*
Limiting test cases to suite(s): quick
Starting CernVM-FS integration test run at Fri Mar 13 13:17:12 CET 2026
Logging test output to /home/sftnight/cvmfs/test/test.log
Running from git revision 6626535d1bb1

Selection preview:
Will run 4 tests.
Excluded by suite (-s) (5):
003-nested ............. SKIP
004-davinci ............ SKIP
005-asetup ............. SKIP
006-buildkernel ........ SKIP
009-tar ................ SKIP
Excluded by -x (1):
007-testjobs ........... SKIP

000-dummy .............. PASS |   0.1s
001-chksetup ........... PASS |   0.3s
002-probe .............. PASS |   4.0s
008-default_domain ..... PASS |   9.9s

Tests:    10
Skipped:  6
Passed:   4
Warnings: 0
Failures: 0

took 18.220 seconds

All executed tests ran **successfully.**
```

Now also has sensible defaults when running ./run.sh without any arguments and a warning if its not run from the parent directory.

See also the output of the checks of this PR.