### PR TITLE
Graceful abort of a transaction under out-of-diskspace conditions

### DIFF
--- a/cvmfs/publish/cmd_abort.cc
+++ b/cvmfs/publish/cmd_abort.cc
@@ -134,7 +134,10 @@ int CmdAbort::Main(const Options &options) {
   }
 
   UniquePtr<Publisher> publisher;
-  publisher = new Publisher(*settings);
+  // Pass exists=false to skip downloading the whitelist and manifest, which
+  // would fail under disk-full conditions. Abort only needs the session (to
+  // drop any gateway lease) and the managed node (to repair mount points).
+  publisher = new Publisher(*settings, false /* exists */);
 
   LogCvmfs(kLogCvmfs, kLogSyslog, "(%s) aborting transaction",
            settings->fqrn().c_str());

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -156,6 +156,8 @@ void Repository::DownloadRootObjects(const std::string &url,
   std::string reflog_path;
   FILE *reflog_fd = CreateTempFile(tmp_dir + "/reflog", kPrivateFileMode, "w",
                                    &reflog_path);
+  if (reflog_fd == NULL)
+    throw EPublish("cannot create reflog temp file (disk full?)");
   const std::string reflog_url = url + "/.cvmfsreflog";
   // TODO(jblomer): verify reflog hash
   // shash::Any reflog_hash(manifest_->GetHashAlgorithm());
@@ -181,6 +183,8 @@ void Repository::DownloadRootObjects(const std::string &url,
   std::string tags_path;
   FILE *tags_fd = CreateTempFile(tmp_dir + "/tags", kPrivateFileMode, "w",
                                  &tags_path);
+  if (tags_fd == NULL)
+    throw EPublish("cannot create tags temp file (disk full?)");
   if (!manifest_->history().IsNull()) {
     const std::string tags_url = url + "/data/"
                                  + manifest_->history().MakePath();
@@ -646,6 +650,13 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
                    EPublish::kFailLayoutRevision);
   }
 
+  // Session and managed node are needed even when skipping downloads (e.g.
+  // for abort under disk-full conditions), so initialize them before the
+  // early return below.
+  if (settings.is_managed())
+    managed_node_ = new ManagedNode(this);
+  session_ = new Session(settings_, llvl_);
+
   if (!exists)
     return;
 
@@ -685,9 +696,6 @@ Publisher::Publisher(const SettingsPublisher &settings, const bool exists)
       throw EPublish("corrupted keychain");
   }
 
-  if (settings.is_managed())
-    managed_node_ = new ManagedNode(this);
-  session_ = new Session(settings_, llvl_);
   if (in_transaction_.IsSet())
     ConstructSpoolers();
 }

--- a/cvmfs/publish/repository_managed.cc
+++ b/cvmfs/publish/repository_managed.cc
@@ -75,7 +75,10 @@ void Publisher::ManagedNode::ClearScratch() {
     // Disk full: cannot create a wastebin directory. Clean scratch/current
     // in place synchronously instead (deletion does not require free space).
     RunSuidHelper("clear_scratch", publisher_->settings_.fqrn());
-    // scratch_dir still exists and is now empty; chown without allocating space
+    // scratch_dir still exists and is now empty; chown without allocating space.
+    // AlterMountpoint(kAlterScratchWipe) is intentionally skipped: it runs
+    // clear_scratch_async to clean the wastebin, but no wastebin was created
+    // in this path so there is nothing to clean asynchronously.
     publisher_->CreateDirectoryAsOwner(scratch_dir, kDefaultDirMode);
   }
 

--- a/cvmfs/publish/repository_managed.cc
+++ b/cvmfs/publish/repository_managed.cc
@@ -63,16 +63,21 @@ void Publisher::ManagedNode::ClearScratch() {
       tmp_dir = publisher_->settings_.transaction().spool_area().tmp_dir();
 
   const std::string waste_dir = CreateTempDir(scratch_wastebin + "/waste");
-  if (waste_dir.empty())
-    throw EPublish("cannot create wastebin directory");
-  const int rvi = rename(scratch_dir.c_str(),
-                         (waste_dir + "/delete-me").c_str());
-  if (rvi != 0)
-    throw EPublish("cannot move scratch directory to wastebin");
-
-  publisher_->CreateDirectoryAsOwner(scratch_dir, kDefaultDirMode);
-
-  AlterMountpoint(kAlterScratchWipe, kLogSyslog);
+  if (!waste_dir.empty()) {
+    // Normal case: move scratch contents to wastebin for async cleanup.
+    const int rvi = rename(scratch_dir.c_str(),
+                           (waste_dir + "/delete-me").c_str());
+    if (rvi != 0)
+      throw EPublish("cannot move scratch directory to wastebin");
+    publisher_->CreateDirectoryAsOwner(scratch_dir, kDefaultDirMode);
+    AlterMountpoint(kAlterScratchWipe, kLogSyslog);
+  } else {
+    // Disk full: cannot create a wastebin directory. Clean scratch/current
+    // in place synchronously instead (deletion does not require free space).
+    RunSuidHelper("clear_scratch", publisher_->settings_.fqrn());
+    // scratch_dir still exists and is now empty; chown without allocating space
+    publisher_->CreateDirectoryAsOwner(scratch_dir, kDefaultDirMode);
+  }
 
   std::vector<mode_t> modes;
   std::vector<std::string> names;
@@ -100,9 +105,13 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
 
   int result = kFailOk;
 
-  shash::Any expected_hash = publisher_->manifest()->catalog_hash();
+  // expected_hash is left null when manifest is not available (e.g. abort
+  // with exists=false), in which case the root hash comparison is skipped.
   const UniquePtr<CheckoutMarker> marker(CheckoutMarker::CreateFrom(
       publisher_->settings_.transaction().spool_area().checkout_marker()));
+  shash::Any expected_hash;
+  if (publisher_->manifest() != NULL)
+    expected_hash = publisher_->manifest()->catalog_hash();
   if (marker.IsValid())
     expected_hash = marker->hash();
 
@@ -114,13 +123,15 @@ int Publisher::ManagedNode::Check(bool is_quiet) {
     const bool retval = platform_getxattr(rdonly_mnt, root_hash_xattr,
                                           &root_hash_str);
     if (retval) {
-      const shash::Any root_hash = shash::MkFromHexPtr(
-          shash::HexPtr(root_hash_str), shash::kSuffixCatalog);
-      if (expected_hash != root_hash) {
-        if (marker.IsValid()) {
-          result |= kFailRdOnlyWrongRevision;
-        } else {
-          result |= kFailRdOnlyOutdated;
+      if (!expected_hash.IsNull()) {
+        const shash::Any root_hash = shash::MkFromHexPtr(
+            shash::HexPtr(root_hash_str), shash::kSuffixCatalog);
+        if (expected_hash != root_hash) {
+          if (marker.IsValid()) {
+            result |= kFailRdOnlyWrongRevision;
+          } else {
+            result |= kFailRdOnlyOutdated;
+          }
         }
       }
     } else {

--- a/cvmfs/publish/repository_transaction.cc
+++ b/cvmfs/publish/repository_transaction.cc
@@ -116,6 +116,9 @@ void Publisher::TransactionImpl(bool waiting_on_lease) {
   }
 
   in_transaction_.Set();
+  // Pre-create the publishing lock file so that Abort() can acquire it even
+  // if the disk fills up before abort is called.
+  is_publishing_.Touch();
   ConstructSpoolers();
   if (marker.IsValid())
     settings_.GetTransaction()->SetBaseHash(marker->hash());

--- a/cvmfs/publish/repository_util.cc
+++ b/cvmfs/publish/repository_util.cc
@@ -17,6 +17,7 @@
 
 #include "crypto/hash.h"
 #include "publish/except.h"
+#include "util/logging.h"
 #include "util/posix.h"
 #include "util/string.h"
 
@@ -90,9 +91,14 @@ void ServerLockFile::Touch() {
   // Pre-create the lock file without locking it, so that a subsequent Lock()
   // can open the existing file even when the disk is full (e.g. during abort
   // after the repository's spool area has been filled up).
-  const int fd = open(path_.c_str(), O_RDONLY | O_CREAT, 0600);
-  if (fd >= 0)
+  const int fd = open(path_.c_str(), O_WRONLY | O_CREAT, 0600);
+  if (fd >= 0) {
     close(fd);
+  } else {
+    LogCvmfs(kLogCvmfs, kLogSyslogWarn,
+             "failed to pre-create lock file %s (errno: %d)",
+             path_.c_str(), errno);
+  }
 }
 
 

--- a/cvmfs/publish/repository_util.cc
+++ b/cvmfs/publish/repository_util.cc
@@ -84,6 +84,18 @@ bool ServerLockFile::TryLock() {
 }
 
 
+void ServerLockFile::Touch() {
+  if (fd_ >= 0)
+    return;
+  // Pre-create the lock file without locking it, so that a subsequent Lock()
+  // can open the existing file even when the disk is full (e.g. during abort
+  // after the repository's spool area has been filled up).
+  const int fd = open(path_.c_str(), O_RDONLY | O_CREAT, 0600);
+  if (fd >= 0)
+    close(fd);
+}
+
+
 void ServerLockFile::Unlock() {
   const int old_fd = fd_;
   assert(old_fd >= 0);

--- a/cvmfs/publish/repository_util.h
+++ b/cvmfs/publish/repository_util.h
@@ -53,6 +53,7 @@ class ServerLockFile {
   void Lock();
   bool TryLock();
   void Unlock();
+  void Touch();
 
   const std::string &path() const { return path_; }
 

--- a/test/src/716-abortdiskfull/main
+++ b/test/src/716-abortdiskfull/main
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+cvmfs_test_name="Abort Transaction Under Disk Full Conditions"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+# Script to fill the disk by creating files until touch fails
+filldisk_script() {
+  cat << 'FILLDISK_EOF'
+#!/bin/bash
+
+TARGET_DIR="${1:-$PWD}"
+OUTPUT_DIR="${2:-$TARGET_DIR}"
+TEST_FILE="${TARGET_DIR%/}/tmp/.diskfull_test_$$"
+
+disk_has_space() {
+    touch "$TEST_FILE" 2>/dev/null && rm -f "$TEST_FILE"
+}
+
+new_output_file() {
+    echo "${OUTPUT_DIR%/}/fillfile_$(tr -dc 'a-f0-9' </dev/urandom | head -c 32)"
+}
+
+FREE=$(( $(stat -f --format="%f * %S" "$TARGET_DIR") ))
+OUTPUT_FILE=$(new_output_file)
+
+echo "Attempting initial fallocate of $FREE bytes into $OUTPUT_FILE..."
+fallocate -l "$FREE" "$OUTPUT_FILE" 2>/dev/null
+
+while disk_has_space; do
+    for SHRINK in 1048576 524288 262144 131072 65536 32768 16384 8192 4096 2048 1024 512 256 128 64 32 16 8 4 2 1; do
+        ATTEMPT=$(( FREE - SHRINK ))
+        [ "$ATTEMPT" -le 0 ] && continue
+        OUTPUT_FILE=$(new_output_file)
+        echo "Trying $ATTEMPT bytes into $OUTPUT_FILE (FREE - $SHRINK)..."
+        if fallocate -l "$ATTEMPT" "$OUTPUT_FILE" 2>/dev/null; then
+            echo "fallocate succeeded, re-checking disk full..."
+            break
+        fi
+    done
+
+    disk_has_space || break
+
+    echo "Disk not full yet, retrying with fresh FREE measurement..."
+    FREE=$(( $(stat -f --format="%f * %S" "$TARGET_DIR") ))
+    OUTPUT_FILE=$(new_output_file)
+    fallocate -l "$FREE" "$OUTPUT_FILE" 2>/dev/null
+done
+
+echo "Disk is full (touch test failed)."
+FILLDISK_EOF
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  cleanup() {
+    echo "cleanup: removing fill files"
+    rm -f "$repo_dir"/tmp/fillfile_* "$repo_dir"/tmp/.diskfull_test_* 2>/dev/null || true
+  }
+  trap cleanup EXIT INT TERM HUP
+
+  echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "add filldisk script to the repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  filldisk_script > "$repo_dir/filldisk.sh"
+  chmod +x "$repo_dir/filldisk.sh"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "start a new transaction"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "run filldisk script to fill the disk"
+  local diskfill_log="${logfile%.log}.diskfill.log"
+  "$repo_dir/filldisk.sh" "$repo_dir" "$repo_dir/tmp" > "$diskfill_log" 2>&1
+
+  echo "change working directory out of /cvmfs"
+  cd /tmp
+
+  echo "try to abort the transaction"
+  abort_transaction $CVMFS_TEST_REPO
+  local abort_result=$?
+
+  if [ $abort_result -ne 0 ]; then
+    echo "FAILED: Could not abort transaction under disk full conditions (exit code: $abort_result)"
+    return 100
+  fi
+
+  echo "SUCCESS: Transaction aborted successfully under disk full conditions"
+  return 0
+}

--- a/test/src/716-abortdiskfull/main
+++ b/test/src/716-abortdiskfull/main
@@ -84,6 +84,9 @@ cvmfs_run_test() {
   abort_transaction $CVMFS_TEST_REPO
   local abort_result=$?
 
+  # Free disk space before returning so the framework's cleanup can proceed.
+  cleanup
+
   if [ $abort_result -ne 0 ]; then
     echo "FAILED: Could not abort transaction under disk full conditions (exit code: $abort_result)"
     return 100


### PR DESCRIPTION
At least when the disk is filled up via the cvmfs overlay. When the disk is filled up outside of /var/spool/cvmfs/ there is still an issue remounting the overlay mounts ronly - not sure if that can be easily fixed.