### PR TITLE
unpacker: Implement multi-arch symlinks

### DIFF
--- a/ducc/cmd/convert_single_image_test.go
+++ b/ducc/cmd/convert_single_image_test.go
@@ -32,11 +32,30 @@ func TestCheckConvertSingleImageLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-func TestCheckConvertSingleImageLocalMultiArch(t *testing.T) {
+
+func TestCheckConvertSingleImageCmdDockerhubMultiArch(t *testing.T) {
+	if !*testutils.Online {
+		t.Skip("Skipping test in offline mode.")
+	}
 	var err error
 	cmd := rootCmd
 	cmd.SetArgs([]string{"convert-single-image", "-m",
 		"registry.hub.docker.com/library/alpine:latest",
+		"-p", "-i", testutils.TestRepo})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckConvertSingleImageLocalMultiArch(t *testing.T) {
+	if !*testutils.LocalRegistry {
+		t.Skip("Skipping test that needs local registry.")
+	}
+	var err error
+	cmd := rootCmd
+	cmd.SetArgs([]string{"convert-single-image", "-m",
+		testutils.GetTestRegistryUrl() + "multi-arch-test:latest",
 		"-p", "-i", testutils.TestRepo})
 	err = cmd.Execute()
 	if err != nil {
@@ -60,6 +79,9 @@ func TestCheckConvertSingleImageCmdShouldFail1(t *testing.T) {
 }
 
 func TestCheckConvertSingleImageCmdShouldFail2(t *testing.T) {
+	if !*testutils.Online {
+		t.Skip("Skipping test in offline mode.")
+	}
 	var err error
 	cmd := rootCmd
 	cmd.SetArgs([]string{"convert-single-image",

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -11,8 +11,11 @@ get_repo_name() {
     # Handle triple-slash separator (for testing): "../../tmp/mockrepo///subdir"
     if [[ "$repo" == *"///"* ]]; then
         echo "${repo%%///*}"
+    elif [[ "$repo" == ".."* ]] || [[ "$repo" == "/.."* ]]; then
+        # Relative/mock-absolute paths like "../../tmp/mockrepo" or "/../../../../tmp/mock" - return as-is
+        echo "$repo"
     else
-        # Handle slash separator: "repo.cern.ch/subdir" or "../tmp/mockrepo"
+        # Handle slash separator: "repo.cern.ch/subdir"
         echo "${repo%%/*}"
     fi
 }
@@ -24,12 +27,14 @@ get_subdir() {
     if [[ "$repo" == *"///"* ]]; then
         local rest="${repo#*///}"
         echo "${rest%/}"
-    elif [[ "$repo" == *"/"* ]] && [[ "$repo" != ".."* ]]; then
-        # Handle slash separator only for absolute paths: "repo.cern.ch/subdir"
+    elif [[ "$repo" == ".."* ]] || [[ "$repo" == "/.."* ]]; then
+        # Relative/mock-absolute paths like "../../tmp/mockrepo" or "/../../../../tmp/mock" have no subdir
+        echo ""
+    elif [[ "$repo" == *"/"* ]]; then
+        # Handle slash separator only for normal paths: "repo.cern.ch/subdir"
         local rest="${repo#*/}"
         echo "${rest%/}"
     else
-        # Relative paths like "../../tmp/mockrepo" have no subdir
         echo ""
     fi
 }

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -172,6 +172,71 @@ func CreateSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLinkName,
 	return err
 }
 
+// CreateVariantSymlinkIntoCVMFS creates a CVMFS variant symlink whose target
+// is stored verbatim (without path resolution or existence checks).  The
+// rawTarget may contain CVMFS variable-expansion expressions such as
+// $(CVMFS_ARCH:-amd64); the CVMFS client will expand them at read time.
+//
+// newLinkName is the symlink path relative to the repository root
+// (without the /cvmfs/<repo>/ prefix).  rawTarget is the exact string that
+// will be stored as the symlink destination.
+func CreateVariantSymlinkIntoCVMFS(CVMFSRepo, newLinkName, rawTarget string) error {
+	return CreateVariantSymlinkIntoCVMFSWithLogger(nil, CVMFSRepo, newLinkName, rawTarget)
+}
+
+func CreateVariantSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLinkName, rawTarget string) (err error) {
+	logger = l.Ensure(logger)
+	fullLinkName := filepath.Join("/", "cvmfs", CVMFSRepo, newLinkName)
+
+	llog := func(entry *log.Entry) *log.Entry {
+		return l.Ensure(entry).WithFields(log.Fields{
+			"action":    "create variant symlink",
+			"repo":      CVMFSRepo,
+			"link name": fullLinkName,
+			"target":    rawTarget,
+		})
+	}
+
+	err = WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
+		linkDir := filepath.Dir(fullLinkName)
+		if mkErr := os.MkdirAll(linkDir, constants.DirPermision); mkErr != nil {
+			llog(l.LogE(mkErr)).WithField("directory", linkDir).
+				Error("Error in creating the directory for the variant symlink")
+			return mkErr
+		}
+
+		// If the symlink already exists with the identical target, skip.
+		if existing, readErr := os.Readlink(fullLinkName); readErr == nil && existing == rawTarget {
+			llog(logger).Trace("Variant symlink already up to date, skipping")
+			return nil
+		}
+
+		// Remove any existing symlink; refuse to overwrite a real file/dir.
+		if lstat, lstatErr := os.Lstat(fullLinkName); !os.IsNotExist(lstatErr) {
+			if lstat.Mode()&os.ModeSymlink != 0 {
+				if rmErr := os.Remove(fullLinkName); rmErr != nil {
+					err := fmt.Errorf("error removing existing variant symlink: %s", rmErr)
+					llog(l.LogE(err)).Error("Error removing existing variant symlink")
+					return err
+				}
+			} else {
+				err := fmt.Errorf("refusing to overwrite non-symlink with variant symlink at %s", fullLinkName)
+				llog(l.LogE(err)).Error("Error creating variant symlink")
+				return err
+			}
+		}
+
+		if symErr := os.Symlink(rawTarget, fullLinkName); symErr != nil {
+			llog(l.LogE(symErr)).Error("Error in creating the variant symlink")
+			return symErr
+		}
+		llog(logger).Info("Created variant symlink")
+		return nil
+	})
+
+	return err
+}
+
 type Backlink struct {
 	Origin []string `json:"origin"`
 }

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -142,36 +142,62 @@ func GetNameWithArch(manifestEntry da.ManifestListItem) (nameWithArch string) {
 }
 
 // archAliases maps non-normalized Docker/OCI architecture identifiers to
-// the directory names used under .multiarch/ (as produced by GetNameWithArch).
-// Architectures with a variant use the "arch:variant" form that
+// candidate .multiarch/ directory names in preference order.  The first
+// candidate directory that exists in the repository is used as the symlink
+// target.  Architectures with a variant use the "arch:variant" form that
 // GetNameWithArch writes to disk (e.g. "arm:v6", not "arm/v6").
-var archAliases = map[string]string{
-	"aarch64": "arm64",
-	"armhf":   "arm",
-	"armel":   "arm:v6",
-	"i386":    "386",
-	"x86_64":  "amd64",
-	"x86-64":  "amd64",
+//
+// "arm64" is listed as an alias for "arm64:v8" because the OCI spec treats
+// arm64 without an explicit variant as equivalent to v8, and many registries
+// only publish the variant form.  "aarch64" prefers plain "arm64" when it
+// exists, and falls back to "arm64:v8" for the same reason.
+var archAliases = map[string][]string{
+	"aarch64": {"arm64", "arm64:v8"},
+	"arm64":   {"arm64:v8"},
+	"armhf":   {"arm"},
+	"armel":   {"arm:v6"},
+	"i386":    {"386"},
+	"x86_64":  {"amd64"},
+	"x86-64":  {"amd64"},
 }
 
 // createMultiarchAliasSymlinksWithLogger creates a .multiarch/<alias> symlink
-// for every entry in archAliases whose normalized target directory already
-// exists under .multiarch/ in the repository.  Aliases that map to a
-// non-existent target are silently skipped.
+// for every entry in archAliases whose first existing candidate directory is
+// found under .multiarch/ in the repository.
+//
+// If the alias name already exists as a real (non-symlink) directory the
+// repository has native content for that arch and no alias is created.
+// Aliases whose every candidate is absent are silently skipped.
 func createMultiarchAliasSymlinksWithLogger(logger *log.Entry, repo string) {
-	for alias, normalized := range archAliases {
-		normalizedFullPath := filepath.Join("/", "cvmfs", repo, ".multiarch", normalized)
-		if _, err := os.Stat(normalizedFullPath); err != nil {
-			// Normalized arch directory does not exist in this repo yet; skip.
+	for alias, candidates := range archAliases {
+		// If the alias name is itself a real directory, native content exists
+		// for that arch — no symlink alias is needed or wanted.
+		aliasFullPath := filepath.Join("/", "cvmfs", repo, ".multiarch", alias)
+		if lstat, err := os.Lstat(aliasFullPath); err == nil && lstat.Mode()&os.ModeSymlink == 0 {
 			continue
 		}
+
+		// Pick the first candidate directory that exists.
+		target := ""
+		for _, candidate := range candidates {
+			candidateFullPath := filepath.Join("/", "cvmfs", repo, ".multiarch", candidate)
+			if _, err := os.Stat(candidateFullPath); err == nil {
+				target = candidate
+				break
+			}
+		}
+		if target == "" {
+			// None of the candidate arch directories exist in this repo; skip.
+			continue
+		}
+
 		aliasPath := filepath.Join(".multiarch", alias)
-		normalizedPath := filepath.Join(".multiarch", normalized)
-		if err := cvmfs.CreateSymlinkIntoCVMFSWithLogger(logger, repo, aliasPath, normalizedPath); err != nil {
+		targetPath := filepath.Join(".multiarch", target)
+		if err := cvmfs.CreateSymlinkIntoCVMFSWithLogger(logger, repo, aliasPath, targetPath); err != nil {
 			l.Ensure(logger).WithFields(log.Fields{
-				"alias":      aliasPath,
-				"normalized": normalizedPath,
-				"error":      err,
+				"alias":  aliasPath,
+				"target": targetPath,
+				"error":  err,
 			}).Warning("Failed to create .multiarch alias symlink")
 		}
 	}

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -406,6 +406,27 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			continue
 
 		}
+
+		// After processing all architectures for this image, create (or update)
+		// the user-facing variant symlink at <registry>/<repo>:<tag>.  The
+		// symlink contains a $(CVMFS_ARCH:-<native>) expression so that the
+		// CVMFS client resolves it to the correct architecture-specific flat
+		// image at runtime without any server-side changes.
+		if multiArch {
+			variantPath := inputImage.GetPublicSymlinkPath()
+			variantTarget := inputImage.GetVariantSymlinkTarget(runtime.GOARCH)
+			variantLogger := l.WithImage(inputImage.GetSimpleName())
+			variantLogger.WithFields(log.Fields{
+				"symlink path": variantPath,
+				"target":       variantTarget,
+			}).Debug("Creating multiarch variant symlink")
+			if vErr := cvmfs.CreateVariantSymlinkIntoCVMFSWithLogger(variantLogger, wish.CvmfsRepo, variantPath, variantTarget); vErr != nil {
+				variantLogger.WithField("error", vErr).Warning("Failed to create variant symlink for multiarch image")
+				if firstError == nil {
+					firstError = vErr
+				}
+			}
+		}
 	}
 	if multiArch {
 		createMultiarchAliasSymlinksWithLogger(nil, wish.CvmfsRepo)

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -141,6 +141,42 @@ func GetNameWithArch(manifestEntry da.ManifestListItem) (nameWithArch string) {
 	return filepath.Join(".multiarch", manifestEntry.Platform.Architecture)
 }
 
+// archAliases maps non-normalized Docker/OCI architecture identifiers to
+// the directory names used under .multiarch/ (as produced by GetNameWithArch).
+// Architectures with a variant use the "arch:variant" form that
+// GetNameWithArch writes to disk (e.g. "arm:v6", not "arm/v6").
+var archAliases = map[string]string{
+	"aarch64": "arm64",
+	"armhf":   "arm",
+	"armel":   "arm:v6",
+	"i386":    "386",
+	"x86_64":  "amd64",
+	"x86-64":  "amd64",
+}
+
+// createMultiarchAliasSymlinksWithLogger creates a .multiarch/<alias> symlink
+// for every entry in archAliases whose normalized target directory already
+// exists under .multiarch/ in the repository.  Aliases that map to a
+// non-existent target are silently skipped.
+func createMultiarchAliasSymlinksWithLogger(logger *log.Entry, repo string) {
+	for alias, normalized := range archAliases {
+		normalizedFullPath := filepath.Join("/", "cvmfs", repo, ".multiarch", normalized)
+		if _, err := os.Stat(normalizedFullPath); err != nil {
+			// Normalized arch directory does not exist in this repo yet; skip.
+			continue
+		}
+		aliasPath := filepath.Join(".multiarch", alias)
+		normalizedPath := filepath.Join(".multiarch", normalized)
+		if err := cvmfs.CreateSymlinkIntoCVMFSWithLogger(logger, repo, aliasPath, normalizedPath); err != nil {
+			l.Ensure(logger).WithFields(log.Fields{
+				"alias":      aliasPath,
+				"normalized": normalizedPath,
+				"error":      err,
+			}).Warning("Failed to create .multiarch alias symlink")
+		}
+	}
+}
+
 // filterManifestList returns the subset of manifests to process.
 // If multiArch is true, all manifests are returned.
 // If multiArch is false, only the manifest matching the native architecture is returned.
@@ -344,6 +380,9 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			continue
 
 		}
+	}
+	if multiArch {
+		createMultiarchAliasSymlinksWithLogger(nil, wish.CvmfsRepo)
 	}
 	return firstError
 }

--- a/ducc/lib/conversion_test.go
+++ b/ducc/lib/conversion_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"path/filepath"
 	"testing"
 
 	da "github.com/cvmfs/ducc/docker-api"
@@ -85,5 +86,66 @@ func TestImageNameWithPlatform(t *testing.T) {
 	want := "registry.example.org/team/demo:latest (linux/arm64/v8)"
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+// TestArchAliasesAllPointToKnownNormalizedNames verifies that every value in
+// archAliases matches the directory name that GetNameWithArch would produce
+// (i.e. the base component of the .multiarch/<dir> path).
+func TestArchAliasesAllPointToKnownNormalizedNames(t *testing.T) {
+	// Build the set of normalized arch dir names that GetNameWithArch can emit.
+	type archVariant struct{ arch, variant string }
+	cases := []archVariant{
+		{"arm64", ""},
+		{"arm", ""},
+		{"arm", "v6"},
+		{"386", ""},
+		{"amd64", ""},
+	}
+	validDirs := map[string]struct{}{}
+	for _, c := range cases {
+		entry := da.ManifestListItem{}
+		entry.Platform.Architecture = c.arch
+		if c.variant != "" {
+			entry.Platform.Variant = &c.variant
+		}
+		nameWithArch := GetNameWithArch(entry)
+		validDirs[filepath.Base(nameWithArch)] = struct{}{}
+	}
+
+	for alias, normalized := range archAliases {
+		if _, ok := validDirs[normalized]; !ok {
+			t.Errorf("archAliases[%q] = %q is not a known .multiarch dir name", alias, normalized)
+		}
+	}
+}
+
+// TestArchAliasesNonNormalizedNamesAreDistinct checks that no alias key is
+// itself a normalized arch name (that would create a self-referential entry).
+func TestArchAliasesNonNormalizedNamesAreDistinct(t *testing.T) {
+	normalizedSet := map[string]struct{}{}
+	for _, v := range archAliases {
+		normalizedSet[v] = struct{}{}
+	}
+	for alias := range archAliases {
+		if _, ok := normalizedSet[alias]; ok {
+			t.Errorf("archAliases key %q is also a normalized arch name — would create a self-referential symlink", alias)
+		}
+	}
+}
+
+// TestGetNameWithArchForAliasedArches verifies that the non-normalized arch
+// names in archAliases do NOT appear as Platform.Architecture values that
+// GetNameWithArch would normalise on its own (they come from the registry
+// verbatim, so a separate alias symlink is required).
+func TestGetNameWithArchForAliasedArches(t *testing.T) {
+	for alias, normalized := range archAliases {
+		entry := da.ManifestListItem{}
+		entry.Platform.Architecture = alias
+		got := GetNameWithArch(entry)
+		wantNot := filepath.Join(".multiarch", normalized)
+		if got == wantNot {
+			t.Errorf("GetNameWithArch with arch=%q already returns %q; alias symlink would be redundant", alias, wantNot)
+		}
 	}
 }

--- a/ducc/lib/conversion_test.go
+++ b/ducc/lib/conversion_test.go
@@ -89,14 +89,15 @@ func TestImageNameWithPlatform(t *testing.T) {
 	}
 }
 
-// TestArchAliasesAllPointToKnownNormalizedNames verifies that every value in
-// archAliases matches the directory name that GetNameWithArch would produce
-// (i.e. the base component of the .multiarch/<dir> path).
-func TestArchAliasesAllPointToKnownNormalizedNames(t *testing.T) {
+// TestArchAliasesAllCandidatesAreKnownNormalizedNames verifies that every
+// candidate in archAliases matches a directory name that GetNameWithArch
+// can produce (i.e. the base component of the .multiarch/<dir> path).
+func TestArchAliasesAllCandidatesAreKnownNormalizedNames(t *testing.T) {
 	// Build the set of normalized arch dir names that GetNameWithArch can emit.
 	type archVariant struct{ arch, variant string }
 	cases := []archVariant{
 		{"arm64", ""},
+		{"arm64", "v8"},
 		{"arm", ""},
 		{"arm", "v6"},
 		{"386", ""},
@@ -113,23 +114,23 @@ func TestArchAliasesAllPointToKnownNormalizedNames(t *testing.T) {
 		validDirs[filepath.Base(nameWithArch)] = struct{}{}
 	}
 
-	for alias, normalized := range archAliases {
-		if _, ok := validDirs[normalized]; !ok {
-			t.Errorf("archAliases[%q] = %q is not a known .multiarch dir name", alias, normalized)
+	for alias, candidates := range archAliases {
+		for _, candidate := range candidates {
+			if _, ok := validDirs[candidate]; !ok {
+				t.Errorf("archAliases[%q] candidate %q is not a known .multiarch dir name", alias, candidate)
+			}
 		}
 	}
 }
 
-// TestArchAliasesNonNormalizedNamesAreDistinct checks that no alias key is
-// itself a normalized arch name (that would create a self-referential entry).
-func TestArchAliasesNonNormalizedNamesAreDistinct(t *testing.T) {
-	normalizedSet := map[string]struct{}{}
-	for _, v := range archAliases {
-		normalizedSet[v] = struct{}{}
-	}
-	for alias := range archAliases {
-		if _, ok := normalizedSet[alias]; ok {
-			t.Errorf("archAliases key %q is also a normalized arch name — would create a self-referential symlink", alias)
+// TestArchAliasesNoSelfReferential checks that no alias lists itself as a
+// candidate target, which would produce a symlink pointing to itself.
+func TestArchAliasesNoSelfReferential(t *testing.T) {
+	for alias, candidates := range archAliases {
+		for _, candidate := range candidates {
+			if alias == candidate {
+				t.Errorf("archAliases[%q] includes itself as a candidate — would create a self-referential symlink", alias)
+			}
 		}
 	}
 }
@@ -139,13 +140,66 @@ func TestArchAliasesNonNormalizedNamesAreDistinct(t *testing.T) {
 // GetNameWithArch would normalise on its own (they come from the registry
 // verbatim, so a separate alias symlink is required).
 func TestGetNameWithArchForAliasedArches(t *testing.T) {
-	for alias, normalized := range archAliases {
+	for alias, candidates := range archAliases {
 		entry := da.ManifestListItem{}
 		entry.Platform.Architecture = alias
 		got := GetNameWithArch(entry)
-		wantNot := filepath.Join(".multiarch", normalized)
-		if got == wantNot {
-			t.Errorf("GetNameWithArch with arch=%q already returns %q; alias symlink would be redundant", alias, wantNot)
+		for _, candidate := range candidates {
+			wantNot := filepath.Join(".multiarch", candidate)
+			if got == wantNot {
+				t.Errorf("GetNameWithArch with arch=%q already returns %q; alias symlink would be redundant", alias, wantNot)
+			}
 		}
+	}
+}
+
+// TestAarch64FallsBackToArm64v8 verifies that when only .multiarch/arm64:v8
+// exists (and not plain .multiarch/arm64), the aarch64 alias still resolves
+// correctly — i.e. arm64:v8 is listed as a fallback candidate for aarch64.
+func TestAarch64FallsBackToArm64v8(t *testing.T) {
+	candidates, ok := archAliases["aarch64"]
+	if !ok {
+		t.Fatal("aarch64 not found in archAliases")
+	}
+	hasArm64 := false
+	hasArm64v8 := false
+	for _, c := range candidates {
+		if c == "arm64" {
+			hasArm64 = true
+		}
+		if c == "arm64:v8" {
+			hasArm64v8 = true
+		}
+	}
+	if !hasArm64 {
+		t.Error("aarch64 candidates must include \"arm64\"")
+	}
+	if !hasArm64v8 {
+		t.Error("aarch64 candidates must include \"arm64:v8\" as fallback")
+	}
+	// arm64 must be listed before arm64:v8 so that plain arm64 is preferred.
+	arm64Idx, arm64v8Idx := -1, -1
+	for i, c := range candidates {
+		switch c {
+		case "arm64":
+			arm64Idx = i
+		case "arm64:v8":
+			arm64v8Idx = i
+		}
+	}
+	if arm64Idx > arm64v8Idx {
+		t.Errorf("aarch64 candidates: \"arm64\" (idx %d) must come before \"arm64:v8\" (idx %d)", arm64Idx, arm64v8Idx)
+	}
+}
+
+// TestArm64AliasTargetsArm64v8 verifies that "arm64" (without variant) is
+// itself an alias whose first — and only — candidate is "arm64:v8".
+func TestArm64AliasTargetsArm64v8(t *testing.T) {
+	candidates, ok := archAliases["arm64"]
+	if !ok {
+		t.Fatal("arm64 not found in archAliases")
+	}
+	if len(candidates) != 1 || candidates[0] != "arm64:v8" {
+		t.Errorf("archAliases[\"arm64\"] = %v; want [\"arm64:v8\"]", candidates)
 	}
 }

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -721,6 +721,31 @@ func (i *Image) GetPublicSymlinkPath() string {
 	return filepath.Join(i.Registry, i.Repository+":"+i.GetSimpleReference())
 }
 
+// GetVariantSymlinkTarget returns the raw symlink target string for a CVMFS
+// variant symlink placed at GetPublicSymlinkPath().  The target embeds a
+// $(CVMFS_ARCH:-defaultArch) expression so the CVMFS client resolves it to
+// the architecture-specific flat image for the current host at runtime.
+//
+// For example, if the public path is "docker.io/user/myimage:latest" and
+// defaultArch is "amd64", the returned target is:
+//
+//	../../.multiarch/$(CVMFS_ARCH:-amd64)/docker.io/user/myimage:latest
+//
+// which, with CVMFS_ARCH=arm64 set in the client config, resolves to
+// .multiarch/arm64/docker.io/user/myimage:latest relative to the repo root.
+func (i *Image) GetVariantSymlinkTarget(defaultArch string) string {
+	publicPath := i.GetPublicSymlinkPath()
+	parentDir := filepath.Dir(publicPath)
+	// Count the number of directory components between the repo root and the
+	// symlink's containing directory; that many "../" steps bring us back to
+	// the repo root from the symlink's location.
+	depth := len(strings.Split(parentDir, "/"))
+	upSteps := strings.Repeat("../", depth)
+	varExpr := fmt.Sprintf("$(CVMFS_ARCH:-%s)", defaultArch)
+	// Explicit string join to preserve the $(VAR) expression intact.
+	return upSteps + ".multiarch/" + varExpr + "/" + publicPath
+}
+
 func (img *Image) getByteManifestList() ([]byte, error) {
 	url := img.GetManifestUrl("")
 	return makeGetRequest(url, map[string]string{"Accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json"})

--- a/ducc/lib/image_test.go
+++ b/ducc/lib/image_test.go
@@ -373,3 +373,59 @@ func TestCacheEmptyToken(t *testing.T) {
 		t.Errorf("Expected empty token, got %q", token)
 	}
 }
+
+func TestGetVariantSymlinkTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		registry    string
+		repository  string
+		tag         string
+		defaultArch string
+		want        string
+	}{
+		{
+			name:        "two-component repo",
+			registry:    "docker.io",
+			repository:  "user/myimage",
+			tag:         "latest",
+			defaultArch: "amd64",
+			// symlink at "docker.io/user/myimage:latest"
+			// parent dir "docker.io/user" has depth 2 → two "../"
+			want: "../../.multiarch/$(CVMFS_ARCH:-amd64)/docker.io/user/myimage:latest",
+		},
+		{
+			name:        "single-component repo",
+			registry:    "registry.cern.ch",
+			repository:  "myimage",
+			tag:         "v1",
+			defaultArch: "arm64",
+			// symlink at "registry.cern.ch/myimage:v1"
+			// parent dir "registry.cern.ch" has depth 1 → one "../"
+			want: "../.multiarch/$(CVMFS_ARCH:-arm64)/registry.cern.ch/myimage:v1",
+		},
+		{
+			name:        "three-component repo",
+			registry:    "registry.cern.ch",
+			repository:  "project/sub/img",
+			tag:         "1.0",
+			defaultArch: "amd64",
+			// symlink at "registry.cern.ch/project/sub/img:1.0"
+			// parent dir "registry.cern.ch/project/sub" has depth 3 → three "../"
+			want: "../../../.multiarch/$(CVMFS_ARCH:-amd64)/registry.cern.ch/project/sub/img:1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img := Image{
+				Registry:   tt.registry,
+				Repository: tt.repository,
+				Tag:        tt.tag,
+			}
+			got := img.GetVariantSymlinkTarget(tt.defaultArch)
+			if got != tt.want {
+				t.Errorf("GetVariantSymlinkTarget(%q) = %q, want %q", tt.defaultArch, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Docker follows the "normalized" go convention for architecture naming (amd64, arm64 ...) whereas CVMFS_ARCH uses what we get from `uname -m` (x86_64, aarch64...) See `platforms.go` for more detail:

https://github.com/containerd/platforms/blob/e543b9fad1cf2363170a0c8788808b5c6e11c737/platforms.go#L80-L96

This patch adds additional symlinks from the non-normalized arch names to the normalized ones:

```
drwxr-xr-x 10 cvmfs cvmfs 4.0K Mar 21 17:37 .
drwxr-xr-x  7 cvmfs cvmfs 4.0K Mar 21 17:36 ..
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 386
lrwxrwxrwx  1 cvmfs cvmfs    8 Mar 21 17:37 aarch64 -> arm64:v8
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 amd64
lrwxrwxrwx  1 cvmfs cvmfs    8 Mar 21 17:37 arm64 -> arm64:v8
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 arm64:v8
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 arm:v6
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 arm:v7
lrwxrwxrwx  1 cvmfs cvmfs    6 Mar 21 17:37 armel -> arm:v6
lrwxrwxrwx  1 cvmfs cvmfs    3 Mar 21 17:37 i386 -> 386
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 ppc64le
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 riscv64
drwxr-xr-x  3 cvmfs cvmfs 4.0K Mar 21 17:37 s390x
lrwxrwxrwx  1 cvmfs cvmfs    5 Mar 21 17:37 x86-64 -> amd64
lrwxrwxrwx  1 cvmfs cvmfs    5 Mar 21 17:37 x86_64 -> amd64

```

This allows to finally add here as well a convenient variant symlink of the form: 

```
/cvmfs/unpacked.cern.ch/registry.cern.ch/docker.io/library/alpine:latest -> '../../../.multiarch/$(CVMFS_ARCH:-amd64)/registry.cern.ch/docker.io/library/alpine:latest'
```
(CVMFS_ARCH set automatically from uname -m by the client, but can be overridden in the cvmfs client config).