### PR TITLE
unittests: fix bug crashing T_CacheManager.TearDown2ReadOnlyTimeout intermittently

### DIFF
--- a/test/unittests/t_cache.cc
+++ b/test/unittests/t_cache.cc
@@ -94,6 +94,7 @@ class T_CacheManager : public ::testing::Test {
     if (sum_ms > timeout_ms) {
       retval = pthread_cancel(thread_teardown);
       assert(retval == 0);
+      pthread_join(thread_teardown, NULL);
       return true;
     }
     pthread_join(thread_teardown, 0);
@@ -842,6 +843,7 @@ TEST_F(T_CacheManager, TearDown2ReadOnly) {
     pthread_join(thread_teardown, NULL);
   else
     pthread_cancel(thread_teardown);
+    pthread_join(thread_teardown, NULL);
 }
 
 


### PR DESCRIPTION
TearDownTimedOut() does pthread_cancel() on teardown thread and doesn't wait for it to terminate with pthread_join() as should be. Because of this, the thread invoking pthread_cancel() goes on to abort the transaction and end the execution of the entire test, including destruction of cache_mgr_.

The other thread may still be executing, and, once the transaction has been aborted, it exits its waiting loop and proceeds to delete the cache manager one more time.