### PR TITLE
Use setsid -w in authz tests to fix flaky test logic

### DIFF
--- a/test/src/600-securecvmfs/main
+++ b/test/src/600-securecvmfs/main
@@ -293,7 +293,7 @@ cvmfs_run_test() {
   sudo -u nobody /bin/sh -c "cat ${mntpnt}/hello_world" || return 31
 
   echo "This should not work"
-  sudo -u nobody setsid /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 32
+  sudo -u nobody setsid -w /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 32
 
   # Put in incorrect key into proxy file.
   echo "make invalid vomsproxy for 'nobody'"
@@ -305,7 +305,7 @@ cvmfs_run_test() {
   cat $nobody_vomsproxy
   sudo chown nobody:             $nobody_vomsproxy || return 21
   echo "This should not work"
-  sudo -u nobody setsid /bin/sh -c "export X509_USER_PROXY=$nobody_vomsproxy; cat ${mntpnt}/hello_world" && return 33
+  sudo -u nobody setsid -w /bin/sh -c "export X509_USER_PROXY=$nobody_vomsproxy; cat ${mntpnt}/hello_world" && return 33
 
   # Take the second proxy and remove the private key - should be invalid.
   echo "make second invalid vomsproxy for 'nobody'"
@@ -316,7 +316,7 @@ cvmfs_run_test() {
   sudo chown nobody:             $nobody_vomsproxy || return 21
   cat $nobody_vomsproxy
   echo "This should not work"
-  sudo -u nobody setsid /bin/sh -c "export X509_USER_PROXY=$nobody_vomsproxy; cat ${mntpnt}/hello_world" && return 33
+  sudo -u nobody setsid -w /bin/sh -c "export X509_USER_PROXY=$nobody_vomsproxy; cat ${mntpnt}/hello_world" && return 33
 
   # Make sure our second VOMS proxy was valid.
   echo "This should work"

--- a/test/src/632-authzhelpers/main
+++ b/test/src/632-authzhelpers/main
@@ -96,7 +96,7 @@ cvmfs_run_test() {
   echo "authz helper has pid $authz_helper_pid; killing it."
   sudo kill -SEGV $authz_helper_pid
   echo "authz helper has died, access should fail"
-  sudo -u nobody setsid /bin/sh -c "cat ${mntpnt}/hello_world" && return 74
+  sudo -u nobody setsid -w /bin/sh -c "cat ${mntpnt}/hello_world" && return 74
   echo "Waiting for rate-limit timeout to pass"
   sleep 11
   #
@@ -109,7 +109,7 @@ cvmfs_run_test() {
         --debug || return 75
   echo "Waiting for reload to finish"
   sleep 2
-  sudo -u nobody setsid /bin/sh -c "cat ${mntpnt}/hello_world" || return 76
+  sudo -u nobody setsid -w /bin/sh -c "cat ${mntpnt}/hello_world" || return 76
   local authz_helper_pid_new=$(pgrep -P $secure_mnt_pid cvmfs_allow)
   echo "new authz helper pid $authz_helper_pid_new"
   [ "x$authz_helper_pid_new" = "x" ] && return 77

--- a/test/src/647-bearercvmfs/main
+++ b/test/src/647-bearercvmfs/main
@@ -290,7 +290,7 @@ cvmfs_run_test() {
   sudo -u nobody /bin/sh -c "cat ${mntpnt}/hello_world" || return 31
 
   echo "*** This should not work"
-  sudo -u nobody setsid /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 32
+  sudo -u nobody setsid -w /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 32
 
 
   echo "*** Check authz attr"
@@ -309,7 +309,7 @@ cvmfs_run_test() {
   echo "*** This should work"
   sudo -u nobody /bin/sh -c "export _CONDOR_CREDS=${TEST647_CRED_DIR}; cat ${mntpnt}/hello_world" > /dev/null || return 51
   echo "*** This should not work"
-  sudo -u nobody setsid /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 52
+  sudo -u nobody setsid -w /bin/sh -c "env && cat ${mntpnt}/hello_world" && return 52
 
   return 0
 }


### PR DESCRIPTION
I believe this patch is necessary due to a recent upgrade of `sudo` that enabled `use_pty` by default. That in turn changes the behavior of `setsid` to fork and return 0 immediately, unless the `-w` option is added.