### PR TITLE
Minor build system fixes in prep for 2.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ endif ()
 #
 
 # workaround for an issue with the libfuse3 target
-if (MACOS)
+if (MACOSX)
   set(BUILD_MANPAGES_DEFAULT OFF)
   set(BUILTIN_EXTERNALS_EXCLUDE_DEFAULT "sqlite3;zlib")
 else()

--- a/ci/build_incremental_multi.sh
+++ b/ci/build_incremental_multi.sh
@@ -46,7 +46,6 @@ if can_build_gateway; then
 fi
 
 
-export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000|https://proxy.golang.org|direct"
 
 echo "configuring using CMake..."
 cmake -DBUILD_SERVER=$build_server          \

--- a/ci/build_incremental_multi.sh
+++ b/ci/build_incremental_multi.sh
@@ -45,7 +45,8 @@ if can_build_gateway; then
   build_gateway="ON"
 fi
 
-host cvm-gomod-proxy1.cern.ch > /dev/null 2>&1 && export GOPROXY=http://cvm-gomod-proxy1.cern.ch:3000
+
+export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000,https://proxy.golang.org,direct"
 
 echo "configuring using CMake..."
 cmake -DBUILD_SERVER=$build_server          \

--- a/ci/build_incremental_multi.sh
+++ b/ci/build_incremental_multi.sh
@@ -46,7 +46,7 @@ if can_build_gateway; then
 fi
 
 
-export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000,https://proxy.golang.org,direct"
+export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000|https://proxy.golang.org|direct"
 
 echo "configuring using CMake..."
 cmake -DBUILD_SERVER=$build_server          \

--- a/ci/build_package.sh
+++ b/ci/build_package.sh
@@ -50,7 +50,7 @@ echo "++ $command_tmpl"
 [ -x $build_script ] || die "build script $build_script is not executable"
 
 # if available, setup a go module proxy
-host cvm-gomod-proxy1.cern.ch > /dev/null 2>&1 && export GOPROXY=http://cvm-gomod-proxy1.cern.ch:3000
+export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000,https://proxy.golang.org,direct"
 
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."

--- a/ci/build_package.sh
+++ b/ci/build_package.sh
@@ -49,8 +49,6 @@ echo "++ $command_tmpl"
 [ -f $build_script ] || die "build script $build_script doesn't exist"
 [ -x $build_script ] || die "build script $build_script is not executable"
 
-# if available, setup a go module proxy
-export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000|https://proxy.golang.org|direct"
 
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."

--- a/ci/build_package.sh
+++ b/ci/build_package.sh
@@ -50,7 +50,7 @@ echo "++ $command_tmpl"
 [ -x $build_script ] || die "build script $build_script is not executable"
 
 # if available, setup a go module proxy
-export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000,https://proxy.golang.org,direct"
+export GOPROXY="http://cvm-gomod-proxy1.cern.ch:3000|https://proxy.golang.org|direct"
 
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -96,6 +96,7 @@ fi
 DEB_BUILD_OPTIONS=parallel=$cpu_cores debuild ${DEBUILD_ARGS} --prepend-path=/usr/local/go/bin \
   -e  CVMFS_EXTERNALS_PREFIX="${CVMFS_EXTERNALS_PREFIX}" \
   -e  CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}" \
+  -e  GOPROXY="${GOPROXY}" \
   --check-dirname-level 0 \
   -us -uc
 cd ${CVMFS_RESULT_LOCATION}


### PR DESCRIPTION
* Fixes a typo that prevented the right defaults on MACOSX being set
* Pass throught the GOPROXY env var to debuild