### PR TITLE
fix: merge nested catalogs by column name instead of position

### DIFF
--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -700,12 +700,25 @@ void WritableCatalog::CopyToParent() {
                                           "AS other;");
   retval = sql_attach.Execute();
   assert(retval);
-  retval = SqlCatalog(database(), "INSERT INTO other.catalog "
-                                  "SELECT * FROM main.catalog;")
+  // The two databases can have a different physical column order: fresh
+  // databases are created with mtimens between mtime and flags, while
+  // databases migrated from schema revision < 7 have mtimens appended at the
+  // end (ALTER TABLE can only append).  A positional "SELECT *" copy would
+  // silently shuffle the values into the wrong columns, so the columns have
+  // to be named explicitly.
+  const string catalog_columns =
+      "md5path_1, md5path_2, parent_1, parent_2, hardlinks, hash, size, "
+      "mode, mtime, mtimens, flags, name, symlink, uid, gid, xattr";
+  retval = SqlCatalog(database(),
+                      "INSERT INTO other.catalog (" + catalog_columns
+                          + ") SELECT " + catalog_columns
+                          + " FROM main.catalog;")
                .Execute();
   assert(retval);
-  retval = SqlCatalog(database(), "INSERT INTO other.chunks "
-                                  "SELECT * FROM main.chunks;")
+  const string chunks_columns = "md5path_1, md5path_2, offset, size, hash";
+  retval = SqlCatalog(database(),
+                      "INSERT INTO other.chunks (" + chunks_columns
+                          + ") SELECT " + chunks_columns + " FROM main.chunks;")
                .Execute();
   assert(retval);
   retval = SqlCatalog(database(), "DETACH other;").Execute();

--- a/test/unittests/t_catalog.cc
+++ b/test/unittests/t_catalog.cc
@@ -6,10 +6,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <set>
+
 #include "catalog.h"
 #include "catalog_rw.h"
 #include "compression/compression.h"
 #include "crypto/hash.h"
+#include "duplex_sqlite3.h"
 #include "shortstring.h"
 #include "testutil.h"
 #include "util/posix.h"
@@ -123,6 +126,37 @@ class T_Catalog : public ::testing::Test {
     delete catalog;
     delete nested;
     RemoveTree(sandbox);
+  }
+
+  /**
+   * Rebuilds the catalog table with the physical column order of a database
+   * that was migrated from schema revision < 7, where mtimens was appended
+   * at the end by ALTER TABLE instead of being created between mtime and
+   * flags.
+   */
+  void RebuildWithTrailingMtimens(const string &db_file) {
+    sqlite3 *db;
+    ASSERT_EQ(SQLITE_OK, sqlite3_open(db_file.c_str(), &db));
+    const char *sql =
+        "BEGIN; "
+        "CREATE TABLE catalog_legacy "
+        "(md5path_1 INTEGER, md5path_2 INTEGER, parent_1 INTEGER, "
+        "parent_2 INTEGER, hardlinks INTEGER, hash BLOB, size INTEGER, "
+        "mode INTEGER, mtime INTEGER, flags INTEGER, name TEXT, symlink TEXT, "
+        "uid INTEGER, gid INTEGER, xattr BLOB, mtimens INTEGER, "
+        "CONSTRAINT pk_catalog PRIMARY KEY (md5path_1, md5path_2)); "
+        "INSERT INTO catalog_legacy (md5path_1, md5path_2, parent_1, parent_2, "
+        "hardlinks, hash, size, mode, mtime, mtimens, flags, name, symlink, "
+        "uid, gid, xattr) "
+        "SELECT md5path_1, md5path_2, parent_1, parent_2, hardlinks, hash, "
+        "size, mode, mtime, mtimens, flags, name, symlink, uid, gid, xattr "
+        "FROM catalog; "
+        "DROP TABLE catalog; "
+        "ALTER TABLE catalog_legacy RENAME TO catalog; "
+        "CREATE INDEX idx_catalog_parent ON catalog (parent_1, parent_2); "
+        "COMMIT;";
+    ASSERT_EQ(SQLITE_OK, sqlite3_exec(db, sql, NULL, NULL, NULL));
+    ASSERT_EQ(SQLITE_OK, sqlite3_close(db));
   }
 
   Catalog *catalog;
@@ -578,6 +612,85 @@ TEST_F(T_Catalog, AttachSchema10) {
   shash::Any hash_compare = shash::MkFromHexPtr(
       shash::HexPtr("0000000000000000000000000000000000000042"));
   EXPECT_EQ(h, hash_compare);
+}
+
+TEST_F(T_Catalog, MergeIntoParentLegacyColumnOrder) {
+  // Merge a freshly created nested catalog into a parent whose catalog table
+  // has the physical column order of a repository migrated from schema
+  // revision < 7 (mtimens as last column).  The copy must map the columns by
+  // name; a positional copy shuffles every column after mtime.
+  const string root_db = CreateCatalogDB("");
+  RebuildWithTrailingMtimens(root_db);
+
+  WritableCatalog *root = WritableCatalog::AttachFreely(
+      "", root_db, shash::Any(shash::kSha1), NULL, false);
+  ASSERT_TRUE(root != NULL);
+  const XattrList no_xattrs;
+  root->AddEntry(
+      DirectoryEntryTestFactory::Directory("dir", 4096, shash::Any(), true),
+      no_xattrs, "/dir", "");
+
+  const string child_db = CreateCatalogDB("/dir");
+  WritableCatalog *child = WritableCatalog::AttachFreely(
+      "/dir", child_db, shash::Any(shash::kSha1), root, true);
+  ASSERT_TRUE(child != NULL);
+  AddEntry(child, "dir", "", S_IFDIR, "");
+  AddEntry(child, "file1", "/dir", S_IFREG,
+           "38be7d1b981f2fb6a4a0a052453f887373dc1fe8", "", true);
+  child->AddFileChunk("/dir/file1", FileChunk());
+  AddEntry(child, "subdir", "/dir", S_IFDIR, "");
+  AddEntry(child, "link1", "/dir", S_IFLNK, "", "/dir/file1");
+  child->Commit();
+
+  shash::Any child_hash = shash::Any(shash::kSha1);
+  ASSERT_TRUE(shash::HashFile(child_db, &child_hash));
+  root->InsertNestedCatalog("/dir", NULL, child_hash, GetFileSize(child_db));
+
+  child->MergeIntoParent();
+  root->Commit();
+  delete child;
+  delete root;
+
+  catalog = catalog::Catalog::AttachFreely("", root_db, shash::Any(), NULL,
+                                           false);
+  ASSERT_TRUE(catalog != NULL);
+
+  DirectoryEntry entry;
+  ASSERT_TRUE(catalog->LookupPath(PathString("/dir"), &entry));
+  EXPECT_TRUE(entry.IsDirectory());
+  EXPECT_FALSE(entry.IsNestedCatalogMountpoint());
+
+  DirectoryEntryList listing;
+  ASSERT_TRUE(catalog->ListingPath(PathString("/dir"), &listing));
+  ASSERT_EQ(3u, listing.size());
+  set<string> listing_names;
+  for (unsigned i = 0; i < listing.size(); ++i)
+    listing_names.insert(listing.at(i).name().ToString());
+  EXPECT_EQ(1u, listing_names.count("file1"));
+  EXPECT_EQ(1u, listing_names.count("link1"));
+  EXPECT_EQ(1u, listing_names.count("subdir"));
+
+  ASSERT_TRUE(catalog->LookupPath(PathString("/dir/file1"), &entry));
+  EXPECT_EQ("file1", entry.name().ToString());
+  EXPECT_TRUE(entry.IsRegular());
+  EXPECT_TRUE(entry.IsChunkedFile());
+  EXPECT_EQ(shash::MkFromHexPtr(
+                shash::HexPtr("38be7d1b981f2fb6a4a0a052453f887373dc1fe8")),
+            entry.checksum());
+
+  ASSERT_TRUE(catalog->LookupPath(PathString("/dir/subdir"), &entry));
+  EXPECT_EQ("subdir", entry.name().ToString());
+  EXPECT_TRUE(entry.IsDirectory());
+
+  ASSERT_TRUE(catalog->LookupPath(PathString("/dir/link1"), &entry));
+  EXPECT_EQ("link1", entry.name().ToString());
+  EXPECT_TRUE(entry.IsLink());
+  EXPECT_EQ("/dir/file1", entry.symlink().ToString());
+
+  FileChunkList chunk_list;
+  EXPECT_TRUE(catalog->ListPathChunks(PathString("/dir/file1"), shash::kSha1,
+                                      &chunk_list));
+  EXPECT_EQ(1u, chunk_list.size());
 }
 
 }  // namespace catalog


### PR DESCRIPTION
🤖 Below is written by an LLM but I think summarises what I found well enough:

Observed on a gateway setup with CernVM-FS 2.13.3 while removing a nested catalog from `lhcbdev.cern.ch` (a repository old enough that its catalog databases predate schema revision 7; the nested catalog had been created recently, i.e. with the fresh layout):

```
$ cvmfs_server transaction lhcbdev.cern.ch/testfiledb-mirror
$ rm /cvmfs/lhcbdev.cern.ch/testfiledb-mirror/.cvmfscatalog
$ cvmfs_server publish lhcbdev.cern.ch
...
Lease end request - error reply: {"reason":"worker 'commit' call failed: possible that the receiver crashed: EOF","status":"error"}
SessionContext: could not commit session. Aborting.
```

The publisher-side `cvmfs_swissknife sync` runs `MergeIntoParent()` to dissolve the nested catalog, producing a corrupted root catalog (767 shifted rows) that it uploads to the backend. During commit, the receiver diffs old vs. new revision: the old listing of the directory has the real entry names, the corrupted new listing has eight directories all named `"1"`. The diff reports them as additions; the second `AddDirectory("/testfiledb-mirror/1")` inserts a duplicate md5 path hash, the SQLite UNIQUE constraint fails, and the `assert(retval)` in `WritableCatalog::AddEntry()` aborts the receiver. The crash is 100% reproducible on every retry.

Note that the receiver crash is what *prevented* the corruption from being published: on a non-gateway repository the same merge runs in `cvmfs_swissknife sync` and the corrupted catalog would be published silently.

## Receiver stack trace

From `/tmp/cvmfs_receiver/stacktrace.*` (2.13.3, paths shortened):

```
Signal: 6 (SIGABRT)
#4  __pthread_kill_implementation
#5  raise
#6  abort
#7  __assert_fail_base.cold
#8  __assert_fail
#9  catalog::WritableCatalog::AddEntry (entry=..., xattrs=...,
        entry_path="/testfiledb-mirror/1", parent_path="/testfiledb-mirror")
        at cvmfs/catalog_rw.cc:166
#10 catalog::WritableCatalogManager::AddDirectory (parent_directory="testfiledb-mirror")
        at cvmfs/catalog_mgr_rw.cc:479
#11 receiver::CatalogMergeTool<WritableCatalogManager, SimpleCatalogManager>::ReportAddition
#12 CatalogDiffTool<catalog::SimpleCatalogManager>::DiffRec at cvmfs/catalog_diff_tool_impl.h:182
#13 CatalogDiffTool<catalog::SimpleCatalogManager>::DiffRec at cvmfs/catalog_diff_tool_impl.h:232
#14 CatalogDiffTool<catalog::SimpleCatalogManager>::Run at cvmfs/catalog_diff_tool_impl.h:88
#15 receiver::CatalogMergeTool<...>::Run at cvmfs/receiver/catalog_merge_tool_impl.h:81
#16 receiver::CommitProcessor::Process (lease_path="lhcbdev.cern.ch/testfiledb-mirror", ...)
        at cvmfs/receiver/commit_processor.cc:201
#17 receiver::Reactor::HandleCommit at cvmfs/receiver/reactor.cc:438
#18 receiver::Reactor::HandleRequest at cvmfs/receiver/reactor.cc:508
#19 receiver::Reactor::Run at cvmfs/receiver/reactor.cc:186
#20 main
```

The corruption is directly visible in the uploaded root catalog — the children of the merged directory, where `name` holds the former `flags` value and `flags` received the (empty) `mtimens`:

```
sqlite> SELECT name, flags, size, mode FROM catalog WHERE parent_1 = ... ;
1|<NULL>|20|16877          -- a directory (kFlagDir = 1)
1|<NULL>|53|16877
...
4|<NULL>|122736|33188      -- a regular file (kFlagFile = 4)
68|<NULL>|634618908|33188  -- a chunked file (kFlagFile | kFlagFileChunk = 68)
```