### PR TITLE
Small bundle prefetching fixes

### DIFF
--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -18,6 +18,7 @@
 #include "cache.h"
 #include "catalog_mgr_client.h"
 #include "fetch.h"
+#include "file_chunk.h"
 #include "json_document.h"
 #include "mountpoint.h"
 #include "options.h"
@@ -235,6 +236,39 @@ void BundleMgr::FetchPath(const PathString &path) {
   }
   LogCvmfs(kLogCvmfs, kLogDebug, "BUNDLE-FETCH: prefetching %s",
            path.ToString().c_str());
+
+  if (dirent.IsChunkedFile()) {
+    // Files above the chunking threshold are stored as per-chunk objects;
+    // their bulk object only exists if the repository sets
+    // CVMFS_GENERATE_LEGACY_BULK_CHUNKS. Fetch the chunks, exactly like the
+    // read path does.
+    FileChunkList chunks;
+    if (!mount_point_->catalog_mgr()->ListFileChunks(
+            path, dirent.hash_algorithm(), &chunks)
+        || chunks.IsEmpty()) {
+      LogCvmfs(kLogCvmfs, kLogDebug, "BUNDLE-FETCH: no chunks found for %s",
+               path.ToString().c_str());
+      return;
+    }
+    for (unsigned i = 0; i < chunks.size(); ++i) {
+      CacheManager::Label label;
+      label.path = path.ToString();
+      label.size = chunks.AtPtr(i)->size();
+      label.zip_algorithm = dirent.compression_algorithm();
+      label.flags |= CacheManager::kLabelChunked;
+      if (mount_point_->catalog_mgr()->volatile_flag())
+        label.flags |= CacheManager::kLabelVolatile;
+      if (dirent.IsExternalFile()) {
+        label.flags |= CacheManager::kLabelExternal;
+        label.range_offset = chunks.AtPtr(i)->offset();
+      }
+      const int fd = this_fetcher->Fetch(
+          CacheManager::LabeledObject(chunks.AtPtr(i)->content_hash(), label));
+      if (fd >= 0)
+        mount_point_->file_system()->cache_mgr()->Close(fd);
+    }
+    return;
+  }
 
   CacheManager::Label label;
   label.path = path.ToString();

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -244,7 +244,10 @@ void BundleMgr::FetchPath(const PathString &path) {
     label.flags |= CacheManager::kLabelVolatile;
   if (dirent.IsExternalFile())
     label.flags |= CacheManager::kLabelExternal;
-  this_fetcher->Fetch(CacheManager::LabeledObject(dirent.checksum(), label));
+  const int fd = this_fetcher->Fetch(
+      CacheManager::LabeledObject(dirent.checksum(), label));
+  if (fd >= 0)
+    mount_point_->file_system()->cache_mgr()->Close(fd);
 }
 
 void *BundleMgr::MainBundleMgrFetcher(void *data) {

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -28,6 +28,7 @@ class BundleMgr : SingleCopy {
   FRIEND_TEST(T_BundleMgr, ExchangePathString);
   FRIEND_TEST(T_BundleMgr, ReceivePathLongerThanPipeBuf);
   FRIEND_TEST(T_BundleMgr, Fetch);
+  FRIEND_TEST(T_BundleMgr, FetchChunked);
 
  public:
   BundleMgr(MountPoint *mp, const PathString &path);

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -278,9 +278,9 @@ class AbstractCatalogManager : public SingleCopy {
   }
   bool ListingStat(const PathString &path, StatEntryList *listing);
 
-  bool ListFileChunks(const PathString &path,
-                      const shash::Algorithms interpret_hashes_as,
-                      FileChunkList *chunks);
+  virtual bool ListFileChunks(const PathString &path,
+                              const shash::Algorithms interpret_hashes_as,
+                              FileChunkList *chunks);
   void SetOwnerMaps(const OwnerMap &uid_map, const OwnerMap &gid_map);
   void SetCatalogWatermark(unsigned limit);
 

--- a/test/common/testutil.h
+++ b/test/common/testutil.h
@@ -466,6 +466,11 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
   bool ListingPath(const PathString &path,
                    catalog::DirectoryEntryList *listing,
                    const bool expand_symlink) const;
+  bool ListPathChunks(const PathString &path,
+                      const shash::Algorithms interpret_hashes_as,
+                      FileChunkList *chunks) const {
+    return false;
+  }
 
   bool GetVOMSAuthz(std::string *authz) { return false; }
 

--- a/test/src/709-cvmfsbundles/main
+++ b/test/src/709-cvmfsbundles/main
@@ -11,6 +11,9 @@ produce_dependency_files() {
   printf "This is dependency 1\n" > dep1.txt
   printf "This is dependency 2\n" > dep2.txt
   printf "This is a trigger\n" > trigger.txt
+  # Large enough to be split into several chunks with the tiny chunk sizes
+  # configured in server.conf (deterministic content, ~120 kB)
+  seq -f "chunked dependency line %06.0f" 1 4000 > dep3_chunked.txt
 
   # dep1 uses the canonical absolute-from-repository-root form, dep2 the
   # form relative to the directory holding the bundle file
@@ -19,7 +22,7 @@ produce_dependency_files() {
   "name": "CVMFS_BUNDLE",
   "version": "1.0.0",
   "encoding": "UTF-8",
-  "dependencies": ["/dep1.txt", "./dep2.txt"]
+  "dependencies": ["/dep1.txt", "./dep2.txt", "/dep3_chunked.txt"]
 }
 EOF
 
@@ -48,6 +51,14 @@ cvmfs_run_test() {
 
   echo "create a fresh repository named $CVMFS_TEST_REPO with user $CVMFS_TEST_USER"
   create_empty_repo $CVMFS_TEST_REPO $CVMFS_TEST_USER || return $?
+
+  echo "enable file chunking with tiny chunk sizes so dep3 gets split"
+  sudo tee -a /etc/cvmfs/repositories.d/$CVMFS_TEST_REPO/server.conf <<-EOF
+CVMFS_USE_FILE_CHUNKING=true
+CVMFS_MIN_CHUNK_SIZE=8192
+CVMFS_AVG_CHUNK_SIZE=16384
+CVMFS_MAX_CHUNK_SIZE=32768
+EOF
 
   echo "starting transaction to edit repository"
   start_transaction $CVMFS_TEST_REPO || return $?
@@ -88,6 +99,15 @@ cvmfs_run_test() {
       return 54
   fi
 
+  echo "make sure dep3 really got chunked (metadata lookup, no data fetch)"
+  local num_chunks=$(get_xattr chunks $mnt_point/dep3_chunked.txt)
+  echo "dep3_chunked.txt consists of ${num_chunks:-?} chunks"
+  if [ "x$num_chunks" = "x" ] || [ $num_chunks -le 1 ]; then
+      echo "dep3_chunked.txt is not chunked; the test would be vacuous"
+      desaster_cleanup $mnt_point $CVMFS_TEST_REPO
+      return 58
+  fi
+
   # core testing here
   echo "Opening trigger file"
   cat $mnt_point/trigger.txt
@@ -118,6 +138,28 @@ cvmfs_run_test() {
       desaster_cleanup $mnt_point $CVMFS_TEST_REPO
       return 57
   fi
+
+  # The chunk objects of dep3 cannot be located in the cache by the file's
+  # (bulk) hash xattr, so prove they were prefetched by cutting the network
+  # and reading the file: every chunk must be served from the local cache.
+  echo "cut the network and read the chunked dependency offline"
+  local talk_socket=$cache/cvmfs_io.$CVMFS_TEST_REPO
+  sudo cvmfs_talk -p $talk_socket proxy set "http://127.0.0.1:40403" \
+    || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 59; }
+  if ! timeout 60 cat $mnt_point/dep3_chunked.txt > $scratch_dir/dep3_offline.txt; then
+      echo "reading the chunked dependency offline failed: its chunks were not prefetched"
+      desaster_cleanup $mnt_point $CVMFS_TEST_REPO
+      return 60
+  fi
+  if ! cmp $scratch_dir/dep3_offline.txt $reference_dir/dep3_chunked.txt; then
+      echo "chunked dependency read offline does not match the reference copy"
+      desaster_cleanup $mnt_point $CVMFS_TEST_REPO
+      return 61
+  fi
+
+  echo "restore the network"
+  sudo cvmfs_talk -p $talk_socket proxy set DIRECT \
+    || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 62; }
 
   echo "check if the mounted repository contains exactly the same as the reference copy"
   compare_directories $mnt_point $reference_dir || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 11; }

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -4,20 +4,27 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <pthread.h>
 
+#include <algorithm>
 #include <atomic>
 #include <climits>
+#include <cstring>
 #include <string>
 #include <vector>
 
 #include "bundle_mgr.h"
 #include "catalog_mgr_client.h"
+#include "crypto/hash.h"
 #include "fetch.h"
 #include "file_bundle.h"
+#include "file_chunk.h"
 #include "json_document.h"
 #include "mountpoint.h"
 #include "options.h"
 #include "shortstring.h"
+#include "testutil.h"
+#include "util/mutex.h"
 #include "util/posix.h"
 
 class MockCatalogManager : public catalog::ClientCatalogManager {
@@ -32,6 +39,12 @@ class MockCatalogManager : public catalog::ClientCatalogManager {
                const catalog::LookupOptions options,
                catalog::DirectoryEntry *dirent),
               (override));
+  MOCK_METHOD(bool,
+              ListFileChunks,
+              (const PathString &path,
+               const shash::Algorithms interpret_hashes_as,
+               FileChunkList *chunks),
+              (override));
 };
 
 class MockFetcher : public cvmfs::Fetcher {
@@ -45,6 +58,10 @@ class MockFetcher : public cvmfs::Fetcher {
   int Fetch(const CacheManager::LabeledObject &object,
             const std::string &alt_url = "") override {
     ++counter_;
+    {
+      const MutexLockGuard guard(&fetched_mutex_);
+      fetched_hashes_.push_back(object.id);
+    }
     // Return an invalid file descriptor on purpose. The mock does not place
     // anything in the cache, so handing back a small fabricated fd (e.g. 1)
     // would make the production code perform a real Pread()/Close() on an
@@ -52,11 +69,23 @@ class MockFetcher : public cvmfs::Fetcher {
     return -1;
   }
   virtual ~MockFetcher() { delete statistics_; }
-  void Reset() { counter_ = 0; }
+  static void Reset() {
+    counter_ = 0;
+    const MutexLockGuard guard(&fetched_mutex_);
+    fetched_hashes_.clear();
+  }
+  static std::vector<shash::Any> FetchedHashes() {
+    const MutexLockGuard guard(&fetched_mutex_);
+    return fetched_hashes_;
+  }
 
   // Shared across all fetcher instances and incremented from several worker
   // threads concurrently, hence atomic.
   inline static std::atomic<size_t> counter_{0};
+  // Every hash requested through Fetch(), in arrival order. Written by the
+  // worker threads concurrently, hence the mutex.
+  inline static pthread_mutex_t fetched_mutex_ = PTHREAD_MUTEX_INITIALIZER;
+  inline static std::vector<shash::Any> fetched_hashes_;
   perf::Statistics *statistics_;
 };
 
@@ -115,7 +144,7 @@ class T_BundleMgr : public ::testing::Test {
     bundle_mgr_->SpawnFetcherPool();
     // Count only the dependency fetches triggered by Fetch(), not the single
     // probe the constructor performed while trying to load the bundle file.
-    MockFetcher::counter_ = 0;
+    MockFetcher::Reset();
     EXPECT_TRUE(bundle_mgr_);
     EXPECT_EQ(bundle_mgr_->bfm_, bfm_);
     MakePipe(common_pipe_);
@@ -232,5 +261,58 @@ TEST_F(T_BundleMgr, Fetch) {
   // is deterministic.
   bundle_mgr_->JoinFetcherPool();
   EXPECT_EQ(MockFetcher::counter_.load(), dependencies_.size());
+}
+
+namespace {
+shash::Any Sha1WithByte(const unsigned char byte) {
+  shash::Any result(shash::kSha1);
+  memset(result.digest, byte, shash::kDigestSizes[shash::kSha1]);
+  return result;
+}
+}  // namespace
+
+TEST_F(T_BundleMgr, FetchChunked) {
+  const shash::Any bulk_hash = Sha1WithByte(0xaa);
+  std::vector<shash::Any> chunk_hashes;
+  for (unsigned char i = 1; i <= 3; ++i) {
+    chunk_hashes.push_back(Sha1WithByte(i));
+  }
+
+  // Dependencies above the chunking threshold have no bulk object in the
+  // repository (unless CVMFS_GENERATE_LEGACY_BULK_CHUNKS is set); only the
+  // per-chunk objects exist.
+  const catalog::DirectoryEntry chunked_dirent =
+      catalog::DirectoryEntryTestFactory::ChunkedFile(bulk_hash);
+  ON_CALL(*mock_catalog_mgr_, LookupPath(testing::_, testing::_, testing::_))
+      .WillByDefault([chunked_dirent](const PathString &,
+                                      const catalog::LookupOptions,
+                                      catalog::DirectoryEntry *out) -> bool {
+        *out = chunked_dirent;
+        return true;
+      });
+  ON_CALL(*mock_catalog_mgr_,
+          ListFileChunks(testing::_, testing::_, testing::_))
+      .WillByDefault([chunk_hashes](const PathString &,
+                                    const shash::Algorithms,
+                                    FileChunkList *chunks) -> bool {
+        off_t offset = 0;
+        for (const shash::Any &hash : chunk_hashes) {
+          chunks->PushBack(FileChunk(hash, offset, 4096));
+          offset += 4096;
+        }
+        return true;
+      });
+
+  bundle_mgr_->Fetch();
+  bundle_mgr_->JoinFetcherPool();
+
+  const std::vector<shash::Any> fetched = MockFetcher::FetchedHashes();
+  EXPECT_EQ(0, std::count(fetched.begin(), fetched.end(), bulk_hash))
+      << "prefetcher requested the (nonexistent) bulk object";
+  const ptrdiff_t n_deps = static_cast<ptrdiff_t>(dependencies_.size());
+  for (const shash::Any &hash : chunk_hashes) {
+    EXPECT_EQ(n_deps, std::count(fetched.begin(), fetched.end(), hash));
+  }
+  EXPECT_EQ(dependencies_.size() * chunk_hashes.size(), fetched.size());
 }
 


### PR DESCRIPTION
Builds on #4351, only the last 3 commits are specific to this PR so I'll leave as draft until it is merged.

Two fixes for bundle prefetching:

- A file descriptor leak in `BundleMgr::FetchPath()`.

- `BundleMgr::FetchPath()` always requested the dirent's bulk hash, but files above the chunking threshold only have per-chunk objects, so the download failed silently. Chunked dependencies are now fetched chunk by chunk, like the read path.

The cvmfsbundles test now includes a chunked dependency, proven prefetched by reading it with the network cut.