### PR TITLE
`mkfs -P`, `cvmfs_server connect-gw`, and some convenience features

### DIFF
--- a/cvmfs/make_cvmfs_server.sh
+++ b/cvmfs/make_cvmfs_server.sh
@@ -42,6 +42,7 @@ COMPONENTS="\
     server/cvmfs_server_masterkeycard.sh
     server/cvmfs_server_import.sh
     server/cvmfs_server_mkfs.sh
+    server/cvmfs_server_connect_gw.sh
     server/cvmfs_server_add_replica.sh
     server/cvmfs_server_rmfs.sh
     server/cvmfs_server_resign.sh

--- a/cvmfs/publish/cmd_mkfs.h
+++ b/cvmfs/publish/cmd_mkfs.h
@@ -92,6 +92,11 @@ class CmdMkfs : public Command {
 
     p.push_back(Parameter::Switch(
         "external", 'X', "Enable to use this repository for external data"));
+
+    // Undocumented dev/convenience flag: publish the repo public key and a
+    // client mount helper script to the HTTP-served storage area.
+    p.push_back(Parameter::Switch("publish-client-setup", 'D', ""));
+
     return p;
   }
   virtual std::string GetUsage() const {

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1189,9 +1189,8 @@ EOF
 }
 
 
-setup_and_mount_new_repository() {
+setup_new_repository_mountpoints() {
   local name=$1
-  local http_timeout=15
 
   # get repository information
   load_repo_config $name
@@ -1218,6 +1217,15 @@ EOF
   fi
   local user_shell="$(get_user_shell $name)"
   $user_shell "touch ${CVMFS_SPOOL_DIR}/client.local"
+}
+
+
+mount_new_repository() {
+  local name=$1
+  local http_timeout=15
+
+  load_repo_config $name
+  local rdonly_dir="${CVMFS_SPOOL_DIR}/rdonly"
 
   # avoid racing against apache; we can safely ignore the certificate validation
   # at this step, we only want to check that the endpoint is up.
@@ -1241,6 +1249,14 @@ EOF
       /run/systemd/generator '' '' 2>/dev/null || true
     systemctl daemon-reload
   fi
+}
+
+
+setup_and_mount_new_repository() {
+  local name=$1
+
+  setup_new_repository_mountpoints $name || return 1
+  mount_new_repository $name
 }
 
 

--- a/cvmfs/server/cvmfs_server_connect_gw.sh
+++ b/cvmfs/server/cvmfs_server_connect_gw.sh
@@ -75,8 +75,27 @@ cvmfs_server_connect_gw() {
   # If -K is given, fetch keys from the gateway
   if [ $fetch_keys -eq 1 ]; then
     echo -n "Fetching repository keys from gateway... "
+
+    # Read the .gw key to compute the HMAC for authentication
+    cvmfs_sys_file_is_regular "$gw_key" || \
+      die "fail! Gateway key not found: $gw_key (needed for authentication)"
+    local gw_key_id
+    local gw_key_secret
+    gw_key_id=$(cat "$gw_key" | awk '{print $2}')
+    gw_key_secret=$(cat "$gw_key" | awk '{print $3}')
+    [ x"$gw_key_id" != x"" ] && [ x"$gw_key_secret" != x"" ] || \
+      die "fail! Could not parse gateway key file: $gw_key"
+
+    # Compute HMAC of the URL path using the gateway secret
+    local api_path="/api/v1/repos/${name}/keys"
+    local hmac_hash
+    hmac_hash=$(echo -n "$api_path" | openssl dgst -sha1 -hmac "$gw_key_secret" | awk '{print $NF}')
+    local hmac_b64
+    hmac_b64=$(echo -n "$hmac_hash" | base64)
+
     local keys_response
-    keys_response=$(curl -sf "${gateway_url}/repos/${name}/keys" 2>&1) || \
+    keys_response=$(curl -sf -H "Authorization: ${gw_key_id} ${hmac_b64}" \
+      "${gateway_url}/repos/${name}/keys" 2>&1) || \
       die "fail! Could not reach gateway key endpoint at ${gateway_url}/repos/${name}/keys
   Make sure the gateway has 'enable_key_endpoint: true' in its configuration."
 

--- a/cvmfs/server/cvmfs_server_connect_gw.sh
+++ b/cvmfs/server/cvmfs_server_connect_gw.sh
@@ -87,13 +87,23 @@ cvmfs_server_connect_gw() {
     keys_import_location="/etc/cvmfs/keys"
   fi
 
-  # If -K is given, fetch keys from the gateway
-  if [ $fetch_keys -eq 1 ]; then
+  # Check that the .gw key exists (always required — it's the secret)
+  local gw_key="${keys_import_location}/${name}.gw"
+  local pub_key="${keys_import_location}/${name}.pub"
+  local crt_key="${keys_import_location}/${name}.crt"
+
+  cvmfs_sys_file_is_regular "$gw_key" || \
+    die "Gateway key not found: $gw_key
+  Copy the .gw file from the gateway machine, or place it in /etc/cvmfs/keys/"
+
+  # Auto-fetch .pub and .crt from the gateway if they are missing
+  # (also triggered explicitly with -K)
+  if [ $fetch_keys -eq 1 ] || \
+     ! cvmfs_sys_file_is_regular "$pub_key" || \
+     ! cvmfs_sys_file_is_regular "$crt_key"; then
     echo -n "Fetching repository keys from gateway... "
 
     # Read the .gw key to compute the HMAC for authentication
-    cvmfs_sys_file_is_regular "$gw_key" || \
-      die "fail! Gateway key not found: $gw_key (needed for authentication)"
     local gw_key_id
     local gw_key_secret
     gw_key_id=$(cat "$gw_key" | awk '{print $2}')
@@ -139,20 +149,13 @@ for ext in ('pub', 'crt'):
     echo "  -> ${keys_import_location}/${name}.crt"
   fi
 
-  # Check that the required key files exist
-  local gw_key="${keys_import_location}/${name}.gw"
-  local pub_key="${keys_import_location}/${name}.pub"
-  local crt_key="${keys_import_location}/${name}.crt"
-
-  cvmfs_sys_file_is_regular "$gw_key" || \
-    die "Gateway key not found: $gw_key
-  Copy the .gw file from the gateway machine, or place it in /etc/cvmfs/keys/"
+  # Final check that all key files are present
   cvmfs_sys_file_is_regular "$pub_key" || \
     die "Public key not found: $pub_key
-  Copy the .pub file from the gateway machine, use -K to fetch it, or place it in /etc/cvmfs/keys/"
+  Could not fetch from gateway. Copy the .pub file from the gateway machine manually."
   cvmfs_sys_file_is_regular "$crt_key" || \
     die "Certificate not found: $crt_key
-  Copy the .crt file from the gateway machine, use -K to fetch it, or place it in /etc/cvmfs/keys/"
+  Could not fetch from gateway. Copy the .crt file from the gateway machine manually."
 
   # Build the upstream string for gateway mode
   local upstream="gw,/srv/cvmfs/${name}/data/txn,${gateway_url}"

--- a/cvmfs/server/cvmfs_server_connect_gw.sh
+++ b/cvmfs/server/cvmfs_server_connect_gw.sh
@@ -73,6 +73,42 @@ cvmfs_server_connect_gw() {
     gateway_url="${gateway_url}/api/v1"
   fi
 
+  # Health check: verify the gateway is reachable
+  echo -n "Checking gateway connectivity at ${gateway_url}... "
+  local gw_host gw_port
+  gw_host=$(echo "$gateway_url" | sed -E 's|https?://([^:/]+).*|\1|')
+  gw_port=$(echo "$gateway_url" | sed -E 's|https?://[^:]+:([0-9]+).*|\1|')
+  [ x"$gw_port" = x"$gateway_url" ] && gw_port=80  # no port matched, default to 80
+
+  # First check if the host/port is reachable at the TCP level
+  if ! timeout 5 bash -c "echo >/dev/tcp/${gw_host}/${gw_port}" 2>/dev/null; then
+    die "fail!
+
+  Cannot connect to ${gw_host}:${gw_port}.
+  Possible causes:
+    - The gateway service is not running (check with: systemctl status cvmfs-gateway)
+    - A firewall is blocking port ${gw_port}
+    - The hostname '${gw_host}' does not resolve or is unreachable
+  "
+  fi
+
+  # Then check if the gateway API responds
+  local health_response
+  health_response=$(curl -sf --max-time 10 "${gateway_url}" 2>&1)
+  if [ $? -ne 0 ]; then
+    die "fail!
+
+  Host ${gw_host}:${gw_port} is reachable but the gateway API is not responding at:
+    ${gateway_url}
+  Possible causes:
+    - The gateway is listening on a different port (default: 4929)
+    - The API path is wrong (expected: /api/v1)
+    - The gateway service is starting up or in a bad state
+  Check the gateway with: curl ${gateway_url}
+  "
+  fi
+  echo "ok"
+
   # default stratum0 URL: derive from gateway URL
   if [ x"$stratum0" = x"" ]; then
     # Strip the port and API path from the gateway URL to build the stratum0 URL

--- a/cvmfs/server/cvmfs_server_connect_gw.sh
+++ b/cvmfs/server/cvmfs_server_connect_gw.sh
@@ -1,0 +1,145 @@
+#
+# This file is part of the CernVM File System
+# This script takes care of connecting a publisher to a gateway
+#
+# Implementation of the "cvmfs_server connect-gw" command
+
+# This file depends on functions implemented in the following files:
+# - cvmfs_server_util.sh
+# - cvmfs_server_common.sh
+# - cvmfs_server_ssl.sh
+# - cvmfs_server_apache.sh
+# - cvmfs_server_json.sh
+# - cvmfs_server_mkfs.sh
+
+
+cvmfs_server_connect_gw() {
+  local name
+  local gateway_url
+  local owner
+  local keys_import_location
+  local stratum0
+  local fetch_keys=0
+
+  # parameter handling
+  OPTIND=1
+  while getopts "u:o:k:w:K" option; do
+    case $option in
+      u)
+        gateway_url=$OPTARG
+      ;;
+      o)
+        owner=$OPTARG
+      ;;
+      k)
+        keys_import_location=$OPTARG
+      ;;
+      w)
+        stratum0=$OPTARG
+      ;;
+      K)
+        fetch_keys=1
+      ;;
+      ?)
+        shift $(($OPTIND-2))
+        usage "Command connect-gw: Unrecognized option: $1"
+      ;;
+    esac
+  done
+
+  # get repository name
+  shift $(($OPTIND-1))
+  check_parameter_count 1 $#
+  name=$(get_repository_name $1)
+
+  is_valid_repo_name "$name" || die "invalid repository name: $name"
+  is_root                    || die "Only root can connect to a gateway"
+
+  # gateway URL is required
+  [ x"$gateway_url" != x"" ] || die "Please specify the gateway API URL with -u (e.g. http://gateway.cern.ch:4929/api/v1)"
+
+  # default stratum0 URL: derive from gateway URL
+  if [ x"$stratum0" = x"" ]; then
+    # Strip the port and API path from the gateway URL to build the stratum0 URL
+    # e.g. http://gateway.cern.ch:4929/api/v1 -> http://gateway.cern.ch/cvmfs/<name>
+    local gw_scheme_host
+    gw_scheme_host=$(echo "$gateway_url" | sed -E 's|(https?://[^:/]+).*|\1|')
+    stratum0="${gw_scheme_host}/cvmfs/${name}"
+  fi
+
+  # default key location
+  if [ x"$keys_import_location" = x"" ]; then
+    keys_import_location="/etc/cvmfs/keys"
+  fi
+
+  # If -K is given, fetch keys from the gateway
+  if [ $fetch_keys -eq 1 ]; then
+    echo -n "Fetching repository keys from gateway... "
+    local keys_response
+    keys_response=$(curl -sf "${gateway_url}/repos/${name}/keys" 2>&1) || \
+      die "fail! Could not reach gateway key endpoint at ${gateway_url}/repos/${name}/keys
+  Make sure the gateway has 'enable_key_endpoint: true' in its configuration."
+
+    local status
+    status=$(echo "$keys_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null) || \
+      die "fail! Could not parse gateway response"
+
+    if [ x"$status" != x"ok" ]; then
+      local reason
+      reason=$(echo "$keys_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('reason','unknown'))" 2>/dev/null)
+      die "fail! Gateway returned error: $reason"
+    fi
+
+    # Decode and write the keys
+    mkdir -p "$keys_import_location"
+    echo "$keys_response" | python3 -c "
+import sys, json, base64
+data = json.load(sys.stdin)['data']
+for ext in ('pub', 'crt'):
+    if ext in data:
+        with open(sys.argv[1] + '/${name}.' + ext, 'wb') as f:
+            f.write(base64.b64decode(data[ext]))
+" "$keys_import_location" || die "fail! Could not write key files"
+    echo "done"
+    echo "  -> ${keys_import_location}/${name}.pub"
+    echo "  -> ${keys_import_location}/${name}.crt"
+  fi
+
+  # Check that the required key files exist
+  local gw_key="${keys_import_location}/${name}.gw"
+  local pub_key="${keys_import_location}/${name}.pub"
+  local crt_key="${keys_import_location}/${name}.crt"
+
+  cvmfs_sys_file_is_regular "$gw_key" || \
+    die "Gateway key not found: $gw_key
+  Copy the .gw file from the gateway machine, or place it in /etc/cvmfs/keys/"
+  cvmfs_sys_file_is_regular "$pub_key" || \
+    die "Public key not found: $pub_key
+  Copy the .pub file from the gateway machine, use -K to fetch it, or place it in /etc/cvmfs/keys/"
+  cvmfs_sys_file_is_regular "$crt_key" || \
+    die "Certificate not found: $crt_key
+  Copy the .crt file from the gateway machine, use -K to fetch it, or place it in /etc/cvmfs/keys/"
+
+  # Build the upstream string for gateway mode
+  local upstream="gw,/srv/cvmfs/${name}/data/txn,${gateway_url}"
+
+  # Default owner
+  if [ x"$owner" = x"" ]; then
+    owner=$(whoami)
+  fi
+
+  echo "Connecting to gateway as publisher for ${name}"
+  echo "  Gateway URL:  $gateway_url"
+  echo "  Stratum 0:    $stratum0"
+  echo "  Upstream:     $upstream"
+  echo "  Keys:         $keys_import_location"
+  echo "  Owner:        $owner"
+  echo
+
+  # Delegate to mkfs with the right parameters
+  cvmfs_server_mkfs -w "$stratum0" \
+                    -u "$upstream" \
+                    -k "$keys_import_location" \
+                    -o "$owner" \
+                    "$name"
+}

--- a/cvmfs/server/cvmfs_server_connect_gw.sh
+++ b/cvmfs/server/cvmfs_server_connect_gw.sh
@@ -56,7 +56,22 @@ cvmfs_server_connect_gw() {
   is_root                    || die "Only root can connect to a gateway"
 
   # gateway URL is required
-  [ x"$gateway_url" != x"" ] || die "Please specify the gateway API URL with -u (e.g. http://gateway.cern.ch:4929/api/v1)"
+  [ x"$gateway_url" != x"" ] || die "Please specify the gateway with -u (e.g. -u gateway.cern.ch)"
+
+  # If the user passed just a hostname (no scheme, no port, no path), expand it
+  # to the full gateway API URL: http://<host>:4929/api/v1
+  if ! echo "$gateway_url" | grep -q '://'; then
+    gateway_url="http://${gateway_url}:4929/api/v1"
+  elif ! echo "$gateway_url" | grep -q '/api/'; then
+    # Has scheme but no API path — append default port and path if missing
+    # Strip trailing slash
+    gateway_url=$(echo "$gateway_url" | sed 's|/$||')
+    # Add port if missing
+    if ! echo "$gateway_url" | grep -qE ':[0-9]+$'; then
+      gateway_url="${gateway_url}:4929"
+    fi
+    gateway_url="${gateway_url}/api/v1"
+  fi
 
   # default stratum0 URL: derive from gateway URL
   if [ x"$stratum0" = x"" ]; then

--- a/cvmfs/server/cvmfs_server_list.sh
+++ b/cvmfs/server/cvmfs_server_list.sh
@@ -45,6 +45,10 @@ cvmfs_server_list() {
       transaction_info=" - in transaction"
     fi
 
+    # get the storage type of the repository
+    local storage_type=""
+    storage_type=$(get_upstream_type $CVMFS_UPSTREAM_STORAGE)
+
     # check if the repository whitelist is accessible and expired
     local whitelist_info=""
     if is_stratum0 $name; then
@@ -58,8 +62,17 @@ cvmfs_server_list() {
     fi
 
     # check if the repository is healthy
+    # For gateway publishers (gw upstream) or mountless gateway backends
+    # (no rdonly/union mounts), skip the health check — the local mount is
+    # expected to be out of date or absent entirely.
     local health_info=""
-    if ! health_check -q $name; then
+    if [ x"$storage_type" = x"gw" ]; then
+      health_info=""
+    elif is_stratum0 $name && \
+         ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly" && \
+         ! is_mounted "/cvmfs/$name"; then
+      health_info=" - gw/mountless"
+    elif ! health_check -q $name; then
       health_info=" - unhealthy"
     fi
 
@@ -70,10 +83,6 @@ cvmfs_server_list() {
       local branch_name=$(get_checked_out_branch $name)
       checkout_info=" [checked out tag '$tag_name' on branch '$branch_name']"
     fi
-
-    # get the storage type of the repository
-    local storage_type=""
-    storage_type=$(get_upstream_type $CVMFS_UPSTREAM_STORAGE)
 
     # print out repository information list
     echo "$name ($CVMFS_REPOSITORY_TYPE / $storage_type$transaction_info$whitelist_info$health_info$checkout_info) $stratum1_info $version_info"

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -102,6 +102,7 @@ cvmfs_server_mkfs() {
   local external_data=false
   local require_masterkeycard=0
   local ignore_manifest_overwrite=0
+  local no_publisher=0
 
   local configure_apache=1
   local voms_authz=""
@@ -109,8 +110,11 @@ cvmfs_server_mkfs() {
 
   # parameter handling
   OPTIND=1
-  while getopts "Xw:u:o:mf:vgG:a:zs:k:pRV:Z:x:I" option; do
+  while getopts "PXw:u:o:mf:vgG:a:zs:k:pRV:Z:x:I" option; do
     case $option in
+      P)
+        no_publisher=1
+      ;;
       X)
         external_data=true
       ;;
@@ -208,6 +212,9 @@ cvmfs_server_mkfs() {
 
   # sanity checks
   local upstream_type=$(get_upstream_type $upstream)
+  if [ $no_publisher -eq 1 ] && [ x"$upstream_type" = xgw ]; then
+    die "No-publisher bootstrap expects direct repository storage for the initial mkfs step. Create the backend repository first and switch to a gw,... upstream afterwards."
+  fi
   check_repository_existence $name  && die "The repository $name already exists"
   # if upstream is a gateway, we expect the repository to not be empty.
   if [ x"$upstream_type" != xgw ]; then
@@ -370,17 +377,25 @@ cvmfs_server_mkfs() {
   fi
   echo "done"
 
-  echo -n "Mounting CernVM-FS Storage... "
-  setup_and_mount_new_repository $name || die "fail"
-  echo "done"
+  if [ $no_publisher -eq 1 ]; then
+    echo -n "Configuring CernVM-FS Mount Points... "
+    setup_new_repository_mountpoints $name || die "fail"
+    echo "done"
+  else
+    echo -n "Mounting CernVM-FS Storage... "
+    setup_and_mount_new_repository $name || die "fail"
+    echo "done"
+  fi
 
   if [ $replicable -eq 1 ]; then
     cvmfs_server_alterfs -m on $name
   fi
 
-  health_check $name || die "fail! (health check after mount)"
+  if [ $no_publisher -eq 0 ]; then
+    health_check $name || die "fail! (health check after mount)"
+  fi
 
-  if [ x"$upstream_type" != xgw -a "x$voms_authz" = "x" ]; then
+  if [ $no_publisher -eq 0 ] && [ x"$upstream_type" != xgw -a "x$voms_authz" = "x" ]; then
       echo -n "Initial commit... "
       cvmfs_server_transaction $name > /dev/null || die "fail (transaction)"
       echo "New CernVM-FS repository for $name" > /cvmfs/${name}/new_repository

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -83,6 +83,126 @@ cvmfs_server_alterfs() {
 
 ################################################################################
 
+# Publish the repository public key and a client mount helper script to the
+# HTTP-served storage area.  This is a convenience/dev feature triggered by the
+# undocumented -D flag.
+_mkfs_publish_client_setup() {
+  local name=$1
+  local upstream=$2
+  local stratum0=$3
+
+  local pub_key="/etc/cvmfs/keys/${name}.pub"
+  if ! cvmfs_sys_file_is_regular "$pub_key"; then
+    echo "Warning: public key $pub_key not found, skipping client setup publish"
+    return
+  fi
+
+  # Determine the public server URL that clients should use.  If stratum0 still
+  # points to localhost, try to replace it with the machine's hostname.
+  local server_url="$stratum0"
+  if echo "$server_url" | grep -q "://localhost"; then
+    local fqdn
+    fqdn=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "localhost")
+    server_url=$(echo "$server_url" | sed "s|://localhost|://${fqdn}|")
+  fi
+
+  # Generate the mount helper script
+  local mount_script_content
+  mount_script_content=$(cat <<MOUNT_SCRIPT_EOF
+#!/bin/sh
+# Auto-generated client setup script for CernVM-FS repository ${name}
+# Usage:  curl <server>/${name}/mount-${name}.sh | sh
+#
+# This script must be run as root.
+
+set -e
+
+REPO="${name}"
+SERVER_URL="${server_url}"
+PUB_KEY_URL="\${SERVER_URL}/${name}.pub"
+KEY_DIR="/etc/cvmfs/keys"
+
+echo "Setting up CernVM-FS client for \${REPO} ..."
+
+# Ensure cvmfs client is installed
+if ! command -v cvmfs2 >/dev/null 2>&1 && ! command -v mount.cvmfs >/dev/null 2>&1; then
+  echo "Error: CernVM-FS client (cvmfs2) is not installed." >&2
+  echo "Install it first, e.g.:  yum install cvmfs  or  apt-get install cvmfs" >&2
+  exit 1
+fi
+
+# Download the public key
+mkdir -p "\${KEY_DIR}"
+echo "Downloading public key from \${PUB_KEY_URL} ..."
+curl -fsSL "\${PUB_KEY_URL}" -o "\${KEY_DIR}/\${REPO}.pub"
+echo "  -> \${KEY_DIR}/\${REPO}.pub"
+
+# Write per-repository client configuration
+REPO_CONF_DIR="/etc/cvmfs/config.d"
+mkdir -p "\${REPO_CONF_DIR}"
+cat > "\${REPO_CONF_DIR}/\${REPO}.conf" <<CONF_EOF
+CVMFS_SERVER_URL=\${SERVER_URL}
+CVMFS_PUBLIC_KEY=\${KEY_DIR}/\${REPO}.pub
+CONF_EOF
+echo "  -> \${REPO_CONF_DIR}/\${REPO}.conf"
+
+# Ensure default.local exists with at least a proxy setting
+if [ ! -f /etc/cvmfs/default.local ]; then
+  cat > /etc/cvmfs/default.local <<DEFAULT_EOF
+CVMFS_HTTP_PROXY=DIRECT
+DEFAULT_EOF
+  echo "  -> created /etc/cvmfs/default.local (proxy=DIRECT)"
+fi
+
+# Create mountpoint and mount
+mkdir -p "/cvmfs/\${REPO}"
+echo "Mounting \${REPO} ..."
+mount -t cvmfs "\${REPO}" "/cvmfs/\${REPO}"
+echo "Done.  Repository is available at /cvmfs/\${REPO}"
+MOUNT_SCRIPT_EOF
+)
+
+  if is_local_upstream $upstream; then
+    local storage_dir="${DEFAULT_LOCAL_STORAGE}/${name}"
+    echo -n "Publishing public key to ${storage_dir}/ ... "
+    cp "$pub_key" "${storage_dir}/${name}.pub" || { echo "fail"; return; }
+    echo "done"
+
+    echo -n "Publishing client mount script to ${storage_dir}/mount-${name}.sh ... "
+    echo "$mount_script_content" > "${storage_dir}/mount-${name}.sh"
+    chmod 0644 "${storage_dir}/mount-${name}.sh"
+    echo "done"
+
+    echo "\
+Client setup published.  On a client machine, run:
+  curl ${server_url}/mount-${name}.sh | sudo sh"
+  elif is_s3_upstream $upstream; then
+    local temp_dir="${CVMFS_SPOOL_DIR}/tmp"
+
+    echo -n "Publishing public key to upstream storage ... "
+    cp "$pub_key" "${temp_dir}/${name}.pub"
+    __swissknife upload -i "${temp_dir}/${name}.pub" -o "${name}.pub" \
+      -r $CVMFS_UPSTREAM_STORAGE > /dev/null || { echo "fail"; return; }
+    rm -f "${temp_dir}/${name}.pub"
+    echo "done"
+
+    echo -n "Publishing client mount script to upstream storage ... "
+    echo "$mount_script_content" > "${temp_dir}/mount-${name}.sh"
+    __swissknife upload -i "${temp_dir}/mount-${name}.sh" -o "mount-${name}.sh" \
+      -r $CVMFS_UPSTREAM_STORAGE > /dev/null || { echo "fail"; return; }
+    rm -f "${temp_dir}/mount-${name}.sh"
+    echo "done"
+
+    echo "\
+Client setup published.  On a client machine, run:
+  curl ${server_url}/mount-${name}.sh | sudo sh"
+  else
+    echo "Warning: client setup publish not supported for upstream type '$(get_upstream_type $upstream)'"
+  fi
+}
+
+################################################################################
+
 
 cvmfs_server_mkfs() {
   local name
@@ -103,6 +223,7 @@ cvmfs_server_mkfs() {
   local require_masterkeycard=0
   local ignore_manifest_overwrite=0
   local no_publisher=0
+  local publish_client_setup=0
 
   local configure_apache=1
   local voms_authz=""
@@ -110,8 +231,11 @@ cvmfs_server_mkfs() {
 
   # parameter handling
   OPTIND=1
-  while getopts "PXw:u:o:mf:vgG:a:zs:k:pRV:Z:x:I" option; do
+  while getopts "PXw:u:o:mf:vgG:a:zs:k:pRV:Z:x:ID" option; do
     case $option in
+      D)
+        publish_client_setup=1
+      ;;
       P)
         no_publisher=1
       ;;
@@ -415,6 +539,10 @@ cvmfs_server_mkfs() {
   syncfs
 
   print_new_repository_notice $name $cvmfs_user $require_masterkeycard
+
+  if [ $publish_client_setup -eq 1 ]; then
+    _mkfs_publish_client_setup $name $upstream $stratum0
+  fi
 }
 
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1289,6 +1289,7 @@ Supported Commands:
                   [-z enable garbage collection] [-v volatile content]
                   [-Z compression algorithm (default: zlib)]
                   [-k path to existing keychain] [-p no apache config]
+                  [-P no publisher bootstrap]
                   [-R require masterkeycard key ]
                   [-V VOMS authorization] [-X (external data)]
                   [-x proxy url]

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1237,7 +1237,7 @@ cvmfs_server_update_geodb() {
 # @return   0 if the command was recognized
 is_subcommand() {
   local subcommand="$1"
-  local supported_commands="mkfs add-replica import publish rollback rmfs alterfs   \
+  local supported_commands="mkfs connect-gw add-replica import publish rollback rmfs alterfs   \
     resign list info tag list-tags lstags check transaction enter abort snapshot    \
     skeleton migrate list-catalogs diff checkout update-geodb gc catalog-chown      \
     eliminate-hardlinks eliminate-bulk-hashes fix-stats update-info update-repoinfo \
@@ -1295,6 +1295,16 @@ Supported Commands:
                   [-x proxy url]
                   <fully qualified repository name>
                   Creates a new repository with a given name
+  connect-gw      -u <gateway API url>
+                  [-w stratum0 url (default: derived from gateway url)]
+                  [-o owner (default: current user)]
+                  [-k path to keys (default: /etc/cvmfs/keys)]
+                  [-K fetch .pub and .crt from the gateway key endpoint]
+                  <fully qualified repository name>
+                  Connect to a gateway as a publisher. Requires the .gw key
+                  file in /etc/cvmfs/keys/ (or path given by -k). The .pub
+                  and .crt files can be fetched from the gateway with -K if
+                  the gateway has enable_key_endpoint enabled.
   add-replica     [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
                   [-a silence apache warning] [-z enable garbage collection]
                   [-n alias name] [-s S3 config file] [-p no apache config]

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1295,7 +1295,7 @@ Supported Commands:
                   [-x proxy url]
                   <fully qualified repository name>
                   Creates a new repository with a given name
-  connect-gw      -u <gateway API url>
+  connect-gw      -u <gateway hostname or API url>
                   [-w stratum0 url (default: derived from gateway url)]
                   [-o owner (default: current user)]
                   [-k path to keys (default: /etc/cvmfs/keys)]

--- a/gateway/CMakeLists.txt
+++ b/gateway/CMakeLists.txt
@@ -31,8 +31,22 @@ install (
   PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
 )
 
-install (
-  FILES         config/repo.json config/user.json
-  DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/gateway"
-  PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-)
+# Install config files without overwriting existing ones.
+# Always ship .dist as a reference; only copy to the real name if absent.
+foreach(_conf repo.json user.json)
+  install(
+    FILES         "config/${_conf}"
+    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/gateway"
+    PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+    RENAME        "${_conf}.dist"
+  )
+  install(CODE "
+    set(_dir \"\$ENV{DESTDIR}${SYSCONF_INSTALL_DIR}/cvmfs/gateway\")
+    if(NOT EXISTS \"\${_dir}/${_conf}\")
+      message(STATUS \"Installing default config: \${_dir}/${_conf}\")
+      execute_process(COMMAND \${CMAKE_COMMAND} -E copy \"\${_dir}/${_conf}.dist\" \"\${_dir}/${_conf}\")
+    else()
+      message(STATUS \"Preserving existing config: \${_dir}/${_conf}\")
+    endif()
+  ")
+endforeach()

--- a/gateway/CMakeLists.txt
+++ b/gateway/CMakeLists.txt
@@ -31,22 +31,9 @@ install (
   PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
 )
 
-# Install config files without overwriting existing ones.
-# Always ship .dist as a reference; only copy to the real name if absent.
-foreach(_conf repo.json user.json)
-  install(
-    FILES         "config/${_conf}"
-    DESTINATION   "${SYSCONF_INSTALL_DIR}/cvmfs/gateway"
-    PERMISSIONS   OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-    RENAME        "${_conf}.dist"
-  )
-  install(CODE "
-    set(_dir \"\$ENV{DESTDIR}${SYSCONF_INSTALL_DIR}/cvmfs/gateway\")
-    if(NOT EXISTS \"\${_dir}/${_conf}\")
-      message(STATUS \"Installing default config: \${_dir}/${_conf}\")
-      execute_process(COMMAND \${CMAKE_COMMAND} -E copy \"\${_dir}/${_conf}.dist\" \"\${_dir}/${_conf}\")
-    else()
-      message(STATUS \"Preserving existing config: \${_dir}/${_conf}\")
-    endif()
-  ")
-endforeach()
+# Install config files.
+install(
+  FILES config/repo.json config/user.json
+  DESTINATION "${SYSCONF_INSTALL_DIR}/cvmfs/gateway"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)

--- a/gateway/internal/gateway/backend/access.go
+++ b/gateway/internal/gateway/backend/access.go
@@ -291,7 +291,7 @@ func keyImporter(ks KeySpec) (string, string, string, bool, error) {
 	case "file":
 		id, sec, err := gw.LoadKey(ks.FileName)
 		if err != nil {
-			return "", "", "", false, fmt.Errorf("could not import key from file")
+			return "", "", "", false, fmt.Errorf("could not import key from file %s: %w", ks.FileName, err)
 		}
 		return id, sec, ks.Path, ks.Admin, nil
 	default:

--- a/gateway/internal/gateway/config.go
+++ b/gateway/internal/gateway/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	WorkDir string `mapstructure:"work_dir"`
 	// MockReceiver enables a mocked implementation of the receiver worker
 	MockReceiver bool `mapstructure:"mock_receiver"`
+	// EnableKeyEndpoint enables the /repos/:name/keys endpoint that allows
+	// publishers to fetch the repository public key and certificate
+	EnableKeyEndpoint bool `mapstructure:"enable_key_endpoint"`
 }
 
 // ReadConfig reads configuration files and commandline flags, and populates a Config object
@@ -49,6 +52,7 @@ func ReadConfig() (*Config, error) {
 	pflag.String("receiver_path", "/usr/bin/cvmfs_receiver", "the path of the cvmfs_receiver executable")
 	pflag.String("work_dir", "/var/lib/cvmfs-gateway", "the working directory for database files")
 	pflag.Bool("mock_receiver", false, "enable the mocked implementation of the receiver process (for testing)")
+	pflag.Bool("enable_key_endpoint", false, "enable the /repos/:name/keys endpoint for publisher key retrieval")
 	pflag.Parse()
 
 	viper.SetConfigFile(configFile)

--- a/gateway/internal/gateway/frontend/authz.go
+++ b/gateway/internal/gateway/frontend/authz.go
@@ -115,6 +115,9 @@ func WithAuthz(ac be.ActionController, next httprouter.Handle) httprouter.Handle
 					return
 				}
 			}
+		} else if strings.HasPrefix(req.URL.Path, APIRoot+"/repos") && req.Method == "GET" {
+			// For GET requests on repo endpoints (e.g. keys), use the URL path to compute HMAC
+			HMACInput = []byte(req.URL.Path)
 		} else if strings.HasPrefix(req.URL.Path, APIRoot+"/payloads") {
 			token := ps.ByName("token")
 			if token != "" {

--- a/gateway/internal/gateway/frontend/frontend.go
+++ b/gateway/internal/gateway/frontend/frontend.go
@@ -10,8 +10,25 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+type frontendConfig struct {
+	enableKeyEndpoint bool
+}
+
+// FrontendOption configures optional frontend behaviour
+type FrontendOption func(*frontendConfig)
+
+// WithKeyEndpoint enables the /repos/:name/keys endpoint
+func WithKeyEndpoint(enable bool) FrontendOption {
+	return func(c *frontendConfig) { c.enableKeyEndpoint = enable }
+}
+
 // NewFrontend builds and configures a new HTTP server, but does not start it
-func NewFrontend(services be.ActionController, port int, timeout time.Duration) *http.Server {
+func NewFrontend(services be.ActionController, port int, timeout time.Duration, opts ...FrontendOption) *http.Server {
+	cfg := frontendConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	router := httprouter.New()
 
 	// middleware which only tags requests for GET
@@ -54,6 +71,9 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 	router.POST(APIRoot+"/notifications/publish", tag(MakeNotificationsHandler(services)))
 	router.GET(APIRoot+"/notifications/subscribe", tag(MakeNotificationsHandler(services)))
 
+	// Repository keys (opt-in endpoint for publisher setup)
+	router.GET(APIRoot+"/repos/:name/keys", tag(MakeRepoKeysHandler(services, cfg.enableKeyEndpoint)))
+
 	// Admin routes
 	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))
 	router.DELETE(APIRoot+"/leases-by-path/*path", amw(MakeAdminLeasesHandler(services)))
@@ -71,8 +91,8 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration) 
 }
 
 // Start HTTP frontend
-func Start(services *be.Services, port int, timeout time.Duration) error {
-	srv := NewFrontend(services, port, timeout)
+func Start(services *be.Services, port int, timeout time.Duration, opts ...FrontendOption) error {
+	srv := NewFrontend(services, port, timeout, opts...)
 	if err := srv.ListenAndServe(); err != nil {
 		return fmt.Errorf("could not run HTTP front-end: %w", err)
 	}

--- a/gateway/internal/gateway/frontend/frontend.go
+++ b/gateway/internal/gateway/frontend/frontend.go
@@ -71,8 +71,8 @@ func NewFrontend(services be.ActionController, port int, timeout time.Duration, 
 	router.POST(APIRoot+"/notifications/publish", tag(MakeNotificationsHandler(services)))
 	router.GET(APIRoot+"/notifications/subscribe", tag(MakeNotificationsHandler(services)))
 
-	// Repository keys (opt-in endpoint for publisher setup)
-	router.GET(APIRoot+"/repos/:name/keys", tag(MakeRepoKeysHandler(services, cfg.enableKeyEndpoint)))
+	// Repository keys (opt-in endpoint for publisher setup, HMAC-authenticated)
+	router.GET(APIRoot+"/repos/:name/keys", mw(MakeRepoKeysHandler(services, cfg.enableKeyEndpoint)))
 
 	// Admin routes
 	router.POST(APIRoot+"/repos/:name", amw(MakeAdminReposHandler(services)))

--- a/gateway/internal/gateway/frontend/keys.go
+++ b/gateway/internal/gateway/frontend/keys.go
@@ -1,0 +1,98 @@
+package frontend
+
+import (
+	"encoding/base64"
+	"net/http"
+	"os"
+
+	gw "github.com/cvmfs/gateway/internal/gateway"
+	be "github.com/cvmfs/gateway/internal/gateway/backend"
+	"github.com/julienschmidt/httprouter"
+)
+
+// MakeRepoKeysHandler creates an HTTP handler for serving repository public keys
+// This endpoint allows publishers to fetch the .pub and .crt files needed to
+// set up a publisher connected to the gateway, without manual file copying.
+//
+// The endpoint is opt-in: it must be enabled via the "enable_key_endpoint"
+// configuration option in user.json.
+func MakeRepoKeysHandler(services be.ActionController, enabled bool) httprouter.Handle {
+	return func(w http.ResponseWriter, h *http.Request, ps httprouter.Params) {
+		ctx := h.Context()
+		msg := make(map[string]interface{})
+
+		if !enabled {
+			msg["status"] = "error"
+			msg["reason"] = "key_endpoint_disabled"
+			gw.LogC(ctx, "http", gw.LogInfo).Msg("key endpoint is disabled")
+			replyJSON(ctx, w, msg)
+			return
+		}
+
+		repoName := ps.ByName("name")
+		if repoName == "" {
+			msg["status"] = "error"
+			msg["reason"] = "missing_repository_name"
+			replyJSON(ctx, w, msg)
+			return
+		}
+
+		// Check that the repository exists
+		rc, err := services.GetRepo(ctx, repoName)
+		if err != nil {
+			msg["status"] = "error"
+			msg["reason"] = err.Error()
+			replyJSON(ctx, w, msg)
+			return
+		}
+		if rc == nil {
+			msg["status"] = "error"
+			msg["reason"] = "invalid_repo"
+			replyJSON(ctx, w, msg)
+			return
+		}
+
+		keysDir := "/etc/cvmfs/keys"
+
+		keyData := make(map[string]string)
+
+		// Read the public key (.pub)
+		pubKeyPath := keysDir + "/" + repoName + ".pub"
+		if data, err := os.ReadFile(pubKeyPath); err == nil {
+			keyData["pub"] = base64.StdEncoding.EncodeToString(data)
+		} else {
+			gw.LogC(ctx, "http", gw.LogError).
+				Err(err).
+				Str("path", pubKeyPath).
+				Msg("could not read public key file")
+			msg["status"] = "error"
+			msg["reason"] = "public_key_not_found"
+			replyJSON(ctx, w, msg)
+			return
+		}
+
+		// Read the certificate (.crt)
+		crtPath := keysDir + "/" + repoName + ".crt"
+		if data, err := os.ReadFile(crtPath); err == nil {
+			keyData["crt"] = base64.StdEncoding.EncodeToString(data)
+		} else {
+			gw.LogC(ctx, "http", gw.LogError).
+				Err(err).
+				Str("path", crtPath).
+				Msg("could not read certificate file")
+			msg["status"] = "error"
+			msg["reason"] = "certificate_not_found"
+			replyJSON(ctx, w, msg)
+			return
+		}
+
+		msg["status"] = "ok"
+		msg["data"] = keyData
+
+		gw.LogC(ctx, "http", gw.LogInfo).
+			Str("repo", repoName).
+			Msg("served repository keys")
+
+		replyJSON(ctx, w, msg)
+	}
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -79,7 +79,7 @@ func main() {
 
 	go func() {
 		timeout := services.Config.MaxLeaseTime
-		if err := fe.Start(services, cfg.Port, timeout); err != nil {
+		if err := fe.Start(services, cfg.Port, timeout, fe.WithKeyEndpoint(cfg.EnableKeyEndpoint)); err != nil {
 			gw.Log("main", gw.LogError).
 				Err(err).
 				Msg("starting the HTTP front-end failed")

--- a/test/src/821-repository_gateway_bootstrap/main
+++ b/test/src/821-repository_gateway_bootstrap/main
@@ -1,0 +1,37 @@
+#!/bin/bash
+cvmfs_test_name="Repository gateway bootstrap without initial publisher mount"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="quick"
+
+
+cvmfs_run_test() {
+    local repo="test.repo.org"
+
+    set_up_repository_gateway -P || return 1
+    load_repo_config $repo || return 2
+
+    echo "*** check bootstrap leaves the repository unmounted"
+    cat /proc/mounts | grep -e " /cvmfs/${repo} " && return 3
+    cat /proc/mounts | grep -e " ${CVMFS_SPOOL_DIR}/rdonly " && return 4
+
+    echo "*** check mountpoint configuration was still created"
+    local fstab_entries=$(grep -c "# added by CernVM-FS for ${repo}" /etc/fstab || true)
+    [ $fstab_entries -eq 2 ] || return 5
+
+    echo "*** check no root hash was pinned during bootstrap"
+    grep -q '^CVMFS_ROOT_HASH=' ${CVMFS_SPOOL_DIR}/client.local && return 6
+
+    echo "*** check bootstrap artifacts are published"
+    curl -sIf ${CVMFS_STRATUM0}/.cvmfspublished >/dev/null || return 7
+    curl -sIf ${CVMFS_STRATUM0}/.cvmfswhitelist >/dev/null || return 8
+
+    echo "*** open a regular gateway transaction after bootstrap"
+    cvmfs_server transaction $repo || return 9
+    echo "bootstrap" > /cvmfs/${repo}/bootstrap.txt || return 10
+    cvmfs_server publish $repo || return 11
+    cvmfs_server check -i $repo || return 12
+
+    grep -qx "bootstrap" /cvmfs/${repo}/bootstrap.txt || return 13
+
+    return 0
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -2640,6 +2640,8 @@ find_or_build_cvmfs_preload() {
 
 # Sets up the CVMFS repository gateway application
 set_up_repository_gateway() {
+    local mkfs_args=("$@")
+
     echo "Setting up repository gateway"
 
     gateway_script=/usr/libexec/cvmfs-gateway/scripts/run_cvmfs_gateway.sh
@@ -2677,7 +2679,7 @@ set_up_repository_gateway() {
 EOF'
 
     echo "  Creating test repo"
-    create_repo test.repo.org `whoami`
+    create_repo test.repo.org `whoami` NO "${mkfs_args[@]}"
 
     echo "  Writing API key file"
     sudo bash -c 'cat <<EOF > /etc/cvmfs/keys/test.repo.org.gw


### PR DESCRIPTION
* The main change here is the addition of  `-P` to `mkfs`, which will skip the creation of the fuse mount. The main use case for this is running a gateway in a container, where fuse and overlayfs are major complications. I've only tested this with a local storage backend, not with s3 but it should work the same.
* I've added a few more changes to make the gateway/publisher setup easier. Now there is
```
cvmfs_server connect-gw  -u gateway.cern.ch test.cern.ch
```
which is equivalent to
```
cvmfs_server mkfs -w http://gateway.cern.ch/cvmfs/test.cern.ch \
                         -u gw,/srv/cvmfs/test.cern.ch/data/txn,http://gateway.cern.ch:4929/api/v1 \
                         -k /tmp/test.cern.ch_keys -o `whoami` test.cern.ch
```
( Fixes #4037 )

* In order to make mounting a test repo simpler, this PR adds a `-D` flag to `mkfs`. This exposes the public key of the repo and a helpful script to mount it via the http server. This is currently undocumented, since this is targeting dev / testing setups. Most repos  distribute the public key openly and allow anyone to mount the repo, so it's  not a drastic change, but of course is off by default.
* To make connect-gw simpler, this adds a `keys` endpoint to the gateway that allows to get the public key and crt similar to mkfs -D. The gateway secret is still needed on the publisher machine in order to use this endpoint.
* The `unhealthy` reported by `cvmfs_server list` when the local fuse mount is on an older revision than the latest one is quite misleading, since on a normal gateway setup it's not used for transactions, so it will always lag behind the latest revision in the backend storage. It will refresh on a transaction or remount anyway, so there is no cause for concern. So here I adapt the wording to simply say "gw" or "gw/mountless". 