### PR TITLE
ducc: singularity dotfile creation directly in overlay

### DIFF
--- a/cvmfs/server/cvmfs_server_overlay.sh
+++ b/cvmfs/server/cvmfs_server_overlay.sh
@@ -86,7 +86,9 @@ cvmfs_server_overlay() {
     -e $hash_algorithm                           \
     -Z $compression_alg                          \
     $(get_swissknife_proxy)                      \
-    $(get_follow_http_redirects_flag)"
+    $(get_follow_http_redirects_flag)             \
+    $([ -n "$oci_config" ] && echo "-c $oci_config") \
+    $([ $skip_singularity -eq 1 ] && echo "-S")"
 
   # ---> do it!
   publish_before_hook $name

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -601,7 +601,7 @@ class SingularitySpoolerSink {
   }
 
   bool GetHash(const string &path, shash::Any *hash) const {
-    map<string, shash::Any>::const_iterator it = hashes_.find(path);
+    const map<string, shash::Any>::const_iterator it = hashes_.find(path);
     if (it == hashes_.end()) return false;
     *hash = it->second;
     return true;
@@ -681,7 +681,7 @@ bool CommandOverlay::InjectSingularityDotfiles(
   // ---------------------------------------------------------------
   // 1.  Parse the OCI image config JSON
   // ---------------------------------------------------------------
-  int fd = open(oci_config_path.c_str(), O_RDONLY);
+  const int fd = open(oci_config_path.c_str(), O_RDONLY);
   if (fd < 0) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "Failed to open OCI config file %s", oci_config_path.c_str());
@@ -696,7 +696,7 @@ bool CommandOverlay::InjectSingularityDotfiles(
   }
   close(fd);
 
-  UniquePtr<JsonDocument> json(JsonDocument::Create(config_json));
+  const UniquePtr<JsonDocument> json(JsonDocument::Create(config_json));
   if (!json.IsValid()) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "Failed to parse OCI config JSON from %s",

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -10,6 +10,7 @@
 
 #include "swissknife_overlay.h"
 
+#include <fcntl.h>
 #include <inttypes.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -18,6 +19,7 @@
 #include <cassert>
 #include <ctime>
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -28,6 +30,8 @@
 #include "compression/compression.h"
 #include "crypto/hash.h"
 #include "directory_entry.h"
+#include "ingestion/ingestion_source.h"
+#include "json_document.h"
 #include "manifest.h"
 #include "network/download.h"
 #include "network/sink_path.h"
@@ -36,6 +40,7 @@
 #include "statistics.h"
 #include "upload.h"
 #include "upload_spooler_definition.h"
+#include "upload_spooler_result.h"
 #include "util/logging.h"
 #include "util/pointer.h"
 #include "util/posix.h"
@@ -67,6 +72,11 @@ ParameterList CommandOverlay::GetParams() const {
                "(default: zlib)"));
   r.push_back(Parameter::Optional('@', "proxy URL"));
   r.push_back(Parameter::Switch('L', "follow HTTP redirects"));
+  r.push_back(Parameter::Optional('c', "OCI image config JSON file path "
+               "(when provided, Singularity .singularity.d dotfiles are "
+               "injected into the merged overlay)"));
+  r.push_back(Parameter::Switch('S', "skip Singularity dotfile injection "
+               "even when an OCI config is provided"));
   return r;
 }
 
@@ -288,6 +298,570 @@ void CommandOverlay::MergeLayer(
   }
 }
 
+
+// ---------------------------------------------------------------------------
+// Singularity dotfile generation
+// ---------------------------------------------------------------------------
+
+// Static file contents for /.singularity.d — these mirror the Go
+// constants in singularity/dotfiles.go (originally from Sylabs/Singularity).
+
+static const char *const kSingExec =
+    "#!/bin/sh\n"
+    "for script in /.singularity.d/env/*.sh; do\n"
+    "    if [ -f \"$script\" ]; then\n"
+    "        . \"$script\"\n"
+    "    fi\n"
+    "done\n"
+    "exec \"$@\"\n";
+
+static const char *const kSingRun =
+    "#!/bin/sh\n"
+    "for script in /.singularity.d/env/*.sh; do\n"
+    "    if [ -f \"$script\" ]; then\n"
+    "        . \"$script\"\n"
+    "    fi\n"
+    "done\n"
+    "if test -n \"${SINGULARITY_APPNAME:-}\"; then\n"
+    "    if test -x \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript\"; then\n"
+    "        exec \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript\" \"$@\"\n"
+    "    else\n"
+    "        echo \"No Singularity runscript for contained app: ${SINGULARITY_APPNAME:-}\"\n"
+    "        exit 1\n"
+    "    fi\n"
+    "elif test -x \"/.singularity.d/runscript\"; then\n"
+    "    exec \"/.singularity.d/runscript\" \"$@\"\n"
+    "else\n"
+    "    echo \"No Singularity runscript found, executing /bin/sh\"\n"
+    "    exec /bin/sh \"$@\"\n"
+    "fi\n";
+
+static const char *const kSingShell =
+    "#!/bin/sh\n"
+    "for script in /.singularity.d/env/*.sh; do\n"
+    "    if [ -f \"$script\" ]; then\n"
+    "        . \"$script\"\n"
+    "    fi\n"
+    "done\n"
+    "if test -n \"$SINGULARITY_SHELL\" -a -x \"$SINGULARITY_SHELL\"; then\n"
+    "    exec $SINGULARITY_SHELL \"$@\"\n"
+    "    echo \"ERROR: Failed running shell as defined by '\\$SINGULARITY_SHELL'\" 1>&2\n"
+    "    exit 1\n"
+    "elif test -x /bin/bash; then\n"
+    "    SHELL=/bin/bash\n"
+    "    PS1=\"Singularity $SINGULARITY_NAME:\\w> \"\n"
+    "    export SHELL PS1\n"
+    "    exec /bin/bash --norc \"$@\"\n"
+    "elif test -x /bin/sh; then\n"
+    "    SHELL=/bin/sh\n"
+    "    export SHELL\n"
+    "    exec /bin/sh \"$@\"\n"
+    "else\n"
+    "    echo \"ERROR: /bin/sh does not exist in container\" 1>&2\n"
+    "fi\n"
+    "exit 1\n";
+
+static const char *const kSingStart =
+    "#!/bin/sh\n"
+    "# if we are here start notify PID 1 to continue\n"
+    "# DON'T REMOVE\n"
+    "kill -CONT 1\n"
+    "for script in /.singularity.d/env/*.sh; do\n"
+    "    if [ -f \"$script\" ]; then\n"
+    "        . \"$script\"\n"
+    "    fi\n"
+    "done\n"
+    "if test -x \"/.singularity.d/startscript\"; then\n"
+    "    exec \"/.singularity.d/startscript\"\n"
+    "fi\n";
+
+static const char *const kSingTest =
+    "#!/bin/sh\n"
+    "for script in /.singularity.d/env/*.sh; do\n"
+    "    if [ -f \"$script\" ]; then\n"
+    "        . \"$script\"\n"
+    "    fi\n"
+    "done\n"
+    "if test -n \"${SINGULARITY_APPNAME:-}\"; then\n"
+    "    if test -x \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/test\"; then\n"
+    "        exec \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/test\" \"$@\"\n"
+    "    else\n"
+    "        echo \"No tests for contained app: ${SINGULARITY_APPNAME:-}\"\n"
+    "        exit 1\n"
+    "    fi\n"
+    "elif test -x \"/.singularity.d/test\"; then\n"
+    "    exec \"/.singularity.d/test\" \"$@\"\n"
+    "else\n"
+    "    echo \"No test found in container, executing /bin/sh -c true\"\n"
+    "    exec /bin/sh -c true\n"
+    "fi\n";
+
+static const char *const kSingEnv01Base =
+    "#!/bin/sh\n"
+    "# \n"
+    "# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.\n"
+    "# Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.\n"
+    "# \n"
+    "# Copyright (c) 2016-2017, The Regents of the University of California,\n"
+    "# through Lawrence Berkeley National Laboratory (subject to receipt of any\n"
+    "# required approvals from the U.S. Dept. of Energy).  All rights reserved.\n"
+    "# \n";
+
+static const char *const kSingEnv90 =
+    "#!/bin/sh\n"
+    "# Custom environment shell code should follow\n";
+
+static const char *const kSingEnv95Apps =
+    "#!/bin/sh\n"
+    "#\n"
+    "# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.\n"
+    "#\n"
+    "if test -n \"${SINGULARITY_APPNAME:-}\"; then\n"
+    "    # The active app should be exported\n"
+    "    export SINGULARITY_APPNAME\n"
+    "    if test -d \"/scif/apps/${SINGULARITY_APPNAME:-}/\"; then\n"
+    "        SCIF_APPS=\"/scif/apps\"\n"
+    "        SCIF_APPROOT=\"/scif/apps/${SINGULARITY_APPNAME:-}\"\n"
+    "        export SCIF_APPROOT SCIF_APPS\n"
+    "        PATH=\"/scif/apps/${SINGULARITY_APPNAME:-}:$PATH\"\n"
+    "        if test -d \"/scif/apps/${SINGULARITY_APPNAME:-}/bin\"; then\n"
+    "            PATH=\"/scif/apps/${SINGULARITY_APPNAME:-}/bin:$PATH\"\n"
+    "        fi\n"
+    "        if test -d \"/scif/apps/${SINGULARITY_APPNAME:-}/lib\"; then\n"
+    "            LD_LIBRARY_PATH=\"/scif/apps/${SINGULARITY_APPNAME:-}/lib:$LD_LIBRARY_PATH\"\n"
+    "            export LD_LIBRARY_PATH\n"
+    "        fi\n"
+    "        if [ -f \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/01-base.sh\" ]; then\n"
+    "            . \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/01-base.sh\"\n"
+    "        fi\n"
+    "        if [ -f \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/90-environment.sh\" ]; then\n"
+    "            . \"/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/90-environment.sh\"\n"
+    "        fi\n"
+    "        export PATH\n"
+    "    else\n"
+    "        echo \"Could not locate the container application: ${SINGULARITY_APPNAME}\"\n"
+    "        exit 1\n"
+    "    fi\n"
+    "fi\n";
+
+static const char *const kSingEnv99Base =
+    "#!/bin/sh\n"
+    "# \n"
+    "# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.\n"
+    "# Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.\n"
+    "# \n"
+    "if [ -z \"$LD_LIBRARY_PATH\" ]; then\n"
+    "    LD_LIBRARY_PATH=\"/.singularity.d/libs\"\n"
+    "else\n"
+    "    LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:/.singularity.d/libs\"\n"
+    "fi\n"
+    "PS1=\"Singularity> \"\n"
+    "export LD_LIBRARY_PATH PS1\n";
+
+static const char *const kSingEnv99Runtimevars =
+    "#!/bin/sh\n"
+    "if [ -n \"${SING_USER_DEFINED_PREPEND_PATH:-}\" ]; then\n"
+    "\tPATH=\"${SING_USER_DEFINED_PREPEND_PATH}:${PATH}\"\n"
+    "fi\n"
+    "if [ -n \"${SING_USER_DEFINED_APPEND_PATH:-}\" ]; then\n"
+    "\tPATH=\"${PATH}:${SING_USER_DEFINED_APPEND_PATH}\"\n"
+    "fi\n"
+    "if [ -n \"${SING_USER_DEFINED_PATH:-}\" ]; then\n"
+    "\tPATH=\"${SING_USER_DEFINED_PATH}\"\n"
+    "fi\n"
+    "unset SING_USER_DEFINED_PREPEND_PATH \\\n"
+    "\t  SING_USER_DEFINED_APPEND_PATH \\\n"
+    "\t  SING_USER_DEFINED_PATH\n"
+    "export PATH\n";
+
+static const char *const kSingStartscript =
+    "#!/bin/sh\n";
+
+
+string CommandOverlay::ShellEscape(const string &s) {
+  string escaped = ReplaceAll(s, "\\", "\\\\");
+  escaped = ReplaceAll(escaped, "\"", "\\\"");
+  escaped = ReplaceAll(escaped, "`", "\\`");
+  escaped = ReplaceAll(escaped, "$", "\\$");
+  return escaped;
+}
+
+
+string CommandOverlay::ArgsQuoted(const vector<string> &args) {
+  string quoted;
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i > 0) quoted += " ";
+    quoted += "\"" + ShellEscape(args[i]) + "\"";
+  }
+  return quoted;
+}
+
+
+string CommandOverlay::GenerateRunscript(
+    const vector<string> &entrypoint,
+    const vector<string> &cmd) {
+  string script = "#!/bin/sh\n";
+  if (!entrypoint.empty()) {
+    script += "OCI_ENTRYPOINT='" + ArgsQuoted(entrypoint) + "'\n";
+  } else {
+    script += "OCI_ENTRYPOINT=''\n";
+  }
+  if (!cmd.empty()) {
+    script += "OCI_CMD='" + ArgsQuoted(cmd) + "'\n";
+  } else {
+    script += "OCI_CMD=''\n";
+  }
+  script +=
+    "CMDLINE_ARGS=\"\"\n"
+    "# prepare command line arguments for evaluation\n"
+    "for arg in \"$@\"; do\n"
+    "    CMDLINE_ARGS=\"${CMDLINE_ARGS} \\\"$arg\\\"\"\n"
+    "done\n"
+    "# ENTRYPOINT only - run entrypoint plus args\n"
+    "if [ -z \"$OCI_CMD\" ] && [ -n \"$OCI_ENTRYPOINT\" ]; then\n"
+    "    if [ $# -gt 0 ]; then\n"
+    "        SINGULARITY_OCI_RUN=\"${OCI_ENTRYPOINT} ${CMDLINE_ARGS}\"\n"
+    "    else\n"
+    "        SINGULARITY_OCI_RUN=\"${OCI_ENTRYPOINT}\"\n"
+    "    fi\n"
+    "fi\n"
+    "# CMD only - run CMD or override with args\n"
+    "if [ -n \"$OCI_CMD\" ] && [ -z \"$OCI_ENTRYPOINT\" ]; then\n"
+    "    if [ $# -gt 0 ]; then\n"
+    "        SINGULARITY_OCI_RUN=\"${CMDLINE_ARGS}\"\n"
+    "    else\n"
+    "        SINGULARITY_OCI_RUN=\"${OCI_CMD}\"\n"
+    "    fi\n"
+    "fi\n"
+    "# ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args\n"
+    "# override with user provided args\n"
+    "if [ $# -gt 0 ]; then\n"
+    "    SINGULARITY_OCI_RUN=\"${OCI_ENTRYPOINT} ${CMDLINE_ARGS}\"\n"
+    "else\n"
+    "    SINGULARITY_OCI_RUN=\"${OCI_ENTRYPOINT} ${OCI_CMD}\"\n"
+    "fi\n"
+    "# Evaluate shell expressions first and set arguments accordingly,\n"
+    "# then execute final command as first container process\n"
+    "eval \"set ${SINGULARITY_OCI_RUN}\"\n"
+    "exec \"$@\"\n";
+  return script;
+}
+
+
+string CommandOverlay::GenerateEnvScript(const vector<string> &env) {
+  string script = "#!/bin/sh\n";
+  for (size_t i = 0; i < env.size(); ++i) {
+    const string &element = env[i];
+    const size_t eq = element.find('=');
+    if (eq == string::npos) {
+      // No '=' — just export empty default
+      script += "export " + element + "=\"${" + element + ":-}\"\n";
+    } else {
+      const string key = element.substr(0, eq);
+      const string val = element.substr(eq + 1);
+      if (key == "PATH") {
+        script += "export PATH=\"" + ShellEscape(val) + "\"\n";
+      } else {
+        script += "export " + key + "=\"${" + key + ":-\""
+                + ShellEscape(val) + "\"}\"\n";
+      }
+    }
+  }
+  return script;
+}
+
+
+OverlayEntry CommandOverlay::MakeDirEntry(const string &path,
+                                          const string &parent) {
+  OverlayEntry oe;
+  oe.path = path;
+  oe.parent = parent;
+  oe.is_whiteout = false;
+  oe.is_opaque_dir = false;
+  oe.entry.name_ = NameString(GetFileName(path));
+  oe.entry.mode_ = S_IFDIR | 0755;
+  oe.entry.uid_ = 0;
+  oe.entry.gid_ = 0;
+  oe.entry.size_ = 4096;
+  oe.entry.mtime_ = time(NULL);
+  oe.entry.linkcount_ = 2;
+  return oe;
+}
+
+
+/**
+ * Helper class to collect spooler results for singularity dotfiles.
+ * Registered as a listener on the spooler, it stores the content hash
+ * for each processed file keyed by path.
+ */
+class SingularitySpoolerSink {
+ public:
+  void OnFileProcessed(const upload::SpoolerResult &result) {
+    hashes_[result.local_path] = result.content_hash;
+  }
+
+  bool GetHash(const string &path, shash::Any *hash) const {
+    map<string, shash::Any>::const_iterator it = hashes_.find(path);
+    if (it == hashes_.end()) return false;
+    *hash = it->second;
+    return true;
+  }
+
+ private:
+  map<string, shash::Any> hashes_;
+};
+
+
+OverlayEntry CommandOverlay::MakeFileEntry(const string &path,
+                                           const string &parent,
+                                           const string &content,
+                                           upload::Spooler *spooler) {
+  // Process the content through the spooler to get a content hash.
+  // We use a StringIngestionSource so no temp file is needed.
+  // The spooler is used in a synchronous fashion: process one file,
+  // wait, then read the result via a temporary listener.
+  SingularitySpoolerSink sink;
+  typename upload::Spooler::CallbackPtr cb = spooler->RegisterListener(
+      &SingularitySpoolerSink::OnFileProcessed, &sink);
+
+  spooler->Process(
+      new StringIngestionSource(content, path),
+      false /* no chunking */);
+  spooler->WaitForUpload();
+  spooler->UnregisterListener(cb);
+
+  shash::Any content_hash;
+  if (!sink.GetHash(path, &content_hash)) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to get content hash for singularity file %s",
+             path.c_str());
+  }
+
+  OverlayEntry oe;
+  oe.path = path;
+  oe.parent = parent;
+  oe.is_whiteout = false;
+  oe.is_opaque_dir = false;
+  oe.entry.name_ = NameString(GetFileName(path));
+  oe.entry.mode_ = S_IFREG | 0755;
+  oe.entry.uid_ = 0;
+  oe.entry.gid_ = 0;
+  oe.entry.size_ = content.size();
+  oe.entry.mtime_ = time(NULL);
+  oe.entry.linkcount_ = 1;
+  oe.entry.checksum_ = content_hash;
+  return oe;
+}
+
+
+OverlayEntry CommandOverlay::MakeSymlinkEntry(const string &path,
+                                              const string &parent,
+                                              const string &target) {
+  OverlayEntry oe;
+  oe.path = path;
+  oe.parent = parent;
+  oe.is_whiteout = false;
+  oe.is_opaque_dir = false;
+  oe.entry.name_ = NameString(GetFileName(path));
+  oe.entry.mode_ = S_IFLNK | 0777;
+  oe.entry.uid_ = 0;
+  oe.entry.gid_ = 0;
+  oe.entry.size_ = target.size();
+  oe.entry.mtime_ = time(NULL);
+  oe.entry.linkcount_ = 1;
+  oe.entry.symlink_ = LinkString(target);
+  return oe;
+}
+
+
+bool CommandOverlay::InjectSingularityDotfiles(
+    const string &oci_config_path,
+    upload::Spooler *spooler,
+    map<string, OverlayEntry> *merged) {
+  // ---------------------------------------------------------------
+  // 1.  Parse the OCI image config JSON
+  // ---------------------------------------------------------------
+  int fd = open(oci_config_path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to open OCI config file %s", oci_config_path.c_str());
+    return false;
+  }
+  string config_json;
+  if (!SafeReadToString(fd, &config_json)) {
+    close(fd);
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to read OCI config from %s", oci_config_path.c_str());
+    return false;
+  }
+  close(fd);
+
+  UniquePtr<JsonDocument> json(JsonDocument::Create(config_json));
+  if (!json.IsValid()) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "Failed to parse OCI config JSON from %s",
+             oci_config_path.c_str());
+    return false;
+  }
+
+  // Extract config.Env, config.Entrypoint, config.Cmd
+  vector<string> entrypoint;
+  vector<string> cmd;
+  vector<string> env;
+
+  const JSON *config_obj =
+      JsonDocument::SearchInObject(json->root(), "config", JSON_OBJECT);
+  if (config_obj != NULL) {
+    const JSON *ep_arr =
+        JsonDocument::SearchInObject(config_obj, "Entrypoint", JSON_ARRAY);
+    if (ep_arr != NULL) {
+      for (JSON::const_iterator it = ep_arr->begin();
+           it != ep_arr->end(); ++it) {
+        if (it->is_string()) entrypoint.push_back(it->get<string>());
+      }
+    }
+    const JSON *cmd_arr =
+        JsonDocument::SearchInObject(config_obj, "Cmd", JSON_ARRAY);
+    if (cmd_arr != NULL) {
+      for (JSON::const_iterator it = cmd_arr->begin();
+           it != cmd_arr->end(); ++it) {
+        if (it->is_string()) cmd.push_back(it->get<string>());
+      }
+    }
+    const JSON *env_arr =
+        JsonDocument::SearchInObject(config_obj, "Env", JSON_ARRAY);
+    if (env_arr != NULL) {
+      for (JSON::const_iterator it = env_arr->begin();
+           it != env_arr->end(); ++it) {
+        if (it->is_string()) env.push_back(it->get<string>());
+      }
+    }
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Injecting Singularity dotfiles (Entrypoint: %zu, Cmd: %zu, "
+           "Env: %zu entries)",
+           entrypoint.size(), cmd.size(), env.size());
+
+  // ---------------------------------------------------------------
+  // 2.  Create directory entries
+  // ---------------------------------------------------------------
+  (*merged)[".singularity.d"] =
+      MakeDirEntry(".singularity.d", "");
+  (*merged)[".singularity.d/libs"] =
+      MakeDirEntry(".singularity.d/libs", ".singularity.d");
+  (*merged)[".singularity.d/actions"] =
+      MakeDirEntry(".singularity.d/actions", ".singularity.d");
+  (*merged)[".singularity.d/env"] =
+      MakeDirEntry(".singularity.d/env", ".singularity.d");
+
+  // Also create common FHS directories if missing
+  const char *fhs_dirs[] = {
+      "dev", "proc", "root", "var", "var/tmp", "tmp", "etc", "sys", "home",
+      NULL};
+  for (int i = 0; fhs_dirs[i] != NULL; ++i) {
+    const string d = fhs_dirs[i];
+    if (merged->find(d) == merged->end()) {
+      const string par = (d.find('/') != string::npos)
+                             ? GetParentPath(d)
+                             : "";
+      (*merged)[d] = MakeDirEntry(d, par);
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // 3.  Create file entries (content is uploaded via spooler)
+  // ---------------------------------------------------------------
+  // Action scripts
+  (*merged)[".singularity.d/actions/exec"] =
+      MakeFileEntry(".singularity.d/actions/exec",
+                    ".singularity.d/actions", kSingExec, spooler);
+  (*merged)[".singularity.d/actions/run"] =
+      MakeFileEntry(".singularity.d/actions/run",
+                    ".singularity.d/actions", kSingRun, spooler);
+  (*merged)[".singularity.d/actions/shell"] =
+      MakeFileEntry(".singularity.d/actions/shell",
+                    ".singularity.d/actions", kSingShell, spooler);
+  (*merged)[".singularity.d/actions/start"] =
+      MakeFileEntry(".singularity.d/actions/start",
+                    ".singularity.d/actions", kSingStart, spooler);
+  (*merged)[".singularity.d/actions/test"] =
+      MakeFileEntry(".singularity.d/actions/test",
+                    ".singularity.d/actions", kSingTest, spooler);
+
+  // Environment scripts
+  (*merged)[".singularity.d/env/01-base.sh"] =
+      MakeFileEntry(".singularity.d/env/01-base.sh",
+                    ".singularity.d/env", kSingEnv01Base, spooler);
+  (*merged)[".singularity.d/env/90-environment.sh"] =
+      MakeFileEntry(".singularity.d/env/90-environment.sh",
+                    ".singularity.d/env", kSingEnv90, spooler);
+  (*merged)[".singularity.d/env/91-environment.sh"] =
+      MakeFileEntry(".singularity.d/env/91-environment.sh",
+                    ".singularity.d/env", kSingEnv90, spooler);
+  (*merged)[".singularity.d/env/95-apps.sh"] =
+      MakeFileEntry(".singularity.d/env/95-apps.sh",
+                    ".singularity.d/env", kSingEnv95Apps, spooler);
+  (*merged)[".singularity.d/env/99-base.sh"] =
+      MakeFileEntry(".singularity.d/env/99-base.sh",
+                    ".singularity.d/env", kSingEnv99Base, spooler);
+  (*merged)[".singularity.d/env/99-runtimevars.sh"] =
+      MakeFileEntry(".singularity.d/env/99-runtimevars.sh",
+                    ".singularity.d/env", kSingEnv99Runtimevars, spooler);
+
+  // OCI-config-dependent files
+  const string runscript = GenerateRunscript(entrypoint, cmd);
+  (*merged)[".singularity.d/runscript"] =
+      MakeFileEntry(".singularity.d/runscript",
+                    ".singularity.d", runscript, spooler);
+  (*merged)[".singularity.d/startscript"] =
+      MakeFileEntry(".singularity.d/startscript",
+                    ".singularity.d", kSingStartscript, spooler);
+
+  const string env_script = GenerateEnvScript(env);
+  (*merged)[".singularity.d/env/10-docker2singularity.sh"] =
+      MakeFileEntry(".singularity.d/env/10-docker2singularity.sh",
+                    ".singularity.d/env", env_script, spooler);
+
+  // ---------------------------------------------------------------
+  // 4.  Create symlinks
+  // ---------------------------------------------------------------
+  // Only create if not already present from a layer
+  if (merged->find("singularity") == merged->end()) {
+    (*merged)["singularity"] =
+        MakeSymlinkEntry("singularity", "",
+                         ".singularity.d/runscript");
+  }
+  if (merged->find(".run") == merged->end()) {
+    (*merged)[".run"] =
+        MakeSymlinkEntry(".run", "",
+                         ".singularity.d/actions/run");
+  }
+  if (merged->find(".shell") == merged->end()) {
+    (*merged)[".shell"] =
+        MakeSymlinkEntry(".shell", "",
+                         ".singularity.d/actions/shell");
+  }
+  if (merged->find(".exec") == merged->end()) {
+    (*merged)[".exec"] =
+        MakeSymlinkEntry(".exec", "",
+                         ".singularity.d/actions/exec");
+  }
+  if (merged->find(".test") == merged->end()) {
+    (*merged)[".test"] =
+        MakeSymlinkEntry(".test", "",
+                         ".singularity.d/actions/test");
+  }
+  if (merged->find("environment") == merged->end()) {
+    (*merged)["environment"] =
+        MakeSymlinkEntry("environment", "",
+                         ".singularity.d/env/90-environment.sh");
+  }
+
+  LogCvmfs(kLogCvmfs, kLogStdout,
+           "Injected Singularity dotfiles into merged overlay");
+  return true;
+}
 
 
 bool CommandOverlay::PublishMergedEntries(
@@ -552,6 +1126,10 @@ int CommandOverlay::Main(const ArgumentList &args) {
         *args.find('Z')->second);
   }
 
+  const string oci_config_path =
+      (args.count('c') > 0) ? *args.find('c')->second : "";
+  const bool skip_singularity = (args.count('S') > 0);
+
   // Parse comma-separated layer paths
   const vector<string> layers = SplitString(layers_str, ',');
   if (layers.empty()) {
@@ -715,6 +1293,15 @@ int CommandOverlay::Main(const ArgumentList &args) {
   }
 
   delete root_catalog;
+
+  // Inject Singularity dotfiles if requested
+  if (!oci_config_path.empty() && !skip_singularity) {
+    if (!InjectSingularityDotfiles(oci_config_path,
+                                   spooler_files.weak_ref(), &merged)) {
+      PrintError("Failed to inject Singularity dotfiles");
+      return 4;
+    }
+  }
 
   // Set up WritableCatalogManager and publish merged entries
   LogCvmfs(kLogCvmfs, kLogStdout,

--- a/cvmfs/swissknife_overlay.h
+++ b/cvmfs/swissknife_overlay.h
@@ -25,6 +25,7 @@
 #include "directory_entry.h"
 #include "shortstring.h"
 #include "swissknife.h"
+#include "upload.h"
 #include "xattr.h"
 
 namespace swissknife {
@@ -130,6 +131,69 @@ class CommandOverlay : public Command {
       catalog::Catalog *root_catalog,
       const std::string &layer_path,
       std::vector<catalog::Catalog *> *loaded_catalogs);
+
+  /**
+   * Parse an OCI image config JSON file and inject Singularity
+   * compatibility dotfiles (.singularity.d/) into the merged overlay
+   * entries.  The generated files include the base environment,
+   * action scripts, runscript (from Entrypoint/Cmd) and environment
+   * variables (from Env).
+   *
+   * File content is uploaded through the spooler so that content hashes
+   * are available for the catalog entries.
+   *
+   * Returns false on error.
+   */
+  bool InjectSingularityDotfiles(
+      const std::string &oci_config_path,
+      upload::Spooler *spooler,
+      std::map<std::string, OverlayEntry> *merged);
+
+  /**
+   * Helper: create an OverlayEntry for a directory.
+   */
+  static OverlayEntry MakeDirEntry(const std::string &path,
+                                   const std::string &parent);
+
+  /**
+   * Helper: create an OverlayEntry for a regular file, uploading
+   * its content through the spooler and blocking until the content
+   * hash is available.
+   */
+  static OverlayEntry MakeFileEntry(const std::string &path,
+                                    const std::string &parent,
+                                    const std::string &content,
+                                    upload::Spooler *spooler);
+
+  /**
+   * Helper: create an OverlayEntry for a symlink.
+   */
+  static OverlayEntry MakeSymlinkEntry(const std::string &path,
+                                       const std::string &parent,
+                                       const std::string &target);
+
+  /**
+   * Shell-escape a string (escape backslash, double-quote, backtick, $).
+   */
+  static std::string ShellEscape(const std::string &s);
+
+  /**
+   * Quote a list of shell args.
+   */
+  static std::string ArgsQuoted(const std::vector<std::string> &args);
+
+  /**
+   * Generate the content of the runscript from OCI Entrypoint and Cmd.
+   */
+  static std::string GenerateRunscript(
+      const std::vector<std::string> &entrypoint,
+      const std::vector<std::string> &cmd);
+
+  /**
+   * Generate the content of env/10-docker2singularity.sh from OCI Env.
+   */
+  static std::string GenerateEnvScript(
+      const std::vector<std::string> &env);
 };
 
 }  // namespace swissknife

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -97,23 +97,49 @@ if [ "$1" == "ingest" ]; then
   fi
 fi
 
-# cvmfs_server overlay -l <layers> -d <dest> <repo>
-# Mock: just create the destination directory
+# cvmfs_server overlay -l <layers> -d <dest> [-c <oci_config>] [-S] <repo>
+# Mock: just create the destination directory and optionally singularity dotfiles
 if [ "$1" == "overlay" ]; then
   shift
   layers=""
   dest=""
+  oci_config=""
+  skip_singularity=0
+  repo=""
   while [ $# -gt 0 ]; do
     case "$1" in
       -l) layers="$2"; shift 2 ;;
       -d) dest="$2"; shift 2 ;;
+      -c) oci_config="$2"; shift 2 ;;
+      -S) skip_singularity=1; shift ;;
       *)  repo="$1"; shift ;;
     esac
   done
-  echo "overlay: layers=$layers dest=$dest repo=$repo"
+  echo "overlay: layers=$layers dest=$dest repo=$repo oci_config=$oci_config skip_singularity=$skip_singularity"
   mkdir -p "$CVMFS_TEST_REPO/$dest"
   # Write a marker file so tests can verify the overlay was called
   echo "layers=$layers" > "$CVMFS_TEST_REPO/$dest/.overlay_marker"
+  # If OCI config is provided and singularity is not skipped, create dotfiles
+  if [ -n "$oci_config" ] && [ $skip_singularity -eq 0 ]; then
+    mkdir -p "$CVMFS_TEST_REPO/$dest/.singularity.d/libs"
+    mkdir -p "$CVMFS_TEST_REPO/$dest/.singularity.d/actions"
+    mkdir -p "$CVMFS_TEST_REPO/$dest/.singularity.d/env"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/runscript"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/startscript"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/actions/exec"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/actions/run"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/actions/shell"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/actions/start"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/actions/test"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/01-base.sh"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/10-docker2singularity.sh"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/90-environment.sh"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/91-environment.sh"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/95-apps.sh"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/99-base.sh"
+    echo '#!/bin/sh' > "$CVMFS_TEST_REPO/$dest/.singularity.d/env/99-runtimevars.sh"
+    echo "oci_config=$oci_config" >> "$CVMFS_TEST_REPO/$dest/.overlay_marker"
+  fi
 fi
 
 # cvmfs_server ingest --catalog -t - -b <dir> <repo>

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -592,10 +592,10 @@ func removeHashMarkerIfPresent(digest string) string {
 // order (base layer first). The destPath is the path inside the CVMFS repository
 // where the merged result will be placed (without the /cvmfs/$REPO prefix).
 func Overlay(CVMFSRepo string, layerPaths []string, destPath string) error {
-	return OverlayWithLogger(nil, CVMFSRepo, layerPaths, destPath)
+	return OverlayWithLogger(nil, CVMFSRepo, layerPaths, destPath, "", false)
 }
 
-func OverlayWithLogger(logger *log.Entry, CVMFSRepo string, layerPaths []string, destPath string) error {
+func OverlayWithLogger(logger *log.Entry, CVMFSRepo string, layerPaths []string, destPath string, ociConfigPath string, skipSingularity bool) error {
 	logger = l.Ensure(logger)
 	if len(layerPaths) == 0 {
 		return fmt.Errorf("no layer paths provided for overlay")
@@ -619,8 +619,16 @@ func OverlayWithLogger(logger *log.Entry, CVMFSRepo string, layerPaths []string,
 
 	args := []string{"cvmfs_server", "overlay",
 		"-l", layers,
-		"-d", destPath,
-		CVMFSRepo}
+		"-d", destPath}
+
+	if ociConfigPath != "" {
+		args = append(args, "-c", ociConfigPath)
+	}
+	if skipSingularity {
+		args = append(args, "-S")
+	}
+
+	args = append(args, CVMFSRepo)
 
 	err := exec.ExecCommandWithLogger(llog(logger), args...).Start()
 	if err != nil {

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -250,3 +250,17 @@ func IngestDeleteWithLogger(logger *log.Entry, CVMFSRepo string, path string) er
 	defer unlock(CVMFSRepo)
 	return exec.ExecCommandWithLogger(ingestLogger, "cvmfs_server", "ingest", "--delete", path, repoName).Start()
 }
+
+func IngestFastDelete(CVMFSRepo string, path string) error {
+	return IngestFastDeleteWithLogger(nil, CVMFSRepo, path)
+}
+
+func IngestFastDeleteWithLogger(logger *log.Entry, CVMFSRepo string, path string) error {
+	logger = l.Ensure(logger)
+	ingestLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "ingest fast-delete", "path": path})
+	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
+	path = PrefixRepoSubdirOnce(CVMFSRepo, path)
+	getLock(CVMFSRepo)
+	defer unlock(CVMFSRepo)
+	return exec.ExecCommandWithLogger(ingestLogger, "cvmfs_server", "ingest", "--fast-delete", path, repoName).Start()
+}

--- a/ducc/go.mod
+++ b/ducc/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/rubyist/lockfile v0.0.0-20140818014254-a66de41d77a7
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/sys v0.42.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -62,8 +63,9 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/tools v0.42.0 // indirect
+	modernc.org/libc v1.70.0 // indirect
+	modernc.org/mathutil v1.7.1 // indirect
+	modernc.org/memory v1.11.0 // indirect
 )
 
 go 1.25.0

--- a/ducc/go.sum
+++ b/ducc/go.sum
@@ -55,6 +55,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -176,6 +178,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -19,7 +19,6 @@ import (
 	da "github.com/cvmfs/ducc/docker-api"
 	l "github.com/cvmfs/ducc/log"
 	notification "github.com/cvmfs/ducc/notification"
-	singularity "github.com/cvmfs/ducc/singularity"
 	temp "github.com/cvmfs/ducc/temp"
 
 	dockerImage "github.com/docker/docker/api/types/image"
@@ -370,49 +369,49 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			i.Action("start_flat_overlay_conversion").Send()
 			i = i.Action("end_flat_overlay_conversion")
 
-			// Use cvmfs_server overlay to merge layers into a flat image
-			_, err = inputImage.CreateFlatOverlayWithLogger(imageLogger, wish.CvmfsRepo)
+			// Download the OCI config JSON and write it to a temp file
+			// so that the overlay command can inject Singularity dotfiles
+			// atomically in the same transaction.
+			ociConfigBytes, err := inputImage.GetRawConfigBytes()
+			if err != nil {
+				if firstError == nil {
+					firstError = err
+				}
+				l.LogE(err).Error("Error in getting the OCI image config")
+				i.Error(err).Elapsed(t1).Send()
+				continue
+			}
+			ociConfigFile, err := os.CreateTemp("", "ducc-oci-config-*.json")
+			if err != nil {
+				if firstError == nil {
+					firstError = err
+				}
+				l.LogE(err).Error("Error creating temp file for OCI config")
+				i.Error(err).Elapsed(t1).Send()
+				continue
+			}
+			_, err = ociConfigFile.Write(ociConfigBytes)
+			ociConfigFile.Close()
+			if err != nil {
+				os.Remove(ociConfigFile.Name())
+				if firstError == nil {
+					firstError = err
+				}
+				l.LogE(err).Error("Error writing OCI config temp file")
+				i.Error(err).Elapsed(t1).Send()
+				continue
+			}
+			defer os.Remove(ociConfigFile.Name())
+
+			// Use cvmfs_server overlay to merge layers into a flat image.
+			// The OCI config is passed so that Singularity dotfiles are
+			// created in the same atomic transaction as the overlay itself.
+			_, err = inputImage.CreateFlatOverlayWithLogger(imageLogger, wish.CvmfsRepo, ociConfigFile.Name(), false)
 			if err != nil {
 				if firstError == nil {
 					firstError = err
 				}
 				imageLogger.WithField("error", err).Error("Error in creating the flat overlay")
-				i.Error(err).Elapsed(t1).Send()
-				continue
-			}
-
-			ociImage, err := inputImage.GetOCIImage()
-			if err != nil {
-				if firstError == nil {
-					firstError = err
-				}
-				l.LogE(err).Error("Error in getting the OCI image configuration")
-				i.Error(err).Elapsed(t1).Send()
-				continue
-			}
-			// we create the singularity dotfiles inside the flat overlay result
-			err = cvmfs.WithinTransaction(wish.CvmfsRepo,
-				func() error {
-					if err := singularity.MakeBaseEnv(completeSingularityPriPath); err != nil {
-						imageLogger.WithField("error", err).Error("Error in creating the base singularity environment")
-						return err
-					}
-					if err := singularity.InsertRunScript(completeSingularityPriPath, ociImage); err != nil {
-						imageLogger.WithField("error", err).Error("Error in inserting the singularity runscript")
-						return err
-					}
-					if err := singularity.InsertEnv(completeSingularityPriPath, ociImage); err != nil {
-						imageLogger.WithField("error", err).Error("Error in inserting the singularity environment")
-						return err
-					}
-					return nil
-				})
-
-			if err != nil {
-				if firstError == nil {
-					firstError = err
-				}
-				imageLogger.WithField("error", err).Error("Error in creating the dotfile inside the flat directory")
 				i.Error(err).Elapsed(t1).Send()
 				continue
 			}

--- a/ducc/lib/conversion.go
+++ b/ducc/lib/conversion.go
@@ -268,6 +268,41 @@ func ConvertWishFlat(wish WishFriendly, multiArch bool) error {
 			completeSingularityPriPath := filepath.Join("/", "cvmfs", wish.CvmfsRepo, singularityPrivatePath)
 			priDirInfo, errPri := os.Stat(completeSingularityPriPath)
 
+			// Validate the flat image: if the private path exists, check that
+			// it contains a .singularity.d directory.  Also check that the
+			// public symlink actually resolves (is not dangling).  If either
+			// check fails, delete the incomplete flat image with fast-delete
+			// and force a re-creation of the overlay.
+			if errPri == nil {
+				singDirPath := filepath.Join(completeSingularityPriPath, ".singularity.d")
+				if _, errSingDir := os.Stat(singDirPath); errSingDir != nil {
+					imageLogger.WithFields(log.Fields{
+						"flat path":       completeSingularityPriPath,
+						"singularity dir": singDirPath,
+					}).Warn("Flat image exists but is incomplete (missing .singularity.d), deleting and re-creating")
+					if delErr := cvmfs.IngestFastDeleteWithLogger(imageLogger, wish.CvmfsRepo, singularityPrivatePath); delErr != nil {
+						imageLogger.WithField("error", delErr).Error("Error deleting incomplete flat image")
+						if firstError == nil {
+							firstError = delErr
+						}
+						continue
+					}
+					// Reset stat results so we fall through to the overlay creation below
+					errPri = fmt.Errorf("flat image deleted (was incomplete)")
+					priDirInfo = nil
+				}
+			}
+			// Check for a dangling public symlink (Lstat succeeds but Stat failed)
+			if errPub != nil && !os.IsNotExist(errPub) {
+				// Stat failed for a reason other than not-exist; could be a dangling symlink
+				if _, errLstat := os.Lstat(completePubSymPath); errLstat == nil {
+					imageLogger.WithField("symlink", completePubSymPath).
+						Warn("Public symlink is dangling, will re-create flat image")
+					// The flat image is already gone (errPri would be non-nil too),
+					// so we just fall through to the overlay path.
+				}
+			}
+
 			imageLogger.WithFields(log.Fields{
 				"public path":            completePubSymPath,
 				"err stats public path":  errPub,

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -1297,11 +1297,14 @@ func (ld *LayerDownloader) DownloadAndIngestWithLogger(logger *log.Entry, CVMFSR
 // CreateFlatOverlay uses cvmfs_server overlay to merge all image layers into a
 // flat filesystem. It returns the singularity path (relative to /cvmfs/$REPO)
 // where the merged image is placed.
-func (img *Image) CreateFlatOverlay(CVMFSRepo string) (singularityPath string, err error) {
-	return img.CreateFlatOverlayWithLogger(nil, CVMFSRepo)
+// When ociConfigPath is non-empty, it is passed to the overlay command so that
+// Singularity .singularity.d dotfiles are created atomically as part of the
+// same transaction.
+func (img *Image) CreateFlatOverlay(CVMFSRepo string, ociConfigPath string) (singularityPath string, err error) {
+	return img.CreateFlatOverlayWithLogger(nil, CVMFSRepo, ociConfigPath, false)
 }
 
-func (img *Image) CreateFlatOverlayWithLogger(logger *log.Entry, CVMFSRepo string) (singularityPath string, err error) {
+func (img *Image) CreateFlatOverlayWithLogger(logger *log.Entry, CVMFSRepo string, ociConfigPath string, skipSingularity bool) (singularityPath string, err error) {
 	logger = l.Ensure(logger)
 	manifest, err := img.GetManifest()
 	if err != nil {
@@ -1331,7 +1334,7 @@ func (img *Image) CreateFlatOverlayWithLogger(logger *log.Entry, CVMFSRepo strin
 	t := time.Now()
 	n.AddField("action", "start_overlay_merge").Send()
 
-	err = cvmfs.OverlayWithLogger(logger, CVMFSRepo, layerPaths, singularityPath)
+	err = cvmfs.OverlayWithLogger(logger, CVMFSRepo, layerPaths, singularityPath, ociConfigPath, skipSingularity)
 
 	n.Elapsed(t).
 		AddField("action", "end_overlay_merge").


### PR DESCRIPTION
Following a major cleanup of unpacked.cern.ch ( cvmfs_ducc prune-images, cvmfs_ducc gc, cvmfs_server gc), several images had their singularity dotfiles missing. This breaks the workflow for users and is not yet understood unfortunately. This PR adds a check that the dotfiles exist as a safeguard, and will re-publish the image if necessary. It also moves the creation of the dotfiles to the cvmfs_server overlay command, further reducing the number of transactions it takes to create one image.