### PR TITLE
Silence  _FORTIFY_SOURCE warning on debug libraries using -O0

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -294,7 +294,7 @@ if (BUILD_CVMFS)
     )
     set_target_properties (cvmfs_fuse_debug PROPERTIES
       VERSION ${CernVM-FS_VERSION_STRING}
-      COMPILE_FLAGS "-DCVMFS_USE_LIBFUSE=2 ${CVMFS_FUSE_CFLAGS} -O0 -DDEBUGMSG"
+      COMPILE_FLAGS "-DCVMFS_USE_LIBFUSE=2 ${CVMFS_FUSE_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG"
       LINK_FLAGS "${CVMFS_FUSE_LDFLAGS}"
     )
     target_link_libraries (cvmfs_fuse
@@ -321,7 +321,7 @@ if (BUILD_CVMFS)
     )
     set_target_properties (cvmfs_fuse3_debug PROPERTIES
       VERSION ${CernVM-FS_VERSION_STRING}
-      COMPILE_FLAGS "-DCVMFS_USE_LIBFUSE=3 ${CVMFS_FUSE_CFLAGS} -O0 -DDEBUGMSG"
+      COMPILE_FLAGS "-DCVMFS_USE_LIBFUSE=3 ${CVMFS_FUSE_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG"
       LINK_FLAGS "${CVMFS_FUSE_LDFLAGS}"
     )
     target_link_libraries (cvmfs_fuse3
@@ -728,7 +728,7 @@ if (BUILD_SERVER)
   if (BUILD_SERVER_DEBUG)
     add_executable (cvmfs_swissknife_debug ${CVMFS_SWISSKNIFE_SOURCES})
     set_target_properties (cvmfs_swissknife_debug PROPERTIES
-      COMPILE_FLAGS "-O0 -DDEBUGMSG"
+      COMPILE_FLAGS "-O0 -Wno-cpp -DDEBUGMSG"
     )
     target_link_libraries (cvmfs_swissknife_debug
                            cvmfs_crypto_debug
@@ -846,7 +846,7 @@ if (BUILD_SERVER)
     add_library (cvmfs_server_debug SHARED ${LIBCVMFS_SERVER_SOURCES})
     set_target_properties (cvmfs_server_debug PROPERTIES
       VERSION ${CernVM-FS_VERSION_STRING}
-      COMPILE_FLAGS "${LIBCVMFS_SERVER_CFLAGS} -O0 -DDEBUGMSG")
+      COMPILE_FLAGS "${LIBCVMFS_SERVER_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG")
     target_link_libraries (cvmfs_server_debug
                            cvmfs_crypto_debug
                            cvmfs_util_debug
@@ -907,7 +907,7 @@ if (BUILD_SERVER)
   if (BUILD_SERVER_DEBUG)
     add_executable (cvmfs_publish_debug ${CVMFS_PUBLISH_SOURCES})
     set_target_properties (cvmfs_publish_debug PROPERTIES
-      COMPILE_FLAGS "${CVMFS_PUBLISH_CFLAGS} -O0 -DDEBUGMSG"
+      COMPILE_FLAGS "${CVMFS_PUBLISH_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG"
     )
     target_link_libraries (cvmfs_publish_debug
                            cvmfs_crypto_debug
@@ -1134,7 +1134,7 @@ if(BUILD_RECEIVER)
   if (BUILD_RECEIVER_DEBUG)
     add_executable(cvmfs_receiver_debug ${CVMFS_RECEIVER_SOURCES})
     set_target_properties (cvmfs_receiver_debug PROPERTIES
-      COMPILE_FLAGS "${CVMFS_RECEIVER_CFLAGS} -O0 -DDEBUGMSG")
+      COMPILE_FLAGS "${CVMFS_RECEIVER_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG")
     target_link_libraries(cvmfs_receiver_debug
                           cvmfs_crypto_debug
                           cvmfs_util_debug

--- a/cvmfs/crypto/CMakeLists.txt
+++ b/cvmfs/crypto/CMakeLists.txt
@@ -50,7 +50,7 @@ if (BUILD_CVMFS OR BUILD_SERVER_DEBUG OR BUILD_RECEIVER_DEBUG OR BUILD_UNITTESTS
   add_library (cvmfs_crypto_debug SHARED ${LIBCVMFS_CRYPTO_SOURCES})
   set_target_properties (cvmfs_crypto_debug PROPERTIES
       VERSION ${CernVM-FS_VERSION_STRING}
-      COMPILE_FLAGS "${LIBCVMFS_CRYPTO_CFLAGS} -O0 -DDEBUGMSG"
+      COMPILE_FLAGS "${LIBCVMFS_CRYPTO_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG"
       LINK_FLAGS "${LIBCVMFS_CRYPTO_LINK_FLAGS}")
   target_include_directories (cvmfs_crypto_debug PRIVATE ${Libcrypto_INCLUDE_DIRS})
   target_link_libraries (cvmfs_crypto_debug

--- a/cvmfs/util/CMakeLists.txt
+++ b/cvmfs/util/CMakeLists.txt
@@ -45,7 +45,7 @@ if (BUILD_CVMFS OR BUILD_SERVER_DEBUG OR BUILD_RECEIVER_DEBUG OR
   add_library(cvmfs_util_debug SHARED ${LIBCVMFS_UTIL_SOURCES})
   set_target_properties (cvmfs_util_debug PROPERTIES
       VERSION ${CernVM-FS_VERSION_STRING}
-      COMPILE_FLAGS "${LIBCVMFS_UTIL_CFLAGS} -DDEBUGMSG -g -O0")
+      COMPILE_FLAGS "${LIBCVMFS_UTIL_CFLAGS} -DDEBUGMSG -g -O0 -Wno-cpp")
   target_link_libraries (cvmfs_util_debug ${LIBCVMFS_UTIL_LINK_LIBRARIES})
   install (TARGETS cvmfs_util_debug LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -298,7 +298,7 @@ if (BUILD_SERVER)
   if (BUILD_UNITTESTS_DEBUG)
   add_executable (cvmfs_test_publish_debug ${CVMFS_UNITTEST_SERVER_SOURCES})
   set_target_properties (cvmfs_test_publish_debug PROPERTIES
-                         COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS} -O0 -DDEBUGMSG"
+                         COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG"
   )
   target_link_libraries (cvmfs_test_publish_debug
                          cvmfs_crypto_debug
@@ -804,7 +804,7 @@ if (BUILD_UNITTESTS_DEBUG)
   add_executable (cvmfs_unittests_debug ${CVMFS_UNITTEST_SOURCES})
   add_dependencies (cvmfs_unittests_debug cache.pb.generated-unittests)
   set_target_properties (cvmfs_unittests_debug PROPERTIES
-                         COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS} -O0 -DDEBUGMSG"
+                         COMPILE_FLAGS "${CVMFS_UNITTEST_COMMON_CFLAGS} -O0 -Wno-cpp -DDEBUGMSG"
   )
   target_link_libraries (cvmfs_unittests_debug
                          cvmfs_crypto_debug


### PR DESCRIPTION
```
In file included from /usr/include/inttypes.h:25,
                 from /root/pkg/BUILD/cvmfs-2.14.0~pre4/cvmfs/xattr.h:8,
                 from /root/pkg/BUILD/cvmfs-2.14.0~pre4/cvmfs/xattr.cc:6:
/usr/include/features.h:414:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  414 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
```