### PR TITLE
test/src/101-cpuaffinity: skip and warn on 1-core system

### DIFF
--- a/test/src/101-cpuaffinity/main
+++ b/test/src/101-cpuaffinity/main
@@ -15,6 +15,11 @@ cvmfs_run_test() {
     return 0
   fi
 
+  if [ "$(nproc)" == 1 ]; then
+    echo "Cannot test CPU affinity behaviour on a single core system"
+    CVMFS_GENERAL_WARNING_FLAG=1
+    return 0
+  fi
   echo "*** mount cernvm-prod.cern.ch with cpu affinity 0,1"
   cvmfs_mount cernvm-prod.cern.ch CVMFS_CPU_AFFINITY=0,1 || return 1
 


### PR DESCRIPTION
When run on a system with a single CPU, the test failed, because it reads back affinity value "0" (first CPU only), while it expects "0,1" (first and second CPU).

It's impossible to test much on a single-core system, so skip it and emit a warning.