### PR TITLE
Append the chain of Stratum1 URLs that where tried to fetch the manif…

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -15,6 +15,7 @@
 #include <climits>
 #include <cstring>
 #include <vector>
+#include <string>
 
 #include "duplex_fuse.h"  // IWYU pragma: keep
 
@@ -1326,6 +1327,13 @@ bool MountPoint::CreateCatalogManager() {
   if (!retval) {
     boot_error_ = "Failed to initialize root file catalog";
     boot_status_ = loader::kFailCatalog;
+    std::vector<std::string> host_chain;
+    download_mgr_->GetHostInfo(&host_chain,nullptr,nullptr);
+    boot_error_ += ". Server chain: ";
+
+    for(auto url :host_chain){
+      boot_error_+=url+"|";
+    }
     return false;
   }
 


### PR DESCRIPTION
Related to https://github.com/cvmfs/cvmfs/issues/4044

The error msg in case of failure now becomes:
```sh
$ sudo mount -t cvmfs lhcb-conddb.cern.ch /cvmfs/lhcb-condb.cern.ch
CernVM-FS: running with credentials 964:964
CernVM-FS: loading Fuse module... Failed to initialize root file catalog. Server chain: http://cvmfs-stratum-one.cern.ch/cvmfs/lhcb-conddb.cern.ch|http://cernvmfs.gridpp.rl.ac.uk/cvmfs/lhcb-conddb.cern.ch|http://cvmfs-s1bnl.opensciencegrid.org/cvmfs/lhcb-conddb.cern.ch|http://cvmfs-s1fnal.opensciencegrid.org/cvmfs/lhcb-conddb.cern.ch| (16 - file catalog failure)
```