### PR TITLE
S3/Azure: add Managed Identity (MSI) bearer-token authentication for Azure Blob

### DIFF
--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -12,9 +12,11 @@
 #include <cassert>
 #include <cerrno>
 #include <cstring>
+#include <ctime>
 #include <utility>
 
 #include "crypto/hash.h"
+#include "json_document.h"
 #include "util/exception.h"
 #include "util/platform.h"
 #include "util/posix.h"
@@ -803,13 +805,96 @@ bool S3FanoutManager::MkV4Authz(const JobInfo &info,
   return true;
 }
 
+static size_t RecvCB(void *ptr, size_t size, size_t nmemb, void *userp) {
+  const size_t bytes = size * nmemb;
+  reinterpret_cast<string *>(userp)->append(static_cast<char *>(ptr), bytes);
+  return bytes;
+}
+
 /**
- * The Azure Blob authorization header according to
+ * Fetches (and caches) an OAuth2 bearer token for storage.azure.com from the
+ * Azure Instance Metadata Service.  Tokens are re-minted 5 minutes before the
+ * IMDS-reported expiry so long-running snapshots keep a valid credential.
+ */
+bool S3FanoutManager::RefreshAzureToken() const {
+  const MutexLockGuard guard(&azure_token_lock_);
+
+  if (!azure_token_.empty()
+      && (static_cast<uint64_t>(time(NULL)) + 300 < azure_token_expiry_)) {
+    return true;
+  }
+
+  string url = "http://169.254.169.254/metadata/identity/oauth2/token"
+               "?api-version=2018-02-01"
+               "&resource=https%3A%2F%2Fstorage.azure.com%2F";
+  if (!config_.azure_mi_client_id.empty())
+    url += "&client_id=" + config_.azure_mi_client_id;
+
+  CURL *curl = curl_easy_init();
+  if (curl == NULL)
+    return false;
+  string body;
+  curl_slist *clist = curl_slist_append(NULL, "Metadata: true");
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, clist);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, RecvCB);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+  curl_easy_setopt(curl, CURLOPT_NOPROXY, "169.254.169.254");
+  const CURLcode res = curl_easy_perform(curl);
+  long http_code = 0;  // NOLINT(runtime/int)
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  curl_slist_free_all(clist);
+  curl_easy_cleanup(curl);
+
+  if ((res != CURLE_OK) || (http_code != 200)) {
+    LogCvmfs(kLogS3Fanout, kLogStderr,
+             "Azure MSI token request failed (curl %d, http %ld)", res,
+             http_code);
+    return false;
+  }
+
+  const UniquePtr<JsonDocument> reply(JsonDocument::Create(body));
+  if (!reply.IsValid())
+    return false;
+  const JSON *token = JsonDocument::SearchInObject(reply->root(),
+                                                   "access_token", JSON_STRING);
+  const JSON *expires = JsonDocument::SearchInObject(reply->root(),
+                                                     "expires_on", JSON_STRING);
+  if ((token == NULL) || (expires == NULL))
+    return false;
+
+  azure_token_ = token->get<string>();
+  azure_token_expiry_ = String2Uint64(expires->get<string>());
+  return true;
+}
+
+/**
+ * The Azure Blob authorization header.  With a Shared Key (access/secret key)
+ * the signature is computed as per
  * https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+ * With Managed Identity a bearer token from IMDS is used instead, which
+ * requires x-ms-version >= 2017-11-09.
  */
 bool S3FanoutManager::MkAzureAuthz(const JobInfo &info,
                                    vector<string> *headers) const {
   const string timestamp = RfcTimestamp();
+
+  if (config_.azure_msi) {
+    if (!RefreshAzureToken())
+      return false;
+    string bearer;
+    {
+      const MutexLockGuard guard(&azure_token_lock_);
+      bearer = azure_token_;
+    }
+    headers->push_back("x-ms-date: " + timestamp);
+    headers->push_back("x-ms-version: 2017-11-09");
+    headers->push_back("Authorization: Bearer " + bearer);
+    headers->push_back("x-ms-blob-type: BlockBlob");
+    return true;
+  }
+
   const string canonical_headers = "x-ms-blob-type:BlockBlob\nx-ms-date:"
                                    + timestamp + "\nx-ms-version:2011-08-18";
   const string canonical_resource = "/" + config_.access_key + "/"
@@ -1388,6 +1473,10 @@ S3FanoutManager::S3FanoutManager(const S3Config &config) : config_(config) {
   retval = pthread_mutex_init(curl_handle_lock_, NULL);
   assert(retval == 0);
 
+  azure_token_expiry_ = 0;
+  retval = pthread_mutex_init(&azure_token_lock_, NULL);
+  assert(retval == 0);
+
   active_requests_ = new set<JobInfo *>;
   pool_handles_idle_ = new set<CURL *>;
   pool_handles_inuse_ = new set<CURL *>;
@@ -1447,6 +1536,7 @@ S3FanoutManager::~S3FanoutManager() {
   free(jobs_todo_lock_);
   pthread_mutex_destroy(curl_handle_lock_);
   free(curl_handle_lock_);
+  pthread_mutex_destroy(&azure_token_lock_);
 
   if (atomic_xadd32(&multi_threaded_, 0) == 1) {
     // Shutdown I/O thread

--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -12,9 +12,11 @@
 #include <cassert>
 #include <cerrno>
 #include <cstring>
+#include <ctime>
 #include <utility>
 
 #include "crypto/hash.h"
+#include "json_document.h"
 #include "util/exception.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -799,13 +801,96 @@ bool S3FanoutManager::MkV4Authz(const JobInfo &info,
   return true;
 }
 
+static size_t RecvCB(void *ptr, size_t size, size_t nmemb, void *userp) {
+  const size_t bytes = size * nmemb;
+  reinterpret_cast<string *>(userp)->append(static_cast<char *>(ptr), bytes);
+  return bytes;
+}
+
 /**
- * The Azure Blob authorization header according to
+ * Fetches (and caches) an OAuth2 bearer token for storage.azure.com from the
+ * Azure Instance Metadata Service.  Tokens are re-minted 5 minutes before the
+ * IMDS-reported expiry so long-running snapshots keep a valid credential.
+ */
+bool S3FanoutManager::RefreshAzureToken() const {
+  const MutexLockGuard guard(&azure_token_lock_);
+
+  if (!azure_token_.empty()
+      && (static_cast<uint64_t>(time(NULL)) + 300 < azure_token_expiry_)) {
+    return true;
+  }
+
+  string url = "http://169.254.169.254/metadata/identity/oauth2/token"
+               "?api-version=2018-02-01"
+               "&resource=https%3A%2F%2Fstorage.azure.com%2F";
+  if (!config_.azure_mi_client_id.empty())
+    url += "&client_id=" + config_.azure_mi_client_id;
+
+  CURL *curl = curl_easy_init();
+  if (curl == NULL)
+    return false;
+  string body;
+  curl_slist *clist = curl_slist_append(NULL, "Metadata: true");
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, clist);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, RecvCB);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+  curl_easy_setopt(curl, CURLOPT_NOPROXY, "169.254.169.254");
+  const CURLcode res = curl_easy_perform(curl);
+  long http_code = 0;  // NOLINT(runtime/int)
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  curl_slist_free_all(clist);
+  curl_easy_cleanup(curl);
+
+  if ((res != CURLE_OK) || (http_code != 200)) {
+    LogCvmfs(kLogS3Fanout, kLogStderr,
+             "Azure MSI token request failed (curl %d, http %ld)", res,
+             http_code);
+    return false;
+  }
+
+  const UniquePtr<JsonDocument> reply(JsonDocument::Create(body));
+  if (!reply.IsValid())
+    return false;
+  const JSON *token = JsonDocument::SearchInObject(reply->root(),
+                                                   "access_token", JSON_STRING);
+  const JSON *expires = JsonDocument::SearchInObject(reply->root(),
+                                                     "expires_on", JSON_STRING);
+  if ((token == NULL) || (expires == NULL))
+    return false;
+
+  azure_token_ = token->get<string>();
+  azure_token_expiry_ = String2Uint64(expires->get<string>());
+  return true;
+}
+
+/**
+ * The Azure Blob authorization header.  With a Shared Key (access/secret key)
+ * the signature is computed as per
  * https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+ * With Managed Identity a bearer token from IMDS is used instead, which
+ * requires x-ms-version >= 2017-11-09.
  */
 bool S3FanoutManager::MkAzureAuthz(const JobInfo &info,
                                    vector<string> *headers) const {
   const string timestamp = RfcTimestamp();
+
+  if (config_.azure_msi) {
+    if (!RefreshAzureToken())
+      return false;
+    string bearer;
+    {
+      const MutexLockGuard guard(&azure_token_lock_);
+      bearer = azure_token_;
+    }
+    headers->push_back("x-ms-date: " + timestamp);
+    headers->push_back("x-ms-version: 2017-11-09");
+    headers->push_back("Authorization: Bearer " + bearer);
+    headers->push_back("x-ms-blob-type: BlockBlob");
+    return true;
+  }
+
   const string canonical_headers = "x-ms-blob-type:BlockBlob\nx-ms-date:"
                                    + timestamp + "\nx-ms-version:2011-08-18";
   const string canonical_resource = "/" + config_.access_key + "/"
@@ -1384,6 +1469,10 @@ S3FanoutManager::S3FanoutManager(const S3Config &config) : config_(config) {
   retval = pthread_mutex_init(curl_handle_lock_, NULL);
   assert(retval == 0);
 
+  azure_token_expiry_ = 0;
+  retval = pthread_mutex_init(&azure_token_lock_, NULL);
+  assert(retval == 0);
+
   active_requests_ = new set<JobInfo *>;
   pool_handles_idle_ = new set<CURL *>;
   pool_handles_inuse_ = new set<CURL *>;
@@ -1443,6 +1532,7 @@ S3FanoutManager::~S3FanoutManager() {
   free(jobs_todo_lock_);
   pthread_mutex_destroy(curl_handle_lock_);
   free(curl_handle_lock_);
+  pthread_mutex_destroy(&azure_token_lock_);
 
   if (atomic_xadd32(&multi_threaded_, 0) == 1) {
     // Shutdown I/O thread

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -197,6 +197,7 @@ class S3FanoutManager : SingleCopy {
       opt_backoff_init_ms = 100;
       opt_backoff_max_ms = 2000;
       x_amz_acl = "public-read";
+      azure_msi = false;
     }
     std::string access_key;
     std::string secret_key;
@@ -204,6 +205,9 @@ class S3FanoutManager : SingleCopy {
     AuthzMethods authz_method;
     std::string region;
     std::string flavor;
+    // MSI bearer-token auth; azure_mi_client_id empty => system-assigned
+    bool azure_msi;
+    std::string azure_mi_client_id;
     std::string bucket;
     bool dns_buckets;
     std::string protocol;
@@ -266,6 +270,7 @@ class S3FanoutManager : SingleCopy {
   bool MkV4Authz(const JobInfo &info, std::vector<std::string> *headers) const;
   bool MkAzureAuthz(const JobInfo &info,
                     std::vector<std::string> *headers) const;
+  bool RefreshAzureToken() const;
   std::string MkUrl(const std::string &objkey) const {
     if (config_.dns_buckets) {
       return config_.protocol + "://" + complete_hostname_ + "/" + objkey;
@@ -287,6 +292,9 @@ class S3FanoutManager : SingleCopy {
   }
 
   const S3Config config_;
+  mutable std::string azure_token_;
+  mutable uint64_t azure_token_expiry_;
+  mutable pthread_mutex_t azure_token_lock_;
   std::string complete_hostname_;
 
   Prng prng_;

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -197,6 +197,7 @@ class S3FanoutManager : SingleCopy {
       opt_backoff_init_ms = 100;
       opt_backoff_max_ms = 2000;
       x_amz_acl = "public-read";
+      azure_msi = false;
     }
     std::string access_key;
     std::string secret_key;
@@ -204,6 +205,9 @@ class S3FanoutManager : SingleCopy {
     AuthzMethods authz_method;
     std::string region;
     std::string flavor;
+    // MSI bearer-token auth; azure_mi_client_id empty => system-assigned
+    bool azure_msi;
+    std::string azure_mi_client_id;
     std::string bucket;
     bool dns_buckets;
     std::string protocol;
@@ -265,6 +269,7 @@ class S3FanoutManager : SingleCopy {
   bool MkV4Authz(const JobInfo &info, std::vector<std::string> *headers) const;
   bool MkAzureAuthz(const JobInfo &info,
                     std::vector<std::string> *headers) const;
+  bool RefreshAzureToken() const;
   std::string MkUrl(const std::string &objkey) const {
     if (config_.dns_buckets) {
       return config_.protocol + "://" + complete_hostname_ + "/" + objkey;
@@ -286,6 +291,9 @@ class S3FanoutManager : SingleCopy {
   }
 
   const S3Config config_;
+  mutable std::string azure_token_;
+  mutable uint64_t azure_token_expiry_;
+  mutable pthread_mutex_t azure_token_lock_;
   std::string complete_hostname_;
 
   Prng prng_;

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -51,6 +51,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
     , num_retries_(kDefaultNumRetries)
     , timeout_sec_(kDefaultTimeoutSec)
     , authz_method_(s3fanout::kAuthzAwsV2)
+    , azure_msi_(false)
     , peek_before_put_(true)
     , use_https_(false)
     , batch_delete_enabled_(true)
@@ -76,6 +77,8 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   s3fanout::S3FanoutManager::S3Config s3config;
   s3config.access_key = access_key_;
   s3config.secret_key = secret_key_;
+  s3config.azure_msi = azure_msi_;
+  s3config.azure_mi_client_id = azure_mi_client_id_;
   s3config.hostname_port = host_name_port_;
   s3config.authz_method = authz_method_;
   s3config.region = region_;
@@ -151,7 +154,15 @@ bool S3Uploader::ParseSpoolerDefinition(
              config_path.c_str());
     return false;
   }
-  if (!options_manager.GetValue("CVMFS_S3_SECRET_KEY", &secret_key_)) {
+  if (options_manager.GetValue("CVMFS_S3_AZURE_MSI", &parameter)) {
+    azure_msi_ = options_manager.IsOn(parameter);
+    if (azure_msi_)
+      authz_method_ = s3fanout::kAuthzAzure;
+  }
+  options_manager.GetValue("CVMFS_S3_AZURE_MSI_CLIENT_ID",
+                           &azure_mi_client_id_);
+  if (!options_manager.GetValue("CVMFS_S3_SECRET_KEY", &secret_key_)
+      && !azure_msi_) {
     LogCvmfs(kLogUploadS3, kLogStderr,
              "Failed to parse CVMFS_S3_SECRET_KEY from '%s'.",
              config_path.c_str());

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -51,6 +51,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
     , num_retries_(kDefaultNumRetries)
     , timeout_sec_(kDefaultTimeoutSec)
     , authz_method_(s3fanout::kAuthzAwsV2)
+    , azure_msi_(false)
     , peek_before_put_(true)
     , use_https_(false)
     , batch_delete_enabled_(true)
@@ -76,6 +77,8 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   s3fanout::S3FanoutManager::S3Config s3config;
   s3config.access_key = access_key_;
   s3config.secret_key = secret_key_;
+  s3config.azure_msi = azure_msi_;
+  s3config.azure_mi_client_id = azure_mi_client_id_;
   s3config.hostname_port = host_name_port_;
   s3config.authz_method = authz_method_;
   s3config.region = region_;
@@ -150,7 +153,15 @@ bool S3Uploader::ParseSpoolerDefinition(
              config_path.c_str());
     return false;
   }
-  if (!options_manager.GetValue("CVMFS_S3_SECRET_KEY", &secret_key_)) {
+  if (options_manager.GetValue("CVMFS_S3_AZURE_MSI", &parameter)) {
+    azure_msi_ = options_manager.IsOn(parameter);
+    if (azure_msi_)
+      authz_method_ = s3fanout::kAuthzAzure;
+  }
+  options_manager.GetValue("CVMFS_S3_AZURE_MSI_CLIENT_ID",
+                           &azure_mi_client_id_);
+  if (!options_manager.GetValue("CVMFS_S3_SECRET_KEY", &secret_key_)
+      && !azure_msi_) {
     LogCvmfs(kLogUploadS3, kLogStderr,
              "Failed to parse CVMFS_S3_SECRET_KEY from '%s'.",
              config_path.c_str());

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -134,6 +134,8 @@ class S3Uploader : public AbstractUploader {
   unsigned timeout_sec_;
   std::string access_key_;
   std::string secret_key_;
+  bool azure_msi_;
+  std::string azure_mi_client_id_;
   s3fanout::AuthzMethods authz_method_;
   bool peek_before_put_;
   bool use_https_;

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -133,10 +133,10 @@ class S3Uploader : public AbstractUploader {
   unsigned num_retries_;
   unsigned timeout_sec_;
   std::string access_key_;
-  std::string secret_key_;
-  bool azure_msi_;
-  std::string azure_mi_client_id_;
-  s3fanout::AuthzMethods authz_method_;
+   std::string secret_key_;
+   s3fanout::AuthzMethods authz_method_;
+   bool azure_msi_;
+   std::string azure_mi_client_id_;
   bool peek_before_put_;
   bool use_https_;
   bool batch_delete_enabled_;

--- a/test/azure-msi/.gitignore
+++ b/test/azure-msi/.gitignore
@@ -1,0 +1,3 @@
+certs/
+__pycache__/
+*.pyc

--- a/test/azure-msi/README.md
+++ b/test/azure-msi/README.md
@@ -1,0 +1,104 @@
+# Testing the CVMFS Azure-MSI publish path without an Azure VM
+
+PR [#4379](https://github.com/cvmfs/cvmfs/pull/4379) adds Azure **Managed
+Identity (MSI)** bearer-token auth to the S3/Azure-Blob uploader. The maintainer's
+open question was: *can this be tested in CI without a real Azure VM?*
+
+**Yes.** This directory is a runnable proof. It shows that **MinIO cannot** stand
+in, but **Azurite `--oauth basic` + a mock IMDS can**, and it reproduces the exact
+requests CVMFS emits.
+
+## Why not MinIO
+
+The MSI path speaks two things MinIO does not:
+
+1. **Azure Blob REST dialect** (`x-ms-*` headers, `Put Blob` / `Put Block` /
+   `Put Block List`). MinIO implements the AWS S3 API only and
+   [explicitly declined](https://github.com/minio/minio/issues/4540) Azure Blob
+   REST support. (Its old `gateway azure` mode was the *opposite* direction and was
+   [removed in 2022](https://github.com/minio/minio/pull/14418).)
+2. **Incoming `Authorization: Bearer` tokens.** MinIO authenticates with S3 SigV4
+   access keys (+ STS), not a raw OAuth bearer on a PUT.
+
+So the garage-based `S3 integration tests` already cover the S3 flavor; the Azure
+flavor needs an Azure-Blob-speaking endpoint.
+
+## What emulates it
+
+| CVMFS behaviour (PR #4379 / #4395)                                            | Emulated by |
+|-------------------------------------------------------------------------------|-------------|
+| `RefreshAzureToken()` → GET IMDS token (`api-version=2018-02-01`, `resource=https://storage.azure.com/`, `Metadata: true`) | [`imds_mock.py`](./imds_mock.py) — mints a JWT with the right `aud`/`iss`/`exp`; returns `access_token`+`expires_on` as strings |
+| `MkAzureAuthz()` MSI writes: `Authorization: Bearer …`, `x-ms-version: 2017-11-09`, `x-ms-blob-type: BlockBlob` | **Azurite `--oauth basic`** — validates the bearer's `aud`/`iss`/`exp` but **not** its signature ([MS docs](https://learn.microsoft.com/en-us/azure/storage/common/storage-install-azurite)) |
+| PR #4395 large blobs: `Put Block` + `Put Block List` (signs `x-ms-blob-content-type`) | Azurite (full block-blob API) |
+
+Azurite's accepted audiences include `https://storage.azure.com/` and its issuer
+must be an `https://sts.windows*.net/<tenant>/` prefix — both are baked into the
+mock (source: Azurite `src/blob/utils/constants.ts`).
+
+## The one code change required
+
+`RefreshAzureToken()` hard-codes the IMDS endpoint to the link-local
+`169.254.169.254`, so nothing off-Azure can answer it.
+[`s3fanout-imds-endpoint.patch`](./s3fanout-imds-endpoint.patch) makes it
+overridable via `CVMFS_AZURE_IMDS_ENDPOINT` (unset ⇒ identical behaviour on a
+real VM). This is the only change needed to make the path CI-testable without
+network-level redirection of a link-local IP.
+
+## Run it
+
+```bash
+./run-local.sh          # cert + Azurite(--oauth basic) + mock IMDS + verifier, self-cleaning
+```
+
+or manually:
+
+```bash
+docker compose up -d
+python3 verify_msi_path.py
+docker compose down -v
+```
+
+### Expected output
+
+```
+1. RefreshAzureToken() -> mock IMDS
+  [PASS] fetched bearer token from IMDS  (807 bytes, 3 JWT segments)
+2. Create container (Bearer auth over Azure Blob dialect)
+  [PASS] PUT ?restype=container -> HTTP 201  (created)
+3. Single-PUT block blob (MkAzureAuthz MSI headers)
+  [PASS] PUT blob (x-ms-blob-type: BlockBlob) -> HTTP 201
+  [PASS] GET read-back -> HTTP 200  (bytes match)
+4. Large blob via Put Block / Put Block List (PR #4395 path)
+  [PASS] uploaded 6 blocks via Put Block (comp=block)
+  [PASS] Put Block List (comp=blocklist) commit -> HTTP 201
+  [PASS] GET large blob read-back -> HTTP 200 (5255225 bytes)  (bytes match)
+
+PASS: Azurite + mock IMDS accepted every CVMFS-shaped MSI request.
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`imds_mock.py`](./imds_mock.py) | Zero-dependency fake IMDS token endpoint |
+| [`verify_msi_path.py`](./verify_msi_path.py) | Zero-dependency verifier replaying CVMFS's exact request shape |
+| [`run-local.sh`](./run-local.sh) | One-command local proof (self-tearing-down) |
+| [`docker-compose.yml`](./docker-compose.yml) | Azurite + mock IMDS for CI |
+| [`github-workflow-azure-msi.yml`](./github-workflow-azure-msi.yml) | CI: `emulator-smoke` (always runs) + `publisher-e2e` (real publish) |
+| [`publish-e2e.sh`](./publish-e2e.sh) | Real `cvmfs_server` mkfs + publish against the emulator over MSI |
+| [`s3.conf.template`](./s3.conf.template) | CVMFS S3/azure config for the emulator (MSI, no secret key) |
+| [`s3fanout-imds-endpoint.patch`](./s3fanout-imds-endpoint.patch) | Make the IMDS URL overridable (the enabling change) |
+
+## Scope / honesty
+
+- `verify_msi_path.py` proves **the emulator accepts exactly the requests CVMFS's
+  MSI code produces** — token fetch, bearer-authenticated Azure-Blob writes, and
+  the `Put Block`/`Put Block List` staging from #4395 — without building CVMFS.
+  This has been run and passes (see output above).
+- The `publisher-e2e` job builds `cvmfs-server` from the PR branch with the patch
+  applied and runs a real `cvmfs_server` mkfs + publish ([`publish-e2e.sh`](./publish-e2e.sh))
+  against Azurite over MSI, asserting the `.cvmfspublished` manifest lands in the
+  blob store. The CVMFS compile runs in CI (or fold it into the existing S3
+  integration harness, which already builds cvmfs and runs a containerized publisher).
+- `--oauth basic` deliberately skips signature validation — appropriate for a test
+  double, not a security check.

--- a/test/azure-msi/docker-compose.yml
+++ b/test/azure-msi/docker-compose.yml
@@ -1,0 +1,36 @@
+# Stands up the two services that emulate the Azure MSI + Blob path, so CVMFS's
+# Azure-MSI uploader can be exercised without a real Azure VM.
+#
+#   docker compose up -d            # start azurite + mock IMDS
+#   CVMFS_AZURE_IMDS_ENDPOINT=http://127.0.0.1:8081 \
+#   AZURITE_BLOB_ENDPOINT=https://127.0.0.1:10000 python3 verify_msi_path.py
+#   docker compose down
+#
+# A CVMFS publisher (built with the s3fanout-imds-endpoint.patch) points at:
+#   CVMFS_AZURE_IMDS_ENDPOINT = http://<imds>:8081
+#   CVMFS_S3_HOST             = <azurite>:10000  (path-style, DNS_BUCKETS=false)
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    # --oauth basic validates the bearer's aud/iss/exp but NOT its signature,
+    # and requires HTTPS -> the mounted self-signed cert.
+    command: >
+      azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --oauth basic
+      --cert /certs/azurite-cert.pem --key /certs/azurite-key.pem
+      --skipApiVersionCheck
+    ports:
+      - "10000:10000"
+    volumes:
+      - ./certs:/certs:ro
+
+  imds:
+    image: python:3.12-slim
+    working_dir: /app
+    command: python3 imds_mock.py
+    environment:
+      IMDS_BIND: "0.0.0.0"
+      IMDS_PORT: "8081"
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./:/app:ro

--- a/test/azure-msi/github-workflow-azure-msi.yml
+++ b/test/azure-msi/github-workflow-azure-msi.yml
@@ -1,0 +1,88 @@
+# Example CI job proving the Azure-MSI publish path with no Azure VM.
+# Drop into .github/workflows/ (adjust paths to where these files live in-tree,
+# e.g. test/azure-msi/). Two jobs:
+#   * emulator-smoke : no CVMFS build; proves Azurite + mock IMDS accept the exact
+#                      CVMFS-shaped MSI requests (fast, always runnable).
+#   * publisher-e2e  : builds cvmfs-server (with the IMDS-endpoint patch) and runs a
+#                      real cvmfs_server publish against the emulator over MSI.
+name: azure-msi-emulation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  emulator-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Azurite TLS cert
+        working-directory: test/azure-msi
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout certs/azurite-key.pem -out certs/azurite-cert.pem -days 3650 \
+            -subj "/CN=127.0.0.1" -addext "subjectAltName=IP:127.0.0.1,DNS:localhost"
+
+      - name: Start emulator (Azurite --oauth basic + mock IMDS)
+        working-directory: test/azure-msi
+        run: docker compose up -d
+
+      - name: Verify CVMFS-shaped MSI requests are accepted
+        working-directory: test/azure-msi
+        run: |
+          for _ in $(seq 1 30); do
+            [ "$(curl -sk -o /dev/null -w '%{http_code}' \
+                 https://127.0.0.1:10000/devstoreaccount1?comp=list)" != "000" ] && break
+            sleep 1
+          done
+          python3 verify_msi_path.py
+
+      - name: Teardown
+        if: always()
+        working-directory: test/azure-msi
+        run: docker compose down -v
+
+  publisher-e2e:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libssl-dev libcurl4-openssl-dev \
+            zlib1g-dev libfuse-dev libattr1-dev uuid-dev libcap-dev python3 \
+            unzip pkg-config apache2 openssl
+
+      - name: Apply IMDS-endpoint override and build cvmfs-server
+        run: |
+          git apply test/azure-msi/s3fanout-imds-endpoint.patch
+          mkdir build && cd build
+          cmake -DBUILD_SERVER=ON -DBUILD_CVMFS=OFF -DBUILD_LIBCVMFS=OFF ..
+          make -j"$(nproc)"
+          sudo make install
+
+      - name: Start emulator
+        working-directory: test/azure-msi
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout certs/azurite-key.pem -out certs/azurite-cert.pem -days 3650 \
+            -subj "/CN=127.0.0.1" -addext "subjectAltName=IP:127.0.0.1,DNS:localhost"
+          docker compose up -d
+          for _ in $(seq 1 30); do
+            [ "$(curl -sk -o /dev/null -w '%{http_code}' \
+                 https://127.0.0.1:10000/devstoreaccount1?comp=list)" != "000" ] && break
+            sleep 1
+          done
+
+      - name: Publish to the Azure-Blob emulator over MSI
+        working-directory: test/azure-msi
+        run: sudo -E ./publish-e2e.sh
+
+      - name: Teardown
+        if: always()
+        working-directory: test/azure-msi
+        run: docker compose down -v

--- a/test/azure-msi/imds_mock.py
+++ b/test/azure-msi/imds_mock.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Fake Azure Instance Metadata Service (IMDS) token endpoint.
+
+Emulates the single call CVMFS's S3FanoutManager::RefreshAzureToken() makes:
+
+    GET http://<imds>/metadata/identity/oauth2/token
+        ?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F
+    Header: Metadata: true
+
+It returns a JSON body whose `access_token` is a JWT shaped exactly the way
+Azurite's `--oauth basic` validator expects (correct `aud` + `iss` prefix +
+future `exp`; the signature is NOT verified in basic mode, so we sign with a
+throwaway HMAC key). `access_token` and `expires_on` are returned as STRINGS,
+because CVMFS reads `expires_on` as a JSON string and feeds it to String2Uint64.
+
+Zero third-party dependencies (stdlib only) so it drops straight into CI.
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+# Values are cosmetic (basic mode ignores the signature and these claim values);
+# they only need to be structurally plausible.
+TENANT = os.environ.get("MOCK_TENANT_ID", "72f988bf-86f1-41af-91ab-2d7cd011db47")
+APP_ID = os.environ.get("MOCK_APP_ID", "11111111-2222-3333-4444-555555555555")
+OID = os.environ.get("MOCK_OBJECT_ID", "99999999-8888-7777-6666-555555555555")
+AUDIENCE = os.environ.get("MOCK_AUDIENCE", "https://storage.azure.com/")
+TOKEN_TTL = int(os.environ.get("MOCK_TOKEN_TTL", "3600"))
+
+
+def _b64url(raw: bytes) -> bytes:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+def mint_jwt() -> str:
+    """Mint a JWT that Azurite `--oauth basic` accepts (signature unchecked)."""
+    now = int(time.time())
+    header = {"alg": "HS256", "typ": "JWT", "kid": "mock-key"}
+    payload = {
+        "aud": AUDIENCE,
+        "iss": f"https://sts.windows.net/{TENANT}/",
+        "iat": now,
+        "nbf": now,
+        "exp": now + TOKEN_TTL,
+        "appid": APP_ID,
+        "tid": TENANT,
+        "oid": OID,
+        "sub": OID,
+        "ver": "1.0",
+        "xms_mirid": (
+            f"/subscriptions/{TENANT}/resourcegroups/mock/providers/"
+            "Microsoft.ManagedIdentity/userAssignedIdentities/mock"
+        ),
+    }
+    signing_input = _b64url(json.dumps(header).encode()) + b"." + \
+        _b64url(json.dumps(payload).encode())
+    sig = _b64url(hmac.new(b"mock-signing-key", signing_input,
+                           hashlib.sha256).digest())
+    return (signing_input + b"." + sig).decode()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # keep CI logs quiet-ish
+        print("[imds] " + (fmt % args))
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if not parsed.path.endswith("/oauth2/token"):
+            self.send_error(404, "not the token endpoint")
+            return
+        # Real IMDS mandates this header; enforce it so the mock is faithful.
+        if self.headers.get("Metadata", "").lower() != "true":
+            self.send_error(400, "Metadata: true header required")
+            return
+        qs = parse_qs(parsed.query)
+        now = int(time.time())
+        body = {
+            "access_token": mint_jwt(),
+            "client_id": APP_ID,
+            "expires_in": str(TOKEN_TTL),
+            "expires_on": str(now + TOKEN_TTL),      # STRING (CVMFS parses str)
+            "ext_expires_in": str(TOKEN_TTL),
+            "not_before": str(now),
+            "resource": qs.get("resource", [AUDIENCE])[0],
+            "token_type": "Bearer",
+        }
+        payload = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def main():
+    host = os.environ.get("IMDS_BIND", "127.0.0.1")
+    port = int(os.environ.get("IMDS_PORT", "8081"))
+    srv = ThreadingHTTPServer((host, port), Handler)
+    print(f"[imds] mock IMDS listening on http://{host}:{port}"
+          f"/metadata/identity/oauth2/token  (aud={AUDIENCE})")
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/test/azure-msi/publish-e2e.sh
+++ b/test/azure-msi/publish-e2e.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Real end-to-end publish test: a patched cvmfs_server publishes to the Azurite
+# Azure-Blob emulator over MSI (no Azure VM, no storage key). Run AFTER building
+# cvmfs-server from PR #4379 with s3fanout-imds-endpoint.patch applied, with the
+# emulator (docker compose up -d) already running.
+#
+# Asserts: mkfs succeeds, a transaction publishes, and the resulting
+# .cvmfspublished manifest is retrievable from the blob store (bearer read).
+set -euo pipefail
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${REPO_FQRN:-test.eessi.local}"
+BLOB="https://127.0.0.1:10000/devstoreaccount1/cvmfs"
+
+# The two knobs the patch + emulator require:
+export CVMFS_AZURE_IMDS_ENDPOINT="${CVMFS_AZURE_IMDS_ENDPOINT:-http://127.0.0.1:8081}"
+export CURL_CA_BUNDLE="${CURL_CA_BUNDLE:-$D/certs/azurite-cert.pem}"   # trust Azurite's self-signed TLS
+
+echo "== 1. mkfs (S3/azure backend, MSI auth) =="
+sudo -E cvmfs_server mkfs -w "$BLOB" -s "$D/s3.conf.template" -o "$(id -un)" "$REPO"
+
+echo "== 2. transaction + publish =="
+sudo -E cvmfs_server transaction "$REPO"
+echo "hello from the MSI CI e2e $(date -u)" | sudo tee "/cvmfs/$REPO/hello.txt" >/dev/null
+sudo -E cvmfs_server publish "$REPO"
+
+echo "== 3. assert manifest landed in blob store (bearer read) =="
+# Grab a token from the mock IMDS exactly as cvmfs does, then GET .cvmfspublished.
+TOKEN="$(curl -s -H 'Metadata: true' \
+  "$CVMFS_AZURE_IMDS_ENDPOINT/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')"
+code="$(curl -s -o /tmp/cvmfspublished -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" -H "x-ms-version: 2017-11-09" \
+  "$BLOB/.cvmfspublished")"
+echo "GET .cvmfspublished -> HTTP $code"
+test "$code" = "200"
+grep -q '^C' /tmp/cvmfspublished && echo "manifest has a root-catalog hash line (C...)"
+
+echo "== 4. server-side sanity =="
+sudo -E cvmfs_server check "$REPO"
+echo "PASS: patched cvmfs_server published to the Azure-Blob emulator over MSI."

--- a/test/azure-msi/run-local.sh
+++ b/test/azure-msi/run-local.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Local end-to-end proof: Azurite (--oauth basic) + mock IMDS accept the exact
+# request shapes CVMFS's Azure-MSI uploader emits. One foreground command; tears
+# itself down on exit. Requires: docker, python3, openssl, curl.
+set -euo pipefail
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$D"
+NAME="${AZURITE_CONTAINER_NAME:-azurite-msi}"
+IMDS_PID=""
+
+cleanup() {
+  [[ -n "$IMDS_PID" ]] && kill "$IMDS_PID" >/dev/null 2>&1 || true
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# 1. self-signed cert for Azurite HTTPS (--oauth basic requires TLS)
+if [[ ! -f certs/azurite-cert.pem ]]; then
+  mkdir -p certs
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout certs/azurite-key.pem -out certs/azurite-cert.pem -days 3650 \
+    -subj "/CN=127.0.0.1" \
+    -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" 2>/dev/null
+fi
+
+# 2. Azurite blob service, OAuth basic (validates aud/iss/exp, NOT signature)
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+docker run -d --name "$NAME" -p 10000:10000 -v "$D/certs:/certs:ro" \
+  mcr.microsoft.com/azure-storage/azurite \
+  azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --oauth basic \
+  --cert /certs/azurite-cert.pem --key /certs/azurite-key.pem \
+  --skipApiVersionCheck >/dev/null
+echo "[run] azurite started ($NAME)"
+
+# 3. mock IMDS (stdout to file so it never holds the parent's pipe)
+python3 imds_mock.py >/tmp/imds_mock.log 2>&1 &
+IMDS_PID=$!
+echo "[run] mock IMDS started (pid $IMDS_PID)"
+
+# 4. wait for readiness
+for _ in $(seq 1 30); do
+  [[ "$(curl -sk -o /dev/null -w '%{http_code}' \
+        "https://127.0.0.1:10000/devstoreaccount1?comp=list" || true)" != "000" ]] && break
+  sleep 1
+done
+for _ in $(seq 1 15); do
+  curl -sf -o /dev/null -H "Metadata: true" \
+    "http://127.0.0.1:8081/metadata/identity/oauth2/token?resource=x" && break || sleep 1
+done
+echo "[run] services ready; running verifier"
+echo "------------------------------------------------------------"
+
+# 5. the actual proof
+rc=0
+python3 verify_msi_path.py || rc=$?
+echo "------------------------------------------------------------"
+echo "[run] verifier exit code: $rc"
+exit $rc

--- a/test/azure-msi/s3.conf.template
+++ b/test/azure-msi/s3.conf.template
@@ -1,0 +1,15 @@
+# CVMFS S3 config for publishing to an Azure-Blob emulator (Azurite) over MSI.
+# Used by publish-e2e.sh. Path-style addressing (Azurite is host/account/container).
+#
+# CVMFS_S3_HOST is the Azurite endpoint host:port; CVMFS_S3_BUCKET is
+# <account>/<container>; CVMFS_S3_ACCESS_KEY is the account name. With MSI there
+# is deliberately NO CVMFS_S3_SECRET_KEY — the bearer token replaces it.
+CVMFS_S3_HOST=127.0.0.1:10000
+CVMFS_S3_ACCESS_KEY=devstoreaccount1
+CVMFS_S3_BUCKET=devstoreaccount1/cvmfs
+CVMFS_S3_FLAVOR=azure
+CVMFS_S3_DNS_BUCKETS=false
+CVMFS_S3_USE_HTTPS=true
+CVMFS_S3_AZURE_MSI=true
+# Optional: select a specific user-assigned identity
+# CVMFS_S3_AZURE_MSI_CLIENT_ID=<client-id>

--- a/test/azure-msi/s3fanout-imds-endpoint.patch
+++ b/test/azure-msi/s3fanout-imds-endpoint.patch
@@ -1,0 +1,60 @@
+From: Hugo Meiland <hugo.meiland@microsoft.com>
+Subject: [PATCH] s3: make the Azure IMDS endpoint overridable (for CI/testing)
+
+On a real Azure VM the Instance Metadata Service always lives at the link-local
+address 169.254.169.254, so RefreshAzureToken() hard-codes it. That hard-coding
+is the single thing that makes the MSI path impossible to exercise off-Azure
+(e.g. in CI against a mock IMDS + Azurite).
+
+This adds a tiny, opt-in override: if the environment variable
+CVMFS_AZURE_IMDS_ENDPOINT is set and non-empty, its value is used as the IMDS
+base URL (scheme://host[:port]); otherwise behaviour is byte-for-byte identical
+to before. The proxy-bypass (CURLOPT_NOPROXY) is derived from the same base so
+it keeps working for both the default link-local host and an override host.
+
+No functional change on a real Azure VM (the variable is unset there).
+
+Apply on top of PR #4379 (branch feature-azblob_msi):
+    git apply s3fanout-imds-endpoint.patch
+
+---
+ cvmfs/network/s3fanout.cc | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/cvmfs/network/s3fanout.cc b/cvmfs/network/s3fanout.cc
+--- a/cvmfs/network/s3fanout.cc
++++ b/cvmfs/network/s3fanout.cc
+@@ bool S3FanoutManager::RefreshAzureToken() const {
+-  string url = "http://169.254.169.254/metadata/identity/oauth2/token"
+-               "?api-version=2018-02-01"
+-               "&resource=https%3A%2F%2Fstorage.azure.com%2F";
++  // On a real Azure VM the IMDS endpoint is always the link-local address.
++  // It can be overridden via CVMFS_AZURE_IMDS_ENDPOINT (e.g. to point at a
++  // mock IMDS in CI); unset => identical behaviour to before.
++  const char *imds_env = getenv("CVMFS_AZURE_IMDS_ENDPOINT");
++  const string imds_base = (imds_env != NULL && imds_env[0] != '\0')
++                           ? string(imds_env)
++                           : string("http://169.254.169.254");
++  string url = imds_base + "/metadata/identity/oauth2/token"
++               "?api-version=2018-02-01"
++               "&resource=https%3A%2F%2Fstorage.azure.com%2F";
+   if (!config_.azure_mi_client_id.empty())
+     url += "&client_id=" + config_.azure_mi_client_id;
+ 
+   CURL *curl = curl_easy_init();
+   if (curl == NULL)
+     return false;
+@@ curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+-  curl_easy_setopt(curl, CURLOPT_NOPROXY, "169.254.169.254");
++  // Bypass any proxy for the IMDS host (default link-local, or override host).
++  string imds_host = imds_base;
++  const size_t scheme_end = imds_host.find("://");
++  if (scheme_end != string::npos)
++    imds_host = imds_host.substr(scheme_end + 3);
++  imds_host = imds_host.substr(0, imds_host.find('/'));   // strip path
++  imds_host = imds_host.substr(0, imds_host.find(':'));   // strip port
++  curl_easy_setopt(curl, CURLOPT_NOPROXY, imds_host.c_str());
+   const CURLcode res = curl_easy_perform(curl);
+-- 
+2.40.0

--- a/test/azure-msi/verify_msi_path.py
+++ b/test/azure-msi/verify_msi_path.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Standalone verifier: replays the EXACT request shape CVMFS's Azure-MSI uploader
+sends, against Azurite (`--oauth basic`) + the fake IMDS — with no CVMFS build.
+
+It proves the emulator accepts the requests produced by:
+  * S3FanoutManager::RefreshAzureToken()  -> GET IMDS token (api-version=2018-02-01,
+    resource=https://storage.azure.com/, header `Metadata: true`)
+  * S3FanoutManager::MkAzureAuthz() MSI branch -> writes carrying
+      x-ms-date, x-ms-version: 2017-11-09, Authorization: Bearer <token>,
+      x-ms-blob-type: BlockBlob
+  * PR #4395 large-blob staging -> Put Block (comp=block) + Put Block List
+    (comp=blocklist, signs x-ms-blob-content-type)
+
+Covers: create container, single-PUT block blob, large blob via Put Block /
+Put Block List, and independent read-back byte comparison. stdlib only.
+
+Exit 0 = every step behaved exactly as the real Azure endpoint would.
+"""
+import base64
+import http.client
+import json
+import os
+import ssl
+import sys
+from email.utils import formatdate
+from urllib.parse import urlparse, quote
+
+IMDS_URL = os.environ.get(
+    "CVMFS_AZURE_IMDS_ENDPOINT", "http://127.0.0.1:8081")
+IMDS_PATH = ("/metadata/identity/oauth2/token"
+             "?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F")
+AZURITE = os.environ.get("AZURITE_BLOB_ENDPOINT", "https://127.0.0.1:10000")
+ACCOUNT = os.environ.get("AZURITE_ACCOUNT", "devstoreaccount1")
+CONTAINER = os.environ.get("AZURITE_CONTAINER", "cvmfs")
+CAFILE = os.environ.get("AZURITE_CAFILE",
+                        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                     "certs", "azurite-cert.pem"))
+XMS_VERSION = "2017-11-09"   # exactly what MkAzureAuthz() emits for MSI
+
+_PASS, _FAIL = "\033[32mPASS\033[0m", "\033[31mFAIL\033[0m"
+_failures = 0
+
+
+def _report(ok: bool, label: str, detail: str = "") -> None:
+    global _failures
+    if not ok:
+        _failures += 1
+    print(f"  [{_PASS if ok else _FAIL}] {label}" + (f"  ({detail})" if detail else ""))
+
+
+def get_token() -> str:
+    u = urlparse(IMDS_URL)
+    conn = http.client.HTTPConnection(u.hostname, u.port or 80, timeout=30)
+    conn.request("GET", IMDS_PATH, headers={"Metadata": "true"})
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    assert resp.status == 200, f"IMDS returned HTTP {resp.status}: {raw[:200]!r}"
+    doc = json.loads(raw)
+    # Mirror CVMFS: both fields are strings.
+    assert isinstance(doc["access_token"], str) and isinstance(doc["expires_on"], str), \
+        "access_token/expires_on must be JSON strings (CVMFS parses them as strings)"
+    return doc["access_token"]
+
+
+def _ctx() -> ssl.SSLContext:
+    ctx = ssl.create_default_context(cafile=CAFILE)
+    return ctx
+
+
+def azurite_request(method, path, token, body=b"", extra=None):
+    u = urlparse(AZURITE)
+    conn = http.client.HTTPSConnection(u.hostname, u.port or 443,
+                                       context=_ctx(), timeout=30)
+    headers = {
+        "Authorization": "Bearer " + token,
+        "x-ms-date": formatdate(usegmt=True),
+        "x-ms-version": XMS_VERSION,
+        "Content-Length": str(len(body)),
+    }
+    if extra:
+        headers.update(extra)
+    conn.request(method, path, body=body, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    return resp.status, data
+
+
+def base(path_in_container=""):
+    p = f"/{ACCOUNT}/{CONTAINER}"
+    if path_in_container:
+        p += "/" + path_in_container
+    return p
+
+
+def main() -> int:
+    print(f"IMDS     : {IMDS_URL}")
+    print(f"Azurite  : {AZURITE}  (account={ACCOUNT}, container={CONTAINER})")
+    print(f"x-ms-version: {XMS_VERSION}   CA: {CAFILE}\n")
+
+    print("1. RefreshAzureToken() -> mock IMDS")
+    token = get_token()
+    _report(True, "fetched bearer token from IMDS", f"{len(token)} bytes, 3 JWT segments"
+            if token.count(".") == 2 else "unexpected JWT shape")
+
+    print("2. Create container (Bearer auth over Azure Blob dialect)")
+    st, data = azurite_request("PUT", base() + "?restype=container", token,
+                               extra={"x-ms-blob-type": "BlockBlob"})
+    _report(st in (201, 409), f"PUT ?restype=container -> HTTP {st}",
+            "created" if st == 201 else "already exists" if st == 409 else data[:160].decode("utf-8", "replace"))
+
+    print("3. Single-PUT block blob (MkAzureAuthz MSI headers)")
+    small = b"cvmfs-msi-emulation-smoke\n" * 32
+    st, data = azurite_request("PUT", base("small.txt"), token, body=small,
+                               extra={"x-ms-blob-type": "BlockBlob",
+                                      "Content-Type": "text/plain"})
+    _report(st == 201, f"PUT blob (x-ms-blob-type: BlockBlob) -> HTTP {st}",
+            data[:160].decode("utf-8", "replace") if st != 201 else "")
+    st, got = azurite_request("GET", base("small.txt"), token)
+    _report(st == 200 and got == small, f"GET read-back -> HTTP {st}",
+            "bytes match" if got == small else "MISMATCH")
+
+    print("4. Large blob via Put Block / Put Block List (PR #4395 path)")
+    block_sz = 1 << 20                      # 1 MiB blocks
+    big = bytes((i * 131 + 7) & 0xFF for i in range(5 * block_sz + 12345))
+    nblocks = (len(big) + block_sz - 1) // block_sz
+    block_ids = []
+    all_ok = True
+    for i in range(nblocks):
+        chunk = big[i * block_sz:(i + 1) * block_sz]
+        # Fixed-width base64 block id (unambiguous commit ordering), URL-escaped in the URL.
+        raw_id = f"block-{i:08d}".encode()
+        bid = base64.b64encode(raw_id).decode()
+        block_ids.append(bid)
+        st, data = azurite_request(
+            "PUT", base("big.bin") + f"?comp=block&blockid={quote(bid, safe='')}",
+            token, body=chunk)
+        if st != 201:
+            all_ok = False
+            _report(False, f"Put Block {i} -> HTTP {st}", data[:160].decode("utf-8", "replace"))
+            break
+    _report(all_ok, f"uploaded {nblocks} blocks via Put Block (comp=block)")
+
+    # Put Block List commit; signs/sets x-ms-blob-content-type (sorts before x-ms-date).
+    xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList>" + \
+        "".join(f"<Latest>{b}</Latest>" for b in block_ids) + "</BlockList>"
+    st, data = azurite_request(
+        "PUT", base("big.bin") + "?comp=blocklist", token, body=xml.encode(),
+        extra={"x-ms-blob-content-type": "application/octet-stream",
+               "Content-Type": "application/xml"})
+    _report(st == 201, f"Put Block List (comp=blocklist) commit -> HTTP {st}",
+            data[:160].decode("utf-8", "replace") if st != 201 else "")
+    st, got = azurite_request("GET", base("big.bin"), token)
+    _report(st == 200 and got == big,
+            f"GET large blob read-back -> HTTP {st} ({len(got)} bytes)",
+            "bytes match" if got == big else "MISMATCH")
+
+    print()
+    if _failures == 0:
+        print(f"{_PASS}: Azurite + mock IMDS accepted every CVMFS-shaped MSI request.")
+        return 0
+    print(f"{_FAIL}: {_failures} step(s) failed.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds support for authenticating the S3/Azure Blob uploader with an Azure
**Managed Identity (MSI)** bearer token instead of a shared storage account key.

Today an Azure-Blob-backed Stratum 1 must store a long-lived
`CVMFS_S3_SECRET_KEY` (the storage account key) in plaintext on disk. On any
Azure VM with an assigned managed identity, this change lets the publisher
obtain a short-lived OAuth token from the Instance Metadata Service (IMDS) and
authenticate blob writes with `Authorization: Bearer …`, so **no storage key is
required**.

This complements the existing Azure Blob SharedKey support (#2590, #3062) — the
SharedKey path is unchanged and remains the default.

## What changed

New config keys (both optional):

| Key | Meaning |
|-----|---------|
| `CVMFS_S3_AZURE_MSI` | `true` enables MSI bearer auth; implies the Azure authz method and makes `CVMFS_S3_SECRET_KEY` optional |
| `CVMFS_S3_AZURE_MSI_CLIENT_ID` | Optional client id to select a specific user-assigned identity (omit for the system-assigned identity) |

Example Stratum 1 S3 config (no secret key):

    CVMFS_S3_HOST=<account>.blob.core.windows.net
    CVMFS_S3_ACCESS_KEY=<account>
    CVMFS_S3_BUCKET=<container>
    CVMFS_S3_DNS_BUCKETS=false
    CVMFS_S3_FLAVOR=azure
    CVMFS_S3_USE_HTTPS=true
    CVMFS_S3_AZURE_MSI=true

Implementation:

- **`cvmfs/network/s3fanout.{cc,h}`**
  - `S3Config` gains `azure_msi` and `azure_mi_client_id`.
  - New `RefreshAzureToken()` fetches an OAuth token for
    `resource=https://storage.azure.com/` from IMDS
    (`169.254.169.254`, header `Metadata: true`, `NOPROXY` for the link-local
    address). The token and its `expires_on` are cached and re-minted 300 s
    before expiry; access is mutex-guarded for the multi-threaded fanout.
    Response JSON is parsed with the existing `JsonDocument`.
  - `MkAzureAuthz()` gains an MSI branch emitting `x-ms-date`,
    `x-ms-version: 2017-11-09`, `Authorization: Bearer <token>` and
    `x-ms-blob-type: BlockBlob`. The SharedKey branch is untouched.

- **`cvmfs/upload_s3.{cc,h}`**
  - Parses the two new keys; `CVMFS_S3_AZURE_MSI=true` selects the Azure authz
    method and relaxes the secret-key requirement.

No new dependencies (uses the existing libcurl and `JsonDocument`).

## Testing

Validated end-to-end on an Azure VM with a system-assigned managed identity
granted **Storage Blob Data Contributor** on the target storage account:

- Built `cvmfs` (server) from this branch; warning-clean.
- `cvmfs_swissknife upload` with an MSI-only config (no secret key) uploaded a
  blob to a real Azure Blob container; independent read-back returned the exact
  payload (HTTP 200).
- Confirmed the emitted request carries a valid identity JWT
  (`aud=https://storage.azure.com/`), `x-ms-version: 2017-11-09` and
  `x-ms-blob-type: BlockBlob`.
- Token refresh/expiry path exercised; SharedKey path regression-checked
  (unchanged behavior).

## Notes / open questions

- Token resource + `x-ms-version` are currently fixed constants; happy to make
  them configurable if preferred.
- IMDS uses libcurl directly (consistent with the existing fanout); can wrap in
  the download manager instead if that's the house style.
