### PR TITLE
test: inflate_file() performance improvement

### DIFF
--- a/test/src/510-filechunks/main
+++ b/test/src/510-filechunks/main
@@ -91,7 +91,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* "$reference_dir" || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/510-filechunks/main
+++ b/test/src/510-filechunks/main
@@ -3,17 +3,6 @@ cvmfs_test_name="Creating File Chunks"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
 	local working_dir=$1
 

--- a/test/src/511-removefilechunks/main
+++ b/test/src/511-removefilechunks/main
@@ -96,7 +96,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* $reference_dir || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/511-removefilechunks/main
+++ b/test/src/511-removefilechunks/main
@@ -3,17 +3,6 @@ cvmfs_test_name="Remove Chunked File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
   local working_dir=$1
 

--- a/test/src/512-movechunkstonested/main
+++ b/test/src/512-movechunkstonested/main
@@ -95,7 +95,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* $reference_dir || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?
@@ -115,7 +115,7 @@ cvmfs_run_test() {
   change_files_in $repo_dir || return 5
 
   echo "create the nested catalog mark in the reference directory"
-  change_files_in $reference_dir || return 6
+  cp -a "$repo_dir"/* "$reference_dir" || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/512-movechunkstonested/main
+++ b/test/src/512-movechunkstonested/main
@@ -3,17 +3,6 @@ cvmfs_test_name="Move Chunked File To Nested Catalog"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
   local working_dir=$1
 

--- a/test/src/513-mergechunksfromnested/main
+++ b/test/src/513-mergechunksfromnested/main
@@ -96,7 +96,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* $reference_dir || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/513-mergechunksfromnested/main
+++ b/test/src/513-mergechunksfromnested/main
@@ -3,17 +3,6 @@ cvmfs_test_name="Merge Nested Catalog Containing Chunked File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
   local working_dir=$1
 

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -138,7 +138,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* "$reference_dir" || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -74,17 +74,7 @@ change_files_in() {
 
   # remove the original 50 megabyte file and replace it by a
   # slightly different version
-  local bigfile=big_file/50megabyte
-  rm $bigfile
-  touch $bigfile
-  local first_hit=0
-  while [ $(stat -c %s $bigfile) -lt 52428800 ]; do
-    cat /bin/ls >> $bigfile
-    if [ $first_hit -eq 0 ]; then
-      echo "You need to understand recursion in order to understand recursion" >> $bigfile
-      first_hit=1
-    fi
-  done
+  inflate_file big_file/50megabyte _ 50000000
 
   popdir
 }
@@ -135,7 +125,7 @@ cvmfs_run_test() {
   change_files_in $repo_dir || return 5
 
   echo "change the chunked file slightly in the reference directory"
-  change_files_in $reference_dir || return 6
+  cp -a "$repo_dir"/* $reference_dir || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -3,17 +3,6 @@ cvmfs_test_name="Change a Chunked File"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
   local working_dir=$1
 

--- a/test/src/514-changechunkedfile/main
+++ b/test/src/514-changechunkedfile/main
@@ -89,34 +89,6 @@ change_files_in() {
   popdir
 }
 
-check_chunk_alignment() {
-  local repo_name=$1
-  local old_clg_hash=$2
-  local new_clg_hash=$3
-
-  local old_catalog="$(download_and_decompress_object $repo_name ${old_clg_hash}C)"
-  local new_catalog="$(download_and_decompress_object $repo_name ${new_clg_hash}C)"
-
-  load_repo_config $repo_name
-
-  local big_file="50megabyte" # see change_files_in()
-
-  # compare the chunk sizes of associated chunks in the old and the new version
-  # of the updated file.
-  # the final output is the chunk difference which occured most frequently
-  # --> in the best case this is 0 :-)
-  most_common_size_difference=$(echo " \
-  ATTACH '${old_catalog}' AS old; \
-  ATTACH '${new_catalog}' AS new; \
-  CREATE TEMPORARY TABLE old_offsets (rownum INTEGER PRIMARY KEY AUTOINCREMENT, offset INTEGER, size INTEGER); \
-  CREATE TEMPORARY TABLE new_offsets (rownum INTEGER PRIMARY KEY AUTOINCREMENT, offset INTEGER, size INTEGER); \
-  INSERT INTO old_offsets (offset, size) SELECT offset, size FROM old.chunks WHERE md5path_1 = (SELECT md5path_1 FROM old.catalog WHERE name = '${big_file}') ORDER BY offset; \
-  INSERT INTO new_offsets (offset, size) SELECT offset, size FROM new.chunks WHERE md5path_1 = (SELECT md5path_1 FROM new.catalog WHERE name = '${big_file}') ORDER BY offset; \
-  SELECT new.size - old.size FROM old_offsets AS old, new_offsets AS new WHERE old.rownum = new.rownum GROUP BY new.size - old.size ORDER BY count(new.size - old.size) DESC LIMIT 1;" | sqlite3)
-
-  [ $most_common_size_difference -eq 0 ]
-}
-
 cvmfs_run_test() {
   logfile=$1
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
@@ -177,11 +149,6 @@ cvmfs_run_test() {
   echo -n "retrieving name of new root catalog... "
   local new_root_catalog="$(get_current_root_catalog $CVMFS_TEST_REPO)"
   echo $new_root_catalog
-
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-  echo "check if most chunks are still aligned after the edit"
-  check_chunk_alignment $CVMFS_TEST_REPO $old_root_catalog $new_root_catalog || return 7
 
   return 0
 }

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -124,7 +124,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* $reference_dir || return 4
 
   local publish_log_1="publish_1.log"
   echo "creating CVMFS snapshot (logging into $publish_log_1)"

--- a/test/src/516-createsnapshotadvanced/main
+++ b/test/src/516-createsnapshotadvanced/main
@@ -2,17 +2,6 @@
 cvmfs_test_name="Create Stratum1 snapshot with nested Catalogs and Chunked Files"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
   local working_dir=$1
 

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -2,17 +2,6 @@
 cvmfs_test_name="Create a Series of Stratum1 snapshots"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
   local working_dir=$1
 

--- a/test/src/521-createmultiplesnapshots/main
+++ b/test/src/521-createmultiplesnapshots/main
@@ -265,7 +265,7 @@ cvmfs_run_test() {
   produce_files_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch space for comparison"
-  produce_files_in $reference_dir || return 4
+  cp -a "$repo_dir"/* $reference_dir || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO || return $?

--- a/test/src/528-recreatespoolarea/main
+++ b/test/src/528-recreatespoolarea/main
@@ -2,17 +2,6 @@
 cvmfs_test_name="Recreate Repository Spool Area"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
 	local working_dir=$1
 

--- a/test/src/530-recreatespoolarea_defaultkey/main
+++ b/test/src/530-recreatespoolarea_defaultkey/main
@@ -2,17 +2,6 @@
 cvmfs_test_name="Recreate Repository Spool Area (Default Key Location)"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
 	local working_dir=$1
 

--- a/test/src/542-storagescrubbing/main
+++ b/test/src/542-storagescrubbing/main
@@ -2,17 +2,6 @@
 cvmfs_test_name="Local File Backend Health Check"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
 	local working_dir=$1
 

--- a/test/src/543-storagescrubbing_scriptable/main
+++ b/test/src/543-storagescrubbing_scriptable/main
@@ -2,17 +2,6 @@
 cvmfs_test_name="Local File Backend Health Check (Machine Readable)"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_in() {
 	local working_dir=$1
 

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -134,7 +134,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 1
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 2
+  cp -a "$repo_dir"/* $reference_dir1 || return 2
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
@@ -155,8 +155,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 4
-  produce_files_2_in $reference_dir2 || return 4
+  cp -a "$repo_dir"/* $reference_dir2 || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
@@ -177,9 +176,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 5
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return 6
-  produce_files_2_in $reference_dir3 || return 6
-  produce_files_3_in $reference_dir3 || return 6
+  cp -a "$repo_dir"/* $reference_dir3 || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?
@@ -200,10 +197,7 @@ cvmfs_run_test() {
   produce_files_4_in $repo_dir || return 7
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir4 || return 8
-  produce_files_2_in $reference_dir4 || return 8
-  produce_files_3_in $reference_dir4 || return 8
-  produce_files_4_in $reference_dir4 || return 8
+  cp -a "$repo_dir"/* $reference_dir4 || return 8
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_4.log 2>&1 || return $?

--- a/test/src/557-basicgarbagecollect/main
+++ b/test/src/557-basicgarbagecollect/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Basic Garbage Collection"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/558-garbagecollectnestedcatalogs/main
+++ b/test/src/558-garbagecollectnestedcatalogs/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Garbage Collection With Nested Catalogs"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/558-garbagecollectnestedcatalogs/main
+++ b/test/src/558-garbagecollectnestedcatalogs/main
@@ -177,7 +177,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 1
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 2
+  cp -a "$repo_dir"/* $reference_dir1 || return 2
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
@@ -195,8 +195,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 4
-  produce_files_2_in $reference_dir2 || return 4
+  cp -a "$repo_dir"/* $reference_dir2 || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
@@ -214,9 +213,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 5
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return 6
-  produce_files_2_in $reference_dir3 || return 6
-  produce_files_3_in $reference_dir3 || return 6
+  cp -a "$repo_dir"/* $reference_dir3 || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?
@@ -234,10 +231,7 @@ cvmfs_run_test() {
   produce_files_4_in $repo_dir || return 7
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir4 || return 8
-  produce_files_2_in $reference_dir4 || return 8
-  produce_files_3_in $reference_dir4 || return 8
-  produce_files_4_in $reference_dir4 || return 8
+  cp -a "$repo_dir"/* $reference_dir4 || return 8
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_4.log 2>&1 || return $?

--- a/test/src/559-garbagecollectnamedtags/main
+++ b/test/src/559-garbagecollectnamedtags/main
@@ -179,7 +179,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 1
 
   echo "*** putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 2
+  cp -a "$repo_dir"/* $reference_dir1 || return 2
 
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO -a revision_1 -m "create some files in dir1" > publish_1.log 2>&1 || return $?
@@ -196,8 +196,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 3
 
   echo "*** putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 4
-  produce_files_2_in $reference_dir2 || return 4
+  cp -a "$repo_dir"/* $reference_dir2 || return 4
 
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO -a revision_2 -m "put some poems in dir2" > publish_2.log 2>&1 || return $?
@@ -214,9 +213,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 5
 
   echo "*** putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return 6
-  produce_files_2_in $reference_dir3 || return 6
-  produce_files_3_in $reference_dir3 || return 6
+  cp -a "$repo_dir"/* $reference_dir3 || return 6
 
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO -a revision_3 -m "put poems in dir3 and remove dir1" > publish_3.log 2>&1 || return $?
@@ -233,10 +230,7 @@ cvmfs_run_test() {
   produce_files_4_in $repo_dir || return 7
 
   echo "*** putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir4 || return 8
-  produce_files_2_in $reference_dir4 || return 8
-  produce_files_3_in $reference_dir4 || return 8
-  produce_files_4_in $reference_dir4 || return 8
+  cp -a "$repo_dir"/* $reference_dir4 || return 8
 
   echo "*** creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO -a revision_4 -m "delete dir3" > publish_4.log 2>&1 || return $?

--- a/test/src/559-garbagecollectnamedtags/main
+++ b/test/src/559-garbagecollectnamedtags/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Garbage Collection With Named Tag Awareness"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/561-garbagecollectmultihash/main
+++ b/test/src/561-garbagecollectmultihash/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Garbage Collection With Multiple Hash Algorithms"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/561-garbagecollectmultihash/main
+++ b/test/src/561-garbagecollectmultihash/main
@@ -183,7 +183,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 1
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 2
+  cp -a "$repo_dir"/* $reference_dir1 || return 2
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
@@ -206,8 +206,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 4
-  produce_files_2_in $reference_dir2 || return 4
+  cp -a "$repo_dir"/* $reference_dir2 || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
@@ -225,9 +224,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 5
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return 6
-  produce_files_2_in $reference_dir3 || return 6
-  produce_files_3_in $reference_dir3 || return 6
+  cp -a "$repo_dir"/* $reference_dir3 || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?
@@ -245,10 +242,7 @@ cvmfs_run_test() {
   produce_files_4_in $repo_dir || return 7
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir4 || return 8
-  produce_files_2_in $reference_dir4 || return 8
-  produce_files_3_in $reference_dir4 || return 8
-  produce_files_4_in $reference_dir4 || return 8
+  cp -a "$repo_dir"/* $reference_dir4 || return 8
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_4.log 2>&1 || return $?

--- a/test/src/573-garbagecollecttimestamp/main
+++ b/test/src/573-garbagecollecttimestamp/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Garbage Collection Until Specified Timestamp"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/573-garbagecollecttimestamp/main
+++ b/test/src/573-garbagecollecttimestamp/main
@@ -189,7 +189,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 1
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 2
+  cp -a "$repo_dir"/* $reference_dir1 || return 2
 
   timestamp1="$(get_timestamp)"
   echo "creating CVMFS snapshot ($(display_timestamp $timestamp1))"
@@ -208,8 +208,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 4
-  produce_files_2_in $reference_dir2 || return 4
+  cp -a "$repo_dir"/* $reference_dir2 || return 4
 
   timestamp2="$(get_timestamp)"
   echo "creating CVMFS snapshot ($(display_timestamp $timestamp2))"
@@ -228,9 +227,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 5
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return 6
-  produce_files_2_in $reference_dir3 || return 6
-  produce_files_3_in $reference_dir3 || return 6
+  cp -a "$repo_dir"/* $reference_dir3 || return 6
 
   timestamp3="$(get_timestamp)"
   echo "creating CVMFS snapshot ($(display_timestamp $timestamp3))"
@@ -249,10 +246,7 @@ cvmfs_run_test() {
   produce_files_4_in $repo_dir || return 7
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir4 || return 8
-  produce_files_2_in $reference_dir4 || return 8
-  produce_files_3_in $reference_dir4 || return 8
-  produce_files_4_in $reference_dir4 || return 8
+  cp -a "$repo_dir"/* $reference_dir4 || return 8
 
   timestamp4="$(get_timestamp)"
   echo "creating CVMFS snapshot ($(display_timestamp $timestamp4))"

--- a/test/src/574-garbagecollecttimestampwithtags/main
+++ b/test/src/574-garbagecollecttimestampwithtags/main
@@ -196,7 +196,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 1
 
   echo "*** {1} putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 2
+  cp -a "$repo_dir"/* $reference_dir1 || return 2
 
   timestamp1="$(get_timestamp)"
   echo "*** {1} creating CVMFS snapshot ($(display_timestamp $timestamp1))"

--- a/test/src/574-garbagecollecttimestampwithtags/main
+++ b/test/src/574-garbagecollecttimestampwithtags/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Garbage Collection Until Specified Timestamp With Named Snapshots"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -219,7 +219,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 4
+  cp -a "$repo_dir"/* $reference_dir1 || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
@@ -237,8 +237,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 5
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 6
-  produce_files_2_in $reference_dir2 || return 6
+  cp -a "$repo_dir"/* $reference_dir2 || return 6
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
@@ -256,9 +255,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 7
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return 8
-  produce_files_2_in $reference_dir3 || return 8
-  produce_files_3_in $reference_dir3 || return 8
+  cp -a "$repo_dir"/* $reference_dir3 || return 8
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?
@@ -276,10 +273,7 @@ cvmfs_run_test() {
   produce_files_4_in $repo_dir || return 9
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir4 || return 10
-  produce_files_2_in $reference_dir4 || return 10
-  produce_files_3_in $reference_dir4 || return 10
-  produce_files_4_in $reference_dir4 || return 10
+  cp -a "$repo_dir"/* $reference_dir4 || return 10
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_4.log 2>&1 || return $?

--- a/test/src/576-garbagecollectstratum1/main
+++ b/test/src/576-garbagecollectstratum1/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Garbage Collection on Replication Server"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/581-snapshotgarbagecollectedrepo/main
+++ b/test/src/581-snapshotgarbagecollectedrepo/main
@@ -149,7 +149,7 @@ cvmfs_run_test() {
   produce_files_1_in $repo_dir || return 3
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir1 || return 4
+  cp -a "$repo_dir"/* $reference_dir1 || return 4
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_1.log 2>&1 || return $?
@@ -167,8 +167,7 @@ cvmfs_run_test() {
   produce_files_2_in $repo_dir || return 5
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir2 || return 6
-  produce_files_2_in $reference_dir2 || return 7
+  cp -a "$repo_dir"/* $reference_dir2 || return 7
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_2.log 2>&1 || return $?
@@ -186,9 +185,7 @@ cvmfs_run_test() {
   produce_files_3_in $repo_dir || return 8
 
   echo "putting exactly the same stuff in the scratch spaces for comparison"
-  produce_files_1_in $reference_dir3 || return  9
-  produce_files_2_in $reference_dir3 || return 10
-  produce_files_3_in $reference_dir3 || return 11
+  cp -a "$repo_dir"/* $reference_dir3 || return 9
 
   echo "creating CVMFS snapshot"
   publish_repo $CVMFS_TEST_REPO > publish_3.log 2>&1 || return $?

--- a/test/src/581-snapshotgarbagecollectedrepo/main
+++ b/test/src/581-snapshotgarbagecollectedrepo/main
@@ -3,17 +3,6 @@
 cvmfs_test_name="Replicate Garbage Collected Repository"
 cvmfs_test_autofs_on_startup=false
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 produce_files_1_in() {
   local working_dir=$1
   pushdir $working_dir

--- a/test/src/660-store_publish_statistics/main
+++ b/test/src/660-store_publish_statistics/main
@@ -10,17 +10,6 @@ CVMFS_TEST_660_TAR_FILE=tarfile.tar
 CVMFS_TEST_660_TAR_DIR=newTarDir
 CVMFS_TEST_660_REPO=
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 test1() {
   local working_dir=$1
 

--- a/test/src/660-store_publish_statistics/main
+++ b/test/src/660-store_publish_statistics/main
@@ -66,8 +66,29 @@ test5() {
   mkdir foo
   touch foo/.cvmfscatalog
   echo "smallfilesmallfile" > foo/smallfile
-  inflate_file foo/mediumfile foo/smallfile 100000     # 100kB file
-  inflate_file foo/bigfile foo/mediumfile   100000000  # 100MB file
+
+  # inflate_file() with random contents results in unstable n_chunks_added.
+  # For backwards compatibility, exactly same content is generated, with what acceleration is possible.
+  #inflate_file foo/mediumfile foo/smallfile 100000     # 100kB file
+  #inflate_file foo/bigfile foo/mediumfile   100000000  # 100MB file
+  local string_bytes=19
+  mediumfile_bytes=$(( (100000 + string_bytes - 1) / string_bytes * string_bytes ))
+  [[ $mediumfile_bytes == 100016 ]]
+  bigfile_bytes=$(( (100000000 + mediumfile_bytes - 1) / mediumfile_bytes * mediumfile_bytes ))
+  [[ $bigfile_bytes == 100016000 ]]
+
+  head -c $mediumfile_bytes > foo/mediumfile <(set +e; yes smallfilesmallfile; true)
+
+  [[ "$(stat -c %s foo/mediumfile)" == $mediumfile_bytes ]]
+  head -c $bigfile_bytes > foo/bigfile <(
+    set +e
+    while cat foo/mediumfile; do
+      true
+    done
+    true
+  )
+  [[ "$(stat -c %s foo/bigfile)" == $bigfile_bytes ]]
+
   popdir
 }
 

--- a/test/src/670-listreflog/main
+++ b/test/src/670-listreflog/main
@@ -3,17 +3,6 @@ cvmfs_test_name="Swissknife list_reflog feature"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-inflate_file() {
-  local destination_file=$1
-  local source_file=$2
-  local desired_file_size=$3
-
-  touch $destination_file
-  while [ $(stat -c %s $destination_file) -lt $desired_file_size ]; do
-    cat $source_file >> $destination_file
-  done
-}
-
 check_reflog_list() {
   list_objects=$(cvmfs_swissknife list_reflog -r /srv/cvmfs/$CVMFS_TEST_REPO -n $CVMFS_TEST_REPO -R /var/spool/cvmfs/$CVMFS_TEST_REPO/reflog.chksum)
   for f in $list_objects; do

--- a/test/test_functions
+++ b/test/test_functions
@@ -2757,3 +2757,16 @@ expect_exit_code() {
   "$@" || rc=$?
   [[ "$rc" == "$expected" ]]
 }
+
+inflate_file() {
+  local destination_file=$1
+  local source_file=${2}
+  local desired_file_size=$3
+
+  local bs=10000
+  local count=$(( desired_file_size / bs + 1 ))
+  local resulting_size=$(( bs * count ))
+  [[ "$resulting_size" -ge "$desired_file_size" ]] || exit 1
+  dd if=/dev/urandom of="$destination_file" bs=$bs count=$count status=none
+  [[ "$(stat -c %s "$destination_file")" -ge "$desired_file_size" ]]
+}


### PR DESCRIPTION
See https://github.com/cvmfs/cvmfs/issues/4253

So I replaced "append small files into bigger file" loop with something faster, specifically `dd if=/dev/urandom bs=10000`. I noticed that `dd` with fixed `count` and `bs` may not always produce exactly the expected size in bytes, so I added assertions for the final file size. But avoidance of a loop with `stat(1)` on every lap is a big part of performance optimization.

Test 660 was a pickle and I restored it to produce exactly the same contents, but faster. I don't see how to tweak the reference values, because the resulting value actually changes every run - it's 14, 15 or 16. I am surprised to see content-dependent chunking - that's something new for me.

```
+ expected_value='expected_values_5[7]'
+ '[' x8 '!=' x15 ']'
+ echo '*** Test 5.7 - n_chunks_added -               (15 vs ref:8) FAILED!'
*** Test 5.7 - n_chunks_added -               (15 vs ref:8) FAILED!
+ return 100
```

I believe it's better for quality assurance to exercise the software on random data, so I prefer to not do the treatment I did to test 660 to all the other ones.