### PR TITLE
unittests: correct T_CacheManager.Dup, add T_CacheManager.DupRefcounted

### DIFF
--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -35,7 +35,16 @@ class T_CacheManager : public ::testing::Test {
     alien_cache_mgr_ = PosixCacheManager::Create(tmp_path_, true);
     ASSERT_TRUE(alien_cache_mgr_ != NULL);
 
+    refcounted_mgr_tmp_path_ = CreateTempDir("./cvmfs_ut_refcounted_cache_manager");
+    refcounted_cache_mgr_ = PosixCacheManager::Create(
+        refcounted_mgr_tmp_path_, /*alien_cache=*/false,
+        /*rename_workaround=*/PosixCacheManager::kRenameNormal,
+        /*do_refcount=*/true);
+    ASSERT_TRUE(refcounted_cache_mgr_ != NULL);
+
     ASSERT_TRUE(cache_mgr_->CommitFromMem(
+        CacheManager::LabeledObject(hash_null_), NULL, 0));
+    ASSERT_TRUE(refcounted_cache_mgr_->CommitFromMem(
         CacheManager::LabeledObject(hash_null_), NULL, 0));
     unsigned char buf = 'A';
     hash_one_.digest[0] = 1;
@@ -54,6 +63,7 @@ class T_CacheManager : public ::testing::Test {
   virtual void TearDown() {
     delete cache_mgr_;
     delete alien_cache_mgr_;
+    delete refcounted_cache_mgr_;
 
     // Empty transaction tmp path
     platform_stat64 info;
@@ -103,7 +113,9 @@ class T_CacheManager : public ::testing::Test {
  protected:
   PosixCacheManager *cache_mgr_;
   PosixCacheManager *alien_cache_mgr_;
+  PosixCacheManager *refcounted_cache_mgr_;
   string tmp_path_;
+  string refcounted_mgr_tmp_path_;
   shash::Any hash_null_;
   shash::Any hash_one_;
   shash::Any hash_page_;
@@ -608,9 +620,21 @@ TEST_F(T_CacheManager, Dup) {
   int fd = cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
   EXPECT_GE(fd, 0);
   int fd_dup = cache_mgr_->Dup(fd);
-  EXPECT_EQ(fd, fd_dup);
+  EXPECT_NE(fd, fd_dup);
   EXPECT_EQ(0, cache_mgr_->Close(fd));
   EXPECT_EQ(0, cache_mgr_->Close(fd_dup));
+}
+
+
+TEST_F(T_CacheManager, DupRefcounted) {
+  EXPECT_EQ(-EBADF, refcounted_cache_mgr_->Dup(-1));
+  int fd = refcounted_cache_mgr_->Open(CacheManager::LabeledObject(hash_null_));
+  EXPECT_GE(fd, 0);
+  int fd_dup = refcounted_cache_mgr_->Dup(fd);
+  EXPECT_EQ(fd, fd_dup);
+  EXPECT_EQ(0, refcounted_cache_mgr_->Close(fd));
+  EXPECT_EQ(0, refcounted_cache_mgr_->Close(fd_dup));
+  EXPECT_NE(0, refcounted_cache_mgr_->Close(fd_dup));
 }
 
 


### PR DESCRIPTION
T_CacheManager.Dup fails, as I would expect from the code, because cache_mgr_ is created with disabled refcounting (which makes it possible to get the same fd instead of the new one).

/usr/local/src/cvmfs/test/unittests/t_cache.cc:621: Failure Expected equality of these values:
  fd
    Which is: 3
  fd_dup
    Which is: 4