### PR TITLE
Reduce output for non-interactive status, and use proxy when contacting stratum 1s

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1214,8 +1214,12 @@ cvmfs_status() {
       RETVAL=1
       continue
     fi
-    export http_proxy="$(attr -qg proxy $mountpoint)"
-    local last_snapshot="$(curl -s -m 5 "$s1/.cvmfs_status.json" | sed -n 's/"//g;s/,$//;s/.*last_snapshot[^ ]* //p')"
+    local proxy="$(attr -qg proxy $mountpoint)"
+    local proxy_env=
+    if [ "$proxy" != DIRECT ]; then
+      proxy_env="env http_proxy=$proxy"
+    fi
+    local last_snapshot="$($proxy_env curl -s -m 5 "$s1/.cvmfs_status.json" | sed -n 's/"//g;s/,$//;s/.*last_snapshot[^ ]* //p')"
     if [ -z "$last_snapshot" ]; then
       echo "- could not read last_snapshot from $s1/.cvmfs_status.json"
       RETVAL=1
@@ -1228,13 +1232,13 @@ cvmfs_status() {
     if [ -n "$external_host" ]; then
       echo "- external host $external_host"
     fi
-    echo "- proxy $http_proxy"
+    echo "- proxy $proxy"
     echo "- host updated $(($age / 60)) minutes and $(($age % 60)) seconds ago"
     local host_list="$(attr -qg host_list $mountpoint)"
     local max_revision=0
     local max_rev_host=""
     for host in ${host_list//;/ }; do
-      local rev="$(curl -s -m 3 "$host/.cvmfspublished" | cat -v | sed -n 's/^S//p')"
+      local rev="$($proxy_env curl -s -m 3 "$host/.cvmfspublished" | cat -v | sed -n 's/^S//p')"
       # Note that later hosts are queried later so they get more time to
       # catch up. That might give them a little advantage.
       if [ -n "$rev" ] && [ "$rev" -gt $max_revision ]; then

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1199,13 +1199,17 @@ cvmfs_status() {
       # no more detail is available on macOS
       continue
     fi
-    # provide more detail if specific repo(s) requested
+    if [ ! -t 0 ]; then
+      continue
+    fi
+    # provide more detail if specific repo(s) requested interactively
     local s1="$(attr -qg host $mountpoint)"
     if [ -z "$s1" ]; then
       echo "- could not read host from $mountpoint"
       RETVAL=1
       continue
     fi
+    export http_proxy="$(attr -qg proxy $mountpoint)"
     local last_snapshot="$(curl -s -m 5 "$s1/.cvmfs_status.json" | sed -n 's/"//g;s/,$//;s/.*last_snapshot[^ ]* //p')"
     if [ -z "$last_snapshot" ]; then
       echo "- could not read last_snapshot from $s1/.cvmfs_status.json"
@@ -1219,7 +1223,7 @@ cvmfs_status() {
     if [ -n "$external_host" ]; then
       echo "- external host $external_host"
     fi
-    echo "- proxy $(attr -qg proxy $mountpoint)"
+    echo "- proxy $http_proxy"
     echo "- host updated $(($age / 60)) minutes and $(($age % 60)) seconds ago"
     local host_list="$(attr -qg host_list $mountpoint)"
     local max_revision=0

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -270,7 +270,7 @@ cvmfs_config_usage() {
   echo ""
   echo "  stat [-v | <repository>]"
   echo ""
-  echo "  status [<repository list>]"
+  echo "  status [-v(erbose, force detail output)] [<repository list>]"
   echo ""
   echo "  probe [<repository list>]"
   echo ""
@@ -1150,6 +1150,11 @@ cvmfs_stat() {
 
 cvmfs_status() {
   local list
+  local verbose=0
+  if [ "x$1" = "x-v" ]; then
+    verbose=1
+    shift
+  fi
   local repos="$@"
   list=""
 
@@ -1200,14 +1205,14 @@ cvmfs_status() {
       # no more detail is available on macOS
       continue
     fi
-    if [ ! -t 0 ]; then
+    if [ $verbose -eq 0 ] && [ ! -t 0 ]; then
       if ! $non_terminal_message; then
-        echo "skipping detail because not running on a terminal"
+        echo "skipping detail because not running on a terminal (use -v to force)"
         non_terminal_message=true
       fi
       continue
     fi
-    # provide more detail if specific repo(s) requested interactively
+    # provide more detail if specific repo(s) requested interactively or via -v
     local s1="$(attr -qg host $mountpoint)"
     if [ -z "$s1" ]; then
       echo "- could not read host from $mountpoint"

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1173,6 +1173,7 @@ cvmfs_status() {
   else
     mountpoints="$mounted_repos"
   fi
+  local non_terminal_message=false
   for mountpoint in $mountpoints
   do
     local fqrn=
@@ -1200,6 +1201,10 @@ cvmfs_status() {
       continue
     fi
     if [ ! -t 0 ]; then
+      if ! $non_terminal_message; then
+        echo "skipping detail because not running on a terminal"
+        non_terminal_message=true
+      fi
       continue
     fi
     # provide more detail if specific repo(s) requested interactively

--- a/test/src/071-cvmfsconfigstatus/main
+++ b/test/src/071-cvmfsconfigstatus/main
@@ -21,7 +21,7 @@ cvmfs_run_test() {
 
   if ! running_on_osx; then
     num_status=$(cvmfs_config status sft.cern.ch | wc -l)
-    if [ $num_status -lt 10 ]; then
+    if [ $num_status -lt 2 ]; then
       return 20
     fi
   fi

--- a/test/src/071-cvmfsconfigstatus/main
+++ b/test/src/071-cvmfsconfigstatus/main
@@ -24,6 +24,25 @@ cvmfs_run_test() {
     if [ $num_status -lt 2 ]; then
       return 20
     fi
+
+    #Check that'cvmfs_config status <repo>' works with CVMFS_HTTP_PROXY_DIRECT
+    cvmfs_clean                                       || return 30
+    cvmfs_mount sft.cern.ch "CVMFS_HTTP_PROXY=DIRECT" || return 31
+
+    local active_proxy
+    active_proxy=$(attr -qg proxy /cvmfs/sft.cern.ch)
+    echo "active proxy after mount with DIRECT: '$active_proxy'"
+    [ "$active_proxy" = "DIRECT" ]                    || return 32
+
+    local status_output
+    status_output=$(env -u http_proxy cvmfs_config status -v sft.cern.ch 2>&1)
+    echo "status output:"
+    echo "$status_output"
+
+    if echo "$status_output" | grep -q "could not read last_snapshot"; then
+      echo "regression: 'cvmfs_config status -v sft.cern.ch' failed with proxy=DIRECT"
+      return 33
+    fi
   fi
 
   return 0


### PR DESCRIPTION
We had a site cause hits direct on stratum 1s from worker nodes because they had a script running `cvmfs_config status repo` on all the mounted repos and the status command did not use the local proxy.  Change the status command to not print the extra details when run non-interactively and also use the proxy for its queries to stratum 1s.