### PR TITLE
Replace in house atomic operations with std::atomic

### DIFF
--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -96,9 +96,7 @@ BundleFileMgr *LoadBundleFromCvmfs(MountPoint *mp,
 }  // namespace
 
 BundleMgr::BundleMgr(MountPoint *mp)
-    : mount_point_(mp)
-    , fetcher_threads_()
-    , pool_size_(kDefaultBundlePoolSize) {
+    : mount_point_(mp), fetcher_threads_(), pool_size_(kDefaultBundlePoolSize) {
   atomic_init32(&terminating_);
   pthread_mutex_init(&worker_read_mutex_, nullptr);
 
@@ -365,7 +363,7 @@ void *BundleMgr::MainBundleMgrDispatcher(void *data) {
     const PathString path = mgr->ReceivePath(rfd);
     // While terminating, drain the queue without processing so that
     // unmounting does not wait for spec downloads
-    if (atomic_read32(&mgr->terminating_) == 0)
+    if (mgr->terminating_.load() == 0)
       mgr->ProcessTrigger(path);
   }
 
@@ -410,7 +408,7 @@ void *BundleMgr::MainBundleMgrFetcher(void *data) {
         }
         // While terminating, drain the queue without fetching so that
         // unmounting does not wait for pending downloads
-        if (atomic_read32(&mgr->terminating_) == 0)
+        if (mgr->terminating_.load() == 0)
           mgr->FetchPath(path);
       } break;
       case Command::kTerminate:
@@ -457,8 +455,7 @@ bool BundleMgr::TrySendPath(int fd, const PathString &path) const {
     return true;
   if ((n < 0) && not(errno == EAGAIN || errno == EWOULDBLOCK)) {
     LogCvmfs(kLogBundleMgr, kLogDebug,
-             "write() on the work queue failed unexpectedly (errno=%d)",
-             errno);
+             "write() on the work queue failed unexpectedly (errno=%d)", errno);
   }
   return false;
 }

--- a/cvmfs/bundle_mgr.cc
+++ b/cvmfs/bundle_mgr.cc
@@ -97,7 +97,7 @@ BundleFileMgr *LoadBundleFromCvmfs(MountPoint *mp,
 
 BundleMgr::BundleMgr(MountPoint *mp)
     : mount_point_(mp), fetcher_threads_(), pool_size_(kDefaultBundlePoolSize) {
-  atomic_init32(&terminating_);
+  terminating_.store(0);
   pthread_mutex_init(&worker_read_mutex_, nullptr);
 
   // Pool size override via CVMFS_BUNDLE_POOL_SIZE

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -51,7 +51,7 @@ class BundleMgr : SingleCopy {
  public:
   explicit BundleMgr(MountPoint *mp);
   virtual ~BundleMgr() {
-    atomic_write32(&terminating_, 1);
+    terminating_.store(1);
     JoinDispatcher();
     JoinFetcherPool();
     pthread_mutex_destroy(&worker_read_mutex_);

--- a/cvmfs/bundle_mgr.h
+++ b/cvmfs/bundle_mgr.h
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <pthread.h>
 
+#include <atomic>
 #include <cstddef>
 #include <memory>
 #include <type_traits>
@@ -17,7 +18,6 @@
 #include "file_bundle.h"
 #include "mountpoint.h"
 #include "shortstring.h"
-#include "util/atomic.h"
 #include "util/posix.h"
 #include "util/single_copy.h"
 
@@ -168,7 +168,7 @@ class BundleMgr : SingleCopy {
    * Set on destruction: queued work is drained but no longer processed, so
    * that unmounting does not wait for pending downloads.
    */
-  atomic_int32 terminating_;
+  std::atomic<int32_t> terminating_;
   bool is_valid_ = true;
 };
 #endif  // CVMFS_BUNDLE_MGR_H_

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -16,6 +16,7 @@
 #ifdef __APPLE__
 #include <cstdlib>
 #endif
+#include <atomic>
 #include <cstring>
 #include <map>
 #include <new>
@@ -24,7 +25,6 @@
 
 #include "cache.pb.h"
 #include "crypto/hash.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 #include "util/exception.h"
 #include "util/logging.h"

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -396,7 +396,7 @@ ExternalCacheManager::ExternalCacheManager(int fd_connection,
   retval = pthread_mutex_init(&lock_inflight_rpcs_, NULL);
   assert(retval == 0);
   memset(&thread_read_, 0, sizeof(thread_read_));
-  atomic_init64(&next_request_id_);
+  next_request_id_.store(0);
 }
 
 

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -402,7 +402,7 @@ ExternalCacheManager::ExternalCacheManager(int fd_connection,
 
 ExternalCacheManager::~ExternalCacheManager() {
   terminated_ = true;
-  MemoryFence();
+  std::atomic_thread_fence(std::memory_order_seq_cst);
   if (session_id_ >= 0) {
     cvmfs::MsgQuit msg_quit;
     msg_quit.set_session_id(session_id_);

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cassert>
 #include <string>
 #include <vector>
@@ -15,10 +16,9 @@
 #include "cache.h"
 #include "cache_transport.h"
 #include "crypto/hash.h"
-#include "fd_table.h"
 #include "duplex_testing.h"
+#include "fd_table.h"
 #include "quota.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 
 
@@ -313,7 +313,7 @@ class ExternalCacheManager : public CacheManager {
   bool spawned_;
   bool terminated_;
   pthread_rwlock_t rwlock_fd_table_;
-  atomic_int64 next_request_id_;
+  std::atomic<int64_t> next_request_id_;
 
   /**
    * Serialize concurrent write access to the session fd

--- a/cvmfs/cache_extern.h
+++ b/cvmfs/cache_extern.h
@@ -298,7 +298,7 @@ class ExternalCacheManager : public CacheManager {
   static bool SpawnPlugin(const std::vector<std::string> &cmd_line);
 
   explicit ExternalCacheManager(int fd_connection, unsigned max_open_fds);
-  int64_t NextRequestId() { return atomic_xadd64(&next_request_id_, 1); }
+  int64_t NextRequestId() { return next_request_id_.fetch_add(1); }
   void CallRemotely(RpcJob *rpc_job);
   int ChangeRefcount(const shash::Any &id, int change_by);
   int DoOpen(const shash::Any &id);

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -178,7 +178,7 @@ CachePlugin::CachePlugin(uint64_t capabilities)
   next_txn_id_.store(0);
   next_lst_id_.store(0);
   // Don't use listing id zero
-  atomic_inc64(&next_lst_id_);
+  next_lst_id_.fetch_add(1);
   txn_ids_.Init(128, UniqueRequest(), HashUniqueRequest);
   memset(&thread_io_, 0, sizeof(thread_io_));
   MakePipe(pipe_ctrl_);

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -877,7 +877,8 @@ void CachePlugin::ProcessRequests(unsigned num_workers) {
                                     this);
   assert(retval == 0);
   NotifySupervisor(CacheTransport::kReadyNotification);
-  atomic_cas32(&running_, 0, 1);
+  int32_t expected_val = 0;
+  running_.compare_exchange_strong(expected_val, 1);
 }
 
 
@@ -900,7 +901,8 @@ void CachePlugin::Terminate() {
     char terminate = kSignalTerminate;
     WritePipe(pipe_ctrl_[1], &terminate, 1);
     pthread_join(thread_io_, NULL);
-    atomic_cas32(&running_, 1, 0);
+    int32_t expected_val = 1;
+    running_.compare_exchange_strong(expected_val, 0);
   }
 }
 

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -174,9 +174,9 @@ CachePlugin::CachePlugin(uint64_t capabilities)
     , num_workers_(0)
     , max_object_size_(kDefaultMaxObjectSize)
     , num_inlimbo_clients_(0) {
-  atomic_init64(&next_session_id_);
-  atomic_init64(&next_txn_id_);
-  atomic_init64(&next_lst_id_);
+  next_session_id_.store(0);
+  next_txn_id_.store(0);
+  next_lst_id_.store(0);
   // Don't use listing id zero
   atomic_inc64(&next_lst_id_);
   txn_ids_.Init(128, UniqueRequest(), HashUniqueRequest);

--- a/cvmfs/cache_plugin/channel.cc
+++ b/cvmfs/cache_plugin/channel.cc
@@ -674,7 +674,7 @@ void CachePlugin::HandleStore(cvmfs::MsgStoreReq *msg_req,
 }
 
 
-bool CachePlugin::IsRunning() { return atomic_read32(&running_) != 0; }
+bool CachePlugin::IsRunning() { return running_.load() != 0; }
 
 
 bool CachePlugin::Listen(const string &locator) {

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -199,11 +199,9 @@ class CachePlugin {
 
   static void *MainProcessRequests(void *data);
 
-  inline uint64_t NextSessionId() {
-    return atomic_xadd64(&next_session_id_, 1);
-  }
-  inline uint64_t NextTxnId() { return atomic_xadd64(&next_txn_id_, 1); }
-  inline uint64_t NextLstId() { return atomic_xadd64(&next_lst_id_, 1); }
+  inline uint64_t NextSessionId() { return next_session_id_.fetch_add(1); }
+  inline uint64_t NextTxnId() { return next_txn_id_.fetch_add(1); }
+  inline uint64_t NextLstId() { return next_lst_id_.fetch_add(1); }
   static inline uint32_t HashUniqueRequest(const UniqueRequest &req) {
     return MurmurHash2(&req, sizeof(req), 0x07387a4f);
   }

--- a/cvmfs/cache_plugin/channel.h
+++ b/cvmfs/cache_plugin/channel.h
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <cassert>
 #include <map>
 #include <set>
@@ -18,7 +19,6 @@
 #include "crypto/hash.h"
 #include "manifest.h"
 #include "smallhash.h"
-#include "util/atomic.h"
 #include "util/murmur.hxx"
 #include "util/single_copy.h"
 
@@ -241,7 +241,7 @@ class CachePlugin {
   uint64_t capabilities_;
   int fd_socket_;
   int fd_socket_lock_;
-  atomic_int32 running_;
+  std::atomic<int32_t> running_;
   unsigned num_workers_;
   unsigned max_object_size_;
   /**
@@ -250,9 +250,9 @@ class CachePlugin {
    */
   uint64_t num_inlimbo_clients_;
   std::string name_;
-  atomic_int64 next_session_id_;
-  atomic_int64 next_txn_id_;
-  atomic_int64 next_lst_id_;
+  std::atomic<int64_t> next_session_id_;
+  std::atomic<int64_t> next_txn_id_;
+  std::atomic<int64_t> next_lst_id_;
   SmallHashDynamic<UniqueRequest, uint64_t> txn_ids_;
   std::set<int> connections_;
   std::map<uint64_t, SessionInfo> sessions_;

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -472,7 +472,7 @@ int main(int argc, char **argv) {
   if (!cvmcache_is_supervised()) {
     LogCvmfs(kLogCache, kLogStdout,
              "Running unsupervised. Quit by SIGINT (CTRL+C)");
-    atomic_init32(&g_terminated);
+    g_terminated.store(0);
     signal(SIGINT, handle_sigint);
     while (g_terminated.load() == 0)
       sleep(1);

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -8,13 +8,13 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <atomic>
 #include <cstring>
 #include <string>
 
 #include "cache_plugin/libcvmfs_cache.h"
 #include "cache_posix.h"
 #include "smallhash.h"
-#include "util/atomic.h"
 #include "util/logging.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -158,7 +158,7 @@ SmallHashDynamic<uint64_t, Txn> *g_transactions;
 SmallHashDynamic<uint64_t, Listing> *g_listings;
 PosixCacheManager *g_cache_mgr;
 cvmcache_context *g_ctx;
-atomic_int32 g_terminated;
+std::atomic<int32_t> g_terminated;
 uint64_t g_pinned_size;
 uint64_t g_used_size;
 uint64_t g_capacity;

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -344,7 +344,7 @@ int posix_breadcrumb_load(const char *fqrn, cvmcache_breadcrumb *breadcrumb) {
 
 void handle_sigint(int sig) {
   cvmcache_terminate(g_ctx);
-  atomic_inc32(&g_terminated);
+  g_terminated.fetch_add(1);
 }
 
 }  // namespace

--- a/cvmfs/cache_plugin/cvmfs_cache_posix.cc
+++ b/cvmfs/cache_plugin/cvmfs_cache_posix.cc
@@ -474,7 +474,7 @@ int main(int argc, char **argv) {
              "Running unsupervised. Quit by SIGINT (CTRL+C)");
     atomic_init32(&g_terminated);
     signal(SIGINT, handle_sigint);
-    while (atomic_read32(&g_terminated) == 0)
+    while (g_terminated.load() == 0)
       sleep(1);
   }
 

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -73,7 +73,7 @@ class CallGuard {
     const int32_t global_drainout = global_drainout_.load();
     drainout_ = (global_drainout != 0);
     if (!drainout_)
-      atomic_inc32(&num_inflight_calls_);
+      num_inflight_calls_.fetch_add(1);
   }
   ~CallGuard() {
     if (!drainout_)
@@ -560,7 +560,7 @@ int PosixCacheManager::StartTxn(const shash::Any &id,
   if (!EnsureCacheDirectories())
     return -EIO;
 
-  atomic_inc32(&no_inflight_txns_);
+  no_inflight_txns_.fetch_add(1);
   if (cache_mode_ == kCacheReadOnly) {
     atomic_dec32(&no_inflight_txns_);
     return -EROFS;

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -70,7 +70,7 @@ namespace {
 class CallGuard {
  public:
   CallGuard() {
-    const int32_t global_drainout = atomic_read32(&global_drainout_);
+    const int32_t global_drainout = global_drainout_.load();
     drainout_ = (global_drainout != 0);
     if (!drainout_)
       atomic_inc32(&num_inflight_calls_);
@@ -81,7 +81,7 @@ class CallGuard {
   }
   static void Drainout() {
     atomic_cas32(&global_drainout_, 0, 1);
-    while (atomic_read32(&num_inflight_calls_) != 0)
+    while (num_inflight_calls_.load() != 0)
       SafeSleepMs(50);
   }
 
@@ -245,11 +245,11 @@ bool PosixCacheManager::InitCacheDirectory(const string &cache_path) {
  * been validated and content is about to be stored (see #4217).
  */
 bool PosixCacheManager::EnsureCacheDirectories() {
-  if (atomic_read32(&cache_dirs_created_))
+  if (cache_dirs_created_.load())
     return true;
 
   const MutexLockGuard guard(lock_cache_dirs_);
-  if (atomic_read32(&cache_dirs_created_))
+  if (cache_dirs_created_.load())
     return true;
 
   const mode_t mode = alien_cache_ ? 0770 : 0700;
@@ -640,7 +640,7 @@ bool PosixCacheManager::StoreBreadcrumb(std::string fqrn,
 
 void PosixCacheManager::TearDown2ReadOnly() {
   cache_mode_ = kCacheReadOnly;
-  while (atomic_read32(&no_inflight_txns_) != 0)
+  while (no_inflight_txns_.load() != 0)
     SafeSleepMs(50);
 
   QuotaManager *old_manager = quota_mgr_;

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -80,7 +80,8 @@ class CallGuard {
       num_inflight_calls_.fetch_sub(1);
   }
   static void Drainout() {
-    atomic_cas32(&global_drainout_, 0, 1);
+    int32_t expected_val = 0;
+    global_drainout_.compare_exchange_strong(expected_val, 1);
     while (num_inflight_calls_.load() != 0)
       SafeSleepMs(50);
   }

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -77,7 +77,7 @@ class CallGuard {
   }
   ~CallGuard() {
     if (!drainout_)
-      atomic_dec32(&num_inflight_calls_);
+      num_inflight_calls_.fetch_sub(1);
   }
   static void Drainout() {
     atomic_cas32(&global_drainout_, 0, 1);
@@ -108,7 +108,7 @@ int PosixCacheManager::AbortTxn(void *txn) {
   close(transaction->fd);
   const int result = unlink(transaction->tmp_path.c_str());
   transaction->~Transaction();
-  atomic_dec32(&no_inflight_txns_);
+  no_inflight_txns_.fetch_sub(1);
   if (result == -1)
     return -errno;
   return 0;
@@ -148,7 +148,7 @@ int PosixCacheManager::CommitTxn(void *txn) {
   if (result < 0) {
     unlink(transaction->tmp_path.c_str());
     transaction->~Transaction();
-    atomic_dec32(&no_inflight_txns_);
+    no_inflight_txns_.fetch_sub(1);
     return result;
   }
 
@@ -166,7 +166,7 @@ int PosixCacheManager::CommitTxn(void *txn) {
                     cache_path_ + "/quarantaine/" + transaction->id.ToString());
       unlink(transaction->tmp_path.c_str());
       transaction->~Transaction();
-      atomic_dec32(&no_inflight_txns_);
+      no_inflight_txns_.fetch_sub(1);
       return -EIO;
     }
   }
@@ -181,7 +181,7 @@ int PosixCacheManager::CommitTxn(void *txn) {
                transaction->id.ToString().c_str());
       unlink(transaction->tmp_path.c_str());
       transaction->~Transaction();
-      atomic_dec32(&no_inflight_txns_);
+      no_inflight_txns_.fetch_sub(1);
       return -ENOSPC;
     }
   }
@@ -212,7 +212,7 @@ int PosixCacheManager::CommitTxn(void *txn) {
     }
   }
   transaction->~Transaction();
-  atomic_dec32(&no_inflight_txns_);
+  no_inflight_txns_.fetch_sub(1);
   return result;
 }
 
@@ -562,7 +562,7 @@ int PosixCacheManager::StartTxn(const shash::Any &id,
 
   no_inflight_txns_.fetch_add(1);
   if (cache_mode_ == kCacheReadOnly) {
-    atomic_dec32(&no_inflight_txns_);
+    no_inflight_txns_.fetch_sub(1);
     return -EROFS;
   }
 
@@ -572,7 +572,7 @@ int PosixCacheManager::StartTxn(const shash::Any &id,
                "file too big for lru cache (%" PRIu64 " "
                "requested but only %" PRIu64 " bytes free)",
                size, quota_mgr_->GetMaxFileSize());
-      atomic_dec32(&no_inflight_txns_);
+      no_inflight_txns_.fetch_sub(1);
       return -ENOSPC;
     }
 
@@ -609,7 +609,7 @@ int PosixCacheManager::StartTxn(const shash::Any &id,
   transaction->fd = mkstemp(template_path);
   if (transaction->fd == -1) {
     transaction->~Transaction();
-    atomic_dec32(&no_inflight_txns_);
+    no_inflight_txns_.fetch_sub(1);
     return -errno;
   }
 

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -39,15 +39,16 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
 #include "crypto/hash.h"
 #include "manifest.h"
 #include "manifest_fetch.h"
 #include "quota.h"
-#include "util/atomic.h"
 #include "util/logging.h"
 #include "util/mutex.h"
 #include "util/platform.h"
@@ -86,11 +87,11 @@ class CallGuard {
 
  private:
   bool drainout_;
-  static atomic_int32 global_drainout_;
-  static atomic_int32 num_inflight_calls_;
+  static std::atomic<int32_t> global_drainout_;
+  static std::atomic<int32_t> num_inflight_calls_;
 };
-atomic_int32 CallGuard::num_inflight_calls_ = 0;
-atomic_int32 CallGuard::global_drainout_ = 0;
+std::atomic<int32_t> CallGuard::num_inflight_calls_ = 0;
+std::atomic<int32_t> CallGuard::global_drainout_ = 0;
 
 }  // anonymous namespace
 
@@ -682,4 +683,3 @@ int64_t PosixCacheManager::Write(const void *buf, uint64_t size, void *txn) {
   transaction->size += written;
   return written;
 }
-

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -291,7 +291,7 @@ bool PosixCacheManager::EnsureCacheDirectories() {
     }
   }
 
-  atomic_write32(&cache_dirs_created_, 1);
+  cache_dirs_created_.store(1);
   return true;
 }
 

--- a/cvmfs/cache_posix.cc
+++ b/cvmfs/cache_posix.cc
@@ -91,8 +91,8 @@ class CallGuard {
   static std::atomic<int32_t> global_drainout_;
   static std::atomic<int32_t> num_inflight_calls_;
 };
-std::atomic<int32_t> CallGuard::num_inflight_calls_ = 0;
-std::atomic<int32_t> CallGuard::global_drainout_ = 0;
+std::atomic<int32_t> CallGuard::num_inflight_calls_(0);
+std::atomic<int32_t> CallGuard::global_drainout_(0);
 
 }  // anonymous namespace
 
@@ -684,3 +684,4 @@ int64_t PosixCacheManager::Write(const void *buf, uint64_t size, void *txn) {
   transaction->size += written;
   return written;
 }
+ 

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -9,14 +9,14 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <string>
 
 #include "cache.h"
-#include "util/pointer.h"
 #include "duplex_testing.h"
 #include "fd_refcount_mgr.h"
 #include "manifest_fetch.h"
-#include "util/atomic.h"
+#include "util/pointer.h"
 
 namespace catalog {
 class DirectoryEntry;
@@ -175,7 +175,7 @@ class PosixCacheManager : public CacheManager {
    * descriptors from transactions are closed.  This is indicated by a zero
    * value in this variable.
    */
-  atomic_int32 no_inflight_txns_;
+  std::atomic<int32_t> no_inflight_txns_;
 
   static const char kMagicRefcount = 123;
   static const char kMagicNoRefcount = '\0';
@@ -198,12 +198,12 @@ class PosixCacheManager : public CacheManager {
    */
   bool is_tmpfs_;
   /**
-   * Set to 1 by EnsureCacheDirectories() once the on-disk cache skeleton exists.
-   * For alien caches the skeleton is created lazily on the first write, so this
-   * starts at 0 and the flag is checked (lock-free) on every StartTxn().  See
-   * issue #4217.
+   * Set to 1 by EnsureCacheDirectories() once the on-disk cache skeleton
+   * exists. For alien caches the skeleton is created lazily on the first write,
+   * so this starts at 0 and the flag is checked (lock-free) on every
+   * StartTxn().  See issue #4217.
    */
-  atomic_int32 cache_dirs_created_;
+  std::atomic<int32_t> cache_dirs_created_;
   /**
    * Serializes the one-time skeleton creation in EnsureCacheDirectories().
    */
@@ -218,4 +218,3 @@ class PosixCacheManager : public CacheManager {
 };  // class PosixCacheManager
 
 #endif  // CVMFS_CACHE_POSIX_H_
-

--- a/cvmfs/cache_posix.h
+++ b/cvmfs/cache_posix.h
@@ -154,8 +154,8 @@ class PosixCacheManager : public CacheManager {
       , do_refcount_(do_refcount)
       , fd_mgr_(new FdRefcountMgr())
       , cleanup_unused_first_(cleanup_unused_first) {
-    atomic_init32(&no_inflight_txns_);
-    atomic_init32(&cache_dirs_created_);
+    no_inflight_txns_.store(0);
+    cache_dirs_created_.store(0);
     pthread_mutex_init(&lock_cache_dirs_, NULL);
   }
 

--- a/cvmfs/catalog_mgr.h
+++ b/cvmfs/catalog_mgr.h
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 #include <pthread.h>
 
+#include <atomic>
 #include <cassert>
 #include <map>
 #include <string>
@@ -20,7 +21,6 @@
 #include "manifest_fetch.h"
 #include "statistics.h"
 #include "util/algorithm.h"
-#include "util/atomic.h"
 #include "util/logging.h"
 #include "util/platform.h"
 
@@ -535,4 +535,3 @@ class InodeNfsGenerationAnnotation : public InodeAnnotation {
 #include "catalog_mgr_impl.h"
 
 #endif  // CVMFS_CATALOG_MGR_H_
-

--- a/cvmfs/catalog_rw.cc
+++ b/cvmfs/catalog_rw.cc
@@ -39,7 +39,7 @@ WritableCatalog::WritableCatalog(const string &path,
     , sql_max_link_id_(NULL)
     , sql_inc_linkcount_(NULL)
     , dirty_(false) {
-  atomic_init32(&dirty_children_);
+  dirty_children_.store(0);
 }
 
 

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -134,9 +134,7 @@ class WritableCatalog : public Catalog {
   }
 
   int dirty_children() const { return dirty_children_.load(); }
-  void set_dirty_children(const int count) {
-    atomic_write32(&dirty_children_, count);
-  }
+  void set_dirty_children(const int count) { dirty_children_.store(count); }
   int DecrementDirtyChildren() {
     return atomic_xadd32(&dirty_children_, -1) - 1;
   }

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -157,7 +157,7 @@ class WritableCatalog : public Catalog {
   DeltaCounters delta_counters_;
 
   // parallel commit state
-  mutable atomic_int32 dirty_children_;
+  mutable std::atomic<int32_t> dirty_children_;
 
   inline void SetDirty() {
     if (!dirty_)

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -133,7 +133,7 @@ class WritableCatalog : public Catalog {
     return static_cast<WritableCatalog *>(parent);
   }
 
-  int dirty_children() const { return atomic_read32(&dirty_children_); }
+  int dirty_children() const { return dirty_children_.load(); }
   void set_dirty_children(const int count) {
     atomic_write32(&dirty_children_, count);
   }

--- a/cvmfs/catalog_rw.h
+++ b/cvmfs/catalog_rw.h
@@ -135,9 +135,7 @@ class WritableCatalog : public Catalog {
 
   int dirty_children() const { return dirty_children_.load(); }
   void set_dirty_children(const int count) { dirty_children_.store(count); }
-  int DecrementDirtyChildren() {
-    return atomic_xadd32(&dirty_children_, -1) - 1;
-  }
+  int DecrementDirtyChildren() { return dirty_children_.fetch_add(-1) - 1; }
 
  private:
   SqlDirentInsert *sql_insert_;

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -240,7 +240,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
 
   void ProcessJobPre(CatalogJob *job) {
     if (!this->PrepareCatalog(job)) {
-      atomic_inc32(&num_errors_);
+      num_errors_.fetch_add(1);
       NotifyFinished();
       return;
     }
@@ -264,7 +264,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
         atomic_write32(&job->children_unprocessed, num_children);
       }
       if (!this->CloseCatalog(false, job)) {
-        atomic_inc32(&num_errors_);
+        num_errors_.fetch_add(1);
         NotifyFinished();
       }
     }
@@ -353,7 +353,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
     // Save time by keeping catalog open when suitable
     if (job->catalog == NULL) {
       if (!this->ReopenCatalog(job)) {
-        atomic_inc32(&num_errors_);
+        num_errors_.fetch_add(1);
         NotifyFinished();
         return;
       }
@@ -366,7 +366,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
     }
     if (!this->no_close_) {
       if (!this->CloseCatalog(true, job)) {
-        atomic_inc32(&num_errors_);
+        num_errors_.fetch_add(1);
         NotifyFinished();
         return;
       }

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -393,7 +393,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
 
   void OnChildFinished(const int &a, CatalogJob *job) {
     // atomic_xadd32 returns value before subtraction -> needs to equal 1
-    if (atomic_xadd32(&job->children_unprocessed, -1) == 1) {
+    if (job->children_unprocessed.fetch_add(-1) == 1) {
       post_job_queue_.EnqueueFront(job);
     }
   }

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -189,7 +189,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
     }
     free(threads_process_);
 
-    if (atomic_read32(&num_errors_))
+    if (num_errors_.load())
       return false;
 
     assert(catalogs_processing_.size() == 0);

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -5,12 +5,12 @@
 #ifndef CVMFS_CATALOG_TRAVERSAL_PARALLEL_H_
 #define CVMFS_CATALOG_TRAVERSAL_PARALLEL_H_
 
+#include <atomic>
 #include <stack>
 #include <string>
 #include <vector>
 
 #include "catalog_traversal.h"
-#include "util/atomic.h"
 #include "util/exception.h"
 #include "util/tube.h"
 
@@ -69,7 +69,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
 
     void WakeParents() { this->NotifyListeners(0); }
 
-    atomic_int32 children_unprocessed;
+    std::atomic<int32_t> children_unprocessed;
   };
 
  public:
@@ -177,8 +177,8 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
     threads_process_ = reinterpret_cast<pthread_t *>(
         smalloc(sizeof(pthread_t) * num_threads_));
     for (unsigned int i = 0; i < num_threads_; ++i) {
-      int const retval = pthread_create(&threads_process_[i], NULL, MainProcessQueue,
-                                  this);
+      int const retval = pthread_create(&threads_process_[i], NULL,
+                                        MainProcessQueue, this);
       if (retval != 0)
         PANIC(kLogStderr, "failed to create thread");
     }
@@ -248,7 +248,8 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
       FinalizeJob(job);
       return;
     }
-    NestedCatalogList const catalog_list = job->catalog->ListOwnNestedCatalogs();
+    NestedCatalogList const catalog_list = job->catalog
+                                               ->ListOwnNestedCatalogs();
     unsigned int num_children;
     // Ensure that pushed children won't call ProcessJobPost on this job
     // before this function finishes
@@ -405,7 +406,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
   TraversalType effective_traversal_type_;
 
   pthread_t *threads_process_;
-  atomic_int32 num_errors_;
+  std::atomic<int32_t> num_errors_;
 
   Tube<CatalogJob> pre_job_queue_;
   Tube<CatalogJob> post_job_queue_;

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -261,7 +261,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
       } else {
         num_children = PushNestedCatalogs(job, catalog_list)
                        + PushPreviousRevision(job);
-        atomic_write32(&job->children_unprocessed, num_children);
+        job->children_unprocessed.store(num_children);
       }
       if (!this->CloseCatalog(false, job)) {
         num_errors_.fetch_add(1);

--- a/cvmfs/catalog_traversal_parallel.h
+++ b/cvmfs/catalog_traversal_parallel.h
@@ -43,7 +43,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
       : CatalogTraversalBase<ObjectFetcherT>(params)
       , num_threads_(params.num_threads)
       , serialize_callbacks_(params.serialize_callbacks) {
-    atomic_init32(&num_errors_);
+    num_errors_.store(0);
     shash::Any null_hash;
     null_hash.SetNull();
     catalogs_processing_.Init(1024, null_hash, hasher);
@@ -64,7 +64,7 @@ class CatalogTraversalParallel : public CatalogTraversalBase<ObjectFetcherT> {
                         CatalogTN *parent = NULL)
         : CatalogTraversal<ObjectFetcherT>::CatalogJob(path, hash, tree_level,
                                                        history_depth, parent) {
-      atomic_init32(&children_unprocessed);
+      children_unprocessed.store(0);
     }
 
     void WakeParents() { this->NotifyListeners(0); }

--- a/cvmfs/compat.h
+++ b/cvmfs/compat.h
@@ -536,8 +536,8 @@ class InodeTracker {
       assert(found);
     }
     // Unlock();
-    // if (found) atomic_inc64(&statistics_.num_hits_path);
-    // else atomic_inc64(&statistics_.num_misses_path);
+    // if (found) statistics_.num_hits_path.fetch_add(1);
+    // else statistics_.num_misses_path.fetch_add(1);
     return found;
   }
 
@@ -740,8 +740,8 @@ class InodeTracker {
       assert(found);
     }
     // Unlock();
-    // if (found) atomic_inc64(&statistics_.num_hits_path);
-    // else atomic_inc64(&statistics_.num_misses_path);
+    // if (found) statistics_.num_hits_path.fetch_add(1);
+    // else statistics_.num_misses_path.fetch_add(1);
     return found;
   }
 

--- a/cvmfs/compat.h
+++ b/cvmfs/compat.h
@@ -268,7 +268,7 @@ class InodeTracker {
     std::atomic<int64_t> num_ancient_hits;
     std::atomic<int64_t> num_ancient_misses;
   };
-  Statistics GetStatistics() { return statistics_; }
+  const Statistics &GetStatistics() { return statistics_; }
 
   InodeTracker() { assert(false); }
   explicit InodeTracker(const InodeTracker &other) { assert(false); }
@@ -923,3 +923,4 @@ void Migrate(ChunkTables *old_tables, ::ChunkTables *new_tables);
 }  // namespace compat
 
 #endif  // CVMFS_COMPAT_H_
+

--- a/cvmfs/compat.h
+++ b/cvmfs/compat.h
@@ -11,6 +11,7 @@
 #include <sched.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <cassert>
 #include <google/sparse_hash_map>
 #include <string>
@@ -22,7 +23,6 @@
 #include "glue_buffer.h"
 #include "shortstring.h"
 #include "util/algorithm.h"
-#include "util/atomic.h"
 
 namespace compat {
 
@@ -260,13 +260,13 @@ class InodeTracker {
       assert(false);
       return "";
     }
-    atomic_int64 num_inserts;
-    atomic_int64 num_dangling_try;
-    atomic_int64 num_double_add;
-    atomic_int64 num_removes;
-    atomic_int64 num_references;
-    atomic_int64 num_ancient_hits;
-    atomic_int64 num_ancient_misses;
+    std::atomic<int64_t> num_inserts;
+    std::atomic<int64_t> num_dangling_try;
+    std::atomic<int64_t> num_double_add;
+    std::atomic<int64_t> num_removes;
+    std::atomic<int64_t> num_references;
+    std::atomic<int64_t> num_ancient_hits;
+    std::atomic<int64_t> num_ancient_misses;
   };
   Statistics GetStatistics() { return statistics_; }
 
@@ -505,12 +505,12 @@ class InodeTracker {
   struct Statistics {
     Statistics() { assert(false); }
     std::string Print() { assert(false); }
-    atomic_int64 num_inserts;
-    atomic_int64 num_removes;
-    atomic_int64 num_references;
-    atomic_int64 num_hits_inode;
-    atomic_int64 num_hits_path;
-    atomic_int64 num_misses_path;
+    std::atomic<int64_t> num_inserts;
+    std::atomic<int64_t> num_removes;
+    std::atomic<int64_t> num_references;
+    std::atomic<int64_t> num_hits_inode;
+    std::atomic<int64_t> num_hits_path;
+    std::atomic<int64_t> num_misses_path;
   };
   Statistics GetStatistics() { assert(false); }
 
@@ -709,12 +709,12 @@ class InodeTracker {
   struct Statistics {
     Statistics() { assert(false); }
     std::string Print() { assert(false); }
-    atomic_int64 num_inserts;
-    atomic_int64 num_removes;
-    atomic_int64 num_references;
-    atomic_int64 num_hits_inode;
-    atomic_int64 num_hits_path;
-    atomic_int64 num_misses_path;
+    std::atomic<int64_t> num_inserts;
+    std::atomic<int64_t> num_removes;
+    std::atomic<int64_t> num_references;
+    std::atomic<int64_t> num_hits_inode;
+    std::atomic<int64_t> num_hits_path;
+    std::atomic<int64_t> num_misses_path;
   };
   Statistics GetStatistics() { assert(false); }
 

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -24,7 +25,6 @@
 
 #include "compression/compression.h"
 #include "crypto/hash.h"
-#include "util/atomic.h"
 #include "util/logging.h"
 #include "util/platform.h"
 #include "util/posix.h"
@@ -42,11 +42,11 @@ enum Errors {
 };
 
 string *g_cache_dir;
-atomic_int32 g_num_files;
-atomic_int32 g_num_err_fixed;
-atomic_int32 g_num_err_unfixed;
-atomic_int32 g_num_err_operational;
-atomic_int32 g_num_tmp_catalog;
+std::atomic<int32_t> g_num_files;
+std::atomic<int32_t> g_num_err_fixed;
+std::atomic<int32_t> g_num_err_unfixed;
+std::atomic<int32_t> g_num_err_operational;
+std::atomic<int32_t> g_num_tmp_catalog;
 /**
  * Traversal of the file system tree is serialized.
  */
@@ -58,8 +58,8 @@ string *g_current_dir; /**< Current cache sub directory */
 int g_num_threads = 1;
 bool g_fix_errors = false;
 bool g_verbose = false;
-atomic_int32 g_force_rebuild;
-atomic_int32 g_modified_cache;
+std::atomic<int32_t> g_force_rebuild;
+std::atomic<int32_t> g_modified_cache;
 
 
 static void Usage() {

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -150,15 +150,15 @@ static void *MainCheck(void *data __attribute__((unused))) {
     if (relative_path[relative_path.length() - 1] == 'T') {
       LogCvmfs(kLogCvmfs, kLogStdout,
                "Warning: temporary file catalog %s found", path.c_str());
-      atomic_inc32(&g_num_tmp_catalog);
+      g_num_tmp_catalog.fetch_add(1);
       if (g_fix_errors) {
         if (unlink(relative_path.c_str()) == 0) {
           LogCvmfs(kLogCvmfs, kLogStdout, "Fix: %s unlinked", path.c_str());
-          atomic_inc32(&g_num_err_fixed);
+          g_num_err_fixed.fetch_add(1);
         } else {
           LogCvmfs(kLogCvmfs, kLogStdout, "Error: failed to unlink %s",
                    path.c_str());
-          atomic_inc32(&g_num_err_unfixed);
+          g_num_err_unfixed.fetch_add(1);
         }
       }
       continue;
@@ -167,7 +167,7 @@ static void *MainCheck(void *data __attribute__((unused))) {
     const int fd_src = open(relative_path.c_str(), O_RDONLY);
     if (fd_src < 0) {
       LogCvmfs(kLogCvmfs, kLogStdout, "Error: cannot open %s", path.c_str());
-      atomic_inc32(&g_num_err_operational);
+      g_num_err_operational.fetch_add(1);
       continue;
     }
     // Don't thrash kernel buffers
@@ -180,14 +180,14 @@ static void *MainCheck(void *data __attribute__((unused))) {
     if (!zlib::CompressFd2Null(fd_src, &hash)) {
       LogCvmfs(kLogCvmfs, kLogStdout, "Error: could not compress %s",
                path.c_str());
-      atomic_inc32(&g_num_err_operational);
+      g_num_err_operational.fetch_add(1);
     } else {
       if (hash != expected_hash) {
         // If the hashes don't match, try hashing the uncompressed file
         if (!shash::HashFile(relative_path, &hash)) {
           LogCvmfs(kLogCvmfs, kLogStdout, "Error: could not hash %s",
                    path.c_str());
-          atomic_inc32(&g_num_err_operational);
+          g_num_err_operational.fetch_add(1);
         }
         if (hash != expected_hash) {
           if (g_fix_errors) {
@@ -214,20 +214,20 @@ static void *MainCheck(void *data __attribute__((unused))) {
             }
 
             if (fixed) {
-              atomic_inc32(&g_num_err_fixed);
+              g_num_err_fixed.fetch_add(1);
 
               // Changes made, we have to rebuild the managed cache db
               atomic_cas32(&g_force_rebuild, 0, 1);
               atomic_cas32(&g_modified_cache, 0, 1);
             } else {
-              atomic_inc32(&g_num_err_unfixed);
+              g_num_err_unfixed.fetch_add(1);
             }
           } else {
             LogCvmfs(kLogCvmfs, kLogStdout,
                      "Error: %s has compressed checksum %s, "
                      "delete this file from cache directory!",
                      path.c_str(), hash.ToString().c_str());
-            atomic_inc32(&g_num_err_unfixed);
+            g_num_err_unfixed.fetch_add(1);
           }
         }
       }
@@ -344,12 +344,12 @@ int main(int argc, char **argv) {
     if (unlink("cachedb") == 0) {
       LogCvmfs(kLogCvmfs, kLogStdout,
                "Fix: managed cache db unlinked, will be rebuilt on next mount");
-      atomic_inc32(&g_num_err_fixed);
+      g_num_err_fixed.fetch_add(1);
     } else {
       if (errno != ENOENT) {
         LogCvmfs(kLogCvmfs, kLogStdout,
                  "Error: could not unlink managed cache database (%d)", errno);
-        atomic_inc32(&g_num_err_unfixed);
+        g_num_err_unfixed.fetch_add(1);
       }
     }
   }

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -219,7 +219,7 @@ static void *MainCheck(void *data __attribute__((unused))) {
               // Changes made, we have to rebuild the managed cache db
               int32_t expected_val = 0;
               g_force_rebuild.compare_exchange_strong(expected_val, 1);
-              int32_t expected_val = 0;
+              expected_val = 0;
               g_modified_cache.compare_exchange_strong(expected_val, 1);
             } else {
               g_num_err_unfixed.fetch_add(1);
@@ -258,10 +258,10 @@ int main(int argc, char **argv) {
       case 'p':
         g_fix_errors = true;
         break;
-      case 'f':
+      case 'f': {
         int32_t expected_val = 0;
         g_force_rebuild.compare_exchange_strong(expected_val, 1);
-        break;
+      } break;
       case 'j':
         g_num_threads = atoi(optarg);
         if (g_num_threads < 1) {
@@ -375,3 +375,4 @@ int main(int argc, char **argv) {
 
   return retval;
 }
+

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -141,7 +141,7 @@ static void *MainCheck(void *data __attribute__((unused))) {
   while (GetNextFile(&relative_path, &hash_name)) {
     const string path = *g_cache_dir + "/" + relative_path;
 
-    const int n = atomic_xadd32(&g_num_files, 1);
+    const int n = g_num_files.fetch_add(1);
     if (g_verbose)
       LogCvmfs(kLogCvmfs, kLogStdout, "Checking file %s", path.c_str());
     if (!g_verbose && ((n % 1000) == 0))

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -335,13 +335,12 @@ int main(int argc, char **argv) {
   free(workers);
   if (!g_verbose)
     LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, "\n");
-  LogCvmfs(kLogCvmfs, kLogStdout, "Verified %d files",
-           atomic_read32(&g_num_files));
+  LogCvmfs(kLogCvmfs, kLogStdout, "Verified %d files", g_num_files.load());
 
-  if (atomic_read32(&g_num_tmp_catalog) > 0)
+  if (g_num_tmp_catalog.load() > 0)
     LogCvmfs(kLogCvmfs, kLogStdout, "Temporary file catalogs were found.");
 
-  if (atomic_read32(&g_force_rebuild)) {
+  if (g_force_rebuild.load()) {
     if (unlink("cachedb") == 0) {
       LogCvmfs(kLogCvmfs, kLogStdout,
                "Fix: managed cache db unlinked, will be rebuilt on next mount");
@@ -355,7 +354,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (atomic_read32(&g_modified_cache)) {
+  if (g_modified_cache.load()) {
     LogCvmfs(kLogCvmfs, kLogStdout,
              "\n"
              "WARNING: There might by corrupted files in the kernel buffers.\n"
@@ -364,11 +363,11 @@ int main(int argc, char **argv) {
   }
 
   int retval = 0;
-  if (atomic_read32(&g_num_err_fixed) > 0)
+  if (g_num_err_fixed.load() > 0)
     retval |= kErrorFixed;
-  if (atomic_read32(&g_num_err_unfixed) > 0)
+  if (g_num_err_unfixed.load() > 0)
     retval |= kErrorUnfixed;
-  if (atomic_read32(&g_num_err_operational) > 0)
+  if (g_num_err_operational.load() > 0)
     retval |= kErrorOperational;
 
   return retval;

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -217,8 +217,10 @@ static void *MainCheck(void *data __attribute__((unused))) {
               g_num_err_fixed.fetch_add(1);
 
               // Changes made, we have to rebuild the managed cache db
-              atomic_cas32(&g_force_rebuild, 0, 1);
-              atomic_cas32(&g_modified_cache, 0, 1);
+              int32_t expected_val = 0;
+              g_force_rebuild.compare_exchange_strong(expected_val, 1);
+              int32_t expected_val = 0;
+              g_modified_cache.compare_exchange_strong(expected_val, 1);
             } else {
               g_num_err_unfixed.fetch_add(1);
             }
@@ -257,7 +259,8 @@ int main(int argc, char **argv) {
         g_fix_errors = true;
         break;
       case 'f':
-        atomic_cas32(&g_force_rebuild, 0, 1);
+        int32_t expected_val = 0;
+        g_force_rebuild.compare_exchange_strong(expected_val, 1);
         break;
       case 'j':
         g_num_threads = atoi(optarg);

--- a/cvmfs/cvmfs_fsck.cc
+++ b/cvmfs/cvmfs_fsck.cc
@@ -240,8 +240,8 @@ static void *MainCheck(void *data __attribute__((unused))) {
 
 
 int main(int argc, char **argv) {
-  atomic_init32(&g_force_rebuild);
-  atomic_init32(&g_modified_cache);
+  g_force_rebuild.store(0);
+  g_modified_cache.store(0);
   g_current_dir = new string();
 
   int c;
@@ -310,11 +310,11 @@ int main(int argc, char **argv) {
   closedir(dirp_txn);
 
   // Run workers to recalculate checksums
-  atomic_init32(&g_num_files);
-  atomic_init32(&g_num_err_fixed);
-  atomic_init32(&g_num_err_unfixed);
-  atomic_init32(&g_num_err_operational);
-  atomic_init32(&g_num_tmp_catalog);
+  g_num_files.store(0);
+  g_num_err_fixed.store(0);
+  g_num_err_unfixed.store(0);
+  g_num_err_operational.store(0);
+  g_num_tmp_catalog.store(0);
   pthread_t *workers = reinterpret_cast<pthread_t *>(
       smalloc(g_num_threads * sizeof(pthread_t)));
   if (!g_verbose)

--- a/cvmfs/fence.h
+++ b/cvmfs/fence.h
@@ -36,7 +36,7 @@ class Fence : public SingleCopy {
     while (blocking_.load()) {
       SafeSleepMs(kBusyWaitBackoffMs);
     }
-    atomic_inc64(&counter_);
+    counter_.fetch_add(1);
   }
 
   void Leave() { atomic_dec64(&counter_); }

--- a/cvmfs/fence.h
+++ b/cvmfs/fence.h
@@ -28,8 +28,8 @@ class Fence : public SingleCopy {
 
  public:
   Fence() {
-    atomic_init64(&counter_);
-    atomic_init32(&blocking_);
+    counter_.store(0);
+    blocking_.store(0);
   }
 
   void Enter() {

--- a/cvmfs/fence.h
+++ b/cvmfs/fence.h
@@ -41,7 +41,10 @@ class Fence : public SingleCopy {
 
   void Leave() { counter_.fetch_sub(1); }
 
-  void Close() { atomic_cas32(&blocking_, 0, 1); }
+  void Close() {
+    int32_t expected_val = 0;
+    blocking_.compare_exchange_strong(expected_val, 1);
+  }
 
   /**
    * Close and let live critical regions exit
@@ -53,7 +56,10 @@ class Fence : public SingleCopy {
     }
   }
 
-  void Open() { atomic_cas32(&blocking_, 1, 0); }
+  void Open() {
+    int32_t expected_val = 1;
+    blocking_.compare_exchange_strong(expected_val, 0);
+  }
 
  private:
   static const unsigned kBusyWaitBackoffMs = 100;

--- a/cvmfs/fence.h
+++ b/cvmfs/fence.h
@@ -33,7 +33,7 @@ class Fence : public SingleCopy {
   }
 
   void Enter() {
-    while (atomic_read32(&blocking_)) {
+    while (blocking_.load()) {
       SafeSleepMs(kBusyWaitBackoffMs);
     }
     atomic_inc64(&counter_);
@@ -48,7 +48,7 @@ class Fence : public SingleCopy {
    */
   void Drain() {
     Close();
-    while (atomic_read64(&counter_) > 0) {
+    while (counter_.load() > 0) {
       SafeSleepMs(kBusyWaitBackoffMs);
     }
   }

--- a/cvmfs/fence.h
+++ b/cvmfs/fence.h
@@ -5,8 +5,9 @@
 #ifndef CVMFS_FENCE_H_
 #define CVMFS_FENCE_H_
 
+#include <atomic>
+
 #include "duplex_testing.h"
-#include "util/atomic.h"
 #include "util/posix.h"
 #include "util/single_copy.h"
 
@@ -60,12 +61,12 @@ class Fence : public SingleCopy {
   /**
    * Number of active critical regions.
    */
-  atomic_int64 counter_;
+  std::atomic<int64_t> counter_;
 
   /**
    * A boolean that indicates if the fence is blocked.
    */
-  atomic_int32 blocking_;
+  std::atomic<int32_t> blocking_;
 };
 
 

--- a/cvmfs/fence.h
+++ b/cvmfs/fence.h
@@ -39,7 +39,7 @@ class Fence : public SingleCopy {
     counter_.fetch_add(1);
   }
 
-  void Leave() { atomic_dec64(&counter_); }
+  void Leave() { counter_.fetch_sub(1); }
 
   void Close() { atomic_cas32(&blocking_, 0, 1); }
 

--- a/cvmfs/file_chunk.h
+++ b/cvmfs/file_chunk.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -21,7 +22,6 @@
 #include "crypto/hash.h"
 #include "shortstring.h"
 #include "smallhash.h"
-#include "util/atomic.h"
 #include "util/single_copy.h"
 
 /**

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -203,7 +203,7 @@ void *FuseInvalidator::MainInvalidator(void *data) {
         || !HasFuseNotifyInval()) {
       while (platform_monotonic_time() < deadline) {
         SafeSleepMs(kCheckTimeoutFreqMs);
-        if (atomic_read32(&invalidator->terminated_) == 1) {
+        if (invalidator->terminated_.load() == 1) {
           LogCvmfs(kLogCvmfs, kLogDebug,
                    "cancel cache eviction due to termination");
           break;
@@ -255,7 +255,7 @@ void *FuseInvalidator::MainInvalidator(void *data) {
                    "cancel cache eviction after %u entries due to timeout", i);
           break;
         }
-        if (atomic_read32(&invalidator->terminated_) == 1) {
+        if (invalidator->terminated_.load() == 1) {
           LogCvmfs(kLogCvmfs, kLogDebug,
                    "cancel cache eviction due to termination");
           break;
@@ -308,7 +308,7 @@ void *FuseInvalidator::MainInvalidator(void *data) {
                   entry_name.GetLength());
 
       if ((++i % kCheckTimeoutFreqOps) == 0) {
-        if (atomic_read32(&invalidator->terminated_) == 1) {
+        if (invalidator->terminated_.load() == 1) {
           LogCvmfs(kLogCvmfs, kLogDebug,
                    "cancel cache eviction due to termination");
           break;

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -26,7 +26,7 @@ FuseInvalidator::Handle::Handle(unsigned timeout_s)
     : timeout_s_((timeout_s == 0) ? 0 : (timeout_s + kTimeoutSafetyMarginSec)) {
   status_ = reinterpret_cast<std::atomic<int32_t> *>(
       smalloc(sizeof(std::atomic<int32_t>)));
-  atomic_init32(status_);
+  status_.store(0);
 }
 
 
@@ -73,7 +73,7 @@ FuseInvalidator::FuseInvalidator(MountPoint *mount_point,
     , spawned_(false) {
   g_fuse_notify_invalidation_ = fuse_notify_invalidation;
   memset(&thread_invalidator_, 0, sizeof(thread_invalidator_));
-  atomic_init32(&terminated_);
+  terminated_.store(0);
 }
 
 FuseInvalidator::FuseInvalidator(glue::InodeTracker *inode_tracker,
@@ -87,7 +87,7 @@ FuseInvalidator::FuseInvalidator(glue::InodeTracker *inode_tracker,
     , spawned_(false) {
   g_fuse_notify_invalidation_ = fuse_notify_invalidation;
   memset(&thread_invalidator_, 0, sizeof(thread_invalidator_));
-  atomic_init32(&terminated_);
+  terminated_.store(0);
 }
 
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -24,7 +24,8 @@ using namespace std;  // NOLINT
 
 FuseInvalidator::Handle::Handle(unsigned timeout_s)
     : timeout_s_((timeout_s == 0) ? 0 : (timeout_s + kTimeoutSafetyMarginSec)) {
-  status_ = reinterpret_cast<atomic_int32 *>(smalloc(sizeof(atomic_int32)));
+  status_ = reinterpret_cast<std::atomic<int32_t> *>(
+      smalloc(sizeof(std::atomic<int32_t>)));
   atomic_init32(status_);
 }
 

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -92,7 +92,8 @@ FuseInvalidator::FuseInvalidator(glue::InodeTracker *inode_tracker,
 
 
 FuseInvalidator::~FuseInvalidator() {
-  atomic_cas32(&terminated_, 0, 1);
+  int32_t expected_val = 0;
+  terminated_.compare_exchange_strong(expected_val, 1);
   if (spawned_) {
     QuitCommand *cmd = new (smalloc(sizeof(QuitCommand))) QuitCommand();
     channel_.PushBack(cmd);

--- a/cvmfs/fuse_evict.cc
+++ b/cvmfs/fuse_evict.cc
@@ -26,7 +26,7 @@ FuseInvalidator::Handle::Handle(unsigned timeout_s)
     : timeout_s_((timeout_s == 0) ? 0 : (timeout_s + kTimeoutSafetyMarginSec)) {
   status_ = reinterpret_cast<std::atomic<int32_t> *>(
       smalloc(sizeof(std::atomic<int32_t>)));
-  status_.store(0);
+  status_->store(0);
 }
 
 

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -56,7 +56,7 @@ class FuseInvalidator : SingleCopy {
     explicit Handle(unsigned timeout_s);
     ~Handle();
     bool IsDone() const { return status_.load() == 1; }
-    void Reset() { atomic_write32(status_, 0); }
+    void Reset() { status_.store(0); }
     void WaitFor();
 
    private:

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -55,7 +55,7 @@ class FuseInvalidator : SingleCopy {
    public:
     explicit Handle(unsigned timeout_s);
     ~Handle();
-    bool IsDone() const { return atomic_read32(status_) == 1; }
+    bool IsDone() const { return status_.load() == 1; }
     void Reset() { atomic_write32(status_, 0); }
     void WaitFor();
 

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -60,7 +60,10 @@ class FuseInvalidator : SingleCopy {
     void WaitFor();
 
    private:
-    void SetDone() { atomic_cas32(status_, 0, 1); }
+    void SetDone() {
+      int32_t expected_val = 0;
+      status_.compare_exchange_strong(expected_val, 1);
+    }
 
     unsigned timeout_s_;
     std::atomic<int32_t> *status_;

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -8,11 +8,12 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <atomic>
+
 #include "bigvector.h"
 #include "duplex_fuse.h"
 #include "duplex_testing.h"
 #include "shortstring.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 #include "util/single_copy.h"
 
@@ -62,7 +63,7 @@ class FuseInvalidator : SingleCopy {
     void SetDone() { atomic_cas32(status_, 0, 1); }
 
     unsigned timeout_s_;
-    atomic_int32 *status_;
+    std::atomic<int32_t> *status_;
   };
 
   struct Command {
@@ -126,7 +127,7 @@ class FuseInvalidator : SingleCopy {
    * An invalidation run can take some time.  Allow for early cancellation if
    * thread should be shut down.
    */
-  atomic_int32 terminated_;
+  std::atomic<int32_t> terminated_;
   BigVector<uint64_t> evict_list_;
 
   static bool g_fuse_notify_invalidation_;

--- a/cvmfs/fuse_evict.h
+++ b/cvmfs/fuse_evict.h
@@ -55,14 +55,14 @@ class FuseInvalidator : SingleCopy {
    public:
     explicit Handle(unsigned timeout_s);
     ~Handle();
-    bool IsDone() const { return status_.load() == 1; }
-    void Reset() { status_.store(0); }
+    bool IsDone() const { return status_->load() == 1; }
+    void Reset() { status_->store(0); }
     void WaitFor();
 
    private:
     void SetDone() {
       int32_t expected_val = 0;
-      status_.compare_exchange_strong(expected_val, 1);
+      status_->compare_exchange_strong(expected_val, 1);
     }
 
     unsigned timeout_s_;
@@ -137,3 +137,4 @@ class FuseInvalidator : SingleCopy {
 };  // class FuseInvalidator
 
 #endif  // CVMFS_FUSE_EVICT_H_
+

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -335,7 +335,7 @@ void FuseRemounter::TryFinish(const shash::Any &root_hash) {
   mountpoint_->path_cache()->Resume();
   mountpoint_->md5path_cache()->Resume();
 
-  atomic_xadd32(&drainout_mode_, -2);  // 2 --> 0, end of drainout mode
+  drainout_mode_.fetch_add(-2);  // 2 --> 0, end of drainout mode
 
   if ((retval == catalog::kLoadFail) || (retval == catalog::kLoadNoSpace)) {
     // Can temporarily "escape" offline mode if update came from updated

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -33,7 +33,8 @@ FuseRemounter::Status FuseRemounter::ChangeRoot(const shash::Any &root_hash) {
   if (IsInMaintenanceMode())
     return kStatusMaintenance;
 
-  if (atomic_cas32(&drainout_mode_, 0, 1)) {
+  if (int32_t expected_val = 0;
+      drainout_mode_.compare_exchange_strong(expected_val, 1)) {
     // As of this point, fuse callbacks return zero as cache timeout
     LogCvmfs(kLogCvmfs, kLogDebug, "chroot, draining out meta-data caches");
     invalidator_handle_.Reset();
@@ -84,7 +85,8 @@ FuseRemounter::Status FuseRemounter::Check() {
   switch (retval) {
     case catalog::kLoadNew:
       SetOfflineMode(false);
-      if (atomic_cas32(&drainout_mode_, 0, 1)) {
+      if (int32_t expected_val = 0;
+          drainout_mode_.compare_exchange_strong(expected_val, 1)) {
         // As of this point, fuse callbacks return zero as cache timeout
         LogCvmfs(kLogCvmfs, kLogDebug,
                  "new catalog revision available, "
@@ -145,7 +147,8 @@ FuseRemounter::Status FuseRemounter::CheckSynchronously() {
 
 void FuseRemounter::EnterMaintenanceMode() {
   fence_maintenance_.Drain();
-  atomic_cas32(&maintenance_mode_, 0, 1);
+  int32_t expected_val = 0;
+  maintenance_mode_.compare_exchange_strong(expected_val, 1);
   fence_maintenance_.Open();
 
   // All running Check() and TryFinish() methods returned.  Both methods now

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -38,7 +38,7 @@ FuseRemounter::Status FuseRemounter::ChangeRoot(const shash::Any &root_hash) {
     LogCvmfs(kLogCvmfs, kLogDebug, "chroot, draining out meta-data caches");
     invalidator_handle_.Reset();
     invalidator_->InvalidateInodes(&invalidator_handle_);
-    atomic_inc32(&drainout_mode_);
+    drainout_mode_.fetch_add(1);
     // drainout_mode_ == 2, IsInDrainoutMode is now 'true'
   } else {
     LogCvmfs(kLogCvmfs, kLogDebug, "already in drainout mode, leaving");
@@ -91,7 +91,7 @@ FuseRemounter::Status FuseRemounter::Check() {
                  "draining out meta-data caches");
         invalidator_handle_.Reset();
         invalidator_->InvalidateInodes(&invalidator_handle_);
-        atomic_inc32(&drainout_mode_);
+        drainout_mode_.fetch_add(1);
         // drainout_mode_ == 2, IsInDrainoutMode is now 'true'
       } else {
         LogCvmfs(kLogCvmfs, kLogDebug, "already in drainout mode, leaving");

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -49,7 +49,7 @@ FuseRemounter::Status FuseRemounter::ChangeRoot(const shash::Any &root_hash) {
   BackoffThrottle throttle;
   do {
     TryFinish(root_hash);
-    drainout_code = atomic_read32(&drainout_mode_);
+    drainout_code = drainout_mode_.load();
     if (drainout_code == 0)
       break;
     throttle.Throttle();

--- a/cvmfs/fuse_remount.cc
+++ b/cvmfs/fuse_remount.cc
@@ -171,9 +171,9 @@ FuseRemounter::FuseRemounter(MountPoint *mountpoint,
     , catalogs_valid_until_(MountPoint::kIndefiniteDeadline) {
   memset(&thread_remount_trigger_, 0, sizeof(thread_remount_trigger_));
   pipe_remount_trigger_[0] = pipe_remount_trigger_[1] = -1;
-  atomic_init32(&drainout_mode_);
-  atomic_init32(&maintenance_mode_);
-  atomic_init32(&critical_section_);
+  drainout_mode_.store(0);
+  maintenance_mode_.store(0);
+  critical_section_.store(0);
 }
 
 FuseRemounter::~FuseRemounter() {

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -77,7 +77,7 @@ class FuseRemounter : SingleCopy {
   void SetAlarm(int timeout);
 
   bool EnterCriticalSection() { return atomic_cas32(&critical_section_, 0, 1); }
-  void LeaveCriticalSection() { atomic_dec32(&critical_section_); /* 1 -> 0 */ }
+  void LeaveCriticalSection() { critical_section_.fetch_sub(1); /* 1 -> 0 */ }
 
   void SetOfflineMode(bool value);
 

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -58,11 +58,10 @@ class FuseRemounter : SingleCopy {
   void TryFinish(const shash::Any &root_hash = shash::Any());
   void EnterMaintenanceMode();
   bool IsCaching() {
-    return (atomic_read32(&maintenance_mode_) == 0)
-           && (atomic_read32(&drainout_mode_) == 0);
+    return (maintenance_mode_.load() == 0) && (drainout_mode_.load() == 0);
   }
-  bool IsInDrainoutMode() { return atomic_read32(&drainout_mode_) == 2; }
-  bool IsInMaintenanceMode() { return atomic_read32(&maintenance_mode_) == 1; }
+  bool IsInDrainoutMode() { return drainout_mode_.load() == 2; }
+  bool IsInMaintenanceMode() { return maintenance_mode_.load() == 1; }
 
   Fence *fence() { return fence_; }
   time_t catalogs_valid_until() { return catalogs_valid_until_; }

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -7,13 +7,13 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <ctime>
 
 #include "crypto/hash.h"
 #include "duplex_fuse.h"
 #include "fence.h"
 #include "fuse_evict.h"
-#include "util/atomic.h"
 #include "util/single_copy.h"
 
 namespace cvmfs {
@@ -127,18 +127,18 @@ class FuseRemounter : SingleCopy {
    * the handle of the FuseInvalidator is prepared, from one to two is the
    * actual move into drainout mode.
    */
-  atomic_int32 drainout_mode_;
+  std::atomic<int32_t> drainout_mode_;
   /**
    * in maintenance mode, cache timeout is 0 and catalogs are not reloaded.
    * Maintenance mode is entered when the fuse module gets reloaded.
    */
-  atomic_int32 maintenance_mode_;
+  std::atomic<int32_t> maintenance_mode_;
   /**
    * Only one thread must perform the actual remount (stopping user-level
    * caches, loading new catalog, etc.).  This is used to protect TyrFinish()
    * from concurrent execution.
    */
-  atomic_int32 critical_section_;
+  std::atomic<int32_t> critical_section_;
 };  // class FuseRemounter
 
 #endif  // CVMFS_FUSE_REMOUNT_H_

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -77,8 +77,8 @@ class FuseRemounter : SingleCopy {
   void SetAlarm(int timeout);
 
   bool EnterCriticalSection() {
-    return int32_t expected_val = 0;
-    critical_section_.compare_exchange_strong(expected_val, 1);
+    int32_t expected_val = 0;
+    return critical_section_.compare_exchange_strong(expected_val, 1);
   }
   void LeaveCriticalSection() { critical_section_.fetch_sub(1); /* 1 -> 0 */ }
 
@@ -144,3 +144,4 @@ class FuseRemounter : SingleCopy {
 };  // class FuseRemounter
 
 #endif  // CVMFS_FUSE_REMOUNT_H_
+

--- a/cvmfs/fuse_remount.h
+++ b/cvmfs/fuse_remount.h
@@ -76,7 +76,10 @@ class FuseRemounter : SingleCopy {
   bool HasRemountTrigger() { return pipe_remount_trigger_[0] >= 0; }
   void SetAlarm(int timeout);
 
-  bool EnterCriticalSection() { return atomic_cas32(&critical_section_, 0, 1); }
+  bool EnterCriticalSection() {
+    return int32_t expected_val = 0;
+    critical_section_.compare_exchange_strong(expected_val, 1);
+  }
   void LeaveCriticalSection() { critical_section_.fetch_sub(1); /* 1 -> 0 */ }
 
   void SetOfflineMode(bool value);

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -8,11 +8,11 @@
  * functions.
  */
 
-#include "duplex_testing.h"
 #include <pthread.h>
 #include <sched.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <cassert>
 #include <cstring>
 #include <string>
@@ -21,9 +21,9 @@
 #include "bigvector.h"
 #include "crypto/hash.h"
 #include "directory_entry.h"
+#include "duplex_testing.h"
 #include "shortstring.h"
 #include "smallhash.h"
-#include "util/atomic.h"
 #include "util/exception.h"
 #include "util/mutex.h"
 #include "util/posix.h"  // IWYU pragma: keep
@@ -636,12 +636,12 @@ class InodeTracker {
              + "  misses(path): "
              + StringifyInt(atomic_read64(&num_misses_path));
     }
-    atomic_int64 num_inserts;
-    atomic_int64 num_removes;
-    atomic_int64 num_references;
-    atomic_int64 num_hits_inode;
-    atomic_int64 num_hits_path;
-    atomic_int64 num_misses_path;
+    std::atomic<int64_t> num_inserts;
+    std::atomic<int64_t> num_removes;
+    std::atomic<int64_t> num_references;
+    std::atomic<int64_t> num_hits_inode;
+    std::atomic<int64_t> num_hits_path;
+    std::atomic<int64_t> num_misses_path;
   };
   Statistics GetStatistics() { return statistics_; }
 

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -608,7 +608,7 @@ class InodeTracker {
         tracker_->path_map_.Erase(md5path);
         tracker_->statistics_.num_removes.fetch_add(1);
       }
-      atomic_xadd64(&tracker_->statistics_.num_references, -int32_t(by));
+      tracker_->statistics_.num_references.fetch_add(-int32_t(by));
       return removed;
     }
 
@@ -658,7 +658,7 @@ class InodeTracker {
     inode_ex_map_.Insert(inode_ex, md5path);
     Unlock();
 
-    atomic_xadd64(&statistics_.num_references, by);
+    statistics_.num_references.fetch_add(by);
     if (is_new_inode)
       statistics_.num_inserts.fetch_add(1);
   }

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -606,7 +606,7 @@ class InodeTracker {
         }
         tracker_->inode_ex_map_.Erase(inode);
         tracker_->path_map_.Erase(md5path);
-        atomic_inc64(&tracker_->statistics_.num_removes);
+        tracker_->statistics_.num_removes.fetch_add(1);
       }
       atomic_xadd64(&tracker_->statistics_.num_references, -int32_t(by));
       return removed;
@@ -660,7 +660,7 @@ class InodeTracker {
 
     atomic_xadd64(&statistics_.num_references, by);
     if (is_new_inode)
-      atomic_inc64(&statistics_.num_inserts);
+      statistics_.num_inserts.fetch_add(1);
   }
 
   void VfsGet(const InodeEx inode_ex, const PathString &path) {
@@ -680,9 +680,9 @@ class InodeTracker {
     Unlock();
 
     if (found) {
-      atomic_inc64(&statistics_.num_hits_path);
+      statistics_.num_hits_path.fetch_add(1);
     } else {
-      atomic_inc64(&statistics_.num_misses_path);
+      statistics_.num_misses_path.fetch_add(1);
     }
     return found;
   }
@@ -691,7 +691,7 @@ class InodeTracker {
     Lock();
     const uint64_t inode = path_map_.LookupInodeByPath(path);
     Unlock();
-    atomic_inc64(&statistics_.num_hits_inode);
+    statistics_.num_hits_inode.fetch_add(1);
     return inode;
   }
 

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -627,6 +627,26 @@ class InodeTracker {
       num_hits_path.store(0);
       num_misses_path.store(0);
     }
+    Statistics(const Statistics &reference)
+        : num_inserts(reference.num_inserts.load())
+        , num_removes(reference.num_removes.load())
+        , num_references(reference.num_references.load())
+        , num_hits_inode(reference.num_hits_inode.load())
+        , num_hits_path(reference.num_hits_path.load())
+        , num_misses_path(reference.num_misses_path.load()) { }
+
+    Statistics &operator=(const Statistics &reference) {
+      if (this != &reference) {
+        num_inserts.store(reference.num_inserts.load());
+        num_removes.store(reference.num_removes.load());
+        num_references.store(reference.num_references.load());
+        num_hits_inode.store(reference.num_hits_inode.load());
+        num_hits_path.store(reference.num_hits_path.load());
+        num_misses_path.store(reference.num_misses_path.load());
+      }
+      return *(this);
+    }
+
     std::string Print() {
       return "inserts: " + StringifyInt(num_inserts.load())
              + "  removes: " + StringifyInt(num_removes.load())

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -620,12 +620,12 @@ class InodeTracker {
   // reloads.  Added manually in the fuse module initialization and in talk.cc.
   struct Statistics {
     Statistics() {
-      atomic_init64(&num_inserts);
-      atomic_init64(&num_removes);
-      atomic_init64(&num_references);
-      atomic_init64(&num_hits_inode);
-      atomic_init64(&num_hits_path);
-      atomic_init64(&num_misses_path);
+      num_inserts.store(0);
+      num_removes.store(0);
+      num_references.store(0);
+      num_hits_inode.store(0);
+      num_hits_path.store(0);
+      num_misses_path.store(0);
     }
     std::string Print() {
       return "inserts: " + StringifyInt(num_inserts.load())

--- a/cvmfs/glue_buffer.h
+++ b/cvmfs/glue_buffer.h
@@ -628,13 +628,12 @@ class InodeTracker {
       atomic_init64(&num_misses_path);
     }
     std::string Print() {
-      return "inserts: " + StringifyInt(atomic_read64(&num_inserts))
-             + "  removes: " + StringifyInt(atomic_read64(&num_removes))
-             + "  references: " + StringifyInt(atomic_read64(&num_references))
-             + "  hits(inode): " + StringifyInt(atomic_read64(&num_hits_inode))
-             + "  hits(path): " + StringifyInt(atomic_read64(&num_hits_path))
-             + "  misses(path): "
-             + StringifyInt(atomic_read64(&num_misses_path));
+      return "inserts: " + StringifyInt(num_inserts.load())
+             + "  removes: " + StringifyInt(num_removes.load())
+             + "  references: " + StringifyInt(num_references.load())
+             + "  hits(inode): " + StringifyInt(num_hits_inode.load())
+             + "  hits(path): " + StringifyInt(num_hits_path.load())
+             + "  misses(path): " + StringifyInt(num_misses_path.load());
     }
     std::atomic<int64_t> num_inserts;
     std::atomic<int64_t> num_removes;

--- a/cvmfs/ingestion/item.cc
+++ b/cvmfs/ingestion/item.cc
@@ -99,7 +99,7 @@ void ChunkItem::ReleaseCompressor() { compressor_.Destroy(); }
 
 //------------------------------------------------------------------------------
 
-std::atomic<int64_t> BlockItem::managed_bytes_ = 0;
+std::atomic<int64_t> BlockItem::managed_bytes_(0);
 
 
 BlockItem::BlockItem(ItemAllocator *allocator)
@@ -224,3 +224,4 @@ uint32_t BlockItem::Write(void *buf, uint32_t count) {
   size_ += nbytes;
   return nbytes;
 }
+ 

--- a/cvmfs/ingestion/item.cc
+++ b/cvmfs/ingestion/item.cc
@@ -99,7 +99,7 @@ void ChunkItem::ReleaseCompressor() { compressor_.Destroy(); }
 
 //------------------------------------------------------------------------------
 
-atomic_int64 BlockItem::managed_bytes_ = 0;
+std::atomic<int64_t> BlockItem::managed_bytes_ = 0;
 
 
 BlockItem::BlockItem(ItemAllocator *allocator)

--- a/cvmfs/ingestion/item.cc
+++ b/cvmfs/ingestion/item.cc
@@ -129,7 +129,7 @@ BlockItem::BlockItem(int64_t tag, ItemAllocator *allocator)
 BlockItem::~BlockItem() {
   if (data_)
     allocator_->Free(data_);
-  atomic_xadd64(&managed_bytes_, -static_cast<int64_t>(capacity_));
+  managed_bytes_.fetch_add(-static_cast<int64_t>(capacity_));
 }
 
 
@@ -153,7 +153,7 @@ void BlockItem::MakeData(uint32_t capacity) {
   type_ = kBlockData;
   capacity_ = capacity;
   data_ = reinterpret_cast<unsigned char *>(allocator_->Malloc(capacity_));
-  atomic_xadd64(&managed_bytes_, static_cast<int64_t>(capacity_));
+  managed_bytes_.fetch_add(static_cast<int64_t>(capacity_));
 }
 
 
@@ -186,14 +186,14 @@ void BlockItem::MakeDataCopy(const unsigned char *data, uint32_t size) {
   capacity_ = size_ = size;
   data_ = reinterpret_cast<unsigned char *>(allocator_->Malloc(capacity_));
   memcpy(data_, data, size);
-  atomic_xadd64(&managed_bytes_, static_cast<int64_t>(capacity_));
+  managed_bytes_.fetch_add(static_cast<int64_t>(capacity_));
 }
 
 
 void BlockItem::Reset() {
   assert(type_ == kBlockData);
 
-  atomic_xadd64(&managed_bytes_, -static_cast<int64_t>(capacity_));
+  managed_bytes_.fetch_add(-static_cast<int64_t>(capacity_));
   allocator_->Free(data_);
   data_ = NULL;
   size_ = capacity_ = 0;

--- a/cvmfs/ingestion/item.cc
+++ b/cvmfs/ingestion/item.cc
@@ -55,7 +55,7 @@ void FileItem::RegisterChunk(const FileChunk &file_chunk) {
       bulk_hash_ = file_chunk.content_hash();
       break;
   }
-  atomic_dec64(&nchunks_in_fly_);
+  nchunks_in_fly_.fetch_sub(1);
 }
 
 

--- a/cvmfs/ingestion/item.cc
+++ b/cvmfs/ingestion/item.cc
@@ -35,8 +35,8 @@ FileItem::FileItem(IngestionSource *source,
     , chunks_(1) {
   const int retval = pthread_mutex_init(&lock_, NULL);
   assert(retval == 0);
-  atomic_init64(&nchunks_in_fly_);
-  atomic_init32(&is_fully_chunked_);
+  nchunks_in_fly_.store(0);
+  is_fully_chunked_.store(0);
 }
 
 FileItem::~FileItem() { pthread_mutex_destroy(&lock_); }

--- a/cvmfs/ingestion/item.h
+++ b/cvmfs/ingestion/item.h
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <cassert>
 #include <string>
 #include <vector>
@@ -17,7 +18,6 @@
 #include "file_chunk.h"
 #include "ingestion/chunk_detector.h"
 #include "ingestion/ingestion_source.h"
-#include "util/atomic.h"
 #include "util/pointer.h"
 #include "util/single_copy.h"
 
@@ -105,12 +105,12 @@ class FileItem : SingleCopy {
   /**
    * Number of chunks created but not yet uploaded and registered
    */
-  atomic_int64 nchunks_in_fly_;
+  std::atomic<int64_t> nchunks_in_fly_;
   /**
    * Switches to true once all of the file has been through the chunking
    * stage
    */
-  atomic_int32 is_fully_chunked_;
+  std::atomic<int32_t> is_fully_chunked_;
   pthread_mutex_t lock_;
 };
 
@@ -226,7 +226,7 @@ class BlockItem : SingleCopy {
   /**
    * Total capacity of all BlockItem()
    */
-  static atomic_int64 managed_bytes_;
+  static std::atomic<int64_t> managed_bytes_;
 
   // Forget pointer to the data
   void Discharge();

--- a/cvmfs/ingestion/item.h
+++ b/cvmfs/ingestion/item.h
@@ -66,8 +66,8 @@ class FileItem : SingleCopy {
   void set_size(uint64_t val) { size_ = val; }
   void set_may_have_chunks(bool val) { may_have_chunks_ = val; }
   void set_is_fully_chunked() { atomic_inc32(&is_fully_chunked_); }
-  bool is_fully_chunked() { return atomic_read32(&is_fully_chunked_) != 0; }
-  uint64_t nchunks_in_fly() { return atomic_read64(&nchunks_in_fly_); }
+  bool is_fully_chunked() { return is_fully_chunked_.load() != 0; }
+  uint64_t nchunks_in_fly() { return nchunks_in_fly_.load(); }
 
   uint64_t GetNumChunks() { return chunks_.size(); }
   FileChunkList *GetChunksPtr() { return &chunks_; }
@@ -83,7 +83,7 @@ class FileItem : SingleCopy {
   void IncNchunksInFly() { atomic_inc64(&nchunks_in_fly_); }
   void RegisterChunk(const FileChunk &file_chunk);
   bool IsProcessed() {
-    return is_fully_chunked() && (atomic_read64(&nchunks_in_fly_) == 0);
+    return is_fully_chunked() && (nchunks_in_fly_.load() == 0);
   }
 
  private:
@@ -220,7 +220,7 @@ class BlockItem : SingleCopy {
   int64_t tag() { return tag_; }
   FileItem *file_item() { return file_item_; }
   ChunkItem *chunk_item() { return chunk_item_; }
-  static uint64_t managed_bytes() { return atomic_read64(&managed_bytes_); }
+  static uint64_t managed_bytes() { return managed_bytes_.load(); }
 
  private:
   /**

--- a/cvmfs/ingestion/item.h
+++ b/cvmfs/ingestion/item.h
@@ -65,7 +65,7 @@ class FileItem : SingleCopy {
 
   void set_size(uint64_t val) { size_ = val; }
   void set_may_have_chunks(bool val) { may_have_chunks_ = val; }
-  void set_is_fully_chunked() { atomic_inc32(&is_fully_chunked_); }
+  void set_is_fully_chunked() { is_fully_chunked_.fetch_add(1); }
   bool is_fully_chunked() { return is_fully_chunked_.load() != 0; }
   uint64_t nchunks_in_fly() { return nchunks_in_fly_.load(); }
 
@@ -80,7 +80,7 @@ class FileItem : SingleCopy {
   bool GetSize(uint64_t *size) { return source_->GetSize(size); }
 
   // Called by ChunkItem constructor, decremented when a chunk is registered
-  void IncNchunksInFly() { atomic_inc64(&nchunks_in_fly_); }
+  void IncNchunksInFly() { nchunks_in_fly_.fetch_add(1); }
   void RegisterChunk(const FileChunk &file_chunk);
   bool IsProcessed() {
     return is_fully_chunked() && (nchunks_in_fly_.load() == 0);

--- a/cvmfs/ingestion/item_mem.cc
+++ b/cvmfs/ingestion/item_mem.cc
@@ -10,7 +10,7 @@
 #include "util/concurrency.h"
 #include "util/exception.h"
 
-atomic_int64 ItemAllocator::total_allocated_ = 0;
+std::atomic<int64_t> ItemAllocator::total_allocated_ = 0;
 
 
 void ItemAllocator::Free(void *ptr) {

--- a/cvmfs/ingestion/item_mem.cc
+++ b/cvmfs/ingestion/item_mem.cc
@@ -10,7 +10,7 @@
 #include "util/concurrency.h"
 #include "util/exception.h"
 
-std::atomic<int64_t> ItemAllocator::total_allocated_ = 0;
+std::atomic<int64_t> ItemAllocator::total_allocated_(0);
 
 
 void ItemAllocator::Free(void *ptr) {
@@ -74,3 +74,4 @@ void *ItemAllocator::Malloc(unsigned size) {
   assert(p != NULL);
   return p;
 }
+ 

--- a/cvmfs/ingestion/item_mem.cc
+++ b/cvmfs/ingestion/item_mem.cc
@@ -23,7 +23,7 @@ void ItemAllocator::Free(void *ptr) {
     for (unsigned i = 0; i < N; ++i) {
       if (malloc_arenas_[i] == M) {
         delete malloc_arenas_[i];
-        atomic_xadd64(&total_allocated_, -static_cast<int>(kArenaSize));
+        total_allocated_.fetch_add(-static_cast<int>(kArenaSize));
         malloc_arenas_.erase(malloc_arenas_.begin() + i);
         idx_last_arena_ = 0;
         return;
@@ -39,13 +39,13 @@ ItemAllocator::ItemAllocator() : idx_last_arena_(0) {
   assert(retval == 0);
 
   malloc_arenas_.push_back(new MallocArena(kArenaSize));
-  atomic_xadd64(&total_allocated_, kArenaSize);
+  total_allocated_.fetch_add(kArenaSize);
 }
 
 
 ItemAllocator::~ItemAllocator() {
   for (unsigned i = 0; i < malloc_arenas_.size(); ++i) {
-    atomic_xadd64(&total_allocated_, -static_cast<int>(kArenaSize));
+    total_allocated_.fetch_add(-static_cast<int>(kArenaSize));
     delete malloc_arenas_[i];
   }
   pthread_mutex_destroy(&lock_);
@@ -68,7 +68,7 @@ void *ItemAllocator::Malloc(unsigned size) {
   }
   idx_last_arena_ = N;
   MallocArena *M = new MallocArena(kArenaSize);
-  atomic_xadd64(&total_allocated_, kArenaSize);
+  total_allocated_.fetch_add(kArenaSize);
   malloc_arenas_.push_back(M);
   p = M->Malloc(size);
   assert(p != NULL);

--- a/cvmfs/ingestion/item_mem.h
+++ b/cvmfs/ingestion/item_mem.h
@@ -7,11 +7,11 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <cassert>
 #include <vector>
 
 #include "malloc_arena.h"
-#include "util/atomic.h"
 
 /**
  * To avoid memory fragmentation, allocate the data buffer inside the BlockItem
@@ -29,7 +29,7 @@ class ItemAllocator {
 
  private:
   static const unsigned kArenaSize = 128 * 1024 * 1024;  // 128 MB
-  static atomic_int64 total_allocated_;
+  static std::atomic<int64_t> total_allocated_;
 
   std::vector<MallocArena *> malloc_arenas_;
   /**

--- a/cvmfs/ingestion/item_mem.h
+++ b/cvmfs/ingestion/item_mem.h
@@ -25,7 +25,7 @@ class ItemAllocator {
   void *Malloc(unsigned size);
   void Free(void *ptr);
 
-  static int64_t total_allocated() { return atomic_read64(&total_allocated_); }
+  static int64_t total_allocated() { return total_allocated_.load(); }
 
  private:
   static const unsigned kArenaSize = 128 * 1024 * 1024;  // 128 MB

--- a/cvmfs/ingestion/task_chunk.cc
+++ b/cvmfs/ingestion/task_chunk.cc
@@ -34,7 +34,7 @@ void TaskChunk::Process(BlockItem *input_block) {
     // This needs to be fixed up later in the pipeline by the write task.
     if (file_item->may_have_chunks()) {
       chunk_info.next_chunk = new ChunkItem(file_item, 0);
-      chunk_info.output_tag_chunk = atomic_xadd64(&tag_seq_, 1);
+      chunk_info.output_tag_chunk = tag_seq_.fetch_add(1);
       if (file_item->has_legacy_bulk_chunk()) {
         chunk_info.bulk_chunk = new ChunkItem(file_item, 0);
       }
@@ -45,7 +45,7 @@ void TaskChunk::Process(BlockItem *input_block) {
     if (chunk_info.bulk_chunk != NULL) {
       chunk_info.bulk_chunk->MakeBulkChunk();
       chunk_info.bulk_chunk->set_size(file_item->size());
-      chunk_info.output_tag_bulk = atomic_xadd64(&tag_seq_, 1);
+      chunk_info.output_tag_bulk = tag_seq_.fetch_add(1);
     }
     tag_map_.Insert(input_tag, chunk_info);
   }
@@ -125,7 +125,7 @@ void TaskChunk::Process(BlockItem *input_block) {
             tubes_out_->Dispatch(block_stop);
 
             chunk_info.next_chunk = new ChunkItem(file_item, cut_mark);
-            chunk_info.output_tag_chunk = atomic_xadd64(&tag_seq_, 1);
+            chunk_info.output_tag_chunk = tag_seq_.fetch_add(1);
           }
           offset_in_block = cut_mark_in_block;
         }

--- a/cvmfs/ingestion/task_chunk.cc
+++ b/cvmfs/ingestion/task_chunk.cc
@@ -15,7 +15,7 @@
  * chunking stage can safely overlap.  Nevertheless, debugging might be easier
  * if they don't.  So let's start with a high number.
  */
-atomic_int64 TaskChunk::tag_seq_ = 2 << 28;
+std::atomic<int64_t> TaskChunk::tag_seq_ = 2 << 28;
 
 /**
  * Consumes the stream of input blocks and produces new output blocks according

--- a/cvmfs/ingestion/task_chunk.h
+++ b/cvmfs/ingestion/task_chunk.h
@@ -7,12 +7,12 @@
 
 #include <stdint.h>
 
+#include <atomic>
 #include <map>
 
 #include "ingestion/item.h"
 #include "ingestion/task.h"
 #include "smallhash.h"
-#include "util/atomic.h"
 #include "util/murmur.hxx"
 #include "util/posix.h"
 #include "util/tube.h"
@@ -80,7 +80,7 @@ class TaskChunk : public TubeConsumer<BlockItem> {
    * Every new chunk increases the tag sequence counter that is used to annotate
    * BlockItems.
    */
-  static atomic_int64 tag_seq_;
+  static std::atomic<int64_t> tag_seq_;
 
   TubeGroup<BlockItem> *tubes_out_;
   ItemAllocator *allocator_;

--- a/cvmfs/ingestion/task_read.cc
+++ b/cvmfs/ingestion/task_read.cc
@@ -18,7 +18,7 @@
 #include "util/smalloc.h"
 
 
-atomic_int64 TaskRead::tag_seq_ = 0;
+std::atomic<int64_t> TaskRead::tag_seq_ = 0;
 
 
 void TaskRead::Process(FileItem *item) {

--- a/cvmfs/ingestion/task_read.cc
+++ b/cvmfs/ingestion/task_read.cc
@@ -24,7 +24,7 @@ std::atomic<int64_t> TaskRead::tag_seq_ = 0;
 void TaskRead::Process(FileItem *item) {
   BackoffThrottle throttle(kThrottleInitMs, kThrottleMaxMs, kThrottleResetMs);
   if ((high_watermark_ > 0) && (BlockItem::managed_bytes() > high_watermark_)) {
-    atomic_inc64(&n_block_);
+    n_block_.fetch_add(1);
     do {
       throttle.Throttle();
     } while (BlockItem::managed_bytes() > low_watermark_);

--- a/cvmfs/ingestion/task_read.cc
+++ b/cvmfs/ingestion/task_read.cc
@@ -18,7 +18,7 @@
 #include "util/smalloc.h"
 
 
-std::atomic<int64_t> TaskRead::tag_seq_ = 0;
+std::atomic<int64_t> TaskRead::tag_seq_(0);
 
 
 void TaskRead::Process(FileItem *item) {
@@ -82,3 +82,4 @@ void TaskRead::SetWatermarks(uint64_t low, uint64_t high) {
   low_watermark_ = low;
   high_watermark_ = high;
 }
+ 

--- a/cvmfs/ingestion/task_read.cc
+++ b/cvmfs/ingestion/task_read.cc
@@ -45,7 +45,7 @@ void TaskRead::Process(FileItem *item) {
   }
 
   unsigned char *buffer[kBlockSize];
-  const uint64_t tag = atomic_xadd64(&tag_seq_, 1);
+  const uint64_t tag = tag_seq_.fetch_add(1);
   ssize_t nbytes = -1;
   unsigned cnt = 0;
   do {

--- a/cvmfs/ingestion/task_read.h
+++ b/cvmfs/ingestion/task_read.h
@@ -7,9 +7,10 @@
 
 #include <stdint.h>
 
+#include <atomic>
+
 #include "ingestion/item.h"
 #include "ingestion/task.h"
-#include "util/atomic.h"
 #include "util/posix.h"
 #include "util/tube.h"
 
@@ -45,7 +46,7 @@ class TaskRead : public TubeConsumer<FileItem> {
    * Every new file increases the tag sequence counter that is used to annotate
    * BlockItems.
    */
-  static atomic_int64 tag_seq_;
+  static std::atomic<int64_t> tag_seq_;
 
   TubeGroup<BlockItem> *tubes_out_;
   ItemAllocator *allocator_;
@@ -62,7 +63,7 @@ class TaskRead : public TubeConsumer<FileItem> {
   /**
    * Number of times reading was blocked on a high watermark.
    */
-  atomic_int64 n_block_;
+  std::atomic<int64_t> n_block_;
 };
 
 #endif  // CVMFS_INGESTION_TASK_READ_H_

--- a/cvmfs/ingestion/task_read.h
+++ b/cvmfs/ingestion/task_read.h
@@ -36,7 +36,7 @@ class TaskRead : public TubeConsumer<FileItem> {
 
   void SetWatermarks(uint64_t low, uint64_t high);
 
-  uint64_t n_block() { return atomic_read64(&n_block_); }
+  uint64_t n_block() { return n_block_.load(); }
 
  protected:
   virtual void Process(FileItem *item);

--- a/cvmfs/ingestion/task_read.h
+++ b/cvmfs/ingestion/task_read.h
@@ -31,7 +31,7 @@ class TaskRead : public TubeConsumer<FileItem> {
       , allocator_(allocator)
       , low_watermark_(0)
       , high_watermark_(0) {
-    atomic_init64(&n_block_);
+    n_block_.store(0);
   }
 
   void SetWatermarks(uint64_t low, uint64_t high);

--- a/cvmfs/lru.h
+++ b/cvmfs/lru.h
@@ -42,6 +42,7 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstring>
 #include <functional>
@@ -50,7 +51,6 @@
 
 #include "smallhash.h"
 #include "statistics.h"
-#include "util/atomic.h"
 #include "util/platform.h"
 #include "util/single_copy.h"
 #include "util/smalloc.h"

--- a/cvmfs/lru_md.h
+++ b/cvmfs/lru_md.h
@@ -9,12 +9,13 @@
 
 #include <stdint.h>
 
+#include <atomic>
+
 #include "crypto/hash.h"
 #include "directory_entry.h"
 #include "duplex_fuse.h"
 #include "lru.h"
 #include "shortstring.h"
-#include "util/atomic.h"
 #include "util/logging.h"
 #include "util/murmur.hxx"
 

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -222,7 +222,7 @@ void Host::CopyFrom(const Host &other) {
  */
 Host Host::ExtendDeadline(const Host &original, unsigned seconds_from_now) {
   Host new_host(original);
-  new_host.id_ = atomic_xadd64(&global_id_, 1);
+  new_host.id_ = global_id_.fetch_add(1);
   new_host.deadline_ = time(NULL) + seconds_from_now;
   return new_host;
 }
@@ -234,7 +234,7 @@ Host Host::ExtendDeadline(const Host &original, unsigned seconds_from_now) {
  */
 Host::Host()
     : deadline_(0)
-    , id_(atomic_xadd64(&global_id_, 1))
+    , id_(global_id_.fetch_add(1))
     , status_(kFailNotYetResolved) { }
 
 

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -193,7 +193,7 @@ std::string AddDefaultScheme(const std::string &proxy) {
 //------------------------------------------------------------------------------
 
 
-std::atomic<int64_t> Host::global_id_ = 0;
+std::atomic<int64_t> Host::global_id_(0);
 
 const set<string> &Host::ViewBestAddresses(IpPreference preference) const {
   if (((preference == kIpPreferSystem) || (preference == kIpPreferV4))
@@ -1325,3 +1325,4 @@ NormalResolver::~NormalResolver() {
 }
 
 }  // namespace dns
+                   

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -193,7 +193,7 @@ std::string AddDefaultScheme(const std::string &proxy) {
 //------------------------------------------------------------------------------
 
 
-atomic_int64 Host::global_id_ = 0;
+std::atomic<int64_t> Host::global_id_ = 0;
 
 const set<string> &Host::ViewBestAddresses(IpPreference preference) const {
   if (((preference == kIpPreferSystem) || (preference == kIpPreferV4))

--- a/cvmfs/network/dns.h
+++ b/cvmfs/network/dns.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include <atomic>
 #include <cstdio>
 #include <ctime>
 #include <map>
@@ -16,7 +17,6 @@
 
 #include "duplex_cares.h"  // IWYU pragma: keep
 #include "duplex_testing.h"
-#include "util/atomic.h"
 #include "util/prng.h"
 #include "util/single_copy.h"
 
@@ -126,7 +126,7 @@ class Host {
    * distinguish two Host objects with the same host name.  E.g. when the proxy
    * list in Download.cc reads "http://A:3128|http://A:3128".
    */
-  static atomic_int64 global_id_;
+  static std::atomic<int64_t> global_id_;
 
   /**
    * When the name resolution becomes outdated, in UTC seconds since UNIX epoch.

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -39,6 +39,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -56,7 +57,6 @@
 #include "sanitizer.h"
 #include "ssl.h"
 #include "util/algorithm.h"
-#include "util/atomic.h"
 #include "util/exception.h"
 #include "util/logging.h"
 #include "util/posix.h"
@@ -1237,7 +1237,8 @@ bool DownloadManager::ValidateProxyIpsUnlocked(const string &url,
     }
   }
   vector<ProxyInfo> new_infos;
-  set<string> const best_addresses = new_host.ViewBestAddresses(opt_ip_preference_);
+  set<string> const best_addresses = new_host.ViewBestAddresses(
+      opt_ip_preference_);
   set<string>::const_iterator iter_ips = best_addresses.begin();
   for (; iter_ips != best_addresses.end(); ++iter_ips) {
     const string url_ip = dns::RewriteUrl(url, *iter_ips);
@@ -1430,11 +1431,9 @@ void DownloadManager::ProcessLink(JobInfo *info) {
     // Don't process the same links again if there are retries
     info->SetLink("");
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslog,
-                 "(manager '%s' - id %" PRId64 ") "
-                 "received %d hosts from metalink server, starting with %s",
-                 name_.c_str(), info->id(),
-                 host_list.size(),
-                 host_list[0].c_str());
+             "(manager '%s' - id %" PRId64 ") "
+             "received %d hosts from metalink server, starting with %s",
+             name_.c_str(), info->id(), host_list.size(), host_list[0].c_str());
   }
 }
 
@@ -1680,10 +1679,8 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
              "(manager '%s' - id %" PRId64 ") "
              "Trying again on same curl handle, %s"
              "error code %d%s",
-             name_.c_str(), info->id(),
-             same_url_retry ? "same url, " : "",
-             info->error_code(),
-             info->nocache() ? ", no cache" : "");
+             name_.c_str(), info->id(), same_url_retry ? "same url, " : "",
+             info->error_code(), info->nocache() ? ", no cache" : "");
     // Reset internal state and destination. In parallel-decompress mode the
     // sink and zstream are owned by the caller thread (it pops and decompresses
     // the queued chunks). Resetting them here would race the caller and, worse,
@@ -1703,7 +1700,8 @@ bool DownloadManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
     }
 
     // The hash context is updated on this (MainDownload) thread in
-    // CallbackCurlData(), so it is reset here regardless of the decompress mode.
+    // CallbackCurlData(), so it is reset here regardless of the decompress
+    // mode.
     if (info->expected_hash()) {
       shash::Init(info->hash_context());
     }
@@ -2010,7 +2008,8 @@ Failures DownloadManager::Fetch(JobInfo *info) {
   // Prepare cvmfs-info: header, allocate string on the stack
   info->SetInfoHeader(NULL);
   if (enable_info_header_) {
-    const string header_info = info->GetInfoHeaderContents(info_header_template_);
+    const string header_info = info->GetInfoHeaderContents(
+        info_header_template_);
     if (header_info != "") {
       const char * const header_name = "cvmfs-info: ";
       const size_t header_name_len = strlen(header_name);
@@ -2084,12 +2083,12 @@ Failures DownloadManager::Fetch(JobInfo *info) {
       if (decompress_err == kFailOk && ele->size > 0) {
         if (info->compressed()) {
           const zlib::StreamStates retval = zlib::DecompressZStream2Sink(
-              ele->data, static_cast<int64_t>(ele->size),
-              info->GetZstreamPtr(), info->sink());
+              ele->data, static_cast<int64_t>(ele->size), info->GetZstreamPtr(),
+              info->sink());
           if (retval == zlib::kStreamDataError) {
             LogCvmfs(kLogDownload, kLogSyslogErr,
-                     "(id %" PRId64 ") failed to decompress %s",
-                     info->id(), info->url()->c_str());
+                     "(id %" PRId64 ") failed to decompress %s", info->id(),
+                     info->url()->c_str());
             decompress_err = kFailBadData;
           } else if (retval == zlib::kStreamIOError) {
             LogCvmfs(kLogDownload, kLogSyslogErr,
@@ -2099,8 +2098,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
           }
         } else {
           const int64_t written = info->sink()->Write(ele->data, ele->size);
-          if (written < 0 ||
-              static_cast<uint64_t>(written) != ele->size) {
+          if (written < 0 || static_cast<uint64_t>(written) != ele->size) {
             LogCvmfs(kLogDownload, kLogDebug,
                      "(id %" PRId64 ") sink write failed for %s (%ld of %zu)",
                      info->id(), info->url()->c_str(),

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1923,7 +1923,7 @@ DownloadManager::DownloadManager(const unsigned max_pool_handles,
     , opt_proxy_groups_reset_after_(0)
     , credentials_attachment_(NULL)
     , counters_(new Counters(statistics)) {
-  atomic_init32(&multi_threaded_);
+  multi_threaded_.store(0);
 
   lock_options_ = reinterpret_cast<pthread_mutex_t *>(
       smalloc(sizeof(pthread_mutex_t)));

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1972,7 +1972,7 @@ void DownloadManager::Spawn() {
                                     static_cast<void *>(this));
   assert(retval == 0);
 
-  atomic_inc32(&multi_threaded_);
+  multi_threaded_.fetch_add(1);
 
   if (health_check_.UseCount() > 0) {
     LogCvmfs(kLogDownload, kLogDebug,

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1819,7 +1819,7 @@ DownloadManager::~DownloadManager() {
     health_check_.Reset();
   }
 
-  if (atomic_xadd32(&multi_threaded_, 0) == 1) {
+  if (multi_threaded_.fetch_add(0) == 1) {
     // Shutdown I/O thread
     pipe_terminate_->Write(kPipeTerminateSignal);
     pthread_join(thread_download_, NULL);
@@ -2037,7 +2037,7 @@ Failures DownloadManager::Fetch(JobInfo *info) {
     memcpy(info->tracing_header_uid(), str_uid.c_str(), str_uid.size() + 1);
   }
 
-  if (atomic_xadd32(&multi_threaded_, 0) == 1) {
+  if (multi_threaded_.fetch_add(0) == 1) {
     if (!info->IsValidPipeJobResults()) {
       info->CreatePipeJobResults();
     }

--- a/cvmfs/network/download.h
+++ b/cvmfs/network/download.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstdio>
 #include <map>
 #include <set>
@@ -27,7 +28,6 @@
 #include "network/sharding_policy.h"
 #include "ssl.h"
 #include "statistics.h"
-#include "util/atomic.h"
 #include "util/pipe.h"
 #include "util/pointer.h"
 #include "util/prng.h"
@@ -311,7 +311,7 @@ class DownloadManager {  // NOLINT(clang-analyzer-optin.performance.Padding)
   char *user_agent_;
 
   pthread_t thread_download_;
-  atomic_int32 multi_threaded_;
+  std::atomic<int32_t> multi_threaded_;
   UniquePtr<Pipe<kPipeThreadTerminator> > pipe_terminate_;
 
   UniquePtr<Pipe<kPipeDownloadJobs> > pipe_jobs_;

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -2,20 +2,21 @@
  * This file is part of the CernVM File System.
  */
 
+#include "jobinfo.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <sys/stat.h>
 
-#include "jobinfo.h"
 #include "util/capabilities.h"
 #include "util/logging.h"
 #include "util/string.h"
 
 namespace download {
 
-atomic_int64 JobInfo::next_uuid = 0;
+std::atomic<int64_t> JobInfo::next_uuid = 0;
 
 JobInfo::JobInfo(const std::string *u, const bool c, const bool ph,
                  const shash::Any *h, cvmfs::Sink *s) {
@@ -131,7 +132,7 @@ std::string EscapeHeader(const std::string &header) {
   return escaped;
 }
 
-} // namespace
+}  // namespace
 
 /*
  * Return the filled-in template of CVMFS_INFO_HEADER
@@ -158,145 +159,145 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
   for (std::string::const_iterator i = templ.begin(); i != templ.end(); i++) {
     const char c = *i;
     switch (parsemode) {
-    case kParseModeDefault:
-      if (c == '%') {
-        parsemode = kParseModeAfterPercent;
-        key = "";
-      } else {
-        answer += c;
-      }
-      break;
-    case kParseModeAfterPercent:
-      if (c == '{') {
-        parsemode = kParseModeInKey;
-      } else {
-        parsemode = kParseModeDefault;
-        answer += '%';
-        answer += c;
-      }
-      break;
-    case kParseModeInKey:
-      if (c != '}') {
-        key += c;
-      } else {
-        parsemode = kParseModeDefault;
-        if (key == "path") {
-          if (path_info_ != NULL) {
-            answer += EscapeHeader(*path_info_);
-          } else {
-            answer += "-";
-          }
-        } else if (key == "pid") {
-          if (pid_ != static_cast<pid_t>(-1)) {
-            answer += StringifyInt(pid_);
-          } else {
-            answer += "-";
-          }
-        } else if (key == "uid") {
-          if (uid_ != static_cast<uid_t>(-1)) {
-            answer += StringifyInt(uid_);
-          } else {
-            answer += "-";
-          }
-        } else if (key == "gid") {
-          if (gid_ != static_cast<gid_t>(-1)) {
-            answer += StringifyInt(gid_);
-          } else {
-            answer += "-";
-          }
-        } else if (key.substr(0, 4) == "env:") {
-          if (!env_attempted) {
-            env_attempted = true;
-#ifndef __APPLE__
+      case kParseModeDefault:
+        if (c == '%') {
+          parsemode = kParseModeAfterPercent;
+          key = "";
+        } else {
+          answer += c;
+        }
+        break;
+      case kParseModeAfterPercent:
+        if (c == '{') {
+          parsemode = kParseModeInKey;
+        } else {
+          parsemode = kParseModeDefault;
+          answer += '%';
+          answer += c;
+        }
+        break;
+      case kParseModeInKey:
+        if (c != '}') {
+          key += c;
+        } else {
+          parsemode = kParseModeDefault;
+          if (key == "path") {
+            if (path_info_ != NULL) {
+              answer += EscapeHeader(*path_info_);
+            } else {
+              answer += "-";
+            }
+          } else if (key == "pid") {
             if (pid_ != static_cast<pid_t>(-1)) {
-              ObtainDacReadSearchCapability();
-              ObtainSysPtraceCapability();
-              const std::string fname = "/proc/" +
-                                        StringifyInt(pid_) +
-                                        "/environ";
-              const int fd = open(fname.c_str(), O_RDONLY);
-              if (fd != -1) {
-                // Unfortunately fstat does not show the size so need to
-                // read it to find out the size
-                ssize_t n;
-                int size = 0;
-                char buf[BUFSIZ];
-                while ((n = read(fd, buf, BUFSIZ)) > 0) {
-                  size += static_cast<int>(n);
-                }
-                if ((n >= 0) && (size > 0)) {
-                  if (lseek(fd, 0, SEEK_SET) >= 0) {
-                    envbuf.resize(size);
-                    if (read(fd, envbuf.data(), size) > 0) {
-                      LogCvmfs(kLogDownload, kLogDebug,
-                        "(job id %" PRId64 ") read %d bytes from %s",
-                        id_, size, fname.c_str());
-                    } else {
-                      envbuf.clear();
+              answer += StringifyInt(pid_);
+            } else {
+              answer += "-";
+            }
+          } else if (key == "uid") {
+            if (uid_ != static_cast<uid_t>(-1)) {
+              answer += StringifyInt(uid_);
+            } else {
+              answer += "-";
+            }
+          } else if (key == "gid") {
+            if (gid_ != static_cast<gid_t>(-1)) {
+              answer += StringifyInt(gid_);
+            } else {
+              answer += "-";
+            }
+          } else if (key.substr(0, 4) == "env:") {
+            if (!env_attempted) {
+              env_attempted = true;
+#ifndef __APPLE__
+              if (pid_ != static_cast<pid_t>(-1)) {
+                ObtainDacReadSearchCapability();
+                ObtainSysPtraceCapability();
+                const std::string fname = "/proc/" + StringifyInt(pid_)
+                                          + "/environ";
+                const int fd = open(fname.c_str(), O_RDONLY);
+                if (fd != -1) {
+                  // Unfortunately fstat does not show the size so need to
+                  // read it to find out the size
+                  ssize_t n;
+                  int size = 0;
+                  char buf[BUFSIZ];
+                  while ((n = read(fd, buf, BUFSIZ)) > 0) {
+                    size += static_cast<int>(n);
+                  }
+                  if ((n >= 0) && (size > 0)) {
+                    if (lseek(fd, 0, SEEK_SET) >= 0) {
+                      envbuf.resize(size);
+                      if (read(fd, envbuf.data(), size) > 0) {
+                        LogCvmfs(kLogDownload, kLogDebug,
+                                 "(job id %" PRId64 ") read %d bytes from %s",
+                                 id_, size, fname.c_str());
+                      } else {
+                        envbuf.clear();
+                      }
                     }
                   }
-                }
-                close(fd);
-              } else {
-                LogCvmfs(kLogDownload, kLogDebug,
-                  "(job id %" PRId64 ") unable to open %s: %s",
-                  id_, fname.c_str(), strerror(errno));
-              }
-              DropSysPtraceCapability();
-              DropDacReadSearchCapability();
-            }
-#endif
-          }
-          if (!envbuf.empty()) {
-            const char * const var = key.c_str() + 4; // everything after "env:"
-            const char *varp = var;
-            std::string val = "";
-            MatchMode matchmode = kMatchModeMatching;
-            const char * const endp = envbuf.data() + envbuf.size();
-            for (const char *p = envbuf.data(); p < endp; p++) {
-              switch (matchmode) {
-              case kMatchModeSkipping:
-                // skipping to next null character
-                if (*p == '\0') {
-                  varp = var;
-                  matchmode = kMatchModeMatching;
-                }
-                break;
-              case kMatchModeMatching:
-                // matching variable name
-                if (*p == '\0') {
-                  // premature end without an '='
-                  varp = var;
-                } else if (*varp == *p) {
-                  // so far so good
-                  ++varp;
-                } else if ((*varp == '\0') && (*p == '=')) {
-                  // matched
-                  matchmode = kMatchModeCollecting;
+                  close(fd);
                 } else {
-                  // didn't match
-                  matchmode = kMatchModeSkipping;
+                  LogCvmfs(kLogDownload, kLogDebug,
+                           "(job id %" PRId64 ") unable to open %s: %s", id_,
+                           fname.c_str(), strerror(errno));
                 }
-                break;
-              case kMatchModeCollecting:
-                // matched, collecting value
-                if (*p == '\0') {
-                  // all done
-                  p = endp;
-                  break;
-                }
-                val += *p;
-                break;
+                DropSysPtraceCapability();
+                DropDacReadSearchCapability();
               }
+#endif
             }
-            if (val != "") {
-              answer += ' ';
-              answer += EscapeHeader(val);
+            if (!envbuf.empty()) {
+              const char * const var = key.c_str()
+                                       + 4;  // everything after "env:"
+              const char *varp = var;
+              std::string val = "";
+              MatchMode matchmode = kMatchModeMatching;
+              const char * const endp = envbuf.data() + envbuf.size();
+              for (const char *p = envbuf.data(); p < endp; p++) {
+                switch (matchmode) {
+                  case kMatchModeSkipping:
+                    // skipping to next null character
+                    if (*p == '\0') {
+                      varp = var;
+                      matchmode = kMatchModeMatching;
+                    }
+                    break;
+                  case kMatchModeMatching:
+                    // matching variable name
+                    if (*p == '\0') {
+                      // premature end without an '='
+                      varp = var;
+                    } else if (*varp == *p) {
+                      // so far so good
+                      ++varp;
+                    } else if ((*varp == '\0') && (*p == '=')) {
+                      // matched
+                      matchmode = kMatchModeCollecting;
+                    } else {
+                      // didn't match
+                      matchmode = kMatchModeSkipping;
+                    }
+                    break;
+                  case kMatchModeCollecting:
+                    // matched, collecting value
+                    if (*p == '\0') {
+                      // all done
+                      p = endp;
+                      break;
+                    }
+                    val += *p;
+                    break;
+                }
+              }
+              if (val != "") {
+                answer += ' ';
+                answer += EscapeHeader(val);
+              }
             }
           }
         }
-      }
-      break;
+        break;
     }
   }
 

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -16,7 +16,7 @@
 
 namespace download {
 
-std::atomic<int64_t> JobInfo::next_uuid = 0;
+std::atomic<int64_t> JobInfo::next_uuid(0);
 
 JobInfo::JobInfo(const std::string *u, const bool c, const bool ph,
                  const shash::Any *h, cvmfs::Sink *s) {
@@ -305,3 +305,4 @@ std::string JobInfo::GetInfoHeaderContents(const std::string &templ) {
 }
 
 }  // namespace download
+                        

--- a/cvmfs/network/jobinfo.cc
+++ b/cvmfs/network/jobinfo.cc
@@ -46,7 +46,7 @@ bool JobInfo::IsFileNotFound() {
 }
 
 void JobInfo::Init() {
-  id_ = atomic_xadd64(&next_uuid, 1);
+  id_ = next_uuid.fetch_add(1);
   pipe_job_results = NULL;
   url_ = NULL;
   compressed_ = false;

--- a/cvmfs/network/jobinfo.h
+++ b/cvmfs/network/jobinfo.h
@@ -62,7 +62,7 @@ struct DataTubeElement : SingleCopy {
  */
 class JobInfo {
  private:
-  static atomic_int64 next_uuid;
+  static std::atomic<int64_t> next_uuid;
   int64_t id_;
   /// Pipe used for the return value
   UniquePtr<Pipe<kPipeDownloadJobsResults> > pipe_job_results;

--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -1448,7 +1448,7 @@ S3FanoutManager::~S3FanoutManager() {
   pthread_mutex_destroy(curl_handle_lock_);
   free(curl_handle_lock_);
 
-  if (atomic_xadd32(&multi_threaded_, 0) == 1) {
+  if (multi_threaded_.fetch_add(0) == 1) {
     // Shutdown I/O thread
     char buf = 'T';
     WritePipe(pipe_terminate_[1], &buf, 1);

--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -16,9 +16,9 @@
 
 #include "crypto/hash.h"
 #include "util/exception.h"
+#include "util/platform.h"
 #include "util/posix.h"
 #include "util/string.h"
-#include "util/platform.h"
 
 using namespace std;  // NOLINT
 
@@ -33,9 +33,15 @@ static string XmlEscape(const string &input) {
   result.reserve(input.size());
   for (unsigned i = 0; i < input.size(); ++i) {
     switch (input[i]) {
-      case '&': result += "&amp;"; break;
-      case '<': result += "&lt;"; break;
-      default:  result += input[i]; break;
+      case '&':
+        result += "&amp;";
+        break;
+      case '<':
+        result += "&lt;";
+        break;
+      default:
+        result += input[i];
+        break;
     }
   }
   return result;
@@ -68,7 +74,8 @@ string MkV2CanonicalResource(const string &bucket, const string &object_key,
  * Uses Quiet mode so the response only contains errors, not successes.
  */
 string ComposeDeleteMultiXml(const vector<string> &keys) {
-  string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Delete><Quiet>true</Quiet>";
+  string xml = "<?xml version=\"1.0\" "
+               "encoding=\"UTF-8\"?><Delete><Quiet>true</Quiet>";
   // ~70 bytes per <Object><Key>...</Key></Object> entry
   xml.reserve(xml.size() + keys.size() * 70 + 10);
   for (unsigned i = 0; i < keys.size(); ++i) {
@@ -99,8 +106,7 @@ unsigned ParseDeleteMultiResponse(const string &response,
     if (err_end == string::npos)
       break;
 
-    const string error_block = response.substr(err_start,
-                                                err_end - err_start);
+    const string error_block = response.substr(err_start, err_end - err_start);
     num_errors++;
 
     // Extract <Key>...</Key>
@@ -146,8 +152,8 @@ const unsigned S3FanoutManager::kThrottleReportIntervalSec = 10;
 const unsigned S3FanoutManager::kDefaultHTTPPort = 80;
 const unsigned S3FanoutManager::kDefaultHTTPSPort = 443;
 
-std::string S3FanoutManager::MkDotCvmfsCacheControlHeader(unsigned defaultMaxAge, int overrideMaxAge)
-{
+std::string S3FanoutManager::MkDotCvmfsCacheControlHeader(
+    unsigned defaultMaxAge, int overrideMaxAge) {
   const char *var;
   int max_age_sec;
   char *at_null_terminator_if_number;
@@ -162,8 +168,7 @@ std::string S3FanoutManager::MkDotCvmfsCacheControlHeader(unsigned defaultMaxAge
     var = getenv("CVMFS_MAX_TTL_SECS");
     if (var && var[0]) {
       max_age_sec = strtoll(var, &at_null_terminator_if_number, 10);
-      if (*at_null_terminator_if_number == '\0'
-          && max_age_sec >= 0) {
+      if (*at_null_terminator_if_number == '\0' && max_age_sec >= 0) {
         value_determined = true;
       }
     }
@@ -173,8 +178,7 @@ std::string S3FanoutManager::MkDotCvmfsCacheControlHeader(unsigned defaultMaxAge
     var = getenv("CVMFS_MAX_TTL");
     if (var && var[0]) {
       max_age_sec = strtoll(var, &at_null_terminator_if_number, 10);
-      if (*at_null_terminator_if_number == '\0'
-          && max_age_sec >= 0) {
+      if (*at_null_terminator_if_number == '\0' && max_age_sec >= 0) {
         max_age_sec *= 60;
         value_determined = true;
       }
@@ -758,9 +762,9 @@ bool S3FanoutManager::MkV4Authz(const JobInfo &info,
 
   const string canonical_request = GetRequestString(info) + "\n"
                                    + GetUriEncode(uri, false) + "\n"
-                                   + canonical_query + "\n"
-                                   + canonical_headers + "\n" + signed_headers
-                                   + "\n" + payload_hash;
+                                   + canonical_query + "\n" + canonical_headers
+                                   + "\n" + signed_headers + "\n"
+                                   + payload_hash;
 
   const string hash_request = shash::Sha256String(canonical_request.c_str());
 
@@ -1369,7 +1373,7 @@ bool S3FanoutManager::VerifyAndFinalize(const int curl_error, JobInfo *info) {
 }
 
 S3FanoutManager::S3FanoutManager(const S3Config &config) : config_(config) {
-  atomic_init32(&multi_threaded_);
+  multi_threaded_.store(0);
   MakePipe(pipe_terminate_);
   MakePipe(pipe_jobs_);
   MakePipe(pipe_completed_);

--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -1499,7 +1499,7 @@ void S3FanoutManager::Spawn() {
                                     static_cast<void *>(this));
   assert(retval == 0);
 
-  atomic_inc32(&multi_threaded_);
+  multi_threaded_.fetch_add(1);
 }
 
 const Statistics &S3FanoutManager::GetStatistics() { return *statistics_; }

--- a/cvmfs/network/s3fanout.h
+++ b/cvmfs/network/s3fanout.h
@@ -103,7 +103,7 @@ struct JobInfo : SingleCopy {
     kReqPutHtml,       // HTML file - display instead of downloading
     kReqPutBucket,     // bucket creation
     kReqDelete,
-    kReqDeleteMulti,   // S3 multi-object delete (POST /?delete)
+    kReqDeleteMulti,  // S3 multi-object delete (POST /?delete)
   };
 
   const std::string object_key;
@@ -235,7 +235,8 @@ class S3FanoutManager : SingleCopy {
   static const char *kCacheControlCas;          // Cache-Control: max-age=259200
   static const unsigned kLowSpeedLimit = 1024;  // Require at least 1kB/s
 
-  std::string MkDotCvmfsCacheControlHeader(unsigned defaultMaxAge=61, int overrideMaxAge=-1);
+  std::string MkDotCvmfsCacheControlHeader(unsigned defaultMaxAge = 61,
+                                           int overrideMaxAge = -1);
 
   static int CallbackCurlSocket(CURL *easy, curl_socket_t s, int action,
                                 void *userp, void *socketp);
@@ -309,7 +310,7 @@ class S3FanoutManager : SingleCopy {
   mutable std::pair<std::string, std::string> last_signing_key_;
 
   pthread_t thread_upload_;
-  atomic_int32 multi_threaded_;
+  std::atomic<int32_t> multi_threaded_;
 
   struct pollfd *watch_fds_;
   uint32_t watch_fds_size_;
@@ -347,7 +348,7 @@ class S3FanoutManager : SingleCopy {
    */
   SslCertificateStore ssl_certificate_store_;
 
-  std::string dot_cvmfs_cache_control_header;           // Cache-Control: max-age=...
+  std::string dot_cvmfs_cache_control_header;  // Cache-Control: max-age=...
 };  // S3FanoutManager
 
 std::string MkV2CanonicalResource(const std::string &bucket,

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -73,7 +73,7 @@ void NfsMapsLeveldb::ForkAwareEnv::Schedule(void (*function)(void *),
 
 
 void NfsMapsLeveldb::ForkAwareEnv::WaitForBGThreads() {
-  while (atomic_read32(&num_bg_threads_) > 0)
+  while (num_bg_threads_.load() > 0)
     SafeSleepMs(100);
 }
 

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -89,7 +89,7 @@ void NfsMapsLeveldb::ForkAwareEnv::SleepForMicroseconds(int micros) {
 void *NfsMapsLeveldb::ForkAwareEnv::MainFakeThread(void *data) {
   FuncArg *funcarg = reinterpret_cast<FuncArg *>(data);
   funcarg->function(funcarg->arg);
-  atomic_dec32(&(funcarg->env->num_bg_threads_));
+  (funcarg->env->num_bg_threads_.fetch_sub(1));
   delete funcarg;
   return NULL;
 }

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -37,7 +37,7 @@ using namespace std;  // NOLINT
 
 NfsMapsLeveldb::ForkAwareEnv::ForkAwareEnv(NfsMapsLeveldb *maps)
     : leveldb::EnvWrapper(leveldb::Env::Default()), maps_(maps) {
-  atomic_init32(&num_bg_threads_);
+  num_bg_threads_.store(0);
 }
 
 

--- a/cvmfs/nfs_maps_leveldb.cc
+++ b/cvmfs/nfs_maps_leveldb.cc
@@ -63,7 +63,7 @@ void NfsMapsLeveldb::ForkAwareEnv::Schedule(void (*function)(void *),
   funcarg->function = function;
   funcarg->arg = arg;
   funcarg->env = this;
-  atomic_inc32(&num_bg_threads_);
+  num_bg_threads_.fetch_add(1);
   pthread_t bg_thread;
   int retval = pthread_create(&bg_thread, NULL, MainFakeThread, funcarg);
   assert(retval == 0);

--- a/cvmfs/nfs_maps_leveldb.h
+++ b/cvmfs/nfs_maps_leveldb.h
@@ -7,12 +7,12 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <string>
 
 #include "crypto/hash.h"
 #include "leveldb/env.h"
 #include "nfs_maps.h"
-#include "util/atomic.h"
 
 
 namespace leveldb {
@@ -65,7 +65,7 @@ class NfsMapsLeveldb : public NfsMaps {
     static void *MainFakeThread(void *data);
 
     NfsMapsLeveldb *maps_;
-    atomic_int32 num_bg_threads_;
+    std::atomic<int32_t> num_bg_threads_;
   };
 
   NfsMapsLeveldb();

--- a/cvmfs/nfs_maps_sqlite.h
+++ b/cvmfs/nfs_maps_sqlite.h
@@ -7,13 +7,13 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <string>
 
 #include "crypto/hash.h"
 #include "duplex_sqlite3.h"
 #include "nfs_maps.h"
 #include "shortstring.h"
-#include "util/atomic.h"
 #include "util/prng.h"
 
 namespace perf {

--- a/cvmfs/notify/subscriber_sse.cc
+++ b/cvmfs/notify/subscriber_sse.cc
@@ -92,7 +92,7 @@ bool SubscriberSSE::Subscribe(const std::string &topic) {
 
 void SubscriberSSE::Unsubscribe() { atomic_write32(&should_quit_, 1); }
 
-bool SubscriberSSE::ShouldQuit() const { return atomic_read32(&should_quit_); }
+bool SubscriberSSE::ShouldQuit() const { return should_quit_.load(); }
 
 void SubscriberSSE::AppendToBuffer(const std::string &s) {
   size_t start = 0;

--- a/cvmfs/notify/subscriber_sse.cc
+++ b/cvmfs/notify/subscriber_sse.cc
@@ -90,7 +90,7 @@ bool SubscriberSSE::Subscribe(const std::string &topic) {
   return success;
 }
 
-void SubscriberSSE::Unsubscribe() { atomic_write32(&should_quit_, 1); }
+void SubscriberSSE::Unsubscribe() { should_quit_.store(1); }
 
 bool SubscriberSSE::ShouldQuit() const { return should_quit_.load(); }
 

--- a/cvmfs/notify/subscriber_sse.h
+++ b/cvmfs/notify/subscriber_sse.h
@@ -5,11 +5,11 @@
 #ifndef CVMFS_NOTIFY_SUBSCRIBER_SSE_H_
 #define CVMFS_NOTIFY_SUBSCRIBER_SSE_H_
 
+#include <atomic>
 #include <string>
 
 #include "duplex_curl.h"
 #include "subscriber.h"
-#include "util/atomic.h"
 
 namespace notify {
 
@@ -57,7 +57,7 @@ class SubscriberSSE : public Subscriber {
   std::string topic_;
   std::string buffer_;
 
-  mutable atomic_int32 should_quit_;
+  mutable std::atomic<int32_t> should_quit_;
 };
 
 }  // namespace notify

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -216,9 +216,9 @@ typedef ShortString<kDefaultMaxName, 1> NameString;
 typedef ShortString<kDefaultMaxLink, 2> LinkString;
 
 template<unsigned char StackSize, char Type>
-std::atomic<int64_t> ShortString<StackSize, Type>::num_overflows_ = 0;
+std::atomic<int64_t> ShortString<StackSize, Type>::num_overflows_(0);
 template<unsigned char StackSize, char Type>
-std::atomic<int64_t> ShortString<StackSize, Type>::num_instances_ = 0;
+std::atomic<int64_t> ShortString<StackSize, Type>::num_instances_(0);
 
 // See posix.cc for the std::string counterparts
 PathString GetParentPath(const PathString &path);
@@ -232,3 +232,4 @@ bool IsSubPath(const PathString &parent, const PathString &path);
 #endif
 
 #endif  // CVMFS_SHORTSTRING_H_
+

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -10,10 +10,9 @@
 #define CVMFS_SHORTSTRING_H_
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <string>
-
-#include "util/atomic.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -208,8 +207,8 @@ class ShortString {
   std::string *long_string_;
   char stack_[StackSize + 1];  // +1 to add a final '\0' if necessary
   unsigned char length_;
-  static atomic_int64 num_overflows_;
-  static atomic_int64 num_instances_;
+  static std::atomic<int64_t> num_overflows_;
+  static std::atomic<int64_t> num_instances_;
 };  // class ShortString
 
 typedef ShortString<kDefaultMaxPath, 0> PathString;
@@ -217,9 +216,9 @@ typedef ShortString<kDefaultMaxName, 1> NameString;
 typedef ShortString<kDefaultMaxLink, 2> LinkString;
 
 template<unsigned char StackSize, char Type>
-atomic_int64 ShortString<StackSize, Type>::num_overflows_ = 0;
+std::atomic<int64_t> ShortString<StackSize, Type>::num_overflows_ = 0;
 template<unsigned char StackSize, char Type>
-atomic_int64 ShortString<StackSize, Type>::num_instances_ = 0;
+std::atomic<int64_t> ShortString<StackSize, Type>::num_instances_ = 0;
 
 // See posix.cc for the std::string counterparts
 PathString GetParentPath(const PathString &path);
@@ -233,4 +232,3 @@ bool IsSubPath(const PathString &parent, const PathString &path);
 #endif
 
 #endif  // CVMFS_SHORTSTRING_H_
-

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -198,8 +198,8 @@ class ShortString {
     return ShortString(this->GetChars() + start_at, length - start_at);
   }
 
-  static uint64_t num_instances() { return atomic_read64(&num_instances_); }
-  static uint64_t num_overflows() { return atomic_read64(&num_overflows_); }
+  static uint64_t num_instances() { return num_instances_.load(); }
+  static uint64_t num_overflows() { return num_overflows_.load(); }
 
   operator bool() const { return not IsEmpty(); }
 

--- a/cvmfs/shortstring.h
+++ b/cvmfs/shortstring.h
@@ -27,24 +27,24 @@ class ShortString {
  public:
   ShortString() : long_string_(NULL), length_(0) {
 #ifdef DEBUGMSG
-    atomic_inc64(&num_instances_);
+    num_instances_.fetch_add(1);
 #endif
   }
   ShortString(const ShortString &other) : long_string_(NULL) {
 #ifdef DEBUGMSG
-    atomic_inc64(&num_instances_);
+    num_instances_.fetch_add(1);
 #endif
     Assign(other);
   }
   ShortString(const char *chars, const unsigned length) : long_string_(NULL) {
 #ifdef DEBUGMSG
-    atomic_inc64(&num_instances_);
+    num_instances_.fetch_add(1);
 #endif
     Assign(chars, length);
   }
   explicit ShortString(const std::string &std_string) : long_string_(NULL) {
 #ifdef DEBUGMSG
-    atomic_inc64(&num_instances_);
+    num_instances_.fetch_add(1);
 #endif
     Assign(std_string.data(), std_string.length());
   }
@@ -63,7 +63,7 @@ class ShortString {
     this->length_ = length;
     if (length > StackSize) {
 #ifdef DEBUGMSG
-      atomic_inc64(&num_overflows_);
+      num_overflows_.fetch_add(1);
 #endif
       long_string_ = new std::string(chars, length);
     } else {
@@ -85,7 +85,7 @@ class ShortString {
     const unsigned new_length = this->length_ + length;
     if (new_length > StackSize) {
 #ifdef DEBUGMSG
-      atomic_inc64(&num_overflows_);
+      num_overflows_.fetch_add(1);
 #endif
       long_string_ = new std::string();
       long_string_->reserve(new_length);

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -707,7 +707,7 @@ int SyncInit(struct fs_traversal *src,
   add_dir_for_sync(base, recursive);
   const int result = !SyncFull(src, dest, pstats, last_print_time);
 
-  while (atomic_read64(&copy_queue) != 0) {
+  while (copy_queue.load() != 0) {
     if (platform_monotonic_time() - last_print_time > stat_update_period_) {
       LogCvmfs(kLogCvmfs, kLogStdout, "%s",
                pstats->PrintList(perf::Statistics::kPrintSimple).c_str());

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -341,7 +341,7 @@ bool handle_file(struct fs_traversal *src,
       FileCopy next_copy(src_ident, dest_data);
 
       WritePipe(pipe_chunks[1], &next_copy, sizeof(next_copy));
-      atomic_inc64(&copy_queue);
+      copy_queue.fetch_add(1);
     } else {
       if (!copyFile(src, src_ident, dest, dest_data, pstats)) {
         LogCvmfs(kLogCvmfs, kLogStderr, "Failed to copy %s->%s : %d : %s",

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -663,7 +663,7 @@ int SyncInit(struct fs_traversal *src,
   perf::Statistics *pstats = GetSyncStatTemplate();
 
   // Initialization
-  atomic_init64(&copy_queue);
+  copy_queue.store(0);
 
   pthread_t *workers = NULL;
 

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include <stdio.h>
 
+#include <atomic>
 #include <fstream>
 #include <map>
 #include <vector>
@@ -18,7 +19,6 @@
 #include "shrinkwrap/posix/interface.h"
 #include "shrinkwrap/spec_tree.h"
 #include "statistics.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 #include "util/logging.h"
 #include "util/platform.h"
@@ -85,7 +85,7 @@ uint64_t stat_update_period_ = 0;  // Off for testing
 int pipe_chunks[2];
 // required for concurrent reading
 pthread_mutex_t lock_pipe = PTHREAD_MUTEX_INITIALIZER;
-atomic_int64 copy_queue;
+std::atomic<int64_t> copy_queue;
 
 vector<RecDir *> dirs_;
 

--- a/cvmfs/shrinkwrap/fs_traversal.cc
+++ b/cvmfs/shrinkwrap/fs_traversal.cc
@@ -619,7 +619,7 @@ static void *MainWorker(void *data) {
     free(next_copy.src);
     free(next_copy.dest);
 
-    atomic_dec64(&copy_queue);
+    copy_queue.fetch_sub(1);
   }
   return NULL;
 }

--- a/cvmfs/smallhash.h
+++ b/cvmfs/smallhash.h
@@ -5,17 +5,17 @@
 #ifndef CVMFS_SMALLHASH_H_
 #define CVMFS_SMALLHASH_H_
 
-#include "duplex_testing.h"
 #include <inttypes.h>
 #include <pthread.h>
 #include <stdint.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstdlib>
 #include <new>
 
-#include "util/atomic.h"
+#include "duplex_testing.h"
 #include "util/murmur.hxx"
 #include "util/prng.h"
 #include "util/smalloc.h"

--- a/cvmfs/statistics.cc
+++ b/cvmfs/statistics.cc
@@ -52,7 +52,7 @@ Statistics *Statistics::Fork() {
                                             iEnd = counters_.end();
        i != iEnd;
        ++i) {
-    atomic_inc32(&i->second->refcnt);
+    i->second->refcnt.fetch_add(1);
   }
   child->counters_ = counters_;
 

--- a/cvmfs/statistics.cc
+++ b/cvmfs/statistics.cc
@@ -181,7 +181,7 @@ Statistics::~Statistics() {
                                             iEnd = counters_.end();
        i != iEnd;
        ++i) {
-    const int32_t old_value = atomic_xadd32(&i->second->refcnt, -1);
+    const int32_t old_value = i->second->refcnt.fetch_add(-1);
     if (old_value == 1)
       delete i->second;
   }

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -26,7 +26,7 @@ namespace perf {
 class Counter {
  public:
   Counter() { counter_.store(0); }
-  void Inc() { atomic_inc64(&counter_); }
+  void Inc() { counter_.fetch_add(1); }
   void Dec() { atomic_dec64(&counter_); }
   int64_t Get() { return counter_.load(); }
   void Set(const int64_t val) { atomic_write64(&counter_, val); }
@@ -80,7 +80,7 @@ class Statistics {
   struct CounterInfo {
     explicit CounterInfo(const std::string &desc) : desc(desc) {
       refcnt.store(0);
-      atomic_inc32(&refcnt);
+      refcnt.fetch_add(1);
     }
     std::atomic<int32_t> refcnt;
     Counter counter;

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -29,7 +29,7 @@ class Counter {
   void Inc() { counter_.fetch_add(1); }
   void Dec() { counter_.fetch_sub(1); }
   int64_t Get() { return counter_.load(); }
-  void Set(const int64_t val) { atomic_write64(&counter_, val); }
+  void Set(const int64_t val) { counter_.store(val); }
   int64_t Xadd(const int64_t delta) { return atomic_xadd64(&counter_, delta); }
 
   std::string Print();

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -27,7 +27,7 @@ class Counter {
  public:
   Counter() { counter_.store(0); }
   void Inc() { counter_.fetch_add(1); }
-  void Dec() { atomic_dec64(&counter_); }
+  void Dec() { counter_.fetch_sub(1); }
   int64_t Get() { return counter_.load(); }
   void Set(const int64_t val) { atomic_write64(&counter_, val); }
   int64_t Xadd(const int64_t delta) { return atomic_xadd64(&counter_, delta); }

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -28,7 +28,7 @@ class Counter {
   Counter() { atomic_init64(&counter_); }
   void Inc() { atomic_inc64(&counter_); }
   void Dec() { atomic_dec64(&counter_); }
-  int64_t Get() { return atomic_read64(&counter_); }
+  int64_t Get() { return counter_.load(); }
   void Set(const int64_t val) { atomic_write64(&counter_, val); }
   int64_t Xadd(const int64_t delta) { return atomic_xadd64(&counter_, delta); }
 

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -30,7 +30,7 @@ class Counter {
   void Dec() { counter_.fetch_sub(1); }
   int64_t Get() { return counter_.load(); }
   void Set(const int64_t val) { counter_.store(val); }
-  int64_t Xadd(const int64_t delta) { return atomic_xadd64(&counter_, delta); }
+  int64_t Xadd(const int64_t delta) { return counter_.fetch_add(delta); }
 
   std::string Print();
   std::string PrintK();

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -8,11 +8,10 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
-
-#include "util/atomic.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -42,7 +41,7 @@ class Counter {
   std::string ToString();
 
  private:
-  atomic_int64 counter_;
+  std::atomic<int64_t> counter_;
 };
 
 // perf::Func(Counter) is more clear to read in the code
@@ -83,7 +82,7 @@ class Statistics {
       atomic_init32(&refcnt);
       atomic_inc32(&refcnt);
     }
-    atomic_int32 refcnt;
+    std::atomic<int32_t> refcnt;
     Counter counter;
     std::string desc;
   };

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -25,7 +25,7 @@ namespace perf {
  */
 class Counter {
  public:
-  Counter() { atomic_init64(&counter_); }
+  Counter() { counter_.store(0); }
   void Inc() { atomic_inc64(&counter_); }
   void Dec() { atomic_dec64(&counter_); }
   int64_t Get() { return counter_.load(); }
@@ -79,7 +79,7 @@ class Statistics {
   Statistics &operator=(const Statistics &other);
   struct CounterInfo {
     explicit CounterInfo(const std::string &desc) : desc(desc) {
-      atomic_init32(&refcnt);
+      refcnt.store(0);
       atomic_inc32(&refcnt);
     }
     std::atomic<int32_t> refcnt;

--- a/cvmfs/statistics.h
+++ b/cvmfs/statistics.h
@@ -26,6 +26,7 @@ namespace perf {
 class Counter {
  public:
   Counter() { counter_.store(0); }
+  Counter(const Counter &cref) { counter_.store(cref.counter_.load()); }
   void Inc() { counter_.fetch_add(1); }
   void Dec() { counter_.fetch_sub(1); }
   int64_t Get() { return counter_.load(); }
@@ -237,3 +238,4 @@ class MultiRecorder {
 #endif
 
 #endif  // CVMFS_STATISTICS_H_
+

--- a/cvmfs/swissknife_filestats.cc
+++ b/cvmfs/swissknife_filestats.cc
@@ -88,7 +88,7 @@ bool CommandFileStats::Run(ObjectFetcherT *object_fetcher) {
 
   const bool ret = traversal.Traverse();
 
-  atomic_inc32(&finished_);
+  finished_.fetch_add(1);
   pthread_join(thread_processing_, NULL);
 
   db_->DestroyStatements();
@@ -101,7 +101,7 @@ void CommandFileStats::CatalogCallback(
   const int32_t num = num_downloaded_.load();
   const string out_path = tmp_db_path_ + StringifyInt(num + 1) + ".db";
   assert(CopyPath2Path(data.catalog->database_path(), out_path));
-  atomic_inc32(&num_downloaded_);
+  num_downloaded_.fetch_add(1);
 }
 
 void *CommandFileStats::MainProcessing(void *data) {

--- a/cvmfs/swissknife_filestats.cc
+++ b/cvmfs/swissknife_filestats.cc
@@ -45,7 +45,7 @@ int CommandFileStats::Main(const ArgumentList &args) {
   }
 
   tmp_db_path_ = tmp_dir + "/cvmfs_filestats/";
-  atomic_init32(&num_downloaded_);
+  num_downloaded_.store(0);
 
   bool success = false;
   if (IsHttpUrl(repo_url)) {
@@ -70,7 +70,7 @@ int CommandFileStats::Main(const ArgumentList &args) {
 
 template<class ObjectFetcherT>
 bool CommandFileStats::Run(ObjectFetcherT *object_fetcher) {
-  atomic_init32(&finished_);
+  finished_.store(0);
 
   const string abs_path = GetAbsolutePath(db_path_);
   unlink(abs_path.c_str());

--- a/cvmfs/swissknife_filestats.cc
+++ b/cvmfs/swissknife_filestats.cc
@@ -98,7 +98,7 @@ bool CommandFileStats::Run(ObjectFetcherT *object_fetcher) {
 
 void CommandFileStats::CatalogCallback(
     const CatalogTraversalData<catalog::Catalog> &data) {
-  const int32_t num = atomic_read32(&num_downloaded_);
+  const int32_t num = num_downloaded_.load();
   const string out_path = tmp_db_path_ + StringifyInt(num + 1) + ".db";
   assert(CopyPath2Path(data.catalog->database_path(), out_path));
   atomic_inc32(&num_downloaded_);
@@ -107,8 +107,8 @@ void CommandFileStats::CatalogCallback(
 void *CommandFileStats::MainProcessing(void *data) {
   CommandFileStats *repo_stats = static_cast<CommandFileStats *>(data);
   int processed = 0;
-  int32_t downloaded = atomic_read32(&repo_stats->num_downloaded_);
-  int32_t fin = atomic_read32(&repo_stats->finished_);
+  int32_t downloaded = repo_stats->num_downloaded_.load();
+  int32_t fin = repo_stats->finished_.load();
 
   repo_stats->db_->BeginTransaction();
   while (fin == 0 || processed < downloaded) {
@@ -119,8 +119,8 @@ void *CommandFileStats::MainProcessing(void *data) {
       repo_stats->ProcessCatalog(db_path);
       ++processed;
     }
-    downloaded = atomic_read32(&repo_stats->num_downloaded_);
-    fin = atomic_read32(&repo_stats->finished_);
+    downloaded = repo_stats->num_downloaded_.load();
+    fin = repo_stats->finished_.load();
   }
   repo_stats->db_->CommitTransaction();
 

--- a/cvmfs/swissknife_filestats.h
+++ b/cvmfs/swissknife_filestats.h
@@ -7,12 +7,12 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <string>
 
 #include "catalog_traversal.h"
 #include "sql.h"
 #include "swissknife.h"
-#include "util/atomic.h"
 
 using namespace std;  // NOLINT
 
@@ -68,8 +68,8 @@ class CommandFileStats : public Command {
   FileStatsDatabase *db_;
 
   pthread_t thread_processing_;
-  atomic_int32 num_downloaded_;
-  atomic_int32 finished_;
+  std::atomic<int32_t> num_downloaded_;
+  std::atomic<int32_t> finished_;
 
   template<class ObjectFetcherT>
   bool Run(ObjectFetcherT *object_fetcher);

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -566,7 +566,7 @@ void CommandMigrate::PrintStatusMessage(const PendingCatalog *catalog,
                                         const shash::Any &content_hash,
                                         const std::string &message) {
   atomic_inc32(&catalogs_processed_);
-  const unsigned int processed = (atomic_read32(&catalogs_processed_) * 100)
+  const unsigned int processed = (catalogs_processed_.load() * 100)
                                  / catalog_count_;
   LogCvmfs(kLogCatalog, kLogStdout, "[%d%%] %s %sC %s", processed,
            message.c_str(), content_hash.ToString().c_str(),

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -565,7 +565,7 @@ void CommandMigrate::UploadCallback(const upload::SpoolerResult &result) {
 void CommandMigrate::PrintStatusMessage(const PendingCatalog *catalog,
                                         const shash::Any &content_hash,
                                         const std::string &message) {
-  atomic_inc32(&catalogs_processed_);
+  catalogs_processed_.fetch_add(1);
   const unsigned int processed = (catalogs_processed_.load() * 100)
                                  / catalog_count_;
   LogCvmfs(kLogCatalog, kLogStdout, "[%d%%] %s %sC %s", processed,

--- a/cvmfs/swissknife_migrate.cc
+++ b/cvmfs/swissknife_migrate.cc
@@ -32,7 +32,7 @@ CommandMigrate::CommandMigrate()
     , uid_(0)
     , gid_(0)
     , root_catalog_(NULL) {
-  atomic_init32(&catalogs_processed_);
+  catalogs_processed_.store(0);
 }
 
 

--- a/cvmfs/swissknife_migrate.h
+++ b/cvmfs/swissknife_migrate.h
@@ -5,6 +5,7 @@
 #ifndef CVMFS_SWISSKNIFE_MIGRATE_H_
 #define CVMFS_SWISSKNIFE_MIGRATE_H_
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
@@ -18,7 +19,6 @@
 #include "uid_map.h"
 #include "upload.h"
 #include "util/algorithm.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 #include "util/future.h"
 #include "util/logging.h"
@@ -391,7 +391,7 @@ class CommandMigrate : public Command {
   unsigned int file_descriptor_limit_;
   CatalogStatisticsList catalog_statistics_list_;
   unsigned int catalog_count_;
-  atomic_int32 catalogs_processed_;
+  std::atomic<int32_t> catalogs_processed_;
   bool has_committed_new_revision_;
 
   uid_t uid_;

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -605,9 +605,9 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   int result = 1;
 
   // Initialization
-  atomic_init64(&overall_chunks);
-  atomic_init64(&overall_new);
-  atomic_init64(&chunk_queue);
+  overall_chunks.store(0);
+  overall_new.store(0);
+  chunk_queue.store(0);
 
   const bool follow_redirects = false;
   const unsigned max_pool_handles = num_parallel + 1;

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -284,7 +284,7 @@ static void *MainWorker(void *data) {
       fclose(fchunk);
       Store(tmp_file, chunk_hash,
             (compression_alg == zlib::kZlibDefault) ? true : false);
-      atomic_inc64(&overall_new);
+      overall_new.fetch_add(1);
     }
     if (atomic_xadd64(&overall_chunks, 1) % 1000 == 0)
       LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, ".");
@@ -467,7 +467,7 @@ bool CommandPull::Pull(const shash::Any &catalog_hash,
     while (catalog->AllChunksNext(&chunk_hash, &compression_alg)) {
       ChunkJob next_chunk(chunk_hash, compression_alg);
       WritePipe(pipe_chunks[1], &next_chunk, sizeof(next_chunk));
-      atomic_inc64(&chunk_queue);
+      chunk_queue.fetch_add(1);
     }
     catalog->AllChunksEnd();
     while (chunk_queue.load() != 0) {

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -977,7 +977,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   WaitForStorage();
   LogCvmfs(kLogCvmfs, kLogStdout,
            "Fetched %" PRId64 " new chunks out of %" PRId64 " processed chunks",
-           (overall_new).load(), atomic_read64(&overall_chunks));
+           (overall_new).load(), overall_chunks.load());
   result = 0;
 
 fini:

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -28,14 +29,13 @@
 #include "manifest.h"
 #include "manifest_fetch.h"
 #include "network/download.h"
-#include "network/sink_path.h"
 #include "network/sink_mem.h"
+#include "network/sink_path.h"
 #include "object_fetcher.h"
 #include "path_filters/inclusion_spec.h"
 #include "path_filters/relaxed_path_filter.h"
 #include "reflog.h"
 #include "upload.h"
-#include "util/atomic.h"
 #include "util/exception.h"
 #include "util/logging.h"
 #include "util/posix.h"
@@ -106,9 +106,9 @@ pthread_mutex_t lock_pipe = PTHREAD_MUTEX_INITIALIZER;
 unsigned retries = 3;
 catalog::RelaxedPathFilter *pathfilter = NULL;
 catalog::InclusionSpec *inclusion_spec = NULL;
-atomic_int64 overall_chunks;
-atomic_int64 overall_new;
-atomic_int64 chunk_queue;
+std::atomic<int64_t> overall_chunks;
+std::atomic<int64_t> overall_new;
+std::atomic<int64_t> chunk_queue;
 bool preload_cache = false;
 string *preload_cachedir = NULL;
 bool inspect_existing_catalogs = false;
@@ -325,7 +325,7 @@ bool CommandPull::PullRecursion(catalog::Catalog *catalog,
                i->mountpoint.c_str());
       shash::Any previous_catalog_hash;  // expected to be null for subcatalog
       const bool retval = Pull(i->hash, i->mountpoint.ToString(),
-                         previous_catalog_hash);
+                               previous_catalog_hash);
       if (!retval)
         return false;
     }
@@ -557,8 +557,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
                "Options -d and -E are mutually exclusive");
       return 1;
     }
-    inclusion_spec =
-        catalog::InclusionSpec::Create(*args.find('E')->second);
+    inclusion_spec = catalog::InclusionSpec::Create(*args.find('E')->second);
     if (inclusion_spec == NULL || !inclusion_spec->IsValid()) {
       LogCvmfs(kLogCvmfs, kLogStderr,
                "Failed to parse inclusion spec from '%s'",
@@ -966,8 +965,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
         const std::string &spec_content = inclusion_spec->content();
         StoreBuffer(
             reinterpret_cast<const unsigned char *>(spec_content.data()),
-            spec_content.size(),
-            ".cvmfs_partial_replication", false);
+            spec_content.size(), ".cvmfs_partial_replication", false);
         LogCvmfs(kLogCvmfs, kLogStdout,
                  "Uploaded partial replication spec to backend");
       }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -376,8 +376,8 @@ bool CommandPull::Pull(const shash::Any &catalog_hash,
     return true;
   }
 
-  const int64_t gauge_chunks = atomic_read64(&overall_chunks);
-  const int64_t gauge_new = atomic_read64(&overall_new);
+  const int64_t gauge_chunks = overall_chunks.load();
+  const int64_t gauge_new = overall_new.load();
 
   // Download and uncompress catalog
   shash::Any chunk_hash;
@@ -470,14 +470,14 @@ bool CommandPull::Pull(const shash::Any &catalog_hash,
       atomic_inc64(&chunk_queue);
     }
     catalog->AllChunksEnd();
-    while (atomic_read64(&chunk_queue) != 0) {
+    while (chunk_queue.load() != 0) {
       SafeSleepMs(100);
     }
     LogCvmfs(kLogCvmfs, kLogStdout,
              " fetched %" PRId64 " new chunks out of "
              "%" PRId64 " unique chunks",
-             atomic_read64(&overall_new) - gauge_new,
-             atomic_read64(&overall_chunks) - gauge_chunks);
+             overall_new.load() - gauge_new,
+             overall_chunks.load() - gauge_chunks);
   }
 
   retval = PullRecursion(catalog, path);
@@ -977,7 +977,7 @@ int swissknife::CommandPull::Main(const swissknife::ArgumentList &args) {
   WaitForStorage();
   LogCvmfs(kLogCvmfs, kLogStdout,
            "Fetched %" PRId64 " new chunks out of %" PRId64 " processed chunks",
-           atomic_read64(&overall_new), atomic_read64(&overall_chunks));
+           (overall_new).load(), atomic_read64(&overall_chunks));
   result = 0;
 
 fini:

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -286,7 +286,7 @@ static void *MainWorker(void *data) {
             (compression_alg == zlib::kZlibDefault) ? true : false);
       overall_new.fetch_add(1);
     }
-    if (atomic_xadd64(&overall_chunks, 1) % 1000 == 0)
+    if (overall_chunks.fetch_add(1) % 1000 == 0)
       LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, ".");
     chunk_queue.fetch_sub(1);
   }

--- a/cvmfs/swissknife_pull.cc
+++ b/cvmfs/swissknife_pull.cc
@@ -288,7 +288,7 @@ static void *MainWorker(void *data) {
     }
     if (atomic_xadd64(&overall_chunks, 1) % 1000 == 0)
       LogCvmfs(kLogCvmfs, kLogStdout | kLogNoLinebreak, ".");
-    atomic_dec64(&chunk_queue);
+    chunk_queue.fetch_sub(1);
   }
   return NULL;
 }

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -56,8 +56,6 @@
 using namespace std;  // NOLINT
 
 
-
-
 void TalkManager::Answer(int con_fd, const string &msg) {
   (void)send(con_fd, &msg[0], msg.length(), MSG_NOSIGNAL);
 }
@@ -620,22 +618,22 @@ void *TalkManager::MainResponder(void *data) {
           page_cache_stats = mount_point->page_cache_tracker()->GetStatistics();
       mount_point->statistics()
           ->Lookup("inode_tracker.n_insert")
-          ->Set(atomic_read64(&inode_stats.num_inserts));
+          ->Set(inode_stats.num_inserts.load());
       mount_point->statistics()
           ->Lookup("inode_tracker.n_remove")
-          ->Set(atomic_read64(&inode_stats.num_removes));
+          ->Set(inode_stats.num_removes.load());
       mount_point->statistics()
           ->Lookup("inode_tracker.no_reference")
-          ->Set(atomic_read64(&inode_stats.num_references));
+          ->Set(inode_stats.num_references.load());
       mount_point->statistics()
           ->Lookup("inode_tracker.n_hit_inode")
-          ->Set(atomic_read64(&inode_stats.num_hits_inode));
+          ->Set(inode_stats.num_hits_inode.load());
       mount_point->statistics()
           ->Lookup("inode_tracker.n_hit_path")
-          ->Set(atomic_read64(&inode_stats.num_hits_path));
+          ->Set(inode_stats.num_hits_path.load());
       mount_point->statistics()
           ->Lookup("inode_tracker.n_miss_path")
-          ->Set(atomic_read64(&inode_stats.num_misses_path));
+          ->Set(inode_stats.num_misses_path.load());
       mount_point->statistics()
           ->Lookup("dentry_tracker.n_insert")
           ->Set(dentry_stats.num_insert);
@@ -926,14 +924,14 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
   // Helper function to format a prometheus metric
   class MetricFormatter {
    public:
-    explicit MetricFormatter(string &result_ref) : result_(result_ref) {}
-    void operator()(const string &name, const string &type,
-                    const string &help, const string &labels,
-                    const string &value) {
+    explicit MetricFormatter(string &result_ref) : result_(result_ref) { }
+    void operator()(const string &name, const string &type, const string &help,
+                    const string &labels, const string &value) {
       result_ += "# HELP " + name + " " + help + "\n";
       result_ += "# TYPE " + name + " " + type + "\n";
       result_ += name + "{" + labels + "} " + value + "\n";
     }
+
    private:
     string &result_;
   };
@@ -946,16 +944,17 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
     const uint64_t size_pinned = quota_mgr->GetSizePinned();
 
     format_metric("cvmfs_cache_cached_bytes", "gauge",
-                  "CVMFS currently cached bytes.",
-                  "repo=\"" + fqrn + "\"", StringifyUint(size_unpinned));
+                  "CVMFS currently cached bytes.", "repo=\"" + fqrn + "\"",
+                  StringifyUint(size_unpinned));
     format_metric("cvmfs_cache_pinned_bytes", "gauge",
-                  "CVMFS currently pinned bytes.",
-                  "repo=\"" + fqrn + "\"", StringifyUint(size_pinned));
+                  "CVMFS currently pinned bytes.", "repo=\"" + fqrn + "\"",
+                  StringifyUint(size_pinned));
   }
 
   // Get cache limit from parameters
   string cache_limit_str;
-  if (file_system->options_mgr()->GetValue("CVMFS_QUOTA_LIMIT", &cache_limit_str)) {
+  if (file_system->options_mgr()->GetValue("CVMFS_QUOTA_LIMIT",
+                                           &cache_limit_str)) {
     const uint64_t cache_limit_mb = String2Uint64(cache_limit_str);
     const uint64_t cache_limit_bytes = cache_limit_mb * 1024 * 1024;
     format_metric("cvmfs_cache_total_size_bytes", "gauge",
@@ -968,8 +967,10 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
   if (file_system->options_mgr()->GetValue("CVMFS_CACHE_BASE", &cache_base)) {
     struct statvfs stat_info;
     if (statvfs(cache_base.c_str(), &stat_info) == 0) {
-      const uint64_t total_size = static_cast<uint64_t>(stat_info.f_blocks) * stat_info.f_frsize;
-      const uint64_t avail_size = static_cast<uint64_t>(stat_info.f_bavail) * stat_info.f_frsize;
+      const uint64_t total_size = static_cast<uint64_t>(stat_info.f_blocks)
+                                  * stat_info.f_frsize;
+      const uint64_t avail_size = static_cast<uint64_t>(stat_info.f_bavail)
+                                  * stat_info.f_frsize;
 
       format_metric("cvmfs_cache_physical_size_bytes", "gauge",
                     "CVMFS cache volume physical size.",
@@ -981,19 +982,22 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
   }
 
   // Version and revision information
-  const string version = string(CVMFS_VERSION) + "." + string(CVMFS_PATCH_LEVEL);
+  const string version = string(CVMFS_VERSION) + "."
+                         + string(CVMFS_PATCH_LEVEL);
   const uint64_t revision = mount_point.catalog_mgr()->GetRevision();
   format_metric("cvmfs_repo", "gauge",
                 "Shows the version of CVMFS used by this repository.",
-                "repo=\"" + fqrn + "\",mountpoint=\"" + mountpoint +
-                "\",version=\"" + version + "\",revision=\"" + StringifyUint(revision) + "\"",
+                "repo=\"" + fqrn + "\",mountpoint=\"" + mountpoint
+                    + "\",version=\"" + version + "\",revision=\""
+                    + StringifyUint(revision) + "\"",
                 "1");
 
   // Statistics-based metrics
   perf::Statistics *statistics = mount_point.statistics();
 
   // Download statistics
-  const int64_t rx_bytes = statistics->Lookup("download.sz_transferred_bytes")->Get();
+  const int64_t rx_bytes = statistics->Lookup("download.sz_transferred_bytes")
+                               ->Get();
   format_metric("cvmfs_net_rx_bytes_total", "counter",
                 "Shows the overall amount of downloaded bytes since mounting.",
                 "repo=\"" + fqrn + "\"", StringifyInt(rx_bytes));
@@ -1004,25 +1008,26 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
                 "repo=\"" + fqrn + "\"", StringifyInt(n_downloads));
 
   // Hit rate calculation
-  const int64_t n_invocations = statistics->Lookup("fetch.n_invocations")->Get();
+  const int64_t n_invocations = statistics->Lookup("fetch.n_invocations")
+                                    ->Get();
   if (n_invocations > 0) {
-    const float hit_ratio = 1.0 - (static_cast<float>(n_downloads) /
-                                   static_cast<float>(n_invocations));
+    const float hit_ratio = 1.0
+                            - (static_cast<float>(n_downloads)
+                               / static_cast<float>(n_invocations));
     format_metric("cvmfs_cache_hit_ratio", "gauge",
-                  "CVMFS cache hit ratio (0-1).",
-                  "repo=\"" + fqrn + "\"", StringifyDouble(hit_ratio));
+                  "CVMFS cache hit ratio (0-1).", "repo=\"" + fqrn + "\"",
+                  StringifyDouble(hit_ratio));
   } else {
     format_metric("cvmfs_cache_hit_ratio", "gauge",
-                  "CVMFS cache hit ratio (0-1).",
-                  "repo=\"" + fqrn + "\"", "0");
+                  "CVMFS cache hit ratio (0-1).", "repo=\"" + fqrn + "\"", "0");
   }
 
   // Cumulative time spent transferring data.  Combined with
   // cvmfs_net_rx_bytes_total this lets consumers compute their own average
   // download speed, rather than exposing a pre-computed rate with implicit
   // units.  The underlying statistic is in milliseconds.
-  const int64_t transfer_time_ms =
-      statistics->Lookup("download.sz_transfer_time")->Get();
+  const int64_t
+      transfer_time_ms = statistics->Lookup("download.sz_transfer_time")->Get();
   format_metric("cvmfs_net_transfer_time_seconds_total", "counter",
                 "Cumulative time spent downloading data since mounting.",
                 "repo=\"" + fqrn + "\"",
@@ -1044,15 +1049,17 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
   if (catalogs_valid_until != MountPoint::kIndefiniteDeadline) {
     const int64_t expires_seconds = (catalogs_valid_until - now);
     format_metric("cvmfs_repo_expires_seconds", "gauge",
-                  "Shows the remaining life time of the mounted root file catalog in seconds.",
+                  "Shows the remaining life time of the mounted root file "
+                  "catalog in seconds.",
                   "repo=\"" + fqrn + "\"", StringifyInt(expires_seconds));
   }
 
   // I/O error count
   const uint64_t nioerr = file_system->io_error_info()->count();
-  format_metric("cvmfs_sys_nioerr_total", "counter",
-                "Shows the total number of I/O errors encountered since mounting.",
-                "repo=\"" + fqrn + "\"", StringifyUint(nioerr));
+  format_metric(
+      "cvmfs_sys_nioerr_total", "counter",
+      "Shows the total number of I/O errors encountered since mounting.",
+      "repo=\"" + fqrn + "\"", StringifyUint(nioerr));
 
   // Timeout information
   unsigned timeout_proxy, timeout_direct;
@@ -1065,7 +1072,8 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
                 "repo=\"" + fqrn + "\"", StringifyUint(timeout_direct));
 
   // Last I/O error timestamp
-  const int64_t timestamp_last_ioerr = file_system->io_error_info()->timestamp_last();
+  const int64_t timestamp_last_ioerr = file_system->io_error_info()
+                                           ->timestamp_last();
   format_metric("cvmfs_sys_last_ioerr_timestamp_seconds", "gauge",
                 "Shows the timestamp of the last ioerror.",
                 "repo=\"" + fqrn + "\"", StringifyInt(timestamp_last_ioerr));
@@ -1089,8 +1097,10 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
                         "CPU time used in userspace by CVMFS mount in seconds.",
                         "repo=\"" + fqrn + "\"", StringifyDouble(user_seconds));
           format_metric("cvmfs_sys_cpu_system_seconds_total", "counter",
-                        "CPU time used in the kernel system calls by CVMFS mount in seconds.",
-                        "repo=\"" + fqrn + "\"", StringifyDouble(system_seconds));
+                        "CPU time used in the kernel system calls by CVMFS "
+                        "mount in seconds.",
+                        "repo=\"" + fqrn + "\"",
+                        StringifyDouble(system_seconds));
         }
       }
     }
@@ -1099,11 +1109,13 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
 
   // File descriptor and directory counts
   format_metric("cvmfs_sys_usedfd", "gauge",
-                "Shows the number of file descriptors currently issued to file system clients.",
+                "Shows the number of file descriptors currently issued to file "
+                "system clients.",
                 "repo=\"" + fqrn + "\"",
                 file_system->no_open_files()->ToString());
   format_metric("cvmfs_sys_useddirp", "gauge",
-                "Shows the number of open directories currently used by file system clients.",
+                "Shows the number of open directories currently used by file "
+                "system clients.",
                 "repo=\"" + fqrn + "\"",
                 file_system->no_open_dirs()->ToString());
   format_metric("cvmfs_sys_ndiropen", "gauge",
@@ -1113,10 +1125,11 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
 
   // Inode max
   format_metric("cvmfs_sys_inode_max", "gauge",
-                "Shows the highest possible inode with the current set of loaded catalogs.",
+                "Shows the highest possible inode with the current set of "
+                "loaded catalogs.",
                 "repo=\"" + fqrn + "\"",
-                StringifyInt(mount_point.inode_annotation()->GetGeneration() +
-                           mount_point.catalog_mgr()->inode_gauge()));
+                StringifyInt(mount_point.inode_annotation()->GetGeneration()
+                             + mount_point.catalog_mgr()->inode_gauge()));
 
   // Process ID
   format_metric("cvmfs_sys_pid", "gauge",
@@ -1147,8 +1160,8 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
   unsigned current_group;
   mount_point.download_mgr()->GetProxyInfo(&proxy_chain, &current_group, NULL);
   string active_proxy = "DIRECT";
-  if (proxy_chain.size() > 0 && current_group < proxy_chain.size() &&
-      proxy_chain[current_group].size() > 0) {
+  if (proxy_chain.size() > 0 && current_group < proxy_chain.size()
+      && proxy_chain[current_group].size() > 0) {
     active_proxy = proxy_chain[current_group][0].url;
   }
   format_metric("cvmfs_net_active_proxy", "gauge",
@@ -1160,120 +1173,182 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
     for (unsigned int j = 0; j < proxy_chain[i].size(); j++) {
       format_metric("cvmfs_net_proxy", "gauge",
                     "Shows all registered proxies for this repository.",
-                    "repo=\"" + fqrn + "\",group=\"" + StringifyInt(i) +
-                    "\",url=\"" + proxy_chain[i][j].url + "\"", "1");
+                    "repo=\"" + fqrn + "\",group=\"" + StringifyInt(i)
+                        + "\",url=\"" + proxy_chain[i][j].url + "\"",
+                    "1");
     }
   }
 
   // Internal affairs metrics (excluding histograms)
 
   // Update string counters manually (same as internal affairs does)
-  mount_point.statistics()->Lookup("pathstring.n_instances")->Set(PathString::num_instances());
-  mount_point.statistics()->Lookup("pathstring.n_overflows")->Set(PathString::num_overflows());
-  mount_point.statistics()->Lookup("namestring.n_instances")->Set(NameString::num_instances());
-  mount_point.statistics()->Lookup("namestring.n_overflows")->Set(NameString::num_overflows());
-  mount_point.statistics()->Lookup("linkstring.n_instances")->Set(LinkString::num_instances());
-  mount_point.statistics()->Lookup("linkstring.n_overflows")->Set(LinkString::num_overflows());
+  mount_point.statistics()
+      ->Lookup("pathstring.n_instances")
+      ->Set(PathString::num_instances());
+  mount_point.statistics()
+      ->Lookup("pathstring.n_overflows")
+      ->Set(PathString::num_overflows());
+  mount_point.statistics()
+      ->Lookup("namestring.n_instances")
+      ->Set(NameString::num_instances());
+  mount_point.statistics()
+      ->Lookup("namestring.n_overflows")
+      ->Set(NameString::num_overflows());
+  mount_point.statistics()
+      ->Lookup("linkstring.n_instances")
+      ->Set(LinkString::num_instances());
+  mount_point.statistics()
+      ->Lookup("linkstring.n_overflows")
+      ->Set(LinkString::num_overflows());
 
   // String statistics
-  const int64_t pathstring_instances = mount_point.statistics()->Lookup("pathstring.n_instances")->Get();
-  const int64_t pathstring_overflows = mount_point.statistics()->Lookup("pathstring.n_overflows")->Get();
-  const int64_t namestring_instances = mount_point.statistics()->Lookup("namestring.n_instances")->Get();
-  const int64_t namestring_overflows = mount_point.statistics()->Lookup("namestring.n_overflows")->Get();
-  const int64_t linkstring_instances = mount_point.statistics()->Lookup("linkstring.n_instances")->Get();
-  const int64_t linkstring_overflows = mount_point.statistics()->Lookup("linkstring.n_overflows")->Get();
+  const int64_t pathstring_instances = mount_point.statistics()
+                                           ->Lookup("pathstring.n_instances")
+                                           ->Get();
+  const int64_t pathstring_overflows = mount_point.statistics()
+                                           ->Lookup("pathstring.n_overflows")
+                                           ->Get();
+  const int64_t namestring_instances = mount_point.statistics()
+                                           ->Lookup("namestring.n_instances")
+                                           ->Get();
+  const int64_t namestring_overflows = mount_point.statistics()
+                                           ->Lookup("namestring.n_overflows")
+                                           ->Get();
+  const int64_t linkstring_instances = mount_point.statistics()
+                                           ->Lookup("linkstring.n_instances")
+                                           ->Get();
+  const int64_t linkstring_overflows = mount_point.statistics()
+                                           ->Lookup("linkstring.n_overflows")
+                                           ->Get();
 
   format_metric("cvmfs_internal_pathstring_instances", "gauge",
-                "Number of PathString instances.",
-                "repo=\"" + fqrn + "\"", StringifyInt(pathstring_instances));
+                "Number of PathString instances.", "repo=\"" + fqrn + "\"",
+                StringifyInt(pathstring_instances));
   format_metric("cvmfs_internal_pathstring_overflows", "counter",
-                "Number of PathString overflows.",
-                "repo=\"" + fqrn + "\"", StringifyInt(pathstring_overflows));
+                "Number of PathString overflows.", "repo=\"" + fqrn + "\"",
+                StringifyInt(pathstring_overflows));
   format_metric("cvmfs_internal_namestring_instances", "gauge",
-                "Number of NameString instances.",
-                "repo=\"" + fqrn + "\"", StringifyInt(namestring_instances));
+                "Number of NameString instances.", "repo=\"" + fqrn + "\"",
+                StringifyInt(namestring_instances));
   format_metric("cvmfs_internal_namestring_overflows", "counter",
-                "Number of NameString overflows.",
-                "repo=\"" + fqrn + "\"", StringifyInt(namestring_overflows));
+                "Number of NameString overflows.", "repo=\"" + fqrn + "\"",
+                StringifyInt(namestring_overflows));
   format_metric("cvmfs_internal_linkstring_instances", "gauge",
-                "Number of LinkString instances.",
-                "repo=\"" + fqrn + "\"", StringifyInt(linkstring_instances));
+                "Number of LinkString instances.", "repo=\"" + fqrn + "\"",
+                StringifyInt(linkstring_instances));
   format_metric("cvmfs_internal_linkstring_overflows", "counter",
-                "Number of LinkString overflows.",
-                "repo=\"" + fqrn + "\"", StringifyInt(linkstring_overflows));
+                "Number of LinkString overflows.", "repo=\"" + fqrn + "\"",
+                StringifyInt(linkstring_overflows));
 
   // Tracker statistics (same as internal affairs does)
-  glue::InodeTracker::Statistics inode_stats = mount_point.inode_tracker()->GetStatistics();
-  const glue::DentryTracker::Statistics dentry_stats = mount_point.dentry_tracker()->GetStatistics();
-  const glue::PageCacheTracker::Statistics page_cache_stats = mount_point.page_cache_tracker()->GetStatistics();
+  glue::InodeTracker::Statistics inode_stats = mount_point.inode_tracker()
+                                                   ->GetStatistics();
+  const glue::DentryTracker::Statistics
+      dentry_stats = mount_point.dentry_tracker()->GetStatistics();
+  const glue::PageCacheTracker::Statistics
+      page_cache_stats = mount_point.page_cache_tracker()->GetStatistics();
 
   // Update statistics manually
-  mount_point.statistics()->Lookup("inode_tracker.n_insert")->Set(atomic_read64(&inode_stats.num_inserts));
-  mount_point.statistics()->Lookup("inode_tracker.n_remove")->Set(atomic_read64(&inode_stats.num_removes));
-  mount_point.statistics()->Lookup("inode_tracker.no_reference")->Set(atomic_read64(&inode_stats.num_references));
-  mount_point.statistics()->Lookup("inode_tracker.n_hit_inode")->Set(atomic_read64(&inode_stats.num_hits_inode));
-  mount_point.statistics()->Lookup("inode_tracker.n_hit_path")->Set(atomic_read64(&inode_stats.num_hits_path));
-  mount_point.statistics()->Lookup("inode_tracker.n_miss_path")->Set(atomic_read64(&inode_stats.num_misses_path));
-  mount_point.statistics()->Lookup("dentry_tracker.n_insert")->Set(dentry_stats.num_insert);
-  mount_point.statistics()->Lookup("dentry_tracker.n_remove")->Set(dentry_stats.num_remove);
-  mount_point.statistics()->Lookup("dentry_tracker.n_prune")->Set(dentry_stats.num_prune);
-  mount_point.statistics()->Lookup("page_cache_tracker.n_insert")->Set(page_cache_stats.n_insert);
-  mount_point.statistics()->Lookup("page_cache_tracker.n_remove")->Set(page_cache_stats.n_remove);
-  mount_point.statistics()->Lookup("page_cache_tracker.n_open_direct")->Set(page_cache_stats.n_open_direct);
-  mount_point.statistics()->Lookup("page_cache_tracker.n_open_flush")->Set(page_cache_stats.n_open_flush);
-  mount_point.statistics()->Lookup("page_cache_tracker.n_open_cached")->Set(page_cache_stats.n_open_cached);
+  mount_point.statistics()
+      ->Lookup("inode_tracker.n_insert")
+      ->Set(inode_stats.num_inserts.load());
+  mount_point.statistics()
+      ->Lookup("inode_tracker.n_remove")
+      ->Set(inode_stats.num_removes.load());
+  mount_point.statistics()
+      ->Lookup("inode_tracker.no_reference")
+      ->Set(inode_stats.num_references.load());
+  mount_point.statistics()
+      ->Lookup("inode_tracker.n_hit_inode")
+      ->Set(inode_stats.num_hits_inode.load());
+  mount_point.statistics()
+      ->Lookup("inode_tracker.n_hit_path")
+      ->Set(inode_stats.num_hits_path.load());
+  mount_point.statistics()
+      ->Lookup("inode_tracker.n_miss_path")
+      ->Set(inode_stats.num_misses_path.load());
+  mount_point.statistics()
+      ->Lookup("dentry_tracker.n_insert")
+      ->Set(dentry_stats.num_insert);
+  mount_point.statistics()
+      ->Lookup("dentry_tracker.n_remove")
+      ->Set(dentry_stats.num_remove);
+  mount_point.statistics()
+      ->Lookup("dentry_tracker.n_prune")
+      ->Set(dentry_stats.num_prune);
+  mount_point.statistics()
+      ->Lookup("page_cache_tracker.n_insert")
+      ->Set(page_cache_stats.n_insert);
+  mount_point.statistics()
+      ->Lookup("page_cache_tracker.n_remove")
+      ->Set(page_cache_stats.n_remove);
+  mount_point.statistics()
+      ->Lookup("page_cache_tracker.n_open_direct")
+      ->Set(page_cache_stats.n_open_direct);
+  mount_point.statistics()
+      ->Lookup("page_cache_tracker.n_open_flush")
+      ->Set(page_cache_stats.n_open_flush);
+  mount_point.statistics()
+      ->Lookup("page_cache_tracker.n_open_cached")
+      ->Set(page_cache_stats.n_open_cached);
 
   // Inode tracker metrics
   format_metric("cvmfs_internal_inode_tracker_inserts_total", "counter",
-                "Number of inode tracker insertions.",
-                "repo=\"" + fqrn + "\"", StringifyInt(atomic_read64(&inode_stats.num_inserts)));
+                "Number of inode tracker insertions.", "repo=\"" + fqrn + "\"",
+                StringifyInt(inode_stats.num_inserts.load()));
   format_metric("cvmfs_internal_inode_tracker_removes_total", "counter",
-                "Number of inode tracker removals.",
-                "repo=\"" + fqrn + "\"", StringifyInt(atomic_read64(&inode_stats.num_removes)));
+                "Number of inode tracker removals.", "repo=\"" + fqrn + "\"",
+                StringifyInt(inode_stats.num_removes.load()));
   format_metric("cvmfs_internal_inode_tracker_references", "gauge",
-                "Number of inode tracker references.",
-                "repo=\"" + fqrn + "\"", StringifyInt(atomic_read64(&inode_stats.num_references)));
+                "Number of inode tracker references.", "repo=\"" + fqrn + "\"",
+                StringifyInt(inode_stats.num_references.load()));
   format_metric("cvmfs_internal_inode_tracker_hits_inode_total", "counter",
-                "Number of inode tracker inode hits.",
-                "repo=\"" + fqrn + "\"", StringifyInt(atomic_read64(&inode_stats.num_hits_inode)));
+                "Number of inode tracker inode hits.", "repo=\"" + fqrn + "\"",
+                StringifyInt(inode_stats.num_hits_inode.load()));
   format_metric("cvmfs_internal_inode_tracker_hits_path_total", "counter",
-                "Number of inode tracker path hits.",
-                "repo=\"" + fqrn + "\"", StringifyInt(atomic_read64(&inode_stats.num_hits_path)));
+                "Number of inode tracker path hits.", "repo=\"" + fqrn + "\"",
+                StringifyInt(inode_stats.num_hits_path.load()));
   format_metric("cvmfs_internal_inode_tracker_misses_path_total", "counter",
-                "Number of inode tracker path misses.",
-                "repo=\"" + fqrn + "\"", StringifyInt(atomic_read64(&inode_stats.num_misses_path)));
+                "Number of inode tracker path misses.", "repo=\"" + fqrn + "\"",
+                StringifyInt(inode_stats.num_misses_path.load()));
 
   // Dentry tracker metrics
   format_metric("cvmfs_internal_dentry_tracker_inserts_total", "counter",
-                "Number of dentry tracker insertions.",
-                "repo=\"" + fqrn + "\"", StringifyInt(dentry_stats.num_insert));
+                "Number of dentry tracker insertions.", "repo=\"" + fqrn + "\"",
+                StringifyInt(dentry_stats.num_insert));
   format_metric("cvmfs_internal_dentry_tracker_removes_total", "counter",
-                "Number of dentry tracker removals.",
-                "repo=\"" + fqrn + "\"", StringifyInt(dentry_stats.num_remove));
+                "Number of dentry tracker removals.", "repo=\"" + fqrn + "\"",
+                StringifyInt(dentry_stats.num_remove));
   format_metric("cvmfs_internal_dentry_tracker_prunes_total", "counter",
-                "Number of dentry tracker prunes.",
-                "repo=\"" + fqrn + "\"", StringifyInt(dentry_stats.num_prune));
+                "Number of dentry tracker prunes.", "repo=\"" + fqrn + "\"",
+                StringifyInt(dentry_stats.num_prune));
 
   // Page cache tracker metrics
   format_metric("cvmfs_internal_page_cache_tracker_inserts_total", "counter",
                 "Number of page cache tracker insertions.",
-                "repo=\"" + fqrn + "\"", StringifyInt(page_cache_stats.n_insert));
+                "repo=\"" + fqrn + "\"",
+                StringifyInt(page_cache_stats.n_insert));
   format_metric("cvmfs_internal_page_cache_tracker_removes_total", "counter",
                 "Number of page cache tracker removals.",
-                "repo=\"" + fqrn + "\"", StringifyInt(page_cache_stats.n_remove));
-  format_metric("cvmfs_internal_page_cache_tracker_opens_direct_total", "counter",
-                "Number of page cache tracker direct opens.",
-                "repo=\"" + fqrn + "\"", StringifyInt(page_cache_stats.n_open_direct));
-  format_metric("cvmfs_internal_page_cache_tracker_opens_flush_total", "counter",
-                "Number of page cache tracker flush opens.",
-                "repo=\"" + fqrn + "\"", StringifyInt(page_cache_stats.n_open_flush));
-  format_metric("cvmfs_internal_page_cache_tracker_opens_cached_total", "counter",
-                "Number of page cache tracker cached opens.",
-                "repo=\"" + fqrn + "\"", StringifyInt(page_cache_stats.n_open_cached));
+                "repo=\"" + fqrn + "\"",
+                StringifyInt(page_cache_stats.n_remove));
+  format_metric("cvmfs_internal_page_cache_tracker_opens_direct_total",
+                "counter", "Number of page cache tracker direct opens.",
+                "repo=\"" + fqrn + "\"",
+                StringifyInt(page_cache_stats.n_open_direct));
+  format_metric("cvmfs_internal_page_cache_tracker_opens_flush_total",
+                "counter", "Number of page cache tracker flush opens.",
+                "repo=\"" + fqrn + "\"",
+                StringifyInt(page_cache_stats.n_open_flush));
+  format_metric("cvmfs_internal_page_cache_tracker_opens_cached_total",
+                "counter", "Number of page cache tracker cached opens.",
+                "repo=\"" + fqrn + "\"",
+                StringifyInt(page_cache_stats.n_open_cached));
 
   // Cache mode information
   if (file_system->cache_mgr()->id() == kPosixCacheManager) {
-    PosixCacheManager *cache_mgr = reinterpret_cast<PosixCacheManager *>(file_system->cache_mgr());
+    PosixCacheManager *cache_mgr = reinterpret_cast<PosixCacheManager *>(
+        file_system->cache_mgr());
     int cache_mode_value = 0;
     switch (cache_mgr->cache_mode()) {
       case PosixCacheManager::kCacheReadWrite:
@@ -1299,15 +1374,16 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
                 "repo=\"" + fqrn + "\"", StringifyInt(drainout_mode ? 1 : 0));
   format_metric("cvmfs_sys_maintenance_mode", "gauge",
                 "Maintenance mode status (0=false, 1=true).",
-                "repo=\"" + fqrn + "\"", StringifyInt(maintenance_mode ? 1 : 0));
+                "repo=\"" + fqrn + "\"",
+                StringifyInt(maintenance_mode ? 1 : 0));
 
   // SQLite statistics
   int current, highwater;
 
   sqlite3_status(SQLITE_STATUS_MALLOC_COUNT, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_malloc_count", "gauge",
-                "Number of SQLite allocations.",
-                "repo=\"" + fqrn + "\"", StringifyInt(current));
+                "Number of SQLite allocations.", "repo=\"" + fqrn + "\"",
+                StringifyInt(current));
 
   sqlite3_status(SQLITE_STATUS_MEMORY_USED, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_memory_used_bytes", "gauge",
@@ -1319,23 +1395,23 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
 
   sqlite3_status(SQLITE_STATUS_MALLOC_SIZE, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_largest_malloc_bytes", "gauge",
-                "SQLite largest malloc size.",
-                "repo=\"" + fqrn + "\"", StringifyInt(highwater));
+                "SQLite largest malloc size.", "repo=\"" + fqrn + "\"",
+                StringifyInt(highwater));
 
   sqlite3_status(SQLITE_STATUS_PAGECACHE_USED, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_pagecache_used", "gauge",
-                "SQLite page cache allocations used.",
-                "repo=\"" + fqrn + "\"", StringifyInt(current));
+                "SQLite page cache allocations used.", "repo=\"" + fqrn + "\"",
+                StringifyInt(current));
   format_metric("cvmfs_internal_sqlite_pagecache_used_highwater", "gauge",
                 "SQLite page cache allocations used high water mark.",
                 "repo=\"" + fqrn + "\"", StringifyInt(highwater));
 
   sqlite3_status(SQLITE_STATUS_PAGECACHE_OVERFLOW, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_pagecache_overflow_bytes", "gauge",
-                "SQLite page cache overflow bytes.",
-                "repo=\"" + fqrn + "\"", StringifyInt(current));
-  format_metric("cvmfs_internal_sqlite_pagecache_overflow_highwater_bytes", "gauge",
-                "SQLite page cache overflow bytes high water mark.",
+                "SQLite page cache overflow bytes.", "repo=\"" + fqrn + "\"",
+                StringifyInt(current));
+  format_metric("cvmfs_internal_sqlite_pagecache_overflow_highwater_bytes",
+                "gauge", "SQLite page cache overflow bytes high water mark.",
                 "repo=\"" + fqrn + "\"", StringifyInt(highwater));
 
   sqlite3_status(SQLITE_STATUS_PAGECACHE_SIZE, &current, &highwater, 0);
@@ -1345,16 +1421,16 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
 
   sqlite3_status(SQLITE_STATUS_SCRATCH_USED, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_scratch_used", "gauge",
-                "SQLite scratch allocations used.",
-                "repo=\"" + fqrn + "\"", StringifyInt(current));
+                "SQLite scratch allocations used.", "repo=\"" + fqrn + "\"",
+                StringifyInt(current));
   format_metric("cvmfs_internal_sqlite_scratch_used_highwater", "gauge",
                 "SQLite scratch allocations used high water mark.",
                 "repo=\"" + fqrn + "\"", StringifyInt(highwater));
 
   sqlite3_status(SQLITE_STATUS_SCRATCH_OVERFLOW, &current, &highwater, 0);
   format_metric("cvmfs_internal_sqlite_scratch_overflow", "gauge",
-                "SQLite scratch overflows.",
-                "repo=\"" + fqrn + "\"", StringifyInt(current));
+                "SQLite scratch overflows.", "repo=\"" + fqrn + "\"",
+                StringifyInt(current));
   format_metric("cvmfs_internal_sqlite_scratch_overflow_highwater", "gauge",
                 "SQLite scratch overflows high water mark.",
                 "repo=\"" + fqrn + "\"", StringifyInt(highwater));
@@ -1369,7 +1445,8 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
     format_metric("cvmfs_sys_nfs_mode", "gauge",
                   "NFS mode enabled (1=true, 0=false).",
                   "repo=\"" + fqrn + "\"", "1");
-    // Note: NFS map statistics are complex strings, skipping detailed parsing for now
+    // Note: NFS map statistics are complex strings, skipping detailed parsing
+    // for now
   } else {
     format_metric("cvmfs_sys_nfs_mode", "gauge",
                   "NFS mode enabled (1=true, 0=false).",

--- a/cvmfs/talk.cc
+++ b/cvmfs/talk.cc
@@ -1241,7 +1241,7 @@ string TalkManager::FormatPrometheusMetrics(MountPoint &mount_point,
                 StringifyInt(linkstring_overflows));
 
   // Tracker statistics (same as internal affairs does)
-  glue::InodeTracker::Statistics inode_stats = mount_point.inode_tracker()
+  const glue::InodeTracker::Statistics inode_stats = mount_point.inode_tracker()
                                                    ->GetStatistics();
   const glue::DentryTracker::Statistics
       dentry_stats = mount_point.dentry_tracker()->GetStatistics();

--- a/cvmfs/telemetry_aggregator.cc
+++ b/cvmfs/telemetry_aggregator.cc
@@ -83,22 +83,22 @@ void TelemetryAggregator::ManuallyUpdateSelectedCounters() {
       page_cache_stats = mount_point_->page_cache_tracker()->GetStatistics();
   mount_point_->statistics()
       ->Lookup("inode_tracker.n_insert")
-      ->Set(atomic_read64(&inode_stats.num_inserts));
+      ->Set(inode_stats.num_inserts.load());
   mount_point_->statistics()
       ->Lookup("inode_tracker.n_remove")
-      ->Set(atomic_read64(&inode_stats.num_removes));
+      ->Set(inode_stats.num_removes.load());
   mount_point_->statistics()
       ->Lookup("inode_tracker.no_reference")
-      ->Set(atomic_read64(&inode_stats.num_references));
+      ->Set(inode_stats.num_references.load());
   mount_point_->statistics()
       ->Lookup("inode_tracker.n_hit_inode")
-      ->Set(atomic_read64(&inode_stats.num_hits_inode));
+      ->Set(inode_stats.num_hits_inode.load());
   mount_point_->statistics()
       ->Lookup("inode_tracker.n_hit_path")
-      ->Set(atomic_read64(&inode_stats.num_hits_path));
+      ->Set(inode_stats.num_hits_path.load());
   mount_point_->statistics()
       ->Lookup("inode_tracker.n_miss_path")
-      ->Set(atomic_read64(&inode_stats.num_misses_path));
+      ->Set(inode_stats.num_misses_path.load());
   mount_point_->statistics()
       ->Lookup("dentry_tracker.n_insert")
       ->Set(dentry_stats.num_insert);

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -163,30 +163,11 @@ void *Tracer::MainFlush(void *data) {
 
     const int base = tracer->flushed_.load() % tracer->buffer_size_;
     int pos, i = 0;
-    while ((i <= tracer->flush_threshold_)
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-               .load()
-           &.load()
-           &.load().load()(
-                   .load() a.load() t.load() o.load() m.load() i.load()
-                       c.load() _.load() r.load() e.load() a.load() d
-                   .load() 3.load() 2.load()(
-                           .load()
-                           .load()
-                           & tracer
-                           ->commit_buffer_[pos = ((base + i)
-                                                   % tracer->buffer_size_)])
-                   == 1)) {
+    while (
+        (i <= tracer->flush_threshold_)
+        && ((tracer->commit_buffer_[pos = ((base + i) % tracer->buffer_size_)])
+                .load()
+            == 1)) {
       string tmp;
       tmp = StringifyTimeval(tracer->ring_buffer_[pos].time_stamp);
       retval = tracer->WriteCsvFile(f, tmp);
@@ -303,3 +284,4 @@ int Tracer::WriteCsvFile(FILE *fp, const string &field) {
 
   return 0;
 }
+

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -87,7 +87,7 @@ int32_t Tracer::DoTrace(const int event,
   ring_buffer_[pos].code = event;
   ring_buffer_[pos].path = path;
   ring_buffer_[pos].msg = msg;
-  atomic_inc32(&commit_buffer_[pos]);
+  commit_buffer_[pos].fetch_add(1);
 
   if (my_seq_no - flushed_.load() == flush_threshold_) {
     const MutexLockGuard m(&sig_flush_mutex_);
@@ -257,7 +257,7 @@ Tracer::~Tracer() {
     DoTrace(kEventStop, PathString("Tracer", 6), "Destroying trace buffer...");
 
     // Trigger flushing and wait for it
-    atomic_inc32(&terminate_flush_thread_);
+    terminate_flush_thread_.fetch_add(1);
     {
       const MutexLockGuard m(&sig_flush_mutex_);
       retval = pthread_cond_signal(&sig_flush_);

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -67,7 +67,7 @@ void Tracer::Activate(const int buffer_size,
 int32_t Tracer::DoTrace(const int event,
                         const PathString &path,
                         const string &msg) {
-  const int32_t my_seq_no = atomic_xadd32(&seq_no_, 1);
+  const int32_t my_seq_no = seq_no_.fetch_add(1);
   timeval now;
   gettimeofday(&now, NULL);
   const int pos = my_seq_no % buffer_size_;
@@ -205,7 +205,7 @@ void *Tracer::MainFlush(void *data) {
     }
     retval = fflush(f);
     assert(retval == 0);
-    atomic_xadd32(&tracer->flushed_, i);
+    tracer->flushed_.fetch_add(i);
     atomic_cas32(&tracer->flush_immediately_, 1, 0);
 
     {

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -72,7 +72,7 @@ int32_t Tracer::DoTrace(const int event,
   gettimeofday(&now, NULL);
   const int pos = my_seq_no % buffer_size_;
 
-  while (my_seq_no - atomic_read32(&flushed_) >= buffer_size_) {
+  while (my_seq_no - flushed_.load() >= buffer_size_) {
     timespec timeout;
     int retval;
     GetTimespecRel(25, &timeout);
@@ -89,7 +89,7 @@ int32_t Tracer::DoTrace(const int event,
   ring_buffer_[pos].msg = msg;
   atomic_inc32(&commit_buffer_[pos]);
 
-  if (my_seq_no - atomic_read32(&flushed_) == flush_threshold_) {
+  if (my_seq_no - flushed_.load() == flush_threshold_) {
     const MutexLockGuard m(&sig_flush_mutex_);
     const int err_code
         __attribute__((unused)) = pthread_cond_signal(&sig_flush_);
@@ -106,7 +106,7 @@ void Tracer::Flush() {
 
   const int32_t save_seq_no = DoTrace(kEventFlush, PathString("Tracer", 6),
                                       "flushed ring buffer");
-  while (atomic_read32(&flushed_) <= save_seq_no) {
+  while (flushed_.load() <= save_seq_no) {
     timespec timeout;
     int retval;
 
@@ -150,24 +150,42 @@ void *Tracer::MainFlush(void *data) {
   struct timespec timeout;
 
   do {
-    while (
-        (atomic_read32(&tracer->terminate_flush_thread_) == 0)
-        && (atomic_read32(&tracer->flush_immediately_) == 0)
-        && (atomic_read32(&tracer->seq_no_) - atomic_read32(&tracer->flushed_)
-            <= tracer->flush_threshold_)) {
+    while ((tracer->terminate_flush_thread_.load() == 0)
+           && (tracer->flush_immediately_.load() == 0)
+           && ((tracer->seq_no_).load() - (tracer->flushed_).load()
+               <= tracer->flush_threshold_)) {
       tracer->GetTimespecRel(2000, &timeout);
       retval = pthread_cond_timedwait(&tracer->sig_flush_,
                                       &tracer->sig_flush_mutex_, &timeout);
       assert(retval != EINVAL);
     }
 
-    const int base = atomic_read32(&tracer->flushed_) % tracer->buffer_size_;
+    const int base = tracer->flushed_.load() % tracer->buffer_size_;
     int pos, i = 0;
     while ((i <= tracer->flush_threshold_)
-           && (atomic_read32(
-                   &tracer->commit_buffer_[pos = ((base + i)
-                                                  % tracer->buffer_size_)])
-               == 1)) {
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+               .load()
+           &.load()
+           &.load().load()(
+                   .load() a.load() t.load() o.load() m.load() i.load()
+                       c.load() _.load() r.load() e.load() a.load() d
+                   .load() 3.load() 2.load()(
+                           .load()
+                           .load()
+                           & tracer
+                           ->commit_buffer_[pos = ((base + i)
+                                                   % tracer->buffer_size_)])
+                   == 1)) {
       string tmp;
       tmp = StringifyTimeval(tracer->ring_buffer_[pos].time_stamp);
       retval = tracer->WriteCsvFile(f, tmp);
@@ -195,9 +213,8 @@ void *Tracer::MainFlush(void *data) {
       retval = pthread_cond_broadcast(&tracer->sig_continue_trace_);
       assert(retval == 0);
     }
-  } while (
-      (atomic_read32(&tracer->terminate_flush_thread_) == 0)
-      || (atomic_read32(&tracer->flushed_) < atomic_read32(&tracer->seq_no_)));
+  } while ((tracer->terminate_flush_thread_.load() == 0)
+           || ((tracer->flushed_).load() < (tracer->seq_no_).load()));
 
   retval = fclose(f);
   assert(retval == 0);

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -200,7 +200,7 @@ void *Tracer::MainFlush(void *data) {
       retval |= (fputc(13, f) - 13) | (fputc(10, f) - 10);
       assert(retval == 0);
 
-      atomic_dec32(&tracer->commit_buffer_[pos]);
+      tracer->commit_buffer_[pos].fetch_sub(1);
       ++i;
     }
     retval = fflush(f);

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -110,7 +110,8 @@ void Tracer::Flush() {
     timespec timeout;
     int retval;
 
-    atomic_cas32(&flush_immediately_, 0, 1);
+    int32_t expected_val = 0;
+    flush_immediately_.compare_exchange_strong(expected_val, 1);
     {
       const MutexLockGuard m(&sig_flush_mutex_);
       retval = pthread_cond_signal(&sig_flush_);
@@ -206,7 +207,8 @@ void *Tracer::MainFlush(void *data) {
     retval = fflush(f);
     assert(retval == 0);
     tracer->flushed_.fetch_add(i);
-    atomic_cas32(&tracer->flush_immediately_, 1, 0);
+    int32_t expected_val = 1;
+    tracer->flush_immediately_.compare_exchange_strong(expected_val, 0);
 
     {
       const MutexLockGuard l(&tracer->sig_continue_trace_mutex_);

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -7,6 +7,7 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <cstdio>
@@ -14,7 +15,6 @@
 #include <cstring>
 #include <string>
 
-#include "util/atomic.h"
 #include "util/concurrency.h"
 #include "util/posix.h"
 #include "util/string.h"
@@ -32,7 +32,7 @@ void Tracer::Activate(const int buffer_size,
          && flush_threshold_ < buffer_size_);
 
   ring_buffer_ = new BufferEntry[buffer_size_];
-  commit_buffer_ = new atomic_int32[buffer_size_];
+  commit_buffer_ = new std::atomic<int32_t>[buffer_size_];
   for (int i = 0; i < buffer_size_; i++)
     atomic_init32(&commit_buffer_[i]);
 

--- a/cvmfs/tracer.cc
+++ b/cvmfs/tracer.cc
@@ -34,7 +34,7 @@ void Tracer::Activate(const int buffer_size,
   ring_buffer_ = new BufferEntry[buffer_size_];
   commit_buffer_ = new std::atomic<int32_t>[buffer_size_];
   for (int i = 0; i < buffer_size_; i++)
-    atomic_init32(&commit_buffer_[i]);
+    commit_buffer_[i].store(0);
 
   int retval;
   retval = pthread_cond_init(&sig_continue_trace_, NULL);
@@ -241,10 +241,10 @@ Tracer::Tracer()
     , ring_buffer_(NULL)
     , commit_buffer_(NULL) {
   memset(&thread_flush_, 0, sizeof(thread_flush_));
-  atomic_init32(&seq_no_);
-  atomic_init32(&flushed_);
-  atomic_init32(&terminate_flush_thread_);
-  atomic_init32(&flush_immediately_);
+  seq_no_.store(0);
+  flushed_.store(0);
+  terminate_flush_thread_.store(0);
+  flush_immediately_.store(0);
 }
 
 

--- a/cvmfs/tracer.h
+++ b/cvmfs/tracer.h
@@ -9,11 +9,11 @@
 #include <pthread.h>
 #include <sys/time.h>
 
+#include <atomic>
 #include <cstdio>
 #include <string>
 
 #include "shortstring.h"
-#include "util/atomic.h"
 #include "util/single_copy.h"
 
 /**
@@ -109,7 +109,7 @@ class Tracer : SingleCopy {
    * the ring buffer memory, the respective flag is set to 1.  Flags are reset
    * to 0 by the flush thread.
    */
-  atomic_int32 *commit_buffer_;
+  std::atomic<int32_t> *commit_buffer_;
   pthread_t thread_flush_;
   pthread_cond_t sig_flush_;
   pthread_mutex_t sig_flush_mutex_;
@@ -119,14 +119,14 @@ class Tracer : SingleCopy {
    * Starts with 0 and gets incremented by each call to trace.  Contains the
    * first non-used sequence number.
    */
-  atomic_int32 seq_no_;
+  std::atomic<int32_t> seq_no_;
   /**
    * Starts with 0 and gets incremented by the flush thread.  Points to the
    * first non-flushed message. flushed <= seq_no holds.
    */
-  atomic_int32 flushed_;
-  atomic_int32 terminate_flush_thread_;
-  atomic_int32 flush_immediately_;
+  std::atomic<int32_t> flushed_;
+  std::atomic<int32_t> terminate_flush_thread_;
+  std::atomic<int32_t> flush_immediately_;
 };
 
 #endif  // CVMFS_TRACER_H_

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -13,7 +13,7 @@
 
 namespace upload {
 
-atomic_int64 UploadStreamHandle::g_upload_stream_tag = 0;
+std::atomic<int64_t> UploadStreamHandle::g_upload_stream_tag = 0;
 
 AbstractUploader::UploadJob::UploadJob(UploadStreamHandle *handle,
                                        UploadBuffer buffer,

--- a/cvmfs/upload_facility.cc
+++ b/cvmfs/upload_facility.cc
@@ -13,7 +13,7 @@
 
 namespace upload {
 
-std::atomic<int64_t> UploadStreamHandle::g_upload_stream_tag = 0;
+std::atomic<int64_t> UploadStreamHandle::g_upload_stream_tag(0);
 
 AbstractUploader::UploadJob::UploadJob(UploadStreamHandle *handle,
                                        UploadBuffer buffer,
@@ -156,3 +156,4 @@ void TaskUpload::Process(AbstractUploader::UploadJob *upload_job) {
 }
 
 }  // namespace upload
+                      

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <string>
 
 #include "ingestion/ingestion_source.h"
@@ -15,7 +16,6 @@
 #include "repository_tag.h"
 #include "statistics.h"
 #include "upload_spooler_definition.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 #include "util/pointer.h"
 #include "util/posix.h"
@@ -463,7 +463,7 @@ class TaskUpload : public TubeConsumer<AbstractUploader::UploadJob> {
  */
 struct UploadStreamHandle {
   typedef AbstractUploader::CallbackTN CallbackTN;
-  static atomic_int64 g_upload_stream_tag;
+  static std::atomic<int64_t> g_upload_stream_tag;
 
   explicit UploadStreamHandle(const CallbackTN *commit_callback)
       : commit_callback(commit_callback)

--- a/cvmfs/upload_facility.h
+++ b/cvmfs/upload_facility.h
@@ -467,7 +467,7 @@ struct UploadStreamHandle {
 
   explicit UploadStreamHandle(const CallbackTN *commit_callback)
       : commit_callback(commit_callback)
-      , tag(atomic_xadd64(&g_upload_stream_tag, 1)) { }
+      , tag(g_upload_stream_tag.fetch_add(1)) { }
   virtual ~UploadStreamHandle() { }
 
   const CallbackTN *commit_callback;

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -126,7 +126,7 @@ bool GatewayUploader::PlaceBootstrappingShortcut(
 }
 
 unsigned int GatewayUploader::GetNumberOfErrors() const {
-  return atomic_read32(&num_errors_);
+  return num_errors_.load();
 }
 
 void GatewayUploader::DoUpload(const std::string &remote_path,

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -111,7 +111,7 @@ void GatewayUploader::WaitForUpload() const {
 std::string GatewayUploader::name() const { return "HTTP"; }
 
 void GatewayUploader::DoRemoveAsync(const std::string & /*file_to_delete*/) {
-  atomic_inc32(&num_errors_);
+  num_errors_.fetch_add(1);
   Respond(NULL, UploaderResults());
 }
 
@@ -254,6 +254,6 @@ int64_t GatewayUploader::DoGetObjectSize(const std::string &file_name) {
   return -EOPNOTSUPP;
 }
 
-void GatewayUploader::BumpErrors() const { atomic_inc32(&num_errors_); }
+void GatewayUploader::BumpErrors() const { num_errors_.fetch_add(1); }
 
 }  // namespace upload

--- a/cvmfs/upload_gateway.cc
+++ b/cvmfs/upload_gateway.cc
@@ -65,7 +65,7 @@ GatewayUploader::GatewayUploader(const SpoolerDefinition &spooler_definition)
     PANIC(kLogStderr, "Error in parsing the spooler definition");
   }
 
-  atomic_init32(&num_errors_);
+  num_errors_.store(0);
 }
 
 GatewayUploader::~GatewayUploader() {

--- a/cvmfs/upload_gateway.h
+++ b/cvmfs/upload_gateway.h
@@ -5,13 +5,13 @@
 #ifndef CVMFS_UPLOAD_GATEWAY_H_
 #define CVMFS_UPLOAD_GATEWAY_H_
 
+#include <atomic>
 #include <string>
 
 #include "pack.h"
 #include "repository_tag.h"
 #include "session_context.h"
 #include "upload_facility.h"
-#include "util/atomic.h"
 
 namespace upload {
 
@@ -95,7 +95,7 @@ class GatewayUploader : public AbstractUploader {
 
   Config config_;
   SessionContext *session_context_;
-  mutable atomic_int32 num_errors_;
+  mutable std::atomic<int32_t> num_errors_;
 };
 
 }  // namespace upload

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -23,7 +23,7 @@ LocalUploader::LocalUploader(const SpoolerDefinition &spooler_definition)
   assert(spooler_definition.IsValid()
          && spooler_definition.driver_type == SpoolerDefinition::Local);
 
-  atomic_init32(&copy_errors_);
+  copy_errors_.store(0);
 }
 
 bool LocalUploader::WillHandle(const SpoolerDefinition &spooler_definition) {

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -31,7 +31,7 @@ bool LocalUploader::WillHandle(const SpoolerDefinition &spooler_definition) {
 }
 
 unsigned int LocalUploader::GetNumberOfErrors() const {
-  return atomic_read32(&copy_errors_);
+  return copy_errors_.load();
 }
 
 bool LocalUploader::Create() {

--- a/cvmfs/upload_local.cc
+++ b/cvmfs/upload_local.cc
@@ -53,7 +53,7 @@ void LocalUploader::DoUpload(const std::string &remote_path,
              "failed to create temp path for "
              "upload of file '%s' (errno: %d)",
              source->GetPath().c_str(), errno);
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
     Respond(callback, UploaderResults(1, source->GetPath()));
     return;
   }
@@ -63,7 +63,7 @@ void LocalUploader::DoUpload(const std::string &remote_path,
   if (!rvb) {
     fclose(ftmp);
     unlink(tmp_path.c_str());
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
     Respond(callback, UploaderResults(100, source->GetPath()));
     return;
   }
@@ -79,7 +79,7 @@ void LocalUploader::DoUpload(const std::string &remote_path,
       source->Close();
       fclose(ftmp);
       unlink(tmp_path.c_str());
-      atomic_inc32(&copy_errors_);
+      copy_errors_.fetch_add(1);
       Respond(callback, UploaderResults(100, source->GetPath()));
       return;
     }
@@ -96,7 +96,7 @@ void LocalUploader::DoUpload(const std::string &remote_path,
              "'%s'",
              tmp_path.c_str(), remote_path.c_str());
     unlink(tmp_path.c_str());
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
     Respond(callback, UploaderResults(rvi, source->GetPath()));
     return;
   }
@@ -109,7 +109,7 @@ UploadStreamHandle *LocalUploader::InitStreamedUpload(
   std::string tmp_path;
   const int tmp_fd = CreateAndOpenTemporaryChunkFile(&tmp_path);
   if (tmp_fd < 0) {
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
     return NULL;
   }
 
@@ -129,7 +129,7 @@ void LocalUploader::StreamedUpload(UploadStreamHandle *handle,
              "failed to write %lu bytes to '%s' "
              "(errno: %d)",
              buffer.size, local_handle->temporary_path.c_str(), cpy_errno);
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
     Respond(callback,
             UploaderResults(UploaderResults::kBufferUpload, cpy_errno));
     return;
@@ -150,7 +150,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
              "failed to close temp file '%s' "
              "(errno: %d)",
              local_handle->temporary_path.c_str(), cpy_errno);
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
     Respond(handle->commit_callback,
             UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
     return;
@@ -171,7 +171,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
                "final location '%s' (errno: %d)",
                local_handle->temporary_path.c_str(), final_path.c_str(),
                cpy_errno);
-      atomic_inc32(&copy_errors_);
+      copy_errors_.fetch_add(1);
       Respond(handle->commit_callback,
               UploaderResults(UploaderResults::kChunkCommit, cpy_errno));
       return;
@@ -207,7 +207,7 @@ void LocalUploader::FinalizeStreamedUpload(UploadStreamHandle *handle,
 void LocalUploader::DoRemoveAsync(const std::string &file_to_delete) {
   const int retval = unlink((upstream_path_ + "/" + file_to_delete).c_str());
   if ((retval != 0) && (errno != ENOENT))
-    atomic_inc32(&copy_errors_);
+    copy_errors_.fetch_add(1);
   Respond(NULL, UploaderResults());
 }
 

--- a/cvmfs/upload_local.h
+++ b/cvmfs/upload_local.h
@@ -8,10 +8,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <string>
 
 #include "upload_facility.h"
-#include "util/atomic.h"
 #include "util/concurrency.h"
 
 namespace upload {
@@ -88,8 +88,8 @@ class LocalUploader : public AbstractUploader {
   // state information
   const std::string upstream_path_;
   const std::string temporary_path_;
-  mutable atomic_int32 copy_errors_;  //!< counts the number of occurred
-                                      //!< errors in Upload()
+  mutable std::atomic<int32_t> copy_errors_;  //!< counts the number of occurred
+                                              //!< errors in Upload()
 };
 
 }  // namespace upload

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -292,9 +292,7 @@ bool S3Uploader::Create() {
 }
 
 
-unsigned int S3Uploader::GetNumberOfErrors() const {
-  return atomic_read32(&io_errors_);
-}
+unsigned int S3Uploader::GetNumberOfErrors() const { return io_errors_.load(); }
 
 
 /**
@@ -346,8 +344,10 @@ void *S3Uploader::MainCollectResults(void *data) {
         }
       }
       // Decrement jobs_in_flight_ once for the entire batch.
-      uploader->Respond(NULL, UploaderResults(UploaderResults::kRemove,
-                        (info->error_code != s3fanout::kFailOk) ? 99 : 0));
+      uploader->Respond(
+          NULL,
+          UploaderResults(UploaderResults::kRemove,
+                          (info->error_code != s3fanout::kFailOk) ? 99 : 0));
     } else if (info->request == s3fanout::JobInfo::kReqDelete) {
       uploader->Respond(NULL, UploaderResults());
     } else if (info->request == s3fanout::JobInfo::kReqHeadOnly) {
@@ -547,8 +547,7 @@ void S3Uploader::FlushDeleteBatch() const {
   if (pending_deletes_.empty())
     return;
 
-  LogCvmfs(kLogUploadS3, kLogDebug,
-           "Flushing batch delete of %lu objects",
+  LogCvmfs(kLogUploadS3, kLogDebug, "Flushing batch delete of %lu objects",
            pending_deletes_.size());
 
   // Build XML request body

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -61,7 +61,7 @@ S3Uploader::S3Uploader(const SpoolerDefinition &spooler_definition)
   assert(spooler_definition.IsValid()
          && spooler_definition.driver_type == SpoolerDefinition::S3);
 
-  atomic_init32(&io_errors_);
+  io_errors_.store(0);
   const int mutex_ret = pthread_mutex_init(&delete_batch_mutex_, NULL);
   assert(mutex_ret == 0);
 

--- a/cvmfs/upload_s3.cc
+++ b/cvmfs/upload_s3.cc
@@ -323,7 +323,7 @@ void *S3Uploader::MainCollectResults(void *data) {
                    s3fanout::Code2Ascii(info->error_code));
         }
         reply_code = 99;
-        atomic_inc32(&uploader->io_errors_);
+        uploader->io_errors_.fetch_add(1);
       }
     }
     if (info->request == s3fanout::JobInfo::kReqDeleteMulti) {
@@ -339,7 +339,7 @@ void *S3Uploader::MainCollectResults(void *data) {
                    "S3 multi-delete error for key '%s': %s - %s",
                    error_keys[i].c_str(), error_codes[i].c_str(),
                    error_messages[i].c_str());
-          atomic_inc32(&uploader->io_errors_);
+          uploader->io_errors_.fetch_add(1);
           failed_keys.insert(error_keys[i]);
         }
       }

--- a/cvmfs/upload_s3.h
+++ b/cvmfs/upload_s3.h
@@ -7,13 +7,13 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "network/s3fanout.h"
 #include "upload_facility.h"
-#include "util/atomic.h"
 #include "util/file_backed_buffer.h"
 #include "util/pointer.h"
 #include "util/single_copy.h"
@@ -142,7 +142,7 @@ class S3Uploader : public AbstractUploader {
   std::string proxy_;
 
   const std::string temporary_path_;
-  mutable atomic_int32 io_errors_;
+  mutable std::atomic<int32_t> io_errors_;
   pthread_t thread_collect_results_;
 
   std::string x_amz_acl_;

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -94,8 +95,13 @@ static std::string GenerateStars(unsigned int n) { return std::string(n, '*'); }
 
 Log2Histogram::Log2Histogram(unsigned int nbins) {
   assert(nbins != 0);
-  this->bins_.assign(nbins + 1, 0);             // +1 for overflow bin.
+  this->bins_.reserve(nbins + 1);               // +1 for overflow bin.
   this->boundary_values_.assign(nbins + 1, 0);  // +1 to avoid big if statement
+
+  for (size_t i = 0; i <= nbins; ++i) {
+    bins_.emplace_back(
+        std::unique_ptr<std::atomic<int32_t> >(new std::atomic<int32_t>(0)));
+  }
 
   unsigned int i;
   for (i = 1; i <= nbins; i++) {
@@ -103,8 +109,8 @@ Log2Histogram::Log2Histogram(unsigned int nbins) {
   }
 }
 
-std::vector<std::atomic<int32_t> > UTLog2Histogram::GetBins(
-    const Log2Histogram &h) {
+const std::vector<std::unique_ptr<std::atomic<int32_t> > > &
+UTLog2Histogram::GetBins(const Log2Histogram &h) {
   return h.bins_;
 }
 
@@ -118,7 +124,7 @@ unsigned int Log2Histogram::GetQuantile(float n) {
   unsigned int i = 0;
   for (i = 1; i <= this->bins_.size() - 1; i++) {
     const unsigned int bin_value = static_cast<unsigned int>(
-        (this->bins_[i].load()));
+        (this->bins_[i]->load()));
     if (pivot <= bin_value) {
       normalized_pivot = static_cast<float>(pivot)
                          / static_cast<float>(bin_value);
@@ -156,15 +162,15 @@ std::string Log2Histogram::ToString() {
     max_right_boundary_count = std::max(max_right_boundary_count,
                                         CountDigits(boundary_values_[i] - 1));
     max_value_count = std::max(max_value_count,
-                               CountDigits((this->bins_[i].load())));
+                               CountDigits((this->bins_[i]->load())));
     max_bins = std::max(max_bins,
-                        static_cast<unsigned int>((this->bins_[i].load())));
-    total_sum_of_bins += static_cast<unsigned int>((this->bins_[i].load()));
+                        static_cast<unsigned int>((this->bins_[i]->load())));
+    total_sum_of_bins += static_cast<unsigned int>((this->bins_[i]->load()));
   }
 
   max_bins = std::max(max_bins,
-                      static_cast<unsigned int>((this->bins_[0].load())));
-  total_sum_of_bins += static_cast<unsigned int>((this->bins_[0].load()));
+                      static_cast<unsigned int>((this->bins_[0]->load())));
+  total_sum_of_bins += static_cast<unsigned int>((this->bins_[0]->load()));
 
   if (total_sum_of_bins != 0) {
     max_stars = max_bins * total_stars / total_sum_of_bins;
@@ -232,7 +238,7 @@ std::string Log2Histogram::ToString() {
   for (i = 1; i <= this->bins_.size() - 1; i++) {
     unsigned int n_of_stars = 0;
     if (total_sum_of_bins != 0) {
-      n_of_stars = static_cast<unsigned int>((this->bins_[i].load()))
+      n_of_stars = static_cast<unsigned int>((this->bins_[i]->load()))
                    * total_stars / total_sum_of_bins;
     }
 
@@ -241,7 +247,7 @@ std::string Log2Histogram::ToString() {
              format.c_str(),
              boundary_values_[i - 1],
              boundary_values_[i] - 1,
-             static_cast<unsigned int>(this->bins_[i].load()),
+             static_cast<unsigned int>(this->bins_[i]->load()),
              GenerateStars(n_of_stars).c_str());
     result_string += buffer;
     memset(buffer, 0, sizeof(buffer));
@@ -249,7 +255,7 @@ std::string Log2Histogram::ToString() {
 
   unsigned int n_of_stars = 0;
   if (total_sum_of_bins != 0) {
-    n_of_stars = static_cast<unsigned int>((this->bins_[0].load()))
+    n_of_stars = static_cast<unsigned int>((this->bins_[0]->load()))
                  * total_stars / total_sum_of_bins;
   }
 
@@ -257,7 +263,7 @@ std::string Log2Histogram::ToString() {
            kBufSize,
            overflow_format.c_str(),
            "overflow",
-           static_cast<unsigned int>((this->bins_[0].load())),
+           static_cast<unsigned int>((this->bins_[0]->load())),
            GenerateStars(n_of_stars).c_str());
   result_string += buffer;
   memset(buffer, 0, sizeof(buffer));
@@ -296,3 +302,4 @@ void Log2Histogram::PrintLog2Histogram() {
 #ifdef CVMFS_NAMESPACE_GUARD
 }  // namespace CVMFS_NAMESPACE_GUARD
 #endif
+

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -118,7 +118,7 @@ unsigned int Log2Histogram::GetQuantile(float n) {
   unsigned int i = 0;
   for (i = 1; i <= this->bins_.size() - 1; i++) {
     const unsigned int bin_value = static_cast<unsigned int>(
-        atomic_read32(&(this->bins_[i])));
+        (this->bins_[i].load()));
     if (pivot <= bin_value) {
       normalized_pivot = static_cast<float>(pivot)
                          / static_cast<float>(bin_value);
@@ -156,17 +156,15 @@ std::string Log2Histogram::ToString() {
     max_right_boundary_count = std::max(max_right_boundary_count,
                                         CountDigits(boundary_values_[i] - 1));
     max_value_count = std::max(max_value_count,
-                               CountDigits(atomic_read32(&(this->bins_[i]))));
-    max_bins = std::max(
-        max_bins, static_cast<unsigned int>(atomic_read32(&(this->bins_[i]))));
-    total_sum_of_bins += static_cast<unsigned int>(
-        atomic_read32(&(this->bins_[i])));
+                               CountDigits((this->bins_[i].load())));
+    max_bins = std::max(max_bins,
+                        static_cast<unsigned int>((this->bins_[i].load())));
+    total_sum_of_bins += static_cast<unsigned int>((this->bins_[i].load()));
   }
 
-  max_bins = std::max(
-      max_bins, static_cast<unsigned int>(atomic_read32(&(this->bins_[0]))));
-  total_sum_of_bins += static_cast<unsigned int>(
-      atomic_read32(&(this->bins_[0])));
+  max_bins = std::max(max_bins,
+                      static_cast<unsigned int>((this->bins_[0].load())));
+  total_sum_of_bins += static_cast<unsigned int>((this->bins_[0].load()));
 
   if (total_sum_of_bins != 0) {
     max_stars = max_bins * total_stars / total_sum_of_bins;
@@ -234,7 +232,7 @@ std::string Log2Histogram::ToString() {
   for (i = 1; i <= this->bins_.size() - 1; i++) {
     unsigned int n_of_stars = 0;
     if (total_sum_of_bins != 0) {
-      n_of_stars = static_cast<unsigned int>(atomic_read32(&(this->bins_[i])))
+      n_of_stars = static_cast<unsigned int>((this->bins_[i].load()))
                    * total_stars / total_sum_of_bins;
     }
 
@@ -243,7 +241,7 @@ std::string Log2Histogram::ToString() {
              format.c_str(),
              boundary_values_[i - 1],
              boundary_values_[i] - 1,
-             static_cast<unsigned int>(atomic_read32(&this->bins_[i])),
+             static_cast<unsigned int>(this->bins_[i].load()),
              GenerateStars(n_of_stars).c_str());
     result_string += buffer;
     memset(buffer, 0, sizeof(buffer));
@@ -251,7 +249,7 @@ std::string Log2Histogram::ToString() {
 
   unsigned int n_of_stars = 0;
   if (total_sum_of_bins != 0) {
-    n_of_stars = static_cast<unsigned int>(atomic_read32(&(this->bins_[0])))
+    n_of_stars = static_cast<unsigned int>((this->bins_[0].load()))
                  * total_stars / total_sum_of_bins;
   }
 
@@ -259,7 +257,7 @@ std::string Log2Histogram::ToString() {
            kBufSize,
            overflow_format.c_str(),
            "overflow",
-           static_cast<unsigned int>(atomic_read32(&(this->bins_[0]))),
+           static_cast<unsigned int>((this->bins_[0].load())),
            GenerateStars(n_of_stars).c_str());
   result_string += buffer;
   memset(buffer, 0, sizeof(buffer));

--- a/cvmfs/util/algorithm.cc
+++ b/cvmfs/util/algorithm.cc
@@ -4,7 +4,12 @@
  * Some common functions.
  */
 
+#include "util/algorithm.h"
+
+#include <sys/time.h>
+
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -12,11 +17,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#include <sys/time.h>
 #include <vector>
 
-#include "util/algorithm.h"
-#include "util/atomic.h"
 #include "util/string.h"
 
 
@@ -101,7 +103,8 @@ Log2Histogram::Log2Histogram(unsigned int nbins) {
   }
 }
 
-std::vector<atomic_int32> UTLog2Histogram::GetBins(const Log2Histogram &h) {
+std::vector<std::atomic<int32_t> > UTLog2Histogram::GetBins(
+    const Log2Histogram &h) {
   return h.bins_;
 }
 

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -153,12 +154,12 @@ class CVMFS_EXPORT Log2Histogram {
 
     for (i = 1; i <= n; i++) {
       if (value < this->boundary_values_[i]) {
-        (this->bins_[i].fetch_add(1));
+        (this->bins_[i]->fetch_add(1));
         return;
       }
     }
 
-    (this->bins_[0].fetch_add(1));  // add to overflow bin.
+    (this->bins_[0]->fetch_add(1));  // add to overflow bin.
   }
 
   /**
@@ -168,7 +169,7 @@ class CVMFS_EXPORT Log2Histogram {
     uint64_t n = 0;
     unsigned int i;
     for (i = 0; i <= this->bins_.size() - 1; i++) {
-      n += static_cast<unsigned int>((this->bins_[i].load()));
+      n += static_cast<unsigned int>((this->bins_[i]->load()));
     }
     return n;
   }
@@ -183,7 +184,7 @@ class CVMFS_EXPORT Log2Histogram {
   void PrintLog2Histogram();
 
  private:
-  std::vector<std::atomic<int32_t> > bins_;
+  std::vector<std::unique_ptr<std::atomic<int32_t> > > bins_;
   // boundary_values_ handle the largest value a certain
   // bin can store in itself.
   std::vector<unsigned int> boundary_values_;
@@ -195,7 +196,8 @@ class CVMFS_EXPORT Log2Histogram {
  */
 class CVMFS_EXPORT UTLog2Histogram {
  public:
-  std::vector<std::atomic<int32_t> > GetBins(const Log2Histogram &h);
+  const std::vector<std::unique_ptr<std::atomic<int32_t> > > &GetBins(
+      const Log2Histogram &h);
 };
 
 
@@ -222,3 +224,4 @@ class CVMFS_EXPORT HighPrecisionTimer : SingleCopy {
 #endif
 
 #endif  // CVMFS_UTIL_ALGORITHM_H_
+

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -15,7 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include "util/atomic.h"
 #include "util/export.h"
 #include "util/murmur.hxx"
 #include "util/platform.h"
@@ -183,7 +183,7 @@ class CVMFS_EXPORT Log2Histogram {
   void PrintLog2Histogram();
 
  private:
-  std::vector<atomic_int32> bins_;
+  std::vector<std::atomic<int32_t> > bins_;
   // boundary_values_ handle the largest value a certain
   // bin can store in itself.
   std::vector<unsigned int> boundary_values_;
@@ -195,7 +195,7 @@ class CVMFS_EXPORT Log2Histogram {
  */
 class CVMFS_EXPORT UTLog2Histogram {
  public:
-  std::vector<atomic_int32> GetBins(const Log2Histogram &h);
+  std::vector<std::atomic<int32_t> > GetBins(const Log2Histogram &h);
 };
 
 

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -168,7 +168,7 @@ class CVMFS_EXPORT Log2Histogram {
     uint64_t n = 0;
     unsigned int i;
     for (i = 0; i <= this->bins_.size() - 1; i++) {
-      n += static_cast<unsigned int>(atomic_read32(&(this->bins_[i])));
+      n += static_cast<unsigned int>((this->bins_[i].load()));
     }
     return n;
   }

--- a/cvmfs/util/algorithm.h
+++ b/cvmfs/util/algorithm.h
@@ -153,12 +153,12 @@ class CVMFS_EXPORT Log2Histogram {
 
     for (i = 1; i <= n; i++) {
       if (value < this->boundary_values_[i]) {
-        atomic_inc32(&(this->bins_[i]));
+        (this->bins_[i].fetch_add(1));
         return;
       }
     }
 
-    atomic_inc32(&(this->bins_[0]));  // add to overflow bin.
+    (this->bins_[0].fetch_add(1));  // add to overflow bin.
   }
 
   /**

--- a/cvmfs/util/concurrency.h
+++ b/cvmfs/util/concurrency.h
@@ -573,7 +573,7 @@ class ConcurrentWorkers : public Observable<typename WorkerT::returned_data> {
 
   inline unsigned int GetNumberOfWorkers() const { return number_of_workers_; }
   inline unsigned int GetNumberOfFailedJobs() const {
-    return atomic_read32(&jobs_failed_);
+    return jobs_failed_.load();
   }
 
   /**

--- a/cvmfs/util/concurrency.h
+++ b/cvmfs/util/concurrency.h
@@ -7,6 +7,7 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <cassert>
 #include <cstddef>
 #include <queue>
@@ -14,7 +15,6 @@
 #include <vector>
 
 #include "util/async.h"
-#include "util/atomic.h"
 #include "util/export.h"
 #include "util/mutex.h"
 #include "util/single_copy.h"
@@ -688,9 +688,9 @@ class ConcurrentWorkers : public Observable<typename WorkerT::returned_data> {
   // job queue
   typedef FifoChannel<WorkerJob> JobQueue;
   JobQueue jobs_queue_;
-  mutable atomic_int32 jobs_pending_;
-  mutable atomic_int32 jobs_failed_;
-  mutable atomic_int64 jobs_processed_;
+  mutable std::atomic<int32_t> jobs_pending_;
+  mutable std::atomic<int32_t> jobs_failed_;
+  mutable std::atomic<int64_t> jobs_processed_;
 
   // callback channel
   typedef FifoChannel<CallbackJob> CallbackQueue;

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -572,7 +572,7 @@ void ConcurrentWorkers<WorkerT>::TruncateJobQueue(const bool forget_pending) {
 
   // if desired, we remove the jobs from the pending 'list'
   if (forget_pending) {
-    atomic_xadd32(&jobs_pending_, -dropped_jobs);
+    jobs_pending_.fetch_add(-dropped_jobs);
   }
 }
 

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -502,7 +502,7 @@ void ConcurrentWorkers<WorkerT>::RunCallbackThread() {
     atomic_inc64(&jobs_processed_);
 
     // signal the Spooler that all jobs are done...
-    if (atomic_read32(&jobs_pending_) == 0) {
+    if (jobs_pending_.load() == 0) {
       pthread_cond_broadcast(&jobs_all_done_);
     }
   }
@@ -603,7 +603,7 @@ void ConcurrentWorkers<WorkerT>::Terminate() {
   pthread_join(callback_thread_, NULL);
 
   // check if we finished all pending jobs
-  const int pending = atomic_read32(&jobs_pending_);
+  const int pending = jobs_pending_.load();
   if (pending > 0) {
     LogCvmfs(kLogConcurrency, kLogWarning,
              "Job queue was not fully processed. "
@@ -613,7 +613,7 @@ void ConcurrentWorkers<WorkerT>::Terminate() {
   }
 
   // check if we had failed jobs
-  const int failed = atomic_read32(&jobs_failed_);
+  const int failed = jobs_failed_.load();
   if (failed > 0) {
     LogCvmfs(kLogConcurrency, kLogWarning, "We've had %d failed jobs.", failed);
   }
@@ -621,19 +621,19 @@ void ConcurrentWorkers<WorkerT>::Terminate() {
   // thanks, and good bye...
   LogCvmfs(kLogConcurrency, kLogVerboseMsg,
            "All workers stopped. They processed %ld jobs. Terminating...",
-           atomic_read64(&jobs_processed_));
+           jobs_processed_.load());
 }
 
 
 template<class WorkerT>
 void ConcurrentWorkers<WorkerT>::WaitForEmptyQueue() const {
   LogCvmfs(kLogConcurrency, kLogVerboseMsg,
-           "Waiting for %d jobs to be finished", atomic_read32(&jobs_pending_));
+           "Waiting for %d jobs to be finished", jobs_pending_.load());
 
   // wait until all pending jobs are processed
   {
     MutexLockGuard lock(jobs_all_done_mutex_);
-    while (atomic_read32(&jobs_pending_) > 0) {
+    while (jobs_pending_.load() > 0) {
       pthread_cond_wait(&jobs_all_done_, &jobs_all_done_mutex_);
     }
   }

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -305,9 +305,9 @@ ConcurrentWorkers<WorkerT>::ConcurrentWorkers(
   assert(maximal_queue_length >= number_of_workers);
   assert(number_of_workers > 0);
 
-  atomic_init32(&jobs_pending_);
-  atomic_init32(&jobs_failed_);
-  atomic_init64(&jobs_processed_);
+  jobs_pending_.store(0);
+  jobs_failed_.store(0);
+  jobs_processed_.store(0);
 }
 
 

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -499,7 +499,7 @@ void ConcurrentWorkers<WorkerT>::RunCallbackThread() {
 
     // remove the job from the pending 'list' and add it to the ready 'list'
     atomic_dec32(&jobs_pending_);
-    atomic_inc64(&jobs_processed_);
+    jobs_processed_.fetch_add(1);
 
     // signal the Spooler that all jobs are done...
     if (jobs_pending_.load() == 0) {
@@ -532,7 +532,7 @@ void ConcurrentWorkers<WorkerT>::Schedule(WorkerJob job) {
 
   jobs_queue_.Enqueue(job);
   if (!job.is_death_sentence) {
-    atomic_inc32(&jobs_pending_);
+    jobs_pending_.fetch_add(1);
   }
 }
 
@@ -661,7 +661,7 @@ void ConcurrentWorkers<WorkerT>::JobDone(
 
   // check if the finished job was successful
   if (!success) {
-    atomic_inc32(&jobs_failed_);
+    jobs_failed_.fetch_add(1);
     LogCvmfs(kLogConcurrency, kLogWarning, "Job failed");
   }
 

--- a/cvmfs/util/concurrency_impl.h
+++ b/cvmfs/util/concurrency_impl.h
@@ -498,7 +498,7 @@ void ConcurrentWorkers<WorkerT>::RunCallbackThread() {
     this->NotifyListeners(callback_job.data);
 
     // remove the job from the pending 'list' and add it to the ready 'list'
-    atomic_dec32(&jobs_pending_);
+    jobs_pending_.fetch_sub(1);
     jobs_processed_.fetch_add(1);
 
     // signal the Spooler that all jobs are done...

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -308,7 +308,7 @@ class PolymorphicConstruction<AbstractProductT, ParameterT, void>
 
 template<class AbstractProductT, typename ParameterT, typename InfoT>
 std::atomic<int32_t> PolymorphicConstructionImpl<AbstractProductT, ParameterT,
-                                                 InfoT>::needs_init_ = 1;
+                                                 InfoT>::needs_init_(1);
 
 template<class AbstractProductT, typename ParameterT, typename InfoT>
 pthread_mutex_t
@@ -329,3 +329,4 @@ typename PolymorphicConstructionImpl<AbstractProductT, ParameterT,
 #endif
 
 #endif  // CVMFS_UTIL_PLUGIN_H_
+

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -7,11 +7,11 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <cassert>
 #include <cstddef>
 #include <vector>
 
-#include "util/atomic.h"
 #include "util/mutex.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
@@ -258,7 +258,7 @@ class PolymorphicConstructionImpl {
   static RegisteredPlugins registered_plugins_;
 
  private:
-  static atomic_int32 needs_init_;
+  static std::atomic<int32_t> needs_init_;
   static pthread_mutex_t init_mutex_;
 };
 
@@ -307,8 +307,8 @@ class PolymorphicConstruction<AbstractProductT, ParameterT, void>
 
 
 template<class AbstractProductT, typename ParameterT, typename InfoT>
-atomic_int32 PolymorphicConstructionImpl<AbstractProductT, ParameterT,
-                                         InfoT>::needs_init_ = 1;
+std::atomic<int32_t> PolymorphicConstructionImpl<AbstractProductT, ParameterT,
+                                                 InfoT>::needs_init_ = 1;
 
 template<class AbstractProductT, typename ParameterT, typename InfoT>
 pthread_mutex_t

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -205,7 +205,7 @@ class PolymorphicConstructionImpl {
       MutexLockGuard m(&init_mutex_);
       if (needs_init_.load()) {
         AbstractProductT::RegisterPlugins();
-        atomic_dec32(&needs_init_);
+        needs_init_.fetch_sub(1);
       }
     }
 

--- a/cvmfs/util/plugin.h
+++ b/cvmfs/util/plugin.h
@@ -201,9 +201,9 @@ class PolymorphicConstructionImpl {
     //   fully initialized!
     // See StackOverflow:
     // http://stackoverflow.com/questions/8097439/lazy-initialized-caching-how-do-i-make-it-thread-safe
-    if (atomic_read32(&needs_init_)) {
+    if (needs_init_.load()) {
       MutexLockGuard m(&init_mutex_);
-      if (atomic_read32(&needs_init_)) {
+      if (needs_init_.load()) {
         AbstractProductT::RegisterPlugins();
         atomic_dec32(&needs_init_);
       }

--- a/cvmfs/util/shared_ptr.h
+++ b/cvmfs/util/shared_ptr.h
@@ -27,7 +27,7 @@ class SharedPtr {
   explicit SharedPtr(Y *p) {
     value_ = static_cast<element_type *>(p);
     count_ = new std::atomic<int64_t>;
-    atomic_write64(count_, 1);
+    count_.store(1);
   }
 
   ~SharedPtr() {  // never throws
@@ -96,7 +96,7 @@ class SharedPtr {
     Reset();
     value_ = static_cast<element_type *>(p);
     count_ = new std::atomic<int64_t>;
-    atomic_write64(count_, 1);
+    count_.store(1);
   }
 
   T &operator*() const {  // never throws

--- a/cvmfs/util/shared_ptr.h
+++ b/cvmfs/util/shared_ptr.h
@@ -33,7 +33,7 @@ class SharedPtr {
   ~SharedPtr() {  // never throws
     if (count_) {
       atomic_dec64(count_);
-      if (atomic_read64(count_) == 0) {
+      if (count_.load() == 0) {
         delete value_;
         delete count_;
       }
@@ -82,7 +82,7 @@ class SharedPtr {
   void Reset() {  // never throws
     if (count_) {
       atomic_dec64(count_);
-      if (atomic_read64(count_) == 0) {
+      if (count_.load() == 0) {
         delete value_;
         delete count_;
       }
@@ -114,11 +114,11 @@ class SharedPtr {
   std::atomic<int64_t> *GetCountPtr() const { return count_; }
 
   bool Unique() const {  // never throws
-    return count_ && (atomic_read64(count_) == 1);
+    return count_ && (count_.load() == 1);
   }
 
   int64_t UseCount() const {  // never throws
-    return count_ ? atomic_read64(count_) : -1;
+    return count_ ? count_.load() : -1;
   }
 
  private:

--- a/cvmfs/util/shared_ptr.h
+++ b/cvmfs/util/shared_ptr.h
@@ -43,7 +43,7 @@ class SharedPtr {
   SharedPtr(SharedPtr const &r)
       : value_(r.value_), count_(r.count_) {  // never throws
     if (count_) {
-      atomic_inc64(count_);
+      count_.fetch_add(1);
     }
   }
 
@@ -51,7 +51,7 @@ class SharedPtr {
   explicit SharedPtr(SharedPtr<Y> const &r)
       : value_(r.value_), count_(r.count_) {  // never throws
     if (count_) {
-      atomic_inc64(count_);
+      count_.fetch_add(1);
     }
   }
 
@@ -63,7 +63,7 @@ class SharedPtr {
     value_ = r.value_;
     count_ = r.count_;
     if (count_) {
-      atomic_inc64(count_);
+      count_.fetch_add(1);
     }
     return *this;
   }
@@ -74,7 +74,7 @@ class SharedPtr {
     value_ = r.Get();
     count_ = r.GetCountPtr();
     if (count_) {
-      atomic_inc64(count_);
+      count_.fetch_add(1);
     }
     return *this;
   }

--- a/cvmfs/util/shared_ptr.h
+++ b/cvmfs/util/shared_ptr.h
@@ -32,7 +32,7 @@ class SharedPtr {
 
   ~SharedPtr() {  // never throws
     if (count_) {
-      atomic_dec64(count_);
+      count_.fetch_sub(1);
       if (count_.load() == 0) {
         delete value_;
         delete count_;
@@ -81,7 +81,7 @@ class SharedPtr {
 
   void Reset() {  // never throws
     if (count_) {
-      atomic_dec64(count_);
+      count_.fetch_sub(1);
       if (count_.load() == 0) {
         delete value_;
         delete count_;

--- a/cvmfs/util/shared_ptr.h
+++ b/cvmfs/util/shared_ptr.h
@@ -5,10 +5,9 @@
 #ifndef CVMFS_UTIL_SHARED_PTR_H_
 #define CVMFS_UTIL_SHARED_PTR_H_
 
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
-
-#include "util/atomic.h"
 
 #ifdef CVMFS_NAMESPACE_GUARD
 namespace CVMFS_NAMESPACE_GUARD {
@@ -27,7 +26,7 @@ class SharedPtr {
   template<class Y>
   explicit SharedPtr(Y *p) {
     value_ = static_cast<element_type *>(p);
-    count_ = new atomic_int64;
+    count_ = new std::atomic<int64_t>;
     atomic_write64(count_, 1);
   }
 
@@ -96,7 +95,7 @@ class SharedPtr {
   void Reset(Y *p) {
     Reset();
     value_ = static_cast<element_type *>(p);
-    count_ = new atomic_int64;
+    count_ = new std::atomic<int64_t>;
     atomic_write64(count_, 1);
   }
 
@@ -112,7 +111,7 @@ class SharedPtr {
     return value_;
   }
 
-  atomic_int64 *GetCountPtr() const { return count_; }
+  std::atomic<int64_t> *GetCountPtr() const { return count_; }
 
   bool Unique() const {  // never throws
     return count_ && (atomic_read64(count_) == 1);
@@ -124,7 +123,7 @@ class SharedPtr {
 
  private:
   element_type *value_;
-  atomic_int64 *count_;
+  std::atomic<int64_t> *count_;
 };
 
 template<class T, class U>

--- a/cvmfs/util/shared_ptr.h
+++ b/cvmfs/util/shared_ptr.h
@@ -27,13 +27,13 @@ class SharedPtr {
   explicit SharedPtr(Y *p) {
     value_ = static_cast<element_type *>(p);
     count_ = new std::atomic<int64_t>;
-    count_.store(1);
+    count_->store(1);
   }
 
   ~SharedPtr() {  // never throws
     if (count_) {
-      count_.fetch_sub(1);
-      if (count_.load() == 0) {
+      count_->fetch_sub(1);
+      if (count_->load() == 0) {
         delete value_;
         delete count_;
       }
@@ -43,7 +43,7 @@ class SharedPtr {
   SharedPtr(SharedPtr const &r)
       : value_(r.value_), count_(r.count_) {  // never throws
     if (count_) {
-      count_.fetch_add(1);
+      count_->fetch_add(1);
     }
   }
 
@@ -51,7 +51,7 @@ class SharedPtr {
   explicit SharedPtr(SharedPtr<Y> const &r)
       : value_(r.value_), count_(r.count_) {  // never throws
     if (count_) {
-      count_.fetch_add(1);
+      count_->fetch_add(1);
     }
   }
 
@@ -63,7 +63,7 @@ class SharedPtr {
     value_ = r.value_;
     count_ = r.count_;
     if (count_) {
-      count_.fetch_add(1);
+      count_->fetch_add(1);
     }
     return *this;
   }
@@ -74,15 +74,15 @@ class SharedPtr {
     value_ = r.Get();
     count_ = r.GetCountPtr();
     if (count_) {
-      count_.fetch_add(1);
+      count_->fetch_add(1);
     }
     return *this;
   }
 
   void Reset() {  // never throws
     if (count_) {
-      count_.fetch_sub(1);
-      if (count_.load() == 0) {
+      count_->fetch_sub(1);
+      if (count_->load() == 0) {
         delete value_;
         delete count_;
       }
@@ -96,7 +96,7 @@ class SharedPtr {
     Reset();
     value_ = static_cast<element_type *>(p);
     count_ = new std::atomic<int64_t>;
-    count_.store(1);
+    count_->store(1);
   }
 
   T &operator*() const {  // never throws
@@ -114,11 +114,11 @@ class SharedPtr {
   std::atomic<int64_t> *GetCountPtr() const { return count_; }
 
   bool Unique() const {  // never throws
-    return count_ && (count_.load() == 1);
+    return count_ && (count_->load() == 1);
   }
 
   int64_t UseCount() const {  // never throws
-    return count_ ? count_.load() : -1;
+    return count_ ? count_->load() : -1;
   }
 
  private:
@@ -174,3 +174,4 @@ SharedPtr<T> ReinterpretPointerCast(SharedPtr<U> const &r) {  // never throws
 #endif
 
 #endif  // CVMFS_UTIL_SHARED_PTR_H_
+

--- a/cvmfs/util/tube.h
+++ b/cvmfs/util/tube.h
@@ -244,7 +244,7 @@ class Tube : SingleCopy {
 template<class ItemT>
 class TubeGroup : SingleCopy {
  public:
-  TubeGroup() : is_active_(false) { atomic_init32(&round_robin_); }
+  TubeGroup() : is_active_(false) { round_robin_.store(0); }
 
   ~TubeGroup() {
     for (unsigned i = 0; i < tubes_.size(); ++i)

--- a/cvmfs/util/tube.h
+++ b/cvmfs/util/tube.h
@@ -8,11 +8,11 @@
 #include <pthread.h>
 #include <stdint.h>
 
+#include <atomic>
 #include <cassert>
 #include <cstddef>
 #include <vector>
 
-#include "util/atomic.h"
 #include "util/mutex.h"
 #include "util/single_copy.h"
 
@@ -286,7 +286,7 @@ class TubeGroup : SingleCopy {
  private:
   bool is_active_;
   std::vector<Tube<ItemT> *> tubes_;
-  atomic_int32 round_robin_;
+  std::atomic<int32_t> round_robin_;
 };
 
 #endif  // CVMFS_UTIL_TUBE_H_

--- a/cvmfs/util/tube.h
+++ b/cvmfs/util/tube.h
@@ -279,7 +279,7 @@ class TubeGroup : SingleCopy {
     assert(is_active_);
     unsigned tube_idx = (tubes_.size() == 1)
                             ? 0
-                            : (atomic_xadd32(&round_robin_, 1) % tubes_.size());
+                            : (round_robin_.fetch_add(1) % tubes_.size());
     return tubes_[tube_idx]->EnqueueBack(item);
   }
 

--- a/test/common/testutil.cc
+++ b/test/common/testutil.cc
@@ -328,7 +328,7 @@ catalog::DirectoryEntry catalog::DirectoryEntryTestFactory::Make(
 //------------------------------------------------------------------------------
 
 
-atomic_int32 MockCatalog::instances;
+std::atomic<int32_t> MockCatalog::instances;
 
 const std::string MockCatalog::rhs = "f9d87ae2cc46be52b324335ff05fae4c1a7c4dd4";
 const shash::Any MockCatalog::root_hash = shash::Any(
@@ -539,8 +539,8 @@ MockObjectFetcher::Failures MockObjectFetcher::FetchManifest(
     manifest::Manifest **manifest) {
   const uint64_t catalog_size = 0;
   const std::string root_path = "";
-  *manifest = new manifest::Manifest(
-      MockCatalog::root_hash, catalog_size, root_path);
+  *manifest = new manifest::Manifest(MockCatalog::root_hash, catalog_size,
+                                     root_path);
   (*manifest)->set_history(MockHistory::root_hash);
   return MockObjectFetcher::kFailOk;
 }

--- a/test/common/testutil.cc
+++ b/test/common/testutil.cc
@@ -334,7 +334,7 @@ const std::string MockCatalog::rhs = "f9d87ae2cc46be52b324335ff05fae4c1a7c4dd4";
 const shash::Any MockCatalog::root_hash = shash::Any(
     shash::kSha1, shash::HexPtr(MockCatalog::rhs), shash::kSuffixCatalog);
 
-void MockCatalog::ResetGlobalState() { atomic_init32(&MockCatalog::instances); }
+void MockCatalog::ResetGlobalState() { MockCatalog::instances.store(0); }
 
 MockCatalog *MockCatalog::AttachFreely(const std::string &root_path,
                                        const std::string &file,

--- a/test/common/testutil.h
+++ b/test/common/testutil.h
@@ -421,7 +421,7 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
     MockCatalog::instances.fetch_add(1);
   }
 
-  ~MockCatalog() { atomic_dec32(&MockCatalog::instances); }
+  ~MockCatalog() { MockCatalog::instances.fetch_sub(1); }
 
   /**
    * Adds a new catalog to the mounted children list

--- a/test/common/testutil.h
+++ b/test/common/testutil.h
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <ctime>
 #include <limits>
 #include <map>
@@ -22,7 +23,6 @@
 #include "ingestion/ingestion_source.h"
 #include "object_fetcher.h"
 #include "upload_facility.h"
-#include "util/atomic.h"
 
 pid_t GetParentPid(const pid_t pid);
 std::string GetProcessname(const pid_t pid);
@@ -306,7 +306,7 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
  public:
   static const std::string rhs;
   static const shash::Any root_hash;
-  static atomic_int32 instances;
+  static std::atomic<int32_t> instances;
 
  public:
   struct NestedCatalog {

--- a/test/common/testutil.h
+++ b/test/common/testutil.h
@@ -400,7 +400,7 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
     string name = root_path.substr(pos + 1, string::npos);
     File mountpoint_file(shash::Any(), 4096, parent_path, name);
     files_.push_back(mountpoint_file);
-    atomic_inc32(&MockCatalog::instances);
+    MockCatalog::instances.fetch_add(1);
   }
 
   MockCatalog(const MockCatalog &other)
@@ -418,7 +418,7 @@ class MockCatalog : public MockObjectStorage<MockCatalog> {
       , children_(other.children_)
       , files_(other.files_)
       , chunks_(other.chunks_) {
-    atomic_inc32(&MockCatalog::instances);
+    MockCatalog::instances.fetch_add(1);
   }
 
   ~MockCatalog() { atomic_dec32(&MockCatalog::instances); }

--- a/test/micro-benchmarks/CMakeLists.txt
+++ b/test/micro-benchmarks/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CVMFS_UBENCHMARKS_FILES
   ../common/testutil.cc
   ../common/catalog_test_tools.cc
 
+  b_atomic.cc
   b_catalog_grafting.cc
   b_compression.cc
   b_gluebuffer.cc

--- a/test/micro-benchmarks/b_atomic.cc
+++ b/test/micro-benchmarks/b_atomic.cc
@@ -1,0 +1,76 @@
+#include <atomic>
+#include <benchmark/benchmark.h>
+#include "util/atomic.h"  // Your in-house atomic header
+
+// In-house atomics
+static void BM_InHouse_AtomicInc32(benchmark::State& state) {
+    atomic_int32 a;
+    atomic_init32(&a);
+    for (auto _ : state) {
+        atomic_inc32(&a);
+    }
+}
+BENCHMARK(BM_InHouse_AtomicInc32);
+
+static void BM_InHouse_AtomicXadd32(benchmark::State& state) {
+    atomic_int32 a;
+    atomic_init32(&a);
+    for (auto _ : state) {
+        atomic_xadd32(&a, 1);
+    }
+}
+BENCHMARK(BM_InHouse_AtomicXadd32);
+
+// std::atomic
+static void BM_Std_AtomicInc32(benchmark::State& state) {
+    std::atomic<int32_t> a(0);
+    for (auto _ : state) {
+        a++;
+    }
+}
+BENCHMARK(BM_Std_AtomicInc32);
+
+static void BM_Std_AtomicFetchAdd32(benchmark::State& state) {
+    std::atomic<int32_t> a(0);
+    for (auto _ : state) {
+        a.fetch_add(1);
+    }
+}
+BENCHMARK(BM_Std_AtomicFetchAdd32);
+
+// 64-bit versions
+static void BM_InHouse_AtomicInc64(benchmark::State& state) {
+    atomic_int64 a;
+    atomic_init64(&a);
+    for (auto _ : state) {
+        atomic_inc64(&a);
+    }
+}
+BENCHMARK(BM_InHouse_AtomicInc64);
+
+static void BM_Std_AtomicInc64(benchmark::State& state) {
+    std::atomic<int64_t> a(0);
+    for (auto _ : state) {
+        a++;
+    }
+}
+BENCHMARK(BM_Std_AtomicInc64);
+
+// CAS operations
+static void BM_InHouse_AtomicCas32(benchmark::State& state) {
+    atomic_int32 a;
+    atomic_init32(&a);
+    for (auto _ : state) {
+        atomic_cas32(&a, 0, 1);
+    }
+}
+BENCHMARK(BM_InHouse_AtomicCas32);
+
+static void BM_Std_AtomicCas32(benchmark::State& state) {
+    std::atomic<int32_t> a(42);
+    for (auto _ : state) {
+        int32_t expected = a.load();
+        a.compare_exchange_strong(expected, 1);
+    }
+}
+BENCHMARK(BM_Std_AtomicCas32);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -749,6 +749,7 @@ target_link_libraries (cvmfs_unittests_mockfuse
                        cvmfs_crypto
                        cvmfs_util
                        leveldb::leveldb
+                       ${FUSE3_LIBRARIES}
                        ${CVMFS_UNITTESTS_LINK_LIBRARIES})
 
 add_executable (cvmfs_unittests ${CVMFS_UNITTEST_SOURCES})

--- a/test/unittests/c_http_server.cc
+++ b/test/unittests/c_http_server.cc
@@ -181,7 +181,7 @@ MockHTTPServer::~MockHTTPServer() {
 bool MockHTTPServer::Start() {
   if (running_.load())
     return false;
-  atomic_write32(&running_, 1);
+  running_.store(1);
   pthread_create(&server_thread_, NULL, Main, this);
   // wait for server thread to open the socket
   while (!server_thread_ready_.load()) {
@@ -193,7 +193,7 @@ bool MockHTTPServer::Start() {
 bool MockHTTPServer::Stop() {
   if (!running_.load())
     return false;
-  atomic_write32(&running_, 0);
+  running_.store(0);
   pthread_join(server_thread_, NULL);
   return true;
 }

--- a/test/unittests/c_http_server.cc
+++ b/test/unittests/c_http_server.cc
@@ -165,8 +165,8 @@ void HTTPRequestParser::FillContentLength() {
 
 
 MockHTTPServer::MockHTTPServer(int port) {
-  atomic_init32(&running_);
-  atomic_init32(&server_thread_ready_);
+  running_.store(0);
+  server_thread_ready_.store(0);
   server_port_ = port;
   callback_func_ = NULL;
   callback_data_ = NULL;

--- a/test/unittests/c_http_server.cc
+++ b/test/unittests/c_http_server.cc
@@ -173,25 +173,25 @@ MockHTTPServer::MockHTTPServer(int port) {
 }
 
 MockHTTPServer::~MockHTTPServer() {
-  if (atomic_read32(&running_)) {
+  if (running_.load()) {
     Stop();
   }
 }
 
 bool MockHTTPServer::Start() {
-  if (atomic_read32(&running_))
+  if (running_.load())
     return false;
   atomic_write32(&running_, 1);
   pthread_create(&server_thread_, NULL, Main, this);
   // wait for server thread to open the socket
-  while (!atomic_read32(&server_thread_ready_)) {
+  while (!server_thread_ready_.load()) {
   }
   return true;
 }
 
 
 bool MockHTTPServer::Stop() {
-  if (!atomic_read32(&running_))
+  if (!running_.load())
     return false;
   atomic_write32(&running_, 0);
   pthread_join(server_thread_, NULL);
@@ -200,7 +200,7 @@ bool MockHTTPServer::Stop() {
 
 bool MockHTTPServer::SetResponseCallback(
     HTTPResponse (*callback_func)(const HTTPRequest &, void *), void *data) {
-  if (atomic_read32(&running_))
+  if (running_.load())
     return false;
   callback_func_ = callback_func;
   callback_data_ = data;
@@ -228,7 +228,7 @@ void *MockHTTPServer::Main(void *data) {
   select_timeout.tv_usec = 2000;  // 2 ms
   fd_set rfds;
   atomic_inc32(&(server->server_thread_ready_));
-  while (atomic_read32(&(server->running_))) {
+  while ((server->running_.load())) {
     // Wait for traffic
     FD_ZERO(&rfds);
     FD_SET(listen_sockfd, &rfds);
@@ -237,8 +237,8 @@ void *MockHTTPServer::Main(void *data) {
     if (retval == 0)  // Timeout
       continue;
 
-    accept_sockfd = accept(
-        listen_sockfd, (struct sockaddr *)&cli_addr, &clilen);
+    accept_sockfd = accept(listen_sockfd, (struct sockaddr *)&cli_addr,
+                           &clilen);
     bzero(buffer, kReadBufferSize);
     int bytes_read = 0;
     HTTPRequestParser parser;

--- a/test/unittests/c_http_server.cc
+++ b/test/unittests/c_http_server.cc
@@ -227,7 +227,7 @@ void *MockHTTPServer::Main(void *data) {
   select_timeout.tv_sec = 0;
   select_timeout.tv_usec = 2000;  // 2 ms
   fd_set rfds;
-  atomic_inc32(&(server->server_thread_ready_));
+  (server->server_thread_ready_.fetch_add(1));
   while ((server->running_.load())) {
     // Wait for traffic
     FD_ZERO(&rfds);

--- a/test/unittests/c_http_server.h
+++ b/test/unittests/c_http_server.h
@@ -7,12 +7,12 @@
 
 #include <pthread.h>
 
+#include <atomic>
 #include <cassert>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "util/atomic.h"
 #include "util/string.h"
 
 typedef std::vector<std::pair<std::string, std::string> > HTTPHeaderList;
@@ -151,8 +151,8 @@ class MockHTTPServer {
   // Handles the entire communication in one event loop.
   static void *Main(void *data);
 
-  atomic_int32 running_;
-  atomic_int32 server_thread_ready_;
+  std::atomic<int32_t> running_;
+  std::atomic<int32_t> server_thread_ready_;
   int server_port_;
 
   void *callback_data_;

--- a/test/unittests/t_catalog_traversal.cc
+++ b/test/unittests/t_catalog_traversal.cc
@@ -94,13 +94,13 @@ class T_CatalogTraversal : public ::testing::Test {
     dice_.InitLocaltime();
     SetupDummyCatalogs();
     EXPECT_EQ(static_cast<int32_t>(initial_catalog_instances),
-              atomic_read32(&MockCatalog::instances));
+              MockCatalog::instances.load());
   }
 
   void TearDown() {
     MockCatalog::Reset();
     MockHistory::Reset();
-    EXPECT_EQ(0, atomic_read32(&MockCatalog::instances));
+    EXPECT_EQ(0, MockCatalog::instances.load());
   }
 
   TraversalParams GetBasicTraversalParams() {
@@ -560,7 +560,7 @@ TYPED_TEST(T_CatalogTraversal, SimpleTraversalNoClose) {
   EXPECT_TRUE(t1);
 
   EXPECT_EQ(static_cast<int32_t>(21 + this->initial_catalog_instances),
-            atomic_read32(&MockCatalog::instances));
+            MockCatalog::instances.load());
 
   std::vector<MockCatalog *>::const_iterator i, iend;
   for (i = SimpleTraversalNoCloseCallback_visited_catalogs.begin(),
@@ -726,7 +726,7 @@ TYPED_TEST(T_CatalogTraversal, FirstLevelHistoryTraversalNoClose) {
   EXPECT_TRUE(t1);
 
   EXPECT_EQ(static_cast<int32_t>(49 + this->initial_catalog_instances),
-            atomic_read32(&MockCatalog::instances));
+            MockCatalog::instances.load());
 
   std::vector<MockCatalog *>::const_iterator i, iend;
   for (i = FirstLevelHistoryTraversalNoClose_visited_catalogs.begin(),

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -6,6 +6,8 @@
 #include <gtest/gtest.h>
 #include <pthread.h>
 
+#include <atomic>
+
 #include "backoff.h"
 #include "cache_posix.h"
 #include "crypto/hash.h"
@@ -13,7 +15,6 @@
 #include "network/download.h"
 #include "statistics.h"
 #include "testutil.h"
-#include "util/atomic.h"
 
 using namespace std;  // NOLINT
 
@@ -169,8 +170,8 @@ class BuggyCacheManager : public CacheManager {
   bool open_2nd_try;
   bool allow_open;
   bool stall_in_ctrltxn;
-  atomic_int32 waiting_in_ctrltxn;
-  atomic_int32 continue_ctrltxn;
+  std::atomic<int32_t> waiting_in_ctrltxn;
+  std::atomic<int32_t> continue_ctrltxn;
   bool allow_open_from_txn;
 };
 

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -148,7 +148,7 @@ class BuggyCacheManager : public CacheManager {
   virtual void CtrlTxn(const Label & /* label */, const int /* flags */,
                        void * /* txn */) {
     if (stall_in_ctrltxn) {
-      atomic_inc32(&waiting_in_ctrltxn);
+      waiting_in_ctrltxn.fetch_add(1);
       while (continue_ctrltxn.load() == 0) {
       }
       atomic_dec32(&waiting_in_ctrltxn);
@@ -373,7 +373,7 @@ void *TestFetchCollapse2(void *data) {
       if (iDownloadQueue->second->size() > 0) {
         // printf("open up %s", iDownloadQueue->first.ToString().c_str());
         bcm->stall_in_ctrltxn = false;
-        atomic_inc32(&bcm->continue_ctrltxn);
+        bcm->continue_ctrltxn.fetch_add(1);
       }
     }
     pthread_mutex_unlock(f->lock_queues_download_);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -151,7 +151,7 @@ class BuggyCacheManager : public CacheManager {
       waiting_in_ctrltxn.fetch_add(1);
       while (continue_ctrltxn.load() == 0) {
       }
-      atomic_dec32(&waiting_in_ctrltxn);
+      waiting_in_ctrltxn.fetch_sub(1);
     }
   }
   virtual int64_t Write(const void *buf, uint64_t sz, void *txn) { return sz; }

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -149,7 +149,7 @@ class BuggyCacheManager : public CacheManager {
                        void * /* txn */) {
     if (stall_in_ctrltxn) {
       atomic_inc32(&waiting_in_ctrltxn);
-      while (atomic_read32(&continue_ctrltxn) == 0) {
+      while (continue_ctrltxn.load() == 0) {
       }
       atomic_dec32(&waiting_in_ctrltxn);
     }
@@ -414,7 +414,7 @@ TEST_F(T_Fetcher, FetchCollapse) {
   EXPECT_EQ(0, pthread_create(&thread_collapse2, NULL, TestFetchCollapse2, &f));
 
   // Piggy-back onto existing download
-  while (atomic_read32(&bcm.waiting_in_ctrltxn) == 0) {
+  while (bcm.waiting_in_ctrltxn.load() == 0) {
   }
   fd = f.Fetch(CacheManager::LabeledObject(hash_catalog_, lbl));
   EXPECT_EQ(-EROFS, fd);

--- a/test/unittests/t_fetch.cc
+++ b/test/unittests/t_fetch.cc
@@ -116,8 +116,8 @@ class BuggyCacheManager : public CacheManager {
       , allow_open(false)
       , stall_in_ctrltxn(false)
       , allow_open_from_txn(false) {
-    atomic_init32(&waiting_in_ctrltxn);
-    atomic_init32(&continue_ctrltxn);
+    waiting_in_ctrltxn.store(0);
+    continue_ctrltxn.store(0);
   }
   virtual CacheManagerIds id() { return kUnknownCacheManager; }
   virtual std::string Describe() { return "test\n"; }

--- a/test/unittests/t_garbage_collector.cc
+++ b/test/unittests/t_garbage_collector.cc
@@ -99,7 +99,7 @@ class T_GarbageCollector : public ::testing::Test {
     MockCatalog::Reset();
     MockHistory::Reset();
     MockReflog::Reset();
-    EXPECT_EQ(0, atomic_read32(&MockCatalog::instances));
+    EXPECT_EQ(0, MockCatalog::instances.load());
     ASSERT_NE(static_cast<GC_MockUploader *>(NULL), uploader_);
     uploader_->TearDown();
     delete uploader_;

--- a/test/unittests/t_ingestion.cc
+++ b/test/unittests/t_ingestion.cc
@@ -50,7 +50,7 @@ class TestTask : public TubeConsumer<DummyItem> {
 
  protected:
   virtual void Process(DummyItem *item) {
-    atomic_xadd32(&item->sum, item->summand);
+    item->sum.fetch_add(item->summand);
     cnt_process.fetch_add(1);
   }
   virtual void OnTerminate() { cnt_terminate.fetch_add(1); }

--- a/test/unittests/t_ingestion.cc
+++ b/test/unittests/t_ingestion.cc
@@ -51,9 +51,9 @@ class TestTask : public TubeConsumer<DummyItem> {
  protected:
   virtual void Process(DummyItem *item) {
     atomic_xadd32(&item->sum, item->summand);
-    atomic_inc32(&cnt_process);
+    cnt_process.fetch_add(1);
   }
-  virtual void OnTerminate() { atomic_inc32(&cnt_terminate); }
+  virtual void OnTerminate() { cnt_terminate.fetch_add(1); }
 };
 std::atomic<int32_t> TestTask::cnt_terminate = 0;
 std::atomic<int32_t> TestTask::cnt_process = 0;
@@ -68,7 +68,7 @@ struct FnFileProcessed {
   FnFileProcessed() { ncall.store(0); }
 
   void OnFileProcessed(const upload::SpoolerResult &spooler_result) {
-    atomic_inc64(&ncall);
+    ncall.fetch_add(1);
   }
 
   std::atomic<int64_t> ncall;
@@ -80,7 +80,7 @@ struct FnFileHashed {
 
   void OnFileProcessed(const ScrubbingResult &scrubbing_result) {
     last_result = scrubbing_result;
-    atomic_inc64(&ncall);
+    ncall.fetch_add(1);
   }
 
   ScrubbingResult last_result;

--- a/test/unittests/t_ingestion.cc
+++ b/test/unittests/t_ingestion.cc
@@ -39,7 +39,7 @@ class DummyItem {
   int summand;
   static std::atomic<int32_t> sum;
 };
-std::atomic<int32_t> DummyItem::sum = 0;
+std::atomic<int32_t> DummyItem::sum(0);
 
 
 class TestTask : public TubeConsumer<DummyItem> {
@@ -55,8 +55,8 @@ class TestTask : public TubeConsumer<DummyItem> {
   }
   virtual void OnTerminate() { cnt_terminate.fetch_add(1); }
 };
-std::atomic<int32_t> TestTask::cnt_terminate = 0;
-std::atomic<int32_t> TestTask::cnt_process = 0;
+std::atomic<int32_t> TestTask::cnt_terminate(0);
+std::atomic<int32_t> TestTask::cnt_process(0);
 }  // anonymous namespace
 
 
@@ -839,3 +839,4 @@ TEST_F(T_Ingestion, Scrubbing) {
   EXPECT_EQ("/dev/null", fn_hashed.last_result.path);
   EXPECT_EQ(null_hash, fn_hashed.last_result.hash);
 }
+ 

--- a/test/unittests/t_ingestion.cc
+++ b/test/unittests/t_ingestion.cc
@@ -65,7 +65,7 @@ std::atomic<int32_t> TestTask::cnt_process = 0;
  * file catalog.
  */
 struct FnFileProcessed {
-  FnFileProcessed() { atomic_init64(&ncall); }
+  FnFileProcessed() { ncall.store(0); }
 
   void OnFileProcessed(const upload::SpoolerResult &spooler_result) {
     atomic_inc64(&ncall);
@@ -76,7 +76,7 @@ struct FnFileProcessed {
 
 
 struct FnFileHashed {
-  FnFileHashed() { atomic_init64(&ncall); }
+  FnFileHashed() { ncall.store(0); }
 
   void OnFileProcessed(const ScrubbingResult &scrubbing_result) {
     last_result = scrubbing_result;

--- a/test/unittests/t_ingestion.cc
+++ b/test/unittests/t_ingestion.cc
@@ -125,9 +125,9 @@ TEST_F(T_Ingestion, TaskBasic) {
   DummyItem i3(3);
 
   task_group_.Spawn();
-  EXPECT_EQ(0, atomic_read32(&TestTask::cnt_terminate));
-  EXPECT_EQ(0, atomic_read32(&TestTask::cnt_process));
-  EXPECT_EQ(0, atomic_read32(&DummyItem::sum));
+  EXPECT_EQ(0, TestTask::cnt_terminate.load());
+  EXPECT_EQ(0, TestTask::cnt_process.load());
+  EXPECT_EQ(0, DummyItem::sum.load());
 
   tube_.EnqueueBack(&i1);
   tube_.EnqueueBack(&i2);
@@ -135,11 +135,10 @@ TEST_F(T_Ingestion, TaskBasic) {
 
   tube_.Wait();
   task_group_.Terminate();
-  EXPECT_EQ(static_cast<int>(kNumTasks),
-            atomic_read32(&TestTask::cnt_terminate));
+  EXPECT_EQ(static_cast<int>(kNumTasks), TestTask::cnt_terminate.load());
 
-  EXPECT_EQ(6, atomic_read32(&DummyItem::sum));
-  EXPECT_EQ(3, atomic_read32(&TestTask::cnt_process));
+  EXPECT_EQ(6, DummyItem::sum.load());
+  EXPECT_EQ(3, TestTask::cnt_process.load());
 }
 
 
@@ -149,9 +148,9 @@ TEST_F(T_Ingestion, TaskStress) {
   DummyItem i3(3);
 
   task_group_.Spawn();
-  EXPECT_EQ(0, atomic_read32(&TestTask::cnt_terminate));
-  EXPECT_EQ(0, atomic_read32(&TestTask::cnt_process));
-  EXPECT_EQ(0, atomic_read32(&DummyItem::sum));
+  EXPECT_EQ(0, TestTask::cnt_terminate.load());
+  EXPECT_EQ(0, TestTask::cnt_process.load());
+  EXPECT_EQ(0, DummyItem::sum.load());
 
   for (unsigned i = 0; i < 10000; ++i) {
     tube_.EnqueueBack(&i1);
@@ -161,11 +160,10 @@ TEST_F(T_Ingestion, TaskStress) {
 
   tube_.Wait();
   task_group_.Terminate();
-  EXPECT_EQ(static_cast<int>(kNumTasks),
-            atomic_read32(&TestTask::cnt_terminate));
+  EXPECT_EQ(static_cast<int>(kNumTasks), TestTask::cnt_terminate.load());
 
-  EXPECT_EQ(10000 * 6, atomic_read32(&DummyItem::sum));
-  EXPECT_EQ(10000 * 3, atomic_read32(&TestTask::cnt_process));
+  EXPECT_EQ(10000 * 6, DummyItem::sum.load());
+  EXPECT_EQ(10000 * 3, TestTask::cnt_process.load());
 }
 
 
@@ -794,7 +792,7 @@ TEST_F(T_Ingestion, PipelineNull) {
   pipeline_straight->Process(new FileIngestionSource(std::string("/dev/null")),
                              true);
   pipeline_straight->WaitFor();
-  EXPECT_EQ(1, atomic_read64(&fn_processed.ncall));
+  EXPECT_EQ(1, fn_processed.ncall.load());
   EXPECT_EQ(1U, uploader_->results.size());
   shash::Any hash_null(spooler_definition.hash_algorithm);
   shash::HashString("", &hash_null);
@@ -837,7 +835,7 @@ TEST_F(T_Ingestion, Scrubbing) {
   pipeline_scrubbing->Process(new FileIngestionSource(std::string("/dev/null")),
                               shash::kShake128, shash::kSuffixNone);
   pipeline_scrubbing->WaitFor();
-  EXPECT_EQ(1, atomic_read64(&fn_hashed.ncall));
+  EXPECT_EQ(1, fn_hashed.ncall.load());
   EXPECT_EQ("/dev/null", fn_hashed.last_result.path);
   EXPECT_EQ(null_hash, fn_hashed.last_result.hash);
 }

--- a/test/unittests/t_ingestion.cc
+++ b/test/unittests/t_ingestion.cc
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
 
@@ -23,7 +24,6 @@
 #include "ingestion/task_write.h"
 #include "testutil.h"
 #include "upload_facility.h"
-#include "util/atomic.h"
 #include "util/pointer.h"
 #include "util/posix.h"
 #include "util/smalloc.h"
@@ -37,15 +37,15 @@ class DummyItem {
   bool IsQuitBeacon() { return summand == -1; }
   explicit DummyItem(int s) : summand(s) { }
   int summand;
-  static atomic_int32 sum;
+  static std::atomic<int32_t> sum;
 };
-atomic_int32 DummyItem::sum = 0;
+std::atomic<int32_t> DummyItem::sum = 0;
 
 
 class TestTask : public TubeConsumer<DummyItem> {
  public:
-  static atomic_int32 cnt_terminate;
-  static atomic_int32 cnt_process;
+  static std::atomic<int32_t> cnt_terminate;
+  static std::atomic<int32_t> cnt_process;
   explicit TestTask(Tube<DummyItem> *tube) : TubeConsumer<DummyItem>(tube) { }
 
  protected:
@@ -55,8 +55,8 @@ class TestTask : public TubeConsumer<DummyItem> {
   }
   virtual void OnTerminate() { atomic_inc32(&cnt_terminate); }
 };
-atomic_int32 TestTask::cnt_terminate = 0;
-atomic_int32 TestTask::cnt_process = 0;
+std::atomic<int32_t> TestTask::cnt_terminate = 0;
+std::atomic<int32_t> TestTask::cnt_process = 0;
 }  // anonymous namespace
 
 
@@ -71,7 +71,7 @@ struct FnFileProcessed {
     atomic_inc64(&ncall);
   }
 
-  atomic_int64 ncall;
+  std::atomic<int64_t> ncall;
 };
 
 
@@ -84,7 +84,7 @@ struct FnFileHashed {
   }
 
   ScrubbingResult last_result;
-  atomic_int64 ncall;
+  std::atomic<int64_t> ncall;
 };
 
 

--- a/test/unittests/t_ingestion_stress.cc
+++ b/test/unittests/t_ingestion_stress.cc
@@ -517,7 +517,7 @@ struct CallbackTest {
 shash::Any CallbackTest::result_content_hash;
 std::string CallbackTest::result_local_path;
 FileChunkList CallbackTest::result_chunk_list;
-std::atomic<int64_t> CallbackTest::counter = 0;
+std::atomic<int64_t> CallbackTest::counter(0);
 }  // anonymous namespace
 
 TEST_F(T_IngestionStress, ProcessingCallbackForSmallFile) {
@@ -599,3 +599,4 @@ TEST_F(T_IngestionStress, RealWorldSlow) {
     free(buffers[i]);
   }
 }
+ 

--- a/test/unittests/t_ingestion_stress.cc
+++ b/test/unittests/t_ingestion_stress.cc
@@ -506,7 +506,7 @@ struct CallbackTest {
 
   static void CallbackCount(const upload::SpoolerResult &result) {
     EXPECT_EQ(0, result.return_code);
-    atomic_inc64(&counter);
+    counter.fetch_add(1);
   }
 
   static std::atomic<int64_t> counter;

--- a/test/unittests/t_ingestion_stress.cc
+++ b/test/unittests/t_ingestion_stress.cc
@@ -2,6 +2,7 @@
  * This file is part of the CernVM File System.
  */
 
+#include <atomic>
 #include <cassert>
 #include <cstdlib>
 #include <set>
@@ -17,7 +18,6 @@
 #include "ingestion/item_mem.h"
 #include "ingestion/pipeline.h"
 #include "testutil.h"
-#include "util/atomic.h"
 #include "util/prng.h"
 #include "util/smalloc.h"
 #include "util/string.h"
@@ -509,7 +509,7 @@ struct CallbackTest {
     atomic_inc64(&counter);
   }
 
-  static atomic_int64 counter;
+  static std::atomic<int64_t> counter;
   static shash::Any result_content_hash;
   static std::string result_local_path;
   static FileChunkList result_chunk_list;
@@ -517,7 +517,7 @@ struct CallbackTest {
 shash::Any CallbackTest::result_content_hash;
 std::string CallbackTest::result_local_path;
 FileChunkList CallbackTest::result_chunk_list;
-atomic_int64 CallbackTest::counter = 0;
+std::atomic<int64_t> CallbackTest::counter = 0;
 }  // anonymous namespace
 
 TEST_F(T_IngestionStress, ProcessingCallbackForSmallFile) {

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <string>
 
 #include "c_file_sandbox.h"
@@ -17,7 +18,6 @@
 #include "upload_local.h"
 #include "upload_s3.h"
 #include "upload_spooler_definition.h"
-#include "util/atomic.h"
 #include "util/file_guard.h"
 #include "util/logging.h"
 #include "util/posix.h"
@@ -63,9 +63,9 @@ class UploadCallbacks {
   }
 
  public:
-  atomic_int32 simple_upload_invocations;
-  atomic_int32 streamed_upload_complete_invocations;
-  atomic_int32 buffer_upload_complete_invocations;
+  std::atomic<int32_t> simple_upload_invocations;
+  std::atomic<int32_t> streamed_upload_complete_invocations;
+  std::atomic<int32_t> buffer_upload_complete_invocations;
 };
 
 
@@ -83,7 +83,7 @@ class T_Uploaders : public FileSandbox {
  public:
   static const unsigned kTotal429Replies;
   static const unsigned k429ThrottleSec;
-  static atomic_int64 gSeed;
+  static std::atomic<int64_t> gSeed;
   struct StreamHandle {
     StreamHandle() : handle(NULL), content_hash(shash::kMd5) {
       content_hash.Randomize(atomic_xadd64(&gSeed, 1));
@@ -474,7 +474,7 @@ bool T_Uploaders<S3Uploader>::IsS3() const {
 }
 
 template<class UploadersT>
-atomic_int64 T_Uploaders<UploadersT>::gSeed = 0;
+std::atomic<int64_t> T_Uploaders<UploadersT>::gSeed = 0;
 
 // Shold be larger than the number of regular retries
 template<class UploadersT>
@@ -661,7 +661,7 @@ namespace {
 struct BatchedRemoveCtx {
   AbstractUploader *uploader;
   unsigned num_keys;
-  atomic_int32 done;
+  std::atomic<int32_t> done;
 };
 
 static void *BatchedRemoveWorker(void *arg) {
@@ -833,8 +833,8 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
       atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
 
   UploadStreamHandle *handle = this->uploader_->InitStreamedUpload(
-      AbstractUploader::MakeClosure(
-          &UploadCallbacks::StreamedUploadComplete, &this->delegate_, 0));
+      AbstractUploader::MakeClosure(&UploadCallbacks::StreamedUploadComplete,
+                                    &this->delegate_, 0));
   ASSERT_NE(static_cast<UploadStreamHandle *>(NULL), handle);
 
   EXPECT_EQ(
@@ -905,8 +905,8 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
   typename TestFixture::BufferStreams::const_iterator iend = streams.end();
   for (; i != iend; ++i) {
     UploadStreamHandle *handle = this->uploader_->InitStreamedUpload(
-        AbstractUploader::MakeClosure(
-            &UploadCallbacks::StreamedUploadComplete, &this->delegate_, 0));
+        AbstractUploader::MakeClosure(&UploadCallbacks::StreamedUploadComplete,
+                                      &this->delegate_, 0));
     ASSERT_NE(static_cast<UploadStreamHandle *>(NULL), handle);
     i->second.handle = handle;
   }

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -86,7 +86,7 @@ class T_Uploaders : public FileSandbox {
   static std::atomic<int64_t> gSeed;
   struct StreamHandle {
     StreamHandle() : handle(NULL), content_hash(shash::kMd5) {
-      content_hash.Randomize(atomic_xadd64(&gSeed, 1));
+      content_hash.Randomize(gSeed.fetch_add(1));
     }
 
     UploadStreamHandle *handle;

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -44,14 +44,14 @@ class UploadCallbacks {
     EXPECT_EQ(UploaderResults::kFileUpload, results.type);
     EXPECT_EQ(expected.return_code, results.return_code);
     EXPECT_EQ(expected.local_path, results.local_path);
-    atomic_inc32(&simple_upload_invocations);
+    simple_upload_invocations.fetch_add(1);
   }
 
   void StreamedUploadComplete(const UploaderResults &results, int return_code) {
     EXPECT_EQ(UploaderResults::kChunkCommit, results.type);
     EXPECT_EQ("", results.local_path);
     EXPECT_EQ(return_code, results.return_code);
-    atomic_inc32(&streamed_upload_complete_invocations);
+    streamed_upload_complete_invocations.fetch_add(1);
   }
 
   void BufferUploadComplete(const UploaderResults &results,
@@ -59,7 +59,7 @@ class UploadCallbacks {
     EXPECT_EQ(UploaderResults::kBufferUpload, results.type);
     EXPECT_EQ("", results.local_path);
     EXPECT_EQ(expected.return_code, results.return_code);
-    atomic_inc32(&buffer_upload_complete_invocations);
+    buffer_upload_complete_invocations.fetch_add(1);
   }
 
  public:
@@ -670,7 +670,7 @@ static void *BatchedRemoveWorker(void *arg) {
     ctx->uploader->RemoveAsync("regression_" + StringifyInt(i));
   }
   ctx->uploader->WaitForUpload();
-  atomic_inc32(&ctx->done);
+  ctx->done.fetch_add(1);
   return NULL;
 }
 }  // namespace

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -474,7 +474,7 @@ bool T_Uploaders<S3Uploader>::IsS3() const {
 }
 
 template<class UploadersT>
-std::atomic<int64_t> T_Uploaders<UploadersT>::gSeed = 0;
+std::atomic<int64_t> T_Uploaders<UploadersT>::gSeed(0);
 
 // Shold be larger than the number of regular retries
 template<class UploadersT>
@@ -987,3 +987,4 @@ TYPED_TEST(T_Uploaders, PlaceBootstrappingShortcut) {
 }
 
 }  // namespace upload
+                      

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -34,9 +34,9 @@ namespace upload {
 class UploadCallbacks {
  public:
   UploadCallbacks() {
-    atomic_init32(&simple_upload_invocations);
-    atomic_init32(&streamed_upload_complete_invocations);
-    atomic_init32(&buffer_upload_complete_invocations);
+    simple_upload_invocations.store(0);
+    streamed_upload_complete_invocations.store(0);
+    buffer_upload_complete_invocations.store(0);
   }
 
   void SimpleUploadClosure(const UploaderResults &results,
@@ -698,7 +698,7 @@ TYPED_TEST(T_Uploaders, BatchedRemoveNoDeadlockSlow) {
   BatchedRemoveCtx ctx;
   ctx.uploader = this->uploader_;
   ctx.num_keys = kNumKeys;
-  atomic_init32(&ctx.done);
+  ctx.done.store(0);
 
   pthread_t worker;
   ASSERT_EQ(0, pthread_create(&worker, NULL, BatchedRemoveWorker, &ctx));

--- a/test/unittests/t_uploaders.cc
+++ b/test/unittests/t_uploaders.cc
@@ -527,7 +527,7 @@ TYPED_TEST(T_Uploaders, RetrySlow) {
   SetAltLogFunc(NULL);
 
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       small_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
 
@@ -562,7 +562,7 @@ TYPED_TEST(T_Uploaders, SimpleFileUpload) {
 
   this->uploader_->WaitForUpload();
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       big_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
 }
@@ -610,7 +610,7 @@ TYPED_TEST(T_Uploaders, PeekIntoStorage) {
   this->uploader_->WaitForUpload();
 
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       small_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
 
@@ -637,7 +637,7 @@ TYPED_TEST(T_Uploaders, RemoveFromStorage) {
   this->uploader_->WaitForUpload();
 
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       small_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
 
@@ -704,12 +704,12 @@ TYPED_TEST(T_Uploaders, BatchedRemoveNoDeadlockSlow) {
   ASSERT_EQ(0, pthread_create(&worker, NULL, BatchedRemoveWorker, &ctx));
 
   unsigned elapsed_ms = 0;
-  while (!atomic_read32(&ctx.done) && elapsed_ms < kTimeoutMs) {
+  while (!ctx.done.load() && elapsed_ms < kTimeoutMs) {
     SafeSleepMs(100);
     elapsed_ms += 100;
   }
 
-  if (!atomic_read32(&ctx.done)) {
+  if (!ctx.done.load()) {
     // Worker is stuck inside RemoveAsync's ++jobs_in_flight_.  The uploader
     // state is unsafe to touch, so report the failure and abort the process
     // rather than risk UB at tear-down or corrupting later tests.
@@ -741,7 +741,7 @@ TYPED_TEST(T_Uploaders, UploadEmptyFile) {
   this->uploader_->WaitForUpload();
 
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       empty_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
   EXPECT_EQ(0, GetFileSize(TestFixture::AbsoluteDestinationPath(dest_name)));
@@ -763,7 +763,7 @@ TYPED_TEST(T_Uploaders, UploadHugeFileSlow) {
   this->uploader_->WaitForUpload();
 
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       huge_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
 }
@@ -809,7 +809,7 @@ TYPED_TEST(T_Uploaders, UploadManyFilesSlow) {
   this->uploader_->WaitForUpload();
 
   EXPECT_EQ(number_of_files,
-            atomic_read32(&(this->delegate_.simple_upload_invocations)));
+            (this->delegate_.simple_upload_invocations.load()));
   for (i = files.begin(); i != iend; ++i) {
     EXPECT_TRUE(TestFixture::CheckFile(i->second));
     TestFixture::CompareFileContents(
@@ -826,22 +826,16 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
   typename TestFixture::Buffers buffers = TestFixture::MakeRandomizedBuffers(
       number_of_buffers, 1337);
 
-  EXPECT_EQ(
-      0, atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      0,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(0, (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(0, (this->delegate_.streamed_upload_complete_invocations.load()));
 
   UploadStreamHandle *handle = this->uploader_->InitStreamedUpload(
       AbstractUploader::MakeClosure(&UploadCallbacks::StreamedUploadComplete,
                                     &this->delegate_, 0));
   ASSERT_NE(static_cast<UploadStreamHandle *>(NULL), handle);
 
-  EXPECT_EQ(
-      0, atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      0,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(0, (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(0, (this->delegate_.streamed_upload_complete_invocations.load()));
 
   typename TestFixture::Buffers::const_iterator i = buffers.begin();
   typename TestFixture::Buffers::const_iterator iend = buffers.end();
@@ -857,24 +851,18 @@ TYPED_TEST(T_Uploaders, SingleStreamedUpload) {
   }
   this->uploader_->WaitForUpload();
 
-  EXPECT_EQ(
-      number_of_buffers,
-      atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      0,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(number_of_buffers,
+            (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(0, (this->delegate_.streamed_upload_complete_invocations.load()));
 
   shash::Any content_hash(shash::kSha1, 'A');
   content_hash.Randomize(42);
   this->uploader_->ScheduleCommit(handle, content_hash);
   this->uploader_->WaitForUpload();
 
-  EXPECT_EQ(
-      number_of_buffers,
-      atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      1,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(number_of_buffers,
+            (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(1, (this->delegate_.streamed_upload_complete_invocations.load()));
 
   const std::string dest = "data/" + content_hash.MakePath();
   EXPECT_TRUE(TestFixture::CheckFile(dest));
@@ -895,11 +883,8 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
       streams = TestFixture::MakeRandomizedBufferStreams(
           number_of_files, max_buffers_per_stream, 42);
 
-  EXPECT_EQ(
-      0, atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      0,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(0, (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(0, (this->delegate_.streamed_upload_complete_invocations.load()));
 
   typename TestFixture::BufferStreams::iterator i = streams.begin();
   typename TestFixture::BufferStreams::const_iterator iend = streams.end();
@@ -911,11 +896,8 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
     i->second.handle = handle;
   }
 
-  EXPECT_EQ(
-      0, atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      0,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(0, (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(0, (this->delegate_.streamed_upload_complete_invocations.load()));
 
   // go through the handles and schedule buffers for them in a round robin
   // fashion --> we want to test concurrent streamed upload behaviour
@@ -949,12 +931,10 @@ TYPED_TEST(T_Uploaders, MultipleStreamedUploadSlow) {
 
   this->uploader_->WaitForUpload();
 
-  EXPECT_EQ(
-      number_of_buffers,
-      atomic_read32(&(this->delegate_.buffer_upload_complete_invocations)));
-  EXPECT_EQ(
-      number_of_files,
-      atomic_read32(&(this->delegate_.streamed_upload_complete_invocations)));
+  EXPECT_EQ(number_of_buffers,
+            (this->delegate_.buffer_upload_complete_invocations.load()));
+  EXPECT_EQ(number_of_files,
+            (this->delegate_.streamed_upload_complete_invocations.load()));
 
   typename TestFixture::BufferStreams::const_iterator k = streams.begin();
   typename TestFixture::BufferStreams::const_iterator kend = streams.end();
@@ -996,7 +976,7 @@ TYPED_TEST(T_Uploaders, PlaceBootstrappingShortcut) {
   this->uploader_->WaitForUpload();
   EXPECT_TRUE(TestFixture::CheckFile(dest_name));
 
-  EXPECT_EQ(1, atomic_read32(&(this->delegate_.simple_upload_invocations)));
+  EXPECT_EQ(1, (this->delegate_.simple_upload_invocations.load()));
   TestFixture::CompareFileContents(
       big_file_path, TestFixture::AbsoluteDestinationPath(dest_name));
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -13,6 +13,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstring>
 #include <ctime>
 #include <limits>
@@ -21,7 +22,6 @@
 #include "shortstring.h"
 #include "testutil.h"
 #include "util/algorithm.h"
-#include "util/atomic.h"
 #include "util/file_guard.h"
 #include "util/mmap_file.h"
 #include "util/pipe.h"
@@ -1756,8 +1756,8 @@ TEST_F(T_Util, ExecuteBinary) {
   argv.push_back(message);
   pid_t gdb_pid = 0;
 
-  result = ExecuteBinary(
-      &fd_stdin, &fd_stdout, &fd_stderr, "/bin/echo", argv, false, &gdb_pid);
+  result = ExecuteBinary(&fd_stdin, &fd_stdout, &fd_stderr, "/bin/echo", argv,
+                         false, &gdb_pid);
   EXPECT_TRUE(result);
   ssize_t bytes_read = read(fd_stdout, buffer, message.length());
   EXPECT_EQ(static_cast<size_t>(bytes_read), message.length());
@@ -2175,7 +2175,7 @@ TEST(Log2Histogram, 2BinEmpty) {
 
   UTLog2Histogram unit_test;
 
-  std::vector<atomic_int32> bins = unit_test.GetBins(log2hist);
+  std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
   int res[3] = {3, 0, 0};
   for (int i = 0; i < 3; i++) {
     EXPECT_EQ(res[i], atomic_read32(&bins[i]));
@@ -2196,7 +2196,7 @@ TEST(Log2Histogram, 2Bins) {
 
   UTLog2Histogram unit_test;
 
-  std::vector<atomic_int32> bins = unit_test.GetBins(log2hist);
+  std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
   int res[3] = {1, 3, 2};
   for (int i = 0; i < 3; i++) {
     EXPECT_EQ(res[i], atomic_read32(&bins[i]));
@@ -2220,7 +2220,7 @@ TEST(Log2Histogram, 3Bins) {
 
   UTLog2Histogram unit_test;
 
-  std::vector<atomic_int32> bins = unit_test.GetBins(log2hist);
+  std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
   int res[4] = {1, 5, 2, 4};
   for (int i = 0; i < 4; i++) {
     EXPECT_EQ(res[i], atomic_read32(&bins[i]));

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -2178,7 +2178,7 @@ TEST(Log2Histogram, 2BinEmpty) {
   std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
   int res[3] = {3, 0, 0};
   for (int i = 0; i < 3; i++) {
-    EXPECT_EQ(res[i], atomic_read32(&bins[i]));
+    EXPECT_EQ(res[i], bins[i].load());
   }
 
   unsigned int q = log2hist.GetQuantile(0.5);
@@ -2199,7 +2199,7 @@ TEST(Log2Histogram, 2Bins) {
   std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
   int res[3] = {1, 3, 2};
   for (int i = 0; i < 3; i++) {
-    EXPECT_EQ(res[i], atomic_read32(&bins[i]));
+    EXPECT_EQ(res[i], bins[i].load());
   }
 }
 
@@ -2223,7 +2223,7 @@ TEST(Log2Histogram, 3Bins) {
   std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
   int res[4] = {1, 5, 2, 4};
   for (int i = 0; i < 4; i++) {
-    EXPECT_EQ(res[i], atomic_read32(&bins[i]));
+    EXPECT_EQ(res[i], bins[i].load());
   }
 }
 

--- a/test/unittests/t_util.cc
+++ b/test/unittests/t_util.cc
@@ -2175,10 +2175,10 @@ TEST(Log2Histogram, 2BinEmpty) {
 
   UTLog2Histogram unit_test;
 
-  std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
+  auto &bins = unit_test.GetBins(log2hist);
   int res[3] = {3, 0, 0};
   for (int i = 0; i < 3; i++) {
-    EXPECT_EQ(res[i], bins[i].load());
+    EXPECT_EQ(res[i], bins[i]->load());
   }
 
   unsigned int q = log2hist.GetQuantile(0.5);
@@ -2196,10 +2196,10 @@ TEST(Log2Histogram, 2Bins) {
 
   UTLog2Histogram unit_test;
 
-  std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
+  auto &bins = unit_test.GetBins(log2hist);
   int res[3] = {1, 3, 2};
   for (int i = 0; i < 3; i++) {
-    EXPECT_EQ(res[i], bins[i].load());
+    EXPECT_EQ(res[i], bins[i]->load());
   }
 }
 
@@ -2220,10 +2220,10 @@ TEST(Log2Histogram, 3Bins) {
 
   UTLog2Histogram unit_test;
 
-  std::vector<std::atomic<int32_t> > bins = unit_test.GetBins(log2hist);
+  auto &bins = unit_test.GetBins(log2hist);
   int res[4] = {1, 5, 2, 4};
   for (int i = 0; i < 4; i++) {
-    EXPECT_EQ(res[i], bins[i].load());
+    EXPECT_EQ(res[i], bins[i]->load());
   }
 }
 
@@ -2253,3 +2253,4 @@ TEST(Log2Histogram, Quantiles) {
     EXPECT_NEAR(q, expected, max_difference);
   }
 }
+


### PR DESCRIPTION
Related to https://github.com/cvmfs/cvmfs/issues/3326

This PR performed the conversion below to replace the in house atomic infrastructure  with std::atomic, since Cpp11 is now supported.

| In-house Function          | std::atomic Replacement                     |
|----------------------------|---------------------------------------------|
| `atomic_init32(&a)`         | `a.store(0)`                               |
| `atomic_init64(&a)`         | `a.store(0)`                               |
| `atomic_read32(&a)`         | `a.load()`                                 |
| `atomic_read64(&a)`         | `a.load()`                                 |
| `atomic_write32(&a, val)`   | `a.store(val)`                             |
| `atomic_write64(&a, val)`   | `a.store(val)`                             |
| `atomic_inc32(&a)`          | `a.fetch_add(1)`                           |
| `atomic_inc64(&a)`          | `a.fetch_add(1)`                           |
| `atomic_dec32(&a)`          | `a.fetch_sub(1)`                           |
| `atomic_dec64(&a)`          | `a.fetch_sub(1)`                           |
| `atomic_xadd32(&a, offset)` | `offset >= 0 ? a.fetch_add(offset) : a.fetch_sub(-offset)` |
| `atomic_xadd64(&a, offset)` | `offset >= 0 ? a.fetch_add(offset) : a.fetch_sub(-offset)` |
| `atomic_cas32(&a, cmp, new)`| `a.compare_exchange_strong(cmp, new)`      |
| `atomic_cas64(&a, cmp, new)`| `a.compare_exchange_strong(cmp, new)`      |
| `MemoryFence()`            | `std::atomic_thread_fence(std::memory_order_seq_cst)` |


There is a dedicated micro benchmarks which shows similar performance between the in house and the standard version. It should probably be removed before merging.