### PR TITLE
feat: support building libcvmfs-crypto against the system OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,22 @@ endif ()
 find_package (OpenSSL REQUIRED)
 set (INCLUDE_DIRECTORIES ${INCLUDE_DIRECTORIES} ${OPENSSL_INCLUDE_DIR})
 
+# libcvmfs_crypto links a private static LibreSSL libcrypto by default. When
+# the libcrypto external is disabled (BUILTIN_EXTERNALS=OFF, an explicit
+# BUILTIN_EXTERNALS_LIST without it, or BUILTIN_EXTERNALS_EXCLUDE=libcrypto),
+# fall back to the system OpenSSL for libcvmfs_crypto as well.
+string (TOLOWER "${BUILTIN_EXTERNALS_LIST}" _builtin_list_lower)
+string (TOLOWER "${BUILTIN_EXTERNALS_EXCLUDE}" _builtin_exclude_lower)
+if (NOT BUILTIN_EXTERNALS
+    OR "libcrypto" IN_LIST _builtin_exclude_lower
+    OR (BUILTIN_EXTERNALS_LIST AND NOT "libcrypto" IN_LIST _builtin_list_lower))
+  set (CVMFS_SYSTEM_LIBCRYPTO ON)
+  message (STATUS "libcvmfs_crypto: using the system OpenSSL libcrypto")
+  add_definitions (-DCVMFS_CRYPTO_SYSTEM_OPENSSL)
+else ()
+  set (CVMFS_SYSTEM_LIBCRYPTO OFF)
+endif ()
+
 find_package (Libcrypto REQUIRED)
 # We do not add the Libcrypto include directories to INCLUDE_DIRECTORIES
 # to avoid a clash with the system openssl. We only use it for libcvmfs_crypto

--- a/cmake/Modules/FindLibcrypto.cmake
+++ b/cmake/Modules/FindLibcrypto.cmake
@@ -7,19 +7,26 @@
 #  Libcrypto_LIBRARIES - Link these to use SHA3
 #
 
-find_path(
-    Libcrypto_INCLUDE_DIRS
-    NAMES tls.h
-    PATHS ${EXTERNALS_INSTALL_LOCATION}/crypto/include
-    NO_DEFAULT_PATH
-)
+if(CVMFS_SYSTEM_LIBCRYPTO)
+  # The built-in LibreSSL is disabled: use the system OpenSSL located by the
+  # mandatory find_package(OpenSSL) instead.
+  set(Libcrypto_LIBRARIES OpenSSL::Crypto)
+  set(Libcrypto_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+else()
+  find_path(
+      Libcrypto_INCLUDE_DIRS
+      NAMES tls.h
+      PATHS ${EXTERNALS_INSTALL_LOCATION}/crypto/include
+      NO_DEFAULT_PATH
+  )
 
-find_library(
-    Libcrypto_LIBRARIES
-    NAMES crypto
-    PATHS ${EXTERNALS_INSTALL_LOCATION}/crypto/lib
-    NO_DEFAULT_PATH
-)
+  find_library(
+      Libcrypto_LIBRARIES
+      NAMES crypto
+      PATHS ${EXTERNALS_INSTALL_LOCATION}/crypto/lib
+      NO_DEFAULT_PATH
+  )
+endif()
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(

--- a/cvmfs/crypto/openssl_version.h
+++ b/cvmfs/crypto/openssl_version.h
@@ -8,8 +8,10 @@
 #include <openssl/opensslv.h>
 
 // Safeguard when compiling libcvmfs_crypto: make sure we pick up the built-in
-// LibreSSL and not the system's OpenSSL
-#ifdef CVMFS_LIBRARY
+// LibreSSL and not the system's OpenSSL. The build system defines
+// CVMFS_CRYPTO_SYSTEM_OPENSSL when the libcrypto external is disabled and
+// the system OpenSSL is the intended crypto provider.
+#if defined(CVMFS_LIBRARY) && !defined(CVMFS_CRYPTO_SYSTEM_OPENSSL)
 #ifndef LIBRESSL_VERSION_NUMBER
 #error "picking up OpenSSL includes instead of LibreSSL"
 #endif


### PR DESCRIPTION
This PR adds a cleaner way (i.e. `-DBUILTIN_EXTERNALS_EXCLUDE=libcrypto`) of supporting OpenSSL for packaging in ecosystems where statically linking LibreSSL is discouraged/forbidden. For example Gentoo has shipped an equivalent patch since 2.10.