### PR TITLE
Fix compiling s3mockserver

### DIFF
--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(s3mockserver
 
 target_link_libraries (s3mockserver
                        cvmfs_util
+                       CURL::libcurl
                        pthread
                        dl
 )


### PR DESCRIPTION
Without this, it complains for absense of curl/curl.h

Fixes: 1e7bacc448cf ("externals: Move curl and c-ares to FetchContent (#4322)")