### PR TITLE
Find the bootstrapped go compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,11 @@ endif ()
 # First check if we have golang available
 #
 if (BUILD_GATEWAY OR BUILD_DUCC OR BUILD_SNAPSHOTTER)
-  find_program(GO_COMPILER go)
+  if (NOT CVMFS_GO_DIR AND NOT "$ENV{CVMFS_GO_DIR}" STREQUAL "")
+    set (CVMFS_GO_DIR "$ENV{CVMFS_GO_DIR}")
+  endif ()
+  find_program(GO_COMPILER go
+               HINTS ${CVMFS_GO_DIR} "${EXTERNALS_INSTALL_LOCATION}/go/bin")
   if(NOT GO_COMPILER)
     message(FATAL_ERROR "go compiler not found")
   else()


### PR DESCRIPTION
This is the first pull request I've sent to CVMFS following the
discussion in #4373. Please let me know if there is anything I missed
during the process.

This applies @vvolkl's suggestion from #4373 as-is: find_program now
honors CVMFS_GO_DIR (CMake variable or environment, as exported by
ci/build_install_builddeps.sh) and falls back to
<externals install location>/go/bin, so a go bootstrapped by
ci/bootstrap_golang.sh is found in a plain `cmake; make install`
workflow.

Tested on Ubuntu 24.04 without a system go (ci/bootstrap_golang.sh,
then cmake -DBUILD_GATEWAY=ON -DBUILTIN_EXTERNALS_EXCLUDE=golang_rev2):
configure fails with "go compiler not found" before this change and
finds the bootstrapped go with it; CVMFS_GO_DIR alone also works, a go
on PATH is still found when the hints are empty, and gateway, ducc and
snapshotter all build with the located compiler. I used AI assistance
for testing and drafting; the change itself is unchanged from the
suggestion.
