### PR TITLE
shrinkwrap: surface the real reason for cache init failures

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -505,8 +506,8 @@ bool FileSystem::LockWorkspace() {
     return true;
 
   if (fd_workspace_lock_ == -1) {
-    boot_error_ = "could not acquire workspace lock (" + StringifyInt(errno)
-                  + ")";
+    boot_error_ = "could not acquire workspace lock " + path_workspace_lock_
+                  + " (" + strerror(errno) + ")";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -520,8 +521,8 @@ bool FileSystem::LockWorkspace() {
 
   fd_workspace_lock_ = LockFile(path_workspace_lock_);
   if (fd_workspace_lock_ < 0) {
-    boot_error_ = "could not acquire workspace lock (" + StringifyInt(errno)
-                  + ")";
+    boot_error_ = "could not acquire workspace lock " + path_workspace_lock_
+                  + " (" + strerror(errno) + ")";
     boot_status_ = loader::kFailCacheDir;
     return false;
   }
@@ -1037,6 +1038,22 @@ void FileSystem::SetupSqlite() {
 }
 
 
+/**
+ * Describes why MkdirDeep() failed for path.  Must be called immediately after
+ * the failure, before errno is clobbered.  MkdirDeep() reports EEXIST both for
+ * a path that is already a directory (not a failure) and for a path that is
+ * taken by a non-directory, so spell out the latter instead of printing the
+ * confusing "File exists".
+ */
+static string DescribeMkdirFailure(const string &path) {
+  const int saved_errno = errno;
+  platform_stat64 info;
+  if ((platform_stat(path.c_str(), &info) == 0) && !S_ISDIR(info.st_mode))
+    return path + " exists but is not a directory";
+  return path + " (" + strerror(saved_errno) + ")";
+}
+
+
 bool FileSystem::SetupWorkspace() {
   string optarg;
   // This is very similar to "determine cache dir".  It's for backward
@@ -1069,7 +1086,8 @@ bool FileSystem::SetupWorkspace() {
   // permission now to 0770 to avoid a race when fixing it later
   const int mode = 0770;
   if (!MkdirDeep(workspace_, mode, false)) {
-    boot_error_ = "cannot create workspace directory " + workspace_;
+    boot_error_ = "cannot create workspace directory "
+                  + DescribeMkdirFailure(workspace_);
     boot_status_ = loader::kFailCacheDir;
     return false;
   }

--- a/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
+++ b/cvmfs/shrinkwrap/fs_traversal_libcvmfs.cc
@@ -215,7 +215,8 @@ struct fs_traversal_context *libcvmfs_initialize(const char *repo,
 
   retval = cvmfs_init_v2(options_mgr);
   if (retval) {
-    LogCvmfs(kLogCvmfs, kLogStderr, "CVMFS Initialization failed : %s", repo);
+    // cvmfs_init_v2() already reported the specific reason on stderr
+    LogCvmfs(kLogCvmfs, kLogDebug, "CVMFS Initialization failed : %s", repo);
     return NULL;
   }
 

--- a/cvmfs/shrinkwrap/posix/interface.cc
+++ b/cvmfs/shrinkwrap/posix/interface.cc
@@ -740,7 +740,8 @@ struct fs_traversal_context *posix_initialize(const char *repo,
   if (!DirectoryExists(req_dirs.c_str())) {
     if (!MkdirDeep(req_dirs.c_str(), 0755, true)) {
       LogCvmfs(kLogCvmfs, kLogStderr,
-               "Failed to create repository directory '%s'", req_dirs.c_str());
+               "Failed to create repository directory '%s' (%s)",
+               req_dirs.c_str(), strerror(errno));
       return NULL;
     }
   }


### PR DESCRIPTION
With CVMFS_CACHE_BASE pointing at an inaccessible directory, cvmfs_shrinkwrap effectively reported only "Unable to initialize source".

The reason already reached stderr via boot_error_ and cvmfs_init_v2, but carried no errno and sat under two content-free lines of equal severity, so the least informative one is what users saw.

  * Add the failing path and strerror(errno) to the workspace and workspace-lock boot_error_ messages. MkdirDeep reports EEXIST for both an existing directory and a path taken by a non-directory, so DescribeMkdirFailure spells out the latter rather than "File exists".
  * Demote "CVMFS Initialization failed : <repo>" to kLogDebug.
  * Add strerror(errno) to the POSIX backend, which had the same gap.

Now prints "cannot create workspace directory <path> (Permission denied)" above the generic line.

Fixes https://github.com/cvmfs/cvmfs/issues/4330