### PR TITLE
Suggestions on the pool of fetchers version

### DIFF
--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -134,7 +134,7 @@ BundleMgr::BundleMgr(MountPoint *mp, const PathString &path)
     }
   }
 
-  SpawnFetcher();
+  SpawnFetcherPool();
 }
 
 void BundleMgr::Fetch() {
@@ -152,7 +152,7 @@ void BundleMgr::Fetch() {
   }
 }
 
-void BundleMgr::JoinFetcher() {
+void BundleMgr::JoinFetcherPool() {
   if (pipe_bm_[1] < 0) return;
   // Send one kTerminate per worker. Workers drain all queued kFetch
   // messages before reaching their kTerminate (FIFO pipe), so we can't
@@ -172,7 +172,7 @@ void BundleMgr::JoinFetcher() {
   ClosePipe(pipe_bm_);
 }
 
-void BundleMgr::SpawnFetcher() {
+void BundleMgr::SpawnFetcherPool() {
   MakePipe(pipe_bm_);
   back_channel_ = pipe_bm_[1];
 

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <memory>
 
 #include <cassert>
 #include <cerrno>
@@ -98,7 +99,7 @@ BundleFileMgr *LoadBundleFromCvmfs(MountPoint *mp,
 BundleMgr::BundleMgr(MountPoint *mp, const PathString &path)
     : mount_point_(mp),
       path_(path),
-      fetcher_threads_(new std::vector<pthread_t>()),
+      fetcher_threads_(),
       pool_size_(kDefaultBundlePoolSize) {
   fname_ = GetFileName(path_);
   parent_path_ = GetParentPath(path_);
@@ -156,7 +157,7 @@ void BundleMgr::JoinFetcher() {
   // Send one kTerminate per worker. Workers drain all queued kFetch
   // messages before reaching their kTerminate (FIFO pipe), so we can't
   // just close the pipe — that would EOF some workers mid-drain.
-  for (size_t i = 0; i < fetcher_threads_->size(); ++i) {
+  for (size_t i = 0; i < fetcher_threads_.size(); ++i) {
     Command cmd = Command::kTerminate;
     while (true) {
       const ssize_t n = ::write(pipe_bm_[1], &cmd, sizeof(Command));
@@ -165,8 +166,8 @@ void BundleMgr::JoinFetcher() {
     }
   }
   // Wait for every worker to drain its share of the queue and exit.
-  for (auto &t : *fetcher_threads_) {
-    pthread_join(t, nullptr);
+  for (auto &t : fetcher_threads_) {
+    pthread_join(*t, nullptr);
   }
   ClosePipe(pipe_bm_);
 }
@@ -181,18 +182,18 @@ void BundleMgr::SpawnFetcher() {
   const int flags = fcntl(back_channel_, F_GETFL);
   fcntl(back_channel_, F_SETFL, flags | O_NONBLOCK);
 
-  fetcher_threads_->resize(pool_size_);
   for (size_t i = 0; i < pool_size_; ++i) {
-    const int res = pthread_create(&(*fetcher_threads_)[i], nullptr,
+    auto thread =std::make_unique<pthread_t>();
+    const int res = pthread_create(thread.get(), nullptr,
                                    MainBundleMgrFetcher, this);
     if (res != 0) {
       LogCvmfs(kLogBundleMgr, kLogDebug,
                "Thread creation failed! pool_size_=%zu spawned=%zu",
                pool_size_, i);
-      fetcher_threads_->resize(i);
       is_valid_ = false;
       return;
     }
+    fetcher_threads_.emplace_back(std::move(thread));
   }
 }
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -30,7 +30,7 @@ class BundleMgr : SingleCopy {
  public:
   BundleMgr(MountPoint *mp, const PathString &path);
   virtual ~BundleMgr() {
-    JoinFetcher();
+    JoinFetcherPool();
     pthread_mutex_destroy(&worker_read_mutex_);
     delete bfm_;
   }
@@ -39,8 +39,8 @@ class BundleMgr : SingleCopy {
 
  private:
   static void *MainBundleMgrFetcher(void *data);
-  void SpawnFetcher();
-  void JoinFetcher();
+  void SpawnFetcherPool();
+  void JoinFetcherPool();
   PathString ReceivePath(int fd) const;
   bool TrySendPath(int fd, const PathString &path) const;
 

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 #include <vector>
 
@@ -31,7 +32,6 @@ class BundleMgr : SingleCopy {
   virtual ~BundleMgr() {
     JoinFetcher();
     pthread_mutex_destroy(&worker_read_mutex_);
-    delete fetcher_threads_;
     delete bfm_;
   }
   void Fetch();
@@ -115,7 +115,7 @@ class BundleMgr : SingleCopy {
   // Pool of fetcher threads. All workers share pipe_bm_[0] (read end)
   // and serialize their reads via worker_read_mutex_ so cmd+payload
   // pairs are received atomically.
-  std::vector<pthread_t> *fetcher_threads_;
+  std::vector<std::unique_ptr<pthread_t> > fetcher_threads_;
   pthread_mutex_t worker_read_mutex_;
   size_t pool_size_;
   int back_channel_;

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -181,6 +181,10 @@ const int kNumReservedFd = 512;
  * Warn if the process has a lower limit for the number of open file descriptors
  */
 const unsigned int kMinOpenFiles = 8192;
+/**
+ * Indicates if file bundle prefetching is enabled.
+ */
+bool prefetch_file_bundles_= false;
 
 
 class FuseInterruptCue : public InterruptCue {
@@ -1200,14 +1204,7 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
 
   perf::Inc(file_system_->n_fs_open());  // Count actual open / fetch operations
 
-  std::string is_prefetching_enabled;
-  if (options_mgr_) {
-    options_mgr_->GetValue("CVMFS_PREFETCH_FILEBUNDLES",
-                           &is_prefetching_enabled);
-  }
-  if (dirent.IsBundleTrigger() and (options_mgr_)
-          ? options_mgr_->IsOn(is_prefetching_enabled)
-          : false) {
+  if (dirent.IsBundleTrigger() and prefetch_file_bundles_) {
     // fetch dependences if not there already
     PathString trigger_path;
     assert(GetPathForInode(ino, &trigger_path)
@@ -2469,6 +2466,16 @@ static int Init(const loader::LoaderExports *loader_exports) {
   crypto::SetupLibcryptoMt();
 
   InitOptionsMgr(loader_exports);
+  if (cvmfs::options_mgr_) {
+    std::string is_prefetching_enabled;
+    cvmfs::options_mgr_->GetValue("CVMFS_PREFETCH_FILEBUNDLES",
+                                  &is_prefetching_enabled);
+    cvmfs::prefetch_file_bundles_ = cvmfs::options_mgr_->IsOn(
+        is_prefetching_enabled);
+  } else {
+    LogCvmfs(kLogCvmfs, kLogSyslog | kLogDebug,
+             "OptionsManager excpected to be initialized but isn't");
+  }
 
   // We need logging set up before forking the watchdog
   FileSystem::SetupLoggingStandalone(*cvmfs::options_mgr_,


### PR DESCRIPTION


1. I change the pool of fetchers from a `std::vector<pthread_t>*` to a `std::vector<std::unique_ptr<pthread_t>>`
The motivation here is that there is no need to keep the pool vector via a pointer (minor) 


2. I changed the pool creation policy.
In the old version first we'ld default construct threads for the entire pool, and in case of an initialization failure we'ld default destruct what was not initialized properly. 
Now I just increment the pool with the properly initialized fetcher threads.

+ Extra:
Determines if feature is used during `Init()`. This should make the decision on whether we should look for a trigger file in the first place faster (important when feature is disabled).