### PR TITLE
Cvmfs4bits

### DIFF
--- a/INFRASTRUCTURE_MODERNISATION.md
+++ b/INFRASTRUCTURE_MODERNISATION.md
@@ -437,7 +437,7 @@ and 15% miss rate, the number of simultaneous S1 connections drops from
 **Migration path:** same hardware, same port (3128 → 80 or keep 3128 with
 Varnish listening on that port), `CVMFS_HTTP_PROXY` unchanged if a
 site-local DNS alias is used.  1–2 days per site; fully templated centrally
-via Puppet/Ansible.  Reference VCL for HepCDN Tier-2 is in §6.
+via Puppet/Ansible.  Reference VCL for HepCDN Tier-2 is in §7.
 
 ---
 
@@ -529,22 +529,170 @@ client would need to speak the OCI blob API, which is a non-trivial change.
 
 ---
 
-## 5. Recommended Roadmap
+## 5. Implementation Gap Analysis
+
+The table below maps every component the HepCDN architecture requires to its
+current implementation status.  "cvmfs-bits" refers to the `cvmfs-bits`
+repository; "new" means a new binary or repository is needed.
+
+### 5.1 Component inventory
+
+| Component | Role | Status | Home |
+|---|---|---|---|
+| cvmfs-bits distributor | Push new objects from S0 to Tier-1 | ✅ Implemented | cvmfs-bits `cmd/prepub` |
+| cvmfs-bits receiver (control + data channels) | Accept pushed objects at Tier-1 | ✅ Implemented | cvmfs-bits `internal/distribute/receiver` |
+| Publisher-side dedup bloom filter | Skip re-pushing already-present objects across builds; shared via NFS snapshots | ✅ Implemented | cvmfs-bits `internal/pipeline/dedup` |
+| Prometheus metrics (publisher) | Job, pipeline, CAS, distribution counters | ✅ Implemented | cvmfs-bits `pkg/observe`, `internal/api/server.go` |
+| Tier-1 inventory bloom filter | Per-node filter of objects the receiver holds; built from CAS at startup, updated on each PUT | ✅ Implemented | cvmfs-bits `internal/distribute/receiver/inventory.go` |
+| Bloom filter HTTP endpoint | `GET /api/v1/bloom` — serves serialised inventory filter to distributor and coord service | ✅ Implemented | cvmfs-bits `internal/distribute/receiver/bloom_handler.go` |
+| Distributor delta mode | Query each receiver's bloom endpoint before pushing; push only absent objects | ✅ Implemented | cvmfs-bits `internal/distribute/distributor.go` (`BloomQueryTimeout`, `fetchReceiverBloom`) |
+| Prometheus /metrics on receiver | Receiver-specific counters (objects received, bytes, bloom size, heartbeat errors) exposed at `/metrics` on the control channel | ✅ Implemented | cvmfs-bits `pkg/observe/metrics.go`, `receiver.go` |
+| Tier-1 registration + heartbeat | Receiver registers with coordination service at startup; sends 30 s heartbeat with bloom_size and ready state; deregisters on shutdown | ✅ Implemented | cvmfs-bits `internal/distribute/receiver/coord_client.go` |
+| **HepCDN coordination service** | Topology-aware routing, health registry, publish announce, Tier-2 pre-warm broadcast | ❌ Missing | New binary (`cmd/hepcdn-coord`) |
+| **Tier-2 pre-warm signal handler** | Receives pre-warm signal from coord service; issues Varnish PURGE+prefetch | ❌ Missing | New sidecar or cvmfs-bits |
+| **AS-topology routing database** | BGP data from GÉANT/ESnet; maps AS → nearest healthy Tier-1 | ❌ Missing | Coord service data layer |
+| Varnish/Nginx at Tier-1 (replaces Apache) | HTTP cache with CVMFS TTL rules | ❌ Not deployed | Site config management |
+| Varnish/Nginx at Tier-2 (replaces Squid) | Site edge cache with pre-warm support | ❌ Not deployed | Site config management |
+| Puppet/Ansible deployment templates | Central config rollout for Tier-1 and Tier-2 | ❌ Missing | Ops/infra repo |
+| Unified Prometheus/Grafana dashboard | Cross-tier hit rate, lag, health | ❌ Missing | Monitoring infrastructure |
+| S1 webhook for pull replication trigger | On publish, notify S1 to run `cvmfs_server snapshot` immediately | ❌ Missing | Separate from cvmfs-bits push |
+
+### 5.2 The two bloom filters and why they are different
+
+A common point of confusion: there are **two distinct bloom filters** in the
+HepCDN design, with different owners, purposes, and sharing mechanisms.
+
+```
+Publisher node (Stratum 0)                   Tier-1 node (Stratum 1)
+─────────────────────────────────            ────────────────────────────────
+Publisher-side dedup filter                  Tier-1 inventory filter
+  Purpose: avoid re-pushing objects            Purpose: answer "do you have
+  already present across builds                hash X?" for delta computation
+  Scope: across all build nodes               Scope: this node's local CAS only
+  Sharing: NFS-shared .bloom snapshots        Sharing: HTTP GET /api/v1/bloom
+  Built: scan shared CAS at startup           Built: walk local CAS at startup,
+         + load peer snapshots                        update on each PUT success
+  Status: ✅ implemented                      Status: ✅ implemented
+  Location: internal/pipeline/dedup/         Location: internal/distribute/receiver/
+```
+
+The dedup filter prevents the distributor from re-uploading objects that are
+already in the shared CAS backend (bandwidth saving within a single publish
+site).  The inventory filter lets the distributor compute a per-Tier-1-node
+delta — pushing only objects the specific remote node does not yet hold — and
+lets the coordination service confirm object availability before routing clients
+there.
+
+### 5.3 Should cvmfs-bits host the bloom filter service?
+
+Yes.  The arguments are decisive:
+
+**Cohesion:** the receiver is the only process that knows exactly which objects
+it has accepted (each successful `PUT /api/v1/objects/{hash}` updates the
+inventory).  Hosting the filter in a separate process would require IPC to stay
+in sync with every PUT.
+
+**Shared dependency:** `github.com/bits-and-blooms/bloom/v3` is already a
+first-class dependency of cvmfs-bits.  The serialisation format (`WriteTo` /
+`ReadFrom`) is already used for the dedup snapshots, so the distributor can
+deserialise a receiver's bloom endpoint response with zero new code on that side.
+
+**Existing HTTPS server:** the receiver already runs a TLS control channel
+(`:9100` by default).  The bloom endpoint and Prometheus metrics are served on
+the same mux:
+
+```go
+controlMux.HandleFunc("/api/v1/bloom", r.bloomHandler)
+controlMux.Handle("/metrics", promhttp.Handler())
+```
+
+**Single binary deployment:** operators install one `cvmfs-prepub --mode receiver`
+unit, not a receiver plus a separate bloom-filter sidecar.
+
+**Registration fits naturally:** at startup the receiver initialises its
+inventory filter by walking the local CAS, then the coordination client
+registers the node with the coordination service.  The registration, heartbeat,
+and filter maintenance are all part of the same lifecycle.
+
+All five points have been validated: these components are now implemented and
+tested in `cvmfs-bits` (see §5.1).
+
+### 5.4 Remaining gaps — priority order
+
+Items 1–4 from the original list are now **implemented and tested** in
+`cvmfs-bits`.  The following components must still be built before HepCDN v1
+can function end-to-end.  They are listed in dependency order.
+
+**✅ Completed (cvmfs-bits):**
+
+1. ~~Inventory bloom filter + HTTP endpoint~~ — done (`inventory.go`,
+   `bloom_handler.go`; `GET /api/v1/bloom` on control channel).
+
+2. ~~Prometheus `/metrics` endpoint on receiver~~ — done (wired via
+   `promhttp.Handler()` on the control mux; four new receiver-specific metrics).
+
+3. ~~Tier-1 registration + heartbeat~~ — done (`coord_client.go`; 30 s
+   heartbeat with `bloom_size` and `ready` state; deregisters on shutdown).
+
+4. ~~Per-node delta push mode~~ — done (`fetchReceiverBloom`,
+   `BloomQueryTimeout` in `distributor.go`; panic-safe bloom deserialisation).
+
+**❌ Still missing — New binary — HepCDN coordination service:**
+
+5. **HepCDN coordination service** (`cmd/hepcdn-coord` in cvmfs-bits, or a
+   separate repository).  Minimum viable API (client protocol already implemented
+   in the receiver — see REFERENCE.md §22):
+
+   ```
+   POST /api/v1/nodes              — Tier-1 registers (node_id, repos, data_url)
+   PUT  /api/v1/nodes/{id}/heartbeat — Tier-1 sends bloom_size + ready
+   DELETE /api/v1/nodes/{id}       — Tier-1 deregisters on shutdown
+   POST /api/v1/announce           — distributor announces publish completion;
+                                     coord broadcasts pre-warm signal to Tier-2
+   GET  /route?client=IP&repo=NAME — returns ordered Tier-1 list for this client
+   GET  /health                    — cluster health summary for monitoring
+   ```
+
+   Phase 1 can use simple IP-geolocation routing (same as GeoAPI) and upgrade
+   to AS-topology routing in Phase 3 without changing the API surface.
+   Estimated effort: 1–2 weeks.
+
+**❌ Still missing — Tier-2 pre-warm handler:**
+
+6. **Pre-warm signal handler** — a small HTTP listener at each Tier-2 node.
+   On signal from the coordination service it issues:
+   `varnishadm ban req.url ~ "\.cvmfspublished$"` (force catalog revalidation)
+   and prefetches the new root catalog.  Can be a 50-line Go binary or a
+   Varnish inline C vmod.  Estimated effort: 1 day.
+
+**❌ Still missing — Supporting infrastructure (ops, not code):**
+
+7. Puppet/Ansible Varnish template for Tier-2 rollout.
+8. Grafana dashboard templates (hit rate, replication lag, node health).
+9. S1 webhook receiver for pull replication triggering (independent of push).
+10. BGP/AS-topology dataset for Phase 3 coord service routing upgrade.
+
+---
+
+## 6. Recommended Roadmap
+
+> Components listed in §5.4 are reflected in phases 1–2 below.
 
 ```
 Now  ──────────────────────────────────────────────────── +3 years
 
  Phase 1 (0–6 months): Prerequisite infrastructure
  ├─ Replace site Squid with Varnish (central Puppet/Ansible template)
- ├─ Deploy cvmfs-bits distributor at Stratum 0 (done in this branch)
+ ├─ Deploy cvmfs-bits distributor at Stratum 0 ✅ done
+ ├─ Receiver: inventory bloom filter, /api/v1/bloom, delta push, coord client ✅ done
  ├─ Enable webhook-triggered S1 replication (eliminates polling lag)
- └─ Instrument Stratum 1 nodes with Prometheus exporters
+ └─ Instrument Stratum 1 nodes with Prometheus exporters (receiver /metrics ✅ done; Grafana dashboards pending)
 
  Phase 2 (6–18 months): HepCDN v1 — coordination + seeding
- ├─ Deploy HepCDN coordination service (routing API, health registry)
+ ├─ Deploy HepCDN coordination service (routing API, health registry) [§5.4 item 5]
  ├─ Upgrade 3–5 pilot Stratum 1 nodes to HepCDN Tier-1 software stack
- │   (cvmfs-bits receiver, bloom filter service, coordination registration)
- ├─ Wire Varnish Tier-2 nodes to receive push pre-warm signals
+ │   (cvmfs-bits receiver + inventory bloom filter + coord registration — DONE in cvmfs-bits)
+ ├─ Wire Varnish Tier-2 nodes to receive push pre-warm signals [§5.4 item 6]
  ├─ Update CVMFS client documentation: coordination service URL replaces
  │   static CVMFS_SERVER_URL list
  └─ Unified Prometheus/Grafana dashboard across all tiers
@@ -568,10 +716,11 @@ Now  ─────────────────────────
 | Option | Ops saving | Perf gain | Disruption | Effort | Phase |
 |---|---|---|---|---|---|
 | Varnish/Nginx replaces Squid | High | Medium | Low | Low | **1 — now** |
-| cvmfs-bits push seeding | High | Very high | Low | Low | **1 — now** |
-| S1 Prometheus instrumentation | Medium | — | Very low | Low | **1 — now** |
+| cvmfs-bits push seeding | High | Very high | Low | Low | **1 — ✅ done** |
+| S1 Prometheus instrumentation | Medium | — | Very low | Low | **1 — ✅ done** |
 | HepCDN coordination service | Very high | High | Medium | Medium | **2** |
-| Tier-1 software upgrade (pilot) | High | High | Low | Medium | **2** |
+| Tier-1 software upgrade — receiver code | High | High | Low | Medium | **1 — ✅ done** |
+| Tier-1 software upgrade — deployment | High | High | Low | Medium | **2** |
 | Unified observability dashboard | Medium | — | Very low | Low | **2** |
 | Full HepCDN Tier-1 rollout | Very high | Very high | Medium | Medium | **3** |
 | K8s-native Tier-1 | High | Low | Medium | Medium | **3** |
@@ -582,7 +731,7 @@ Now  ─────────────────────────
 
 ---
 
-## 6. Reference Varnish Configuration for HepCDN Tier-2
+## 7. Reference Varnish Configuration for HepCDN Tier-2
 
 Squid is the biggest operational burden and the area where a drop-in replacement
 delivers the most value with the least risk.

--- a/INFRASTRUCTURE_MODERNISATION.md
+++ b/INFRASTRUCTURE_MODERNISATION.md
@@ -25,7 +25,7 @@ Publisher workstation
        │  HTTP (port 8000)
        │
 ┌──────▼──────────────────────────────────────────────────────────┐
-│  Site Squid proxy  (1–3 per grid site, ~700 sites worldwide)    │
+│  Site Squid proxy  (1–3 per grid site, ~70 sites worldwide)     │
 │  Squid 3/4/5  with disk cache (200 GB – 2 TB)                  │
 │  Config: cache_peer to Stratum 1, hierarchy_stoplist, acl      │
 │  WPAD / PAC file or static CVMFS_HTTP_PROXY on each worker     │
@@ -62,7 +62,7 @@ Publisher workstation
 
 | Area | Problem |
 |---|---|
-| **Squid ops burden** | Each of ~700 sites runs 1–3 Squid instances. Requires local sysadmin expertise: config, disk management, cache tuning, security patches. |
+| **Squid ops burden** | Each of ~70 sites runs 1–3 Squid instances. Requires local sysadmin expertise: config, disk management, cache tuning, security patches. |
 | **Squid age** | Squid 3/4 is a 25-year-old C codebase. Limited observability, TLS termination is awkward, no native HTTP/2. |
 | **Stratum 1 lag** | Pull-based replication adds 5–120 min staleness. Clients hold stale catalog views during the window. |
 | **Cold-start thundering herd** | After a publish, 100s of workers simultaneously miss the Squid cold cache, hammering Stratum 1. |
@@ -405,17 +405,17 @@ it; the burst drops to zero upstream requests.
 | Squid (cold cache) | ~2,000 connections in < 10 s |
 | Varnish + push pre-warm | 0–1 (only the pre-warm fetch) |
 
-**Ops savings across the WLCG grid (~700 sites):**
+**Ops savings across the WLCG grid (~70 sites):**
 
 | Activity | Squid | Varnish/Nginx | Saving |
 |---|---|---|---|
 | Initial config per site | 4 h manual | 30 min (Puppet template) | −87% |
 | Annual maintenance per site | 8 h (patches, tuning, restarts) | 1 h (OS package update) | −87% |
 | Emergency response (security CVE) | 2–5 days, all sites manually | 1 PR → Puppet → all sites in 2 h | −95% |
-| Total grid-wide ops (700 sites) | ~700 × 8 h = 5,600 h/yr | ~700 × 1 h = 700 h/yr | **−4,900 h/yr** |
+| Total grid-wide ops (70 sites) | ~70 × 8 h = 560 h/yr | ~70 × 1 h = 70 h/yr | **−490 h/yr** |
 
 At a representative sysadmin cost of €80/h, that is a saving of approximately
-**€390,000/year** across the grid — without any hardware procurement.
+**€39,000/year** across the grid — without any hardware procurement.
 
 **Stratum 1 upstream load:**
 

--- a/INFRASTRUCTURE_MODERNISATION.md
+++ b/INFRASTRUCTURE_MODERNISATION.md
@@ -1,0 +1,670 @@
+# CVMFS Infrastructure Modernisation Analysis
+
+## 1. Current Architecture
+
+### 1.1 The canonical deployment (WLCG / HEP grid)
+
+```
+Publisher workstation
+        │  cvmfs_server publish / gateway lease
+        ▼
+┌───────────────┐
+│  Stratum 0    │  Single write-authoritative origin.
+│  Apache/Nginx │  Serves HTTP; not directly exposed to clients.
+│  local disk   │  ~1–4 TB NVMe or Ceph RBD.
+│  or S3 bucket │
+└──────┬────────┘
+       │  cvmfs_server snapshot (pull, every 5–15 min or webhook)
+       │
+┌──────▼────────────────────────────────────────────────────────┐
+│  Stratum 1 mirrors  (10–50 globally for CMS/ATLAS/LHCb repos) │
+│  Apache + mod_wsgi  serving static content-addressed files     │
+│  Each: ~10–40 TB disk, 10 Gbps uplink                         │
+│  Sites: CERN, BNL, IN2P3, GridKA, NIKHEF, RAL, TRIUMF, …    │
+└──────┬────────────────────────────────────────────────────────┘
+       │  HTTP (port 8000)
+       │
+┌──────▼──────────────────────────────────────────────────────────┐
+│  Site Squid proxy  (1–3 per grid site, ~700 sites worldwide)    │
+│  Squid 3/4/5  with disk cache (200 GB – 2 TB)                  │
+│  Config: cache_peer to Stratum 1, hierarchy_stoplist, acl      │
+│  WPAD / PAC file or static CVMFS_HTTP_PROXY on each worker     │
+└──────┬──────────────────────────────────────────────────────────┘
+       │  HTTP (port 3128)
+       │
+┌──────▼─────────────────────────────────────────────────────────┐
+│  Worker nodes  (batch farm: 10 – 100,000 per site)             │
+│  cvmfs2 FUSE client  /cvmfs/<repo>                             │
+│  Local page cache (kernel + CVMFS client cache, ~20 GB)        │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### 1.2 Client request lifecycle
+
+1. FUSE open triggers catalog lookup → client checks its local SQLite cache.
+2. On miss: HTTP GET to Squid (CVMFS_HTTP_PROXY).
+3. Squid checks its disk cache. On hit: served from disk (~0.1 ms local LAN).
+4. On Squid miss: Squid fetches from Stratum 1 (GeoAPI-sorted by client IP).
+5. Stratum 1 serves from local disk or fetches from Stratum 0 if not yet
+   replicated.
+6. Chunk data flows back to client; client assembles file via FUSE and
+   populates kernel page cache.
+
+### 1.3 Consistency and TTL
+
+- Root catalog TTL is embedded in the catalog itself (typically 4–240 min).
+- Clients poll for new root catalog hash every TTL seconds.
+- Stratum 1 replication lag adds to effective staleness (minutes to ~2 h in
+  busy deployments without webhook notification).
+- No push mechanism to clients; all consistency is pull-based with TTL expiry.
+
+### 1.4 Key pain points
+
+| Area | Problem |
+|---|---|
+| **Squid ops burden** | Each of ~700 sites runs 1–3 Squid instances. Requires local sysadmin expertise: config, disk management, cache tuning, security patches. |
+| **Squid age** | Squid 3/4 is a 25-year-old C codebase. Limited observability, TLS termination is awkward, no native HTTP/2. |
+| **Stratum 1 lag** | Pull-based replication adds 5–120 min staleness. Clients hold stale catalog views during the window. |
+| **Cold-start thundering herd** | After a publish, 100s of workers simultaneously miss the Squid cold cache, hammering Stratum 1. |
+| **GeoAPI coupling** | Client Stratum 1 selection depends on a custom GeoAPI call. Single point of coordination, not topology-aware within a region. |
+| **WPAD/PAC fragility** | Sites configure CVMFS_HTTP_PROXY manually or via WPAD. Misconfigured proxies silently bypass caching. |
+| **No negative caching** | Every lookup for a missing path goes all the way to the server; no bloom filter or negative-cache in the proxy tier. |
+| **Monitoring gaps** | Squid hit rates and S1 replication state are monitored inconsistently across sites; no unified observability plane. |
+
+---
+
+## 2. Why a Commercial CDN Is Not the Answer
+
+The properties of CVMFS content — entirely content-addressed, immutable data
+objects with a small set of short-TTL mutable manifests — make it structurally
+ideal for CDN-style distribution.  A commercial CDN (Cloudflare, Fastly,
+CloudFront) would eliminate the Stratum 1 and Squid tiers in one step.  The
+argument is attractive on paper but fails on four grounds that are specific to
+HEP grid operations.
+
+### 2.1 Research-network policy and routing
+
+WLCG, OSG, and EGI traffic flows predominantly through dedicated research
+networks — GÉANT (Europe), ESnet (US), NorduNet, KISTI (Korea), RNP (Brazil)
+and their national affiliates.  These networks have bilateral peering agreements
+with each other and with CERN, BNL, IN2P3 and other Tier-1 centres that
+guarantee high bandwidth at zero marginal cost.  Commercial CDN PoPs sit outside
+this peering fabric: traffic routed through a commercial PoP must traverse the
+public internet at some point, losing the bandwidth guarantees and potentially
+incurring latency penalties on cross-continent paths that the research network
+peering was specifically designed to avoid.  Several national networks explicitly
+prohibit commercial CDN intermediation of traffic classified as "research data"
+in their acceptable-use policies.
+
+### 2.2 Cost at HEP scale
+
+The top five HEP software repositories collectively serve O(10⁸) file-opens per
+day across ~100,000 active worker cores.  Even with generous object-level cache
+hit rates (>98% for data chunks, ~80% for catalogs at a warm site proxy), the
+residual Stratum 1 → client traffic is in the tens of terabytes per day.
+Commercial CDN egress pricing — typically $0.04–$0.09/GB after negotiated
+discounts — would translate to $200,000–$500,000/year for the WLCG software
+corpus alone.  Research-programme pricing exists (Cloudflare for
+Nonprofits, Internet Archive partnerships) but is not guaranteed, subject to
+terms changes, and does not cover the full WLCG traffic volume.
+
+### 2.3 Data governance and sovereignty
+
+Collaboration software tarballs and conditions databases may contain
+pre-publication components subject to experiment-internal data-handling
+agreements.  Routing this content through commercial infrastructure whose data
+retention, access-logging, and jurisdiction policies are outside the
+collaboration's control is incompatible with those agreements.  CVMFS
+cryptographic signing provides object integrity but not confidentiality; once
+content transits a third-party PoP, the collaboration loses audit-trail control.
+
+### 2.4 Protocol opacity
+
+Commercial CDNs treat all traffic as opaque HTTP.  They cannot participate in
+CVMFS-specific mechanisms: the cvmfs-bits push protocol for zero-latency cache
+seeding, bloom-filter negotiation for object presence, catalog-tree-aware
+pre-warming, or the cryptographic whitelist verification that CVMFS clients
+perform on catalog files.  A commercial CDN would serve objects correctly but
+would be blind to the CVMFS consistency model, making the push-based
+replication improvements developed in this branch inapplicable.
+
+---
+
+## 3. HepCDN — A Community-Owned Content Delivery Network Seeded by CVMFS
+
+### 3.1 The core insight: HEP already operates a CDN
+
+The existing CVMFS distribution infrastructure is, structurally, a content
+delivery network.  It has PoPs (Stratum 1 mirrors at Tier-1 and Tier-2 sites),
+edge caches (site Squid proxies), a routing layer (GeoAPI), and an origin
+(Stratum 0).  What it lacks is:
+
+- a **unified coordination plane** (topology registry, health state, routing
+  policy) operated as a service rather than embedded in static config files;
+- a **push seeding protocol** to fill caches before clients request content
+  (current: pull-on-demand with TTL-gated revalidation);
+- **modern cache software** at the edge (Squid → Varnish/Nginx);
+- **unified observability** across all tiers.
+
+HepCDN is the proposal to add exactly these four missing pieces to the existing
+hardware, using CVMFS Stratum 0/1 as the seeding layer.  No new PoP hardware
+is needed for an initial deployment; the upgrade path is purely software.
+
+### 3.2 Proposed architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  CVMFS Stratum 0  +  cvmfs-bits distributor  (Seed tier)            │
+│                                                                      │
+│  On publish:                                                         │
+│  1. New objects pushed to all Tier-1 nodes via cvmfs-bits protocol  │
+│  2. Bloom filter snapshot broadcast to Tier-2 edge caches           │
+│  3. Root catalog hash announced to HepCDN coordination service      │
+└───────────────────────┬──────────────────────────────────────────────┘
+                        │  push (cvmfs-bits)  +  announce
+                        │
+┌───────────────────────▼──────────────────────────────────────────────┐
+│  HepCDN Tier-1  (Regional nodes — existing Stratum 1 hardware)       │
+│                                                                      │
+│  Upgraded software stack per node:                                   │
+│  • Varnish or Nginx (replaces Apache) with CVMFS-tuned cache rules  │
+│  • cvmfs-bits receiver: accepts pushed objects, writes to cache      │
+│  • Bloom filter service: answers "do you have <hash>?" queries       │
+│  • Prometheus exporter: hit rate, fill %, replication lag, uptime   │
+│  • Registers with HepCDN coordination service at startup            │
+│                                                                      │
+│  Nodes: CERN, BNL, IN2P3, GridKA, NIKHEF, RAL, TRIUMF, KISTI, …  │
+└───────────────────────┬──────────────────────────────────────────────┘
+                        │  HTTP/2 or HTTP/3
+                        │  (routed by coordination service)
+┌───────────────────────▼──────────────────────────────────────────────┐
+│  HepCDN Tier-2  (Site edge — existing Squid hardware, new software)  │
+│                                                                      │
+│  Varnish replacing Squid:                                            │
+│  • Upstream selected from coordination service (not static config)   │
+│  • On bloom-filter hit: pre-warm cache from Tier-1 push signal       │
+│  • Negative caching: 404 responses cached 30 s                      │
+│  • Prometheus metrics → site and central monitoring                  │
+└───────────────────────┬──────────────────────────────────────────────┘
+                        │  HTTP (LAN, <0.5 ms)
+                        ▼
+                  Worker nodes
+                  CVMFS client: CVMFS_SERVER_URL points to
+                  coordination service (resolves to nearest Tier-1)
+                  CVMFS_HTTP_PROXY points to site Tier-2
+```
+
+### 3.3 HepCDN coordination service
+
+A lightweight Go service (one or two active replicas, stateless query path)
+replacing the existing GeoAPI.  It exposes:
+
+```
+GET /route?client=<IP>&repo=<name>
+→  { "tier1": ["https://cvmfs-s1.cern.ch", "https://cvmfs-s1.bnl.gov"],
+     "bloom_endpoint": "https://cvmfs-s1.cern.ch/bloom/<repo>" }
+
+GET /health
+→  { "tier1_nodes": 14, "healthy": 13, "seeding_lag_ms": 420 }
+
+POST /announce   (called by cvmfs-bits after publish)
+→  triggers Tier-2 edge pre-warm signal broadcast
+```
+
+Routing logic: map client IP → AS number → research-network topology graph
+(derived from GÉANT/ESnet BGP data, updated weekly) → nearest healthy Tier-1
+node with confirmed object availability (bloom filter).  This is significantly
+more accurate than the IP-geolocation approach used by GeoAPI today, which
+misroutes clients behind VPNs and multi-homed sites.
+
+### 3.4 CVMFS as the seeding layer
+
+CVMFS Stratum 0 is uniquely positioned as the seeding source because it has:
+
+**Complete object inventory.** The reflog and catalog tree enumerate every
+object hash in the repository.  The cvmfs-bits distributor can generate a
+precise list of new objects after each publish — no directory scan, no
+heuristic, no over-fetching.
+
+**Cryptographic integrity.** Every object is content-addressed by SHA-256 or
+BLAKE2b.  A Tier-1 node that receives a pushed object can verify it
+independently without trusting the push source.  The existing CVMFS whitelist
+and signature chain extends naturally to HepCDN nodes.
+
+**Publish-time knowledge.** The distributor runs immediately after the ingestion
+pipeline and before the gateway lease is committed.  Tier-1 caches are
+pre-filled with the new objects before the new root catalog hash is visible to
+any client, eliminating the cold-start thundering herd by construction.
+
+**Differential pushes.** The bloom filter maintained per publish allows the
+distributor to push only the delta (objects in the new catalog tree that are
+absent from a node's current bloom filter), keeping seeding bandwidth
+proportional to the publish size, not the total repository size.
+
+### 3.5 What changes at each tier
+
+| Component | Today | HepCDN |
+|---|---|---|
+| Stratum 0 | Publishes, serves origin | Publishes + runs cvmfs-bits distributor; announces to coordination service |
+| Stratum 1 | Periodic pull, Apache serve | Receives pushed objects, Varnish serve, exports metrics, registers with coordination service |
+| Site proxy | Squid, static upstream list | Varnish, upstream from coordination service, pre-warms on push signal |
+| Client config | `CVMFS_SERVER_URL` = static list; `CVMFS_HTTP_PROXY` = static list | `CVMFS_SERVER_URL` = coordination service URL; `CVMFS_HTTP_PROXY` = site Varnish |
+| Routing | GeoAPI (IP geolocation) | Coordination service (AS-topology + bloom-filter-confirmed availability) |
+| Replication | Pull every 5–15 min | Push on publish (<5 s lag) |
+| Observability | Per-site, inconsistent | Unified Prometheus + Grafana dashboard |
+
+### 3.6 Comparison with commercial CDN
+
+| Criterion | Commercial CDN | HepCDN |
+|---|---|---|
+| Research-network routing | No — public internet egress | Yes — stays on GÉANT/ESnet |
+| PoPs at major grid sites | No | Yes (existing Stratum 1) |
+| Marginal cost per GB | $0.04–$0.09 | ~$0 (existing hardware) |
+| CVMFS push seeding | Not possible | Native (cvmfs-bits) |
+| Bloom-filter presence queries | Not possible | Native |
+| Catalog-aware pre-warming | Not possible | Native |
+| Data governance | Third-party jurisdiction | Full collaboration control |
+| Cryptographic audit trail | Opaque to CDN | End-to-end verifiable |
+| New PoP deployment | Self-service (minutes) | New Stratum 1 + registration |
+| Cold-start thundering herd | Absorbed at PoP (random) | Eliminated by push pre-fill |
+
+The fundamental asymmetry is that a commercial CDN is a generic HTTP cache that
+happens to work adequately for content-addressed objects, while HepCDN is a
+distribution system that understands CVMFS semantics end-to-end.  The latter
+enables capabilities — push seeding, differential bloom-filter updates,
+topology-aware routing within the research-network fabric — that are
+structurally impossible with an opaque third-party intermediary.
+
+---
+
+## 4. Other Improvements (Independent of HepCDN)
+
+### 4.1 Varnish or Nginx as a drop-in Squid replacement  ★ near-term
+
+Replace site Squid instances with Varnish Cache or Nginx proxy_cache.  This
+improvement is a prerequisite for HepCDN Tier-2 (the pre-warm signalling and
+Prometheus integration require Varnish or Nginx) but is also valuable
+standalone, independent of the coordination layer.
+
+#### 4.1.1 Architecture comparison
+
+```
+CURRENT — Squid                         PROPOSED — Varnish / Nginx
+═══════════════════════════════════     ══════════════════════════════════════
+Stratum 1                               Stratum 1 / HepCDN Tier-1
+┌─────────────────────────────┐         ┌──────────────────────────────────────┐
+│ Apache HTTP                 │         │ Varnish + cvmfs-bits receiver        │
+│ pull replication            │         │ Prometheus exporter                  │
+│ no metrics                  │         │ HTTP/2 listen                        │
+└──────────┬──────────────────┘         └───────────┬──────────────────────────┘
+           │ HTTP/1.1 (new TCP per req)             │ HTTP/2 multiplexed
+           ▼                                        ▼
+┌──────────────────────────┐            ┌──────────────────────────────────────┐
+│  Squid proxy (site)      │            │  Varnish / Nginx (site Tier-2)       │
+│  ✗ No Prometheus         │            │  ✓ Prometheus /metrics               │
+│  ✗ No HTTP/2 upstream    │            │  ✓ HTTP/2 upstream to S1             │
+│  ✗ Coarse TTL control    │            │  ✓ Per-object TTL (VCL/config)       │
+│  ✗ Opaque disk cache     │            │  ✓ Pre-warm on push signal           │
+└──────────┬───────────────┘            └───────────┬──────────────────────────┘
+           │                                        │
+           ▼                                        ▼
+  CVMFS clients (workers)                 CVMFS clients (workers)
+  CVMFS_HTTP_PROXY=squid:3128             CVMFS_HTTP_PROXY=varnish:80
+                                          (drop-in replacement, no client change)
+
+  MISS path: Squid → S1 (HTTP/1.1)       MISS path: Varnish → S1 (HTTP/2)
+                                          PUSH path: S1 → Varnish pre-warm ←──
+                                                     (eliminates cold-start herd)
+```
+
+#### 4.1.2 Feature comparison
+
+| Feature | Squid 3/4/5 | Varnish Cache | Nginx proxy_cache |
+|---|---|---|---|
+| Cache HIT latency | 3–10 ms (disk I/O) | **0.5–2 ms (RAM)** | 1–3 ms (sendfile) |
+| Upstream protocol | HTTP/1.1 only | HTTP/2 (`vmod_http2`) | HTTP/2 (`http2`) |
+| Per-object TTL rules | `refresh_pattern` (coarse) | **VCL: exact per-URL** | `proxy_cache_valid` (per-code) |
+| Prometheus metrics | None (cachemgr.cgi only) | **varnish-exporter** | nginx-prometheus-exporter |
+| Push pre-warm support | No | **Yes (VCL PURGE + BAN)** | Yes (proxy_cache_purge) |
+| Stale-while-revalidate | Limited | **Grace mode** | `proxy_cache_use_stale` |
+| Negative caching (404) | Requires `negative_ttl` | **VCL explicit** | `proxy_cache_valid 404` |
+| Config management | Per-site squid.conf | **Central VCL template** | Central nginx.conf |
+| Active security patches | Slow (C codebase, OSS) | Active (2–4 wk CVE lag) | Active (nginx core team) |
+| Memory footprint | ~100–300 MB | ~50–150 MB | ~30–100 MB |
+
+#### 4.1.3 Varnish VCL caching rules for CVMFS
+
+The key insight is that CVMFS objects are content-addressed: a hash-named
+data file never changes, so it can be cached indefinitely, while catalog and
+manifest files must respect the 60-second TTL.  Squid cannot express this
+distinction cleanly; Varnish VCL makes it explicit:
+
+```vcl
+sub vcl_backend_response {
+    # Content-addressed data objects: hash is in the URL → cache forever.
+    if (bereq.url ~ "^/data/[0-9a-f]{2}/[0-9a-f]{38}") {
+        set beresp.ttl    = 365d;
+        set beresp.grace  = 30d;   # serve stale while revalidating
+        unset beresp.http.Set-Cookie;
+        return (deliver);
+    }
+    # Catalog and manifest files: respect the 60-second polling interval.
+    if (bereq.url ~ "\.(cvmfspublished|cvmfswhitelist|cvmfschecksum)$"
+        || bereq.url ~ "^/.cvmfs") {
+        set beresp.ttl   = 60s;
+        set beresp.grace = 10s;
+        return (deliver);
+    }
+    # Default: 5-minute TTL for anything else.
+    set beresp.ttl = 5m;
+}
+```
+
+The equivalent Nginx stanza is more compact but less expressive:
+
+```nginx
+proxy_cache_path /var/cache/nginx/cvmfs levels=2:2
+    keys_zone=cvmfs:64m max_size=2t inactive=365d;
+
+location ~ ^/data/[0-9a-f]{2}/[0-9a-f]{38} {
+    proxy_cache            cvmfs;
+    proxy_cache_valid      200 365d;
+    proxy_cache_use_stale  error timeout updating;
+    proxy_pass             http://stratum1_upstream;
+}
+location ~ \.(cvmfspublished|cvmfschecksum|cvmfswhitelist)$ {
+    proxy_cache            cvmfs;
+    proxy_cache_valid      200 60s;
+    proxy_pass             http://stratum1_upstream;
+}
+```
+
+#### 4.1.4 Quantified performance and savings estimates
+
+**Reference site:** 2,000 grid workers, 200 GB Squid disk cache, average
+cache hit rate 85%, publish frequency 4×/day, catalog check period 5 min.
+
+**Latency improvement (cache HIT path):**
+
+| Path | Squid | Varnish | Saving |
+|---|---|---|---|
+| Cache hit (data object) | 5 ms (avg disk seek + TCP) | 1 ms (RAM, kernel sendfile) | −4 ms |
+| Catalog check (60 s cycle, 2,000 workers) | 5 ms × 2,000 = 10 CPU-s/min | 1 ms × 2,000 = 2 CPU-s/min | −80% worker idle wait |
+| Catalog miss (fetch from S1) | 200 ms (HTTP/1.1, new TCP) | 160 ms (HTTP/2, reuse) | −20% miss latency |
+
+**Cold-start thundering herd (post-publish):**
+
+With Squid, 2,000 workers simultaneously poll for the new catalog, all miss,
+and all open connections to the same Stratum 1 simultaneously — a burst of
+2,000 HTTP requests within a 5-second window.  With Varnish pre-warmed via a
+cvmfs-bits push signal, the new catalog is in RAM before any worker requests
+it; the burst drops to zero upstream requests.
+
+| Scenario | S1 upstream requests (5-min window post-publish) |
+|---|---|
+| Squid (cold cache) | ~2,000 connections in < 10 s |
+| Varnish + push pre-warm | 0–1 (only the pre-warm fetch) |
+
+**Ops savings across the WLCG grid (~700 sites):**
+
+| Activity | Squid | Varnish/Nginx | Saving |
+|---|---|---|---|
+| Initial config per site | 4 h manual | 30 min (Puppet template) | −87% |
+| Annual maintenance per site | 8 h (patches, tuning, restarts) | 1 h (OS package update) | −87% |
+| Emergency response (security CVE) | 2–5 days, all sites manually | 1 PR → Puppet → all sites in 2 h | −95% |
+| Total grid-wide ops (700 sites) | ~700 × 8 h = 5,600 h/yr | ~700 × 1 h = 700 h/yr | **−4,900 h/yr** |
+
+At a representative sysadmin cost of €80/h, that is a saving of approximately
+**€390,000/year** across the grid — without any hardware procurement.
+
+**Stratum 1 upstream load:**
+
+HTTP/2 multiplexing allows Varnish to reuse a single TCP connection for all
+concurrent upstream fetches to a given S1.  For a site with 2,000 workers
+and 15% miss rate, the number of simultaneous S1 connections drops from
+~300 (Squid, one TCP per request) to ~10 (Varnish, H2 streams).
+
+**Nginx advantages over Varnish (simpler sites):**
+
+- Already installed at many sites (reverse proxy for other services) — zero
+  new package dependencies.
+- `proxy_cache_purge` module handles push pre-warm via a simple HTTP PURGE
+  request from the cvmfs-bits signal handler.
+- Lower memory footprint; suitable for sites with < 64 GB RAM.
+- Slightly lower peak throughput than Varnish for very hot objects (Varnish
+  worker threads vs Nginx event loop), but negligible at typical HEP site scale.
+
+**Migration path:** same hardware, same port (3128 → 80 or keep 3128 with
+Varnish listening on that port), `CVMFS_HTTP_PROXY` unchanged if a
+site-local DNS alias is used.  1–2 days per site; fully templated centrally
+via Puppet/Ansible.  Reference VCL for HepCDN Tier-2 is in §6.
+
+---
+
+### 4.2 Kubernetes-native Stratum 1  ★ medium-term ops simplification
+
+Replace manually managed Stratum 1 VMs with Kubernetes workloads (Deployment +
+HPA + PVC).
+
+```yaml
+deployment:
+  image: cvmfs/stratum1-hepcdn:latest   # adds cvmfs-bits receiver + exporter
+  replicas: 2
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 60
+storage:
+  storageClass: ceph-rbd
+  size: 20Ti
+```
+
+Auto-scaling handles post-publish bursts; rolling updates for cvmfs-bits
+receiver upgrades require zero downtime; health checks restart unhealthy
+replicas automatically.  Declarative config managed in Git and reviewed via PR.
+
+---
+
+### 4.3 HTTP/3 (QUIC) transport for client downloads  ★ medium-term performance
+
+CVMFS clients currently use HTTP/1.1 via libcurl over TCP.  QUIC (RFC 9000)
+provides:
+
+- **0-RTT connection resumption**: catalog checks from returning workers take
+  one fewer round-trip (~10–50 ms saving on high-latency WAN links).
+- **Multiplexed streams without HOL blocking**: parallel chunk fetches over a
+  single QUIC connection avoid TCP head-of-line blocking.
+- **Connection migration**: dual-NIC or VPN transitions don't break downloads.
+
+**Implementation path:** libcurl ≥ 7.88.0 supports QUIC; Nginx ≥ 1.25.0
+serves HTTP/3.  Adding `CURLOPT_HTTP_VERSION = CURL_HTTP_VERSION_3` with
+fallback to HTTP/2 in the CVMFS download manager requires ~50 lines of change.
+
+**Estimated gain (500 km WAN, 5 ms RTT):** ~40 ms per catalog check, ~15%
+throughput improvement for many-small-file workloads.
+
+---
+
+### 4.4 Push-based cache seeding (cvmfs-bits)  ★ eliminates replication lag
+
+Implemented in this branch.  After publish, Stratum 0 pushes new objects
+directly to all registered HepCDN Tier-1 and Tier-2 nodes via the cvmfs-bits
+distributor before the gateway lease is committed.  In HepCDN context:
+
+- The distributor queries each Tier-1 node's bloom filter to identify which
+  objects are missing, then pushes only the delta.
+- Tier-1 nodes relay push signals to downstream Tier-2 caches, which
+  pre-warm the objects most likely to be requested at job startup.
+- The coordination service is notified of the new root catalog hash only after
+  all Tier-1 nodes confirm object receipt, guaranteeing that clients routed to
+  a Tier-1 node by the coordination service will always find the objects they
+  request.
+
+Result: replication lag drops from 5–120 min to < 5 s; cold-start thundering
+herd is eliminated.
+
+---
+
+### 4.5 eBPF-accelerated in-kernel object cache  ★ long-term / experimental
+
+An XDP/eBPF program on a Tier-1 or Tier-2 host intercepts CVMFS HTTP GETs at
+the NIC, looks up the content hash in a shared BPF map, and returns cached
+bytes directly from a pinned memory region — bypassing the TCP stack entirely.
+
+**Realistic gains:** for hot objects (root catalog polled every ~5 min by
+10,000 workers): 0.1 ms → < 0.01 ms at the edge node.
+
+**Maturity:** proof-of-concept only.  Requires kernel ≥ 5.15 and privileged
+container access.  Not recommended for near-term deployment.
+
+---
+
+### 4.6 OCI Distribution as transport layer  ★ speculative
+
+CVMFS objects are structurally identical to OCI image layers: content-addressed
+blobs referenced by a manifest.  An OCI Distribution v1.1 registry (Zot,
+Harbor) could serve as a Tier-1 node, with registry replication replacing
+cvmfs_server snapshot.  Suitable as a long-term research direction; the CVMFS
+client would need to speak the OCI blob API, which is a non-trivial change.
+
+---
+
+## 5. Recommended Roadmap
+
+```
+Now  ──────────────────────────────────────────────────── +3 years
+
+ Phase 1 (0–6 months): Prerequisite infrastructure
+ ├─ Replace site Squid with Varnish (central Puppet/Ansible template)
+ ├─ Deploy cvmfs-bits distributor at Stratum 0 (done in this branch)
+ ├─ Enable webhook-triggered S1 replication (eliminates polling lag)
+ └─ Instrument Stratum 1 nodes with Prometheus exporters
+
+ Phase 2 (6–18 months): HepCDN v1 — coordination + seeding
+ ├─ Deploy HepCDN coordination service (routing API, health registry)
+ ├─ Upgrade 3–5 pilot Stratum 1 nodes to HepCDN Tier-1 software stack
+ │   (cvmfs-bits receiver, bloom filter service, coordination registration)
+ ├─ Wire Varnish Tier-2 nodes to receive push pre-warm signals
+ ├─ Update CVMFS client documentation: coordination service URL replaces
+ │   static CVMFS_SERVER_URL list
+ └─ Unified Prometheus/Grafana dashboard across all tiers
+
+ Phase 3 (18–36 months): HepCDN full rollout
+ ├─ All Stratum 1 nodes registered as HepCDN Tier-1
+ ├─ K8s-native Tier-1 deployment at 3+ sites (pilot)
+ ├─ AS-topology routing replaces GeoAPI at all registered sites
+ ├─ HTTP/3 support in CVMFS client (libcurl QUIC, opt-in flag)
+ └─ Differential bloom-filter seeding for large repos (CMS, ATLAS)
+
+ Phase 4 (36+ months): Research and extension
+ ├─ New grid sites join HepCDN by registering a Varnish node
+ │   (no Stratum 1 hardware required for pure Tier-2 membership)
+ ├─ OCI Distribution as optional Tier-1 backend (research)
+ └─ eBPF catalog cache at highest-traffic Tier-1 nodes (research)
+```
+
+### Priority matrix
+
+| Option | Ops saving | Perf gain | Disruption | Effort | Phase |
+|---|---|---|---|---|---|
+| Varnish/Nginx replaces Squid | High | Medium | Low | Low | **1 — now** |
+| cvmfs-bits push seeding | High | Very high | Low | Low | **1 — now** |
+| S1 Prometheus instrumentation | Medium | — | Very low | Low | **1 — now** |
+| HepCDN coordination service | Very high | High | Medium | Medium | **2** |
+| Tier-1 software upgrade (pilot) | High | High | Low | Medium | **2** |
+| Unified observability dashboard | Medium | — | Very low | Low | **2** |
+| Full HepCDN Tier-1 rollout | Very high | Very high | Medium | Medium | **3** |
+| K8s-native Tier-1 | High | Low | Medium | Medium | **3** |
+| HTTP/3 client transport | Low | Medium | Very low | Low | **3** |
+| AS-topology routing | Medium | Medium | Low | Medium | **3** |
+| OCI Distribution backend | Medium | Low | Very high | Very high | Research |
+| eBPF cache | Low | Very high (hot) | High | Very high | Research |
+
+---
+
+## 6. Reference Varnish Configuration for HepCDN Tier-2
+
+Squid is the biggest operational burden and the area where a drop-in replacement
+delivers the most value with the least risk.
+
+**Why sites keep Squid today:**
+- CVMFS documentation explicitly recommends it.
+- Existing Puppet modules at WLCG sites configure it.
+- Squid's `cache_peer` hierarchy mirrors how CVMFS proxy lists work.
+
+**Varnish feature parity:**
+
+| Squid feature | Varnish equivalent |
+|---|---|
+| `cache_dir ufs` | `storage = file` |
+| `cache_peer` hierarchy | `bereq.backend` in `vcl_backend_fetch` |
+| `acl localnet` | `req.http.X-Forwarded-For` match in VCL |
+| `maximum_object_size` | `beresp.http.Content-Length` check in VCL |
+| `refresh_pattern` | `beresp.ttl` override in `vcl_backend_response` |
+| `log_format` | `varnishncsa -F` with custom format |
+| Prometheus metrics | `varnish_exporter` sidecar |
+
+**Reference VCL for a HepCDN Tier-2 node** (upstream list supplied by
+coordination service; pre-warm hook called on push signal from Tier-1):
+
+```vcl
+vcl 4.1;
+
+# Upstream Tier-1 nodes — in production, populated from HepCDN coordination
+# service via a config-management template (Puppet/Ansible/Helm).
+backend tier1_a { .host = "cvmfs-s1.cern.ch";    .port = "8000"; }
+backend tier1_b { .host = "cvmfs-s1.bnl.gov";    .port = "8000"; }
+
+import directors;
+
+sub vcl_init {
+    new vd = directors.round_robin();
+    vd.add_backend(tier1_a);
+    vd.add_backend(tier1_b);
+}
+
+sub vcl_recv {
+    set req.backend_hint = vd.backend();
+    # Normalise: strip Range headers for small catalog objects to maximise
+    # cache key collision and hit rate.
+    if (req.url !~ "^/data/") { unset req.http.Range; }
+    return(hash);
+}
+
+sub vcl_backend_response {
+    # Content-addressed data objects are immutable: cache indefinitely.
+    if (bereq.url ~ "^/data/[0-9a-f]{2}/[0-9a-f]+$") {
+        set beresp.ttl = 365d;
+        set beresp.grace = 24h;
+        return(deliver);
+    }
+    # Root catalog and whitelist: short TTL, serve stale while revalidating.
+    if (bereq.url ~ "\.cvmfspublished$|\.cvmfswhitelist$") {
+        set beresp.ttl = 60s;
+        set beresp.grace = 300s;
+        return(deliver);
+    }
+    # Catalog SQLite databases are versioned by hash in path: immutable.
+    if (bereq.url ~ "\.cvmfsc(\.gz)?$") {
+        set beresp.ttl = 365d;
+        return(deliver);
+    }
+    # Negative caching: suppress thundering-herd retries for absent paths.
+    if (beresp.status == 404) {
+        set beresp.ttl = 30s;
+        return(deliver);
+    }
+}
+
+sub vcl_deliver {
+    # Expose cache status for monitoring and debugging.
+    set resp.http.X-Cache        = (obj.hits > 0) ? "HIT" : "MISS";
+    set resp.http.X-Cache-Hits   = obj.hits;
+    set resp.http.X-Served-By    = server.hostname;
+}
+```
+
+This config replicates the functionally important parts of a CVMFS Squid setup
+in ~45 lines of readable VCL versus ~120 lines of opaque Squid directives, and
+adds negative caching, stale-while-revalidate, and structured cache-status
+headers as a bonus.

--- a/PERF_IMPROVEMENTS.md
+++ b/PERF_IMPROVEMENTS.md
@@ -1,0 +1,313 @@
+# Publishing Pipeline Performance Improvements
+
+This branch applies a series of targeted performance improvements to the CVMFS
+publishing pipeline. All changes are relative to the current `devel` branch.
+No existing behaviour, wire format, or on-disk catalog schema is altered.
+
+---
+
+## Overview
+
+The CVMFS publishing path consists of four major phases:
+
+1. **Directory traversal** — union filesystem scratch layer is walked to detect
+   added, modified, and removed entries.
+2. **Ingestion pipeline** — changed files are read, chunked, compressed, hashed,
+   and uploaded to the storage backend concurrently.
+3. **Catalog finalization** — writable SQLite catalog databases are updated,
+   counters recalculated, and each catalog file is VACUUM-ed and uploaded.
+4. **Manifest commit** — the updated root catalog hash is signed and published.
+
+Profiling and code inspection identified eight independent bottlenecks. Each is
+addressed by a self-contained change described below.
+
+---
+
+## Change 1 — Parallel directory tree traversal
+
+**Files:** `cvmfs/util/fs_traversal.h`, `cvmfs/sync_union_overlayfs.cc`,
+`cvmfs/sync_union_aufs.cc`
+
+### Problem
+
+`FileSystemTraversal<T>::Recurse()` performs a fully serial depth-first walk.
+On a scratch layer with tens of thousands of files, `opendir` / `readdir` /
+`lstat` calls dominate publish time, and only one directory is processed at a
+time. Modern storage (NVMe, network-attached FUSE-over-Ceph) can service many
+concurrent metadata requests.
+
+### Solution
+
+A new `RecurseParallel(root_path, num_threads = 0)` method implements a
+two-phase design:
+
+- **Phase 1 (parallel):** A work-queue of `DirScanNode` items is processed by
+  `num_threads` workers (auto-detected from `sysconf(_SC_NPROCESSORS_ONLN)`
+  when 0). Each worker calls `opendir` / `readdir` / `lstat` and pushes child
+  directories back into the queue, building an in-memory tree.
+- **Phase 2 (serial):** `ReplayTree()` walks the pre-built tree in exactly the
+  same DFS order as the original `Recurse()`, firing `fn_enter_dir`,
+  per-entry-type, and `fn_leave_dir` callbacks sequentially.
+
+Serial replay is required because `SyncMediator::EnterDirectory` /
+`LeaveDirectory` update a shared catalog traversal stack that is not
+thread-safe. The two-phase split achieves parallel I/O without touching any
+callback concurrency contract.
+
+Both `SyncUnionOverlayfs::Traverse()` and `SyncUnionAufs::Traverse()` are
+updated to call `RecurseParallel`.
+
+---
+
+## Change 2 — Parallel leaf catalog finalization
+
+**Files:** `cvmfs/catalog_mgr_rw.h`, `cvmfs/catalog_mgr_rw.cc`
+
+### Problem
+
+`WritableCatalogManager::SnapshotCatalogs()` collects all leaf catalogs (those
+with no nested children) and finalizes them in a serial loop. Each
+`FinalizeCatalog()` call runs `UpdateCounters`, `Commit`, and
+`VacuumDatabaseIfNecessary`. The VACUUM operation rewrites the entire SQLite
+file and is strongly I/O-bound — it dominates finalization time. With N leaf
+catalogs, the total cost is O(N × VACUUM_time).
+
+### Solution
+
+Leaf catalogs own independent SQLite files with no shared mutable state during
+finalization (the one shared read — `parent->FindNested` — is already protected
+by `sync_lock_`). A `FinalizeLeafThread` static method is introduced; one
+`pthread_t` is created per leaf catalog, all threads are joined before
+processing non-leaf catalogs. This turns O(N × VACUUM_time) into
+O(max_VACUUM_time) for the leaf tier.
+
+The serial path (one leaf, or `stop_for_tweaks` mode) is preserved unchanged.
+
+---
+
+## Change 3 — Larger ingestion pipeline block sizes
+
+**Files:** `cvmfs/ingestion/task_read.h`, `cvmfs/ingestion/task_compress.h`
+
+### Problem
+
+The read stage dispatches 16 KB `BlockItem` objects into the chunk tube; the
+compress stage dispatches 8 KB compressed `BlockItem` objects into the hash
+tube. Each dispatch involves a mutex acquire and a condvar signal. For a large
+file, a single 16 KB read block produces at least two 8 KB compress dispatches,
+meaning three tube round-trips (read→chunk, chunk→compress, compress→hash) for
+every 8 KB of data.
+
+### Solution
+
+| Constant | Before | After |
+|---|---|---|
+| `TaskRead::kBlockSize` | `kPageSize × 4` (16 KB) | `kPageSize × 32` (128 KB) |
+| `TaskCompress::kCompressedBlockSize` | `kPageSize × 2` (8 KB) | `kPageSize × 16` (64 KB) |
+
+For typical files, the number of tube dispatches drops by approximately 8×
+with no change to correctness or memory safety. The pipeline watermark system
+(low/high watermarks on `BlockItem::managed_bytes()`) continues to provide
+backpressure.
+
+---
+
+## Change 4 — Hash stage merged into Compress stage
+
+**Files:** `cvmfs/ingestion/task_compress.cc`, `cvmfs/ingestion/pipeline.h`,
+`cvmfs/ingestion/pipeline.cc`, `cvmfs/compression/compression.h`
+
+### Problem
+
+The ingestion pipeline has a dedicated `TaskHash` stage between Compress and
+Write. Its `Process()` method calls `shash::Update()` on each block and
+forwards the block unchanged. This costs a full inter-thread tube dispatch (one
+mutex + condvar pair, per block) just to call one OpenSSL function on data that
+is already in memory.
+
+### Solution
+
+`TaskHash::Process()` logic is moved inline into `TaskCompress::Process()`:
+
+- After each compressed output block is ready and before it is dispatched to
+  `tubes_write_`, `shash::Update()` is called on its data.
+- On the flush (stop) block, `shash::Final()` is called after the last data
+  block is dispatched, before the stop sentinel is sent downstream.
+
+`TaskHash`, `kNforkHash`, `tubes_hash_`, and `tasks_hash_` are removed from
+`IngestionPipeline`. `ScrubbingPipeline` and `CompressHashPipeline` retain
+their own independent hash stages and are unaffected.
+
+Additionally, `EchoCompressor` (used when `kNoCompression` is selected) gains
+`IsPassthrough() const → true`. `TaskCompress::Process()` short-circuits the
+entire allocate-deflate-copy loop for passthrough compressors: `shash::Update`
+is called directly on the input block's data buffer, and the block is forwarded
+to the write stage with zero copies and zero intermediate buffer allocations.
+This benefits repositories storing pre-compressed content (`.tar.gz`, `.ROOT`,
+HDF5) where `kNoCompression` is the typical setting.
+
+---
+
+## Change 5 — Upload task parallelism scales with CPU count
+
+**Files:** `cvmfs/upload_spooler_definition.h`,
+`cvmfs/upload_spooler_definition.cc`
+
+### Problem
+
+`SpoolerDefinition::kDefaultNumUploadTasks = 1`. The ingestion pipeline
+compresses and hashes multiple files concurrently across 4–16 workers, but by
+default only one upload task ships compressed blocks to the backend. For local
+filesystem backends and the gateway uploader, this serialises all I/O writes
+regardless of storage throughput. (The S3 uploader already overrides this with
+its own 16-connection pool; the gap affects everyone else.)
+
+### Solution
+
+The `num_upload_tasks` field is initialised at construction time using
+`GetNumberOfCpuCores()`:
+
+```cpp
+num_upload_tasks = std::min(16U, std::max(4U, GetNumberOfCpuCores() / 2))
+```
+
+This gives 4 upload tasks on a 4-core machine, scales linearly to 16 on a
+32-core machine, and caps at 16 to avoid overwhelming backends with too many
+concurrent connections. Operators may override via the existing spooler
+configuration mechanism.
+
+---
+
+## Change 6 — SQLite WAL mode and `synchronous=OFF` for publish catalogs
+
+**Files:** `cvmfs/sql_impl.h`
+
+### Problem
+
+`Database<DerivedT>::Configure()` applies pragmas only for read-only opens. For
+read-write opens (publish-path writable catalogs) no pragmas are set, so SQLite
+uses its defaults: DELETE rollback journal mode and `synchronous=FULL`. The
+latter calls `fsync()` after every transaction commit. During a publish with
+hundreds of catalog updates, this produces hundreds of serialised `fsync` calls,
+each of which stalls all further SQLite writes until the OS confirms the data
+has reached stable storage.
+
+### Solution
+
+The read-write branch of `Configure()` now applies:
+
+```sql
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=OFF;
+```
+
+WAL (Write-Ahead Log) replaces random-write rollback journals with sequential
+append writes, improving throughput on all storage types and allowing readers
+to proceed concurrently with writers.
+
+`synchronous=OFF` is safe here because a failed publish is recovered by gateway
+lease rollback — the partially-written catalog is discarded and the repository
+state reverts to the pre-publish snapshot. There is no data-integrity scenario
+that requires fsync during a publish transaction.
+
+Read-only database opens (CVMFS clients, stratum-1 mirrors, catalog readers)
+are unaffected; their `Configure()` branch is unchanged.
+
+---
+
+## Change 7 — Sequential read-ahead hint for ingestion source files
+
+**Files:** `cvmfs/util/platform_linux.h`, `cvmfs/util/platform_osx.h`,
+`cvmfs/ingestion/ingestion_source.h`
+
+### Problem
+
+`FileIngestionSource::Open()` opens files with `O_RDONLY` and begins reading
+them in sequential blocks, but does not tell the kernel about the access
+pattern. The kernel's heuristic read-ahead starts conservatively and ramps up
+slowly, causing I/O stalls for the first several blocks of large files and
+under-utilising the available I/O bandwidth when many read workers are active.
+
+### Solution
+
+A platform-abstracted `platform_fadvise_sequential(int fd)` function is added:
+
+- Linux: `posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL)` — doubles the
+  kernel read-ahead window and marks pages for discard after use.
+- macOS: no-op (no `posix_fadvise` equivalent with equivalent semantics).
+
+The call is placed immediately after the successful `open()` in
+`FileIngestionSource::Open()`. `Close()` already calls
+`platform_invalidate_kcache` (`POSIX_FADV_DONTNEED`) to release pages.
+
+---
+
+## Change 8 — Extended attribute pre-fetch moves off the pipeline thread
+
+**Files:** `cvmfs/sync_item.h`, `cvmfs/sync_item.cc`,
+`cvmfs/sync_mediator.cc`
+
+### Problem
+
+When `--include-xattrs` is active, `SyncMediator::PublishFilesCallback()`
+calls `XattrList::CreateFromFile()` on the union filesystem path for every
+completed file. This callback runs on the ingestion pipeline's observer thread
+(fired from `TaskRegister` via `NotifyListeners`). Because `TaskRegister` has a
+single worker, this serialises all `lgetxattr` syscalls — and therefore all
+`catalog_manager_->AddFile()` catalog insertions — through a single thread,
+regardless of how many files the compress/hash/write stages have processed in
+parallel.
+
+### Solution
+
+`SyncItem` gains a `XattrList *cached_xattrs_` private field (null-initialised,
+freed in the destructor) and ownership-transfer accessors `SetCachedXattrs()`
+and `TakeCachedXattrs()`.
+
+In `SyncMediator::AddFile()`, immediately before inserting the entry into
+`file_queue_` (which happens on the traversal thread), xattrs are read and
+stored on the `SyncItem`:
+
+```cpp
+if (params_->include_xattrs) {
+  entry->SetCachedXattrs(XattrList::CreateFromFile(entry->GetUnionPath()));
+}
+```
+
+In `PublishFilesCallback()`, the `XattrList::CreateFromFile()` call is replaced
+with `item.TakeCachedXattrs()`. If the returned pointer is non-null it is used
+directly and then `delete`-d; otherwise `default_xattrs_` is used as before.
+The `TaskRegister` thread no longer performs any filesystem I/O.
+
+---
+
+## Building
+
+```bash
+pip install cmake --break-system-packages          # cmake >= 3.24
+apt-get install -y libfuse3-dev libcap-dev libacl1-dev uuid-dev python3-dev
+
+cmake -B build -S . \
+  -DBUILD_UNITTESTS=ON \
+  -DBUILD_UBENCHMARKS=ON \
+  -DBUILTIN_EXTERNALS=ON
+
+cmake --build build -j$(nproc)
+```
+
+## Testing
+
+```bash
+# Unit tests (focused on changed components)
+./build/cvmfs_unittests \
+  --gtest_filter='T_Compression*:T_Compressor*:T_CatalogSql*:T_CatalogMgrRw*:T_Shash*' \
+  --gtest_print_time=1
+
+# Micro-benchmarks for compression and hash throughput
+./build/cvmfs_ubenchmarks \
+  --benchmark_filter='BM_Compression|BM_Hash' \
+  --benchmark_repetitions=5
+
+# Full unit suite (skipping slow integration tests)
+./build/cvmfs_unittests --gtest_filter=-*Slow
+```

--- a/PERF_IMPROVEMENTS.md
+++ b/PERF_IMPROVEMENTS.md
@@ -151,7 +151,8 @@ HDF5) where `kNoCompression` is the typical setting.
 ## Change 5 — Upload task parallelism scales with CPU count
 
 **Files:** `cvmfs/upload_spooler_definition.h`,
-`cvmfs/upload_spooler_definition.cc`
+`cvmfs/upload_spooler_definition.cc`, `cvmfs/swissknife_sync.h`,
+`cvmfs/swissknife_sync.cc`
 
 ### Problem
 
@@ -164,21 +165,24 @@ its own 16-connection pool; the gap affects everyone else.)
 
 ### Solution
 
-The `num_upload_tasks` field is initialised at construction time using
-`GetNumberOfCpuCores()`:
+The `num_upload_tasks` field is initialised at `SpoolerDefinition` construction
+time using `GetNumberOfCpuCores()`:
 
 ```cpp
 num_upload_tasks = std::min(16U, std::max(4U, GetNumberOfCpuCores() / 2))
 ```
 
 This gives 4 upload tasks on a 4-core machine, scales linearly to 16 on a
-32-core machine, and caps at 16 to avoid overwhelming backends with too many
-concurrent connections. Operators may override via the existing spooler
-configuration mechanism.
+32-core machine, and caps at 16 to avoid overwhelming backends.
+
+`SyncParameters::num_upload_tasks` is changed from `1` to `0` (sentinel meaning
+"inherit from SpoolerDefinition"). The override in `swissknife_sync.cc` is
+made conditional: `spooler_definition.num_upload_tasks` is only overwritten
+when the operator explicitly passes the `-0` flag.
 
 ---
 
-## Change 6 — SQLite WAL mode and `synchronous=OFF` for publish catalogs
+## Change 6 — `synchronous=NORMAL` for publish catalogs
 
 **Files:** `cvmfs/sql_impl.h`
 
@@ -186,29 +190,33 @@ configuration mechanism.
 
 `Database<DerivedT>::Configure()` applies pragmas only for read-only opens. For
 read-write opens (publish-path writable catalogs) no pragmas are set, so SQLite
-uses its defaults: DELETE rollback journal mode and `synchronous=FULL`. The
-latter calls `fsync()` after every transaction commit. During a publish with
-hundreds of catalog updates, this produces hundreds of serialised `fsync` calls,
-each of which stalls all further SQLite writes until the OS confirms the data
-has reached stable storage.
+uses its defaults: `synchronous=FULL`. This calls `fsync()` after every
+transaction commit — once to flush the rollback journal and once to flush the
+database file. During a publish with hundreds of catalog updates, this produces
+hundreds of serialised `fsync` pairs, each stalling all SQLite writes until the
+OS confirms the data has reached stable storage.
 
 ### Solution
 
 The read-write branch of `Configure()` now applies:
 
 ```sql
-PRAGMA journal_mode=WAL;
-PRAGMA synchronous=OFF;
+PRAGMA synchronous=NORMAL;
 ```
 
-WAL (Write-Ahead Log) replaces random-write rollback journals with sequential
-append writes, improving throughput on all storage types and allowing readers
-to proceed concurrently with writers.
+`synchronous=NORMAL` omits the fsync on rollback-journal deletion (the fsync
+that fires after every commit in FULL mode). Data is still written to the main
+database file before the SQLite connection moves on, so
+`ScheduleCatalogProcessing` can read the raw file with the spooler and upload
+a correct, up-to-date catalog.
 
-`synchronous=OFF` is safe here because a failed publish is recovered by gateway
-lease rollback — the partially-written catalog is discarded and the repository
-state reverts to the pre-publish snapshot. There is no data-integrity scenario
-that requires fsync during a publish transaction.
+`journal_mode=WAL` was deliberately considered and rejected for this use case:
+in WAL mode, committed pages live in a `<db>-wal` sidecar file until a
+checkpoint is performed. The spooler reads only the main database file at the
+OS level, so uploading before an explicit `PRAGMA wal_checkpoint` would silently
+upload a stale (pre-commit) catalog — a correctness bug. `synchronous=NORMAL`
+with the default DELETE journal gives the same fsync reduction without that
+ordering hazard.
 
 Read-only database opens (CVMFS clients, stratum-1 mirrors, catalog readers)
 are unaffected; their `Configure()` branch is unchanged.

--- a/PERF_IMPROVEMENTS.md
+++ b/PERF_IMPROVEMENTS.md
@@ -435,6 +435,51 @@ while VACUUM is in progress.
 
 ---
 
+## Change 12 — Counter updates already batched by outer catalog transaction
+
+**Files:** `cvmfs/catalog_counters_impl.h`, `cvmfs/catalog_rw.cc`
+
+### Analysis
+
+`TreeCountersBase<FieldT>::WriteToDatabase()` fires 24 `SqlUpdateCounter::Execute()`
+calls — one per counter column.  The na&iuml;ve reading suggests that, without an
+enclosing transaction, each call triggers SQLite's implicit transaction machinery
+(BEGIN → UPDATE → COMMIT → journal flush), producing 1,200 round-trips for a
+50-catalog publish.
+
+### Why no additional transaction is needed
+
+`WriteToDatabase()` is only ever called from `WritableCatalog::UpdateCounters()`,
+which asserts `dirty_ == true`.  The `dirty_` flag is set by
+`WritableCatalog::SetDirty()`, which immediately opens a catalog-wide SQLite
+transaction via `WritableCatalog::Transaction()` (a `BEGIN;` statement).
+All 24 counter UPDATEs therefore execute inside that outer transaction and are
+flushed together by the subsequent `WritableCatalog::Commit()` call.
+
+Adding an inner `BeginTransaction()` would issue a nested `BEGIN;`, which
+SQLite rejects with `SQLITE_ERROR: cannot start a transaction within a
+transaction`, causing the `assert(retval)` in `UpdateCounters()` to fire.
+
+### Outcome
+
+The 24 → 1 transaction consolidation is already achieved by the outer catalog
+transaction.  No change to `WriteToDatabase()` itself is required; a clarifying
+comment has been added to document the invariant:
+
+```cpp
+// NOTE: always called inside the outer transaction opened by SetDirty().
+// All 24 UPDATEs are committed together by WritableCatalog::Commit().
+// No additional SAVEPOINT/RELEASE is needed here.
+```
+
+### Effect
+
+Same as if an explicit inner transaction were added — 50 BEGIN/COMMIT pairs
+for a 50-catalog publish instead of 1,200 — but via the outer transaction that
+was already in place rather than a nested one that would have failed.
+
+---
+
 ## Performance Estimates
 
 ### Reference workload

--- a/PERF_IMPROVEMENTS.md
+++ b/PERF_IMPROVEMENTS.md
@@ -18,7 +18,7 @@ The CVMFS publishing path consists of four major phases:
    counters recalculated, and each catalog file is VACUUM-ed and uploaded.
 4. **Manifest commit** — the updated root catalog hash is signed and published.
 
-Profiling and code inspection identified eight independent bottlenecks. Each is
+Profiling and code inspection identified eleven independent bottlenecks. Each is
 addressed by a self-contained change described below.
 
 ---
@@ -165,24 +165,26 @@ its own 16-connection pool; the gap affects everyone else.)
 
 ### Solution
 
-The `num_upload_tasks` field is initialised at `SpoolerDefinition` construction
-time using `GetNumberOfCpuCores()`:
+The `num_upload_tasks` field is initialised at construction time using
+`GetNumberOfCpuCores()`:
 
 ```cpp
 num_upload_tasks = std::min(16U, std::max(4U, GetNumberOfCpuCores() / 2))
 ```
 
 This gives 4 upload tasks on a 4-core machine, scales linearly to 16 on a
-32-core machine, and caps at 16 to avoid overwhelming backends.
+32-core machine, and caps at 16 to avoid overwhelming backends with too many
+concurrent connections.
 
 `SyncParameters::num_upload_tasks` is changed from `1` to `0` (sentinel meaning
 "inherit from SpoolerDefinition"). The override in `swissknife_sync.cc` is
 made conditional: `spooler_definition.num_upload_tasks` is only overwritten
-when the operator explicitly passes the `-0` flag.
+when the operator explicitly passes the `-0` flag, preserving the CPU-scaled
+default in all other cases.
 
 ---
 
-## Change 6 — `synchronous=NORMAL` for publish catalogs
+## Change 6 — Reduced fsync overhead and larger SQLite page cache for publish catalogs
 
 **Files:** `cvmfs/sql_impl.h`
 
@@ -190,22 +192,24 @@ when the operator explicitly passes the `-0` flag.
 
 `Database<DerivedT>::Configure()` applies pragmas only for read-only opens. For
 read-write opens (publish-path writable catalogs) no pragmas are set, so SQLite
-uses its defaults: `synchronous=FULL`. This calls `fsync()` after every
-transaction commit — once to flush the rollback journal and once to flush the
-database file. During a publish with hundreds of catalog updates, this produces
-hundreds of serialised `fsync` pairs, each stalling all SQLite writes until the
-OS confirms the data has reached stable storage.
+uses its defaults: `synchronous=FULL` (an `fsync()` after every transaction
+commit), a 128-page buffer pool (≈ 512 KB with 4 KB pages), and no
+memory-mapped I/O. During a publish with hundreds of catalog updates this
+produces hundreds of serialised `fsync` pairs and repeated physical page reads
+for hot catalog rows.
 
 ### Solution
 
-The read-write branch of `Configure()` now applies:
+The read-write branch of `Configure()` now applies three pragmas:
 
 ```sql
 PRAGMA synchronous=NORMAL;
+PRAGMA cache_size=-65536;
+PRAGMA mmap_size=134217728;
 ```
 
-`synchronous=NORMAL` omits the fsync on rollback-journal deletion (the fsync
-that fires after every commit in FULL mode). Data is still written to the main
+**`synchronous=NORMAL`** omits the fsync on rollback-journal deletion that
+fires after every commit in FULL mode. Data is still written to the main
 database file before the SQLite connection moves on, so
 `ScheduleCatalogProcessing` can read the raw file with the spooler and upload
 a correct, up-to-date catalog.
@@ -217,6 +221,17 @@ OS level, so uploading before an explicit `PRAGMA wal_checkpoint` would silently
 upload a stale (pre-commit) catalog — a correctness bug. `synchronous=NORMAL`
 with the default DELETE journal gives the same fsync reduction without that
 ordering hazard.
+
+**`cache_size=-65536`** sets a 64 MB page buffer pool (the negative value is
+interpreted as kibibytes by SQLite ≥ 3.7.10, which CVMFS's bundled SQLite
+satisfies). This keeps hot catalog pages in the process address space across
+the many `AddEntry` and `UpdateCounters` calls that touch the same rows
+repeatedly during a publish session.
+
+**`mmap_size=134217728`** allows SQLite to memory-map up to 128 MB of the
+database file. For catalogs that fit within the map window, random page reads
+become simple memory accesses with no `pread()` syscall overhead. SQLite
+re-establishes the mapping correctly after a VACUUM rewrites the file.
 
 Read-only database opens (CVMFS clients, stratum-1 mirrors, catalog readers)
 are unaffected; their `Configure()` branch is unchanged.
@@ -289,6 +304,685 @@ The `TaskRegister` thread no longer performs any filesystem I/O.
 
 ---
 
+## Change 9 — Hardlink group ID cached per catalog
+
+**Files:** `cvmfs/catalog_rw.h`, `cvmfs/catalog_rw.cc`,
+`cvmfs/catalog_mgr_rw.cc`
+
+### Problem
+
+`WritableCatalogManager::AddHardlinkGroup()` called `catalog->GetMaxLinkId()`
+once per hardlink group to obtain the next available group ID. Each call
+executes `SELECT MAX(hardlinks>>32)` against the catalog database. With N
+hardlink groups all landing in the same catalog, this is N redundant queries
+where one would suffice — the result only changes because we just incremented
+it ourselves.
+
+### Solution
+
+`WritableCatalog` gains two new private fields:
+
+```cpp
+bool     link_id_ready_;   // false until first IssueHardlinkGroupId() call
+uint32_t link_id_seq_;     // next group ID to hand out
+```
+
+A new public method `IssueHardlinkGroupId()` replaces the `GetMaxLinkId() + 1`
+call at the use site:
+
+```cpp
+uint32_t WritableCatalog::IssueHardlinkGroupId() {
+  if (!link_id_ready_) {
+    link_id_seq_   = GetMaxLinkId() + 1;  // one DB query, first call only
+    link_id_ready_ = true;
+  }
+  assert(link_id_seq_ > 0);
+  return link_id_seq_++;                  // pure in-memory increment thereafter
+}
+```
+
+The first call during a publish session executes exactly one
+`SELECT MAX(hardlinks>>32)` query; every subsequent call for the same catalog
+increments `link_id_seq_` in memory. For a publish with N hardlink groups in a
+single catalog, the query count drops from N to 1.
+
+`GetMaxLinkId()` is retained for use in `CopyToParent()`, where a live DB query
+is required to compute the rebase offset when merging a nested catalog into its
+parent.
+
+---
+
+## Change 10 — O(1) hardlink callback lookup via index map
+
+**Files:** `cvmfs/sync_mediator.h`, `cvmfs/sync_mediator.cc`
+
+### Problem
+
+`SyncMediator::PublishHardlinksCallback()` received a spooler result and located
+the matching `HardlinkGroup` in `hardlink_queue_` by scanning the entire vector
+with a string comparison on each element's `master->GetUnionPath()`. With N
+hardlink groups this scan is O(N) per callback, and there are N callbacks —
+O(N²) string comparisons in total.
+
+### Solution
+
+`SyncMediator` gains a new private field:
+
+```cpp
+std::unordered_map<std::string, size_t> hardlink_index_;
+```
+
+When a group is enqueued in `PrepareHardlinks()`, its master path and queue
+position are recorded together:
+
+```cpp
+hardlink_index_[i->second.master->GetUnionPath()] = hardlink_queue_.size();
+hardlink_queue_.push_back(i->second);
+```
+
+In `PublishHardlinksCallback()`, the O(N) scan is replaced by a single map
+lookup:
+
+```cpp
+const auto idx_it = hardlink_index_.find(result.local_path);
+assert(idx_it != hardlink_index_.end());
+// update hardlink_queue_[idx_it->second] directly
+```
+
+Total callback work drops from O(N²) to O(N). The index is fully populated
+before any spooler callbacks can fire and is never written during the callback
+phase, so no additional synchronisation is required.
+
+---
+
+## Change 11 — `VacuumDatabaseIfNecessary` releases lock before I/O
+
+**Files:** `cvmfs/catalog_rw.cc`
+
+### Problem
+
+`WritableCatalog::VacuumDatabaseIfNecessary()` held `lock_` for the entire
+function body, including the `db.Vacuum()` call. SQLite VACUUM rewrites the
+entire catalog file and can take several seconds on a large catalog. While the
+lock was held, any concurrent caller of `UpdateNestedCatalog()` — which also
+acquires `lock_` — would stall for the full VACUUM duration. With parallel leaf
+finalization (Change 2), multiple finalization threads run concurrently and can
+encounter this contention on shared parent catalogs.
+
+### Solution
+
+`lock_` is scoped tightly to just the metric-reading section; the VACUUM I/O
+proceeds without holding it:
+
+```cpp
+{
+  const MutexLockGuard m(lock_);
+  if (db.GetFreePageRatio() > kMaximalFreePageRatio) { ... }
+  else if (db.GetRowIdWasteRatio() > kMaximalRowIdWasteRatio) { ... }
+}  // lock_ released here
+
+if (needs_defragmentation) {
+  db.Vacuum();  // runs without holding lock_
+}
+```
+
+This is safe because `VacuumDatabaseIfNecessary()` is called only from
+`FinalizeCatalog()`, which is itself triggered only after a catalog's
+`dirty_children` counter reaches zero. That counter reaching zero is the
+ordering guarantee that all concurrent `UpdateNestedCatalog()` calls on that
+catalog have already completed — no other thread will acquire `lock_` on it
+while VACUUM is in progress.
+
+---
+
+## Performance Estimates
+
+### Reference workload
+
+| Parameter | Value |
+|---|---|
+| Repository size | 2 GB, 500,000 files |
+| Files published (new / changed) | 100,000 |
+| Average file size | ~4 KB (software distribution: headers, configs, scripts, small binaries) |
+| New content volume | ~400 MB |
+| Nested catalogs (dirty after publish) | ~50 |
+| Hardlink groups | ~5,000 |
+| Server | 8-core, NVMe-backed overlayFS, local filesystem CAS backend |
+
+All timings are first-principles estimates based on typical syscall latencies
+and SQLite throughput figures.  They are not measurements; actual numbers
+depend heavily on hardware, kernel version, filesystem driver, and repository
+structure.  A ±30% band around each figure is realistic.
+
+### Baseline publish time: ~60 s
+
+| Phase | Time | Dominant cost |
+|---|---|---|
+| Scratch-layer traversal | 6 s | 100 K lstat + readdir syscalls through overlayFS |
+| Ingestion pipeline | 12 s | Per-file open/read/compress/hash overhead for 100 K small files |
+| CAS upload (objects) | 8 s | 100 K small-file writes, single-threaded |
+| Catalog SQL | 4 s | 100 K INSERTs + 50 × 24 counter UPDATEs; synchronous page fetches |
+| Catalog VACUUM | 22 s | ~12 catalogs × ~1.8 s each, executed serially |
+| Catalog upload + manifest | 8 s | ~50 catalog files (~250 MB) + signing round-trip |
+| **Total** | **60 s** | |
+
+VACUUM dominates because it rewrites the entire SQLite file for each affected
+catalog; with 12 catalogs needing defragmentation the serial cost accumulates
+to more than a third of total publish time.
+
+### Per-change improvement estimates
+
+| Change | Phase affected | Mechanism | Saved (s) | Notes |
+|---|---|---|---|---|
+| 1 — Parallel traversal | Traversal (6 s) | 8 worker threads replace serial DFS | **~4.5 s** | Scales with core count; larger gain on NFS (50 µs/lstat vs 2 µs) |
+| 2 — Parallel leaf VACUUM | VACUUM (22 s) | Up to N threads, one per leaf catalog | **~19 s** | 12 catalogs run concurrently; residual limited by disk bandwidth |
+| 3 — Larger block sizes | Ingestion (12 s) | 8× fewer tube dispatches for files > 16 KB | **~1 s** | 4 KB average size means ~30 % of files cross the old 16 KB threshold |
+| 4 — Hash merged into Compress | Ingestion (12 s) | Eliminates one inter-thread tube dispatch per block | **~1.5 s** | Every file benefits; also enables zero-copy passthrough for pre-compressed content |
+| 5 — Upload task parallelism | CAS upload (8 s) | 1 → 4 upload tasks; 100 K small writes parallelised | **~5 s** | Largest relative gain on gateway / S3 backends (network RTT dominates) |
+| 6 — SQLite pragmas | Catalog SQL (4 s) | 64 MB page cache + mmap eliminate page re-reads; synchronous=NORMAL drops post-journal fsync | **~1.5 s** | Benefit grows with catalog size; cold-cache runs see larger gains |
+| 7 — Sequential read-ahead | Ingestion (12 s) | Kernel doubles read-ahead window for files > 128 KB | **~0.5 s** | Marginal for 4 KB average; significant for repos with large binaries |
+| 8 — Xattr pre-fetch | Ingestion (12 s) | Moves lgetxattr off single-threaded TaskRegister onto traversal workers | **0 s / ~2 s** | **Zero unless `--include-xattrs` is active** |
+| 9 — Hardlink ID cache | Ingestion (12 s) | 5 K groups × 1 DB query → 50 queries (one per catalog) | **~1 s** | Proportional to hardlink group count |
+| 10 — O(1) hardlink lookup | Ingestion (12 s) | O(N²) string scans → O(N) hash-map lookups | **~0.1 s** | Negligible at 5 K groups; matters at 100 K+ groups |
+| 11 — Vacuum lock narrowing | VACUUM (22 s) | Releases lock_ before I/O so parent finalization is not blocked | **~2.5 s** | Synergistic: without this, parallel VACUUM (Change 2) stalls on parent catalog lock |
+
+Changes 2 and 11 are synergistic: Change 11 removes the locking bottleneck
+that would otherwise prevent Change 2 from achieving full thread-level
+parallelism.  Their combined saving of ~21.5 s is attributed jointly.
+
+### Combined estimate (all changes, `--include-xattrs` disabled)
+
+| Phase | Baseline | After | Saved |
+|---|---|---|---|
+| Traversal | 6 s | 1.5 s | 4.5 s |
+| Ingestion pipeline | 12 s | 8 s | 4 s |
+| CAS upload | 8 s | 3 s | 5 s |
+| Catalog SQL | 4 s | 2.5 s | 1.5 s |
+| Catalog VACUUM | 22 s | 2.5 s | 19.5 s |
+| Catalog upload + manifest | 8 s | 8 s | 0 s |
+| **Total** | **60 s** | **~26 s** | **~34 s** |
+
+**Overall speedup: ~2.3× (57 % reduction in publish time).**
+
+With `--include-xattrs` active: additional ~2 s saved → ~2.4× speedup.
+
+### Sensitivity to deployment conditions
+
+| Condition | Effect on total saving |
+|---|---|
+| NFS-backed overlayFS (lstat ~50 µs) | Traversal baseline ~30 s; Change 1 saves ~25 s; total speedup grows to ~3–4× |
+| Gateway or S3 backend (10 ms/object RTT) | CAS upload baseline ~1,000 s for 100 K objects at 1 task; Change 5 alone saves ~750 s |
+| Mostly large files (avg > 1 MB) | Changes 3, 4, 7 together give 2–3× ingestion speedup instead of ~1.5× |
+| Few or no hardlinks | Changes 9 & 10 contribute < 0.1 s; negligible |
+| Few catalogs needing VACUUM | Changes 2 & 11 contribute proportionally less; floor ~1 s |
+| 32-core server | Change 1 scales to ~12× traversal speedup; Change 2 parallelises all leaf VACUUMs simultaneously |
+
+---
+
+### End-to-end impact with cvmfs-bits
+
+The pipeline changes above reduce the Stratum-0 publish time from ~60 s to
+~26 s.  cvmfs-bits changes the scope of what is measured: the relevant figure
+shifts from "time until Stratum-0 commits" to "time until every Stratum-1
+mirror is consistent and all worker nodes can efficiently access new content".
+
+#### Additional scenario parameters
+
+| Parameter | Value |
+|---|---|
+| Stratum-1 mirrors | 5, geographically distributed |
+| Stratum-0 → Stratum-1 bandwidth (datacenter) | 10 Gbps shared |
+| Stratum-1 → client bandwidth | 1 Gbps |
+| Concurrent worker nodes accessing new version | 100 |
+| Files accessed per job (subset of new content) | ~10,000 files (~40 MB) |
+| Content dedup rate (bloom filter, rolling release) | ~25 % (objects from prior version already on mirrors) |
+
+#### Metric definitions
+
+**Time to publish (T_pub):** wall time from invoking the publish command to the
+new root catalog hash being signed and recorded on Stratum-0.  This is what the
+pipeline changes above optimise.
+
+**Time to consistency (T_con):** time from T_pub until all Stratum-1 mirrors
+hold a complete, queryable copy of every new object and the updated catalogs.
+Before cvmfs-bits, Stratum-1 replication is a passive pull triggered after
+T_pub; with cvmfs-bits it is a proactive push that begins during the publish
+pipeline and finishes at or before T_pub.
+
+**Time to production (T_pro):** time from invoking publish until all 100 worker
+nodes have successfully opened the new catalog and can read every required file
+at full throughput.  This is the figure that determines how long an HPC slot
+sits idle waiting for software.
+
+#### Estimates
+
+| Scenario | T_pub | T_con | T_pro | Notes |
+|---|---|---|---|---|
+| **Baseline** — no pipeline improvements, no cvmfs-bits | 60 s | 60 s + 90 s = **150 s** | 150 s + 30 s = **180 s** | Stratum-1 pulls 400 MB serially after commit; 100 workers cold-fetch simultaneously (thundering herd) |
+| **Pipeline improvements only** — Changes 1–11, no cvmfs-bits | 26 s | 26 s + 90 s = **116 s** | 116 s + 30 s = **146 s** | Same replication lag; thundering herd unchanged |
+| **Improvements + cvmfs-bits, no pre-warming** | 26 s | **~26 s** | 26 s + 30 s = **56 s** | Content pre-pushed to all 5 mirrors in parallel during publish; replication lag eliminated; cold-fetch thundering herd remains |
+| **Improvements + cvmfs-bits + cache pre-warming** | **~29 s** | **~29 s** | **~31 s** | Pre-warming adds ~3 s (400 MB × 0.75 dedup → 300 MB pushed at 10 Gbps, pipelined with ingestion); clients read from warm Stratum-1 cache → thundering herd eliminated |
+
+#### How the numbers are derived
+
+**Stratum-1 replication lag without cvmfs-bits (~90 s):**
+A Stratum-1 mirror receives a notify webhook on commit, then pulls the changed
+root catalog, walks the delta, and fetches 400 MB of new objects.  At a
+realistic pull rate of ~300 Mbps sustained (competing with client traffic on a
+1 Gbps link): 400 MB / 37.5 MB/s ≈ 11 s per mirror for data alone, plus 5–10 s
+catalog walk and HTTP overhead per object → easily 60–120 s wall time,
+serialised through the Stratum-0 HTTP server.  Five mirrors pulling
+simultaneously saturate Stratum-0 uplink and push this to 90 s median.
+
+**Thundering herd cold-fetch (~30 s):**
+100 worker nodes simultaneously open the new catalog version.  Each node reads
+~10,000 files × 4 KB = 40 MB.  With a cold Stratum-1 cache, these 100 × 40 MB
+= 4 GB of requests arrive within seconds.  At 1 Gbps Stratum-1 output bandwidth
+shared across 100 clients: each client waits an average of 4 GB / 125 MB/s / 10
+concurrent = 3.2 s for data, but with per-file RTT overhead (~0.5 ms × 10,000
+files) and OS page-fault stalls the practical wait before a job's first real
+work is done is 20–40 s.  Median ~30 s.
+
+**cvmfs-bits parallel push (overlaps ingestion, net +0 s for T_pub):**
+cvmfs-bits streams compressed objects to all 5 Stratum-1 mirrors concurrently
+as soon as the ingestion pipeline produces them.  At 10 Gbps datacenter
+bandwidth, 300 MB (after 25 % bloom-filter dedup) takes 300 MB / 1,250 MB/s
+= 0.24 s per mirror; with 5 mirrors in parallel and pipelining the push
+overlaps almost entirely with the 8 s ingestion phase.  Net addition to T_pub:
+~0 s.  Catalogs (250 MB) are pushed immediately after finalization, also within
+the existing T_pub budget.
+
+**Cache pre-warming (+3 s, eliminates thundering herd):**
+Pre-warming pushes the 100 most-accessed entry points (root catalog, top-level
+directory listings, the ~10,000 files that jobs access on startup) to each
+Stratum-1 node's memory cache before the gateway lease is committed.  This adds
+~3 s to T_pub (300 MB of targeted pre-warm data per mirror at 10 Gbps,
+sequential after catalog finalization).  After commit, client cold-fetches hit
+an already-warm cache: per-file latency drops to sub-millisecond, and 100
+simultaneous workers consume from cache bandwidth rather than object-store
+bandwidth.  T_pro ≈ T_pub + ~2 s (catalog open + first file access).
+
+#### Summary
+
+```
+Scenario                                     T_pub   T_con   T_pro
+─────────────────────────────────────────────────────────────────────
+Baseline (no improvements, no cvmfs-bits)     60 s   150 s   180 s
+Pipeline improvements only                    26 s   116 s   146 s
+Improvements + cvmfs-bits (no pre-warming)    26 s    26 s    56 s
+Improvements + cvmfs-bits + pre-warming       29 s    29 s    31 s
+─────────────────────────────────────────────────────────────────────
+Speedup vs baseline (T_pro)                   2.3×    5.2×    5.8×
+```
+
+The pipeline changes alone yield a **2.3× reduction in publish time** but leave
+the end-to-end worker wait largely dominated by Stratum-1 replication lag and
+cold-fetch overhead.  Adding cvmfs-bits eliminates the replication lag and,
+with pre-warming, the thundering herd as well — pushing the overall
+**T_pro speedup to ~5.8×** relative to the unmodified baseline.
+
+---
+
+## Gateway Analysis
+
+The CVMFS gateway (`cvmfs/gateway/`) sits on the T_pub critical path for every
+publish that goes through a lease: a publisher acquires a lease, uploads
+payload, and commits — all via gateway RPC calls.  For the reference workload
+(2 GB release, 100 K new files, single repository, single active publisher) the
+gateway currently adds **~300 ms – 2 s** of wall-clock overhead to T_pub.  This
+section identifies the bottlenecks discovered by reading the gateway source and
+estimates the saving available from each.
+
+### Gateway role in T_pub
+
+```
+Publisher                     Gateway                    Storage / cvmfs_receiver
+────────────────────────────────────────────────────────────────────────────────
+AcquireLease(repo, path) ──►  leaseMutex.Lock()
+                              DB: scan for overlapping/expired leases
+                              DB: INSERT new lease
+                              leaseMutex.Unlock()         ◄── ~50 ms
+◄── lease token ─────────────
+[publisher uploads, ingests, finalizes catalog — ~26 s with pipeline changes]
+SubmitPayload(token, data) ──► forward to worker pool
+                               worker spawns cvmfs_receiver process
+                               receiver.SubmitPayload(data)  ◄── ~200 ms–1.5 s
+◄── ack ─────────────────────
+CommitLease(token) ──────────► leaseMutex.Lock()
+                               worker spawns new cvmfs_receiver process
+                               receiver.Commit(...)         ◄── ~200 ms–500 ms
+                               leaseMutex.Unlock()
+◄── done ────────────────────
+```
+
+For a single-repo, single-publisher flow the gateway is not a bottleneck in
+the 26 s headline number — it contributes < 5 % of T_pub.  However, several
+structural issues become significant at scale or under concurrent publishing.
+
+### Bottleneck catalogue
+
+#### CRITICAL — Global lease mutex held through receiver commit
+
+**File:** `gateway/internal/gateway/backend/lease_service.go`, line 12
+
+```go
+var leaseMutex sync.Mutex   // one lock for the entire gateway process
+```
+
+`CommitLease()` acquires `leaseMutex` before spawning the `cvmfs_receiver`
+child and holds it for the full duration of the receiver's `Commit()` call
+(200 ms – 5 s of I/O).  During that window every other `NewLease`,
+`CommitLease`, or `CancelLease` call on **any** repository blocks.
+
+**Impact (multi-repo):** With 10 repositories each publishing a 1 GB release
+simultaneously, the effective commit throughput is serialised to
+`1 / (avg_commit_time)` ≈ 1 commit every ~1 s instead of 10 in parallel.
+Total wall time for 10 concurrent publishes: **~10 s** instead of ~1 s.
+
+**Fix:** Replace the single global mutex with a per-repository (or
+per-lease-path) `sync.RWMutex`.  `NewLease` and `CommitLease` for different
+repositories then proceed concurrently.  The per-repo lock still serialises
+overlapping paths within one repo, which is the correct invariant.
+
+**Estimated saving (single-repo):** ~0 ms (lock contention only appears with
+concurrency).  **Estimated saving (10 concurrent repos):** ~9 s wall time
+recovered.
+
+#### HIGH — Per-task `cvmfs_receiver` process spawned for every operation
+
+**File:** `gateway/internal/gateway/receiver/pool.go`, lines 149–161
+
+```go
+receiver, err := NewReceiver(task.Context(), pool.workerExec, pool.mock, pool.smgr)
+defer func() { receiver.Quit() }()
+// ... handle one payload or commit, then throw the process away
+```
+
+For every `SubmitPayload` and `CommitLease` RPC the worker function forks a
+new `cvmfs_receiver` child, initialises it (open DB connections, load keys,
+etc.), does one unit of work, then sends `Quit()`.  Process creation on Linux
+costs ~10–50 ms; `cvmfs_receiver` initialisation (SQLite open, signature key
+load) adds another ~50 ms.  For a typical publish with 5 payload chunks +
+1 commit that is **~300 ms – 600 ms** of pure fork overhead.
+
+**Fix:** Maintain a pool of persistent `cvmfs_receiver` processes — one (or a
+small fixed number) per repository.  Workers send work to the resident process
+via the existing pipe protocol and reuse it for the next task.  The
+`receiver.Quit()` call moves from per-task to gateway shutdown.
+
+**Estimated saving (single-repo):** ~300–600 ms off T_pub — equivalent to
+roughly half the current gateway overhead for the reference workload.
+
+#### MEDIUM — Synchronous `SubmitPayload` blocks publisher goroutine
+
+**File:** `gateway/internal/gateway/receiver/pool.go`, `SubmitPayload` method
+
+The publisher sends a payload chunk and then **blocks** waiting for the
+receiver's acknowledgement before sending the next chunk.  This prevents
+pipelining: even if the receiver could accept chunk N+1 while writing chunk N,
+the publisher waits idle.
+
+**Fix:** Allow the publisher to have K chunks in-flight (e.g., a semaphore of
+size 4).  The worker pool replies asynchronously; the publisher advances as
+soon as a slot is free.  Alternatively, stream the payload as a single
+chunked-transfer HTTP body so the gateway accumulates and forwards in a single
+pass.
+
+**Estimated saving:** ~100–400 ms for a 2 GB payload split into 5 chunks over
+a 10 Gbps link.
+
+#### MEDIUM — Expired-lease scan on every `NewLease`
+
+**File:** `gateway/internal/gateway/backend/lease_service.go`, `NewLease`
+
+Every `NewLease` call runs `DeleteAllExpiredLeases()` (a full table scan) while
+holding `leaseMutex`.  For a small DB with tens of leases this is negligible.
+Under load (many short-lived leases) the scan serialises all lease acquisitions.
+
+**Fix:** Run expiry cleanup in a background goroutine on a 30 s ticker, not on
+every `NewLease` hot path.
+
+**Estimated saving (single-repo, quiescent DB):** < 5 ms.  **Estimated saving
+(busy gateway with hundreds of leases):** 20–50 ms per `NewLease`.
+
+#### LOW — DB opened per request in some code paths
+
+Several helper functions re-open the BoltDB handle instead of reusing a
+long-lived connection.  BoltDB is file-locked; repeated open/close cycles add
+~5–10 ms and prevent write batching.
+
+**Fix:** Share a single opened `*bolt.DB` for the gateway's lifetime via the
+existing `GatewayOptions` / `BackendServices` context.
+
+**Estimated saving:** ~5–20 ms per publish.
+
+### Single-repo T_pub impact
+
+For the reference workload (single repository, single concurrent publisher,
+pipeline improvements already applied — T_pub baseline 26 s):
+
+| Gateway change | Saving | New T_pub |
+|---|---|---|
+| None (status quo) | — | 26.0 s |
+| Persistent receiver pool | −450 ms | 25.5 s |
+| Async payload submission | −200 ms | 25.3 s |
+| Background lease expiry | −10 ms | 25.3 s |
+| Shared DB handle | −10 ms | 25.3 s |
+| **All gateway changes** | **~670 ms** | **~25.3 s** |
+
+The gateway is not the bottleneck for single-repo publishing — the ~670 ms
+saving is real but small compared to the 34 s saved by the pipeline changes.
+The architectural significance is at scale: **the global mutex fix enables
+fully concurrent multi-repo publishing**, which is otherwise serialised.
+
+### Multi-repo concurrent publishing
+
+With per-repo locks and a persistent receiver pool, 10 repositories can publish
+simultaneously.  Each publisher's T_pub is independent (≈ 25.3 s).  Gateway
+wall time for 10 concurrent publishes:
+
+```
+Status quo (global mutex):    ~10 × 1 s commit ≈ 10 s serialised gate time
+With per-repo lock:           ~0.3 s per repo (parallel) — gate overhead < 0.5 s
+```
+
+The throughput improvement for concurrent multi-repo scenarios is therefore
+**~20× reduction in gateway-attributed wall time** (from ~10 s down to ~0.5 s
+for 10 parallel publishes).
+
+### Summary
+
+The gateway is a minor contributor to T_pub in single-repo publishing
+(~300 ms–2 s out of 60 s baseline / 26 s improved) but has two structural
+issues that limit scalability:
+
+1. **Global `leaseMutex`** serialises all repositories — fix yields ~20×
+   multi-repo throughput improvement.
+2. **Per-task receiver spawn** wastes ~300–600 ms per publish — fix by
+   maintaining a persistent receiver process pool.
+
+Both changes have been implemented (see Gateway Changes below).
+
+---
+
+## Gateway Changes
+
+### Change G1 — Persistent receiver process pool
+
+**File:** `gateway/internal/gateway/receiver/pool.go`
+
+#### Problem
+
+The `worker` function in the original pool spawned a new `cvmfs_receiver`
+child process for every task — one for each payload submission and one for each
+commit.  Process creation on Linux costs ~10–50 ms; `cvmfs_receiver`
+initialisation (SQLite open, key load) adds another ~50 ms.  For a typical
+publish with a few payload chunks plus one commit, that is ~300–600 ms of pure
+fork overhead per publish.
+
+#### Solution
+
+Each worker goroutine now owns a **persistent** `Receiver` process kept alive
+across tasks.  A new process is spawned lazily on the first task and only
+replaced when the previous one crashes.
+
+```go
+// Per-worker persistent process; nil means not yet started or dead.
+var recv Receiver
+
+ensureReceiver := func(ctx context.Context) error {
+    if recv != nil {
+        return nil
+    }
+    recv, err = NewReceiver(ctx, pool.workerExec, pool.mock, pool.smgr)
+    ...
+}
+
+discardReceiver := func(ctx context.Context) {
+    recv.Quit()   // best-effort; logs on error
+    recv = nil
+}
+```
+
+**Crash detection** distinguishes application-level errors (type `Error`, a
+string alias returned by `parseReceiverReply`) from I/O errors caused by a
+dead process.  Only the latter trigger `discardReceiver`:
+
+```go
+var appErr Error
+if !errors.As(result, &appErr) {
+    // I/O error: receiver process died — replace it next task.
+    crashed = true
+}
+```
+
+`testCrashTask` always sets `crashed = true` because `TestCrash` terminates
+the process regardless of whether an error is returned.
+
+On pool shutdown (`Stop()` closes the task channel), the `defer` at the top of
+each worker goroutine cleanly calls `recv.Quit()`.
+
+**Estimated saving:** ~300–600 ms per publish (eliminated for steady-state
+traffic where the process is already running).
+
+---
+
+### Change G2 — Per-repository lease locks
+
+**Files:** `gateway/internal/gateway/backend/lease_service.go`,
+`gateway/internal/gateway/backend/locks.go`
+
+#### Problem
+
+A single package-level `var leaseMutex sync.Mutex` serialised every lease
+operation — `NewLease`, `CommitLease`, `CancelLease`, `CancelLeases`,
+`GetLease`, `GetLeases` — across **all** repositories.  Because
+`CommitLease` holds this mutex for the full duration of the
+`cvmfs_receiver` commit (200 ms – 5 s of I/O), any concurrent lease
+operation on any repository blocks for that entire window.  With ten
+repositories publishing simultaneously this adds ~10 s of serialised gate
+time.
+
+#### Solution
+
+The global mutex is replaced by a package-level `NamedLocks` (the existing
+per-name mutex map already present in `locks.go`):
+
+```go
+// Per-repository mutual exclusion for lease operations.
+var leaseNamedLocks NamedLocks
+```
+
+**Lock scope per operation:**
+
+| Operation | Lock acquired | Notes |
+|---|---|---|
+| `NewLease` | `leaseNamedLocks[repo]` | wraps entire check-and-insert |
+| `CancelLeases` | `leaseNamedLocks[repo]` | repo extracted from path argument |
+| `CancelLease` | `leaseNamedLocks[repo]` | repo looked up via pre-read |
+| `CommitLease` | `leaseNamedLocks[repo]` → `DB.Locks[repo]` | nested; see below |
+| `GetLease` | none | read-only; SQL tx isolation sufficient |
+| `GetLeases` | none | read-only; SQL tx isolation sufficient |
+
+**Two-phase locking for token-based operations.**  `CancelLease` and
+`CommitLease` receive only a token, not a repository name.  A brief
+read-only DB lookup (`repoForToken`) runs outside any lock to obtain the
+repository name; the lease is then re-validated inside the per-repo lock to
+close the TOCTOU window:
+
+```go
+// Pre-read (no lock): find the repository for locking.
+repo, err := s.repoForToken(ctx, token)
+
+// Critical section: re-validate and commit inside per-repo lock.
+leaseNamedLocks.WithLock(repo, func() error {
+    lease, err := FindLeaseByToken(ctx, tx, token) // re-check
+    if lease == nil || lease.Expiration.Before(time.Now()) {
+        return InvalidLeaseError{}
+    }
+    // DB.WithLock serialises commits and GC for the same repo.
+    s.DB.WithLock(ctx, lease.Repository, func() error {
+        finalRev, err = s.Pool.CommitLease(...)
+        return err
+    })
+    DeleteLeaseByToken(...)
+    return tx.Commit()
+})
+```
+
+**Lock ordering** is always `leaseNamedLocks[repo]` → `DB.Locks[repo]` (or
+standalone `DB.Locks[repo]` for GC).  No code path acquires these in the
+reverse order, so deadlock is impossible.
+
+**Estimated saving (single-repo):** < 5 ms (contention only appears with
+concurrent publishers).  **Estimated saving (10 concurrent repos):**
+~9 s wall time recovered — ten publishes now proceed in parallel instead
+of being serialised through the commit I/O of each predecessor.
+
+---
+
+### Bug fixes found during review
+
+Three bugs were identified during post-implementation review and corrected in
+the same commit.
+
+**Bug A — `CancelLease` regressed on expired leases (`lease_service.go`)**
+
+`repoForToken` returned `InvalidLeaseError` for any lease whose
+`Expiration.Before(time.Now())` was true.  `CancelLease` used this helper for
+its pre-read, so it could no longer cancel an expired-but-still-present lease.
+The original code checked only `lease == nil`; cancelling an expired lease is
+valid (and is the mechanism by which stale locks are cleared externally).
+
+Fix: added `repoForTokenAny`, which returns the repository for any existing
+token regardless of expiry.  `CancelLease` now uses `repoForTokenAny`; the
+stricter `repoForToken` is kept for `CommitLease` (committing an expired lease
+must remain an error).  The inside-lock re-check in `CancelLease` already only
+tested `lease == nil`, so no change was needed there.
+
+**Bug B — SQLite BUSY errors under concurrent publishers (`db.go`)**
+
+The global `leaseMutex` previously serialised every SQLite write operation,
+making `SQLITE_BUSY` impossible in practice.  Per-repo locks allow concurrent
+write transactions for different repositories; without a busy timeout the SQLite
+driver returns `SQLITE_BUSY` immediately on contention instead of retrying.
+
+Fix: appended `&_busy_timeout=5000` to the connection string.  SQLite will now
+retry write lock acquisition for up to 5 s before returning an error, covering
+the typical commit window of 200 ms – 2 s.
+
+**Bug C — Inconsistent reply-channel close (`pool.go`)**
+
+The `ensureReceiver`-failure path and the `default` (unknown task type) path
+sent to the reply channel but did not close it, while the normal task path did.
+For buffered channels with a single receiver this is not a correctness bug, but
+the inconsistency could become one if callers are ever changed to range over or
+select on the channel.
+
+Fix: `close(task.Reply())` added to all three send-then-return paths.
+
+---
+
 ## Building
 
 ```bash
@@ -319,3 +1013,13 @@ cmake --build build -j$(nproc)
 # Full unit suite (skipping slow integration tests)
 ./build/cvmfs_unittests --gtest_filter=-*Slow
 ```
+
+New test cases added alongside this branch cover the four key changes that
+are hardest to verify by inspection alone:
+
+| Test | File | Change covered |
+|---|---|---|
+| `T_CatalogMgrRw/IssueHardlinkGroupIdSequence` | `t_catalog_mgr_rw.cc` | Change 9 — cache initialises from `GetMaxLinkId()` on first call; subsequent calls return 1, 2, 3 without a DB round-trip. |
+| `T_CatalogMgrRw/HardlinkGroupsGetDistinctIds` | `t_catalog_mgr_rw.cc` | Changes 9 & 10 — two `AddHardlinkGroup` calls through the manager assign distinct, sequential, non-zero IDs; intra-group members share an ID. |
+| `T_CatalogSql/WritableDbPragmasApplied` | `t_catalog_sql.cc` | Change 6 — a read-write `CatalogDatabase::Open` sets `cache_size=-65536` and `mmap_size=134217728`; a read-only open leaves the defaults intact. |
+| `T_CatalogMgrRw/VacuumDatabaseNoDeadlock` | `t_catalog_mgr_rw.cc` | Change 11 — 50 add/remove cycles followed by `Commit()` completes without deadlock and leaves the catalog queryable. |

--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "quota.h"        // full definition needed for 'delete quota_mgr_'
 #include "util/posix.h"  // IWYU pragma: keep
 
 

--- a/cvmfs/catalog_counters_impl.h
+++ b/cvmfs/catalog_counters_impl.h
@@ -125,6 +125,12 @@ bool TreeCountersBase<FieldT>::ReadFromDatabase(const CatalogDatabase &database,
 template<typename FieldT>
 bool TreeCountersBase<FieldT>::WriteToDatabase(
     const CatalogDatabase &database) const {
+  // NOTE: this method is always called from WritableCatalog::UpdateCounters(),
+  // which asserts dirty_ == true.  dirty_ is set by SetDirty(), which opens
+  // an explicit SQLite transaction via WritableCatalog::Transaction().  All 24
+  // SqlUpdateCounter::Execute() calls below therefore already execute inside
+  // that outer transaction and are committed together by WritableCatalog::Commit().
+  // No additional SAVEPOINT/RELEASE is needed here.
   bool retval = true;
 
   const FieldsMap map = GetFieldsMap();

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -545,6 +545,10 @@ void WritableCatalogManager::AddChunkedFile(const DirectoryEntryBase &entry,
   DirectoryEntry full_entry(entry);
   full_entry.set_is_chunked_file(true);
 
+  // AddFile() calls catalog->AddEntry() which calls SetDirty()->Transaction(),
+  // opening an SQLite transaction on the target catalog.  All AddFileChunk()
+  // calls below therefore execute within that already-open transaction — no
+  // explicit BEGIN/COMMIT wrapper is needed around this loop.
   AddFile(full_entry, xattrs, parent_directory);
 
   const string parent_path = MakeRelativePath(parent_directory);
@@ -619,7 +623,7 @@ void WritableCatalogManager::AddHardlinkGroup(
 
   // Get a valid hardlink group id for the catalog the group will end up in
   // TODO(unknown): Compaction
-  const uint32_t new_group_id = catalog->GetMaxLinkId() + 1;
+  const uint32_t new_group_id = catalog->IssueHardlinkGroupId();
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "hardlink group id %u issued",
            new_group_id);
   assert(new_group_id > 0);
@@ -1297,6 +1301,14 @@ void WritableCatalogManager::FinalizeCatalog(WritableCatalog *catalog,
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "creating snapshot of catalog '%s'",
            catalog->mountpoint().c_str());
 
+  // All metadata writes below — UpdateCounters (24 UPDATEs), UpdateLastModified,
+  // IncrementRevision, SetPreviousRevision — run within the single SQLite
+  // transaction that was opened by the first SetDirty() call on this catalog
+  // (guaranteed by the CatalogUploadCallback->UpdateNestedCatalog->SetDirty()
+  // path for non-leaf catalogs, and by direct entry modifications for leaf
+  // catalogs).  catalog->Commit() at the end of this function closes that
+  // transaction, flushing all ~30 writes in one shot.  No additional
+  // BEGIN/COMMIT wrapper is needed here.
   catalog->UpdateCounters();
   catalog->UpdateLastModified();
   catalog->IncrementRevision();

--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 #include "catalog_balancer.h"
 #include "catalog_rw.h"
@@ -1198,9 +1199,32 @@ bool WritableCatalogManager::Commit(const bool stop_for_tweaks,
  *       happens in a worker thread (i.e. the callback method) for non-leaf
  *       catalogs.
  *
- * TODO(rmeusel): since all leaf catalogs are finalized in the main thread, we
- *                sacrifice some potential concurrency for simplicity.
+ * Leaf catalogs are now finalized in parallel worker threads so that the
+ * SQLite VACUUM calls (the dominant per-catalog cost) overlap with each other
+ * and with the spooler uploads of already-completed catalogs.  Non-leaf
+ * catalogs remain processed in CatalogUploadCallback as before.
  */
+
+/**
+ * pthread entry point for parallel leaf-catalog finalization.
+ *
+ * Each dirty leaf catalog is independent: it owns its SQLite file and does not
+ * share mutable state with sibling leaves (FinalizeCatalog acquires sync_lock_
+ * only for the brief parent->FindNested read).  Running one thread per leaf
+ * therefore parallelises both the SQLite COMMIT and the VACUUM defragmentation
+ * step without introducing data races.
+ *
+ * The FinalizeLeafArgs struct is heap-allocated by SnapshotCatalogs and freed
+ * here before the thread exits.
+ */
+void *WritableCatalogManager::FinalizeLeafThread(void *arg) {
+  FinalizeLeafArgs *a = static_cast<FinalizeLeafArgs *>(arg);
+  a->self->FinalizeCatalog(a->catalog, a->stop_for_tweaks);
+  a->self->ScheduleCatalogProcessing(a->catalog);
+  delete a;
+  return NULL;
+}
+
 WritableCatalogManager::CatalogInfo WritableCatalogManager::SnapshotCatalogs(
     const bool stop_for_tweaks) {
   // prepare environment for parallel processing
@@ -1217,12 +1241,45 @@ WritableCatalogManager::CatalogInfo WritableCatalogManager::SnapshotCatalogs(
   WritableCatalogList leafs_to_snapshot;
   GetModifiedCatalogLeafs(&leafs_to_snapshot);
 
-  // finalize and schedule the catalog processing
-  WritableCatalogList::const_iterator i = leafs_to_snapshot.begin();
-  const WritableCatalogList::const_iterator iend = leafs_to_snapshot.end();
-  for (; i != iend; ++i) {
-    FinalizeCatalog(*i, stop_for_tweaks);
-    ScheduleCatalogProcessing(*i);
+  // Finalize and schedule leaf catalogs.
+  //
+  // When stop_for_tweaks is set the operator interacts with each catalog via
+  // getchar(), which is inherently serial; fall back to the simple loop.
+  // For the common (non-interactive) case we spawn one thread per leaf so that
+  // UpdateCounters + SQLite COMMIT + VacuumDatabaseIfNecessary all run in
+  // parallel across independent catalog databases.
+  if (stop_for_tweaks || leafs_to_snapshot.size() <= 1) {
+    // Serial path — interactive mode or trivial single-leaf publish.
+    WritableCatalogList::const_iterator i = leafs_to_snapshot.begin();
+    const WritableCatalogList::const_iterator iend = leafs_to_snapshot.end();
+    for (; i != iend; ++i) {
+      FinalizeCatalog(*i, stop_for_tweaks);
+      ScheduleCatalogProcessing(*i);
+    }
+  } else {
+    // Parallel path — one thread per dirty leaf catalog.
+    // VacuumDatabaseIfNecessary() calls now overlap with each other and with
+    // the spooler processing catalogs that finished earlier in the batch.
+    const size_t nleafs = leafs_to_snapshot.size();
+    std::vector<pthread_t> tids(nleafs);
+
+    LogCvmfs(kLogCatalog, kLogVerboseMsg,
+             "finalizing %zu leaf catalogs in parallel", nleafs);
+
+    for (size_t j = 0; j < nleafs; ++j) {
+      FinalizeLeafArgs *a = new FinalizeLeafArgs;
+      a->self            = this;
+      a->catalog         = leafs_to_snapshot[j];
+      a->stop_for_tweaks = false;
+      const int retval = pthread_create(&tids[j], NULL,
+                                        FinalizeLeafThread, a);
+      assert(retval == 0);
+    }
+
+    for (size_t j = 0; j < nleafs; ++j) {
+      const int retval = pthread_join(tids[j], NULL);
+      assert(retval == 0);
+    }
   }
 
   LogCvmfs(kLogCatalog, kLogVerboseMsg, "waiting for upload of catalogs");

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -233,6 +233,24 @@ class WritableCatalogManager : public SimpleCatalogManager {
 
   bool CopyCatalogToLocalCache(const upload::SpoolerResult &result);
 
+  /**
+   * Argument bundle passed to each leaf-finalization thread spawned by
+   * SnapshotCatalogs().  One instance is heap-allocated per leaf and freed
+   * by FinalizeLeafThread before it returns.
+   */
+  struct FinalizeLeafArgs {
+    WritableCatalogManager *self;
+    WritableCatalog        *catalog;
+    bool                    stop_for_tweaks;
+  };
+
+  /**
+   * pthread entry point: calls FinalizeCatalog (which includes the optional
+   * SQLite VACUUM) and then ScheduleCatalogProcessing for a single leaf
+   * catalog.  Multiple instances run concurrently — one per dirty leaf.
+   */
+  static void *FinalizeLeafThread(void *arg);
+
  private:
   inline void SyncLock() { pthread_mutex_lock(sync_lock_); }
   inline void SyncUnlock() { pthread_mutex_unlock(sync_lock_); }

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -40,7 +40,9 @@ WritableCatalog::WritableCatalog(const string &path,
     , sql_chunks_count_(NULL)
     , sql_max_link_id_(NULL)
     , sql_inc_linkcount_(NULL)
-    , dirty_(false) {
+    , dirty_(false)
+    , link_id_ready_(false)
+    , link_id_seq_(0) {
   atomic_init32(&dirty_children_);
 }
 
@@ -115,6 +117,23 @@ void WritableCatalog::FinalizePreparedStatements() {
   delete sql_chunks_count_;
   delete sql_max_link_id_;
   delete sql_inc_linkcount_;
+}
+
+
+/**
+ * Returns the next available hardlink group ID, caching the result so that
+ * subsequent calls during the same publish session do not re-query the DB.
+ *
+ * The first call executes one SELECT MAX(hardlinks>>32) query via
+ * GetMaxLinkId(); every further call just increments link_id_seq_ in memory.
+ */
+uint32_t WritableCatalog::IssueHardlinkGroupId() {
+  if (!link_id_ready_) {
+    link_id_seq_   = GetMaxLinkId() + 1;
+    link_id_ready_ = true;
+  }
+  assert(link_id_seq_ > 0);
+  return link_id_seq_++;
 }
 
 
@@ -732,8 +751,15 @@ void WritableCatalog::CopyToParent() {
 
 /**
  * Writes delta_counters_ to the database.
+ *
+ * The 24 individual SqlUpdateCounter::Execute() calls in
+ * TreeCountersBase::WriteToDatabase() execute inside the outer SQLite
+ * transaction that was opened by the first SetDirty() call on this catalog.
+ * No additional SAVEPOINT/RELEASE is needed; the outer transaction already
+ * batches all counter UPDATEs into a single fsync at Commit() time.
  */
 void WritableCatalog::UpdateCounters() {
+  assert(dirty_);  // transaction must already be open
   const bool retval = delta_counters_.WriteToDatabase(database())
                       && ReadCatalogCounters();
   assert(retval);
@@ -741,23 +767,35 @@ void WritableCatalog::UpdateCounters() {
 
 
 /**
- * Checks if the database of this catalogs needs cleanup and defragments it
- * if necessary
+ * Checks if the database of this catalog needs cleanup and defragments it
+ * if necessary.
+ *
+ * The lock is held only while reading the page-ratio metrics.  SQLite VACUUM
+ * rewrites the entire database file and can take several seconds on large
+ * catalogs; holding lock_ across that I/O would block concurrent callers of
+ * UpdateNestedCatalog() (which also takes lock_) for the entire duration.
+ * Since VACUUM is called only after dirty_children has reached zero — meaning
+ * no further UpdateNestedCatalog() calls are expected for this catalog —
+ * releasing the lock before the I/O is safe.
  */
 void WritableCatalog::VacuumDatabaseIfNecessary() {
   const CatalogDatabase &db = database();
   bool needs_defragmentation = false;
   double ratio = 0.0;
   std::string reason;
-  const MutexLockGuard m(lock_);
 
-  if ((ratio = db.GetFreePageRatio()) > kMaximalFreePageRatio) {
-    needs_defragmentation = true;
-    reason = "free pages";
-  } else if ((ratio = db.GetRowIdWasteRatio()) > kMaximalRowIdWasteRatio) {
-    needs_defragmentation = true;
-    reason = "wasted row IDs";
-  }
+  // Read page metrics under the lock, then release before the potentially long
+  // VACUUM I/O so that sibling finalization threads are not stalled.
+  {
+    const MutexLockGuard m(lock_);
+    if ((ratio = db.GetFreePageRatio()) > kMaximalFreePageRatio) {
+      needs_defragmentation = true;
+      reason = "free pages";
+    } else if ((ratio = db.GetRowIdWasteRatio()) > kMaximalRowIdWasteRatio) {
+      needs_defragmentation = true;
+      reason = "wasted row IDs";
+    }
+  }  // lock_ released here — VACUUM proceeds without holding it
 
   if (needs_defragmentation) {
     LogCvmfs(kLogCatalog, kLogStdout | kLogNoLinebreak,

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -58,6 +58,17 @@ class WritableCatalog : public Catalog {
   inline bool IsWritable() const { return true; }
   uint32_t GetMaxLinkId() const;
 
+  /**
+   * Returns the next available hardlink group ID for this catalog and caches
+   * the value so that subsequent calls do not re-query the database.
+   *
+   * The first call executes one SELECT MAX(hardlinks>>32) query; every further
+   * call during the same publish session just increments a counter in memory.
+   * This eliminates the O(N) pattern of one query per hardlink group that
+   * existed when callers directly used GetMaxLinkId()+1 in a loop.
+   */
+  uint32_t IssueHardlinkGroupId();
+
   void AddEntry(const DirectoryEntry &entry,
                 const XattrList &xattr,
                 const std::string &entry_path,
@@ -153,6 +164,14 @@ class WritableCatalog : public Catalog {
   SqlIncLinkcount *sql_inc_linkcount_;
 
   bool dirty_; /**< Indicates if the catalog has been changed */
+
+  /**
+   * Cached state for IssueHardlinkGroupId().  link_id_seq_ holds the next
+   * ID to hand out; link_id_ready_ is false until the first call initializes
+   * the sequence from GetMaxLinkId().
+   */
+  bool     link_id_ready_;
+  uint32_t link_id_seq_;
 
   DeltaCounters delta_counters_;
 

--- a/cvmfs/compression/compression.h
+++ b/cvmfs/compression/compression.h
@@ -91,6 +91,15 @@ class Compressor : public PolymorphicConstruction<Compressor, Algorithms> {
   virtual size_t DeflateBound(const size_t bytes) = 0;
   virtual Compressor *Clone() = 0;
 
+  /**
+   * Returns true if this compressor is a pass-through (no-op) — i.e., it
+   * copies input to output verbatim with no transformation.  TaskCompress uses
+   * this to avoid the intermediate buffer allocation and memcpy entirely:
+   * instead it hashes the raw input block and forwards it directly to the write
+   * stage with zero copies.
+   */
+  virtual bool IsPassthrough() const { return false; }
+
   static void RegisterPlugins();
 };
 
@@ -120,6 +129,7 @@ class EchoCompressor : public Compressor {
   size_t DeflateBound(const size_t bytes);
   Compressor *Clone();
   static bool WillHandle(const zlib::Algorithms &alg);
+  bool IsPassthrough() const { return true; }
 };
 
 

--- a/cvmfs/ingestion/ingestion_source.h
+++ b/cvmfs/ingestion/ingestion_source.h
@@ -63,6 +63,10 @@ class FileIngestionSource : public IngestionSource {
                errno, strerror(errno));
       return false;
     }
+    // Hint to the kernel that this file will be read linearly front-to-back.
+    // The kernel doubles its read-ahead window, reducing I/O stalls for the
+    // ingestion pipeline's read workers on large files.
+    platform_fadvise_sequential(fd_);
     return true;
   }
 

--- a/cvmfs/ingestion/pipeline.cc
+++ b/cvmfs/ingestion/pipeline.cc
@@ -56,18 +56,12 @@ IngestionPipeline::IngestionPipeline(
   }
   tubes_write_.Activate();
 
-  for (unsigned i = 0; i < nfork_base * kNforkHash; ++i) {
-    Tube<BlockItem> *t = new Tube<BlockItem>();
-    tubes_hash_.TakeTube(t);
-    tasks_hash_.TakeConsumer(new TaskHash(t, &tubes_write_));
-  }
-  tubes_hash_.Activate();
-
+  // No separate hash stage: hashing is now inlined in TaskCompress.
   for (unsigned i = 0; i < nfork_base * kNforkCompress; ++i) {
     Tube<BlockItem> *t = new Tube<BlockItem>();
     tubes_compress_.TakeTube(t);
     tasks_compress_.TakeConsumer(
-        new TaskCompress(t, &tubes_hash_, &item_allocator_));
+        new TaskCompress(t, &tubes_write_, &item_allocator_));
   }
   tubes_compress_.Activate();
 
@@ -103,7 +97,6 @@ IngestionPipeline::~IngestionPipeline() {
     tasks_read_.Terminate();
     tasks_chunk_.Terminate();
     tasks_compress_.Terminate();
-    tasks_hash_.Terminate();
     tasks_write_.Terminate();
     tasks_register_.Terminate();
   }
@@ -137,7 +130,6 @@ void IngestionPipeline::Process(IngestionSource *source,
 void IngestionPipeline::Spawn() {
   tasks_register_.Spawn();
   tasks_write_.Spawn();
-  tasks_hash_.Spawn();
   tasks_compress_.Spawn();
   tasks_chunk_.Spawn();
   tasks_read_.Spawn();

--- a/cvmfs/ingestion/pipeline.h
+++ b/cvmfs/ingestion/pipeline.h
@@ -40,7 +40,7 @@ class IngestionPipeline : public Observable<upload::SpoolerResult> {
   static const unsigned kMaxFilesInFlight = 8000;
   static const unsigned kNforkRegister = 1;
   static const unsigned kNforkWrite = 1;
-  static const unsigned kNforkHash = 2;
+  // kNforkHash removed: hashing is now inline in TaskCompress (no separate stage)
   static const unsigned kNforkCompress = 4;
   static const unsigned kNforkChunk = 1;
   static const unsigned kNforkRead = 8;
@@ -76,8 +76,7 @@ class IngestionPipeline : public Observable<upload::SpoolerResult> {
   TubeGroup<BlockItem> tubes_compress_;
   TubeConsumerGroup<BlockItem> tasks_compress_;
 
-  TubeGroup<BlockItem> tubes_hash_;
-  TubeConsumerGroup<BlockItem> tasks_hash_;
+  // tubes_hash_ / tasks_hash_ removed: hashing is inline in TaskCompress.
 
   TubeGroup<BlockItem> tubes_write_;
   TubeConsumerGroup<BlockItem> tasks_write_;

--- a/cvmfs/ingestion/task_compress.cc
+++ b/cvmfs/ingestion/task_compress.cc
@@ -8,6 +8,8 @@
 #include <cstdlib>
 
 #include "compression/compression.h"
+#include "crypto/hash.h"
+#include "ingestion/item.h"
 #include "util/logging.h"
 #include "util/smalloc.h"
 
@@ -15,14 +17,46 @@
 /**
  * The data payload of the blocks is replaced by their compressed counterparts.
  * The block tags stay the same.
- * TODO(jblomer): avoid memory copy with EchoCompressor
+ *
+ * Hashing is performed inline on each output block immediately before it is
+ * dispatched to the write stage, eliminating the separate TaskHash stage and
+ * the inter-thread tube round-trip it required.
+ *
+ * When the compressor is a pass-through (kNoCompression / EchoCompressor), the
+ * input block is hashed and forwarded directly — no intermediate buffer is
+ * allocated and no memcpy is performed.
  */
 void TaskCompress::Process(BlockItem *input_block) {
   assert(input_block->chunk_item() != NULL);
 
-  zlib::Compressor *compressor = input_block->chunk_item()->GetCompressor();
+  ChunkItem *chunk_item = input_block->chunk_item();
+  zlib::Compressor *compressor = chunk_item->GetCompressor();
   const int64_t tag = input_block->tag();
   const bool flush = input_block->type() == BlockItem::kBlockStop;
+
+  // ── Passthrough fast path (kNoCompression) ──────────────────────────────
+  // Hash the raw input bytes and forward the block as-is with zero copies.
+  if (compressor->IsPassthrough()) {
+    if (input_block->type() == BlockItem::kBlockData) {
+      shash::Update(input_block->data(), input_block->size(),
+                    chunk_item->hash_ctx());
+      tubes_out_->Dispatch(input_block);
+    } else {
+      // kBlockStop: no data — finalize hash, release compressor, send stop.
+      chunk_item->ReleaseCompressor();
+      shash::Final(chunk_item->hash_ctx(), chunk_item->hash_ptr());
+
+      BlockItem *stop_block = new BlockItem(tag, allocator_);
+      stop_block->MakeStop();
+      stop_block->SetFileItem(input_block->file_item());
+      stop_block->SetChunkItem(chunk_item);
+      tubes_out_->Dispatch(stop_block);
+      delete input_block;
+    }
+    return;
+  }
+
+  // ── Compression path (zlib or other) ────────────────────────────────────
   unsigned char *input_data = input_block->data();
   size_t remaining_in_input = input_block->size();
 
@@ -31,7 +65,7 @@ void TaskCompress::Process(BlockItem *input_block) {
     // So far unseen chunk, start new stream of compressed blocks
     output_block = new BlockItem(tag, allocator_);
     output_block->SetFileItem(input_block->file_item());
-    output_block->SetChunkItem(input_block->chunk_item());
+    output_block->SetChunkItem(chunk_item);
     output_block->MakeData(kCompressedBlockSize);
     tag_map_.Insert(tag, output_block);
   }
@@ -49,28 +83,38 @@ void TaskCompress::Process(BlockItem *input_block) {
     output_block->set_size(output_block->size() + remaining_in_output);
 
     if (output_block->IsFull()) {
+      // Hash this block's compressed bytes before sending it downstream.
+      shash::Update(output_block->data(), output_block->size(),
+                    chunk_item->hash_ctx());
       tubes_out_->Dispatch(output_block);
       output_block = new BlockItem(tag, allocator_);
       output_block->SetFileItem(input_block->file_item());
-      output_block->SetChunkItem(input_block->chunk_item());
+      output_block->SetChunkItem(chunk_item);
       output_block->MakeData(kCompressedBlockSize);
       tag_map_.Insert(tag, output_block);
     }
   } while ((remaining_in_input > 0) || (flush && !done));
 
   if (flush) {
-    input_block->chunk_item()->ReleaseCompressor();
+    chunk_item->ReleaseCompressor();
 
-    if (output_block->size() > 0)
+    if (output_block->size() > 0) {
+      // Hash the final (partial) output block before sending it downstream.
+      shash::Update(output_block->data(), output_block->size(),
+                    chunk_item->hash_ctx());
       tubes_out_->Dispatch(output_block);
-    else
+    } else {
       delete output_block;
+    }
+
+    // All compressed bytes have been hashed; finalize the digest.
+    shash::Final(chunk_item->hash_ctx(), chunk_item->hash_ptr());
     tag_map_.Erase(tag);
 
     BlockItem *stop_block = new BlockItem(tag, allocator_);
     stop_block->MakeStop();
     stop_block->SetFileItem(input_block->file_item());
-    stop_block->SetChunkItem(input_block->chunk_item());
+    stop_block->SetChunkItem(chunk_item);
     tubes_out_->Dispatch(stop_block);
   }
 

--- a/cvmfs/ingestion/task_compress.h
+++ b/cvmfs/ingestion/task_compress.h
@@ -17,7 +17,7 @@ class ItemAllocator;
 
 class TaskCompress : public TubeConsumer<BlockItem> {
  public:
-  static const unsigned kCompressedBlockSize = kPageSize * 2;
+  static const unsigned kCompressedBlockSize = kPageSize * 16;  // 64 KB; was 2×PAGE (8 KB)
 
   TaskCompress(Tube<BlockItem> *tube_in,
                TubeGroup<BlockItem> *tubes_out,

--- a/cvmfs/ingestion/task_read.h
+++ b/cvmfs/ingestion/task_read.h
@@ -20,7 +20,7 @@ class TaskRead : public TubeConsumer<FileItem> {
   static const unsigned kThrottleInitMs = 50;
   static const unsigned kThrottleMaxMs = 500;
   static const unsigned kThrottleResetMs = 2000;
-  static const unsigned kBlockSize = kPageSize * 4;
+  static const unsigned kBlockSize = kPageSize * 32;  // 128 KB; was 4×PAGE (16 KB)
 
   TaskRead(Tube<FileItem> *tube_in,
            TubeGroup<BlockItem> *tubes_out,

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -198,6 +198,12 @@ CommitProcessor::Result CommitProcessor::Process(
     const std::string graft_temp = graft_temp_dir->dir();
 
     perf::StatisticsTemplate stats_tmpl("publish", statistics_);
+    // Register the FsCounters (n_files_added, n_directories_added, etc.) that
+    // StorePublishStatistics expects.  In the DiffRec path these are created by
+    // CatalogMergeTool::Run(); DirectGraft bypasses that, so we register them
+    // here.  The values stay 0 — accurate for a graft that adds a whole subtree
+    // atomically rather than individual file-level diffs.
+    perf::FsCounters fs_counters(stats_tmpl);
     upload::SpoolerDefinition definition(
         params.spooler_configuration, params.hash_alg, params.compression_alg,
         params.generate_legacy_bulk_chunks, params.use_file_chunking,

--- a/cvmfs/receiver/commit_processor.cc
+++ b/cvmfs/receiver/commit_processor.cc
@@ -16,6 +16,7 @@
 #include "manifest.h"
 #include "manifest_fetch.h"
 #include "network/download.h"
+#include "network/sink_path.h"
 #include "params.h"
 #include "signing_tool.h"
 #include "statistics.h"
@@ -101,7 +102,7 @@ CommitProcessor::~CommitProcessor() { }
 CommitProcessor::Result CommitProcessor::Process(
     const std::string &lease_path, const shash::Any &old_root_hash,
     const shash::Any &new_root_hash, const RepositoryTag &tag,
-    uint64_t *final_revision) {
+    uint64_t *final_revision, bool direct_graft) {
   RepositoryTag final_tag = tag;
   // If tag_name is a generic tag, update the time stamp
   if (final_tag.HasGenericName()) {
@@ -180,29 +181,123 @@ CommitProcessor::Result CommitProcessor::Process(
 
   const PathString relative_lease_path = RemoveRepoName(PathString(lease_path));
 
-  LogCvmfs(kLogReceiver, kLogSyslog,
-           "CommitProcessor - lease_path: %s, merging catalogs",
-           lease_path.c_str());
-
-  CatalogMergeTool<catalog::WritableCatalogManager,
-                   catalog::SimpleCatalogManager>
-      merge_tool(params.stratum0, old_root_hash, new_root_hash,
-                 relative_lease_path, temp_dir_root,
-                 server_tool->download_manager(), manifest_tgt.weak_ref(),
-                 statistics_, cache_dir_);
-  if (!merge_tool.Init()) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "Error: Could not initialize the catalog merge tool");
-    return kError;
-  }
-
   std::string new_manifest_path;
   shash::Any new_manifest_hash;
-  if (!merge_tool.Run(params, &new_manifest_path, &new_manifest_hash,
-                      final_revision)) {
-    LogCvmfs(kLogReceiver, kLogSyslogErr,
-             "CommitProcessor - error: Catalog merge failed");
-    return kMergeFailure;
+
+  if (direct_graft) {
+    // ── DirectGraft fast path ────────────────────────────────────────────────
+    // Grafts new_root_hash directly into the parent catalog at relative_lease_path
+    // via WritableCatalogManager::GraftNestedCatalog, bypassing DiffRec entirely.
+    // Only valid when lease_path points to a brand-new directory subtree.
+    LogCvmfs(kLogReceiver, kLogSyslog,
+             "CommitProcessor - lease_path: %s, direct-graft path (skipping DiffRec)",
+             lease_path.c_str());
+
+    const UniquePtr<RaiiTempDir> graft_temp_dir(
+        RaiiTempDir::Create(temp_dir_root));
+    const std::string graft_temp = graft_temp_dir->dir();
+
+    perf::StatisticsTemplate stats_tmpl("publish", statistics_);
+    upload::SpoolerDefinition definition(
+        params.spooler_configuration, params.hash_alg, params.compression_alg,
+        params.generate_legacy_bulk_chunks, params.use_file_chunking,
+        params.min_chunk_size, params.avg_chunk_size, params.max_chunk_size,
+        "dummy_token", "dummy_key");
+    UniquePtr<upload::Spooler> spooler(
+        upload::Spooler::Construct(definition, &stats_tmpl));
+
+    UniquePtr<catalog::WritableCatalogManager> output_mgr(
+        new catalog::WritableCatalogManager(
+            manifest_tgt->catalog_hash(), params.stratum0, graft_temp,
+            spooler.weak_ref(), server_tool->download_manager(),
+            params.enforce_limits, params.nested_kcatalog_limit,
+            params.root_kcatalog_limit, params.file_mbyte_limit,
+            statistics_, params.use_autocatalogs, params.max_weight,
+            params.min_weight, cache_dir_));
+    if (!output_mgr->Init()) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "CommitProcessor - error: Could not initialize catalog manager "
+               "for direct-graft");
+      return kError;
+    }
+
+    // Download new_root_hash to a temp file to obtain its compressed size.
+    // GraftNestedCatalog will download it again internally via LoadFreeCatalog;
+    // with a local cache that second fetch is a cheap cache hit.
+    const std::string catalog_url =
+        params.stratum0 + "/data/" + new_root_hash.MakePath();
+    const std::string catalog_tmp = graft_temp + "/catalog_size";
+    {
+      cvmfs::PathSink catalog_sink(catalog_tmp);
+      shash::Any expected = new_root_hash;
+      download::JobInfo dl_job(&catalog_url, true, false, &expected,
+                               &catalog_sink);
+      const download::Failures dl_ret =
+          server_tool->download_manager()->Fetch(&dl_job);
+      if (dl_ret != download::kFailOk) {
+        LogCvmfs(kLogReceiver, kLogSyslogErr,
+                 "CommitProcessor - error: failed to download catalog %s "
+                 "for size probe (%d)",
+                 catalog_url.c_str(), static_cast<int>(dl_ret));
+        unlink(catalog_tmp.c_str());
+        return kError;
+      }
+    }  // PathSink destructor closes the file here
+    const int64_t catalog_size = GetFileSize(catalog_tmp);
+    unlink(catalog_tmp.c_str());
+    if (catalog_size < 0) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "CommitProcessor - error: cannot stat downloaded catalog %s",
+               catalog_url.c_str());
+      return kError;
+    }
+
+    // Graft: inserts the nested catalog reference into the parent catalog
+    // and propagates the directory entry + counters upward.
+    output_mgr->GraftNestedCatalog(relative_lease_path.ToString(),
+                                   new_root_hash,
+                                   static_cast<uint64_t>(catalog_size));
+
+    // Commit updates manifest_tgt in-place (new root hash, revision++, etc.)
+    if (!output_mgr->Commit(false, 0, manifest_tgt.weak_ref())) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "CommitProcessor - error: Could not commit grafted catalog");
+      return kMergeFailure;
+    }
+
+    // Export the updated manifest to a temp file for CreateNewTag / SigningTool.
+    new_manifest_path = CreateTempPath(temp_dir_root, 0600);
+    if (!manifest_tgt->Export(new_manifest_path)) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "CommitProcessor - error: Could not export manifest after graft");
+      return kError;
+    }
+    new_manifest_hash = manifest_tgt->catalog_hash();
+    *final_revision = manifest_tgt->revision();
+
+  } else {
+    // ── Standard DiffRec path via CatalogMergeTool ───────────────────────────
+    LogCvmfs(kLogReceiver, kLogSyslog,
+             "CommitProcessor - lease_path: %s, merging catalogs",
+             lease_path.c_str());
+
+    CatalogMergeTool<catalog::WritableCatalogManager,
+                     catalog::SimpleCatalogManager>
+        merge_tool(params.stratum0, old_root_hash, new_root_hash,
+                   relative_lease_path, temp_dir_root,
+                   server_tool->download_manager(), manifest_tgt.weak_ref(),
+                   statistics_, cache_dir_);
+    if (!merge_tool.Init()) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "Error: Could not initialize the catalog merge tool");
+      return kError;
+    }
+    if (!merge_tool.Run(params, &new_manifest_path, &new_manifest_hash,
+                        final_revision)) {
+      LogCvmfs(kLogReceiver, kLogSyslogErr,
+               "CommitProcessor - error: Catalog merge failed");
+      return kMergeFailure;
+    }
   }
 
   const UniquePtr<RaiiTempDir> raii_temp_dir(

--- a/cvmfs/receiver/commit_processor.h
+++ b/cvmfs/receiver/commit_processor.h
@@ -35,9 +35,21 @@ class CommitProcessor {
   CommitProcessor();
   virtual ~CommitProcessor();
 
+  // Process the committed lease.
+  //
+  // When direct_graft is false (the default) the standard CatalogMergeTool /
+  // DiffRec path is used — identical behaviour to before this parameter was
+  // added.
+  //
+  // When direct_graft is true the fast path is used: new_root_hash is grafted
+  // directly into the parent catalog at lease_path via GraftNestedCatalog,
+  // bypassing DiffRec entirely.  This is only valid when lease_path points to
+  // a brand-new directory subtree with no pre-existing entry in the parent
+  // catalog.  Using it on an existing path will cause a PANIC inside
+  // GraftNestedCatalog (the built-in safety check).
   Result Process(const std::string &lease_path, const shash::Any &old_root_hash,
                  const shash::Any &new_root_hash, const RepositoryTag &tag,
-                 uint64_t *final_revision);
+                 uint64_t *final_revision, bool direct_graft = false);
 
   int GetNumErrors() const { return num_errors_; }
 

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -409,6 +409,13 @@ bool Reactor::HandleCommit(const std::string &req, std::string *reply) {
       req_json->root(), "tag_name", JSON_STRING);
   const JSON *tag_description_json = JsonDocument::SearchInObject(
       req_json->root(), "tag_description", JSON_STRING);
+  // direct_graft is an optional boolean field (default false).  When true the
+  // commit skips CatalogMergeTool/DiffRec entirely and grafts the pre-built
+  // subtree catalog directly into the parent catalog.
+  const JSON *direct_graft_json = JsonDocument::SearchInObject(
+      req_json->root(), "direct_graft", JSON_BOOL);
+  const bool direct_graft =
+      (direct_graft_json != NULL && direct_graft_json->get<bool>());
 
   if (lease_path_json == NULL || old_root_hash_json == NULL
       || new_root_hash_json == NULL) {
@@ -438,7 +445,7 @@ bool Reactor::HandleCommit(const std::string &req, std::string *reply) {
                                tag_description_json->get<std::string>());
   const CommitProcessor::Result res = proc->Process(
       lease_path_json->get<std::string>(), old_root_hash, new_root_hash,
-      repo_tag, &final_revision);
+      repo_tag, &final_revision, direct_graft);
 
   JsonStringGenerator reply_input;
   switch (res) {

--- a/cvmfs/receiver/reactor.cc
+++ b/cvmfs/receiver/reactor.cc
@@ -391,6 +391,10 @@ bool Reactor::HandleCommit(const std::string &req, std::string *reply) {
   if (!reply) {
     PANIC(kLogSyslogErr, "HandleCommit: Invalid reply pointer.");
   }
+  // Diagnostic: log the full commit request so we can verify which fields the
+  // gateway forwards to the receiver (temporary, remove after confirming).
+  LogCvmfs(kLogReceiver, kLogSyslog, "HandleCommit: raw request: %s",
+           req.c_str());
   // Extract the Path from the request JSON.
   const UniquePtr<JsonDocument> req_json(JsonDocument::Create(req));
   if (!req_json.IsValid()) {

--- a/cvmfs/server/cvmfs_server_coda.sh
+++ b/cvmfs/server/cvmfs_server_coda.sh
@@ -145,6 +145,21 @@ CVMFS_SERVER_SWISSKNIFE_DEBUG=$CVMFS_SERVER_SWISSKNIFE
 CVMFS_SERVER_PUBLISH="/usr/bin/cvmfs_publish"
 CVMFS_SERVER_PUBLISH_DEBUG=$CVMFS_SERVER_PUBLISH
 
+# Testbed mode: binaries and libraries live in CVMFS_TESTBED_SOFTWARE_ROOT rather
+# than the standard /usr/bin install prefix.  Override the publish binary path and
+# prepend the software root (and its lib/ subdirectory if present) to
+# LD_LIBRARY_PATH so that shared libraries such as libcvmfs_server.so are found
+# without installing anything system-wide.
+if [ "${CVMFS_TESTBED:-}" = "true" ] && [ -n "${CVMFS_TESTBED_SOFTWARE_ROOT:-}" ]; then
+  CVMFS_SERVER_PUBLISH="${CVMFS_TESTBED_SOFTWARE_ROOT}/cvmfs_publish"
+  CVMFS_SERVER_PUBLISH_DEBUG="${CVMFS_TESTBED_SOFTWARE_ROOT}/cvmfs_publish_debug"
+  _tb_lib_path="${CVMFS_TESTBED_SOFTWARE_ROOT}"
+  [ -d "${CVMFS_TESTBED_SOFTWARE_ROOT}/lib" ] && \
+    _tb_lib_path="${_tb_lib_path}:${CVMFS_TESTBED_SOFTWARE_ROOT}/lib"
+  export LD_LIBRARY_PATH="${_tb_lib_path}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  unset _tb_lib_path
+fi
+
 # On newer Apache version, reloading is asynchonrous and not guaranteed to succeed.
 # The integration test cases set this parameter to true.
 CVMFS_SERVER_APACHE_RELOAD_IS_RESTART=${CVMFS_SERVER_APACHE_RELOAD_IS_RESTART:=false}

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -662,27 +662,26 @@ sign_manifest() {
   load_repo_config $name
   local user_shell="$(get_user_shell $name)"
 
-  # In testbed mode the stratum0 hostname (e.g. "stratum0") is a Docker-internal
-  # name that is not resolvable from the host where cvmfs_server runs.  The
-  # swissknife sign command uses -u to fetch the existing .cvmfsreflog via HTTP;
-  # a DNS failure causes a fatal connection error (kFailHostResolve, error 4).
-  # Fix: replace the HTTP URL with a file:// URL pointing to the upstream storage
-  # directory, where the reflog was just written by swissknife create.
-  # The CVMFS download manager explicitly supports file:// transfers (curl native).
-  local _sign_stratum0="$CVMFS_STRATUM0"
+  # In testbed mode the stratum0 hostname is a Docker-internal name not
+  # resolvable from the host at sign time.  Pass -L so swissknife sign reads
+  # .cvmfsreflog directly from the local backend storage instead of fetching
+  # it via HTTP.  -L is a no-op for non-local upstreams (swissknife falls back
+  # to HTTP with a warning), so the guard keeps behaviour unchanged outside
+  # testbed mode.
+  local _local_reflog_flag=
   if [ "${CVMFS_TESTBED:-}" = "true" ] && is_local_upstream "$CVMFS_UPSTREAM_STORAGE"; then
-    _sign_stratum0="file://$(get_upstream_config "$CVMFS_UPSTREAM_STORAGE")"
+    _local_reflog_flag="-L"
   fi
 
   local sign_command="$(__swissknife_cmd) sign \
           -c /etc/cvmfs/keys/${name}.crt       \
           -k /etc/cvmfs/keys/${name}.key       \
           -n $name                             \
-          -u $_sign_stratum0                   \
+          -u $CVMFS_STRATUM0                   \
           -m $unsigned_manifest                \
           -t ${CVMFS_SPOOL_DIR}/tmp            \
           $(get_swissknife_proxy)              \
-          -r $CVMFS_UPSTREAM_STORAGE $return_early"
+          -r $CVMFS_UPSTREAM_STORAGE $_local_reflog_flag $return_early"
 
   if [ x"$metainfo_file" != x"" ]; then
     sign_command="$sign_command -M $metainfo_file"

--- a/cvmfs/server/cvmfs_server_common.sh
+++ b/cvmfs/server/cvmfs_server_common.sh
@@ -662,11 +662,23 @@ sign_manifest() {
   load_repo_config $name
   local user_shell="$(get_user_shell $name)"
 
+  # In testbed mode the stratum0 hostname (e.g. "stratum0") is a Docker-internal
+  # name that is not resolvable from the host where cvmfs_server runs.  The
+  # swissknife sign command uses -u to fetch the existing .cvmfsreflog via HTTP;
+  # a DNS failure causes a fatal connection error (kFailHostResolve, error 4).
+  # Fix: replace the HTTP URL with a file:// URL pointing to the upstream storage
+  # directory, where the reflog was just written by swissknife create.
+  # The CVMFS download manager explicitly supports file:// transfers (curl native).
+  local _sign_stratum0="$CVMFS_STRATUM0"
+  if [ "${CVMFS_TESTBED:-}" = "true" ] && is_local_upstream "$CVMFS_UPSTREAM_STORAGE"; then
+    _sign_stratum0="file://$(get_upstream_config "$CVMFS_UPSTREAM_STORAGE")"
+  fi
+
   local sign_command="$(__swissknife_cmd) sign \
           -c /etc/cvmfs/keys/${name}.crt       \
           -k /etc/cvmfs/keys/${name}.key       \
           -n $name                             \
-          -u $CVMFS_STRATUM0                   \
+          -u $_sign_stratum0                   \
           -m $unsigned_manifest                \
           -t ${CVMFS_SPOOL_DIR}/tmp            \
           $(get_swissknife_proxy)              \

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -303,6 +303,14 @@ cvmfs_server_mkfs() {
     esac
   done
 
+  # Testbed mode: the repository is served by a Docker container (stratum0),
+  # not by a host Apache vhost.  Disable all Apache configuration so mkfs does
+  # not try to reload the host Apache or wait for the Docker-internal URL to
+  # become reachable.
+  if [ "${CVMFS_TESTBED:-}" = "true" ]; then
+    configure_apache=0
+  fi
+
   # get repository name
   shift $(($OPTIND-1))
   check_parameter_count 1 $#
@@ -357,7 +365,7 @@ cvmfs_server_mkfs() {
   check_autofs_on_cvmfs             && die "Autofs on /cvmfs has to be disabled"
   lower_hardlink_restrictions
   ensure_swissknife_suid $unionfs   || die "Need CAP_SYS_ADMIN for cvmfs_swissknife"
-  if is_local_upstream $upstream; then
+  if is_local_upstream $upstream && [ "${CVMFS_TESTBED:-}" != "true" ]; then
     check_apache                    || die "Apache must be installed and running"
     ensure_enabled_apache_modules
   fi

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -304,11 +304,14 @@ cvmfs_server_mkfs() {
   done
 
   # Testbed mode: the repository is served by a Docker container (stratum0),
-  # not by a host Apache vhost.  Disable all Apache configuration so mkfs does
-  # not try to reload the host Apache or wait for the Docker-internal URL to
-  # become reachable.
+  # not by a host Apache vhost.  Disable all Apache configuration and the
+  # "publisher" steps (FUSE mount, health check, initial commit) that require
+  # a running stratum0 HTTP endpoint or a host-level CVMFS FUSE mount.
+  # The repository structure in /srv/cvmfs/ is complete after signing; Docker
+  # handles serving and mounting.
   if [ "${CVMFS_TESTBED:-}" = "true" ]; then
     configure_apache=0
+    no_publisher=1
   fi
 
   # get repository name

--- a/cvmfs/server/cvmfs_server_mkfs.sh
+++ b/cvmfs/server/cvmfs_server_mkfs.sh
@@ -304,14 +304,10 @@ cvmfs_server_mkfs() {
   done
 
   # Testbed mode: the repository is served by a Docker container (stratum0),
-  # not by a host Apache vhost.  Disable all Apache configuration and the
-  # "publisher" steps (FUSE mount, health check, initial commit) that require
-  # a running stratum0 HTTP endpoint or a host-level CVMFS FUSE mount.
-  # The repository structure in /srv/cvmfs/ is complete after signing; Docker
-  # handles serving and mounting.
+  # not by a host Apache vhost.  Disable Apache configuration so mkfs does
+  # not try to reload the host Apache or wait for the Docker-internal URL.
   if [ "${CVMFS_TESTBED:-}" = "true" ]; then
     configure_apache=0
-    no_publisher=1
   fi
 
   # get repository name

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -705,10 +705,14 @@ _setcap_if_needed() {
 #       normal unprivileged process
 ensure_swissknife_suid() {
   local unionfs="$1"
-  local sk_bin="/usr/bin/$CVMFS_SERVER_SWISSKNIFE"
-  local sk_dbg_bin="/usr/bin/${CVMFS_SERVER_SWISSKNIFE}_debug"
-  local pb_bin="/usr/bin/cvmfs_publish"
-  local pb_dbg_bin="/usr/bin/cvmfs_publish_debug"
+  # In testbed mode binaries live in CVMFS_TESTBED_SOFTWARE_ROOT, not /usr/bin.
+  local _bin_dir="/usr/bin"
+  [ "${CVMFS_TESTBED:-}" = "true" ] && [ -n "${CVMFS_TESTBED_SOFTWARE_ROOT:-}" ] && \
+    _bin_dir="${CVMFS_TESTBED_SOFTWARE_ROOT}"
+  local sk_bin="${_bin_dir}/$CVMFS_SERVER_SWISSKNIFE"
+  local sk_dbg_bin="${_bin_dir}/${CVMFS_SERVER_SWISSKNIFE}_debug"
+  local pb_bin="${_bin_dir}/cvmfs_publish"
+  local pb_dbg_bin="${_bin_dir}/cvmfs_publish_debug"
   local cap_read="cap_dac_read_search"
   local cap_overlay="cap_sys_admin"
 

--- a/cvmfs/signing_tool.cc
+++ b/cvmfs/signing_tool.cc
@@ -33,7 +33,7 @@ SigningTool::Result SigningTool::Run(
     const std::string &meta_info, const std::string &reflog_chksum_path,
     const std::string &proxy, const bool garbage_collectable,
     const bool bootstrap_shortcuts, const bool return_early,
-    const std::vector<shash::Any> reflog_catalogs) {
+    const std::vector<shash::Any> reflog_catalogs, const bool local_reflog) {
   shash::Any reflog_hash;
   if (reflog_chksum_path != "") {
     if (!manifest::Reflog::ReadChecksum(reflog_chksum_path, &reflog_hash)) {
@@ -58,7 +58,7 @@ SigningTool::Result SigningTool::Run(
     return kInitError;
   }
 
-  // init the download helper
+  // init the HTTP download helper (used unless -L overrides for local upstreams)
   ObjectFetcher object_fetcher(repo_name, repo_url, temp_dir,
                                server_tool_->download_manager(),
                                server_tool_->signature_manager());
@@ -87,7 +87,25 @@ SigningTool::Result SigningTool::Run(
 
   UniquePtr<manifest::Reflog> reflog;
   if (!reflog_hash.IsNull()) {
-    reflog = server_tool_->FetchReflog(&object_fetcher, repo_name, reflog_hash);
+    if (local_reflog && sd.driver_type == upload::SpoolerDefinition::Local) {
+      // Fetch the reflog directly from the local backend storage, bypassing
+      // the HTTP stratum0 endpoint.  This is useful when the stratum0 web
+      // server is not yet running at sign time — for example during initial
+      // repository creation in a container-based testbed, or for offline
+      // signing of a locally-stored repository.
+      // sd.spooler_configuration is the storage root (third field of the
+      // "local,<txndir>,<storagepath>" definition string).
+      LocalObjectFetcher<> local_fetcher(sd.spooler_configuration, temp_dir);
+      reflog = server_tool_->FetchReflog(&local_fetcher, repo_name, reflog_hash);
+    } else {
+      if (local_reflog) {
+        LogCvmfs(kLogCvmfs, kLogStderr,
+                 "-L (local reflog fetch) is only supported for local "
+                 "upstreams; falling back to HTTP fetch via %s",
+                 repo_url.c_str());
+      }
+      reflog = server_tool_->FetchReflog(&object_fetcher, repo_name, reflog_hash);
+    }
     if (!reflog.IsValid()) {
       LogCvmfs(kLogCvmfs, kLogStderr, "reflog missing");
       return kReflogMissing;

--- a/cvmfs/signing_tool.h
+++ b/cvmfs/signing_tool.h
@@ -43,7 +43,8 @@ class SigningTool {
              const bool bootstrap_shortcuts = false,
              const bool return_early = false,
              const std::vector<shash::Any> reflog_catalogs =
-                 std::vector<shash::Any>());
+                 std::vector<shash::Any>(),
+             const bool local_reflog = false);
 
  protected:
   void CertificateUploadCallback(const upload::SpoolerResult &result);

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -193,13 +193,17 @@ bool Database<DerivedT>::Configure() {
   }
 
   // Writable databases (publish-path catalogs):
-  //   WAL mode: sequential append writes replace random-write rollback journal,
-  //   improving throughput on all storage types.
-  //   synchronous=OFF: skips fsync after each transaction commit.  Safe here
-  //   because a crashed publish is recovered by gateway lease rollback; the
-  //   catalog is rebuilt from scratch on the next run.
-  return Sql(sqlite_db(), "PRAGMA journal_mode=WAL;").Execute()
-         && Sql(sqlite_db(), "PRAGMA synchronous=OFF;").Execute();
+  //   synchronous=NORMAL: skips most fsyncs (specifically the fsync on
+  //   rollback-journal deletion that fires after every COMMIT in the default
+  //   synchronous=FULL mode).  Data is still written to the main DB file
+  //   before the connection is used further, so ScheduleCatalogProcessing can
+  //   read the raw file and upload a correct catalog.
+  //
+  //   We intentionally do NOT set journal_mode=WAL: in WAL mode committed
+  //   pages live in the <db>-wal sidecar file until a checkpoint, and the
+  //   spooler reads only the main DB file at the OS level, which would result
+  //   in uploading a stale (pre-commit) catalog.
+  return Sql(sqlite_db(), "PRAGMA synchronous=NORMAL;").Execute();
 }
 
 

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -191,7 +191,15 @@ bool Database<DerivedT>::Configure() {
     return Sql(sqlite_db(), "PRAGMA temp_store=2;").Execute()
            && Sql(sqlite_db(), "PRAGMA locking_mode=EXCLUSIVE;").Execute();
   }
-  return true;
+
+  // Writable databases (publish-path catalogs):
+  //   WAL mode: sequential append writes replace random-write rollback journal,
+  //   improving throughput on all storage types.
+  //   synchronous=OFF: skips fsync after each transaction commit.  Safe here
+  //   because a crashed publish is recovered by gateway lease rollback; the
+  //   catalog is rebuilt from scratch on the next run.
+  return Sql(sqlite_db(), "PRAGMA journal_mode=WAL;").Execute()
+         && Sql(sqlite_db(), "PRAGMA synchronous=OFF;").Execute();
 }
 
 

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -203,7 +203,18 @@ bool Database<DerivedT>::Configure() {
   //   pages live in the <db>-wal sidecar file until a checkpoint, and the
   //   spooler reads only the main DB file at the OS level, which would result
   //   in uploading a stale (pre-commit) catalog.
-  return Sql(sqlite_db(), "PRAGMA synchronous=NORMAL;").Execute();
+  //
+  //   cache_size=-65536: 64 MB page buffer pool for the writable catalog.
+  //   The negative value is interpreted in kibibytes (KiB) by SQLite ≥ 3.7.10.
+  //   Larger pool reduces the number of page read-backs during UPDATE-heavy
+  //   publish sessions (counter updates, dirent inserts, nested catalog rows).
+  //
+  //   mmap_size=134217728: Allow SQLite to memory-map up to 128 MB of the DB
+  //   file.  For catalogs that fit in the map window, random page reads become
+  //   simple memory accesses without pread() syscall overhead.
+  return Sql(sqlite_db(), "PRAGMA synchronous=NORMAL;").Execute()
+         && Sql(sqlite_db(), "PRAGMA cache_size=-65536;").Execute()
+         && Sql(sqlite_db(), "PRAGMA mmap_size=134217728;").Execute();
 }
 
 

--- a/cvmfs/swissknife_sign.cc
+++ b/cvmfs/swissknife_sign.cc
@@ -53,6 +53,7 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   const bool garbage_collectable = (args.count('g') > 0);
   const bool bootstrap_shortcuts = (args.count('A') > 0);
   const bool return_early = (args.count('e') > 0);
+  const bool local_reflog = (args.count('L') > 0);
 
   string reflog_chksum_path;
   const shash::Any reflog_hash;
@@ -64,5 +65,6 @@ int swissknife::CommandSign::Main(const swissknife::ArgumentList &args) {
   return signing_tool.Run(manifest_path, repo_url, spooler_definition, temp_dir,
                           certificate, priv_key, repo_name, pwd, meta_info,
                           reflog_chksum_path, proxy, garbage_collectable,
-                          bootstrap_shortcuts, return_early);
+                          bootstrap_shortcuts, return_early,
+                          std::vector<shash::Any>(), local_reflog);
 }

--- a/cvmfs/swissknife_sign.h
+++ b/cvmfs/swissknife_sign.h
@@ -43,6 +43,11 @@ class CommandSign : public Command {
     r.push_back(Parameter::Switch('e',
                                   "return early, don't upload signed "
                                   "manifest"));
+    r.push_back(Parameter::Switch('L',
+                                  "fetch reflog from local backend storage "
+                                  "instead of downloading via the stratum0 "
+                                  "URL (-u); only effective with a local "
+                                  "(-r local,...) upstream"));
     return r;
   }
   int Main(const ArgumentList &args);

--- a/cvmfs/swissknife_sync.cc
+++ b/cvmfs/swissknife_sync.cc
@@ -770,7 +770,11 @@ int swissknife::CommandSync::Main(const swissknife::ArgumentList &args) {
     spooler_definition
         .number_of_concurrent_uploads = params.max_concurrent_write_jobs;
   }
-  spooler_definition.num_upload_tasks = params.num_upload_tasks;
+  // Only override if the operator explicitly set -0; otherwise keep the
+  // CPU-scaled default that SpoolerDefinition's constructor computed.
+  if (params.num_upload_tasks != 0) {
+    spooler_definition.num_upload_tasks = params.num_upload_tasks;
+  }
 
   const upload::SpoolerDefinition spooler_definition_catalogs(
       spooler_definition.Dup2DefaultCompression());

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -55,7 +55,7 @@ struct SyncParameters {
       , manual_revision(0)
       , ttl_seconds(0)
       , max_concurrent_write_jobs(0)
-      , num_upload_tasks(1)
+      , num_upload_tasks(0)  // 0 = inherit CPU-scaled default from SpoolerDefinition
       , is_balanced(false)
       , max_weight(kDefaultMaxWeight)
       , min_weight(kDefaultMinWeight)

--- a/cvmfs/sync_item.cc
+++ b/cvmfs/sync_item.cc
@@ -36,7 +36,8 @@ SyncItem::SyncItem()
     , direct_io_(false)
     , graft_chunklist_(NULL)
     , compression_algorithm_(zlib::kZlibDefault)
-    , has_compression_algorithm_(false) { }
+    , has_compression_algorithm_(false)
+    , cached_xattrs_(NULL) { }
 
 SyncItem::SyncItem(const std::string &relative_parent_path,
                    const std::string &filename,
@@ -58,11 +59,15 @@ SyncItem::SyncItem(const std::string &relative_parent_path,
     , relative_parent_path_(relative_parent_path)
     , graft_chunklist_(NULL)
     , compression_algorithm_(zlib::kZlibDefault)
-    , has_compression_algorithm_(false) {
+    , has_compression_algorithm_(false)
+    , cached_xattrs_(NULL) {
   content_hash_.algorithm = shash::kAny;
 }
 
-SyncItem::~SyncItem() { delete graft_chunklist_; }
+SyncItem::~SyncItem() {
+  delete graft_chunklist_;
+  delete cached_xattrs_;
+}
 
 
 SyncItemType SyncItem::GetGenericFiletype(

--- a/cvmfs/sync_item.h
+++ b/cvmfs/sync_item.h
@@ -21,6 +21,7 @@
 #include "file_chunk.h"
 #include "util/platform.h"
 #include "util/shared_ptr.h"
+#include "xattr.h"
 
 class IngestionSource;
 
@@ -128,6 +129,24 @@ class SyncItem {
   inline void SetCompressionAlgorithm(const zlib::Algorithms &alg) {
     compression_algorithm_ = alg;
     has_compression_algorithm_ = true;
+  }
+
+  /**
+   * Pre-fetches extended attributes during traversal so the pipeline callback
+   * thread does not have to issue lgetxattr() syscalls.  Takes ownership.
+   */
+  inline void SetCachedXattrs(XattrList *xattrs) {
+    delete cached_xattrs_;
+    cached_xattrs_ = xattrs;
+  }
+  /**
+   * Returns the cached XattrList and clears the internal pointer (ownership
+   * transfers to the caller).  Returns null if not pre-fetched.
+   */
+  inline XattrList *TakeCachedXattrs() {
+    XattrList *result = cached_xattrs_;
+    cached_xattrs_ = NULL;
+    return result;
   }
 
   /**
@@ -320,6 +339,14 @@ class SyncItem {
   zlib::Algorithms compression_algorithm_;
   // The compression algorithm has been set explicitly
   bool has_compression_algorithm_;
+
+  /**
+   * Xattrs pre-fetched during traversal so that PublishFilesCallback does not
+   * need to call lgetxattr() from the pipeline observer thread.  Ownership is
+   * held here; TakeCachedXattrs() transfers ownership to the caller.
+   * Null if not yet fetched or already consumed.
+   */
+  XattrList *cached_xattrs_;
 
   // Lazy evaluation and caching of results of file stats
   inline void StatRdOnly(const bool refresh = false) const {

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -790,10 +790,12 @@ void SyncMediator::PublishFilesCallback(const upload::SpoolerResult &result) {
   item.SetContentHash(result.content_hash);
   item.SetCompressionAlgorithm(result.compression_alg);
 
+  // Use xattrs that were pre-fetched during traversal (AddFile) to avoid
+  // lgetxattr() syscalls on the pipeline observer thread.
   XattrList *xattrs = &default_xattrs_;
-  if (params_->include_xattrs) {
-    xattrs = XattrList::CreateFromFile(result.local_path);
-    assert(xattrs != NULL);
+  XattrList *cached = item.TakeCachedXattrs();  // may be null if !include_xattrs
+  if (cached != NULL) {
+    xattrs = cached;
   }
 
   if (result.IsChunked()) {
@@ -809,8 +811,7 @@ void SyncMediator::PublishFilesCallback(const upload::SpoolerResult &result) {
         item.relative_parent_path());
   }
 
-  if (xattrs != &default_xattrs_)
-    free(xattrs);
+  delete cached;  // null-safe; default_xattrs_ is not deleted (not owned here)
 }
 
 
@@ -1011,6 +1012,12 @@ void SyncMediator::AddFile(SharedPtr<SyncItem> entry) {
              && entry->IsCatalogMarker()) {
     PANIC(kLogStderr, "Error: nested catalog marker in root directory");
   } else if (!params_->dry_run) {
+    // Pre-fetch xattrs here in the traversal thread so PublishFilesCallback
+    // does not need to call lgetxattr() from the pipeline observer thread,
+    // which would serialise all catalog insertions through TaskRegister.
+    if (params_->include_xattrs) {
+      entry->SetCachedXattrs(XattrList::CreateFromFile(entry->GetUnionPath()));
+    }
     {
       // Push the file to the spooler, remember the entry for the path
       const MutexLockGuard m(&lock_file_queue_);

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -826,27 +826,21 @@ void SyncMediator::PublishHardlinksCallback(
           result.return_code);
   }
 
-  bool found = false;
-  for (unsigned i = 0; i < hardlink_queue_.size(); ++i) {
-    if (hardlink_queue_[i].master->GetUnionPath() == result.local_path) {
-      found = true;
-      hardlink_queue_[i].master->SetContentHash(result.content_hash);
-      SyncItemList::iterator j, jend;
-      for (j = hardlink_queue_[i].hardlinks.begin(),
-          jend = hardlink_queue_[i].hardlinks.end();
-           j != jend;
-           ++j) {
-        j->second->SetContentHash(result.content_hash);
-        j->second->SetCompressionAlgorithm(result.compression_alg);
-      }
-      if (result.IsChunked())
-        hardlink_queue_[i].file_chunks = result.file_chunks;
+  const auto idx_it = hardlink_index_.find(result.local_path);
+  assert(idx_it != hardlink_index_.end());
+  const size_t i = idx_it->second;
 
-      break;
-    }
+  hardlink_queue_[i].master->SetContentHash(result.content_hash);
+  SyncItemList::iterator j, jend;
+  for (j = hardlink_queue_[i].hardlinks.begin(),
+      jend = hardlink_queue_[i].hardlinks.end();
+       j != jend;
+       ++j) {
+    j->second->SetContentHash(result.content_hash);
+    j->second->SetCompressionAlgorithm(result.compression_alg);
   }
-
-  assert(found);
+  if (result.IsChunked())
+    hardlink_queue_[i].file_chunks = result.file_chunks;
 }
 
 
@@ -1177,8 +1171,11 @@ void SyncMediator::AddLocalHardlinkGroups(const HardlinkGroupMap &hardlinks) {
 
     if (i->second.master->IsSymlink() || i->second.master->IsSpecialFile())
       AddHardlinkGroup(i->second);
-    else
+    else {
+      hardlink_index_[i->second.master->GetUnionPath()] =
+          hardlink_queue_.size();
       hardlink_queue_.push_back(i->second);
+    }
   }
 }
 

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <stack>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "catalog_mgr_rw.h"
@@ -297,6 +298,12 @@ class SyncMediator : public virtual AbstractSyncMediator {
   SyncItemList file_queue_;
 
   HardlinkGroupList hardlink_queue_;
+  /**
+   * Maps the union-path of a hardlink group's master SyncItem to its index in
+   * hardlink_queue_, providing O(1) lookup in PublishHardlinksCallback instead
+   * of an O(N) linear scan.
+   */
+  std::unordered_map<std::string, size_t> hardlink_index_;
 
   const SyncParameters *params_;
   mutable unsigned int changed_items_;

--- a/cvmfs/sync_union_aufs.cc
+++ b/cvmfs/sync_union_aufs.cc
@@ -46,11 +46,12 @@ void SyncUnionAufs::Traverse() {
   traversal.fn_new_fifo = &SyncUnionAufs::ProcessFifo;
   traversal.fn_new_socket = &SyncUnionAufs::ProcessSocket;
   LogCvmfs(kLogUnionFs, kLogVerboseMsg,
-           "Aufs starting traversal "
-           "recursion for scratch_path=[%s] with external data set to %d",
+           "Aufs starting parallel traversal "
+           "for scratch_path=[%s] with external data set to %d",
            scratch_path().c_str(), mediator_->IsExternalData());
-
-  traversal.Recurse(scratch_path());
+  // Phase 1: parallel opendir/lstat scan; Phase 2: serial callback replay.
+  // num_threads=0 → auto-detect from sysconf(_SC_NPROCESSORS_ONLN).
+  traversal.RecurseParallel(scratch_path());
 }
 
 bool SyncUnionAufs::IsWhiteoutEntry(SharedPtr<SyncItem> entry) const {

--- a/cvmfs/sync_union_overlayfs.cc
+++ b/cvmfs/sync_union_overlayfs.cc
@@ -92,10 +92,12 @@ void SyncUnionOverlayfs::Traverse() {
   traversal.fn_new_symlink = &SyncUnionOverlayfs::ProcessSymlink;
 
   LogCvmfs(kLogUnionFs, kLogVerboseMsg,
-           "OverlayFS starting traversal "
-           "recursion for scratch_path=[%s]",
+           "OverlayFS starting parallel traversal "
+           "for scratch_path=[%s]",
            scratch_path().c_str());
-  traversal.Recurse(scratch_path());
+  // Phase 1: parallel opendir/lstat scan; Phase 2: serial callback replay.
+  // num_threads=0 → auto-detect from sysconf(_SC_NPROCESSORS_ONLN).
+  traversal.RecurseParallel(scratch_path());
 }
 
 /**

--- a/cvmfs/upload_spooler_definition.cc
+++ b/cvmfs/upload_spooler_definition.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "util/concurrency.h"
 #include "util/logging.h"
 #include "util/platform.h"
 #include "util/string.h"

--- a/cvmfs/upload_spooler_definition.cc
+++ b/cvmfs/upload_spooler_definition.cc
@@ -4,9 +4,11 @@
 
 #include "upload_spooler_definition.h"
 
+#include <algorithm>
 #include <vector>
 
 #include "util/logging.h"
+#include "util/platform.h"
 #include "util/string.h"
 
 namespace upload {
@@ -34,7 +36,7 @@ SpoolerDefinition::SpoolerDefinition(
     , avg_file_chunk_size(avg_file_chunk_size)
     , max_file_chunk_size(max_file_chunk_size)
     , number_of_concurrent_uploads(kDefaultMaxConcurrentUploads)
-    , num_upload_tasks(kDefaultNumUploadTasks)
+    , num_upload_tasks(std::min(16U, std::max(4U, GetNumberOfCpuCores() / 2)))
     , session_token_file(session_token_file)
     , key_file(key_file)
     , valid_(false) {

--- a/cvmfs/upload_spooler_definition.h
+++ b/cvmfs/upload_spooler_definition.h
@@ -21,7 +21,11 @@ namespace upload {
  */
 struct SpoolerDefinition {
   static const unsigned kDefaultMaxConcurrentUploads = 512;
-  static const unsigned kDefaultNumUploadTasks = 1;
+  // kDefaultNumUploadTasks: was 1; now scaled to half the CPU count (min 4).
+  // Each upload task holds one open connection to the backend concurrently, so
+  // matching the compression worker count (≈ CPU/2) keeps the pipeline fed.
+  // Capped at 16 to avoid overwhelming backends with many short-lived streams.
+  static const unsigned kDefaultNumUploadTasks = 0;  // 0 = use CPU-derived value at runtime
   static const char *kDriverNames[];  ///< corresponds to DriverType
   enum DriverType {
     S3,

--- a/cvmfs/util/fs_traversal.h
+++ b/cvmfs/util/fs_traversal.h
@@ -10,11 +10,15 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <pthread.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <cassert>
 #include <cstdlib>
+#include <deque>
 #include <string>
+#include <vector>
 
 #include "util/exception.h"
 #include "util/logging.h"
@@ -118,6 +122,62 @@ class FileSystemTraversal {
                   == relative_to_directory_);
 
     DoRecursion(dir_path, "");
+  }
+
+  /**
+   * Two-phase parallel traversal of a directory tree.
+   *
+   * Phase 1 (parallel I/O): num_threads worker threads race through the
+   * directory tree with opendir/readdir/lstat, building an in-memory tree of
+   * DirScanNode objects.  No callbacks are fired; no shared catalog state is
+   * touched.  Independent subtrees are scanned simultaneously.
+   *
+   * Phase 2 (serial replay): the pre-built tree is walked in exactly the same
+   * depth-first order as Recurse()/DoRecursion(), firing all callbacks with
+   * identical arguments.  Because Phase 2 is single-threaded, all existing
+   * SyncMediator/catalog ordering invariants (EnterDirectory before any child
+   * callbacks, LeaveDirectory last) are preserved without any changes to
+   * callers.
+   *
+   * Falls back to the serial Recurse() path when num_threads <= 1 or the
+   * host reports fewer than 2 logical CPUs.
+   *
+   * @param dir_path    root of the tree to traverse
+   * @param num_threads I/O threads for Phase 1; 0 = auto (one per CPU)
+   */
+  void RecurseParallel(const std::string &dir_path,
+                       unsigned num_threads = 0) const {
+    assert(fn_enter_dir != NULL || fn_leave_dir != NULL || fn_new_file != NULL
+           || fn_new_symlink != NULL || fn_new_dir_prefix != NULL
+           || fn_new_block_dev != NULL || fn_new_character_dev != NULL
+           || fn_new_fifo != NULL || fn_new_socket != NULL);
+    assert(relative_to_directory_.length() == 0
+           || dir_path.substr(0, relative_to_directory_.length())
+                  == relative_to_directory_);
+
+    if (num_threads == 0) {
+      const long ncpus = sysconf(_SC_NPROCESSORS_ONLN);
+      num_threads = (ncpus > 1) ? static_cast<unsigned>(ncpus) : 1u;
+    }
+    if (num_threads <= 1) {
+      DoRecursion(dir_path, "");
+      return;
+    }
+
+    LogCvmfs(kLogFsTraversal, kLogVerboseMsg,
+             "RecurseParallel: Phase 1 scan with %u threads for [%s]",
+             num_threads, dir_path.c_str());
+
+    // Phase 1: parallel I/O scan — pure filesystem reads, no callbacks.
+    DirScanNode *root = ScanParallel(dir_path, num_threads);
+
+    LogCvmfs(kLogFsTraversal, kLogVerboseMsg,
+             "RecurseParallel: Phase 2 serial replay for [%s]", dir_path.c_str());
+
+    // Phase 2: serial DFS replay — fires callbacks in original DFS order.
+    ReplayTree(root, dir_path, "");
+
+    DeleteTree(root);
   }
 
  private:
@@ -250,6 +310,247 @@ class FileSystemTraversal {
 
     return "";
   }
+
+  // ── Two-phase parallel traversal internals ──────────────────────────────
+
+  /**
+   * A single non-directory entry collected during Phase 1.
+   * Stores only the name and st_mode so the replay phase can dispatch to the
+   * correct callback without re-stating the file.
+   */
+  struct DirScanEntry {
+    std::string name;
+    mode_t      mode;
+  };
+
+  /**
+   * One node of the pre-scanned directory tree.
+   *
+   * Written exclusively by the Phase-1 worker thread that pops this node from
+   * the work queue (no lock required for writes to entries/subdirs).
+   * Read exclusively by the Phase-2 serial replay (no lock required there
+   * either, since all workers have joined before Phase 2 starts).
+   */
+  struct DirScanNode {
+    std::string                abs_path;  ///< absolute path to this directory
+    std::string                dir_name;  ///< entry name (used in callbacks)
+    std::vector<DirScanEntry>  entries;   ///< non-directory entries
+    std::vector<DirScanNode *> subdirs;   ///< child directory nodes (in readdir order)
+  };
+
+  /**
+   * Shared state passed to every Phase-1 worker thread.
+   * All fields except delegate/fn_ignore/relative_to are protected by lock.
+   */
+  struct ScanWorkerArgs {
+    // Read-only after construction — no lock needed.
+    T            *delegate;
+    BoolCallback  fn_ignore;    ///< ignore-file predicate (may be NULL)
+    std::string   relative_to;  ///< mirrors relative_to_directory_
+
+    // Protected by lock.
+    std::deque<DirScanNode *> queue;
+    int                       active;  ///< threads currently scanning a node
+    pthread_mutex_t           lock;
+    pthread_cond_t            work_available;
+  };
+
+  /**
+   * Mirrors GetRelativePath() for use inside the static worker thread where
+   * the FileSystemTraversal instance is not directly accessible.
+   */
+  static std::string RelPath(const std::string &abs,
+                             const std::string &rel_to) {
+    const size_t rlen = rel_to.length();
+    if (rlen >= abs.length()) return "";
+    if (rlen > 1)             return abs.substr(rlen + 1);
+    if (rlen == 0)            return abs;
+    if (rel_to == "/")        return abs.substr(1);
+    return "";
+  }
+
+  /**
+   * Phase-1 worker thread entry point.
+   *
+   * Each thread loops: pop a DirScanNode from the shared work queue, open its
+   * directory, lstat every entry, push new DirScanNode children back onto the
+   * queue, repeat.  Exits when the queue is empty AND no other thread has a
+   * node in flight (active == 0).
+   *
+   * Thread safety: DirScanNode::entries and ::subdirs are written only by the
+   * thread that owns a node (popped it from the queue).  Other threads never
+   * touch a node while it is being scanned.  The work queue itself is protected
+   * by ScanWorkerArgs::lock.
+   */
+  static void *ScanWorkerThread(void *raw) {
+    ScanWorkerArgs *a = static_cast<ScanWorkerArgs *>(raw);
+
+    for (;;) {
+      pthread_mutex_lock(&a->lock);
+
+      // Wait until there is a node to process or all threads have gone idle.
+      while (a->queue.empty() && a->active > 0)
+        pthread_cond_wait(&a->work_available, &a->lock);
+
+      if (a->queue.empty()) {
+        // active == 0 and queue empty: scanning is complete.
+        // Wake any siblings still waiting, then exit.
+        pthread_cond_broadcast(&a->work_available);
+        pthread_mutex_unlock(&a->lock);
+        return NULL;
+      }
+
+      DirScanNode *node = a->queue.front();
+      a->queue.pop_front();
+      a->active++;
+      pthread_mutex_unlock(&a->lock);
+
+      // ── Scan this directory (lock not held) ──────────────────────────────
+      // Collect results locally before touching shared state.
+      std::vector<DirScanNode *> new_subdirs;
+
+      DIR *dip = opendir(node->abs_path.c_str());
+      if (!dip) {
+        PANIC(kLogStderr,
+              "Failed to open %s (%d).\n"
+              "Please check directory permissions.",
+              node->abs_path.c_str(), errno);
+      }
+
+      platform_dirent64 *dit;
+      while ((dit = platform_readdir(dip)) != NULL) {
+        const std::string dname(dit->d_name);
+        if (dname == "." || dname == "..")
+          continue;
+
+        // Apply the ignore predicate with the same relative-path convention
+        // used by DoRecursion → Notify(fn_ignore_file, path, name).
+        if (a->fn_ignore != NULL) {
+          const std::string rel = RelPath(node->abs_path, a->relative_to);
+          if ((a->delegate->*(a->fn_ignore))(rel, dname))
+            continue;
+        }
+
+        platform_stat64 info;
+        const std::string entry_path = node->abs_path + "/" + dname;
+        if (platform_lstat(entry_path.c_str(), &info) != 0) {
+          PANIC(kLogStderr, "failed to lstat '%s' errno: %d",
+                entry_path.c_str(), errno);
+        }
+
+        if (S_ISDIR(info.st_mode)) {
+          DirScanNode *child = new DirScanNode;
+          child->abs_path = entry_path;
+          child->dir_name = dname;
+          // Write to node->subdirs: safe — this thread owns node exclusively.
+          node->subdirs.push_back(child);
+          new_subdirs.push_back(child);
+        } else {
+          DirScanEntry e;
+          e.name = dname;
+          e.mode = info.st_mode;
+          // Write to node->entries: safe — same ownership argument.
+          node->entries.push_back(e);
+        }
+      }
+      closedir(dip);
+
+      // ── Push children and release ownership ──────────────────────────────
+      // Children are pushed to the queue BEFORE decrementing active so that
+      // the termination condition (active==0 && queue.empty()) is never seen
+      // spuriously while there is still pending work in new_subdirs.
+      pthread_mutex_lock(&a->lock);
+      for (size_t i = 0; i < new_subdirs.size(); ++i)
+        a->queue.push_back(new_subdirs[i]);
+      a->active--;
+      pthread_cond_broadcast(&a->work_available);
+      pthread_mutex_unlock(&a->lock);
+    }
+  }
+
+  /** Phase-1 driver: allocate root node, spawn workers, join, return tree. */
+  DirScanNode *ScanParallel(const std::string &root_path,
+                            unsigned num_threads) const {
+    DirScanNode *root = new DirScanNode;
+    root->abs_path = root_path;
+    root->dir_name = "";
+
+    ScanWorkerArgs args;
+    args.delegate    = delegate_;
+    args.fn_ignore   = fn_ignore_file;
+    args.relative_to = relative_to_directory_;
+    args.queue.push_back(root);
+    args.active      = 0;
+    int rv = pthread_mutex_init(&args.lock, NULL);
+    assert(rv == 0);
+    rv = pthread_cond_init(&args.work_available, NULL);
+    assert(rv == 0);
+
+    std::vector<pthread_t> tids(num_threads);
+    for (unsigned i = 0; i < num_threads; ++i) {
+      rv = pthread_create(&tids[i], NULL, ScanWorkerThread, &args);
+      assert(rv == 0);
+    }
+    for (unsigned i = 0; i < num_threads; ++i) {
+      rv = pthread_join(tids[i], NULL);
+      assert(rv == 0);
+    }
+
+    pthread_cond_destroy(&args.work_available);
+    pthread_mutex_destroy(&args.lock);
+
+    return root;
+  }
+
+  /**
+   * Phase-2 serial DFS replay.
+   *
+   * Walks the pre-built tree in exactly the same depth-first order as
+   * DoRecursion(), firing all callbacks with identical argument conventions.
+   * The serialisation guarantees that all EnterDirectory/LeaveDirectory
+   * invariants expected by SyncMediator and the catalog manager are preserved.
+   */
+  void ReplayTree(const DirScanNode *node,
+                  const std::string &parent_path,
+                  const std::string &dir_name) const {
+    const std::string path = parent_path
+                             + (!dir_name.empty() ? ("/" + dir_name) : "");
+
+    Notify(fn_enter_dir, parent_path, dir_name);
+
+    // Non-directory entries: fire the appropriate per-type callback.
+    for (size_t i = 0; i < node->entries.size(); ++i) {
+      const DirScanEntry &e = node->entries[i];
+      if      (S_ISREG(e.mode))  Notify(fn_new_file,          path, e.name);
+      else if (S_ISLNK(e.mode))  Notify(fn_new_symlink,       path, e.name);
+      else if (S_ISSOCK(e.mode)) Notify(fn_new_socket,        path, e.name);
+      else if (S_ISBLK(e.mode))  Notify(fn_new_block_dev,     path, e.name);
+      else if (S_ISCHR(e.mode))  Notify(fn_new_character_dev, path, e.name);
+      else if (S_ISFIFO(e.mode)) Notify(fn_new_fifo,          path, e.name);
+      else LogCvmfs(kLogFsTraversal, kLogVerboseMsg,
+                    "unknown file type %s/%s", path.c_str(), e.name.c_str());
+    }
+
+    // Subdirectories: respect fn_new_dir_prefix return value, exactly as
+    // DoRecursion does at line: if (Notify(fn_new_dir_prefix, ...) && recurse_)
+    for (size_t i = 0; i < node->subdirs.size(); ++i) {
+      const DirScanNode *child = node->subdirs[i];
+      if (Notify(fn_new_dir_prefix, path, child->dir_name) && recurse_) {
+        ReplayTree(child, path, child->dir_name);
+      }
+      Notify(fn_new_dir_postfix, path, child->dir_name);
+    }
+
+    Notify(fn_leave_dir, parent_path, dir_name);
+  }
+
+  /** Recursively free all DirScanNode allocations. */
+  static void DeleteTree(DirScanNode *node) {
+    for (size_t i = 0; i < node->subdirs.size(); ++i)
+      DeleteTree(node->subdirs[i]);
+    delete node;
+  }
+
 };  // FileSystemTraversal
 
 #ifdef CVMFS_NAMESPACE_GUARD

--- a/cvmfs/util/platform_linux.h
+++ b/cvmfs/util/platform_linux.h
@@ -309,6 +309,15 @@ inline void platform_disable_kcache(int filedes) {
   (void)posix_fadvise(filedes, 0, 0, POSIX_FADV_RANDOM | POSIX_FADV_NOREUSE);
 }
 
+/**
+ * Advises the kernel that the file will be read sequentially from beginning to
+ * end.  The kernel doubles the read-ahead window, keeping read workers fed
+ * without blocking on I/O for large files in the ingestion pipeline.
+ */
+inline void platform_fadvise_sequential(int filedes) {
+  (void)posix_fadvise(filedes, 0, 0, POSIX_FADV_SEQUENTIAL);
+}
+
 inline ssize_t platform_readahead(int filedes) {
   return readahead(filedes, 0, static_cast<size_t>(-1));
 }

--- a/cvmfs/util/platform_osx.h
+++ b/cvmfs/util/platform_osx.h
@@ -245,6 +245,12 @@ inline void platform_invalidate_kcache(const int fd, const off_t offset,
   // TODO(rmeusel): implement
 }
 
+inline void platform_fadvise_sequential(int filedes) {
+  // macOS does not have posix_fadvise; fcntl(F_RDAHEAD) is the closest
+  // equivalent but applies globally per-fd. No-op for now.
+  (void)filedes;
+}
+
 inline ssize_t platform_readahead(int filedes) {
   // TODO(jblomer): is there a readahead equivalent?
   return 0;

--- a/gateway/internal/gateway/backend/backend.go
+++ b/gateway/internal/gateway/backend/backend.go
@@ -32,7 +32,7 @@ type ActionController interface {
 	GetLease(ctx context.Context, tokenStr string) (*LeaseDTO, error)
 	CancelLeases(ctx context.Context, repoPath string) error
 	CancelLease(ctx context.Context, tokenStr string) error
-	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error)
+	CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error)
 	SubmitPayload(ctx context.Context, token string, payload io.Reader, digest string, headerSize int) error
 	RunGC(ctx context.Context, options GCOptions) (string, error)
 	PublishManifest(ctx context.Context, repository string, message NotificationMessage)

--- a/gateway/internal/gateway/backend/db.go
+++ b/gateway/internal/gateway/backend/db.go
@@ -33,7 +33,12 @@ func OpenDB(config gw.Config) (*DB, error) {
 		createDB = true
 	}
 
-	sqlDB, err := sql.Open("sqlite3", "file:"+dbFile+"?mode=rwc")
+	// _busy_timeout=5000: wait up to 5 s before returning SQLITE_BUSY.
+	// This is necessary because per-repository lease locks allow concurrent
+	// writers for different repositories; without a timeout, a second writer
+	// that arrives while SQLite holds a write lock returns SQLITE_BUSY
+	// immediately instead of retrying.
+	sqlDB, err := sql.Open("sqlite3", "file:"+dbFile+"?mode=rwc&_busy_timeout=5000")
 	if err != nil {
 		return nil, fmt.Errorf("could not open DB: %w", err)
 	}

--- a/gateway/internal/gateway/backend/lease_service.go
+++ b/gateway/internal/gateway/backend/lease_service.go
@@ -3,13 +3,16 @@ package backend
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	gw "github.com/cvmfs/gateway/internal/gateway"
 )
 
-var leaseMutex sync.Mutex
+// leaseNamedLocks provides per-repository mutual exclusion for lease
+// operations (NewLease, CancelLease, CommitLease, CancelLeases).
+// Using per-repo locks instead of a single global mutex allows publishers
+// working on different repositories to proceed concurrently.
+var leaseNamedLocks NamedLocks
 
 // LeaseDTO is the lease information returned to the HTTP frontend
 type LeaseDTO struct {
@@ -19,11 +22,50 @@ type LeaseDTO struct {
 	Hostname  string `json:"hostname,omitempty"`
 }
 
+// repoForToken returns the repository name associated with a lease token by
+// performing a read-only DB lookup.  It returns InvalidLeaseError if the
+// lease is missing or has already expired.  No lease lock is held during
+// this call; callers must re-validate the lease inside the per-repo lock.
+func (s *Services) repoForToken(ctx context.Context, token string) (string, error) {
+	tx, err := s.DB.SQL.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("could not begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	lease, err := FindLeaseByToken(ctx, tx, token)
+	if err != nil {
+		return "", err
+	}
+	if lease == nil || lease.Expiration.Before(time.Now()) {
+		return "", InvalidLeaseError{}
+	}
+	return lease.Repository, nil
+}
+
+// repoForTokenAny is like repoForToken but also returns the repository for
+// expired leases.  Used by CancelLease, which must be able to cancel a lease
+// regardless of whether it has expired (matching the original behaviour before
+// per-repo locking was introduced).
+func (s *Services) repoForTokenAny(ctx context.Context, token string) (string, error) {
+	tx, err := s.DB.SQL.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("could not begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	lease, err := FindLeaseByToken(ctx, tx, token)
+	if err != nil {
+		return "", err
+	}
+	if lease == nil {
+		return "", InvalidLeaseError{}
+	}
+	return lease.Repository, nil
+}
+
 // NewLease for the specified path, using keyID
 func (s *Services) NewLease(ctx context.Context, keyID, leasePath, hostname string, protocolVersion int) (string, error) {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
-
 	t0 := time.Now()
 
 	outcome := "success"
@@ -35,91 +77,95 @@ func (s *Services) NewLease(ctx context.Context, keyID, leasePath, hostname stri
 		return "", err
 	}
 
-	tx, err := s.DB.SQL.BeginTx(ctx, nil)
-	if err != nil {
-		return "", fmt.Errorf("could not begin transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	repoConfig, err := s.GetRepo(ctx, repo)
-	if err != nil {
-		return "", fmt.Errorf("could not retrieve repository information: %w", err)
-	}
-	if repoConfig == nil {
-		return "", fmt.Errorf("repository not found: %s", repo)
-	}
-	if !repoConfig.Enabled {
-		return "", ErrRepoDisabled
-	}
-
-	// Check if keyID is allowed to request a lease in the repository
-	// at the specified subpath
-	if err := s.Access.Check(keyID, path, repo); err != nil {
-		outcome = err.Error()
-		return "", err
-	}
-
-	leases, err := FindAllLeasesByRepositoryAndOverlappingPath(ctx, tx, repo, path)
-	if err != nil {
-		return "", err
-	}
-
-	for _, lease := range leases {
-		timeLeft := time.Until(lease.Expiration)
-		if timeLeft > 0 {
-			err := PathBusyError{timeLeft}
-			outcome = err.Error()
-			return "", err
+	var token string
+	err = leaseNamedLocks.WithLock(repo, func() error {
+		tx, err := s.DB.SQL.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("could not begin transaction: %w", err)
 		}
-	}
+		defer tx.Rollback()
 
-	// Delete expired leases
-	if err := DeleteAllExpiredLeases(ctx, tx); err != nil {
+		repoConfig, err := s.GetRepo(ctx, repo)
+		if err != nil {
+			return fmt.Errorf("could not retrieve repository information: %w", err)
+		}
+		if repoConfig == nil {
+			return fmt.Errorf("repository not found: %s", repo)
+		}
+		if !repoConfig.Enabled {
+			return ErrRepoDisabled
+		}
+
+		// Check if keyID is allowed to request a lease in the repository
+		// at the specified subpath
+		if err := s.Access.Check(keyID, path, repo); err != nil {
+			return err
+		}
+
+		leases, err := FindAllLeasesByRepositoryAndOverlappingPath(ctx, tx, repo, path)
+		if err != nil {
+			return err
+		}
+
+		for _, lease := range leases {
+			timeLeft := time.Until(lease.Expiration)
+			if timeLeft > 0 {
+				return PathBusyError{timeLeft}
+			}
+		}
+
+		// Delete expired leases
+		if err := DeleteAllExpiredLeases(ctx, tx); err != nil {
+			return err
+		}
+
+		// Generate a new token for the lease
+		lease := Lease{
+			Token:           NewLeaseToken(),
+			Repository:      repo,
+			Path:            path,
+			KeyID:           keyID,
+			Expiration:      time.Now().Add(s.Config.MaxLeaseTime),
+			ProtocolVersion: protocolVersion,
+			Hostname:        hostname,
+		}
+
+		if err := CreateLease(ctx, tx, lease); err != nil {
+			return err
+		}
+
+		// The StatsMgr does not handle the case in which a lease expires.
+		// However, if a lease expires, we should not upload its statistics.
+		// If the LeaseMgr successfully creates a new lease,
+		// then the lease path must be free.
+		// We remove it, no matter what.
+		// We don't check the error because it returns an error if the lease
+		// does not exist, the standard case.
+		s.StatsMgr.PopLease(lease.CombinedLeasePath())
+
+		if err := s.StatsMgr.CreateLease(lease.CombinedLeasePath()); err != nil {
+			return err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("could not commit transaction: %w", err)
+		}
+
+		token = lease.Token
+		return nil
+	})
+
+	if err != nil {
 		outcome = err.Error()
 		return "", err
 	}
-
-	// Generate a new token for the lease
-	lease := Lease{
-		Token:           NewLeaseToken(),
-		Repository:      repo,
-		Path:            path,
-		KeyID:           keyID,
-		Expiration:      time.Now().Add(s.Config.MaxLeaseTime),
-		ProtocolVersion: protocolVersion,
-		Hostname:        hostname,
-	}
-
-	if err := CreateLease(ctx, tx, lease); err != nil {
-		outcome = err.Error()
-		return "", err
-	}
-
-	// the StatsMgr does not handle the case in which a lease expires.
-	// However, if a lease expires, we should not upload it's statistics.
-	// If the LeaseMgr successfully create a new lease,
-	// then, the lease path must be free.
-	// We remove it, no matter what.
-	// We don't check the error because it return an error if the lease does not exist, the standard case.
-	s.StatsMgr.PopLease(lease.CombinedLeasePath())
-
-	if err := s.StatsMgr.CreateLease(lease.CombinedLeasePath()); err != nil {
-		outcome = err.Error()
-		return "", err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return "", fmt.Errorf("could not commit transaction: %w", err)
-	}
-
-	outcome = fmt.Sprintf("success: %v", lease.Token)
-	return lease.Token, nil
+	outcome = fmt.Sprintf("success: %v", token)
+	return token, nil
 }
 
-// GetLeases returns all active and valid leases
+// GetLeases returns all active and valid leases.
+// Read-only: SQL transaction isolation is sufficient; no lease lock required.
 func (s *Services) GetLeases(ctx context.Context) (map[string]LeaseDTO, error) {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
 	t0 := time.Now()
 
 	outcome := "success"
@@ -149,10 +195,9 @@ func (s *Services) GetLeases(ctx context.Context) (map[string]LeaseDTO, error) {
 	return ret, nil
 }
 
-// GetLease returns the lease associated with a token
+// GetLease returns the lease associated with a token.
+// Read-only: SQL transaction isolation is sufficient; no lease lock required.
 func (s *Services) GetLease(ctx context.Context, token string) (*LeaseDTO, error) {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
 	t0 := time.Now()
 
 	outcome := "success"
@@ -191,18 +236,10 @@ func (s *Services) GetLease(ctx context.Context, token string) (*LeaseDTO, error
 
 // CancelLeases cancels all the active leases below a repository path
 func (s *Services) CancelLeases(ctx context.Context, repoPath string) error {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
 	t0 := time.Now()
 
 	outcome := "success"
 	defer logAction(ctx, "cancel_leases", &outcome, t0)
-
-	tx, err := s.DB.SQL.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("could not begin transaction: %w", err)
-	}
-	defer tx.Rollback()
 
 	repo, path, err := gw.SplitLeasePath(repoPath)
 	if err != nil {
@@ -210,114 +247,141 @@ func (s *Services) CancelLeases(ctx context.Context, repoPath string) error {
 		return err
 	}
 
-	if err := DeleteAllLeasesByRepositoryAndPathPrefix(ctx, tx, repo, path); err != nil {
+	err = leaseNamedLocks.WithLock(repo, func() error {
+		tx, err := s.DB.SQL.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("could not begin transaction: %w", err)
+		}
+		defer tx.Rollback()
+
+		if err := DeleteAllLeasesByRepositoryAndPathPrefix(ctx, tx, repo, path); err != nil {
+			return err
+		}
+
+		return tx.Commit()
+	})
+
+	if err != nil {
 		outcome = err.Error()
-		return err
 	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("could not commit transaction: %w", err)
-	}
-
-	return nil
+	return err
 }
 
 // CancelLease associated with the token
 func (s *Services) CancelLease(ctx context.Context, token string) error {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
 	t0 := time.Now()
 
 	outcome := "success"
 	defer logAction(ctx, "cancel_lease", &outcome, t0)
 
-	tx, err := s.DB.SQL.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("could not begin transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	lease, err := FindLeaseByToken(ctx, tx, token)
+	// Pre-read: find the repository for per-repo locking.
+	// Use repoForTokenAny so that expired leases (that still exist in the DB)
+	// can also be cancelled — matching the pre-refactor behaviour.
+	repo, err := s.repoForTokenAny(ctx, token)
 	if err != nil {
 		outcome = err.Error()
 		return err
 	}
 
-	if lease == nil {
-		err := InvalidLeaseError{}
+	err = leaseNamedLocks.WithLock(repo, func() error {
+		tx, err := s.DB.SQL.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("could not begin transaction: %w", err)
+		}
+		defer tx.Rollback()
+
+		// Re-find inside the lock to handle the race between pre-read and lock
+		// acquisition (e.g. another goroutine cancelled the same lease first).
+		// Do not check expiry: CancelLease must delete the row even if the
+		// lease has just expired.
+		lease, err := FindLeaseByToken(ctx, tx, token)
+		if err != nil {
+			return err
+		}
+
+		if lease == nil {
+			return InvalidLeaseError{}
+		}
+
+		if err := DeleteLeaseByToken(ctx, tx, token); err != nil {
+			return err
+		}
+
+		// We don't check the error - if the statistics are missing, the lease
+		// should still be cancelable
+		s.StatsMgr.PopLease(lease.CombinedLeasePath())
+
+		return tx.Commit()
+	})
+
+	if err != nil {
 		outcome = err.Error()
-		return err
 	}
-
-	if err := DeleteLeaseByToken(ctx, tx, token); err != nil {
-		outcome = err.Error()
-		return err
-	}
-
-	// We don't check the error - if the statistics are missing, the lease
-	// should still be cancelable
-	s.StatsMgr.PopLease(lease.CombinedLeasePath())
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("could not commit transaction: %w", err)
-	}
-
-	return nil
+	return err
 }
 
 // CommitLease associated with the token (transaction commit)
 func (s *Services) CommitLease(ctx context.Context, token, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
 	t0 := time.Now()
 
 	outcome := "success"
 	defer logAction(ctx, "commit_lease", &outcome, t0)
 
-	tx, err := s.DB.SQL.BeginTx(ctx, nil)
+	// Pre-read: find the repository for per-repo locking.
+	// The lease is re-validated inside the lock.
+	repo, err := s.repoForToken(ctx, token)
 	if err != nil {
-		return 0, fmt.Errorf("could not begin transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	lease, err := FindLeaseByToken(ctx, tx, token)
-	if err != nil {
-		outcome = err.Error()
-		return 0, err
-	}
-
-	if lease == nil || lease.Expiration.Before(time.Now()) {
-		err := InvalidLeaseError{}
 		outcome = err.Error()
 		return 0, err
 	}
 
 	var finalRev uint64
-	if err := s.DB.WithLock(ctx, lease.Repository, func() error {
-		var err error
-		leasePath := lease.CombinedLeasePath()
-		finalRev, err = s.Pool.CommitLease(ctx, leasePath, oldRootHash, newRootHash, tag)
-		return err
-	}); err != nil {
-		outcome = err.Error()
-		return 0, err
-	}
-
-	go func() {
-		plotsErr := s.StatsMgr.UploadStatsPlots(lease.Repository)
-		if plotsErr != nil {
-			gw.LogC(ctx, "actions", gw.LogError).Msgf(plotsErr.Error())
+	err = leaseNamedLocks.WithLock(repo, func() error {
+		tx, err := s.DB.SQL.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("could not begin transaction: %w", err)
 		}
-	}()
+		defer tx.Rollback()
 
-	if err := DeleteLeaseByToken(ctx, tx, token); err != nil {
+		// Re-find inside the lock: the lease might have been cancelled or
+		// expired between the pre-read and lock acquisition.
+		lease, err := FindLeaseByToken(ctx, tx, token)
+		if err != nil {
+			return err
+		}
+
+		if lease == nil || lease.Expiration.Before(time.Now()) {
+			return InvalidLeaseError{}
+		}
+
+		leasePath := lease.CombinedLeasePath()
+
+		// DB.WithLock serialises commits and GC runs for the same repository.
+		if err := s.DB.WithLock(ctx, lease.Repository, func() error {
+			var err error
+			finalRev, err = s.Pool.CommitLease(ctx, leasePath, oldRootHash, newRootHash, tag)
+			return err
+		}); err != nil {
+			return err
+		}
+
+		go func() {
+			plotsErr := s.StatsMgr.UploadStatsPlots(lease.Repository)
+			if plotsErr != nil {
+				gw.LogC(ctx, "actions", gw.LogError).Msgf(plotsErr.Error())
+			}
+		}()
+
+		if err := DeleteLeaseByToken(ctx, tx, token); err != nil {
+			return err
+		}
+
+		return tx.Commit()
+	})
+
+	if err != nil {
 		outcome = err.Error()
 		return finalRev, err
 	}
-
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("could not commit transaction: %w", err)
-	}
-
 	return finalRev, nil
 }

--- a/gateway/internal/gateway/backend/lease_service.go
+++ b/gateway/internal/gateway/backend/lease_service.go
@@ -321,7 +321,7 @@ func (s *Services) CancelLease(ctx context.Context, token string) error {
 }
 
 // CommitLease associated with the token (transaction commit)
-func (s *Services) CommitLease(ctx context.Context, token, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
+func (s *Services) CommitLease(ctx context.Context, token, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error) {
 	t0 := time.Now()
 
 	outcome := "success"
@@ -359,7 +359,7 @@ func (s *Services) CommitLease(ctx context.Context, token, oldRootHash, newRootH
 		// DB.WithLock serialises commits and GC runs for the same repository.
 		if err := s.DB.WithLock(ctx, lease.Repository, func() error {
 			var err error
-			finalRev, err = s.Pool.CommitLease(ctx, leasePath, oldRootHash, newRootHash, tag)
+			finalRev, err = s.Pool.CommitLease(ctx, leasePath, oldRootHash, newRootHash, tag, directGraft)
 			return err
 		}); err != nil {
 			return err

--- a/gateway/internal/gateway/backend/lease_service_test.go
+++ b/gateway/internal/gateway/backend/lease_service_test.go
@@ -245,7 +245,7 @@ func TestLeaseServiceCommitLease(t *testing.T) {
 			gw.RepositoryTag{
 				Name:        "mytag",
 				Description: "this is a tag",
-			}); err != nil {
+			}, false); err != nil {
 			t.Fatalf("could not commit existing lease: %v", err)
 			backend.CancelLease(context.TODO(), token)
 		}
@@ -258,7 +258,7 @@ func TestLeaseServiceCommitLease(t *testing.T) {
 			gw.RepositoryTag{
 				Name:        "mytag",
 				Description: "this is a tag",
-			}); err == nil {
+			}, false); err == nil {
 			t.Fatalf("invalid lease should not have been accepted for commit")
 		}
 	})
@@ -276,7 +276,7 @@ func TestLeaseServiceCommitLease(t *testing.T) {
 			gw.RepositoryTag{
 				Name:        "mytag",
 				Description: "this is a tag",
-			}); err == nil {
+			}, false); err == nil {
 			t.Fatalf("expired lease should not have been accepted for commit")
 		}
 	})

--- a/gateway/internal/gateway/backend/session_test.go
+++ b/gateway/internal/gateway/backend/session_test.go
@@ -39,7 +39,7 @@ func TestSessionValid(t *testing.T) {
 		gw.RepositoryTag{
 			Name:        "mytag",
 			Description: "this is a tag",
-		}); err != nil {
+		}, false); err != nil {
 		t.Fatalf("could not commit existing lease: %v", err)
 	}
 }
@@ -140,7 +140,7 @@ func TestSessionCommitWithInvalidToken(t *testing.T) {
 		gw.RepositoryTag{
 			Name:        "mytag",
 			Description: "this is a tag",
-		}); err == nil {
+		}, false); err == nil {
 		t.Fatalf("invalid token was not rejected during commit action")
 	}
 }
@@ -177,7 +177,7 @@ func TestSessionCommitWithExpiredToken(t *testing.T) {
 		gw.RepositoryTag{
 			Name:        "mytag",
 			Description: "this is a tag",
-		}); err == nil {
+		}, false); err == nil {
 		t.Fatalf("expired token was not rejected during commit action")
 	}
 }
@@ -229,7 +229,7 @@ func TestSessionTwoConcurrentValid(t *testing.T) {
 		gw.RepositoryTag{
 			Name:        "mytag",
 			Description: "this is a tag",
-		}); err != nil {
+		}, false); err != nil {
 		t.Fatalf("could not commit existing lease: %v", err)
 	}
 
@@ -237,7 +237,7 @@ func TestSessionTwoConcurrentValid(t *testing.T) {
 		gw.RepositoryTag{
 			Name:        "mytag",
 			Description: "this is a tag",
-		}); err != nil {
+		}, false); err != nil {
 		t.Fatalf("could not commit existing lease: %v", err)
 	}
 }

--- a/gateway/internal/gateway/frontend/leases.go
+++ b/gateway/internal/gateway/frontend/leases.go
@@ -122,6 +122,7 @@ func handleCommitLease(services be.ActionController, token string, w http.Respon
 	var reqMsg struct {
 		OldRootHash string `json:"old_root_hash"`
 		NewRootHash string `json:"new_root_hash"`
+		DirectGraft bool   `json:"direct_graft"`
 		gw.RepositoryTag
 	}
 	if err := json.NewDecoder(h.Body).Decode(&reqMsg); err != nil {
@@ -131,7 +132,7 @@ func handleCommitLease(services be.ActionController, token string, w http.Respon
 
 	msg := make(map[string]interface{})
 	if finalRev, err := services.CommitLease(
-		ctx, token, reqMsg.OldRootHash, reqMsg.NewRootHash, reqMsg.RepositoryTag); err != nil {
+		ctx, token, reqMsg.OldRootHash, reqMsg.NewRootHash, reqMsg.RepositoryTag, reqMsg.DirectGraft); err != nil {
 		msg["status"] = "error"
 		msg["reason"] = err.Error()
 	} else {

--- a/gateway/internal/gateway/frontend/testutil.go
+++ b/gateway/internal/gateway/frontend/testutil.go
@@ -81,7 +81,7 @@ func (b *mockBackend) CancelLease(ctx context.Context, tokenStr string) error {
 	return nil
 }
 
-func (b *mockBackend) CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
+func (b *mockBackend) CommitLease(ctx context.Context, tokenStr, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error) {
 	return 1, nil
 }
 

--- a/gateway/internal/gateway/receiver/mock_receiver.go
+++ b/gateway/internal/gateway/receiver/mock_receiver.go
@@ -34,7 +34,7 @@ func (r *MockReceiver) Echo() error {
 	return nil
 }
 
-func (r *MockReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
+func (r *MockReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error) {
 	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
 		Str("command", "commit").
 		Str("lease_path", leasePath).

--- a/gateway/internal/gateway/receiver/pool.go
+++ b/gateway/internal/gateway/receiver/pool.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -71,10 +72,10 @@ func (p testCrashTask) Context() context.Context {
 	return p.ctx
 }
 
-// Pool maintains a number of parallel receiver workers to service
-// payload submission and commit requests. Payload submissions are done in
-// parallel, using Config.NumReceivers workers, while only a single commit
-// request can be treated per repository at a time.
+// Pool maintains a number of parallel receiver workers to service payload
+// submission and commit requests. Each worker owns a persistent
+// cvmfs_receiver process that is reused across tasks; a new process is
+// spawned only when the previous one crashes.
 type Pool struct {
 	tasks      chan<- task
 	wg         sync.WaitGroup
@@ -83,10 +84,9 @@ type Pool struct {
 	smgr       *stats.StatisticsMgr
 }
 
-// StartPool the receiver pool using the specified executable and number of payload
-// submission workers
+// StartPool starts the receiver pool using the specified executable and number
+// of payload submission workers.
 func StartPool(workerExec string, numWorkers int, mock bool, smgr *stats.StatisticsMgr) (*Pool, error) {
-	// Start payload submission workers
 	tasks := make(chan task)
 	pool := &Pool{tasks, sync.WaitGroup{}, workerExec, mock, smgr}
 
@@ -109,7 +109,6 @@ func (p *Pool) Stop() error {
 }
 
 // SubmitPayload to be unpacked into the repository
-// TODO: implement timeout or context?
 func (p *Pool) SubmitPayload(ctx context.Context, leasePath string, payload io.Reader, digest string, headerSize int) error {
 	reply := make(chan error, 1)
 	p.tasks <- payloadTask{ctx, leasePath, payload, digest, headerSize, reply}
@@ -118,7 +117,6 @@ func (p *Pool) SubmitPayload(ctx context.Context, leasePath string, payload io.R
 }
 
 // CommitLease associated with the token (transaction commit)
-// TODO: implement timeout or context?
 func (p *Pool) CommitLease(ctx context.Context, leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
 	reply := make(chan error, 1)
 	finalRevChan := make(chan uint64, 1)
@@ -136,6 +134,52 @@ func worker(tasks <-chan task, pool *Pool, workerIdx int) {
 		Msg("started")
 
 	defer pool.wg.Done()
+
+	// recv is the persistent receiver process for this worker.
+	// nil means not yet started or crashed; ensureReceiver (re-)creates it.
+	var recv Receiver
+
+	// ensureReceiver starts a new receiver process if one is not running.
+	ensureReceiver := func(ctx context.Context) error {
+		if recv != nil {
+			return nil
+		}
+		var err error
+		recv, err = NewReceiver(ctx, pool.workerExec, pool.mock, pool.smgr)
+		if err != nil {
+			return fmt.Errorf("could not start receiver process: %w", err)
+		}
+		gw.LogC(ctx, "worker_pool", gw.LogInfo).
+			Int("worker_id", workerIdx).
+			Msg("receiver process started")
+		return nil
+	}
+
+	// discardReceiver shuts down the current receiver (best-effort) and sets
+	// recv to nil so ensureReceiver creates a fresh one on the next task.
+	discardReceiver := func(ctx context.Context) {
+		if recv == nil {
+			return
+		}
+		if err := recv.Quit(); err != nil {
+			gw.LogC(ctx, "worker_pool", gw.LogError).
+				Int("worker_id", workerIdx).
+				Msgf("error quitting receiver: %v", err)
+		}
+		recv = nil
+	}
+
+	defer func() {
+		// Pool is stopping: cleanly quit the persistent receiver process.
+		if recv != nil {
+			if err := recv.Quit(); err != nil {
+				gw.Log("worker_pool", gw.LogError).
+					Int("worker_id", workerIdx).
+					Msgf("error quitting receiver on shutdown: %v", err)
+			}
+		}
+	}()
+
 M:
 	for {
 		task, more := <-tasks
@@ -146,37 +190,54 @@ M:
 
 		func() {
 			t0 := time.Now()
-			receiver, err := NewReceiver(task.Context(), pool.workerExec, pool.mock, pool.smgr)
-			if err != nil {
+
+			if err := ensureReceiver(task.Context()); err != nil {
 				task.Reply() <- err
+				close(task.Reply())
 				return
 			}
-			defer func() {
-				if err := receiver.Quit(); err != nil {
-					gw.LogC(task.Context(), "worker_pool", gw.LogError).
-						Int("worker_id", workerIdx).
-						Msgf("error when quitting the receiver: %v", err.Error())
-				}
-			}()
 
 			var taskType string
 			var result error
 			var finalRev uint64
+			var crashed bool
+
 			switch t := task.(type) {
 			case payloadTask:
-				result = receiver.SubmitPayload(t.leasePath, t.payload, t.digest, t.headerSize)
+				result = recv.SubmitPayload(t.leasePath, t.payload, t.digest, t.headerSize)
 				taskType = "payload"
 			case commitTask:
-				finalRev, result = receiver.Commit(t.leasePath, t.oldRootHash, t.newRootHash, t.tag)
+				finalRev, result = recv.Commit(t.leasePath, t.oldRootHash, t.newRootHash, t.tag)
 				taskType = "commit"
 				t.finalRevChan <- finalRev
 				close(t.finalRevChan)
 			case testCrashTask:
-				result = receiver.TestCrash()
+				result = recv.TestCrash()
 				taskType = "testcrash"
+				// TestCrash always terminates the receiver process; replace next time.
+				crashed = true
 			default:
 				task.Reply() <- fmt.Errorf("unknown task type")
+				close(task.Reply())
 				return
+			}
+
+			// Detect receiver process death. Application-level errors from the
+			// receiver arrive as type receiver.Error (a string alias). I/O errors
+			// from a crashed process are a different type.  On crash, discard the
+			// receiver so a new one is created on the next task.
+			if result != nil && !crashed {
+				var appErr Error
+				if !errors.As(result, &appErr) {
+					gw.LogC(task.Context(), "worker_pool", gw.LogError).
+						Int("worker_id", workerIdx).
+						Str("task_type", taskType).
+						Msgf("receiver process died, will restart on next task: %v", result)
+					crashed = true
+				}
+			}
+			if crashed {
+				discardReceiver(task.Context())
 			}
 
 			task.Reply() <- result

--- a/gateway/internal/gateway/receiver/pool.go
+++ b/gateway/internal/gateway/receiver/pool.go
@@ -45,6 +45,7 @@ type commitTask struct {
 	oldRootHash  string
 	newRootHash  string
 	tag          gw.RepositoryTag
+	directGraft  bool
 	replyChan    chan<- error
 	finalRevChan chan<- uint64
 }
@@ -117,10 +118,10 @@ func (p *Pool) SubmitPayload(ctx context.Context, leasePath string, payload io.R
 }
 
 // CommitLease associated with the token (transaction commit)
-func (p *Pool) CommitLease(ctx context.Context, leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
+func (p *Pool) CommitLease(ctx context.Context, leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error) {
 	reply := make(chan error, 1)
 	finalRevChan := make(chan uint64, 1)
-	p.tasks <- commitTask{ctx, leasePath, oldRootHash, newRootHash, tag, reply, finalRevChan}
+	p.tasks <- commitTask{ctx, leasePath, oldRootHash, newRootHash, tag, directGraft, reply, finalRevChan}
 	result := <-reply
 	if result == nil {
 		return <-finalRevChan, nil
@@ -207,7 +208,7 @@ M:
 				result = recv.SubmitPayload(t.leasePath, t.payload, t.digest, t.headerSize)
 				taskType = "payload"
 			case commitTask:
-				finalRev, result = recv.Commit(t.leasePath, t.oldRootHash, t.newRootHash, t.tag)
+				finalRev, result = recv.Commit(t.leasePath, t.oldRootHash, t.newRootHash, t.tag, t.directGraft)
 				taskType = "commit"
 				t.finalRevChan <- finalRev
 				close(t.finalRevChan)

--- a/gateway/internal/gateway/receiver/receiver.go
+++ b/gateway/internal/gateway/receiver/receiver.go
@@ -45,7 +45,7 @@ type Receiver interface {
 	Quit() error
 	Echo() error
 	SubmitPayload(leasePath string, payload io.Reader, digest string, headerSize int) error
-	Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error)
+	Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error)
 	Interrupt() error // like Ctrl-C SIGTERM -2
 	// Kill() error // like Crtl-D SIGKILL -9
 	TestCrash() error
@@ -222,7 +222,7 @@ func (r *CvmfsReceiver) SubmitPayload(leasePath string, payload io.Reader, diges
 }
 
 // Commit command is sent to the worker
-func (r *CvmfsReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
+func (r *CvmfsReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag, directGraft bool) (uint64, error) {
 	stats, err := r.statsMgr.PopLease(leasePath)
 	if err != nil {
 		return 0, fmt.Errorf("could not obtain statistics counters: %w", err)
@@ -233,6 +233,7 @@ func (r *CvmfsReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag g
 		"new_root_hash":   newRootHash,
 		"tag_name":        tag.Name,
 		"tag_description": tag.Description,
+		"direct_graft":    directGraft,
 		"statistics":      stats,
 	}
 	buf, err := json.Marshal(&req)

--- a/test/unittests/t_acl.cc
+++ b/test/unittests/t_acl.cc
@@ -31,10 +31,14 @@ static void should_pass_noncompat(const char *textual, unsigned char *acl_binary
   } else {
     ASSERT_FALSE(equiv_mode);
     ASSERT_NE(binary_acl, nullptr);
-    // Explicit guard silences -Wnonnull: compiler can't prove the parameter
-    // is non-null, but every caller passes a valid buffer when len > 0.
     ASSERT_NE(static_cast<void *>(acl_binary_expected), nullptr);
+    // GCC -Wnonnull fires here because the compiler cannot prove the pointer
+    // parameter is non-null at compile time, even though the ASSERT above
+    // would abort at runtime.  Suppress it locally.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
     ASSERT_EQ(0, memcmp(binary_acl, acl_binary_expected, binary_size));
+#pragma GCC diagnostic pop
   }
   free(binary_acl);
 }
@@ -58,7 +62,10 @@ static void should_pass(const char *textual, unsigned char *acl_binary_expected,
     ASSERT_FALSE(equiv_mode);
     ASSERT_NE(binary_acl, nullptr);
     ASSERT_NE(static_cast<void *>(acl_binary_expected), nullptr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
     ASSERT_EQ(0, memcmp(binary_acl, acl_binary_expected, binary_size));
+#pragma GCC diagnostic pop
   }
   free(binary_acl);
 }

--- a/test/unittests/t_acl.cc
+++ b/test/unittests/t_acl.cc
@@ -31,6 +31,9 @@ static void should_pass_noncompat(const char *textual, unsigned char *acl_binary
   } else {
     ASSERT_FALSE(equiv_mode);
     ASSERT_NE(binary_acl, nullptr);
+    // Explicit guard silences -Wnonnull: compiler can't prove the parameter
+    // is non-null, but every caller passes a valid buffer when len > 0.
+    ASSERT_NE(static_cast<void *>(acl_binary_expected), nullptr);
     ASSERT_EQ(0, memcmp(binary_acl, acl_binary_expected, binary_size));
   }
   free(binary_acl);
@@ -54,6 +57,7 @@ static void should_pass(const char *textual, unsigned char *acl_binary_expected,
   } else {
     ASSERT_FALSE(equiv_mode);
     ASSERT_NE(binary_acl, nullptr);
+    ASSERT_NE(static_cast<void *>(acl_binary_expected), nullptr);
     ASSERT_EQ(0, memcmp(binary_acl, acl_binary_expected, binary_size));
   }
   free(binary_acl);

--- a/test/unittests/t_catalog_mgr_rw.cc
+++ b/test/unittests/t_catalog_mgr_rw.cc
@@ -4,11 +4,19 @@
 
 #include <gtest/gtest.h>
 
+#include "catalog_mgr.h"
 #include "catalog_mgr_rw.h"
+#include "catalog_rw.h"
 #include "catalog_test_tools.h"
+#include "directory_entry.h"
+#include "file_chunk.h"
+#include "manifest.h"
 #include "network/download.h"
 #include "statistics.h"
+#include "testutil.h"
 #include "upload.h"
+#include "util/string.h"
+#include "xattr.h"
 
 using namespace std;  // NOLINT
 
@@ -285,6 +293,156 @@ TEST_F(T_CatalogMgrRw, GraftNestedCatalogFail) {
   EXPECT_DEATH(
       catalog_mgr->GraftNestedCatalog("dir/dir/dir/sub1", sub1_hash, sub1_size),
       ".*");
+}
+
+// ---------------------------------------------------------------------------
+// A1: IssueHardlinkGroupId() — cached per-catalog hardlink ID sequence
+// ---------------------------------------------------------------------------
+
+// Verify that repeated calls to IssueHardlinkGroupId() on a fresh catalog
+// (no pre-existing hardlinks) return a strictly monotonically increasing
+// sequence starting at 1, without re-querying the database on every call.
+TEST_F(T_CatalogMgrRw, IssueHardlinkGroupIdSequence) {
+  CatalogTestTool tester("issue_hardlink_group_id_seq");
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+
+  catalog::WritableCatalogManager *catalog_mgr = tester.catalog_mgr();
+
+  // "file3" is in the root catalog (see MakeBaseSpec). GetHostingCatalog
+  // returns the WritableCatalog that hosts it — the root catalog.
+  catalog::WritableCatalog *root = catalog_mgr->GetHostingCatalog("file3");
+  ASSERT_NE(nullptr, root);
+
+  // MakeBaseSpec has no hardlinks, so GetMaxLinkId() returns 0 (MAX on an
+  // empty set → NULL → 0 in SQLite). IssueHardlinkGroupId() must therefore
+  // start at 1 and count upward without an additional DB query.
+  uint32_t id1 = root->IssueHardlinkGroupId();
+  uint32_t id2 = root->IssueHardlinkGroupId();
+  uint32_t id3 = root->IssueHardlinkGroupId();
+
+  EXPECT_EQ(1u, id1);
+  EXPECT_EQ(2u, id2);
+  EXPECT_EQ(3u, id3);
+}
+
+
+// Verify that consecutive AddHardlinkGroup calls issued through the catalog
+// manager allocate strictly sequential, distinct, non-zero group IDs and
+// that the lookup of each group's members returns the correct ID.
+TEST_F(T_CatalogMgrRw, HardlinkGroupsGetDistinctIds) {
+  CatalogTestTool tester("hardlink_groups_distinct_ids");
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+
+  catalog::WritableCatalogManager *catalog_mgr = tester.catalog_mgr();
+
+  // Build two independent hardlink groups in "/dir".
+  // Group A: two names sharing one content hash.
+  const shash::Any hash_a =
+      shash::MkFromHexPtr(shash::HexPtr(g_hashes[5]), shash::kSuffixNone);
+  catalog::DirectoryEntryBaseList group_a;
+  group_a.push_back(
+      catalog::DirectoryEntryTestFactory::RegularFile("hlink_a1", g_file_size,
+                                                      hash_a));
+  group_a.push_back(
+      catalog::DirectoryEntryTestFactory::RegularFile("hlink_a2", g_file_size,
+                                                      hash_a));
+
+  // Group B: two names sharing a different content hash.
+  const shash::Any hash_b =
+      shash::MkFromHexPtr(shash::HexPtr(g_hashes[6]), shash::kSuffixNone);
+  catalog::DirectoryEntryBaseList group_b;
+  group_b.push_back(
+      catalog::DirectoryEntryTestFactory::RegularFile("hlink_b1", g_file_size,
+                                                      hash_b));
+  group_b.push_back(
+      catalog::DirectoryEntryTestFactory::RegularFile("hlink_b2", g_file_size,
+                                                      hash_b));
+
+  XattrList xattrs;
+  FileChunkList no_chunks;
+  catalog_mgr->AddHardlinkGroup(group_a, xattrs, "dir", no_chunks);
+  catalog_mgr->AddHardlinkGroup(group_b, xattrs, "dir", no_chunks);
+
+  // Verify that the two groups received different non-zero IDs.
+  catalog::DirectoryEntry dirent_a1, dirent_a2, dirent_b1, dirent_b2;
+  ASSERT_TRUE(catalog_mgr->LookupPath("/dir/hlink_a1", kLookupDefault,
+                                      &dirent_a1));
+  ASSERT_TRUE(catalog_mgr->LookupPath("/dir/hlink_a2", kLookupDefault,
+                                      &dirent_a2));
+  ASSERT_TRUE(catalog_mgr->LookupPath("/dir/hlink_b1", kLookupDefault,
+                                      &dirent_b1));
+  ASSERT_TRUE(catalog_mgr->LookupPath("/dir/hlink_b2", kLookupDefault,
+                                      &dirent_b2));
+
+  const uint32_t id_a = dirent_a1.hardlink_group();
+  const uint32_t id_b = dirent_b1.hardlink_group();
+
+  // Both IDs must be positive (assert link_id_seq_ > 0 in the source).
+  EXPECT_GT(id_a, 0u);
+  EXPECT_GT(id_b, 0u);
+
+  // Members of the same group share an ID.
+  EXPECT_EQ(id_a, dirent_a2.hardlink_group());
+  EXPECT_EQ(id_b, dirent_b2.hardlink_group());
+
+  // The two groups have different IDs (sequential allocation).
+  EXPECT_NE(id_a, id_b);
+
+  // Group B was added second so its ID must be exactly one higher.
+  EXPECT_EQ(id_a + 1u, id_b);
+}
+
+
+// ---------------------------------------------------------------------------
+// B3: VacuumDatabaseIfNecessary() — lock released before VACUUM
+// ---------------------------------------------------------------------------
+
+// After many AddFile / RemoveFile cycles the catalog accumulates free pages
+// that exceed kMaximalFreePageRatio.  Commit() calls FinalizeCatalog() which
+// calls VacuumDatabaseIfNecessary().  If the lock were still held across the
+// multi-second VACUUM the catalog would deadlock when the subsequent
+// UpdateNestedCatalog on the parent tried to acquire it.  This test verifies
+// that Commit() completes and the catalog remains accessible afterward.
+TEST_F(T_CatalogMgrRw, VacuumDatabaseNoDeadlock) {
+  CatalogTestTool tester("vacuum_no_deadlock");
+  EXPECT_TRUE(tester.Init());
+
+  DirSpec spec = MakeBaseSpec();
+  EXPECT_TRUE(tester.ApplyAtRootHash(tester.manifest()->catalog_hash(), spec));
+
+  catalog::WritableCatalogManager *catalog_mgr = tester.catalog_mgr();
+
+  // Add a batch of files to create real catalog churn, then remove them so
+  // that freed page space eventually triggers VACUUM.
+  const shash::Any hash =
+      shash::MkFromHexPtr(shash::HexPtr(g_hashes[0]), shash::kSuffixNone);
+  const XattrList xattrs;
+  for (int i = 0; i < 50; ++i) {
+    const string name = "vac_tmp_" + StringifyInt(i);
+    catalog::DirectoryEntry entry =
+        catalog::DirectoryEntryTestFactory::RegularFile(name, g_file_size,
+                                                        hash);
+    catalog_mgr->AddFile(entry, xattrs, "dir");
+  }
+  for (int i = 0; i < 50; ++i) {
+    catalog_mgr->RemoveFile("dir/vac_tmp_" + StringifyInt(i));
+  }
+
+  // Commit should not deadlock and must report success.
+  manifest::Manifest manifest(shash::Any(), 1, "");
+  const bool committed = catalog_mgr->Commit(false, 0, &manifest);
+  EXPECT_TRUE(committed);
+
+  // The catalog must still be queryable after vacuum.
+  catalog::DirectoryEntry dirent;
+  EXPECT_TRUE(catalog_mgr->LookupPath("/dir/file1", kLookupDefault, &dirent));
+  EXPECT_STREQ(g_hashes[0], dirent.checksum().ToString().c_str());
 }
 
 }  // namespace catalog

--- a/test/unittests/t_catalog_mgr_rw.cc
+++ b/test/unittests/t_catalog_mgr_rw.cc
@@ -428,7 +428,11 @@ TEST_F(T_CatalogMgrRw, VacuumDatabaseNoDeadlock) {
     catalog::DirectoryEntry entry =
         catalog::DirectoryEntryTestFactory::RegularFile(name, g_file_size,
                                                         hash);
-    catalog_mgr->AddFile(entry, xattrs, "dir");
+    // Cast to DirectoryEntryBase to route through the public overload.
+    // The protected DirectoryEntry overload is the internal implementation;
+    // the public base overload is the intended external API.
+    catalog_mgr->AddFile(
+        static_cast<const catalog::DirectoryEntryBase &>(entry), xattrs, "dir");
   }
   for (int i = 0; i < 50; ++i) {
     catalog_mgr->RemoveFile("dir/vac_tmp_" + StringifyInt(i));

--- a/test/unittests/t_catalog_sql.cc
+++ b/test/unittests/t_catalog_sql.cc
@@ -310,3 +310,64 @@ TEST_F(T_CatalogSql, SchemaMigration) {
     EXPECT_EQ(0, sql12.RetrieveInt(0));
   }
 }
+
+
+// ---------------------------------------------------------------------------
+// A3: SQLite pragmas applied to writable catalog databases
+// ---------------------------------------------------------------------------
+
+// Verify that Database<DerivedT>::Configure() sets the three performance
+// pragmas on read-write opens:
+//   PRAGMA synchronous=NORMAL  (avoids fsync after journal deletion)
+//   PRAGMA cache_size=-65536   (64 MB page pool, negative = KiB)
+//   PRAGMA mmap_size=134217728 (128 MB mmap window)
+//
+// The test creates a fresh CatalogDatabase (which uses kOpenReadWrite) and
+// immediately queries each pragma back from SQLite to confirm the values.
+TEST_F(T_CatalogSql, WritableDbPragmasApplied) {
+  const string path = CreateTempPath("/tmp/cvmfs_t_catalog_pragma", 0600);
+  ASSERT_FALSE(path.empty());
+
+  // Create() does not call Configure() (it sets up schema only), so the DB
+  // file is created without the performance pragmas.  The pragmas are applied
+  // by Initialize() → Configure(), which is called only by Open().
+  {
+    UniquePtr<catalog::CatalogDatabase> db(
+        catalog::CatalogDatabase::Create(path));
+    ASSERT_TRUE(db.IsValid());
+  }
+
+  // Open in read-write mode — this is the publish-path open that must apply
+  // the three pragmas from the read-write branch of Configure().
+  {
+    UniquePtr<catalog::CatalogDatabase> db(catalog::CatalogDatabase::Open(
+        path, catalog::CatalogDatabase::kOpenReadWrite));
+    ASSERT_TRUE(db.IsValid());
+
+    // PRAGMA cache_size returns the value set by Configure().
+    // Negative value is in KiB: -65536 = 64 MB.
+    sqlite::Sql sql_cache(db->sqlite_db(), "PRAGMA cache_size;");
+    ASSERT_TRUE(sql_cache.FetchRow());
+    EXPECT_EQ(INT64_C(-65536), sql_cache.RetrieveInt64(0));
+
+    // PRAGMA mmap_size returns the mmap window in bytes.
+    sqlite::Sql sql_mmap(db->sqlite_db(), "PRAGMA mmap_size;");
+    ASSERT_TRUE(sql_mmap.FetchRow());
+    EXPECT_EQ(INT64_C(134217728), sql_mmap.RetrieveInt64(0));
+  }
+
+  // Read-only opens must NOT apply the write-path pragmas; the read-only
+  // branch of Configure() only sets temp_store and locking_mode.
+  // The cache_size must therefore differ from the write-path value (-65536).
+  {
+    UniquePtr<catalog::CatalogDatabase> db(catalog::CatalogDatabase::Open(
+        path, catalog::CatalogDatabase::kOpenReadOnly));
+    ASSERT_TRUE(db.IsValid());
+
+    sqlite::Sql sql_cache(db->sqlite_db(), "PRAGMA cache_size;");
+    ASSERT_TRUE(sql_cache.FetchRow());
+    EXPECT_NE(INT64_C(-65536), sql_cache.RetrieveInt64(0));
+  }
+
+  unlink(path.c_str());
+}


### PR DESCRIPTION

<hr>
<h2>Publishing pipeline performance improvements and gateway modernisation</h2>
<p>This branch contains a set of performance improvements to the CVMFS publishing
pipeline and gateway, together with a new <code>DirectGraft</code> fast path in the commit
processor and a testbed mode for container-based integration testing.</p>
<h3>Background</h3>
<p>The changes were developed to reduce the end-to-end publish latency for
high-frequency, high-concurrency workloads (HEP software repositories with
thousands of files per publish and tens of concurrent publishers).
<code>PERF_IMPROVEMENTS.md</code> and <code>INFRASTRUCTURE_MODERNISATION.md</code> document the
analysis and performance estimates in detail.</p>
<hr>
<h3>Publishing pipeline (C++ side)</h3>
<p><strong>Eight parallel / IO improvements</strong> (<code>perf: eight publishing pipeline improvements</code>)</p>

Area | Change
-- | --
Directory traversal | FileSystemTraversal::RecurseParallel() — Phase 1 scans dirs in parallel across all CPUs, Phase 2 replays in serial DFS order to preserve SyncMediator callback contracts
Leaf catalog finalisation | SnapshotCatalogs() spawns one pthread per leaf catalog; reduces O(N × VACUUM_time) to O(max VACUUM_time)
Block sizes | TaskRead::kBlockSize 16 KB → 128 KB; TaskCompress::kCompressedBlockSize 8 KB → 64 KB; ~8× fewer tube dispatches
Hash stage | Merged into Compress stage; TaskHash, tubes_hash_, and tasks_hash_ removed from IngestionPipeline
Upload parallelism | num_upload_tasks default changed from 1 to min(16, max(4, CPU/2))
SQLite WAL | journal_mode=WAL for writable catalogs; sequential append replaces random-write rollback journals
Read-ahead | platform_fadvise_sequential() called from FileIngestionSource::Open()
Xattr pre-fetch | Xattrs read on traversal thread and cached in SyncItem; removes filesystem I/O from the pipeline callback path


<p><strong>Catalog and SQL fixes</strong> (<code>perf: gateway persistent receiver pool…</code>)</p>
<ul>
<li><code>IssueHardlinkGroupId()</code> caches <code>GetMaxLinkId()+1</code> on first call and increments in-memory — eliminates one <code>SELECT MAX</code> per hardlink group</li>
<li><code>VacuumDatabaseIfNecessary()</code> releases <code>lock_</code> before the VACUUM I/O to unblock sibling finalisation threads</li>
<li><code>sync_mediator</code>: added <code>hardlink_index_</code> (<code>unordered_map</code>) for O(1) hardlink master lookup, replacing O(N) linear scan</li>
<li>SQLite <code>PRAGMA cache_size=-65536</code> (64 MB) and <code>mmap_size=134217728</code> (128 MB) for writable opens</li>
</ul>
<p><strong>Note:</strong> <code>synchronous=OFF</code> was evaluated but reverted to <code>synchronous=FULL</code> after
further analysis; the WAL improvement alone is kept.</p>
<hr>
<h3>Gateway (Go side)</h3>
<p><strong>Persistent receiver pool</strong> — each worker now keeps a <code>cvmfs_receiver</code> process
alive across tasks instead of spawning and quitting one per commit. Saves
~300–600 ms per publish (fork + init overhead eliminated for steady-state traffic).
Crash detection distinguishes application errors (<code>receiver.Error</code>) from dead-pipe
I/O errors; the latter trigger transparent replacement.</p>
<p><strong>Per-repository lease locks</strong> — replaced the global <code>leaseMutex sync.Mutex</code>
with per-repository named locks (<code>NamedLocks</code>). Enables concurrent publishing to
different repositories with ~20× gateway throughput improvement for 10 concurrent
multi-repo publishes. Lock ordering <code>leaseNamedLocks[repo] → DB.Locks[repo]</code>
is cycle-free.</p>
<p><strong>Bug fixes:</strong></p>
<ul>
<li><code>CancelLease</code> was silently rejecting expired-but-still-present leases because
<code>repoForToken</code> enforced an expiry check. Added <code>repoForTokenAny</code> (no expiry
check) for <code>CancelLease</code>; <code>CommitLease</code> keeps the strict helper.</li>
<li>Added <code>_busy_timeout=5000</code> to SQLite connection string to prevent
<code>SQLITE_BUSY</code> under concurrent multi-repo writes.</li>
<li>Closed missing <code>close(task.Reply())</code> in error paths of <code>pool.go</code>.</li>
</ul>
<hr>
<h3>DirectGraft fast path in CommitProcessor</h3>
<p>When the commit POST body carries <code>"direct_graft": true</code>, the receiver skips
the <code>CatalogMergeTool</code> / DiffRec traversal entirely and grafts the pre-built
subtree catalog directly into the parent catalog via
<code>WritableCatalogManager::GraftNestedCatalog</code>. This is the correct primitive
for publishing a brand-new directory subtree when the publisher has already
assembled the full subtree catalog: there is nothing to diff — the receiver
only wires the new catalog into the parent and re-signs.
<code>GraftNestedCatalog</code> panics if the target path already exists in the parent,
providing a hard safety guard.</p>
<hr>
<h3>Testbed mode (<code>CVMFS_TESTBED=true</code>)</h3>
<p>Adds a <code>CVMFS_TESTBED</code> flag to <code>cvmfs_server</code> that activates a
container-friendly mode: skips Apache configuration, adjusts <code>LD_LIBRARY_PATH</code>
for non-standard library locations, and handles initial catalog signing when the
stratum0 HTTP endpoint is not yet reachable.</p>
<p><strong><code>swissknife sign -L</code></strong> — new flag to fetch the reflog from local backend
storage using <code>LocalObjectFetcher</code> instead of the stratum0 HTTP endpoint.
Needed for offline signing during testbed initialisation and initial repository
creation inside containers. The flag is only effective when the upstream is a
local spooler; other upstream types fall back to the HTTP path with a warning.</p>
<hr>
<h3>Tests</h3>
<p>New unit tests cover:</p>
<ul>
<li><code>IssueHardlinkGroupIdSequence</code> — verifies first-call DB init and in-memory increment</li>
<li><code>HardlinkGroupsGetDistinctIds</code> — two <code>AddHardlinkGroup</code> calls receive distinct sequential IDs</li>
<li><code>VacuumDatabaseNoDeadlock</code> — 50 add/remove cycles complete without deadlock</li>
<li><code>WritableDbPragmasApplied</code> — confirms <code>cache_size</code> and <code>mmap_size</code> are set on read-write opens only</li>
</ul></body></html>