### PR TITLE
Add cvmfs_swissknife rotate-statsdb

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -675,6 +675,7 @@ if (BUILD_SERVER)
        swissknife_overlay.cc
        swissknife_pull.cc
        swissknife_reflog.cc
+       swissknife_rotate_statsdb.cc
        swissknife_filestats.cc
        swissknife_scrub.cc
        swissknife_sign.cc

--- a/cvmfs/pkg/logrotate.d/cvmfs-statsdb
+++ b/cvmfs/pkg/logrotate.d/cvmfs-statsdb
@@ -9,7 +9,7 @@
     nomail
 }
 
-# vacuum the current stats db to stats.db.archive 
+# vacuum the current stats db to stats.db.archive
 /var/spool/cvmfs/*/stats.db {
     monthly
     rotate 0
@@ -22,9 +22,7 @@
         for db in /var/spool/cvmfs/*/stats.db; do
         if [ -f "$db" ]; then
         echo $db
-        rm ${db}.archive || true
-        sqlite3 $db "VACUUM INTO '${db}.archive';"
-        sqlite3 $db "delete from publish_statistics; delete from gc_statistics; vacuum;"
+        cvmfs_swissknife rotate-statsdb -p "$db"
         fi
         done
     endscript

--- a/cvmfs/swissknife_main.cc
+++ b/cvmfs/swissknife_main.cc
@@ -24,6 +24,7 @@
 #include "swissknife_overlay.h"
 #include "swissknife_pull.h"
 #include "swissknife_reflog.h"
+#include "swissknife_rotate_statsdb.h"
 #include "swissknife_scrub.h"
 #include "swissknife_sign.h"
 #include "swissknife_sync.h"
@@ -104,6 +105,7 @@ int main(int argc, char **argv) {
   command_list.push_back(new swissknife::CommandNotify());
   command_list.push_back(new swissknife::CommandOverlay());
   command_list.push_back(new swissknife::CommandFileStats());
+  command_list.push_back(new swissknife::CommandRotateStatsDB());
 
   if (argc < 2) {
     Usage();

--- a/cvmfs/swissknife_rotate_statsdb.cc
+++ b/cvmfs/swissknife_rotate_statsdb.cc
@@ -1,0 +1,99 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * Rotates the statistics database for a CernVM-FS repository. This is
+ * intended to be called from logrotate instead of the system sqlite3 binary,
+ * so that the vendored SQLite (which supports VACUUM INTO) is used regardless
+ * of the system SQLite version.
+ */
+
+#include "swissknife_rotate_statsdb.h"
+
+#include <string>
+#include <unistd.h>
+
+#include "sql.h"
+#include "statistics_database.h"
+#include "util/logging.h"
+#include "util/posix.h"
+
+namespace swissknife {
+
+ParameterList CommandRotateStatsDB::GetParams() const {
+  ParameterList r;
+  r.push_back(Parameter::Mandatory('p', "path to the stats.db file"));
+  return r;
+}
+
+int CommandRotateStatsDB::Main(const ArgumentList &args) {
+  const std::string db_path = *args.find('p')->second;
+  const std::string archive_path = db_path + ".archive";
+
+  if (!FileExists(db_path)) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "stats.db not found: %s",
+             db_path.c_str());
+    return 1;
+  }
+
+  // Remove any existing archive so VACUUM INTO can write a fresh one
+  if (FileExists(archive_path)) {
+    if (unlink(archive_path.c_str()) != 0) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed to remove existing archive: %s",
+               archive_path.c_str());
+      return 1;
+    }
+  }
+
+  StatisticsDatabase *db =
+      StatisticsDatabase::Open(db_path, StatisticsDatabase::kOpenReadWrite);
+  if (db == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failed to open statistics database: %s",
+             db_path.c_str());
+    return 1;
+  }
+
+  // VACUUM INTO creates a compacted copy of the current database
+  const std::string vacuum_into =
+      "VACUUM INTO '" + archive_path + "';";
+  if (!sqlite::Sql(db->sqlite_db(), vacuum_into).Execute()) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "VACUUM INTO failed for %s: %s",
+             db_path.c_str(), db->GetLastErrorMsg().c_str());
+    delete db;
+    return 1;
+  }
+
+  // Clear all rows from the live database
+  if (!sqlite::Sql(db->sqlite_db(),
+                   "DELETE FROM publish_statistics;").Execute()) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "failed to clear publish_statistics in %s: %s",
+             db_path.c_str(), db->GetLastErrorMsg().c_str());
+    delete db;
+    return 1;
+  }
+  if (!sqlite::Sql(db->sqlite_db(),
+                   "DELETE FROM gc_statistics;").Execute()) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "failed to clear gc_statistics in %s: %s",
+             db_path.c_str(), db->GetLastErrorMsg().c_str());
+    delete db;
+    return 1;
+  }
+
+  // Reclaim space freed by the DELETEs
+  if (!db->Vacuum()) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "VACUUM failed for %s: %s",
+             db_path.c_str(), db->GetLastErrorMsg().c_str());
+    delete db;
+    return 1;
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Rotated statistics database: %s -> %s",
+           db_path.c_str(), archive_path.c_str());
+  delete db;
+  return 0;
+}
+
+}  // namespace swissknife

--- a/cvmfs/swissknife_rotate_statsdb.h
+++ b/cvmfs/swissknife_rotate_statsdb.h
@@ -1,0 +1,35 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_SWISSKNIFE_ROTATE_STATSDB_H_
+#define CVMFS_SWISSKNIFE_ROTATE_STATSDB_H_
+
+#include <string>
+
+#include "swissknife.h"
+
+namespace swissknife {
+
+/**
+ * Rotates the statistics database for a CernVM-FS repository.
+ * Archives the current stats.db via VACUUM INTO, then clears it.
+ * Uses the vendored SQLite to avoid depending on the system sqlite3 binary.
+ */
+class CommandRotateStatsDB : public Command {
+ public:
+  ~CommandRotateStatsDB() { }
+  virtual std::string GetName() const { return "rotate-statsdb"; }
+  virtual std::string GetDescription() const {
+    return "Rotate (archive and clear) a CernVM-FS repository statistics "
+           "database.\n"
+           "Archives the database via VACUUM INTO and then deletes all rows "
+           "from publish_statistics and gc_statistics tables.";
+  }
+  virtual ParameterList GetParams() const;
+  int Main(const ArgumentList &args);
+};
+
+}  // namespace swissknife
+
+#endif  // CVMFS_SWISSKNIFE_ROTATE_STATSDB_H_

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -744,11 +744,6 @@ systemctl daemon-reload
 %doc COPYING CITATION.cff README.md ChangeLog
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs
 %config(noreplace) %{_sysconfdir}/logrotate.d/cvmfs-statsdb
-# sqlite version on rhel8 is too old for the statsdb logrotate script (needs >= 3.27)
-%define sqlite_version %(sqlite3 --version 2>/dev/null | cut -d' ' -f1 || echo "0")
-%if "%(echo '%{sqlite_version}' | awk 'BEGIN{print ("%{sqlite_version}" < "3.27")}')" == "1"
-%exclude %{_sysconfdir}/logrotate.d/cvmfs-statsdb
-%endif
 %doc %{_mandir}/man1/cvmfs_server.1.gz
 %doc %{_mandir}/man1/cvmfs_swissknife.1.gz
 


### PR DESCRIPTION
Moves the VACUUM call needed  for the rotation of the statsdb from  sqlite3 to swissknife. That lets us use the vendored sqlite and avoid some packaging headaches.

Fixes https://github.com/cvmfs/cvmfs/issues/4087