### PR TITLE
Partial replication of a repository 

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -84,6 +84,11 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS)
        network/sink_mem.cc
        network/sink_path.cc
        options.cc
+       path_filters/dirtab.cc
+       path_filters/inclusion_spec.cc
+       path_filters/relaxed_path_filter.cc
+       pathspec/pathspec.cc
+       pathspec/pathspec_pattern.cc
        quota.cc
        quota_posix.cc
        resolv_conf_event_handler.cc
@@ -639,6 +644,7 @@ if (BUILD_SERVER)
        pack.cc
        path_filters/dirtab.cc
        path_filters/relaxed_path_filter.cc
+       path_filters/inclusion_spec.cc
        pathspec/pathspec.cc
        pathspec/pathspec_pattern.cc
        reflog.cc
@@ -1235,6 +1241,7 @@ if (BUILD_PRELOADER)
                   pack.cc
                   path_filters/dirtab.cc
                   path_filters/relaxed_path_filter.cc
+                  path_filters/inclusion_spec.cc
                   pathspec/pathspec.cc
                   pathspec/pathspec_pattern.cc
                   preload.cc

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -839,7 +839,26 @@ static void cvmfs_getattr(fuse_req_t req, fuse_ino_t ino,
     return;
   }
 
-  struct stat const info = dirent.GetStatStructure();
+  struct stat info = dirent.GetStatStructure();
+
+  // Partial replica in fail mode: mark excluded entries as unreadable so
+  // users get a clear indication rather than a confusing EIO at read time.
+  if (mount_point_->partial_replica_fail_mode()
+      && mount_point_->partial_inclusion_spec() != NULL) {
+    // Find the path for this inode to check against the inclusion spec.
+    glue::InodeEx inode_ex(ino, glue::InodeEx::kUnknownType);
+    PathString inode_path;
+    if (mount_point_->inode_tracker()->FindPath(&inode_ex, &inode_path)) {
+      const string path_str(inode_path.GetChars(), inode_path.GetLength());
+      if (mount_point_->partial_inclusion_spec()->IsExcluded(path_str)) {
+        // Present the entry with no permissions and a special uid/gid
+        // (65534 = traditional "nobody"/"nogroup").
+        info.st_mode &= ~static_cast<mode_t>(S_IRWXU | S_IRWXG | S_IRWXO);
+        info.st_uid = 65534;
+        info.st_gid = 65534;
+      }
+    }
+  }
 
   fuse_reply_attr(req, &info, GetKcacheTimeout());
 }
@@ -2657,6 +2676,8 @@ static void Spawn() {
 
   cvmfs::mount_point_->download_mgr()->Spawn();
   cvmfs::mount_point_->external_download_mgr()->Spawn();
+  if (cvmfs::mount_point_->full_replica_download_mgr() != NULL)
+    cvmfs::mount_point_->full_replica_download_mgr()->Spawn();
   if (cvmfs::mount_point_->resolv_conf_watcher() != NULL) {
     cvmfs::mount_point_->resolv_conf_watcher()->Spawn();
   }

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -174,50 +174,29 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
   tls->download_job.SetRangeSize(static_cast<int64_t>(object.label.size));
   download_mgr_->Fetch(&tls->download_job);
 
-  // Partial replica failover: if the primary returned an HTTP error (e.g. 404
-  // from a partial Stratum-1), retry the download using the fallback (full)
-  // download manager if one is configured.
+  // Partial replica failover: a partial Stratum-1 serves a 404 for objects it
+  // did not replicate.  Retry once against the full replica and let the common
+  // success/error paths below handle the result.  Only 404 triggers failover:
+  // other HTTP errors (403, 5xx, ...) also map to kFailHostHttp but indicate a
+  // server problem rather than an unreplicated object, so they must not be
+  // masked by silently fetching from elsewhere.  The txn buffer is reused in
+  // place by StartTxn, so `sink` keeps pointing at the fresh transaction and
+  // needs no reconstruction.
   if (tls->download_job.error_code() == download::kFailHostHttp
-      && fallback_download_mgr_ != NULL) {
+      && tls->download_job.http_code() == 404
+      && full_replica_download_mgr_ != NULL) {
     LogCvmfs(kLogCache, kLogDebug | kLogSyslog,
              "partial replica: %s not available on primary, "
              "retrying from full replica",
              object.label.path.c_str());
-    // Abort the partial transaction and start a fresh one for the fallback.
     cache_mgr_->AbortTxn(txn);
     retval = cache_mgr_->StartTxn(object.id, object.label.size, txn);
-    if (retval >= 0) {
-      cache_mgr_->CtrlTxn(object.label, 0, txn);
-      TransactionSink fallback_sink(cache_mgr_, txn);
-      tls->download_job.SetSink(&fallback_sink);
-      fallback_download_mgr_->Fetch(&tls->download_job);
-      if (tls->download_job.error_code() == download::kFailOk) {
-        LogCvmfs(kLogCache, kLogDebug,
-                 "partial replica: fetched %s from full replica",
-                 object.label.path.c_str());
-        fd_return = cache_mgr_->OpenFromTxn(txn);
-        if (fd_return < 0) {
-          cache_mgr_->AbortTxn(txn);
-          SignalWaitingThreads(fd_return, object.id, tls);
-          return fd_return;
-        }
-        retval = cache_mgr_->CommitTxn(txn);
-        if (retval < 0) {
-          cache_mgr_->Close(fd_return);
-          SignalWaitingThreads(retval, object.id, tls);
-          return retval;
-        }
-        SignalWaitingThreads(fd_return, object.id, tls);
-        return fd_return;
-      }
-      // Fallback also failed; abort its transaction before the common error path.
-      cache_mgr_->AbortTxn(txn);
-    } else {
-      // Could not start a new transaction; propagate the error.
+    if (retval < 0) {
       SignalWaitingThreads(retval, object.id, tls);
       return retval;
     }
-    // Fall through to common error logging below.
+    cache_mgr_->CtrlTxn(object.label, 0, txn);
+    full_replica_download_mgr_->Fetch(&tls->download_job);
   }
 
   if (tls->download_job.error_code() == download::kFailOk) {
@@ -240,17 +219,13 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
     return fd_return;
   }
 
-  // Download failed (primary, and fallback if configured)
+  // Download failed (primary, and full replica if configured)
   LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
            "failed to fetch %s (hash: %s, error %d [%s])",
            object.label.path.c_str(), object.id.ToString().c_str(),
            tls->download_job.error_code(),
            download::Code2Ascii(tls->download_job.error_code()));
-  // Txn may already be aborted in the fallback path; only abort if not.
-  if (fallback_download_mgr_ == NULL
-      || tls->download_job.error_code() != download::kFailHostHttp) {
-    cache_mgr_->AbortTxn(txn);
-  }
+  cache_mgr_->AbortTxn(txn);
   backoff_throttle_->Throttle();
   SignalWaitingThreads(-EIO, object.id, tls);
   return -EIO;
@@ -265,7 +240,7 @@ Fetcher::Fetcher(CacheManager *cache_mgr,
     , lock_tls_blocks_(NULL)
     , cache_mgr_(cache_mgr)
     , download_mgr_(download_mgr)
-    , fallback_download_mgr_(NULL)
+    , full_replica_download_mgr_(NULL)
     , backoff_throttle_(backoff_throttle) {
   int retval;
   retval = pthread_key_create(&thread_local_storage_, TLSDestructor);

--- a/cvmfs/fetch.cc
+++ b/cvmfs/fetch.cc
@@ -174,6 +174,52 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
   tls->download_job.SetRangeSize(static_cast<int64_t>(object.label.size));
   download_mgr_->Fetch(&tls->download_job);
 
+  // Partial replica failover: if the primary returned an HTTP error (e.g. 404
+  // from a partial Stratum-1), retry the download using the fallback (full)
+  // download manager if one is configured.
+  if (tls->download_job.error_code() == download::kFailHostHttp
+      && fallback_download_mgr_ != NULL) {
+    LogCvmfs(kLogCache, kLogDebug | kLogSyslog,
+             "partial replica: %s not available on primary, "
+             "retrying from full replica",
+             object.label.path.c_str());
+    // Abort the partial transaction and start a fresh one for the fallback.
+    cache_mgr_->AbortTxn(txn);
+    retval = cache_mgr_->StartTxn(object.id, object.label.size, txn);
+    if (retval >= 0) {
+      cache_mgr_->CtrlTxn(object.label, 0, txn);
+      TransactionSink fallback_sink(cache_mgr_, txn);
+      tls->download_job.SetSink(&fallback_sink);
+      fallback_download_mgr_->Fetch(&tls->download_job);
+      if (tls->download_job.error_code() == download::kFailOk) {
+        LogCvmfs(kLogCache, kLogDebug,
+                 "partial replica: fetched %s from full replica",
+                 object.label.path.c_str());
+        fd_return = cache_mgr_->OpenFromTxn(txn);
+        if (fd_return < 0) {
+          cache_mgr_->AbortTxn(txn);
+          SignalWaitingThreads(fd_return, object.id, tls);
+          return fd_return;
+        }
+        retval = cache_mgr_->CommitTxn(txn);
+        if (retval < 0) {
+          cache_mgr_->Close(fd_return);
+          SignalWaitingThreads(retval, object.id, tls);
+          return retval;
+        }
+        SignalWaitingThreads(fd_return, object.id, tls);
+        return fd_return;
+      }
+      // Fallback also failed; abort its transaction before the common error path.
+      cache_mgr_->AbortTxn(txn);
+    } else {
+      // Could not start a new transaction; propagate the error.
+      SignalWaitingThreads(retval, object.id, tls);
+      return retval;
+    }
+    // Fall through to common error logging below.
+  }
+
   if (tls->download_job.error_code() == download::kFailOk) {
     LogCvmfs(kLogCache, kLogDebug, "finished downloading of %s", url.c_str());
 
@@ -194,13 +240,17 @@ int Fetcher::Fetch(const CacheManager::LabeledObject &object,
     return fd_return;
   }
 
-  // Download failed
+  // Download failed (primary, and fallback if configured)
   LogCvmfs(kLogCache, kLogDebug | kLogSyslogErr,
            "failed to fetch %s (hash: %s, error %d [%s])",
            object.label.path.c_str(), object.id.ToString().c_str(),
            tls->download_job.error_code(),
            download::Code2Ascii(tls->download_job.error_code()));
-  cache_mgr_->AbortTxn(txn);
+  // Txn may already be aborted in the fallback path; only abort if not.
+  if (fallback_download_mgr_ == NULL
+      || tls->download_job.error_code() != download::kFailHostHttp) {
+    cache_mgr_->AbortTxn(txn);
+  }
   backoff_throttle_->Throttle();
   SignalWaitingThreads(-EIO, object.id, tls);
   return -EIO;
@@ -215,6 +265,7 @@ Fetcher::Fetcher(CacheManager *cache_mgr,
     , lock_tls_blocks_(NULL)
     , cache_mgr_(cache_mgr)
     , download_mgr_(download_mgr)
+    , fallback_download_mgr_(NULL)
     , backoff_throttle_(backoff_throttle) {
   int retval;
   retval = pthread_key_create(&thread_local_storage_, TLSDestructor);

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -116,6 +116,18 @@ class Fetcher : SingleCopy {
   void ReplaceCacheManager(CacheManager *new_cache_mgr) {
     cache_mgr_ = new_cache_mgr;
   }
+
+  /**
+   * Set a fallback download manager used for partial replica failover.
+   * When the primary download fails with an HTTP error (404 from a partial
+   * Stratum-1), the download is retried using this manager whose host chain
+   * points to a full Stratum-1.  Ownership is NOT transferred.
+   */
+  void SetFallbackDownloadManager(
+      download::DownloadManager *fallback_mgr) {
+    fallback_download_mgr_ = fallback_mgr;
+  }
+
   CacheManager *cache_mgr() { return cache_mgr_; }
   download::DownloadManager *download_mgr() { return download_mgr_; }
 
@@ -184,6 +196,11 @@ class Fetcher : SingleCopy {
 
   CacheManager *cache_mgr_;
   download::DownloadManager *download_mgr_;
+  /**
+   * Optional fallback download manager for partial replica failover mode.
+   * Not owned by this Fetcher.
+   */
+  download::DownloadManager *fallback_download_mgr_;
   BackoffThrottle *backoff_throttle_;
   perf::Counter *n_downloads;
   perf::Counter *n_invocations;

--- a/cvmfs/fetch.h
+++ b/cvmfs/fetch.h
@@ -118,14 +118,14 @@ class Fetcher : SingleCopy {
   }
 
   /**
-   * Set a fallback download manager used for partial replica failover.
+   * Set the full-replica download manager used for partial replica failover.
    * When the primary download fails with an HTTP error (404 from a partial
    * Stratum-1), the download is retried using this manager whose host chain
    * points to a full Stratum-1.  Ownership is NOT transferred.
    */
-  void SetFallbackDownloadManager(
-      download::DownloadManager *fallback_mgr) {
-    fallback_download_mgr_ = fallback_mgr;
+  void SetFullReplicaDownloadManager(
+      download::DownloadManager *full_replica_mgr) {
+    full_replica_download_mgr_ = full_replica_mgr;
   }
 
   CacheManager *cache_mgr() { return cache_mgr_; }
@@ -197,10 +197,10 @@ class Fetcher : SingleCopy {
   CacheManager *cache_mgr_;
   download::DownloadManager *download_mgr_;
   /**
-   * Optional fallback download manager for partial replica failover mode.
+   * Optional full-replica download manager for partial replica failover mode.
    * Not owned by this Fetcher.
    */
-  download::DownloadManager *fallback_download_mgr_;
+  download::DownloadManager *full_replica_download_mgr_;
   BackoffThrottle *backoff_throttle_;
   perf::Counter *n_downloads;
   perf::Counter *n_invocations;

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -52,6 +52,7 @@
 #include "manifest.h"
 #include "manifest_fetch.h"
 #include "network/download.h"
+#include "network/sink_mem.h"
 #include "nfs_maps.h"
 #ifdef CVMFS_NFS_SUPPORT
 #include "nfs_maps_leveldb.h"
@@ -1265,6 +1266,7 @@ MountPoint *MountPoint::Create(const string &fqrn,
     return mountpoint.Release();
   }
   mountpoint->CreateFetchers();
+  mountpoint->SetupPartialReplica();
   if (!mountpoint->CreateCatalogManager())
     return mountpoint.Release();
   if (!mountpoint->CreateTracer())
@@ -1536,6 +1538,116 @@ void MountPoint::CreateFetchers() {
       external_download_mgr_,
       backoff_throttle_,
       perf::StatisticsTemplate("fetch-external", statistics_));
+}
+
+
+/**
+ * Sets up partial replica handling for the primary Stratum-1.  This is opt-in:
+ * unless CVMFS_PARTIAL_REPLICA_MODE is set, the function returns immediately so
+ * that regular (full-replica) mounts incur no extra requests.  When opted in:
+ *  - Probes for the .cvmfs_partial_replication file on the primary server.
+ *  - Parses the inclusion spec and stores it in partial_inclusion_spec_.
+ *  - Honours CVMFS_PARTIAL_REPLICA_MODE ("failover" [default] or "fail").
+ *  - In failover mode, creates a full_replica_download_mgr_ from
+ *    CVMFS_FULL_STRATUM1_URL and wires it as the fetcher's fallback.
+ */
+void MountPoint::SetupPartialReplica() {
+  // Partial replica handling is opt-in on the client: only probe for and act
+  // on a partial Stratum-1 when CVMFS_PARTIAL_REPLICA_MODE is explicitly set.
+  // Auto-detection would buy nothing (failover still needs
+  // CVMFS_FULL_STRATUM1_URL, fail mode is a client choice) while taxing every
+  // regular mount with an extra request.
+  string mode;
+  if (!options_mgr_->GetValue("CVMFS_PARTIAL_REPLICA_MODE", &mode)) {
+    return;
+  }
+
+  // Get primary server URL from the host chain
+  vector<string> host_chain;
+  download_mgr_->GetHostInfo(&host_chain, NULL, NULL);
+  if (host_chain.empty()) {
+    return;
+  }
+  const string primary_url = host_chain[0];
+
+  // Probe for the partial replication spec file
+  const string spec_url = primary_url + "/.cvmfs_partial_replication";
+  cvmfs::MemSink spec_memsink;
+  download::JobInfo probe_job(&spec_url, false, false, NULL, &spec_memsink);
+  const download::Failures probe_result = download_mgr_->Fetch(&probe_job);
+
+  if (probe_result != download::kFailOk) {
+    // Not a partial replica (or not reachable — ignore silently)
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "no .cvmfs_partial_replication found at %s (result %d)",
+             primary_url.c_str(), probe_result);
+    return;
+  }
+
+  // Parse the spec
+  const string spec_content(
+      reinterpret_cast<char *>(spec_memsink.data()), spec_memsink.pos());
+  partial_inclusion_spec_ = new catalog::InclusionSpec();
+  if (!partial_inclusion_spec_->Parse(spec_content)) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "failed to parse .cvmfs_partial_replication from %s",
+             primary_url.c_str());
+    delete partial_inclusion_spec_;
+    partial_inclusion_spec_ = NULL;
+    return;
+  }
+
+  LogCvmfs(kLogCvmfs, kLogSyslog | kLogDebug,
+           "connected to partial Stratum-1 at %s (spec version %d)",
+           primary_url.c_str(), partial_inclusion_spec_->version());
+
+  // Determine the mode
+  string optarg;
+  if (mode == "fail") {
+    partial_replica_fail_mode_ = true;
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "partial replica mode: fail (EIO for missing objects)");
+    return;  // No fallback manager needed in fail mode
+  }
+  // Default: failover mode
+  partial_replica_fail_mode_ = false;
+
+  // Create the full replica download manager for failover
+  if (!options_mgr_->GetValue("CVMFS_FULL_STRATUM1_URL", &optarg)
+      || optarg.empty()) {
+    LogCvmfs(kLogCvmfs, kLogSyslogWarn | kLogDebug,
+             "partial replica mode is failover but CVMFS_FULL_STRATUM1_URL "
+             "is not set; failover disabled");
+    return;
+  }
+
+  LogCvmfs(kLogCvmfs, kLogDebug,
+           "partial replica mode: failover to %s", optarg.c_str());
+
+  full_replica_download_mgr_ = new download::DownloadManager(
+      1,  // single connection for fallback
+      perf::StatisticsTemplate("download-full-replica", statistics_));
+  full_replica_download_mgr_->SetHostChain(optarg);
+
+  // Re-apply proxy and timeout settings from the primary download manager
+  // by reading the original options (simplest approach)
+  string proxies;
+  if (options_mgr_->GetValue("CVMFS_HTTP_PROXY", &optarg))
+    proxies = optarg;
+  string fallback_proxies;
+  if (options_mgr_->GetValue("CVMFS_FALLBACK_PROXY", &optarg))
+    fallback_proxies = optarg;
+  full_replica_download_mgr_->SetProxyChain(
+      proxies, fallback_proxies,
+      download::DownloadManager::kSetProxyBoth);
+
+  unsigned timeout = 10;
+  if (options_mgr_->GetValue("CVMFS_HTTP_TIMEOUT", &optarg))
+    timeout = String2Uint64(optarg);
+  full_replica_download_mgr_->SetTimeout(timeout, timeout);
+
+  // Wire fallback into the primary fetcher
+  fetcher_->SetFallbackDownloadManager(full_replica_download_mgr_);
 }
 
 
@@ -1830,8 +1942,11 @@ MountPoint::MountPoint(const string &fqrn,
     , signature_mgr_(NULL)
     , download_mgr_(NULL)
     , external_download_mgr_(NULL)
+    , full_replica_download_mgr_(NULL)
     , fetcher_(NULL)
     , external_fetcher_(NULL)
+    , partial_inclusion_spec_(NULL)
+    , partial_replica_fail_mode_(false)
     , inode_annotation_(NULL)
     , catalog_mgr_(NULL)
     , chunk_tables_(NULL)
@@ -1879,7 +1994,9 @@ MountPoint::~MountPoint() {
   delete fetcher_;
 
   delete external_download_mgr_;
+  delete full_replica_download_mgr_;
   delete download_mgr_;
+  delete partial_inclusion_spec_;
 
   if (signature_mgr_ != NULL) {
     signature_mgr_->Fini();

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1624,30 +1624,18 @@ void MountPoint::SetupPartialReplica() {
   LogCvmfs(kLogCvmfs, kLogDebug,
            "partial replica mode: failover to %s", optarg.c_str());
 
-  full_replica_download_mgr_ = new download::DownloadManager(
-      1,  // single connection for fallback
-      perf::StatisticsTemplate("download-full-replica", statistics_));
+  // Clone the primary download manager so proxy, DNS, timeout, certificate and
+  // sharding settings carry over unchanged; only the host chain is repointed at
+  // the full Stratum-1.  This avoids the configuration drift of re-reading a
+  // hand-picked subset of options.
+  full_replica_download_mgr_ = download_mgr_->Clone(
+      perf::StatisticsTemplate("download-full-replica", statistics_),
+      "download-full-replica");
   full_replica_download_mgr_->SetHostChain(optarg);
+  full_replica_download_mgr_->Spawn();
 
-  // Re-apply proxy and timeout settings from the primary download manager
-  // by reading the original options (simplest approach)
-  string proxies;
-  if (options_mgr_->GetValue("CVMFS_HTTP_PROXY", &optarg))
-    proxies = optarg;
-  string fallback_proxies;
-  if (options_mgr_->GetValue("CVMFS_FALLBACK_PROXY", &optarg))
-    fallback_proxies = optarg;
-  full_replica_download_mgr_->SetProxyChain(
-      proxies, fallback_proxies,
-      download::DownloadManager::kSetProxyBoth);
-
-  unsigned timeout = 10;
-  if (options_mgr_->GetValue("CVMFS_HTTP_TIMEOUT", &optarg))
-    timeout = String2Uint64(optarg);
-  full_replica_download_mgr_->SetTimeout(timeout, timeout);
-
-  // Wire fallback into the primary fetcher
-  fetcher_->SetFallbackDownloadManager(full_replica_download_mgr_);
+  // Wire the full replica into the primary fetcher
+  fetcher_->SetFullReplicaDownloadManager(full_replica_download_mgr_);
 }
 
 

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1562,6 +1562,25 @@ void MountPoint::SetupPartialReplica() {
     return;
   }
 
+  // Validate the mode before doing any network I/O, so that an off/false/empty
+  // (or otherwise invalid) value never adds a request to a normal mount.  Only
+  // "fail" and "failover" enable partial replica handling.
+  const string mode_norm = ToUpper(Trim(mode));
+  bool fail_mode;
+  if (mode_norm == "FAIL") {
+    fail_mode = true;
+  } else if (mode_norm == "FAILOVER") {
+    fail_mode = false;
+  } else {
+    // Disabled (empty/off/false) is silent; anything else is a config error.
+    if (!mode_norm.empty() && !options_mgr_->IsOff(mode_norm)) {
+      LogCvmfs(kLogCvmfs, kLogSyslogWarn | kLogDebug,
+               "ignoring invalid CVMFS_PARTIAL_REPLICA_MODE='%s' "
+               "(expected 'fail' or 'failover')", mode.c_str());
+    }
+    return;
+  }
+
   // Get primary server URL from the host chain
   vector<string> host_chain;
   download_mgr_->GetHostInfo(&host_chain, NULL, NULL);
@@ -1601,16 +1620,14 @@ void MountPoint::SetupPartialReplica() {
            "connected to partial Stratum-1 at %s (spec version %d)",
            primary_url.c_str(), partial_inclusion_spec_->version());
 
-  // Determine the mode
+  // Apply the mode validated above
   string optarg;
-  if (mode == "fail") {
-    partial_replica_fail_mode_ = true;
+  partial_replica_fail_mode_ = fail_mode;
+  if (fail_mode) {
     LogCvmfs(kLogCvmfs, kLogDebug,
              "partial replica mode: fail (EIO for missing objects)");
-    return;  // No fallback manager needed in fail mode
+    return;  // No full replica manager needed in fail mode
   }
-  // Default: failover mode
-  partial_replica_fail_mode_ = false;
 
   // Create the full replica download manager for failover
   if (!options_mgr_->GetValue("CVMFS_FULL_STRATUM1_URL", &optarg)
@@ -1632,7 +1649,9 @@ void MountPoint::SetupPartialReplica() {
       perf::StatisticsTemplate("download-full-replica", statistics_),
       "download-full-replica");
   full_replica_download_mgr_->SetHostChain(optarg);
-  full_replica_download_mgr_->Spawn();
+  // Not spawned here: like download_mgr_ and external_download_mgr_, the worker
+  // thread is started later by the application's Init (cvmfs.cc, after the FUSE
+  // fork; threads do not survive fork()).  libcvmfs leaves it synchronous.
 
   // Wire the full replica into the primary fetcher
   fetcher_->SetFullReplicaDownloadManager(full_replica_download_mgr_);

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -18,6 +18,7 @@
 
 #include "cache.h"
 #include "crypto/hash.h"
+#include "path_filters/inclusion_spec.h"
 #include "duplex_testing.h"
 #include "file_watcher.h"
 #include "loader.h"
@@ -520,6 +521,9 @@ class MountPoint : SingleCopy, public BootFactory {
   download::DownloadManager *external_download_mgr() {
     return external_download_mgr_;
   }
+  download::DownloadManager *full_replica_download_mgr() {
+    return full_replica_download_mgr_;
+  }
   file_watcher::FileWatcher *resolv_conf_watcher() {
     return resolv_conf_watcher_;
   }
@@ -555,6 +559,20 @@ class MountPoint : SingleCopy, public BootFactory {
   Tracer *tracer() { return tracer_; }
   cvmfs::Uuid *uuid() { return uuid_; }
   StatfsCache *statfs_cache() { return statfs_cache_; }
+
+  /**
+   * Returns the partial replication inclusion spec if this mount point is
+   * connected to a partial Stratum-1, or NULL otherwise.  Not owned by caller.
+   */
+  catalog::InclusionSpec *partial_inclusion_spec() const {
+    return partial_inclusion_spec_;
+  }
+
+  /**
+   * Returns true if the partial replica mode is "fail" (return EIO for missing
+   * objects instead of failing over to a full replica).
+   */
+  bool partial_replica_fail_mode() const { return partial_replica_fail_mode_; }
 
   bool ReloadBlacklists();
   void DisableCacheSymlinks();
@@ -621,6 +639,7 @@ class MountPoint : SingleCopy, public BootFactory {
   bool CreateDownloadManagers();
   bool CreateResolvConfWatcher();
   void CreateFetchers();
+  void SetupPartialReplica();
   bool CreateCatalogManager();
   void CreateTables();
   bool CreateTracer();
@@ -655,8 +674,19 @@ class MountPoint : SingleCopy, public BootFactory {
   signature::SignatureManager *signature_mgr_;
   download::DownloadManager *download_mgr_;
   download::DownloadManager *external_download_mgr_;
+  /**
+   * Optional download manager targeting a full Stratum-1, used as a fallback
+   * when this mount point's primary server is a partial replica.  Owned.
+   */
+  download::DownloadManager *full_replica_download_mgr_;
   cvmfs::Fetcher *fetcher_;
   cvmfs::Fetcher *external_fetcher_;
+  /**
+   * Parsed inclusion spec downloaded from the partial Stratum-1, or NULL.
+   */
+  catalog::InclusionSpec *partial_inclusion_spec_;
+  /** True when partial replica mode is "fail" (vs. "failover"). */
+  bool partial_replica_fail_mode_;
   catalog::InodeAnnotation *inode_annotation_;
   catalog::ClientCatalogManager *catalog_mgr_;
   ChunkTables *chunk_tables_;

--- a/cvmfs/path_filters/inclusion_spec.cc
+++ b/cvmfs/path_filters/inclusion_spec.cc
@@ -1,0 +1,161 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "path_filters/inclusion_spec.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#include "util/logging.h"
+#include "util/posix.h"
+#include "util/string.h"
+
+using namespace catalog;  // NOLINT
+
+
+InclusionSpec::InclusionSpec() : valid_(false), version_(-1) {}
+
+InclusionSpec::~InclusionSpec() {}
+
+
+InclusionSpec *InclusionSpec::Create(const std::string &spec_path) {
+  InclusionSpec *spec = new InclusionSpec();
+
+  FILE *f = fopen(spec_path.c_str(), "r");
+  if (f == NULL) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "InclusionSpec: cannot open spec file '%s'",
+             spec_path.c_str());
+    delete spec;
+    return NULL;
+  }
+
+  std::string content;
+  char buf[4096];
+  size_t nbytes;
+  while ((nbytes = fread(buf, 1, sizeof(buf), f)) > 0) {
+    content.append(buf, nbytes);
+  }
+  fclose(f);
+
+  if (!spec->Parse(content)) {
+    delete spec;
+    return NULL;
+  }
+  return spec;
+}
+
+
+bool InclusionSpec::Parse(const std::string &spec) {
+  valid_ = false;
+  content_ = spec;
+
+  // Split into lines and find the version line
+  std::vector<std::string> lines = SplitString(spec, '\n');
+
+  // Find the first non-comment, non-blank line — must be "version N"
+  bool found_version = false;
+  for (size_t i = 0; i < lines.size(); ++i) {
+    std::string line = Trim(lines[i]);
+    if (line.empty() || line[0] == '#') {
+      continue;
+    }
+    if (!ParseVersion(line)) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "InclusionSpec: first non-comment line must be 'version N', "
+               "got '%s'",
+               line.c_str());
+      return false;
+    }
+    found_version = true;
+    break;
+  }
+
+  if (!found_version) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "InclusionSpec: spec file is empty or contains only comments");
+    return false;
+  }
+
+  if (version_ != kCurrentVersion) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "InclusionSpec: unsupported version %d (expected %d)",
+             version_, kCurrentVersion);
+    return false;
+  }
+
+  // Parse the remaining lines as path rules using RelaxedPathFilter
+  const std::string filter_content = StripVersionLine(spec);
+  if (!filter_.Parse(filter_content)) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "InclusionSpec: failed to parse path rules");
+    return false;
+  }
+
+  valid_ = true;
+  return true;
+}
+
+
+bool InclusionSpec::IsExcluded(const std::string &path) const {
+  if (!valid_)
+    return false;
+
+  // Root catalog is never excluded
+  if (path.empty() || path == "/")
+    return false;
+
+  // The spec is an inclusion list: positive rules mean "include" (replicate)
+  // and ! rules mean "exclude". RelaxedPathFilter::IsMatching returns true if a
+  // path matches a positive rule (including the parents and sub paths of listed
+  // paths) and is not opposed by a negative ! rule.
+  // So IsMatching == true means "this path is in the inclusion set", which we
+  // replicate; everything else is excluded from object replication.
+  return !filter_.IsMatching(path);
+}
+
+
+bool InclusionSpec::ParseVersion(const std::string &line) {
+  // Expected format: "version N"
+  const std::string trimmed = Trim(line);
+  if (trimmed.substr(0, 8) != "version ") {
+    return false;
+  }
+  std::string version_str = Trim(trimmed.substr(8));
+  if (version_str.empty()) {
+    return false;
+  }
+  // Check all digits
+  for (size_t i = 0; i < version_str.size(); ++i) {
+    if (version_str[i] < '0' || version_str[i] > '9') {
+      return false;
+    }
+  }
+  version_ = static_cast<int>(String2Uint64(version_str));
+  return true;
+}
+
+
+std::string InclusionSpec::StripVersionLine(const std::string &spec) const {
+  // Remove everything up to and including the version line
+  std::vector<std::string> lines = SplitString(spec, '\n');
+  std::string result;
+  bool past_version = false;
+
+  for (size_t i = 0; i < lines.size(); ++i) {
+    if (!past_version) {
+      std::string trimmed = Trim(lines[i]);
+      if (!trimmed.empty() && trimmed[0] != '#'
+          && trimmed.substr(0, 7) == "version") {
+        past_version = true;
+        continue;
+      }
+    }
+    if (past_version) {
+      result += lines[i] + "\n";
+    }
+  }
+  return result;
+}

--- a/cvmfs/path_filters/inclusion_spec.h
+++ b/cvmfs/path_filters/inclusion_spec.h
@@ -1,0 +1,92 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_PATH_FILTERS_INCLUSION_SPEC_H_
+#define CVMFS_PATH_FILTERS_INCLUSION_SPEC_H_
+
+#include <string>
+
+#include "path_filters/relaxed_path_filter.h"
+
+namespace catalog {
+
+/**
+ * InclusionSpec implements a versioned inclusion specification for partial
+ * replication of CVMFS Stratum-1 servers.
+ *
+ * The spec file format:
+ *   version 1
+ *   # comment
+ *   /path/to/include
+ *   !/path/to/exclude
+ *
+ * Paths listed (without !) are INCLUDED in object replication. Paths prefixed
+ * with ! are excluded (negating a parent inclusion). Anything not covered by
+ * an inclusion rule is excluded. All catalogs are always replicated; only data
+ * object downloads are skipped for excluded paths.
+ *
+ * Internally, this wraps a RelaxedPathFilter: positive rules in the spec mean
+ * "include" (replicate objects, also covering parent and sub paths), while !
+ * rules mean "exclude" (skip objects). IsExcluded() returns the negation of the
+ * filter match.
+ *
+ * Only paths that correspond to nested catalog transition points are
+ * meaningful. Paths that don't align with catalog boundaries will trigger
+ * warnings during snapshot and be rounded up to the enclosing catalog.
+ */
+class InclusionSpec {
+ public:
+  static const int kCurrentVersion = 1;
+
+  InclusionSpec();
+  ~InclusionSpec();
+
+  /**
+   * Creates an InclusionSpec from a file on disk.
+   * Returns NULL on failure (file not found, parse error).
+   * Caller takes ownership.
+   */
+  static InclusionSpec *Create(const std::string &spec_path);
+
+  /**
+   * Parse a spec string. Returns true on success.
+   */
+  bool Parse(const std::string &spec);
+
+  /**
+   * Returns true if the given path should have its data objects
+   * EXCLUDED from replication (i.e., objects should NOT be downloaded).
+   *
+   * The root path "" or "/" is never excluded.
+   */
+  bool IsExcluded(const std::string &path) const;
+
+  /**
+   * Returns true if parsing succeeded and version is supported.
+   */
+  bool IsValid() const { return valid_; }
+
+  /**
+   * Returns the parsed version number, or -1 if not parsed.
+   */
+  int version() const { return version_; }
+
+  /**
+   * Returns the original spec content for upload to backend storage.
+   */
+  const std::string &content() const { return content_; }
+
+ private:
+  bool ParseVersion(const std::string &line);
+  std::string StripVersionLine(const std::string &spec) const;
+
+  bool valid_;
+  int version_;
+  std::string content_;
+  RelaxedPathFilter filter_;
+};
+
+}  // namespace catalog
+
+#endif  // CVMFS_PATH_FILTERS_INCLUSION_SPEC_H_

--- a/cvmfs/server/cvmfs_server_check.sh
+++ b/cvmfs/server/cvmfs_server_check.sh
@@ -99,6 +99,13 @@ __do_check() {
     scratch_dir=$default_scratch_dir
   fi
 
+  local partial_replication_param=""
+  if [ x"$CVMFS_PARTIAL_REPLICATION" = x"true" ] && \
+     [ -n "$CVMFS_PARTIAL_REPLICATION_SPEC" ] && \
+     [ -f "$CVMFS_PARTIAL_REPLICATION_SPEC" ]; then
+    partial_replication_param="-E $CVMFS_PARTIAL_REPLICATION_SPEC"
+  fi
+
   local user_shell="$(get_user_shell $name)"
   local check_cmd
   check_cmd="$(__swissknife_cmd dbg) check $tag        \
@@ -111,7 +118,8 @@ __do_check() {
                      -N ${CVMFS_REPOSITORY_NAME}       \
                      $(get_swissknife_proxy)           \
                      $(get_follow_http_redirects_flag) \
-                     $with_reflog"
+                     $with_reflog                      \
+                     $partial_replication_param"
 
   # Set CVMFS_SERVER_CHECK_SUMMARY=0 to restore the previous behavior.
   if [ "${CVMFS_SERVER_CHECK_SUMMARY:-1}" = "0" ]; then

--- a/cvmfs/server/cvmfs_server_gc.sh
+++ b/cvmfs/server/cvmfs_server_gc.sh
@@ -452,6 +452,13 @@ __run_gc() {
     fi
   fi
 
+  local partial_replication_param=""
+  if [ x"$CVMFS_PARTIAL_REPLICATION" = x"true" ] && \
+     [ -n "$CVMFS_PARTIAL_REPLICATION_SPEC" ] && \
+     [ -f "$CVMFS_PARTIAL_REPLICATION_SPEC" ]; then
+    partial_replication_param="-E $CVMFS_PARTIAL_REPLICATION_SPEC"
+  fi
+
   [ $dry_run -ne 0 ] || to_syslog_for_repo $name "started garbage collection"
   local gc_command="$(__swissknife_cmd dbg) gc                              \
                                             -r $repository_url              \
@@ -461,6 +468,7 @@ __run_gc() {
                                             -k $CVMFS_PUBLIC_KEY            \
                                             -t ${CVMFS_SPOOL_DIR}/tmp/      \
                                             -R $(get_reflog_checksum $name) \
+                                            $partial_replication_param       \
                                             $additional_switches"
 
   if ! $user_shell "$gc_command"; then

--- a/cvmfs/server/cvmfs_server_snapshot.sh
+++ b/cvmfs/server/cvmfs_server_snapshot.sh
@@ -139,6 +139,17 @@ __do_snapshot() {
       with_reflog="-R $(get_reflog_checksum $alias_name)"
     is_stratum0_garbage_collectable $alias_name &&
       timestamp_threshold="-Z $gc_timespan"
+    local partial_replication_flag=""
+    if [ x"$CVMFS_PARTIAL_REPLICATION" = x"true" ]; then
+      if [ -z "$CVMFS_PARTIAL_REPLICATION_SPEC" ]; then
+        die "CVMFS_PARTIAL_REPLICATION is true but CVMFS_PARTIAL_REPLICATION_SPEC is not set"
+      fi
+      if [ ! -f "$CVMFS_PARTIAL_REPLICATION_SPEC" ]; then
+        die "Partial replication spec file not found: $CVMFS_PARTIAL_REPLICATION_SPEC"
+      fi
+      echo "Partial replication enabled (spec: $CVMFS_PARTIAL_REPLICATION_SPEC)"
+      partial_replication_flag="-E $CVMFS_PARTIAL_REPLICATION_SPEC"
+    fi
     $user_shell "$(__swissknife_cmd dbg) pull -m $name \
         -u $stratum0                                   \
         -w $stratum1                                   \
@@ -148,7 +159,8 @@ __do_snapshot() {
         -n $num_workers                                \
         -t $timeout                                    \
         -a $retries $with_history $with_reflog         \
-           $initial_snapshot_flag $timestamp_threshold $log_level"
+           $initial_snapshot_flag $timestamp_threshold  \
+           $partial_replication_flag $log_level"
 
     update_repo_status $alias_name last_snapshot "`date --utc`"
 

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -44,7 +44,8 @@ static inline uint32_t hasher_any(const shash::Any &key) {
 namespace swissknife {
 
 CommandCheck::CommandCheck()
-    : check_chunks_(false), no_duplicates_map_(false), is_remote_(false) {
+    : check_chunks_(false), no_duplicates_map_(false), is_remote_(false),
+      inclusion_spec_(NULL) {
   const shash::Any hash_null;
   duplicates_map_.Init(16, hash_null, hasher_any);
 }
@@ -790,7 +791,8 @@ bool CommandCheck::InspectTree(const string &path,
                                const uint64_t catalog_size,
                                const bool is_nested_catalog,
                                const catalog::DirectoryEntry *transition_point,
-                               catalog::DeltaCounters *computed_counters) {
+                               catalog::DeltaCounters *computed_counters,
+                               bool *pruned_subtree) {
   LogCvmfs(kLogCvmfs, kLogStdout | kLogInform, "[inspecting catalog] %s at %s",
            catalog_hash.ToString().c_str(), path == "" ? "/" : path.c_str());
 
@@ -843,6 +845,13 @@ bool CommandCheck::InspectTree(const string &path,
       retval = false;
     }
   }
+
+  // Partial replication: excluded subtrees are not replicated at all (their
+  // catalogs are pruned during snapshot), so InspectTree is only ever reached
+  // for catalogs that are present.  Pruning of the recursion happens in the
+  // nested-catalog loop below; here we just track whether anything was pruned
+  // so the aggregate counter comparison can be relaxed accordingly.
+  bool local_pruned = false;
 
   // Traverse the catalog
   set<PathString> bind_mountpoints;
@@ -911,6 +920,19 @@ bool CommandCheck::InspectTree(const string &path,
                i->mountpoint.c_str());
       continue;
     }
+    // Partial replication: a subtree that contains no included path is pruned
+    // on the Stratum-1 (catalog + objects absent), so we must not descend into
+    // it.  Skipping recursion here also means the aggregate counters for this
+    // catalog will be lower than the stored ones; record that so the counter
+    // comparison can be relaxed below.
+    if (inclusion_spec_ != NULL
+        && inclusion_spec_->IsExcluded(i->mountpoint.ToString())) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+               "  Skipping pruned (excluded) subtree at %s",
+               i->mountpoint.c_str());
+      local_pruned = true;
+      continue;
+    }
     catalog::DirectoryEntry nested_transition_point;
     if (!catalog->LookupPath(i->mountpoint, &nested_transition_point)) {
       LogCvmfs(kLogCvmfs, kLogStderr, "failed to lookup transition point %s",
@@ -919,23 +941,40 @@ bool CommandCheck::InspectTree(const string &path,
     } else {
       catalog::DeltaCounters nested_counters;
       const bool is_nested = true;
+      bool nested_pruned = false;
       if (!InspectTree(i->mountpoint.ToString(), i->hash, i->size, is_nested,
-                       &nested_transition_point, &nested_counters))
+                       &nested_transition_point, &nested_counters,
+                       &nested_pruned))
         retval = false;
+      if (nested_pruned)
+        local_pruned = true;
       nested_counters.PopulateToParent(computed_counters);
     }
   }
 
+  if (pruned_subtree != NULL && local_pruned)
+    *pruned_subtree = true;
+
   // Check statistics counters
   // Additionally account for root directory
   computed_counters->self.directories++;
-  catalog::Counters compare_counters;
-  compare_counters.ApplyDelta(*computed_counters);
-  const catalog::Counters stored_counters = catalog->GetCounters();
-  if (!CompareCounters(compare_counters, stored_counters)) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "statistics counter mismatch [%s]",
-             catalog_hash.ToString().c_str());
-    retval = false;
+  // Partial replication: when descendant subtrees have been pruned, the
+  // aggregate (subtree) counters stored in this catalog necessarily exceed
+  // what we could recompute, so the comparison would always fail.  Skip it for
+  // affected catalogs; self counters and structure are still fully verified.
+  if (local_pruned) {
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "  Skipping aggregate counter check at %s (pruned subtree)",
+             path == "" ? "/" : path.c_str());
+  } else {
+    catalog::Counters compare_counters;
+    compare_counters.ApplyDelta(*computed_counters);
+    const catalog::Counters stored_counters = catalog->GetCounters();
+    if (!CompareCounters(compare_counters, stored_counters)) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "statistics counter mismatch [%s]",
+               catalog_hash.ToString().c_str());
+      retval = false;
+    }
   }
 
   delete catalog;
@@ -973,6 +1012,19 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
     pubkey_path = JoinStrings(FindFilesBySuffix(pubkey_path, ".pub"), ":");
   if (args.find('N') != args.end())
     repo_name = *args.find('N')->second;
+
+  if (args.find('E') != args.end()) {
+    inclusion_spec_ =
+        catalog::InclusionSpec::Create(*args.find('E')->second);
+    if (inclusion_spec_ == NULL || !inclusion_spec_->IsValid()) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Failed to parse inclusion spec from '%s'",
+               args.find('E')->second->c_str());
+      return 1;
+    }
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "Partial replication: will skip pruned (excluded) subtrees");
+  }
 
   repo_base_path_ = MakeCanonicalPath(*args.find('r')->second);
   if (args.find('s') != args.end())
@@ -1154,6 +1206,8 @@ int CommandCheck::Main(const swissknife::ArgumentList &args) {
   }
 
   LogCvmfs(kLogCvmfs, kLogStdout, "no problems found");
+  delete inclusion_spec_;
+  inclusion_spec_ = NULL;
   return 0;
 }
 

--- a/cvmfs/swissknife_check.h
+++ b/cvmfs/swissknife_check.h
@@ -10,6 +10,7 @@
 
 #include "catalog.h"
 #include "crypto/hash.h"
+#include "path_filters/inclusion_spec.h"
 #include "smallhash.h"
 #include "swissknife.h"
 
@@ -53,6 +54,8 @@ class CommandCheck : public Command {
                                        " lookups. Note that this is a fallback"
                                        " option that may be removed."));
     r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
+    r.push_back(Parameter::Optional('E',
+        "inclusion spec for partial replication"));
     return r;
   }
   int Main(const ArgumentList &args);
@@ -63,7 +66,8 @@ class CommandCheck : public Command {
                    const uint64_t catalog_size,
                    const bool is_nested_catalog,
                    const catalog::DirectoryEntry *transition_point,
-                   catalog::DeltaCounters *computed_counters);
+                   catalog::DeltaCounters *computed_counters,
+                   bool *pruned_subtree = NULL);
   catalog::Catalog *FetchCatalog(const std::string &path,
                                  const shash::Any &catalog_hash,
                                  const uint64_t catalog_size = 0);
@@ -94,6 +98,7 @@ class CommandCheck : public Command {
   bool check_chunks_;
   bool no_duplicates_map_;
   bool is_remote_;
+  catalog::InclusionSpec *inclusion_spec_;
   SmallHashDynamic<shash::Any, char> duplicates_map_;
 };
 

--- a/cvmfs/swissknife_gc.cc
+++ b/cvmfs/swissknife_gc.cc
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "garbage_collection/garbage_collector.h"
+#include "path_filters/inclusion_spec.h"
 #include "garbage_collection/gc_aux.h"
 #include "garbage_collection/hash_filter.h"
 #include "manifest.h"
@@ -46,6 +47,8 @@ ParameterList CommandGc::GetParams() const {
   r.push_back(Parameter::Switch('d', "dry run"));
   r.push_back(Parameter::Switch('l', "list objects to be removed"));
   r.push_back(Parameter::Switch('I', "upload updated statistics DB file"));
+  r.push_back(Parameter::Optional('E',
+      "inclusion spec for partial replication"));
   return r;
 }
 
@@ -85,6 +88,28 @@ int CommandGc::Main(const ArgumentList &args) {
   const unsigned int num_threads = (args.count('N') > 0)
                                        ? String2Uint64(*args.find('N')->second)
                                        : 8;
+
+  // Partial replication: no functional changes needed.  Excluded subtrees are
+  // pruned during snapshot, so both their catalogs and their objects are
+  // absent.  The catalog traversal already runs with ignore_load_failure=true
+  // (see GarbageCollector::GetTraversalParams), so pruned nested catalogs are
+  // silently skipped along with their entire subtree; and the sweep phase is a
+  // no-op for objects that were never downloaded.
+  if (args.count('E') > 0) {
+    catalog::InclusionSpec *inclusion_spec =
+        catalog::InclusionSpec::Create(*args.find('E')->second);
+    if (inclusion_spec != NULL && inclusion_spec->IsValid()) {
+      LogCvmfs(kLogCvmfs, kLogStdout,
+               "Partial replication mode: GC will skip pruned (excluded) "
+               "catalogs and their objects");
+    } else {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Warning: could not parse inclusion spec '%s', "
+               "continuing without partial replication awareness",
+               args.find('E')->second->c_str());
+    }
+    delete inclusion_spec;
+  }
 
   if (timestamp == GcConfig::kNoTimestamp
       && revisions == GcConfig::kFullHistory) {

--- a/cvmfs/swissknife_gc.h
+++ b/cvmfs/swissknife_gc.h
@@ -7,6 +7,8 @@
 
 #include <string>
 
+#include "catalog_traversal.h"
+#include "path_filters/inclusion_spec.h"
 #include "swissknife.h"
 
 namespace swissknife {

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -31,6 +31,7 @@
 #include "network/sink_path.h"
 #include "network/sink_mem.h"
 #include "object_fetcher.h"
+#include "path_filters/inclusion_spec.h"
 #include "path_filters/relaxed_path_filter.h"
 #include "reflog.h"
 #include "upload.h"
@@ -104,6 +105,7 @@ int pipe_chunks[2];
 pthread_mutex_t lock_pipe = PTHREAD_MUTEX_INITIALIZER;
 unsigned retries = 3;
 catalog::RelaxedPathFilter *pathfilter = NULL;
+catalog::InclusionSpec *inclusion_spec = NULL;
 atomic_int64 overall_chunks;
 atomic_int64 overall_new;
 atomic_int64 chunk_queue;
@@ -306,6 +308,19 @@ bool CommandPull::PullRecursion(catalog::Catalog *catalog,
              iEnd = nested_catalogs.end();
          i != iEnd;
          ++i) {
+      // Partial replication: prune entire subtrees that contain no included
+      // path.  IsExcluded() is true exactly when the subtree rooted at this
+      // mountpoint is disjoint from the inclusion set, so neither this nested
+      // catalog nor any of its descendants need to be replicated.  Ancestor
+      // catalogs on the way to an included subtree are *not* excluded and are
+      // therefore still pulled and recursed into.
+      if (inclusion_spec
+          && inclusion_spec->IsExcluded(i->mountpoint.ToString())) {
+        LogCvmfs(kLogCvmfs, kLogStdout,
+                 "Pruning excluded subtree (catalog + objects) at %s",
+                 i->mountpoint.c_str());
+        continue;
+      }
       LogCvmfs(kLogCvmfs, kLogStdout, "Replicating from catalog at %s",
                i->mountpoint.c_str());
       shash::Any previous_catalog_hash;  // expected to be null for subcatalog
@@ -436,29 +451,34 @@ bool CommandPull::Pull(const shash::Any &catalog_hash,
   }
   apply_timestamp_threshold = true;
 
-  // Traverse the chunks
-  LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
-           "  Processing chunks [%" PRIu64 " registered chunks]: ",
-           catalog->GetNumChunks());
-  retval = catalog->AllChunksBegin();
-  if (!retval) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "failed to gather chunks");
-    goto pull_cleanup;
+  // Traverse the chunks.  In partial replication mode, excluded subtrees are
+  // pruned before reaching this point (see PullRecursion), so any catalog we
+  // pull here has its objects replicated.  Ancestor catalogs on the way to an
+  // included subtree are replicated in full, which keeps navigation intact.
+  {
+    LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak,
+             "  Processing chunks [%" PRIu64 " registered chunks]: ",
+             catalog->GetNumChunks());
+    retval = catalog->AllChunksBegin();
+    if (!retval) {
+      LogCvmfs(kLogCvmfs, kLogStderr, "failed to gather chunks");
+      goto pull_cleanup;
+    }
+    while (catalog->AllChunksNext(&chunk_hash, &compression_alg)) {
+      ChunkJob next_chunk(chunk_hash, compression_alg);
+      WritePipe(pipe_chunks[1], &next_chunk, sizeof(next_chunk));
+      atomic_inc64(&chunk_queue);
+    }
+    catalog->AllChunksEnd();
+    while (atomic_read64(&chunk_queue) != 0) {
+      SafeSleepMs(100);
+    }
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             " fetched %" PRId64 " new chunks out of "
+             "%" PRId64 " unique chunks",
+             atomic_read64(&overall_new) - gauge_new,
+             atomic_read64(&overall_chunks) - gauge_chunks);
   }
-  while (catalog->AllChunksNext(&chunk_hash, &compression_alg)) {
-    ChunkJob next_chunk(chunk_hash, compression_alg);
-    WritePipe(pipe_chunks[1], &next_chunk, sizeof(next_chunk));
-    atomic_inc64(&chunk_queue);
-  }
-  catalog->AllChunksEnd();
-  while (atomic_read64(&chunk_queue) != 0) {
-    SafeSleepMs(100);
-  }
-  LogCvmfs(kLogCvmfs, kLogStdout,
-           " fetched %" PRId64 " new chunks out of "
-           "%" PRId64 " unique chunks",
-           atomic_read64(&overall_new) - gauge_new,
-           atomic_read64(&overall_chunks) - gauge_chunks);
 
   retval = PullRecursion(catalog, path);
   previous_catalog = catalog->GetPreviousRevision();
@@ -530,6 +550,24 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   if (args.find('d') != args.end()) {
     pathfilter = catalog::RelaxedPathFilter::Create(*args.find('d')->second);
     assert(pathfilter->IsValid());
+  }
+  if (args.find('E') != args.end()) {
+    if (pathfilter != NULL) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Options -d and -E are mutually exclusive");
+      return 1;
+    }
+    inclusion_spec =
+        catalog::InclusionSpec::Create(*args.find('E')->second);
+    if (inclusion_spec == NULL || !inclusion_spec->IsValid()) {
+      LogCvmfs(kLogCvmfs, kLogStderr,
+               "Failed to parse inclusion spec from '%s'",
+               args.find('E')->second->c_str());
+      return 1;
+    }
+    LogCvmfs(kLogCvmfs, kLogStdout,
+             "CernVM-FS: partial replication with inclusion spec (version %d)",
+             inclusion_spec->version());
   }
   if (args.find('p') != args.end())
     pull_history = true;
@@ -922,6 +960,17 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
                   ".cvmfswhitelist", false);
       StoreBuffer(ensemble.raw_manifest_buf, ensemble.raw_manifest_size,
                   ".cvmfspublished", false);
+
+      // Upload the partial replication spec to the backend
+      if (inclusion_spec != NULL) {
+        const std::string &spec_content = inclusion_spec->content();
+        StoreBuffer(
+            reinterpret_cast<const unsigned char *>(spec_content.data()),
+            spec_content.size(),
+            ".cvmfs_partial_replication", false);
+        LogCvmfs(kLogCvmfs, kLogStdout,
+                 "Uploaded partial replication spec to backend");
+      }
     }
     LogCvmfs(kLogCvmfs, kLogStdout, "Serving revision %" PRIu64,
              ensemble.manifest->revision());
@@ -939,6 +988,8 @@ fini:
   free(workers);
   delete spooler;
   delete pathfilter;
+  delete inclusion_spec;
+  inclusion_spec = NULL;
   return result;
 }
 

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -40,6 +40,8 @@ class CommandPull : public Command {
     r.push_back(Parameter::Optional('t', "timeout (s)"));
     r.push_back(Parameter::Optional('a', "number of retries"));
     r.push_back(Parameter::Optional('d', "directory for path specification"));
+    r.push_back(Parameter::Optional('E',
+        "inclusion spec for partial replication"));
     r.push_back(Parameter::Optional('Z', "pull revisions younger than <Z>"));
     r.push_back(Parameter::Optional('@', "proxy url"));
     r.push_back(Parameter::Switch('p', "pull catalog history, too"));

--- a/test/src/650-partialreplication/main
+++ b/test/src/650-partialreplication/main
@@ -1,0 +1,158 @@
+#!/bin/bash
+cvmfs_test_name="Partial Replication of Stratum1"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  # Create nested catalog structure
+  mkdir -p dir1/sub1
+  touch dir1/sub1/.cvmfscatalog
+  echo "sub1 content alpha" > dir1/sub1/file_alpha.txt
+  echo "sub1 content beta"  > dir1/sub1/file_beta.txt
+
+  mkdir -p dir1/sub2
+  touch dir1/sub2/.cvmfscatalog
+  echo "sub2 content gamma" > dir1/sub2/file_gamma.txt
+  echo "sub2 content delta" > dir1/sub2/file_delta.txt
+
+  mkdir -p dir1/sub3
+  touch dir1/sub3/.cvmfscatalog
+  echo "sub3 content epsilon" > dir1/sub3/file_epsilon.txt
+
+  mkdir -p dir2/sub1
+  touch dir2/sub1/.cvmfscatalog
+  echo "dir2 sub1 content"   > dir2/sub1/file_zeta.txt
+
+  # Files in root catalog (always replicated)
+  echo "root file" > root_file.txt
+
+  popdir
+}
+
+produce_more_files_in() {
+  local working_dir=$1
+
+  pushdir $working_dir
+
+  # Add files to both included (sub1, dir2) and excluded (sub2, sub3) dirs
+  echo "sub1 new content" > dir1/sub1/file_new.txt
+  echo "sub2 new content" > dir1/sub2/file_new.txt
+  echo "sub3 new content" > dir1/sub3/file_new.txt
+  echo "dir2 new content" > dir2/sub1/file_new.txt
+
+  popdir
+}
+
+desaster_cleanup() {
+  local mountpoint=$1
+  local replica_name=$2
+
+  sudo umount $mountpoint > /dev/null 2>&1
+  sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
+  local scratch_dir=$(pwd)
+  local mnt_point="$(pwd)/mountpoint"
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  echo "*** Create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
+  # 'NO' = no debug log; -z = enable garbage collection in the manifest
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -z || return $?
+
+  echo "*** Starting transaction to edit repository"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "*** Putting files with nested catalogs in the repository"
+  produce_files_in $repo_dir || return 3
+
+  echo "*** Publishing repository"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** Check catalog and data integrity of Stratum-0"
+  check_repository $CVMFS_TEST_REPO -i || return $?
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Create Stratum1 repository on the same machine"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+    || { desaster_cleanup $mnt_point $replica_name; return 7; }
+
+  echo "*** Configure partial replication"
+  # Create inclusion spec: replicate /dir1/sub1 and /dir2, which leaves
+  # /dir1/sub2 and /dir1/sub3 excluded. Excluded subtrees are pruned entirely:
+  # neither their catalogs nor their objects are replicated. The /dir1 parent
+  # catalog is still replicated as an ancestor of the included /dir1/sub1.
+  # 'cvmfs_server check -c' below validates that this prune is self-consistent.
+  local spec_file="${scratch_dir}/partial_replication.spec"
+  cat > $spec_file << EOF
+version 1
+# Include sub1 and dir2; sub2 and sub3 are excluded
+/dir1/sub1
+/dir2
+EOF
+
+  # Add partial replication config to the replica
+  load_repo_config $replica_name
+  local replica_conf="/etc/cvmfs/repositories.d/${replica_name}/server.conf"
+  sudo sh -c "echo 'CVMFS_PARTIAL_REPLICATION=true' >> $replica_conf"
+  sudo sh -c "echo 'CVMFS_PARTIAL_REPLICATION_SPEC=$spec_file' >> $replica_conf"
+  load_repo_config $CVMFS_TEST_REPO
+
+  echo "*** Create a partial snapshot of the Stratum0 repository"
+  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 9; }
+
+  echo "*** Verify .cvmfs_partial_replication exists in backend"
+  peek_backend_raw $replica_name ".cvmfs_partial_replication" \
+    || { desaster_cleanup $mnt_point $replica_name; return 10; }
+  echo "  .cvmfs_partial_replication found in backend"
+
+  echo "*** Run cvmfs_server check on the partial replica"
+  sudo cvmfs_server check $replica_name || { desaster_cleanup $mnt_point $replica_name; return 11; }
+
+  echo "*** Run cvmfs_server check -c (with chunk check) on the partial replica"
+  sudo cvmfs_server check -c $replica_name || { desaster_cleanup $mnt_point $replica_name; return 12; }
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Test second revision"
+  echo "*** Starting transaction"
+  start_transaction $CVMFS_TEST_REPO || return $?
+
+  echo "*** Adding more files"
+  produce_more_files_in $repo_dir || return 13
+
+  echo "*** Publishing new revision"
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  echo "*** Snapshot the new revision"
+  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $mnt_point $replica_name; return 14; }
+
+  echo "*** Check partial replica after second snapshot"
+  sudo cvmfs_server check -c $replica_name || { desaster_cleanup $mnt_point $replica_name; return 15; }
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Test garbage collection on partial replica"
+  sudo cvmfs_server gc -f $replica_name || { desaster_cleanup $mnt_point $replica_name; return 16; }
+
+  echo "*** Check partial replica after GC"
+  sudo cvmfs_server check -c $replica_name || { desaster_cleanup $mnt_point $replica_name; return 17; }
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Clean up"
+  sudo cvmfs_server rmfs -f $replica_name
+
+  return 0
+}

--- a/test/src/651-partialreplicationgc/main
+++ b/test/src/651-partialreplicationgc/main
@@ -1,0 +1,114 @@
+#!/bin/bash
+cvmfs_test_name="Garbage Collection on Partial Replication Stratum1"
+cvmfs_test_autofs_on_startup=false
+
+# Creates a test repo structure with nested catalogs under /dir1 and /dir2.
+# /dir1/sub1 will be INCLUDED in replication; /dir1/sub2 will be EXCLUDED.
+produce_files_v1_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  mkdir -p dir1/sub1
+  touch dir1/sub1/.cvmfscatalog
+  echo "sub1 content v1" > dir1/sub1/file_a.txt
+
+  mkdir -p dir1/sub2
+  touch dir1/sub2/.cvmfscatalog
+  echo "sub2 content v1" > dir1/sub2/file_b.txt
+
+  mkdir -p dir2
+  echo "root dir2 content" > dir2/file_c.txt
+
+  popdir
+}
+
+# Second revision: updates files in both included and excluded dirs.
+produce_files_v2_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  echo "sub1 content v2" > dir1/sub1/file_a.txt
+  echo "sub1 new file"   > dir1/sub1/file_new.txt
+  echo "sub2 content v2" > dir1/sub2/file_b.txt
+
+  popdir
+}
+
+desaster_cleanup() {
+  local replica_name=$1
+  sudo cvmfs_server rmfs -f $replica_name > /dev/null 2>&1
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+  local replica_name="$(get_stratum1_name $CVMFS_TEST_REPO)"
+
+  echo "*** Create repository $CVMFS_TEST_REPO (with GC enabled)"
+  # 'NO' = no debug log; -z = enable garbage collection in the manifest
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -z || return $?
+
+  echo "*** Publish first revision"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_files_v1_in $repo_dir        || return 3
+  publish_repo $CVMFS_TEST_REPO        || return $?
+
+  echo "*** Publish second revision"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_files_v2_in $repo_dir        || return 4
+  publish_repo $CVMFS_TEST_REPO        || return $?
+
+  echo "*** Create partial Stratum-1"
+  load_repo_config $CVMFS_TEST_REPO
+  create_stratum1 $replica_name                          \
+                  $CVMFS_TEST_USER                       \
+                  $CVMFS_STRATUM0                        \
+                  /etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub \
+    || { desaster_cleanup $replica_name; return 7; }
+
+  echo "*** Configure partial replication (include /dir1/sub1 and /dir2, leaving /dir1/sub2 excluded)"
+  local spec_file="${scratch_dir}/partial_gc_test.spec"
+  cat > $spec_file << EOF
+version 1
+/dir1/sub1
+/dir2
+EOF
+
+  load_repo_config $replica_name
+  local replica_conf="/etc/cvmfs/repositories.d/${replica_name}/server.conf"
+  sudo sh -c "echo 'CVMFS_PARTIAL_REPLICATION=true'           >> $replica_conf"
+  sudo sh -c "echo 'CVMFS_PARTIAL_REPLICATION_SPEC=$spec_file' >> $replica_conf"
+  load_repo_config $CVMFS_TEST_REPO
+
+  echo "*** Snapshot both revisions to partial Stratum-1"
+  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $replica_name; return 9; }
+
+  echo "*** Check partial replica"
+  sudo cvmfs_server check -c $replica_name || { desaster_cleanup $replica_name; return 10; }
+
+  echo "*** Run GC on partial replica (keep only latest revision)"
+  sudo cvmfs_server gc -r 0 -f $replica_name \
+    || { desaster_cleanup $replica_name; return 11; }
+
+  echo "*** Check partial replica after GC"
+  sudo cvmfs_server check -c $replica_name || { desaster_cleanup $replica_name; return 12; }
+
+  echo "*** Verify .cvmfs_partial_replication still present after GC"
+  peek_backend_raw $replica_name ".cvmfs_partial_replication" \
+    || { desaster_cleanup $replica_name; return 13; }
+  echo "  .cvmfs_partial_replication found after GC"
+
+  echo "*** Publish third revision (stress test: GC again after new snapshot)"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  echo "sub1 content v3" > ${repo_dir}/dir1/sub1/file_a.txt
+  publish_repo $CVMFS_TEST_REPO || return $?
+
+  sudo cvmfs_server snapshot $replica_name || { desaster_cleanup $replica_name; return 14; }
+  sudo cvmfs_server gc -r 0 -f $replica_name || { desaster_cleanup $replica_name; return 15; }
+  sudo cvmfs_server check -c $replica_name || { desaster_cleanup $replica_name; return 16; }
+
+  echo "*** Clean up"
+  sudo cvmfs_server rmfs -f $replica_name
+  return 0
+}

--- a/test/src/652-partialreplicationclient/main
+++ b/test/src/652-partialreplicationclient/main
@@ -1,0 +1,178 @@
+#!/bin/bash
+cvmfs_test_name="Client Failover from Partial to Full Stratum-1"
+cvmfs_test_autofs_on_startup=false
+
+produce_files_in() {
+  local working_dir=$1
+  pushdir $working_dir
+
+  # Root files (always replicated)
+  echo "root content" > root_file.txt
+
+  # /included — will be INCLUDED in the partial replica
+  mkdir -p included
+  touch included/.cvmfscatalog
+  echo "included file content" > included/file_included.txt
+
+  # /excluded — will be EXCLUDED from the partial replica
+  mkdir -p excluded
+  touch excluded/.cvmfscatalog
+  echo "excluded file content" > excluded/file_excluded.txt
+
+  popdir
+}
+
+desaster_cleanup() {
+  local mnt1="$1"
+  local mnt2="$2"
+  local partial_replica="$3"
+  local full_replica="$4"
+
+  sudo umount $mnt1 > /dev/null 2>&1
+  sudo umount $mnt2 > /dev/null 2>&1
+  sudo cvmfs_server rmfs -f $partial_replica > /dev/null 2>&1
+  sudo cvmfs_server rmfs -f $full_replica    > /dev/null 2>&1
+}
+
+cvmfs_run_test() {
+  logfile=$1
+  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
+  local scratch_dir=$(pwd)
+
+  local partial_replica="$(get_stratum1_name $CVMFS_TEST_REPO).partial"
+  local full_replica="$(get_stratum1_name $CVMFS_TEST_REPO).full"
+  local mnt_partial="${scratch_dir}/mnt_partial"
+  local mnt_fail="${scratch_dir}/mnt_fail"
+
+  echo "*** Create repository $CVMFS_TEST_REPO"
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "*** Publish files"
+  start_transaction $CVMFS_TEST_REPO || return $?
+  produce_files_in $repo_dir          || return 3
+  publish_repo $CVMFS_TEST_REPO       || return $?
+
+  load_repo_config $CVMFS_TEST_REPO
+  local stratum0_url=$CVMFS_STRATUM0
+  local pub_key=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
+
+  echo "*** Create full Stratum-1 (normal replica)"
+  create_stratum1 $full_replica          \
+                  $CVMFS_TEST_USER       \
+                  $stratum0_url          \
+                  $pub_key               \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 7; }
+  sudo cvmfs_server snapshot $full_replica \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 8; }
+
+  echo "*** Create partial Stratum-1 (excluding /excluded)"
+  create_stratum1 $partial_replica       \
+                  $CVMFS_TEST_USER       \
+                  $stratum0_url          \
+                  $pub_key               \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 9; }
+
+  local spec_file="${scratch_dir}/partial_client_test.spec"
+  cat > $spec_file << EOF
+version 1
+/included
+EOF
+
+  load_repo_config $partial_replica
+  local partial_conf="/etc/cvmfs/repositories.d/${partial_replica}/server.conf"
+  sudo sh -c "echo 'CVMFS_PARTIAL_REPLICATION=true'            >> $partial_conf"
+  sudo sh -c "echo 'CVMFS_PARTIAL_REPLICATION_SPEC=$spec_file' >> $partial_conf"
+  load_repo_config $CVMFS_TEST_REPO
+
+  sudo cvmfs_server snapshot $partial_replica \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 10; }
+
+  echo "*** Verify .cvmfs_partial_replication exists on partial replica"
+  peek_backend_raw $partial_replica ".cvmfs_partial_replication" \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 11; }
+  echo "  .cvmfs_partial_replication found on partial replica"
+
+  local partial_url=$(get_repo_url $partial_replica)
+  local full_url=$(get_repo_url $full_replica)
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Mount via partial replica with failover mode"
+  # Build a config that points to the partial replica as primary
+  # and the full replica as fallback
+  local failover_config="${scratch_dir}/failover.conf"
+  local failover_cache="${scratch_dir}/cache_failover"
+  cat > $failover_config << EOF
+CVMFS_MOUNT_DIR=/cvmfs
+CVMFS_CACHE_BASE=$failover_cache
+CVMFS_RELOAD_SOCKETS=$failover_cache
+CVMFS_SERVER_URL=$partial_url
+CVMFS_HTTP_PROXY=DIRECT
+CVMFS_PUBLIC_KEY=$pub_key
+CVMFS_PARTIAL_REPLICA_MODE=failover
+CVMFS_FULL_STRATUM1_URL=$full_url
+CVMFS_DEBUGLOG=${scratch_dir}/failover.log
+EOF
+
+  mkdir -p $mnt_partial $failover_cache
+  cvmfs2 -d -o config=$failover_config $CVMFS_TEST_REPO $mnt_partial \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 12; }
+
+  echo "*** In failover mode: included file should be readable"
+  cat ${mnt_partial}/included/file_included.txt \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 13; }
+
+  echo "*** In failover mode: excluded file should be readable (via fallback)"
+  cat ${mnt_partial}/excluded/file_excluded.txt \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 14; }
+
+  sudo umount $mnt_partial
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Mount via partial replica with fail mode"
+  local fail_config="${scratch_dir}/fail.conf"
+  local fail_cache="${scratch_dir}/cache_fail"
+  cat > $fail_config << EOF
+CVMFS_MOUNT_DIR=/cvmfs
+CVMFS_CACHE_BASE=$fail_cache
+CVMFS_RELOAD_SOCKETS=$fail_cache
+CVMFS_SERVER_URL=$partial_url
+CVMFS_HTTP_PROXY=DIRECT
+CVMFS_PUBLIC_KEY=$pub_key
+CVMFS_PARTIAL_REPLICA_MODE=fail
+CVMFS_DEBUGLOG=${scratch_dir}/fail.log
+EOF
+
+  mkdir -p $mnt_fail $fail_cache
+  cvmfs2 -d -o config=$fail_config $CVMFS_TEST_REPO $mnt_fail \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 15; }
+
+  echo "*** In fail mode: included file should be readable"
+  cat ${mnt_fail}/included/file_included.txt \
+    || { desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica; return 16; }
+
+  echo "*** In fail mode: excluded file permissions should be 0000"
+  local perms
+  perms=$(stat -c "%a" ${mnt_fail}/excluded/file_excluded.txt 2>/dev/null || echo "000")
+  echo "  Permissions of excluded file: $perms"
+  [ "$perms" = "0" ] || [ "$perms" = "000" ] \
+    || { echo "WARN: expected 000 permissions on excluded file, got $perms"; }
+
+  echo "*** In fail mode: reading excluded file should fail"
+  if cat ${mnt_fail}/excluded/file_excluded.txt > /dev/null 2>&1; then
+    echo "ERROR: reading excluded file should have failed in fail mode"
+    desaster_cleanup $mnt_partial $mnt_fail $partial_replica $full_replica
+    return 17
+  fi
+  echo "  (read correctly returned an error)"
+
+  sudo umount $mnt_fail
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  echo "*** Clean up"
+  sudo cvmfs_server rmfs -f $partial_replica
+  sudo cvmfs_server rmfs -f $full_replica
+  return 0
+}

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -412,6 +412,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_reflog.cc
   t_repository_tag.cc
   t_relaxed_path_filter.cc
+  t_inclusion_spec.cc
   t_s3fanout.cc
   t_resolv_conf_event_handler.cc
   t_ring_buffer.cc
@@ -526,6 +527,7 @@ set(CVMFS_UNITTEST_SOURCES
   ${CVMFS_SOURCE_DIR}/options.cc
   ${CVMFS_SOURCE_DIR}/pack.cc
   ${CVMFS_SOURCE_DIR}/path_filters/dirtab.cc
+  ${CVMFS_SOURCE_DIR}/path_filters/inclusion_spec.cc
   ${CVMFS_SOURCE_DIR}/path_filters/relaxed_path_filter.cc
   ${CVMFS_SOURCE_DIR}/pathspec/pathspec.cc
   ${CVMFS_SOURCE_DIR}/pathspec/pathspec_pattern.cc
@@ -702,6 +704,7 @@ set(CVMFS_UNITTEST_MOCKFUSE_SOURCES
   ${CVMFS_SOURCE_DIR}/options.cc
   ${CVMFS_SOURCE_DIR}/pack.cc
   ${CVMFS_SOURCE_DIR}/path_filters/dirtab.cc
+  ${CVMFS_SOURCE_DIR}/path_filters/inclusion_spec.cc
   ${CVMFS_SOURCE_DIR}/path_filters/relaxed_path_filter.cc
   ${CVMFS_SOURCE_DIR}/pathspec/pathspec.cc
   ${CVMFS_SOURCE_DIR}/pathspec/pathspec_pattern.cc

--- a/test/unittests/t_inclusion_spec.cc
+++ b/test/unittests/t_inclusion_spec.cc
@@ -1,0 +1,183 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "path_filters/inclusion_spec.h"
+#include "util/posix.h"
+
+class T_InclusionSpec : public ::testing::Test {
+ protected:
+  catalog::InclusionSpec spec;
+};
+
+
+TEST_F(T_InclusionSpec, ValidVersionParsing) {
+  EXPECT_TRUE(spec.Parse("version 1\n"
+                         "/some/path\n"));
+  EXPECT_TRUE(spec.IsValid());
+  EXPECT_EQ(1, spec.version());
+}
+
+
+TEST_F(T_InclusionSpec, VersionWithLeadingComments) {
+  EXPECT_TRUE(spec.Parse("# This is a comment\n"
+                         "\n"
+                         "version 1\n"
+                         "/some/path\n"));
+  EXPECT_TRUE(spec.IsValid());
+  EXPECT_EQ(1, spec.version());
+}
+
+
+TEST_F(T_InclusionSpec, MissingVersion) {
+  EXPECT_FALSE(spec.Parse("/some/path\n"));
+  EXPECT_FALSE(spec.IsValid());
+}
+
+
+TEST_F(T_InclusionSpec, UnsupportedVersion) {
+  EXPECT_FALSE(spec.Parse("version 99\n"
+                          "/some/path\n"));
+  EXPECT_FALSE(spec.IsValid());
+  EXPECT_EQ(99, spec.version());
+}
+
+
+TEST_F(T_InclusionSpec, EmptySpec) {
+  EXPECT_FALSE(spec.Parse(""));
+  EXPECT_FALSE(spec.IsValid());
+}
+
+
+TEST_F(T_InclusionSpec, CommentsOnly) {
+  EXPECT_FALSE(spec.Parse("# just a comment\n"
+                          "# another comment\n"));
+  EXPECT_FALSE(spec.IsValid());
+}
+
+
+TEST_F(T_InclusionSpec, VersionOnly) {
+  EXPECT_TRUE(spec.Parse("version 1\n"));
+  EXPECT_TRUE(spec.IsValid());
+}
+
+
+TEST_F(T_InclusionSpec, BasicInclusion) {
+  EXPECT_TRUE(spec.Parse("version 1\n"
+                         "/software/releases/old\n"
+                         "/data/simulation/2019\n"));
+  EXPECT_TRUE(spec.IsValid());
+
+  // Root is never excluded
+  EXPECT_FALSE(spec.IsExcluded(""));
+  EXPECT_FALSE(spec.IsExcluded("/"));
+
+  // Included paths are not excluded
+  EXPECT_FALSE(spec.IsExcluded("/software/releases/old"));
+  EXPECT_FALSE(spec.IsExcluded("/data/simulation/2019"));
+
+  // Sub-paths of included paths are also included
+  EXPECT_FALSE(spec.IsExcluded("/software/releases/old/sub1"));
+  EXPECT_FALSE(spec.IsExcluded("/data/simulation/2019/run1"));
+
+  // Parent paths of included paths are not excluded either: RelaxedPathFilter
+  // matches them positively so their catalogs/objects stay replicable as the
+  // path to the included subtree.
+  EXPECT_FALSE(spec.IsExcluded("/software"));
+  EXPECT_FALSE(spec.IsExcluded("/software/releases"));
+
+  // Anything not covered by an inclusion rule is excluded
+  EXPECT_TRUE(spec.IsExcluded("/software/releases/new"));
+  EXPECT_TRUE(spec.IsExcluded("/data/simulation/2020"));
+  EXPECT_TRUE(spec.IsExcluded("/completely/different"));
+}
+
+
+TEST_F(T_InclusionSpec, Negation) {
+  EXPECT_TRUE(spec.Parse("version 1\n"
+                         "/software/releases/old\n"
+                         "!/software/releases/old/critical\n"));
+  EXPECT_TRUE(spec.IsValid());
+
+  // Included
+  EXPECT_FALSE(spec.IsExcluded("/software/releases/old"));
+  EXPECT_FALSE(spec.IsExcluded("/software/releases/old/other"));
+
+  // Excluded via negation
+  EXPECT_TRUE(spec.IsExcluded("/software/releases/old/critical"));
+  EXPECT_TRUE(spec.IsExcluded("/software/releases/old/critical/sub"));
+}
+
+
+TEST_F(T_InclusionSpec, WildcardInclusion) {
+  EXPECT_TRUE(spec.Parse("version 1\n"
+                         "/data/scratch/*\n"));
+  EXPECT_TRUE(spec.IsValid());
+
+  EXPECT_FALSE(spec.IsExcluded("/data/scratch/temp1"));
+  EXPECT_FALSE(spec.IsExcluded("/data/scratch/temp2"));
+  // The parent path /data/scratch itself
+  // With RelaxedPathFilter, parents of matching paths also match
+  EXPECT_FALSE(spec.IsExcluded("/data/scratch"));
+
+  // Unrelated paths are excluded
+  EXPECT_TRUE(spec.IsExcluded("/data/other"));
+}
+
+
+TEST_F(T_InclusionSpec, TrailingSlashIgnored) {
+  EXPECT_TRUE(spec.Parse("version 1\n"
+                         "/software/releases/old/\n"));
+  EXPECT_TRUE(spec.IsValid());
+
+  EXPECT_FALSE(spec.IsExcluded("/software/releases/old"));
+  EXPECT_FALSE(spec.IsExcluded("/software/releases/old/sub"));
+  EXPECT_TRUE(spec.IsExcluded("/software/releases/new"));
+}
+
+
+TEST_F(T_InclusionSpec, InvalidPathNotExcluded) {
+  // Without successful parse, nothing is excluded
+  catalog::InclusionSpec bad_spec;
+  EXPECT_FALSE(bad_spec.IsExcluded("/any/path"));
+}
+
+
+TEST_F(T_InclusionSpec, CreateFromFile) {
+  std::string content = "version 1\n/sw/repo/ASG\n";
+  std::string spec_path;
+  FILE *f = CreateTempFile("./cvmfs-spec", 0600, "w", &spec_path);
+  ASSERT_TRUE(f != NULL);
+  fwrite(content.data(), content.size(), 1, f);
+  fclose(f);
+
+  catalog::InclusionSpec *spec_from_file =
+      catalog::InclusionSpec::Create(spec_path);
+  ASSERT_TRUE(spec_from_file != NULL);
+  EXPECT_TRUE(spec_from_file->IsValid());
+  EXPECT_EQ(1, spec_from_file->version());
+  EXPECT_FALSE(spec_from_file->IsExcluded("/sw/repo/ASG"));
+  EXPECT_FALSE(spec_from_file->IsExcluded("/sw/repo/ASG/AnalysisTop"));
+  EXPECT_TRUE(spec_from_file->IsExcluded("/sw/repo/other"));
+
+  delete spec_from_file;
+  unlink(spec_path.c_str());
+}
+
+
+TEST_F(T_InclusionSpec, CreateFromNonexistentFile) {
+  catalog::InclusionSpec *spec_from_file =
+      catalog::InclusionSpec::Create("/nonexistent/path/to/spec");
+  EXPECT_TRUE(spec_from_file == NULL);
+}
+
+
+TEST_F(T_InclusionSpec, ContentPreserved) {
+  std::string input = "version 1\n/some/path\n";
+  EXPECT_TRUE(spec.Parse(input));
+  EXPECT_EQ(input, spec.content());
+}


### PR DESCRIPTION


* Uses a spec file to exlude parts of the repo tree from being replicated. Currently can only exclude full catalogs, so directories with a .cvmfscatalog file.
* The spec file is made available as  .cvmfs_partial_replica on the server to indicate the stratum-1 status
* Two modes for the client: Either transparently fall back to a full stratum 1, which looks to the client as if the full repository is available, or fail with an I/O error on any attempt to access them. The ownership of non-replicated file is changed to `nobody` to indicate that they are not available.


Future improvements: More monitoring, counters for potential fallbacks to full stratum-1s. Documentation and usage examples, which should make it clearer how this will work in practice

See #3554 