### PR TITLE
selinux: provide a default context if unset

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -1928,7 +1928,12 @@ static void cvmfs_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   if (!magic_xattr.IsNull()) {
     attribute_result = magic_xattr->GetValue(attr_req_page, xattr_mode);
   } else {
-    if (!xattrs.Get(attr, &attribute_result.second)) {
+    /* security.selinux is excluded from catalog hashing and storage (see
+     * HashMeta). Synthesize a host-local default at query time rather than
+     * storing policy-dependent labels in the content-addressed catalog. */
+    if (strcmp(attr.c_str(), "security.selinux") == 0) {
+      attribute_result.second = "system_u:object_r:fusefs_t:s0";
+    } else if (!xattrs.Get(attr, &attribute_result.second)) {
       fuse_reply_err(req, ENOATTR);
       return;
     }


### PR DESCRIPTION
The `default_t` context is a suitable non-value.  It should map into any selinux policy with limited consequences and no realy change in current behavior.

The major limitation is `default_t` doesn't actually permit execution of confined processes by default.

If we don't need RHEL7 compat, the context should default to `fusefs_t` to match the policy in modern systems.

I'm not clear there are any confined selinux users of this container on RHEL7, since it won't allow access.  If this is desired, `usr_t` might be more appropriate as that is the default context for `/opt` and its content.

The PR currently implements "just enough" to make the undefined context errors go away, but should be modified to select an actually useful default context.

Fixes: https://github.com/cvmfs/cvmfs/issues/4190