### PR TITLE
Reduce package size: make gdb optional, strip debug symbols into separate package.

### DIFF
--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -48,8 +48,9 @@ Depends:
  ${shlibs:Depends}
 Recommends:
  autofs (>= 5.1.2),
-# gdb adds details to watchdog crash reports.
- gdb
+# gdb and matching debug symbols add details to watchdog crash reports.
+ gdb,
+ cvmfs-dbg (= ${binary:Version})
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System
  HTTP File System for Distributing Software to CernVM.

--- a/packaging/debian/cvmfs/control
+++ b/packaging/debian/cvmfs/control
@@ -40,7 +40,6 @@ Depends:
  lsof,
  attr,
  zlib1g,
- gdb,
  uuid-dev,
  uuid,
  adduser,
@@ -48,7 +47,9 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends}
 Recommends:
- autofs (>= 5.1.2)
+ autofs (>= 5.1.2),
+# gdb adds details to watchdog crash reports.
+ gdb
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System
  HTTP File System for Distributing Software to CernVM.
@@ -117,6 +118,21 @@ Depends:
 Homepage: http://cernvm.cern.ch
 Description: CernVM File System fuse3 libraries
  Shared libraries implementing the CernVM-FS fuse module based on libfuse3
+
+Package: cvmfs-dbg
+Architecture: amd64 armhf arm64
+Section: debug
+Priority: optional
+Depends:
+ ${misc:Depends}
+Homepage: http://cernvm.cern.ch
+Description: CernVM File System debug symbols
+ Detached debug symbols for the CernVM-FS binaries and libraries, indexed by
+ build ID under /usr/lib/debug/.build-id.
+ .
+ This package is only needed to turn a crash backtrace into file names and line
+ numbers. The shipped binaries keep their symbol table, so function names are
+ already available without it.
 
 #GATEWAY-BEGIN
 Package: cvmfs-gateway

--- a/packaging/debian/cvmfs/cvmfs-dbg.lintian-overrides
+++ b/packaging/debian/cvmfs/cvmfs-dbg.lintian-overrides
@@ -1,0 +1,2 @@
+# A custom debug package keeps .symtab for watchdog backtraces.
+cvmfs-dbg: debug-package-should-be-named-dbgsym

--- a/packaging/debian/cvmfs/rules
+++ b/packaging/debian/cvmfs/rules
@@ -14,6 +14,17 @@ BUILD_LIBFUSE2 := 'no'
 
 CVMFS_BUILD_UNITTESTS ?= no
 
+# Packages whose debug info is moved into cvmfs-dbg (excluding Go packages).
+STRIP_PACKAGES := debian/cvmfs debian/cvmfs-libs debian/cvmfs-fuse3 \
+	debian/cvmfs-server debian/cvmfs-shrinkwrap
+
+# Keep .symtab so watchdog backtraces include function names.
+ifeq (,$(filter nostrip,$(DEB_BUILD_OPTIONS)))
+STRIP_DEBUGINFO := debian/strip-debuginfo.sh debian/cvmfs-dbg $(STRIP_PACKAGES)
+else
+STRIP_DEBUGINFO := echo "DEB_BUILD_OPTIONS=nostrip: keeping debug info in place"
+endif
+
 # Detect Go once; gateway and snapshotter packages are only built when available.
 BUILD_GO := $(shell if go version >/dev/null 2>&1; then echo "yes"; else echo "no"; fi)
 ifeq ($(BUILD_GO),no)
@@ -114,13 +125,14 @@ binary-arch: build install
 #        dh_undocumented
 	dh_installchangelogs ChangeLog
 	dh_link
-#	dh_strip
+	mkdir -p debian/cvmfs-dbg
+	$(STRIP_DEBUGINFO)
 	dh_compress
 	dh_fixperms --exclude cvmfs_suid_helper
-	dh_makeshlibs
+	dh_makeshlibs -Ncvmfs-dbg
 	dh_installdeb
 #        dh_perl
-	dh_shlibdeps
+	dh_shlibdeps -Ncvmfs-dbg
 	dh_gencontrol $(GO_SKIP)
 	dh_md5sums $(GO_SKIP)
 	dh_builddeb $(GO_SKIP)

--- a/packaging/debian/cvmfs/strip-debuginfo.sh
+++ b/packaging/debian/cvmfs/strip-debuginfo.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Moves debug info into cvmfs-dbg using the standard build-ID layout.
+# Unlike dh_strip, --strip-debug keeps .symtab for watchdog backtraces.
+# Usage: strip-debuginfo.sh <cvmfs-dbg staging dir> <staging dir>...
+
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <dbg staging dir> <staging dir>..." >&2
+  exit 1
+fi
+
+dbg_dir="$1"
+shift
+
+filelist="$(mktemp)"
+trap 'rm -f "$filelist"' EXIT
+
+# Some configurations omit package staging directories.
+: > "$filelist"
+for dir in "$@"; do
+  if [ -d "$dir" ]; then
+    find "$dir" -type f -print >> "$filelist"
+  else
+    echo "strip-debuginfo: no staging directory $dir, skipping"
+  fi
+done
+
+# Keep the loop in this shell so set -e applies.
+while IFS= read -r file; do
+  case "$(file -b "$file")" in
+    *ELF*executable*|*ELF*shared\ object*) ;;
+    *) continue ;;
+  esac
+
+  # Preserve Go runtime tracebacks.
+  if readelf -SW "$file" | grep -q ' \.gopclntab'; then
+    echo "strip-debuginfo: skipping Go binary $file"
+    continue
+  fi
+
+  # Build ID follows the NT_GNU_BUILD_ID label.
+  build_id="$(readelf -nW "$file" \
+              | sed -n 's/.*Build ID:[[:space:]]*\([0-9a-f]\{16,\}\).*/\1/p' \
+              | head -n 1)"
+  if [ -z "$build_id" ]; then
+    echo "strip-debuginfo: no build ID, not stripping $file" >&2
+    continue
+  fi
+
+  # GDB finds this path from the build ID without .gnu_debuglink.
+  debug_file="$dbg_dir/usr/lib/debug/.build-id/$(echo "$build_id" | cut -c1-2)"
+  debug_file="$debug_file/$(echo "$build_id" | cut -c3-).debug"
+
+  mkdir -p "$(dirname "$debug_file")"
+  objcopy --only-keep-debug "$file" "$debug_file"
+  chmod 644 "$debug_file"
+
+  # Keep .symtab and preserve the executable mode.
+  strip --strip-debug --remove-section=.comment "$file"
+done < "$filelist"

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -66,8 +66,10 @@
 %define hardlink /usr/bin/hardlink
 %endif
 
-%define __strip /bin/true
-%define debug_package %{nil}
+# Move DWARF to -debuginfo while keeping .symtab for watchdog backtraces.
+%global _find_debuginfo_opts -g
+# Prevent the later brp pass from stripping .symtab.
+%global __brp_strip %{nil}
 %if 0%{?el6} || 0%{?el5} || 0%{?el4}
 %define __os_install_post %{nil}
 %endif
@@ -160,7 +162,8 @@ Requires: zlib
 %if !0%{?suse_version}
 Requires: protobuf
 %endif
-Requires: gdb
+# gdb adds details to watchdog crash reports.
+Recommends: gdb
 %if 0%{?suse_version}
 Requires: libarchive13
 %else

--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -162,8 +162,9 @@ Requires: zlib
 %if !0%{?suse_version}
 Requires: protobuf
 %endif
-# gdb adds details to watchdog crash reports.
+# gdb and matching debug symbols add details to watchdog crash reports.
 Recommends: gdb
+Recommends: %{name}-debuginfo%{?_isa} = %{version}-%{release}
 %if 0%{?suse_version}
 Requires: libarchive13
 %else


### PR DESCRIPTION
For regular users this hopefully leaves everything unchanged, but with
```
yum install cvmfs --setopt=install_weak_deps=False
```
users who care about package size can save some 80 MB.

Fixes https://github.com/cvmfs/cvmfs/issues/4186