### PR TITLE
test: drop the unimplemented CVMFS_TEST_SRVDEBUG debug mode

### DIFF
--- a/test/test_functions
+++ b/test/test_functions
@@ -1,13 +1,4 @@
 #!/bin/bash
-# By default, this script runs in testing mode
-# Although it allows for a server debugging mode, which attaches gdb to
-# the `cvmfs_server publish` process and allows for both online and
-# failure debugging.
-#
-# To allow for online debugging, export CVMFS_TEST_SRVDEBUG like so:
-#
-# `export CVMFS_TEST_SRVDEBUG=fail`    - for crash debugging with gdb
-# `export CVMFS_TEST_SRVDEBUG=startup` - for interactive debugging with gdb
 
 CVMFS_SERVER_APACHE_RELOAD_IS_RESTART=true
 CVMFS_TEST_USE_MACFUSE_KEXT=${CVMFS_TEST_USE_MACFUSE_KEXT:=no}
@@ -28,7 +19,6 @@ CVMFS_TEST_GEO_LICENSE_KEY=${CVMFS_TEST_GEO_LICENSE_KEY:=}
 CVMFS_TEST_GEO_ACCOUNT_ID=${CVMFS_TEST_GEO_ACCOUNT_ID:=}
 
 CVMFS_TEST_UNIONFS=${CVMFS_TEST_UNIONFS:=} # union filesystem type to test
-CVMFS_TEST_SRVDEBUG=${CVMFS_TEST_SRVDEBUG:=}
 CVMFS_TEST_HASHALGO=${CVMFS_TEST_HASHALGO:=sha1}
 CVMFS_TEST_S3_CONFIG=${CVMFS_TEST_S3_CONFIG:=}
 CVMFS_TEST_S3_STORAGE=${CVMFS_TEST_S3_STORAGE:=}
@@ -1363,20 +1353,7 @@ publish_repo() {
   local repo=$1
   shift 1
 
-  # enable the debug mode?
-  # in debug mode we redirect output directly to the interactive shell,
-  # overriding any redirections to logfiles or whatever... We want to hack!
-  case $CVMFS_TEST_SRVDEBUG in
-    fail)
-      cvmfs_server publish -dv "$@" $repo > /dev/tty 2>&1 || return 100
-    ;;
-    startup)
-      cvmfs_server publish -Dv "$@" $repo > /dev/tty 2>&1 || return 100
-    ;;
-    *)
-      cvmfs_server publish -v "$@" $repo || return 100
-    ;;
-  esac
+  cvmfs_server publish -v "$@" $repo || return 100
 
   return 0
 }


### PR DESCRIPTION
`publish_repo()` turns `CVMFS_TEST_SRVDEBUG` into `cvmfs_server publish -d` or `-D`. Neither flag does what the comment above it describes: both were dropped in 2016 when publish moved into its own file, and `-d` came back in 2021 meaning direct I/O. So today `fail` publishes with direct I/O silently enabled and `startup` aborts with "Unrecognized option".

This removes the variable, its documentation and the two dead branches, leaving the plain publish call that every test already takes.

Fixes #4238
