### PR TITLE
build: quiet warnings from newer c-ares/curl/protobuf

### DIFF
--- a/cvmfs/cache.proto
+++ b/cvmfs/cache.proto
@@ -6,6 +6,8 @@
 // mirroring currently open files.  Only objects with reference count zero may
 // be removed from the store.
 
+syntax = "proto2";
+
 package cvmfs;
 
 option optimize_for = LITE_RUNTIME;

--- a/cvmfs/cache_extern.cc
+++ b/cvmfs/cache_extern.cc
@@ -133,7 +133,7 @@ int ExternalCacheManager::ChangeRefcount(const shash::Any &id, int change_by) {
   msg_refcount.set_change_by(change_by);
   RpcJob rpc_job(&msg_refcount);
   CallRemotely(&rpc_job);
-  msg_refcount.release_object_id();
+  (void)msg_refcount.release_object_id();
 
   cvmfs::MsgRefcountReply *msg_reply = rpc_job.msg_refcount_reply();
   return Ack2Errno(msg_reply->status());
@@ -446,7 +446,7 @@ int ExternalCacheManager::Flush(bool do_commit, Transaction *transaction) {
   rpc_job.set_attachment_send(transaction->buffer, transaction->buf_pos);
   // TODO(jblomer): allow for out of order chunk upload
   CallRemotely(&rpc_job);
-  msg_store.release_object_id();
+  (void)msg_store.release_object_id();
 
   cvmfs::MsgStoreReply *msg_reply = rpc_job.msg_store_reply();
   if (msg_reply->status() == cvmfs::STATUS_OK) {
@@ -478,7 +478,7 @@ int64_t ExternalCacheManager::GetSize(int fd) {
   msg_info.set_allocated_object_id(&object_id);
   RpcJob rpc_job(&msg_info);
   CallRemotely(&rpc_job);
-  msg_info.release_object_id();
+  (void)msg_info.release_object_id();
 
   cvmfs::MsgObjectInfoReply *msg_reply = rpc_job.msg_object_info_reply();
   if (msg_reply->status() == cvmfs::STATUS_OK) {
@@ -614,7 +614,7 @@ int64_t ExternalCacheManager::Pread(int fd,
     rpc_job.set_attachment_recv(reinterpret_cast<char *>(buf) + nbytes,
                                 batch_size);
     CallRemotely(&rpc_job);
-    msg_read.release_object_id();
+    (void)msg_read.release_object_id();
 
     cvmfs::MsgReadReply *msg_reply = rpc_job.msg_read_reply();
     if (msg_reply->status() == cvmfs::STATUS_OK) {
@@ -658,7 +658,7 @@ int ExternalCacheManager::Reset(void *txn) {
   msg_abort.set_allocated_object_id(&object_id);
   RpcJob rpc_job(&msg_abort);
   CallRemotely(&rpc_job);
-  msg_abort.release_object_id();
+  (void)msg_abort.release_object_id();
   cvmfs::MsgStoreReply *msg_reply = rpc_job.msg_store_reply();
   transaction->transaction_id = NextRequestId();
   transaction->flushed = false;
@@ -715,8 +715,8 @@ bool ExternalCacheManager::StoreBreadcrumb(const manifest::Manifest &manifest) {
   msg_breadcrumb_store.set_allocated_breadcrumb(&breadcrumb);
   RpcJob rpc_job(&msg_breadcrumb_store);
   CallRemotely(&rpc_job);
-  msg_breadcrumb_store.release_breadcrumb();
-  breadcrumb.release_hash();
+  (void)msg_breadcrumb_store.release_breadcrumb();
+  (void)breadcrumb.release_hash();
 
   cvmfs::MsgBreadcrumbReply *msg_reply = rpc_job.msg_breadcrumb_reply();
   return msg_reply->status() == cvmfs::STATUS_OK;

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -525,8 +525,9 @@ void CacheTransport::SendNonBlocking(struct iovec *iov, unsigned iovcnt) {
 
 void CacheTransport::SendFrame(CacheTransport::Frame *frame) {
   cvmfs::MsgRpc *msg_rpc = frame->GetMsgRpc();
-  const int32_t size = static_cast<int32_t>(msg_rpc->ByteSizeLong());
-  assert(size > 0);
+  const size_t byte_size = msg_rpc->ByteSizeLong();
+  assert((byte_size > 0) && (byte_size <= kMaxMsgSize));
+  const uint32_t size = static_cast<uint32_t>(byte_size);
 #ifdef __APPLE__
   void *buffer = smalloc(size);
 #else

--- a/cvmfs/cache_transport.cc
+++ b/cvmfs/cache_transport.cc
@@ -106,29 +106,29 @@ void CacheTransport::Frame::Release() {
   if (owns_msg_typed_)
     return;
 
-  msg_rpc_.release_msg_refcount_req();
-  msg_rpc_.release_msg_refcount_reply();
-  msg_rpc_.release_msg_read_req();
-  msg_rpc_.release_msg_read_reply();
-  msg_rpc_.release_msg_object_info_req();
-  msg_rpc_.release_msg_object_info_reply();
-  msg_rpc_.release_msg_store_req();
-  msg_rpc_.release_msg_store_abort_req();
-  msg_rpc_.release_msg_store_reply();
-  msg_rpc_.release_msg_handshake();
-  msg_rpc_.release_msg_handshake_ack();
-  msg_rpc_.release_msg_quit();
-  msg_rpc_.release_msg_ioctl();
-  msg_rpc_.release_msg_info_req();
-  msg_rpc_.release_msg_info_reply();
-  msg_rpc_.release_msg_shrink_req();
-  msg_rpc_.release_msg_shrink_reply();
-  msg_rpc_.release_msg_list_req();
-  msg_rpc_.release_msg_list_reply();
-  msg_rpc_.release_msg_detach();
-  msg_rpc_.release_msg_breadcrumb_store_req();
-  msg_rpc_.release_msg_breadcrumb_load_req();
-  msg_rpc_.release_msg_breadcrumb_reply();
+  (void)msg_rpc_.release_msg_refcount_req();
+  (void)msg_rpc_.release_msg_refcount_reply();
+  (void)msg_rpc_.release_msg_read_req();
+  (void)msg_rpc_.release_msg_read_reply();
+  (void)msg_rpc_.release_msg_object_info_req();
+  (void)msg_rpc_.release_msg_object_info_reply();
+  (void)msg_rpc_.release_msg_store_req();
+  (void)msg_rpc_.release_msg_store_abort_req();
+  (void)msg_rpc_.release_msg_store_reply();
+  (void)msg_rpc_.release_msg_handshake();
+  (void)msg_rpc_.release_msg_handshake_ack();
+  (void)msg_rpc_.release_msg_quit();
+  (void)msg_rpc_.release_msg_ioctl();
+  (void)msg_rpc_.release_msg_info_req();
+  (void)msg_rpc_.release_msg_info_reply();
+  (void)msg_rpc_.release_msg_shrink_req();
+  (void)msg_rpc_.release_msg_shrink_reply();
+  (void)msg_rpc_.release_msg_list_req();
+  (void)msg_rpc_.release_msg_list_reply();
+  (void)msg_rpc_.release_msg_detach();
+  (void)msg_rpc_.release_msg_breadcrumb_store_req();
+  (void)msg_rpc_.release_msg_breadcrumb_load_req();
+  (void)msg_rpc_.release_msg_breadcrumb_reply();
 }
 
 
@@ -525,7 +525,7 @@ void CacheTransport::SendNonBlocking(struct iovec *iov, unsigned iovcnt) {
 
 void CacheTransport::SendFrame(CacheTransport::Frame *frame) {
   cvmfs::MsgRpc *msg_rpc = frame->GetMsgRpc();
-  const int32_t size = msg_rpc->ByteSize();
+  const int32_t size = static_cast<int32_t>(msg_rpc->ByteSizeLong());
   assert(size > 0);
 #ifdef __APPLE__
   void *buffer = smalloc(size);

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -40,6 +40,11 @@
 #include "util/smalloc.h"
 #include "util/string.h"
 
+// c-ares 1.x deprecates the classic ares_parse_*/ares_search/ares_getsock/
+// ares_get_servers entry points. They remain functional; migrating to the
+// ares_dns_record API is a separate, testable change. Accept them for now.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using namespace std;  // NOLINT
 
 namespace dns {

--- a/cvmfs/network/dns.cc
+++ b/cvmfs/network/dns.cc
@@ -40,9 +40,12 @@
 #include "util/smalloc.h"
 #include "util/string.h"
 
-// c-ares 1.x deprecates the classic ares_parse_*/ares_search/ares_getsock/
-// ares_get_servers entry points. They remain functional; migrating to the
-// ares_dns_record API is a separate, testable change. Accept them for now.
+// c-ares 1.28.0 deprecates the ares_parse_* / ares_seach /
+// / ares_getsock / ares_get_servers functions in favor of the new
+// new ares_dns_record API (ares_dns_parse, ares_search_dnsrec,
+// ares_get_servers_csv, ARES_OPT_EVENT_THREAD/ARES_OPT_SOCK_STATE_CB).
+// The new API is not supported yet by AlmaLinux 8's system c-ares (1.13)
+// though, so we will wait with the migration until Almalinux 8 is EOL (2029).
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 using namespace std;  // NOLINT

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1258,11 +1258,11 @@ bool DownloadManager::ValidateProxyIpsUnlocked(const string &url,
  * Adds transfer time and downloaded bytes to the global counters.
  */
 void DownloadManager::UpdateStatistics(CURL *handle) {
-  double val;
+  curl_off_t val;
   int retval;
   int64_t sum = 0;
 
-  retval = curl_easy_getinfo(handle, CURLINFO_SIZE_DOWNLOAD, &val);
+  retval = curl_easy_getinfo(handle, CURLINFO_SIZE_DOWNLOAD_T, &val);
   assert(retval == CURLE_OK);
   sum += static_cast<int64_t>(val);
   /*retval = curl_easy_getinfo(handle, CURLINFO_HEADER_SIZE, &val);
@@ -1434,7 +1434,7 @@ void DownloadManager::ProcessLink(JobInfo *info) {
                  "(manager '%s' - id %" PRId64 ") "
                  "received %d hosts from metalink server, starting with %s",
                  name_.c_str(), info->id(),
-                 host_list.size(),
+                 static_cast<int>(host_list.size()),
                  host_list[0].c_str());
   }
 }

--- a/cvmfs/network/download.cc
+++ b/cvmfs/network/download.cc
@@ -1432,9 +1432,9 @@ void DownloadManager::ProcessLink(JobInfo *info) {
     info->SetLink("");
     LogCvmfs(kLogDownload, kLogDebug | kLogSyslog,
                  "(manager '%s' - id %" PRId64 ") "
-                 "received %d hosts from metalink server, starting with %s",
+                 "received %zu hosts from metalink server, starting with %s",
                  name_.c_str(), info->id(),
-                 static_cast<int>(host_list.size()),
+                 host_list.size(),
                  host_list[0].c_str());
   }
 }

--- a/cvmfs/network/s3fanout.cc
+++ b/cvmfs/network/s3fanout.cc
@@ -1204,9 +1204,9 @@ void S3FanoutManager::SetUrlOptions(JobInfo *info) const {
  * Adds transfer time and uploaded bytes to the global counters.
  */
 void S3FanoutManager::UpdateStatistics(CURL *handle) {
-  double val;
+  curl_off_t val;
 
-  if (curl_easy_getinfo(handle, CURLINFO_SIZE_UPLOAD, &val) == CURLE_OK)
+  if (curl_easy_getinfo(handle, CURLINFO_SIZE_UPLOAD_T, &val) == CURLE_OK)
     statistics_->transferred_bytes += val;
 }
 

--- a/externals/libcurl/CMakeLists.txt
+++ b/externals/libcurl/CMakeLists.txt
@@ -97,7 +97,10 @@ FetchContent_Declare(
   DOWNLOAD_DIR ${EXTERNALS_DOWNLOAD_LOCATION}
   INSTALL_DIR ${EXTERNALS_INSTALL_LOCATION}
   EXCLUDE_FROM_ALL
-  FIND_PACKAGE_ARGS
+  # Require 7.55.0+: needed for CURLINFO_SIZE_DOWNLOAD_T/CURLINFO_SIZE_UPLOAD_T
+  # (used in download.cc). All currently supported platforms should have a newer libcurl, 
+  # but better to be explicit, that lets us fall back to the vendored copy.
+  FIND_PACKAGE_ARGS 7.55.0
 )
 
 FetchContent_MakeAvailable(CURL)


### PR DESCRIPTION
void-cast intentional protobuf release_*() discards, use ByteSizeLong and CURLINFO_*_T, fix a %d/size_t format, mute c-ares deprecations.