### PR TITLE
[deb-release] remove static lists for each release

### DIFF
--- a/packaging/debian/cernvm.list.resolute
+++ b/packaging/debian/cernvm.list.resolute
@@ -1,0 +1,2 @@
+deb http://cvmrepo.s3.cern.ch/cvmrepo/apt resolute-prod main
+# deb http://cvmrepo.s3.cern.ch/cvmrepo/apt resolute-testing main

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -1,4 +1,12 @@
 
+cvmfs-release (5.0) unstable; urgency=low
+
+  * Derive the apt suite (<codename>-prod) from os-release at install time
+    instead of shipping a cernvm.list.<codename> file per release; new
+    Debian/Ubuntu releases now work without a cvmfs-release update
+
+ -- Valentin Volkl <vavolkl@cern.ch>  Mon, 25 May 2026 09:34:00 +0200
+
 cvmfs-release (4.9) unstable; urgency=low
 
   * Add Ubuntu 26.04 "resolute"

--- a/packaging/debian/cvmfs-release/changelog
+++ b/packaging/debian/cvmfs-release/changelog
@@ -1,4 +1,13 @@
 
+cvmfs-release (4.9) unstable; urgency=low
+
+  * Add Ubuntu 26.04 "resolute"
+  * Fix Ubuntu fallback: $ID in os-release is lowercase "ubuntu", so
+    unsupported Ubuntu releases were wrongly falling back to Debian bookworm
+  * Add noble (24.04) and resolute (26.04) Ubuntu fallback tiers
+
+ -- Valentin Volkl <vavolkl@cern.ch>  Mon, 25 May 2026 09:34:00 +0200
+
 cvmfs-release (4.8) unstable; urgency=low
 
   * Add Ubuntu 25.10 "questing"

--- a/packaging/debian/cvmfs-release/postinst
+++ b/packaging/debian/cvmfs-release/postinst
@@ -29,8 +29,14 @@ case "$1" in
 	else
 		version_major=$(env -i sh -c '. /etc/os-release; echo $VERSION_ID' | cut -d. -f1)
 		fallback_release=
-    if [ "$ID" = "Ubuntu" ]; then
-      if [ $version_major -ge 22 ]; then
+    if [ "$ID" = "ubuntu" ]; then
+      if [ $version_major -ge 26 ]; then
+        echo "Warning: this distribution is not supported. Using Ubuntu 26.04 packages as fallback."
+        fallback_release=resolute
+      elif [ $version_major -ge 24 ]; then
+        echo "Warning: this distribution is not supported. Using Ubuntu 24.04 packages as fallback."
+        fallback_release=noble
+      elif [ $version_major -ge 22 ]; then
         echo "Warning: this distribution is not supported. Using Ubuntu 22.04 packages as fallback."
         fallback_release=jammy
       elif [ $version_major -ge 20 ]; then

--- a/packaging/debian/cvmfs-release/postinst
+++ b/packaging/debian/cvmfs-release/postinst
@@ -31,22 +31,35 @@ case "$1" in
 	# the server, e.g. a freshly released distro CVMFS has not built for yet.
 	# This list changes rarely (roughly once per LTS), never per release.
 	case "$id" in
-	    ubuntu) fallbacks="noble jammy focal bionic xenial" ;;
+	    ubuntu) fallbacks="resolute noble jammy focal bionic xenial" ;;
 	    *)      fallbacks="trixie bookworm bullseye buster" ;; # debian & derivatives
 	esac
 
 	# Returns 0 if "<suite>-prod" is published, 1 if not, 2 if we cannot tell
-	# (no probing tool / no network). Never aborts under 'set -e'.
+	# (no probing tool / transport failure). Never aborts under 'set -e'.
 	suite_published() {
 	    _url="$base_url/dists/$1-prod/InRelease"
 	    if command -v curl >/dev/null 2>&1; then
-	        curl -fsI --max-time 10 "$_url" >/dev/null 2>&1
+	        _status=$(curl -sS -o /dev/null -w '%{http_code}' -I --max-time 10 "$_url")
+	        _rc=$?
+	        [ $_rc -eq 0 ] || return 2
+	        [ "$_status" = 200 ] && return 0
+	        [ "$_status" = 404 ] && return 1
+	        return 2
 	    elif command -v wget >/dev/null 2>&1; then
-	        wget -q --timeout=10 --spider "$_url" >/dev/null 2>&1
+	        _response=$(wget -q --timeout=10 --spider --server-response "$_url" 2>&1)
+	        _rc=$?
+	        [ $_rc -eq 0 ] && return 0
+	        _status=$(printf '%s\n' "$_response" |
+	            awk '$1 ~ /^HTTP\// { status=$2 } END { print status }')
+	        [ "$_status" = 404 ] && return 1
+	        return 2
 	    elif [ -x /usr/lib/apt/apt-helper ]; then
 	        _tmp=$(mktemp)
 	        /usr/lib/apt/apt-helper download-file "$_url" "$_tmp" >/dev/null 2>&1
-	        _rc=$?; rm -f "$_tmp"; return $_rc
+	        _rc=$?; rm -f "$_tmp"
+	        [ $_rc -eq 0 ] && return 0
+	        return 2
 	    else
 	        return 2
 	    fi
@@ -66,7 +79,9 @@ case "$1" in
 	fi
 	if [ -z "$suite" ]; then
 	    for cand in $fallbacks; do
-	        if suite_published "$cand"; then suite="$cand"; break; fi
+	        rc=0; suite_published "$cand" || rc=$?
+	        if [ $rc -eq 0 ]; then suite="$cand"; break; fi
+	        [ $rc -eq 2 ] && break
 	    done
 	    if [ -n "$suite" ]; then
 	        echo "Warning: '${codename}-prod' is not available yet; using '${suite}-prod' as fallback." >&2

--- a/packaging/debian/cvmfs-release/postinst
+++ b/packaging/debian/cvmfs-release/postinst
@@ -20,44 +20,67 @@ set -e
 
 case "$1" in
     configure)
+	base_url="http://cvmrepo.s3.cern.ch/cvmrepo/apt"
+	dest="/etc/apt/sources.list.d/cernvm.list"
+
 	codename=$(env -i sh -c '. /etc/os-release; echo $VERSION_CODENAME')
-	ID=$(env -i sh -c '. /etc/os-release; echo $ID')
-	repolist=/usr/share/cvmfs-release/cernvm.list.${codename}
-	mkdir -p /etc/apt/sources.list.d
-	if [ -f $repolist ]; then
-	  ln -f -s $repolist /etc/apt/sources.list.d/cernvm.list
-	else
-		version_major=$(env -i sh -c '. /etc/os-release; echo $VERSION_ID' | cut -d. -f1)
-		fallback_release=
-    if [ "$ID" = "ubuntu" ]; then
-      if [ $version_major -ge 26 ]; then
-        echo "Warning: this distribution is not supported. Using Ubuntu 26.04 packages as fallback."
-        fallback_release=resolute
-      elif [ $version_major -ge 24 ]; then
-        echo "Warning: this distribution is not supported. Using Ubuntu 24.04 packages as fallback."
-        fallback_release=noble
-      elif [ $version_major -ge 22 ]; then
-        echo "Warning: this distribution is not supported. Using Ubuntu 22.04 packages as fallback."
-        fallback_release=jammy
-      elif [ $version_major -ge 20 ]; then
-        echo "Warning: this distribution is not supported. Using Ubuntu 20.04 packages as fallback."
-        fallback_release=focal
-      elif [ $version_major -ge 18 ]; then
-        echo "Warning: this distribution is not supported. Using Ubuntu 18.04 packages as fallback."
-        fallback_release=bionic
-      else
-        echo "Warning: this distribution is not supported. Using Ubuntu 16.04 packages as fallback."
-        fallback_release=xenial
-      fi
-    else
-      # debian
-      echo "Warning: this distribution is not supported. Using Debian bookworm packages as fallback."
-      fallback_release=bookworm
-    fi
-    
-		ln -f -s /usr/share/cvmfs-release/cernvm.list.$fallback_release \
-	        /etc/apt/sources.list.d/cernvm.list
+	id=$(env -i sh -c '. /etc/os-release; echo $ID')
+
+	# Ordered fallback suites (newest first). Only used when the running
+	# distribution's own "<codename>-prod" suite is not (yet) published on
+	# the server, e.g. a freshly released distro CVMFS has not built for yet.
+	# This list changes rarely (roughly once per LTS), never per release.
+	case "$id" in
+	    ubuntu) fallbacks="noble jammy focal bionic xenial" ;;
+	    *)      fallbacks="trixie bookworm bullseye buster" ;; # debian & derivatives
+	esac
+
+	# Returns 0 if "<suite>-prod" is published, 1 if not, 2 if we cannot tell
+	# (no probing tool / no network). Never aborts under 'set -e'.
+	suite_published() {
+	    _url="$base_url/dists/$1-prod/InRelease"
+	    if command -v curl >/dev/null 2>&1; then
+	        curl -fsI --max-time 10 "$_url" >/dev/null 2>&1
+	    elif command -v wget >/dev/null 2>&1; then
+	        wget -q --timeout=10 --spider "$_url" >/dev/null 2>&1
+	    elif [ -x /usr/lib/apt/apt-helper ]; then
+	        _tmp=$(mktemp)
+	        /usr/lib/apt/apt-helper download-file "$_url" "$_tmp" >/dev/null 2>&1
+	        _rc=$?; rm -f "$_tmp"; return $_rc
+	    else
+	        return 2
+	    fi
+	}
+
+	# Prefer the distribution's own suite, derived from the codename. This is
+	# what makes new Debian/Ubuntu releases work with no package update: as
+	# soon as the server publishes "<codename>-prod", users get it. If that
+	# suite is not yet there (and we can probe), degrade to the newest
+	# available fallback. If we cannot probe at all, trust the codename.
+	suite=""
+	if [ -n "$codename" ]; then
+	    rc=0; suite_published "$codename" || rc=$?
+	    if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then
+	        suite="$codename"
+	    fi
 	fi
+	if [ -z "$suite" ]; then
+	    for cand in $fallbacks; do
+	        if suite_published "$cand"; then suite="$cand"; break; fi
+	    done
+	    if [ -n "$suite" ]; then
+	        echo "Warning: '${codename}-prod' is not available yet; using '${suite}-prod' as fallback." >&2
+	    fi
+	fi
+	# Last resort: trust the codename even if unverified, so apt at least
+	# points somewhere meaningful and reports a clear error on update.
+	[ -n "$suite" ] || suite="$codename"
+
+	mkdir -p /etc/apt/sources.list.d
+	cat > "$dest" <<EOF
+deb $base_url ${suite}-prod main
+# deb $base_url ${suite}-testing main
+EOF
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
With this PR, we no longer need to update the cvmfs release package for each debian / ubuntu update. Instead, it will try the current release codename and will only fall back when no packages are available under the expected URL.