### PR TITLE
micro-benchmarks: fix build errors

### DIFF
--- a/test/micro-benchmarks/CMakeLists.txt
+++ b/test/micro-benchmarks/CMakeLists.txt
@@ -29,6 +29,7 @@ set (CVMFS_UBENCHMARKS_SOURCES
   ${CVMFS_SOURCE_DIR}/cache_transport.cc
   ${CVMFS_SOURCE_DIR}/catalog.cc
   ${CVMFS_SOURCE_DIR}/catalog_counters.cc
+  ${CVMFS_SOURCE_DIR}/catalog_downloader.cc
   ${CVMFS_SOURCE_DIR}/catalog_mgr_ro.cc
   ${CVMFS_SOURCE_DIR}/catalog_mgr_rw.cc
   ${CVMFS_SOURCE_DIR}/catalog_rw.cc
@@ -66,7 +67,6 @@ set (CVMFS_UBENCHMARKS_SOURCES
   ${CVMFS_SOURCE_DIR}/network/sink_path.cc
   ${CVMFS_SOURCE_DIR}/options.cc
   ${CVMFS_SOURCE_DIR}/pack.cc
-  ${CVMFS_SOURCE_DIR}/receiver/lease_path_util.cc
   ${CVMFS_SOURCE_DIR}/reflog.cc
   ${CVMFS_SOURCE_DIR}/reflog_sql.cc
   ${CVMFS_SOURCE_DIR}/upload_facility.cc
@@ -86,6 +86,7 @@ set (CVMFS_UBENCHMARKS_SOURCES
   ${CVMFS_SOURCE_DIR}/swissknife_lease_curl.cc
   ${CVMFS_SOURCE_DIR}/upload.cc
   ${CVMFS_SOURCE_DIR}/util/algorithm.cc
+  ${CVMFS_SOURCE_DIR}/util/capabilities.cc
   ${CVMFS_SOURCE_DIR}/util/concurrency.cc
   ${CVMFS_SOURCE_DIR}/util/exception.cc
   ${CVMFS_SOURCE_DIR}/util/file_backed_buffer.cc
@@ -138,6 +139,10 @@ set (UBENCHMARKS_LINK_LIBRARIES ${GOOGLEBENCH_LIBRARIES}
                                 ${ZLIB_LIBRARIES}
                                 ${RT_LIBRARY}
                                 ${SQLITE3_LIBRARY}
+                                ${CAP_LIBRARIES}
+                                GTest::gmock
+                                GTest::gtest
+                                LibArchive::LibArchive
                                 nlohmann_json::nlohmann_json
                                 pthread dl)
 


### PR DESCRIPTION
```
CMake Error at test/micro-benchmarks/CMakeLists.txt:123 (add_executable):
  Cannot find source file:

    /usr/local/src/cvmfs/cvmfs/receiver/lease_path_util.cc
```
```
[100%] Linking CXX executable cvmfs_ubenchmarks
...
/usr/local/src/cvmfs/test/common/catalog_test_tools.cc:659:(.text+0x5a4d): undefined reference to `testing::Message::Message()' /usr/bin/ld: /usr/local/src/cvmfs/test/common/catalog_test_tools.cc:659:(.text+0x5a6a): undefined reference to `testing::internal::GetBoolAssertionFailureMessage[abi:cxx11](testing::AssertionResult const&, char const*, char const*, char const*)' /usr/bin/ld: /usr/local/src/cvmfs/test/common/catalog_test_tools.cc:659:(.text+0x5a86): undefined reference to `testing::internal::AssertHelper::AssertHelper(testing::TestPartResult::Type, char const*, int, char const*)' /usr/bin/ld: /usr/local/src/cvmfs/test/common/catalog_test_tools.cc:659:(.text+0x5a96): undefined reference to `testing::internal::AssertHelper::operator=(testing::Message const&) const' /usr/bin/ld: /usr/local/src/cvmfs/test/common/catalog_test_tools.cc:659:(.text+0x5a9f): undefined reference to `testing::internal::AssertHelper::~AssertHelper()' /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1673:(.text+0x8679): undefined reference to `CatalogDownloadPipeline::CatalogDownloadPipeline(catalog::SimpleCatalogManager*)' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1677:(.text+0x86c4): undefined reference to `CatalogDownloadPipeline::Spawn()' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1692:(.text+0x882a): undefined reference to `CatalogDownloadPipeline::Process(shash::Any const&)' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/catalog_mgr_rw.cc:1696:(.text+0x886d): undefined reference to `CatalogDownloadPipeline::WaitFor()' /usr/local/src/cvmfs/cvmfs/monitor.cc:411:(.text+0x5b4): undefined reference to `SetuidCapabilityPermitted()' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/monitor.cc:433:(.text+0x5de): undefined reference to `ClearPermittedCapabilities(std::vector<int, std::allocator<int> > const&, std::vector<int, std::allocator<int> > const&)' /usr/local/src/cvmfs/cvmfs/network/jobinfo.cc:212:(.text+0xa2a): undefined reference to `ObtainDacReadSearchCapability()' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/network/jobinfo.cc:213:(.text+0xa2f): undefined reference to `ObtainSysPtraceCapability()' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/network/jobinfo.cc:245:(.text+0xc7c): undefined reference to `DropSysPtraceCapability()' /usr/bin/ld: /usr/local/src/cvmfs/cvmfs/network/jobinfo.cc:246:(.text+0xc81): undefined reference to `DropDacReadSearchCapability()' /usr/local/src/cvmfs/cvmfs/util/posix.cc:810:(.text+0x298f): undefined reference to `ObtainSetuidgidCapabilities(bool)'
```

I got it to run now but these assertion failures are a bit worrying:
```
[root@a65d836267df cvmfs]# test/micro-benchmarks/cvmfs_ubenchmarks
2026-04-28T13:36:46+00:00
Running test/micro-benchmarks/cvmfs_ubenchmarks
Run on (56 X 2394.65 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x56)
  L1 Instruction 32 KiB (x56)
  L2 Unified 4096 KiB (x56)
  L3 Unified 16384 KiB (x1)
Load Average: 1.44, 1.39, 1.04
/usr/local/src/cvmfs/test/common/catalog_test_tools.cc:514: Failure
Value of: signature_mgr->KeysMatch()
  Actual: false
Expected: true

Note: Catalog at /dir/1/2/3/4 gets defragmented (33.33% wasted row IDs)... done
Note: Catalog at /dir/1/2/3 gets defragmented (55.56% wasted row IDs)... done
Note: Catalog at /dir/1/2 gets defragmented (66.67% wasted row IDs)... done
Note: Catalog at /dir/1 gets defragmented (73.33% wasted row IDs)... done
/usr/local/src/cvmfs/test/common/catalog_test_tools.cc:514: Failure
Value of: signature_mgr->KeysMatch()
  Actual: false
Expected: true

Note: Catalog at /dir/1/2/3/4 gets defragmented (33.33% wasted row IDs)... done
Note: Catalog at /dir/1/2/3 gets defragmented (55.56% wasted row IDs)... done
Note: Catalog at /dir/1/2 gets defragmented (66.67% wasted row IDs)... done
Note: Catalog at /dir/1 gets defragmented (73.33% wasted row IDs)... done
/usr/local/src/cvmfs/test/common/catalog_test_tools.cc:514: Failure
Value of: signature_mgr->KeysMatch()
  Actual: false
Expected: true
```