### PR TITLE
feat: prefetch file bundles asynchronously and support libcvmfs  (2.14 cherry-pick)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           cd test/common/container
           docker compose up --build -d cvmfs-dev
 
+      - name: Install integration test dependencies
+        run: |
+          docker exec -u sftnight -t cvmfs-dev bash -c \
+            "cd /home/sftnight/cvmfs && ./ci/build_install_builddeps.sh --test-deps"
+
       - name: Setup CVMFS
         run: |
           docker exec -u sftnight -t cvmfs-dev bash -c \

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -66,6 +66,9 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get install -y /home/runner/.cache/cvmfs-build-deps_*_all.deb
+      - name: Install integration test dependencies
+        run: |
+          ./ci/build_install_builddeps.sh --test-deps
       - name: Hash Externals
         id: get-externals-hash
         run: |

--- a/ci/build_install_builddeps.sh
+++ b/ci/build_install_builddeps.sh
@@ -8,10 +8,11 @@ set -euo pipefail
 # Options:
 #   -l, --list       List build and runtime dependencies instead of installing
 #   -i, --install    Install build dependencies (default)
+#   --test-deps      Install dependencies needed by integration tests
 #   -h, --help       Show this help
 # Examples:
 #   ci/build_install_builddeps.sh --list
-#   ci/build_install_builddeps.sh --install /path/to/cvmfs
+#   ci/build_install_builddeps.sh --test-deps
 
 ########################
 # Utilities
@@ -94,8 +95,9 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -l|--list) MODE="list"; shift;;
     -i|--install) MODE="install"; shift;;
+    --test-deps) MODE="test-deps"; shift;;
     -h|--help)
-      sed -n '1,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+      sed -n '5,15p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
     --) shift; break;;
     -*) die "Unknown option: $1";;
     *) REPO_ARG="$1"; shift;;
@@ -116,7 +118,7 @@ SUDO=""
 if check_available sudo; then
   SUDO="sudo"
 else
-  if [[ "${MODE}" = "install" ]] && [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  if [[ "${MODE}" != "list" ]] && [[ ${EUID:-$(id -u)} -ne 0 ]]; then
     die "sudo not found and not running as root; cannot install packages"
   fi
 fi
@@ -255,6 +257,20 @@ install_deps_suse() {
   $SUDO zypper -n install $pkgs
 }
 
+install_test_deps() {
+  log "Installing integration test dependencies"
+  case "$OS_FAMILY" in
+    deb)
+      export DEBIAN_FRONTEND=noninteractive
+      $SUDO apt-get -y update
+      $SUDO apt-get -y install g++
+      ;;
+    rhel) $SUDO dnf -y install gcc-c++;;
+    suse) $SUDO zypper -n install gcc-c++;;
+    *) die "Unsupported OS family for test dependencies: $OS_FAMILY";;
+  esac
+}
+
 ########################
 # Main
 ########################
@@ -283,6 +299,10 @@ case "$MODE" in
     log "Build dependencies installed successfully"
     bootstrap_cmake_if_needed
     bootstrap_golang_if_needed
+    ;;
+  test-deps)
+    install_test_deps
+    log "Integration test dependencies installed successfully"
     ;;
   *) die "Unknown mode: $MODE";;
 esac

--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -44,6 +44,7 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS)
        authz/authz_fetch.cc
        authz/authz_session.cc
        backoff.cc
+       bundle_mgr.cc
        cache.cc
        cache.pb.cc cache.pb.h
        cache_extern.cc
@@ -94,6 +95,7 @@ if (BUILD_CVMFS OR BUILD_LIBCVMFS)
        resolv_conf_event_handler.cc
        ring_buffer.cc
        sanitizer.cc
+       shortstring.cc
        sql.cc
        sqlitemem.cc
        sqlitevfs.cc
@@ -239,7 +241,6 @@ if (BUILD_CVMFS)
   set (CVMFS_FUSE_SOURCES
        ${CVMFS_COMMON_CLIENT_SOURCES}
        auto_umount.cc
-       bundle_mgr.cc
        compat.cc
        cvmfs.cc
        fuse_evict.cc
@@ -251,7 +252,6 @@ if (BUILD_CVMFS)
        notify/subscriber_supervisor.cc
        notify/subscriber_sse.cc
        quota_listener.cc
-       shortstring.cc
        supervisor.cc
        talk.cc
        url.cc

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
@@ -94,28 +95,12 @@ BundleFileMgr *LoadBundleFromCvmfs(MountPoint *mp,
 }
 }  // namespace
 
-BundleMgr::BundleMgr(MountPoint *mp, const PathString &path)
+BundleMgr::BundleMgr(MountPoint *mp)
     : mount_point_(mp)
-    , path_(path)
     , fetcher_threads_()
     , pool_size_(kDefaultBundlePoolSize) {
-  fname_ = GetFileName(path_);
-  parent_path_ = GetParentPath(path_);
-  // There is a naming convention regarding the name of the file with the
-  // contents of the bundle
-  bundle_file_path_ = PathString(parent_path_.ToString() + "/.cvmfsbundle-"
-                                 + fname_.ToString());
-
-  pipe_bm_[0] = pipe_bm_[1] = -1;
+  atomic_init32(&terminating_);
   pthread_mutex_init(&worker_read_mutex_, nullptr);
-
-  bfm_ = LoadBundleFromCvmfs(mount_point_, bundle_file_path_);
-  if (bfm_ == nullptr) {
-    LogCvmfs(kLogCvmfs, kLogDebug, "BundleMgr: failed to load bundle file %s",
-             bundle_file_path_.ToString().c_str());
-    is_valid_ = false;
-    return;
-  }
 
   // Pool size override via CVMFS_BUNDLE_POOL_SIZE
   if (mount_point_ != nullptr && mount_point_->file_system() != nullptr
@@ -131,24 +116,43 @@ BundleMgr::BundleMgr(MountPoint *mp, const PathString &path)
     }
   }
 
-  SpawnFetcherPool();
+  // The queues are created here so that ScheduleTrigger() can already
+  // enqueue before Spawn(); pipe file descriptors, unlike threads, survive
+  // the fuse client's daemonization fork.
+  MakePipe(pipe_bm_);
+  MakePipe(pipe_triggers_);
+
+  // Non-blocking writes so TrySendPath/ScheduleTrigger can drop when a
+  // queue is full. Per pipe(7), writes <= PIPE_BUF are atomic on
+  // non-blocking pipes: they either fully succeed or fail with EAGAIN.
+  int flags = fcntl(pipe_bm_[1], F_GETFL);
+  fcntl(pipe_bm_[1], F_SETFL, flags | O_NONBLOCK);
+  flags = fcntl(pipe_triggers_[1], F_GETFL);
+  fcntl(pipe_triggers_[1], F_SETFL, flags | O_NONBLOCK);
 }
 
-void BundleMgr::Fetch() {
+void BundleMgr::Spawn() {
+  SpawnFetcherPool();
+  if (is_valid_)
+    SpawnDispatcher();
+}
+
+bool BundleMgr::ScheduleTrigger(const PathString &path) {
   if (not is_valid_) {
     LogCvmfs(kLogBundleMgr,
              kLogDebug,
-             "BundleMgr is not in a valid state. Can't fetch!");
-    return;
+             "BundleMgr is not in a valid state. Can't schedule trigger!");
+    return false;
   }
-
-  while (auto file = bfm_->GetNext()) {
-    const PathString path = NormalizeDependencyPath(file);
-    // A TrySendPath() here is used as a profylaxis to a scenario where the pipe
-    // is currently blocked.
-    while (not TrySendPath(back_channel_, path)) {
-    }
+  // A single non-blocking attempt: prefetching is best-effort, so if the
+  // trigger queue is full the request is dropped instead of stalling the
+  // caller (an open() holding the remount fence).
+  if (not TrySendPath(pipe_triggers_[1], path)) {
+    LogCvmfs(kLogBundleMgr, kLogDebug, "trigger queue full, dropping %s",
+             path.ToString().c_str());
+    return false;
   }
+  return true;
 }
 
 /**
@@ -156,13 +160,14 @@ void BundleMgr::Fetch() {
  * Entries without a leading slash (optionally prefixed with "./") are
  * resolved relative to the directory holding the bundle file.
  */
-PathString BundleMgr::NormalizeDependencyPath(const PathString &path) const {
+PathString BundleMgr::NormalizeDependencyPath(const PathString &path,
+                                              const PathString &parent_path) {
   if (path.StartsWith(PathString("/", 1)))
     return path;
   const PathString relative = path.StartsWith(PathString("./", 2))
                                   ? path.Suffix(2)
                                   : path;
-  PathString normalized(parent_path_);
+  PathString normalized(parent_path);
   normalized.Append("/", 1);
   normalized.Append(relative.GetChars(), relative.GetLength());
   return normalized;
@@ -197,15 +202,6 @@ void BundleMgr::JoinFetcherPool() {
 }
 
 void BundleMgr::SpawnFetcherPool() {
-  MakePipe(pipe_bm_);
-  back_channel_ = pipe_bm_[1];
-
-  // Non-blocking writes on the work-queue pipe so TrySendPath can poll.
-  // Per pipe(7), writes <= PIPE_BUF are atomic on non-blocking pipes:
-  // they either fully succeed or fail with EAGAIN.
-  const int flags = fcntl(back_channel_, F_GETFL);
-  fcntl(back_channel_, F_SETFL, flags | O_NONBLOCK);
-
   for (size_t i = 0; i < pool_size_; ++i) {
     std::unique_ptr<pthread_t> thread(new pthread_t());
     const int res = pthread_create(thread.get(), nullptr, MainBundleMgrFetcher,
@@ -218,6 +214,73 @@ void BundleMgr::SpawnFetcherPool() {
       return;
     }
     fetcher_threads_.emplace_back(std::move(thread));
+  }
+}
+
+void BundleMgr::SpawnDispatcher() {
+  dispatcher_thread_.reset(new pthread_t());
+  const int res = pthread_create(dispatcher_thread_.get(), nullptr,
+                                 MainBundleMgrDispatcher, this);
+  if (res != 0) {
+    LogCvmfs(kLogBundleMgr, kLogDebug, "Dispatcher thread creation failed!");
+    dispatcher_thread_.reset();
+    is_valid_ = false;
+  }
+}
+
+void BundleMgr::JoinDispatcher() {
+  if (pipe_triggers_[1] < 0)
+    return;
+  // The dispatcher only exists once Spawn() has run; without it there is
+  // just the pipe to close.
+  if (dispatcher_thread_) {
+    Command cmd = Command::kTerminate;
+    while (true) {
+      const ssize_t n = ::write(pipe_triggers_[1], &cmd, sizeof(Command));
+      if (n == sizeof(Command))
+        break;
+      if (errno != EAGAIN && errno != EWOULDBLOCK)
+        break;
+    }
+    pthread_join(*dispatcher_thread_, nullptr);
+    dispatcher_thread_.reset();
+  }
+  ClosePipe(pipe_triggers_);
+  pipe_triggers_[0] = pipe_triggers_[1] = -1;
+}
+
+/**
+ * Loads the bundle spec that belongs to the given trigger file and enqueues
+ * its dependencies for the fetcher pool. Runs on the dispatcher thread.
+ */
+void BundleMgr::ProcessTrigger(const PathString &trigger_path) {
+  const NameString fname = GetFileName(trigger_path);
+  const PathString parent_path = GetParentPath(trigger_path);
+  // There is a naming convention regarding the name of the file with the
+  // contents of the bundle
+  const PathString bundle_file_path(parent_path.ToString() + "/.cvmfsbundle-"
+                                    + fname.ToString());
+
+  const std::unique_ptr<BundleFileMgr> bfm(
+      LoadBundleFromCvmfs(mount_point_, bundle_file_path));
+  if (bfm == nullptr) {
+    LogCvmfs(kLogCvmfs, kLogDebug, "Couldn't fetch bundle associated to %s",
+             trigger_path.ToString().c_str());
+    return;
+  }
+  EnqueueDependencies(bfm.get(), parent_path);
+}
+
+void BundleMgr::EnqueueDependencies(BundleFileMgr *bfm,
+                                    const PathString &parent_path) {
+  while (auto file = bfm->GetNext()) {
+    const PathString path = NormalizeDependencyPath(file, parent_path);
+    // A single non-blocking attempt: if the dependency queue is full the
+    // entry is dropped (prefetching is best-effort) instead of spinning.
+    if (not TrySendPath(pipe_bm_[1], path)) {
+      LogCvmfs(kLogBundleMgr, kLogDebug, "dependency queue full, dropping %s",
+               path.ToString().c_str());
+    }
   }
 }
 
@@ -284,6 +347,31 @@ void BundleMgr::FetchPath(const PathString &path) {
     mount_point_->file_system()->cache_mgr()->Close(fd);
 }
 
+void *BundleMgr::MainBundleMgrDispatcher(void *data) {
+#ifndef __APPLE__
+  pthread_setname_np(pthread_self(), "bm_dispatch");
+#endif
+  BundleMgr *mgr = static_cast<BundleMgr *>(data);
+  const int rfd = mgr->pipe_triggers_[0];
+
+  // Single reader on this pipe, so no receive mutex is needed here
+  while (true) {
+    Command cmd = Command::kTerminate;
+    const ssize_t n = read(rfd, &cmd, sizeof(Command));
+    if (n != static_cast<ssize_t>(sizeof(Command)))
+      break;
+    if (cmd != Command::kFetch)
+      break;
+    const PathString path = mgr->ReceivePath(rfd);
+    // While terminating, drain the queue without processing so that
+    // unmounting does not wait for spec downloads
+    if (atomic_read32(&mgr->terminating_) == 0)
+      mgr->ProcessTrigger(path);
+  }
+
+  pthread_exit(nullptr);
+}
+
 void *BundleMgr::MainBundleMgrFetcher(void *data) {
 #ifndef __APPLE__
   pthread_setname_np(pthread_self(), "bm_fetcher");
@@ -320,7 +408,10 @@ void *BundleMgr::MainBundleMgrFetcher(void *data) {
           terminate = true;
           break;
         }
-        mgr->FetchPath(path);
+        // While terminating, drain the queue without fetching so that
+        // unmounting does not wait for pending downloads
+        if (atomic_read32(&mgr->terminating_) == 0)
+          mgr->FetchPath(path);
       } break;
       case Command::kTerminate:
       default:
@@ -342,17 +433,32 @@ PathString BundleMgr::ReceivePath(int fd) const {
 }
 
 bool BundleMgr::TrySendPath(int fd, const PathString &path) const {
-  Command cmd = Command::kFetch;
-  if ((write(fd, &cmd, sizeof(Command))) != sizeof(Command)) {
-    if (not(errno == EAGAIN || errno == EWOULDBLOCK)) {
-      LogCvmfs(kLogBundleMgr,
-               kLogDebug,
-               "write() on back channel failed unexpectedly");
-    }
+  // The whole message (command + length + payload) is sent as a single
+  // write: per pipe(7), writes <= PIPE_BUF to a non-blocking pipe are
+  // atomic, they either fully succeed or fail with EAGAIN. Sending the
+  // parts separately could hit a full queue in the middle of a message
+  // and corrupt the stream for all readers.
+  const Command cmd = Command::kFetch;
+  const size_t length = path.GetLength();
+  const size_t msg_size = sizeof(cmd) + sizeof(length) + length;
+  if (msg_size > PIPE_BUF) {
+    LogCvmfs(kLogBundleMgr, kLogDebug,
+             "path too long for the work queue, dropping %s",
+             path.ToString().c_str());
     return false;
-  } else {
-    BlockingSend(fd, path);
   }
-  return true;
-}
+  char msg[PIPE_BUF];
+  memcpy(msg, &cmd, sizeof(cmd));
+  memcpy(msg + sizeof(cmd), &length, sizeof(length));
+  memcpy(msg + sizeof(cmd) + sizeof(length), path.GetChars(), length);
 
+  const ssize_t n = write(fd, msg, msg_size);
+  if (n == static_cast<ssize_t>(msg_size))
+    return true;
+  if ((n < 0) && not(errno == EAGAIN || errno == EWOULDBLOCK)) {
+    LogCvmfs(kLogBundleMgr, kLogDebug,
+             "write() on the work queue failed unexpectedly (errno=%d)",
+             errno);
+  }
+  return false;
+}

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -17,36 +17,73 @@
 #include "file_bundle.h"
 #include "mountpoint.h"
 #include "shortstring.h"
+#include "util/atomic.h"
 #include "util/posix.h"
 #include "util/single_copy.h"
 
 class MockFetcher;
 
+/**
+ * Long-lived, best-effort prefetcher for file bundles. One instance per
+ * mount point (created when CVMFS_PREFETCH_FILEBUNDLES is on) owns a
+ * dispatcher thread and a pool of fetcher threads for the lifetime of the
+ * mount. open() calls of a bundle trigger merely enqueue the trigger path
+ * via ScheduleTrigger() and return; spec loading and dependency downloads
+ * happen entirely on the background threads.
+ *
+ * The constructor only sets up the bounded queues; the threads are started
+ * by Spawn(). The fuse client daemonizes between initialization and
+ * cvmfs::Spawn(), and threads do not survive the fork, so Spawn() must not
+ * be called before then. libcvmfs never forks and calls Spawn() right after
+ * creating the mount point.
+ */
 class BundleMgr : SingleCopy {
   friend class T_BundleMgr;
   FRIEND_TEST(T_BundleMgr, ExchangeCT);
   FRIEND_TEST(T_BundleMgr, ExchangePathString);
   FRIEND_TEST(T_BundleMgr, ReceivePathLongerThanPipeBuf);
-  FRIEND_TEST(T_BundleMgr, Fetch);
+  FRIEND_TEST(T_BundleMgr, EnqueueDependencies);
   FRIEND_TEST(T_BundleMgr, FetchChunked);
+  FRIEND_TEST(T_BundleMgr, ScheduleTrigger);
+  FRIEND_TEST(T_BundleMgr, ScheduleTriggerBeforeSpawn);
+  FRIEND_TEST(T_BundleMgr, TrySendPathDropsWhenFull);
 
  public:
-  BundleMgr(MountPoint *mp, const PathString &path);
+  explicit BundleMgr(MountPoint *mp);
   virtual ~BundleMgr() {
+    atomic_write32(&terminating_, 1);
+    JoinDispatcher();
     JoinFetcherPool();
     pthread_mutex_destroy(&worker_read_mutex_);
-    delete bfm_;
   }
-  void Fetch();
+
+  /**
+   * Starts the dispatcher thread and the fetcher pool. Triggers scheduled
+   * before Spawn() wait in the queue until the threads come up.
+   */
+  void Spawn();
+
+  /**
+   * Hands a trigger file over to the background prefetcher. Never blocks:
+   * if the trigger queue is full the request is dropped (prefetching is
+   * best-effort). Returns whether the trigger was enqueued.
+   */
+  bool ScheduleTrigger(const PathString &path);
   explicit operator bool() const { return is_valid_; }
 
  private:
   static void *MainBundleMgrFetcher(void *data);
+  static void *MainBundleMgrDispatcher(void *data);
   void SpawnFetcherPool();
   void JoinFetcherPool();
+  void SpawnDispatcher();
+  void JoinDispatcher();
+  void ProcessTrigger(const PathString &trigger_path);
+  void EnqueueDependencies(BundleFileMgr *bfm, const PathString &parent_path);
   PathString ReceivePath(int fd) const;
   bool TrySendPath(int fd, const PathString &path) const;
-  PathString NormalizeDependencyPath(const PathString &path) const;
+  static PathString NormalizeDependencyPath(const PathString &path,
+                                            const PathString &parent_path);
 
   void FetchPath(const PathString &path);
 
@@ -101,21 +138,14 @@ class BundleMgr : SingleCopy {
   }
 
   MountPoint *mount_point_;
-  PathString path_;
-  NameString fname_;
-  PathString parent_path_;
-
-  // The file that contains the dependences
-  PathString bundle_file_path_;
-  BundleFileMgr *bfm_;
 
   // Pool of fetcher threads. All workers share pipe_bm_[0] (read end)
   // and serialize their reads via worker_read_mutex_ so cmd+payload
   // pairs are received atomically.
   std::vector<std::unique_ptr<pthread_t> > fetcher_threads_;
+  std::unique_ptr<pthread_t> dispatcher_thread_;
   pthread_mutex_t worker_read_mutex_;
   size_t pool_size_;
-  int back_channel_;
 
   enum class Command {
     kTerminate,
@@ -123,11 +153,22 @@ class BundleMgr : SingleCopy {
   };
 
   /**
-   * Work queue (a pipe). Main thread writes Command + path payload to
-   * pipe_bm_[1]; workers read from pipe_bm_[0] under worker_read_mutex_.
+   * Dependency work queue (a pipe with a non-blocking write end). The
+   * dispatcher writes Command + path payload to pipe_bm_[1]; workers read
+   * from pipe_bm_[0] under worker_read_mutex_.
    */
   int pipe_bm_[2];
+  /**
+   * Trigger queue (a pipe with a non-blocking write end). ScheduleTrigger()
+   * writes Command + path payload to pipe_triggers_[1]; the dispatcher
+   * reads from pipe_triggers_[0].
+   */
+  int pipe_triggers_[2];
+  /**
+   * Set on destruction: queued work is drained but no longer processed, so
+   * that unmounting does not wait for pending downloads.
+   */
+  atomic_int32 terminating_;
   bool is_valid_ = true;
 };
 #endif  // CVMFS_BUNDLE_MGR_H_
-

--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -181,10 +181,6 @@ const int kNumReservedFd = 512;
  * Warn if the process has a lower limit for the number of open file descriptors
  */
 const unsigned int kMinOpenFiles = 8192;
-/**
- * Indicates if file bundle prefetching is enabled.
- */
-bool prefetch_file_bundles_= false;
 
 
 class FuseInterruptCue : public InterruptCue {
@@ -1223,18 +1219,11 @@ static void cvmfs_open(fuse_req_t req, fuse_ino_t ino,
 
   perf::Inc(file_system_->n_fs_open());  // Count actual open / fetch operations
 
-  if (dirent.IsBundleTrigger() and prefetch_file_bundles_) {
-    // fetch dependences if not there already
-    PathString trigger_path;
-    assert(GetPathForInode(ino, &trigger_path)
-           && "Unable to retrieve the path of the trigger file");
-    BundleMgr bundle_mgr(mount_point_, trigger_path);
-    if (bundle_mgr) {
-      bundle_mgr.Fetch();
-    } else {
-      LogCvmfs(kLogCvmfs, kLogDebug,
-               "Couldn't fetch bundle associated to file %s", path.c_str());
-    }
+  if (dirent.IsBundleTrigger() and (mount_point_->bundle_mgr() != nullptr)) {
+    // Hand the trigger over to the long-lived prefetcher; spec loading and
+    // dependency downloads happen on its background threads, so the open()
+    // does not wait for them (and does not hold the remount fence hostage).
+    mount_point_->bundle_mgr()->ScheduleTrigger(path);
   }
 
   glue::PageCacheTracker::OpenDirectives open_directives;
@@ -2485,16 +2474,6 @@ static int Init(const loader::LoaderExports *loader_exports) {
   crypto::SetupLibcryptoMt();
 
   InitOptionsMgr(loader_exports);
-  if (cvmfs::options_mgr_) {
-    std::string is_prefetching_enabled;
-    cvmfs::options_mgr_->GetValue("CVMFS_PREFETCH_FILEBUNDLES",
-                                  &is_prefetching_enabled);
-    cvmfs::prefetch_file_bundles_ = cvmfs::options_mgr_->IsOn(
-        is_prefetching_enabled);
-  } else {
-    LogCvmfs(kLogCvmfs, kLogSyslog | kLogDebug,
-             "OptionsManager expected to be initialized but isn't");
-  }
 
   // We need logging set up before forking the watchdog
   FileSystem::SetupLoggingStandalone(*cvmfs::options_mgr_,
@@ -2706,6 +2685,10 @@ static void Spawn() {
 
   if (cvmfs::mount_point_->telemetry_aggr() != NULL) {
     cvmfs::mount_point_->telemetry_aggr()->Spawn();
+  }
+
+  if (cvmfs::mount_point_->bundle_mgr() != NULL) {
+    cvmfs::mount_point_->bundle_mgr()->Spawn();
   }
 }
 

--- a/cvmfs/libcvmfs_int.cc
+++ b/cvmfs/libcvmfs_int.cc
@@ -46,6 +46,7 @@
 #include <string>
 #include <vector>
 
+#include "bundle_mgr.h"
 #include "cache_posix.h"
 #include "catalog.h"
 #include "catalog_mgr_client.h"
@@ -151,6 +152,11 @@ LibContext *LibContext::Create(const string &fqrn,
 
   ctx->mount_point_ = MountPoint::Create(
       fqrn, LibGlobals::GetInstance()->file_system(), options_mgr);
+  // The library never daemonizes, so the prefetcher threads can start
+  // right away (the fuse client defers this until after the fork)
+  if (ctx->mount_point_->bundle_mgr() != nullptr) {
+    ctx->mount_point_->bundle_mgr()->Spawn();
+  }
   return ctx;
 }
 
@@ -543,6 +549,14 @@ int LibContext::Open(const char *c_path) {
 
   if (!found) {
     return -ENOENT;
+  }
+
+  BundleMgr *bundle_mgr = mount_point_->bundle_mgr();
+  if (bundle_mgr != nullptr && dirent.IsBundleTrigger()) {
+    // Hand the trigger over to the long-lived prefetcher; spec loading and
+    // dependency downloads happen on its background threads, so the open()
+    // does not wait for them.
+    bundle_mgr->ScheduleTrigger(path);
   }
 
   if (dirent.IsChunkedFile()) {

--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -31,6 +31,7 @@
 #include "authz/authz_fetch.h"
 #include "authz/authz_session.h"
 #include "backoff.h"
+#include "bundle_mgr.h"
 #include "cache.h"
 #include "cache_extern.h"
 #include "cache_posix.h"
@@ -1294,6 +1295,7 @@ MountPoint *MountPoint::Create(const string &fqrn,
   mountpoint->CreateTables();
   if (!mountpoint->SetupBehavior())
     return mountpoint.Release();
+  mountpoint->CreateBundleMgr();
 
   mountpoint->boot_status_ = loader::kFailOk;
   return mountpoint.Release();
@@ -1318,6 +1320,15 @@ void MountPoint::CreateAuthz() {
 
   authz_attachment_ = new AuthzAttachment(authz_session_mgr_);
   assert(authz_attachment_ != NULL);
+}
+
+
+void MountPoint::CreateBundleMgr() {
+  std::string optarg;
+  if (options_mgr_->GetValue("CVMFS_PREFETCH_FILEBUNDLES", &optarg)
+      && options_mgr_->IsOn(optarg)) {
+    bundle_mgr_ = new BundleMgr(this);
+  }
 }
 
 
@@ -1974,6 +1985,7 @@ MountPoint::MountPoint(const string &fqrn,
     , partial_replica_fail_mode_(false)
     , inode_annotation_(NULL)
     , catalog_mgr_(NULL)
+    , bundle_mgr_(NULL)
     , chunk_tables_(NULL)
     , simple_chunk_tables_(NULL)
     , inode_cache_(NULL)
@@ -2002,6 +2014,11 @@ MountPoint::MountPoint(const string &fqrn,
 
 MountPoint::~MountPoint() {
   pthread_mutex_destroy(&lock_max_ttl_);
+
+  // The bundle prefetcher owns background threads that use the catalog
+  // manager, the fetchers and the cache manager; join them before any of
+  // those are destroyed.
+  delete bundle_mgr_;
 
   delete page_cache_tracker_;
   delete dentry_tracker_;

--- a/cvmfs/mountpoint.h
+++ b/cvmfs/mountpoint.h
@@ -29,6 +29,7 @@ class AuthzAttachment;
 class AuthzFetcher;
 class AuthzSessionManager;
 class BackoffThrottle;
+class BundleMgr;
 class CacheManager;
 namespace catalog {
 class ClientCatalogManager;
@@ -515,6 +516,10 @@ class MountPoint : SingleCopy, public BootFactory {
 
   AuthzSessionManager *authz_session_mgr() { return authz_session_mgr_; }
   BackoffThrottle *backoff_throttle() { return backoff_throttle_; }
+  /**
+   * The file bundle prefetcher; NULL unless CVMFS_PREFETCH_FILEBUNDLES is on.
+   */
+  BundleMgr *bundle_mgr() { return bundle_mgr_; }
   catalog::ClientCatalogManager *catalog_mgr() { return catalog_mgr_; }
   ChunkTables *chunk_tables() { return chunk_tables_; }
   download::DownloadManager *download_mgr() { return download_mgr_; }
@@ -634,6 +639,7 @@ class MountPoint : SingleCopy, public BootFactory {
 
   void CreateStatistics();
   void CreateAuthz();
+  void CreateBundleMgr();
   bool CreateSignatureManager();
   bool CheckBlacklists();
   bool CreateDownloadManagers();
@@ -689,6 +695,12 @@ class MountPoint : SingleCopy, public BootFactory {
   bool partial_replica_fail_mode_;
   catalog::InodeAnnotation *inode_annotation_;
   catalog::ClientCatalogManager *catalog_mgr_;
+  /**
+   * File bundle prefetcher, NULL unless CVMFS_PREFETCH_FILEBUNDLES is on.
+   * Owns background threads that use catalog_mgr_ and the fetchers, so it
+   * must be destroyed before them.
+   */
+  BundleMgr *bundle_mgr_;
   ChunkTables *chunk_tables_;
   SimpleChunkTables *simple_chunk_tables_;
   lru::InodeCache *inode_cache_;

--- a/test/src/602-libcvmfs/main
+++ b/test/src/602-libcvmfs/main
@@ -23,8 +23,14 @@ cvmfs_run_test() {
   # Sanity check
   [ "x$cache_dir" != "x$PWD" ] || return 1
 
+  if ! command -v g++ > /dev/null 2>&1; then
+    echo "Warning: g++ is not available, skipping libcvmfs test"
+    CVMFS_GENERAL_WARNING_FLAG=1
+    return 0
+  fi
+
   echo "compiling libcvmfs test binary..."
-  g++ -o "$bin_name" -DDEBUGMSG "$workdir/main.cc" -lcvmfs_client -pthread -ldl -lssl -lcrypto -luuid -lcap -lrt || return 1
+  compile_libcvmfs_binary "$bin_name" "$workdir/main.cc" -DDEBUGMSG || return 1
 
   echo "register cleanup trap"
   trap cleanup EXIT HUP INT TERM || return $?

--- a/test/src/709-cvmfsbundles/main
+++ b/test/src/709-cvmfsbundles/main
@@ -29,17 +29,32 @@ EOF
   popd >/dev/null || return 1
 }
 
-# Path of a file's content object in the local cache, derived from its
-# hash extended attribute (a metadata lookup that does not fetch content)
+desaster_cleanup() {
+  local mountpoint=$1
+  local repo_name=$2
+
+  # Cleanup must not hide the original failure under the test runner's `set -e`.
+  sudo umount "$mountpoint" > /dev/null 2>&1 || true
+  sudo cvmfs_server rmfs -f "$repo_name" > /dev/null 2>&1 || true
+}
+
+# Path of a content object in a cache directory, given its content hash
 cache_object_path() {
   local cache=$1
-  local file=$2
-  local hash=$(get_xattr hash "$file")
+  local hash=$2
   echo "$cache/$(echo $hash | cut -c 1-2)/$(echo $hash | cut -c 3-)"
+}
+
+# Number of finalized content objects in the local cache (the two-hex-digit
+# CAS directories; excludes txn/ scratch files and quota bookkeeping)
+cache_object_count() {
+  local cache=$1
+  find "$cache" -mindepth 2 -maxdepth 2 -type f -path "*/??/*" 2>/dev/null | wc -l
 }
 
 cvmfs_run_test() {
   logfile=$1
+  local workdir="$2"
   local repo_dir=/cvmfs/$CVMFS_TEST_REPO
 
   local scratch_dir=$(mktemp -d)
@@ -88,9 +103,13 @@ EOF
   do_local_mount $mnt_point $CVMFS_TEST_REPO $(get_repo_url $CVMFS_TEST_REPO) \
     "" "CVMFS_PREFETCH_FILEBUNDLES=yes" || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 10; }
 
-  local trigger_in_cache=$(cache_object_path $cache "$mnt_point/trigger.txt")
-  local dep1_in_cache=$(cache_object_path $cache "$mnt_point/dep1.txt")
-  local dep2_in_cache=$(cache_object_path $cache "$mnt_point/dep2.txt")
+  # The hash xattr is a metadata lookup that does not fetch content
+  local trigger_hash=$(get_xattr hash "$mnt_point/trigger.txt")
+  local dep1_hash=$(get_xattr hash "$mnt_point/dep1.txt")
+  local dep2_hash=$(get_xattr hash "$mnt_point/dep2.txt")
+  local trigger_in_cache=$(cache_object_path $cache $trigger_hash)
+  local dep1_in_cache=$(cache_object_path $cache $dep1_hash)
+  local dep2_in_cache=$(cache_object_path $cache $dep2_hash)
 
   echo "make sure the dependencies are not in the cache before the trigger is opened"
   if [ -f "$dep1_in_cache" ] || [ -f "$dep2_in_cache" ]; then
@@ -109,11 +128,30 @@ EOF
   fi
 
   # core testing here
+  local objects_before=$(cache_object_count $cache)
+
   echo "Opening trigger file"
   cat $mnt_point/trigger.txt
 
   echo "Cache location"
   echo $cache
+
+  # Prefetching is asynchronous: opening the trigger only hands the path to
+  # the background prefetcher. Wait for the expected objects to arrive:
+  # trigger + bundle spec + dep1 + dep2 + one object per chunk of dep3.
+  local objects_expected=$((objects_before + 4 + num_chunks))
+  echo "waiting for the cache to grow from $objects_before to $objects_expected objects"
+  local waited=0
+  while [ $(cache_object_count $cache) -lt $objects_expected ]; do
+    if [ $waited -ge 120 ]; then
+      echo "timeout: $(cache_object_count $cache) of $objects_expected objects after ${waited}s"
+      desaster_cleanup $mnt_point $CVMFS_TEST_REPO
+      return 63
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  echo "prefetch finished after ${waited}s"
 
   if [ -f "$trigger_in_cache" ]; then
       echo "Trigger FOUND inside the cache in the expected location"
@@ -166,6 +204,34 @@ EOF
 
   echo "unmount the repository"
   sudo umount $mnt_point || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 12; }
+
+  echo "opening the trigger through libcvmfs must prefetch the same bundle"
+  local bin_name="709-test"
+  local libcvmfs_cache=$scratch_dir/libcvmfs-cache
+
+  if ! command -v g++ > /dev/null 2>&1; then
+    echo "Warning: g++ is not available, skipping libcvmfs coverage"
+    CVMFS_GENERAL_WARNING_FLAG=1
+  else
+    echo "compiling libcvmfs test binary"
+    compile_libcvmfs_binary "$bin_name" "$workdir/main.cc" \
+      || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 64; }
+
+    echo "opening the trigger through libcvmfs and waiting for the prefetch"
+    ./$bin_name "$(get_repo_url $CVMFS_TEST_REPO)" "$CVMFS_TEST_REPO" "$libcvmfs_cache" \
+      $((4 + num_chunks)) 120 \
+      || { desaster_cleanup $mnt_point $CVMFS_TEST_REPO; return 65; }
+
+    echo "verify the prefetched objects in the libcvmfs cache by hash"
+    local hash
+    for hash in $trigger_hash $dep1_hash $dep2_hash; do
+      if [ ! -f "$(cache_object_path $libcvmfs_cache $hash)" ]; then
+        echo "object $hash missing from the libcvmfs cache"
+        desaster_cleanup $mnt_point $CVMFS_TEST_REPO
+        return 66
+      fi
+    done
+  fi
 
   echo "clean up"
   sudo cvmfs_server rmfs -f $CVMFS_TEST_REPO

--- a/test/src/709-cvmfsbundles/main.cc
+++ b/test/src/709-cvmfsbundles/main.cc
@@ -1,0 +1,116 @@
+/**
+ * This file is part of the CernVM File System.
+ *
+ * Opens the bundle trigger file of the given repository through libcvmfs
+ * and waits until the expected number of prefetched objects arrived in the
+ * client cache.  See the `main` script for the surrounding test.
+ */
+
+#include <ctype.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "libcvmfs.h"
+
+// Number of finalized content objects in the cache: the files inside the
+// two-hex-digit CAS directories directly below the cache root (excludes
+// txn/ scratch files and quota bookkeeping)
+static int CountCacheObjects(const std::string &cache_dir) {
+  int count = 0;
+  DIR *top = opendir(cache_dir.c_str());
+  if (top == NULL)
+    return 0;
+  struct dirent *entry;
+  while ((entry = readdir(top)) != NULL) {
+    const std::string name = entry->d_name;
+    if ((name.length() != 2) || !isxdigit(name[0]) || !isxdigit(name[1]))
+      continue;
+    const std::string subdir_path = cache_dir + "/" + name;
+    DIR *subdir = opendir(subdir_path.c_str());
+    if (subdir == NULL)
+      continue;
+    struct dirent *object;
+    while ((object = readdir(subdir)) != NULL) {
+      if (object->d_name[0] != '.')
+        ++count;
+    }
+    closedir(subdir);
+  }
+  closedir(top);
+  return count;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 6) {
+    fprintf(stderr,
+            "Usage: %s <repo url> <repo name> <cache dir> "
+            "<# expected new objects> <timeout in s>\n",
+            argv[0]);
+    return 1;
+  }
+  const char *url = argv[1];
+  const char *fqrn = argv[2];
+  const std::string cache_dir = argv[3];
+  const int expected_new = atoi(argv[4]);
+  const int timeout_s = atoi(argv[5]);
+
+  cvmfs_option_map *global_opts = cvmfs_options_init();
+  cvmfs_options_set(global_opts, "CVMFS_CACHE_DIR", cache_dir.c_str());
+  if (cvmfs_init_v2(global_opts) != LIBCVMFS_ERR_OK) {
+    fprintf(stderr, "couldn't initialize libcvmfs\n");
+    return 2;
+  }
+
+  cvmfs_option_map *repo_opts = cvmfs_options_clone(global_opts);
+  const std::string pubkey = std::string("/etc/cvmfs/keys/") + fqrn + ".pub";
+  cvmfs_options_set(repo_opts, "CVMFS_SERVER_URL", url);
+  cvmfs_options_set(repo_opts, "CVMFS_PUBLIC_KEY", pubkey.c_str());
+  cvmfs_options_set(repo_opts, "CVMFS_HTTP_PROXY", "DIRECT");
+  cvmfs_options_set(repo_opts, "CVMFS_PREFETCH_FILEBUNDLES", "yes");
+
+  cvmfs_context *ctx = NULL;
+  if (cvmfs_attach_repo_v2(fqrn, repo_opts, &ctx) != LIBCVMFS_ERR_OK) {
+    fprintf(stderr, "couldn't attach repository %s\n", fqrn);
+    return 3;
+  }
+
+  // Attaching fetched the certificate and the root catalog; everything
+  // arriving from here on is due to opening the bundle trigger.
+  const int objects_before = CountCacheObjects(cache_dir);
+
+  const int fd = cvmfs_open(ctx, "/trigger.txt");
+  if (fd < 0) {
+    fprintf(stderr, "couldn't open /trigger.txt\n");
+    return 4;
+  }
+  cvmfs_close(ctx, fd);
+
+  // Prefetching is asynchronous; wait for the expected objects to arrive.
+  // The repository must stay attached while waiting: detaching drains the
+  // prefetch queues.
+  const int objects_expected = objects_before + expected_new;
+  printf("waiting for the cache to grow from %d to %d objects\n",
+         objects_before, objects_expected);
+  fflush(stdout);
+  int waited = 0;
+  while (CountCacheObjects(cache_dir) < objects_expected) {
+    if (waited >= timeout_s) {
+      fprintf(stderr, "timeout: %d of %d objects after %ds\n",
+              CountCacheObjects(cache_dir), objects_expected, waited);
+      return 5;
+    }
+    sleep(1);
+    ++waited;
+  }
+  printf("prefetch finished after %ds\n", waited);
+
+  cvmfs_detach_repo(ctx);
+  cvmfs_fini();
+  cvmfs_options_fini(repo_opts);
+  cvmfs_options_fini(global_opts);
+  return 0;
+}

--- a/test/test_functions
+++ b/test/test_functions
@@ -2748,6 +2748,30 @@ lockfile() {
   ./lockfile $1
 }
 
+# Compile a program against the installed libcvmfs client library.
+#   compile_libcvmfs_binary <output> <source> [extra compiler flags...]
+#
+# libcvmfs_client is a shared library that records its own dependencies, so
+# consumers must not repeat them on the link line.  Spelling out -lssl,
+# -lcrypto, -luuid, ... (a leftover from the days when libcvmfs was a static
+# library) requires the corresponding -devel packages, which are not part of
+# the test node setup and made the link fail with "cannot find -lssl".
+compile_libcvmfs_binary() {
+  local output="$1"
+  local source="$2"
+  shift 2
+
+  local cflags=""
+  local libs="-lcvmfs_client"
+  if pkg-config --exists libcvmfs 2>/dev/null; then
+    cflags="$(pkg-config --cflags libcvmfs)"
+    libs="$(pkg-config --libs libcvmfs)"
+  fi
+
+  echo "g++ -o $output $cflags $@ $source $libs -pthread"
+  g++ -o "$output" $cflags "$@" "$source" $libs -pthread
+}
+
 # Run a command and assert it exits with an expected status.
 #   expect_exit_code <expected> <command> [args...]
 expect_exit_code() {

--- a/test/unittests/t_bundle_mgr.cc
+++ b/test/unittests/t_bundle_mgr.cc
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <fcntl.h>
 #include <pthread.h>
 
 #include <algorithm>
@@ -130,31 +131,27 @@ class T_BundleMgr : public ::testing::Test {
     mount_point_->fetcher_ = mock_fetcher_;
     mount_point_->external_fetcher_ = mock_external_fetcher_;
 
-    bundle_mgr_ = new BundleMgr(mount_point_, trigger_path_);
+    bundle_mgr_ = new BundleMgr(mount_point_);
+    EXPECT_TRUE(static_cast<bool>(*bundle_mgr_));
+    bundle_mgr_->Spawn();
+    EXPECT_TRUE(static_cast<bool>(*bundle_mgr_));
 
+    // A parsed bundle spec, handed to EnqueueDependencies() directly; the
+    // production path would obtain it from the dispatcher thread via
+    // ProcessTrigger().
     bfm_ = new BundleFileMgr(JsonDocument::Create(CreateJsonTxt()));
 
-    delete bundle_mgr_->bfm_;
-    bundle_mgr_->bfm_ = bfm_;
-    // Under the mocked fetcher the constructor cannot load the real bundle
-    // file, so it leaves the manager invalid and without a worker pool. Put
-    // it into a valid state around the injected bfm_ and start the pool so
-    // that Fetch() actually dispatches work.
-    bundle_mgr_->is_valid_ = true;
-    bundle_mgr_->SpawnFetcherPool();
-    // Count only the dependency fetches triggered by Fetch(), not the single
-    // probe the constructor performed while trying to load the bundle file.
+    // Reset the shared counters so each test starts from a clean slate
     MockFetcher::Reset();
-    EXPECT_TRUE(bundle_mgr_);
-    EXPECT_EQ(bundle_mgr_->bfm_, bfm_);
     MakePipe(common_pipe_);
   }
 
   virtual void TearDown() {
-    // Destroy the BundleMgr first: its destructor joins the worker threads,
-    // which may still dereference mount_point_/file_system_ while draining
-    // the queue.
+    // Destroy the BundleMgr first: its destructor joins the dispatcher and
+    // the worker threads, which may still dereference mount_point_ and
+    // file_system_ while draining their queues.
     delete bundle_mgr_;
+    delete bfm_;
     delete mount_point_;
     delete file_system_;
     ClosePipe(common_pipe_);
@@ -185,11 +182,9 @@ class T_BundleMgr : public ::testing::Test {
   SimpleOptionsParser options_mgr_;
   std::string tmp_path_;
 
-  PathString trigger_file_path_;
   BundleMgr *bundle_mgr_;
 
   catalog::DirectoryEntry trigger_dirent_{};
-  PathString trigger_path_{};
 
   // Mocks
   BundleFileMgr *bfm_;
@@ -238,14 +233,13 @@ TEST_F(T_BundleMgr, ExchangePathString) {
   EXPECT_EQ(path, bundle_mgr_->ReceivePath(rfd_));
 }
 
-// A dependency path published in a repo's .cvmfsbundle spec can be longer
-// than PIPE_BUF (4096 on Linux, 512 on macOS) and the fetcher work queue must
-// carry it intact: in production it flows through BundleMgr::Fetch ->
-// TrySendPath -> worker ReceivePath. This exercises the receive side directly
-// over the fixture's blocking common_pipe_, mirroring ExchangePathString with
-// a payload beyond the PIPE_BUF boundary. The send side over the pool's own
-// O_NONBLOCK work-queue pipe still cannot deliver such payloads (WritePipe
-// asserts on a short or EAGAIN write); that path is not exercised here.
+// The transport helpers must carry paths longer than PIPE_BUF (4096 on
+// Linux, 512 on macOS) intact: BlockingReceive must not bound the payload
+// length. This mirrors ExchangePathString over the fixture's blocking
+// common_pipe_ with a payload beyond the PIPE_BUF boundary. (The production
+// work queue sends each message with a single atomic write and TrySendPath
+// drops paths that do not fit into PIPE_BUF, so overlong paths never reach
+// the workers there.)
 TEST_F(T_BundleMgr, ReceivePathLongerThanPipeBuf) {
   // 2 * PIPE_BUF still fits comfortably in the pipe's buffer, so the single
   // write()/read() in WritePipe/ReadPipe transfers the whole payload.
@@ -254,13 +248,58 @@ TEST_F(T_BundleMgr, ReceivePathLongerThanPipeBuf) {
   EXPECT_EQ(long_path, bundle_mgr_->ReceivePath(rfd_));
 }
 
-TEST_F(T_BundleMgr, Fetch) {
-  bundle_mgr_->Fetch();
+TEST_F(T_BundleMgr, EnqueueDependencies) {
+  bundle_mgr_->EnqueueDependencies(bfm_, PathString("/bundle/dir"));
   // JoinFetcherPool() drains the work queue: every dependency is fetched
   // before the workers reach their terminate command, so the resulting count
   // is deterministic.
   bundle_mgr_->JoinFetcherPool();
   EXPECT_EQ(MockFetcher::counter_.load(), dependencies_.size());
+}
+
+TEST_F(T_BundleMgr, ScheduleTrigger) {
+  EXPECT_TRUE(bundle_mgr_->ScheduleTrigger(PathString("/trigger.txt")));
+  // JoinDispatcher() drains the trigger queue before terminating: the
+  // dispatcher tries to load the bundle spec through the mocked fetcher,
+  // which is the single fetch observed here (and fails, so no dependencies
+  // are enqueued).
+  bundle_mgr_->JoinDispatcher();
+  bundle_mgr_->JoinFetcherPool();
+  EXPECT_EQ(MockFetcher::counter_.load(), 1u);
+}
+
+// In the fuse client, Spawn() only runs after daemonization (threads do not
+// survive the fork), so a trigger scheduled before Spawn() must wait in the
+// queue and be processed once the threads come up.
+TEST_F(T_BundleMgr, ScheduleTriggerBeforeSpawn) {
+  BundleMgr mgr(mount_point_);
+  EXPECT_TRUE(mgr.ScheduleTrigger(PathString("/trigger.txt")));
+  mgr.Spawn();
+  mgr.JoinDispatcher();
+  mgr.JoinFetcherPool();
+  EXPECT_EQ(MockFetcher::counter_.load(), 1u);
+}
+
+TEST_F(T_BundleMgr, TrySendPathDropsWhenFull) {
+  int full_pipe[2];
+  MakePipe(full_pipe);
+  const int flags = fcntl(full_pipe[1], F_GETFL);
+  fcntl(full_pipe[1], F_SETFL, flags | O_NONBLOCK);
+
+  // Nobody reads from this pipe, so it fills up after finitely many sends;
+  // TrySendPath must then report failure instead of blocking the caller.
+  const PathString path("/some/bundle/dependency.txt");
+  const size_t kSendLimit = 1000000;
+  size_t n_sent = 0;
+  bool sent = true;
+  while (sent && (n_sent < kSendLimit)) {
+    sent = bundle_mgr_->TrySendPath(full_pipe[1], path);
+    if (sent)
+      ++n_sent;
+  }
+  EXPECT_FALSE(sent);
+  EXPECT_GT(n_sent, 0u);
+  ClosePipe(full_pipe);
 }
 
 namespace {
@@ -303,7 +342,7 @@ TEST_F(T_BundleMgr, FetchChunked) {
         return true;
       });
 
-  bundle_mgr_->Fetch();
+  bundle_mgr_->EnqueueDependencies(bfm_, PathString("/bundle/dir"));
   bundle_mgr_->JoinFetcherPool();
 
   const std::vector<shash::Any> fetched = MockFetcher::FetchedHashes();


### PR DESCRIPTION
Currently file bundles are:

* Not supported in libcvmfs
* Block the `open` call until all files in the bundle are downloaded, this also held the remount fence and blocks catalog reloads
* Relatively heavy when enabled as a dedicated threadpool is started every time a bundle is hit

This PR fixes this by:

* Moving `BundleMgr` to be owned by the mount point rather than being created each time a bundle is hit
* This allows the overhead to be once per mount rather than per `cvmfs_open` call and is no longer blocking
* The second commit then adds support for bundles in libcvmfs

---------