### PR TITLE
Fix default for CMAKE_EXPORT_COMPILE_COMMANDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@
 #
 
 cmake_minimum_required (VERSION 3.24..3.30)
+
+# Enable creation of compile_commands.json by default. Needed by LSPs, useful for devs
+# Must be set before project() so the generator picks it up
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "Export compile_commands.json for LSPs")
+
 set (PROJECT_NAME "CernVM-FS")
 project (${PROJECT_NAME})
 

--- a/cmake/Modules/cvmfs_options.cmake
+++ b/cmake/Modules/cvmfs_options.cmake
@@ -64,8 +64,4 @@ set (BUILTIN_EXTERNALS_EXCLUDE ${BUILTIN_EXTERNALS_EXCLUDE_DEFAULT} CACHE STRING
 
 
 option (ENABLE_ASAN             "Enable the Address Sanitizer"                                     OFF)
-# Enable creation of compile_commands.json by default. Needed by LSPs, useful for devs
-if(NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
-    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-endif()
 option (CHECK_SYSTEM_HEADERS    "Check System for required headers"                                 OFF)


### PR DESCRIPTION
The lines we had in cvmfs_options.cmake were not effective because this has to be set before project()