### PR TITLE
Fix blank configuration settings

### DIFF
--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -64,6 +64,15 @@ string OptionsManager::TrimParameter(const string &parameter) {
   } else if (result.find("export ") == 0) {
     result = result.substr(7);
     result = Trim(result);
+    // This enables a hack to ignore a variable setting in cvmfs versions
+    // prior to 2.14.2 which also stopped setting variables to blank when
+    // they are defined only in false conditionals.  The hack is to use
+    // 'export X VAR=VAL', where VAR will be recognized in 2.14.2 and later
+    // and ignored prior to 2.14.2.
+    const size_t last_space = result.find_last_of(" ");
+    if (last_space != string::npos) {
+      result = result.substr(last_space + 1);
+    }
   } else if (result.find("eval ") == 0) {
     result = result.substr(5);
     result = Trim(result);

--- a/cvmfs/options.cc
+++ b/cvmfs/options.cc
@@ -248,10 +248,12 @@ void BashOptionsManager::ParsePath(const string &config_file,
 
     ConfigValue value;
     value.source = config_file;
-    const string sh_echo = "echo $" + parameter + "\n";
+    const string sh_echo = "echo ${" + parameter + "-xNOTxSETx}\n";
     WritePipe(fd_stdin, sh_echo.data(), sh_echo.length());
     GetLineFd(fd_stdout, &value.value);
-    PopulateParameter(parameter, value);
+    if (value.value != "xNOTxSETx") {
+      PopulateParameter(parameter, value);
+    }
   }
 
   close(fd_stderr);

--- a/test/unittests/t_options.cc
+++ b/test/unittests/t_options.cc
@@ -36,6 +36,7 @@ class T_Options : public ::testing::Test {
             "CVMFS_SHARED_CACHE=no\n"
             "CVMFS_HTTP_PROXY=DIRECT\n"
             "export A=B\n"
+            "export X B=C\n"
             "=only equal sign\n"
             " =equal sign with space\n"
             "\n"
@@ -43,6 +44,12 @@ class T_Options : public ::testing::Test {
             "D=E # with a comment\n"
             "F=\"G\"\n"
             "H='I' \n"
+            "if false; then\n"
+            "  VALFALSE=value\n"
+            "fi\n"
+            "if true; then\n"
+            "  VALTRUE=value\n"
+            "fi\n"
             "FOO=abc/@fqrn@/@foo@.@bar@\n"
             "BAR=abc@def.com");
     int result = fclose(temp_file);
@@ -61,11 +68,12 @@ class T_Options : public ::testing::Test {
   struct type { };
 
   unsigned ExpectedValues(const type<BashOptionsManager> type_specifier) {
-    return 14u;
+    return 15u;
   }
 
   unsigned ExpectedValues(const type<SimpleOptionsParser> type_specifier) {
-    return 14u;
+    // the extras here are XYZABC and VALFALSE
+    return 17u;
   }
 
   unsigned ExpectedValues() { return ExpectedValues(type<OptionsT>()); }
@@ -94,7 +102,7 @@ TYPED_TEST(T_Options, ParsePath) {
   options_manager.ParsePath(config_file, false);
   options_manager.SwitchTemplateManager(opt_temp_mgr);
 
-  // printf("DUMP: ***\n%s\n***\n", options_manager.Dump().c_str());
+  SCOPED_TRACE(options_manager.Dump());
   ASSERT_EQ(expected_number_elements, options_manager.GetAllKeys().size());
 
   EXPECT_TRUE(options_manager.GetValue("CVMFS_CACHE_BASE", &container));


### PR DESCRIPTION
This makes two changes related to configuration variables getting set to blank:
1. Adds `declare -g` to the prefixes recognized as setting variables.  This enables adding a backwards-compatible config variable setting that does not set a value to blank when the setting is only in a false conditional block, because previous versions will ignore the line.  EDIT: Since `declare -g` fails on Debian, instead use `export X VAR=VAL`.
2. If a variable is only set within a false conditional block, it will no longer get set to blank, it will just not be set.

- Fixes #4430