### PR TITLE
fix: handle mountpoint paths in showconfig

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -266,7 +266,8 @@ cvmfs_config_usage() {
   fi
   echo "  chksetup"
   echo ""
-  echo "  showconfig [-s(hort output, only parameters set in the configuration)] [-j|--json] [<repository>]"
+  echo "  showconfig [-s(hort output, only parameters set in the" \
+       "configuration)] [-j|--json] [<repository>|<mountpoint>]"
   echo ""
   echo "  stat [-v | <repository>]"
   echo ""
@@ -1029,9 +1030,18 @@ cvmfs_showconfig() {
     return 0
   fi
 
-  fqrn=`cvmfs_mkfqrn $org`
-  org=`cvmfs_getorg $fqrn`
-  cvmfs_readconfig $fqrn || die "Failed to read CernVM-FS configuration"
+  local mount_prefix="${CVMFS_MOUNT_DIR%/}/"
+  if [[ "$org" == "$mount_prefix"* ]]; then
+    org=${org#"$mount_prefix"}
+    org=${org%/}
+  fi
+  if [[ -z "$org" || "$org" == */* ]]; then
+    die "Invalid repository path"
+  fi
+
+  fqrn=$(cvmfs_mkfqrn "$org")
+  org=$(cvmfs_getorg "$fqrn")
+  cvmfs_readconfig "$fqrn" || die "Failed to read CernVM-FS configuration"
   retval=$?
   if [ $retval -ne 0 ]; then
     return $retval
@@ -1084,10 +1094,10 @@ cvmfs_showconfig() {
     line=$(echo "$CVMFS_PARMS" | grep "^${var}=")
     if [ "x$line" != "x" ]; then
       if [ "x$org" != "x" ]; then
-        line=`echo "$line" | sed s/@org@/$org/g`
+        line=${line//@org@/$org}
       fi
       if [ "x$fqrn" != "x" ]; then
-        line=`echo "$line" | sed s/@fqrn@/$fqrn/g`
+        line=${line//@fqrn@/$fqrn}
       fi
       echo "$line"
     else

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -983,7 +983,6 @@ json_string() {
 cvmfs_showconfig() {
   local fqrn
   local org
-  local retval
   local short_output=0
   local json_output=0
   local short_opt=
@@ -1030,22 +1029,19 @@ cvmfs_showconfig() {
     return 0
   fi
 
+  local given_path="$org"
   local mount_prefix="${CVMFS_MOUNT_DIR%/}/"
   if [[ "$org" == "$mount_prefix"* ]]; then
     org=${org#"$mount_prefix"}
-    org=${org%/}
   fi
+  org=${org%/}
   if [[ -z "$org" || "$org" == */* ]]; then
-    die "Invalid repository path"
+    die "Invalid repository path: $given_path"
   fi
 
   fqrn=$(cvmfs_mkfqrn "$org")
   org=$(cvmfs_getorg "$fqrn")
   cvmfs_readconfig "$fqrn" || die "Failed to read CernVM-FS configuration"
-  retval=$?
-  if [ $retval -ne 0 ]; then
-    return $retval
-  fi
 
   local setting=
   local all_vars=
@@ -1104,6 +1100,9 @@ cvmfs_showconfig() {
       [ $short_output -eq 0 ] && echo "${var}="
     fi
   done <<< "$all_vars"
+  # In short mode the loop's last command may be the failed condition above;
+  # don't let that become the function's exit status.
+  return 0
 }
 
 

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -1891,7 +1891,7 @@ cvmfs_bugreport() {
 
 
 die() {
-  echo -e $1 >&2
+  echo -e "$1" >&2
   exit 1
 }
 

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -102,7 +102,7 @@ cvmfs_run_test() {
 
   # A repository mountpoint must resolve like the repository name in both
   # output formats.
-  local plain_by_name plain_by_path plain_by_path_slash
+  local plain_by_name plain_by_path plain_by_path_slash plain_by_name_slash
   local json_by_name json_by_path line mount_dir
   local short_by_name short_by_path
   plain_by_name=$(cvmfs_config showconfig grid.cern.ch) || retval=47
@@ -128,25 +128,29 @@ cvmfs_run_test() {
   diff <(printf '%s\n' "$plain_by_name" | normalize_plain) \
        <(printf '%s\n' "$plain_by_path_slash" | normalize_plain) \
        || retval=53
+  plain_by_name_slash=$(cvmfs_config showconfig grid.cern.ch/) || retval=54
+  diff <(printf '%s\n' "$plain_by_name" | normalize_plain) \
+       <(printf '%s\n' "$plain_by_name_slash" | normalize_plain) \
+       || retval=55
 
-  json_by_name=$(cvmfs_config showconfig -j grid.cern.ch) || retval=54
+  json_by_name=$(cvmfs_config showconfig -j grid.cern.ch) || retval=56
   json_by_path=$(cvmfs_config showconfig -j \
-    "${mount_dir%/}/grid.cern.ch") || retval=55
+    "${mount_dir%/}/grid.cern.ch") || retval=57
   diff <(printf '%s\n' "$json_by_name" | normalize_json) \
-       <(printf '%s\n' "$json_by_path" | normalize_json) || retval=56
+       <(printf '%s\n' "$json_by_path" | normalize_json) || retval=58
   jq -e '.CVMFS_REPOSITORY_NAME == "grid.cern.ch"' \
-    <<< "$json_by_path" >/dev/null || retval=57
+    <<< "$json_by_path" >/dev/null || retval=59
 
-  short_by_name=$(cvmfs_config showconfig -s grid.cern.ch) || retval=58
+  short_by_name=$(cvmfs_config showconfig -s grid.cern.ch) || retval=60
   short_by_path=$(cvmfs_config showconfig -s \
-    "${mount_dir%/}/grid.cern.ch") || retval=59
+    "${mount_dir%/}/grid.cern.ch") || retval=61
   diff <(printf '%s\n' "$short_by_name" | normalize_plain) \
-       <(printf '%s\n' "$short_by_path" | normalize_plain) || retval=60
+       <(printf '%s\n' "$short_by_path" | normalize_plain) || retval=62
 
   expect_exit_code 1 cvmfs_config showconfig \
-    "${mount_dir%/}/grid.cern.ch/subdir" || retval=61
+    "${mount_dir%/}/grid.cern.ch/subdir" || retval=63
   expect_exit_code 1 cvmfs_config showconfig \
-    /tmp/grid.cern.ch || retval=62
+    /tmp/grid.cern.ch || retval=64
 
   cvmfs_umount grid.cern.ch || retval=5
 

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -100,6 +100,54 @@ cvmfs_run_test() {
     | jq -e "(.CVMFS_SERVER_URL // \"\") | test(\"'\") | not" >/dev/null \
     || retval=46
 
+  # A repository mountpoint must resolve like the repository name in both
+  # output formats.
+  local plain_by_name plain_by_path plain_by_path_slash
+  local json_by_name json_by_path line mount_dir
+  local short_by_name short_by_path
+  plain_by_name=$(cvmfs_config showconfig grid.cern.ch) || retval=47
+  while read -r line; do
+    if [[ "$line" == CVMFS_MOUNT_DIR=* ]]; then
+      mount_dir=${line#CVMFS_MOUNT_DIR=}
+      break
+    fi
+  done < <(printf '%s\n' "$plain_by_name" | normalize_plain)
+  if [[ -z "$mount_dir" ]]; then
+    retval=48
+    mount_dir=/cvmfs
+  fi
+
+  plain_by_path=$(cvmfs_config showconfig \
+    "${mount_dir%/}/grid.cern.ch") || retval=49
+  diff <(printf '%s\n' "$plain_by_name" | normalize_plain) \
+       <(printf '%s\n' "$plain_by_path" | normalize_plain) || retval=50
+  grep -q '^CVMFS_REPOSITORY_NAME=grid.cern.ch$' \
+    <<< "$plain_by_path" || retval=51
+  plain_by_path_slash=$(cvmfs_config showconfig \
+    "${mount_dir%/}/grid.cern.ch/") || retval=52
+  diff <(printf '%s\n' "$plain_by_name" | normalize_plain) \
+       <(printf '%s\n' "$plain_by_path_slash" | normalize_plain) \
+       || retval=53
+
+  json_by_name=$(cvmfs_config showconfig -j grid.cern.ch) || retval=54
+  json_by_path=$(cvmfs_config showconfig -j \
+    "${mount_dir%/}/grid.cern.ch") || retval=55
+  diff <(printf '%s\n' "$json_by_name" | normalize_json) \
+       <(printf '%s\n' "$json_by_path" | normalize_json) || retval=56
+  jq -e '.CVMFS_REPOSITORY_NAME == "grid.cern.ch"' \
+    <<< "$json_by_path" >/dev/null || retval=57
+
+  short_by_name=$(cvmfs_config showconfig -s grid.cern.ch) || retval=58
+  short_by_path=$(cvmfs_config showconfig -s \
+    "${mount_dir%/}/grid.cern.ch") || retval=59
+  diff <(printf '%s\n' "$short_by_name" | normalize_plain) \
+       <(printf '%s\n' "$short_by_path" | normalize_plain) || retval=60
+
+  expect_exit_code 1 cvmfs_config showconfig \
+    "${mount_dir%/}/grid.cern.ch/subdir" || retval=61
+  expect_exit_code 1 cvmfs_config showconfig \
+    /tmp/grid.cern.ch || retval=62
+
   cvmfs_umount grid.cern.ch || retval=5
 
   cvmfs_mount grid.cern.ch "CVMFS_KCACHE_TIMEOUT=4" || retval=6


### PR DESCRIPTION
`cvmfs_config showconfig /cvmfs/software.eessi.io` currently treats the full mountpoint as the repository name. This also breaks the plain output because the path is passed to `sed`.

Strip `CVMFS_MOUNT_DIR` from mountpoint arguments before loading the repository configuration. Trailing slashes are tolerated and invalid paths abort with an error naming the argument. Plain output now uses shell parameter expansion, as the JSON output already does.

The new test exposed a pre-existing bug: in short mode the last command of the output loop can be a failed `[ ... ]` condition, so `showconfig -s` printed the correct output but exited 1. The plain output branch now returns 0 explicitly, as the JSON branch already does.

Test 046 covers repository names and mountpoints in regular, JSON, and short output, including trailing slashes, invalid paths, and exit codes.

Fixes #4080