### PR TITLE
server: update fstab format for server mounts

### DIFF
--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -852,6 +852,18 @@ int FuseMain(int argc, char *argv[]) {
     }
   }
 
+  // Set fsname to repository FQRN for identifiability in mount output.
+  // mount.cvmfs passes fsname=<fqrn> already; for direct invocations
+  // or mounts via mount.fuse that don't set fsname, add it here.
+  if (!MatchFuseOption(mount_options, "fsname=")) {
+    fuse_opt_add_arg(mount_options,
+                     ("-ofsname=" + *repository_name_).c_str());
+  }
+  // Set subtype so mount output shows "fuse.cvmfs2" as the type
+  if (!MatchFuseOption(mount_options, "subtype=")) {
+    fuse_opt_add_arg(mount_options, "-osubtype=cvmfs2");
+  }
+
   if (!premounted_ && !DirectoryExists(*mount_point_)) {
     LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
              "Mount point %s does not exist", mount_point_->c_str());
@@ -1099,10 +1111,11 @@ int FuseMain(int argc, char *argv[]) {
     if (MatchFuseOption(mount_options, "ro")) {
       flags |= MS_RDONLY;
     }
-    if (mount("cvmfs2", mount_point_->c_str(), "fuse", flags, opts) == -1) {
+    if (mount(repository_name_->c_str(), mount_point_->c_str(),
+              "fuse.cvmfs2", flags, opts) == -1) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to mount -t fuse -o %s cvmfs2 %s (%d)", opts,
-               mount_point_->c_str(), errno);
+               "Failed to mount -t fuse.cvmfs2 -o %s %s %s (%d)", opts,
+               repository_name_->c_str(), mount_point_->c_str(), errno);
       return kFailPermission;
     }
 

--- a/cvmfs/loader.cc
+++ b/cvmfs/loader.cc
@@ -1097,7 +1097,8 @@ int FuseMain(int argc, char *argv[]) {
     dounmount = true;
     char opts[128];
     snprintf(
-        opts, sizeof(opts), "fd=%i,rootmode=%o,user_id=0,group_id=0%s%s",
+        opts, sizeof(opts),
+        "fd=%i,rootmode=%o,user_id=0,group_id=0,subtype=cvmfs2%s%s",
         premount_fd, info.st_mode & S_IFMT,
         MatchFuseOption(mount_options, "default_permissions")
             ? ",default_permissions"
@@ -1111,10 +1112,10 @@ int FuseMain(int argc, char *argv[]) {
     if (MatchFuseOption(mount_options, "ro")) {
       flags |= MS_RDONLY;
     }
-    if (mount(repository_name_->c_str(), mount_point_->c_str(),
-              "fuse.cvmfs2", flags, opts) == -1) {
+    if (mount(repository_name_->c_str(), mount_point_->c_str(), "fuse",
+              flags, opts) == -1) {
       LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
-               "Failed to mount -t fuse.cvmfs2 -o %s %s %s (%d)", opts,
+               "Failed to mount -t fuse -o %s %s %s (%d)", opts,
                repository_name_->c_str(), mount_point_->c_str(), errno);
       return kFailPermission;
     }
@@ -1205,7 +1206,7 @@ int FuseMain(int argc, char *argv[]) {
       }
       if (tokens.size() < i + 3)
         continue;
-      if (tokens[i + 2] != "cvmfs2")
+      if (tokens[i + 2] != *repository_name_)
         continue;
       loader_exports_->device_id = tokens[2];
       break;

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -1202,7 +1202,7 @@ setup_new_repository_mountpoints() {
   if [ x"$CVMFS_UNION_FS_TYPE" = x"overlayfs" ]; then
     echo -n "(overlayfs) "
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+$name $rdonly_dir cvmfs allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 overlay_$name /cvmfs/$name overlay upperdir=${scratch_dir},lowerdir=${rdonly_dir},workdir=$ofs_workdir,noauto,nodev,ro 0 0 # added by CernVM-FS for $name
 EOF
   else
@@ -1211,7 +1211,7 @@ EOF
       selinux_context=",context=\"system_u:object_r:default_t:s0\""
     fi
     cat >> /etc/fstab << EOF
-cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
+$name $rdonly_dir cvmfs allow_other,config=/etc/cvmfs/repositories.d/${name}/client.conf:${CVMFS_SPOOL_DIR}/client.local,cvmfs_suid,noauto 0 0 # added by CernVM-FS for $name
 aufs_$name /cvmfs/$name aufs br=${scratch_dir}=rw:${rdonly_dir}=rr,udba=none,noauto,nodev,ro$selinux_context 0 0 # added by CernVM-FS for $name
 EOF
   fi

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -559,9 +559,11 @@ _migrate_144() {
   echo "--> adjusting /etc/fstab (use type cvmfs instead of fuse)"
   # Replace old-style fstab entries:
   #   cvmfs2#name ... fuse allow_other,fsname=name,config=... -> name ... cvmfs allow_other,config=...
-  # Also handle entries already migrated to fuse.cvmfs2 by PR #3903
-  sed -i -e "s|^cvmfs2#\(${name}\) \(.*\) fuse \(.*\)fsname=${name},\(.*# added by CernVM-FS for ${name}\)|\1 \2 cvmfs \3\4|" /etc/fstab
-  sed -i -e "s|^\(${name}\) \(.*\) fuse\.cvmfs2 \(.*\)fsname=${name},\(.*# added by CernVM-FS for ${name}\)|\1 \2 cvmfs \3\4|" /etc/fstab
+  # Also handle entries already migrated to fuse.cvmfs2 by PR #3903.  Dots
+  # are valid in repository names but are BRE wildcards, so escape them.
+  local name_pattern=$(printf '%s' "$name" | sed 's/\./\\./g')
+  sed -i -e "s|^cvmfs2#\(${name_pattern}\) \(.*\) fuse \(.*\)fsname=${name_pattern},\(.*# added by CernVM-FS for ${name_pattern}\)|\1 \2 cvmfs \3\4|" /etc/fstab
+  sed -i -e "s|^\(${name_pattern}\) \(.*\) fuse\.cvmfs2 \(.*\)fsname=${name_pattern},\(.*# added by CernVM-FS for ${name_pattern}\)|\1 \2 cvmfs \3\4|" /etc/fstab
 
   # Make sure the systemd mount unit exists
   if is_systemd; then

--- a/cvmfs/server/cvmfs_server_migrate.sh
+++ b/cvmfs/server/cvmfs_server_migrate.sh
@@ -548,6 +548,36 @@ _migrate_143() {
 }
 
 
+_migrate_144() {
+  local name=$1
+  local destination_version="144"
+  local server_conf="/etc/cvmfs/repositories.d/${name}/server.conf"
+
+  load_repo_config $name
+  echo "Migrating repository '$name' from layout revision $(mangle_version_string $CVMFS_CREATOR_VERSION) to revision $(mangle_version_string $destination_version)"
+
+  echo "--> adjusting /etc/fstab (use type cvmfs instead of fuse)"
+  # Replace old-style fstab entries:
+  #   cvmfs2#name ... fuse allow_other,fsname=name,config=... -> name ... cvmfs allow_other,config=...
+  # Also handle entries already migrated to fuse.cvmfs2 by PR #3903
+  sed -i -e "s|^cvmfs2#\(${name}\) \(.*\) fuse \(.*\)fsname=${name},\(.*# added by CernVM-FS for ${name}\)|\1 \2 cvmfs \3\4|" /etc/fstab
+  sed -i -e "s|^\(${name}\) \(.*\) fuse\.cvmfs2 \(.*\)fsname=${name},\(.*# added by CernVM-FS for ${name}\)|\1 \2 cvmfs \3\4|" /etc/fstab
+
+  # Make sure the systemd mount unit exists
+  if is_systemd; then
+    /usr/lib/systemd/system-generators/systemd-fstab-generator \
+      /run/systemd/generator '' '' 2>/dev/null || true
+    systemctl daemon-reload
+  fi
+
+  echo "--> updating server.conf"
+  sed -i -e "s/^\(CVMFS_CREATOR_VERSION\)=.*/\1=$destination_version/" $server_conf
+
+  # update repository information
+  load_repo_config $name
+}
+
+
 cvmfs_server_migrate() {
   local names
   local retcode=0
@@ -688,6 +718,11 @@ cvmfs_server_migrate() {
 
     if [ "$creator" -lt 143 ] && is_stratum0 $name; then
       _migrate_143 $name
+      creator="$(repository_creator_version $name)"
+    fi
+
+    if [ "$creator" -lt 144 ]; then
+      _migrate_144 $name
       creator="$(repository_creator_version $name)"
     fi
 

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -509,7 +509,7 @@ cvmfs_version_string() {
 
 # Tracks changes to the organization of files and directories.
 # Stored in CVMFS_CREATOR_VERSION.  Started with 137.
-cvmfs_layout_revision() { echo "143"; }
+cvmfs_layout_revision() { echo "144"; }
 
 version_major() { echo $1 | cut --delimiter=. --fields=1 | grep -oe '^[0-9]\+'; }
 version_minor() { echo $1 | cut --delimiter=. --fields=2 | grep -oe '^[0-9]\+'; }

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -449,7 +449,10 @@ int main(int argc, char **argv) {
   }
 
   options_manager_.ParseDefault("");
-  const string fqrn = MkFqrn(device);
+  // A config= option is passed directly to cvmfs2, where it preserves the
+  // device name verbatim.  Do the same here: server repositories may have an
+  // unqualified name and their client.conf need not define a default domain.
+  const string fqrn = config_files_opt.empty() ? MkFqrn(device) : device;
   // Bail in case we could not form a Fqrn
   if (fqrn.empty()) {
     LogCvmfs(kLogCvmfs, kLogStderr | kLogSyslogErr,
@@ -458,11 +461,12 @@ int main(int argc, char **argv) {
   }
   options_manager_.SwitchTemplateManager(
       new DefaultOptionsTemplateManager(fqrn));
-  options_manager_.ParseDefault(fqrn);
 
-  // Parse additional config files specified via config= mount option
-  // (e.g. server-side client.conf). These override the defaults.
-  if (!config_files_opt.empty()) {
+  if (config_files_opt.empty()) {
+    options_manager_.ParseDefault(fqrn);
+  } else {
+    // Match cvmfs2's config= behavior: these files replace the normal
+    // repository configuration and are parsed after the global defaults.
     vector<string> cf = SplitString(config_files_opt, ':');
     for (unsigned i = 0; i < cf.size(); ++i) {
       options_manager_.ParsePath(cf[i], false);

--- a/mount/mount.cvmfs.cc
+++ b/mount/mount.cvmfs.cc
@@ -436,6 +436,18 @@ int main(int argc, char **argv) {
     (void) SwitchCredentials(pw->pw_uid, pw->pw_gid, true);
   }
 
+  // Check mount options for config= parameter (used by server fstab entries)
+  // These config files will be parsed after defaults to override settings
+  string config_files_opt;
+  for (unsigned i = 0; i < mount_options.size(); ++i) {
+    vector<string> tokens = SplitString(mount_options[i], ',');
+    for (unsigned j = 0; j < tokens.size(); ++j) {
+      if (HasPrefix(tokens[j], "config=", false)) {
+        config_files_opt = tokens[j].substr(7);
+      }
+    }
+  }
+
   options_manager_.ParseDefault("");
   const string fqrn = MkFqrn(device);
   // Bail in case we could not form a Fqrn
@@ -447,6 +459,15 @@ int main(int argc, char **argv) {
   options_manager_.SwitchTemplateManager(
       new DefaultOptionsTemplateManager(fqrn));
   options_manager_.ParseDefault(fqrn);
+
+  // Parse additional config files specified via config= mount option
+  // (e.g. server-side client.conf). These override the defaults.
+  if (!config_files_opt.empty()) {
+    vector<string> cf = SplitString(config_files_opt, ':');
+    for (unsigned i = 0; i < cf.size(); ++i) {
+      options_manager_.ParsePath(cf[i], false);
+    }
+  }
 
   if (pw != NULL) {
     (void) SwitchCredentials(0, 0, true);
@@ -637,7 +658,7 @@ int main(int argc, char **argv) {
 #endif
 
   AddMountOption("system_mount", &mount_options);
-  AddMountOption("fsname=cvmfs2", &mount_options);
+  AddMountOption("fsname=" + fqrn, &mount_options);
   AddMountOption("allow_other", &mount_options);
   AddMountOption("grab_mountpoint", &mount_options);
   AddMountOption("uid=" + StringifyInt(uid_cvmfs), &mount_options);


### PR DESCRIPTION
This changes  also the fsname (as shown in mount -l) for the client. fsname is now fqrn, and subtype is cvmfs. As a nice side-effect, this allows to parse cvmfs mount points from the output of mount -l.

Supersedes https://github.com/cvmfs/cvmfs/pull/3903


Co-authored-by: Andriy Utkin <hello@autkin.net>

---

Assisted-by: Claude:claude-3-opus


 ### 1. mount/mount.cvmfs.cc — Make mount helper work for server fstab
 entries

 - Parse config= from mount options: Extract the config=path1:path2 option and parse those config files via `options_manager_.ParsePath()` after the defaults. This allows mount.cvmfs to find CVMFS_HTTP_PROXY, CVMFS_USER, etc. from the server's client.conf.
 - Set `fsname=<fqrn>` instead of `fsname=cvmfs2`, so the repository FQRN appears in mount output.

 ### 2. cvmfs/server/cvmfs_server_common.sh — New fstab format

 - Changed from: `cvmfs2#$name $rdonly_dir fuse allow_other,fsname=$name,config=...`
 - Changed to: `$name $rdonly_dir cvmfs allow_other,config=...`
 - Type cvmfs → invokes mount.cvmfs directly (no mount.fuse/fusermount needed)
 - fsname= removed from options (set automatically by mount.cvmfs and cvmfs2)
 - `cvmfs2#` prefix removed (was a deprecated mount.fuse convention)

 ### 3. cvmfs/loader.cc — Consistent fsname and subtype in the FUSE binary

 - Made MatchFuseOption() available for both libfuse2 and libfuse3 (was #if-guarded to libfuse3 only)
 - Added `fsname=<fqrn>` if not already set by the mount helper
 - Added subtype=cvmfs2 if not already set, so mount shows fuse.cvmfs2 as the type
 - Changed the premount mount() syscall to use repository_name_ as source and fuse.cvmfs2 as type instead of hardcoded "cvmfs2" and "fuse"

 ### 4. cvmfs/server/cvmfs_server_migrate.sh — Migration for existing
 installations

 - Added _migrate_144() which rewrites old fstab entries to the new format
 - Handles both the original cvmfs2#name ... fuse format and the intermediate name ... fuse.cvmfs2 format (from PR #3903)
 - Regenerates systemd mount units after the change

 ### 5. cvmfs/server/cvmfs_server_util.sh — Bump layout revision