### PR TITLE
ci: Add bootstrap scripts for  cmake and golang

### DIFF
--- a/ci/bootstrap_cmake.sh
+++ b/ci/bootstrap_cmake.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+# Bootstrap CMake to a sufficiently new version for building CernVM-FS.
+# Downloads Kitware pre-built binaries for x86_64 and aarch64 on Linux;
+# builds from source for other architectures.
+#
+# Usage:
+#   ci/bootstrap_cmake.sh [OPTIONS]
+# Options:
+#   --install-dir <dir>     Override install location (default: externals_install*)
+#   --cmake-version <ver>   CMake version to fetch  (default: 3.31.7,
+#                           or env CMAKE_BOOTSTRAP_VERSION)
+#   --min-version <ver>     Minimum acceptable version (default: 3.24.0,
+#                           or env CMAKE_MIN_VERSION)
+#   -h, --help              Show this help
+#
+# Logs go to stderr.  On success, prints exactly one line to stdout:
+#   CVMFS_CMAKE_DIR=<path/to/dir/containing/cmake>
+# Callers can eval that line to capture the path, e.g.:
+#   eval "$(ci/bootstrap_cmake.sh)"
+
+set -euo pipefail
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+log()  { echo "[bootstrap-cmake] $*" >&2; }
+check_available() { command -v "$1" >/dev/null 2>&1; }
+
+CMAKE_VERSION="${CMAKE_BOOTSTRAP_VERSION:-3.31.7}"
+MIN_VERSION="${CMAKE_MIN_VERSION:-3.24.0}"
+INSTALL_DIR_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-dir)    INSTALL_DIR_OVERRIDE="$2"; shift 2;;
+    --cmake-version)  CMAKE_VERSION="$2";        shift 2;;
+    --min-version)    MIN_VERSION="$2";          shift 2;;
+    -h|--help) sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    *) die "Unknown argument: $1";;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+
+# version_ge A B — succeeds (returns 0) when A >= B
+version_ge() {
+  local a="$1" b="$2"
+  IFS='.' read -ra av <<< "$a"
+  IFS='.' read -ra bv <<< "$b"
+  local i
+  for i in 0 1 2; do
+    local an="${av[$i]:-0}"
+    local bn="${bv[$i]:-0}"
+    (( an > bn )) && return 0
+    (( an < bn )) && return 1
+  done
+  return 0  # equal
+}
+
+cmake_installed_version() {
+  "${1:-cmake}" --version 2>/dev/null \
+    | head -1 \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+    || true
+}
+
+# ---------------------------------------------------------------------------
+# Check whether the system cmake already satisfies the requirement
+# ---------------------------------------------------------------------------
+if check_available cmake; then
+  CURRENT_VER="$(cmake_installed_version cmake)"
+  if [ -n "$CURRENT_VER" ] && version_ge "$CURRENT_VER" "$MIN_VERSION"; then
+    log "cmake ${CURRENT_VER} >= ${MIN_VERSION} — no bootstrap needed"
+    echo "CVMFS_CMAKE_DIR=$(dirname "$(command -v cmake)")"
+    exit 0
+  fi
+  log "cmake ${CURRENT_VER:-unknown} < ${MIN_VERSION} — bootstrapping..."
+else
+  log "cmake not found — bootstrapping..."
+fi
+
+# ---------------------------------------------------------------------------
+# Determine install location  (mirrors build_libfuse.sh logic)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARCH="$(uname -m)"
+
+if [ -n "$INSTALL_DIR_OVERRIDE" ]; then
+  EXTERNALS_INSTALL_LOCATION="$INSTALL_DIR_OVERRIDE"
+else
+  DISTRO=""
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release 2>/dev/null || true
+    if [ -n "${PLATFORM_ID:-}" ]; then
+      DISTRO="${PLATFORM_ID#*:}"           # e.g. "platform:el9" → "el9"
+    else
+      DISTRO="${ID:-}${VERSION_ID:-}"
+      DISTRO="${DISTRO//\"/}"
+    fi
+  fi
+
+  if [ -d "${REPO_ROOT}/externals_build" ] && [ -d "${REPO_ROOT}/externals_install" ]; then
+    EXTERNALS_INSTALL_LOCATION="${REPO_ROOT}/externals_install"
+  else
+    EXTERNALS_INSTALL_LOCATION="${REPO_ROOT}/externals_install.${ARCH}"
+    if [ -n "$DISTRO" ]; then
+      EXTERNALS_INSTALL_LOCATION="${EXTERNALS_INSTALL_LOCATION}.${DISTRO}"
+    fi
+  fi
+fi
+
+mkdir -p "${EXTERNALS_INSTALL_LOCATION}"
+CMAKE_BIN="${EXTERNALS_INSTALL_LOCATION}/bin/cmake"
+
+# ---------------------------------------------------------------------------
+# Short-circuit: already installed at target with a good-enough version
+# ---------------------------------------------------------------------------
+if [ -x "${CMAKE_BIN}" ]; then
+  INSTALLED_VER="$(cmake_installed_version "${CMAKE_BIN}")"
+  if [ -n "$INSTALLED_VER" ] && version_ge "$INSTALLED_VER" "$MIN_VERSION"; then
+    log "cmake ${INSTALLED_VER} already present at ${EXTERNALS_INSTALL_LOCATION}/bin"
+    echo "CVMFS_CMAKE_DIR=${EXTERNALS_INSTALL_LOCATION}/bin"
+    exit 0
+  fi
+fi
+
+log "Installing cmake ${CMAKE_VERSION} into ${EXTERNALS_INSTALL_LOCATION}"
+
+KITWARE_BASE="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}"
+OS="$(uname -s)"
+
+# ---------------------------------------------------------------------------
+# Install from Kitware pre-built binary (Linux self-extracting shell script)
+# ---------------------------------------------------------------------------
+install_cmake_binary() {
+  local arch_label="$1"    # e.g. x86_64, aarch64
+  local platform_label="$2" # e.g. linux
+  local url="${KITWARE_BASE}/cmake-${CMAKE_VERSION}-${platform_label}-${arch_label}.sh"
+  local installer="${EXTERNALS_INSTALL_LOCATION}/_cmake_installer_$$.sh"
+
+  log "Downloading ${url}"
+  check_available curl || die "curl is required to download cmake"
+  curl -fsSL "${url}" -o "${installer}" \
+    || die "Failed to download cmake from ${url}"
+  chmod +x "${installer}"
+
+  log "Extracting into ${EXTERNALS_INSTALL_LOCATION}..."
+  # --exclude-subdir installs bin/, lib/, share/ directly under the prefix
+  "${installer}" --skip-license --prefix="${EXTERNALS_INSTALL_LOCATION}" --exclude-subdir
+  rm -f "${installer}"
+}
+
+# ---------------------------------------------------------------------------
+# Build cmake from source (fallback for exotic architectures / macOS)
+# ---------------------------------------------------------------------------
+build_cmake_from_source() {
+  local url="${KITWARE_BASE}/cmake-${CMAKE_VERSION}.tar.gz"
+  local build_dir
+  build_dir="$(mktemp -d)"
+  local tarball="${build_dir}/cmake-${CMAKE_VERSION}.tar.gz"
+  local srcdir="${build_dir}/cmake-${CMAKE_VERSION}"
+
+  log "Downloading source ${url}"
+  check_available curl || die "curl is required to download cmake source"
+  curl -fsSL "${url}" -o "${tarball}" \
+    || die "Failed to download cmake source from ${url}"
+  tar -xzf "${tarball}" -C "${build_dir}"
+
+  local jobs
+  jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+  log "Building cmake from source with ${jobs} parallel jobs (this may take a while)..."
+
+  cd "${srcdir}"
+  # Disable OpenSSL to avoid dependency issues; cmake can use its own curl/openssl
+  ./bootstrap \
+    --prefix="${EXTERNALS_INSTALL_LOCATION}" \
+    --parallel="${jobs}" \
+    -- -DCMAKE_USE_OPENSSL=OFF \
+    || die "cmake bootstrap script failed"
+  make -j"${jobs}" || die "cmake source build failed"
+  make install     || die "cmake install failed"
+  cd - >/dev/null
+  rm -rf "${build_dir}"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${OS}" in
+  Linux)
+    case "${ARCH}" in
+      x86_64)         install_cmake_binary "x86_64"  "linux" ;;
+      aarch64|arm64)  install_cmake_binary "aarch64" "linux" ;;
+      *)
+        log "No Kitware binary for ${ARCH} — building from source"
+        build_cmake_from_source
+        ;;
+    esac
+    ;;
+  Darwin)
+    # Homebrew is the easiest path on macOS; fall back to source build
+    if check_available brew; then
+      log "macOS + brew detected — running: brew install cmake"
+      brew install cmake >/dev/null
+      # Homebrew installs cmake into its prefix; find it
+      BREW_CMAKE="$(brew --prefix cmake 2>/dev/null)/bin/cmake"
+      if [ -x "${BREW_CMAKE}" ]; then
+        log "cmake installed via brew at $(dirname "${BREW_CMAKE}")"
+        echo "CVMFS_CMAKE_DIR=$(dirname "${BREW_CMAKE}")"
+        exit 0
+      fi
+    fi
+    log "No brew or brew cmake path not found — building from source"
+    build_cmake_from_source
+    ;;
+  *)
+    log "Unknown OS '${OS}' — building cmake from source"
+    build_cmake_from_source
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+[ -x "${CMAKE_BIN}" ] \
+  || die "cmake installation failed: ${CMAKE_BIN} not found after install"
+
+INSTALLED_VER="$(cmake_installed_version "${CMAKE_BIN}")"
+log "cmake ${INSTALLED_VER} installed successfully"
+echo "CVMFS_CMAKE_DIR=${EXTERNALS_INSTALL_LOCATION}/bin"

--- a/ci/bootstrap_cmake.sh
+++ b/ci/bootstrap_cmake.sh
@@ -102,13 +102,12 @@ else
     fi
   fi
 
-  if [ -d "${REPO_ROOT}/externals_build" ] && [ -d "${REPO_ROOT}/externals_install" ]; then
-    EXTERNALS_INSTALL_LOCATION="${REPO_ROOT}/externals_install"
-  else
-    EXTERNALS_INSTALL_LOCATION="${REPO_ROOT}/externals_install.${ARCH}"
-    if [ -n "$DISTRO" ]; then
-      EXTERNALS_INSTALL_LOCATION="${EXTERNALS_INSTALL_LOCATION}.${DISTRO}"
-    fi
+  # CVMFS_EXTERNALS_PREFIX overrides the base directory; otherwise fall back to
+  # the repo root.  The install path is always the arch/distro-suffixed form.
+  _BASE="${CVMFS_EXTERNALS_PREFIX:-${REPO_ROOT}}"
+  EXTERNALS_INSTALL_LOCATION="${_BASE}/externals_install.${ARCH}"
+  if [ -n "$DISTRO" ]; then
+    EXTERNALS_INSTALL_LOCATION="${EXTERNALS_INSTALL_LOCATION}.${DISTRO}"
   fi
 fi
 
@@ -149,7 +148,8 @@ install_cmake_binary() {
 
   log "Extracting into ${EXTERNALS_INSTALL_LOCATION}..."
   # --exclude-subdir installs bin/, lib/, share/ directly under the prefix
-  "${installer}" --skip-license --prefix="${EXTERNALS_INSTALL_LOCATION}" --exclude-subdir
+  # Redirect to stderr so that only CVMFS_CMAKE_DIR= reaches stdout (for eval)
+  "${installer}" --skip-license --prefix="${EXTERNALS_INSTALL_LOCATION}" --exclude-subdir >&2
   rm -f "${installer}"
 }
 
@@ -175,13 +175,14 @@ build_cmake_from_source() {
 
   cd "${srcdir}"
   # Disable OpenSSL to avoid dependency issues; cmake can use its own curl/openssl
+  # Redirect to stderr so that only CVMFS_CMAKE_DIR= reaches stdout (for eval)
   ./bootstrap \
     --prefix="${EXTERNALS_INSTALL_LOCATION}" \
     --parallel="${jobs}" \
     -- -DCMAKE_USE_OPENSSL=OFF \
-    || die "cmake bootstrap script failed"
-  make -j"${jobs}" || die "cmake source build failed"
-  make install     || die "cmake install failed"
+    >&2 || die "cmake bootstrap script failed"
+  make -j"${jobs}" >&2 || die "cmake source build failed"
+  make install     >&2 || die "cmake install failed"
   cd - >/dev/null
   rm -rf "${build_dir}"
 }

--- a/ci/bootstrap_golang.sh
+++ b/ci/bootstrap_golang.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+# Bootstrap Go to a sufficiently new version for building CernVM-FS.
+# Downloads pre-built binaries from go.dev for Linux and macOS (x86_64/aarch64).
+#
+# Usage:
+#   ci/bootstrap_golang.sh [OPTIONS]
+# Options:
+#   --install-dir <dir>    Override install location (default: externals_install*)
+#   --go-version <ver>     Go version to fetch (default: 1.24.2,
+#                          or env GO_BOOTSTRAP_VERSION)
+#   --min-version <ver>    Minimum acceptable version (default: 1.24.0,
+#                          or env GO_MIN_VERSION)
+#   -h, --help             Show this help
+#
+# Logs go to stderr.  On success, prints exactly one line to stdout:
+#   CVMFS_GO_DIR=<path/to/dir/containing/go>
+# Callers can eval that line to capture the path, e.g.:
+#   eval "$(ci/bootstrap_golang.sh)"
+
+set -euo pipefail
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+log()  { echo "[bootstrap-golang] $*" >&2; }
+check_available() { command -v "$1" >/dev/null 2>&1; }
+
+GO_VERSION="${GO_BOOTSTRAP_VERSION:-1.25.8}"
+MIN_VERSION="${GO_MIN_VERSION:-1.24.0}"
+INSTALL_DIR_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-dir)  INSTALL_DIR_OVERRIDE="$2"; shift 2;;
+    --go-version)   GO_VERSION="$2";           shift 2;;
+    --min-version)  MIN_VERSION="$2";          shift 2;;
+    -h|--help) sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    *) die "Unknown argument: $1";;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+
+# version_ge A B — succeeds (returns 0) when A >= B
+version_ge() {
+  local a="$1" b="$2"
+  IFS='.' read -ra av <<< "$a"
+  IFS='.' read -ra bv <<< "$b"
+  local i
+  for i in 0 1 2; do
+    local an="${av[$i]:-0}"
+    local bn="${bv[$i]:-0}"
+    (( an > bn )) && return 0
+    (( an < bn )) && return 1
+  done
+  return 0  # equal
+}
+
+go_installed_version() {
+  "${1:-go}" version 2>/dev/null \
+    | grep -oE 'go[0-9]+\.[0-9]+(\.[0-9]+)?' \
+    | head -1 \
+    | sed 's/^go//' \
+    || true
+}
+
+# ---------------------------------------------------------------------------
+# Check whether the system go already satisfies the requirement
+# ---------------------------------------------------------------------------
+if check_available go; then
+  CURRENT_VER="$(go_installed_version go)"
+  if [ -n "$CURRENT_VER" ] && version_ge "$CURRENT_VER" "$MIN_VERSION"; then
+    log "go ${CURRENT_VER} >= ${MIN_VERSION} — no bootstrap needed"
+    echo "CVMFS_GO_DIR=$(dirname "$(command -v go)")"
+    exit 0
+  fi
+  log "go ${CURRENT_VER:-unknown} < ${MIN_VERSION} — bootstrapping..."
+else
+  log "go not found — bootstrapping..."
+fi
+
+# ---------------------------------------------------------------------------
+# Determine install location (mirrors bootstrap_cmake.sh logic)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARCH="$(uname -m)"
+
+if [ -n "$INSTALL_DIR_OVERRIDE" ]; then
+  EXTERNALS_INSTALL_LOCATION="$INSTALL_DIR_OVERRIDE"
+else
+  DISTRO=""
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release 2>/dev/null || true
+    if [ -n "${PLATFORM_ID:-}" ]; then
+      DISTRO="${PLATFORM_ID#*:}"           # e.g. "platform:el9" → "el9"
+    else
+      DISTRO="${ID:-}${VERSION_ID:-}"
+      DISTRO="${DISTRO//\"/}"
+    fi
+  fi
+
+  # CVMFS_EXTERNALS_PREFIX overrides the base directory; otherwise fall back to
+  # the repo root.  The install path is always the arch/distro-suffixed form.
+  _BASE="${CVMFS_EXTERNALS_PREFIX:-${REPO_ROOT}}"
+  EXTERNALS_INSTALL_LOCATION="${_BASE}/externals_install.${ARCH}"
+  if [ -n "$DISTRO" ]; then
+    EXTERNALS_INSTALL_LOCATION="${EXTERNALS_INSTALL_LOCATION}.${DISTRO}"
+  fi
+fi
+
+mkdir -p "${EXTERNALS_INSTALL_LOCATION}"
+# go.dev tarballs always extract into a 'go/' subdirectory
+GO_BIN="${EXTERNALS_INSTALL_LOCATION}/go/bin/go"
+
+# ---------------------------------------------------------------------------
+# Short-circuit: already installed at target with a good-enough version
+# ---------------------------------------------------------------------------
+if [ -x "${GO_BIN}" ]; then
+  INSTALLED_VER="$(go_installed_version "${GO_BIN}")"
+  if [ -n "$INSTALLED_VER" ] && version_ge "$INSTALLED_VER" "$MIN_VERSION"; then
+    log "go ${INSTALLED_VER} already present at ${EXTERNALS_INSTALL_LOCATION}/go/bin"
+    echo "CVMFS_GO_DIR=${EXTERNALS_INSTALL_LOCATION}/go/bin"
+    exit 0
+  fi
+fi
+
+log "Installing go ${GO_VERSION} into ${EXTERNALS_INSTALL_LOCATION}"
+
+OS="$(uname -s)"
+
+# Map uname arch to Go's arch naming
+go_arch() {
+  case "$1" in
+    x86_64)        echo "amd64" ;;
+    aarch64|arm64) echo "arm64" ;;
+    *) die "Unsupported architecture for Go pre-built binary: $1" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Install from go.dev pre-built tarball
+# ---------------------------------------------------------------------------
+install_go_binary() {
+  local os_label="$1"    # e.g. linux, darwin
+  local arch_label="$2"  # e.g. amd64, arm64
+  local url="https://go.dev/dl/go${GO_VERSION}.${os_label}-${arch_label}.tar.gz"
+  local tarball="${EXTERNALS_INSTALL_LOCATION}/_go_tarball_$$.tar.gz"
+
+  log "Downloading ${url}"
+  check_available curl || die "curl is required to download Go"
+  curl -fsSL "${url}" -o "${tarball}" \
+    || die "Failed to download Go from ${url}"
+
+  log "Extracting into ${EXTERNALS_INSTALL_LOCATION}..."
+  # Remove any previous installation before extracting
+  rm -rf "${EXTERNALS_INSTALL_LOCATION}/go"
+  tar -xzf "${tarball}" -C "${EXTERNALS_INSTALL_LOCATION}" >&2
+  rm -f "${tarball}"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${OS}" in
+  Linux)
+    install_go_binary "linux"  "$(go_arch "${ARCH}")"
+    ;;
+  Darwin)
+    install_go_binary "darwin" "$(go_arch "${ARCH}")"
+    ;;
+  *)
+    die "Unsupported OS '${OS}' — install Go manually: https://go.dev/doc/install"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+[ -x "${GO_BIN}" ] \
+  || die "Go installation failed: ${GO_BIN} not found after install"
+
+INSTALLED_VER="$(go_installed_version "${GO_BIN}")"
+log "go ${INSTALLED_VER} installed successfully"
+echo "CVMFS_GO_DIR=${EXTERNALS_INSTALL_LOCATION}/go/bin"

--- a/ci/build_install_builddeps.sh
+++ b/ci/build_install_builddeps.sh
@@ -21,6 +21,44 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 log() { echo "[builddeps] $*"; }
 check_available() { command -v "$1" >/dev/null 2>&1; }
 
+# cmake_version_ge A B — succeeds when cmake version A >= B
+cmake_version_ge() {
+  local a="$1" b="$2"
+  IFS='.' read -ra av <<< "$a"
+  IFS='.' read -ra bv <<< "$b"
+  local i
+  for i in 0 1 2; do
+    local an="${av[$i]:-0}"
+    local bn="${bv[$i]:-0}"
+    (( an > bn )) && return 0
+    (( an < bn )) && return 1
+  done
+  return 0
+}
+
+bootstrap_cmake_if_needed() {
+  local min_ver="3.24.0"
+  local current_ver=""
+  if check_available cmake; then
+    current_ver="$(cmake --version 2>/dev/null \
+      | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+  fi
+  if [ -n "$current_ver" ] && cmake_version_ge "$current_ver" "$min_ver"; then
+    log "cmake ${current_ver} is sufficient (>= ${min_ver})"
+    return 0
+  fi
+  if [ -n "$current_ver" ]; then
+    log "cmake ${current_ver} < ${min_ver} — bootstrapping a newer cmake"
+  else
+    log "cmake not found — bootstrapping cmake"
+  fi
+  local cmake_dir_line
+  cmake_dir_line="$("${SCRIPT_DIR}/bootstrap_cmake.sh")"
+  eval "$cmake_dir_line"
+  export CVMFS_CMAKE_DIR
+  log "cmake bootstrapped at: ${CVMFS_CMAKE_DIR}/cmake"
+}
+
 get_script_dir() { cd "$(dirname "$0")" && pwd; }
 
 ########################
@@ -218,6 +256,7 @@ case "$MODE" in
       die "Unsupported OS family for install: $OS_FAMILY"
     fi
     log "Build dependencies installed successfully"
+    bootstrap_cmake_if_needed
     ;;
   *) die "Unknown mode: $MODE";;
 esac

--- a/ci/build_install_builddeps.sh
+++ b/ci/build_install_builddeps.sh
@@ -59,6 +59,29 @@ bootstrap_cmake_if_needed() {
   log "cmake bootstrapped at: ${CVMFS_CMAKE_DIR}/cmake"
 }
 
+bootstrap_golang_if_needed() {
+  local min_ver="1.24.0"
+  local current_ver=""
+  if check_available go; then
+    current_ver="$(go version 2>/dev/null \
+      | grep -oE 'go[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | sed 's/^go//' || true)"
+  fi
+  if [ -n "$current_ver" ] && cmake_version_ge "$current_ver" "$min_ver"; then
+    log "go ${current_ver} is sufficient (>= ${min_ver})"
+    return 0
+  fi
+  if [ -n "$current_ver" ]; then
+    log "go ${current_ver} < ${min_ver} — bootstrapping a newer go"
+  else
+    log "go not found — bootstrapping go"
+  fi
+  local go_dir_line
+  go_dir_line="$("${SCRIPT_DIR}/bootstrap_golang.sh")"
+  eval "$go_dir_line"
+  export CVMFS_GO_DIR
+  log "go bootstrapped at: ${CVMFS_GO_DIR}/go"
+}
+
 get_script_dir() { cd "$(dirname "$0")" && pwd; }
 
 ########################
@@ -197,12 +220,14 @@ list_deps_rpm() {
 ########################
 install_deps_deb() {
   [ -f "$DEB_CONTROL" ] || die "Debian control file not found at $DEB_CONTROL"
+
+  export DEBIAN_FRONTEND=noninteractive
   $SUDO apt-get -y update
   if ! check_available mk-build-deps || ! dpkg -s equivs >/dev/null 2>&1; then
     $SUDO apt-get -y install devscripts equivs
   fi
   # Use mk-build-deps to create and install the meta-package, then remove it
-  $SUDO DEBIAN_FRONTEND=noninteractive mk-build-deps -i -r "$DEB_CONTROL"
+  $SUDO mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i -r "$DEB_CONTROL"
 }
 
 install_deps_rhel() {
@@ -214,7 +239,7 @@ install_deps_rhel() {
   $SUDO dnf builddep -y "$RPM_SPEC" && return 0
   # Fallback: parse spec and install packages directly
   local pkgs
-  pkgs=$(list_deps_rpm "$RPM_SPEC" || true)
+  pkgs=$(list_deps_rpm "$RPM_SPEC" | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$' || true)
   [ -n "${pkgs:-}" ] || die "Could not determine RPM build dependencies"
   $SUDO dnf -y install $pkgs
 }
@@ -225,7 +250,7 @@ install_deps_suse() {
     $SUDO zypper -n install rpm-build
   fi
   local pkgs
-  pkgs=$(list_deps_rpm "$RPM_SPEC" || true)
+  pkgs=$(list_deps_rpm "$RPM_SPEC" | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$' || true)
   [ -n "${pkgs:-}" ] || die "Could not determine RPM build dependencies"
   $SUDO zypper -n install $pkgs
 }
@@ -257,6 +282,7 @@ case "$MODE" in
     fi
     log "Build dependencies installed successfully"
     bootstrap_cmake_if_needed
+    bootstrap_golang_if_needed
     ;;
   *) die "Unknown mode: $MODE";;
 esac

--- a/ci/build_package.sh
+++ b/ci/build_package.sh
@@ -30,12 +30,16 @@ CVMFS_BUILD_LOCATION="$2"
 CVMFS_PACKAGE_NAME="$3"
 shift 3
 
-# If ci/build_install_builddeps.sh bootstrapped a custom cmake it will have
-# exported CVMFS_CMAKE_DIR (the directory containing the cmake binary).
-# Package build scripts that sanitise the environment (e.g. ci/cvmfs/deb.sh
-# via debuild) honour this variable to re-inject the path.  You can also set
-# it manually when calling this script:
-#   CVMFS_CMAKE_DIR=/path/to/externals_install/bin ci/build_package.sh ...
+# If ci/build_install_builddeps.sh bootstrapped custom tools it will have
+# exported CVMFS_CMAKE_DIR and CVMFS_GO_DIR (directories containing the
+# respective binaries).  Package build scripts that sanitise the environment
+# (e.g. ci/cvmfs/deb.sh via debuild) honour these variables to re-inject the
+# paths.  You can also set them manually when calling this script:
+#   CVMFS_CMAKE_DIR=/path/to/externals_install/bin \
+#   CVMFS_GO_DIR=/path/to/externals_install/go/bin \
+#   ci/build_package.sh ...
+# Alternatively, set CVMFS_EXTERNALS_PREFIX to the base directory used during
+# the bootstrap and both paths will be auto-detected from there.
 
 # build the invocation string and print it for debugging reasons
 args=""

--- a/ci/build_package.sh
+++ b/ci/build_package.sh
@@ -30,6 +30,13 @@ CVMFS_BUILD_LOCATION="$2"
 CVMFS_PACKAGE_NAME="$3"
 shift 3
 
+# If ci/build_install_builddeps.sh bootstrapped a custom cmake it will have
+# exported CVMFS_CMAKE_DIR (the directory containing the cmake binary).
+# Package build scripts that sanitise the environment (e.g. ci/cvmfs/deb.sh
+# via debuild) honour this variable to re-inject the path.  You can also set
+# it manually when calling this script:
+#   CVMFS_CMAKE_DIR=/path/to/externals_install/bin ci/build_package.sh ...
+
 # build the invocation string and print it for debugging reasons
 args=""
 while [ $# -gt 0 ]; do

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -61,7 +61,11 @@ get_cvmfs_prerelease_from_cmake() {
 
 get_cvmfs_git_revision() {
   local source_directory="$1"
-  echo "$(cd $source_directory; git rev-parse HEAD | head -c16)"
+  if ! command -v git >/dev/null 2>&1; then
+    echo ""
+    return 0
+  fi
+  echo "$(cd $source_directory; git rev-parse HEAD 2>/dev/null | head -c16)"
 }
 
 get_repository_root() {

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -93,7 +93,17 @@ DEBUILD_ARGS=""
 if [ x"$CVMFS_LINT_PKG" = x ]; then
   DEBUILD_ARGS="--no-lintian"
 fi
-DEB_BUILD_OPTIONS=parallel=$cpu_cores debuild ${DEBUILD_ARGS} --prepend-path=/usr/local/go/bin \
+# debuild sanitises PATH, so a custom cmake installed by bootstrap_cmake.sh
+# must be injected explicitly via --prepend-path.  Set CVMFS_CMAKE_DIR to the
+# directory that contains the cmake binary (e.g. externals_install/bin) before
+# calling this script or build_package.sh.
+DEBUILD_CMAKE_PATH=""
+if [ -n "${CVMFS_CMAKE_DIR:-}" ]; then
+  DEBUILD_CMAKE_PATH="--prepend-path=${CVMFS_CMAKE_DIR}"
+fi
+DEB_BUILD_OPTIONS=parallel=$cpu_cores debuild ${DEBUILD_ARGS} \
+  --prepend-path=/usr/local/go/bin \
+  ${DEBUILD_CMAKE_PATH} \
   -e  CVMFS_EXTERNALS_PREFIX="${CVMFS_EXTERNALS_PREFIX}" \
   -e  CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}" \
   -e  GOPROXY="${GOPROXY}" \

--- a/ci/cvmfs/deb.sh
+++ b/ci/cvmfs/deb.sh
@@ -93,17 +93,51 @@ DEBUILD_ARGS=""
 if [ x"$CVMFS_LINT_PKG" = x ]; then
   DEBUILD_ARGS="--no-lintian"
 fi
-# debuild sanitises PATH, so a custom cmake installed by bootstrap_cmake.sh
-# must be injected explicitly via --prepend-path.  Set CVMFS_CMAKE_DIR to the
-# directory that contains the cmake binary (e.g. externals_install/bin) before
-# calling this script or build_package.sh.
-DEBUILD_CMAKE_PATH=""
-if [ -n "${CVMFS_CMAKE_DIR:-}" ]; then
-  DEBUILD_CMAKE_PATH="--prepend-path=${CVMFS_CMAKE_DIR}"
+# debuild sanitises PATH, so custom tools installed by bootstrap_cmake.sh /
+# bootstrap_golang.sh must be injected explicitly via --prepend-path.
+# Compute the externals install directory once; both cmake and go use it.
+# Mirror bootstrap_cmake.sh/bootstrap_golang.sh: prefer CVMFS_EXTERNALS_PREFIX,
+# fall back to the source tree root (which is their REPO_ROOT fallback).
+_base="${CVMFS_EXTERNALS_PREFIX:-${CVMFS_SOURCE_LOCATION}}"
+_arch="$(uname -m)"
+_distro=""
+if [ -f /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release 2>/dev/null || true
+  if [ -n "${PLATFORM_ID:-}" ]; then
+    _distro="${PLATFORM_ID#*:}"
+  else
+    _distro="$(echo "${ID:-}${VERSION_ID:-}" | tr -d '"')"
+  fi
 fi
+_install_dir="${_base}/externals_install.${_arch}"
+if [ -n "$_distro" ]; then
+  _install_dir="${_install_dir}.${_distro}"
+fi
+
+# cmake: CVMFS_CMAKE_DIR (explicit) → auto-detected from prefix
+_cmake_dir="${CVMFS_CMAKE_DIR:-}"
+if [ -z "$_cmake_dir" ] && [ -x "${_install_dir}/bin/cmake" ]; then
+  _cmake_dir="${_install_dir}/bin"
+fi
+
+# go: CVMFS_GO_DIR (explicit) → auto-detected from prefix → /usr/local/go/bin (fallback)
+_go_dir="${CVMFS_GO_DIR:-}"
+if [ -z "$_go_dir" ] && [ -x "${_install_dir}/go/bin/go" ]; then
+  _go_dir="${_install_dir}/go/bin"
+fi
+if [ -z "$_go_dir" ]; then
+  _go_dir="/usr/local/go/bin"
+fi
+
+# Combine into one --prepend-path: debuild only honours the last occurrence.
+_prepend_path="${_go_dir}"
+if [ -n "$_cmake_dir" ]; then
+  _prepend_path="${_cmake_dir}:${_prepend_path}"
+fi
+
 DEB_BUILD_OPTIONS=parallel=$cpu_cores debuild ${DEBUILD_ARGS} \
-  --prepend-path=/usr/local/go/bin \
-  ${DEBUILD_CMAKE_PATH} \
+  --prepend-path="${_prepend_path}" \
   -e  CVMFS_EXTERNALS_PREFIX="${CVMFS_EXTERNALS_PREFIX}" \
   -e  CMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}" \
   -e  GOPROXY="${GOPROXY}" \

--- a/ci/cvmfs/rpm.sh
+++ b/ci/cvmfs/rpm.sh
@@ -42,6 +42,40 @@ for d in $rpm_infra_dirs; do
   mkdir ${CVMFS_RESULT_LOCATION}/${d}
 done
 
+# Prepend bootstrapped cmake and go to PATH if available.
+# rpmbuild inherits PATH from the shell so we update it directly here,
+# unlike deb.sh which must use debuild's --prepend-path.
+_base="${CVMFS_EXTERNALS_PREFIX:-${CVMFS_SOURCE_LOCATION}}"
+_arch="$(uname -m)"
+_distro=""
+if [ -f /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release 2>/dev/null || true
+  if [ -n "${PLATFORM_ID:-}" ]; then
+    _distro="${PLATFORM_ID#*:}"
+  else
+    _distro="$(echo "${ID:-}${VERSION_ID:-}" | tr -d '"')"
+  fi
+fi
+_install_dir="${_base}/externals_install.${_arch}"
+if [ -n "$_distro" ]; then
+  _install_dir="${_install_dir}.${_distro}"
+fi
+
+_cmake_dir="${CVMFS_CMAKE_DIR:-}"
+if [ -z "$_cmake_dir" ] && [ -x "${_install_dir}/bin/cmake" ]; then
+  _cmake_dir="${_install_dir}/bin"
+fi
+_go_dir="${CVMFS_GO_DIR:-}"
+if [ -z "$_go_dir" ] && [ -x "${_install_dir}/go/bin/go" ]; then
+  _go_dir="${_install_dir}/go/bin"
+fi
+
+_prepend="${_cmake_dir:+${_cmake_dir}:}${_go_dir}"
+if [ -n "$_prepend" ]; then
+  export PATH="${_prepend}:${PATH}"
+fi
+
 git_hash="$(get_cvmfs_git_revision $CVMFS_SOURCE_LOCATION)"
 tarball="cvmfs-${cvmfs_version}.tar.gz"
 echo "creating source tar ball '$tarball'..."
@@ -67,6 +101,7 @@ if [ $CVMFS_NIGHTLY_BUILD_NUMBER -gt 0 ]; then
 else
   echo "creating release: $cvmfs_version"
 fi
+
 
 default_arch=$(get_default_compiler_arch)
 echo "building ($default_arch)..."

--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -14,6 +14,16 @@ BUILD_LIBFUSE2 := 'no'
 
 CVMFS_BUILD_UNITTESTS ?= no
 
+# Detect Go once; gateway and snapshotter packages are only built when available.
+BUILD_GO := $(shell if go version >/dev/null 2>&1; then echo "yes"; else echo "no"; fi)
+ifeq ($(BUILD_GO),no)
+GO_SKIP := -Ncvmfs-gateway -Ncvmfs-snapshotter
+GO_INSTALL_DEPS :=
+else
+GO_SKIP :=
+GO_INSTALL_DEPS := debian/cvmfs-gateway.install debian/cvmfs-snapshotter.install
+endif
+
 # TODO:
 #  -> Support debian multiarch
 #       CMake's GNUInstallDirs supports multiarch beginning from CMake 2.8.8...
@@ -32,8 +42,8 @@ Makefile:
 		-DBUILD_RECEIVER=yes -DBUILD_RECEIVER_DEBUG=yes -DBUILD_SHRINKWRAP=yes \
 		-DBUILD_UNITTESTS=$(CVMFS_BUILD_UNITTESTS) -DINSTALL_UNITTESTS=no -DINSTALL_PUBLIC_KEYS=no \
 		-DBUILD_LIBCVMFS=yes -DBUILD_LIBCVMFS_CACHE=yes \
-		-DBUILD_GATEWAY=$(shell if go version >/dev/null 2>&1; then echo "yes"; else echo "no"; fi) \
-		-DBUILD_SNAPSHOTTER=$(shell if go version >/dev/null 2>&1; then echo "yes"; else echo "no"; fi) \
+		-DBUILD_GATEWAY=$(BUILD_GO) \
+		-DBUILD_SNAPSHOTTER=$(BUILD_GO) \
 		-DBUILD_LIBFUSE2=$(BUILD_LIBFUSE2) \
 		-DCMAKE_INSTALL_PREFIX:PATH=/usr \
 		.
@@ -65,7 +75,7 @@ debian/%.install: debian/%.install.in
   fi
 	sed "s/@CVMFS_VERSION@/$(shell dpkg-parsechangelog | sed -n -e 's/^Version: \([0-9]\.[0-9][0-9]\.[0-9][0-9]*\).*/\1/p')/g" $< | grep . > $@
 
-install: build debian/cvmfs-libs.install debian/cvmfs-dev.install debian/cvmfs.install debian/cvmfs-server.install debian/cvmfs-fuse3.install debian/cvmfs-gateway.install debian/cvmfs-snapshotter.install
+install: build debian/cvmfs-libs.install debian/cvmfs-dev.install debian/cvmfs.install debian/cvmfs-server.install debian/cvmfs-fuse3.install $(GO_INSTALL_DEPS)
 	dh_testdir
 	dh_testroot
 	dh_prep
@@ -79,7 +89,7 @@ install: build debian/cvmfs-libs.install debian/cvmfs-dev.install debian/cvmfs.i
 	rm -f ${CURDIR}/debian/tmp/etc/cvmfs/domain.d/*.conf
 	rm -f ${CURDIR}/debian/tmp/etc/cvmfs/default.d/*.conf
 	rm -f ${CURDIR}/debian/tmp/etc/cvmfs/serverorder.sh
-	dh_install --sourcedir=${CURDIR}/debian/tmp
+	dh_install --sourcedir=${CURDIR}/debian/tmp $(GO_SKIP)
 
 # Build architecture-independent files here.
 binary-indep: build install
@@ -111,9 +121,9 @@ binary-arch: build install
 	dh_installdeb
 #        dh_perl
 	dh_shlibdeps
-	dh_gencontrol
-	dh_md5sums
-	dh_builddeb
+	dh_gencontrol $(GO_SKIP)
+	dh_md5sums $(GO_SKIP)
+	dh_builddeb $(GO_SKIP)
 
 binary: binary-indep binary-arch
 .PHONY: build clean binary-indep binary-arch binary install


### PR DESCRIPTION
Ubuntu 22.04, Suse 15.5, and Debian 11 have system cmake packages that are too old for the features we use (FetchContent).  It's easy to install a newer version of this build dependency from upstream, so this patch adds a script to this in a seamless way ( done automatically via build_install_builddeps.sh).