### PR TITLE
tidy: Make template impl headers self-contained

### DIFF
--- a/cvmfs/catalog_counters_impl.h
+++ b/cvmfs/catalog_counters_impl.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 
+#include "catalog_counters.h"
 #include "catalog_sql.h"
 #include "util/string.h"
 

--- a/cvmfs/server_tool_impl.h
+++ b/cvmfs/server_tool_impl.h
@@ -7,6 +7,8 @@
 
 #include <string>
 
+#include "server_tool.h"
+
 template<class ObjectFetcherT>
 manifest::Reflog *ServerTool::FetchReflog(ObjectFetcherT *object_fetcher,
                                           const std::string &repo_name,

--- a/cvmfs/sql_impl.h
+++ b/cvmfs/sql_impl.h
@@ -11,6 +11,7 @@
 #include <cerrno>
 #include <string>
 
+#include "sql.h"
 #include "sqlitemem.h"
 #include "util/logging.h"
 #include "util/platform.h"


### PR DESCRIPTION
The *_impl.h template implementation headers are included at the bottom of their primary header, after the corresponding class is declared. They did not include that primary header themselves, so they could not be parsed as a standalone translation unit. This made clang-tidy emit spurious parse errors (undeclared identifiers, protected-member access, out-of-line definition without definition) whenever clang-tidy-diff fed one of these headers to the compiler directly.

Add the self-include guarded by the existing include guard, matching the convention already used by catalog_mgr_impl.h and catalog_diff_tool_impl.h.