### PR TITLE
shrinkwrap: create the .data directory structure in parallel

### DIFF
--- a/cvmfs/shrinkwrap/posix/data_dir_mgmt.cc
+++ b/cvmfs/shrinkwrap/posix/data_dir_mgmt.cc
@@ -3,60 +3,145 @@
  */
 #include "data_dir_mgmt.h"
 
+#include <assert.h>
 #include <errno.h>
+#include <pthread.h>
 #include <stdio.h>
+
+#include <algorithm>
+#include <string>
 
 #include "helpers.h"
 #include "shrinkwrap/fs_traversal_interface.h"
 #include "util/posix.h"
+#include "util/smalloc.h"
 
 /**
- * Method which recursively creates the .data subdirectories
+ * Number of directories per level (16^kDigitsPerDirLevel)
  */
-void PosixCheckDirStructure(std::string cur_path,
-                            mode_t mode,
-                            unsigned depth = 1) {
-  std::string max_dir_name = std::string(kDigitsPerDirLevel, 'f');
-  // Build current base path
-  if (depth == 1) {
-    bool res1 = MkdirDeep(cur_path.c_str(), mode);
-    assert(res1);
-  } else {
-    int res = mkdir(cur_path.c_str(), mode);
-    assert(res == 0 || errno == EEXIST);
-  }
-  // Build template for directory names:
+static const unsigned kDirsPerLevel = 1U << (4 * kDigitsPerDirLevel);
+
+struct posix_dir_init_thread {
+  const char *data;
+  mode_t mode;
+  unsigned thread_total;
+  unsigned thread_num;
+};
+
+/**
+ * Returns the name of the i-th directory of a level
+ * (zero padded hexadecimal, kDigitsPerDirLevel digits)
+ */
+static std::string DirLevelName(unsigned i) {
   assert(kDigitsPerDirLevel <= 99);
-  char hex[kDigitsPerDirLevel + 1];
   char dir_name_template[5];
-  snprintf(dir_name_template,
-           sizeof(dir_name_template),
-           "%%%02ux",
+  snprintf(dir_name_template, sizeof(dir_name_template), "%%%02ux",
            kDigitsPerDirLevel);
-  // Go through all levels:
-  for (; depth <= kDirLevels; depth++) {
-    if (!DirectoryExists(cur_path + "/" + max_dir_name)) {
-      // Directories in this level not yet fully created...
-      for (unsigned int i = 0;
-           i < (((unsigned int)1) << 4 * kDigitsPerDirLevel);
-           i++) {
-        // Go through directories 0^kDigitsPerDirLevel to f^kDigitsPerDirLevel
-        snprintf(hex, sizeof(hex), dir_name_template, i);
-        std::string this_path = cur_path + "/" + std::string(hex);
-        int res = mkdir(this_path.c_str(), mode);
-        assert(res == 0 || errno == EEXIST);
-        // Once directory created: Prepare substructures
-        PosixCheckDirStructure(this_path, mode, depth + 1);
-      }
-      break;
-    } else {
-      // Directories on this level fully created; check ./
-      PosixCheckDirStructure(cur_path + "/" + max_dir_name, mode, depth + 1);
-    }
+  char hex[kDigitsPerDirLevel + 1];
+  snprintf(hex, sizeof(hex), dir_name_template, i);
+  return std::string(hex);
+}
+
+static void PosixMkdir(const std::string &path, mode_t mode) {
+  int res = mkdir(path.c_str(), mode);
+  assert(res == 0 || errno == EEXIST);
+}
+
+/**
+ * Method which recursively creates the .data subdirectories below cur_path
+ * (which is expected to exist already). depth is the level of the directories
+ * created by this call.
+ *
+ * If the last directory of a level exists we assume that the level was fully
+ * created by a previous run and only descend into it. This keeps the cost of
+ * re-initializing an existing destination at O(kDirLevels).
+ */
+static void PosixCheckDirStructure(const std::string &cur_path, mode_t mode,
+                                   unsigned depth) {
+  if (depth > kDirLevels)
+    return;
+  const std::string max_dir_name = DirLevelName(kDirsPerLevel - 1);
+  if (DirectoryExists(cur_path + "/" + max_dir_name)) {
+    // Directories on this level fully created; check ./
+    PosixCheckDirStructure(cur_path + "/" + max_dir_name, mode, depth + 1);
+    return;
+  }
+  // Directories in this level not yet fully created...
+  for (unsigned i = 0; i < kDirsPerLevel; i++) {
+    // Go through directories 0^kDigitsPerDirLevel to f^kDigitsPerDirLevel
+    const std::string this_path = cur_path + "/" + DirLevelName(i);
+    PosixMkdir(this_path, mode);
+    // Once directory created: Prepare substructures
+    PosixCheckDirStructure(this_path, mode, depth + 1);
   }
 }
 
+/**
+ * Main worker of the parallel .data directory initialization.
+ * The thread with thread number j creates the top level directories
+ * /j/, /j+n/, /j+2n/, ... (where n is the total number of threads) together
+ * with all their subdirectories. The subtrees rooted at the top level
+ * directories are independent of each other, so no synchronization is needed.
+ */
+static void *PosixDataDirInitMainWorker(void *data) {
+  struct posix_dir_init_thread
+      *thread_context = reinterpret_cast<struct posix_dir_init_thread *>(data);
+  for (unsigned i = thread_context->thread_num; i < kDirsPerLevel;
+       i += thread_context->thread_total) {
+    const std::string this_path = std::string(thread_context->data) + "/"
+                                  + DirLevelName(i);
+    PosixMkdir(this_path, thread_context->mode);
+    PosixCheckDirStructure(this_path, thread_context->mode, 2);
+  }
+  return NULL;
+}
+
+/**
+ * Creates the .data directory structure.
+ * Will use posix_ctx->num_threads in parallel for the task.
+ * For posix_ctx->num_threads <= 1 there is a fallback to a sequential version.
+ */
 void InitializeDataDirectory(struct fs_traversal_context *ctx) {
-  // NOTE(steuber): Can we do this in parallel?
-  PosixCheckDirStructure(ctx->data, 0700);
+  struct fs_traversal_posix_context
+      *posix_ctx = reinterpret_cast<struct fs_traversal_posix_context *>(
+          ctx->ctx);
+  const mode_t mode = 0700;
+  bool res = MkdirDeep(ctx->data, mode);
+  assert(res);
+  if (kDirLevels == 0)
+    return;
+
+  // More threads than top level directories do not help
+  const unsigned thread_total = std::min(
+      static_cast<unsigned>(std::max(posix_ctx->num_threads, 1)),
+      kDirsPerLevel);
+
+  // The sequential version is also used if the top level was already created
+  // by a previous run, in which case there is nothing left to parallelize.
+  if (thread_total <= 1
+      || DirectoryExists(std::string(ctx->data) + "/"
+                         + DirLevelName(kDirsPerLevel - 1))) {
+    PosixCheckDirStructure(ctx->data, mode, 1);
+    return;
+  }
+
+  struct posix_dir_init_thread
+      *thread_contexts = reinterpret_cast<struct posix_dir_init_thread *>(
+          smalloc(sizeof(struct posix_dir_init_thread) * thread_total));
+  pthread_t *workers = reinterpret_cast<pthread_t *>(
+      smalloc(sizeof(pthread_t) * thread_total));
+  for (unsigned i = 0; i < thread_total; i++) {
+    thread_contexts[i].data = ctx->data;
+    thread_contexts[i].mode = mode;
+    thread_contexts[i].thread_total = thread_total;
+    thread_contexts[i].thread_num = i;
+    int retval = pthread_create(&workers[i], NULL, PosixDataDirInitMainWorker,
+                                &thread_contexts[i]);
+    assert(retval == 0);
+  }
+  for (unsigned i = 0; i < thread_total; i++) {
+    pthread_join(workers[i], NULL);
+  }
+  free(workers);
+  free(thread_contexts);
 }

--- a/cvmfs/shrinkwrap/posix/data_dir_mgmt.cc
+++ b/cvmfs/shrinkwrap/posix/data_dir_mgmt.cc
@@ -43,7 +43,7 @@ static std::string DirLevelName(unsigned i) {
 }
 
 static void PosixMkdir(const std::string &path, mode_t mode) {
-  int res = mkdir(path.c_str(), mode);
+  const int res = mkdir(path.c_str(), mode);
   assert(res == 0 || errno == EEXIST);
 }
 
@@ -106,7 +106,7 @@ void InitializeDataDirectory(struct fs_traversal_context *ctx) {
       *posix_ctx = reinterpret_cast<struct fs_traversal_posix_context *>(
           ctx->ctx);
   const mode_t mode = 0700;
-  bool res = MkdirDeep(ctx->data, mode);
+  const bool res = MkdirDeep(ctx->data, mode);
   assert(res);
   if (kDirLevels == 0)
     return;
@@ -135,7 +135,7 @@ void InitializeDataDirectory(struct fs_traversal_context *ctx) {
     thread_contexts[i].mode = mode;
     thread_contexts[i].thread_total = thread_total;
     thread_contexts[i].thread_num = i;
-    int retval = pthread_create(&workers[i], NULL, PosixDataDirInitMainWorker,
+    const int retval = pthread_create(&workers[i], NULL, PosixDataDirInitMainWorker,
                                 &thread_contexts[i]);
     assert(retval == 0);
   }

--- a/cvmfs/shrinkwrap/posix/data_dir_mgmt.h
+++ b/cvmfs/shrinkwrap/posix/data_dir_mgmt.h
@@ -19,7 +19,9 @@
 /**
  * Method which initializes the .data directory with all subdirectories.
  * Depending on kDirLevels and kDigitsPerDirLevel (defined in helpers.h)
- * this process might be very slow.
+ * this process might be very slow, which is why the top level directories
+ * (and their independent subtrees) are distributed over the
+ * fs_traversal_posix_context::num_threads worker threads.
  */
 void InitializeDataDirectory(struct fs_traversal_context *ctx);
 

--- a/test/unittests/shrinkwrap/t_fs_posix.cc
+++ b/test/unittests/shrinkwrap/t_fs_posix.cc
@@ -53,6 +53,27 @@ TEST_F(T_FsPosix, Init) {
 }
 
 
+TEST_F(T_FsPosix, InitParallel) {
+  // The .data directory structure is built by num_threads workers, each
+  // taking care of an independent set of top level directories.
+  interface_->finalize(interface_->context_);
+  interface_->context_ = interface_->initialize("InitParallel-2", "./",
+                                                "./.data-InitParallel", NULL,
+                                                8);
+  EXPECT_TRUE(DirectoryExists("./.data-InitParallel"));
+  EXPECT_TRUE(DirectoryExists("./.data-InitParallel/00/00"));
+  EXPECT_TRUE(DirectoryExists("./.data-InitParallel/7f/80"));
+  EXPECT_TRUE(DirectoryExists("./.data-InitParallel/ff/ff"));
+
+  // Re-initializing an already existing structure must be a no-op
+  interface_->finalize(interface_->context_);
+  interface_->context_ = interface_->initialize("InitParallel-3", "./",
+                                                "./.data-InitParallel", NULL,
+                                                8);
+  EXPECT_TRUE(DirectoryExists("./.data-InitParallel/ff/ff"));
+}
+
+
 TEST_F(T_FsPosix, ListDir) {
   ASSERT_TRUE(MkdirDeep("./ListDir/testdir", 0700));
   const bool ignore_failure = false;


### PR DESCRIPTION
InitializeDataDirectory() created the ~65k directories of the .data structure with a single thread before the export could start. On destinations with high per-syscall latency (e.g. NFS) this dominated the runtime of the tool.

Distribute the top level directories - and the independent subtrees rooted at them - over the already available num_threads workers, in the same way RunGarbageCollection() partitions the identical index space. Concurrent creation of the subtrees needs no synchronization, and mkdir() already tolerates EEXIST throughout.

While at it, replace the level loop of PosixCheckDirStructure() by plain recursion. The loop re-checked the same path after descending into the last directory of a level, which was redundant work.

Fixes #4331