### PR TITLE
Fix building with only BUILD_LIBCVMFS enabled

### DIFF
--- a/.github/workflows/ci_libcvmfs.yml
+++ b/.github/workflows/ci_libcvmfs.yml
@@ -1,0 +1,51 @@
+name: CI libcvmfs
+
+on:
+  push:
+      branches: ['devel', 'cvmfs*']
+  pull_request:
+      branches: ['devel', 'cvmfs*']
+
+jobs:
+  libcvmfs-only:
+    name: "Client library only (BUILD_LIBCVMFS)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake g++ make patch \
+            libarchive-dev \
+            libc-ares-dev \
+            libcap-dev \
+            libcurl4-openssl-dev \
+            libleveldb-dev \
+            libprotobuf-dev \
+            libsparsehash-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            nlohmann-json3-dev \
+            protobuf-compiler \
+            uuid-dev \
+            zlib1g-dev
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DBUILD_CVMFS=OFF \
+            -DBUILD_SERVER=OFF \
+            -DBUILD_RECEIVER=OFF \
+            -DBUILD_GEOAPI=OFF \
+            -DBUILD_LIBCVMFS=ON \
+            -DBUILD_LIBCVMFS_CACHE=OFF \
+            -DINSTALL_MOUNT_SCRIPTS=OFF \
+            -DINSTALL_PUBLIC_KEYS=OFF \
+            -DINSTALL_BASH_COMPLETION=OFF
+
+      - name: Build
+        run: cmake --build build -j"$(nproc)"

--- a/.github/workflows/ci_libcvmfs.yml
+++ b/.github/workflows/ci_libcvmfs.yml
@@ -20,7 +20,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake g++ make patch \
-            libarchive-dev \
             libc-ares-dev \
             libcap-dev \
             libcurl4-openssl-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,11 +515,14 @@ if (BUILD_CVMFS)
   endif (MACOSX)
 endif ()
 
-# libcap is needed by cvmfs2, cvmfs_fuse*_stub, mount.cvmfs, and the
-# server-side swissknife — every target that links cvmfs/util/capabilities.cc.
+# libcap is needed by every target that links cvmfs/util/capabilities.cc,
+# i.e. everything that builds libcvmfs-util.
 # macOS has stubbed-out implementations in capabilities.{cc,h} that don't
 # reference libcap symbols, so the lookup is skipped there.
-if (NOT MACOSX AND (BUILD_CVMFS OR BUILD_SERVER OR BUILD_SERVER_DEBUG OR INSTALL_MOUNT_SCRIPTS))
+if (NOT MACOSX AND (BUILD_CVMFS OR BUILD_LIBCVMFS OR BUILD_LIBCVMFS_CACHE OR
+                    BUILD_SERVER OR BUILD_SERVER_DEBUG OR BUILD_RECEIVER OR
+                    BUILD_SHRINKWRAP OR BUILD_PRELOADER OR BUILD_UNITTESTS OR
+                    BUILD_STRESS_TESTS OR INSTALL_MOUNT_SCRIPTS))
   find_package(LibCAP REQUIRED)
 endif ()
 

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -4,7 +4,12 @@ include(${CMAKE_SOURCE_DIR}/cmake/Modules/ExternalDepMacros.cmake)
 
 set(EXTERNALS_INSTALL_TARGETS "")
 
-add_subdirectory(libarchive)
+# libarchive is only used for tarball ingestion by the publishing tools
+# (cvmfs_swissknife, cvmfs_publish, cvmfs_preload)
+if(BUILD_CVMFS OR BUILD_SERVER OR BUILD_SERVER_DEBUG OR BUILD_RECEIVER OR
+   BUILD_PRELOADER)
+  add_subdirectory(libarchive)
+endif()
 add_subdirectory(json)
 add_subdirectory(pacparser)
 add_subdirectory(protobuf)


### PR DESCRIPTION
Fixes an issue introduced in 1146921d8 which broke library-only builds. Also adds a GHA test for the client library only build.

Also removes the libarchive dependency from components that don't need it.