### PR TITLE
shrinkwrap: Fix spec tree exclusion and support gitignore-style re-inclusion (2.14 cherry-pick)

### DIFF
--- a/cvmfs/shrinkwrap/spec_tree.cc
+++ b/cvmfs/shrinkwrap/spec_tree.cc
@@ -50,9 +50,11 @@ bool SpecTree::IsMatching(std::string path) {
   SpecTreeNode *cur_node = root_;
   bool is_wildcard = (cur_node->mode == '*');
   bool is_flat_cp = (cur_node->mode == '^');
+  bool is_excluded_by_wildcard = false;
   if (cur_node->mode == '!') {
     return false;
   }
+
   if (path.length() > 0 && path.at(path.length() - 1) == '/') {
     path.erase(path.length() - 1);
   }
@@ -61,8 +63,12 @@ bool SpecTree::IsMatching(std::string path) {
            path_parts.begin() + 1;
        part_it != path_parts.end();
        part_it++) {
+    const bool parent_excludes_children = cur_node->exclude_children;
     cur_node = cur_node->GetNode(*part_it);
     if (cur_node == NULL) {
+      if (is_excluded_by_wildcard || parent_excludes_children) {
+        return false;
+      }
       if (is_wildcard || (is_flat_cp && (part_it + 1) == path_parts.end())) {
         return true;
       }
@@ -72,6 +78,9 @@ bool SpecTree::IsMatching(std::string path) {
     if (cur_node->mode == '!') {
       return false;
     }
+    if (parent_excludes_children || is_excluded_by_wildcard) {
+      is_excluded_by_wildcard = (cur_node->mode == '-');
+    }
     if (cur_node->mode == '*') {
       is_wildcard = true;
     }
@@ -79,8 +88,9 @@ bool SpecTree::IsMatching(std::string path) {
       is_flat_cp = true;
     }
   }
-  return is_wildcard || is_flat_cp || cur_node->mode == '_'
-         || cur_node->mode == 0;
+  return !is_excluded_by_wildcard
+         && (is_wildcard || is_flat_cp || cur_node->mode == '_'
+             || cur_node->mode == 0 || cur_node->exclude_children);
 }
 
 void SpecTree::Parse(FILE *spec_file) {
@@ -116,6 +126,7 @@ void SpecTree::Parse(FILE *spec_file) {
 
     // FIND inclusion_mode (START)
     inclusion_mode = 0;
+    bool exclude_children = false;
     if (line.at(0) == '^' || line.at(0) == '!') {
       inclusion_mode = line.at(0);
       line.erase(0, 1);
@@ -125,6 +136,9 @@ void SpecTree::Parse(FILE *spec_file) {
     if (line.at(line.length() - 1) == '*') {
       if (inclusion_mode == 0) {
         inclusion_mode = '*';
+      } else if (inclusion_mode == '!' && line.length() >= 2
+                 && line.at(line.length() - 2) == '/') {
+        exclude_children = true;
       }
       line.erase(line.length() - 1);
     } else if (inclusion_mode == '^') {
@@ -146,7 +160,7 @@ void SpecTree::Parse(FILE *spec_file) {
       }
     }
     char passthrough_mode = '_';
-    if (inclusion_mode == '!')
+    if (inclusion_mode == '!' && !exclude_children)
       passthrough_mode = '-';
     // Split remaining path into its parts
     std::vector<std::string> path_parts = SplitString(line, '/');
@@ -171,19 +185,24 @@ void SpecTree::Parse(FILE *spec_file) {
       past_1_mode = past_2_mode;
       past_2_mode = passthrough_mode;
     }
-    cur_node->mode = inclusion_mode;
-    if (inclusion_mode != '!' && past_1_mode == '-') {
-      node_cache.pop();
-      while (!node_cache.empty() && node_cache.top()->node->mode == '-') {
-        node_cache.top()->node->mode = '_';
-        node_backup.push(node_cache.top());
+    if (exclude_children) {
+      cur_node->exclude_children = true;
+      cur_node->ExcludeChildren();
+    } else {
+      cur_node->mode = inclusion_mode;
+      if (inclusion_mode != '!' && past_1_mode == '-') {
         node_cache.pop();
+        while (!node_cache.empty() && node_cache.top()->node->mode == '-') {
+          node_cache.top()->node->mode = '_';
+          node_backup.push(node_cache.top());
+          node_cache.pop();
+        }
+        while (!node_backup.empty()) {
+          node_cache.push(node_backup.top());
+          node_cache.pop();
+        }
+        node_cache.push(entr);
       }
-      while (!node_backup.empty()) {
-        node_cache.push(node_backup.top());
-        node_cache.pop();
-      }
-      node_cache.push(entr);
     }
   }
   while (!node_cache.empty()) {
@@ -198,9 +217,11 @@ int SpecTree::ListDir(const char *dir, char ***buf, size_t *len) {
   SpecTreeNode *cur_node = root_;
   bool is_wildcard = (cur_node->mode == '*');
   bool is_flat_cp = (cur_node->mode == '^');
+  bool is_excluded_by_wildcard = false;
   if (cur_node->mode == '!') {
     return -1;
   }
+
   if (path.length() > 0 && path.at(path.length() - 1) == '/') {
     path.erase(path.length() - 1);
   }
@@ -209,10 +230,14 @@ int SpecTree::ListDir(const char *dir, char ***buf, size_t *len) {
            path_parts.begin() + 1;
        part_it != path_parts.end();
        part_it++) {
+    const bool parent_excludes_children = cur_node->exclude_children;
     cur_node = cur_node->GetNode(*part_it);
     if (cur_node == NULL) {
+      if (is_excluded_by_wildcard || parent_excludes_children) {
+        return -1;
+      }
       if (is_wildcard) {
-        break;
+        return SPEC_READ_FS;
       }
       return -1;
     }
@@ -220,12 +245,24 @@ int SpecTree::ListDir(const char *dir, char ***buf, size_t *len) {
     if (cur_node->mode == '!') {
       return -1;
     }
+    if (parent_excludes_children || is_excluded_by_wildcard) {
+      is_excluded_by_wildcard = (cur_node->mode == '-');
+    }
     if (cur_node->mode == '*') {
       is_wildcard = true;
     }
     if (cur_node->mode == '^') {
       is_flat_cp = true;
     }
+  }
+  if (cur_node->exclude_children || is_excluded_by_wildcard) {
+    const int result = cur_node->GetListing(path, buf, len);
+    if (*len == 0) {
+      cvmfs_list_free(*buf);
+      *buf = NULL;
+      return -1;
+    }
+    return result;
   }
   if (is_wildcard || is_flat_cp) {
     return SPEC_READ_FS;
@@ -242,6 +279,14 @@ SpecTreeNode *SpecTreeNode::GetNode(const std::string &name) {
 
 void SpecTreeNode::AddNode(const std::string &name, SpecTreeNode *node) {
   nodes_[name] = node;
+}
+
+void SpecTreeNode::ExcludeChildren() {
+  for (std::map<std::string, SpecTreeNode *>::iterator it = nodes_.begin();
+       it != nodes_.end();
+       it++) {
+    it->second->mode = '!';
+  }
 }
 
 int SpecTreeNode::GetListing(std::string base_path, char ***buf, size_t *len) {

--- a/cvmfs/shrinkwrap/spec_tree.h
+++ b/cvmfs/shrinkwrap/spec_tree.h
@@ -14,7 +14,8 @@ enum SPEC_READ_ST {
 
 class SpecTreeNode {
  public:
-  explicit SpecTreeNode(char modeParam) : mode(modeParam) { }
+  explicit SpecTreeNode(char modeParam)
+      : mode(modeParam), exclude_children(false) { }
   ~SpecTreeNode() {
     for (std::map<std::string, SpecTreeNode *>::iterator it = nodes_.begin();
          it != nodes_.end();
@@ -26,6 +27,7 @@ class SpecTreeNode {
   int GetListing(std::string base_path, char ***buf, size_t *len);
 
   void AddNode(const std::string &name, SpecTreeNode *node);
+  void ExcludeChildren();
 
   /**
    * 0: include this file
@@ -38,6 +40,12 @@ class SpecTreeNode {
    * !: Do not include this file
    */
   char mode;
+
+  // True for specifications that exclude all children of a path.
+  //
+  // The node itself remains traversable, but its children are excluded by
+  // default unless they are explicitly mentioned by a later rule.
+  bool exclude_children;
 
  private:
   std::map<std::string, SpecTreeNode *> nodes_;

--- a/test/unittests/shrinkwrap/t_spec_tree.cc
+++ b/test/unittests/shrinkwrap/t_spec_tree.cc
@@ -59,6 +59,65 @@ TEST_F(T_SpecTree, BasicMatchTest) {
 }
 
 
+TEST(T_SpecTreeStandalone, GitignoreStyleReinclude) {
+  const std::string spec_file = "./cvmfs-spec-tree-gitignore-test.spec.txt";
+  const std::string content = "/base*\n"
+                              "!/base/accel/amd/*\n"
+                              "/base/accel/amd/gfx90a\n"
+                              "!/base/accel/amd/gfx90a/excluded\n";
+  ASSERT_TRUE(SafeWriteToFile(content, spec_file, 0600));
+
+  SpecTree *specs = SpecTree::Create(spec_file);
+
+  EXPECT_TRUE(specs->IsMatching("/base/accel/amd"));
+  EXPECT_FALSE(specs->IsMatching("/base/accel/amd/gfx900"));
+  EXPECT_FALSE(specs->IsMatching("/base/accel/amd/gfx900/file"));
+  EXPECT_TRUE(specs->IsMatching("/base/accel/amd/gfx90a"));
+  EXPECT_TRUE(specs->IsMatching("/base/accel/amd/gfx90a/file"));
+  EXPECT_FALSE(specs->IsMatching("/base/accel/amd/gfx90a/excluded"));
+  EXPECT_FALSE(specs->IsMatching("/base/accel/amd/gfx90a/excluded/file"));
+
+  size_t listLen = 0;
+  char **dirList = NULL;
+  EXPECT_EQ(0, specs->ListDir("/base/accel/amd", &dirList, &listLen));
+  EXPECT_EQ(1U, listLen);
+  ExpectListHas("gfx90a", dirList);
+  FreeList(dirList, listLen);
+  dirList = NULL;
+  listLen = 0;
+
+  EXPECT_EQ(SPEC_READ_FS,
+            specs->ListDir("/base/accel/amd/gfx90a", &dirList, &listLen));
+  EXPECT_EQ(-1, specs->ListDir("/base/accel/amd/gfx900", &dirList, &listLen));
+
+  delete specs;
+  unlink(spec_file.c_str());
+}
+
+
+TEST(T_SpecTreeStandalone, ExcludeChildrenHonorsOrder) {
+  const std::string spec_file = "./cvmfs-spec-tree-order-test.spec.txt";
+  const std::string content = "/base*\n"
+                              "/base/accel/amd/gfx90a\n"
+                              "!/base/accel/amd/*\n";
+  ASSERT_TRUE(SafeWriteToFile(content, spec_file, 0600));
+
+  SpecTree *specs = SpecTree::Create(spec_file);
+
+  EXPECT_TRUE(specs->IsMatching("/base/accel/amd"));
+  EXPECT_FALSE(specs->IsMatching("/base/accel/amd/gfx90a"));
+  EXPECT_FALSE(specs->IsMatching("/base/accel/amd/gfx90a/file"));
+
+  size_t listLen = 0;
+  char **dirList = NULL;
+  EXPECT_EQ(-1, specs->ListDir("/base/accel/amd", &dirList, &listLen));
+  EXPECT_EQ(NULL, dirList);
+
+  delete specs;
+  unlink(spec_file.c_str());
+}
+
+
 TEST_F(T_SpecTree, CheckListings) {
   size_t listLen = 0;
   char **dirList = NULL;


### PR DESCRIPTION

The shrinkwrap spec tree mishandled `!/dir/*` exclusions: a single hit_exclusion flag and the final-node logic could neither exclude a directory's children while still traversing into it, nor honor a later rule re-including a specific child.

A per-node exclude_children flag now marks such a directory as traversable but excludes its children by default, so a subsequent `/dir/child` rule re-includes just that child, with the same last-rule-wins ordering as .gitignore. IsMatching() and ListDir() return early on a plain '!' node and consult the flag for unlisted paths.
