### PR TITLE
Fix failover with caller-side decompression

### DIFF
--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1666,21 +1666,34 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
              "error code %d no-cache %d",
              name_.c_str(), info->id(), same_url_retry, info->error_code(),
              info->nocache());
-    // Reset internal state and destination
-    if (info->sink() != NULL && info->sink()->Reset() != 0) {
-      info->SetErrorCode(kFailLocalIO);
-      goto verify_and_finalize_stop;
+    // Reset internal state and destination. In parallel-decompress mode the
+    // sink and zstream are owned by the caller thread (it pops and decompresses
+    // the queued chunks). Resetting them here would race the caller and, worse,
+    // leave the bytes of this failed attempt in the tube to be decompressed
+    // into the output. Defer the reset by enqueuing an ordered marker; the
+    // caller discards this attempt's bytes when it pops it (see below).
+    const bool defer_reset = info->IsValidDataTube();
+    if (!defer_reset) {
+      if (info->sink() != NULL && info->sink()->Reset() != 0) {
+        info->SetErrorCode(kFailLocalIO);
+        goto verify_and_finalize_stop;
+      }
     }
     if (info->interrupt_cue() && info->interrupt_cue()->IsCanceled()) {
       info->SetErrorCode(kFailCanceled);
       goto verify_and_finalize_stop;
     }
 
+    // The hash context is updated on this (MainDownload) thread in
+    // CallbackCurlData(), so it is reset here regardless of the decompress mode.
     if (info->expected_hash()) {
       shash::Init(info->hash_context());
     }
-    if (info->compressed()) {
+    if (info->compressed() && !defer_reset) {
       zlib::DecompressInit(info->GetZstreamPtr());
+    }
+    if (defer_reset) {
+      info->GetDataTubePtr()->EnqueueBack(new DataTubeElement(kActionReset));
     }
 
     if (sharding_policy_.UseCount() > 0) {  // sharding policy
@@ -2029,6 +2042,24 @@ Failures DownloadManager::Fetch(JobInfo *info) {
       if (ele->action == kActionStop) {
         delete ele;
         break;
+      }
+
+      if (ele->action == kActionReset) {
+        // The chunks popped so far belonged to a download attempt that was
+        // superseded by a retry / host fail-over (VerifyAndFinalize enqueued
+        // this marker). Discard their — possibly corrupt — decompressed output
+        // and start fresh so the next attempt's bytes are processed cleanly.
+        if (info->compressed()) {
+          zlib::DecompressFini(info->GetZstreamPtr());
+          zlib::DecompressInit(info->GetZstreamPtr());
+        }
+        if (info->sink() != NULL && info->sink()->Reset() != 0) {
+          decompress_err = kFailLocalIO;
+        } else {
+          decompress_err = kFailOk;
+        }
+        delete ele;
+        continue;
       }
 
       if (decompress_err == kFailOk && ele->size > 0) {

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -29,7 +29,12 @@ namespace download {
 enum DataTubeAction {
   kActionStop = 0,
   kActionContinue,
-  kActionDecompress
+  kActionDecompress,
+  // Marks the boundary of a superseded download attempt (retry / host
+  // fail-over). When the caller pops this it must discard the bytes it has
+  // decompressed so far, reset its sink and zstream, and clear any
+  // decompression error before processing the bytes of the next attempt.
+  kActionReset
 };
 
 /**

--- a/test/src/523-corruptchunkfailover/main
+++ b/test/src/523-corruptchunkfailover/main
@@ -3,8 +3,8 @@ cvmfs_test_name="Data Corruption in Data Chunk"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
-# Note: this test is currently supposed to fail because cvmfs does not fail-over
-# on S1 data corruption
+# Note: corrupting the data chunks on Stratum0 must make cvmfs transparently
+# fail-over to the intact Stratum1 replica, so every file stays readable.
 
 desaster_cleanup() {
   local mnt_point=$1
@@ -55,8 +55,12 @@ EOF
   cvmfs2 -d -o config=private.conf $CVMFS_TEST_REPO $mnt_point >> cvmfs2_output.log 2>&1 || { desaster_cleanup $mnt_point $replica_name; return 6; }
 
   echo "try to access files in the repository"
+  # Reading a file whose Stratum0 chunk is corrupt must transparently fail over
+  # to the (intact) Stratum1 replica, so a single read of each file has to
+  # succeed.  (A retry here would mask the parallel-decompress fail-over bug
+  # that this test guards against.)
   for f in $(find $mnt_point -maxdepth 1 -type f); do
-    cat $f || { desaster_cleanup $mnt_point $replica_name; return 7; }
+    cat $f > /dev/null || { desaster_cleanup $mnt_point $replica_name; return 7; }
   done
 
   echo "clean up"


### PR DESCRIPTION
Add a kActionReset to the DataTube to be used when failing over due to corruption

Introduced by #4002 