### PR TITLE
unittest: rename T_GCDatabase.LargeNumberOfPaths{ -> Slow }

### DIFF
--- a/test/unittests/t_gc_database.cc
+++ b/test/unittests/t_gc_database.cc
@@ -194,7 +194,7 @@ TEST_F(T_GCDatabase, ReadPreservesInsertionOrder) {
   EXPECT_EQ("m_third", paths[2]);
 }
 
-TEST_F(T_GCDatabase, LargeNumberOfPaths) {
+TEST_F(T_GCDatabase, LargeNumberOfPathsSlow) {
   std::vector<std::string> input;
   for (int i = 0; i < 5000; ++i) {
     input.push_back(".layers/sha256/" + StringifyInt(i));


### PR DESCRIPTION
This is the longest-running unittest not having "Slow" suffix, and it should get one.

It takes a long time, especially on HDD rather than SSD.

In Github Actions runner, it took 4888 ms
https://github.com/cvmfs/cvmfs/actions/runs/26385195422/job/77662143553

On my HDD based setup, it took 10 minutes on idle system:

    [       OK ] T_GCDatabase.LargeNumberOfPaths (597168 ms)

and almost half an hour under load of 4 runs in parallel:

    [1121/1121] T_GCDatabase.LargeNumberOfPaths (1573035 ms)
    touch unittests-parallel.done                                                                                                                                                                                        touch tests.done                                                                                                                                                                                                     make[1]: Leaving directory '/usr/local/src/ways-to-test-cvmfs/testability/podman/almalinux_9'
    [1121/1121] T_GCDatabase.LargeNumberOfPaths (1569835 ms)
    touch unittests-parallel.done
    touch tests.done
    make[1]: Leaving directory '/usr/local/src/ways-to-test-cvmfs/testability/podman/ubuntu_24.04'
    [1121/1121] T_GCDatabase.LargeNumberOfPaths (1402346 ms)
    touch unittests-parallel.done
    touch tests.done
    make[1]: Leaving directory '/usr/local/src/ways-to-test-cvmfs/testability/podman/centos_9'
    [1121/1121] T_GCDatabase.LargeNumberOfPaths (1666098 ms)
    touch unittests-parallel.done
    touch tests.done
    make[1]: Leaving directory '/usr/local/src/ways-to-test-cvmfs/testability/podman/fedora_43'

This is definitely just a slower system, but simpler tests may be 100x slower, for example, with T_GCDatabase.ReadEmptyDatabase 3 ms turns into 368 ms.

To see the ranking of unittests by runtime, you can run

    grep ' ms[)]' 0_unittest_ubuntu.txt | awk '{ print $(NF-1) " " $(NF-2) }' | sed -e 's:^[(]::' | sort -n | grep -C9999 Slow

The "Slow" prefix is somewhat inconsistently used, but all unittests running for 1334 ms or longer have it, except for our subject:

    1000 T_CatalogMgrRw.GraftNestedCatalogFail
    1000 T_SessionToken.CheckExpiredTokenSlow
    1000 T_UtilConcurrency.WriteLockGuard
    1280 T_CatalogTraversal/1.TraverseBreadthFirstParallelStressSlow
    1288 T_Util.SafeWriteV
    1290 T_Tracer.FlushTen
    1334 T_Tracer.MultiThreadedTenSlow
    1372 T_Uploaders/1.UploadHugeFileSlow
    1502 T_CatalogTraversal/1.TraverseDepthFirstParallelStressSlow
    1543 T_HashFilter/0.FillManyRandomHashesSlow
    1778 T_Atomic.ConcurrentTransactionalAssignmentsSlow
    1894 T_LruCache.LeastRecentlyUsedReplacementSlow
    2181 T_QuotaManager.CleanupLru
    2530 T_Uploaders/0.UploadHugeFileSlow
    2561 T_Dns.CaresResolverTimeout
    2596 T_ChunkDetectors.Xor32ChunkDetectorSlow
    3000 T_UploadFacility.CallbacksSlow
    3030 T_Uploaders/1.MultipleStreamedUploadSlow
    3461 T_Pack.RealWorldSlow
    3878 T_Atomic.ConcurrentWriteOfAtomicIntsSlow
    4004 T_GlueBuffer.DentryCleanerSlow
    4011 T_Uploaders/1.UploadManyFilesSlow
    4055 T_Uploaders/0.RetrySlow
    4402 T_CatalogMgrRw.SwapNestedCatalogFailSlow
    4435 T_IngestionStress.ProcessMultipleFilesInSeparateWavesSlow
    4888 T_GCDatabase.LargeNumberOfPaths   <<<===========================
    5274 T_Uploaders/0.MultipleStreamedUploadSlow
    5306 T_AuthzFetch.ExecHelperSlow
    5541 T_IngestionStress.ProcessHugeFileSlow
    6000 T_Supervisor.kCooldownSlow
    7666 T_IngestionStress.ProcessMultipeFilesWithoutChunkingSlow
    8321 T_IngestionStress.ProcessMultipleFilesSlow
    9001 T_SynchronizingCounter.WaitForDecrementSlow
    9001 T_SynchronizingCounter.WaitForIncrementSlow
    9768 T_SynchronizingCounter.MultiThreadCountingSlow
    9940 T_IngestionStress.RealWorldSlow
    11743 T_Uploaders/0.UploadManyFilesSlow
    12222 T_MallocArena.MonteCarloSlow
    15797 T_Libcvmfs.TemplatingSlow
    81041 T_Shash.LongTestVectorsSlow