### PR TITLE
Ignore missing hardlink targets when ingesting container layers

### DIFF
--- a/cvmfs/catalog_mgr_rw.cc
+++ b/cvmfs/catalog_mgr_rw.cc
@@ -284,16 +284,33 @@ void WritableCatalogManager::RemoveDirectory(const std::string &path) {
  * @params destination, the name of the new file, complete path
  * @params source, the name of the file to clone, which must be already in the
  * repository
- * @return void
+ * @params fail_if_source_missing, when true (default) abort if the source is
+ * not in the catalog; when false, skip the clone and return false instead.
+ * This is used by the tarball ingestion engine to tolerate hardlinks whose
+ * target is not part of the same archive (e.g. cross-layer hardlinks in OCI
+ * image layers).
+ * @return true if the file was cloned, false if the source was missing and
+ * fail_if_source_missing was false
  */
-void WritableCatalogManager::Clone(const std::string destination,
-                                   const std::string source) {
+bool WritableCatalogManager::Clone(const std::string destination,
+                                   const std::string source,
+                                   const bool fail_if_source_missing) {
   const std::string relative_source = MakeRelativePath(source);
 
   DirectoryEntry source_dirent;
   if (!LookupPath(relative_source, kLookupDefault, &source_dirent)) {
-    PANIC(kLogStderr, "catalog for file '%s' cannot be found, aborting",
-          source.c_str());
+    if (fail_if_source_missing) {
+      PANIC(kLogStderr, "catalog for file '%s' cannot be found, aborting",
+            source.c_str());
+    }
+    // The caller opted out of aborting and is expected to handle the missing
+    // source (e.g. by materializing a replacement file), so only log at debug
+    // level here to avoid duplicate user-facing warnings.
+    LogCvmfs(kLogCatalog, kLogDebug,
+             "catalog for clone source '%s' cannot be found, not cloning "
+             "to '%s'",
+             source.c_str(), destination.c_str());
+    return false;
   }
   if (source_dirent.IsDirectory()) {
     PANIC(kLogStderr, "Trying to clone a directory: '%s', aborting",
@@ -319,6 +336,7 @@ void WritableCatalogManager::Clone(const std::string destination,
   // TODO(jblomer): clone is used by tarball engine and should eventually
   // support extended attributes
   this->AddFile(destination_dirent, empty_xattrs, destination_dirname);
+  return true;
 }
 
 

--- a/cvmfs/catalog_mgr_rw.h
+++ b/cvmfs/catalog_mgr_rw.h
@@ -118,7 +118,8 @@ class WritableCatalogManager : public SimpleCatalogManager {
                       const std::string &directory_path);
   void RemoveDirectory(const std::string &directory_path);
 
-  void Clone(const std::string from, const std::string to);
+  bool Clone(const std::string from, const std::string to,
+             const bool fail_if_source_missing = true);
   void CloneTree(const std::string &from_dir, const std::string &to_dir);
 
   // Hardlink group handling

--- a/cvmfs/directory_entry.h
+++ b/cvmfs/directory_entry.h
@@ -27,6 +27,7 @@ class SyncItemNative;
 class SyncItemTar;
 class SyncItemDummyDir;
 class SyncItemDummyCatalog;
+class SyncItemDummyFile;
 }  // namespace publish
 namespace swissknife {
 class CommandMigrate;
@@ -69,6 +70,7 @@ class DirectoryEntryBase {
   friend class publish::SyncItemTar;
   friend class publish::SyncItemDummyDir;
   friend class publish::SyncItemDummyCatalog;
+  friend class publish::SyncItemDummyFile;
   friend class swissknife::CommandOverlay;
   friend class swissknife::IngestSQL;  // TODO(vvolkl): can probably avoided
                                        // with new setters

--- a/cvmfs/server/cvmfs_server_ingest.sh
+++ b/cvmfs/server/cvmfs_server_ingest.sh
@@ -118,6 +118,7 @@ cvmfs_server_ingest() {
   local keep_ownership=false
   local create_catalog=false
   local fast_delete=false
+  local tolerate_missing_hardlinks=false
   local gc_db=""
 
   local force_native=0
@@ -174,6 +175,9 @@ cvmfs_server_ingest() {
       --gc-db )
         gc_db=$2
         fast_delete=true
+        ;;
+      -m | --tolerate-missing-hardlinks )
+        tolerate_missing_hardlinks=true
         ;;
     esac
     shift
@@ -500,6 +504,10 @@ cvmfs_server_ingest() {
 
   if [ "$fast_delete" = true ]; then
     ingest_command="$ingest_command -f"
+  fi
+
+  if [ "$tolerate_missing_hardlinks" = true ]; then
+    ingest_command="$ingest_command -m"
   fi
 
   if [ ! x"$gc_db" = "x" ]; then

--- a/cvmfs/server/cvmfs_server_util.sh
+++ b/cvmfs/server/cvmfs_server_util.sh
@@ -1427,6 +1427,9 @@ Supported Commands:
                   -b base directory
                   [-d <folder to delete>]
                   [-c create nested catalog in base directory]
+                  [-m tolerate hardlinks whose target is missing from the
+                      tarball; materialize an empty file with a warning
+                      instead of aborting]
                   [--gc-db <path to GC SQLite database>]
                   <fully qualified name>
                   Extract the content of the tarfile inside the base directory,

--- a/cvmfs/swissknife_ingest.cc
+++ b/cvmfs/swissknife_ingest.cc
@@ -101,6 +101,9 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   if (args.find('f') != args.end()) {
     params.fast_delete = true;
   }
+  if (args.find('m') != args.end()) {
+    params.tolerate_missing_hardlinks = true;
+  }
   shash::Algorithms hash_algorithm = shash::kSha1;
   if (args.find('e') != args.end()) {
     hash_algorithm = shash::ParseHashAlgorithm(*args.find('e')->second);
@@ -217,7 +220,7 @@ int swissknife::Ingest::Main(const swissknife::ArgumentList &args) {
   publish::SyncUnion *sync = new publish::SyncUnionTarball(
       &mediator, params.dir_rdonly, params.tar_file, params.base_directory,
       params.uid, params.gid, params.to_delete, create_catalog,
-      params.fast_delete, "///");
+      params.fast_delete, "///", params.tolerate_missing_hardlinks);
 
   if (!sync->Initialize()) {
     LogCvmfs(kLogCvmfs, kLogStderr,

--- a/cvmfs/swissknife_ingest.h
+++ b/cvmfs/swissknife_ingest.h
@@ -49,6 +49,9 @@ class Ingest : public Command {
         "gid of new owner of the ingested data (-1 for keep tarball owner)"));
     r.push_back(Parameter::Switch('j', "enable nanosecond timestamps"));
     r.push_back(Parameter::Switch('f', "fast delete for nested catalogs"));
+    r.push_back(Parameter::Switch(
+        'm', "tolerate hardlinks whose target is missing from the tarball "
+             "(materialize an empty file with a warning instead of aborting)"));
     r.push_back(Parameter::Optional(
         'Q', "GC SQLite database: read pending paths and delete them"));
     r.push_back(Parameter::Optional(

--- a/cvmfs/swissknife_sync.h
+++ b/cvmfs/swissknife_sync.h
@@ -38,6 +38,7 @@ struct SyncParameters {
       , include_xattrs(false)
       , enable_mtime_ns(false)
       , fast_delete(false)
+      , tolerate_missing_hardlinks(false)
       , external_data(false)
       , direct_io(false)
       , voms_authz(false)
@@ -92,6 +93,7 @@ struct SyncParameters {
   bool include_xattrs;
   bool enable_mtime_ns;
   bool fast_delete;
+  bool tolerate_missing_hardlinks;
   bool external_data;
   bool direct_io;
   bool voms_authz;

--- a/cvmfs/sync_item_dummy.h
+++ b/cvmfs/sync_item_dummy.h
@@ -59,6 +59,73 @@ class SyncItemDummyCatalog : public SyncItem {
   void MakePlaceholderDirectory() const { }
 };
 
+/**
+ * Represents an empty regular file that is materialized on the fly, without a
+ * backing entry in the tarball.  It is used by the tarball engine to stand in
+ * for a hardlink whose target is not part of the archive (e.g. a cross-layer
+ * hardlink in an OCI image layer): instead of cloning a non-existent source we
+ * create an empty file with the link's own ownership and permissions.  The
+ * content (and therefore the content hash) is the empty string, pushed through
+ * the normal ingestion pipeline so that the empty object is uploaded and
+ * compressed/hashed consistently with the spooler configuration.
+ */
+class SyncItemDummyFile : public SyncItem {
+  friend class SyncUnionTarball;
+
+ protected:
+  SyncItemDummyFile(const std::string &relative_parent_path,
+                    const std::string &filename, const SyncUnion *union_engine,
+                    const unsigned int mode, const uid_t uid, const gid_t gid,
+                    const time_t mtime)
+      : SyncItem(relative_parent_path, filename, union_engine, kItemFile)
+      , mode_(mode)
+      , uid_(uid)
+      , gid_(gid)
+      , mtime_(mtime) { }
+
+ public:
+  bool IsType(const SyncItemType expected_type) const {
+    return expected_type == kItemFile;
+  }
+
+  catalog::DirectoryEntryBase CreateBasicCatalogDirent(
+      bool /* enable_mtime_ns */) const {
+    catalog::DirectoryEntryBase dirent;
+    dirent.inode_ = catalog::DirectoryEntry::kInvalidInode;
+    dirent.linkcount_ = 1;
+    // Force a regular file type, keeping only the permission bits of the
+    // original hardlink entry.
+    dirent.mode_ = (mode_ & 07777) | S_IFREG;
+    dirent.uid_ = uid_;
+    dirent.gid_ = gid_;
+    dirent.size_ = 0;
+    dirent.mtime_ = mtime_;
+    dirent.checksum_ = this->GetContentHash();
+    dirent.is_external_file_ = false;
+    dirent.compression_algorithm_ = this->GetCompressionAlgorithm();
+
+    dirent.name_.Assign(this->filename().data(), this->filename().length());
+
+    return dirent;
+  }
+
+  IngestionSource *CreateIngestionSource() const {
+    return new StringIngestionSource("", GetUnionPath());
+  }
+
+  void StatScratch(const bool /* refresh */) const { return; }
+
+  SyncItemType GetScratchFiletype() const { return kItemFile; }
+
+  void MakePlaceholderDirectory() const { }
+
+ private:
+  const unsigned int mode_;
+  const uid_t uid_;
+  const gid_t gid_;
+  const time_t mtime_;
+};
+
 /*
  * This class represents dummy directories that we know are going to be there
  * but we still haven't found yet. This is possible in the extraction of

--- a/cvmfs/sync_mediator.cc
+++ b/cvmfs/sync_mediator.cc
@@ -260,8 +260,9 @@ void SyncMediator::Replace(SharedPtr<SyncItem> entry) {
   Add(entry);
 }
 
-void SyncMediator::Clone(const std::string from, const std::string to) {
-  catalog_manager_->Clone(from, to);
+bool SyncMediator::Clone(const std::string from, const std::string to,
+                         bool fail_if_source_missing) {
+  return catalog_manager_->Clone(from, to, fail_if_source_missing);
 }
 
 void SyncMediator::EnterDirectory(SharedPtr<SyncItem> entry) {
@@ -347,6 +348,13 @@ bool SyncMediator::Commit(manifest::Manifest *manifest) {
 
   if (union_engine_)
     union_engine_->PostUpload();
+
+  // PostUpload may have spooled additional files (the tarball engine
+  // materializes empty files for hardlinks whose target is missing from the
+  // archive).  Wait for those uploads so their catalog entries are added by
+  // the file callback before the listeners are unregistered below.
+  if (!params_->dry_run)
+    params_->spooler->WaitForUpload();
 
   params_->spooler->UnregisterListeners();
 

--- a/cvmfs/sync_mediator.h
+++ b/cvmfs/sync_mediator.h
@@ -115,7 +115,10 @@ class AbstractSyncMediator {
   virtual void Touch(SharedPtr<SyncItem> entry) = 0;
   virtual void Remove(SharedPtr<SyncItem> entry, bool fast_delete = false) = 0;
   virtual void Replace(SharedPtr<SyncItem> entry) = 0;
-  virtual void Clone(const std::string from, const std::string to) = 0;
+  // Returns false if the source was missing and fail_if_source_missing was
+  // false (the clone was skipped); true otherwise.
+  virtual bool Clone(const std::string from, const std::string to,
+                     bool fail_if_source_missing) = 0;
 
   virtual void AddUnmaterializedDirectory(SharedPtr<SyncItem> entry) = 0;
 
@@ -158,7 +161,8 @@ class SyncMediator : public virtual AbstractSyncMediator {
   void Touch(SharedPtr<SyncItem> entry);
   void Remove(SharedPtr<SyncItem> entry, bool fast_delete = false);
   void Replace(SharedPtr<SyncItem> entry);
-  void Clone(const std::string from, const std::string to);
+  bool Clone(const std::string from, const std::string to,
+             bool fail_if_source_missing);
 
   void AddUnmaterializedDirectory(SharedPtr<SyncItem> entry);
 

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -37,7 +37,8 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
                                    const std::string &to_delete,
                                    const bool create_catalog_on_root,
                                    const bool fast_delete,
-                                   const std::string &path_delimiter)
+                                   const std::string &path_delimiter,
+                                   const bool tolerate_missing_hardlinks)
     : SyncUnion(mediator, rdonly_path, "", "")
     , src(NULL)
     , tarball_path_(tarball_path)
@@ -48,6 +49,7 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
     , create_catalog_on_root_(create_catalog_on_root)
     , fast_delete_(fast_delete)
     , path_delimiter_(path_delimiter)
+    , tolerate_missing_hardlinks_(tolerate_missing_hardlinks)
     , read_archive_signal_(new Signal) { }
 
 SyncUnionTarball::~SyncUnionTarball() { delete read_archive_signal_; }
@@ -230,11 +232,21 @@ void SyncUnionTarball::ProcessArchiveEntry(struct archive_entry *entry) {
                                      ? base_directory_ + "/" + hardlink_name
                                      : hardlink_name;
 
+    // Capture the link's own ownership/permissions so that, if the target is
+    // not part of this archive, an empty file can be materialized in its place
+    // (see PostUpload and tolerate_missing_hardlinks_).  Read directly from the
+    // tar header, applying the same uid/gid override as SyncItemTar.
+    const struct stat *link_stat = archive_entry_stat(entry);
+    const uid_t link_uid = (uid_ != -1u) ? uid_ : link_stat->st_uid;
+    const gid_t link_gid = (gid_ != -1u) ? gid_ : link_stat->st_gid;
+    const HardlinkDestination destination(complete_path, link_stat->st_mode,
+                                          link_uid, link_gid,
+                                          link_stat->st_mtime);
     if (hardlinks_.find(hardlink) != hardlinks_.end()) {
-      hardlinks_.find(hardlink)->second.push_back(complete_path);
+      hardlinks_.find(hardlink)->second.push_back(destination);
     } else {
-      std::list<std::string> to_hardlink;
-      to_hardlink.push_back(complete_path);
+      std::list<HardlinkDestination> to_hardlink;
+      to_hardlink.push_back(destination);
       hardlinks_[hardlink] = to_hardlink;
     }
     if (filename == ".cvmfscatalog") {
@@ -306,13 +318,39 @@ std::string SyncUnionTarball::SanitizePath(const std::string &path) {
 }
 
 void SyncUnionTarball::PostUpload() {
-  std::map<const std::string, std::list<std::string> >::iterator hardlink;
+  // When tolerating missing hardlink targets we ask Clone not to abort on a
+  // missing source; it returns false instead and we materialize an empty file.
+  const bool fail_if_target_missing = !tolerate_missing_hardlinks_;
+  std::map<const std::string, std::list<HardlinkDestination> >::iterator
+      hardlink;
   for (hardlink = hardlinks_.begin(); hardlink != hardlinks_.end();
        ++hardlink) {
-    std::list<std::string>::iterator entry;
+    const std::string &target = hardlink->first;
+    std::list<HardlinkDestination>::iterator entry;
     for (entry = hardlink->second.begin(); entry != hardlink->second.end();
          ++entry) {
-      mediator_->Clone(*entry, hardlink->first);
+      const bool cloned = mediator_->Clone(entry->path, target,
+                                           fail_if_target_missing);
+      if (cloned)
+        continue;
+
+      // The hardlink target is not part of this archive (e.g. a cross-layer
+      // hardlink in an OCI image layer).  Materialize an empty regular file at
+      // the link's path, preserving its ownership and permissions, and push it
+      // through the normal ingestion pipeline so the empty object is stored.
+      std::string parent_path;
+      std::string filename;
+      SplitPath(entry->path, &parent_path, &filename);
+      if (parent_path == ".")
+        parent_path.clear();
+      const SharedPtr<SyncItem> empty_file = SharedPtr<SyncItem>(
+          new SyncItemDummyFile(parent_path, filename, this, entry->mode,
+                                entry->uid, entry->gid, entry->mtime));
+      ProcessFile(empty_file);
+      LogCvmfs(kLogUnionFs, kLogStderr | kLogSyslogWarn,
+               "hardlink target '%s' is not present in the tarball; "
+               "materialized an empty file at '%s'",
+               target.c_str(), entry->path.c_str());
     }
   }
 }

--- a/cvmfs/sync_union_tarball.h
+++ b/cvmfs/sync_union_tarball.h
@@ -35,7 +35,8 @@ class SyncUnionTarball : public SyncUnion {
                    const std::string &to_delete,
                    const bool create_catalog_on_root,
                    const bool fast_delete = false,
-                   const std::string &path_delimiter = ":");
+                   const std::string &path_delimiter = ":",
+                   const bool tolerate_missing_hardlinks = false);
 
   ~SyncUnionTarball();
 
@@ -72,6 +73,11 @@ class SyncUnionTarball : public SyncUnion {
   const bool create_catalog_on_root_;
   const bool fast_delete_;
   const std::string path_delimiter_;  ///< delimiter used to split paths
+  /// when true, a hardlink whose target is not present in the archive is
+  /// materialized as an empty file (with a warning) instead of aborting the
+  /// ingestion (used by ducc for OCI image layers that may contain cross-layer
+  /// hardlinks)
+  const bool tolerate_missing_hardlinks_;
   std::set<std::string>
       know_directories_;  ///< directory that we know already exist
 
@@ -88,10 +94,26 @@ class SyncUnionTarball : public SyncUnion {
   std::map<std::string, SharedPtr<SyncItem> > dirs_;
 
   /**
-   * map all the file that point to the same hardlink to the path of the file
-   * itself
+   * A hardlink destination: the path of the link plus the ownership and
+   * permission metadata captured from its tar header.  The metadata is only
+   * needed to materialize an empty file when the hardlink target is missing
+   * from the archive (see tolerate_missing_hardlinks_).
    */
-  std::map<const std::string, std::list<std::string> > hardlinks_;
+  struct HardlinkDestination {
+    HardlinkDestination(const std::string &p, unsigned int m, uid_t u, gid_t g,
+                        time_t t)
+        : path(p), mode(m), uid(u), gid(g), mtime(t) { }
+    std::string path;
+    unsigned int mode;
+    uid_t uid;
+    gid_t gid;
+    time_t mtime;
+  };
+
+  /**
+   * map the path of a hardlink target to the list of links pointing to it
+   */
+  std::map<const std::string, std::list<HardlinkDestination> > hardlinks_;
 
   /**
    * Conditional variable to keep track of when is possible to read the tar file

--- a/doc/fix-ducc-missing-hardlink-targets.md
+++ b/doc/fix-ducc-missing-hardlink-targets.md
@@ -1,0 +1,69 @@
+# Tolerating hardlinks with missing targets in tarball ingestion
+
+## Problem
+
+`cvmfs_ducc` ingests each OCI/Docker image layer independently into its own
+isolated subtree `.layers/<digest>/layerfs` via `cvmfs_server ingest`. Some
+layers (e.g. `dnf clean`-style cache-cleaning layers) contain many identical
+0-byte files — whiteout markers (`.wh.*`) and empty cache placeholders — that
+the image exporter deduplicates into **hardlinks pointing at a single canonical
+0-byte member**. When that canonical member lives in a *lower* layer, the layer
+being ingested contains a hardlink whose target is not present in its own tar
+(a cross-layer / dangling hardlink).
+
+The tarball engine resolves every tar hardlink in `PostUpload` by cloning it
+from its target (`WritableCatalogManager::Clone` → `LookupPath`). A missing
+target aborted the whole ingest:
+
+```
+PANIC: catalog_mgr_rw.cc : catalog for file
+  '.layers/47/4714.../layerfs/var/cache/dnf/.../comps.xml.gz'
+  cannot be found, aborting
+terminate called after throwing an instance of 'ECvmfsException'
+```
+
+The crash is a deterministic property of the offending layer's tar; it was not
+reproducible on a blank test repo only because that conversion ingested a
+different (self-consistent) image build, not because of repo state. (DUCC also
+skips a layer entirely if `.layers/<digest>/layerfs` already exists, so a
+half-failed ingest never commits and re-crashes on every run.)
+
+## Fix
+
+Add an **opt-in** flag that makes the tarball engine tolerate a hardlink whose
+target is absent from the archive by **materializing an empty regular file** at
+the link's path instead of aborting. The default behavior of every other caller
+(`cvmfs_server publish`, etc.) is unchanged — they still abort.
+
+- `WritableCatalogManager::Clone` gains `fail_if_source_missing` (default
+  `true`). When `false`, a missing source returns `false` instead of `PANIC`.
+- `SyncUnionTarball::PostUpload`: on a missing target it creates a
+  `SyncItemDummyFile` (a new empty-content `SyncItem`, analogous to the
+  `.cvmfscatalog` marker) at the link path, preserving the link's
+  ownership/permissions, and pushes it through the normal ingestion pipeline so
+  the empty object is compressed, hashed, and uploaded consistently. The link's
+  `mode/uid/gid/mtime` are captured from the tar header at processing time
+  (the `archive_entry` is reused, so they cannot be read later).
+- `SyncMediator::Commit` waits for these late uploads before unregistering the
+  spooler listeners, so the materialized files' catalog entries are added.
+- Plumbed end to end: `swissknife ingest -m` →
+  `cvmfs_server ingest -m / --tolerate-missing-hardlinks` →
+  `cvmfs_ducc` passes `--tolerate-missing-hardlinks` on every layer ingest.
+
+A fabricated catalog entry with a null hash is not enough: the client rejects
+null hashes (`fetch.cc` → `-EIO`), so the empty object must actually exist in
+storage — hence materialization goes through the spooler rather than just
+writing a directory entry.
+
+## Files touched
+
+- `cvmfs/catalog_mgr_rw.{h,cc}` — `Clone` returns `bool`, optional non-fatal.
+- `cvmfs/sync_mediator.{h,cc}` — propagate the flag; wait for late uploads.
+- `cvmfs/sync_union_tarball.{h,cc}` — capture link stat; materialize on miss.
+- `cvmfs/sync_item_dummy.h` — new `SyncItemDummyFile`.
+- `cvmfs/directory_entry.h` — friend declaration for `SyncItemDummyFile`.
+- `cvmfs/swissknife_ingest.{h,cc}`, `cvmfs/swissknife_sync.h` — `-m` flag.
+- `cvmfs/server/cvmfs_server_ingest.sh`, `cvmfs/server/cvmfs_server_util.sh` —
+  `--tolerate-missing-hardlinks` option and usage.
+- `test/unittests/mock/m_sync_mediator.h` — updated mock signature.
+- `ducc/lib/image.go` — pass the flag when ingesting layers.

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -142,36 +142,65 @@ if [ "$1" == "overlay" ]; then
   fi
 fi
 
-# cvmfs_server ingest --catalog -t - -b <dir> <repo>
-arg2=$(echo $@ | cut -d ' ' -f 2)
-arg3=$(echo $@ | cut -d ' ' -f 3)
-arg4=$(echo $@ | cut -d ' ' -f 4)
-arg5=$(echo $@ | cut -d ' ' -f 5)
+# cvmfs_server ingest [--catalog] -t <tar|-> [--tolerate-missing-hardlinks] -b <dir> <repo>
+#
+# Parse the options position-independently.  The real cvmfs_server uses a
+# getopts-style loop, so flags may appear in any order; in particular the
+# tarball engine's --tolerate-missing-hardlinks (-m) sits between "-t -" and
+# "-b", which used to shift "-b" out of the fixed argument slot and silently
+# disable extraction here.
 if [ "$1" == "ingest" ]; then
-  if [ "$arg2" == "--catalog" ]; then
-    if [ "$arg3" == "-t" ]; then
-      if [ "$arg4" == "-" ]; then
-        if [ "$arg5" == "-b" ]; then
-          # Get the base directory (6th argument)
-          base_dir="$6"
-          # Get the repo argument (7th argument)
-          repo_arg="$7"
-          
-          # Extract repo name and subdir
-          repo_name=$(get_repo_name "$repo_arg")
-          subdir=$(get_subdir "$repo_arg")
-          
-          # If there's a subdir, prepend it to the base directory
-          if [ -n "$subdir" ]; then
-              base_dir="$subdir/$base_dir"
-          fi
-          
-          echo "ingesting to $CVMFS_TEST_REPO/$base_dir (repo: $repo_name, subdir: $subdir)"
-          mkdir -p /$CVMFS_TEST_REPO/$base_dir
-          cat - > /tmp/tmptar.tar
-          tar xf /tmp/tmptar.tar -C /$CVMFS_TEST_REPO/$base_dir
-        fi
-      fi
+  shift
+  ingest_tar=""        # tar source: a path, or "-" for stdin
+  ingest_stdin=false
+  base_dir=""
+  repo_arg=""
+  tolerate_missing_hardlinks=false
+  saw_ingest_opts=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --catalog | -c )
+        saw_ingest_opts=true; shift ;;
+      -t | --tar_file )
+        ingest_tar="$2"; saw_ingest_opts=true
+        [ "$2" == "-" ] && ingest_stdin=true
+        shift 2 ;;
+      -b | --base_dir )
+        base_dir="$2"; saw_ingest_opts=true; shift 2 ;;
+      -m | --tolerate-missing-hardlinks )
+        tolerate_missing_hardlinks=true; saw_ingest_opts=true; shift ;;
+      * )
+        repo_arg="$1"; shift ;;
+    esac
+  done
+
+  # Only the tarball-ingest form is mocked here; the --delete / --fast-delete
+  # forms are handled by their own blocks above.
+  if [ "$saw_ingest_opts" == true ] && [ -n "$base_dir" ] && [ -n "$ingest_tar" ]; then
+    # Extract repo name and subdir
+    repo_name=$(get_repo_name "$repo_arg")
+    subdir=$(get_subdir "$repo_arg")
+
+    # If there's a subdir, prepend it to the base directory
+    if [ -n "$subdir" ]; then
+        base_dir="$subdir/$base_dir"
+    fi
+
+    echo "ingesting to $CVMFS_TEST_REPO/$base_dir (repo: $repo_name, subdir: $subdir, tolerate_missing_hardlinks: $tolerate_missing_hardlinks)"
+    mkdir -p /$CVMFS_TEST_REPO/$base_dir
+    if [ "$ingest_stdin" == true ]; then
+        cat - > /tmp/tmptar.tar
+    else
+        cp "$ingest_tar" /tmp/tmptar.tar
+    fi
+    if [ "$tolerate_missing_hardlinks" == true ]; then
+        # The real engine materializes an empty file for a hardlink whose
+        # target is missing from the archive; GNU tar instead fails the entry
+        # (exit != 0) but still extracts everything else.  Mirror "tolerate" by
+        # not letting a dangling hardlink fail the ingest.
+        tar xf /tmp/tmptar.tar -C /$CVMFS_TEST_REPO/$base_dir 2>/dev/null || true
+    else
+        tar xf /tmp/tmptar.tar -C /$CVMFS_TEST_REPO/$base_dir
     fi
   fi
 fi

--- a/ducc/lib/image.go
+++ b/ducc/lib/image.go
@@ -904,6 +904,7 @@ func (d *downloadedLayer) IngestIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo
 
 	err := cvmfs.IngestWithLogger(logger, CVMFSRepo, d.Path,
 		"--catalog", "-t", "-",
+		"--tolerate-missing-hardlinks",
 		"-b", ingestPath)
 	if err != nil {
 		logger.WithFields(log.Fields{"layer": d.Name, "error": err}).

--- a/test/unittests/mock/m_sync_mediator.h
+++ b/test/unittests/mock/m_sync_mediator.h
@@ -43,7 +43,9 @@ class MockSyncMediator : public AbstractSyncMediator {
     last_fast_delete = fast_delete;
   }
   virtual void Replace(SharedPtr<SyncItem> /* entry */) { }
-  virtual void Clone(const std::string /* from */, const std::string /* to */) {
+  virtual bool Clone(const std::string /* from */, const std::string /* to */,
+                     bool /* fail_if_source_missing */) {
+    return true;
   }
 
   virtual void AddUnmaterializedDirectory(SharedPtr<SyncItem> /* entry */) {


### PR DESCRIPTION
Tar files representing OCI container layers are allowed to add hardlinks referencing targets in earlier layers (the overlay engine keeps an inode table). CVMFS ingest will panic when encountering a missing hardlink target in a tarball. This happens most commonly on whiteout files (which are zero-byte). This doesn't trigger often, and when it does it's often on a forgotten dnf/apt cache which should be removed anyway. However, the unpacking should be fixed, and this PR does this by adding an option to materialize hardlinks with missing targets as empty files. This does not yet handle correctly the case where  the hardlink target is a non-empty file, but this should be even more rare, if needed at all.