### PR TITLE
Treat empty METALINK variables the same as unset

### DIFF
--- a/cvmfs/mountpoint.cc
+++ b/cvmfs/mountpoint.cc
@@ -1409,7 +1409,7 @@ bool MountPoint::CreateDownloadManagers() {
     download_mgr_->SetFailoverIndefinitely();
   }
 
-  if (options_mgr_->GetValue("CVMFS_METALINK_URL", &optarg)) {
+  if (options_mgr_->GetValue("CVMFS_METALINK_URL", &optarg) && (optarg != "")) {
     download_mgr_->SetMetalinkChain(optarg);
     // host chain will be set later when the metalink server is contacted
     download_mgr_->SetHostChain("");
@@ -2274,7 +2274,8 @@ bool MountPoint::SetupExternalDownloadMgr(bool dogeosort) {
   }
   external_download_mgr_->SetTimeout(timeout, timeout_direct);
 
-  if (options_mgr_->GetValue("CVMFS_EXTERNAL_METALINK", &optarg)) {
+  if (options_mgr_->GetValue("CVMFS_EXTERNAL_METALINK", &optarg) &&
+      (optarg != "")) {
     external_download_mgr_->SetMetalinkChain(optarg);
     // host chain will be set later when the metalink server is contacted
     external_download_mgr_->SetHostChain("");


### PR DESCRIPTION
I have a need to be able to unset `CVMFS_EXTERNAL_METALINK` later in the configuration files than where a default is set, and this makes an empty setting of that and `CVMFS_METALINK_URL` to be treated as if they were never set.  There's no way to unset a variable in a CVMFS config, it can only be overridden to empty.

(In particular the current need is for the Fermilab site to override the external origin when the data source for osgstorage.org repositories is locally hosted).