### PR TITLE
server: Always refresh mountpoint for gw publication to fix race

### DIFF
--- a/.github/workflows/ci_stale_mount.yml
+++ b/.github/workflows/ci_stale_mount.yml
@@ -1,0 +1,68 @@
+name: CI_stale_mount
+
+# Regression test for issue #3867: a gateway release manager with a stale
+# read-only mount must not drop content another release manager added.
+on:
+  push:
+    branches: ['devel', 'cvmfs*']
+  pull_request:
+    paths:
+      - 'cvmfs/publish/**'
+      - 'cvmfs/receiver/**'
+      - 'cvmfs/catalog_diff_tool*'
+      - 'gateway/**'
+      - 'test/container/501-stale-mount-drop/**'
+      - '.github/workflows/ci_stale_mount.yml'
+    branches: ['devel', 'cvmfs*']
+  workflow_dispatch:
+
+jobs:
+  stale-mount-drop:
+    name: "Gateway stale-mount content drop (#3867)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    defaults:
+      run:
+        working-directory: test/container/501-stale-mount-drop
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the dev image once with a persistent layer cache. All three compose
+      # services reference cvmfs-stale-mount:latest, so this is the only build.
+      - name: Build dev image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: test/common/container/Dockerfile-dev
+          tags: cvmfs-stale-mount:latest
+          load: true
+          cache-from: type=gha,scope=stale-mount-dev
+          cache-to: type=gha,mode=max,scope=stale-mount-dev
+
+      - name: Start the stack
+        run: docker compose up -d --no-build
+
+      - name: Run the regression scenario
+        run: ./test.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== docker compose ps ==="
+          docker compose ps -a
+          for c in cvmfs-gw1 cvmfs-pub1 cvmfs-pub2; do
+            echo "=== $c: cvmfs_receiver debug log ==="
+            docker exec "$c" tail -n 100 /var/log/cvmfs_receiver/debug.log 2>/dev/null || true
+            echo "=== $c: journal (cvmfs-gateway) ==="
+            docker exec "$c" journalctl -u cvmfs-gateway --no-pager -n 80 2>/dev/null || true
+          done
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v --remove-orphans || true

--- a/cvmfs/publish/repository.cc
+++ b/cvmfs/publish/repository.cc
@@ -155,6 +155,11 @@ void Repository::DownloadRootObjects(const std::string &url,
   delete manifest_;
   manifest_ = new manifest::Manifest(*ensemble.manifest);
 
+  // The read-only catalog manager is cached and bound to the previous root
+  // hash; drop it so it is rebuilt against the refreshed manifest on next use.
+  delete simple_catalog_mgr_;
+  simple_catalog_mgr_ = NULL;
+
   std::string reflog_path;
   FILE *reflog_fd = CreateTempFile(tmp_dir + "/reflog", kPrivateFileMode, "w",
                                    &reflog_path);

--- a/cvmfs/publish/repository.h
+++ b/cvmfs/publish/repository.h
@@ -367,7 +367,7 @@ class __attribute__((visibility("default"))) Publisher : public Repository {
   void CheckTagName(const std::string &name);
 
   void TransactionRetry();
-  void TransactionImpl(bool waiting_on_lease = false);
+  void TransactionImpl();
 
   SettingsPublisher settings_;
   UniquePtr<perf::StatisticsTemplate> statistics_publish_;

--- a/cvmfs/publish/repository_transaction.cc
+++ b/cvmfs/publish/repository_transaction.cc
@@ -23,7 +23,6 @@ namespace publish {
 
 
 void Publisher::TransactionRetry() {
-  bool waiting_on_lease = false;
   if (managed_node_.IsValid()) {
     const int rvi = managed_node_->Check(false /* is_quiet */);
     if (rvi != 0)
@@ -40,7 +39,7 @@ void Publisher::TransactionRetry() {
 
   while (true) {
     try {
-      TransactionImpl(waiting_on_lease);
+      TransactionImpl();
       break;
     } catch (const publish::EPublish &e) {
       if (e.failure() != EPublish::kFailTransactionState) {
@@ -53,7 +52,6 @@ void Publisher::TransactionRetry() {
         if (platform_monotonic_time() > deadline)
           throw;
 
-        waiting_on_lease = true;
         LogCvmfs(kLogCvmfs, kLogStdout, "repository busy, retrying");
         throttle.Throttle();
         continue;
@@ -68,7 +66,7 @@ void Publisher::TransactionRetry() {
 }
 
 
-void Publisher::TransactionImpl(bool waiting_on_lease) {
+void Publisher::TransactionImpl() {
   if (in_transaction_.IsSet()) {
     throw EPublish("another transaction is already open",
                    EPublish::kFailTransactionState);
@@ -79,6 +77,28 @@ void Publisher::TransactionImpl(bool waiting_on_lease) {
   // On error, Transaction() will release the transaction lock and drop
   // the session
   session_->Acquire();
+
+  // Now that the lease is held (the lease subtree is frozen) refresh to the
+  // current HEAD before any HEAD-dependent step. The manifest fetched when this
+  // process started can be stale: another release manager may have advanced HEAD
+  // in the meantime. Refreshing here makes both the lease-path validation below
+  // and the catalog diff at publish time see post-lease HEAD. Without it, a
+  // parent path another publisher just created looks absent (spurious
+  // kFailLeaseNoEntry), and concurrently-added content looks deleted and gets
+  // dropped (#3867). Done on every gateway transaction, not only when waiting on
+  // a busy lease -- staleness is independent of contention. DownloadRootObjects
+  // also invalidates the cached read-only catalog manager; Check() remounts the
+  // read-only layer only if outdated; managed_node_ is absent for mount-less
+  // publishing.
+  if (settings_.storage().type() == upload::SpoolerDefinition::Gateway) {
+    DownloadRootObjects(settings_.url(), settings_.fqrn(),
+                        settings_.transaction().spool_area().tmp_dir());
+    if (managed_node_.IsValid()) {
+      const int rvi = managed_node_->Check(true /* is_quiet */);
+      if (rvi != 0)
+        throw EPublish("cannot establish writable mountpoint");
+    }
+  }
 
   // We might have a valid lease for a non-existing path. Nevertheless, we run
   // run into problems when merging catalogs later, so for the time being we
@@ -103,17 +123,6 @@ void Publisher::TransactionImpl(bool waiting_on_lease) {
 
   const UniquePtr<CheckoutMarker> marker(CheckoutMarker::CreateFrom(
       settings_.transaction().spool_area().checkout_marker()));
-  // TODO(jblomer): take root hash from r/o mountpoint?
-
-
-  if (settings_.storage().type() == upload::SpoolerDefinition::Gateway
-      && waiting_on_lease) {
-    DownloadRootObjects(settings_.url(), settings_.fqrn(),
-                        settings_.transaction().spool_area().tmp_dir());
-    const int rvi = managed_node_->Check(true /* is_quiet */);
-    if (rvi != 0)
-      throw EPublish("cannot establish writable mountpoint");
-  }
 
   in_transaction_.Set();
   // Pre-create the publishing lock file so that Abort() can acquire it even

--- a/test/container/501-stale-mount-drop/README.md
+++ b/test/container/501-stale-mount-drop/README.md
@@ -1,0 +1,25 @@
+# 501 - gateway stale-mount content drop (issue #3867)
+
+Regression test for the bug where a gateway release manager whose read-only
+mount is behind HEAD drops content that another release manager added.
+
+The failure is reproduced **deterministically** (no `sleep`/`-t` hammering) using
+the existing `transaction_before_hook` as a barrier: pub1 is parked right after
+it freezes its manifest but before it acquires the lease, pub2 advances HEAD in
+that window, then pub1 is released and publishes an unrelated change. Without the
+fix pub1 diffs its stale mount and the gateway records pub2's nested catalog as a
+deletion; with the fix pub1's post-lease mount refresh pulls it in first.
+
+```sh
+docker compose up --build -d
+./test.sh
+docker compose down -v --remove-orphans
+```
+
+`test.sh` exits non-zero (and prints `FAIL: dir/sub/payload was DROPPED`) on a
+buggy build, and prints `PASS` once the publisher refreshes its mount on every
+gateway transaction.
+
+Stack: `gw1` (Stratum-0 + cvmfs-gateway, local Apache upstream), `pub1` (victim),
+`pub2` (advances HEAD). All built from the working tree so `pub1` exercises the
+fix. Wired into CI by `.github/workflows/ci_stale_mount.yml`.

--- a/test/container/501-stale-mount-drop/config/repo.json
+++ b/test/container/501-stale-mount-drop/config/repo.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+
+  "repos": [
+    "test.repo.org"
+  ]
+}

--- a/test/container/501-stale-mount-drop/config/user.json
+++ b/test/container/501-stale-mount-drop/config/user.json
@@ -1,0 +1,9 @@
+{
+    "max_lease_time" : 7200,
+    "port" : 4929,
+    "num_receivers": 1,
+    "receiver_path": "/usr/bin/cvmfs_receiver",
+    "log_level" : "info",
+    "log_timestamps" : false,
+    "work_dir": "/var/lib/cvmfs-gateway"
+}

--- a/test/container/501-stale-mount-drop/docker-compose.yml
+++ b/test/container/501-stale-mount-drop/docker-compose.yml
@@ -1,0 +1,62 @@
+# Regression stack for the gateway stale-mount content-drop bug (issue #3867).
+#
+#   gw1   - Stratum-0 + cvmfs-gateway (local Apache upstream)
+#   pub1  - release manager whose read-only mount goes stale (the victim)
+#   pub2  - release manager that advances HEAD while pub1 is parked
+#
+# All three are built from the PR's sources (Dockerfile-dev), so pub1 exercises
+# the fix. systemd runs as PID 1 -> privileged + cgroup host are required.
+#
+#   docker compose up --build -d
+#   ./test.sh
+#   docker compose down -v --remove-orphans
+
+name: cvmfs-stale-mount-drop
+
+x-cvmfs-dev: &cvmfs-dev
+  image: cvmfs-stale-mount:latest
+  privileged: true
+  cgroup: host
+  build:
+    context: ../../..
+    dockerfile: test/common/container/Dockerfile-dev
+
+services:
+  gw1:
+    <<: *cvmfs-dev
+    container_name: cvmfs-gw1
+    hostname: cvmfs-gw1
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - ./scripts:/scripts
+      - ./config:/etc/cvmfs/gateway
+      - keys:/etc/cvmfs/keys
+      - var_spool_gw:/var/spool/cvmfs
+
+  pub1:
+    <<: *cvmfs-dev
+    container_name: cvmfs-pub1
+    hostname: cvmfs-pub1
+    depends_on: [gw1]
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - ./scripts:/scripts
+      - keys:/etc/cvmfs/keys
+      - var_spool_pub1:/var/spool/cvmfs
+
+  pub2:
+    <<: *cvmfs-dev
+    container_name: cvmfs-pub2
+    hostname: cvmfs-pub2
+    depends_on: [gw1]
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - ./scripts:/scripts
+      - keys:/etc/cvmfs/keys
+      - var_spool_pub2:/var/spool/cvmfs
+
+volumes:
+  keys:
+  var_spool_gw:
+  var_spool_pub1:
+  var_spool_pub2:

--- a/test/container/501-stale-mount-drop/scripts/pub1_hooks.sh
+++ b/test/container/501-stale-mount-drop/scripts/pub1_hooks.sh
@@ -1,0 +1,19 @@
+# /etc/cvmfs/cvmfs_server_hooks.sh on pub1 (test instrumentation only).
+#
+# Deterministic barrier: when armed, transaction_before_hook parks the
+# transaction *after* the publisher has frozen its manifest (constructor) but
+# *before* it acquires the lease and runs the post-lease mount refresh. That is
+# exactly the window in which pub2 advances HEAD, so without the fix pub1 ends
+# up diffing a stale read-only mount.
+#
+# The driver (test.sh) arms a single transaction by creating /tmp/arm_barrier
+# and releases it by writing to the FIFO /tmp/release_fifo. Both files must
+# already exist before the armed transaction starts.
+transaction_before_hook() {
+    [ -f /tmp/arm_barrier ] || return 0   # only the armed transaction blocks
+    rm -f /tmp/arm_barrier                # one-shot
+    touch /tmp/pub1_parked                # signal the driver we are parked
+    cat /tmp/release_fifo > /dev/null     # block (no spin) until released
+    rm -f /tmp/pub1_parked
+    return 0
+}

--- a/test/container/501-stale-mount-drop/scripts/setup_gateway.sh
+++ b/test/container/501-stale-mount-drop/scripts/setup_gateway.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Initialise the Stratum-0 + gateway inside the gw1 container.
+set -e
+
+FQRN="${FQRN:-test.repo.org}"
+
+# Wait until systemd is up enough to accept systemctl commands.
+while ! systemctl status &>/dev/null; do sleep 0.2; done
+
+# Gateway lease key (shared with publishers via the `keys` volume).
+echo "plain_text mykey mysecret" > /etc/cvmfs/keys/${FQRN}.gw
+
+# Apache serves the Stratum-0 data to the connected publishers.
+systemctl start httpd
+
+# Local-upstream Stratum-0.
+cvmfs_server mkfs -o root "${FQRN}"
+
+# Make the public + gateway keys readable by the publishers.
+chmod 0644 /etc/cvmfs/keys/${FQRN}.pub /etc/cvmfs/keys/${FQRN}.gw
+
+# Gateway service: mediates leases and spawns cvmfs_receiver.
+systemctl start cvmfs-gateway
+
+echo "[setup_gateway] done"

--- a/test/container/501-stale-mount-drop/scripts/setup_publisher.sh
+++ b/test/container/501-stale-mount-drop/scripts/setup_publisher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Attach a connected release manager to the gateway (gw upstream).
+set -e
+
+FQRN="${FQRN:-test.repo.org}"
+GW="${GW:-http://cvmfs-gw1}"
+
+cvmfs_server mkfs \
+    -w "$GW/cvmfs/$FQRN" \
+    -u "gw,/srv/cvmfs/$FQRN/data/txn,$GW:4929/api/v1" \
+    -k /etc/cvmfs/keys \
+    -o "$(whoami)" \
+    "$FQRN"
+
+echo "[setup_publisher] $(hostname) attached to $GW"

--- a/test/container/501-stale-mount-drop/test.sh
+++ b/test/container/501-stale-mount-drop/test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Regression test for issue #3867: a gateway release manager whose read-only
+# mount is behind HEAD must not drop content another release manager added.
+#
+# Deterministic, no timing races: pub1 is parked in transaction_before_hook
+# (after it froze its manifest, before it takes the lease); pub2 advances HEAD
+# in that window; pub1 is then released and publishes an unrelated change.
+#
+#   - With the fix:  pub1's post-lease refresh pulls in pub2's nested catalog
+#                    -> it survives.
+#   - Without it:    pub1 diffs a stale mount, old_root_hash already has the
+#                    nested catalog -> it is reported as a deletion and dropped.
+#
+# Assumes the stack is already up:  docker compose up --build -d
+set -euo pipefail
+
+cd "$(dirname "$0")"
+REPO=test.repo.org
+DC="docker compose"
+
+# exec helpers (no TTY, for CI)
+ex()  { $DC exec -T "$@"; }                 # ex <service> <cmd...>
+gw()  { ex gw1  "$@"; }
+p1()  { ex pub1 "$@"; }
+p2()  { ex pub2 "$@"; }
+
+wait_for() {  # wait_for <desc> <max_tries> <service> <cmd...>
+    local desc=$1 tries=$2; shift 2
+    for ((i=1; i<=tries; i++)); do
+        if ex "$@" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "FATAL: timed out waiting for: $desc"; return 1
+}
+
+echo "=== 1. set up gateway (Stratum-0 + cvmfs-gateway) ==="
+gw /scripts/setup_gateway.sh
+wait_for "httpd serving the repo" 60 gw1 \
+    curl -sf http://localhost/cvmfs/$REPO/.cvmfspublished
+wait_for "gateway API on :4929" 60 gw1 \
+    curl -sf http://localhost:4929/api/v1/repos
+
+echo "=== 2. attach the two release managers ==="
+p1 /scripts/setup_publisher.sh
+p2 /scripts/setup_publisher.sh
+
+echo "=== 3. baseline: pub1 creates /dir/keep (HEAD = H0) ==="
+p1 cvmfs_server transaction $REPO
+p1 bash -c "mkdir -p /cvmfs/$REPO/dir && echo keep > /cvmfs/$REPO/dir/keep"
+p1 cvmfs_server publish $REPO
+
+echo "=== 4. arm the deterministic barrier on pub1 ==="
+p1 cp /scripts/pub1_hooks.sh /etc/cvmfs/cvmfs_server_hooks.sh
+p1 bash -c 'rm -f /tmp/pub1_parked /tmp/release_fifo /tmp/arm_barrier;
+            mkfifo /tmp/release_fifo; touch /tmp/arm_barrier'
+
+echo "=== 5. start pub1 transaction on /dir; it parks in the hook ==="
+# Run the (blocking) transaction in a host-side background job. The hook keeps
+# it parked until we write to the FIFO; pub1's manifest is already frozen at H0.
+( p1 cvmfs_server transaction $REPO/dir ) &
+txn_job=$!
+wait_for "pub1 to park in transaction_before_hook" 60 pub1 test -f /tmp/pub1_parked
+
+echo "=== 6. pub2 publishes sibling nested catalog dir/sub (HEAD -> H1) ==="
+p2 cvmfs_server transaction $REPO/dir
+p2 bash -c "mkdir -p /cvmfs/$REPO/dir/sub &&
+            touch /cvmfs/$REPO/dir/sub/.cvmfscatalog &&
+            echo payload > /cvmfs/$REPO/dir/sub/payload"
+p2 cvmfs_server publish $REPO
+
+echo "=== 7. release pub1; it acquires the lease and must refresh its mount ==="
+p1 bash -c 'echo go > /tmp/release_fifo'
+wait $txn_job   # transaction command returns once the lease is held
+
+echo "=== 8. pub1 publishes an unrelated change under the same lease ==="
+p1 bash -c "echo other > /cvmfs/$REPO/dir/other"
+p1 cvmfs_server publish $REPO
+
+echo "=== 9. verify the published HEAD ==="
+# Inspect the *published* repository, not pub1's local read-only mount. A gateway
+# publish does NOT fast-forward the publisher's local mount to the just-committed
+# revision: cvmfs_server_publish.sh returns early for `gw` upstreams (never
+# reaching set_ro_root_hash), and close_transaction remounts rdonly at the
+# unchanged CVMFS_ROOT_HASH -- i.e. the pre-publish base the transaction was
+# refreshed to. That base holds `keep` and pub2's `sub` but NOT pub1's own
+# freshly-committed `other`, so checking the local mount would spuriously fail.
+# Opening a fresh transaction refreshes rdonly to HEAD (the #3867 fix); we
+# inspect there and abort to restore a clean state.
+p1 cvmfs_server transaction $REPO
+echo "--- pub1 view of /$REPO/dir at HEAD ---"
+p1 bash -c "ls -la /cvmfs/$REPO/dir/ /cvmfs/$REPO/dir/sub/ 2>&1" || true
+gw cvmfs_server tag -l $REPO 2>/dev/null || true
+
+rc=0
+p1 test -e /cvmfs/$REPO/dir/sub/payload \
+    || { echo "FAIL: dir/sub/payload was DROPPED -> bug present"; rc=1; }
+p1 test -e /cvmfs/$REPO/dir/other \
+    || { echo "FAIL: dir/other (pub1's own change) missing";       rc=1; }
+p1 test -e /cvmfs/$REPO/dir/keep \
+    || { echo "FAIL: dir/keep (baseline) missing";                 rc=1; }
+
+p1 cvmfs_server abort -f $REPO || true
+
+if [ $rc -eq 0 ]; then
+    echo "PASS: concurrently-added nested catalog preserved across uncontended publish"
+fi
+exit $rc

--- a/test/src/814-expired_lease/main
+++ b/test/src/814-expired_lease/main
@@ -3,6 +3,19 @@ cvmfs_test_name="Automatic cleanup when a lease has expired"
 cvmfs_test_autofs_on_startup=false
 cvmfs_test_suites="quick"
 
+CVMFS_TEST_814_USER_JSON=/etc/cvmfs/gateway/user.json
+CVMFS_TEST_814_BACKUP=
+
+# Restore the global gateway config we mutated. Registered as a trap so a failure
+# anywhere between the backup and the inline restore below does not leave
+# max_lease_time=1 installed system-wide, which would break every later run.
+cleanup() {
+    if [ -n "$CVMFS_TEST_814_BACKUP" ] && [ -f "$CVMFS_TEST_814_BACKUP" ]; then
+        echo "*** cleanup: restoring gateway lease config"
+        sudo mv "$CVMFS_TEST_814_BACKUP" "$CVMFS_TEST_814_USER_JSON"
+        restart_repository_gateway
+    fi
+}
 
 cvmfs_run_test() {
     set_up_repository_gateway || return 1
@@ -12,9 +25,11 @@ cvmfs_run_test() {
     cvmfs_server publish test.repo.org     || return 11
 
     echo "*** Reducing lease lifetime"
-    cp /etc/cvmfs/gateway/user.json user.json.orig
-    jq '.max_lease_time = 1' /etc/cvmfs/gateway/user.json > user.json.new
-    sudo mv user.json.new /etc/cvmfs/gateway/user.json
+    CVMFS_TEST_814_BACKUP="$(pwd)/user.json.orig"
+    trap cleanup EXIT HUP INT TERM || return 12
+    cp "$CVMFS_TEST_814_USER_JSON" "$CVMFS_TEST_814_BACKUP" || return 13
+    jq '.max_lease_time = 1' "$CVMFS_TEST_814_USER_JSON" > user.json.new || return 14
+    sudo mv user.json.new "$CVMFS_TEST_814_USER_JSON"
     restart_repository_gateway
 
     echo "*** Transaction should fail but recover through abort -f"
@@ -24,12 +39,11 @@ cvmfs_run_test() {
     cvmfs_server abort -f test.repo.org    || return 22
 
     echo "*** Restore lease lifetime"
-    sudo mv user.json.orig /etc/cvmfs/gateway/user.json
-    restart_repository_gateway
+    cleanup
+    trap - EXIT HUP INT TERM
 
     cvmfs_server transaction test.repo.org/ || return 30
     cvmfs_server publish test.repo.org || return 31
 
     return 0
 }
-


### PR DESCRIPTION
This extends the fix from https://github.com/cvmfs/cvmfs/pull/3771 to the case where no -t argument is given.

Fixes https://github.com/cvmfs/cvmfs/issues/3867