### PR TITLE
Replace all asserts that have side effects

### DIFF
--- a/cvmfs/cvmfs.cc
+++ b/cvmfs/cvmfs.cc
@@ -2617,9 +2617,13 @@ static void Spawn() {
       // Reserve the capabilities to read process environments
       const std::vector<cap_value_t> reservecaps = {CAP_DAC_READ_SEARCH,
                                                     CAP_SYS_PTRACE};
-      assert(ClearPermittedCapabilities(reservecaps, nocaps));
+      if (!ClearPermittedCapabilities(reservecaps, nocaps))
+        PANIC(kLogStderr | kLogSyslogErr,
+              "Failed to reduce process capabilities");
     } else {
-      assert(ClearPermittedCapabilities(nocaps, nocaps));
+      if (!ClearPermittedCapabilities(nocaps, nocaps))
+        PANIC(kLogStderr | kLogSyslogErr,
+              "Failed to clear process capabilities");
     }
   } else {
     LogCvmfs(kLogCvmfs, kLogDebug, "Not clearing capabilities, uid %d euid%d",

--- a/cvmfs/monitor.cc
+++ b/cvmfs/monitor.cc
@@ -424,16 +424,22 @@ void Watchdog::Fork(bool needs_read_environ) {
                 const std::vector<cap_value_t> reservecaps = {CAP_SYS_ADMIN,
                                                               CAP_SYS_PTRACE};
                 const std::vector<cap_value_t> inheritcaps = {CAP_SYS_PTRACE};
-                assert(ClearPermittedCapabilities(reservecaps, inheritcaps));
+                if (!ClearPermittedCapabilities(reservecaps, inheritcaps))
+                  PANIC(kLogStderr | kLogSyslogErr,
+                        "Failed to reduce watchdog process capabilities");
               } else {
                 const std::vector<cap_value_t> reservecaps = {CAP_SYS_ADMIN};
-                assert(ClearPermittedCapabilities(reservecaps, nocaps));
+                if (!ClearPermittedCapabilities(reservecaps, nocaps))
+                  PANIC(kLogStderr | kLogSyslogErr,
+                        "Failed to reduce watchdog process capabilities");
               }
             } else {
               // Only need to be able to do the stack trace, and the
               // main process needs no extra capabilities, so we can
               // drop all capabilities.
-              assert(ClearPermittedCapabilities(nocaps, nocaps));
+              if (!ClearPermittedCapabilities(nocaps, nocaps))
+                PANIC(kLogStderr | kLogSyslogErr,
+                      "Failed to clear watchdog process capabilities");
             }
           }
           // send the watchdog PID to the supervisee
@@ -610,7 +616,9 @@ void *Watchdog::MainWatchdogListener(void *data) {
   if ((getuid() != 0) && SetuidCapabilityPermitted()) {
     // Drop all capabilities, none are needed in the listener
     const std::vector<cap_value_t> nocaps;
-    assert(ClearPermittedCapabilities(nocaps, nocaps));
+    if (!ClearPermittedCapabilities(nocaps, nocaps))
+      PANIC(kLogStderr | kLogSyslogErr,
+            "Failed to clear watchdog listener capabilities");
   }
 
   struct pollfd watch_fds[2];

--- a/cvmfs/quota_posix.cc
+++ b/cvmfs/quota_posix.cc
@@ -1246,11 +1246,17 @@ int PosixQuotaManager::MainCacheManager(int argc, char **argv) {
   if ((geteuid() != 0) && SetuidCapabilityPermitted()) {
     // Permanently drop credentials
     const std::vector<cap_value_t> nocaps;
-    assert(ClearPermittedCapabilities(nocaps, nocaps));
+    if (!ClearPermittedCapabilities(nocaps, nocaps))
+      PANIC(kLogStderr | kLogSyslogErr,
+            "Failed to clear quota manager capabilities");
     // Leave this process ptraceable
-    assert(platform_set_dumpable());
+    if (!platform_set_dumpable())
+      PANIC(kLogStderr | kLogSyslogErr,
+            "Failed to make quota manager process ptraceable");
     // but without core dumps
-    assert(SetLimitCore(0));
+    if (!SetLimitCore(0))
+      PANIC(kLogStderr | kLogSyslogErr,
+            "Failed to disable quota manager core dumps");
   }
 
   const std::unique_ptr<Watchdog> watchdog(

--- a/cvmfs/swissknife_ingestsql.cc
+++ b/cvmfs/swissknife_ingestsql.cc
@@ -29,19 +29,21 @@
 #include "upload.h"
 #include "util/logging.h"
 
-#define CHECK_SQLITE_ERROR(ret, expected)                         \
-  do {                                                            \
-    if ((ret) != expected) {                                      \
-      LogCvmfs(kLogCvmfs, kLogStderr, "SQLite error: %d", (ret)); \
-      assert(0);                                                  \
-    }                                                             \
+#define CHECK_SQLITE_ERROR(ret, expected)                            \
+  do {                                                               \
+    const int sqlite_result = (ret);                                \
+    if (sqlite_result != (expected)) {                              \
+      LogCvmfs(kLogCvmfs, kLogStderr, "SQLite error: %d",          \
+               sqlite_result);                                      \
+      abort();                                                       \
+    }                                                                \
   } while (0)
 
 #define CUSTOM_ASSERT(check, msg, ...)                     \
   do {                                                     \
     if (!(check)) {                                        \
       LogCvmfs(kLogCvmfs, kLogStderr, msg, ##__VA_ARGS__); \
-      assert(0);                                           \
+      abort();                                             \
     }                                                      \
   } while (0)
 
@@ -439,9 +441,7 @@ static XattrList marshal_xattrs(const char *acl_string) {
   if (ret) {
     LogCvmfs(kLogCvmfs, kLogStderr,
              "failure of acl_from_text_to_xattr_value(%s)", acl_string);
-    assert(
-        0);  // TODO(vavolkl): incorporate error handling other than asserting
-    return aclobj;
+    abort();
   }
   if (!equiv_mode) {
     CUSTOM_ASSERT(
@@ -1069,7 +1069,8 @@ int swissknife::IngestSQL::do_additions(
       bool exists = false;
       exists = catalog_manager.LookupDirEntry(
           MakeCatalogPath(curr_dir), catalog::kLookupDefault, &dir_entry);
-      assert(exists);  // the dir must exist at this point
+      CUSTOM_ASSERT(exists, "Directory %s is missing from the catalog",
+                    curr_dir.c_str());
       if (dir_entry.IsNestedCatalogMountpoint()
           || dir_entry.IsNestedCatalogRoot()) {
         catalog_manager.AddCatalogToQueue(curr_dir);

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -55,7 +55,7 @@ SyncUnionTarball::SyncUnionTarball(AbstractSyncMediator *mediator,
 SyncUnionTarball::~SyncUnionTarball() { delete read_archive_signal_; }
 
 bool SyncUnionTarball::Initialize() {
-  bool result;
+  int result;
 
   // We are just deleting entity from the repo
   if (tarball_path_ == "") {
@@ -64,8 +64,23 @@ bool SyncUnionTarball::Initialize() {
   }
 
   src = archive_read_new();
-  assert(ARCHIVE_OK == archive_read_support_format_tar(src));
-  assert(ARCHIVE_OK == archive_read_support_format_empty(src));
+  if (src == NULL) {
+    LogCvmfs(kLogUnionFs, kLogStderr,
+             "Impossible to create an archive reader");
+    return false;
+  }
+
+  result = archive_read_support_format_tar(src);
+  if (result == ARCHIVE_OK)
+    result = archive_read_support_format_empty(src);
+  if (result != ARCHIVE_OK) {
+    LogCvmfs(kLogUnionFs, kLogStderr,
+             "Impossible to configure the archive reader: %s",
+             archive_error_string(src));
+    archive_read_free(src);
+    src = NULL;
+    return false;
+  }
 
   if (tarball_path_ == "-") {
     result = archive_read_open_filename(src, NULL, kBlockSize);
@@ -78,6 +93,8 @@ bool SyncUnionTarball::Initialize() {
   if (result != ARCHIVE_OK) {
     LogCvmfs(kLogUnionFs, kLogStderr, "Impossible to open the archive: %s",
              archive_error_string(src));
+    archive_read_free(src);
+    src = NULL;
     return false;
   }
 

--- a/cvmfs/sync_union_tarball.cc
+++ b/cvmfs/sync_union_tarball.cc
@@ -70,16 +70,17 @@ bool SyncUnionTarball::Initialize() {
     return false;
   }
 
+  // Registering the tar/empty formats on a freshly allocated reader can only
+  // fail due to an internal libarchive/allocation error, never because of
+  // anything in the tarball itself, so treat failure as a bug, not a runtime
+  // condition to handle gracefully.
   result = archive_read_support_format_tar(src);
   if (result == ARCHIVE_OK)
     result = archive_read_support_format_empty(src);
   if (result != ARCHIVE_OK) {
-    LogCvmfs(kLogUnionFs, kLogStderr,
-             "Impossible to configure the archive reader: %s",
-             archive_error_string(src));
-    archive_read_free(src);
-    src = NULL;
-    return false;
+    PANIC(kLogStderr | kLogSyslogErr,
+          "Impossible to configure the archive reader: %s",
+          archive_error_string(src));
   }
 
   if (tarball_path_ == "-") {

--- a/cvmfs/util/capabilities.cc
+++ b/cvmfs/util/capabilities.cc
@@ -82,15 +82,33 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
   const int nreservecaps = (int) reservecaps.size();
   const int ninheritcaps = (int) inheritcaps.size();
 
-  if (!SetpcapCapabilityPermitted()) {
-    if (nreservecaps > 0) {
-      LogCvmfs(kLogCvmfs, kLogDebug,
-        "Capabilities cannot be reserved because setpcap is not permitted.");
+  {
+    cap_t caps_proc = cap_get_proc();
+    if (caps_proc == NULL) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Failed to get process capabilities (errno: %d)", errno);
       return false;
     }
-    LogCvmfs(kLogCvmfs, kLogDebug,
-      "Capabilities are already cleared because setpcap is not permitted.");
-    return true;
+    cap_flag_value_t cap_state;
+    retval = cap_get_flag(caps_proc, CAP_SETPCAP, CAP_PERMITTED, &cap_state);
+    cap_free(caps_proc);
+    if (retval != 0) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Failed to inspect setpcap capability (errno: %d)", errno);
+      return false;
+    }
+    if (cap_state != CAP_SET) {
+      if (nreservecaps > 0) {
+        LogCvmfs(kLogCvmfs, kLogDebug,
+                 "Capabilities cannot be reserved because setpcap is not "
+                 "permitted.");
+        return false;
+      }
+      LogCvmfs(kLogCvmfs, kLogDebug,
+               "Capabilities are already cleared because setpcap is not "
+               "permitted.");
+      return true;
+    }
   }
   
   uid = geteuid();
@@ -108,11 +126,21 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
     if (nreservecaps != 0) {
       // keep all capabilities when switching uid, and clear all but the
       // reserved ones below
-      assert(platform_keepcaps(true));
+      if (!platform_keepcaps(true)) {
+        LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+                 "Failed to retain capabilities while switching credentials "
+                 "(errno: %d)", errno);
+        return false;
+      }
     }
     retval = setgid(gid) || setuid(uid);
     if (nreservecaps != 0) {
-      assert(platform_keepcaps(false));
+      if (!platform_keepcaps(false)) {
+        LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+                 "Failed to stop retaining capabilities after switching "
+                 "credentials (errno: %d)", errno);
+        return false;
+      }
     }
     if (retval != 0) {
       LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
@@ -126,21 +154,40 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
     }
   }
 
-  assert(ObtainSetpcapCapability());
+  if (!ObtainSetpcapCapability()) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "Failed to obtain setpcap capability while clearing capabilities "
+             "(errno: %d)", errno);
+    return false;
+  }
 
   cap_t caps_proc = cap_get_proc();
-  assert(caps_proc != NULL);
+  if (caps_proc == NULL) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "Failed to get process capabilities (errno: %d)", errno);
+    return false;
+  }
 
   for (int i = 0; i < nreservecaps; i++) {
     const cap_value_t cap = reservecaps[i];
 
 #ifdef CAP_IS_SUPPORTED
-    assert(CAP_IS_SUPPORTED(cap));
+    if (!CAP_IS_SUPPORTED(cap)) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Capability 0x%x is not supported", cap);
+      cap_free(caps_proc);
+      return false;
+    }
 #endif
 
     cap_flag_value_t cap_state;
     retval = cap_get_flag(caps_proc, cap, CAP_PERMITTED, &cap_state);
-    assert(retval == 0);
+    if (retval != 0) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Failed to inspect capability 0x%x (errno: %d)", cap, errno);
+      cap_free(caps_proc);
+      return false;
+    }
     if (cap_state != CAP_SET) {
       LogCvmfs(kLogCvmfs, kLogDebug,
                "Warning: cap 0x%x cannot be reserved. "
@@ -152,16 +199,32 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
   // Drop all EFFECTIVE, PERMITTED, and INHERITABLE capabilities other
   // than those requested PERMITTED & INHERITABLE capabilities.
   retval = cap_clear(caps_proc);
-  assert(retval == 0);
+  if (retval != 0) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "Failed to clear process capabilities (errno: %d)", errno);
+    cap_free(caps_proc);
+    return false;
+  }
 
   if (nreservecaps != 0) {
     retval = cap_set_flag(caps_proc, CAP_PERMITTED,
                           nreservecaps, reservecaps.data(), CAP_SET);
-    assert(retval == 0);
+    if (retval != 0) {
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Failed to reserve process capabilities (errno: %d)", errno);
+      cap_free(caps_proc);
+      return false;
+    }
     if (ninheritcaps != 0) {
       retval = cap_set_flag(caps_proc, CAP_INHERITABLE,
                             ninheritcaps, inheritcaps.data(), CAP_SET);
-      assert(retval == 0);
+      if (retval != 0) {
+        LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+                 "Failed to make process capabilities inheritable (errno: %d)",
+                 errno);
+        cap_free(caps_proc);
+        return false;
+      }
     }
   }
 
@@ -182,7 +245,12 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
     for (int i = 0; i < ninheritcaps; i++) {
       retval = prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE,
                      inheritcaps[i], 0, 0);
-      assert(retval == 0);
+      if (retval != 0) {
+        LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+                 "Failed to raise ambient capability 0x%x (errno: %d)",
+                 inheritcaps[i], errno);
+        return false;
+      }
     }
   }
 
@@ -195,15 +263,31 @@ bool ObtainCapability(const cap_value_t cap,
                       const char *capname,
                       const bool avoid_mutexes = false) {
 #ifdef CAP_IS_SUPPORTED
-  assert(CAP_IS_SUPPORTED(cap));
+  if (!CAP_IS_SUPPORTED(cap)) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Capability %s is not supported", capname);
+    return false;
+  }
 #endif
 
   cap_t caps_proc = cap_get_proc();
-  assert(caps_proc != NULL);
+  if (caps_proc == NULL) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot get process capabilities (errno: %d)", errno);
+    return false;
+  }
 
   cap_flag_value_t cap_state;
   int retval = cap_get_flag(caps_proc, cap, CAP_EFFECTIVE, &cap_state);
-  assert(retval == 0);
+  if (retval != 0) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot inspect %s capability (errno: %d)", capname, errno);
+    cap_free(caps_proc);
+    return false;
+  }
 
   if (cap_state == CAP_SET) {
     cap_free(caps_proc);
@@ -211,7 +295,13 @@ bool ObtainCapability(const cap_value_t cap,
   }
 
   retval = cap_get_flag(caps_proc, cap, CAP_PERMITTED, &cap_state);
-  assert(retval == 0);
+  if (retval != 0) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot inspect %s capability (errno: %d)", capname, errno);
+    cap_free(caps_proc);
+    return false;
+  }
   if (cap_state != CAP_SET) {
     if (!avoid_mutexes) {
       LogCvmfs(kLogCvmfs, kLogDebug,
@@ -224,7 +314,13 @@ bool ObtainCapability(const cap_value_t cap,
   }
 
   retval = cap_set_flag(caps_proc, CAP_EFFECTIVE, 1, &cap, CAP_SET);
-  assert(retval == 0);
+  if (retval != 0) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot enable %s capability (errno: %d)", capname, errno);
+    cap_free(caps_proc);
+    return false;
+  }
 
   retval = cap_set_proc(caps_proc);
   cap_free(caps_proc);
@@ -245,15 +341,31 @@ bool DropCapability(const cap_value_t cap,
                     const char *capname,
                     const bool avoid_mutexes = false) {
 #ifdef CAP_IS_SUPPORTED
-  assert(CAP_IS_SUPPORTED(cap));
+  if (!CAP_IS_SUPPORTED(cap)) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Capability %s is not supported", capname);
+    return false;
+  }
 #endif
 
   cap_t caps_proc = cap_get_proc();
-  assert(caps_proc != NULL);
+  if (caps_proc == NULL) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot get process capabilities (errno: %d)", errno);
+    return false;
+  }
 
   cap_flag_value_t cap_state;
   int retval = cap_get_flag(caps_proc, cap, CAP_EFFECTIVE, &cap_state);
-  assert(retval == 0);
+  if (retval != 0) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot inspect %s capability (errno: %d)", capname, errno);
+    cap_free(caps_proc);
+    return false;
+  }
 
   if (cap_state == CAP_CLEAR) {
     cap_free(caps_proc);
@@ -261,7 +373,13 @@ bool DropCapability(const cap_value_t cap,
   }
 
   retval = cap_set_flag(caps_proc, CAP_EFFECTIVE, 1, &cap, CAP_CLEAR);
-  assert(retval == 0);
+  if (retval != 0) {
+    if (!avoid_mutexes)
+      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+               "Cannot disable %s capability (errno: %d)", capname, errno);
+    cap_free(caps_proc);
+    return false;
+  }
 
   retval = cap_set_proc(caps_proc);
   cap_free(caps_proc);
@@ -280,14 +398,23 @@ bool DropCapability(const cap_value_t cap,
 
 bool CheckCapabilityPermitted(const cap_value_t cap) {
   cap_t caps_proc = cap_get_proc();
-  assert(caps_proc != NULL);
+  if (caps_proc == NULL) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "Cannot get process capabilities (errno: %d)", errno);
+    return false;
+  }
   cap_flag_value_t cap_state;
   const int retval = cap_get_flag(caps_proc,
                                   cap,
                                   CAP_PERMITTED,
                                   &cap_state);
-  assert(retval == 0);
   cap_free(caps_proc);
+  if (retval != 0) {
+    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
+             "Cannot inspect permitted capability 0x%x (errno: %d)", cap,
+             errno);
+    return false;
+  }
   return (cap_state == CAP_SET);
 }
 

--- a/cvmfs/util/capabilities.cc
+++ b/cvmfs/util/capabilities.cc
@@ -247,29 +247,28 @@ bool ObtainCapability(const cap_value_t cap,
                       const bool avoid_mutexes = false) {
 #ifdef CAP_IS_SUPPORTED
   if (!CAP_IS_SUPPORTED(cap)) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Capability %s is not supported", capname);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Capability %s is not supported", capname);
   }
 #endif
 
   cap_t caps_proc = cap_get_proc();
   if (caps_proc == NULL) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot get process capabilities (errno: %d)", errno);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug,
+          "Cannot get process capabilities (errno: %d)", errno);
   }
 
   cap_flag_value_t cap_state;
   int retval = cap_get_flag(caps_proc, cap, CAP_EFFECTIVE, &cap_state);
   if (retval != 0) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot inspect %s capability (errno: %d)", capname, errno);
     cap_free(caps_proc);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Cannot inspect %s capability (errno: %d)",
+          capname, errno);
   }
 
   if (cap_state == CAP_SET) {
@@ -279,11 +278,11 @@ bool ObtainCapability(const cap_value_t cap,
 
   retval = cap_get_flag(caps_proc, cap, CAP_PERMITTED, &cap_state);
   if (retval != 0) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot inspect %s capability (errno: %d)", capname, errno);
     cap_free(caps_proc);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Cannot inspect %s capability (errno: %d)",
+          capname, errno);
   }
   if (cap_state != CAP_SET) {
     if (!avoid_mutexes) {
@@ -298,11 +297,11 @@ bool ObtainCapability(const cap_value_t cap,
 
   retval = cap_set_flag(caps_proc, CAP_EFFECTIVE, 1, &cap, CAP_SET);
   if (retval != 0) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot enable %s capability (errno: %d)", capname, errno);
     cap_free(caps_proc);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Cannot enable %s capability (errno: %d)",
+          capname, errno);
   }
 
   retval = cap_set_proc(caps_proc);
@@ -325,29 +324,28 @@ bool DropCapability(const cap_value_t cap,
                     const bool avoid_mutexes = false) {
 #ifdef CAP_IS_SUPPORTED
   if (!CAP_IS_SUPPORTED(cap)) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Capability %s is not supported", capname);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Capability %s is not supported", capname);
   }
 #endif
 
   cap_t caps_proc = cap_get_proc();
   if (caps_proc == NULL) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot get process capabilities (errno: %d)", errno);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug,
+          "Cannot get process capabilities (errno: %d)", errno);
   }
 
   cap_flag_value_t cap_state;
   int retval = cap_get_flag(caps_proc, cap, CAP_EFFECTIVE, &cap_state);
   if (retval != 0) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot inspect %s capability (errno: %d)", capname, errno);
     cap_free(caps_proc);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Cannot inspect %s capability (errno: %d)",
+          capname, errno);
   }
 
   if (cap_state == CAP_CLEAR) {
@@ -357,11 +355,11 @@ bool DropCapability(const cap_value_t cap,
 
   retval = cap_set_flag(caps_proc, CAP_EFFECTIVE, 1, &cap, CAP_CLEAR);
   if (retval != 0) {
-    if (!avoid_mutexes)
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Cannot disable %s capability (errno: %d)", capname, errno);
     cap_free(caps_proc);
-    return false;
+    if (avoid_mutexes)
+      return false;
+    PANIC(kLogSyslogErr | kLogDebug, "Cannot disable %s capability (errno: %d)",
+          capname, errno);
   }
 
   retval = cap_set_proc(caps_proc);

--- a/cvmfs/util/capabilities.cc
+++ b/cvmfs/util/capabilities.cc
@@ -10,6 +10,8 @@
 #include <sys/prctl.h>
 #endif
 
+#include <cstdlib>
+
 #include "util/capabilities.h"
 #include "util/exception.h"
 #include "util/logging.h"
@@ -248,7 +250,7 @@ bool ObtainCapability(const cap_value_t cap,
 #ifdef CAP_IS_SUPPORTED
   if (!CAP_IS_SUPPORTED(cap)) {
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Capability %s is not supported", capname);
   }
 #endif
@@ -256,7 +258,7 @@ bool ObtainCapability(const cap_value_t cap,
   cap_t caps_proc = cap_get_proc();
   if (caps_proc == NULL) {
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug,
           "Cannot get process capabilities (errno: %d)", errno);
   }
@@ -266,7 +268,7 @@ bool ObtainCapability(const cap_value_t cap,
   if (retval != 0) {
     cap_free(caps_proc);
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Cannot inspect %s capability (errno: %d)",
           capname, errno);
   }
@@ -280,7 +282,7 @@ bool ObtainCapability(const cap_value_t cap,
   if (retval != 0) {
     cap_free(caps_proc);
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Cannot inspect %s capability (errno: %d)",
           capname, errno);
   }
@@ -299,7 +301,7 @@ bool ObtainCapability(const cap_value_t cap,
   if (retval != 0) {
     cap_free(caps_proc);
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Cannot enable %s capability (errno: %d)",
           capname, errno);
   }
@@ -325,7 +327,7 @@ bool DropCapability(const cap_value_t cap,
 #ifdef CAP_IS_SUPPORTED
   if (!CAP_IS_SUPPORTED(cap)) {
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Capability %s is not supported", capname);
   }
 #endif
@@ -333,7 +335,7 @@ bool DropCapability(const cap_value_t cap,
   cap_t caps_proc = cap_get_proc();
   if (caps_proc == NULL) {
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug,
           "Cannot get process capabilities (errno: %d)", errno);
   }
@@ -343,7 +345,7 @@ bool DropCapability(const cap_value_t cap,
   if (retval != 0) {
     cap_free(caps_proc);
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Cannot inspect %s capability (errno: %d)",
           capname, errno);
   }
@@ -357,7 +359,7 @@ bool DropCapability(const cap_value_t cap,
   if (retval != 0) {
     cap_free(caps_proc);
     if (avoid_mutexes)
-      return false;
+      abort();
     PANIC(kLogSyslogErr | kLogDebug, "Cannot disable %s capability (errno: %d)",
           capname, errno);
   }

--- a/cvmfs/util/capabilities.cc
+++ b/cvmfs/util/capabilities.cc
@@ -10,9 +10,8 @@
 #include <sys/prctl.h>
 #endif
 
-#include <cassert>
-
 #include "util/capabilities.h"
+#include "util/exception.h"
 #include "util/logging.h"
 #include "util/platform.h"
 #include "util/posix.h"
@@ -82,33 +81,17 @@ bool ClearPermittedCapabilities(const std::vector<cap_value_t> &reservecaps,
   const int nreservecaps = (int) reservecaps.size();
   const int ninheritcaps = (int) inheritcaps.size();
 
-  {
-    cap_t caps_proc = cap_get_proc();
-    if (caps_proc == NULL) {
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Failed to get process capabilities (errno: %d)", errno);
-      return false;
-    }
-    cap_flag_value_t cap_state;
-    retval = cap_get_flag(caps_proc, CAP_SETPCAP, CAP_PERMITTED, &cap_state);
-    cap_free(caps_proc);
-    if (retval != 0) {
-      LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-               "Failed to inspect setpcap capability (errno: %d)", errno);
-      return false;
-    }
-    if (cap_state != CAP_SET) {
-      if (nreservecaps > 0) {
-        LogCvmfs(kLogCvmfs, kLogDebug,
-                 "Capabilities cannot be reserved because setpcap is not "
-                 "permitted.");
-        return false;
-      }
+  if (!SetpcapCapabilityPermitted()) {
+    if (nreservecaps > 0) {
       LogCvmfs(kLogCvmfs, kLogDebug,
-               "Capabilities are already cleared because setpcap is not "
+               "Capabilities cannot be reserved because setpcap is not "
                "permitted.");
-      return true;
+      return false;
     }
+    LogCvmfs(kLogCvmfs, kLogDebug,
+             "Capabilities are already cleared because setpcap is not "
+             "permitted.");
+    return true;
   }
   
   uid = geteuid();
@@ -398,23 +381,19 @@ bool DropCapability(const cap_value_t cap,
 
 bool CheckCapabilityPermitted(const cap_value_t cap) {
   cap_t caps_proc = cap_get_proc();
-  if (caps_proc == NULL) {
-    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-             "Cannot get process capabilities (errno: %d)", errno);
-    return false;
-  }
+  if (caps_proc == NULL)
+    PANIC(kLogSyslogErr | kLogDebug,
+          "Cannot get process capabilities (errno: %d)", errno);
   cap_flag_value_t cap_state;
   const int retval = cap_get_flag(caps_proc,
                                   cap,
                                   CAP_PERMITTED,
                                   &cap_state);
   cap_free(caps_proc);
-  if (retval != 0) {
-    LogCvmfs(kLogCvmfs, kLogSyslogErr | kLogDebug,
-             "Cannot inspect permitted capability 0x%x (errno: %d)", cap,
-             errno);
-    return false;
-  }
+  if (retval != 0)
+    PANIC(kLogSyslogErr | kLogDebug,
+          "Cannot inspect permitted capability 0x%x (errno: %d)", cap,
+          errno);
   return (cap_state == CAP_SET);
 }
 


### PR DESCRIPTION
This PR removes all asserts with production logic and replaces them with exceptions or other error handling. This prevents issues with builds where asserts are compiled out.