### PR TITLE
fix: add showconfig --all

### DIFF
--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -994,35 +994,39 @@ json_string() {
   printf '"%s"' "$s"
 }
 
+cvmfs_showconfig_all_requested() {
+  local option
+  for option in "$@"; do
+    case "$option" in
+      -a|--all)
+        return 0
+      ;;
+    esac
+  done
+  return 1
+}
+
 cvmfs_showconfig() {
   local fqrn
   local org
   local short_output=0
   local json_output=0
-  local all_output=0
-  local short_opt=
-  local all_opt=
-  # Loop over the output flags and the repository name. Flag order does not
-  # matter.
-  while [ $# -gt 0 ]; do
-    case "$1" in
+  local option
+  # Keep the arguments intact so -a/--all can be checked after configuration
+  # variables have been evaluated in this dynamic scope.
+  for option in "$@"; do
+    case "$option" in
       -s)
         short_output=1
-        short_opt="-s "
-        shift 1
       ;;
       -a|--all)
-        all_output=1
-        all_opt="-a "
-        shift 1
+        continue
       ;;
       -j|--json)
         json_output=1
-        shift 1
       ;;
       *)
-        org=$1
-        shift 1
+        org=$option
       ;;
     esac
   done
@@ -1037,15 +1041,15 @@ cvmfs_showconfig() {
       for entry in $list; do
         [ $first -eq 0 ] && echo "," # comma between JSON objects
         # Emit a JSON object for this repository.
-        cvmfs_showconfig -j $short_opt$all_opt$entry
+        cvmfs_showconfig "$@" "$entry"
         first=0
       done
       echo "]"
     else
       for entry in $list; do
         echo
-        echo "Running $0 $short_opt$all_opt$entry:"
-        cvmfs_showconfig $short_opt$all_opt$entry
+        echo "Running $0" "$@" "$entry:"
+        cvmfs_showconfig "$@" "$entry"
       done
     fi
     return 0
@@ -1072,7 +1076,7 @@ cvmfs_showconfig() {
   # valid shell assignment names only.
   while read setting; do
     [[ "$setting" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
-    if [ $all_output -eq 0 ]; then
+    if ! cvmfs_showconfig_all_requested "$@"; then
       [ "x${setting:0:6}" != "xCVMFS_" ] && continue
     fi
     set_vars="$set_vars ${setting%%=*}"

--- a/cvmfs/cvmfs_config
+++ b/cvmfs/cvmfs_config
@@ -82,9 +82,10 @@ esac
 
 fi  # CVMFS_CONFIG_SKIP_ENV_PROBE
 
-# This list of known parameters will be merged with all CVMFS_... environment
-# variable for cvmfs_config showconfig.  It is useful to keep this list to show
-# in cvmfs_config showconfig which known parameters are _not_ set.
+# This list of known parameters is merged with configured variable names for
+# cvmfs_config showconfig.  By default, only configured CVMFS_ names are added;
+# showconfig --all also adds configured names without that prefix.  The list
+# lets showconfig display known parameters that are _not_ set.
 parm_list="CVMFS_USER CVMFS_NFILES CVMFS_CACHE_BASE CVMFS_CACHE_DIR CVMFS_MOUNT_DIR CVMFS_QUOTA_LIMIT \
           CVMFS_SERVER_URL CVMFS_DEBUGLOG CVMFS_HTTP_PROXY \
           CERNVM_GRID_UI_VERSION CVMFS_SYSLOG_LEVEL CVMFS_SYSLOG_FACILITY CVMFS_TRACEFILE \
@@ -278,7 +279,9 @@ cvmfs_config_usage() {
   echo "  chksetup"
   echo ""
   echo "  showconfig [-s(hort output, only parameters set in the" \
-       "configuration)] [-j|--json] [<repository>|<mountpoint>]"
+       "configuration)]" \
+       "[-a|--all (include configured non-CVMFS parameters)]" \
+       "[-j|--json] [<repository>|<mountpoint>]"
   echo ""
   echo "  stat [-v | <repository>]"
   echo ""
@@ -996,14 +999,21 @@ cvmfs_showconfig() {
   local org
   local short_output=0
   local json_output=0
+  local all_output=0
   local short_opt=
-  # Loop over all arguments: -s for short output, -j for JSON output, and the org name
-  # order of flags (-s and -j) does not matter
+  local all_opt=
+  # Loop over the output flags and the repository name. Flag order does not
+  # matter.
   while [ $# -gt 0 ]; do
     case "$1" in
       -s)
         short_output=1
         short_opt="-s "
+        shift 1
+      ;;
+      -a|--all)
+        all_output=1
+        all_opt="-a "
         shift 1
       ;;
       -j|--json)
@@ -1026,15 +1036,16 @@ cvmfs_showconfig() {
       echo "["
       for entry in $list; do
         [ $first -eq 0 ] && echo "," # comma between JSON objects
-        cvmfs_showconfig -j $short_opt$entry # emit JSON object for this repository
+        # Emit a JSON object for this repository.
+        cvmfs_showconfig -j $short_opt$all_opt$entry
         first=0
       done
       echo "]"
     else
       for entry in $list; do
         echo
-        echo "Running $0 $short_opt$entry:"
-        cvmfs_showconfig $short_opt$entry
+        echo "Running $0 $short_opt$all_opt$entry:"
+        cvmfs_showconfig $short_opt$all_opt$entry
       done
     fi
     return 0
@@ -1057,8 +1068,13 @@ cvmfs_showconfig() {
   local setting=
   local all_vars=
   local set_vars=          # names present in the config file
+  # CVMFS_PARMS contains resolved config assignments and a header.  Collect
+  # valid shell assignment names only.
   while read setting; do
-    [ "x${setting:0:6}" != "xCVMFS_" ] && continue
+    [[ "$setting" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+    if [ $all_output -eq 0 ]; then
+      [ "x${setting:0:6}" != "xCVMFS_" ] && continue
+    fi
     set_vars="$set_vars ${setting%%=*}"
   done <<< "$CVMFS_PARMS"
   all_vars="$(echo $set_vars $var_list | tr ' ' '\n' | sort -u)"

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -6,6 +6,9 @@ cvmfs_test_suites="quick"
 create_config_files() {
   sudo sh -c "echo CVMFS_KCACHE_TIMEOUT=2 > /etc/cvmfs/default.d/50-testA.conf" || return 1
   sudo sh -c "echo CVMFS_KCACHE_TIMEOUT=3 > /etc/cvmfs/default.d/50-testB.conf" || return 2
+  sudo sh -c \
+    "echo EESSI_HOST_INJECTIONS=/tmp/eessi/host_injections \
+    > /etc/cvmfs/default.d/50-testC.conf" || return 3
 
   return 0
 }
@@ -151,6 +154,45 @@ cvmfs_run_test() {
     "${mount_dir%/}/grid.cern.ch/subdir" || retval=63
   expect_exit_code 1 cvmfs_config showconfig \
     /tmp/grid.cern.ch || retval=64
+
+  # Non-CVMFS parameters are hidden by default and shown only on request.
+  local variant_name=EESSI_HOST_INJECTIONS
+  local variant_value=/tmp/eessi/host_injections
+  local all_plain all_json short_all_plain short_all_json
+  local recursive_all_plain recursive_all_json
+  grep -q "^${variant_name}=" <<< "$plain_by_name" && retval=65
+  jq -e --arg key "$variant_name" 'has($key) | not' \
+    <<< "$json_by_name" >/dev/null || retval=66
+
+  all_plain=$(cvmfs_config showconfig -a grid.cern.ch) || retval=67
+  grep -q "^${variant_name}=${variant_value}$" \
+    <<< "$(printf '%s\n' "$all_plain" | normalize_plain)" || retval=68
+  all_json=$(cvmfs_config showconfig --all -j grid.cern.ch) || retval=69
+  jq -e --arg value "$variant_value" \
+    '.EESSI_HOST_INJECTIONS == $value' \
+    <<< "$all_json" >/dev/null || retval=70
+  diff <(printf '%s\n' "$all_plain" | normalize_plain) \
+       <(printf '%s\n' "$all_json" | normalize_json) || retval=71
+
+  short_all_plain=$(cvmfs_config showconfig -s -a grid.cern.ch) \
+    || retval=72
+  short_all_json=$(cvmfs_config showconfig --all -s -j grid.cern.ch) \
+    || retval=73
+  jq -e --arg value "$variant_value" \
+    '.EESSI_HOST_INJECTIONS == $value' \
+    <<< "$short_all_json" >/dev/null || retval=74
+  diff <(printf '%s\n' "$short_all_plain" | normalize_plain) \
+       <(printf '%s\n' "$short_all_json" | normalize_json) || retval=75
+
+  recursive_all_plain=$(cvmfs_config showconfig -a) || retval=76
+  grep -q "^${variant_name}=${variant_value}$" \
+    <<< "$(printf '%s\n' "$recursive_all_plain" | normalize_plain)" \
+    || retval=77
+  recursive_all_json=$(cvmfs_config showconfig --all -j) || retval=78
+  jq -e --arg value "$variant_value" '
+    .[] | select(.CVMFS_REPOSITORY_NAME == "grid.cern.ch")
+    | .EESSI_HOST_INJECTIONS == $value
+  ' <<< "$recursive_all_json" >/dev/null || retval=79
 
   cvmfs_umount grid.cern.ch || retval=5
 

--- a/test/src/046-defaultd/main
+++ b/test/src/046-defaultd/main
@@ -9,6 +9,11 @@ create_config_files() {
   sudo sh -c \
     "echo EESSI_HOST_INJECTIONS=/tmp/eessi/host_injections \
     > /etc/cvmfs/default.d/50-testC.conf" || return 3
+  # These valid config names must not collide with showconfig's option state.
+  sudo sh -c \
+    "echo all_output=0 > /etc/cvmfs/default.d/50-testD.conf" || return 4
+  sudo sh -c \
+    "echo all_opt= > /etc/cvmfs/default.d/50-testE.conf" || return 5
 
   return 0
 }
@@ -171,28 +176,30 @@ cvmfs_run_test() {
   jq -e --arg value "$variant_value" \
     '.EESSI_HOST_INJECTIONS == $value' \
     <<< "$all_json" >/dev/null || retval=70
+  jq -e '.all_output == "0" and .all_opt == ""' \
+    <<< "$all_json" >/dev/null || retval=71
   diff <(printf '%s\n' "$all_plain" | normalize_plain) \
-       <(printf '%s\n' "$all_json" | normalize_json) || retval=71
+       <(printf '%s\n' "$all_json" | normalize_json) || retval=72
 
   short_all_plain=$(cvmfs_config showconfig -s -a grid.cern.ch) \
-    || retval=72
-  short_all_json=$(cvmfs_config showconfig --all -s -j grid.cern.ch) \
     || retval=73
+  short_all_json=$(cvmfs_config showconfig --all -s -j grid.cern.ch) \
+    || retval=74
   jq -e --arg value "$variant_value" \
     '.EESSI_HOST_INJECTIONS == $value' \
-    <<< "$short_all_json" >/dev/null || retval=74
+    <<< "$short_all_json" >/dev/null || retval=75
   diff <(printf '%s\n' "$short_all_plain" | normalize_plain) \
-       <(printf '%s\n' "$short_all_json" | normalize_json) || retval=75
+       <(printf '%s\n' "$short_all_json" | normalize_json) || retval=76
 
-  recursive_all_plain=$(cvmfs_config showconfig -a) || retval=76
+  recursive_all_plain=$(cvmfs_config showconfig -a) || retval=77
   grep -q "^${variant_name}=${variant_value}$" \
     <<< "$(printf '%s\n' "$recursive_all_plain" | normalize_plain)" \
-    || retval=77
-  recursive_all_json=$(cvmfs_config showconfig --all -j) || retval=78
+    || retval=78
+  recursive_all_json=$(cvmfs_config showconfig --all -j) || retval=79
   jq -e --arg value "$variant_value" '
     .[] | select(.CVMFS_REPOSITORY_NAME == "grid.cern.ch")
     | .EESSI_HOST_INJECTIONS == $value
-  ' <<< "$recursive_all_json" >/dev/null || retval=79
+  ' <<< "$recursive_all_json" >/dev/null || retval=80
 
   cvmfs_umount grid.cern.ch || retval=5
 


### PR DESCRIPTION
`cvmfs_config showconfig` currently hides configured variables that do not start with `CVMFS_`, including variables used by variant symlinks such as `EESSI_HOST_INJECTIONS`.

Add `-a` / `--all` to include all parameters returned by the configuration parser. This is opt-in, so the existing output remains unchanged. The flag also works with `-s`, `-j`, mountpoint paths, and the no-repository form.

Extended `046-defaultd` to cover the new flag and unchanged default behavior.

Fixes #4098