### PR TITLE
test: do not use $USER in tests

### DIFF
--- a/test/src/400-ducc-ingest_images/main
+++ b/test/src/400-ducc-ingest_images/main
@@ -132,7 +132,7 @@ EOL
 
     # crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."
-    create_empty_repo $CVMFS_TEST400_REPOSITORY $USER || return $?
+    create_empty_repo $CVMFS_TEST400_REPOSITORY $CVMFS_TEST_USER || return $?
     echo "done"
 
     echo -n "*** Changing configuration to read the new repo..."

--- a/test/src/401-ducc-convert_singularity/main
+++ b/test/src/401-ducc-convert_singularity/main
@@ -18,7 +18,7 @@ cvmfs_run_test() {
   trap ducc_test_401_clean_up EXIT HUP INT TERM
 
   echo "*** creating empty repo ***"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return 1
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
 
   echo "*** converting image to flat ***"
   cvmfs_ducc convert-single-image --skip-layers $DOCKER_TEST_IMAGE1 $CVMFS_TEST_REPO || return 2

--- a/test/src/402-ducc-ingest-temp-dir/main
+++ b/test/src/402-ducc-ingest-temp-dir/main
@@ -56,7 +56,7 @@ EOL
 
     # crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."
-    create_empty_repo $CVMFS_TEST402_REPOSITORY $USER || return $?
+    create_empty_repo $CVMFS_TEST402_REPOSITORY $CVMFS_TEST_USER || return $?
     echo "done"
     
     # start by running the docker registry on localhost

--- a/test/src/403-ducc-star/main
+++ b/test/src/403-ducc-star/main
@@ -61,7 +61,7 @@ EOL
 
     # crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."
-    create_empty_repo $CVMFS_TEST403_REPOSITORY $USER || return $?
+    create_empty_repo $CVMFS_TEST403_REPOSITORY $CVMFS_TEST_USER || return $?
     echo "done"
 
     # start by running the docker registry on localhost

--- a/test/src/404-ducc-ingest_single_image_thin/main
+++ b/test/src/404-ducc-ingest_single_image_thin/main
@@ -23,7 +23,7 @@ cvmfs_run_test() {
   trap ducc_test_401_clean_up EXIT HUP INT TERM
 
   echo "*** creating empty repo ***"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return 1
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return 1
     
   echo -n "*** Starting docker registry for tests..."
   docker run -d -p 5000:5000 --name $CVMFS_TEST404_REGISTRY registry:2 >> /dev/null || return 3

--- a/test/src/405-ducc-convert-podman/main
+++ b/test/src/405-ducc-convert-podman/main
@@ -46,7 +46,7 @@ EOL
 
 	# crete the repository where to store the content
     echo -n "*** Creating CVMFS repo..."
-    create_empty_repo $CVMFS_TEST405_REPOSITORY $USER || return $?
+    create_empty_repo $CVMFS_TEST405_REPOSITORY $CVMFS_TEST_USER || return $?
     echo "done"
 
 	touch $CVMFS_TEST405_DUCC_ERR

--- a/test/src/407-ducc-subdir/main
+++ b/test/src/407-ducc-subdir/main
@@ -35,7 +35,7 @@ EOL
     echo "done"
 
     echo -n "*** Creating CVMFS repo..."
-    create_empty_repo $CVMFS_TEST407_REPOSITORY $USER || return $?
+    create_empty_repo $CVMFS_TEST407_REPOSITORY $CVMFS_TEST_USER || return $?
     echo "done"
 
     echo "*** Starting test."

--- a/test/src/652-tarball_ingest_various_paths/main
+++ b/test/src/652-tarball_ingest_various_paths/main
@@ -40,7 +40,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
   echo "CVMFS_ENABLE_MTIME_NS=true" | sudo tee -a /etc/cvmfs/repositories.d/${CVMFS_TEST_REPO}/server.conf
 
   # ============================================================================

--- a/test/src/653-tarball_ingest_from_stdin/main
+++ b/test/src/653-tarball_ingest_from_stdin/main
@@ -77,7 +77,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/654-tarball_ingest_special_files/main
+++ b/test/src/654-tarball_ingest_special_files/main
@@ -67,7 +67,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/655-tarball_multiple_ingest_same_location/main
+++ b/test/src/655-tarball_multiple_ingest_same_location/main
@@ -37,7 +37,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/656-tarball_remove_directory/main
+++ b/test/src/656-tarball_remove_directory/main
@@ -38,7 +38,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/657-tarball_remove_base_directory/main
+++ b/test/src/657-tarball_remove_base_directory/main
@@ -37,7 +37,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/658-tarball_ingest_catalogs/main
+++ b/test/src/658-tarball_ingest_catalogs/main
@@ -43,7 +43,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/659-tarball_ingest_in_root/main
+++ b/test/src/659-tarball_ingest_in_root/main
@@ -35,7 +35,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
   
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 

--- a/test/src/666-ingestownership/main
+++ b/test/src/666-ingestownership/main
@@ -55,7 +55,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
 
   echo "---------------------"

--- a/test/src/667-ingestnested/main
+++ b/test/src/667-ingestnested/main
@@ -18,7 +18,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   echo "*** create deeply nested catalogs"
   start_transaction $CVMFS_TEST_REPO

--- a/test/src/671-stats_db_upgrade/main
+++ b/test/src/671-stats_db_upgrade/main
@@ -19,7 +19,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   echo "*** replace stats.db with an old one"
   cp $script_location/stats-rev01.db /var/spool/cvmfs/$CVMFS_TEST_REPO/

--- a/test/src/715-tarball_fast_delete/main
+++ b/test/src/715-tarball_fast_delete/main
@@ -39,7 +39,7 @@ cvmfs_run_test() {
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   echo "*** create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
-  create_empty_repo $CVMFS_TEST_REPO $USER || return $?
+  create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
 
   # ============================================================================
 


### PR DESCRIPTION
Most tests use CVMFS_TEST_USER which the test harness itself sets. USER is a standard system variable but it may be unset, particularly in container environments, and the test harness doesn't set it.

This change brings the few divergences from the standard practice into uniformity.

The entire change was generated by the following command:

 grep -l '[$]USER\>' test/src -RnI | xargs sed -i -e 's:[$]USER\>:$CVMFS_TEST_USER:g'

Co-authored-by: sed
Co-authored-by: grep
Co-authored-by: xargs
Co-authored-by: bash

This will be more important if/when the project adopts `set -u` (abort on referencing undefined variable).