### PR TITLE
container: Less noise in unpacker logs

### DIFF
--- a/ducc/cmd/conversion_summary.go
+++ b/ducc/cmd/conversion_summary.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cvmfs/ducc/lib"
+	l "github.com/cvmfs/ducc/log"
+)
+
+func logConversionSummary(prefix string, summary lib.ConversionSummary) {
+	l.Log().Info(formatConversionSummary(prefix, summary))
+}
+
+func formatConversionSummary(prefix string, summary lib.ConversionSummary) string {
+	return fmt.Sprintf("%s\n  %s\n  %s\n  %s",
+		prefix,
+		formatConversionSummaryLine("Added", summary.Added),
+		formatConversionSummaryLine("Updated", summary.Updated),
+		formatConversionSummaryLine("Skipped", summary.Skipped),
+	)
+}
+
+func formatConversionSummaryLine(label string, images []string) string {
+	if len(images) == 0 {
+		return fmt.Sprintf("%s (0): none", label)
+	}
+	sortedImages := append([]string(nil), images...)
+	sort.Strings(sortedImages)
+	return fmt.Sprintf("%s (%d): %s", label, len(sortedImages), strings.Join(sortedImages, ", "))
+}

--- a/ducc/cmd/conversion_summary.go
+++ b/ducc/cmd/conversion_summary.go
@@ -1,32 +1,24 @@
 package cmd
 
 import (
-	"fmt"
 	"sort"
-	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/cvmfs/ducc/lib"
 	l "github.com/cvmfs/ducc/log"
 )
 
-func logConversionSummary(prefix string, summary lib.ConversionSummary) {
-	l.Log().Info(formatConversionSummary(prefix, summary))
+func sortedImageList(images []string) []string {
+	sorted := append([]string(nil), images...)
+	sort.Strings(sorted)
+	return sorted
 }
 
-func formatConversionSummary(prefix string, summary lib.ConversionSummary) string {
-	return fmt.Sprintf("%s\n  %s\n  %s\n  %s",
-		prefix,
-		formatConversionSummaryLine("Added", summary.Added),
-		formatConversionSummaryLine("Updated", summary.Updated),
-		formatConversionSummaryLine("AlreadyConverted", summary.AlreadyConverted),
-	)
-}
-
-func formatConversionSummaryLine(label string, images []string) string {
-	if len(images) == 0 {
-		return fmt.Sprintf("%s (0): none", label)
-	}
-	sortedImages := append([]string(nil), images...)
-	sort.Strings(sortedImages)
-	return fmt.Sprintf("%s (%d): %s", label, len(sortedImages), strings.Join(sortedImages, ", "))
+func logConversionSummary(message string, summary lib.ConversionSummary) {
+	l.Log().WithFields(log.Fields{
+		"added":             sortedImageList(summary.Added),
+		"updated":           sortedImageList(summary.Updated),
+		"already converted": sortedImageList(summary.AlreadyConverted),
+	}).Info(message)
 }

--- a/ducc/cmd/conversion_summary.go
+++ b/ducc/cmd/conversion_summary.go
@@ -18,7 +18,7 @@ func formatConversionSummary(prefix string, summary lib.ConversionSummary) strin
 		prefix,
 		formatConversionSummaryLine("Added", summary.Added),
 		formatConversionSummaryLine("Updated", summary.Updated),
-		formatConversionSummaryLine("Skipped", summary.Skipped),
+		formatConversionSummaryLine("AlreadyConverted", summary.AlreadyConverted),
 	)
 }
 

--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -121,6 +121,10 @@ var convertCmd = &cobra.Command{
 			os.Exit(1)
 		}()
 		defer signal.Stop(sigChan)
+		if !skipThinImage && recipe.OutputFormat == "" {
+			l.Log().Info("Using default output image name $(scheme)://$(registry)/$(repository)_thin:$(tag)")
+		}
+
 		var conversionErrors []string
 		totalSummary := lib.ConversionSummary{}
 		for wish := range recipe.Wishes {
@@ -140,6 +144,12 @@ var convertCmd = &cobra.Command{
 				} else {
 					l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
 					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+				}
+			} else {
+				if len(summary.Added) == 0 && len(summary.Updated) == 0 {
+					l.Log().WithFields(fields).Info("All layers already converted, nothing to do")
+				} else {
+					l.Log().WithFields(fields).Info("Successfully converted the layers")
 				}
 			}
 			if !skipThinImage {

--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -122,6 +122,7 @@ var convertCmd = &cobra.Command{
 		}()
 		defer signal.Stop(sigChan)
 		var conversionErrors []string
+		totalSummary := lib.ConversionSummary{}
 		for wish := range recipe.Wishes {
 			fields := log.Fields{"input image": wish.InputName,
 				"repository":   wish.CvmfsRepo,
@@ -131,7 +132,8 @@ var convertCmd = &cobra.Command{
 			// Check if this wish is in the ignore errors list
 			isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
 
-			err = lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
+			summary, err := lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
+			totalSummary.Merge(summary)
 			if err != nil {
 				if isIgnored {
 					l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
@@ -174,6 +176,7 @@ var convertCmd = &cobra.Command{
 				}
 			}
 		}
+		logConversionSummary("Conversion summary:", totalSummary)
 		if len(conversionErrors) > 0 {
 			summary := fmt.Sprintf("%d conversion error(s):\n  %s", len(conversionErrors), strings.Join(conversionErrors, "\n  "))
 			l.Log().Error(summary)

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -96,9 +96,11 @@ var convertSingleImageCmd = &cobra.Command{
 			"total attempts": attempts}
 
 		var conversionErrors []string
+		totalSummary := lib.ConversionSummary{}
 
 		for i := 0; i < attempts; i++ {
-			err = lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
+			attemptSummary, err := lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
+			totalSummary.Merge(attemptSummary)
 			log := l.LogE(err).WithFields(fields).
 				WithFields(log.Fields{"attempts number": i})
 			if err != nil {
@@ -112,6 +114,7 @@ var convertSingleImageCmd = &cobra.Command{
 			log.Error("Multiple Errors in converting layers, going on")
 			conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", err))
 		}
+		logConversionSummary(fmt.Sprintf("Conversion summary for %s:", wish.InputName), totalSummary)
 
 		if !skipFlat {
 			for i := 0; i < attempts; i++ {

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -51,8 +51,10 @@ var convertSingleImageCmd = &cobra.Command{
 			skipPodman = true
 		}
 		if thinImageName == "" {
-			l.Log().Info("Skipping the creation of the thin image since did not provided a name for the thin image using the --thin-image-name flag")
-			skipThinImage = true
+			if !skipThinImage {
+				l.Log().Trace("Skipping the creation of the thin image since no name was provided via --thin-image-name")
+				skipThinImage = true
+			}
 			// we need a thinImageName to parse the wish
 			thinImageName = inputImage + "_thin"
 		}

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -106,7 +106,11 @@ var convertSingleImageCmd = &cobra.Command{
 			if err != nil {
 				log.Warning("Could not convert wish (layers), trying again")
 			} else {
-				log.Info("Successfully converted the layers")
+				if len(totalSummary.Added) == 0 && len(totalSummary.Updated) == 0 {
+					log.Info("All layers already converted, nothing to do")
+				} else {
+					log.Info("Successfully converted the layers")
+				}
 				break
 			}
 		}

--- a/ducc/cmd/convert_test.go
+++ b/ducc/cmd/convert_test.go
@@ -80,7 +80,7 @@ func TestFormatConversionSummary(t *testing.T) {
 		"Conversion summary:",
 		"Added (2): a-image, z-image",
 		"Updated (1): updated-image",
-		"Skipped (0): none",
+		"AlreadyConverted (0): none",
 	}
 	for _, line := range expectedLines {
 		if !strings.Contains(formatted, line) {

--- a/ducc/cmd/convert_test.go
+++ b/ducc/cmd/convert_test.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"strings"
 	"testing"
-
-	"github.com/cvmfs/ducc/lib"
 )
 
 func TestIsInIgnoreList(t *testing.T) {
@@ -68,23 +65,30 @@ func TestIsInIgnoreList(t *testing.T) {
 	}
 }
 
-func TestFormatConversionSummary(t *testing.T) {
-	summary := lib.ConversionSummary{
-		Added:   []string{"z-image", "a-image"},
-		Updated: []string{"updated-image"},
+func TestSortedImageList(t *testing.T) {
+	result := sortedImageList([]string{"z-image", "a-image", "m-image"})
+	expected := []string{"a-image", "m-image", "z-image"}
+	if len(result) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, result)
 	}
-
-	formatted := formatConversionSummary("Conversion summary:", summary)
-
-	expectedLines := []string{
-		"Conversion summary:",
-		"Added (2): a-image, z-image",
-		"Updated (1): updated-image",
-		"AlreadyConverted (0): none",
-	}
-	for _, line := range expectedLines {
-		if !strings.Contains(formatted, line) {
-			t.Fatalf("expected formatted summary to contain %q, got %q", line, formatted)
+	for i, v := range expected {
+		if result[i] != v {
+			t.Fatalf("expected %v at index %d, got %v", v, i, result[i])
 		}
+	}
+}
+
+func TestSortedImageListEmpty(t *testing.T) {
+	result := sortedImageList([]string{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty slice, got %v", result)
+	}
+}
+
+func TestSortedImageListDoesNotMutateInput(t *testing.T) {
+	input := []string{"z-image", "a-image"}
+	_ = sortedImageList(input)
+	if input[0] != "z-image" {
+		t.Fatalf("sortedImageList mutated the input slice")
 	}
 }

--- a/ducc/cmd/convert_test.go
+++ b/ducc/cmd/convert_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/cvmfs/ducc/lib"
 )
 
 func TestIsInIgnoreList(t *testing.T) {
@@ -62,5 +65,26 @@ func TestIsInIgnoreList(t *testing.T) {
 				t.Errorf("isInIgnoreList(%q, %v) = %v, expected %v", tt.imageName, tt.ignoreList, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFormatConversionSummary(t *testing.T) {
+	summary := lib.ConversionSummary{
+		Added:   []string{"z-image", "a-image"},
+		Updated: []string{"updated-image"},
+	}
+
+	formatted := formatConversionSummary("Conversion summary:", summary)
+
+	expectedLines := []string{
+		"Conversion summary:",
+		"Added (2): a-image, z-image",
+		"Updated (1): updated-image",
+		"Skipped (0): none",
+	}
+	for _, line := range expectedLines {
+		if !strings.Contains(formatted, line) {
+			t.Fatalf("expected formatted summary to contain %q, got %q", line, formatted)
+		}
 	}
 }

--- a/ducc/cmd/loop.go
+++ b/ducc/cmd/loop.go
@@ -76,6 +76,7 @@ var loopCmd = &cobra.Command{
 				os.Exit(RepoNotExistsError)
 			}
 			var conversionErrors []string
+			iterationSummary := lib.ConversionSummary{}
 			for wish := range recipe.Wishes {
 				fields := log.Fields{"input image": wish.InputName,
 					"repository":   wish.CvmfsRepo,
@@ -85,7 +86,8 @@ var loopCmd = &cobra.Command{
 				// Check if this wish is in the ignore errors list
 				isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
 
-				err = lib.ConvertWish(wish, convertAgain, overwriteLayer, false, maxConcurrentDownloads)
+				summary, err := lib.ConvertWish(wish, convertAgain, overwriteLayer, false, maxConcurrentDownloads)
+				iterationSummary.Merge(summary)
 				if err != nil {
 					if isIgnored {
 						l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
@@ -129,6 +131,7 @@ var loopCmd = &cobra.Command{
 				}
 				checkQuitSignal()
 			}
+			logConversionSummary("Conversion summary for this iteration:", iterationSummary)
 			if len(conversionErrors) > 0 {
 				summary := fmt.Sprintf("%d conversion error(s) in this iteration:\n  %s", len(conversionErrors), strings.Join(conversionErrors, "\n  "))
 				l.Log().Error(summary)

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -25,26 +25,32 @@ import (
 // target: the path of the target in the normal FS, the thing to ingest
 // if no error is returned, we remove the target from the FS
 func PublishToCVMFS(CVMFSRepo string, path string, target string) (err error) {
+	return PublishToCVMFSWithLogger(nil, CVMFSRepo, path, target)
+}
+
+func PublishToCVMFSWithLogger(logger *log.Entry, CVMFSRepo string, path string, target string) (err error) {
+	logger = l.Ensure(logger)
+	opLogger := logger.WithFields(log.Fields{"target": target, "action": "ingesting"})
 	defer func() {
 		if err == nil {
-			l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Deleting temporary directory")
+			opLogger.Trace("Deleting temporary directory")
 			os.RemoveAll(target)
 		}
 	}()
-	l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Start ingesting")
+	opLogger.Trace("Start ingesting")
 
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	path = PrefixRepoSubdirOnce(CVMFSRepo, path)
 	path = filepath.Join("/", "cvmfs", repoName, path)
 
-	l.Log().WithFields(log.Fields{"target": target, "action": "ingesting"}).Info("Start transaction")
+	opLogger.Trace("Start transaction")
 
-	err = WithinTransaction(CVMFSRepo, func() error {
-		l.Log().WithFields(log.Fields{"target": target, "path": path, "action": "ingesting"}).Info("Copying target into path")
+	err = WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
+		opLogger.WithField("path", path).Trace("Copying target into path")
 
 		targetStat, err := os.Stat(target)
 		if err != nil {
-			l.LogE(err).WithFields(log.Fields{"target": target}).Error("Impossible to obtain information about the target")
+			opLogger.WithField("error", err).Error("Impossible to obtain information about the target")
 			return err
 		}
 
@@ -52,7 +58,7 @@ func PublishToCVMFS(CVMFSRepo string, path string, target string) (err error) {
 			os.RemoveAll(path)
 			err = os.MkdirAll(path, constants.DirPermision)
 			if err != nil {
-				l.LogE(err).WithFields(log.Fields{"repo": CVMFSRepo}).Warning("Error in creating the directory where to copy the singularity")
+				opLogger.WithFields(log.Fields{"repo": CVMFSRepo, "error": err}).Warning("Error in creating the directory where to copy the singularity")
 			}
 			err = copy.Copy(target, path, copy.Options{PreserveTimes: true})
 
@@ -81,7 +87,7 @@ func PublishToCVMFS(CVMFSRepo string, path string, target string) (err error) {
 		}
 
 		if err != nil {
-			l.LogE(err).WithFields(log.Fields{"repo": CVMFSRepo, "target": target}).Error("Error in moving the target inside the CVMFS repo")
+			opLogger.WithFields(log.Fields{"repo": CVMFSRepo, "error": err}).Error("Error in moving the target inside the CVMFS repo")
 			return err
 		}
 		return nil
@@ -94,12 +100,17 @@ func PublishToCVMFS(CVMFSRepo string, path string, target string) (err error) {
 // newLinkName: comes without the /cvmfs/$REPO/ prefix
 // toLinkPath: comes without the /cvmfs/$REPO/ prefix
 func CreateSymlinkIntoCVMFS(CVMFSRepo, newLinkName, toLinkPath string) (err error) {
+	return CreateSymlinkIntoCVMFSWithLogger(nil, CVMFSRepo, newLinkName, toLinkPath)
+}
+
+func CreateSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLinkName, toLinkPath string) (err error) {
+	logger = l.Ensure(logger)
 	// add the necessary prefix
 	newLinkName = filepath.Join("/", "cvmfs", CVMFSRepo, newLinkName)
 	toLinkPath = filepath.Join("/", "cvmfs", CVMFSRepo, toLinkPath)
 
-	llog := func(l *log.Entry) *log.Entry {
-		return l.WithFields(log.Fields{"action": "save backlink",
+	llog := func(entry *log.Entry) *log.Entry {
+		return l.Ensure(entry).WithFields(log.Fields{"action": "create symlink",
 			"repo":           CVMFSRepo,
 			"link name":      newLinkName,
 			"target to link": toLinkPath})
@@ -120,7 +131,7 @@ func CreateSymlinkIntoCVMFS(CVMFSRepo, newLinkName, toLinkPath string) (err erro
 	linkChunks := strings.Split(relativePath, string(os.PathSeparator))
 	link := filepath.Join(linkChunks[1:]...)
 
-	err = WithinTransaction(CVMFSRepo, func() error {
+	err = WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
 		linkDir := filepath.Dir(newLinkName)
 		err = os.MkdirAll(linkDir, constants.DirPermision)
 		if err != nil {
@@ -213,12 +224,16 @@ func GetBacklinkFromLayer(CVMFSRepo, layerDigest string) (backlink Backlink, err
 }
 
 func SaveLayersBacklink(CVMFSRepo string, imgManifest da.Manifest, layerDigest []string) error {
-	llog := func(l *log.Entry) *log.Entry {
-		return l.WithFields(log.Fields{"action": "save backlink",
+	return SaveLayersBacklinkWithLogger(nil, CVMFSRepo, imgManifest, layerDigest)
+}
+
+func SaveLayersBacklinkWithLogger(logger *log.Entry, CVMFSRepo string, imgManifest da.Manifest, layerDigest []string) error {
+	llog := func(entry *log.Entry) *log.Entry {
+		return l.Ensure(entry).WithFields(log.Fields{"action": "save backlink",
 			"repo": CVMFSRepo})
 	}
 
-	llog(l.Log()).Info("Start saving backlinks")
+	llog(logger).Trace("Start saving backlinks")
 
 	backlinks := make(map[string][]byte)
 
@@ -244,8 +259,8 @@ func SaveLayersBacklink(CVMFSRepo string, imgManifest da.Manifest, layerDigest [
 		backlinks[backlinkPath] = backlinkBytesMarshal
 	}
 
-	llog(l.Log()).Info("Start transaction")
-	err := WithinTransaction(CVMFSRepo, func() error {
+	llog(logger).Trace("Start transaction")
+	err := WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
 
 		for path, fileContent := range backlinks {
 			// the path may not be there, check,
@@ -266,7 +281,7 @@ func SaveLayersBacklink(CVMFSRepo string, imgManifest da.Manifest, layerDigest [
 					"Error in writing the backlink file, skipping...")
 				continue
 			}
-			llog(l.LogE(err)).WithFields(log.Fields{"file": path}).Info(
+			llog(logger).WithFields(log.Fields{"file": path}).Trace(
 				"Wrote backlink")
 		}
 		return nil
@@ -280,9 +295,13 @@ func RemoveScheduleLocation(CVMFSRepo string) string {
 }
 
 func AddManifestToRemoveScheduler(CVMFSRepo string, manifest da.Manifest) error {
+	return AddManifestToRemoveSchedulerWithLogger(nil, CVMFSRepo, manifest)
+}
+
+func AddManifestToRemoveSchedulerWithLogger(logger *log.Entry, CVMFSRepo string, manifest da.Manifest) error {
 	schedulePath := RemoveScheduleLocation(CVMFSRepo)
-	llog := func(l *log.Entry) *log.Entry {
-		return l.WithFields(log.Fields{
+	llog := func(entry *log.Entry) *log.Entry {
+		return l.Ensure(entry).WithFields(log.Fields{
 			"action": "add manifest to remove schedule",
 			"file":   schedulePath})
 	}
@@ -326,7 +345,7 @@ func AddManifestToRemoveScheduler(CVMFSRepo string, manifest da.Manifest) error 
 		return schedule
 	}()
 
-	err := WithinTransaction(CVMFSRepo, func() error {
+	err := WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
 		if _, err := os.Stat(schedulePath); os.IsNotExist(err) {
 			err = os.MkdirAll(filepath.Dir(schedulePath), constants.DirPermision)
 			if err != nil {
@@ -343,7 +362,7 @@ func AddManifestToRemoveScheduler(CVMFSRepo string, manifest da.Manifest) error 
 			if err != nil {
 				llog(l.LogE(err)).Error("Error in writing the new schedule")
 			} else {
-				llog(l.Log()).Info("Wrote new remove schedule")
+				llog(logger).Trace("Wrote new remove schedule")
 			}
 		}
 		return nil
@@ -397,13 +416,18 @@ func RemoveLayer(CVMFSRepo, layerDigest string) error {
 }
 
 func RemoveDirectory(CVMFSRepo string, dirPath ...string) error {
+	return RemoveDirectoryWithLogger(nil, CVMFSRepo, dirPath...)
+}
+
+func RemoveDirectoryWithLogger(logger *log.Entry, CVMFSRepo string, dirPath ...string) error {
+	logger = l.Ensure(logger)
 	path := []string{"/cvmfs", CVMFSRepo}
 	for _, p := range dirPath {
 		path = append(path, p)
 	}
 	directory := filepath.Join(path...)
-	llog := func(l *log.Entry) *log.Entry {
-		return l.WithFields(log.Fields{
+	llog := func(entry *log.Entry) *log.Entry {
+		return l.Ensure(entry).WithFields(log.Fields{
 			"action": "removing directory", "directory": directory})
 	}
 	stat, err := os.Stat(directory)
@@ -427,7 +451,7 @@ func RemoveDirectory(CVMFSRepo string, dirPath ...string) error {
 		llog(l.LogE(err)).Error("Error in opening the transaction")
 		return err
 	}
-	err = WithinTransaction(CVMFSRepo, func() error {
+	err = WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
 		err := os.RemoveAll(directory)
 		if err != nil {
 			llog(l.LogE(err)).Error("Error in publishing after adding the backlinks")
@@ -439,6 +463,10 @@ func RemoveDirectory(CVMFSRepo string, dirPath ...string) error {
 }
 
 func CreateCatalogIntoDir(CVMFSRepo, dir string) (err error) {
+	return CreateCatalogIntoDirWithLogger(nil, CVMFSRepo, dir)
+}
+
+func CreateCatalogIntoDirWithLogger(logger *log.Entry, CVMFSRepo, dir string) (err error) {
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	normalizedDir := PrefixRepoSubdirOnce(CVMFSRepo, dir)
 	catalogRelativePath := filepath.Join(normalizedDir, ".cvmfscatalog")
@@ -451,7 +479,7 @@ func CreateCatalogIntoDir(CVMFSRepo, dir string) (err error) {
 		if err := tmpFile.Close(); err != nil {
 			return err
 		}
-		err = PublishToCVMFS(repoName, catalogRelativePath, tmpFile.Name())
+		err = PublishToCVMFSWithLogger(logger, repoName, catalogRelativePath, tmpFile.Name())
 		if err != nil {
 			return err
 		}
@@ -462,23 +490,28 @@ func CreateCatalogIntoDir(CVMFSRepo, dir string) (err error) {
 
 // writes data to file and publish in cvmfs repo path
 func WriteDataToCvmfs(CVMFSRepo, path string, data []byte) (err error) {
+	return WriteDataToCvmfsWithLogger(nil, CVMFSRepo, path, data)
+}
+
+func WriteDataToCvmfsWithLogger(logger *log.Entry, CVMFSRepo, path string, data []byte) (err error) {
+	logger = l.Ensure(logger)
 	tmpFile, err := temp.UserDefinedTempFile()
 	if err != nil {
-		l.LogE(err).Error("Error in creating temporary file for writing data")
+		logger.WithField("error", err).Error("Error in creating temporary file for writing data")
 		return err
 	}
 	defer os.RemoveAll(tmpFile.Name())
 	err = ioutil.WriteFile(tmpFile.Name(), data, 0644)
 	if err != nil {
-		l.LogE(err).Error("Error in writing data to file")
+		logger.WithField("error", err).Error("Error in writing data to file")
 		return err
 	}
 	err = tmpFile.Close()
 	if err != nil {
-		l.LogE(err).Error("Error in closing temporary file")
+		logger.WithField("error", err).Error("Error in closing temporary file")
 		return err
 	}
-	return PublishToCVMFS(CVMFSRepo, path, tmpFile.Name())
+	return PublishToCVMFSWithLogger(logger, CVMFSRepo, path, tmpFile.Name())
 }
 
 func removeHashMarkerIfPresent(digest string) string {
@@ -494,14 +527,19 @@ func removeHashMarkerIfPresent(digest string) string {
 // order (base layer first). The destPath is the path inside the CVMFS repository
 // where the merged result will be placed (without the /cvmfs/$REPO prefix).
 func Overlay(CVMFSRepo string, layerPaths []string, destPath string) error {
+	return OverlayWithLogger(nil, CVMFSRepo, layerPaths, destPath)
+}
+
+func OverlayWithLogger(logger *log.Entry, CVMFSRepo string, layerPaths []string, destPath string) error {
+	logger = l.Ensure(logger)
 	if len(layerPaths) == 0 {
 		return fmt.Errorf("no layer paths provided for overlay")
 	}
 
 	layers := strings.Join(layerPaths, ",")
 
-	llog := func(ll *log.Entry) *log.Entry {
-		return ll.WithFields(log.Fields{
+	llog := func(entry *log.Entry) *log.Entry {
+		return l.Ensure(entry).WithFields(log.Fields{
 			"action": "overlay",
 			"repo":   CVMFSRepo,
 			"layers": layers,
@@ -509,7 +547,7 @@ func Overlay(CVMFSRepo string, layerPaths []string, destPath string) error {
 		})
 	}
 
-	llog(l.Log()).Info("Starting overlay merge")
+	llog(logger).Trace("Starting overlay merge")
 
 	getLock(CVMFSRepo)
 	defer unlock(CVMFSRepo)
@@ -519,12 +557,12 @@ func Overlay(CVMFSRepo string, layerPaths []string, destPath string) error {
 		"-d", destPath,
 		CVMFSRepo}
 
-	err := exec.ExecCommand(args...).Start()
+	err := exec.ExecCommandWithLogger(llog(logger), args...).Start()
 	if err != nil {
 		llog(l.LogE(err)).Error("Error in overlay merge")
 		return err
 	}
 
-	llog(l.Log()).Info("Overlay merge complete")
+	llog(logger).Trace("Overlay merge complete")
 	return nil
 }

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -83,6 +83,12 @@ func unlock(CVMFSRepo string) {
 }
 
 func ExecuteAndOpenTransaction(CVMFSRepo string, f func() error, options ...TransactionOption) error {
+	return ExecuteAndOpenTransactionWithLogger(nil, CVMFSRepo, f, options...)
+}
+
+func ExecuteAndOpenTransactionWithLogger(logger *log.Entry, CVMFSRepo string, f func() error, options ...TransactionOption) error {
+	logger = l.Ensure(logger)
+	transactionLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "transaction"})
 	cmd := []string{"cvmfs_server", "transaction"}
 	for _, opt := range options {
 		cmd = append(cmd, opt.ToString())
@@ -93,53 +99,66 @@ func ExecuteAndOpenTransaction(CVMFSRepo string, f func() error, options ...Tran
 		unlock(CVMFSRepo)
 		return err
 	}
-	err := exec.ExecCommand(cmd...).Start()
+	err := exec.ExecCommandWithLogger(transactionLogger, cmd...).Start()
 	if err != nil {
-		l.LogE(err).WithFields(
-			log.Fields{"repo": CVMFSRepo}).
-			Error("Error in opening the transaction")
-		Abort(CVMFSRepo)
+		transactionLogger.WithField("error", err).Error("Error in opening the transaction")
+		AbortWithLogger(logger, CVMFSRepo)
 	}
 	return err
 
 }
 
 func OpenTransaction(CVMFSRepo string, options ...TransactionOption) error {
-	return ExecuteAndOpenTransaction(CVMFSRepo, func() error { return nil }, options...)
+	return OpenTransactionWithLogger(nil, CVMFSRepo, options...)
+}
+
+func OpenTransactionWithLogger(logger *log.Entry, CVMFSRepo string, options ...TransactionOption) error {
+	return ExecuteAndOpenTransactionWithLogger(logger, CVMFSRepo, func() error { return nil }, options...)
 }
 
 func Publish(CVMFSRepo string) error {
+	return PublishWithLogger(nil, CVMFSRepo)
+}
+
+func PublishWithLogger(logger *log.Entry, CVMFSRepo string) error {
+	logger = l.Ensure(logger)
+	publishLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "publish"})
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	defer unlock(CVMFSRepo)
-	err := exec.ExecCommand("cvmfs_server", "publish", repoName).Start()
+	err := exec.ExecCommandWithLogger(publishLogger, "cvmfs_server", "publish", repoName).Start()
 	if err != nil {
-		l.LogE(err).WithFields(
-			log.Fields{"repo": CVMFSRepo}).
-			Error("Error in publishing the repository")
-		abort(CVMFSRepo)
+		publishLogger.WithField("error", err).Error("Error in publishing the repository")
+		abortWithLogger(logger, CVMFSRepo)
 		return err
 	}
 
-	l.LogE(err).WithFields(
-		log.Fields{"repo": CVMFSRepo}).
-		Info("Publish complete")
+	publishLogger.Trace("Publish complete")
 	return nil
 }
 
 func Abort(CVMFSRepo string) error {
+	return AbortWithLogger(nil, CVMFSRepo)
+}
+
+func AbortWithLogger(logger *log.Entry, CVMFSRepo string) error {
 	defer unlock(CVMFSRepo)
-	err := abort(CVMFSRepo)
+	err := abortWithLogger(logger, CVMFSRepo)
 	if err != nil {
-		l.LogE(err).WithFields(
-			log.Fields{"repo": CVMFSRepo}).
+		l.Ensure(logger).WithFields(log.Fields{"repo": CVMFSRepo, "action": "abort", "error": err}).
 			Error("Error in abort the transaction")
 	}
 	return err
 }
 
 func abort(CVMFSRepo string) error {
+	return abortWithLogger(nil, CVMFSRepo)
+}
+
+func abortWithLogger(logger *log.Entry, CVMFSRepo string) error {
+	logger = l.Ensure(logger)
+	abortLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "abort"})
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
-	return exec.ExecCommand("cvmfs_server", "abort", "-f", repoName).Start()
+	return exec.ExecCommandWithLogger(abortLogger, "cvmfs_server", "abort", "-f", repoName).Start()
 }
 
 func RepositoryExists(CVMFSRepo string) bool {
@@ -185,18 +204,28 @@ func repositoryExistsInList(stdoutString, repo string) bool {
 }
 
 func WithinTransaction(CVMFSRepo string, f func() error, opts ...TransactionOption) error {
-	err := OpenTransaction(CVMFSRepo, opts...)
+	return WithinTransactionWithLogger(nil, CVMFSRepo, f, opts...)
+}
+
+func WithinTransactionWithLogger(logger *log.Entry, CVMFSRepo string, f func() error, opts ...TransactionOption) error {
+	err := OpenTransactionWithLogger(logger, CVMFSRepo, opts...)
 	if err != nil {
 		return err
 	}
 	err = f()
 	if err != nil {
-		return Abort(CVMFSRepo)
+		return AbortWithLogger(logger, CVMFSRepo)
 	}
-	return Publish(CVMFSRepo)
+	return PublishWithLogger(logger, CVMFSRepo)
 }
 
 func Ingest(CVMFSRepo string, input io.ReadCloser, options ...string) error {
+	return IngestWithLogger(nil, CVMFSRepo, input, options...)
+}
+
+func IngestWithLogger(logger *log.Entry, CVMFSRepo string, input io.ReadCloser, options ...string) error {
+	logger = l.Ensure(logger)
+	ingestLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "ingest"})
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	cmd := []string{"cvmfs_server", "ingest"}
 	for _, opt := range options {
@@ -205,13 +234,19 @@ func Ingest(CVMFSRepo string, input io.ReadCloser, options ...string) error {
 	cmd = append(cmd, repoName)
 	getLock(CVMFSRepo)
 	defer unlock(CVMFSRepo)
-	return exec.ExecCommand(cmd...).StdIn(input).Start()
+	return exec.ExecCommandWithLogger(ingestLogger, cmd...).StdIn(input).Start()
 }
 
 func IngestDelete(CVMFSRepo string, path string) error {
+	return IngestDeleteWithLogger(nil, CVMFSRepo, path)
+}
+
+func IngestDeleteWithLogger(logger *log.Entry, CVMFSRepo string, path string) error {
+	logger = l.Ensure(logger)
+	ingestLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "ingest delete", "path": path})
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	path = PrefixRepoSubdirOnce(CVMFSRepo, path)
 	getLock(CVMFSRepo)
 	defer unlock(CVMFSRepo)
-	return exec.ExecCommand("cvmfs_server", "ingest", "--delete", path, repoName).Start()
+	return exec.ExecCommandWithLogger(ingestLogger, "cvmfs_server", "ingest", "--delete", path, repoName).Start()
 }

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -65,7 +65,7 @@ func getLock(CVMFSRepo string) {
 		// this may happen if the kernel detect a deadlock
 		// it should never happen in our case, (of a single global lock)
 		// but still we can protect against it
-		l.LogE(err).Info("Error in getting the FS lock")
+		l.LogE(err).Warning("Error in getting the FS lock")
 		time.Sleep(100 * time.Millisecond)
 		err = f.LockWriteB()
 	}

--- a/ducc/exec/exec.go
+++ b/ducc/exec/exec.go
@@ -16,28 +16,34 @@ type execCmd struct {
 	out   io.ReadCloser
 	in    io.WriteCloser
 	stdin *io.ReadCloser
+	log   *log.Entry
 }
 
 func ExecCommand(input ...string) *execCmd {
-	l.Log().WithFields(log.Fields{"action": "executing"}).Info(input)
+	return ExecCommandWithLogger(nil, input...)
+}
+
+func ExecCommandWithLogger(logger *log.Entry, input ...string) *execCmd {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "executing", "command": input}).Trace("Running command")
 	cmd := exec.Command(input[0], input[1:]...)
 	stdout, errOUT := cmd.StdoutPipe()
 	if errOUT != nil {
-		l.LogE(errOUT).Warning("Impossible to obtain the STDOUT pipe")
+		logger.WithField("error", errOUT).Warning("Impossible to obtain the STDOUT pipe")
 		return nil
 	}
 	stderr, errERR := cmd.StderrPipe()
 	if errERR != nil {
-		l.LogE(errERR).Warning("Impossible to obtain the STDERR pipe")
+		logger.WithField("error", errERR).Warning("Impossible to obtain the STDERR pipe")
 		return nil
 	}
 	stdin, errERR := cmd.StdinPipe()
 	if errERR != nil {
-		l.LogE(errERR).Warning("Impossible to obtain the STDIN pipe")
+		logger.WithField("error", errERR).Warning("Impossible to obtain the STDIN pipe")
 		return nil
 	}
 
-	return &execCmd{cmd: cmd, err: stderr, out: stdout, in: stdin}
+	return &execCmd{cmd: cmd, err: stderr, out: stdout, in: stdin, log: logger}
 }
 
 func (e *execCmd) StdIn(input io.ReadCloser) *execCmd {
@@ -61,19 +67,20 @@ func (e *execCmd) StdOut() io.ReadCloser {
 }
 
 func (e *execCmd) StartWithOutput() (error, bytes.Buffer, bytes.Buffer) {
-	var outb, errb bytes.Buffer
-	e.cmd.Stdout = &outb
-	e.cmd.Stderr = &errb
-
 	if e == nil {
 		err := fmt.Errorf("Use of nil execCmd")
 		l.LogE(err).Error("Call start with nil cmd, maybe error in the constructor")
-		return err, outb, errb
+		return err, bytes.Buffer{}, bytes.Buffer{}
 	}
+
+	var outb, errb bytes.Buffer
+	e.cmd.Stdout = &outb
+	e.cmd.Stderr = &errb
+	logger := l.Ensure(e.log)
 
 	err := e.cmd.Start()
 	if err != nil {
-		l.LogE(err).Error("Error in starting the command")
+		logger.WithField("error", err).Error("Error in starting the command")
 		return err, outb, errb
 	}
 
@@ -82,18 +89,18 @@ func (e *execCmd) StartWithOutput() (error, bytes.Buffer, bytes.Buffer) {
 			defer (*e.stdin).Close()
 			defer e.in.Close()
 			n, err := io.Copy(e.in, *e.stdin)
-			l.Log().WithFields(log.Fields{"n": n}).Info("Copied n bytes to STDIN")
+			logger.WithFields(log.Fields{"n": n}).Trace("Copied n bytes to STDIN")
 			if err != nil {
-				l.LogE(err).Error("Error in copying the input into STDIN.")
+				logger.WithField("error", err).Error("Error in copying the input into STDIN.")
 				return
 			}
 			for n > 0 {
 				n, err = io.Copy(e.in, *e.stdin)
 				if err != nil {
-					l.LogE(err).Error("Error in copying the input into STDIN")
+					logger.WithField("error", err).Error("Error in copying the input into STDIN")
 					return
 				}
-				l.Log().WithFields(log.Fields{"n": n}).Info("Copied additionally n bytes to STDIN")
+				logger.WithFields(log.Fields{"n": n}).Trace("Copied additionally n bytes to STDIN")
 			}
 		}()
 	}
@@ -103,12 +110,13 @@ func (e *execCmd) StartWithOutput() (error, bytes.Buffer, bytes.Buffer) {
 
 func (e *execCmd) Start() error {
 	err, stdout, stderr := e.StartWithOutput()
+	logger := l.Ensure(e.log)
 	if err == nil {
 		return nil
 	} else {
-		l.LogE(err).Error("Error in executing the command")
-		l.Log().WithFields(log.Fields{"pipe": "STDOUT"}).Info(string(stdout.Bytes()))
-		l.Log().WithFields(log.Fields{"pipe": "STDERR"}).Info(string(stderr.Bytes()))
+		logger.WithField("error", err).Error("Error in executing the command")
+		logger.WithFields(log.Fields{"pipe": "STDOUT"}).Trace(string(stdout.Bytes()))
+		logger.WithFields(log.Fields{"pipe": "STDERR"}).Trace(string(stderr.Bytes()))
 		return err
 	}
 }

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -567,6 +567,9 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 				noErrors = false
 			}
 			if err == nil {
+				layerLogger.WithFields(log.Fields{
+					"duration": time.Since(t1).Round(time.Millisecond),
+				}).Info("Layer ingest into CVMFS finished")
 				n.Action("publish_layer").AddField("layer_digest", layerDigest).Send()
 			}
 			layerLogger.Trace("Finished ingesting the file")

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -552,7 +552,7 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 			layerDigest := strings.Split(layer.Name, ":")[1]
 			layerLogger := logger.WithField("layer", layer.Name)
 
-			layerLogger.Trace("Start ingesting the file into CVMFS")
+			layerLogger.Info("Start ingesting layer into CVMFS")
 
 			ln := n.AddField("layer", layerDigest).AddId()
 			ln.Action("start_layer_conversion").Send()

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -522,8 +522,8 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 		layersToConvert = append(layersToConvert, shortDigest)
 	}
 	logger.WithFields(log.Fields{
-		"layers to convert":    layersToConvert,
-		"already converted":    layersAlreadyConverted,
+		"layers to convert": layersToConvert,
+		"already converted": layersAlreadyConverted,
 	}).Info("Starting layer conversion")
 
 	if alreadyConverted == ConversionMatch {

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -495,6 +495,33 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 		}
 	}
 
+	// Classify layers into those already present in CVMFS and those that need
+	// to be downloaded and ingested, mirroring the forceDownload logic in
+	// GetLayersWithLogger so the message accurately reflects what will happen.
+	var layersToConvert, layersPresent []string
+	for _, layer := range manifest.Layers {
+		if layer.MediaType == "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip" {
+			continue
+		}
+		digest := strings.Split(layer.Digest, ":")[1]
+		shortDigest := digest
+		if len(shortDigest) > 12 {
+			shortDigest = shortDigest[:12]
+		}
+		layerPath := cvmfs.LayerRootfsPath(repo, digest)
+		if !forceDownload {
+			if _, statErr := os.Stat(layerPath); statErr == nil {
+				layersPresent = append(layersPresent, shortDigest)
+				continue
+			}
+		}
+		layersToConvert = append(layersToConvert, shortDigest)
+	}
+	logger.WithFields(log.Fields{
+		"layers to convert": layersToConvert,
+		"layers present":    layersPresent,
+	}).Info("Starting layer conversion")
+
 	layersChanell := make(chan downloadedLayer, 10)
 	manifestChanell := make(chan string, 1)
 	stopGettingLayers := make(chan bool, 1)

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -569,6 +569,7 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 			if err == nil {
 				layerLogger.WithFields(log.Fields{
 					"duration": time.Since(t1).Round(time.Millisecond),
+					"size":     fmt.Sprintf("%.1f MB", float64(layer.GetSize())/1e6),
 				}).Info("Layer ingest into CVMFS finished")
 				n.Action("publish_layer").AddField("layer_digest", layerDigest).Send()
 			}

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -235,6 +235,10 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 					}
 				}
 				if err == nil {
+					imageLogger.WithFields(log.Fields{
+						"flat path":    completeSingularityPriPath,
+						"symlink path": completePubSymPath,
+					}).Info("Updated flat image symlink")
 					n.Action("publish_flat_image").AddField("public_path", publicSymlinkPath).AddField("private_path", singularityPrivatePath).Send()
 				}
 				continue
@@ -255,6 +259,10 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 					}
 				}
 				if err == nil {
+					imageLogger.WithFields(log.Fields{
+						"flat path":    completeSingularityPriPath,
+						"symlink path": completePubSymPath,
+					}).Info("Created flat image symlink")
 					n.Action("publish_flat_image").AddField("public_path", publicSymlinkPath).AddField("private_path", singularityPrivatePath).Send()
 				}
 				continue
@@ -327,6 +335,10 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			}
 			i.Error(err).Elapsed(t1).Send()
 			if err == nil {
+				imageLogger.WithFields(log.Fields{
+					"flat path":    completeSingularityPriPath,
+					"symlink path": completePubSymPath,
+				}).Info("Created flat image and symlink")
 				n.Action("publish_flat_image").AddField("public_path", publicSymlinkPath).AddField("private_path", singularityPrivatePath).Send()
 			}
 			continue

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -40,9 +40,9 @@ const (
 const ConversionUnknown ConversionResult = -1
 
 type ConversionSummary struct {
-	Added   []string
-	Updated []string
-	Skipped []string
+	Added            []string
+	Updated          []string
+	AlreadyConverted []string
 }
 
 func removeImage(images []string, image string) []string {
@@ -80,19 +80,19 @@ func (s *ConversionSummary) Add(result ConversionResult, image string) {
 	switch result {
 	case ConversionNotFound:
 		s.Updated = removeImage(s.Updated, image)
-		s.Skipped = removeImage(s.Skipped, image)
+		s.AlreadyConverted = removeImage(s.AlreadyConverted, image)
 		s.addUnique(&s.Added, image)
 	case ConversionNotMatch:
 		if containsImage(s.Added, image) {
 			return
 		}
-		s.Skipped = removeImage(s.Skipped, image)
+		s.AlreadyConverted = removeImage(s.AlreadyConverted, image)
 		s.addUnique(&s.Updated, image)
 	case ConversionMatch:
 		if containsImage(s.Added, image) || containsImage(s.Updated, image) {
 			return
 		}
-		s.addUnique(&s.Skipped, image)
+		s.addUnique(&s.AlreadyConverted, image)
 	}
 }
 
@@ -103,7 +103,7 @@ func (s *ConversionSummary) Merge(other ConversionSummary) {
 	for _, image := range other.Updated {
 		s.Add(ConversionNotMatch, image)
 	}
-	for _, image := range other.Skipped {
+	for _, image := range other.AlreadyConverted {
 		s.Add(ConversionMatch, image)
 	}
 }

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -37,6 +37,100 @@ const (
 	ConversionNotMatch = iota
 )
 
+const ConversionUnknown ConversionResult = -1
+
+type ConversionSummary struct {
+	Added   []string
+	Updated []string
+	Skipped []string
+}
+
+func removeImage(images []string, image string) []string {
+	filtered := images[:0]
+	for _, existing := range images {
+		if existing != image {
+			filtered = append(filtered, existing)
+		}
+	}
+	return filtered
+}
+
+func containsImage(images []string, image string) bool {
+	for _, existing := range images {
+		if existing == image {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ConversionSummary) addUnique(dst *[]string, image string) {
+	if image == "" {
+		return
+	}
+	for _, existing := range *dst {
+		if existing == image {
+			return
+		}
+	}
+	*dst = append(*dst, image)
+}
+
+func (s *ConversionSummary) Add(result ConversionResult, image string) {
+	switch result {
+	case ConversionNotFound:
+		s.Updated = removeImage(s.Updated, image)
+		s.Skipped = removeImage(s.Skipped, image)
+		s.addUnique(&s.Added, image)
+	case ConversionNotMatch:
+		if containsImage(s.Added, image) {
+			return
+		}
+		s.Skipped = removeImage(s.Skipped, image)
+		s.addUnique(&s.Updated, image)
+	case ConversionMatch:
+		if containsImage(s.Added, image) || containsImage(s.Updated, image) {
+			return
+		}
+		s.addUnique(&s.Skipped, image)
+	}
+}
+
+func (s *ConversionSummary) Merge(other ConversionSummary) {
+	for _, image := range other.Added {
+		s.Add(ConversionNotFound, image)
+	}
+	for _, image := range other.Updated {
+		s.Add(ConversionNotMatch, image)
+	}
+	for _, image := range other.Skipped {
+		s.Add(ConversionMatch, image)
+	}
+}
+
+func platformLabel(manifestEntry da.ManifestListItem) string {
+	parts := []string{}
+	if manifestEntry.Platform.OS != "" {
+		parts = append(parts, manifestEntry.Platform.OS)
+	}
+	if manifestEntry.Platform.Architecture != "" {
+		parts = append(parts, manifestEntry.Platform.Architecture)
+	}
+	if manifestEntry.Platform.Variant != nil && *manifestEntry.Platform.Variant != "" {
+		parts = append(parts, *manifestEntry.Platform.Variant)
+	}
+	return strings.Join(parts, "/")
+}
+
+func imageNameWithPlatform(inputImage *Image, manifestEntry da.ManifestListItem) string {
+	imageName := inputImage.GetSimpleName()
+	platform := platformLabel(manifestEntry)
+	if platform == "" {
+		return imageName
+	}
+	return fmt.Sprintf("%s (%s)", imageName, platform)
+}
+
 func GetNameWithArch(manifestEntry da.ManifestListItem) (nameWithArch string) {
 	if manifestEntry.Platform.Architecture == "" {
 		return ""
@@ -85,7 +179,7 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 	for _, inputImage := range wish.ExpandedTagImagesFlat {
 		manifestList, err := inputImage.GetManifestList()
 		if err != nil {
-			l.LogE(err).Error("Error in getting the manifest list")
+			l.WithImageE(err, inputImage.GetSimpleName()).Error("Error in getting the manifest list")
 			if firstError == nil {
 				firstError = err
 			}
@@ -97,6 +191,7 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			if multiArch {
 				nameWithArch = GetNameWithArch(manifestEntry)
 			}
+			imageLogger := l.WithImage(imageNameWithPlatform(inputImage, manifestEntry))
 			publicSymlinkPath := inputImage.GetPublicSymlinkPathWithArch(nameWithArch)
 			completePubSymPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, publicSymlinkPath)
 			pubDirInfo, errPub := os.Stat(completePubSymPath)
@@ -111,29 +206,28 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			completeSingularityPriPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, singularityPrivatePath)
 			priDirInfo, errPri := os.Stat(completeSingularityPriPath)
 
-			l.Log().WithFields(log.Fields{
-				"image":                  inputImage.GetSimpleName(),
+			imageLogger.WithFields(log.Fields{
 				"public path":            completePubSymPath,
 				"err stats pubblic path": errPub,
 				"private path":           completeSingularityPriPath,
 				"err stats private path": errPri,
-			}).Info("Checking if images links are up to date.")
+			}).Trace("Checking if images links are up to date")
 			// no error in stating both directories
 			// either the image is up to date or the image became stale
 			if errPub == nil && errPri == nil {
 				if os.SameFile(pubDirInfo, priDirInfo) {
 					// the link is up to date
-					l.Log().WithFields(log.Fields{"image": inputImage.GetSimpleName()}).Info("Singularity Image up to date")
+					imageLogger.Trace("Singularity image is up to date")
 					continue
 				}
 				// delete the old pubLink
 				// make a new Link to the privatePaht
 				// after that skip and continue
-				l.Log().WithFields(log.Fields{"image": inputImage.GetSimpleName()}).Info("Updating Singularity Image")
-				err = cvmfs.CreateSymlinkIntoCVMFS(wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
+				imageLogger.Trace("Updating singularity image symlink")
+				err = cvmfs.CreateSymlinkIntoCVMFSWithLogger(imageLogger, wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
 				if err != nil {
 					errF := fmt.Errorf("Error in updating symlink for singularity image: %s", inputImage.GetSimpleName())
-					l.LogE(errF).WithFields(
+					imageLogger.WithField("error", errF).WithFields(
 						log.Fields{"to": publicSymlinkPath, "from": singularityPrivatePath}).
 						Error("Error in creating symlink")
 					if firstError == nil {
@@ -149,11 +243,11 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			// no error in stating the private directory, but the public one does not exists
 			// we simply create the public directory
 			if errPri == nil && os.IsNotExist(errPub) {
-				l.Log().WithFields(log.Fields{"image": inputImage.GetSimpleName()}).Info("Creating link for Singularity Image")
-				err = cvmfs.CreateSymlinkIntoCVMFS(wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
+				imageLogger.Trace("Creating singularity image symlink")
+				err = cvmfs.CreateSymlinkIntoCVMFSWithLogger(imageLogger, wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
 				if err != nil {
 					errF := fmt.Errorf("Error in creating symlink for singularity image: %s", publicSymlinkPath)
-					l.LogE(errF).WithFields(
+					imageLogger.WithField("error", errF).WithFields(
 						log.Fields{"to": publicSymlinkPath, "from": singularityPrivatePath}).
 						Error("Error in creating symlink")
 					if firstError == nil {
@@ -166,18 +260,18 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 				continue
 			}
 
-			i := n.AddField("image", inputImage.GetSimpleName()).AddId()
+			i := n.AddField("image", imageNameWithPlatform(inputImage, manifestEntry)).AddId()
 			t1 := time.Now()
 			i.Action("start_flat_overlay_conversion").Send()
 			i = i.Action("end_flat_overlay_conversion")
 
 			// Use cvmfs_server overlay to merge layers into a flat image
-			_, err = inputImage.CreateFlatOverlay(wish.CvmfsRepo)
+			_, err = inputImage.CreateFlatOverlayWithLogger(imageLogger, wish.CvmfsRepo)
 			if err != nil {
 				if firstError == nil {
 					firstError = err
 				}
-				l.LogE(err).Error("Error in creating the flat overlay")
+				imageLogger.WithField("error", err).Error("Error in creating the flat overlay")
 				i.Error(err).Elapsed(t1).Send()
 				continue
 			}
@@ -195,15 +289,15 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			err = cvmfs.WithinTransaction(wish.CvmfsRepo,
 				func() error {
 					if err := singularity.MakeBaseEnv(completeSingularityPriPath); err != nil {
-						l.LogE(err).Error("Error in creating the base singularity environment")
+						imageLogger.WithField("error", err).Error("Error in creating the base singularity environment")
 						return err
 					}
 					if err := singularity.InsertRunScript(completeSingularityPriPath, ociImage); err != nil {
-						l.LogE(err).Error("Error in inserting the singularity runscript")
+						imageLogger.WithField("error", err).Error("Error in inserting the singularity runscript")
 						return err
 					}
 					if err := singularity.InsertEnv(completeSingularityPriPath, ociImage); err != nil {
-						l.LogE(err).Error("Error in inserting the singularity environment")
+						imageLogger.WithField("error", err).Error("Error in inserting the singularity environment")
 						return err
 					}
 					return nil
@@ -213,16 +307,16 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 				if firstError == nil {
 					firstError = err
 				}
-				l.LogE(err).Error("Error in creating the dotfile inside the flat directory")
+				imageLogger.WithField("error", err).Error("Error in creating the dotfile inside the flat directory")
 				i.Error(err).Elapsed(t1).Send()
 				continue
 			}
 			// we create the public link
 
-			err = cvmfs.CreateSymlinkIntoCVMFS(wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
+			err = cvmfs.CreateSymlinkIntoCVMFSWithLogger(imageLogger, wish.CvmfsRepo, publicSymlinkPath, singularityPrivatePath)
 			if err != nil {
 				errF := fmt.Errorf("Error in creating symlink for singularity image: %s", inputImage.GetSimpleName())
-				l.LogE(errF).WithFields(
+				imageLogger.WithField("error", errF).WithFields(
 					log.Fields{"to": publicSymlinkPath, "from": singularityPrivatePath}).
 					Error("Error in creating symlink")
 				if firstError == nil {
@@ -259,12 +353,13 @@ func ConvertWishDocker(wish WishFriendly) (err error) {
 	}
 	var firstError error
 	for _, expandedImgTag := range wish.ExpandedTagImagesLayer {
+		imageLogger := l.WithImage(expandedImgTag.GetSimpleName())
 		tag := expandedImgTag.Tag
 		outputWithTag := outputImageForExpandedTag(inputImage, outputImage, tag)
 
 		manifestPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, ".metadata", expandedImgTag.GetSimpleName(), "manifest.json")
 		if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
-			l.Log().Info("Layers not downloaded yet, not converting for docker, moving on")
+			imageLogger.Trace("Layers not downloaded yet, not converting for docker")
 			continue
 		}
 		manifest, err := expandedImgTag.GetManifest()
@@ -277,11 +372,11 @@ func ConvertWishDocker(wish WishFriendly) (err error) {
 			layerPath := cvmfs.LayerRootfsPath(wish.CvmfsRepo, layerDigest)
 			layerLocations[layer.Digest] = layerPath
 		}
-		err = CreateThinImage(manifest, layerLocations, *expandedImgTag, outputWithTag)
+		err = CreateThinImageWithLogger(imageLogger, manifest, layerLocations, *expandedImgTag, outputWithTag)
 		if err != nil && firstError == nil {
 			firstError = err
 		}
-		err = PushImageToRegistry(outputWithTag)
+		err = PushImageToRegistryWithLogger(imageLogger.WithField("thin_image", outputWithTag.GetSimpleName()), outputWithTag)
 		if err != nil && firstError == nil {
 			firstError = err
 		}
@@ -306,6 +401,7 @@ func outputRepositoryForImport(outputImage Image) string {
 func ConvertWishPodman(wish WishFriendly, convertAgain bool) (err error) {
 	var firstError error
 	for _, expandedImgTag := range wish.ExpandedTagImagesLayer {
+		imageLogger := l.WithImage(expandedImgTag.GetSimpleName())
 		manifest, err := expandedImgTag.GetManifest()
 		if err != nil {
 			return err
@@ -314,10 +410,10 @@ func ConvertWishPodman(wish WishFriendly, convertAgain bool) (err error) {
 
 		// check if image is already present in podman store
 		manifestPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, rootPath, imageMetadataDir, imageID, "manifest")
-		alreadyConverted := AlreadyConverted(manifestPath, manifest.Config.Digest)
+		alreadyConverted := AlreadyConvertedWithLogger(imageLogger, manifestPath, manifest.Config.Digest)
 		if alreadyConverted == ConversionMatch {
 			if convertAgain == false {
-				l.Log().Info("Image already present in podman store, moving on")
+				imageLogger.Trace("Image already present in podman store, moving on")
 				continue
 			}
 		}
@@ -325,11 +421,11 @@ func ConvertWishPodman(wish WishFriendly, convertAgain bool) (err error) {
 		// convert for podman only after manifest is stored in .metadata
 		manifestPath = filepath.Join("/", "cvmfs", wish.CvmfsRepo, ".metadata", expandedImgTag.GetSimpleName(), "manifest.json")
 		if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
-			l.Log().Info("Layers not downloaded yet, not converting for podman, moving on")
+			imageLogger.Trace("Layers not downloaded yet, not converting for podman")
 			continue
 		}
 
-		err = expandedImgTag.CreatePodmanImageStore(wish.CvmfsRepo, constants.SubDirInsideRepo)
+		err = expandedImgTag.CreatePodmanImageStoreWithLogger(imageLogger, wish.CvmfsRepo, constants.SubDirInsideRepo)
 		if err != nil && firstError == nil {
 			firstError = err
 		}
@@ -337,7 +433,7 @@ func ConvertWishPodman(wish WishFriendly, convertAgain bool) (err error) {
 	return firstError
 }
 
-func ConvertWish(wish WishFriendly, convertAgain, forceDownload, multiArch bool, maxConcurrentDownloads int) (err error) {
+func ConvertWish(wish WishFriendly, convertAgain, forceDownload, multiArch bool, maxConcurrentDownloads int) (summary ConversionSummary, err error) {
 	err = cvmfs.CreateCatalogIntoDir(wish.CvmfsRepo, constants.SubDirInsideRepo)
 	if err != nil {
 		l.LogE(err).WithFields(log.Fields{
@@ -346,46 +442,56 @@ func ConvertWish(wish WishFriendly, convertAgain, forceDownload, multiArch bool,
 	}
 	var firstError error
 	for _, expandedImgTag := range wish.ExpandedTagImagesLayer {
-		err = convertInputOutput(expandedImgTag, wish.CvmfsRepo, convertAgain, forceDownload, multiArch, maxConcurrentDownloads)
+		imageSummary, err := convertInputOutput(expandedImgTag, wish.CvmfsRepo, convertAgain, forceDownload, multiArch, maxConcurrentDownloads)
+		summary.Merge(imageSummary)
 		if err != nil && firstError == nil {
 			firstError = err
 		}
 	}
-	return firstError
+	return summary, firstError
 }
 
-func convertInputOutput(inputImage *Image, repo string, convertAgain, forceDownload bool, multiArch bool, maxConcurrentDownloads int) error {
+func convertInputOutput(inputImage *Image, repo string, convertAgain, forceDownload bool, multiArch bool, maxConcurrentDownloads int) (ConversionSummary, error) {
 	manifestList, err := inputImage.GetManifestList()
 	if err != nil {
-		l.LogE(err).Error("Error in getting the manifest list")
-		return err
+		l.WithImageE(err, inputImage.GetSimpleName()).Error("Error in getting the manifest list")
+		return ConversionSummary{}, err
 	}
+	summary := ConversionSummary{}
 	var firstError error
 	for _, manifestEntry := range filterManifestList(manifestList, multiArch) {
 		inputImage.Manifest = &(manifestEntry.Manifest)
 		nameWithArch := GetNameWithArch(manifestEntry)
 		nameWithArch = filepath.Join(nameWithArch, inputImage.GetSimpleName())
-		if err := convertInputOutput2(inputImage, nameWithArch, repo, convertAgain, forceDownload, maxConcurrentDownloads); err != nil {
+		imageLabel := imageNameWithPlatform(inputImage, manifestEntry)
+		result, err := convertInputOutput2(inputImage, imageLabel, nameWithArch, repo, convertAgain, forceDownload, maxConcurrentDownloads)
+		if err == nil {
+			summary.Add(result, imageLabel)
+		}
+		if err != nil {
 			if firstError == nil {
 				firstError = err
 			}
 		}
 	}
-	return firstError
+	return summary, firstError
 }
 
-func convertInputOutput2(inputImage *Image, nameWithArch, repo string, convertAgain, forceDownload bool, maxConcurrentDownloads int) (err error) {
+func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo string, convertAgain, forceDownload bool, maxConcurrentDownloads int) (result ConversionResult, err error) {
+	result = ConversionUnknown
+	logger := l.WithImage(imageLabel)
 	path := filepath.Join("/", "cvmfs", repo, ".metadata")
 	manifest, _ := inputImage.GetManifest()
 
 	manifestPath := filepath.Join(path, nameWithArch, "manifest.json")
-	alreadyConverted := AlreadyConverted(manifestPath, manifest.Config.Digest)
+	alreadyConverted := AlreadyConvertedWithLogger(logger, manifestPath, manifest.Config.Digest)
+	result = alreadyConverted
 
 	if alreadyConverted == ConversionMatch {
 		if !convertAgain {
-			l.Log().WithFields(log.Fields{"alreadyConverted": alreadyConverted}).Info(
-				"Already converted the image, skipping.")
-			return nil
+			logger.WithFields(log.Fields{"alreadyConverted": alreadyConverted}).Trace(
+				"Already converted the image, skipping")
+			return result, nil
 		}
 	}
 
@@ -395,7 +501,7 @@ func convertInputOutput2(inputImage *Image, nameWithArch, repo string, convertAg
 	noErrorInConversion := make(chan bool, 1)
 
 	n := notification.NewNotification(NotificationService)
-	n = n.AddField("image", inputImage.GetSimpleName())
+	n = n.AddField("image", imageLabel)
 
 	go func() {
 		noErrors := true
@@ -407,43 +513,44 @@ func convertInputOutput2(inputImage *Image, nameWithArch, repo string, convertAg
 
 		for layer := range layersChanell {
 			layerDigest := strings.Split(layer.Name, ":")[1]
+			layerLogger := logger.WithField("layer", layer.Name)
 
-			l.Log().WithFields(log.Fields{"layer": layer.Name}).Info("Start Ingesting the file into CVMFS")
+			layerLogger.Trace("Start ingesting the file into CVMFS")
 
 			ln := n.AddField("layer", layerDigest).AddId()
 			ln.Action("start_layer_conversion").Send()
 
 			t1 := time.Now()
-			err = layer.IngestIntoCVMFS(repo)
+			err = layer.IngestIntoCVMFSWithLogger(layerLogger, repo)
 
 			ln.Elapsed(t1).Action("end_layer_conversion").Error(err).SizeBytes(layer.GetSize()).Send()
 
 			if err != nil {
-				l.LogE(err).Error("Error in ingesting the layer in cvmfs")
+				layerLogger.WithField("error", err).Error("Error in ingesting the layer in cvmfs")
 				noErrors = false
 			}
 			if err == nil {
 				n.Action("publish_layer").AddField("layer_digest", layerDigest).Send()
 			}
-			l.Log().WithFields(log.Fields{"layer": layer.Name}).Info("Finish Ingesting the file")
+			layerLogger.Trace("Finished ingesting the file")
 
 			layer.Close()
 		}
-		l.Log().Info("Finished pushing the layers into CVMFS")
+		logger.Trace("Finished pushing the layers into CVMFS")
 	}()
 	// we create a temp directory for all the files needed, when this function finish we can remove the temp directory cleaning up
 	tmpDir, err := temp.UserDefinedTempDir("", "conversion")
 	if err != nil {
-		l.LogE(err).Error("Error in creating a temporary directory for all the files")
+		logger.WithField("error", err).Error("Error in creating a temporary directory for all the files")
 		return
 	}
 	defer os.RemoveAll(tmpDir)
 
 	// this will start to feed the above goroutine by writing into layersChanell
-	err = inputImage.GetLayers(manifest, layersChanell, manifestChanell, stopGettingLayers, tmpDir, maxConcurrentDownloads, repo, forceDownload)
+	err = inputImage.GetLayersWithLogger(logger, manifest, layersChanell, manifestChanell, stopGettingLayers, tmpDir, maxConcurrentDownloads, repo, forceDownload)
 	if err != nil {
-		l.LogE(err).Error("Error in getting layers")
-		return err
+		logger.WithField("error", err).Error("Error in getting layers")
+		return result, err
 	}
 
 	// Collect all layer digests from the manifest for backlink saving,
@@ -460,38 +567,43 @@ func convertInputOutput2(inputImage *Image, nameWithArch, repo string, convertAg
 	// and if there was no error we conclude everything writing the manifest into the repository
 	noErrorInConversionValue := <-noErrorInConversion
 
-	err = cvmfs.SaveLayersBacklink(repo, manifest, layerDigests)
+	err = cvmfs.SaveLayersBacklinkWithLogger(logger, repo, manifest, layerDigests)
 	if err != nil {
-		l.LogE(err).Error("Error in saving the backlinks")
+		logger.WithField("error", err).Error("Error in saving the backlinks")
 		noErrorInConversionValue = false
 	}
 
 	if noErrorInConversionValue {
 		manifestPath2 := filepath.Join(".metadata", nameWithArch, "manifest.json")
-		errIng := cvmfs.PublishToCVMFS(repo, manifestPath2, <-manifestChanell)
+		errIng := cvmfs.PublishToCVMFSWithLogger(logger, repo, manifestPath2, <-manifestChanell)
 		if errIng != nil {
-			l.LogE(errIng).Error("Error in storing the manifest in the repository")
-			return errIng
+			logger.WithField("error", errIng).Error("Error in storing the manifest in the repository")
+			return result, errIng
 		}
 
 		var errRemoveSchedule error
 		if alreadyConverted == ConversionNotMatch {
-			l.Log().Info("Image already converted, but it does not match the manifest, adding it to the remove scheduler")
-			errRemoveSchedule = cvmfs.AddManifestToRemoveScheduler(repo, manifest)
+			logger.Trace("Image already converted, but it does not match the manifest, adding it to the remove scheduler")
+			errRemoveSchedule = cvmfs.AddManifestToRemoveSchedulerWithLogger(logger, repo, manifest)
 			if errRemoveSchedule != nil {
-				l.Log().Warning("Error in adding the image to the remove schedule")
-				return errRemoveSchedule
+				logger.WithField("error", errRemoveSchedule).Warning("Error in adding the image to the remove schedule")
+				return result, errRemoveSchedule
 			}
 		}
-		l.Log().Info("Conversion completed")
-		return nil
+		logger.Trace("Conversion completed")
+		return result, nil
 	}
 
-	l.Log().Warn("Some error during the conversion, we are not storing it into the database")
-	return nil
+	logger.Warn("Some error during the conversion, we are not storing it into the database")
+	return ConversionUnknown, nil
 }
 
 func CreateThinImage(manifest da.Manifest, layerLocations map[string]string, inputImage, outputImage Image) (err error) {
+	return CreateThinImageWithLogger(nil, manifest, layerLocations, inputImage, outputImage)
+}
+
+func CreateThinImageWithLogger(logger *log.Entry, manifest da.Manifest, layerLocations map[string]string, inputImage, outputImage Image) (err error) {
+	logger = l.Ensure(logger)
 	thin, err := da.MakeThinImage(manifest, layerLocations, inputImage.WholeName())
 	if err != nil {
 		return
@@ -538,16 +650,21 @@ func CreateThinImage(manifest da.Manifest, layerLocations map[string]string, inp
 		outputRepositoryForImport(outputImage),
 		importOptions)
 	if err != nil {
-		l.LogE(err).Error("Error in image import")
+		logger.WithField("error", err).Error("Error in image import")
 		return
 	}
 	defer importResult.Close()
-	l.Log().Info("Created the image in the local docker daemon")
+	logger.Trace("Created the image in the local docker daemon")
 
 	return nil
 }
 
 func PushImageToRegistry(outputImage Image) (err error) {
+	return PushImageToRegistryWithLogger(nil, outputImage)
+}
+
+func PushImageToRegistryWithLogger(logger *log.Entry, outputImage Image) (err error) {
+	logger = l.Ensure(logger)
 	// the authentication must be provided for the ImagePush api,
 	// even if the documentation says otherwise
 	password, err := GetPassword()
@@ -579,15 +696,15 @@ func PushImageToRegistry(outputImage Image) (err error) {
 		return err
 	}
 	b, _ := ioutil.ReadAll(res)
-	l.Log().WithFields(log.Fields{"action": "prepared thin-image manifest"}).Info(string(b))
+	logger.WithField("action", "prepared thin-image manifest").Trace(string(b))
 	defer res.Close()
 	// here is possible to use the result of the above ReadAll to have
 	// informantion about the status of the upload.
 	_, errReadDocker := ioutil.ReadAll(res)
 	if err != nil {
-		l.LogE(errReadDocker).Warning("Error in reading the status from docker")
+		logger.WithField("error", errReadDocker).Warning("Error in reading the status from docker")
 	}
-	l.Log().Info("Finish pushing the image to the registry")
+	logger.Trace("Finished pushing the image to the registry")
 	return
 }
 
@@ -601,7 +718,12 @@ func NewDockerClient() (*client.Client, error) {
 }
 
 func StoreLayerInfo(CVMFSRepo string, layerDigest string, r ReadHashCloseSizer) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Ingesting layers.json"}).Info("store layer information in .layers")
+	return StoreLayerInfoWithLogger(nil, CVMFSRepo, layerDigest, r)
+}
+
+func StoreLayerInfoWithLogger(logger *log.Entry, CVMFSRepo string, layerDigest string, r ReadHashCloseSizer) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithField("action", "ingesting layers.json").Trace("Store layer information in .layers")
 	layersdata := []LayerInfo{}
 	layerInfoPath := filepath.Join(cvmfs.LayerMetadataPath(CVMFSRepo, layerDigest), "layers.json")
 
@@ -619,32 +741,37 @@ func StoreLayerInfo(CVMFSRepo string, layerDigest string, r ReadHashCloseSizer) 
 
 	jsonLayerInfo, err := json.MarshalIndent(layersdata, "", " ")
 	if err != nil {
-		l.LogE(err).Error("Error in marshaling json data for layers.json")
+		logger.WithField("error", err).Error("Error in marshaling json data for layers.json")
 		return err
 	}
 
-	err = cvmfs.WriteDataToCvmfs(CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(layerInfoPath), jsonLayerInfo)
+	err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(layerInfoPath), jsonLayerInfo)
 	if err != nil {
-		l.LogE(err).Error("Error in writing layers.json file")
+		logger.WithField("error", err).Error("Error in writing layers.json file")
 		return err
 	}
 	return
 }
 
 func AlreadyConverted(manifestPath, reference string) ConversionResult {
+	return AlreadyConvertedWithLogger(nil, manifestPath, reference)
+}
+
+func AlreadyConvertedWithLogger(logger *log.Entry, manifestPath, reference string) ConversionResult {
+	logger = l.Ensure(logger)
 	manifestStat, err := os.Stat(manifestPath)
 	if os.IsNotExist(err) {
-		l.Log().Info("Manifest not existing")
+		logger.Trace("Manifest not existing")
 		return ConversionNotFound
 	}
 	if !manifestStat.Mode().IsRegular() {
-		l.Log().Info("Manifest not a regular file")
+		logger.Trace("Manifest not a regular file")
 		return ConversionNotFound
 	}
 
 	manifestFile, err := os.Open(manifestPath)
 	if err != nil {
-		l.Log().Info("Error in opening the manifest")
+		logger.WithField("error", err).Trace("Error in opening the manifest")
 		return ConversionNotFound
 	}
 	defer manifestFile.Close()
@@ -654,7 +781,7 @@ func AlreadyConverted(manifestPath, reference string) ConversionResult {
 	var manifest da.Manifest
 	err = json.Unmarshal(bytes, &manifest)
 	if err != nil {
-		l.LogE(err).Warning("Error in unmarshaling the manifest")
+		logger.WithField("error", err).Warning("Error in unmarshaling the manifest")
 		return ConversionNotFound
 	}
 	if manifest.Config.Digest == reference {

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -487,18 +487,10 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 	alreadyConverted := AlreadyConvertedWithLogger(logger, manifestPath, manifest.Config.Digest)
 	result = alreadyConverted
 
-	if alreadyConverted == ConversionMatch {
-		if !convertAgain {
-			logger.WithFields(log.Fields{"alreadyConverted": alreadyConverted}).Trace(
-				"Already converted the image, skipping")
-			return result, nil
-		}
-	}
-
 	// Classify layers into those already present in CVMFS and those that need
 	// to be downloaded and ingested, mirroring the forceDownload logic in
 	// GetLayersWithLogger so the message accurately reflects what will happen.
-	var layersToConvert, layersPresent []string
+	var layersToConvert, layersAlreadyConverted []string
 	for _, layer := range manifest.Layers {
 		if layer.MediaType == "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip" {
 			continue
@@ -511,16 +503,22 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 		layerPath := cvmfs.LayerRootfsPath(repo, digest)
 		if !forceDownload {
 			if _, statErr := os.Stat(layerPath); statErr == nil {
-				layersPresent = append(layersPresent, shortDigest)
+				layersAlreadyConverted = append(layersAlreadyConverted, shortDigest)
 				continue
 			}
 		}
 		layersToConvert = append(layersToConvert, shortDigest)
 	}
 	logger.WithFields(log.Fields{
-		"layers to convert": layersToConvert,
-		"layers present":    layersPresent,
+		"layers to convert":    layersToConvert,
+		"already converted":    layersAlreadyConverted,
 	}).Info("Starting layer conversion")
+
+	if alreadyConverted == ConversionMatch {
+		if !convertAgain {
+			return result, nil
+		}
+	}
 
 	layersChanell := make(chan downloadedLayer, 10)
 	manifestChanell := make(chan string, 1)

--- a/ducc/lib/conversion_test.go
+++ b/ducc/lib/conversion_test.go
@@ -53,13 +53,13 @@ func TestConversionSummaryPrefersAddedOverOtherStates(t *testing.T) {
 	if len(summary.Updated) != 0 {
 		t.Fatalf("expected no updated images, got %+v", summary.Updated)
 	}
-	if len(summary.Skipped) != 0 {
-		t.Fatalf("expected no skipped images, got %+v", summary.Skipped)
+	if len(summary.AlreadyConverted) != 0 {
+		t.Fatalf("expected no already-converted images, got %+v", summary.AlreadyConverted)
 	}
 }
 
 func TestConversionSummaryMergeKeepsHighestPriorityState(t *testing.T) {
-	summary := ConversionSummary{Skipped: []string{"img-a", "img-b"}}
+	summary := ConversionSummary{AlreadyConverted: []string{"img-a", "img-b"}}
 	summary.Merge(ConversionSummary{Updated: []string{"img-a"}, Added: []string{"img-b"}})
 
 	if len(summary.Added) != 1 || summary.Added[0] != "img-b" {
@@ -68,8 +68,8 @@ func TestConversionSummaryMergeKeepsHighestPriorityState(t *testing.T) {
 	if len(summary.Updated) != 1 || summary.Updated[0] != "img-a" {
 		t.Fatalf("expected img-a to be updated, got %+v", summary)
 	}
-	if len(summary.Skipped) != 0 {
-		t.Fatalf("expected skipped images to be cleared, got %+v", summary.Skipped)
+	if len(summary.AlreadyConverted) != 0 {
+		t.Fatalf("expected already-converted images to be cleared, got %+v", summary.AlreadyConverted)
 	}
 }
 

--- a/ducc/lib/conversion_test.go
+++ b/ducc/lib/conversion_test.go
@@ -1,6 +1,10 @@
 package lib
 
-import "testing"
+import (
+	"testing"
+
+	da "github.com/cvmfs/ducc/docker-api"
+)
 
 func TestOutputImageForExpandedTagWildcard(t *testing.T) {
 	input := &Image{TagWildcard: true}
@@ -34,5 +38,52 @@ func TestOutputRepositoryForImport(t *testing.T) {
 
 	if got != "localhost:5000/mock/repo" {
 		t.Fatalf("expected repository-only reference, got %q", got)
+	}
+}
+
+func TestConversionSummaryPrefersAddedOverOtherStates(t *testing.T) {
+	summary := ConversionSummary{}
+	summary.Add(ConversionMatch, "example:latest")
+	summary.Add(ConversionNotMatch, "example:latest")
+	summary.Add(ConversionNotFound, "example:latest")
+
+	if len(summary.Added) != 1 || summary.Added[0] != "example:latest" {
+		t.Fatalf("expected image to be tracked as added, got %+v", summary)
+	}
+	if len(summary.Updated) != 0 {
+		t.Fatalf("expected no updated images, got %+v", summary.Updated)
+	}
+	if len(summary.Skipped) != 0 {
+		t.Fatalf("expected no skipped images, got %+v", summary.Skipped)
+	}
+}
+
+func TestConversionSummaryMergeKeepsHighestPriorityState(t *testing.T) {
+	summary := ConversionSummary{Skipped: []string{"img-a", "img-b"}}
+	summary.Merge(ConversionSummary{Updated: []string{"img-a"}, Added: []string{"img-b"}})
+
+	if len(summary.Added) != 1 || summary.Added[0] != "img-b" {
+		t.Fatalf("expected img-b to be added, got %+v", summary)
+	}
+	if len(summary.Updated) != 1 || summary.Updated[0] != "img-a" {
+		t.Fatalf("expected img-a to be updated, got %+v", summary)
+	}
+	if len(summary.Skipped) != 0 {
+		t.Fatalf("expected skipped images to be cleared, got %+v", summary.Skipped)
+	}
+}
+
+func TestImageNameWithPlatform(t *testing.T) {
+	variant := "v8"
+	image := &Image{Registry: "registry.example.org", Repository: "team/demo", Tag: "latest"}
+	manifestEntry := da.ManifestListItem{}
+	manifestEntry.Platform.OS = "linux"
+	manifestEntry.Platform.Architecture = "arm64"
+	manifestEntry.Platform.Variant = &variant
+
+	got := imageNameWithPlatform(image, manifestEntry)
+	want := "registry.example.org/team/demo:latest (linux/arm64/v8)"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -843,6 +843,11 @@ func (d *downloadedLayer) Close() error {
 }
 
 func (d *downloadedLayer) IngestIntoCVMFS(CVMFSRepo string) error {
+	return d.IngestIntoCVMFSWithLogger(nil, CVMFSRepo)
+}
+
+func (d *downloadedLayer) IngestIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo string) error {
+	logger = l.Ensure(logger)
 	layerDigest := strings.Split(d.Name, ":")[1]
 	layerPath := cvmfs.LayerRootfsPath(CVMFSRepo, layerDigest)
 	if _, err := os.Stat(layerPath); err == nil {
@@ -850,29 +855,26 @@ func (d *downloadedLayer) IngestIntoCVMFS(CVMFSRepo string) error {
 		return nil
 	}
 	superDir := filepath.Dir(filepath.Dir(cvmfs.TrimCVMFSRepoPrefix(layerPath)))
-	if err := cvmfs.CreateCatalogIntoDir(CVMFSRepo, superDir); err != nil {
-		l.LogE(err).WithFields(
-			log.Fields{"layer": d.Name, "dir": superDir}).
+	if err := cvmfs.CreateCatalogIntoDirWithLogger(logger, CVMFSRepo, superDir); err != nil {
+		logger.WithFields(log.Fields{"layer": d.Name, "dir": superDir, "error": err}).
 			Error("Error creating catalog for layer directory")
 		return err
 	}
 	ingestPath := cvmfs.TrimCVMFSRepoPrefix(layerPath)
 
-	err := cvmfs.Ingest(CVMFSRepo, d.Path,
+	err := cvmfs.IngestWithLogger(logger, CVMFSRepo, d.Path,
 		"--catalog", "-t", "-",
 		"-b", ingestPath)
 	if err != nil {
-		l.LogE(err).WithFields(
-			log.Fields{"layer": d.Name}).
+		logger.WithFields(log.Fields{"layer": d.Name, "error": err}).
 			Error("Some error in ingest the layer")
-		if errDelete := cvmfs.IngestDelete(CVMFSRepo, ingestPath); errDelete != nil {
-			l.LogE(errDelete).WithFields(
-				log.Fields{"layer": d.Name, "path": ingestPath}).
+		if errDelete := cvmfs.IngestDeleteWithLogger(logger, CVMFSRepo, ingestPath); errDelete != nil {
+			logger.WithFields(log.Fields{"layer": d.Name, "path": ingestPath, "error": errDelete}).
 				Warning("Error cleaning up failed ingest path")
 		}
 		return err
 	}
-	err = StoreLayerInfo(CVMFSRepo, layerDigest, d.Path)
+	err = StoreLayerInfoWithLogger(logger, CVMFSRepo, layerDigest, d.Path)
 	if err != nil {
 		return err
 	}
@@ -888,10 +890,15 @@ func (d *downloadedLayer) GetSize() int64 {
 }
 
 func (img *Image) GetLayers(manifest da.Manifest, layersChan chan<- downloadedLayer, manifestChan chan<- string, stopGettingLayers <-chan bool, rootPath string, maxConcurrentDownloads int, CVMFSRepo string, forceDownload bool) error {
+	return img.GetLayersWithLogger(nil, manifest, layersChan, manifestChan, stopGettingLayers, rootPath, maxConcurrentDownloads, CVMFSRepo, forceDownload)
+}
+
+func (img *Image) GetLayersWithLogger(logger *log.Entry, manifest da.Manifest, layersChan chan<- downloadedLayer, manifestChan chan<- string, stopGettingLayers <-chan bool, rootPath string, maxConcurrentDownloads int, CVMFSRepo string, forceDownload bool) error {
+	logger = l.Ensure(logger)
 	defer close(layersChan)
 	defer close(manifestChan)
 
-	layerDownloader := NewLayerDownloader(img)
+	layerDownloader := NewLayerDownloaderWithLogger(logger, img)
 	_, err := layerDownloader.getToken()
 	if err != nil {
 		return err
@@ -910,7 +917,7 @@ func (img *Image) GetLayers(manifest da.Manifest, layersChan chan<- downloadedLa
 		case <-stopGettingLayers:
 			err := fmt.Errorf("detect errors, stop getting layer")
 			errorChannel <- err
-			l.LogE(err).Error("Detect error, stop getting layers")
+			logger.WithField("error", err).Error("Detect error, stop getting layers")
 			cancel()
 			return
 		}
@@ -945,21 +952,20 @@ func (img *Image) GetLayers(manifest da.Manifest, layersChan chan<- downloadedLa
 
 			layerDigest := strings.Split(layer.Digest, ":")[1]
 			layerPath := cvmfs.LayerRootfsPath(CVMFSRepo, layerDigest)
+			layerLogger := logger.WithField("layer", layer.Digest)
 			if !forceDownload {
 				if _, err := os.Stat(layerPath); err == nil {
-					l.Log().WithFields(log.Fields{"layer": layer.Digest}).Info("Skipping download of layer, already exists")
+					layerLogger.Trace("Skipping download of layer, already exists")
 					return
 				}
 			}
 
-			l.Log().WithFields(
-				log.Fields{"layer": layer.Digest}).
-				Info("Start working on layer")
+			layerLogger.Trace("Start working on layer")
 
 			toSend, err := layerDownloader.DownloadLayer(layer)
 
 			if err != nil {
-				l.LogE(err).Error("Error in downloading a layer")
+				layerLogger.WithField("error", err).Error("Error in downloading a layer")
 				toSend.Close()
 				return
 			}
@@ -975,13 +981,13 @@ func (img *Image) GetLayers(manifest da.Manifest, layersChan chan<- downloadedLa
 	// finally we marshal the manifest and store it into a file
 	manifestBytes, err := json.Marshal(manifest)
 	if err != nil {
-		l.LogE(err).Error("Error in marshaling the manifest")
+		logger.WithField("error", err).Error("Error in marshaling the manifest")
 		return err
 	}
 	manifestPath := filepath.Join(rootPath, "manifest.json")
 	err = ioutil.WriteFile(manifestPath, manifestBytes, 0666)
 	if err != nil {
-		l.LogE(err).Error("Error in writing the manifest to file")
+		logger.WithField("error", err).Error("Error in writing the manifest to file")
 		return err
 	}
 	// ship the manifest file
@@ -998,6 +1004,11 @@ func (img *Image) GetLayers(manifest da.Manifest, layersChan chan<- downloadedLa
 }
 
 func (img *Image) downloadLayer(layer da.Layer, token string) (toSend downloadedLayer, err error) {
+	return img.downloadLayerWithLogger(nil, layer, token)
+}
+
+func (img *Image) downloadLayerWithLogger(logger *log.Entry, layer da.Layer, token string) (toSend downloadedLayer, err error) {
+	logger = l.Ensure(logger)
 	layerUrl := getLayerUrl(img, layer.Digest)
 	if token == "" {
 		token, err = firstRequestForAuth(layerUrl)
@@ -1010,15 +1021,13 @@ func (img *Image) downloadLayer(layer da.Layer, token string) (toSend downloaded
 		client := &http.Client{}
 		req, errR := http.NewRequest("GET", layerUrl, nil)
 		if errR != nil {
-			l.LogE(errR).Error("Impossible to create the HTTP request.")
+			logger.WithField("error", errR).Error("Impossible to create the HTTP request")
 			err = errR
 			break
 		}
 		req.Header.Set("Authorization", token)
 		resp, errReq := client.Do(req)
-		l.Log().WithFields(
-			log.Fields{"layer": layer.Digest, "size in MB": (layer.Size / 1e6)}).
-			Info("Make request for layer")
+		logger.WithField("size in MB", (layer.Size / 1e6)).Trace("Make request for layer")
 		if errReq != nil {
 			err = errReq
 			break
@@ -1034,7 +1043,7 @@ func (img *Image) downloadLayer(layer da.Layer, token string) (toSend downloaded
 			gread, errG := gzip.NewReader(resp.Body)
 			if errG != nil {
 				err = errG
-				l.LogE(err).Warning("Error in creating the zip to unzip the layer")
+				logger.WithField("error", err).Warning("Error in creating the zip to unzip the layer")
 				resp.Body.Close()
 				continue
 			}
@@ -1043,20 +1052,20 @@ func (img *Image) downloadLayer(layer da.Layer, token string) (toSend downloaded
 			return toSend, nil
 		} else {
 			err = fmt.Errorf("layer not received, status code: %d", resp.StatusCode)
-			l.LogE(err).Warning("Received status code ", resp.StatusCode)
+			logger.WithField("error", err).Warnf("Received status code %d", resp.StatusCode)
 			resp.Body.Close()
 			if resp.StatusCode == 401 {
 				// try to get the token again
 				newToken, errToken := firstRequestForAuth(layerUrl)
 				if errToken != nil {
-					l.LogE(errToken).Warning("Error in refreshing the token")
+					logger.WithField("error", errToken).Warning("Error in refreshing the token")
 				} else {
 					token = newToken
 				}
 			}
 		}
 	}
-	l.LogE(err).Warning("return from error path")
+	logger.WithField("error", err).Warning("Return from error path")
 	return
 }
 
@@ -1150,13 +1159,22 @@ func requestAuthToken(token, user, pass string) (authToken string, expiresIn int
 
 type LayerDownloader struct {
 	image    *Image
+	logger   *log.Entry
 	token    string
 	attempts map[string]int
 	lock     sync.Mutex
 }
 
 func NewLayerDownloader(image *Image) LayerDownloader {
-	return LayerDownloader{image: image, token: "", attempts: make(map[string]int)}
+	return NewLayerDownloaderWithLogger(nil, image)
+}
+
+func NewLayerDownloaderWithLogger(logger *log.Entry, image *Image) LayerDownloader {
+	return LayerDownloader{image: image, logger: l.Ensure(logger), token: "", attempts: make(map[string]int)}
+}
+
+func (ld *LayerDownloader) loggerForLayer(layer da.Layer) *log.Entry {
+	return l.Ensure(ld.logger).WithField("layer", layer.Digest)
 }
 
 func (ld *LayerDownloader) getToken() (token string, err error) {
@@ -1188,6 +1206,7 @@ func (ld *LayerDownloader) getToken() (token string, err error) {
 }
 
 func (ld *LayerDownloader) DownloadLayer(layer da.Layer) (downloadedLayer, error) {
+	logger := ld.loggerForLayer(layer)
 	token, err := ld.getToken()
 	if err != nil {
 		return downloadedLayer{}, err
@@ -1200,9 +1219,9 @@ func (ld *LayerDownloader) DownloadLayer(layer da.Layer) (downloadedLayer, error
 	// if the layer is bigger than 50M we download it using the disk storage
 	if att == 0 && layer.Size < 50e6 {
 		// in this case it is smaller and we do an early exit
-		return ld.image.downloadLayer(layer, token)
+		return ld.image.downloadLayerWithLogger(logger, layer, token)
 	}
-	inMem, err := ld.image.downloadLayer(layer, token)
+	inMem, err := ld.image.downloadLayerWithLogger(logger, layer, token)
 	if err != nil {
 		return inMem, err
 	}
@@ -1214,6 +1233,11 @@ func (ld *LayerDownloader) DownloadLayer(layer da.Layer) (downloadedLayer, error
 }
 
 func (ld *LayerDownloader) DownloadAndIngest(CVMFSRepo string, layer da.Layer) error {
+	return ld.DownloadAndIngestWithLogger(nil, CVMFSRepo, layer)
+}
+
+func (ld *LayerDownloader) DownloadAndIngestWithLogger(logger *log.Entry, CVMFSRepo string, layer da.Layer) error {
+	ld.logger = l.Ensure(logger)
 	err := error(nil)
 	for i := 0; i <= 5; i += 1 {
 		to_ingest, err := ld.DownloadLayer(layer)
@@ -1222,7 +1246,7 @@ func (ld *LayerDownloader) DownloadAndIngest(CVMFSRepo string, layer da.Layer) e
 			continue
 		}
 		defer to_ingest.Close()
-		err = to_ingest.IngestIntoCVMFS(CVMFSRepo)
+		err = to_ingest.IngestIntoCVMFSWithLogger(ld.loggerForLayer(layer), CVMFSRepo)
 		if err == nil {
 			return nil
 		}
@@ -1234,6 +1258,11 @@ func (ld *LayerDownloader) DownloadAndIngest(CVMFSRepo string, layer da.Layer) e
 // flat filesystem. It returns the singularity path (relative to /cvmfs/$REPO)
 // where the merged image is placed.
 func (img *Image) CreateFlatOverlay(CVMFSRepo string) (singularityPath string, err error) {
+	return img.CreateFlatOverlayWithLogger(nil, CVMFSRepo)
+}
+
+func (img *Image) CreateFlatOverlayWithLogger(logger *log.Entry, CVMFSRepo string) (singularityPath string, err error) {
+	logger = l.Ensure(logger)
 	manifest, err := img.GetManifest()
 	if err != nil {
 		return
@@ -1262,7 +1291,7 @@ func (img *Image) CreateFlatOverlay(CVMFSRepo string) (singularityPath string, e
 	t := time.Now()
 	n.AddField("action", "start_overlay_merge").Send()
 
-	err = cvmfs.Overlay(CVMFSRepo, layerPaths, singularityPath)
+	err = cvmfs.OverlayWithLogger(logger, CVMFSRepo, layerPaths, singularityPath)
 
 	n.Elapsed(t).
 		AddField("action", "end_overlay_merge").
@@ -1270,7 +1299,7 @@ func (img *Image) CreateFlatOverlay(CVMFSRepo string) (singularityPath string, e
 		Send()
 
 	if err != nil {
-		l.LogE(err).Error("Error in creating flat overlay for image")
+		logger.WithField("error", err).Error("Error in creating flat overlay for image")
 		return
 	}
 	return

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -974,6 +974,7 @@ func (img *Image) GetLayersWithLogger(logger *log.Entry, manifest da.Manifest, l
 
 			layerLogger.Trace("Start working on layer")
 
+			t0 := time.Now()
 			toSend, err := layerDownloader.DownloadLayer(layer)
 
 			if err != nil {
@@ -981,6 +982,10 @@ func (img *Image) GetLayersWithLogger(logger *log.Entry, manifest da.Manifest, l
 				toSend.Close()
 				return
 			}
+			layerLogger.WithFields(log.Fields{
+				"duration":    time.Since(t0).Round(time.Millisecond),
+				"size":        fmt.Sprintf("%.1f MB", float64(layer.Size)/1e6),
+			}).Info("Layer download finished")
 			select {
 			case layersChan <- toSend:
 				return

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -974,7 +974,6 @@ func (img *Image) GetLayersWithLogger(logger *log.Entry, manifest da.Manifest, l
 
 			layerLogger.Trace("Start working on layer")
 
-			t0 := time.Now()
 			toSend, err := layerDownloader.DownloadLayer(layer)
 
 			if err != nil {
@@ -982,10 +981,6 @@ func (img *Image) GetLayersWithLogger(logger *log.Entry, manifest da.Manifest, l
 				toSend.Close()
 				return
 			}
-			layerLogger.WithFields(log.Fields{
-				"duration":    time.Since(t0).Round(time.Millisecond),
-				"size":        fmt.Sprintf("%.1f MB", float64(layer.Size)/1e6),
-			}).Info("Layer download finished")
 			select {
 			case layersChan <- toSend:
 				return

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -29,6 +29,18 @@ import (
 	notification "github.com/cvmfs/ducc/notification"
 )
 
+var (
+	logCurlReqOnce    sync.Once
+	logCurlReqEnabled bool
+)
+
+func logCurlEnabled() bool {
+	logCurlReqOnce.Do(func() {
+		logCurlReqEnabled = os.Getenv("DUCC_DEBUG_LOG_CURL_REQ") != ""
+	})
+	return logCurlReqEnabled
+}
+
 type ManifestRequest struct {
 	Image    Image
 	Password string
@@ -755,12 +767,12 @@ func firstRequestForAuth_internal(url, user, pass string) (token string, err err
 		req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json")
 
 		// for debugging: log curl command corresponding to request
-		if log.IsLevelEnabled(log.TraceLevel) {
+		if logCurlEnabled() {
 			curlcmd, curlErr := curling.NewFromRequest(req)
 			if curlErr != nil {
 				log.Fatal(curlErr)
 			}
-			log.Trace(curlcmd)
+			log.Debug(curlcmd)
 		}
 
 		resp, respErr := client.Do(req)
@@ -1356,12 +1368,12 @@ func makeGetRequest(url string, headers map[string]string) ([]byte, error) {
 		}
 
 		// for debugging: log curl command corresponding to request
-		if log.IsLevelEnabled(log.TraceLevel) {
+		if logCurlEnabled() {
 			curlcmd, curlErr := curling.NewFromRequest(req)
 			if curlErr != nil {
 				log.Fatal(curlErr)
 			}
-			log.Trace(curlcmd)
+			log.Debug(curlcmd)
 		}
 
 		resp, respErr := client.Do(req)

--- a/ducc/lib/podman_store.go
+++ b/ducc/lib/podman_store.go
@@ -70,13 +70,18 @@ var (
 
 // creates layers.json file in podmanStore.
 func (img *Image) PublishLayerInfo(CVMFSRepo string, digestMap map[string]string) (err error) {
+	return img.PublishLayerInfoWithLogger(nil, CVMFSRepo, digestMap)
+}
+
+func (img *Image) PublishLayerInfoWithLogger(logger *log.Entry, CVMFSRepo string, digestMap map[string]string) (err error) {
+	logger = l.Ensure(logger)
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return
 	}
 	//create layers.json file
-	l.Log().WithFields(log.Fields{"action": "Ingesting layers.json in podman store"}).Info(img.GetSimpleName())
+	logger.WithFields(log.Fields{"action": "Ingesting layers.json in podman store"}).Trace(img.GetSimpleName())
 
 	layersdata := []LayerInfo{}
 	layerInfoPath := filepath.Join("/", "cvmfs", CVMFSRepo, rootPath, layerMetadataDir, "layers.json")
@@ -84,7 +89,7 @@ func (img *Image) PublishLayerInfo(CVMFSRepo string, digestMap map[string]string
 	if _, err := os.Stat(layerInfoPath); err == nil {
 		file, err := ioutil.ReadFile(layerInfoPath)
 		if err != nil {
-			l.LogE(err).Error("Error in reading layers.json file")
+			logger.WithField("error", err).Error("Error in reading layers.json file")
 			return err
 		}
 		json.Unmarshal(file, &layersdata)
@@ -101,7 +106,7 @@ func (img *Image) PublishLayerInfo(CVMFSRepo string, digestMap map[string]string
 		if _, err := os.Stat(storedlayerinfopath); err == nil {
 			file, err := ioutil.ReadFile(storedlayerinfopath)
 			if err != nil {
-				l.LogE(err).Error("Error in reading layers.json file")
+				logger.WithField("error", err).Error("Error in reading layers.json file")
 				return err
 			}
 			json.Unmarshal(file, &storedlayerdata)
@@ -137,13 +142,13 @@ func (img *Image) PublishLayerInfo(CVMFSRepo string, digestMap map[string]string
 	layersdata = append(layersdata, storedlayersdata...)
 	jsonLayerInfo, err := json.MarshalIndent(layersdata, "", " ")
 	if err != nil {
-		l.LogE(err).Error("Error in marshaling json data for layers.json")
+		logger.WithField("error", err).Error("Error in marshaling json data for layers.json")
 		return err
 	}
 
-	err = cvmfs.WriteDataToCvmfs(CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(layerInfoPath), jsonLayerInfo)
+	err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(layerInfoPath), jsonLayerInfo)
 	if err != nil {
-		l.LogE(err).Error("Error in writing layers.json file")
+		logger.WithField("error", err).Error("Error in writing layers.json file")
 		return err
 	}
 	return
@@ -151,13 +156,18 @@ func (img *Image) PublishLayerInfo(CVMFSRepo string, digestMap map[string]string
 
 // create images.json file in podmanStore
 func (img *Image) PublishImageInfo(CVMFSRepo string, digestMap map[string]string) (err error) {
+	return img.PublishImageInfoWithLogger(nil, CVMFSRepo, digestMap)
+}
+
+func (img *Image) PublishImageInfoWithLogger(logger *log.Entry, CVMFSRepo string, digestMap map[string]string) (err error) {
+	logger = l.Ensure(logger)
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return
 	}
 	//create images.json file
-	l.Log().WithFields(log.Fields{"action": "Ingesting images.json in podman store"}).Info(img.GetSimpleName())
+	logger.WithFields(log.Fields{"action": "Ingesting images.json in podman store"}).Trace(img.GetSimpleName())
 	imagedata := []ImageInfo{}
 	imageInfoPath := filepath.Join("/", "cvmfs", CVMFSRepo, rootPath, imageMetadataDir, "images.json")
 
@@ -165,7 +175,7 @@ func (img *Image) PublishImageInfo(CVMFSRepo string, digestMap map[string]string
 	if _, err := os.Stat(imageInfoPath); err == nil {
 		file, err := ioutil.ReadFile(imageInfoPath)
 		if err != nil {
-			l.LogE(err).Error("Error in reading images.json file")
+			logger.WithField("error", err).Error("Error in reading images.json file")
 			return err
 		}
 		json.Unmarshal(file, &imagedata)
@@ -187,13 +197,13 @@ func (img *Image) PublishImageInfo(CVMFSRepo string, digestMap map[string]string
 	imagedata = append(imagedata, *imageinfo)
 	imgInfo, err := json.MarshalIndent(imagedata, "", " ")
 	if err != nil {
-		l.LogE(err).Error("Error in marshaling json data for images.json")
+		logger.WithField("error", err).Error("Error in marshaling json data for images.json")
 		return err
 	}
 
-	err = cvmfs.WriteDataToCvmfs(CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(imageInfoPath), imgInfo)
+	err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(imageInfoPath), imgInfo)
 	if err != nil {
-		l.LogE(err).Error("Error in writing images.json")
+		logger.WithField("error", err).Error("Error in writing images.json")
 		return err
 	}
 	return nil
@@ -201,10 +211,15 @@ func (img *Image) PublishImageInfo(CVMFSRepo string, digestMap map[string]string
 
 // Ingest the exploded rootfs in podman store.
 func (img *Image) LinkRootfsIntoPodmanStore(CVMFSRepo, subDirInsideRepo string, digestMap map[string]string) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Ingesting layer rootfs into podman store for the image"}).Info(img.GetSimpleName())
+	return img.LinkRootfsIntoPodmanStoreWithLogger(nil, CVMFSRepo, subDirInsideRepo, digestMap)
+}
+
+func (img *Image) LinkRootfsIntoPodmanStoreWithLogger(logger *log.Entry, CVMFSRepo, subDirInsideRepo string, digestMap map[string]string) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "Ingesting layer rootfs into podman store for the image"}).Trace(img.GetSimpleName())
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return err
 	}
 	// this is extremely bad, we are making one transaction for each layer
@@ -221,9 +236,9 @@ func (img *Image) LinkRootfsIntoPodmanStore(CVMFSRepo, subDirInsideRepo string, 
 		targetPath := filepath.Join(subDirInsideRepo, layerid[:2], layerid, "layerfs")
 
 		if _, err := os.Stat(symlinkPath); os.IsNotExist(err) {
-			err = cvmfs.CreateSymlinkIntoCVMFS(CVMFSRepo, symlinkPath, targetPath)
+			err = cvmfs.CreateSymlinkIntoCVMFSWithLogger(logger, CVMFSRepo, symlinkPath, targetPath)
 			if err != nil {
-				l.LogE(err).Error("Error in creating the symlink for the diff dir")
+				logger.WithField("error", err).Error("Error in creating the symlink for the diff dir")
 				return err
 			}
 		}
@@ -233,10 +248,15 @@ func (img *Image) LinkRootfsIntoPodmanStore(CVMFSRepo, subDirInsideRepo string, 
 
 // Create the link dir and link file for exploded rootfs.
 func (img *Image) CreateLinkDir(CVMFSRepo, subDirInsideRepo string, digestMap, layerIdMap map[string]string) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Creating Link files for layer rootfs for the image"}).Info(img.GetSimpleName())
+	return img.CreateLinkDirWithLogger(nil, CVMFSRepo, subDirInsideRepo, digestMap, layerIdMap)
+}
+
+func (img *Image) CreateLinkDirWithLogger(logger *log.Entry, CVMFSRepo, subDirInsideRepo string, digestMap, layerIdMap map[string]string) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "Creating Link files for layer rootfs for the image"}).Trace(img.GetSimpleName())
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return err
 	}
 	// also here, we are making one transaction for each layer
@@ -250,13 +270,13 @@ func (img *Image) CreateLinkDir(CVMFSRepo, subDirInsideRepo string, digestMap, l
 			//generate the link id
 			lid, err := generateID(26)
 			if err != nil {
-				l.LogE(err).Error("Error generating file name for Link dir")
+				logger.WithField("error", err).Error("Error generating file name for Link dir")
 				return err
 			}
 			layerIdMap[layer.Digest] = filepath.Join("l", lid)
-			err = cvmfs.WriteDataToCvmfs(CVMFSRepo, linkPath, []byte(lid))
+			err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, linkPath, []byte(lid))
 			if err != nil {
-				l.LogE(err).Error("Error in writing link id to podman store")
+				logger.WithField("error", err).Error("Error in writing link id to podman store")
 				return err
 			}
 
@@ -264,15 +284,15 @@ func (img *Image) CreateLinkDir(CVMFSRepo, subDirInsideRepo string, digestMap, l
 			symlinkPath := filepath.Join(rootPath, rootfsDir, "l", lid)
 			targetPath := filepath.Join(rootPath, rootfsDir, layerdir, "diff")
 
-			err = cvmfs.CreateSymlinkIntoCVMFS(CVMFSRepo, symlinkPath, targetPath)
+			err = cvmfs.CreateSymlinkIntoCVMFSWithLogger(logger, CVMFSRepo, symlinkPath, targetPath)
 			if err != nil {
-				l.LogE(err).Error("Error in creating the symlink for the Link dir")
+				logger.WithField("error", err).Error("Error in creating the symlink for the Link dir")
 				return err
 			}
 		} else {
 			data, err := ioutil.ReadFile(linkPath)
 			if err != nil {
-				l.LogE(err).Error("Error in reading link file")
+				logger.WithField("error", err).Error("Error in reading link file")
 				return err
 			}
 			layerIdMap[layer.Digest] = string(data)
@@ -283,10 +303,15 @@ func (img *Image) CreateLinkDir(CVMFSRepo, subDirInsideRepo string, digestMap, l
 
 // Create the lower files for diff dirs to be used by podman.
 func (img *Image) CreateLowerFiles(CVMFSRepo string, digestMap, layerIdMap map[string]string) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Creating Lower files for diff dirs in podman store"}).Info(img.GetSimpleName())
+	return img.CreateLowerFilesWithLogger(nil, CVMFSRepo, digestMap, layerIdMap)
+}
+
+func (img *Image) CreateLowerFilesWithLogger(logger *log.Entry, CVMFSRepo string, digestMap, layerIdMap map[string]string) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "Creating Lower files for diff dirs in podman store"}).Trace(img.GetSimpleName())
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return err
 	}
 
@@ -305,16 +330,16 @@ func (img *Image) CreateLowerFiles(CVMFSRepo string, digestMap, layerIdMap map[s
 				if lastLowerData != "" {
 					lowerdata = lowerdata + ":" + lastLowerData
 				}
-				err = cvmfs.WriteDataToCvmfs(CVMFSRepo, lowerPath, []byte(lowerdata))
+				err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, lowerPath, []byte(lowerdata))
 				if err != nil {
-					l.LogE(err).Warn("Error in writing lower files")
+					logger.WithField("error", err).Warn("Error in writing lower files")
 					return err
 				}
 				lastLowerData = lowerdata
 			} else {
 				data, err := ioutil.ReadFile(lowerPath)
 				if err != nil {
-					l.LogE(err).Error("Error in reading lower file")
+					logger.WithField("error", err).Error("Error in reading lower file")
 					return err
 				}
 				lastLowerData = string(data)
@@ -327,16 +352,21 @@ func (img *Image) CreateLowerFiles(CVMFSRepo string, digestMap, layerIdMap map[s
 
 // Ingest the image config file in podman store.
 func (img *Image) CreateConfigFile(CVMFSRepo string) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Creating config file for the image in podman store"}).Info(img.GetSimpleName())
+	return img.CreateConfigFileWithLogger(nil, CVMFSRepo)
+}
+
+func (img *Image) CreateConfigFileWithLogger(logger *log.Entry, CVMFSRepo string) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "Creating config file for the image in podman store"}).Trace(img.GetSimpleName())
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return err
 	}
 	//generate config file path.
 	fname, err := generateConfigFileName(manifest.Config.Digest)
 	if err != nil {
-		l.LogE(err).Warning("Error in generating config file name")
+		logger.WithField("error", err).Warning("Error in generating config file name")
 		return err
 	}
 
@@ -347,14 +377,14 @@ func (img *Image) CreateConfigFile(CVMFSRepo string) (err error) {
 
 		token, err := firstRequestForAuth(configUrl)
 		if err != nil {
-			l.LogE(err).Warning("Unable to retrieve the token for downloading config file")
+			logger.WithField("error", err).Warning("Unable to retrieve the token for downloading config file")
 			return err
 		}
 
 		client := &http.Client{}
 		req, err := http.NewRequest("GET", configUrl, nil)
 		if err != nil {
-			l.LogE(err).Warning("Unable to create a request for getting config file.")
+			logger.WithField("error", err).Warning("Unable to create a request for getting config file.")
 			return err
 		}
 		req.Header.Set("Authorization", token)
@@ -362,16 +392,20 @@ func (img *Image) CreateConfigFile(CVMFSRepo string) (err error) {
 		req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
 
 		resp, err := client.Do(req)
+		if err != nil {
+			logger.WithField("error", err).Warning("Unable to retrieve config file")
+			return err
+		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			l.LogE(err).Warning("Error in reading the body from the configuration")
+			logger.WithField("error", err).Warning("Error in reading the body from the configuration")
 			return err
 		}
 
-		err = cvmfs.WriteDataToCvmfs(CVMFSRepo, configFilePath, []byte(body))
+		err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, configFilePath, []byte(body))
 		if err != nil {
-			l.LogE(err).Warning("Error in writing config file")
+			logger.WithField("error", err).Warning("Error in writing config file")
 			return err
 		}
 	}
@@ -380,10 +414,15 @@ func (img *Image) CreateConfigFile(CVMFSRepo string) (err error) {
 
 // Ingest the image manifest in podman store.
 func (img *Image) PublishImageManifest(CVMFSRepo string) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Creating manifest file for the image in podman store"}).Info(img.GetSimpleName())
+	return img.PublishImageManifestWithLogger(nil, CVMFSRepo)
+}
+
+func (img *Image) PublishImageManifestWithLogger(logger *log.Entry, CVMFSRepo string) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "Creating manifest file for the image in podman store"}).Trace(img.GetSimpleName())
 	manifest, err := img.GetManifest()
 	if err != nil {
-		l.LogE(err).Warn("Error in getting the image manifest")
+		logger.WithField("error", err).Warn("Error in getting the image manifest")
 		return err
 	}
 	imageID := strings.Split(manifest.Config.Digest, ":")[1]
@@ -391,9 +430,9 @@ func (img *Image) PublishImageManifest(CVMFSRepo string) (err error) {
 	symlinkPath := filepath.Join(rootPath, imageMetadataDir, imageID, "manifest")
 	targetPath := filepath.Join(".metadata", img.Registry, img.Repository+img.GetReference(), "manifest.json")
 
-	err = cvmfs.CreateSymlinkIntoCVMFS(CVMFSRepo, symlinkPath, targetPath)
+	err = cvmfs.CreateSymlinkIntoCVMFSWithLogger(logger, CVMFSRepo, symlinkPath, targetPath)
 	if err != nil {
-		l.LogE(err).Error("Error in creating the symlink for manifest.json")
+		logger.WithField("error", err).Error("Error in creating the symlink for manifest.json")
 		return err
 	}
 	return nil
@@ -402,7 +441,12 @@ func (img *Image) PublishImageManifest(CVMFSRepo string) (err error) {
 // Create images.lock and layers.lock file to be used by podman.
 // Libpod expects these files to be present in its image stores.
 func (img *Image) CreateLockFiles(CVMFSRepo string) (err error) {
-	l.Log().WithFields(log.Fields{"action": "Creating lock file for the image"}).Info(img.GetSimpleName())
+	return img.CreateLockFilesWithLogger(nil, CVMFSRepo)
+}
+
+func (img *Image) CreateLockFilesWithLogger(logger *log.Entry, CVMFSRepo string) (err error) {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "Creating lock file for the image"}).Trace(img.GetSimpleName())
 	layerlockpath := filepath.Join("/cvmfs", CVMFSRepo, rootPath, layerMetadataDir, "layers.lock")
 	imagelockpath := filepath.Join("/cvmfs", CVMFSRepo, rootPath, imageMetadataDir, "images.lock")
 	var paths []string
@@ -416,11 +460,13 @@ func (img *Image) CreateLockFiles(CVMFSRepo string) (err error) {
 	for _, file := range paths {
 		if _, err := os.Stat(file); os.IsNotExist(err) {
 			tmpFile, err := ioutil.TempFile("", "lock")
-			tmpFile.Close()
 			if err != nil {
 				return err
 			}
-			err = cvmfs.PublishToCVMFS(CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(file), tmpFile.Name())
+			if err := tmpFile.Close(); err != nil {
+				return err
+			}
+			err = cvmfs.PublishToCVMFSWithLogger(logger, CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(file), tmpFile.Name())
 			os.RemoveAll(tmpFile.Name())
 			if err != nil {
 				return err
@@ -434,7 +480,12 @@ func (img *Image) CreateLockFiles(CVMFSRepo string) (err error) {
 // If an older version is found, removes it from store and updates images.json file.
 // Note: The layers are not removed. Only the manifest, config file and images.json are updated.
 func (img *Image) CheckImageChanged(CVMFSRepo string) error {
-	l.Log().WithFields(log.Fields{"action": "checking if old image version with same tag exists"}).Info(img.GetSimpleName())
+	return img.CheckImageChangedWithLogger(nil, CVMFSRepo)
+}
+
+func (img *Image) CheckImageChangedWithLogger(logger *log.Entry, CVMFSRepo string) error {
+	logger = l.Ensure(logger)
+	logger.WithFields(log.Fields{"action": "checking if old image version with same tag exists"}).Trace(img.GetSimpleName())
 	path := filepath.Join("/cvmfs", CVMFSRepo, rootPath, imageMetadataDir, "images.json")
 	if _, err := os.Stat(path); err == nil {
 		var imagesinfo []ImageInfo
@@ -442,7 +493,7 @@ func (img *Image) CheckImageChanged(CVMFSRepo string) error {
 
 		file, err := ioutil.ReadFile(path)
 		if err != nil {
-			l.LogE(err).Error("error in reading images.json file")
+			logger.WithField("error", err).Error("error in reading images.json file")
 			return err
 		}
 
@@ -453,11 +504,11 @@ func (img *Image) CheckImageChanged(CVMFSRepo string) error {
 				// we have already checked if the same image is present in the podman store or not.
 				// hence if the we find another image with same name, it means its content (digest) has changed.
 				if name == img.GetSimpleName() {
-					l.Log().WithFields(log.Fields{"image": img.GetSimpleName()}).Info("older image version present, cleaning and ingesting newer version")
+					logger.Info("older image version present, cleaning and ingesting newer version")
 					present = true
-					err := cvmfs.RemoveDirectory(CVMFSRepo, rootPath, imageMetadataDir, image.ID)
+					err := cvmfs.RemoveDirectoryWithLogger(logger, CVMFSRepo, rootPath, imageMetadataDir, image.ID)
 					if err != nil {
-						l.LogE(err).Error("error while removing older image version from podman store")
+						logger.WithField("error", err).Error("error while removing older image version from podman store")
 						return err
 					}
 					break
@@ -469,13 +520,13 @@ func (img *Image) CheckImageChanged(CVMFSRepo string) error {
 		}
 		imgInfo, err := json.MarshalIndent(newimagesinfo, "", " ")
 		if err != nil {
-			l.LogE(err).Error("Error in marshaling json data for images.json")
+			logger.WithField("error", err).Error("Error in marshaling json data for images.json")
 			return err
 		}
 
-		err = cvmfs.WriteDataToCvmfs(CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(path), imgInfo)
+		err = cvmfs.WriteDataToCvmfsWithLogger(logger, CVMFSRepo, cvmfs.TrimCVMFSRepoPrefix(path), imgInfo)
 		if err != nil {
-			l.LogE(err).Error("Error in writing images.json")
+			logger.WithField("error", err).Error("Error in writing images.json")
 			return err
 		}
 	}
@@ -484,6 +535,11 @@ func (img *Image) CheckImageChanged(CVMFSRepo string) error {
 
 // Ingest all the necessary files and dir in podmanStore dir.
 func (img *Image) CreatePodmanImageStore(CVMFSRepo, subDirInsideRepo string) (err error) {
+	return img.CreatePodmanImageStoreWithLogger(nil, CVMFSRepo, subDirInsideRepo)
+}
+
+func (img *Image) CreatePodmanImageStoreWithLogger(logger *log.Entry, CVMFSRepo, subDirInsideRepo string) (err error) {
+	logger = l.Ensure(logger)
 	// this code is extremely slow
 	// if opens and publish several transaction and I believe it is possible to do pretty much anything in a single transaction
 	// it should be rewritten.
@@ -494,26 +550,26 @@ func (img *Image) CreatePodmanImageStore(CVMFSRepo, subDirInsideRepo string) (er
 		n.Elapsed(t).Action("end_podman_ingestion").Send()
 	}()
 
-	err = img.CheckImageChanged(CVMFSRepo)
+	err = img.CheckImageChangedWithLogger(logger, CVMFSRepo)
 	if err != nil {
-		l.LogE(err).Error("error while checking if older image version with same tag present in store")
+		logger.WithField("error", err).Error("error while checking if older image version with same tag present in store")
 		return err
 	}
 
-	l.Log().WithFields(log.Fields{"action": "Ingest the image into podman store"}).Info(img.GetSimpleName())
+	logger.WithFields(log.Fields{"action": "Ingest the image into podman store"}).Trace(img.GetSimpleName())
 	createCatalogIntoDirs := []string{rootPath, filepath.Join(rootPath, rootfsDir), filepath.Join(rootPath, imageMetadataDir), filepath.Join(rootPath, layerMetadataDir)}
 	for _, dir := range createCatalogIntoDirs {
-		err = cvmfs.CreateCatalogIntoDir(CVMFSRepo, dir)
+		err = cvmfs.CreateCatalogIntoDirWithLogger(logger, CVMFSRepo, dir)
 		if err != nil {
-			l.LogE(err).WithFields(log.Fields{
+			logger.WithField("error", err).WithFields(log.Fields{
 				"directory": dir}).Error(
 				"Impossible to create subcatalog in the directory.")
 		}
 	}
 
-	err = img.CreateConfigFile(CVMFSRepo)
+	err = img.CreateConfigFileWithLogger(logger, CVMFSRepo)
 	if err != nil {
-		l.LogE(err).Error("Unable to create config file in podman store")
+		logger.WithField("error", err).Error("Unable to create config file in podman store")
 		return err
 	}
 
@@ -523,47 +579,47 @@ func (img *Image) CreatePodmanImageStore(CVMFSRepo, subDirInsideRepo string) (er
 	layerIdMap := make(map[string]string)
 
 	// no one read the layers.json file
-	err = img.PublishLayerInfo(CVMFSRepo, digestMap)
+	err = img.PublishLayerInfoWithLogger(logger, CVMFSRepo, digestMap)
 	if err != nil {
-		l.LogE(err).Error("Unable to create layers.json file in podman store")
+		logger.WithField("error", err).Error("Unable to create layers.json file in podman store")
 		return err
 	}
 
-	err = img.PublishImageInfo(CVMFSRepo, digestMap)
+	err = img.PublishImageInfoWithLogger(logger, CVMFSRepo, digestMap)
 	if err != nil {
-		l.LogE(err).Error("Unable to create images.json file in podman store")
+		logger.WithField("error", err).Error("Unable to create images.json file in podman store")
 		return err
 	}
 
-	err = img.LinkRootfsIntoPodmanStore(CVMFSRepo, subDirInsideRepo, digestMap)
+	err = img.LinkRootfsIntoPodmanStoreWithLogger(logger, CVMFSRepo, subDirInsideRepo, digestMap)
 	if err != nil {
-		l.LogE(err).Error("Error ingesting rootfs into podman image store")
+		logger.WithField("error", err).Error("Error ingesting rootfs into podman image store")
 		return err
 	}
 
-	err = img.CreateLinkDir(CVMFSRepo, subDirInsideRepo, digestMap, layerIdMap)
+	err = img.CreateLinkDirWithLogger(logger, CVMFSRepo, subDirInsideRepo, digestMap, layerIdMap)
 	if err != nil {
-		l.LogE(err).Error("Unable to create the link dir in podman store")
+		logger.WithField("error", err).Error("Unable to create the link dir in podman store")
 		return err
 	}
 
-	err = img.CreateLowerFiles(CVMFSRepo, digestMap, layerIdMap)
+	err = img.CreateLowerFilesWithLogger(logger, CVMFSRepo, digestMap, layerIdMap)
 	if err != nil {
-		l.LogE(err).Error("Unable to create the lower files in podman store")
+		logger.WithField("error", err).Error("Unable to create the lower files in podman store")
 		return err
 	}
 
-	err = img.CreateLockFiles(CVMFSRepo)
+	err = img.CreateLockFilesWithLogger(logger, CVMFSRepo)
 	if err != nil {
-		l.LogE(err).Error("Unable to create lock files in podman store")
+		logger.WithField("error", err).Error("Unable to create lock files in podman store")
 		return err
 	}
 
-	err = img.PublishImageManifest(CVMFSRepo)
+	err = img.PublishImageManifestWithLogger(logger, CVMFSRepo)
 	if err != nil {
-		l.LogE(err).Error("Unable to create manifest file in podman store")
+		logger.WithField("error", err).Error("Unable to create manifest file in podman store")
 		return err
 	}
-	l.Log().Info("Image successfully ingested into podmanStore")
+	logger.Trace("Image successfully ingested into podmanStore")
 	return nil
 }

--- a/ducc/lib/recipe.go
+++ b/ducc/lib/recipe.go
@@ -31,6 +31,7 @@ type Recipe struct {
 	Repo             string
 	Wishes           chan WishFriendly
 	IgnoreErrorsList []string
+	OutputFormat     string
 }
 
 // loadIgnoreErrorsList loads the ignore errors list from an external file if DUCC_IGNORE_ERRORS_FILE env var is set
@@ -67,6 +68,7 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 	recipe := Recipe{}
 	recipe.Repo = recipeYamlV1.CVMFSRepo
 	recipe.Wishes = make(chan WishFriendly, 500)
+	recipe.OutputFormat = recipeYamlV1.OutputFormat
 
 	// Load ignore errors list from recipe file
 	recipe.IgnoreErrorsList = recipeYamlV1.IgnoreErrors
@@ -102,15 +104,11 @@ func ParseYamlRecipeV1(data []byte) (Recipe, error) {
 	for reg, inputImages := range registryMap {
 		wg.Add(1)
 		go func(inputImages []Image, reg string) {
-			l.Log().Info("Starting with", inputImages[0])
 			defer wg.Done()
 			for _, input := range inputImages {
 				if reg == "gitlab-registry.cern.ch" {
 					time.Sleep(500*time.Millisecond + time.Duration(rand.Intn(500))*time.Millisecond)
 				}
-
-				l.Log().Info(reg)
-				l.Log().Info(input)
 
 				output := formatOutputImage(recipeYamlV1.OutputFormat, input)
 				wish, err := CreateWish(input, output, recipeYamlV1.CVMFSRepo, recipeYamlV1.User, recipeYamlV1.User)
@@ -129,7 +127,6 @@ func formatOutputImage(OutputFormat string, inputImage Image) string {
 
 	if OutputFormat == "" {
 		OutputFormat = "$(scheme)://$(registry)/$(repository)_thin:$(tag)"
-		l.Log().Info("Using default output image name ", OutputFormat)
 	}
 
 	s := strings.Replace(OutputFormat, "$(scheme)", inputImage.Scheme, 5)

--- a/ducc/lib/utils.go
+++ b/ducc/lib/utils.go
@@ -51,7 +51,7 @@ func NewOnDiskReadAndHash(r io.ReadCloser) (*OnDiskReadAndHash, error) {
 		os.RemoveAll(f.Name())
 		return &OnDiskReadAndHash{}, err
 	}
-	l.Log().Info("Done downloading")
+	l.Log().Trace("Done downloading")
 	readAndHash := NewReadAndHash(f)
 	return &OnDiskReadAndHash{ReadAndHash: readAndHash, path: f.Name()}, nil
 }

--- a/ducc/lib/wish.go
+++ b/ducc/lib/wish.go
@@ -83,6 +83,17 @@ func CreateWish(inputImg Image, outputImage, cvmfsRepo, userInput, userOutput st
 	}()
 	wg.Wait()
 
+	if iImage.TagWildcard {
+		tags := make([]string, 0, len(expandedTagImagesLayer))
+		for _, img := range expandedTagImagesLayer {
+			tags = append(tags, img.Tag)
+		}
+		l.Log().WithFields(log.Fields{
+			"input image":   inputImg.WholeName(),
+			"expanded tags": tags,
+		}).Info("Expanded wildcard")
+	}
+
 	wish.ExpandedTagImagesLayer = expandedTagImagesLayer
 	wish.ExpandedTagImagesFlat = expandedTagImagesFlat
 

--- a/ducc/log/log.go
+++ b/ducc/log/log.go
@@ -11,3 +11,24 @@ func LogE(err error) *log.Entry {
 func Log() *log.Entry {
 	return log.WithFields(log.Fields{})
 }
+
+func Ensure(entry *log.Entry) *log.Entry {
+	if entry != nil {
+		return entry
+	}
+	return Log()
+}
+
+func WithImage(image string) *log.Entry {
+	if image == "" {
+		return Log()
+	}
+	return Log().WithField("image", image)
+}
+
+func WithImageE(err error, image string) *log.Entry {
+	if image == "" {
+		return LogE(err)
+	}
+	return LogE(err).WithField("image", image)
+}


### PR DESCRIPTION
Much of the current log output of the unpacker lacks context (especially when a lot of images are unpacked at the same time, it becomes impssible to know what "Start transaction" refers to) or usefulness. With this PR, it goes from:

```
INFO[0000] Skipping the creation of the thin image since did not provided a name for the thin image using the --thin-image-name flag
INFO[0000] [cvmfs_server list]                           action=executing
INFO[0000] Start ingesting                               action=ingesting target=/tmp/tempCatalog2475491397
INFO[0000] Start transaction                             action=ingesting target=/tmp/tempCatalog2475491397
INFO[0000] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0000] Copying target into path                      action=ingesting path=/cvmfs/test.cern.ch/.layers/.cvmfscatalog target=/tmp/tempCatalog2475491397
INFO[0000] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0001] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0001] Deleting temporary directory                  action=ingesting target=/tmp/tempCatalog2475491397
INFO[0001] Manifest not existing
INFO[0001] Start working on layer                        layer="sha256:56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819"
INFO[0001] Make request for layer                        layer="sha256:56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819" size in MB=106
INFO[0001] Start Ingesting the file into CVMFS           layer="sha256:56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819"
INFO[0001] Start ingesting                               action=ingesting target=/tmp/tempCatalog1442080767
INFO[0001] Start transaction                             action=ingesting target=/tmp/tempCatalog1442080767
INFO[0001] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0001] Copying target into path                      action=ingesting path=/cvmfs/test.cern.ch/.layers/56/.cvmfscatalog target=/tmp/tempCatalog1442080767
INFO[0001] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0002] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0002] Deleting temporary directory                  action=ingesting target=/tmp/tempCatalog1442080767
INFO[0002] [cvmfs_server ingest --catalog -t - -b .layers/56/56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819/layerfs test.cern.ch]  action=executing
INFO[0011] Copied n bytes to STDIN                       n=267424256
INFO[0011] Copied additionally n bytes to STDIN          n=0
INFO[0016] store layer information in .layers            action="Ingesting layers.json"
INFO[0016] Start ingesting                               action=ingesting target=/tmp/write_data308678420
INFO[0016] Start transaction                             action=ingesting target=/tmp/write_data308678420
INFO[0016] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0016] Copying target into path                      action=ingesting path=/cvmfs/test.cern.ch/.layers/56/56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819/.metadata/layers.json target=/tmp/write_data308678420
INFO[0016] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0017] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0017] Deleting temporary directory                  action=ingesting target=/tmp/write_data308678420
INFO[0017] Finish Ingesting the file                     layer="sha256:56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819"
INFO[0017] Finished pushing the layers into CVMFS
INFO[0017] Start saving backlinks                        action="save backlink" repo=test.cern.ch
INFO[0017] Start transaction                             action="save backlink" repo=test.cern.ch
INFO[0017] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0017] Wrote backlink                                action="save backlink" error="<nil>" file=/cvmfs/test.cern.ch/.layers/56/56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819/.metadata/origin.json repo=test.cern.ch
INFO[0017] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0018] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0018] Start ingesting                               action=ingesting target=/tmp/conversion1822613292/manifest.json
INFO[0018] Start transaction                             action=ingesting target=/tmp/conversion1822613292/manifest.json
INFO[0018] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0018] Copying target into path                      action=ingesting path="/cvmfs/test.cern.ch/.metadata/gitlab-registry.cern.ch/linuxsupport/alma10-base:10/manifest.json" target=/tmp/conversion1822613292/manifest.json
INFO[0018] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0019] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0019] Deleting temporary directory                  action=ingesting target=/tmp/conversion1822613292/manifest.json
INFO[0019] Conversion completed
INFO[0019] Successfully converted the layers             attempts number=0 error="<nil>" input image="https://gitlab-registry.cern.ch/linuxsupport/alma10-base:10" repository=test.cern.ch total attempts=1
INFO[0019] Start ingesting                               action=ingesting target=/tmp/tempCatalog3663649262
INFO[0019] Start transaction                             action=ingesting target=/tmp/tempCatalog3663649262
INFO[0019] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0019] Copying target into path                      action=ingesting path=/cvmfs/test.cern.ch/.flat/.cvmfscatalog target=/tmp/tempCatalog3663649262
INFO[0019] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0020] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0020] Deleting temporary directory                  action=ingesting target=/tmp/tempCatalog3663649262
INFO[0020] Checking if images links are up to date.      err stats private path="stat /cvmfs/test.cern.ch/.flat/55/55ebb6aede661a356a8dab025e3101651ae0720b66aaa3ad2e753829e754c9e0: no such file or directory" err stats pubblic path="stat /cvmfs/test.cern.ch/gitlab-registry.cern.ch/linuxsupport/alma10-base:10: no such file or directory" image="gitlab-registry.cern.ch/linuxsupport/alma10-base:10" private path=/cvmfs/test.cern.ch/.flat/55/55ebb6aede661a356a8dab025e3101651ae0720b66aaa3ad2e753829e754c9e0 public path="/cvmfs/test.cern.ch/gitlab-registry.cern.ch/linuxsupport/alma10-base:10"
INFO[0020] Starting overlay merge                        action=overlay dest=.flat/55/55ebb6aede661a356a8dab025e3101651ae0720b66aaa3ad2e753829e754c9e0 layers=.layers/56/56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819/layerfs repo=test.cern.ch
INFO[0020] [cvmfs_server overlay -l .layers/56/56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819/layerfs -d .flat/55/55ebb6aede661a356a8dab025e3101651ae0720b66aaa3ad2e753829e754c9e0 test.cern.ch]  action=executing
INFO[0021] Overlay merge complete                        action=overlay dest=.flat/55/55ebb6aede661a356a8dab025e3101651ae0720b66aaa3ad2e753829e754c9e0 layers=.layers/56/56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819/layerfs repo=test.cern.ch
INFO[0021] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0022] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0022] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0022] [cvmfs_server transaction test.cern.ch]       action=executing
INFO[0022] [cvmfs_server publish test.cern.ch]           action=executing
INFO[0023] Publish complete                              error="<nil>" repo=test.cern.ch
INFO[0023] Successfully created the singularity image    attempts number=0 error="<nil>" input image="https://gitlab-registry.cern.ch/linuxsupport/alma10-base:10" repository=test.cern.ch total attempts=1
```

to

```
INFO[0001] Starting layer conversion                     already converted="[]" image="gitlab-registry.cern.ch/linuxsupport/alma10-base:10" layers to convert="[56a82dc42e4d]"
INFO[0017] Layer ingest into CVMFS finished              duration=15.984s image="gitlab-registry.cern.ch/linuxsupport/alma10-base:10" layer="sha256:56a82dc42e4d6189552134793b03de54c19c3f053bfb36d06f161b23b7acf819" size="267.4 MB"
INFO[0019] Successfully converted the layers             attempts number=0 error="<nil>" input image="https://gitlab-registry.cern.ch/linuxsupport/alma10-base:10" repository=test.cern.ch total attempts=1
INFO[0019] Conversion summary for https://gitlab-registry.cern.ch/linuxsupport/alma10-base:10:  added="[gitlab-registry.cern.ch/linuxsupport/alma10-base:10]" already converted="[]" updated="[]"
INFO[0023] Created flat image and symlink                flat path=/cvmfs/test.cern.ch/.flat/55/55ebb6aede661a356a8dab025e3101651ae0720b66aaa3ad2e753829e754c9e0 image="gitlab-registry.cern.ch/linuxsupport/alma10-base:10" symlink path="/cvmfs/test.cern.ch/gitlab-registry.cern.ch/linuxsupport/alma10-base:10"
INFO[0023] Successfully created the singularity image    attempts number=0 error="<nil>" input image="https://gitlab-registry.cern.ch/linuxsupport/alma10-base:10" repository=test.cern.ch total attempts=1
```

Bit of a huge PR, but I think the benefits are evident. There is still the `-v trace` argument that restores much of the previous wordiness.