### PR TITLE
test/run.sh: shuffle the test cases order

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -207,7 +207,7 @@ if [ $test_exclusions -ne 0 ]; then
   shift # get rid of '--'
 fi
 
-testsuite="$@"
+testsuite=$(shuf -e $@)
 if [ -z "$testsuite" ]; then
   if [ "$suite_option_provided" -eq 0 ] && [ -z "$labels" ]; then
     labels="quick"

--- a/test/run.sh
+++ b/test/run.sh
@@ -207,7 +207,14 @@ if [ $test_exclusions -ne 0 ]; then
   shift # get rid of '--'
 fi
 
-testsuite=$(shuf -e $@)
+# Optionally shuffle the order of the explicitly listed test cases. This is off
+# by default so that foundational tests (e.g. 000-dummy, 001-chksetup) run first;
+# set CVMFS_TEST_SHUFFLE=1 to stress-test that tests have no ordering dependency.
+if [ -n "$CVMFS_TEST_SHUFFLE" ] && [ "$CVMFS_TEST_SHUFFLE" != "0" ]; then
+  testsuite=$(shuf -e $@)
+else
+  testsuite="$@"
+fi
 if [ -z "$testsuite" ]; then
   if [ "$suite_option_provided" -eq 0 ] && [ -z "$labels" ]; then
     labels="quick"


### PR DESCRIPTION
This is to stress the assumptions that the tests do not have dependency on each other and that the cleanup after each test is sufficient.