### PR TITLE
test: Drop all mentions of obsolete CVMFS_TEST_STRATUM0

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -33,7 +33,6 @@ CVMFS_TEST_HASHALGO=${CVMFS_TEST_HASHALGO:=sha1}
 CVMFS_TEST_S3_CONFIG=${CVMFS_TEST_S3_CONFIG:=}
 CVMFS_TEST_S3_STORAGE=${CVMFS_TEST_S3_STORAGE:=}
 CVMFS_TEST_HTTP_BASE=${CVMFS_TEST_HTTP_BASE:=}
-CVMFS_TEST_STRATUM0=${CVMFS_TEST_STRATUM0:=}   # backward compatibility! use CVMFS_TEST_HTTP_BASE instead
 
 # These OPT variables are for the benchmark options under the benchmarks folder
 CVMFS_OPT_WARM_CACHE=${CVMFS_OPT_WARM_CACHE:=yes}
@@ -47,15 +46,6 @@ CVMFS_OPT_OUTPUT_DIR=${CVMFS_OPT_OUTPUT_DIR:=/tmp/cvmfs_benchmarks}
 CVMFS_OPT_CACHEDIR=${CVMFS_OPT_CACHEDIR:=~/.benchmark}
 CVMFS_OPT_PARALLEL_RUNS=${CVMFS_OPT_PARALLEL_RUNS:=1}
 CVMFS_OPT_MTAB_MODIFIED="false"
-
-# backward compatibility.
-#     CVMFS_TEST_STRATUM0 was replaced by CVMFS_TEST_HTTP_BASE to better reflect
-#     the purpose of this variable. Please don't use CVMFS_TEST_STRATUM0 anymore
-if [ -z "$CVMFS_TEST_HTTP_BASE" ] && [ ! -z "$CVMFS_TEST_STRATUM0" ]; then
-  echo "Warning: You are using the deprecated CVMFS_TEST_STRATUM0 variable."
-  echo "         Please consider switching to CVMFS_TEST_HTTP_BASE"
-  CVMFS_TEST_HTTP_BASE="$CVMFS_TEST_STRATUM0"
-fi
 
 if [ ! -z "$CVMFS_TEST_GEO_LICENSE_KEY" ]; then
   echo "CVMFS_GEO_LICENSE_KEY=$CVMFS_TEST_GEO_LICENSE_KEY" | sudo tee /etc/cvmfs/server.local > /dev/null


### PR DESCRIPTION
10+ years is enough of backwards compatibility and warnings.