### PR TITLE
Make RepoMetainfoMagicXattr::kMaxMetainfoLength const

### DIFF
--- a/cvmfs/magic_xattr.cc
+++ b/cvmfs/magic_xattr.cc
@@ -653,7 +653,7 @@ void RepoCountersMagicXattr::FinalizeValue() {
   result_pages_.push_back(counters_.GetCsvMap());
 }
 
-uint64_t RepoMetainfoMagicXattr::kMaxMetainfoLength = 65536;
+const uint64_t RepoMetainfoMagicXattr::kMaxMetainfoLength = 65536;
 
 bool RepoMetainfoMagicXattr::PrepareValueFenced() {
   if (!xattr_mgr_->mount_point()->catalog_mgr()->manifest()) {

--- a/cvmfs/magic_xattr.h
+++ b/cvmfs/magic_xattr.h
@@ -427,7 +427,7 @@ class RepoCountersMagicXattr : public BaseMagicXattr {
 };
 
 class RepoMetainfoMagicXattr : public BaseMagicXattr {
-  static uint64_t kMaxMetainfoLength;
+  static const uint64_t kMaxMetainfoLength;
 
   shash::Any metainfo_hash_;
   std::string error_reason_;


### PR DESCRIPTION
Fix the compilation warning:

/usr/local/src/cvmfs/cvmfs/magic_xattr.cc:700:15: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  700 |   char buffer[kMaxMetainfoLength];
      |               ^~~~~~~~~~~~~~~~~~
/usr/local/src/cvmfs/cvmfs/magic_xattr.cc:700:15: note: read of non-const variable 'kMaxMetainfoLength' is not allowed in a constant expression
/usr/local/src/cvmfs/cvmfs/magic_xattr.cc:656:34: note: declared here
  656 | uint64_t RepoMetainfoMagicXattr::kMaxMetainfoLength = 65536;
      |                                  ^
1 warning generated.