### PR TITLE
cleanup: remove __STDC_FORMAT_MACROS definition

### DIFF
--- a/add-ons/test_libcvmfs.cc
+++ b/add-ons/test_libcvmfs.cc
@@ -9,8 +9,6 @@
  * proper set of symbols to be used by a C program.
  */
 
-#define __STDC_FORMAT_MACROS
-
 
 #include <errno.h>
 #include <inttypes.h>

--- a/cvmfs/authz/authz_curl.cc
+++ b/cvmfs/authz/authz_curl.cc
@@ -1,7 +1,6 @@
 /**
  * This file is part of the CernVM File System.
  */
-#define __STDC_FORMAT_MACROS
 #include "authz_curl.h"
 
 #include <openssl/err.h>

--- a/cvmfs/authz/authz_fetch.cc
+++ b/cvmfs/authz/authz_fetch.cc
@@ -2,7 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
 #include "authz_fetch.h"
 
 #include <errno.h>

--- a/cvmfs/authz/authz_session.cc
+++ b/cvmfs/authz/authz_session.cc
@@ -2,7 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
 #include "authz_session.h"
 
 #include <errno.h>

--- a/cvmfs/cache.h
+++ b/cvmfs/cache.h
@@ -5,10 +5,6 @@
 #ifndef CVMFS_CACHE_H_
 #define CVMFS_CACHE_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <stdint.h>
 
 #include <string>

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -4,10 +4,6 @@
 #ifndef CVMFS_CACHE_EXTERN_H_
 #define CVMFS_CACHE_EXTERN_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <pthread.h>
 #include <stdint.h>
 #include <unistd.h>

--- a/cvmfs/cache_plugin/cvmfs_cache_null.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_null.cc
@@ -5,8 +5,6 @@
  * complete but quite inefficient.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include <alloca.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/cvmfs/cache_plugin/cvmfs_cache_ram.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_ram.cc
@@ -4,8 +4,6 @@
  * A cache plugin that stores all data in a fixed-size memory chunk.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include <alloca.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/cvmfs/cache_plugin/libcvmfs_cache.cc
+++ b/cvmfs/cache_plugin/libcvmfs_cache.cc
@@ -3,7 +3,6 @@
  */
 
 #define _FILE_OFFSET_BITS 64
-#define __STDC_FORMAT_MACROS
 
 
 #include "libcvmfs_cache.h"

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -24,9 +24,6 @@
  * the download and informs the other, waiting threads on pipes.
  */
 
-#define __STDC_FORMAT_MACROS
-
-
 #include "cache_posix.h"
 
 #include <dirent.h>

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -5,10 +5,6 @@
 #ifndef CVMFS_CATALOG_MGR_H_
 #define CVMFS_CATALOG_MGR_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <pthread.h>
 

--- a/cvmfs/catalog_mgr_impl.h
+++ b/cvmfs/catalog_mgr_impl.h
@@ -6,10 +6,6 @@
 #ifndef CVMFS_CATALOG_MGR_IMPL_H_
 #define CVMFS_CATALOG_MGR_IMPL_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 
 #include <cassert>
 #include <string>

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM file system.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "catalog_mgr_rw.h"
 
 #include <inttypes.h>

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "catalog_rw.h"
 
 #include <inttypes.h>

--- a/cvmfs/catalog_sql.h
+++ b/cvmfs/catalog_sql.h
@@ -16,10 +16,6 @@
 #ifndef CVMFS_CATALOG_SQL_H_
 #define CVMFS_CATALOG_SQL_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <inttypes.h>
 
 #include <string>

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -24,10 +24,6 @@
 
 #define ENOATTR ENODATA /**< instead of including attr/xattr.h */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 // sys/xattr.h conflicts with linux/xattr.h and needs to be loaded very early
 // clang-format off
 #include <sys/xattr.h>  // NOLINT

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -2,9 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
-
 #include "fuse_evict.h"
 
 #include <inttypes.h>

--- a/cvmfs/glue_buffer.cc
+++ b/cvmfs/glue_buffer.cc
@@ -2,9 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
-
 #include "glue_buffer.h"
 
 #include <errno.h>

--- a/cvmfs/libcvmfs.cc
+++ b/cvmfs/libcvmfs.cc
@@ -7,10 +7,6 @@
 
 #define _FILE_OFFSET_BITS 64
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 
 #include "libcvmfs.h"
 

--- a/cvmfs/lru_md.h
+++ b/cvmfs/lru_md.h
@@ -7,10 +7,6 @@
 #ifndef CVMFS_LRU_MD_H_
 #define CVMFS_LRU_MD_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <stdint.h>
 
 #include "crypto/hash.h"

--- a/cvmfs/malloc_arena.cc
+++ b/cvmfs/malloc_arena.cc
@@ -2,9 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
-
 #include "malloc_arena.h"
 
 #include <cassert>

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -25,9 +25,6 @@
  */
 
 // TODO(jblomer): MS for time summing
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-
 
 #include "download.h"
 

--- a/cvmfs/nfs_maps.h
+++ b/cvmfs/nfs_maps.h
@@ -5,10 +5,6 @@
 #ifndef CVMFS_NFS_MAPS_H_
 #define CVMFS_NFS_MAPS_H_
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 

--- a/cvmfs/notification_client.cc
+++ b/cvmfs/notification_client.cc
@@ -2,11 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "notification_client.h"
 
 #include <inttypes.h>

--- a/cvmfs/notify/cmd_sub.cc
+++ b/cvmfs/notify/cmd_sub.cc
@@ -2,11 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "cmd_sub.h"
 
 #include <inttypes.h>

--- a/cvmfs/publish/cmd_diff.cc
+++ b/cvmfs/publish/cmd_diff.cc
@@ -5,10 +5,6 @@
 
 #include "cmd_diff.h"
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <inttypes.h>
 
 #include <cassert>

--- a/cvmfs/publish/cmd_hash.cc
+++ b/cvmfs/publish/cmd_hash.cc
@@ -5,10 +5,6 @@
 
 #include "cmd_hash.h"
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -13,7 +13,6 @@
  */
 
 #define __STDC_LIMIT_MACROS
-#define __STDC_FORMAT_MACROS
 
 
 #include "quota_posix.h"

--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -5,11 +5,6 @@
 #ifndef CVMFS_SMALLHASH_H_
 #define CVMFS_SMALLHASH_H_
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "duplex_testing.h"
 #include <inttypes.h>
 #include <pthread.h>

--- a/cvmfs/sqlitemem.cc
+++ b/cvmfs/sqlitemem.cc
@@ -2,9 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
-
 #include "sqlitemem.h"
 
 #include <cassert>

--- a/cvmfs/sqlitevfs.cc
+++ b/cvmfs/sqlitevfs.cc
@@ -7,11 +7,6 @@
  * the SQlite file once opened.  It works purely on the file descriptor.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-
 #include "sqlitevfs.h"
 
 #include <dlfcn.h>

--- a/cvmfs/swissknife_check.cc
+++ b/cvmfs/swissknife_check.cc
@@ -4,9 +4,6 @@
  * This tool checks a cvmfs repository for file catalog errors.
  */
 
-#define __STDC_FORMAT_MACROS
-
-
 #include "swissknife_check.h"
 
 #include <inttypes.h>

--- a/cvmfs/swissknife_info.cc
+++ b/cvmfs/swissknife_info.cc
@@ -5,8 +5,6 @@
  * to the user.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "swissknife_info.h"
 
 #include <string>

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -6,8 +6,6 @@
  * and publishes the result as a repository subdirectory.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "swissknife_overlay.h"
 
 #include <fcntl.h>

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -7,8 +7,6 @@
 
 // NOLINTNEXTLINE
 #define _FILE_OFFSET_BITS 64
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
 
 
 #include "swissknife_pull.h"

--- a/cvmfs/swissknife_scrub.cc
+++ b/cvmfs/swissknife_scrub.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "swissknife_scrub.h"
 
 #include "util/fs_traversal.h"

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -18,8 +18,6 @@
 
 // NOLINTNEXTLINE
 #define _FILE_OFFSET_BITS 64
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
 
 #include "swissknife_sync.h"
 

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "sync_mediator.h"
 
 #include <fcntl.h>

--- a/cvmfs/sync_union.cc
+++ b/cvmfs/sync_union.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "sync_union.h"
 
 #include "sync_mediator.h"

--- a/cvmfs/sync_union_aufs.cc
+++ b/cvmfs/sync_union_aufs.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "sync_union_aufs.h"
 
 #include <string>

--- a/cvmfs/sync_union_overlayfs.cc
+++ b/cvmfs/sync_union_overlayfs.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "sync_union_overlayfs.h"
 
 #include <sys/types.h>

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -2,8 +2,6 @@
  * This file is part of the CernVM File System
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "sync_union_tarball.h"
 
 #include <pthread.h>

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -12,11 +12,6 @@
  * The talk module runs in a separate thread.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-
 #include "talk.h"
 
 #include <errno.h>

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -4,11 +4,6 @@
  * Some common functions.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/cvmfs/util/mmap_file.cc
+++ b/cvmfs/util/mmap_file.cc
@@ -4,12 +4,6 @@
  * Some common functions.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
-
 #include "mmap_file.h"
 
 #include <cstddef>

--- a/cvmfs/util/posix.cc
+++ b/cvmfs/util/posix.cc
@@ -4,11 +4,6 @@
  * Some common functions.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <cctype>
 #include <stdlib.h>
 #include <cstdlib>

--- a/cvmfs/util/string.cc
+++ b/cvmfs/util/string.cc
@@ -4,11 +4,6 @@
  * Some common functions.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-// NOLINTNEXTLINE
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "string.h"
 
 #include <cctype>

--- a/cvmfs/util/uuid.cc
+++ b/cvmfs/util/uuid.cc
@@ -4,8 +4,6 @@
  * UUID generation and caching.
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "util/uuid.h"
 
 #include <cassert>

--- a/test/micro-benchmarks/b_catalog_grafting.cc
+++ b/test/micro-benchmarks/b_catalog_grafting.cc
@@ -1,7 +1,6 @@
 /**
  * This file is part of the CernVM File System.
  */
-#define __STDC_FORMAT_MACROS
 #include <benchmark/benchmark.h>
 
 #include <inttypes.h>

--- a/test/micro-benchmarks/b_gluebuffer.cc
+++ b/test/micro-benchmarks/b_gluebuffer.cc
@@ -1,7 +1,6 @@
 /**
  * This file is part of the CernVM File System.
  */
-#define __STDC_FORMAT_MACROS
 #include <benchmark/benchmark.h>
 
 #include <cassert>

--- a/test/micro-benchmarks/b_smallhash.cc
+++ b/test/micro-benchmarks/b_smallhash.cc
@@ -1,7 +1,6 @@
 /**
  * This file is part of the CernVM File System.
  */
-#define __STDC_FORMAT_MACROS
 #include <benchmark/benchmark.h>
 #include <inttypes.h>
 #include <stdint.h>


### PR DESCRIPTION
No longer needed  since we use C++11 consistently.