### PR TITLE
Add concurrency support to sweep phase of GC

### DIFF
--- a/cvmfs/catalog_traversal.h
+++ b/cvmfs/catalog_traversal.h
@@ -540,6 +540,13 @@ class CatalogTraversal : public CatalogTraversalBase<ObjectFetcherT> {
   explicit CatalogTraversal(const Parameters &params)
       : CatalogTraversalBase<ObjectFetcherT>(params) { }
 
+  /**
+   * No-op in the serial traversal; callbacks are inherently sequential.
+   * Declared so the templated GarbageCollector can call it regardless of
+   * which traversal class it was instantiated with.
+   */
+  void SetSerializeCallbacks(bool /* serialize */) { }
+
   bool Traverse(const TraversalType type = Base::kBreadthFirst) {
     const shash::Any root_catalog_hash = this->GetRepositoryRootCatalogHash();
     if (root_catalog_hash.IsNull()) {

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -111,6 +111,16 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
   }
 
   /**
+   * Controls whether the callback mutex serializes NotifyListeners() calls.
+   * The default (constructed from Parameters::serialize_callbacks) is true;
+   * callers whose registered listeners are thread-safe can flip it to false
+   * at runtime to let multiple workers run their callbacks concurrently.
+   */
+  void SetSerializeCallbacks(bool serialize) {
+    serialize_callbacks_ = serialize;
+  }
+
+  /**
    * Start the traversal process from a list of root catalogs. Same as
    * TraverseRevision function, TraverseList does not traverse into predecessor
    * catalog revisions and ignores TraversalParameter settings.

--- a/cvmfs/garbage_collection/garbage_collector.h
+++ b/cvmfs/garbage_collection/garbage_collector.h
@@ -33,6 +33,7 @@
 #define CVMFS_GARBAGE_COLLECTION_GARBAGE_COLLECTOR_H_
 
 #include <inttypes.h>
+#include <pthread.h>
 
 #include <vector>
 
@@ -40,6 +41,8 @@
 #include "garbage_collection/hash_filter.h"
 #include "statistics.h"
 #include "upload_facility.h"
+#include "util/atomic.h"
+#include "util/mutex.h"
 
 template<class CatalogTraversalT, class HashFilterT>
 class GarbageCollector {
@@ -89,17 +92,26 @@ class GarbageCollector {
 
  public:
   explicit GarbageCollector(const Configuration &configuration);
+  ~GarbageCollector();
 
   void UseReflogTimestamps();
   bool Collect();
 
-  uint64_t preserved_catalog_count() const { return preserved_catalogs_; }
-  uint64_t condemned_catalog_count() const { return condemned_catalogs_; }
-  uint64_t condemned_objects_count() const { return condemned_objects_; }
-  uint64_t duplicate_delete_requests() const {
-    return duplicate_delete_requests_;
+  uint64_t preserved_catalog_count() const {
+    return atomic_read64(&preserved_catalogs_);
   }
-  uint64_t condemned_bytes_count() const { return condemned_bytes_; }
+  uint64_t condemned_catalog_count() const {
+    return atomic_read64(&condemned_catalogs_);
+  }
+  uint64_t condemned_objects_count() const {
+    return atomic_read64(&condemned_objects_);
+  }
+  uint64_t duplicate_delete_requests() const {
+    return atomic_read64(&duplicate_delete_requests_);
+  }
+  uint64_t condemned_bytes_count() const {
+    return atomic_read64(&condemned_bytes_);
+  }
   uint64_t oldest_trunk_catalog() const { return oldest_trunk_catalog_; }
 
  protected:
@@ -118,7 +130,7 @@ class GarbageCollector {
 
   void PrintCatalogTreeEntry(const unsigned int tree_level,
                              const CatalogTN *catalog) const;
-  void LogDeletion(const shash::Any &hash) const;
+  void LogDeletion(const shash::Any &hash);
 
  private:
   class ReflogBasedInfoShim
@@ -144,8 +156,13 @@ class GarbageCollector {
   ReflogBasedInfoShim catalog_info_shim_;
   CatalogTraversalT traversal_;
   HashFilterT hash_filter_;
-  HashFilterT hash_map_delete_requests_;
-
+  /// Hashes already dispatched for deletion, so each object is deleted at
+  /// most once.  Written concurrently from sweep threads.
+  ShardedHashFilter hash_map_delete_requests_;
+  /**
+   * Protects fprintf() to configuration_.deleted_objects_logfile.
+   */
+  pthread_mutex_t log_mutex_;
 
   bool use_reflog_timestamps_;
   /**
@@ -156,28 +173,31 @@ class GarbageCollector {
    */
   uint64_t oldest_trunk_catalog_;
   bool oldest_trunk_catalog_found_;
-  uint64_t preserved_catalogs_;
+  mutable atomic_int64 preserved_catalogs_;
   /**
    * Number of catalogs in the reflog that are to be deleted (in fact, some of
-   * them might not exist anymore).
+   * them might not exist anymore).  Set once before the sweep traversal starts
+   * and read-only during sweep, so no atomicity required.
    */
   uint64_t unreferenced_trees_;
   /**
    * Number of root catalogs garbage collected, count grows as GC progresses
    */
-  uint64_t condemned_trees_;
+  mutable atomic_int64 condemned_trees_;
   /**
    * Number of catalogs garbage collected, count grows as GC progresses
    */
-  uint64_t condemned_catalogs_;
+  mutable atomic_int64 condemned_catalogs_;
   /**
-   * Keeps track if the last status report issued, between 0 and 1
+   * Keeps track of the last status report issued, as an integer percent
+   * (0-100).  Updated via atomic CAS so each percentile bucket logs at most
+   * once even when multiple sweep threads cross the threshold simultaneously.
    */
-  float last_reported_status_;
+  mutable atomic_int32 last_reported_status_;
 
-  uint64_t condemned_objects_;
-  uint64_t condemned_bytes_;
-  uint64_t duplicate_delete_requests_;
+  mutable atomic_int64 condemned_objects_;
+  mutable atomic_int64 condemned_bytes_;
+  mutable atomic_int64 duplicate_delete_requests_;
 };
 
 #include "garbage_collector_impl.h"

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -308,8 +308,26 @@ bool GarbageCollector<CatalogTraversalT, HashFilterT>::SweepReflog() {
     }
   }
   unreferenced_trees_ = to_sweep.size();
-  bool success = traversal_.TraverseList(to_sweep,
-                                         CatalogTraversalT::kDepthFirst);
+  // Publish all hash_filter_ writes from the (serial) mark phase before
+  // sweep workers begin reading it.  The matching acquire is provided by
+  // the parallel traversal's task-queue mutex: each worker's lock-acquire
+  // when it dequeues a sweep task synchronizes-with the producer's
+  // lock-release after this fence, so all hash_filter_ writes are visible
+  // before SweepDataObjects runs.  Made explicit for weakly-ordered
+  // architectures (e.g. ARM).
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+  bool success;
+  {
+    struct SerializeCallbacksGuard {
+      CatalogTraversalT &traversal;
+      explicit SerializeCallbacksGuard(CatalogTraversalT &t) : traversal(t) {
+        traversal.SetSerializeCallbacks(false);
+      }
+      ~SerializeCallbacksGuard() { traversal.SetSerializeCallbacks(true); }
+    } guard(traversal_);
+    success = traversal_.TraverseList(to_sweep,
+                                      CatalogTraversalT::kDepthFirst);
+  }
   traversal_.UnregisterListener(callback);
 
   i = to_sweep.begin();

--- a/cvmfs/garbage_collection/garbage_collector_impl.h
+++ b/cvmfs/garbage_collection/garbage_collector_impl.h
@@ -40,15 +40,22 @@ GarbageCollector<CatalogTraversalT, HashFilterT>::GarbageCollector(
     , use_reflog_timestamps_(false)
     , oldest_trunk_catalog_(static_cast<uint64_t>(-1))
     , oldest_trunk_catalog_found_(false)
-    , preserved_catalogs_(0)
-    , unreferenced_trees_(0)
-    , condemned_trees_(0)
-    , condemned_catalogs_(0)
-    , last_reported_status_(0.0)
-    , condemned_objects_(0)
-    , condemned_bytes_(0)
-    , duplicate_delete_requests_(0) {
+    , unreferenced_trees_(0) {
+  atomic_init64(&preserved_catalogs_);
+  atomic_init64(&condemned_trees_);
+  atomic_init64(&condemned_catalogs_);
+  atomic_init32(&last_reported_status_);
+  atomic_init64(&condemned_objects_);
+  atomic_init64(&condemned_bytes_);
+  atomic_init64(&duplicate_delete_requests_);
+  pthread_mutex_init(&log_mutex_, NULL);
   assert(configuration_.uploader != NULL);
+}
+
+
+template<class CatalogTraversalT, class HashFilterT>
+GarbageCollector<CatalogTraversalT, HashFilterT>::~GarbageCollector() {
+  pthread_mutex_destroy(&log_mutex_);
 }
 
 
@@ -82,7 +89,7 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::PreserveDataObjects(
                            HashFilterT>::TraversalCallbackDataTN
         &data  // NOLINT(runtime/references)
 ) {
-  ++preserved_catalogs_;
+  atomic_inc64(&preserved_catalogs_);
 
   if (data.catalog->IsRoot()) {
     const uint64_t mtime = use_reflog_timestamps_
@@ -130,9 +137,9 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects(
                            HashFilterT>::TraversalCallbackDataTN
         &data  // NOLINT(runtime/references)
 ) {
-  ++condemned_catalogs_;
+  atomic_inc64(&condemned_catalogs_);
   if (data.catalog->IsRoot())
-    ++condemned_trees_;
+    atomic_inc64(&condemned_trees_);
 
   if (configuration_.verbose) {
     if (data.catalog->IsRoot()) {
@@ -157,15 +164,27 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects(
   // the catalog itself is also condemned and needs to be removed
   CheckAndSweep(data.catalog->hash());
 
-  float threshold = static_cast<float>(condemned_trees_)
-                    / static_cast<float>(unreferenced_trees_);
-  if (threshold > last_reported_status_ + 0.1) {
-    LogCvmfs(kLogGc, kLogStdout | kLogDebug,
-             "      - %02.0f%%    %" PRIu64 " / %" PRIu64
-             " unreferenced revisions removed [%s]",
-             100.0 * threshold, condemned_trees_, unreferenced_trees_,
-             RfcTimestamp().c_str());
-    last_reported_status_ = threshold;
+  // Progress reporting.  Use integer percent so the shared counter can be
+  // an atomic_int32 updated via CAS -- this ensures each 10%-bucket logs
+  // at most once even if several threads cross the threshold concurrently.
+  // The CAS is retried so that when two threads race (e.g. one with pct=20
+  // and one with pct=30 against last=10), the loser still publishes its
+  // bucket instead of being silently dropped.
+  const int64_t condemned_trees = atomic_read64(&condemned_trees_);
+  const int32_t pct = static_cast<int32_t>(
+      (100.0 * static_cast<float>(condemned_trees))
+      / static_cast<float>(unreferenced_trees_));
+  for (;;) {
+    const int32_t last_pct = atomic_read32(&last_reported_status_);
+    if (pct < last_pct + 10) break;
+    if (atomic_cas32(&last_reported_status_, last_pct, pct)) {
+      LogCvmfs(kLogGc, kLogStdout | kLogDebug,
+               "      - %d%%    %" PRIu64 " / %" PRIu64
+               " unreferenced revisions removed [%s]",
+               pct, static_cast<uint64_t>(condemned_trees),
+               unreferenced_trees_, RfcTimestamp().c_str());
+      break;
+    }
   }
 }
 
@@ -173,12 +192,13 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::SweepDataObjects(
 template<class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::CheckAndSweep(
     const shash::Any &hash) {
+  // hash_filter_ is read-only during the sweep phase (mark phase has
+  // completed), so Contains() needs no synchronization.
   if (!hash_filter_.Contains(hash)) {
-    if (!hash_map_delete_requests_.Contains(hash)) {
-      hash_map_delete_requests_.Fill(hash);
+    if (!hash_map_delete_requests_.ContainsOrInsert(hash)) {
       Sweep(hash);
     } else {
-      ++duplicate_delete_requests_;
+      atomic_inc64(&duplicate_delete_requests_);
       LogCvmfs(kLogGc, kLogDebug, "Hash %s already marked as to delete",
                hash.ToString().c_str());
     }
@@ -189,12 +209,12 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::CheckAndSweep(
 template<class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::Sweep(
     const shash::Any &hash) {
-  ++condemned_objects_;
+  atomic_inc64(&condemned_objects_);
   if (configuration_.extended_stats) {
     if (!hash.HasSuffix() || hash.suffix == shash::kSuffixPartial) {
       int64_t condemned_bytes = configuration_.uploader->GetObjectSize(hash);
       if (condemned_bytes > 0) {
-        condemned_bytes_ += condemned_bytes;
+        atomic_xadd64(&condemned_bytes_, condemned_bytes);
       }
     }
   }
@@ -349,13 +369,14 @@ void GarbageCollector<CatalogTraversalT, HashFilterT>::PrintCatalogTreeEntry(
 
 template<class CatalogTraversalT, class HashFilterT>
 void GarbageCollector<CatalogTraversalT, HashFilterT>::LogDeletion(
-    const shash::Any &hash) const {
+    const shash::Any &hash) {
   if (configuration_.verbose) {
     LogCvmfs(kLogGc, kLogStdout | kLogDebug, "Sweep: %s",
              hash.ToStringWithSuffix().c_str());
   }
 
   if (configuration_.has_deletion_log()) {
+    MutexLockGuard guard(&log_mutex_);
     const int written = fprintf(configuration_.deleted_objects_logfile, "%s\n",
                                 hash.ToStringWithSuffix().c_str());
     if (written < 0) {

--- a/cvmfs/garbage_collection/hash_filter.h
+++ b/cvmfs/garbage_collection/hash_filter.h
@@ -125,4 +125,60 @@ class SmallhashFilter : public AbstractHashFilter {
   bool frozen_;
 };
 
+
+//------------------------------------------------------------------------------
+
+
+/**
+ * Thread-safe AbstractHashFilter backed by MultiHash with per-shard locks.
+ */
+class ShardedHashFilter : public AbstractHashFilter {
+ public:
+  ShardedHashFilter() {
+    // zero_element is MD5("unobtanium")
+    const shash::Any zero_element(
+        shash::kMd5, shash::HexPtr("d61f853acc5a39e01f3906f73e31d256"));
+    // 255 is MultiHash's uint8_t shard-index limit; more shards reduce
+    // lock contention under concurrent access.
+    hashmap_.Init(255, zero_element, &ShardedHashFilter::hasher);
+  }
+
+  void Fill(const shash::Any &hash) { hashmap_.Insert(hash, true); }
+
+  bool Contains(const shash::Any &hash) const {
+    return hashmap_.Contains(hash);
+  }
+
+  /**
+   * Atomically checks if the hash is present; if not, inserts it.  Returns
+   * true if the hash was already present (duplicate).
+   */
+  bool ContainsOrInsert(const shash::Any &hash) {
+    return hashmap_.ContainsOrInsert(hash, true);
+  }
+
+  void Freeze() { }
+
+  /// Sum of per-shard sizes; takes all shard locks in turn, so the result
+  /// is only a snapshot and may be stale under concurrent mutation.
+  size_t Count() const {
+    uint32_t sizes[255];
+    hashmap_.GetSizes(sizes);
+    size_t total = 0;
+    for (uint32_t i = 0; i < hashmap_.num_hashmaps(); ++i) {
+      total += sizes[i];
+    }
+    return total;
+  }
+
+ private:
+  static uint32_t hasher(const shash::Any &key) {
+    // Don't start with the first bytes, because == is using them as well
+    return static_cast<uint32_t>(
+        *(reinterpret_cast<const uint32_t *>(key.digest) + 1));
+  }
+
+  MultiHash<shash::Any, bool> hashmap_;
+};
+
 #endif  // CVMFS_GARBAGE_COLLECTION_HASH_FILTER_H_

--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -417,7 +417,7 @@ class MultiHash {
     delete[] hashmaps_;
   }
 
-  bool Lookup(const Key &key, Value *value) {
+  bool Lookup(const Key &key, Value *value) const {
     uint8_t target = SelectHashmap(key);
     Lock(target);
     const bool result = hashmaps_[target].Lookup(key, value);
@@ -430,6 +430,35 @@ class MultiHash {
     Lock(target);
     hashmaps_[target].Insert(key, value);
     Unlock(target);
+  }
+
+  bool Contains(const Key &key) const {
+    uint8_t target = SelectHashmap(key);
+    Lock(target);
+    const bool result = hashmaps_[target].Contains(key);
+    Unlock(target);
+    return result;
+  }
+
+  /**
+   * Atomically checks if the key is present; if not, inserts it.  Returns
+   * true if the key was already present (i.e. this call was a duplicate),
+   * false if the key was freshly inserted.
+   *
+   * Holding a single per-shard lock around the Contains+Insert pair avoids
+   * the TOCTOU race that would occur if callers composed Contains() and
+   * Insert() themselves.
+   */
+  bool ContainsOrInsert(const Key &key, const Value &value) {
+    uint8_t target = SelectHashmap(key);
+    Lock(target);
+    if (hashmaps_[target].Contains(key)) {
+      Unlock(target);
+      return true;
+    }
+    hashmaps_[target].Insert(key, value);
+    Unlock(target);
+    return false;
   }
 
   void Erase(const Key &key) {
@@ -450,7 +479,7 @@ class MultiHash {
 
   uint8_t num_hashmaps() const { return num_hashmaps_; }
 
-  void GetSizes(uint32_t *sizes) {
+  void GetSizes(uint32_t *sizes) const {
     for (uint8_t i = 0; i < num_hashmaps_; ++i) {
       Lock(i);
       sizes[i] = hashmaps_[i].size();
@@ -467,7 +496,7 @@ class MultiHash {
   }
 
  private:
-  inline uint8_t SelectHashmap(const Key &key) {
+  inline uint8_t SelectHashmap(const Key &key) const {
     uint32_t hash = MurmurHash2(&key, sizeof(key), 0x37);
     double bucket = static_cast<double>(hash)
                     * static_cast<double>(num_hashmaps_)
@@ -475,19 +504,19 @@ class MultiHash {
     return static_cast<uint32_t>(bucket) % num_hashmaps_;
   }
 
-  inline void Lock(const uint8_t target) {
+  inline void Lock(const uint8_t target) const {
     int retval = pthread_mutex_lock(&locks_[target]);
     assert(retval == 0);
   }
 
-  inline void Unlock(const uint8_t target) {
+  inline void Unlock(const uint8_t target) const {
     int retval = pthread_mutex_unlock(&locks_[target]);
     assert(retval == 0);
   }
 
   uint8_t num_hashmaps_;
   SmallHashDynamic<Key, Value> *hashmaps_;
-  pthread_mutex_t *locks_;
+  mutable pthread_mutex_t *locks_;
 };
 
 

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -28,8 +28,20 @@ typedef MockedCatalogTraversal::Parameters TraversalParams;
 
 class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
  public:
+  // Fixed byte size returned by DoGetObjectSize when mock_object_size_ is
+  // set.  Tests that exercise extended_stats assert the aggregated
+  // condemned_bytes counter equals condemned_objects_count * kMockObjectSize.
+  static const int64_t kMockObjectSize = 100;
+
   explicit GC_MockUploader(const SpoolerDefinition &spooler_definition)
-      : AbstractMockUploader<GC_MockUploader>(spooler_definition) { }
+      : AbstractMockUploader<GC_MockUploader>(spooler_definition)
+      , mock_object_size_(-EOPNOTSUPP) {
+    pthread_mutex_init(&deleted_hashes_mutex_, NULL);
+  }
+
+  virtual ~GC_MockUploader() {
+    pthread_mutex_destroy(&deleted_hashes_mutex_);
+  }
 
   virtual std::string name() const { return "GCMock"; }
 
@@ -54,21 +66,34 @@ class GC_MockUploader : public AbstractMockUploader<GC_MockUploader> {
   virtual void DoRemoveAsync(const std::string &file_to_delete) {
     shash::Any hash_to_delete(shash::MkFromSuffixedHexPtr(
         shash::HexPtr(file_to_delete.substr(5, 2) + file_to_delete.substr(8))));
-    deleted_hashes.insert(hash_to_delete);
+    {
+      MutexLockGuard guard(&deleted_hashes_mutex_);
+      deleted_hashes.insert(hash_to_delete);
+    }
     Respond(NULL, upload::UploaderResults());
   }
 
   virtual unsigned GetNumberOfErrors() const { return 0; }
   virtual int64_t DoGetObjectSize(const std::string &file_name) {
-    return -EOPNOTSUPP;
+    return mock_object_size_;
   }
 
   bool HasDeleted(const shash::Any &hash) const {
+    MutexLockGuard guard(&deleted_hashes_mutex_);
     return deleted_hashes.find(hash) != deleted_hashes.end();
   }
 
  public:
+  // Direct reads of deleted_hashes are only safe after Collect() has
+  // returned and all worker threads have joined.  Concurrent access during
+  // an in-flight sweep must go through HasDeleted(), which takes
+  // deleted_hashes_mutex_.
   std::set<shash::Any> deleted_hashes;
+  mutable pthread_mutex_t deleted_hashes_mutex_;
+  // Value returned by DoGetObjectSize.  Defaults to -EOPNOTSUPP to match
+  // historical behaviour; tests that need a real size set this to
+  // kMockObjectSize before invoking GC.
+  int64_t mock_object_size_;
 };
 
 typedef std::map<std::pair<unsigned int, std::string>, MockCatalog *>
@@ -1449,4 +1474,184 @@ TYPED_TEST(T_GarbageCollector, FindAndSweepOrphanedNamedSnapshot) {
   EXPECT_EQ(8u, new_gc.preserved_catalog_count());
   EXPECT_EQ(static_cast<unsigned>(t(25, 12, 2004)),
             new_gc.oldest_trunk_catalog());
+}
+
+
+//------------------------------------------------------------------------------
+// Concurrent sweep fixture -- parallel traversal only, because num_threads > 1
+// only makes sense with CatalogTraversalParallel.
+//------------------------------------------------------------------------------
+class T_GarbageCollectorConcurrentSweep
+    : public T_GarbageCollector<MockedCatalogTraversalParallel> { };
+
+
+TEST_F(T_GarbageCollectorConcurrentSweep, ConcurrentSweepWithMultipleThreads) {
+  // Same catalog hierarchy as KeepLastRevision but driven by four worker
+  // threads running sweep callbacks concurrently.  Asserts the same
+  // per-hash / per-catalog outcomes to verify that the thread-safe
+  // bookkeeping (atomic counters, ShardedHashFilter dedup) produces
+  // bit-identical results to the serial sweep.
+  GcConfiguration config = GetStandardGarbageCollectorConfiguration();
+  config.keep_history_depth = 0;
+  config.num_threads = 4;
+
+  MyGarbageCollector gc(config);
+  const bool success = gc.Collect();
+  EXPECT_TRUE(success);
+  EXPECT_EQ(11u, gc.preserved_catalog_count());
+  EXPECT_EQ(5u, gc.condemned_catalog_count());
+  EXPECT_EQ(0u, gc.duplicate_delete_requests());
+  EXPECT_EQ(static_cast<unsigned>(t(26, 12, 2004)), gc.oldest_trunk_catalog());
+
+  GC_MockUploader *upl = static_cast<GC_MockUploader *>(config.uploader);
+  RevisionMap &c = this->catalogs_;
+
+  // Preserved data objects (none of these should be swept).
+  EXPECT_FALSE(upl->HasDeleted(h("b52945d780f8cc16711d4e670d82499dad99032d")));
+  EXPECT_FALSE(upl->HasDeleted(h("d650d325d59ea9ca754f9b37293cd08d0b12584c")));
+  EXPECT_FALSE(upl->HasDeleted(h("4083d30ba1f72e1dfad4cdbfc60ea3c38bfa600d")));
+  EXPECT_FALSE(upl->HasDeleted(h("c308c87d518c86130d9b9d34723b2a7d4e232ce9")));
+  EXPECT_FALSE(upl->HasDeleted(h("8967a86ddf51d89aaad5ad0b7f29bdfc7f7aef2a")));
+  EXPECT_FALSE(upl->HasDeleted(h("372e393bb9f5c33440f842b47b8f6aa3ed4f2943")));
+  EXPECT_FALSE(upl->HasDeleted(h("50c44954ab4348a6a3772ee5bd30ab7a1494c692")));
+  EXPECT_FALSE(upl->HasDeleted(h("2dc2b87b8ac840e4fb1cad25c806395c931f7b31")));
+  EXPECT_FALSE(upl->HasDeleted(h("a727b47d99fba5fe196400a3c7bc1738172dff71")));
+  EXPECT_FALSE(upl->HasDeleted(h("80b59550342b6f5141b42e5b2d58ce453f12d710")));
+  EXPECT_FALSE(
+      upl->HasDeleted(h("defae1853b929bbbdbc7c6d4e75531273f1ae4cb", 'P')));
+  EXPECT_FALSE(
+      upl->HasDeleted(h("24bf4276fcdbe57e648b82af4e8fece5bd3581c7", 'P')));
+  EXPECT_FALSE(
+      upl->HasDeleted(h("acc4c10cf875861ec8d6744a9ab81cb2abe433b4", 'P')));
+  EXPECT_FALSE(
+      upl->HasDeleted(h("654be8b6938b3fb30be3e9476f3ed26db74e0a9e", 'P')));
+  EXPECT_FALSE(
+      upl->HasDeleted(h("1a17be523120c7d3a7be745ada1658cc74e8507b", 'P')));
+  EXPECT_FALSE(upl->HasDeleted(h("18588c597700a7e2d3b4ce91bdf5a947a4ad13fc")));
+  EXPECT_FALSE(upl->HasDeleted(h("fea3b5156ebbeddb89c85bc14c8e9caa185c10c7")));
+  EXPECT_FALSE(upl->HasDeleted(h("0aceb47a362df1522a69217736617493bef07d5a")));
+  EXPECT_FALSE(upl->HasDeleted(h("d2068490d25c1bd4ef2f3d3a0568a76046466860")));
+  EXPECT_FALSE(upl->HasDeleted(h("283144632474a0e553e3b61c1f272257942e7a61")));
+  EXPECT_FALSE(upl->HasDeleted(h("213bec88ed6729219d94fc9281893ba93fca2a02")));
+  EXPECT_FALSE(upl->HasDeleted(h("7d4d0ec225ebe13839d71c0dc0982567cc810402")));
+  EXPECT_FALSE(upl->HasDeleted(h("bb5a7bbe8410f0268a9b12285b6f1fd26e038023")));
+  EXPECT_FALSE(upl->HasDeleted(h("59b63e8478fb7fc02c54a85767c7116573907364")));
+  EXPECT_FALSE(upl->HasDeleted(h("09fd3486d370013d859651eb164ec71a3a09f5cb")));
+  EXPECT_FALSE(upl->HasDeleted(h("e0862f1d936037eb0c2be7ccf289f5dbf469244b")));
+  EXPECT_FALSE(upl->HasDeleted(h("8031b9ad81b52cd772db9b1b12d38994fdd9dbe4")));
+
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(5, "00")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(5, "10")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(5, "11")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(5, "20")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(2, "00")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(2, "10")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(2, "11")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(4, "00")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(4, "10")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(4, "11")]->hash()));
+  EXPECT_FALSE(upl->HasDeleted(c[this->mp(4, "20")]->hash()));
+
+  // Condemned data objects.
+  EXPECT_TRUE(upl->HasDeleted(h("2e87adef242bc67cb66fcd61238ad808a7b44aab")));
+  EXPECT_TRUE(upl->HasDeleted(h("3bf4854891899670727fc8e9c6e454f7e4058454")));
+  EXPECT_TRUE(upl->HasDeleted(h("12ea064b069d98cb9da09219568ff2f8dd7d0a7e")));
+  EXPECT_TRUE(upl->HasDeleted(h("20c2e6328f943003254693a66434ff01ebba26f0")));
+  EXPECT_TRUE(upl->HasDeleted(h("219d1ca4c958bd615822f8c125701e73ce379428")));
+  EXPECT_TRUE(upl->HasDeleted(c[this->mp(1, "00")]->hash()));
+  EXPECT_TRUE(upl->HasDeleted(c[this->mp(1, "10")]->hash()));
+  EXPECT_TRUE(upl->HasDeleted(c[this->mp(3, "00")]->hash()));
+  EXPECT_TRUE(upl->HasDeleted(c[this->mp(3, "10")]->hash()));
+  EXPECT_TRUE(upl->HasDeleted(c[this->mp(3, "11")]->hash()));
+
+  EXPECT_EQ(11u, upl->deleted_hashes.size());
+}
+
+
+TEST_F(T_GarbageCollectorConcurrentSweep, ConcurrentSweepWithExtendedStats) {
+  // Enables extended_stats to exercise the concurrent
+  //   atomic_xadd64(&condemned_bytes_, uploader->GetObjectSize(hash))
+  // code path from multiple sweep threads.  The mock uploader returns a
+  // fixed size per object so the final byte total is deterministic.
+  GcConfiguration config = GetStandardGarbageCollectorConfiguration();
+  config.keep_history_depth = 0;
+  config.num_threads = 4;
+  config.extended_stats = true;
+  static_cast<GC_MockUploader *>(config.uploader)->mock_object_size_ =
+      GC_MockUploader::kMockObjectSize;
+
+  MyGarbageCollector gc(config);
+  const bool success = gc.Collect();
+  EXPECT_TRUE(success);
+  EXPECT_EQ(5u, gc.condemned_catalog_count());
+
+  GC_MockUploader *upl = static_cast<GC_MockUploader *>(config.uploader);
+  EXPECT_EQ(11u, upl->deleted_hashes.size());
+
+  // Sweep() only counts bytes for objects with no suffix or the Partial
+  // suffix.  Sum the expected total from the actual deleted-hash set so
+  // the assertion does not drift if the catalog hierarchy changes.
+  int64_t expected_bytes = 0;
+  for (std::set<shash::Any>::const_iterator i = upl->deleted_hashes.begin(),
+                                            iend = upl->deleted_hashes.end();
+       i != iend; ++i) {
+    if (!i->HasSuffix() || i->suffix == shash::kSuffixPartial) {
+      expected_bytes += GC_MockUploader::kMockObjectSize;
+    }
+  }
+  EXPECT_GT(expected_bytes, 0);
+  EXPECT_EQ(static_cast<uint64_t>(expected_bytes), gc.condemned_bytes_count());
+}
+
+
+TEST_F(T_GarbageCollectorConcurrentSweep, ConcurrentSweepWithDeletionLog) {
+  // Runs GC with four sweep threads against a real FILE* deletion log and
+  // then verifies every line is intact.  This is the most sensitive way a
+  // concurrent sweep could regress silently: interleaved fprintf() output
+  // would corrupt log lines without affecting counter totals.
+  string dest_path;
+  FILE *deletion_log = this->CreateTemporaryFile(&dest_path);
+  ASSERT_TRUE(deletion_log != NULL);
+  UnlinkGuard unlink_guard(dest_path);
+
+  GcConfiguration config = GetStandardGarbageCollectorConfiguration();
+  config.keep_history_depth = 0;
+  config.num_threads = 4;
+  config.deleted_objects_logfile = deletion_log;
+
+  MyGarbageCollector gc(config);
+  const bool success = gc.Collect();
+  EXPECT_TRUE(success);
+  EXPECT_EQ(5u, gc.condemned_catalog_count());
+
+  GC_MockUploader *upl = static_cast<GC_MockUploader *>(config.uploader);
+  ASSERT_EQ(11u, upl->deleted_hashes.size());
+
+  // Build the expected set of textual hashes from the uploader's view of
+  // what was actually swept.  Every line in the log must match one of
+  // these entries exactly (no truncation, no interleaving).
+  std::set<std::string> expected_lines;
+  for (std::set<shash::Any>::const_iterator i = upl->deleted_hashes.begin(),
+                                            iend = upl->deleted_hashes.end();
+       i != iend; ++i) {
+    expected_lines.insert(i->ToStringWithSuffix());
+  }
+  ASSERT_EQ(11u, expected_lines.size());
+
+  // Read the log back from start; every line must be present in the
+  // expected set and every line must be unique.
+  ASSERT_EQ(0, fseek(deletion_log, 0, SEEK_SET));
+  std::set<std::string> seen_lines;
+  std::string log_line;
+  while (GetLineFile(deletion_log, &log_line)) {
+    EXPECT_FALSE(log_line.empty())
+        << "empty line in deletion log indicates a corrupted write";
+    EXPECT_EQ(1u, expected_lines.count(log_line))
+        << "unexpected or corrupted log line: '" << log_line << "'";
+    EXPECT_TRUE(seen_lines.insert(log_line).second)
+        << "duplicate log line: '" << log_line << "'";
+  }
+  fclose(deletion_log);
+
+  EXPECT_EQ(expected_lines.size(), seen_lines.size());
 }

--- a/test/unittests/t_smallhash.cc
+++ b/test/unittests/t_smallhash.cc
@@ -10,6 +10,7 @@
 
 #include "crypto/hash.h"
 #include "smallhash.h"
+#include "util/atomic.h"
 #include "util/murmur.hxx"
 
 static uint32_t hasher_int(const int &key) {
@@ -64,15 +65,35 @@ class T_Smallhash : public ::testing::Test {
     return NULL;
   }
 
+  /**
+   * Every thread races against all other threads over the full key range so
+   * that ContainsOrInsert sees heavy duplicate traffic.  Each thread-local
+   * "newly inserted" count is aggregated into fresh_insert_count; the test
+   * then asserts the aggregate equals kContainsOrInsertPoolSize.
+   */
+  static void *tf_contains_or_insert(void *data) {
+    int ID = reinterpret_cast<uint64_t>(data);
+    (void)ID;
+    for (unsigned i = 0; i < kContainsOrInsertPoolSize; ++i) {
+      if (!active_multihash->ContainsOrInsert(i, i)) {
+        atomic_inc64(&fresh_insert_count);
+      }
+    }
+    return NULL;
+  }
+
   static const unsigned kNumElements = 1000000;
   static const unsigned kNumHashmaps = 42;
   static const unsigned kNumThreads = 8;
+  static const unsigned kContainsOrInsertPoolSize = 50000;
   SmallHashDynamic<int, int> smallhash_;
   SmallHashDynamic<shash::Md5, int> smallhash_md5_;
   MultiHash<int, int> multihash_;
   static MultiHash<int, int> *active_multihash;
+  static atomic_int64 fresh_insert_count;
 };
 MultiHash<int, int> *T_Smallhash::active_multihash = NULL;
+atomic_int64 T_Smallhash::fresh_insert_count = 0;
 
 
 TEST_F(T_Smallhash, Insert) {
@@ -229,6 +250,54 @@ TEST_F(T_Smallhash, MultihashMultithread) {
   }
   EXPECT_EQ(unsigned(0), GetMultiSize());
 }
+
+TEST_F(T_Smallhash, MultihashContainsOrInsert) {
+  // Single-threaded baseline for ContainsOrInsert / Contains on MultiHash.
+  const unsigned N = 1000;
+  for (unsigned i = 0; i < N; ++i) {
+    // First call: key absent, should be inserted and return false.
+    EXPECT_FALSE(multihash_.ContainsOrInsert(i, i));
+  }
+  for (unsigned i = 0; i < N; ++i) {
+    // Second call: key present, must return true and leave the map unchanged.
+    EXPECT_TRUE(multihash_.ContainsOrInsert(i, -1));
+  }
+  EXPECT_EQ(N, GetMultiSize());
+  for (unsigned i = 0; i < N; ++i) {
+    EXPECT_TRUE(multihash_.Contains(i));
+    int value = -1;
+    ASSERT_TRUE(multihash_.Lookup(i, &value));
+    // Value stored at first insert must survive the duplicate ContainsOrInsert.
+    EXPECT_EQ(static_cast<int>(i), value);
+  }
+  EXPECT_FALSE(multihash_.Contains(N + 1));
+}
+
+
+TEST_F(T_Smallhash, MultihashContainsOrInsertMultithread) {
+  // All threads race over the same key pool.  Exactly PoolSize calls (one per
+  // unique key) must observe the "freshly inserted" return value, regardless
+  // of how many threads tried to insert the same key.
+  const unsigned PoolSize = kContainsOrInsertPoolSize;
+  atomic_init64(&fresh_insert_count);
+
+  pthread_t threads[kNumThreads];
+  for (unsigned i = 0; i < kNumThreads; ++i) {
+    pthread_create(&threads[i], NULL, tf_contains_or_insert,
+                   reinterpret_cast<void *>(i));
+  }
+  for (unsigned i = 0; i < kNumThreads; ++i) {
+    pthread_join(threads[i], NULL);
+  }
+
+  EXPECT_EQ(static_cast<int64_t>(PoolSize),
+            atomic_read64(&fresh_insert_count));
+  EXPECT_EQ(PoolSize, GetMultiSize());
+  for (unsigned i = 0; i < PoolSize; ++i) {
+    EXPECT_TRUE(multihash_.Contains(i));
+  }
+}
+
 
 TEST_F(T_Smallhash, CanDestructUninitialized) {
   SmallHashDynamic<int, int>


### PR DESCRIPTION
Thread-safe primitives and concurrent sweep for garbage collection (step 2 of #4118).

Two commits, intended to be reviewed in order:
1. Adds thread-safety primitives (`ContainsOrInsert`, `ShardedHashFilter`, atomic counters, `log_mutex_`).
2. Flips callback serialization off during sweep, with three new parallel-specific tests.