### PR TITLE
Enable Bash strict mode for end to end tests

### DIFF
--- a/doc/developer/60-debugging-and-testing.md
+++ b/doc/developer/60-debugging-and-testing.md
@@ -135,6 +135,7 @@ Writing your own integration tests is done the following way:
     - [Strict mode is not inherited in subshells, be careful to reenable it there if needed](https://fosstodon.org/@autkin/116612829870054231).
     - Strict mode bits like `set -e` cannot be enabled from a function, must be initiated in outer context.
     - When failure of a particular line of code doesn't matter, append `|| true`, this is an idiomatic way to express that.
+    - When expecting the command to fail with a specific exitcode, use `expect_exit_code <expected> <command> [args...]`
     - To get hold of exit code for expressions, you can disable parts of strict mode in subshells for readability:
       ```bash
       RC=$(

--- a/doc/developer/60-debugging-and-testing.md
+++ b/doc/developer/60-debugging-and-testing.md
@@ -105,14 +105,15 @@ Writing your own integration tests is done the following way:
 - Your test can be executed like all the other tests. No compilation of the `cvmfs` source code needed.
 
 
-> **_Tips_** &nbsp;
-> - `return` values must be handed up to the parent function `my_sub_func || return $?`
-> - For readability it might be nice to split the test routines in multiple files
->     - Use the line `source ./src/701-xattr-catalog_counters/<filename>` to include another file in the file `main`. It should be positioned after the `cvmfs_test_suites` parameter
-> - For `cvmfs_talk` when interacting with locally mounted repository (= *server test*) you have to use the socket of the repository and not the repository name
->   ```bash
->   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs
->   ```        
+#### Tips
+
+- `return` values must be handed up to the parent function `my_sub_func || return $?`
+- For readability it might be nice to split the test routines in multiple files
+    - Use the line `source ./src/701-xattr-catalog_counters/<filename>` to include another file in the file `main`. It should be positioned after the `cvmfs_test_suites` parameter
+- For `cvmfs_talk` when interacting with locally mounted repository (= *server test*) you have to use the socket of the repository and not the repository name
+  ```bash
+  sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs
+  ```
 
 ## Unit Tests
 

--- a/doc/developer/60-debugging-and-testing.md
+++ b/doc/developer/60-debugging-and-testing.md
@@ -114,6 +114,44 @@ Writing your own integration tests is done the following way:
   ```bash
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO internal affairs
   ```
+- Use trace mode `set -x` to debug shell code.
+- Do not suppress stdout and especially stderr unnecessarily. The failure may be not readily reproducible. It is a delay and cost to have to edit the suppression and re-run the CI workflow just to see the reason of the failure.
+- Integration tests are executed with Bash. Use Bash builtin constructs for brevity and performance:
+    - arrays for accumulation of tokens, including passing command line parameters, without re-tokenization problems with empty tokens and escaping;
+    - `[[ ... ]]` test clauses (no need for `[ "x$var" = x ]`);
+    - `$(( ... ))` arithmetic clauses;
+    - avoid `sed` and `awk` and lean into [Parameter Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) like `${var#removed_prefix}`, `${var%removed_suffix}`, `${var/pattern/replacement}`;
+- Use [Bash strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) to the maximum extent, to ensure test code doesn't silently ignore failed operations.
+    - `set -euo pipefail` is the essence of Bash strict mode.
+    - Each line of code is an assertion that the command exits successfully. Use it:
+      ```bash
+      [[ -d "$repo_dir"/this_should_exist ]] || return 8
+      ```
+    - You don't have to give each line of code a unique return code. The following works fine. Enable trace mode (`set -x`) and it will print each command prefixed with `+ ` into stderr.
+      ```bash
+      [[ -d "$repo_dir"/this_should_exist ]]
+      ```
+    - Change of `IFS` described in the original article is not necessary - for correct tokenization quote the array: `for name in "${names[@]}"; do echo "$name"; done`
+    - [Strict mode is not inherited in subshells, be careful to reenable it there if needed](https://fosstodon.org/@autkin/116612829870054231).
+    - Strict mode bits like `set -e` cannot be enabled from a function, must be initiated in outer context.
+    - When failure of a particular line of code doesn't matter, append `|| true`, this is an idiomatic way to express that.
+    - To get hold of exit code for expressions, you can disable parts of strict mode in subshells for readability:
+      ```bash
+      RC=$(
+          set +e
+          cvmfs_server transaction $CVMFS_TEST_REPO >/dev/null
+          echo $?
+      )
+      # Expect EEXIST
+      [[ "$RC" == 17 ]] || return 30
+      ```
+    - `set -o pipefail` means all exit codes of pipeline processes matter, not just of the last part.
+        - These commands will trigger failure unless pipefail is disabled:
+            - `... | head -n$N` or `... | head -c$N` - the source gets "broken pipe" when writing because head terminates early;
+            - `... | grep -q` - grep quits as soon as it finds the first match, because it doesn't have to print all matches.
+        - `set -o pipefail` friendly expressions:
+            - `dd` instructed to copy exact amount doesn't fail like `cat ... | head -c$N`
+            - `find ... -print -quit` outputs the first match, doesn't fail like `fild ... | head -n1`
 
 ## Unit Tests
 

--- a/gateway/pkg/run_cvmfs_gateway.sh
+++ b/gateway/pkg/run_cvmfs_gateway.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
 has_systemd=false
-if [ x"$(pidof systemd >/dev/null && echo yes || echo no)" = "xyes" ]; then
+if [ -d /run/systemd/system ]; then
     has_systemd=true
 fi
 

--- a/gateway/pkg/run_cvmfs_gateway.sh
+++ b/gateway/pkg/run_cvmfs_gateway.sh
@@ -41,9 +41,9 @@ elif [ x"$action" = xrestart ]; then
     echo "CVMFS repository gateway restarted."
 elif [ x"$action" = xstatus ]; then
     if $has_systemd; then
-        systemctl status cvmfs-gateway@$user > /dev/null 2>&1
+        systemctl status cvmfs-gateway@$user
     else
-        service cvmfs-gateway status > /dev/null 2>&1
+        service cvmfs-gateway status
     fi
     retval=$?
     if [ "x$retval" = "x0" ]; then

--- a/mount/default.conf
+++ b/mount/default.conf
@@ -93,7 +93,7 @@ CVMFS_LOW_SPEED_LIMIT=1024
 
 # Don't touch the following values unless you're absolutely
 # sure what you do.  Don't copy them to default.local either.
-if [ "x$CVMFS_BASE_ENV" = "x" ]; then
+if [ "x${CVMFS_BASE_ENV:-}" = "x" ]; then
   readonly CVMFS_USER=cvmfs
   readonly CVMFS_MOUNT_DIR=/cvmfs
   readonly CVMFS_RELOAD_SOCKETS=/var/run/cvmfs

--- a/test/cloud_testing/platforms/centos7_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos7_x86_64_setup.sh
@@ -15,7 +15,7 @@ sudo sed -i 's#http://linuxsoft.cern.ch/epel/7/#http://linuxsoft.cern.ch/interna
 
 # Place the overlay directories on 16GB ext4 partition
 sudo dd if=/dev/zero of=/ext4-backend bs=$((1024*1024)) count=$((16*1024))
-sudo yes | sudo mkfs.ext4 /ext4-backend
+sudo mkfs.ext4 -FF /ext4-backend
 sudo mkdir -p /var/spool/cvmfs
 sudo mount /ext4-backend /var/spool/cvmfs
 

--- a/test/cloud_testing/platforms/centos8_x86_64_setup.sh
+++ b/test/cloud_testing/platforms/centos8_x86_64_setup.sh
@@ -12,7 +12,7 @@ script_location=$(dirname $(readlink --canonicalize $0))
 
 # Place the overlay directories on 16GB ext4 partition
 sudo dd if=/dev/zero of=/ext4-backend bs=$((1024*1024)) count=$((16*1024))
-sudo yes | sudo mkfs.ext4 /ext4-backend
+sudo mkfs.ext4 -FF /ext4-backend
 sudo mkdir -p /var/spool/cvmfs
 sudo mount /ext4-backend /var/spool/cvmfs
 

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -264,9 +264,11 @@ uninstall_package() {
 find_new_package() {
   local name="$1"
   local dir="${CVMFS_PACKAGE_DIR:-/tmp}"
-  if has_binary rpm; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     (ls ${dir}/${name}*.rpm 2>/dev/null || true) | head -1
   else
+    [[ "$ID_LIKE" =~ debian ]]
     (ls ${dir}/${name}*.deb 2>/dev/null || true) | head -1
   fi
 }

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -128,7 +128,7 @@ package_version() {
   local pkg_path=$1
 
   if has_binary rpm; then
-    rpm -qp --queryformat='%{VERSION}' $pkg_path 2>/dev/null
+    rpm -qp --queryformat='%{VERSION}' $pkg_path
   elif has_binary dpkg; then
     dpkg --info $pkg_path 2>/dev/null | grep -e "^ Version:" | sed 's/^ Version: \([0-9]\.[0-9]\.[0-9]*\).*$/\1/'
   else

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -106,12 +106,6 @@ version_lower_or_equal() {
 }
 
 
-has_binary() {
-  local binary_name=$1
-  command -v $binary_name > /dev/null 2>&1
-}
-
-
 decrement_version() {
   local input_version=$1
   local patch_number
@@ -141,9 +135,10 @@ package_version() {
 get_providing_packages() {
   local virt_pkg_name=$1
 
-  if has_binary rpm; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     rpm -q --whatprovides $virt_pkg_name
-  elif has_binary dpkg; then
+  elif [[ "$ID_LIKE" =~ debian ]]; then
     dpkg -l | grep $virt_pkg_name | awk '{print $2}'
   else
     return 1
@@ -154,9 +149,10 @@ get_providing_packages() {
 installed_package_version() {
   local pkg_name=$1
 
-  if has_binary rpm; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     echo $(rpm -qa --queryformat '%{version}' $pkg_name)
-  elif has_binary dpkg; then
+  elif [[ "$ID_LIKE" =~ debian ]]; then
     dpkg --status $pkg_name 2>/dev/null | grep -e "^Version:" | sed 's/^Version: \([0-9]\.[0-9]\.[0-9]*\).*$/\1/'
   else
     return 1
@@ -167,11 +163,10 @@ installed_package_version() {
 is_installed() {
   local pkg_name=$1
 
-  if has_binary dnf; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     dnf info $pkg_name > /dev/null
-  elif has_binary yum; then
-    yum info $pkg_name > /dev/null
-  elif has_binary dpkg; then
+  elif [[ "$ID_LIKE" =~ debian ]]; then
     dpkg --status $pkg_name > /dev/null
   else
     return 1
@@ -228,15 +223,10 @@ yum_update_fallback() {
 install_packages() {
   local pkg_paths="$@"
 
-  if has_binary dnf; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     dnf_install_packages "$pkg_paths"
-  elif has_binary yum; then
-    if version_lower_or_equal $(installed_package_version 'yum') '3.2.22'; then
-      yum_update_fallback "$pkg_paths"
-    else
-      yum_install_packages "$pkg_paths"
-    fi
-  elif has_binary dpkg; then
+  elif [[ "$ID_LIKE" =~ debian ]]; then
     sudo dpkg --install $pkg_paths
     sudo apt-get --assume-yes -f install
   else
@@ -248,11 +238,10 @@ install_packages() {
 uninstall_package() {
   local pkg_names="$1"
 
-  if has_binary dnf; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     sudo dnf -y erase $pkg_names
-  elif has_binary yum; then
-    sudo yum -y erase $pkg_names
-  elif has_binary apt-get; then
+  elif [[ "$ID_LIKE" =~ debian ]]; then
     sudo apt-get --assume-yes purge $pkg_names
   else
     return 1
@@ -277,10 +266,12 @@ find_new_package() {
 
 # Install all CernVM-FS packages found in CVMFS_PACKAGE_DIR.
 install_new_packages() {
+  source /etc/os-release
   local dir="${CVMFS_PACKAGE_DIR:-/tmp}"
-  if has_binary rpm; then
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     install_packages ${dir}/cvmfs*.rpm
   else
+    [[ "$ID_LIKE" =~ debian ]]
     install_packages ${dir}/cvmfs*.deb
   fi
 }

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -265,9 +265,9 @@ find_new_package() {
   local name="$1"
   local dir="${CVMFS_PACKAGE_DIR:-/tmp}"
   if has_binary rpm; then
-    ls ${dir}/${name}*.rpm 2>/dev/null | head -1
+    (ls ${dir}/${name}*.rpm 2>/dev/null || true) | head -1
   else
-    ls ${dir}/${name}*.deb 2>/dev/null | head -1
+    (ls ${dir}/${name}*.deb 2>/dev/null || true) | head -1
   fi
 }
 

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -127,9 +127,10 @@ decrement_version() {
 package_version() {
   local pkg_path=$1
 
-  if has_binary rpm; then
+  source /etc/os-release
+  if [[ "$ID_LIKE" =~ rhel ]]; then
     rpm -qp --queryformat='%{VERSION}' $pkg_path
-  elif has_binary dpkg; then
+  elif [[ "$ID_LIKE" =~ debian ]]; then
     dpkg --info $pkg_path 2>/dev/null | grep -e "^ Version:" | sed 's/^ Version: \([0-9]\.[0-9]\.[0-9]*\).*$/\1/'
   else
     return 1

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -275,39 +275,3 @@ install_new_packages() {
     install_packages ${dir}/cvmfs*.deb
   fi
 }
-
-
-#
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-#
-
-
-# check availability of packages
-if ! [[ -v CVMFS_CLIENT_PACKAGE ]]; then
-  echo "CernVM-FS client package not specified in CVMFS_CLIENT_PACKAGE!"
-  # not fatal
-elif [ ! -f "$CVMFS_CLIENT_PACKAGE" ]; then
-  echo "CernVM-FS client package '$CVMFS_CLIENT_PACKAGE' not found!"
-  # not fatal
-fi
-
-if ! [[ -v CVMFS_SERVER_PACKAGE ]]; then
-  CVMFS_SERVER_PACKAGE="${CVMFS_CLIENT_PACKAGE/cvmfs/cvmfs-server}"
-fi
-if [ ! -f $CVMFS_SERVER_PACKAGE ]; then
-  echo "CernVM-FS server package '$CVMFS_SERVER_PACKAGE' not found!"
-fi
-
-if ! [[ -v CVMFS_LIBS_PACKAGE ]]; then
-  CVMFS_LIBS_PACKAGE="${CVMFS_CLIENT_PACKAGE/cvmfs/cvmfs-libs}"
-fi
-if [ ! -f $CVMFS_LIBS_PACKAGE ]; then
-  echo "CernVM-FS libs package '$CVMFS_LIBS_PACKAGE' not found!"
-fi
-
-if ! [[ -v CVMFS_FUSE_PACKAGE ]]; then
-  CVMFS_FUSE_PACKAGE="${CVMFS_CLIENT_PACKAGE/cvmfs/cvmfs-fuse3}"
-fi
-if [ ! -f $CVMFS_FUSE_PACKAGE ]; then
-  echo "CernVM-FS fuse package '$CVMFS_FUSE_PACKAGE' not found!"
-fi

--- a/test/common/migration_tests/common.sh
+++ b/test/common/migration_tests/common.sh
@@ -283,25 +283,29 @@ install_new_packages() {
 
 
 # check availability of packages
-if [ x"$CVMFS_CLIENT_PACKAGE" = x"" ] || [ ! -f $CVMFS_CLIENT_PACKAGE ]; then
+if ! [[ -v CVMFS_CLIENT_PACKAGE ]]; then
+  echo "CernVM-FS client package not specified in CVMFS_CLIENT_PACKAGE!"
+  # not fatal
+elif [ ! -f "$CVMFS_CLIENT_PACKAGE" ]; then
   echo "CernVM-FS client package '$CVMFS_CLIENT_PACKAGE' not found!"
+  # not fatal
 fi
 
-if [ x"$CVMFS_SERVER_PACKAGE" = x"" ]; then
+if ! [[ -v CVMFS_SERVER_PACKAGE ]]; then
   CVMFS_SERVER_PACKAGE="${CVMFS_CLIENT_PACKAGE/cvmfs/cvmfs-server}"
 fi
 if [ ! -f $CVMFS_SERVER_PACKAGE ]; then
   echo "CernVM-FS server package '$CVMFS_SERVER_PACKAGE' not found!"
 fi
 
-if [ x"$CVMFS_LIBS_PACKAGE" = x"" ]; then
+if ! [[ -v CVMFS_LIBS_PACKAGE ]]; then
   CVMFS_LIBS_PACKAGE="${CVMFS_CLIENT_PACKAGE/cvmfs/cvmfs-libs}"
 fi
 if [ ! -f $CVMFS_LIBS_PACKAGE ]; then
   echo "CernVM-FS libs package '$CVMFS_LIBS_PACKAGE' not found!"
 fi
 
-if [ x"$CVMFS_FUSE_PACKAGE" = x"" ]; then
+if ! [[ -v CVMFS_FUSE_PACKAGE ]]; then
   CVMFS_FUSE_PACKAGE="${CVMFS_CLIENT_PACKAGE/cvmfs/cvmfs-fuse3}"
 fi
 if [ ! -f $CVMFS_FUSE_PACKAGE ]; then

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -6,7 +6,7 @@ tar_gzip_and_hash() {
     local dir_path=$1
     local tar_log=$2
     local script_location=$3
-    local result_file=$4
+    local result_file=${4:-}
 
     local tar_archive="$(mktemp ./tar.XXXX)"
 
@@ -15,7 +15,7 @@ tar_gzip_and_hash() {
     md5_result="$(${script_location}/tarsum $tar_archive | cut -d' ' -f1 | sort | md5sum | cut -d' ' -f1)"
     rm -f $tar_archive || return 2
 
-    if [ x"$result_file" != x"" ]; then
+    if [[ "$result_file" != '' ]]; then
       echo -n "$md5_result" > $result_file
     else
       echo -n "$md5_result"

--- a/test/migration_tests/001-hotpatch/main
+++ b/test/migration_tests/001-hotpatch/main
@@ -2,11 +2,6 @@
 cvmfs_test_name="Hotpatching during Linux kernel tar and checksumming large files"
 
 
-skip_bytes() {
-    local num_of_bytes=$1
-    dd bs=512k 2>/dev/null | { dd bs=$num_of_bytes count=1 > /dev/null 2>&1; dd bs=512k 2>/dev/null; }
-}
-
 tar_gzip_and_hash() {
     local dir_path=$1
     local tar_log=$2

--- a/test/run.sh
+++ b/test/run.sh
@@ -593,6 +593,7 @@ run_test_with_timeout() {
         set -e &&
         set -o pipefail &&
         set -x &&
+        set -u &&
         cd "$4" &&
         . ./test_functions &&
         . "$1/main" &&

--- a/test/run.sh
+++ b/test/run.sh
@@ -591,6 +591,7 @@ run_test_with_timeout() {
 
       bash -c '\''
         set -e &&
+        set -o pipefail &&
         cd "$4" &&
         . ./test_functions &&
         . "$1/main" &&

--- a/test/run.sh
+++ b/test/run.sh
@@ -592,6 +592,7 @@ run_test_with_timeout() {
       bash -c '\''
         set -e &&
         set -o pipefail &&
+        set -x &&
         cd "$4" &&
         . ./test_functions &&
         . "$1/main" &&

--- a/test/run.sh
+++ b/test/run.sh
@@ -590,6 +590,7 @@ run_test_with_timeout() {
       trap '\''stop_test_tree TERM; wait "$test_tree_pid" 2>/dev/null || true; exit 143'\'' TERM
 
       bash -c '\''
+        set -e &&
         cd "$4" &&
         . ./test_functions &&
         . "$1/main" &&

--- a/test/src/016-dnsunreachable/main
+++ b/test/src/016-dnsunreachable/main
@@ -29,7 +29,8 @@ cvmfs_run_test() {
   echo "trying to mount again with unreachable DNS"
   local milliseconds
   cvmfs_disable_config_repository
-  milliseconds=$(stop_watch do_faulty_mount)
+  # should fail
+  milliseconds=$(stop_watch do_faulty_mount) && return 4
   cvmfs_enable_config_repository
   echo "timeout was $milliseconds seconds"
 

--- a/test/src/027-autoumount/main
+++ b/test/src/027-autoumount/main
@@ -22,11 +22,8 @@ cvmfs_run_test() {
   echo "wait for things to settle"
   sleep 20
 
-  echo "try to list /cvmfs/atlas.cern.ch again"
-  ls .
-  if [ $? -eq 0 ]; then
-    return 4
-  fi
+  echo "try to list /cvmfs/atlas.cern.ch again (should fail)"
+  ls . && return 4
 
   echo "change directory out of /cvmfs/atlas.cern.ch to $OLDPWD"
   cd $OLDPWD

--- a/test/src/028-negativecache/main
+++ b/test/src/028-negativecache/main
@@ -9,12 +9,10 @@ cvmfs_run_test() {
   cvmfs_mount sft.cern.ch CVMFS_CLIENT_PROFILE=custom || return 1
 
   sudo cvmfs_talk -i sft.cern.ch proxy set "invalid"
-  ls /cvmfs/sft.cern.ch/lcg/external/ROOT
-  [ $? -eq 0 ] && return 2
+  ls /cvmfs/sft.cern.ch/lcg/external/ROOT && return 2
 
   sudo cvmfs_talk -i sft.cern.ch proxy set "DIRECT"
-  ls /cvmfs/sft.cern.ch/lcg/external/ROOT
-  [ $? -ne 0 ] && return 3
+  ls /cvmfs/sft.cern.ch/lcg/external/ROOT || return 3
 
   return 0
 }

--- a/test/src/030-missingrootcatalog/main
+++ b/test/src/030-missingrootcatalog/main
@@ -71,7 +71,7 @@ cvmfs_run_test() {
     local expected_max=6000  
   fi
 
-  if [ $milliseconds -gt $expected_max ]; then
+  if [ "$milliseconds" -gt "$expected_max" ]; then
     echo "mounting took too long with $milliseconds seconds (expected $expected_max)"
     CVMFS_TIME_WARNING_FLAG=1
   fi

--- a/test/src/037-strictmount/main
+++ b/test/src/037-strictmount/main
@@ -9,11 +9,6 @@ cvmfs_run_test() {
   cvmfs_mount "atlas.cern.ch" \
     "CVMFS_STRICT_MOUNT=yes" || return 1
 
-  try_automount lhcb.cern.ch
-  RETVAL=$?
-  if [ $RETVAL -eq 0 ]; then
-    return 2
-  fi
-  return 0
+  try_automount lhcb.cern.ch && return 2
 }
 

--- a/test/src/037-strictmount/main
+++ b/test/src/037-strictmount/main
@@ -10,5 +10,6 @@ cvmfs_run_test() {
     "CVMFS_STRICT_MOUNT=yes" || return 1
 
   try_automount lhcb.cern.ch && return 2
+  return 0
 }
 

--- a/test/src/041-rocache/main
+++ b/test/src/041-rocache/main
@@ -65,8 +65,7 @@ cvmfs_run_test() {
     "CVMFS_STRICT_MOUNT=yes" || return 2
 
   echo "try to remount with open r/w descriptors (should fail)"
-  sudo mount -o remount,ro $CVMFS_TEST_041_TMPDIR
-  if [ $? -eq 0 ]; then
+  if sudo mount -o remount,ro $CVMFS_TEST_041_TMPDIR; then
     echo "r/o remount is not supposed to work at this stage"
     return 4
   fi

--- a/test/src/042-cleanuppipes/main
+++ b/test/src/042-cleanuppipes/main
@@ -27,10 +27,7 @@ cvmfs_run_test() {
   cvmfs_umount "lhcb.cern.ch" || return 3
   cvmfs_mount "lhcb.cern.ch" || return 4
   sudo stat ${cache_dir}/fifo000 || return 8
-  sudo stat ${cache_dir}/pipe000
-  if [ $? -eq 0 ]; then
-    return 6
-  fi
+  sudo stat ${cache_dir}/pipe000 && return 6
 
   return 0
 }

--- a/test/src/045-oasis/main
+++ b/test/src/045-oasis/main
@@ -8,6 +8,4 @@ cvmfs_run_test() {
 
   cvmfs_mount oasis.opensciencegrid.org,atlas.cern.ch \
     "CVMFS_HTTP_PROXY=DIRECT" || return 3
-
-  return $retval
 }

--- a/test/src/057-parallelmakecache/main
+++ b/test/src/057-parallelmakecache/main
@@ -18,7 +18,6 @@ cvmfs_run_test() {
 
   sudo mkdir -p ${cache_dir}/10 ${cache_dir}/20
   sudo chown -R cvmfs:cvmfs ${cache_dir}
-  ls -lah ${cache_dir}
   autofs_switch off
   autofs_switch on
   cvmfs_mount grid.cern.ch || return 20

--- a/test/src/058-keysdir/main
+++ b/test/src/058-keysdir/main
@@ -11,10 +11,7 @@ cvmfs_run_test() {
   cvmfs_remove_breadcrumb grid.cern.ch
   cvmfs_umount grid.cern.ch
 
-  cvmfs_mount grid.cern.ch "CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/egi.eu/egi.eu.pub"
-  if [ $? -eq 0 ]; then
-    return 10
-  fi
+  cvmfs_mount grid.cern.ch "CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/egi.eu/egi.eu.pub" && return 10
 
   autofs_switch off
   autofs_switch on

--- a/test/src/059-fallbackproxy/main
+++ b/test/src/059-fallbackproxy/main
@@ -17,10 +17,7 @@ cvmfs_run_test() {
 
   cvmfs_umount grid.cern.ch
   cvmfs_mount grid.cern.ch "CVMFS_CLIENT_PROFILE=custom" || return 2
-  sudo cvmfs_talk -i grid.cern.ch proxy info | tail -n 1 | grep 'fallback group:'
-  if [ $? -eq 0 ]; then
-    return 20
-  fi
+  sudo cvmfs_talk -i grid.cern.ch proxy info | tail -n 1 | grep 'fallback group:' && return 20
 
   # Set only fallback proxy
   cvmfs_umount grid.cern.ch
@@ -29,33 +26,21 @@ cvmfs_run_test() {
   sudo cvmfs_talk -i grid proxy info | tail -n 4 | grep "http://A:3128" || return 30
   sudo cvmfs_talk -i grid proxy info | tail -n 4 | grep "http://B1:3128" | grep "http://B2:3128" || return 31
   sudo cvmfs_talk -i grid proxy info | tail -n 4 | grep "fallback group:" || return 32
-  sudo cvmfs_talk -i grid proxy info | grep "DIRECT"
-  if [ $? -eq 0 ]; then
-    return 33
-  fi
+  sudo cvmfs_talk -i grid proxy info | grep "DIRECT" && return 33
 
   # Set only proxy
   ## replaced http://D:3128 with http://H:3128 as D:3128 is used at CERN
   sudo cvmfs_talk -i grid proxy set "http://C:3128|http://H:3128;DIRECT"
-  sudo cvmfs_talk -i grid proxy info | grep "DIRECT"
-  if [ $? -eq 0 ]; then
-    return 40
-  fi
+  sudo cvmfs_talk -i grid proxy info | grep "DIRECT" && return 40
   sudo cvmfs_talk -i grid proxy info | head -n 2 | grep "http://C:3128" | grep "http://H:3128" #|| return 41
 
   sudo cvmfs_talk -i grid proxy set "DIRECT"
-  sudo cvmfs_talk -i grid proxy info | grep "DIRECT"
-  if [ $? -eq 0 ]; then
-    return 50
-  fi
+  sudo cvmfs_talk -i grid proxy info | grep "DIRECT" && return 50
 
   # Recover direct after removing fallback proxies
   sudo cvmfs_talk -i grid.cern.ch proxy fallback DIRECT # DIRECT is removed
   sudo cvmfs_talk -i grid proxy info | grep "DIRECT" || return 60
-  sudo cvmfs_talk -i grid proxy info | grep "fallback group:"
-  if [ $? -eq 0 ]; then
-    return 61
-  fi
+  sudo cvmfs_talk -i grid proxy info | grep "fallback group:" && return 61
 
   return 0
 }

--- a/test/src/064-fsck/main
+++ b/test/src/064-fsck/main
@@ -14,11 +14,11 @@ cvmfs_run_test() {
 
   cvmfs_umount atlas.cern.ch,lhcb.cern.ch,cms.cern.ch || return 10
 
-  echo "Destroying data integrity in $cms_cachedir"
+  echo "Destroying data integrity in cachedir"
   cms_cachedir=$(get_cvmfs_cachedir cms.cern.ch)
-  [ "x$cms_cachedir" = "x" ] && return 11
-  for f in $(sudo find $cms_cachedir -mindepth 2 -type f); do
-    sudo sh -c "cat /dev/null > $f"
+  [[ "$cms_cachedir" == "" ]] && return 11
+  for f in $(sudo find "$cms_cachedir" -mindepth 2 -type f); do
+    sudo truncate -s0 "$f"
   done
   (
     set +e
@@ -27,8 +27,8 @@ cvmfs_run_test() {
       return 12
     fi
   )
-  sudo mkdir -p $cms_cachedir/aa
-  sudo touch $cms_cachedir/aa/aaaaaaaa # made-up, too short hash
+  sudo mkdir -p "$cms_cachedir"/aa
+  sudo touch "$cms_cachedir"/aa/aaaaaaaa # made-up, too short hash
   sudo cvmfs_config fsck -q && return 13
 
   return 0

--- a/test/src/064-fsck/main
+++ b/test/src/064-fsck/main
@@ -20,10 +20,13 @@ cvmfs_run_test() {
   for f in $(sudo find $cms_cachedir -mindepth 2 -type f); do
     sudo sh -c "cat /dev/null > $f"
   done
-  sudo cvmfs_config fsck -j8 -p
-  if [ $? -ne 1 ]; then
-    return 12
-  fi
+  (
+    set +e
+    sudo cvmfs_config fsck -j8 -p
+    if [ $? -ne 1 ]; then
+      return 12
+    fi
+  )
   sudo mkdir -p $cms_cachedir/aa
   sudo touch $cms_cachedir/aa/aaaaaaaa # made-up, too short hash
   sudo cvmfs_config fsck -q && return 13

--- a/test/src/064-fsck/main
+++ b/test/src/064-fsck/main
@@ -20,13 +20,7 @@ cvmfs_run_test() {
   for f in $(sudo find "$cms_cachedir" -mindepth 2 -type f); do
     sudo truncate -s0 "$f"
   done
-  (
-    set +e
-    sudo cvmfs_config fsck -j8 -p
-    if [ $? -ne 1 ]; then
-      return 12
-    fi
-  )
+  expect_exit_code 1 sudo cvmfs_config fsck -j8 -p || return 12
   sudo mkdir -p "$cms_cachedir"/aa
   sudo touch "$cms_cachedir"/aa/aaaaaaaa # made-up, too short hash
   sudo cvmfs_config fsck -q && return 13

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -155,7 +155,7 @@ test_extra_args(){
 }
 
 logdebug(){
-  if [[  "${DEBUG_LOGGING_MODE}" == "colored"  ]]; then
+  if [[  "${DEBUG_LOGGING_MODE:-}" == "colored"  ]]; then
     echo -e "\e[35m$1\e[0m"
   else
     echo -e "$1"

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -33,7 +33,7 @@ fs_cleanup(){
   # unfreeze it and unmount it
   if mountpoint -q "${DEST}"; then
     local loopdev=$(findmnt -n -o SOURCE --target "$DEST")
-    sudo fsfreeze -u ${DEST} 2> /dev/null
+    sudo fsfreeze -u ${DEST}
     sudo umount ${DEST}
     sudo losetup -d "$loopdev"
     sudo rm -rf ${DEST}

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -33,7 +33,7 @@ fs_cleanup(){
   # unfreeze it and unmount it
   if mountpoint -q "${DEST}"; then
     local loopdev=$(findmnt -n -o SOURCE --target "$DEST")
-    sudo fsfreeze -u ${DEST}
+    sudo fsfreeze -u ${DEST} || true # may be unfrozen and give EINVAL
     sudo umount ${DEST}
     sudo losetup -d "$loopdev"
     sudo rm -rf ${DEST}

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -35,7 +35,6 @@ fs_cleanup(){
     local loopdev=$(findmnt -n -o SOURCE --target "$DEST")
     sudo fsfreeze -u ${DEST} || true # may be unfrozen and give EINVAL
     sudo umount ${DEST}
-    sudo losetup -d "$loopdev"
     sudo rm -rf ${DEST}
   fi
   if [ -f ${SRC} ]; then

--- a/test/src/066-killall/main
+++ b/test/src/066-killall/main
@@ -180,11 +180,11 @@ cvmfs_run_test() {
 
   sudo cvmfs_config killall || return 20
   echo "Wait for reload to finish"
-  wait $reload_pid
+  # non-zero exit code is legit but not tested for, got 137 as of 2026-05-30
+  wait $reload_pid || true
 
   echo "Killall once again because we don't know where the reloaded was interrupted"
   sudo cvmfs_config killall || return 30
-  wait $!
 
   if [ "$(uname)" != "Linux" ]; then
     # specific killall options are not meant

--- a/test/src/068-rocache/main
+++ b/test/src/068-rocache/main
@@ -17,7 +17,7 @@ cvmfs_run_test() {
   mkdir $CVMFS_TEST068_TMPDIR
   trap cleanup EXIT HUP INT TERM
   sudo cvmfs2 __MK_ALIEN_CACHE__ "$CVMFS_TEST068_TMPDIR" $(id -u cvmfs) $(id -g cvmfs) || return 10
-  if which chcon; then
+  if has_selinux; then
     sudo chcon -Rv --type=cvmfs_cache_t $CVMFS_TEST068_TMPDIR
   fi
 

--- a/test/src/069-systemremount/main
+++ b/test/src/069-systemremount/main
@@ -47,5 +47,7 @@ cvmfs_run_test() {
   sudo umount $mountpoint || return 60
   sudo mount -t cvmfs -o remount $repo $mountpoint && return 61
 
+  trap - EXIT HUP INT TERM
+  sudo rmdir "$mountpoint"
   return 0
 }

--- a/test/src/075-reloadenv/main
+++ b/test/src/075-reloadenv/main
@@ -8,7 +8,7 @@ cvmfs_run_test() {
 
   echo "*** create reload script"
   local tainted_env="$(mktemp ./setenv.XXXXXX)"
-  echo "export LD_LIBRARY_PATH=/cvmfs/grid.cern.ch:$LD_LIBRARY_PATH" > $tainted_env
+  echo "export LD_LIBRARY_PATH=/cvmfs/grid.cern.ch:${LD_LIBRARY_PATH:-}" > $tainted_env
   echo "env" >> $tainted_env
   echo "cvmfs_config reload" >> $tainted_env
   chmod +x $tainted_env

--- a/test/src/077-doublemount/main
+++ b/test/src/077-doublemount/main
@@ -25,7 +25,7 @@ cvmfs_run_test() {
   ls $CVMFS_TEST077_MOUNTPOINT_ONE || return 11
 
   sudo mount -t cvmfs grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" && return 20
-  sudo mount -t cvmfs grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1 \
+  (! sudo mount -t cvmfs grid.cern.ch "$CVMFS_TEST077_MOUNTPOINT_TWO" 2>&1) \
     | grep "$CVMFS_TEST077_MOUNTPOINT_ONE" \
     || return 21
   # TODO(vvolkl) check mounting on same directory without the mount helper

--- a/test/src/077-doublemount/main
+++ b/test/src/077-doublemount/main
@@ -7,7 +7,9 @@ CVMFS_TEST077_MOUNTPOINT_ONE=
 CVMFS_TEST077_MOUNTPOINT_TWO=
 
 cleanup() {
-  sudo umount $CVMFS_TEST077_MOUNTPOINT_ONE $CVMFS_TEST077_MOUNTPOINT_TWO
+  sudo umount $CVMFS_TEST077_MOUNTPOINT_ONE
+  # mountpoint_two is not expected to be mounted normally, but it might in case of a bug
+  sudo umount $CVMFS_TEST077_MOUNTPOINT_TWO || true
 }
 
 cvmfs_run_test() {

--- a/test/src/080-tracing/main
+++ b/test/src/080-tracing/main
@@ -4,6 +4,8 @@ cvmfs_test_suites="quick"
 
 CVMFS_TEST080_TRACELOG=
 
+repo="grid.cern.ch"
+
 cleanup() {
   if [ "x$CVMFS_TEST080_TRACELOG" != "x" ]; then
     sudo rm -f /tmp/cvmfs-$repo.trace.log 2> /dev/null
@@ -12,7 +14,6 @@ cleanup() {
 
 cvmfs_run_test() {
   logfile=$1
-  local repo="grid.cern.ch"
   CVMFS_TEST080_TRACELOG=/tmp/cvmfs-$repo.trace.log
   echo "*** Setup..."
   cleanup

--- a/test/src/080-tracing/main
+++ b/test/src/080-tracing/main
@@ -31,7 +31,11 @@ cvmfs_run_test() {
     return 2
   fi
 
-  sudo truncate -s0 $CVMFS_TEST080_TRACELOG > /dev/null
+  CVMFS_USER=$(
+    source /etc/cvmfs/default.conf >/dev/null
+    printf %s "$CVMFS_USER"
+  )
+  sudo -u "$CVMFS_USER" truncate -s0 $CVMFS_TEST080_TRACELOG > /dev/null
 
   echo "*** Executing a few operations to check tracing..."
 

--- a/test/src/080-tracing/main
+++ b/test/src/080-tracing/main
@@ -32,6 +32,7 @@ cvmfs_run_test() {
     return 2
   fi
 
+  #TODO(vavolkl): use cvmfs tooling ( showconfig ) to set CVMFS_USER
   CVMFS_USER=$(
     source /etc/cvmfs/default.conf >/dev/null
     printf %s "$CVMFS_USER"

--- a/test/src/081-shrinkwrap/main
+++ b/test/src/081-shrinkwrap/main
@@ -109,6 +109,5 @@ cvmfs_run_test() {
       --dest-base $CVMFS_TEST081_SHRINKWRAP_DEST
     [ $? -eq 0 ] || return 30
     ls $CVMFS_TEST081_SHRINKWRAP_DEST/$repo/lcg/lastUpdate || return 31
-    rm $workdir
     return 0
 }

--- a/test/src/081-shrinkwrap/main
+++ b/test/src/081-shrinkwrap/main
@@ -98,8 +98,7 @@ cvmfs_run_test() {
     sudo stat $CVMFS_TEST081_SHRINKWRAP_DEST/.data || return 11
     ls $CVMFS_TEST081_SHRINKWRAP_DEST/.provenance || return 12
 
-    ls $CVMFS_TEST081_SHRINKWRAP_DEST/$repo/lcg/lastUpdate
-    [ $? -ne 0 ] || return 20
+    ls $CVMFS_TEST081_SHRINKWRAP_DEST/$repo/lcg/lastUpdate && return 20
 
     echo "*** Update destination..."
     echo | sudo tee -a $workdir/cvmfs-$repo.spec.txt

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -198,11 +198,6 @@ Pages available: 1"
   [ "x$info_machine" != "$info_machine_correct" ] || return 41
 
   echo "*** Check invalid input for num pages"
-  negative_num=$(get_xattr proxy_list@-2 /cvmfs/grid.cern.ch/README 2>&1)
-  large_num=$(get_xattr proxy_list~1000 /cvmfs/grid.cern.ch/README 2>&1)  
-  letters_num=$(get_xattr proxy_list~xxx /cvmfs/grid.cern.ch/README 2>&1) 
-  nothing=$(get_xattr proxy_list@ /cvmfs/grid.cern.ch/README 2>&1) 
-
   local error
   if running_on_osx; then
     error="No message available on STREAM"
@@ -210,18 +205,14 @@ Pages available: 1"
     error="attr_get: No data available"
   fi
 
-  if echo $negative_num | grep -v "$error"; then
-    return 50
-  fi
-  if echo $large_num | grep -v "$error"; then
-    return 51
-  fi
-  if echo $letters_num | grep -v "$error"; then
-    return 52
-  fi
-  if echo $nothing | grep -v "$error"; then
-    return 53
-  fi
+  # negative
+  get_xattr proxy_list@-2 /cvmfs/grid.cern.ch/README 2>&1 | grep -v "$error" && return 50
+  # large_num
+  get_xattr proxy_list~1000 /cvmfs/grid.cern.ch/README 2>&1 | grep -v "$error" && return 51
+  # letters
+  get_xattr proxy_list~xxx /cvmfs/grid.cern.ch/README 2>&1 | grep -v "$error" && return 52
+  # nothing
+  get_xattr proxy_list@ /cvmfs/grid.cern.ch/README 2>&1 | grep -v "$error" && return 53
 
   cvmfs_umount grid.cern.ch || return 2
 

--- a/test/src/087-xattrs/main
+++ b/test/src/087-xattrs/main
@@ -59,7 +59,10 @@ cvmfs_run_test() {
 
   echo "Test listing magic extended attributes"
 
-  local attributes_err=$(list_xattrs /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local attributes_err=$(
+    set +x # disable trace mode if it was enabled
+    list_xattrs /cvmfs/grid.cern.ch 2>&1 1>/dev/null
+  )
   local attributes=$(list_xattrs /cvmfs/grid.cern.ch)
   if [ "x$attributes" = "x" ] || [ "x$attributes_err" != "x" ]; then
     return 2
@@ -67,7 +70,10 @@ cvmfs_run_test() {
 
   echo "Test 'repo_counters' magic extended attribute"
 
-  local repo_counters_err=$(get_xattr repo_counters /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local repo_counters_err=$(
+    set +x
+    get_xattr repo_counters /cvmfs/grid.cern.ch 2>&1 1>/dev/null
+  )
   local repo_counters=$(get_xattr repo_counters /cvmfs/grid.cern.ch)
   if [ "x$repo_counters" = "x" ] || [ "x$repo_counters_err" != "x" ]; then
     return 3
@@ -76,7 +82,10 @@ cvmfs_run_test() {
   echo "Test 'catalog_counters' magic extended attribute"
 
   # test nested catalog counters (test can break if grid.cern.ch repo changes)
-  local catalog_counters_nested_err=$(get_xattr catalog_counters /cvmfs/grid.cern.ch/etc 2>&1 1>/dev/null)
+  local catalog_counters_nested_err=$(
+    set +x
+    get_xattr catalog_counters /cvmfs/grid.cern.ch/etc 2>&1 1>/dev/null
+  )
   local catalog_counters_nested=$(get_xattr catalog_counters /cvmfs/grid.cern.ch/etc)
   if [ "x$catalog_counters_nested" = "x" ] || [ "x$catalog_counters_nested_err" != "x" ]; then
     return 4
@@ -115,7 +124,10 @@ cvmfs_run_test() {
 
   echo "Test 'cleanup_unused_first' magic extended attribute"
 
-  local cleanup_unused_first_err=$(get_xattr cleanup_unused_first /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local cleanup_unused_first_err=$(
+    set +x
+    get_xattr cleanup_unused_first /cvmfs/grid.cern.ch 2>&1 1>/dev/null
+  )
   local cleanup_unused_first=$(get_xattr cleanup_unused_first /cvmfs/grid.cern.ch)
   if [ "x$cleanup_unused_first" = "x" ] || [ "x$cleanup_unused_first_err" != "x" ]; then
     return 13
@@ -123,7 +135,10 @@ cvmfs_run_test() {
 
   echo "Test 'list_open_hashes' magic extended attribute"
 
-  local list_open_hashes_err=$(get_xattr list_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null)
+  local list_open_hashes_err=$(
+    set +x
+    get_xattr list_open_hashes /cvmfs/grid.cern.ch 2>&1 1>/dev/null
+  )
   local list_open_hashes=$(get_xattr list_open_hashes /cvmfs/grid.cern.ch)
   if [ "$cleanup_unused_first" = "yes" ]; then
     if [ "x$list_open_hashes" = "x" ] || [ "x$list_open_hashes_err" != "x" ]; then

--- a/test/src/095-fuser/main
+++ b/test/src/095-fuser/main
@@ -27,7 +27,7 @@ cvmfs_run_test() {
 
   echo "*** start unshared background process accessing it, and check that"
   sudo unshare -m sh -c \
-    "cd /cvmfs/grid.cern.ch && cut -d' ' -f4 /proc/self/stat > $PWD/started && /bin/sleep 10000" &
+    "cd /cvmfs/grid.cern.ch && cut -d' ' -f4 /proc/self/stat > $PWD/started.wip && mv $PWD/started{.wip,} && /bin/sleep 10000" &
   sudopid=$!
   trap cleanup EXIT HUP INT TERM || return $?
   while [ ! -f started ]; do
@@ -48,7 +48,7 @@ cvmfs_run_test() {
   echo "*** stopping shared background process"
   pids="`sudo cvmfs_config fuser grid.cern.ch`"
   sudo kill -15 $backpid
-  sudo kill -15 -$sudopid
+  sudo kill -15 -$sudopid || true
   sudo wait $backpid 2>/dev/null || true
   echo "*** pids: $pids, backpid: $backpid"
   [[ " $pids " == *" $backpid "* ]] || return 20

--- a/test/src/100-reload-switch-debug/main
+++ b/test/src/100-reload-switch-debug/main
@@ -24,7 +24,7 @@ reload_without_debuglog() {
   local specific_repo
   specific_repo=$1
   local some_file
-  some_file=$(find /cvmfs/lhcb.cern.ch/lib/etc/ -type f | head -n1)
+  some_file=$(find /cvmfs/lhcb.cern.ch/lib/etc/ -type f -print -quit)
   echo "   ** Access some data at $TEST100_REPO: $some_file"
   cat "$some_file" > /dev/null || return 10
 

--- a/test/src/100-reload-switch-debug/main
+++ b/test/src/100-reload-switch-debug/main
@@ -30,6 +30,13 @@ reload_without_debuglog() {
 
   # assumption: debug log is already there
   echo "   ** Check non-empty existence of debug log"
+  # as observed, it's not there yet
+  for attempt in {1..10}; do
+    if [ -s "$CVMFS_TEST_100_TMPFILE" ]; then
+      break
+    fi
+    sleep 1
+  done
   if [ -s "$CVMFS_TEST_100_TMPFILE" ]
   then
     echo "     *** True"

--- a/test/src/102-reusefd/main
+++ b/test/src/102-reusefd/main
@@ -106,9 +106,8 @@ cvmfs_run_test() {
   sleep 1
   local got_emfile=0
   for p in $job_pids; do
-    kill -USR1 $p
-    wait $p
-    if [ $? -ne 0 ]; then
+    kill -USR1 $p || true
+    if ! wait $p; then
       got_emfile=1
     fi
   done
@@ -125,9 +124,8 @@ cvmfs_run_test() {
   sleep 1
   got_emfile=0
   for p in $job_pids; do
-    kill -USR1 $p
-    wait $p
-    if [ $? -ne 0 ]; then
+    kill -USR1 $p || true
+    if ! wait $p; then
       got_emfile=1
     fi
   done

--- a/test/src/105-streaming-cache/main
+++ b/test/src/105-streaming-cache/main
@@ -13,8 +13,11 @@ cvmfs_run_test() {
   echo "*** root hash is $root_hash"
 
   local nfiles=100
-  find /cvmfs/alice.cern.ch/el9-x86_64/Packages/AEGIS -type f -size +100k -size -10M | head -n $nfiles \
-    > filelist || return 10
+  (
+    set +o pipefail
+    find /cvmfs/alice.cern.ch/el9-x86_64/Packages/AEGIS -type f -size +100k -size -10M | head -n $nfiles \
+      > filelist || return 10
+  )
 
   echo "*** Checksuming reference file set"
   cat filelist | while read LINE; do

--- a/test/src/108-global-config/main
+++ b/test/src/108-global-config/main
@@ -11,7 +11,8 @@ clean_up() {
 }
 
 do_test() {
-    sudo cp src/108-global-config/default.local "${CVMFS_CONFIG_FILE}"
+    local script_location=$1
+    sudo cp "$script_location"/default.local "${CVMFS_CONFIG_FILE}"
     sudo sed -i "s|LOGFILE|$logfile|g" "$CVMFS_CONFIG_FILE"
     sudo sed -i "s|PROXY_SERVER|$CVMFS_TEST_PROXY|g" "$CVMFS_CONFIG_FILE"
 
@@ -32,6 +33,7 @@ do_test() {
 
 cvmfs_run_test() {
   local logfile=$1
+  local script_location=$2
 
   if [[ -z "$logfile" ]]; then
     logfile=/tmp/version_env_test.log
@@ -42,10 +44,10 @@ cvmfs_run_test() {
 
   if [[ -f "${CVMFS_CONFIG_FILE}" ]]; then
     sudo mv "${CVMFS_CONFIG_FILE}" "${CVMFS_CONFIG_FILE}.bak"
-    do_test
+    do_test "$script_location"
     sudo mv "${CVMFS_CONFIG_FILE}.bak" "${CVMFS_CONFIG_FILE}"
   else
-    do_test
+    do_test "$script_location"
   fi
 }
 

--- a/test/src/111-ignore-mount-attempt/main
+++ b/test/src/111-ignore-mount-attempt/main
@@ -46,10 +46,7 @@ cvmfs_run_test() {
   to_syslog "CVMFS_TEST_111_SYSLOG_MARKER_1"
 
   echo "*** accessing ignored repo ${ignored_repo} via autofs (should fail)"
-  local ls_output
-  ls_output=$(ls /cvmfs/${ignored_repo}/ 2>&1)
-  local ls_retval=$?
-  if [ $ls_retval -eq 0 ]; then
+  if ls /cvmfs/${ignored_repo}/; then
     echo "ERROR: listing ignored repo ${ignored_repo} via autofs should have failed"
     return 20
   fi
@@ -97,9 +94,7 @@ cvmfs_run_test() {
   to_syslog "CVMFS_TEST_111_SYSLOG_MARKER_2"
 
   echo "*** attempting to access ignored repo with spaces in list (should fail)"
-  ls_output=$(ls /cvmfs/${ignored_repo}/ 2>&1)
-  ls_retval=$?
-  if [ $ls_retval -eq 0 ]; then
+  if ls /cvmfs/${ignored_repo}/; then
     echo "ERROR: access to ignored repo should have failed (spaces test)"
     return 60
   fi

--- a/test/src/111-ignore-mount-attempt/main
+++ b/test/src/111-ignore-mount-attempt/main
@@ -5,7 +5,7 @@ cvmfs_test_suites="quick"
 
 cleanup() {
   echo "running cleanup()"
-  sudo umount /cvmfs/projects.cern.ch 2>/dev/null
+  ! sudo umount /cvmfs/projects.cern.ch 2>/dev/null
   if [ -f /etc/cvmfs/default.local.111bak ]; then
     sudo cp /etc/cvmfs/default.local.111bak /etc/cvmfs/default.local
     sudo rm -f /etc/cvmfs/default.local.111bak

--- a/test/src/113-quota-atomic-init-commands/main
+++ b/test/src/113-quota-atomic-init-commands/main
@@ -145,7 +145,7 @@ cvmfs_run_test() {
   echo "*** shared cachemgr PID: $cachemgr_pid_initial"
 
   local stable_file
-  stable_file=$(find /cvmfs/$STABLE_REPO -maxdepth 4 -type f 2>/dev/null | head -1)
+  stable_file=$(find /cvmfs/$STABLE_REPO -maxdepth 4 -type f -print -quit)
   if [ -z "$stable_file" ]; then
     echo "ERROR: could not find a stable file to emit Touch traffic"
     return 15

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -61,13 +61,8 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return $?
 
   echo "*** checking transaction retries"
-  RC=$(
-    set +e
-    cvmfs_server transaction $CVMFS_TEST_REPO >/dev/null
-    echo $?
-  )
   # Expect EEXIST
-  [ "$RC" -eq 17 ] || return 30
+  expect_exit_code 17 cvmfs_server transaction $CVMFS_TEST_REPO >/dev/null || return 30
   cvmfs_server transaction -t 0 $CVMFS_TEST_REPO &
   local pid_txn=$!
   sleep 2

--- a/test/src/500-mkrepo/main
+++ b/test/src/500-mkrepo/main
@@ -61,9 +61,13 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return $?
 
   echo "*** checking transaction retries"
-  cvmfs_server transaction $CVMFS_TEST_REPO
+  RC=$(
+    set +e
+    cvmfs_server transaction $CVMFS_TEST_REPO >/dev/null
+    echo $?
+  )
   # Expect EEXIST
-  [ $? -eq 17 ] || return 30
+  [ "$RC" -eq 17 ] || return 30
   cvmfs_server transaction -t 0 $CVMFS_TEST_REPO &
   local pid_txn=$!
   sleep 2

--- a/test/src/520-history/main
+++ b/test/src/520-history/main
@@ -244,18 +244,14 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {4} check tag descriptions"
-  if cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$first_tag"       && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$first_tag_desc"  && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$second_tag"      && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$second_tag_desc" && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$third_tag"       && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$third_tag_desc"  && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$trunk_tag"       && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag"; then
-    echo "*** {4} all tags and their descriptions found"
-  else
-    return 9
-  fi
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$trunk_tag"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
 
   # ============================================================================
 
@@ -272,20 +268,16 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {5} check tag descriptions"
-  if cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$first_tag"       && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$first_tag_desc"  && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$second_tag"      && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$second_tag_desc" && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"; then
-    echo "*** {5} all tags and their descriptions found"
-  else
-    return 11
-  fi
-  if [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"      | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc" | wc -l) -ne 0 ]; then
-    return 12
-  fi
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$first_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$second_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$trunk_tag"
+
+  # These MUST NOT be found in output
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
 
   # ============================================================================
 
@@ -308,19 +300,14 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {6} check tag descriptions"
-  if cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$first_tag"       && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$first_tag_desc"  && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$second_tag"      && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$second_tag_desc" && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"       && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag"; then
-    echo "*** {6} all tags and their descriptions found"
-  else
-    return 15
-  fi
-  if [ $(cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$third_tag_desc" | wc -l) -ne 0 ]; then
-    return 16
-  fi
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$first_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$second_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$trunk_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
+
+  ! cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$third_tag_desc"
 
   # ============================================================================
 
@@ -337,20 +324,15 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {7} check tag descriptions"
-  if cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$first_tag"      && \
-     cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$first_tag_desc" && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO    | grep -q "$trunk_tag"; then
-    echo "*** {7} all tags and their descriptions found"
-  else
-    return 18
-  fi
-  if [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"      | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc" | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"  | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag"  | wc -l) -ne 0 ]; then
-    return 19
-  fi
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  cvmfs_server tag -l $CVMFS_TEST_REPO    | grep "$trunk_tag"
+
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
 
   # ============================================================================
 
@@ -386,20 +368,15 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {9} check tag descriptions"
-  if cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$first_tag"        && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$first_tag_desc+1" && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"        && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag"; then
-    echo "*** {9} all tags and their descriptions found"
-  else
-    return 21
-  fi
-  if [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"      | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc" | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"  | wc -l) -ne 0 ]; then
-    return 22
-  fi
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$first_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$first_tag_desc+1"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$trunk_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
+
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
 
   # ============================================================================
 
@@ -410,20 +387,15 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {10} check tag existence"
-  if cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"        && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag"; then
-    echo "*** {10} all tags and their descriptions found"
-  else
-    return 24
-  fi
-  if [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"  | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"      | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc" | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"  | wc -l) -ne 0 ]; then
-    return 25
-  fi
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$trunk_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
+
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
 
   # ============================================================================
 
@@ -449,20 +421,15 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {11} check tag existence (especially $prev_trunk_tag)"
-  if cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"        && \
-     cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag"; then
-    echo "all tags and their descriptions found"
-  else
-    return 29
-  fi
-  if [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"  | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"      | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc" | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"  | wc -l) -ne 0 ]; then
-    return 30
-  fi
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag"
+
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
 
   echo "*** {11} initiate a rollback"
   cvmfs_server rollback -f $CVMFS_TEST_REPO || return 31
@@ -477,20 +444,15 @@ cvmfs_run_test() {
   cvmfs_server tag -l $CVMFS_TEST_REPO
 
   echo "*** {11} check tag existence (especially $prev_trunk_tag)"
-  if cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag"; then
-    echo "*** {11} all tags and their descriptions found"
-  else
-    return 33
-  fi
-  if [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"  | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"      | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc" | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"       | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"  | wc -l) -ne 0 ] || \
-     [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag"  | wc -l) -ne 0 ]; then
-    return 34
-  fi
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$trunk_tag"
+
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$first_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$second_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$third_tag_desc"
+  ! cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag"
 
   # ============================================================================
 
@@ -507,7 +469,7 @@ cvmfs_run_test() {
   cvmfs_server tag -r $oldest_tag -f $CVMFS_TEST_REPO  && return 37
 
   echo "*** {13} check if tag is still there"
-  cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$oldest_tag" || return 38
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$oldest_tag"|| return 38
 
   echo "*** {13} abort transaction"
   cvmfs_server abort -f $CVMFS_TEST_REPO || return 39
@@ -525,11 +487,11 @@ cvmfs_run_test() {
   cvmfs_server tag $remove_flags -f $CVMFS_TEST_REPO || return 40
 
   echo "*** {14} check that trunk is still there"
-  cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$trunk_tag" || return 41
+  cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$trunk_tag" || return 41
 
   echo "*** {14} check that the tags ($oldest_tags_list) are gone"
   for tag in $oldest_tags; do
-    cvmfs_server tag -l $CVMFS_TEST_REPO | grep -q "$tag" && return 42
+    cvmfs_server tag -l $CVMFS_TEST_REPO | grep "$tag" && return 42
   done
 
   echo "*** {14} check the number of tags"
@@ -542,7 +504,7 @@ cvmfs_run_test() {
   publish_repo $CVMFS_TEST_REPO      || return 44
 
   echo "*** {15} check if trunk-previous is there"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" || return 45
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" || return 45
 
   # ============================================================================
 
@@ -553,7 +515,7 @@ cvmfs_run_test() {
   cvmfs_server rollback -f $CVMFS_TEST_REPO && return 46
 
   echo "*** {16} check if tag is still there"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" || return 47
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" || return 47
 
   echo "*** {16} abort transaction"
   cvmfs_server abort -f $CVMFS_TEST_REPO || return 48
@@ -569,8 +531,8 @@ cvmfs_run_test() {
   cvmfs_server tag $remove_flags -f $CVMFS_TEST_REPO || return 49
 
   echo "*** {17} check if trunk and trunk-previous are there"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$trunk_tag"      || return 50
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" || return 50
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$trunk_tag"      || return 50
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" || return 50
 
   echo "*** {17} check the number of tags"
   [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | wc -l) -eq 2 ] || return 51
@@ -598,8 +560,8 @@ cvmfs_run_test() {
   done
 
   echo "*** {18} check if trunk and trunk-previous are there"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$trunk_tag"      || return 54
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" || return 54
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$trunk_tag"      || return 54
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" || return 54
 
   echo "*** {18} check the number of tags"
   [ $(cvmfs_server tag -l -x $CVMFS_TEST_REPO | wc -l) -eq 2 ] || return 55
@@ -613,8 +575,8 @@ cvmfs_run_test() {
   # ============================================================================
 
   echo "*** {19} check if we have undo tags"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$trunk_tag"      || return 57
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" || return 58
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$trunk_tag"      || return 57
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" || return 58
 
   echo "*** {19} try to delete undo tags (should fail)"
   cvmfs_server tag -r $trunk_tag -f                    $CVMFS_TEST_REPO && return 59
@@ -622,8 +584,8 @@ cvmfs_run_test() {
   cvmfs_server tag -r $trunk_tag -r $prev_trunk_tag -f $CVMFS_TEST_REPO && return 61
 
   echo "*** {19} check that we still have undo tags"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$trunk_tag"      || return 62
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" || return 63
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$trunk_tag"      || return 62
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" || return 63
 
   # ============================================================================
 
@@ -631,13 +593,13 @@ cvmfs_run_test() {
   cvmfs_server rollback -f $CVMFS_TEST_REPO || return 64
 
   echo "*** {20} check if $prev_trunk_tag is gone"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" && return 64
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" && return 64
 
   echo "*** {20} try to recreate $prev_trunk_tag (should fail)"
   cvmfs_server tag -a $prev_trunk_tag $CVMFS_TEST_REPO && return 65
 
   echo "*** {20} check if $prev_trunk_tag is still not there"
-  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep -q "$prev_trunk_tag" && return 66
+  cvmfs_server tag -l -x $CVMFS_TEST_REPO | grep "$prev_trunk_tag" && return 66
 
   return 0
 }

--- a/test/src/523-corruptchunkfailover/main
+++ b/test/src/523-corruptchunkfailover/main
@@ -60,7 +60,7 @@ EOF
   # succeed.  (A retry here would mask the parallel-decompress fail-over bug
   # that this test guards against.)
   for f in $(find $mnt_point -maxdepth 1 -type f); do
-    cat $f > /dev/null || { desaster_cleanup $mnt_point $replica_name; return 7; }
+    cat $f > /dev/null || { desaster_cleanup $mnt_point $replica_name; cat cvmfs2_output.log; return 7; }
   done
 
   echo "clean up"

--- a/test/src/527-publishretval/main
+++ b/test/src/527-publishretval/main
@@ -17,11 +17,7 @@ cvmfs_run_test() {
   sudo rm -f /etc/cvmfs/keys/$CVMFS_TEST_REPO.pub
 
   echo "creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO
-  local retval=$?
-
-  echo "Return value is $retval"
-  if [ $retval -eq 0 ]; then
+  if publish_repo $CVMFS_TEST_REPO; then
     echo "error retval expected but retval was ok"
     return 5
   fi

--- a/test/src/536-healthcheck/main
+++ b/test/src/536-healthcheck/main
@@ -30,19 +30,19 @@ cvmfs_run_test() {
   sudo umount $repo_dir || return 3
 
   echo "*** check the repository (failure is expected)"
-  cvmfs_server check $CVMFS_TEST_REPO 2>&1 | grep -q "$repo_dir is not mounted" || return 4
+  (! cvmfs_server check $CVMFS_TEST_REPO 2>&1) | grep -q "$repo_dir is not mounted" || return 4
 
   echo "*** unmount read-only cvmfs branch"
   sudo umount $rd_only || return 5
 
   echo "*** check the repository (failure is expected)"
-  cvmfs_server check $CVMFS_TEST_REPO 2>&1 | grep -q "$rd_only is not mounted" || return 6
+  (! cvmfs_server check $CVMFS_TEST_REPO 2>&1) | grep -q "$rd_only is not mounted" || return 6
 
   echo "*** mount union file system mountpoint"
   sudo mount $repo_dir || return 7
 
   echo "*** try to open transaction (failure is expected)"
-  cvmfs_server transaction $CVMFS_TEST_REPO 2>&1 | grep -q "$rd_only is not mounted" || return 8
+  (! cvmfs_server transaction $CVMFS_TEST_REPO 2>&1) | grep -q "$rd_only is not mounted" || return 8
 
   echo "*** repair the repository state"
   sudo umount $repo_dir || return 9
@@ -56,7 +56,7 @@ cvmfs_run_test() {
   sudo mount -o remount,ro $repo_dir || return 12
 
   echo "*** try to publish (failure is expected)"
-  cvmfs_server publish $CVMFS_TEST_REPO 2>&1 | grep -q "$CVMFS_TEST_REPO is in a transaction but" || return 13
+  (! cvmfs_server publish $CVMFS_TEST_REPO 2>&1) | grep -q "$CVMFS_TEST_REPO is in a transaction but" || return 13
 
   echo "*** repair the state of the mountpoint"
   sudo mount -o remount,rw $repo_dir || return 14
@@ -68,7 +68,7 @@ cvmfs_run_test() {
   sudo mount -o remount,rw $repo_dir || return 15
 
   echo "*** try to open transaction (failure is expected)"
-  cvmfs_server transaction $CVMFS_TEST_REPO 2>&1 | grep -q "$CVMFS_TEST_REPO is not in a transaction but" || return 16
+  (! cvmfs_server transaction $CVMFS_TEST_REPO 2>&1) | grep -q "$CVMFS_TEST_REPO is not in a transaction but" || return 16
 
   echo "*** repair the state of the mountpoint"
   sudo mount -o remount,ro $repo_dir || return 17

--- a/test/src/536-healthcheck/main
+++ b/test/src/536-healthcheck/main
@@ -84,7 +84,8 @@ cvmfs_run_test() {
   sudo mount $repo_dir  || return 21
 
   echo "*** create a transaction (should fail)"
-  start_transaction $CVMFS_TEST_REPO 2>&1 | grep -q "$CVMFS_TEST_REPO is not based on the newest" || return 22
+  start_transaction $CVMFS_TEST_REPO 2>transaction.err && return 22
+  grep -q "$CVMFS_TEST_REPO is not based on the newest" transaction.err || return 22
 
   echo "*** repair the root hash ($latest_root_hash)"
   sed -i -e "s/CVMFS_ROOT_HASH=.*/CVMFS_ROOT_HASH=${latest_root_hash}/" $client_config

--- a/test/src/537-symlinkedbackend/main
+++ b/test/src/537-symlinkedbackend/main
@@ -43,6 +43,7 @@ cvmfs_run_test() {
   mkdir reference_dir
   local reference_dir=$scratch_dir/reference_dir
 
+  sudo mkdir -p /srv/cvmfs
   local backend_dir="/srv/cvmfs/${CVMFS_TEST_REPO}"
   local alternative_backend="/opt/cvmfs"
   local symlink_destination="${alternative_backend}/${CVMFS_TEST_REPO}"

--- a/test/src/540-rootcvmfscatalog/main
+++ b/test/src/540-rootcvmfscatalog/main
@@ -16,9 +16,8 @@ cvmfs_run_test() {
   echo "touch /cvmfs/$CVMFS_TEST_REPO/.cvmfscatalog"
   sudo touch /cvmfs/$CVMFS_TEST_REPO/.cvmfscatalog || return 3
 
-  echo "creating CVMFS snapshot"
-  publish_repo $CVMFS_TEST_REPO
-  if [ $? -eq 0 ]; then
+  echo "creating CVMFS snapshot" 
+  if publish_repo $CVMFS_TEST_REPO; then
     echo "publish should not have succeeded"
     return 4
   fi

--- a/test/src/541-preloadcache/main
+++ b/test/src/541-preloadcache/main
@@ -33,7 +33,6 @@ cleanup() {
   echo "running cleanup()"
   if [ ! -z $CVMFS_TEST_541_MOUNTPOINT ]; then
     sudo fusermount -u $CVMFS_TEST_541_MOUNTPOINT
-    sudo umount        $CVMFS_TEST_541_MOUNTPOINT
   fi
 }
 

--- a/test/src/551-openfds/main
+++ b/test/src/551-openfds/main
@@ -56,13 +56,13 @@ cvmfs_run_test() {
 
   cd /cvmfs/$CVMFS_TEST_REPO || return 8
   start_transaction $CVMFS_TEST_REPO || return 9
-  echo y | publish_repo $CVMFS_TEST_REPO
-  if [ $? -eq 0 ]; then
+  if echo y | publish_repo $CVMFS_TEST_REPO; then
+    echo "Should have refused due to busy dir, telling user to cd out"
     return 10
   fi
   cd foo || return 11
-  echo y | publish_repo $CVMFS_TEST_REPO
-  if [ $? -eq 0 ]; then
+  if echo y | publish_repo $CVMFS_TEST_REPO; then
+    echo "Should have refused due to busy dir, telling user to cd out"
     return 12
   fi
   cd / || return 13

--- a/test/src/551-openfds/main
+++ b/test/src/551-openfds/main
@@ -52,7 +52,7 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return 5
   publish_repo $CVMFS_TEST_REPO || return 6
 
-  kill $pid || return 7
+  kill $pid || true
 
   cd /cvmfs/$CVMFS_TEST_REPO || return 8
   start_transaction $CVMFS_TEST_REPO || return 9

--- a/test/src/551-openfds/main
+++ b/test/src/551-openfds/main
@@ -24,7 +24,6 @@ produce_files_in() {
 }
 
 block_repo() {
-  cd /cvmfs/$CVMFS_TEST_REPO
   while true; do ls .; sleep 1; done
 }
 
@@ -40,7 +39,9 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO || return $?
 
   echo "block repository"
+  pushd /cvmfs/$CVMFS_TEST_REPO
   block_repo &
+  popd
   local pid=$!
 
   echo "putting some stuff in the new repository"

--- a/test/src/552-repodate/main
+++ b/test/src/552-repodate/main
@@ -50,8 +50,8 @@ CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/${CVMFS_TEST_REPO}.pub
 CVMFS_REPOSITORY_DATE=$stamp_zero
 EOF
 
-  cvmfs2 -d -o config=$conf $CVMFS_TEST_REPO $mountpoint >> $output 2>&1
-  if [ $? -eq 0 ]; then
+  
+  if cvmfs2 -d -o config=$conf $CVMFS_TEST_REPO $mountpoint >> $output 2>&1; then
     fusermount -u $mountpoint
     return 34
   fi

--- a/test/src/563-garbagecollectlegacy/main
+++ b/test/src/563-garbagecollectlegacy/main
@@ -122,7 +122,7 @@ e1db87c42de2501a3999b6fbbfdf9674ad968e71
   local all_reflog_entries_found=1
   for clg in $cvmfs20_root_clgs $cvmfs21_root_clgs; do
     echo -n "looking for ${clg}... "
-    cat $gc_log_1 | grep -q "Catalog: $clg" && echo "found" || { echo "not found"; all_reflog_entries_found=0; }
+    grep -q "Catalog: $clg" "$gc_log_1" && echo "found" || { echo "not found"; all_reflog_entries_found=0; }
   done
   [ $all_reflog_entries_found -eq 1 ] || return 103
 

--- a/test/src/570-remountrace/main
+++ b/test/src/570-remountrace/main
@@ -140,7 +140,7 @@ cvmfs_run_test() {
 
   echo "trying to publish with forced remount (might confuse the culprit)"
   local publish_log_5="${scratch_dir}/publish_5.log"
-  yes | publish_repo $CVMFS_TEST_REPO > $publish_log_5 || return 20
+  publish_repo $CVMFS_TEST_REPO > $publish_log_5 || return 20
 
   echo "check for the error message"
   cat $publish_log_5 | grep 'WARNING.*open read-only' || return 21

--- a/test/src/571-localbackendumask/main
+++ b/test/src/571-localbackendumask/main
@@ -56,21 +56,21 @@ check_permissions_of_new_files() {
 
 create_random_files() {
   local filename_dummy="$1"
-  local bytes="$2"
+  local kbytes="$2"
   local filecount="$3"
 
   local i=0
   while [ $i -lt $filecount ]; do
     local filename=$(mktemp $filename_dummy)
-    dd if=/dev/urandom of="$filename" bs=1 count=$bytes status=none || return 1
+    dd if=/dev/urandom of="$filename" bs=1K count=$kbytes status=none || return 1
     i=$(( $i + 1 ))
   done
 }
 
 put_files_in() {
   local repo_dir="$1"
-  create_random_files "${repo_dir}/largeXXXXXX" $(( 15 * 1024 * 1024 ))  2
-  create_random_files "${repo_dir}/smallXXXXXX" $(( 15 * 1024 ))        10
+  create_random_files "${repo_dir}/largeXXXXXX" $(( 15 * 1024 ))  2
+  create_random_files "${repo_dir}/smallXXXXXX" $(( 15 ))        10
 }
 
 cvmfs_run_test() {

--- a/test/src/571-localbackendumask/main
+++ b/test/src/571-localbackendumask/main
@@ -62,7 +62,7 @@ create_random_files() {
   local i=0
   while [ $i -lt $filecount ]; do
     local filename=$(mktemp $filename_dummy)
-    cat /dev/urandom | base64 -w0 | head -c $bytes > $filename 2>/dev/null || return 1
+    dd if=/dev/urandom of="$filename" bs=1 count=$bytes status=none || return 1
     i=$(( $i + 1 ))
   done
 }

--- a/test/src/577-garbagecollecthiddenstratum1revision/main
+++ b/test/src/577-garbagecollecthiddenstratum1revision/main
@@ -61,7 +61,7 @@ cvmfs_run_test() {
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER and disabled auto-tagging"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER NO -g -z || return $?
-  condemned_clgs="$condemned_clgs $(get_current_root_catalog $CVMFS_TEST_REPO)"
+  condemned_clgs="$(get_current_root_catalog $CVMFS_TEST_REPO)"
 
   echo "disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?

--- a/test/src/578-automaticgarbagecollection/main
+++ b/test/src/578-automaticgarbagecollection/main
@@ -48,7 +48,7 @@ cvmfs_run_test() {
   peek_backend_raw $CVMFS_TEST_REPO .cvmfs_status.json || return 60
   root_catalog0="$(get_current_root_catalog $CVMFS_TEST_REPO)C"
 
-  echo "*** configure repository to automatically delete revisions older than $thresh_seconds seconds"
+  echo "*** configure repository to automatically delete revisions older than threshold"
   local server_conf="/etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf"
   echo "CVMFS_AUTO_GC_TIMESPAN=now" | sudo tee --append $server_conf || return 1
 

--- a/test/src/592-magicsymlinks/main
+++ b/test/src/592-magicsymlinks/main
@@ -173,8 +173,7 @@ cvmfs_run_test() {
   check_symlinks "$TEST_592_MOUNTPOINT" || return 5
 
   echo "ensure raw symlinks in server mode"
-  check_symlinks "/var/spool/cvmfs/${CVMFS_TEST_REPO}/rdonly"
-  if [ $? -eq 0 ]; then
+  if check_symlinks "/var/spool/cvmfs/${CVMFS_TEST_REPO}/rdonly"; then
     return 30
   fi
 

--- a/test/src/595-geoipdbupdate/main
+++ b/test/src/595-geoipdbupdate/main
@@ -86,7 +86,7 @@ cvmfs_run_test() {
   if [ -f /etc/cvmfs/server.local ]; then
     . /etc/cvmfs/server.local
   fi
-  if [ -n "$CVMFS_GEO_DB_FILE" ]; then
+  if ! [[ -v CVMFS_GEO_DB_FILE ]]; then
     echo "Geo database update disabled, skipping tests"
     CVMFS_GENERAL_WARNING_FLAG=1
     return 0

--- a/test/src/606-graftutil/main
+++ b/test/src/606-graftutil/main
@@ -46,10 +46,6 @@ cvmfs_run_test() {
   echo "$output"
 
   verify_hello_world "$output"
-  local verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
 
   #################################################################
   echo "Test empty file"
@@ -74,10 +70,6 @@ cvmfs_run_test() {
   echo "$output"
 
   verify_hello_world "$output"
-  verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
 
   local uncompressed_cksum=$(echo "hello world" | cvmfs_swissknife graft -i - | grep checksum | tr '=' ' ' | awk '{print $2;}')
   local uncompressed_cksum_real=$(echo "hello world" | sha1sum | awk '{print $1;}')
@@ -99,10 +91,6 @@ cvmfs_run_test() {
   fi
 
   verify_hello_world "`cat simple1/.cvmfsgraft-hello_world`"
-  verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
 
   #################################################################
   echo "Single file output, absolute graft path"
@@ -116,10 +104,6 @@ cvmfs_run_test() {
   fi
 
   verify_hello_world "`cat simple2/.cvmfsgraft-hello_world2`"
-  verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
 
   #################################################################
   echo "Test nested directory."
@@ -149,23 +133,11 @@ cvmfs_run_test() {
   fi
 
   verify_hello_world "`cat deep_output/.cvmfsgraft-hello_world`"
-  verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
 
   verify_hello_world "`cat deep_output/sub1/sub2/.cvmfsgraft-hello_world`"
-  verify_result=$?
-  if [ $verify_result -ne 0 ]; then
-    return $verify_result
-  fi
 
   echo "Verifying test breaks on invalid input:"
-  verify_hello_world "`cat deep_output/sub1/sub2/.cvmfsgraft-check_break`"
-  verify_result=$?
-  if [ $verify_result -eq 0 ]; then
-    return $verify_result
-  fi
+  ! verify_hello_world "`cat deep_output/sub1/sub2/.cvmfsgraft-check_break`"
 
   echo "Test hash algorithm"
   local shake_checksum=$(echo -n "abc" | cvmfs_swissknife graft -i - -a shake128 \

--- a/test/src/608-infofile/main
+++ b/test/src/608-infofile/main
@@ -6,7 +6,8 @@ cvmfs_test_suites="quick"
 CVMFS_TEST_608_REPLICA_NAME=
 cleanup() {
   echo "running cleanup..."
-  [ -z $CVMFS_TEST_608_REPLICA_NAME ] ||  sudo cvmfs_server rmfs -f $CVMFS_TEST_608_REPLICA_NAME
+  # may not actually exist at some points
+  [ -z $CVMFS_TEST_608_REPLICA_NAME ] ||  sudo cvmfs_server rmfs -f $CVMFS_TEST_608_REPLICA_NAME || true
 }
 
 d() {

--- a/test/src/610-altpath/main
+++ b/test/src/610-altpath/main
@@ -8,7 +8,8 @@ CVMFS_TEST_610_REPLICA_NAME=
 CVMFS_TEST_610_MOUNTPOINT=
 cleanup() {
   [ -z $CVMFS_TEST_610_MOUNTPOINT ] || sudo umount $CVMFS_TEST_610_MOUNTPOINT > /dev/null 2>&1
-  [ -z $CVMFS_TEST_610_REPLICA_NAME ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_610_REPLICA_NAME
+  # may not actually exist at some points
+  [ -z $CVMFS_TEST_610_REPLICA_NAME ] || sudo cvmfs_server rmfs -f $CVMFS_TEST_610_REPLICA_NAME || true
 }
 
 produce_files_in() {

--- a/test/src/611-idleclient/main
+++ b/test/src/611-idleclient/main
@@ -65,10 +65,7 @@ cvmfs_run_test() {
                  "$CVMFS_TEST_REPO"     \
                  "$(get_repo_url $CVMFS_TEST_REPO)" || return 4
 
-  stat $TEST_611_MOUNTPOINT/nested/updated
-  if [ $? -eq 0 ]; then
-    return 20
-  fi
+  stat $TEST_611_MOUNTPOINT/nested/updated && return 20
   stat $TEST_611_MOUNTPOINT/nested || return 25
 
   echo "starting transaction to update repository"
@@ -87,10 +84,7 @@ cvmfs_run_test() {
   local sleep_time=$((1 + $kcache_timeout + 2))
   echo "sleeping $sleep_time seconds to let ttl and kernel caches expire"
   sleep $sleep_time
-  stat $TEST_611_MOUNTPOINT/nested/updated
-  if [ $? -ne 0 ]; then
-    return 21
-  fi
+  stat $TEST_611_MOUNTPOINT/nested/updated || return 21
 
   echo "starting transaction to update repository again"
   start_transaction $CVMFS_TEST_REPO || return $?

--- a/test/src/614-geoservice/main
+++ b/test/src/614-geoservice/main
@@ -176,7 +176,7 @@ cvmfs_run_test() {
   result="`curl -s -H "$cdnheader: $ipv4addr" http://localhost/$api/x/$cerncdn,$fnalcdn,$ihepcdn|head -5`"
   cvmfs_check_georesult "$result" $me cern,fnal,ihep || return 10
 
-  echo "checking $CDN IPv6"
+  echo "checking CDN IPv6"
   result="`curl -s -H "$cdnheader: $ipv6addr" http://localhost/$api/x/$ihepcdn,$cerncdn,$fnalcdn|head -5`"
   cvmfs_check_georesult "$result" $me ihep,cern,fnal || return 11
 

--- a/test/src/616-blacklistconfigrepo/main
+++ b/test/src/616-blacklistconfigrepo/main
@@ -42,7 +42,7 @@ cvmfs_run_test() {
   TEST_616_MOUNTPOINT_MORE="$(pwd)/local_mount_more"
   do_616_mount || return 5
 
-  ls $TEST_611_MOUNTPOINT_MORE || return 11
+  ls $TEST_616_MOUNTPOINT_MORE || return 11
   remove_local_mount $TEST_616_MOUNTPOINT_MORE || return 13
 
   echo "starting transaction to edit repository"

--- a/test/src/618-repometainfo/main
+++ b/test/src/618-repometainfo/main
@@ -23,7 +23,7 @@ cvmfs_run_test() {
   sudo sh -c "echo 'echo reference' >> $tty_bin" || return 12
   sudo chmod +x $tty_bin || return 13
   touch reference
-  yes | EDITOR="cat" cvmfs_server update-repoinfo $CVMFS_TEST_REPO
+  EDITOR="cat" cvmfs_server update-repoinfo $CVMFS_TEST_REPO
   local retval=$?
   sudo mv ${tty_bin}.disabled $tty_bin || return 14
   if [ $retval -ne 0 ]; then

--- a/test/src/621-snapshotallgcall/main
+++ b/test/src/621-snapshotallgcall/main
@@ -214,8 +214,9 @@ cvmfs_run_test() {
   [ "$rep4_last_gc" != "$rep4_now_gc" ]                   || return 83
 
   echo "*** checking that gc only ran in replica 4"
-  diff gc.log /var/log/cvmfs | grep ${replica_name}-1     && return 85
-  diff gc.log /var/log/cvmfs | grep ${replica_name}-4     || return 86
+  diff gc.log /var/log/cvmfs > gc.log.diff
+  grep ${replica_name}-1 gc.log.diff && return 85
+  grep ${replica_name}-4 gc.log.diff || return 86
 
   return 0
 }

--- a/test/src/621-snapshotallgcall/main
+++ b/test/src/621-snapshotallgcall/main
@@ -102,7 +102,9 @@ cvmfs_run_test() {
   echo "*** ms0 ***"
   cat ms0
   echo "*** mr0 ***"
-  cat mr0
+  if ! running_on_s3; then
+    cat mr0
+  fi
   echo "*** mr1 ***"
   cat mr1
   echo "*** mr5 ***"

--- a/test/src/621-snapshotallgcall/main
+++ b/test/src/621-snapshotallgcall/main
@@ -216,7 +216,7 @@ cvmfs_run_test() {
   [ "$rep4_last_gc" != "$rep4_now_gc" ]                   || return 83
 
   echo "*** checking that gc only ran in replica 4"
-  diff gc.log /var/log/cvmfs > gc.log.diff
+  diff gc.log /var/log/cvmfs > gc.log.diff || true
   grep ${replica_name}-1 gc.log.diff && return 85
   grep ${replica_name}-4 gc.log.diff || return 86
 

--- a/test/src/626-cacheexpiry/main
+++ b/test/src/626-cacheexpiry/main
@@ -44,7 +44,8 @@ CVMFS_TEST_626_REPLICA_NAME=""
 cleanup() {
   echo "running cleanup()"
   if [ ! -z $CVMFS_TEST_626_REPLICA_NAME ]; then
-    sudo cvmfs_server rmfs -f $CVMFS_TEST_626_REPLICA_NAME
+    # may not actually exist at some points
+    sudo cvmfs_server rmfs -f $CVMFS_TEST_626_REPLICA_NAME || true
   fi
 }
 

--- a/test/src/627-reflog/main
+++ b/test/src/627-reflog/main
@@ -101,7 +101,7 @@ cvmfs_run_test() {
   echo "creating a tag in Stratum0"
   cvmfs_server tag -a "foobar"                          \
                    -m "new tag to create a new history" \
-                   -h "$root_hash_1" $CVMFS_TEST_REPO || return 6
+                   -h "$root_hash_1" $CVMFS_TEST_REPO || (sudo journalctl -xe; return 6)
 
   echo "extracting root hashes from Stratum0"
   local root_hash_2=$(get_manifest_field $CVMFS_TEST_REPO 'C')

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -97,7 +97,10 @@ cvmfs_run_test() {
   # but be different if PID gets recycled.
   local authz_helper_pid_stat=$(stat --terse /proc/"$authz_helper_pid")
   echo "authz helper has pid $authz_helper_pid; killing it."
+  sudo ps axfu
   sudo kill -KILL $authz_helper_pid
+  sleep 1
+  sudo ps axfu
   while [[ -d /proc/"$authz_helper_pid" ]] && [[ "$(stat --terse /proc/"$authz_helper_pid")" == "$authz_helper_pid_stat" ]]; do
     sleep 0.1
   done

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -93,8 +93,14 @@ cvmfs_run_test() {
   local secure_mnt_pid=$(get_xattr pid $mntpnt)
   echo "secure mount point has pid $secure_mnt_pid"
   local authz_helper_pid=$(pgrep -P $secure_mnt_pid cvmfs_allow)
+  # a bunch of info about /proc/PID dir, supposed to stay unchanged within process lifetime
+  # but be different if PID gets recycled.
+  local authz_helper_pid_stat=$(stat --terse /proc/"$authz_helper_pid")
   echo "authz helper has pid $authz_helper_pid; killing it."
   sudo kill -SEGV $authz_helper_pid
+  while [[ -d /proc/"$authz_helper_pid" ]] && [[ "$(stat --terse /proc/"$authz_helper_pid")" == "$authz_helper_pid_stat" ]]; do
+    sleep 0.1
+  done
   echo "authz helper has died, access should fail"
   sudo -u nobody setsid -w /bin/sh -c "cat ${mntpnt}/hello_world" && return 74
   echo "Waiting for rate-limit timeout to pass"

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -97,7 +97,7 @@ cvmfs_run_test() {
   # but be different if PID gets recycled.
   local authz_helper_pid_stat=$(stat --terse /proc/"$authz_helper_pid")
   echo "authz helper has pid $authz_helper_pid; killing it."
-  sudo kill -SEGV $authz_helper_pid
+  sudo kill -KILL $authz_helper_pid
   while [[ -d /proc/"$authz_helper_pid" ]] && [[ "$(stat --terse /proc/"$authz_helper_pid")" == "$authz_helper_pid_stat" ]]; do
     sleep 0.1
   done

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -97,13 +97,14 @@ cvmfs_run_test() {
   # but be different if PID gets recycled.
   local authz_helper_pid_stat=$(stat --terse /proc/"$authz_helper_pid")
   echo "authz helper has pid $authz_helper_pid; killing it."
-  sudo ps axfu
+  sudo ps -fu -p "$authz_helper_pid"
   sudo kill -KILL $authz_helper_pid
-  sleep 1
-  sudo ps axfu
-  while [[ -d /proc/"$authz_helper_pid" ]] && [[ "$(stat --terse /proc/"$authz_helper_pid")" == "$authz_helper_pid_stat" ]]; do
+  sudo ps -fu -p "$authz_helper_pid" || true
+  # authz_helper_pid is observed a zombie not reaped by cvmfs2 for a long time. 2026-05-30
+  while [[ -d /proc/"$authz_helper_pid" ]] && [[ "$(stat --terse /proc/"$authz_helper_pid")" == "$authz_helper_pid_stat" ]] && [[ "$(ps -o stat= -p "$authz_helper_pid")" != Z ]]; do
     sleep 0.1
   done
+  sudo ps -fu -p "$authz_helper_pid" || true
   echo "authz helper has died, access should fail"
   sudo -u nobody setsid -w /bin/sh -c "cat ${mntpnt}/hello_world" && return 74
   echo "Waiting for rate-limit timeout to pass"

--- a/test/src/633a-changedfiles/main
+++ b/test/src/633a-changedfiles/main
@@ -161,10 +161,10 @@ cvmfs_run_test() {
 
   rm -f stop_topen
 
-  ./topen ${mntpnt}/dir/small > topen02_small.stdout 2> topen02_small.stderr &
+  ./topen ${mntpnt}/dir/small > topen02_small.stdout &
   local pid_small02=$!
   TEST633_PIDS="$TEST633_PIDS $pid_small02"
-  ./topen ${mntpnt}/dir/large > topen02_large.stdout 2> topen02_large.stderr &
+  ./topen ${mntpnt}/dir/large > topen02_large.stdout &
   local pid_large02=$!
   TEST633_PIDS="$TEST633_PIDS $pid_large02"
   echo "*** {2} topen process pids: $pid_small02, $pid_large02"
@@ -237,10 +237,10 @@ cvmfs_run_test() {
   echo "*** {3} inodes: $inode_small03 [small]    $inode_large03 [large]"
   echo "*** {3} sizes: $size_small03 [small]    $size_large03 [large]"
 
-  ./topen ${mntpnt}/dir/small > topen03_small.stdout 2> topen03_small.stderr &
+  ./topen ${mntpnt}/dir/small > topen03_small.stdout &
   local pid_small03=$!
   TEST633_PIDS="$TEST633_PIDS $pid_small03"
-  ./topen ${mntpnt}/dir/large > topen03_large.stdout 2> topen03_large.stderr &
+  ./topen ${mntpnt}/dir/large > topen03_large.stdout &
   local pid_large03=$!
   TEST633_PIDS="$TEST633_PIDS $pid_large03"
   echo "*** {3} topen process pids: $pid_small03, $pid_large03"
@@ -329,10 +329,10 @@ cvmfs_run_test() {
   echo "*** {4} inodes: $inode_small04 [small]    $inode_large04 [large]"
   echo "*** {4} sizes: $size_small04 [small]    $size_large04 [large]"
 
-  ./topen ${mntpnt}/dir/small > topen04_small.stdout 2> topen04_small.stderr &
+  ./topen ${mntpnt}/dir/small > topen04_small.stdout &
   local pid_small04=$!
   TEST633_PIDS="$TEST633_PIDS $pid_small04"
-  ./topen ${mntpnt}/dir/large > topen04_large.stdout 2> topen04_large.stderr &
+  ./topen ${mntpnt}/dir/large > topen04_large.stdout &
   local pid_large04=$!
   TEST633_PIDS="$TEST633_PIDS $pid_large04"
   echo "*** {4} topen process pids: $pid_small04, $pid_large04"
@@ -404,19 +404,14 @@ cvmfs_run_test() {
   [ $(get_internal_counter cvmfs.n_fs_inode_replace) -gt 0 ] || return 33
 
   touch stop_topen
-  wait $TEST633_PIDS
+  for pid in $TEST633_PIDS; do
+    wait "$pid"
+  done
   TEST633_PIDS=
 
   [ x"$(get_checksum ${mntpnt}/dir/small)" = x"$chksum_small04" ] || return 91
   [ x"$(get_checksum ${mntpnt}/dir/large)" = x"$chksum_large04" ] || return 92
   purge_disk_cache
-
-  [ -s topen02_small.stderr ] && return 30
-  [ -s topen02_large.stderr ] && return 31
-  [ -s topen03_small.stderr ] && return 32
-  [ -s topen03_large.stderr ] && return 33
-  [ -s topen04_small.stderr ] && return 33
-  [ -s topen04_large.stderr ] && return 34
 
   [ x"$(get_checksum ${mntpnt}/dir/small)" = x"$chksum_small04" ] || return 93
   [ x"$(get_checksum ${mntpnt}/dir/large)" = x"$chksum_large04" ] || return 94

--- a/test/src/633a-changedfiles/main
+++ b/test/src/633a-changedfiles/main
@@ -88,7 +88,7 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO                              || return $?
   mkdir /cvmfs/$CVMFS_TEST_REPO/dir                               || return 3
   echo "Hello World" > $small_file                                || return 3
-  dd if=/dev/urandom of=$large_file bs=$((32*1024)) count=1024    || return 3
+  (yes || true) | head -c $((32*1024*1024)) > $large_file                   || return 3
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
   local mntpnt="${scratch_dir}/private_mnt"

--- a/test/src/633a-changedfiles/main
+++ b/test/src/633a-changedfiles/main
@@ -88,7 +88,7 @@ cvmfs_run_test() {
   start_transaction $CVMFS_TEST_REPO                              || return $?
   mkdir /cvmfs/$CVMFS_TEST_REPO/dir                               || return 3
   echo "Hello World" > $small_file                                || return 3
-  yes | head -c $((32*1024*1024)) > $large_file                   || return 3
+  dd if=/dev/urandom of=$large_file bs=$((32*1024)) count=1024    || return 3
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
   local mntpnt="${scratch_dir}/private_mnt"

--- a/test/src/634-reflogchecksum/main
+++ b/test/src/634-reflogchecksum/main
@@ -30,7 +30,7 @@ cvmfs_run_test() {
 
   echo "*** check validation of checksum"
   mv $checksum $checksum.backup
-  cat /dev/zero | head -c 40 > $checksum
+  dd if=/dev/zero bs=40 count=1 status=none of=$checksum
   check_repository $CVMFS_TEST_REPO && return 21
   start_transaction $CVMFS_TEST_REPO || return $?
   publish_repo $CVMFS_TEST_REPO && return 20

--- a/test/src/638-virtualdir/main
+++ b/test/src/638-virtualdir/main
@@ -143,7 +143,7 @@ cvmfs_run_test() {
   [ "x$uid_before" != "x0" -o "x$gid_before" != "x0" ] && return 60
   echo "0 1" > uidmap
   echo "0 1" > gidmap
-  sudo cvmfs_server catalog-chown -u uidmap -g gidmap $CVMFS_TEST_REPO || return 61
+  sudo cvmfs_server catalog-chown -u uidmap -g gidmap $CVMFS_TEST_REPO || (sudo journalctl -xe; return 61)
   local uid_after=$(stat -c %u /cvmfs/$CVMFS_TEST_REPO/.cvmfs/snapshots)
   local gid_after=$(stat -c %g /cvmfs/$CVMFS_TEST_REPO/.cvmfs/snapshots)
   [ "x$uid_after" != "x0" -o "x$gid_after" != "x0" ] && return 62

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -34,6 +34,7 @@ produce_tarball() {
 
 cvmfs_run_test() {
   logfile=$1
+  local script_location=$2
   local scratch_dir=$(pwd)
   local tarfile=$scratch_dir/tarball.tar
   local dir=tar_dir

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -6,7 +6,6 @@ cvmfs_test_suites="quick"
 
 produce_tarball() {
   local tarball_name=$1
-  local script_location=$2
 
   mkdir tarball_foo
   mkdir -p tarball_foo/a/b/c

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -50,7 +50,7 @@ cvmfs_run_test() {
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
   echo "*** delete older stats.db files:"
-  rm -vf $CVMFS_TEST_662_DB_PATH
+  rm -vf $CVMFS_TEST_661_DB_PATH
 
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?

--- a/test/src/661-garbage_collector_statistics/main
+++ b/test/src/661-garbage_collector_statistics/main
@@ -49,9 +49,6 @@ cvmfs_run_test() {
   echo "*** disable automatic garbage collection"
   disable_auto_garbage_collection $CVMFS_TEST_REPO || return $?
 
-  echo "*** delete older stats.db files:"
-  rm -vf $CVMFS_TEST_661_DB_PATH
-
   echo "*** starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
   echo "*** putting some stuff in the repository"

--- a/test/src/666-ingestownership/main
+++ b/test/src/666-ingestownership/main
@@ -13,6 +13,12 @@ cleanup() {
   fi
 
   if [ "x$CVMFS_TEST666_TEST_UID" != "x" ]; then
+    # systemd user session automatically started by `sudo` fails userdel. Seen on CentOS 9.
+    # Waiting for it to terminate on its own takes 10 seconds.
+    sudo kill $(ps -u cvmfstestuser -o pid=) || true
+    while ps -u cvmfstestuser -o pid= >/dev/null; do
+      sleep 1
+    done
     sudo userdel cvmfstestuser
   fi
 

--- a/test/src/668-nfschunkinodes/main
+++ b/test/src/668-nfschunkinodes/main
@@ -43,13 +43,14 @@ cvmfs_run_test() {
   echo "*** put a a large file into $CVMFS_TEST_REPO"
   start_transaction $CVMFS_TEST_REPO                              || return $?
   mkdir /cvmfs/$CVMFS_TEST_REPO/dir                               || return 3
-  yes | head -c $size > /cvmfs/$CVMFS_TEST_REPO/dir/large         || return 3
+  dd if=/dev/urandom bs=1 count=$size of=/cvmfs/$CVMFS_TEST_REPO/dir/large || return 3
+  sha1sum /cvmfs/$CVMFS_TEST_REPO/dir/large > CHECKSUM
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
   local mntpnt="${scratch_dir}/private_mnt"
   echo "*** mount private mount point"
   private_mount $mntpnt || return 20
-  [ "x$(tail -n 1 ${mntpnt}/dir/large)" = "xy" ] || return 21
+  sha1sum -c CHECKSUM || return 21
 
   local revision_old=$(get_xattr revision ${mntpnt}) || return 25
   echo "*** revision is $revision_old"
@@ -65,7 +66,8 @@ cvmfs_run_test() {
   echo "*** change contents of large file"
   ls -lisa ${mntpnt}/dir/*
   start_transaction $CVMFS_TEST_REPO                         || return $?
-  yes n | head -c $size > /cvmfs/$CVMFS_TEST_REPO/dir/large  || return 30
+  dd if=/dev/urandom bs=1 count=$size of=/cvmfs/$CVMFS_TEST_REPO/dir/large || return 30
+  sha1sum /cvmfs/$CVMFS_TEST_REPO/dir/large > CHECKSUM
   publish_repo $CVMFS_TEST_REPO -v                           || return $?
 
   echo "*** remount private mount point"
@@ -76,7 +78,7 @@ cvmfs_run_test() {
 
   echo "*** verify new content"
   ls -lisa ${mntpnt}/dir/*
-  [ "x$(tail -n 1 ${mntpnt}/dir/large)" = "xn" ] || return 50
+  sha1sum -c CHECKSUM || return 50
 
   echo "*** verify that our open tail processes did acutally run"
   /bin/kill -TERM $TEST668_TAIL_PID || return 61

--- a/test/src/668-nfschunkinodes/main
+++ b/test/src/668-nfschunkinodes/main
@@ -39,11 +39,10 @@ cvmfs_run_test() {
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
-  local size=$((32*1024*1024))
   echo "*** put a a large file into $CVMFS_TEST_REPO"
   start_transaction $CVMFS_TEST_REPO                              || return $?
   mkdir /cvmfs/$CVMFS_TEST_REPO/dir                               || return 3
-  dd if=/dev/urandom bs=1 count=$size of=/cvmfs/$CVMFS_TEST_REPO/dir/large || return 3
+  dd if=/dev/urandom bs=1M count=32 of=/cvmfs/$CVMFS_TEST_REPO/dir/large || return 3
   sha1sum /cvmfs/$CVMFS_TEST_REPO/dir/large > CHECKSUM
   publish_repo $CVMFS_TEST_REPO -v                                || return $?
 
@@ -66,7 +65,7 @@ cvmfs_run_test() {
   echo "*** change contents of large file"
   ls -lisa ${mntpnt}/dir/*
   start_transaction $CVMFS_TEST_REPO                         || return $?
-  dd if=/dev/urandom bs=1 count=$size of=/cvmfs/$CVMFS_TEST_REPO/dir/large || return 30
+  dd if=/dev/urandom bs=1M count=32 of=/cvmfs/$CVMFS_TEST_REPO/dir/large || return 30
   sha1sum /cvmfs/$CVMFS_TEST_REPO/dir/large > CHECKSUM
   publish_repo $CVMFS_TEST_REPO -v                           || return $?
 

--- a/test/src/674-alienupdate/main
+++ b/test/src/674-alienupdate/main
@@ -10,11 +10,9 @@ cleanup() {
   echo "running cleanup()"
   if [ ! -z $CVMFS_TEST_674_MOUNTPOINT_A ]; then
     sudo fusermount -u $CVMFS_TEST_674_MOUNTPOINT_A
-    sudo umount        $CVMFS_TEST_674_MOUNTPOINT_A
   fi
   if [ ! -z $CVMFS_TEST_674_MOUNTPOINT_B ]; then
     sudo fusermount -u $CVMFS_TEST_674_MOUNTPOINT_B
-    sudo umount        $CVMFS_TEST_674_MOUNTPOINT_B
   fi
 }
 

--- a/test/src/677-removebulkhashes/main
+++ b/test/src/677-removebulkhashes/main
@@ -13,22 +13,19 @@ cvmfs_run_test() {
   echo "*** create small and large files"
   start_transaction $CVMFS_TEST_REPO || return $?
   echo "small" > /cvmfs/$CVMFS_TEST_REPO/small
-  cat /dev/urandom | base64 -w0 | head -c $((1024*1024*32)) \
-    > /cvmfs/$CVMFS_TEST_REPO/only_chunks
+  dd if=/dev/urandom bs=$((32*1024)) count=1024 of=/cvmfs/$CVMFS_TEST_REPO/only_chunks
   publish_repo $CVMFS_TEST_REPO || return 10
 
   echo "CVMFS_GENERATE_LEGACY_BULK_CHUNKS=true" \
     | sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
   start_transaction $CVMFS_TEST_REPO || return $?
-  cat /dev/urandom | base64 -w0 | head -c $((1024*1024*32)) \
-    > /cvmfs/$CVMFS_TEST_REPO/chunks_and_bulk
+  dd if=/dev/urandom bs=$((32*1024)) count=1024 of=/cvmfs/$CVMFS_TEST_REPO/chunks_and_bulk
   publish_repo $CVMFS_TEST_REPO || return 20
 
   echo "CVMFS_USE_FILE_CHUNKING=false" \
     | sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
   start_transaction $CVMFS_TEST_REPO || return $?
-  cat /dev/urandom | base64 -w0 | head -c $((1024*1024*32)) \
-    > /cvmfs/$CVMFS_TEST_REPO/only_bulk
+  dd if=/dev/urandom bs=$((32*1024)) count=1024 of=/cvmfs/$CVMFS_TEST_REPO/only_bulk
   publish_repo $CVMFS_TEST_REPO || return 30
 
   echo "*** check catalog and data integrity"

--- a/test/src/678-preloadautoupdate/main
+++ b/test/src/678-preloadautoupdate/main
@@ -9,7 +9,6 @@ cleanup() {
   echo "running cleanup()"
   if [ ! -z $CVMFS_TEST_654_MOUNTPOINT ]; then
     sudo fusermount -u $CVMFS_TEST_654_MOUNTPOINT
-    sudo umount        $CVMFS_TEST_654_MOUNTPOINT
   fi
 }
 

--- a/test/src/680-migratestats/main
+++ b/test/src/680-migratestats/main
@@ -28,10 +28,8 @@ cvmfs_run_test() {
   ln -s regular /cvmfs/$CVMFS_TEST_REPO/nested/symlink6
   ln -s regular /cvmfs/$CVMFS_TEST_REPO/nested/symlink7
 
-  cat /dev/zero | base64 -w0 | head -c $((1024*1024*32)) \
-    > /cvmfs/$CVMFS_TEST_REPO/chunks
-  cat /dev/zero | base64 -w0 | head -c $((1024*1024*32)) \
-    > /cvmfs/$CVMFS_TEST_REPO/nested/chunks
+  dd if=/dev/zero bs=32K count=1024 of=/cvmfs/$CVMFS_TEST_REPO/chunks
+  cp /cvmfs/$CVMFS_TEST_REPO/chunks /cvmfs/$CVMFS_TEST_REPO/nested/chunks
 
   mkfifo /cvmfs/$CVMFS_TEST_REPO/fifo
   mkfifo /cvmfs/$CVMFS_TEST_REPO/nested/fifo

--- a/test/src/685-mkfs_proxy/main
+++ b/test/src/685-mkfs_proxy/main
@@ -34,6 +34,15 @@ Listen 127.0.0.1:8008
   </Proxy>
 </VirtualHost>
 EOF
+  # The following a2enmod invocation failure is not critical.
+  # Debian-like distros are expected to have a2enmod.
+  # Ubuntu 24.04 has it.
+  # The following don't, but have proxy module config enabled:
+  # Almalinux 9
+  # CentOS 9
+  # Fedora 43
+  sudo a2enmod proxy || true
+
   apache_switch off > /dev/null
   apache_switch on  > /dev/null
 

--- a/test/src/688-checkall/main
+++ b/test/src/688-checkall/main
@@ -131,7 +131,8 @@ cvmfs_run_test() {
 
   create_fake_gc_lock ${replica_name}-1
   echo "*** verify that fake gc lock prevents gc"
-  cvmfs_server gc -f ${replica_name}-1 2>&1 | grep aborting || return 60
+  ! cvmfs_server gc -f ${replica_name}-1 &> gc.err
+  grep aborting gc.err || return 60
   remove_fake_gc_lock ${replica_name}-1
 
   return 0

--- a/test/src/688-checkall/main
+++ b/test/src/688-checkall/main
@@ -8,7 +8,8 @@ CVMFS_TEST_688_REPO_NAMES=
 cleanup() {
   if [ -n "$CVMFS_TEST_688_REPO_NAMES" ]; then
     for repo in $CVMFS_TEST_688_REPO_NAMES; do
-      sudo cvmfs_server rmfs -f $repo
+      # may not exist
+      sudo cvmfs_server rmfs -f $repo || true
     done
   fi
 }

--- a/test/src/689-inodes/main
+++ b/test/src/689-inodes/main
@@ -51,7 +51,8 @@ cvmfs_run_test() {
   sudo cvmfs_talk -p ${mntpnt}c/$CVMFS_TEST_REPO/cvmfs_io.$CVMFS_TEST_REPO remount sync || return 22
 
   # TODO(jblomer): adjust once the client is properly fixed; for now, test issue diagnostics
-  ls -lah ${mntpnt}/bar # || return 30
+  # ls -lah ${mntpnt}/bar # || return 30
+  ls -lah ${mntpnt}/bar || true # 2026-05-30: fails with "Input/output error"
   # Second attempt should work
   ls -lah ${mntpnt}/bar || return 30
   ls -lah ${mntpnt}/bar/realdir || return 31

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -35,7 +35,7 @@ cvmfs_run_test() {
   echo "CVMFS_COMPRESSION_ALGORITHM=none" | \
     sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
   mkdir -p ${repo_dir}/external                                           || return 6
-  cat /dev/urandom | head -c $((1000*1000*25)) > ${repo_dir}/external/foo || return 7
+  dd if=/dev/urandom bs=25000 count=1000 of=${repo_dir}/external/foo || return 7
   local external_md5=$(cat ${repo_dir}/external/foo | cvmfs_publish hash -a md5)
   echo "*** MD5 hash of ${repo_dir}/external/foo is $external_md5"
   if ! running_on_s3; then

--- a/test/src/690-streamingcache/main
+++ b/test/src/690-streamingcache/main
@@ -28,7 +28,7 @@ cvmfs_run_test() {
   mkdir -p ${repo_dir}/nested                                    || return 2
   touch ${repo_dir}/nested/.cvmfscatalog                         || return 2
   echo "Hello World" > ${repo_dir}/internal/small                || return 3
-  cat /dev/urandom | head -c 2500 > ${repo_dir}/internal/bar     || return 4
+  dd if=/dev/urandom bs=2500 count=1 of="${repo_dir}"/internal/bar || return 4
   publish_repo $CVMFS_TEST_REPO -v                               || return 5
 
   start_transaction $CVMFS_TEST_REPO                                      || return $?

--- a/test/src/699-servermount/main
+++ b/test/src/699-servermount/main
@@ -241,7 +241,7 @@ cvmfs_run_test() {
   cat /proc/mounts | grep -e " $repo2_rdonly_dir " && return 61
 
   echo "do \`cvmfs_server mount -a\` to bring all repositories back into proper shape"
-  sudo cvmfs_server mount -a || return 62
+  sudo cvmfs_server mount -a || (sudo journalctl -xe; return 62)
 
   echo "Check that the repositories are properly mounted"
   cat /proc/mounts | grep -e " $repo_dir "         || return 63

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -139,7 +139,7 @@ run_test_cases() {
     local status4=$?
 
     echo "$@ - Check deleting files in the lower read-only branch of the union fs: Status $status1"
-    echo "$@ - Check open file paths in /proc/$PID/fd: Status $status2"
+    echo "$@ - Check open file paths in /proc/PID/fd: Status $status2"
     echo "$@ - Check deleting directories in the lower read-only branch of the union fs: Status $status3"
     echo "$@ - Check suid or sgid bits during writes on overlayfs: Status $status4"
 

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -46,7 +46,7 @@ delete_file_in_lower_branch() {
     set_up_work_dir $@
 
     echo "$@ - Delete file from read-only layer"
-    rm -f $union/foo/bar
+    sudo rm -f $union/foo/bar
 
     # ls produces obviously bogus output (a non-zero return code here, makes the test case fail)
     ls -lisa $union

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -17,7 +17,7 @@ set_up_work_dir() {
 
     test_volume=$(pwd)/test_vol
     sudo dd if=/dev/zero of=$test_volume bs=1 count=0 seek=2GB
-    sudo yes | sudo mkfs.$fs_type $fs_args $test_volume
+    sudo mkfs.$fs_type $fs_args $test_volume
 
     # preparation
     echo "$fs_type $mkfs_args - Creating overlay fs"
@@ -149,13 +149,13 @@ run_test_cases() {
 cvmfs_run_test() {
     trap clean_work_dir EXIT HUP INT TERM || return $?
 
-    run_test_cases "xfs"
+    run_test_cases "xfs -f"
     local status_xfs1=$?
 
-    run_test_cases "xfs -n ftype=1"
+    run_test_cases "xfs -f -n ftype=1"
     local status_xfs2=$?
 
-    run_test_cases "ext4"
+    run_test_cases "ext4 -FF"
     local status_ext4=$?
 
     return $(check_status $(( $status_xfs1 || $status_xfs2 || $status_ext4 )))

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -17,7 +17,7 @@ set_up_work_dir() {
 
     test_volume=$(pwd)/test_vol
     sudo dd if=/dev/zero of=$test_volume bs=1 count=0 seek=2GB
-    sudo mkfs.$fs_type $fs_args $test_volume
+    sudo mkfs.$fs_type "${mkfs_args[@]}" $test_volume
 
     # preparation
     echo "$fs_type $mkfs_args - Creating overlay fs"

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -158,6 +158,7 @@ cvmfs_run_test() {
     run_test_cases "ext4 -FF"
     local status_ext4=$?
 
+    trap - EXIT HUP INT TERM
     return $(check_status $(( $status_xfs1 || $status_xfs2 || $status_ext4 )))
 }
 

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -87,7 +87,7 @@ delete_dir_in_lower_branch () {
     set_up_work_dir $@
 
     # reproduction
-    rm -fR $union/foo
+    sudo rm -fR $union/foo
 
     # ls shows that 'foo' is still there
     ls -lisa $union

--- a/test/src/700-overlayfs_validation/main
+++ b/test/src/700-overlayfs_validation/main
@@ -7,7 +7,7 @@ cvmfs_test_suites="quick"
 set_up_work_dir() {
     fs_type=$1
     shift
-    mkfs_args=$@
+    mkfs_args=($@)
 
     root_dir=$(pwd)
     read_only=$root_dir/read_only
@@ -20,7 +20,7 @@ set_up_work_dir() {
     sudo mkfs.$fs_type "${mkfs_args[@]}" $test_volume
 
     # preparation
-    echo "$fs_type $mkfs_args - Creating overlay fs"
+    echo "$fs_type ${mkfs_args[@]} - Creating overlay fs"
     mkdir -p $read_only $read_write $work_dir $union
     sudo mount -o loop $test_volume $read_only
     sudo mkdir $read_only/foo

--- a/test/src/704-world_readable/setup_teardown
+++ b/test/src/704-world_readable/setup_teardown
@@ -4,10 +4,6 @@ create_world_readable_repo() {
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
-  local short_name="$1"
-  local long_name="$2"
-  local symlink_name="$3"  
-
   start_transaction $CVMFS_TEST_REPO || return $?
 
   touch /cvmfs/$CVMFS_TEST_REPO/test1.txt

--- a/test/src/705-evict/setup_teardown
+++ b/test/src/705-evict/setup_teardown
@@ -4,10 +4,6 @@ create_evict_repo() {
   echo "*** CREATE a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
-  local short_name="$1"
-  local long_name="$2"
-  local symlink_name="$3"  
-
   start_transaction $CVMFS_TEST_REPO || return $?
 
   dd if=/dev/urandom of=/cvmfs/$CVMFS_TEST_REPO/large bs=2MB count=40 status=none

--- a/test/src/716-abortdiskfull/main
+++ b/test/src/716-abortdiskfull/main
@@ -51,9 +51,10 @@ echo "Disk is full (touch test failed)."
 FILLDISK_EOF
 }
 
+repo_dir=/cvmfs/$CVMFS_TEST_REPO
+
 cvmfs_run_test() {
   logfile=$1
-  local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   cleanup() {
     echo "cleanup: removing fill files"

--- a/test/src/800-repository_gateway/main
+++ b/test/src/800-repository_gateway/main
@@ -233,7 +233,7 @@ cvmfs_run_test() {
     else
         local repo_storage=$(get_local_repo_storage test.repo.org)
     fi
-    find ${repo_storage}/data -type f -name *C 2>/dev/null | rev | cut -d"/" -f 1-2 | rev | tr -d "/C" | sort | uniq > actual_catalogs.txt
+    (set +e; find ${repo_storage}/data -type f -name *C; true) | rev | cut -d"/" -f 1-2 | rev | tr -d "/C" | sort | uniq > actual_catalogs.txt
     diff reflog_catalogs.txt actual_catalogs.txt || return 111
 
     return 0

--- a/test/src/805-repository_gateway_reflog/main
+++ b/test/src/805-repository_gateway_reflog/main
@@ -14,7 +14,9 @@ cvmfs_run_test() {
     cvmfs_server transaction ${test_repo} || return 11
     echo "*** Transaction opened"
 
+    set +o pipefail
     cvmfs_server publish ${test_repo} 2>&1 | tee publish.log || return 12
+    set -o pipefail
     local output=$(cat publish.log | grep "missing_reflog")
 
     if [ x"$output" = x"" ]; then

--- a/test/src/805-repository_gateway_reflog/main
+++ b/test/src/805-repository_gateway_reflog/main
@@ -33,8 +33,7 @@ cvmfs_run_test() {
 
     # Run repository check
     echo "*** Repository verification"
-    cvmfs_server check -i ${test_repo}
-    if [ $? -ne 0 ]; then
+    if ! cvmfs_server check -i ${test_repo}; then
         echo "Repository integrity check failed with \"reflog.chksum\" present"
         return 30
     fi
@@ -45,10 +44,6 @@ cvmfs_run_test() {
 
     # Re-run repository check
     cvmfs_server check -i ${test_repo} || return 41
-    if [ $? -ne 0 ]; then
-        echo "Repository integrity check failed with \"reflog.chksum\" missing"
-        return 42
-    fi
 
     check_repo_integrity test.repo.org || return 50
 

--- a/test/src/807-nested_new_directories_gateway_ingest/main
+++ b/test/src/807-nested_new_directories_gateway_ingest/main
@@ -25,9 +25,13 @@ cvmfs_run_test() {
     set_up_repository_gateway || return 1
 
     echo "  Getting lease on subdirectory that does not exists yet should not work"
-    cvmfs_server transaction test.repo.org/foo/bar/
+    local retval=$(
+        set +e
+        cvmfs_server transaction test.repo.org/foo/bar/ >/dev/null
+        echo $?
+    )
     # Expect ENOENT
-    if [ $? -ne 2 ]; then
+    if [ $retval -ne 2 ]; then
         echo "  Error should not be possible to open a transaction on a directory that does not exists"
         return 10
     fi

--- a/test/src/807-nested_new_directories_gateway_ingest/main
+++ b/test/src/807-nested_new_directories_gateway_ingest/main
@@ -25,13 +25,8 @@ cvmfs_run_test() {
     set_up_repository_gateway || return 1
 
     echo "  Getting lease on subdirectory that does not exists yet should not work"
-    local retval=$(
-        set +e
-        cvmfs_server transaction test.repo.org/foo/bar/ >/dev/null
-        echo $?
-    )
     # Expect ENOENT
-    if [ $retval -ne 2 ]; then
+    if ! expect_exit_code 2 cvmfs_server transaction test.repo.org/foo/bar/ >/dev/null; then
         echo "  Error should not be possible to open a transaction on a directory that does not exists"
         return 10
     fi

--- a/test/src/808-repository-gateway_watchdog/main
+++ b/test/src/808-repository-gateway_watchdog/main
@@ -8,7 +8,7 @@ cvmfs_run_test() {
     receiver_logdir=$(pwd)/receiver_logs
 
     # Receiver tries to read, fails, and exits gracefully
-    cvmfs_receiver -i 420 -o 421 -w $receiver_logdir
+    cvmfs_receiver -i 420 -o 421 -w $receiver_logdir || true
     n_stacktraces_1=$(ls $receiver_logdir | wc -l)
     # No stacktraces are produced
     [ $n_stacktraces_1 -eq 0 ] || return 2

--- a/test/src/809-lease_failure/main
+++ b/test/src/809-lease_failure/main
@@ -21,8 +21,12 @@ cvmfs_run_test() {
     echo "New file" > /cvmfs/test.repo.org/new/c/d/new_file.txt || return 12
 
     echo "  *** Checking that we cannot open a transaction again"
-    cvmfs_server transaction test.repo.org
-    if [ $? -ne 17 ]; then
+    local retval=$(
+      set +e
+      cvmfs_server transaction test.repo.org >/dev/null
+      echo $?
+    )
+    if [ $retval -ne 17 ]; then
         echo "cvmfs_server transaction should tell us that we have a transaction already"
         return 20
     fi

--- a/test/src/809-lease_failure/main
+++ b/test/src/809-lease_failure/main
@@ -21,12 +21,8 @@ cvmfs_run_test() {
     echo "New file" > /cvmfs/test.repo.org/new/c/d/new_file.txt || return 12
 
     echo "  *** Checking that we cannot open a transaction again"
-    local retval=$(
-      set +e
-      cvmfs_server transaction test.repo.org >/dev/null
-      echo $?
-    )
-    if [ $retval -ne 17 ]; then
+    # Expect EEXIST
+    if ! expect_exit_code 17 cvmfs_server transaction test.repo.org >/dev/null; then
         echo "cvmfs_server transaction should tell us that we have a transaction already"
         return 20
     fi
@@ -45,12 +41,8 @@ cvmfs_run_test() {
       /var/spool/cvmfs/test.repo.org/session_token.save || return 41
 
     echo "  *** Checking that the lease is taken and that cvmfs_transaction fails"
-    retcode=$(
-      set +e
-      cvmfs_server transaction test.repo.org/new/c >&2
-      echo $?
-    )
-    if [ $retcode -ne 16 ]; then
+    # Expect EBUSY
+    if ! expect_exit_code 16 cvmfs_server transaction test.repo.org/new/c >&2; then
         echo "Return code should be 16 EBUSY instead of ${retcode}"
         return 50
     fi

--- a/test/src/809-lease_failure/main
+++ b/test/src/809-lease_failure/main
@@ -45,8 +45,11 @@ cvmfs_run_test() {
       /var/spool/cvmfs/test.repo.org/session_token.save || return 41
 
     echo "  *** Checking that the lease is taken and that cvmfs_transaction fails"
-    cvmfs_server transaction test.repo.org/new/c
-    retcode=$?
+    retcode=$(
+      set +e
+      cvmfs_server transaction test.repo.org/new/c >&2
+      echo $?
+    )
     if [ $retcode -ne 16 ]; then
         echo "Return code should be 16 EBUSY instead of ${retcode}"
         return 50

--- a/test/src/822-repository_gateway_mountless_ingest/main
+++ b/test/src/822-repository_gateway_mountless_ingest/main
@@ -49,8 +49,8 @@ cvmfs_run_test() {
 
 
   echo "*** verify published ingest artifacts without remounting the publisher view"
-  cvmfs_server list-catalogs -x "$repo" | grep -q "foo/tarball_foo/a" || return 31
-  cvmfs_server list-catalogs -x "$repo" | grep -q "bar/tarball_foo/a" || return 32
+  cvmfs_server list-catalogs -x "$repo" | grep "foo/tarball_foo/a" || return 31
+  cvmfs_server list-catalogs -x "$repo" | grep "bar/tarball_foo/a" || return 32
 
   echo "*** verify file content was actually ingested"
   local content_size

--- a/test/test_functions
+++ b/test/test_functions
@@ -1581,7 +1581,7 @@ remove_apache_config_file() {
 
   # disable configuration on newer apache versions
   if [ x"$(get_apache_conf_mode)" = x"$APACHE_CONF_MODE_CONFAVAIL" ]; then
-    sudo a2disconf $file_name > /dev/null 2>&1 || return 1
+    sudo a2disconf $file_name || return 1
   fi
 
   # remove configuration file

--- a/test/test_functions
+++ b/test/test_functions
@@ -657,7 +657,7 @@ has_selinux() {
 
 
 get_cvmfs_cachedir() {
-  local repository=$1
+  local repository=${1:-}
 
   local cache_dir=$(cvmfs_config showconfig $repository | grep CVMFS_WORKSPACE | awk '{print $1}' | cut -d= -f2)
   if [ "x$cache_dir" = "x" ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -854,10 +854,10 @@ create_repo() {
 create_empty_repo() {
   local repo=$1
   local uid=$2
-  local debug_log=$3
+  local debug_log=${3:-''}
   shift $(min $# 3)
 
-  create_repo $repo $uid $debug_log "$@" || return 101
+  create_repo $repo $uid "$debug_log" "$@" || return 101
 
   if [ -f /cvmfs/$repo/new_repository ]; then
     sudo cvmfs_server transaction $repo || return 102

--- a/test/test_functions
+++ b/test/test_functions
@@ -1669,7 +1669,7 @@ cleanup_legacy_repo_leftovers() {
      [ -f /etc/cvmfs/keys/${legacy_repo_name}.masterkey ]; then
     sudo rm -f /etc/cvmfs/keys/${legacy_repo_name}.*
   fi
-  remove_apache_config_file $apache_config_file
+  remove_apache_config_file $apache_config_file || true
   echo "done"
 }
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -791,7 +791,7 @@ has_repo() {
 create_repo() {
   local repo=$1
   local uid=$2
-  local debug_log=$3
+  local debug_log=${3:-''}
   shift $(min $# 3)
 
   echo "Shutting down autofs for the cvmfs mounts"
@@ -844,7 +844,7 @@ create_repo() {
 
   local client_conf="/etc/cvmfs/repositories.d/${repo}/client.conf"
 
-  if [ x$debug_log != x -a x$debug_log != xNO ]; then
+  if [[ "$debug_log" != "" ]] && [[ "$debug_log" != NO ]]; then
     echo "CVMFS_DEBUGLOG=$debug_log" | sudo tee -a $client_conf
     sudo sed -i.bak -e "s/^\(cvmfs2#$repo.*\)\(allow_other.*\)/\1debug,\2/" /etc/fstab
   fi

--- a/test/test_functions
+++ b/test/test_functions
@@ -1490,20 +1490,9 @@ pushdir() {
   fi
 }
 
-
-# wrapper around popd (that is not available in dash)
-# if popd is not available, a normal `cd -` is used to go back to the last dir
-# Note: We do not reimplement the whole functionality of popd, with our work-
-#       around it is only possible to have ONE directory-level stored
+# Deprecated. Was devised for compatibility across bash and dash
 popdir() {
-  type popd > /dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    popd $1
-    return $?
-  else
-    cd -
-    return $?
-  fi
+  popd
 }
 
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2747,3 +2747,13 @@ lockfile() {
   fi
   ./lockfile $1
 }
+
+# Run a command and assert it exits with an expected status.
+#   expect_exit_code <expected> <command> [args...]
+expect_exit_code() {
+  local expected="$1"
+  shift
+  local rc=0
+  "$@" || rc=$?
+  [[ "$rc" == "$expected" ]]
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -1644,7 +1644,7 @@ get_apache_config_filename() {
 }
 
 get_backend_spooler() {
-  if [ -n "${TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE}" ] ; then
+  if [[ -n "${TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE:-}" ]] ; then
     # A gateway test is running: access the backend storage directly
     echo "${TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE}"
   else

--- a/test/test_functions
+++ b/test/test_functions
@@ -590,7 +590,7 @@ _cvmfs_mount_manually() {
 }
 
 cvmfs_umount() {
-  if [ x$PARROT_ENABLED = "xTRUE" ]; then
+  if [ "${PARROT_ENABLED:-}" = "TRUE" ]; then
     return 0
   fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -341,8 +341,12 @@ autofs_check() {
 # @param state   the desired state of autofs (on|off)
 # @return        0 on success
 autofs_switch() {
-  autofs_check
-  if service_should_switch $1 $?; then
+  RC=$(
+    set +e
+    autofs_check &>/dev/null
+    echo $?
+  )
+  if service_should_switch $1 "$RC"; then
     service_switch autofs $1
   fi
 }
@@ -352,8 +356,12 @@ autofs_switch() {
 # @param state   the desired state of autofs (on|off)
 # @return        0 on success
 apache_switch() {
-  service_request $APACHE_SERVICE status > /dev/null 2>&1
-  if service_should_switch $1 $?; then
+  RC=$(
+    set +e
+    service_request $APACHE_SERVICE status > /dev/null 2>&1
+    echo $?
+  )
+  if service_should_switch $1 "$RC"; then
     service_switch $APACHE_SERVICE $1
   fi
 }

--- a/test/test_functions
+++ b/test/test_functions
@@ -874,9 +874,9 @@ create_empty_repo() {
 create_filled_repo() {
   local repo=$1
   local uid=$2
-  local debug_log=$3
+  local debug_log=${3:-}
 
-  create_empty_repo $repo $uid $debug_log || return 101
+  create_empty_repo $repo $uid "$debug_log" || return 101
 
   sudo cvmfs_server transaction $repo || return 102
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -770,7 +770,7 @@ destroy_repo() {
   fi
 
   load_repo_config $repo
-  if [ x"$TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE" != x"" ]; then
+  if [ "${TEST_CVMFS_RECEIVER_UPSTREAM_STORAGE:-}" != "" ]; then
     # It is possible to have publisher and gateway on the same machine for testing purposes.
     # However, `cvmfs_server rmfs` then incorrectly does not delete the repository backend storage.
     # Let's do it here instead.

--- a/test/test_functions
+++ b/test/test_functions
@@ -1711,7 +1711,7 @@ _resign_legacy_repository() {
 # @param verbose  print the verbose output of tar
 plant_tarball() {
   local tarball="$1"
-  local verbose="$2"
+  local verbose=${2:-}
   local olddir="$(pwd)"
   local tar_params="xzf"
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -521,7 +521,7 @@ cvmfs_mount_direct() {
 }
 
 cvmfs_mount() {
-  if [ x$PARROT_ENABLED = "xTRUE" ]; then
+  if [ "${PARROT_ENABLED:-}" = "TRUE" ]; then
     return 0
   fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -1734,8 +1734,8 @@ plant_tarball() {
 plant_legacy_repository_revision() {
   local tarball="$1"
   local legacy_repo_name="$2"
-  local repo_owner="$3"
-  local verbose="$4"
+  local repo_owner=${3:-}
+  local verbose=${4:-}
   local legacy_repo_storage="$(get_local_repo_storage $legacy_repo_name)"
 
   plant_tarball "$tarball" "$verbose" || return 104

--- a/test/test_functions
+++ b/test/test_functions
@@ -2460,17 +2460,18 @@ __do_local_mount() {
   local mountpoint="$3"
   local repo_name="$4"
   local repo_url="$5"
-  local config_file="$6"   # config file containing CVMFS client options,
+  # sometimes not passed:
+  local config_file="${6:-}"   # config file containing CVMFS client options,
                            # if used the options listed below are not added
-  local extra_option="$7"  # CVMFS client options as str
-  local mount_options="$8" # comma separated mount options
+  local extra_option="${7:-}"  # CVMFS client options as str
+  local mount_options="${8:-}" # comma separated mount options
 
   local cache="$(get_cache_directory $mountpoint)"
   local config="$(mktemp ${mountpoint}.conf.XXXXX)"
   local output="$(mktemp ${mountpoint}.log.XXXXX)"
 
   mkdir -p $mountpoint $cache
-  if [ -z $config_file ]; then
+  if [ -z "$config_file" ]; then
     cat > $config << EOF
 CVMFS_MOUNT_DIR=/cvmfs
 CVMFS_CACHE_BASE=$cache
@@ -2483,13 +2484,13 @@ CVMFS_DEBUGLOG=$output
 CVMFS_USYSLOG=${mountpoint}.log
 EOF
   else
-    cat $config_file > $config
+    cat "$config_file" > $config
   fi
   printf "$extra_option\n" >> $config
   echo "  *** local mount config:"
   cat "$config"
 
-  if [ ! -z $mount_options ]; then
+  if [ ! -z "$mount_options" ]; then
     mount_options="${mount_options},"
   fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -1085,7 +1085,7 @@ create_listing() {
 compare_directories() {
   local dir1=$1
   local dir2=$2
-  local repo_name=$3
+  local repo_name=${3:-''}
   local show_linkcount="yes"
 
   if [ ! -z $repo_name ] && uses_overlayfs $repo_name; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -64,7 +64,7 @@ if [ ! -z "$CVMFS_TEST_GEO_ACCOUNT_ID" ]; then
   echo "CVMFS_GEO_ACCOUNT_ID=$CVMFS_TEST_GEO_ACCOUNT_ID" | sudo tee -a /etc/cvmfs/server.local > /dev/null
 fi
 
-if [ -z "$CVMFS_TEST_DOCKER" ]; then
+if ! [[ -v CVMFS_TEST_DOCKER ]]; then
   if [ -f /.dockerinit ]; then
     CVMFS_TEST_DOCKER=yes
   else

--- a/test/test_functions
+++ b/test/test_functions
@@ -547,7 +547,7 @@ cvmfs_mount() {
   fi
 
   # add additional parameters
-  local proberunner
+  local proberunner=
   while [ $# -gt 0 ]; do
     local param="$1"
     if [ "$param" = "CVMFS_SUID=yes" ]; then

--- a/test/test_functions
+++ b/test/test_functions
@@ -557,19 +557,19 @@ cvmfs_mount() {
     shift 1
   done
 
-  if [ "x$CVMFS_TEST_DEBUGLOG" != "x" ]; then
+  if [[ "${CVMFS_TEST_DEBUGLOG:-}" != '' ]]; then
     sudo sh -c "echo 'CVMFS_DEBUGLOG=${CVMFS_TEST_DEBUGLOG}' >> /etc/cvmfs/default.local" || return 100
   fi
 
-  if [ "x$CVMFS_TEST_QUOTED_PARAM_KEY_VAL" != "x" ]; then
+  if [[ -v CVMFS_TEST_QUOTED_PARAM_KEY_VAL ]]; then
     sudo sh -c "echo '${CVMFS_TEST_QUOTED_PARAM_KEY_VAL}' >> /etc/cvmfs/default.local" || return 100
   fi
 
   if running_on_osx; then
     cvmfs_mount_direct $repositories
   fi
-  if [ "x$cvmfs_test_autofs_on_startup" = "xfalse" ] || \
-     [ "x$CVMFS_TEST_DOCKER" = "xyes" ]; then
+  if [ "${cvmfs_test_autofs_on_startup:-}" = "false" ] || \
+     [ "${CVMFS_TEST_DOCKER:-}" = "yes" ]; then
     cvmfs_mount_direct $repositories
   fi
 

--- a/test/test_functions
+++ b/test/test_functions
@@ -2547,6 +2547,8 @@ purge_disk_cache() {
 }
 
 try_automount() {
+  (
+  set +e
   local repo=$1
   local retval
   if running_on_osx; then
@@ -2561,6 +2563,7 @@ try_automount() {
   else
     ls /cvmfs/${repo}
   fi
+  )
 }
 
 # figures out where syslog is found on this system and prints it to stdout

--- a/test/test_functions
+++ b/test/test_functions
@@ -1622,8 +1622,8 @@ get_s3_repo_url() {
 }
 
 get_repo_url() {
-  local repo_name="$1"
-  if [ x"$CVMFS_TEST_S3_CONFIG" != x"" ]; then
+  local repo_name="${1:-}"
+  if [ "${CVMFS_TEST_S3_CONFIG:-}" != "" ]; then
     get_s3_repo_url "$repo_name"
   else
     get_local_repo_url "$repo_name"

--- a/test/test_functions
+++ b/test/test_functions
@@ -2715,11 +2715,7 @@ EOF'
     # Wait for the gateway to be ready: `status` only confirms the VM is up,
     # not that the HTTP listener on :4929 is accepting connections.  Probe the
     # API endpoint directly so callers of acquire-lease don't race startup.
-    if ! timeout 30 bash -c "
-        until $gateway_script status &>/dev/null \
-              && curl -sf -o /dev/null -m 2 http://localhost:4929/api/v1/repos; do
-            sleep 1
-        done"; then
+    if ! curl -v -f --retry 30 --retry-max-time 30 --retry-connrefused -o /dev/null -m 2 http://localhost:4929/api/v1/repos; then
         echo "Gateway failed to start within 30 seconds" >&2
         return 1
     fi


### PR DESCRIPTION
http://redsymbol.net/articles/unofficial-bash-strict-mode/

Enables `set -e`, `set -u`, `set -o pipefail` for each test run. Regressions were fixed, and a bunch of genuine bugs discovered were fixed along the way.

Also enables `set -x`, which was instrumental in debugging and I believe it will be useful for future investigations.

Please don't squash-merge as the commit messages contain per-case evidence and sometimes extra comments.

My CI runs shows green:

https://github.com/andrey-utkin/cvmfs/actions/runs/26807898524
https://github.com/andrey-utkin/cvmfs/actions/runs/26807898502
https://github.com/andrey-utkin/cvmfs/actions/runs/26807898496
https://github.com/andrey-utkin/cvmfs/actions/runs/26807898479
https://github.com/andrey-utkin/cvmfs/actions/runs/26807898445