### PR TITLE
server: never publish a snapshot with a missing root catalog

### DIFF
--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -321,7 +321,8 @@ bool CommandPull::PullRecursion(catalog::Catalog *catalog,
 
 bool CommandPull::Pull(const shash::Any &catalog_hash,
                        const std::string &path,
-                       shash::Any &previous_catalog) {
+                       shash::Any &previous_catalog,
+                       bool is_historic_catalog) {
   int retval;
   download::Failures dl_retval;
   assert(shash::kSuffixCatalog == catalog_hash.suffix);
@@ -390,10 +391,12 @@ bool CommandPull::Pull(const shash::Any &catalog_hash,
   dl_retval = download_manager()->Fetch(&download_catalog);
   fclose(fcatalog_vanilla);
   if (dl_retval != download::kFailOk) {
-    if (path == "" && is_garbage_collectable) {
+    const bool genuinely_missing = (dl_retval == download::kFailHostHttp)
+                                   && (download_catalog.http_code() == 404);
+    if (is_historic_catalog && is_garbage_collectable && genuinely_missing) {
       LogCvmfs(kLogCvmfs, kLogStdout,
-               "skipping missing root catalog %s - "
-               "probably sweeped by garbage collection",
+               "skipping missing catalog %s - "
+               "probably swept by garbage collection",
                catalog_hash.ToString().c_str());
       goto pull_skip;
     } else {
@@ -771,14 +774,21 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
 
   LogCvmfs(kLogCvmfs, kLogStdout, "Replicating from trunk catalog at /");
   current_catalog_hash = ensemble.manifest->catalog_hash();
-  do {
-    retval = Pull(current_catalog_hash, "", previous_catalog_hash);
-    if (pull_history && !previous_catalog_hash.IsNull()) {
-      LogCvmfs(kLogCvmfs, kLogStdout, "Replicating from historic catalog %s",
-               previous_catalog_hash.ToString().c_str());
-    }
-    current_catalog_hash = previous_catalog_hash;
-  } while (pull_history && !previous_catalog_hash.IsNull());
+  retval = 1;
+  {
+    bool is_historic = false;
+    do {
+      retval = static_cast<int>(
+          Pull(current_catalog_hash, "", previous_catalog_hash, is_historic)
+          && (retval != 0));
+      if (pull_history && !previous_catalog_hash.IsNull()) {
+        LogCvmfs(kLogCvmfs, kLogStdout, "Replicating from historic catalog %s",
+                 previous_catalog_hash.ToString().c_str());
+      }
+      current_catalog_hash = previous_catalog_hash;
+      is_historic = true;
+    } while (pull_history && !previous_catalog_hash.IsNull());
+  }
 
   if (!historic_tags.empty()) {
     LogCvmfs(kLogCvmfs, kLogStdout, "Checking tagged snapshots...");
@@ -793,10 +803,12 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
              i->name.c_str());
     apply_timestamp_threshold = false;
 
-    bool retval2;
+    bool retval2 = true;
     current_catalog_hash = i->root_hash;
     do {
-      retval2 = Pull(current_catalog_hash, "", previous_catalog_hash);
+      retval2 = Pull(current_catalog_hash, "", previous_catalog_hash,
+                     true /* is_historic_catalog */)
+                && retval2;
       if (pull_history && !previous_catalog_hash.IsNull()) {
         LogCvmfs(kLogCvmfs, kLogStdout, "Replicating from historic catalog %s",
                  previous_catalog_hash.ToString().c_str());
@@ -820,6 +832,15 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
 
   if (!retval)
     goto fini;
+
+  WaitForStorage();
+  if (!Peek(ensemble.manifest->catalog_hash())) {
+    LogCvmfs(kLogCvmfs, kLogStderr,
+             "root catalog %s is missing from the destination - refusing to "
+             "publish an incomplete revision",
+             ensemble.manifest->catalog_hash().ToString().c_str());
+    goto fini;
+  }
 
   // Upload manifest ensemble
   {

--- a/cvmfs/swissknife_pull.h
+++ b/cvmfs/swissknife_pull.h
@@ -56,7 +56,8 @@ class CommandPull : public Command {
 
  protected:
   bool PullRecursion(catalog::Catalog *catalog, const std::string &path);
-  bool Pull(const shash::Any &catalog_hash, const std::string &path, shash::Any &previous_catalog);
+  bool Pull(const shash::Any &catalog_hash, const std::string &path,
+            shash::Any &previous_catalog, bool is_historic_catalog = false);
 };
 
 }  // namespace swissknife


### PR DESCRIPTION
When a stratum 0 becomes unreachable or slow mid-replication, cvmfs_server snapshot can, under some circumstances, advance the stratum 1 to a revision whose root catalog was never replicated, leaving the repository broken for clients.

* Any download failure of a root catalog on a garbage-collectable repo was treated as "probably swept by garbage collection" and reported as success, but this should only apply to 404s, not timeouts due to slow network. 

* The skip also applied to the trunk/HEAD root catalog the manifest points to, which must never be absent. Add an is_historic_catalog flag so only previous revisions and named tags may be skipped; the HEAD catalog and nested catalogs are always required.

* The trunk and tag do/while loops overwrote retval each iteration. Pull() sets the previous_catalog out-param even on failure, so a failed HEAD pull was masked by a subsequent "Catalog up to date" historic revision. Accumulate failures with && instead.

Finally, add a guard before uploading the manifest ensemble and refuse to publish if it is missing.

Fixes #4270