### PR TITLE
Fix deadlock with batched deletes on s3

### DIFF
--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -419,7 +419,8 @@ class AbstractUploader
    * Used by concrete implementations when they use callbacks where it's not
    * already foreseen, e.g. S3Uploader::Peek().
    */
-  void IncJobsInFlight() { ++jobs_in_flight_; }
+  void IncJobsInFlight() const { ++jobs_in_flight_; }
+  void DecJobsInFlight() const { --jobs_in_flight_; }
 
  private:
   const SpoolerDefinition spooler_definition_;

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -326,10 +326,6 @@ void *S3Uploader::MainCollectResults(void *data) {
           failed_keys.insert(error_keys[i]);
         }
       }
-      // Log per-key errors if any
-      if (!failed_keys.empty() || info->error_code != s3fanout::kFailOk) {
-        atomic_inc32(&uploader->io_errors_);
-      }
       // Decrement jobs_in_flight_ once for the entire batch.
       uploader->Respond(NULL, UploaderResults(UploaderResults::kRemove,
                         (info->error_code != s3fanout::kFailOk) ? 99 : 0));

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -326,17 +326,13 @@ void *S3Uploader::MainCollectResults(void *data) {
           failed_keys.insert(error_keys[i]);
         }
       }
-      // Decrement jobs_in_flight_ once per key in the batch.
-      // Report per-key error code so callers can distinguish failures.
-      const unsigned batch_size = info->multi_delete_keys.size();
-      const int batch_error = (info->error_code != s3fanout::kFailOk) ? 99 : 0;
-      for (unsigned i = 0; i < batch_size; ++i) {
-        const int key_error = batch_error
-            ? batch_error
-            : (failed_keys.count(info->multi_delete_keys[i]) ? 99 : 0);
-        uploader->Respond(NULL, UploaderResults(UploaderResults::kRemove,
-                                                key_error));
+      // Log per-key errors if any
+      if (!failed_keys.empty() || info->error_code != s3fanout::kFailOk) {
+        atomic_inc32(&uploader->io_errors_);
       }
+      // Decrement jobs_in_flight_ once for the entire batch.
+      uploader->Respond(NULL, UploaderResults(UploaderResults::kRemove,
+                        (info->error_code != s3fanout::kFailOk) ? 99 : 0));
     } else if (info->request == s3fanout::JobInfo::kReqDelete) {
       uploader->Respond(NULL, UploaderResults());
     } else if (info->request == s3fanout::JobInfo::kReqHeadOnly) {
@@ -513,7 +509,16 @@ void S3Uploader::DoRemoveAsync(const std::string &file_to_delete) {
     return;
   }
 
-  // Batch delete: collect keys and flush when batch is full
+  // Batch delete: collect keys and flush when the S3 batch limit is reached.
+  //
+  // The caller (RemoveAsync) already incremented jobs_in_flight_ for this key.
+  // We undo that immediately: for batched deletes, jobs_in_flight_ is managed
+  // per-batch rather than per-key.  FlushDeleteBatch() increments once when
+  // the batch is dispatched, and MainCollectResults decrements once when the
+  // batch response arrives.  This avoids a deadlock where jobs_in_flight_
+  // saturates (e.g. at 512) before the batch threshold (1000) is reached,
+  // blocking forever on a flush that never happens.
+  DecJobsInFlight();
   const MutexLockGuard guard(delete_batch_mutex_);
   pending_deletes_.push_back(mangled_path);
   if (pending_deletes_.size() >= kMaxBatchDeleteSize) {
@@ -542,8 +547,9 @@ void S3Uploader::FlushDeleteBatch() const {
   info->request = s3fanout::JobInfo::kReqDeleteMulti;
   info->multi_delete_keys.swap(pending_deletes_);
 
-  // Each key was already counted in jobs_in_flight_ by DoRemoveAsync().
-  // MainCollectResults will call Respond() once per key to balance them.
+  // Track this batch as a single job in flight.  MainCollectResults will
+  // call Respond() exactly once for kReqDeleteMulti to balance it.
+  IncJobsInFlight();
   s3fanout_mgr_->PushNewJob(info);
 }
 

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -654,6 +654,77 @@ TYPED_TEST(T_Uploaders, RemoveFromStorage) {
 }
 
 
+//------------------------------------------------------------------------------
+
+
+namespace {
+struct BatchedRemoveCtx {
+  AbstractUploader *uploader;
+  unsigned num_keys;
+  atomic_int32 done;
+};
+
+static void *BatchedRemoveWorker(void *arg) {
+  BatchedRemoveCtx *ctx = static_cast<BatchedRemoveCtx *>(arg);
+  for (unsigned i = 0; i < ctx->num_keys; ++i) {
+    ctx->uploader->RemoveAsync("regression_" + StringifyInt(i));
+  }
+  ctx->uploader->WaitForUpload();
+  atomic_inc32(&ctx->done);
+  return NULL;
+}
+}  // namespace
+
+
+// Regression test for the S3 batched-delete deadlock.
+//
+// With batched deletes enabled, the base-class RemoveAsync() increments
+// jobs_in_flight_ for every key while the batch only flushes every
+// kMaxBatchDeleteSize (1000) keys.  jobs_in_flight_ is capped at
+// number_of_concurrent_uploads (default 512) and saturates long before the
+// batch is full, blocking the next RemoveAsync() forever.
+//
+// Enqueuing > 512 but < kMaxBatchDeleteSize keys triggers the deadlock.  The
+// loop runs in a worker thread so the main thread can bail out after a
+// generous timeout if the bug is present.
+TYPED_TEST(T_Uploaders, BatchedRemoveNoDeadlockSlow) {
+  if (!TestFixture::IsS3()) {
+    SUCCEED();
+    return;
+  }
+
+  const unsigned kNumKeys = 600;
+  const unsigned kTimeoutMs = 30000;
+
+  BatchedRemoveCtx ctx;
+  ctx.uploader = this->uploader_;
+  ctx.num_keys = kNumKeys;
+  atomic_init32(&ctx.done);
+
+  pthread_t worker;
+  ASSERT_EQ(0, pthread_create(&worker, NULL, BatchedRemoveWorker, &ctx));
+
+  unsigned elapsed_ms = 0;
+  while (!atomic_read32(&ctx.done) && elapsed_ms < kTimeoutMs) {
+    SafeSleepMs(100);
+    elapsed_ms += 100;
+  }
+
+  if (!atomic_read32(&ctx.done)) {
+    // Worker is stuck inside RemoveAsync's ++jobs_in_flight_.  The uploader
+    // state is unsafe to touch, so report the failure and abort the process
+    // rather than risk UB at tear-down or corrupting later tests.
+    ADD_FAILURE() << "RemoveAsync/WaitForUpload deadlocked with " << kNumKeys
+                  << " batched deletes";
+    fflush(stdout);
+    fflush(stderr);
+    _exit(1);
+  }
+  pthread_join(worker, NULL);
+  EXPECT_EQ(0U, this->uploader_->GetNumberOfErrors());
+}
+
+
 //
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //


### PR DESCRIPTION
@chrisburr The batched deletes introduced in #4122 clash with the `jobs_in_flight_` logic and deadlocked gc - fix is to count per batch instead of per key.  

Also shows that we need to run integration tests against s3 - I'm about to add a new containerized setup using garage for that.