### PR TITLE
` cvmfs_ducc convert` without fuse mounts

### DIFF
--- a/cvmfs/server/cvmfs_server_overlay.sh
+++ b/cvmfs/server/cvmfs_server_overlay.sh
@@ -10,6 +10,101 @@
 # - cvmfs_server_common.sh
 
 
+# Mountless gateway overlay helpers.  These mirror the equivalents in
+# cvmfs_server_ingest.sh: a mountless publisher has no FUSE overlay to
+# open/close, so the transaction is just a gateway lease that is acquired up
+# front and dropped (or committed by the merge) at the end.
+# TODO: these are duplicated from cvmfs_server_ingest.sh; both should move to
+# cvmfs_server_common.sh (see the refactor TODO at the top of that script).
+cvmfs_server_overlay_release_gateway_lease() {
+  local name="$1"
+  local gateway_api_url="$2"
+  local gw_key_file="$3"
+  local lease_path="$4"
+  local session_token_file="/var/spool/cvmfs/${name}/session_token"
+
+  cvmfs_sys_file_is_regular "$session_token_file" || return 0
+  cvmfs_swissknife lease -u "$gateway_api_url" -a drop \
+    -k "$gw_key_file" -p "$lease_path"
+}
+
+
+cvmfs_server_overlay_abort_transaction() {
+  local name="$1"
+  local mountless_gateway_overlay="$2"
+  local gateway_api_url="$3"
+  local gw_key_file="$4"
+  local lease_path="$5"
+
+  if [ $mountless_gateway_overlay -eq 1 ]; then
+    cvmfs_server_overlay_release_gateway_lease \
+      "$name" "$gateway_api_url" "$gw_key_file" "$lease_path" \
+      >/dev/null 2>&1 || true
+  else
+    cvmfs_server_abort -f "$name"
+  fi
+}
+
+
+# Failure handler for the mountless gateway overlay path.  Mirrors
+# publish_failed but skips the run_suid_helper open/close calls that require a
+# FUSE overlay.
+cvmfs_server_overlay_publish_failed_mountless() {
+  local name="$1"
+  local gateway_api_url="$2"
+  local gw_key_file="$3"
+  local lease_path="$4"
+  load_repo_config $name
+  local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
+  trap - EXIT HUP INT TERM
+  cvmfs_server_overlay_release_gateway_lease \
+    "$name" "$gateway_api_url" "$gw_key_file" "$lease_path" \
+    >/dev/null 2>&1 || true
+  release_lock $pub_lock
+  to_syslog_for_repo $name "failed to publish"
+}
+
+
+# Like publish_starting but for the mountless gateway overlay path: acquire the
+# publishing lock and set an EXIT trap that includes gateway lease cleanup,
+# omitting the run_suid_helper lock call that needs a FUSE overlay.
+cvmfs_server_overlay_publish_starting_mountless() {
+  local name="$1"
+  local gateway_api_url="$2"
+  local gw_key_file="$3"
+  local lease_path="$4"
+  load_repo_config $name
+  local pub_lock="${CVMFS_SPOOL_DIR}/is_publishing"
+  acquire_lock "$pub_lock" || {
+    cvmfs_server_overlay_release_gateway_lease \
+      "$name" "$gateway_api_url" "$gw_key_file" "$lease_path" \
+      >/dev/null 2>&1 || true
+    die "Failed to acquire publishing lock"
+  }
+  trap "cvmfs_server_overlay_publish_failed_mountless '$name' '$gateway_api_url' '$gw_key_file' '$lease_path'" EXIT HUP INT TERM
+  to_syslog_for_repo $name "started publishing"
+}
+
+
+# Combined failure handler called from error blocks AFTER publish_starting (or
+# its mountless variant).  Drops the gateway lease for mountless, aborts the
+# FUSE-backed transaction otherwise.
+cvmfs_server_overlay_fail() {
+  local name="$1"
+  local mountless_gateway_overlay="$2"
+  local gateway_api_url="$3"
+  local gw_key_file="$4"
+  local lease_path="$5"
+  if [ $mountless_gateway_overlay -eq 1 ]; then
+    cvmfs_server_overlay_publish_failed_mountless \
+      "$name" "$gateway_api_url" "$gw_key_file" "$lease_path"
+  else
+    publish_failed "$name"
+    cvmfs_server_abort -f "$name"
+  fi
+}
+
+
 cvmfs_server_overlay() {
   local layers=""
   local dest_path=""
@@ -63,20 +158,57 @@ cvmfs_server_overlay() {
   local upstream=$CVMFS_UPSTREAM_STORAGE
   local upstream_type=$(get_upstream_type $upstream)
 
-  # Open a transaction for the overlay operation
+  local spool_dir=$CVMFS_SPOOL_DIR
+  local gw_key_file=/etc/cvmfs/keys/${name}.gw
+  local mountless_gateway_overlay=0
+  local gateway_api_url=""
+  local gateway_lease_path=""
+
+  # Open a transaction for the overlay operation.  When the upstream is a
+  # gateway and there is no FUSE mount (mountless publisher), acquire the
+  # gateway lease directly instead of going through cvmfs_server_transaction,
+  # which would try to (re)mount the publisher overlay.
   if [ x"$upstream_type" = xgw ]; then
-    cvmfs_server_transaction "$name/$dest_path" || die "Impossible to start a transaction"
+    gateway_lease_path="$name/$dest_path"
+    if ! is_mounted "/cvmfs/$name" && ! is_mounted "${CVMFS_SPOOL_DIR}/rdonly"; then
+      mountless_gateway_overlay=1
+      if is_checked_out $name; then
+        die "Mountless gateway overlay requires a mounted publisher for checked-out repositories."
+      fi
+      gateway_api_url=$(get_upstream_config "$upstream")
+      cvmfs_swissknife lease -u "$gateway_api_url" -a acquire \
+        -k "$gw_key_file" -p "$gateway_lease_path" || \
+        die "Impossible to start a transaction"
+    else
+      cvmfs_server_transaction "$gateway_lease_path" || die "Impossible to start a transaction"
+    fi
   else
     cvmfs_server_transaction $name || die "Impossible to start a transaction"
   fi
 
-  local spool_dir=$CVMFS_SPOOL_DIR
+  # Abort/fail helpers, defined once the gateway variables are known.
+  _abort() {
+    cvmfs_server_overlay_abort_transaction \
+      "$name" "$mountless_gateway_overlay" "$gateway_api_url" \
+      "$gw_key_file" "$gateway_lease_path"
+  }
+  _fail() {
+    cvmfs_server_overlay_fail \
+      "$name" "$mountless_gateway_overlay" "$gateway_api_url" \
+      "$gw_key_file" "$gateway_lease_path"
+  }
+
   local stratum0=$CVMFS_STRATUM0
   local hash_algorithm="${CVMFS_HASH_ALGORITHM-sha1}"
   local compression_alg="${CVMFS_COMPRESSION_ALGORITHM-default}"
 
   local user_shell="$(get_user_shell $name)"
-  local base_hash=$(get_mounted_root_hash $name)
+  local base_hash=
+  if [ $mountless_gateway_overlay -eq 1 ]; then
+    base_hash=$(get_published_root_hash $name) || { _abort; die "Failed to get published root hash for $name"; }
+  else
+    base_hash=$(get_mounted_root_hash $name)
+  fi
   local manifest="${spool_dir}/tmp/manifest"
 
   # Build the swissknife overlay command
@@ -98,23 +230,45 @@ cvmfs_server_overlay() {
     $([ -n "$oci_config" ] && echo "-c $oci_config") \
     $([ $skip_singularity -eq 1 ] && echo "-S")"
 
+  # For a gateway upstream the merge is committed through the lease, so pass
+  # the gateway key and session token (mirrors cvmfs_server ingest).  The
+  # session token file is created by the lease acquire above (mountless) or by
+  # cvmfs_server_transaction (mounted gateway).
+  if [ x"$upstream_type" = xgw ]; then
+    overlay_command="$overlay_command -H $gw_key_file -P ${spool_dir}/session_token"
+  fi
+
   # ---> do it!
   publish_before_hook $name
 
-  # check if we have open file descriptors on /cvmfs/<name>
-  [ $(count_wr_fds /cvmfs/$name) -eq 0 ] || { cvmfs_server_abort -f $name; die "Open writable file descriptors on $name"; }
+  # check if we have open file descriptors on /cvmfs/<name> (only meaningful
+  # when there is a FUSE mount, i.e. not in the mountless gateway path)
   local use_fd_fallback=0
-  handle_read_only_file_descriptors_on_mount_point $name $open_fd_dialog || use_fd_fallback=1
+  if [ $mountless_gateway_overlay -ne 1 ]; then
+    [ $(count_wr_fds /cvmfs/$name) -eq 0 ] || { _abort; die "Open writable file descriptors on $name"; }
+    handle_read_only_file_descriptors_on_mount_point $name $open_fd_dialog || use_fd_fallback=1
+  fi
 
-  publish_starting $name
+  if [ $mountless_gateway_overlay -eq 1 ]; then
+    cvmfs_server_overlay_publish_starting_mountless \
+      "$name" "$gateway_api_url" "$gw_key_file" "$gateway_lease_path"
+  else
+    publish_starting $name
+  fi
 
-  $user_shell "$overlay_command" || { publish_failed $name; cvmfs_server_abort -f $name; die "Overlay merge failed\n\nExecuted Command:\n$overlay_command"; }
-  cvmfs_sys_file_is_regular $manifest || { publish_failed $name; cvmfs_server_abort -f $name; die "Manifest creation failed"; }
+  $user_shell "$overlay_command" || { _fail; die "Overlay merge failed\n\nExecuted Command:\n$overlay_command"; }
+  cvmfs_sys_file_is_regular $manifest || { _fail; die "Manifest creation failed"; }
 
   local trunk_hash=$(grep "^C" $manifest | tr -d C)
 
   if [ x"$upstream_type" = xgw ]; then
-    close_transaction $name $use_fd_fallback
+    if [ $mountless_gateway_overlay -ne 1 ]; then
+      close_transaction $name $use_fd_fallback
+    else
+      # No FUSE overlay to close; the merge already committed the gateway lease
+      # (FinalizeSession(true)).  Only the local session_token file remains.
+      rm -f "${spool_dir}/session_token"
+    fi
     publish_after_hook $name
     publish_succeeded $name
     echo "Changes submitted to repository gateway"

--- a/cvmfs/swissknife_overlay.cc
+++ b/cvmfs/swissknife_overlay.cc
@@ -57,6 +57,11 @@ ParameterList CommandOverlay::GetParams() const {
   r.push_back(Parameter::Mandatory('b', "base hash of current root catalog"));
   r.push_back(Parameter::Mandatory('K', "public key path"));
   r.push_back(Parameter::Mandatory('N', "repository name"));
+  // Gateway publishing (same convention as ingest): when the upstream is a
+  // repository gateway these carry the lease so the merge can be committed
+  // without a local FUSE mount (mountless publishing).
+  r.push_back(Parameter::Optional('P', "session token file (gateway)"));
+  r.push_back(Parameter::Optional('H', "gateway key file"));
 
   // Overlay-specific parameters
   r.push_back(Parameter::Mandatory('l', "comma-separated layer paths "
@@ -1126,6 +1131,13 @@ int CommandOverlay::Main(const ArgumentList &args) {
       (args.count('c') > 0) ? *args.find('c')->second : "";
   const bool skip_singularity = (args.count('S') > 0);
 
+  // Gateway lease: empty for a directly-writable (S3/local) upstream, set when
+  // committing through a repository gateway (mountless publishing).
+  const string session_token_file =
+      (args.count('P') > 0) ? *args.find('P')->second : "";
+  const string key_file =
+      (args.count('H') > 0) ? *args.find('H')->second : "";
+
   // Parse comma-separated layer paths
   const vector<string> layers = SplitString(layers_str, ',');
   if (layers.empty()) {
@@ -1147,7 +1159,7 @@ int CommandOverlay::Main(const ArgumentList &args) {
       false /* generate_legacy_bulk_chunks */,
       false /* use_file_chunking */,
       0, 0, 0 /* chunk sizes: unused */,
-      "" /* session_token_file */, "" /* key_file */);
+      session_token_file, key_file);
 
   const upload::SpoolerDefinition spooler_definition_catalogs(
       spooler_definition.Dup2DefaultCompression());

--- a/ducc/cmd/root.go
+++ b/ducc/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cvmfs/ducc/cvmfs"
 	lib "github.com/cvmfs/ducc/lib"
 	l "github.com/cvmfs/ducc/log"
 	"github.com/cvmfs/ducc/temp"
@@ -16,6 +17,10 @@ import (
 
 var v string
 
+// mountlessPublishing is bound to --mountless and applied in PersistentPreRun.
+// Its default tracks CVMFS_DUCC_MOUNTLESS_PUBLISHING (read in the cvmfs pkg).
+var mountlessPublishing bool
+
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&temp.TemporaryBaseDir, "temporary-dir", "t", "", "Temporary directory to store files necessary during the conversion of images, it can grow large ~1G. If not set we use the standard of the system $TMP, usually /tmp")
 	if temp.TemporaryBaseDir == "" {
@@ -23,6 +28,7 @@ func init() {
 	}
 	rootCmd.PersistentFlags().StringVarP(&lib.NotificationFile, "notification-file", "n", "", "File where to publish notification about DUCC progression")
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", logrus.InfoLevel.String(), "Log level (trace, debug, info, warn, error, fatal, panic")
+	rootCmd.PersistentFlags().BoolVar(&mountlessPublishing, "mountless", cvmfs.MountlessPublishing(), "Publish via 'cvmfs_server ingest' only, for mountless gateway publishers (no FUSE mount / transaction needed)")
 }
 
 func DuccRootCmd() *cobra.Command {
@@ -30,6 +36,7 @@ func DuccRootCmd() *cobra.Command {
 		Use:   "cvmfs_ducc",
 		Short: "Show the available commands.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cvmfs.SetMountlessPublishing(mountlessPublishing)
 			lib.SetupNotification()
 			lib.SetupRegistries()
 			setUpLogs(os.Stdout, v)

--- a/ducc/cvmfs/.mockcvmfs/cvmfs_server
+++ b/ducc/cvmfs/.mockcvmfs/cvmfs_server
@@ -174,9 +174,10 @@ if [ "$1" == "ingest" ]; then
     esac
   done
 
-  # Only the tarball-ingest form is mocked here; the --delete / --fast-delete
-  # forms are handled by their own blocks above.
-  if [ "$saw_ingest_opts" == true ] && [ -n "$base_dir" ] && [ -n "$ingest_tar" ]; then
+  # Only the tarball-ingest form is mocked here (it always carries -t); the
+  # --delete / --fast-delete forms have no tar and are handled above.  An empty
+  # base_dir is valid and means "extract at the repository root".
+  if [ "$saw_ingest_opts" == true ] && [ -n "$ingest_tar" ]; then
     # Extract repo name and subdir
     repo_name=$(get_repo_name "$repo_arg")
     subdir=$(get_subdir "$repo_arg")

--- a/ducc/cvmfs/cvmfs.go
+++ b/ducc/cvmfs/cvmfs.go
@@ -39,6 +39,12 @@ func PublishToCVMFSWithLogger(logger *log.Entry, CVMFSRepo string, path string, 
 	}()
 	opLogger.Trace("Start ingesting")
 
+	if MountlessPublishing() {
+		// The deferred cleanup above removes target on success (err == nil).
+		err = publishToCVMFSMountless(logger, CVMFSRepo, path, target)
+		return err
+	}
+
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	path = PrefixRepoSubdirOnce(CVMFSRepo, path)
 	path = filepath.Join("/", "cvmfs", repoName, path)
@@ -105,6 +111,8 @@ func CreateSymlinkIntoCVMFS(CVMFSRepo, newLinkName, toLinkPath string) (err erro
 
 func CreateSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLinkName, toLinkPath string) (err error) {
 	logger = l.Ensure(logger)
+	// repository-relative link path (kept for the mountless ingest path)
+	repoRelLink := newLinkName
 	// add the necessary prefix
 	newLinkName = filepath.Join("/", "cvmfs", CVMFSRepo, newLinkName)
 	toLinkPath = filepath.Join("/", "cvmfs", CVMFSRepo, toLinkPath)
@@ -116,11 +124,7 @@ func CreateSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLinkName,
 			"target to link": toLinkPath})
 	}
 
-	// check if the file we want to link actually exists
-	if _, err := os.Stat(toLinkPath); os.IsNotExist(err) {
-		return err
-	}
-
+	// Compute the relative link target (pure path arithmetic, no I/O).
 	relativePath, err := filepath.Rel(newLinkName, toLinkPath)
 	if err != nil {
 		llog(l.LogE(err)).Error("Error in find the relative path")
@@ -130,6 +134,16 @@ func CreateSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLinkName,
 	// The part we remove represents the same directory where is the target.
 	linkChunks := strings.Split(relativePath, string(os.PathSeparator))
 	link := filepath.Join(linkChunks[1:]...)
+
+	if MountlessPublishing() {
+		// No mount to stat the target against; create the link via ingest.
+		return createSymlinkMountless(logger, CVMFSRepo, repoRelLink, link)
+	}
+
+	// check if the file we want to link actually exists
+	if _, err := os.Stat(toLinkPath); os.IsNotExist(err) {
+		return err
+	}
 
 	err = WithinTransactionWithLogger(logger, CVMFSRepo, func() error {
 		linkDir := filepath.Dir(newLinkName)
@@ -195,6 +209,11 @@ func CreateVariantSymlinkIntoCVMFSWithLogger(logger *log.Entry, CVMFSRepo, newLi
 			"link name": fullLinkName,
 			"target":    rawTarget,
 		})
+	}
+
+	if MountlessPublishing() {
+		// rawTarget is stored verbatim (it may contain $(...) expansions).
+		return createSymlinkMountless(logger, CVMFSRepo, newLinkName, rawTarget)
 	}
 
 	err = WithinTransactionWithLogger(logger, CVMFSRepo, func() error {

--- a/ducc/cvmfs/mountless.go
+++ b/ducc/cvmfs/mountless.go
@@ -1,0 +1,194 @@
+package cvmfs
+
+// Mountless publishing support.
+//
+// A mountless gateway publisher (cvmfs_server mkfs -P / connect-gw -P) has no
+// FUSE union mount, so the transaction+publish workflow used by
+// PublishToCVMFS / CreateSymlinkIntoCVMFS / CreateCatalogIntoDir does not work.
+// Everything those helpers do, however, can be expressed as a
+// `cvmfs_server ingest` of a small tar stream, which works in both mounted and
+// mountless setups (the server auto-detects the mount state).
+//
+// These helpers are only used when mountless publishing is enabled
+// (CVMFS_DUCC_MOUNTLESS_PUBLISHING or SetMountlessPublishing); the default
+// path is unchanged for mounted publishers.
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	l "github.com/cvmfs/ducc/log"
+)
+
+// mountlessPublishing routes repo writes through `cvmfs_server ingest` instead
+// of transaction+publish.  Enabled by env for convenience and by
+// SetMountlessPublishing from the CLI.
+var mountlessPublishing = os.Getenv("CVMFS_DUCC_MOUNTLESS_PUBLISHING") != ""
+
+// SetMountlessPublishing toggles ingest-based writes for mountless gateway
+// publishers.  Call once at start-up (e.g. from a --mountless flag).
+func SetMountlessPublishing(v bool) { mountlessPublishing = v }
+
+// MountlessPublishing reports whether ingest-based writes are in effect.
+func MountlessPublishing() bool { return mountlessPublishing }
+
+// ingestTarStreamWithLogger pipes a tar archive (produced by fill) into
+//
+//	cvmfs_server ingest [extraOpts...] -t - -b <baseDir> <repo>
+//
+// baseDir is the repository-relative path (subdir prefix included, as for
+// layer ingestion).  The tar is generated on the fly, so no temporary files
+// are needed.
+func ingestTarStreamWithLogger(logger *log.Entry, CVMFSRepo, baseDir string,
+	fill func(tw *tar.Writer) error, extraOpts ...string) error {
+	pr, pw := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(pw)
+		err := fill(tw)
+		if err == nil {
+			err = tw.Close()
+		}
+		// Propagate a fill/close error to the reader so the ingest aborts
+		// instead of consuming a truncated archive.
+		pw.CloseWithError(err)
+	}()
+
+	opts := append([]string{}, extraOpts...)
+	opts = append(opts, "-t", "-", "-b", baseDir)
+	return IngestWithLogger(logger, CVMFSRepo, pr, opts...)
+}
+
+// publishToCVMFSMountless materializes a regular file or a directory tree at
+// repoPath (repository path without the /cvmfs/<repo>/ prefix) via ingest.
+func publishToCVMFSMountless(logger *log.Entry, CVMFSRepo, repoPath, target string) error {
+	logger = l.Ensure(logger)
+	st, err := os.Stat(target)
+	if err != nil {
+		logger.WithField("error", err).Error("mountless publish: cannot stat target")
+		return err
+	}
+
+	// Repository-relative destination, with the subdir prefix applied exactly
+	// once (matches the convention used for layer ingestion).
+	dest := PrefixRepoSubdirOnce(CVMFSRepo, repoPath)
+
+	if st.Mode().IsDir() {
+		// Replace any previous tree: only --fast-delete is available mountless
+		// (regular --delete needs the rdonly mount for traversal).  Best effort
+		// — the path may not exist yet.
+		_ = IngestFastDeleteWithLogger(logger, CVMFSRepo, dest)
+		return ingestTarStreamWithLogger(logger, CVMFSRepo, dest,
+			func(tw *tar.Writer) error { return writeDirTree(tw, target) })
+	}
+
+	if !st.Mode().IsRegular() {
+		return fmt.Errorf("Trying to ingest neither a file nor a directory")
+	}
+
+	// A single regular file: extract one named member into the parent dir.
+	// The tarball engine adds-or-replaces the entry, so no delete is needed.
+	baseDir := filepath.Dir(dest)
+	if baseDir == "." {
+		baseDir = ""
+	}
+	name := filepath.Base(dest)
+	return ingestTarStreamWithLogger(logger, CVMFSRepo, baseDir,
+		func(tw *tar.Writer) error { return writeRegularFile(tw, name, target, st) })
+}
+
+// createSymlinkMountless creates (or replaces) a symlink at repoLink pointing
+// to linkTarget (the verbatim link contents).
+func createSymlinkMountless(logger *log.Entry, CVMFSRepo, repoLink, linkTarget string) error {
+	logger = l.Ensure(logger)
+	dest := PrefixRepoSubdirOnce(CVMFSRepo, repoLink)
+	baseDir := filepath.Dir(dest)
+	if baseDir == "." {
+		baseDir = ""
+	}
+	name := filepath.Base(dest)
+	return ingestTarStreamWithLogger(logger, CVMFSRepo, baseDir,
+		func(tw *tar.Writer) error {
+			return tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeSymlink,
+				Name:     name,
+				Linkname: linkTarget,
+				Mode:     0777,
+				Uid:      os.Getuid(),
+				Gid:      os.Getgid(),
+				ModTime:  time.Now(),
+			})
+		})
+}
+
+// writeRegularFile writes target as a single tar member called name.
+func writeRegularFile(tw *tar.Writer, name, target string, st os.FileInfo) error {
+	hdr := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Mode:     int64(st.Mode().Perm()),
+		Size:     st.Size(),
+		Uid:      os.Getuid(),
+		Gid:      os.Getgid(),
+		ModTime:  st.ModTime(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	f, err := os.Open(target)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(tw, f)
+	return err
+}
+
+// writeDirTree walks root and writes its contents into the tar with paths
+// relative to root (so they land directly under the ingest base_dir).
+func writeDirTree(tw *tar.Writer, root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil // the base_dir itself is created by the ingest
+		}
+
+		var link string
+		if info.Mode()&os.ModeSymlink != 0 {
+			if link, err = os.Readlink(path); err != nil {
+				return err
+			}
+		}
+		hdr, err := tar.FileInfoHeader(info, link)
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		hdr.Uid = os.Getuid()
+		hdr.Gid = os.Getgid()
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(tw, f)
+		return err
+	})
+}

--- a/ducc/cvmfs/mountless_test.go
+++ b/ducc/cvmfs/mountless_test.go
@@ -1,0 +1,131 @@
+package cvmfs
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests exercise the ingest-based write helpers used for mountless
+// gateway publishing.  They run against the mock cvmfs_server (set up in
+// TestMain), whose ingest handler extracts the streamed tar into the mock
+// repository — the same path a real mountless publisher would take.
+
+func withMountlessPublishing(t *testing.T) {
+	t.Helper()
+	SetMountlessPublishing(true)
+	t.Cleanup(func() { SetMountlessPublishing(false) })
+}
+
+func TestMountlessPublishFile(t *testing.T) {
+	withMountlessPublishing(t)
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+
+	f, err := os.CreateTemp("", "MountlessPublishFile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("mountless-file-content")
+	if _, err := f.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if err := PublishToCVMFS(".."+mockrepo, "sub/dir/published.txt", f.Name()); err != nil {
+		t.Fatalf("mountless PublishToCVMFS failed: %v", err)
+	}
+
+	readback, err := os.ReadFile(filepath.Join(mockrepo, "sub", "dir", "published.txt"))
+	if err != nil {
+		t.Fatalf("published file not found: %v", err)
+	}
+	if !bytes.Equal(readback, content) {
+		t.Fatalf("published content differs: got %q", readback)
+	}
+}
+
+func TestMountlessPublishFileAtRoot(t *testing.T) {
+	withMountlessPublishing(t)
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+
+	f, err := os.CreateTemp("", "MountlessRootFile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("root-content")
+	if _, err := f.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// A repository-root path yields an empty ingest base_dir; make sure that
+	// is handled (no -B passed to the real server; root extraction in the mock).
+	if err := PublishToCVMFS(".."+mockrepo, "root_published.txt", f.Name()); err != nil {
+		t.Fatalf("mountless PublishToCVMFS at root failed: %v", err)
+	}
+
+	readback, err := os.ReadFile(filepath.Join(mockrepo, "root_published.txt"))
+	if err != nil {
+		t.Fatalf("root-published file not found: %v", err)
+	}
+	if !bytes.Equal(readback, content) {
+		t.Fatalf("root-published content differs: got %q", readback)
+	}
+}
+
+func TestMountlessCreateSymlink(t *testing.T) {
+	withMountlessPublishing(t)
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+
+	// The mountless path does not stat the target (no mount), so the target
+	// need not exist; the stored link is pure path arithmetic.
+	if err := CreateSymlinkIntoCVMFS(".."+mockrepo, "images/myimage", ".flat/deadbeef"); err != nil {
+		t.Fatalf("mountless CreateSymlinkIntoCVMFS failed: %v", err)
+	}
+
+	linkPath := filepath.Join(mockrepo, "images", "myimage")
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("symlink not created at %s: %v", linkPath, err)
+	}
+	// Rel(/cvmfs/<r>/images/myimage, /cvmfs/<r>/.flat/deadbeef) -> ../../.flat/deadbeef
+	// with the first chunk (the link's own dir) dropped -> ../.flat/deadbeef
+	if want := filepath.Join("..", ".flat", "deadbeef"); target != want {
+		t.Fatalf("symlink target = %q, want %q", target, want)
+	}
+}
+
+func TestMountlessCreateVariantSymlink(t *testing.T) {
+	withMountlessPublishing(t)
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+
+	// Variant symlinks store their target verbatim (including $(...) exprs).
+	const rawTarget = "$(CVMFS_ARCH:-amd64)/rootfs"
+	if err := CreateVariantSymlinkIntoCVMFS(".."+mockrepo, "variants/multiarch", rawTarget); err != nil {
+		t.Fatalf("mountless CreateVariantSymlinkIntoCVMFS failed: %v", err)
+	}
+
+	linkPath := filepath.Join(mockrepo, "variants", "multiarch")
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("variant symlink not created at %s: %v", linkPath, err)
+	}
+	if target != rawTarget {
+		t.Fatalf("variant symlink target = %q, want %q", target, rawTarget)
+	}
+}
+
+func TestMountlessCreateCatalog(t *testing.T) {
+	withMountlessPublishing(t)
+	mockrepo := filepath.Clean("/" + os.Getenv("CVMFS_TEST_REPO"))
+
+	if err := CreateCatalogIntoDir(".."+mockrepo, "catalogdir/nested"); err != nil {
+		t.Fatalf("mountless CreateCatalogIntoDir failed: %v", err)
+	}
+
+	catalog := filepath.Join(mockrepo, "catalogdir", "nested", ".cvmfscatalog")
+	if _, err := os.Stat(catalog); err != nil {
+		t.Fatalf("expected .cvmfscatalog at %s: %v", catalog, err)
+	}
+}

--- a/ducc/cvmfs/raw.go
+++ b/ducc/cvmfs/raw.go
@@ -243,6 +243,11 @@ func IngestDelete(CVMFSRepo string, path string) error {
 
 func IngestDeleteWithLogger(logger *log.Entry, CVMFSRepo string, path string) error {
 	logger = l.Ensure(logger)
+	// Mountless gateway publishing supports only --fast-delete: regular
+	// --delete needs the rdonly mount for filesystem traversal.
+	if MountlessPublishing() {
+		return IngestFastDeleteWithLogger(logger, CVMFSRepo, path)
+	}
 	ingestLogger := logger.WithFields(log.Fields{"repo": CVMFSRepo, "action": "ingest delete", "path": path})
 	repoName, _ := GetRepoAndSubdir(CVMFSRepo)
 	path = PrefixRepoSubdirOnce(CVMFSRepo, path)

--- a/ducc/testutils/cmd/testregistry/main.go
+++ b/ducc/testutils/cmd/testregistry/main.go
@@ -1,0 +1,82 @@
+// Command testregistry runs an in-process OCI registry on a fixed address and
+// seeds it with the crafted dangling-hardlink image (and any extra images
+// requested).  It is used by integration tests so that `cvmfs_ducc convert`
+// has a local image source without needing an external registry.
+//
+//	testregistry -addr :5000 -ref ducc-test/dangling-hardlink:latest
+//
+// The process serves until killed (SIGINT/SIGTERM).
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+
+	"github.com/cvmfs/ducc/testutils"
+)
+
+func main() {
+	addr := flag.String("addr", ":5000", "address to listen on")
+	ref := flag.String("ref", "ducc-test/dangling-hardlink:latest",
+		"repository:tag for the crafted dangling-hardlink image")
+	flag.Parse()
+
+	srv := &http.Server{Addr: *addr, Handler: registry.New()}
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("listen on %s: %v", *addr, err)
+	}
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("registry serve: %v", err)
+		}
+	}()
+
+	// The push target uses the concrete host:port the listener bound to.
+	host := *addr
+	if strings.HasPrefix(host, ":") {
+		host = "localhost" + host
+	}
+	fullRef := fmt.Sprintf("%s/%s", host, *ref)
+
+	ctx := context.Background()
+	if err := waitReady(host, 15*time.Second); err != nil {
+		log.Fatalf("registry not ready: %v", err)
+	}
+	if err := testutils.PushDanglingHardlinkImage(ctx, fullRef); err != nil {
+		log.Fatalf("push dangling-hardlink image: %v", err)
+	}
+	log.Printf("ready: pushed dangling-hardlink image to %s", fullRef)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
+}
+
+func waitReady(address string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, time.Second)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for %s", address)
+}

--- a/ducc/testutils/hardlink.go
+++ b/ducc/testutils/hardlink.go
@@ -1,0 +1,138 @@
+package testutils
+
+// Helpers to build and push an OCI image whose layer contains a *dangling*
+// hardlink: a tar hardlink entry (TypeLink) whose target is not a member of the
+// same layer.  This reproduces the cross-layer / cleaned-cache hardlinks found
+// in real images (e.g. `dnf clean`-style layers) that crash `cvmfs_server
+// ingest` unless --tolerate-missing-hardlinks is used.
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+// Paths used by the crafted dangling-hardlink layer.  DanglingHardlinkLinkPath
+// is the hardlink whose target (DanglingHardlinkTargetPath) is deliberately
+// absent from the layer's tar.
+const (
+	DanglingHardlinkRegularPath = "usr/share/ducc-test/data.txt"
+	DanglingHardlinkLinkPath    = "var/cache/dnf/x86_64/repodata/comps.xml.gz"
+	DanglingHardlinkTargetPath  = "var/cache/dnf/noarch/repodata/comps.xml.gz"
+)
+
+// CreateDanglingHardlinkLayer builds a single image layer that contains one
+// real regular file plus a hardlink entry pointing at a path that is NOT
+// present in the layer (a dangling/cross-layer hardlink).
+func CreateDanglingHardlinkLayer() (v1.Layer, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	content := []byte("regular file so the layer carries real content\n")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     DanglingHardlinkRegularPath,
+		Mode:     0644,
+		Size:     int64(len(content)),
+		ModTime:  time.Unix(0, 0),
+	}); err != nil {
+		return nil, fmt.Errorf("write regular header: %w", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		return nil, fmt.Errorf("write regular content: %w", err)
+	}
+
+	// The dangling hardlink: TypeLink with a Linkname that is not a member of
+	// this archive.  Hardlink entries carry no data (Size 0).
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeLink,
+		Name:     DanglingHardlinkLinkPath,
+		Linkname: DanglingHardlinkTargetPath,
+		Mode:     0644,
+		ModTime:  time.Unix(0, 0),
+	}); err != nil {
+		return nil, fmt.Errorf("write hardlink header: %w", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("close tar: %w", err)
+	}
+
+	return tarball.LayerFromReader(&buf)
+}
+
+// CreateDanglingHardlinkImage builds an image with the dangling-hardlink layer.
+func CreateDanglingHardlinkImage() (v1.Image, error) {
+	layer, err := CreateDanglingHardlinkLayer()
+	if err != nil {
+		return nil, err
+	}
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return nil, fmt.Errorf("append layer: %w", err)
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Created = v1.Time{Time: time.Unix(0, 0)}
+	cfg.Author = "ducc dangling-hardlink test"
+	cfg.Config.Cmd = []string{"/bin/true"}
+	return mutate.ConfigFile(img, cfg)
+}
+
+// PushDanglingHardlinkImage builds and pushes the dangling-hardlink image to
+// the given (insecure, http) registry reference, e.g.
+// "localhost:5000/ducc-test/dangling-hardlink:latest".
+func PushDanglingHardlinkImage(ctx context.Context, ref string) error {
+	img, err := CreateDanglingHardlinkImage()
+	if err != nil {
+		return err
+	}
+	tag, err := name.NewTag(ref, name.Insecure)
+	if err != nil {
+		return fmt.Errorf("parse tag %q: %w", ref, err)
+	}
+	return remote.Write(tag, img, remote.WithContext(ctx))
+}
+
+// layerHasDanglingHardlink scans an (uncompressed) layer tar and reports
+// whether it contains a hardlink to linkTarget while linkTarget itself is not
+// a regular-file member — i.e. a dangling hardlink.  Exposed for tests.
+func layerHasDanglingHardlink(layer v1.Layer, linkTarget string) (bool, error) {
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		return false, err
+	}
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	sawLink := false
+	targetPresent := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return false, err
+		}
+		if hdr.Typeflag == tar.TypeLink && hdr.Linkname == linkTarget {
+			sawLink = true
+		}
+		if hdr.Name == linkTarget {
+			targetPresent = true
+		}
+	}
+	return sawLink && !targetPresent, nil
+}

--- a/ducc/testutils/hardlink_test.go
+++ b/ducc/testutils/hardlink_test.go
@@ -1,0 +1,35 @@
+package testutils
+
+import "testing"
+
+// TestCraftedLayerHasDanglingHardlink verifies that the crafted layer actually
+// reproduces the bug condition: a hardlink whose target is absent from the
+// layer's own tar.  This is hermetic (no registry/network needed).
+func TestCraftedLayerHasDanglingHardlink(t *testing.T) {
+	layer, err := CreateDanglingHardlinkLayer()
+	if err != nil {
+		t.Fatalf("CreateDanglingHardlinkLayer: %v", err)
+	}
+	dangling, err := layerHasDanglingHardlink(layer, DanglingHardlinkTargetPath)
+	if err != nil {
+		t.Fatalf("scan layer: %v", err)
+	}
+	if !dangling {
+		t.Fatalf("crafted layer does not contain a dangling hardlink to %q",
+			DanglingHardlinkTargetPath)
+	}
+}
+
+func TestCraftedImageBuilds(t *testing.T) {
+	img, err := CreateDanglingHardlinkImage()
+	if err != nil {
+		t.Fatalf("CreateDanglingHardlinkImage: %v", err)
+	}
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatalf("img.Layers: %v", err)
+	}
+	if len(layers) != 1 {
+		t.Fatalf("expected 1 layer, got %d", len(layers))
+	}
+}

--- a/test/src/408-ducc-mountless-missing-hardlink/main
+++ b/test/src/408-ducc-mountless-missing-hardlink/main
@@ -1,0 +1,108 @@
+#!/bin/bash
+cvmfs_test_name="DUCC mountless convert tolerates missing hardlink targets"
+cvmfs_test_autofs_on_startup=false
+cvmfs_test_suites="ducc"
+
+# This test reproduces the cross-layer / cleaned-cache hardlink crash:
+# cvmfs_ducc ingests each image layer in isolation, so a layer containing a
+# hardlink whose target lives in another layer used to PANIC the tarball
+# engine.  The fix (--tolerate-missing-hardlinks, passed by ducc on every layer
+# ingest) materializes an empty file instead.
+#
+# The whole conversion runs against a MOUNTLESS gateway publisher and a local
+# in-process registry (built from ducc/testutils/cmd/testregistry), so it needs
+# no external registry and exercises the mountless ducc-convert path end to end:
+# layer ingest, cvmfs_server overlay (flat image), and the symlink/catalog
+# writes — all via `cvmfs_server ingest`.
+
+CVMFS_TEST408_REG_PID=
+CVMFS_TEST408_REG_BIN=
+
+ducc_test_408_clean_up() {
+    echo "*** Cleaning up..."
+    [ -n "$CVMFS_TEST408_REG_PID" ] && kill "$CVMFS_TEST408_REG_PID" 2>/dev/null
+    [ -n "$CVMFS_TEST408_REG_BIN" ] && rm -f "$CVMFS_TEST408_REG_BIN"
+    sudo cvmfs_server rmfs -f test.repo.org 2>/dev/null
+}
+
+cvmfs_run_test() {
+    local repo="test.repo.org"
+    local image_ref="ducc-test/dangling-hardlink:latest"
+    local reg_port=5000
+
+    trap ducc_test_408_clean_up EXIT HUP INT TERM
+
+    # --- prerequisites -----------------------------------------------------
+    which cvmfs_ducc >/dev/null 2>&1 || { echo "cvmfs_ducc not installed"; return 1; }
+    which go >/dev/null 2>&1         || { echo "go toolchain not available"; return 1; }
+
+    local ducc_src="$TEST_ROOT/../ducc"
+    [ -d "$ducc_src" ] || { echo "ducc source tree not found at $ducc_src"; return 1; }
+
+    # --- 1. mountless gateway repository -----------------------------------
+    set_up_repository_gateway -P || return 10
+    load_repo_config "$repo"     || return 11
+
+    echo "*** verifying the publisher is mountless"
+    cat /proc/mounts | grep -e " /cvmfs/${repo} " && return 12
+    cat /proc/mounts | grep -e " ${CVMFS_SPOOL_DIR}/rdonly " && return 13
+
+    # --- 2. build & launch the local registry serving the crafted image ----
+    CVMFS_TEST408_REG_BIN="$(pwd)/testregistry"
+    echo "*** building test registry helper"
+    ( cd "$ducc_src" && go build -o "$CVMFS_TEST408_REG_BIN" ./testutils/cmd/testregistry ) \
+        || { echo "failed to build testregistry"; return 20; }
+
+    echo "*** starting test registry on :${reg_port}"
+    "$CVMFS_TEST408_REG_BIN" -addr ":${reg_port}" -ref "$image_ref" > registry.log 2>&1 &
+    CVMFS_TEST408_REG_PID=$!
+
+    local i=0
+    until grep -q "ready:" registry.log 2>/dev/null; do
+        sleep 1
+        i=$((i + 1))
+        if ! kill -0 "$CVMFS_TEST408_REG_PID" 2>/dev/null; then
+            echo "registry exited early"; cat registry.log; return 21
+        fi
+        [ $i -gt 30 ] && { echo "registry not ready in time"; cat registry.log; return 22; }
+    done
+    echo "*** registry ready"
+
+    # --- 3. full mountless conversion --------------------------------------
+    # -p: skip the podman store; the thin image is skipped by default.  The
+    # flat (singularity) image is created, exercising the mountless overlay.
+    echo "*** converting image via cvmfs_ducc --mountless"
+    cvmfs_ducc --mountless convert-single-image -p \
+        "http://localhost:${reg_port}/${image_ref}" "$repo" \
+        > convert.log 2>&1
+    local rc=$?
+
+    echo "*** ==== convert.log ===="
+    cat convert.log
+
+    # --- 4. assertions -----------------------------------------------------
+    # 4a. the pre-fix failure mode was a PANIC in the tarball engine
+    if grep -q "PANIC" convert.log; then
+        echo "FAIL: ingest PANICked on the missing hardlink target"
+        return 30
+    fi
+    # 4b. with the fix the whole conversion succeeds
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: cvmfs_ducc convert exited with $rc"
+        return 31
+    fi
+    # 4c. the materialization path should have run (best effort: the engine
+    #     also logs this to syslog, which may not reach convert.log)
+    if ! grep -q "materialized an empty file" convert.log; then
+        echo "WARN: did not see the materialization message in convert.log"
+    fi
+
+    # --- 5. mountless invariant preserved ----------------------------------
+    cat /proc/mounts | grep -e " /cvmfs/${repo} " && return 32
+
+    # --- 6. layers were actually published ---------------------------------
+    cvmfs_server list-catalogs -x "$repo" | grep -q "\.layers" || return 33
+
+    echo "*** Test successful"
+    return 0
+}


### PR DESCRIPTION
Container unpacking still required a fuse mount on the publisher. By replaying the patch already done for ingest, and using ingest instead of transaction/publish for metadata etc., we can avoid this and run the full conversion in a container.