### PR TITLE
Add json output flag to cvmfs_config showconfig

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -266,7 +266,7 @@ cvmfs_config_usage() {
   fi
   echo "  chksetup"
   echo ""
-  echo "  showconfig [-s(hort output, only non-empty parameters)] [<repository>]"
+  echo "  showconfig [-s(hort output, only non-empty parameters)] [-j|--json] [<repository>]"
   echo ""
   echo "  stat [-v | <repository>]"
   echo ""
@@ -965,29 +965,61 @@ cvmfs_chksetup() {
 }
 
 
+# Ensure that a string is properly escaped for JSON output
+json_string() {
+  local s=$1
+  s=${s//\\/\\\\} # every \ becomes \\
+  s=${s//\"/\\\"} # every " becomes \"
+  printf '"%s"' "$s"
+}
+
 cvmfs_showconfig() {
   local fqrn
   local org
   local retval
   local short_output=0
+  local json_output=0
   local short_opt=
-  org=$1
-  if [ "x$org" = "x-s" ]; then
-    short_output=1
-    short_opt="-s "
-    shift 1
-    org=$1
-  fi
+  # Loop over all arguments: -s for short output, -j for JSON output, and the org name
+  # order of flags (-s and -j) does not matter
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -s)
+        short_output=1
+        short_opt="-s "
+        shift 1
+      ;;
+      -j|--json)
+        json_output=1
+        shift 1
+      ;;
+      *)
+        org=$1
+        shift 1
+      ;;
+    esac
+  done
 
   cvmfs_readconfig || die "Failed to read CernVM-FS configuration"
   if [ -z "$org" ]; then
     list="$(list_repos)"
-    for entry in $list
-    do
-      echo
-      echo "Running $0 $short_opt$entry:"
-      cvmfs_showconfig $short_opt$entry
-    done
+    if [ $json_output -eq 1 ]; then
+      # Emit all repositories as a JSON array of config objects - no repository argument was given
+      local first=1 entry
+      echo "["
+      for entry in $list; do
+        [ $first -eq 0 ] && echo "," # comma between JSON objects
+        cvmfs_showconfig -j $short_opt$entry # emit JSON object for this repository
+        first=0
+      done
+      echo "]"
+    else
+      for entry in $list; do
+        echo
+        echo "Running $0 $short_opt$entry:"
+        cvmfs_showconfig $short_opt$entry
+      done
+    fi
     return 0
   fi
 
@@ -1001,12 +1033,32 @@ cvmfs_showconfig() {
 
   local setting=
   local all_vars=
+  local set_vars=          # names present in the config file
   while read setting; do
     [ "x${setting:0:6}" != "xCVMFS_" ] && continue
-    var=$(echo "$setting" | cut -d= -f1)
-    all_vars="$all_vars $var"
+    set_vars="$set_vars ${setting%%=*}"
   done <<< "$CVMFS_PARMS"
-  all_vars="$(echo $all_vars $var_list | tr ' ' '\n' | sort -u)"
+  all_vars="$(echo $set_vars $var_list | tr ' ' '\n' | sort -u)"
+
+  if [ $json_output -eq 1 ]; then
+    # Emit this repository's configuration as a single JSON object + the repository name
+    echo "{"
+    printf '  "CVMFS_REPOSITORY_NAME": %s' "$(json_string "$fqrn")"
+    local jvar=
+    while read jvar; do
+      local value=${!jvar}
+      value=${value//@org@/$org}
+      value=${value//@fqrn@/$fqrn}
+      # short mode: hide only never-set parameters, like the plain output
+      if [ $short_output -eq 1 ] && [ -z "$value" ] \
+         && [[ " $set_vars " != *" $jvar "* ]]; then
+        continue
+      fi
+      printf ',\n  "%s": %s' "$jvar" "$(json_string "$value")"
+    done <<< "$all_vars"
+    printf '\n}\n'
+    return 0
+  fi
 
   echo "CVMFS_REPOSITORY_NAME=$fqrn"
   local var=

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cvmfs_test_name="Using config files from /etc/cvmfs/default.d/"
+cvmfs_test_name="Client configuration files and showconfig output"
 cvmfs_test_suites="quick"
 
 create_config_files() {
@@ -14,6 +14,26 @@ cleanup_config_files() {
   sudo rm -f /etc/cvmfs/default.d/50-test*
 }
 
+# Turn the plain 'showconfig' output into sorted KEY=VALUE lines: keep only
+# parameter lines, dropping the "# from SOURCE" provenance and the shell quoting.
+normalize_plain() {
+  awk -v q="'" '
+    /^[A-Za-z_][A-Za-z0-9_]*=/ {
+      eq = index($0, "=")
+      key = substr($0, 1, eq - 1)
+      value = substr($0, eq + 1)
+      sub(/[ \t]+# from .*$/, "", value)
+      gsub("^" q "|" q "$", "", value)
+      print key "=" value
+    }
+  ' | sort
+}
+
+# Turn a 'showconfig -j' object into the same sorted KEY=VALUE lines.
+normalize_json() {
+  jq -r 'to_entries[] | "\(.key)=\(.value)"' | sort
+}
+
 cvmfs_run_test() {
   logfile=$1
 
@@ -23,6 +43,21 @@ cvmfs_run_test() {
   cvmfs_mount grid.cern.ch || retval=2
   sudo cvmfs_talk -i grid.cern.ch parameters | grep CVMFS_KCACHE_TIMEOUT=3 | grep /etc/cvmfs/default.d/50-testB.conf || retval=3
   cvmfs_config showconfig grid.cern.ch | grep CVMFS_KCACHE_TIMEOUT=3 | grep /etc/cvmfs/default.d/50-testB.conf || retval=4
+
+  # The JSON output (-j) must expose the same resolved configuration as the
+  # plain text output.
+  # the value resolved above must also appear in the JSON object
+  cvmfs_config showconfig -j grid.cern.ch | jq -e '.CVMFS_KCACHE_TIMEOUT == "3"' > /dev/null || retval=40
+  # the JSON object carries the same parameters as the plain output
+  diff <(cvmfs_config showconfig    grid.cern.ch | normalize_plain) \
+       <(cvmfs_config showconfig -j grid.cern.ch | normalize_json) || retval=41
+  # the short output (-s) is identical in plain and JSON form
+  diff <(cvmfs_config showconfig -s   grid.cern.ch | normalize_plain) \
+       <(cvmfs_config showconfig -s -j grid.cern.ch | normalize_json) || retval=42
+  # without a repository name the output is a JSON array, one object per repo
+  diff <(cvmfs_config showconfig    | normalize_plain) \
+       <(cvmfs_config showconfig -j | jq '.[]' | normalize_json) || retval=43
+
   cvmfs_umount grid.cern.ch || retval=5
 
   cvmfs_mount grid.cern.ch "CVMFS_KCACHE_TIMEOUT=4" || retval=6


### PR DESCRIPTION
## Summary
Adds a `-j` / `--json` flag to `cvmfs_config showconfig` so its output can be parsed programmatically instead of scraping the plain `KEY=VALUE` text.

### Behaviour
- `cvmfs_config showconfig -j <repo>` prints the repository's effective configuration as a single JSON object.
- `cvmfs_config showconfig -j` (no repository specified) prints a JSON array containing one configuration object per repository defined in the `CVMFS_REPOSITORIES` parameter.
- Combines with the existing `-s` short flag; `--json` is accepted as a long alias, and flag order is independent.
- The default plain-text output remains completely unchanged, maintaining backward compatibility.

### Example
```bash
$ cvmfs_config showconfig -j grid.cern.ch
{
  "CVMFS_REPOSITORY_NAME": "grid.cern.ch",
  "CVMFS_SERVER_URL": "[http://cvmfs-stratum-one.cern.ch:8080/cvmfs/grid.cern.ch](http://cvmfs-stratum-one.cern.ch:8080/cvmfs/grid.cern.ch);...",
  "CVMFS_HTTP_PROXY": "[http://ca-proxy.cern.ch:3128](http://ca-proxy.cern.ch:3128)",
  ...
}
```
Closes #4082