### PR TITLE
server: do not abort on bundle dependency paths reaching PIPE_BUF

### DIFF
--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -8,7 +8,6 @@
 #include <limits.h>
 #include <pthread.h>
 
-#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <type_traits>

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -27,6 +27,7 @@ class BundleMgr : SingleCopy {
   friend class T_BundleMgr;
   FRIEND_TEST(T_BundleMgr, ExchangeCT);
   FRIEND_TEST(T_BundleMgr, ExchangePathString);
+  FRIEND_TEST(T_BundleMgr, ReceivePathLongerThanPipeBuf);
   FRIEND_TEST(T_BundleMgr, Fetch);
 
  public:
@@ -93,7 +94,6 @@ class BundleMgr : SingleCopy {
 
   std::string BlockingReceive(int fd) const {
     const size_t size = BlockingReceive<size_t>(fd);
-    assert(size * sizeof(char) < PIPE_BUF);
     std::string result(size, '\t');
     ReadPipe(fd, static_cast<void *>(&result[0]), size * sizeof(char));
     return result;

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <climits>
 #include <string>
 #include <vector>
 
@@ -206,6 +207,22 @@ TEST_F(T_BundleMgr, ExchangePathString) {
 
   bundle_mgr_->BlockingSend(wfd_, path);
   EXPECT_EQ(path, bundle_mgr_->ReceivePath(rfd_));
+}
+
+// A dependency path published in a repo's .cvmfsbundle spec can be longer
+// than PIPE_BUF (4096 on Linux, 512 on macOS) and the fetcher work queue must
+// carry it intact: in production it flows through BundleMgr::Fetch ->
+// TrySendPath -> worker ReceivePath. This exercises the receive side directly
+// over the fixture's blocking common_pipe_, mirroring ExchangePathString with
+// a payload beyond the PIPE_BUF boundary. The send side over the pool's own
+// O_NONBLOCK work-queue pipe still cannot deliver such payloads (WritePipe
+// asserts on a short or EAGAIN write); that path is not exercised here.
+TEST_F(T_BundleMgr, ReceivePathLongerThanPipeBuf) {
+  // 2 * PIPE_BUF still fits comfortably in the pipe's buffer, so the single
+  // write()/read() in WritePipe/ReadPipe transfers the whole payload.
+  const PathString long_path(std::string(2 * PIPE_BUF, 'a'));
+  bundle_mgr_->BlockingSend(wfd_, long_path);
+  EXPECT_EQ(long_path, bundle_mgr_->ReceivePath(rfd_));
 }
 
 TEST_F(T_BundleMgr, Fetch) {


### PR DESCRIPTION
This PR adds a failing test and fixes it by removing the assert. There is still a limit on the sender side (64KiB on Linux, less macOS) but I think that's unlikely to be a problem in practice.