### PR TITLE
fix(gw): don't hold leaseMutex during commit

### DIFF
--- a/gateway/internal/gateway/backend/lease_service.go
+++ b/gateway/internal/gateway/backend/lease_service.go
@@ -267,31 +267,49 @@ func (s *Services) CancelLease(ctx context.Context, token string) error {
 
 // CommitLease associated with the token (transaction commit)
 func (s *Services) CommitLease(ctx context.Context, token, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
-	leaseMutex.Lock()
-	defer leaseMutex.Unlock()
 	t0 := time.Now()
 
 	outcome := "success"
 	defer logAction(ctx, "commit_lease", &outcome, t0)
 
-	tx, err := s.DB.SQL.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("could not begin transaction: %w", err)
-	}
-	defer tx.Rollback()
+	// Look up and validate the lease. leaseMutex is only held for this short
+	// SQLite read, not for the (potentially very slow) commit below, so that
+	// concurrent lease listing/acquisition is not blocked behind a commit.
+	lease, err := func() (*Lease, error) {
+		leaseMutex.Lock()
+		defer leaseMutex.Unlock()
 
-	lease, err := FindLeaseByToken(ctx, tx, token)
+		tx, err := s.DB.SQL.BeginTx(ctx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not begin transaction: %w", err)
+		}
+		defer tx.Rollback()
+
+		lease, err := FindLeaseByToken(ctx, tx, token)
+		if err != nil {
+			outcome = err.Error()
+			return nil, err
+		}
+
+		if lease == nil || lease.Expiration.Before(time.Now()) {
+			err := InvalidLeaseError{}
+			outcome = err.Error()
+			return nil, err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("could not commit transaction: %w", err)
+		}
+
+		return lease, nil
+	}()
 	if err != nil {
-		outcome = err.Error()
 		return 0, err
 	}
 
-	if lease == nil || lease.Expiration.Before(time.Now()) {
-		err := InvalidLeaseError{}
-		outcome = err.Error()
-		return 0, err
-	}
-
+	// Perform the actual commit through the receiver. This can take a long
+	// time, so it must run without holding leaseMutex. The per-repository
+	// commit lock still serialises commits (and GC) for the same repository.
 	var finalRev uint64
 	if err := s.DB.WithLock(ctx, lease.Repository, func() error {
 		var err error
@@ -310,13 +328,30 @@ func (s *Services) CommitLease(ctx context.Context, token, oldRootHash, newRootH
 		}
 	}()
 
-	if err := DeleteLeaseByToken(ctx, tx, token); err != nil {
-		outcome = err.Error()
-		return finalRev, err
-	}
+	// Remove the now-committed lease. Again only a short SQLite write under
+	// leaseMutex.
+	if err := func() error {
+		leaseMutex.Lock()
+		defer leaseMutex.Unlock()
 
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("could not commit transaction: %w", err)
+		tx, err := s.DB.SQL.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("could not begin transaction: %w", err)
+		}
+		defer tx.Rollback()
+
+		if err := DeleteLeaseByToken(ctx, tx, token); err != nil {
+			outcome = err.Error()
+			return err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("could not commit transaction: %w", err)
+		}
+
+		return nil
+	}(); err != nil {
+		return finalRev, err
 	}
 
 	return finalRev, nil

--- a/gateway/internal/gateway/backend/lease_service_test.go
+++ b/gateway/internal/gateway/backend/lease_service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	gw "github.com/cvmfs/gateway/internal/gateway"
+	"github.com/cvmfs/gateway/internal/gateway/receiver"
 )
 
 func TestLeaseServiceNewLease(t *testing.T) {
@@ -280,4 +281,62 @@ func TestLeaseServiceCommitLease(t *testing.T) {
 			t.Fatalf("expired lease should not have been accepted for commit")
 		}
 	})
+}
+
+// TestCommitLeaseDoesNotBlockGetLeases is a regression test for issue #4103: a
+// slow commit must not hold leaseMutex while the external receiver is running,
+// otherwise lease listing blocks for the whole commit duration.
+func TestCommitLeaseDoesNotBlockGetLeases(t *testing.T) {
+	backend, tmp := StartTestBackend("lease_concurrency_test", 10*time.Second)
+	defer func() {
+		backend.Stop()
+		os.RemoveAll(tmp)
+	}()
+
+	keyID := "keyid1"
+	leasePath := "test2.repo.org/some/path"
+	token, err := backend.NewLease(context.TODO(), keyID, leasePath, "host", 3)
+	if err != nil {
+		t.Fatalf("could not obtain new lease: %v", err)
+	}
+
+	// Gate the mock receiver so the commit parks in flight, holding only the
+	// per-repository lock (not leaseMutex).
+	gate := make(chan struct{})
+	entered := receiver.SetMockCommitGate(gate)
+	defer receiver.SetMockCommitGate(nil)
+
+	commitDone := make(chan struct{})
+	go func() {
+		backend.CommitLease(context.TODO(), token, "old_hash", "new_hash", gw.RepositoryTag{Name: "mytag"})
+		close(commitDone)
+	}()
+
+	// Wait until the commit is actually parked inside the receiver, so that on
+	// the buggy code leaseMutex is provably held while we time GetLeases.
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("commit never reached the receiver")
+	}
+
+	// GetLeases must return promptly even while the commit is parked, since it
+	// no longer waits on leaseMutex held across the external commit.
+	getLeasesDone := make(chan struct{})
+	go func() {
+		if _, err := backend.GetLeases(context.TODO()); err != nil {
+			t.Errorf("GetLeases failed: %v", err)
+		}
+		close(getLeasesDone)
+	}()
+
+	select {
+	case <-getLeasesDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetLeases blocked behind an in-flight CommitLease (issue #4103 regression)")
+	}
+
+	// Release the parked commit and let it finish cleanly.
+	close(gate)
+	<-commitDone
 }

--- a/gateway/internal/gateway/receiver/mock_receiver.go
+++ b/gateway/internal/gateway/receiver/mock_receiver.go
@@ -14,6 +14,29 @@ type MockReceiver struct {
 	ctx context.Context
 }
 
+// mockCommitGate, when non-nil, blocks MockReceiver.Commit until it can receive
+// from the channel. mockCommitEntered is signalled each time a commit reaches
+// the gate. Both are used by tests to keep a commit parked in flight.
+var (
+	mockCommitGate    chan struct{}
+	mockCommitEntered chan struct{}
+)
+
+// SetMockCommitGate makes every subsequent mock commit block until a value can
+// be received from release. The returned channel receives a value each time a
+// commit reaches the gate, letting tests wait until a commit is parked in
+// flight. Pass nil to remove the gate.
+func SetMockCommitGate(release chan struct{}) <-chan struct{} {
+	mockCommitGate = release
+	if release == nil {
+		mockCommitEntered = nil
+		return nil
+	}
+	entered := make(chan struct{}, 1)
+	mockCommitEntered = entered
+	return entered
+}
+
 // NewMockReceiver constructs a new MockReceiver object which implements the
 // Receiver interface
 func NewMockReceiver(ctx context.Context) (Receiver, error) {
@@ -35,6 +58,15 @@ func (r *MockReceiver) Echo() error {
 }
 
 func (r *MockReceiver) Commit(leasePath, oldRootHash, newRootHash string, tag gw.RepositoryTag) (uint64, error) {
+	if entered := mockCommitEntered; entered != nil {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+	}
+	if gate := mockCommitGate; gate != nil {
+		<-gate
+	}
 	gw.LogC(r.ctx, "mock_receiver", gw.LogDebug).
 		Str("command", "commit").
 		Str("lease_path", leasePath).


### PR DESCRIPTION
`CommitLease` held the global `leaseMutex` for its whole duration, including the slow external receiver call. Because `GetLeases` acquires the same mutex, listing leases blocked behind any in-flight commit, causing `/api/v1/leases` to be extremely slow when the gateway is busy.

Split `CommitLease` into three phases so `leaseMutex` only guards the short SQLite reads/writes: look up + validate the lease, run the receiver commit without `leaseMutex` (still serialised per-repository by the existing per-repo commit lock), then delete the committed lease. This also removes the nested leaseMutex -> repo-lock acquisition.

Fixes #4103