### PR TITLE
Fix S3 V2 signature for multi-object delete with DNS buckets

### DIFF
--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -43,6 +43,27 @@ static string XmlEscape(const string &input) {
 
 
 /**
+ * The CanonicalizedResource of an S3 V2 signature.  It must mirror MkUrl():
+ * the server rebuilds the resource from the request path, so any difference,
+ * down to a trailing slash, yields SignatureDoesNotMatch.
+ *
+ * With DNS buckets the bucket lives in the hostname and the path is
+ * "/" + object_key, so an empty key gives "/<bucket>/".  In path style the
+ * path already carries the bucket and an empty key gives "/<bucket>".
+ */
+string MkV2CanonicalResource(const string &bucket, const string &object_key,
+                             bool dns_buckets, bool multi_delete) {
+  string resource = "/" + bucket;
+  if (dns_buckets || !object_key.empty())
+    resource += "/" + object_key;
+  // V2 requires subresources to be signed; multi-delete posts to "?delete"
+  if (multi_delete)
+    resource += "?delete";
+  return resource;
+}
+
+
+/**
  * Builds an S3 DeleteObjects XML request body for multi-object delete.
  * Uses Quiet mode so the response only contains errors, not successes.
  */
@@ -604,25 +625,14 @@ bool S3FanoutManager::MkV2Authz(const JobInfo &info,
   const string timestamp = RfcTimestamp();
   string to_sign = request + "\n" + payload_hash + "\n" + content_type + "\n"
                    + timestamp + "\n";
-  if (config_.x_amz_acl != "") {
-    if (info.object_key.empty()) {
-      to_sign += "x-amz-acl:" + config_.x_amz_acl + "\n" +  // default ACL
-                 "/" + config_.bucket;
-    } else {
-      to_sign += "x-amz-acl:" + config_.x_amz_acl + "\n" +  // default ACL
-                 "/" + config_.bucket + "/" + info.object_key;
-    }
-  }
-  // S3 V2 requires subresources to be included in the string to sign.
-  // For kReqDeleteMulti, object_key is intentionally empty: the canonical
-  // resource becomes "/<bucket>?delete", matching the POST URL.
-  if (info.request == JobInfo::kReqDeleteMulti) {
-    if (config_.x_amz_acl == "")
-      to_sign += "/" + config_.bucket;
-    to_sign += "?delete";
-  }
-  LogCvmfs(kLogS3Fanout, kLogDebug, "%s string to sign for: %s",
-           request.c_str(), info.object_key.c_str());
+  if (config_.x_amz_acl != "")
+    to_sign += "x-amz-acl:" + config_.x_amz_acl
+               + "\n";  // CanonicalizedAmzHeaders
+  to_sign += MkV2CanonicalResource(config_.bucket, info.object_key,
+                                   config_.dns_buckets,
+                                   info.request == JobInfo::kReqDeleteMulti);
+  LogCvmfs(kLogS3Fanout, kLogDebug, "%s string to sign: %s", request.c_str(),
+           to_sign.c_str());
 
   shash::Any hmac;
   hmac.algorithm = shash::kSha1;

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -350,6 +350,9 @@ class S3FanoutManager : SingleCopy {
   std::string dot_cvmfs_cache_control_header;           // Cache-Control: max-age=...
 };  // S3FanoutManager
 
+std::string MkV2CanonicalResource(const std::string &bucket,
+                                  const std::string &object_key,
+                                  bool dns_buckets, bool multi_delete);
 std::string ComposeDeleteMultiXml(const std::vector<std::string> &keys);
 unsigned ParseDeleteMultiResponse(const std::string &response,
                                   std::vector<std::string> *error_keys,

--- a/test/unittests/t_s3fanout.cc
+++ b/test/unittests/t_s3fanout.cc
@@ -53,6 +53,31 @@ TEST(T_S3Fanout, DetectThrottleIndicator) {
 }
 
 
+TEST(T_S3Fanout, MkV2CanonicalResource) {
+  // The resource must mirror MkUrl().  With DNS buckets the request path is
+  // "/" + object_key, so an empty key keeps the trailing slash; in path style
+  // the bucket is the path and an empty key has no trailing slash.
+  EXPECT_EQ(
+      "/bkt/data/ab/file1",
+      s3fanout::MkV2CanonicalResource("bkt", "data/ab/file1", true, false));
+  EXPECT_EQ(
+      "/bkt/data/ab/file1",
+      s3fanout::MkV2CanonicalResource("bkt", "data/ab/file1", false, false));
+
+  // Multi-object delete posts to the bucket root with an empty object key.
+  // Signing "/bkt?delete" here makes Ceph RGW reject the request with
+  // SignatureDoesNotMatch, because it rebuilds the resource from the path "/".
+  EXPECT_EQ("/bkt/?delete",
+            s3fanout::MkV2CanonicalResource("bkt", "", true, true));
+  EXPECT_EQ("/bkt?delete",
+            s3fanout::MkV2CanonicalResource("bkt", "", false, true));
+
+  // Bucket creation is the other empty-key request
+  EXPECT_EQ("/bkt/", s3fanout::MkV2CanonicalResource("bkt", "", true, false));
+  EXPECT_EQ("/bkt", s3fanout::MkV2CanonicalResource("bkt", "", false, false));
+}
+
+
 TEST(T_S3Fanout, ComposeDeleteMultiXmlSingleKey) {
   vector<string> keys;
   keys.push_back("data/ab/file1");


### PR DESCRIPTION
QA testing found that batch deletes during gc fail against Ceph RGW with 403 SignatureDoesNotMatch:

  Running automatic garbage collection
    --> sweeping unreferenced objects
  S3: HTTP failure 403
  Batch delete of 100 objects failed. (error code: 3 - S3: forbidden)

Multi-object delete is the only request with an empty object key, so it posts to the bucket root. With DNS buckets MkUrl() yields https://<bucket>.<host>/?delete and the request path is a single "/". The server rebuilds the V2 CanonicalizedResource from that path as /<bucket>/?delete, while MkV2Authz() signed /<bucket>?delete. This differs by one slash and the signature is rejected.

The original batch-delete implementation was correct, but the subsequent PR for the s3 garage CI test added an empty-object-key case to MkUrl(), but only for path-style addressing, where dropping the trailing slash is correct. It mirrored that into MkV2Authz() unconditionally, and since the DNS bucket branch of MkUrl() still emits the slash, the signature stopped matching the URL it signs for. MkV4Authz() was changed in the same commit but branches on dns_buckets and stayed consistent, which is why only V2 is affected.

Derive the canonical resource in one place instead, branching on dns_buckets the way MkUrl() does. This also repairs two other empty-key cases broken since #4202: bucket creation (kReqPutBucket, which only runs with DNS buckets), and CVMFS_S3_X_AMZ_ACL= (empty is an allowed value), which signed no canonical resource at all.

Only 2.14.0 with CVMFS_S3_BATCH_DELETE is affected. As a workaround, setting CVMFS_S3_BATCH_DELETE=false uses per-object deletes, which are not affacted.

The debug log now prints the string to sign rather than the object key. The string contains no secret material, and should help with debugging.

Fixes: #4334 

Assisted-by: Claude (claude-opus-4-8)