### PR TITLE
unpacker: Skip overlay on error

### DIFF
--- a/ducc/cmd/convert.go
+++ b/ducc/cmd/convert.go
@@ -136,14 +136,14 @@ var convertCmd = &cobra.Command{
 			// Check if this wish is in the ignore errors list
 			isIgnored := isInIgnoreList(wish.InputName, recipe.IgnoreErrorsList)
 
-			summary, err := lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
+			summary, layerErr := lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
 			totalSummary.Merge(summary)
-			if err != nil {
+			if layerErr != nil {
 				if isIgnored {
-					l.LogE(err).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
+					l.LogE(layerErr).WithFields(fields).Warning("Error in converting wish (layers), but image is in ignoreErrors list")
 				} else {
-					l.LogE(err).WithFields(fields).Error("Error in converting wish (layers), going on")
-					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, err))
+					l.LogE(layerErr).WithFields(fields).Error("Error in converting wish (layers), going on")
+					conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] layers: %s", wish.InputName, layerErr))
 				}
 			} else {
 				if len(summary.Added) == 0 && len(summary.Updated) == 0 {
@@ -175,13 +175,17 @@ var convertCmd = &cobra.Command{
 				}
 			}
 			if !skipFlat {
-				err = lib.ConvertWishFlat(wish, multiArch)
-				if err != nil {
-					if isIgnored {
-						l.LogE(err).WithFields(fields).Warning("Error in converting wish (singularity), but image is in ignoreErrors list")
-					} else {
-						l.LogE(err).WithFields(fields).Error("Error in converting wish (singularity), going on")
-						conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] singularity: %s", wish.InputName, err))
+				if layerErr != nil {
+					l.LogE(layerErr).WithFields(fields).Warning("Skipping overlay: layer ingestion had errors")
+				} else {
+					err = lib.ConvertWishFlat(wish, multiArch)
+					if err != nil {
+						if isIgnored {
+							l.LogE(err).WithFields(fields).Warning("Error in converting wish (singularity), but image is in ignoreErrors list")
+						} else {
+							l.LogE(err).WithFields(fields).Error("Error in converting wish (singularity), going on")
+							conversionErrors = append(conversionErrors, fmt.Sprintf("[%s] singularity: %s", wish.InputName, err))
+						}
 					}
 				}
 			}

--- a/ducc/cmd/convert_single_image.go
+++ b/ducc/cmd/convert_single_image.go
@@ -99,13 +99,15 @@ var convertSingleImageCmd = &cobra.Command{
 
 		var conversionErrors []string
 		totalSummary := lib.ConversionSummary{}
+		var layerErr error
 
 		for i := 0; i < attempts; i++ {
-			attemptSummary, err := lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
+			var attemptSummary lib.ConversionSummary
+			attemptSummary, layerErr = lib.ConvertWish(wish, convertAgain, overwriteLayer, multiArch, maxConcurrentDownloads)
 			totalSummary.Merge(attemptSummary)
-			log := l.LogE(err).WithFields(fields).
+			log := l.LogE(layerErr).WithFields(fields).
 				WithFields(log.Fields{"attempts number": i})
-			if err != nil {
+			if layerErr != nil {
 				log.Warning("Could not convert wish (layers), trying again")
 			} else {
 				if len(totalSummary.Added) == 0 && len(totalSummary.Updated) == 0 {
@@ -116,28 +118,31 @@ var convertSingleImageCmd = &cobra.Command{
 				break
 			}
 		}
-		if err != nil {
+		if layerErr != nil {
 			log.Error("Multiple Errors in converting layers, going on")
-			conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", err))
+			conversionErrors = append(conversionErrors, fmt.Sprintf("layers: %s", layerErr))
 		}
 		logConversionSummary(fmt.Sprintf("Conversion summary for %s:", wish.InputName), totalSummary)
 
 		if !skipFlat {
-			for i := 0; i < attempts; i++ {
-				err = lib.ConvertWishFlat(wish, multiArch)
-				log := l.LogE(err).WithFields(fields).
-					WithFields(log.Fields{"attempts number": i})
-				if err != nil {
-					log.Warning("Error in converting singularity image, trying again")
-				} else {
-					log.Info("Successfully created the singularity image")
-					break
+			if layerErr != nil {
+				l.LogE(layerErr).WithFields(fields).Warning("Skipping overlay: layer ingestion had errors")
+			} else {
+				for i := 0; i < attempts; i++ {
+					err = lib.ConvertWishFlat(wish, multiArch)
+					log := l.LogE(err).WithFields(fields).
+						WithFields(log.Fields{"attempts number": i})
+					if err != nil {
+						log.Warning("Error in converting singularity image, trying again")
+					} else {
+						log.Info("Successfully created the singularity image")
+						break
+					}
 				}
-			}
-
-			if err != nil {
-				log.Error("Multiple Errors in converting singularity image, going on")
-				conversionErrors = append(conversionErrors, fmt.Sprintf("singularity: %s", err))
+				if err != nil {
+					log.Error("Multiple Errors in converting singularity image, going on")
+					conversionErrors = append(conversionErrors, fmt.Sprintf("singularity: %s", err))
+				}
 			}
 		}
 

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -636,7 +636,7 @@ func convertInputOutput2(inputImage *Image, imageLabel, nameWithArch, repo strin
 	}
 
 	logger.Warn("Some error during the conversion, we are not storing it into the database")
-	return ConversionUnknown, nil
+	return ConversionUnknown, fmt.Errorf("error ingesting one or more layers for image %s", inputImage.GetSimpleName())
 }
 
 func CreateThinImage(manifest da.Manifest, layerLocations map[string]string, inputImage, outputImage Image) (err error) {


### PR DESCRIPTION
If one or more layer fails to be ingested, the overlay would still run, which is guaranteed to fail, so bail out early.