### PR TITLE
Fix a compilation warning in cache.h

### DIFF
--- a/cvmfs/cache_tiered.cc
+++ b/cvmfs/cache_tiered.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "quota.h"  // IWYU pragma: keep - complete type needed for delete
 #include "util/posix.h"  // IWYU pragma: keep
 
 


### PR DESCRIPTION
 ```
 In file included from /root/cvmfs/cvmfs/cache_tiered.h:12,
                   from /root/cvmfs/cvmfs/cache_tiered.cc:5:
  /root/cvmfs/cvmfs/cache.h:17:7: note: forward declaration of ‘class
  QuotaManager’
     17 | class QuotaManager;
        |       ^~~~~~~~~~~~
  /root/cvmfs/cvmfs/cache_tiered.cc:132:3: note: neither the destructor nor the
  class-specific ‘operator delete’ will be called, even if they are declared
  when the class is defined
    132 |   delete cache_mgr->quota_mgr_;
```