### PR TITLE
Fix issues in cvmfs_config showconfig -j

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -266,7 +266,7 @@ cvmfs_config_usage() {
   fi
   echo "  chksetup"
   echo ""
-  echo "  showconfig [-s(hort output, only non-empty parameters)] [-j|--json] [<repository>]"
+  echo "  showconfig [-s(hort output, only parameters set in the configuration)] [-j|--json] [<repository>]"
   echo ""
   echo "  stat [-v | <repository>]"
   echo ""
@@ -968,8 +968,14 @@ cvmfs_chksetup() {
 # Ensure that a string is properly escaped for JSON output
 json_string() {
   local s=$1
-  s=${s//\\/\\\\} # every \ becomes \\
-  s=${s//\"/\\\"} # every " becomes \"
+  s=${s//\\/\\\\}     # every \ becomes \\
+  s=${s//\"/\\\"}     # every " becomes \"
+  # Control characters are not allowed literally inside a JSON string
+  s=${s//$'\b'/\\b}
+  s=${s//$'\f'/\\f}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
   printf '"%s"' "$s"
 }
 
@@ -1046,10 +1052,16 @@ cvmfs_showconfig() {
     printf '  "CVMFS_REPOSITORY_NAME": %s' "$(json_string "$fqrn")"
     local jvar=
     while read jvar; do
-      local value=${!jvar}
-      value=${value//@org@/$org}
-      value=${value//@fqrn@/$fqrn}
-      # short mode: hide only never-set parameters, like the plain output
+      local value=
+      if [ "x$jvar" = "xCVMFS_CACHE_DIR" ]; then
+        # Derived in cvmfs_readconfig (unset beforehand), never from the shell.
+        value=$CVMFS_CACHE_DIR
+      elif [[ " $set_vars " == *" $jvar "* ]]; then
+        value=${!jvar}
+        value=${value//@org@/$org}
+        value=${value//@fqrn@/$fqrn}
+      fi
+      # short mode: hide only never-set parameters
       if [ $short_output -eq 1 ] && [ -z "$value" ] \
          && [[ " $set_vars " != *" $jvar "* ]]; then
         continue

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -14,6 +14,20 @@ cleanup_config_files() {
   sudo rm -f /etc/cvmfs/default.d/50-test*
 }
 
+# Sort ';'- separated components within each value: some (e.g. CVMFS_PAC_URLS,
+# randomized in cvmfs-config.cern.ch's default.conf because of $RANDOM) aren't guaranteed to
+# keep a stable order across separate showconfig invocations.
+sort_value_lists() {
+  awk '{
+    eq = index($0, "=")
+    n = split(substr($0, eq + 1), v, ";")
+    n = asort(v)
+    val = v[1]
+    for (i = 2; i <= n; i++) val = val ";" v[i]
+    print substr($0, 1, eq) val
+  }'
+}
+
 # Turn the plain 'showconfig' output into sorted KEY=VALUE lines: keep only
 # parameter lines, dropping the "# from SOURCE" provenance and inverting the
 # shell quoting that 'cvmfs2 -o parse' applies (EscapeShell in options.cc).
@@ -41,12 +55,12 @@ normalize_plain() {
       }
       print key "=" value
     }
-  ' | sort
+  ' | sort_value_lists | sort
 }
 
 # Turn a 'showconfig -j' object into the same sorted KEY=VALUE lines.
 normalize_json() {
-  jq -r 'to_entries[] | "\(.key)=\(.value)"' | sort
+  jq -r 'to_entries[] | "\(.key)=\(.value)"' | sort_value_lists | sort
 }
 
 cvmfs_run_test() {
@@ -58,10 +72,6 @@ cvmfs_run_test() {
   cvmfs_mount grid.cern.ch || retval=2
   sudo cvmfs_talk -i grid.cern.ch parameters | grep CVMFS_KCACHE_TIMEOUT=3 | grep /etc/cvmfs/default.d/50-testB.conf || retval=3
   cvmfs_config showconfig grid.cern.ch | grep CVMFS_KCACHE_TIMEOUT=3 | grep /etc/cvmfs/default.d/50-testB.conf || retval=4
-
-  # TODO(vavolkl): Re-enable once test logic is fixed
-  cleanup_config_files
-  return $retval
 
   # The JSON output (-j) must expose the same resolved configuration as the
   # plain text output.
@@ -76,6 +86,19 @@ cvmfs_run_test() {
   # without a repository name the output is a JSON array, one object per repo
   diff <(cvmfs_config showconfig    | normalize_plain) \
        <(cvmfs_config showconfig -j | jq '.[]' | normalize_json) || retval=43
+
+  # Check that the environment variable CVMFS_USE_CDN is not leaked into the JSON and plain output
+  local leaked="shell_leak_sentinel"
+  [ "$(CVMFS_USE_CDN=$leaked cvmfs_config showconfig -j grid.cern.ch \
+         | jq -r '.CVMFS_USE_CDN')" = "$leaked" ] && retval=44
+  CVMFS_USE_CDN=$leaked cvmfs_config showconfig grid.cern.ch \
+    | grep -q "^CVMFS_USE_CDN=$leaked" && retval=45
+
+  # grid.cern.ch is a repository that has 4 server urls, separated by ';' so we check that the JSON output
+  # does not contain any single quotes put by EscapeShell()
+  cvmfs_config showconfig -j grid.cern.ch \
+    | jq -e "(.CVMFS_SERVER_URL // \"\") | test(\"'\") | not" >/dev/null \
+    || retval=46
 
   cvmfs_umount grid.cern.ch || retval=5
 


### PR DESCRIPTION
This PR fixes issues regarding the JSON output:

- **Shell environment leak:** `showconfig -j` outputs what is actually set in the config files, ignoring variables exported in the local shell.
- **EscapeShell quotes:** Fixed the bug where semicolon-separated URLs (like in `CVMFS_SERVER_URL`) kept their shell-protection single quotes in the JSON output.
- **Control characters:** Added mappings for `\n`, `\r`, `\t`, etc., in the `json_string()` function so config files with weird line endings (that Windows adds) don't result in invalid JSON syntax.
- **Tests:** Renewed the test no. 046 (defaultd) so it tests these edge cases (by leaking a variable in shell, and by testing the EscapeShell bug against grid.cern.ch which is configured to have 4 server urls, separated by ';').
- **Documentation** Fixed a small inaccuracy in the `showconfig -s` usage description (ignores empty-valued parameters -> ignores not set parameters).