### PR TITLE
Add a `revision_timestamp` magic xattr

### DIFF
--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -50,6 +50,7 @@ MagicXattrManager::MagicXattrManager(
   Register("user.repo_counters", new RepoCountersMagicXattr());
   Register("user.repo_metainfo", new RepoMetainfoMagicXattr());
   Register("user.revision", new RevisionMagicXattr());
+  Register("user.revision_timestamp", new RevisionTimestampMagicXattr());
   Register("user.root_hash", new RootHashMagicXattr());
   Register("user.rx", new RxMagicXattr());
   Register("user.speed", new SpeedMagicXattr());
@@ -716,6 +717,15 @@ bool RevisionMagicXattr::PrepareValueFenced() {
 
 void RevisionMagicXattr::FinalizeValue() {
   result_pages_.push_back(StringifyUint(revision_));
+}
+
+bool RevisionTimestampMagicXattr::PrepareValueFenced() {
+  timestamp_ = xattr_mgr_->mount_point()->catalog_mgr()->GetTimestamp();
+  return true;
+}
+
+void RevisionTimestampMagicXattr::FinalizeValue() {
+  result_pages_.push_back(StringifyUint(timestamp_));
 }
 
 bool RootHashMagicXattr::PrepareValueFenced() {

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -445,6 +445,13 @@ class RevisionMagicXattr : public BaseMagicXattr {
   virtual void FinalizeValue();
 };
 
+class RevisionTimestampMagicXattr : public BaseMagicXattr {
+  uint64_t timestamp_;
+
+  virtual bool PrepareValueFenced();
+  virtual void FinalizeValue();
+};
+
 class RootHashMagicXattr : public BaseMagicXattr {
   shash::Any root_hash_;
 

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -137,6 +137,19 @@ cvmfs_run_test() {
   [ "x$proxy_list" != "x" ] || return 21
   [ "x$proxy_list_external" != "x" ] || return 22
 
+  echo "*** Test 'revision' and 'revision_timestamp' magic extended attributes"
+  local revision=$(get_xattr revision /cvmfs/grid.cern.ch)
+  [ "x$revision" != "x" ] || return 23
+  # revision should be a positive integer
+  [ "$revision" -gt 0 ] 2>/dev/null || return 24
+
+  local revision_timestamp=$(get_xattr revision_timestamp /cvmfs/grid.cern.ch)
+  [ "x$revision_timestamp" != "x" ] || return 25
+  # timestamp should be a positive integer (Unix epoch seconds)
+  [ "$revision_timestamp" -gt 0 ] 2>/dev/null || return 26
+  # sanity check: timestamp should be after 2010-01-01 (1262304000)
+  [ "$revision_timestamp" -gt 1262304000 ] || return 27
+
   # check different access modes 
   echo "*** Check different access modes: human vs machine"
   runc_chunk_list_machine=$(get_xattr chunk_list~0 /cvmfs/grid.cern.ch/vc/containers/runc)


### PR DESCRIPTION
We already expose the revision number, but a lot of repositories still publish a `lastUpdated` file with a timestamp of the last publication, since the timestamp can be more informative thant the revision number. Having an xattr with the timestamp makes this unnecessary, or at least serves as a sanity check because there have been situations where `lastUpdated` went out of sync due to unrelated problems.