### PR TITLE
fix: preserve the configured CMAKE_BUILD_TYPE across the externals setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,11 +318,13 @@ endif(BUILTIN_EXTERNALS)
 # Migrate bootstrap.sh to cmake
 if(BUILTIN_EXTERNALS)
   message(STATUS "Entering external dependencies setup")
+  # Some vendored externals (e.g. libarchive) force their preferred
+  # CMAKE_BUILD_TYPE into the cache; save the configured value and restore
+  # it afterwards.
+  set(_cvmfs_build_type "${CMAKE_BUILD_TYPE}")
   add_subdirectory(externals)
+  set(CMAKE_BUILD_TYPE "${_cvmfs_build_type}" CACHE STRING "Build Type" FORCE)
 endif()
-
-# reset cache variables the externals may have changed
-set(CMAKE_BUILD_TYPE "" CACHE STRING "Build Type" FORCE)
 
 #
 # include some common functionality


### PR DESCRIPTION
🤖 Below is an LLM generated description but I think it's clearer than anything I'd write:

> Since a99918410 the cache reset after the externals setup unconditionally clears `CMAKE_BUILD_TYPE`, so a user-provided `-DCMAKE_BUILD_TYPE` is silently discarded. The reset exists because some vendored externals (`libarchive`) force their own build type into the cache; save the configured value and restore it instead of resetting to empty.
> 
> Among other things the discarded build type drops `-DNDEBUG` from Release builds, which breaks linking against `protobuf >= 22`: the generated code keeps its `ABSL_DCHECK` paths and fails with undefined abseil symbols unless abseil is linked explicitly.