### PR TITLE
client: add CVMFS_REPOSITORIES_NOMOUNT param to help with syslog noise

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -768,14 +768,14 @@ int FuseMain(int argc, char *argv[]) {
     premount_fuse_ = false;
   }
 
-  if (options_manager->GetValue("CVMFS_IGNORED_REPOS", &parameter)
+  if (options_manager->GetValue("CVMFS_REPOSITORIES_NOMOUNT", &parameter)
       && !parameter.empty()) {
     const vector<string> ignored_repos = SplitString(parameter, ',');
     for (unsigned i = 0, s = ignored_repos.size(); i < s; ++i) {
       if (Trim(ignored_repos[i]) == *repository_name_) {
         LogCvmfs(kLogCvmfs, kLogStdout,
                  "CernVM-FS: mount attempt for %s ignored "
-                 "(listed in CVMFS_IGNORED_REPOS)",
+                 "(listed in CVMFS_REPOSITORIES_NOMOUNT)",
                  repository_name_->c_str());
         delete options_manager;
         fuse_opt_free_args(mount_options);

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -768,6 +768,23 @@ int FuseMain(int argc, char *argv[]) {
     premount_fuse_ = false;
   }
 
+  if (options_manager->GetValue("CVMFS_IGNORED_REPOS", &parameter)
+      && !parameter.empty()) {
+    const vector<string> ignored_repos = SplitString(parameter, ',');
+    for (unsigned i = 0, s = ignored_repos.size(); i < s; ++i) {
+      if (Trim(ignored_repos[i]) == *repository_name_) {
+        LogCvmfs(kLogCvmfs, kLogStdout,
+                 "CernVM-FS: mount attempt for %s ignored "
+                 "(listed in CVMFS_IGNORED_REPOS)",
+                 repository_name_->c_str());
+        delete options_manager;
+        fuse_opt_free_args(mount_options);
+        delete mount_options;
+        return kFailIgnoredMount;
+      }
+    }
+  }
+
 #ifdef __APPLE__
   string volname = "-ovolname=" + *repository_name_;
   fuse_opt_add_arg(mount_options, volname.c_str());

--- a/cvmfs/loader.h
+++ b/cvmfs/loader.h
@@ -51,6 +51,7 @@ enum Failures {
   kFailWpad,
   kFailLockWorkspace,
   kFailRevisionBlacklisted,
+  kFailIgnoredMount,
 
   kFailNumEntries
 };
@@ -83,7 +84,8 @@ inline const char *Code2Ascii(const Failures error) {
   texts[23] = "proxy auto-discovery failed";
   texts[24] = "workspace already locked";
   texts[25] = "revision blacklisted";
-  texts[26] = "no text";
+  texts[26] = "mount attempt ignored";
+  texts[27] = "no text";
   return texts[error];
 }
 

--- a/test/src/111-ignore-mount-attempt/main
+++ b/test/src/111-ignore-mount-attempt/main
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+cvmfs_test_name="Ignore mount attempts for configured repositories"
+cvmfs_test_suites="quick"
+
+cleanup() {
+  echo "running cleanup()"
+  sudo umount /cvmfs/projects.cern.ch 2>/dev/null
+  if [ -f /etc/cvmfs/default.local.111bak ]; then
+    sudo cp /etc/cvmfs/default.local.111bak /etc/cvmfs/default.local
+    sudo rm -f /etc/cvmfs/default.local.111bak
+  fi
+  autofs_switch on
+}
+
+cvmfs_run_test() {
+  logfile=$1
+
+  local repo="atlas.cern.ch"
+  local ignored_repo="projects.cern.ch"
+
+  echo "*** backing up default.local"
+  if [ -f /etc/cvmfs/default.local ]; then
+    sudo cp /etc/cvmfs/default.local /etc/cvmfs/default.local.111bak
+  fi
+
+  trap cleanup EXIT HUP INT TERM || return 2
+
+  # =========================================================================
+  # Test 1: accessing an ignored repo via autofs fails silently
+  # =========================================================================
+
+  echo "*** setting up config with CVMFS_IGNORED_REPOS via cvmfs_mount"
+  cvmfs_mount ${repo} \
+    "CVMFS_IGNORED_REPOS=${ignored_repo},another.example.tld" \
+    || return 10
+
+  # Unmount everything so we can restart cleanly with autofs
+  echo "*** unmounting repos before switching to autofs"
+  sudo umount /cvmfs/${repo} 2>/dev/null
+  sudo umount /cvmfs/cvmfs-config.cern.ch 2>/dev/null
+
+  echo "*** switching on autofs"
+  autofs_switch on || return 11
+
+  to_syslog "CVMFS_TEST_111_SYSLOG_MARKER_1"
+
+  echo "*** accessing ignored repo ${ignored_repo} via autofs (should fail)"
+  local ls_output
+  ls_output=$(ls /cvmfs/${ignored_repo}/ 2>&1)
+  local ls_retval=$?
+  if [ $ls_retval -eq 0 ]; then
+    echo "ERROR: listing ignored repo ${ignored_repo} via autofs should have failed"
+    return 20
+  fi
+  echo "*** access to ignored repo correctly failed"
+
+  sleep 2
+  local syslog_noise
+  syslog_noise=$(cat_syslog | \
+    sed -n '/CVMFS_TEST_111_SYSLOG_MARKER_1/,$p' | \
+    grep -i "(${ignored_repo})" | \
+    grep -v "CVMFS_TEST_111_SYSLOG_MARKER" || true)
+  if [ "x${syslog_noise}" != "x" ]; then
+    echo "ERROR: found syslog entries for ignored repo (autofs test):"
+    echo "${syslog_noise}"
+    return 30
+  fi
+  echo "*** no syslog noise (autofs test), good"
+
+  # =========================================================================
+  # Test 2: non-ignored repo still works via autofs
+  # =========================================================================
+
+  echo "*** verifying non-ignored repo ${repo} works via autofs"
+  ls /cvmfs/${repo}/ > /dev/null 2>&1 || return 40
+  echo "*** non-ignored repo ${repo} is accessible via autofs, good"
+
+  # =========================================================================
+  # Test 3: spaces in the comma-separated list are handled
+  # =========================================================================
+
+  echo "*** unmounting repos for spaces test"
+  sudo umount /cvmfs/${repo} 2>/dev/null
+  sudo umount /cvmfs/cvmfs-config.cern.ch 2>/dev/null
+
+  echo "*** setting up config with spaces in ignore list"
+  cvmfs_mount ${repo} \
+    "CVMFS_IGNORED_REPOS= ${ignored_repo} , another.example.tld " \
+    || return 50
+
+  # Restart with autofs
+  sudo umount /cvmfs/${repo} 2>/dev/null
+  sudo umount /cvmfs/cvmfs-config.cern.ch 2>/dev/null
+  autofs_switch on || return 51
+
+  to_syslog "CVMFS_TEST_111_SYSLOG_MARKER_2"
+
+  echo "*** attempting to access ignored repo with spaces in list (should fail)"
+  ls_output=$(ls /cvmfs/${ignored_repo}/ 2>&1)
+  ls_retval=$?
+  if [ $ls_retval -eq 0 ]; then
+    echo "ERROR: access to ignored repo should have failed (spaces test)"
+    return 60
+  fi
+  echo "*** access correctly failed"
+
+  sleep 2
+  syslog_noise=$(cat_syslog | \
+    sed -n '/CVMFS_TEST_111_SYSLOG_MARKER_2/,$p' | \
+    grep -i "(${ignored_repo})" | \
+    grep -v "CVMFS_TEST_111_SYSLOG_MARKER" || true)
+  if [ "x${syslog_noise}" != "x" ]; then
+    echo "ERROR: found syslog entries for ignored repo (spaces test):"
+    echo "${syslog_noise}"
+    return 70
+  fi
+  echo "*** no syslog noise (spaces test), good"
+
+  return 0
+}

--- a/test/src/111-ignore-mount-attempt/main
+++ b/test/src/111-ignore-mount-attempt/main
@@ -30,9 +30,9 @@ cvmfs_run_test() {
   # Test 1: accessing an ignored repo via autofs fails silently
   # =========================================================================
 
-  echo "*** setting up config with CVMFS_IGNORED_REPOS via cvmfs_mount"
+  echo "*** setting up config with CVMFS_REPOSITORIES_NOMOUNT via cvmfs_mount"
   cvmfs_mount ${repo} \
-    "CVMFS_IGNORED_REPOS=${ignored_repo},another.example.tld" \
+    "CVMFS_REPOSITORIES_NOMOUNT=${ignored_repo},another.example.tld" \
     || return 10
 
   # Unmount everything so we can restart cleanly with autofs
@@ -86,7 +86,7 @@ cvmfs_run_test() {
 
   echo "*** setting up config with spaces in ignore list"
   cvmfs_mount ${repo} \
-    "CVMFS_IGNORED_REPOS= ${ignored_repo} , another.example.tld " \
+    "CVMFS_REPOSITORIES_NOMOUNT= ${ignored_repo} , another.example.tld " \
     || return 50
 
   # Restart with autofs


### PR DESCRIPTION
This PR implements a longstanding request to help with log noise from mount attempts on projects.cern.ch. This is a repository that can only be mounted on an internal network, but since it's in a search path for experiment software, there are frequent mount attempts when using autofs in an external network, which cannot easily be avoided by fixing the software. This causes lots of noise in the syslogs since each failed mount attempt is logged like:

```
cvmfs2[2714102]: (no.such.repo) failed to download repository manifest (2 - malformed URL)
cvmfs2[2714102]: (no.such.repo) Failed to initialize root file catalog (16 - file catalog failure)
 ```
 
 We've thought about several other solutions and workarounds, including configuring the squids to redirect external requests to another server url that serves an existing but empty repo, but ultimately I think it's best to do it explicitly and fail early in the loader.
 
 I'm still moderately worried about getting tickets where this feature is mistaken for a cvmfs issue, but I've tried to add clear debug log messages for the problem. Care should be taken by the admins to only deploy this config site-locally in the right environment ( in order to not ignore projects.cern.ch in the cern network for example). Please also add appropriate comments so it is not copied blindly.