### PR TITLE
rpm: remove json-devel dependency

### DIFF
--- a/packaging/rpm/cvmfs-universal.spec
+++ b/packaging/rpm/cvmfs-universal.spec
@@ -128,11 +128,6 @@ BuildRequires: pkgconfig
 BuildRequires: %{cvmfs_python_devel}
 BuildRequires: unzip
 BuildRequires: zlib-devel
-%if 0%{?suse_version}
-BuildRequires: nlohmann_json-devel
-%else
-BuildRequires: json-devel
-%endif
 BuildRequires: libarchive-devel
 # protobuf is optional: the build uses the system package when present and
 # otherwise falls back to the vendored (FetchContent) sources. protoc ships in a
@@ -261,11 +256,6 @@ BuildRequires: %{cvmfs_python_devel}
 BuildRequires: libcap-devel
 BuildRequires: help2man
 BuildRequires: unzip
-%if 0%{?suse_version}
-BuildRequires: nlohmann_json-devel
-%else
-BuildRequires: json-devel
-%endif
 BuildRequires: libarchive-devel
 BuildRequires: %{cvmfs_python_setuptools}
 %if 0%{?suse_version}


### PR DESCRIPTION
On el10 and newer, json-devel moved to epel-release. Since nlohmann-json is header-only, rather than
adding epel to the build dependencies, I think it's better to just use the vendored library.