### PR TITLE
Make LRU commands atomic to avoid race conditions

### DIFF
--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -425,8 +425,8 @@ PosixQuotaManager *PosixQuotaManager::CreateShared(
     return NULL;
   }
   LogCvmfs(kLogQuota, kLogDebug,
-           "new cache manager pid: %d protocol revision %d",
-           new_cachemgr_pid, QuotaManager::kProtocolRevision);
+           "new cache manager pid: %d protocol revision %d", new_cachemgr_pid,
+           QuotaManager::kProtocolRevision);
   quota_mgr->SetCacheMgrPid(new_cachemgr_pid);
   const int fd_lockfile_rw = open((workspace_dir + "/lock_cachemgr").c_str(),
                                   O_RDWR | O_TRUNC, 0600);
@@ -553,17 +553,20 @@ bool PosixQuotaManager::DoCleanup(const uint64_t leave_size) {
 
       // Avoid evicting open files hopping there are enough more recently used
       // files to satisfy the cleanup request
-/*
-      const bool is_open = std::find_if(
-                               open_files_.begin(), open_files_.end(),
-                               [&candidates, &i](const auto &elem) -> bool {
-                                 return elem.Collide(candidates[i].hash);
-                               })
-                           != open_files_.end();
-*/
-      bool is_open=false;
-      for(auto it=open_files_.begin();it!=open_files_.end();++it){
-        if (it->Collide(candidates[i].hash)){is_open=true; break;}
+      /*
+            const bool is_open = std::find_if(
+                                     open_files_.begin(), open_files_.end(),
+                                     [&candidates, &i](const auto &elem) -> bool
+         { return elem.Collide(candidates[i].hash);
+                                     })
+                                 != open_files_.end();
+      */
+      bool is_open = false;
+      for (auto it = open_files_.begin(); it != open_files_.end(); ++it) {
+        if (it->Collide(candidates[i].hash)) {
+          is_open = true;
+          break;
+        }
       }
 
       if (is_pinned) {
@@ -792,29 +795,47 @@ uint32_t PosixQuotaManager::GetProtocolRevision() {
 }
 
 void PosixQuotaManager::SetCleanupPolicy(bool cleanup_unused_first) {
-  if (protocol_revision_ < 3) return;
+  if (protocol_revision_ < 3)
+    return;
 
-  LruCommand cmd;
-  cmd.command_type = kSetCleanupPolicy;
-  WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
+  LogCvmfs(
+      kLogQuota, kLogDebug, "Set cleanup policy to %s",
+      (cleanup_unused_first) ? "cleanup unused files first." : "vanilla lru.");
 
-  WritePipe(pipe_lru_[1], &cleanup_unused_first, sizeof(bool));
+  char policy = (cleanup_unused_first) ? 'S' : 'R';  // S: smart, R: regular;
+
+  LruCommand *cmd = reinterpret_cast<LruCommand *>(
+      alloca(sizeof(LruCommand) + sizeof(policy)));
+  new (cmd) LruCommand;
+  cmd->command_type = kSetCleanupPolicy;
+  cmd->desc_length = sizeof(policy);
+  memcpy(reinterpret_cast<char *>(cmd) + sizeof(LruCommand), &policy,
+         sizeof(policy));
+  WritePipe(pipe_lru_[1], cmd, sizeof(LruCommand) + sizeof(policy));
 }
 
 void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
-  if (protocol_revision_ < 3) return;
+  if (protocol_revision_ < 3)
+    return;
 
-  LruCommand cmd;
-  cmd.command_type = kRegisterMountpoint;
-  WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
+  LogCvmfs(kLogQuota, kLogDebug, "Register Mountpoint %s", mountpoint.c_str());
 
-  size_t mp_size = mountpoint.size();
-  WritePipe(pipe_lru_[1], &mp_size, sizeof(size_t));
-  WritePipe(pipe_lru_[1], mountpoint.data(), mp_size);
+  const unsigned desc_length = (mountpoint.size() > kMaxDescription)
+                                   ? kMaxDescription
+                                   : mountpoint.size();
+  LruCommand *cmd = reinterpret_cast<LruCommand *>(
+      alloca(sizeof(LruCommand) + desc_length));
+  new (cmd) LruCommand;
+  cmd->command_type = kRegisterMountpoint;
+  cmd->desc_length = desc_length;
+  memcpy(reinterpret_cast<char *>(cmd) + sizeof(LruCommand), mountpoint.data(),
+         desc_length);
+  WritePipe(pipe_lru_[1], cmd, sizeof(LruCommand) + desc_length);
 }
 
 std::string PosixQuotaManager::GetMountpoints() {
-  if (protocol_revision_ < 3) return "";
+  if (protocol_revision_ < 3)
+    return "";
 
   int pipe_mp[2];
   MakeReturnPipe(pipe_mp);
@@ -831,7 +852,8 @@ std::string PosixQuotaManager::GetMountpoints() {
 }
 
 std::string PosixQuotaManager::GetGroupHashes() {
-  if (protocol_revision_ < 3) return "";
+  if (protocol_revision_ < 3)
+    return "";
 
   int pipe_gh[2];
   MakeReturnPipe(pipe_gh);
@@ -1222,7 +1244,8 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
     assert(SetLimitCore(0));
   }
 
-  const UniquePtr<Watchdog> watchdog(Watchdog::Create(NULL, false /* needs_read_environ */));
+  const UniquePtr<Watchdog> watchdog(
+      Watchdog::Create(NULL, false /* needs_read_environ */));
   assert(watchdog.IsValid());
   watchdog->Spawn("./stacktrace.cachemgr");
 
@@ -1344,7 +1367,9 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Inserts and pins come with a description (usually a path)
     if ((command_type == kInsert) || (command_type == kInsertVolatile)
-        || (command_type == kPin) || (command_type == kPinRegular)) {
+        || (command_type == kPin) || (command_type == kPinRegular)
+        || (command_type == kRegisterMountpoint)
+        || (command_type == kSetCleanupPolicy)) {
       const int desc_length = command_buffer[num_commands].desc_length;
       ReadPipe(quota_mgr->pipe_lru_[0],
                &description_buffer[kMaxDescription * num_commands],
@@ -1365,10 +1390,8 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Register a new mountpoint
     if (command_type == kRegisterMountpoint) {
-      size_t mp_size = 0;
-      ReadPipe(quota_mgr->pipe_lru_[0], &mp_size, sizeof(size_t));
-      std::string mountpoint(mp_size, '\0');
-      ReadPipe(quota_mgr->pipe_lru_[0], (void *)mountpoint.data(), mp_size);
+      std::string mountpoint(description_buffer,
+                             command_buffer[num_commands].desc_length);
       quota_mgr->mountpoints_.push_back(mountpoint);
       LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
                "Mountpoint %s registered in the group", mountpoint.c_str());
@@ -1377,9 +1400,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Set Cleanup Policy
     if (command_type == kSetCleanupPolicy) {
-      bool policy = false;
-      ReadPipe(quota_mgr->pipe_lru_[0], &policy, sizeof(bool));
-      quota_mgr->cleanup_unused_first_ = policy;
+      quota_mgr->cleanup_unused_first_ = (description_buffer[0] == 'S') ? true : false;
       continue;
     }
     // Mountpoints are returned immediately
@@ -2314,7 +2335,8 @@ void *PosixQuotaManager::CollectMountpointsHashes(void *data) {
   }
   const MutexLockGuard lock_guard(handler->l);
   for (auto hash_str : hash_strs) {
-    handler->of.push_back(shash::Short( shash::MkFromHexPtr(shash::HexPtr(hash_str)) ));
+    handler->of.push_back(
+        shash::Short(shash::MkFromHexPtr(shash::HexPtr(hash_str))));
   }
 #endif
   pthread_exit(nullptr);

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1390,7 +1390,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Register a new mountpoint
     if (command_type == kRegisterMountpoint) {
-      const std::string mountpoint(description_buffer,
+      const std::string mountpoint(&description_buffer[num_commands*kMaxDescription],
                              command_buffer[num_commands].desc_length);
       quota_mgr->mountpoints_.push_back(mountpoint);
       LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,
@@ -1400,7 +1400,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Set Cleanup Policy
     if (command_type == kSetCleanupPolicy) {
-      quota_mgr->cleanup_unused_first_ = (description_buffer[0] == 'S') ? true : false;
+      quota_mgr->cleanup_unused_first_ = (description_buffer[num_commands * kMaxDescription] == 'S') ? true : false;
       continue;
     }
     // Mountpoints are returned immediately

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -833,6 +833,15 @@ void PosixQuotaManager::RegisterMountpoint(const std::string &mountpoint) {
   WritePipe(pipe_lru_[1], cmd, sizeof(LruCommand) + desc_length);
 }
 
+std::string PosixQuotaManager::ReadPipeString(int fd, size_t size) {
+  if (size == 0)
+    return "";
+
+  std::vector<char> buf(size);
+  ManagedReadHalfPipe(fd, buf.data(), size);
+  return std::string(buf.data(), size);
+}
+
 std::string PosixQuotaManager::GetMountpoints() {
   if (protocol_revision_ < 3)
     return "";
@@ -846,9 +855,9 @@ std::string PosixQuotaManager::GetMountpoints() {
   WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
   size_t mp_str_size = 0;
   ManagedReadHalfPipe(pipe_mp[0], &mp_str_size, sizeof(size_t));
-  char *buf = (char *)malloc(mp_str_size * sizeof(char));
-  ManagedReadHalfPipe(pipe_mp[0], buf, mp_str_size);
-  return std::string(buf);
+  const std::string result = ReadPipeString(pipe_mp[0], mp_str_size);
+  CloseReturnPipe(pipe_mp);
+  return result;
 }
 
 std::string PosixQuotaManager::GetGroupHashes() {
@@ -864,9 +873,9 @@ std::string PosixQuotaManager::GetGroupHashes() {
   WritePipe(pipe_lru_[1], &cmd, sizeof(cmd));
   size_t mp_str_size = 0;
   ManagedReadHalfPipe(pipe_gh[0], &mp_str_size, sizeof(size_t));
-  char *buf = (char *)malloc(mp_str_size * sizeof(char));
-  ManagedReadHalfPipe(pipe_gh[0], buf, mp_str_size);
-  return std::string(buf);
+  const std::string result = ReadPipeString(pipe_gh[0], mp_str_size);
+  CloseReturnPipe(pipe_gh);
+  return result;
 }
 
 /**

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1390,7 +1390,7 @@ void *PosixQuotaManager::MainCommandServer(void *data) {
 
     // Register a new mountpoint
     if (command_type == kRegisterMountpoint) {
-      std::string mountpoint(description_buffer,
+      const std::string mountpoint(description_buffer,
                              command_buffer[num_commands].desc_length);
       quota_mgr->mountpoints_.push_back(mountpoint);
       LogCvmfs(kLogQuota, kLogDebug | kLogSyslog,

--- a/cvmfs/quota_posix.h
+++ b/cvmfs/quota_posix.h
@@ -38,6 +38,9 @@ class PosixQuotaManager : public QuotaManager {
   FRIEND_TEST(T_QuotaManager, Contains);
   FRIEND_TEST(T_QuotaManager, InitDatabase);
   FRIEND_TEST(T_QuotaManager, MakeReturnPipe);
+  FRIEND_TEST(T_QuotaManager, ReadPipeStringUsesExactLength);
+  FRIEND_TEST(T_QuotaManager, RegisterMountpointUsesCorrectDescriptionBuffer);
+  FRIEND_TEST(T_QuotaManager, SetCleanupPolicyUsesCorrectDescriptionBuffer);
 
  public:
   static PosixQuotaManager *Create(const std::string &cache_workspace,
@@ -273,6 +276,7 @@ class PosixQuotaManager : public QuotaManager {
   PosixQuotaManager(const uint64_t limit, const uint64_t cleanup_threshold,
                     const std::string &cache_workspace);
   void SkipEviction(const EvictCandidate &candidate);
+  std::string ReadPipeString(int fd, size_t size);
 
   /**
    * Indicates if the cache manager is a shared process or a thread within the

--- a/test/profiles/streamingcache.sh
+++ b/test/profiles/streamingcache.sh
@@ -28,7 +28,8 @@ PROFILE_EXCLUSIONS="\
   src/094-attachmount \
   src/096-cancelreq \
   src/102-reusefd \
-  src/103-reloadcachemgr"
+  src/103-reloadcachemgr \
+  src/112-quota-multiwrite-race"
 
 profile_setup() {
   local conf=/etc/cvmfs/default.d/90-streamingcache.conf

--- a/test/src/112-quota-multiwrite-race/main
+++ b/test/src/112-quota-multiwrite-race/main
@@ -1,0 +1,223 @@
+#!/bin/bash
+
+cvmfs_test_name="Shared quota manager FIFO multi-write race"
+cvmfs_test_suites="quick"
+cvmfs_test_timeout=900
+
+# Reproducer for the cachemgr panic triggered by the non-atomic multi-write
+# protocol of kSetCleanupPolicy and kRegisterMountpoint introduced in #4029.
+#
+# These methods (PosixQuotaManager::SetCleanupPolicy / RegisterMountpoint) emit
+# the LruCommand and its trailing payload (bool / size_t + string) in *separate*
+# WritePipe calls. The shared-cache FIFO is written to by every FUSE client of
+# the same cachemgr. With concurrent Touch traffic from worker threads in
+# already-mounted repos, another atomic LruCommand can land between the two
+# writes of one logical command, desynchronising the cachemgr's read stream
+# and causing it to PANIC(NULL) on an unrecognised command_type at
+# quota_posix.cc:2014.
+#
+# The race window per fnInit call is microseconds, so the test maximises the
+# rate of both (a) Touch writes from worker threads of stable mounts, and
+# (b) fnInit invocations on cycle mounts. Touch is driven by tight-loop
+# open()s on already-cached files; fnInit is driven by a fan of parallel
+# autofs-triggered mount/unmount cycles on several different repositories.
+# The cachemgr stays alive throughout because the stable mounts always have
+# the FIFO write end open (cvmfs_config reload, by contrast, drains every
+# writer at once and the cachemgr exits cleanly on EOF — that's a different
+# code path and obscures the race we're after).
+#
+# The test fails if syslog shows a PANIC from quota_posix.cc, a FUSE process
+# logs "watchdog disappeared", a mount probe times out, or any /cvmfs mount
+# stops being readable.
+
+# Stable repositories drive Touch traffic. CYCLE_REPOS are mounted/unmounted
+# in parallel to fire SetCleanupPolicy + RegisterMountpoint over and over.
+STABLE_REPOS="sft.cern.ch atlas.cern.ch cms.cern.ch alice.cern.ch"
+CYCLE_REPOS="lhcb.cern.ch grid.cern.ch na62.cern.ch ams.cern.ch geant4.cern.ch"
+ALL_REPOS="$STABLE_REPOS $CYCLE_REPOS"
+ALL_REPOS_CSV=$(echo $ALL_REPOS | tr ' ' ',')
+
+HAMMERS_PER_REPO=4
+ITERATIONS_PER_CYCLER=400
+
+BG_PIDS=""
+
+cleanup() {
+  echo "running cleanup() ..."
+  if [ -n "$BG_PIDS" ]; then
+    for p in $BG_PIDS; do
+      kill $p 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+  fi
+  for r in $CYCLE_REPOS; do
+    local mp="/tmp/cvmfs-cycle-${r//./_}"
+    sudo umount -l "$mp" 2>/dev/null || true
+    sudo rmdir "$mp" 2>/dev/null || true
+  done
+}
+
+# Ask any of the stable repos for the shared cachemgr PID via the talk
+# socket. All mounts share one cachemgr, so any repo answers identically.
+# `pid cachemgr` does a pipe RPC into the cachemgr; if the cachemgr is dead
+# the FUSE side blocks on the write, so wrap it in a timeout.
+get_cachemgr_pid() {
+  local probe_repo=${STABLE_REPOS%% *}
+  sudo timeout 5 cvmfs_talk -i $probe_repo pid cachemgr 2>/dev/null \
+    | tr -d '[:space:]'
+}
+
+# Tight-loop reader of a fixed cached-file list. After warmup every read
+# is a cache HIT, which the client serves via PosixCacheManager::Open ->
+# PosixQuotaManager::Touch -> single WritePipe of an LruCommand{kTouch}.
+hammer() {
+  local repo=$1
+  local files
+  files=$(find /cvmfs/$repo -maxdepth 4 -type f 2>/dev/null \
+            | head -50 \
+            | tr '\n' ' ')
+  if [ -z "$files" ]; then
+    return
+  fi
+  # Warm the cache so subsequent reads stay local.
+  for f in $files; do cat "$f" >/dev/null 2>&1; done
+  while true; do
+    for f in $files; do
+      cat "$f" >/dev/null 2>&1
+    done
+  done
+}
+
+# Repeatedly mount and unmount one repository at a private mountpoint that
+# autofs does NOT manage, so every iteration is a guaranteed fresh cvmfs2
+# spawn -> fnInit -> SetCleanupPolicy (2 writes) + RegisterMountpoint
+# (3 writes) on the shared FIFO. Going via /cvmfs/$repo would let autofs
+# cache the mount and skip Init on subsequent iterations.
+cycler() {
+  local repo=$1
+  local n=$2
+  local mp="/tmp/cvmfs-cycle-${repo//./_}"
+  sudo mkdir -p "$mp" 2>/dev/null
+  local i
+  for i in $(seq 1 $n); do
+    if ! sudo timeout 30 mount -t cvmfs $repo "$mp" 2>/dev/null; then
+      continue
+    fi
+    sudo umount "$mp" 2>/dev/null || sudo umount -l "$mp" 2>/dev/null || true
+  done
+  sudo rmdir "$mp" 2>/dev/null || true
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local src_location=$2
+
+  trap cleanup EXIT HUP INT TERM || return $?
+
+  echo "*** mounting all repositories with shared cache: $ALL_REPOS_CSV"
+  cvmfs_mount $ALL_REPOS_CSV \
+    "CVMFS_KCACHE_TIMEOUT=3" \
+    "CVMFS_SHARED_CACHE=yes" \
+    || return 10
+
+  local cachemgr_pid_initial
+  cachemgr_pid_initial=$(get_cachemgr_pid)
+  if [ -z "$cachemgr_pid_initial" ]; then
+    echo "ERROR: no shared cachemgr process found after mount"
+    return 11
+  fi
+  echo "*** shared cachemgr PID: $cachemgr_pid_initial"
+
+  # The cycle repos are mounted by cvmfs_mount above as a sanity check; the
+  # cyclers themselves use private mountpoints under /tmp, so detach the
+  # /cvmfs entries here to keep autofs out of the way.
+  local r
+  for r in $CYCLE_REPOS; do
+    sudo umount /cvmfs/$r 2>/dev/null || true
+  done
+
+  echo "*** starting $HAMMERS_PER_REPO hammer(s) per stable repo"
+  for r in $STABLE_REPOS; do
+    local h
+    for h in $(seq 1 $HAMMERS_PER_REPO); do
+      hammer $r &
+      BG_PIDS="$BG_PIDS $!"
+    done
+  done
+  echo "*** background hammer PIDs:$BG_PIDS"
+
+  # Let the hammers warm up and start emitting Touch.
+  sleep 5
+
+  echo "*** starting parallel cyclers ($ITERATIONS_PER_CYCLER iters each):"
+  echo "***   $CYCLE_REPOS"
+  local cycler_pids=""
+  for r in $CYCLE_REPOS; do
+    cycler $r $ITERATIONS_PER_CYCLER &
+    cycler_pids="$cycler_pids $!"
+    BG_PIDS="$BG_PIDS $!"
+  done
+
+  # Periodically poll the cachemgr while the cyclers run, so a wedged or
+  # panicked cachemgr surfaces immediately instead of after the loop ends.
+  echo "*** monitoring cachemgr every 10s"
+  local poll
+  for poll in $(seq 1 80); do
+    sleep 10
+
+    # Have all cyclers finished?
+    local still_running=0
+    local p
+    for p in $cycler_pids; do
+      if kill -0 $p 2>/dev/null; then
+        still_running=$((still_running + 1))
+      fi
+    done
+
+    local pid_now
+    pid_now=$(get_cachemgr_pid)
+    if [ -z "$pid_now" ]; then
+      echo "ERROR: cachemgr unreachable after poll $poll (cyclers running: $still_running)"
+      echo "--- syslog tail (looking for PANIC) ---"
+      sudo grep -E "PANIC.*quota_posix\.cc|Signal: 6, errno: 2|watchdog disappeared" \
+        $CVMFS_TEST_SYSLOG_TARGET /var/log/messages 2>/dev/null \
+        | tail -5
+      return 21
+    fi
+    echo "    poll $poll (${still_running} cyclers running): cachemgr PID $pid_now"
+
+    if [ $still_running -eq 0 ]; then
+      break
+    fi
+  done
+
+  # Smoking-gun checks in syslog. The cachemgr's PANIC at quota_posix.cc:2014
+  # (which the optimiser sometimes attributes to neighbouring lines) goes to
+  # kLogSyslogErr; the FUSE-side cascade emits "watchdog disappeared".
+  if sudo grep -E "PANIC.*quota_posix\.cc" \
+       $CVMFS_TEST_SYSLOG_TARGET >>$logfile 2>&1; then
+    echo "ERROR: cachemgr logged PANIC from quota_posix.cc"
+    return 31
+  fi
+  if sudo grep -E "watchdog disappeared" \
+       $CVMFS_TEST_SYSLOG_TARGET >>$logfile 2>&1; then
+    echo "ERROR: a FUSE process aborted because the watchdog disappeared"
+    return 32
+  fi
+  if sudo grep -E "Signal: 6.*errno: 2" \
+       $CVMFS_TEST_SYSLOG_TARGET >>$logfile 2>&1; then
+    echo "ERROR: a cvmfs2 process aborted with SIGABRT/ENOENT (cachemgr panic signature)"
+    return 33
+  fi
+
+  # Final liveness check: each stable mount must still serve reads.
+  for r in $STABLE_REPOS; do
+    if ! sudo timeout 10 ls /cvmfs/$r >/dev/null 2>&1; then
+      echo "ERROR: /cvmfs/$r is no longer readable after the loop"
+      return 40
+    fi
+  done
+
+  echo "*** cachemgr survived; no panic detected"
+  return 0
+}

--- a/test/src/112-quota-multiwrite-race/main
+++ b/test/src/112-quota-multiwrite-race/main
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cvmfs_test_name="Shared quota manager FIFO multi-write race"
-cvmfs_test_suites="quick"
+cvmfs_test_suites="slow"
 cvmfs_test_timeout=900
 
 # Reproducer for the cachemgr panic triggered by the non-atomic multi-write

--- a/test/src/113-quota-atomic-init-commands/main
+++ b/test/src/113-quota-atomic-init-commands/main
@@ -19,7 +19,10 @@ cvmfs_test_autofs_on_startup=false
 
 STABLE_REPO="atlas.cern.ch"
 CYCLE_REPOS="grid.cern.ch lhcb.cern.ch"
-ITERATIONS_PER_CYCLER=80
+# Each mount/umount cycle costs ~2-4s on a typical test host. Keep the count
+# low enough that two parallel cyclers comfortably finish inside
+# cvmfs_test_timeout, with margin for the polling loop and final checks.
+ITERATIONS_PER_CYCLER=25
 BG_PIDS=""
 TMPDIR_113=""
 SHARED_WORKSPACE=""
@@ -84,19 +87,21 @@ cycler() {
   local i
 
   sudo mkdir -p "$mp" 2>/dev/null
+  # Initialise the status file so a kill mid-run still leaves an answer
+  # behind and the main test reports actual progress instead of "missing".
+  echo "$ok" > "$status_file"
   for i in $(seq 1 $n); do
-    if ! sudo timeout 30 mount -t cvmfs $repo "$mp" >/dev/null 2>&1; then
-      continue
-    fi
-
-    if sudo timeout 10 ls "$mp" >/dev/null 2>&1; then
+    # mount itself drives cvmfs2 fnInit -> SetCleanupPolicy +
+    # RegisterMountpoint, which is the protocol we want to exercise. No
+    # need for an extra ls round-trip per iteration.
+    if sudo timeout 20 mount -t cvmfs $repo "$mp" >/dev/null 2>&1; then
       ok=$((ok + 1))
+      sudo umount "$mp" >/dev/null 2>&1 \
+        || sudo umount -l "$mp" >/dev/null 2>&1 || true
     fi
-
-    sudo umount "$mp" >/dev/null 2>&1 || sudo umount -l "$mp" >/dev/null 2>&1 || true
+    echo "$ok" > "$status_file"
   done
 
-  echo "$ok" > "$status_file"
   sudo rmdir "$mp" 2>/dev/null || true
 }
 
@@ -159,8 +164,10 @@ cvmfs_run_test() {
     BG_PIDS="$BG_PIDS $!"
   done
 
+  local poll=0
   while true; do
     sleep 2
+    poll=$((poll + 1))
 
     local still_running=0
     local p
@@ -192,6 +199,18 @@ cvmfs_run_test() {
     if ! sudo timeout 10 ls /cvmfs/$STABLE_REPO >/dev/null 2>&1; then
       echo "ERROR: stable mount stopped being readable"
       return 24
+    fi
+
+    # Log progress every 5 polls (~10s) so a hang is debuggable.
+    if (( poll % 5 == 0 )) || [ $still_running -eq 0 ]; then
+      local progress=""
+      for repo in $CYCLE_REPOS; do
+        local sf="$TMPDIR_113/${repo//./_}.ok"
+        local n="?"
+        [ -f "$sf" ] && n=$(cat "$sf")
+        progress="$progress $repo=$n"
+      done
+      echo "    poll $poll: cyclers running=$still_running cachemgr=$pid_now$progress"
     fi
 
     if [ $still_running -eq 0 ]; then

--- a/test/src/113-quota-atomic-init-commands/main
+++ b/test/src/113-quota-atomic-init-commands/main
@@ -45,7 +45,10 @@ cleanup() {
 
 get_cachemgr_pid_from_lock() {
   local lockfile="$SHARED_WORKSPACE/lock_cachemgr"
-  python3 - "$lockfile" <<'PY'
+  # The lockfile lives inside the shared-cache workspace, which is owned by
+  # the cvmfs user with mode 0700, so the unprivileged test driver can't
+  # read it directly — drop into the cvmfs user via sudo.
+  sudo python3 - "$lockfile" <<'PY'
 import os
 import struct
 import sys
@@ -117,7 +120,9 @@ cvmfs_run_test() {
   fi
 
   SHARED_WORKSPACE="$(get_cvmfs_cachedir $STABLE_REPO)"
-  if [ ! -p "$SHARED_WORKSPACE/cachemgr" ]; then
+  # The shared-cache workspace is mode 0700 owned by the cvmfs user, so
+  # the unprivileged test driver needs sudo to stat files inside it.
+  if ! sudo test -p "$SHARED_WORKSPACE/cachemgr"; then
     echo "ERROR: shared cachemgr FIFO not found in $SHARED_WORKSPACE"
     return 12
   fi
@@ -179,7 +184,7 @@ cvmfs_run_test() {
       echo "ERROR: cachemgr pid $pid_now died while cyclers were running"
       return 22
     fi
-    if [ ! -p "$SHARED_WORKSPACE/cachemgr" ]; then
+    if ! sudo test -p "$SHARED_WORKSPACE/cachemgr"; then
       echo "ERROR: shared cachemgr FIFO disappeared"
       return 23
     fi

--- a/test/src/113-quota-atomic-init-commands/main
+++ b/test/src/113-quota-atomic-init-commands/main
@@ -1,0 +1,229 @@
+#!/bin/bash
+
+cvmfs_test_name="Shared quota manager atomic init commands"
+cvmfs_test_suites="quick"
+cvmfs_test_timeout=180
+cvmfs_test_autofs_on_startup=false
+
+# Focused regression test for the shared-cache FIFO protocol used by
+# SetCleanupPolicy and RegisterMountpoint during fnInit.
+#
+# One stable mount keeps the shared cachemgr alive and emits lightweight Touch
+# traffic by repeatedly reading a cached file. In parallel, private mount/
+# unmount cycles on other repositories repeatedly trigger fnInit and thus the
+# shared-FIFO init commands.
+#
+# This keeps the important multi-writer shared-FIFO coverage from
+# 112-quota-multiwrite-race, but runs much faster and avoids relying on talk
+# sockets for liveness checks.
+
+STABLE_REPO="atlas.cern.ch"
+CYCLE_REPOS="grid.cern.ch lhcb.cern.ch"
+ITERATIONS_PER_CYCLER=80
+BG_PIDS=""
+TMPDIR_113=""
+SHARED_WORKSPACE=""
+
+cleanup() {
+  if [ -n "$BG_PIDS" ]; then
+    for p in $BG_PIDS; do
+      kill $p 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+  fi
+
+  for r in $CYCLE_REPOS; do
+    local mp="/tmp/cvmfs-cycle-${r//./_}"
+    sudo umount -l "$mp" 2>/dev/null || true
+    sudo rmdir "$mp" 2>/dev/null || true
+  done
+
+  if [ -n "$TMPDIR_113" ] && [ -d "$TMPDIR_113" ]; then
+    rm -rf "$TMPDIR_113"
+  fi
+}
+
+get_cachemgr_pid_from_lock() {
+  local lockfile="$SHARED_WORKSPACE/lock_cachemgr"
+  python3 - "$lockfile" <<'PY'
+import os
+import struct
+import sys
+
+path = sys.argv[1]
+try:
+    data = open(path, 'rb').read()
+except IOError:
+    sys.exit(1)
+if len(data) < 8:
+    sys.exit(1)
+magic, pid = struct.unpack('=Ii', data[:8])
+if magic == 0 or pid <= 0:
+    sys.exit(1)
+print(pid)
+PY
+}
+
+light_toucher() {
+  local file=$1
+  cat "$file" >/dev/null 2>&1 || return
+  while true; do
+    cat "$file" >/dev/null 2>&1 || return
+  done
+}
+
+cycler() {
+  local repo=$1
+  local n=$2
+  local status_file=$3
+  local mp="/tmp/cvmfs-cycle-${repo//./_}"
+  local ok=0
+  local i
+
+  sudo mkdir -p "$mp" 2>/dev/null
+  for i in $(seq 1 $n); do
+    if ! sudo timeout 30 mount -t cvmfs $repo "$mp" >/dev/null 2>&1; then
+      continue
+    fi
+
+    if sudo timeout 10 ls "$mp" >/dev/null 2>&1; then
+      ok=$((ok + 1))
+    fi
+
+    sudo umount "$mp" >/dev/null 2>&1 || sudo umount -l "$mp" >/dev/null 2>&1 || true
+  done
+
+  echo "$ok" > "$status_file"
+  sudo rmdir "$mp" 2>/dev/null || true
+}
+
+cvmfs_run_test() {
+  local logfile=$1
+  local src_location=$2
+  local repo
+
+  trap cleanup EXIT HUP INT TERM || return $?
+  TMPDIR_113=$(mktemp -d)
+
+  echo "*** mounting stable repo with shared cache: $STABLE_REPO"
+  cvmfs_mount "$STABLE_REPO" \
+    "CVMFS_KCACHE_TIMEOUT=3" \
+    "CVMFS_SHARED_CACHE=yes" \
+    || return 10
+
+  if ! sudo timeout 10 ls /cvmfs/$STABLE_REPO >/dev/null 2>&1; then
+    echo "ERROR: stable mount is not readable"
+    return 11
+  fi
+
+  SHARED_WORKSPACE="$(get_cvmfs_cachedir $STABLE_REPO)"
+  if [ ! -p "$SHARED_WORKSPACE/cachemgr" ]; then
+    echo "ERROR: shared cachemgr FIFO not found in $SHARED_WORKSPACE"
+    return 12
+  fi
+
+  local cachemgr_pid_initial
+  cachemgr_pid_initial=$(get_cachemgr_pid_from_lock)
+  if [ -z "$cachemgr_pid_initial" ]; then
+    echo "ERROR: no shared cachemgr pid found in lock file"
+    return 13
+  fi
+  if ! sudo kill -0 "$cachemgr_pid_initial" 2>/dev/null; then
+    echo "ERROR: shared cachemgr pid $cachemgr_pid_initial is not alive"
+    return 14
+  fi
+  echo "*** shared cachemgr PID: $cachemgr_pid_initial"
+
+  local stable_file
+  stable_file=$(find /cvmfs/$STABLE_REPO -maxdepth 4 -type f 2>/dev/null | head -1)
+  if [ -z "$stable_file" ]; then
+    echo "ERROR: could not find a stable file to emit Touch traffic"
+    return 15
+  fi
+
+  echo "*** starting lightweight Touch traffic on $stable_file"
+  light_toucher "$stable_file" &
+  BG_PIDS="$BG_PIDS $!"
+
+  echo "*** starting cyclers on: $CYCLE_REPOS"
+  local cycler_pids=""
+  for repo in $CYCLE_REPOS; do
+    local status_file="$TMPDIR_113/${repo//./_}.ok"
+    cycler "$repo" "$ITERATIONS_PER_CYCLER" "$status_file" &
+    cycler_pids="$cycler_pids $!"
+    BG_PIDS="$BG_PIDS $!"
+  done
+
+  while true; do
+    sleep 2
+
+    local still_running=0
+    local p
+    for p in $cycler_pids; do
+      if kill -0 $p 2>/dev/null; then
+        still_running=$((still_running + 1))
+      fi
+    done
+
+    local pid_now
+    pid_now=$(get_cachemgr_pid_from_lock)
+    if [ -z "$pid_now" ]; then
+      echo "ERROR: cachemgr lock file became unreadable while cyclers were running"
+      return 20
+    fi
+    if [ "$pid_now" != "$cachemgr_pid_initial" ]; then
+      echo "ERROR: cachemgr PID changed from $cachemgr_pid_initial to $pid_now"
+      return 21
+    fi
+    if ! sudo kill -0 "$pid_now" 2>/dev/null; then
+      echo "ERROR: cachemgr pid $pid_now died while cyclers were running"
+      return 22
+    fi
+    if [ ! -p "$SHARED_WORKSPACE/cachemgr" ]; then
+      echo "ERROR: shared cachemgr FIFO disappeared"
+      return 23
+    fi
+
+    if ! sudo timeout 10 ls /cvmfs/$STABLE_REPO >/dev/null 2>&1; then
+      echo "ERROR: stable mount stopped being readable"
+      return 24
+    fi
+
+    if [ $still_running -eq 0 ]; then
+      break
+    fi
+  done
+
+  for repo in $CYCLE_REPOS; do
+    local status_file="$TMPDIR_113/${repo//./_}.ok"
+    if [ ! -f "$status_file" ]; then
+      echo "ERROR: cycler status for $repo missing"
+      return 30
+    fi
+
+    local ok
+    ok=$(cat "$status_file")
+    echo "*** successful private mounts for $repo: $ok"
+    if [ "$ok" -eq 0 ]; then
+      echo "ERROR: cycler for $repo did not complete any successful mount cycle"
+      return 31
+    fi
+  done
+
+  local syslog_matches="$TMPDIR_113/syslog.matches"
+  for log in $CVMFS_TEST_SYSLOG_TARGET /var/log/messages; do
+    if [ -f "$log" ]; then
+      sudo tail -500 "$log" 2>/dev/null \
+        | grep -E "PANIC.*quota_posix\.cc|watchdog disappeared|Signal: 6.*errno: 2" \
+        >> "$syslog_matches" || true
+    fi
+  done
+  if [ -s "$syslog_matches" ]; then
+    cat "$syslog_matches" >> "$logfile"
+    echo "ERROR: detected cachemgr panic/watchdog signature in recent syslog"
+    return 40
+  fi
+
+  echo "*** cachemgr survived focused shared-FIFO init-command exercise"
+  return 0
+}

--- a/test/unittests/t_quota.cc
+++ b/test/unittests/t_quota.cc
@@ -570,6 +570,43 @@ TEST_F(T_QuotaManager, Touch) {
   EXPECT_EQ("a\n", PrintStringVector(quota_mgr_->List()));
 }
 
+TEST_F(T_QuotaManager, ReadPipeStringUsesExactLength) {
+  int mypipe[2];
+  MakePipe(mypipe);
+
+  const char payload[] = {'a', '\0', 'b'};
+  WritePipe(mypipe[1], payload, sizeof(payload));
+  close(mypipe[1]);
+
+  const string result = quota_mgr_->ReadPipeString(mypipe[0], sizeof(payload));
+  close(mypipe[0]);
+
+  ASSERT_EQ(sizeof(payload), result.size());
+  EXPECT_EQ('a', result[0]);
+  EXPECT_EQ('\0', result[1]);
+  EXPECT_EQ('b', result[2]);
+}
+
+
+TEST_F(T_QuotaManager, RegisterMountpointUsesCorrectDescriptionBuffer) {
+  quota_mgr_->Insert(hashes_[0], 0, "wrongmountpoint");
+  quota_mgr_->RegisterMountpoint("rightmountpoint");
+  quota_mgr_->List();  // synchronize with the quota manager thread
+
+  ASSERT_EQ(1U, quota_mgr_->mountpoints_.size());
+  EXPECT_EQ("rightmountpoint", quota_mgr_->mountpoints_[0]);
+}
+
+
+TEST_F(T_QuotaManager, SetCleanupPolicyUsesCorrectDescriptionBuffer) {
+  quota_mgr_->Insert(hashes_[0], 0, "regular");
+  quota_mgr_->SetCleanupPolicy(true);
+  quota_mgr_->List();  // synchronize with the quota manager thread
+
+  EXPECT_TRUE(quota_mgr_->cleanup_unused_first_);
+}
+
+
 TEST_F(T_QuotaManager, SetLimit) {
   quota_mgr_->SetLimit(100);
   const uint64_t limit = quota_mgr_->GetCapacity();


### PR DESCRIPTION
With the addition of the open file aware LRU commands, we've seen race conditions happening cause the cvmfs process to crash https://github.com/cvmfs/cvmfs/issues/4226.

This is probably due to the fact that in the current implementation a single command would be completed with multiple pipe writes. With this commit we pass the extra information through the command description following the example of the `DoInsert()`.